### PR TITLE
docs: CHANGELOG + README for v0.76.0 and v0.77.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to `agent_sdk` are documented in this file.
 
+## [0.77.0] - 2026-03-20
+
+### Added
+- **Plan module** (`Plan`): goal decomposition into ordered steps with dependency DAG. Step lifecycle (Pending/Running/Done/Failed/Skipped), re-planning, progress tracking, JSON serialization. Complementary to Durable (Plan = what to do, Durable = how to execute reliably). 20 tests.
+- `examples/plan_execute_demo.ml`: 4 scenarios (linear deployment, re-planning after failure, serialization, dependency graph).
+
+### Design decisions
+- Norm module deferred to MASC. Norms are inter-agent (social), not intra-agent. Principle: "agent itself = OAS, MASC = consumer".
+
+## [0.76.0] - 2026-03-20
+
+### Added
+- **Governance layer**: runtime governance for agent decisions.
+  - `Policy`: priority-ordered rule evaluation at 6 decision points (BeforeToolCall, BeforeHandoff, BeforeResponse, ResourceRequest, BeforeMemoryWrite, Custom) with 4 verdicts (Allow, Deny, AllowWithCondition, Escalate). 11 tests.
+  - `Audit`: immutable log of policy decisions with capacity eviction, query filters, JSON export. 11 tests.
+  - `Durable`: typed step chains with execution journal for crash recovery. Execute/resume/suspend with retry. JSON round-trip. 20 tests.
+- `test_governance_integration.ml`: 9 integration tests (Policy+Audit, Durable+Audit, full governance flow).
+- `examples/governance_demo.ml`: 6 scenarios (tool governance, handoff escalation, resource budget, durable pipeline, resume, serialization).
+- `Fs_result`: Result-based filesystem operations replacing scattered try/with patterns.
+- `Memory_tools`: agent-facing memory store/recall/forget tools.
+- `Verified_output`: phantom-typed compile-time output verification (`unverified`/`verified` type tags).
+- `Memory_access`: deny-by-default agent-scoped permission layer (prefix-based key patterns).
+- Gemini native backend: `contents/parts` wire format, `thinkingConfig`, `functionCall/Response`, SSE streaming. 30 tests.
+- Inline tests via `ppx_inline_test` for 13 modules.
+
+### Changed
+- 5 files migrated to `Fs_result`, removing 143 lines of duplicated I/O.
+- `Thread.create` replaced with `Eio.Fiber.fork` in runtime server.
+- `Digest.string` replaced with stable hash; 18 bare catch-all patterns eliminated.
+
 ## [0.75.0] - 2026-03-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # OAS — OCaml Agent SDK
 
-OCaml 5.x + Eio 기반 에이전트 SDK. v0.76.0.
+OCaml 5.x + Eio 기반 에이전트 SDK. v0.77.0.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/jeong-sik/oas/actions/workflows/ci.yml/badge.svg)](https://github.com/jeong-sik/oas/actions/workflows/ci.yml)
 
-A native OCaml implementation of the Anthropic Agent SDK using OCaml 5.x + Eio for structured concurrency. Supports Anthropic Messages API, OpenAI-compatible endpoints, and Ollama.
+A native OCaml implementation of the Anthropic Agent SDK using OCaml 5.x + Eio for structured concurrency. Supports Anthropic Messages API, OpenAI-compatible endpoints, and Gemini.
 
 - OCaml package: `agent_sdk`
 - OCaml module: `Agent_sdk`
@@ -66,7 +66,7 @@ let agent =
     ~tools:[] ()
 ```
 
-See `examples/` for more: `basic_agent.ml`, `tool_use.ml`, `streaming.ml`, `review_agent.ml`, `swarm_review.ml`.
+See `examples/` for more: `basic_agent.ml`, `tool_use.ml`, `streaming.ml`, `review_agent.ml`, `swarm_review.ml`, `governance_demo.ml`, `plan_execute_demo.ml`.
 
 ## Provider support
 
@@ -75,7 +75,7 @@ See `examples/` for more: `basic_agent.ml`, `tool_use.ml`, `streaming.ml`, `revi
 | Local (llama-server) | `Provider.Local { base_url }` | `http://127.0.0.1:8085` |
 | Anthropic | `Provider.Anthropic` | `https://api.anthropic.com` |
 | OpenAI-compatible | `Provider.OpenAICompat { base_url; ... }` | Any `/chat/completions` |
-| Ollama | `Provider.Ollama { base_url; mode }` | `http://127.0.0.1:11434` |
+| Gemini | `Provider.Gemini` | `https://generativelanguage.googleapis.com` |
 | OpenRouter | `Provider.openrouter ()` | `https://openrouter.ai/api/v1` |
 
 `Provider.resolve` returns `(base_url * api_key * headers, sdk_error) result`. Missing env vars produce `Error`, not silent fallback.
@@ -121,6 +121,13 @@ Layer 1: agent_sdk  (lib/)
 | `Streaming` | Multi-provider SSE parsing (Anthropic + OpenAI-compatible) |
 | `Pipeline` | 6-stage turn pipeline with Provider_intf routing |
 | `Contract` | Runtime contracts: instruction layers, triggers, tool grants |
+| `Memory` | 5-tier memory: Scratchpad, Working, Episodic, Procedural, Long_term |
+| `Memory_access` | Deny-by-default agent-scoped memory permissions |
+| `Verified_output` | Phantom-typed compile-time output verification |
+| `Policy` | Priority-ordered rule evaluation at decision points |
+| `Audit` | Immutable log of policy decisions and agent actions |
+| `Durable` | Typed step chains with execution journal for crash recovery |
+| `Plan` | Goal decomposition with dependency DAG and re-planning |
 
 ### Layer 2: Swarm Engine (`agent_sdk_swarm`)
 
@@ -141,11 +148,11 @@ Not all modules are equally stable. Use this to gauge risk when depending on a m
 
 **Evolving** -- API may change between minor versions:
 
-`Streaming`, `Structured`, `Orchestrator`, `Checkpoint`, `Mcp`, `Session`, `Skill`, `Subagent`, `Handoff`, `Contract`, `Context_reducer`, `Event_bus`, `Pipeline`, `Error_domain`, `Provider_intf`
+`Streaming`, `Structured`, `Orchestrator`, `Checkpoint`, `Mcp`, `Session`, `Skill`, `Subagent`, `Handoff`, `Contract`, `Context_reducer`, `Event_bus`, `Pipeline`, `Error_domain`, `Provider_intf`, `Memory`, `Memory_access`, `Collaboration`
 
 **Experimental** -- may be redesigned or removed:
 
-`Runtime`, `Transport`, `Client`, `Sessions`, `Conformance`, `Direct_evidence`, `Raw_trace`, `Otel_tracer`, `Checkpoint_store`, `Swarm_checkpoint`
+`Runtime`, `Transport`, `Client`, `Sessions`, `Conformance`, `Direct_evidence`, `Raw_trace`, `Otel_tracer`, `Checkpoint_store`, `Swarm_checkpoint`, `Verified_output`, `Policy`, `Audit`, `Durable`, `Plan`
 
 ## Tool definition
 
@@ -247,7 +254,7 @@ dune exec examples/review_agent.exe -- jeong-sik/oas 123
 
 ## Versioning
 
-0.50.0
+0.77.0
 
 We follow semver intent within the 0.x series:
 - **0.x.0**: May contain breaking changes with migration guide in CHANGELOG.


### PR DESCRIPTION
## Summary
- CHANGELOG: v0.76.0 (Governance) + v0.77.0 (Plan) entries
- README: version 0.50.0 → 0.77.0, Ollama → Gemini, 7 new modules, stability tiers updated, examples list expanded
- CLAUDE.md version sync