### PR TITLE
test: expand coverage 82→84% with inline + external tests

### DIFF
--- a/lib/api.ml
+++ b/lib/api.ml
@@ -289,3 +289,107 @@ let%test "text_blocks_to_string joins text" =
   let blocks = [Types.Text "a"; Types.Text "b"] in
   let result = text_blocks_to_string blocks in
   String.length result > 0
+
+(* --- Additional coverage tests for api.ml --- *)
+
+let%test "map_named_cascade_error HttpError 500" =
+  let err = Llm_provider.Http_client.HttpError { code = 500; body = "server error" } in
+  match map_named_cascade_error err with
+  | Error.Api _ -> true
+  | _ -> false
+
+let%test "map_named_cascade_error HttpError 429" =
+  let err = Llm_provider.Http_client.HttpError { code = 429; body = "rate limit" } in
+  match map_named_cascade_error err with
+  | Error.Api _ -> true
+  | _ -> false
+
+let%test "named_cascade defaults" =
+  let nc = named_cascade ~name:"default" ~defaults:[] () in
+  nc.name = "default" && nc.defaults = [] && nc.config_path = None
+
+let%test "string_is_blank tab only" =
+  string_is_blank "\t" = true
+
+let%test "string_is_blank newline only" =
+  string_is_blank "\n" = true
+
+let%test "string_is_blank mixed whitespace" =
+  string_is_blank " \t\n " = true
+
+let%test "string_is_blank single char" =
+  string_is_blank "x" = false
+
+let%test "json_of_string_or_raw empty string" =
+  match json_of_string_or_raw "" with
+  | `Assoc [("raw", `String "")] -> true
+  | _ -> false
+
+let%test "json_of_string_or_raw integer string" =
+  match json_of_string_or_raw "42" with
+  | `Int 42 -> true
+  | _ -> false
+
+let%test "json_of_string_or_raw array" =
+  match json_of_string_or_raw "[1,2,3]" with
+  | `List _ -> true
+  | _ -> false
+
+let%test "json_of_string_or_raw null" =
+  match json_of_string_or_raw "null" with
+  | `Null -> true
+  | _ -> false
+
+let%test "content_block_to_json tool_use block" =
+  let block = Types.ToolUse { id = "t1"; name = "fn"; input = `Assoc [("x", `Int 1)] } in
+  let json = content_block_to_json block in
+  let open Yojson.Safe.Util in
+  json |> member "type" |> to_string = "tool_use"
+
+let%test "content_block_of_json tool_use block" =
+  let json = `Assoc [
+    ("type", `String "tool_use");
+    ("id", `String "t1");
+    ("name", `String "fn");
+    ("input", `Assoc [("x", `Int 1)]);
+  ] in
+  match content_block_of_json json with
+  | Some (Types.ToolUse { id = "t1"; name = "fn"; _ }) -> true
+  | _ -> false
+
+let%test "content_block_of_json tool_result" =
+  let json = `Assoc [
+    ("type", `String "tool_result");
+    ("tool_use_id", `String "t1");
+    ("content", `String "ok");
+  ] in
+  match content_block_of_json json with
+  | Some (Types.ToolResult { tool_use_id = "t1"; content = "ok"; _ }) -> true
+  | _ -> false
+
+let%test "content_block_of_json unknown type" =
+  let json = `Assoc [("type", `String "unknown_type")] in
+  content_block_of_json json = None
+
+let%test "message_to_json assistant message" =
+  let msg : Types.message = {
+    role = Assistant; content = [Types.Text "response"];
+    name = None; tool_call_id = None } in
+  let json = message_to_json msg in
+  let open Yojson.Safe.Util in
+  json |> member "role" |> to_string = "assistant"
+
+let%test "text_blocks_to_string empty" =
+  text_blocks_to_string [] = ""
+
+let%test "text_blocks_to_string single" =
+  let result = text_blocks_to_string [Types.Text "only"] in
+  String.length result > 0
+
+let%test "text_blocks_to_string non-text blocks ignored" =
+  let blocks = [
+    Types.ToolUse { id = "t"; name = "f"; input = `Null };
+    Types.Text "visible";
+  ] in
+  let result = text_blocks_to_string blocks in
+  String.length result > 0

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -549,3 +549,263 @@ let%test "openai_messages_of_message system" =
   let msg = { role = System; content = [Text "system prompt"]; name = None; tool_call_id = None } in
   let result = openai_messages_of_message msg in
   List.length result = 1
+
+(* --- Additional coverage tests --- *)
+
+let%test "openai_messages_of_message user empty content" =
+  let msg = { role = User; content = []; name = None; tool_call_id = None } in
+  let result = openai_messages_of_message msg in
+  (* no content parts and no tool results *)
+  result = []
+
+let%test "openai_messages_of_message user with image" =
+  let msg = { role = User; content = [
+    Image { media_type = "image/png"; data = "abc123"; source_type = "base64" };
+    Text "describe this";
+  ]; name = None; tool_call_id = None } in
+  let result = openai_messages_of_message msg in
+  (* multimodal -> content is a list *)
+  List.length result = 1
+
+let%test "openai_messages_of_message user with document" =
+  let msg = { role = User; content = [
+    Document { media_type = "application/pdf"; data = "abc"; source_type = "base64" };
+  ]; name = None; tool_call_id = None } in
+  let result = openai_messages_of_message msg in
+  List.length result = 1
+
+let%test "openai_messages_of_message user with audio" =
+  let msg = { role = User; content = [
+    Audio { media_type = "audio/wav"; data = "audiodata"; source_type = "base64" };
+  ]; name = None; tool_call_id = None } in
+  let result = openai_messages_of_message msg in
+  List.length result = 1
+
+let%test "openai_messages_of_message assistant text only" =
+  let msg = { role = Assistant; content = [Text "hello"]; name = None; tool_call_id = None } in
+  let result = openai_messages_of_message msg in
+  let json = List.hd result in
+  let open Yojson.Safe.Util in
+  json |> member "content" |> to_string = "hello"
+
+let%test "openai_messages_of_message assistant blank text with tool_calls" =
+  let msg = { role = Assistant; content = [
+    Text "";
+    ToolUse { id = "tc1"; name = "fn"; input = `Assoc [] };
+  ]; name = None; tool_call_id = None } in
+  let result = openai_messages_of_message msg in
+  let json = List.hd result in
+  let open Yojson.Safe.Util in
+  json |> member "content" = `Null
+
+let%test "openai_messages_of_message Tool role with ToolResult" =
+  let msg = { role = Tool; content = [
+    ToolResult { tool_use_id = "tc1"; content = "result data"; is_error = false };
+  ]; name = None; tool_call_id = None } in
+  let result = openai_messages_of_message msg in
+  List.length result = 1
+  && (let json = List.hd result in
+      let open Yojson.Safe.Util in
+      json |> member "role" |> to_string = "tool")
+
+let%test "openai_messages_of_message Tool role without ToolResult fallback to user" =
+  let msg = { role = Tool; content = [Text "fallback"]; name = None; tool_call_id = None } in
+  let result = openai_messages_of_message msg in
+  let json = List.hd result in
+  let open Yojson.Safe.Util in
+  json |> member "role" |> to_string = "user"
+
+let%test "build_openai_tool_json with parameters field" =
+  let tool_json = `Assoc [
+    ("name", `String "my_fn");
+    ("description", `String "does stuff");
+    ("parameters", `Assoc [("type", `String "object")]);
+  ] in
+  let result = build_openai_tool_json tool_json in
+  let open Yojson.Safe.Util in
+  result |> member "function" |> member "parameters" |> member "type" |> to_string = "object"
+
+let%test "build_openai_tool_json missing all optional fields" =
+  let tool_json = `Assoc [] in
+  let result = build_openai_tool_json tool_json in
+  let open Yojson.Safe.Util in
+  result |> member "function" |> member "name" |> to_string = "tool"
+  && result |> member "function" |> member "description" |> to_string = ""
+
+let%test "strip_json_markdown_fences no closing fence" =
+  let input = "```json\n{\"key\":\"value\"}" in
+  strip_json_markdown_fences input = input
+
+let%test "strip_json_markdown_fences empty content" =
+  strip_json_markdown_fences "" = ""
+
+let%test "parse_openai_response unknown finish_reason" =
+  let json_str = Yojson.Safe.to_string (`Assoc [
+    ("id", `String "c1");
+    ("model", `String "m");
+    ("choices", `List [
+      `Assoc [
+        ("finish_reason", `String "something_new");
+        ("message", `Assoc [("content", `String "text")]);
+      ];
+    ]);
+  ]) in
+  let resp = parse_openai_response json_str in
+  resp.stop_reason = Unknown "something_new"
+
+let%test "parse_openai_response end_turn finish_reason" =
+  let json_str = Yojson.Safe.to_string (`Assoc [
+    ("id", `String "c1");
+    ("model", `String "m");
+    ("choices", `List [
+      `Assoc [
+        ("finish_reason", `String "end_turn");
+        ("message", `Assoc [("content", `String "done")]);
+      ];
+    ]);
+  ]) in
+  let resp = parse_openai_response json_str in
+  resp.stop_reason = EndTurn
+
+let%test "parse_openai_response null content" =
+  let json_str = Yojson.Safe.to_string (`Assoc [
+    ("id", `String "c1");
+    ("model", `String "m");
+    ("choices", `List [
+      `Assoc [
+        ("finish_reason", `String "stop");
+        ("message", `Assoc [("content", `Null)]);
+      ];
+    ]);
+  ]) in
+  let resp = parse_openai_response json_str in
+  resp.stop_reason = EndTurn
+
+let%test "parse_openai_response list content" =
+  let json_str = Yojson.Safe.to_string (`Assoc [
+    ("id", `String "c1");
+    ("model", `String "m");
+    ("choices", `List [
+      `Assoc [
+        ("finish_reason", `String "stop");
+        ("message", `Assoc [
+          ("content", `List [`String "part1"; `String "part2"])
+        ]);
+      ];
+    ]);
+  ]) in
+  let resp = parse_openai_response json_str in
+  match resp.content with
+  | [Text t] -> String.length t > 0
+  | _ -> false
+
+let%test "parse_openai_response list content with assoc text blocks" =
+  let json_str = Yojson.Safe.to_string (`Assoc [
+    ("id", `String "c1");
+    ("model", `String "m");
+    ("choices", `List [
+      `Assoc [
+        ("finish_reason", `String "stop");
+        ("message", `Assoc [
+          ("content", `List [
+            `Assoc [("text", `String "block1")];
+            `Assoc [("text", `String "block2")];
+          ])
+        ]);
+      ];
+    ]);
+  ]) in
+  let resp = parse_openai_response json_str in
+  match resp.content with
+  | [Text t] -> t = "block1block2"
+  | _ -> false
+
+let%test "parse_openai_response with reasoning_content" =
+  let json_str = Yojson.Safe.to_string (`Assoc [
+    ("id", `String "c1");
+    ("model", `String "deepseek-r1");
+    ("choices", `List [
+      `Assoc [
+        ("finish_reason", `String "stop");
+        ("message", `Assoc [
+          ("content", `String "answer");
+          ("reasoning_content", `String "I thought about it");
+        ]);
+      ];
+    ]);
+  ]) in
+  let resp = parse_openai_response json_str in
+  let has_thinking = List.exists (function
+    | Thinking _ -> true | _ -> false) resp.content in
+  has_thinking
+
+let%test "parse_openai_response JSON list wrapping" =
+  let inner = `Assoc [
+    ("id", `String "c1");
+    ("model", `String "m");
+    ("choices", `List [
+      `Assoc [
+        ("finish_reason", `String "stop");
+        ("message", `Assoc [("content", `String "ok")]);
+      ];
+    ]);
+  ] in
+  let json_str = Yojson.Safe.to_string (`List [inner]) in
+  let resp = parse_openai_response json_str in
+  resp.id = "c1"
+
+let%test "parse_openai_response error without message" =
+  let json_str = Yojson.Safe.to_string (`Assoc [
+    ("error", `Assoc []);
+  ]) in
+  try
+    ignore (parse_openai_response json_str);
+    false
+  with Openai_api_error msg -> msg = "Unknown API error"
+
+let%test "usage_of_openai_json prompt_tokens_details null" =
+  let json = `Assoc [
+    ("usage", `Assoc [
+      ("prompt_tokens", `Int 50);
+      ("completion_tokens", `Int 25);
+      ("prompt_tokens_details", `Null);
+    ]);
+  ] in
+  match usage_of_openai_json json with
+  | Some u -> u.cache_read_input_tokens = 0
+  | None -> false
+
+let%test "openai_content_parts_of_blocks image block" =
+  let blocks = [
+    Image { media_type = "image/png"; data = "abc"; source_type = "base64" };
+  ] in
+  let result = openai_content_parts_of_blocks blocks in
+  List.length result = 1
+
+let%test "openai_content_parts_of_blocks document block" =
+  let blocks = [
+    Document { media_type = "application/pdf"; data = "abc"; source_type = "base64" };
+  ] in
+  let result = openai_content_parts_of_blocks blocks in
+  List.length result = 1
+
+let%test "openai_content_parts_of_blocks audio block" =
+  let blocks = [
+    Audio { media_type = "audio/wav"; data = "abc"; source_type = "base64" };
+  ] in
+  let result = openai_content_parts_of_blocks blocks in
+  List.length result = 1
+
+let%test "openai_content_parts_of_blocks redacted thinking filtered" =
+  let blocks = [
+    RedactedThinking "secret";
+    Text "visible";
+  ] in
+  let result = openai_content_parts_of_blocks blocks in
+  List.length result = 1
+
+let%test "openai_content_parts_of_blocks tool_result filtered" =
+  let blocks = [
+    ToolResult { tool_use_id = "t1"; content = "result"; is_error = false };
+  ] in
+  openai_content_parts_of_blocks blocks = []

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -544,3 +544,196 @@ let%test "finalize_stream_acc includes usage" =
     u.input_tokens = 100 && u.output_tokens = 50
     && u.cache_creation_input_tokens = 10 && u.cache_read_input_tokens = 20
   | None -> false
+
+(* --- gemini_url tests --- *)
+
+let%test "gemini_url sync no api_key" =
+  let config : Provider_config.t = {
+    kind = Provider_config.Gemini;
+    model_id = "gemini-2.5-flash";
+    base_url = "https://gen.googleapis.com/v1beta";
+    api_key = ""; request_path = ""; headers = [];
+    system_prompt = None; temperature = None; max_tokens = 1024;
+    top_p = None; top_k = None; min_p = None;
+    enable_thinking = None; thinking_budget = None;
+    tool_choice = None; disable_parallel_tool_use = false;
+    response_format_json = false; cache_system_prompt = false;
+  } in
+  let url = gemini_url ~config ~stream:false in
+  url = "https://gen.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
+
+let%test "gemini_url sync with api_key" =
+  let config : Provider_config.t = {
+    kind = Gemini; model_id = "gemini-2.5-flash";
+    base_url = "https://gen.googleapis.com/v1beta";
+    api_key = "mykey"; request_path = ""; headers = [];
+    system_prompt = None; temperature = None; max_tokens = 1024;
+    top_p = None; top_k = None; min_p = None;
+    enable_thinking = None; thinking_budget = None;
+    tool_choice = None; disable_parallel_tool_use = false;
+    response_format_json = false; cache_system_prompt = false;
+  } in
+  let url = gemini_url ~config ~stream:false in
+  url = "https://gen.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=mykey"
+
+let%test "gemini_url stream with api_key" =
+  let config : Provider_config.t = {
+    kind = Gemini; model_id = "gemini-2.5-flash";
+    base_url = "https://gen.googleapis.com/v1beta";
+    api_key = "mykey"; request_path = ""; headers = [];
+    system_prompt = None; temperature = None; max_tokens = 1024;
+    top_p = None; top_k = None; min_p = None;
+    enable_thinking = None; thinking_budget = None;
+    tool_choice = None; disable_parallel_tool_use = false;
+    response_format_json = false; cache_system_prompt = false;
+  } in
+  let url = gemini_url ~config ~stream:true in
+  url = "https://gen.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?key=mykey&alt=sse"
+
+let%test "gemini_url stream no api_key" =
+  let config : Provider_config.t = {
+    kind = Gemini; model_id = "gemini-2.5-flash";
+    base_url = "https://gen.googleapis.com/v1beta";
+    api_key = ""; request_path = ""; headers = [];
+    system_prompt = None; temperature = None; max_tokens = 1024;
+    top_p = None; top_k = None; min_p = None;
+    enable_thinking = None; thinking_budget = None;
+    tool_choice = None; disable_parallel_tool_use = false;
+    response_format_json = false; cache_system_prompt = false;
+  } in
+  let url = gemini_url ~config ~stream:true in
+  url = "https://gen.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse"
+
+(* --- accumulate_event edge cases --- *)
+
+let%test "accumulate_event ContentBlockDelta on unknown index creates buffer" =
+  let acc = create_stream_acc () in
+  accumulate_event acc (Types.ContentBlockDelta {
+    index = 99; delta = Types.TextDelta "orphan" });
+  match Hashtbl.find_opt acc.block_texts 99 with
+  | Some buf -> Buffer.contents buf = "orphan"
+  | None -> false
+
+let%test "accumulate_event ContentBlockStart with tool_id and tool_name" =
+  let acc = create_stream_acc () in
+  accumulate_event acc (Types.ContentBlockStart {
+    index = 0; content_type = "tool_use";
+    tool_id = Some "tid-1"; tool_name = Some "my_fn" });
+  Hashtbl.find acc.block_tool_ids 0 = "tid-1"
+  && Hashtbl.find acc.block_tool_names 0 = "my_fn"
+
+let%test "accumulate_event ThinkingDelta appends to buffer" =
+  let acc = create_stream_acc () in
+  accumulate_event acc (Types.ContentBlockStart {
+    index = 0; content_type = "thinking"; tool_id = None; tool_name = None });
+  accumulate_event acc (Types.ContentBlockDelta {
+    index = 0; delta = Types.ThinkingDelta "step1" });
+  accumulate_event acc (Types.ContentBlockDelta {
+    index = 0; delta = Types.ThinkingDelta " step2" });
+  let buf = Hashtbl.find acc.block_texts 0 in
+  Buffer.contents buf = "step1 step2"
+
+let%test "accumulate_event InputJsonDelta appends to buffer" =
+  let acc = create_stream_acc () in
+  accumulate_event acc (Types.ContentBlockStart {
+    index = 0; content_type = "tool_use"; tool_id = None; tool_name = None });
+  accumulate_event acc (Types.ContentBlockDelta {
+    index = 0; delta = Types.InputJsonDelta "{\"k\":" });
+  accumulate_event acc (Types.ContentBlockDelta {
+    index = 0; delta = Types.InputJsonDelta "\"v\"}" });
+  let buf = Hashtbl.find acc.block_texts 0 in
+  Buffer.contents buf = "{\"k\":\"v\"}"
+
+let%test "accumulate_event MessageDelta None stop_reason keeps default" =
+  let acc = create_stream_acc () in
+  accumulate_event acc (Types.MessageDelta {
+    stop_reason = None; usage = None });
+  !(acc.stop_reason) = Types.EndTurn
+
+let%test "accumulate_event MessageDelta None usage does not change tokens" =
+  let acc = create_stream_acc () in
+  acc.output_tokens := 10;
+  accumulate_event acc (Types.MessageDelta {
+    stop_reason = None; usage = None });
+  !(acc.output_tokens) = 10
+
+let%test "accumulate_event MessageStop is no-op" =
+  let acc = create_stream_acc () in
+  acc.id := "keep";
+  accumulate_event acc Types.MessageStop;
+  !(acc.id) = "keep"
+
+let%test "accumulate_event Ping is no-op" =
+  let acc = create_stream_acc () in
+  accumulate_event acc Types.Ping;
+  !(acc.id) = ""
+
+let%test "accumulate_event SSEError is no-op" =
+  let acc = create_stream_acc () in
+  accumulate_event acc (Types.SSEError "bad");
+  !(acc.id) = ""
+
+(* --- finalize_stream_acc edge cases --- *)
+
+let%test "finalize_stream_acc empty produces empty content" =
+  let acc = create_stream_acc () in
+  let result = finalize_stream_acc acc in
+  result.content = []
+
+let%test "finalize_stream_acc unknown block type filtered out" =
+  let acc = create_stream_acc () in
+  Hashtbl.replace acc.block_types 0 "unknown_type";
+  let buf = Buffer.create 16 in
+  Buffer.add_string buf "data";
+  Hashtbl.replace acc.block_texts 0 buf;
+  let result = finalize_stream_acc acc in
+  result.content = []
+
+let%test "finalize_stream_acc tool_use with invalid json falls back to empty assoc" =
+  let acc = create_stream_acc () in
+  Hashtbl.replace acc.block_types 0 "tool_use";
+  let buf = Buffer.create 16 in
+  Buffer.add_string buf "not valid json";
+  Hashtbl.replace acc.block_texts 0 buf;
+  let result = finalize_stream_acc acc in
+  match result.content with
+  | [Types.ToolUse { input = `Assoc []; _ }] -> true
+  | _ -> false
+
+let%test "finalize_stream_acc tool_use missing id/name defaults to empty" =
+  let acc = create_stream_acc () in
+  Hashtbl.replace acc.block_types 0 "tool_use";
+  let buf = Buffer.create 16 in
+  Buffer.add_string buf "{}";
+  Hashtbl.replace acc.block_texts 0 buf;
+  let result = finalize_stream_acc acc in
+  match result.content with
+  | [Types.ToolUse { id = ""; name = ""; _ }] -> true
+  | _ -> false
+
+let%test "finalize_stream_acc block with no text buffer produces empty text" =
+  let acc = create_stream_acc () in
+  Hashtbl.replace acc.block_types 0 "text";
+  (* No buffer added for index 0 *)
+  let result = finalize_stream_acc acc in
+  match result.content with
+  | [Types.Text ""] -> true
+  | _ -> false
+
+let%test "is_retryable 200 not retryable" =
+  is_retryable (Http_client.HttpError { code = 200; body = "" }) = false
+
+let%test "is_retryable 403 not retryable" =
+  is_retryable (Http_client.HttpError { code = 403; body = "" }) = false
+
+let%test "accumulate_event multiple MessageDelta accumulates tokens" =
+  let acc = create_stream_acc () in
+  accumulate_event acc (Types.MessageDelta {
+    stop_reason = None;
+    usage = Some { input_tokens = 0; output_tokens = 30;
+                   cache_creation_input_tokens = 0; cache_read_input_tokens = 0 }});
+  accumulate_event acc (Types.MessageDelta {
+    stop_reason = None;
+    usage = Some { input_tokens = 0; output_tokens = 20;
+                   cache_creation_input_tokens = 0; cache_read_input_tokens = 0 }});
+  !(acc.output_tokens) = 50

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -255,3 +255,290 @@ let summary_to_json endpoints =
     ("available_capacity", `Int available_capacity);
     ("active_requests", `Int active_requests);
   ]
+
+[@@@coverage off]
+(* === Inline tests === *)
+
+(* --- default_endpoint --- *)
+
+let%test "default_endpoint is localhost:8085" =
+  default_endpoint = "http://127.0.0.1:8085"
+
+(* --- endpoints_from_env --- *)
+
+let%test "endpoints_from_env default when unset" =
+  (match Sys.getenv_opt "LLM_ENDPOINTS" with
+   | Some _ -> Unix.putenv "LLM_ENDPOINTS" ""
+   | None -> ());
+  endpoints_from_env () = [default_endpoint]
+
+let%test "endpoints_from_env parses comma-separated" =
+  Unix.putenv "LLM_ENDPOINTS" "http://a:8080,http://b:8081";
+  let eps = endpoints_from_env () in
+  Unix.putenv "LLM_ENDPOINTS" "";
+  eps = ["http://a:8080"; "http://b:8081"]
+
+let%test "endpoints_from_env trims whitespace" =
+  Unix.putenv "LLM_ENDPOINTS" "  http://a:8080 , http://b:8081  ";
+  let eps = endpoints_from_env () in
+  Unix.putenv "LLM_ENDPOINTS" "";
+  eps = ["http://a:8080"; "http://b:8081"]
+
+let%test "endpoints_from_env filters empty parts" =
+  Unix.putenv "LLM_ENDPOINTS" "http://a,,http://b,";
+  let eps = endpoints_from_env () in
+  Unix.putenv "LLM_ENDPOINTS" "";
+  eps = ["http://a"; "http://b"]
+
+let%test "endpoints_from_env empty string returns default" =
+  Unix.putenv "LLM_ENDPOINTS" "";
+  let eps = endpoints_from_env () in
+  eps = [default_endpoint]
+
+(* --- parse_models --- *)
+
+let%test "parse_models valid" =
+  let json = `Assoc [("data", `List [
+    `Assoc [("id", `String "qwen3.5-35b"); ("owned_by", `String "local")];
+    `Assoc [("id", `String "llama-4-scout"); ("owned_by", `String "meta")];
+  ])] in
+  let models = parse_models json in
+  List.length models = 2
+  && (List.hd models).id = "qwen3.5-35b"
+
+let%test "parse_models empty data" =
+  let json = `Assoc [("data", `List [])] in
+  parse_models json = []
+
+let%test "parse_models missing data" =
+  let json = `Assoc [] in
+  parse_models json = []
+
+let%test "parse_models non-list data" =
+  let json = `Assoc [("data", `String "bad")] in
+  parse_models json = []
+
+let%test "parse_models missing id skipped" =
+  let json = `Assoc [("data", `List [
+    `Assoc [("owned_by", `String "local")];
+  ])] in
+  parse_models json = []
+
+let%test "parse_models owned_by defaults to unknown" =
+  let json = `Assoc [("data", `List [
+    `Assoc [("id", `String "model1")];
+  ])] in
+  let models = parse_models json in
+  List.length models = 1
+  && (List.hd models).owned_by = "unknown"
+
+(* --- parse_props --- *)
+
+let%test "parse_props valid" =
+  let json = `Assoc [
+    ("total_slots", `Int 4);
+    ("default_generation_settings", `Assoc [
+      ("n_ctx", `Int 8192);
+      ("model", `String "qwen3.5");
+    ]);
+  ] in
+  match parse_props json with
+  | Some p -> p.total_slots = 4 && p.ctx_size = 8192 && p.model = "qwen3.5"
+  | None -> false
+
+let%test "parse_props missing total_slots" =
+  let json = `Assoc [] in
+  parse_props json = None
+
+let%test "parse_props total_slots not int" =
+  let json = `Assoc [("total_slots", `String "4")] in
+  parse_props json = None
+
+let%test "parse_props missing dgs" =
+  let json = `Assoc [("total_slots", `Int 2)] in
+  match parse_props json with
+  | Some p -> p.total_slots = 2 && p.ctx_size = 0 && p.model = ""
+  | None -> false
+
+let%test "parse_props dgs missing n_ctx" =
+  let json = `Assoc [
+    ("total_slots", `Int 1);
+    ("default_generation_settings", `Assoc [("model", `String "m")]);
+  ] in
+  match parse_props json with
+  | Some p -> p.ctx_size = 0 && p.model = "m"
+  | None -> false
+
+let%test "parse_props dgs missing model" =
+  let json = `Assoc [
+    ("total_slots", `Int 1);
+    ("default_generation_settings", `Assoc [("n_ctx", `Int 4096)]);
+  ] in
+  match parse_props json with
+  | Some p -> p.model = "" && p.ctx_size = 4096
+  | None -> false
+
+(* --- parse_slots --- *)
+
+let%test "parse_slots valid" =
+  let json = `List [
+    `Assoc [("is_processing", `Bool true)];
+    `Assoc [("is_processing", `Bool false)];
+    `Assoc [("is_processing", `Bool false)];
+  ] in
+  match parse_slots json with
+  | Some s -> s.total = 3 && s.busy = 1 && s.idle = 2
+  | None -> false
+
+let%test "parse_slots empty list" =
+  parse_slots (`List []) = None
+
+let%test "parse_slots non-list" =
+  parse_slots (`String "bad") = None
+
+let%test "parse_slots state-based busy detection" =
+  let json = `List [
+    `Assoc [("state", `Int 1)];
+    `Assoc [("state", `Int 0)];
+  ] in
+  match parse_slots json with
+  | Some s -> s.busy = 1 && s.idle = 1
+  | None -> false
+
+let%test "parse_slots neither is_processing nor state defaults to idle" =
+  let json = `List [`Assoc []] in
+  match parse_slots json with
+  | Some s -> s.busy = 0 && s.idle = 1
+  | None -> false
+
+(* --- string_contains_ci --- *)
+
+let%test "string_contains_ci case insensitive match" =
+  string_contains_ci ~haystack:"Qwen3.5-35B" ~needle:"qwen" = true
+
+let%test "string_contains_ci no match" =
+  string_contains_ci ~haystack:"llama" ~needle:"qwen" = false
+
+let%test "string_contains_ci needle longer than haystack" =
+  string_contains_ci ~haystack:"ab" ~needle:"abcdef" = false
+
+let%test "string_contains_ci empty needle" =
+  string_contains_ci ~haystack:"anything" ~needle:"" = true
+
+let%test "string_contains_ci exact match" =
+  string_contains_ci ~haystack:"QWEN" ~needle:"qwen" = true
+
+(* --- infer_capabilities --- *)
+
+let%test "infer_capabilities qwen model gets extended" =
+  let models = [{ id = "Qwen3.5-35B-A3B"; owned_by = "local" }] in
+  let caps = infer_capabilities models None in
+  caps.supports_reasoning = true
+  && caps.supports_top_k = true
+  && caps.supports_min_p = true
+
+let%test "infer_capabilities unknown model gets basic openai" =
+  let models = [{ id = "my-custom-model"; owned_by = "local" }] in
+  let caps = infer_capabilities models None in
+  caps.supports_tools = true
+  && caps.supports_reasoning = false
+
+let%test "infer_capabilities known model lookup has priority" =
+  let models = [{ id = "claude-opus-4-20260320"; owned_by = "anthropic" }] in
+  let caps = infer_capabilities models None in
+  caps.supports_caching = true
+  && caps.supports_computer_use = true
+
+let%test "infer_capabilities merges ctx_size from props" =
+  let models = [{ id = "my-model"; owned_by = "local" }] in
+  let props = Some { total_slots = 4; ctx_size = 32768; model = "my-model" } in
+  let caps = infer_capabilities models props in
+  caps.max_context_tokens = Some 32768
+
+let%test "infer_capabilities no models defaults" =
+  let caps = infer_capabilities [] None in
+  caps.supports_tools = true
+
+(* --- JSON serialization --- *)
+
+let%test "model_info_to_json" =
+  let json = model_info_to_json { id = "m1"; owned_by = "local" } in
+  let open Yojson.Safe.Util in
+  json |> member "id" |> to_string = "m1"
+  && json |> member "owned_by" |> to_string = "local"
+
+let%test "server_props_to_json" =
+  let json = server_props_to_json { total_slots = 4; ctx_size = 8192; model = "qwen" } in
+  let open Yojson.Safe.Util in
+  json |> member "total_slots" |> to_int = 4
+  && json |> member "ctx_size" |> to_int = 8192
+
+let%test "slot_status_to_json" =
+  let json = slot_status_to_json { total = 4; busy = 1; idle = 3 } in
+  let open Yojson.Safe.Util in
+  json |> member "total" |> to_int = 4
+  && json |> member "busy" |> to_int = 1
+
+let%test "capabilities_to_json" =
+  let json = capabilities_to_json Capabilities.default_capabilities in
+  let open Yojson.Safe.Util in
+  json |> member "tools" |> to_bool = false
+
+let%test "endpoint_status_to_json without props and slots" =
+  let es = {
+    url = "http://localhost:8085"; healthy = true;
+    models = []; props = None; slots = None;
+    capabilities = Capabilities.default_capabilities;
+  } in
+  let json = endpoint_status_to_json es in
+  let open Yojson.Safe.Util in
+  json |> member "url" |> to_string = "http://localhost:8085"
+  && json |> member "healthy" |> to_bool = true
+
+let%test "endpoint_status_to_json with props and slots" =
+  let es = {
+    url = "http://localhost:8085"; healthy = true;
+    models = [{ id = "m1"; owned_by = "local" }];
+    props = Some { total_slots = 4; ctx_size = 8192; model = "m1" };
+    slots = Some { total = 4; busy = 1; idle = 3 };
+    capabilities = Capabilities.default_capabilities;
+  } in
+  let json = endpoint_status_to_json es in
+  let open Yojson.Safe.Util in
+  (json |> member "props" |> member "total_slots" |> to_int) = 4
+  && (json |> member "slots" |> member "busy" |> to_int) = 1
+
+let%test "summary_to_json empty endpoints" =
+  let json = summary_to_json [] in
+  let open Yojson.Safe.Util in
+  json |> member "total_capacity" |> to_int = 0
+  && json |> member "available_capacity" |> to_int = 0
+  && json |> member "active_requests" |> to_int = 0
+
+let%test "summary_to_json with slots" =
+  let eps = [{
+    url = "a"; healthy = true; models = [];
+    props = None;
+    slots = Some { total = 4; busy = 1; idle = 3 };
+    capabilities = Capabilities.default_capabilities;
+  }; {
+    url = "b"; healthy = true; models = [];
+    props = None;
+    slots = Some { total = 2; busy = 2; idle = 0 };
+    capabilities = Capabilities.default_capabilities;
+  }] in
+  let json = summary_to_json eps in
+  let open Yojson.Safe.Util in
+  json |> member "total_capacity" |> to_int = 6
+  && json |> member "available_capacity" |> to_int = 3
+  && json |> member "active_requests" |> to_int = 3
+
+let%test "summary_to_json endpoint without slots ignored" =
+  let eps = [{
+    url = "a"; healthy = false; models = [];
+    props = None; slots = None;
+    capabilities = Capabilities.default_capabilities;
+  }] in
+  let json = summary_to_json eps in
+  let open Yojson.Safe.Util in
+  json |> member "total_capacity" |> to_int = 0

--- a/lib/memory.ml
+++ b/lib/memory.ml
@@ -383,3 +383,591 @@ let forget_procedure t id =
 
 let procedure_count t =
   List.length (keys_in_tier t Procedural)
+
+[@@@coverage off]
+(* === Inline tests === *)
+
+(* --- scope_of_tier --- *)
+
+let%test "scope_of_tier Scratchpad" =
+  scope_of_tier Scratchpad = Context.Temp
+
+let%test "scope_of_tier Working" =
+  scope_of_tier Working = Context.Session
+
+let%test "scope_of_tier Episodic" =
+  scope_of_tier Episodic = Context.Custom "ep"
+
+let%test "scope_of_tier Procedural" =
+  scope_of_tier Procedural = Context.Custom "pr"
+
+let%test "scope_of_tier Long_term" =
+  scope_of_tier Long_term = Context.Custom "lt"
+
+(* --- create / store / recall --- *)
+
+let%test "create default memory" =
+  let mem = create () in
+  stats mem = (0, 0, 0, 0, 0)
+
+let%test "store and recall Working" =
+  let mem = create () in
+  store mem ~tier:Working "k1" (`String "v1");
+  recall mem ~tier:Working "k1" = Some (`String "v1")
+
+let%test "store and recall Scratchpad" =
+  let mem = create () in
+  store mem ~tier:Scratchpad "sp" (`Int 42);
+  recall mem ~tier:Scratchpad "sp" = Some (`Int 42)
+
+let%test "recall Working falls through to Long_term" =
+  let mem = create () in
+  store mem ~tier:Long_term "lt_key" (`String "lt_val");
+  recall mem ~tier:Working "lt_key" = Some (`String "lt_val")
+
+let%test "recall Scratchpad falls through to Working" =
+  let mem = create () in
+  store mem ~tier:Working "wk" (`String "from_working");
+  recall mem ~tier:Scratchpad "wk" = Some (`String "from_working")
+
+let%test "recall Scratchpad falls through to Long_term" =
+  let mem = create () in
+  store mem ~tier:Long_term "deep" (`Bool true);
+  recall mem ~tier:Scratchpad "deep" = Some (`Bool true)
+
+let%test "recall Episodic no fallback" =
+  let mem = create () in
+  store mem ~tier:Working "wk" (`String "val");
+  recall mem ~tier:Episodic "wk" = None
+
+let%test "recall Procedural no fallback" =
+  let mem = create () in
+  store mem ~tier:Working "wk" (`String "val");
+  recall mem ~tier:Procedural "wk" = None
+
+let%test "recall missing key" =
+  let mem = create () in
+  recall mem ~tier:Working "nonexistent" = None
+
+(* --- recall_exact --- *)
+
+let%test "recall_exact no fallback" =
+  let mem = create () in
+  store mem ~tier:Scratchpad "sp" (`Int 1);
+  store mem ~tier:Working "sp" (`Int 2);
+  recall_exact mem ~tier:Scratchpad "sp" = Some (`Int 1)
+
+let%test "recall_exact Working does not fall through" =
+  let mem = create () in
+  store mem ~tier:Long_term "lt" (`String "val");
+  recall_exact mem ~tier:Working "lt" = None
+
+let%test "recall_exact Long_term" =
+  let mem = create () in
+  store mem ~tier:Long_term "lt" (`Bool true);
+  recall_exact mem ~tier:Long_term "lt" = Some (`Bool true)
+
+(* --- forget --- *)
+
+let%test "forget removes key" =
+  let mem = create () in
+  store mem ~tier:Working "k" (`Int 1);
+  forget mem ~tier:Working "k";
+  recall_exact mem ~tier:Working "k" = None
+
+let%test "forget Long_term without backend" =
+  let mem = create () in
+  store mem ~tier:Long_term "k" (`Int 1);
+  forget mem ~tier:Long_term "k";
+  recall_exact mem ~tier:Long_term "k" = None
+
+(* --- promote --- *)
+
+let%test "promote moves from Scratchpad to Working" =
+  let mem = create () in
+  store mem ~tier:Scratchpad "item" (`String "data");
+  let result = promote mem "item" in
+  result = true
+  && recall_exact mem ~tier:Working "item" = Some (`String "data")
+  && recall_exact mem ~tier:Scratchpad "item" = None
+
+let%test "promote missing key returns false" =
+  let mem = create () in
+  promote mem "nonexistent" = false
+
+(* --- entries / clear / keys --- *)
+
+let%test "working_entries returns stored items" =
+  let mem = create () in
+  store mem ~tier:Working "a" (`Int 1);
+  store mem ~tier:Working "b" (`Int 2);
+  List.length (working_entries mem) = 2
+
+let%test "scratchpad_entries returns stored items" =
+  let mem = create () in
+  store mem ~tier:Scratchpad "x" (`Bool true);
+  List.length (scratchpad_entries mem) = 1
+
+let%test "clear_scratchpad removes all" =
+  let mem = create () in
+  store mem ~tier:Scratchpad "a" (`Int 1);
+  store mem ~tier:Scratchpad "b" (`Int 2);
+  clear_scratchpad mem;
+  scratchpad_entries mem = []
+
+let%test "keys_in_tier" =
+  let mem = create () in
+  store mem ~tier:Working "k1" (`Null);
+  store mem ~tier:Working "k2" (`Null);
+  List.length (keys_in_tier mem Working) = 2
+
+(* --- stats --- *)
+
+let%test "stats counts tiers" =
+  let mem = create () in
+  store mem ~tier:Scratchpad "s" (`Null);
+  store mem ~tier:Working "w1" (`Null);
+  store mem ~tier:Working "w2" (`Null);
+  let (sp, wk, ep, pr, lt) = stats mem in
+  sp = 1 && wk = 2 && ep = 0 && pr = 0 && lt = 0
+
+(* --- outcome JSON roundtrip --- *)
+
+let%test "outcome_to_json success" =
+  match outcome_to_json (Success "done") with
+  | `Assoc pairs ->
+    List.assoc "type" pairs = `String "success"
+    && List.assoc "detail" pairs = `String "done"
+  | _ -> false
+
+let%test "outcome_to_json failure" =
+  match outcome_to_json (Failure "bad") with
+  | `Assoc pairs ->
+    List.assoc "type" pairs = `String "failure"
+  | _ -> false
+
+let%test "outcome_to_json neutral" =
+  match outcome_to_json Neutral with
+  | `Assoc pairs ->
+    List.assoc "type" pairs = `String "neutral"
+  | _ -> false
+
+let%test "outcome_of_json success" =
+  let json = `Assoc [("type", `String "success"); ("detail", `String "ok")] in
+  outcome_of_json json = Success "ok"
+
+let%test "outcome_of_json failure" =
+  let json = `Assoc [("type", `String "failure"); ("detail", `String "err")] in
+  outcome_of_json json = Failure "err"
+
+let%test "outcome_of_json neutral" =
+  let json = `Assoc [("type", `String "neutral")] in
+  outcome_of_json json = Neutral
+
+let%test "outcome_of_json unknown type defaults to Neutral" =
+  let json = `Assoc [("type", `String "other")] in
+  outcome_of_json json = Neutral
+
+let%test "outcome_of_json non-assoc defaults to Neutral" =
+  outcome_of_json (`String "bad") = Neutral
+
+let%test "outcome_of_json success missing detail" =
+  let json = `Assoc [("type", `String "success")] in
+  outcome_of_json json = Success ""
+
+(* --- episode roundtrip --- *)
+
+let%test "episode_to_json and episode_of_json roundtrip" =
+  let ep = {
+    id = "e1"; timestamp = 100.0;
+    participants = ["alice"; "bob"];
+    action = "deployed";
+    outcome = Success "ok";
+    salience = 0.8;
+    metadata = [("env", `String "prod")];
+  } in
+  let json = episode_to_json ep in
+  match episode_of_json json with
+  | Some ep2 ->
+    ep2.id = "e1"
+    && ep2.action = "deployed"
+    && ep2.salience = 0.8
+    && List.length ep2.participants = 2
+  | None -> false
+
+let%test "episode_of_json invalid json" =
+  episode_of_json (`String "bad") = None
+
+(* --- episodic memory operations --- *)
+
+let%test "store_episode and recall_episode" =
+  let mem = create () in
+  let ep = {
+    id = "ep1"; timestamp = 100.0;
+    participants = []; action = "test";
+    outcome = Neutral; salience = 0.5;
+    metadata = [];
+  } in
+  store_episode mem ep;
+  match recall_episode mem "ep1" with
+  | Some ep2 -> ep2.id = "ep1"
+  | None -> false
+
+let%test "recall_episode missing" =
+  let mem = create () in
+  recall_episode mem "nope" = None
+
+let%test "all_episodes returns stored" =
+  let mem = create () in
+  let ep1 = { id = "e1"; timestamp = 100.0; participants = [];
+              action = "a1"; outcome = Neutral; salience = 0.5; metadata = [] } in
+  let ep2 = { id = "e2"; timestamp = 200.0; participants = [];
+              action = "a2"; outcome = Neutral; salience = 0.7; metadata = [] } in
+  store_episode mem ep1;
+  store_episode mem ep2;
+  List.length (all_episodes mem) = 2
+
+let%test "forget_episode removes" =
+  let mem = create () in
+  let ep = { id = "e1"; timestamp = 100.0; participants = [];
+             action = "a"; outcome = Neutral; salience = 0.5; metadata = [] } in
+  store_episode mem ep;
+  forget_episode mem "e1";
+  recall_episode mem "e1" = None
+
+let%test "episode_count" =
+  let mem = create () in
+  let ep = { id = "e1"; timestamp = 100.0; participants = [];
+             action = "a"; outcome = Neutral; salience = 0.5; metadata = [] } in
+  store_episode mem ep;
+  episode_count mem = 1
+
+(* --- decayed_salience --- *)
+
+let%test "decayed_salience no age returns same" =
+  let ep = { id = "e"; timestamp = 100.0; participants = [];
+             action = "a"; outcome = Neutral; salience = 0.8; metadata = [] } in
+  let result = decayed_salience ~now:100.0 ~decay_rate:0.01 ep in
+  Float.abs (result -. 0.8) < 0.001
+
+let%test "decayed_salience with age reduces" =
+  let ep = { id = "e"; timestamp = 0.0; participants = [];
+             action = "a"; outcome = Neutral; salience = 1.0; metadata = [] } in
+  let result = decayed_salience ~now:100.0 ~decay_rate:0.01 ep in
+  result < 1.0 && result > 0.0
+
+(* --- recall_episodes --- *)
+
+let%test "recall_episodes filters by salience" =
+  let mem = create () in
+  let ep = { id = "e1"; timestamp = 0.0; participants = [];
+             action = "old"; outcome = Neutral; salience = 0.001; metadata = [] } in
+  store_episode mem ep;
+  let results = recall_episodes mem ~now:10000.0 ~min_salience:0.1 () in
+  results = []
+
+let%test "recall_episodes respects limit" =
+  let mem = create () in
+  for i = 1 to 10 do
+    let ep = { id = Printf.sprintf "e%d" i;
+               timestamp = Unix.gettimeofday ();
+               participants = []; action = "a";
+               outcome = Neutral; salience = 0.9; metadata = [] } in
+    store_episode mem ep
+  done;
+  let results = recall_episodes mem ~limit:3 () in
+  List.length results <= 3
+
+let%test "recall_episodes with filter" =
+  let mem = create () in
+  let now = Unix.gettimeofday () in
+  let ep1 = { id = "e1"; timestamp = now; participants = ["alice"];
+              action = "deploy"; outcome = Neutral; salience = 0.9; metadata = [] } in
+  let ep2 = { id = "e2"; timestamp = now; participants = ["bob"];
+              action = "review"; outcome = Neutral; salience = 0.9; metadata = [] } in
+  store_episode mem ep1;
+  store_episode mem ep2;
+  let results = recall_episodes mem ~filter:(fun ep -> List.mem "alice" ep.participants) () in
+  List.length results = 1
+
+(* --- boost_salience --- *)
+
+let%test "boost_salience increases" =
+  let mem = create () in
+  let ep = { id = "e1"; timestamp = Unix.gettimeofday (); participants = [];
+             action = "a"; outcome = Neutral; salience = 0.5; metadata = [] } in
+  store_episode mem ep;
+  boost_salience mem "e1" 0.3;
+  match recall_episode mem "e1" with
+  | Some ep2 -> ep2.salience = 0.8
+  | None -> false
+
+let%test "boost_salience caps at 1.0" =
+  let mem = create () in
+  let ep = { id = "e1"; timestamp = Unix.gettimeofday (); participants = [];
+             action = "a"; outcome = Neutral; salience = 0.9; metadata = [] } in
+  store_episode mem ep;
+  boost_salience mem "e1" 0.5;
+  match recall_episode mem "e1" with
+  | Some ep2 -> ep2.salience = 1.0
+  | None -> false
+
+let%test "boost_salience missing id no-op" =
+  let mem = create () in
+  boost_salience mem "nonexistent" 0.5;
+  true
+
+(* --- procedural memory --- *)
+
+let%test "compute_confidence zero total" =
+  compute_confidence ~success_count:0 ~failure_count:0 = 0.0
+
+let%test "compute_confidence all success" =
+  compute_confidence ~success_count:10 ~failure_count:0 = 1.0
+
+let%test "compute_confidence mixed" =
+  let c = compute_confidence ~success_count:3 ~failure_count:1 in
+  Float.abs (c -. 0.75) < 0.001
+
+let%test "procedure_to_json and procedure_of_json roundtrip" =
+  let proc : procedure = {
+    id = "p1"; pattern = "build"; action = "make all";
+    success_count = 5; failure_count = 2;
+    confidence = 0.71; last_used = 1000.0;
+    metadata = [];
+  } in
+  let json = procedure_to_json proc in
+  match procedure_of_json json with
+  | Some p2 ->
+    p2.id = "p1" && p2.pattern = "build"
+    && p2.success_count = 5 && p2.failure_count = 2
+  | None -> false
+
+let%test "procedure_of_json invalid" =
+  procedure_of_json (`String "bad") = None
+
+let%test "store_procedure and all_procedures" =
+  let mem = create () in
+  let proc : procedure = {
+    id = "p1"; pattern = "deploy"; action = "run deploy.sh";
+    success_count = 1; failure_count = 0;
+    confidence = 1.0; last_used = 100.0; metadata = [];
+  } in
+  store_procedure mem proc;
+  List.length (all_procedures mem) = 1
+
+let%test "string_contains empty needle" =
+  string_contains ~needle:"" "anything" = true
+
+let%test "string_contains found" =
+  string_contains ~needle:"world" "hello world" = true
+
+let%test "string_contains not found" =
+  string_contains ~needle:"xyz" "hello" = false
+
+let%test "string_contains same string" =
+  string_contains ~needle:"abc" "abc" = true
+
+let%test "string_contains needle longer than haystack" =
+  string_contains ~needle:"longer" "abc" = false
+
+let%test "matching_procedures finds match" =
+  let mem = create () in
+  let proc : procedure = {
+    id = "p1"; pattern = "build ocaml"; action = "dune build";
+    success_count = 5; failure_count = 0;
+    confidence = 1.0; last_used = 100.0; metadata = [];
+  } in
+  store_procedure mem proc;
+  let results = matching_procedures mem ~pattern:"build" () in
+  List.length results = 1
+
+let%test "matching_procedures min_confidence filter" =
+  let mem = create () in
+  let proc : procedure = {
+    id = "p1"; pattern = "build"; action = "make";
+    success_count = 1; failure_count = 9;
+    confidence = 0.1; last_used = 100.0; metadata = [];
+  } in
+  store_procedure mem proc;
+  let results = matching_procedures mem ~pattern:"build" ~min_confidence:0.5 () in
+  results = []
+
+let%test "find_procedure returns best" =
+  let mem = create () in
+  let proc1 : procedure = {
+    id = "p1"; pattern = "deploy"; action = "slow deploy";
+    success_count = 1; failure_count = 1;
+    confidence = 0.5; last_used = 100.0; metadata = [];
+  } in
+  let proc2 : procedure = {
+    id = "p2"; pattern = "deploy fast"; action = "fast deploy";
+    success_count = 9; failure_count = 1;
+    confidence = 0.9; last_used = 200.0; metadata = [];
+  } in
+  store_procedure mem proc1;
+  store_procedure mem proc2;
+  match find_procedure mem ~pattern:"deploy" () with
+  | Some p -> p.id = "p2"
+  | None -> false
+
+let%test "find_procedure no match" =
+  let mem = create () in
+  find_procedure mem ~pattern:"nonexistent" () = None
+
+let%test "find_procedure with touch updates last_used" =
+  let mem = create () in
+  let proc : procedure = {
+    id = "p1"; pattern = "build"; action = "make";
+    success_count = 5; failure_count = 0;
+    confidence = 1.0; last_used = 0.0; metadata = [];
+  } in
+  store_procedure mem proc;
+  match find_procedure mem ~pattern:"build" ~touch:true () with
+  | Some p -> p.last_used > 0.0
+  | None -> false
+
+let%test "best_procedure delegates to find_procedure" =
+  let mem = create () in
+  let proc : procedure = {
+    id = "p1"; pattern = "test"; action = "run tests";
+    success_count = 3; failure_count = 0;
+    confidence = 1.0; last_used = 100.0; metadata = [];
+  } in
+  store_procedure mem proc;
+  match best_procedure mem ~pattern:"test" with
+  | Some p -> p.id = "p1"
+  | None -> false
+
+let%test "record_success increments" =
+  let mem = create () in
+  let proc : procedure = {
+    id = "p1"; pattern = "build"; action = "make";
+    success_count = 2; failure_count = 1;
+    confidence = 0.67; last_used = 100.0; metadata = [];
+  } in
+  store_procedure mem proc;
+  record_success mem "p1";
+  match find_procedure mem ~pattern:"build" () with
+  | Some p -> p.success_count = 3
+  | None -> false
+
+let%test "record_failure increments" =
+  let mem = create () in
+  let proc : procedure = {
+    id = "p1"; pattern = "build"; action = "make";
+    success_count = 2; failure_count = 1;
+    confidence = 0.67; last_used = 100.0; metadata = [];
+  } in
+  store_procedure mem proc;
+  record_failure mem "p1";
+  match find_procedure mem ~pattern:"build" () with
+  | Some p -> p.failure_count = 2
+  | None -> false
+
+let%test "forget_procedure removes" =
+  let mem = create () in
+  let proc : procedure = {
+    id = "p1"; pattern = "build"; action = "make";
+    success_count = 1; failure_count = 0;
+    confidence = 1.0; last_used = 100.0; metadata = [];
+  } in
+  store_procedure mem proc;
+  forget_procedure mem "p1";
+  procedure_count mem = 0
+
+let%test "procedure_count" =
+  let mem = create () in
+  let proc : procedure = {
+    id = "p1"; pattern = "build"; action = "make";
+    success_count = 1; failure_count = 0;
+    confidence = 1.0; last_used = 100.0; metadata = [];
+  } in
+  store_procedure mem proc;
+  procedure_count mem = 1
+
+let%test "update_procedure missing id no-op" =
+  let mem = create () in
+  update_procedure mem "nonexistent" (fun p -> p);
+  true
+
+(* --- legacy_backend --- *)
+
+let%test "legacy_backend persist and retrieve" =
+  let tbl = Hashtbl.create 4 in
+  let backend = legacy_backend
+    ~persist:(fun ~key value -> Hashtbl.replace tbl key value)
+    ~retrieve:(fun ~key -> Hashtbl.find_opt tbl key)
+    ~remove:(fun ~key -> Hashtbl.remove tbl key) in
+  (match backend.persist ~key:"k" (`String "v") with
+   | Ok () -> backend.retrieve ~key:"k" = Some (`String "v")
+   | Error _ -> false)
+
+let%test "legacy_backend remove" =
+  let tbl = Hashtbl.create 4 in
+  let backend = legacy_backend
+    ~persist:(fun ~key value -> Hashtbl.replace tbl key value)
+    ~retrieve:(fun ~key -> Hashtbl.find_opt tbl key)
+    ~remove:(fun ~key -> Hashtbl.remove tbl key) in
+  ignore (backend.persist ~key:"k" (`Null));
+  ignore (backend.remove ~key:"k");
+  backend.retrieve ~key:"k" = None
+
+let%test "legacy_backend batch_persist" =
+  let tbl = Hashtbl.create 4 in
+  let backend = legacy_backend
+    ~persist:(fun ~key value -> Hashtbl.replace tbl key value)
+    ~retrieve:(fun ~key -> Hashtbl.find_opt tbl key)
+    ~remove:(fun ~key -> Hashtbl.remove tbl key) in
+  (match backend.batch_persist [("a", `Int 1); ("b", `Int 2)] with
+   | Ok () ->
+     Hashtbl.find_opt tbl "a" = Some (`Int 1)
+     && Hashtbl.find_opt tbl "b" = Some (`Int 2)
+   | Error _ -> false)
+
+let%test "legacy_backend query always empty" =
+  let backend = legacy_backend
+    ~persist:(fun ~key:_ _v -> ())
+    ~retrieve:(fun ~key:_ -> None)
+    ~remove:(fun ~key:_ -> ()) in
+  backend.query ~prefix:"" ~limit:10 = []
+
+(* --- long_term with backend --- *)
+
+let%test "store Long_term with backend persists" =
+  let tbl = Hashtbl.create 4 in
+  let backend = legacy_backend
+    ~persist:(fun ~key value -> Hashtbl.replace tbl key value)
+    ~retrieve:(fun ~key -> Hashtbl.find_opt tbl key)
+    ~remove:(fun ~key -> Hashtbl.remove tbl key) in
+  let mem = create () in
+  set_long_term_backend mem backend;
+  store mem ~tier:Long_term "k" (`String "v");
+  Hashtbl.find_opt tbl "k" = Some (`String "v")
+
+let%test "recall Long_term with backend retrieves" =
+  let tbl = Hashtbl.create 4 in
+  Hashtbl.replace tbl "bk" (`Int 99);
+  let backend = legacy_backend
+    ~persist:(fun ~key value -> Hashtbl.replace tbl key value)
+    ~retrieve:(fun ~key -> Hashtbl.find_opt tbl key)
+    ~remove:(fun ~key -> Hashtbl.remove tbl key) in
+  let mem = create () in
+  set_long_term_backend mem backend;
+  recall mem ~tier:Long_term "bk" = Some (`Int 99)
+
+let%test "recall_exact Long_term with backend" =
+  let tbl = Hashtbl.create 4 in
+  Hashtbl.replace tbl "bk" (`Bool true);
+  let backend = legacy_backend
+    ~persist:(fun ~key value -> Hashtbl.replace tbl key value)
+    ~retrieve:(fun ~key -> Hashtbl.find_opt tbl key)
+    ~remove:(fun ~key -> Hashtbl.remove tbl key) in
+  let mem = create () in
+  set_long_term_backend mem backend;
+  recall_exact mem ~tier:Long_term "bk" = Some (`Bool true)
+
+let%test "context accessor" =
+  let mem = create () in
+  let _ctx = context mem in
+  true

--- a/lib/memory_tools.ml
+++ b/lib/memory_tools.ml
@@ -381,3 +381,388 @@ let all_acl acl ~agent_name =
     remember_episode_acl acl ~agent_name;
     find_procedure_acl acl ~agent_name;
   ]
+
+[@@@coverage off]
+(* === Inline tests === *)
+
+(* --- json_string / ok_json / tool_error --- *)
+
+let%test "json_string encodes value" =
+  json_string (`String "hello") = "\"hello\""
+
+let%test "json_string encodes int" =
+  json_string (`Int 42) = "42"
+
+let%test "ok_json wraps as tool result" =
+  match ok_json (`Bool true) with
+  | Ok { Types.content } -> content = "true"
+  | Error _ -> false
+
+let%test "tool_error returns recoverable error" =
+  match tool_error "bad input" with
+  | Error { Types.message = "bad input"; recoverable = true } -> true
+  | _ -> false
+
+(* --- bind --- *)
+
+let%test "bind ok" =
+  bind (Ok 1) (fun x -> Ok (x + 1)) = Ok 2
+
+let%test "bind error propagates" =
+  let err = Error { Types.message = "fail"; recoverable = true } in
+  match bind err (fun _ -> Ok 0) with
+  | Error { message = "fail"; _ } -> true
+  | _ -> false
+
+(* --- tier_to_string --- *)
+
+let%test "tier_to_string scratchpad" =
+  tier_to_string Memory.Scratchpad = "scratchpad"
+
+let%test "tier_to_string working" =
+  tier_to_string Memory.Working = "working"
+
+let%test "tier_to_string episodic" =
+  tier_to_string Memory.Episodic = "episodic"
+
+let%test "tier_to_string procedural" =
+  tier_to_string Memory.Procedural = "procedural"
+
+let%test "tier_to_string long_term" =
+  tier_to_string Memory.Long_term = "long_term"
+
+(* --- parse_string_field --- *)
+
+let%test "parse_string_field present" =
+  let json = `Assoc [("key", `String "val")] in
+  parse_string_field json "key" = Ok "val"
+
+let%test "parse_string_field missing" =
+  let json = `Assoc [] in
+  match parse_string_field json "key" with
+  | Error _ -> true
+  | Ok _ -> false
+
+let%test "parse_string_field null" =
+  let json = `Assoc [("key", `Null)] in
+  match parse_string_field json "key" with
+  | Error _ -> true
+  | Ok _ -> false
+
+let%test "parse_string_field wrong type" =
+  let json = `Assoc [("key", `Int 42)] in
+  match parse_string_field json "key" with
+  | Error _ -> true
+  | Ok _ -> false
+
+(* --- parse_optional_string_field --- *)
+
+let%test "parse_optional_string_field present" =
+  let json = `Assoc [("key", `String "val")] in
+  parse_optional_string_field json "key" = Ok (Some "val")
+
+let%test "parse_optional_string_field null" =
+  let json = `Assoc [("key", `Null)] in
+  parse_optional_string_field json "key" = Ok None
+
+let%test "parse_optional_string_field missing" =
+  let json = `Assoc [] in
+  parse_optional_string_field json "key" = Ok None
+
+let%test "parse_optional_string_field wrong type" =
+  let json = `Assoc [("key", `Int 42)] in
+  match parse_optional_string_field json "key" with
+  | Error _ -> true
+  | Ok _ -> false
+
+(* --- parse_bool_field --- *)
+
+let%test "parse_bool_field present true" =
+  let json = `Assoc [("flag", `Bool true)] in
+  parse_bool_field json "flag" ~default:false = Ok true
+
+let%test "parse_bool_field present false" =
+  let json = `Assoc [("flag", `Bool false)] in
+  parse_bool_field json "flag" ~default:true = Ok false
+
+let%test "parse_bool_field null uses default" =
+  let json = `Assoc [("flag", `Null)] in
+  parse_bool_field json "flag" ~default:true = Ok true
+
+let%test "parse_bool_field missing uses default" =
+  let json = `Assoc [] in
+  parse_bool_field json "flag" ~default:false = Ok false
+
+let%test "parse_bool_field wrong type" =
+  let json = `Assoc [("flag", `String "yes")] in
+  match parse_bool_field json "flag" ~default:false with
+  | Error _ -> true
+  | Ok _ -> false
+
+(* --- parse_float_field --- *)
+
+let%test "parse_float_field float" =
+  let json = `Assoc [("val", `Float 3.14)] in
+  parse_float_field json "val" ~default:0.0 = Ok 3.14
+
+let%test "parse_float_field int coerced to float" =
+  let json = `Assoc [("val", `Int 42)] in
+  parse_float_field json "val" ~default:0.0 = Ok 42.0
+
+let%test "parse_float_field null uses default" =
+  let json = `Assoc [] in
+  parse_float_field json "val" ~default:1.5 = Ok 1.5
+
+let%test "parse_float_field wrong type" =
+  let json = `Assoc [("val", `String "nope")] in
+  match parse_float_field json "val" ~default:0.0 with
+  | Error _ -> true
+  | Ok _ -> false
+
+(* --- parse_generic_tier --- *)
+
+let%test "parse_generic_tier scratchpad" =
+  let json = `Assoc [("tier", `String "scratchpad")] in
+  parse_generic_tier json ~default:Memory.Working = Ok Memory.Scratchpad
+
+let%test "parse_generic_tier working" =
+  let json = `Assoc [("tier", `String "working")] in
+  parse_generic_tier json ~default:Memory.Scratchpad = Ok Memory.Working
+
+let%test "parse_generic_tier long_term" =
+  let json = `Assoc [("tier", `String "long_term")] in
+  parse_generic_tier json ~default:Memory.Working = Ok Memory.Long_term
+
+let%test "parse_generic_tier long-term hyphen" =
+  let json = `Assoc [("tier", `String "long-term")] in
+  parse_generic_tier json ~default:Memory.Working = Ok Memory.Long_term
+
+let%test "parse_generic_tier episodic rejected" =
+  let json = `Assoc [("tier", `String "episodic")] in
+  match parse_generic_tier json ~default:Memory.Working with
+  | Error _ -> true
+  | Ok _ -> false
+
+let%test "parse_generic_tier procedural rejected" =
+  let json = `Assoc [("tier", `String "procedural")] in
+  match parse_generic_tier json ~default:Memory.Working with
+  | Error _ -> true
+  | Ok _ -> false
+
+let%test "parse_generic_tier invalid string" =
+  let json = `Assoc [("tier", `String "garbage")] in
+  match parse_generic_tier json ~default:Memory.Working with
+  | Error _ -> true
+  | Ok _ -> false
+
+let%test "parse_generic_tier null uses default" =
+  let json = `Assoc [] in
+  parse_generic_tier json ~default:Memory.Long_term = Ok Memory.Long_term
+
+let%test "parse_generic_tier wrong type" =
+  let json = `Assoc [("tier", `Int 1)] in
+  match parse_generic_tier json ~default:Memory.Working with
+  | Error _ -> true
+  | Ok _ -> false
+
+let%test "parse_generic_tier uppercase scratchpad" =
+  let json = `Assoc [("tier", `String "Scratchpad")] in
+  parse_generic_tier json ~default:Memory.Working = Ok Memory.Scratchpad
+
+(* --- parse_string_list_field --- *)
+
+let%test "parse_string_list_field empty list" =
+  let json = `Assoc [("tags", `List [])] in
+  parse_string_list_field json "tags" = Ok []
+
+let%test "parse_string_list_field with strings" =
+  let json = `Assoc [("tags", `List [`String "a"; `String "b"])] in
+  parse_string_list_field json "tags" = Ok ["a"; "b"]
+
+let%test "parse_string_list_field null returns empty" =
+  let json = `Assoc [] in
+  parse_string_list_field json "tags" = Ok []
+
+let%test "parse_string_list_field non-string element" =
+  let json = `Assoc [("tags", `List [`Int 1])] in
+  match parse_string_list_field json "tags" with
+  | Error _ -> true
+  | Ok _ -> false
+
+let%test "parse_string_list_field wrong type" =
+  let json = `Assoc [("tags", `String "not a list")] in
+  match parse_string_list_field json "tags" with
+  | Error _ -> true
+  | Ok _ -> false
+
+(* --- parse_metadata_field --- *)
+
+let%test "parse_metadata_field object" =
+  let json = `Assoc [("metadata", `Assoc [("k", `String "v")])] in
+  parse_metadata_field json = Ok [("k", `String "v")]
+
+let%test "parse_metadata_field null" =
+  let json = `Assoc [] in
+  parse_metadata_field json = Ok []
+
+let%test "parse_metadata_field wrong type" =
+  let json = `Assoc [("metadata", `List [])] in
+  match parse_metadata_field json with
+  | Error _ -> true
+  | Ok _ -> false
+
+(* --- parse_value_json --- *)
+
+let%test "parse_value_json valid json" =
+  let json = `Assoc [("value_json", `String "{\"a\":1}")] in
+  match parse_value_json json with
+  | Ok (`Assoc [("a", `Int 1)]) -> true
+  | _ -> false
+
+let%test "parse_value_json invalid json stored as raw string" =
+  let json = `Assoc [("value_json", `String "not json")] in
+  match parse_value_json json with
+  | Ok (`String "not json") -> true
+  | _ -> false
+
+let%test "parse_value_json missing field" =
+  let json = `Assoc [] in
+  match parse_value_json json with
+  | Error _ -> true
+  | Ok _ -> false
+
+(* --- parse_outcome --- *)
+
+let%test "parse_outcome success" =
+  let json = `Assoc [("outcome", `String "success"); ("detail", `String "done")] in
+  parse_outcome json = Ok (Memory.Success "done")
+
+let%test "parse_outcome failure" =
+  let json = `Assoc [("outcome", `String "failure"); ("detail", `String "bad")] in
+  parse_outcome json = Ok (Memory.Failure "bad")
+
+let%test "parse_outcome neutral" =
+  let json = `Assoc [("outcome", `String "neutral")] in
+  parse_outcome json = Ok Memory.Neutral
+
+let%test "parse_outcome null" =
+  let json = `Assoc [] in
+  parse_outcome json = Ok Memory.Neutral
+
+let%test "parse_outcome invalid string" =
+  let json = `Assoc [("outcome", `String "unknown")] in
+  match parse_outcome json with
+  | Error _ -> true
+  | Ok _ -> false
+
+let%test "parse_outcome wrong type" =
+  let json = `Assoc [("outcome", `Int 1)] in
+  match parse_outcome json with
+  | Error _ -> true
+  | Ok _ -> false
+
+let%test "parse_outcome success no detail" =
+  let json = `Assoc [("outcome", `String "success")] in
+  parse_outcome json = Ok (Memory.Success "")
+
+(* --- procedure_to_json --- *)
+
+let%test "procedure_to_json roundtrip fields" =
+  let proc : Memory.procedure = {
+    id = "p1"; pattern = "build"; action = "run make";
+    success_count = 5; failure_count = 1;
+    confidence = 0.83; last_used = 1000.0;
+    metadata = [("env", `String "prod")];
+  } in
+  let json = procedure_to_json proc in
+  let open Yojson.Safe.Util in
+  json |> member "id" |> to_string = "p1"
+  && json |> member "pattern" |> to_string = "build"
+  && json |> member "success_count" |> to_int = 5
+
+(* --- generated_episode_id --- *)
+
+let%test "generated_episode_id starts with ep_" =
+  let id = generated_episode_id () in
+  String.length id > 3 && String.sub id 0 3 = "ep_"
+
+(* --- remember_tool / recall_tool / all tools --- *)
+
+let%test "all returns 4 tools" =
+  let mem = Memory.create () in
+  List.length (all mem) = 4
+
+let%test "all_acl returns 4 tools" =
+  let mem = Memory.create () in
+  let acl = Memory_access.create mem in
+  List.length (all_acl acl ~agent_name:"test") = 4
+
+let%test "remember_tool stores and recall_tool retrieves" =
+  let mem = Memory.create () in
+  let rem = remember mem in
+  let rec_ = recall mem in
+  let store_input = `Assoc [
+    ("key", `String "test_key");
+    ("value_json", `String "{\"v\":1}");
+  ] in
+  (match Tool.execute rem store_input with
+   | Ok _ ->
+     let recall_input = `Assoc [
+       ("key", `String "test_key");
+     ] in
+     (match Tool.execute rec_ recall_input with
+      | Ok { content } ->
+        let json = Yojson.Safe.from_string content in
+        let open Yojson.Safe.Util in
+        json |> member "found" |> to_bool = true
+      | Error _ -> false)
+   | Error _ -> false)
+
+let%test "recall_tool missing key" =
+  let mem = Memory.create () in
+  let rec_ = recall mem in
+  let input = `Assoc [("key", `String "nonexistent")] in
+  match Tool.execute rec_ input with
+  | Ok { content } ->
+    let json = Yojson.Safe.from_string content in
+    let open Yojson.Safe.Util in
+    json |> member "found" |> to_bool = false
+  | Error _ -> false
+
+let%test "remember_tool with explicit tier" =
+  let mem = Memory.create () in
+  let rem = remember mem in
+  let input = `Assoc [
+    ("tier", `String "scratchpad");
+    ("key", `String "sp_key");
+    ("value_json", `String "\"hello\"");
+  ] in
+  match Tool.execute rem input with
+  | Ok { content } ->
+    let json = Yojson.Safe.from_string content in
+    let open Yojson.Safe.Util in
+    json |> member "ok" |> to_bool = true
+    && json |> member "tier" |> to_string = "scratchpad"
+  | Error _ -> false
+
+let%test "recall_tool with exact=true" =
+  let mem = Memory.create () in
+  let rem = remember mem in
+  let rec_ = recall mem in
+  ignore (Tool.execute rem (`Assoc [
+    ("tier", `String "working");
+    ("key", `String "exact_key");
+    ("value_json", `String "\"data\"");
+  ]));
+  let input = `Assoc [
+    ("tier", `String "working");
+    ("key", `String "exact_key");
+    ("exact", `Bool true);
+  ] in
+  match Tool.execute rec_ input with
+  | Ok { content } ->
+    let json = Yojson.Safe.from_string content in
+    let open Yojson.Safe.Util in
+    json |> member "found" |> to_bool = true
+    && json |> member "exact" |> to_bool = true
+  | Error _ -> false

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -476,3 +476,55 @@ let%test "tag_error with Agent error" =
 
 let%test "tag_error string result Ok" =
   tag_error "collect" (Ok "success") = Ok "success"
+
+(* --- Additional pipeline tests --- *)
+
+let%test "last_tool_results_from only non-user roles" =
+  let msgs = [
+    { role = System; content = [Text "system"]; name = None; tool_call_id = None };
+    { role = Assistant; content = [Text "reply"]; name = None; tool_call_id = None };
+  ] in
+  last_tool_results_from msgs = []
+
+let%test "last_tool_results_from multiple tool results in one message" =
+  let msgs = [
+    { role = User; content = [
+        ToolResult { tool_use_id = "t1"; content = "r1"; is_error = false };
+        ToolResult { tool_use_id = "t2"; content = "r2"; is_error = false };
+        ToolResult { tool_use_id = "t3"; content = "r3"; is_error = true };
+      ]; name = None; tool_call_id = None };
+  ] in
+  List.length (last_tool_results_from msgs) = 3
+
+let%test "last_tool_results_from user msg with only non-tool content" =
+  let msgs = [
+    { role = User; content = [
+        Text "just text";
+        Types.ToolUse { id = "tu1"; name = "fn"; input = `Null };
+      ]; name = None; tool_call_id = None };
+  ] in
+  last_tool_results_from msgs = []
+
+let%test "tag_error with Serialization error" =
+  let err = Error.Serialization (JsonParseError { detail = "bad json" }) in
+  match tag_error "route" (Error err) with
+  | Error e -> e = err
+  | Ok _ -> false
+
+let%test "tag_error with Io error" =
+  let err = Error.Io (FileOpFailed { op = "read"; path = "/tmp/x"; detail = "not found" }) in
+  match tag_error "input" (Error err) with
+  | Error e -> e = err
+  | Ok _ -> false
+
+let%test "tag_error with Mcp error" =
+  let err = Error.Mcp (InitializeFailed { detail = "timeout" }) in
+  match tag_error "parse" (Error err) with
+  | Error e -> e = err
+  | Ok _ -> false
+
+let%test "tag_error Ok unit" =
+  tag_error "collect" (Ok ()) = Ok ()
+
+let%test "tag_error Ok list" =
+  tag_error "output" (Ok [1; 2; 3]) = Ok [1; 2; 3]

--- a/lib/protocol/mcp_http.ml
+++ b/lib/protocol/mcp_http.ml
@@ -364,3 +364,61 @@ let%test "parse_sse_body multi-line non-data ignored" =
   match parse_sse_body body with
   | Some (`Assoc [("x", `Int 99)]) -> true
   | _ -> false
+
+(* --- Additional coverage tests for mcp_http --- *)
+
+let%test "parse_sse_body data line shorter than 5 chars ignored" =
+  let body = "dat\n" in
+  parse_sse_body body = None
+
+let%test "parse_sse_body only non-data prefixed lines returns None" =
+  let body = "event: message\nid: 42\nretry: 5000\n\n" in
+  parse_sse_body body = None
+
+let%test "parse_sse_body single valid data line" =
+  let body = "data: {\"single\":true}\n" in
+  match parse_sse_body body with
+  | Some (`Assoc [("single", `Bool true)]) -> true
+  | _ -> false
+
+let%test "parse_response_body empty string as json returns None" =
+  parse_response_body ~content_type:(Some "application/json") "" = None
+
+let%test "parse_response_body sse with empty body" =
+  parse_response_body ~content_type:(Some "text/event-stream") "" = None
+
+let%test "parse_response_body exactly 17 char content type as sse" =
+  (* "text/event-stream" is exactly 17 chars *)
+  let body = "data: {\"ok\":true}\n" in
+  match parse_response_body ~content_type:(Some "text/event-stream") body with
+  | Some (`Assoc [("ok", `Bool true)]) -> true
+  | _ -> false
+
+let%test "parse_response_body 16 char content type is not sse" =
+  (* shorter than "text/event-strea" = 16 chars, not SSE *)
+  let body = "{\"ok\":true}" in
+  match parse_response_body ~content_type:(Some "text/event-strea") body with
+  | Some (`Assoc [("ok", `Bool true)]) -> true
+  | _ -> false
+
+let%test "make_headers empty config and empty extra" =
+  let cfg = { default_config with headers = [] } in
+  let h = make_headers cfg [] in
+  Http.Header.get h "Content-Type" = Some "application/json"
+
+let%test "make_headers preserves order with multiple extras" =
+  let cfg = { default_config with headers = [("X-A", "1")] } in
+  let h = make_headers cfg [("X-B", "2"); ("X-C", "3")] in
+  Http.Header.get h "X-A" = Some "1"
+  && Http.Header.get h "X-B" = Some "2"
+  && Http.Header.get h "X-C" = Some "3"
+
+let%test "parse_sse_body three data lines takes last" =
+  let body = "data: {\"a\":1}\ndata: {\"b\":2}\ndata: {\"c\":3}\n" in
+  match parse_sse_body body with
+  | Some (`Assoc [("c", `Int 3)]) -> true
+  | _ -> false
+
+let%test "default_config reconnect and timeout positive" =
+  default_config.reconnect_max_s > 0.0
+  && default_config.request_timeout_s > 0.0

--- a/lib_swarm/swarm_checkpoint.ml
+++ b/lib_swarm/swarm_checkpoint.ml
@@ -435,3 +435,132 @@ let%test "restore: history preserved" =
   match restore cp ~agent_lookup:lookup ~base_config:cfg with
   | Ok restored -> List.length restored.history = 1
   | Error _ -> false
+
+(* --- Additional checkpoint tests --- *)
+
+let%test "config_snapshot_to_json None convergence fields" =
+  let snap = {
+    entry_names = ["x"];
+    mode = Swarm_types.Pipeline_mode;
+    max_parallel = 1;
+    prompt = "p";
+    timeout_sec = None;
+    convergence_target = None;
+    convergence_max_iterations = None;
+    convergence_patience = None;
+  } in
+  let json = config_snapshot_to_json snap in
+  let open Yojson.Safe.Util in
+  json |> member "timeout_sec" = `Null
+  && json |> member "convergence_target" = `Null
+  && json |> member "convergence_max_iterations" = `Null
+  && json |> member "convergence_patience" = `Null
+
+let%test "config_snapshot_to_json Some convergence fields" =
+  let snap = {
+    entry_names = [];
+    mode = Swarm_types.Supervisor;
+    max_parallel = 4;
+    prompt = "go";
+    timeout_sec = Some 60.0;
+    convergence_target = Some 0.95;
+    convergence_max_iterations = Some 100;
+    convergence_patience = Some 5;
+  } in
+  let json = config_snapshot_to_json snap in
+  let open Yojson.Safe.Util in
+  json |> member "timeout_sec" |> to_float = 60.0
+  && json |> member "convergence_target" |> to_float = 0.95
+
+let%test "iteration_record_to_json with agent_results" =
+  let rec_ = make_iteration ~iteration:2
+    ~agent_results:[("w1", Swarm_types.Idle); ("w2", Swarm_types.Idle)]
+    ~elapsed:3.0 ~timestamp:500.0 () in
+  let json = iteration_record_to_json rec_ in
+  let open Yojson.Safe.Util in
+  let agents = json |> member "agent_results" |> to_list in
+  List.length agents = 2
+
+let%test "iteration_record_of_json preserves agent names" =
+  let json = `Assoc [
+    ("iteration", `Int 1);
+    ("metric_value", `Null);
+    ("agent_results", `List [
+      `Assoc [("name", `String "worker1"); ("status", `String "Idle")];
+    ]);
+    ("elapsed", `Float 1.0);
+    ("timestamp", `Float 200.0);
+  ] in
+  let rec_ = iteration_record_of_json json in
+  rec_.iteration = 1
+  && List.length rec_.agent_results = 1
+  && fst (List.hd rec_.agent_results) = "worker1"
+
+let%test "to_json best_metric None" =
+  let cfg = make_config () in
+  let state = Swarm_types.create_state cfg in
+  state.best_metric <- None;
+  let cp = of_state state in
+  let json = to_json cp in
+  let open Yojson.Safe.Util in
+  json |> member "best_metric" = `Null
+
+let%test "to_json best_metric Some" =
+  let cfg = make_config () in
+  let state = Swarm_types.create_state cfg in
+  state.best_metric <- Some 0.99;
+  let cp = of_state state in
+  let json = to_json cp in
+  let open Yojson.Safe.Util in
+  json |> member "best_metric" |> to_float = 0.99
+
+let%test "of_state patience_counter from state" =
+  let cfg = make_config () in
+  let state = Swarm_types.create_state cfg in
+  state.patience_counter <- 7;
+  let cp = of_state state in
+  cp.patience_counter = 7
+
+let%test "of_state best_iteration from state" =
+  let cfg = make_config () in
+  let state = Swarm_types.create_state cfg in
+  state.best_iteration <- 3;
+  let cp = of_state state in
+  cp.best_iteration = 3
+
+let%test "restore: best_iteration restored" =
+  let cfg = make_config () in
+  let state = Swarm_types.create_state cfg in
+  state.best_iteration <- 4;
+  let cp = of_state state in
+  let lookup name =
+    if name = "a1" || name = "a2" then Some (make_entry name) else None in
+  match restore cp ~agent_lookup:lookup ~base_config:cfg with
+  | Ok restored -> restored.best_iteration = 4
+  | Error _ -> false
+
+let%test "snapshot_of_config: Supervisor mode preserved" =
+  let cfg = make_config ~mode:Swarm_types.Supervisor () in
+  let snap = snapshot_of_config cfg in
+  snap.mode = Swarm_types.Supervisor
+
+let%test "snapshot_of_config: Pipeline mode preserved" =
+  let cfg = make_config ~mode:Swarm_types.Pipeline_mode () in
+  let snap = snapshot_of_config cfg in
+  snap.mode = Swarm_types.Pipeline_mode
+
+let%test "to_json history empty" =
+  let cfg = make_config () in
+  let state = Swarm_types.create_state cfg in
+  let cp = of_state state in
+  let json = to_json cp in
+  let open Yojson.Safe.Util in
+  json |> member "history" |> to_list = []
+
+let%test "to_json created_at is positive" =
+  let cfg = make_config () in
+  let state = Swarm_types.create_state cfg in
+  let cp = of_state state in
+  let json = to_json cp in
+  let open Yojson.Safe.Util in
+  json |> member "created_at" |> to_float > 0.0

--- a/test/dune
+++ b/test/dune
@@ -696,3 +696,19 @@
 (test
  (name test_plan)
  (libraries agent_sdk alcotest yojson unix))
+
+(test
+ (name test_memory_coverage)
+ (libraries agent_sdk alcotest yojson unix))
+
+(test
+ (name test_runtime_projection_cov2)
+ (libraries agent_sdk alcotest yojson unix))
+
+(test
+ (name test_eval_coverage)
+ (libraries agent_sdk alcotest yojson unix eio eio_main))
+
+(test
+ (name test_skill_coverage2)
+ (libraries agent_sdk alcotest yojson unix))

--- a/test/test_eval_coverage.ml
+++ b/test/test_eval_coverage.ml
@@ -1,0 +1,552 @@
+(** Extended coverage tests for Eval and Eval_report modules.
+
+    Existing tests cover:
+    - metric_value yojson roundtrip, to_float
+    - metric yojson roundtrip
+    - collector basic, verdict
+    - comparison regression/improvement/unchanged
+    - threshold pass/fail max/min
+    - find_metric
+    - run_metrics yojson
+    - eval_collector basic
+
+    This file targets uncovered paths in:
+    - Eval.ml: metric_value_of_yojson error path, compute_delta edge cases
+      (baseline zero, non-numeric, custom threshold), pp_* formatters,
+      show_run_metrics, metric_of_yojson error path, run_metrics_of_yojson
+      error path, set_trace_summary, find_metric_value
+    - Eval_report.ml: to_string with comparison diffs (Unchanged filtered),
+      generate pass/fail threshold boundary (pass_at_k exactly 0.5)
+    - Eval_baseline.ml: show_diff all variants, compare with near-zero baseline,
+      compare non-numeric metrics *)
+
+open Agent_sdk
+
+(* ── Helpers ──────────────────────────────────────────── *)
+
+let mk_metric ?(unit_ = None) ?(tags = []) name value : Eval.metric =
+  { name; value; unit_; tags }
+
+let mk_run ?(run_id = "r1") ?(agent_name = "test") ?(verdicts = [])
+    ?(trace_summary = None) metrics : Eval.run_metrics =
+  { run_id; agent_name; timestamp = 1000.0;
+    metrics; harness_verdicts = verdicts; trace_summary }
+
+let pass_verdict : Harness.verdict =
+  { passed = true; score = Some 1.0; evidence = []; detail = None }
+
+(* ── metric_value_of_yojson error ─────────────────────── *)
+
+let test_metric_value_of_yojson_error () =
+  match Eval.metric_value_of_yojson (`List []) with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected error for list"
+
+let test_metric_value_of_yojson_null () =
+  match Eval.metric_value_of_yojson `Null with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected error for null"
+
+(* ── show_metric_value all variants ───────────────────── *)
+
+let test_show_metric_value_int () =
+  Alcotest.(check string) "int" "42" (Eval.show_metric_value (Int_val 42))
+
+let test_show_metric_value_bool_false () =
+  Alcotest.(check string) "false" "false" (Eval.show_metric_value (Bool_val false))
+
+let test_show_metric_value_string () =
+  Alcotest.(check string) "str" "hello" (Eval.show_metric_value (String_val "hello"))
+
+(* ── pp_metric_value ──────────────────────────────────── *)
+
+let test_pp_metric_value () =
+  let buf = Buffer.create 16 in
+  let fmt = Format.formatter_of_buffer buf in
+  Eval.pp_metric_value fmt (Float_val 3.14);
+  Format.pp_print_flush fmt ();
+  let s = Buffer.contents buf in
+  Alcotest.(check bool) "contains 3.14" true
+    (Util.string_contains ~needle:"3.14" s)
+
+(* ── pp_metric ────────────────────────────────────────── *)
+
+let test_pp_metric () =
+  let buf = Buffer.create 32 in
+  let fmt = Format.formatter_of_buffer buf in
+  Eval.pp_metric fmt (mk_metric "latency" (Float_val 1.5));
+  Format.pp_print_flush fmt ();
+  let s = Buffer.contents buf in
+  Alcotest.(check bool) "contains latency" true
+    (Util.string_contains ~needle:"latency" s)
+
+(* ── show_metric ──────────────────────────────────────── *)
+
+let test_show_metric () =
+  let s = Eval.show_metric (mk_metric "x" (Int_val 1)) in
+  Alcotest.(check string) "format" "x=1" s
+
+(* ── show_run_metrics ─────────────────────────────────── *)
+
+let test_show_run_metrics () =
+  let rm = mk_run [mk_metric "a" (Int_val 1); mk_metric "b" (Float_val 2.5)] in
+  let s = Eval.show_run_metrics rm in
+  Alcotest.(check bool) "contains run=" true (Util.string_contains ~needle:"run=" s);
+  Alcotest.(check bool) "contains agent=" true (Util.string_contains ~needle:"agent=" s)
+
+(* ── pp_run_metrics ───────────────────────────────────── *)
+
+let test_pp_run_metrics () =
+  let buf = Buffer.create 64 in
+  let fmt = Format.formatter_of_buffer buf in
+  let rm = mk_run [mk_metric "x" (Int_val 1)] in
+  Eval.pp_run_metrics fmt rm;
+  Format.pp_print_flush fmt ();
+  let s = Buffer.contents buf in
+  Alcotest.(check bool) "non-empty" true (String.length s > 0)
+
+(* ── metric_of_yojson error path ──────────────────────── *)
+
+let test_metric_of_yojson_type_error () =
+  let json = `Assoc [("name", `Int 42)] in
+  match Eval.metric_of_yojson json with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected error for bad name type"
+
+let test_metric_of_yojson_bad_value () =
+  let json = `Assoc [("name", `String "x"); ("value", `List [])] in
+  match Eval.metric_of_yojson json with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected error for bad value"
+
+(* ── metric_of_yojson: no tags, no unit ───────────────── *)
+
+let test_metric_of_yojson_minimal () =
+  let json = `Assoc [("name", `String "x"); ("value", `Int 1)] in
+  match Eval.metric_of_yojson json with
+  | Ok m ->
+    Alcotest.(check string) "name" "x" m.name;
+    Alcotest.(check (option string)) "no unit" None m.unit_;
+    Alcotest.(check int) "no tags" 0 (List.length m.tags)
+  | Error e -> Alcotest.fail e
+
+(* ── metric_to_yojson: with unit and tags ─────────────── *)
+
+let test_metric_to_yojson_full () =
+  let m = mk_metric ~unit_:(Some "ms") ~tags:[("env", "prod")] "lat" (Float_val 1.5) in
+  let json = Eval.metric_to_yojson m in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "unit" "ms" (json |> member "unit" |> to_string);
+  let tags = json |> member "tags" in
+  Alcotest.(check string) "env tag" "prod" (tags |> member "env" |> to_string)
+
+(* ── metric_to_yojson: no unit no tags ────────────────── *)
+
+let test_metric_to_yojson_minimal () =
+  let m = mk_metric "x" (Int_val 1) in
+  let json = Eval.metric_to_yojson m in
+  let s = Yojson.Safe.to_string json in
+  (* No "unit" or "tags" key *)
+  Alcotest.(check bool) "no unit" false (Util.string_contains ~needle:"\"unit\"" s);
+  Alcotest.(check bool) "no tags" false (Util.string_contains ~needle:"\"tags\"" s)
+
+(* ── run_metrics_of_yojson error path ─────────────────── *)
+
+let test_run_metrics_of_yojson_type_error () =
+  let json = `String "bad" in
+  match Eval.run_metrics_of_yojson json with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected error"
+
+let test_run_metrics_of_yojson_bad_metric () =
+  let json = `Assoc [
+    ("run_id", `String "r");
+    ("agent_name", `String "a");
+    ("timestamp", `Float 0.0);
+    ("metrics", `List [`Assoc [("name", `Int 42)]]);
+  ] in
+  match Eval.run_metrics_of_yojson json with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected error for bad metric"
+
+(* ── run_metrics_to_yojson with verdicts ──────────────── *)
+
+let test_run_metrics_to_yojson_with_verdicts () =
+  let v : Harness.verdict = {
+    passed = false; score = None; evidence = ["e1"]; detail = Some "d1";
+  } in
+  let rm = mk_run ~verdicts:[v] [mk_metric "x" (Int_val 1)] in
+  let json = Eval.run_metrics_to_yojson rm in
+  let open Yojson.Safe.Util in
+  let verdicts = json |> member "harness_verdicts" |> to_list in
+  Alcotest.(check int) "1 verdict" 1 (List.length verdicts);
+  let v0 = List.hd verdicts in
+  Alcotest.(check bool) "passed false" false (v0 |> member "passed" |> to_bool);
+  Alcotest.(check string) "detail" "d1" (v0 |> member "detail" |> to_string)
+
+let test_run_metrics_to_yojson_score_none () =
+  let v : Harness.verdict = {
+    passed = true; score = None; evidence = []; detail = None;
+  } in
+  let rm = mk_run ~verdicts:[v] [] in
+  let json = Eval.run_metrics_to_yojson rm in
+  let open Yojson.Safe.Util in
+  let verdicts = json |> member "harness_verdicts" |> to_list in
+  let v0 = List.hd verdicts in
+  Alcotest.(check bool) "score null" true (v0 |> member "score" = `Null)
+
+(* ── set_trace_summary ────────────────────────────────── *)
+
+let test_set_trace_summary () =
+  let c = Eval.create_collector ~agent_name:"a" ~run_id:"r" in
+  let summary : Trace_eval.summary = {
+    total_spans = 10; agent_runs = 2; api_calls = 5;
+    tool_execs = 3; hook_invokes = 0; failed_spans = 1;
+    failed_api_calls = 0; failed_tool_execs = 1;
+    total_events = 20; average_duration_ms = Some 150.0;
+    longest_span_name = Some "agent_run/main";
+  } in
+  Eval.set_trace_summary c summary;
+  let rm = Eval.finalize c in
+  Alcotest.(check bool) "has trace summary" true (Option.is_some rm.trace_summary)
+
+let test_run_metrics_to_yojson_with_trace () =
+  let summary : Trace_eval.summary = {
+    total_spans = 5; agent_runs = 1; api_calls = 2;
+    tool_execs = 1; hook_invokes = 0; failed_spans = 0;
+    failed_api_calls = 0; failed_tool_execs = 0;
+    total_events = 10; average_duration_ms = None;
+    longest_span_name = None;
+  } in
+  let rm = { (mk_run []) with trace_summary = Some summary } in
+  let json = Eval.run_metrics_to_yojson rm in
+  let open Yojson.Safe.Util in
+  Alcotest.(check bool) "has_trace_summary" true
+    (json |> member "has_trace_summary" |> to_bool)
+
+(* ── find_metric_value ────────────────────────────────── *)
+
+let test_find_metric_value_found () =
+  let rm = mk_run [mk_metric "score" (Float_val 0.95)] in
+  match Eval.find_metric_value rm "score" with
+  | Some (Float_val f) -> Alcotest.(check (float 0.01)) "value" 0.95 f
+  | _ -> Alcotest.fail "expected Float_val"
+
+let test_find_metric_value_missing () =
+  let rm = mk_run [] in
+  Alcotest.(check bool) "None" true
+    (Eval.find_metric_value rm "nonexistent" = None)
+
+(* ── compute_delta edge cases ─────────────────────────── *)
+
+let test_compute_delta_baseline_zero () =
+  let dir, pct = Eval.compute_delta
+    ~baseline_val:(Float_val 0.0) ~candidate_val:(Float_val 5.0) () in
+  Alcotest.(check bool) "regression for zero baseline" true
+    (dir = Eval.Regression);
+  Alcotest.(check bool) "no pct" true (pct = None)
+
+let test_compute_delta_both_zero () =
+  let dir, _ = Eval.compute_delta
+    ~baseline_val:(Float_val 0.0) ~candidate_val:(Float_val 0.0) () in
+  Alcotest.(check bool) "unchanged" true (dir = Eval.Unchanged)
+
+let test_compute_delta_zero_baseline_negative () =
+  let dir, _ = Eval.compute_delta
+    ~baseline_val:(Float_val 0.0) ~candidate_val:(Float_val (-1.0)) () in
+  Alcotest.(check bool) "improvement" true (dir = Eval.Improvement)
+
+let test_compute_delta_non_numeric () =
+  let dir, pct = Eval.compute_delta
+    ~baseline_val:(String_val "a") ~candidate_val:(String_val "b") () in
+  Alcotest.(check bool) "unchanged for strings" true (dir = Eval.Unchanged);
+  Alcotest.(check bool) "no pct" true (pct = None)
+
+let test_compute_delta_custom_threshold () =
+  let dir, _ = Eval.compute_delta ~threshold_pct:1.0
+    ~baseline_val:(Float_val 100.0) ~candidate_val:(Float_val 102.0) () in
+  Alcotest.(check bool) "regression with 1% threshold" true (dir = Eval.Regression)
+
+let test_compute_delta_bool_values () =
+  let dir, _ = Eval.compute_delta
+    ~baseline_val:(Bool_val false) ~candidate_val:(Bool_val true) () in
+  Alcotest.(check bool) "regression false->true" true (dir = Eval.Regression)
+
+(* ── compare: missing metric in candidate ─────────────── *)
+
+let test_compare_missing_candidate_metric () =
+  let baseline = mk_run [mk_metric "a" (Float_val 1.0); mk_metric "b" (Float_val 2.0)] in
+  let candidate = mk_run ~run_id:"r2" [mk_metric "a" (Float_val 1.0)] in
+  let cmp = Eval.compare ~baseline ~candidate in
+  (* "b" is in baseline but not candidate -- it is simply absent from deltas
+     because compare only iterates baseline metrics and filters by candidate *)
+  Alcotest.(check int) "unchanged" 1 (List.length cmp.unchanged)
+
+(* ── compare: string metric unchanged ─────────────────── *)
+
+let test_compare_string_metric () =
+  let baseline = mk_run [mk_metric "name" (String_val "test")] in
+  let candidate = mk_run ~run_id:"r2" [mk_metric "name" (String_val "test")] in
+  let cmp = Eval.compare ~baseline ~candidate in
+  Alcotest.(check int) "unchanged" 1 (List.length cmp.unchanged)
+
+(* ── threshold: no matching metric ────────────────────── *)
+
+let test_threshold_no_matching_metric () =
+  let rm = mk_run [mk_metric "x" (Int_val 1)] in
+  let ths = [{ Eval.metric_name = "missing"; max_value = Some (Int_val 10); min_value = None }] in
+  let v = Eval.check_thresholds rm ths in
+  Alcotest.(check bool) "pass when metric absent" true v.passed
+
+(* ── threshold: non-numeric values ────────────────────── *)
+
+let test_threshold_non_numeric () =
+  let rm = mk_run [mk_metric "name" (String_val "test")] in
+  let ths = [{ Eval.metric_name = "name"; max_value = Some (String_val "z"); min_value = None }] in
+  let v = Eval.check_thresholds rm ths in
+  Alcotest.(check bool) "pass for non-numeric" true v.passed
+
+(* ── threshold: both max and min ──────────────────────── *)
+
+let test_threshold_both_pass () =
+  let rm = mk_run [mk_metric "x" (Float_val 50.0)] in
+  let ths = [{
+    Eval.metric_name = "x";
+    max_value = Some (Float_val 100.0);
+    min_value = Some (Float_val 10.0);
+  }] in
+  let v = Eval.check_thresholds rm ths in
+  Alcotest.(check bool) "both pass" true v.passed
+
+let test_threshold_both_fail_min () =
+  let rm = mk_run [mk_metric "x" (Float_val 5.0)] in
+  let ths = [{
+    Eval.metric_name = "x";
+    max_value = Some (Float_val 100.0);
+    min_value = Some (Float_val 10.0);
+  }] in
+  let v = Eval.check_thresholds rm ths in
+  Alcotest.(check bool) "fail min" false v.passed
+
+(* ── Eval_baseline: show_diff all variants ────────────── *)
+
+let test_show_diff_unchanged () =
+  let s = Eval_baseline.show_diff Unchanged in
+  Alcotest.(check string) "unchanged" "unchanged" s
+
+let test_show_diff_improved () =
+  let s = Eval_baseline.show_diff (Improved {
+    name = "score"; baseline_val = 0.8; current_val = 0.9; delta_pct = 12.5;
+  }) in
+  Alcotest.(check bool) "contains score" true
+    (Util.string_contains ~needle:"score" s);
+  Alcotest.(check bool) "contains +" true
+    (Util.string_contains ~needle:"+" s)
+
+let test_show_diff_added () =
+  let s = Eval_baseline.show_diff (Added {
+    name = "new_metric"; value = Int_val 42;
+  }) in
+  Alcotest.(check bool) "contains NEW" true
+    (Util.string_contains ~needle:"NEW" s)
+
+let test_show_diff_removed () =
+  let s = Eval_baseline.show_diff (Removed {
+    name = "old_metric"; value = Float_val 1.0;
+  }) in
+  Alcotest.(check bool) "contains REMOVED" true
+    (Util.string_contains ~needle:"REMOVED" s)
+
+(* ── Eval_baseline: compare near-zero baseline ────────── *)
+
+let test_compare_near_zero_baseline () =
+  let baseline_rm = mk_run [mk_metric "x" (Float_val 0.0)] in
+  let baseline = Eval_baseline.create ~description:"base" baseline_rm in
+  let current = mk_run [mk_metric "x" (Float_val 0.001)] in
+  let c = Eval_baseline.compare ~baseline ~current () in
+  Alcotest.(check bool) "improved" true (c.improvements > 0)
+
+let test_compare_near_zero_both () =
+  let baseline_rm = mk_run [mk_metric "x" (Float_val 0.0)] in
+  let baseline = Eval_baseline.create ~description:"base" baseline_rm in
+  let current = mk_run [mk_metric "x" (Float_val 0.0)] in
+  let c = Eval_baseline.compare ~baseline ~current () in
+  let unchanged = List.filter (function Eval_baseline.Unchanged -> true | _ -> false) c.diffs in
+  Alcotest.(check int) "1 unchanged" 1 (List.length unchanged)
+
+(* ── Eval_baseline: compare non-numeric equality/inequality ── *)
+
+let test_compare_non_numeric_equal () =
+  let baseline_rm = mk_run [mk_metric "tag" (String_val "v1")] in
+  let baseline = Eval_baseline.create ~description:"base" baseline_rm in
+  let current = mk_run [mk_metric "tag" (String_val "v1")] in
+  let c = Eval_baseline.compare ~baseline ~current () in
+  let unchanged = List.filter (function Eval_baseline.Unchanged -> true | _ -> false) c.diffs in
+  Alcotest.(check int) "unchanged" 1 (List.length unchanged)
+
+let test_compare_non_numeric_changed () =
+  let baseline_rm = mk_run [mk_metric "tag" (String_val "v1")] in
+  let baseline = Eval_baseline.create ~description:"base" baseline_rm in
+  let current = mk_run [mk_metric "tag" (String_val "v2")] in
+  let c = Eval_baseline.compare ~baseline ~current () in
+  Alcotest.(check int) "1 regression" 1 c.regressions
+
+(* ── Eval_baseline: compare with custom tolerance ─────── *)
+
+let test_compare_custom_tolerance () =
+  let baseline_rm = mk_run [mk_metric "x" (Float_val 100.0)] in
+  let baseline = Eval_baseline.create ~description:"base" baseline_rm in
+  let current = mk_run [mk_metric "x" (Float_val 102.0)] in
+  let c1 = Eval_baseline.compare ~tolerance_pct:5.0 ~baseline ~current () in
+  Alcotest.(check int) "within 5%: no regression" 0 c1.regressions;
+  let c2 = Eval_baseline.compare ~tolerance_pct:1.0 ~baseline ~current () in
+  Alcotest.(check int) "outside 1%: improvement" 1 c2.improvements
+
+(* ── Eval_report: pass_at_k boundary ──────────────────── *)
+
+let test_report_pass_at_k_exactly_half () =
+  let baseline_rm = mk_run [mk_metric "x" (Float_val 1.0)] ~verdicts:[pass_verdict] in
+  let baseline = Eval_baseline.create ~description:"base" baseline_rm in
+  let fail_v : Harness.verdict = { passed = false; score = None; evidence = []; detail = None } in
+  let runs = [
+    mk_run [mk_metric "x" (Float_val 1.0)] ~verdicts:[pass_verdict];
+    mk_run [mk_metric "x" (Float_val 1.0)] ~verdicts:[fail_v];
+  ] in
+  let report = Eval_report.generate ~baseline runs in
+  Alcotest.(check (float 0.01)) "pass_at_k" 0.5 report.pass_at_k;
+  (* 0.5 >= 0.5 -> Pass *)
+  (match report.verdict with
+   | `Pass -> ()
+   | _ -> Alcotest.fail "expected Pass at exactly 0.5")
+
+(* ── Eval_report: to_string with comparison that has Unchanged diffs ── *)
+
+let test_report_to_string_unchanged_filtered () =
+  let baseline_rm = mk_run [mk_metric "x" (Float_val 1.0)] ~verdicts:[pass_verdict] in
+  let baseline = Eval_baseline.create ~description:"base" baseline_rm in
+  let runs = [mk_run [mk_metric "x" (Float_val 1.0)] ~verdicts:[pass_verdict]] in
+  let report = Eval_report.generate ~baseline runs in
+  let s = Eval_report.to_string report in
+  (* Unchanged diffs should be filtered out of to_string *)
+  Alcotest.(check bool) "does not contain unchanged" false
+    (Util.string_contains ~needle:"unchanged" s)
+
+(* ── Eval_collector: AgentCompleted event ─────────────── *)
+
+let test_eval_collector_agent_completed () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let ec = Eval_collector.wrap_run ~bus ~agent_name:"bot" ~run_id:"r1" () in
+  let ok_response : Types.api_response = {
+    id = "r1"; model = "m"; stop_reason = EndTurn;
+    content = [Text "done"]; usage = None;
+  } in
+  Event_bus.publish bus (AgentCompleted {
+    agent_name = "bot"; task_id = "t1"; elapsed = 2.5; result = Ok ok_response;
+  });
+  let rm = Eval_collector.finalize ec in
+  (match Eval.find_metric_value rm "elapsed_s" with
+   | Some (Float_val f) -> Alcotest.(check (float 0.1)) "elapsed" 2.5 f
+   | _ -> Alcotest.fail "expected elapsed_s metric");
+  (match Eval.find_metric_value rm "success" with
+   | Some (Bool_val true) -> ()
+   | _ -> Alcotest.fail "expected success=true")
+
+let test_eval_collector_agent_completed_error () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let ec = Eval_collector.wrap_run ~bus ~agent_name:"bot" ~run_id:"r1" () in
+  Event_bus.publish bus (AgentCompleted {
+    agent_name = "bot"; task_id = "t1"; elapsed = 1.0;
+    result = Error (Error.Internal "fail");
+  });
+  let rm = Eval_collector.finalize ec in
+  (match Eval.find_metric_value rm "success" with
+   | Some (Bool_val false) -> ()
+   | _ -> Alcotest.fail "expected success=false")
+
+(* ── Test runner ───────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Eval_coverage" [
+    "metric_value_of_yojson", [
+      Alcotest.test_case "list error" `Quick test_metric_value_of_yojson_error;
+      Alcotest.test_case "null error" `Quick test_metric_value_of_yojson_null;
+    ];
+    "show_metric_value", [
+      Alcotest.test_case "int" `Quick test_show_metric_value_int;
+      Alcotest.test_case "bool false" `Quick test_show_metric_value_bool_false;
+      Alcotest.test_case "string" `Quick test_show_metric_value_string;
+    ];
+    "formatters", [
+      Alcotest.test_case "pp_metric_value" `Quick test_pp_metric_value;
+      Alcotest.test_case "pp_metric" `Quick test_pp_metric;
+      Alcotest.test_case "show_metric" `Quick test_show_metric;
+      Alcotest.test_case "show_run_metrics" `Quick test_show_run_metrics;
+      Alcotest.test_case "pp_run_metrics" `Quick test_pp_run_metrics;
+    ];
+    "metric_of_yojson", [
+      Alcotest.test_case "type error" `Quick test_metric_of_yojson_type_error;
+      Alcotest.test_case "bad value" `Quick test_metric_of_yojson_bad_value;
+      Alcotest.test_case "minimal" `Quick test_metric_of_yojson_minimal;
+    ];
+    "metric_to_yojson", [
+      Alcotest.test_case "full" `Quick test_metric_to_yojson_full;
+      Alcotest.test_case "minimal" `Quick test_metric_to_yojson_minimal;
+    ];
+    "run_metrics_of_yojson", [
+      Alcotest.test_case "type error" `Quick test_run_metrics_of_yojson_type_error;
+      Alcotest.test_case "bad metric" `Quick test_run_metrics_of_yojson_bad_metric;
+    ];
+    "run_metrics_to_yojson", [
+      Alcotest.test_case "with verdicts" `Quick test_run_metrics_to_yojson_with_verdicts;
+      Alcotest.test_case "score None" `Quick test_run_metrics_to_yojson_score_none;
+      Alcotest.test_case "with trace summary" `Quick test_run_metrics_to_yojson_with_trace;
+    ];
+    "trace_summary", [
+      Alcotest.test_case "set_trace_summary" `Quick test_set_trace_summary;
+    ];
+    "find_metric_value", [
+      Alcotest.test_case "found" `Quick test_find_metric_value_found;
+      Alcotest.test_case "missing" `Quick test_find_metric_value_missing;
+    ];
+    "compute_delta", [
+      Alcotest.test_case "baseline zero" `Quick test_compute_delta_baseline_zero;
+      Alcotest.test_case "both zero" `Quick test_compute_delta_both_zero;
+      Alcotest.test_case "zero negative" `Quick test_compute_delta_zero_baseline_negative;
+      Alcotest.test_case "non-numeric" `Quick test_compute_delta_non_numeric;
+      Alcotest.test_case "custom threshold" `Quick test_compute_delta_custom_threshold;
+      Alcotest.test_case "bool values" `Quick test_compute_delta_bool_values;
+    ];
+    "compare_extra", [
+      Alcotest.test_case "missing candidate" `Quick test_compare_missing_candidate_metric;
+      Alcotest.test_case "string metric" `Quick test_compare_string_metric;
+    ];
+    "threshold_extra", [
+      Alcotest.test_case "no matching metric" `Quick test_threshold_no_matching_metric;
+      Alcotest.test_case "non-numeric" `Quick test_threshold_non_numeric;
+      Alcotest.test_case "both pass" `Quick test_threshold_both_pass;
+      Alcotest.test_case "both fail min" `Quick test_threshold_both_fail_min;
+    ];
+    "show_diff", [
+      Alcotest.test_case "unchanged" `Quick test_show_diff_unchanged;
+      Alcotest.test_case "improved" `Quick test_show_diff_improved;
+      Alcotest.test_case "added" `Quick test_show_diff_added;
+      Alcotest.test_case "removed" `Quick test_show_diff_removed;
+    ];
+    "baseline_compare_extra", [
+      Alcotest.test_case "near zero" `Quick test_compare_near_zero_baseline;
+      Alcotest.test_case "near zero both" `Quick test_compare_near_zero_both;
+      Alcotest.test_case "non-numeric equal" `Quick test_compare_non_numeric_equal;
+      Alcotest.test_case "non-numeric changed" `Quick test_compare_non_numeric_changed;
+      Alcotest.test_case "custom tolerance" `Quick test_compare_custom_tolerance;
+    ];
+    "eval_report_extra", [
+      Alcotest.test_case "pass_at_k boundary" `Quick test_report_pass_at_k_exactly_half;
+      Alcotest.test_case "to_string unchanged filtered" `Quick test_report_to_string_unchanged_filtered;
+    ];
+    "eval_collector_extra", [
+      Alcotest.test_case "agent completed" `Quick test_eval_collector_agent_completed;
+      Alcotest.test_case "agent completed error" `Quick test_eval_collector_agent_completed_error;
+    ];
+  ]

--- a/test/test_memory_coverage.ml
+++ b/test/test_memory_coverage.ml
@@ -1,0 +1,740 @@
+(** Extended coverage tests for Memory, Memory_tools, and Memory_access.
+
+    Targets uncovered paths via PUBLIC API only:
+    - Memory.ml: tier fallback chains (scratchpad->working->backend/ctx),
+      recall_exact for Long_term with/without backend,
+      Episodic/Procedural recall returning None (no fallback),
+      scratchpad_entries, episode store/recall roundtrip with various outcomes,
+      procedure store/matching (exercises string_contains, compute_confidence),
+      record_success/failure on missing IDs, boost on missing,
+      all_episodes enumeration via recall_episodes
+    - Memory_tools.ml: parse field edge cases (bad types), tier variants,
+      ACL-backed tools, episode with explicit id, outcome variants
+    - Memory_access.ml: recall_exact, forget, recall_episodes with grant,
+      permission_includes ReadWrite edge, revoke/memory accessor *)
+
+open Agent_sdk
+
+(* ── Helpers ──────────────────────────────────────────── *)
+
+let json_s s = `String s
+let json_i i = `Int i
+
+let execute_ok_json tool input =
+  match Tool.execute tool input with
+  | Ok { content } -> Yojson.Safe.from_string content
+  | Error { message; _ } -> Alcotest.fail ("expected Ok: " ^ message)
+
+let execute_error tool input =
+  match Tool.execute tool input with
+  | Ok { content } -> Alcotest.fail ("expected Error: " ^ content)
+  | Error { message; _ } -> message
+
+(* ── Memory: recall Episodic/Procedural returns None ──── *)
+
+let test_recall_episodic_returns_none () =
+  let mem = Memory.create () in
+  Alcotest.(check bool) "episodic miss no fallback" true
+    (Memory.recall mem ~tier:Episodic "nonexistent" = None)
+
+let test_recall_procedural_returns_none () =
+  let mem = Memory.create () in
+  Alcotest.(check bool) "procedural miss no fallback" true
+    (Memory.recall mem ~tier:Procedural "nonexistent" = None)
+
+(* ── Memory: recall_exact Long_term with backend ──────── *)
+
+let test_recall_exact_long_term_with_backend () =
+  let store = Hashtbl.create 4 in
+  let backend : Memory.long_term_backend = {
+    persist = (fun ~key value -> Hashtbl.replace store key value; Ok ());
+    retrieve = (fun ~key -> Hashtbl.find_opt store key);
+    remove = (fun ~key -> Hashtbl.remove store key; Ok ());
+    batch_persist = (fun pairs ->
+      List.iter (fun (k, v) -> Hashtbl.replace store k v) pairs; Ok ());
+    query = (fun ~prefix:_ ~limit:_ -> []);
+  } in
+  let mem = Memory.create ~long_term:backend () in
+  Hashtbl.replace store "only_backend" (json_s "from_store");
+  match Memory.recall_exact mem ~tier:Long_term "only_backend" with
+  | Some (`String "from_store") -> ()
+  | _ -> Alcotest.fail "backend should return value"
+
+let test_recall_exact_long_term_no_backend () =
+  let mem = Memory.create () in
+  Memory.store mem ~tier:Long_term "local_lt" (json_s "v");
+  match Memory.recall_exact mem ~tier:Long_term "local_lt" with
+  | Some (`String "v") -> ()
+  | _ -> Alcotest.fail "should use local ctx"
+
+(* ── Memory: scratchpad recall chain to long_term ─────── *)
+
+let test_scratchpad_recall_chain_with_backend () =
+  let store = Hashtbl.create 4 in
+  let backend : Memory.long_term_backend = {
+    persist = (fun ~key value -> Hashtbl.replace store key value; Ok ());
+    retrieve = (fun ~key -> Hashtbl.find_opt store key);
+    remove = (fun ~key -> Hashtbl.remove store key; Ok ());
+    batch_persist = (fun _ -> Ok ());
+    query = (fun ~prefix:_ ~limit:_ -> []);
+  } in
+  let mem = Memory.create ~long_term:backend () in
+  Hashtbl.replace store "deep" (json_i 99);
+  match Memory.recall mem ~tier:Scratchpad "deep" with
+  | Some (`Int 99) -> ()
+  | _ -> Alcotest.fail "scratchpad should chain to long_term backend"
+
+let test_scratchpad_recall_chain_no_backend () =
+  let mem = Memory.create () in
+  Memory.store mem ~tier:Long_term "deep" (json_i 42);
+  match Memory.recall mem ~tier:Scratchpad "deep" with
+  | Some (`Int 42) -> ()
+  | _ -> Alcotest.fail "scratchpad should chain to local long_term ctx"
+
+(* ── Memory: Long_term recall with/without backend ────── *)
+
+let test_long_term_recall_no_backend_none () =
+  let mem = Memory.create () in
+  Alcotest.(check bool) "None without backend" true
+    (Memory.recall mem ~tier:Long_term "ghost" = None)
+
+(* ── Memory: scratchpad_entries ───────────────────────── *)
+
+let test_scratchpad_entries () =
+  let mem = Memory.create () in
+  Memory.store mem ~tier:Scratchpad "a" (json_i 1);
+  Memory.store mem ~tier:Scratchpad "b" (json_i 2);
+  Memory.store mem ~tier:Working "c" (json_i 3);
+  let entries = Memory.scratchpad_entries mem in
+  Alcotest.(check int) "2 scratchpad entries" 2 (List.length entries)
+
+(* ── Memory: episode store/recall with all outcome types ── *)
+
+let test_episode_success_outcome () =
+  let mem = Memory.create () in
+  let ep : Memory.episode = {
+    id = "e-success"; timestamp = 100.0; participants = ["alice"];
+    action = "deploy"; outcome = Success "deployed"; salience = 0.8;
+    metadata = [("env", `String "prod")];
+  } in
+  Memory.store_episode mem ep;
+  match Memory.recall_episode mem "e-success" with
+  | Some found ->
+    Alcotest.(check string) "id" "e-success" found.id;
+    (match found.outcome with
+     | Memory.Success "deployed" -> ()
+     | _ -> Alcotest.fail "wrong outcome")
+  | None -> Alcotest.fail "not found"
+
+let test_episode_failure_outcome () =
+  let mem = Memory.create () in
+  let ep : Memory.episode = {
+    id = "e-fail"; timestamp = 100.0; participants = [];
+    action = "deploy"; outcome = Failure "timeout"; salience = 0.9;
+    metadata = [];
+  } in
+  Memory.store_episode mem ep;
+  match Memory.recall_episode mem "e-fail" with
+  | Some found ->
+    (match found.outcome with
+     | Memory.Failure "timeout" -> ()
+     | _ -> Alcotest.fail "wrong outcome")
+  | None -> Alcotest.fail "not found"
+
+let test_episode_neutral_outcome () =
+  let mem = Memory.create () in
+  let ep : Memory.episode = {
+    id = "e-neutral"; timestamp = 100.0; participants = [];
+    action = "idle"; outcome = Neutral; salience = 0.5;
+    metadata = [];
+  } in
+  Memory.store_episode mem ep;
+  match Memory.recall_episode mem "e-neutral" with
+  | Some found ->
+    (match found.outcome with
+     | Memory.Neutral -> ()
+     | _ -> Alcotest.fail "wrong outcome")
+  | None -> Alcotest.fail "not found"
+
+(* ── Memory: episode with metadata ────────────────────── *)
+
+let test_episode_with_metadata () =
+  let mem = Memory.create () in
+  Memory.store_episode mem {
+    id = "e-meta"; timestamp = 100.0; participants = [];
+    action = "test"; outcome = Neutral; salience = 0.5;
+    metadata = [("key", `Int 42); ("tag", `String "test")];
+  };
+  let count = Memory.episode_count mem in
+  Alcotest.(check int) "1 episode" 1 count
+
+(* ── Memory: recall_episodes enumeration ──────────────── *)
+
+let test_recall_episodes_multiple () =
+  let mem = Memory.create () in
+  let now = 200.0 in
+  for i = 0 to 4 do
+    Memory.store_episode mem {
+      id = Printf.sprintf "e%d" i; timestamp = Float.of_int (i * 10 + 100);
+      participants = []; action = "a"; outcome = Neutral;
+      salience = 0.9; metadata = [];
+    }
+  done;
+  let episodes = Memory.recall_episodes mem ~now ~min_salience:0.01 () in
+  Alcotest.(check int) "5 episodes" 5 (List.length episodes)
+
+(* ── Memory: procedure matching exercises string_contains ── *)
+
+let test_procedure_matching_empty_pattern () =
+  let mem = Memory.create () in
+  Memory.store_procedure mem {
+    id = "p1"; pattern = "anything"; action = "do";
+    success_count = 1; failure_count = 0; confidence = 1.0;
+    last_used = 0.0; metadata = [];
+  };
+  (* Empty pattern should match everything (string_contains ~needle:"") *)
+  let results = Memory.matching_procedures mem ~pattern:"" () in
+  Alcotest.(check int) "matches all" 1 (List.length results)
+
+let test_procedure_matching_no_match () =
+  let mem = Memory.create () in
+  Memory.store_procedure mem {
+    id = "p1"; pattern = "deploy"; action = "rollback";
+    success_count = 1; failure_count = 0; confidence = 1.0;
+    last_used = 0.0; metadata = [];
+  };
+  let results = Memory.matching_procedures mem ~pattern:"zzzzz" () in
+  Alcotest.(check int) "no match" 0 (List.length results)
+
+(* ── Memory: record_success/failure on missing IDs ────── *)
+
+let test_record_success_missing () =
+  let mem = Memory.create () in
+  Memory.record_success mem "ghost";
+  Alcotest.(check int) "still 0" 0 (Memory.procedure_count mem)
+
+let test_record_failure_missing () =
+  let mem = Memory.create () in
+  Memory.record_failure mem "ghost";
+  Alcotest.(check int) "still 0" 0 (Memory.procedure_count mem)
+
+(* ── Memory: boost_salience on missing ────────────────── *)
+
+let test_boost_salience_missing () =
+  let mem = Memory.create () in
+  Memory.boost_salience mem "ghost" 0.5;
+  Alcotest.(check int) "no episode created" 0 (Memory.episode_count mem)
+
+(* ── Memory: procedure with zero total (compute_confidence 0/0) ── *)
+
+let test_procedure_zero_total () =
+  let mem = Memory.create () in
+  Memory.store_procedure mem {
+    id = "p0"; pattern = "test"; action = "nothing";
+    success_count = 0; failure_count = 0; confidence = 0.0;
+    last_used = 0.0; metadata = [];
+  };
+  match Memory.best_procedure mem ~pattern:"test" with
+  | Some p -> Alcotest.(check (float 0.01)) "confidence 0" 0.0 p.confidence
+  | None -> Alcotest.fail "not found"
+
+(* ── Memory_tools: tier variants ──────────────────────── *)
+
+let test_tier_long_term_dash () =
+  let mem = Memory.create () in
+  let tool = Memory_tools.remember mem in
+  let json = execute_ok_json tool
+    (`Assoc [
+      ("tier", `String "long-term");
+      ("key", `String "k");
+      ("value_json", `String "1");
+    ]) in
+  Alcotest.(check string) "tier" "long_term"
+    Yojson.Safe.Util.(json |> member "tier" |> to_string)
+
+let test_tier_invalid_string () =
+  let mem = Memory.create () in
+  let tool = Memory_tools.remember mem in
+  let msg = execute_error tool
+    (`Assoc [
+      ("tier", `String "bogus");
+      ("key", `String "k");
+      ("value_json", `String "1");
+    ]) in
+  Alcotest.(check bool) "mentions invalid" true
+    (Util.string_contains ~needle:"invalid" msg)
+
+let test_tier_non_string () =
+  let mem = Memory.create () in
+  let tool = Memory_tools.remember mem in
+  let msg = execute_error tool
+    (`Assoc [
+      ("tier", `Int 42);
+      ("key", `String "k");
+      ("value_json", `String "1");
+    ]) in
+  Alcotest.(check bool) "mentions string" true
+    (Util.string_contains ~needle:"string" msg)
+
+(* ── Memory_tools: recall with exact=true ─────────────── *)
+
+let test_recall_exact_flag () =
+  let mem = Memory.create () in
+  Memory.store mem ~tier:Working "only_work" (json_s "here");
+  let tool = Memory_tools.recall mem in
+  let json = execute_ok_json tool
+    (`Assoc [
+      ("key", `String "only_work");
+      ("tier", `String "scratchpad");
+      ("exact", `Bool true);
+    ]) in
+  Alcotest.(check bool) "not found" false
+    Yojson.Safe.Util.(json |> member "found" |> to_bool)
+
+(* ── Memory_tools: remember_episode with explicit id ──── *)
+
+let test_remember_episode_explicit_id () =
+  let mem = Memory.create () in
+  let tool = Memory_tools.remember_episode mem in
+  let json = execute_ok_json tool
+    (`Assoc [
+      ("id", `String "my-custom-id");
+      ("action", `String "test action");
+    ]) in
+  Alcotest.(check string) "custom id" "my-custom-id"
+    Yojson.Safe.Util.(json |> member "id" |> to_string)
+
+(* ── Memory_tools: episode outcome variants ───────────── *)
+
+let test_remember_episode_failure_outcome () =
+  let mem = Memory.create () in
+  let tool = Memory_tools.remember_episode mem in
+  let _ = execute_ok_json tool
+    (`Assoc [
+      ("action", `String "deploy");
+      ("outcome", `String "failure");
+      ("detail", `String "crashed");
+    ]) in
+  ()
+
+let test_remember_episode_neutral_outcome () =
+  let mem = Memory.create () in
+  let tool = Memory_tools.remember_episode mem in
+  let _ = execute_ok_json tool
+    (`Assoc [
+      ("action", `String "idle");
+      ("outcome", `String "neutral");
+    ]) in
+  ()
+
+let test_remember_episode_invalid_outcome () =
+  let mem = Memory.create () in
+  let tool = Memory_tools.remember_episode mem in
+  let msg = execute_error tool
+    (`Assoc [
+      ("action", `String "deploy");
+      ("outcome", `String "bogus");
+    ]) in
+  Alcotest.(check bool) "mentions outcome" true
+    (Util.string_contains ~needle:"outcome" msg)
+
+let test_remember_episode_outcome_non_string () =
+  let mem = Memory.create () in
+  let tool = Memory_tools.remember_episode mem in
+  let msg = execute_error tool
+    (`Assoc [
+      ("action", `String "deploy");
+      ("outcome", `Int 42);
+    ]) in
+  Alcotest.(check bool) "mentions string" true
+    (Util.string_contains ~needle:"string" msg)
+
+(* ── Memory_tools: parse_string_list_field errors ─────── *)
+
+let test_remember_episode_bad_participants () =
+  let mem = Memory.create () in
+  let tool = Memory_tools.remember_episode mem in
+  let msg = execute_error tool
+    (`Assoc [
+      ("action", `String "deploy");
+      ("participants", `List [`Int 1]);
+    ]) in
+  Alcotest.(check bool) "mentions array" true
+    (Util.string_contains ~needle:"array" msg)
+
+let test_remember_episode_participants_non_list () =
+  let mem = Memory.create () in
+  let tool = Memory_tools.remember_episode mem in
+  let msg = execute_error tool
+    (`Assoc [
+      ("action", `String "deploy");
+      ("participants", `String "not-a-list");
+    ]) in
+  Alcotest.(check bool) "mentions array" true
+    (Util.string_contains ~needle:"array" msg)
+
+(* ── Memory_tools: parse_metadata_field error ─────────── *)
+
+let test_remember_episode_bad_metadata () =
+  let mem = Memory.create () in
+  let tool = Memory_tools.remember_episode mem in
+  let msg = execute_error tool
+    (`Assoc [
+      ("action", `String "deploy");
+      ("metadata", `String "not-object");
+    ]) in
+  Alcotest.(check bool) "mentions object" true
+    (Util.string_contains ~needle:"object" msg)
+
+(* ── Memory_tools: salience as int and bad type ───────── *)
+
+let test_remember_episode_salience_int () =
+  let mem = Memory.create () in
+  let tool = Memory_tools.remember_episode mem in
+  let _ = execute_ok_json tool
+    (`Assoc [("action", `String "test"); ("salience", `Int 1)]) in
+  ()
+
+let test_remember_episode_salience_bad () =
+  let mem = Memory.create () in
+  let tool = Memory_tools.remember_episode mem in
+  let msg = execute_error tool
+    (`Assoc [("action", `String "test"); ("salience", `String "high")]) in
+  Alcotest.(check bool) "mentions number" true
+    (Util.string_contains ~needle:"number" msg)
+
+(* ── Memory_tools: missing key ────────────────────────── *)
+
+let test_remember_missing_key () =
+  let mem = Memory.create () in
+  let tool = Memory_tools.remember mem in
+  let msg = execute_error tool (`Assoc [("value_json", `String "1")]) in
+  Alcotest.(check bool) "mentions key" true
+    (Util.string_contains ~needle:"key" msg)
+
+(* ── Memory_tools: bad exact field type ───────────────── *)
+
+let test_recall_bad_exact_type () =
+  let mem = Memory.create () in
+  let tool = Memory_tools.recall mem in
+  let msg = execute_error tool
+    (`Assoc [("key", `String "k"); ("exact", `String "true")]) in
+  Alcotest.(check bool) "mentions boolean" true
+    (Util.string_contains ~needle:"boolean" msg)
+
+(* ── Memory_tools: find_procedure not found ───────────── *)
+
+let test_find_procedure_not_found () =
+  let mem = Memory.create () in
+  let tool = Memory_tools.find_procedure mem in
+  let json = execute_ok_json tool
+    (`Assoc [("pattern", `String "nothing")]) in
+  Alcotest.(check bool) "not found" false
+    Yojson.Safe.Util.(json |> member "found" |> to_bool)
+
+(* ── Memory_tools: with metadata ──────────────────────── *)
+
+let test_remember_episode_with_metadata () =
+  let mem = Memory.create () in
+  let tool = Memory_tools.remember_episode mem in
+  let _ = execute_ok_json tool
+    (`Assoc [
+      ("action", `String "deploy");
+      ("metadata", `Assoc [("env", `String "prod")]);
+      ("salience", `Float 0.9);
+    ]) in
+  ()
+
+(* ── Memory_access: recall_exact ──────────────────────── *)
+
+let test_acl_recall_exact () =
+  let mem = Memory.create () in
+  let acl = Memory_access.create mem in
+  Memory_access.grant acl {
+    agent_name = "alice"; tier = Working;
+    key_pattern = "*"; permission = ReadWrite;
+  };
+  Memory.store mem ~tier:Working "k" (json_s "v");
+  match Memory_access.recall_exact acl ~agent:"alice" ~tier:Working "k" with
+  | Ok (Some (`String "v")) -> ()
+  | _ -> Alcotest.fail "should recall exact"
+
+let test_acl_recall_exact_denied () =
+  let mem = Memory.create () in
+  let acl = Memory_access.create mem in
+  match Memory_access.recall_exact acl ~agent:"alice" ~tier:Working "k" with
+  | Error (Denied _) -> ()
+  | _ -> Alcotest.fail "should be denied"
+
+(* ── Memory_access: forget ────────────────────────────── *)
+
+let test_acl_forget () =
+  let mem = Memory.create () in
+  let acl = Memory_access.create mem in
+  Memory_access.grant acl {
+    agent_name = "alice"; tier = Working;
+    key_pattern = "*"; permission = ReadWrite;
+  };
+  Memory.store mem ~tier:Working "k" (json_s "v");
+  (match Memory_access.forget acl ~agent:"alice" ~tier:Working "k" with
+   | Ok () -> ()
+   | Error _ -> Alcotest.fail "should forget");
+  Alcotest.(check bool) "forgotten" true
+    (Memory.recall_exact mem ~tier:Working "k" = None)
+
+let test_acl_forget_denied () =
+  let mem = Memory.create () in
+  let acl = Memory_access.create mem in
+  match Memory_access.forget acl ~agent:"alice" ~tier:Working "k" with
+  | Error (Denied _) -> ()
+  | _ -> Alcotest.fail "should be denied"
+
+(* ── Memory_access: recall_episodes with grant ────────── *)
+
+let test_acl_recall_episodes_allowed () =
+  let mem = Memory.create () in
+  let acl = Memory_access.create mem in
+  Memory_access.grant acl {
+    agent_name = "alice"; tier = Episodic;
+    key_pattern = "*"; permission = ReadWrite;
+  };
+  Memory.store_episode mem {
+    id = "e1"; timestamp = 100.0; participants = [];
+    action = "test"; outcome = Neutral; salience = 0.9; metadata = [];
+  };
+  match Memory_access.recall_episodes acl ~agent:"alice" ~now:200.0 () with
+  | Ok episodes -> Alcotest.(check int) "1 episode" 1 (List.length episodes)
+  | Error _ -> Alcotest.fail "should be allowed"
+
+(* ── Memory_access: memory accessor ───────────────────── *)
+
+let test_acl_memory_accessor () =
+  let mem = Memory.create () in
+  let acl = Memory_access.create mem in
+  let underlying = Memory_access.memory acl in
+  Memory.store underlying ~tier:Working "direct" (json_s "val");
+  match Memory.recall_exact underlying ~tier:Working "direct" with
+  | Some (`String "val") -> ()
+  | _ -> Alcotest.fail "should access underlying memory"
+
+(* ── Memory_access: permission edge cases ─────────────── *)
+
+let test_permission_readwrite_needed () =
+  let mem = Memory.create () in
+  let acl = Memory_access.create mem in
+  Memory_access.grant acl {
+    agent_name = "alice"; tier = Working;
+    key_pattern = "*"; permission = Read;
+  };
+  Alcotest.(check bool) "ReadWrite not satisfied by Read" false
+    (Memory_access.check acl ~agent:"alice" ~tier:Working ~key:"k" ReadWrite)
+
+let test_permission_readwrite_grant () =
+  let mem = Memory.create () in
+  let acl = Memory_access.create mem in
+  Memory_access.grant acl {
+    agent_name = "alice"; tier = Working;
+    key_pattern = "*"; permission = ReadWrite;
+  };
+  Alcotest.(check bool) "ReadWrite satisfied" true
+    (Memory_access.check acl ~agent:"alice" ~tier:Working ~key:"k" ReadWrite)
+
+(* ── Memory_access: error string all tiers ────────────── *)
+
+let test_access_error_all_tiers () =
+  let tiers = [Memory.Scratchpad; Working; Episodic; Procedural; Long_term] in
+  List.iter (fun tier ->
+    let err = Memory_access.Denied {
+      agent_name = "bob"; tier; key = "k"; needed = Read;
+    } in
+    let s = Memory_access.access_error_to_string err in
+    Alcotest.(check bool) "non-empty" true (String.length s > 0)
+  ) tiers
+
+(* ── Memory_access: revoke edge cases ─────────────────── *)
+
+let test_acl_revoke_other_tiers_remain () =
+  let mem = Memory.create () in
+  let acl = Memory_access.create mem in
+  Memory_access.grant acl {
+    agent_name = "alice"; tier = Working;
+    key_pattern = "*"; permission = ReadWrite;
+  };
+  Memory_access.grant acl {
+    agent_name = "alice"; tier = Scratchpad;
+    key_pattern = "*"; permission = Read;
+  };
+  Memory_access.revoke acl ~agent_name:"alice" ~tier:Working;
+  let policies = Memory_access.policies_for acl "alice" in
+  Alcotest.(check int) "1 remaining" 1 (List.length policies)
+
+let test_acl_revoke_none () =
+  let mem = Memory.create () in
+  let acl = Memory_access.create mem in
+  Memory_access.revoke acl ~agent_name:"nobody" ~tier:Working;
+  Alcotest.(check int) "still 0" 0
+    (List.length (Memory_access.policies_for acl "nobody"))
+
+(* ── Memory_tools: ACL-backed tools ───────────────────── *)
+
+let test_recall_acl_allowed () =
+  let mem = Memory.create () in
+  let acl = Memory_access.create mem in
+  Memory_access.grant acl {
+    agent_name = "alice"; tier = Working;
+    key_pattern = "*"; permission = ReadWrite;
+  };
+  Memory.store mem ~tier:Working "k" (json_s "v");
+  let tool = Memory_tools.recall_acl acl ~agent_name:"alice" in
+  let json = execute_ok_json tool (`Assoc [("key", `String "k")]) in
+  Alcotest.(check bool) "found" true
+    Yojson.Safe.Util.(json |> member "found" |> to_bool)
+
+let test_recall_acl_denied () =
+  let mem = Memory.create () in
+  let acl = Memory_access.create mem in
+  let tool = Memory_tools.recall_acl acl ~agent_name:"bob" in
+  let msg = execute_error tool (`Assoc [("key", `String "k")]) in
+  Alcotest.(check bool) "denied" true
+    (Util.string_contains ~needle:"Access denied" msg)
+
+let test_remember_episode_acl_allowed () =
+  let mem = Memory.create () in
+  let acl = Memory_access.create mem in
+  Memory_access.grant acl {
+    agent_name = "alice"; tier = Episodic;
+    key_pattern = "*"; permission = ReadWrite;
+  };
+  let tool = Memory_tools.remember_episode_acl acl ~agent_name:"alice" in
+  let json = execute_ok_json tool
+    (`Assoc [("action", `String "test")]) in
+  Alcotest.(check bool) "ok" true
+    Yojson.Safe.Util.(json |> member "ok" |> to_bool)
+
+let test_remember_episode_acl_denied () =
+  let mem = Memory.create () in
+  let acl = Memory_access.create mem in
+  let tool = Memory_tools.remember_episode_acl acl ~agent_name:"bob" in
+  let msg = execute_error tool
+    (`Assoc [("action", `String "test")]) in
+  Alcotest.(check bool) "denied" true
+    (Util.string_contains ~needle:"Access denied" msg)
+
+let test_find_procedure_acl_allowed () =
+  let mem = Memory.create () in
+  let acl = Memory_access.create mem in
+  Memory_access.grant acl {
+    agent_name = "alice"; tier = Procedural;
+    key_pattern = "*"; permission = ReadWrite;
+  };
+  Memory.store_procedure mem {
+    id = "pr1"; pattern = "deploy"; action = "retry";
+    success_count = 5; failure_count = 0; confidence = 1.0;
+    last_used = 0.0; metadata = [];
+  };
+  let tool = Memory_tools.find_procedure_acl acl ~agent_name:"alice" in
+  let json = execute_ok_json tool
+    (`Assoc [("pattern", `String "deploy")]) in
+  Alcotest.(check bool) "found" true
+    Yojson.Safe.Util.(json |> member "found" |> to_bool)
+
+let test_find_procedure_acl_denied () =
+  let mem = Memory.create () in
+  let acl = Memory_access.create mem in
+  let tool = Memory_tools.find_procedure_acl acl ~agent_name:"bob" in
+  let msg = execute_error tool
+    (`Assoc [("pattern", `String "deploy")]) in
+  Alcotest.(check bool) "denied" true
+    (Util.string_contains ~needle:"Access denied" msg)
+
+(* ── Test runner ───────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Memory_coverage" [
+    "recall_no_fallback", [
+      Alcotest.test_case "episodic miss" `Quick test_recall_episodic_returns_none;
+      Alcotest.test_case "procedural miss" `Quick test_recall_procedural_returns_none;
+    ];
+    "recall_exact_long_term", [
+      Alcotest.test_case "with backend" `Quick test_recall_exact_long_term_with_backend;
+      Alcotest.test_case "no backend" `Quick test_recall_exact_long_term_no_backend;
+    ];
+    "scratchpad_chain", [
+      Alcotest.test_case "with backend" `Quick test_scratchpad_recall_chain_with_backend;
+      Alcotest.test_case "no backend" `Quick test_scratchpad_recall_chain_no_backend;
+    ];
+    "long_term_recall", [
+      Alcotest.test_case "no backend none" `Quick test_long_term_recall_no_backend_none;
+    ];
+    "entries", [
+      Alcotest.test_case "scratchpad_entries" `Quick test_scratchpad_entries;
+    ];
+    "episodic", [
+      Alcotest.test_case "success outcome" `Quick test_episode_success_outcome;
+      Alcotest.test_case "failure outcome" `Quick test_episode_failure_outcome;
+      Alcotest.test_case "neutral outcome" `Quick test_episode_neutral_outcome;
+      Alcotest.test_case "with metadata" `Quick test_episode_with_metadata;
+      Alcotest.test_case "recall multiple" `Quick test_recall_episodes_multiple;
+    ];
+    "procedural", [
+      Alcotest.test_case "empty pattern" `Quick test_procedure_matching_empty_pattern;
+      Alcotest.test_case "no match" `Quick test_procedure_matching_no_match;
+      Alcotest.test_case "zero total" `Quick test_procedure_zero_total;
+    ];
+    "missing_ops", [
+      Alcotest.test_case "record_success missing" `Quick test_record_success_missing;
+      Alcotest.test_case "record_failure missing" `Quick test_record_failure_missing;
+      Alcotest.test_case "boost missing" `Quick test_boost_salience_missing;
+    ];
+    "tools_tier", [
+      Alcotest.test_case "long-term dash" `Quick test_tier_long_term_dash;
+      Alcotest.test_case "invalid string" `Quick test_tier_invalid_string;
+      Alcotest.test_case "non-string" `Quick test_tier_non_string;
+    ];
+    "tools_recall", [
+      Alcotest.test_case "exact flag" `Quick test_recall_exact_flag;
+      Alcotest.test_case "bad exact type" `Quick test_recall_bad_exact_type;
+      Alcotest.test_case "missing key" `Quick test_remember_missing_key;
+      Alcotest.test_case "not found" `Quick test_find_procedure_not_found;
+    ];
+    "tools_episode", [
+      Alcotest.test_case "explicit id" `Quick test_remember_episode_explicit_id;
+      Alcotest.test_case "failure outcome" `Quick test_remember_episode_failure_outcome;
+      Alcotest.test_case "neutral outcome" `Quick test_remember_episode_neutral_outcome;
+      Alcotest.test_case "invalid outcome" `Quick test_remember_episode_invalid_outcome;
+      Alcotest.test_case "outcome non-string" `Quick test_remember_episode_outcome_non_string;
+      Alcotest.test_case "bad participants" `Quick test_remember_episode_bad_participants;
+      Alcotest.test_case "participants non-list" `Quick test_remember_episode_participants_non_list;
+      Alcotest.test_case "bad metadata" `Quick test_remember_episode_bad_metadata;
+      Alcotest.test_case "with metadata" `Quick test_remember_episode_with_metadata;
+      Alcotest.test_case "salience int" `Quick test_remember_episode_salience_int;
+      Alcotest.test_case "salience bad" `Quick test_remember_episode_salience_bad;
+    ];
+    "acl_exact", [
+      Alcotest.test_case "allowed" `Quick test_acl_recall_exact;
+      Alcotest.test_case "denied" `Quick test_acl_recall_exact_denied;
+    ];
+    "acl_forget", [
+      Alcotest.test_case "allowed" `Quick test_acl_forget;
+      Alcotest.test_case "denied" `Quick test_acl_forget_denied;
+    ];
+    "acl_episodes", [
+      Alcotest.test_case "allowed" `Quick test_acl_recall_episodes_allowed;
+    ];
+    "acl_permission", [
+      Alcotest.test_case "ReadWrite not Read" `Quick test_permission_readwrite_needed;
+      Alcotest.test_case "ReadWrite grant" `Quick test_permission_readwrite_grant;
+      Alcotest.test_case "error all tiers" `Quick test_access_error_all_tiers;
+      Alcotest.test_case "memory accessor" `Quick test_acl_memory_accessor;
+      Alcotest.test_case "revoke other remain" `Quick test_acl_revoke_other_tiers_remain;
+      Alcotest.test_case "revoke none" `Quick test_acl_revoke_none;
+    ];
+    "acl_tools", [
+      Alcotest.test_case "recall allowed" `Quick test_recall_acl_allowed;
+      Alcotest.test_case "recall denied" `Quick test_recall_acl_denied;
+      Alcotest.test_case "episode allowed" `Quick test_remember_episode_acl_allowed;
+      Alcotest.test_case "episode denied" `Quick test_remember_episode_acl_denied;
+      Alcotest.test_case "procedure allowed" `Quick test_find_procedure_acl_allowed;
+      Alcotest.test_case "procedure denied" `Quick test_find_procedure_acl_denied;
+    ];
+  ]

--- a/test/test_runtime_projection_cov2.ml
+++ b/test/test_runtime_projection_cov2.ml
@@ -1,0 +1,541 @@
+(** Extended coverage for runtime_projection.ml — targeting remaining uncovered paths.
+
+    Existing test_runtime_projection_unit.ml covers:
+    - phase_to/of_collaboration all 7 variants
+    - participant_state_to_collaboration all 7 variants
+    - participant_to_collaboration field mapping
+    - artifact_to_collaboration
+    - contribution_of_runtime_vote
+    - collaboration_of_session / update_session_from_collaboration
+
+    This file targets uncovered paths in:
+    - apply_event: all 14 event_kind branches
+    - initial_session: construction from start_request
+    - update_participant: new participant creation (not found path)
+    - ensure_active_phase: terminal phase errors
+    - count_by_state: all state variants
+    - build_report: all fields, participant summary None/Some
+    - build_proof: all proof checks (seq_contiguous, artifact uniqueness, etc.)
+    - make_session_id
+    - make_planned_participant *)
+
+open Agent_sdk
+
+(* ── Helpers ────────────────────────────────────────────── *)
+
+let mk_event ?(seq = 1) ?(ts = 100.0) kind : Runtime.event =
+  { seq; ts; kind }
+
+let mk_start_request ?(goal = "test") ?(participants = []) () : Runtime.start_request =
+  { session_id = None; goal; participants;
+    provider = Some "anthropic"; model = Some "sonnet-4-6";
+    permission_mode = None; system_prompt = Some "sys prompt";
+    max_turns = Some 5; workdir = Some "/tmp" }
+
+let mk_session
+    ?(session_id = "s-001")
+    ?(goal = "test")
+    ?(phase = Runtime.Running)
+    ?(participants = [])
+    ?(artifacts = [])
+    ?(votes = [])
+    ?(outcome = None)
+    ?(turn_count = 0)
+    ?(last_seq = 0)
+    () : Runtime.session =
+  {
+    session_id; goal; title = None; tag = None;
+    permission_mode = None; phase;
+    created_at = 100.0; updated_at = 200.0;
+    provider = Some "anthropic"; model = Some "sonnet-4-6";
+    system_prompt = Some "sys"; max_turns = 10;
+    workdir = Some "/tmp";
+    planned_participants = List.map (fun (p : Runtime.participant) -> p.name) participants;
+    participants; artifacts; votes;
+    turn_count; last_seq; outcome;
+  }
+
+let mk_participant
+    ?(name = "alice")
+    ?(state = Runtime.Planned)
+    ?(started_at = None)
+    () : Runtime.participant =
+  {
+    name; role = None; aliases = []; worker_id = None;
+    runtime_actor = None; requested_provider = None;
+    requested_model = None; requested_policy = None;
+    provider = None; model = None;
+    resolved_provider = None; resolved_model = None;
+    state; summary = None;
+    accepted_at = None; ready_at = None;
+    first_progress_at = None; started_at;
+    finished_at = None; last_progress_at = None;
+    last_error = None;
+  }
+
+(* ── initial_session ──────────────────────────────────── *)
+
+let test_initial_session_basic () =
+  let req = mk_start_request ~goal:"deploy" ~participants:["alice"; "bob"] () in
+  let session = Runtime_projection.initial_session req in
+  Alcotest.(check string) "goal" "deploy" session.goal;
+  Alcotest.(check int) "2 participants" 2 (List.length session.participants);
+  Alcotest.(check bool) "phase Bootstrapping" true (session.phase = Runtime.Bootstrapping);
+  Alcotest.(check int) "max_turns" 5 session.max_turns;
+  Alcotest.(check (option string)) "provider" (Some "anthropic") session.provider;
+  Alcotest.(check int) "turn_count 0" 0 session.turn_count;
+  Alcotest.(check int) "last_seq 0" 0 session.last_seq
+
+let test_initial_session_defaults () =
+  let req : Runtime.start_request = {
+    session_id = None; goal = "g"; participants = [];
+    provider = None; model = None; permission_mode = None;
+    system_prompt = None; max_turns = None; workdir = None;
+  } in
+  let session = Runtime_projection.initial_session req in
+  Alcotest.(check int) "default max_turns=8" 8 session.max_turns;
+  Alcotest.(check bool) "session_id non-empty" true
+    (String.length session.session_id > 0)
+
+let test_initial_session_explicit_id () =
+  let req = { (mk_start_request ()) with session_id = Some "custom-id" } in
+  let session = Runtime_projection.initial_session req in
+  Alcotest.(check string) "custom id" "custom-id" session.session_id
+
+(* ── ensure_active_phase (tested via apply_event on terminal phases) ── *)
+
+let test_turn_on_running_ok () =
+  let session = mk_session ~phase:Running () in
+  let event = mk_event (Turn_recorded { actor = None; message = "x" }) in
+  match Runtime_projection.apply_event session event with
+  | Ok _ -> ()
+  | Error _ -> Alcotest.fail "Running should accept turns"
+
+let test_turn_on_bootstrapping_ok () =
+  let session = mk_session ~phase:Bootstrapping () in
+  let event = mk_event (Turn_recorded { actor = None; message = "x" }) in
+  match Runtime_projection.apply_event session event with
+  | Ok _ -> ()
+  | Error _ -> Alcotest.fail "Bootstrapping should accept turns"
+
+let test_turn_on_waiting_ok () =
+  let session = mk_session ~phase:Waiting_on_workers () in
+  let event = mk_event (Turn_recorded { actor = None; message = "x" }) in
+  match Runtime_projection.apply_event session event with
+  | Ok _ -> ()
+  | Error _ -> Alcotest.fail "Waiting should accept turns"
+
+let test_turn_on_finalizing_ok () =
+  let session = mk_session ~phase:Finalizing () in
+  let event = mk_event (Turn_recorded { actor = None; message = "x" }) in
+  match Runtime_projection.apply_event session event with
+  | Ok _ -> ()
+  | Error _ -> Alcotest.fail "Finalizing should accept turns"
+
+let test_turn_on_completed_fails () =
+  let session = mk_session ~phase:Completed () in
+  let event = mk_event (Turn_recorded { actor = None; message = "x" }) in
+  match Runtime_projection.apply_event session event with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "Completed should reject turns"
+
+let test_turn_on_failed_fails () =
+  let session = mk_session ~phase:Failed () in
+  let event = mk_event (Turn_recorded { actor = None; message = "x" }) in
+  match Runtime_projection.apply_event session event with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "Failed should reject turns"
+
+let test_turn_on_cancelled_fails () =
+  let session = mk_session ~phase:Cancelled () in
+  let event = mk_event (Turn_recorded { actor = None; message = "x" }) in
+  match Runtime_projection.apply_event session event with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "Cancelled should reject turns"
+
+(* ── apply_event: Session_started ─────────────────────── *)
+
+let test_apply_session_started () =
+  let session = mk_session ~phase:Bootstrapping () in
+  let event = mk_event (Session_started { goal = "test"; participants = [] }) in
+  match Runtime_projection.apply_event session event with
+  | Ok s -> Alcotest.(check bool) "Running" true (s.phase = Runtime.Running)
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+(* ── apply_event: Session_settings_updated ────────────── *)
+
+let test_apply_settings_updated () =
+  let session = mk_session () in
+  let event = mk_event (Session_settings_updated {
+    model = Some "new-model"; permission_mode = Some "auto";
+  }) in
+  match Runtime_projection.apply_event session event with
+  | Ok s ->
+    Alcotest.(check (option string)) "model" (Some "new-model") s.model;
+    Alcotest.(check (option string)) "perm" (Some "auto") s.permission_mode
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+(* ── apply_event: Turn_recorded ───────────────────────── *)
+
+let test_apply_turn_recorded () =
+  let session = mk_session ~turn_count:2 () in
+  let event = mk_event (Turn_recorded { actor = Some "alice"; message = "hello" }) in
+  match Runtime_projection.apply_event session event with
+  | Ok s -> Alcotest.(check int) "turn_count" 3 s.turn_count
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+let test_apply_turn_recorded_terminal_fails () =
+  let session = mk_session ~phase:Completed () in
+  let event = mk_event (Turn_recorded { actor = None; message = "x" }) in
+  match Runtime_projection.apply_event session event with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "should fail on terminal phase"
+
+(* ── apply_event: Agent_spawn_requested ───────────────── *)
+
+let test_apply_agent_spawn () =
+  let session = mk_session () in
+  let event = mk_event (Agent_spawn_requested {
+    participant_name = "bob"; role = Some "reviewer";
+    prompt = "review"; provider = Some "openai";
+    model = Some "gpt-4"; permission_mode = None;
+  }) in
+  match Runtime_projection.apply_event session event with
+  | Ok s ->
+    let bob = List.find (fun (p : Runtime.participant) -> p.name = "bob") s.participants in
+    Alcotest.(check bool) "state Starting" true (bob.state = Starting);
+    Alcotest.(check (option string)) "role" (Some "reviewer") bob.role;
+    Alcotest.(check (option string)) "req_provider" (Some "openai") bob.requested_provider
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+(* ── apply_event: Agent_became_live ───────────────────── *)
+
+let test_apply_agent_became_live () =
+  let p = mk_participant ~name:"alice" ~state:Starting () in
+  let session = mk_session ~participants:[p] () in
+  let event = mk_event (Agent_became_live {
+    participant_name = "alice"; summary = Some "ready";
+    provider = Some "anthropic"; model = Some "haiku"; error = None;
+  }) in
+  match Runtime_projection.apply_event session event with
+  | Ok s ->
+    let alice = List.hd s.participants in
+    Alcotest.(check bool) "Live" true (alice.state = Live);
+    Alcotest.(check (option string)) "summary" (Some "ready") alice.summary
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+(* ── apply_event: Agent_output_delta ──────────────────── *)
+
+let test_apply_agent_output_delta () =
+  let p = mk_participant ~name:"alice" ~state:Live () in
+  let session = mk_session ~participants:[p] () in
+  let event = mk_event (Agent_output_delta {
+    participant_name = "alice"; delta = "some output";
+  }) in
+  match Runtime_projection.apply_event session event with
+  | Ok s ->
+    let alice = List.hd s.participants in
+    Alcotest.(check bool) "still Live" true (alice.state = Live)
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+(* ── apply_event: Agent_completed ─────────────────────── *)
+
+let test_apply_agent_completed () =
+  let p = mk_participant ~name:"alice" ~state:Live ~started_at:(Some 90.0) () in
+  let session = mk_session ~participants:[p] () in
+  let event = mk_event ~ts:200.0 (Agent_completed {
+    participant_name = "alice"; summary = Some "done";
+    provider = None; model = None; error = None;
+  }) in
+  match Runtime_projection.apply_event session event with
+  | Ok s ->
+    let alice = List.hd s.participants in
+    Alcotest.(check bool) "Done" true (alice.state = Done);
+    Alcotest.(check (option string)) "summary" (Some "done") alice.summary;
+    Alcotest.(check bool) "finished_at" true (alice.finished_at = Some 200.0)
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+(* ── apply_event: Agent_failed ────────────────────────── *)
+
+let test_apply_agent_failed () =
+  let p = mk_participant ~name:"alice" ~state:Live () in
+  let session = mk_session ~participants:[p] () in
+  let event = mk_event ~ts:200.0 (Agent_failed {
+    participant_name = "alice"; summary = Some "crashed";
+    provider = None; model = None; error = Some "timeout";
+  }) in
+  match Runtime_projection.apply_event session event with
+  | Ok s ->
+    let alice = List.hd s.participants in
+    Alcotest.(check bool) "Failed_participant" true (alice.state = Failed_participant);
+    Alcotest.(check (option string)) "error" (Some "timeout") alice.last_error
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+(* ── apply_event: Artifact_attached ───────────────────── *)
+
+let test_apply_artifact_attached () =
+  let session = mk_session () in
+  let event = mk_event (Artifact_attached {
+    artifact_id = "art-1"; name = "report.md"; kind = "document";
+    mime_type = "text/markdown"; path = "/tmp/report.md"; size_bytes = 1024;
+  }) in
+  match Runtime_projection.apply_event session event with
+  | Ok s ->
+    Alcotest.(check int) "1 artifact" 1 (List.length s.artifacts);
+    let a = List.hd s.artifacts in
+    Alcotest.(check string) "id" "art-1" a.artifact_id
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+(* ── apply_event: Vote_recorded ───────────────────────── *)
+
+let test_apply_vote_recorded () =
+  let session = mk_session () in
+  let vote : Runtime.vote = {
+    topic = "ready"; options = ["yes"; "no"]; choice = "yes";
+    actor = Some "alice"; created_at = 100.0;
+  } in
+  let event = mk_event (Vote_recorded vote) in
+  match Runtime_projection.apply_event session event with
+  | Ok s -> Alcotest.(check int) "1 vote" 1 (List.length s.votes)
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+(* ── apply_event: Checkpoint_saved ────────────────────── *)
+
+let test_apply_checkpoint_saved () =
+  let session = mk_session () in
+  let event = mk_event (Checkpoint_saved { label = Some "cp1"; path = "/tmp/cp" }) in
+  match Runtime_projection.apply_event session event with
+  | Ok s -> Alcotest.(check string) "session unchanged" "s-001" s.session_id
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+(* ── apply_event: Finalize_requested ──────────────────── *)
+
+let test_apply_finalize_requested () =
+  let session = mk_session () in
+  let event = mk_event (Finalize_requested { reason = Some "done" }) in
+  match Runtime_projection.apply_event session event with
+  | Ok s ->
+    Alcotest.(check bool) "Finalizing" true (s.phase = Finalizing);
+    Alcotest.(check (option string)) "outcome" (Some "done") s.outcome
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+(* ── apply_event: Session_completed ───────────────────── *)
+
+let test_apply_session_completed () =
+  let session = mk_session () in
+  let event = mk_event ~ts:300.0 (Session_completed { outcome = Some "merged" }) in
+  match Runtime_projection.apply_event session event with
+  | Ok s ->
+    Alcotest.(check bool) "Completed" true (s.phase = Completed);
+    Alcotest.(check (option string)) "outcome" (Some "merged") s.outcome;
+    Alcotest.(check (float 0.01)) "updated_at" 300.0 s.updated_at
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+(* ── apply_event: Session_failed ──────────────────────── *)
+
+let test_apply_session_failed () =
+  let session = mk_session () in
+  let event = mk_event ~ts:300.0 (Session_failed { outcome = Some "error" }) in
+  match Runtime_projection.apply_event session event with
+  | Ok s ->
+    Alcotest.(check bool) "Failed" true (s.phase = Failed);
+    Alcotest.(check (option string)) "outcome" (Some "error") s.outcome
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+(* ── update_participant: new participant (not found) ──── *)
+
+let test_update_participant_new () =
+  let session = mk_session () in
+  let event = mk_event (Agent_spawn_requested {
+    participant_name = "new-agent"; role = Some "worker";
+    prompt = "do stuff"; provider = None; model = None; permission_mode = None;
+  }) in
+  match Runtime_projection.apply_event session event with
+  | Ok s ->
+    Alcotest.(check int) "1 participant added" 1 (List.length s.participants);
+    let p = List.hd s.participants in
+    Alcotest.(check string) "name" "new-agent" p.name
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+(* ── count_by_state (tested indirectly via build_report) ── *)
+
+let test_count_by_state_via_report () =
+  let p1 = mk_participant ~name:"a" ~state:Done () in
+  let p2 = mk_participant ~name:"b" ~state:Done () in
+  let p3 = mk_participant ~name:"c" ~state:Failed_participant () in
+  let session = mk_session ~phase:Completed ~participants:[p1; p2; p3] () in
+  let report = Runtime_projection.build_report session [] in
+  (* Report summary includes "Participants done: N" and "Participants failed: N" *)
+  let has needle = List.exists (fun line -> Util.string_contains ~needle line) report.summary in
+  Alcotest.(check bool) "done count 2" true (has "done: 2");
+  Alcotest.(check bool) "failed count 1" true (has "failed: 1")
+
+(* ── build_report ─────────────────────────────────────── *)
+
+let test_build_report_basic () =
+  let p1 = { (mk_participant ~name:"a" ~state:Done ()) with summary = Some "finished" } in
+  let p2 = { (mk_participant ~name:"b" ~state:Live ()) with summary = None } in
+  let session = mk_session ~session_id:"s-report" ~goal:"deploy"
+    ~phase:Completed ~participants:[p1; p2] ~turn_count:3 () in
+  let events = [
+    mk_event ~seq:1 (Session_started { goal = "deploy"; participants = [] });
+    mk_event ~seq:2 (Turn_recorded { actor = Some "a"; message = "hi" });
+  ] in
+  let report = Runtime_projection.build_report session events in
+  Alcotest.(check string) "session_id" "s-report" report.session_id;
+  Alcotest.(check bool) "summary non-empty" true (List.length report.summary > 0);
+  Alcotest.(check bool) "markdown non-empty" true (String.length report.markdown > 0);
+  (* Verify participant with None summary shows n/a *)
+  Alcotest.(check bool) "contains n/a" true
+    (Util.string_contains ~needle:"n/a" report.markdown)
+
+let test_build_report_empty () =
+  let session = mk_session ~phase:Completed () in
+  let report = Runtime_projection.build_report session [] in
+  Alcotest.(check string) "session_id" "s-001" report.session_id
+
+(* ── build_proof ──────────────────────────────────────── *)
+
+let test_build_proof_passing () =
+  let p = mk_participant ~name:"a" ~state:Done () in
+  let session = mk_session ~phase:Completed ~participants:[p] ~last_seq:4
+    ~artifacts:[{
+      artifact_id = "a1"; name = "f"; kind = "k"; mime_type = "t";
+      path = Some "/p"; inline_content = None; size_bytes = 0; created_at = 0.0;
+    }] () in
+  let events = [
+    mk_event ~seq:1 ~ts:10.0 (Session_started { goal = "g"; participants = [] });
+    mk_event ~seq:2 ~ts:20.0 (Turn_recorded { actor = None; message = "m" });
+    mk_event ~seq:3 ~ts:30.0 (Agent_completed {
+      participant_name = "a"; summary = None; provider = None; model = None; error = None;
+    });
+    mk_event ~seq:4 ~ts:40.0 (Session_completed { outcome = Some "ok" });
+  ] in
+  let proof = Runtime_projection.build_proof session events in
+  Alcotest.(check bool) "proof ok" true proof.ok;
+  Alcotest.(check bool) "all checks passed" true
+    (List.for_all (fun (c : Runtime.proof_check) -> c.passed) proof.checks)
+
+let test_build_proof_failing () =
+  let session = mk_session ~phase:Running () in
+  let events = [] in
+  let proof = Runtime_projection.build_proof session events in
+  Alcotest.(check bool) "proof not ok" false proof.ok;
+  (* seq_contiguous should fail for empty events *)
+  let seq_check = List.find (fun (c : Runtime.proof_check) -> c.name = "seq_contiguous") proof.checks in
+  Alcotest.(check bool) "seq_contiguous fails" false seq_check.passed
+
+let test_build_proof_duplicate_artifact_ids () =
+  let art1 : Runtime.artifact = {
+    artifact_id = "dup"; name = "a"; kind = "k"; mime_type = "m";
+    path = Some "/p"; inline_content = None; size_bytes = 0; created_at = 0.0;
+  } in
+  let art2 = { art1 with name = "b" } in
+  let session = mk_session ~phase:Completed ~artifacts:[art1; art2] () in
+  let events = [
+    mk_event ~seq:1 (Session_started { goal = "g"; participants = [] });
+    mk_event ~seq:2 (Session_completed { outcome = None });
+  ] in
+  let proof = Runtime_projection.build_proof session events in
+  let artifact_check = List.find (fun (c : Runtime.proof_check) -> c.name = "artifact_ids_unique") proof.checks in
+  Alcotest.(check bool) "artifact_ids_unique fails" false artifact_check.passed
+
+let test_build_proof_non_contiguous_seq () =
+  let session = mk_session ~phase:Completed () in
+  let events = [
+    mk_event ~seq:1 (Session_started { goal = "g"; participants = [] });
+    mk_event ~seq:3 (Session_completed { outcome = None });
+  ] in
+  let proof = Runtime_projection.build_proof session events in
+  let seq_check = List.find (fun (c : Runtime.proof_check) -> c.name = "seq_contiguous") proof.checks in
+  Alcotest.(check bool) "seq_contiguous fails" false seq_check.passed
+
+(* ── apply multiple events ────────────────────────────── *)
+
+let test_apply_event_sequence () =
+  let req = mk_start_request ~goal:"full flow" ~participants:["alice"] () in
+  let session = Runtime_projection.initial_session req in
+  let events = [
+    mk_event ~seq:1 ~ts:10.0 (Session_started { goal = "full flow"; participants = ["alice"] });
+    mk_event ~seq:2 ~ts:20.0 (Turn_recorded { actor = Some "user"; message = "do it" });
+    mk_event ~seq:3 ~ts:30.0 (Agent_spawn_requested {
+      participant_name = "alice"; role = Some "exec"; prompt = "go";
+      provider = None; model = None; permission_mode = None;
+    });
+    mk_event ~seq:4 ~ts:40.0 (Agent_became_live {
+      participant_name = "alice"; summary = None;
+      provider = Some "anthropic"; model = Some "sonnet"; error = None;
+    });
+    mk_event ~seq:5 ~ts:50.0 (Agent_completed {
+      participant_name = "alice"; summary = Some "completed";
+      provider = None; model = None; error = None;
+    });
+    mk_event ~seq:6 ~ts:60.0 (Session_completed { outcome = Some "success" });
+  ] in
+  let result = List.fold_left (fun session event ->
+    match session with
+    | Error e -> Error e
+    | Ok s -> Runtime_projection.apply_event s event
+  ) (Ok session) events in
+  match result with
+  | Ok final ->
+    Alcotest.(check bool) "Completed" true (final.phase = Completed);
+    Alcotest.(check int) "turn_count" 1 final.turn_count;
+    Alcotest.(check (option string)) "outcome" (Some "success") final.outcome;
+    let alice = List.find (fun (p : Runtime.participant) -> p.name = "alice") final.participants in
+    Alcotest.(check bool) "alice Done" true (alice.state = Done)
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+(* ── Test runner ───────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Runtime_projection_cov2" [
+    "initial_session", [
+      Alcotest.test_case "basic" `Quick test_initial_session_basic;
+      Alcotest.test_case "defaults" `Quick test_initial_session_defaults;
+      Alcotest.test_case "explicit id" `Quick test_initial_session_explicit_id;
+    ];
+    "ensure_active_phase", [
+      Alcotest.test_case "Running ok" `Quick test_turn_on_running_ok;
+      Alcotest.test_case "Bootstrapping ok" `Quick test_turn_on_bootstrapping_ok;
+      Alcotest.test_case "Waiting ok" `Quick test_turn_on_waiting_ok;
+      Alcotest.test_case "Finalizing ok" `Quick test_turn_on_finalizing_ok;
+      Alcotest.test_case "Completed fails" `Quick test_turn_on_completed_fails;
+      Alcotest.test_case "Failed fails" `Quick test_turn_on_failed_fails;
+      Alcotest.test_case "Cancelled fails" `Quick test_turn_on_cancelled_fails;
+    ];
+    "apply_event", [
+      Alcotest.test_case "Session_started" `Quick test_apply_session_started;
+      Alcotest.test_case "Settings_updated" `Quick test_apply_settings_updated;
+      Alcotest.test_case "Turn_recorded" `Quick test_apply_turn_recorded;
+      Alcotest.test_case "Turn terminal fails" `Quick test_apply_turn_recorded_terminal_fails;
+      Alcotest.test_case "Spawn_requested" `Quick test_apply_agent_spawn;
+      Alcotest.test_case "Became_live" `Quick test_apply_agent_became_live;
+      Alcotest.test_case "Output_delta" `Quick test_apply_agent_output_delta;
+      Alcotest.test_case "Completed" `Quick test_apply_agent_completed;
+      Alcotest.test_case "Failed" `Quick test_apply_agent_failed;
+      Alcotest.test_case "Artifact_attached" `Quick test_apply_artifact_attached;
+      Alcotest.test_case "Vote_recorded" `Quick test_apply_vote_recorded;
+      Alcotest.test_case "Checkpoint_saved" `Quick test_apply_checkpoint_saved;
+      Alcotest.test_case "Finalize_requested" `Quick test_apply_finalize_requested;
+      Alcotest.test_case "Session_completed" `Quick test_apply_session_completed;
+      Alcotest.test_case "Session_failed" `Quick test_apply_session_failed;
+      Alcotest.test_case "new participant" `Quick test_update_participant_new;
+    ];
+    "count_by_state", [
+      Alcotest.test_case "via report" `Quick test_count_by_state_via_report;
+    ];
+    "build_report", [
+      Alcotest.test_case "basic" `Quick test_build_report_basic;
+      Alcotest.test_case "empty" `Quick test_build_report_empty;
+    ];
+    "build_proof", [
+      Alcotest.test_case "passing" `Quick test_build_proof_passing;
+      Alcotest.test_case "failing" `Quick test_build_proof_failing;
+      Alcotest.test_case "duplicate artifact ids" `Quick test_build_proof_duplicate_artifact_ids;
+      Alcotest.test_case "non-contiguous seq" `Quick test_build_proof_non_contiguous_seq;
+    ];
+    "integration", [
+      Alcotest.test_case "full event sequence" `Quick test_apply_event_sequence;
+    ];
+  ]

--- a/test/test_skill_coverage2.ml
+++ b/test/test_skill_coverage2.ml
@@ -1,0 +1,455 @@
+(** Extended Skill and Skill_registry coverage — targeting remaining uncovered paths.
+
+    Existing tests cover:
+    - strip_quotes, split_csv, replace_all, parse_frontmatter basics
+    - frontmatter_value/values, scope_of_string
+    - of_markdown (full/no_frontmatter/name_from_path)
+    - render_prompt (no_args/$ARGUMENTS/mustache/both)
+    - supporting_file_paths (no_path/with_path)
+    - load nonexistent, show functions
+    - Skill_registry CRUD, JSON roundtrip, load_from_dir missing
+
+    This file targets uncovered paths in:
+    - Skill.ml: parse_frontmatter with blank lines before/inside,
+      assoc_replace duplicate keys, of_markdown with scope from arg,
+      of_markdown with allowed_tools via allowed-tools AND allowed_tools keys,
+      of_markdown with argument_hint via underscore key,
+      of_markdown with supporting_files via underscore key,
+      replace_all at boundary positions, load_dir (real directory),
+      load_dir ignoring dotfiles and non-.md files
+    - Skill_registry.ml: skill_to_json with scope, load_from_dir success,
+      skill_of_json with allowed_tools as non-list,
+      of_json error paths *)
+
+open Agent_sdk
+
+(* ── Skill: parse_frontmatter edge cases ──────────────── *)
+
+let test_parse_frontmatter_leading_blank_lines () =
+  let md = "\n\n---\nname: test\n---\nBody" in
+  let fm, body = Skill.parse_frontmatter md in
+  Alcotest.(check (option string)) "name" (Some "test")
+    (Skill.frontmatter_value fm "name");
+  Alcotest.(check string) "body" "Body" body
+
+let test_parse_frontmatter_blank_inside () =
+  let md = "---\nname: test\n\ndescription: desc\n---\nBody" in
+  let fm, body = Skill.parse_frontmatter md in
+  Alcotest.(check (option string)) "name" (Some "test")
+    (Skill.frontmatter_value fm "name");
+  Alcotest.(check (option string)) "desc" (Some "desc")
+    (Skill.frontmatter_value fm "description");
+  Alcotest.(check string) "body" "Body" body
+
+let test_parse_frontmatter_comment_line () =
+  let md = "---\nname: test\n# this is a comment\ndescription: desc\n---\nBody" in
+  let fm, body = Skill.parse_frontmatter md in
+  Alcotest.(check (option string)) "name" (Some "test")
+    (Skill.frontmatter_value fm "name");
+  Alcotest.(check (option string)) "desc" (Some "desc")
+    (Skill.frontmatter_value fm "description");
+  Alcotest.(check string) "body" "Body" body
+
+let test_parse_frontmatter_no_closing () =
+  let md = "---\nname: test\nno closing delimiter" in
+  let fm, body = Skill.parse_frontmatter md in
+  Alcotest.(check (option string)) "name" (Some "test")
+    (Skill.frontmatter_value fm "name");
+  Alcotest.(check string) "body empty" "" body
+
+let test_parse_frontmatter_no_colon () =
+  let md = "---\nname: test\nweird line without colon\ndescription: d\n---\nBody" in
+  let fm, body = Skill.parse_frontmatter md in
+  Alcotest.(check (option string)) "name" (Some "test")
+    (Skill.frontmatter_value fm "name");
+  Alcotest.(check string) "body" "Body" body
+
+let test_parse_frontmatter_duplicate_key () =
+  let md = "---\nname: first\nname: second\n---\nBody" in
+  let fm, body = Skill.parse_frontmatter md in
+  Alcotest.(check (option string)) "name replaced" (Some "second")
+    (Skill.frontmatter_value fm "name");
+  Alcotest.(check string) "body" "Body" body
+
+let test_parse_frontmatter_list_item_no_current_key () =
+  let md = "---\n- orphan_item\nname: test\n---\nBody" in
+  let fm, body = Skill.parse_frontmatter md in
+  Alcotest.(check (option string)) "name" (Some "test")
+    (Skill.frontmatter_value fm "name");
+  Alcotest.(check string) "body" "Body" body
+
+let test_parse_frontmatter_key_empty_then_list () =
+  let md = "---\ntools:\n- bash\n- read\n---\nBody" in
+  let fm, _body = Skill.parse_frontmatter md in
+  let tools = Skill.frontmatter_values fm "tools" in
+  Alcotest.(check (list string)) "tools" ["bash"; "read"] tools
+
+(* ── Skill: of_markdown with scope from arg ───────────── *)
+
+let test_of_markdown_scope_from_arg () =
+  let skill = Skill.of_markdown ~scope:User "Body" in
+  (match skill.scope with
+   | Some Skill.User -> ()
+   | _ -> Alcotest.fail "expected User scope from arg")
+
+let test_of_markdown_scope_from_frontmatter_overrides_arg () =
+  let md = "---\nscope: local\n---\nBody" in
+  let skill = Skill.of_markdown ~scope:Project md in
+  (match skill.scope with
+   | Some Skill.Local -> ()
+   | _ -> Alcotest.fail "frontmatter scope should override arg")
+
+(* ── Skill: of_markdown allowed_tools via underscore key ── *)
+
+let test_of_markdown_allowed_tools_underscore () =
+  let md = "---\nname: test\nallowed_tools: [bash, read]\n---\nBody" in
+  let skill = Skill.of_markdown md in
+  Alcotest.(check (list string)) "tools underscore" ["bash"; "read"] skill.allowed_tools
+
+let test_of_markdown_allowed_tools_both_keys () =
+  let md = "---\nname: test\nallowed-tools: [bash]\nallowed_tools: [read]\n---\nBody" in
+  let skill = Skill.of_markdown md in
+  (* Both keys are concatenated *)
+  Alcotest.(check int) "2 tools" 2 (List.length skill.allowed_tools)
+
+(* ── Skill: of_markdown argument_hint underscore ──────── *)
+
+let test_of_markdown_argument_hint_underscore () =
+  let md = "---\nname: test\nargument_hint: <file>\n---\nBody" in
+  let skill = Skill.of_markdown md in
+  Alcotest.(check (option string)) "hint" (Some "<file>") skill.argument_hint
+
+let test_of_markdown_argument_hint_dash_overrides () =
+  let md = "---\nname: test\nargument-hint: <from-dash>\nargument_hint: <from-underscore>\n---\nBody" in
+  let skill = Skill.of_markdown md in
+  (* Dash key has priority *)
+  Alcotest.(check (option string)) "hint from dash" (Some "<from-dash>") skill.argument_hint
+
+(* ── Skill: of_markdown supporting_files underscore ───── *)
+
+let test_of_markdown_supporting_files_underscore () =
+  let md = "---\nname: test\nsupporting_files: [helpers.sh]\n---\nBody" in
+  let skill = Skill.of_markdown md in
+  Alcotest.(check (list string)) "files" ["helpers.sh"] skill.supporting_files
+
+let test_of_markdown_supporting_files_both () =
+  let md = "---\nname: test\nsupporting-files: [a.sh]\nsupporting_files: [b.sh]\n---\nBody" in
+  let skill = Skill.of_markdown md in
+  Alcotest.(check int) "2 files" 2 (List.length skill.supporting_files)
+
+(* ── Skill: replace_all boundary positions ────────────── *)
+
+let test_replace_all_at_start () =
+  let result = Skill.replace_all ~pattern:"ABC" ~replacement:"X" "ABCdef" in
+  Alcotest.(check string) "start" "Xdef" result
+
+let test_replace_all_at_end () =
+  let result = Skill.replace_all ~pattern:"DEF" ~replacement:"X" "abcDEF" in
+  Alcotest.(check string) "end" "abcX" result
+
+let test_replace_all_whole_string () =
+  let result = Skill.replace_all ~pattern:"abc" ~replacement:"xyz" "abc" in
+  Alcotest.(check string) "whole" "xyz" result
+
+let test_replace_all_overlapping () =
+  let result = Skill.replace_all ~pattern:"aa" ~replacement:"b" "aaa" in
+  (* First match at 0: "aa" -> "b", then remaining "a" *)
+  Alcotest.(check string) "overlapping" "ba" result
+
+let test_replace_all_empty_text () =
+  let result = Skill.replace_all ~pattern:"x" ~replacement:"y" "" in
+  Alcotest.(check string) "empty text" "" result
+
+(* ── Skill: load_dir ──────────────────────────────────── *)
+
+let test_load_dir_real () =
+  let dir = Filename.temp_file "oas_skill_" "_dir" in
+  (* Remove the file and create a directory *)
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.remove (Filename.concat dir "test.md") with _ -> ());
+      (try Sys.remove (Filename.concat dir ".hidden.md") with _ -> ());
+      (try Sys.remove (Filename.concat dir "readme.txt") with _ -> ());
+      (try Unix.rmdir dir with _ -> ()))
+    (fun () ->
+      (* Create test files *)
+      let write_file path content =
+        let oc = open_out path in
+        output_string oc content;
+        close_out oc
+      in
+      write_file (Filename.concat dir "test.md")
+        "---\nname: test-skill\n---\nBody";
+      write_file (Filename.concat dir ".hidden.md")
+        "---\nname: hidden\n---\nHidden";
+      write_file (Filename.concat dir "readme.txt")
+        "Not a markdown file";
+      let skills = Skill.load_dir dir in
+      Alcotest.(check int) "1 visible .md file" 1 (List.length skills);
+      let s = List.hd skills in
+      Alcotest.(check string) "name" "test-skill" s.name)
+
+(* ── Skill: load success ──────────────────────────────── *)
+
+let test_load_success () =
+  let path = Filename.temp_file "oas_skill_" ".md" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      let oc = open_out path in
+      output_string oc "---\nname: loaded\ndescription: from file\n---\nBody content";
+      close_out oc;
+      match Skill.load path with
+      | Ok skill ->
+        Alcotest.(check string) "name" "loaded" skill.name;
+        Alcotest.(check (option string)) "desc" (Some "from file") skill.description;
+        Alcotest.(check string) "body" "Body content" skill.body;
+        Alcotest.(check (option string)) "path" (Some path) skill.path
+      | Error e -> Alcotest.fail (Error.to_string e))
+
+let test_load_with_scope () =
+  let path = Filename.temp_file "oas_skill_" ".md" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      let oc = open_out path in
+      output_string oc "---\nname: scoped\n---\nBody";
+      close_out oc;
+      match Skill.load ~scope:Project path with
+      | Ok skill ->
+        (match skill.scope with
+         | Some Skill.Project -> ()
+         | _ -> Alcotest.fail "expected Project scope")
+      | Error e -> Alcotest.fail (Error.to_string e))
+
+(* ── Skill: render_prompt no arguments (None branch) ──── *)
+
+let test_render_prompt_none_no_sub () =
+  let skill = Skill.of_markdown "Process $ARGUMENTS here" in
+  let result = Skill.render_prompt skill in
+  Alcotest.(check string) "no substitution" "Process $ARGUMENTS here" result
+
+(* ── Skill: supporting_file_paths empty list ──────────── *)
+
+let test_supporting_empty_list () =
+  let skill = { (Skill.of_markdown "") with
+    path = Some "/skills/s.md"; supporting_files = [] } in
+  let paths = Skill.supporting_file_paths skill in
+  Alcotest.(check (list string)) "empty" [] paths
+
+(* ── Skill_registry: skill_to_json with scope ─────────── *)
+
+let test_skill_to_json_with_scope () =
+  let skill = {
+    (Skill.of_markdown "---\nname: test\n---\nBody") with
+    scope = Some Project;
+  } in
+  let json = Skill_registry.skill_to_json skill in
+  let open Yojson.Safe.Util in
+  let scope_str = json |> member "scope" |> to_string in
+  Alcotest.(check bool) "scope present" true (String.length scope_str > 0)
+
+let test_skill_to_json_no_scope () =
+  let skill = Skill.of_markdown "---\nname: test\n---\nBody" in
+  let json = Skill_registry.skill_to_json skill in
+  let s = Yojson.Safe.to_string json in
+  Alcotest.(check bool) "no scope" false
+    (Util.string_contains ~needle:"\"scope\"" s)
+
+(* ── Skill_registry: load_from_dir success ────────────── *)
+
+let test_load_from_dir_success () =
+  let dir = Filename.temp_file "oas_reg_" "_dir" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.remove (Filename.concat dir "a.md") with _ -> ());
+      (try Sys.remove (Filename.concat dir "b.md") with _ -> ());
+      (try Unix.rmdir dir with _ -> ()))
+    (fun () ->
+      let write_file path content =
+        let oc = open_out path in
+        output_string oc content;
+        close_out oc
+      in
+      write_file (Filename.concat dir "a.md") "---\nname: alpha\n---\nAlpha";
+      write_file (Filename.concat dir "b.md") "---\nname: beta\n---\nBeta";
+      let reg = Skill_registry.create () in
+      match Skill_registry.load_from_dir reg dir with
+      | Ok count ->
+        Alcotest.(check int) "loaded 2" 2 count;
+        Alcotest.(check int) "registry count" 2 (Skill_registry.count reg)
+      | Error e -> Alcotest.fail (Error.to_string e))
+
+let test_load_from_dir_with_scope () =
+  let dir = Filename.temp_file "oas_reg_" "_dir" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.remove (Filename.concat dir "s.md") with _ -> ());
+      (try Unix.rmdir dir with _ -> ()))
+    (fun () ->
+      let oc = open_out (Filename.concat dir "s.md") in
+      output_string oc "---\nname: scoped\n---\nBody";
+      close_out oc;
+      let reg = Skill_registry.create () in
+      match Skill_registry.load_from_dir reg ~scope:User dir with
+      | Ok 1 -> ()
+      | _ -> Alcotest.fail "expected 1 skill loaded")
+
+(* ── Skill_registry: skill_of_json edge cases ─────────── *)
+
+let test_skill_of_json_allowed_tools_non_list () =
+  let json = `Assoc [
+    ("name", `String "t"); ("body", `String "b");
+    ("allowed_tools", `String "not-a-list");
+  ] in
+  match Skill_registry.skill_of_json json with
+  | Ok skill -> Alcotest.(check (list string)) "empty tools" [] skill.allowed_tools
+  | Error _ -> Alcotest.fail "should parse with non-list tools"
+
+let test_skill_of_json_supporting_files_non_list () =
+  let json = `Assoc [
+    ("name", `String "t"); ("body", `String "b");
+    ("supporting_files", `String "not-a-list");
+  ] in
+  match Skill_registry.skill_of_json json with
+  | Ok skill -> Alcotest.(check (list string)) "empty files" [] skill.supporting_files
+  | Error _ -> Alcotest.fail "should parse with non-list files"
+
+let test_skill_of_json_all_optional_present () =
+  let json = `Assoc [
+    ("name", `String "full");
+    ("body", `String "body");
+    ("description", `String "desc");
+    ("path", `String "/p");
+    ("model", `String "gpt");
+    ("argument_hint", `String "hint");
+    ("allowed_tools", `List [`String "bash"]);
+    ("supporting_files", `List [`String "f.sh"]);
+  ] in
+  match Skill_registry.skill_of_json json with
+  | Ok skill ->
+    Alcotest.(check (option string)) "desc" (Some "desc") skill.description;
+    Alcotest.(check (option string)) "path" (Some "/p") skill.path;
+    Alcotest.(check (option string)) "model" (Some "gpt") skill.model;
+    Alcotest.(check (option string)) "hint" (Some "hint") skill.argument_hint;
+    Alcotest.(check (list string)) "tools" ["bash"] skill.allowed_tools;
+    Alcotest.(check (list string)) "files" ["f.sh"] skill.supporting_files
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+let test_skill_of_json_mixed_array_items () =
+  let json = `Assoc [
+    ("name", `String "t"); ("body", `String "b");
+    ("allowed_tools", `List [`String "bash"; `Int 42; `String "read"]);
+  ] in
+  match Skill_registry.skill_of_json json with
+  | Ok skill ->
+    (* Int items are filtered out *)
+    Alcotest.(check (list string)) "2 tools" ["bash"; "read"] skill.allowed_tools
+  | Error _ -> Alcotest.fail "should parse filtering non-strings"
+
+(* ── Skill_registry: of_json additional error ─────────── *)
+
+let test_of_json_no_skills_key () =
+  let json = `Assoc [("count", `Int 0)] in
+  match Skill_registry.of_json json with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected error without skills key"
+
+(* ── Skill_registry: skill_to_json roundtrip completeness ── *)
+
+let test_skill_to_json_full_fields () =
+  let skill : Skill.t = {
+    name = "full"; description = Some "desc"; body = "body";
+    path = Some "/p"; scope = Some (Custom "team");
+    allowed_tools = ["bash"; "read"]; argument_hint = Some "<arg>";
+    model = Some "gpt-4"; supporting_files = ["h.sh"];
+    metadata = [];
+  } in
+  let json = Skill_registry.skill_to_json skill in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "name" "full" (json |> member "name" |> to_string);
+  Alcotest.(check string) "desc" "desc" (json |> member "description" |> to_string);
+  Alcotest.(check string) "body" "body" (json |> member "body" |> to_string);
+  Alcotest.(check string) "path" "/p" (json |> member "path" |> to_string);
+  Alcotest.(check string) "model" "gpt-4" (json |> member "model" |> to_string);
+  Alcotest.(check string) "hint" "<arg>" (json |> member "argument_hint" |> to_string);
+  let tools = json |> member "allowed_tools" |> to_list in
+  Alcotest.(check int) "2 tools" 2 (List.length tools);
+  let files = json |> member "supporting_files" |> to_list in
+  Alcotest.(check int) "1 file" 1 (List.length files)
+
+(* ── Test runner ───────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Skill_coverage2" [
+    "frontmatter_edge_cases", [
+      Alcotest.test_case "leading blank lines" `Quick test_parse_frontmatter_leading_blank_lines;
+      Alcotest.test_case "blank inside" `Quick test_parse_frontmatter_blank_inside;
+      Alcotest.test_case "comment line" `Quick test_parse_frontmatter_comment_line;
+      Alcotest.test_case "no closing" `Quick test_parse_frontmatter_no_closing;
+      Alcotest.test_case "no colon" `Quick test_parse_frontmatter_no_colon;
+      Alcotest.test_case "duplicate key" `Quick test_parse_frontmatter_duplicate_key;
+      Alcotest.test_case "orphan list item" `Quick test_parse_frontmatter_list_item_no_current_key;
+      Alcotest.test_case "empty key then list" `Quick test_parse_frontmatter_key_empty_then_list;
+    ];
+    "of_markdown_scope", [
+      Alcotest.test_case "scope from arg" `Quick test_of_markdown_scope_from_arg;
+      Alcotest.test_case "frontmatter overrides" `Quick test_of_markdown_scope_from_frontmatter_overrides_arg;
+    ];
+    "of_markdown_tools", [
+      Alcotest.test_case "underscore key" `Quick test_of_markdown_allowed_tools_underscore;
+      Alcotest.test_case "both keys" `Quick test_of_markdown_allowed_tools_both_keys;
+    ];
+    "of_markdown_hint", [
+      Alcotest.test_case "underscore key" `Quick test_of_markdown_argument_hint_underscore;
+      Alcotest.test_case "dash overrides" `Quick test_of_markdown_argument_hint_dash_overrides;
+    ];
+    "of_markdown_files", [
+      Alcotest.test_case "underscore key" `Quick test_of_markdown_supporting_files_underscore;
+      Alcotest.test_case "both keys" `Quick test_of_markdown_supporting_files_both;
+    ];
+    "replace_all_boundary", [
+      Alcotest.test_case "at start" `Quick test_replace_all_at_start;
+      Alcotest.test_case "at end" `Quick test_replace_all_at_end;
+      Alcotest.test_case "whole string" `Quick test_replace_all_whole_string;
+      Alcotest.test_case "overlapping" `Quick test_replace_all_overlapping;
+      Alcotest.test_case "empty text" `Quick test_replace_all_empty_text;
+    ];
+    "load", [
+      Alcotest.test_case "success" `Quick test_load_success;
+      Alcotest.test_case "with scope" `Quick test_load_with_scope;
+    ];
+    "load_dir", [
+      Alcotest.test_case "real dir" `Quick test_load_dir_real;
+    ];
+    "render_prompt", [
+      Alcotest.test_case "None no sub" `Quick test_render_prompt_none_no_sub;
+    ];
+    "supporting_paths", [
+      Alcotest.test_case "empty list" `Quick test_supporting_empty_list;
+    ];
+    "registry_to_json", [
+      Alcotest.test_case "with scope" `Quick test_skill_to_json_with_scope;
+      Alcotest.test_case "no scope" `Quick test_skill_to_json_no_scope;
+      Alcotest.test_case "full fields" `Quick test_skill_to_json_full_fields;
+    ];
+    "registry_load_from_dir", [
+      Alcotest.test_case "success" `Quick test_load_from_dir_success;
+      Alcotest.test_case "with scope" `Quick test_load_from_dir_with_scope;
+    ];
+    "registry_skill_of_json", [
+      Alcotest.test_case "non-list tools" `Quick test_skill_of_json_allowed_tools_non_list;
+      Alcotest.test_case "non-list files" `Quick test_skill_of_json_supporting_files_non_list;
+      Alcotest.test_case "all optional" `Quick test_skill_of_json_all_optional_present;
+      Alcotest.test_case "mixed array" `Quick test_skill_of_json_mixed_array_items;
+    ];
+    "registry_of_json", [
+      Alcotest.test_case "no skills key" `Quick test_of_json_no_skills_key;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- Coverage: 82.15% → **84.27%** (+299 points)
- 10 modules with expanded inline tests + 4 new external test files
- +4360 lines of test code, 0 failures

## Test plan
- [x] `dune build --root .` — 0 errors
- [x] `dune runtest --root .` — 0 failures
- [x] bisect coverage: 84.27%

🤖 Generated with [Claude Code](https://claude.com/claude-code)