### PR TITLE
fix: error handling contract + API compatibility (v0.25.1)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,12 +7,12 @@
 - [x] **Multimodal 지원**: `Image`, `Document` content_block variant. base64 source 직렬화/역직렬화.
 - [x] **Middleware/Hooks**: `Hooks` 모듈 -- BeforeTurn, AfterTurn, PreToolUse (Skip/Override), PostToolUse, OnStop lifecycle events.
 - [x] **PR 상신 및 Merge**: v0.3.0 main 머지 완료.
+- [x] **Property-based Testing**: `QCheck` 기반 도구 호출 시나리오 엣지 케이스 탐색 (`test/test_property.ml`).
 
 ## Remaining
 
 - [ ] **Prompt Caching**: `cache_control` 파라미터 지원. system prompt에 `{"type":"ephemeral"}` 캐시 제어 + usage 통계에 cache_creation/cache_read 토큰 추출.
 - [ ] **Eio Multicore 활용**: 여러 에이전트를 동시에 돌릴 때 멀티코어 성능을 극대화할 수 있도록 `Eio.Executor` 활용 검토.
-- [ ] **Property-based Testing**: `Crowbar` 등을 사용하여 도구 호출 시나리오의 엣지 케이스 자동 탐색.
 
 ---
-*Last Updated: 2026-03-09*
+*Last Updated: 2026-03-16*

--- a/lib/agent.ml
+++ b/lib/agent.ml
@@ -926,6 +926,7 @@ let checkpoint ?(session_id="") agent =
     created_at = Unix.gettimeofday ();
     tools = List.map (fun (t : Tool.t) -> t.schema) agent.tools;
     tool_choice = agent.state.config.tool_choice;
+    disable_parallel_tool_use = agent.state.config.disable_parallel_tool_use;
     temperature = agent.state.config.temperature;
     top_p = agent.state.config.top_p;
     top_k = agent.state.config.top_k;

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -94,6 +94,7 @@ let create_agent ~net ?name ?model ?system_prompt ?max_tokens ?max_turns
     response_format_json = default_config.response_format_json;
     thinking_budget = default_config.thinking_budget;
     tool_choice = default_config.tool_choice;
+    disable_parallel_tool_use = default_config.disable_parallel_tool_use;
     cache_system_prompt = Option.value cache_system_prompt ~default:default_config.cache_system_prompt;
     max_input_tokens = default_config.max_input_tokens;
     max_total_tokens = default_config.max_total_tokens;

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -63,6 +63,7 @@ module Types : sig
     | Auto
     | Any
     | Tool of string
+    | None_
   [@@deriving show]
 
   val tool_choice_to_json : tool_choice -> Yojson.Safe.t
@@ -131,6 +132,7 @@ module Types : sig
     response_format_json: bool;
     thinking_budget: int option;
     tool_choice: tool_choice option;
+    disable_parallel_tool_use: bool;
     cache_system_prompt: bool;
     max_input_tokens: int option;
     max_total_tokens: int option;
@@ -1031,6 +1033,7 @@ module Checkpoint : sig
     created_at: float;
     tools: Types.tool_schema list;
     tool_choice: Types.tool_choice option;
+    disable_parallel_tool_use: bool;
     temperature: float option;
     top_p: float option;
     top_k: int option;
@@ -1457,6 +1460,7 @@ module Builder : sig
   val with_tool_grants : string list -> t -> t
   val with_mcp_tool_allowlist : string list -> t -> t
   val with_tool_choice : Types.tool_choice -> t -> t
+  val with_disable_parallel_tool_use : bool -> t -> t
   val with_thinking_budget : int -> t -> t
   val with_max_input_tokens : int -> t -> t
   val with_max_total_tokens : int -> t -> t

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -106,6 +106,8 @@ let create_message ~sw ~net ?(base_url=default_base_url) ?provider ?clock ?retry
       Error (Retry.NetworkError { message = Printexc.to_string exn })
     | Unix.Unix_error _ as exn ->
       Error (Retry.NetworkError { message = Printexc.to_string exn })
+    | Api_openai.Openai_api_error msg ->
+      Error (Retry.InvalidRequest { message = msg })
     | Failure msg ->
       Error (Retry.NetworkError { message = msg })
     | Yojson.Json_error msg ->

--- a/lib/api_anthropic.ml
+++ b/lib/api_anthropic.ml
@@ -51,8 +51,27 @@ let build_body_assoc ~config ~messages ?tools ~stream () =
     | None -> body_assoc
   in
   let body_assoc = match config.config.tool_choice with
-    | Some tc -> ("tool_choice", tool_choice_to_json tc) :: body_assoc
-    | None -> body_assoc
+    | Some tc ->
+        let tc_json = tool_choice_to_json tc in
+        let tc_json =
+          if config.config.disable_parallel_tool_use then
+            match tc_json with
+            | `Assoc fields ->
+                `Assoc (("disable_parallel_tool_use", `Bool true) :: fields)
+            | other -> other
+          else
+            tc_json
+        in
+        ("tool_choice", tc_json) :: body_assoc
+    | None ->
+        if config.config.disable_parallel_tool_use then
+          let tc_json = `Assoc [
+            ("type", `String "auto");
+            ("disable_parallel_tool_use", `Bool true);
+          ] in
+          ("tool_choice", tc_json) :: body_assoc
+        else
+          body_assoc
   in
   let body_assoc = match config.config.thinking_budget with
     | Some budget ->

--- a/lib/api_ollama.ml
+++ b/lib/api_ollama.ml
@@ -15,7 +15,9 @@ let build_ollama_chat_body ~provider_config ~config ~messages ?tools () =
            :: ("think", `Bool false)
            :: ("options", `Assoc [("num_predict", `Int config.config.max_tokens)])
            :: fields))
-  | _ -> assert false
+  | other ->
+      failwith (Printf.sprintf "build_ollama_chat_body: unexpected JSON shape: %s"
+        (Yojson.Safe.to_string other))
 
 let build_ollama_generate_body ~config ~messages () =
   let prompt =

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -2,6 +2,10 @@
 
 open Types
 
+(** Raised when the OpenAI-compatible API returns an error in the response body.
+    Caught by [Api.create_message] and classified as [Retry.InvalidRequest]. *)
+exception Openai_api_error of string
+
 let tool_calls_to_openai_json blocks =
   blocks
   |> List.filter_map (function
@@ -108,6 +112,7 @@ let tool_choice_to_openai_json = function
           ("type", `String "function");
           ("function", `Assoc [("name", `String name)]);
         ]
+  | None_ -> `String "none"
 
 let strip_json_markdown_fences text =
   let trimmed = String.trim text in
@@ -229,6 +234,12 @@ let build_openai_body ?provider_config ~config ~messages ?tools () =
     | Some _ -> body_assoc
   in
   let body_assoc =
+    if config.config.disable_parallel_tool_use && capabilities.supports_tools then
+      ("parallel_tool_calls", `Bool false) :: body_assoc
+    else
+      body_assoc
+  in
+  let body_assoc =
     if config.config.response_format_json
        && capabilities.supports_response_format_json
     then
@@ -333,4 +344,4 @@ let parse_openai_response json_str =
       let msg =
         err |> member "message" |> to_string_option |> Option.value ~default:"Unknown API error"
       in
-      failwith msg
+      raise (Openai_api_error msg)

--- a/lib/builder.ml
+++ b/lib/builder.ml
@@ -18,6 +18,7 @@ type t = {
   response_format_json: bool;
   thinking_budget: int option;
   tool_choice: tool_choice option;
+  disable_parallel_tool_use: bool;
   cache_system_prompt: bool;
   max_input_tokens: int option;
   max_total_tokens: int option;
@@ -54,6 +55,7 @@ let create ~net ~model =
     response_format_json = default_config.response_format_json;
     thinking_budget = default_config.thinking_budget;
     tool_choice = default_config.tool_choice;
+    disable_parallel_tool_use = default_config.disable_parallel_tool_use;
     cache_system_prompt = default_config.cache_system_prompt;
     max_input_tokens = default_config.max_input_tokens;
     max_total_tokens = default_config.max_total_tokens;
@@ -107,6 +109,7 @@ let with_tool_grants tool_names b =
 let with_mcp_tool_allowlist tool_names b =
   with_contract (Contract.with_mcp_tool_allowlist tool_names Contract.empty) b
 let with_tool_choice tc b = { b with tool_choice = Some tc }
+let with_disable_parallel_tool_use v b = { b with disable_parallel_tool_use = v }
 let with_thinking_budget n b = { b with thinking_budget = Some n }
 let with_max_input_tokens n b = { b with max_input_tokens = Some n }
 let with_max_total_tokens n b = { b with max_total_tokens = Some n }
@@ -146,6 +149,7 @@ let build b =
     response_format_json = b.response_format_json;
     thinking_budget = b.thinking_budget;
     tool_choice = b.tool_choice;
+    disable_parallel_tool_use = b.disable_parallel_tool_use;
     cache_system_prompt = b.cache_system_prompt;
     max_input_tokens = b.max_input_tokens;
     max_total_tokens = b.max_total_tokens;

--- a/lib/checkpoint.ml
+++ b/lib/checkpoint.ml
@@ -21,6 +21,7 @@ type t = {
   created_at: float;
   tools: tool_schema list;
   tool_choice: tool_choice option;
+  disable_parallel_tool_use: bool;
   temperature: float option;
   top_p: float option;
   top_k: int option;
@@ -189,6 +190,7 @@ let to_json cp =
     ("enable_thinking", Option.value ~default:`Null (Option.map (fun v -> `Bool v) cp.enable_thinking));
     ("response_format_json", `Bool cp.response_format_json);
     ("thinking_budget", Option.value ~default:`Null (Option.map (fun v -> `Int v) cp.thinking_budget));
+    ("disable_parallel_tool_use", `Bool cp.disable_parallel_tool_use);
     ("cache_system_prompt", `Bool cp.cache_system_prompt);
     ("max_input_tokens", Option.value ~default:`Null (Option.map (fun v -> `Int v) cp.max_input_tokens));
     ("max_total_tokens", Option.value ~default:`Null (Option.map (fun v -> `Int v) cp.max_total_tokens));
@@ -249,6 +251,9 @@ let of_json json =
                created_at = json |> member "created_at" |> to_float;
                tools;
                tool_choice;
+               disable_parallel_tool_use =
+                 json |> member "disable_parallel_tool_use" |> to_bool_option
+                 |> Option.value ~default:false;
                temperature = json |> member "temperature" |> to_float_option;
                top_p = json |> member "top_p" |> to_float_option;
                top_k = json |> member "top_k" |> to_int_option;

--- a/lib/runtime_server.ml
+++ b/lib/runtime_server.ml
@@ -356,11 +356,9 @@ let run_participant store state session_id
       Ok full
   | _ ->
       Eio.Switch.run @@ fun sw ->
-      let session =
-        match Runtime_store.load_session store session_id with
-        | Ok session -> session
-        | Error err -> raise (Failure (Error.to_string err))
-      in
+      match Runtime_store.load_session store session_id with
+      | Error err -> Error err
+      | Ok session ->
       let config =
         {
           Types.default_config with

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -66,12 +66,14 @@ type tool_choice =
   | Auto
   | Any
   | Tool of string
+  | None_  (** Disables tool use for a turn. Anthropic: {"type":"none"}, OpenAI: "none" *)
 [@@deriving show]
 
 let tool_choice_to_json = function
   | Auto -> `Assoc [("type", `String "auto")]
   | Any -> `Assoc [("type", `String "any")]
   | Tool name -> `Assoc [("type", `String "tool"); ("name", `String name)]
+  | None_ -> `Assoc [("type", `String "none")]
 
 let tool_choice_of_json json =
   let open Yojson.Safe.Util in
@@ -82,6 +84,7 @@ let tool_choice_of_json json =
     | "tool" ->
       let name = json |> member "name" |> to_string in
       Ok (Tool name)
+    | "none" -> Ok None_
     | other -> Error (Error.Serialization (UnknownVariant { type_name = "tool_choice"; value = other }))
   with
   | Yojson.Safe.Util.Type_error (msg, _) ->
@@ -155,6 +158,7 @@ type agent_config = {
   response_format_json: bool;
   thinking_budget: int option; (* For Claude 3.7+ extended thinking *)
   tool_choice: tool_choice option;
+  disable_parallel_tool_use: bool; (* Anthropic: tool_choice.disable_parallel_tool_use, OpenAI: parallel_tool_calls=false *)
   cache_system_prompt: bool; (* Wrap system prompt with cache_control ephemeral *)
   max_input_tokens: int option; (* Token budget: max cumulative input tokens *)
   max_total_tokens: int option; (* Token budget: max cumulative total tokens *)
@@ -175,6 +179,7 @@ let default_config = {
   response_format_json = false;
   thinking_budget = None;
   tool_choice = None;
+  disable_parallel_tool_use = false;
   cache_system_prompt = false;
   max_input_tokens = None;
   max_total_tokens = None;

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -509,6 +509,38 @@ let test_ollama_tool_args_object () =
   | _ -> fail "expected single ToolUse block with object arguments"
 
 (* ------------------------------------------------------------------ *)
+(* F1: OpenAI API error → Openai_api_error exception                    *)
+(* ------------------------------------------------------------------ *)
+
+let test_openai_api_error_raises () =
+  let error_json = {|{"error":{"message":"Invalid API key","type":"invalid_request_error"}}|} in
+  let raised = ref false in
+  (try ignore (Api.parse_openai_response error_json) with
+   | _ -> raised := true);
+  check bool "exception raised on API error" true !raised
+
+let test_openai_api_error_unknown_message () =
+  let error_json = {|{"error":{}}|} in
+  let raised = ref false in
+  (try ignore (Api.parse_openai_response error_json) with
+   | _ -> raised := true);
+  check bool "exception raised on empty error" true !raised
+
+(* ------------------------------------------------------------------ *)
+(* F2: Ollama build body non-assoc JSON                                 *)
+(* ------------------------------------------------------------------ *)
+
+let test_openai_error_not_failwith () =
+  (* Verify that the error is NOT a plain Failure (which would be misclassified
+     as NetworkError). It should be a distinct exception type. *)
+  let error_json = {|{"error":{"message":"bad request"}}|} in
+  let is_failure = ref false in
+  (try ignore (Api.parse_openai_response error_json) with
+   | Failure _ -> is_failure := true
+   | _ -> ());
+  check bool "not a Failure exception" false !is_failure
+
+(* ------------------------------------------------------------------ *)
 (* Test runner                                                          *)
 (* ------------------------------------------------------------------ *)
 
@@ -543,6 +575,11 @@ let () =
       test_case "unknown stop_reason" `Quick test_parse_response_unknown_stop;
       test_case "strip fenced json" `Quick test_parse_openai_response_strips_fenced_json;
       test_case "cache tokens in usage" `Quick test_parse_response_with_cache_tokens;
+    ];
+    "error_handling", [
+      test_case "openai api error raises Openai_api_error" `Quick test_openai_api_error_raises;
+      test_case "openai api error unknown message" `Quick test_openai_api_error_unknown_message;
+      test_case "openai error not Failure" `Quick test_openai_error_not_failwith;
     ];
     "parse_sse_event", [
       test_case "message_start" `Quick test_parse_sse_message_start;

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -26,6 +26,7 @@ let make_checkpoint
     created_at = 1000.0;
     tools;
     tool_choice;
+    disable_parallel_tool_use = false;
     temperature = None;
     top_p = None;
     top_k = None;
@@ -272,6 +273,11 @@ let () =
         let cp = make_checkpoint ~tool_choice:None () in
         let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
         check bool "none" true (cp2.tool_choice = None));
+
+      test_case "None_ roundtrip" `Quick (fun () ->
+        let cp = make_checkpoint ~tool_choice:(Some Types.None_) () in
+        let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
+        check bool "none_" true (cp2.tool_choice = Some Types.None_));
     ];
 
     "model", [

--- a/test/test_checkpoint_store.ml
+++ b/test/test_checkpoint_store.ml
@@ -16,6 +16,7 @@ let make_checkpoint ?(session_id = "test-session") ?(created_at = 1000.0) () :
     created_at;
     tools = [];
     tool_choice = None;
+    disable_parallel_tool_use = false;
     temperature = None;
     top_p = None;
     top_k = None;

--- a/test/test_session_resume.ml
+++ b/test/test_session_resume.ml
@@ -27,6 +27,7 @@ let make_checkpoint
     created_at;
     tools;
     tool_choice;
+    disable_parallel_tool_use = false;
     temperature = None;
     top_p = None;
     top_k = None;
@@ -207,6 +208,7 @@ let test_resume_restores_tool_choice () =
     | Some Types.Any -> "any"
     | Some Types.Auto -> "auto"
     | Some (Types.Tool n) -> "tool:" ^ n
+    | Some Types.None_ -> "none_"
     | None -> "none"
   in
   Alcotest.(check string) "tool_choice" "any" tc_str

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -73,6 +73,17 @@ let test_tool_choice_tool () =
   | `Assoc [("type", `String "tool"); ("name", `String "calculator")] -> ()
   | _ -> Alcotest.fail "expected tool with name"
 
+let test_tool_choice_none () =
+  let json = Types.tool_choice_to_json Types.None_ in
+  (match json with
+   | `Assoc [("type", `String "none")] -> ()
+   | _ -> Alcotest.fail "expected none type");
+  let rt = Types.tool_choice_of_json json in
+  match rt with
+  | Ok Types.None_ -> ()
+  | Ok _ -> Alcotest.fail "expected None_ variant"
+  | Error _ -> Alcotest.fail "expected Ok"
+
 let test_add_usage () =
   let stats = Types.empty_usage in
   let u : Types.api_usage = {
@@ -136,6 +147,7 @@ let () =
       Alcotest.test_case "auto" `Quick test_tool_choice_auto;
       Alcotest.test_case "any" `Quick test_tool_choice_any;
       Alcotest.test_case "tool" `Quick test_tool_choice_tool;
+      Alcotest.test_case "none roundtrip" `Quick test_tool_choice_none;
     ];
     "usage", [
       Alcotest.test_case "add_usage" `Quick test_add_usage;


### PR DESCRIPTION
## Summary

- **F1**: `api_openai.ml` — `failwith` → `Openai_api_error` 전용 예외. `api.ml`에서 `InvalidRequest`로 정확히 분류 (기존: `NetworkError`로 오분류 → 불필요한 retry)
- **F2**: `api_ollama.ml` — `assert false` → descriptive `failwith` (기존: `Assert_failure` uncaught → 프로그램 크래시)
- **F3**: `runtime_server.ml` — `raise (Failure ...)` → `Result` 전파 (기존: worker thread에서 예외 소실)
- **P1**: `tool_choice: None_` variant 추가 (Anthropic `{"type":"none"}`, OpenAI `"none"`)
- **P2**: `disable_parallel_tool_use` 설정 필드 추가 (Anthropic `tool_choice.disable_parallel_tool_use`, OpenAI `parallel_tool_calls`)
- TODO.md에서 Property-based Testing을 Done으로 이동

## Test plan

- [x] `dune build @all` — 빌드 성공
- [x] `dune runtest` — 53+ 기존 테스트 + 신규 테스트 전부 통과
- [x] tool_choice None_ roundtrip (types, checkpoint)
- [x] OpenAI API 에러 응답 → 예외 발생 확인
- [x] OpenAI API 에러가 `Failure`가 아닌 전용 예외인지 확인
- [ ] `LLAMA_LIVE_TEST=1 dune exec ./test/test_e2e_v024.exe` (llama-server 실행 시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)