### PR TITLE
refactor: unify buffer size constants, fix 1MB agent_registry limit

### DIFF
--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -8,8 +8,13 @@ open Types
 let default_base_url = "https://api.anthropic.com"
 let api_version = "2023-06-01"
 
-(** Maximum response body size (10 MB) *)
+(** Maximum HTTP response body size (10 MB).
+    Used for LLM API responses, MCP HTTP, and agent registry. *)
 let max_response_body = 10 * 1024 * 1024
+
+(** Maximum stdio process buffer size (16 MB).
+    Larger than HTTP because stdio carries full JSON-RPC frames. *)
+let max_stdio_buffer = 16 * 1024 * 1024
 
 let string_is_blank s =
   String.trim s = ""

--- a/lib/llm_provider/api_common.mli
+++ b/lib/llm_provider/api_common.mli
@@ -3,6 +3,7 @@
 val default_base_url : string
 val api_version : string
 val max_response_body : int
+val max_stdio_buffer : int
 
 val string_is_blank : string -> bool
 val text_blocks_to_string : Types.content_block list -> string

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -69,7 +69,7 @@ let post_stream ~sw ~net ~url ~headers ~body =
     in
     match Cohttp.Response.status resp with
     | `OK ->
-        Ok (Eio.Buf_read.of_flow ~max_size:(1024 * 1024 * 10) resp_body)
+        Ok (Eio.Buf_read.of_flow ~max_size:Api_common.max_response_body resp_body)
     | status ->
         let code = Cohttp.Code.code_of_status status in
         let body_str =

--- a/lib/protocol/agent_registry.ml
+++ b/lib/protocol/agent_registry.ml
@@ -86,7 +86,7 @@ let fetch_remote_card ~sw ~net url =
     in
     match Cohttp.Response.status resp with
     | `OK ->
-      let body_str = Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) in
+      let body_str = Eio.Buf_read.(of_flow ~max_size:Llm_provider.Api_common.max_response_body body |> take_all) in
       (try
          let json = Yojson.Safe.from_string body_str in
          Agent_card.of_json json

--- a/lib/protocol/mcp.ml
+++ b/lib/protocol/mcp.ml
@@ -62,7 +62,7 @@ let connect ~sw ~(mgr : _ Eio.Process.mgr) ~command ~args ?env () =
     Eio.Flow.close w_child_stdout;
     let reader =
       Eio.Buf_read.of_flow (r_child_stdout :> _ Eio.Flow.source)
-        ~max_size:(16 * 1024 * 1024)
+        ~max_size:Llm_provider.Api_common.max_stdio_buffer
     in
     let kill () =
       try Eio.Process.signal proc Sys.sigterm

--- a/lib/protocol/mcp_http.ml
+++ b/lib/protocol/mcp_http.ml
@@ -109,7 +109,7 @@ let send_request t ~method_ ?params () =
       in
       match Cohttp.Response.status resp with
       | `OK ->
-        let resp_body = Eio.Buf_read.(of_flow ~max_size:(10 * 1024 * 1024) body |> take_all) in
+        let resp_body = Eio.Buf_read.(of_flow ~max_size:Llm_provider.Api_common.max_response_body body |> take_all) in
         let content_type = Cohttp.Header.get (Cohttp.Response.headers resp) "content-type" in
         (match parse_response_body ~content_type resp_body with
          | None ->

--- a/lib/transport.ml
+++ b/lib/transport.ml
@@ -232,7 +232,7 @@ let connect ~sw ~(mgr : _ Eio.Process.mgr) ?(options = default_options) () =
     Eio.Flow.close w_child_stdout;
     let reader =
       Eio.Buf_read.of_flow (r_child_stdout :> _ Eio.Flow.source)
-        ~max_size:(16 * 1024 * 1024)
+        ~max_size:Llm_provider.Api_common.max_stdio_buffer
     in
     let kill () =
       try Eio.Process.signal proc Sys.sigterm


### PR DESCRIPTION
## Summary
- `Api_common`에 `max_response_body` (10MB) + `max_stdio_buffer` (16MB) 상수 통일
- 5개 사이트의 매직 넘버를 named constant 참조로 교체
- `agent_registry.ml`의 1MB → 10MB 수정 (실제 버그: 큰 agent card 잘림)

## Before/After

| 파일 | Before | After |
|------|--------|-------|
| `http_client.ml` | `1024 * 1024 * 10` | `Api_common.max_response_body` |
| `mcp_http.ml` | `10 * 1024 * 1024` | `Api_common.max_response_body` |
| `agent_registry.ml` | `1024 * 1024` (1MB) | `Api_common.max_response_body` (10MB) |
| `transport.ml` | `16 * 1024 * 1024` | `Api_common.max_stdio_buffer` |
| `mcp.ml` | `16 * 1024 * 1024` | `Api_common.max_stdio_buffer` |

## Test plan
- [x] `dune build` 통과
- [x] `dune runtest` 전체 통과
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)