### PR TITLE
feat(checkpoint): add versioned agent state serialization

### DIFF
--- a/lib/agent.ml
+++ b/lib/agent.ml
@@ -335,3 +335,19 @@ let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
   agent_with_handoffs.state <- { agent_with_handoffs.state with
     messages = agent_with_handoffs.state.messages @ [{ role = User; content = [Text user_prompt] }] };
   loop ()
+
+(** Create a checkpoint from the current agent state. *)
+let checkpoint ?(session_id="") agent =
+  {
+    Checkpoint.version = Checkpoint.checkpoint_version;
+    session_id;
+    agent_name = agent.state.config.name;
+    model = agent.state.config.model;
+    system_prompt = agent.state.config.system_prompt;
+    messages = agent.state.messages;
+    usage = agent.state.usage;
+    turn_count = agent.state.turn_count;
+    created_at = Unix.gettimeofday ();
+    tools = List.map (fun (t : Tool.t) -> t.schema) agent.tools;
+    tool_choice = agent.state.config.tool_choice;
+  }

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -53,6 +53,7 @@ module Api = Api
 module Streaming = Streaming
 module Subagent = Subagent
 module Structured = Structured
+module Checkpoint = Checkpoint
 module Agent = Agent
 
 (** Quick start: create an agent with default config *)

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -61,6 +61,7 @@ module Types : sig
   [@@deriving show]
 
   val tool_choice_to_json : tool_choice -> Yojson.Safe.t
+  val tool_choice_of_json : Yojson.Safe.t -> (tool_choice, string) result
 
   (** Content block types *)
   type content_block =
@@ -701,6 +702,37 @@ module Structured : sig
     ('a, string) result
 end
 
+(** {1 Checkpoint} *)
+
+module Checkpoint : sig
+  (** Versioned snapshot of agent conversation state.
+      Pure serialization — no file I/O dependency. *)
+
+  type t = {
+    version: int;
+    session_id: string;
+    agent_name: string;
+    model: Types.model;
+    system_prompt: string option;
+    messages: Types.message list;
+    usage: Types.usage_stats;
+    turn_count: int;
+    created_at: float;
+    tools: Types.tool_schema list;
+    tool_choice: Types.tool_choice option;
+  }
+
+  val checkpoint_version : int
+
+  val to_json : t -> Yojson.Safe.t
+  val of_json : Yojson.Safe.t -> (t, string) result
+  val to_string : t -> string
+  val of_string : string -> (t, string) result
+
+  val message_count : t -> int
+  val token_usage : t -> Types.usage_stats
+end
+
 (** {1 Agent} *)
 
 module Agent : sig
@@ -773,6 +805,11 @@ module Agent : sig
     targets:Handoff.handoff_target list ->
     string ->
     (Types.api_response, string) result
+
+  (** Create a checkpoint from the current agent state.
+      The checkpoint captures messages, usage, tools, and config
+      for later serialization via {!Checkpoint}. *)
+  val checkpoint : ?session_id:string -> t -> Checkpoint.t
 end
 
 (** {1 Quick Start} *)

--- a/lib/checkpoint.ml
+++ b/lib/checkpoint.ml
@@ -1,0 +1,181 @@
+(** Agent state checkpoint — versioned JSON serialization.
+
+    Captures the full conversation state (messages, usage, config) so an
+    agent can be suspended and later resumed.  All functions are pure
+    (string / Yojson.Safe.t in, string / Yojson.Safe.t out); file I/O is
+    left to the caller. *)
+
+open Types
+
+let checkpoint_version = 1
+
+type t = {
+  version: int;
+  session_id: string;
+  agent_name: string;
+  model: model;
+  system_prompt: string option;
+  messages: message list;
+  usage: usage_stats;
+  turn_count: int;
+  created_at: float;
+  tools: tool_schema list;
+  tool_choice: tool_choice option;
+}
+
+(* ── Serialization helpers ──────────────────────────────────────── *)
+
+let usage_to_json u =
+  `Assoc [
+    ("total_input_tokens", `Int u.total_input_tokens);
+    ("total_output_tokens", `Int u.total_output_tokens);
+    ("total_cache_creation_input_tokens", `Int u.total_cache_creation_input_tokens);
+    ("total_cache_read_input_tokens", `Int u.total_cache_read_input_tokens);
+    ("api_calls", `Int u.api_calls);
+  ]
+
+let usage_of_json json =
+  let open Yojson.Safe.Util in
+  {
+    total_input_tokens = json |> member "total_input_tokens" |> to_int;
+    total_output_tokens = json |> member "total_output_tokens" |> to_int;
+    total_cache_creation_input_tokens =
+      json |> member "total_cache_creation_input_tokens" |> to_int_option
+      |> Option.value ~default:0;
+    total_cache_read_input_tokens =
+      json |> member "total_cache_read_input_tokens" |> to_int_option
+      |> Option.value ~default:0;
+    api_calls =
+      json |> member "api_calls" |> to_int_option
+      |> Option.value ~default:0;
+  }
+
+let tool_param_to_json (p : tool_param) =
+  `Assoc [
+    ("name", `String p.name);
+    ("description", `String p.description);
+    ("param_type", `String (param_type_to_string p.param_type));
+    ("required", `Bool p.required);
+  ]
+
+let tool_param_of_json json =
+  let open Yojson.Safe.Util in
+  let type_str = json |> member "param_type" |> to_string in
+  let param_type = match type_str with
+    | "string" -> String
+    | "integer" -> Integer
+    | "number" -> Number
+    | "boolean" -> Boolean
+    | "array" -> Array
+    | "object" -> Object
+    | _ -> String
+  in
+  {
+    name = json |> member "name" |> to_string;
+    description = json |> member "description" |> to_string;
+    param_type;
+    required = json |> member "required" |> to_bool;
+  }
+
+let tool_schema_to_json (s : tool_schema) =
+  `Assoc [
+    ("name", `String s.name);
+    ("description", `String s.description);
+    ("parameters", `List (List.map tool_param_to_json s.parameters));
+  ]
+
+let tool_schema_of_json json =
+  let open Yojson.Safe.Util in
+  {
+    name = json |> member "name" |> to_string;
+    description = json |> member "description" |> to_string;
+    parameters = json |> member "parameters" |> to_list |> List.map tool_param_of_json;
+  }
+
+let message_of_json json =
+  let open Yojson.Safe.Util in
+  let role_str = json |> member "role" |> to_string in
+  let role = match role_str with
+    | "assistant" -> Assistant
+    | _ -> User
+  in
+  let content =
+    json |> member "content" |> to_list
+    |> List.filter_map Api.content_block_of_json
+  in
+  { role; content }
+
+(* ── Public API ─────────────────────────────────────────────────── *)
+
+let to_json cp =
+  `Assoc [
+    ("version", `Int cp.version);
+    ("session_id", `String cp.session_id);
+    ("agent_name", `String cp.agent_name);
+    ("model", model_to_yojson cp.model);
+    ("system_prompt",
+      (match cp.system_prompt with Some s -> `String s | None -> `Null));
+    ("messages", `List (List.map Api.message_to_json cp.messages));
+    ("usage", usage_to_json cp.usage);
+    ("turn_count", `Int cp.turn_count);
+    ("created_at", `Float cp.created_at);
+    ("tools", `List (List.map tool_schema_to_json cp.tools));
+    ("tool_choice",
+      (match cp.tool_choice with
+       | Some tc -> tool_choice_to_json tc
+       | None -> `Null));
+  ]
+
+let of_json json =
+  try
+    let open Yojson.Safe.Util in
+    let version = json |> member "version" |> to_int in
+    if version <> checkpoint_version then
+      Error (Printf.sprintf "Unsupported checkpoint version: %d (expected %d)"
+        version checkpoint_version)
+    else
+      let tool_choice =
+        match json |> member "tool_choice" with
+        | `Null -> Ok None
+        | tc -> Result.map Option.some (tool_choice_of_json tc)
+      in
+      match tool_choice with
+      | Error e -> Error e
+      | Ok tool_choice ->
+        Ok {
+          version;
+          session_id = json |> member "session_id" |> to_string;
+          agent_name = json |> member "agent_name" |> to_string;
+          model =
+            (match model_of_yojson (json |> member "model") with
+             | Ok m -> m
+             | Error _ -> Claude_sonnet_4_6);
+          system_prompt = json |> member "system_prompt" |> to_string_option;
+          messages =
+            json |> member "messages" |> to_list |> List.map message_of_json;
+          usage = json |> member "usage" |> usage_of_json;
+          turn_count = json |> member "turn_count" |> to_int;
+          created_at = json |> member "created_at" |> to_float;
+          tools =
+            json |> member "tools" |> to_list |> List.map tool_schema_of_json;
+          tool_choice;
+        }
+  with
+  | Yojson.Safe.Util.Type_error (msg, _) ->
+    Error (Printf.sprintf "Checkpoint.of_json: %s" msg)
+  | exn ->
+    Error (Printf.sprintf "Checkpoint.of_json: %s" (Printexc.to_string exn))
+
+let to_string cp =
+  to_json cp |> Yojson.Safe.to_string
+
+let of_string s =
+  try
+    let json = Yojson.Safe.from_string s in
+    of_json json
+  with Yojson.Json_error msg ->
+    Error (Printf.sprintf "Invalid JSON: %s" msg)
+
+let message_count cp = List.length cp.messages
+
+let token_usage cp = cp.usage

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -66,6 +66,16 @@ let tool_choice_to_json = function
   | Any -> `Assoc [("type", `String "any")]
   | Tool name -> `Assoc [("type", `String "tool"); ("name", `String name)]
 
+let tool_choice_of_json json =
+  let open Yojson.Safe.Util in
+  match json |> member "type" |> to_string with
+  | "auto" -> Ok Auto
+  | "any" -> Ok Any
+  | "tool" ->
+    let name = json |> member "name" |> to_string in
+    Ok (Tool name)
+  | other -> Error (Printf.sprintf "Unknown tool_choice type: %s" other)
+
 (** Content block types - Tuple Style for safety *)
 type content_block =
   | Text of string

--- a/test/dune
+++ b/test/dune
@@ -106,3 +106,7 @@
 (test
  (name test_mcp)
  (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_checkpoint)
+ (libraries agent_sdk alcotest yojson unix))

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -1,0 +1,300 @@
+open Agent_sdk
+
+(* Helper: build a minimal checkpoint for testing *)
+let make_checkpoint
+    ?(session_id="test-session")
+    ?(agent_name="test-agent")
+    ?(model=Types.Claude_sonnet_4_6)
+    ?(system_prompt=Some "You are helpful.")
+    ?(messages=[])
+    ?(usage=Types.empty_usage)
+    ?(turn_count=0)
+    ?(tools=[])
+    ?(tool_choice=None)
+    () : Checkpoint.t =
+  {
+    version = Checkpoint.checkpoint_version;
+    session_id;
+    agent_name;
+    model;
+    system_prompt;
+    messages;
+    usage;
+    turn_count;
+    created_at = 1000.0;
+    tools;
+    tool_choice;
+  }
+
+(* Helper: a sample tool_schema *)
+let sample_tool_schema : Types.tool_schema = {
+  name = "get_weather";
+  description = "Get weather for a city";
+  parameters = [
+    { name = "city"; description = "City name";
+      param_type = Types.String; required = true };
+    { name = "units"; description = "Temperature units";
+      param_type = Types.String; required = false };
+  ];
+}
+
+let () =
+  let open Alcotest in
+  run "Checkpoint" [
+    "version", [
+      test_case "checkpoint_version is 1" `Quick (fun () ->
+        check int "version" 1 Checkpoint.checkpoint_version);
+
+      test_case "version field in to_json" `Quick (fun () ->
+        let cp = make_checkpoint () in
+        let json = Checkpoint.to_json cp in
+        let v = Yojson.Safe.Util.(json |> member "version" |> to_int) in
+        check int "version" 1 v);
+
+      test_case "wrong version returns Error" `Quick (fun () ->
+        let cp = make_checkpoint () in
+        let json = Checkpoint.to_json cp in
+        let bad = match json with
+          | `Assoc pairs ->
+            `Assoc (List.map (fun (k, v) ->
+              if k = "version" then (k, `Int 999) else (k, v)
+            ) pairs)
+          | other -> other
+        in
+        check bool "is error" true (Result.is_error (Checkpoint.of_json bad)));
+    ];
+
+    "roundtrip_basic", [
+      test_case "empty checkpoint roundtrip" `Quick (fun () ->
+        let cp = make_checkpoint () in
+        let json = Checkpoint.to_json cp in
+        let cp2 = Result.get_ok (Checkpoint.of_json json) in
+        check string "session_id" cp.session_id cp2.session_id;
+        check string "agent_name" cp.agent_name cp2.agent_name;
+        check int "turn_count" cp.turn_count cp2.turn_count);
+
+      test_case "to_string / of_string roundtrip" `Quick (fun () ->
+        let cp = make_checkpoint ~session_id:"s1" ~turn_count:5 () in
+        let s = Checkpoint.to_string cp in
+        let cp2 = Result.get_ok (Checkpoint.of_string s) in
+        check string "session_id" "s1" cp2.session_id;
+        check int "turn_count" 5 cp2.turn_count);
+
+      test_case "system_prompt None roundtrip" `Quick (fun () ->
+        let cp = make_checkpoint ~system_prompt:None () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        check (option string) "system_prompt" None cp2.system_prompt);
+
+      test_case "system_prompt Some roundtrip" `Quick (fun () ->
+        let cp = make_checkpoint ~system_prompt:(Some "Be concise.") () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        check (option string) "system_prompt" (Some "Be concise.") cp2.system_prompt);
+    ];
+
+    "messages", [
+      test_case "Text message roundtrip" `Quick (fun () ->
+        let msgs = [
+          { Types.role = Types.User; content = [Types.Text "Hello"] };
+          { Types.role = Types.Assistant; content = [Types.Text "Hi there"] };
+        ] in
+        let cp = make_checkpoint ~messages:msgs () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        check int "message count" 2 (List.length cp2.messages);
+        let first = List.hd cp2.messages in
+        check bool "user role" true (first.role = Types.User);
+        match List.hd first.content with
+        | Types.Text t -> check string "text" "Hello" t
+        | _ -> fail "expected Text");
+
+      test_case "ToolUse message roundtrip" `Quick (fun () ->
+        let msgs = [
+          { Types.role = Types.Assistant;
+            content = [Types.ToolUse ("id1", "get_weather",
+              `Assoc [("city", `String "Seoul")])] };
+        ] in
+        let cp = make_checkpoint ~messages:msgs () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        match (List.hd cp2.messages).content with
+        | [Types.ToolUse (id, name, _)] ->
+          check string "id" "id1" id;
+          check string "name" "get_weather" name
+        | _ -> fail "expected ToolUse");
+
+      test_case "ToolResult message roundtrip" `Quick (fun () ->
+        let msgs = [
+          { Types.role = Types.User;
+            content = [Types.ToolResult ("id1", "Sunny 22C", false)] };
+        ] in
+        let cp = make_checkpoint ~messages:msgs () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        match (List.hd cp2.messages).content with
+        | [Types.ToolResult (id, content, is_err)] ->
+          check string "id" "id1" id;
+          check string "content" "Sunny 22C" content;
+          check bool "is_error" false is_err
+        | _ -> fail "expected ToolResult");
+
+      test_case "empty messages roundtrip" `Quick (fun () ->
+        let cp = make_checkpoint ~messages:[] () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        check int "no messages" 0 (List.length cp2.messages));
+
+      test_case "mixed content blocks" `Quick (fun () ->
+        let msgs = [
+          { Types.role = Types.Assistant;
+            content = [
+              Types.Text "Let me check.";
+              Types.ToolUse ("t1", "search", `Assoc [("q", `String "test")]);
+            ] };
+          { Types.role = Types.User;
+            content = [Types.ToolResult ("t1", "found it", false)] };
+        ] in
+        let cp = make_checkpoint ~messages:msgs () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        check int "2 messages" 2 (List.length cp2.messages);
+        let first = List.hd cp2.messages in
+        check int "2 blocks in first" 2 (List.length first.content));
+    ];
+
+    "usage", [
+      test_case "usage roundtrip" `Quick (fun () ->
+        let u : Types.usage_stats = {
+          total_input_tokens = 1000;
+          total_output_tokens = 500;
+          total_cache_creation_input_tokens = 200;
+          total_cache_read_input_tokens = 100;
+          api_calls = 3;
+        } in
+        let cp = make_checkpoint ~usage:u () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        check int "input" 1000 cp2.usage.total_input_tokens;
+        check int "output" 500 cp2.usage.total_output_tokens;
+        check int "cache_create" 200 cp2.usage.total_cache_creation_input_tokens;
+        check int "cache_read" 100 cp2.usage.total_cache_read_input_tokens;
+        check int "api_calls" 3 cp2.usage.api_calls);
+
+      test_case "empty usage roundtrip" `Quick (fun () ->
+        let cp = make_checkpoint ~usage:Types.empty_usage () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        check int "input" 0 cp2.usage.total_input_tokens;
+        check int "api_calls" 0 cp2.usage.api_calls);
+    ];
+
+    "tools", [
+      test_case "tool_schema roundtrip" `Quick (fun () ->
+        let cp = make_checkpoint ~tools:[sample_tool_schema] () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        check int "1 tool" 1 (List.length cp2.tools);
+        let t = List.hd cp2.tools in
+        check string "name" "get_weather" t.name;
+        check string "desc" "Get weather for a city" t.description;
+        check int "2 params" 2 (List.length t.parameters);
+        let p1 = List.hd t.parameters in
+        check string "param name" "city" p1.name;
+        check bool "required" true p1.required);
+
+      test_case "empty tools roundtrip" `Quick (fun () ->
+        let cp = make_checkpoint ~tools:[] () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        check int "no tools" 0 (List.length cp2.tools));
+
+      test_case "param_type variants" `Quick (fun () ->
+        let params = List.map (fun (n, pt) ->
+          { Types.name = n; description = n;
+            param_type = pt; required = true }
+        ) [
+          ("s", Types.String); ("i", Types.Integer);
+          ("n", Types.Number); ("b", Types.Boolean);
+          ("a", Types.Array); ("o", Types.Object);
+        ] in
+        let tool : Types.tool_schema = {
+          name = "multi"; description = "test"; parameters = params } in
+        let cp = make_checkpoint ~tools:[tool] () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        let t = List.hd cp2.tools in
+        check int "6 params" 6 (List.length t.parameters));
+    ];
+
+    "tool_choice", [
+      test_case "Auto roundtrip" `Quick (fun () ->
+        let cp = make_checkpoint ~tool_choice:(Some Types.Auto) () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        check bool "auto" true (cp2.tool_choice = Some Types.Auto));
+
+      test_case "Any roundtrip" `Quick (fun () ->
+        let cp = make_checkpoint ~tool_choice:(Some Types.Any) () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        check bool "any" true (cp2.tool_choice = Some Types.Any));
+
+      test_case "Tool name roundtrip" `Quick (fun () ->
+        let cp = make_checkpoint ~tool_choice:(Some (Types.Tool "search")) () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        check bool "tool" true (cp2.tool_choice = Some (Types.Tool "search")));
+
+      test_case "None roundtrip" `Quick (fun () ->
+        let cp = make_checkpoint ~tool_choice:None () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        check bool "none" true (cp2.tool_choice = None));
+    ];
+
+    "model", [
+      test_case "Opus model roundtrip" `Quick (fun () ->
+        let cp = make_checkpoint ~model:Types.Claude_opus_4_6 () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        check bool "model" true (cp2.model = Types.Claude_opus_4_6));
+
+      test_case "Custom model roundtrip" `Quick (fun () ->
+        let cp = make_checkpoint ~model:(Types.Custom "my-model-v1") () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        check bool "custom" true (cp2.model = Types.Custom "my-model-v1"));
+    ];
+
+    "helpers", [
+      test_case "message_count" `Quick (fun () ->
+        let msgs = [
+          { Types.role = Types.User; content = [Types.Text "a"] };
+          { Types.role = Types.Assistant; content = [Types.Text "b"] };
+          { Types.role = Types.User; content = [Types.Text "c"] };
+        ] in
+        let cp = make_checkpoint ~messages:msgs () in
+        check int "count" 3 (Checkpoint.message_count cp));
+
+      test_case "token_usage returns usage" `Quick (fun () ->
+        let u : Types.usage_stats = {
+          total_input_tokens = 42;
+          total_output_tokens = 10;
+          total_cache_creation_input_tokens = 0;
+          total_cache_read_input_tokens = 0;
+          api_calls = 1;
+        } in
+        let cp = make_checkpoint ~usage:u () in
+        let result = Checkpoint.token_usage cp in
+        check int "input" 42 result.total_input_tokens);
+    ];
+
+    "error_cases", [
+      test_case "malformed JSON string" `Quick (fun () ->
+        check bool "error" true
+          (Result.is_error (Checkpoint.of_string "not json at all")));
+
+      test_case "missing required field" `Quick (fun () ->
+        let bad = `Assoc [("version", `Int 1)] in
+        check bool "error" true (Result.is_error (Checkpoint.of_json bad)));
+
+      test_case "wrong type for field" `Quick (fun () ->
+        let cp = make_checkpoint () in
+        let json = Checkpoint.to_json cp in
+        let bad = match json with
+          | `Assoc pairs ->
+            `Assoc (List.map (fun (k, v) ->
+              if k = "turn_count" then (k, `String "not_int") else (k, v)
+            ) pairs)
+          | other -> other
+        in
+        check bool "error" true (Result.is_error (Checkpoint.of_json bad)));
+
+      test_case "empty JSON object" `Quick (fun () ->
+        check bool "error" true
+          (Result.is_error (Checkpoint.of_json (`Assoc []))));
+    ];
+  ]


### PR DESCRIPTION
## Summary
- Add `Checkpoint` module for serializing agent state (messages, usage, tools, config) to versioned JSON
- Add `Agent.checkpoint` function to snapshot current agent state
- Add `Types.tool_choice_of_json` to close the deserialization gap for round-trip support
- 29 new tests covering all content_block variants, error paths, and helper functions

## Design decisions
- **Pure functions**: `to_string`/`of_string` with no file I/O — caller controls persistence
- **Version field**: `checkpoint_version = 1` enables future schema migration
- **Api.ml reuse**: Uses existing `content_block_to_json/of_json` and `message_to_json` to keep serialization DRY

## Test plan
- [x] `dune build @all` — zero warnings
- [x] `dune runtest` — 293 tests pass (29 new checkpoint tests)
- [ ] Cross-model review (GLM-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)