### PR TITLE
perf(a2a): O(1) list ops + bounded in-memory task store

### DIFF
--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -3860,8 +3860,9 @@ module A2a_task : sig
   val task_of_yojson : Yojson.Safe.t -> (task, string) result
 
   (** {2 In-memory store} *)
+  val default_max_tasks : int
   type store
-  val create_store : unit -> store
+  val create_store : ?max_tasks:int -> unit -> store
   val store_task : store -> task -> unit
   val get_task : store -> task_id -> task option
   val list_tasks : store -> task list

--- a/lib/protocol/a2a_task.ml
+++ b/lib/protocol/a2a_task.ml
@@ -309,15 +309,49 @@ let task_of_yojson json =
 
 (* ── In-memory store ──────────────────────────────────────────── *)
 
-type store = (task_id, task) Hashtbl.t
+let default_max_tasks = 10_000
 
-let create_store () : store = Hashtbl.create 64
+type store = {
+  tasks : (task_id, task) Hashtbl.t;
+  max_tasks : int;
+}
+
+let create_store ?(max_tasks = default_max_tasks) () : store =
+  { tasks = Hashtbl.create 64; max_tasks }
+
+(** Evict terminal tasks (oldest updated_at first) when store is at capacity. *)
+let evict_if_needed (s : store) : unit =
+  if Hashtbl.length s.tasks < s.max_tasks then ()
+  else
+    let terminals =
+      Hashtbl.fold (fun id t acc ->
+        if is_terminal t.state then (id, t.updated_at) :: acc
+        else acc
+      ) s.tasks []
+    in
+    match terminals with
+    | [] -> () (* all tasks are active; cannot evict *)
+    | _ ->
+      let sorted =
+        List.sort (fun (_, a) (_, b) -> Float.compare a b) terminals
+      in
+      (* Remove oldest terminal tasks to free 10% capacity *)
+      let to_remove = max 1 (s.max_tasks / 10) in
+      let rec remove n = function
+        | [] -> ()
+        | _ when n <= 0 -> ()
+        | (id, _) :: rest ->
+          Hashtbl.remove s.tasks id;
+          remove (n - 1) rest
+      in
+      remove to_remove sorted
 
 let store_task (s : store) (t : task) : unit =
-  Hashtbl.replace s t.id t
+  evict_if_needed s;
+  Hashtbl.replace s.tasks t.id t
 
 let get_task (s : store) (id : task_id) : task option =
-  Hashtbl.find_opt s id
+  Hashtbl.find_opt s.tasks id
 
 let list_tasks (s : store) : task list =
-  Hashtbl.fold (fun _ t acc -> t :: acc) s []
+  Hashtbl.fold (fun _ t acc -> t :: acc) s.tasks []

--- a/test/test_a2a.ml
+++ b/test/test_a2a.ml
@@ -161,6 +161,55 @@ let test_store () =
   let tasks = A2a_task.list_tasks store in
   Alcotest.(check int) "one task" 1 (List.length tasks)
 
+let test_store_eviction () =
+  (* max_tasks=5, so filling with 5 terminal + 1 active should evict terminals *)
+  let store = A2a_task.create_store ~max_tasks:5 () in
+  (* Insert 5 terminal (completed) tasks with staggered updated_at *)
+  for i = 0 to 4 do
+    let msg = mk_message (Printf.sprintf "q%d" i) in
+    let task = A2a_task.create msg in
+    let task = { task with
+      id = Printf.sprintf "term_%d" i;
+      updated_at = float_of_int i;
+    } in
+    let task = match A2a_task.transition task Working with
+      | Ok t -> t | Error _ -> task in
+    let task = match A2a_task.transition task Completed with
+      | Ok t -> { t with updated_at = float_of_int i }
+      | Error _ -> task in
+    A2a_task.store_task store task
+  done;
+  Alcotest.(check int) "5 tasks before eviction" 5
+    (List.length (A2a_task.list_tasks store));
+  (* Add one more -- should trigger eviction of oldest terminal *)
+  let active = A2a_task.create (mk_message "active") in
+  let active = { active with id = "active_task" } in
+  A2a_task.store_task store active;
+  let tasks = A2a_task.list_tasks store in
+  (* Should have evicted at least 1 terminal (oldest) and added the active *)
+  Alcotest.(check bool) "active task present" true
+    (List.exists (fun (t : A2a_task.task) -> t.id = "active_task") tasks);
+  Alcotest.(check bool) "oldest terminal evicted" true
+    (not (List.exists (fun (t : A2a_task.task) -> t.id = "term_0") tasks))
+
+let test_store_eviction_preserves_active () =
+  (* When all tasks are active (non-terminal), eviction cannot remove any *)
+  let store = A2a_task.create_store ~max_tasks:3 () in
+  for i = 0 to 2 do
+    let task = A2a_task.create (mk_message (Printf.sprintf "w%d" i)) in
+    let task = { task with id = Printf.sprintf "working_%d" i } in
+    let task = match A2a_task.transition task Working with
+      | Ok t -> t | Error _ -> task in
+    A2a_task.store_task store task
+  done;
+  (* Store one more -- all are active so no eviction possible *)
+  let extra = A2a_task.create (mk_message "extra") in
+  let extra = { extra with id = "extra" } in
+  A2a_task.store_task store extra;
+  (* All 4 should be present (store exceeds max_tasks because no terminals to evict) *)
+  Alcotest.(check int) "all kept" 4
+    (List.length (A2a_task.list_tasks store))
+
 (* ── A2A Server tests ─────────────────────────────────────────── *)
 
 let test_well_known_agent_json () =
@@ -314,6 +363,8 @@ let () =
     ];
     "store", [
       Alcotest.test_case "CRUD" `Quick test_store;
+      Alcotest.test_case "eviction" `Quick test_store_eviction;
+      Alcotest.test_case "eviction preserves active" `Quick test_store_eviction_preserves_active;
     ];
     "server", [
       Alcotest.test_case "well-known" `Quick test_well_known_agent_json;


### PR DESCRIPTION
## Summary
- **M12**: Replace O(n) `@` list append in `add_message`/`add_artifact` with O(1) `::` cons. Internal storage is reverse-chronological; `task_to_yojson` uses `List.rev_map` for correct wire order. Same fix applied to `artifact_of_yojson` fold.
- **M13**: Add size-bounded in-memory task store (`max_tasks` default 10,000). Evicts oldest terminal tasks (Completed/Failed/Canceled) when limit reached. Active tasks are never evicted. 10% capacity evicted per trigger.

## Test plan
- [x] `dune build` passes
- [x] 21 A2A tests pass (including 2 new eviction tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)