### PR TITLE
fix: remove duplicate dune/builder entries from merge

### DIFF
--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -126,7 +126,6 @@ let with_max_total_tokens n b = { b with max_total_tokens = Some n }
 let with_initial_messages msgs b = { b with initial_messages = msgs }
 let with_response_format_json v b = { b with response_format_json = v }
 let with_cache_system_prompt v b = { b with cache_system_prompt = v }
-let with_initial_messages msgs b = { b with initial_messages = msgs }
 let with_event_bus bus b = { b with event_bus = Some bus }
 let with_cascade cascade b = { b with cascade = Some cascade }
 let with_max_idle_turns n b = { b with max_idle_turns = n }

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -28,7 +28,6 @@ val with_max_total_tokens : int -> t -> t
 val with_initial_messages : Types.message list -> t -> t
 val with_response_format_json : bool -> t -> t
 val with_cache_system_prompt : bool -> t -> t
-val with_initial_messages : Types.message list -> t -> t
 
 (** {2 Tools and MCP} *)
 

--- a/test/dune
+++ b/test/dune
@@ -408,7 +408,3 @@
 (test
  (name test_cascade_config)
  (libraries llm_provider alcotest yojson unix eio eio_main))
-
-(test
- (name test_initial_messages)
- (libraries agent_sdk alcotest yojson eio eio_main))


### PR DESCRIPTION
## Summary
- Remove duplicate `test_initial_messages` test stanza in `test/dune`
- Remove duplicate `with_initial_messages` in `builder.ml` and `builder.mli`
- Caused by merge conflict in #219/#221

Blocks `opam install agent_sdk` for all downstream consumers (masc-mcp CI).

## Test plan
- [x] `dune build --root .` passes
- [ ] `opam install agent_sdk` succeeds

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>