### PR TITLE
feat(memory): add Memory_access — agent-scoped permission layer

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -118,6 +118,7 @@ module Agent_typed = Agent_typed
 module Cost_tracker = Cost_tracker
 module Context_offload = Context_offload
 module Memory = Memory
+module Memory_access = Memory_access
 module Guardrails_async = Guardrails_async
 module Eval_baseline = Eval_baseline
 module Eval_report = Eval_report

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -89,6 +89,7 @@ module Agent_typed = Agent_typed
 module Cost_tracker = Cost_tracker
 module Context_offload = Context_offload
 module Memory = Memory
+module Memory_access = Memory_access
 module Guardrails_async = Guardrails_async
 module Eval_baseline = Eval_baseline
 module Eval_report = Eval_report

--- a/lib/memory_access.ml
+++ b/lib/memory_access.ml
@@ -1,0 +1,132 @@
+(** Memory access control — agent-scoped permission layer.
+
+    @since 0.76.0 *)
+
+type permission =
+  | Read
+  | Write
+  | ReadWrite
+
+type policy = {
+  agent_name: string;
+  tier: Memory.tier;
+  key_pattern: string;
+  permission: permission;
+}
+
+type access_error =
+  | Denied of { agent_name: string; tier: Memory.tier; key: string; needed: permission }
+
+type t = {
+  mem: Memory.t;
+  policies: (string, policy list) Hashtbl.t;  (* agent_name -> policies *)
+}
+
+let create mem =
+  { mem; policies = Hashtbl.create 8 }
+
+let memory t = t.mem
+
+let grant t policy =
+  let existing = match Hashtbl.find_opt t.policies policy.agent_name with
+    | Some ps -> ps
+    | None -> []
+  in
+  Hashtbl.replace t.policies policy.agent_name (policy :: existing)
+
+let revoke t ~agent_name ~tier =
+  match Hashtbl.find_opt t.policies agent_name with
+  | None -> ()
+  | Some ps ->
+    let filtered = List.filter (fun p -> p.tier <> tier) ps in
+    if filtered = [] then Hashtbl.remove t.policies agent_name
+    else Hashtbl.replace t.policies agent_name filtered
+
+let revoke_all t ~agent_name =
+  Hashtbl.remove t.policies agent_name
+
+let policies_for t agent_name =
+  match Hashtbl.find_opt t.policies agent_name with
+  | Some ps -> ps
+  | None -> []
+
+(* Pattern matching: "*" matches everything, otherwise prefix match *)
+let pattern_matches ~pattern key =
+  pattern = "*" ||
+  let plen = String.length pattern in
+  let klen = String.length key in
+  klen >= plen && String.sub key 0 plen = pattern
+
+let permission_includes ~needed ~granted =
+  match needed, granted with
+  | Read, (Read | ReadWrite) -> true
+  | Write, (Write | ReadWrite) -> true
+  | ReadWrite, ReadWrite -> true
+  | _ -> false
+
+let check t ~agent ~tier ~key needed =
+  let ps = policies_for t agent in
+  List.exists (fun p ->
+    p.tier = tier &&
+    pattern_matches ~pattern:p.key_pattern key &&
+    permission_includes ~needed ~granted:p.permission
+  ) ps
+
+let require t ~agent ~tier ~key needed =
+  if check t ~agent ~tier ~key needed then Ok ()
+  else Error (Denied { agent_name = agent; tier; key; needed })
+
+let store t ~agent ~tier key value =
+  match require t ~agent ~tier ~key Write with
+  | Ok () -> Memory.store t.mem ~tier key value; Ok ()
+  | Error _ as err -> err
+
+let recall t ~agent ~tier key =
+  match require t ~agent ~tier ~key Read with
+  | Ok () -> Ok (Memory.recall t.mem ~tier key)
+  | Error _ as err -> err
+
+let recall_exact t ~agent ~tier key =
+  match require t ~agent ~tier ~key Read with
+  | Ok () -> Ok (Memory.recall_exact t.mem ~tier key)
+  | Error _ as err -> err
+
+let forget t ~agent ~tier key =
+  match require t ~agent ~tier ~key Write with
+  | Ok () -> Memory.forget t.mem ~tier key; Ok ()
+  | Error _ as err -> err
+
+let store_episode t ~agent (ep : Memory.episode) =
+  match require t ~agent ~tier:Episodic ~key:ep.id Write with
+  | Ok () -> Memory.store_episode t.mem ep; Ok ()
+  | Error _ as err -> err
+
+let recall_episodes t ~agent ?now ?decay_rate ?min_salience ?limit () =
+  match require t ~agent ~tier:Episodic ~key:"*" Read with
+  | Ok () -> Ok (Memory.recall_episodes t.mem ?now ?decay_rate ?min_salience ?limit ())
+  | Error _ as err -> err
+
+let store_procedure t ~agent (proc : Memory.procedure) =
+  match require t ~agent ~tier:Procedural ~key:proc.id Write with
+  | Ok () -> Memory.store_procedure t.mem proc; Ok ()
+  | Error _ as err -> err
+
+let best_procedure t ~agent ~pattern =
+  match require t ~agent ~tier:Procedural ~key:"*" Read with
+  | Ok () -> Ok (Memory.best_procedure t.mem ~pattern)
+  | Error _ as err -> err
+
+let access_error_to_string = function
+  | Denied { agent_name; tier; key; needed } ->
+    let tier_str = match tier with
+      | Memory.Scratchpad -> "Scratchpad"
+      | Memory.Working -> "Working"
+      | Memory.Episodic -> "Episodic"
+      | Memory.Procedural -> "Procedural"
+      | Memory.Long_term -> "Long_term"
+    in
+    let perm_str = match needed with
+      | Read -> "Read" | Write -> "Write" | ReadWrite -> "ReadWrite"
+    in
+    Printf.sprintf "Access denied: agent '%s' needs %s on %s:%s"
+      agent_name perm_str tier_str key

--- a/lib/memory_access.mli
+++ b/lib/memory_access.mli
@@ -1,0 +1,121 @@
+(** Memory access control — agent-scoped permission layer.
+
+    Wraps {!Memory.t} with per-agent, per-tier, per-key permissions.
+    Agents can only access memory entries they are authorized for.
+
+    Inspired by Collaborative Memory (arXiv 2505.18279):
+    Dynamic Bipartite Access Graph with Read/Write permissions.
+
+    Usage:
+    {[
+      let acl = Memory_access.create mem in
+      Memory_access.grant acl
+        { agent_name = "alice"; tier = Working; key_pattern = "*"; permission = ReadWrite };
+      Memory_access.grant acl
+        { agent_name = "bob"; tier = Working; key_pattern = "shared_*"; permission = Read };
+
+      (* alice can write *)
+      Memory_access.store acl ~agent:"alice" ~tier:Working "shared_goal" value;  (* Ok *)
+      (* bob can only read *)
+      Memory_access.store acl ~agent:"bob" ~tier:Working "shared_goal" value;  (* Error *)
+    ]}
+
+    @since 0.76.0 *)
+
+(** {1 Permissions} *)
+
+type permission =
+  | Read
+  | Write
+  | ReadWrite
+
+(** A single access policy entry. [key_pattern] supports ["*"] for
+    all keys, or a prefix match (e.g., ["shared_"] matches ["shared_goal"]). *)
+type policy = {
+  agent_name: string;
+  tier: Memory.tier;
+  key_pattern: string;
+  permission: permission;
+}
+
+(** {1 Access-controlled memory} *)
+
+type t
+
+(** Create an access-controlled wrapper around a {!Memory.t}.
+    By default, no agent has any access (deny-by-default). *)
+val create : Memory.t -> t
+
+(** Access the underlying memory (bypasses ACL). *)
+val memory : t -> Memory.t
+
+(** {1 Policy management} *)
+
+(** Grant access to an agent. Multiple policies can be granted per agent.
+    Later grants do not revoke earlier ones. *)
+val grant : t -> policy -> unit
+
+(** Revoke all policies for an agent on a specific tier. *)
+val revoke : t -> agent_name:string -> tier:Memory.tier -> unit
+
+(** Revoke all policies for an agent across all tiers. *)
+val revoke_all : t -> agent_name:string -> unit
+
+(** List all policies for an agent. *)
+val policies_for : t -> string -> policy list
+
+(** {1 Access-controlled operations} *)
+
+(** Access error returned when an operation is denied. *)
+type access_error =
+  | Denied of { agent_name: string; tier: Memory.tier; key: string; needed: permission }
+
+(** Store a value, checking Write permission.
+    Returns [Error (Denied _)] if the agent lacks write access. *)
+val store :
+  t -> agent:string -> tier:Memory.tier -> string -> Yojson.Safe.t ->
+  (unit, access_error) result
+
+(** Recall a value, checking Read permission. *)
+val recall :
+  t -> agent:string -> tier:Memory.tier -> string ->
+  (Yojson.Safe.t option, access_error) result
+
+(** Recall without fallback, checking Read permission. *)
+val recall_exact :
+  t -> agent:string -> tier:Memory.tier -> string ->
+  (Yojson.Safe.t option, access_error) result
+
+(** Forget a key, checking Write permission. *)
+val forget :
+  t -> agent:string -> tier:Memory.tier -> string ->
+  (unit, access_error) result
+
+(** {1 Episodic access control} *)
+
+val store_episode :
+  t -> agent:string -> Memory.episode ->
+  (unit, access_error) result
+
+val recall_episodes :
+  t -> agent:string -> ?now:float -> ?decay_rate:float ->
+  ?min_salience:float -> ?limit:int -> unit ->
+  (Memory.episode list, access_error) result
+
+(** {1 Procedural access control} *)
+
+val store_procedure :
+  t -> agent:string -> Memory.procedure ->
+  (unit, access_error) result
+
+val best_procedure :
+  t -> agent:string -> pattern:string ->
+  (Memory.procedure option, access_error) result
+
+(** {1 Utilities} *)
+
+(** Check if an agent has a specific permission for a tier and key. *)
+val check : t -> agent:string -> tier:Memory.tier -> key:string -> permission -> bool
+
+(** Format an access error for logging. *)
+val access_error_to_string : access_error -> string

--- a/test/dune
+++ b/test/dune
@@ -652,3 +652,7 @@
 (test
  (name test_memory_procedural)
  (libraries agent_sdk alcotest))
+
+(test
+ (name test_memory_access)
+ (libraries agent_sdk llm_provider alcotest))

--- a/test/test_memory_access.ml
+++ b/test/test_memory_access.ml
@@ -1,0 +1,187 @@
+open Agent_sdk
+
+let () = Alcotest.run "Memory_Access" [
+  "deny_by_default", [
+    Alcotest.test_case "store denied without grant" `Quick (fun () ->
+      let mem = Memory.create () in
+      let acl = Memory_access.create mem in
+      match Memory_access.store acl ~agent:"alice" ~tier:Working "key" (`String "v") with
+      | Ok () -> Alcotest.fail "should be denied"
+      | Error (Denied _) -> ()
+    );
+
+    Alcotest.test_case "recall denied without grant" `Quick (fun () ->
+      let mem = Memory.create () in
+      let acl = Memory_access.create mem in
+      match Memory_access.recall acl ~agent:"alice" ~tier:Working "key" with
+      | Ok _ -> Alcotest.fail "should be denied"
+      | Error (Denied _) -> ()
+    );
+  ];
+
+  "grant_revoke", [
+    Alcotest.test_case "grant allows access" `Quick (fun () ->
+      let mem = Memory.create () in
+      let acl = Memory_access.create mem in
+      Memory_access.grant acl {
+        agent_name = "alice"; tier = Working;
+        key_pattern = "*"; permission = ReadWrite;
+      };
+      (match Memory_access.store acl ~agent:"alice" ~tier:Working "key" (`String "v") with
+       | Ok () -> ()
+       | Error _ -> Alcotest.fail "should be allowed");
+      match Memory_access.recall acl ~agent:"alice" ~tier:Working "key" with
+      | Ok (Some (`String "v")) -> ()
+      | _ -> Alcotest.fail "should recall value"
+    );
+
+    Alcotest.test_case "revoke removes access" `Quick (fun () ->
+      let mem = Memory.create () in
+      let acl = Memory_access.create mem in
+      Memory_access.grant acl {
+        agent_name = "alice"; tier = Working;
+        key_pattern = "*"; permission = ReadWrite;
+      };
+      Memory_access.revoke acl ~agent_name:"alice" ~tier:Working;
+      match Memory_access.store acl ~agent:"alice" ~tier:Working "key" (`String "v") with
+      | Ok () -> Alcotest.fail "should be denied after revoke"
+      | Error (Denied _) -> ()
+    );
+
+    Alcotest.test_case "revoke_all clears everything" `Quick (fun () ->
+      let mem = Memory.create () in
+      let acl = Memory_access.create mem in
+      Memory_access.grant acl {
+        agent_name = "alice"; tier = Working;
+        key_pattern = "*"; permission = ReadWrite;
+      };
+      Memory_access.grant acl {
+        agent_name = "alice"; tier = Scratchpad;
+        key_pattern = "*"; permission = Read;
+      };
+      Memory_access.revoke_all acl ~agent_name:"alice";
+      Alcotest.(check int) "no policies" 0
+        (List.length (Memory_access.policies_for acl "alice"))
+    );
+  ];
+
+  "permission_levels", [
+    Alcotest.test_case "read-only cannot write" `Quick (fun () ->
+      let mem = Memory.create () in
+      let acl = Memory_access.create mem in
+      Memory_access.grant acl {
+        agent_name = "bob"; tier = Working;
+        key_pattern = "*"; permission = Read;
+      };
+      (* First store directly to memory so there's something to read *)
+      Memory.store mem ~tier:Working "key" (`String "v");
+      (match Memory_access.recall acl ~agent:"bob" ~tier:Working "key" with
+       | Ok (Some _) -> ()
+       | _ -> Alcotest.fail "should read");
+      match Memory_access.store acl ~agent:"bob" ~tier:Working "key" (`String "v2") with
+      | Ok () -> Alcotest.fail "read-only should not write"
+      | Error (Denied _) -> ()
+    );
+
+    Alcotest.test_case "write-only cannot read" `Quick (fun () ->
+      let mem = Memory.create () in
+      let acl = Memory_access.create mem in
+      Memory_access.grant acl {
+        agent_name = "charlie"; tier = Working;
+        key_pattern = "*"; permission = Write;
+      };
+      (match Memory_access.store acl ~agent:"charlie" ~tier:Working "key" (`String "v") with
+       | Ok () -> ()
+       | Error _ -> Alcotest.fail "should write");
+      match Memory_access.recall acl ~agent:"charlie" ~tier:Working "key" with
+      | Ok _ -> Alcotest.fail "write-only should not read"
+      | Error (Denied _) -> ()
+    );
+  ];
+
+  "key_patterns", [
+    Alcotest.test_case "prefix pattern match" `Quick (fun () ->
+      let mem = Memory.create () in
+      let acl = Memory_access.create mem in
+      Memory_access.grant acl {
+        agent_name = "alice"; tier = Working;
+        key_pattern = "shared_"; permission = ReadWrite;
+      };
+      (match Memory_access.store acl ~agent:"alice" ~tier:Working "shared_goal" (`String "v") with
+       | Ok () -> ()
+       | Error _ -> Alcotest.fail "prefix should match");
+      match Memory_access.store acl ~agent:"alice" ~tier:Working "private_key" (`String "v") with
+      | Ok () -> Alcotest.fail "non-matching prefix should be denied"
+      | Error (Denied _) -> ()
+    );
+  ];
+
+  "episodic_procedural", [
+    Alcotest.test_case "episodic access control" `Quick (fun () ->
+      let mem = Memory.create () in
+      let acl = Memory_access.create mem in
+      Memory_access.grant acl {
+        agent_name = "alice"; tier = Episodic;
+        key_pattern = "*"; permission = ReadWrite;
+      };
+      let ep : Memory.episode = {
+        id = "ep1"; timestamp = 100.0; participants = ["alice"];
+        action = "test"; outcome = Neutral; salience = 0.9; metadata = [];
+      } in
+      (match Memory_access.store_episode acl ~agent:"alice" ep with
+       | Ok () -> ()
+       | Error _ -> Alcotest.fail "should store episode");
+      (* bob has no access *)
+      match Memory_access.recall_episodes acl ~agent:"bob" ~now:200.0 () with
+      | Ok _ -> Alcotest.fail "bob should be denied"
+      | Error (Denied _) -> ()
+    );
+
+    Alcotest.test_case "procedural access control" `Quick (fun () ->
+      let mem = Memory.create () in
+      let acl = Memory_access.create mem in
+      Memory_access.grant acl {
+        agent_name = "alice"; tier = Procedural;
+        key_pattern = "*"; permission = ReadWrite;
+      };
+      let proc : Memory.procedure = {
+        id = "pr1"; pattern = "deploy"; action = "rollback";
+        success_count = 5; failure_count = 1;
+        confidence = 0.833; last_used = 100.0; metadata = [];
+      } in
+      (match Memory_access.store_procedure acl ~agent:"alice" proc with
+       | Ok () -> ()
+       | Error _ -> Alcotest.fail "should store procedure");
+      match Memory_access.best_procedure acl ~agent:"bob" ~pattern:"deploy" with
+      | Ok _ -> Alcotest.fail "bob should be denied"
+      | Error (Denied _) -> ()
+    );
+  ];
+
+  "check_utility", [
+    Alcotest.test_case "check returns bool" `Quick (fun () ->
+      let mem = Memory.create () in
+      let acl = Memory_access.create mem in
+      Alcotest.(check bool) "denied" false
+        (Memory_access.check acl ~agent:"alice" ~tier:Working ~key:"k" Read);
+      Memory_access.grant acl {
+        agent_name = "alice"; tier = Working;
+        key_pattern = "*"; permission = ReadWrite;
+      };
+      Alcotest.(check bool) "granted" true
+        (Memory_access.check acl ~agent:"alice" ~tier:Working ~key:"k" Read)
+    );
+  ];
+
+  "error_format", [
+    Alcotest.test_case "error string" `Quick (fun () ->
+      let err = Memory_access.Denied {
+        agent_name = "bob"; tier = Working; key = "secret"; needed = Write;
+      } in
+      let s = Memory_access.access_error_to_string err in
+      Alcotest.(check bool) "contains agent" true (String.length s > 0);
+      Alcotest.(check bool) "contains bob" true
+        (Util.string_contains ~needle:"bob" s)
+    );
+  ];
+]


### PR DESCRIPTION
## Summary
- New `Memory_access` module: deny-by-default access control wrapping `Memory.t`
- Per-agent, per-tier, per-key pattern permissions (Read/Write/ReadWrite)
- Covers all 5 tiers including Episodic and Procedural
- Part of Phase 2 (v0.80) of the Agent Society roadmap

## Design
- Separate module (not embedded in Memory.t) for backward compatibility
- Inspired by Collaborative Memory (arXiv 2505.18279) Dynamic Bipartite Access Graph
- `"*"` pattern matches all keys, prefix patterns for selective access

## Test plan
- [x] 12 new tests (deny/grant/revoke, permission levels, key patterns, episodic/procedural)
- [x] All existing tests pass unchanged
- [x] `dune build --root .` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)