### PR TITLE
fix(security): quote shell args in examples, reject path traversal

### DIFF
--- a/examples/codegen_agent.ml
+++ b/examples/codegen_agent.ml
@@ -89,6 +89,10 @@ let write_file_tool =
       let open Yojson.Safe.Util in
       let path = args |> member "path" |> to_string in
       let code = args |> member "code" |> to_string in
+      (* Reject path traversal attempts *)
+      if String.contains path '\000' || (String.length path > 2 && String.sub path 0 2 = "..") || (try ignore (Str.search_forward (Str.regexp_string "/../") path 0); true with Not_found -> false) then
+        Error { message = Printf.sprintf "Rejected path: %s (path traversal)" path; recoverable = false }
+      else
       (try
         let oc = open_out path in
         output_string oc code;

--- a/examples/swarm_review.ml
+++ b/examples/swarm_review.ml
@@ -70,7 +70,7 @@ let get_diff_tool repo pr_num =
     ~description:"Get the unified diff of the PR"
     ~parameters:[]
     (fun _args ->
-      let cmd = Printf.sprintf "gh pr diff %s --repo %s" pr_num repo in
+      let cmd = Printf.sprintf "gh pr diff %s --repo %s" (Filename.quote pr_num) (Filename.quote repo) in
       match run_command cmd with
       | Ok output ->
         let max_len = 8000 in
@@ -85,7 +85,7 @@ let get_files_tool repo pr_num =
     ~description:"List files changed in the PR"
     ~parameters:[]
     (fun _args ->
-      let cmd = Printf.sprintf "gh pr view %s --repo %s --json files --jq '.files[].path'" pr_num repo in
+      let cmd = Printf.sprintf "gh pr view %s --repo %s --json files --jq '.files[].path'" (Filename.quote pr_num) (Filename.quote repo) in
       match run_command cmd with
       | Ok output -> Ok { content = output }
       | Error msg -> Error { message = msg; recoverable = true })


### PR DESCRIPTION
## Summary

- `swarm_review.ml`: add `Filename.quote` for repo/pr_num in shell commands
- `codegen_agent.ml`: reject paths containing `../` or null bytes in write_file_tool

Found by GLM-5 external review of #129.

## Test plan

- [x] `dune build --root .` clean
- [x] No behavioral change for normal inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)