### PR TITLE
feat: GLM model-specific capabilities + capability-aware cascade filtering

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -246,13 +246,38 @@ let for_model_id model_id =
            supports_structured_output = true;
            supports_native_streaming = true;
            supports_caching = true }
-  else if starts_with "glm" then
+  else if starts_with "glm-4.5" || starts_with "glm-5" then
     Some { default_capabilities with
            max_context_tokens = Some 200_000;
            max_output_tokens = Some 128_000;
            supports_tools = true;
+           supports_tool_choice = true;
            supports_reasoning = true;
            supports_structured_output = true;
+           supports_response_format_json = true;
+           supports_multimodal_inputs = true;
+           supports_image_input = true;
+           supports_native_streaming = true }
+  else if starts_with "glm-4-flash" then
+    Some { default_capabilities with
+           max_context_tokens = Some 128_000;
+           max_output_tokens = Some 4_096;
+           supports_tools = true;
+           supports_native_streaming = true }
+  else if starts_with "glm-4v" then
+    Some { default_capabilities with
+           max_context_tokens = Some 128_000;
+           max_output_tokens = Some 4_096;
+           supports_tools = true;
+           supports_multimodal_inputs = true;
+           supports_image_input = true;
+           supports_native_streaming = true }
+  else if starts_with "glm-4" then
+    Some { default_capabilities with
+           max_context_tokens = Some 128_000;
+           max_output_tokens = Some 4_096;
+           supports_tools = true;
+           supports_tool_choice = true;
            supports_native_streaming = true }
   else
     None
@@ -260,3 +285,30 @@ let for_model_id model_id =
 (** Merge Discovery ctx_size into capabilities. *)
 let with_context_size caps ~ctx_size =
   { caps with max_context_tokens = Some ctx_size }
+
+[@@@coverage off]
+
+let%test "for_model_id glm-4.5 has reasoning" =
+  match for_model_id "glm-4.5" with
+  | Some c -> c.supports_reasoning && c.max_context_tokens = Some 200_000
+  | None -> false
+
+let%test "for_model_id glm-4 no reasoning" =
+  match for_model_id "glm-4-chat" with
+  | Some c -> not c.supports_reasoning && c.max_context_tokens = Some 128_000
+  | None -> false
+
+let%test "for_model_id glm-4v has vision" =
+  match for_model_id "glm-4v-flash" with
+  | Some c -> c.supports_image_input && c.supports_multimodal_inputs
+  | None -> false
+
+let%test "for_model_id glm-4-flash basic" =
+  match for_model_id "glm-4-flash" with
+  | Some c -> c.supports_tools && c.max_output_tokens = Some 4_096
+  | None -> false
+
+let%test "for_model_id glm-5 advanced" =
+  match for_model_id "glm-5" with
+  | Some c -> c.supports_reasoning && c.supports_image_input
+  | None -> false

--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -175,6 +175,31 @@ let filter_healthy ~sw ~net (providers : Provider_config.t list) =
     else
       cloud_providers  (* All locals unhealthy — cloud only *)
 
+(* ── Capability-aware filtering ─────────────────────────── *)
+
+(** Filter providers by a capability predicate.
+    Uses {!Capabilities.for_model_id} to resolve model-specific capabilities,
+    falling back to the provider-level defaults from the registry.
+
+    Providers that do not satisfy [pred] are removed.
+    If all providers are filtered out, returns the original list
+    (let the provider return an API error rather than an empty cascade). *)
+let filter_by_capabilities ~(pred : Capabilities.capabilities -> bool)
+    (providers : Provider_config.t list) =
+  let satisfies (cfg : Provider_config.t) =
+    let caps = match Capabilities.for_model_id cfg.model_id with
+      | Some c -> c
+      | None ->
+        match Provider_registry.find default_registry cfg.model_id with
+        | Some entry -> entry.capabilities
+        | None -> Capabilities.default_capabilities
+    in
+    pred caps
+  in
+  let filtered = List.filter satisfies providers in
+  if filtered = [] then providers  (* fallback: pass all through *)
+  else filtered
+
 (* ── Helpers ────────────────────────────────────────────── *)
 
 let text_of_response (resp : Types.api_response) : string =
@@ -535,3 +560,25 @@ let%test "parse_model_string case-insensitive provider" =
   match parse_model_string "LLAMA:model1" with
   | Some cfg -> cfg.model_id = "model1"
   | None -> false
+
+let%test "filter_by_capabilities keeps tool-supporting providers" =
+  let tool_cfg = Provider_config.make ~kind:OpenAI_compat ~model_id:"qwen3.5"
+    ~base_url:"http://localhost:8085" () in
+  let no_tool_cfg = Provider_config.make ~kind:OpenAI_compat ~model_id:"unknown-no-tools"
+    ~base_url:"http://localhost:8085" () in
+  let result = filter_by_capabilities
+    ~pred:(fun c -> c.Capabilities.supports_tools)
+    [tool_cfg; no_tool_cfg] in
+  (* qwen3.5 has tools via for_model_id, unknown falls back to default (no tools) *)
+  List.length result = 1
+
+let%test "filter_by_capabilities returns all if none match" =
+  let cfg1 = Provider_config.make ~kind:OpenAI_compat ~model_id:"unknown-a"
+    ~base_url:"http://localhost:8085" () in
+  let cfg2 = Provider_config.make ~kind:OpenAI_compat ~model_id:"unknown-b"
+    ~base_url:"http://localhost:8085" () in
+  let result = filter_by_capabilities
+    ~pred:(fun c -> c.Capabilities.supports_computer_use)
+    [cfg1; cfg2] in
+  (* Neither supports computer_use, fallback to all *)
+  List.length result = 2

--- a/lib/llm_provider/cascade_config.mli
+++ b/lib/llm_provider/cascade_config.mli
@@ -68,6 +68,24 @@ val filter_healthy :
   Provider_config.t list ->
   Provider_config.t list
 
+(** {1 Capability-Aware Filtering} *)
+
+(** Filter providers by a capability predicate.
+
+    Resolves capabilities per-model (via {!Capabilities.for_model_id})
+    with registry-level fallback. Removes providers that do not satisfy
+    [pred]. If all providers would be removed, returns the original list
+    unchanged (let the provider return an API error).
+
+    Example: filter to providers supporting tools:
+    {[ filter_by_capabilities ~pred:(fun c -> c.supports_tools) providers ]}
+
+    @since 0.78.0 *)
+val filter_by_capabilities :
+  pred:(Capabilities.capabilities -> bool) ->
+  Provider_config.t list ->
+  Provider_config.t list
+
 (** {1 Named Cascade Execution} *)
 
 (** Extract the concatenated text content from an API response.


### PR DESCRIPTION
## Summary
- GLM capabilities를 4개 모델별 tier로 세분화
- `filter_by_capabilities` 추가: cascade에서 capability 기반 provider 필터링
- 7개 인라인 테스트 추가

## GLM Model Tiers
| Model | Context | Output | Tools | Reasoning | Vision |
|-------|---------|--------|-------|-----------|--------|
| glm-4.5/5 | 200K | 128K | Yes | Yes | Yes |
| glm-4 | 128K | 4K | Yes | No | No |
| glm-4-flash | 128K | 4K | Yes | No | No |
| glm-4v | 128K | 4K | Yes | No | Yes |

## filter_by_capabilities
```ocaml
(* tools를 지원하는 provider만 남기기 *)
let filtered = Cascade_config.filter_by_capabilities
  ~pred:(fun c -> c.supports_tools) providers

(* 모든 provider가 필터되면 원래 리스트 반환 (안전 장치) *)
```

## Test plan
- [x] `dune build --root .` passes
- [x] `dune runtest --root . --force` — 0 failures
- [x] 5 GLM model-specific capability tests
- [x] 2 filter_by_capabilities tests (keep/fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)