### PR TITLE
feat: eval extension with Model Grader + regression detection

### DIFF
--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -293,3 +293,34 @@ let find_metric (rm : run_metrics) name =
 
 let find_metric_value rm name =
   Option.map (fun (m : metric) -> m.value) (find_metric rm name)
+
+(* ── Statistical regression detection ──────────────────────── *)
+
+(** Compare two run_metrics using statistical testing.
+    Extracts float values for each metric name, applies Welch's t-test
+    across all matching metrics. Returns a comparison enhanced with
+    statistical significance. *)
+let compare_statistical ~(baselines : run_metrics list) ~(candidates : run_metrics list) =
+  (* Collect per-metric float lists *)
+  let collect_metric_values (runs : run_metrics list) name =
+    List.filter_map (fun (rm : run_metrics) ->
+      match find_metric rm name with
+      | Some m -> metric_value_to_float m.value
+      | None -> None
+    ) runs
+  in
+  (* Get all metric names from baselines *)
+  let metric_names = List.sort_uniq String.compare
+    (List.concat_map (fun (rm : run_metrics) ->
+      List.map (fun (m : metric) -> m.name) rm.metrics
+    ) baselines)
+  in
+  let regressions = List.filter_map (fun name ->
+    let baseline_vals = collect_metric_values baselines name in
+    let candidate_vals = collect_metric_values candidates name in
+    if Eval_stats.is_regression ~baseline:baseline_vals ~current:candidate_vals then
+      let eff = Eval_stats.effect_size baseline_vals candidate_vals in
+      Some (name, eff)
+    else None
+  ) metric_names in
+  regressions

--- a/lib/eval.mli
+++ b/lib/eval.mli
@@ -124,3 +124,13 @@ val find_metric : run_metrics -> string -> metric option
 
 (** Find a metric value by name. *)
 val find_metric_value : run_metrics -> string -> metric_value option
+
+(** {1 Statistical regression detection} *)
+
+(** Compare multiple baseline runs against candidate runs.
+    Uses Welch's t-test per metric. Returns list of regressed
+    metric names with optional Cohen's d effect sizes. *)
+val compare_statistical :
+  baselines:run_metrics list ->
+  candidates:run_metrics list ->
+  (string * float option) list

--- a/lib/eval_stats.ml
+++ b/lib/eval_stats.ml
@@ -1,0 +1,157 @@
+(** Statistical utilities for eval regression detection.
+
+    @since 0.79.0 *)
+
+type stats = {
+  n: int;
+  mean: float;
+  std_dev: float;
+  min_val: float;
+  max_val: float;
+}
+
+let sum xs = List.fold_left ( +. ) 0.0 xs
+
+let mean xs =
+  let n = List.length xs in
+  if n = 0 then 0.0
+  else sum xs /. float_of_int n
+
+let variance xs =
+  let n = List.length xs in
+  if n < 2 then 0.0
+  else
+    let m = mean xs in
+    let ss = List.fold_left (fun acc x -> acc +. (x -. m) *. (x -. m)) 0.0 xs in
+    ss /. float_of_int (n - 1)
+
+let std_dev xs = sqrt (variance xs)
+
+let summary_stats xs =
+  match xs with
+  | [] -> None
+  | _ ->
+    let n = List.length xs in
+    let m = mean xs in
+    let sd = std_dev xs in
+    let min_val = List.fold_left Float.min Float.max_float xs in
+    let max_val = List.fold_left Float.max Float.min_float xs in
+    Some { n; mean = m; std_dev = sd; min_val; max_val }
+
+(** Z-score for common confidence levels (normal approximation). *)
+let z_score confidence =
+  if confidence >= 0.99 then 2.576
+  else if confidence >= 0.95 then 1.960
+  else if confidence >= 0.90 then 1.645
+  else 1.0
+
+let confidence_interval xs ~confidence =
+  let n = List.length xs in
+  if n < 2 then None
+  else
+    let m = mean xs in
+    let se = std_dev xs /. sqrt (float_of_int n) in
+    let z = z_score confidence in
+    Some (m -. z *. se, m +. z *. se)
+
+(** Welch's t-test: tests whether current is significantly higher than baseline.
+    One-sided test at alpha=0.05.
+    Uses approximate critical value t=1.645 (conservative for df > 30). *)
+let is_regression ~baseline ~current =
+  let n1 = List.length baseline in
+  let n2 = List.length current in
+  if n1 < 2 || n2 < 2 then false
+  else
+    let m1 = mean baseline in
+    let m2 = mean current in
+    let v1 = variance baseline in
+    let v2 = variance current in
+    let se = sqrt (v1 /. float_of_int n1 +. v2 /. float_of_int n2) in
+    if se < 1e-10 then
+      m2 > m1  (* Zero variance: any increase is a regression *)
+    else
+      let t = (m2 -. m1) /. se in
+      t > 1.645  (* One-sided alpha=0.05 *)
+
+let effect_size xs ys =
+  let n1 = List.length xs in
+  let n2 = List.length ys in
+  if n1 < 2 || n2 < 2 then None
+  else
+    let m1 = mean xs in
+    let m2 = mean ys in
+    let v1 = variance xs in
+    let v2 = variance ys in
+    let pooled_var =
+      (float_of_int (n1 - 1) *. v1 +. float_of_int (n2 - 1) *. v2)
+      /. float_of_int (n1 + n2 - 2)
+    in
+    let pooled_sd = sqrt pooled_var in
+    if pooled_sd < 1e-10 then None
+    else Some ((m2 -. m1) /. pooled_sd)
+
+[@@@coverage off]
+(* === Inline tests === *)
+
+let%test "summary_stats empty" =
+  summary_stats [] = None
+
+let%test "summary_stats single element" =
+  match summary_stats [5.0] with
+  | Some s -> s.n = 1 && s.mean = 5.0 && s.min_val = 5.0 && s.max_val = 5.0
+  | None -> false
+
+let%test "summary_stats multiple" =
+  match summary_stats [1.0; 2.0; 3.0; 4.0; 5.0] with
+  | Some s -> s.n = 5 && s.mean = 3.0 && s.min_val = 1.0 && s.max_val = 5.0
+  | None -> false
+
+let%test "summary_stats std_dev" =
+  match summary_stats [2.0; 4.0; 4.0; 4.0; 5.0; 5.0; 7.0; 9.0] with
+  | Some s -> s.std_dev > 2.0 && s.std_dev < 2.2  (* ~2.138 *)
+  | None -> false
+
+let%test "confidence_interval too small" =
+  confidence_interval [1.0] ~confidence:0.95 = None
+
+let%test "confidence_interval 95%" =
+  match confidence_interval [1.0; 2.0; 3.0; 4.0; 5.0] ~confidence:0.95 with
+  | Some (lo, hi) -> lo < 3.0 && hi > 3.0 && lo > 0.0 && hi < 6.0
+  | None -> false
+
+let%test "is_regression no data" =
+  is_regression ~baseline:[1.0] ~current:[2.0] = false
+
+let%test "is_regression same distribution" =
+  is_regression
+    ~baseline:[1.0; 2.0; 3.0; 4.0; 5.0]
+    ~current:[1.0; 2.0; 3.0; 4.0; 5.0] = false
+
+let%test "is_regression significant increase" =
+  is_regression
+    ~baseline:[1.0; 1.0; 1.0; 1.0; 1.0; 1.0; 1.0; 1.0; 1.0; 1.0]
+    ~current:[5.0; 5.0; 5.0; 5.0; 5.0; 5.0; 5.0; 5.0; 5.0; 5.0] = true
+
+let%test "is_regression slight increase not significant" =
+  is_regression
+    ~baseline:[10.0; 10.1; 9.9; 10.2; 9.8]
+    ~current:[10.1; 10.2; 10.0; 10.3; 9.9] = false
+
+let%test "effect_size too small" =
+  effect_size [1.0] [2.0] = None
+
+let%test "effect_size zero difference" =
+  match effect_size [1.0; 2.0; 3.0] [1.0; 2.0; 3.0] with
+  | Some d -> Float.abs d < 0.01
+  | None -> false
+
+let%test "effect_size large difference" =
+  match effect_size
+    [1.0; 1.0; 1.0; 1.0; 1.0]
+    [5.0; 5.0; 5.0; 5.0; 5.0] with
+  | Some d -> d > 3.0  (* Very large effect *)
+  | None -> false
+
+let%test "effect_size identical values returns None" =
+  (* All same -> pooled_sd = 0 -> None *)
+  effect_size [1.0; 1.0; 1.0] [1.0; 1.0; 1.0] = None

--- a/lib/eval_stats.mli
+++ b/lib/eval_stats.mli
@@ -1,0 +1,35 @@
+(** Statistical utilities for eval regression detection.
+
+    Provides summary statistics, confidence intervals, and
+    Welch's t-test for comparing two samples.
+
+    @since 0.79.0 *)
+
+(** Summary statistics for a sample. *)
+type stats = {
+  n: int;
+  mean: float;
+  std_dev: float;
+  min_val: float;
+  max_val: float;
+}
+
+(** Compute summary statistics for a list of floats.
+    Returns [None] for empty lists. *)
+val summary_stats : float list -> stats option
+
+(** Compute a confidence interval using the normal approximation.
+    Returns [(lower, upper)] bounds.
+    [confidence] should be between 0 and 1 (e.g. 0.95 for 95% CI).
+    Returns [None] if sample size < 2. *)
+val confidence_interval : float list -> confidence:float -> (float * float) option
+
+(** Detect regression using Welch's t-test.
+    Returns [true] if the current sample is significantly worse
+    (higher values) than baseline at the 0.05 significance level.
+    Returns [false] if either sample has fewer than 2 elements. *)
+val is_regression : baseline:float list -> current:float list -> bool
+
+(** Compute Cohen's d effect size between two samples.
+    Returns [None] if either sample has fewer than 2 elements or pooled std_dev is 0. *)
+val effect_size : float list -> float list -> float option

--- a/lib/harness.ml
+++ b/lib/harness.ml
@@ -497,3 +497,55 @@ module Composability = struct
             obs.total_turns limit);
       }
 end
+
+(* ── Model grader ──────────────────────────────────────────── *)
+
+module Model_grader = struct
+  (** Configuration for LLM-based evaluation. *)
+  type config = {
+    prompt_template: string;   (** Must contain {goal} and {result} placeholders *)
+    rubric: string;            (** Evaluation criteria *)
+    weight: float;             (** 0.0-1.0 weight for this grader *)
+  }
+
+  (** Grade a result using an LLM.
+      [complete_fn] is a dependency-injected completion function.
+      Returns a verdict with score extracted from the LLM response.
+
+      The prompt is constructed by replacing \{goal\} and \{result\}
+      in the template, appending the rubric. The LLM response is
+      parsed for a numeric score (first float found). *)
+  let grade ~complete_fn (config : config) ~goal ~result : verdict =
+    let prompt = config.prompt_template
+      |> Str.global_replace (Str.regexp_string "{goal}") goal
+      |> Str.global_replace (Str.regexp_string "{result}") result
+    in
+    let full_prompt = Printf.sprintf "%s\n\nRubric:\n%s\n\nRespond with a score from 0.0 to 1.0 on the first line, then explanation."
+      prompt config.rubric
+    in
+    match complete_fn full_prompt with
+    | Error msg ->
+      { passed = false; score = None;
+        evidence = [Printf.sprintf "grader_error=%s" msg];
+        detail = Some (Printf.sprintf "Model grader failed: %s" msg) }
+    | Ok response ->
+      (* Extract first float from response *)
+      let score = try
+        let _ = Str.search_forward (Str.regexp {|[0-9]+\.[0-9]+|}) response 0 in
+        Some (float_of_string (Str.matched_string response))
+      with Not_found | Failure _ -> None
+      in
+      let score = Option.map (fun s -> Float.min 1.0 (Float.max 0.0 s)) score in
+      let passed = match score with
+        | Some s -> s >= 0.5 *. config.weight
+        | None -> false
+      in
+      { passed; score;
+        evidence = [
+          Printf.sprintf "weight=%.2f" config.weight;
+          Printf.sprintf "response_len=%d" (String.length response);
+        ];
+        detail = match score with
+          | Some s -> Some (Printf.sprintf "Score: %.2f (weight: %.2f)" s config.weight)
+          | None -> Some "Could not extract score from model response" }
+end

--- a/lib/harness.mli
+++ b/lib/harness.mli
@@ -168,3 +168,24 @@ module Composability : sig
   (** Evaluate composability observation against expectation. *)
   val evaluate : observation -> expectation -> verdict
 end
+
+(** {1 Model grader} *)
+
+module Model_grader : sig
+  (** Configuration for LLM-based evaluation. *)
+  type config = {
+    prompt_template: string;   (** Must contain \{goal\} and \{result\} placeholders *)
+    rubric: string;            (** Evaluation criteria *)
+    weight: float;             (** 0.0-1.0 weight for this grader *)
+  }
+
+  (** Grade a result using an LLM via dependency-injected [complete_fn].
+      Extracts a numeric score from the LLM response.
+      [passed] is true when score >= 0.5 * weight. *)
+  val grade :
+    complete_fn:(string -> (string, string) result) ->
+    config ->
+    goal:string ->
+    result:string ->
+    verdict
+end


### PR DESCRIPTION
## Summary
- New `eval_stats.ml`: summary_stats, confidence_interval, Welch t-test, Cohen d
- New `Harness.Model_grader`: LLM-based grading with dependency-injected `complete_fn`
- New `Eval.compare_statistical`: multi-run regression detection per metric

## Changes
- `lib/eval_stats.ml/.mli`: New statistical utilities (14 inline tests)
- `lib/harness.ml/.mli`: `Model_grader` module
- `lib/eval.ml/.mli`: `compare_statistical` function

## Test plan
- [x] `dune build` clean
- [x] `dune runtest` all pass
- [ ] Cross-model review

🤖 Generated with [Claude Code](https://claude.com/claude-code)