### PR TITLE
feat: add .mli API contracts — consolidated batch (11 modules)

### DIFF
--- a/lib/agent/agent_config.mli
+++ b/lib/agent/agent_config.mli
@@ -1,0 +1,75 @@
+(** Agent configuration file parsing and MCP server connection.
+
+    Loads agent configuration from JSON files, resolves providers,
+    and connects MCP servers. *)
+
+type tool_file_config = {
+  name: string;
+  description: string;
+  parameters: Types.tool_param list;
+}
+
+type mcp_file_config =
+  | Stdio_mcp of {
+      command: string;
+      args: string list;
+      name: string;
+      env: string list;
+    }
+  | Http_mcp of {
+      url: string;
+      headers: (string * string) list;
+      name: string;
+    }
+
+type agent_file_config = {
+  name: string;
+  model: string;
+  system_prompt: string option;
+  max_tokens: int option;
+  max_turns: int option;
+  enable_thinking: bool option;
+  thinking_budget: int option;
+  provider: string option;
+  base_url: string option;
+  tools: tool_file_config list;
+  mcp_servers: mcp_file_config list;
+}
+
+(** {1 Parsing} *)
+
+val parse_param : Yojson.Safe.t -> (Types.tool_param, Error.sdk_error) result
+val parse_tool : Yojson.Safe.t -> (tool_file_config, Error.sdk_error) result
+val parse_mcp : Yojson.Safe.t -> (mcp_file_config, Error.sdk_error) result
+val of_json : Yojson.Safe.t -> (agent_file_config, Error.sdk_error) result
+val load : string -> (agent_file_config, Error.sdk_error) result
+
+(** {1 Provider resolution} *)
+
+val resolve_provider :
+  model_id:Types.model -> string -> string option -> Provider.config
+
+(** {1 MCP connection} *)
+
+val connect_mcp_server :
+  sw:Eio.Switch.t ->
+  mgr:[ `Generic | `Unix ] Eio.Process.mgr_ty Eio.Resource.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  mcp_file_config ->
+  (Mcp.managed, Error.sdk_error) result
+
+val connect_mcp_servers_best_effort :
+  sw:Eio.Switch.t ->
+  mgr:[ `Generic | `Unix ] Eio.Process.mgr_ty Eio.Resource.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  mcp_file_config list ->
+  Mcp.managed list
+
+(** {1 Builder conversion} *)
+
+val to_builder :
+  ?sw:Eio.Switch.t ->
+  ?mgr:[ `Generic | `Unix ] Eio.Process.mgr_ty Eio.Resource.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  agent_file_config ->
+  Builder.t

--- a/lib/conformance.mli
+++ b/lib/conformance.mli
@@ -1,0 +1,56 @@
+(** Conformance checking for agent session proofs.
+
+    Transforms a {!Sessions.proof_bundle} into a structured report
+    with 17 conformance checks covering lifecycle, identity, tracing,
+    and resolution. *)
+
+type check = {
+  code: string;
+  name: string;
+  passed: bool;
+  detail: string option;
+}
+[@@deriving yojson]
+
+type summary = {
+  session_id: string;
+  generated_at: float;
+  worker_run_count: int;
+  raw_trace_run_count: int;
+  validated_worker_run_count: int;
+  latest_accepted_worker_run_id: string option;
+  latest_ready_worker_run_id: string option;
+  latest_running_worker_run_id: string option;
+  latest_worker_run_id: string option;
+  latest_completed_worker_run_id: string option;
+  latest_worker_agent_name: string option;
+  latest_worker_status: string option;
+  latest_worker_role: string option;
+  latest_worker_aliases: string list;
+  latest_worker_validated: bool option;
+  latest_failed_worker_run_id: string option;
+  latest_failure_reason: string option;
+  latest_resolved_provider: string option;
+  latest_resolved_model: string option;
+  hook_event_count: int;
+  tool_catalog_count: int;
+  trace_capabilities: Sessions.trace_capability list;
+}
+[@@deriving yojson]
+
+type report = {
+  ok: bool;
+  summary: summary;
+  checks: check list;
+}
+[@@deriving yojson]
+
+(** Generate a conformance report from a proof bundle. *)
+val report : Sessions.proof_bundle -> report
+
+(** Run conformance checks from a session on disk. *)
+val run :
+  ?session_root:string ->
+  session_id:string ->
+  unit ->
+  (report, Error.sdk_error) result

--- a/lib/direct_evidence.mli
+++ b/lib/direct_evidence.mli
@@ -1,0 +1,73 @@
+(** Direct evidence extraction from agent runs.
+
+    Materializes worker run data, proof bundles, and conformance
+    reports from a live {!Agent.t} and its {!Raw_trace.t}. *)
+
+type options = {
+  session_root: string option;
+  session_id: string;
+  goal: string;
+  title: string option;
+  tag: string option;
+  worker_id: string option;
+  runtime_actor: string option;
+  role: string option;
+  aliases: string list;
+  requested_provider: string option;
+  requested_model: string option;
+  requested_policy: string option;
+  workdir: string option;
+}
+
+type raw_details = {
+  validated: bool;
+  tool_names: string list;
+  final_text: string option;
+  stop_reason: string option;
+  error: string option;
+  paired_tool_result_count: int;
+  has_file_write: bool;
+  verification_pass_after_file_write: bool;
+  failure_reason: string option;
+}
+
+(** Extract a single worker run from an agent and its trace. *)
+val get_worker_run :
+  agent:Agent.t ->
+  raw_trace:Raw_trace.t ->
+  options:options ->
+  unit ->
+  (Sessions.worker_run, Error.sdk_error) result
+
+(** Persist evidence and return a proof bundle. *)
+val get_proof_bundle :
+  agent:Agent.t ->
+  raw_trace:Raw_trace.t ->
+  options:options ->
+  unit ->
+  (Sessions.proof_bundle, Error.sdk_error) result
+
+(** Generate a conformance report from an agent run. *)
+val get_conformance :
+  agent:Agent.t ->
+  raw_trace:Raw_trace.t ->
+  options:options ->
+  unit ->
+  (Conformance.report, Error.sdk_error) result
+
+(** Alias for {!get_conformance}. *)
+val run_conformance :
+  agent:Agent.t ->
+  raw_trace:Raw_trace.t ->
+  options:options ->
+  unit ->
+  (Conformance.report, Error.sdk_error) result
+
+(** Persist evidence to disk and return a proof bundle.
+    Used by examples and external tools. *)
+val persist :
+  agent:Agent.t ->
+  raw_trace:Raw_trace.t ->
+  options:options ->
+  unit ->
+  (Sessions.proof_bundle, Error.sdk_error) result

--- a/lib/internal_query_engine.mli
+++ b/lib/internal_query_engine.mli
@@ -1,0 +1,51 @@
+(** Internal query engine: SDK-side event loop over runtime transport.
+
+    Manages runtime connection, event synchronization, message buffering,
+    and permission/hook callbacks. Used by {!Client} and {!Internal_client}. *)
+
+type t = {
+  runtime: Runtime_client.t;
+  mutable options: Sdk_client_types.options;
+  mutable session_id: string option;
+  mutable last_event_seq: int;
+  mutable buffered_messages: Sdk_client_types.message list;
+  message_mu: Eio.Mutex.t;
+  message_cv: Eio.Condition.t;
+  mutable can_use_tool: Sdk_client_types.can_use_tool option;
+  mutable hook_callback: Sdk_client_types.hook_callback option;
+}
+
+(** {1 Lifecycle} *)
+
+val connect :
+  sw:Eio.Switch.t ->
+  mgr:_ Eio.Process.mgr ->
+  ?options:Sdk_client_types.options ->
+  unit ->
+  (t, Error.sdk_error) result
+
+val close : t -> unit
+
+(** {1 Message operations} *)
+
+val receive_messages : t -> Sdk_client_types.message list
+val has_pending_messages : t -> bool
+val wait_for_messages : ?timeout:float -> t -> Sdk_client_types.message list
+
+(** {1 Session state} *)
+
+val current_session_id : t -> string option
+
+(** {1 Configuration} *)
+
+val set_permission_mode :
+  t -> Sdk_client_types.permission_mode -> (unit, Error.sdk_error) result
+val set_model : t -> string option -> (unit, Error.sdk_error) result
+val set_can_use_tool : t -> Sdk_client_types.can_use_tool -> unit
+val set_hook_callback : t -> Sdk_client_types.hook_callback -> unit
+
+(** {1 Execution} *)
+
+val query_turn : t -> string -> (unit, Error.sdk_error) result
+val finalize : t -> ?reason:string -> unit -> (unit, Error.sdk_error) result
+val interrupt : t -> (unit, Error.sdk_error) result

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -1,0 +1,40 @@
+(** SSE event parsing for Anthropic and OpenAI streaming APIs.
+
+    Pure functions — no I/O or agent_sdk coupling. *)
+
+open Types
+
+(** {1 Anthropic SSE} *)
+
+val parse_sse_event : string option -> string -> sse_event option
+val emit_synthetic_events : api_response -> (sse_event -> unit) -> unit
+
+(** {1 OpenAI SSE} *)
+
+type openai_tool_call_delta = {
+  tc_index: int;
+  tc_id: string option;
+  tc_name: string option;
+  tc_arguments: string option;
+}
+
+type openai_chunk = {
+  chunk_id: string;
+  chunk_model: string;
+  delta_content: string option;
+  delta_reasoning: string option;
+  delta_tool_calls: openai_tool_call_delta list;
+  finish_reason: string option;
+  chunk_usage: api_usage option;
+}
+
+type openai_stream_state = {
+  mutable thinking_block_started: bool;
+  mutable text_block_started: bool;
+  tool_block_indices: (int, int) Hashtbl.t;
+  mutable next_block_index: int;
+}
+
+val parse_openai_sse_chunk : string -> openai_chunk option
+val create_openai_stream_state : unit -> openai_stream_state
+val openai_chunk_to_events : openai_stream_state -> openai_chunk -> sse_event list

--- a/lib/otel_tracer.mli
+++ b/lib/otel_tracer.mli
@@ -1,0 +1,95 @@
+(** OpenTelemetry-compatible tracing with OTLP JSON export.
+
+    Provides span lifecycle management, event recording, and
+    OTLP JSON serialization. Supports both Stdlib.Mutex (non-Eio)
+    and Eio.Mutex backends. *)
+
+(** {1 Types} *)
+
+type otel_span_kind = Internal | Client | Server | Producer | Consumer
+
+type otel_event = {
+  event_name: string;
+  timestamp_ns: Int64.t;
+  attributes: (string * string) list;
+}
+
+type span = {
+  trace_id: string;
+  span_id: string;
+  parent_span_id: string option;
+  name: string;
+  kind: otel_span_kind;
+  start_time_ns: Int64.t;
+  mutable end_time_ns: Int64.t option;
+  mutable status: bool option;
+  mutable attributes: (string * string) list;
+  mutable events: otel_event list;
+}
+
+type config = {
+  service_name: string;
+  endpoint: string option;
+}
+
+type mutex_impl =
+  | Stdlib_mu of Mutex.t
+  | Eio_mu of Eio.Mutex.t
+
+type instance = {
+  config: config;
+  mu: mutex_impl;
+  mutable current_spans: span list;
+  mutable completed_spans: span list;
+}
+
+(** {1 Config} *)
+
+val default_config : config
+val otel_span_kind_to_int : otel_span_kind -> int
+
+(** {1 Utilities} *)
+
+val now_ns : unit -> Int64.t
+val map_span_kind : Tracing.span_kind -> otel_span_kind
+val semantic_attrs : Tracing.span_attrs -> (string * string) list
+val span_kind_to_string : Tracing.span_kind -> string
+val make_span_name : Tracing.span_attrs -> string
+
+(** {1 Instance operations} *)
+
+val create_instance : ?config:config -> unit -> instance
+val create_instance_eio : ?config:config -> unit -> instance
+val inst_start_span : instance -> Tracing.span_attrs -> span
+val inst_end_span : instance -> span -> ok:bool -> unit
+val inst_add_event : instance -> span -> string -> unit
+val inst_add_attrs : instance -> span -> (string * string) list -> unit
+val inst_flush : instance -> span list
+val inst_reset : instance -> unit
+val inst_completed_count : instance -> int
+val inst_active_count : instance -> int
+
+(** {1 Global operations} *)
+
+val start_span : Tracing.span_attrs -> span
+val end_span : span -> ok:bool -> unit
+val add_event : span -> string -> unit
+val add_attrs : span -> (string * string) list -> unit
+val flush : unit -> span list
+val reset : unit -> unit
+val completed_count : unit -> int
+val active_count : unit -> int
+
+(** {1 JSON serialization} *)
+
+val attrs_to_json : (string * string) list -> Yojson.Safe.t
+val event_to_json : otel_event -> Yojson.Safe.t
+val status_to_json : span -> Yojson.Safe.t
+val span_to_json : span -> Yojson.Safe.t
+val to_otlp_json : config -> Yojson.Safe.t
+
+(** {1 First-class module constructors} *)
+
+val tracer_of_instance : instance -> Tracing.t
+val create : ?config:config -> unit -> Tracing.t
+val create_eio : ?config:config -> unit -> Tracing.t

--- a/lib/protocol/a2a_task.mli
+++ b/lib/protocol/a2a_task.mli
@@ -1,0 +1,94 @@
+(** A2A Task Lifecycle — Agent-to-Agent protocol task state machine.
+
+    Tasks flow through a well-defined state machine:
+    Submitted -> Working -> Completed/Failed/Canceled.
+    Illegal transitions return [Error]. *)
+
+(** {1 State machine} *)
+
+type task_state =
+  | Submitted
+  | Working
+  | Input_required
+  | Completed
+  | Failed
+  | Canceled
+
+type transition_error =
+  | InvalidTransition of { from_state: task_state; to_state: task_state }
+  | TaskAlreadyTerminal of { state: task_state }
+
+val task_state_to_string : task_state -> string
+val task_state_of_string : string -> (task_state, string) result
+val task_state_to_yojson : task_state -> Yojson.Safe.t
+val task_state_of_yojson : Yojson.Safe.t -> (task_state, string) result
+val pp_task_state : Format.formatter -> task_state -> unit
+val show_task_state : task_state -> string
+
+val valid_transitions : task_state -> task_state list
+val is_terminal : task_state -> bool
+val transition_error_to_string : transition_error -> string
+
+(** {1 Message and artifact types} *)
+
+type message_part =
+  | Text_part of string
+  | File_part of { name: string; mime_type: string; data: string }
+  | Data_part of Yojson.Safe.t
+
+val message_part_to_yojson : message_part -> Yojson.Safe.t
+val message_part_of_yojson : Yojson.Safe.t -> (message_part, string) result
+val pp_message_part : Format.formatter -> message_part -> unit
+val show_message_part : message_part -> string
+
+type task_role = TaskUser | TaskAgent
+
+type task_message = {
+  role: task_role;
+  parts: message_part list;
+  metadata: (string * Yojson.Safe.t) list;
+}
+
+val task_message_to_yojson : task_message -> Yojson.Safe.t
+val task_message_of_yojson : Yojson.Safe.t -> (task_message, string) result
+
+type artifact = {
+  name: string;
+  parts: message_part list;
+  metadata: (string * Yojson.Safe.t) list;
+}
+
+val artifact_to_yojson : artifact -> Yojson.Safe.t
+val artifact_of_yojson : Yojson.Safe.t -> (artifact, string) result
+
+(** {1 Task} *)
+
+type task_id = string
+
+type task = {
+  id: task_id;
+  state: task_state;
+  messages: task_message list;
+  artifacts: artifact list;
+  metadata: (string * Yojson.Safe.t) list;
+  created_at: float;
+  updated_at: float;
+}
+
+val create : task_message -> task
+val transition : task -> task_state -> (task, transition_error) result
+val add_message : task -> task_message -> task
+val add_artifact : task -> artifact -> task
+
+val task_to_yojson : task -> Yojson.Safe.t
+val task_of_yojson : Yojson.Safe.t -> (task, string) result
+
+(** {1 In-memory store} *)
+
+type store
+
+val create_store : ?max_tasks:int -> unit -> store
+val evict_if_needed : store -> unit
+val store_task : store -> task -> unit
+val get_task : store -> task_id -> task option
+val list_tasks : store -> task list

--- a/lib/protocol/mcp.mli
+++ b/lib/protocol/mcp.mli
@@ -1,0 +1,110 @@
+(** MCP (Model Context Protocol) client.
+
+    Spawns an MCP subprocess and communicates via JSON-RPC 2.0 NDJSON
+    over stdin/stdout. Handles tool invocation, resource listing,
+    and prompt fetching. *)
+
+(** {1 Re-exported schema types} *)
+
+(** Re-exports from {!Mcp_schema}. *)
+
+type mcp_tool = Mcp_schema.mcp_tool = {
+  name: string;
+  description: string;
+  input_schema: Yojson.Safe.t;
+}
+
+type mcp_resource = Mcp_schema.mcp_resource
+type mcp_resource_contents = Mcp_schema.mcp_resource_contents
+type mcp_prompt = Mcp_schema.mcp_prompt
+type mcp_prompt_result = Mcp_schema.mcp_prompt_result
+
+val json_schema_type_to_param_type : string -> Types.param_type
+val json_schema_to_params : Yojson.Safe.t -> Types.tool_param list
+val mcp_tool_of_sdk_tool : Mcp_schema.Sdk_types.tool -> mcp_tool
+val mcp_tool_to_sdk_tool :
+  call_fn:(Yojson.Safe.t -> Types.tool_result) -> mcp_tool -> Tool.t
+
+val mcp_tool_of_json : Yojson.Safe.t -> mcp_tool option
+
+(** {1 Client handle} *)
+
+type t
+
+(** {1 Connection lifecycle} *)
+
+val connect :
+  sw:Eio.Switch.t ->
+  mgr:_ Eio.Process.mgr ->
+  command:string ->
+  args:string list ->
+  ?env:string array ->
+  unit ->
+  (t, Error.sdk_error) result
+
+val initialize : t -> (unit, Error.sdk_error) result
+val close : t -> unit
+val is_alive : t -> bool
+
+(** {1 Tool operations} *)
+
+val list_tools : t -> (mcp_tool list, Error.sdk_error) result
+val call_tool : t -> name:string -> arguments:Yojson.Safe.t -> Types.tool_result
+val to_tools : t -> mcp_tool list -> Tool.t list
+
+(** {1 Resource and prompt operations} *)
+
+val list_resources : t -> (Mcp_schema.mcp_resource list, Error.sdk_error) result
+val read_resource : t -> uri:string -> (Mcp_schema.mcp_resource_contents list, Error.sdk_error) result
+val list_prompts : t -> (Mcp_schema.mcp_prompt list, Error.sdk_error) result
+val get_prompt :
+  t ->
+  name:string ->
+  ?arguments:(string * string) list ->
+  unit ->
+  (Mcp_schema.mcp_prompt_result, Error.sdk_error) result
+
+(** {1 Output utilities} *)
+
+val output_token_budget : unit -> int
+val truncate_output : string -> string
+val text_of_tool_result : Mcp_schema.Sdk_types.tool_result -> string
+val merge_env : (string * string) list -> string array
+
+(** {1 Managed connections} *)
+
+type server_spec = {
+  command: string;
+  args: string list;
+  env: (string * string) list;
+  name: string;
+}
+
+type transport =
+  | Stdio of { client: t; spec: server_spec }
+  | Http of { close_fn: unit -> unit }
+
+type managed = {
+  tools: Tool.t list;
+  name: string;
+  transport: transport;
+}
+
+val connect_and_load :
+  sw:Eio.Switch.t -> mgr:_ Eio.Process.mgr -> server_spec ->
+  (managed, Error.sdk_error) result
+
+val connect_all :
+  sw:Eio.Switch.t -> mgr:_ Eio.Process.mgr -> server_spec list ->
+  (managed list, Error.sdk_error) result
+
+val reconnect :
+  sw:Eio.Switch.t -> mgr:_ Eio.Process.mgr -> managed ->
+  (managed, Error.sdk_error) result
+
+val connect_all_best_effort :
+  sw:Eio.Switch.t -> mgr:_ Eio.Process.mgr -> server_spec list ->
+  managed list * (string * Error.sdk_error) list
+
+val close_managed : managed -> unit
+val close_all : managed list -> unit

--- a/lib/runtime_evidence.mli
+++ b/lib/runtime_evidence.mli
@@ -1,0 +1,52 @@
+(** Runtime evidence: telemetry reports and evidence bundles.
+
+    Generates structured telemetry from session events and
+    collects file-level evidence with MD5 checksums. *)
+
+type telemetry_step = {
+  seq: int;
+  ts: float;
+  event_name: string;
+  kind: string;
+  participant: string option;
+  detail: string option;
+  actor: string option;
+  role: string option;
+  provider: string option;
+  model: string option;
+  artifact_id: string option;
+  artifact_name: string option;
+  artifact_kind: string option;
+  checkpoint_label: string option;
+  outcome: string option;
+}
+
+type telemetry_report = {
+  session_id: string;
+  generated_at: float;
+  step_count: int;
+  event_counts: (string * int) list;
+  event_name_counts: (string * int) list;
+  steps: telemetry_step list;
+}
+
+type evidence_file = {
+  label: string;
+  path: string;
+  size_bytes: int;
+  md5: string;
+}
+
+type evidence_bundle = {
+  session_id: string;
+  generated_at: float;
+  files: evidence_file list;
+  missing_files: (string * string) list;
+}
+
+val now : unit -> float
+val build_telemetry_report : Runtime.session -> Runtime.event list -> telemetry_report
+val telemetry_report_to_json : telemetry_report -> Yojson.Safe.t
+val telemetry_report_to_markdown : telemetry_report -> string
+val build_evidence_bundle : session_id:string -> (string * string) list -> evidence_bundle
+val evidence_bundle_to_json : evidence_bundle -> Yojson.Safe.t

--- a/lib/runtime_server.mli
+++ b/lib/runtime_server.mli
@@ -1,0 +1,46 @@
+(** Runtime protocol server: reads NDJSON from stdin, dispatches requests.
+
+    Entry point for the oas_runtime binary. Integrates with
+    {!Runtime_server_types}, {!Runtime_server_resolve}, and
+    {!Runtime_server_worker} for request handling. *)
+
+open Runtime
+open Runtime_server_types
+
+(** {1 Server entry point} *)
+
+(** Main server loop: reads protocol messages from stdin and processes
+    them until a Shutdown message is received. *)
+val serve_stdio : net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t -> unit -> unit
+
+(** {1 Request handling} *)
+
+val handle_request :
+  state -> request -> (response, Error.sdk_error) result
+
+val start_session :
+  state -> start_request -> (response, Error.sdk_error) result
+
+val finalize_session :
+  state -> Runtime_store.t -> session -> string option -> (response, Error.sdk_error) result
+
+val apply_command :
+  state -> Runtime_store.t -> session -> command -> (response, Error.sdk_error) result
+
+(** {1 Control channel} *)
+
+val read_control_response :
+  state -> string -> (control_response, Error.sdk_error) result
+
+val ask_permission :
+  state ->
+  action:string ->
+  subject:string ->
+  payload:Yojson.Safe.t ->
+  (control_response, Error.sdk_error) result
+
+val invoke_hook :
+  state ->
+  hook_name:string ->
+  payload:Yojson.Safe.t ->
+  (control_response, Error.sdk_error) result

--- a/lib/runtime_store.mli
+++ b/lib/runtime_store.mli
@@ -1,0 +1,63 @@
+(** File-based session store for the OAS runtime.
+
+    Provides path construction, text I/O, and serialization for
+    sessions, events, artifacts, reports, and proofs. *)
+
+(** Store handle wrapping a root directory. *)
+type t = { root: string }
+
+(** {1 Store creation} *)
+
+val default_root : unit -> string
+val create : ?root:string -> unit -> (t, Error.sdk_error) result
+val ensure_dir : string -> (unit, Error.sdk_error) result
+val ensure_tree : t -> string -> (unit, Error.sdk_error) result
+
+(** {1 Path constructors} *)
+
+val sessions_dir : t -> string
+val session_dir : t -> string -> string
+val session_path : t -> string -> string
+val events_path : t -> string -> string
+val snapshots_dir : t -> string -> string
+val artifacts_dir : t -> string -> string
+val raw_traces_dir : t -> string -> string
+val report_json_path : t -> string -> string
+val report_md_path : t -> string -> string
+val proof_json_path : t -> string -> string
+val proof_md_path : t -> string -> string
+
+(** {1 Text I/O} *)
+
+val save_text : string -> string -> (unit, Error.sdk_error) result
+val load_text : string -> (string, Error.sdk_error) result
+
+(** {1 Session I/O} *)
+
+val save_session : t -> Runtime.session -> (unit, Error.sdk_error) result
+val load_session : t -> string -> (Runtime.session, Error.sdk_error) result
+
+(** {1 Event I/O} *)
+
+val append_event : t -> string -> Runtime.event -> (unit, Error.sdk_error) result
+val read_events :
+  t -> string -> ?after_seq:int -> unit ->
+  (Runtime.event list, Error.sdk_error) result
+
+(** {1 Snapshots} *)
+
+val snapshot_path : t -> string -> seq:int -> label:string option -> string
+val save_snapshot :
+  t -> Runtime.session -> label:string option ->
+  (string, Error.sdk_error) result
+
+(** {1 Artifacts} *)
+
+val save_artifact_text :
+  t -> string -> name:string -> kind:string -> content:string ->
+  (string, Error.sdk_error) result
+
+(** {1 Reports and proofs} *)
+
+val save_report : t -> Runtime.report -> (unit, Error.sdk_error) result
+val save_proof : t -> Runtime.proof -> (unit, Error.sdk_error) result


### PR DESCRIPTION
## Summary

Consolidated .mli interface files from PRs #225 and #227 (non-overlapping portions), rebased on current main which already includes #224 and #230.

- 11 new .mli files adding API boundaries to core modules
- .mli coverage: 61 → 72/128 (48% → 56%)
- Supersedes open PRs #225 and #227 (can be closed after merge)

### Modules covered

| Module | LOC (.ml) | Key design |
|--------|-----------|------------|
| a2a_task | 304 | Abstract `store` type |
| mcp | 447 | Abstract `type t`, re-exported schema types |
| conformance | 310 | 17 check predicates hidden, `report` + `run` public |
| direct_evidence | 406 | 24 helpers hidden, 5 public + `persist` |
| runtime_server | 336 | serve_stdio entry + request handlers |
| runtime_store | 293 | File-based session store |
| runtime_evidence | 280 | Telemetry reports + evidence bundles |
| agent_config | 76 | Config parsing + MCP connection |
| otel_tracer | 96 | OpenTelemetry spans, instance record exposed |
| streaming | 41 | SSE parsing for Anthropic + OpenAI |
| internal_query_engine | 52 | SDK-side event loop |

## Test plan

- [x] `dune build` clean
- [x] 145+ related tests pass
- [x] `test_conformance` failure is pre-existing (fails on main too)
- [ ] Full test suite via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)