### PR TITLE
feat(swarm): add .mli API contracts for all lib_swarm modules

### DIFF
--- a/lib_swarm/runner.mli
+++ b/lib_swarm/runner.mli
@@ -1,0 +1,43 @@
+(** Swarm runner — multi-agent parallel execution with convergence loops.
+
+    Runs N agents in one of three modes:
+    - {b Decentralized}: all agents run in parallel via [Eio.Fiber.List.map].
+    - {b Supervisor}: workers run in parallel, then supervisor synthesizes.
+    - {b Pipeline}: agents run sequentially, each receiving previous output.
+
+    When [convergence] is configured, the runner loops until the metric
+    reaches the target, patience is exhausted, or max_iterations is hit.
+    Swarm state is protected by [Eio.Mutex] during convergence loops.
+
+    @since 0.42.0 *)
+
+open Agent_sdk
+
+(** {1 Main entry point} *)
+
+(** Run a swarm of agents according to {!Swarm_types.swarm_config}.
+
+    Without [convergence]: single pass, all agents run once.
+    With [convergence]: iterative loop with metric evaluation.
+    With [timeout_sec]: aborts with [TaskTimeout] if exceeded.
+
+    @param callbacks Optional lifecycle callbacks (default: {!Swarm_types.no_callbacks}) *)
+val run :
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  ?callbacks:Swarm_types.swarm_callbacks ->
+  Swarm_types.swarm_config ->
+  (Swarm_types.swarm_result, Error.sdk_error) result
+
+(** {1 Metric utilities} *)
+
+(** Evaluate a metric source. [Shell_command] runs a shell command and
+    parses stdout as float. [Callback] invokes the function directly. *)
+val eval_metric : Swarm_types.metric_source -> (float, string) result
+
+(** Aggregate a list of scores using the given strategy. *)
+val aggregate_scores :
+  Swarm_types.aggregate_strategy -> float list -> float
+
+(** Extract text content from an API response. *)
+val text_of_response : Types.api_response -> string

--- a/lib_swarm/swarm_checkpoint.mli
+++ b/lib_swarm/swarm_checkpoint.mli
@@ -1,0 +1,59 @@
+(** Swarm state checkpoint — save and restore convergence loop progress.
+
+    Closures ([agent_entry.run]) are not serializable, so we save entry
+    names and rebind via [agent_lookup] on restore.
+
+    @since 0.43.0 *)
+
+open Agent_sdk
+
+(** {1 Types} *)
+
+type config_snapshot = {
+  entry_names: string list;
+  mode: Swarm_types.orchestration_mode;
+  max_parallel: int;
+  prompt: string;
+  timeout_sec: float option;
+  convergence_target: float option;
+  convergence_max_iterations: int option;
+  convergence_patience: int option;
+}
+
+type t = {
+  version: int;
+  config_snapshot: config_snapshot;
+  iteration: int;
+  best_metric: float option;
+  best_iteration: int;
+  patience_counter: int;
+  history: Swarm_types.iteration_record list;
+  created_at: float;
+}
+
+val checkpoint_version : int
+
+(** {1 Save} *)
+
+(** Create a checkpoint from the current swarm state. *)
+val of_state : Swarm_types.swarm_state -> t
+
+(** Snapshot config without closures. *)
+val snapshot_of_config : Swarm_types.swarm_config -> config_snapshot
+
+(** {1 Serialization} *)
+
+val to_json : t -> Yojson.Safe.t
+val save : t -> path:string -> unit
+val load : path:string -> (t, Error.sdk_error) result
+
+(** {1 Restore} *)
+
+(** Restore swarm state from a checkpoint.
+    [agent_lookup] rebinds entry names to live [agent_entry] closures.
+    Returns [Error] if any entry name cannot be found. *)
+val restore :
+  t ->
+  agent_lookup:(string -> Swarm_types.agent_entry option) ->
+  base_config:Swarm_types.swarm_config ->
+  (Swarm_types.swarm_state, Error.sdk_error) result

--- a/lib_swarm/swarm_types.mli
+++ b/lib_swarm/swarm_types.mli
@@ -1,0 +1,133 @@
+(** Swarm types — core type definitions for multi-agent swarm execution.
+
+    Part of the [agent_sdk_swarm] library (Layer 2).
+
+    @since 0.42.0 *)
+
+open Agent_sdk
+
+(** {1 Agent Roles} *)
+
+type agent_role =
+  | Discover
+  | Verify
+  | Execute
+  | Summarize
+  | Custom_role of string
+[@@deriving show]
+
+(** {1 Orchestration} *)
+
+type orchestration_mode =
+  | Decentralized
+  | Supervisor
+  | Pipeline_mode
+[@@deriving show]
+
+type aggregate_strategy =
+  | Best_score
+  | Average_score
+  | Majority_vote
+  | Custom_agg of (float list -> float)
+
+type metric_source =
+  | Shell_command of string
+  | Callback of (unit -> float)
+
+type convergence_config = {
+  metric: metric_source;
+  target: float;
+  max_iterations: int;
+  patience: int;
+  aggregate: aggregate_strategy;
+}
+
+(** {1 Swarm Configuration} *)
+
+(** Closure-based agent entry. [run] captures the agent and clock
+    so that the swarm runner only needs [sw] and [prompt]. *)
+type agent_entry = {
+  name: string;
+  run: sw:Eio.Switch.t -> string -> (Types.api_response, Error.sdk_error) result;
+  role: agent_role;
+}
+
+(** Wrap an {!Agent.t} into an {!agent_entry}.
+    The clock is captured in the closure. *)
+val make_entry :
+  name:string ->
+  role:agent_role ->
+  clock:_ Eio.Time.clock ->
+  Agent.t ->
+  agent_entry
+
+type resource_budget = {
+  max_total_tokens: int option;
+  max_total_time_sec: float option;
+  max_total_api_calls: int option;
+}
+
+val no_budget : resource_budget
+
+type swarm_config = {
+  entries: agent_entry list;
+  mode: orchestration_mode;
+  convergence: convergence_config option;
+  max_parallel: int;
+  prompt: string;
+  timeout_sec: float option;
+  budget: resource_budget;
+}
+
+(** {1 Execution State} *)
+
+type agent_status =
+  | Idle
+  | Working
+  | Done_ok of { elapsed: float; text: string }
+  | Done_error of { elapsed: float; error: string }
+[@@deriving show]
+
+type iteration_record = {
+  iteration: int;
+  metric_value: float option;
+  agent_results: (string * agent_status) list;
+  elapsed: float;
+  timestamp: float;
+}
+
+type swarm_state = {
+  config: swarm_config;
+  mutable current_iteration: int;
+  mutable best_metric: float option;
+  mutable best_iteration: int;
+  mutable patience_counter: int;
+  mutable agent_statuses: (string * agent_status) list;
+  mutable history: iteration_record list;
+  mutable converged: bool;
+}
+
+val create_state : swarm_config -> swarm_state
+
+(** {1 Callbacks} *)
+
+type swarm_callbacks = {
+  on_iteration_start: (int -> unit) option;
+  on_iteration_end: (iteration_record -> unit) option;
+  on_agent_start: (string -> unit) option;
+  on_agent_done: (string -> agent_status -> unit) option;
+  on_converged: (swarm_state -> unit) option;
+  on_error: (string -> unit) option;
+}
+
+val no_callbacks : swarm_callbacks
+
+(** {1 Result} *)
+
+type swarm_result = {
+  iterations: iteration_record list;
+  final_metric: float option;
+  converged: bool;
+  total_elapsed: float;
+  total_usage: Types.usage_stats;
+}

--- a/lib_swarm/test_helpers.mli
+++ b/lib_swarm/test_helpers.mli
@@ -1,0 +1,46 @@
+(** Test helper factories for swarm testing — zero-LLM mock patterns.
+
+    All helpers create {!Swarm_types.agent_entry} values with closure-based
+    run functions that return immediate results without LLM calls.
+
+    @since 0.43.0 *)
+
+open Agent_sdk
+
+(** Create a mock [Ok] api_response with the given text. *)
+val text_response :
+  string -> (Types.api_response, Error.sdk_error) result
+
+(** Create a mock [Error] response with the given message. *)
+val error_response :
+  string -> (Types.api_response, Error.sdk_error) result
+
+(** Create a mock agent_entry that always returns the given text.
+    @param role Default: {!Swarm_types.Execute} *)
+val mock_entry :
+  name:string ->
+  ?role:Swarm_types.agent_role ->
+  string ->
+  Swarm_types.agent_entry
+
+(** Create a mock agent_entry that always fails with the given message. *)
+val failing_entry :
+  name:string ->
+  ?role:Swarm_types.agent_role ->
+  string ->
+  Swarm_types.agent_entry
+
+(** Create a mock agent_entry with a counter tracking call count.
+    Returns the entry and a function to read the count. *)
+val counting_entry :
+  name:string ->
+  ?role:Swarm_types.agent_role ->
+  string ->
+  Swarm_types.agent_entry * (unit -> int)
+
+(** Create a basic {!Swarm_types.swarm_config} with Decentralized mode,
+    no convergence, and [max_parallel] equal to the number of entries. *)
+val basic_config :
+  prompt:string ->
+  Swarm_types.agent_entry list ->
+  Swarm_types.swarm_config


### PR DESCRIPTION
## Summary

- lib_swarm/ 4개 모듈에 .mli 인터페이스 파일 추가
- `Runner` 내부 함수들 (`run_one_agent`, `fire`, `state_handle`) 캡슐화
- Layer 2 public API 계약 명확화

## Files

| File | LOC | Key exports |
|------|-----|-------------|
| `swarm_types.mli` | 134 | types, `make_entry`, `create_state`, `no_callbacks` |
| `runner.mli` | 42 | `run`, `eval_metric`, `aggregate_scores` |
| `swarm_checkpoint.mli` | 59 | `of_state`, `save`, `load`, `restore` |
| `test_helpers.mli` | 46 | `mock_entry`, `failing_entry`, `counting_entry`, `basic_config` |

## Test plan

- [x] `dune build` 성공
- [x] `test_swarm` 31/31 PASS
- [x] `test_traced_swarm` 3/3 PASS

Generated with [Claude Code](https://claude.com/claude-code)