### PR TITLE
feat: Agent_turn_budget — self-extending turn control

### DIFF
--- a/lib/agent/agent_turn_budget.ml
+++ b/lib/agent/agent_turn_budget.ml
@@ -1,0 +1,160 @@
+(** Agent_turn_budget — Self-extending turn budget with guardrails.
+    @since 0.78.0 *)
+
+open Types
+
+type extension_result = {
+  granted: int;
+  new_max: int;
+  ceiling: int;
+  extensions_so_far: int;
+  reason: string;
+}
+
+type denial_reason =
+  | Ceiling_reached
+  | Extension_limit_reached
+  | Per_extend_cap_exceeded
+  | Agent_idle
+  | Cost_exceeded
+
+let denial_reason_to_string = function
+  | Ceiling_reached -> "ceiling_reached"
+  | Extension_limit_reached -> "extension_limit_reached"
+  | Per_extend_cap_exceeded -> "per_extend_cap_exceeded"
+  | Agent_idle -> "agent_idle"
+  | Cost_exceeded -> "cost_exceeded"
+
+type t = {
+  initial: int;
+  ceiling: int;
+  max_per_extend: int;
+  max_extensions: int;
+  mutable current_max: int;
+  mutable extensions_count: int;
+  mutable total_extended: int;
+  mutable history: (float * int * string) list;  (* ts, granted, reason *)
+}
+
+let create ~initial ~ceiling ?(max_per_extend=20) ?(max_extensions=10) () =
+  { initial;
+    ceiling = max ceiling initial;
+    max_per_extend;
+    max_extensions;
+    current_max = initial;
+    extensions_count = 0;
+    total_extended = 0;
+    history = [];
+  }
+
+let current_max t = t.current_max
+
+let try_extend t ~additional ~reason =
+  if t.extensions_count >= t.max_extensions then
+    Error Extension_limit_reached
+  else if additional > t.max_per_extend then
+    Error Per_extend_cap_exceeded
+  else
+    let additional = max 1 additional in
+    let new_max = min (t.current_max + additional) t.ceiling in
+    let granted = new_max - t.current_max in
+    if granted <= 0 then
+      Error Ceiling_reached
+    else begin
+      t.current_max <- new_max;
+      t.extensions_count <- t.extensions_count + 1;
+      t.total_extended <- t.total_extended + granted;
+      t.history <- (Unix.gettimeofday (), granted, reason) :: t.history;
+      Ok { granted; new_max; ceiling = t.ceiling;
+           extensions_so_far = t.extensions_count; reason }
+    end
+
+let make_tool ~agent_ref ~budget ?(max_idle_before_extend=2) () =
+  let handler input =
+    let additional =
+      try Yojson.Safe.Util.(member "additional_turns" input |> to_int)
+      with _ -> 5
+    in
+    let reason =
+      try Yojson.Safe.Util.(member "reason" input |> to_string)
+      with _ -> "no reason given"
+    in
+    (* Check agent-level guardrails *)
+    let agent_check =
+      match !agent_ref with
+      | None -> Ok ()
+      | Some agent ->
+        let state = Agent_types.state agent in
+        (* Idle check: deny if agent has been idle *)
+        if (Agent_types.options agent).max_idle_turns > 0
+           && agent.consecutive_idle_turns >= max_idle_before_extend then
+          Error Agent_idle
+        (* Cost check: deny if cost budget exceeded *)
+        else match state.config.max_cost_usd with
+          | Some max_cost when state.usage.estimated_cost_usd >= max_cost ->
+            Error Cost_exceeded
+          | _ -> Ok ()
+    in
+    match agent_check with
+    | Error reason_code ->
+      let msg = Printf.sprintf "Denied: %s. Budget: %d/%d."
+        (denial_reason_to_string reason_code)
+        budget.current_max budget.ceiling in
+      Ok { content = msg }
+    | Ok () ->
+      match try_extend budget ~additional ~reason with
+      | Error reason_code ->
+        let msg = Printf.sprintf "Denied: %s. Budget: %d/%d, extensions: %d/%d."
+          (denial_reason_to_string reason_code)
+          budget.current_max budget.ceiling
+          budget.extensions_count budget.max_extensions in
+        Ok { content = msg }
+      | Ok result ->
+        (* Apply to agent state *)
+        (match !agent_ref with
+         | Some agent ->
+           let state = Agent_types.state agent in
+           Agent_types.set_state agent
+             { state with config =
+                 { state.config with max_turns = result.new_max } }
+         | None -> ());
+        let msg = Printf.sprintf
+          "Granted %d turns. New budget: %d (ceiling: %d). Extensions: %d/%d. Reason: %s"
+          result.granted result.new_max result.ceiling
+          result.extensions_so_far budget.max_extensions reason in
+        Ok { content = msg }
+  in
+  Tool.create
+    ~name:"extend_turns"
+    ~description:"Request additional turns when you need more time to complete \
+                   your current task. The system checks guardrails (cost budget, \
+                   idle detection, ceiling) before granting. Call this when you \
+                   judge you need more steps, not preemptively."
+    ~parameters:[
+      { name = "additional_turns";
+        description = "Number of additional turns to request (1-20)";
+        param_type = Integer;
+        required = true };
+      { name = "reason";
+        description = "Brief explanation of why more turns are needed";
+        param_type = String;
+        required = true };
+    ]
+    handler
+
+let stats_json t =
+  `Assoc [
+    ("initial", `Int t.initial);
+    ("current_max", `Int t.current_max);
+    ("ceiling", `Int t.ceiling);
+    ("extensions_count", `Int t.extensions_count);
+    ("max_extensions", `Int t.max_extensions);
+    ("total_extended", `Int t.total_extended);
+    ("max_per_extend", `Int t.max_per_extend);
+    ("history", `List (List.rev_map (fun (ts, granted, reason) ->
+      `Assoc [
+        ("ts", `Float ts);
+        ("granted", `Int granted);
+        ("reason", `String reason);
+      ]) t.history));
+  ]

--- a/lib/agent/agent_turn_budget.mli
+++ b/lib/agent/agent_turn_budget.mli
@@ -1,0 +1,74 @@
+(** Agent_turn_budget — Self-extending turn budget with guardrails.
+
+    Agents start with an initial turn budget and can request more via
+    the [extend_turns] tool.  Each extension request is gated by:
+
+    - Absolute ceiling (hard cap, never exceeded)
+    - Per-extension cap (max turns per single request)
+    - Total extension count (max number of extend calls)
+
+    Cost and idle checks are delegated to the caller via the
+    agent ref (reads [agent_state.usage] and [consecutive_idle_turns]).
+
+    @since 0.78.0 *)
+
+type extension_result = {
+  granted: int;
+  new_max: int;
+  ceiling: int;
+  extensions_so_far: int;
+  reason: string;
+}
+
+type denial_reason =
+  | Ceiling_reached
+  | Extension_limit_reached
+  | Per_extend_cap_exceeded
+  | Agent_idle
+  | Cost_exceeded
+
+val denial_reason_to_string : denial_reason -> string
+
+(** Budget tracker. *)
+type t
+
+(** Create a turn budget.
+
+    @param initial Starting max_turns (the agent begins with this many)
+    @param ceiling Absolute hard cap (extend_turns cannot go beyond this)
+    @param max_per_extend Max turns grantable per single extend call (default 20)
+    @param max_extensions Max number of extend calls per session (default 10) *)
+val create :
+  initial:int ->
+  ceiling:int ->
+  ?max_per_extend:int ->
+  ?max_extensions:int ->
+  unit -> t
+
+(** Try to extend the turn budget. Returns Ok with details or Error with reason. *)
+val try_extend :
+  t ->
+  additional:int ->
+  reason:string ->
+  (extension_result, denial_reason) result
+
+(** Current effective max_turns. *)
+val current_max : t -> int
+
+(** Build the [extend_turns] Tool.t.
+
+    The tool reads the agent state via [agent_ref] to check idle turns
+    and cost budget.  The ref is initially [None] and must be set to
+    [Some agent] after [Agent.create].
+
+    @param agent_ref Mutable ref to the agent (set after creation)
+    @param budget The turn budget tracker
+    @param max_idle_before_extend Deny if consecutive_idle_turns >= this (default 2) *)
+val make_tool :
+  agent_ref:Agent_types.t option ref ->
+  budget:t ->
+  ?max_idle_before_extend:int ->
+  unit -> Tool.t
+
+(** JSON summary for metrics/logging. *)
+val stats_json : t -> Yojson.Safe.t

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -78,6 +78,7 @@ module Agent_turn = Agent_turn
 module Agent_handoff = Agent_handoff
 module Agent_tools = Agent_tools
 module Agent_checkpoint = Agent_checkpoint
+module Agent_turn_budget = Agent_turn_budget
 module Agent = Agent
 module Builder = Builder
 module Agent_card = Agent_card

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -49,6 +49,7 @@ module Agent_turn = Agent_turn
 module Agent_handoff = Agent_handoff
 module Agent_tools = Agent_tools
 module Agent_checkpoint = Agent_checkpoint
+module Agent_turn_budget = Agent_turn_budget
 module Agent = Agent
 module Builder = Builder
 module Agent_card = Agent_card

--- a/test/dune
+++ b/test/dune
@@ -736,3 +736,7 @@
 (test
  (name test_checkpoint_validation)
  (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_turn_budget)
+ (libraries agent_sdk alcotest yojson str))

--- a/test/test_turn_budget.ml
+++ b/test/test_turn_budget.ml
@@ -1,0 +1,128 @@
+(** Tests for Agent_turn_budget — self-extending turn budget with guardrails. *)
+
+open Agent_sdk
+
+let test_create () =
+  let b = Agent_turn_budget.create ~initial:10 ~ceiling:100 () in
+  Alcotest.(check int) "initial max" 10 (Agent_turn_budget.current_max b)
+
+let test_extend_basic () =
+  let b = Agent_turn_budget.create ~initial:10 ~ceiling:100 () in
+  match Agent_turn_budget.try_extend b ~additional:5 ~reason:"need more" with
+  | Error _ -> Alcotest.fail "should succeed"
+  | Ok r ->
+    Alcotest.(check int) "granted" 5 r.granted;
+    Alcotest.(check int) "new_max" 15 r.new_max;
+    Alcotest.(check int) "ceiling" 100 r.ceiling;
+    Alcotest.(check int) "extensions_so_far" 1 r.extensions_so_far;
+    Alcotest.(check int) "current_max updated" 15 (Agent_turn_budget.current_max b)
+
+let test_extend_clamp_to_ceiling () =
+  let b = Agent_turn_budget.create ~initial:95 ~ceiling:100 () in
+  match Agent_turn_budget.try_extend b ~additional:20 ~reason:"big ask" with
+  | Error _ -> Alcotest.fail "should grant partial"
+  | Ok r ->
+    Alcotest.(check int) "granted clamped" 5 r.granted;
+    Alcotest.(check int) "new_max at ceiling" 100 r.new_max
+
+let test_ceiling_reached () =
+  let b = Agent_turn_budget.create ~initial:100 ~ceiling:100 () in
+  match Agent_turn_budget.try_extend b ~additional:5 ~reason:"no room" with
+  | Ok _ -> Alcotest.fail "should deny"
+  | Error reason ->
+    Alcotest.(check string) "reason" "ceiling_reached"
+      (Agent_turn_budget.denial_reason_to_string reason)
+
+let test_extension_limit () =
+  let b = Agent_turn_budget.create ~initial:10 ~ceiling:1000 ~max_extensions:3 () in
+  (* Use up all 3 extensions *)
+  for _ = 1 to 3 do
+    match Agent_turn_budget.try_extend b ~additional:1 ~reason:"ok" with
+    | Error _ -> Alcotest.fail "should succeed"
+    | Ok _ -> ()
+  done;
+  (* 4th should fail *)
+  match Agent_turn_budget.try_extend b ~additional:1 ~reason:"too many" with
+  | Ok _ -> Alcotest.fail "should deny"
+  | Error reason ->
+    Alcotest.(check string) "reason" "extension_limit_reached"
+      (Agent_turn_budget.denial_reason_to_string reason)
+
+let test_per_extend_cap () =
+  let b = Agent_turn_budget.create ~initial:10 ~ceiling:1000 ~max_per_extend:5 () in
+  match Agent_turn_budget.try_extend b ~additional:10 ~reason:"too much" with
+  | Ok _ -> Alcotest.fail "should deny"
+  | Error reason ->
+    Alcotest.(check string) "reason" "per_extend_cap_exceeded"
+      (Agent_turn_budget.denial_reason_to_string reason)
+
+let test_multiple_extensions () =
+  let b = Agent_turn_budget.create ~initial:10 ~ceiling:50 ~max_extensions:5 () in
+  (* 3 extensions of 10 each *)
+  for i = 1 to 3 do
+    match Agent_turn_budget.try_extend b ~additional:10 ~reason:(Printf.sprintf "ext %d" i) with
+    | Error _ -> Alcotest.fail (Printf.sprintf "ext %d should succeed" i)
+    | Ok r ->
+      Alcotest.(check int) "granted" 10 r.granted;
+      Alcotest.(check int) "extensions" i r.extensions_so_far
+  done;
+  Alcotest.(check int) "current_max" 40 (Agent_turn_budget.current_max b);
+  (* 4th extension: only 10 left to ceiling *)
+  match Agent_turn_budget.try_extend b ~additional:20 ~reason:"partial" with
+  | Error _ -> Alcotest.fail "should grant partial"
+  | Ok r ->
+    Alcotest.(check int) "granted clamped to ceiling" 10 r.granted;
+    Alcotest.(check int) "at ceiling" 50 r.new_max
+
+let test_stats_json () =
+  let b = Agent_turn_budget.create ~initial:10 ~ceiling:100 () in
+  ignore (Agent_turn_budget.try_extend b ~additional:5 ~reason:"test");
+  let json = Agent_turn_budget.stats_json b in
+  let open Yojson.Safe.Util in
+  Alcotest.(check int) "initial" 10 (json |> member "initial" |> to_int);
+  Alcotest.(check int) "current_max" 15 (json |> member "current_max" |> to_int);
+  Alcotest.(check int) "extensions_count" 1 (json |> member "extensions_count" |> to_int);
+  Alcotest.(check int) "total_extended" 5 (json |> member "total_extended" |> to_int);
+  let history = json |> member "history" |> to_list in
+  Alcotest.(check int) "history length" 1 (List.length history)
+
+let test_ceiling_at_least_initial () =
+  (* ceiling < initial should be clamped to initial *)
+  let b = Agent_turn_budget.create ~initial:50 ~ceiling:10 () in
+  Alcotest.(check int) "ceiling >= initial" 50 (Agent_turn_budget.current_max b)
+
+let test_make_tool_no_agent () =
+  let agent_ref = ref None in
+  let b = Agent_turn_budget.create ~initial:10 ~ceiling:100 () in
+  let tool = Agent_turn_budget.make_tool ~agent_ref ~budget:b () in
+  (* Call tool without agent — should still work (grant turns) *)
+  let input = `Assoc [
+    ("additional_turns", `Int 5);
+    ("reason", `String "testing");
+  ] in
+  let result = Tool.execute tool input in
+  match result with
+  | Ok { content } ->
+    Alcotest.(check bool) "contains Granted" true
+      (String.length content > 0 &&
+       try ignore (Str.search_forward (Str.regexp_string "Granted") content 0); true
+       with Not_found -> false);
+    Alcotest.(check int) "budget updated" 15 (Agent_turn_budget.current_max b)
+  | Error { message; _ } ->
+    Alcotest.fail (Printf.sprintf "tool should succeed: %s" message)
+
+let () =
+  Alcotest.run "Turn Budget" [
+    "budget", [
+      Alcotest.test_case "create" `Quick test_create;
+      Alcotest.test_case "extend basic" `Quick test_extend_basic;
+      Alcotest.test_case "clamp to ceiling" `Quick test_extend_clamp_to_ceiling;
+      Alcotest.test_case "ceiling reached" `Quick test_ceiling_reached;
+      Alcotest.test_case "extension limit" `Quick test_extension_limit;
+      Alcotest.test_case "per extend cap" `Quick test_per_extend_cap;
+      Alcotest.test_case "multiple extensions" `Quick test_multiple_extensions;
+      Alcotest.test_case "stats json" `Quick test_stats_json;
+      Alcotest.test_case "ceiling >= initial" `Quick test_ceiling_at_least_initial;
+      Alcotest.test_case "tool no agent" `Quick test_make_tool_no_agent;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- Agent가 자기 판단으로 턴 예산을 요청할 수 있는 `extend_turns` tool + guardrails 모듈
- 2-Layer: Codex-style 높은 ceiling + agent-initiated extension
- 5 guardrails: ceiling, per-extend cap, extension count, idle detection, cost budget
- 기존 Agent.run 코드 변경 0줄 — 소비자가 tool로 주입

## Context
업계 비교: OpenAI/Claude/Google ADK/LangGraph 모두 fixed max_turns + hard error. Codex만 무제한 루프.
이 구현은 둘을 결합: 초기 예산(효율 유도) + self-extend(자율성) + guardrails(안전).

## Test plan
- [x] 10 unit tests (budget logic, guardrail denials, tool execution, stats)
- [x] `dune build` clean
- [ ] MASC keeper 통합 테스트 (별도 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)