### PR TITLE
refactor: provider-aware pricing, deduplicate capabilities, remove dead code

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -42,6 +42,7 @@ let openai_chat_capabilities = {
   supports_tool_choice = true;
   supports_response_format_json = true;
   supports_multimodal_inputs = true;
+  supports_native_streaming = true;
 }
 
 let openai_chat_extended_capabilities = {

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -22,16 +22,7 @@ type request_kind =
   | Openai_chat_completions
   | Custom of string
 
-type capabilities = {
-  supports_tools: bool;
-  supports_tool_choice: bool;
-  supports_reasoning: bool;
-  supports_response_format_json: bool;
-  supports_multimodal_inputs: bool;
-  supports_native_streaming: bool;
-  supports_top_k: bool;
-  supports_min_p: bool;
-}
+include Llm_provider.Capabilities
 
 type model_spec = {
   provider: provider;
@@ -40,42 +31,6 @@ type model_spec = {
   request_kind: request_kind;
   request_path: string;
   capabilities: capabilities;
-}
-
-let default_capabilities = {
-  supports_tools = false;
-  supports_tool_choice = false;
-  supports_reasoning = false;
-  supports_response_format_json = false;
-  supports_multimodal_inputs = false;
-  supports_native_streaming = false;
-  supports_top_k = false;
-  supports_min_p = false;
-}
-
-let anthropic_capabilities = {
-  default_capabilities with
-  supports_tools = true;
-  supports_tool_choice = true;
-  supports_reasoning = true;
-  supports_multimodal_inputs = true;
-  supports_native_streaming = true;
-}
-
-let openai_chat_capabilities = {
-  default_capabilities with
-  supports_tools = true;
-  supports_tool_choice = true;
-  supports_response_format_json = true;
-  supports_multimodal_inputs = true;
-  supports_native_streaming = true;
-}
-
-let openai_chat_extended_capabilities = {
-  openai_chat_capabilities with
-  supports_reasoning = true;
-  supports_top_k = true;
-  supports_min_p = true;
 }
 
 let string_contains = Util.string_contains
@@ -280,16 +235,19 @@ let pricing_for_model model_id =
       (2.0, 8.0), no_cache
     else if string_contains ~needle:"o3-mini" normalized then
       (1.1, 4.4), no_cache
-    else if string_contains ~needle:"ollama" normalized
-         || string_contains ~needle:"qwen" normalized
-         || string_contains ~needle:"llama" normalized then
-      (0.0, 0.0), no_cache
     else
       (0.0, 0.0), no_cache
   in
   let input_per_million, output_per_million = base in
   { input_per_million; output_per_million;
     cache_write_multiplier = cw; cache_read_multiplier = cr }
+
+let pricing_for_provider ~(provider : provider) ~(model_id : string) =
+  match provider with
+  | Local _ ->
+    { input_per_million = 0.0; output_per_million = 0.0;
+      cache_write_multiplier = 1.0; cache_read_multiplier = 1.0 }
+  | _ -> pricing_for_model model_id
 
 let estimate_cost ~(pricing : pricing)
     ~input_tokens ~output_tokens

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -84,6 +84,7 @@ type pricing = {
 }
 
 val pricing_for_model : string -> pricing
+val pricing_for_provider : provider:provider -> model_id:string -> pricing
 val estimate_cost :
   pricing:pricing ->
   input_tokens:int ->

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -42,15 +42,6 @@ type model = string
     Delegates to {!Model_registry.resolve_model_id}. *)
 let model_to_string = Model_registry.resolve_model_id
 
-(* Backward-compatible constructors for code that used the old enum.
-   Each resolves the alias immediately so the config holds the full ID. *)
-let _Claude_opus_4_6 = "claude-opus-4-6"
-let _Claude_sonnet_4_6 = "claude-sonnet-4-6"
-let _Claude_opus_4_5 = "claude-opus-4-5"
-let _Claude_sonnet_4 = "claude-sonnet-4"
-let _Claude_haiku_4_5 = "claude-haiku-4-5"
-let _Claude_3_7_sonnet = "claude-3-7-sonnet"
-
 (** Agent configuration *)
 type agent_config = {
   name: string;

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -177,7 +177,9 @@ let test_pricing_sonnet () =
   Alcotest.(check (float 0.001)) "cache_read" 0.1 p.cache_read_multiplier
 
 let test_pricing_local () =
-  let p = Provider.pricing_for_model "qwen3.5-35b-a3b" in
+  let p = Provider.pricing_for_provider
+    ~provider:(Local { base_url = "http://127.0.0.1:8085" })
+    ~model_id:"qwen3.5-35b-a3b" in
   Alcotest.(check (float 0.001)) "free" 0.0 p.input_per_million;
   Alcotest.(check (float 0.001)) "free output" 0.0 p.output_per_million
 


### PR DESCRIPTION
## Summary
- `pricing_for_provider ~provider ~model_id`: Local provider = free (0.0), 벤더 substring 매칭 제거
- capabilities 중복 제거: `provider.ml` → `include Llm_provider.Capabilities` (divergence 수정 포함)
- dead code 제거: `_Claude_*` 6개 unused backward-compat 변수 삭제

## Vendor Hardcoding Cleanup Series Phase 2 (OAS)

### capabilities divergence 수정
`openai_chat_capabilities`가 `capabilities.ml`에서 `supports_native_streaming = false`였지만 `provider.ml` 복사본에서는 `true`. 정본(`capabilities.ml`)을 `true`로 수정하여 통일.

## Test plan
- [x] `dune build --root .` 통과
- [x] `dune runtest --root .` 전체 통과 (0 failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)