### PR TITLE
feat: add .mli API contracts — batch 2 (sessions)

### DIFF
--- a/lib/sessions.mli
+++ b/lib/sessions.mli
@@ -1,0 +1,9 @@
+(** Sessions — public API facade.
+
+    Re-exports types from {!Sessions_types}, store operations from
+    {!Sessions_store}, and proof assembly from {!Sessions_proof}.
+    This module is the single entry point for session access. *)
+
+include module type of Sessions_types
+include module type of Sessions_store
+include module type of Sessions_proof

--- a/lib/sessions_proof.mli
+++ b/lib/sessions_proof.mli
@@ -1,0 +1,70 @@
+(** Sessions proof assembly — worker-run construction and proof bundle.
+
+    Transforms raw trace data and runtime participant metadata into
+    structured {!Sessions_types.worker_run} records and assembles
+    the complete {!Sessions_types.proof_bundle}. *)
+
+open Sessions_types
+
+(** {1 Worker run construction} *)
+
+val worker_run_of_raw :
+  Runtime.session -> raw_trace_summary -> raw_trace_validation -> worker_run
+
+val summary_only_worker_run :
+  Runtime.session -> int -> Runtime.participant -> worker_run
+
+(** {1 Worker run queries} *)
+
+val sort_worker_runs : worker_run list -> worker_run list
+
+val latest_worker_by :
+  (worker_run -> bool) -> worker_run list -> worker_run option
+
+val get_worker_runs :
+  ?session_root:string -> session_id:string -> unit ->
+  (worker_run list, Error.sdk_error) result
+
+val get_latest_worker_run :
+  ?session_root:string -> session_id:string -> unit ->
+  (worker_run option, Error.sdk_error) result
+
+val get_latest_accepted_worker_run :
+  ?session_root:string -> session_id:string -> unit ->
+  (worker_run option, Error.sdk_error) result
+
+val get_latest_ready_worker_run :
+  ?session_root:string -> session_id:string -> unit ->
+  (worker_run option, Error.sdk_error) result
+
+val get_latest_running_worker_run :
+  ?session_root:string -> session_id:string -> unit ->
+  (worker_run option, Error.sdk_error) result
+
+val get_latest_completed_worker_run :
+  ?session_root:string -> session_id:string -> unit ->
+  (worker_run option, Error.sdk_error) result
+
+val get_latest_failed_worker_run :
+  ?session_root:string -> session_id:string -> unit ->
+  (worker_run option, Error.sdk_error) result
+
+val get_latest_validated_worker_run :
+  ?session_root:string -> session_id:string -> unit ->
+  (worker_run option, Error.sdk_error) result
+
+(** {1 Evidence capabilities} *)
+
+val unique_trace_capabilities : worker_run list -> trace_capability list
+
+val evidence_capabilities_of_bundle :
+  raw_trace_runs:raw_trace_run list ->
+  raw_trace_summaries:raw_trace_summary list ->
+  raw_trace_validations:raw_trace_validation list ->
+  evidence_capabilities
+
+(** {1 Proof bundle} *)
+
+val get_proof_bundle :
+  ?session_root:string -> session_id:string -> unit ->
+  (proof_bundle, Error.sdk_error) result

--- a/lib/sessions_store.mli
+++ b/lib/sessions_store.mli
@@ -1,0 +1,151 @@
+(** Sessions store operations — file I/O, artifact retrieval, raw trace access.
+
+    Read-from-store operations that bridge the runtime file layout
+    with the typed Sessions domain. *)
+
+open Sessions_types
+
+(** {1 Store construction} *)
+
+val make_store :
+  ?session_root:string -> unit ->
+  (Runtime_store.t, Error.sdk_error) result
+
+(** {1 Helpers} *)
+
+val file_read_error : path:string -> detail:string -> Error.sdk_error
+
+val first_some : 'a option -> 'a option -> 'a option
+
+val primary_alias : string list -> string option
+
+val latest_named_artifact :
+  Runtime.artifact list -> string -> Runtime.artifact option
+
+(** {1 Session access} *)
+
+val list_sessions :
+  ?session_root:string -> unit ->
+  (session_info list, Error.sdk_error) result
+
+val get_session :
+  ?session_root:string -> string ->
+  (Runtime.session, Error.sdk_error) result
+
+val get_session_events :
+  ?session_root:string -> string ->
+  (Runtime.event list, Error.sdk_error) result
+
+(** {1 Report / Proof} *)
+
+val get_report :
+  ?session_root:string -> session_id:string -> unit ->
+  (Runtime.report, Error.sdk_error) result
+
+val get_proof :
+  ?session_root:string -> session_id:string -> unit ->
+  (Runtime.proof, Error.sdk_error) result
+
+(** {1 Artifacts} *)
+
+val get_named_artifact :
+  ?session_root:string -> session_id:string -> name:string -> unit ->
+  (Runtime.artifact, Error.sdk_error) result
+
+val get_optional_named_artifact :
+  ?session_root:string -> session_id:string -> name:string -> unit ->
+  (Runtime.artifact option, Error.sdk_error) result
+
+val list_artifacts :
+  ?session_root:string -> session_id:string -> unit ->
+  (Runtime.artifact list, Error.sdk_error) result
+
+val get_artifact_text :
+  ?session_root:string -> session_id:string -> artifact_id:string -> unit ->
+  (string, Error.sdk_error) result
+
+(** {1 Telemetry} *)
+
+val get_telemetry :
+  ?session_root:string -> session_id:string -> unit ->
+  (telemetry, Error.sdk_error) result
+
+val get_telemetry_structured :
+  ?session_root:string -> session_id:string -> unit ->
+  (structured_telemetry, Error.sdk_error) result
+
+(** {1 Evidence} *)
+
+val get_evidence :
+  ?session_root:string -> session_id:string -> unit ->
+  (evidence, Error.sdk_error) result
+
+(** {1 Hooks} *)
+
+val get_hook_summary :
+  ?session_root:string -> session_id:string -> unit ->
+  (hook_summary list, Error.sdk_error) result
+
+(** {1 Tool catalog} *)
+
+val get_tool_catalog :
+  ?session_root:string -> session_id:string -> unit ->
+  (tool_contract list, Error.sdk_error) result
+
+(** {1 Raw trace} *)
+
+val get_raw_trace_dir :
+  ?session_root:string -> session_id:string -> unit ->
+  (string, Error.sdk_error) result
+
+val get_raw_trace_files :
+  ?session_root:string -> session_id:string -> unit ->
+  (string list, Error.sdk_error) result
+
+val get_raw_trace_runs :
+  ?session_root:string -> session_id:string -> unit ->
+  (raw_trace_run list, Error.sdk_error) result
+
+val get_raw_trace_run :
+  ?session_root:string -> session_id:string -> worker_run_id:string -> unit ->
+  (raw_trace_run, Error.sdk_error) result
+
+val get_raw_trace_records :
+  ?session_root:string -> session_id:string -> worker_run_id:string -> unit ->
+  (Raw_trace.record list, Error.sdk_error) result
+
+val get_raw_trace_summary :
+  ?session_root:string -> session_id:string -> worker_run_id:string -> unit ->
+  (raw_trace_summary, Error.sdk_error) result
+
+val validate_raw_trace_run :
+  ?session_root:string -> session_id:string -> worker_run_id:string -> unit ->
+  (raw_trace_validation, Error.sdk_error) result
+
+val get_latest_raw_trace_run :
+  ?session_root:string -> session_id:string -> unit ->
+  (raw_trace_run option, Error.sdk_error) result
+
+val summarize_runs :
+  raw_trace_run list -> (raw_trace_summary list, Error.sdk_error) result
+
+val get_raw_trace_summaries :
+  ?session_root:string -> session_id:string -> unit ->
+  (raw_trace_summary list, Error.sdk_error) result
+
+val validate_runs :
+  raw_trace_run list -> (raw_trace_validation list, Error.sdk_error) result
+
+val get_raw_trace_validations :
+  ?session_root:string -> session_id:string -> unit ->
+  (raw_trace_validation list, Error.sdk_error) result
+
+(** {1 Session mutation} *)
+
+val rename_session :
+  ?session_root:string -> session_id:string -> title:string -> unit ->
+  (unit, Error.sdk_error) result
+
+val tag_session :
+  ?session_root:string -> session_id:string -> tag:string option -> unit ->
+  (unit, Error.sdk_error) result

--- a/lib/sessions_store_parsers.mli
+++ b/lib/sessions_store_parsers.mli
@@ -1,0 +1,38 @@
+(** Pure JSON decoders for session store artifacts.
+
+    Stateless parsing functions bridging raw JSON to typed
+    {!Sessions_types} records.  No file I/O or store access. *)
+
+(** {1 Generic JSON parsing} *)
+
+val parse_json_string :
+  string -> (Yojson.Safe.t, Error.sdk_error) result
+
+val parse_runtime_json :
+  (Yojson.Safe.t -> ('a, string) result) ->
+  string -> ('a, Error.sdk_error) result
+
+val decode_json_with :
+  (Yojson.Safe.t -> 'a) ->
+  string -> ('a, Error.sdk_error) result
+
+(** {1 Domain decoders} *)
+
+val shell_constraints_of_json : Yojson.Safe.t -> Tool.shell_constraints option
+
+val tool_contract_of_json : Yojson.Safe.t -> Sessions_types.tool_contract
+
+val telemetry_of_json : Yojson.Safe.t -> Sessions_types.telemetry
+
+val structured_telemetry_of_json :
+  Yojson.Safe.t -> Sessions_types.structured_telemetry
+
+val evidence_of_json : Yojson.Safe.t -> Sessions_types.evidence
+
+(** {1 Helpers} *)
+
+val contains_substring : sub:string -> string -> bool
+
+val workdir_policy_of_string : string -> Tool.workdir_policy option
+
+val infer_event_name_from_kind : string -> string

--- a/lib/sessions_types.mli
+++ b/lib/sessions_types.mli
@@ -1,0 +1,208 @@
+(** Sessions type definitions — pure data structures.
+
+    All types carry [@@deriving yojson, show] for serialisation. *)
+
+type trace_capability =
+  | Raw [@name "raw"]
+  | Summary_only [@name "summary_only"]
+  | No_trace [@name "none"]
+[@@deriving yojson, show]
+
+type session_info = {
+  session_id: string;
+  title: string option;
+  tag: string option;
+  goal: string;
+  updated_at: float;
+  phase: Runtime.phase;
+  participant_count: int;
+  path: string;
+}
+[@@deriving yojson, show]
+
+type telemetry_event_count = {
+  name: string;
+  count: int;
+}
+[@@deriving yojson, show]
+
+type telemetry_step = {
+  seq: int;
+  ts: float;
+  kind: string;
+  participant: string option;
+  detail: string option;
+}
+[@@deriving yojson, show]
+
+type telemetry = {
+  session_id: string;
+  generated_at: float;
+  step_count: int;
+  event_counts: telemetry_event_count list;
+  steps: telemetry_step list;
+}
+[@@deriving yojson, show]
+
+type structured_event_count = {
+  event_name: string;
+  count: int;
+}
+[@@deriving yojson, show]
+
+type structured_telemetry_step = {
+  seq: int;
+  ts: float;
+  event_name: string;
+  participant: string option;
+  detail: string option;
+  actor: string option;
+  role: string option;
+  provider: string option;
+  model: string option;
+  artifact_id: string option;
+  artifact_name: string option;
+  artifact_kind: string option;
+  checkpoint_label: string option;
+  outcome: string option;
+}
+[@@deriving yojson, show]
+
+type structured_telemetry = {
+  session_id: string;
+  generated_at: float;
+  step_count: int;
+  event_counts: structured_event_count list;
+  steps: structured_telemetry_step list;
+}
+[@@deriving yojson, show]
+
+type evidence_file = {
+  label: string;
+  path: string;
+  size_bytes: int;
+  md5: string;
+}
+[@@deriving yojson, show]
+
+type missing_file = {
+  label: string;
+  path: string;
+}
+[@@deriving yojson, show]
+
+type evidence = {
+  session_id: string;
+  generated_at: float;
+  files: evidence_file list;
+  missing_files: missing_file list;
+}
+[@@deriving yojson, show]
+
+type hook_summary = {
+  hook_name: string;
+  count: int;
+  latest_decision: string option;
+  latest_detail: string option;
+  latest_ts: float option;
+}
+[@@deriving yojson, show]
+
+type tool_contract = {
+  name: string;
+  description: string;
+  origin: string option;
+  kind: string option;
+  shell: Tool.shell_constraints option;
+  notes: string list;
+  examples: string list;
+}
+[@@deriving yojson, show]
+
+type raw_trace_run = Raw_trace.run_ref
+[@@deriving yojson, show]
+type raw_trace_summary = Raw_trace.run_summary
+[@@deriving yojson, show]
+type raw_trace_validation = Raw_trace.run_validation
+[@@deriving yojson, show]
+
+type worker_status =
+  | Planned [@name "planned"]
+  | Accepted [@name "accepted"]
+  | Ready [@name "ready"]
+  | Running [@name "running"]
+  | Completed [@name "completed"]
+  | Failed [@name "failed"]
+[@@deriving yojson, show]
+
+type worker_run = {
+  worker_run_id: string;
+  worker_id: string option;
+  agent_name: string;
+  runtime_actor: string option;
+  role: string option;
+  aliases: string list;
+  primary_alias: string option;
+  provider: string option;
+  model: string option;
+  requested_provider: string option;
+  requested_model: string option;
+  requested_policy: string option;
+  resolved_provider: string option;
+  resolved_model: string option;
+  status: worker_status;
+  trace_capability: trace_capability;
+  validated: bool;
+  tool_names: string list;
+  final_text: string option;
+  stop_reason: string option;
+  error: string option;
+  failure_reason: string option;
+  accepted_at: float option;
+  ready_at: float option;
+  first_progress_at: float option;
+  started_at: float option;
+  finished_at: float option;
+  last_progress_at: float option;
+  policy_snapshot: string option;
+  paired_tool_result_count: int;
+  has_file_write: bool;
+  verification_pass_after_file_write: bool;
+}
+[@@deriving yojson, show]
+
+type evidence_capabilities = {
+  raw_trace: bool;
+  validated_summary: bool;
+  proof_bundle: bool;
+}
+[@@deriving yojson, show]
+
+type proof_bundle = {
+  session: Runtime.session;
+  report: Runtime.report;
+  proof: Runtime.proof;
+  telemetry: telemetry;
+  structured_telemetry: structured_telemetry;
+  evidence: evidence;
+  hook_summary: hook_summary list;
+  tool_catalog: tool_contract list;
+  latest_raw_trace_run: raw_trace_run option;
+  raw_trace_runs: raw_trace_run list;
+  raw_trace_summaries: raw_trace_summary list;
+  raw_trace_validations: raw_trace_validation list;
+  worker_runs: worker_run list;
+  latest_accepted_worker_run: worker_run option;
+  latest_ready_worker_run: worker_run option;
+  latest_running_worker_run: worker_run option;
+  latest_worker_run: worker_run option;
+  latest_completed_worker_run: worker_run option;
+  latest_validated_worker_run: worker_run option;
+  latest_failed_worker_run: worker_run option;
+  validated_worker_runs: worker_run list;
+  raw_trace_run_count: int;
+  validated_worker_run_count: int;
+  trace_capabilities: trace_capability list;
+  capabilities: evidence_capabilities;
+}
+[@@deriving yojson, show]


### PR DESCRIPTION
## Summary
- Add .mli interface files for 5 sessions modules (sessions_types, sessions_store_parsers, sessions_store, sessions_proof, sessions facade)
- Part of Phase 1 (v0.75 Foundation Hardening): .mli 100% coverage goal

## Test plan
- [x] `dune build --root .` green
- [x] `dune runtest --root .` all tests pass
- [ ] MASC compatibility check

🤖 Generated with [Claude Code](https://claude.com/claude-code)