### PR TITLE
feat: add Claude_code provider kind and cc cascade label

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -132,6 +132,14 @@ let gemini_capabilities = {
   supports_code_execution = true;
 }
 
+let claude_code_capabilities = {
+  anthropic_capabilities with
+  max_context_tokens = Some 1_000_000;  (* 1M context via Claude Code *)
+  max_output_tokens = Some 64_000;
+  supports_computer_use = true;
+  supports_code_execution = true;
+}
+
 (* ── Model-specific overrides (lookup table) ─────────── *)
 
 (** Lookup capabilities by model_id prefix.

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -40,6 +40,7 @@ val anthropic_capabilities : capabilities
 val openai_chat_capabilities : capabilities
 val openai_chat_extended_capabilities : capabilities
 val gemini_capabilities : capabilities
+val claude_code_capabilities : capabilities
 
 (** Lookup capabilities for a known model_id.
     Returns [None] if the model is not in the built-in table. *)

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -28,6 +28,11 @@ let gemini_url ~(config : Provider_config.t) ~stream =
 
 let complete_http ~sw ~net ~(config : Provider_config.t)
     ~(messages : Types.message list) ~tools =
+  if config.kind = Provider_config.Claude_code then
+    (Error (Http_client.NetworkError {
+       message = "Claude_code provider requires a transport (use Transport_claude_code.create)" }),
+     0)
+  else
   let body_str = match config.kind with
     | Provider_config.Anthropic ->
         Backend_anthropic.build_request ~config ~messages ~tools ()
@@ -35,6 +40,7 @@ let complete_http ~sw ~net ~(config : Provider_config.t)
         Backend_openai.build_request ~config ~messages ~tools ()
     | Provider_config.Gemini ->
         Backend_gemini.build_request ~config ~messages ~tools ()
+    | Provider_config.Claude_code -> assert false (* guarded above *)
   in
   let url = match config.kind with
     | Provider_config.Gemini -> gemini_url ~config ~stream:false
@@ -56,6 +62,7 @@ let complete_http ~sw ~net ~(config : Provider_config.t)
             | Provider_config.Gemini ->
                 Backend_gemini.parse_response
                   (Yojson.Safe.from_string body)
+            | Provider_config.Claude_code -> assert false
           in
           Ok response
         else
@@ -313,6 +320,10 @@ let finalize_stream_acc (acc : stream_acc) =
 let complete_stream_http ~sw ~net ~(config : Provider_config.t)
     ~(messages : Types.message list) ~tools
     ~(on_event : Types.sse_event -> unit) =
+  if config.kind = Provider_config.Claude_code then
+    Error (Http_client.NetworkError {
+      message = "Claude_code provider requires a transport (use Transport_claude_code.create)" })
+  else
   let body_str = match config.kind with
     | Provider_config.Anthropic ->
         Backend_anthropic.build_request ~stream:true ~config ~messages ~tools ()
@@ -320,6 +331,7 @@ let complete_stream_http ~sw ~net ~(config : Provider_config.t)
         Backend_openai.build_request ~stream:true ~config ~messages ~tools ()
     | Provider_config.Gemini ->
         Backend_gemini.build_request ~stream:true ~config ~messages ~tools ()
+    | Provider_config.Claude_code -> assert false
   in
   let url = match config.kind with
     | Provider_config.Gemini -> gemini_url ~config ~stream:true
@@ -361,6 +373,7 @@ let complete_stream_http ~sw ~net ~(config : Provider_config.t)
               (match Streaming.parse_gemini_sse_chunk data with
                | Some chunk -> Streaming.gemini_chunk_to_events state chunk
                | None -> [])
+          | Provider_config.Claude_code -> []  (* guarded above *)
         in
         List.iter (fun evt ->
           on_event evt;

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -5,6 +5,7 @@ type provider_kind =
   | Anthropic
   | OpenAI_compat
   | Gemini
+  | Claude_code
 
 type t = {
   kind: provider_kind;
@@ -41,6 +42,7 @@ let make ~kind ~model_id ~base_url
       | Anthropic -> "/v1/messages"
       | OpenAI_compat -> "/v1/chat/completions"
       | Gemini -> ""
+      | Claude_code -> ""
   in
   { kind; model_id; base_url; api_key; headers; request_path;
     max_tokens; temperature; top_p; top_k; min_p;

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -10,6 +10,7 @@ type provider_kind =
   | Anthropic
   | OpenAI_compat
   | Gemini
+  | Claude_code  (** Subprocess transport via [claude -p]. @since 0.78.0 *)
 
 type t = {
   kind: provider_kind;

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -106,4 +106,22 @@ let default () =
   reg "gemini" gemini_defaults Capabilities.gemini_capabilities;
   reg "glm" glm_defaults Capabilities.openai_chat_capabilities;
   reg "openrouter" openrouter_defaults Capabilities.openai_chat_extended_capabilities;
+  (* Claude Code subprocess — always available if claude is in PATH *)
+  let cc_defaults = {
+    kind = Claude_code;
+    base_url = "";
+    api_key_env = "";
+    request_path = "";
+  } in
+  let cc_available () =
+    try
+      let ic = Unix.open_process_in "which claude 2>/dev/null" in
+      let result = try input_line ic with End_of_file -> "" in
+      ignore (Unix.close_process_in ic);
+      String.length (String.trim result) > 0
+    with _ -> false
+  in
+  register t { name = "cc"; defaults = cc_defaults;
+               capabilities = Capabilities.claude_code_capabilities;
+               is_available = cc_available };
   t


### PR DESCRIPTION
## Summary
- `provider_kind`에 `Claude_code` variant 추가
- Provider_Registry에 `cc` 라벨 등록 (1M context, tools, code_execution)
- `claude_code_capabilities` 프리셋 추가
- Complete HTTP path에서 Claude_code kind guard (transport 필수)

## Usage
```ocaml
(* "cc:opus" 파싱 *)
let config = Cascade_config.parse_model_string "cc:opus" in
(* Provider_config.t with kind=Claude_code *)

(* cascade에서 사용 *)
Cascade_config.complete_named ~defaults:["cc:opus"; "llama:qwen3.5"] ...
(* cc:opus → transport 필요, llama:qwen3.5 → HTTP 직접 *)
```

## Availability
`cc` provider는 `which claude`로 PATH에서 확인. claude가 없으면 `is_available()` = false → cascade에서 건너뜀.

## Test plan
- [x] `dune build --root .` passes
- [x] `dune runtest --root . --force` — 0 failures
- [x] All existing match arms exhaustive (no warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)