### PR TITLE
feat(ci): add GitHub Actions build, test, and lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
           ocaml-compiler: 5.4.x
           dune-cache: true
 
+      - name: Pin MCP protocol packages
+        run: |
+          opam pin add mcp_protocol git+https://github.com/jeong-sik/mcp-protocol-sdk.git#main --no-action --yes
+          opam pin add mcp_protocol_eio git+https://github.com/jeong-sik/mcp-protocol-sdk.git#main --no-action --yes
+
       - name: Install dependencies
         run: |
           for attempt in 1 2 3; do
@@ -61,6 +66,11 @@ jobs:
         with:
           ocaml-compiler: 5.4.x
           dune-cache: true
+
+      - name: Pin MCP protocol packages
+        run: |
+          opam pin add mcp_protocol git+https://github.com/jeong-sik/mcp-protocol-sdk.git#main --no-action --yes
+          opam pin add mcp_protocol_eio git+https://github.com/jeong-sik/mcp-protocol-sdk.git#main --no-action --yes
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- OAS에 GitHub Actions CI 추가 (기존 0개 → 2개 job)
- **Build and Test**: dune build + dune test (60min timeout, OCaml 5.4.x)
- **Lint**: warnings-as-errors 체크

## Changes
- `.github/workflows/ci.yml`: 2-job CI pipeline (masc-mcp ci.yml 기반 축소)

## Test plan
- [ ] CI green 확인 (첫 실행)
- [ ] PR에서 check status 표시 확인

Generated with [Claude Code](https://claude.com/claude-code)