### PR TITLE
fix: race semantics (first-to-finish) + hierarchical fiber limit

### DIFF
--- a/lib/async_agent.ml
+++ b/lib/async_agent.ml
@@ -52,11 +52,6 @@ let cancel future =
 
 (* ── Combinators ──────────────────────────────────────────────────── *)
 
-(** Internal exception for propagating sdk_error across fiber boundaries.
-    Used only within [race] to convert Result errors into exceptions
-    that Eio.Fiber.first can propagate. *)
-exception Race_error of Error.sdk_error
-
 let race ~sw ?clock agents =
   match agents with
   | [] ->
@@ -67,16 +62,20 @@ let race ~sw ?clock agents =
      | Ok resp -> Ok (name, resp)
      | Error e -> Error e)
   | _ ->
-    (* Build (unit -> 'a) closures for each agent.
-       Eio.Fiber.first cancels the loser; recursive nesting
-       cancels all remaining when one finishes. *)
+    (* Each closure returns (name, result) — both Ok and Error are
+       normal completions. Eio.Fiber.first returns the first fiber to
+       finish and cancels the rest. No exception-based signaling. *)
     let fns =
       List.map (fun (agent, prompt) ->
         fun () ->
           let name = agent_name agent in
-          match Agent.run ~sw ?clock agent prompt with
-          | Ok resp -> (name, resp)
-          | Error e -> raise (Race_error e))
+          let result =
+            try Agent.run ~sw ?clock agent prompt
+            with
+            | Raw_trace.Trace_error e -> Error e
+            | exn -> Error (Error.Internal (Printexc.to_string exn))
+          in
+          (name, result))
         agents
     in
     let rec any_of = function
@@ -84,8 +83,8 @@ let race ~sw ?clock agents =
       | [f] -> f ()
       | f :: rest -> Eio.Fiber.first f (fun () -> any_of rest)
     in
-    (try Ok (any_of fns)
-     with Race_error e -> Error e)
+    let (name, result) = any_of fns in
+    Result.map (fun resp -> (name, resp)) result
 
 let all ~sw ?clock ?max_fibers agents =
   let run_one (agent, prompt) =

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -361,8 +361,8 @@ let execute_consensus ~sw ?clock orch ~prompt ~agents ~strategy =
     attributed to [label].
 
     Results from all sub-orchestrators are returned in input order. *)
-let execute_hierarchical ~sw ?clock sub_plans =
-  Eio.Fiber.List.map (fun (label, sub_orch, sub_plan) ->
+let execute_hierarchical ~sw ?clock ?(max_parallel = 4) sub_plans =
+  Eio.Fiber.List.map ~max_fibers:max_parallel (fun (label, sub_orch, sub_plan) ->
     let t0 = Unix.gettimeofday () in
     let sub_results = execute ~sw ?clock sub_orch sub_plan in
     let elapsed = Unix.gettimeofday () -. t0 in

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -109,5 +109,6 @@ val execute_consensus :
     becomes a single task_result attributed to [label]. *)
 val execute_hierarchical :
   sw:Eio.Switch.t -> ?clock:_ Eio.Time.clock ->
+  ?max_parallel:int ->
   (string * t * plan) list ->
   task_result list


### PR DESCRIPTION
## Summary
1. **race 의미론 수정**: Error를 exception으로 변환하던 패턴 제거. Agent A가 Error를 빠르게 반환하고 Agent B가 느리게 Ok를 반환하면, 이전에는 B가 이겼으나 이제 A가 이긴다 (first-to-finish). `Race_error` exception 타입도 제거.

2. **execute_hierarchical fiber 제한**: `~max_parallel` 파라미터 추가 (기본 4). 이전에는 모든 sub-orchestrator가 무제한 동시 실행되어 fiber 폭발 가능성이 있었다.

## Test plan
- [x] async_agent 8개 테스트 통과
- [x] orchestrator 73개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)