### PR TITLE
fix: self-review findings — 4 modules hardened

### DIFF
--- a/lib/append_instruction.ml
+++ b/lib/append_instruction.ml
@@ -34,7 +34,10 @@ let render_source ?context ~turn = function
        Fun.protect
          ~finally:(fun () -> close_in_noerr ic)
          (fun () -> Some (really_input_string ic (in_channel_length ic)))
-     with _ -> None)
+     with exn ->
+       let _ = Printf.eprintf "[append_instruction] FromFile %s failed: %s\n%!"
+         path (Printexc.to_string exn) in
+       None)
   | Dynamic f -> f turn
 
 (* ── Public API ──────────────────────────────────────────────────── *)

--- a/lib/async_agent.ml
+++ b/lib/async_agent.ml
@@ -30,8 +30,9 @@ let spawn ~sw ?clock agent prompt =
   Eio.Fiber.fork ~sw (fun () ->
     let result =
       try Agent.run ~sw ?clock agent prompt
-      with exn ->
-        Error (Error.Internal (Printexc.to_string exn))
+      with
+      | Raw_trace.Trace_error e -> Error e
+      | exn -> Error (Error.Internal (Printexc.to_string exn))
     in
     resolve_once future result);
   future

--- a/lib/async_agent.mli
+++ b/lib/async_agent.mli
@@ -40,8 +40,12 @@ val is_ready : 'a future -> bool
 (** {1 Cancellation} *)
 
 (** [cancel future] resolves the future with [Error (Internal "cancelled")]
-    if it has not already been resolved. The underlying fiber may continue
-    running until it finishes naturally (cooperative cancellation). *)
+    if it has not already been resolved.
+
+    {b Limitation}: The underlying Eio fiber continues running until
+    natural completion. [cancel] only short-circuits [await] — it does
+    not stop the agent's network calls or computation. The fiber will
+    be cleaned up when the parent switch is cancelled. *)
 val cancel : 'a future -> unit
 
 (** {1 Combinators} *)

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -361,7 +361,7 @@ let execute_consensus ~sw ?clock orch ~prompt ~agents ~strategy =
     attributed to [label].
 
     Results from all sub-orchestrators are returned in input order. *)
-let execute_hierarchical ~sw ?clock ~parent:_ sub_plans =
+let execute_hierarchical ~sw ?clock sub_plans =
   Eio.Fiber.List.map (fun (label, sub_orch, sub_plan) ->
     let t0 = Unix.gettimeofday () in
     let sub_results = execute ~sw ?clock sub_orch sub_plan in

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -109,6 +109,5 @@ val execute_consensus :
     becomes a single task_result attributed to [label]. *)
 val execute_hierarchical :
   sw:Eio.Switch.t -> ?clock:_ Eio.Time.clock ->
-  parent:t ->
   (string * t * plan) list ->
   task_result list

--- a/lib/protocol/a2a_client.ml
+++ b/lib/protocol/a2a_client.ml
@@ -60,7 +60,11 @@ let rpc_call ~sw ~net endpoint method_ params =
        | `Null ->
          Ok (json |> member "result")
        | err ->
-         let msg = err |> member "message" |> to_string in
+         let msg =
+           match err |> member "message" |> to_string_option with
+           | Some s -> s
+           | None -> Yojson.Safe.to_string err
+         in
          Error (Error.A2a (ProtocolError { detail = msg }))
      with
      | Yojson.Json_error e ->

--- a/test/test_orchestrator.ml
+++ b/test/test_orchestrator.ml
@@ -709,8 +709,7 @@ let test_hierarchical_basic () =
   let plan2 = Orchestrator.Sequential [
     { id = "s2"; prompt = "q"; agent_name = "ghost" }
   ] in
-  let parent = Orchestrator.create [] in
-  let results = Orchestrator.execute_hierarchical ~sw ~parent
+  let results = Orchestrator.execute_hierarchical ~sw
     [("sub-a", sub1, plan1); ("sub-b", sub2, plan2)] in
   check int "2 hierarchical results" 2 (List.length results);
   List.iter (fun tr ->


### PR DESCRIPTION
## Summary
셀프 리뷰에서 발견한 4개 수정:
- `a2a_client`: JSON-RPC 에러 `message` 필드 누락 시 Type_error 방지
- `append_instruction`: `FromFile` 실패를 stderr로 로깅 (silent failure 제거)
- `orchestrator`: `execute_hierarchical`의 미사용 `~parent` 파라미터 제거
- `async_agent`: `Trace_error` 구조화 에러 보존 + `cancel` 한계 명시

## Test plan
- [x] 전체 `dune runtest` 실패 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)