### PR TITLE
fix: catch Gemini_api_error in api.ml (uncaught exception)

### DIFF
--- a/lib/api.ml
+++ b/lib/api.ml
@@ -118,6 +118,8 @@ let create_message ~sw ~net ?(base_url=default_base_url) ?provider ?clock ?retry
       Error (Retry.NetworkError { message = Printexc.to_string exn })
     | Api_openai.Openai_api_error msg ->
       Error (Retry.InvalidRequest { message = msg })
+    | Llm_provider.Backend_gemini.Gemini_api_error msg ->
+      Error (Retry.InvalidRequest { message = msg })
     | Failure msg ->
       Error (Retry.NetworkError { message = msg })
     | Yojson.Json_error msg ->


### PR DESCRIPTION
## Summary
`api.ml`의 error handler에 `Gemini_api_error` catch가 누락되어 있었습니다.

Gemini API가 에러를 반환하면 `parse_response` → `raise (Gemini_api_error msg)` → api.ml catch를 통과 → uncaught exception으로 fiber 사망.

`Openai_api_error`와 동일하게 `Retry.InvalidRequest`로 변환하도록 2줄 추가.

## Root Cause
`api.ml`은 Anthropic 시절에 작성되어 `Openai_api_error`만 처리. Gemini backend(PR #263) 추가 시 catch가 누락됨.

## Test plan
- [x] `dune build` 통과
- [x] `dune runtest` 통과
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)