### PR TITLE
refactor: migrate 5 files to Fs_result (-143 lines)

### DIFF
--- a/lib/checkpoint_store.ml
+++ b/lib/checkpoint_store.ml
@@ -13,17 +13,7 @@ let validate_session_id id =
     Error (Error.Io (ValidationFailed { detail = "session_id must not contain null byte" }))
   else Ok ()
 
-(** Convert file I/O exceptions to sdk_error. Re-raises non-recoverable exceptions. *)
-let io_error_of_exn ~op ~path = function
-  | Eio.Io _ as exn ->
-    Error (Error.Io (FileOpFailed { op; path; detail = Printexc.to_string exn }))
-  | Unix.Unix_error _ as exn ->
-    Error (Error.Io (FileOpFailed { op; path; detail = Printexc.to_string exn }))
-  | Failure msg ->
-    Error (Error.Io (FileOpFailed { op; path; detail = msg }))
-  | Yojson.Json_error msg ->
-    Error (Error.Io (FileOpFailed { op; path; detail = "JSON error: " ^ msg }))
-  | exn -> raise exn
+let io_error_of_exn = Fs_result.io_error_of_exn
 
 let create base_dir =
   try

--- a/lib/context_offload.ml
+++ b/lib/context_offload.ml
@@ -49,17 +49,14 @@ let maybe_offload ~(config : config) ~(tool_name : string) (content : string)
       (int_of_float (Unix.gettimeofday () *. 1000.0))
     in
     let path = Filename.concat config.output_dir filename in
-    try
-      let oc = open_out path in
-      Fun.protect
-        ~finally:(fun () -> close_out_noerr oc)
-        (fun () -> output_string oc content);
+    match Fs_result.write_file path content with
+    | Ok () ->
       let preview =
         if len <= config.preview_len then content
         else String.sub content 0 config.preview_len
       in
       Offloaded { path; preview; original_bytes = len }
-    with _ ->
+    | Error _ ->
       (* Fail-open: if we can't write, keep original content *)
       Kept content
 

--- a/lib/protocol/a2a_task_store.ml
+++ b/lib/protocol/a2a_task_store.ml
@@ -19,17 +19,7 @@ let validate_task_id id =
     Error (Error.Io (ValidationFailed { detail = "task_id must not contain null byte" }))
   else Ok ()
 
-(** Convert file I/O exceptions to sdk_error.  Re-raises non-recoverable exceptions. *)
-let io_error_of_exn ~op ~path = function
-  | Eio.Io _ as exn ->
-    Error (Error.Io (FileOpFailed { op; path; detail = Printexc.to_string exn }))
-  | Unix.Unix_error _ as exn ->
-    Error (Error.Io (FileOpFailed { op; path; detail = Printexc.to_string exn }))
-  | Failure msg ->
-    Error (Error.Io (FileOpFailed { op; path; detail = msg }))
-  | Yojson.Json_error msg ->
-    Error (Error.Io (FileOpFailed { op; path; detail = "JSON error: " ^ msg }))
-  | exn -> raise exn
+let io_error_of_exn = Fs_result.io_error_of_exn
 
 let file_path store id = Eio.Path.(store.base_dir / (id ^ ".json"))
 let tmp_path store id = Eio.Path.(store.base_dir / (id ^ ".json.tmp"))

--- a/lib/raw_trace.ml
+++ b/lib/raw_trace.ml
@@ -108,8 +108,6 @@ exception Trace_error of Error.sdk_error
 let trace_version = 1
 
 let json_parse_error = Util.json_parse_error
-let file_read_error = Util.file_read_error
-let file_write_error = Util.file_write_error
 
 let safe_name name =
   let trimmed = String.trim name in
@@ -120,23 +118,7 @@ let safe_name name =
       | c -> c)
     base
 
-let rec ensure_dir path =
-  if path = "" || path = "." || path = "/" then Ok ()
-  else
-    try
-      if Sys.file_exists path then Ok ()
-      else (
-        let parent = Filename.dirname path in
-        match ensure_dir parent with
-        | Error _ as err -> err
-        | Ok () ->
-            Unix.mkdir path 0o755;
-            Ok ())
-    with
-    | Unix.Unix_error (err, _, _) ->
-        Error (file_write_error ~path ~detail:(Unix.error_message err))
-    | Sys_error detail ->
-        Error (file_write_error ~path ~detail)
+let ensure_dir = Fs_result.ensure_dir
 
 let record_type_to_string = function
   | Run_started -> "run_started"
@@ -243,23 +225,11 @@ let parse_json_string raw =
   with Yojson.Json_error detail -> Error (json_parse_error detail)
 
 let load_lines path =
-  if not (Sys.file_exists path) then Ok []
+  if not (Fs_result.file_exists path) then Ok []
   else
-    try
-      let ic = open_in_bin path in
-      Fun.protect
-        ~finally:(fun () -> close_in_noerr ic)
-        (fun () ->
-          let rec loop acc =
-            match input_line ic with
-            | line -> loop (line :: acc)
-            | exception End_of_file -> Ok (List.rev acc)
-          in
-          loop [])
-    with
-    | Sys_error detail -> Error (file_read_error ~path ~detail)
-    | Unix.Unix_error (err, _, _) ->
-        Error (file_read_error ~path ~detail:(Unix.error_message err))
+    let* raw = Fs_result.read_file path in
+    Ok (String.split_on_char '\n' raw
+        |> List.filter (fun line -> line <> ""))
 
 let read_all ~path () =
   let* lines = load_lines path in
@@ -321,21 +291,8 @@ let next_worker_run_id sink =
   Printf.sprintf "wr-%08x-%04x-%04x" ts pid idx
 
 let append_locked sink (record : record) =
-  try
-    let oc =
-      open_out_gen [ Open_creat; Open_append; Open_text ] 0o644 sink.path
-    in
-    Fun.protect
-      ~finally:(fun () -> close_out_noerr oc)
-      (fun () ->
-        output_string oc (record_to_json record |> Yojson.Safe.to_string);
-        output_char oc '\n';
-        flush oc;
-        Ok ())
-  with
-  | Sys_error detail -> Error (file_write_error ~path:sink.path ~detail)
-  | Unix.Unix_error (err, _, _) ->
-      Error (file_write_error ~path:sink.path ~detail:(Unix.error_message err))
+  let line = (record_to_json record |> Yojson.Safe.to_string) ^ "\n" in
+  Fs_result.append_file sink.path line
 
 let append_record active ~record_type ?prompt ?block_index ?block_kind
     ?assistant_block ?tool_use_id ?tool_name ?tool_input ?tool_result ?tool_error

--- a/lib/runtime_store.ml
+++ b/lib/runtime_store.ml
@@ -18,26 +18,7 @@ let report_md_path store session_id = Filename.concat (artifacts_dir store sessi
 let proof_json_path store session_id = Filename.concat (artifacts_dir store session_id) "proof.json"
 let proof_md_path store session_id = Filename.concat (artifacts_dir store session_id) "proof.md"
 
-let ensure_dir path =
-  try
-    if Sys.file_exists path then Ok ()
-    else (
-      Unix.mkdir path 0o755;
-      Ok ())
-  with
-  | Unix.Unix_error (err, _, _) ->
-      Error
-        (Error.Io
-           (FileOpFailed
-              {
-                op = "mkdir";
-                path;
-                detail = Unix.error_message err;
-              }))
-  | Sys_error detail ->
-      Error
-        (Error.Io
-           (FileOpFailed { op = "mkdir"; path; detail }))
+let ensure_dir = Fs_result.ensure_dir
 
 let ensure_tree store session_id =
   let* () = ensure_dir store.root in
@@ -63,50 +44,9 @@ let create ?root () =
   let* () = ensure_dir (sessions_dir store) in
   Ok store
 
-let save_text path content =
-  try
-    let temp_path =
-      Printf.sprintf "%s.tmp-%d-%06x" path (Unix.getpid ()) (Random.int 0xFFFFFF)
-    in
-    let oc = open_out_bin temp_path in
-    Fun.protect
-      ~finally:(fun () -> close_out_noerr oc)
-      (fun () ->
-        output_string oc content;
-        flush oc;
-        Unix.rename temp_path path;
-        Ok ())
-  with
-  | Sys_error detail ->
-      Error
-        (Error.Io
-           (FileOpFailed { op = "write"; path; detail }))
-  | Unix.Unix_error (err, _, _) ->
-      Error
-        (Error.Io
-           (FileOpFailed { op = "write"; path; detail = Unix.error_message err }))
+let save_text = Fs_result.write_file
 
-let load_text path =
-  try
-    let ic = open_in_bin path in
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () ->
-        let len = in_channel_length ic in
-        Ok (really_input_string ic len))
-  with
-  | Sys_error detail ->
-      Error
-        (Error.Io
-           (FileOpFailed { op = "read"; path; detail }))
-  | Unix.Unix_error (err, _, _) ->
-      Error
-        (Error.Io
-           (FileOpFailed { op = "read"; path; detail = Unix.error_message err }))
-  | End_of_file ->
-      Error
-        (Error.Io
-           (FileOpFailed { op = "read"; path; detail = "unexpected end of file" }))
+let load_text = Fs_result.read_file
 
 let save_session store (session : session) =
   let* () = ensure_tree store session.session_id in
@@ -162,25 +102,8 @@ let load_session store session_id =
 let append_event store session_id (event : event) =
   let* () = ensure_tree store session_id in
   let path = events_path store session_id in
-  try
-    let oc =
-      open_out_gen [ Open_creat; Open_text; Open_append ] 0o644 path
-    in
-    Fun.protect
-      ~finally:(fun () -> close_out_noerr oc)
-      (fun () ->
-        output_string oc (event |> event_to_yojson |> Yojson.Safe.to_string);
-        output_char oc '\n';
-        flush oc;
-        Ok ())
-  with
-  | Sys_error detail ->
-      Error
-        (Error.Io (FileOpFailed { op = "append"; path; detail }))
-  | Unix.Unix_error (err, _, _) ->
-      Error
-        (Error.Io
-           (FileOpFailed { op = "append"; path; detail = Unix.error_message err }))
+  let line = (event |> event_to_yojson |> Yojson.Safe.to_string) ^ "\n" in
+  Fs_result.append_file path line
 
 let read_events store session_id ?after_seq () =
   let path = events_path store session_id in


### PR DESCRIPTION
## Summary
- `runtime_store.ml`: `ensure_dir`/`save_text`/`load_text`/`append_event` → `Fs_result` (−67줄)
- `raw_trace.ml`: `ensure_dir`/`load_lines`/`append_locked` → `Fs_result` (−55줄)
- `context_offload.ml`: `open_out` + bare `with _` → `Fs_result.write_file` (−3줄)
- `checkpoint_store.ml`: 로컬 `io_error_of_exn` → `Fs_result.io_error_of_exn` (−10줄)
- `a2a_task_store.ml`: 로컬 `io_error_of_exn` → `Fs_result.io_error_of_exn` (−10줄)

## Motivation
PR #265에서 추가한 `Fs_result` 모듈을 실제 사용. 중복 I/O 에러 처리 143줄 제거, `Eio.Io` 예외 누출 방지.

## Test plan
- [x] `dune build` 통과
- [x] `dune runtest` 전체 통과
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)