### PR TITLE
refactor: /simplify review — extract tool ID + exception consistency

### DIFF
--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -16,6 +16,12 @@ let max_response_body = 10 * 1024 * 1024
     Larger than HTTP because stdio carries full JSON-RPC frames. *)
 let max_stdio_buffer = 16 * 1024 * 1024
 
+(** Synthesize a deterministic tool_use_id from function name and args.
+    Gemini API does not return tool IDs; we generate stable ones via MD5. *)
+let synthesize_tool_use_id ~name args =
+  Printf.sprintf "call_%s_%s" name
+    Digest.(to_hex (string (Yojson.Safe.to_string args)))
+
 let string_is_blank s =
   String.trim s = ""
 

--- a/lib/llm_provider/api_common.mli
+++ b/lib/llm_provider/api_common.mli
@@ -4,6 +4,7 @@ val default_base_url : string
 val api_version : string
 val max_response_body : int
 val max_stdio_buffer : int
+val synthesize_tool_use_id : name:string -> Yojson.Safe.t -> string
 
 val string_is_blank : string -> bool
 val text_blocks_to_string : Types.content_block list -> string

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -240,9 +240,7 @@ let parse_response json =
             | `Assoc _ as fc ->
                 let name = fc |> member "name" |> to_string in
                 let args = fc |> member "args" in
-                let id = Printf.sprintf "call_%s_%s"
-                    name Digest.(to_hex (string (Yojson.Safe.to_string args)))
-                in
+                let id = Api_common.synthesize_tool_use_id ~name args in
                 Some (ToolUse { id; name; input = args })
             | _ -> None
       ) parts in

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -389,8 +389,7 @@ let gemini_chunk_to_events (state : openai_stream_state)
              let name = fc |> member "name" |> to_string_option
                         |> Option.value ~default:"" in
              let args = fc |> member "args" in
-             let id = Printf.sprintf "call_%s_%s"
-                 name Digest.(to_hex (string (Yojson.Safe.to_string args))) in
+             let id = Api_common.synthesize_tool_use_id ~name args in
              let idx = state.next_block_index in
              emit (ContentBlockStart {
                index = idx; content_type = "tool_use";

--- a/lib/protocol/mcp_http.ml
+++ b/lib/protocol/mcp_http.ml
@@ -210,7 +210,7 @@ let call_tool t ~name ~arguments =
     let is_error = try
       result |> member "isError" |> to_bool_option
       |> Option.value ~default:false
-    with Yojson.Safe.Util.Type_error _ -> false
+    with Yojson.Safe.Util.Type_error _ | Not_found -> false
     in
     if is_error then
       (Error { Types.message = content; recoverable = true } : Types.tool_result)

--- a/lib/trajectory.ml
+++ b/lib/trajectory.ml
@@ -113,9 +113,9 @@ let of_raw_trace_records (records : Raw_trace.record list) : trajectory =
          let content = match r.assistant_block with
            | Some json ->
              (try Yojson.Safe.Util.(json |> member "content" |> to_string)
-              with Yojson.Safe.Util.Type_error _ ->
+              with Yojson.Safe.Util.Type_error _ | Not_found ->
                 try Yojson.Safe.Util.(json |> member "thinking" |> to_string)
-                with Yojson.Safe.Util.Type_error _ -> Yojson.Safe.to_string json)
+                with Yojson.Safe.Util.Type_error _ | Not_found -> Yojson.Safe.to_string json)
            | None -> ""
          in
          add_step (Think { content; ts = r.ts })
@@ -123,7 +123,7 @@ let of_raw_trace_records (records : Raw_trace.record list) : trajectory =
          let content = match r.assistant_block with
            | Some json ->
              (try Yojson.Safe.Util.(json |> member "text" |> to_string)
-              with Yojson.Safe.Util.Type_error _ -> Yojson.Safe.to_string json)
+              with Yojson.Safe.Util.Type_error _ | Not_found -> Yojson.Safe.to_string json)
            | None -> ""
          in
          add_step (Respond { content; ts = r.ts })


### PR DESCRIPTION
## Summary
3-agent 병렬 리뷰(/simplify) 결과 수정:

1. **tool ID 중복 추출**: `backend_gemini.ml` + `streaming.ml`의 동일한 `Digest.to_hex` 패턴 → `Api_common.synthesize_tool_use_id`
2. **exception handler 일관성**: `trajectory.ml`(2곳) + `mcp_http.ml`(1곳)에 `Not_found` 추가

## Review Results
- Reuse: Clean (2건 수정)
- Quality: Good (3건 수정)
- Efficiency: A+ (수정 불요)

## Test plan
- [x] `dune build` 통과
- [x] `dune runtest` 전체 통과 (Gemini edge cases 포함)
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)