### PR TITLE
feat(builder): add with_memory for Memory.t injection

### DIFF
--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -29,6 +29,7 @@ type options = Agent_types.options = {
   elicitation: Hooks.elicitation_callback option;
   description: string option;
   periodic_callbacks: periodic_callback list;
+  memory: Memory.t option;
 }
 
 type lifecycle_status = Agent_lifecycle.lifecycle_status =
@@ -54,6 +55,7 @@ val context : t -> Context.t
 val options : t -> options
 val net : t -> [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
 val description : t -> string option
+val memory : t -> Memory.t option
 
 (** {1 Defaults} *)
 

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -23,6 +23,7 @@ type options = {
   elicitation: Hooks.elicitation_callback option;
   description: string option;
   periodic_callbacks: periodic_callback list;
+  memory: Memory.t option;
 }
 
 (* Re-export lifecycle types from Agent_lifecycle.
@@ -72,6 +73,7 @@ let default_options = {
   skill_registry = None;
   elicitation = None;
   description = None;
+  memory = None;
   periodic_callbacks = [];
 }
 
@@ -98,6 +100,7 @@ let options t = t.options
 let net t = t.net
 let set_state t s = t.state <- s
 let description t = t.options.description
+let memory t = t.options.memory
 
 let sdk_version = Sdk_version.version
 

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -45,6 +45,7 @@ type t = {
   description: string option;
   periodic_callbacks: Agent.periodic_callback list;
   contract: Contract.t;
+  memory: Memory.t option;
 }
 
 let create ~net ~model =
@@ -89,6 +90,7 @@ let create ~net ~model =
     description = None;
     periodic_callbacks = [];
     contract = Contract.empty;
+    memory = None;
   }
 
 let with_system_prompt prompt b = { b with system_prompt = Some prompt }
@@ -139,6 +141,7 @@ let with_context_injector injector b = { b with context_injector = Some injector
 let with_skill_registry reg b = { b with skill_registry = Some reg }
 let with_elicitation cb b = { b with elicitation = Some cb }
 let with_description desc b = { b with description = Some desc }
+let with_memory mem b = { b with memory = Some mem }
 let with_periodic_callback cb b =
   { b with periodic_callbacks = b.periodic_callbacks @ [cb] }
 let with_periodic_callbacks cbs b =
@@ -204,6 +207,7 @@ let build b =
     elicitation = b.elicitation;
     description = b.description;
     periodic_callbacks = b.periodic_callbacks;
+    memory = b.memory;
   } in
   Agent.create ~net:b.net ~config ~tools:(Tool_set.to_list tools) ?context
     ?named_cascade:b.named_cascade ~options ()

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -50,6 +50,7 @@ val with_event_bus : Event_bus.t -> t -> t
 val with_max_idle_turns : int -> t -> t
 val with_elicitation : Hooks.elicitation_callback -> t -> t
 val with_description : string -> t -> t
+val with_memory : Memory.t -> t -> t
 val with_periodic_callback : Agent.periodic_callback -> t -> t
 val with_periodic_callbacks : Agent.periodic_callback list -> t -> t
 


### PR DESCRIPTION
## Summary

- Builder에 `with_memory : Memory.t -> t -> t` 추가
- Agent options에 `memory: Memory.t option` 필드 추가
- Agent.mli에 `val memory : t -> Memory.t option` accessor 추가
- 하위 호환 (memory defaults to None)

## Usage

```ocaml
let backend = { persist; retrieve; remove } in
let memory = Memory.create ~long_term:backend () in
let agent = Builder.create ~net ~model:"qwen3.5"
  |> Builder.with_memory memory
  |> Builder.with_system_prompt "..."
  |> Builder.build
```

## Test plan

- [x] `dune build` 성공
- [x] Memory 테스트 15/15 통과
- [x] 기존 빌드 호환 (memory = None default)

## Next

MASC PR #1793 (Memory_oas_bridge)에서 이 API를 사용하여 memory_stream을 Agent.t에 연결.


🤖 Generated with [Claude Code](https://claude.com/claude-code)