### PR TITLE
fix: sync sdk_version.ml to 0.77.0

### DIFF
--- a/lib/sdk_version.ml
+++ b/lib/sdk_version.ml
@@ -1,5 +1,5 @@
 (** Single source of truth for the SDK version string.
     All other modules reference this instead of hardcoding. *)
 
-let version = "0.75.0"
+let version = "0.77.0"
 let sdk_name = "agent_sdk"


### PR DESCRIPTION
## Summary

- `sdk_version.ml` 버전을 `0.75.0` → `0.77.0`으로 수정하여 `dune-project`과 일치시킴
- 모든 open PR (#283-#286)의 Version Consistency check 실패 원인 해소

## Test plan

- [x] `dune runtest --force` 전체 통과
- [x] Version Consistency: `dune-project (0.77.0) == sdk_version.ml (0.77.0)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)