### PR TITLE
refactor: vendor-neutral capability naming

### DIFF
--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -46,7 +46,7 @@ type t = {
 
 let create ~net ~model =
   {
-    net; model;
+    net; model = Model_registry.resolve_model_id model;
     name = default_config.name;
     system_prompt = default_config.system_prompt;
     max_tokens = default_config.max_tokens;

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -44,7 +44,7 @@ let openai_chat_capabilities = {
   supports_multimodal_inputs = true;
 }
 
-let qwen_openai_chat_capabilities = {
+let openai_chat_extended_capabilities = {
   openai_chat_capabilities with
   supports_reasoning = true;
   supports_top_k = true;

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -14,4 +14,4 @@ type capabilities = {
 val default_capabilities : capabilities
 val anthropic_capabilities : capabilities
 val openai_chat_capabilities : capabilities
-val qwen_openai_chat_capabilities : capabilities
+val openai_chat_extended_capabilities : capabilities

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -135,11 +135,11 @@ let string_contains_ci ~haystack ~needle =
     !found
 
 let infer_capabilities models =
-  let has_qwen =
+  let needs_extended =
     List.exists (fun (m : model_info) ->
       string_contains_ci ~haystack:m.id ~needle:"qwen") models
   in
-  if has_qwen then Capabilities.qwen_openai_chat_capabilities
+  if needs_extended then Capabilities.openai_chat_extended_capabilities
   else Capabilities.openai_chat_capabilities
 
 (* ── Probe ───────────────────────────────────────────────── *)

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -71,7 +71,7 @@ let openai_chat_capabilities = {
   supports_native_streaming = true;
 }
 
-let qwen_openai_chat_capabilities = {
+let openai_chat_extended_capabilities = {
   openai_chat_capabilities with
   supports_reasoning = true;
   supports_top_k = true;
@@ -80,7 +80,9 @@ let qwen_openai_chat_capabilities = {
 
 let string_contains = Util.string_contains
 
-let is_qwen_family model_id =
+(** Check if a model needs extended OpenAI capabilities
+    (reasoning, top_k, min_p). Currently triggers on qwen family models. *)
+let needs_extended_capabilities model_id =
   let normalized = String.lowercase_ascii (String.trim model_id) in
   string_contains ~needle:"qwen" normalized
 
@@ -119,7 +121,7 @@ let capabilities_for_model ~(provider : provider) ~(model_id : string) =
   match provider with
   | Anthropic | Local _ -> anthropic_capabilities
   | OpenAICompat _ ->
-      if is_qwen_family model_id then qwen_openai_chat_capabilities
+      if needs_extended_capabilities model_id then openai_chat_extended_capabilities
       else openai_chat_capabilities
   | Custom_registered { name } ->
       (match find_provider name with

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -37,7 +37,7 @@ let check_model msg expected actual =
 let test_create_sets_model () =
   with_net @@ fun net ->
   let agent = Builder.create ~net ~model:"claude-haiku-4-5" |> Builder.build_safe |> Result.get_ok in
-  check_model "model" "claude-haiku-4-5" (Agent.state agent).config.model
+  check_model "model" "claude-haiku-4-5-20251001" (Agent.state agent).config.model
 
 (* --- 2. with_system_prompt --- *)
 
@@ -442,7 +442,7 @@ let test_build_produces_valid_agent () =
   in
   let cfg = (Agent.state agent).config in
   Alcotest.(check string) "name" "full-agent" cfg.name;
-  check_model "model" "claude-opus-4-5" cfg.model;
+  check_model "model" "claude-opus-4-5-20251101" cfg.model;
   Alcotest.(check (option string)) "system_prompt"
     (Some "Be concise.") cfg.system_prompt;
   Alcotest.(check int) "max_tokens" 2048 cfg.max_tokens;
@@ -548,7 +548,7 @@ let test_build_minimal_required_only () =
   with_net @@ fun net ->
   let agent =
     Builder.create ~net ~model:"claude-3-7-sonnet" |> Builder.build_safe |> Result.get_ok in
-  check_model "model" "claude-3-7-sonnet" (Agent.state agent).config.model;
+  check_model "model" "claude-3-7-sonnet-20250219" (Agent.state agent).config.model;
   Alcotest.(check string) "name" "agent" (Agent.state agent).config.name;
   Alcotest.(check int) "max_tokens" 4096 (Agent.state agent).config.max_tokens;
   Alcotest.(check int) "max_turns" 10 (Agent.state agent).config.max_turns;

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -453,17 +453,17 @@ let () =
         check bool "error" true
           (Result.is_error (Checkpoint.of_json (`Assoc []))));
 
-      test_case "invalid model tag returns Error" `Quick (fun () ->
+      test_case "any string is valid model" `Quick (fun () ->
         let cp = make_checkpoint () in
         let json = Checkpoint.to_json cp in
-        let bad = match json with
+        let custom = match json with
           | `Assoc pairs ->
             `Assoc (List.map (fun (k, v) ->
-              if k = "model" then (k, `String "not-a-real-model") else (k, v)
+              if k = "model" then (k, `String "my-custom-model") else (k, v)
             ) pairs)
           | other -> other
         in
-        check bool "error" true (Result.is_error (Checkpoint.of_json bad)));
+        check bool "ok" true (Result.is_ok (Checkpoint.of_json custom)));
 
       test_case "invalid role returns Error" `Quick (fun () ->
         let cp = make_checkpoint ~messages:[

--- a/test/test_discovery.ml
+++ b/test/test_discovery.ml
@@ -55,7 +55,7 @@ let test_endpoint_status_to_json_healthy () =
     models = [{ id = "qwen3.5-35b"; owned_by = "llama-server" }];
     props = Some { total_slots = 4; ctx_size = 32768; model = "qwen3.5-35b" };
     slots = Some { total = 4; busy = 1; idle = 3 };
-    capabilities = Capabilities.qwen_openai_chat_capabilities;
+    capabilities = Capabilities.openai_chat_extended_capabilities;
   } in
   let json = Discovery.endpoint_status_to_json status in
   let open Yojson.Safe.Util in

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -150,7 +150,7 @@ let test_model_spec_openrouter_capabilities () =
   Alcotest.(check bool) "supports json response" true
     spec.capabilities.supports_response_format_json
 
-let test_qwen_family_openai_capabilities () =
+let test_extended_openai_capabilities () =
   let capabilities =
     Provider.capabilities_for_model
       ~provider:
@@ -248,8 +248,8 @@ let () =
         test_model_spec_local_llm_capabilities;
       Alcotest.test_case "openrouter model spec capabilities" `Quick
         test_model_spec_openrouter_capabilities;
-      Alcotest.test_case "qwen family openai capabilities" `Quick
-        test_qwen_family_openai_capabilities;
+      Alcotest.test_case "extended openai capabilities" `Quick
+        test_extended_openai_capabilities;
     ];
     "pricing", [
       Alcotest.test_case "sonnet pricing" `Quick test_pricing_sonnet;

--- a/test/test_subagent.ml
+++ b/test/test_subagent.ml
@@ -11,7 +11,7 @@ let () =
         check (option string) "desc" (Some "Code review agent") spec.description;
         check string "prompt" "You review code." spec.prompt;
         check bool "model is sonnet" true
-          (spec.model = Subagent.Use_model "claude-sonnet-4-6"));
+          (spec.model = Subagent.Use_model "claude-sonnet-4-6-20250514"));
 
       test_case "inherit model" `Quick (fun () ->
         let spec = Subagent.of_markdown "Just a prompt" in
@@ -194,39 +194,39 @@ let () =
       test_case "sonnet alias" `Quick (fun () ->
         check bool "sonnet" true
           (Subagent.model_override_of_string "sonnet" =
-           Subagent.Use_model "claude-sonnet-4-6"));
+           Subagent.Use_model "claude-sonnet-4-6-20250514"));
       test_case "claude-sonnet-4-6" `Quick (fun () ->
         check bool "sonnet 4.6" true
           (Subagent.model_override_of_string "claude-sonnet-4-6" =
-           Subagent.Use_model "claude-sonnet-4-6"));
+           Subagent.Use_model "claude-sonnet-4-6-20250514"));
       test_case "opus alias" `Quick (fun () ->
         check bool "opus" true
           (Subagent.model_override_of_string "opus" =
-           Subagent.Use_model "claude-opus-4-6"));
+           Subagent.Use_model "claude-opus-4-6-20250514"));
       test_case "claude-opus-4-6" `Quick (fun () ->
         check bool "opus 4.6" true
           (Subagent.model_override_of_string "claude-opus-4-6" =
-           Subagent.Use_model "claude-opus-4-6"));
+           Subagent.Use_model "claude-opus-4-6-20250514"));
       test_case "claude-opus-4-5" `Quick (fun () ->
         check bool "opus 4.5" true
           (Subagent.model_override_of_string "claude-opus-4-5" =
-           Subagent.Use_model "claude-opus-4-5"));
+           Subagent.Use_model "claude-opus-4-5-20251101"));
       test_case "claude-sonnet-4" `Quick (fun () ->
         check bool "sonnet 4" true
           (Subagent.model_override_of_string "claude-sonnet-4" =
-           Subagent.Use_model "claude-sonnet-4"));
+           Subagent.Use_model "claude-sonnet-4-20250514"));
       test_case "haiku alias" `Quick (fun () ->
         check bool "haiku" true
           (Subagent.model_override_of_string "haiku" =
-           Subagent.Use_model "claude-haiku-4-5"));
+           Subagent.Use_model "claude-haiku-4-5-20251001"));
       test_case "claude-haiku-4-5" `Quick (fun () ->
         check bool "haiku" true
           (Subagent.model_override_of_string "claude-haiku-4-5" =
-           Subagent.Use_model "claude-haiku-4-5"));
+           Subagent.Use_model "claude-haiku-4-5-20251001"));
       test_case "claude-3-7-sonnet" `Quick (fun () ->
         check bool "3.7" true
           (Subagent.model_override_of_string "claude-3-7-sonnet" =
-           Subagent.Use_model "claude-3-7-sonnet"));
+           Subagent.Use_model "claude-3-7-sonnet-20250219"));
       test_case "custom fallback" `Quick (fun () ->
         match Subagent.model_override_of_string "gpt-4o" with
         | Subagent.Use_model "gpt-4o" -> ()
@@ -404,7 +404,7 @@ let () =
           ~parent_config:Types.default_config ~base_tools:tools spec in
         check string "name" "helper" target.name;
         check string "desc" "Helps out" target.description;
-        check bool "model" true (target.config.model = "claude-haiku-4-5");
+        check bool "model" true (target.config.model = "claude-haiku-4-5-20251001");
         check int "max_turns" 3 target.config.max_turns;
         check (option string) "system_prompt" (Some "You help.") target.config.system_prompt);
 


### PR DESCRIPTION
## Summary
- `qwen_openai_chat_capabilities` → `openai_chat_extended_capabilities`
- `is_qwen_family` → `needs_extended_capabilities` (동작 기술)
- `Builder.create`에서 `Model_registry.resolve_model_id` 적용 (eager resolution)
- Phase 2 테스트 기대값 수정 (resolved full model ID)

## Vendor Hardcoding Cleanup Series (3/3 OAS)
Phase 3: Capabilities 벤더 이름 정리. Low risk.

## Test plan
- [x] `dune build --root .` 통과
- [x] `dune runtest --root .` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)