### PR TITLE
feat: add .mli API contracts — batch 3 (api + llm_provider)

### DIFF
--- a/lib/api.mli
+++ b/lib/api.mli
@@ -1,0 +1,115 @@
+(** API dispatch — routes requests to provider-specific backends. *)
+
+(** {1 Named cascade} *)
+
+type named_cascade = {
+  name : string;
+  defaults : string list;
+  config_path : string option;
+}
+
+val named_cascade :
+  ?config_path:string -> name:string -> defaults:string list ->
+  unit -> named_cascade
+
+(** {1 Re-exports from Api_common} *)
+
+val default_base_url : string
+val api_version : string
+val max_response_body : int
+val string_is_blank : string -> bool
+val text_blocks_to_string : Types.content_block list -> string
+val json_of_string_or_raw : string -> Yojson.Safe.t
+val content_block_to_json : Types.content_block -> Yojson.Safe.t
+val content_block_of_json : Yojson.Safe.t -> Types.content_block option
+val message_to_json : Types.message -> Yojson.Safe.t
+val make_https :
+  unit ->
+  (Uri.t ->
+   [> `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t ->
+   Tls_eio.t) option
+
+(** {1 Re-exports from Api_anthropic} *)
+
+val parse_response : Yojson.Safe.t -> Types.api_response
+val build_body_assoc :
+  config:Types.agent_state ->
+  messages:Types.message list ->
+  ?tools:Yojson.Safe.t list ->
+  stream:bool ->
+  unit -> (string * Yojson.Safe.t) list
+
+(** {1 Re-exports from Api_openai} *)
+
+val openai_messages_of_message : Types.message -> Yojson.Safe.t list
+val openai_content_parts_of_blocks : Types.content_block list -> Yojson.Safe.t list
+val build_openai_body :
+  ?provider_config:Provider.config ->
+  config:Types.agent_state ->
+  messages:Types.message list ->
+  ?tools:Yojson.Safe.t list ->
+  unit -> string
+val parse_openai_response : string -> Types.api_response
+
+(** {1 Non-streaming request} *)
+
+val create_message :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?base_url:string ->
+  ?provider:Provider.config ->
+  ?clock:_ Eio.Time.clock ->
+  ?retry_config:Retry.retry_config ->
+  config:Types.agent_state ->
+  messages:Types.message list ->
+  ?tools:Yojson.Safe.t list ->
+  unit ->
+  (Types.api_response, Error.sdk_error) result
+
+(** {1 Cascade request} *)
+
+val create_message_cascade :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?clock:_ Eio.Time.clock ->
+  ?retry_config:Retry.retry_config ->
+  cascade:Provider.cascade ->
+  config:Types.agent_state ->
+  messages:Types.message list ->
+  ?tools:Yojson.Safe.t list ->
+  unit ->
+  (Types.api_response, Error.sdk_error) result
+
+(** {1 Named cascade request} *)
+
+val create_message_named :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?clock:_ Eio.Time.clock ->
+  named_cascade:named_cascade ->
+  config:Types.agent_state ->
+  messages:Types.message list ->
+  ?tools:Yojson.Safe.t list ->
+  ?temperature:float ->
+  ?max_tokens:int ->
+  ?system_prompt:string ->
+  ?accept:(Types.api_response -> bool) ->
+  ?timeout_sec:int ->
+  unit ->
+  (Types.api_response, Error.sdk_error) result
+
+val create_message_named_stream :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?clock:_ Eio.Time.clock ->
+  named_cascade:named_cascade ->
+  config:Types.agent_state ->
+  messages:Types.message list ->
+  ?tools:Yojson.Safe.t list ->
+  ?temperature:float ->
+  ?max_tokens:int ->
+  ?system_prompt:string ->
+  ?timeout_sec:int ->
+  on_event:(Types.sse_event -> unit) ->
+  unit ->
+  (Types.api_response, Error.sdk_error) result

--- a/lib/api_anthropic.mli
+++ b/lib/api_anthropic.mli
@@ -1,0 +1,12 @@
+(** Anthropic Claude API request building and response parsing. *)
+
+(** Parse Anthropic API response JSON. *)
+val parse_response : Yojson.Safe.t -> Types.api_response
+
+(** Build request body assoc list for Anthropic Messages API. *)
+val build_body_assoc :
+  config:Types.agent_state ->
+  messages:Types.message list ->
+  ?tools:Yojson.Safe.t list ->
+  stream:bool ->
+  unit -> (string * Yojson.Safe.t) list

--- a/lib/api_common.mli
+++ b/lib/api_common.mli
@@ -1,0 +1,2 @@
+(** Re-export from {!Llm_provider.Api_common} for backward compatibility. *)
+include module type of Llm_provider.Api_common

--- a/lib/api_openai.mli
+++ b/lib/api_openai.mli
@@ -1,0 +1,15 @@
+(** OpenAI-compatible API request building and response parsing.
+
+    Includes re-exports from {!Llm_provider.Backend_openai}. *)
+
+include module type of Llm_provider.Backend_openai
+
+(** Build OpenAI-compatible request body JSON string.
+    Respects provider capabilities for tool_choice, top_k, min_p,
+    reasoning, response_format_json. *)
+val build_openai_body :
+  ?provider_config:Provider.config ->
+  config:Types.agent_state ->
+  messages:Types.message list ->
+  ?tools:Yojson.Safe.t list ->
+  unit -> string

--- a/lib/llm_provider/error.mli
+++ b/lib/llm_provider/error.mli
@@ -1,0 +1,12 @@
+(** Provider-level error types.
+
+    Independent of the OAS [Error.sdk_error] hierarchy. *)
+
+type provider_error =
+  | MissingApiKey of { var_name: string }
+  | InvalidConfig of { field: string; detail: string }
+  | ParseError of { detail: string }
+  | UnknownVariant of { type_name: string; value: string }
+  | ProviderUnavailable of { provider: string; detail: string }
+
+val to_string : provider_error -> string

--- a/lib/llm_provider/pricing.mli
+++ b/lib/llm_provider/pricing.mli
@@ -1,0 +1,23 @@
+(** Per-model cost estimation. *)
+
+type pricing = {
+  input_per_million: float;
+  output_per_million: float;
+  cache_write_multiplier: float;
+  cache_read_multiplier: float;
+}
+
+(** Substring match helper. *)
+val string_contains : needle:string -> string -> bool
+
+(** Look up pricing for a model ID (case-insensitive, prefix-matched). *)
+val pricing_for_model : string -> pricing
+
+(** Estimate USD cost from token counts. *)
+val estimate_cost :
+  pricing:pricing ->
+  input_tokens:int ->
+  output_tokens:int ->
+  ?cache_creation_input_tokens:int ->
+  ?cache_read_input_tokens:int ->
+  unit -> float

--- a/lib/llm_provider/retry.mli
+++ b/lib/llm_provider/retry.mli
@@ -1,0 +1,45 @@
+(** Structured API errors and retry logic with exponential backoff + jitter. *)
+
+(** {1 Error types} *)
+
+type api_error =
+  | RateLimited of { retry_after: float option; message: string }
+  | Overloaded of { message: string }
+  | ServerError of { status: int; message: string }
+  | AuthError of { message: string }
+  | InvalidRequest of { message: string }
+  | NetworkError of { message: string }
+  | Timeout of { message: string }
+
+type retry_config = {
+  max_retries: int;
+  initial_delay: float;
+  max_delay: float;
+  backoff_factor: float;
+}
+
+val default_config : retry_config
+
+(** {1 Error classification} *)
+
+val is_retryable : api_error -> bool
+val error_message : api_error -> string
+val classify_error : status:int -> body:string -> api_error
+
+(** {1 Retry execution} *)
+
+val calculate_delay : retry_config -> int -> float
+
+val with_retry :
+  clock:_ Eio.Time.clock ->
+  ?config:retry_config ->
+  (unit -> ('a, api_error) result) ->
+  ('a, api_error) result
+
+val with_cascade :
+  clock:_ Eio.Time.clock ->
+  ?config:retry_config ->
+  primary:(unit -> ('a, api_error) result) ->
+  fallbacks:(unit -> ('a, api_error) result) list ->
+  unit ->
+  ('a, api_error) result

--- a/lib/llm_provider/sse_parser.mli
+++ b/lib/llm_provider/sse_parser.mli
@@ -1,0 +1,18 @@
+(** SSE (Server-Sent Events) line-level parser.
+
+    Follows the SSE spec: event/data/id/retry fields,
+    blank line = dispatch. *)
+
+type raw_sse_event = {
+  event_type: string option;
+  data: string;
+  id: string option;
+  retry: int option;
+}
+
+(** Parse SSE lines from a buffered reader, calling [on_event] for
+    each complete event.  Returns when the stream ends. *)
+val parse_lines :
+  Eio.Buf_read.t ->
+  on_event:(raw_sse_event -> unit) ->
+  unit


### PR DESCRIPTION
## Summary
- Add .mli interface files for 8 api/llm_provider modules
- Part of Phase 1 (v0.75 Foundation Hardening): .mli 100% coverage goal

## Test plan
- [x] `dune build --root .` green
- [x] `dune runtest --root .` all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)