### PR TITLE
feat(structured): extractor API + run_structured

### DIFF
--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -69,6 +69,51 @@ let extract ~sw ~net ?base_url ?provider ~config ~(schema : 'a schema) prompt
      | Ok v -> Ok v
      | Error e -> Error e)
 
+(* ── Extractors ────────────────────────────────────────────────── *)
+
+(** An extractor converts an api_response into a typed value.
+    Use with {!run_structured} for Agent.t-level structured output. *)
+type 'a extractor = api_response -> ('a, string) result
+
+(** Extract a JSON value from the first text block and parse it. *)
+let json_extractor (parse : Yojson.Safe.t -> 'a) : 'a extractor =
+  fun resp ->
+    let texts =
+      List.filter_map (function Text s -> Some s | _ -> None) resp.content
+    in
+    match texts with
+    | [] -> Error "no text content in response"
+    | text :: _ ->
+      (try Ok (parse (Yojson.Safe.from_string text))
+       with
+       | Yojson.Json_error e -> Error (Printf.sprintf "JSON parse: %s" e)
+       | exn -> Error (Printexc.to_string exn))
+
+(** Extract a value from the first text block using a string parser. *)
+let text_extractor (parse : string -> 'a option) : 'a extractor =
+  fun resp ->
+    let texts =
+      List.filter_map (function Text s -> Some s | _ -> None) resp.content
+    in
+    match texts with
+    | [] -> Error "no text content in response"
+    | text :: _ ->
+      (match parse text with
+       | Some v -> Ok v
+       | None -> Error "text extractor returned None")
+
+(** Run an agent with a prompt and extract a structured value from the response.
+    Uses the full Agent pipeline (hooks, tools, tracing) unlike {!extract}
+    which calls the API directly. *)
+let run_structured ~sw ?clock agent prompt ~(extract : 'a extractor) =
+  match Agent.run ~sw ?clock agent prompt with
+  | Error e -> Error e
+  | Ok response ->
+    (match extract response with
+     | Ok v -> Ok v
+     | Error detail ->
+       Error (Error.Serialization (JsonParseError { detail })))
+
 (** Extract structured output with SSE streaming.
     Like [extract] but uses [Streaming.create_message_stream] to receive
     incremental SSE events.  Calls [on_event] for each event.

--- a/test/test_structured.ml
+++ b/test/test_structured.ml
@@ -272,6 +272,52 @@ let test_schema_mixed_required () =
   Alcotest.(check bool) "c required" true (List.mem "c" required);
   Alcotest.(check bool) "e required" true (List.mem "e" required)
 
+(* --- Extractors --- *)
+
+let make_response content : Types.api_response =
+  { id = "m"; model = "m"; stop_reason = EndTurn; content; usage = None }
+
+let test_json_extractor_success () =
+  let extract = Structured.json_extractor (fun json ->
+    Yojson.Safe.Util.(json |> member "value" |> to_int))
+  in
+  let resp = make_response [Text {|{"value": 42}|}] in
+  match extract resp with
+  | Ok v -> Alcotest.(check int) "extracted value" 42 v
+  | Error e -> Alcotest.fail e
+
+let test_json_extractor_invalid_json () =
+  let extract = Structured.json_extractor (fun _ -> 0) in
+  let resp = make_response [Text "not json"] in
+  match extract resp with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected parse error"
+
+let test_json_extractor_no_text () =
+  let extract = Structured.json_extractor (fun _ -> 0) in
+  let resp = make_response [] in
+  match extract resp with
+  | Error msg ->
+    Alcotest.(check bool) "mentions no text" true
+      (String.length msg > 0)
+  | Ok _ -> Alcotest.fail "expected error"
+
+let test_text_extractor_success () =
+  let extract = Structured.text_extractor (fun s ->
+    if String.length s > 0 then Some (String.length s) else None)
+  in
+  let resp = make_response [Text "hello world"] in
+  match extract resp with
+  | Ok v -> Alcotest.(check int) "text length" 11 v
+  | Error e -> Alcotest.fail e
+
+let test_text_extractor_none () =
+  let extract = Structured.text_extractor (fun _ -> None) in
+  let resp = make_response [Text "anything"] in
+  match extract resp with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected error"
+
 (* --- Runner --- *)
 
 let () =
@@ -296,5 +342,12 @@ let () =
       Alcotest.test_case "parse error type" `Quick test_extract_parse_error_is_serialization;
       Alcotest.test_case "missing tool type" `Quick test_extract_missing_tool_is_internal;
       Alcotest.test_case "ignores tool_result" `Quick test_extract_ignores_tool_result;
+    ];
+    "extractors", [
+      Alcotest.test_case "json_extractor success" `Quick test_json_extractor_success;
+      Alcotest.test_case "json_extractor invalid" `Quick test_json_extractor_invalid_json;
+      Alcotest.test_case "json_extractor no text" `Quick test_json_extractor_no_text;
+      Alcotest.test_case "text_extractor success" `Quick test_text_extractor_success;
+      Alcotest.test_case "text_extractor none" `Quick test_text_extractor_none;
     ];
   ]


### PR DESCRIPTION
## Summary

- `json_extractor`: JSON 파싱 기반 extractor (first text block)
- `text_extractor`: 문자열 파서 기반 extractor (first text block)
- `run_structured`: `Agent.run` + extractor를 결합한 고수준 API — 전체 파이프라인(hooks, tools, tracing) 활용

기존 `extract`는 `Api.create_message`를 직접 호출하므로 hooks/tracing이 없다. `run_structured`는 Agent.t를 통해 전체 파이프라인을 활용한다.

Ref: #144

## Test plan

- [x] 5개 새 extractor 테스트 추가 (mock api_response, LLM 불필요)
- [x] 기존 17개 structured 테스트 회귀 없음
- [x] 전체 22개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)