### PR TITLE
fix: inline test expects 6 providers

### DIFF
--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -580,8 +580,8 @@ let%test "resolve_model_strings named takes priority over default" =
     Sys.remove tmp;
     result = ["glm:flash"])
 
-let%test "default_registry has 5 providers" =
-  List.length (Provider_registry.all default_registry) = 5
+let%test "default_registry has 6 providers" =
+  List.length (Provider_registry.all default_registry) = 6
 
 let%test "default_registry llama is OpenAI_compat" =
   match Provider_registry.find default_registry "llama" with


### PR DESCRIPTION
## Summary

- `cascade_config.ml` 인라인 테스트 `default_registry has 5 providers` → `6`으로 수정
- #284에서 `cc` (Claude Code) provider가 추가되면서 6개로 증가했으나 인라인 테스트가 미수정

## Test plan

- [x] `dune runtest --force` FAILED 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)