### PR TITLE
fix: address v0.8.1 review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to `agent_sdk` are documented in this file.
 
 ### Changed (breaking)
 - `Mcp_session.reconnect_all`: return type changed from `Mcp.managed list * info list` to `Mcp.managed list * (info * string) list` — callers matching on the second element need to destructure the `(info, error_msg)` pair
+- `Event_bus.filter_agent`: `Custom` events now pass through all agent-scoped filters (previously silently dropped because `Custom` had no `agent_name` field)
 
 ## [0.8.0] - 2026-03-11
 

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -957,6 +957,8 @@ module Event_bus : sig
   (** {2 Built-in filters} *)
 
   val accept_all : filter
+  (** Match events whose [agent_name] equals the given name.
+      [Custom] events always pass (they have no agent scope). *)
   val filter_agent : string -> filter
   val filter_tools_only : filter
 end

--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -69,9 +69,10 @@ let filter_tools_only : filter = function
 (* ── Subscribe / unsubscribe ───────────────────────────────────────── *)
 
 let subscribe ?(filter = accept_all) bus =
+  let stream = Eio.Stream.create bus.buffer_size in
   Eio.Mutex.use_rw ~protect:true bus.mu (fun () ->
     let id = bus.next_id in
-    let sub = { id; stream = Eio.Stream.create bus.buffer_size; filter } in
+    let sub = { id; stream; filter } in
     bus.subscribers <- sub :: bus.subscribers;
     bus.next_id <- id + 1;
     sub)

--- a/lib/mcp_session.ml
+++ b/lib/mcp_session.ml
@@ -12,7 +12,10 @@
       (* ... serialize infos into checkpoint JSON ... *)
 
       (* On resume *)
-      let managed, failed = Mcp_session.reconnect_all ~sw ~mgr infos in
+      let managed, failed_with_reasons = Mcp_session.reconnect_all ~sw ~mgr infos in
+      List.iter (fun (info, err) ->
+        Printf.eprintf "Failed to reconnect %s: %s\n" info.server_name err
+      ) failed_with_reasons;
     ]} *)
 
 open Types


### PR DESCRIPTION
## Summary
- `mcp_session.ml`: update lifecycle doc example to match new `(info * string) list` return type
- `event_bus.ml`: move `Eio.Stream.create` outside mutex critical section (narrower lock scope)
- `CHANGELOG`: document `filter_agent` Custom event behavior change as breaking
- `agent_sdk.mli`: add doc comment for `filter_agent` Custom passthrough contract

Follow-up to PR #43. Both self-review and external review flagged these 4 items.

## Test plan
- [x] `dune build --root .` — 0 warnings
- [x] `dune runtest --root . --force` — 586 tests, 0 failures

Generated with [Claude Code](https://claude.com/claude-code)