### PR TITLE
feat: add .mli API contracts for runtime_projection, transport

### DIFF
--- a/lib/runtime_projection.mli
+++ b/lib/runtime_projection.mli
@@ -1,0 +1,48 @@
+(** Runtime session state machine and collaboration bridge.
+
+    Provides the core event-sourcing logic for {!Runtime.session}:
+    create sessions, apply events to evolve state, and generate
+    reports/proofs.
+
+    Also provides lossy projections between {!Runtime.session} (18 fields)
+    and {!Collaboration.t} (12 fields) for the ongoing migration. *)
+
+(** {1 Session lifecycle} *)
+
+(** Create an initial session from a start request.
+    Sets phase to [Bootstrapping], turn count to 0, and
+    initialises participants as [Planned]. *)
+val initial_session : Runtime.start_request -> Runtime.session
+
+(** Apply a single event to a session, evolving its state.
+    Returns [Error] if the session is in a terminal phase
+    ([Completed], [Failed], [Cancelled]) when a non-terminal
+    event is applied. *)
+val apply_event :
+  Runtime.session -> Runtime.event -> (Runtime.session, Error.sdk_error) result
+
+(** {1 Reporting and proofs} *)
+
+(** Build a human-readable report from a session and its event trace. *)
+val build_report : Runtime.session -> Runtime.event list -> Runtime.report
+
+(** Build a machine-verifiable proof from a session and its event trace.
+    Checks: session started, turn recorded, participant outcome,
+    terminal phase/event, sequence contiguity, artifact ID uniqueness. *)
+val build_proof : Runtime.session -> Runtime.event list -> Runtime.proof
+
+(** {1 Collaboration bridge}
+
+    Lossy projections between {!Runtime.session} and {!Collaboration.t}.
+    [Runtime.participant] (21 fields) compresses to
+    [Collaboration.participant] (6 fields). *)
+
+(** Extract a {!Collaboration.t} from a {!Runtime.session}.
+    [shared_context] is set to a fresh empty context. *)
+val collaboration_of_session : Runtime.session -> Collaboration.t
+
+(** Sync collaboration-owned fields back into a {!Runtime.session}.
+    Only updates [goal], [phase], [outcome], [updated_at].
+    Does {b not} touch [participants], [artifacts], or [contributions]. *)
+val update_session_from_collaboration :
+  Runtime.session -> Collaboration.t -> Runtime.session

--- a/lib/transport.mli
+++ b/lib/transport.mli
@@ -1,0 +1,63 @@
+(** IPC transport for oas_runtime using Eio structured concurrency.
+
+    Spawns an oas_runtime subprocess, communicates via NDJSON over
+    stdin/stdout pipes, and coordinates responses via [Eio.Promise].
+
+    All mutable state is protected by [Eio.Mutex]. *)
+
+(** {1 Configuration} *)
+
+type options = {
+  runtime_path: string option;
+  session_root: string option;
+  provider: string option;
+  model: string option;
+  permission_mode: string option;
+  include_partial_messages: bool;
+  setting_sources: string list;
+  resume_session: string option;
+  cwd: string option;
+}
+
+val default_options : options
+
+(** {1 Callback types} *)
+
+type control_handler =
+  Runtime.control_request -> (Runtime.control_response, Error.sdk_error) result
+
+type event_handler = Runtime.event -> unit
+
+(** {1 Transport handle} *)
+
+(** An opaque transport connection to an oas_runtime subprocess. *)
+type t
+
+(** {1 Lifecycle} *)
+
+(** Spawn a runtime subprocess and establish the NDJSON transport.
+    Performs the Initialize handshake and verifies protocol version. *)
+val connect :
+  sw:Eio.Switch.t ->
+  mgr:_ Eio.Process.mgr ->
+  ?options:options ->
+  unit ->
+  (t, Error.sdk_error) result
+
+(** Send a request and await the response.
+    Optionally sets control and event handlers for the duration. *)
+val request :
+  ?control_handler:control_handler ->
+  ?event_handler:event_handler ->
+  t ->
+  Runtime.request ->
+  (Runtime.response, Error.sdk_error) result
+
+(** Query connection status. *)
+val status : t -> [ `Connected | `Disconnected | `Error of string ]
+
+(** Gracefully shut down the transport: send Shutdown, then SIGTERM. *)
+val close : t -> unit
+
+(** Return the init response received during [connect], if available. *)
+val server_info : t -> Runtime.init_response option


### PR DESCRIPTION
## Summary
- Add `.mli` API contracts for 4 core modules (Phase 1 Tier 1, batch 1)
- `runtime.mli`: wire protocol types — all types + JSON helpers exposed
- `runtime_projection.mli`: session state machine + collaboration bridge — 12 internal helpers hidden, 6 public functions exposed
- `context_reducer.mli`: message windowing strategies — abstract `apply_*` functions, expose convenience constructors
- `transport.mli`: IPC transport — `type t` made abstract, internal state fully encapsulated
- Sync `test_initial_messages.ml` from main to fix worktree divergence

## Context
OAS has 126 `.ml` files but only 53 `.mli` files (42% coverage). This PR starts a systematic effort to reach 70%+ `.mli` coverage, beginning with the highest-LOC modules.

## Test plan
- [x] `dune build --root .` passes
- [x] `dune runtest --root .` passes (7/7 tests)
- [x] No API surface changes — .mli matches existing public usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)