### PR TITLE
chore: release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to `agent_sdk` are documented in this file.
 
+## [0.24.0] - 2026-03-16
+
+### Added
+- **Cascade failover** (`Provider.cascade`): multi-provider failover with primary + fallback list. Retry-aware cascade with `Retry.with_cascade`.
+- **Idle detection**: fingerprint-based tool call repetition detection. Configurable `max_idle_turns` with `OnIdle` hook event and `IdleDetected` error.
+- **Context compaction** (`Context_reducer`): 6 strategies — `Keep_last_n`, `Token_budget`, `Prune_tool_outputs`, `Merge_contiguous`, `Drop_thinking`, `Compose`. Turn-boundary-aware grouping preserves ToolUse/ToolResult pairs.
+- **Context injection** (`Hooks.context_injector`): post-tool-execution hook that updates `Context` key-value store and appends extra messages to the conversation.
+- **Cost tracking** (`Provider.pricing_for_model`, `Provider.estimate_cost`): per-model pricing with cumulative `estimated_cost_usd` in `usage_stats`.
+- `test_bug_hunt.ml`: 7 bug candidate reproduction and fix verification tests.
+- `test_e2e_v024.ml`: 5 end-to-end integration scenarios against live local LLM (gated behind `LLAMA_LIVE_TEST=1`).
+
+### Fixed
+- **B1 CRITICAL**: `context_injector` exception crashed the tool loop. Wrapped in `try-with`; exceptions are caught and logged silently.
+- **B2 HIGH**: `create_message_cascade` with `clock=None` skipped all fallback providers. Fallbacks are now tried sequentially on retryable errors.
+- **B3 HIGH**: Injected `extra_messages` could violate role alternation. Added role validation that drops messages creating same-role adjacency.
+- **B4 HIGH**: `Token_budget` strategy returned empty message list when budget was smaller than the most recent turn. Added guard that always keeps the last turn.
+- **B5 MEDIUM**: Idle detection failed for empty-empty fingerprint comparison (`[] <> []` = false). Changed `last_tool_calls` from `list` to `option` to distinguish "not yet set" from "empty set".
+- **B6 MEDIUM**: `Drop_thinking` replaced thinking-only messages with `Text ""`. Changed to drop the entire message instead of inserting empty text.
+
+### Changed
+- `Agent.t.last_tool_calls`: internal type changed from `tool_call_fingerprint list` to `tool_call_fingerprint list option` (not in public API).
+
 ## [0.23.0] - 2026-03-15
 
 ### Breaking

--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,6 @@
 (lang dune 3.11)
 (name agent_sdk)
-(version 0.23.0)
+(version 0.24.0)
 
 (generate_opam_files true)
 

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -109,5 +109,5 @@ let runtime_query = Runtime_query.query
 let query = Query.query
 
 (** Version info *)
-let version = "0.23.0"
+let version = "0.24.0"
 let sdk_name = "agent_sdk"

--- a/test/test_agent_sdk.ml
+++ b/test/test_agent_sdk.ml
@@ -51,7 +51,7 @@ let test_agent_accessors () =
   Alcotest.(check string) "base_url" "http://test" opts.base_url
 
 let test_version_info () =
-  Alcotest.(check string) "version" "0.23.0" Agent_sdk.version;
+  Alcotest.(check string) "version" "0.24.0" Agent_sdk.version;
   Alcotest.(check string) "sdk_name" "agent_sdk" Agent_sdk.sdk_name
 
 let test_build_safe_valid () =


### PR DESCRIPTION
## Summary

OAS v0.24.0 릴리즈. Cascade failover, Idle detection, Context compaction/injection, Cost tracking 5개 트랙 + 6개 버그 수정 + e2e integration test.

### Version bump
- `dune-project`: 0.23.0 → 0.24.0
- `lib/agent_sdk.ml`: 0.23.0 → 0.24.0
- `test/test_agent_sdk.ml`: version check 갱신

### CHANGELOG
- 7 Added, 6 Fixed, 1 Changed

### Pending after merge
- `git tag v0.24.0` + `git push origin v0.24.0`
- v0.23.0 태그도 누락 상태 — 함께 생성 필요

## Test plan
- [x] `dune build @all` — 0 errors
- [x] `dune runtest --force` — 전체 pass (version test 포함)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)