### PR TITLE
fix: replace Stdlib.Mutex with Eio.Mutex in cascade_config + fix gemini test

### DIFF
--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -149,11 +149,10 @@ let parse_model_strings ?(temperature = 0.3) ?(max_tokens = 500)
 
 let config_cache : (string, float * Yojson.Safe.t) Hashtbl.t =
   Hashtbl.create 4
-let config_cache_mu = Mutex.create ()
+let config_cache_mu = Eio.Mutex.create ()
 
 let load_json path =
-  Mutex.lock config_cache_mu;
-  Fun.protect ~finally:(fun () -> Mutex.unlock config_cache_mu) (fun () ->
+  Eio.Mutex.use_rw ~protect:true config_cache_mu (fun () ->
     try
       let st = Unix.stat path in
       let mtime = st.Unix.st_mtime in
@@ -586,7 +585,8 @@ let%test "text_of_response non-text blocks ignored" =
   text_of_response resp = "only this"
 
 let%test "load_profile nonexistent file returns empty" =
-  load_profile ~config_path:"/nonexistent/file.json" ~name:"test" = []
+  Eio_main.run (fun _env ->
+    load_profile ~config_path:"/nonexistent/file.json" ~name:"test" = [])
 
 let%test "known_providers has 5 entries" =
   List.length known_providers = 5
@@ -597,8 +597,8 @@ let%test "llama_defaults has OpenAI_compat kind" =
 let%test "claude_defaults has Anthropic kind" =
   claude_defaults.kind = Anthropic
 
-let%test "gemini_defaults has OpenAI_compat kind" =
-  gemini_defaults.kind = OpenAI_compat
+let%test "gemini_defaults has Gemini kind" =
+  gemini_defaults.kind = Gemini
 
 let%test "glm_defaults has OpenAI_compat kind" =
   glm_defaults.kind = OpenAI_compat

--- a/lib/llm_provider/dune
+++ b/lib/llm_provider/dune
@@ -3,7 +3,7 @@
 (library
  (name llm_provider)
  (public_name agent_sdk.llm_provider)
- (libraries yojson ppx_deriving_yojson.runtime eio cohttp-eio tls tls-eio ca-certs uri)
+ (libraries yojson ppx_deriving_yojson.runtime eio eio_main cohttp-eio tls tls-eio ca-certs uri)
  (inline_tests)
  (preprocess (pps ppx_deriving_yojson ppx_deriving.show ppx_inline_test))
  (instrumentation (backend bisect_ppx)))

--- a/test/dune
+++ b/test/dune
@@ -453,7 +453,7 @@
 
 (test
  (name test_cascade_config_ext)
- (libraries llm_provider alcotest yojson unix))
+ (libraries llm_provider alcotest yojson unix eio eio_main))
 
 (test
  (name test_complete_ext)
@@ -530,7 +530,7 @@
 
 (test
  (name test_cascade_deep)
- (libraries agent_sdk llm_provider alcotest yojson unix))
+ (libraries agent_sdk llm_provider alcotest yojson unix eio eio_main))
 
 (test
  (name test_trajectory_unit)

--- a/test/test_cascade_config.ml
+++ b/test/test_cascade_config.ml
@@ -79,6 +79,7 @@ let with_temp_json content f =
     (fun () -> f path)
 
 let test_load_profile_found () =
+  Eio_main.run @@ fun _env ->
   with_temp_json
     {|{"test_action_models": ["llama:qwen3.5", "glm:auto"]}|}
     (fun path ->
@@ -90,6 +91,7 @@ let test_load_profile_found () =
        check string "second" "glm:auto" (List.nth models 1))
 
 let test_load_profile_missing_key () =
+  Eio_main.run @@ fun _env ->
   with_temp_json {|{"other_models": ["llama:x"]}|} (fun path ->
     let models =
       Cascade_config.load_profile ~config_path:path ~name:"nonexistent"
@@ -97,6 +99,7 @@ let test_load_profile_missing_key () =
     check int "empty" 0 (List.length models))
 
 let test_load_profile_missing_file () =
+  Eio_main.run @@ fun _env ->
   let models =
     Cascade_config.load_profile
       ~config_path:"/tmp/does_not_exist_cascade.json"
@@ -105,6 +108,7 @@ let test_load_profile_missing_file () =
   check int "empty on missing file" 0 (List.length models)
 
 let test_load_profile_hot_reload () =
+  Eio_main.run @@ fun _env ->
   let path = Filename.temp_file "cascade_reload_" ".json" in
   Fun.protect
     ~finally:(fun () -> try Sys.remove path with _ -> ())

--- a/test/test_cascade_config_ext.ml
+++ b/test/test_cascade_config_ext.ml
@@ -152,32 +152,38 @@ let with_temp_file content f =
        f path)
 
 let test_load_profile_valid () =
+  Eio_main.run @@ fun _env ->
   with_temp_file {|{"myname_models": ["llama:q1", "glm:auto"]}|} (fun path ->
     let models = Cascade_config.load_profile ~config_path:path ~name:"myname" in
     check int "2 models" 2 (List.length models);
     check string "first" "llama:q1" (List.nth models 0))
 
 let test_load_profile_missing_key () =
+  Eio_main.run @@ fun _env ->
   with_temp_file {|{"other_models": ["a"]}|} (fun path ->
     let models = Cascade_config.load_profile ~config_path:path ~name:"myname" in
     check int "empty" 0 (List.length models))
 
 let test_load_profile_nonexistent () =
+  Eio_main.run @@ fun _env ->
   let models = Cascade_config.load_profile
       ~config_path:"/nonexistent.json" ~name:"x" in
   check int "empty on missing" 0 (List.length models)
 
 let test_load_profile_non_string_items () =
+  Eio_main.run @@ fun _env ->
   with_temp_file {|{"x_models": ["valid", 42, true, "also_valid"]}|} (fun path ->
     let models = Cascade_config.load_profile ~config_path:path ~name:"x" in
     check int "filters non-strings" 2 (List.length models))
 
 let test_load_profile_not_list () =
+  Eio_main.run @@ fun _env ->
   with_temp_file {|{"x_models": "not_a_list"}|} (fun path ->
     let models = Cascade_config.load_profile ~config_path:path ~name:"x" in
     check int "not a list" 0 (List.length models))
 
 let test_load_profile_invalid_json () =
+  Eio_main.run @@ fun _env ->
   with_temp_file "not json" (fun path ->
     let models = Cascade_config.load_profile ~config_path:path ~name:"x" in
     check int "invalid json" 0 (List.length models))

--- a/test/test_cascade_deep.ml
+++ b/test/test_cascade_deep.ml
@@ -158,18 +158,20 @@ let test_parse_model_strings_with_params () =
 (* ── load_json / load_profile ────────────────────────────────── *)
 
 let test_load_json_nonexistent () =
+  Eio_main.run @@ fun _env ->
   let path = "/tmp/cascade_nonexistent_file_12345.json" in
-  (* load_profile should return [] for nonexistent file *)
   let r = Cascade_config.load_profile ~config_path:path ~name:"test" in
   Alcotest.(check int) "nonexistent -> empty" 0 (List.length r)
 
 let test_load_json_invalid_json () =
+  Eio_main.run @@ fun _env ->
   let path = write_temp_file "not valid json {{{" in
   let r = Cascade_config.load_profile ~config_path:path ~name:"test" in
   Alcotest.(check int) "invalid json -> empty" 0 (List.length r);
   Sys.remove path
 
 let test_load_profile_valid () =
+  Eio_main.run @@ fun _env ->
   let json = {|{"myprofile_models": ["llama:qwen", "custom:x@http://a.b"]}|} in
   let path = write_temp_file json in
   let r = Cascade_config.load_profile ~config_path:path ~name:"myprofile" in
@@ -179,6 +181,7 @@ let test_load_profile_valid () =
   Sys.remove path
 
 let test_load_profile_missing_key () =
+  Eio_main.run @@ fun _env ->
   let json = {|{"other_models": ["llama:qwen"]}|} in
   let path = write_temp_file json in
   let r = Cascade_config.load_profile ~config_path:path ~name:"myprofile" in
@@ -186,6 +189,7 @@ let test_load_profile_missing_key () =
   Sys.remove path
 
 let test_load_profile_non_string_items () =
+  Eio_main.run @@ fun _env ->
   let json = {|{"test_models": ["llama:a", 42, "llama:b", null]}|} in
   let path = write_temp_file json in
   let r = Cascade_config.load_profile ~config_path:path ~name:"test" in
@@ -193,6 +197,7 @@ let test_load_profile_non_string_items () =
   Sys.remove path
 
 let test_load_profile_not_a_list () =
+  Eio_main.run @@ fun _env ->
   let json = {|{"test_models": "not-a-list"}|} in
   let path = write_temp_file json in
   let r = Cascade_config.load_profile ~config_path:path ~name:"test" in
@@ -200,6 +205,7 @@ let test_load_profile_not_a_list () =
   Sys.remove path
 
 let test_load_json_caching () =
+  Eio_main.run @@ fun _env ->
   let json = {|{"cache_models": ["llama:m1"]}|} in
   let path = write_temp_file json in
   let r1 = Cascade_config.load_profile ~config_path:path ~name:"cache" in


### PR DESCRIPTION
## Summary
- `cascade_config.ml`의 `Stdlib.Mutex` → `Eio.Mutex.use_rw` 전환 (EDEADLK 방지)
- `gemini_defaults` 인라인 테스트가 `OpenAI_compat`를 assert하던 버그 수정 → `Gemini`
- `load_profile` 호출 테스트 17건에 `Eio_main.run` context 추가

## Changes
| 파일 | 변경 |
|------|------|
| `lib/llm_provider/cascade_config.ml` | Mutex→Eio.Mutex, gemini test fix |
| `lib/llm_provider/dune` | +eio_main (inline test context) |
| `test/dune` | +eio eio_main for cascade_config_ext, cascade_deep |
| `test/test_cascade_config.ml` | 4 tests + Eio_main.run |
| `test/test_cascade_config_ext.ml` | 6 tests + Eio_main.run |
| `test/test_cascade_deep.ml` | 7 tests + Eio_main.run |

## Test plan
- [x] `dune build --root .` passes
- [x] `dune runtest --root . --force` — 0 failures
- [x] All 17 load_profile tests pass with Eio context

🤖 Generated with [Claude Code](https://claude.com/claude-code)