### PR TITLE
feat: add Llm_transport abstraction for pluggable completion backends

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -66,7 +66,8 @@ let complete_http ~sw ~net ~(config : Provider_config.t)
 
 (* ── Sync completion ─────────────────────────────────── *)
 
-let complete ~sw ~net ~(config : Provider_config.t)
+let complete ~sw ~net ?(transport : Llm_transport.t option)
+    ~(config : Provider_config.t)
     ~(messages : Types.message list) ?(tools=[])
     ?(cache : Cache.t option) ?(metrics : Metrics.t option) () =
   let m = match metrics with Some m -> m | None -> Metrics.noop in
@@ -93,8 +94,13 @@ let complete ~sw ~net ~(config : Provider_config.t)
   | Some (result, _key) -> result
   | None ->
       m.on_request_start ~model_id;
-      let (result, latency_ms) =
-        complete_http ~sw ~net ~config ~messages ~tools
+      let { Llm_transport.response = result; latency_ms } =
+        match transport with
+        | Some t ->
+          t.complete_sync { Llm_transport.config; messages; tools }
+        | None ->
+          let (resp, lat) = complete_http ~sw ~net ~config ~messages ~tools in
+          { Llm_transport.response = resp; latency_ms = lat }
       in
       (match result with
        | Ok resp ->
@@ -138,7 +144,7 @@ let is_retryable = function
       code = 429 || code = 500 || code = 502 || code = 503 || code = 529
   | Http_client.NetworkError _ -> true
 
-let complete_with_retry ~sw ~net ~clock
+let complete_with_retry ~sw ~net ?transport ~clock
     ~(config : Provider_config.t)
     ~(messages : Types.message list) ?(tools=[])
     ?(retry_config=default_retry_config)
@@ -149,7 +155,7 @@ let complete_with_retry ~sw ~net ~clock
     delay *. factor
   in
   let rec attempt n delay =
-    match complete ~sw ~net ~config ~messages ~tools ?cache ?metrics () with
+    match complete ~sw ~net ?transport ~config ~messages ~tools ?cache ?metrics () with
     | Ok _ as success -> success
     | Error err when is_retryable err && n < retry_config.max_retries ->
         Eio.Time.sleep clock (jittered delay);
@@ -170,7 +176,7 @@ type cascade = {
   fallbacks: Provider_config.t list;
 }
 
-let complete_cascade ~sw ~net ?clock ?retry_config
+let complete_cascade ~sw ~net ?transport ?clock ?retry_config
     ~(cascade : cascade)
     ~(messages : Types.message list) ?(tools=[])
     ?cache ?metrics () =
@@ -178,10 +184,10 @@ let complete_cascade ~sw ~net ?clock ?retry_config
   let try_provider cfg =
     match clock with
     | Some clock ->
-        complete_with_retry ~sw ~net ~clock ~config:cfg
+        complete_with_retry ~sw ~net ?transport ~clock ~config:cfg
           ~messages ~tools ?retry_config ?cache ?metrics ()
     | None ->
-        complete ~sw ~net ~config:cfg ~messages ~tools ?cache ?metrics ()
+        complete ~sw ~net ?transport ~config:cfg ~messages ~tools ?cache ?metrics ()
   in
   match try_provider cascade.primary with
   | Ok _ as success -> success
@@ -303,9 +309,10 @@ let finalize_stream_acc (acc : stream_acc) =
       cache_read_input_tokens = !(acc.cache_read);
     } }
 
-let complete_stream ~sw ~net ~(config : Provider_config.t)
-    ~(messages : Types.message list) ?(tools=[])
-    ~(on_event : Types.sse_event -> unit) () =
+(* Internal: HTTP-specific streaming implementation. *)
+let complete_stream_http ~sw ~net ~(config : Provider_config.t)
+    ~(messages : Types.message list) ~tools
+    ~(on_event : Types.sse_event -> unit) =
   let body_str = match config.kind with
     | Provider_config.Anthropic ->
         Backend_anthropic.build_request ~stream:true ~config ~messages ~tools ()
@@ -319,7 +326,7 @@ let complete_stream ~sw ~net ~(config : Provider_config.t)
     | _ -> config.base_url ^ config.request_path
   in
   let body_with_stream = match config.kind with
-    | Provider_config.Gemini -> body_str  (* Gemini: no body stream param *)
+    | Provider_config.Gemini -> body_str
     | _ -> Http_client.inject_stream_param body_str
   in
   match Http_client.post_stream ~sw ~net ~url
@@ -362,6 +369,30 @@ let complete_stream ~sw ~net ~(config : Provider_config.t)
       ) ();
       Ok (finalize_stream_acc acc)
 
+let complete_stream ~sw ~net ?(transport : Llm_transport.t option)
+    ~(config : Provider_config.t)
+    ~(messages : Types.message list) ?(tools=[])
+    ~(on_event : Types.sse_event -> unit) () =
+  match transport with
+  | Some t ->
+    t.complete_stream ~on_event { Llm_transport.config; messages; tools }
+  | None ->
+    complete_stream_http ~sw ~net ~config ~messages ~tools ~on_event
+
+(* ── HTTP Transport constructor ─────────────────────── *)
+
+let make_http_transport ~sw ~net : Llm_transport.t = {
+  complete_sync = (fun (req : Llm_transport.completion_request) ->
+    let (response, latency_ms) =
+      complete_http ~sw ~net ~config:req.config
+        ~messages:req.messages ~tools:req.tools
+    in
+    { Llm_transport.response; latency_ms });
+  complete_stream = (fun ~on_event (req : Llm_transport.completion_request) ->
+    complete_stream_http ~sw ~net ~config:req.config
+      ~messages:req.messages ~tools:req.tools ~on_event);
+}
+
 (* ── Streaming Cascade ──────────────────────────── *)
 
 (** Streaming cascade: try each provider in order, failover on
@@ -370,14 +401,14 @@ let complete_stream ~sw ~net ~(config : Provider_config.t)
     No mid-stream failover, no retry, no caching.
 
     @since 0.61.0 *)
-let complete_stream_cascade ~sw ~net
+let complete_stream_cascade ~sw ~net ?transport
     ~(cascade : cascade)
     ~(messages : Types.message list) ?(tools=[])
     ~(on_event : Types.sse_event -> unit)
     ?(metrics : Metrics.t option) () =
   let m = match metrics with Some m -> m | None -> Metrics.noop in
   let try_provider cfg =
-    complete_stream ~sw ~net ~config:cfg ~messages ~tools ~on_event ()
+    complete_stream ~sw ~net ?transport ~config:cfg ~messages ~tools ~on_event ()
   in
   match try_provider cascade.primary with
   | Ok _ as success -> success

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -1,11 +1,12 @@
-(** Standalone LLM completion: build request, HTTP POST, parse response.
+(** Standalone LLM completion: build request, send via transport, parse response.
 
     Self-contained in llm_provider -- no agent_sdk dependency.
     Both OAS and MASC can call these functions directly.
 
     @since 0.46.0  Sync completion
     @since 0.53.0  Streaming, retry, cascade
-    @since 0.54.0  Optional cache + metrics hooks *)
+    @since 0.54.0  Optional cache + metrics hooks
+    @since 0.78.0  Transport abstraction *)
 
 (** {1 Gemini URL Construction} *)
 
@@ -14,18 +15,35 @@
 val gemini_url :
   config:Provider_config.t -> stream:bool -> string
 
+(** {1 Transport} *)
+
+(** Create an HTTP-based transport.
+    Wraps the internal HTTP completion pipeline into a
+    {!Llm_transport.t} value that can be passed to [complete]
+    or [complete_stream] via [?transport].
+
+    @since 0.78.0 *)
+val make_http_transport :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  Llm_transport.t
+
 (** {1 Sync Completion} *)
 
 (** Execute a single LLM completion round-trip.
 
-    When [cache] is provided, checks cache before HTTP and stores on success.
+    When [transport] is provided, uses that transport for I/O.
+    Otherwise falls back to the built-in HTTP transport.
+
+    When [cache] is provided, checks cache before I/O and stores on success.
     When [metrics] is provided, fires lifecycle callbacks.
 
     @return [Ok api_response] on success (possibly from cache)
-    @return [Error http_error] on HTTP or network failure *)
+    @return [Error http_error] on failure *)
 val complete :
   sw:Eio.Switch.t ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?transport:Llm_transport.t ->
   config:Provider_config.t ->
   messages:Types.message list ->
   ?tools:Yojson.Safe.t list ->
@@ -52,10 +70,11 @@ val default_retry_config : retry_config
 val is_retryable : Http_client.http_error -> bool
 
 (** Completion with exponential backoff retry.
-    Passes [cache] and [metrics] through to each attempt. *)
+    Passes [transport], [cache] and [metrics] through to each attempt. *)
 val complete_with_retry :
   sw:Eio.Switch.t ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?transport:Llm_transport.t ->
   clock:_ Eio.Time.clock ->
   config:Provider_config.t ->
   messages:Types.message list ->
@@ -81,6 +100,7 @@ type cascade = {
 val complete_cascade :
   sw:Eio.Switch.t ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?transport:Llm_transport.t ->
   ?clock:_ Eio.Time.clock ->
   ?retry_config:retry_config ->
   cascade:cascade ->
@@ -102,6 +122,7 @@ val complete_cascade :
 val complete_stream :
   sw:Eio.Switch.t ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?transport:Llm_transport.t ->
   config:Provider_config.t ->
   messages:Types.message list ->
   ?tools:Yojson.Safe.t list ->
@@ -126,6 +147,7 @@ val complete_stream :
 val complete_stream_cascade :
   sw:Eio.Switch.t ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?transport:Llm_transport.t ->
   cascade:cascade ->
   messages:Types.message list ->
   ?tools:Yojson.Safe.t list ->

--- a/lib/llm_provider/llm_transport.ml
+++ b/lib/llm_provider/llm_transport.ml
@@ -1,0 +1,24 @@
+(** Abstract transport for LLM completions.
+
+    @since 0.78.0 *)
+
+type completion_request = {
+  config: Provider_config.t;
+  messages: Types.message list;
+  tools: Yojson.Safe.t list;
+}
+
+type sync_result = {
+  response: (Types.api_response, Http_client.http_error) result;
+  latency_ms: int;
+}
+
+type stream_result = (Types.api_response, Http_client.http_error) result
+
+type t = {
+  complete_sync : completion_request -> sync_result;
+  complete_stream :
+    on_event:(Types.sse_event -> unit) ->
+    completion_request ->
+    stream_result;
+}

--- a/lib/llm_provider/llm_transport.mli
+++ b/lib/llm_provider/llm_transport.mli
@@ -1,0 +1,37 @@
+(** Abstract transport for LLM completions.
+
+    Decouples the completion logic (cache, retry, cascade) from
+    the underlying I/O mechanism (HTTP, subprocess, etc.).
+
+    @since 0.78.0 *)
+
+(** A completion request: everything needed to produce a response. *)
+type completion_request = {
+  config: Provider_config.t;
+  messages: Types.message list;
+  tools: Yojson.Safe.t list;
+}
+
+(** Result of a sync completion. *)
+type sync_result = {
+  response: (Types.api_response, Http_client.http_error) result;
+  latency_ms: int;
+}
+
+(** Result of a streaming completion. *)
+type stream_result = (Types.api_response, Http_client.http_error) result
+
+(** Transport interface.
+
+    Both [complete_sync] and [complete_stream] handle the full
+    request → I/O → response pipeline for their transport kind.
+
+    - HTTP transport: build request body, POST, parse response
+    - Subprocess transport: write stdin, read stdout, parse output *)
+type t = {
+  complete_sync : completion_request -> sync_result;
+  complete_stream :
+    on_event:(Types.sse_event -> unit) ->
+    completion_request ->
+    stream_result;
+}


### PR DESCRIPTION
## Summary
- `Llm_transport.t` 인터페이스 추가: sync/stream completion을 추상화
- `complete`, `complete_with_retry`, `complete_cascade`, `complete_stream`, `complete_stream_cascade`에 `?transport` 파라미터 추가
- `make_http_transport` 노출: 명시적 HTTP transport 생성
- 기존 동작 변경 없음 (transport 미지정 시 built-in HTTP 사용)

## Design
```
                    Llm_transport.t
                    ├── complete_sync
                    └── complete_stream
                          │
            ┌─────────────┼─────────────┐
            │             │             │
    HTTP Transport   CC Transport    (future)
    (built-in)       (PR 2b)
```

`complete_stream_http`를 internal function으로 추출하여 `make_http_transport`과 `complete_stream` 모두에서 재사용.

## Test plan
- [x] `dune build --root .` passes
- [x] `dune runtest --root . --force` — 0 failures
- [x] All existing callers work unchanged (optional param)

🤖 Generated with [Claude Code](https://claude.com/claude-code)