### PR TITLE
feat: add Fs_result module (Bos-style Result I/O)

### DIFF
--- a/lib/fs_result.ml
+++ b/lib/fs_result.ml
@@ -1,0 +1,76 @@
+(** Result-based filesystem operations.
+
+    Normalizes [Eio.Io], [Unix.Unix_error], [Sys_error], and [Failure]
+    into [Error.Io (FileOpFailed ...)].
+    Pattern extracted from checkpoint_store.ml / a2a_task_store.ml. *)
+
+let ( let* ) = Result.bind
+
+let io_error_of_exn ~op ~path = function
+  | Eio.Io _ as exn ->
+    Error (Error.Io (FileOpFailed { op; path; detail = Printexc.to_string exn }))
+  | Unix.Unix_error _ as exn ->
+    Error (Error.Io (FileOpFailed { op; path; detail = Printexc.to_string exn }))
+  | Sys_error detail ->
+    Error (Error.Io (FileOpFailed { op; path; detail }))
+  | Failure msg ->
+    Error (Error.Io (FileOpFailed { op; path; detail = msg }))
+  | Yojson.Json_error msg ->
+    Error (Error.Io (FileOpFailed { op; path; detail = "JSON error: " ^ msg }))
+  | exn -> raise exn
+
+let read_file path =
+  try Ok (In_channel.with_open_bin path In_channel.input_all)
+  with exn -> io_error_of_exn ~op:"read" ~path exn
+
+let ensure_dir path =
+  try
+    if not (Sys.file_exists path) then
+      Sys.mkdir path 0o755;
+    Ok ()
+  with exn -> io_error_of_exn ~op:"mkdir" ~path exn
+
+let ensure_dir_recursive path =
+  let rec aux p =
+    if Sys.file_exists p then ()
+    else begin
+      aux (Filename.dirname p);
+      (try Sys.mkdir p 0o755 with Sys_error _ -> ())
+    end
+  in
+  try aux path; Ok ()
+  with exn -> io_error_of_exn ~op:"mkdir_p" ~path exn
+
+let write_file path content =
+  try
+    let* () = ensure_dir_recursive (Filename.dirname path) in
+    let tmp_path = path ^ ".tmp" in
+    Out_channel.with_open_bin tmp_path (fun oc ->
+      Out_channel.output_string oc content);
+    Sys.rename tmp_path path;
+    Ok ()
+  with exn -> io_error_of_exn ~op:"write" ~path exn
+
+let append_file path content =
+  try
+    let* () = ensure_dir_recursive (Filename.dirname path) in
+    let oc = open_out_gen [ Open_append; Open_creat; Open_binary ] 0o644 path in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () -> output_string oc content);
+    Ok ()
+  with exn -> io_error_of_exn ~op:"append" ~path exn
+
+let read_dir path =
+  try Ok (Sys.readdir path |> Array.to_list |> List.sort String.compare)
+  with exn -> io_error_of_exn ~op:"read_dir" ~path exn
+
+let file_exists path =
+  try Sys.file_exists path && not (Sys.is_directory path)
+  with Sys_error _ -> false
+
+let remove_file path =
+  try
+    if Sys.file_exists path then Sys.remove path;
+    Ok ()
+  with exn -> io_error_of_exn ~op:"remove" ~path exn

--- a/lib/fs_result.mli
+++ b/lib/fs_result.mli
@@ -1,0 +1,43 @@
+(** Result-based filesystem operations.
+
+    All functions return [('a, Error.sdk_error) result] instead of raising.
+    Catches [Eio.Io], [Unix.Unix_error], [Sys_error], and [Failure].
+    Non-recoverable exceptions (e.g. [Out_of_memory]) are re-raised.
+
+    @raises only truly non-recoverable exceptions *)
+
+(** {1 Core I/O} *)
+
+(** Read entire file contents. *)
+val read_file : string -> (string, Error.sdk_error) result
+
+(** Write file atomically via .tmp + rename. Creates parent dirs. *)
+val write_file : string -> string -> (unit, Error.sdk_error) result
+
+(** Append content to file. Creates parent dirs if needed. *)
+val append_file : string -> string -> (unit, Error.sdk_error) result
+
+(** {1 Directory operations} *)
+
+(** Ensure directory exists (recursive). *)
+val ensure_dir : string -> (unit, Error.sdk_error) result
+
+(** List directory entries. *)
+val read_dir : string -> (string list, Error.sdk_error) result
+
+(** {1 Queries} *)
+
+(** Check if path exists as a regular file. *)
+val file_exists : string -> bool
+
+(** {1 Deletion} *)
+
+(** Remove a file. Returns [Ok ()] if file does not exist. *)
+val remove_file : string -> (unit, Error.sdk_error) result
+
+(** {1 Utilities} *)
+
+(** Convert I/O exceptions to [Error.sdk_error].
+    Re-raises non-recoverable exceptions.
+    Extracted from checkpoint_store.ml for reuse. *)
+val io_error_of_exn : op:string -> path:string -> exn -> (_, Error.sdk_error) result


### PR DESCRIPTION
## Summary
- `checkpoint_store.ml`/`a2a_task_store.ml`의 `io_error_of_exn` 패턴을 공통 `Fs_result` 모듈로 추출
- `Eio.Io`, `Unix.Unix_error`, `Sys_error`, `Failure` 4종 예외를 `Error.Io (FileOpFailed ...)` Result로 통일
- 7개 함수: `read_file`, `write_file` (atomic), `append_file`, `ensure_dir`, `read_dir`, `file_exists`, `remove_file`
- `.mli` API 계약 포함

## Motivation
OAS의 11개 파일이 blocking stdlib I/O를 사용하면서 `Sys_error`만 catch → `Eio.Io` 예외 누출.
`Fs_result`를 도입하여 I/O 에러 처리를 통일하고, 점진적으로 기존 파일들을 전환.

## Next Steps (Stacked PRs)
1. `runtime_store.ml`을 `Fs_result` 사용으로 전환
2. `raw_trace.ml`, `event_forward.ml` 전환
3. `checkpoint_store.ml`, `a2a_task_store.ml`의 로컬 `io_error_of_exn` 제거 → `Fs_result.io_error_of_exn` 사용

## Test plan
- [x] `dune build` 통과
- [x] `dune runtest` 14 tests pass
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)