### PR TITLE
fix: remove duplicate declarations in sessions_proof.mli

### DIFF
--- a/lib/sessions_proof.mli
+++ b/lib/sessions_proof.mli
@@ -24,20 +24,6 @@ val worker_order_ts : worker_run -> float option
 
 (** {1 Worker run construction} *)
 
-val participant_by_name :
-  Runtime.session -> string -> Runtime.participant option
-
-val resolved_provider_of_participant :
-  Runtime.session -> Runtime.participant option -> string option
-
-val resolved_model_of_participant :
-  Runtime.session -> Runtime.participant option -> string option
-
-val worker_status_of_participant :
-  Runtime.participant option -> worker_status
-
-val worker_order_ts : worker_run -> float option
-
 val worker_run_of_raw :
   Runtime.session -> raw_trace_summary -> raw_trace_validation -> worker_run
 


### PR DESCRIPTION
## Summary
- Lines 27-39 in sessions_proof.mli were exact duplicates of lines 11-23
- Caused warning 32 (unused-value-declaration) treated as error
- Broke `make test` / `make coverage` on main

## Test plan
- [x] `dune build --root .` — 0 errors
- [x] `dune runtest --root .` — 0 failures
- [x] Coverage: 83.24%

🤖 Generated with [Claude Code](https://claude.com/claude-code)