### PR TITLE
refactor: Collaboration.t — vote → generic contribution

### DIFF
--- a/lib/collaboration.ml
+++ b/lib/collaboration.ml
@@ -38,11 +38,11 @@ type artifact = {
 }
 [@@deriving yojson, show]
 
-type vote = {
-  topic: string;
-  choice: string;
-  voter: string;
-  cast_at: float;
+type contribution = {
+  agent: string;
+  kind: string;
+  content: string;
+  created_at: float;
 }
 [@@deriving yojson, show]
 
@@ -52,7 +52,7 @@ type t = {
   phase: phase;
   participants: participant list;
   artifacts: artifact list;
-  votes: vote list;
+  contributions: contribution list;
   shared_context: Context.t;
   created_at: float;
   updated_at: float;
@@ -79,7 +79,7 @@ let create ?id ?shared_context ~goal () =
     phase = Bootstrapping;
     participants = [];
     artifacts = [];
-    votes = [];
+    contributions = [];
     shared_context = Option.value shared_context ~default:(Context.create ());
     created_at = now;
     updated_at = now;
@@ -122,13 +122,13 @@ let active_participants t =
     | _ -> false
   ) t.participants
 
-(* --- Artifact and vote operations --- *)
+(* --- Artifact and contribution operations --- *)
 
 let add_artifact t a =
   { t with artifacts = t.artifacts @ [a] } |> touch
 
-let cast_vote t v =
-  { t with votes = t.votes @ [v] } |> touch
+let add_contribution t c =
+  { t with contributions = t.contributions @ [c] } |> touch
 
 (* --- Phase and outcome --- *)
 
@@ -152,7 +152,7 @@ let to_json t =
     ("phase", phase_to_yojson t.phase);
     ("participants", `List (List.map participant_to_yojson t.participants));
     ("artifacts", `List (List.map artifact_to_yojson t.artifacts));
-    ("votes", `List (List.map vote_to_yojson t.votes));
+    ("contributions", `List (List.map contribution_to_yojson t.contributions));
     ("shared_context", Context.to_json t.shared_context);
     ("created_at", `Float t.created_at);
     ("updated_at", `Float t.updated_at);
@@ -194,8 +194,30 @@ let of_json json =
         parse_list participant_of_yojson (json |> member "participants");
       artifacts =
         parse_list artifact_of_yojson (json |> member "artifacts");
-      votes =
-        parse_list vote_of_yojson (json |> member "votes");
+      contributions =
+        (match json |> member "contributions" with
+         | `Null ->
+           (* Backward compat: parse legacy "votes" key as contributions *)
+           (match json |> member "votes" with
+            | `Null -> []
+            | `List votes_json ->
+              List.map (fun vj ->
+                let topic =
+                  (try to_string (vj |> member "topic") with _ -> "") in
+                let choice =
+                  (try to_string (vj |> member "choice") with _ -> "") in
+                let voter =
+                  (try to_string (vj |> member "voter") with _ -> "anonymous") in
+                let cast_at =
+                  (try to_float (vj |> member "cast_at") with _ -> 0.0) in
+                { agent = voter;
+                  kind = "vote";
+                  content = topic ^ ": " ^ choice;
+                  created_at = cast_at; }
+              ) votes_json
+            | _ -> [])
+         | contributions_json ->
+           parse_list contribution_of_yojson contributions_json);
       shared_context;
       created_at = json |> member "created_at" |> to_float;
       updated_at = json |> member "updated_at" |> to_float;

--- a/lib/collaboration.mli
+++ b/lib/collaboration.mli
@@ -39,7 +39,7 @@ type participant = {
 }
 [@@deriving yojson, show]
 
-(** {1 Artifacts and votes} *)
+(** {1 Artifacts and contributions} *)
 
 type artifact = {
   id: string;
@@ -50,11 +50,22 @@ type artifact = {
 }
 [@@deriving yojson, show]
 
-type vote = {
-  topic: string;
-  choice: string;
-  voter: string;
-  cast_at: float;
+(** Generic contribution record.
+
+    Replaces the domain-specific [vote] type.  Agent state (participants,
+    phase, contributions) belongs in OAS; domain-specific semantics
+    (governance votes, rulings) belong to consumers such as MASC.
+
+    The [kind] field distinguishes contribution types:
+    - ["vote"]   — a governance decision
+    - ["review"] — a code/artifact review
+    - ["idea"]   — a suggestion or proposal
+    - any other consumer-defined string *)
+type contribution = {
+  agent: string;
+  kind: string;
+  content: string;
+  created_at: float;
 }
 [@@deriving yojson, show]
 
@@ -70,7 +81,7 @@ type t = {
   phase: phase;
   participants: participant list;
   artifacts: artifact list;
-  votes: vote list;
+  contributions: contribution list;
   shared_context: Context.t;
   created_at: float;
   updated_at: float;
@@ -97,10 +108,10 @@ val remove_participant : t -> string -> t
 val find_participant : t -> string -> participant option
 val active_participants : t -> participant list
 
-(** {1 Artifact and vote operations} *)
+(** {1 Artifact and contribution operations} *)
 
 val add_artifact : t -> artifact -> t
-val cast_vote : t -> vote -> t
+val add_contribution : t -> contribution -> t
 
 (** {1 Phase and outcome} *)
 

--- a/lib/runtime_projection.ml
+++ b/lib/runtime_projection.ml
@@ -491,12 +491,12 @@ let artifact_to_collaboration (a : artifact) : Collaboration.artifact =
     created_at = a.created_at;
   }
 
-let vote_to_collaboration (v : vote) : Collaboration.vote =
+let contribution_of_runtime_vote (v : vote) : Collaboration.contribution =
   {
-    topic = v.topic;
-    choice = v.choice;
-    voter = Option.value v.actor ~default:"anonymous";
-    cast_at = v.created_at;
+    agent = Option.value v.actor ~default:"anonymous";
+    kind = "vote";
+    content = v.topic ^ ": " ^ v.choice;
+    created_at = v.created_at;
   }
 
 (** Extract a {!Collaboration.t} from a {!Runtime.session}.
@@ -513,7 +513,7 @@ let collaboration_of_session (session : session) : Collaboration.t =
     participants =
       List.map participant_to_collaboration session.participants;
     artifacts = List.map artifact_to_collaboration session.artifacts;
-    votes = List.map vote_to_collaboration session.votes;
+    contributions = List.map contribution_of_runtime_vote session.votes;
     shared_context = Context.create ();
     created_at = session.created_at;
     updated_at = session.updated_at;
@@ -525,7 +525,7 @@ let collaboration_of_session (session : session) : Collaboration.t =
 (** Sync collaboration-owned fields back into a {!Runtime.session}.
 
     Only updates: [goal], [phase], [outcome], [updated_at].
-    Does {b not} touch [participants], [artifacts], or [votes]
+    Does {b not} touch [participants], [artifacts], or [contributions]
     because Runtime versions of these carry richer data (21-field
     participant vs 6-field).  Use per-field update functions for those. *)
 let update_session_from_collaboration

--- a/test/test_collaboration.ml
+++ b/test/test_collaboration.ml
@@ -124,7 +124,7 @@ let () =
         check int "active count" 2 (List.length active));
     ];
 
-    "artifacts_votes", [
+    "artifacts_contributions", [
       test_case "add artifact" `Quick (fun () ->
         let c = Collaboration.create ~goal:"test" () in
         let a = Collaboration.{
@@ -135,15 +135,15 @@ let () =
         check int "count" 1 (List.length c.artifacts);
         check string "name" "report" (List.hd c.artifacts).name);
 
-      test_case "cast vote" `Quick (fun () ->
+      test_case "add contribution" `Quick (fun () ->
         let c = Collaboration.create ~goal:"test" () in
         let v = Collaboration.{
-          topic = "merge?"; choice = "yes";
-          voter = "bob"; cast_at = 2.0;
+          agent = "bob"; kind = "vote";
+          content = "merge?: yes"; created_at = 2.0;
         } in
-        let c = Collaboration.cast_vote c v in
-        check int "count" 1 (List.length c.votes);
-        check string "choice" "yes" (List.hd c.votes).choice);
+        let c = Collaboration.add_contribution c v in
+        check int "count" 1 (List.length c.contributions);
+        check string "content" "merge?: yes" (List.hd c.contributions).content);
     ];
 
     "phase_lifecycle", [
@@ -225,24 +225,24 @@ let () =
         check (option string) "role" (Some "reviewer") p2.role;
         check bool "state" true (p2.state = Collaboration.Working));
 
-      test_case "roundtrip with artifacts and votes" `Quick (fun () ->
-        let c = Collaboration.create ~id:"rt-3" ~goal:"vote" () in
+      test_case "roundtrip with artifacts and contributions" `Quick (fun () ->
+        let c = Collaboration.create ~id:"rt-3" ~goal:"contrib" () in
         let a = Collaboration.{
           id = "a1"; name = "patch"; kind = "code";
           producer = "frank"; created_at = 50.0;
         } in
         let v = Collaboration.{
-          topic = "approve?"; choice = "lgtm";
-          voter = "grace"; cast_at = 60.0;
+          agent = "grace"; kind = "review";
+          content = "lgtm"; created_at = 60.0;
         } in
         let c = Collaboration.add_artifact c a in
-        let c = Collaboration.cast_vote c v in
+        let c = Collaboration.add_contribution c v in
         let json = Collaboration.to_json c in
         let c2 = Result.get_ok (Collaboration.of_json json) in
         check int "artifacts" 1 (List.length c2.artifacts);
-        check int "votes" 1 (List.length c2.votes);
+        check int "contributions" 1 (List.length c2.contributions);
         check string "artifact name" "patch" (List.hd c2.artifacts).name;
-        check string "vote choice" "lgtm" (List.hd c2.votes).choice);
+        check string "contribution content" "lgtm" (List.hd c2.contributions).content);
 
       test_case "roundtrip with metadata" `Quick (fun () ->
         let c = Collaboration.create ~id:"rt-4" ~goal:"meta" () in

--- a/test/test_collaboration_bridge.ml
+++ b/test/test_collaboration_bridge.ml
@@ -136,7 +136,7 @@ let () =
         ) pairs);
     ];
 
-    "artifact_vote_projection", [
+    "artifact_contribution_projection", [
       test_case "artifact projection" `Quick (fun () ->
         let session = {
           Runtime.session_id = "s5"; goal = "g"; title = None;
@@ -162,7 +162,7 @@ let () =
         check string "kind" "document" a.kind;
         check string "producer is empty (lossy)" "" a.producer);
 
-      test_case "vote projection" `Quick (fun () ->
+      test_case "vote projects as contribution" `Quick (fun () ->
         let session = {
           Runtime.session_id = "s6"; goal = "g"; title = None;
           tag = None; permission_mode = None; phase = Completed;
@@ -177,11 +177,11 @@ let () =
           turn_count = 0; last_seq = 0; outcome = None;
         } in
         let collab = Runtime_projection.collaboration_of_session session in
-        check int "1 vote" 1 (List.length collab.votes);
-        let v = List.hd collab.votes in
-        check string "topic" "merge?" v.topic;
-        check string "choice" "yes" v.choice;
-        check string "voter" "bob" v.voter);
+        check int "1 contribution" 1 (List.length collab.contributions);
+        let c = List.hd collab.contributions in
+        check string "agent" "bob" c.agent;
+        check string "kind" "vote" c.kind;
+        check string "content" "merge?: yes" c.content);
 
       test_case "vote with no actor defaults to anonymous" `Quick (fun () ->
         let session = {
@@ -198,7 +198,7 @@ let () =
           turn_count = 0; last_seq = 0; outcome = None;
         } in
         let collab = Runtime_projection.collaboration_of_session session in
-        check string "voter" "anonymous" (List.hd collab.votes).voter);
+        check string "agent" "anonymous" (List.hd collab.contributions).agent);
     ];
 
     "collaboration_of_session", [


### PR DESCRIPTION
## Summary

도메인 개념(vote)을 범용 개념(contribution)으로 일반화.

OAS Collaboration은 에이전트 조율 메커니즘. 투표/리뷰/아이디어 같은 도메인 해석은 consumer(MASC 등)가 담당.

### Changes
- `vote { topic; choice; voter; cast_at }` → `contribution { agent; kind; content; created_at }`
- `cast_vote` → `add_contribution`
- JSON backward compat: `"votes"` key도 파싱 (legacy migration)
- `Runtime.vote` wire type 유지 (별도 마이그레이션)

5 files, +84/-51. 88 tests pass.

Closes #218
Ref: jeong-sik/masc-mcp#1736

🤖 Generated with [Claude Code](https://claude.com/claude-code)