### PR TITLE
feat: add .mli API contracts — batch 4 (runtime + protocol)

### DIFF
--- a/lib/protocol/agent_card.mli
+++ b/lib/protocol/agent_card.mli
@@ -1,0 +1,70 @@
+(** Agent Card — self-describing metadata for agent capability negotiation.
+
+    Inspired by the A2A (Agent-to-Agent) protocol. *)
+
+(** {1 Capability} *)
+
+type capability =
+  | Tools
+  | Streaming
+  | Thinking
+  | StructuredOutput
+  | Handoff
+  | Checkpoint
+  | MCP
+  | Elicitation
+  | Custom_cap of string
+[@@deriving yojson, show]
+
+val capability_to_string : capability -> string
+val capability_of_string : string -> capability
+
+(** {1 Agent Card} *)
+
+type authentication = {
+  schemes: string list;
+  credentials: string option;
+}
+
+type agent_card = {
+  name: string;
+  description: string option;
+  version: string;
+  url: string option;
+  authentication: authentication option;
+  capabilities: capability list;
+  tools: Types.tool_schema list;
+  skills: Skill.t list;
+  supported_providers: string list;
+  metadata: (string * Yojson.Safe.t) list;
+}
+
+(** {1 Serialization} *)
+
+val to_json : agent_card -> Yojson.Safe.t
+val of_json : Yojson.Safe.t -> (agent_card, Error.sdk_error) result
+
+(** {1 Construction from agent info} *)
+
+type agent_info = {
+  agent_name: string;
+  agent_description: string option;
+  version: string;
+  config: Types.agent_config;
+  tool_schemas: Types.tool_schema list;
+  provider: Provider.config option;
+  cascade: Provider.cascade option;
+  mcp_clients_count: int;
+  has_elicitation: bool;
+  skill_registry: Skill_registry.t option;
+}
+
+val provider_name : Provider.config -> string
+
+val of_info : agent_info -> agent_card
+
+(** {1 Queries} *)
+
+val has_capability : agent_card -> capability -> bool
+val can_handle_tool : agent_card -> string -> bool
+val has_skill : agent_card -> string -> bool

--- a/lib/protocol/mcp_schema.mli
+++ b/lib/protocol/mcp_schema.mli
@@ -1,0 +1,26 @@
+(** MCP schema bridge — converts between MCP SDK types and OAS types. *)
+
+module Sdk_types = Mcp_protocol.Mcp_types
+
+(** {1 Schema conversion} *)
+
+val json_schema_type_to_param_type : string -> Types.param_type
+val json_schema_to_params : Yojson.Safe.t -> Types.tool_param list
+
+(** {1 MCP tool types} *)
+
+type mcp_tool = {
+  name: string;
+  description: string;
+  input_schema: Yojson.Safe.t;
+}
+
+type mcp_resource = Sdk_types.resource
+type mcp_resource_contents = Sdk_types.resource_contents
+type mcp_prompt = Sdk_types.prompt
+type mcp_prompt_result = Sdk_types.prompt_result
+
+val mcp_tool_of_sdk_tool : Sdk_types.tool -> mcp_tool
+val mcp_tool_to_sdk_tool :
+  call_fn:Tool.tool_handler ->
+  mcp_tool -> Tool.t

--- a/lib/runtime_client.mli
+++ b/lib/runtime_client.mli
@@ -1,0 +1,75 @@
+(** Client for the runtime protocol over stdio transport. *)
+
+(** {1 Options} *)
+
+type options = Transport.options = {
+  runtime_path: string option;
+  session_root: string option;
+  provider: string option;
+  model: string option;
+  permission_mode: string option;
+  include_partial_messages: bool;
+  setting_sources: string list;
+  resume_session: string option;
+  cwd: string option;
+}
+
+val default_options : options
+
+(** {1 Client} *)
+
+type t
+
+val connect :
+  sw:Eio.Switch.t ->
+  mgr:_ Eio.Process.mgr ->
+  ?options:options ->
+  unit ->
+  (t, Error.sdk_error) result
+
+val request :
+  ?control_handler:Transport.control_handler ->
+  ?event_handler:Transport.event_handler ->
+  t -> Runtime.request ->
+  (Runtime.response, Error.sdk_error) result
+
+val close : t -> unit
+
+(** {1 Convenience helpers} *)
+
+val init_info : t -> (Runtime.response, Error.sdk_error) result
+val get_server_info : t -> Runtime.init_response option
+
+val start_session :
+  ?control_handler:Transport.control_handler ->
+  ?event_handler:Transport.event_handler ->
+  t -> Runtime.start_request ->
+  (Runtime.session, Error.sdk_error) result
+
+val apply_command :
+  ?control_handler:Transport.control_handler ->
+  ?event_handler:Transport.event_handler ->
+  t -> session_id:string -> Runtime.command ->
+  (Runtime.session, Error.sdk_error) result
+
+val status :
+  t -> session_id:string ->
+  (Runtime.session, Error.sdk_error) result
+
+val events :
+  t -> session_id:string -> ?after_seq:int -> unit ->
+  (Runtime.event list, Error.sdk_error) result
+
+val finalize :
+  ?control_handler:Transport.control_handler ->
+  ?event_handler:Transport.event_handler ->
+  t -> session_id:string -> ?reason:string -> unit ->
+  (Runtime.session, Error.sdk_error) result
+
+val report :
+  t -> session_id:string ->
+  (Runtime.report, Error.sdk_error) result
+
+val prove :
+  t -> session_id:string ->
+  (Runtime.proof, Error.sdk_error) result

--- a/lib/runtime_query.mli
+++ b/lib/runtime_query.mli
@@ -1,0 +1,9 @@
+(** Convenience wrapper for one-shot runtime protocol queries. *)
+
+val query :
+  sw:Eio.Switch.t ->
+  mgr:_ Eio.Process.mgr ->
+  ?runtime_path:string ->
+  ?session_root:string ->
+  Runtime.request ->
+  (Runtime.response, Error.sdk_error) result

--- a/lib/runtime_server_resolve.mli
+++ b/lib/runtime_server_resolve.mli
@@ -1,0 +1,20 @@
+(** Provider resolution for the runtime server. *)
+
+type execution_resolution = {
+  selected_provider: string;
+  requested_model: string option;
+  resolved_provider: string option;
+  resolved_model: string option;
+  provider_cfg: Provider.config option;
+}
+
+val provider_runtime_name :
+  string -> Provider.config option -> string
+
+val resolve_provider :
+  ?provider:string -> ?model:string -> unit ->
+  Provider.config option
+
+val resolve_execution :
+  Runtime.session -> Runtime.spawn_agent_request ->
+  execution_resolution

--- a/lib/runtime_server_types.mli
+++ b/lib/runtime_server_types.mli
@@ -1,0 +1,29 @@
+(** Server-side state and helpers for the runtime server. *)
+
+type state = {
+  net: [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t;
+  event_bus: Event_bus.t;
+  mutable session_root: string option;
+  mutable next_control_id: int;
+  stdout_mu: Eio.Mutex.t;
+  store_mu: Eio.Mutex.t;
+}
+
+val runtime_version : string
+
+val create :
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  unit -> state
+
+val store_of_state :
+  state -> (Runtime_store.t, Error.sdk_error) result
+
+val session_root_request_path : string option -> string option
+
+val write_protocol_message :
+  state -> Runtime.protocol_message -> unit
+
+val next_control_id : state -> string
+
+val emit_event :
+  state -> string -> Runtime.event -> unit

--- a/lib/runtime_server_worker.mli
+++ b/lib/runtime_server_worker.mli
@@ -1,0 +1,40 @@
+(** Runtime server worker — agent execution and event persistence. *)
+
+open Runtime_server_types
+open Runtime_server_resolve
+
+(** {1 Helpers} *)
+
+val extract_text : Types.api_response -> string
+val make_event : Runtime.session -> Runtime.event_kind -> Runtime.event
+
+(** {1 Event persistence} *)
+
+val with_store_lock : state -> (unit -> 'a) -> 'a
+
+val persist_event_locked :
+  Runtime_store.t -> state -> Runtime.session -> Runtime.event_kind ->
+  (Runtime.session * Runtime.event, Error.sdk_error) result
+
+val persist_event :
+  Runtime_store.t -> state -> string -> Runtime.event_kind ->
+  (Runtime.session * Runtime.event, Error.sdk_error) result
+
+(** {1 Report generation} *)
+
+val generate_report_and_proof :
+  Runtime_store.t -> state -> string ->
+  (Runtime.session * Runtime.report * Runtime.proof, Error.sdk_error) result
+
+(** {1 Output streaming} *)
+
+val emit_output_delta :
+  Runtime_store.t -> state -> string -> string -> string ->
+  (unit, Error.sdk_error) result
+
+(** {1 Participant execution} *)
+
+val run_participant :
+  Runtime_store.t -> state -> string ->
+  execution_resolution -> Runtime.spawn_agent_request ->
+  (string, Error.sdk_error) result


### PR DESCRIPTION
## Summary
- Add .mli interface files for 7 runtime/protocol modules
- Part of Phase 1 (v0.75 Foundation Hardening): .mli 100% coverage goal

## Test plan
- [x] `dune build --root .` green
- [x] `dune runtest --root .` all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)