### PR TITLE
feat(checkpoint-store): add file-backed checkpoint persistence

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -54,6 +54,7 @@ module Streaming = Streaming
 module Subagent = Subagent
 module Structured = Structured
 module Checkpoint = Checkpoint
+module Checkpoint_store = Checkpoint_store
 module Session = Session
 module Agent = Agent
 module Builder = Builder

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -803,6 +803,24 @@ module Checkpoint : sig
   val token_usage : t -> Types.usage_stats
 end
 
+(** {1 File-backed Checkpoint Store} *)
+
+module Checkpoint_store : sig
+  (** File-backed checkpoint persistence.
+      Layout: [<base_dir>/<session_id>.json].
+      Uses atomic writes (.tmp + rename). *)
+
+  type t
+
+  val create : Eio.Fs.dir_ty Eio.Path.t -> t
+  val save : t -> Checkpoint.t -> (unit, string) result
+  val load : t -> string -> (Checkpoint.t, string) result
+  val latest : t -> (Checkpoint.t, string) result
+  val list : t -> string list
+  val delete : t -> string -> (unit, string) result
+  val exists : t -> string -> bool
+end
+
 (** {1 Session Management} *)
 
 module Session : sig

--- a/lib/checkpoint_store.ml
+++ b/lib/checkpoint_store.ml
@@ -1,0 +1,104 @@
+(** File-backed checkpoint persistence using Eio.Path.
+
+    Layout: [<base_dir>/<session_id>.json].
+    Atomic writes via .tmp + rename. *)
+
+type t = { base_dir: Eio.Fs.dir_ty Eio.Path.t }
+
+(** Validate session_id: reject empty, containing '/', containing '\000'. *)
+let validate_session_id id =
+  if String.length id = 0 then Error "session_id must not be empty"
+  else if String.contains id '/' then Error "session_id must not contain '/'"
+  else if String.contains id '\000' then
+    Error "session_id must not contain null byte"
+  else Ok ()
+
+let create base_dir =
+  (try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 base_dir with _ -> ());
+  { base_dir }
+
+let file_path store id = Eio.Path.(store.base_dir / (id ^ ".json"))
+let tmp_path store id = Eio.Path.(store.base_dir / (id ^ ".json.tmp"))
+
+let save store (cp : Checkpoint.t) =
+  match validate_session_id cp.session_id with
+  | Error e -> Error e
+  | Ok () ->
+    let data = Checkpoint.to_string cp in
+    let tmp = tmp_path store cp.session_id in
+    let target = file_path store cp.session_id in
+    (try
+       Eio.Path.save ~create:(`Or_truncate 0o644) tmp data;
+       Eio.Path.rename tmp target;
+       Ok ()
+     with exn ->
+       (try Eio.Path.unlink tmp with _ -> ());
+       Error
+         (Printf.sprintf "Failed to save checkpoint: %s"
+            (Printexc.to_string exn)))
+
+let load store id =
+  match validate_session_id id with
+  | Error e -> Error e
+  | Ok () ->
+    let path = file_path store id in
+    (try
+       let data = Eio.Path.load path in
+       Checkpoint.of_string data
+     with exn ->
+       Error
+         (Printf.sprintf "Failed to load checkpoint: %s"
+            (Printexc.to_string exn)))
+
+let list store =
+  try
+    let entries = Eio.Path.read_dir store.base_dir in
+    entries
+    |> List.filter (fun name ->
+           let len = String.length name in
+           len > 5
+           && String.sub name (len - 5) 5 = ".json"
+           && not (len > 9 && String.sub name (len - 9) 9 = ".json.tmp"))
+    |> List.map (fun name -> String.sub name 0 (String.length name - 5))
+    |> List.sort String.compare
+  with _ -> []
+
+let delete store id =
+  match validate_session_id id with
+  | Error e -> Error e
+  | Ok () ->
+    let path = file_path store id in
+    (try
+       Eio.Path.unlink path;
+       Ok ()
+     with exn ->
+       Error
+         (Printf.sprintf "Failed to delete checkpoint: %s"
+            (Printexc.to_string exn)))
+
+let exists store id =
+  match validate_session_id id with
+  | Error _ -> false
+  | Ok () ->
+    let path = file_path store id in
+    Eio.Path.is_file path
+
+let latest store =
+  let ids = list store in
+  if ids = [] then Error "No checkpoints found"
+  else
+    let best =
+      List.fold_left
+        (fun acc id ->
+          match load store id with
+          | Error _ -> acc
+          | Ok cp -> (
+            match acc with
+            | None -> Some cp
+            | Some prev ->
+              if cp.created_at > prev.created_at then Some cp else Some prev))
+        None ids
+    in
+    match best with
+    | Some cp -> Ok cp
+    | None -> Error "All checkpoints corrupted"

--- a/test/dune
+++ b/test/dune
@@ -126,3 +126,7 @@
 (test
  (name test_builder)
  (libraries agent_sdk alcotest eio eio_main yojson))
+
+(test
+ (name test_checkpoint_store)
+ (libraries agent_sdk alcotest eio eio_main yojson unix))

--- a/test/test_checkpoint_store.ml
+++ b/test/test_checkpoint_store.ml
@@ -1,0 +1,524 @@
+open Agent_sdk
+
+(* ── Helpers ─────────────────────────────────────────────────────── *)
+
+let make_checkpoint ?(session_id = "test-session") ?(created_at = 1000.0) () :
+    Checkpoint.t =
+  {
+    version = Checkpoint.checkpoint_version;
+    session_id;
+    agent_name = "test-agent";
+    model = Types.Claude_sonnet_4_6;
+    system_prompt = Some "test prompt";
+    messages = [ { role = User; content = [ Text "hello" ] } ];
+    usage = Types.empty_usage;
+    turn_count = 1;
+    created_at;
+    tools = [];
+    tool_choice = None;
+  }
+
+let sample_tool_schema : Types.tool_schema =
+  {
+    name = "get_weather";
+    description = "Get weather";
+    parameters =
+      [
+        {
+          name = "city";
+          description = "City name";
+          param_type = Types.String;
+          required = true;
+        };
+      ];
+  }
+
+let with_tmp_store f =
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let suffix = string_of_int (Random.int 999999) in
+  let tmp_dir = Eio.Path.(fs / "/tmp" / ("oas-test-" ^ suffix)) in
+  let store = Checkpoint_store.create tmp_dir in
+  Fun.protect
+    ~finally:(fun () ->
+      try Eio.Path.rmtree ~missing_ok:true tmp_dir with _ -> ())
+    (fun () -> f store tmp_dir)
+
+(* ── Tests ───────────────────────────────────────────────────────── *)
+
+let test_create_store () =
+  with_tmp_store (fun _store tmp_dir ->
+      Alcotest.(check bool)
+        "dir exists" true
+        (Eio.Path.is_directory tmp_dir))
+
+let test_create_auto_creates_directory () =
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let suffix = string_of_int (Random.int 999999) in
+  let tmp_dir =
+    Eio.Path.(fs / "/tmp" / ("oas-test-nested-" ^ suffix) / "sub" / "dir")
+  in
+  let parent =
+    Eio.Path.(fs / "/tmp" / ("oas-test-nested-" ^ suffix))
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      try Eio.Path.rmtree ~missing_ok:true parent with _ -> ())
+    (fun () ->
+      let _store = Checkpoint_store.create tmp_dir in
+      Alcotest.(check bool)
+        "nested dir exists" true
+        (Eio.Path.is_directory tmp_dir))
+
+let test_save_writes_file () =
+  with_tmp_store (fun store tmp_dir ->
+      let cp = make_checkpoint () in
+      let result = Checkpoint_store.save store cp in
+      Alcotest.(check bool) "save ok" true (Result.is_ok result);
+      let path = Eio.Path.(tmp_dir / "test-session.json") in
+      Alcotest.(check bool) "file exists" true (Eio.Path.is_file path))
+
+let test_save_writes_valid_json () =
+  with_tmp_store (fun store tmp_dir ->
+      let cp = make_checkpoint () in
+      let _ = Checkpoint_store.save store cp in
+      let data = Eio.Path.load Eio.Path.(tmp_dir / "test-session.json") in
+      let json = Yojson.Safe.from_string data in
+      let sid =
+        Yojson.Safe.Util.(json |> member "session_id" |> to_string)
+      in
+      Alcotest.(check string) "session_id" "test-session" sid)
+
+let test_save_atomic_no_tmp_residue () =
+  with_tmp_store (fun store _tmp_dir ->
+      let cp = make_checkpoint () in
+      let _ = Checkpoint_store.save store cp in
+      let ids = Checkpoint_store.list store in
+      (* No .tmp files should appear in the listing *)
+      Alcotest.(check (list string))
+        "only json" [ "test-session" ] ids)
+
+let test_save_empty_session_id () =
+  with_tmp_store (fun store _tmp_dir ->
+      let cp = make_checkpoint ~session_id:"" () in
+      let result = Checkpoint_store.save store cp in
+      Alcotest.(check bool) "error" true (Result.is_error result);
+      match result with
+      | Error msg ->
+        Alcotest.(check bool)
+          "contains empty" true
+          (String.length msg > 0)
+      | Ok () -> Alcotest.fail "expected error")
+
+let test_save_slash_in_session_id () =
+  with_tmp_store (fun store _tmp_dir ->
+      let cp = make_checkpoint ~session_id:"a/b" () in
+      let result = Checkpoint_store.save store cp in
+      Alcotest.(check bool) "error" true (Result.is_error result))
+
+let test_save_null_byte_in_session_id () =
+  with_tmp_store (fun store _tmp_dir ->
+      let cp = make_checkpoint ~session_id:"a\000b" () in
+      let result = Checkpoint_store.save store cp in
+      Alcotest.(check bool) "error" true (Result.is_error result))
+
+let test_save_overwrites_existing () =
+  with_tmp_store (fun store _tmp_dir ->
+      let cp1 = make_checkpoint ~created_at:1000.0 () in
+      let _ = Checkpoint_store.save store cp1 in
+      let cp2 = make_checkpoint ~created_at:2000.0 () in
+      let _ = Checkpoint_store.save store cp2 in
+      match Checkpoint_store.load store "test-session" with
+      | Ok loaded ->
+        Alcotest.(check (float 0.1))
+          "updated created_at" 2000.0 loaded.created_at
+      | Error e -> Alcotest.fail e)
+
+let test_load_existing () =
+  with_tmp_store (fun store _tmp_dir ->
+      let cp = make_checkpoint () in
+      let _ = Checkpoint_store.save store cp in
+      let result = Checkpoint_store.load store "test-session" in
+      Alcotest.(check bool) "load ok" true (Result.is_ok result))
+
+let test_load_missing () =
+  with_tmp_store (fun store _tmp_dir ->
+      let result = Checkpoint_store.load store "nonexistent" in
+      Alcotest.(check bool) "load error" true (Result.is_error result))
+
+let test_load_corrupted () =
+  with_tmp_store (fun _store tmp_dir ->
+      let path = Eio.Path.(tmp_dir / "corrupted.json") in
+      Eio.Path.save ~create:(`Or_truncate 0o644) path "not valid json{{{";
+      let store = Checkpoint_store.create tmp_dir in
+      let result = Checkpoint_store.load store "corrupted" in
+      Alcotest.(check bool) "load error" true (Result.is_error result))
+
+let test_load_invalid_id () =
+  with_tmp_store (fun store _tmp_dir ->
+      let result = Checkpoint_store.load store "" in
+      Alcotest.(check bool) "error" true (Result.is_error result))
+
+let test_roundtrip_preserves_all_fields () =
+  with_tmp_store (fun store _tmp_dir ->
+      let cp = make_checkpoint ~session_id:"rt1" ~created_at:42.5 () in
+      let _ = Checkpoint_store.save store cp in
+      match Checkpoint_store.load store "rt1" with
+      | Error e -> Alcotest.fail e
+      | Ok loaded ->
+        Alcotest.(check int) "version" cp.version loaded.version;
+        Alcotest.(check string) "session_id" cp.session_id loaded.session_id;
+        Alcotest.(check string) "agent_name" cp.agent_name loaded.agent_name;
+        Alcotest.(check (float 0.01))
+          "created_at" cp.created_at loaded.created_at;
+        Alcotest.(check int) "turn_count" cp.turn_count loaded.turn_count)
+
+let test_roundtrip_preserves_messages () =
+  with_tmp_store (fun store _tmp_dir ->
+      let cp =
+        {
+          (make_checkpoint ~session_id:"rt-msg" ()) with
+          messages =
+            [
+              { role = User; content = [ Text "hello" ] };
+              { role = Assistant; content = [ Text "world" ] };
+            ];
+        }
+      in
+      let _ = Checkpoint_store.save store cp in
+      match Checkpoint_store.load store "rt-msg" with
+      | Error e -> Alcotest.fail e
+      | Ok loaded ->
+        Alcotest.(check int) "msg count" 2 (List.length loaded.messages))
+
+let test_roundtrip_preserves_usage () =
+  with_tmp_store (fun store _tmp_dir ->
+      let cp =
+        {
+          (make_checkpoint ~session_id:"rt-usage" ()) with
+          usage =
+            {
+              total_input_tokens = 100;
+              total_output_tokens = 200;
+              total_cache_creation_input_tokens = 10;
+              total_cache_read_input_tokens = 20;
+              api_calls = 3;
+            };
+        }
+      in
+      let _ = Checkpoint_store.save store cp in
+      match Checkpoint_store.load store "rt-usage" with
+      | Error e -> Alcotest.fail e
+      | Ok loaded ->
+        Alcotest.(check int)
+          "input_tokens" 100 loaded.usage.total_input_tokens;
+        Alcotest.(check int)
+          "output_tokens" 200 loaded.usage.total_output_tokens;
+        Alcotest.(check int) "api_calls" 3 loaded.usage.api_calls)
+
+let test_roundtrip_preserves_tools () =
+  with_tmp_store (fun store _tmp_dir ->
+      let cp =
+        {
+          (make_checkpoint ~session_id:"rt-tools" ()) with
+          tools = [ sample_tool_schema ];
+        }
+      in
+      let _ = Checkpoint_store.save store cp in
+      match Checkpoint_store.load store "rt-tools" with
+      | Error e -> Alcotest.fail e
+      | Ok loaded ->
+        Alcotest.(check int) "tools count" 1 (List.length loaded.tools);
+        let t = List.hd loaded.tools in
+        Alcotest.(check string) "tool name" "get_weather" t.name)
+
+let test_roundtrip_preserves_tool_choice () =
+  with_tmp_store (fun store _tmp_dir ->
+      let cp =
+        {
+          (make_checkpoint ~session_id:"rt-tc" ()) with
+          tool_choice = Some (Types.Tool "get_weather");
+        }
+      in
+      let _ = Checkpoint_store.save store cp in
+      match Checkpoint_store.load store "rt-tc" with
+      | Error e -> Alcotest.fail e
+      | Ok loaded ->
+        Alcotest.(check bool) "has tool_choice" true
+          (Option.is_some loaded.tool_choice))
+
+let test_list_empty_store () =
+  with_tmp_store (fun store _tmp_dir ->
+      let ids = Checkpoint_store.list store in
+      Alcotest.(check (list string)) "empty" [] ids)
+
+let test_list_returns_all_saved () =
+  with_tmp_store (fun store _tmp_dir ->
+      let _ =
+        Checkpoint_store.save store (make_checkpoint ~session_id:"aaa" ())
+      in
+      let _ =
+        Checkpoint_store.save store (make_checkpoint ~session_id:"bbb" ())
+      in
+      let _ =
+        Checkpoint_store.save store (make_checkpoint ~session_id:"ccc" ())
+      in
+      let ids = Checkpoint_store.list store in
+      Alcotest.(check (list string)) "all three" [ "aaa"; "bbb"; "ccc" ] ids)
+
+let test_list_excludes_tmp_files () =
+  with_tmp_store (fun store tmp_dir ->
+      let _ =
+        Checkpoint_store.save store (make_checkpoint ~session_id:"good" ())
+      in
+      (* Manually create a .tmp file *)
+      Eio.Path.save
+        ~create:(`Or_truncate 0o644)
+        Eio.Path.(tmp_dir / "orphan.json.tmp")
+        "{}";
+      let ids = Checkpoint_store.list store in
+      Alcotest.(check (list string)) "no tmp" [ "good" ] ids)
+
+let test_list_is_sorted () =
+  with_tmp_store (fun store _tmp_dir ->
+      let _ =
+        Checkpoint_store.save store (make_checkpoint ~session_id:"zebra" ())
+      in
+      let _ =
+        Checkpoint_store.save store (make_checkpoint ~session_id:"alpha" ())
+      in
+      let _ =
+        Checkpoint_store.save store (make_checkpoint ~session_id:"mid" ())
+      in
+      let ids = Checkpoint_store.list store in
+      Alcotest.(check (list string))
+        "sorted" [ "alpha"; "mid"; "zebra" ] ids)
+
+let test_list_after_delete () =
+  with_tmp_store (fun store _tmp_dir ->
+      let _ =
+        Checkpoint_store.save store (make_checkpoint ~session_id:"keep" ())
+      in
+      let _ =
+        Checkpoint_store.save store (make_checkpoint ~session_id:"remove" ())
+      in
+      let _ = Checkpoint_store.delete store "remove" in
+      let ids = Checkpoint_store.list store in
+      Alcotest.(check (list string)) "after delete" [ "keep" ] ids)
+
+let test_delete_existing () =
+  with_tmp_store (fun store _tmp_dir ->
+      let _ =
+        Checkpoint_store.save store (make_checkpoint ~session_id:"del" ())
+      in
+      let result = Checkpoint_store.delete store "del" in
+      Alcotest.(check bool) "delete ok" true (Result.is_ok result);
+      Alcotest.(check bool) "gone" false (Checkpoint_store.exists store "del"))
+
+let test_delete_missing () =
+  with_tmp_store (fun store _tmp_dir ->
+      let result = Checkpoint_store.delete store "nonexistent" in
+      Alcotest.(check bool) "delete error" true (Result.is_error result))
+
+let test_delete_invalid_id () =
+  with_tmp_store (fun store _tmp_dir ->
+      let result = Checkpoint_store.delete store "" in
+      Alcotest.(check bool) "error" true (Result.is_error result))
+
+let test_load_after_delete () =
+  with_tmp_store (fun store _tmp_dir ->
+      let _ =
+        Checkpoint_store.save store (make_checkpoint ~session_id:"ephemeral" ())
+      in
+      let _ = Checkpoint_store.delete store "ephemeral" in
+      let result = Checkpoint_store.load store "ephemeral" in
+      Alcotest.(check bool) "load error" true (Result.is_error result))
+
+let test_latest_returns_most_recent () =
+  with_tmp_store (fun store _tmp_dir ->
+      let _ =
+        Checkpoint_store.save store
+          (make_checkpoint ~session_id:"old" ~created_at:100.0 ())
+      in
+      let _ =
+        Checkpoint_store.save store
+          (make_checkpoint ~session_id:"new" ~created_at:300.0 ())
+      in
+      let _ =
+        Checkpoint_store.save store
+          (make_checkpoint ~session_id:"mid" ~created_at:200.0 ())
+      in
+      match Checkpoint_store.latest store with
+      | Error e -> Alcotest.fail e
+      | Ok cp ->
+        Alcotest.(check string) "latest session_id" "new" cp.session_id)
+
+let test_latest_empty_store () =
+  with_tmp_store (fun store _tmp_dir ->
+      let result = Checkpoint_store.latest store in
+      Alcotest.(check bool) "error" true (Result.is_error result))
+
+let test_latest_with_single () =
+  with_tmp_store (fun store _tmp_dir ->
+      let _ =
+        Checkpoint_store.save store
+          (make_checkpoint ~session_id:"only" ~created_at:500.0 ())
+      in
+      match Checkpoint_store.latest store with
+      | Error e -> Alcotest.fail e
+      | Ok cp -> Alcotest.(check string) "session_id" "only" cp.session_id)
+
+let test_latest_ignores_corrupted () =
+  with_tmp_store (fun store tmp_dir ->
+      let _ =
+        Checkpoint_store.save store
+          (make_checkpoint ~session_id:"valid" ~created_at:100.0 ())
+      in
+      (* Write corrupted file manually *)
+      Eio.Path.save
+        ~create:(`Or_truncate 0o644)
+        Eio.Path.(tmp_dir / "bad.json")
+        "not json";
+      match Checkpoint_store.latest store with
+      | Error e -> Alcotest.fail e
+      | Ok cp -> Alcotest.(check string) "session_id" "valid" cp.session_id)
+
+let test_exists_true_for_saved () =
+  with_tmp_store (fun store _tmp_dir ->
+      let _ =
+        Checkpoint_store.save store
+          (make_checkpoint ~session_id:"present" ())
+      in
+      Alcotest.(check bool)
+        "exists" true
+        (Checkpoint_store.exists store "present"))
+
+let test_exists_false_for_missing () =
+  with_tmp_store (fun store _tmp_dir ->
+      Alcotest.(check bool)
+        "not exists" false
+        (Checkpoint_store.exists store "ghost"))
+
+let test_exists_false_after_delete () =
+  with_tmp_store (fun store _tmp_dir ->
+      let _ =
+        Checkpoint_store.save store (make_checkpoint ~session_id:"temp" ())
+      in
+      let _ = Checkpoint_store.delete store "temp" in
+      Alcotest.(check bool)
+        "not exists" false
+        (Checkpoint_store.exists store "temp"))
+
+let test_multiple_save_same_id_overwrites () =
+  with_tmp_store (fun store _tmp_dir ->
+      let cp1 =
+        { (make_checkpoint ~session_id:"dup" ()) with turn_count = 1 }
+      in
+      let _ = Checkpoint_store.save store cp1 in
+      let cp2 =
+        { (make_checkpoint ~session_id:"dup" ()) with turn_count = 99 }
+      in
+      let _ = Checkpoint_store.save store cp2 in
+      match Checkpoint_store.load store "dup" with
+      | Error e -> Alcotest.fail e
+      | Ok loaded ->
+        Alcotest.(check int) "overwritten turn_count" 99 loaded.turn_count)
+
+(* ── Runner ──────────────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Checkpoint_store"
+    [
+      ( "create",
+        [
+          Alcotest.test_case "create store" `Quick test_create_store;
+          Alcotest.test_case "create auto creates directory" `Quick
+            test_create_auto_creates_directory;
+        ] );
+      ( "save",
+        [
+          Alcotest.test_case "save writes file" `Quick test_save_writes_file;
+          Alcotest.test_case "save writes valid JSON" `Quick
+            test_save_writes_valid_json;
+          Alcotest.test_case "save atomic - no .tmp residue" `Quick
+            test_save_atomic_no_tmp_residue;
+          Alcotest.test_case "save empty session_id error" `Quick
+            test_save_empty_session_id;
+          Alcotest.test_case "save slash in session_id error" `Quick
+            test_save_slash_in_session_id;
+          Alcotest.test_case "save null byte in session_id error" `Quick
+            test_save_null_byte_in_session_id;
+          Alcotest.test_case "save overwrites existing" `Quick
+            test_save_overwrites_existing;
+        ] );
+      ( "load",
+        [
+          Alcotest.test_case "load existing checkpoint" `Quick
+            test_load_existing;
+          Alcotest.test_case "load missing returns error" `Quick
+            test_load_missing;
+          Alcotest.test_case "load corrupted returns error" `Quick
+            test_load_corrupted;
+          Alcotest.test_case "load invalid id returns error" `Quick
+            test_load_invalid_id;
+        ] );
+      ( "roundtrip",
+        [
+          Alcotest.test_case "roundtrip preserves all fields" `Quick
+            test_roundtrip_preserves_all_fields;
+          Alcotest.test_case "roundtrip preserves messages" `Quick
+            test_roundtrip_preserves_messages;
+          Alcotest.test_case "roundtrip preserves usage" `Quick
+            test_roundtrip_preserves_usage;
+          Alcotest.test_case "roundtrip preserves tools" `Quick
+            test_roundtrip_preserves_tools;
+          Alcotest.test_case "roundtrip preserves tool_choice" `Quick
+            test_roundtrip_preserves_tool_choice;
+        ] );
+      ( "list",
+        [
+          Alcotest.test_case "list empty store" `Quick test_list_empty_store;
+          Alcotest.test_case "list returns all saved" `Quick
+            test_list_returns_all_saved;
+          Alcotest.test_case "list excludes .tmp files" `Quick
+            test_list_excludes_tmp_files;
+          Alcotest.test_case "list is sorted" `Quick test_list_is_sorted;
+          Alcotest.test_case "list after delete" `Quick test_list_after_delete;
+        ] );
+      ( "delete",
+        [
+          Alcotest.test_case "delete existing" `Quick test_delete_existing;
+          Alcotest.test_case "delete missing returns error" `Quick
+            test_delete_missing;
+          Alcotest.test_case "delete invalid id returns error" `Quick
+            test_delete_invalid_id;
+          Alcotest.test_case "load after delete returns error" `Quick
+            test_load_after_delete;
+        ] );
+      ( "latest",
+        [
+          Alcotest.test_case "latest returns most recent by created_at" `Quick
+            test_latest_returns_most_recent;
+          Alcotest.test_case "latest empty store error" `Quick
+            test_latest_empty_store;
+          Alcotest.test_case "latest with single checkpoint" `Quick
+            test_latest_with_single;
+          Alcotest.test_case "latest ignores corrupted files" `Quick
+            test_latest_ignores_corrupted;
+        ] );
+      ( "exists",
+        [
+          Alcotest.test_case "exists returns true for saved" `Quick
+            test_exists_true_for_saved;
+          Alcotest.test_case "exists returns false for missing" `Quick
+            test_exists_false_for_missing;
+          Alcotest.test_case "exists returns false after delete" `Quick
+            test_exists_false_after_delete;
+        ] );
+      ( "overwrite",
+        [
+          Alcotest.test_case "multiple save same id overwrites" `Quick
+            test_multiple_save_same_id_overwrites;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- `Checkpoint_store` module wrapping `Checkpoint.to_string/of_string` with Eio.Path file I/O
- Atomic writes via `.tmp` + `Eio.Path.rename` (POSIX atomic)
- Session ID validation (rejects empty, `/`, `\000`)
- `latest` resolves by `created_at` field (clock-change safe)

## Changes
- **New**: `lib/checkpoint_store.ml` (~120 LOC)
- **Modified**: `lib/agent_sdk.ml`, `lib/agent_sdk.mli`
- **New**: `test/test_checkpoint_store.ml` (35 tests)

## Test plan
- [x] `dune build --root . @all` — no warnings
- [x] `dune runtest --root . --force` — 35 new tests pass
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)