### PR TITLE
feat(context): add Prune_tool_args strategy for ToolUse input truncation

### DIFF
--- a/lib/context_reducer.ml
+++ b/lib/context_reducer.ml
@@ -17,6 +17,7 @@ type strategy =
   | Keep_last_n of int
   | Token_budget of int
   | Prune_tool_outputs of { max_output_len: int }
+  | Prune_tool_args of { max_arg_len: int; keep_recent: int }
   | Merge_contiguous
   | Drop_thinking
   | Keep_first_and_last of { first_n: int; last_n: int }
@@ -130,6 +131,57 @@ let apply_prune_tool_outputs ~max_output_len messages =
     { msg with content }
   ) messages
 
+(** Truncate long string values in ToolUse input JSON.
+    Walks the JSON tree and replaces string values exceeding [max_arg_len]
+    with a truncated prefix plus a marker. Returns the original JSON
+    unchanged if no values exceed the limit. *)
+let truncate_json_strings ~max_arg_len (json : Yojson.Safe.t) : Yojson.Safe.t =
+  let changed = ref false in
+  let rec walk = function
+    | `String s when String.length s > max_arg_len ->
+      changed := true;
+      let prefix = if max_arg_len >= 20 then String.sub s 0 20
+                   else String.sub s 0 (min max_arg_len (String.length s)) in
+      `String (Printf.sprintf "%s...(truncated %d chars)" prefix (String.length s))
+    | `Assoc pairs ->
+      `Assoc (List.map (fun (k, v) -> (k, walk v)) pairs)
+    | `List items ->
+      `List (List.map walk items)
+    | other -> other
+  in
+  let result = walk json in
+  if !changed then result else json
+
+(** Prune tool arguments: truncate long string values in ToolUse input
+    for older messages, keeping the most recent [keep_recent] turns intact.
+    Targets ToolUse blocks whose input JSON contains strings exceeding
+    [max_arg_len]. This is a lightweight pre-summarization optimization
+    inspired by Deep Agents' TruncateArgsSettings. *)
+let apply_prune_tool_args ~max_arg_len ~keep_recent messages =
+  let turns = group_into_turns messages in
+  let total = List.length turns in
+  if total <= keep_recent then messages
+  else
+    let process_turn i turn =
+      if i >= total - keep_recent then turn  (* preserve recent turns *)
+      else
+        List.map (fun (msg : message) ->
+          if msg.role <> Assistant then msg
+          else
+            let content = List.map (fun block ->
+              match block with
+              | ToolUse { id; name; input } ->
+                let truncated = truncate_json_strings ~max_arg_len input in
+                if truncated == input then block  (* physical equality: unchanged *)
+                else ToolUse { id; name; input = truncated }
+              | other -> other
+            ) msg.content in
+            { msg with content }
+        ) turn
+    in
+    let processed = List.mapi process_turn turns in
+    List.concat processed
+
 (** Merge contiguous messages with the same role.
     Concatenates content blocks. Respects ToolUse/ToolResult pairing
     by not merging User messages that contain ToolResult blocks. *)
@@ -215,6 +267,7 @@ and apply_strategy strategy messages =
   | Keep_last_n n -> apply_keep_last_n n messages
   | Token_budget budget -> apply_token_budget budget messages
   | Prune_tool_outputs { max_output_len } -> apply_prune_tool_outputs ~max_output_len messages
+  | Prune_tool_args { max_arg_len; keep_recent } -> apply_prune_tool_args ~max_arg_len ~keep_recent messages
   | Merge_contiguous -> apply_merge_contiguous messages
   | Drop_thinking -> apply_drop_thinking messages
   | Keep_first_and_last { first_n; last_n } ->
@@ -235,6 +288,8 @@ and apply_strategy strategy messages =
 let keep_last n = { strategy = Keep_last_n n }
 let token_budget n = { strategy = Token_budget n }
 let prune_tool_outputs ~max_output_len = { strategy = Prune_tool_outputs { max_output_len } }
+let prune_tool_args ~max_arg_len ?(keep_recent=20) () =
+  { strategy = Prune_tool_args { max_arg_len; keep_recent } }
 let merge_contiguous = { strategy = Merge_contiguous }
 let drop_thinking = { strategy = Drop_thinking }
 let keep_first_and_last ~first_n ~last_n =

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -407,6 +407,115 @@ let test_summarize_old_all_recent () =
   (* All turns fit in keep_recent, no summarization *)
   Alcotest.(check int) "no change" 2 (List.length result)
 
+(* --- prune_tool_args --- *)
+
+(** Helper: build an assistant message with a ToolUse whose input has a long string arg. *)
+let tool_use_msg_with_input id name input =
+  Types.{ role = Assistant; content = [ToolUse { id; name; input }] }
+
+let test_prune_tool_args_short_unchanged () =
+  let input = `Assoc [("content", `String "short")] in
+  let msgs = [
+    user_msg "turn1";
+    tool_use_msg_with_input "t1" "write_file" input;
+    tool_result_msg "t1" "ok";
+    user_msg "turn2"; asst_msg "done";
+  ] in
+  let reducer = Context_reducer.prune_tool_args ~max_arg_len:2000 () in
+  let result = Context_reducer.reduce reducer msgs in
+  (* Short args unchanged *)
+  (match List.nth result 1 with
+   | { Types.content = [Types.ToolUse { input = `Assoc pairs; _ }]; _ } ->
+     (match List.assoc "content" pairs with
+      | `String s -> Alcotest.(check string) "unchanged" "short" s
+      | _ -> Alcotest.fail "expected string")
+   | _ -> Alcotest.fail "expected tool use")
+
+let test_prune_tool_args_long_truncated () =
+  let long_str = String.make 3000 'x' in
+  let input = `Assoc [("content", `String long_str); ("path", `String "/file.txt")] in
+  let msgs = [
+    user_msg "turn1";
+    tool_use_msg_with_input "t1" "write_file" input;
+    tool_result_msg "t1" "ok";
+    user_msg "turn2"; asst_msg "done";
+  ] in
+  (* keep_recent=1 so turn1 (with tool use) is in the old zone *)
+  let reducer = Context_reducer.prune_tool_args ~max_arg_len:2000 ~keep_recent:1 () in
+  let result = Context_reducer.reduce reducer msgs in
+  (match List.nth result 1 with
+   | { Types.content = [Types.ToolUse { input = `Assoc pairs; _ }]; _ } ->
+     (* "content" should be truncated *)
+     (match List.assoc "content" pairs with
+      | `String s ->
+        Alcotest.(check bool) "truncated" true (String.length s < 3000);
+        let has_truncated_marker =
+          try let _ = Str.search_forward (Str.regexp_string "(truncated") s 0 in true
+          with Not_found -> false in
+        Alcotest.(check bool) "has marker" true has_truncated_marker
+      | _ -> Alcotest.fail "expected string");
+     (* "path" should be unchanged (short) *)
+     (match List.assoc "path" pairs with
+      | `String s -> Alcotest.(check string) "path unchanged" "/file.txt" s
+      | _ -> Alcotest.fail "expected string")
+   | _ -> Alcotest.fail "expected tool use")
+
+let test_prune_tool_args_preserves_recent () =
+  let long_str = String.make 3000 'x' in
+  let input = `Assoc [("content", `String long_str)] in
+  let msgs = [
+    user_msg "turn1";
+    tool_use_msg_with_input "t1" "write_file" input;
+    tool_result_msg "t1" "ok";
+  ] in
+  (* keep_recent=1 means all turns are recent *)
+  let reducer = Context_reducer.prune_tool_args ~max_arg_len:100 ~keep_recent:1 () in
+  let result = Context_reducer.reduce reducer msgs in
+  (match List.nth result 1 with
+   | { Types.content = [Types.ToolUse { input = `Assoc pairs; _ }]; _ } ->
+     (match List.assoc "content" pairs with
+      | `String s -> Alcotest.(check int) "not truncated" 3000 (String.length s)
+      | _ -> Alcotest.fail "expected string")
+   | _ -> Alcotest.fail "expected tool use")
+
+let test_prune_tool_args_nested_json () =
+  let long_str = String.make 3000 'y' in
+  let input = `Assoc [("nested", `Assoc [("deep", `String long_str)])] in
+  let msgs = [
+    user_msg "old turn";
+    tool_use_msg_with_input "t1" "edit_file" input;
+    tool_result_msg "t1" "ok";
+    user_msg "recent"; asst_msg "done";
+  ] in
+  let reducer = Context_reducer.prune_tool_args ~max_arg_len:100 ~keep_recent:1 () in
+  let result = Context_reducer.reduce reducer msgs in
+  (match List.nth result 1 with
+   | { Types.content = [Types.ToolUse { input = `Assoc pairs; _ }]; _ } ->
+     (match List.assoc "nested" pairs with
+      | `Assoc nested_pairs ->
+        (match List.assoc "deep" nested_pairs with
+         | `String s ->
+           Alcotest.(check bool) "nested truncated" true (String.length s < 3000)
+         | _ -> Alcotest.fail "expected string")
+      | _ -> Alcotest.fail "expected nested assoc")
+   | _ -> Alcotest.fail "expected tool use")
+
+let test_prune_tool_args_non_assistant_untouched () =
+  (* User messages should never be modified, even with ToolResult *)
+  let msgs = [
+    user_msg "turn1";
+    tool_use_msg_with_input "t1" "calc" (`Assoc [("x", `String (String.make 5000 'z'))]);
+    tool_result_msg "t1" (String.make 5000 'r');
+    user_msg "turn2"; asst_msg "done";
+  ] in
+  let reducer = Context_reducer.prune_tool_args ~max_arg_len:100 () in
+  let result = Context_reducer.reduce reducer msgs in
+  (* ToolResult (in User msg) should be unchanged *)
+  (match List.nth result 2 with
+   | { Types.content = [Types.ToolResult { content; _ }]; _ } ->
+     Alcotest.(check int) "tool result unchanged" 5000 (String.length content)
+   | _ -> Alcotest.fail "expected tool result")
+
 let () =
   Alcotest.run "Context_reducer" [
     "keep_last_n", [
@@ -462,6 +571,13 @@ let () =
     "summarize_old", [
       Alcotest.test_case "basic summarization" `Quick test_summarize_old_basic;
       Alcotest.test_case "all recent no-op" `Quick test_summarize_old_all_recent;
+    ];
+    "prune_tool_args", [
+      Alcotest.test_case "short args unchanged" `Quick test_prune_tool_args_short_unchanged;
+      Alcotest.test_case "long args truncated" `Quick test_prune_tool_args_long_truncated;
+      Alcotest.test_case "preserves recent turns" `Quick test_prune_tool_args_preserves_recent;
+      Alcotest.test_case "nested JSON truncated" `Quick test_prune_tool_args_nested_json;
+      Alcotest.test_case "non-assistant untouched" `Quick test_prune_tool_args_non_assistant_untouched;
     ];
     "edge_cases", [
       Alcotest.test_case "empty messages" `Quick test_empty;


### PR DESCRIPTION
## Summary
- Inspired by [Deep Agents](https://github.com/langchain-ai/deepagents) `TruncateArgsSettings` pattern
- New `Prune_tool_args` strategy: truncates long string values in `ToolUse` input JSON for older messages while preserving recent turns
- Generic approach — targets all tools, not just `write_file`/`edit_file`
- `truncate_json_strings`: recursive JSON tree walker that replaces strings > `max_arg_len` with truncated prefix + marker

## Test plan
- [x] 37/37 context_reducer tests passing (32 existing + 5 new)
- [x] Full OAS test suite passing
- [ ] Review truncation threshold defaults (max_arg_len=2000, keep_recent=20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)