### PR TITLE
feat: add Verified_output — phantom-typed compile-time output verification

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -119,6 +119,7 @@ module Cost_tracker = Cost_tracker
 module Context_offload = Context_offload
 module Memory = Memory
 module Memory_access = Memory_access
+module Verified_output = Verified_output
 module Guardrails_async = Guardrails_async
 module Eval_baseline = Eval_baseline
 module Eval_report = Eval_report

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -90,6 +90,7 @@ module Cost_tracker = Cost_tracker
 module Context_offload = Context_offload
 module Memory = Memory
 module Memory_access = Memory_access
+module Verified_output = Verified_output
 module Guardrails_async = Guardrails_async
 module Eval_baseline = Eval_baseline
 module Eval_report = Eval_report

--- a/lib/verified_output.ml
+++ b/lib/verified_output.ml
@@ -1,0 +1,84 @@
+(** Phantom-typed verified output.
+
+    The phantom type parameter ['status] is erased at runtime.
+    [unverified output] and [verified output] have identical
+    runtime representation — the difference is purely in the
+    type system.
+
+    @since 0.76.0 *)
+
+type unverified
+type verified
+
+type verification_result =
+  | Verified of { verifier: string; confidence: float; evidence: string }
+  | Disputed of { verifier: string; reason: string }
+  | Abstained of { verifier: string; reason: string }
+
+(* The actual record — 'status is phantom (not stored anywhere) *)
+type _ output = {
+  response: Types.api_response;
+  producer: string;
+  verifications: verification_result list;
+  verified_flag: bool;
+}
+
+let of_response ~producer response =
+  { response; producer; verifications = []; verified_flag = false }
+
+let verify (out : unverified output) ~verifier ~confidence ~evidence =
+  if confidence >= 0.5 then
+    let result = Verified { verifier; confidence; evidence } in
+    Some { response = out.response;
+           producer = out.producer;
+           verifications = result :: out.verifications;
+           verified_flag = true }
+  else
+    None
+
+let verify_with_results (out : unverified output) results
+    ?(min_confidence = 0.5) () =
+  let has_verified =
+    List.exists (function
+      | Verified { confidence; _ } -> confidence >= min_confidence
+      | Disputed _ | Abstained _ -> false
+    ) results
+  in
+  if has_verified then
+    Some { response = out.response;
+           producer = out.producer;
+           verifications = results @ out.verifications;
+           verified_flag = true }
+  else
+    None
+
+let trust (out : unverified output) ~reason =
+  let result = Verified { verifier = "trusted"; confidence = 1.0; evidence = reason } in
+  { response = out.response;
+    producer = out.producer;
+    verifications = result :: out.verifications;
+    verified_flag = true }
+
+let content (out : verified output) = out.response
+
+let text (out : verified output) =
+  out.response.content
+  |> List.filter_map (function Types.Text s -> Some s | _ -> None)
+  |> String.concat "\n"
+
+let producer (type s) (out : s output) = out.producer
+
+let verifications (type s) (out : s output) = out.verifications
+
+let is_verified (type s) (out : s output) = out.verified_flag
+
+let raw_json (type s) (out : s output) =
+  let text_content = out.response.content
+    |> List.filter_map (function Types.Text s -> Some s | _ -> None)
+    |> String.concat "\n" in
+  `Assoc [
+    ("id", `String out.response.id);
+    ("model", `String out.response.model);
+    ("producer", `String out.producer);
+    ("text", `String text_content);
+  ]

--- a/lib/verified_output.mli
+++ b/lib/verified_output.mli
@@ -1,0 +1,117 @@
+(** Phantom-typed verified output — compile-time enforcement of output verification.
+
+    In a multi-agent society, agent outputs must be verified before
+    being used as final results.  This module uses OCaml phantom types
+    to make it impossible to use unverified outputs where verified
+    ones are required.
+
+    {b Key guarantee}: The function {!val-content} only accepts
+    [verified output], so unverified outputs cannot be used as
+    final results.  This is enforced at compile time — no runtime
+    checks needed.
+
+    Usage:
+    {[
+      (* Producer creates unverified output *)
+      let raw = Verified_output.of_response ~producer:"alice" response in
+
+      (* Verifier checks and marks as verified *)
+      let result = Verified_output.verify raw
+        ~verifier:"bob" ~confidence:0.95 ~evidence:"cross-checked" in
+      match result with
+      | Some verified ->
+        (* Only verified outputs can extract content *)
+        let response = Verified_output.content verified in
+        ...
+      | None -> (* verification failed *)
+    ]}
+
+    Inspired by the 17x Error Trap (Bag of Agents anti-pattern):
+    in a 10-stage agent chain with 99% per-stage reliability,
+    overall reliability drops to 90.4%.  Phantom types make
+    unverified pipeline stages a compile error, not a runtime bug.
+
+    @since 0.76.0 *)
+
+(** {1 Phantom type tags} *)
+
+(** Type-level tag: output has not been verified. *)
+type unverified
+
+(** Type-level tag: output has been verified by at least one verifier. *)
+type verified
+
+(** {1 Verification result} *)
+
+type verification_result =
+  | Verified of { verifier: string; confidence: float; evidence: string }
+  | Disputed of { verifier: string; reason: string }
+  | Abstained of { verifier: string; reason: string }
+
+(** {1 Phantom-typed output} *)
+
+(** An agent output tagged with its verification status.
+    The type parameter ['status] is either {!unverified} or {!verified}.
+    It exists only at the type level — no runtime overhead. *)
+type 'status output
+
+(** {1 Construction} *)
+
+(** Create an unverified output from an API response. *)
+val of_response :
+  producer:string -> Types.api_response -> unverified output
+
+(** {1 Verification} *)
+
+(** Attempt to verify an output.  Returns [Some (verified output)]
+    if at least one verification result is [Verified] with
+    confidence >= [min_confidence] (default 0.5).
+    Returns [None] if verification fails. *)
+val verify :
+  unverified output ->
+  verifier:string ->
+  confidence:float ->
+  evidence:string ->
+  verified output option
+
+(** Mark as verified with explicit verification results.
+    Succeeds if any result is [Verified] above threshold. *)
+val verify_with_results :
+  unverified output ->
+  verification_result list ->
+  ?min_confidence:float ->
+  unit ->
+  verified output option
+
+(** Force-verify an output (bypass verification).
+    Use only for testing or trusted sources.  The [reason] is
+    recorded in the verification trail. *)
+val trust : unverified output -> reason:string -> verified output
+
+(** {1 Accessors (verified only)} *)
+
+(** Extract the API response.  Only callable on verified outputs.
+    {b This is the key safety guarantee}: unverified outputs
+    cannot reach this function. *)
+val content : verified output -> Types.api_response
+
+(** Extract text content from a verified output. *)
+val text : verified output -> string
+
+(** {1 Accessors (any status)} *)
+
+(** The agent that produced this output. *)
+val producer : _ output -> string
+
+(** Verification results attached to this output. *)
+val verifications : _ output -> verification_result list
+
+(** Whether the output has been verified (runtime check, for logging). *)
+val is_verified : _ output -> bool
+
+(** {1 Downgrade} *)
+
+(** Access the raw response regardless of status.
+    Intentionally returns [Yojson.Safe.t] instead of [Types.api_response]
+    to discourage using unverified outputs directly. *)
+val raw_json : _ output -> Yojson.Safe.t

--- a/test/dune
+++ b/test/dune
@@ -656,3 +656,7 @@
 (test
  (name test_memory_access)
  (libraries agent_sdk llm_provider alcotest))
+
+(test
+ (name test_verified_output)
+ (libraries agent_sdk alcotest))

--- a/test/test_verified_output.ml
+++ b/test/test_verified_output.ml
@@ -1,0 +1,96 @@
+open Agent_sdk
+
+let mock_response text =
+  { Types.id = "r1"; model = "test"; stop_reason = Types.EndTurn;
+    content = [Types.Text text]; usage = None }
+
+let () = Alcotest.run "Verified_Output" [
+  "phantom_safety", [
+    Alcotest.test_case "verified output gives content" `Quick (fun () ->
+      let raw = Verified_output.of_response ~producer:"alice" (mock_response "hello") in
+      match Verified_output.verify raw ~verifier:"bob" ~confidence:0.9 ~evidence:"checked" with
+      | Some verified ->
+        let resp = Verified_output.content verified in
+        Alcotest.(check string) "text" "hello" (Verified_output.text verified);
+        Alcotest.(check string) "id" "r1" resp.id
+      | None -> Alcotest.fail "verification should succeed"
+    );
+
+    (* This test documents the compile-time guarantee:
+       Uncommenting the line below would cause a type error:
+       let _ = Verified_output.content raw  (* TYPE ERROR: unverified output *)
+    *)
+    Alcotest.test_case "unverified cannot access content (documented)" `Quick (fun () ->
+      let _raw = Verified_output.of_response ~producer:"alice" (mock_response "hello") in
+      (* Verified_output.content _raw would not compile *)
+      Alcotest.(check bool) "type system prevents misuse" true true
+    );
+  ];
+
+  "verification_flow", [
+    Alcotest.test_case "low confidence fails verification" `Quick (fun () ->
+      let raw = Verified_output.of_response ~producer:"alice" (mock_response "hello") in
+      match Verified_output.verify raw ~verifier:"bob" ~confidence:0.3 ~evidence:"weak" with
+      | Some _ -> Alcotest.fail "low confidence should fail"
+      | None -> ()
+    );
+
+    Alcotest.test_case "verify_with_results quorum" `Quick (fun () ->
+      let raw = Verified_output.of_response ~producer:"alice" (mock_response "hello") in
+      let results = [
+        Verified_output.Verified { verifier = "bob"; confidence = 0.8; evidence = "ok" };
+        Verified_output.Disputed { verifier = "charlie"; reason = "disagree" };
+        Verified_output.Verified { verifier = "dave"; confidence = 0.9; evidence = "confirmed" };
+      ] in
+      match Verified_output.verify_with_results raw results () with
+      | Some verified ->
+        Alcotest.(check int) "3 verifications" 3
+          (List.length (Verified_output.verifications verified))
+      | None -> Alcotest.fail "quorum should pass"
+    );
+
+    Alcotest.test_case "verify_with_results all disputed fails" `Quick (fun () ->
+      let raw = Verified_output.of_response ~producer:"alice" (mock_response "hello") in
+      let results = [
+        Verified_output.Disputed { verifier = "bob"; reason = "wrong" };
+        Verified_output.Abstained { verifier = "charlie"; reason = "unsure" };
+      ] in
+      match Verified_output.verify_with_results raw results () with
+      | Some _ -> Alcotest.fail "all disputed should fail"
+      | None -> ()
+    );
+  ];
+
+  "trust", [
+    Alcotest.test_case "trust bypasses verification" `Quick (fun () ->
+      let raw = Verified_output.of_response ~producer:"alice" (mock_response "trusted") in
+      let verified = Verified_output.trust raw ~reason:"unit test" in
+      Alcotest.(check string) "text" "trusted" (Verified_output.text verified);
+      Alcotest.(check bool) "is_verified" true (Verified_output.is_verified verified)
+    );
+  ];
+
+  "accessors", [
+    Alcotest.test_case "producer works on any status" `Quick (fun () ->
+      let raw = Verified_output.of_response ~producer:"alice" (mock_response "hello") in
+      Alcotest.(check string) "producer unverified" "alice" (Verified_output.producer raw);
+      let verified = Verified_output.trust raw ~reason:"test" in
+      Alcotest.(check string) "producer verified" "alice" (Verified_output.producer verified)
+    );
+
+    Alcotest.test_case "is_verified tracks status" `Quick (fun () ->
+      let raw = Verified_output.of_response ~producer:"alice" (mock_response "hello") in
+      Alcotest.(check bool) "unverified" false (Verified_output.is_verified raw);
+      let verified = Verified_output.trust raw ~reason:"test" in
+      Alcotest.(check bool) "verified" true (Verified_output.is_verified verified)
+    );
+
+    Alcotest.test_case "raw_json returns JSON" `Quick (fun () ->
+      let raw = Verified_output.of_response ~producer:"alice" (mock_response "hello") in
+      let json = Verified_output.raw_json raw in
+      match json with
+      | `Assoc _ -> ()
+      | _ -> Alcotest.fail "expected JSON object"
+    );
+  ];
+]


### PR DESCRIPTION
## Summary
- New `Verified_output` module with phantom types for compile-time output verification
- `unverified output` cannot be used where `verified output` is required — enforced by OCaml type system
- Part of Phase 4 of the Agent Society roadmap (Killer Feature #1)

## Key guarantee
```ocaml
(* This compiles *)
let verified = Verified_output.trust raw ~reason:"test" in
let response = Verified_output.content verified

(* This does NOT compile — type error at compile time *)
let response = Verified_output.content raw  (* unverified! *)
```

## API
- `of_response` — create unverified output
- `verify` / `verify_with_results` — attempt verification (returns option)
- `trust` — bypass for testing
- `content` / `text` — extract from verified output only

## Test plan
- [x] 9 tests (phantom safety, verification flow, trust, accessors)
- [x] `dune build --root .` green
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)