### PR TITLE
refactor: lazy-cache cc_available + effective_max_context fallback

### DIFF
--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -175,6 +175,14 @@ let filter_healthy ~sw ~net (providers : Provider_config.t list) =
     else
       cloud_providers  (* All locals unhealthy — cloud only *)
 
+(* ── Context window resolution ──────────────────────────── *)
+
+let effective_max_context (entry : Provider_registry.entry)
+    (caps : Capabilities.capabilities) =
+  match caps.max_context_tokens with
+  | Some n -> n
+  | None -> entry.max_context
+
 (* ── Capability-aware filtering ─────────────────────────── *)
 
 (** Filter providers by a capability predicate.
@@ -626,3 +634,27 @@ let%test "filter_by_capabilities returns all if none match" =
     [cfg1; cfg2] in
   (* Neither supports computer_use, fallback to all *)
   List.length result = 2
+
+let%test "effective_max_context uses capability when present" =
+  let entry : Provider_registry.entry = {
+    name = "test"; max_context = 128_000;
+    defaults = { kind = OpenAI_compat; base_url = ""; api_key_env = "";
+                 request_path = "" };
+    capabilities = Capabilities.default_capabilities;
+    is_available = (fun () -> true);
+  } in
+  let caps = { Capabilities.default_capabilities with
+               max_context_tokens = Some 200_000 } in
+  effective_max_context entry caps = 200_000
+
+let%test "effective_max_context falls back to registry entry" =
+  let entry : Provider_registry.entry = {
+    name = "test"; max_context = 128_000;
+    defaults = { kind = OpenAI_compat; base_url = ""; api_key_env = "";
+                 request_path = "" };
+    capabilities = Capabilities.default_capabilities;
+    is_available = (fun () -> true);
+  } in
+  let caps = { Capabilities.default_capabilities with
+               max_context_tokens = None } in
+  effective_max_context entry caps = 128_000

--- a/lib/llm_provider/cascade_config.mli
+++ b/lib/llm_provider/cascade_config.mli
@@ -83,6 +83,17 @@ val filter_healthy :
   Provider_config.t list ->
   Provider_config.t list
 
+(** {1 Context Window Resolution} *)
+
+(** Effective max context tokens for a provider entry.
+
+    Returns [caps.max_context_tokens] when known (per-model), otherwise
+    falls back to [entry.max_context] (per-provider default from the registry).
+
+    @since 0.78.0 *)
+val effective_max_context :
+  Provider_registry.entry -> Capabilities.capabilities -> int
+
 (** {1 Capability-Aware Filtering} *)
 
 (** Filter providers by a capability predicate.

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -119,13 +119,16 @@ let default () =
     api_key_env = "";
     request_path = "";
   } in
-  let cc_available () =
-    try
-      let ic = Unix.open_process_in "which claude 2>/dev/null" in
-      let result = try input_line ic with End_of_file -> "" in
-      ignore (Unix.close_process_in ic);
-      String.length (String.trim result) > 0
-    with _ -> false
+  let cc_available =
+    let cached = lazy (
+      try
+        let ic = Unix.open_process_in "which claude 2>/dev/null" in
+        let result = try input_line ic with End_of_file -> "" in
+        ignore (Unix.close_process_in ic);
+        String.length (String.trim result) > 0
+      with _ -> false
+    ) in
+    fun () -> Lazy.force cached
   in
   register t { name = "cc"; defaults = cc_defaults; max_context = 200_000;
                capabilities = Capabilities.claude_code_capabilities;


### PR DESCRIPTION
## Summary

- `cc_available()`: `which claude` subprocess를 매 호출 spawn → `lazy`로 프로세스 생애주기 1회 실행
- `effective_max_context`: `Capabilities.max_context_tokens`가 `None`일 때 `Provider_registry.entry.max_context`를 fallback으로 사용하는 헬퍼 추가 (`.mli` 노출 + inline 테스트 2개)

## Test plan

- [x] `dune build` 성공
- [x] `dune test` 기존 실패(`eval_stats.ml effect_size`) 외 전부 통과
- [x] 새 inline 테스트 2개 (`effective_max_context uses capability when present`, `effective_max_context falls back to registry entry`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)