### PR TITLE
feat(mcp): unify HTTP + stdio transports under Mcp.managed

### DIFF
--- a/bin/oas_cli.ml
+++ b/bin/oas_cli.ml
@@ -21,7 +21,8 @@ let run_cmd config_file prompt =
     Eio_main.run @@ fun env ->
     let net = Eio.Stdenv.net env in
     Eio.Switch.run @@ fun sw ->
-    let builder = Agent_sdk.Agent_config.to_builder ~net cfg in
+    let mgr = Eio.Stdenv.process_mgr env in
+    let builder = Agent_sdk.Agent_config.to_builder ~sw ~mgr ~net cfg in
     match Agent_sdk.Builder.build_safe builder with
     | Error e ->
       Printf.eprintf "Error building agent: %s\n" (Agent_sdk.Error.to_string e);
@@ -100,7 +101,7 @@ let card_cmd config_file =
   | Ok cfg ->
     Eio_main.run @@ fun env ->
     let net = Eio.Stdenv.net env in
-    let builder = Agent_sdk.Agent_config.to_builder ~net cfg in
+    let builder = Agent_sdk.Agent_config.to_builder ~net cfg in  (* no sw/mgr for card *)
     match Agent_sdk.Builder.build_safe builder with
     | Error e ->
       Printf.eprintf "Error building agent: %s\n" (Agent_sdk.Error.to_string e);

--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -42,12 +42,18 @@ type tool_file_config = {
 
 (* ── MCP server config ───────────────────────────────────── *)
 
-type mcp_file_config = {
-  command: string;
-  args: string list;
-  name: string;
-  env: string list;
-}
+type mcp_file_config =
+  | Stdio_mcp of {
+      command: string;
+      args: string list;
+      name: string;
+      env: string list;
+    }
+  | Http_mcp of {
+      url: string;
+      headers: (string * string) list;
+      name: string;
+    }
 
 (* ── Agent config ────────────────────────────────────────── *)
 
@@ -108,18 +114,33 @@ let parse_tool json =
 let parse_mcp json =
   let open Yojson.Safe.Util in
   try
-    let command = json |> member "command" |> to_string in
-    let args = match json |> member "args" with
-      | `List items -> List.filter_map to_string_option items
-      | _ -> []
-    in
-    let name = json |> member "name" |> to_string_option
-      |> Option.value ~default:command in
-    let env = match json |> member "env" with
-      | `List items -> List.filter_map to_string_option items
-      | _ -> []
-    in
-    Ok { command; args; name; env }
+    match json |> member "url" |> to_string_option with
+    | Some url ->
+        (* HTTP MCP: { "url": "...", "name": "...", "headers": {...} } *)
+        let name = json |> member "name" |> to_string_option
+          |> Option.value ~default:url in
+        let headers = match json |> member "headers" with
+          | `Assoc pairs ->
+              List.filter_map (fun (k, v) ->
+                match v with `String s -> Some (k, s) | _ -> None
+              ) pairs
+          | _ -> []
+        in
+        Ok (Http_mcp { url; headers; name })
+    | None ->
+        (* Stdio MCP: { "command": "...", "args": [...], ... } *)
+        let command = json |> member "command" |> to_string in
+        let args = match json |> member "args" with
+          | `List items -> List.filter_map to_string_option items
+          | _ -> []
+        in
+        let name = json |> member "name" |> to_string_option
+          |> Option.value ~default:command in
+        let env = match json |> member "env" with
+          | `List items -> List.filter_map to_string_option items
+          | _ -> []
+        in
+        Ok (Stdio_mcp { command; args; name; env })
   with Type_error (msg, _) ->
     Error (Error.Config (InvalidConfig { field = "mcp_server"; detail = msg }))
 
@@ -222,8 +243,41 @@ let resolve_provider ~model_id provider_str base_url =
           path = "/v1/chat/completions"; static_token = None };
         model_id; api_key_env = other }
 
-(** Convert a loaded config to a Builder.t. *)
-let to_builder ~net (cfg : agent_file_config) =
+(** Convert mcp_file_config to a server spec for stdio, or connect HTTP directly. *)
+let connect_mcp_server ~sw ~mgr ~net mcp_cfg =
+  match mcp_cfg with
+  | Stdio_mcp { command; args; name; env } ->
+      let env_pairs = List.filter_map (fun entry ->
+        match String.split_on_char '=' entry with
+        | k :: rest -> Some (k, String.concat "=" rest)
+        | [] -> None
+      ) env in
+      let spec : Mcp.server_spec = { command; args; env = env_pairs; name } in
+      Mcp.connect_and_load ~sw ~mgr spec
+  | Http_mcp { url; headers; name } ->
+      let spec : Mcp_http.http_spec = { base_url = url; headers; name } in
+      Mcp_http.connect_and_load_managed ~sw ~net spec
+
+(** Connect all MCP servers from config (best-effort: failures are logged,
+    not fatal). *)
+let connect_mcp_servers_best_effort ~sw ~mgr ~net mcp_cfgs =
+  List.fold_left (fun acc cfg ->
+    match connect_mcp_server ~sw ~mgr ~net cfg with
+    | Ok managed -> managed :: acc
+    | Error e ->
+        let name = match cfg with
+          | Stdio_mcp { name; _ } -> name
+          | Http_mcp { name; _ } -> name
+        in
+        Printf.eprintf "[oas] MCP server '%s' failed: %s\n%!" name (Error.to_string e);
+        acc
+  ) [] mcp_cfgs
+  |> List.rev
+
+(** Convert a loaded config to a Builder.t.
+    When [~sw] and [~mgr] are provided, MCP servers from config are connected
+    and their tools are registered.  Without them, MCP servers are skipped. *)
+let to_builder ?sw ?mgr ~net (cfg : agent_file_config) =
   let model = Model_registry.resolve_model_id cfg.model in
   let b = Builder.create ~net ~model in
   let b = Builder.with_name cfg.name b in
@@ -259,4 +313,11 @@ let to_builder ~net (cfg : agent_file_config) =
           tc.name (Yojson.Safe.to_string input) })
   ) cfg.tools in
   let b = if tools <> [] then Builder.with_tools tools b else b in
+  (* Connect MCP servers if sw+mgr provided *)
+  let b = match sw, mgr with
+    | Some sw, Some mgr when cfg.mcp_servers <> [] ->
+        let managed = connect_mcp_servers_best_effort ~sw ~mgr ~net cfg.mcp_servers in
+        if managed <> [] then Builder.with_mcp_clients managed b else b
+    | _ -> b
+  in
   b

--- a/lib/protocol/mcp.ml
+++ b/lib/protocol/mcp.ml
@@ -381,12 +381,16 @@ type server_spec = {
   name: string;
 }
 
+(** Transport backend for a managed MCP connection. *)
+type transport =
+  | Stdio of { client: t; spec: server_spec }
+  | Http of { close_fn: unit -> unit }
+
 (** A connected MCP server together with its converted SDK tools. *)
 type managed = {
-  client: t;
   tools: Tool.t list;
   name: string;
-  spec: server_spec;
+  transport: transport;
 }
 
 (** Merge extra key-value pairs into the current process environment.
@@ -405,10 +409,18 @@ let merge_env extras =
     let extra_entries = List.map (fun (k, v) -> k ^ "=" ^ v) extras in
     Array.of_list (base_filtered @ extra_entries)
 
+(** Close a single managed MCP connection (transport-aware). *)
+let close_managed m =
+  match m.transport with
+  | Stdio { client; _ } ->
+      (try close client with Eio.Io _ | Unix.Unix_error _ | Failure _ -> ())
+  | Http { close_fn; _ } ->
+      (try close_fn () with _ -> ())
+
 (** Close all managed MCP server connections.
     Exceptions from individual servers are swallowed (best-effort). *)
 let close_all managed_list =
-  List.iter (fun m -> close m.client) managed_list
+  List.iter close_managed managed_list
 
 (** Connect to an MCP server, perform the initialize handshake, fetch
     tools, and convert them to SDK [Tool.t] values.
@@ -426,7 +438,8 @@ let connect_and_load ~sw ~mgr spec =
         | Error e -> close client; Error e
         | Ok mcp_tools ->
           let tools = to_tools client mcp_tools in
-          Ok { client; tools; name = spec.name; spec }
+          Ok { tools; name = spec.name;
+               transport = Stdio { client; spec } }
     with
     | Out_of_memory -> close client; raise Out_of_memory
     | Stack_overflow -> close client; raise Stack_overflow
@@ -453,10 +466,16 @@ let connect_all ~sw ~mgr specs =
 
 (** Reconnect a managed MCP server by closing the old connection
     and starting a fresh one from its spec.
-    Returns the new managed value on success. *)
+    Returns the new managed value on success.
+    Only stdio transports can be reconnected (HTTP has no persistent spec). *)
 let reconnect ~sw ~mgr (m : managed) =
-  (try close m.client with Eio.Io _ | Unix.Unix_error _ | Failure _ -> ());
-  connect_and_load ~sw ~mgr m.spec
+  match m.transport with
+  | Stdio { client; spec } ->
+      (try close client with Eio.Io _ | Unix.Unix_error _ | Failure _ -> ());
+      connect_and_load ~sw ~mgr spec
+  | Http _ ->
+      Error (Error.Mcp (InitializeFailed {
+        detail = Printf.sprintf "Cannot reconnect HTTP MCP server '%s'" m.name }))
 
 (** Connect to multiple MCP servers, returning all that succeed.
     Failed servers are reported in the second element of the pair

--- a/lib/protocol/mcp_http.ml
+++ b/lib/protocol/mcp_http.ml
@@ -123,7 +123,7 @@ let connect ~sw:_ ~net config =
 let initialize t =
   let* result = send_request t ~method_:"initialize"
     ~params:(`Assoc [
-      ("protocolVersion", `String "2024-11-05");
+      ("protocolVersion", `String "2025-11-25");
       ("capabilities", `Assoc []);
       ("clientInfo", `Assoc [
         ("name", `String "oas-sdk");
@@ -186,7 +186,7 @@ let call_tool t ~name ~arguments =
 
 let close _t = ()
 
-(* ── Managed client ──────────────────────────────────────── *)
+(* ── Managed client (returns unified Mcp.managed) ─────────── *)
 
 type http_spec = {
   base_url: string;
@@ -194,15 +194,10 @@ type http_spec = {
   name: string;
 }
 
-type managed = {
-  client: t;
-  tools: Tool.t list;
-  name: string;
-  spec: http_spec;
-}
-
-(** Connect, initialize, load tools, and wrap as [managed]. *)
-let connect_and_load ~sw ~net (spec : http_spec) =
+(** Connect, initialize, load tools, and wrap as unified [Mcp.managed].
+    The returned managed value uses [Mcp.Http] transport. *)
+let connect_and_load_managed ~sw ~net (spec : http_spec) :
+    (Mcp.managed, Error.sdk_error) result =
   let config = {
     base_url = spec.base_url;
     headers = spec.headers;
@@ -216,4 +211,9 @@ let connect_and_load ~sw ~net (spec : http_spec) =
     Mcp.mcp_tool_to_sdk_tool mt
       ~call_fn:(fun input -> call_tool client ~name:mt.name ~arguments:input)
   ) mcp_tools in
-  Ok { client; tools; name = spec.name; spec }
+  Ok { Mcp.tools; name = spec.name;
+       transport = Http { close_fn = (fun () -> close client) } }
+
+(** @deprecated Use {!connect_and_load_managed} instead.
+    Kept for backward compatibility. *)
+let connect_and_load ~sw ~net spec = connect_and_load_managed ~sw ~net spec

--- a/lib/protocol/mcp_http.mli
+++ b/lib/protocol/mcp_http.mli
@@ -30,13 +30,12 @@ type http_spec = {
   name: string;
 }
 
-type managed = {
-  client: t;
-  tools: Tool.t list;
-  name: string;
-  spec: http_spec;
-}
+(** Connect, initialize, load tools, and return a unified [Mcp.managed]. *)
+val connect_and_load_managed :
+  sw:Eio.Switch.t -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  http_spec -> (Mcp.managed, Error.sdk_error) result
 
+(** @deprecated Alias for {!connect_and_load_managed}. *)
 val connect_and_load :
   sw:Eio.Switch.t -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
-  http_spec -> (managed, Error.sdk_error) result
+  http_spec -> (Mcp.managed, Error.sdk_error) result

--- a/lib/protocol/mcp_session.ml
+++ b/lib/protocol/mcp_session.ml
@@ -20,24 +20,31 @@
 
 open Types
 
+(** Transport kind tag for serialization. *)
+type transport_kind = Stdio | Http
+
 (** Serializable MCP session information. *)
 type info = {
   server_name: string;
-  command: string;
-  args: string list;
+  command: string;     (** For HTTP: "http"; for stdio: the executable *)
+  args: string list;   (** For HTTP: [url]; for stdio: command-line args *)
   env: (string * string) list;
   tool_schemas: tool_schema list;
+  transport_kind: transport_kind;
 }
 
 (** Capture session info from a connected managed server. *)
 let capture (m : Mcp.managed) : info =
-  {
-    server_name = m.spec.name;
-    command = m.spec.command;
-    args = m.spec.args;
-    env = m.spec.env;
-    tool_schemas = List.map (fun (t : Tool.t) -> t.schema) m.tools;
-  }
+  let tool_schemas = List.map (fun (t : Tool.t) -> t.schema) m.tools in
+  match m.transport with
+  | Mcp.Stdio { spec; _ } ->
+      { server_name = m.name; command = spec.command;
+        args = spec.args; env = spec.env;
+        tool_schemas; transport_kind = Stdio }
+  | Mcp.Http _ ->
+      { server_name = m.name; command = "http";
+        args = []; env = [];
+        tool_schemas; transport_kind = Http }
 
 (** Capture session info from all connected managed servers. *)
 let capture_all (managed_list : Mcp.managed list) : info list =
@@ -54,13 +61,21 @@ let to_server_spec (info : info) : Mcp.server_spec =
 
 (** Reconnect to MCP servers from saved session info.
     Returns a pair: (successfully connected, failed infos with error messages).
-    Failed connections do not abort the others. *)
+    Failed connections do not abort the others.
+    HTTP servers cannot be reconnected from session info alone — they are
+    reported as failed with an informational error. *)
 let reconnect_all ~sw ~mgr (infos : info list) : Mcp.managed list * (info * Error.sdk_error) list =
   List.fold_left (fun (connected, failed) info ->
-    let spec = to_server_spec info in
-    match Mcp.connect_and_load ~sw ~mgr spec with
-    | Ok m -> (m :: connected, failed)
-    | Error e -> (connected, (info, e) :: failed)
+    match info.transport_kind with
+    | Http ->
+        let e = Error.Mcp (InitializeFailed {
+          detail = Printf.sprintf "HTTP MCP server '%s' cannot be reconnected from session" info.server_name }) in
+        (connected, (info, e) :: failed)
+    | Stdio ->
+        let spec = to_server_spec info in
+        (match Mcp.connect_and_load ~sw ~mgr spec with
+         | Ok m -> (m :: connected, failed)
+         | Error e -> (connected, (info, e) :: failed))
   ) ([], []) infos
   |> fun (connected, failed) -> (List.rev connected, List.rev failed)
 
@@ -132,6 +147,14 @@ let tool_schema_of_json json =
 
 (* ── info JSON ─────────────────────────────────────────────────── *)
 
+let transport_kind_to_string = function
+  | Stdio -> "stdio"
+  | Http -> "http"
+
+let transport_kind_of_string = function
+  | "http" -> Http
+  | _ -> Stdio  (* default to stdio for backward compat *)
+
 let info_to_json (info : info) : Yojson.Safe.t =
   `Assoc [
     ("server_name", `String info.server_name);
@@ -139,6 +162,7 @@ let info_to_json (info : info) : Yojson.Safe.t =
     ("args", `List (List.map (fun s -> `String s) info.args));
     ("env", `List (List.map env_pair_to_json info.env));
     ("tool_schemas", `List (List.map tool_schema_to_json info.tool_schemas));
+    ("transport_kind", `String (transport_kind_to_string info.transport_kind));
   ]
 
 let info_of_json json : (info, Error.sdk_error) result =
@@ -154,12 +178,18 @@ let info_of_json json : (info, Error.sdk_error) result =
     in
     match env_result, tools_result with
     | Ok env, Ok tool_schemas ->
+      let transport_kind =
+        json |> member "transport_kind" |> to_string_option
+        |> Option.value ~default:"stdio"
+        |> transport_kind_of_string
+      in
       Ok {
         server_name = json |> member "server_name" |> to_string;
         command = json |> member "command" |> to_string;
         args = json |> member "args" |> to_list |> List.map to_string;
         env;
         tool_schemas;
+        transport_kind;
       }
     | Error e, _ -> Error e
     | _, Error e -> Error e

--- a/lib/protocol/mcp_session.mli
+++ b/lib/protocol/mcp_session.mli
@@ -5,12 +5,15 @@
 
 open Types
 
+type transport_kind = Stdio | Http
+
 type info = {
   server_name: string;
   command: string;
   args: string list;
   env: (string * string) list;
   tool_schemas: tool_schema list;
+  transport_kind: transport_kind;
 }
 
 val capture : Mcp.managed -> info

--- a/test/test_agent_config.ml
+++ b/test/test_agent_config.ml
@@ -59,9 +59,12 @@ let test_full_config () =
     check string "tool name" "get_weather" tool.name;
     check int "tool params" 1 (List.length tool.parameters);
     check int "mcp" 1 (List.length cfg.mcp_servers);
-    let mcp = List.hd cfg.mcp_servers in
-    check string "mcp command" "npx" mcp.command;
-    check string "mcp name" "my-server" mcp.name
+    (match List.hd cfg.mcp_servers with
+     | Agent_config.Stdio_mcp { command; name; _ } ->
+         check string "mcp command" "npx" command;
+         check string "mcp name" "my-server" name
+     | Agent_config.Http_mcp _ ->
+         fail "expected Stdio_mcp")
   | Error e -> fail (Error.to_string e)
 
 let test_defaults () =
@@ -182,10 +185,13 @@ let test_mcp_defaults () =
   match Agent_config.of_json json with
   | Ok cfg ->
     check int "1 mcp" 1 (List.length cfg.mcp_servers);
-    let mcp = List.hd cfg.mcp_servers in
-    check string "name defaults to command" "node" mcp.name;
-    check (list string) "empty args" [] mcp.args;
-    check (list string) "empty env" [] mcp.env
+    (match List.hd cfg.mcp_servers with
+     | Agent_config.Stdio_mcp { name; args; env; _ } ->
+         check string "name defaults to command" "node" name;
+         check (list string) "empty args" [] args;
+         check (list string) "empty env" [] env
+     | Agent_config.Http_mcp _ ->
+         fail "expected Stdio_mcp")
   | Error e -> fail (Error.to_string e)
 
 let test_mcp_with_env () =
@@ -202,9 +208,12 @@ let test_mcp_with_env () =
   ] in
   match Agent_config.of_json json with
   | Ok cfg ->
-    let mcp = List.hd cfg.mcp_servers in
-    check (list string) "env" ["NODE_ENV=production"] mcp.env;
-    check (list string) "args" ["server.js"] mcp.args
+    (match List.hd cfg.mcp_servers with
+     | Agent_config.Stdio_mcp { env; args; _ } ->
+         check (list string) "env" ["NODE_ENV=production"] env;
+         check (list string) "args" ["server.js"] args
+     | Agent_config.Http_mcp _ ->
+         fail "expected Stdio_mcp")
   | Error e -> fail (Error.to_string e)
 
 (* ── parse_tool: param type mapping ──────────────────── *)
@@ -244,6 +253,82 @@ let test_tool_no_params () =
     check int "no params" 0 (List.length tool.parameters)
   | Error e -> fail (Error.to_string e)
 
+(* ── HTTP MCP parsing ──────────────────────────────────── *)
+
+let test_http_mcp_config () =
+  let json = `Assoc [
+    ("name", `String "test");
+    ("mcp_servers", `List [
+      `Assoc [
+        ("url", `String "http://localhost:8935/mcp");
+        ("name", `String "masc");
+        ("headers", `Assoc [("Authorization", `String "Bearer tok")]);
+      ]
+    ]);
+  ] in
+  match Agent_config.of_json json with
+  | Ok cfg ->
+    check int "1 mcp" 1 (List.length cfg.mcp_servers);
+    (match List.hd cfg.mcp_servers with
+     | Agent_config.Http_mcp { url; name; headers } ->
+         check string "url" "http://localhost:8935/mcp" url;
+         check string "name" "masc" name;
+         check int "1 header" 1 (List.length headers);
+         let (hk, hv) = List.hd headers in
+         check string "header key" "Authorization" hk;
+         check string "header val" "Bearer tok" hv
+     | Agent_config.Stdio_mcp _ ->
+         fail "expected Http_mcp")
+  | Error e -> fail (Error.to_string e)
+
+let test_http_mcp_defaults () =
+  let json = `Assoc [
+    ("name", `String "test");
+    ("mcp_servers", `List [
+      `Assoc [
+        ("url", `String "http://example.com/mcp");
+      ]
+    ]);
+  ] in
+  match Agent_config.of_json json with
+  | Ok cfg ->
+    (match List.hd cfg.mcp_servers with
+     | Agent_config.Http_mcp { url; name; headers } ->
+         check string "url" "http://example.com/mcp" url;
+         check string "name defaults to url" "http://example.com/mcp" name;
+         check (list (pair string string)) "no headers" [] headers
+     | Agent_config.Stdio_mcp _ ->
+         fail "expected Http_mcp")
+  | Error e -> fail (Error.to_string e)
+
+let test_mixed_mcp_config () =
+  let json = `Assoc [
+    ("name", `String "test");
+    ("mcp_servers", `List [
+      `Assoc [
+        ("command", `String "npx");
+        ("args", `List [`String "-y"; `String "server"]);
+        ("name", `String "stdio-server");
+      ];
+      `Assoc [
+        ("url", `String "http://localhost:8080/mcp");
+        ("name", `String "http-server");
+      ];
+    ]);
+  ] in
+  match Agent_config.of_json json with
+  | Ok cfg ->
+    check int "2 mcp servers" 2 (List.length cfg.mcp_servers);
+    (match List.nth cfg.mcp_servers 0 with
+     | Agent_config.Stdio_mcp { name; _ } ->
+         check string "first is stdio" "stdio-server" name
+     | _ -> fail "expected Stdio_mcp first");
+    (match List.nth cfg.mcp_servers 1 with
+     | Agent_config.Http_mcp { name; _ } ->
+         check string "second is http" "http-server" name
+     | _ -> fail "expected Http_mcp second")
+  | Error e -> fail (Error.to_string e)
+
 (* ── Suite ──────────────────────────────────────────────── *)
 
 let () =
@@ -256,6 +341,9 @@ let () =
       test_case "mcp with env" `Quick test_mcp_with_env;
       test_case "tool param types" `Quick test_tool_param_types;
       test_case "tool no params" `Quick test_tool_no_params;
+      test_case "http mcp" `Quick test_http_mcp_config;
+      test_case "http mcp defaults" `Quick test_http_mcp_defaults;
+      test_case "mixed mcp" `Quick test_mixed_mcp_config;
     ];
     "load", [
       test_case "nonexistent" `Quick test_load_nonexistent;

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -591,6 +591,7 @@ let () =
           args = ["--port"; "8080"];
           env = [("API_KEY", "secret123")];
           tool_schemas = [sample_tool_schema];
+          transport_kind = Stdio;
         } in
         let cp = make_checkpoint ~mcp_sessions:[info] () in
         let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
@@ -609,11 +610,13 @@ let () =
           server_name = "server-a";
           command = "mcp-a"; args = []; env = [];
           tool_schemas = [];
+          transport_kind = Stdio;
         } in
         let info2 : Mcp_session.info = {
           server_name = "server-b";
           command = "mcp-b"; args = ["--verbose"]; env = [("X", "1")];
           tool_schemas = [sample_tool_schema];
+          transport_kind = Stdio;
         } in
         let cp = make_checkpoint ~mcp_sessions:[info1; info2] () in
         let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in

--- a/test/test_mcp_http.ml
+++ b/test/test_mcp_http.ml
@@ -107,6 +107,60 @@ let test_http_transport_error () =
     (Error.is_retryable (Error.Mcp (ServerStartFailed { command = "x"; detail = "y" })));
   check bool "http transport is retryable" true (Error.is_retryable err)
 
+(* ── Managed type integration ──────────────────────────── *)
+
+let test_connect_and_load_returns_mcp_managed () =
+  (* connect_and_load_managed should return Mcp.managed (not Mcp_http.managed).
+     We test the type system guarantees by assigning to Mcp.managed. *)
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  Eio.Switch.run @@ fun sw ->
+  let spec : Mcp_http.http_spec = {
+    base_url = "http://127.0.0.1:19999";
+    headers = [("X-Custom", "test")];
+    name = "typed-test";
+  } in
+  let result : (Mcp.managed, Error.sdk_error) result =
+    Mcp_http.connect_and_load_managed ~sw ~net spec
+  in
+  match result with
+  | Error _ -> ()  (* expected — unreachable, but type check passes *)
+  | Ok managed ->
+      check string "name" "typed-test" managed.name;
+      (match managed.transport with
+       | Mcp.Http _ -> ()
+       | Mcp.Stdio _ -> fail "expected Http transport")
+
+let test_session_transport_kind () =
+  (* Verify that transport_kind roundtrips through JSON *)
+  let info : Mcp_session.info = {
+    server_name = "http-srv";
+    command = "http";
+    args = [];
+    env = [];
+    tool_schemas = [];
+    transport_kind = Http;
+  } in
+  let json = Mcp_session.info_to_json info in
+  let info2 = Result.get_ok (Mcp_session.info_of_json json) in
+  check bool "transport_kind is Http" true
+    (info2.transport_kind = Mcp_session.Http);
+  check string "command" "http" info2.command
+
+let test_session_transport_kind_stdio_default () =
+  (* Old JSON without transport_kind should default to Stdio *)
+  let json = `Assoc [
+    ("server_name", `String "old-srv");
+    ("command", `String "cmd");
+    ("args", `List []);
+    ("env", `List []);
+    ("tool_schemas", `List []);
+    (* no transport_kind field *)
+  ] in
+  let info = Result.get_ok (Mcp_session.info_of_json json) in
+  check bool "defaults to Stdio" true
+    (info.transport_kind = Mcp_session.Stdio)
+
 (* ── Suite ──────────────────────────────────────────────── *)
 
 let () =
@@ -121,8 +175,13 @@ let () =
       test_case "call_tool unreachable" `Quick test_call_tool_unreachable;
       test_case "close safe" `Quick test_close_safe;
       test_case "connect_and_load unreachable" `Quick test_connect_and_load_unreachable;
+      test_case "connect_and_load returns Mcp.managed" `Quick test_connect_and_load_returns_mcp_managed;
     ];
     "errors", [
       test_case "http transport error" `Quick test_http_transport_error;
+    ];
+    "session", [
+      test_case "transport_kind roundtrip" `Quick test_session_transport_kind;
+      test_case "transport_kind default stdio" `Quick test_session_transport_kind_stdio_default;
     ];
   ]

--- a/test/test_mcp_session.ml
+++ b/test/test_mcp_session.ml
@@ -29,7 +29,8 @@ let make_info
     ?(env=[])
     ?(tool_schemas=[])
     () : Mcp_session.info =
-  { server_name; command; args; env; tool_schemas }
+  { server_name; command; args; env; tool_schemas;
+    transport_kind = Stdio }
 
 let () =
   let open Alcotest in


### PR DESCRIPTION
## Summary

- `Mcp.managed`에 `transport` variant(`Stdio | Http`) 도입하여 stdio/HTTP MCP 서버를 단일 타입으로 통합
- `Agent_config.to_builder`에 optional `~sw ~mgr` 파라미터 추가 — MCP 서버를 best-effort로 연결하고 도구 자동 발견
- `agent.json`에서 `"url"` 키 존재 여부로 stdio/HTTP MCP 자동 판별

## Changes

| File | Change |
|------|--------|
| `lib/protocol/mcp.ml` | `managed.transport` variant, `close_managed`, reconnect 분기 |
| `lib/protocol/mcp_http.ml` | `connect_and_load_managed` → `Mcp.managed` 반환, protocol 2025-11-25 |
| `lib/protocol/mcp_session.ml` | `transport_kind` 필드 추가, HTTP session capture |
| `lib/agent/agent_config.ml` | `Stdio_mcp | Http_mcp` variant, `to_builder` MCP 연결 |
| `bin/oas_cli.ml` | `run_cmd`에 `~sw ~mgr` 전달 |

## Config Example

```json
{
  "mcp_servers": [
    { "command": "npx", "args": ["-y", "server"], "name": "stdio-srv" },
    { "url": "http://localhost:8935/mcp", "name": "http-srv" }
  ]
}
```

## Test plan

- [x] `dune build --root .` 통과
- [x] `dune runtest --root .` 전체 통과 (exit 0)
- [x] HTTP MCP 파싱 테스트 3종 추가 (http_mcp, http_mcp_defaults, mixed_mcp)
- [x] transport_kind 직렬화 roundtrip 테스트
- [x] 기존 stdio 테스트 하위 호환 유지
- [ ] 라이브 테스트: `oas run --config agent.json "prompt"` with HTTP MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)