### PR TITLE
fix(streaming): parse reasoning_content in OpenAI SSE stream

### DIFF
--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -146,6 +146,7 @@ type openai_chunk = {
   chunk_id: string;
   chunk_model: string;
   delta_content: string option;
+  delta_reasoning: string option;
   delta_tool_calls: openai_tool_call_delta list;
   finish_reason: string option;
   chunk_usage: api_usage option;
@@ -168,6 +169,7 @@ let parse_openai_sse_chunk data_str : openai_chunk option =
       let choice = json |> member "choices" |> index 0 in
       let delta = choice |> member "delta" in
       let delta_content = delta |> member "content" |> to_string_option in
+      let delta_reasoning = delta |> member "reasoning_content" |> to_string_option in
       let delta_tool_calls =
         match delta |> member "tool_calls" with
         | `List calls ->
@@ -207,7 +209,7 @@ let parse_openai_sse_chunk data_str : openai_chunk option =
             cache_read_input_tokens = cached;
           }
       in
-      Some { chunk_id; chunk_model; delta_content;
+      Some { chunk_id; chunk_model; delta_content; delta_reasoning;
              delta_tool_calls; finish_reason; chunk_usage }
     with
     | Yojson.Safe.Util.Type_error _ | Yojson.Safe.Util.Undefined _
@@ -215,12 +217,14 @@ let parse_openai_sse_chunk data_str : openai_chunk option =
 
 (** Mutable state for converting OpenAI flat deltas to block-based events. *)
 type openai_stream_state = {
+  mutable thinking_block_started: bool;
   mutable text_block_started: bool;
   tool_block_indices: (int, int) Hashtbl.t;  (** tool_call index -> block index *)
   mutable next_block_index: int;
 }
 
 let create_openai_stream_state () = {
+  thinking_block_started = false;
   text_block_started = false;
   tool_block_indices = Hashtbl.create 4;
   next_block_index = 0;
@@ -233,6 +237,18 @@ let openai_chunk_to_events (state : openai_stream_state)
     (chunk : openai_chunk) : sse_event list =
   let events = ref [] in
   let emit evt = events := evt :: !events in
+  (* Reasoning content delta — emitted before text *)
+  (match chunk.delta_reasoning with
+   | Some text when text <> "" ->
+       if not state.thinking_block_started then begin
+         emit (ContentBlockStart {
+           index = state.next_block_index; content_type = "thinking";
+           tool_id = None; tool_name = None });
+         state.thinking_block_started <- true;
+         state.next_block_index <- state.next_block_index + 1
+       end;
+       emit (ContentBlockDelta { index = 0; delta = ThinkingDelta text })
+   | _ -> ());
   (* Text content delta *)
   (match chunk.delta_content with
    | Some text when text <> "" ->
@@ -243,7 +259,8 @@ let openai_chunk_to_events (state : openai_stream_state)
          state.text_block_started <- true;
          state.next_block_index <- state.next_block_index + 1
        end;
-       emit (ContentBlockDelta { index = 0; delta = TextDelta text })
+       let text_idx = if state.thinking_block_started then 1 else 0 in
+       emit (ContentBlockDelta { index = text_idx; delta = TextDelta text })
    | _ -> ());
   (* Tool call deltas *)
   List.iter (fun (tc : openai_tool_call_delta) ->

--- a/test/test_streaming_openai.ml
+++ b/test/test_streaming_openai.ml
@@ -80,7 +80,7 @@ let test_events_text_first_chunk () =
   let state = S.create_openai_stream_state () in
   let chunk : S.openai_chunk = {
     chunk_id = "c"; chunk_model = "m"; delta_content = Some "Hi";
-    delta_tool_calls = []; finish_reason = None; chunk_usage = None;
+    delta_reasoning = None; delta_tool_calls = []; finish_reason = None; chunk_usage = None;
   } in
   let events = S.openai_chunk_to_events state chunk in
   Alcotest.(check int) "2 events" 2 (List.length events);
@@ -98,11 +98,11 @@ let test_events_text_subsequent () =
   (* First chunk starts the block *)
   let _ = S.openai_chunk_to_events state
     { chunk_id = "c"; chunk_model = "m"; delta_content = Some "A";
-      delta_tool_calls = []; finish_reason = None; chunk_usage = None } in
+      delta_reasoning = None; delta_tool_calls = []; finish_reason = None; chunk_usage = None } in
   (* Second chunk: no ContentBlockStart *)
   let events = S.openai_chunk_to_events state
     { chunk_id = "c"; chunk_model = "m"; delta_content = Some "B";
-      delta_tool_calls = []; finish_reason = None; chunk_usage = None } in
+      delta_reasoning = None; delta_tool_calls = []; finish_reason = None; chunk_usage = None } in
   Alcotest.(check int) "1 event" 1 (List.length events);
   (match List.hd events with
    | ContentBlockDelta { delta = TextDelta s; _ } ->
@@ -117,7 +117,7 @@ let test_events_tool_call () =
   } in
   let events = S.openai_chunk_to_events state
     { chunk_id = "c"; chunk_model = "m"; delta_content = None;
-      delta_tool_calls = [tc]; finish_reason = None; chunk_usage = None } in
+      delta_reasoning = None; delta_tool_calls = [tc]; finish_reason = None; chunk_usage = None } in
   Alcotest.(check int) "2 events" 2 (List.length events);
   (match List.nth events 0 with
    | ContentBlockStart { content_type; tool_id; tool_name; _ } ->
@@ -135,7 +135,7 @@ let test_events_finish_reason () =
   let events = S.openai_chunk_to_events state
     { chunk_id = "c"; chunk_model = "m"; delta_content = None;
       delta_tool_calls = [];
-      finish_reason = Some "stop"; chunk_usage = None } in
+      delta_reasoning = None; finish_reason = Some "stop"; chunk_usage = None } in
   Alcotest.(check int) "1 event" 1 (List.length events);
   (match List.hd events with
    | MessageDelta { stop_reason = Some EndTurn; _ } -> ()
@@ -146,7 +146,7 @@ let test_events_tool_calls_finish () =
   let events = S.openai_chunk_to_events state
     { chunk_id = "c"; chunk_model = "m"; delta_content = None;
       delta_tool_calls = [];
-      finish_reason = Some "tool_calls"; chunk_usage = None } in
+      delta_reasoning = None; finish_reason = Some "tool_calls"; chunk_usage = None } in
   (match List.hd events with
    | MessageDelta { stop_reason = Some StopToolUse; _ } -> ()
    | _ -> Alcotest.fail "expected StopToolUse")
@@ -156,7 +156,7 @@ let test_events_length_finish () =
   let events = S.openai_chunk_to_events state
     { chunk_id = "c"; chunk_model = "m"; delta_content = None;
       delta_tool_calls = [];
-      finish_reason = Some "length"; chunk_usage = None } in
+      delta_reasoning = None; finish_reason = Some "length"; chunk_usage = None } in
   (match List.hd events with
    | MessageDelta { stop_reason = Some MaxTokens; _ } -> ()
    | _ -> Alcotest.fail "expected MaxTokens")
@@ -165,8 +165,44 @@ let test_events_empty_content_ignored () =
   let state = S.create_openai_stream_state () in
   let events = S.openai_chunk_to_events state
     { chunk_id = "c"; chunk_model = "m"; delta_content = Some "";
-      delta_tool_calls = []; finish_reason = None; chunk_usage = None } in
+      delta_reasoning = None; delta_tool_calls = []; finish_reason = None; chunk_usage = None } in
   Alcotest.(check int) "0 events" 0 (List.length events)
+
+let test_parse_reasoning_chunk () =
+  let data = {|{"id":"c-r","model":"qwen","choices":[{"index":0,"delta":{"reasoning_content":"Let me think"},"finish_reason":null}]}|} in
+  match S.parse_openai_sse_chunk data with
+  | Some chunk ->
+      Alcotest.(check (option string)) "reasoning" (Some "Let me think") chunk.delta_reasoning;
+      Alcotest.(check (option string)) "no content" None chunk.delta_content
+  | None -> Alcotest.fail "expected Some chunk"
+
+let test_events_reasoning_then_text () =
+  let state = S.create_openai_stream_state () in
+  let r_events = S.openai_chunk_to_events state
+    { chunk_id = "c"; chunk_model = "m"; delta_content = None;
+      delta_reasoning = Some "thinking...";
+      delta_tool_calls = []; finish_reason = None; chunk_usage = None } in
+  Alcotest.(check int) "2 events (start+delta)" 2 (List.length r_events);
+  (match List.nth r_events 0 with
+   | ContentBlockStart { content_type; _ } ->
+       Alcotest.(check string) "thinking type" "thinking" content_type
+   | _ -> Alcotest.fail "expected ContentBlockStart thinking");
+  (match List.nth r_events 1 with
+   | ContentBlockDelta { delta = ThinkingDelta s; _ } ->
+       Alcotest.(check string) "thinking text" "thinking..." s
+   | _ -> Alcotest.fail "expected ThinkingDelta");
+  let t_events = S.openai_chunk_to_events state
+    { chunk_id = "c"; chunk_model = "m"; delta_content = Some "answer";
+      delta_reasoning = None; delta_tool_calls = []; finish_reason = None; chunk_usage = None } in
+  Alcotest.(check int) "2 events (start+delta)" 2 (List.length t_events);
+  (match List.nth t_events 0 with
+   | ContentBlockStart { content_type; _ } ->
+       Alcotest.(check string) "text type" "text" content_type
+   | _ -> Alcotest.fail "expected ContentBlockStart text");
+  (match List.nth t_events 1 with
+   | ContentBlockDelta { index = 1; delta = TextDelta s } ->
+       Alcotest.(check string) "text" "answer" s
+   | _ -> Alcotest.fail "expected TextDelta at index 1")
 
 let () =
   let open Alcotest in
@@ -180,6 +216,7 @@ let () =
       test_case "usage" `Quick test_parse_usage;
       test_case "invalid JSON" `Quick test_parse_invalid_json;
       test_case "empty choices" `Quick test_parse_empty_choices;
+      test_case "reasoning_content" `Quick test_parse_reasoning_chunk;
     ];
     "openai_chunk_to_events", [
       test_case "text first chunk" `Quick test_events_text_first_chunk;
@@ -189,5 +226,6 @@ let () =
       test_case "finish tool_calls" `Quick test_events_tool_calls_finish;
       test_case "finish length" `Quick test_events_length_finish;
       test_case "empty content ignored" `Quick test_events_empty_content_ignored;
+      test_case "reasoning then text" `Quick test_events_reasoning_then_text;
     ];
   ]


### PR DESCRIPTION
## Summary
- #205와 동일한 `reasoning_content` 유실 버그의 SSE 스트리밍 경로 수정
- `parse_openai_sse_chunk`에서 `delta.reasoning_content` 파싱
- `openai_chunk_to_events`에서 `ThinkingDelta` 이벤트 생성

## 버그 상세
스트리밍 모드에서 llama-server(Qwen3.5)가 `delta.reasoning_content`로 thinking을 보내지만, OAS가 이 필드를 무시. #205에서 non-streaming 경로만 수정했고, streaming 경로는 누락.

## Test plan
- [x] `test_streaming_openai.exe` 17/17 통과 (기존 15 + 신규 2)
- [x] `dune runtest --root .` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)