### PR TITLE
test: harden coverage for retry, provider, api modules

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -40,7 +40,7 @@
 
 (test
  (name test_retry)
- (libraries agent_sdk alcotest yojson))
+ (libraries agent_sdk alcotest yojson eio eio_main))
 
 (test
  (name test_streaming)

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -208,6 +208,160 @@ let test_message_to_json () =
   check int "1 block" 1 (List.length content)
 
 (* ------------------------------------------------------------------ *)
+(* build_body_assoc: cache_system_prompt                                *)
+(* ------------------------------------------------------------------ *)
+
+let test_build_body_with_cache () =
+  let config = { Types.default_config with
+    system_prompt = Some "You are a cached helper.";
+    cache_system_prompt = true;
+  } in
+  let state = { Types.config; messages = []; turn_count = 0; usage = Types.empty_usage } in
+  let assoc = Api.build_body_assoc ~config:state ~messages:[] ~stream:false () in
+  let json = `Assoc assoc in
+  let open Yojson.Safe.Util in
+  let system = json |> member "system" in
+  (* cache_system_prompt wraps as [{"type":"text","text":"...","cache_control":{"type":"ephemeral"}}] *)
+  let blocks = system |> to_list in
+  check int "1 system block" 1 (List.length blocks);
+  let block = List.hd blocks in
+  check string "block type" "text" (block |> member "type" |> to_string);
+  check string "block text" "You are a cached helper." (block |> member "text" |> to_string);
+  let cc = block |> member "cache_control" in
+  check string "cache_control type" "ephemeral" (cc |> member "type" |> to_string)
+
+let test_build_body_no_system_prompt () =
+  let state = { Types.config = Types.default_config;
+                messages = []; turn_count = 0; usage = Types.empty_usage } in
+  let assoc = Api.build_body_assoc ~config:state ~messages:[] ~stream:false () in
+  let has_system = List.exists (fun (k, _) -> k = "system") assoc in
+  check bool "no system key" false has_system
+
+(* ------------------------------------------------------------------ *)
+(* parse_response: cache tokens in usage                               *)
+(* ------------------------------------------------------------------ *)
+
+let test_parse_response_with_cache_tokens () =
+  let json = Yojson.Safe.from_string {|{
+    "id": "msg_cache",
+    "model": "claude-sonnet-4-6-20250514",
+    "stop_reason": "end_turn",
+    "content": [{"type": "text", "text": "cached"}],
+    "usage": {
+      "input_tokens": 50,
+      "output_tokens": 25,
+      "cache_creation_input_tokens": 1000,
+      "cache_read_input_tokens": 800
+    }
+  }|} in
+  let resp = Api.parse_response json in
+  match resp.usage with
+  | Some u ->
+    check int "input" 50 u.Types.input_tokens;
+    check int "output" 25 u.output_tokens;
+    check int "cache_creation" 1000 u.cache_creation_input_tokens;
+    check int "cache_read" 800 u.cache_read_input_tokens
+  | None -> fail "expected usage"
+
+(* ------------------------------------------------------------------ *)
+(* parse_sse_event                                                      *)
+(* ------------------------------------------------------------------ *)
+
+let test_parse_sse_message_start () =
+  let data = {|{"message":{"id":"msg_1","model":"claude-sonnet-4-6","usage":{"input_tokens":10}}}|} in
+  match Api.parse_sse_event (Some "message_start") data with
+  | Some (Types.MessageStart { id; model; usage }) ->
+    check string "id" "msg_1" id;
+    check string "model" "claude-sonnet-4-6" model;
+    (match usage with
+     | Some (inp, _) -> check int "input" 10 inp
+     | None -> fail "expected usage")
+  | _ -> fail "expected MessageStart"
+
+let test_parse_sse_content_block_delta_text () =
+  let data = {|{"index":0,"delta":{"type":"text_delta","text":"hello"}}|} in
+  match Api.parse_sse_event (Some "content_block_delta") data with
+  | Some (Types.ContentBlockDelta { index; delta = Types.TextDelta t }) ->
+    check int "index" 0 index;
+    check string "text" "hello" t
+  | _ -> fail "expected ContentBlockDelta TextDelta"
+
+let test_parse_sse_content_block_delta_thinking () =
+  let data = {|{"index":0,"delta":{"type":"thinking_delta","thinking":"hmm"}}|} in
+  match Api.parse_sse_event (Some "content_block_delta") data with
+  | Some (Types.ContentBlockDelta { delta = Types.ThinkingDelta t; _ }) ->
+    check string "thinking" "hmm" t
+  | _ -> fail "expected ThinkingDelta"
+
+let test_parse_sse_content_block_delta_input_json () =
+  let data = {|{"index":1,"delta":{"type":"input_json_delta","partial_json":"{\"x\":1"}}|} in
+  match Api.parse_sse_event (Some "content_block_delta") data with
+  | Some (Types.ContentBlockDelta { delta = Types.InputJsonDelta j; _ }) ->
+    check string "partial json" {|{"x":1|} j
+  | _ -> fail "expected InputJsonDelta"
+
+let test_parse_sse_content_block_start () =
+  let data = {|{"index":0,"content_block":{"type":"tool_use","id":"tu_1","name":"calc"}}|} in
+  match Api.parse_sse_event (Some "content_block_start") data with
+  | Some (Types.ContentBlockStart { index; content_type; tool_id; tool_name }) ->
+    check int "index" 0 index;
+    check string "type" "tool_use" content_type;
+    check (option string) "tool_id" (Some "tu_1") tool_id;
+    check (option string) "tool_name" (Some "calc") tool_name
+  | _ -> fail "expected ContentBlockStart"
+
+let test_parse_sse_message_delta () =
+  let data = {|{"delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":42}}|} in
+  match Api.parse_sse_event (Some "message_delta") data with
+  | Some (Types.MessageDelta { stop_reason; usage }) ->
+    (match stop_reason with
+     | Some Types.EndTurn -> ()
+     | _ -> fail "expected EndTurn");
+    (match usage with
+     | Some (_, out) -> check int "output" 42 out
+     | None -> fail "expected usage")
+  | _ -> fail "expected MessageDelta"
+
+let test_parse_sse_message_stop () =
+  match Api.parse_sse_event (Some "message_stop") "{}" with
+  | Some Types.MessageStop -> ()
+  | _ -> fail "expected MessageStop"
+
+let test_parse_sse_ping () =
+  match Api.parse_sse_event (Some "ping") "{}" with
+  | Some Types.Ping -> ()
+  | _ -> fail "expected Ping"
+
+let test_parse_sse_error () =
+  let data = {|{"error":{"message":"rate limited"}}|} in
+  match Api.parse_sse_event (Some "error") data with
+  | Some (Types.SSEError msg) -> check string "error msg" "rate limited" msg
+  | _ -> fail "expected SSEError"
+
+let test_parse_sse_unknown_type () =
+  match Api.parse_sse_event (Some "future_event") "{}" with
+  | None -> ()
+  | Some _ -> fail "expected None for unknown type"
+
+let test_parse_sse_malformed_json () =
+  match Api.parse_sse_event (Some "message_start") "not json" with
+  | None -> ()
+  | Some _ -> fail "expected None for malformed JSON"
+
+(* ------------------------------------------------------------------ *)
+(* message_to_json: assistant + mixed content                           *)
+(* ------------------------------------------------------------------ *)
+
+let test_message_to_json_assistant () =
+  let msg = { Types.role = Types.Assistant;
+              content = [Types.Text "hi"; Types.ToolUse ("t1", "calc", `Null)] } in
+  let json = Api.message_to_json msg in
+  let open Yojson.Safe.Util in
+  check string "role" "assistant" (json |> member "role" |> to_string);
+  let content = json |> member "content" |> to_list in
+  check int "2 blocks" 2 (List.length content)
+
+(* ------------------------------------------------------------------ *)
 (* Test runner                                                          *)
 (* ------------------------------------------------------------------ *)
 
@@ -230,13 +384,30 @@ let () =
       test_case "without thinking" `Quick test_build_body_without_thinking;
       test_case "with tool_choice" `Quick test_build_body_with_tool_choice;
       test_case "with tools" `Quick test_build_body_with_tools;
+      test_case "with cache_system_prompt" `Quick test_build_body_with_cache;
+      test_case "no system prompt" `Quick test_build_body_no_system_prompt;
     ];
     "parse_response", [
       test_case "complete response" `Quick test_parse_response_complete;
       test_case "tool_use response" `Quick test_parse_response_tool_use;
       test_case "unknown stop_reason" `Quick test_parse_response_unknown_stop;
+      test_case "cache tokens in usage" `Quick test_parse_response_with_cache_tokens;
+    ];
+    "parse_sse_event", [
+      test_case "message_start" `Quick test_parse_sse_message_start;
+      test_case "content_block_delta text" `Quick test_parse_sse_content_block_delta_text;
+      test_case "content_block_delta thinking" `Quick test_parse_sse_content_block_delta_thinking;
+      test_case "content_block_delta input_json" `Quick test_parse_sse_content_block_delta_input_json;
+      test_case "content_block_start" `Quick test_parse_sse_content_block_start;
+      test_case "message_delta" `Quick test_parse_sse_message_delta;
+      test_case "message_stop" `Quick test_parse_sse_message_stop;
+      test_case "ping" `Quick test_parse_sse_ping;
+      test_case "error" `Quick test_parse_sse_error;
+      test_case "unknown event type" `Quick test_parse_sse_unknown_type;
+      test_case "malformed JSON" `Quick test_parse_sse_malformed_json;
     ];
     "message_to_json", [
       test_case "user message" `Quick test_message_to_json;
+      test_case "assistant mixed content" `Quick test_message_to_json_assistant;
     ];
   ]

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -65,6 +65,58 @@ let test_anthropic_provider () =
   | Error e ->
     Alcotest.fail (Printf.sprintf "should succeed but got: %s" e)
 
+let test_openai_compat_resolve_success () =
+  let env_var = "AGENT_SDK_TEST_OPENROUTER_KEY_q1w2e3" in
+  Unix.putenv env_var "or-test-key";
+  let cfg : Provider.config = {
+    provider = OpenAICompat {
+      base_url = "https://openrouter.ai/api/v1";
+      auth_header = "Authorization";
+    };
+    model_id = "anthropic/claude-sonnet-4-6";
+    api_key_env = env_var;
+  } in
+  match Provider.resolve cfg with
+  | Ok (base_url, api_key, headers) ->
+    Alcotest.(check string) "base_url" "https://openrouter.ai/api/v1" base_url;
+    Alcotest.(check string) "api_key" "or-test-key" api_key;
+    let auth = List.assoc "Authorization" headers in
+    Alcotest.(check string) "bearer token" "Bearer or-test-key" auth
+  | Error e ->
+    Alcotest.fail (Printf.sprintf "should succeed: %s" e)
+
+let test_openai_compat_resolve_missing_key () =
+  let cfg : Provider.config = {
+    provider = OpenAICompat {
+      base_url = "https://example.com";
+      auth_header = "Authorization";
+    };
+    model_id = "test";
+    api_key_env = "AGENT_SDK_TEST_NONEXISTENT_COMPAT_KEY_z0z0";
+  } in
+  match Provider.resolve cfg with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "should fail when env var missing"
+
+let test_anthropic_headers () =
+  let env_var = "AGENT_SDK_TEST_HDR_KEY_h3h3" in
+  Unix.putenv env_var "sk-ant-hdr-test";
+  let cfg : Provider.config = {
+    provider = Anthropic;
+    model_id = "test";
+    api_key_env = env_var;
+  } in
+  match Provider.resolve cfg with
+  | Ok (_, _, headers) ->
+    let xkey = List.assoc "x-api-key" headers in
+    Alcotest.(check string) "x-api-key header" "sk-ant-hdr-test" xkey;
+    let version = List.assoc "anthropic-version" headers in
+    Alcotest.(check string) "anthropic-version" "2023-06-01" version;
+    let ct = List.assoc "Content-Type" headers in
+    Alcotest.(check string) "content-type" "application/json" ct
+  | Error e ->
+    Alcotest.fail (Printf.sprintf "should succeed: %s" e)
+
 let () =
   Alcotest.run "Provider" [
     "resolve", [
@@ -72,5 +124,8 @@ let () =
       Alcotest.test_case "present env var returns Ok" `Quick test_present_env_var;
       Alcotest.test_case "local skips env var" `Quick test_local_skips_env_var;
       Alcotest.test_case "anthropic provider" `Quick test_anthropic_provider;
+      Alcotest.test_case "openai compat success" `Quick test_openai_compat_resolve_success;
+      Alcotest.test_case "openai compat missing key" `Quick test_openai_compat_resolve_missing_key;
+      Alcotest.test_case "anthropic headers" `Quick test_anthropic_headers;
     ];
   ]

--- a/test/test_retry.ml
+++ b/test/test_retry.ml
@@ -38,6 +38,35 @@ let test_classify_error () =
   Retry.classify_error ~status:529 ~body:"overloaded"
   |> expect_overloaded
 
+let test_classify_error_edge_cases () =
+  (* 429 with retry_after field *)
+  (match Retry.classify_error ~status:429 ~body:{|{"error":{"message":"slow down","retry_after":2.5}}|} with
+   | Retry.RateLimited { retry_after = Some ra; _ } ->
+       check (float 0.01) "retry_after parsed" 2.5 ra
+   | Retry.RateLimited { retry_after = None; _ } ->
+       fail "expected retry_after to be Some"
+   | _ -> fail "expected RateLimited");
+  (* 422 -> InvalidRequest *)
+  (match Retry.classify_error ~status:422 ~body:"validation error" with
+   | Retry.InvalidRequest { message } ->
+       check string "422 message" "validation error" message
+   | _ -> fail "expected InvalidRequest for 422");
+  (* 502 -> ServerError *)
+  (match Retry.classify_error ~status:502 ~body:"bad gateway" with
+   | Retry.ServerError { status; _ } ->
+       check int "502 status" 502 status
+   | _ -> fail "expected ServerError for 502");
+  (* malformed JSON body -> falls back to raw body *)
+  (match Retry.classify_error ~status:500 ~body:"not json at all" with
+   | Retry.ServerError { message; _ } ->
+       check string "raw body fallback" "not json at all" message
+   | _ -> fail "expected ServerError with raw body");
+  (* unmapped status (e.g. 404) -> catch-all InvalidRequest *)
+  (match Retry.classify_error ~status:404 ~body:"not found" with
+   | Retry.InvalidRequest { message } ->
+       check string "404 catch-all" "not found" message
+   | _ -> fail "expected InvalidRequest for 404")
+
 let test_is_retryable () =
   check bool "rate limited retryable" true
     (Retry.is_retryable (Retry.RateLimited { retry_after = None; message = "" }));
@@ -47,10 +76,26 @@ let test_is_retryable () =
     (Retry.is_retryable (Retry.ServerError { status = 500; message = "" }));
   check bool "network retryable" true
     (Retry.is_retryable (Retry.NetworkError { message = "" }));
+  check bool "timeout retryable" true
+    (Retry.is_retryable (Retry.Timeout { message = "" }));
   check bool "auth not retryable" false
     (Retry.is_retryable (Retry.AuthError { message = "" }));
   check bool "invalid request not retryable" false
     (Retry.is_retryable (Retry.InvalidRequest { message = "" }))
+
+let test_error_message_all_variants () =
+  let cases = [
+    (Retry.RateLimited { retry_after = None; message = "slow" }, "Rate limited: slow");
+    (Retry.Overloaded { message = "busy" }, "Overloaded: busy");
+    (Retry.ServerError { status = 503; message = "down" }, "Server error 503: down");
+    (Retry.AuthError { message = "bad key" }, "Auth error: bad key");
+    (Retry.InvalidRequest { message = "wrong" }, "Invalid request: wrong");
+    (Retry.NetworkError { message = "dns" }, "Network error: dns");
+    (Retry.Timeout { message = "10s" }, "Timeout: 10s");
+  ] in
+  List.iter (fun (err, expected) ->
+    check string "error_message" expected (Retry.error_message err)
+  ) cases
 
 let test_calculate_delay_ranges () =
   Random.init 0;
@@ -61,6 +106,113 @@ let test_calculate_delay_ranges () =
   check bool "attempt 1 range" true (delay1 >= 1.0 && delay1 <= 3.0);
   let delay2 = Retry.calculate_delay config 2 in
   check bool "attempt 2 range" true (delay2 >= 2.0 && delay2 <= 6.0)
+
+let test_calculate_delay_cap () =
+  let config : Retry.retry_config = {
+    max_retries = 10;
+    initial_delay = 1.0;
+    max_delay = 5.0;
+    backoff_factor = 2.0;
+  } in
+  (* At attempt 10, base = 1.0 * 2^10 = 1024, capped at 5.0 *)
+  (* With jitter: [5.0 * 0.5, 5.0 * 1.5] = [2.5, 7.5] *)
+  for _ = 0 to 9 do
+    let delay = Retry.calculate_delay config 10 in
+    check bool "capped upper bound" true (delay <= 7.5);
+    check bool "capped lower bound" true (delay >= 2.5)
+  done
+
+(* --- with_retry tests (require Eio runtime) --- *)
+
+let fast_config : Retry.retry_config = {
+  max_retries = 3;
+  initial_delay = 0.001;
+  max_delay = 0.005;
+  backoff_factor = 2.0;
+}
+
+let test_with_retry_succeeds_first_try () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  match Retry.with_retry ~clock ~config:fast_config (fun () -> Ok 42) with
+  | Ok v -> check int "immediate success" 42 v
+  | Error e -> fail (Printf.sprintf "unexpected error: %s" (Retry.error_message e))
+
+let test_with_retry_succeeds_after_retries () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let attempt = ref 0 in
+  let f () =
+    incr attempt;
+    if !attempt < 3 then Error (Retry.ServerError { status = 500; message = "transient" })
+    else Ok "recovered"
+  in
+  (match Retry.with_retry ~clock ~config:fast_config f with
+   | Ok v -> check string "eventual success" "recovered" v
+   | Error e -> fail (Printf.sprintf "unexpected error: %s" (Retry.error_message e)));
+  check int "took 3 attempts" 3 !attempt
+
+let test_with_retry_non_retryable_stops () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let attempt = ref 0 in
+  let f () =
+    incr attempt;
+    Error (Retry.AuthError { message = "invalid" })
+  in
+  let res = Retry.with_retry ~clock ~config:fast_config f in
+  (match res with
+   | Error (Retry.AuthError _) -> ()
+   | _ -> fail "expected AuthError");
+  check int "only 1 attempt" 1 !attempt
+
+let test_with_retry_rate_limited_uses_retry_after () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let attempt = ref 0 in
+  let f () =
+    incr attempt;
+    if !attempt < 2 then
+      Error (Retry.RateLimited { retry_after = Some 0.001; message = "slow down" })
+    else Ok "ok"
+  in
+  (match Retry.with_retry ~clock ~config:fast_config f with
+   | Ok v -> check string "recovered after rate limit" "ok" v
+   | Error e -> fail (Printf.sprintf "unexpected: %s" (Retry.error_message e)));
+  check int "2 attempts" 2 !attempt
+
+let test_with_retry_non_retryable_during_loop () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let attempt = ref 0 in
+  let f () =
+    incr attempt;
+    if !attempt = 1 then
+      Error (Retry.ServerError { status = 500; message = "transient" })
+    else
+      Error (Retry.InvalidRequest { message = "bad input" })
+  in
+  let res = Retry.with_retry ~clock ~config:fast_config f in
+  (match res with
+   | Error (Retry.InvalidRequest { message }) ->
+       check string "non-retryable in loop" "bad input" message
+   | _ -> fail "expected InvalidRequest from loop");
+  check int "stopped at 2" 2 !attempt
+
+let test_with_retry_max_retries_exhausted () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let attempt = ref 0 in
+  let f () =
+    incr attempt;
+    Error (Retry.NetworkError { message = "unreachable" })
+  in
+  (* 1 initial + 3 retries = 4 total attempts *)
+  let res = Retry.with_retry ~clock ~config:fast_config f in
+  (match res with
+   | Error (Retry.NetworkError _) -> ()
+   | _ -> fail "expected NetworkError after exhaustion");
+  check int "1 + max_retries attempts" 4 !attempt
 
 let test_provider_constructors () =
   let p = Provider.local_qwen () in
@@ -82,10 +234,21 @@ let () =
   run "Retry" [
     "classify", [
       test_case "http status mapping" `Quick test_classify_error;
+      test_case "edge cases" `Quick test_classify_error_edge_cases;
     ];
     "retryability", [
       test_case "retryable predicates" `Quick test_is_retryable;
+      test_case "error_message all variants" `Quick test_error_message_all_variants;
       test_case "delay ranges" `Quick test_calculate_delay_ranges;
+      test_case "delay cap" `Quick test_calculate_delay_cap;
+    ];
+    "with_retry", [
+      test_case "succeeds first try" `Quick test_with_retry_succeeds_first_try;
+      test_case "succeeds after retries" `Quick test_with_retry_succeeds_after_retries;
+      test_case "rate limited uses retry_after" `Quick test_with_retry_rate_limited_uses_retry_after;
+      test_case "non-retryable stops immediately" `Quick test_with_retry_non_retryable_stops;
+      test_case "non-retryable during loop" `Quick test_with_retry_non_retryable_during_loop;
+      test_case "max retries exhausted" `Quick test_with_retry_max_retries_exhausted;
     ];
     "providers", [
       test_case "constructor defaults" `Quick test_provider_constructors;


### PR DESCRIPTION
## Summary
- test_retry.ml 4 → 13 cases: with_retry Eio loop 전체 경로, classify_error edge cases, error_message 7 variants, delay cap, provider constructors
- test_provider.ml 4 → 7 cases: OpenAICompat resolve, Anthropic headers
- test_api.ml 18 → 33 cases: SSE event parsing 11종, cache_system_prompt, cache tokens, assistant message
- retry.ml coverage: 91% → 96% (57/59 points)
- Overall bisect_ppx: 61.8% (671/1086)

## Changes
| File | Before | After | Delta |
|------|--------|-------|-------|
| test_retry.ml | 4 cases | 13 cases | +9 |
| test_provider.ml | 4 cases | 7 cases | +3 |
| test_api.ml | 18 cases | 33 cases | +15 |
| **Total** | **26** | **53** | **+27** |

## Test plan
- [x] `dune build --root .` — 0 warnings
- [x] `dune runtest --root .` — 202 tests, 0 failures
- [x] bisect_ppx coverage report generated

Generated with [Claude Code](https://claude.com/claude-code)