### PR TITLE
feat(event-bus): typed publish/subscribe for agent lifecycle events

### DIFF
--- a/lib/agent.ml
+++ b/lib/agent.ml
@@ -16,6 +16,7 @@ type options = {
   approval: Hooks.approval_callback option;
   context_reducer: Context_reducer.t option;
   mcp_clients: Mcp.managed list;
+  event_bus: Event_bus.t option;
 }
 
 let default_options = {
@@ -27,6 +28,7 @@ let default_options = {
   approval = None;
   context_reducer = None;
   mcp_clients = [];
+  event_bus = None;
 }
 
 type t = {
@@ -76,8 +78,13 @@ let close agent =
 (** Helper: find and execute a tool, invoke PostToolUse hook.
     Returns (id, content, is_error) triple. *)
 let find_and_execute_tool agent name input id =
+  (* ToolCalled event *)
+  (match agent.options.event_bus with
+   | Some bus -> Event_bus.publish bus
+       (ToolCalled { agent_name = agent.state.config.name; tool_name = name; input })
+   | None -> ());
   let tool_opt = List.find_opt (fun (tool: Tool.t) -> tool.schema.name = name) agent.tools in
-  match tool_opt with
+  let triple = match tool_opt with
   | Some tool ->
     let result = Tool.execute ~context:agent.context tool input in
     let _post = Hooks.invoke agent.options.hooks.post_tool_use
@@ -88,6 +95,16 @@ let find_and_execute_tool agent name input id =
     in
     (id, content, is_error)
   | None -> (id, "Tool not found", true)
+  in
+  (* ToolCompleted event *)
+  (match agent.options.event_bus with
+   | Some bus ->
+     let (_, content, is_error) = triple in
+     let output = if is_error then Error content else Ok content in
+     Event_bus.publish bus
+       (ToolCompleted { agent_name = agent.state.config.name; tool_name = name; output })
+   | None -> ());
+  triple
 
 (** Execute tools in parallel using Eio fibers.
     Applies PreToolUse/PostToolUse hooks and passes context to context-aware handlers.
@@ -131,6 +148,12 @@ let run_turn ~sw ?clock agent =
   let _before = Hooks.invoke agent.options.hooks.before_turn
     (Hooks.BeforeTurn { turn = agent.state.turn_count; messages = agent.state.messages }) in
 
+  (* TurnStarted event *)
+  (match agent.options.event_bus with
+   | Some bus -> Event_bus.publish bus
+       (TurnStarted { agent_name = agent.state.config.name; turn = agent.state.turn_count })
+   | None -> ());
+
   (* Apply guardrails: filter tools visible to LLM *)
   let visible_tools = Guardrails.filter_tools agent.options.guardrails agent.tools in
   let tool_schemas = List.map Tool.schema_to_json visible_tools in
@@ -164,6 +187,12 @@ let run_turn ~sw ?clock agent =
       (* AfterTurn hook *)
       let _after = Hooks.invoke agent.options.hooks.after_turn
         (Hooks.AfterTurn { turn = agent.state.turn_count; response }) in
+
+      (* TurnCompleted event *)
+      (match agent.options.event_bus with
+       | Some bus -> Event_bus.publish bus
+           (TurnCompleted { agent_name = agent.state.config.name; turn = agent.state.turn_count })
+       | None -> ());
 
       agent.state <- { agent.state with
         messages = agent.state.messages @ [{ role = Assistant; content = response.content }];
@@ -245,6 +274,12 @@ let run_turn_stream ~sw ?clock ~on_event agent =
   let _before = Hooks.invoke agent.options.hooks.before_turn
     (Hooks.BeforeTurn { turn = agent.state.turn_count; messages = agent.state.messages }) in
 
+  (* TurnStarted event *)
+  (match agent.options.event_bus with
+   | Some bus -> Event_bus.publish bus
+       (TurnStarted { agent_name = agent.state.config.name; turn = agent.state.turn_count })
+   | None -> ());
+
   (* Apply guardrails: filter tools visible to LLM *)
   let visible_tools = Guardrails.filter_tools agent.options.guardrails agent.tools in
   let tool_schemas = List.map Tool.schema_to_json visible_tools in
@@ -301,6 +336,12 @@ let run_turn_stream ~sw ?clock ~on_event agent =
     (* AfterTurn hook *)
     let _after = Hooks.invoke agent.options.hooks.after_turn
       (Hooks.AfterTurn { turn = agent.state.turn_count; response }) in
+
+    (* TurnCompleted event *)
+    (match agent.options.event_bus with
+     | Some bus -> Event_bus.publish bus
+         (TurnCompleted { agent_name = agent.state.config.name; turn = agent.state.turn_count })
+     | None -> ());
 
     agent.state <- { agent.state with
       messages = agent.state.messages @ [{ role = Assistant; content = response.content }];

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -48,6 +48,7 @@ module Mcp = Mcp
 module Mcp_bridge = Mcp_bridge
 module Mcp_session = Mcp_session
 module Guardrails = Guardrails
+module Event_bus = Event_bus
 module Skill = Skill
 module Handoff = Handoff
 module Api = Api

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -830,38 +830,6 @@ module Mcp_session : sig
   val info_list_of_json : Yojson.Safe.t -> (info list, string) result
 end
 
-(** {1 MCP Session Persistence} *)
-
-module Mcp_session : sig
-  (** Serializable MCP session info for checkpoint/resume.
-      Captures server specification and discovered tool schemas.
-      Live connections cannot be serialized — use {!reconnect_all}
-      on resume to re-establish them. *)
-
-  type info = {
-    server_name: string;
-    command: string;
-    args: string list;
-    env: (string * string) list;
-    tool_schemas: Types.tool_schema list;
-  }
-
-  val capture : Mcp.managed -> info
-  val capture_all : Mcp.managed list -> info list
-  val to_server_spec : info -> Mcp.server_spec
-
-  (** Reconnect to MCP servers from saved session info.
-      Returns [(connected, failed)].  Failed connections do not abort others. *)
-  val reconnect_all :
-    sw:Eio.Switch.t -> mgr:_ Eio.Process.mgr ->
-    info list -> Mcp.managed list * info list
-
-  val info_to_json : info -> Yojson.Safe.t
-  val info_of_json : Yojson.Safe.t -> (info, string) result
-  val info_list_to_json : info list -> Yojson.Safe.t
-  val info_list_of_json : Yojson.Safe.t -> (info list, string) result
-end
-
 (** {1 Checkpoint} *)
 
 module Checkpoint : sig
@@ -942,6 +910,56 @@ module Session : sig
   val of_json : Yojson.Safe.t -> (t, string) result
 end
 
+(** {1 Event Bus} *)
+
+module Event_bus : sig
+  (** Typed publish/subscribe for agent lifecycle events.
+      Each subscriber gets its own bounded {!Eio.Stream.t}; [publish] copies
+      each event to every matching subscriber. *)
+
+  (** Lifecycle event variants. *)
+  type event =
+    | AgentStarted of { agent_name: string; task_id: string }
+    | AgentCompleted of { agent_name: string; task_id: string;
+                          result: (Types.api_response, string) result; elapsed: float }
+    | ToolCalled of { agent_name: string; tool_name: string; input: Yojson.Safe.t }
+    | ToolCompleted of { agent_name: string; tool_name: string;
+                         output: (string, string) result }
+    | TurnStarted of { agent_name: string; turn: int }
+    | TurnCompleted of { agent_name: string; turn: int }
+    | Custom of string * Yojson.Safe.t
+
+  (** Predicate for filtering events. *)
+  type filter = event -> bool
+
+  (** A subscription handle with its own buffered stream. *)
+  type subscription = {
+    id: int;
+    stream: event Eio.Stream.t;
+    filter: filter;
+  }
+
+  (** The event bus instance. All state is internal — no globals. *)
+  type t
+
+  val create : ?buffer_size:int -> unit -> t
+  val subscribe : ?filter:filter -> t -> subscription
+  val unsubscribe : t -> subscription -> unit
+  val publish : t -> event -> unit
+
+  (** Drain all buffered events from a subscription (non-blocking). *)
+  val drain : subscription -> event list
+
+  (** Number of active subscribers. *)
+  val subscriber_count : t -> int
+
+  (** {2 Built-in filters} *)
+
+  val accept_all : filter
+  val filter_agent : string -> filter
+  val filter_tools_only : filter
+end
+
 (** {1 Agent} *)
 
 module Agent : sig
@@ -957,6 +975,7 @@ module Agent : sig
     approval: Hooks.approval_callback option;
     context_reducer: Context_reducer.t option;
     mcp_clients: Mcp.managed list;
+    event_bus: Event_bus.t option;
   }
 
   val default_options : options
@@ -1094,6 +1113,7 @@ module Builder : sig
   val with_max_total_tokens : int -> t -> t
   val with_response_format_json : bool -> t -> t
   val with_cache_system_prompt : bool -> t -> t
+  val with_event_bus : Event_bus.t -> t -> t
   val build : t -> Agent.t
 end
 
@@ -1136,6 +1156,7 @@ module Orchestrator : sig
     on_task_start: (task -> unit) option;
     on_task_complete: (task_result -> unit) option;
     timeout_per_task: float option;
+    event_bus: Event_bus.t option;
   }
 
   val default_config : config

--- a/lib/builder.ml
+++ b/lib/builder.ml
@@ -27,6 +27,7 @@ type t = {
   approval: Hooks.approval_callback option;
   context_reducer: Context_reducer.t option;
   mcp_clients: Mcp.managed list;
+  event_bus: Event_bus.t option;
 }
 
 let create ~net ~model =
@@ -53,6 +54,7 @@ let create ~net ~model =
     approval = None;
     context_reducer = None;
     mcp_clients = [];
+    event_bus = None;
   }
 
 let with_system_prompt prompt b = { b with system_prompt = Some prompt }
@@ -77,6 +79,7 @@ let with_max_input_tokens n b = { b with max_input_tokens = Some n }
 let with_max_total_tokens n b = { b with max_total_tokens = Some n }
 let with_response_format_json v b = { b with response_format_json = v }
 let with_cache_system_prompt v b = { b with cache_system_prompt = v }
+let with_event_bus bus b = { b with event_bus = Some bus }
 
 let build b =
   let config = {
@@ -102,5 +105,6 @@ let build b =
     approval = b.approval;
     context_reducer = b.context_reducer;
     mcp_clients = b.mcp_clients;
+    event_bus = b.event_bus;
   } in
   Agent.create ~net:b.net ~config ~tools:b.tools ?context:b.context ~options ()

--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -1,0 +1,117 @@
+(** Agent Event Bus — typed publish/subscribe for agent lifecycle events.
+
+    Each subscriber gets its own bounded {!Eio.Stream.t}; [publish] copies
+    each event to every matching subscriber.  Filters allow subscribers to
+    receive only the events they care about (e.g. one agent, tools only).
+
+    All state is internal to [t] — no globals.  GC collects everything
+    when the bus goes out of scope. *)
+
+open Types
+
+(* ── Event type ────────────────────────────────────────────────────── *)
+
+type event =
+  | AgentStarted of { agent_name: string; task_id: string }
+  | AgentCompleted of { agent_name: string; task_id: string;
+                        result: (api_response, string) result; elapsed: float }
+  | ToolCalled of { agent_name: string; tool_name: string; input: Yojson.Safe.t }
+  | ToolCompleted of { agent_name: string; tool_name: string;
+                       output: (string, string) result }
+  | TurnStarted of { agent_name: string; turn: int }
+  | TurnCompleted of { agent_name: string; turn: int }
+  | Custom of string * Yojson.Safe.t
+
+(* ── Subscription ──────────────────────────────────────────────────── *)
+
+type filter = event -> bool
+
+type subscription = {
+  id: int;
+  stream: event Eio.Stream.t;
+  filter: filter;
+}
+
+(* ── Bus ───────────────────────────────────────────────────────────── *)
+
+type t = {
+  mutable subscribers: subscription list;
+  mutable next_id: int;
+  mu: Eio.Mutex.t;
+  buffer_size: int;
+}
+
+let create ?(buffer_size = 256) () = {
+  subscribers = [];
+  next_id = 0;
+  mu = Eio.Mutex.create ();
+  buffer_size;
+}
+
+(* ── Filters ───────────────────────────────────────────────────────── *)
+
+let accept_all : filter = fun _ -> true
+
+let filter_agent name : filter = fun event ->
+  let n = match event with
+    | AgentStarted r -> r.agent_name
+    | AgentCompleted r -> r.agent_name
+    | ToolCalled r -> r.agent_name
+    | ToolCompleted r -> r.agent_name
+    | TurnStarted r -> r.agent_name
+    | TurnCompleted r -> r.agent_name
+    | Custom _ -> ""
+  in
+  n = name
+
+let filter_tools_only : filter = function
+  | ToolCalled _ | ToolCompleted _ -> true
+  | _ -> false
+
+(* ── Subscribe / unsubscribe ───────────────────────────────────────── *)
+
+let subscribe ?(filter = accept_all) bus =
+  Eio.Mutex.lock bus.mu;
+  let id = bus.next_id in
+  let sub = { id; stream = Eio.Stream.create bus.buffer_size; filter } in
+  bus.subscribers <- sub :: bus.subscribers;
+  bus.next_id <- id + 1;
+  Eio.Mutex.unlock bus.mu;
+  sub
+
+let unsubscribe bus sub =
+  Eio.Mutex.lock bus.mu;
+  bus.subscribers <- List.filter (fun s -> s.id <> sub.id) bus.subscribers;
+  Eio.Mutex.unlock bus.mu
+
+(* ── Publish ───────────────────────────────────────────────────────── *)
+
+let publish bus event =
+  (* Snapshot subscriber list under lock, then deliver outside lock.
+     Stream.add can block on a full stream — holding the lock would
+     deadlock if another fiber tries to subscribe concurrently. *)
+  Eio.Mutex.lock bus.mu;
+  let subs = bus.subscribers in
+  Eio.Mutex.unlock bus.mu;
+  List.iter (fun sub ->
+    if sub.filter event then
+      Eio.Stream.add sub.stream event
+  ) subs
+
+(* ── Drain ─────────────────────────────────────────────────────────── *)
+
+let drain sub =
+  let rec collect acc =
+    match Eio.Stream.take_nonblocking sub.stream with
+    | Some event -> collect (event :: acc)
+    | None -> List.rev acc
+  in
+  collect []
+
+(* ── Queries ───────────────────────────────────────────────────────── *)
+
+let subscriber_count bus =
+  Eio.Mutex.lock bus.mu;
+  let n = List.length bus.subscribers in
+  Eio.Mutex.unlock bus.mu;
+  n

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -33,6 +33,7 @@ type config = {
   on_task_start: (task -> unit) option;
   on_task_complete: (task_result -> unit) option;
   timeout_per_task: float option;
+  event_bus: Event_bus.t option;
 }
 
 let default_config = {
@@ -41,6 +42,7 @@ let default_config = {
   on_task_start = None;
   on_task_complete = None;
   timeout_per_task = None;
+  event_bus = None;
 }
 
 type t = {
@@ -83,6 +85,11 @@ let run_agent_with_timeout ~sw ?clock config agent prompt =
 
 let run_task ~sw ?clock orch task =
   Option.iter (fun cb -> cb task) orch.config.on_task_start;
+  (* AgentStarted event *)
+  (match orch.config.event_bus with
+   | Some bus -> Event_bus.publish bus
+       (AgentStarted { agent_name = task.agent_name; task_id = task.id })
+   | None -> ());
   let t0 = Unix.gettimeofday () in
   let result =
     match find_agent orch task.agent_name with
@@ -98,6 +105,12 @@ let run_task ~sw ?clock orch task =
   in
   let elapsed = Unix.gettimeofday () -. t0 in
   let tr = { task_id = task.id; agent_name = task.agent_name; result; elapsed } in
+  (* AgentCompleted event *)
+  (match orch.config.event_bus with
+   | Some bus -> Event_bus.publish bus
+       (AgentCompleted { agent_name = task.agent_name; task_id = task.id;
+                         result; elapsed })
+   | None -> ());
   Option.iter (fun cb -> cb tr) orch.config.on_task_complete;
   tr
 

--- a/test/dune
+++ b/test/dune
@@ -152,5 +152,9 @@
  (libraries agent_sdk alcotest yojson eio eio_main unix))
 
 (test
+ (name test_event_bus)
+ (libraries agent_sdk alcotest yojson eio eio_main))
+
+(test
  (name test_otel)
  (libraries agent_sdk alcotest yojson))

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -1,0 +1,225 @@
+(** Tests for Event_bus — typed publish/subscribe for agent lifecycle events. *)
+
+open Alcotest
+open Agent_sdk
+
+(* ── Helpers ──────────────────────────────────────────────────────── *)
+
+let mock_response text = {
+  Types.id = "r-1"; model = "mock"; stop_reason = Types.EndTurn;
+  content = [Types.Text text]; usage = None;
+}
+
+(* ── create ───────────────────────────────────────────────────────── *)
+
+let test_create_default () =
+  let bus = Event_bus.create () in
+  check int "no subscribers" 0 (Event_bus.subscriber_count bus)
+
+let test_create_custom_buffer () =
+  let bus = Event_bus.create ~buffer_size:8 () in
+  check int "no subscribers" 0 (Event_bus.subscriber_count bus)
+
+(* ── subscribe / unsubscribe ──────────────────────────────────────── *)
+
+let test_subscribe_count () =
+  let bus = Event_bus.create () in
+  let _sub = Event_bus.subscribe bus in
+  check int "one subscriber" 1 (Event_bus.subscriber_count bus)
+
+let test_unsubscribe_count () =
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  Event_bus.unsubscribe bus sub;
+  check int "zero after unsub" 0 (Event_bus.subscriber_count bus)
+
+(* ── publish / drain ──────────────────────────────────────────────── *)
+
+let test_publish_received () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  Event_bus.publish bus (TurnStarted { agent_name = "a"; turn = 0 });
+  let events = Event_bus.drain sub in
+  check int "one event" 1 (List.length events)
+
+let test_publish_multiple_subscribers () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub1 = Event_bus.subscribe bus in
+  let sub2 = Event_bus.subscribe bus in
+  Event_bus.publish bus (TurnStarted { agent_name = "a"; turn = 0 });
+  let e1 = Event_bus.drain sub1 in
+  let e2 = Event_bus.drain sub2 in
+  check int "sub1 got event" 1 (List.length e1);
+  check int "sub2 got event" 1 (List.length e2)
+
+let test_unsubscribed_no_receive () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  Event_bus.unsubscribe bus sub;
+  Event_bus.publish bus (TurnStarted { agent_name = "a"; turn = 0 });
+  let events = Event_bus.drain sub in
+  check int "no events after unsub" 0 (List.length events)
+
+(* ── drain ────────────────────────────────────────────────────────── *)
+
+let test_drain_fifo () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  Event_bus.publish bus (TurnStarted { agent_name = "a"; turn = 0 });
+  Event_bus.publish bus (TurnStarted { agent_name = "a"; turn = 1 });
+  Event_bus.publish bus (TurnStarted { agent_name = "a"; turn = 2 });
+  let events = Event_bus.drain sub in
+  check int "three events" 3 (List.length events);
+  (* Verify FIFO order *)
+  (match events with
+   | [TurnStarted r0; TurnStarted r1; TurnStarted r2] ->
+     check int "first turn" 0 r0.turn;
+     check int "second turn" 1 r1.turn;
+     check int "third turn" 2 r2.turn
+   | _ -> fail "unexpected event types")
+
+let test_drain_empty () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  let events = Event_bus.drain sub in
+  check int "no events" 0 (List.length events)
+
+(* ── filters ──────────────────────────────────────────────────────── *)
+
+let test_filter_agent_name () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe ~filter:(Event_bus.filter_agent "alpha") bus in
+  Event_bus.publish bus (TurnStarted { agent_name = "alpha"; turn = 0 });
+  Event_bus.publish bus (TurnStarted { agent_name = "beta"; turn = 0 });
+  Event_bus.publish bus (TurnCompleted { agent_name = "alpha"; turn = 0 });
+  let events = Event_bus.drain sub in
+  check int "only alpha events" 2 (List.length events)
+
+let test_filter_tools_only () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe ~filter:Event_bus.filter_tools_only bus in
+  Event_bus.publish bus (TurnStarted { agent_name = "a"; turn = 0 });
+  Event_bus.publish bus (ToolCalled { agent_name = "a"; tool_name = "calc"; input = `Null });
+  Event_bus.publish bus (ToolCompleted { agent_name = "a"; tool_name = "calc"; output = Ok "42" });
+  Event_bus.publish bus (TurnCompleted { agent_name = "a"; turn = 0 });
+  let events = Event_bus.drain sub in
+  check int "only tool events" 2 (List.length events)
+
+let test_accept_all () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe ~filter:Event_bus.accept_all bus in
+  Event_bus.publish bus (TurnStarted { agent_name = "a"; turn = 0 });
+  Event_bus.publish bus (ToolCalled { agent_name = "a"; tool_name = "x"; input = `Null });
+  Event_bus.publish bus (Custom ("test", `Null));
+  let events = Event_bus.drain sub in
+  check int "all three events" 3 (List.length events)
+
+(* ── event types ──────────────────────────────────────────────────── *)
+
+let test_custom_event () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  let payload = `Assoc [("key", `String "value")] in
+  Event_bus.publish bus (Custom ("my_event", payload));
+  let events = Event_bus.drain sub in
+  check int "one event" 1 (List.length events);
+  match events with
+  | [Custom (name, _)] -> check string "event name" "my_event" name
+  | _ -> fail "expected Custom event"
+
+let test_multiple_event_types () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  Event_bus.publish bus (AgentStarted { agent_name = "a"; task_id = "t1" });
+  Event_bus.publish bus (TurnStarted { agent_name = "a"; turn = 0 });
+  Event_bus.publish bus (ToolCalled { agent_name = "a"; tool_name = "f"; input = `Null });
+  Event_bus.publish bus (ToolCompleted { agent_name = "a"; tool_name = "f"; output = Ok "ok" });
+  Event_bus.publish bus (TurnCompleted { agent_name = "a"; turn = 0 });
+  Event_bus.publish bus (AgentCompleted { agent_name = "a"; task_id = "t1";
+                                          result = Ok (mock_response "done"); elapsed = 0.1 });
+  let events = Event_bus.drain sub in
+  check int "six events" 6 (List.length events)
+
+(* ── field access ─────────────────────────────────────────────────── *)
+
+let test_agent_started_fields () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  Event_bus.publish bus (AgentStarted { agent_name = "worker"; task_id = "t-42" });
+  match Event_bus.drain sub with
+  | [AgentStarted r] ->
+    check string "agent_name" "worker" r.agent_name;
+    check string "task_id" "t-42" r.task_id
+  | _ -> fail "expected AgentStarted"
+
+let test_tool_called_fields () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  let input = `Assoc [("x", `Int 1)] in
+  Event_bus.publish bus (ToolCalled { agent_name = "a"; tool_name = "calc"; input });
+  match Event_bus.drain sub with
+  | [ToolCalled r] ->
+    check string "agent_name" "a" r.agent_name;
+    check string "tool_name" "calc" r.tool_name;
+    check string "input json" {|{"x":1}|} (Yojson.Safe.to_string r.input)
+  | _ -> fail "expected ToolCalled"
+
+let test_turn_started_fields () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  Event_bus.publish bus (TurnStarted { agent_name = "bot"; turn = 5 });
+  match Event_bus.drain sub with
+  | [TurnStarted r] ->
+    check string "agent_name" "bot" r.agent_name;
+    check int "turn" 5 r.turn
+  | _ -> fail "expected TurnStarted"
+
+(* ── Suite ────────────────────────────────────────────────────────── *)
+
+let () =
+  run "Event_bus" [
+    "create", [
+      test_case "default" `Quick test_create_default;
+      test_case "custom buffer" `Quick test_create_custom_buffer;
+    ];
+    "subscribe", [
+      test_case "count" `Quick test_subscribe_count;
+      test_case "unsubscribe" `Quick test_unsubscribe_count;
+    ];
+    "publish", [
+      test_case "received" `Quick test_publish_received;
+      test_case "multiple subscribers" `Quick test_publish_multiple_subscribers;
+      test_case "unsubscribed no receive" `Quick test_unsubscribed_no_receive;
+    ];
+    "drain", [
+      test_case "fifo order" `Quick test_drain_fifo;
+      test_case "empty" `Quick test_drain_empty;
+    ];
+    "filters", [
+      test_case "agent name" `Quick test_filter_agent_name;
+      test_case "tools only" `Quick test_filter_tools_only;
+      test_case "accept all" `Quick test_accept_all;
+    ];
+    "event_types", [
+      test_case "custom" `Quick test_custom_event;
+      test_case "multiple types" `Quick test_multiple_event_types;
+    ];
+    "fields", [
+      test_case "agent_started" `Quick test_agent_started_fields;
+      test_case "tool_called" `Quick test_tool_called_fields;
+      test_case "turn_started" `Quick test_turn_started_fields;
+    ];
+  ]

--- a/test/test_orchestrator.ml
+++ b/test/test_orchestrator.ml
@@ -332,6 +332,52 @@ let test_task_fields () =
   check string "prompt" "do something" task.prompt;
   check string "agent_name" "worker" task.agent_name
 
+(* ── event_bus ───────────────────────────────────────────────────── *)
+
+let test_event_bus_config_none () =
+  check bool "default event_bus is None" true
+    (Option.is_none Orchestrator.default_config.event_bus)
+
+let test_event_bus_receives_started () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  let cfg = { Orchestrator.default_config with event_bus = Some bus } in
+  let orch = Orchestrator.create ~config:cfg [] in
+  let task : Orchestrator.task =
+    { id = "eb-1"; prompt = "hi"; agent_name = "ghost" }
+  in
+  let _tr = Orchestrator.run_task ~sw orch task in
+  let events = Event_bus.drain sub in
+  (* Should have AgentStarted + AgentCompleted *)
+  check bool "has events" true (List.length events >= 2);
+  match List.hd events with
+  | AgentStarted r ->
+    check string "agent_name" "ghost" r.agent_name;
+    check string "task_id" "eb-1" r.task_id
+  | _ -> fail "expected AgentStarted first"
+
+let test_event_bus_receives_completed () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  let cfg = { Orchestrator.default_config with event_bus = Some bus } in
+  let orch = Orchestrator.create ~config:cfg [] in
+  let task : Orchestrator.task =
+    { id = "eb-2"; prompt = "hi"; agent_name = "phantom" }
+  in
+  let _tr = Orchestrator.run_task ~sw orch task in
+  let events = Event_bus.drain sub in
+  let last = List.nth events (List.length events - 1) in
+  match last with
+  | AgentCompleted r ->
+    check string "agent_name" "phantom" r.agent_name;
+    check string "task_id" "eb-2" r.task_id;
+    check bool "result is error (unknown agent)" true (Result.is_error r.result)
+  | _ -> fail "expected AgentCompleted last"
+
 (* ── Suite ────────────────────────────────────────────────────────── *)
 
 let () =
@@ -394,5 +440,10 @@ let () =
       test_case "unknown agent" `Quick test_run_task_unknown_agent;
       test_case "callbacks called" `Quick test_run_task_unknown_agent_callbacks_called;
       test_case "elapsed nonneg" `Quick test_run_task_elapsed_nonnegative;
+    ];
+    "event_bus", [
+      test_case "config none" `Quick test_event_bus_config_none;
+      test_case "receives started" `Quick test_event_bus_receives_started;
+      test_case "receives completed" `Quick test_event_bus_receives_completed;
     ];
   ]


### PR DESCRIPTION
## Summary
- Add `Event_bus` module: Eio.Stream-based per-subscriber event delivery with typed variants and predicate filters
- 7 event types: `AgentStarted`, `AgentCompleted`, `ToolCalled`, `ToolCompleted`, `TurnStarted`, `TurnCompleted`, `Custom`
- 3 built-in filters: `filter_agent`, `filter_tools_only`, `accept_all`
- Integrated into `Agent.options`, `Orchestrator.config`, and `Builder.with_event_bus`
- Agent publishes Turn/Tool events from `run_turn`, `run_turn_stream`, `find_and_execute_tool`
- Orchestrator publishes Agent lifecycle events from `run_task`

## Design decisions
- Eio.Stream per subscriber (bounded, 256 default) — backpressure on slow consumers
- Snapshot pattern in `publish`: lock → copy subscriber list → unlock → deliver (prevents deadlock when Stream.add blocks)
- Hooks vs Event Bus separation: hooks are synchronous behavior control, event bus is asynchronous external observation
- No global state: everything inside `Event_bus.t`, GC-collected

## Files changed
| File | Change |
|------|--------|
| `lib/event_bus.ml` | New: core module (~117 LOC) |
| `lib/agent.ml` | +43: event_bus in options, Turn/Tool event publishing |
| `lib/orchestrator.ml` | +13: event_bus in config, Agent lifecycle publishing |
| `lib/builder.ml` | +4: event_bus field + with_event_bus |
| `lib/agent_sdk.ml` | +1: module re-export |
| `lib/agent_sdk.mli` | +53: Event_bus sig, options/config updates |
| `test/test_event_bus.ml` | New: 17 tests (create, subscribe, publish, drain, filters, event_types, fields) |
| `test/test_orchestrator.ml` | +51: 3 event_bus integration tests |
| `test/dune` | +4: test_event_bus entry |

## Test plan
- [x] `dune build --root .` — 0 warnings, 0 errors
- [x] `dune runtest --root .` — 557 tests, 0 failures
- [ ] GLM-5 external review

🤖 Generated with [Claude Code](https://claude.com/claude-code)