### PR TITLE
refactor: add default cascade profile fallback

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,0 +1,4 @@
+{
+  "default_models": ["llama:auto", "glm:auto"],
+  "briefing_models": ["llama:auto", "glm:flash", "gemini:flash", "glm:auto"]
+}

--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -184,6 +184,20 @@ let text_of_response (resp : Types.api_response) : string =
     | _ -> None)
   |> String.concat ""
 
+(* ── Model resolution: named → "default" → hardcoded ─── *)
+
+(* TODO: per-profile temperature / max_tokens overrides from JSON *)
+
+let resolve_model_strings ?config_path ~name ~defaults () =
+  match config_path with
+  | Some path ->
+    let from_file = load_profile ~config_path:path ~name in
+    if from_file <> [] then from_file
+    else
+      let fallback = load_profile ~config_path:path ~name:"default" in
+      if fallback <> [] then fallback else defaults
+  | None -> defaults
+
 (* ── Named cascade execution ───────────────────────────── *)
 
 (** Accept-aware cascade: try each provider, skip on failure or rejection. *)
@@ -258,14 +272,8 @@ let complete_named ~sw ~net ?clock ?config_path
     ?(tools = []) ?(temperature = 0.3) ?(max_tokens = 500)
     ?system_prompt ?(accept = fun _ -> true)
     ?timeout_sec ?cache ?metrics () =
-  (* 1. Load from config file, fall back to defaults *)
-  let model_strings =
-    match config_path with
-    | Some path ->
-      let from_file = load_profile ~config_path:path ~name in
-      if from_file <> [] then from_file else defaults
-    | None -> defaults
-  in
+  (* 1. Resolve: named profile → "default" profile → hardcoded defaults *)
+  let model_strings = resolve_model_strings ?config_path ~name ~defaults () in
   (* 2. Parse model strings → Provider_config.t list *)
   let providers =
     parse_model_strings ~temperature ~max_tokens ?system_prompt model_strings
@@ -369,12 +377,7 @@ let complete_named_stream ~sw ~net ?clock ?config_path
     ~name ~defaults ~messages
     ?(tools = []) ?(temperature = 0.3) ?(max_tokens = 500)
     ?system_prompt ?timeout_sec ?metrics ~on_event () =
-  let model_strings = match config_path with
-    | Some path ->
-      let from_file = load_profile ~config_path:path ~name in
-      if from_file <> [] then from_file else defaults
-    | None -> defaults
-  in
+  let model_strings = resolve_model_strings ?config_path ~name ~defaults () in
   let providers =
     parse_model_strings ~temperature ~max_tokens ?system_prompt model_strings
   in
@@ -510,6 +513,47 @@ let%test "text_of_response non-text blocks ignored" =
 let%test "load_profile nonexistent file returns empty" =
   Eio_main.run (fun _env ->
     load_profile ~config_path:"/nonexistent/file.json" ~name:"test" = [])
+
+let%test "resolve_model_strings no config_path returns defaults" =
+  resolve_model_strings ~name:"test" ~defaults:["llama:auto"] () = ["llama:auto"]
+
+let%test "resolve_model_strings nonexistent file returns defaults" =
+  Eio_main.run (fun _env ->
+    resolve_model_strings ~config_path:"/nonexistent.json"
+      ~name:"test" ~defaults:["llama:auto"] () = ["llama:auto"])
+
+let%test "resolve_model_strings named profile found" =
+  Eio_main.run (fun _env ->
+    let tmp = Filename.temp_file "cascade" ".json" in
+    let oc = open_out tmp in
+    output_string oc {|{"foo_models": ["glm:flash"]}|};
+    close_out oc;
+    let result = resolve_model_strings ~config_path:tmp
+      ~name:"foo" ~defaults:["llama:auto"] () in
+    Sys.remove tmp;
+    result = ["glm:flash"])
+
+let%test "resolve_model_strings falls back to default profile" =
+  Eio_main.run (fun _env ->
+    let tmp = Filename.temp_file "cascade" ".json" in
+    let oc = open_out tmp in
+    output_string oc {|{"default_models": ["glm:auto", "llama:auto"]}|};
+    close_out oc;
+    let result = resolve_model_strings ~config_path:tmp
+      ~name:"nonexistent" ~defaults:["fallback:x"] () in
+    Sys.remove tmp;
+    result = ["glm:auto"; "llama:auto"])
+
+let%test "resolve_model_strings named takes priority over default" =
+  Eio_main.run (fun _env ->
+    let tmp = Filename.temp_file "cascade" ".json" in
+    let oc = open_out tmp in
+    output_string oc {|{"named_models": ["glm:flash"], "default_models": ["llama:auto"]}|};
+    close_out oc;
+    let result = resolve_model_strings ~config_path:tmp
+      ~name:"named" ~defaults:["fallback:x"] () in
+    Sys.remove tmp;
+    result = ["glm:flash"])
 
 let%test "default_registry has 5 providers" =
   List.length (Provider_registry.all default_registry) = 5

--- a/lib/llm_provider/cascade_config.mli
+++ b/lib/llm_provider/cascade_config.mli
@@ -50,6 +50,21 @@ val load_profile :
   name:string ->
   string list
 
+(** Resolve model strings for a named cascade.
+
+    Resolution order:
+    1. Named profile "{name}_models" from [config_path]
+    2. "default_models" profile from [config_path] (fallback)
+    3. Hardcoded [defaults]
+
+    When [config_path] is [None], returns [defaults] directly. *)
+val resolve_model_strings :
+  ?config_path:string ->
+  name:string ->
+  defaults:string list ->
+  unit ->
+  string list
+
 (** {1 Discovery-Aware Health Filtering} *)
 
 (** Filter a provider list by local endpoint health.

--- a/test/test_cascade_config.ml
+++ b/test/test_cascade_config.ml
@@ -133,6 +133,52 @@ let test_load_profile_hot_reload () =
        check int "reloaded" 2 (List.length m2);
        check string "v2" "llama:v2" (List.hd m2))
 
+(* ── resolve_model_strings ────────────────────────────── *)
+
+let test_resolve_no_config_path () =
+  let result = Cascade_config.resolve_model_strings
+      ~name:"test" ~defaults:["llama:auto"] () in
+  check int "count" 1 (List.length result);
+  check string "first" "llama:auto" (List.hd result)
+
+let test_resolve_named_profile () =
+  Eio_main.run @@ fun _env ->
+  with_temp_json
+    {|{"myprofile_models": ["glm:flash", "llama:qwen3.5"]}|}
+    (fun path ->
+       let result = Cascade_config.resolve_model_strings
+           ~config_path:path ~name:"myprofile" ~defaults:["fallback:x"] () in
+       check int "count" 2 (List.length result);
+       check string "first" "glm:flash" (List.hd result))
+
+let test_resolve_falls_back_to_default () =
+  Eio_main.run @@ fun _env ->
+  with_temp_json
+    {|{"default_models": ["glm:auto", "llama:auto"]}|}
+    (fun path ->
+       let result = Cascade_config.resolve_model_strings
+           ~config_path:path ~name:"nonexistent" ~defaults:["hardcoded:x"] () in
+       check int "count" 2 (List.length result);
+       check string "first" "glm:auto" (List.hd result))
+
+let test_resolve_named_over_default () =
+  Eio_main.run @@ fun _env ->
+  with_temp_json
+    {|{"named_models": ["glm:flash"], "default_models": ["llama:auto"]}|}
+    (fun path ->
+       let result = Cascade_config.resolve_model_strings
+           ~config_path:path ~name:"named" ~defaults:["hardcoded:x"] () in
+       check int "count" 1 (List.length result);
+       check string "named wins" "glm:flash" (List.hd result))
+
+let test_resolve_hardcoded_when_no_profiles () =
+  Eio_main.run @@ fun _env ->
+  with_temp_json {|{"other_models": ["glm:x"]}|} (fun path ->
+    let result = Cascade_config.resolve_model_strings
+        ~config_path:path ~name:"missing" ~defaults:["hardcoded:x"] () in
+    check int "count" 1 (List.length result);
+    check string "hardcoded fallback" "hardcoded:x" (List.hd result))
+
 (* ── Health filtering ─────────────────────────────────── *)
 
 let test_is_local_detection () =
@@ -198,6 +244,13 @@ let () =
       test_case "missing key" `Quick test_load_profile_missing_key;
       test_case "missing file" `Quick test_load_profile_missing_file;
       test_case "hot reload" `Quick test_load_profile_hot_reload;
+    ];
+    "resolve", [
+      test_case "no config_path" `Quick test_resolve_no_config_path;
+      test_case "named profile" `Quick test_resolve_named_profile;
+      test_case "falls back to default" `Quick test_resolve_falls_back_to_default;
+      test_case "named over default" `Quick test_resolve_named_over_default;
+      test_case "hardcoded when no profiles" `Quick test_resolve_hardcoded_when_no_profiles;
     ];
     "health", [
       test_case "local detection" `Quick test_is_local_detection;


### PR DESCRIPTION
## Summary

- `resolve_model_strings` 헬퍼 추출: named profile → "default" profile → hardcoded defaults 3-tier fallback
- `config/cascade.json` 신규: `default_models`와 `briefing_models` 프로필 정의
- `complete_named` / `complete_named_stream` 중복 로직 제거
- 인라인 테스트 5개 + alcotest 5개 추가

## Motivation

모든 cascade profile이 동일한 `["llama:auto", "glm:auto"]`를 반복하고 있었음. JSON에 `default_models` 하나만 두면 unnamed profile이 자동으로 fallback.

## TODO

- [ ] per-profile temperature / max_tokens override (JSON에서 읽기)

## Test plan

- [x] `dune build` 성공
- [x] `dune runtest --force` 전체 통과 (FAILED 0)
- [x] `resolve_model_strings` 5개 시나리오 검증 (no config, named, default fallback, priority, hardcoded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)