### PR TITLE
feat: add governance layer — Durable, Policy, Audit

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -126,6 +126,9 @@ module Eval_baseline = Eval_baseline
 module Eval_report = Eval_report
 module Defaults = Defaults
 module Runtime_store = Runtime_store
+module Durable = Durable
+module Policy = Policy
+module Audit = Audit
 
 (** Quick start: create an agent with default config *)
 let create_agent ~net ?name ?model ?system_prompt ?max_tokens ?max_turns

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -97,6 +97,9 @@ module Eval_baseline = Eval_baseline
 module Eval_report = Eval_report
 module Defaults = Defaults
 module Runtime_store = Runtime_store
+module Durable = Durable
+module Policy = Policy
+module Audit = Audit
 
 (** {1 Quick Start} *)
 

--- a/lib/audit.ml
+++ b/lib/audit.ml
@@ -1,0 +1,72 @@
+(** Audit trail — immutable log of policy decisions and agent actions.
+
+    Records every decision point evaluation, providing accountability
+    and transparency for agent behavior in a society.
+
+    @since 0.76.0 *)
+
+type entry = {
+  id: string;
+  timestamp: float;
+  agent_name: string;
+  action: string;
+  decision_point: Policy.decision_point option;
+  verdict: Policy.verdict option;
+  detail: Yojson.Safe.t;
+}
+
+type t = {
+  mutable entries: entry list;
+  max_entries: int option;
+}
+
+let create ?max_entries () =
+  { entries = []; max_entries }
+
+let record t entry =
+  t.entries <- entry :: t.entries;
+  match t.max_entries with
+  | None -> ()
+  | Some max when List.length t.entries > max ->
+    (* Keep only the newest [max] entries.
+       entries are stored newest-first, so take the first [max]. *)
+    t.entries <- List.filteri (fun i _ -> i < max) t.entries
+  | Some _ -> ()
+
+let query t ?agent ?action ?since () =
+  t.entries
+  |> List.filter (fun e ->
+    (match agent with None -> true | Some a -> e.agent_name = a)
+    && (match action with None -> true | Some a -> e.action = a)
+    && (match since with None -> true | Some ts -> e.timestamp >= ts))
+
+let count t = List.length t.entries
+
+let latest t n =
+  (* entries are stored newest-first, take first n *)
+  List.filteri (fun i _ -> i < n) t.entries
+
+let entry_to_json e =
+  let verdict_json = match e.verdict with
+    | None -> `Null
+    | Some v -> `String (Policy.verdict_to_string v)
+  in
+  let dp_json = match e.decision_point with
+    | None -> `Null
+    | Some dp -> `String (Policy.decision_point_to_string dp)
+  in
+  `Assoc [
+    ("id", `String e.id);
+    ("timestamp", `Float e.timestamp);
+    ("agent_name", `String e.agent_name);
+    ("action", `String e.action);
+    ("decision_point", dp_json);
+    ("verdict", verdict_json);
+    ("detail", e.detail);
+  ]
+
+let entries_to_json entries =
+  `List (List.map entry_to_json entries)
+
+let to_json t =
+  entries_to_json t.entries

--- a/lib/audit.mli
+++ b/lib/audit.mli
@@ -1,0 +1,44 @@
+(** Audit trail — immutable log of policy decisions and agent actions.
+
+    Records every decision point evaluation, providing accountability
+    and transparency for agent behavior in a society.
+
+    @since 0.76.0 *)
+
+(** {1 Audit entries} *)
+
+type entry = {
+  id: string;
+  timestamp: float;
+  agent_name: string;
+  action: string;
+  decision_point: Policy.decision_point option;
+  verdict: Policy.verdict option;
+  detail: Yojson.Safe.t;
+}
+
+(** {1 Audit log} *)
+
+type t
+
+(** Create an audit log with optional max capacity.
+    When capacity is exceeded, oldest entries are evicted. *)
+val create : ?max_entries:int -> unit -> t
+
+(** Record an entry. *)
+val record : t -> entry -> unit
+
+(** {1 Queries} *)
+
+val query :
+  t -> ?agent:string -> ?action:string -> ?since:float ->
+  unit -> entry list
+
+val count : t -> int
+
+val latest : t -> int -> entry list
+
+(** {1 Export} *)
+
+val to_json : t -> Yojson.Safe.t
+val entries_to_json : entry list -> Yojson.Safe.t

--- a/lib/durable.ml
+++ b/lib/durable.ml
@@ -1,0 +1,267 @@
+(** Durable state machine — typed step chains with execution journal.
+
+    Enables long-running agent workflows to survive process crashes
+    and resume from the exact point of interruption.
+
+    @since 0.76.0 *)
+
+type journal_entry = {
+  step_name: string;
+  started_at: float;
+  completed_at: float option;
+  input_json: Yojson.Safe.t;
+  output_json: Yojson.Safe.t option;
+  error: string option;
+  attempt: int;
+}
+
+type execution_state =
+  | NotStarted
+  | InProgress of { current_step: string; attempt: int; journal: journal_entry list }
+  | Suspended of { at_step: string; journal: journal_entry list; reason: string }
+  | Completed of { journal: journal_entry list; final_output: Yojson.Safe.t }
+  | Failed of { at_step: string; journal: journal_entry list; error: string }
+
+type step = {
+  name: string;
+  execute: Yojson.Safe.t -> (Yojson.Safe.t, string) result;
+  retry_limit: int;
+}
+
+type t = {
+  name: string;
+  steps: step list;
+}
+
+let create ~name () = { name; steps = [] }
+
+let add_step t step = { t with steps = t.steps @ [step] }
+
+let name t = t.name
+let step_count t = List.length t.steps
+let step_names t = List.map (fun (s : step) -> s.name) t.steps
+
+let is_terminal = function
+  | Completed _ | Failed _ -> true
+  | NotStarted | InProgress _ | Suspended _ -> false
+
+(** Run steps starting from index [start_idx] with given [input]
+    and accumulated [journal]. *)
+let run_from t ~start_idx ~input ~journal =
+  let steps = Array.of_list t.steps in
+  let total = Array.length steps in
+  let rec loop idx cur_input acc_journal =
+    if idx >= total then
+      Completed { journal = List.rev acc_journal; final_output = cur_input }
+    else begin
+      let step = steps.(idx) in
+      let rec try_step attempt =
+        let started_at = Unix.gettimeofday () in
+        match step.execute cur_input with
+        | Ok output ->
+          let completed_at = Unix.gettimeofday () in
+          let je = {
+            step_name = step.name;
+            started_at;
+            completed_at = Some completed_at;
+            input_json = cur_input;
+            output_json = Some output;
+            error = None;
+            attempt;
+          } in
+          loop (idx + 1) output (je :: acc_journal)
+        | Error err ->
+          let completed_at = Unix.gettimeofday () in
+          let je = {
+            step_name = step.name;
+            started_at;
+            completed_at = Some completed_at;
+            input_json = cur_input;
+            output_json = None;
+            error = Some err;
+            attempt;
+          } in
+          if attempt < step.retry_limit then
+            try_step (attempt + 1)
+          else
+            Failed {
+              at_step = step.name;
+              journal = List.rev (je :: acc_journal);
+              error = err;
+            }
+      in
+      try_step 1
+    end
+  in
+  loop start_idx input journal
+
+let execute t input =
+  run_from t ~start_idx:0 ~input ~journal:[]
+
+let resume t state =
+  match state with
+  | Suspended { at_step; journal; _ } | Failed { at_step; journal; _ } ->
+    (* Find the step index for at_step *)
+    let steps = t.steps in
+    let rec find_idx idx = function
+      | [] -> None
+      | (s : step) :: rest ->
+        if s.name = at_step then Some idx
+        else find_idx (idx + 1) rest
+    in
+    (match find_idx 0 steps with
+     | None ->
+       Failed {
+         at_step;
+         journal;
+         error = Printf.sprintf "step '%s' not found in pipeline" at_step;
+       }
+     | Some idx ->
+       (* Determine input: use the last successful step's output,
+          or if resuming at first step, look at the journal's first entry input *)
+       let input =
+         match List.rev journal with
+         | [] -> `Null
+         | entries ->
+           (* Find the last entry before at_step that has output *)
+           let rec find_last_output = function
+             | [] -> `Null
+             | e :: rest ->
+               if e.step_name <> at_step then
+                 (match e.output_json with
+                  | Some o -> o
+                  | None -> find_last_output rest)
+               else
+                 (* This is the failed/suspended step, use its input *)
+                 e.input_json
+           in
+           find_last_output (List.rev entries)
+       in
+       (* Keep journal entries before the current step *)
+       let prior_journal =
+         List.filter (fun e -> e.step_name <> at_step) journal
+       in
+       run_from t ~start_idx:idx ~input ~journal:(List.rev prior_journal))
+  | NotStarted -> execute t `Null
+  | InProgress _ -> state  (* already running *)
+  | Completed _ -> state   (* already done *)
+
+let suspend _t state ~reason =
+  match state with
+  | InProgress { current_step; journal; _ } ->
+    Suspended { at_step = current_step; journal; reason }
+  | _ -> state
+
+(* ── Serialization ────────────────────────────────── *)
+
+let journal_entry_to_json je =
+  `Assoc [
+    ("step_name", `String je.step_name);
+    ("started_at", `Float je.started_at);
+    ("completed_at",
+     (match je.completed_at with None -> `Null | Some f -> `Float f));
+    ("input_json", je.input_json);
+    ("output_json",
+     (match je.output_json with None -> `Null | Some j -> j));
+    ("error",
+     (match je.error with None -> `Null | Some e -> `String e));
+    ("attempt", `Int je.attempt);
+  ]
+
+let journal_entry_of_json json =
+  let open Yojson.Safe.Util in
+  try
+    let step_name = json |> member "step_name" |> to_string in
+    let started_at = json |> member "started_at" |> to_float in
+    let completed_at =
+      match json |> member "completed_at" with
+      | `Null -> None | j -> Some (to_float j) in
+    let input_json = json |> member "input_json" in
+    let output_json =
+      match json |> member "output_json" with
+      | `Null -> None | j -> Some j in
+    let error =
+      match json |> member "error" with
+      | `Null -> None | j -> Some (to_string j) in
+    let attempt = json |> member "attempt" |> to_int in
+    Ok { step_name; started_at; completed_at; input_json; output_json;
+         error; attempt }
+  with exn -> Error (Printexc.to_string exn)
+
+let journal_list_to_json journal =
+  `List (List.map journal_entry_to_json journal)
+
+let journal_list_of_json json =
+  let open Yojson.Safe.Util in
+  let entries = to_list json in
+  let rec collect acc = function
+    | [] -> Ok (List.rev acc)
+    | j :: rest ->
+      match journal_entry_of_json j with
+      | Ok e -> collect (e :: acc) rest
+      | Error e -> Error e
+  in
+  collect [] entries
+
+let execution_state_to_json = function
+  | NotStarted ->
+    `Assoc [("state", `String "NotStarted")]
+  | InProgress { current_step; attempt; journal } ->
+    `Assoc [
+      ("state", `String "InProgress");
+      ("current_step", `String current_step);
+      ("attempt", `Int attempt);
+      ("journal", journal_list_to_json journal);
+    ]
+  | Suspended { at_step; journal; reason } ->
+    `Assoc [
+      ("state", `String "Suspended");
+      ("at_step", `String at_step);
+      ("journal", journal_list_to_json journal);
+      ("reason", `String reason);
+    ]
+  | Completed { journal; final_output } ->
+    `Assoc [
+      ("state", `String "Completed");
+      ("journal", journal_list_to_json journal);
+      ("final_output", final_output);
+    ]
+  | Failed { at_step; journal; error } ->
+    `Assoc [
+      ("state", `String "Failed");
+      ("at_step", `String at_step);
+      ("journal", journal_list_to_json journal);
+      ("error", `String error);
+    ]
+
+let execution_state_of_json json =
+  let open Yojson.Safe.Util in
+  try
+    let state = json |> member "state" |> to_string in
+    match state with
+    | "NotStarted" -> Ok NotStarted
+    | "InProgress" ->
+      let current_step = json |> member "current_step" |> to_string in
+      let attempt = json |> member "attempt" |> to_int in
+      (match journal_list_of_json (json |> member "journal") with
+       | Ok journal -> Ok (InProgress { current_step; attempt; journal })
+       | Error e -> Error e)
+    | "Suspended" ->
+      let at_step = json |> member "at_step" |> to_string in
+      let reason = json |> member "reason" |> to_string in
+      (match journal_list_of_json (json |> member "journal") with
+       | Ok journal -> Ok (Suspended { at_step; journal; reason })
+       | Error e -> Error e)
+    | "Completed" ->
+      let final_output = json |> member "final_output" in
+      (match journal_list_of_json (json |> member "journal") with
+       | Ok journal -> Ok (Completed { journal; final_output })
+       | Error e -> Error e)
+    | "Failed" ->
+      let at_step = json |> member "at_step" |> to_string in
+      let error = json |> member "error" |> to_string in
+      (match journal_list_of_json (json |> member "journal") with
+       | Ok journal -> Ok (Failed { at_step; journal; error })
+       | Error e -> Error e)
+    | unknown -> Error (Printf.sprintf "unknown execution state: %s" unknown)
+  with exn -> Error (Printexc.to_string exn)

--- a/lib/durable.mli
+++ b/lib/durable.mli
@@ -1,0 +1,76 @@
+(** Durable state machine — typed step chains with execution journal.
+
+    Enables long-running agent workflows to survive process crashes
+    and resume from the exact point of interruption.  Each step's
+    input/output is serialized to a journal, providing a complete
+    audit trail of execution.
+
+    Inspired by LangGraph 1.0 durable execution, implemented with
+    OCaml's type system for step chain safety.
+
+    @since 0.76.0 *)
+
+(** {1 Journal} *)
+
+type journal_entry = {
+  step_name: string;
+  started_at: float;
+  completed_at: float option;
+  input_json: Yojson.Safe.t;
+  output_json: Yojson.Safe.t option;
+  error: string option;
+  attempt: int;
+}
+
+(** {1 Execution state} *)
+
+type execution_state =
+  | NotStarted
+  | InProgress of { current_step: string; attempt: int; journal: journal_entry list }
+  | Suspended of { at_step: string; journal: journal_entry list; reason: string }
+  | Completed of { journal: journal_entry list; final_output: Yojson.Safe.t }
+  | Failed of { at_step: string; journal: journal_entry list; error: string }
+
+(** {1 Steps} *)
+
+(** A single execution step with serialization support. *)
+type step = {
+  name: string;
+  execute: Yojson.Safe.t -> (Yojson.Safe.t, string) result;
+  retry_limit: int;
+}
+
+(** {1 State machine} *)
+
+type t
+
+(** Create a new durable state machine. *)
+val create : name:string -> unit -> t
+
+(** Add a step to the pipeline (appended in order). *)
+val add_step : t -> step -> t
+
+(** {1 Execution} *)
+
+(** Execute the pipeline from the beginning. *)
+val execute : t -> Yojson.Safe.t -> execution_state
+
+(** Resume from a previously suspended or failed state. *)
+val resume : t -> execution_state -> execution_state
+
+(** Suspend execution at the current step with a reason. *)
+val suspend : t -> execution_state -> reason:string -> execution_state
+
+(** {1 Serialization} *)
+
+val execution_state_to_json : execution_state -> Yojson.Safe.t
+val execution_state_of_json : Yojson.Safe.t -> (execution_state, string) result
+
+(** {1 Queries} *)
+
+val name : t -> string
+val step_count : t -> int
+val step_names : t -> string list
+
+(** Check if a state is terminal (Completed or Failed). *)
+val is_terminal : execution_state -> bool

--- a/lib/policy.ml
+++ b/lib/policy.ml
@@ -1,0 +1,77 @@
+(** Policy engine — runtime governance for agent decisions.
+
+    Rules are evaluated in priority order (highest first).
+    First matching rule determines the verdict.
+    Returns [Allow] if no rule matches.
+
+    @since 0.76.0 *)
+
+type decision_point =
+  | BeforeToolCall of { tool_name: string; agent_name: string }
+  | BeforeHandoff of { from_agent: string; to_agent: string }
+  | BeforeResponse of { agent_name: string; content_preview: string }
+  | ResourceRequest of { agent_name: string; resource: string; amount: float }
+  | BeforeMemoryWrite of { agent_name: string; tier: string; key: string }
+  | Custom of { name: string; detail: string }
+
+type verdict =
+  | Allow
+  | Deny of string
+  | AllowWithCondition of string
+  | Escalate of string
+
+type rule = {
+  name: string;
+  priority: int;
+  applies_to: decision_point -> bool;
+  evaluate: decision_point -> verdict;
+}
+
+type t = { rules: rule list }
+
+(** Sort rules by priority descending. *)
+let sort_rules rules =
+  List.sort (fun a b -> Int.compare b.priority a.priority) rules
+
+let create rules =
+  { rules = sort_rules rules }
+
+let evaluate t dp =
+  let rec find = function
+    | [] -> Allow
+    | r :: rest ->
+      if r.applies_to dp then r.evaluate dp
+      else find rest
+  in
+  find t.rules
+
+let add_rule t rule =
+  { rules = sort_rules (rule :: t.rules) }
+
+let remove_rule t name =
+  { rules = List.filter (fun r -> r.name <> name) t.rules }
+
+let rules t = t.rules
+let rule_count t = List.length t.rules
+
+let verdict_to_string = function
+  | Allow -> "Allow"
+  | Deny reason -> Printf.sprintf "Deny(%s)" reason
+  | AllowWithCondition cond -> Printf.sprintf "AllowWithCondition(%s)" cond
+  | Escalate reason -> Printf.sprintf "Escalate(%s)" reason
+
+let decision_point_to_string = function
+  | BeforeToolCall { tool_name; agent_name } ->
+    Printf.sprintf "BeforeToolCall(tool=%s, agent=%s)" tool_name agent_name
+  | BeforeHandoff { from_agent; to_agent } ->
+    Printf.sprintf "BeforeHandoff(from=%s, to=%s)" from_agent to_agent
+  | BeforeResponse { agent_name; content_preview } ->
+    Printf.sprintf "BeforeResponse(agent=%s, preview=%s)" agent_name content_preview
+  | ResourceRequest { agent_name; resource; amount } ->
+    Printf.sprintf "ResourceRequest(agent=%s, resource=%s, amount=%.2f)"
+      agent_name resource amount
+  | BeforeMemoryWrite { agent_name; tier; key } ->
+    Printf.sprintf "BeforeMemoryWrite(agent=%s, tier=%s, key=%s)"
+      agent_name tier key
+  | Custom { name; detail } ->
+    Printf.sprintf "Custom(%s: %s)" name detail

--- a/lib/policy.mli
+++ b/lib/policy.mli
@@ -1,0 +1,60 @@
+(** Policy engine — runtime governance for agent decisions.
+
+    Evaluates rules at decision points during agent execution.
+    Rules are checked in priority order (highest first).
+    First matching rule determines the verdict.
+
+    Inspired by MI9 Agent Intelligence Protocol (arXiv 2508.03858).
+
+    @since 0.76.0 *)
+
+(** {1 Decision points} *)
+
+type decision_point =
+  | BeforeToolCall of { tool_name: string; agent_name: string }
+  | BeforeHandoff of { from_agent: string; to_agent: string }
+  | BeforeResponse of { agent_name: string; content_preview: string }
+  | ResourceRequest of { agent_name: string; resource: string; amount: float }
+  | BeforeMemoryWrite of { agent_name: string; tier: string; key: string }
+  | Custom of { name: string; detail: string }
+
+(** {1 Verdicts} *)
+
+type verdict =
+  | Allow
+  | Deny of string
+  | AllowWithCondition of string
+  | Escalate of string
+
+(** {1 Rules} *)
+
+type rule = {
+  name: string;
+  priority: int;
+  applies_to: decision_point -> bool;
+  evaluate: decision_point -> verdict;
+}
+
+(** {1 Policy engine} *)
+
+type t
+
+(** Create a policy engine with a list of rules. *)
+val create : rule list -> t
+
+(** Evaluate a decision point against all applicable rules.
+    Rules are checked in priority order (highest first).
+    Returns [Allow] if no rule matches. *)
+val evaluate : t -> decision_point -> verdict
+
+(** {1 Rule management} *)
+
+val add_rule : t -> rule -> t
+val remove_rule : t -> string -> t
+val rules : t -> rule list
+val rule_count : t -> int
+
+(** {1 Utilities} *)
+
+val verdict_to_string : verdict -> string
+val decision_point_to_string : decision_point -> string

--- a/test/dune
+++ b/test/dune
@@ -676,3 +676,15 @@
 (test
  (name test_gemini_edge_cases)
  (libraries llm_provider yojson))
+
+(test
+ (name test_policy)
+ (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_audit)
+ (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_durable)
+ (libraries agent_sdk alcotest yojson unix))

--- a/test/test_audit.ml
+++ b/test/test_audit.ml
@@ -1,0 +1,163 @@
+(** Unit tests for Audit module (v0.76.0). *)
+
+open Alcotest
+open Agent_sdk
+
+(* ── Helpers ──────────────────────────────────────── *)
+
+let make_entry ?(id="e1") ?(ts=1000.0) ?(agent="agent-a")
+    ?(action="tool_call") ?(dp=None) ?(verdict=None)
+    ?(detail=`Null) () : Audit.entry =
+  { id; timestamp = ts; agent_name = agent; action;
+    decision_point = dp; verdict; detail }
+
+(* ── Basic record/count ──────────────────────────── *)
+
+let test_record_and_count () =
+  let log = Audit.create () in
+  check int "empty" 0 (Audit.count log);
+  Audit.record log (make_entry ());
+  check int "one entry" 1 (Audit.count log);
+  Audit.record log (make_entry ~id:"e2" ~ts:2000.0 ());
+  check int "two entries" 2 (Audit.count log)
+
+(* ── Query by agent ──────────────────────────────── *)
+
+let test_query_by_agent () =
+  let log = Audit.create () in
+  Audit.record log (make_entry ~agent:"alice" ());
+  Audit.record log (make_entry ~id:"e2" ~agent:"bob" ());
+  Audit.record log (make_entry ~id:"e3" ~agent:"alice" ());
+  let alice = Audit.query log ~agent:"alice" () in
+  check int "alice entries" 2 (List.length alice);
+  let bob = Audit.query log ~agent:"bob" () in
+  check int "bob entries" 1 (List.length bob)
+
+(* ── Query by action ─────────────────────────────── *)
+
+let test_query_by_action () =
+  let log = Audit.create () in
+  Audit.record log (make_entry ~action:"tool_call" ());
+  Audit.record log (make_entry ~id:"e2" ~action:"handoff" ());
+  Audit.record log (make_entry ~id:"e3" ~action:"tool_call" ());
+  let tool_calls = Audit.query log ~action:"tool_call" () in
+  check int "tool_call entries" 2 (List.length tool_calls)
+
+(* ── Query by since ──────────────────────────────── *)
+
+let test_query_by_since () =
+  let log = Audit.create () in
+  Audit.record log (make_entry ~ts:100.0 ());
+  Audit.record log (make_entry ~id:"e2" ~ts:200.0 ());
+  Audit.record log (make_entry ~id:"e3" ~ts:300.0 ());
+  let recent = Audit.query log ~since:200.0 () in
+  check int "since 200" 2 (List.length recent)
+
+(* ── Combined query ──────────────────────────────── *)
+
+let test_query_combined () =
+  let log = Audit.create () in
+  Audit.record log (make_entry ~agent:"alice" ~action:"tool_call" ~ts:100.0 ());
+  Audit.record log (make_entry ~id:"e2" ~agent:"alice" ~action:"handoff" ~ts:200.0 ());
+  Audit.record log (make_entry ~id:"e3" ~agent:"bob" ~action:"tool_call" ~ts:300.0 ());
+  let r = Audit.query log ~agent:"alice" ~action:"tool_call" () in
+  check int "alice + tool_call" 1 (List.length r)
+
+(* ── Latest ──────────────────────────────────────── *)
+
+let test_latest () =
+  let log = Audit.create () in
+  Audit.record log (make_entry ~id:"e1" ~ts:100.0 ());
+  Audit.record log (make_entry ~id:"e2" ~ts:200.0 ());
+  Audit.record log (make_entry ~id:"e3" ~ts:300.0 ());
+  let top2 = Audit.latest log 2 in
+  check int "latest 2" 2 (List.length top2);
+  (* Newest first — e3 should be first *)
+  let ids = List.map (fun (e : Audit.entry) -> e.id) top2 in
+  check (list string) "order" ["e3"; "e2"] ids
+
+(* ── Max capacity eviction ───────────────────────── *)
+
+let test_max_capacity () =
+  let log = Audit.create ~max_entries:3 () in
+  Audit.record log (make_entry ~id:"e1" ~ts:100.0 ());
+  Audit.record log (make_entry ~id:"e2" ~ts:200.0 ());
+  Audit.record log (make_entry ~id:"e3" ~ts:300.0 ());
+  check int "at capacity" 3 (Audit.count log);
+  (* Add one more — oldest should be evicted *)
+  Audit.record log (make_entry ~id:"e4" ~ts:400.0 ());
+  check int "still 3" 3 (Audit.count log);
+  (* e1 (oldest) should be gone, e4 (newest) should be present *)
+  let ids = List.map (fun (e : Audit.entry) -> e.id) (Audit.query log ()) in
+  check bool "e1 evicted" true (not (List.mem "e1" ids));
+  check bool "e4 present" true (List.mem "e4" ids)
+
+let test_no_max_unlimited () =
+  let log = Audit.create () in
+  for i = 1 to 100 do
+    Audit.record log (make_entry ~id:(string_of_int i) ~ts:(float_of_int i) ())
+  done;
+  check int "100 entries" 100 (Audit.count log)
+
+(* ── Export to JSON ──────────────────────────────── *)
+
+let test_to_json () =
+  let dp = Policy.BeforeToolCall { tool_name = "search"; agent_name = "alice" } in
+  let log = Audit.create () in
+  Audit.record log (make_entry
+    ~dp:(Some dp)
+    ~verdict:(Some Policy.Allow)
+    ~detail:(`String "searched") ());
+  let json = Audit.to_json log in
+  match json with
+  | `List [entry] ->
+    let open Yojson.Safe.Util in
+    check string "agent" "agent-a" (entry |> member "agent_name" |> to_string);
+    check string "action" "tool_call" (entry |> member "action" |> to_string);
+    (* verdict should be present *)
+    let v = entry |> member "verdict" |> to_string in
+    check string "verdict" "Allow" v
+  | _ -> fail "expected single-entry list"
+
+let test_entries_to_json () =
+  let entries = [
+    make_entry ~id:"e1" ();
+    make_entry ~id:"e2" ~agent:"bob" ();
+  ] in
+  match Audit.entries_to_json entries with
+  | `List items -> check int "2 items" 2 (List.length items)
+  | _ -> fail "expected list"
+
+(* ── Empty queries ───────────────────────────────── *)
+
+let test_query_empty_log () =
+  let log = Audit.create () in
+  check int "empty query" 0 (List.length (Audit.query log ()));
+  check int "empty latest" 0 (List.length (Audit.latest log 10))
+
+(* ── Suite ────────────────────────────────────────── *)
+
+let () =
+  run "audit" [
+    "basic", [
+      test_case "record and count" `Quick test_record_and_count;
+    ];
+    "query", [
+      test_case "by agent" `Quick test_query_by_agent;
+      test_case "by action" `Quick test_query_by_action;
+      test_case "by since" `Quick test_query_by_since;
+      test_case "combined" `Quick test_query_combined;
+      test_case "empty log" `Quick test_query_empty_log;
+    ];
+    "latest", [
+      test_case "latest entries" `Quick test_latest;
+    ];
+    "capacity", [
+      test_case "max capacity eviction" `Quick test_max_capacity;
+      test_case "no max unlimited" `Quick test_no_max_unlimited;
+    ];
+    "export", [
+      test_case "to_json" `Quick test_to_json;
+      test_case "entries_to_json" `Quick test_entries_to_json;
+    ];
+  ]

--- a/test/test_durable.ml
+++ b/test/test_durable.ml
@@ -1,0 +1,304 @@
+(** Unit tests for Durable module (v0.76.0). *)
+
+open Alcotest
+open Agent_sdk
+
+(* ── Helpers ──────────────────────────────────────── *)
+
+let ok_step name f : Durable.step =
+  { name; execute = (fun input -> Ok (f input)); retry_limit = 1 }
+
+let fail_step name msg : Durable.step =
+  { name; execute = (fun _ -> Error msg); retry_limit = 1 }
+
+let increment_step name : Durable.step =
+  ok_step name (fun j ->
+    let open Yojson.Safe.Util in
+    `Int (j |> to_int |> succ))
+
+let double_step name : Durable.step =
+  ok_step name (fun j ->
+    let open Yojson.Safe.Util in
+    `Int (j |> to_int |> ( * ) 2))
+
+(* ── Basic execution ─────────────────────────────── *)
+
+let test_single_step () =
+  let sm = Durable.create ~name:"single" () in
+  let sm = Durable.add_step sm (increment_step "inc") in
+  match Durable.execute sm (`Int 10) with
+  | Completed { final_output = `Int 11; journal } ->
+    check int "journal entries" 1 (List.length journal)
+  | state ->
+    fail (Printf.sprintf "expected Completed, got %s"
+      (Yojson.Safe.to_string (Durable.execution_state_to_json state)))
+
+let test_multi_step_chain () =
+  let sm = Durable.create ~name:"chain" () in
+  let sm = Durable.add_step sm (increment_step "inc") in
+  let sm = Durable.add_step sm (double_step "double") in
+  let sm = Durable.add_step sm (increment_step "inc2") in
+  (* 5 -> inc -> 6 -> double -> 12 -> inc2 -> 13 *)
+  match Durable.execute sm (`Int 5) with
+  | Completed { final_output = `Int 13; journal } ->
+    check int "3 journal entries" 3 (List.length journal)
+  | state ->
+    fail (Printf.sprintf "expected Completed(13), got %s"
+      (Yojson.Safe.to_string (Durable.execution_state_to_json state)))
+
+let test_empty_pipeline () =
+  let sm = Durable.create ~name:"empty" () in
+  match Durable.execute sm (`String "pass-through") with
+  | Completed { final_output = `String "pass-through"; _ } -> ()
+  | _ -> fail "expected pass-through completion"
+
+(* ── Step failure ────────────────────────────────── *)
+
+let test_step_failure () =
+  let sm = Durable.create ~name:"fail" () in
+  let sm = Durable.add_step sm (increment_step "inc") in
+  let sm = Durable.add_step sm (fail_step "broken" "kaboom") in
+  let sm = Durable.add_step sm (increment_step "never") in
+  match Durable.execute sm (`Int 0) with
+  | Failed { at_step; error; journal } ->
+    check string "at_step" "broken" at_step;
+    check string "error" "kaboom" error;
+    (* journal should have inc success + broken failure *)
+    check int "journal" 2 (List.length journal)
+  | _ -> fail "expected Failed"
+
+(* ── Retry ───────────────────────────────────────── *)
+
+let test_retry_succeeds () =
+  let call_count = ref 0 in
+  let flaky : Durable.step = {
+    name = "flaky";
+    retry_limit = 3;
+    execute = (fun input ->
+      incr call_count;
+      if !call_count < 3 then Error "not yet"
+      else Ok input);
+  } in
+  let sm = Durable.create ~name:"retry" () in
+  let sm = Durable.add_step sm flaky in
+  match Durable.execute sm (`Int 42) with
+  | Completed { final_output = `Int 42; _ } ->
+    check int "called 3 times" 3 !call_count
+  | _ -> fail "expected Completed after retries"
+
+let test_retry_exhausted () =
+  let flaky : Durable.step = {
+    name = "always-fail";
+    retry_limit = 2;
+    execute = (fun _ -> Error "nope");
+  } in
+  let sm = Durable.create ~name:"exhaust" () in
+  let sm = Durable.add_step sm flaky in
+  match Durable.execute sm (`Int 0) with
+  | Failed { at_step = "always-fail"; error = "nope"; _ } -> ()
+  | _ -> fail "expected Failed after retry exhaustion"
+
+(* ── Resume ──────────────────────────────────────── *)
+
+let test_resume_from_failed () =
+  (* First run: step 2 fails *)
+  let attempt = ref 0 in
+  let step2 : Durable.step = {
+    name = "step2";
+    retry_limit = 1;
+    execute = (fun input ->
+      incr attempt;
+      if !attempt <= 1 then Error "fail-first-time"
+      else Ok input);
+  } in
+  let sm = Durable.create ~name:"resume" () in
+  let sm = Durable.add_step sm (increment_step "step1") in
+  let sm = Durable.add_step sm step2 in
+  let state = Durable.execute sm (`Int 10) in
+  (match state with
+   | Failed { at_step = "step2"; _ } -> ()
+   | _ -> fail "expected Failed at step2");
+  (* Resume — step2 should succeed on second attempt *)
+  let state2 = Durable.resume sm state in
+  (match state2 with
+   | Completed { final_output = `Int 11; _ } -> ()
+   | state ->
+     fail (Printf.sprintf "expected Completed(11), got %s"
+       (Yojson.Safe.to_string (Durable.execution_state_to_json state))))
+
+let test_resume_not_started () =
+  let sm = Durable.create ~name:"r" () in
+  let passthrough : Durable.step =
+    { name = "pass"; execute = (fun x -> Ok x); retry_limit = 1 }
+  in
+  let sm = Durable.add_step sm passthrough in
+  match Durable.resume sm Durable.NotStarted with
+  | Completed { final_output = `Null; _ } -> ()
+  | _ -> fail "expected Completed with Null from NotStarted resume"
+
+let test_resume_completed_is_noop () =
+  let state = Durable.Completed { journal = []; final_output = `Int 42 } in
+  let sm = Durable.create ~name:"noop" () in
+  let result = Durable.resume sm state in
+  match result with
+  | Completed { final_output = `Int 42; _ } -> ()
+  | _ -> fail "resume of Completed should return same state"
+
+(* ── Suspend ─────────────────────────────────────── *)
+
+let test_suspend_in_progress () =
+  let state = Durable.InProgress {
+    current_step = "step2"; attempt = 1;
+    journal = [];
+  } in
+  let sm = Durable.create ~name:"s" () in
+  match Durable.suspend sm state ~reason:"user requested" with
+  | Suspended { at_step = "step2"; reason = "user requested"; _ } -> ()
+  | _ -> fail "expected Suspended"
+
+let test_suspend_non_in_progress () =
+  let state = Durable.NotStarted in
+  let sm = Durable.create ~name:"s" () in
+  match Durable.suspend sm state ~reason:"why" with
+  | NotStarted -> ()  (* should return state unchanged *)
+  | _ -> fail "suspend of NotStarted should be noop"
+
+(* ── Serialization round-trip ────────────────────── *)
+
+let test_serialization_not_started () =
+  let state = Durable.NotStarted in
+  let json = Durable.execution_state_to_json state in
+  match Durable.execution_state_of_json json with
+  | Ok NotStarted -> ()
+  | _ -> fail "round-trip NotStarted"
+
+let test_serialization_completed () =
+  let state = Durable.Completed {
+    journal = [];
+    final_output = `String "done";
+  } in
+  let json = Durable.execution_state_to_json state in
+  match Durable.execution_state_of_json json with
+  | Ok (Completed { final_output = `String "done"; _ }) -> ()
+  | _ -> fail "round-trip Completed"
+
+let test_serialization_failed () =
+  let state = Durable.Failed {
+    at_step = "step3";
+    journal = [];
+    error = "timeout";
+  } in
+  let json = Durable.execution_state_to_json state in
+  match Durable.execution_state_of_json json with
+  | Ok (Failed { at_step = "step3"; error = "timeout"; _ }) -> ()
+  | _ -> fail "round-trip Failed"
+
+let test_serialization_suspended () =
+  let state = Durable.Suspended {
+    at_step = "step2";
+    journal = [];
+    reason = "paused";
+  } in
+  let json = Durable.execution_state_to_json state in
+  match Durable.execution_state_of_json json with
+  | Ok (Suspended { at_step = "step2"; reason = "paused"; _ }) -> ()
+  | _ -> fail "round-trip Suspended"
+
+let test_serialization_in_progress () =
+  let state = Durable.InProgress {
+    current_step = "step1";
+    attempt = 2;
+    journal = [];
+  } in
+  let json = Durable.execution_state_to_json state in
+  match Durable.execution_state_of_json json with
+  | Ok (InProgress { current_step = "step1"; attempt = 2; _ }) -> ()
+  | _ -> fail "round-trip InProgress"
+
+let test_serialization_with_journal () =
+  let je : Durable.journal_entry = {
+    step_name = "s1";
+    started_at = 1000.0;
+    completed_at = Some 1001.0;
+    input_json = `Int 5;
+    output_json = Some (`Int 6);
+    error = None;
+    attempt = 1;
+  } in
+  let state = Durable.Completed {
+    journal = [je];
+    final_output = `Int 6;
+  } in
+  let json = Durable.execution_state_to_json state in
+  match Durable.execution_state_of_json json with
+  | Ok (Completed { journal; final_output = `Int 6 }) ->
+    check int "journal len" 1 (List.length journal);
+    let j = List.hd journal in
+    check string "step_name" "s1" j.step_name;
+    check int "attempt" 1 j.attempt
+  | _ -> fail "round-trip with journal"
+
+let test_deserialization_invalid () =
+  match Durable.execution_state_of_json (`String "garbage") with
+  | Error _ -> ()
+  | Ok _ -> fail "expected error on invalid json"
+
+(* ── Queries ─────────────────────────────────────── *)
+
+let test_name_and_step_count () =
+  let sm = Durable.create ~name:"my-sm" () in
+  check string "name" "my-sm" (Durable.name sm);
+  check int "initial steps" 0 (Durable.step_count sm);
+  let sm = Durable.add_step sm (increment_step "a") in
+  let sm = Durable.add_step sm (double_step "b") in
+  check int "2 steps" 2 (Durable.step_count sm);
+  check (list string) "names" ["a"; "b"] (Durable.step_names sm)
+
+let test_is_terminal () =
+  check bool "NotStarted" false (Durable.is_terminal NotStarted);
+  check bool "InProgress" false
+    (Durable.is_terminal (InProgress { current_step = "x"; attempt = 1; journal = [] }));
+  check bool "Suspended" false
+    (Durable.is_terminal (Suspended { at_step = "x"; journal = []; reason = "r" }));
+  check bool "Completed" true
+    (Durable.is_terminal (Completed { journal = []; final_output = `Null }));
+  check bool "Failed" true
+    (Durable.is_terminal (Failed { at_step = "x"; journal = []; error = "e" }))
+
+(* ── Suite ────────────────────────────────────────── *)
+
+let () =
+  run "durable" [
+    "execution", [
+      test_case "single step" `Quick test_single_step;
+      test_case "multi step chain" `Quick test_multi_step_chain;
+      test_case "empty pipeline" `Quick test_empty_pipeline;
+      test_case "step failure" `Quick test_step_failure;
+    ];
+    "retry", [
+      test_case "retry succeeds" `Quick test_retry_succeeds;
+      test_case "retry exhausted" `Quick test_retry_exhausted;
+    ];
+    "resume", [
+      test_case "resume from failed" `Quick test_resume_from_failed;
+      test_case "resume not started" `Quick test_resume_not_started;
+      test_case "resume completed is noop" `Quick test_resume_completed_is_noop;
+    ];
+    "suspend", [
+      test_case "suspend in progress" `Quick test_suspend_in_progress;
+      test_case "suspend non-in-progress" `Quick test_suspend_non_in_progress;
+    ];
+    "serialization", [
+      test_case "NotStarted round-trip" `Quick test_serialization_not_started;
+      test_case "Completed round-trip" `Quick test_serialization_completed;
+      test_case "Failed round-trip" `Quick test_serialization_failed;
+      test_case "Suspended round-trip" `Quick test_serialization_suspended;
+      test_case "InProgress round-trip" `Quick test_serialization_in_progress;
+      test_case "with journal" `Quick test_serialization_with_journal;
+      test_case "invalid json" `Quick test_deserialization_invalid;
+    ];
+    "queries", [
+      test_case "name and step count" `Quick test_name_and_step_count;
+      test_case "is_terminal" `Quick test_is_terminal;
+    ];
+  ]

--- a/test/test_policy.ml
+++ b/test/test_policy.ml
@@ -1,0 +1,233 @@
+(** Unit tests for Policy module (v0.76.0). *)
+
+open Alcotest
+open Agent_sdk
+
+(* ── Helpers ──────────────────────────────────────── *)
+
+let deny_all_rule =
+  Policy.{
+    name = "deny-all";
+    priority = 100;
+    applies_to = (fun _ -> true);
+    evaluate = (fun _ -> Deny "blocked");
+  }
+
+let allow_tool_rule tool =
+  Policy.{
+    name = "allow-" ^ tool;
+    priority = 50;
+    applies_to = (fun dp ->
+      match dp with
+      | BeforeToolCall { tool_name; _ } -> tool_name = tool
+      | _ -> false);
+    evaluate = (fun _ -> Allow);
+  }
+
+let escalate_handoff_rule =
+  Policy.{
+    name = "escalate-handoff";
+    priority = 75;
+    applies_to = (fun dp ->
+      match dp with BeforeHandoff _ -> true | _ -> false);
+    evaluate = (fun _ -> Escalate "needs approval");
+  }
+
+(* ── Priority ordering ───────────────────────────── *)
+
+let test_higher_priority_wins () =
+  let low = Policy.{
+    name = "low-allow";
+    priority = 10;
+    applies_to = (fun _ -> true);
+    evaluate = (fun _ -> Allow);
+  } in
+  let high = Policy.{
+    name = "high-deny";
+    priority = 90;
+    applies_to = (fun _ -> true);
+    evaluate = (fun _ -> Deny "high wins");
+  } in
+  (* Create with low first, high second — priority should sort *)
+  let p = Policy.create [low; high] in
+  let dp = Policy.BeforeToolCall { tool_name = "test"; agent_name = "a" } in
+  match Policy.evaluate p dp with
+  | Deny "high wins" -> ()
+  | v -> fail (Printf.sprintf "expected Deny, got %s" (Policy.verdict_to_string v))
+
+let test_rules_sorted_by_priority () =
+  let r1 = Policy.{ name = "r1"; priority = 10;
+    applies_to = (fun _ -> true); evaluate = (fun _ -> Allow) } in
+  let r2 = Policy.{ name = "r2"; priority = 50;
+    applies_to = (fun _ -> true); evaluate = (fun _ -> Allow) } in
+  let r3 = Policy.{ name = "r3"; priority = 30;
+    applies_to = (fun _ -> true); evaluate = (fun _ -> Allow) } in
+  let p = Policy.create [r1; r2; r3] in
+  let names = List.map (fun (r : Policy.rule) -> r.name) (Policy.rules p) in
+  check (list string) "sorted desc" ["r2"; "r3"; "r1"] names
+
+(* ── No-match returns Allow ──────────────────────── *)
+
+let test_no_matching_rule_returns_allow () =
+  let rule = Policy.{
+    name = "only-handoff";
+    priority = 50;
+    applies_to = (fun dp ->
+      match dp with BeforeHandoff _ -> true | _ -> false);
+    evaluate = (fun _ -> Deny "no handoff");
+  } in
+  let p = Policy.create [rule] in
+  let dp = Policy.BeforeToolCall { tool_name = "x"; agent_name = "a" } in
+  match Policy.evaluate p dp with
+  | Allow -> ()
+  | v -> fail (Printf.sprintf "expected Allow, got %s" (Policy.verdict_to_string v))
+
+let test_empty_policy_returns_allow () =
+  let p = Policy.create [] in
+  let dp = Policy.Custom { name = "test"; detail = "detail" } in
+  match Policy.evaluate p dp with
+  | Allow -> ()
+  | v -> fail (Printf.sprintf "expected Allow, got %s" (Policy.verdict_to_string v))
+
+(* ── Verdict types ───────────────────────────────── *)
+
+let test_all_verdict_types () =
+  let dp = Policy.BeforeToolCall { tool_name = "t"; agent_name = "a" } in
+  (* Deny *)
+  let p1 = Policy.create [deny_all_rule] in
+  (match Policy.evaluate p1 dp with Deny "blocked" -> () | _ -> fail "expected Deny");
+  (* Allow *)
+  let p2 = Policy.create [allow_tool_rule "t"] in
+  (match Policy.evaluate p2 dp with Allow -> () | _ -> fail "expected Allow");
+  (* AllowWithCondition *)
+  let cond_rule = Policy.{
+    name = "conditional";
+    priority = 50;
+    applies_to = (fun _ -> true);
+    evaluate = (fun _ -> AllowWithCondition "log it");
+  } in
+  let p3 = Policy.create [cond_rule] in
+  (match Policy.evaluate p3 dp with
+   | AllowWithCondition "log it" -> ()
+   | _ -> fail "expected AllowWithCondition");
+  (* Escalate *)
+  let hdp = Policy.BeforeHandoff { from_agent = "a"; to_agent = "b" } in
+  let p4 = Policy.create [escalate_handoff_rule] in
+  (match Policy.evaluate p4 hdp with
+   | Escalate "needs approval" -> ()
+   | _ -> fail "expected Escalate")
+
+(* ── Rule management ─────────────────────────────── *)
+
+let test_add_rule () =
+  let p = Policy.create [] in
+  check int "initial count" 0 (Policy.rule_count p);
+  let p = Policy.add_rule p deny_all_rule in
+  check int "after add" 1 (Policy.rule_count p);
+  let dp = Policy.Custom { name = "x"; detail = "" } in
+  match Policy.evaluate p dp with
+  | Deny "blocked" -> ()
+  | _ -> fail "expected Deny after add"
+
+let test_remove_rule () =
+  let p = Policy.create [deny_all_rule; escalate_handoff_rule] in
+  check int "initial" 2 (Policy.rule_count p);
+  let p = Policy.remove_rule p "deny-all" in
+  check int "after remove" 1 (Policy.rule_count p);
+  let dp = Policy.Custom { name = "x"; detail = "" } in
+  (* deny-all removed, no rule matches Custom *)
+  match Policy.evaluate p dp with
+  | Allow -> ()
+  | _ -> fail "expected Allow after removing deny-all"
+
+let test_add_maintains_priority_order () =
+  let low = Policy.{
+    name = "low"; priority = 10;
+    applies_to = (fun _ -> true); evaluate = (fun _ -> Allow) } in
+  let high = Policy.{
+    name = "high"; priority = 99;
+    applies_to = (fun _ -> true); evaluate = (fun _ -> Deny "high") } in
+  let p = Policy.create [low] in
+  let p = Policy.add_rule p high in
+  let names = List.map (fun (r : Policy.rule) -> r.name) (Policy.rules p) in
+  check (list string) "high first" ["high"; "low"] names
+
+(* ── String conversions ──────────────────────────── *)
+
+let test_verdict_to_string () =
+  check string "allow" "Allow" (Policy.verdict_to_string Allow);
+  check string "deny" "Deny(reason)" (Policy.verdict_to_string (Deny "reason"));
+  check string "cond" "AllowWithCondition(cond)"
+    (Policy.verdict_to_string (AllowWithCondition "cond"));
+  check string "escalate" "Escalate(esc)"
+    (Policy.verdict_to_string (Escalate "esc"))
+
+let test_decision_point_to_string () =
+  let s1 = Policy.decision_point_to_string
+    (BeforeToolCall { tool_name = "t"; agent_name = "a" }) in
+  check bool "contains BeforeToolCall" true (String.length s1 > 0);
+  let s2 = Policy.decision_point_to_string
+    (BeforeHandoff { from_agent = "x"; to_agent = "y" }) in
+  check bool "contains BeforeHandoff" true (String.length s2 > 0);
+  let s3 = Policy.decision_point_to_string
+    (BeforeResponse { agent_name = "a"; content_preview = "hi" }) in
+  check bool "contains BeforeResponse" true (String.length s3 > 0);
+  let s4 = Policy.decision_point_to_string
+    (ResourceRequest { agent_name = "a"; resource = "gpu"; amount = 1.0 }) in
+  check bool "contains ResourceRequest" true (String.length s4 > 0);
+  let s5 = Policy.decision_point_to_string
+    (BeforeMemoryWrite { agent_name = "a"; tier = "working"; key = "k" }) in
+  check bool "contains BeforeMemoryWrite" true (String.length s5 > 0);
+  let s6 = Policy.decision_point_to_string
+    (Custom { name = "custom"; detail = "d" }) in
+  check bool "contains Custom" true (String.length s6 > 0)
+
+(* ── First match semantics ───────────────────────── *)
+
+let test_first_matching_rule_wins () =
+  (* Two rules both match, higher priority wins *)
+  let r1 = Policy.{
+    name = "first";
+    priority = 80;
+    applies_to = (fun _ -> true);
+    evaluate = (fun _ -> Deny "first-match");
+  } in
+  let r2 = Policy.{
+    name = "second";
+    priority = 60;
+    applies_to = (fun _ -> true);
+    evaluate = (fun _ -> Deny "second-match");
+  } in
+  let p = Policy.create [r2; r1] in
+  let dp = Policy.Custom { name = "x"; detail = "" } in
+  match Policy.evaluate p dp with
+  | Deny "first-match" -> ()
+  | v -> fail (Printf.sprintf "expected first-match, got %s"
+    (Policy.verdict_to_string v))
+
+(* ── Suite ────────────────────────────────────────── *)
+
+let () =
+  run "policy" [
+    "priority", [
+      test_case "higher priority wins" `Quick test_higher_priority_wins;
+      test_case "rules sorted by priority" `Quick test_rules_sorted_by_priority;
+      test_case "first matching rule wins" `Quick test_first_matching_rule_wins;
+    ];
+    "no-match", [
+      test_case "no matching rule returns Allow" `Quick test_no_matching_rule_returns_allow;
+      test_case "empty policy returns Allow" `Quick test_empty_policy_returns_allow;
+    ];
+    "verdicts", [
+      test_case "all verdict types" `Quick test_all_verdict_types;
+    ];
+    "management", [
+      test_case "add rule" `Quick test_add_rule;
+      test_case "remove rule" `Quick test_remove_rule;
+      test_case "add maintains priority order" `Quick test_add_maintains_priority_order;
+    ];
+    "strings", [
+      test_case "verdict_to_string" `Quick test_verdict_to_string;
+      test_case "decision_point_to_string" `Quick test_decision_point_to_string;
+    ];
+  ]


### PR DESCRIPTION
## Summary

- **Durable**: Typed step chain state machine with execution journal, retry, suspend/resume, and JSON serialization for crash-recoverable agent workflows
- **Policy**: Priority-ordered rule engine for runtime governance at decision points (tool calls, handoffs, memory writes, etc.)
- **Audit**: Immutable log of policy decisions with query-by-agent/action/time, max capacity eviction, and JSON export

Phase 3 of the Agent Society roadmap. All three modules have `.mli` contracts and are re-exported through `Agent_sdk`.

## Test plan

- [x] `test_policy.ml`: 11 tests — priority ordering, verdict types, no-match Allow, rule add/remove, string conversions
- [x] `test_audit.ml`: 11 tests — record, query filters (agent/action/since/combined), max capacity eviction, JSON export
- [x] `test_durable.ml`: 20 tests — step chain execution, retry, resume from failed, suspend, serialization round-trip, queries
- [x] `dune build` green
- [x] All 42 new tests pass

Generated with [Claude Code](https://claude.com/claude-code)