### PR TITLE
feat(context-reducer): add message windowing with turn-boundary grouping

### DIFF
--- a/lib/agent.ml
+++ b/lib/agent.ml
@@ -14,11 +14,12 @@ type t = {
   guardrails: Guardrails.t;
   tracer: Tracing.t;
   approval: Hooks.approval_callback option;
+  context_reducer: Context_reducer.t option;
 }
 
 let create ~net ?(config=default_config) ?(tools=[]) ?(base_url=Api.default_base_url)
     ?provider ?(hooks=Hooks.empty) ?context ?(guardrails=Guardrails.default)
-    ?(tracer=Tracing.null) ?approval () =
+    ?(tracer=Tracing.null) ?approval ?context_reducer () =
   let state = {
     config;
     messages = [];
@@ -29,7 +30,8 @@ let create ~net ?(config=default_config) ?(tools=[]) ?(base_url=Api.default_base
     | Some c -> c
     | None -> Context.create ()
   in
-  { state; tools; base_url; provider; net; hooks; context = ctx; guardrails; tracer; approval }
+  { state; tools; base_url; provider; net; hooks; context = ctx; guardrails;
+    tracer; approval; context_reducer }
 
 (** Helper: find and execute a tool, invoke PostToolUse hook.
     Returns (id, content, is_error) triple. *)
@@ -94,6 +96,13 @@ let run_turn ~sw ?clock agent =
   let tool_schemas = List.map Tool.schema_to_json visible_tools in
   let tools_json = if tool_schemas = [] then None else Some tool_schemas in
 
+  (* Apply context reducer: only the API call sees the windowed messages.
+     The full history is preserved in agent.state.messages. *)
+  let effective_messages = match agent.context_reducer with
+    | None -> agent.state.messages
+    | Some reducer -> Context_reducer.reduce reducer agent.state.messages
+  in
+
   let api_result = Tracing.with_span agent.tracer
     { kind = Api_call; name = "create_message";
       agent_name = agent.state.config.name;
@@ -101,7 +110,7 @@ let run_turn ~sw ?clock agent =
     (fun _tracer ->
       Api.create_message ~sw ~net:agent.net ~base_url:agent.base_url
         ?provider:agent.provider ?clock ~config:agent.state
-        ~messages:agent.state.messages ?tools:tools_json ())
+        ~messages:effective_messages ?tools:tools_json ())
   in
   match api_result with
   | Error e -> Error e

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -51,6 +51,7 @@ module Skill = Skill
 module Subagent = Subagent
 module Structured = Structured
 module Tracing = Tracing
+module Context_reducer = Context_reducer
 
 (** Quick start: create an agent with default config *)
 let create_agent ~net ?name ?model ?system_prompt ?max_tokens ?max_turns ?cache_system_prompt ?provider () =

--- a/lib/context_reducer.ml
+++ b/lib/context_reducer.ml
@@ -1,0 +1,107 @@
+(** Context reducer: message windowing strategies.
+
+    Reduces message lists before API calls while preserving the full history
+    in agent state. This avoids sending the entire conversation on every
+    request, cutting input tokens without losing debuggability.
+
+    Critical constraint: Anthropic API requires that every ToolUse block has
+    a matching ToolResult in the subsequent User message. All strategies
+    respect turn boundaries so ToolUse/ToolResult pairs are never split.
+
+    Token estimation uses a 4-char-per-token heuristic. This is deliberately
+    approximate -- the goal is budget sizing, not exact counting. *)
+
+open Types
+
+type strategy =
+  | Keep_last_n of int
+  | Token_budget of int
+  | Custom of (message list -> message list)
+
+type t = { strategy : strategy }
+
+(** Estimate tokens for a single content block.
+    Heuristic: 4 characters ~ 1 token. *)
+let estimate_block_tokens = function
+  | Text s -> (String.length s + 3) / 4
+  | Thinking (_, s) -> (String.length s + 3) / 4
+  | RedactedThinking _ -> 50
+  | ToolUse (_, name, input) ->
+    let input_str = Yojson.Safe.to_string input in
+    ((String.length name + String.length input_str) + 3) / 4
+  | ToolResult (_, content, _) -> (String.length content + 3) / 4
+  | Image _ -> 1000
+  | Document _ -> 2000
+
+(** Estimate tokens for a message (sum of its content blocks). *)
+let estimate_message_tokens (msg : message) : int =
+  List.fold_left (fun acc block -> acc + estimate_block_tokens block) 0 msg.content
+
+(** Group messages into turns.
+
+    A turn starts with a User message and includes all following messages
+    until the next User message. User messages whose content contains a
+    ToolResult do NOT start a new turn -- they belong to the preceding turn
+    because the ToolResult must stay paired with its ToolUse.
+
+    The first group may start with an Assistant message if the conversation
+    does not begin with a User message (unusual but handled). *)
+let group_into_turns (messages : message list) : message list list =
+  let rec aux current_turn acc = function
+    | [] ->
+      if current_turn = [] then List.rev acc
+      else List.rev (List.rev current_turn :: acc)
+    | msg :: rest ->
+      if msg.role = User && current_turn <> [] then
+        let has_tool_result =
+          List.exists (function ToolResult _ -> true | _ -> false) msg.content
+        in
+        if has_tool_result then
+          aux (msg :: current_turn) acc rest
+        else
+          aux [msg] (List.rev current_turn :: acc) rest
+      else
+        aux (msg :: current_turn) acc rest
+  in
+  aux [] [] messages
+
+(** Keep the last [n] turn groups. *)
+let apply_keep_last_n n messages =
+  let turns = group_into_turns messages in
+  let total = List.length turns in
+  if total <= n then messages
+  else
+    let kept = List.filteri (fun i _ -> i >= total - n) turns in
+    List.concat kept
+
+(** Keep as many recent turns as fit within [budget] tokens.
+    Iterates from the most recent turn backward, accumulating until
+    the budget is exhausted. *)
+let apply_token_budget budget messages =
+  let turns = group_into_turns messages in
+  let reversed = List.rev turns in
+  let rec take_turns acc remaining = function
+    | [] -> acc
+    | turn :: rest ->
+      let turn_tokens =
+        List.fold_left (fun sum msg -> sum + estimate_message_tokens msg) 0 turn
+      in
+      if remaining >= turn_tokens then
+        take_turns (turn :: acc) (remaining - turn_tokens) rest
+      else
+        acc
+  in
+  let kept = take_turns [] budget reversed in
+  List.concat kept
+
+(** Reduce messages according to the configured strategy. *)
+let reduce (reducer : t) (messages : message list) : message list =
+  match reducer.strategy with
+  | Keep_last_n n -> apply_keep_last_n n messages
+  | Token_budget budget -> apply_token_budget budget messages
+  | Custom f -> f messages
+
+(** Convenience constructors. *)
+let keep_last n = { strategy = Keep_last_n n }
+let token_budget n = { strategy = Token_budget n }
+let custom f = { strategy = Custom f }

--- a/test/dune
+++ b/test/dune
@@ -94,6 +94,11 @@
  (name test_structured)
  (libraries agent_sdk alcotest yojson))
 
+
 (test
  (name test_tracing)
  (libraries agent_sdk alcotest unix str))
+
+(test
+ (name test_context_reducer)
+ (libraries agent_sdk alcotest yojson))

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -1,0 +1,214 @@
+(** Tests for Context_reducer — pure functions, no Eio needed. *)
+
+open Agent_sdk
+
+let user_msg text = Types.{ role = User; content = [Text text] }
+let asst_msg text = Types.{ role = Assistant; content = [Text text] }
+let tool_use_msg id name = Types.{ role = Assistant; content = [ToolUse (id, name, `Null)] }
+let tool_result_msg id content = Types.{ role = User; content = [ToolResult (id, content, false)] }
+
+(* --- keep_last_n --- *)
+
+let test_keep_last_n_identity () =
+  let msgs = [user_msg "a"; asst_msg "b"] in
+  let result = Context_reducer.reduce (Context_reducer.keep_last 10) msgs in
+  Alcotest.(check int) "all preserved" (List.length msgs) (List.length result)
+
+let test_keep_last_n_trims () =
+  let msgs = [
+    user_msg "turn1"; asst_msg "r1";
+    user_msg "turn2"; asst_msg "r2";
+    user_msg "turn3"; asst_msg "r3";
+  ] in
+  let result = Context_reducer.reduce (Context_reducer.keep_last 2) msgs in
+  Alcotest.(check int) "trimmed to 2 turns (4 msgs)" 4 (List.length result);
+  (* First message in result should be "turn2" *)
+  (match result with
+   | { Types.content = [Types.Text t]; _ } :: _ ->
+     Alcotest.(check string) "first msg is turn2" "turn2" t
+   | _ -> Alcotest.fail "unexpected first message")
+
+let test_keep_last_n_tool_pairing () =
+  (* Turn 1: user + assistant(ToolUse) + user(ToolResult) + assistant *)
+  (* Turn 2: user + assistant *)
+  let msgs = [
+    user_msg "turn1";
+    tool_use_msg "t1" "calc";
+    tool_result_msg "t1" "42";
+    asst_msg "answer is 42";
+    user_msg "turn2";
+    asst_msg "done";
+  ] in
+  let result = Context_reducer.reduce (Context_reducer.keep_last 1) msgs in
+  (* Last turn is [user_msg "turn2"; asst_msg "done"] *)
+  Alcotest.(check int) "last turn only" 2 (List.length result)
+
+let test_keep_last_n_keeps_tool_pair_in_turn () =
+  (* Keeping last 2 turns when turn1 has tool use/result *)
+  let msgs = [
+    user_msg "turn0"; asst_msg "r0";
+    user_msg "turn1";
+    tool_use_msg "t1" "calc";
+    tool_result_msg "t1" "42";
+    asst_msg "answer";
+    user_msg "turn2"; asst_msg "done";
+  ] in
+  let result = Context_reducer.reduce (Context_reducer.keep_last 2) msgs in
+  (* turn1 has 4 messages (user + tool_use + tool_result + asst), turn2 has 2 *)
+  Alcotest.(check int) "2 turns with tool pair" 6 (List.length result);
+  (* Verify tool_result is present *)
+  let has_tool_result = List.exists (fun (m : Types.message) ->
+    List.exists (function Types.ToolResult _ -> true | _ -> false) m.content
+  ) result in
+  Alcotest.(check bool) "tool result present" true has_tool_result
+
+(* --- token_budget --- *)
+
+let test_token_budget_within () =
+  let msgs = [user_msg "hi"; asst_msg "hello"] in
+  let result = Context_reducer.reduce (Context_reducer.token_budget 10000) msgs in
+  Alcotest.(check int) "all preserved" (List.length msgs) (List.length result)
+
+let test_token_budget_exceeds () =
+  (* Each turn is ~1 token for short text, but let's use longer strings *)
+  let long = String.make 400 'x' in (* 400 chars ~ 100 tokens *)
+  let msgs = [
+    user_msg long; asst_msg long;  (* turn1: ~200 tokens *)
+    user_msg long; asst_msg long;  (* turn2: ~200 tokens *)
+    user_msg long; asst_msg long;  (* turn3: ~200 tokens *)
+  ] in
+  let result = Context_reducer.reduce (Context_reducer.token_budget 250) msgs in
+  (* Budget 250 fits 1 turn (~200 tokens), not 2 *)
+  Alcotest.(check int) "only last turn" 2 (List.length result)
+
+let test_token_budget_image_doc () =
+  let msgs = [
+    Types.{ role = User; content = [Image { media_type = "image/png"; data = "abc"; source_type = "base64" }] };
+    asst_msg "nice image";
+    Types.{ role = User; content = [Document { media_type = "application/pdf"; data = "abc"; source_type = "base64" }] };
+    asst_msg "nice doc";
+  ] in
+  (* Image turn ~ 1000+, Document turn ~ 2000+. Budget 1500 should keep only doc turn *)
+  let result = Context_reducer.reduce (Context_reducer.token_budget 2100) msgs in
+  Alcotest.(check int) "doc turn only" 2 (List.length result)
+
+(* --- estimate_message_tokens --- *)
+
+let test_estimate_text () =
+  let msg = user_msg "hello world" in (* 11 chars -> (11+3)/4 = 3 *)
+  let tokens = Context_reducer.estimate_message_tokens msg in
+  Alcotest.(check int) "text estimation" 3 tokens
+
+let test_estimate_tool_use () =
+  let msg = Types.{ role = Assistant; content = [ToolUse ("id1", "calc", `String "input")] } in
+  let tokens = Context_reducer.estimate_message_tokens msg in
+  (* "calc" = 4 chars, `String "input" -> "\"input\"" = 7 chars, total 11, (11+3)/4 = 3 *)
+  Alcotest.(check bool) "tool_use > 0" true (tokens > 0)
+
+let test_estimate_tool_result () =
+  let msg = Types.{ role = User; content = [ToolResult ("id1", "result text", false)] } in
+  let tokens = Context_reducer.estimate_message_tokens msg in
+  (* "result text" = 11 chars -> (11+3)/4 = 3 *)
+  Alcotest.(check int) "tool_result estimation" 3 tokens
+
+let test_estimate_image () =
+  let msg = Types.{ role = User; content = [Image { media_type = "image/png"; data = "x"; source_type = "base64" }] } in
+  let tokens = Context_reducer.estimate_message_tokens msg in
+  Alcotest.(check int) "image estimation" 1000 tokens
+
+let test_estimate_document () =
+  let msg = Types.{ role = User; content = [Document { media_type = "application/pdf"; data = "x"; source_type = "base64" }] } in
+  let tokens = Context_reducer.estimate_message_tokens msg in
+  Alcotest.(check int) "document estimation" 2000 tokens
+
+(* --- group_into_turns --- *)
+
+let test_group_basic () =
+  let msgs = [
+    user_msg "a"; asst_msg "b";
+    user_msg "c"; asst_msg "d";
+  ] in
+  let turns = Context_reducer.group_into_turns msgs in
+  Alcotest.(check int) "2 turns" 2 (List.length turns);
+  Alcotest.(check int) "turn1 has 2 msgs" 2 (List.length (List.nth turns 0));
+  Alcotest.(check int) "turn2 has 2 msgs" 2 (List.length (List.nth turns 1))
+
+let test_group_tool_result_stays () =
+  let msgs = [
+    user_msg "q";
+    tool_use_msg "t1" "calc";
+    tool_result_msg "t1" "42";
+    asst_msg "done";
+  ] in
+  let turns = Context_reducer.group_into_turns msgs in
+  (* All 4 messages should be in one turn because ToolResult prevents split *)
+  Alcotest.(check int) "1 turn" 1 (List.length turns);
+  Alcotest.(check int) "4 msgs in turn" 4 (List.length (List.nth turns 0))
+
+let test_group_assistant_first () =
+  let msgs = [asst_msg "orphan"; user_msg "a"; asst_msg "b"] in
+  let turns = Context_reducer.group_into_turns msgs in
+  (* First turn: [orphan], second turn: [a, b] *)
+  Alcotest.(check int) "2 turns" 2 (List.length turns)
+
+(* --- custom strategy --- *)
+
+let test_custom () =
+  let called = ref false in
+  let strategy = Context_reducer.custom (fun msgs ->
+    called := true;
+    List.rev msgs
+  ) in
+  let msgs = [user_msg "a"; asst_msg "b"] in
+  let result = Context_reducer.reduce strategy msgs in
+  Alcotest.(check bool) "custom fn called" true !called;
+  Alcotest.(check int) "same length" 2 (List.length result);
+  (* Result is reversed *)
+  (match result with
+   | { Types.role = Types.Assistant; _ } :: _ -> ()
+   | _ -> Alcotest.fail "expected reversed order")
+
+(* --- edge cases --- *)
+
+let test_empty () =
+  let result = Context_reducer.reduce (Context_reducer.keep_last 5) [] in
+  Alcotest.(check int) "empty" 0 (List.length result)
+
+let test_single_message () =
+  let msgs = [user_msg "only"] in
+  let result = Context_reducer.reduce (Context_reducer.keep_last 5) msgs in
+  Alcotest.(check int) "single" 1 (List.length result)
+
+let () =
+  Alcotest.run "Context_reducer" [
+    "keep_last_n", [
+      Alcotest.test_case "fewer turns than N" `Quick test_keep_last_n_identity;
+      Alcotest.test_case "trims oldest turns" `Quick test_keep_last_n_trims;
+      Alcotest.test_case "tool pairing: last turn only" `Quick test_keep_last_n_tool_pairing;
+      Alcotest.test_case "tool pair kept in turn" `Quick test_keep_last_n_keeps_tool_pair_in_turn;
+    ];
+    "token_budget", [
+      Alcotest.test_case "within budget" `Quick test_token_budget_within;
+      Alcotest.test_case "exceeds budget" `Quick test_token_budget_exceeds;
+      Alcotest.test_case "image/doc estimation" `Quick test_token_budget_image_doc;
+    ];
+    "estimate_tokens", [
+      Alcotest.test_case "text" `Quick test_estimate_text;
+      Alcotest.test_case "tool_use" `Quick test_estimate_tool_use;
+      Alcotest.test_case "tool_result" `Quick test_estimate_tool_result;
+      Alcotest.test_case "image" `Quick test_estimate_image;
+      Alcotest.test_case "document" `Quick test_estimate_document;
+    ];
+    "group_into_turns", [
+      Alcotest.test_case "basic grouping" `Quick test_group_basic;
+      Alcotest.test_case "tool_result stays in turn" `Quick test_group_tool_result_stays;
+      Alcotest.test_case "assistant-first" `Quick test_group_assistant_first;
+    ];
+    "custom", [
+      Alcotest.test_case "custom fn called" `Quick test_custom;
+    ];
+    "edge_cases", [
+      Alcotest.test_case "empty messages" `Quick test_empty;
+      Alcotest.test_case "single message" `Quick test_single_message;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- `Context_reducer` module with 3 strategies: `Keep_last_n`, `Token_budget`, `Custom`
- Turn-boundary grouping: ToolUse/ToolResult pairs never split (Anthropic API constraint)
- Token estimation: 4-char heuristic with conservative Image (1000) / Document (2000) estimates
- `Agent.t` gets optional `context_reducer` field
- Reducer applied as view-only: full history preserved in state, only API call uses reduced messages
- 18 new tests, 0 warnings, all existing tests pass

## Design
- Pure functions only, no IO or Eio dependency
- Turn boundary = User message without ToolResult content
- User message with ToolResult stays in previous turn (preserves ToolUse-ToolResult pairing)
- `Custom` strategy as escape hatch for precise tokenizer or custom logic

## Test plan
- [ ] `dune build @all` — 0 warnings
- [ ] `dune runtest` — all pass
- [ ] keep_last_n: identity, trim, tool pairing preserved
- [ ] token_budget: within, exceeds, large blocks
- [ ] estimate_tokens: all content_block variants
- [ ] group_into_turns: boundaries, ToolResult grouping
- [ ] Custom strategy call
- [ ] Edge cases: empty, single message

Part of v0.5.0 (Tracing + HITL + Context Reducer)