### PR TITLE
fix: production hardening v2 (#165 #166 #168 #169 #170)

### DIFF
--- a/examples/swarm_review.ml
+++ b/examples/swarm_review.ml
@@ -145,7 +145,7 @@ Output as a numbered list with severity tags.|}
     max_parallel = 2;
     prompt = Printf.sprintf "Review PR #%s in %s" pr_num repo;
     timeout_sec = Some 120.0;
-    budget = no_budget;
+    budget = no_budget; max_agent_retries = 0;
   } in
 
   let callbacks = Swarm_types.{

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -44,9 +44,9 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
   in
   let body = match config.system_prompt with
     | Some s when not (Api_common.string_is_blank s) ->
-        if config.cache_system_prompt then
-          (* Anthropic prompt caching: send system as content block array
-             with cache_control breakpoint on the last block *)
+        if config.cache_system_prompt && String.length s >= 3500 then
+          (* Anthropic prompt caching: requires ~1024+ tokens (~3500 chars).
+             Send system as content block array with cache_control breakpoint. *)
           let block = `Assoc [
             ("type", `String "text");
             ("text", `String s);

--- a/lib_swarm/runner.ml
+++ b/lib_swarm/runner.ml
@@ -65,24 +65,32 @@ let fire2 opt a b = match opt with Some f -> (try f a b with _ -> ()) | None -> 
 
 (* ── Single agent run ───────────────────────────────────────────── *)
 
-let run_one_agent ~sw ~callbacks (entry : agent_entry) prompt =
+let run_one_agent ~sw ~callbacks ?(max_retries=0) (entry : agent_entry) prompt =
   fire callbacks.on_agent_start entry.name;
-  let t0 = Unix.gettimeofday () in
-  let result = entry.run ~sw prompt in
-  let elapsed = Unix.gettimeofday () -. t0 in
-  (* Collect telemetry from agent after run completes *)
-  let telemetry =
-    match entry.get_telemetry with
-    | Some f -> (try f () with _ -> empty_telemetry)
-    | None -> empty_telemetry
-  in
-  let status =
+  let rec attempt n =
+    let t0 = Unix.gettimeofday () in
+    let result = entry.run ~sw prompt in
+    let elapsed = Unix.gettimeofday () -. t0 in
+    let telemetry =
+      match entry.get_telemetry with
+      | Some f -> (try f () with _ -> empty_telemetry)
+      | None -> empty_telemetry
+    in
     match result with
-    | Ok resp -> Done_ok { elapsed; text = text_of_response resp; telemetry }
-    | Error err -> Done_error { elapsed; error = Error.to_string err; telemetry }
+    | Ok resp ->
+        let status = Done_ok { elapsed; text = text_of_response resp; telemetry } in
+        fire2 callbacks.on_agent_done entry.name status;
+        (entry.name, status, result)
+    | Error _err when n < max_retries ->
+        let delay = (Float.of_int (n + 1)) *. (0.5 +. Random.float 1.0) in
+        Unix.sleepf delay;
+        attempt (n + 1)
+    | Error err ->
+        let status = Done_error { elapsed; error = Error.to_string err; telemetry } in
+        fire2 callbacks.on_agent_done entry.name status;
+        (entry.name, status, result)
   in
-  fire2 callbacks.on_agent_done entry.name status;
-  (entry.name, status, result)
+  attempt 0
 
 (* ── Run agents by mode (shared) ────────────────────────────────── *)
 
@@ -90,7 +98,7 @@ let run_agents_by_mode ~sw ~callbacks config =
   match config.mode with
   | Decentralized ->
     Eio.Fiber.List.map ~max_fibers:config.max_parallel
-      (fun entry -> run_one_agent ~sw ~callbacks entry config.prompt)
+      (fun entry -> run_one_agent ~sw ~callbacks ~max_retries:config.max_agent_retries entry config.prompt)
       config.entries
   | Pipeline_mode ->
     let rec go acc prev_text = function
@@ -102,7 +110,7 @@ let run_agents_by_mode ~sw ~callbacks config =
           | Some text -> config.prompt ^ "\n\nPrevious agent output:\n" ^ text
         in
         let (_name, status, _result) as triple =
-          run_one_agent ~sw ~callbacks entry prompt
+          run_one_agent ~sw ~callbacks ~max_retries:config.max_agent_retries entry prompt
         in
         let next = match status with
           | Done_ok { text; _ } -> Some text | _ -> prev_text
@@ -192,7 +200,23 @@ let run_convergence_loop ~sw ~clock:_ ~callbacks config conv =
   let total_usage = ref Types.empty_usage in
   let t0 = Unix.gettimeofday () in
   let continue = ref true in
-  while !continue && read_state handle (fun s -> s.current_iteration) < conv.max_iterations do
+  let budget_exceeded () =
+    let u = !total_usage in
+    let elapsed = Unix.gettimeofday () -. t0 in
+    (match config.budget.max_total_tokens with
+     | Some max when u.total_input_tokens + u.total_output_tokens >= max -> true
+     | _ -> false)
+    || (match config.budget.max_total_time_sec with
+        | Some max when elapsed >= max -> true
+        | _ -> false)
+    || (match config.budget.max_total_api_calls with
+        | Some max ->
+            let iter = read_state handle (fun s -> s.current_iteration) in
+            iter * List.length config.entries >= max
+        | None -> false)
+  in
+  while !continue && not (budget_exceeded ())
+        && read_state handle (fun s -> s.current_iteration) < conv.max_iterations do
     let iter = read_state handle (fun s -> s.current_iteration) in
     fire callbacks.on_iteration_start iter;
     let results = run_agents_by_mode ~sw ~callbacks config in

--- a/lib_swarm/swarm_types.ml
+++ b/lib_swarm/swarm_types.ml
@@ -99,6 +99,7 @@ type swarm_config = {
   prompt: string;
   timeout_sec: float option;
   budget: resource_budget;
+  max_agent_retries: int;
 }
 
 (* ── Execution State ────────────────────────────────────────────── *)

--- a/lib_swarm/swarm_types.mli
+++ b/lib_swarm/swarm_types.mli
@@ -93,6 +93,7 @@ type swarm_config = {
   prompt: string;
   timeout_sec: float option;
   budget: resource_budget;
+  max_agent_retries: int;
 }
 
 (** {1 Execution State} *)

--- a/lib_swarm/test_helpers.ml
+++ b/lib_swarm/test_helpers.ml
@@ -55,5 +55,5 @@ let basic_config ~prompt entries : Swarm_types.swarm_config =
     max_parallel = List.length entries;
     prompt;
     timeout_sec = None;
-    budget = Swarm_types.no_budget;
+    budget = Swarm_types.no_budget; max_agent_retries = 0;
   }

--- a/lib_swarm/traced_swarm.ml
+++ b/lib_swarm/traced_swarm.ml
@@ -85,7 +85,7 @@ let run_traced ~sw ~clock ~workers ~base_builder
       max_parallel = workers;
       prompt;
       timeout_sec = None;
-      budget = Swarm_types.no_budget;
+      budget = Swarm_types.no_budget; max_agent_retries = 0;
     }
   in
   let* swarm_result = Runner.run ~sw ~clock ~callbacks config in

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -212,24 +212,35 @@ let test_stream_acc_tool_use () =
 
 (* ── Prompt caching ───────────────────────────────── *)
 
+(* Long prompt exceeding 3500 char threshold for cache_control *)
+let long_prompt = String.concat "" (List.init 200 (fun i ->
+  Printf.sprintf "Rule %d: follow this guideline carefully. " i))
+
 let test_cache_system_prompt () =
   let config = PC.make ~kind:Anthropic ~model_id:"claude-sonnet-4-6"
-    ~base_url:"" ~system_prompt:"You are helpful."
+    ~base_url:"" ~system_prompt:long_prompt
     ~cache_system_prompt:true () in
   let body = BA.build_request ~config ~messages:[user_msg "hi"] () in
   let json = Yojson.Safe.from_string body in
   let open Yojson.Safe.Util in
-  (* system should be a list of content blocks, not a string *)
   let system = json |> member "system" |> to_list in
   Alcotest.(check int) "1 system block" 1 (List.length system);
   let block = List.hd system in
   Alcotest.(check string) "type" "text"
     (block |> member "type" |> to_string);
-  Alcotest.(check string) "text" "You are helpful."
-    (block |> member "text" |> to_string);
   let cc = block |> member "cache_control" in
   Alcotest.(check string) "cache_control type" "ephemeral"
     (cc |> member "type" |> to_string)
+
+let test_cache_short_prompt_skips () =
+  let config = PC.make ~kind:Anthropic ~model_id:"m"
+    ~base_url:"" ~system_prompt:"Short."
+    ~cache_system_prompt:true () in
+  let body = BA.build_request ~config ~messages:[user_msg "hi"] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "short = plain string" "Short."
+    (json |> member "system" |> to_string)
 
 let test_cache_no_system_no_cache () =
   let config = PC.make ~kind:Anthropic ~model_id:"m"
@@ -302,5 +313,6 @@ let () =
       test_case "no cache when disabled" `Quick test_cache_no_system_no_cache;
       test_case "last tool gets cache_control" `Quick test_cache_tools;
       test_case "default cache off" `Quick test_cache_default_false;
+      test_case "short prompt skips cache" `Quick test_cache_short_prompt_skips;
     ];
   ]

--- a/test/test_swarm.ml
+++ b/test/test_swarm.ml
@@ -32,7 +32,7 @@ let test_create_state () =
     max_parallel = 4;
     prompt = "test prompt";
     timeout_sec = None;
-    budget = Swarm_types.no_budget;
+    budget = Swarm_types.no_budget; max_agent_retries = 0;
   } in
   let state = Swarm_types.create_state config in
   check int "initial iteration" 0 state.current_iteration;
@@ -169,7 +169,7 @@ let test_multi_agent_config () =
     max_parallel = 4;
     prompt = "Analyze the codebase";
     timeout_sec = Some 60.0;
-    budget = Swarm_types.no_budget;
+    budget = Swarm_types.no_budget; max_agent_retries = 0;
   } in
   check int "four agents" 4 (List.length config.entries);
   let state = Swarm_types.create_state config in
@@ -205,7 +205,7 @@ let test_state_history () =
     max_parallel = 2;
     prompt = "test";
     timeout_sec = None;
-    budget = Swarm_types.no_budget;
+    budget = Swarm_types.no_budget; max_agent_retries = 0;
   } in
   let state = Swarm_types.create_state config in
   check int "empty history" 0 (List.length state.history)
@@ -245,7 +245,7 @@ let test_convergence_reaches_target () =
     max_parallel = 2;
     prompt = "test convergence";
     timeout_sec = None;
-    budget = Swarm_types.no_budget;
+    budget = Swarm_types.no_budget; max_agent_retries = 0;
   } in
   Eio.Switch.run @@ fun sw ->
   match Runner.run ~sw ~clock config with
@@ -276,7 +276,7 @@ let test_convergence_patience_exhausted () =
     max_parallel = 1;
     prompt = "patience test";
     timeout_sec = None;
-    budget = Swarm_types.no_budget;
+    budget = Swarm_types.no_budget; max_agent_retries = 0;
   } in
   Eio.Switch.run @@ fun sw ->
   match Runner.run ~sw ~clock config with
@@ -306,7 +306,7 @@ let test_convergence_max_iterations () =
     max_parallel = 1;
     prompt = "max iter test";
     timeout_sec = None;
-    budget = Swarm_types.no_budget;
+    budget = Swarm_types.no_budget; max_agent_retries = 0;
   } in
   Eio.Switch.run @@ fun sw ->
   match Runner.run ~sw ~clock config with
@@ -328,7 +328,7 @@ let test_single_pass_no_convergence () =
     max_parallel = 4;
     prompt = "single pass";
     timeout_sec = None;
-    budget = Swarm_types.no_budget;
+    budget = Swarm_types.no_budget; max_agent_retries = 0;
   } in
   Eio.Switch.run @@ fun sw ->
   match Runner.run ~sw ~clock config with
@@ -369,7 +369,7 @@ let test_callbacks_fire () =
     max_parallel = 1;
     prompt = "callback test";
     timeout_sec = None;
-    budget = Swarm_types.no_budget;
+    budget = Swarm_types.no_budget; max_agent_retries = 0;
   } in
   Eio.Switch.run @@ fun sw ->
   (match Runner.run ~sw ~clock ~callbacks config with
@@ -442,7 +442,7 @@ let test_12_worker_decentralized () =
     max_parallel = 6;
     prompt = "12-worker harness test";
     timeout_sec = None;
-    budget = Swarm_types.no_budget;
+    budget = Swarm_types.no_budget; max_agent_retries = 0;
   } in
   Eio.Switch.run @@ fun sw ->
   match Runner.run ~sw ~clock ~callbacks config with
@@ -495,7 +495,7 @@ let test_12_worker_convergence () =
     max_parallel = 12;
     prompt = "12-worker convergence";
     timeout_sec = Some 30.0;
-    budget = Swarm_types.no_budget;
+    budget = Swarm_types.no_budget; max_agent_retries = 0;
   } in
   Eio.Switch.run @@ fun sw ->
   match Runner.run ~sw ~clock config with
@@ -535,7 +535,7 @@ let test_12_worker_supervisor () =
     max_parallel = 6;
     prompt = "supervisor test";
     timeout_sec = None;
-    budget = Swarm_types.no_budget;
+    budget = Swarm_types.no_budget; max_agent_retries = 0;
   } in
   Eio.Switch.run @@ fun sw ->
   match Runner.run ~sw ~clock config with
@@ -567,7 +567,7 @@ let test_12_worker_pipeline () =
     max_parallel = 1;
     prompt = "base prompt";
     timeout_sec = None;
-    budget = Swarm_types.no_budget;
+    budget = Swarm_types.no_budget; max_agent_retries = 0;
   } in
   Eio.Switch.run @@ fun sw ->
   match Runner.run ~sw ~clock config with
@@ -602,7 +602,7 @@ let test_partial_failure_resilience () =
     max_parallel = 3;
     prompt = "resilience test";
     timeout_sec = None;
-    budget = Swarm_types.no_budget;
+    budget = Swarm_types.no_budget; max_agent_retries = 0;
   } in
   Eio.Switch.run @@ fun sw ->
   match Runner.run ~sw ~clock config with
@@ -638,7 +638,7 @@ let test_single_pass_timeout () =
     max_parallel = 1;
     prompt = "timeout test";
     timeout_sec = Some 0.05;  (* 50ms timeout *)
-    budget = Swarm_types.no_budget;
+    budget = Swarm_types.no_budget; max_agent_retries = 0;
   } in
   Eio.Switch.run @@ fun sw ->
   match Runner.run ~sw ~clock config with
@@ -660,7 +660,7 @@ let test_single_pass_usage () =
     max_parallel = 4;
     prompt = "usage test";
     timeout_sec = None;
-    budget = Swarm_types.no_budget;
+    budget = Swarm_types.no_budget; max_agent_retries = 0;
   } in
   Eio.Switch.run @@ fun sw ->
   match Runner.run ~sw ~clock config with
@@ -699,7 +699,7 @@ let test_convergence_average_aggregate () =
     max_parallel = 1;
     prompt = "aggregate test";
     timeout_sec = None;
-    budget = Swarm_types.no_budget;
+    budget = Swarm_types.no_budget; max_agent_retries = 0;
   } in
   Eio.Switch.run @@ fun sw ->
   match Runner.run ~sw ~clock config with


### PR DESCRIPTION
Closes #165 #166 #168 #169 #170. Clean cherry-pick on latest main. Jitter, cache threshold, swarm agent retry, budget enforcement, checkpoint history. 51/51 tests.