### PR TITLE
test: fix eval_stats large effect inline test

### DIFF
--- a/lib/eval_stats.ml
+++ b/lib/eval_stats.ml
@@ -147,8 +147,8 @@ let%test "effect_size zero difference" =
 
 let%test "effect_size large difference" =
   match effect_size
-    [1.0; 1.0; 1.0; 1.0; 1.0]
-    [5.0; 5.0; 5.0; 5.0; 5.0] with
+    [1.0; 1.0; 1.0; 1.0; 2.0]
+    [5.0; 5.0; 5.0; 5.0; 4.0] with
   | Some d -> d > 3.0  (* Very large effect *)
   | None -> false
 


### PR DESCRIPTION
## Summary
- fix the `effect_size large difference` inline test to use non-zero-variance samples
- keep `Eval_stats.effect_size` contract unchanged when pooled std_dev is zero

## Why
The current test expects a large Cohen's d from two constant samples. That contradicts the implementation and `mli` contract, which both return `None` when pooled standard deviation is zero.

## Test plan
- [x] `env DUNE_CACHE=disabled opam exec -- dune exec --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix/eval-stats-inline-test ./_build/default/lib/.agent_sdk.inline-tests/inline-test-runner.exe -- inline-test-runner agent_sdk -partition eval_stats.ml -source-tree-root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix/eval-stats-inline-test/lib -diff-cmd -`
- [ ] Cross-model review evidence to add
