### PR TITLE
fix: restore coverage build and raise gate to 80%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,9 @@ jobs:
           COVERAGE=$(opam exec -- bisect-ppx-report summary 2>/dev/null | grep -oP '\d+\.\d+(?=%)' | head -1 || echo "0")
           echo "Total coverage: ${COVERAGE}%"
           opam exec -- bisect-ppx-report summary --per-file || true
-          # Enforce minimum coverage threshold (65%)
+          # Enforce minimum coverage threshold (80%)
           if [ -n "$COVERAGE" ]; then
-            THRESHOLD=65
+            THRESHOLD=80
             if [ "$(echo "$COVERAGE < $THRESHOLD" | bc -l)" -eq 1 ]; then
               echo "Coverage ${COVERAGE}% is below threshold ${THRESHOLD}%"
               exit 1

--- a/lib/sessions_proof.mli
+++ b/lib/sessions_proof.mli
@@ -8,6 +8,20 @@ open Sessions_types
 
 (** {1 Worker run construction} *)
 
+val participant_by_name :
+  Runtime.session -> string -> Runtime.participant option
+
+val resolved_provider_of_participant :
+  Runtime.session -> Runtime.participant option -> string option
+
+val resolved_model_of_participant :
+  Runtime.session -> Runtime.participant option -> string option
+
+val worker_status_of_participant :
+  Runtime.participant option -> worker_status
+
+val worker_order_ts : worker_run -> float option
+
 val worker_run_of_raw :
   Runtime.session -> raw_trace_summary -> raw_trace_validation -> worker_run
 


### PR DESCRIPTION
## Summary
- restore `make coverage` by exporting the `Sessions` helper functions used by `test_sessions_proof_unit`
- raise the CI coverage threshold from `65%` to `80%`
- validate the new floor against the current branch baseline

## Related
- closes #247

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/chore/coverage-threshold-80`
- `DUNE_CACHE=disabled BISECT_FILE=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/chore/coverage-threshold-80/bisect dune runtest --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/chore/coverage-threshold-80 --instrument-with bisect_ppx --force`
- `bisect-ppx-report summary --coverage-path=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/chore/coverage-threshold-80` -> `81.39%`
