### PR TITLE
feat: add .mli API contracts — batch 1 (agent/ submodules)

### DIFF
--- a/lib/agent/agent_checkpoint.mli
+++ b/lib/agent/agent_checkpoint.mli
@@ -1,0 +1,33 @@
+(** Checkpoint build/restore logic.
+
+    Takes explicit parameters to avoid circular dependency with [Agent.t].
+    The caller wraps results into [Agent.t]. *)
+
+(** {1 Resume} *)
+
+(** State recovered from a checkpoint. *)
+type resume_state = {
+  state: Types.agent_state;
+  context: Context.t;
+}
+
+(** Build restored state from a checkpoint.
+    Returns state + context; the caller wraps these into [Agent.t]. *)
+val build_resume :
+  checkpoint:Checkpoint.t ->
+  ?config:Types.agent_config ->
+  ?context:Context.t ->
+  unit -> resume_state
+
+(** {1 Checkpoint creation} *)
+
+(** Build a checkpoint from explicit state parameters.
+    The caller extracts fields from [Agent.t] before calling this. *)
+val build_checkpoint :
+  ?session_id:string ->
+  ?working_context:Yojson.Safe.t ->
+  state:Types.agent_state ->
+  tools:Tool_set.t ->
+  context:Context.t ->
+  mcp_clients:Mcp.managed list ->
+  unit -> Checkpoint.t

--- a/lib/agent/agent_handoff.mli
+++ b/lib/agent/agent_handoff.mli
@@ -1,0 +1,24 @@
+(** Handoff message helpers — pure functions for handoff detection
+    and message manipulation.
+
+    These functions operate only on [Types.message] lists and have no
+    dependency on [Agent.t]. *)
+
+(** {1 Handoff detection} *)
+
+(** Find the most recent assistant message and extract the first handoff
+    [ToolUse].  Returns [(tool_use_id, target_name, prompt)] or [None]. *)
+val find_handoff_in_messages :
+  Types.message list -> (string * string * string) option
+
+(** {1 Message manipulation} *)
+
+(** Replace the [ToolResult] for a specific [tool_id] in the most recent
+    user message.  Used by handoff interception to overwrite the sentinel
+    handler output with the delegated agent response. *)
+val replace_tool_result :
+  Types.message list ->
+  tool_id:string ->
+  content:string ->
+  is_error:bool ->
+  Types.message list

--- a/lib/agent/agent_lifecycle.mli
+++ b/lib/agent/agent_lifecycle.mli
@@ -1,0 +1,62 @@
+(** Lifecycle types and pure helpers for the Agent module.
+
+    Extracted from agent.ml to reduce file size.  No dependency on
+    [Agent.t] — all functions take explicit parameters. *)
+
+(** {1 Lifecycle status} *)
+
+type lifecycle_status =
+  | Accepted
+  | Ready
+  | Running
+  | Completed
+  | Failed
+[@@deriving show]
+
+(** Snapshot of an agent's lifecycle at a given moment. *)
+type lifecycle_snapshot = {
+  current_run_id: string option;
+  agent_name: string;
+  worker_id: string option;
+  runtime_actor: string option;
+  status: lifecycle_status;
+  requested_provider: string option;
+  requested_model: string option;
+  resolved_provider: string option;
+  resolved_model: string option;
+  last_error: string option;
+  accepted_at: float option;
+  ready_at: float option;
+  first_progress_at: float option;
+  started_at: float option;
+  last_progress_at: float option;
+  finished_at: float option;
+}
+
+(** {1 Construction} *)
+
+(** Extract a human-readable provider name from config. *)
+val provider_runtime_name : Provider.config option -> string option
+
+(** String representation of a hook decision for tracing. *)
+val hook_decision_to_string : Hooks.hook_decision -> string
+
+(** Build a new lifecycle snapshot, optionally merging with [previous].
+    Pure function — the caller handles mutation on [Agent.t]. *)
+val build_snapshot :
+  agent_name:string ->
+  provider:Provider.config option ->
+  model:Types.model ->
+  ?previous:lifecycle_snapshot ->
+  ?current_run_id:string ->
+  ?worker_id:string ->
+  ?runtime_actor:string ->
+  ?last_error:string ->
+  ?accepted_at:float ->
+  ?ready_at:float ->
+  ?first_progress_at:float ->
+  ?started_at:float ->
+  ?last_progress_at:float ->
+  ?finished_at:float ->
+  lifecycle_status ->
+  lifecycle_snapshot

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -5,14 +5,6 @@
 
 open Types
 
-let hook_decision_to_string = function
-  | Hooks.Continue -> "continue"
-  | Hooks.Skip -> "skip"
-  | Hooks.Override _ -> "override"
-  | Hooks.ApprovalRequired -> "approval_required"
-  | Hooks.AdjustParams _ -> "adjust_params"
-  | Hooks.ElicitInput _ -> "elicit_input"
-
 let invoke_hook ?on_hook_invoked ~tracer ~agent_name ~turn_count ~hook_name
     hook_opt event =
   Tracing.with_span tracer

--- a/lib/agent/agent_tools.mli
+++ b/lib/agent/agent_tools.mli
@@ -1,0 +1,75 @@
+(** Tool execution helpers — lookup, hooks, event bus, parallel Eio fibers.
+
+    These functions are parameterized by explicit fields rather than [Agent.t]
+    to avoid circular module dependencies ([Agent_tools] is compiled before
+    [Agent]). *)
+
+(** {1 Hook invocation} *)
+
+(** Invoke a hook, recording the decision via optional [on_hook_invoked] callback
+    and [tracer] span.  Returns the hook's decision. *)
+val invoke_hook :
+  ?on_hook_invoked:(hook_name:string ->
+    decision:Hooks.hook_decision ->
+    detail:string option -> unit) ->
+  tracer:Tracing.t ->
+  agent_name:string ->
+  turn_count:int ->
+  hook_name:string ->
+  (Hooks.hook_event -> Hooks.hook_decision) option ->
+  Hooks.hook_event ->
+  Hooks.hook_decision
+
+(** {1 Single tool execution} *)
+
+(** Find a tool by name and execute it, invoking [PostToolUse] (and
+    [PostToolUseFailure] on error) hooks.  Publishes [ToolCalled] and
+    [ToolCompleted] events to the event bus.
+    Returns [(tool_use_id, content, is_error)]. *)
+val find_and_execute_tool :
+  context:Context.t ->
+  tools:Tool.t list ->
+  hooks:Hooks.hooks ->
+  event_bus:Event_bus.t option ->
+  tracer:Tracing.t ->
+  agent_name:string ->
+  turn_count:int ->
+  ?on_hook_invoked:(hook_name:string ->
+    decision:Hooks.hook_decision ->
+    detail:string option -> unit) ->
+  string -> Yojson.Safe.t -> string ->
+  string * string * bool
+
+(** {1 Parallel tool execution} *)
+
+(** Execute tool-use content blocks in parallel using Eio fibers.
+
+    For each [ToolUse] block, applies the [PreToolUse] hook before execution.
+    Supports approval flow: if the hook returns [ApprovalRequired], the
+    [approval] callback is invoked.
+
+    Each fiber catches exceptions to prevent one tool failure from
+    canceling siblings (except [Out_of_memory], [Stack_overflow],
+    [Sys.Break]).
+
+    Returns [(tool_use_id, content, is_error)] triples in the same order
+    as the input. *)
+val execute_tools :
+  context:Context.t ->
+  tools:Tool.t list ->
+  hooks:Hooks.hooks ->
+  event_bus:Event_bus.t option ->
+  tracer:Tracing.t ->
+  agent_name:string ->
+  turn_count:int ->
+  usage:Types.usage_stats ->
+  approval:Hooks.approval_callback option ->
+  ?on_tool_execution_started:(tool_use_id:string ->
+    tool_name:string -> input:Yojson.Safe.t -> unit) ->
+  ?on_tool_execution_finished:(tool_use_id:string ->
+    tool_name:string -> content:string -> is_error:bool -> unit) ->
+  ?on_hook_invoked:(hook_name:string ->
+    decision:Hooks.hook_decision ->
+    detail:string option -> unit) ->
+  Types.content_block list ->
+  (string * string * bool) list

--- a/lib/agent/agent_trace.mli
+++ b/lib/agent/agent_trace.mli
@@ -1,0 +1,56 @@
+(** Raw-trace integration helpers for the Agent module.
+
+    Wraps [Raw_trace] calls with lifecycle updates and hook invocation
+    tracing.  These functions depend on [Agent_types.t] (mutable state). *)
+
+open Agent_types
+
+(** {1 Hook recording} *)
+
+(** Record a hook invocation in the active raw-trace run (no-op when
+    [active_run] is [None]). *)
+val record_hook_invocation :
+  Raw_trace.active_run option ->
+  hook_name:string ->
+  decision:Hooks.hook_decision ->
+  ?detail:string ->
+  unit -> unit
+
+(** Invoke a hook within a tracing span, recording the decision. *)
+val invoke_hook_with_trace :
+  t ->
+  ?raw_trace_run:Raw_trace.active_run ->
+  hook_name:string ->
+  (Hooks.hook_event -> Hooks.hook_decision) option ->
+  Hooks.hook_event ->
+  Hooks.hook_decision
+
+(** {1 Tool execution with tracing} *)
+
+(** Execute tool-use blocks with full raw-trace recording (started/finished
+    events, lifecycle updates).  Delegates to [Agent_tools.execute_tools]. *)
+val execute_tools_with_trace :
+  t ->
+  Raw_trace.active_run option ->
+  Types.content_block list ->
+  (string * string * bool) list
+
+(** {1 Assistant block recording} *)
+
+(** Record assistant content blocks in the active run. *)
+val trace_assistant_blocks :
+  Raw_trace.active_run option ->
+  Types.content_block list ->
+  (unit, Error.sdk_error) result
+
+(** {1 Run lifecycle} *)
+
+(** Execute [f] within a raw-trace run, handling start/finish recording
+    and lifecycle status updates.  [f] receives [Some active_run] when
+    raw-trace is configured, [None] otherwise. *)
+val with_raw_trace_run :
+  t ->
+  string ->
+  (Raw_trace.active_run option ->
+    (Types.api_response, Error.sdk_error) result) ->
+  (Types.api_response, Error.sdk_error) result

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -9,8 +9,6 @@
 
 open Types
 
-let ( let* ) = Result.bind
-
 (* ── Fingerprint-based idle detection ─────────────────────────── *)
 
 type tool_call_fingerprint = {

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -1,0 +1,122 @@
+(** Shared turn logic for sync and streaming paths.
+
+    Contains helper functions that both [Agent.run_turn_with_trace] and
+    [Agent.run_turn_stream_with_trace] call, eliminating code duplication.
+
+    These functions take explicit parameters (not [Agent.t]) to avoid
+    circular module dependency: [Agent -> Agent_turn] is fine,
+    [Agent_turn -> Agent] is not. *)
+
+(** {1 Idle detection} *)
+
+(** Fingerprint of a single tool call for idle detection. *)
+type tool_call_fingerprint = {
+  fp_name: string;
+  fp_input: string;
+}
+
+(** Compute fingerprints from content blocks containing [ToolUse]. *)
+val compute_fingerprints : Types.content_block list -> tool_call_fingerprint list
+
+(** Return [true] when [current] fingerprints match [prev] exactly. *)
+val is_idle : tool_call_fingerprint list option -> tool_call_fingerprint list -> bool
+
+(** {1 Turn preparation} *)
+
+(** Pre-processed inputs for an LLM turn. *)
+type turn_preparation = {
+  tools_json: Yojson.Safe.t list option;
+  effective_messages: Types.message list;
+  effective_guardrails: Guardrails.t;
+}
+
+(** Prepare tool schemas, applying optional [tool_filter_override]. *)
+val prepare_tools :
+  guardrails:Guardrails.t ->
+  tools:Tool_set.t ->
+  turn_params:Hooks.turn_params ->
+  Yojson.Safe.t list option * Guardrails.t
+
+(** Reduce messages and inject extra system context. *)
+val prepare_messages :
+  messages:Types.message list ->
+  context_reducer:Context_reducer.t option ->
+  turn_params:Hooks.turn_params ->
+  Types.message list
+
+(** Full turn preparation: tools + messages + guardrails. *)
+val prepare_turn :
+  guardrails:Guardrails.t ->
+  tools:Tool_set.t ->
+  messages:Types.message list ->
+  context_reducer:Context_reducer.t option ->
+  turn_params:Hooks.turn_params ->
+  turn_preparation
+
+(** {1 Usage accumulation} *)
+
+(** Accumulate response usage into running totals, including cost estimation. *)
+val accumulate_usage :
+  current_usage:Types.usage_stats ->
+  provider:Provider.config option ->
+  response_usage:Types.api_usage option ->
+  Types.usage_stats
+
+(** {1 Turn params resolution} *)
+
+(** Resolve per-turn parameters by invoking the [BeforeTurnParams] hook. *)
+val resolve_turn_params :
+  hooks:Hooks.hooks ->
+  messages:Types.message list ->
+  invoke_hook:(hook_name:string ->
+    (Hooks.hook_event -> Hooks.hook_decision) option ->
+    Hooks.hook_event ->
+    Hooks.hook_decision) ->
+  Hooks.turn_params
+
+(** {1 Context injection} *)
+
+(** Filter extra messages to avoid consecutive same-role entries. *)
+val filter_valid_messages :
+  messages:Types.message list ->
+  Types.message list ->
+  Types.message list
+
+(** Apply context injector after tool execution, updating context and messages. *)
+val apply_context_injection :
+  context:Context.t ->
+  messages:Types.message list ->
+  injector:Hooks.context_injector ->
+  tool_uses:Types.content_block list ->
+  results:(string * string * bool) list ->
+  Types.message list
+
+(** {1 Token budget} *)
+
+(** Check input/total token budgets; return an error if exceeded. *)
+val check_token_budget :
+  Types.agent_config -> Types.usage_stats -> Error.sdk_error option
+
+(** {1 Idle state tracking} *)
+
+type idle_state = {
+  last_tool_calls: tool_call_fingerprint list option;
+  consecutive_idle_turns: int;
+}
+
+type idle_result = {
+  new_state: idle_state;
+  is_idle: bool;
+}
+
+(** Update idle detection state after a tool-use turn. *)
+val update_idle_detection :
+  idle_state:idle_state ->
+  tool_uses:Types.content_block list ->
+  idle_result
+
+(** {1 Tool result construction} *)
+
+(** Convert [(id, content, is_error)] triples into [ToolResult] content blocks. *)
+val make_tool_results :
+  (string * string * bool) list -> Types.content_block list

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -1,0 +1,140 @@
+(** Core types for the Agent module.
+
+    [Agent_types.t] exposes record fields for library-internal code.
+    External consumers should use the abstract [Agent.t] and its
+    accessor functions instead. *)
+
+(** {1 Configuration} *)
+
+type periodic_callback = {
+  interval_sec: float;
+  callback: unit -> unit;
+}
+
+type options = {
+  base_url: string;
+  provider: Provider.config option;
+  cascade: Provider.cascade option;
+  max_idle_turns: int;
+  hooks: Hooks.hooks;
+  guardrails: Guardrails.t;
+  guardrails_async: Guardrails_async.t;
+  tracer: Tracing.t;
+  raw_trace: Raw_trace.t option;
+  approval: Hooks.approval_callback option;
+  context_reducer: Context_reducer.t option;
+  context_injector: Hooks.context_injector option;
+  mcp_clients: Mcp.managed list;
+  event_bus: Event_bus.t option;
+  skill_registry: Skill_registry.t option;
+  elicitation: Hooks.elicitation_callback option;
+  description: string option;
+  periodic_callbacks: periodic_callback list;
+  memory: Memory.t option;
+}
+
+(** {1 Lifecycle re-exports} *)
+
+type lifecycle_status = Agent_lifecycle.lifecycle_status =
+  | Accepted
+  | Ready
+  | Running
+  | Completed
+  | Failed
+[@@deriving show]
+
+type lifecycle_snapshot = Agent_lifecycle.lifecycle_snapshot = {
+  current_run_id: string option;
+  agent_name: string;
+  worker_id: string option;
+  runtime_actor: string option;
+  status: lifecycle_status;
+  requested_provider: string option;
+  requested_model: string option;
+  resolved_provider: string option;
+  resolved_model: string option;
+  last_error: string option;
+  accepted_at: float option;
+  ready_at: float option;
+  first_progress_at: float option;
+  started_at: float option;
+  last_progress_at: float option;
+  finished_at: float option;
+}
+
+(** {1 Agent state} *)
+
+type tool_call_fingerprint = Agent_turn.tool_call_fingerprint
+
+(** Mutable agent record — library-internal only.
+    External code must use [Agent.t] (abstract) and its accessors. *)
+type t = {
+  mutable state: Types.agent_state;
+  mutable lifecycle: lifecycle_snapshot option;
+  mutable last_tool_calls: tool_call_fingerprint list option;
+  mutable consecutive_idle_turns: int;
+  named_cascade: Api.named_cascade option;
+  tools: Tool_set.t;
+  net: [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t;
+  context: Context.t;
+  options: options;
+}
+
+(** {1 Defaults} *)
+
+val default_options : options
+
+(** {1 Accessors} *)
+
+val state : t -> Types.agent_state
+val lifecycle : t -> lifecycle_snapshot option
+val tools : t -> Tool_set.t
+val context : t -> Context.t
+val options : t -> options
+val net : t -> [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+val set_state : t -> Types.agent_state -> unit
+val description : t -> string option
+val memory : t -> Memory.t option
+
+(** {1 SDK version} *)
+
+val sdk_version : string
+
+(** {1 Construction} *)
+
+val create :
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?config:Types.agent_config ->
+  ?tools:Tool.t list ->
+  ?context:Context.t ->
+  ?named_cascade:Api.named_cascade ->
+  ?options:options ->
+  unit -> t
+
+val clone : ?copy_context:bool -> t -> t
+
+(** {1 Agent card} *)
+
+val card : t -> Agent_card.agent_card
+
+(** {1 Lifecycle management} *)
+
+val set_lifecycle :
+  t ->
+  ?current_run_id:string ->
+  ?worker_id:string ->
+  ?runtime_actor:string ->
+  ?last_error:string ->
+  ?accepted_at:float ->
+  ?ready_at:float ->
+  ?first_progress_at:float ->
+  ?started_at:float ->
+  ?last_progress_at:float ->
+  ?finished_at:float ->
+  Agent_lifecycle.lifecycle_status -> unit
+
+(** {1 Trace / Checkpoint} *)
+
+val last_raw_trace_run : t -> Raw_trace.run_ref option
+val lifecycle_snapshot : t -> lifecycle_snapshot option
+val close : t -> unit


### PR DESCRIPTION
## Summary
- Add .mli interface files for 7 agent/ submodules (agent_types, agent_turn, agent_tools, agent_lifecycle, agent_checkpoint, agent_handoff, agent_trace)
- Remove 2 dead code items exposed by .mli constraint (duplicate hook_decision_to_string, unused let* binding)
- Part of Phase 1 (v0.75 Foundation Hardening): .mli 100% coverage goal

## Test plan
- [x] `dune build --root .` green
- [x] `dune runtest --root .` all tests pass
- [ ] MASC compatibility check

🤖 Generated with [Claude Code](https://claude.com/claude-code)