### PR TITLE
refactor(agent): consolidate config fields into options record

### DIFF
--- a/lib/agent.ml
+++ b/lib/agent.ml
@@ -3,23 +3,40 @@
 
 open Types
 
-type t = {
-  mutable state: agent_state;
-  tools: Tool.t list;
+(** Configuration options for agent behavior.
+    Core runtime resources (net, tools, context) are kept on Agent.t directly;
+    everything else lives here so new options don't bloat the Agent.create
+    signature. *)
+type options = {
   base_url: string;
   provider: Provider.config option;
-  net: [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t;
   hooks: Hooks.hooks;
-  context: Context.t;
   guardrails: Guardrails.t;
   tracer: Tracing.t;
   approval: Hooks.approval_callback option;
   context_reducer: Context_reducer.t option;
 }
 
-let create ~net ?(config=default_config) ?(tools=[]) ?(base_url=Api.default_base_url)
-    ?provider ?(hooks=Hooks.empty) ?context ?(guardrails=Guardrails.default)
-    ?(tracer=Tracing.null) ?approval ?context_reducer () =
+let default_options = {
+  base_url = Api.default_base_url;
+  provider = None;
+  hooks = Hooks.empty;
+  guardrails = Guardrails.default;
+  tracer = Tracing.null;
+  approval = None;
+  context_reducer = None;
+}
+
+type t = {
+  mutable state: agent_state;
+  tools: Tool.t list;
+  net: [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t;
+  context: Context.t;
+  options: options;
+}
+
+let create ~net ?(config=default_config) ?(tools=[]) ?context
+    ?(options=default_options) () =
   let state = {
     config;
     messages = [];
@@ -30,8 +47,7 @@ let create ~net ?(config=default_config) ?(tools=[]) ?(base_url=Api.default_base
     | Some c -> c
     | None -> Context.create ()
   in
-  { state; tools; base_url; provider; net; hooks; context = ctx; guardrails;
-    tracer; approval; context_reducer }
+  { state; tools; net; context = ctx; options }
 
 (** Helper: find and execute a tool, invoke PostToolUse hook.
     Returns (id, content, is_error) triple. *)
@@ -40,7 +56,7 @@ let find_and_execute_tool agent name input id =
   match tool_opt with
   | Some tool ->
     let result = Tool.execute ~context:agent.context tool input in
-    let _post = Hooks.invoke agent.hooks.post_tool_use
+    let _post = Hooks.invoke agent.options.hooks.post_tool_use
       (Hooks.PostToolUse { tool_name = name; input; output = result }) in
     let content, is_error = match result with
       | Ok output -> output, false
@@ -56,20 +72,20 @@ let execute_tools agent tool_uses =
   Eio.Fiber.List.map (fun block ->
     match block with
     | ToolUse (id, name, input) ->
-        Tracing.with_span agent.tracer
+        Tracing.with_span agent.options.tracer
           { kind = Tool_exec; name;
             agent_name = agent.state.config.name;
             turn = agent.state.turn_count; extra = [] }
           (fun _tracer ->
             (try
               (* PreToolUse hook *)
-              let decision = Hooks.invoke agent.hooks.pre_tool_use
+              let decision = Hooks.invoke agent.options.hooks.pre_tool_use
                 (Hooks.PreToolUse { tool_name = name; input }) in
               (match decision with
               | Hooks.Skip -> (id, "Tool execution skipped by hook", false)
               | Hooks.Override value -> (id, value, false)
               | Hooks.ApprovalRequired ->
-                (match agent.approval with
+                (match agent.options.approval with
                 | None ->
                   (* No callback registered: permissive default, execute normally *)
                   find_and_execute_tool agent name input id
@@ -88,28 +104,28 @@ let execute_tools agent tool_uses =
 (** Run a single turn with hook and guardrail support *)
 let run_turn ~sw ?clock agent =
   (* BeforeTurn hook *)
-  let _before = Hooks.invoke agent.hooks.before_turn
+  let _before = Hooks.invoke agent.options.hooks.before_turn
     (Hooks.BeforeTurn { turn = agent.state.turn_count; messages = agent.state.messages }) in
 
   (* Apply guardrails: filter tools visible to LLM *)
-  let visible_tools = Guardrails.filter_tools agent.guardrails agent.tools in
+  let visible_tools = Guardrails.filter_tools agent.options.guardrails agent.tools in
   let tool_schemas = List.map Tool.schema_to_json visible_tools in
   let tools_json = if tool_schemas = [] then None else Some tool_schemas in
 
   (* Apply context reducer: only the API call sees the windowed messages.
      The full history is preserved in agent.state.messages. *)
-  let effective_messages = match agent.context_reducer with
+  let effective_messages = match agent.options.context_reducer with
     | None -> agent.state.messages
     | Some reducer -> Context_reducer.reduce reducer agent.state.messages
   in
 
-  let api_result = Tracing.with_span agent.tracer
+  let api_result = Tracing.with_span agent.options.tracer
     { kind = Api_call; name = "create_message";
       agent_name = agent.state.config.name;
       turn = agent.state.turn_count; extra = [] }
     (fun _tracer ->
-      Api.create_message ~sw ~net:agent.net ~base_url:agent.base_url
-        ?provider:agent.provider ?clock ~config:agent.state
+      Api.create_message ~sw ~net:agent.net ~base_url:agent.options.base_url
+        ?provider:agent.options.provider ?clock ~config:agent.state
         ~messages:effective_messages ?tools:tools_json ())
   in
   match api_result with
@@ -122,7 +138,7 @@ let run_turn ~sw ?clock agent =
       in
 
       (* AfterTurn hook *)
-      let _after = Hooks.invoke agent.hooks.after_turn
+      let _after = Hooks.invoke agent.options.hooks.after_turn
         (Hooks.AfterTurn { turn = agent.state.turn_count; response }) in
 
       agent.state <- { agent.state with
@@ -137,7 +153,7 @@ let run_turn ~sw ?clock agent =
 
         (* Guardrail: check tool call count limit *)
         let count = List.length tool_uses in
-        (match Guardrails.exceeds_limit agent.guardrails count with
+        (match Guardrails.exceeds_limit agent.options.guardrails count with
         | true ->
           let msg = Printf.sprintf "Tool call limit exceeded: %d calls in one turn" count in
           agent.state <- { agent.state with
@@ -152,7 +168,7 @@ let run_turn ~sw ?clock agent =
           Ok (`ToolsExecuted))
       | EndTurn | MaxTokens | StopSequence ->
         (* OnStop hook *)
-        let _stop = Hooks.invoke agent.hooks.on_stop
+        let _stop = Hooks.invoke agent.options.hooks.on_stop
           (Hooks.OnStop { reason = response.stop_reason; response }) in
         Ok (`Complete response)
       | Unknown reason ->
@@ -289,8 +305,9 @@ let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
             | Some target ->
               (* Create sub-agent with target's config and tools *)
               let sub = create ~net:agent.net ~config:target.config
-                ~tools:target.tools ~base_url:agent.base_url
-                ?provider:agent.provider () in
+                ~tools:target.tools ~options:{ default_options with
+                  base_url = agent.options.base_url;
+                  provider = agent.options.provider } () in
                (match run ~sw ?clock sub prompt with
                | Error e ->
                  let err_msg = Printf.sprintf "Handoff to %s failed: %s" target_name e in

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -66,7 +66,11 @@ let create_agent ~net ?name ?model ?system_prompt ?max_tokens ?max_turns ?cache_
     max_turns = Option.value max_turns ~default:default_config.max_turns;
     cache_system_prompt = Option.value cache_system_prompt ~default:default_config.cache_system_prompt;
   } in
-  Agent.create ~net ~config ?provider ()
+  let options = match provider with
+    | None -> Agent.default_options
+    | Some p -> { Agent.default_options with provider = Some p }
+  in
+  Agent.create ~net ~config ~options ()
 
 (** Version info *)
 let version = "0.5.0"

--- a/test/test_agent_sdk.ml
+++ b/test/test_agent_sdk.ml
@@ -35,13 +35,15 @@ let test_extract_text () =
 
 let test_agent_create () =
   Eio_main.run @@ fun env ->
-  let agent = Agent.create ~net:env#net ~base_url:"http://test" () in
+  let options = { Agent.default_options with base_url = "http://test" } in
+  let agent = Agent.create ~net:env#net ~options () in
   Alcotest.(check int) "initial turn count" 0 agent.state.turn_count;
   Alcotest.(check int) "initial messages" 0 (List.length agent.state.messages)
 
 let test_add_message () =
   Eio_main.run @@ fun env ->
-  let agent = Agent.create ~net:env#net ~base_url:"http://test" () in
+  let options = { Agent.default_options with base_url = "http://test" } in
+  let agent = Agent.create ~net:env#net ~options () in
   agent.state <- { agent.state with messages = agent.state.messages @ [{ role = User; content = [Text "Hi"] }] };
   Alcotest.(check int) "message count" 1 (List.length agent.state.messages)
 

--- a/test/test_approval.ml
+++ b/test/test_approval.ml
@@ -15,7 +15,8 @@ let run_execute ~hooks ?approval tool_uses =
   Eio_main.run @@ fun env ->
   let net = Eio.Stdenv.net env in
   let tools = [make_echo_tool "safe"; make_echo_tool "dangerous"] in
-  let agent = Agent.create ~net ~hooks ?approval ~tools () in
+  let options = { Agent.default_options with hooks; approval } in
+  let agent = Agent.create ~net ~tools ~options () in
   Agent.execute_tools agent tool_uses
 
 (* --- Test cases --- *)

--- a/test/test_handoff.ml
+++ b/test/test_handoff.ml
@@ -130,7 +130,8 @@ let test_run_with_handoffs_intercepts_tool_use () =
         config = { default_config with name = "researcher" };
         tools = [];
       } in
-      let agent = Agent.create ~net:env#net ~base_url () in
+      let options = { Agent.default_options with base_url } in
+      let agent = Agent.create ~net:env#net ~options () in
       match Agent.run_with_handoffs ~sw agent ~targets:[target] "delegate" with
       | Ok response ->
           let text =
@@ -163,7 +164,8 @@ let test_run_with_handoffs_reports_unknown_target () =
         config = { default_config with name = "researcher" };
         tools = [];
       } in
-      let agent = Agent.create ~net:env#net ~base_url () in
+      let options = { Agent.default_options with base_url } in
+      let agent = Agent.create ~net:env#net ~options () in
       match Agent.run_with_handoffs ~sw agent ~targets:[target] "delegate_unknown" with
       | Ok response ->
           let text =

--- a/test/test_integration.ml
+++ b/test/test_integration.ml
@@ -47,7 +47,8 @@ let test_simple_conversation () =
       let server = Cohttp_eio.Server.make ~callback:mock_handler () in
       Eio.Fiber.fork ~sw (fun () -> Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
 
-      let agent = Agent.create ~net:env#net ~base_url () in
+      let options = { Agent.default_options with base_url } in
+      let agent = Agent.create ~net:env#net ~options () in
       match Agent.run ~sw agent "ping" with
       | Ok response ->
           let text = List.filter_map (function Text s -> Some s | _ -> None) response.content |> String.concat "" in
@@ -72,7 +73,8 @@ let test_tool_use () =
          let b = Yojson.Safe.Util.(input |> member "b" |> to_int) in
          Ok (string_of_int (a + b))) in
 
-      let agent = Agent.create ~net:env#net ~base_url ~tools:[calc_tool] () in
+      let options = { Agent.default_options with base_url } in
+      let agent = Agent.create ~net:env#net ~tools:[calc_tool] ~options () in
       match Agent.run ~sw agent "use_tool" with
       | Ok response ->
           let text = List.filter_map (function Text s -> Some s | _ -> None) response.content |> String.concat "" in

--- a/test/test_local_llm.ml
+++ b/test/test_local_llm.ml
@@ -21,7 +21,8 @@ let test_simple_chat () =
     max_tokens = 100;
     max_turns = 1;
   } in
-  let agent = Agent.create ~net:env#net ~config ~base_url () in
+  let options = { Agent.default_options with base_url } in
+  let agent = Agent.create ~net:env#net ~config ~options () in
   match Agent.run ~sw agent "What is 2+3? Answer with just the number." with
   | Ok response ->
     let text = List.filter_map (function Text s -> Some s | _ -> None) response.content
@@ -61,7 +62,8 @@ let test_tool_calling () =
       (* Simple eval for demo *)
       Ok (Printf.sprintf "Result of %s = 5" expr))
   in
-  let agent = Agent.create ~net:env#net ~config ~base_url ~tools:[calc_tool] () in
+  let options = { Agent.default_options with base_url } in
+  let agent = Agent.create ~net:env#net ~config ~tools:[calc_tool] ~options () in
   match Agent.run ~sw agent "What is 2+3? Use the calculator tool." with
   | Ok response ->
     let text = List.filter_map (function Text s -> Some s | _ -> None) response.content
@@ -96,7 +98,8 @@ let test_multi_tool () =
       Printf.printf "  [Tool called] read_file(%s)\n%!" path;
       Ok "hello world\nthis is a test file\n")
   in
-  let agent = Agent.create ~net:env#net ~config ~base_url ~tools:[read_file_tool] () in
+  let options = { Agent.default_options with base_url } in
+  let agent = Agent.create ~net:env#net ~config ~tools:[read_file_tool] ~options () in
   match Agent.run ~sw agent "Read the file at /tmp/test.txt and tell me what it says." with
   | Ok response ->
     let text = List.filter_map (function Text s -> Some s | _ -> None) response.content


### PR DESCRIPTION
## Summary

- `Agent.t`의 11개 필드 중 7개 설정 필드를 `options` record로 추출
- Runtime state (state, tools, net, context) vs Configuration (hooks, tracer, guardrails, approval, context_reducer, base_url, provider) 명확히 분리
- `default_options` constructor로 zero-config 생성 패턴 제공
- Open-Closed Principle: 새 옵션 추가 시 `create` signature 변경 불필요

## Changes

| File | Change |
|------|--------|
| `lib/agent.ml` | `type options` + `default_options` 추가, `create` 시그니처 변경, 16개 내부 필드 접근 업데이트 |
| `lib/agent_sdk.ml` | `create_agent` 편의 함수 options 패턴 적용 |
| `test/test_agent_sdk.ml` | options record 패턴 적용 (2곳) |
| `test/test_approval.ml` | options record 패턴 적용 |
| `test/test_handoff.ml` | options record 패턴 적용 (2곳) |
| `test/test_integration.ml` | options record 패턴 적용 (2곳) |
| `test/test_local_llm.ml` | options record 패턴 적용 (3곳) |

## Test plan

- [x] `dune build --root . @all` — 0 errors, 0 warnings
- [x] `dune runtest --root .` — 222 tests, 0 failures
- [x] All existing test suites pass without modification to test logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)