### PR TITLE
feat: Agent_typed — phantom-type lifecycle (experimental)

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -112,6 +112,7 @@ module Provider_bridge = Provider_bridge
 module Async_agent = Async_agent
 module Append_instruction = Append_instruction
 module Consumer = Consumer
+module Agent_typed = Agent_typed
 
 (** Quick start: create an agent with default config *)
 let create_agent ~net ?name ?model ?system_prompt ?max_tokens ?max_turns

--- a/lib/agent_typed.ml
+++ b/lib/agent_typed.ml
@@ -1,0 +1,29 @@
+(** Agent_typed — phantom-type lifecycle state machine.
+
+    @since 0.55.0 *)
+
+(* Phantom state tags *)
+type created
+type completed
+
+(* The phantom type parameter is unused at runtime —
+   the underlying representation is always Agent.t.
+   OCaml's type system enforces state transitions at compile time. *)
+type _ t = T : Agent.t -> _ t
+
+let create ~net ?config ?tools ?context ?options () =
+  T (Agent.create ~net ?config ?tools ?context ?options ())
+
+let run ~sw ?clock (T agent) prompt =
+  match Agent.run ~sw ?clock agent prompt with
+  | Ok response -> Ok (response, T agent)
+  | Error e -> Error e
+
+let close (T agent) =
+  Agent.close agent
+
+let inner (T agent) = agent
+
+let card (T agent) = Agent.card agent
+
+let last_trace (T agent) = Agent.last_raw_trace_run agent

--- a/lib/agent_typed.mli
+++ b/lib/agent_typed.mli
@@ -1,0 +1,62 @@
+(** Agent_typed — phantom-type lifecycle state machine.
+
+    Wraps {!Agent.t} with phantom type parameters that encode lifecycle
+    state at the type level. Prevents calling [run] on a completed agent
+    or [close] before completion at compile time.
+
+    This is an {b experimental} opt-in module. Existing [Agent.t] API
+    is unaffected.
+
+    Usage:
+    {[
+      let agent = Agent_typed.create ~net () in
+      let completed = Agent_typed.run ~sw agent "hello" in
+      Agent_typed.close completed
+      (* Agent_typed.run ~sw completed "again"  -- TYPE ERROR *)
+    ]}
+
+    @since 0.55.0 *)
+
+(** Phantom state tags. Not constructible — used only as type parameters. *)
+type created
+type completed
+
+(** Agent with phantom lifecycle state. *)
+type _ t
+
+(** {1 Construction} *)
+
+(** Create a new agent in the [created] state. *)
+val create :
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?config:Types.agent_config ->
+  ?tools:Tool.t list ->
+  ?context:Context.t ->
+  ?options:Agent.options ->
+  unit -> created t
+
+(** {1 Execution} *)
+
+(** Run the agent. Transitions [created -> completed].
+    Returns the response and the agent in [completed] state. *)
+val run :
+  sw:Eio.Switch.t ->
+  ?clock:_ Eio.Time.clock ->
+  created t -> string ->
+  (Types.api_response * completed t, Error.sdk_error) result
+
+(** {1 Cleanup} *)
+
+(** Close a completed agent, releasing resources. *)
+val close : completed t -> unit
+
+(** {1 Accessors (any state)} *)
+
+(** Access the underlying {!Agent.t}. Escape hatch for interop. *)
+val inner : _ t -> Agent.t
+
+(** Get the agent card. *)
+val card : _ t -> Agent_card.agent_card
+
+(** Get the last raw trace run reference. *)
+val last_trace : _ t -> Raw_trace.run_ref option

--- a/test/dune
+++ b/test/dune
@@ -388,3 +388,7 @@
 (test
  (name test_a2a_client)
  (libraries agent_sdk alcotest yojson unix))
+
+(test
+ (name test_agent_typed)
+ (libraries agent_sdk alcotest yojson eio eio_main))

--- a/test/test_agent_typed.ml
+++ b/test/test_agent_typed.ml
@@ -1,0 +1,57 @@
+(** Tests for Agent_typed — phantom-type lifecycle state machine.
+
+    Verifies that the typed wrapper correctly delegates to Agent.t
+    and that state transitions produce the expected types. *)
+
+open Agent_sdk
+open Alcotest
+
+let test_create () =
+  Eio_main.run @@ fun env ->
+  let agent = Agent_typed.create ~net:env#net () in
+  let card = Agent_typed.card agent in
+  check bool "has name" true (String.length card.name > 0)
+
+let test_inner () =
+  Eio_main.run @@ fun env ->
+  let typed = Agent_typed.create ~net:env#net
+    ~config:{ Types.default_config with name = "typed-test" } () in
+  let inner = Agent_typed.inner typed in
+  let card = Agent.card inner in
+  check string "inner name" "typed-test" card.name
+
+let test_last_trace_none () =
+  Eio_main.run @@ fun env ->
+  let agent = Agent_typed.create ~net:env#net () in
+  check bool "no trace" true (Option.is_none (Agent_typed.last_trace agent))
+
+(** Compile-time type safety test:
+    The following would NOT compile, proving phantom types work:
+
+    {[
+      let agent = Agent_typed.create ~net () in
+      match Agent_typed.run ~sw agent "hi" with
+      | Ok (_resp, completed) ->
+        (* This would be a TYPE ERROR: *)
+        let _ = Agent_typed.run ~sw completed "again" in
+        ()
+    ]}
+
+    We can't write a runtime test for "does not compile",
+    so this test just documents the intended constraint. *)
+let test_phantom_type_documented () =
+  (* This test exists to verify the module compiles correctly.
+     The phantom type safety is structural — enforced by the .mli. *)
+  check bool "module loads" true true
+
+(* ── Suite ────────────────────────────────────────────────────── *)
+
+let () =
+  run "agent_typed" [
+    "lifecycle", [
+      test_case "create" `Quick test_create;
+      test_case "inner" `Quick test_inner;
+      test_case "last_trace_none" `Quick test_last_trace_none;
+      test_case "phantom_documented" `Quick test_phantom_type_documented;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- `Agent_typed` 모듈: phantom type으로 agent lifecycle 상태를 컴파일 타임에 강제
- `created t` → `run` 가능, `completed t` → `close`만 가능 (run은 타입 에러)
- GADT (`T : Agent.t -> _ t`)로 런타임 오버헤드 0
- `inner` escape hatch로 기존 Agent.t API와 호환
- Experimental opt-in — 기존 API 영향 없음

Ref: #144

## Test plan
- [x] 4개 테스트 (create, inner, last_trace, phantom documented)
- [x] `dune build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)