### PR TITLE
feat(builder): add Builder pattern for fluent agent configuration

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -56,6 +56,7 @@ module Structured = Structured
 module Checkpoint = Checkpoint
 module Session = Session
 module Agent = Agent
+module Builder = Builder
 
 (** Quick start: create an agent with default config *)
 let create_agent ~net ?name ?model ?system_prompt ?max_tokens ?max_turns ?cache_system_prompt ?provider () =

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -929,6 +929,40 @@ module Agent : sig
   val checkpoint : ?session_id:string -> t -> Checkpoint.t
 end
 
+(** {1 Builder Pattern} *)
+
+module Builder : sig
+  (** Flat, chainable API for agent creation.
+      Alternative to the nested [Agent.create ~config ~options] pattern. *)
+
+  type t
+
+  val create : net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t -> model:Types.model -> t
+  val with_system_prompt : string -> t -> t
+  val with_name : string -> t -> t
+  val with_max_tokens : int -> t -> t
+  val with_max_turns : int -> t -> t
+  val with_temperature : float -> t -> t
+  val with_tools : Tool.t list -> t -> t
+  val with_tool : Tool.t -> t -> t
+  val with_hooks : Hooks.hooks -> t -> t
+  val with_tracer : Tracing.t -> t -> t
+  val with_approval : Hooks.approval_callback -> t -> t
+  val with_context_reducer : Context_reducer.t -> t -> t
+  val with_context : Context.t -> t -> t
+  val with_provider : Provider.config -> t -> t
+  val with_base_url : string -> t -> t
+  val with_mcp_clients : Mcp.managed list -> t -> t
+  val with_guardrails : Guardrails.t -> t -> t
+  val with_tool_choice : Types.tool_choice -> t -> t
+  val with_thinking_budget : int -> t -> t
+  val with_max_input_tokens : int -> t -> t
+  val with_max_total_tokens : int -> t -> t
+  val with_response_format_json : bool -> t -> t
+  val with_cache_system_prompt : bool -> t -> t
+  val build : t -> Agent.t
+end
+
 (** {1 Quick Start} *)
 
 (** Create an agent with default config and optional overrides *)

--- a/lib/builder.ml
+++ b/lib/builder.ml
@@ -1,0 +1,106 @@
+(** Builder pattern for Agent creation.
+    Provides a flat, chainable API as an alternative to nested Agent.create params. *)
+
+open Types
+
+type t = {
+  net: [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t;
+  model: model;
+  name: string;
+  system_prompt: string option;
+  max_tokens: int;
+  max_turns: int;
+  temperature: float option;
+  response_format_json: bool;
+  thinking_budget: int option;
+  tool_choice: tool_choice option;
+  cache_system_prompt: bool;
+  max_input_tokens: int option;
+  max_total_tokens: int option;
+  tools: Tool.t list;
+  context: Context.t option;
+  base_url: string;
+  provider: Provider.config option;
+  hooks: Hooks.hooks;
+  guardrails: Guardrails.t;
+  tracer: Tracing.t;
+  approval: Hooks.approval_callback option;
+  context_reducer: Context_reducer.t option;
+  mcp_clients: Mcp.managed list;
+}
+
+let create ~net ~model =
+  {
+    net; model;
+    name = default_config.name;
+    system_prompt = default_config.system_prompt;
+    max_tokens = default_config.max_tokens;
+    max_turns = default_config.max_turns;
+    temperature = default_config.temperature;
+    response_format_json = default_config.response_format_json;
+    thinking_budget = default_config.thinking_budget;
+    tool_choice = default_config.tool_choice;
+    cache_system_prompt = default_config.cache_system_prompt;
+    max_input_tokens = default_config.max_input_tokens;
+    max_total_tokens = default_config.max_total_tokens;
+    tools = [];
+    context = None;
+    base_url = Api.default_base_url;
+    provider = None;
+    hooks = Hooks.empty;
+    guardrails = Guardrails.default;
+    tracer = Tracing.null;
+    approval = None;
+    context_reducer = None;
+    mcp_clients = [];
+  }
+
+let with_system_prompt prompt b = { b with system_prompt = Some prompt }
+let with_name name b = { b with name }
+let with_max_tokens n b = { b with max_tokens = n }
+let with_max_turns n b = { b with max_turns = n }
+let with_temperature t b = { b with temperature = Some t }
+let with_tools tools b = { b with tools }
+let with_tool tool b = { b with tools = b.tools @ [tool] }
+let with_hooks hooks b = { b with hooks }
+let with_tracer tracer b = { b with tracer }
+let with_approval approval b = { b with approval = Some approval }
+let with_context_reducer reducer b = { b with context_reducer = Some reducer }
+let with_context ctx b = { b with context = Some ctx }
+let with_provider provider b = { b with provider = Some provider }
+let with_base_url url b = { b with base_url = url }
+let with_mcp_clients clients b = { b with mcp_clients = clients }
+let with_guardrails guardrails b = { b with guardrails }
+let with_tool_choice tc b = { b with tool_choice = Some tc }
+let with_thinking_budget n b = { b with thinking_budget = Some n }
+let with_max_input_tokens n b = { b with max_input_tokens = Some n }
+let with_max_total_tokens n b = { b with max_total_tokens = Some n }
+let with_response_format_json v b = { b with response_format_json = v }
+let with_cache_system_prompt v b = { b with cache_system_prompt = v }
+
+let build b =
+  let config = {
+    name = b.name;
+    model = b.model;
+    system_prompt = b.system_prompt;
+    max_tokens = b.max_tokens;
+    max_turns = b.max_turns;
+    temperature = b.temperature;
+    response_format_json = b.response_format_json;
+    thinking_budget = b.thinking_budget;
+    tool_choice = b.tool_choice;
+    cache_system_prompt = b.cache_system_prompt;
+    max_input_tokens = b.max_input_tokens;
+    max_total_tokens = b.max_total_tokens;
+  } in
+  let options = {
+    Agent.base_url = b.base_url;
+    provider = b.provider;
+    hooks = b.hooks;
+    guardrails = b.guardrails;
+    tracer = b.tracer;
+    approval = b.approval;
+    context_reducer = b.context_reducer;
+    mcp_clients = b.mcp_clients;
+  } in
+  Agent.create ~net:b.net ~config ~tools:b.tools ?context:b.context ~options ()

--- a/test/dune
+++ b/test/dune
@@ -122,3 +122,7 @@
 (test
  (name test_mcp_bridge)
  (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_builder)
+ (libraries agent_sdk alcotest eio eio_main yojson))

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -1,0 +1,460 @@
+(** Tests for Builder module — chainable agent construction API. *)
+
+open Agent_sdk
+
+(** Run a function inside Eio with network access. *)
+let with_net f =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  f net
+
+(** Helper: create a simple echo tool. *)
+let make_tool name =
+  Tool.create ~name ~description:("tool:" ^ name) ~parameters:[] (fun input ->
+    Ok (Yojson.Safe.to_string input))
+
+(** Helper: compare model fields via string. *)
+let check_model msg expected actual =
+  Alcotest.(check string) msg
+    (Types.model_to_string expected)
+    (Types.model_to_string actual)
+
+(* --- 1. create sets model --- *)
+
+let test_create_sets_model () =
+  with_net @@ fun net ->
+  let agent = Builder.create ~net ~model:Types.Claude_haiku_4_5 |> Builder.build in
+  check_model "model" Types.Claude_haiku_4_5 agent.state.config.model
+
+(* --- 2. with_system_prompt --- *)
+
+let test_with_system_prompt () =
+  with_net @@ fun net ->
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_system_prompt "You are helpful."
+    |> Builder.build
+  in
+  Alcotest.(check (option string)) "system_prompt"
+    (Some "You are helpful.") agent.state.config.system_prompt
+
+(* --- 3. with_name --- *)
+
+let test_with_name () =
+  with_net @@ fun net ->
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_name "test-agent"
+    |> Builder.build
+  in
+  Alcotest.(check string) "name" "test-agent" agent.state.config.name
+
+(* --- 4. with_max_tokens --- *)
+
+let test_with_max_tokens () =
+  with_net @@ fun net ->
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_max_tokens 8192
+    |> Builder.build
+  in
+  Alcotest.(check int) "max_tokens" 8192 agent.state.config.max_tokens
+
+(* --- 5. with_max_turns --- *)
+
+let test_with_max_turns () =
+  with_net @@ fun net ->
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_max_turns 25
+    |> Builder.build
+  in
+  Alcotest.(check int) "max_turns" 25 agent.state.config.max_turns
+
+(* --- 6. with_temperature --- *)
+
+let test_with_temperature () =
+  with_net @@ fun net ->
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_temperature 0.7
+    |> Builder.build
+  in
+  Alcotest.(check (option (float 0.001))) "temperature"
+    (Some 0.7) agent.state.config.temperature
+
+(* --- 7. with_tools replaces --- *)
+
+let test_with_tools_replaces () =
+  with_net @@ fun net ->
+  let t1 = make_tool "a" in
+  let t2 = make_tool "b" in
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_tool t1
+    |> Builder.with_tools [t2]
+    |> Builder.build
+  in
+  Alcotest.(check int) "tool count" 1 (List.length agent.tools);
+  Alcotest.(check string) "tool name" "b"
+    (List.hd agent.tools).schema.name
+
+(* --- 8. with_tool appends --- *)
+
+let test_with_tool_appends () =
+  with_net @@ fun net ->
+  let t1 = make_tool "first" in
+  let t2 = make_tool "second" in
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_tool t1
+    |> Builder.with_tool t2
+    |> Builder.build
+  in
+  Alcotest.(check int) "tool count" 2 (List.length agent.tools);
+  Alcotest.(check string) "first tool" "first"
+    (List.nth agent.tools 0).schema.name;
+  Alcotest.(check string) "second tool" "second"
+    (List.nth agent.tools 1).schema.name
+
+(* --- 9. with_hooks --- *)
+
+let test_with_hooks () =
+  with_net @@ fun net ->
+  let hook _event = Hooks.Skip in
+  let hooks = { Hooks.empty with before_turn = Some hook } in
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_hooks hooks
+    |> Builder.build
+  in
+  Alcotest.(check bool) "before_turn set" true
+    (Option.is_some agent.options.hooks.before_turn)
+
+(* --- 10. with_tracer --- *)
+
+let test_with_tracer () =
+  with_net @@ fun net ->
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_tracer Tracing.fmt
+    |> Builder.build
+  in
+  Alcotest.(check bool) "tracer not null" true
+    (agent.options.tracer != Tracing.null)
+
+(* --- 11. with_approval --- *)
+
+let test_with_approval () =
+  with_net @@ fun net ->
+  let approval ~tool_name:_ ~input:_ = Hooks.Approve in
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_approval approval
+    |> Builder.build
+  in
+  Alcotest.(check bool) "approval set" true
+    (Option.is_some agent.options.approval)
+
+(* --- 12. with_context_reducer --- *)
+
+let test_with_context_reducer () =
+  with_net @@ fun net ->
+  let reducer = Context_reducer.keep_last 5 in
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_context_reducer reducer
+    |> Builder.build
+  in
+  Alcotest.(check bool) "context_reducer set" true
+    (Option.is_some agent.options.context_reducer)
+
+(* --- 13. with_context --- *)
+
+let test_with_context () =
+  with_net @@ fun net ->
+  let ctx = Context.create () in
+  Context.set ctx "key" (`String "value");
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_context ctx
+    |> Builder.build
+  in
+  Alcotest.(check (option string)) "context key"
+    (Some "value")
+    (match Context.get agent.context "key" with
+     | Some (`String s) -> Some s
+     | _ -> None)
+
+(* --- 14. with_provider --- *)
+
+let test_with_provider () =
+  with_net @@ fun net ->
+  let provider = Provider.anthropic_haiku () in
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_provider provider
+    |> Builder.build
+  in
+  Alcotest.(check bool) "provider set" true
+    (Option.is_some agent.options.provider)
+
+(* --- 15. with_base_url --- *)
+
+let test_with_base_url () =
+  with_net @@ fun net ->
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_base_url "http://localhost:8080"
+    |> Builder.build
+  in
+  Alcotest.(check string) "base_url"
+    "http://localhost:8080" agent.options.base_url
+
+(* --- 16. with_mcp_clients --- *)
+
+let test_with_mcp_clients () =
+  with_net @@ fun net ->
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_mcp_clients []
+    |> Builder.build
+  in
+  Alcotest.(check int) "mcp_clients" 0
+    (List.length agent.options.mcp_clients)
+
+(* --- 17. with_guardrails --- *)
+
+let test_with_guardrails () =
+  with_net @@ fun net ->
+  let guardrails : Guardrails.t =
+    { tool_filter = Guardrails.AllowList ["safe"];
+      max_tool_calls_per_turn = Some 3 } in
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_guardrails guardrails
+    |> Builder.build
+  in
+  Alcotest.(check bool) "max_tool_calls set" true
+    (agent.options.guardrails.max_tool_calls_per_turn = Some 3)
+
+(* --- 18. with_tool_choice --- *)
+
+let test_with_tool_choice () =
+  with_net @@ fun net ->
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_tool_choice Types.Any
+    |> Builder.build
+  in
+  let expected = Types.tool_choice_to_json Types.Any in
+  let actual = match agent.state.config.tool_choice with
+    | Some tc -> Types.tool_choice_to_json tc
+    | None -> `Null
+  in
+  Alcotest.(check string) "tool_choice Any"
+    (Yojson.Safe.to_string expected)
+    (Yojson.Safe.to_string actual)
+
+(* --- 19. with_thinking_budget --- *)
+
+let test_with_thinking_budget () =
+  with_net @@ fun net ->
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_thinking_budget 10000
+    |> Builder.build
+  in
+  Alcotest.(check (option int)) "thinking_budget"
+    (Some 10000) agent.state.config.thinking_budget
+
+(* --- 20. with_max_input_tokens --- *)
+
+let test_with_max_input_tokens () =
+  with_net @@ fun net ->
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_max_input_tokens 50000
+    |> Builder.build
+  in
+  Alcotest.(check (option int)) "max_input_tokens"
+    (Some 50000) agent.state.config.max_input_tokens
+
+(* --- 21. with_max_total_tokens --- *)
+
+let test_with_max_total_tokens () =
+  with_net @@ fun net ->
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_max_total_tokens 100000
+    |> Builder.build
+  in
+  Alcotest.(check (option int)) "max_total_tokens"
+    (Some 100000) agent.state.config.max_total_tokens
+
+(* --- 22. build produces valid agent --- *)
+
+let test_build_produces_valid_agent () =
+  with_net @@ fun net ->
+  let agent =
+    Builder.create ~net ~model:Types.Claude_opus_4_5
+    |> Builder.with_name "full-agent"
+    |> Builder.with_system_prompt "Be concise."
+    |> Builder.with_max_tokens 2048
+    |> Builder.with_max_turns 5
+    |> Builder.with_temperature 0.3
+    |> Builder.build
+  in
+  let cfg = agent.state.config in
+  Alcotest.(check string) "name" "full-agent" cfg.name;
+  check_model "model" Types.Claude_opus_4_5 cfg.model;
+  Alcotest.(check (option string)) "system_prompt"
+    (Some "Be concise.") cfg.system_prompt;
+  Alcotest.(check int) "max_tokens" 2048 cfg.max_tokens;
+  Alcotest.(check int) "max_turns" 5 cfg.max_turns;
+  Alcotest.(check (option (float 0.001))) "temperature"
+    (Some 0.3) cfg.temperature;
+  Alcotest.(check int) "messages empty" 0
+    (List.length agent.state.messages);
+  Alcotest.(check int) "turn_count zero" 0 agent.state.turn_count;
+  Alcotest.(check int) "api_calls zero" 0 agent.state.usage.api_calls
+
+(* --- 23. chain multiple --- *)
+
+let test_chain_multiple () =
+  with_net @@ fun net ->
+  let t1 = make_tool "t1" in
+  let t2 = make_tool "t2" in
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4
+    |> Builder.with_name "chained"
+    |> Builder.with_system_prompt "system"
+    |> Builder.with_max_tokens 1024
+    |> Builder.with_max_turns 3
+    |> Builder.with_temperature 0.5
+    |> Builder.with_tool t1
+    |> Builder.with_tool t2
+    |> Builder.with_base_url "http://test:9090"
+    |> Builder.with_thinking_budget 5000
+    |> Builder.build
+  in
+  Alcotest.(check string) "name" "chained" agent.state.config.name;
+  Alcotest.(check int) "max_tokens" 1024 agent.state.config.max_tokens;
+  Alcotest.(check int) "max_turns" 3 agent.state.config.max_turns;
+  Alcotest.(check int) "tool count" 2 (List.length agent.tools);
+  Alcotest.(check string) "base_url" "http://test:9090" agent.options.base_url;
+  Alcotest.(check (option int)) "thinking_budget"
+    (Some 5000) agent.state.config.thinking_budget
+
+(* --- 24. immutability check --- *)
+
+let test_immutability_check () =
+  with_net @@ fun net ->
+  let original = Builder.create ~net ~model:Types.Claude_sonnet_4_6 in
+  let _modified = original |> Builder.with_name "modified" in
+  let agent_from_original = Builder.build original in
+  Alcotest.(check string) "original name unchanged"
+    "agent" agent_from_original.state.config.name
+
+(* --- 25. defaults match Agent.create defaults --- *)
+
+let test_defaults_match_agent_create () =
+  with_net @@ fun net ->
+  let builder_agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6 |> Builder.build in
+  let direct_agent = Agent.create ~net () in
+  let bc = builder_agent.state.config in
+  let dc = direct_agent.state.config in
+  Alcotest.(check string) "name" dc.name bc.name;
+  check_model "model" dc.model bc.model;
+  Alcotest.(check (option string)) "system_prompt"
+    dc.system_prompt bc.system_prompt;
+  Alcotest.(check int) "max_tokens" dc.max_tokens bc.max_tokens;
+  Alcotest.(check int) "max_turns" dc.max_turns bc.max_turns;
+  Alcotest.(check (option (float 0.001))) "temperature"
+    dc.temperature bc.temperature;
+  Alcotest.(check bool) "response_format_json"
+    dc.response_format_json bc.response_format_json;
+  Alcotest.(check (option int)) "thinking_budget"
+    dc.thinking_budget bc.thinking_budget;
+  Alcotest.(check bool) "cache_system_prompt"
+    dc.cache_system_prompt bc.cache_system_prompt;
+  Alcotest.(check (option int)) "max_input_tokens"
+    dc.max_input_tokens bc.max_input_tokens;
+  Alcotest.(check (option int)) "max_total_tokens"
+    dc.max_total_tokens bc.max_total_tokens;
+  Alcotest.(check string) "base_url"
+    direct_agent.options.base_url builder_agent.options.base_url;
+  Alcotest.(check bool) "provider none"
+    (Option.is_none direct_agent.options.provider)
+    (Option.is_none builder_agent.options.provider);
+  Alcotest.(check int) "tools" 0 (List.length builder_agent.tools)
+
+(* --- 26. build with tools merges mcp --- *)
+
+let test_build_with_tools_merges_mcp () =
+  with_net @@ fun net ->
+  let t1 = make_tool "explicit" in
+  let agent =
+    Builder.create ~net ~model:Types.Claude_sonnet_4_6
+    |> Builder.with_tool t1
+    |> Builder.with_mcp_clients []
+    |> Builder.build
+  in
+  Alcotest.(check int) "tool count with empty mcp" 1
+    (List.length agent.tools);
+  Alcotest.(check string) "tool name" "explicit"
+    (List.hd agent.tools).schema.name
+
+(* --- 27. build minimal: only net+model, rest defaults --- *)
+
+let test_build_minimal_required_only () =
+  with_net @@ fun net ->
+  let agent =
+    Builder.create ~net ~model:Types.Claude_3_7_sonnet |> Builder.build in
+  check_model "model" Types.Claude_3_7_sonnet agent.state.config.model;
+  Alcotest.(check string) "name" "agent" agent.state.config.name;
+  Alcotest.(check int) "max_tokens" 4096 agent.state.config.max_tokens;
+  Alcotest.(check int) "max_turns" 10 agent.state.config.max_turns;
+  Alcotest.(check int) "tools" 0 (List.length agent.tools);
+  Alcotest.(check string) "base_url"
+    "https://api.anthropic.com" agent.options.base_url
+
+(* --- Run all --- *)
+
+let () =
+  Alcotest.run "Builder" [
+    "create", [
+      Alcotest.test_case "sets model" `Quick test_create_sets_model;
+    ];
+    "with_setters", [
+      Alcotest.test_case "system_prompt" `Quick test_with_system_prompt;
+      Alcotest.test_case "name" `Quick test_with_name;
+      Alcotest.test_case "max_tokens" `Quick test_with_max_tokens;
+      Alcotest.test_case "max_turns" `Quick test_with_max_turns;
+      Alcotest.test_case "temperature" `Quick test_with_temperature;
+      Alcotest.test_case "tools replaces" `Quick test_with_tools_replaces;
+      Alcotest.test_case "tool appends" `Quick test_with_tool_appends;
+      Alcotest.test_case "hooks" `Quick test_with_hooks;
+      Alcotest.test_case "tracer" `Quick test_with_tracer;
+      Alcotest.test_case "approval" `Quick test_with_approval;
+      Alcotest.test_case "context_reducer" `Quick test_with_context_reducer;
+      Alcotest.test_case "context" `Quick test_with_context;
+      Alcotest.test_case "provider" `Quick test_with_provider;
+      Alcotest.test_case "base_url" `Quick test_with_base_url;
+      Alcotest.test_case "mcp_clients" `Quick test_with_mcp_clients;
+      Alcotest.test_case "guardrails" `Quick test_with_guardrails;
+      Alcotest.test_case "tool_choice" `Quick test_with_tool_choice;
+      Alcotest.test_case "thinking_budget" `Quick test_with_thinking_budget;
+      Alcotest.test_case "max_input_tokens" `Quick test_with_max_input_tokens;
+      Alcotest.test_case "max_total_tokens" `Quick test_with_max_total_tokens;
+    ];
+    "build", [
+      Alcotest.test_case "valid agent" `Quick test_build_produces_valid_agent;
+      Alcotest.test_case "chain multiple" `Quick test_chain_multiple;
+      Alcotest.test_case "immutability" `Quick test_immutability_check;
+      Alcotest.test_case "defaults match Agent.create" `Quick test_defaults_match_agent_create;
+      Alcotest.test_case "tools merges mcp" `Quick test_build_with_tools_merges_mcp;
+      Alcotest.test_case "minimal required only" `Quick test_build_minimal_required_only;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- Flat chainable API surface (`Builder.create ~net ~model |> with_system_prompt "..." |> with_tools [...] |> build`)
- 22 `with_*` setters unifying `agent_config` + `options` into a single immutable record
- `Builder.build` calls `Agent.create` internally — backward compatible, alternative API surface

## Changes
- **New**: `lib/builder.ml` (~150 LOC)
- **Modified**: `lib/agent_sdk.ml`, `lib/agent_sdk.mli`
- **New**: `test/test_builder.ml` (27 tests)

## Test plan
- [x] `dune build --root . @all` — no warnings
- [x] `dune runtest --root . --force` — 27 new tests pass
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)