### PR TITLE
feat(hooks): add cost/size context to PreToolUse/PostToolUse

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -53,10 +53,15 @@ let find_and_execute_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tra
   let triple = match tool_opt with
   | Some tool ->
     let result = Tool.execute ~context tool input in
+    let result_bytes = match result with
+      | Ok { content } -> String.length content
+      | Error { message; _ } -> String.length message
+    in
     let _post =
       invoke_hook ?on_hook_invoked ~tracer ~agent_name ~turn_count
         ~hook_name:"post_tool_use" hooks.post_tool_use
-        (Hooks.PostToolUse { tool_name = name; input; output = result })
+        (Hooks.PostToolUse { tool_name = name; input; output = result;
+                             result_bytes })
     in
     (match result with
      | Error { message; _ } ->
@@ -90,7 +95,8 @@ let find_and_execute_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tra
     Applies PreToolUse/PostToolUse hooks and passes context to context-aware handlers.
     Each fiber catches exceptions to prevent one tool failure from canceling siblings. *)
 let execute_tools ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tracer
-    ~agent_name ~turn_count ~approval ?on_tool_execution_started
+    ~agent_name ~turn_count ~(usage : Types.usage_stats) ~approval
+    ?on_tool_execution_started
     ?on_tool_execution_finished ?on_hook_invoked tool_uses =
   Eio.Fiber.List.map (fun block ->
     match block with
@@ -108,7 +114,9 @@ let execute_tools ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tracer
               let decision =
                 invoke_hook ?on_hook_invoked ~tracer ~agent_name ~turn_count
                   ~hook_name:"pre_tool_use" hooks.pre_tool_use
-                  (Hooks.PreToolUse { tool_name = name; input })
+                  (Hooks.PreToolUse { tool_name = name; input;
+                                     accumulated_cost_usd = usage.Types.estimated_cost_usd;
+                                     turn = turn_count })
               in
               (match decision with
               | Hooks.Skip -> (id, "Tool execution skipped by hook", false)

--- a/lib/agent/agent_trace.ml
+++ b/lib/agent/agent_trace.ml
@@ -54,7 +54,8 @@ let execute_tools_with_trace agent active_run tool_uses =
     ~context:agent.context ~tools:(Tool_set.to_list agent.tools)
     ~hooks:agent.options.hooks ~event_bus:agent.options.event_bus
     ~tracer:agent.options.tracer ~agent_name:agent.state.config.name
-    ~turn_count:agent.state.turn_count ~approval:agent.options.approval
+    ~turn_count:agent.state.turn_count ~usage:agent.state.usage
+    ~approval:agent.options.approval
     ?on_tool_execution_started ?on_tool_execution_finished ~on_hook_invoked
     tool_uses
 

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -83,8 +83,10 @@ type hook_event =
       reasoning: reasoning_summary;
     }
   | AfterTurn of { turn: int; response: api_response }
-  | PreToolUse of { tool_name: string; input: Yojson.Safe.t }
-  | PostToolUse of { tool_name: string; input: Yojson.Safe.t; output: Types.tool_result }
+  | PreToolUse of { tool_name: string; input: Yojson.Safe.t;
+                    accumulated_cost_usd: float; turn: int }
+  | PostToolUse of { tool_name: string; input: Yojson.Safe.t;
+                     output: Types.tool_result; result_bytes: int }
   | PostToolUseFailure of { tool_name: string; input: Yojson.Safe.t; error: string }
   | OnStop of { reason: stop_reason; response: api_response }
   | OnIdle of { consecutive_idle_turns: int; tool_names: string list }

--- a/lib/hooks.mli
+++ b/lib/hooks.mli
@@ -33,9 +33,10 @@ type hook_event =
       reasoning: reasoning_summary;
     }
   | AfterTurn of { turn: int; response: Types.api_response }
-  | PreToolUse of { tool_name: string; input: Yojson.Safe.t }
+  | PreToolUse of { tool_name: string; input: Yojson.Safe.t;
+                    accumulated_cost_usd: float; turn: int }
   | PostToolUse of { tool_name: string; input: Yojson.Safe.t;
-                     output: Types.tool_result }
+                     output: Types.tool_result; result_bytes: int }
   | PostToolUseFailure of { tool_name: string; input: Yojson.Safe.t;
                             error: string }
   | OnStop of { reason: Types.stop_reason; response: Types.api_response }

--- a/test/test_approval.ml
+++ b/test/test_approval.ml
@@ -22,7 +22,8 @@ let run_execute ~hooks ?approval tool_uses =
     ~context:(Agent.context agent) ~tools:(Tool_set.to_list (Agent.tools agent))
     ~hooks:opts.hooks ~event_bus:opts.event_bus
     ~tracer:opts.tracer ~agent_name:(Agent.state agent).config.name
-    ~turn_count:(Agent.state agent).turn_count ~approval:opts.approval
+    ~turn_count:(Agent.state agent).turn_count ~usage:(Agent.state agent).usage
+    ~approval:opts.approval
     tool_uses
 
 (* --- Test cases --- *)

--- a/test/test_hooks.ml
+++ b/test/test_hooks.ml
@@ -25,13 +25,13 @@ let test_invoke_continue () =
 let test_invoke_skip () =
   let hook _event = Hooks.Skip in
   let result = Hooks.invoke (Some hook)
-    (Hooks.PreToolUse { tool_name = "echo"; input = `Null }) in
+    (Hooks.PreToolUse { tool_name = "echo"; input = `Null; accumulated_cost_usd = 0.0; turn = 0 }) in
   check bool "hook returns Skip" true (result = Hooks.Skip)
 
 let test_invoke_override () =
   let hook _event = Hooks.Override "custom value" in
   let result = Hooks.invoke (Some hook)
-    (Hooks.PreToolUse { tool_name = "echo"; input = `Null }) in
+    (Hooks.PreToolUse { tool_name = "echo"; input = `Null; accumulated_cost_usd = 0.0; turn = 0 }) in
   check bool "hook returns Override" true (result = Hooks.Override "custom value")
 
 let test_hook_receives_event () =
@@ -43,7 +43,7 @@ let test_hook_receives_event () =
     | _ -> Hooks.Continue
   in
   let _result = Hooks.invoke (Some hook)
-    (Hooks.PreToolUse { tool_name = "test_tool"; input = `Null }) in
+    (Hooks.PreToolUse { tool_name = "test_tool"; input = `Null; accumulated_cost_usd = 0.0; turn = 0 }) in
   check string "hook received tool_name" "test_tool" !received
 
 let test_post_tool_use_event () =
@@ -58,7 +58,8 @@ let test_post_tool_use_event () =
     (Hooks.PostToolUse {
       tool_name = "echo";
       input = `Null;
-      output = Ok { Types.content = "hello" }
+      output = Ok { Types.content = "hello" };
+      result_bytes = 5
     }) in
   check string "hook received output" "hello" !received_output
 
@@ -80,7 +81,7 @@ let test_post_tool_use_failure_event () =
 let test_invoke_approval_required () =
   let hook _event = Hooks.ApprovalRequired in
   let result = Hooks.invoke (Some hook)
-    (Hooks.PreToolUse { tool_name = "dangerous"; input = `Null }) in
+    (Hooks.PreToolUse { tool_name = "dangerous"; input = `Null; accumulated_cost_usd = 0.0; turn = 0 }) in
   check bool "hook returns ApprovalRequired" true (result = Hooks.ApprovalRequired)
 
 let () =


### PR DESCRIPTION
## Summary

PreToolUse와 PostToolUse hook event에 누락된 컨텍스트를 추가한다.

**PreToolUse**:
- `accumulated_cost_usd: float` — 현재까지 누적 비용. Consumer가 cost-based rejection 가능
- `turn: int` — 현재 턴 번호

**PostToolUse**:
- `result_bytes: int` — tool result 크기. Consumer가 context offload 판단 가능

### 왜 필요한가

MASC가 OAS Agent.run에 에이전트 라이프사이클을 위임하려면, OAS hook에서 MASC의 Eval_gate(비용 체크)와 Context_offload(대형 결과 처리)를 구현할 수 있어야 한다. 현재 PreToolUse에 비용 정보가 없어서 MASC가 자체 브릿지 코드를 유지해야 했다.

이 PR로 OAS hook만으로 두 기능을 구현할 수 있다:
- `PreToolUse { accumulated_cost_usd; _ }` -> budget 초과 시 `Skip` 반환
- `PostToolUse { result_bytes; _ }` -> threshold 초과 시 offload 후 `Override` 반환

### 변경 (+28 -14, 6 files)

| File | Change |
|------|--------|
| `hooks.ml/mli` | PreToolUse에 cost/turn, PostToolUse에 result_bytes 추가 |
| `agent_tools.ml` | execute_tools에 ~usage 파라미터 추가, 이벤트 생성 시 전달 |
| `agent_trace.ml` | usage 파라미터 전파 |
| `test_hooks.ml` | 새 필드 반영 |
| `test_approval.ml` | 새 필드 반영 |

## Test plan
- [x] 전체 테스트 통과 (`dune test --root .`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)