### PR TITLE
refactor: narrow catch-all exception handlers to specific types

### DIFF
--- a/lib/async_agent.ml
+++ b/lib/async_agent.ml
@@ -45,6 +45,9 @@ let spawn ~sw ?clock agent prompt =
       with
       | Cancelled -> Error (Error.Internal "cancelled")
       | Raw_trace.Trace_error e -> Error e
+      | Out_of_memory -> raise Out_of_memory
+      | Stack_overflow -> raise Stack_overflow
+      | Sys.Break -> raise Sys.Break
       | exn -> Error (Error.Internal (Printexc.to_string exn))
     in
     resolve_once future result);
@@ -89,6 +92,9 @@ let race ~sw ?clock agents =
             try Agent.run ~sw ?clock agent prompt
             with
             | Raw_trace.Trace_error e -> Error e
+            | Out_of_memory -> raise Out_of_memory
+            | Stack_overflow -> raise Stack_overflow
+            | Sys.Break -> raise Sys.Break
             | exn -> Error (Error.Internal (Printexc.to_string exn))
           in
           (name, result))

--- a/lib/checkpoint.ml
+++ b/lib/checkpoint.ml
@@ -143,8 +143,10 @@ let content_block_of_json_strict json =
   with
   | Yojson.Safe.Util.Type_error (msg, _) ->
       Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Invalid content block: %s" msg }))
-  | exn ->
-      Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Invalid content block: %s" (Printexc.to_string exn) }))
+  | Yojson.Json_error msg ->
+      Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Invalid content block: %s" msg }))
+  | Failure msg ->
+      Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Invalid content block: %s" msg }))
 
 let message_of_json json =
   let open Yojson.Safe.Util in
@@ -285,8 +287,10 @@ let of_json json =
   with
   | Yojson.Safe.Util.Type_error (msg, _) ->
     Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Checkpoint.of_json: %s" msg }))
-  | exn ->
-    Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Checkpoint.of_json: %s" (Printexc.to_string exn) }))
+  | Yojson.Json_error msg ->
+    Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Checkpoint.of_json: %s" msg }))
+  | Failure msg ->
+    Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Checkpoint.of_json: %s" msg }))
 
 let to_string cp =
   to_json cp |> Yojson.Safe.to_string

--- a/lib/collaboration.ml
+++ b/lib/collaboration.ml
@@ -230,7 +230,11 @@ let of_json json =
   | Yojson.Safe.Util.Type_error (msg, _) ->
     Error (Error.Serialization
       (JsonParseError { detail = "Collaboration.of_json: " ^ msg }))
-  | exn ->
+  | Yojson.Json_error msg ->
     Error (Error.Serialization
       (JsonParseError
-        { detail = "Collaboration.of_json: " ^ Printexc.to_string exn }))
+        { detail = "Collaboration.of_json: " ^ msg }))
+  | Failure msg ->
+    Error (Error.Serialization
+      (JsonParseError
+        { detail = "Collaboration.of_json: " ^ msg }))

--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -177,7 +177,8 @@ let load_json path =
     | Sys_error msg -> Error msg
     | Unix.Unix_error (err, fn, arg) ->
       Error (Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err))
-    | exn -> Error (Printexc.to_string exn))
+    | Yojson.Json_error msg -> Error (Printf.sprintf "JSON error: %s" msg)
+    | End_of_file -> Error "unexpected end of file")
 
 let load_profile ~config_path ~name =
   let key = name ^ "_models" in

--- a/lib/protocol/mcp_session.ml
+++ b/lib/protocol/mcp_session.ml
@@ -196,8 +196,10 @@ let info_of_json json : (info, Error.sdk_error) result =
   with
   | Yojson.Safe.Util.Type_error (msg, _) ->
     Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Mcp_session.info_of_json: %s" msg }))
-  | exn ->
-    Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Mcp_session.info_of_json: %s" (Printexc.to_string exn) }))
+  | Yojson.Json_error msg ->
+    Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Mcp_session.info_of_json: %s" msg }))
+  | Failure msg ->
+    Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Mcp_session.info_of_json: %s" msg }))
 
 let info_list_to_json (infos : info list) : Yojson.Safe.t =
   `List (List.map info_to_json infos)
@@ -209,5 +211,7 @@ let info_list_of_json json : (info list, Error.sdk_error) result =
   with
   | Yojson.Safe.Util.Type_error (msg, _) ->
     Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Mcp_session.info_list_of_json: %s" msg }))
-  | exn ->
-    Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Mcp_session.info_list_of_json: %s" (Printexc.to_string exn) }))
+  | Yojson.Json_error msg ->
+    Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Mcp_session.info_list_of_json: %s" msg }))
+  | Failure msg ->
+    Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Mcp_session.info_list_of_json: %s" msg }))

--- a/lib/raw_trace.ml
+++ b/lib/raw_trace.ml
@@ -135,8 +135,8 @@ let rec ensure_dir path =
     with
     | Unix.Unix_error (err, _, _) ->
         Error (file_write_error ~path ~detail:(Unix.error_message err))
-    | exn ->
-        Error (file_write_error ~path ~detail:(Printexc.to_string exn))
+    | Sys_error detail ->
+        Error (file_write_error ~path ~detail)
 
 let record_type_to_string = function
   | Run_started -> "run_started"
@@ -258,7 +258,8 @@ let load_lines path =
           loop [])
     with
     | Sys_error detail -> Error (file_read_error ~path ~detail)
-    | exn -> Error (file_read_error ~path ~detail:(Printexc.to_string exn))
+    | Unix.Unix_error (err, _, _) ->
+        Error (file_read_error ~path ~detail:(Unix.error_message err))
 
 let read_all ~path () =
   let* lines = load_lines path in
@@ -333,7 +334,8 @@ let append_locked sink (record : record) =
         Ok ())
   with
   | Sys_error detail -> Error (file_write_error ~path:sink.path ~detail)
-  | exn -> Error (file_write_error ~path:sink.path ~detail:(Printexc.to_string exn))
+  | Unix.Unix_error (err, _, _) ->
+      Error (file_write_error ~path:sink.path ~detail:(Unix.error_message err))
 
 let append_record active ~record_type ?prompt ?block_index ?block_kind
     ?assistant_block ?tool_use_id ?tool_name ?tool_input ?tool_result ?tool_error

--- a/lib/runtime_store.ml
+++ b/lib/runtime_store.ml
@@ -34,11 +34,10 @@ let ensure_dir path =
                 path;
                 detail = Unix.error_message err;
               }))
-  | exn ->
+  | Sys_error detail ->
       Error
         (Error.Io
-           (FileOpFailed
-              { op = "mkdir"; path; detail = Printexc.to_string exn }))
+           (FileOpFailed { op = "mkdir"; path; detail }))
 
 let ensure_tree store session_id =
   let* () = ensure_dir store.root in
@@ -82,11 +81,10 @@ let save_text path content =
       Error
         (Error.Io
            (FileOpFailed { op = "write"; path; detail }))
-  | exn ->
+  | Unix.Unix_error (err, _, _) ->
       Error
         (Error.Io
-           (FileOpFailed
-              { op = "write"; path; detail = Printexc.to_string exn }))
+           (FileOpFailed { op = "write"; path; detail = Unix.error_message err }))
 
 let load_text path =
   try
@@ -101,11 +99,14 @@ let load_text path =
       Error
         (Error.Io
            (FileOpFailed { op = "read"; path; detail }))
-  | exn ->
+  | Unix.Unix_error (err, _, _) ->
       Error
         (Error.Io
-           (FileOpFailed
-              { op = "read"; path; detail = Printexc.to_string exn }))
+           (FileOpFailed { op = "read"; path; detail = Unix.error_message err }))
+  | End_of_file ->
+      Error
+        (Error.Io
+           (FileOpFailed { op = "read"; path; detail = "unexpected end of file" }))
 
 let save_session store (session : session) =
   let* () = ensure_tree store session.session_id in
@@ -176,11 +177,10 @@ let append_event store session_id (event : event) =
   | Sys_error detail ->
       Error
         (Error.Io (FileOpFailed { op = "append"; path; detail }))
-  | exn ->
+  | Unix.Unix_error (err, _, _) ->
       Error
         (Error.Io
-           (FileOpFailed
-              { op = "append"; path; detail = Printexc.to_string exn }))
+           (FileOpFailed { op = "append"; path; detail = Unix.error_message err }))
 
 let read_events store session_id ?after_seq () =
   let path = events_path store session_id in

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -90,4 +90,5 @@ let of_json json =
     }
   with
   | Yojson.Safe.Util.Type_error (msg, _) -> Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Session.of_json: %s" msg }))
-  | exn -> Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Session.of_json: %s" (Printexc.to_string exn) }))
+  | Yojson.Json_error msg -> Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Session.of_json: %s" msg }))
+  | Failure msg -> Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Session.of_json: %s" msg }))

--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -87,7 +87,8 @@ let json_extractor (parse : Yojson.Safe.t -> 'a) : 'a extractor =
       (try Ok (parse (Yojson.Safe.from_string text))
        with
        | Yojson.Json_error e -> Error (Printf.sprintf "JSON parse: %s" e)
-       | exn -> Error (Printexc.to_string exn))
+       | Yojson.Safe.Util.Type_error (msg, _) -> Error (Printf.sprintf "JSON type: %s" msg)
+       | Failure msg -> Error (Printf.sprintf "parse failure: %s" msg))
 
 (** Extract a value from the first text block using a string parser. *)
 let text_extractor (parse : string -> 'a option) : 'a extractor =

--- a/lib/transport.ml
+++ b/lib/transport.ml
@@ -311,14 +311,14 @@ let connect ~sw ~(mgr : _ Eio.Process.mgr) ?(options = default_options) () =
                 path = runtime_path;
                 detail = Unix.error_message err;
               }))
-  | exn ->
+  | Failure msg ->
       Error
         (Io
            (FileOpFailed
               {
                 op = "spawn";
                 path = runtime_path;
-                detail = Printexc.to_string exn;
+                detail = msg;
               }))
 
 let request ?control_handler ?event_handler transport request =


### PR DESCRIPTION
## Summary

Phase 2 of OAS improvement plan — catch-all `| exn ->` pattern triage.

- 22 `| exn ->` patterns analyzed across `lib/`
- 16 patterns narrowed to specific exception types
- 6 patterns retained (intentional: re-raise or user-tool boundary)
- Bug fix: `async_agent.ml` was swallowing `Out_of_memory`/`Stack_overflow`

### Changes by category

| Category | Files | Pattern |
|----------|-------|---------|
| File I/O | runtime_store, raw_trace | `Sys_error`, `Unix.Unix_error`, `End_of_file` |
| JSON parsing | checkpoint, collaboration, session, mcp_session, structured | `Yojson.Json_error`, `Failure` |
| Process spawn | transport | `Failure` |
| Config loading | cascade_config | `Yojson.Json_error`, `End_of_file` |
| Critical re-raise | async_agent | `Out_of_memory`, `Stack_overflow`, `Sys.Break` |

### Retained `| exn ->`

| File | Reason |
|------|--------|
| checkpoint_store.ml | `raise exn` (correct re-raise) |
| a2a_task_store.ml | `raise exn` (correct re-raise) |
| agent_tools.ml | User-defined tool boundary (critical already re-raised) |
| mcp.ml | External MCP server boundary (critical already re-raised) |
| async_agent.ml (2) | Agent.run boundary (critical re-raise added in this PR) |

## Test plan

- [x] `dune build` clean
- [x] 143 related tests pass (checkpoint 48, collaboration 40, raw_trace 9, async_agent 8, mcp_session 13, cascade_config 14, session 11)
- [ ] Full test suite via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)