### PR TITLE
feat: add .mli API contracts — batch 4 (5 modules)

### DIFF
--- a/lib/approval.mli
+++ b/lib/approval.mli
@@ -1,0 +1,45 @@
+(** Composable multi-stage approval pipeline for tool execution.
+
+    Stages evaluate sequentially; first {!Decided} wins.
+    If all stages return {!Pass}, the default is {!Hooks.Approve}. *)
+
+(** {1 Types} *)
+
+type risk_level = Low | Medium | High | Critical
+
+val risk_level_to_string : risk_level -> string
+
+type approval_context = {
+  tool_name: string;
+  input: Yojson.Safe.t;
+  agent_name: string;
+  turn: int;
+  risk_level: risk_level;
+}
+
+type stage_result =
+  | Decided of Hooks.approval_decision
+  | Pass
+
+type approval_stage = {
+  name: string;
+  evaluate: approval_context -> stage_result;
+  timeout_s: float option;
+}
+
+type t
+
+(** {1 Pipeline} *)
+
+val create : approval_stage list -> t
+val evaluate : t -> tool_name:string -> input:Yojson.Safe.t -> agent_name:string -> turn:int -> Hooks.approval_decision
+val as_callback : t -> Hooks.approval_callback
+
+(** {1 Built-in stages} *)
+
+val auto_approve_known_tools : string list -> approval_stage
+val reject_dangerous_patterns : (string * string) list -> approval_stage
+val risk_classifier : (string -> Yojson.Safe.t -> risk_level) -> approval_stage
+val human_callback : Hooks.approval_callback -> approval_stage
+val always_approve : approval_stage
+val always_reject : string -> approval_stage

--- a/lib/contract.mli
+++ b/lib/contract.mli
@@ -1,0 +1,59 @@
+(** Explicit runtime contract helpers.
+
+    Packages system prompt, tools, MCP clients, guardrails, context,
+    and skill bundles into a first-class contract. *)
+
+(** {1 Types} *)
+
+type trigger = {
+  kind: string;
+  source: string option;
+  reason: string option;
+  payload: Yojson.Safe.t option;
+}
+
+type instruction_layer = {
+  label: string option;
+  content: string;
+}
+
+type t = {
+  runtime_awareness: string option;
+  trigger: trigger option;
+  instruction_layers: instruction_layer list;
+  skills: Skill.t list;
+  tool_grants: string list option;
+  mcp_tool_allowlist: string list option;
+}
+
+val context_key : string
+val empty : t
+
+(** {1 Builders} *)
+
+val with_runtime_awareness : string -> t -> t
+val with_trigger : ?source:string -> ?reason:string -> ?payload:Yojson.Safe.t -> string -> t -> t
+val add_instruction_layer : ?label:string -> string -> t -> t
+val with_skill : Skill.t -> t -> t
+val with_skills : Skill.t list -> t -> t
+val with_tool_grants : string list -> t -> t
+val with_mcp_tool_allowlist : string list -> t -> t
+
+(** {1 Operations} *)
+
+val merge : t -> t -> t
+val is_empty : t -> bool
+
+(** {1 Serialization} *)
+
+val to_json : t -> Yojson.Safe.t
+
+(** {1 Rendering} *)
+
+val compose_system_prompt : ?base:string -> t -> string option
+
+(** {1 Filtering} *)
+
+val filter_tools : t -> Tool.t list -> Tool.t list
+val filter_mcp_clients : t -> Mcp.managed list -> Mcp.managed list
+val context_with_contract : ?context:Context.t -> t -> Context.t option

--- a/lib/skill.mli
+++ b/lib/skill.mli
@@ -1,0 +1,51 @@
+(** Markdown skill loading with lightweight frontmatter support.
+
+    Parses YAML-like frontmatter (---/--- delimited) into key-value pairs
+    and extracts the body for prompt composition. *)
+
+(** {1 Types} *)
+
+type scope =
+  | Project
+  | User
+  | Local
+  | Custom of string
+[@@deriving show]
+
+type t = {
+  name: string;
+  description: string option;
+  body: string;
+  path: string option;
+  scope: scope option;
+  allowed_tools: string list;
+  argument_hint: string option;
+  model: string option;
+  supporting_files: string list;
+  metadata: (string * string list) list;
+}
+[@@deriving show]
+
+(** {1 String helpers} *)
+
+val strip_quotes : string -> string
+val split_csv : string -> string list
+val replace_all : pattern:string -> replacement:string -> string -> string
+
+(** {1 Frontmatter parsing} *)
+
+val parse_frontmatter : string -> (string * string list) list * string
+val frontmatter_value : (string * string list) list -> string -> string option
+val frontmatter_values : (string * string list) list -> string -> string list
+
+(** {1 Constructors} *)
+
+val scope_of_string : string -> scope
+val of_markdown : ?path:string -> ?scope:scope -> string -> t
+val load : ?scope:scope -> string -> (t, Error.sdk_error) result
+val load_dir : ?scope:scope -> string -> t list
+
+(** {1 Prompt composition} *)
+
+val render_prompt : ?arguments:string -> t -> string
+val supporting_file_paths : t -> string list

--- a/lib/structured.mli
+++ b/lib/structured.mli
@@ -1,0 +1,82 @@
+(** Structured output via tool_use pattern.
+
+    Uses tool_choice=Tool(name) to force the model to call a specific tool,
+    then extracts the input JSON as structured output. *)
+
+open Types
+
+(** {1 Schema} *)
+
+type 'a schema = {
+  name: string;
+  description: string;
+  params: tool_param list;
+  parse: Yojson.Safe.t -> ('a, string) result;
+}
+
+val schema_to_tool_json : _ schema -> Yojson.Safe.t
+val extract_tool_input : schema:'a schema -> content_block list -> ('a, Error.sdk_error) result
+
+(** {1 Direct extraction} *)
+
+val extract :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?base_url:string ->
+  ?provider:Provider.config ->
+  config:agent_config ->
+  schema:'a schema ->
+  string ->
+  ('a, Error.sdk_error) result
+
+(** {1 Extractors} *)
+
+type 'a extractor = api_response -> ('a, string) result
+
+val json_extractor : (Yojson.Safe.t -> 'a) -> 'a extractor
+val text_extractor : (string -> 'a option) -> 'a extractor
+
+(** {1 Agent-level structured output} *)
+
+val run_structured :
+  sw:Eio.Switch.t ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  Agent.t ->
+  string ->
+  extract:'a extractor ->
+  ('a, Error.sdk_error) result
+
+(** {1 Retry with validation feedback} *)
+
+type 'a retry_result = {
+  value: 'a;
+  total_usage: api_usage option;
+  attempts: int;
+}
+
+val extract_with_retry :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?base_url:string ->
+  ?provider:Provider.config ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  config:agent_config ->
+  schema:'a schema ->
+  ?max_retries:int ->
+  ?on_validation_error:(int -> string -> unit) ->
+  string ->
+  ('a retry_result, Error.sdk_error) result
+
+(** {1 Streaming extraction} *)
+
+val extract_stream :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?base_url:string ->
+  ?provider:Provider.config ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  config:agent_config ->
+  schema:'a schema ->
+  on_event:(sse_event -> unit) ->
+  string ->
+  ('a * api_response, Error.sdk_error) result

--- a/lib/subagent.mli
+++ b/lib/subagent.mli
@@ -1,0 +1,61 @@
+(** Typed subagent specifications for delegation via Handoff.
+
+    Loads subagent definitions from markdown frontmatter and converts
+    them into {!Handoff.handoff_target} values for the agent runner. *)
+
+(** {1 Types} *)
+
+type model_override =
+  | Inherit_model
+  | Use_model of Types.model
+[@@deriving show]
+
+type isolation =
+  | Shared
+  | Worktree
+[@@deriving show]
+
+type state_isolation =
+  | Inherit_all
+  | Isolated
+  | Selective of string list
+[@@deriving show]
+
+type t = {
+  name: string;
+  description: string option;
+  prompt: string;
+  tools: string list option;
+  disallowed_tools: string list;
+  model: model_override;
+  max_turns: int option;
+  skill_refs: string list;
+  skills: Skill.t list;
+  isolation: isolation;
+  state_isolation: state_isolation;
+  background: bool;
+  path: string option;
+  metadata: (string * string list) list;
+}
+[@@deriving show]
+
+(** {1 Parsing helpers} *)
+
+val model_override_of_string : string -> model_override
+val isolation_of_string : string -> isolation
+val state_isolation_of_string : string -> state_isolation
+
+(** {1 Constructors} *)
+
+val of_markdown : ?path:string -> ?skills:Skill.t list -> string -> t
+val load : ?skill_roots:string list -> string -> (t, Error.sdk_error) result
+
+(** {1 Prompt composition} *)
+
+val state_isolation_preamble : state_isolation -> string option
+val compose_prompt : ?arguments:string -> t -> string
+
+(** {1 Tool filtering and conversion} *)
+
+val filter_tools : t -> Tool.t list -> Tool.t list
+val to_handoff_target : parent_config:Types.agent_config -> base_tools:Tool.t list -> t -> Handoff.handoff_target


### PR DESCRIPTION
## Summary

5 new .mli interface files. .mli coverage: 74 -> 79/128 (58% -> 62%).

| Module | LOC | Key design |
|--------|-----|------------|
| approval | 168 | Abstract `type t`, composable stages |
| skill | 215 | Record exposed, frontmatter parsing |
| subagent | 222 | Record exposed, markdown constructor |
| contract | 251 | Record exposed, builder pattern |
| structured | 230 | Parametric `'a schema`, extractors |

## Test plan

- [x] `dune build` clean
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)