### PR TITLE
docs: release hygiene v0.27.0–v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to `agent_sdk` are documented in this file.
 
+## [0.30.0] - 2026-03-16
+
+### Added
+- Skill Registry (`skill_registry.ml`) — runtime skill loading/matching
+- Agent Card (`agent_card.ml`) — agent metadata + capability declaration
+- ElicitInput handler — interactive user input during agent runs
+
+## [0.28.1] - 2026-03-16
+
+### Fixed
+- MCP `read_response` non-tail-recursive loop — stack overflow risk on long sessions
+- MCP `mcp_tool_of_json` silent "tool" name fallback — now returns None
+
+### Added
+- 101 new tests, coverage 65.32% to 75.14%
+- Export missing `[@@deriving yojson, show]` in `agent_sdk.mli`
+
+## [0.28.0] - 2026-03-16
+
+### Changed
+- Split `sessions.ml` into `sessions_types.ml` + `sessions_store.ml` + `sessions_proof.ml`
+
+### Added
+- Cache cost tracking (`Provider.pricing_for_model`, `estimate_cost`)
+- Context reduction strategies (`context_reducer.ml`)
+
+## [0.27.0] - 2026-03-16
+
+### Added
+- Prompt caching for all providers (Anthropic `cache_control` ephemeral)
+- Provider registry E2E integration tests
+- Extracted module tests (`api_dispatch`, `api_ollama`)
+
 ## [0.26.0] - 2026-03-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ dune exec examples/streaming.exe
 
 ## Versioning
 
-0.26.0
+0.30.0
 
 We follow semver intent within the 0.x series:
 - **0.x.0**: May contain breaking changes with migration guide in CHANGELOG.


### PR DESCRIPTION
## Summary
- CHANGELOG에 v0.27.0, v0.28.0, v0.28.1, v0.30.0 엔트리 추가
- README 버전 0.26.0 → 0.30.0 갱신
- 코드 변경 없음, 문서만

## Context
PR #100 (v0.28.1) 머지 후 git tag가 v0.26.0에서 멈춰있고 CHANGELOG/README도 미갱신 상태.
머지 후 해당 커밋들에 git tag v0.27.0 ~ v0.30.0 부여 예정.

## Test plan
- [ ] CHANGELOG 최상단에 v0.30.0 섹션 존재
- [ ] README에 0.30.0 표시
- [ ] `dune build` 통과 (코드 변경 없으므로 형식적)

🤖 Generated with [Claude Code](https://claude.com/claude-code)