### PR TITLE
fix: eliminate file handle leaks, complete Fs_result migration

### DIFF
--- a/lib/append_instruction.ml
+++ b/lib/append_instruction.ml
@@ -29,14 +29,11 @@ let render_source ?context ~turn = function
         | None -> None)
      | None -> None)
   | FromFile path ->
-    (try
-       let ic = open_in_bin path in
-       Fun.protect
-         ~finally:(fun () -> close_in_noerr ic)
-         (fun () -> Some (really_input_string ic (in_channel_length ic)))
-     with exn ->
+    (match Fs_result.read_file path with
+     | Ok content -> Some content
+     | Error err ->
        let _ = Printf.eprintf "[append_instruction] FromFile %s failed: %s\n%!"
-         path (Printexc.to_string exn) in
+         path (Error.to_string err) in
        None)
   | Dynamic f -> f turn
 

--- a/lib/eval_baseline.ml
+++ b/lib/eval_baseline.ml
@@ -36,26 +36,16 @@ let save ~path (baseline : baseline) =
     ("created_at", `Float baseline.created_at);
     ("description", `String baseline.description);
   ] in
-  try
-    let oc = open_out path in
-    Fun.protect
-      ~finally:(fun () -> close_out_noerr oc)
-      (fun () -> output_string oc (Yojson.Safe.pretty_to_string json));
-    Ok ()
-  with exn ->
-    Error (Printf.sprintf "Failed to save baseline: %s" (Printexc.to_string exn))
+  match Fs_result.write_file path (Yojson.Safe.pretty_to_string json) with
+  | Ok () -> Ok ()
+  | Error err -> Error (Printf.sprintf "Failed to save baseline: %s" (Error.to_string err))
 
 (** Load a baseline from a JSON file. *)
 let load ~path : (baseline, string) result =
   try
-    let ic = open_in path in
-    let content = Fun.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () ->
-        let len = in_channel_length ic in
-        let buf = Bytes.create len in
-        really_input ic buf 0 len;
-        Bytes.to_string buf)
+    let content = match Fs_result.read_file path with
+      | Ok c -> c
+      | Error err -> failwith (Error.to_string err)
     in
     let json = Yojson.Safe.from_string content in
     let open Yojson.Safe.Util in

--- a/lib/event_forward.ml
+++ b/lib/event_forward.ml
@@ -129,18 +129,17 @@ let create ~targets ?(batch_size = 10)
 (* ── Delivery ─────────────────────────────────────────────────── *)
 
 let deliver_to_file t path payloads =
-  let lines = List.map (fun p ->
-    Yojson.Safe.to_string (payload_to_json p) ^ "\n"
-  ) payloads in
-  try
-    let oc = open_out_gen [Open_append; Open_creat; Open_wronly] 0o644 path in
-    List.iter (output_string oc) lines;
-    close_out oc;
+  let content = String.concat ""
+    (List.map (fun p ->
+      Yojson.Safe.to_string (payload_to_json p) ^ "\n"
+    ) payloads) in
+  match Fs_result.append_file path content with
+  | Ok () ->
     t.delivered_count <- t.delivered_count + List.length payloads
-  with exn ->
+  | Error err ->
     t.failed_count <- t.failed_count + List.length payloads;
     Log.warn t.log "file delivery failed"
-      [Log.S ("path", path); Log.S ("error", Printexc.to_string exn)]
+      [Log.S ("path", path); Log.S ("error", Error.to_string err)]
 
 let deliver_to_custom t name deliver payloads =
   List.iter (fun p ->

--- a/lib/skill.ml
+++ b/lib/skill.ml
@@ -175,14 +175,9 @@ let of_markdown ?path ?scope markdown =
   }
 
 let load ?scope path =
-  try
-    let ch = open_in_bin path in
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ch)
-      (fun () ->
-        let content = really_input_string ch (in_channel_length ch) in
-        Ok (of_markdown ~path ?scope content))
-  with exn -> Error (Error.Io (FileOpFailed { op = "load"; path; detail = Printexc.to_string exn }))
+  match Fs_result.read_file path with
+  | Error _ as err -> err
+  | Ok content -> Ok (of_markdown ~path ?scope content)
 
 let load_dir ?scope dir =
   Sys.readdir dir

--- a/lib/subagent.ml
+++ b/lib/subagent.ml
@@ -126,28 +126,24 @@ let of_markdown ?path ?(skills = []) markdown =
 (* --- File loading with skill resolution --- *)
 
 let load ?(skill_roots = []) path =
-  try
-    let ch = open_in_bin path in
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ch)
-      (fun () ->
-        let content = really_input_string ch (in_channel_length ch) in
-        let initial = of_markdown ~path content in
-        let base_dirs = (Filename.dirname path) :: skill_roots in
-        let resolve ref_name =
-          let candidates =
-            ref_name :: List.map (fun d -> Filename.concat d ref_name) base_dirs
-          in
-          match List.find_opt Sys.file_exists candidates with
-          | Some p ->
-            (match Skill.load p with
-             | Ok skill -> Some skill
-             | Error _ -> None)
-          | None -> None
-        in
-        let resolved = List.filter_map resolve initial.skill_refs in
-        Ok { initial with skills = resolved })
-  with exn -> Error (Error.Io (FileOpFailed { op = "load"; path; detail = Printexc.to_string exn }))
+  match Fs_result.read_file path with
+  | Error _ as err -> err
+  | Ok content ->
+    let initial = of_markdown ~path content in
+    let base_dirs = (Filename.dirname path) :: skill_roots in
+    let resolve ref_name =
+      let candidates =
+        ref_name :: List.map (fun d -> Filename.concat d ref_name) base_dirs
+      in
+      match List.find_opt Sys.file_exists candidates with
+      | Some p ->
+        (match Skill.load p with
+         | Ok skill -> Some skill
+         | Error _ -> None)
+      | None -> None
+    in
+    let resolved = List.filter_map resolve initial.skill_refs in
+    Ok { initial with skills = resolved }
 
 (* --- Prompt composition --- *)
 


### PR DESCRIPTION
## Summary
- `event_forward.ml`: 실제 file descriptor leak 수정 (open_out_gen 후 예외 시 close 미실행)
- 나머지 4파일: blocking I/O → `Fs_result` 전환으로 lib/ 전체 I/O 통일 완료
- −23줄 순삭제

## Context
PR #265(Fs_result 모듈) + #267(5파일 전환) 이후 남아있던 마지막 blocking I/O 파일들.
이 PR로 `lib/` 내 모든 파일 I/O가 `Fs_result`를 경유합니다.

## Test plan
- [x] `dune build` 통과
- [x] `dune runtest` 전체 통과
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)