### PR TITLE
feat(orchestrator): add multi-agent task orchestration

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -58,6 +58,7 @@ module Checkpoint_store = Checkpoint_store
 module Session = Session
 module Agent = Agent
 module Builder = Builder
+module Orchestrator = Orchestrator
 
 (** Quick start: create an agent with default config *)
 let create_agent ~net ?name ?model ?system_prompt ?max_tokens ?max_turns ?cache_system_prompt ?provider () =

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -1004,6 +1004,83 @@ module Builder : sig
   val build : t -> Agent.t
 end
 
+(** {1 Multi-Agent Orchestration} *)
+
+module Orchestrator : sig
+  (** Distribute tasks across multiple named agents and collect results.
+      External code decides the execution plan; the LLM does not participate
+      in routing (contrast with {!Handoff} where the LLM decides). *)
+
+  (** A unit of work: a prompt directed at a named agent. *)
+  type task = {
+    id: string;
+    prompt: string;
+    agent_name: string;
+  }
+
+  (** Result of executing a single task. *)
+  type task_result = {
+    task_id: string;
+    agent_name: string;
+    result: (Types.api_response, string) result;
+    elapsed: float;
+  }
+
+  (** Execution plan variants. *)
+  type plan =
+    | Sequential of task list  (** Run tasks one by one in order. *)
+    | Parallel of task list    (** Run tasks concurrently via Eio fibers. *)
+    | FanOut of { prompt: string; agents: string list }
+      (** Same prompt sent to multiple agents in parallel. *)
+    | Pipeline of task list
+      (** Run sequentially; each task's prompt is appended with the
+          previous task's text output. *)
+
+  (** Orchestrator configuration. *)
+  type config = {
+    max_parallel: int;
+    shared_context: Context.t option;
+    on_task_start: (task -> unit) option;
+    on_task_complete: (task_result -> unit) option;
+    timeout_per_task: float option;
+  }
+
+  val default_config : config
+
+  (** Orchestrator instance: a registry of named agents plus config. *)
+  type t = {
+    agents: (string * Agent.t) list;
+    config: config;
+  }
+
+  val create : ?config:config -> (string * Agent.t) list -> t
+  val add_agent : t -> string -> Agent.t -> t
+  val find_agent : t -> string -> Agent.t option
+
+  (** Execute a single task against the named agent. *)
+  val run_task :
+    sw:Eio.Switch.t -> ?clock:_ Eio.Time.clock -> t -> task -> task_result
+
+  (** Execute an entire plan. *)
+  val execute :
+    sw:Eio.Switch.t -> ?clock:_ Eio.Time.clock -> t -> plan -> task_result list
+
+  (** Fan out: send the same prompt to every registered agent. *)
+  val fan_out :
+    sw:Eio.Switch.t -> ?clock:_ Eio.Time.clock -> t -> string -> task_result list
+
+  (** Pipeline: chain tasks sequentially, feeding each output into the
+      next task's prompt. *)
+  val pipeline :
+    sw:Eio.Switch.t -> ?clock:_ Eio.Time.clock -> t -> task list -> task_result list
+
+  (** Extract concatenated text from all successful results. *)
+  val collect_text : task_result list -> string
+
+  (** [true] when every result is [Ok _]. *)
+  val all_ok : task_result list -> bool
+end
+
 (** {1 Quick Start} *)
 
 (** Create an agent with default config and optional overrides *)

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -1,0 +1,170 @@
+(** Multi-agent orchestration.
+
+    Distributes tasks across named agents and collects results.
+    External code decides the execution plan (Sequential, Parallel,
+    FanOut, Pipeline); the LLM does not participate in routing. *)
+
+open Types
+
+(* ── Types ────────────────────────────────────────────────────────── *)
+
+type task = {
+  id: string;
+  prompt: string;
+  agent_name: string;
+}
+
+type task_result = {
+  task_id: string;
+  agent_name: string;
+  result: (api_response, string) result;
+  elapsed: float;
+}
+
+type plan =
+  | Sequential of task list
+  | Parallel of task list
+  | FanOut of { prompt: string; agents: string list }
+  | Pipeline of task list
+
+type config = {
+  max_parallel: int;
+  shared_context: Context.t option;
+  on_task_start: (task -> unit) option;
+  on_task_complete: (task_result -> unit) option;
+  timeout_per_task: float option;
+}
+
+let default_config = {
+  max_parallel = 4;
+  shared_context = None;
+  on_task_start = None;
+  on_task_complete = None;
+  timeout_per_task = None;
+}
+
+type t = {
+  agents: (string * Agent.t) list;
+  config: config;
+}
+
+(* ── Constructor / lookup ─────────────────────────────────────────── *)
+
+let create ?(config = default_config) agents =
+  { agents; config }
+
+let add_agent orch name agent =
+  { orch with agents = (name, agent) :: orch.agents }
+
+let find_agent orch name =
+  List.assoc_opt name orch.agents
+
+(* ── Internal helpers ─────────────────────────────────────────────── *)
+
+(** Extract concatenated text from a successful api_response. *)
+let text_of_response (resp : api_response) =
+  List.filter_map (function Text s -> Some s | _ -> None) resp.content
+  |> String.concat "\n"
+
+(** Run Agent.run with optional timeout.
+    Uses [Eio.Time.with_timeout_exn] which raises [Eio.Time.Timeout]
+    if the deadline expires. *)
+let run_agent_with_timeout ~sw ?clock config agent prompt =
+  match config.timeout_per_task, clock with
+  | Some timeout, Some clk ->
+    (try
+       Eio.Time.with_timeout_exn clk timeout (fun () ->
+         Agent.run ~sw ~clock:clk agent prompt)
+     with Eio.Time.Timeout -> Error "Task timed out")
+  | _ ->
+    Agent.run ~sw ?clock agent prompt
+
+(* ── Core execution ───────────────────────────────────────────────── *)
+
+let run_task ~sw ?clock orch task =
+  Option.iter (fun cb -> cb task) orch.config.on_task_start;
+  let t0 = Unix.gettimeofday () in
+  let result =
+    match find_agent orch task.agent_name with
+    | None -> Error (Printf.sprintf "Unknown agent: %s" task.agent_name)
+    | Some agent ->
+      (* If shared_context is configured, merge it into the agent's context *)
+      (match orch.config.shared_context with
+       | Some ctx ->
+         let pairs = Hashtbl.fold (fun k v acc -> (k, v) :: acc) ctx [] in
+         Context.merge agent.context pairs
+       | None -> ());
+      run_agent_with_timeout ~sw ?clock orch.config agent task.prompt
+  in
+  let elapsed = Unix.gettimeofday () -. t0 in
+  let tr = { task_id = task.id; agent_name = task.agent_name; result; elapsed } in
+  Option.iter (fun cb -> cb tr) orch.config.on_task_complete;
+  tr
+
+(* ── Plan execution ───────────────────────────────────────────────── *)
+
+let execute_sequential ~sw ?clock orch tasks =
+  List.map (run_task ~sw ?clock orch) tasks
+
+let execute_parallel ~sw ?clock orch tasks =
+  Eio.Fiber.List.map ~max_fibers:orch.config.max_parallel
+    (run_task ~sw ?clock orch) tasks
+
+let execute_fan_out ~sw ?clock orch ~prompt ~agents =
+  let tasks = List.mapi (fun i agent_name ->
+    { id = Printf.sprintf "fanout-%d" i;
+      prompt;
+      agent_name }
+  ) agents in
+  execute_parallel ~sw ?clock orch tasks
+
+let execute_pipeline ~sw ?clock orch tasks =
+  let rec go acc prev_text = function
+    | [] -> List.rev acc
+    | task :: rest ->
+      let effective_prompt =
+        match prev_text with
+        | None -> task.prompt
+        | Some text -> task.prompt ^ "\n\n" ^ text
+      in
+      let effective_task = { task with prompt = effective_prompt } in
+      let tr = run_task ~sw ?clock orch effective_task in
+      let next_text =
+        match tr.result with
+        | Ok resp -> Some (text_of_response resp)
+        | Error _ -> prev_text
+      in
+      go (tr :: acc) next_text rest
+  in
+  go [] None tasks
+
+let execute ~sw ?clock orch plan =
+  match plan with
+  | Sequential tasks -> execute_sequential ~sw ?clock orch tasks
+  | Parallel tasks -> execute_parallel ~sw ?clock orch tasks
+  | FanOut { prompt; agents } -> execute_fan_out ~sw ?clock orch ~prompt ~agents
+  | Pipeline tasks -> execute_pipeline ~sw ?clock orch tasks
+
+(* ── Convenience shorthands ───────────────────────────────────────── *)
+
+let fan_out ~sw ?clock orch prompt =
+  let agents = List.map fst orch.agents in
+  execute ~sw ?clock orch (FanOut { prompt; agents })
+
+let pipeline ~sw ?clock orch tasks =
+  execute ~sw ?clock orch (Pipeline tasks)
+
+(* ── Utilities ────────────────────────────────────────────────────── *)
+
+let collect_text results =
+  List.filter_map (fun tr ->
+    match tr.result with
+    | Ok resp -> Some (text_of_response resp)
+    | Error _ -> None
+  ) results
+  |> String.concat "\n"
+
+let all_ok results =
+  List.for_all (fun tr ->
+    match tr.result with Ok _ -> true | Error _ -> false
+  ) results

--- a/test/dune
+++ b/test/dune
@@ -134,3 +134,7 @@
 (test
  (name test_agent_stream)
  (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_orchestrator)
+ (libraries agent_sdk alcotest yojson eio eio_main unix))

--- a/test/test_orchestrator.ml
+++ b/test/test_orchestrator.ml
@@ -1,0 +1,398 @@
+(** Tests for orchestrator.ml — multi-agent task distribution. *)
+
+open Alcotest
+open Agent_sdk
+open Types
+
+(* ── Helpers ──────────────────────────────────────────────────────── *)
+
+(** Build a mock api_response with the given text. *)
+let mock_response text = {
+  id = "resp-1";
+  model = "mock";
+  stop_reason = EndTurn;
+  content = [Text text];
+  usage = Some {
+    input_tokens = 10;
+    output_tokens = 5;
+    cache_creation_input_tokens = 0;
+    cache_read_input_tokens = 0;
+  };
+}
+
+let _mock_error_response = {
+  id = "resp-err";
+  model = "mock";
+  stop_reason = EndTurn;
+  content = [Text "error"];
+  usage = None;
+}
+
+(** Build a task_result from an Ok response. *)
+let ok_result ?(task_id="t1") ?(agent_name="a") text = {
+  Orchestrator.task_id;
+  agent_name;
+  result = Ok (mock_response text);
+  elapsed = 0.01;
+}
+
+(** Build a task_result from an Error. *)
+let err_result ?(task_id="t2") ?(agent_name="b") msg = {
+  Orchestrator.task_id;
+  agent_name;
+  result = Error msg;
+  elapsed = 0.0;
+}
+
+(** Make a mock agent that does not call any API.
+    We create a real Agent.t with env#net from Eio_main.
+    The agent itself is valid; we just never call Agent.run in
+    pure tests. *)
+let make_mock_agent env =
+  Agent.create ~net:env#net
+    ~config:{ default_config with name = "mock"; max_turns = 1 } ()
+
+(* ── create ───────────────────────────────────────────────────────── *)
+
+let test_create_empty () =
+  let orch = Orchestrator.create [] in
+  check int "no agents" 0 (List.length orch.agents)
+
+let test_create_with_agents () =
+  Eio_main.run @@ fun env ->
+  let a = make_mock_agent env in
+  let orch = Orchestrator.create [("alpha", a)] in
+  check int "one agent" 1 (List.length orch.agents)
+
+let test_create_with_config () =
+  let cfg = { Orchestrator.default_config with max_parallel = 8 } in
+  let orch = Orchestrator.create ~config:cfg [] in
+  check int "max_parallel" 8 orch.config.max_parallel
+
+let test_create_preserves_agent_order () =
+  Eio_main.run @@ fun env ->
+  let a = make_mock_agent env in
+  let b = make_mock_agent env in
+  let orch = Orchestrator.create [("first", a); ("second", b)] in
+  let names = List.map fst orch.agents in
+  check (list string) "order preserved" ["first"; "second"] names
+
+(* ── add_agent ────────────────────────────────────────────────────── *)
+
+let test_add_agent () =
+  Eio_main.run @@ fun env ->
+  let a = make_mock_agent env in
+  let orch = Orchestrator.create [] in
+  let orch' = Orchestrator.add_agent orch "new" a in
+  check int "one agent after add" 1 (List.length orch'.agents);
+  check int "original unchanged" 0 (List.length orch.agents)
+
+let test_add_agent_prepends () =
+  Eio_main.run @@ fun env ->
+  let a = make_mock_agent env in
+  let b = make_mock_agent env in
+  let orch = Orchestrator.create [("a", a)] in
+  let orch' = Orchestrator.add_agent orch "b" b in
+  let names = List.map fst orch'.agents in
+  check string "new agent first" "b" (List.hd names)
+
+(* ── find_agent ───────────────────────────────────────────────────── *)
+
+let test_find_agent_present () =
+  Eio_main.run @@ fun env ->
+  let a = make_mock_agent env in
+  let orch = Orchestrator.create [("alpha", a)] in
+  check bool "found" true (Option.is_some (Orchestrator.find_agent orch "alpha"))
+
+let test_find_agent_missing () =
+  let orch = Orchestrator.create [] in
+  check bool "not found" true (Option.is_none (Orchestrator.find_agent orch "ghost"))
+
+let test_find_agent_first_match () =
+  Eio_main.run @@ fun env ->
+  let a = make_mock_agent env in
+  let b = make_mock_agent env in
+  (* Two agents with different names *)
+  let orch = Orchestrator.create [("x", a); ("y", b)] in
+  check bool "x found" true (Option.is_some (Orchestrator.find_agent orch "x"));
+  check bool "y found" true (Option.is_some (Orchestrator.find_agent orch "y"))
+
+(* ── plan construction ────────────────────────────────────────────── *)
+
+let test_plan_sequential () =
+  let tasks = [{ Orchestrator.id = "1"; prompt = "hello"; agent_name = "a" }] in
+  match Orchestrator.Sequential tasks with
+  | Orchestrator.Sequential ts -> check int "one task" 1 (List.length ts)
+  | _ -> fail "wrong plan variant"
+
+let test_plan_parallel () =
+  let tasks = [
+    { Orchestrator.id = "1"; prompt = "a"; agent_name = "x" };
+    { Orchestrator.id = "2"; prompt = "b"; agent_name = "y" };
+  ] in
+  match Orchestrator.Parallel tasks with
+  | Orchestrator.Parallel ts -> check int "two tasks" 2 (List.length ts)
+  | _ -> fail "wrong plan variant"
+
+let test_plan_fanout () =
+  let plan = Orchestrator.FanOut { prompt = "test"; agents = ["a"; "b"; "c"] } in
+  match plan with
+  | Orchestrator.FanOut { prompt; agents } ->
+    check string "prompt" "test" prompt;
+    check int "3 agents" 3 (List.length agents)
+  | _ -> fail "wrong plan variant"
+
+let test_plan_pipeline () =
+  let tasks = [
+    { Orchestrator.id = "s1"; prompt = "step1"; agent_name = "a" };
+    { Orchestrator.id = "s2"; prompt = "step2"; agent_name = "b" };
+  ] in
+  match Orchestrator.Pipeline tasks with
+  | Orchestrator.Pipeline ts -> check int "two stages" 2 (List.length ts)
+  | _ -> fail "wrong plan variant"
+
+let test_plan_empty_sequential () =
+  match Orchestrator.Sequential [] with
+  | Orchestrator.Sequential ts -> check int "empty" 0 (List.length ts)
+  | _ -> fail "wrong plan variant"
+
+(* ── task_result ──────────────────────────────────────────────────── *)
+
+let test_task_result_ok_fields () =
+  let tr = ok_result ~task_id:"t-ok" ~agent_name:"alpha" "hello" in
+  check string "task_id" "t-ok" tr.task_id;
+  check string "agent_name" "alpha" tr.agent_name;
+  check bool "is ok" true (Result.is_ok tr.result)
+
+let test_task_result_error_fields () =
+  let tr = err_result ~task_id:"t-err" ~agent_name:"beta" "boom" in
+  check string "task_id" "t-err" tr.task_id;
+  check string "agent_name" "beta" tr.agent_name;
+  check bool "is error" true (Result.is_error tr.result)
+
+let test_task_result_elapsed () =
+  let tr = { (ok_result "x") with elapsed = 1.5 } in
+  check bool "elapsed > 0" true (tr.elapsed > 0.0)
+
+(* ── collect_text ─────────────────────────────────────────────────── *)
+
+let test_collect_text_empty () =
+  check string "empty list" "" (Orchestrator.collect_text [])
+
+let test_collect_text_single_ok () =
+  let results = [ok_result "hello world"] in
+  check string "single text" "hello world" (Orchestrator.collect_text results)
+
+let test_collect_text_multiple_ok () =
+  let results = [
+    ok_result ~task_id:"1" "first";
+    ok_result ~task_id:"2" "second";
+  ] in
+  check string "joined" "first\nsecond" (Orchestrator.collect_text results)
+
+let test_collect_text_skips_errors () =
+  let results = [
+    ok_result ~task_id:"1" "good";
+    err_result ~task_id:"2" "bad";
+    ok_result ~task_id:"3" "also good";
+  ] in
+  check string "errors skipped" "good\nalso good" (Orchestrator.collect_text results)
+
+let test_collect_text_all_errors () =
+  let results = [
+    err_result ~task_id:"1" "err1";
+    err_result ~task_id:"2" "err2";
+  ] in
+  check string "all errors" "" (Orchestrator.collect_text results)
+
+let test_collect_text_multiblock () =
+  (* Response with multiple Text blocks *)
+  let resp = {
+    id = "r"; model = "m"; stop_reason = EndTurn;
+    content = [Text "line1"; Text "line2"]; usage = None;
+  } in
+  let tr = { Orchestrator.task_id = "t"; agent_name = "a";
+             result = Ok resp; elapsed = 0.0 } in
+  check string "multi text blocks" "line1\nline2" (Orchestrator.collect_text [tr])
+
+(* ── all_ok ───────────────────────────────────────────────────────── *)
+
+let test_all_ok_empty () =
+  check bool "empty is ok" true (Orchestrator.all_ok [])
+
+let test_all_ok_true () =
+  let results = [ok_result "a"; ok_result "b"] in
+  check bool "all ok" true (Orchestrator.all_ok results)
+
+let test_all_ok_false () =
+  let results = [ok_result "a"; err_result "oops"] in
+  check bool "not all ok" false (Orchestrator.all_ok results)
+
+let test_all_ok_single_error () =
+  let results = [err_result "fail"] in
+  check bool "single error" false (Orchestrator.all_ok results)
+
+(* ── config defaults ──────────────────────────────────────────────── *)
+
+let test_default_config_max_parallel () =
+  check int "default max_parallel" 4 Orchestrator.default_config.max_parallel
+
+let test_default_config_no_shared_context () =
+  check bool "no shared context" true
+    (Option.is_none Orchestrator.default_config.shared_context)
+
+let test_default_config_no_callbacks () =
+  check bool "no on_task_start" true
+    (Option.is_none Orchestrator.default_config.on_task_start);
+  check bool "no on_task_complete" true
+    (Option.is_none Orchestrator.default_config.on_task_complete)
+
+let test_default_config_no_timeout () =
+  check bool "no timeout" true
+    (Option.is_none Orchestrator.default_config.timeout_per_task)
+
+(* ── callback tracking ────────────────────────────────────────────── *)
+
+let test_callback_on_task_start_tracking () =
+  let started = ref [] in
+  let cfg = { Orchestrator.default_config with
+    on_task_start = Some (fun task -> started := task.id :: !started);
+  } in
+  (* Verify the callback is set *)
+  check bool "callback is set" true (Option.is_some cfg.on_task_start);
+  (* Manually invoke to test *)
+  let task : Orchestrator.task = { id = "cb-1"; prompt = "hi"; agent_name = "a" } in
+  (match cfg.on_task_start with
+   | Some cb -> cb task
+   | None -> ());
+  check (list string) "started recorded" ["cb-1"] !started
+
+let test_callback_on_task_complete_tracking () =
+  let completed = ref [] in
+  let cfg = { Orchestrator.default_config with
+    on_task_complete = Some (fun tr -> completed := tr.Orchestrator.task_id :: !completed);
+  } in
+  let tr = ok_result ~task_id:"cb-2" "done" in
+  (match cfg.on_task_complete with
+   | Some cb -> cb tr
+   | None -> ());
+  check (list string) "completed recorded" ["cb-2"] !completed
+
+(* ── run_task: unknown agent error ────────────────────────────────── *)
+
+let test_run_task_unknown_agent () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let orch = Orchestrator.create [] in
+  let task : Orchestrator.task =
+    { id = "t1"; prompt = "hi"; agent_name = "ghost" }
+  in
+  let tr = Orchestrator.run_task ~sw orch task in
+  check bool "is error" true (Result.is_error tr.result);
+  match tr.result with
+  | Error msg ->
+    check bool "mentions agent name" true
+      (String.length msg > 0 && String.sub msg 0 14 = "Unknown agent:")
+  | Ok _ -> fail "expected error"
+
+let test_run_task_unknown_agent_callbacks_called () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let start_called = ref false in
+  let complete_called = ref false in
+  let cfg = { Orchestrator.default_config with
+    on_task_start = Some (fun _ -> start_called := true);
+    on_task_complete = Some (fun _ -> complete_called := true);
+  } in
+  let orch = Orchestrator.create ~config:cfg [] in
+  let task : Orchestrator.task =
+    { id = "t1"; prompt = "hi"; agent_name = "missing" }
+  in
+  let _tr = Orchestrator.run_task ~sw orch task in
+  check bool "start called" true !start_called;
+  check bool "complete called" true !complete_called
+
+let test_run_task_elapsed_nonnegative () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let orch = Orchestrator.create [] in
+  let task : Orchestrator.task =
+    { id = "t1"; prompt = "hi"; agent_name = "nope" }
+  in
+  let tr = Orchestrator.run_task ~sw orch task in
+  check bool "elapsed >= 0" true (tr.elapsed >= 0.0)
+
+(* ── task field access ────────────────────────────────────────────── *)
+
+let test_task_fields () =
+  let task : Orchestrator.task =
+    { id = "abc"; prompt = "do something"; agent_name = "worker" }
+  in
+  check string "id" "abc" task.id;
+  check string "prompt" "do something" task.prompt;
+  check string "agent_name" "worker" task.agent_name
+
+(* ── Suite ────────────────────────────────────────────────────────── *)
+
+let () =
+  run "Orchestrator" [
+    "create", [
+      test_case "empty" `Quick test_create_empty;
+      test_case "with agents" `Quick test_create_with_agents;
+      test_case "with config" `Quick test_create_with_config;
+      test_case "preserves order" `Quick test_create_preserves_agent_order;
+    ];
+    "add_agent", [
+      test_case "add one" `Quick test_add_agent;
+      test_case "prepends" `Quick test_add_agent_prepends;
+    ];
+    "find_agent", [
+      test_case "present" `Quick test_find_agent_present;
+      test_case "missing" `Quick test_find_agent_missing;
+      test_case "first match" `Quick test_find_agent_first_match;
+    ];
+    "plan", [
+      test_case "sequential" `Quick test_plan_sequential;
+      test_case "parallel" `Quick test_plan_parallel;
+      test_case "fanout" `Quick test_plan_fanout;
+      test_case "pipeline" `Quick test_plan_pipeline;
+      test_case "empty sequential" `Quick test_plan_empty_sequential;
+    ];
+    "task", [
+      test_case "fields" `Quick test_task_fields;
+    ];
+    "task_result", [
+      test_case "ok fields" `Quick test_task_result_ok_fields;
+      test_case "error fields" `Quick test_task_result_error_fields;
+      test_case "elapsed" `Quick test_task_result_elapsed;
+    ];
+    "collect_text", [
+      test_case "empty" `Quick test_collect_text_empty;
+      test_case "single ok" `Quick test_collect_text_single_ok;
+      test_case "multiple ok" `Quick test_collect_text_multiple_ok;
+      test_case "skips errors" `Quick test_collect_text_skips_errors;
+      test_case "all errors" `Quick test_collect_text_all_errors;
+      test_case "multi text blocks" `Quick test_collect_text_multiblock;
+    ];
+    "all_ok", [
+      test_case "empty" `Quick test_all_ok_empty;
+      test_case "all ok" `Quick test_all_ok_true;
+      test_case "mixed" `Quick test_all_ok_false;
+      test_case "single error" `Quick test_all_ok_single_error;
+    ];
+    "config", [
+      test_case "default max_parallel" `Quick test_default_config_max_parallel;
+      test_case "no shared context" `Quick test_default_config_no_shared_context;
+      test_case "no callbacks" `Quick test_default_config_no_callbacks;
+      test_case "no timeout" `Quick test_default_config_no_timeout;
+    ];
+    "callbacks", [
+      test_case "on_task_start" `Quick test_callback_on_task_start_tracking;
+      test_case "on_task_complete" `Quick test_callback_on_task_complete_tracking;
+    ];
+    "run_task", [
+      test_case "unknown agent" `Quick test_run_task_unknown_agent;
+      test_case "callbacks called" `Quick test_run_task_unknown_agent_callbacks_called;
+      test_case "elapsed nonneg" `Quick test_run_task_elapsed_nonnegative;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- `Orchestrator` module for distributing tasks across named agents and collecting results
- Four plan types: `Sequential`, `Parallel` (Eio fibers), `FanOut` (same prompt to all), `Pipeline` (chain output)
- Timeout support via `Eio.Time.with_timeout_exn`, shared context, task lifecycle callbacks

## Changes
- **New**: `lib/orchestrator.ml` (~170 LOC)
- **Modified**: `lib/agent_sdk.ml`, `lib/agent_sdk.mli`
- **New**: `test/test_orchestrator.ml` (37 tests)

## Test plan
- [x] `dune build --root . @all` — no warnings
- [x] `dune runtest --root . --force` — 37 new tests pass
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)