### PR TITLE
feat: support mixed harness datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,10 @@ make coverage
 # Harness datasets
 oas eval record-trace --session /path/to/raw-trace.ndjson --out evals/replay.jsonl
 oas eval run --dataset examples/evals/replay.jsonl --out _build/evals
+oas eval run --config oas.json --dataset examples/evals/mixed.jsonl --out _build/evals
 oas eval run --config oas.json --dataset evals/replay.jsonl --out _build/evals
+
+# `trace_replay` cases run offline, `fixture` cases use --config live in the same dataset
 
 # Integration tests (requires local LLM server)
 LLAMA_LIVE_TEST=1 dune exec ./test/test_local_llm.exe

--- a/bin/oas_cli.ml
+++ b/bin/oas_cli.ml
@@ -192,25 +192,7 @@ let eval_run_cmd config_file dataset_path out_dir =
   | Ok dataset ->
     (match config_file with
      | None ->
-       let results =
-         List.map (fun (case_ : Agent_sdk.Harness_case.t) ->
-           match Agent_sdk.Harness_runner.grade_case_from_trace case_ with
-           | Ok result -> result
-           | Error e ->
-             {
-               Agent_sdk.Harness_report.case_id = case_.id;
-               kind = case_.kind;
-               status = Agent_sdk.Harness_report.Fail;
-               verdicts = [];
-               evidence = [];
-               detail = Some (Agent_sdk.Error.to_string e);
-               response_text = None;
-               raw_trace_path = case_.source_trace_path;
-               metrics = None;
-             }
-         ) dataset
-       in
-       let report = Agent_sdk.Harness_report.of_results results in
+       let report = Agent_sdk.Harness_runner.run_dataset_mixed dataset in
        write_report_artifacts ~out_dir report;
        exit_for_report report
      | Some config_file ->
@@ -237,8 +219,9 @@ let eval_run_cmd config_file dataset_path out_dir =
            in
            Agent_sdk.Builder.build_safe builder
          in
+         let run_fixture = Agent_sdk.Harness_runner.run_case ~sw ~clock ~build_agent in
          let report =
-           Agent_sdk.Harness_runner.run_dataset ~sw ~clock ~build_agent dataset
+           Agent_sdk.Harness_runner.run_dataset_mixed ~run_fixture dataset
          in
          write_report_artifacts ~out_dir report;
          exit_for_report report)

--- a/examples/evals/mixed.jsonl
+++ b/examples/evals/mixed.jsonl
@@ -1,0 +1,2 @@
+{"id":"hello-fixture","kind":"fixture","prompt":"Reply with the single word: hello","tags":["example","fixture"],"assertions":[{"type":"trace_succeeds"}],"artifacts":[],"source_trace_path":null}
+{"id":"hello-replay","kind":"trace_replay","prompt":"Say hello from replay","tags":["example","trace-replay"],"assertions":[{"type":"response_exact_text","value":"hello from replay"},{"type":"trace_succeeds"},{"type":"trace_max_turns","value":1}],"artifacts":["examples/evals/hello-trace.ndjson"],"source_trace_path":"examples/evals/hello-trace.ndjson"}

--- a/lib/harness_runner.ml
+++ b/lib/harness_runner.ml
@@ -3,6 +3,20 @@
 let mk_verdict ?score ~detail passed evidence : Harness.verdict =
   { passed; score; evidence; detail }
 
+let case_failure ?detail ?response_text ?metrics ?raw_trace_path
+    (case_ : Harness_case.t) =
+  {
+    Harness_report.case_id = case_.id;
+    kind = case_.kind;
+    status = Harness_report.Fail;
+    verdicts = [];
+    evidence = [];
+    detail;
+    response_text;
+    raw_trace_path = Util.first_some raw_trace_path case_.source_trace_path;
+    metrics;
+  }
+
 let response_text_of_result = function
   | Ok (response : Types.api_response) ->
     response.content
@@ -345,20 +359,26 @@ let grade_case_from_trace (case_ : Harness_case.t) =
          ~raw_trace_path:path
          case_))
 
+let execute_case ?run_fixture (case_ : Harness_case.t) =
+  match case_.kind with
+  | Harness_case.Trace_replay ->
+    (match grade_case_from_trace case_ with
+     | Ok result -> result
+     | Error e -> case_failure case_ ~detail:(Error.to_string e))
+  | Harness_case.Fixture ->
+    (match run_fixture with
+     | Some run_fixture -> run_fixture case_
+     | None ->
+       case_failure case_
+         ~detail:(
+           (Printf.sprintf
+              "case '%s' requires live fixture execution; rerun with --config"
+              case_.id)))
+
 let run_case ~sw ~clock ~build_agent (case_ : Harness_case.t) =
   match build_agent case_ with
   | Error err ->
-    {
-      Harness_report.case_id = case_.id;
-      kind = case_.kind;
-      status = Harness_report.Fail;
-      verdicts = [];
-      evidence = [];
-      detail = Some (Error.to_string err);
-      response_text = None;
-      raw_trace_path = case_.source_trace_path;
-      metrics = None;
-    }
+    case_failure case_ ~detail:(Error.to_string err)
   | Ok agent ->
     let run_result = Consumer.run_agent ~sw ~clock agent case_.prompt in
     let obs = Harness.Behavioral.observe agent run_result.response in
@@ -377,7 +397,11 @@ let run_case ~sw ~clock ~build_agent (case_ : Harness_case.t) =
       ?raw_trace_path
       case_
 
-let run_dataset ~sw ~clock ~build_agent cases =
+let run_dataset_mixed ?run_fixture cases =
   cases
-  |> List.map (run_case ~sw ~clock ~build_agent)
+  |> List.map (execute_case ?run_fixture)
   |> Harness_report.of_results
+
+let run_dataset ~sw ~clock ~build_agent cases =
+  let run_fixture = run_case ~sw ~clock ~build_agent in
+  run_dataset_mixed ~run_fixture cases

--- a/lib/harness_runner.mli
+++ b/lib/harness_runner.mli
@@ -14,12 +14,22 @@ val grade_case_from_trace :
   Harness_case.t ->
   (Harness_report.case_result, Error.sdk_error) result
 
+val execute_case :
+  ?run_fixture:(Harness_case.t -> Harness_report.case_result) ->
+  Harness_case.t ->
+  Harness_report.case_result
+
 val run_case :
   sw:Eio.Switch.t ->
   clock:_ Eio.Time.clock ->
   build_agent:(Harness_case.t -> (Agent.t, Error.sdk_error) result) ->
   Harness_case.t ->
   Harness_report.case_result
+
+val run_dataset_mixed :
+  ?run_fixture:(Harness_case.t -> Harness_report.case_result) ->
+  Harness_case.t list ->
+  Harness_report.t
 
 val run_dataset :
   sw:Eio.Switch.t ->

--- a/test/dune
+++ b/test/dune
@@ -328,7 +328,7 @@
 
 (test
  (name test_cli)
- (libraries agent_sdk alcotest yojson unix str)
+ (libraries agent_sdk alcotest yojson unix str eio eio_main cohttp-eio)
  (deps ../bin/oas_cli.exe))
 
 (test

--- a/test/test_cli.ml
+++ b/test/test_cli.ml
@@ -24,6 +24,63 @@ let cli_exe =
       (* Last resort: just try the path and let it fail at runtime *)
       candidate
 
+let quick_response text =
+  Printf.sprintf
+    {|{"id":"m","type":"message","role":"assistant","model":"m","content":[{"type":"text","text":"%s"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}|}
+    text
+
+let start_mock ~sw ~net ~clock ~port response_text =
+  let handler _conn _req body =
+    let _ = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    ignore clock;
+    Cohttp_eio.Server.respond_string
+      ~status:`OK ~body:(quick_response response_text) ()
+  in
+  let socket =
+    Eio.Net.listen net ~sw ~backlog:128 ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  let server = Cohttp_eio.Server.make ~callback:handler () in
+  Eio.Fiber.fork ~sw (fun () ->
+    Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+  Printf.sprintf "http://127.0.0.1:%d" port
+
+let read_all_lines flow =
+  let buf = Buffer.create 256 in
+  let reader = Eio.Buf_read.of_flow flow ~max_size:(1024 * 1024) in
+  try
+    while true do
+      Buffer.add_string buf (Eio.Buf_read.line reader);
+      Buffer.add_char buf '\n'
+    done;
+    Buffer.contents buf
+  with End_of_file ->
+    Buffer.contents buf
+
+let run_cli_capture ~sw ~mgr args =
+  let r_stdout, w_stdout = Eio_unix.pipe sw in
+  let r_stderr, w_stderr = Eio_unix.pipe sw in
+  let proc =
+    Eio.Process.spawn ~sw mgr
+      ~stdout:(w_stdout :> Eio.Flow.sink_ty Eio.Resource.t)
+      ~stderr:(w_stderr :> Eio.Flow.sink_ty Eio.Resource.t)
+      (cli_exe :: args)
+  in
+  Eio.Flow.close w_stdout;
+  Eio.Flow.close w_stderr;
+  let stdout_buf = ref "" in
+  let stderr_buf = ref "" in
+  Eio.Fiber.both
+    (fun () -> stdout_buf := read_all_lines (r_stdout :> _ Eio.Flow.source))
+    (fun () -> stderr_buf := read_all_lines (r_stderr :> _ Eio.Flow.source));
+  (Eio.Process.await proc, !stdout_buf, !stderr_buf)
+
+let remove_path path =
+  try Sys.remove path with _ -> ()
+
+let remove_dir_if_empty path =
+  try Sys.rmdir path with _ -> ()
+
 (* ── Version subcommand ─────────────────────────────────── *)
 
 let test_version_output () =
@@ -250,6 +307,89 @@ let test_eval_run_trace_replay_dataset () =
       check bool "report markdown exists" true
         (Sys.file_exists (Filename.concat out_dir "report.md")))
 
+let test_eval_run_mixed_dataset () =
+  let trace_path = Printf.sprintf "/tmp/oas_cli_mixed_trace_%d.ndjson" (Unix.getpid ()) in
+  let dataset_path = Printf.sprintf "/tmp/oas_cli_mixed_%d.jsonl" (Unix.getpid ()) in
+  let config_path = Printf.sprintf "/tmp/oas_cli_mixed_%d.json" (Unix.getpid ()) in
+  let out_dir = Printf.sprintf "/tmp/oas_cli_mixed_out_%d" (Unix.getpid ()) in
+  let fixture_trace = Filename.concat out_dir "fixture-live.ndjson" in
+  let port = 19150 + (Unix.getpid () mod 1000) in
+  Fun.protect
+    ~finally:(fun () ->
+      remove_path trace_path;
+      remove_path dataset_path;
+      remove_path config_path;
+      remove_path (Filename.concat out_dir "report.json");
+      remove_path (Filename.concat out_dir "report.md");
+      remove_path (Filename.concat out_dir "report.junit.xml");
+      remove_path fixture_trace;
+      remove_dir_if_empty out_dir)
+    (fun () ->
+      Out_channel.with_open_text trace_path (fun oc ->
+        output_string oc
+          {|{"trace_version":1,"worker_run_id":"wr-cli","seq":1,"ts":1.0,"agent_name":"cli-agent","session_id":null,"record_type":"run_started","prompt":"Replay me","block_index":null,"block_kind":null,"assistant_block":null,"tool_use_id":null,"tool_name":null,"tool_input":null,"tool_result":null,"tool_error":null,"hook_name":null,"hook_decision":null,"hook_detail":null,"final_text":null,"stop_reason":null,"error":null}|};
+        output_char oc '\n';
+        output_string oc
+          {|{"trace_version":1,"worker_run_id":"wr-cli","seq":2,"ts":1.5,"agent_name":"cli-agent","session_id":null,"record_type":"run_finished","prompt":null,"block_index":null,"block_kind":null,"assistant_block":null,"tool_use_id":null,"tool_name":null,"tool_input":null,"tool_result":null,"tool_error":null,"hook_name":null,"hook_decision":null,"hook_detail":null,"final_text":"done","stop_reason":"end_turn","error":null}|};
+        output_char oc '\n');
+      Out_channel.with_open_text dataset_path (fun oc ->
+        output_string oc
+          {|{"id":"fixture-live","kind":"fixture","prompt":"Say fixture ok","tags":["test"],"assertions":[{"type":"response_exact_text","value":"fixture ok"},{"type":"trace_succeeds"}],"artifacts":[],"source_trace_path":null}|};
+        output_char oc '\n';
+        output_string oc
+          (Printf.sprintf
+             {|{"id":"trace-offline","kind":"trace_replay","prompt":"Replay me","tags":["test"],"assertions":[{"type":"response_exact_text","value":"done"},{"type":"trace_succeeds"}],"artifacts":["%s"],"source_trace_path":"%s"}|}
+             trace_path trace_path);
+        output_char oc '\n');
+      Eio_main.run @@ fun env ->
+      let clock = Eio.Stdenv.clock env in
+      let mgr = Eio.Stdenv.process_mgr env in
+      try
+        Eio.Switch.run @@ fun sw ->
+        let url = start_mock ~sw ~net:env#net ~clock ~port "fixture ok" in
+        Out_channel.with_open_text config_path (fun oc ->
+          output_string oc
+            (Printf.sprintf
+               {|{"name":"eval-mixed","model":"mock-model","provider":"local","base_url":"%s","max_turns":1}|}
+               url));
+        let status, stdout, stderr =
+          run_cli_capture ~sw ~mgr
+            [
+              "eval";
+              "run";
+              "--config"; config_path;
+              "--dataset"; dataset_path;
+              "--out"; out_dir;
+            ]
+        in
+        (match status with
+         | `Exited 0 -> ()
+         | `Exited code ->
+           fail (Printf.sprintf "cli exited %d\nstdout:\n%s\nstderr:\n%s" code stdout stderr)
+         | _ ->
+           fail (Printf.sprintf "cli terminated unexpectedly\nstdout:\n%s\nstderr:\n%s"
+                   stdout stderr));
+        check bool "report json exists" true
+          (Sys.file_exists (Filename.concat out_dir "report.json"));
+        let report_json =
+          In_channel.with_open_text (Filename.concat out_dir "report.json")
+            (fun ic -> Yojson.Safe.from_string (In_channel.input_all ic))
+        in
+        let open Yojson.Safe.Util in
+        check int "total" 2 (report_json |> member "summary" |> member "total" |> to_int);
+        check int "passed" 2 (report_json |> member "summary" |> member "passed" |> to_int);
+        check bool "fixture trace exists" true (Sys.file_exists fixture_trace);
+        let kinds =
+          report_json
+          |> member "results"
+          |> to_list
+          |> List.map (fun json -> json |> member "kind" |> to_string)
+        in
+        check bool "has fixture result" true (List.mem "fixture" kinds);
+        check bool "has trace replay result" true (List.mem "trace_replay" kinds);
+        Eio.Switch.fail sw Exit
+      with Exit -> ())
+
 (* ── Suite ──────────────────────────────────────────────── *)
 
 let () =
@@ -275,5 +415,6 @@ let () =
       test_case "record trace" `Quick test_eval_record_trace;
       test_case "run empty dataset" `Quick test_eval_run_empty_dataset;
       test_case "run trace replay dataset" `Quick test_eval_run_trace_replay_dataset;
+      test_case "run mixed dataset" `Quick test_eval_run_mixed_dataset;
     ];
   ]

--- a/test/test_harness_runner.ml
+++ b/test/test_harness_runner.ml
@@ -57,6 +57,33 @@ let mk_trajectory ?(success = true) ?(tool_names = []) ?(response_text = "done")
     error = None;
   }
 
+let with_trace_file name body =
+  let trace_path =
+    Printf.sprintf "/tmp/oas_harness_%s_%d.ndjson" name (Unix.getpid ())
+  in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove trace_path with _ -> ())
+    (fun () ->
+      Out_channel.with_open_text trace_path (fun oc ->
+        output_string oc
+          {|{"trace_version":1,"worker_run_id":"wr-file","seq":1,"ts":1.0,"agent_name":"runner-agent","session_id":null,"record_type":"run_started","prompt":"Replay this","block_index":null,"block_kind":null,"assistant_block":null,"tool_use_id":null,"tool_name":null,"tool_input":null,"tool_result":null,"tool_error":null,"hook_name":null,"hook_decision":null,"hook_detail":null,"final_text":null,"stop_reason":null,"error":null}|};
+        output_char oc '\n';
+        output_string oc
+          {|{"trace_version":1,"worker_run_id":"wr-file","seq":2,"ts":2.0,"agent_name":"runner-agent","session_id":null,"record_type":"run_finished","prompt":null,"block_index":null,"block_kind":null,"assistant_block":null,"tool_use_id":null,"tool_name":null,"tool_input":null,"tool_result":null,"tool_error":null,"hook_name":null,"hook_decision":null,"hook_detail":null,"final_text":"done","stop_reason":"end_turn","error":null}|};
+        output_char oc '\n');
+      body trace_path)
+
+let trace_case ~id ~trace_path =
+  Harness_case.make_trace_replay
+    ~assertions:[
+      Harness_case.Response (Harness_case.Exact_text "done");
+      Harness_case.Trace Harness_case.Succeeds;
+    ]
+    ~id
+    ~prompt:"Replay this"
+    ~source_trace_path:trace_path
+    ()
+
 let test_grade_case_fixture () =
   let case_ =
     Harness_case.make_fixture
@@ -159,28 +186,8 @@ let test_grade_case_trace_replay () =
     (String.length (Harness_report.to_markdown report) > 0)
 
 let test_grade_case_from_trace_file () =
-  let trace_path = Printf.sprintf "/tmp/oas_harness_trace_%d.ndjson" (Unix.getpid ()) in
-  Fun.protect
-    ~finally:(fun () -> try Sys.remove trace_path with _ -> ())
-    (fun () ->
-      Out_channel.with_open_text trace_path (fun oc ->
-        output_string oc
-          {|{"trace_version":1,"worker_run_id":"wr-file","seq":1,"ts":1.0,"agent_name":"runner-agent","session_id":null,"record_type":"run_started","prompt":"Replay this","block_index":null,"block_kind":null,"assistant_block":null,"tool_use_id":null,"tool_name":null,"tool_input":null,"tool_result":null,"tool_error":null,"hook_name":null,"hook_decision":null,"hook_detail":null,"final_text":null,"stop_reason":null,"error":null}|};
-        output_char oc '\n';
-        output_string oc
-          {|{"trace_version":1,"worker_run_id":"wr-file","seq":2,"ts":2.0,"agent_name":"runner-agent","session_id":null,"record_type":"run_finished","prompt":null,"block_index":null,"block_kind":null,"assistant_block":null,"tool_use_id":null,"tool_name":null,"tool_input":null,"tool_result":null,"tool_error":null,"hook_name":null,"hook_decision":null,"hook_detail":null,"final_text":"done","stop_reason":"end_turn","error":null}|};
-        output_char oc '\n');
-      let case_ =
-        Harness_case.make_trace_replay
-          ~assertions:[
-            Harness_case.Response (Harness_case.Exact_text "done");
-            Harness_case.Trace Harness_case.Succeeds;
-          ]
-          ~id:"trace-file"
-          ~prompt:"Replay this"
-          ~source_trace_path:trace_path
-          ()
-      in
+  with_trace_file "trace" (fun trace_path ->
+      let case_ = trace_case ~id:"trace-file" ~trace_path in
       match Harness_runner.grade_case_from_trace case_ with
       | Error e -> fail (Error.to_string e)
       | Ok result ->
@@ -224,6 +231,60 @@ let test_grade_case_negative_metric_tolerance () =
   in
   check bool "failed" true (result.status = Harness_report.Fail)
 
+let test_run_dataset_mixed_dispatches_by_kind () =
+  with_trace_file "mixed" (fun trace_path ->
+      let fixture_case =
+        Harness_case.make_fixture
+          ~assertions:[Harness_case.Response (Harness_case.Exact_text "fixture ok")]
+          ~id:"fixture-live"
+          ~prompt:"noop"
+          ()
+      in
+      let run_fixture case_ =
+        Harness_runner.grade_case
+          ~agent_name:"runner-agent"
+          ~elapsed:0.1
+          ~response:(Ok (ok_response "fixture ok"))
+          ~observation:(mk_observation ~final_response:"fixture ok" ())
+          case_
+      in
+      let report =
+        Harness_runner.run_dataset_mixed
+          ~run_fixture
+          [fixture_case; trace_case ~id:"trace-offline" ~trace_path]
+      in
+      check int "total" 2 report.summary.total;
+      check int "passed" 2 report.summary.passed;
+      check int "failed" 0 report.summary.failed)
+
+let test_run_dataset_mixed_without_fixture_runner_fails_fixture_only () =
+  with_trace_file "mixed-no-config" (fun trace_path ->
+      let fixture_case =
+        Harness_case.make_fixture
+          ~assertions:[Harness_case.Trace Harness_case.Succeeds]
+          ~id:"fixture-needs-config"
+          ~prompt:"noop"
+          ()
+      in
+      let report =
+        Harness_runner.run_dataset_mixed
+          [fixture_case; trace_case ~id:"trace-offline" ~trace_path]
+      in
+      check int "total" 2 report.summary.total;
+      check int "passed" 1 report.summary.passed;
+      check int "failed" 1 report.summary.failed;
+      let fixture_result =
+        match List.find_opt (fun (result : Harness_report.case_result) ->
+                result.case_id = "fixture-needs-config") report.results with
+        | Some result -> result
+        | None -> fail "missing fixture result"
+      in
+      check bool "fixture failed" true (fixture_result.status = Harness_report.Fail);
+      check bool "detail mentions config" true
+        (match fixture_result.detail with
+         | Some detail -> Util.string_contains ~needle:"--config" detail
+         | None -> false))
+
 let () =
   run "harness_runner" [
     "grade_case", [
@@ -232,5 +293,9 @@ let () =
       test_case "from trace file" `Quick test_grade_case_from_trace_file;
       test_case "rejects fixture in trace mode" `Quick test_grade_case_from_trace_rejects_fixture_kind;
       test_case "rejects negative tolerance" `Quick test_grade_case_negative_metric_tolerance;
+      test_case "mixed dataset dispatches by kind" `Quick
+        test_run_dataset_mixed_dispatches_by_kind;
+      test_case "mixed dataset without fixture runner fails fixture only" `Quick
+        test_run_dataset_mixed_without_fixture_runner_fails_fixture_only;
     ];
   ]


### PR DESCRIPTION
## Summary
- support mixed harness datasets by dispatching per-case between offline trace replay and live fixture execution
- update `oas eval run` to execute mixed datasets and fail fixture-only cases clearly when `--config` is missing
- add mixed dataset examples and runner/CLI regression coverage

## Validation
- `dune build --root . ./bin/oas_cli.exe ./test/test_harness_runner.exe ./test/test_cli.exe`
- `dune exec --root . ./test/test_harness_runner.exe`
- `dune exec --root . ./test/test_cli.exe`

## Notes
- `test_cli` binds a local loopback port for the mixed fixture mock server