### PR TITLE
fix: replace Thread.create with Eio.Fiber.fork

### DIFF
--- a/bin/oas_runtime.ml
+++ b/bin/oas_runtime.ml
@@ -1,4 +1,5 @@
 let () =
   Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
   let net = Eio.Stdenv.net env in
-  Agent_sdk__Runtime_server.serve_stdio ~net ()
+  Agent_sdk__Runtime_server.serve_stdio ~sw ~net ()

--- a/lib/runtime_server.ml
+++ b/lib/runtime_server.ml
@@ -89,7 +89,7 @@ let finalize_session state store (session : session) reason =
   in
   Ok (Finalized final_session)
 
-let apply_command state store (session : session) command =
+let apply_command ~sw state store (session : session) command =
   let session_id = session.session_id in
   match command with
   | Record_turn detail ->
@@ -155,54 +155,50 @@ let apply_command state store (session : session) command =
         Ok (Command_applied session)
       else
         let participant_name = detail.participant_name in
-        let _worker =
-          Thread.create
-            (fun () ->
-              ignore
-                (match
-                   persist_event store state session_id
-                     (Agent_became_live
-                        {
-                          participant_name;
-                          summary = Some "runtime-started";
-                          provider = resolution.resolved_provider;
-                          model = resolution.resolved_model;
-                          error = None;
-                        })
+        Eio.Fiber.fork ~sw (fun () ->
+          ignore
+            (match
+               persist_event store state session_id
+                 (Agent_became_live
+                    {
+                      participant_name;
+                      summary = Some "runtime-started";
+                      provider = resolution.resolved_provider;
+                      model = resolution.resolved_model;
+                      error = None;
+                    })
+             with
+             | Error _ -> Ok ()
+             | Ok _ -> (
+                 match
+                   run_participant store state session_id resolution detail
                  with
-                 | Error _ -> Ok ()
-                 | Ok _ -> (
-                     match
-                       run_participant store state session_id resolution detail
-                     with
-                     | Ok summary ->
-                         let* _session, _ =
-                           persist_event store state session_id
-                             (Agent_completed
-                                {
-                                  participant_name;
-                                  summary = Some summary;
-                                  provider = resolution.resolved_provider;
-                                  model = resolution.resolved_model;
-                                  error = None;
-                                })
-                         in
-                         Ok ()
-                     | Error err ->
-                         let* _session, _ =
-                           persist_event store state session_id
-                             (Agent_failed
-                                {
-                                  participant_name;
-                                  summary = None;
-                                  provider = resolution.resolved_provider;
-                                  model = resolution.resolved_model;
-                                  error = Some (Error.to_string err);
-                                })
-                         in
-                         Ok ())))
-            ()
-        in
+                 | Ok summary ->
+                     let* _session, _ =
+                       persist_event store state session_id
+                         (Agent_completed
+                            {
+                              participant_name;
+                              summary = Some summary;
+                              provider = resolution.resolved_provider;
+                              model = resolution.resolved_model;
+                              error = None;
+                            })
+                     in
+                     Ok ()
+                 | Error err ->
+                     let* _session, _ =
+                       persist_event store state session_id
+                         (Agent_failed
+                            {
+                              participant_name;
+                              summary = None;
+                              provider = resolution.resolved_provider;
+                              model = resolution.resolved_model;
+                              error = Some (Error.to_string err);
+                            })
+                     in
+                     Ok ())));
         Ok (Command_applied session)
   | Attach_artifact detail ->
       let* artifact =
@@ -247,7 +243,7 @@ let apply_command state store (session : session) command =
       Ok (Command_applied session)
   | Request_finalize detail -> finalize_session state store session detail.reason
 
-let handle_request state request =
+let handle_request ~sw state request =
   match request with
   | Initialize detail ->
       state.session_root <- session_root_request_path detail.session_root;
@@ -275,7 +271,7 @@ let handle_request state request =
   | Apply_command { session_id; command } ->
       let* store = store_of_state state in
       let* session = Runtime_store.load_session store session_id in
-      apply_command state store session command
+      apply_command ~sw state store session command
   | Status { session_id } ->
       let* store = store_of_state state in
       let* session = Runtime_store.load_session store session_id in
@@ -314,7 +310,7 @@ let handle_request state request =
       Ok (Prove_response proof)
   | Shutdown -> Ok Shutdown_ack
 
-let serve_stdio ~net () =
+let serve_stdio ~sw ~net () =
   let state = create ~net () in
   let rec loop () =
     match input_line stdin with
@@ -324,7 +320,7 @@ let serve_stdio ~net () =
         match protocol_message_of_string raw with
         | Ok (Request_message payload) ->
             let response =
-              match handle_request state payload.request with
+              match handle_request ~sw state payload.request with
               | Ok response -> response
               | Error err -> Error_response (Error.to_string err)
             in
@@ -344,7 +340,7 @@ let serve_stdio ~net () =
                 loop ()
             | Ok request ->
             let response =
-              match handle_request state request with
+              match handle_request ~sw state request with
               | Ok response -> response
               | Error err -> Error_response (Error.to_string err)
             in

--- a/lib/runtime_server.mli
+++ b/lib/runtime_server.mli
@@ -11,12 +11,12 @@ open Runtime_server_types
 
 (** Main server loop: reads protocol messages from stdin and processes
     them until a Shutdown message is received. *)
-val serve_stdio : net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t -> unit -> unit
+val serve_stdio : sw:Eio.Switch.t -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t -> unit -> unit
 
 (** {1 Request handling} *)
 
 val handle_request :
-  state -> request -> (response, Error.sdk_error) result
+  sw:Eio.Switch.t -> state -> request -> (response, Error.sdk_error) result
 
 val start_session :
   state -> start_request -> (response, Error.sdk_error) result
@@ -25,7 +25,7 @@ val finalize_session :
   state -> Runtime_store.t -> session -> string option -> (response, Error.sdk_error) result
 
 val apply_command :
-  state -> Runtime_store.t -> session -> command -> (response, Error.sdk_error) result
+  sw:Eio.Switch.t -> state -> Runtime_store.t -> session -> command -> (response, Error.sdk_error) result
 
 (** {1 Control channel} *)
 


### PR DESCRIPTION
## Summary
- `Thread.create` → `Eio.Fiber.fork ~sw`: 비감독 OS 스레드를 Eio structured concurrency로 전환
- `~sw` 파라미터를 `apply_command` → `handle_request` → `serve_stdio` 호출 체인에 전파
- `oas_runtime.ml` 진입점에 `Eio.Switch.run` 추가

## Why
`Thread.create`는 Eio 런타임 밖에서 실행되어:
1. 예외가 소실됨 (fire-and-forget)
2. Eio 스케줄러와 협력하지 않음 (blocking risk)
3. Eio.Mutex와의 상호작용이 정의되지 않음

## Test plan
- [x] `dune build` 통과
- [x] `dune runtest` 전체 통과
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)