### PR TITLE
chore: add Makefile with coverage pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: build test coverage coverage-html coverage-clean
+
+build:
+	dune build
+
+test:
+	dune runtest
+
+# Coverage pipeline — generates summary + per-file report
+coverage: coverage-clean
+	BISECT_FILE=$(CURDIR)/bisect dune runtest --instrument-with bisect_ppx --force
+	bisect-ppx-report summary --coverage-path=$(CURDIR) --per-file
+	@echo "---"
+	@echo "For HTML report: make coverage-html"
+
+coverage-html: coverage-clean
+	BISECT_FILE=$(CURDIR)/bisect dune runtest --instrument-with bisect_ppx --force
+	bisect-ppx-report html --coverage-path=$(CURDIR)
+	@echo "HTML report: _coverage/index.html"
+
+coverage-clean:
+	rm -f bisect*.coverage
+	rm -rf _coverage


### PR DESCRIPTION
## Summary
- Makefile with `make coverage` / `make coverage-html` / `make coverage-clean`
- Fixes coverage pipeline: `BISECT_FILE=$(CURDIR)/bisect` is required for bisect_ppx to emit `.coverage` files
- Current baseline: **70.71%** (5,173/7,316 points)

## Test plan
- [x] `make coverage` produces per-file summary
- [x] `make coverage-html` generates `_coverage/index.html`
- [x] `.gitignore` already covers `*.coverage` and `_coverage/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)