### PR TITLE
fix: retry jitter + prompt caching min threshold

### DIFF
--- a/lib/api_anthropic.ml
+++ b/lib/api_anthropic.ml
@@ -18,8 +18,12 @@ let build_body_assoc ~config ~messages ?tools ~stream () =
     ("messages", `List (List.map Api_common.message_to_json messages));
     ("stream", `Bool stream);
   ] in
+  (* Anthropic requires ~1024+ tokens for cache_control to take effect.
+     Heuristic: 1 token ≈ 4 chars, so 4096 chars ≈ 1024 tokens minimum. *)
+  let min_cache_chars = 4096 in
   let body_assoc = match config.config.system_prompt with
-    | Some s when config.config.cache_system_prompt ->
+    | Some s when config.config.cache_system_prompt
+                  && String.length s >= min_cache_chars ->
         let cached_block = `Assoc [
           ("type", `String "text");
           ("text", `String s);

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -117,11 +117,16 @@ let complete_with_retry ~sw ~net ~clock
     ~(messages : Types.message list) ?(tools=[])
     ?(retry_config=default_retry_config)
     ?cache ?metrics () =
+  (* Jitter: randomize delay by 0.5x-1.5x to prevent thundering herd *)
+  let jittered delay =
+    let factor = 0.5 +. Random.float 1.0 in
+    delay *. factor
+  in
   let rec attempt n delay =
     match complete ~sw ~net ~config ~messages ~tools ?cache ?metrics () with
     | Ok _ as success -> success
     | Error err when is_retryable err && n < retry_config.max_retries ->
-        Eio.Time.sleep clock delay;
+        Eio.Time.sleep clock (jittered delay);
         let next_delay =
           Float.min
             (delay *. retry_config.backoff_multiplier)


### PR DESCRIPTION
Closes #165 (thundering herd jitter), closes #166 (caching min tokens).