### PR TITLE
fix(async_agent): cancel terminates fiber via sub-switch

### DIFF
--- a/lib/async_agent.ml
+++ b/lib/async_agent.ml
@@ -2,12 +2,17 @@
 
     @since 0.55.0 *)
 
-(* ── Future type ──────────────────────────────────────────────────── *)
+(* ── Internal cancellation exception ──────────────────────────── *)
+
+exception Cancelled
+
+(* ── Future type ──────────────────────────────────────────────── *)
 
 type 'a future = {
   promise: ('a, Error.sdk_error) result Eio.Promise.t;
   resolver: ('a, Error.sdk_error) result Eio.Promise.u;
   resolved: bool Atomic.t;
+  mutable cancel_fn: (unit -> unit) option;
 }
 
 (** Resolve the future exactly once. Subsequent calls are no-ops. *)
@@ -15,29 +20,37 @@ let resolve_once future result =
   if not (Atomic.exchange future.resolved true) then
     Eio.Promise.resolve future.resolver result
 
-(* ── Agent name extraction ────────────────────────────────────────── *)
+(* ── Agent name extraction ────────────────────────────────────── *)
 
 let agent_name agent =
   let card = Agent.card agent in
   card.Agent_card.name
 
-(* ── Spawning ─────────────────────────────────────────────────────── *)
+(* ── Spawning ─────────────────────────────────────────────────── *)
 
 let spawn ~sw ?clock agent prompt =
   let promise, resolver = Eio.Promise.create () in
   let resolved = Atomic.make false in
-  let future = { promise; resolver; resolved } in
+  let future = { promise; resolver; resolved; cancel_fn = None } in
   Eio.Fiber.fork ~sw (fun () ->
+    (* Run agent inside a sub-switch so cancel can terminate the fiber.
+       Eio.Switch.run creates an independent error domain — failing it
+       cancels all I/O (HTTP, DNS, etc.) within Agent.run. *)
     let result =
-      try Agent.run ~sw ?clock agent prompt
+      try
+        Eio.Switch.run (fun sub_sw ->
+          future.cancel_fn <- Some (fun () ->
+            Eio.Switch.fail sub_sw Cancelled);
+          Agent.run ~sw:sub_sw ?clock agent prompt)
       with
+      | Cancelled -> Error (Error.Internal "cancelled")
       | Raw_trace.Trace_error e -> Error e
       | exn -> Error (Error.Internal (Printexc.to_string exn))
     in
     resolve_once future result);
   future
 
-(* ── Awaiting ─────────────────────────────────────────────────────── *)
+(* ── Awaiting ─────────────────────────────────────────────────── *)
 
 let await future =
   Eio.Promise.await future.promise
@@ -45,12 +58,15 @@ let await future =
 let is_ready future =
   Option.is_some (Eio.Promise.peek future.promise)
 
-(* ── Cancellation ─────────────────────────────────────────────────── *)
+(* ── Cancellation ─────────────────────────────────────────────── *)
 
 let cancel future =
-  resolve_once future (Error (Error.Internal "cancelled"))
+  resolve_once future (Error (Error.Internal "cancelled"));
+  match future.cancel_fn with
+  | Some f -> (try f () with _ -> ())
+  | None -> ()
 
-(* ── Combinators ──────────────────────────────────────────────────── *)
+(* ── Combinators ──────────────────────────────────────────────── *)
 
 let race ~sw ?clock agents =
   match agents with
@@ -64,7 +80,7 @@ let race ~sw ?clock agents =
   | _ ->
     (* Each closure returns (name, result) — both Ok and Error are
        normal completions. Eio.Fiber.first returns the first fiber to
-       finish and cancels the rest. No exception-based signaling. *)
+       finish and cancels the rest via structured concurrency. *)
     let fns =
       List.map (fun (agent, prompt) ->
         fun () ->

--- a/lib/async_agent.mli
+++ b/lib/async_agent.mli
@@ -39,13 +39,11 @@ val is_ready : 'a future -> bool
 
 (** {1 Cancellation} *)
 
-(** [cancel future] resolves the future with [Error (Internal "cancelled")]
-    if it has not already been resolved.
+(** [cancel future] terminates the agent's execution by:
+    1. Resolving the promise with [Error (Internal "cancelled")]
+    2. Failing the agent's sub-switch, cancelling all in-flight I/O
 
-    {b Limitation}: The underlying Eio fiber continues running until
-    natural completion. [cancel] only short-circuits [await] — it does
-    not stop the agent's network calls or computation. The fiber will
-    be cleaned up when the parent switch is cancelled. *)
+    If the agent has already completed, this is a no-op. *)
 val cancel : 'a future -> unit
 
 (** {1 Combinators} *)


### PR DESCRIPTION
Closes #175. cancel이 실제로 fiber를 종료한다.

**이전**: cancel은 promise만 resolve하고 fiber는 계속 실행 → HTTP 연결 + CPU 낭비
**이후**: spawn이 Agent.run을 전용 sub-switch 안에서 실행. cancel이 sub-switch를 fail시켜 모든 I/O를 즉시 취소.

8개 테스트 통과 (cancel 테스트가 5초 서버를 기다리지 않고 즉시 완료됨).

🤖 Generated with [Claude Code](https://claude.com/claude-code)