### PR TITLE
feat(cascade): add timeout_sec to complete_named

### DIFF
--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -320,7 +320,7 @@ let complete_named ~sw ~net ?clock ?config_path
     ~name ~defaults ~messages
     ?(tools = []) ?(temperature = 0.3) ?(max_tokens = 500)
     ?system_prompt ?(accept = fun _ -> true)
-    ?cache ?metrics () =
+    ?timeout_sec ?cache ?metrics () =
   (* 1. Load from config file, fall back to defaults *)
   let model_strings =
     match config_path with
@@ -350,6 +350,18 @@ let complete_named ~sw ~net ?clock ?config_path
               "All providers unhealthy for cascade '%s'" name
         })
     else
-      (* 4. Execute cascade with accept validation *)
-      complete_cascade_with_accept ~sw ~net ?clock ?cache ?metrics
-        ~accept healthy_providers ~messages ~tools
+      (* 4. Execute cascade with accept validation, enforcing timeout *)
+      let run () =
+        complete_cascade_with_accept ~sw ~net ?clock ?cache ?metrics
+          ~accept healthy_providers ~messages ~tools
+      in
+      match clock, timeout_sec with
+      | Some clk, Some secs when secs > 0 ->
+        (try Eio.Time.with_timeout_exn clk (float_of_int secs) run
+         with Eio.Time.Timeout ->
+           Error (Http_client.NetworkError {
+               message =
+                 Printf.sprintf
+                   "Cascade '%s' timed out after %ds" name secs
+             }))
+      | _ -> run ()

--- a/lib/llm_provider/cascade_config.mli
+++ b/lib/llm_provider/cascade_config.mli
@@ -114,6 +114,7 @@ val complete_named :
   ?max_tokens:int ->
   ?system_prompt:string ->
   ?accept:(Types.api_response -> bool) ->
+  ?timeout_sec:int ->
   ?cache:Cache.t ->
   ?metrics:Metrics.t ->
   unit ->


### PR DESCRIPTION
## Summary
- `complete_named`에 `?timeout_sec:int` 파라미터 추가
- clock + timeout_sec 모두 제공 시 `Eio.Time.with_timeout_exn`으로 cascade 실행을 감싸서 시간 제한
- timeout 초과 시 `NetworkError`로 명확한 에러 반환

## Motivation
MASC `Llm_cascade.call`이 `timeout_sec`을 받지만 `ignore timeout_sec`로 무시하고 있었다. OAS `complete_named`에 timeout 지원이 없었기 때문. 결과적으로 LLM 호출이 무한 대기하면서 Eio cooperative scheduler를 블로킹하고, MASC HTTP 서버 전체가 60초+ 응답 지연.

## Test plan
- [x] 기존 14개 cascade_config 테스트 통과
- [ ] MASC에서 `ignore timeout_sec` 제거 후 `~timeout_sec` 전달 (PR 연동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)