### PR TITLE
feat(tracing): add observability module with TRACER module type

### DIFF
--- a/lib/agent.ml
+++ b/lib/agent.ml
@@ -12,10 +12,12 @@ type t = {
   hooks: Hooks.hooks;
   context: Context.t;
   guardrails: Guardrails.t;
+  tracer: Tracing.t;
 }
 
 let create ~net ?(config=default_config) ?(tools=[]) ?(base_url=Api.default_base_url)
-    ?provider ?(hooks=Hooks.empty) ?context ?(guardrails=Guardrails.default) () =
+    ?provider ?(hooks=Hooks.empty) ?context ?(guardrails=Guardrails.default)
+    ?(tracer=Tracing.null) () =
   let state = {
     config;
     messages = [];
@@ -26,7 +28,7 @@ let create ~net ?(config=default_config) ?(tools=[]) ?(base_url=Api.default_base
     | Some c -> c
     | None -> Context.create ()
   in
-  { state; tools; base_url; provider; net; hooks; context = ctx; guardrails }
+  { state; tools; base_url; provider; net; hooks; context = ctx; guardrails; tracer }
 
 (** Execute tools in parallel using Eio fibers.
     Applies PreToolUse/PostToolUse hooks and passes context to context-aware handlers.
@@ -35,30 +37,35 @@ let execute_tools agent tool_uses =
   Eio.Fiber.List.map (fun block ->
     match block with
     | ToolUse (id, name, input) ->
-        (try
-          (* PreToolUse hook *)
-          let decision = Hooks.invoke agent.hooks.pre_tool_use
-            (Hooks.PreToolUse { tool_name = name; input }) in
-          (match decision with
-          | Hooks.Skip -> (id, "Tool execution skipped by hook", false)
-          | Hooks.Override value -> (id, value, false)
-          | Hooks.Continue ->
-            let tool_opt = List.find_opt (fun (tool: Tool.t) -> tool.schema.name = name) agent.tools in
-            (match tool_opt with
-            | Some tool ->
-                let result = Tool.execute ~context:agent.context tool input in
-                (* PostToolUse hook *)
-                let _post = Hooks.invoke agent.hooks.post_tool_use
-                  (Hooks.PostToolUse { tool_name = name; input; output = result }) in
-                let content, is_error = match result with
-                  | Ok output -> output, false
-                  | Error err -> err, true
-                in
-                (id, content, is_error)
-            | None -> (id, "Tool not found", true)))
-        with exn ->
-          let msg = Printf.sprintf "Tool '%s' raised: %s" name (Printexc.to_string exn) in
-          (id, msg, true))
+        Tracing.with_span agent.tracer
+          { kind = Tool_exec; name;
+            agent_name = agent.state.config.name;
+            turn = agent.state.turn_count; extra = [] }
+          (fun _tracer ->
+            (try
+              (* PreToolUse hook *)
+              let decision = Hooks.invoke agent.hooks.pre_tool_use
+                (Hooks.PreToolUse { tool_name = name; input }) in
+              (match decision with
+              | Hooks.Skip -> (id, "Tool execution skipped by hook", false)
+              | Hooks.Override value -> (id, value, false)
+              | Hooks.Continue ->
+                let tool_opt = List.find_opt (fun (tool: Tool.t) -> tool.schema.name = name) agent.tools in
+                (match tool_opt with
+                | Some tool ->
+                    let result = Tool.execute ~context:agent.context tool input in
+                    (* PostToolUse hook *)
+                    let _post = Hooks.invoke agent.hooks.post_tool_use
+                      (Hooks.PostToolUse { tool_name = name; input; output = result }) in
+                    let content, is_error = match result with
+                      | Ok output -> output, false
+                      | Error err -> err, true
+                    in
+                    (id, content, is_error)
+                | None -> (id, "Tool not found", true)))
+            with exn ->
+              let msg = Printf.sprintf "Tool '%s' raised: %s" name (Printexc.to_string exn) in
+              (id, msg, true)))
     | _ -> ("", "", true)
   ) tool_uses
 
@@ -73,7 +80,16 @@ let run_turn ~sw ?clock agent =
   let tool_schemas = List.map Tool.schema_to_json visible_tools in
   let tools_json = if tool_schemas = [] then None else Some tool_schemas in
 
-  match Api.create_message ~sw ~net:agent.net ~base_url:agent.base_url ?provider:agent.provider ?clock ~config:agent.state ~messages:agent.state.messages ?tools:tools_json () with
+  let api_result = Tracing.with_span agent.tracer
+    { kind = Api_call; name = "create_message";
+      agent_name = agent.state.config.name;
+      turn = agent.state.turn_count; extra = [] }
+    (fun _tracer ->
+      Api.create_message ~sw ~net:agent.net ~base_url:agent.base_url
+        ?provider:agent.provider ?clock ~config:agent.state
+        ~messages:agent.state.messages ?tools:tools_json ())
+  in
+  match api_result with
   | Error e -> Error e
   | Ok response ->
       (* Accumulate usage stats *)

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -50,6 +50,7 @@ module Session = Session
 module Skill = Skill
 module Subagent = Subagent
 module Structured = Structured
+module Tracing = Tracing
 
 (** Quick start: create an agent with default config *)
 let create_agent ~net ?name ?model ?system_prompt ?max_tokens ?max_turns ?cache_system_prompt ?provider () =

--- a/lib/tracing.ml
+++ b/lib/tracing.ml
@@ -1,0 +1,86 @@
+(** Tracing / Observability module.
+    Defines a TRACER module type and two built-in implementations:
+    - Null_tracer: zero-allocation no-op (default)
+    - Fmt_tracer: stderr output for development/debugging
+
+    Uses first-class modules for runtime tracer selection. *)
+
+type span_kind = Agent_run | Api_call | Tool_exec | Hook_invoke
+
+type span_attrs = {
+  kind: span_kind;
+  name: string;
+  agent_name: string;
+  turn: int;
+  extra: (string * string) list;
+}
+
+module type TRACER = sig
+  type span
+  val start_span : span_attrs -> span
+  val end_span : span -> ok:bool -> unit
+  val add_event : span -> string -> unit
+  val add_attrs : span -> (string * string) list -> unit
+end
+
+module Null_tracer : TRACER with type span = unit = struct
+  type span = unit
+  let start_span _attrs = ()
+  let end_span () ~ok:_ = ()
+  let add_event () _msg = ()
+  let add_attrs () _attrs = ()
+end
+
+module Fmt_tracer : TRACER = struct
+  type span = {
+    attrs: span_attrs;
+    start_time: float;
+  }
+
+  let span_kind_to_string = function
+    | Agent_run -> "agent_run"
+    | Api_call -> "api_call"
+    | Tool_exec -> "tool_exec"
+    | Hook_invoke -> "hook_invoke"
+
+  let start_span attrs =
+    let start_time = Unix.gettimeofday () in
+    Format.eprintf "[TRACE] START %s/%s (agent=%s turn=%d)@."
+      (span_kind_to_string attrs.kind) attrs.name
+      attrs.agent_name attrs.turn;
+    { attrs; start_time }
+
+  let end_span span ~ok =
+    let elapsed = Unix.gettimeofday () -. span.start_time in
+    Format.eprintf "[TRACE] END %s/%s ok=%b elapsed=%.3fs@."
+      (span_kind_to_string span.attrs.kind) span.attrs.name
+      ok elapsed
+
+  let add_event span msg =
+    Format.eprintf "[TRACE] EVENT %s/%s: %s@."
+      (span_kind_to_string span.attrs.kind) span.attrs.name msg
+
+  let add_attrs span attrs =
+    List.iter (fun (k, v) ->
+      Format.eprintf "[TRACE] ATTR %s/%s: %s=%s@."
+        (span_kind_to_string span.attrs.kind) span.attrs.name k v
+    ) attrs
+end
+
+type t = (module TRACER)
+
+let null : t = (module Null_tracer)
+let fmt : t = (module Fmt_tracer)
+
+(** Run [f] within a traced span. [end_span] is called on both normal return
+    and exception, with [ok] set accordingly. The exception is re-raised. *)
+let with_span (type a) (tracer : t) (attrs : span_attrs) (f : t -> a) : a =
+  let module T = (val tracer : TRACER) in
+  let span = T.start_span attrs in
+  match f tracer with
+  | result ->
+    T.end_span span ~ok:true;
+    result
+  | exception exn ->
+    T.end_span span ~ok:false;
+    raise exn

--- a/test/dune
+++ b/test/dune
@@ -89,3 +89,7 @@
 (test
  (name test_structured)
  (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_tracing)
+ (libraries agent_sdk alcotest unix str))

--- a/test/test_tracing.ml
+++ b/test/test_tracing.ml
@@ -1,0 +1,148 @@
+(** Tests for tracing.ml -- TRACER module type and built-in implementations *)
+
+open Alcotest
+open Agent_sdk
+
+let test_null_tracer_no_op () =
+  let open Tracing.Null_tracer in
+  let span = start_span { kind = Agent_run; name = "test";
+    agent_name = "a"; turn = 0; extra = [] } in
+  add_event span "msg";
+  add_attrs span [("k", "v")];
+  end_span span ~ok:true;
+  check pass "null_tracer completes without error" () ()
+
+let test_null_tracer_false_ok () =
+  let open Tracing.Null_tracer in
+  let span = start_span { kind = Api_call; name = "call";
+    agent_name = "a"; turn = 1; extra = [] } in
+  end_span span ~ok:false;
+  check pass "null_tracer end_span ok:false succeeds" () ()
+
+let test_fmt_tracer_outputs () =
+  let buf = Buffer.create 256 in
+  (* Save original err_formatter output functions *)
+  let orig_out, orig_flush =
+    Format.pp_get_formatter_output_functions Format.err_formatter ()
+  in
+  (* Redirect err_formatter to buffer *)
+  Format.pp_set_formatter_output_functions Format.err_formatter
+    (fun s ofs len -> Buffer.add_substring buf s ofs len)
+    (fun () -> ());
+  let module T = (val Tracing.fmt : Tracing.TRACER) in
+  let span = T.start_span { kind = Tool_exec; name = "grep";
+    agent_name = "searcher"; turn = 2; extra = [] } in
+  T.add_event span "found 3 results";
+  T.add_attrs span [("count", "3")];
+  T.end_span span ~ok:true;
+  (* Restore original err_formatter *)
+  Format.pp_set_formatter_output_functions Format.err_formatter
+    orig_out orig_flush;
+  let output = Buffer.contents buf in
+  check bool "output contains [TRACE]" true (String.length output > 0
+    && try let _ = Str.search_forward (Str.regexp_string "[TRACE]") output 0 in true
+       with Not_found -> false)
+
+let test_with_span_success () =
+  let result = Tracing.with_span Tracing.null
+    { kind = Agent_run; name = "run"; agent_name = "a"; turn = 0; extra = [] }
+    (fun _tracer -> 42)
+  in
+  check int "with_span returns function result" 42 result
+
+let test_with_span_exception () =
+  let raised = ref false in
+  (try
+    let _ = Tracing.with_span Tracing.null
+      { kind = Agent_run; name = "fail"; agent_name = "a"; turn = 0; extra = [] }
+      (fun _tracer -> failwith "boom")
+    in
+    ()
+  with Failure msg ->
+    raised := true;
+    check string "exception message preserved" "boom" msg);
+  check bool "exception was re-raised" true !raised
+
+(** Custom recording tracer to verify the module type contract. *)
+module Recording_tracer : sig
+  include Tracing.TRACER
+  val events : unit -> string list
+  val reset : unit -> unit
+end = struct
+  type span = { span_name: string }
+  let log : string list ref = ref []
+  let start_span (attrs : Tracing.span_attrs) =
+    log := (Printf.sprintf "start:%s" attrs.name) :: !log;
+    { span_name = attrs.name }
+  let end_span span ~ok =
+    log := (Printf.sprintf "end:%s:ok=%b" span.span_name ok) :: !log
+  let add_event span msg =
+    log := (Printf.sprintf "event:%s:%s" span.span_name msg) :: !log
+  let add_attrs span kvs =
+    List.iter (fun (k, v) ->
+      log := (Printf.sprintf "attr:%s:%s=%s" span.span_name k v) :: !log
+    ) kvs
+  let events () = List.rev !log
+  let reset () = log := []
+end
+
+let test_custom_tracer () =
+  Recording_tracer.reset ();
+  let span = Recording_tracer.start_span
+    { kind = Hook_invoke; name = "custom"; agent_name = "x"; turn = 0; extra = [] } in
+  Recording_tracer.add_event span "hi";
+  Recording_tracer.add_attrs span [("a", "1")];
+  Recording_tracer.end_span span ~ok:true;
+  let evts = Recording_tracer.events () in
+  check int "4 events recorded" 4 (List.length evts);
+  check string "first is start" "start:custom" (List.nth evts 0);
+  check string "second is event" "event:custom:hi" (List.nth evts 1);
+  check string "third is attr" "attr:custom:a=1" (List.nth evts 2);
+  check string "fourth is end" "end:custom:ok=true" (List.nth evts 3)
+
+let test_span_kind_coverage () =
+  let kinds = Tracing.[Agent_run; Api_call; Tool_exec; Hook_invoke] in
+  List.iteri (fun i kind ->
+    let result = Tracing.with_span Tracing.null
+      { kind; name = Printf.sprintf "kind_%d" i;
+        agent_name = "a"; turn = 0; extra = [] }
+      (fun _tracer -> i)
+    in
+    check int (Printf.sprintf "kind %d returns correctly" i) i result
+  ) kinds
+
+let test_with_span_exception_ends_span () =
+  Recording_tracer.reset ();
+  let tracer : Tracing.t = (module Recording_tracer) in
+  (try
+    let _ = Tracing.with_span tracer
+      { kind = Api_call; name = "err"; agent_name = "a"; turn = 0; extra = [] }
+      (fun _tracer -> failwith "oops")
+    in ()
+  with Failure _ -> ());
+  let evts = Recording_tracer.events () in
+  check int "2 events (start + end)" 2 (List.length evts);
+  check string "start recorded" "start:err" (List.nth evts 0);
+  check string "end with ok=false" "end:err:ok=false" (List.nth evts 1)
+
+let () =
+  run "Tracing" [
+    "null_tracer", [
+      test_case "no-op operations" `Quick test_null_tracer_no_op;
+      test_case "end_span ok:false" `Quick test_null_tracer_false_ok;
+    ];
+    "fmt_tracer", [
+      test_case "outputs to stderr" `Quick test_fmt_tracer_outputs;
+    ];
+    "with_span", [
+      test_case "success path" `Quick test_with_span_success;
+      test_case "exception path" `Quick test_with_span_exception;
+      test_case "exception ends span" `Quick test_with_span_exception_ends_span;
+    ];
+    "custom", [
+      test_case "recording tracer" `Quick test_custom_tracer;
+    ];
+    "coverage", [
+      test_case "all span_kind variants" `Quick test_span_kind_coverage;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- `Tracing` module with `TRACER` module type (first-class module pattern, Caqti-style)
- `Null_tracer`: zero-allocation no-op (default). `Fmt_tracer`: stderr output for dev/debug
- `Agent.t` gets `tracer` field (optional, default `Tracing.null`)
- API calls and tool executions wrapped with `with_span` for structured tracing
- 8 new tests, 0 warnings, all existing tests pass

## Design
- No hard dependency on OpenTelemetry (Imandra v0.12 is Beta)
- Users can implement custom `TRACER` adapter for OTel, Datadog, etc.
- `with_span` guarantees `end_span` even on exception (RAII pattern)

## Test plan
- [ ] `dune build @all` — 0 warnings
- [ ] `dune runtest` — all pass
- [ ] Null_tracer: no-op correctness
- [ ] Fmt_tracer: stderr output capture
- [ ] with_span: success + exception paths
- [ ] Custom TRACER: module type satisfaction
- [ ] All 4 span_kind variants covered

Part of v0.5.0 (Tracing + HITL + Context Reducer)