### PR TITLE
feat(agent_config): add provider, thinking fields to JSON config

### DIFF
--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -11,6 +11,10 @@
         "system_prompt": "You are helpful.",
         "max_tokens": 4096,
         "max_turns": 10,
+        "provider": "local",
+        "base_url": "http://127.0.0.1:8085",
+        "enable_thinking": true,
+        "thinking_budget": 2048,
         "tools": [
           { "name": "get_weather", "description": "Get weather",
             "parameters": [...] }
@@ -21,6 +25,9 @@
         ]
       }
     ]}
+
+    Provider values: "local" (llama-server), "anthropic", "openai",
+    or any string (treated as OpenAI-compatible with api_key_env = that string).
 *)
 
 let ( let* ) = Result.bind
@@ -50,6 +57,10 @@ type agent_file_config = {
   system_prompt: string option;
   max_tokens: int option;
   max_turns: int option;
+  enable_thinking: bool option;
+  thinking_budget: int option;
+  provider: string option;
+  base_url: string option;
   tools: tool_file_config list;
   mcp_servers: mcp_file_config list;
 }
@@ -122,6 +133,10 @@ let of_json json =
     let system_prompt = json |> member "system_prompt" |> to_string_option in
     let max_tokens = json |> member "max_tokens" |> to_int_option in
     let max_turns = json |> member "max_turns" |> to_int_option in
+    let enable_thinking = json |> member "enable_thinking" |> to_bool_option in
+    let thinking_budget = json |> member "thinking_budget" |> to_int_option in
+    let provider = json |> member "provider" |> to_string_option in
+    let base_url = json |> member "base_url" |> to_string_option in
     let tools_json = match json |> member "tools" with
       | `List ts -> ts
       | _ -> []
@@ -154,6 +169,10 @@ let of_json json =
       system_prompt;
       max_tokens;
       max_turns;
+      enable_thinking;
+      thinking_budget;
+      provider;
+      base_url;
       tools = List.rev tools;
       mcp_servers = List.rev mcp_servers;
     }
@@ -171,6 +190,38 @@ let load path =
   | Yojson.Json_error msg ->
     Error (Error.Io (FileOpFailed { op = "load"; path; detail = "JSON error: " ^ msg }))
 
+(** Resolve provider string + optional base_url to a Provider.config. *)
+let resolve_provider ~model_id provider_str base_url =
+  match provider_str with
+  | "local" ->
+      let url = match base_url with
+        | Some u -> u
+        | None -> Defaults.local_llm_url
+      in
+      { Provider.provider = Local { base_url = url };
+        model_id; api_key_env = "" }
+  | "anthropic" ->
+      { Provider.provider = Anthropic;
+        model_id; api_key_env = "ANTHROPIC_API_KEY" }
+  | "openai" ->
+      let url = match base_url with
+        | Some u -> u
+        | None -> "https://api.openai.com"
+      in
+      { Provider.provider = OpenAICompat {
+          base_url = url; auth_header = None;
+          path = "/v1/chat/completions"; static_token = None };
+        model_id; api_key_env = "OPENAI_API_KEY" }
+  | other ->
+      let url = match base_url with
+        | Some u -> u
+        | None -> Defaults.local_llm_url
+      in
+      { Provider.provider = OpenAICompat {
+          base_url = url; auth_header = None;
+          path = "/v1/chat/completions"; static_token = None };
+        model_id; api_key_env = other }
+
 (** Convert a loaded config to a Builder.t. *)
 let to_builder ~net (cfg : agent_file_config) =
   let model = Model_registry.resolve_model_id cfg.model in
@@ -186,6 +237,18 @@ let to_builder ~net (cfg : agent_file_config) =
   in
   let b = match cfg.max_turns with
     | Some n -> Builder.with_max_turns n b
+    | None -> b
+  in
+  let b = match cfg.enable_thinking with
+    | Some v -> Builder.with_enable_thinking v b
+    | None -> b
+  in
+  let b = match cfg.thinking_budget with
+    | Some n -> Builder.with_thinking_budget n b
+    | None -> b
+  in
+  let b = match cfg.provider with
+    | Some p -> Builder.with_provider (resolve_provider ~model_id:model p cfg.base_url) b
     | None -> b
   in
   let tools = List.map (fun (tc : tool_file_config) ->

--- a/test/test_agent_config.ml
+++ b/test/test_agent_config.ml
@@ -115,6 +115,8 @@ let test_to_builder () =
     max_turns = Some 5;
     tools = [{ name = "echo"; description = "Echo"; parameters = [] }];
     mcp_servers = [];
+    enable_thinking = None; thinking_budget = None;
+    provider = None; base_url = None;
   } in
   let builder = Agent_config.to_builder ~net cfg in
   match Builder.build_safe builder with
@@ -134,6 +136,8 @@ let test_to_builder_no_tools () =
     max_turns = None;
     tools = [];
     mcp_servers = [];
+    enable_thinking = None; thinking_budget = None;
+    provider = None; base_url = None;
   } in
   let builder = Agent_config.to_builder ~net cfg in
   match Builder.build_safe builder with
@@ -154,6 +158,8 @@ let test_to_builder_all_models () =
     let cfg : Agent_config.agent_file_config = {
       name = "m-test"; model = model_str;
       system_prompt = None; max_tokens = None; max_turns = None;
+      enable_thinking = None; thinking_budget = None;
+      provider = None; base_url = None;
       tools = []; mcp_servers = [];
     } in
     let builder = Agent_config.to_builder ~net cfg in


### PR DESCRIPTION
## Summary
- OAS CLI JSON config에 `provider`, `base_url`, `enable_thinking`, `thinking_budget` 필드 추가
- `provider: "local"`로 llama-server 직접 연결 가능 (기존에는 ANTHROPIC_API_KEY 필수)
- thinking 설정이 JSON config에서 직접 지원

## 동기
- OAS CLI(`oas run`)가 로컬 LLM을 사용하려면 Provider를 프로그래밍 방식으로만 설정 가능했음
- thinking 테스트도 CLI에서 불가능 — MASC 내부 스폰에서만 동작
- 독립 CLI 사용성을 위해 JSON config 확장 필요

## 변경사항
- `lib/agent/agent_config.ml`: 4개 optional 필드 + `resolve_provider` 함수
- `test/test_agent_config.ml`: 기존 테스트에 새 필드 반영

## 라이브 검증
```bash
oas run --config local-thinking.json "봄을 주제로 시를 쓰세요"
# -> llama-server 연결 + 도구 호출 + thinking 동작 확인
```

## Test plan
- [x] `dune build --root .` 성공
- [x] `dune runtest --root .` 전체 통과
- [x] 라이브 테스트: `provider: "local"` + `enable_thinking: true` + 도구 호출

🤖 Generated with [Claude Code](https://claude.com/claude-code)