### PR TITLE
test: fix eval_stats large-effect inline test

### DIFF
--- a/lib/eval_stats.ml
+++ b/lib/eval_stats.ml
@@ -147,8 +147,8 @@ let%test "effect_size zero difference" =
 
 let%test "effect_size large difference" =
   match effect_size
-    [1.0; 1.0; 1.0; 1.0; 1.0]
-    [5.0; 5.0; 5.0; 5.0; 5.0] with
+    [1.0; 1.0; 1.0; 2.0; 2.0]
+    [4.0; 4.0; 5.0; 5.0; 5.0] with
   | Some d -> d > 3.0  (* Very large effect *)
   | None -> false
 


### PR DESCRIPTION
## Summary
- fix the `eval_stats` inline test data so the large-effect case has non-zero variance
- unblock CI failures triggered in both OCaml 5.1.x and 5.4.x `Test` jobs after #296 merged

## Validation
- `opam exec -- dune build --root . @runtest` filtered to confirm the previous blocker pattern no longer appears
- `./_build/default/test/test_cli.exe`

## Notes
- this is a follow-up to the already-merged #296; the failure was in `lib/eval_stats.ml` inline tests, not in the baseline CLI wiring itself