### PR TITLE
fix(agent): expose record fields via manifest types in agent.mli

### DIFF
--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -6,9 +6,30 @@
 
 (** {1 Types (re-exported from Agent_types)} *)
 
-type periodic_callback = Agent_types.periodic_callback
+type periodic_callback = Agent_types.periodic_callback = {
+  interval_sec: float;
+  callback: unit -> unit;
+}
 
-type options = Agent_types.options
+type options = Agent_types.options = {
+  base_url: string;
+  provider: Provider.config option;
+  cascade: Provider.cascade option;
+  max_idle_turns: int;
+  hooks: Hooks.hooks;
+  guardrails: Guardrails.t;
+  tracer: Tracing.t;
+  raw_trace: Raw_trace.t option;
+  approval: Hooks.approval_callback option;
+  context_reducer: Context_reducer.t option;
+  context_injector: Hooks.context_injector option;
+  mcp_clients: Mcp.managed list;
+  event_bus: Event_bus.t option;
+  skill_registry: Skill_registry.t option;
+  elicitation: Hooks.elicitation_callback option;
+  description: string option;
+  periodic_callbacks: periodic_callback list;
+}
 
 type lifecycle_status = Agent_lifecycle.lifecycle_status =
   | Accepted


### PR DESCRIPTION
## Summary

- `type periodic_callback = Agent_types.periodic_callback`를 manifest type으로 변경
- `type options = Agent_types.options`도 동일하게 변경
- 외부 소비자가 `Agent.interval_sec`, `Agent.base_url` 등 레코드 필드에 직접 접근 가능

## Root cause

OCaml에서 `type t = Other_module.t`는 type equation이지만, 레코드 필드 이름은 원본 모듈(`Agent_types`)에서만 resolve됨. `Agent_types`가 public 모듈이어도, 소비자가 `Agent.field_name` 형태로 접근하려면 manifest type(`type t = Other.t = { fields }`)이 필요.

## Test plan

- [x] OAS `dune build` 성공
- [x] masc-mcp `dune build` 성공 (이전: `Unbound record field Oas.Agent.interval_sec`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)