### PR TITLE
feat(swarm): telemetry bridge — Layer 1 trace refs

### DIFF
--- a/lib_swarm/runner.ml
+++ b/lib_swarm/runner.ml
@@ -70,10 +70,16 @@ let run_one_agent ~sw ~callbacks (entry : agent_entry) prompt =
   let t0 = Unix.gettimeofday () in
   let result = entry.run ~sw prompt in
   let elapsed = Unix.gettimeofday () -. t0 in
+  (* Collect telemetry from agent after run completes *)
+  let telemetry =
+    match entry.get_telemetry with
+    | Some f -> (try f () with _ -> empty_telemetry)
+    | None -> empty_telemetry
+  in
   let status =
     match result with
-    | Ok resp -> Done_ok { elapsed; text = text_of_response resp }
-    | Error err -> Done_error { elapsed; error = Error.to_string err }
+    | Ok resp -> Done_ok { elapsed; text = text_of_response resp; telemetry }
+    | Error err -> Done_error { elapsed; error = Error.to_string err; telemetry }
   in
   fire2 callbacks.on_agent_done entry.name status;
   (entry.name, status, result)
@@ -124,6 +130,16 @@ let run_agents_by_mode ~sw ~callbacks config =
          (config.prompt ^ "\n\nWorker results:\n" ^ summary) in
        wr @ [sr])
 
+(* ── Collect trace refs from agent results ─────────────────────── *)
+
+let collect_trace_refs agent_results =
+  List.filter_map (fun (_name, status) ->
+    match status with
+    | Done_ok { telemetry; _ } -> telemetry.trace_ref
+    | Done_error { telemetry; _ } -> telemetry.trace_ref
+    | Idle | Working -> None
+  ) agent_results
+
 (* ── Collect usage from results ─────────────────────────────────── *)
 
 let collect_usage acc results =
@@ -150,6 +166,7 @@ let run_single_pass ~sw ~clock:_ ?(callbacks = no_callbacks) config =
     agent_results;
     elapsed;
     timestamp = Unix.gettimeofday ();
+    trace_refs = collect_trace_refs agent_results;
   }, usage)
 
 (* ── Eio.Mutex-protected state handle ───────────────────────────── *)
@@ -195,6 +212,7 @@ let run_convergence_loop ~sw ~clock:_ ~callbacks config conv =
       agent_results;
       elapsed;
       timestamp = Unix.gettimeofday ();
+      trace_refs = collect_trace_refs agent_results;
     } in
     (* Update state under mutex *)
     with_state handle (fun state ->

--- a/lib_swarm/swarm_types.ml
+++ b/lib_swarm/swarm_types.ml
@@ -43,20 +43,36 @@ type convergence_config = {
   aggregate: aggregate_strategy;
 }
 
+(* ── Agent Telemetry ────────────────────────────────────────────── *)
+
+(** Per-agent telemetry collected after each run.
+    Exposed to swarm consumers (e.g. MASC) so they don't need to
+    re-query Layer 1 internals. *)
+type agent_telemetry = {
+  trace_ref: Raw_trace.run_ref option;
+}
+[@@deriving show]
+
+let empty_telemetry = { trace_ref = None }
+
 (* ── Swarm Configuration ────────────────────────────────────────── *)
 
 type agent_entry = {
   name: string;
   run: sw:Eio.Switch.t -> string -> (Types.api_response, Error.sdk_error) result;
   role: agent_role;
+  get_telemetry: (unit -> agent_telemetry) option;
 }
 
 
-(** Wrap an [Agent.t] into an [agent_entry]. Clock is captured via closure. *)
+(** Wrap an [Agent.t] into an [agent_entry]. Clock is captured via closure.
+    Automatically wires [get_telemetry] to extract [Agent.last_raw_trace_run]. *)
 let make_entry ~name ~role ~(clock : _ Eio.Time.clock) (agent : Agent.t) =
   { name;
     run = (fun ~sw prompt -> Agent.run ~sw ~clock agent prompt);
-    role }
+    role;
+    get_telemetry = Some (fun () ->
+      { trace_ref = Agent.last_raw_trace_run agent }) }
 
 type resource_budget = {
   max_total_tokens: int option;
@@ -85,8 +101,10 @@ type swarm_config = {
 type agent_status =
   | Idle
   | Working
-  | Done_ok of { elapsed: float; text: string }
-  | Done_error of { elapsed: float; error: string }
+  | Done_ok of { elapsed: float; text: string;
+                 telemetry: agent_telemetry }
+  | Done_error of { elapsed: float; error: string;
+                    telemetry: agent_telemetry }
 [@@deriving show]
 
 type iteration_record = {
@@ -95,6 +113,8 @@ type iteration_record = {
   agent_results: (string * agent_status) list;
   elapsed: float;
   timestamp: float;
+  (* Layer 1 telemetry — aggregated from agent runs *)
+  trace_refs: Raw_trace.run_ref list;
 }
 
 type swarm_state = {

--- a/lib_swarm/swarm_types.mli
+++ b/lib_swarm/swarm_types.mli
@@ -42,14 +42,28 @@ type convergence_config = {
   aggregate: aggregate_strategy;
 }
 
+(** {1 Agent Telemetry} *)
+
+(** Per-agent telemetry collected after each run.
+    Exposed to swarm consumers so they don't need to
+    re-query Layer 1 internals. *)
+type agent_telemetry = {
+  trace_ref: Raw_trace.run_ref option;
+}
+[@@deriving show]
+
+val empty_telemetry : agent_telemetry
+
 (** {1 Swarm Configuration} *)
 
 (** Closure-based agent entry. [run] captures the agent and clock
-    so that the swarm runner only needs [sw] and [prompt]. *)
+    so that the swarm runner only needs [sw] and [prompt].
+    [get_telemetry] optionally extracts Layer 1 telemetry after each run. *)
 type agent_entry = {
   name: string;
   run: sw:Eio.Switch.t -> string -> (Types.api_response, Error.sdk_error) result;
   role: agent_role;
+  get_telemetry: (unit -> agent_telemetry) option;
 }
 
 (** Wrap an {!Agent.t} into an {!agent_entry}.
@@ -84,8 +98,10 @@ type swarm_config = {
 type agent_status =
   | Idle
   | Working
-  | Done_ok of { elapsed: float; text: string }
-  | Done_error of { elapsed: float; error: string }
+  | Done_ok of { elapsed: float; text: string;
+                 telemetry: agent_telemetry }
+  | Done_error of { elapsed: float; error: string;
+                    telemetry: agent_telemetry }
 [@@deriving show]
 
 type iteration_record = {
@@ -94,6 +110,7 @@ type iteration_record = {
   agent_results: (string * agent_status) list;
   elapsed: float;
   timestamp: float;
+  trace_refs: Raw_trace.run_ref list;
 }
 
 type swarm_state = {

--- a/lib_swarm/test_helpers.ml
+++ b/lib_swarm/test_helpers.ml
@@ -24,6 +24,7 @@ let mock_entry ~name ?(role = Swarm_types.Execute) text : Swarm_types.agent_entr
   { name;
     run = (fun ~sw:_ _prompt -> text_response text);
     role;
+    get_telemetry = None;
   }
 
 (** Create a mock agent_entry that fails with the given message. *)
@@ -31,6 +32,7 @@ let failing_entry ~name ?(role = Swarm_types.Execute) msg : Swarm_types.agent_en
   { name;
     run = (fun ~sw:_ _prompt -> Error (Error.Internal msg));
     role;
+    get_telemetry = None;
   }
 
 (** Create a mock agent_entry with a counter (tracks call count). *)
@@ -41,6 +43,7 @@ let counting_entry ~name ?(role = Swarm_types.Execute) text
     name;
     run = (fun ~sw:_ _prompt -> incr count; text_response text);
     role;
+    get_telemetry = None;
   } in
   (entry, fun () -> !count)
 

--- a/test/test_review_agent.ml
+++ b/test/test_review_agent.ml
@@ -23,7 +23,7 @@ let test_review_mock_flow () =
       Ok { Types.id = "m2"; model = "mock"; stop_reason = EndTurn;
            content = [Text "Review complete."]; usage = None }
   in
-  let entry = { Swarm_types.name = "reviewer"; run = mock_run; role = Execute } in
+  let entry = { Swarm_types.name = "reviewer"; run = mock_run; role = Execute; get_telemetry = None } in
   let config = Test_helpers.basic_config ~prompt:"Review PR #1 in test/repo" [entry] in
   let state = Swarm_types.create_state config in
   check int "initial iteration" 0 state.current_iteration;

--- a/test/test_swarm.ml
+++ b/test/test_swarm.ml
@@ -70,8 +70,8 @@ let test_agent_status_show () =
   let statuses = [
     Swarm_types.Idle;
     Swarm_types.Working;
-    Swarm_types.Done_ok { elapsed = 1.5; text = "hello" };
-    Swarm_types.Done_error { elapsed = 0.3; error = "timeout" };
+    Swarm_types.Done_ok { elapsed = 1.5; text = "hello"; telemetry = Swarm_types.empty_telemetry };
+    Swarm_types.Done_error { elapsed = 0.3; error = "timeout"; telemetry = Swarm_types.empty_telemetry };
   ] in
   List.iter (fun s -> ignore (Swarm_types.show_agent_status s)) statuses
 
@@ -232,7 +232,7 @@ let test_convergence_reaches_target () =
   in
   let config : Swarm_types.swarm_config = {
     entries = [
-      { name = "worker-1"; run = mock_run "result-1"; role = Execute };
+      { name = "worker-1"; run = mock_run "result-1"; role = Execute; get_telemetry = None };
     ];
     mode = Decentralized;
     convergence = Some {
@@ -263,7 +263,7 @@ let test_convergence_patience_exhausted () =
   let metric_fn () = 0.3 in  (* Never improves *)
   let config : Swarm_types.swarm_config = {
     entries = [
-      { name = "stuck"; run = mock_run "stuck"; role = Execute };
+      { name = "stuck"; run = mock_run "stuck"; role = Execute; get_telemetry = None };
     ];
     mode = Decentralized;
     convergence = Some {
@@ -293,7 +293,7 @@ let test_convergence_max_iterations () =
   let metric_fn () = incr counter; float_of_int !counter *. 0.1 in
   let config : Swarm_types.swarm_config = {
     entries = [
-      { name = "w"; run = mock_run "x"; role = Execute };
+      { name = "w"; run = mock_run "x"; role = Execute; get_telemetry = None };
     ];
     mode = Decentralized;
     convergence = Some {
@@ -320,8 +320,8 @@ let test_single_pass_no_convergence () =
   let clock = Eio.Stdenv.clock env in
   let config : Swarm_types.swarm_config = {
     entries = [
-      { name = "a1"; run = mock_run "hello"; role = Discover };
-      { name = "a2"; run = mock_run "world"; role = Verify };
+      { name = "a1"; run = mock_run "hello"; role = Discover; get_telemetry = None };
+      { name = "a2"; run = mock_run "world"; role = Verify; get_telemetry = None };
     ];
     mode = Decentralized;
     convergence = None;
@@ -356,7 +356,7 @@ let test_callbacks_fire () =
   } in
   let config : Swarm_types.swarm_config = {
     entries = [
-      { name = "cb-agent"; run = mock_run "ok"; role = Execute };
+      { name = "cb-agent"; run = mock_run "ok"; role = Execute; get_telemetry = None };
     ];
     mode = Decentralized;
     convergence = Some {
@@ -420,7 +420,7 @@ let test_12_worker_decentralized () =
     { Swarm_types.name;
       run = mock_run_with_latency ~clock ~latency_ms:latency
               (Printf.sprintf "output-%s" name);
-      role }
+      role; get_telemetry = None }
   in
   let config : Swarm_types.swarm_config = {
     entries = [
@@ -475,7 +475,7 @@ let test_12_worker_convergence () =
     let name = Printf.sprintf "w%d" i in
     { Swarm_types.name;
       run = mock_run_with_latency ~clock ~latency_ms:5 (Printf.sprintf "r%d" i);
-      role }
+      role; get_telemetry = None }
   in
   let config : Swarm_types.swarm_config = {
     entries = List.init 12 (fun i ->
@@ -524,11 +524,11 @@ let test_12_worker_supervisor () =
     { Swarm_types.name = Printf.sprintf "worker-%d" i;
       run = mock_run_with_latency ~clock ~latency_ms:5
               (Printf.sprintf "worker-%d output" i);
-      role = Execute }
+      role = Execute; get_telemetry = None }
   in
   let config : Swarm_types.swarm_config = {
     entries =
-      { name = "supervisor"; run = supervisor_run; role = Summarize }
+      { name = "supervisor"; run = supervisor_run; role = Summarize; get_telemetry = None }
       :: List.init 11 (fun i -> make_worker (i + 1));
     mode = Supervisor;
     convergence = None;
@@ -561,7 +561,7 @@ let test_12_worker_pipeline () =
       let name = Printf.sprintf "stage-%d" i in
       { Swarm_types.name;
         run = pipeline_run name;
-        role = Execute });
+        role = Execute; get_telemetry = None });
     mode = Pipeline_mode;
     convergence = None;
     max_parallel = 1;
@@ -591,11 +591,11 @@ let test_partial_failure_resilience () =
   let counter = ref 0 in
   let config : Swarm_types.swarm_config = {
     entries = [
-      { name = "ok-1"; run = mock_run "fine"; role = Execute };
+      { name = "ok-1"; run = mock_run "fine"; role = Execute; get_telemetry = None };
       { name = "fail-1";
         run = mock_run_failing ~fail_on_call:1 counter;
-        role = Execute };
-      { name = "ok-2"; run = mock_run "also-fine"; role = Execute };
+        role = Execute; get_telemetry = None };
+      { name = "ok-2"; run = mock_run "also-fine"; role = Execute; get_telemetry = None };
     ];
     mode = Decentralized;
     convergence = None;
@@ -632,7 +632,7 @@ let test_single_pass_timeout () =
          content = [Types.Text "late"]; usage = None }
   in
   let config : Swarm_types.swarm_config = {
-    entries = [{ name = "slow"; run = slow_run; role = Execute }];
+    entries = [{ name = "slow"; run = slow_run; role = Execute; get_telemetry = None }];
     mode = Decentralized;
     convergence = None;
     max_parallel = 1;
@@ -652,8 +652,8 @@ let test_single_pass_usage () =
   let clock = Eio.Stdenv.clock env in
   let config : Swarm_types.swarm_config = {
     entries = [
-      { name = "a1"; run = mock_run "hello"; role = Discover };
-      { name = "a2"; run = mock_run "world"; role = Verify };
+      { name = "a1"; run = mock_run "hello"; role = Discover; get_telemetry = None };
+      { name = "a2"; run = mock_run "world"; role = Verify; get_telemetry = None };
     ];
     mode = Decentralized;
     convergence = None;
@@ -686,7 +686,7 @@ let test_convergence_average_aggregate () =
   in
   let config : Swarm_types.swarm_config = {
     entries = [
-      { name = "w"; run = mock_run "x"; role = Execute };
+      { name = "w"; run = mock_run "x"; role = Execute; get_telemetry = None };
     ];
     mode = Decentralized;
     convergence = Some {

--- a/test/test_traced_swarm.ml
+++ b/test/test_traced_swarm.ml
@@ -37,6 +37,7 @@ let traced_mock_entry ~trace_dir ~name ~tool_names text =
       Ok { Types.id = "m"; model = "m"; stop_reason = EndTurn;
            content = [Text text]; usage = None });
     role = Execute;
+    get_telemetry = None;
   }
 
 (* ── Tests ────────────────────────────────────────────────── *)


### PR DESCRIPTION
## Summary

- `agent_telemetry` 타입 추가: `trace_ref: Raw_trace.run_ref option` — agent 실행 후 Layer 1 trace 데이터 참조
- `agent_entry`에 `get_telemetry` closure 추가 — `make_entry`에서 자동 연결
- `agent_status` Done_ok/Done_error에 `telemetry` 페이로드 포함
- `iteration_record`에 `trace_refs` 리스트 추가 — agent 결과에서 자동 집계
- `runner.ml`에 `collect_trace_refs` 헬퍼 추가

MASC가 OAS 내부 모듈을 재구현하지 않고도 trace 데이터를 소비할 수 있게 된다.

Ref: #144

## Test plan

- [x] 31개 swarm 테스트 회귀 없음
- [x] 전체 `dune runtest` 통과 (실패 0건)
- [x] test_helpers.ml, test_review_agent.ml, test_traced_swarm.ml 업데이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)