### PR TITLE
fix: sync version test assertion to 0.27.0

### DIFF
--- a/test/test_agent_sdk.ml
+++ b/test/test_agent_sdk.ml
@@ -51,7 +51,7 @@ let test_agent_accessors () =
   Alcotest.(check string) "base_url" "http://test" opts.base_url
 
 let test_version_info () =
-  Alcotest.(check string) "version" "0.26.0" Agent_sdk.version;
+  Alcotest.(check string) "version" "0.27.0" Agent_sdk.version;
   Alcotest.(check string) "sdk_name" "agent_sdk" Agent_sdk.sdk_name
 
 let test_build_safe_valid () =


### PR DESCRIPTION
## Summary
- v0.27.0 merge에서 `test_agent_sdk.ml`의 version assertion이 누락되어 CI Build & Test 실패
- `"0.26.0"` → `"0.27.0"` 1줄 수정

## Test plan
- [x] `test_agent_sdk.exe` version info 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)