### PR TITLE
Add permission-aware runtime kernel APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,40 @@
 # Changelog
 
-All notable changes to `agent_sdk` are documented in this file.
+All notable changes to `agent_sdk` are documented here.
+
+## [0.4.0] - 2026-03-09
+
+### Added
+- `Session` module for lifecycle metadata, resumable state, and hook-visible session IDs
+- `Skill` module for markdown frontmatter parsing, prompt rendering, and supporting-file resolution
+- `Subagent` module for typed subagent specs and conversion into handoff targets
+- `Types.tool_kind` plus `Tool.create ?kind` / `Tool.create_with_context ?kind`
+- permission-aware `Guardrails` with `permission_mode`, allow/ask/deny lists, additional directories, and output truncation
+- new hook events for session lifecycle, permission requests, and subagent lifecycle
+- `Agent.run_with_subagents` convenience API
+
+### Changed
+- `Agent.create` now accepts optional `session`
+- `Handoff.handoff_target` can carry hooks, guardrails, and sessions into delegated sub-agents
+- README and shipped surface are now aligned around the actual public modules and streaming support
 
 ## [0.3.0] - 2026-03-05
 
 ### Added
-- Fleet Orchestration: `Fleet` module with member selection, parallel execution (#747)
-- `Handoff` module for multi-agent tool delegation (#747)
-- `Context` module for shared key-value state across agents (#747)
-- `Guardrails` module with tool filtering (AllowList, DenyList, Custom) and turn limits (#747)
-- `Streaming` module with SSE event parsing and usage tracking (#747)
-- API retry with exponential backoff and configurable max attempts (#749)
-
-### Changed
-- Provider config extended with `max_retries` field (#749)
+- `Handoff` module for multi-agent tool delegation
+- `Context` module for shared key-value state across agents
+- `Guardrails` module with tool visibility filters and turn limits
+- SSE streaming support in `Api` with usage tracking
+- API retry with exponential backoff and configurable max attempts
 
 ## [0.2.0] - 2026-03-01
 
 ### Added
-- Provider abstraction: Anthropic, Local (OpenAI-compatible), OpenAICompat (#730)
-- Hook system: `before_api_call`, `after_api_call`, `before_tool_use`, `after_tool_use` (#730)
-- Agent loop with tool execution and multi-turn conversation (#730)
+- Provider abstraction: Anthropic, Local, OpenAI-compatible
+- Basic hook system for turn and tool lifecycle
+- Agent loop with tool execution and multi-turn conversation
 
 ## [0.1.0] - 2026-02-11
 
 ### Added
-- Initial release: Types, API client, basic agent loop
+- Initial release: `Types`, `Api`, `Agent`, `Tool`

--- a/README.md
+++ b/README.md
@@ -1,134 +1,189 @@
-# agent-sdk
+# `agent_sdk`
 
-이 디렉토리가 현재 작업 환경에서의 로컬 SSOT다.
+OCaml 5.x + Eio 기반 agent runtime kernel.
 
-- 사람 기준 이름: `agent-sdk`
-- local workspace path in this environment: `~/me/workspace/yousleepwhen/agent-sdk`
-- OCaml 패키지 이름: `agent_sdk`
-- OCaml 모듈 이름: `Agent_sdk`
-- `agent-swarm` 코드는 별도 제품이 아니라 `~/me/workspace/yousleepwhen/masc-mcp` 내부 구현으로 이관한다
+- repo: `https://github.com/jeong-sik/oas`
+- local workspace path in this environment: `~/me/workspace/yousleepwhen/oas`
+- opam package: `agent_sdk`
+- OCaml module: `Agent_sdk`
 
-OCaml 5.x + Eio 기반 LLM Agent SDK. Anthropic Messages API와 OpenAI-compatible local LLM 엔드포인트를 지원한다.
+`masc-mcp` 같은 orchestration layer가 재사용할 수 있도록, single-agent loop 위에 `hooks`, `permission-aware guardrails`, `sessions`, `skills`, `subagents`를 얹는 방향으로 설계되어 있다.
 
-## 아키텍처
+## Module Map
 
-```
-Provider  →  API  →  Agent  →  Tool
-(endpoint)  (HTTP)  (loop)   (functions)
-```
+| Module | Role |
+| --- | --- |
+| `Types` | message/content/tool schema/streaming events |
+| `Provider` | Anthropic / local / OpenAI-compatible endpoint resolution |
+| `Api` | `create_message`, `create_message_stream`, SSE parsing |
+| `Agent` | multi-turn tool loop, permission checks, handoffs, subagents |
+| `Tool` | tool definition, kind metadata, JSON schema export |
+| `Hooks` | lifecycle / permission / subagent hook events |
+| `Guardrails` | tool visibility, permission mode, output limits |
+| `Context` | shared mutable key-value context |
+| `Session` | resumable session metadata and lifecycle state |
+| `Skill` | markdown + frontmatter parser for reusable prompt skills |
+| `Subagent` | typed subagent spec and handoff target conversion |
+| `Handoff` | delegated sub-agent tool contract |
+| `Retry` | HTTP/network retry classification |
 
-| 모듈 | 역할 |
-|------|------|
-| `Types` | 메시지, 역할, stop_reason 등 도메인 타입 |
-| `Provider` | LLM 엔드포인트 추상화 (Local / Anthropic) |
-| `Api` | HTTP 클라이언트 — `create_message` 호출 |
-| `Agent` | 멀티턴 에이전트 루프 (tool_use 자동 처리) |
-| `Tool` | 도구 정의 + JSON Schema 생성 + 실행 |
+## Feature Matrix
 
-## Provider 패턴
+| Feature | Status | Notes |
+| --- | --- | --- |
+| Multi-turn tool loop | Stable | `Agent.run` |
+| SSE streaming | Stable | `Api.create_message_stream` + parsed SSE events |
+| Hooks | Stable | turn/tool/session/permission/subagent events |
+| Permission-aware guardrails | Stable | `permission_mode`, allow/ask/deny lists, output caps |
+| Shared context | Stable | `Context.t` |
+| Handoff tools | Stable | `Agent.run_with_handoffs` |
+| Sessions | Stable | `Session.t`, hook-visible lifecycle |
+| Skill markdown loader | Experimental | lightweight frontmatter subset |
+| Typed subagent specs | Experimental | `Subagent.t` -> `Handoff.handoff_target` |
+| Prompt caching | Planned | not implemented yet |
+| Multimodal content blocks | Planned | not implemented yet |
+| MCP resources / prompts | Planned | integration surface not added yet |
 
-```ocaml
-(* Local LLM (llama-server, vllm-mlx 등) *)
-let local_cfg : Provider.config = {
-  provider = Local { base_url = "http://127.0.0.1:8085" };
-  model_id = "qwen3.5-35b";
-  api_key_env = "LOCAL_LLM_KEY";
-}
-
-(* Anthropic *)
-let anthropic_cfg : Provider.config = {
-  provider = Anthropic;
-  model_id = "claude-sonnet-4-20250514";
-  api_key_env = "ANTHROPIC_API_KEY";
-}
-```
-
-`Provider.resolve`는 `(base_url * api_key * headers, error_msg) result`를 반환한다. 환경변수가 없으면 `Error`를 반환하며, silent fallback 없음.
-
-## 사용법
+## Quick Start
 
 ```ocaml
 open Agent_sdk
 
+let echo_tool =
+  Tool.create
+    ~name:"echo"
+    ~description:"Echo back the input"
+    ~parameters:[
+      {
+        Types.name = "message";
+        description = "Text to echo";
+        param_type = Types.String;
+        required = true;
+      };
+    ]
+    (fun input ->
+      let message = Yojson.Safe.Util.(input |> member "message" |> to_string) in
+      Ok message)
+
 let () =
   Eio_main.run @@ fun env ->
-  let net = Eio.Stdenv.net env in
   Eio.Switch.run @@ fun sw ->
-  let provider : Provider.config = {
-    provider = Local { base_url = "http://127.0.0.1:8085" };
-    model_id = "qwen3.5-35b";
-    api_key_env = "LOCAL_LLM_KEY";
-  } in
-  let agent = Agent.create
-    ~provider
-    ~system_prompt:"You are a helpful assistant."
-    ~tools:[]
-    ~max_turns:5 in
-  match Agent.run ~sw ~net agent "What is 2+2?" with
-  | Ok response -> Printf.printf "Response: %s\n" response
-  | Error e -> Printf.eprintf "Error: %s\n" e
+    let provider =
+      {
+        Provider.provider = Provider.Local { base_url = "http://127.0.0.1:8085" };
+        model_id = "qwen3.5-35b";
+        api_key_env = "LOCAL_LLM_KEY";
+      }
+    in
+    let agent =
+      Agent.create
+        ~net:env#net
+        ~provider
+        ~config:{
+          Types.default_config with
+          name = "echo-agent";
+          system_prompt = Some "You are a concise assistant.";
+          max_turns = 5;
+        }
+        ~tools:[echo_tool]
+        ()
+    in
+    match Agent.run ~sw agent "Say hello" with
+    | Ok response ->
+        response.Types.content
+        |> List.iter (function
+             | Types.Text text -> print_endline text
+             | _ -> ())
+    | Error err ->
+        prerr_endline err
 ```
 
-## 도구 정의
+## Tool Kinds and Guardrails
+
+`Tool.create` and `Tool.create_with_context` support `?kind`.
 
 ```ocaml
-let calc_tool = Tool.create
-  ~name:"calculator"
-  ~description:"Evaluate a math expression"
-  ~parameters:[
-    ("expression", `String, "The math expression to evaluate", true);
-  ]
-  ~handler:(fun args ->
-    match List.assoc_opt "expression" args with
-    | Some expr -> Printf.sprintf "Result: %s" expr
-    | None -> "Error: missing expression"
-  )
+let edit_tool =
+  Tool.create
+    ~kind:Types.File_edit
+    ~name:"write_file"
+    ~description:"Write a file"
+    ~parameters:[]
+    (fun _ -> Ok "done")
 ```
 
-## 빌드
+`Guardrails.permission_mode` drives runtime behavior:
 
-```bash
-# from the repo root
-dune build @all
+- `Default`: read-only tools auto-allow, others require approval
+- `Accept_edits`: read-only and file-edit tools auto-allow
+- `Dont_ask`: tools that need approval are rejected
+- `Bypass_permissions`: everything allows unless explicitly denied
+- `Plan`: read-only tools only
+
+Approval-requiring tools emit `Hooks.PermissionRequest`.
+
+## Skills and Subagents
+
+`Skill` parses markdown files with a lightweight frontmatter subset:
+
+```md
+---
+name: code-review
+description: Review code changes
+allowed-tools: Read, Grep
+argument-hint: revision range
+disable-model-invocation: true
+---
+Review the diff in $ARGUMENTS.
 ```
 
-## 테스트
+`Subagent` parses Claude-style subagent metadata and can be converted into a handoff target:
+
+```ocaml
+let reviewer_skill = Skill.load ".claude/skills/review.md"
+
+let reviewer =
+  Subagent.of_markdown
+    ~skills:[reviewer_skill]
+    {|
+---
+name: reviewer
+tools: grep, read
+disallowed-tools: edit
+permission-mode: accept-edits
+max-turns: 3
+---
+Review the implementation and summarize issues.
+|}
+```
+
+Run with typed subagents:
+
+```ocaml
+let result = Agent.run_with_subagents ~sw agent ~specs:[reviewer] "delegate"
+```
+
+## Build and Test
 
 ```bash
-# 단위 테스트
+dune build
 dune runtest
-
-# 통합 테스트 (로컬 LLM 서버 필요)
-LLAMA_LIVE_TEST=1 dune exec ./test/test_local_llm.exe
-LLAMA_LIVE_TEST=1 dune exec ./test/test_streaming_e2e.exe
-dune exec ./test/test_integration.exe
 ```
 
-## stop_reason 처리
+Selected executables:
 
-API 응답의 `stop_reason` 필드는 `Unknown of string` variant를 포함한다. 알 수 없는 값이 들어와도 silent 무시하지 않고 원본 문자열을 보존한다.
-
-```ocaml
-match Types.stop_reason_of_string "some_new_reason" with
-| Types.Unknown s -> Printf.printf "Unknown stop reason: %s\n" s
-| Types.EndTurn -> (* ... *)
-| _ -> (* ... *)
+```bash
+dune exec ./test/test_local_llm.exe
+dune exec ./test/test_streaming_e2e.exe
 ```
 
-## 의존성
+## Constraints
 
-- `eio`, `eio_main` — 구조적 동시성
-- `cohttp-eio` — HTTP 클라이언트
-- `yojson` — JSON 파싱
-- `ppx_deriving` — show, eq 자동 생성
-- `alcotest` — 테스트 (dev)
+- HTTP response body hard limit: 10MB
+- streaming retry is not automatic; callers should wrap `create_message_stream` externally
+- frontmatter parsing is intentionally lightweight, not full YAML
+- skill/subagent filesystem loading is local-only and synchronous
 
-## 제약 및 트레이드오프
+## Version
 
-- HTTP 응답 본문 상한: 10MB. 이보다 큰 응답은 에러 처리.
-- streaming 미지원. 전체 응답을 버퍼링한 뒤 파싱.
-- tool_use 루프에서 max_turns 초과 시 마지막 응답을 반환하고 종료.
-
-## 버전
-
-0.2.0
+`0.4.0`

--- a/TODO.md
+++ b/TODO.md
@@ -1,20 +1,21 @@
-# Agent SDK OCaml - 2026 Roadmap
+# `agent_sdk` Roadmap
 
-최신 Anthropic Claude 3.7+ 스펙 반영 및 프로덕션 급 완성도를 위한 할 일 목록
+## High Priority
 
-## 🚀 High Priority (핵심 기능)
-- [ ] **Streaming (SSE) 지원**: `Cohttp_eio`를 활용하여 `Thinking` 블록과 `Text` 블록을 실시간으로 스트리밍하는 기능 구현.
-- [ ] **PR 상신 및 Merge**: 현재 `workspace`에 있는 코드를 `main` 브랜치로 안전하게 머지 (Worktree 활용 필수).
-- [ ] **Detailed Error Handling**: API 에러 응답(429, 503 등)을 단순 문자열이 아닌 커스텀 Variant 타입으로 정의하여 재시도 로직과 연동.
+- [ ] Add typed multimodal content blocks (`Image`, `Document`) and response parsing
+- [ ] Add prompt caching primitives and cache-control helpers
+- [ ] Add MCP resource / prompt surfaces so orchestration layers can mount MCP without flattening everything into tools
+- [ ] Add richer permission adapters for interactive approval flows beyond hook-based allow/deny
 
-## 🛠 Medium Priority (사용성 개선)
-- [ ] **Multimodal 지원**: `ContentBlock`에 `Image` 및 `Document` (PDF 등) 타입 추가.
-- [ ] **Prompt Caching**: `cache_control` 파라미터 지원 및 에이전트 레벨의 캐싱 전략 구현.
-- [ ] **Middleware/Hooks**: 에이전트 실행 전후에 로깅이나 인시던트 트래킹을 할 수 있는 훅 시스템 도입.
+## Medium Priority
 
-## 🧪 Low Priority (최적화 및 테스트)
-- [ ] **Eio Multicore 활용**: 여러 에이전트를 동시에 돌릴 때 멀티코어 성능을 극대화할 수 있도록 `Eio.Executor` 활용 검토.
-- [ ] **Property-based Testing**: `Crowbar` 등을 사용하여 도구 호출 시나리오의 엣지 케이스 자동 탐색.
+- [ ] Add async/background hook adapters (command / HTTP / prompt) instead of raw callback-only hooks
+- [ ] Add session persistence helpers for transcript snapshots and resume points
+- [ ] Add first-class output artifact types instead of string-only tool results
+- [ ] Add stronger frontmatter parsing or structured config loading for skills/subagents
 
----
-*Last Updated: 2026-02-20*
+## Low Priority
+
+- [ ] Property-based tests for tool loop and permission transitions
+- [ ] Better performance benchmarks for parallel tool execution and multi-agent delegation
+- [ ] Compaction / memory summarization hooks for long-running sessions

--- a/lib/agent.ml
+++ b/lib/agent.ml
@@ -1,141 +1,218 @@
 (** Agent implementation using Eio structured concurrency.
-    Supports hooks, context, guardrails, and handoffs as optional features. *)
+    Supports hooks, context, guardrails, sessions, skills, and handoffs. *)
 
 open Types
 
 type t = {
-  mutable state: agent_state;
-  tools: Tool.t list;
-  base_url: string;
-  provider: Provider.config option;
-  net: [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t;
-  hooks: Hooks.hooks;
-  context: Context.t;
-  guardrails: Guardrails.t;
+  mutable state : agent_state;
+  tools : Tool.t list;
+  base_url : string;
+  provider : Provider.config option;
+  net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t;
+  hooks : Hooks.hooks;
+  context : Context.t;
+  guardrails : Guardrails.t;
+  session : Session.t;
 }
 
-let create ~net ?(config=default_config) ?(tools=[]) ?(base_url=Api.default_base_url)
-    ?provider ?(hooks=Hooks.empty) ?context ?(guardrails=Guardrails.default) () =
+let create ~net ?(config = default_config) ?(tools = []) ?(base_url = Api.default_base_url)
+    ?provider ?(hooks = Hooks.empty) ?context ?(guardrails = Guardrails.default)
+    ?session () =
   let state = {
     config;
     messages = [];
     turn_count = 0;
     usage = empty_usage;
   } in
-  let ctx = match context with
-    | Some c -> c
-    | None -> Context.create ()
+  let context = Option.value context ~default:(Context.create ()) in
+  let session = Option.value session ~default:(Session.create ()) in
+  { state; tools; base_url; provider; net; hooks; context; guardrails; session }
+
+let emit_session_end agent result =
+  let _ =
+    Hooks.invoke agent.hooks.session_end
+      (Hooks.SessionEnd { session = agent.session; result })
   in
-  { state; tools; base_url; provider; net; hooks; context = ctx; guardrails }
+  result
+
+let authorize_tool_use agent (tool : Tool.t) input =
+  match Guardrails.permission_for_tool agent.guardrails tool.schema with
+  | Guardrails.Authorized -> Ok ()
+  | Guardrails.Rejected reason -> Error reason
+  | Guardrails.Requires_confirmation reason ->
+      let decision =
+        Hooks.invoke agent.hooks.permission_request
+          (Hooks.PermissionRequest {
+             tool_name = tool.schema.name;
+             tool_kind = tool.schema.kind;
+             input;
+             permission_mode = agent.guardrails.permission_mode;
+             reason;
+           })
+      in
+      (match decision with
+       | Hooks.Allow -> Ok ()
+       | Hooks.Deny msg -> Error msg
+       | Hooks.Skip -> Error "tool blocked by permission hook"
+       | Hooks.Ask | Hooks.Continue ->
+           Error (Printf.sprintf "permission required for tool '%s': %s"
+                    tool.schema.name reason)
+       | Hooks.Override _ -> Ok ())
+
+let apply_output_limit agent content =
+  Guardrails.apply_output_limit agent.guardrails content |> fst
 
 (** Execute tools in parallel using Eio fibers.
-    Applies PreToolUse/PostToolUse hooks and passes context to context-aware handlers.
-    Each fiber catches exceptions to prevent one tool failure from canceling siblings. *)
+    Each fiber catches exceptions so one tool failure does not cancel siblings. *)
 let execute_tools agent tool_uses =
   Eio.Fiber.List.map (fun block ->
     match block with
     | ToolUse (id, name, input) ->
         (try
-          (* PreToolUse hook *)
-          let decision = Hooks.invoke agent.hooks.pre_tool_use
-            (Hooks.PreToolUse { tool_name = name; input }) in
-          (match decision with
-          | Hooks.Skip -> (id, "Tool execution skipped by hook", false)
-          | Hooks.Override value -> (id, value, false)
-          | Hooks.Continue ->
-            let tool_opt = List.find_opt (fun (tool: Tool.t) -> tool.schema.name = name) agent.tools in
-            (match tool_opt with
-            | Some tool ->
-                let result = Tool.execute ~context:agent.context tool input in
-                (* PostToolUse hook *)
-                let _post = Hooks.invoke agent.hooks.post_tool_use
-                  (Hooks.PostToolUse { tool_name = name; input; output = result }) in
-                let content, is_error = match result with
-                  | Ok output -> output, false
-                  | Error err -> err, true
-                in
-                (id, content, is_error)
-            | None -> (id, "Tool not found", true)))
-        with exn ->
-          let msg = Printf.sprintf "Tool '%s' raised: %s" name (Printexc.to_string exn) in
-          (id, msg, true))
-    | _ -> ("", "", true)
-  ) tool_uses
+           let decision =
+             Hooks.invoke agent.hooks.pre_tool_use
+               (Hooks.PreToolUse { tool_name = name; input })
+           in
+           match decision with
+           | Hooks.Skip -> (id, "Tool execution skipped by hook", false)
+           | Hooks.Override value -> (id, value, false)
+           | Hooks.Deny msg -> (id, msg, true)
+           | Hooks.Ask -> (id, "Tool execution deferred by hook", true)
+           | Hooks.Allow | Hooks.Continue ->
+               let tool_opt =
+                 List.find_opt (fun (tool : Tool.t) -> tool.schema.name = name) agent.tools
+               in
+               match tool_opt with
+               | None -> (id, "Tool not found", true)
+               | Some tool ->
+                   (match authorize_tool_use agent tool input with
+                    | Error reason -> (id, reason, true)
+                    | Ok () ->
+                        let result = Tool.execute ~context:agent.context tool input in
+                        let result =
+                          match result with
+                          | Ok output -> Ok (apply_output_limit agent output)
+                          | Error _ as err -> err
+                        in
+                        let _ =
+                          Hooks.invoke agent.hooks.post_tool_use
+                            (Hooks.PostToolUse {
+                               tool_name = name;
+                               input;
+                               output = result;
+                             })
+                        in
+                        match result with
+                        | Ok output -> (id, output, false)
+                        | Error err -> (id, err, true))
+         with exn ->
+           let msg =
+             Printf.sprintf "Tool '%s' raised: %s" name (Printexc.to_string exn)
+           in
+           (id, msg, true))
+    | _ -> ("", "", true))
+    tool_uses
 
-(** Run a single turn with hook and guardrail support *)
 let run_turn ~sw ?clock agent =
-  (* BeforeTurn hook *)
-  let _before = Hooks.invoke agent.hooks.before_turn
-    (Hooks.BeforeTurn { turn = agent.state.turn_count; messages = agent.state.messages }) in
+  let _ =
+    Hooks.invoke agent.hooks.before_turn
+      (Hooks.BeforeTurn {
+         turn = agent.state.turn_count;
+         messages = agent.state.messages;
+       })
+  in
 
-  (* Apply guardrails: filter tools visible to LLM *)
   let visible_tools = Guardrails.filter_tools agent.guardrails agent.tools in
   let tool_schemas = List.map Tool.schema_to_json visible_tools in
   let tools_json = if tool_schemas = [] then None else Some tool_schemas in
 
-  match Api.create_message ~sw ~net:agent.net ~base_url:agent.base_url ?provider:agent.provider ?clock ~config:agent.state ~messages:agent.state.messages ?tools:tools_json () with
+  match
+    Api.create_message ~sw ~net:agent.net ~base_url:agent.base_url ?provider:agent.provider
+      ?clock ~config:agent.state ~messages:agent.state.messages ?tools:tools_json ()
+  with
   | Error e -> Error e
   | Ok response ->
-      (* Accumulate usage stats *)
-      let usage = match response.usage with
-        | Some (input, output) -> add_usage agent.state.usage input output
+      let usage =
+        match response.usage with
+        | Some (input_tokens, output_tokens) ->
+            add_usage agent.state.usage input_tokens output_tokens
         | None -> { agent.state.usage with api_calls = agent.state.usage.api_calls + 1 }
       in
-
-      (* AfterTurn hook *)
-      let _after = Hooks.invoke agent.hooks.after_turn
-        (Hooks.AfterTurn { turn = agent.state.turn_count; response }) in
-
-      agent.state <- { agent.state with
-        messages = agent.state.messages @ [{ role = Assistant; content = response.content }];
+      let _ =
+        Hooks.invoke agent.hooks.after_turn
+          (Hooks.AfterTurn { turn = agent.state.turn_count; response })
+      in
+      agent.state <- {
+        agent.state with
+        messages = agent.state.messages @ [ { role = Assistant; content = response.content } ];
         turn_count = agent.state.turn_count + 1;
         usage;
       };
+      Session.record_turn agent.session;
 
       match response.stop_reason with
       | StopToolUse ->
-        let tool_uses = List.filter (function ToolUse _ -> true | _ -> false) response.content in
-
-        (* Guardrail: check tool call count limit *)
-        let count = List.length tool_uses in
-        (match Guardrails.exceeds_limit agent.guardrails count with
-        | true ->
-          let msg = Printf.sprintf "Tool call limit exceeded: %d calls in one turn" count in
-          agent.state <- { agent.state with
-            messages = agent.state.messages @ [{ role = User; content = [Text msg] }] };
-          Ok (`ToolsExecuted)
-        | false ->
-          let results = execute_tools agent tool_uses in
-          let tool_results = List.map (fun (id, content, is_error) ->
-            ToolResult (id, content, is_error)
-          ) results in
-          agent.state <- { agent.state with messages = agent.state.messages @ [{ role = User; content = tool_results }] };
-          Ok (`ToolsExecuted))
+          let tool_uses =
+            List.filter (function ToolUse _ -> true | _ -> false) response.content
+          in
+          let count = List.length tool_uses in
+          if Guardrails.exceeds_limit agent.guardrails count then (
+            let msg =
+              Printf.sprintf "Tool call limit exceeded: %d calls in one turn" count
+            in
+            agent.state <- {
+              agent.state with
+              messages =
+                agent.state.messages @ [ { role = User; content = [ Text msg ] } ];
+            };
+            Ok `ToolsExecuted
+          ) else (
+            let results = execute_tools agent tool_uses in
+            let tool_results =
+              List.map (fun (id, content, is_error) -> ToolResult (id, content, is_error))
+                results
+            in
+            agent.state <- {
+              agent.state with
+              messages =
+                agent.state.messages @ [ { role = User; content = tool_results } ];
+            };
+            Ok `ToolsExecuted
+          )
       | EndTurn | MaxTokens | StopSequence ->
-        (* OnStop hook *)
-        let _stop = Hooks.invoke agent.hooks.on_stop
-          (Hooks.OnStop { reason = response.stop_reason; response }) in
-        Ok (`Complete response)
+          let _ =
+            Hooks.invoke agent.hooks.on_stop
+              (Hooks.OnStop { reason = response.stop_reason; response })
+          in
+          Ok (`Complete response)
       | Unknown reason ->
-        Error (Printf.sprintf "Unrecognized stop_reason from API: %s" reason)
+          Error (Printf.sprintf "Unrecognized stop_reason from API: %s" reason)
 
-(** Run loop *)
 let run ~sw ?clock agent user_prompt =
-  agent.state <- { agent.state with messages = agent.state.messages @ [{ role = User; content = [Text user_prompt] }] };
+  let _ =
+    Hooks.invoke agent.hooks.session_start
+      (Hooks.SessionStart { session = agent.session; prompt = user_prompt })
+  in
+  let _ =
+    Hooks.invoke agent.hooks.user_prompt_submit
+      (Hooks.UserPromptSubmit { session = agent.session; prompt = user_prompt })
+  in
+  agent.state <- {
+    agent.state with
+    messages = agent.state.messages @ [ { role = User; content = [ Text user_prompt ] } ];
+  };
 
   let rec loop () =
     if agent.state.turn_count >= agent.state.config.max_turns then
-      Error "Max turns exceeded"
+      emit_session_end agent (Error "Max turns exceeded")
     else
       match run_turn ~sw ?clock agent with
-      | Error e -> Error e
-      | Ok `Complete response -> Ok response
+      | Error e -> emit_session_end agent (Error e)
+      | Ok (`Complete response) -> emit_session_end agent (Ok response)
       | Ok `ToolsExecuted -> loop ()
   in
   loop ()
 
-(** Find the most recent assistant message and extract the first handoff ToolUse.
-    Returns (tool_use_id, target_name, prompt) or None. *)
 let find_handoff_in_messages messages =
   let last_assistant =
     List.rev messages |> List.find_opt (fun message -> message.role = Assistant)
@@ -143,44 +220,41 @@ let find_handoff_in_messages messages =
   match last_assistant with
   | None -> None
   | Some assistant_message ->
-      List.fold_left (fun acc block ->
-        match acc with
-        | Some _ -> acc
-        | None ->
-            match block with
-            | ToolUse (id, name, input) when Handoff.is_handoff_tool name ->
-                let target_name = Handoff.target_name_of_tool name in
-                let prompt =
-                  match input with
-                  | `Assoc pairs ->
-                      (match List.assoc_opt "prompt" pairs with
-                       | Some (`String s) -> s
-                       | _ -> "Continue the conversation.")
-                  | _ -> "Continue the conversation."
-                in
-                Some (id, target_name, prompt)
-            | _ -> None
-      ) None assistant_message.content
+      List.fold_left
+        (fun acc block ->
+          match acc with
+          | Some _ -> acc
+          | None ->
+              match block with
+              | ToolUse (id, name, input) when Handoff.is_handoff_tool name ->
+                  let target_name = Handoff.target_name_of_tool name in
+                  let prompt =
+                    match input with
+                    | `Assoc pairs ->
+                        (match List.assoc_opt "prompt" pairs with
+                         | Some (`String s) -> s
+                         | _ -> "Continue the conversation.")
+                    | _ -> "Continue the conversation."
+                  in
+                  Some (id, target_name, prompt)
+              | _ -> None)
+        None assistant_message.content
 
-(** Replace the tool result emitted for a specific ToolUse id in the most recent
-    user tool_result message. This lets handoff interception overwrite the
-    sentinel handler output with the delegated agent response. *)
 let replace_tool_result messages ~tool_id ~content ~is_error =
   let replace_in_content blocks =
     List.map (function
       | ToolResult (id, _, _) when id = tool_id -> ToolResult (id, content, is_error)
-      | block -> block
-    ) blocks
+      | block -> block)
+      blocks
   in
   let rec rewrite rev_prefix = function
     | [] ->
-        List.rev ({ role = User; content = [ToolResult (tool_id, content, is_error)] } :: rev_prefix)
+        List.rev ({ role = User; content = [ ToolResult (tool_id, content, is_error) ] } :: rev_prefix)
     | ((message : message) :: rest) ->
         let has_tool_result =
-          List.exists (function
-            | ToolResult (id, _, _) when id = tool_id -> true
-            | _ -> false
-          ) message.content
+          List.exists
+            (function ToolResult (id, _, _) when id = tool_id -> true | _ -> false)
+            message.content
         in
         if message.role = User && has_tool_result then
           List.rev_append rev_prefix ({ message with content = replace_in_content message.content } :: rest)
@@ -189,67 +263,126 @@ let replace_tool_result messages ~tool_id ~content ~is_error =
   in
   rewrite [] (List.rev messages)
 
-(** Run with handoff support.
-    Handoff tools are added to the agent's tool list.
-    When the LLM calls a transfer_to_* tool, a sub-agent is spawned and run.
-    The sub-agent's final text is returned as the tool result. *)
 let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
   let handoff_tools = List.map Handoff.make_handoff_tool targets in
   let all_tools = agent.tools @ handoff_tools in
   let agent_with_handoffs = { agent with tools = all_tools } in
 
   let rec loop () =
-    if agent_with_handoffs.state.turn_count >= agent_with_handoffs.state.config.max_turns then
-      Error "Max turns exceeded"
+    if agent_with_handoffs.state.turn_count >= agent_with_handoffs.state.config.max_turns
+    then emit_session_end agent_with_handoffs (Error "Max turns exceeded")
     else
       match run_turn ~sw ?clock agent_with_handoffs with
-      | Error e -> Error e
-      | Ok `Complete response -> Ok response
+      | Error e -> emit_session_end agent_with_handoffs (Error e)
+      | Ok (`Complete response) -> emit_session_end agent_with_handoffs (Ok response)
       | Ok `ToolsExecuted ->
-        (* Check if the last assistant message contained a handoff tool call *)
-        (match find_handoff_in_messages agent_with_handoffs.state.messages with
-         | Some (tool_id, target_name, prompt) ->
-           (* Find matching target definition *)
-           let target_opt = List.find_opt
-             (fun (t : Handoff.handoff_target) -> t.name = target_name) targets in
-           (match target_opt with
-            | None ->
-              (* Unknown target: replace the sentinel result with a useful error. *)
-              let err_msg = Printf.sprintf "Unknown handoff target: %s" target_name in
-              agent_with_handoffs.state <- { agent_with_handoffs.state with
-                messages =
-                  replace_tool_result agent_with_handoffs.state.messages
-                    ~tool_id ~content:err_msg ~is_error:true };
-              loop ()
-            | Some target ->
-              (* Create sub-agent with target's config and tools *)
-              let sub = create ~net:agent.net ~config:target.config
-                ~tools:target.tools ~base_url:agent.base_url
-                ?provider:agent.provider () in
-               (match run ~sw ?clock sub prompt with
-               | Error e ->
-                 let err_msg = Printf.sprintf "Handoff to %s failed: %s" target_name e in
-                 agent_with_handoffs.state <- { agent_with_handoffs.state with
-                   messages =
-                     replace_tool_result agent_with_handoffs.state.messages
-                       ~tool_id ~content:err_msg ~is_error:true };
-                 loop ()
-               | Ok sub_response ->
-                 (* Extract text from sub-agent response *)
-                 let text = List.fold_left (fun acc block ->
-                   match block with
-                   | Text s -> if acc = "" then s else acc ^ "\n" ^ s
-                   | _ -> acc
-                 ) "" sub_response.content in
-                 agent_with_handoffs.state <- { agent_with_handoffs.state with
-                   messages =
-                     replace_tool_result agent_with_handoffs.state.messages
-                       ~tool_id ~content:text ~is_error:false };
-                 loop ()))
-         | None ->
-           (* No handoff detected, normal tool execution loop *)
-           loop ())
+          (match find_handoff_in_messages agent_with_handoffs.state.messages with
+           | None -> loop ()
+           | Some (tool_id, target_name, prompt) ->
+               let target_opt =
+                 List.find_opt (fun (target : Handoff.handoff_target) -> target.name = target_name)
+                   targets
+               in
+               match target_opt with
+               | None ->
+                   let err_msg = Printf.sprintf "Unknown handoff target: %s" target_name in
+                   agent_with_handoffs.state <- {
+                     agent_with_handoffs.state with
+                     messages =
+                       replace_tool_result agent_with_handoffs.state.messages
+                         ~tool_id ~content:err_msg ~is_error:true;
+                   };
+                   loop ()
+               | Some target ->
+                   let _ =
+                     Hooks.invoke agent_with_handoffs.hooks.subagent_start
+                       (Hooks.SubagentStart {
+                          session = agent_with_handoffs.session;
+                          target_name;
+                          prompt;
+                        })
+                   in
+                   let sub =
+                     create ~net:agent.net ~config:target.config ~tools:target.tools
+                       ~base_url:agent.base_url ?provider:agent.provider
+                       ?hooks:target.hooks ?guardrails:target.guardrails
+                       ?session:target.session ()
+                   in
+                   (match run ~sw ?clock sub prompt with
+                    | Error e ->
+                        let err_msg =
+                          Printf.sprintf "Handoff to %s failed: %s" target_name e
+                        in
+                        let _ =
+                          Hooks.invoke agent_with_handoffs.hooks.subagent_stop
+                            (Hooks.SubagentStop {
+                               session = agent_with_handoffs.session;
+                               target_name;
+                               result = Error e;
+                             })
+                        in
+                        agent_with_handoffs.state <- {
+                          agent_with_handoffs.state with
+                          messages =
+                            replace_tool_result agent_with_handoffs.state.messages
+                              ~tool_id ~content:err_msg ~is_error:true;
+                        };
+                        loop ()
+                    | Ok sub_response ->
+                        let text =
+                          List.fold_left
+                            (fun acc block ->
+                              match block with
+                              | Text s when acc = "" -> s
+                              | Text s -> acc ^ "\n" ^ s
+                              | _ -> acc)
+                            "" sub_response.content
+                        in
+                        let _ =
+                          Hooks.invoke agent_with_handoffs.hooks.subagent_stop
+                            (Hooks.SubagentStop {
+                               session = agent_with_handoffs.session;
+                               target_name;
+                               result = Ok text;
+                             })
+                        in
+                        agent_with_handoffs.state <- {
+                          agent_with_handoffs.state with
+                          messages =
+                            replace_tool_result agent_with_handoffs.state.messages
+                              ~tool_id ~content:text ~is_error:false;
+                        };
+                        loop ()))
   in
-  agent_with_handoffs.state <- { agent_with_handoffs.state with
-    messages = agent_with_handoffs.state.messages @ [{ role = User; content = [Text user_prompt] }] };
+
+  let _ =
+    Hooks.invoke agent_with_handoffs.hooks.session_start
+      (Hooks.SessionStart { session = agent_with_handoffs.session; prompt = user_prompt })
+  in
+  let _ =
+    Hooks.invoke agent_with_handoffs.hooks.user_prompt_submit
+      (Hooks.UserPromptSubmit {
+         session = agent_with_handoffs.session;
+         prompt = user_prompt;
+       })
+  in
+  agent_with_handoffs.state <- {
+    agent_with_handoffs.state with
+    messages =
+      agent_with_handoffs.state.messages
+      @ [ { role = User; content = [ Text user_prompt ] } ];
+  };
   loop ()
+
+let run_with_subagents ~sw ?clock agent ~specs user_prompt =
+  let targets =
+    List.map
+      (Subagent.to_handoff_target
+         ~parent_config:agent.state.config
+         ~base_tools:agent.tools
+         ~base_guardrails:agent.guardrails
+         ~base_hooks:agent.hooks
+         ~base_session:agent.session)
+      specs
+  in
+  run_with_handoffs ~sw ?clock agent ~targets user_prompt

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -46,9 +46,13 @@ module Hooks = Hooks
 module Context = Context
 module Guardrails = Guardrails
 module Handoff = Handoff
+module Session = Session
+module Skill = Skill
+module Subagent = Subagent
 
 (** Quick start: create an agent with default config *)
-let create_agent ~net ?name ?model ?system_prompt ?max_tokens ?max_turns ?provider () =
+let create_agent ~net ?name ?model ?system_prompt ?max_tokens ?max_turns
+    ?provider ?hooks ?guardrails ?session () =
   let open Types in
   let config = {
     default_config with
@@ -58,8 +62,8 @@ let create_agent ~net ?name ?model ?system_prompt ?max_tokens ?max_turns ?provid
     max_tokens = Option.value max_tokens ~default:default_config.max_tokens;
     max_turns = Option.value max_turns ~default:default_config.max_turns;
   } in
-  Agent.create ~net ~config ?provider ()
+  Agent.create ~net ~config ?provider ?hooks ?guardrails ?session ()
 
 (** Version info *)
-let version = "0.2.0"
+let version = "0.4.0"
 let sdk_name = "anthropic-agent-sdk"

--- a/lib/dune
+++ b/lib/dune
@@ -1,5 +1,5 @@
 (library
  (name agent_sdk)
  (public_name agent_sdk)
- (libraries eio eio_main cohttp-eio tls tls-eio ca-certs yojson ppx_deriving_yojson.runtime uri)
+ (libraries eio eio_main cohttp-eio tls tls-eio ca-certs yojson ppx_deriving_yojson.runtime uri unix str)
  (preprocess (pps ppx_deriving_yojson ppx_deriving.show)))

--- a/lib/guardrails.ml
+++ b/lib/guardrails.ml
@@ -1,43 +1,121 @@
-(** Guardrails for tool filtering and execution limits.
-    Inspired by Anthropic SDK's allowedTools + permissionMode.
-
-    Filters are applied when building the tool list sent to the API,
-    so the LLM only sees allowed tools. *)
+(** Guardrails for tool visibility, permission handling, and output limits.
+    Inspired by Claude Code's allowedTools + permissionMode model. *)
 
 open Types
 
-(** Tool filter: controls which tools are visible to the LLM *)
 type tool_filter =
   | AllowAll
   | AllowList of string list
   | DenyList of string list
   | Custom of (tool_schema -> bool)
 
-(** Guardrail configuration *)
+type permission_mode =
+  | Default
+  | Accept_edits
+  | Dont_ask
+  | Bypass_permissions
+  | Plan
+[@@deriving show]
+
+type permission_outcome =
+  | Authorized
+  | Requires_confirmation of string
+  | Rejected of string
+[@@deriving show]
+
 type t = {
-  tool_filter: tool_filter;
-  max_tool_calls_per_turn: int option;
+  tool_filter : tool_filter;
+  max_tool_calls_per_turn : int option;
+  permission_mode : permission_mode;
+  allow_tools : string list;
+  ask_tools : string list;
+  deny_tools : string list;
+  additional_directories : string list;
+  max_output_chars : int option;
+  disable_bypass_permissions : bool;
 }
 
 let default = {
   tool_filter = AllowAll;
   max_tool_calls_per_turn = None;
+  permission_mode = Default;
+  allow_tools = [];
+  ask_tools = [];
+  deny_tools = [];
+  additional_directories = [];
+  max_output_chars = None;
+  disable_bypass_permissions = false;
 }
 
-(** Check if a tool is allowed by the filter *)
+let match_rule rule (schema : tool_schema) =
+  let rule = String.trim rule in
+  rule = "*"
+  || rule = schema.name
+  || (String.starts_with ~prefix:"kind:" rule
+      && String.equal
+           (String.lowercase_ascii (String.sub rule 5 (String.length rule - 5)))
+           (tool_kind_to_string schema.kind))
+  || (String.ends_with ~suffix:"*" rule
+      && String.starts_with
+           ~prefix:(String.sub rule 0 (String.length rule - 1))
+           schema.name)
+
 let is_allowed guardrails (schema : tool_schema) =
   match guardrails.tool_filter with
   | AllowAll -> true
-  | AllowList names -> List.mem schema.name names
-  | DenyList names -> not (List.mem schema.name names)
+  | AllowList names -> List.exists (fun rule -> match_rule rule schema) names
+  | DenyList names -> not (List.exists (fun rule -> match_rule rule schema) names)
   | Custom pred -> pred schema
 
-(** Filter a list of tools based on guardrails *)
 let filter_tools guardrails tools =
   List.filter (fun (tool : Tool.t) -> is_allowed guardrails tool.schema) tools
 
-(** Check if tool call count exceeds the per-turn limit *)
 let exceeds_limit guardrails count =
   match guardrails.max_tool_calls_per_turn with
   | None -> false
-  | Some max -> count > max
+  | Some max_calls -> count > max_calls
+
+let listed rules schema =
+  List.exists (fun rule -> match_rule rule schema) rules
+
+let permission_for_tool guardrails (schema : tool_schema) =
+  if listed guardrails.deny_tools schema then
+    Rejected "tool is explicitly denied by guardrails"
+  else if listed guardrails.allow_tools schema then
+    Authorized
+  else if listed guardrails.ask_tools schema then
+    Requires_confirmation "tool requires explicit approval"
+  else
+    match guardrails.permission_mode, schema.kind with
+    | Bypass_permissions, _ when not guardrails.disable_bypass_permissions -> Authorized
+    | Bypass_permissions, _ -> Rejected "bypass_permissions is disabled by guardrails"
+    | Plan, Read_only -> Authorized
+    | Plan, _ -> Rejected "permission mode 'plan' allows read-only tools only"
+    | Dont_ask, Read_only -> Authorized
+    | Dont_ask, _ -> Rejected "permission mode 'dont_ask' rejects tools that would need confirmation"
+    | Accept_edits, (Read_only | File_edit) -> Authorized
+    | Accept_edits, _ -> Requires_confirmation "tool needs explicit approval in accept_edits mode"
+    | Default, Read_only -> Authorized
+    | Default, _ -> Requires_confirmation "tool needs explicit approval in default mode"
+
+let path_is_allowed guardrails path =
+  guardrails.additional_directories = []
+  || List.exists
+       (fun dir ->
+         let dir =
+           if String.ends_with ~suffix:"/" dir then dir else dir ^ "/"
+         in
+         path = String.sub dir 0 (String.length dir - 1)
+         || String.starts_with ~prefix:dir path)
+       guardrails.additional_directories
+
+let apply_output_limit guardrails output =
+  match guardrails.max_output_chars with
+  | None -> (output, false)
+  | Some max_chars when String.length output <= max_chars -> (output, false)
+  | Some max_chars ->
+      let keep = max 0 (min max_chars (String.length output)) in
+      let trimmed =
+        if keep = 0 then "" else String.sub output 0 keep
+      in
+      (trimmed ^ "\n...[truncated by guardrails]", true)

--- a/lib/handoff.ml
+++ b/lib/handoff.ml
@@ -1,62 +1,51 @@
-(** Sub-agent delegation and handoff.
-    Inspired by Anthropic SDK's AgentDefinition + Task tool
-    and Google ADK's Root/Sub-agent pattern.
+(** Sub-agent delegation and handoff. *)
 
-    To avoid circular dependency with Agent, handoff defines types and
-    a tool constructor. Actual delegation is done by Agent.run_with_handoffs
-    which intercepts ToolUse blocks matching "transfer_to_*" names. *)
-
-(** Handoff target definition *)
 type handoff_target = {
-  name: string;
-  description: string;
-  config: Types.agent_config;
-  tools: Tool.t list;
+  name : string;
+  description : string;
+  config : Types.agent_config;
+  tools : Tool.t list;
+  hooks : Hooks.hooks option;
+  guardrails : Guardrails.t option;
+  session : Session.t option;
 }
 
-(** Result of a handoff execution *)
 type handoff_result = {
-  target_name: string;
-  response: Types.api_response;
+  target_name : string;
+  response : Types.api_response;
 }
 
-(** Delegate function type -- provided by Agent at runtime.
-    Takes switch, target definition, and user prompt.
-    Returns the sub-agent's API response or an error. *)
 type delegate_fn =
   sw:Eio.Switch.t ->
   handoff_target ->
   string ->
   (Types.api_response, string) result
 
-(** Prefix used to identify handoff tools in ToolUse blocks *)
 let handoff_prefix = "transfer_to_"
 
-(** Check if a tool name is a handoff tool *)
 let is_handoff_tool name =
   let prefix_len = String.length handoff_prefix in
   String.length name >= prefix_len
   && String.sub name 0 prefix_len = handoff_prefix
 
-(** Extract target name from handoff tool name *)
 let target_name_of_tool name =
   let prefix_len = String.length handoff_prefix in
   String.sub name prefix_len (String.length name - prefix_len)
 
-(** Create a handoff tool visible to the LLM.
-    The handler is a stub -- actual delegation is intercepted
-    by the agent runner before this handler is called. *)
 let make_handoff_tool (target : handoff_target) : Tool.t =
   let handler _input =
     Error "Handoff tools are intercepted by the agent runner"
   in
   Tool.create
+    ~kind:Task
     ~name:(Printf.sprintf "%s%s" handoff_prefix target.name)
     ~description:(Printf.sprintf "Hand off to %s: %s" target.name target.description)
     ~parameters:[
-      { Types.name = "prompt";
+      {
+        Types.name = "prompt";
         description = "Instructions for the sub-agent";
         param_type = Types.String;
-        required = true }
+        required = true;
+      };
     ]
     handler

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -1,48 +1,87 @@
 (** Lifecycle hooks for agent execution.
-    Inspired by Anthropic SDK PreToolUse/PostToolUse/Stop
-    and Google ADK ToolContext patterns.
-
-    All hook types use exhaustive variants for compile-time safety. *)
+    Inspired by Claude Code hooks and SDK runtime callbacks. *)
 
 open Types
 
-(** Events emitted during agent execution *)
-type hook_event =
-  | BeforeTurn of { turn: int; messages: message list }
-  | AfterTurn of { turn: int; response: api_response }
-  | PreToolUse of { tool_name: string; input: Yojson.Safe.t }
-  | PostToolUse of { tool_name: string; input: Yojson.Safe.t; output: (string, string) result }
-  | OnStop of { reason: stop_reason; response: api_response }
-
-(** Decision returned by a hook *)
-type hook_decision =
-  | Continue
-  | Skip           (** PreToolUse only: skip this tool execution *)
-  | Override of string  (** PreToolUse only: return this value instead *)
-
-(** A hook function *)
-type hook = hook_event -> hook_decision
-
-(** Collection of optional hooks *)
-type hooks = {
-  before_turn: hook option;
-  after_turn: hook option;
-  pre_tool_use: hook option;
-  post_tool_use: hook option;
-  on_stop: hook option;
+type permission_request = {
+  tool_name : string;
+  tool_kind : tool_kind;
+  input : Yojson.Safe.t;
+  permission_mode : Guardrails.permission_mode;
+  reason : string;
 }
 
-(** Empty hooks -- no-op default *)
+type hook_event =
+  | SessionStart of { session : Session.t; prompt : string }
+  | SessionEnd of { session : Session.t; result : (api_response, string) result }
+  | UserPromptSubmit of { session : Session.t; prompt : string }
+  | BeforeTurn of { turn : int; messages : message list }
+  | AfterTurn of { turn : int; response : api_response }
+  | PermissionRequest of permission_request
+  | PreToolUse of { tool_name : string; input : Yojson.Safe.t }
+  | PostToolUse of {
+      tool_name : string;
+      input : Yojson.Safe.t;
+      output : (string, string) result;
+    }
+  | SubagentStart of { session : Session.t; target_name : string; prompt : string }
+  | SubagentStop of {
+      session : Session.t;
+      target_name : string;
+      result : (string, string) result;
+    }
+  | PreCompact of { session : Session.t; reason : string }
+  | ConfigChange of {
+      session : Session.t;
+      key : string;
+      old_value : Yojson.Safe.t option;
+      new_value : Yojson.Safe.t;
+    }
+  | OnStop of { reason : stop_reason; response : api_response }
+
+type hook_decision =
+  | Continue
+  | Allow
+  | Ask
+  | Deny of string
+  | Skip
+  | Override of string
+
+type hook = hook_event -> hook_decision
+
+type hooks = {
+  session_start : hook option;
+  session_end : hook option;
+  user_prompt_submit : hook option;
+  before_turn : hook option;
+  after_turn : hook option;
+  permission_request : hook option;
+  pre_tool_use : hook option;
+  post_tool_use : hook option;
+  subagent_start : hook option;
+  subagent_stop : hook option;
+  pre_compact : hook option;
+  config_change : hook option;
+  on_stop : hook option;
+}
+
 let empty = {
+  session_start = None;
+  session_end = None;
+  user_prompt_submit = None;
   before_turn = None;
   after_turn = None;
+  permission_request = None;
   pre_tool_use = None;
   post_tool_use = None;
+  subagent_start = None;
+  subagent_stop = None;
+  pre_compact = None;
+  config_change = None;
   on_stop = None;
 }
 
-(** Invoke a hook if present, returning Continue if absent *)
 let invoke hook_opt event =
   match hook_opt with
   | None -> Continue
-  | Some f -> f event
+  | Some fn -> fn event

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -1,0 +1,83 @@
+(** Session lifecycle and resumable metadata for agent executions. *)
+
+let () = Random.self_init ()
+
+type t = {
+  id : string;
+  started_at_unix : float;
+  mutable last_active_at_unix : float;
+  mutable turn_count : int;
+  resumed_from : string option;
+  cwd : string option;
+  metadata : Context.t;
+}
+
+let now_unix () = Unix.gettimeofday ()
+
+let generate_id () =
+  Printf.sprintf "session-%08x%08x" (Random.bits ()) (Random.bits ())
+
+let create ?id ?resumed_from ?cwd ?(metadata = Context.create ()) () =
+  let started_at_unix = now_unix () in
+  {
+    id = Option.value id ~default:(generate_id ());
+    started_at_unix;
+    last_active_at_unix = started_at_unix;
+    turn_count = 0;
+    resumed_from;
+    cwd;
+    metadata;
+  }
+
+let record_turn session =
+  session.turn_count <- session.turn_count + 1;
+  session.last_active_at_unix <- now_unix ()
+
+let touch session =
+  session.last_active_at_unix <- now_unix ()
+
+let merge_metadata session pairs =
+  Context.merge session.metadata pairs;
+  touch session
+
+let to_json session =
+  `Assoc [
+    ("id", `String session.id);
+    ("started_at_unix", `Float session.started_at_unix);
+    ("last_active_at_unix", `Float session.last_active_at_unix);
+    ("turn_count", `Int session.turn_count);
+    ("resumed_from",
+      match session.resumed_from with
+      | Some value -> `String value
+      | None -> `Null);
+    ("cwd",
+      match session.cwd with
+      | Some value -> `String value
+      | None -> `Null);
+    ("metadata", Context.to_json session.metadata);
+  ]
+
+let of_json json =
+  let open Yojson.Safe.Util in
+  let metadata =
+    match json |> member "metadata" with
+    | `Null -> Context.create ()
+    | value -> Context.of_json value
+  in
+  let session =
+    create
+      ?id:(json |> member "id" |> to_string_option)
+      ?resumed_from:(json |> member "resumed_from" |> to_string_option)
+      ?cwd:(json |> member "cwd" |> to_string_option)
+      ~metadata
+      ()
+  in
+  session.turn_count <-
+    (match json |> member "turn_count" |> to_int_option with
+     | Some value -> value
+     | None -> 0);
+  session.last_active_at_unix <-
+    (match json |> member "last_active_at_unix" |> to_float_option with
+     | Some value -> value
+     | None -> session.started_at_unix);
+  session

--- a/lib/skill.ml
+++ b/lib/skill.ml
@@ -1,0 +1,205 @@
+(** Markdown skill loading with lightweight frontmatter support.
+
+    The parser intentionally accepts only the small subset of metadata the
+    runtime needs for tool policy and prompt composition. *)
+
+type scope =
+  | Project
+  | User
+  | Local
+  | Custom of string
+[@@deriving show]
+
+type t = {
+  name : string;
+  description : string option;
+  body : string;
+  path : string option;
+  scope : scope option;
+  allowed_tools : string list;
+  argument_hint : string option;
+  model : string option;
+  disable_model_invocation : bool;
+  supporting_files : string list;
+  metadata : (string * string list) list;
+}
+[@@deriving show]
+
+let trim = String.trim
+
+let strip_quotes value =
+  let value = trim value in
+  let len = String.length value in
+  if len >= 2 then
+    let first = value.[0] in
+    let last = value.[len - 1] in
+    if (first = '"' && last = '"') || (first = '\'' && last = '\'') then
+      String.sub value 1 (len - 2)
+    else
+      value
+  else
+    value
+
+let split_csv value =
+  let value = trim value in
+  let inner =
+    if String.length value >= 2 && value.[0] = '[' && value.[String.length value - 1] = ']'
+    then String.sub value 1 (String.length value - 2)
+    else value
+  in
+  inner
+  |> String.split_on_char ','
+  |> List.map strip_quotes
+  |> List.filter (fun item -> item <> "")
+
+let assoc_replace key values pairs =
+  let without_key = List.remove_assoc key pairs in
+  (key, values) :: without_key
+
+let parse_frontmatter markdown =
+  let rec drop_leading_blank = function
+    | [] -> []
+    | line :: rest when trim line = "" -> drop_leading_blank rest
+    | lines -> lines
+  in
+  let lines =
+    String.split_on_char '\n' markdown
+    |> List.map (fun line ->
+      if String.ends_with ~suffix:"\r" line then
+        String.sub line 0 (String.length line - 1)
+      else
+        line)
+    |> drop_leading_blank
+  in
+  match lines with
+  | "---" :: rest ->
+      let rec consume current_key acc frontmatter body =
+        match frontmatter with
+        | [] -> (List.rev acc, body)
+        | "---" :: remaining -> (List.rev acc, remaining)
+        | line :: remaining ->
+            let line = trim line in
+            if line = "" || String.starts_with ~prefix:"# " line then
+              consume current_key acc remaining body
+            else if String.starts_with ~prefix:"- " line then
+              let item = String.sub line 2 (String.length line - 2) |> strip_quotes in
+              (match current_key with
+               | Some key ->
+                   let existing =
+                     match List.assoc_opt key acc with
+                     | Some values -> values
+                     | None -> []
+                   in
+                   consume current_key (assoc_replace key (existing @ [ item ]) acc)
+                     remaining body
+               | None ->
+                   consume current_key acc remaining body)
+            else
+              match String.index_opt line ':' with
+              | None -> consume current_key acc remaining body
+              | Some idx ->
+                  let key = String.sub line 0 idx |> trim |> String.lowercase_ascii in
+                  let raw =
+                    String.sub line (idx + 1) (String.length line - idx - 1) |> trim
+                  in
+                  let values = if raw = "" then [] else split_csv raw in
+                  consume (Some key) (assoc_replace key values acc) remaining body
+      in
+      let frontmatter, body_lines = consume None [] rest rest in
+      (frontmatter, String.concat "\n" body_lines |> trim)
+  | _ -> ([], trim markdown)
+
+let frontmatter_value frontmatter key =
+  match List.assoc_opt key frontmatter with
+  | Some (value :: _) -> Some value
+  | _ -> None
+
+let frontmatter_values frontmatter key =
+  match List.assoc_opt key frontmatter with
+  | Some values -> values
+  | None -> []
+
+let scope_of_string = function
+  | "project" -> Project
+  | "user" -> User
+  | "local" -> Local
+  | other -> Custom other
+
+let basename_without_ext path =
+  path |> Filename.basename |> Filename.remove_extension
+
+let of_markdown ?path ?scope markdown =
+  let frontmatter, body = parse_frontmatter markdown in
+  let description = frontmatter_value frontmatter "description" in
+  let name =
+    match frontmatter_value frontmatter "name", path with
+    | Some value, _ -> value
+    | None, Some value -> basename_without_ext value
+    | None, None -> "skill"
+  in
+  {
+    name;
+    description;
+    body;
+    path;
+    scope = (
+      match frontmatter_value frontmatter "scope", scope with
+      | Some value, _ -> Some (scope_of_string value)
+      | None, value -> value
+    );
+    allowed_tools =
+      frontmatter_values frontmatter "allowed-tools"
+      @ frontmatter_values frontmatter "allowed_tools";
+    argument_hint = (
+      match frontmatter_value frontmatter "argument-hint" with
+      | Some _ as value -> value
+      | None -> frontmatter_value frontmatter "argument_hint"
+    );
+    model = frontmatter_value frontmatter "model";
+    disable_model_invocation =
+      List.exists
+        (fun value -> String.lowercase_ascii value = "true")
+        (frontmatter_values frontmatter "disable-model-invocation"
+         @ frontmatter_values frontmatter "disable_model_invocation");
+    supporting_files =
+      frontmatter_values frontmatter "supporting-files"
+      @ frontmatter_values frontmatter "supporting_files";
+    metadata = frontmatter;
+  }
+
+let load ?scope path =
+  let channel = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr channel)
+    (fun () ->
+      let content = really_input_string channel (in_channel_length channel) in
+      of_markdown ~path ?scope content)
+
+let load_dir ?scope dir =
+  Sys.readdir dir
+  |> Array.to_list
+  |> List.filter (fun name ->
+    Filename.check_suffix name ".md" && not (String.starts_with ~prefix:"." name))
+  |> List.sort String.compare
+  |> List.map (fun name -> load ?scope (Filename.concat dir name))
+
+let render_prompt ?arguments skill =
+  let rendered =
+    match arguments with
+    | None -> skill.body
+    | Some value ->
+        skill.body
+        |> Str.global_replace (Str.regexp_string "$ARGUMENTS") value
+        |> Str.global_replace (Str.regexp_string "{{arguments}}") value
+  in
+  rendered |> trim
+
+let supporting_file_paths skill =
+  match skill.path with
+  | None -> skill.supporting_files
+  | Some path ->
+      let base_dir = Filename.dirname path in
+      List.map
+        (fun item ->
+          if Filename.is_relative item then Filename.concat base_dir item else item)
+        skill.supporting_files

--- a/lib/subagent.ml
+++ b/lib/subagent.ml
@@ -1,0 +1,240 @@
+(** Typed subagent specifications inspired by Claude Code subagents. *)
+
+open Types
+
+type memory_scope =
+  | Inherit
+  | Project
+  | User
+  | Local
+[@@deriving show]
+
+type isolation =
+  | Shared
+  | Worktree
+[@@deriving show]
+
+type model_override =
+  | Inherit_model
+  | Use_model of Types.model
+[@@deriving show]
+
+type t = {
+  name : string;
+  description : string option;
+  prompt : string;
+  tools : string list option;
+  disallowed_tools : string list;
+  model : model_override;
+  permission_mode : Guardrails.permission_mode option;
+  max_turns : int option;
+  skill_refs : string list;
+  skills : Skill.t list;
+  mcp_servers : string list;
+  hook_refs : string list;
+  memory : memory_scope;
+  isolation : isolation;
+  background : bool;
+  path : string option;
+  metadata : (string * string list) list;
+}
+[@@deriving show]
+
+let trim = String.trim
+
+let int_opt_of_string value =
+  try Some (int_of_string value) with _ -> None
+
+let permission_mode_of_string value =
+  match String.lowercase_ascii value with
+  | "default" -> Some Guardrails.Default
+  | "acceptedits" | "accept-edits" | "accept_edits" -> Some Guardrails.Accept_edits
+  | "dontask" | "dont-ask" | "dont_ask" -> Some Guardrails.Dont_ask
+  | "bypasspermissions" | "bypass-permissions" | "bypass_permissions" ->
+      Some Guardrails.Bypass_permissions
+  | "plan" -> Some Guardrails.Plan
+  | _ -> None
+
+let memory_scope_of_string value =
+  match String.lowercase_ascii value with
+  | "inherit" -> Inherit
+  | "project" -> Project
+  | "user" -> User
+  | "local" -> Local
+  | _ -> Inherit
+
+let isolation_of_string value =
+  match String.lowercase_ascii value with
+  | "worktree" -> Worktree
+  | _ -> Shared
+
+let model_override_of_string value =
+  match String.lowercase_ascii value with
+  | "inherit" -> Inherit_model
+  | "sonnet" | "claude-sonnet-4" -> Use_model Types.Claude_sonnet_4
+  | "opus" | "claude-opus-4-5" -> Use_model Types.Claude_opus_4_5
+  | "haiku" | "claude-haiku-4-5" -> Use_model Types.Claude_haiku_4_5
+  | "claude-3-7-sonnet" -> Use_model Types.Claude_3_7_sonnet
+  | other -> Use_model (Types.Custom other)
+
+let of_markdown ?path ?(skills = []) markdown =
+  let frontmatter, prompt = Skill.parse_frontmatter markdown in
+  let name =
+    match Skill.frontmatter_value frontmatter "name", path with
+    | Some value, _ -> value
+    | None, Some value -> value |> Filename.basename |> Filename.remove_extension
+    | None, None -> "subagent"
+  in
+  let description = Skill.frontmatter_value frontmatter "description" in
+  {
+    name;
+    description;
+    prompt;
+    tools = (
+      let tool_values =
+        Skill.frontmatter_values frontmatter "tools"
+        |> List.filter (fun value -> trim value <> "")
+      in
+      if tool_values = [] then None else Some tool_values
+    );
+    disallowed_tools =
+      Skill.frontmatter_values frontmatter "disallowed-tools"
+      @ Skill.frontmatter_values frontmatter "disallowed_tools";
+    model = (
+      match Skill.frontmatter_value frontmatter "model" with
+      | Some value -> model_override_of_string value
+      | None -> Inherit_model
+    );
+    permission_mode = (
+      Skill.frontmatter_value frontmatter "permission-mode"
+      |> Option.value ~default:(Option.value (Skill.frontmatter_value frontmatter "permission_mode") ~default:"")
+      |> fun value -> if value = "" then None else permission_mode_of_string value
+    );
+    max_turns = (
+      Skill.frontmatter_value frontmatter "max-turns"
+      |> Option.value ~default:(Option.value (Skill.frontmatter_value frontmatter "max_turns") ~default:"")
+      |> fun value -> if value = "" then None else int_opt_of_string value
+    );
+    skill_refs =
+      Skill.frontmatter_values frontmatter "skills";
+    skills;
+    mcp_servers =
+      Skill.frontmatter_values frontmatter "mcp-servers"
+      @ Skill.frontmatter_values frontmatter "mcp_servers";
+    hook_refs =
+      Skill.frontmatter_values frontmatter "hooks";
+    memory = (
+      Skill.frontmatter_value frontmatter "memory"
+      |> Option.map memory_scope_of_string
+      |> Option.value ~default:Inherit
+    );
+    isolation = (
+      Skill.frontmatter_value frontmatter "isolation"
+      |> Option.map isolation_of_string
+      |> Option.value ~default:Shared
+    );
+    background =
+      List.exists
+        (fun value -> String.lowercase_ascii value = "true")
+        (Skill.frontmatter_values frontmatter "background");
+    path;
+    metadata = frontmatter;
+  }
+
+let load ?(skill_roots = []) path =
+  let channel = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr channel)
+    (fun () ->
+      let content = really_input_string channel (in_channel_length channel) in
+      let initial = of_markdown ~path content in
+      let base_dirs =
+        (Filename.dirname path)
+        :: skill_roots
+      in
+      let resolve_skill ref_name =
+        let candidate_paths =
+          ref_name :: List.map (fun dir -> Filename.concat dir ref_name) base_dirs
+        in
+        match List.find_opt Sys.file_exists candidate_paths with
+        | Some skill_path -> Some (Skill.load skill_path)
+        | None -> None
+      in
+      let resolved_skills =
+        List.filter_map resolve_skill initial.skill_refs
+      in
+      { initial with skills = resolved_skills })
+
+let compose_prompt ?arguments spec =
+  let rendered_skills =
+    spec.skills
+    |> List.map (Skill.render_prompt ?arguments)
+    |> List.filter (fun value -> value <> "")
+  in
+  match trim spec.prompt, rendered_skills with
+  | "", [] -> ""
+  | prompt, [] -> prompt
+  | "", extras -> String.concat "\n\n" extras
+  | prompt, extras ->
+      String.concat "\n\n"
+        (prompt :: List.map (fun value -> Printf.sprintf "[Skill]\n%s" value) extras)
+
+let filter_tools spec base_tools =
+  let explicitly_allowed tool_name =
+    match spec.tools with
+    | None -> true
+    | Some names -> List.mem tool_name names
+  in
+  base_tools
+  |> List.filter (fun (tool : Tool.t) -> explicitly_allowed tool.schema.name)
+  |> List.filter (fun (tool : Tool.t) -> not (List.mem tool.schema.name spec.disallowed_tools))
+
+let to_handoff_target ?base_guardrails ?base_hooks ?base_session
+    ~(parent_config : Types.agent_config) ~base_tools spec =
+  let tools = filter_tools spec base_tools in
+  let config =
+    {
+      parent_config with
+      name = spec.name;
+      model =
+        (match spec.model with
+         | Inherit_model -> parent_config.model
+         | Use_model model -> model);
+      max_turns = Option.value spec.max_turns ~default:parent_config.max_turns;
+      system_prompt =
+        (match compose_prompt spec with
+         | "" -> parent_config.system_prompt
+         | prompt -> Some prompt);
+    }
+  in
+  let guardrails =
+    Option.map
+      (fun base ->
+        let tool_filter =
+          Guardrails.Custom
+            (fun schema ->
+              Guardrails.is_allowed base schema
+              &&
+              (match spec.tools with
+               | None -> true
+               | Some names -> List.mem schema.name names)
+              &&
+              not (List.mem schema.name spec.disallowed_tools))
+        in
+        {
+          base with
+          tool_filter;
+          permission_mode =
+            Option.value spec.permission_mode ~default:base.permission_mode;
+        })
+      base_guardrails
+  in
+  {
+    Handoff.name = spec.name;
+    description = Option.value spec.description ~default:"Subagent";
+    config;
+    tools;
+    hooks = base_hooks;
+    guardrails;
+    session = base_session;
+  }

--- a/lib/tool.ml
+++ b/lib/tool.ml
@@ -19,13 +19,13 @@ type t = {
 }
 
 (** Create a tool with a simple handler *)
-let create ~name ~description ~parameters handler =
-  let schema = { name; description; parameters } in
+let create ?(kind = Read_only) ~name ~description ~parameters handler =
+  let schema = { name; description; parameters; kind } in
   { schema; handler = Simple handler }
 
 (** Create a tool with a context-aware handler *)
-let create_with_context ~name ~description ~parameters handler =
-  let schema = { name; description; parameters } in
+let create_with_context ?(kind = Read_only) ~name ~description ~parameters handler =
+  let schema = { name; description; parameters; kind } in
   { schema; handler = WithContext handler }
 
 (** Execute a tool, optionally passing context *)
@@ -54,6 +54,7 @@ let schema_to_json tool =
   `Assoc [
     ("name", `String tool.schema.name);
     ("description", `String tool.schema.description);
+    ("x-kind", `String (tool_kind_to_string tool.schema.kind));
     ("input_schema", `Assoc [
       ("type", `String "object");
       ("properties", `Assoc (List.rev properties));

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -34,6 +34,23 @@ let param_type_to_string = function
   | Array -> "array"
   | Object -> "object"
 
+type tool_kind =
+  | Read_only
+  | File_edit
+  | Command
+  | Network
+  | Task
+  | Unknown
+[@@deriving yojson, show]
+
+let tool_kind_to_string = function
+  | Read_only -> "read_only"
+  | File_edit -> "file_edit"
+  | Command -> "command"
+  | Network -> "network"
+  | Task -> "task"
+  | Unknown -> "unknown"
+
 type tool_param = {
   name: string;
   description: string;
@@ -47,6 +64,7 @@ type tool_schema = {
   name: string;
   description: string;
   parameters: tool_param list;
+  kind: tool_kind;
 }
 [@@deriving yojson, show]
 

--- a/test/dune
+++ b/test/dune
@@ -23,6 +23,18 @@
  (libraries agent_sdk alcotest yojson))
 
 (test
+ (name test_session)
+ (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_skill)
+ (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_subagent)
+ (libraries agent_sdk alcotest yojson))
+
+(test
  (name test_guardrails)
  (libraries agent_sdk alcotest yojson))
 

--- a/test/test_guardrails.ml
+++ b/test/test_guardrails.ml
@@ -11,8 +11,8 @@ let test_default () =
   let g = Guardrails.default in
   check bool "default filter is AllowAll" true
     (g.tool_filter = Guardrails.AllowAll);
-  check bool "default limit is None" true
-    (g.max_tool_calls_per_turn = None)
+  check bool "default limit is None" true (g.max_tool_calls_per_turn = None);
+  check bool "default permission mode" true (g.permission_mode = Guardrails.Default)
 
 let test_allow_all () =
   let g = Guardrails.default in
@@ -61,6 +61,39 @@ let test_exceeds_limit_over () =
   let g = { Guardrails.default with max_tool_calls_per_turn = Some 5 } in
   check bool "over limit" true (Guardrails.exceeds_limit g 6)
 
+let test_permission_default_read_only () =
+  let tool = make_tool "read_file" in
+  check (of_pp Guardrails.pp_permission_outcome) "read-only auto allowed"
+    Guardrails.Authorized
+    (Guardrails.permission_for_tool Guardrails.default tool.schema)
+
+let test_permission_default_command_requires_confirmation () =
+  let tool =
+    Tool.create ~kind:Command ~name:"bash" ~description:"run command" ~parameters:[]
+      (fun _ -> Ok "ok")
+  in
+  check (of_pp Guardrails.pp_permission_outcome) "command requires confirmation"
+    (Guardrails.Requires_confirmation "tool needs explicit approval in default mode")
+    (Guardrails.permission_for_tool Guardrails.default tool.schema)
+
+let test_permission_plan_rejects_edits () =
+  let tool =
+    Tool.create ~kind:File_edit ~name:"edit" ~description:"edit file" ~parameters:[]
+      (fun _ -> Ok "ok")
+  in
+  let guardrails = { Guardrails.default with permission_mode = Guardrails.Plan } in
+  check bool "plan rejects edit"
+    true
+    (match Guardrails.permission_for_tool guardrails tool.schema with
+     | Guardrails.Rejected _ -> true
+     | _ -> false)
+
+let test_output_limit_truncates () =
+  let guardrails = { Guardrails.default with max_output_chars = Some 5 } in
+  let output, truncated = Guardrails.apply_output_limit guardrails "123456789" in
+  check bool "output truncated" true truncated;
+  check bool "suffix added" true (String.ends_with ~suffix:"[truncated by guardrails]" output)
+
 let () =
   run "Guardrails" [
     "default", [
@@ -77,5 +110,10 @@ let () =
       test_case "under limit" `Quick test_exceeds_limit_under;
       test_case "at limit" `Quick test_exceeds_limit_equal;
       test_case "over limit" `Quick test_exceeds_limit_over;
+      test_case "permission read-only" `Quick test_permission_default_read_only;
+      test_case "permission command confirm" `Quick
+        test_permission_default_command_requires_confirmation;
+      test_case "permission plan rejects edits" `Quick test_permission_plan_rejects_edits;
+      test_case "output limit truncates" `Quick test_output_limit_truncates;
     ];
   ]

--- a/test/test_handoff.ml
+++ b/test/test_handoff.ml
@@ -29,6 +29,9 @@ let test_make_handoff_tool_name () =
     description = "Research specialist";
     config = default_config;
     tools = [];
+    hooks = None;
+    guardrails = None;
+    session = None;
   } in
   let tool = Handoff.make_handoff_tool target in
   check string "tool name" "transfer_to_researcher" tool.schema.name
@@ -39,6 +42,9 @@ let test_make_handoff_tool_description () =
     description = "Writes code";
     config = default_config;
     tools = [];
+    hooks = None;
+    guardrails = None;
+    session = None;
   } in
   let tool = Handoff.make_handoff_tool target in
   check bool "description contains name" true
@@ -50,6 +56,9 @@ let test_make_handoff_tool_parameters () =
     description = "General helper";
     config = default_config;
     tools = [];
+    hooks = None;
+    guardrails = None;
+    session = None;
   } in
   let tool = Handoff.make_handoff_tool target in
   check int "has prompt parameter" 1 (List.length tool.schema.parameters);
@@ -63,6 +72,9 @@ let test_make_handoff_tool_handler_is_sentinel () =
     description = "Intercept-only test target";
     config = default_config;
     tools = [];
+    hooks = None;
+    guardrails = None;
+    session = None;
   } in
   let tool = Handoff.make_handoff_tool target in
   match Tool.execute tool `Null with
@@ -114,6 +126,11 @@ let handoff_mock_handler _conn req body =
 let test_run_with_handoffs_intercepts_tool_use () =
   let port = 8083 in
   let base_url = Printf.sprintf "http://127.0.0.1:%d" port in
+  let provider = {
+    Provider.provider = Local { base_url };
+    model_id = "mock-local";
+    api_key_env = "DUMMY_KEY";
+  } in
   Eio_main.run @@ fun env ->
   try
     Eio.Switch.run @@ fun sw ->
@@ -129,8 +146,11 @@ let test_run_with_handoffs_intercepts_tool_use () =
         description = "Research specialist";
         config = { default_config with name = "researcher" };
         tools = [];
+        hooks = None;
+        guardrails = None;
+        session = None;
       } in
-      let agent = Agent.create ~net:env#net ~base_url () in
+      let agent = Agent.create ~net:env#net ~base_url ~provider () in
       match Agent.run_with_handoffs ~sw agent ~targets:[target] "delegate" with
       | Ok response ->
           let text =
@@ -147,6 +167,11 @@ let test_run_with_handoffs_intercepts_tool_use () =
 let test_run_with_handoffs_reports_unknown_target () =
   let port = 8084 in
   let base_url = Printf.sprintf "http://127.0.0.1:%d" port in
+  let provider = {
+    Provider.provider = Local { base_url };
+    model_id = "mock-local";
+    api_key_env = "DUMMY_KEY";
+  } in
   Eio_main.run @@ fun env ->
   try
     Eio.Switch.run @@ fun sw ->
@@ -162,8 +187,11 @@ let test_run_with_handoffs_reports_unknown_target () =
         description = "Research specialist";
         config = { default_config with name = "researcher" };
         tools = [];
+        hooks = None;
+        guardrails = None;
+        session = None;
       } in
-      let agent = Agent.create ~net:env#net ~base_url () in
+      let agent = Agent.create ~net:env#net ~base_url ~provider () in
       match Agent.run_with_handoffs ~sw agent ~targets:[target] "delegate_unknown" with
       | Ok response ->
           let text =
@@ -172,6 +200,57 @@ let test_run_with_handoffs_reports_unknown_target () =
           in
           check string "unknown target error"
             "handoff complete: Unknown handoff target: unknown" text;
+          Eio.Switch.fail sw Exit
+      | Error e ->
+          fail e
+  with Exit -> ()
+
+let test_run_with_subagents_uses_spec () =
+  let port = 8085 in
+  let base_url = Printf.sprintf "http://127.0.0.1:%d" port in
+  let provider = {
+    Provider.provider = Local { base_url };
+    model_id = "mock-local";
+    api_key_env = "DUMMY_KEY";
+  } in
+  Eio_main.run @@ fun env ->
+  try
+    Eio.Switch.run @@ fun sw ->
+      let socket =
+        Eio.Net.listen env#net ~sw ~backlog:128 ~reuse_addr:true
+          (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+      in
+      let server = Cohttp_eio.Server.make ~callback:handoff_mock_handler () in
+      Eio.Fiber.fork ~sw (fun () ->
+        Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+      let reviewer_skill =
+        Skill.of_markdown
+          {|
+---
+name: reviewer
+---
+Always write a concise review.
+|}
+      in
+      let subagent =
+        Subagent.of_markdown ~skills:[reviewer_skill]
+          {|
+---
+name: researcher
+tools: []
+---
+Research the task and respond clearly.
+|}
+      in
+      let agent = Agent.create ~net:env#net ~base_url ~provider () in
+      match Agent.run_with_subagents ~sw agent ~specs:[subagent] "delegate" with
+      | Ok response ->
+          let text =
+            List.filter_map (function Text s -> Some s | _ -> None) response.content
+            |> String.concat ""
+          in
+          check string "subagent final text"
+            "handoff complete: delegated response" text;
           Eio.Switch.fail sw Exit
       | Error e ->
           fail e
@@ -197,5 +276,7 @@ let () =
         test_run_with_handoffs_intercepts_tool_use;
       test_case "reports unknown target" `Quick
         test_run_with_handoffs_reports_unknown_target;
+      test_case "run_with_subagents uses typed spec" `Quick
+        test_run_with_subagents_uses_spec;
     ];
   ]

--- a/test/test_hooks.ml
+++ b/test/test_hooks.ml
@@ -5,10 +5,18 @@ open Agent_sdk
 
 let test_empty_hooks () =
   let hooks = Hooks.empty in
+  check bool "session_start is None" true (hooks.session_start = None);
+  check bool "session_end is None" true (hooks.session_end = None);
+  check bool "user_prompt_submit is None" true (hooks.user_prompt_submit = None);
   check bool "before_turn is None" true (hooks.before_turn = None);
   check bool "after_turn is None" true (hooks.after_turn = None);
+  check bool "permission_request is None" true (hooks.permission_request = None);
   check bool "pre_tool_use is None" true (hooks.pre_tool_use = None);
   check bool "post_tool_use is None" true (hooks.post_tool_use = None);
+  check bool "subagent_start is None" true (hooks.subagent_start = None);
+  check bool "subagent_stop is None" true (hooks.subagent_stop = None);
+  check bool "pre_compact is None" true (hooks.pre_compact = None);
+  check bool "config_change is None" true (hooks.config_change = None);
   check bool "on_stop is None" true (hooks.on_stop = None)
 
 let test_invoke_none () =
@@ -19,6 +27,11 @@ let test_invoke_continue () =
   let hook _event = Hooks.Continue in
   let result = Hooks.invoke (Some hook) (Hooks.BeforeTurn { turn = 0; messages = [] }) in
   check bool "hook returns Continue" true (result = Hooks.Continue)
+
+let test_invoke_allow () =
+  let hook _event = Hooks.Allow in
+  let result = Hooks.invoke (Some hook) (Hooks.BeforeTurn { turn = 0; messages = [] }) in
+  check bool "hook returns Allow" true (result = Hooks.Allow)
 
 let test_invoke_skip () =
   let hook _event = Hooks.Skip in
@@ -60,6 +73,27 @@ let test_post_tool_use_event () =
     }) in
   check string "hook received output" "hello" !received_output
 
+let test_permission_request_event () =
+  let mode = ref Guardrails.Default in
+  let hook = function
+    | Hooks.PermissionRequest { permission_mode; _ } ->
+      mode := permission_mode;
+      Hooks.Allow
+    | _ -> Hooks.Continue
+  in
+  let result =
+    Hooks.invoke (Some hook)
+      (Hooks.PermissionRequest {
+         tool_name = "write_file";
+         tool_kind = Types.File_edit;
+         input = `Null;
+         permission_mode = Guardrails.Default;
+         reason = "edit";
+       })
+  in
+  check bool "permission hook allows" true (result = Hooks.Allow);
+  check bool "permission mode propagated" true (!mode = Guardrails.Default)
+
 let () =
   run "Hooks" [
     "empty", [
@@ -68,9 +102,11 @@ let () =
     "invoke", [
       test_case "invoke None" `Quick test_invoke_none;
       test_case "invoke Continue" `Quick test_invoke_continue;
+      test_case "invoke Allow" `Quick test_invoke_allow;
       test_case "invoke Skip" `Quick test_invoke_skip;
       test_case "invoke Override" `Quick test_invoke_override;
       test_case "receives event" `Quick test_hook_receives_event;
       test_case "post_tool_use event" `Quick test_post_tool_use_event;
+      test_case "permission_request event" `Quick test_permission_request_event;
     ];
   ]

--- a/test/test_integration.ml
+++ b/test/test_integration.ml
@@ -39,6 +39,11 @@ let mock_handler _conn req body =
 let test_simple_conversation () =
   let port = 8081 in
   let base_url = Printf.sprintf "http://127.0.0.1:%d" port in
+  let provider = {
+    Provider.provider = Local { base_url };
+    model_id = "mock-local";
+    api_key_env = "DUMMY_KEY";
+  } in
   
   Eio_main.run @@ fun env ->
   try
@@ -47,7 +52,7 @@ let test_simple_conversation () =
       let server = Cohttp_eio.Server.make ~callback:mock_handler () in
       Eio.Fiber.fork ~sw (fun () -> Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
 
-      let agent = Agent.create ~net:env#net ~base_url () in
+      let agent = Agent.create ~net:env#net ~base_url ~provider () in
       match Agent.run ~sw agent "ping" with
       | Ok response ->
           let text = List.filter_map (function Text s -> Some s | _ -> None) response.content |> String.concat "" in
@@ -59,6 +64,11 @@ let test_simple_conversation () =
 let test_tool_use () =
   let port = 8082 in
   let base_url = Printf.sprintf "http://127.0.0.1:%d" port in
+  let provider = {
+    Provider.provider = Local { base_url };
+    model_id = "mock-local";
+    api_key_env = "DUMMY_KEY";
+  } in
   
   Eio_main.run @@ fun env ->
   try
@@ -72,7 +82,7 @@ let test_tool_use () =
          let b = Yojson.Safe.Util.(input |> member "b" |> to_int) in
          Ok (string_of_int (a + b))) in
 
-      let agent = Agent.create ~net:env#net ~base_url ~tools:[calc_tool] () in
+      let agent = Agent.create ~net:env#net ~base_url ~provider ~tools:[calc_tool] () in
       match Agent.run ~sw agent "use_tool" with
       | Ok response ->
           let text = List.filter_map (function Text s -> Some s | _ -> None) response.content |> String.concat "" in

--- a/test/test_session.ml
+++ b/test/test_session.ml
@@ -1,0 +1,34 @@
+open Alcotest
+open Agent_sdk
+
+let test_create_session () =
+  let session = Session.create ~id:"session-1" ~cwd:"/tmp/oas" () in
+  check string "id" "session-1" session.id;
+  check (option string) "cwd" (Some "/tmp/oas") session.cwd;
+  check int "turn count" 0 session.turn_count
+
+let test_record_turn () =
+  let session = Session.create ~id:"session-2" () in
+  Session.record_turn session;
+  Session.record_turn session;
+  check int "turn count increments" 2 session.turn_count
+
+let test_json_roundtrip () =
+  let session = Session.create ~id:"session-3" ~cwd:"/tmp/roundtrip" () in
+  Session.merge_metadata session [ ("hello", `String "world") ];
+  Session.record_turn session;
+  let restored = Session.to_json session |> Session.of_json in
+  check string "id restored" session.id restored.id;
+  check int "turn_count restored" session.turn_count restored.turn_count;
+  check (option string) "cwd restored" session.cwd restored.cwd;
+  check (option string) "metadata restored" (Some "world")
+    Yojson.Safe.Util.(Context.get restored.metadata "hello" |> Option.map to_string)
+
+let () =
+  run "Session" [
+    "session", [
+      test_case "create" `Quick test_create_session;
+      test_case "record_turn" `Quick test_record_turn;
+      test_case "json_roundtrip" `Quick test_json_roundtrip;
+    ];
+  ]

--- a/test/test_skill.ml
+++ b/test/test_skill.ml
@@ -1,0 +1,45 @@
+open Alcotest
+open Agent_sdk
+
+let skill_doc =
+  {|
+---
+name: code-review
+description: Review code changes
+allowed-tools: Read, Grep
+argument-hint: diff range
+model: sonnet
+disable-model-invocation: true
+supporting-files:
+  - notes.md
+---
+Review the diff in $ARGUMENTS.
+|}
+
+let test_parse_frontmatter () =
+  let skill = Skill.of_markdown ~path:"/tmp/code-review.md" skill_doc in
+  check string "name" "code-review" skill.name;
+  check (option string) "description" (Some "Review code changes") skill.description;
+  check (list string) "allowed_tools" [ "Read"; "Grep" ] skill.allowed_tools;
+  check (option string) "argument_hint" (Some "diff range") skill.argument_hint;
+  check bool "disable_model_invocation" true skill.disable_model_invocation
+
+let test_render_prompt () =
+  let skill = Skill.of_markdown skill_doc in
+  let rendered = Skill.render_prompt ~arguments:"HEAD~1..HEAD" skill in
+  check string "arguments substituted" "Review the diff in HEAD~1..HEAD." rendered
+
+let test_supporting_file_paths () =
+  let skill = Skill.of_markdown ~path:"/tmp/skills/code-review.md" skill_doc in
+  check (list string) "supporting paths"
+    [ "/tmp/skills/notes.md" ]
+    (Skill.supporting_file_paths skill)
+
+let () =
+  run "Skill" [
+    "skill", [
+      test_case "parse_frontmatter" `Quick test_parse_frontmatter;
+      test_case "render_prompt" `Quick test_render_prompt;
+      test_case "supporting_files" `Quick test_supporting_file_paths;
+    ];
+  ]

--- a/test/test_subagent.ml
+++ b/test/test_subagent.ml
@@ -1,0 +1,75 @@
+open Alcotest
+open Agent_sdk
+open Types
+
+let subagent_doc =
+  {|
+---
+name: reviewer
+description: Review implementation quality
+tools: grep, read
+disallowed-tools: edit
+model: opus
+permission-mode: accept-edits
+max-turns: 3
+skills: review.md
+memory: project
+isolation: worktree
+background: true
+---
+Review the implementation and summarize issues.
+|}
+
+let review_skill =
+  Skill.of_markdown
+    {|
+---
+name: review
+---
+Always include risk-oriented findings first.
+|}
+
+let make_tool name =
+  Tool.create ~name ~description:"test" ~parameters:[] (fun _ -> Ok "ok")
+
+let test_parse_subagent () =
+  let spec = Subagent.of_markdown ~path:"/tmp/reviewer.md" ~skills:[ review_skill ] subagent_doc in
+  check string "name" "reviewer" spec.name;
+  check bool "background true" true spec.background;
+  check bool "worktree isolation" true (spec.isolation = Subagent.Worktree);
+  check bool "project memory" true (spec.memory = Subagent.Project);
+  check bool "max_turns parsed" true (spec.max_turns = Some 3)
+
+let test_to_handoff_target_filters_tools () =
+  let spec = Subagent.of_markdown ~skills:[ review_skill ] subagent_doc in
+  let base_tools = [ make_tool "grep"; make_tool "read"; make_tool "edit" ] in
+  let target =
+    Subagent.to_handoff_target
+      ~parent_config:default_config
+      ~base_tools
+      ~base_guardrails:Guardrails.default
+      spec
+  in
+  let names = List.map (fun (tool : Tool.t) -> tool.schema.name) target.tools in
+  check (list string) "tool filtering" [ "grep"; "read" ] names;
+  check bool "permission override" true
+    (match target.guardrails with
+     | Some g -> g.permission_mode = Guardrails.Accept_edits
+     | None -> false)
+
+let test_compose_prompt_includes_skill () =
+  let spec = Subagent.of_markdown ~skills:[ review_skill ] subagent_doc in
+  let prompt = Subagent.compose_prompt spec in
+  check bool "base prompt present" true
+    (String.contains prompt 'R');
+  check bool "skill content appended" true
+    (String.ends_with ~suffix:"Always include risk-oriented findings first." prompt)
+
+let () =
+  run "Subagent" [
+    "subagent", [
+      test_case "parse" `Quick test_parse_subagent;
+      test_case "to_handoff_target filters tools" `Quick test_to_handoff_target_filters_tools;
+      test_case "compose_prompt includes skills" `Quick test_compose_prompt_includes_skill;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- add session, skill, and subagent modules to the public SDK surface
- make guardrails permission-aware with tool kinds, allow/ask/deny policy, and output truncation
- wire hooks, handoffs, and typed subagents into the agent runtime and align README/changelog/TODO with shipped behavior

## Testing
- dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/codex-sdk-kernel-hardening
- dune runtest --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/codex-sdk-kernel-hardening
