### PR TITLE
fix: revert raw_trace to Stdlib.Mutex — CI green

### DIFF
--- a/lib/raw_trace.ml
+++ b/lib/raw_trace.ml
@@ -88,7 +88,7 @@ type record = {
 type t = {
   path: string;
   session_id: string option;
-  lock: Eio.Mutex.t;
+  lock: Mutex.t;
   mutable next_seq: int;
   mutable run_counter: int;
   mutable last_run: run_ref option;
@@ -293,7 +293,7 @@ let create ?session_id ~path () =
     {
       path;
       session_id;
-      lock = Eio.Mutex.create ();
+      lock = Mutex.create ();
       next_seq;
       run_counter = 0;
       last_run = None;
@@ -338,7 +338,8 @@ let append_locked sink (record : record) =
 let append_record active ~record_type ?prompt ?block_index ?block_kind
     ?assistant_block ?tool_use_id ?tool_name ?tool_input ?tool_result ?tool_error
     ?hook_name ?hook_decision ?hook_detail ?final_text ?stop_reason ?error () =
-  Eio.Mutex.use_rw ~protect:true active.sink.lock (fun () ->
+  Mutex.lock active.sink.lock;
+  Fun.protect (fun () ->
     let seq = active.sink.next_seq in
     let record =
       {
@@ -374,12 +375,12 @@ let append_record active ~record_type ?prompt ?block_index ?block_kind
          active.end_seq <- max active.end_seq seq
      | Error _ -> ());
     Result.map (fun () -> seq) result)
+  ~finally:(fun () -> Mutex.unlock active.sink.lock)
 
 let start_run sink ~agent_name ~prompt =
-  let worker_run_id =
-    Eio.Mutex.use_rw ~protect:true sink.lock (fun () ->
-      next_worker_run_id sink)
-  in
+  Mutex.lock sink.lock;
+  let worker_run_id = next_worker_run_id sink in
+  Mutex.unlock sink.lock;
   let active =
     {
       sink;
@@ -447,8 +448,9 @@ let finish_run active ~(final_text : string option)
       session_id = active.session_id;
     }
   in
-  Eio.Mutex.use_rw ~protect:true active.sink.lock (fun () ->
-    active.sink.last_run <- Some run_ref);
+  Mutex.lock active.sink.lock;
+  active.sink.last_run <- Some run_ref;
+  Mutex.unlock active.sink.lock;
   Ok run_ref
 
 let raise_if_error : type a. (a, Error.sdk_error) result -> unit = function


### PR DESCRIPTION
## Summary

raw_trace.ml was migrated to Eio.Mutex in PR #115, but it runs in
oas_runtime.exe which spawns threads outside the Eio scheduler.
Eio.Mutex.use_rw requires a fiber context, causing Effect.Unhandled
crashes in CI (test_conformance, test_runtime — 9 failures).

Reverts raw_trace.ml to Stdlib.Mutex. File I/O is blocking anyway,
so Eio.Mutex provides no cooperative scheduling benefit here.

## Test plan
- [x] test_conformance: 2/2 pass (was 0/2)
- [x] test_runtime: 12/12 pass (was 5/12)
- [x] test_swarm, test_otel: unaffected
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)