### PR TITLE
docs: harden third-party readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,8 @@ jobs:
 
       - name: Build documentation (odoc)
         if: matrix.ocaml-compiler == '5.4.x'
-        continue-on-error: true
         run: |
-          opam install odoc --yes || true
+          opam install odoc --yes
           opam exec -- dune build @doc
 
   lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ All notable changes to `agent_sdk` are documented in this file.
 - `Agent.t` is now an abstract type. Direct field access (`agent.state`, `agent.tools`, etc.) is replaced by accessor functions: `Agent.state`, `Agent.lifecycle`, `Agent.tools`, `Agent.context`, `Agent.options`, `Agent.net`.
 - `test_add_message` test removed (external mutation of agent state is no longer possible).
 
+### Migration from 0.22.x
+
+`Agent.t` field access must be replaced with accessor functions:
+
+```ocaml
+(* Before (0.22.x) *)
+let state = agent.state in
+let tools = agent.tools in
+let ctx = agent.context in
+
+(* After (0.23.0) *)
+let state = Agent.state agent in
+let tools = Agent.tools agent in
+let ctx = Agent.context agent in
+```
+
+`Builder.build` still works but emits a deprecation warning. Switch to `build_safe` for validation:
+
+```ocaml
+(* Before *)
+let agent = Builder.build builder in
+
+(* After *)
+match Builder.build_safe builder with
+| Ok agent -> (* use agent *)
+| Error err -> Printf.eprintf "Config error: %s\n" (Error.to_string err)
+```
+
 ### Added
 - `Agent.state`, `Agent.lifecycle`, `Agent.tools`, `Agent.context`, `Agent.options`, `Agent.net` accessor functions.
 - `Builder.build_safe : t -> (Agent.t, Error.sdk_error) result` with validation:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,11 +62,17 @@ Implementation follows the interface, not the other way around.
 3. **CHANGELOG**: Add an entry under `## [Unreleased]` in `CHANGELOG.md`.
 4. **One concern per PR**: Keep PRs focused. Split unrelated changes.
 
-## bisect_ppx fork
+## Pinned fork dependencies
 
-The upstream `bisect_ppx >= 2.8` does not build on OCaml 5.4.x.
-We pin `patricoferris/bisect_ppx#5.2` which adds OCaml 5.4 support.
-This pin is required for `--with-test` installation and coverage reporting.
+Two dependencies are pinned to forks. Both are temporary.
+
+| Package | Fork | Why | Upstream status |
+|---------|------|-----|-----------------|
+| `bisect_ppx` | `patricoferris/bisect_ppx#5.2` | Upstream 2.8.x fails on OCaml 5.4. This fork adds 5.4 compat. | PR pending upstream. Remove pin when bisect_ppx >= 2.9 ships. |
+| `mcp_protocol`, `mcp_protocol_eio` | `jeong-sik/mcp-protocol-sdk#main` | OCaml MCP client bindings not yet on opam. | Same author. Publish to opam when MCP spec stabilizes. |
+
+These pins are set in CI (`ci.yml`) and in the build instructions above.
+When upstream releases resolve the issue, remove the pin and use the opam version.
 
 ## Versioning policy
 


### PR DESCRIPTION
## Summary
- CI: odoc 빌드 `continue-on-error` 제거. 문서 생성 실패를 감지할 수 있도록.
- CHANGELOG: v0.23.0 마이그레이션 가이드 추가 (Agent.t abstraction, Builder.build_safe) before/after 코드 블록
- CONTRIBUTING: fork 의존성 테이블 추가 (bisect_ppx, mcp_protocol) — 왜 pin했는지, 언제 해소되는지 명시

## Test plan
- [ ] CI green 확인 (odoc 빌드가 실제로 통과하는지)
- [x] `dune build --root .` 성공
- [x] 마크다운 렌더링 확인 (코드 블록, 테이블)

Generated with [Claude Code](https://claude.com/claude-code)