### PR TITLE
feat(approval): add human-in-the-loop approval callback

### DIFF
--- a/lib/agent.ml
+++ b/lib/agent.ml
@@ -13,11 +13,12 @@ type t = {
   context: Context.t;
   guardrails: Guardrails.t;
   tracer: Tracing.t;
+  approval: Hooks.approval_callback option;
 }
 
 let create ~net ?(config=default_config) ?(tools=[]) ?(base_url=Api.default_base_url)
     ?provider ?(hooks=Hooks.empty) ?context ?(guardrails=Guardrails.default)
-    ?(tracer=Tracing.null) () =
+    ?(tracer=Tracing.null) ?approval () =
   let state = {
     config;
     messages = [];
@@ -28,7 +29,23 @@ let create ~net ?(config=default_config) ?(tools=[]) ?(base_url=Api.default_base
     | Some c -> c
     | None -> Context.create ()
   in
-  { state; tools; base_url; provider; net; hooks; context = ctx; guardrails; tracer }
+  { state; tools; base_url; provider; net; hooks; context = ctx; guardrails; tracer; approval }
+
+(** Helper: find and execute a tool, invoke PostToolUse hook.
+    Returns (id, content, is_error) triple. *)
+let find_and_execute_tool agent name input id =
+  let tool_opt = List.find_opt (fun (tool: Tool.t) -> tool.schema.name = name) agent.tools in
+  match tool_opt with
+  | Some tool ->
+    let result = Tool.execute ~context:agent.context tool input in
+    let _post = Hooks.invoke agent.hooks.post_tool_use
+      (Hooks.PostToolUse { tool_name = name; input; output = result }) in
+    let content, is_error = match result with
+      | Ok output -> output, false
+      | Error err -> err, true
+    in
+    (id, content, is_error)
+  | None -> (id, "Tool not found", true)
 
 (** Execute tools in parallel using Eio fibers.
     Applies PreToolUse/PostToolUse hooks and passes context to context-aware handlers.
@@ -49,20 +66,17 @@ let execute_tools agent tool_uses =
               (match decision with
               | Hooks.Skip -> (id, "Tool execution skipped by hook", false)
               | Hooks.Override value -> (id, value, false)
-              | Hooks.Continue ->
-                let tool_opt = List.find_opt (fun (tool: Tool.t) -> tool.schema.name = name) agent.tools in
-                (match tool_opt with
-                | Some tool ->
-                    let result = Tool.execute ~context:agent.context tool input in
-                    (* PostToolUse hook *)
-                    let _post = Hooks.invoke agent.hooks.post_tool_use
-                      (Hooks.PostToolUse { tool_name = name; input; output = result }) in
-                    let content, is_error = match result with
-                      | Ok output -> output, false
-                      | Error err -> err, true
-                    in
-                    (id, content, is_error)
-                | None -> (id, "Tool not found", true)))
+              | Hooks.ApprovalRequired ->
+                (match agent.approval with
+                | None ->
+                  (* No callback registered: permissive default, execute normally *)
+                  find_and_execute_tool agent name input id
+                | Some approve_fn ->
+                  (match approve_fn ~tool_name:name ~input with
+                  | Hooks.Approve -> find_and_execute_tool agent name input id
+                  | Hooks.Reject reason -> (id, "Tool rejected: " ^ reason, true)
+                  | Hooks.Edit new_input -> find_and_execute_tool agent name new_input id))
+              | Hooks.Continue -> find_and_execute_tool agent name input id)
             with exn ->
               let msg = Printf.sprintf "Tool '%s' raised: %s" name (Printexc.to_string exn) in
               (id, msg, true)))

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -19,6 +19,18 @@ type hook_decision =
   | Continue
   | Skip           (** PreToolUse only: skip this tool execution *)
   | Override of string  (** PreToolUse only: return this value instead *)
+  | ApprovalRequired  (** PreToolUse only: signals that tool needs approval before execution *)
+
+(** Decision from approval callback *)
+type approval_decision =
+  | Approve                      (** Proceed with original input *)
+  | Reject of string             (** Block execution with reason *)
+  | Edit of Yojson.Safe.t        (** Proceed with modified input *)
+
+(** Approval callback: called when a hook returns ApprovalRequired.
+    Receives tool name and input, returns approval decision. *)
+type approval_callback =
+  tool_name:string -> input:Yojson.Safe.t -> approval_decision
 
 (** A hook function *)
 type hook = hook_event -> hook_decision

--- a/test/dune
+++ b/test/dune
@@ -19,6 +19,10 @@
  (libraries agent_sdk alcotest yojson))
 
 (test
+ (name test_approval)
+ (libraries agent_sdk alcotest yojson eio eio_main))
+
+(test
  (name test_context)
  (libraries agent_sdk alcotest yojson))
 

--- a/test/test_approval.ml
+++ b/test/test_approval.ml
@@ -1,0 +1,142 @@
+(** Tests for approval callback (human-in-the-loop) in execute_tools. *)
+
+open Alcotest
+open Agent_sdk
+open Types
+
+(** Helper: create a simple tool that echoes its input as JSON string *)
+let make_echo_tool name =
+  Tool.create ~name ~description:"echo" ~parameters:[] (fun input ->
+    Ok (Yojson.Safe.to_string input))
+
+(** Helper: create a minimal agent inside Eio with given hooks and approval.
+    Returns execute_tools results for the given tool_uses. *)
+let run_execute ~hooks ?approval tool_uses =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  let tools = [make_echo_tool "safe"; make_echo_tool "dangerous"] in
+  let agent = Agent.create ~net ~hooks ?approval ~tools () in
+  Agent.execute_tools agent tool_uses
+
+(* --- Test cases --- *)
+
+let test_approval_required_no_callback () =
+  (* ApprovalRequired with no callback registered: permissive fallthrough *)
+  let hooks = { Hooks.empty with
+    pre_tool_use = Some (fun _event -> Hooks.ApprovalRequired) } in
+  let results = run_execute ~hooks [ToolUse ("t1", "safe", `String "hello")] in
+  match results with
+  | [(id, content, is_error)] ->
+    check string "id" "t1" id;
+    check string "content" {|"hello"|} content;
+    check bool "no error" false is_error
+  | _ -> fail "expected exactly one result"
+
+let test_approval_approve () =
+  let hooks = { Hooks.empty with
+    pre_tool_use = Some (fun _event -> Hooks.ApprovalRequired) } in
+  let approval ~tool_name:_ ~input:_ = Hooks.Approve in
+  let results = run_execute ~hooks ~approval
+    [ToolUse ("t1", "safe", `String "data")] in
+  match results with
+  | [(id, content, is_error)] ->
+    check string "id" "t1" id;
+    check string "content" {|"data"|} content;
+    check bool "no error" false is_error
+  | _ -> fail "expected exactly one result"
+
+let test_approval_reject () =
+  let hooks = { Hooks.empty with
+    pre_tool_use = Some (fun _event -> Hooks.ApprovalRequired) } in
+  let approval ~tool_name:_ ~input:_ = Hooks.Reject "too dangerous" in
+  let results = run_execute ~hooks ~approval
+    [ToolUse ("t1", "dangerous", `String "rm -rf")] in
+  match results with
+  | [(id, content, is_error)] ->
+    check string "id" "t1" id;
+    check string "content" "Tool rejected: too dangerous" content;
+    check bool "is error" true is_error
+  | _ -> fail "expected exactly one result"
+
+let test_approval_edit () =
+  let hooks = { Hooks.empty with
+    pre_tool_use = Some (fun _event -> Hooks.ApprovalRequired) } in
+  let safe_input = `String "sanitized" in
+  let approval ~tool_name:_ ~input:_ = Hooks.Edit safe_input in
+  let results = run_execute ~hooks ~approval
+    [ToolUse ("t1", "dangerous", `String "original")] in
+  match results with
+  | [(id, content, is_error)] ->
+    check string "id" "t1" id;
+    check string "content uses edited input" {|"sanitized"|} content;
+    check bool "no error" false is_error
+  | _ -> fail "expected exactly one result"
+
+let test_selective_approval () =
+  (* Only "dangerous" requires approval; "safe" is auto-approved *)
+  let hooks = { Hooks.empty with
+    pre_tool_use = Some (fun event ->
+      match event with
+      | Hooks.PreToolUse { tool_name; _ } when tool_name = "dangerous" ->
+        Hooks.ApprovalRequired
+      | _ -> Hooks.Continue) } in
+  let approval ~tool_name ~input:_ =
+    if tool_name = "dangerous" then Hooks.Reject "blocked"
+    else Hooks.Approve
+  in
+  let results = run_execute ~hooks ~approval [
+    ToolUse ("t1", "safe", `String "ok");
+    ToolUse ("t2", "dangerous", `String "bad");
+  ] in
+  (* Results may be in any order due to Eio.Fiber.List.map, so sort by id *)
+  let sorted = List.sort (fun (a, _, _) (b, _, _) -> String.compare a b) results in
+  (match sorted with
+  | [(id1, content1, err1); (id2, content2, err2)] ->
+    check string "safe id" "t1" id1;
+    check string "safe executed" {|"ok"|} content1;
+    check bool "safe no error" false err1;
+    check string "dangerous id" "t2" id2;
+    check string "dangerous rejected" "Tool rejected: blocked" content2;
+    check bool "dangerous is error" true err2
+  | _ -> fail "expected exactly two results")
+
+let test_skip_override_unaffected () =
+  (* Skip and Override decisions still work when approval is configured *)
+  let hooks = { Hooks.empty with
+    pre_tool_use = Some (fun event ->
+      match event with
+      | Hooks.PreToolUse { tool_name = "safe"; _ } -> Hooks.Skip
+      | Hooks.PreToolUse { tool_name = "dangerous"; _ } -> Hooks.Override "overridden"
+      | _ -> Hooks.Continue) } in
+  let approval_called = ref false in
+  let approval ~tool_name:_ ~input:_ =
+    approval_called := true;
+    Hooks.Approve
+  in
+  let results = run_execute ~hooks ~approval [
+    ToolUse ("t1", "safe", `Null);
+    ToolUse ("t2", "dangerous", `Null);
+  ] in
+  let sorted = List.sort (fun (a, _, _) (b, _, _) -> String.compare a b) results in
+  check bool "approval callback not called" false !approval_called;
+  (match sorted with
+  | [(id1, content1, err1); (id2, content2, err2)] ->
+    check string "skip id" "t1" id1;
+    check string "skipped" "Tool execution skipped by hook" content1;
+    check bool "skip not error" false err1;
+    check string "override id" "t2" id2;
+    check string "overridden" "overridden" content2;
+    check bool "override not error" false err2
+  | _ -> fail "expected exactly two results")
+
+let () =
+  run "Approval" [
+    "approval_required", [
+      test_case "no callback = fallthrough" `Quick test_approval_required_no_callback;
+      test_case "Approve = normal execution" `Quick test_approval_approve;
+      test_case "Reject with reason" `Quick test_approval_reject;
+      test_case "Edit modifies input" `Quick test_approval_edit;
+      test_case "selective by tool name" `Quick test_selective_approval;
+      test_case "Skip/Override unaffected" `Quick test_skip_override_unaffected;
+    ];
+  ]

--- a/test/test_hooks.ml
+++ b/test/test_hooks.ml
@@ -60,6 +60,12 @@ let test_post_tool_use_event () =
     }) in
   check string "hook received output" "hello" !received_output
 
+let test_invoke_approval_required () =
+  let hook _event = Hooks.ApprovalRequired in
+  let result = Hooks.invoke (Some hook)
+    (Hooks.PreToolUse { tool_name = "dangerous"; input = `Null }) in
+  check bool "hook returns ApprovalRequired" true (result = Hooks.ApprovalRequired)
+
 let () =
   run "Hooks" [
     "empty", [
@@ -70,6 +76,7 @@ let () =
       test_case "invoke Continue" `Quick test_invoke_continue;
       test_case "invoke Skip" `Quick test_invoke_skip;
       test_case "invoke Override" `Quick test_invoke_override;
+      test_case "invoke ApprovalRequired" `Quick test_invoke_approval_required;
       test_case "receives event" `Quick test_hook_receives_event;
       test_case "post_tool_use event" `Quick test_post_tool_use_event;
     ];


### PR DESCRIPTION
## Summary
- `ApprovalRequired` variant added to `hook_decision` (non-breaking addition)
- `approval_decision` type: `Approve | Reject of string | Edit of Yojson.Safe.t`
- `approval_callback` type for pluggable approval logic (CLI prompt, HTTP, WebSocket)
- `Agent.t` gets optional `approval` field
- `find_and_execute_tool` helper extracted to eliminate code duplication
- 6 new approval tests + 1 hooks test, 0 warnings, all existing tests pass

## Design
- Separation of concerns: Hook decides IF approval needed, callback decides HOW
- `Edit` variant enables input modification before execution (search query rewrite, etc.)
- No callback registered = permissive fallthrough (backward-compatible)
- `hook_decision` variant addition produces warning 8 in user code (non-breaking, documented)

## Test plan
- [ ] `dune build @all` — 0 warnings
- [ ] `dune runtest` — all pass
- [ ] ApprovalRequired + no callback = fallthrough
- [ ] Approve = normal execution
- [ ] Reject with reason string
- [ ] Edit modifies tool input
- [ ] Selective approval by tool name
- [ ] Existing Skip/Override unaffected

Part of v0.5.0 (Tracing + HITL + Context Reducer)