### PR TITLE
feat(agent): add Agent.clone and Context.copy

### DIFF
--- a/lib/agent.ml
+++ b/lib/agent.ml
@@ -55,6 +55,20 @@ let create ~net ?(config=default_config) ?(tools=[]) ?context
   in
   { state; tools = all_tools; net; context = ctx; options }
 
+(** Clone an agent with independent state.
+    By default the clone gets a fresh (empty) context.
+    Pass [~copy_context:true] to shallow-copy all context entries.
+    Tools, net, options, and mcp_clients are shared (immutable/stateless). *)
+let clone ?(copy_context=false) agent =
+  let ctx = if copy_context then Context.copy agent.context else Context.create () in
+  let state = {
+    config = agent.state.config;
+    messages = agent.state.messages;
+    turn_count = agent.state.turn_count;
+    usage = agent.state.usage;
+  } in
+  { state; tools = agent.tools; net = agent.net; context = ctx; options = agent.options }
+
 (** Close all MCP server connections held by this agent. *)
 let close agent =
   Mcp.close_all agent.options.mcp_clients

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -187,6 +187,11 @@ module Context : sig
   (** Deserialize from JSON.  Returns an empty context if [json] is not
       a JSON object (i.e. not [`Assoc _]). *)
   val of_json : Yojson.Safe.t -> t
+
+  (** Shallow-copy all entries into a fresh context.
+      Values are [Yojson.Safe.t] (structurally immutable), so shallow copy
+      is sufficient for full independence. *)
+  val copy : t -> t
 end
 
 (** {1 LLM Provider Abstraction} *)
@@ -947,6 +952,12 @@ module Agent : sig
     targets:Handoff.handoff_target list ->
     string ->
     (Types.api_response, string) result
+
+  (** Clone an agent with independent mutable state.
+      The clone shares [tools], [net], [options], and [mcp_clients]
+      (immutable / stateless).  By default it gets a fresh empty context;
+      pass [~copy_context:true] to shallow-copy all context entries. *)
+  val clone : ?copy_context:bool -> t -> t
 
   (** Close all MCP server connections held by this agent.
       Safe to call even if no MCP servers were configured. *)

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -30,3 +30,8 @@ let of_json (json : Yojson.Safe.t) : t =
    | `Assoc pairs -> List.iter (fun (k, v) -> Hashtbl.replace ctx k v) pairs
    | _ -> ());
   ctx
+
+let copy (ctx : t) : t =
+  let new_ctx = create () in
+  Hashtbl.iter (fun k v -> Hashtbl.replace new_ctx k v) ctx;
+  new_ctx

--- a/test/dune
+++ b/test/dune
@@ -87,6 +87,10 @@
  (libraries agent_sdk alcotest yojson))
 
 (test
+ (name test_clone)
+ (libraries agent_sdk alcotest yojson eio eio_main))
+
+(test
  (name test_property)
  (libraries agent_sdk alcotest qcheck-core qcheck-alcotest yojson))
 

--- a/test/test_clone.ml
+++ b/test/test_clone.ml
@@ -1,0 +1,175 @@
+(** Tests for Agent.clone — independent agent duplication. *)
+
+open Alcotest
+open Agent_sdk
+
+(* ── Helpers ──────────────────────────────────────────────────────── *)
+
+let make_agent env =
+  Agent.create ~net:env#net
+    ~config:{ Types.default_config with name = "original"; max_turns = 5 } ()
+
+let make_agent_with_context env =
+  let ctx = Context.create () in
+  Context.set ctx "key1" (`String "val1");
+  Context.set ctx "key2" (`Int 42);
+  Agent.create ~net:env#net
+    ~config:{ Types.default_config with name = "ctx-agent" }
+    ~context:ctx ()
+
+(* ── 1. clone_fresh_context ──────────────────────────────────────── *)
+
+let test_clone_fresh_context () =
+  Eio_main.run @@ fun env ->
+  let agent = make_agent_with_context env in
+  let clone = Agent.clone agent in
+  check (list string) "clone context is empty" [] (Context.keys clone.context);
+  let orig_keys = List.sort String.compare (Context.keys agent.context) in
+  check (list string) "original unchanged" ["key1"; "key2"] orig_keys
+
+(* ── 2. clone_copy_context ───────────────────────────────────────── *)
+
+let test_clone_copy_context () =
+  Eio_main.run @@ fun env ->
+  let agent = make_agent_with_context env in
+  let clone = Agent.clone ~copy_context:true agent in
+  check bool "key1 copied" true
+    (Context.get clone.context "key1" = Some (`String "val1"));
+  check bool "key2 copied" true
+    (Context.get clone.context "key2" = Some (`Int 42))
+
+(* ── 3. clone_context_independence ───────────────────────────────── *)
+
+let test_clone_context_independence () =
+  Eio_main.run @@ fun env ->
+  let agent = make_agent_with_context env in
+  let clone = Agent.clone ~copy_context:true agent in
+  Context.set clone.context "key1" (`String "changed");
+  check bool "original key1 unchanged" true
+    (Context.get agent.context "key1" = Some (`String "val1"))
+
+(* ── 4. clone_state_independence ─────────────────────────────────── *)
+
+let test_clone_state_independence () =
+  Eio_main.run @@ fun env ->
+  let agent = make_agent env in
+  let clone = Agent.clone agent in
+  clone.state <- { clone.state with turn_count = 99 };
+  check int "original turn_count unchanged" 0 agent.state.turn_count
+
+(* ── 5. clone_preserves_messages ─────────────────────────────────── *)
+
+let test_clone_preserves_messages () =
+  Eio_main.run @@ fun env ->
+  let agent = make_agent env in
+  agent.state <- { agent.state with
+    messages = [{ Types.role = User; content = [Text "hello"] }] };
+  let clone = Agent.clone agent in
+  check int "clone has same messages" 1 (List.length clone.state.messages)
+
+(* ── 6. clone_preserves_turn_count ───────────────────────────────── *)
+
+let test_clone_preserves_turn_count () =
+  Eio_main.run @@ fun env ->
+  let agent = make_agent env in
+  agent.state <- { agent.state with turn_count = 7 };
+  let clone = Agent.clone agent in
+  check int "turn_count matches" 7 clone.state.turn_count
+
+(* ── 7. clone_preserves_usage ────────────────────────────────────── *)
+
+let test_clone_preserves_usage () =
+  Eio_main.run @@ fun env ->
+  let agent = make_agent env in
+  agent.state <- { agent.state with
+    usage = { Types.empty_usage with total_input_tokens = 100; api_calls = 3 } };
+  let clone = Agent.clone agent in
+  check int "input tokens match" 100 clone.state.usage.total_input_tokens;
+  check int "api calls match" 3 clone.state.usage.api_calls
+
+(* ── 8. clone_preserves_config ───────────────────────────────────── *)
+
+let test_clone_preserves_config () =
+  Eio_main.run @@ fun env ->
+  let agent = make_agent env in
+  let clone = Agent.clone agent in
+  check string "name" "original" clone.state.config.name;
+  check int "max_turns" 5 clone.state.config.max_turns
+
+(* ── 9. clone_shares_tools ───────────────────────────────────────── *)
+
+let test_clone_shares_tools () =
+  Eio_main.run @@ fun env ->
+  let tool = Tool.create ~name:"echo" ~description:"echo"
+    ~parameters:[] (fun _ -> Ok "ok") in
+  let agent = Agent.create ~net:env#net
+    ~config:Types.default_config ~tools:[tool] () in
+  let clone = Agent.clone agent in
+  check bool "tools physically identical" true (agent.tools == clone.tools)
+
+(* ── 10. clone_shares_options ────────────────────────────────────── *)
+
+let test_clone_shares_options () =
+  Eio_main.run @@ fun env ->
+  let agent = make_agent env in
+  let clone = Agent.clone agent in
+  check bool "options identical" true (agent.options == clone.options)
+
+(* ── 11. clone_state_divergence ──────────────────────────────────── *)
+
+let test_clone_state_divergence () =
+  Eio_main.run @@ fun env ->
+  let agent = make_agent env in
+  let clone = Agent.clone agent in
+  (* Mutate original *)
+  agent.state <- { agent.state with
+    turn_count = 10;
+    messages = [{ Types.role = User; content = [Text "original only"] }] };
+  (* Clone should be unaffected *)
+  check int "clone turn_count unchanged" 0 clone.state.turn_count;
+  check int "clone messages unchanged" 0 (List.length clone.state.messages)
+
+(* ── 12. clone_from_resumed_agent ────────────────────────────────── *)
+
+let test_clone_from_resumed_agent () =
+  Eio_main.run @@ fun env ->
+  let agent = make_agent env in
+  agent.state <- { agent.state with
+    turn_count = 3;
+    messages = [
+      { Types.role = User; content = [Text "msg1"] };
+      { Types.role = Assistant; content = [Text "reply1"] };
+    ] };
+  (* Simulate resume by creating checkpoint and restoring *)
+  let cp = Agent.checkpoint ~session_id:"s1" agent in
+  let resumed = Agent.resume ~net:env#net ~checkpoint:cp () in
+  let clone = Agent.clone ~copy_context:true resumed in
+  check int "clone turn_count from resumed" 3 clone.state.turn_count;
+  check int "clone messages from resumed" 2 (List.length clone.state.messages);
+  check string "clone config name" "original" clone.state.config.name
+
+(* ── Suite ────────────────────────────────────────────────────────── *)
+
+let () =
+  run "Agent.clone" [
+    "context", [
+      test_case "fresh context" `Quick test_clone_fresh_context;
+      test_case "copy context" `Quick test_clone_copy_context;
+      test_case "context independence" `Quick test_clone_context_independence;
+    ];
+    "state", [
+      test_case "state independence" `Quick test_clone_state_independence;
+      test_case "preserves messages" `Quick test_clone_preserves_messages;
+      test_case "preserves turn_count" `Quick test_clone_preserves_turn_count;
+      test_case "preserves usage" `Quick test_clone_preserves_usage;
+      test_case "preserves config" `Quick test_clone_preserves_config;
+    ];
+    "sharing", [
+      test_case "shares tools" `Quick test_clone_shares_tools;
+      test_case "shares options" `Quick test_clone_shares_options;
+    ];
+    "divergence", [
+      test_case "state divergence" `Quick test_clone_state_divergence;
+      test_case "from resumed agent" `Quick test_clone_from_resumed_agent;
+    ];
+  ]

--- a/test/test_context.ml
+++ b/test/test_context.ml
@@ -61,6 +61,27 @@ let test_of_json_non_assoc () =
   let ctx = Context.of_json (`String "invalid") in
   check (list string) "non-Assoc gives empty context" [] (Context.keys ctx)
 
+let test_copy_empty () =
+  let ctx = Context.create () in
+  let copy = Context.copy ctx in
+  check (list string) "copy of empty is empty" [] (Context.keys copy)
+
+let test_copy_values () =
+  let ctx = Context.create () in
+  Context.set ctx "a" (`String "hello");
+  Context.set ctx "b" (`Int 99);
+  let copy = Context.copy ctx in
+  check bool "a copied" true (Context.get copy "a" = Some (`String "hello"));
+  check bool "b copied" true (Context.get copy "b" = Some (`Int 99))
+
+let test_copy_independence () =
+  let ctx = Context.create () in
+  Context.set ctx "x" (`String "original");
+  let copy = Context.copy ctx in
+  Context.set copy "x" (`String "modified");
+  check bool "original unchanged" true
+    (Context.get ctx "x" = Some (`String "original"))
+
 let () =
   run "Context" [
     "create", [
@@ -81,5 +102,10 @@ let () =
       test_case "to_json" `Quick test_to_json;
       test_case "of_json roundtrip" `Quick test_of_json_roundtrip;
       test_case "of_json non-Assoc" `Quick test_of_json_non_assoc;
+    ];
+    "copy", [
+      test_case "copy empty" `Quick test_copy_empty;
+      test_case "copy values" `Quick test_copy_values;
+      test_case "copy independence" `Quick test_copy_independence;
     ];
   ]


### PR DESCRIPTION
## Summary

- `Context.copy`: shallow-copy all entries into a fresh Hashtbl (+4 LOC, 3 tests)
- `Agent.clone`: create independent agent with own mutable state, shared immutable resources (+14 LOC, 12 tests)
- `.mli` updated with `Context.copy` and `Agent.clone` signatures

## Design decisions

- **Context**: fresh by default, `~copy_context:true` for shallow copy. Yojson values are structurally immutable, so shallow copy gives full independence.
- **State**: new record via field copy. `mutable state` slot belongs to new `Agent.t`, so mutations are isolated.
- **Shared**: `tools`, `net`, `options`, `mcp_clients` are immutable/stateless or external connections — intentionally shared.

## Test plan

- [x] `test_clone.ml`: 12 tests covering context modes, state independence, config/usage/message preservation, tool/option sharing, divergence, resume-then-clone
- [x] `test_context.ml`: 3 new tests for `copy` (empty, values, independence)
- [x] `dune build @all` — 0 warnings, 0 errors
- [x] `dune runtest` — all 537+ tests pass

Part of v0.8.0 (PR 1/4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)