### PR TITLE
feat: add harness-first runtime sdk layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agent-sdk
 
-OCaml 5.x + Eio 기반 LLM Agent SDK. Anthropic Messages API와 OpenAI-compatible local LLM 엔드포인트를 지원한다.
+OCaml 5.x + Eio 기반 agent runtime SDK. Anthropic Messages API와 OpenAI-compatible local LLM 엔드포인트를 지원하며, `query` / `Client` public API 뒤에 bundled subprocess runtime을 두는 구조를 제공한다.
 
 - OCaml 패키지 이름: `agent_sdk`
 - OCaml 모듈 이름: `Agent_sdk`
@@ -8,10 +8,15 @@ OCaml 5.x + Eio 기반 LLM Agent SDK. Anthropic Messages API와 OpenAI-compatibl
 ## 아키텍처
 
 ```
-Provider  ->  API  ->  Agent  ->  Tool
-(endpoint)   (HTTP)   (loop)    (functions)
-               |
-            Streaming (SSE)
+Public SDK (`query` / `Client`)
+           |
+      Transport
+           |
+  Bundled `oas-runtime`
+           |
+ Runtime journal + projection
+           |
+ Provider  ->  API  ->  Agent  ->  Tool
 ```
 
 | 모듈 | 역할 |
@@ -19,6 +24,9 @@ Provider  ->  API  ->  Agent  ->  Tool
 | `Types` | 메시지, 역할, stop_reason, content_block (Text/Thinking/Image/Document), SSE event 등 도메인 타입 |
 | `Provider` | LLM 엔드포인트 추상화 (Local / Anthropic / OpenAICompat) |
 | `Api` | HTTP 클라이언트 -- `create_message` (동기) + `create_message_stream` (SSE) |
+| `Runtime` | 세션/이벤트/명령/리포트/증명 타입을 정의하는 런타임 프로토콜 |
+| `Transport` | `oas-runtime` subprocess transport와 runtime binary 탐색 |
+| `Client` | persistent runtime client (`connect`, `start_session`, `apply_command`, `status`, `finalize`) |
 | `Agent` | 멀티턴 에이전트 루프 (tool_use 자동 처리) |
 | `Tool` | 도구 정의 + JSON Schema 생성 + 실행 (Simple / WithContext) |
 | `Retry` | 구조적 API 에러 분류 (7 variant) + exponential backoff with jitter |
@@ -67,6 +75,118 @@ let openrouter_cfg = Provider.openrouter ~model_id:"anthropic/claude-sonnet-4-6"
 `Provider.resolve`는 `(base_url * api_key * headers, error_msg) result`를 반환한다. 환경변수가 없으면 `Error`를 반환하며, silent fallback 없음.
 
 ## 사용법
+
+### One-shot Query
+
+```ocaml
+open Agent_sdk
+
+let () =
+  match
+    query
+      ~options:
+        {
+          Client.default_options with
+          session_root = Some "./.oas-runtime-demo";
+          provider = Some "mock";
+          agents =
+            [
+              ( "planner",
+                {
+                  Client.description = "planner";
+                  prompt = "Break the problem into steps.";
+                  tools = None;
+                  model = None;
+                } );
+            ];
+        }
+      ~prompt:"Coordinate a small runtime task"
+      ()
+  with
+  | Ok messages ->
+      Printf.printf "Collected %d runtime messages\n" (List.length messages)
+  | Error err ->
+      Printf.eprintf "Query failed: %s\n" (Error.to_string err)
+```
+
+### Interactive Client
+
+```ocaml
+open Agent_sdk
+
+let () =
+  match
+    Client.connect
+      ~options:
+        {
+          Client.default_options with
+          session_root = Some "./.oas-runtime-demo";
+          provider = Some "mock";
+          agents =
+            [
+              ( "reviewer",
+                {
+                  Client.description = "reviewer";
+                  prompt = "Review the user request carefully.";
+                  tools = None;
+                  model = None;
+                } );
+            ];
+        }
+      ()
+  with
+  | Error err -> prerr_endline (Error.to_string err)
+  | Ok client ->
+      Fun.protect
+        ~finally:(fun () -> Client.close client)
+        (fun () ->
+          match Client.query client "Review this runtime setup" with
+          | Error err -> prerr_endline (Error.to_string err)
+          | Ok () ->
+              ignore (Client.finalize client ());
+              let messages = Client.receive_messages client in
+              Printf.printf "Received %d buffered messages\n"
+                (List.length messages))
+```
+
+### Session Helpers
+
+```ocaml
+open Agent_sdk
+
+let () =
+  match Sessions.list_sessions ~session_root:"./.oas-runtime-demo" () with
+  | Ok infos -> Printf.printf "Known sessions: %d\n" (List.length infos)
+  | Error err -> prerr_endline (Error.to_string err)
+```
+
+### Advanced Runtime Access
+
+```ocaml
+open Agent_sdk
+
+let request =
+  Runtime.Start_session
+    {
+      session_id = Some "demo-session";
+      goal = "Coordinate a small runtime task";
+      participants = [ "planner"; "builder" ];
+      provider = Some "mock";
+      model = None;
+      system_prompt = Some "Coordinate the team carefully.";
+      max_turns = Some 3;
+      workdir = None;
+    }
+
+let () =
+  match runtime_query ~session_root:"./.oas-runtime-demo" request with
+  | Ok (Runtime.Session_started_response session) ->
+      Printf.printf "Started %s\n" session.session_id
+  | Ok other ->
+      Printf.eprintf "Unexpected response: %s\n" (Runtime.show_response other)
+  | Error err ->
+      Printf.eprintf "Runtime error: %s\n" (Error.to_string err)
+```
 
 ### 기본 에이전트
 
@@ -188,6 +308,9 @@ let stateful_tool = Tool.create_with_context
 
 ```bash
 dune build @all
+
+# runtime binary
+_build/default/bin/oas_runtime.exe
 ```
 
 ## 테스트
@@ -195,6 +318,9 @@ dune build @all
 ```bash
 # 단위 테스트
 dune runtest
+
+# runtime query/client vertical slice
+dune exec ./test/test_runtime.exe
 
 # 통합 테스트 (로컬 LLM 서버 필요)
 LLAMA_LIVE_TEST=1 dune exec ./test/test_local_llm.exe

--- a/_bundled/.gitignore
+++ b/_bundled/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+

--- a/bin/dune
+++ b/bin/dune
@@ -1,0 +1,5 @@
+(executable
+ (name oas_runtime)
+ (public_name oas-runtime)
+ (libraries agent_sdk eio eio_main yojson unix))
+

--- a/bin/oas_runtime.ml
+++ b/bin/oas_runtime.ml
@@ -1,0 +1,4 @@
+let () =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  Agent_sdk__Runtime_server.serve_stdio ~net ()

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -62,6 +62,11 @@ module Agent = Agent
 module Builder = Builder
 module Orchestrator = Orchestrator
 module Otel_tracer = Otel_tracer
+module Runtime = Runtime
+module Transport = Transport
+module Runtime_client = Runtime_client
+module Client = Client
+module Sessions = Sessions
 
 (** Quick start: create an agent with default config *)
 let create_agent ~net ?name ?model ?system_prompt ?max_tokens ?max_turns ?cache_system_prompt ?provider () =
@@ -81,6 +86,9 @@ let create_agent ~net ?name ?model ?system_prompt ?max_tokens ?max_turns ?cache_
     | Some p -> { Agent.default_options with provider = Some p }
   in
   Agent.create ~net ~config ~options ()
+
+let runtime_query = Runtime_query.query
+let query = Query.query
 
 (** Version info *)
 let version = "0.9.0"

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -1214,6 +1214,538 @@ module Otel_tracer : sig
   val create : ?config:config -> unit -> Tracing.t
 end
 
+module Runtime : sig
+  type phase =
+    | Bootstrapping
+    | Running
+    | Waiting_on_workers
+    | Finalizing
+    | Completed
+    | Failed
+    | Cancelled
+  [@@deriving yojson, show]
+
+  type participant_state =
+    | Planned
+    | Starting
+    | Live
+    | Idle
+    | Done
+    | Failed_participant
+    | Detached
+  [@@deriving yojson, show]
+
+  type participant = {
+    name: string;
+    role: string option;
+    state: participant_state;
+    summary: string option;
+    started_at: float option;
+    finished_at: float option;
+    last_error: string option;
+  }
+  [@@deriving yojson, show]
+
+  type artifact = {
+    name: string;
+    kind: string;
+    path: string option;
+    inline_content: string option;
+    created_at: float;
+  }
+  [@@deriving yojson, show]
+
+  type vote = {
+    topic: string;
+    options: string list;
+    choice: string;
+    actor: string option;
+    created_at: float;
+  }
+  [@@deriving yojson, show]
+
+  type session = {
+    session_id: string;
+    goal: string;
+    title: string option;
+    tag: string option;
+    phase: phase;
+    created_at: float;
+    updated_at: float;
+    provider: string option;
+    model: string option;
+    system_prompt: string option;
+    max_turns: int;
+    workdir: string option;
+    planned_participants: string list;
+    participants: participant list;
+    artifacts: artifact list;
+    votes: vote list;
+    turn_count: int;
+    last_seq: int;
+    outcome: string option;
+  }
+  [@@deriving yojson, show]
+
+  type init_request = {
+    session_root: string option;
+  }
+  [@@deriving yojson, show]
+
+  type init_response = {
+    sdk_name: string;
+    sdk_version: string;
+    runtime_version: string;
+    protocol_version: string;
+    capabilities: string list;
+  }
+  [@@deriving yojson, show]
+
+  type permission_request = {
+    action: string;
+    subject: string;
+    payload: Yojson.Safe.t;
+  }
+  [@@deriving yojson, show]
+
+  type permission_response = {
+    allow: bool;
+    message: string option;
+    interrupt: bool;
+  }
+  [@@deriving yojson, show]
+
+  type hook_request = {
+    hook_name: string;
+    payload: Yojson.Safe.t;
+  }
+  [@@deriving yojson, show]
+
+  type hook_response = {
+    continue_: bool; [@key "continue"]
+    message: string option;
+  }
+  [@@deriving yojson, show]
+
+  type start_request = {
+    session_id: string option;
+    goal: string;
+    participants: string list;
+    provider: string option;
+    model: string option;
+    system_prompt: string option;
+    max_turns: int option;
+    workdir: string option;
+  }
+  [@@deriving yojson, show]
+
+  type record_turn_request = {
+    actor: string option;
+    message: string;
+  }
+  [@@deriving yojson, show]
+
+  type spawn_agent_request = {
+    participant_name: string;
+    role: string option;
+    prompt: string;
+    provider: string option;
+    model: string option;
+    system_prompt: string option;
+    max_turns: int option;
+  }
+  [@@deriving yojson, show]
+
+  type attach_artifact_request = {
+    name: string;
+    kind: string;
+    content: string;
+  }
+  [@@deriving yojson, show]
+
+  type vote_request = {
+    topic: string;
+    options: string list;
+    choice: string;
+    actor: string option;
+  }
+  [@@deriving yojson, show]
+
+  type checkpoint_request = {
+    label: string option;
+  }
+  [@@deriving yojson, show]
+
+  type finalize_request = {
+    reason: string option;
+  }
+  [@@deriving yojson, show]
+
+  type command =
+    | Record_turn of record_turn_request
+    | Spawn_agent of spawn_agent_request
+    | Attach_artifact of attach_artifact_request
+    | Vote of vote_request
+    | Checkpoint of checkpoint_request
+    | Request_finalize of finalize_request
+  [@@deriving yojson, show]
+
+  type start_event = {
+    goal: string;
+    participants: string list;
+  }
+  [@@deriving yojson, show]
+
+  type turn_event = {
+    actor: string option;
+    message: string;
+  }
+  [@@deriving yojson, show]
+
+  type spawn_event = {
+    participant_name: string;
+    role: string option;
+    prompt: string;
+    provider: string option;
+    model: string option;
+  }
+  [@@deriving yojson, show]
+
+  type participant_event = {
+    participant_name: string;
+    summary: string option;
+    error: string option;
+  }
+  [@@deriving yojson, show]
+
+  type artifact_event = {
+    name: string;
+    kind: string;
+    path: string;
+  }
+  [@@deriving yojson, show]
+
+  type checkpoint_event = {
+    label: string option;
+    path: string;
+  }
+  [@@deriving yojson, show]
+
+  type completion_event = {
+    outcome: string option;
+  }
+  [@@deriving yojson, show]
+
+  type event_kind =
+    | Session_started of start_event
+    | Turn_recorded of turn_event
+    | Agent_spawn_requested of spawn_event
+    | Agent_became_live of participant_event
+    | Agent_completed of participant_event
+    | Agent_failed of participant_event
+    | Artifact_attached of artifact_event
+    | Vote_recorded of vote
+    | Checkpoint_saved of checkpoint_event
+    | Finalize_requested of finalize_request
+    | Session_completed of completion_event
+    | Session_failed of completion_event
+  [@@deriving yojson, show]
+
+  type event = {
+    seq: int;
+    ts: float;
+    kind: event_kind;
+  }
+  [@@deriving yojson, show]
+
+  type report = {
+    session_id: string;
+    summary: string list;
+    markdown: string;
+    generated_at: float;
+  }
+  [@@deriving yojson, show]
+
+  type proof_check = {
+    name: string;
+    passed: bool;
+  }
+  [@@deriving yojson, show]
+
+  type proof = {
+    session_id: string;
+    ok: bool;
+    checks: proof_check list;
+    evidence: string list;
+    generated_at: float;
+  }
+  [@@deriving yojson, show]
+
+  type request =
+    | Initialize of init_request
+    | Start_session of start_request
+    | Apply_command of { session_id: string; command: command }
+    | Status of { session_id: string }
+    | Events of { session_id: string; after_seq: int option }
+    | Finalize of { session_id: string; reason: string option }
+    | Report of { session_id: string }
+    | Prove of { session_id: string }
+    | Shutdown
+  [@@deriving yojson, show]
+
+  type response =
+    | Initialized of init_response
+    | Session_started_response of session
+    | Command_applied of session
+    | Status_response of session
+    | Events_response of event list
+    | Finalized of session
+    | Report_response of report
+    | Prove_response of proof
+    | Shutdown_ack
+    | Error_response of string
+  [@@deriving yojson, show]
+
+  type control_request =
+    | Permission_request of permission_request
+    | Hook_request of hook_request
+  [@@deriving yojson, show]
+
+  type control_response =
+    | Permission_response of permission_response
+    | Hook_response of hook_response
+  [@@deriving yojson, show]
+
+  type protocol_message =
+    | Request_message of { request_id: string; request: request }
+    | Response_message of { request_id: string; response: response }
+    | Control_request_message of { control_id: string; request: control_request }
+    | Control_response_message of { control_id: string; response: control_response }
+    | Event_message of { session_id: string option; event: event }
+    | System_message of { level: string; message: string }
+  [@@deriving yojson, show]
+
+  val request_to_json : request -> Yojson.Safe.t
+  val request_of_json : Yojson.Safe.t -> (request, string) result
+  val response_to_json : response -> Yojson.Safe.t
+  val response_of_json : Yojson.Safe.t -> (response, string) result
+  val protocol_message_to_json : protocol_message -> Yojson.Safe.t
+  val protocol_message_of_json : Yojson.Safe.t -> (protocol_message, string) result
+  val request_to_string : request -> string
+  val response_to_string : response -> string
+  val protocol_message_to_string : protocol_message -> string
+  val request_of_string : string -> (request, string) result
+  val response_of_string : string -> (response, string) result
+  val protocol_message_of_string : string -> (protocol_message, string) result
+  val protocol_version : string
+end
+
+module Transport : sig
+  type options = {
+    runtime_path: string option;
+    session_root: string option;
+  }
+
+  val default_options : options
+
+  type t
+
+  val connect : ?options:options -> unit -> (t, Error.sdk_error) result
+  val request :
+    ?control_handler:
+      (Runtime.control_request -> (Runtime.control_response, Error.sdk_error) result) ->
+    ?event_handler:(Runtime.event -> unit) ->
+    t ->
+    Runtime.request ->
+    (Runtime.response, Error.sdk_error) result
+  val close : t -> unit
+end
+
+module Runtime_client : sig
+  type options = Transport.options = {
+    runtime_path: string option;
+    session_root: string option;
+  }
+
+  val default_options : options
+
+  type t
+
+  val connect : ?options:options -> unit -> (t, Error.sdk_error) result
+  val request :
+    ?control_handler:
+      (Runtime.control_request -> (Runtime.control_response, Error.sdk_error) result) ->
+    ?event_handler:(Runtime.event -> unit) ->
+    t ->
+    Runtime.request ->
+    (Runtime.response, Error.sdk_error) result
+  val init_info : t -> (Runtime.response, Error.sdk_error) result
+  val start_session :
+    ?control_handler:
+      (Runtime.control_request -> (Runtime.control_response, Error.sdk_error) result) ->
+    ?event_handler:(Runtime.event -> unit) ->
+    t ->
+    Runtime.start_request ->
+    (Runtime.session, Error.sdk_error) result
+  val apply_command :
+    ?control_handler:
+      (Runtime.control_request -> (Runtime.control_response, Error.sdk_error) result) ->
+    ?event_handler:(Runtime.event -> unit) ->
+    t ->
+    session_id:string ->
+    Runtime.command ->
+    (Runtime.session, Error.sdk_error) result
+  val status : t -> session_id:string -> (Runtime.session, Error.sdk_error) result
+  val events :
+    t ->
+    session_id:string ->
+    ?after_seq:int ->
+    unit ->
+    (Runtime.event list, Error.sdk_error) result
+  val finalize :
+    ?control_handler:
+      (Runtime.control_request -> (Runtime.control_response, Error.sdk_error) result) ->
+    ?event_handler:(Runtime.event -> unit) ->
+    t ->
+    session_id:string ->
+    ?reason:string ->
+    unit ->
+    (Runtime.session, Error.sdk_error) result
+  val report : t -> session_id:string -> (Runtime.report, Error.sdk_error) result
+  val prove : t -> session_id:string -> (Runtime.proof, Error.sdk_error) result
+  val close : t -> unit
+end
+
+val runtime_query :
+  ?runtime_path:string ->
+  ?session_root:string ->
+  Runtime.request ->
+  (Runtime.response, Error.sdk_error) result
+
+module Client : sig
+  type permission_mode =
+    | Default
+    | Accept_edits
+    | Plan
+    | Bypass_permissions
+  [@@deriving show]
+
+  type setting_source =
+    | User
+    | Project
+    | Local
+  [@@deriving show]
+
+  type agent_definition = {
+    description: string;
+    prompt: string;
+    tools: string list option;
+    model: string option;
+  }
+  [@@deriving show]
+
+  type options = {
+    runtime_path: string option;
+    session_root: string option;
+    cwd: string option;
+    permission_mode: permission_mode;
+    model: string option;
+    system_prompt: string option;
+    max_turns: int option;
+    provider: string option;
+    agents: (string * agent_definition) list;
+    include_partial_messages: bool;
+    setting_sources: setting_source list;
+  }
+  [@@deriving show]
+
+  type message =
+    | System_message of string
+    | Session_status of Runtime.session
+    | Session_events of Runtime.event list
+    | Session_report of Runtime.report
+    | Session_proof of Runtime.proof
+  [@@deriving show]
+
+  type permission_result =
+    | Permission_result_allow of { message: string option }
+    | Permission_result_deny of { message: string option; interrupt: bool }
+
+  type tool_permission_context = {
+    suggestions: string list;
+  }
+
+  type can_use_tool =
+    string -> Yojson.Safe.t -> tool_permission_context -> permission_result
+
+  type hook_result =
+    | Hook_continue
+    | Hook_block of string option
+
+  type hook_callback =
+    string -> Yojson.Safe.t -> hook_result
+
+  val default_options : options
+
+  type t
+
+  val connect : ?options:options -> unit -> (t, Error.sdk_error) result
+  val query : t -> string -> (unit, Error.sdk_error) result
+  val receive_messages : t -> message list
+  val interrupt : t -> (unit, Error.sdk_error) result
+  val set_permission_mode : t -> permission_mode -> unit
+  val set_model : t -> string option -> unit
+  val set_can_use_tool : t -> can_use_tool -> unit
+  val set_hook_callback : t -> hook_callback -> unit
+  val current_session_id : t -> string option
+  val finalize :
+    t ->
+    ?reason:string ->
+    unit ->
+    (unit, Error.sdk_error) result
+  val close : t -> unit
+end
+
+module Sessions : sig
+  type session_info = {
+    session_id: string;
+    title: string option;
+    tag: string option;
+    goal: string;
+    updated_at: float;
+    phase: Runtime.phase;
+    participant_count: int;
+    path: string;
+  }
+
+  val list_sessions :
+    ?session_root:string -> unit -> (session_info list, Error.sdk_error) result
+  val get_session :
+    ?session_root:string -> string -> (Runtime.session, Error.sdk_error) result
+  val get_session_events :
+    ?session_root:string ->
+    string ->
+    (Runtime.event list, Error.sdk_error) result
+  val rename_session :
+    ?session_root:string ->
+    session_id:string ->
+    title:string ->
+    unit ->
+    (unit, Error.sdk_error) result
+  val tag_session :
+    ?session_root:string ->
+    session_id:string ->
+    tag:string option ->
+    unit ->
+    (unit, Error.sdk_error) result
+end
+
+val query :
+  ?options:Client.options ->
+  prompt:string ->
+  unit ->
+  (Client.message list, Error.sdk_error) result
+
 (** {1 Quick Start} *)
 
 (** Create an agent with default config and optional overrides *)

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -1,0 +1,75 @@
+type permission_mode = Sdk_client_types.permission_mode =
+  | Default
+  | Accept_edits
+  | Plan
+  | Bypass_permissions
+[@@deriving show]
+
+type setting_source = Sdk_client_types.setting_source =
+  | User
+  | Project
+  | Local
+[@@deriving show]
+
+type agent_definition = Sdk_client_types.agent_definition = {
+  description: string;
+  prompt: string;
+  tools: string list option;
+  model: string option;
+}
+[@@deriving show]
+
+type options = Sdk_client_types.options = {
+  runtime_path: string option;
+  session_root: string option;
+  cwd: string option;
+  permission_mode: permission_mode;
+  model: string option;
+  system_prompt: string option;
+  max_turns: int option;
+  provider: string option;
+  agents: (string * agent_definition) list;
+  include_partial_messages: bool;
+  setting_sources: setting_source list;
+}
+[@@deriving show]
+
+type message = Sdk_client_types.message =
+  | System_message of string
+  | Session_status of Runtime.session
+  | Session_events of Runtime.event list
+  | Session_report of Runtime.report
+  | Session_proof of Runtime.proof
+[@@deriving show]
+
+type permission_result = Sdk_client_types.permission_result =
+  | Permission_result_allow of { message: string option }
+  | Permission_result_deny of { message: string option; interrupt: bool }
+
+type tool_permission_context = Sdk_client_types.tool_permission_context = {
+  suggestions: string list;
+}
+
+type can_use_tool = Sdk_client_types.can_use_tool
+
+type hook_result = Sdk_client_types.hook_result =
+  | Hook_continue
+  | Hook_block of string option
+
+type hook_callback = Sdk_client_types.hook_callback
+
+type t = Internal_query_engine.t
+
+let default_options = Sdk_client_types.default_options
+
+let connect = Internal_query_engine.connect
+let query = Internal_query_engine.query_turn
+let receive_messages = Internal_query_engine.receive_messages
+let interrupt = Internal_query_engine.interrupt
+let set_permission_mode = Internal_query_engine.set_permission_mode
+let set_model = Internal_query_engine.set_model
+let set_can_use_tool = Internal_query_engine.set_can_use_tool
+let set_hook_callback = Internal_query_engine.set_hook_callback
+let current_session_id = Internal_query_engine.current_session_id
+let finalize = Internal_query_engine.finalize
+let close = Internal_query_engine.close

--- a/lib/internal_client.ml
+++ b/lib/internal_client.ml
@@ -1,0 +1,11 @@
+let ( let* ) = Result.bind
+
+let process_query ?(options = Sdk_client_types.default_options) ~prompt () =
+  let* client = Internal_query_engine.connect ~options () in
+  Fun.protect
+    ~finally:(fun () -> Internal_query_engine.close client)
+    (fun () ->
+      let* () = Internal_query_engine.query_turn client prompt in
+      let* () = Internal_query_engine.finalize client () in
+      Ok (Internal_query_engine.receive_messages client))
+

--- a/lib/internal_message_parser.ml
+++ b/lib/internal_message_parser.ml
@@ -1,0 +1,6 @@
+let status session = Sdk_client_types.Session_status session
+let events events = Sdk_client_types.Session_events events
+let report report = Sdk_client_types.Session_report report
+let proof proof = Sdk_client_types.Session_proof proof
+let system text = Sdk_client_types.System_message text
+

--- a/lib/internal_query_engine.ml
+++ b/lib/internal_query_engine.ml
@@ -1,0 +1,220 @@
+type t = {
+  runtime: Runtime_client.t;
+  mutable options: Sdk_client_types.options;
+  mutable session_id: string option;
+  mutable last_event_seq: int;
+  mutable buffered_messages: Sdk_client_types.message list;
+  mutable can_use_tool: Sdk_client_types.can_use_tool option;
+  mutable hook_callback: Sdk_client_types.hook_callback option;
+}
+
+let ( let* ) = Result.bind
+
+let append_message state message =
+  state.buffered_messages <- state.buffered_messages @ [ message ]
+
+let runtime_options options =
+  {
+    Runtime_client.runtime_path = options.Sdk_client_types.runtime_path;
+    session_root = options.session_root;
+  }
+
+let connect ?(options = Sdk_client_types.default_options) () =
+  let* runtime = Runtime_client.connect ~options:(runtime_options options) () in
+  Ok
+    {
+      runtime;
+      options;
+      session_id = None;
+      last_event_seq = 0;
+      buffered_messages = [];
+      can_use_tool = None;
+      hook_callback = None;
+    }
+
+let receive_messages state =
+  let messages = state.buffered_messages in
+  state.buffered_messages <- [];
+  messages
+
+let current_session_id state = state.session_id
+
+let set_permission_mode state permission_mode =
+  state.options <- { state.options with permission_mode }
+
+let set_model state model =
+  state.options <- { state.options with model }
+
+let set_can_use_tool state callback =
+  state.can_use_tool <- Some callback
+
+let set_hook_callback state callback =
+  state.hook_callback <- Some callback
+
+let close state = Runtime_client.close state.runtime
+
+let handle_event state (event : Runtime.event) =
+  state.last_event_seq <- max state.last_event_seq event.seq;
+  append_message state (Internal_message_parser.events [ event ])
+
+let handle_control_request state request =
+  let open Sdk_client_types in
+  match request with
+  | Runtime.Permission_request detail -> (
+      match state.can_use_tool with
+      | Some callback -> (
+          match callback detail.action detail.payload { suggestions = [] } with
+          | Permission_result_allow { message } ->
+              Ok
+                (Runtime.Permission_response
+                   { allow = true; message; interrupt = false })
+          | Permission_result_deny { message; interrupt } ->
+              Ok
+                (Runtime.Permission_response
+                   { allow = false; message; interrupt }))
+      | None ->
+          Ok
+            (Runtime.Permission_response
+               { allow = true; message = None; interrupt = false }))
+  | Runtime.Hook_request detail -> (
+      match state.hook_callback with
+      | Some callback -> (
+          match callback detail.hook_name detail.payload with
+          | Hook_continue ->
+              Ok (Runtime.Hook_response { continue_ = true; message = None })
+          | Hook_block message ->
+              Ok (Runtime.Hook_response { continue_ = false; message }))
+      | None ->
+          Ok (Runtime.Hook_response { continue_ = true; message = None }))
+
+let sync_events state =
+  match state.session_id with
+  | None -> Ok ()
+  | Some session_id ->
+      let* events =
+        Runtime_client.events state.runtime ~session_id
+          ~after_seq:state.last_event_seq ()
+      in
+      (match List.rev events with
+       | { Runtime.seq; _ } :: _ -> state.last_event_seq <- seq
+       | [] -> ());
+      if events <> [] then
+        append_message state (Internal_message_parser.events events);
+      Ok ()
+
+let ensure_session state ~prompt =
+  let start_new () =
+    let participants =
+      Sdk_client_types.agent_entries state.options |> List.map fst
+    in
+    let request =
+      Runtime.
+        {
+          session_id = None;
+          goal = prompt;
+          participants;
+          provider = state.options.provider;
+          model = state.options.model;
+          system_prompt = state.options.system_prompt;
+          max_turns = state.options.max_turns;
+          workdir = state.options.cwd;
+        }
+    in
+    let* session =
+      Runtime_client.start_session ~control_handler:(handle_control_request state)
+        ~event_handler:(handle_event state) state.runtime request
+    in
+    state.session_id <- Some session.session_id;
+    state.last_event_seq <- session.last_seq;
+    append_message state (Internal_message_parser.status session);
+    Ok session
+  in
+  match state.session_id with
+  | None -> start_new ()
+  | Some session_id ->
+      let* session = Runtime_client.status state.runtime ~session_id in
+      (match session.phase with
+       | Runtime.Completed | Runtime.Failed | Runtime.Cancelled ->
+           state.session_id <- None;
+           state.last_event_seq <- 0;
+           start_new ()
+       | Runtime.Bootstrapping | Runtime.Running | Runtime.Waiting_on_workers
+       | Runtime.Finalizing ->
+           Ok session)
+
+let compose_spawn_prompt definition prompt =
+  let prefix =
+    match String.trim definition.Sdk_client_types.prompt with
+    | "" -> ""
+    | value -> value ^ "\n\n"
+  in
+  prefix ^ prompt
+
+let query_turn state prompt =
+  let* session = ensure_session state ~prompt in
+  let* session =
+    Runtime_client.apply_command ~control_handler:(handle_control_request state)
+      ~event_handler:(handle_event state) state.runtime
+      ~session_id:session.session_id
+      (Runtime.Record_turn { actor = None; message = prompt })
+  in
+  append_message state (Internal_message_parser.status session);
+  let* () =
+    Sdk_client_types.agent_entries state.options
+    |> List.fold_left
+         (fun acc (name, (definition : Sdk_client_types.agent_definition)) ->
+           let* () = acc in
+           let command =
+             Runtime.Spawn_agent
+               {
+                 participant_name = name;
+                 role = Some definition.description;
+                 prompt = compose_spawn_prompt definition prompt;
+                 provider = state.options.provider;
+                 model =
+                   (match definition.model with
+                    | Some _ as model -> model
+                    | None -> state.options.model);
+                 system_prompt = state.options.system_prompt;
+                 max_turns = state.options.max_turns;
+               }
+           in
+           let* session =
+             Runtime_client.apply_command
+               ~control_handler:(handle_control_request state)
+               ~event_handler:(handle_event state) state.runtime
+               ~session_id:session.session_id
+               command
+           in
+           append_message state (Internal_message_parser.status session);
+           Ok ())
+         (Ok ())
+  in
+  sync_events state
+
+let finalize state ?reason () =
+  match state.session_id with
+  | None -> Ok ()
+  | Some session_id ->
+      let* session =
+        Runtime_client.finalize
+          ~control_handler:(handle_control_request state)
+          ~event_handler:(handle_event state) state.runtime
+          ~session_id ?reason ()
+      in
+      append_message state (Internal_message_parser.status session);
+      let* report = Runtime_client.report state.runtime ~session_id in
+      append_message state (Internal_message_parser.report report);
+      let* proof = Runtime_client.prove state.runtime ~session_id in
+      append_message state (Internal_message_parser.proof proof);
+      let* () = sync_events state in
+      state.session_id <- None;
+      Ok ()
+
+let interrupt state =
+  match state.session_id with
+  | None ->
+      append_message state
+        (Internal_message_parser.system "No active session to interrupt.");
+      Ok ()
+  | Some _ -> finalize state ~reason:"Interrupted by user" ()

--- a/lib/query.ml
+++ b/lib/query.ml
@@ -1,0 +1,1 @@
+let query = Internal_client.process_query

--- a/lib/runtime.ml
+++ b/lib/runtime.ml
@@ -1,0 +1,338 @@
+type phase =
+  | Bootstrapping
+  | Running
+  | Waiting_on_workers
+  | Finalizing
+  | Completed
+  | Failed
+  | Cancelled
+[@@deriving yojson, show]
+
+type participant_state =
+  | Planned
+  | Starting
+  | Live
+  | Idle
+  | Done
+  | Failed_participant
+  | Detached
+[@@deriving yojson, show]
+
+type participant = {
+  name: string;
+  role: string option;
+  state: participant_state;
+  summary: string option;
+  started_at: float option;
+  finished_at: float option;
+  last_error: string option;
+}
+[@@deriving yojson, show]
+
+type artifact = {
+  name: string;
+  kind: string;
+  path: string option;
+  inline_content: string option;
+  created_at: float;
+}
+[@@deriving yojson, show]
+
+type vote = {
+  topic: string;
+  options: string list;
+  choice: string;
+  actor: string option;
+  created_at: float;
+}
+[@@deriving yojson, show]
+
+type session = {
+  session_id: string;
+  goal: string;
+  title: string option;
+  tag: string option;
+  phase: phase;
+  created_at: float;
+  updated_at: float;
+  provider: string option;
+  model: string option;
+  system_prompt: string option;
+  max_turns: int;
+  workdir: string option;
+  planned_participants: string list;
+  participants: participant list;
+  artifacts: artifact list;
+  votes: vote list;
+  turn_count: int;
+  last_seq: int;
+  outcome: string option;
+}
+[@@deriving yojson, show]
+
+type init_request = {
+  session_root: string option;
+}
+[@@deriving yojson, show]
+
+type init_response = {
+  sdk_name: string;
+  sdk_version: string;
+  runtime_version: string;
+  protocol_version: string;
+  capabilities: string list;
+}
+[@@deriving yojson, show]
+
+type permission_request = {
+  action: string;
+  subject: string;
+  payload: Yojson.Safe.t;
+}
+[@@deriving yojson, show]
+
+type permission_response = {
+  allow: bool;
+  message: string option;
+  interrupt: bool;
+}
+[@@deriving yojson, show]
+
+type hook_request = {
+  hook_name: string;
+  payload: Yojson.Safe.t;
+}
+[@@deriving yojson, show]
+
+type hook_response = {
+  continue_: bool; [@key "continue"]
+  message: string option;
+}
+[@@deriving yojson, show]
+
+type start_request = {
+  session_id: string option;
+  goal: string;
+  participants: string list;
+  provider: string option;
+  model: string option;
+  system_prompt: string option;
+  max_turns: int option;
+  workdir: string option;
+}
+[@@deriving yojson, show]
+
+type record_turn_request = {
+  actor: string option;
+  message: string;
+}
+[@@deriving yojson, show]
+
+type spawn_agent_request = {
+  participant_name: string;
+  role: string option;
+  prompt: string;
+  provider: string option;
+  model: string option;
+  system_prompt: string option;
+  max_turns: int option;
+}
+[@@deriving yojson, show]
+
+type attach_artifact_request = {
+  name: string;
+  kind: string;
+  content: string;
+}
+[@@deriving yojson, show]
+
+type vote_request = {
+  topic: string;
+  options: string list;
+  choice: string;
+  actor: string option;
+}
+[@@deriving yojson, show]
+
+type checkpoint_request = {
+  label: string option;
+}
+[@@deriving yojson, show]
+
+type finalize_request = {
+  reason: string option;
+}
+[@@deriving yojson, show]
+
+type command =
+  | Record_turn of record_turn_request
+  | Spawn_agent of spawn_agent_request
+  | Attach_artifact of attach_artifact_request
+  | Vote of vote_request
+  | Checkpoint of checkpoint_request
+  | Request_finalize of finalize_request
+[@@deriving yojson, show]
+
+type start_event = {
+  goal: string;
+  participants: string list;
+}
+[@@deriving yojson, show]
+
+type turn_event = {
+  actor: string option;
+  message: string;
+}
+[@@deriving yojson, show]
+
+type spawn_event = {
+  participant_name: string;
+  role: string option;
+  prompt: string;
+  provider: string option;
+  model: string option;
+}
+[@@deriving yojson, show]
+
+type participant_event = {
+  participant_name: string;
+  summary: string option;
+  error: string option;
+}
+[@@deriving yojson, show]
+
+type artifact_event = {
+  name: string;
+  kind: string;
+  path: string;
+}
+[@@deriving yojson, show]
+
+type checkpoint_event = {
+  label: string option;
+  path: string;
+}
+[@@deriving yojson, show]
+
+type completion_event = {
+  outcome: string option;
+}
+[@@deriving yojson, show]
+
+type event_kind =
+  | Session_started of start_event
+  | Turn_recorded of turn_event
+  | Agent_spawn_requested of spawn_event
+  | Agent_became_live of participant_event
+  | Agent_completed of participant_event
+  | Agent_failed of participant_event
+  | Artifact_attached of artifact_event
+  | Vote_recorded of vote
+  | Checkpoint_saved of checkpoint_event
+  | Finalize_requested of finalize_request
+  | Session_completed of completion_event
+  | Session_failed of completion_event
+[@@deriving yojson, show]
+
+type event = {
+  seq: int;
+  ts: float;
+  kind: event_kind;
+}
+[@@deriving yojson, show]
+
+type report = {
+  session_id: string;
+  summary: string list;
+  markdown: string;
+  generated_at: float;
+}
+[@@deriving yojson, show]
+
+type proof_check = {
+  name: string;
+  passed: bool;
+}
+[@@deriving yojson, show]
+
+type proof = {
+  session_id: string;
+  ok: bool;
+  checks: proof_check list;
+  evidence: string list;
+  generated_at: float;
+}
+[@@deriving yojson, show]
+
+type request =
+  | Initialize of init_request
+  | Start_session of start_request
+  | Apply_command of { session_id: string; command: command }
+  | Status of { session_id: string }
+  | Events of { session_id: string; after_seq: int option }
+  | Finalize of { session_id: string; reason: string option }
+  | Report of { session_id: string }
+  | Prove of { session_id: string }
+  | Shutdown
+[@@deriving yojson, show]
+
+type response =
+  | Initialized of init_response
+  | Session_started_response of session
+  | Command_applied of session
+  | Status_response of session
+  | Events_response of event list
+  | Finalized of session
+  | Report_response of report
+  | Prove_response of proof
+  | Shutdown_ack
+  | Error_response of string
+[@@deriving yojson, show]
+
+type control_request =
+  | Permission_request of permission_request
+  | Hook_request of hook_request
+[@@deriving yojson, show]
+
+type control_response =
+  | Permission_response of permission_response
+  | Hook_response of hook_response
+[@@deriving yojson, show]
+
+type protocol_message =
+  | Request_message of { request_id: string; request: request }
+  | Response_message of { request_id: string; response: response }
+  | Control_request_message of { control_id: string; request: control_request }
+  | Control_response_message of { control_id: string; response: control_response }
+  | Event_message of { session_id: string option; event: event }
+  | System_message of { level: string; message: string }
+[@@deriving yojson, show]
+
+let request_to_json = request_to_yojson
+let request_of_json json = request_of_yojson json
+
+let response_to_json = response_to_yojson
+let response_of_json json = response_of_yojson json
+
+let protocol_message_to_json = protocol_message_to_yojson
+let protocol_message_of_json json = protocol_message_of_yojson json
+
+let request_to_string req = req |> request_to_json |> Yojson.Safe.to_string
+let response_to_string resp = resp |> response_to_json |> Yojson.Safe.to_string
+let protocol_version = "oas-runtime-0.1"
+let protocol_message_to_string msg = msg |> protocol_message_to_json |> Yojson.Safe.to_string
+
+let request_of_string raw =
+  try request_of_json (Yojson.Safe.from_string raw)
+  with Yojson.Json_error msg ->
+    Error (Printf.sprintf "Invalid runtime request JSON: %s" msg)
+
+let response_of_string raw =
+  try response_of_json (Yojson.Safe.from_string raw)
+  with Yojson.Json_error msg ->
+    Error (Printf.sprintf "Invalid runtime response JSON: %s" msg)
+
+let protocol_message_of_string raw =
+  try protocol_message_of_json (Yojson.Safe.from_string raw)
+  with Yojson.Json_error msg ->
+    Error (Printf.sprintf "Invalid runtime protocol JSON: %s" msg)

--- a/lib/runtime_client.ml
+++ b/lib/runtime_client.ml
@@ -1,0 +1,112 @@
+type options = Transport.options = {
+  runtime_path: string option;
+  session_root: string option;
+}
+
+let ( let* ) = Result.bind
+
+let default_options = Transport.default_options
+
+type t = {
+  transport: Transport.t;
+}
+
+let connect ?(options = default_options) () =
+  match Transport.connect ~options () with
+  | Ok transport -> Ok { transport }
+  | Error err -> Error err
+
+let request ?control_handler ?event_handler client request =
+  let open Error in
+  let* response =
+    Transport.request ?control_handler ?event_handler client.transport request
+  in
+  match response with
+  | Runtime.Error_response detail -> Error (Internal detail)
+  | _ -> Ok response
+
+let init_info client =
+  request client (Runtime.Initialize { session_root = None })
+
+let start_session ?control_handler ?event_handler client request_data =
+  let* response =
+    request ?control_handler ?event_handler client
+      (Runtime.Start_session request_data)
+  in
+  match response with
+  | Runtime.Session_started_response session -> Ok session
+  | other ->
+      Error
+        (Error.Internal
+           (Printf.sprintf "Unexpected start_session response: %s"
+              (Runtime.show_response other)))
+
+let apply_command ?control_handler ?event_handler client ~session_id command =
+  let* response =
+    request ?control_handler ?event_handler client
+      (Runtime.Apply_command { session_id; command })
+  in
+  match response with
+  | Runtime.Command_applied session
+  | Runtime.Finalized session ->
+      Ok session
+  | other ->
+      Error
+        (Error.Internal
+           (Printf.sprintf "Unexpected apply_command response: %s"
+              (Runtime.show_response other)))
+
+let status client ~session_id =
+  let* response = request client (Runtime.Status { session_id }) in
+  match response with
+  | Runtime.Status_response session -> Ok session
+  | other ->
+      Error
+        (Error.Internal
+           (Printf.sprintf "Unexpected status response: %s"
+              (Runtime.show_response other)))
+
+let events client ~session_id ?after_seq () =
+  let* response = request client (Runtime.Events { session_id; after_seq }) in
+  match response with
+  | Runtime.Events_response events -> Ok events
+  | other ->
+      Error
+        (Error.Internal
+           (Printf.sprintf "Unexpected events response: %s"
+              (Runtime.show_response other)))
+
+let finalize ?control_handler ?event_handler client ~session_id ?reason () =
+  let* response =
+    request ?control_handler ?event_handler client
+      (Runtime.Finalize { session_id; reason })
+  in
+  match response with
+  | Runtime.Finalized session -> Ok session
+  | other ->
+      Error
+        (Error.Internal
+           (Printf.sprintf "Unexpected finalize response: %s"
+              (Runtime.show_response other)))
+
+let report client ~session_id =
+  let* response = request client (Runtime.Report { session_id }) in
+  match response with
+  | Runtime.Report_response report -> Ok report
+  | other ->
+      Error
+        (Error.Internal
+           (Printf.sprintf "Unexpected report response: %s"
+              (Runtime.show_response other)))
+
+let prove client ~session_id =
+  let* response = request client (Runtime.Prove { session_id }) in
+  match response with
+  | Runtime.Prove_response proof -> Ok proof
+  | other ->
+      Error
+        (Error.Internal
+           (Printf.sprintf "Unexpected prove response: %s"
+              (Runtime.show_response other)))
+
+let close client = Transport.close client.transport

--- a/lib/runtime_projection.ml
+++ b/lib/runtime_projection.ml
@@ -1,0 +1,276 @@
+open Runtime
+
+let ( let* ) = Result.bind
+
+let now () = Unix.gettimeofday ()
+
+let make_session_id () =
+  let base = int_of_float (now () *. 1000.0) in
+  let salt = Random.int 0xFFFF in
+  Printf.sprintf "rt-%08x-%04x" base salt
+
+let make_planned_participant name =
+  {
+    name;
+    role = None;
+    state = Planned;
+    summary = None;
+    started_at = None;
+    finished_at = None;
+    last_error = None;
+  }
+
+let initial_session (request : start_request) =
+  let ts = now () in
+  {
+    session_id =
+      Option.value request.session_id ~default:(make_session_id ());
+    goal = request.goal;
+    title = None;
+    tag = None;
+    phase = Bootstrapping;
+    created_at = ts;
+    updated_at = ts;
+    provider = request.provider;
+    model = request.model;
+    system_prompt = request.system_prompt;
+    max_turns = Option.value request.max_turns ~default:8;
+    workdir = request.workdir;
+    planned_participants = request.participants;
+    participants = List.map make_planned_participant request.participants;
+    artifacts = [];
+    votes = [];
+    turn_count = 0;
+    last_seq = 0;
+    outcome = None;
+  }
+
+let update_participant (session : session) name f =
+  let rec loop found acc = function
+    | [] ->
+        if found then List.rev acc
+        else
+          List.rev
+            (f
+               ({
+                 name;
+                 role = None;
+                 state = Planned;
+                 summary = None;
+                 started_at = None;
+                 finished_at = None;
+                 last_error = None;
+               } : participant)
+             :: acc)
+    | (participant : participant) :: rest when String.equal participant.name name ->
+        loop true (f participant :: acc) rest
+    | (participant : participant) :: rest -> loop found (participant :: acc) rest
+  in
+  { session with participants = loop false [] session.participants }
+
+let update_session_meta session event =
+  { session with updated_at = event.ts; last_seq = event.seq }
+
+let ensure_active_phase session =
+  match session.phase with
+  | Completed | Failed | Cancelled ->
+      Error
+        (Error.Internal
+           (Printf.sprintf "Session %s is terminal" session.session_id))
+  | Bootstrapping | Running | Waiting_on_workers | Finalizing -> Ok session
+
+let apply_event (session : session) (event : event) =
+  let session = update_session_meta session event in
+  match event.kind with
+  | Session_started _ ->
+      Ok { session with phase = Running }
+  | Turn_recorded _ ->
+      let* session = ensure_active_phase session in
+      Ok { session with turn_count = session.turn_count + 1 }
+  | Agent_spawn_requested detail ->
+      let* session = ensure_active_phase session in
+      Ok
+        (update_participant session detail.participant_name (fun participant ->
+             {
+               participant with
+               role = detail.role;
+               state = Starting;
+               summary = None;
+               started_at = Some event.ts;
+               finished_at = None;
+               last_error = None;
+             }))
+  | Agent_became_live detail ->
+      let* session = ensure_active_phase session in
+      Ok
+        (update_participant session detail.participant_name (fun participant ->
+             {
+               participant with
+               state = Live;
+               summary = detail.summary;
+               started_at = Some (Option.value participant.started_at ~default:event.ts);
+               last_error = None;
+             }))
+  | Agent_completed detail ->
+      let* session = ensure_active_phase session in
+      Ok
+        (update_participant session detail.participant_name (fun participant ->
+             {
+               participant with
+               state = Done;
+               summary = detail.summary;
+               finished_at = Some event.ts;
+               last_error = None;
+             }))
+  | Agent_failed detail ->
+      let* session = ensure_active_phase session in
+      Ok
+        (update_participant session detail.participant_name (fun participant ->
+             {
+               participant with
+               state = Failed_participant;
+               summary = detail.summary;
+               finished_at = Some event.ts;
+               last_error = detail.error;
+             }))
+  | Artifact_attached detail ->
+      let* session = ensure_active_phase session in
+      let artifact =
+        {
+          name = detail.name;
+          kind = detail.kind;
+          path = Some detail.path;
+          inline_content = None;
+          created_at = event.ts;
+        }
+      in
+      Ok { session with artifacts = session.artifacts @ [ artifact ] }
+  | Vote_recorded vote ->
+      let* session = ensure_active_phase session in
+      Ok { session with votes = session.votes @ [ vote ] }
+  | Checkpoint_saved _ ->
+      let* session = ensure_active_phase session in
+      Ok session
+  | Finalize_requested detail ->
+      let* session = ensure_active_phase session in
+      Ok { session with phase = Finalizing; outcome = detail.reason }
+  | Session_completed detail ->
+      Ok
+        {
+          session with
+          phase = Completed;
+          outcome = detail.outcome;
+          updated_at = event.ts;
+        }
+  | Session_failed detail ->
+      Ok
+        {
+          session with
+          phase = Failed;
+          outcome = detail.outcome;
+          updated_at = event.ts;
+        }
+
+let count_by_state target (session : session) =
+  session.participants
+  |> List.filter (fun participant -> participant.state = target)
+  |> List.length
+
+let build_report (session : session) (events : event list) =
+  let generated_at = now () in
+  let summary =
+    [
+      Printf.sprintf "Goal: %s" session.goal;
+      Printf.sprintf "Phase: %s" (show_phase session.phase);
+      Printf.sprintf "Turns: %d" session.turn_count;
+      Printf.sprintf "Participants done: %d" (count_by_state Done session);
+      Printf.sprintf "Participants failed: %d"
+        (count_by_state Failed_participant session);
+      Printf.sprintf "Artifacts: %d" (List.length session.artifacts);
+    ]
+  in
+  let participant_lines =
+    session.participants
+    |> List.map (fun (participant : participant) ->
+           let summary =
+             match participant.summary with
+             | Some text when String.trim text <> "" -> text
+             | _ -> "n/a"
+           in
+           Printf.sprintf "- %s [%s] %s" participant.name
+             (show_participant_state participant.state)
+             summary)
+    |> String.concat "\n"
+  in
+  let event_lines =
+    events
+    |> List.map (fun event ->
+           Printf.sprintf "- #%d %s %s" event.seq
+             (show_event_kind event.kind) (Printf.sprintf "@ %.3f" event.ts))
+    |> String.concat "\n"
+  in
+  {
+    session_id = session.session_id;
+    summary;
+    generated_at;
+    markdown =
+      String.concat "\n"
+        [
+          "# Runtime Session Report";
+          "";
+          Printf.sprintf "- Session ID: %s" session.session_id;
+          Printf.sprintf "- Goal: %s" session.goal;
+          Printf.sprintf "- Phase: %s" (show_phase session.phase);
+          Printf.sprintf "- Outcome: %s"
+            (Option.value session.outcome ~default:"n/a");
+          "";
+          "## Summary";
+          String.concat "\n" (List.map (fun line -> "- " ^ line) summary);
+          "";
+          "## Participants";
+          participant_lines;
+          "";
+          "## Event Trace";
+          event_lines;
+          "";
+        ];
+  }
+
+let build_proof (session : session) (events : event list) =
+  let generated_at = now () in
+  let has_turn = List.exists (function { kind = Turn_recorded _; _ } -> true | _ -> false) events in
+  let has_spawn =
+    List.exists
+      (function { kind = Agent_completed _ | Agent_failed _; _ } -> true | _ -> false)
+      events
+  in
+  let finalized =
+    match session.phase with
+    | Completed | Failed | Cancelled -> true
+    | Bootstrapping | Running | Waiting_on_workers | Finalizing -> false
+  in
+  let checks =
+    [
+      { name = "session_started"; passed = session.last_seq >= 1 };
+      { name = "turn_recorded"; passed = has_turn };
+      { name = "participant_outcome"; passed = has_spawn };
+      { name = "terminal_phase"; passed = finalized };
+    ]
+  in
+  let ok = List.for_all (fun check -> check.passed) checks in
+  let evidence =
+    [
+      Printf.sprintf "last_seq=%d" session.last_seq;
+      Printf.sprintf "turn_count=%d" session.turn_count;
+      Printf.sprintf "participants=%d" (List.length session.participants);
+      Printf.sprintf "artifacts=%d" (List.length session.artifacts);
+      Printf.sprintf "phase=%s" (show_phase session.phase);
+    ]
+  in
+  {
+    session_id = session.session_id;
+    ok;
+    checks;
+    evidence;
+    generated_at;
+  }

--- a/lib/runtime_query.ml
+++ b/lib/runtime_query.ml
@@ -1,0 +1,9 @@
+let query ?runtime_path ?session_root request =
+  let options = { Transport.runtime_path; session_root } in
+  match Runtime_client.connect ~options () with
+  | Error err -> Error err
+  | Ok client ->
+      Fun.protect
+        ~finally:(fun () -> Runtime_client.close client)
+        (fun () -> Runtime_client.request client request)
+

--- a/lib/runtime_server.ml
+++ b/lib/runtime_server.ml
@@ -1,0 +1,465 @@
+open Runtime
+
+let ( let* ) = Result.bind
+
+type state = {
+  net: [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t;
+  event_bus: Event_bus.t;
+  mutable session_root: string option;
+  mutable next_control_id: int;
+}
+
+let runtime_version = "0.1.0"
+
+let first_some a b =
+  match a with
+  | Some _ -> a
+  | None -> b
+
+let create ~net () =
+  {
+    net;
+    event_bus = Event_bus.create ();
+    session_root = None;
+    next_control_id = 1;
+  }
+
+let store_of_state state =
+  Runtime_store.create ?root:state.session_root ()
+
+let session_root_request_path = function
+  | Some value when String.trim value <> "" -> Some (String.trim value)
+  | _ -> None
+
+let write_protocol_message message =
+  output_string stdout (protocol_message_to_string message);
+  output_char stdout '\n';
+  flush stdout
+
+let next_control_id state =
+  let id = state.next_control_id in
+  state.next_control_id <- id + 1;
+  Printf.sprintf "ctrl-%06d" id
+
+let emit_event state session_id (event : event) =
+  Event_bus.publish state.event_bus
+    (Event_bus.Custom ("runtime.event", event |> event_to_yojson));
+  write_protocol_message (Event_message { session_id = Some session_id; event })
+
+let rec read_control_response state control_id =
+  match input_line stdin with
+  | exception End_of_file ->
+      Error
+        (Error.Io
+           (FileOpFailed
+              {
+                op = "read";
+                path = "stdin";
+                detail = "runtime control channel closed";
+              }))
+  | raw -> (
+      match protocol_message_of_string raw with
+      | Error detail ->
+          Error (Error.Serialization (JsonParseError { detail }))
+      | Ok (Control_response_message payload)
+        when String.equal payload.control_id control_id ->
+          Ok payload.response
+      | Ok _ -> read_control_response state control_id)
+
+let ask_permission state ~action ~subject ~payload =
+  let control_id = next_control_id state in
+  write_protocol_message
+    (Control_request_message
+       {
+         control_id;
+         request = Permission_request { action; subject; payload };
+       });
+  read_control_response state control_id
+
+let invoke_hook state ~hook_name ~payload =
+  let control_id = next_control_id state in
+  write_protocol_message
+    (Control_request_message
+       {
+         control_id;
+         request = Hook_request { hook_name; payload };
+       });
+  read_control_response state control_id
+
+let resolve_provider ?provider ?model () =
+  let selected =
+    match provider with
+    | Some value when String.trim value <> "" -> String.lowercase_ascii (String.trim value)
+    | _ -> "local-qwen"
+  in
+  let base =
+    match selected with
+    | "mock" | "echo" -> None
+    | "local-qwen" -> Some (Provider.local_qwen ())
+    | "local-mlx" -> Some (Provider.local_mlx ())
+    | "sonnet" -> Some (Provider.anthropic_sonnet ())
+    | "haiku" -> Some (Provider.anthropic_haiku ())
+    | "opus" -> Some (Provider.anthropic_opus ())
+    | "openrouter" -> Some (Provider.openrouter ())
+    | "ollama" -> Some (Provider.ollama ())
+    | other ->
+        Some
+          {
+            Provider.provider = Local { base_url = "http://127.0.0.1:8085" };
+            model_id = other;
+            api_key_env = "LOCAL_LLM_KEY";
+          }
+  in
+  match base with
+  | None -> None
+  | Some cfg ->
+      Some
+        {
+          cfg with
+          model_id =
+            (match model with Some value when String.trim value <> "" -> value | _ -> cfg.model_id);
+        }
+
+let extract_text (resp : Types.api_response) =
+  resp.content
+  |> List.filter_map (function Types.Text s -> Some s | _ -> None)
+  |> String.concat "\n"
+
+let make_event (session : session) kind =
+  {
+    seq = session.last_seq + 1;
+    ts = Unix.gettimeofday ();
+    kind;
+  }
+
+let persist_event store state session kind =
+  let event = make_event session kind in
+  let* projected = Runtime_projection.apply_event session event in
+  let* () = Runtime_store.append_event store session.session_id event in
+  let* () = Runtime_store.save_session store projected in
+  let () = emit_event state session.session_id event in
+  Ok (projected, event)
+
+let generate_report_and_proof store (session : session) =
+  let* events = Runtime_store.read_events store session.session_id () in
+  let report = Runtime_projection.build_report session events in
+  let proof = Runtime_projection.build_proof session events in
+  let* () = Runtime_store.save_report store report in
+  let* () = Runtime_store.save_proof store proof in
+  Ok (report, proof)
+
+let run_participant state (session : session) (detail : spawn_agent_request) =
+  match String.lowercase_ascii (Option.value detail.provider ~default:"") with
+  | "mock" | "echo" ->
+      Ok
+        (Printf.sprintf "Mock runtime response for %s: %s" detail.participant_name
+           detail.prompt)
+  | _ ->
+      let provider_cfg = resolve_provider ?provider:detail.provider ?model:detail.model () in
+      Eio.Switch.run @@ fun sw ->
+      let config =
+        {
+          Types.default_config with
+          name = detail.participant_name;
+          model =
+            (match detail.model with
+             | Some value when String.trim value <> "" -> Types.Custom value
+             | _ -> Types.default_config.model);
+          system_prompt =
+            (match detail.system_prompt with
+             | Some prompt when String.trim prompt <> "" -> Some prompt
+             | _ -> session.system_prompt);
+          max_turns = Option.value detail.max_turns ~default:session.max_turns;
+        }
+      in
+      let options =
+        match provider_cfg with
+        | Some provider -> { Agent.default_options with provider = Some provider }
+        | None -> Agent.default_options
+      in
+      let agent = Agent.create ~net:state.net ~config ~options () in
+      match Agent.run ~sw agent detail.prompt with
+      | Ok response -> Ok (extract_text response)
+      | Error err -> Error err
+
+let start_session state (request : start_request) =
+  let* store = store_of_state state in
+  let session = Runtime_projection.initial_session request in
+  let* _ =
+    invoke_hook state ~hook_name:"SessionStart"
+      ~payload:(start_request_to_yojson request)
+  in
+  let event =
+    make_event session
+      (Session_started { goal = request.goal; participants = request.participants })
+  in
+  let* projected = Runtime_projection.apply_event session event in
+  let* () = Runtime_store.append_event store session.session_id event in
+  let* () = Runtime_store.save_session store projected in
+  let () = emit_event state session.session_id event in
+  Ok (Session_started_response projected)
+
+let finalize_session state store session reason =
+  let* session, _ =
+    match session.phase with
+    | Finalizing ->
+        Ok (session, make_event session (Finalize_requested { reason }))
+    | Bootstrapping | Running | Waiting_on_workers ->
+        persist_event store state session (Finalize_requested { reason })
+    | Completed | Failed | Cancelled ->
+        Ok (session, make_event session (Session_completed { outcome = session.outcome }))
+  in
+  let completion_kind =
+    match session.phase with
+    | Failed -> Session_failed { outcome = reason }
+    | Completed | Cancelled -> Session_completed { outcome = session.outcome }
+    | Bootstrapping | Running | Waiting_on_workers | Finalizing ->
+        Session_completed { outcome = first_some reason session.outcome }
+  in
+  let* final_session, _ = persist_event store state session completion_kind in
+  let* _report, _proof = generate_report_and_proof store final_session in
+  Ok (Finalized final_session)
+
+let apply_command state store session command =
+  match command with
+  | Record_turn detail ->
+      let* session, _ =
+        persist_event store state session
+          (Turn_recorded { actor = detail.actor; message = detail.message })
+      in
+      Ok (Command_applied session)
+  | Spawn_agent detail ->
+      let* permission =
+        ask_permission state ~action:"spawn_agent" ~subject:detail.participant_name
+          ~payload:(spawn_agent_request_to_yojson detail)
+      in
+      let permission_allowed, permission_message =
+        match permission with
+        | Permission_response result -> (result.allow, result.message)
+        | Hook_response _ -> (true, None)
+      in
+      let* session, _ =
+        persist_event store state session
+          (Agent_spawn_requested
+             {
+               participant_name = detail.participant_name;
+               role = detail.role;
+               prompt = detail.prompt;
+               provider = detail.provider;
+               model = detail.model;
+             })
+      in
+      let* hook_response =
+        invoke_hook state ~hook_name:"PreSpawn"
+          ~payload:(spawn_agent_request_to_yojson detail)
+      in
+      let hook_allowed, hook_message =
+        match hook_response with
+        | Hook_response result -> (result.continue_, result.message)
+        | Permission_response _ -> (true, None)
+      in
+      if not permission_allowed || not hook_allowed then
+        let* session, _ =
+          persist_event store state session
+            (Agent_failed
+               {
+                 participant_name = detail.participant_name;
+                 summary = None;
+                 error =
+                   Some
+                     (Option.value
+                        ~default:"spawn blocked by control policy"
+                        (first_some permission_message hook_message));
+               })
+        in
+        Ok (Command_applied session)
+      else
+        let* session, _ =
+          persist_event store state session
+            (Agent_became_live
+               {
+                 participant_name = detail.participant_name;
+                 summary = Some "runtime-started";
+                 error = None;
+               })
+        in
+        (match run_participant state session detail with
+         | Ok summary ->
+             let* _ =
+               invoke_hook state ~hook_name:"PostSpawn"
+                 ~payload:(`Assoc [ ("participant_name", `String detail.participant_name); ("status", `String "ok") ])
+             in
+             let* session, _ =
+               persist_event store state session
+                 (Agent_completed
+                    {
+                      participant_name = detail.participant_name;
+                      summary = Some summary;
+                      error = None;
+                    })
+             in
+             Ok (Command_applied session)
+         | Error err ->
+             let* _ =
+               invoke_hook state ~hook_name:"PostSpawn"
+                 ~payload:
+                   (`Assoc
+                      [
+                        ("participant_name", `String detail.participant_name);
+                        ("status", `String "error");
+                        ("error", `String (Error.to_string err));
+                      ])
+             in
+             let* session, _ =
+               persist_event store state session
+                 (Agent_failed
+                    {
+                      participant_name = detail.participant_name;
+                      summary = None;
+                      error = Some (Error.to_string err);
+                    })
+             in
+             Ok (Command_applied session))
+  | Attach_artifact detail ->
+      let* path =
+        Runtime_store.save_artifact_text store session.session_id ~name:detail.name
+          ~kind:detail.kind ~content:detail.content
+      in
+      let* session, _ =
+        persist_event store state session
+          (Artifact_attached
+             { name = detail.name; kind = detail.kind; path })
+      in
+      Ok (Command_applied session)
+  | Vote detail ->
+      let vote =
+        {
+          topic = detail.topic;
+          options = detail.options;
+          choice = detail.choice;
+          actor = detail.actor;
+          created_at = Unix.gettimeofday ();
+        }
+      in
+      let* session, _ = persist_event store state session (Vote_recorded vote) in
+      Ok (Command_applied session)
+  | Checkpoint detail ->
+      let path =
+        Runtime_store.snapshot_path store session.session_id
+          ~seq:(session.last_seq + 1) ~label:detail.label
+      in
+      let* session, _ =
+        persist_event store state session
+          (Checkpoint_saved { label = detail.label; path })
+      in
+      let* _ = Runtime_store.save_snapshot store session ~label:detail.label in
+      Ok (Command_applied session)
+  | Request_finalize detail -> finalize_session state store session detail.reason
+
+let handle_request state request =
+  match request with
+  | Initialize detail ->
+      state.session_root <- session_root_request_path detail.session_root;
+      let* _store = store_of_state state in
+      Ok
+        (Initialized
+           {
+             sdk_name = "agent_sdk";
+             sdk_version = "0.9.0";
+             runtime_version;
+             protocol_version = Runtime.protocol_version;
+             capabilities =
+               [
+                 "initialize";
+                 "start_session";
+                 "apply_command";
+                 "status";
+                 "events";
+                 "finalize";
+                 "report";
+                 "prove";
+               ];
+           })
+  | Start_session detail -> start_session state detail
+  | Apply_command { session_id; command } ->
+      let* store = store_of_state state in
+      let* session = Runtime_store.load_session store session_id in
+      apply_command state store session command
+  | Status { session_id } ->
+      let* store = store_of_state state in
+      let* session = Runtime_store.load_session store session_id in
+      Ok (Status_response session)
+  | Events { session_id; after_seq } ->
+      let* store = store_of_state state in
+      let* events = Runtime_store.read_events store session_id ?after_seq () in
+      Ok (Events_response events)
+  | Finalize { session_id; reason } ->
+      let* store = store_of_state state in
+      let* session = Runtime_store.load_session store session_id in
+      let* _ =
+        invoke_hook state ~hook_name:"Stop"
+          ~payload:
+            (`Assoc
+               [
+                 ("session_id", `String session_id);
+                 ( "reason",
+                   match reason with Some value -> `String value | None -> `Null );
+               ])
+      in
+      finalize_session state store session reason
+  | Report { session_id } ->
+      let* store = store_of_state state in
+      let* session = Runtime_store.load_session store session_id in
+      let* events = Runtime_store.read_events store session_id () in
+      let report = Runtime_projection.build_report session events in
+      let* () = Runtime_store.save_report store report in
+      Ok (Report_response report)
+  | Prove { session_id } ->
+      let* store = store_of_state state in
+      let* session = Runtime_store.load_session store session_id in
+      let* events = Runtime_store.read_events store session_id () in
+      let proof = Runtime_projection.build_proof session events in
+      let* () = Runtime_store.save_proof store proof in
+      Ok (Prove_response proof)
+  | Shutdown -> Ok Shutdown_ack
+
+let serve_stdio ~net () =
+  let state = create ~net () in
+  let rec loop () =
+    match input_line stdin with
+    | exception End_of_file -> ()
+    | raw -> (
+        match protocol_message_of_string raw with
+        | Ok (Request_message payload) ->
+            let response =
+              match handle_request state payload.request with
+              | Ok response -> response
+              | Error err -> Error_response (Error.to_string err)
+            in
+            write_protocol_message
+              (Response_message
+                 { request_id = payload.request_id; response });
+            (match response with
+             | Shutdown_ack -> ()
+             | _ -> loop ())
+        | Ok _ -> loop ()
+        | Error _ -> (
+            match request_of_string raw with
+            | Error detail ->
+                write_protocol_message
+                  (Response_message
+                     { request_id = "legacy"; response = Error_response detail });
+                loop ()
+            | Ok request ->
+            let response =
+              match handle_request state request with
+              | Ok response -> response
+              | Error err -> Error_response (Error.to_string err)
+            in
+            write_protocol_message
+              (Response_message { request_id = "legacy"; response });
+            match response with
+            | Shutdown_ack -> ()
+            | _ -> loop ()))
+  in
+  loop ()

--- a/lib/runtime_store.ml
+++ b/lib/runtime_store.ml
@@ -1,0 +1,252 @@
+open Runtime
+
+let ( let* ) = Result.bind
+
+type t = {
+  root: string;
+}
+
+let sessions_dir store = Filename.concat store.root "sessions"
+let session_dir store session_id = Filename.concat (sessions_dir store) session_id
+let session_path store session_id = Filename.concat (session_dir store session_id) "session.json"
+let events_path store session_id = Filename.concat (session_dir store session_id) "events.jsonl"
+let snapshots_dir store session_id = Filename.concat (session_dir store session_id) "snapshots"
+let artifacts_dir store session_id = Filename.concat (session_dir store session_id) "artifacts"
+let report_json_path store session_id = Filename.concat (artifacts_dir store session_id) "report.json"
+let report_md_path store session_id = Filename.concat (artifacts_dir store session_id) "report.md"
+let proof_json_path store session_id = Filename.concat (artifacts_dir store session_id) "proof.json"
+let proof_md_path store session_id = Filename.concat (artifacts_dir store session_id) "proof.md"
+
+let ensure_dir path =
+  try
+    if Sys.file_exists path then Ok ()
+    else (
+      Unix.mkdir path 0o755;
+      Ok ())
+  with
+  | Unix.Unix_error (err, _, _) ->
+      Error
+        (Error.Io
+           (FileOpFailed
+              {
+                op = "mkdir";
+                path;
+                detail = Unix.error_message err;
+              }))
+  | exn ->
+      Error
+        (Error.Io
+           (FileOpFailed
+              { op = "mkdir"; path; detail = Printexc.to_string exn }))
+
+let ensure_tree store session_id =
+  let* () = ensure_dir store.root in
+  let* () = ensure_dir (sessions_dir store) in
+  let* () = ensure_dir (session_dir store session_id) in
+  let* () = ensure_dir (snapshots_dir store session_id) in
+  ensure_dir (artifacts_dir store session_id)
+
+let default_root () =
+  match Sys.getenv_opt "OAS_RUNTIME_SESSION_ROOT" with
+  | Some value when String.trim value <> "" -> String.trim value
+  | _ -> Filename.concat (Sys.getcwd ()) ".oas-runtime"
+
+let create ?root () =
+  let resolved =
+    match root with
+    | Some value when String.trim value <> "" -> String.trim value
+    | _ -> default_root ()
+  in
+  let store = { root = resolved } in
+  let* () = ensure_dir resolved in
+  let* () = ensure_dir (sessions_dir store) in
+  Ok store
+
+let save_text path content =
+  try
+    let oc = open_out_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () ->
+        output_string oc content;
+        flush oc;
+        Ok ())
+  with
+  | Sys_error detail ->
+      Error
+        (Error.Io
+           (FileOpFailed { op = "write"; path; detail }))
+  | exn ->
+      Error
+        (Error.Io
+           (FileOpFailed
+              { op = "write"; path; detail = Printexc.to_string exn }))
+
+let load_text path =
+  try
+    let ic = open_in_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+        let len = in_channel_length ic in
+        Ok (really_input_string ic len))
+  with
+  | Sys_error detail ->
+      Error
+        (Error.Io
+           (FileOpFailed { op = "read"; path; detail }))
+  | exn ->
+      Error
+        (Error.Io
+           (FileOpFailed
+              { op = "read"; path; detail = Printexc.to_string exn }))
+
+let save_session store (session : session) =
+  let* () = ensure_tree store session.session_id in
+  save_text
+    (session_path store session.session_id)
+    (session |> session_to_yojson |> Yojson.Safe.pretty_to_string)
+
+let load_session store session_id =
+  let* raw = load_text (session_path store session_id) in
+  try
+    match session_of_yojson (Yojson.Safe.from_string raw) with
+    | Ok session -> Ok session
+    | Error detail ->
+        Error
+          (Error.Serialization (JsonParseError { detail }))
+  with Yojson.Json_error detail ->
+    Error (Error.Serialization (JsonParseError { detail }))
+
+let append_event store session_id (event : event) =
+  let* () = ensure_tree store session_id in
+  let path = events_path store session_id in
+  try
+    let oc =
+      open_out_gen [ Open_creat; Open_text; Open_append ] 0o644 path
+    in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () ->
+        output_string oc (event |> event_to_yojson |> Yojson.Safe.to_string);
+        output_char oc '\n';
+        flush oc;
+        Ok ())
+  with
+  | Sys_error detail ->
+      Error
+        (Error.Io (FileOpFailed { op = "append"; path; detail }))
+  | exn ->
+      Error
+        (Error.Io
+           (FileOpFailed
+              { op = "append"; path; detail = Printexc.to_string exn }))
+
+let read_events store session_id ?after_seq () =
+  let path = events_path store session_id in
+  if not (Sys.file_exists path) then Ok []
+  else
+    let* raw = load_text path in
+    raw
+    |> String.split_on_char '\n'
+    |> List.filter (fun line -> String.trim line <> "")
+    |> List.fold_left
+         (fun acc line ->
+           let* rev = acc in
+           try
+             match event_of_yojson (Yojson.Safe.from_string line) with
+             | Ok event ->
+                 let should_include =
+                   match after_seq with
+                   | Some min_seq -> event.seq > min_seq
+                   | None -> true
+                 in
+                 if should_include then Ok (event :: rev) else Ok rev
+             | Error detail ->
+                 Error
+                   (Error.Serialization (JsonParseError { detail }))
+           with Yojson.Json_error detail ->
+             Error (Error.Serialization (JsonParseError { detail })))
+         (Ok [])
+    |> Result.map List.rev
+
+let snapshot_path store session_id ~seq ~label =
+  let base =
+    match label with
+    | Some value when String.trim value <> "" ->
+        Printf.sprintf "%04d-%s.json" seq
+          (String.map (function '/' | ' ' -> '_' | c -> c) value)
+    | _ -> Printf.sprintf "%04d.json" seq
+  in
+  Filename.concat (snapshots_dir store session_id) base
+
+let save_snapshot store (session : session) ~label =
+  let path = snapshot_path store session.session_id ~seq:session.last_seq ~label in
+  let* () = ensure_tree store session.session_id in
+  let* () =
+    save_text path (session |> session_to_yojson |> Yojson.Safe.pretty_to_string)
+  in
+  Ok path
+
+let save_artifact_text store session_id ~name ~kind ~content =
+  let safe_name =
+    if String.trim name = "" then "artifact"
+    else String.map (function '/' | ' ' -> '_' | c -> c) name
+  in
+  let extension =
+    match String.lowercase_ascii kind with
+    | "markdown" | "md" -> "md"
+    | "json" -> "json"
+    | "text" | "txt" -> "txt"
+    | other when other <> "" -> other
+    | _ -> "txt"
+  in
+  let path =
+    Filename.concat (artifacts_dir store session_id)
+      (Printf.sprintf "%s.%s" safe_name extension)
+  in
+  let* () = ensure_tree store session_id in
+  let* () = save_text path content in
+  Ok path
+
+let save_report store (report : report) =
+  let* () = ensure_tree store report.session_id in
+  let* () =
+    save_text (report_json_path store report.session_id)
+      (report |> report_to_yojson |> Yojson.Safe.pretty_to_string)
+  in
+  save_text (report_md_path store report.session_id) report.markdown
+
+let save_proof store (proof : proof) =
+  let* () = ensure_tree store proof.session_id in
+  let* () =
+    save_text (proof_json_path store proof.session_id)
+      (proof |> proof_to_yojson |> Yojson.Safe.pretty_to_string)
+  in
+  let markdown =
+    let checks =
+      proof.checks
+      |> List.map (fun check ->
+             Printf.sprintf "- [%s] %s"
+               (if check.passed then "x" else " ") check.name)
+      |> String.concat "\n"
+    in
+    let evidence =
+      proof.evidence |> List.map (fun line -> "- " ^ line) |> String.concat "\n"
+    in
+    String.concat "\n"
+      [
+        "# Runtime Proof";
+        "";
+        Printf.sprintf "- Session ID: %s" proof.session_id;
+        Printf.sprintf "- Overall OK: %b" proof.ok;
+        "";
+        "## Checks";
+        checks;
+        "";
+        "## Evidence";
+        evidence;
+        "";
+      ]
+  in
+  save_text (proof_md_path store proof.session_id) markdown

--- a/lib/sdk_client_types.ml
+++ b/lib/sdk_client_types.ml
@@ -1,0 +1,89 @@
+type permission_mode =
+  | Default
+  | Accept_edits
+  | Plan
+  | Bypass_permissions
+[@@deriving show]
+
+type setting_source =
+  | User
+  | Project
+  | Local
+[@@deriving show]
+
+type agent_definition = {
+  description: string;
+  prompt: string;
+  tools: string list option;
+  model: string option;
+}
+[@@deriving show]
+
+type options = {
+  runtime_path: string option;
+  session_root: string option;
+  cwd: string option;
+  permission_mode: permission_mode;
+  model: string option;
+  system_prompt: string option;
+  max_turns: int option;
+  provider: string option;
+  agents: (string * agent_definition) list;
+  include_partial_messages: bool;
+  setting_sources: setting_source list;
+}
+[@@deriving show]
+
+type message =
+  | System_message of string
+  | Session_status of Runtime.session
+  | Session_events of Runtime.event list
+  | Session_report of Runtime.report
+  | Session_proof of Runtime.proof
+[@@deriving show]
+
+type permission_result =
+  | Permission_result_allow of { message: string option }
+  | Permission_result_deny of { message: string option; interrupt: bool }
+
+type tool_permission_context = {
+  suggestions: string list;
+}
+
+type can_use_tool =
+  string -> Yojson.Safe.t -> tool_permission_context -> permission_result
+
+type hook_result =
+  | Hook_continue
+  | Hook_block of string option
+
+type hook_callback =
+  string -> Yojson.Safe.t -> hook_result
+
+let default_options =
+  {
+    runtime_path = None;
+    session_root = None;
+    cwd = None;
+    permission_mode = Default;
+    model = None;
+    system_prompt = None;
+    max_turns = Some 8;
+    provider = None;
+    agents = [];
+    include_partial_messages = false;
+    setting_sources = [];
+  }
+
+let default_agent =
+  {
+    description = "General purpose assistant";
+    prompt = "";
+    tools = None;
+    model = None;
+  }
+
+let agent_entries options =
+  match options.agents with
+  | [] -> [ ("assistant", default_agent) ]
+  | entries -> entries

--- a/lib/sessions.ml
+++ b/lib/sessions.ml
@@ -1,0 +1,74 @@
+type session_info = {
+  session_id: string;
+  title: string option;
+  tag: string option;
+  goal: string;
+  updated_at: float;
+  phase: Runtime.phase;
+  participant_count: int;
+  path: string;
+}
+
+let ( let* ) = Result.bind
+
+let make_store ?session_root () =
+  Runtime_store.create ?root:session_root ()
+
+let list_sessions ?session_root () =
+  let* store = make_store ?session_root () in
+  let root = Runtime_store.sessions_dir store in
+  if not (Sys.file_exists root) then Ok []
+  else
+    root |> Sys.readdir |> Array.to_list |> List.sort String.compare
+    |> List.fold_left
+         (fun acc session_id ->
+           let* rev = acc in
+           let path = Runtime_store.session_path store session_id in
+           if Sys.is_directory (Runtime_store.session_dir store session_id) then
+             match Runtime_store.load_session store session_id with
+             | Ok session ->
+                 Ok
+                   ({
+                      session_id = session.session_id;
+                      title = session.title;
+                      tag = session.tag;
+                      goal = session.goal;
+                      updated_at = session.updated_at;
+                      phase = session.phase;
+                      participant_count = List.length session.participants;
+                      path;
+                    }
+                    :: rev)
+             | Error _ -> Ok rev
+           else Ok rev)
+         (Ok [])
+    |> Result.map List.rev
+
+let get_session ?session_root session_id =
+  let* store = make_store ?session_root () in
+  Runtime_store.load_session store session_id
+
+let get_session_events ?session_root session_id =
+  let* store = make_store ?session_root () in
+  Runtime_store.read_events store session_id ()
+
+let rename_session ?session_root ~session_id ~title () =
+  let* store = make_store ?session_root () in
+  let* session = Runtime_store.load_session store session_id in
+  let title =
+    match String.trim title with
+    | "" ->
+        None
+    | value -> Some value
+  in
+  Runtime_store.save_session store { session with title }
+
+let tag_session ?session_root ~session_id ~tag () =
+  let* store = make_store ?session_root () in
+  let* session = Runtime_store.load_session store session_id in
+  let normalized =
+    match tag with
+    | Some value when String.trim value <> "" -> Some (String.trim value)
+    | _ -> None
+  in
+  Runtime_store.save_session store { session with tag = normalized }

--- a/lib/transport.ml
+++ b/lib/transport.ml
@@ -1,0 +1,217 @@
+type options = {
+  runtime_path: string option;
+  session_root: string option;
+}
+
+let ( let* ) = Result.bind
+
+let default_options = {
+  runtime_path = None;
+  session_root = None;
+}
+
+type t = {
+  runtime_path: string;
+  ic: in_channel;
+  oc: out_channel;
+  ec: in_channel;
+  mutable closed: bool;
+  mutable next_request_id: int;
+}
+
+type control_handler =
+  Runtime.control_request -> (Runtime.control_response, Error.sdk_error) result
+
+type event_handler = Runtime.event -> unit
+
+let candidate_paths ?runtime_path () =
+  let env_runtime = Sys.getenv_opt "OAS_RUNTIME_PATH" in
+  let exe_dir = Filename.dirname Sys.executable_name in
+  let from_exe =
+    [
+      Filename.concat exe_dir "../bin/oas_runtime.exe";
+      Filename.concat exe_dir "oas_runtime.exe";
+      Filename.concat exe_dir "_bundled/oas-runtime";
+      Filename.concat exe_dir "_bundled/oas_runtime.exe";
+    ]
+  in
+  let cwd = Sys.getcwd () in
+  let from_cwd =
+    [
+      Filename.concat cwd "_build/default/bin/oas_runtime.exe";
+      Filename.concat cwd "bin/oas_runtime.exe";
+      Filename.concat cwd "_bundled/oas-runtime";
+    ]
+  in
+  let from_path =
+    match Sys.getenv_opt "PATH" with
+    | None -> []
+    | Some path ->
+        path
+        |> String.split_on_char ':'
+        |> List.concat_map (fun dir ->
+               [ Filename.concat dir "oas-runtime"; Filename.concat dir "oas_runtime.exe" ])
+  in
+  List.filter_map
+    (fun value ->
+      match value with
+      | Some candidate when String.trim candidate <> "" -> Some candidate
+      | _ -> None)
+    [ runtime_path; env_runtime ]
+  @ from_exe @ from_cwd @ from_path
+
+let is_runnable path =
+  Sys.file_exists path && not (Sys.is_directory path)
+
+let find_runtime ?runtime_path () =
+  match List.find_opt is_runnable (candidate_paths ?runtime_path ()) with
+  | Some path -> Ok path
+  | None ->
+      Error
+        (Error.Io
+           (Error.FileOpFailed
+              {
+                op = "find_runtime";
+                path = "oas_runtime";
+                detail =
+                  "No runtime binary found. Set OAS_RUNTIME_PATH or build bin/oas_runtime.exe.";
+              }))
+
+let write_protocol_message oc message =
+  output_string oc (Runtime.protocol_message_to_string message);
+  output_char oc '\n';
+  flush oc
+
+let next_request_id transport =
+  let id = transport.next_request_id in
+  transport.next_request_id <- id + 1;
+  Printf.sprintf "req-%06d" id
+
+let respond_to_control transport control_id response =
+  write_protocol_message transport.oc
+    (Runtime.Control_response_message { control_id; response })
+
+let rec read_until_response ?control_handler ?event_handler transport request_id =
+  let open Error in
+  try
+    let line = input_line transport.ic in
+    match Runtime.protocol_message_of_string line with
+    | Error detail ->
+        Error (Serialization (JsonParseError { detail }))
+    | Ok (Runtime.Response_message payload) when String.equal payload.request_id request_id ->
+        Ok payload.response
+    | Ok (Runtime.Control_request_message payload) -> (
+        let response =
+          match control_handler with
+          | Some handler -> handler payload.request
+          | None ->
+              Ok
+                (match payload.request with
+                 | Runtime.Permission_request _ ->
+                     Runtime.Permission_response
+                       { allow = true; message = None; interrupt = false }
+                 | Runtime.Hook_request _ ->
+                     Runtime.Hook_response { continue_ = true; message = None })
+        in
+        (match response with
+         | Ok response ->
+             respond_to_control transport payload.control_id response;
+             read_until_response ?control_handler ?event_handler transport request_id
+         | Error err -> Error err))
+    | Ok (Runtime.Event_message payload) ->
+        Option.iter (fun handle -> handle payload.event) event_handler;
+        read_until_response ?control_handler ?event_handler transport request_id
+    | Ok (Runtime.System_message _) ->
+        read_until_response ?control_handler ?event_handler transport request_id
+    | Ok _ ->
+        read_until_response ?control_handler ?event_handler transport request_id
+  with
+  | End_of_file ->
+      Error
+        (Io
+           (FileOpFailed
+              {
+                op = "read";
+                path = transport.runtime_path;
+                detail = "Runtime closed the stream";
+              }))
+  | Sys_error detail ->
+      Error
+        (Io
+           (FileOpFailed
+              { op = "request"; path = transport.runtime_path; detail }))
+  | exn ->
+      Error
+        (Io
+           (FileOpFailed
+              {
+                op = "request";
+                path = transport.runtime_path;
+                detail = Printexc.to_string exn;
+              }))
+
+let connect ?(options = default_options) () =
+  let open Error in
+  let* runtime_path = find_runtime ?runtime_path:options.runtime_path () in
+  try
+    let env = Unix.environment () in
+    let argv = [| runtime_path |] in
+    let ic, oc, ec = Unix.open_process_args_full runtime_path argv env in
+    let transport = { runtime_path; ic; oc; ec; closed = false; next_request_id = 1 } in
+    let init_request_id = next_request_id transport in
+    write_protocol_message oc
+      (Runtime.Request_message
+         {
+           request_id = init_request_id;
+           request = Runtime.Initialize { session_root = options.session_root };
+         });
+    let* response = read_until_response transport init_request_id in
+    (match response with
+     | Runtime.Initialized init when String.equal init.protocol_version Runtime.protocol_version ->
+         Ok transport
+     | Runtime.Initialized init ->
+         Error
+           (Internal
+              (Printf.sprintf "Protocol version mismatch: runtime=%s sdk=%s"
+                 init.protocol_version Runtime.protocol_version))
+     | Runtime.Error_response detail -> Error (Internal detail)
+     | other ->
+         Error
+           (Internal
+              (Printf.sprintf "Unexpected init response: %s"
+                 (Runtime.show_response other))))
+  with
+  | Unix.Unix_error (err, _, _) ->
+      Error
+        (Io
+           (FileOpFailed
+              {
+                op = "spawn";
+                path = runtime_path;
+                detail = Unix.error_message err;
+              }))
+  | exn ->
+      Error
+        (Io
+           (FileOpFailed
+              {
+                op = "spawn";
+                path = runtime_path;
+                detail = Printexc.to_string exn;
+              }))
+
+let request ?control_handler ?event_handler transport request =
+  let open Error in
+  if transport.closed then
+    Error (Internal "Runtime transport is already closed")
+  else
+    let request_id = next_request_id transport in
+    write_protocol_message transport.oc
+      (Runtime.Request_message { request_id; request });
+    read_until_response ?control_handler ?event_handler transport request_id
+
+let close transport =
+  if not transport.closed then (
+    (match request transport Runtime.Shutdown with _ -> ());
+    transport.closed <- true;
+    ignore (Unix.close_process_full (transport.ic, transport.oc, transport.ec)))

--- a/test/dune
+++ b/test/dune
@@ -163,3 +163,8 @@
 (test
  (name test_otel_tracer)
  (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_runtime)
+ (libraries agent_sdk alcotest unix)
+ (deps ../bin/oas_runtime.exe))

--- a/test/test_runtime.ml
+++ b/test/test_runtime.ml
@@ -1,0 +1,365 @@
+open Agent_sdk
+
+let runtime_path () =
+  let exe_dir = Filename.dirname Sys.executable_name in
+  let candidates =
+    [
+      Filename.concat exe_dir "../bin/oas_runtime.exe";
+      Filename.concat exe_dir "oas_runtime.exe";
+      Filename.concat (Sys.getcwd ()) "_build/default/bin/oas_runtime.exe";
+    ]
+  in
+  match List.find_opt Sys.file_exists candidates with
+  | Some path -> path
+  | None ->
+      Alcotest.fail
+        (Printf.sprintf "Unable to locate oas_runtime.exe from %s" Sys.executable_name)
+
+let with_temp_dir f =
+  let root =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "oas-runtime-%d-%06x" (Unix.getpid ()) (Random.int 0xFFFFFF))
+  in
+  Unix.mkdir root 0o755;
+  Fun.protect ~finally:(fun () -> ignore (Sys.command (Printf.sprintf "rm -rf %s" root)))
+    (fun () -> f root)
+
+let unwrap_response = function
+  | Ok response -> response
+  | Error err -> Alcotest.fail (Error.to_string err)
+
+let unwrap = function
+  | Ok value -> value
+  | Error err -> Alcotest.fail (Error.to_string err)
+
+let test_query_lifecycle () =
+  with_temp_dir @@ fun session_root ->
+  let runtime = runtime_path () in
+  let start_request =
+    Runtime.
+      {
+        session_id = Some "sess-query";
+        goal = "Ship the runtime";
+        participants = [ "planner"; "builder" ];
+        provider = Some "mock";
+        model = None;
+        system_prompt = Some "Coordinate the team";
+        max_turns = Some 3;
+        workdir = None;
+      }
+  in
+  let session =
+    match unwrap_response (runtime_query ~runtime_path:runtime ~session_root (Runtime.Start_session start_request)) with
+    | Runtime.Session_started_response session -> session
+    | other -> Alcotest.fail (Runtime.show_response other)
+  in
+  Alcotest.(check string) "session id" "sess-query" session.session_id;
+  Alcotest.(check bool) "phase running" true (session.phase = Runtime.Running);
+  let session =
+    match
+      unwrap_response
+        (runtime_query ~runtime_path:runtime ~session_root
+           (Runtime.Apply_command
+              {
+                session_id = session.session_id;
+                command =
+                  Runtime.Record_turn
+                    { actor = Some "supervisor"; message = "Plan the work." };
+              }))
+    with
+    | Runtime.Command_applied session -> session
+    | other -> Alcotest.fail (Runtime.show_response other)
+  in
+  Alcotest.(check int) "turn count" 1 session.turn_count;
+  let session =
+    match
+      unwrap_response
+        (runtime_query ~runtime_path:runtime ~session_root
+           (Runtime.Apply_command
+              {
+                session_id = session.session_id;
+                command =
+                  Runtime.Spawn_agent
+                    {
+                      participant_name = "planner";
+                      role = Some "planner";
+                      prompt = "Break the goal into two tasks.";
+                      provider = Some "mock";
+                      model = None;
+                      system_prompt = None;
+                      max_turns = Some 2;
+                    };
+              }))
+    with
+    | Runtime.Command_applied session -> session
+    | other -> Alcotest.fail (Runtime.show_response other)
+  in
+  let planner =
+    match
+      List.find_opt
+        (fun (participant : Runtime.participant) -> String.equal participant.name "planner")
+        ((session : Runtime.session).participants)
+    with
+    | Some participant -> participant
+    | None -> Alcotest.fail "planner participant missing"
+  in
+  Alcotest.(check bool) "planner done" true (planner.state = Runtime.Done);
+  let events =
+    match unwrap_response (runtime_query ~runtime_path:runtime ~session_root (Runtime.Events { session_id = session.session_id; after_seq = None })) with
+    | Runtime.Events_response events -> events
+    | other -> Alcotest.fail (Runtime.show_response other)
+  in
+  Alcotest.(check bool) "events non-empty" true (List.length events >= 4);
+  let session =
+    match unwrap_response (runtime_query ~runtime_path:runtime ~session_root (Runtime.Finalize { session_id = session.session_id; reason = Some "done" })) with
+    | Runtime.Finalized session -> session
+    | other -> Alcotest.fail (Runtime.show_response other)
+  in
+  Alcotest.(check bool) "completed" true (session.phase = Runtime.Completed);
+  let report =
+    match unwrap_response (runtime_query ~runtime_path:runtime ~session_root (Runtime.Report { session_id = session.session_id })) with
+    | Runtime.Report_response report -> report
+    | other -> Alcotest.fail (Runtime.show_response other)
+  in
+  Alcotest.(check bool) "report mentions session" true
+    (String.contains report.markdown 's');
+  let proof =
+    match unwrap_response (runtime_query ~runtime_path:runtime ~session_root (Runtime.Prove { session_id = session.session_id })) with
+    | Runtime.Prove_response proof -> proof
+    | other -> Alcotest.fail (Runtime.show_response other)
+  in
+  Alcotest.(check bool) "proof ok" true proof.ok
+
+let test_runtime_client_roundtrip () =
+  with_temp_dir @@ fun session_root ->
+  let client =
+    unwrap
+      (Runtime_client.connect
+         ~options:
+           {
+             Runtime_client.runtime_path = Some (runtime_path ());
+             session_root = Some session_root;
+           }
+         ())
+  in
+  Fun.protect
+    ~finally:(fun () -> Runtime_client.close client)
+    (fun () ->
+      let session =
+        unwrap
+          (Runtime_client.start_session client
+             Runtime.
+               {
+                 session_id = Some "sess-client";
+                 goal = "Inspect runtime";
+                 participants = [ "reviewer" ];
+                 provider = Some "mock";
+                 model = None;
+                 system_prompt = None;
+                 max_turns = Some 2;
+                 workdir = None;
+               })
+      in
+      let session =
+        unwrap
+          (Runtime_client.apply_command client ~session_id:session.session_id
+             (Runtime.Spawn_agent
+                {
+                  participant_name = "reviewer";
+                  role = Some "reviewer";
+                  prompt = "Review the session.";
+                  provider = Some "mock";
+                  model = None;
+                  system_prompt = None;
+                  max_turns = Some 1;
+                }))
+      in
+      let status = unwrap (Runtime_client.status client ~session_id:session.session_id) in
+      Alcotest.(check bool) "last seq progressed" true (status.last_seq >= 3))
+
+let test_high_level_query_and_sessions () =
+  with_temp_dir @@ fun session_root ->
+  let messages =
+    unwrap
+      (query
+         ~options:
+           {
+             Client.default_options with
+             runtime_path = Some (runtime_path ());
+             session_root = Some session_root;
+             provider = Some "mock";
+             system_prompt = Some "Use the harness.";
+             max_turns = Some 2;
+             agents =
+               [
+                 ( "planner",
+                   {
+                     Client.description = "planner";
+                     prompt = "Create a concise plan.";
+                     tools = None;
+                     model = None;
+                   } );
+               ];
+           }
+         ~prompt:"Implement a plan with one worker."
+         ())
+  in
+  Alcotest.(check bool) "messages returned" true (List.length messages >= 4);
+  let infos = unwrap (Sessions.list_sessions ~session_root ()) in
+  Alcotest.(check int) "one session listed" 1 (List.length infos);
+  let session_id =
+    match infos with
+    | [ info ] -> info.Sessions.session_id
+    | _ -> Alcotest.fail "expected exactly one session info"
+  in
+  unwrap
+    (Sessions.rename_session ~session_root ~session_id
+       ~title:"Renamed runtime session" ());
+  unwrap (Sessions.tag_session ~session_root ~session_id ~tag:(Some "experiment") ());
+  let session = unwrap (Sessions.get_session ~session_root session_id) in
+  Alcotest.(check (option string)) "title updated"
+    (Some "Renamed runtime session") session.title;
+  Alcotest.(check (option string)) "tag updated" (Some "experiment")
+    session.tag;
+  let events = unwrap (Sessions.get_session_events ~session_root session_id) in
+  Alcotest.(check bool) "events still available" true (List.length events >= 4)
+
+let test_control_roundtrip_callbacks () =
+  with_temp_dir @@ fun session_root ->
+  let client =
+    unwrap
+      (Client.connect
+         ~options:
+           {
+             Client.default_options with
+             runtime_path = Some (runtime_path ());
+             session_root = Some session_root;
+             provider = Some "mock";
+             agents =
+               [
+                 ( "guarded-worker",
+                   {
+                     Client.description = "guarded-worker";
+                     prompt = "Try to run, but require permission.";
+                     tools = None;
+                     model = None;
+                   } );
+               ];
+           }
+         ())
+  in
+  let permission_calls = ref 0 in
+  let hook_calls = ref [] in
+  Client.set_can_use_tool client (fun action payload _ctx ->
+      incr permission_calls;
+      let subject =
+        payload |> Yojson.Safe.Util.member "participant_name"
+        |> Yojson.Safe.Util.to_string_option
+      in
+      match (action, subject) with
+      | "spawn_agent", Some "guarded-worker" ->
+          Client.Permission_result_deny
+            { message = Some "blocked by permission callback"; interrupt = false }
+      | _ -> Client.Permission_result_allow { message = None });
+  Client.set_hook_callback client (fun hook_name _payload ->
+      hook_calls := hook_name :: !hook_calls;
+      Client.Hook_continue);
+  unwrap (Client.query client "Attempt the guarded worker.");
+  unwrap (Client.finalize client ());
+  let messages = Client.receive_messages client in
+  Client.close client;
+  Alcotest.(check int) "permission callback hit" 1 !permission_calls;
+  Alcotest.(check bool) "session start hook seen" true (List.mem "SessionStart" !hook_calls);
+  Alcotest.(check bool) "pre spawn hook seen" true (List.mem "PreSpawn" !hook_calls);
+  Alcotest.(check bool) "stop hook seen" true (List.mem "Stop" !hook_calls);
+  let final_status =
+    messages
+    |> List.filter_map (function
+         | Client.Session_status session -> Some session
+         | _ -> None)
+    |> List.rev
+    |> function
+    | session :: _ -> session
+    | [] -> Alcotest.fail "missing final session status"
+  in
+  let participant =
+    match
+      List.find_opt
+        (fun (participant : Runtime.participant) ->
+          String.equal participant.name "guarded-worker")
+        final_status.participants
+    with
+    | Some participant -> participant
+    | None -> Alcotest.fail "missing guarded worker"
+  in
+  Alcotest.(check bool) "guarded worker failed"
+    true (participant.state = Runtime.Failed_participant);
+  Alcotest.(check (option string)) "failure message"
+    (Some "blocked by permission callback") participant.last_error
+
+let test_receive_messages_streams_progressively () =
+  with_temp_dir @@ fun session_root ->
+  let client =
+    unwrap
+      (Client.connect
+         ~options:
+           {
+             Client.default_options with
+             runtime_path = Some (runtime_path ());
+             session_root = Some session_root;
+             provider = Some "mock";
+             agents =
+               [
+                 ( "stream-worker",
+                   {
+                     Client.description = "stream-worker";
+                     prompt = "Emit progress.";
+                     tools = None;
+                     model = None;
+                   } );
+               ];
+           }
+         ())
+  in
+  unwrap (Client.query client "Show me progressive runtime messages.");
+  let first_batch = Client.receive_messages client in
+  Alcotest.(check bool) "first batch non-empty" true (List.length first_batch >= 3);
+  let second_batch = Client.receive_messages client in
+  Alcotest.(check int) "buffer drained" 0 (List.length second_batch);
+  unwrap (Client.finalize client ());
+  let final_batch = Client.receive_messages client in
+  Client.close client;
+  let has_report =
+    List.exists
+      (function
+        | Client.Session_report _ -> true
+        | _ -> false)
+      final_batch
+  in
+  let has_proof =
+    List.exists
+      (function
+        | Client.Session_proof _ -> true
+        | _ -> false)
+      final_batch
+  in
+  Alcotest.(check bool) "report arrives later" true has_report;
+  Alcotest.(check bool) "proof arrives later" true has_proof
+
+let () =
+  Random.self_init ();
+  Alcotest.run "runtime"
+    [
+      ("query", [ Alcotest.test_case "lifecycle" `Quick test_query_lifecycle ]);
+      ( "runtime_client",
+        [ Alcotest.test_case "roundtrip" `Quick test_runtime_client_roundtrip ] );
+      ( "sdk",
+        [
+          Alcotest.test_case "high level query and sessions" `Quick
+            test_high_level_query_and_sessions;
+          Alcotest.test_case "control roundtrip callbacks" `Quick
+            test_control_roundtrip_callbacks;
+          Alcotest.test_case "receive messages progressively" `Quick
+            test_receive_messages_streams_progressively;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- add a harness-first runtime layer around a bundled `oas-runtime` subprocess
- split public SDK into high-level `query`/`Client` and low-level `runtime_query`/`Runtime_client`
- add runtime journal/session helpers (`Sessions`) plus control-protocol callback round-trips

## What Changed
- added typed runtime protocol, file-backed runtime store, report/proof projection, and `oas-runtime` executable
- added internal query engine/message parser/client layers so root `Client` is a thin facade
- added session listing/rename/tag helpers and runtime callback support for permission + hook control requests
- updated README to document the harness-first path

## Validation
- `dune build @all`
- `./_build/default/test/test_runtime.exe`
- `dune runtest`
- `git diff --check`

## Follow-up
- true background reader / long-lived interactive streaming client
- partial-message streaming parity with Claude Python SDK
