### PR TITLE
refactor: v0.25.0 — Agent_turn extraction + streaming feature parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `agent_sdk` are documented in this file.
 ## [0.25.0] - 2026-03-16
 
 ### Added
+- **`Agent_turn` module** (new): Common turn logic extracted from `agent.ml`. Provides `prepare_turn`, `accumulate_usage`, `update_idle_detection`, `apply_context_injection`, `check_token_budget`, `make_tool_results`, and `filter_valid_messages`.
+
+### Changed
+- **Streaming path feature parity**: `run_turn_stream_with_trace` now includes `BeforeTurnParams` hook, `apply_turn_params`, `extra_system_context`, `tool_filter_override`, and `context_injector`.
+- `agent.ml` reduced by ~50 lines through delegation to `Agent_turn`.
+
+### Added (v0.25.0-rc)
 - **Test harness framework** (`Harness`): 6-type pluggable verification — Behavioral, Adversarial, Performance, Regression, Swiss Cheese (multi-layer), Composability.
 - **Provider mock** (`Provider_mock`): network-free scripted responses with cycling, convenience builders for text/tool_use/thinking responses.
 - **Per-turn parameter adjustment** (`Hooks.turn_params`, `BeforeTurnParams`): hooks can adjust temperature, thinking_budget, tool_choice, tool_filter per turn via `AdjustParams` decision. Parameters revert after each API call.

--- a/lib/agent.ml
+++ b/lib/agent.ml
@@ -68,10 +68,7 @@ let default_options = {
   event_bus = None;
 }
 
-type tool_call_fingerprint = {
-  fp_name: string;
-  fp_input: string;
-}
+type tool_call_fingerprint = Agent_turn.tool_call_fingerprint
 
 type t = {
   mutable state: agent_state;
@@ -490,19 +487,10 @@ let run_turn_with_trace ~sw ?clock ?raw_trace_run agent =
       let ts = Unix.gettimeofday () in
       set_lifecycle agent ~first_progress_at:ts ~last_progress_at:ts Running;
       let* () = trace_assistant_blocks raw_trace_run response.content in
-      (* Accumulate usage stats + cost *)
-      let usage = match response.usage with
-        | Some u ->
-          let base = add_usage agent.state.usage u in
-          let model_id = match agent.options.provider with
-            | Some cfg -> cfg.model_id
-            | None -> Types.model_to_string agent.state.config.model
-          in
-          let pricing = Provider.pricing_for_model model_id in
-          let turn_cost = Provider.estimate_cost ~pricing
-            ~input_tokens:u.input_tokens ~output_tokens:u.output_tokens in
-          { base with estimated_cost_usd = base.estimated_cost_usd +. turn_cost }
-        | None -> { agent.state.usage with api_calls = agent.state.usage.api_calls + 1 }
+      let usage = Agent_turn.accumulate_usage
+        ~current_usage:agent.state.usage
+        ~provider:agent.options.provider
+        ~response_usage:response.usage
       in
 
       (* AfterTurn hook *)
@@ -528,34 +516,28 @@ let run_turn_with_trace ~sw ?clock ?raw_trace_run agent =
       | StopToolUse ->
         let tool_uses = List.filter (function ToolUse _ -> true | _ -> false) response.content in
 
-        (* Idle detection: compare tool call fingerprints with previous turn *)
-        let current_fps = List.filter_map (function
-          | ToolUse { name; input; _ } ->
-            Some { fp_name = name; fp_input = Yojson.Safe.to_string input }
-          | _ -> None
-        ) tool_uses in
-        (* Idle check: fingerprints match previous turn (including both-empty).
-           None = first tool turn, no comparison possible. *)
-        let is_idle = match agent.last_tool_calls with
-          | None -> false
-          | Some prev ->
-            List.length current_fps = List.length prev &&
-            List.for_all2 (fun a b -> a.fp_name = b.fp_name && a.fp_input = b.fp_input)
-              current_fps prev
+        (* Idle detection via Agent_turn *)
+        let idle_result = Agent_turn.update_idle_detection
+          ~idle_state:{
+            last_tool_calls = agent.last_tool_calls;
+            consecutive_idle_turns = agent.consecutive_idle_turns;
+          }
+          ~tool_uses
         in
-        agent.last_tool_calls <- Some current_fps;
-        if is_idle then begin
-          agent.consecutive_idle_turns <- agent.consecutive_idle_turns + 1;
+        agent.last_tool_calls <- idle_result.new_state.last_tool_calls;
+        agent.consecutive_idle_turns <- idle_result.new_state.consecutive_idle_turns;
+        if idle_result.is_idle then begin
           let _idle =
             invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"on_idle"
               agent.options.hooks.on_idle
               (Hooks.OnIdle {
                 consecutive_idle_turns = agent.consecutive_idle_turns;
-                tool_names = List.map (fun fp -> fp.fp_name) current_fps })
+                tool_names = List.filter_map (function
+                  | ToolUse { name; _ } -> Some name | _ -> None
+                ) tool_uses })
           in
           ()
-        end else
-          agent.consecutive_idle_turns <- 0;
+        end;
 
         (* Guardrail: check tool call count limit *)
         let count = List.length tool_uses in
@@ -571,59 +553,19 @@ let run_turn_with_trace ~sw ?clock ?raw_trace_run agent =
             with Raw_trace.Trace_error err -> Error err
           in
           let* results = results in
-          let tool_results = List.map (fun (tool_use_id, content, is_error) ->
-            ToolResult { tool_use_id; content; is_error }
-          ) results in
+          let tool_results = Agent_turn.make_tool_results results in
           agent.state <- { agent.state with messages = agent.state.messages @ [{ role = User; content = tool_results }] };
-          (* Context injection: call injector for each tool execution.
-             Wrapped in try-with so a faulty injector does not crash the tool loop. *)
+          (* Context injection *)
           (match agent.options.context_injector with
            | None -> ()
            | Some injector ->
-             List.iter2 (fun block (_, content, is_error) ->
-               match block with
-               | ToolUse { name; input; _ } ->
-                 let output : Types.tool_result =
-                   if is_error then Error { message = content; recoverable = true }
-                   else Ok { content }
-                 in
-                 (try
-                   match injector ~tool_name:name ~input ~output with
-                   | None -> ()
-                   | Some inj ->
-                     List.iter (fun (key, value) ->
-                       Context.set agent.context key value
-                     ) inj.Hooks.context_updates;
-                     (* Validate role alternation before appending extra_messages.
-                        The last message in agent.state.messages is User (ToolResult).
-                        Only append messages that maintain valid alternation. *)
-                     let valid_messages = match agent.state.messages with
-                       | [] -> inj.extra_messages
-                       | _ ->
-                         let last_role = (List.nth agent.state.messages
-                           (List.length agent.state.messages - 1)).role in
-                         let rec filter_valid prev_role = function
-                           | [] -> []
-                           | (msg : Types.message) :: rest ->
-                             if msg.role = prev_role then
-                               filter_valid prev_role rest  (* skip: same role *)
-                             else
-                               msg :: filter_valid msg.role rest
-                         in
-                         filter_valid last_role inj.extra_messages
-                     in
-                     if valid_messages <> [] then
-                       agent.state <- { agent.state with
-                         messages = agent.state.messages @ valid_messages }
-                 with exn ->
-                   Printf.eprintf
-                     "[oas] context_injector for tool '%s' raised: %s\n%!"
-                     name (Printexc.to_string exn))
-               | _ -> ()
-             ) tool_uses results);
+             let new_messages = Agent_turn.apply_context_injection
+               ~context:agent.context ~messages:agent.state.messages
+               ~injector ~tool_uses ~results
+             in
+             agent.state <- { agent.state with messages = new_messages });
           Ok (`ToolsExecuted))
       | EndTurn | MaxTokens | StopSequence ->
-        (* OnStop hook *)
         let _stop =
           invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"on_stop"
             agent.options.hooks.on_stop
@@ -633,26 +575,7 @@ let run_turn_with_trace ~sw ?clock ?raw_trace_run agent =
       | Unknown reason ->
         Error (Error.Agent (UnrecognizedStopReason { reason }))
 
-(** Check if token budget has been exceeded. Returns a structured error or None. *)
-let check_token_budget config usage =
-  let exceeded_input =
-    match config.max_input_tokens with
-    | Some limit when usage.total_input_tokens > limit ->
-        Some (Error.Agent (TokenBudgetExceeded { kind = "Input"; used = usage.total_input_tokens; limit }))
-    | _ -> None
-  in
-  let exceeded_total =
-    match config.max_total_tokens with
-    | Some limit ->
-        let total = usage.total_input_tokens + usage.total_output_tokens in
-        if total > limit then
-          Some (Error.Agent (TokenBudgetExceeded { kind = "Total"; used = total; limit }))
-        else None
-    | _ -> None
-  in
-  match exceeded_input with
-  | Some _ as err -> err
-  | None -> exceeded_total
+let check_token_budget = Agent_turn.check_token_budget
 
 (** Run loop *)
 let run ~sw ?clock agent user_prompt =
@@ -688,21 +611,41 @@ let run_turn_stream_with_trace ~sw ?clock ~on_event ?raw_trace_run agent =
       (Hooks.BeforeTurn { turn = agent.state.turn_count; messages = agent.state.messages })
   in
 
+  (* BeforeTurnParams hook: same as non-streaming path *)
+  let turn_params = match agent.options.hooks.before_turn_params with
+    | None -> Hooks.default_turn_params
+    | Some _ ->
+      let last_results = last_tool_results_from agent.state.messages in
+      let reasoning = Hooks.extract_reasoning agent.state.messages in
+      let decision =
+        invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"before_turn_params"
+          agent.options.hooks.before_turn_params
+          (Hooks.BeforeTurnParams {
+            turn = agent.state.turn_count;
+            messages = agent.state.messages;
+            last_tool_results = last_results;
+            current_params = Hooks.default_turn_params;
+            reasoning;
+          })
+      in
+      match decision with
+      | Hooks.AdjustParams params -> params
+      | _ -> Hooks.default_turn_params
+  in
+
+  let original_config = apply_turn_params agent turn_params in
+
   (* TurnStarted event *)
   (match agent.options.event_bus with
    | Some bus -> Event_bus.publish bus
        (TurnStarted { agent_name = agent.state.config.name; turn = agent.state.turn_count })
    | None -> ());
 
-  (* Apply guardrails: filter tools visible to LLM *)
-  let visible_tools = Guardrails.filter_tools agent.options.guardrails agent.tools in
-  let tool_schemas = List.map Tool.schema_to_json visible_tools in
-  let tools_json = if tool_schemas = [] then None else Some tool_schemas in
-
-  (* Apply context reducer *)
-  let effective_messages = match agent.options.context_reducer with
-    | None -> agent.state.messages
-    | Some reducer -> Context_reducer.reduce reducer agent.state.messages
+  (* Prepare tools and messages via Agent_turn *)
+  let prep = Agent_turn.prepare_turn
+    ~guardrails:agent.options.guardrails ~tools:agent.tools
+    ~messages:agent.state.messages
+    ~context_reducer:agent.options.context_reducer ~turn_params
   in
 
   let api_result = Tracing.with_span agent.options.tracer
@@ -710,28 +653,26 @@ let run_turn_stream_with_trace ~sw ?clock ~on_event ?raw_trace_run agent =
       agent_name = agent.state.config.name;
       turn = agent.state.turn_count; extra = [] }
     (fun _tracer ->
-      (* Try streaming first for Anthropic, fallback for others *)
       let stream_result =
         Streaming.create_message_stream ~sw ~net:agent.net
           ~base_url:agent.options.base_url ?provider:agent.options.provider
-          ~config:agent.state ~messages:effective_messages ?tools:tools_json
-          ~on_event ()
+          ~config:agent.state ~messages:prep.effective_messages
+          ?tools:prep.tools_json ~on_event ()
       in
       match stream_result with
       | Ok _ -> stream_result
       | Error (Error.Config (UnsupportedProvider _)) ->
-          (* Non-Anthropic provider: fallback to sync + synthetic events *)
           let sync_result =
             match agent.options.cascade with
             | Some casc ->
               Api.create_message_cascade ~sw ~net:agent.net ?clock
                 ~cascade:casc ~config:agent.state
-                ~messages:effective_messages ?tools:tools_json ()
+                ~messages:prep.effective_messages ?tools:prep.tools_json ()
             | None ->
               Api.create_message ~sw ~net:agent.net
                 ~base_url:agent.options.base_url ?provider:agent.options.provider
-                ?clock ~config:agent.state ~messages:effective_messages
-                ?tools:tools_json ()
+                ?clock ~config:agent.state ~messages:prep.effective_messages
+                ?tools:prep.tools_json ()
           in
           (match sync_result with
            | Ok response ->
@@ -740,25 +681,18 @@ let run_turn_stream_with_trace ~sw ?clock ~on_event ?raw_trace_run agent =
            | Error _ -> sync_result)
       | Error _ -> stream_result)
   in
+  (* Restore original config after API call *)
+  agent.state <- { agent.state with config = original_config };
   match api_result with
   | Error e -> Error e
   | Ok response ->
     let ts = Unix.gettimeofday () in
     set_lifecycle agent ~first_progress_at:ts ~last_progress_at:ts Running;
     let* () = trace_assistant_blocks raw_trace_run response.content in
-    (* Accumulate usage stats + cost *)
-    let usage = match response.usage with
-      | Some u ->
-        let base = add_usage agent.state.usage u in
-        let model_id = match agent.options.provider with
-          | Some cfg -> cfg.model_id
-          | None -> Types.model_to_string agent.state.config.model
-        in
-        let pricing = Provider.pricing_for_model model_id in
-        let turn_cost = Provider.estimate_cost ~pricing
-          ~input_tokens:u.input_tokens ~output_tokens:u.output_tokens in
-        { base with estimated_cost_usd = base.estimated_cost_usd +. turn_cost }
-      | None -> { agent.state.usage with api_calls = agent.state.usage.api_calls + 1 }
+    let usage = Agent_turn.accumulate_usage
+      ~current_usage:agent.state.usage
+      ~provider:agent.options.provider
+      ~response_usage:response.usage
     in
 
     (* AfterTurn hook *)
@@ -784,35 +718,31 @@ let run_turn_stream_with_trace ~sw ?clock ~on_event ?raw_trace_run agent =
     | StopToolUse ->
       let tool_uses = List.filter (function ToolUse _ -> true | _ -> false) response.content in
 
-      (* Idle detection: compare tool call fingerprints with previous turn *)
-      let current_fps = List.filter_map (function
-        | ToolUse { name; input; _ } ->
-          Some { fp_name = name; fp_input = Yojson.Safe.to_string input }
-        | _ -> None
-      ) tool_uses in
-      let is_idle = match agent.last_tool_calls with
-        | None -> false
-        | Some prev ->
-          List.length current_fps = List.length prev &&
-          List.for_all2 (fun a b -> a.fp_name = b.fp_name && a.fp_input = b.fp_input)
-            current_fps prev
+      (* Idle detection via Agent_turn *)
+      let idle_result = Agent_turn.update_idle_detection
+        ~idle_state:{
+          last_tool_calls = agent.last_tool_calls;
+          consecutive_idle_turns = agent.consecutive_idle_turns;
+        }
+        ~tool_uses
       in
-      agent.last_tool_calls <- Some current_fps;
-      if is_idle then begin
-        agent.consecutive_idle_turns <- agent.consecutive_idle_turns + 1;
+      agent.last_tool_calls <- idle_result.new_state.last_tool_calls;
+      agent.consecutive_idle_turns <- idle_result.new_state.consecutive_idle_turns;
+      if idle_result.is_idle then begin
         let _idle =
           invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"on_idle"
             agent.options.hooks.on_idle
             (Hooks.OnIdle {
               consecutive_idle_turns = agent.consecutive_idle_turns;
-              tool_names = List.map (fun fp -> fp.fp_name) current_fps })
+              tool_names = List.filter_map (function
+                | ToolUse { name; _ } -> Some name | _ -> None
+              ) tool_uses })
         in
         ()
-      end else
-        agent.consecutive_idle_turns <- 0;
+      end;
 
       let count = List.length tool_uses in
-      (match Guardrails.exceeds_limit agent.options.guardrails count with
+      (match Guardrails.exceeds_limit prep.effective_guardrails count with
       | true ->
         let msg = Printf.sprintf "Tool call limit exceeded: %d calls in one turn" count in
         agent.state <- { agent.state with
@@ -824,11 +754,18 @@ let run_turn_stream_with_trace ~sw ?clock ~on_event ?raw_trace_run agent =
           with Raw_trace.Trace_error err -> Error err
         in
         let* results = results in
-        let tool_results = List.map (fun (tool_use_id, content, is_error) ->
-          ToolResult { tool_use_id; content; is_error }
-        ) results in
+        let tool_results = Agent_turn.make_tool_results results in
         agent.state <- { agent.state with
           messages = agent.state.messages @ [{ role = User; content = tool_results }] };
+        (* Context injection — now in streaming path too *)
+        (match agent.options.context_injector with
+         | None -> ()
+         | Some injector ->
+           let new_messages = Agent_turn.apply_context_injection
+             ~context:agent.context ~messages:agent.state.messages
+             ~injector ~tool_uses ~results
+           in
+           agent.state <- { agent.state with messages = new_messages });
         Ok (`ToolsExecuted))
     | EndTurn | MaxTokens | StopSequence ->
       let _stop =

--- a/lib/agent_turn.ml
+++ b/lib/agent_turn.ml
@@ -1,0 +1,229 @@
+(** Shared turn logic for sync and streaming paths.
+
+    Contains helper functions that both [Agent.run_turn_with_trace] and
+    [Agent.run_turn_stream_with_trace] call, eliminating ~60% code duplication.
+
+    These functions take explicit parameters (not Agent.t) to avoid
+    circular module dependency: Agent -> Agent_turn is fine,
+    Agent_turn -> Agent is not. *)
+
+open Types
+
+let ( let* ) = Result.bind
+
+(* ── Fingerprint-based idle detection ─────────────────────────── *)
+
+type tool_call_fingerprint = {
+  fp_name: string;
+  fp_input: string;
+}
+
+let compute_fingerprints tool_uses =
+  List.filter_map (function
+    | ToolUse { name; input; _ } ->
+      Some { fp_name = name; fp_input = Yojson.Safe.to_string input }
+    | _ -> None
+  ) tool_uses
+
+let is_idle (prev : tool_call_fingerprint list option) current =
+  match prev with
+  | None -> false
+  | Some prev_fps ->
+    List.length current = List.length prev_fps &&
+    List.for_all2 (fun a b -> a.fp_name = b.fp_name && a.fp_input = b.fp_input)
+      current prev_fps
+
+(* ── Turn preparation ─────────────────────────────────────────── *)
+
+type turn_preparation = {
+  tools_json: Yojson.Safe.t list option;
+  effective_messages: message list;
+  effective_guardrails: Guardrails.t;
+}
+
+let prepare_tools ~guardrails ~tools ~turn_params =
+  let effective_guardrails = match turn_params.Hooks.tool_filter_override with
+    | Some filter -> { guardrails with Guardrails.tool_filter = filter }
+    | None -> guardrails
+  in
+  let visible_tools = Guardrails.filter_tools effective_guardrails tools in
+  let tool_schemas = List.map Tool.schema_to_json visible_tools in
+  let tools_json = if tool_schemas = [] then None else Some tool_schemas in
+  (tools_json, effective_guardrails)
+
+let prepare_messages ~messages ~context_reducer ~turn_params =
+  let effective = match context_reducer with
+    | None -> messages
+    | Some reducer -> Context_reducer.reduce reducer messages
+  in
+  match turn_params.Hooks.extra_system_context with
+  | None -> effective
+  | Some ctx ->
+    let system_msg = { role = User; content = [Text ("[system context] " ^ ctx)] } in
+    system_msg :: effective
+
+let prepare_turn ~guardrails ~tools ~messages ~context_reducer ~turn_params =
+  let tools_json, effective_guardrails =
+    prepare_tools ~guardrails ~tools ~turn_params
+  in
+  let effective_messages =
+    prepare_messages ~messages ~context_reducer ~turn_params
+  in
+  { tools_json; effective_messages; effective_guardrails }
+
+(* ── Usage accumulation ───────────────────────────────────────── *)
+
+let accumulate_usage ~current_usage ~provider ~response_usage =
+  match response_usage with
+  | Some u ->
+    let base = add_usage current_usage u in
+    let model_id = match provider with
+      | Some (cfg : Provider.config) -> cfg.model_id
+      | None -> ""
+    in
+    let pricing = Provider.pricing_for_model model_id in
+    let turn_cost = Provider.estimate_cost ~pricing
+      ~input_tokens:u.input_tokens ~output_tokens:u.output_tokens in
+    { base with estimated_cost_usd = base.estimated_cost_usd +. turn_cost }
+  | None -> { current_usage with api_calls = current_usage.api_calls + 1 }
+
+(* ── Turn params resolution ───────────────────────────────────── *)
+
+let resolve_turn_params ~hooks ~messages ~invoke_hook =
+  match hooks.Hooks.before_turn_params with
+  | None -> Hooks.default_turn_params
+  | Some _ ->
+    let last_results =
+      let rec find_last = function
+        | [] -> []
+        | msg :: rest ->
+          if msg.role = User then
+            let results = List.filter_map (function
+              | ToolResult { content; is_error; _ } ->
+                if is_error then Some (Error { message = content; recoverable = true } : tool_result)
+                else Some (Ok { content } : tool_result)
+              | _ -> None
+            ) msg.content in
+            if results <> [] then results
+            else find_last rest
+          else find_last rest
+      in
+      find_last (List.rev messages)
+    in
+    let reasoning = Hooks.extract_reasoning messages in
+    let decision =
+      invoke_hook ~hook_name:"before_turn_params"
+        hooks.Hooks.before_turn_params
+        (Hooks.BeforeTurnParams {
+          turn = 0;  (* overridden by caller *)
+          messages;
+          last_tool_results = last_results;
+          current_params = Hooks.default_turn_params;
+          reasoning;
+        })
+    in
+    match decision with
+    | Hooks.AdjustParams params -> params
+    | _ -> Hooks.default_turn_params
+
+(* ── Context injection after tool execution ───────────────────── *)
+
+let filter_valid_messages ~messages extra_messages =
+  match messages with
+  | [] -> extra_messages
+  | _ ->
+    let last_role = (List.nth messages
+      (List.length messages - 1)).role in
+    let rec filter_valid prev_role = function
+      | [] -> []
+      | (msg : message) :: rest ->
+        if msg.role = prev_role then
+          filter_valid prev_role rest
+        else
+          msg :: filter_valid msg.role rest
+    in
+    filter_valid last_role extra_messages
+
+let apply_context_injection ~context ~messages ~injector ~tool_uses ~results =
+  let current_messages = ref messages in
+  List.iter2 (fun block (_, content, is_error) ->
+    match block with
+    | ToolUse { name; input; _ } ->
+      let output : tool_result =
+        if is_error then Error { message = content; recoverable = true }
+        else Ok { content }
+      in
+      (try
+        match injector ~tool_name:name ~input ~output with
+        | None -> ()
+        | Some inj ->
+          List.iter (fun (key, value) ->
+            Context.set context key value
+          ) inj.Hooks.context_updates;
+          let valid_messages =
+            filter_valid_messages ~messages:!current_messages inj.extra_messages
+          in
+          if valid_messages <> [] then
+            current_messages := !current_messages @ valid_messages
+      with exn ->
+        Printf.eprintf
+          "[oas] context_injector for tool '%s' raised: %s\n%!"
+          name (Printexc.to_string exn))
+    | _ -> ()
+  ) tool_uses results;
+  !current_messages
+
+(* ── Token budget check ───────────────────────────────────────── *)
+
+let check_token_budget config usage =
+  let exceeded_input =
+    match config.max_input_tokens with
+    | Some limit when usage.total_input_tokens > limit ->
+        Some (Error.Agent (TokenBudgetExceeded { kind = "Input"; used = usage.total_input_tokens; limit }))
+    | _ -> None
+  in
+  let exceeded_total =
+    match config.max_total_tokens with
+    | Some limit ->
+        let total = usage.total_input_tokens + usage.total_output_tokens in
+        if total > limit then
+          Some (Error.Agent (TokenBudgetExceeded { kind = "Total"; used = total; limit }))
+        else None
+    | _ -> None
+  in
+  match exceeded_input with
+  | Some _ as err -> err
+  | None -> exceeded_total
+
+(* ── Stop reason handling (tool execution branch) ─────────────── *)
+
+type idle_state = {
+  last_tool_calls: tool_call_fingerprint list option;
+  consecutive_idle_turns: int;
+}
+
+type idle_result = {
+  new_state: idle_state;
+  is_idle: bool;
+}
+
+let update_idle_detection ~idle_state ~tool_uses =
+  let current_fps = compute_fingerprints tool_uses in
+  let idle = is_idle idle_state.last_tool_calls current_fps in
+  let new_consecutive =
+    if idle then idle_state.consecutive_idle_turns + 1
+    else 0
+  in
+  {
+    new_state = {
+      last_tool_calls = Some current_fps;
+      consecutive_idle_turns = new_consecutive;
+    };
+    is_idle = idle;
+  }
+
+(** Process tool results into ToolResult content blocks. *)
+let make_tool_results results =
+  List.map (fun (tool_use_id, content, is_error) ->
+    ToolResult { tool_use_id; content; is_error }
+  ) results

--- a/test/test_agent_sdk.ml
+++ b/test/test_agent_sdk.ml
@@ -51,7 +51,7 @@ let test_agent_accessors () =
   Alcotest.(check string) "base_url" "http://test" opts.base_url
 
 let test_version_info () =
-  Alcotest.(check string) "version" "0.24.1" Agent_sdk.version;
+  Alcotest.(check string) "version" "0.25.0" Agent_sdk.version;
   Alcotest.(check string) "sdk_name" "agent_sdk" Agent_sdk.sdk_name
 
 let test_build_safe_valid () =


### PR DESCRIPTION
## Summary
- New `lib/agent_turn.ml` (229 lines): common turn logic extracted from `agent.ml` — `prepare_turn`, `accumulate_usage`, `update_idle_detection`, `apply_context_injection`, `check_token_budget`, `make_tool_results`
- Streaming path now has **full feature parity** with non-streaming: `BeforeTurnParams` hook, `apply_turn_params`, `extra_system_context`, `tool_filter_override`, and `context_injector` were all missing
- `agent.ml` reduced by ~50 net lines through delegation
- Public API (`agent_sdk.mli`) unchanged — `Agent_turn` is internal only

## Context
Adversarial review found ~60% code duplication between sync and streaming turn paths. The streaming path was also missing 4 features added in PR #81 (deep improvement). This extraction ensures both paths stay in sync.

Depends on: PR #83 (v0.24.1 bug fixes)

## Test plan
- [x] All existing tests pass (`dune runtest` — 0 failures)
- [x] Build clean (`dune build` — no warnings)
- [x] Version consistency: `dune-project`, `agent_sdk.ml` at `0.25.0`
- [x] `git diff lib/agent_sdk.mli` — no public API changes
- [ ] E2E with live LLM: `LLAMA_LIVE_TEST=1 dune exec test/test_e2e_v024.exe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)