### PR TITLE
feat(orchestrator): consensus + hierarchical patterns

### DIFF
--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -280,3 +280,102 @@ and execute_conditional_inner ~sw ?clock orch last_result plan =
         else iterate all_acc new_last (iteration + 1)
     in
     iterate [] last_result 0
+
+(* ── Consensus orchestration ─────────────────────────────────────── *)
+
+(** Strategy for selecting a winner from multiple agent results. *)
+type selection_strategy =
+  | FirstOk
+      (** First non-error result in completion order. *)
+  | BestBy of (task_result -> float)
+      (** Highest score wins. Only considers Ok results. *)
+  | MajorityText
+      (** Most common text response wins. Ties broken by first occurrence. *)
+
+(** Select the winning result from a list using the given strategy. *)
+let select_winner strategy results =
+  match strategy with
+  | FirstOk ->
+    List.find_opt (fun tr ->
+      match tr.result with Ok _ -> true | Error _ -> false
+    ) results
+  | BestBy score_fn ->
+    let scored =
+      List.filter_map (fun tr ->
+        match tr.result with
+        | Ok _ -> Some (tr, score_fn tr)
+        | Error _ -> None
+      ) results
+    in
+    (match scored with
+     | [] -> None
+     | _ ->
+       Some (fst (List.fold_left (fun (best_tr, best_s) (tr, s) ->
+         if s > best_s then (tr, s) else (best_tr, best_s)
+       ) (List.hd scored) (List.tl scored))))
+  | MajorityText ->
+    let texts =
+      List.filter_map (fun tr ->
+        match tr.result with
+        | Ok resp -> Some (tr, text_of_response resp)
+        | Error _ -> None
+      ) results
+    in
+    let counts =
+      List.fold_left (fun acc (_tr, text) ->
+        let prev = match List.assoc_opt text acc with Some n -> n | None -> 0 in
+        (text, prev + 1) :: List.remove_assoc text acc
+      ) [] texts
+    in
+    let best_text =
+      match counts with
+      | [] -> None
+      | _ ->
+        Some (fst (List.fold_left (fun (bt, bc) (t, c) ->
+          if c > bc then (t, c) else (bt, bc)
+        ) (List.hd counts) (List.tl counts)))
+    in
+    match best_text with
+    | None -> None
+    | Some text ->
+      Some (fst (List.find (fun (_tr, t) -> t = text) texts))
+
+(** Run N agents with the same prompt and select a winner.
+    All agents run in parallel. Returns all results + the selected winner.
+
+    @param agents list of agent names to participate
+    @param strategy how to pick the winning result *)
+let execute_consensus ~sw ?clock orch ~prompt ~agents ~strategy =
+  let tasks = List.mapi (fun i agent_name ->
+    { id = Printf.sprintf "consensus-%d" i; prompt; agent_name }
+  ) agents in
+  let results = execute_parallel ~sw ?clock orch tasks in
+  let winner = select_winner strategy results in
+  (results, winner)
+
+(* ── Hierarchical orchestration ──────────────────────────────────── *)
+
+(** Run sub-orchestrators as if they were agents.
+    Each [(label, sub_orch, sub_plan)] is executed independently,
+    and the collected text from each sub-plan becomes a task_result
+    attributed to [label].
+
+    Results from all sub-orchestrators are returned in input order. *)
+let execute_hierarchical ~sw ?clock ~parent:_ sub_plans =
+  Eio.Fiber.List.map (fun (label, sub_orch, sub_plan) ->
+    let t0 = Unix.gettimeofday () in
+    let sub_results = execute ~sw ?clock sub_orch sub_plan in
+    let elapsed = Unix.gettimeofday () -. t0 in
+    let combined_text = collect_text sub_results in
+    let combined_response : api_response = {
+      id = label;
+      model = "orchestrator";
+      stop_reason = EndTurn;
+      content = [Text combined_text];
+      usage = None;
+    } in
+    { task_id = label;
+      agent_name = label;
+      result = Ok combined_response;
+      elapsed }
+  ) sub_plans

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -83,3 +83,32 @@ val execute_conditional : sw:Eio.Switch.t -> ?clock:_ Eio.Time.clock -> t -> con
 
 val collect_text : task_result list -> string
 val all_ok : task_result list -> bool
+
+(** {2 Consensus Orchestration} *)
+
+(** Strategy for selecting a winner from multiple agent results. *)
+type selection_strategy =
+  | FirstOk
+  | BestBy of (task_result -> float)
+  | MajorityText
+
+val select_winner : selection_strategy -> task_result list -> task_result option
+
+(** Run all [agents] with the same [prompt] in parallel, then select
+    a winner using [strategy]. Returns [(all_results, winner)]. *)
+val execute_consensus :
+  sw:Eio.Switch.t -> ?clock:_ Eio.Time.clock ->
+  t -> prompt:string -> agents:string list ->
+  strategy:selection_strategy ->
+  task_result list * task_result option
+
+(** {2 Hierarchical Orchestration} *)
+
+(** Run sub-orchestrators as independent units. Each
+    [(label, sub_orch, sub_plan)] is executed and its collected text
+    becomes a single task_result attributed to [label]. *)
+val execute_hierarchical :
+  sw:Eio.Switch.t -> ?clock:_ Eio.Time.clock ->
+  parent:t ->
+  (string * t * plan) list ->
+  task_result list

--- a/test/test_orchestrator.ml
+++ b/test/test_orchestrator.ml
@@ -649,6 +649,74 @@ let test_execute_conditional_loop_stops_on_condition () =
   let results = Orchestrator.execute_conditional ~sw orch plan in
   check int "1 iteration (until=Always)" 1 (List.length results)
 
+(* ── Consensus ─────────────────────────────────────────────────────── *)
+
+let test_consensus_first_ok () =
+  let results = [
+    err_result ~task_id:"c0" ~agent_name:"a0" (Error.Internal "fail");
+    ok_result ~task_id:"c1" ~agent_name:"a1" "winner";
+    ok_result ~task_id:"c2" ~agent_name:"a2" "also ok";
+  ] in
+  match Orchestrator.select_winner FirstOk results with
+  | Some tr -> check string "first ok agent" "a1" tr.agent_name
+  | None -> fail "expected a winner"
+
+let test_consensus_majority_text () =
+  let results = [
+    ok_result ~task_id:"c0" ~agent_name:"a0" "yes";
+    ok_result ~task_id:"c1" ~agent_name:"a1" "no";
+    ok_result ~task_id:"c2" ~agent_name:"a2" "yes";
+  ] in
+  match Orchestrator.select_winner MajorityText results with
+  | Some tr ->
+    (* "yes" appears twice, "no" once *)
+    let text = Orchestrator.collect_text [tr] in
+    check string "majority text" "yes" text
+  | None -> fail "expected a winner"
+
+let test_consensus_best_by () =
+  let score_fn tr = tr.Orchestrator.elapsed in
+  let results = [
+    { (ok_result ~task_id:"c0" ~agent_name:"slow" "x") with elapsed = 1.0 };
+    { (ok_result ~task_id:"c1" ~agent_name:"fast" "y") with elapsed = 5.0 };
+    { (ok_result ~task_id:"c2" ~agent_name:"mid" "z") with elapsed = 3.0 };
+  ] in
+  match Orchestrator.select_winner (BestBy score_fn) results with
+  | Some tr -> check string "highest score" "fast" tr.agent_name
+  | None -> fail "expected a winner"
+
+let test_consensus_all_error () =
+  let results = [
+    err_result ~task_id:"c0" ~agent_name:"a0" (Error.Internal "e1");
+    err_result ~task_id:"c1" ~agent_name:"a1" (Error.Internal "e2");
+  ] in
+  match Orchestrator.select_winner FirstOk results with
+  | None -> ()
+  | Some _ -> fail "expected no winner"
+
+(* ── Hierarchical ──────────────────────────────────────────────── *)
+
+let test_hierarchical_basic () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  (* Two sub-orchestrators, each with no agents (returns UnknownAgent errors).
+     Hierarchical wraps each sub-orch result into a single task_result. *)
+  let sub1 = Orchestrator.create [] in
+  let sub2 = Orchestrator.create [] in
+  let plan1 = Orchestrator.Sequential [
+    { Orchestrator.id = "s1"; prompt = "p"; agent_name = "ghost" }
+  ] in
+  let plan2 = Orchestrator.Sequential [
+    { id = "s2"; prompt = "q"; agent_name = "ghost" }
+  ] in
+  let parent = Orchestrator.create [] in
+  let results = Orchestrator.execute_hierarchical ~sw ~parent
+    [("sub-a", sub1, plan1); ("sub-b", sub2, plan2)] in
+  check int "2 hierarchical results" 2 (List.length results);
+  List.iter (fun tr ->
+    check bool "has result" true (Result.is_ok tr.Orchestrator.result)
+  ) results
+
 (* ── Suite ────────────────────────────────────────────────────────── *)
 
 let () =
@@ -760,5 +828,14 @@ let () =
       test_case "cond_parallel" `Quick test_execute_conditional_cond_parallel;
       test_case "loop max_iterations" `Quick test_execute_conditional_loop_max_iterations;
       test_case "loop stops on condition" `Quick test_execute_conditional_loop_stops_on_condition;
+    ];
+    "consensus", [
+      test_case "first_ok" `Quick test_consensus_first_ok;
+      test_case "majority_text" `Quick test_consensus_majority_text;
+      test_case "best_by" `Quick test_consensus_best_by;
+      test_case "all_error" `Quick test_consensus_all_error;
+    ];
+    "hierarchical", [
+      test_case "sub_orchestrators" `Quick test_hierarchical_basic;
     ];
   ]


### PR DESCRIPTION
## Summary
- **Consensus**: N agents 동일 prompt 병렬 실행 → 전략 기반 winner 선택 (FirstOk/BestBy/MajorityText)
- **Hierarchical**: sub-orchestrator를 독립 실행 단위로 취급, 결과를 단일 task_result로 수집

Ref: #144

## Test plan
- [x] 5개 새 테스트 (4 consensus + 1 hierarchical)
- [x] 기존 orchestrator 테스트 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)