### PR TITLE
feat: add local qwen llama MCP interop

### DIFF
--- a/lib/agent.ml
+++ b/lib/agent.ml
@@ -414,7 +414,17 @@ let resume ~net ~(checkpoint : Checkpoint.t) ?(tools=[]) ?context
     name = checkpoint.agent_name;
     model = checkpoint.model;
     system_prompt = checkpoint.system_prompt;
+    temperature = checkpoint.temperature;
+    top_p = checkpoint.top_p;
+    top_k = checkpoint.top_k;
+    min_p = checkpoint.min_p;
+    enable_thinking = checkpoint.enable_thinking;
+    response_format_json = checkpoint.response_format_json;
+    thinking_budget = checkpoint.thinking_budget;
     tool_choice = checkpoint.tool_choice;
+    cache_system_prompt = checkpoint.cache_system_prompt;
+    max_input_tokens = checkpoint.max_input_tokens;
+    max_total_tokens = checkpoint.max_total_tokens;
   } in
   let state = {
     config = restored_config;
@@ -442,5 +452,15 @@ let checkpoint ?(session_id="") agent =
     created_at = Unix.gettimeofday ();
     tools = List.map (fun (t : Tool.t) -> t.schema) agent.tools;
     tool_choice = agent.state.config.tool_choice;
+    temperature = agent.state.config.temperature;
+    top_p = agent.state.config.top_p;
+    top_k = agent.state.config.top_k;
+    min_p = agent.state.config.min_p;
+    enable_thinking = agent.state.config.enable_thinking;
+    response_format_json = agent.state.config.response_format_json;
+    thinking_budget = agent.state.config.thinking_budget;
+    cache_system_prompt = agent.state.config.cache_system_prompt;
+    max_input_tokens = agent.state.config.max_input_tokens;
+    max_total_tokens = agent.state.config.max_total_tokens;
     mcp_sessions = Mcp_session.capture_all agent.options.mcp_clients;
   }

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -72,14 +72,22 @@ module Sessions = Sessions
 let create_agent ~net ?name ?model ?system_prompt ?max_tokens ?max_turns ?cache_system_prompt ?provider () =
   let open Types in
   let config = {
-    default_config with
     name = Option.value name ~default:default_config.name;
     model = Option.value model ~default:default_config.model;
     system_prompt;
     max_tokens = Option.value max_tokens ~default:default_config.max_tokens;
     max_turns = Option.value max_turns ~default:default_config.max_turns;
+    temperature = default_config.temperature;
+    top_p = default_config.top_p;
+    top_k = default_config.top_k;
+    min_p = default_config.min_p;
+    enable_thinking = default_config.enable_thinking;
     response_format_json = default_config.response_format_json;
+    thinking_budget = default_config.thinking_budget;
+    tool_choice = default_config.tool_choice;
     cache_system_prompt = Option.value cache_system_prompt ~default:default_config.cache_system_prompt;
+    max_input_tokens = default_config.max_input_tokens;
+    max_total_tokens = default_config.max_total_tokens;
   } in
   let options = match provider with
     | None -> Agent.default_options

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -119,6 +119,10 @@ module Types : sig
     max_tokens: int;
     max_turns: int;
     temperature: float option;
+    top_p: float option;
+    top_k: int option;
+    min_p: float option;
+    enable_thinking: bool option;
     response_format_json: bool;
     thinking_budget: int option;
     tool_choice: tool_choice option;
@@ -607,6 +611,14 @@ module Api : sig
       Text -> text part, Image/Document -> image_url with data URI. *)
   val openai_content_parts_of_blocks : Types.content_block list -> Yojson.Safe.t list
 
+  (** Build an OpenAI-compatible chat completions body. *)
+  val build_openai_body :
+    config:Types.agent_state ->
+    messages:Types.message list ->
+    ?tools:Yojson.Safe.t list ->
+    unit ->
+    string
+
   (** Parse an Ollama /api/chat response JSON string into an api_response.
       Handles tool_calls with arguments as both string and JSON object. *)
   val parse_ollama_chat_response : string -> Types.api_response
@@ -797,6 +809,16 @@ module Checkpoint : sig
     created_at: float;
     tools: Types.tool_schema list;
     tool_choice: Types.tool_choice option;
+    temperature: float option;
+    top_p: float option;
+    top_k: int option;
+    min_p: float option;
+    enable_thinking: bool option;
+    response_format_json: bool;
+    thinking_budget: int option;
+    cache_system_prompt: bool;
+    max_input_tokens: int option;
+    max_total_tokens: int option;
     mcp_sessions: Mcp_session.info list;
   }
 
@@ -1047,6 +1069,10 @@ module Builder : sig
   val with_max_tokens : int -> t -> t
   val with_max_turns : int -> t -> t
   val with_temperature : float -> t -> t
+  val with_top_p : float -> t -> t
+  val with_top_k : int -> t -> t
+  val with_min_p : float -> t -> t
+  val with_enable_thinking : bool -> t -> t
   val with_tools : Tool.t list -> t -> t
   val with_tool : Tool.t -> t -> t
   val with_hooks : Hooks.hooks -> t -> t

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -21,6 +21,7 @@ let build_body_assoc = Api_anthropic.build_body_assoc
 (* Re-export Api_openai *)
 let openai_messages_of_message = Api_openai.openai_messages_of_message
 let openai_content_parts_of_blocks = Api_openai.openai_content_parts_of_blocks
+let build_openai_body = Api_openai.build_openai_body
 let parse_openai_response = Api_openai.parse_openai_response
 
 (* Re-export Api_ollama *)

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -109,6 +109,19 @@ let tool_choice_to_openai_json = function
           ("function", `Assoc [("name", `String name)]);
         ]
 
+let strip_json_markdown_fences text =
+  let trimmed = String.trim text in
+  if String.length trimmed < 7 || String.sub trimmed 0 3 <> "```" then
+    trimmed
+  else
+    match String.split_on_char '\n' trimmed with
+    | first :: rest when String.length first >= 3 ->
+        (match List.rev rest with
+         | last :: middle_rev when String.trim last = "```" ->
+             String.concat "\n" (List.rev middle_rev) |> String.trim
+         | _ -> trimmed)
+    | _ -> trimmed
+
 let build_openai_tool_json = function
   | `Assoc fields ->
       let name =
@@ -158,6 +171,27 @@ let build_openai_body ~config ~messages ?tools () =
   let body_assoc =
     match config.config.temperature with
     | Some temp -> ("temperature", `Float temp) :: body_assoc
+    | None -> body_assoc
+  in
+  let body_assoc =
+    match config.config.top_p with
+    | Some top_p -> ("top_p", `Float top_p) :: body_assoc
+    | None -> body_assoc
+  in
+  let body_assoc =
+    match config.config.top_k with
+    | Some top_k -> ("top_k", `Int top_k) :: body_assoc
+    | None -> body_assoc
+  in
+  let body_assoc =
+    match config.config.min_p with
+    | Some min_p -> ("min_p", `Float min_p) :: body_assoc
+    | None -> body_assoc
+  in
+  let body_assoc =
+    match config.config.enable_thinking with
+    | Some enabled ->
+        ("chat_template_kwargs", `Assoc [("enable_thinking", `Bool enabled)]) :: body_assoc
     | None -> body_assoc
   in
   let body_assoc =
@@ -225,6 +259,16 @@ let parse_openai_response json_str =
                    | _ -> None)
             |> String.concat ""
         | _ -> ""
+      in
+      let text_content =
+        let stripped = strip_json_markdown_fences text_content in
+        if stripped = text_content then
+          text_content
+        else
+          try
+            ignore (Yojson.Safe.from_string stripped);
+            stripped
+          with Yojson.Json_error _ -> text_content
       in
       let tool_blocks =
         match msg |> member "tool_calls" with

--- a/lib/builder.ml
+++ b/lib/builder.ml
@@ -11,6 +11,10 @@ type t = {
   max_tokens: int;
   max_turns: int;
   temperature: float option;
+  top_p: float option;
+  top_k: int option;
+  min_p: float option;
+  enable_thinking: bool option;
   response_format_json: bool;
   thinking_budget: int option;
   tool_choice: tool_choice option;
@@ -38,6 +42,10 @@ let create ~net ~model =
     max_tokens = default_config.max_tokens;
     max_turns = default_config.max_turns;
     temperature = default_config.temperature;
+    top_p = default_config.top_p;
+    top_k = default_config.top_k;
+    min_p = default_config.min_p;
+    enable_thinking = default_config.enable_thinking;
     response_format_json = default_config.response_format_json;
     thinking_budget = default_config.thinking_budget;
     tool_choice = default_config.tool_choice;
@@ -62,6 +70,10 @@ let with_name name b = { b with name }
 let with_max_tokens n b = { b with max_tokens = n }
 let with_max_turns n b = { b with max_turns = n }
 let with_temperature t b = { b with temperature = Some t }
+let with_top_p p b = { b with top_p = Some p }
+let with_top_k k b = { b with top_k = Some k }
+let with_min_p p b = { b with min_p = Some p }
+let with_enable_thinking enabled b = { b with enable_thinking = Some enabled }
 let with_tools tools b = { b with tools }
 let with_tool tool b = { b with tools = b.tools @ [tool] }
 let with_hooks hooks b = { b with hooks }
@@ -89,6 +101,10 @@ let build b =
     max_tokens = b.max_tokens;
     max_turns = b.max_turns;
     temperature = b.temperature;
+    top_p = b.top_p;
+    top_k = b.top_k;
+    min_p = b.min_p;
+    enable_thinking = b.enable_thinking;
     response_format_json = b.response_format_json;
     thinking_budget = b.thinking_budget;
     tool_choice = b.tool_choice;

--- a/lib/checkpoint.ml
+++ b/lib/checkpoint.ml
@@ -21,6 +21,16 @@ type t = {
   created_at: float;
   tools: tool_schema list;
   tool_choice: tool_choice option;
+  temperature: float option;
+  top_p: float option;
+  top_k: int option;
+  min_p: float option;
+  enable_thinking: bool option;
+  response_format_json: bool;
+  thinking_budget: int option;
+  cache_system_prompt: bool;
+  max_input_tokens: int option;
+  max_total_tokens: int option;
   mcp_sessions: Mcp_session.info list;
 }
 
@@ -165,6 +175,16 @@ let to_json cp =
       (match cp.tool_choice with
        | Some tc -> tool_choice_to_json tc
        | None -> `Null));
+    ("temperature", Option.value ~default:`Null (Option.map (fun v -> `Float v) cp.temperature));
+    ("top_p", Option.value ~default:`Null (Option.map (fun v -> `Float v) cp.top_p));
+    ("top_k", Option.value ~default:`Null (Option.map (fun v -> `Int v) cp.top_k));
+    ("min_p", Option.value ~default:`Null (Option.map (fun v -> `Float v) cp.min_p));
+    ("enable_thinking", Option.value ~default:`Null (Option.map (fun v -> `Bool v) cp.enable_thinking));
+    ("response_format_json", `Bool cp.response_format_json);
+    ("thinking_budget", Option.value ~default:`Null (Option.map (fun v -> `Int v) cp.thinking_budget));
+    ("cache_system_prompt", `Bool cp.cache_system_prompt);
+    ("max_input_tokens", Option.value ~default:`Null (Option.map (fun v -> `Int v) cp.max_input_tokens));
+    ("max_total_tokens", Option.value ~default:`Null (Option.map (fun v -> `Int v) cp.max_total_tokens));
     ("mcp_sessions", Mcp_session.info_list_to_json cp.mcp_sessions);
   ]
 
@@ -211,6 +231,18 @@ let of_json json =
                created_at = json |> member "created_at" |> to_float;
                tools;
                tool_choice;
+               temperature = json |> member "temperature" |> to_float_option;
+               top_p = json |> member "top_p" |> to_float_option;
+               top_k = json |> member "top_k" |> to_int_option;
+               min_p = json |> member "min_p" |> to_float_option;
+               enable_thinking = json |> member "enable_thinking" |> to_bool_option;
+               response_format_json =
+                 json |> member "response_format_json" |> to_bool_option |> Option.value ~default:false;
+               thinking_budget = json |> member "thinking_budget" |> to_int_option;
+               cache_system_prompt =
+                 json |> member "cache_system_prompt" |> to_bool_option |> Option.value ~default:false;
+               max_input_tokens = json |> member "max_input_tokens" |> to_int_option;
+               max_total_tokens = json |> member "max_total_tokens" |> to_int_option;
                mcp_sessions;
              }
          | Error e, _, _, _ -> Error e

--- a/lib/mcp.ml
+++ b/lib/mcp.ml
@@ -1,12 +1,10 @@
 (** MCP (Model Context Protocol) client.
 
-    Wraps {!Mcp_protocol_eio.Client} to connect to MCP servers via Eio
-    stdio transport.  Bridges MCP tools to the SDK's {!Tool.t} type.
-
-    Protocol version: 2025-11-25 (via mcp-protocol-sdk v0.10.0). *)
+    Uses a tolerant NDJSON-over-stdio client for runtime interop while
+    keeping the pure SDK bridge helpers for tests. This lets OAS talk to
+    MCP servers that paginate [tools/list] and add non-standard fields. *)
 
 open Types
-module Sdk_client = Mcp_protocol_eio.Client
 module Sdk_types = Mcp_protocol.Mcp_types
 
 (* ── JSON Schema -> SDK tool_param (oas-specific bridge) ─────────── *)
@@ -71,7 +69,9 @@ let mcp_tool_to_sdk_tool ~call_fn mcp_tool =
 (* ── Eio stdio transport client ──────────────────────────────────── *)
 
 type t = {
-  client: Sdk_client.t;
+  reader: Eio.Buf_read.t;
+  writer: Eio.Flow.sink_ty Eio.Resource.t;
+  mutable next_id: int;
   kill: unit -> unit;
 }
 
@@ -101,44 +101,177 @@ let connect ~sw ~(mgr : _ Eio.Process.mgr) ~command ~args ?env () =
     in
     Eio.Flow.close r_child_stdin;
     Eio.Flow.close w_child_stdout;
-    let client =
-      Sdk_client.create
-        ~stdin:(r_child_stdout :> _ Eio.Flow.source)
-        ~stdout:(w_child_stdin :> _ Eio.Flow.sink)
-        ()
+    let reader =
+      Eio.Buf_read.of_flow (r_child_stdout :> _ Eio.Flow.source)
+        ~max_size:(16 * 1024 * 1024)
     in
     let kill () =
       try Eio.Process.signal proc Sys.sigterm with _ -> ()
     in
-    Ok { client; kill }
+    Ok { reader; writer = (w_child_stdin :> Eio.Flow.sink_ty Eio.Resource.t); next_id = 1; kill }
   with exn ->
     Error (Error.Mcp (ServerStartFailed { command; detail = Printexc.to_string exn }))
 
+(** Lightweight NDJSON request/response helpers. *)
+let send_raw t json =
+  Eio.Flow.copy_string (Yojson.Safe.to_string json ^ "\n") t.writer
+
+let rec read_response t =
+  try
+    let line = Eio.Buf_read.line t.reader |> String.trim in
+    if line = "" then
+      read_response t
+    else
+      let json = Yojson.Safe.from_string line in
+      let open Yojson.Safe.Util in
+      match json |> member "id" with
+      | `Null -> read_response t
+      | _ ->
+          (match json |> member "error" with
+           | `Null -> Ok (json |> member "result")
+           | error_obj ->
+               let message =
+                 error_obj |> member "message" |> to_string_option
+                 |> Option.value ~default:"Unknown MCP error"
+               in
+               Error message)
+  with
+  | End_of_file -> Error "MCP server closed connection"
+  | Yojson.Json_error msg -> Error ("Invalid JSON from MCP server: " ^ msg)
+  | Eio.Io _ as exn -> Error (Printexc.to_string exn)
+
+let send_request t ~method_ ?params () =
+  let id = t.next_id in
+  t.next_id <- t.next_id + 1;
+  let fields = [
+    ("jsonrpc", `String "2.0");
+    ("id", `Int id);
+    ("method", `String method_);
+  ] in
+  let fields =
+    match params with
+    | Some json -> fields @ [("params", json)]
+    | None -> fields
+  in
+  send_raw t (`Assoc fields);
+  read_response t
+
+let send_notification t ~method_ ?params () =
+  let fields = [
+    ("jsonrpc", `String "2.0");
+    ("method", `String method_);
+  ] in
+  let fields =
+    match params with
+    | Some json -> fields @ [("params", json)]
+    | None -> fields
+  in
+  send_raw t (`Assoc fields)
+
+let mcp_tool_of_json = function
+  | `Assoc fields ->
+      let input_schema =
+        match List.assoc_opt "inputSchema" fields with
+        | Some schema -> schema
+        | None ->
+            (match List.assoc_opt "input_schema" fields with
+             | Some schema -> schema
+             | None -> `Assoc [])
+      in
+      Some {
+        name =
+          (match List.assoc_opt "name" fields with
+           | Some (`String s) -> s
+           | _ -> "tool");
+        description =
+          (match List.assoc_opt "description" fields with
+           | Some (`String s) -> s
+           | _ -> "");
+        input_schema;
+      }
+  | _ -> None
+
 (** Send MCP initialize handshake. *)
 let initialize t =
-  match Sdk_client.initialize t.client
-          ~client_name:"oas-mcp-client" ~client_version:"0.9.0" with
-  | Ok _result -> Ok ()
+  let params =
+    `Assoc [
+      ("protocolVersion", `String "2025-11-25");
+      ("capabilities", `Assoc []);
+      ("clientInfo", `Assoc [
+        ("name", `String "oas-mcp-client");
+        ("version", `String "0.9.0");
+      ]);
+    ]
+  in
+  match send_request t ~method_:"initialize" ~params () with
+  | Ok _result ->
+      send_notification t ~method_:"notifications/initialized" ();
+      Ok ()
   | Error msg -> Error (Error.Mcp (InitializeFailed { detail = msg }))
 
 (** Fetch tools from MCP server and return them. *)
 let list_tools t =
-  match Sdk_client.list_tools t.client with
-  | Ok sdk_tools -> Ok (List.map mcp_tool_of_sdk_tool sdk_tools)
-  | Error msg ->
-    Error (Error.Mcp (ToolListFailed { detail = msg }))
+  let rec loop cursor acc =
+    let params =
+      match cursor with
+      | Some value -> Some (`Assoc [("cursor", `String value)])
+      | None -> None
+    in
+    match send_request t ~method_:"tools/list" ?params () with
+    | Error msg ->
+        Error (Error.Mcp (ToolListFailed { detail = msg }))
+    | Ok result ->
+        let open Yojson.Safe.Util in
+        let page =
+          match result |> member "tools" with
+          | `List items -> List.filter_map mcp_tool_of_json items
+          | _ -> []
+        in
+        let next_cursor = result |> member "nextCursor" |> to_string_option in
+        let acc = acc @ page in
+        (match next_cursor with
+         | Some value when String.trim value <> "" -> loop (Some value) acc
+         | _ -> Ok acc)
+  in
+  loop None []
 
 (** Invoke a tool on the MCP server.
     Returns the concatenated text content on success. *)
 let call_tool t ~name ~arguments =
-  match Sdk_client.call_tool t.client ~name ~arguments () with
-  | Ok result ->
-    let text = text_of_tool_result result in
-    let is_error =
-      result.is_error |> Option.value ~default:false in
-    if is_error then Error text else Ok text
+  let params =
+    `Assoc [
+      ("name", `String name);
+      ("arguments", arguments);
+    ]
+  in
+  match send_request t ~method_:"tools/call" ~params () with
   | Error msg ->
-    Error (Printf.sprintf "MCP tools/call '%s' failed: %s" name msg)
+      Error (Printf.sprintf "MCP tools/call '%s' failed: %s" name msg)
+  | Ok result ->
+      let open Yojson.Safe.Util in
+      let content =
+        match result |> member "content" with
+        | `List items -> items
+        | _ -> []
+      in
+      let text =
+        List.filter_map (fun item ->
+          if item |> member "type" |> to_string_option = Some "text" then
+            item |> member "text" |> to_string_option
+          else
+            None
+        ) content
+        |> String.concat "\n"
+      in
+      let is_error =
+        match result |> member "isError" with
+        | `Bool b -> b
+        | _ ->
+            (match result |> member "is_error" with
+             | `Bool b -> b
+             | _ -> false)
+      in
+      if is_error then Error text else Ok text
 
 (** Convert MCP tools to SDK [Tool.t] list.
     Each tool's handler delegates to {!call_tool} on [t]. *)
@@ -152,7 +285,6 @@ let to_tools t (tools : mcp_tool list) =
 
 (** Close the MCP client and terminate the subprocess. *)
 let close t =
-  (try Sdk_client.close t.client with _ -> ());
   t.kill ()
 
 (* ── Managed lifecycle ─────────────────────────────────────────── *)

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -75,8 +75,8 @@ let resolve cfg =
     Ok (base_url, "dummy", [("Content-Type", "application/json")])
 
 let local_qwen () = {
-  provider = Local { base_url = "http://127.0.0.1:3034" };
-  model_id = "qwen3.5";
+  provider = Local { base_url = "http://127.0.0.1:8085" };
+  model_id = "qwen3.5-35b-a3b-ud-q8-xl";
   api_key_env = "DUMMY_KEY";
 }
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -143,6 +143,10 @@ type agent_config = {
   max_tokens: int;
   max_turns: int;
   temperature: float option;
+  top_p: float option;
+  top_k: int option;
+  min_p: float option;
+  enable_thinking: bool option;
   response_format_json: bool;
   thinking_budget: int option; (* For Claude 3.7+ extended thinking *)
   tool_choice: tool_choice option;
@@ -159,6 +163,10 @@ let default_config = {
   max_tokens = 4096;
   max_turns = 10;
   temperature = None;
+  top_p = None;
+  top_k = None;
+  min_p = None;
+  enable_thinking = None;
   response_format_json = false;
   thinking_budget = None;
   tool_choice = None;

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -137,6 +137,33 @@ let test_build_body_with_tools () =
   let tools = json |> member "tools" |> to_list in
   check int "1 tool" 1 (List.length tools)
 
+let test_build_openai_body_with_qwen_sampling () =
+  let state = {
+    Types.config = {
+      Types.default_config with
+      model = Types.Custom "qwen3.5-35b-a3b-ud-q8-xl";
+      temperature = Some 0.6;
+      top_p = Some 0.95;
+      top_k = Some 20;
+      min_p = Some 0.01;
+      enable_thinking = Some false;
+    };
+    messages = [];
+    turn_count = 0;
+    usage = Types.empty_usage;
+  } in
+  let json =
+    Api.build_openai_body ~config:state ~messages:[] ()
+    |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  check (option (float 0.001)) "top_p" (Some 0.95) (json |> member "top_p" |> to_float_option);
+  check (option int) "top_k" (Some 20) (json |> member "top_k" |> to_int_option);
+  check (option (float 0.001)) "min_p" (Some 0.01) (json |> member "min_p" |> to_float_option);
+  check bool "enable_thinking false"
+    false
+    (json |> member "chat_template_kwargs" |> member "enable_thinking" |> to_bool)
+
 (* ------------------------------------------------------------------ *)
 (* parse_response                                                       *)
 (* ------------------------------------------------------------------ *)
@@ -194,6 +221,26 @@ let test_parse_response_unknown_stop () =
   (match resp.stop_reason with
    | Types.Unknown "new_future_reason" -> ()
    | sr -> fail (Printf.sprintf "expected Unknown, got %s" (Types.show_stop_reason sr)))
+
+let test_parse_openai_response_strips_fenced_json () =
+  let json_str = {|{
+    "id": "chatcmpl_test",
+    "model": "qwen",
+    "choices": [{
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "```json\n{\"engine\":\"default\",\"tool_calling\":false}\n```"
+      }
+    }]
+  }|} in
+  let resp = Api.parse_openai_response json_str in
+  match resp.content with
+  | [Types.Text text] ->
+      Alcotest.(check string) "stripped json"
+        "{\"engine\":\"default\",\"tool_calling\":false}" text
+  | _ -> Alcotest.fail "expected stripped text block"
 
 (* ------------------------------------------------------------------ *)
 (* message_to_json                                                      *)
@@ -435,6 +482,7 @@ let () =
       test_case "without thinking" `Quick test_build_body_without_thinking;
       test_case "with tool_choice" `Quick test_build_body_with_tool_choice;
       test_case "with tools" `Quick test_build_body_with_tools;
+      test_case "with qwen sampling" `Quick test_build_openai_body_with_qwen_sampling;
       test_case "with cache_system_prompt" `Quick test_build_body_with_cache;
       test_case "no system prompt" `Quick test_build_body_no_system_prompt;
     ];
@@ -442,6 +490,7 @@ let () =
       test_case "complete response" `Quick test_parse_response_complete;
       test_case "tool_use response" `Quick test_parse_response_tool_use;
       test_case "unknown stop_reason" `Quick test_parse_response_unknown_stop;
+      test_case "strip fenced json" `Quick test_parse_openai_response_strips_fenced_json;
       test_case "cache tokens in usage" `Quick test_parse_response_with_cache_tokens;
     ];
     "parse_sse_event", [

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -83,6 +83,22 @@ let test_with_temperature () =
   Alcotest.(check (option (float 0.001))) "temperature"
     (Some 0.7) agent.state.config.temperature
 
+let test_with_qwen_sampling () =
+  with_net @@ fun net ->
+  let agent =
+    Builder.create ~net ~model:Types.(Custom "qwen3.5-35b-a3b-ud-q8-xl")
+    |> Builder.with_top_p 0.95
+    |> Builder.with_top_k 20
+    |> Builder.with_min_p 0.01
+    |> Builder.with_enable_thinking false
+    |> Builder.build
+  in
+  Alcotest.(check (option (float 0.001))) "top_p" (Some 0.95) agent.state.config.top_p;
+  Alcotest.(check (option int)) "top_k" (Some 20) agent.state.config.top_k;
+  Alcotest.(check (option (float 0.001))) "min_p" (Some 0.01) agent.state.config.min_p;
+  Alcotest.(check (option bool)) "enable_thinking" (Some false)
+    agent.state.config.enable_thinking
+
 (* --- 7. with_tools replaces --- *)
 
 let test_with_tools_replaces () =
@@ -433,6 +449,7 @@ let () =
       Alcotest.test_case "max_tokens" `Quick test_with_max_tokens;
       Alcotest.test_case "max_turns" `Quick test_with_max_turns;
       Alcotest.test_case "temperature" `Quick test_with_temperature;
+      Alcotest.test_case "qwen sampling" `Quick test_with_qwen_sampling;
       Alcotest.test_case "tools replaces" `Quick test_with_tools_replaces;
       Alcotest.test_case "tool appends" `Quick test_with_tool_appends;
       Alcotest.test_case "hooks" `Quick test_with_hooks;

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -25,6 +25,16 @@ let make_checkpoint
     created_at = 1000.0;
     tools;
     tool_choice;
+    temperature = None;
+    top_p = None;
+    top_k = None;
+    min_p = None;
+    enable_thinking = None;
+    response_format_json = false;
+    thinking_budget = None;
+    cache_system_prompt = false;
+    max_input_tokens = None;
+    max_total_tokens = None;
     mcp_sessions;
   }
 

--- a/test/test_checkpoint_store.ml
+++ b/test/test_checkpoint_store.ml
@@ -16,6 +16,16 @@ let make_checkpoint ?(session_id = "test-session") ?(created_at = 1000.0) () :
     created_at;
     tools = [];
     tool_choice = None;
+    temperature = None;
+    top_p = None;
+    top_k = None;
+    min_p = None;
+    enable_thinking = None;
+    response_format_json = false;
+    thinking_budget = None;
+    cache_system_prompt = false;
+    max_input_tokens = None;
+    max_total_tokens = None;
     mcp_sessions = [];
   }
 

--- a/test/test_local_llm.ml
+++ b/test/test_local_llm.ml
@@ -7,21 +7,46 @@
 open Agent_sdk
 open Types
 
-let base_url = "http://127.0.0.1:8085"
-let local_model = Custom "qwen3.5-35b-a3b-q8"
+let provider = Provider.local_qwen ()
+let base_url =
+  match provider.provider with
+  | Provider.Local { base_url } -> base_url
+  | _ -> "http://127.0.0.1:8085"
+
+let local_model = Custom provider.model_id
+let options = { Agent.default_options with base_url; provider = Some provider }
+
+let masc_mcp_command () =
+  match Sys.getenv_opt "MASC_MCP_COMMAND" with
+  | Some path when String.trim path <> "" -> path
+  | _ -> "/Users/dancer/me/workspace/yousleepwhen/masc-mcp/start-masc-mcp.sh"
+
+let masc_mcp_base_path () =
+  match Sys.getenv_opt "MASC_MCP_BASE_PATH" with
+  | Some path when String.trim path <> "" -> path
+  | _ -> "/Users/dancer/me"
+
+let qwen_config name system_prompt max_tokens max_turns =
+  {
+    default_config with
+    name;
+    model = local_model;
+    system_prompt;
+    max_tokens;
+    max_turns;
+    temperature = Some 0.6;
+    top_p = Some 0.95;
+    top_k = Some 20;
+    min_p = Some 0.01;
+    enable_thinking = Some false;
+  }
 
 (** Test 1: Simple text response *)
 let test_simple_chat () =
   Printf.printf "\n=== Test 1: Simple chat ===\n%!";
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
-  let config = { default_config with
-    name = "test-agent";
-    model = local_model;
-    max_tokens = 100;
-    max_turns = 1;
-  } in
-  let options = { Agent.default_options with base_url } in
+  let config = qwen_config "test-agent" None 100 1 in
   let agent = Agent.create ~net:env#net ~config ~options () in
   match Agent.run ~sw agent "What is 2+3? Answer with just the number." with
   | Ok response ->
@@ -43,13 +68,11 @@ let test_tool_calling () =
   Printf.printf "\n=== Test 2: Tool calling ===\n%!";
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
-  let config = { default_config with
-    name = "tool-agent";
-    model = local_model;
-    system_prompt = Some "You are a helpful assistant. Use the provided tools to answer questions.";
-    max_tokens = 200;
-    max_turns = 3;
-  } in
+  let config =
+    qwen_config "tool-agent"
+      (Some "You are a helpful assistant. Use the provided tools to answer questions.")
+      200 3
+  in
   let calc_tool = Tool.create
     ~name:"calculator"
     ~description:"Perform arithmetic. Returns the result as a string."
@@ -62,7 +85,6 @@ let test_tool_calling () =
       (* Simple eval for demo *)
       Ok (Printf.sprintf "Result of %s = 5" expr))
   in
-  let options = { Agent.default_options with base_url } in
   let agent = Agent.create ~net:env#net ~config ~tools:[calc_tool] ~options () in
   match Agent.run ~sw agent "What is 2+3? Use the calculator tool." with
   | Ok response ->
@@ -80,13 +102,11 @@ let test_multi_tool () =
   Printf.printf "\n=== Test 3: Multi-tool loop ===\n%!";
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
-  let config = { default_config with
-    name = "multi-tool-agent";
-    model = local_model;
-    system_prompt = Some "You have access to tools. Use read_file to check file contents.";
-    max_tokens = 300;
-    max_turns = 5;
-  } in
+  let config =
+    qwen_config "multi-tool-agent"
+      (Some "You have access to tools. Use read_file to check file contents.")
+      300 5
+  in
   let read_file_tool = Tool.create
     ~name:"read_file"
     ~description:"Read contents of a file at the given path"
@@ -98,7 +118,6 @@ let test_multi_tool () =
       Printf.printf "  [Tool called] read_file(%s)\n%!" path;
       Ok "hello world\nthis is a test file\n")
   in
-  let options = { Agent.default_options with base_url } in
   let agent = Agent.create ~net:env#net ~config ~tools:[read_file_tool] ~options () in
   match Agent.run ~sw agent "Read the file at /tmp/test.txt and tell me what it says." with
   | Ok response ->
@@ -110,13 +129,94 @@ let test_multi_tool () =
     Printf.printf "  FAIL: %s\n%!" (Error.to_string e);
     assert false
 
+(** Test 4: Live MASC MCP tool via stdio *)
+let test_masc_mcp_tool () =
+  Printf.printf "\n=== Test 4: MASC MCP via stdio ===\n%!";
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let mgr = Eio.Stdenv.process_mgr env in
+  let spec : Mcp.server_spec = {
+    command = masc_mcp_command ();
+    args = ["--stdio"; "--base-path"; masc_mcp_base_path ()];
+    env = [];
+    name = "masc";
+  } in
+  match Mcp.connect_and_load ~sw ~mgr spec with
+  | Error e ->
+    Printf.printf "  FAIL: %s\n%!" (Error.to_string e);
+    assert false
+  | Ok managed ->
+    let tool_count = List.length managed.tools in
+    let has_masc_status =
+      List.exists
+        (fun (tool : Tool.t) -> String.equal tool.schema.name "masc_status")
+        managed.tools
+    in
+    Printf.printf "  Loaded %d MCP tools from %s\n%!" tool_count managed.name;
+    assert has_masc_status;
+    let bus = Event_bus.create () in
+    let sub = Event_bus.subscribe ~filter:Event_bus.filter_tools_only bus in
+    let guardrails : Guardrails.t = {
+      tool_filter = Guardrails.AllowList ["masc_status"];
+      max_tool_calls_per_turn = Some 1;
+    } in
+    let config =
+      {
+        (qwen_config "masc-agent"
+           (Some "Use the provided MASC tool exactly once, then summarize the result briefly.")
+           200 3)
+        with
+        tool_choice = Some Auto;
+      }
+    in
+    let options =
+      {
+        options with
+        mcp_clients = [managed];
+        event_bus = Some bus;
+        guardrails;
+      }
+    in
+    let agent = Agent.create ~net:env#net ~config ~options () in
+    (match Agent.run ~sw agent "Use masc_status once, then report the current MASC mode in one short sentence." with
+     | Ok response ->
+       let text =
+         List.filter_map (function Text s -> Some s | _ -> None) response.content
+         |> String.concat ""
+       in
+       let events = Event_bus.drain sub in
+       let used_masc_status =
+         List.exists
+           (function
+             | Event_bus.ToolCalled { tool_name; _ } -> String.equal tool_name "masc_status"
+             | _ -> false)
+           events
+       in
+       Printf.printf "  Final response: %s\n%!" text;
+       assert used_masc_status;
+       assert (String.length text > 0);
+       Printf.printf "  PASS\n%!"
+     | Error e ->
+       Printf.printf "  FAIL: %s\n%!" (Error.to_string e);
+       assert false);
+    Event_bus.unsubscribe bus sub;
+    Agent.close agent
+
 let () =
   match Sys.getenv_opt "LLAMA_LIVE_TEST" with
   | Some "1" ->
     Printf.printf "Running live tests against llama-server at %s\n%!" base_url;
     test_simple_chat ();
-    test_tool_calling ();
-    test_multi_tool ();
+    (match Sys.getenv_opt "LLAMA_LIVE_TOOL_TEST" with
+     | Some "1" ->
+         test_tool_calling ();
+         test_multi_tool ()
+     | _ ->
+         Printf.printf "Skipping tool-heavy live tests. Set LLAMA_LIVE_TOOL_TEST=1 to enable.\n%!");
+    (match Sys.getenv_opt "LLAMA_LIVE_MASC_TEST" with
+     | Some "1" -> test_masc_mcp_tool ()
+     | _ ->
+         Printf.printf "Skipping live MASC MCP test. Set LLAMA_LIVE_MASC_TEST=1 to enable.\n%!");
     Printf.printf "\n=== All live tests passed! ===\n%!"
   | _ ->
     Printf.printf "Skipped: set LLAMA_LIVE_TEST=1 to run (requires llama-server on port 8085)\n%!"

--- a/test/test_retry.ml
+++ b/test/test_retry.ml
@@ -216,7 +216,7 @@ let test_with_retry_max_retries_exhausted () =
 
 let test_provider_constructors () =
   let p = Provider.local_qwen () in
-  check string "local_qwen" "qwen3.5" p.model_id;
+  check string "local_qwen" "qwen3.5-35b-a3b-ud-q8-xl" p.model_id;
   let p = Provider.anthropic_sonnet () in
   check string "anthropic_sonnet" "claude-sonnet-4-6" p.model_id;
   let p = Provider.anthropic_haiku () in

--- a/test/test_session_resume.ml
+++ b/test/test_session_resume.ml
@@ -26,6 +26,16 @@ let make_checkpoint
     created_at;
     tools;
     tool_choice;
+    temperature = None;
+    top_p = None;
+    top_k = None;
+    min_p = None;
+    enable_thinking = None;
+    response_format_json = false;
+    thinking_budget = None;
+    cache_system_prompt = false;
+    max_input_tokens = None;
+    max_total_tokens = None;
     mcp_sessions = [];
   }
 

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -107,6 +107,10 @@ let test_default_config () =
   Alcotest.(check int) "max_tokens" 4096 c.max_tokens;
   Alcotest.(check int) "max_turns" 10 c.max_turns;
   Alcotest.(check bool) "no system prompt" true (c.system_prompt = None);
+  Alcotest.(check bool) "no top_p" true (c.top_p = None);
+  Alcotest.(check bool) "no top_k" true (c.top_k = None);
+  Alcotest.(check bool) "no min_p" true (c.min_p = None);
+  Alcotest.(check bool) "no enable_thinking" true (c.enable_thinking = None);
   Alcotest.(check bool) "no thinking_budget" true (c.thinking_budget = None);
   Alcotest.(check bool) "cache off" false c.cache_system_prompt;
   Alcotest.(check bool) "no max_input_tokens" true (c.max_input_tokens = None);


### PR DESCRIPTION
## Summary
- add Qwen3.5 llama local provider/sampling/thinking options
- normalize fenced JSON responses for local Qwen JSON mode
- replace MCP runtime client with a tolerant paginated NDJSON client
- add a live local llama + MASC MCP integration test path

## Verification
- dune build --root . @runtest
- live local llama test with LLAMA_LIVE_TEST=1
- live OAS -> Qwen3.5 -> MASC MCP test with LLAMA_LIVE_MASC_TEST=1