### PR TITLE
feat: cascade_source tracing + strict_name validation

### DIFF
--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -221,15 +221,21 @@ let text_of_response (resp : Types.api_response) : string =
 
 (* TODO: per-profile temperature / max_tokens overrides from JSON *)
 
-let resolve_model_strings ?config_path ~name ~defaults () =
+type cascade_source = Named | Default_fallback | Hardcoded_defaults
+
+let resolve_model_strings_traced ?config_path ~name ~defaults () =
   match config_path with
   | Some path ->
     let from_file = load_profile ~config_path:path ~name in
-    if from_file <> [] then from_file
+    if from_file <> [] then (from_file, Named)
     else
       let fallback = load_profile ~config_path:path ~name:"default" in
-      if fallback <> [] then fallback else defaults
-  | None -> defaults
+      if fallback <> [] then (fallback, Default_fallback)
+      else (defaults, Hardcoded_defaults)
+  | None -> (defaults, Hardcoded_defaults)
+
+let resolve_model_strings ?config_path ~name ~defaults () =
+  fst (resolve_model_strings_traced ?config_path ~name ~defaults ())
 
 (* ── Named cascade execution ───────────────────────────── *)
 
@@ -303,10 +309,23 @@ let complete_cascade_with_accept ~sw ~net ?clock ?cache ?metrics
 let complete_named ~sw ~net ?clock ?config_path
     ~name ~defaults ~messages
     ?(tools = []) ?(temperature = 0.3) ?(max_tokens = 500)
-    ?system_prompt ?(accept = fun _ -> true)
+    ?system_prompt ?(accept = fun _ -> true) ?(strict_name = false)
     ?timeout_sec ?cache ?metrics () =
   (* 1. Resolve: named profile → "default" profile → hardcoded defaults *)
-  let model_strings = resolve_model_strings ?config_path ~name ~defaults () in
+  let model_strings, source =
+    resolve_model_strings_traced ?config_path ~name ~defaults ()
+  in
+  if strict_name && source <> Named then
+    Error (Http_client.NetworkError {
+        message =
+          Printf.sprintf
+            "Cascade '%s' not found in config (resolved via %s)"
+            name (match source with
+                  | Named -> "named"
+                  | Default_fallback -> "default_fallback"
+                  | Hardcoded_defaults -> "hardcoded_defaults")
+      })
+  else
   (* 2. Parse model strings → Provider_config.t list *)
   let providers =
     parse_model_strings ~temperature ~max_tokens ?system_prompt model_strings
@@ -409,8 +428,20 @@ let complete_cascade_stream ~sw ~net ?(metrics : Metrics.t option)
 let complete_named_stream ~sw ~net ?clock ?config_path
     ~name ~defaults ~messages
     ?(tools = []) ?(temperature = 0.3) ?(max_tokens = 500)
-    ?system_prompt ?timeout_sec ?metrics ~on_event () =
-  let model_strings = resolve_model_strings ?config_path ~name ~defaults () in
+    ?system_prompt ?(strict_name = false)
+    ?timeout_sec ?metrics ~on_event () =
+  let model_strings, source =
+    resolve_model_strings_traced ?config_path ~name ~defaults ()
+  in
+  if strict_name && source <> Named then
+    Error (Http_client.NetworkError {
+      message = Printf.sprintf
+        "Streaming cascade '%s' not found in config (resolved via %s)"
+        name (match source with
+              | Named -> "named"
+              | Default_fallback -> "default_fallback"
+              | Hardcoded_defaults -> "hardcoded_defaults") })
+  else
   let providers =
     parse_model_strings ~temperature ~max_tokens ?system_prompt model_strings
   in
@@ -658,3 +689,41 @@ let%test "effective_max_context falls back to registry entry" =
   let caps = { Capabilities.default_capabilities with
                max_context_tokens = None } in
   effective_max_context entry caps = 128_000
+
+let%test "resolve_model_strings_traced returns Named for existing profile" =
+  Eio_main.run (fun _env ->
+    let tmp = Filename.temp_file "cascade" ".json" in
+    let oc = open_out tmp in
+    output_string oc {|{"myname_models": ["llama:auto"]}|};
+    close_out oc;
+    let (_models, source) = resolve_model_strings_traced ~config_path:tmp
+      ~name:"myname" ~defaults:["fallback:x"] () in
+    Sys.remove tmp;
+    source = Named)
+
+let%test "resolve_model_strings_traced returns Default_fallback on missing name" =
+  Eio_main.run (fun _env ->
+    let tmp = Filename.temp_file "cascade" ".json" in
+    let oc = open_out tmp in
+    output_string oc {|{"default_models": ["glm:auto"]}|};
+    close_out oc;
+    let (models, source) = resolve_model_strings_traced ~config_path:tmp
+      ~name:"typo_name" ~defaults:["fallback:x"] () in
+    Sys.remove tmp;
+    source = Default_fallback && models = ["glm:auto"])
+
+let%test "resolve_model_strings_traced returns Hardcoded_defaults when no config" =
+  let (_models, source) = resolve_model_strings_traced
+    ~name:"any" ~defaults:["llama:auto"] () in
+  source = Hardcoded_defaults
+
+let%test "resolve_model_strings_traced returns Hardcoded_defaults on empty config" =
+  Eio_main.run (fun _env ->
+    let tmp = Filename.temp_file "cascade" ".json" in
+    let oc = open_out tmp in
+    output_string oc {|{"other_models": ["glm:auto"]}|};
+    close_out oc;
+    let (_models, source) = resolve_model_strings_traced ~config_path:tmp
+      ~name:"missing" ~defaults:["fallback:x"] () in
+    Sys.remove tmp;
+    source = Hardcoded_defaults)

--- a/lib/llm_provider/cascade_config.mli
+++ b/lib/llm_provider/cascade_config.mli
@@ -50,6 +50,12 @@ val load_profile :
   name:string ->
   string list
 
+(** How a cascade name was resolved. *)
+type cascade_source =
+  | Named              (** Found as "{name}_models" in config *)
+  | Default_fallback   (** Name not found; used "default_models" *)
+  | Hardcoded_defaults (** Neither found; used hardcoded [defaults] *)
+
 (** Resolve model strings for a named cascade.
 
     Resolution order:
@@ -64,6 +70,18 @@ val resolve_model_strings :
   defaults:string list ->
   unit ->
   string list
+
+(** Like {!resolve_model_strings} but also returns which resolution
+    path was taken. Use this to detect typos: if [source <> Named]
+    when you expected a named profile, the cascade name is likely wrong.
+
+    @since 0.78.0 *)
+val resolve_model_strings_traced :
+  ?config_path:string ->
+  name:string ->
+  defaults:string list ->
+  unit ->
+  string list * cascade_source
 
 (** {1 Discovery-Aware Health Filtering} *)
 
@@ -130,6 +148,9 @@ val text_of_response : Types.api_response -> string
     rejects causes the cascade to try the next provider (same as a
     retryable failure). This enables retry-on-invalid-format patterns.
 
+    When [strict_name] is [true], returns [Error] if the named profile
+    is not found in the config file (prevents silent fallback on typos).
+
     @return [Ok api_response] on success
     @return [Error http_error] when all providers fail or are rejected *)
 val complete_named :
@@ -145,6 +166,7 @@ val complete_named :
   ?max_tokens:int ->
   ?system_prompt:string ->
   ?accept:(Types.api_response -> bool) ->
+  ?strict_name:bool ->
   ?timeout_sec:int ->
   ?cache:Cache.t ->
   ?metrics:Metrics.t ->
@@ -181,6 +203,7 @@ val complete_named_stream :
   ?temperature:float ->
   ?max_tokens:int ->
   ?system_prompt:string ->
+  ?strict_name:bool ->
   ?timeout_sec:int ->
   ?metrics:Metrics.t ->
   on_event:(Types.sse_event -> unit) ->


### PR DESCRIPTION
## Summary

- `cascade_source` 타입 추가: `Named | Default_fallback | Hardcoded_defaults`
- `resolve_model_strings_traced`: resolution 경로를 함께 반환
- `complete_named` / `complete_named_stream`에 `?strict_name:bool` 파라미터 추가
- `strict_name=true`이면 named profile 미발견 시 Error 반환 (silent fallback 방지)
- 기존 호출자 하위호환 (`strict_name` 기본값 `false`)

## Background

cascade name에 typo가 있으면 `resolve_model_strings`가 silent하게 `default_models` → hardcoded defaults로 fallback. 에러 없이 의도하지 않은 모델로 실행됨. MASC에서 23개 파일이 cascade name을 참조하며, 대부분 JSON에 정의되지 않은 이름 → 전부 defaults로 실행 중이었음.

## Test plan

- [x] `dune build` 성공
- [x] `test_cascade_config.exe` 19개 테스트 전부 통과
- [x] 새 inline 테스트 4개: Named/Default_fallback/Hardcoded_defaults 경로 검증
- [x] CLI help 테스트 실패는 worktree 빌드 경로 해석 차이 (main에서 재현 안 됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)