### PR TITLE
fix(provider): route Local provider through OpenAI Chat Completions

### DIFF
--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -74,7 +74,13 @@ let registered_providers () =
 
 let capabilities_for_model ~(provider : provider) ~(model_id : string) =
   match provider with
-  | Anthropic | Local _ -> anthropic_capabilities
+  | Anthropic -> anthropic_capabilities
+  | Local _ ->
+      (* Local (llama-server) uses OpenAI-compatible API.
+         Resolve capabilities by model_id, fall back to openai_chat. *)
+      (match Llm_provider.Capabilities.for_model_id model_id with
+       | Some caps -> caps
+       | None -> openai_chat_capabilities)
   | OpenAICompat _ ->
       if needs_extended_capabilities model_id then openai_chat_extended_capabilities
       else openai_chat_capabilities
@@ -84,15 +90,16 @@ let capabilities_for_model ~(provider : provider) ~(model_id : string) =
        | None -> default_capabilities)
 
 let request_kind = function
-  | Local _ | Anthropic -> Anthropic_messages
-  | OpenAICompat _ -> Openai_chat_completions
+  | Anthropic -> Anthropic_messages
+  | Local _ | OpenAICompat _ -> Openai_chat_completions
   | Custom_registered { name } ->
       (match find_provider name with
        | Some impl -> impl.request_kind
        | None -> Custom name)
 
 let request_path = function
-  | Local _ | Anthropic -> "/v1/messages"
+  | Anthropic -> "/v1/messages"
+  | Local { base_url = _ } -> "/v1/chat/completions"
   | OpenAICompat { path; _ } -> path
   | Custom_registered { name } ->
       (match find_provider name with

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -130,12 +130,13 @@ let test_model_spec_local_llm_capabilities () =
     api_key_env = "DUMMY_KEY";
   } in
   let spec = Provider.model_spec_of_config local_llm in
-  Alcotest.(check string) "request path" "/v1/messages" spec.request_path;
-  Alcotest.(check bool) "supports tools" true spec.capabilities.supports_tools;
-  Alcotest.(check bool) "supports reasoning" true
-    spec.capabilities.supports_reasoning;
-  Alcotest.(check bool) "supports native streaming" true
-    spec.capabilities.supports_native_streaming
+  Alcotest.(check string) "request path" "/v1/chat/completions" spec.request_path;
+  Alcotest.(check string) "request kind" "Openai_chat_completions"
+    (match spec.request_kind with
+     | Provider.Openai_chat_completions -> "Openai_chat_completions"
+     | Provider.Anthropic_messages -> "Anthropic_messages"
+     | Provider.Custom n -> "Custom:" ^ n);
+  Alcotest.(check bool) "supports tools" true spec.capabilities.supports_tools
 
 let test_model_spec_openrouter_capabilities () =
   let spec =


### PR DESCRIPTION
## Summary

MASC keeper tool_calls=0의 근본 원인 수정.

OAS `provider.ml`에서 `Local` provider(llama-server)가 `Anthropic_messages` request kind로 분류됨.
llama-server는 OpenAI-compatible API(`/v1/chat/completions`)를 쓰므로, Anthropic 형식으로 보낸 tool definitions가 무시됨.

### 변경
- `request_kind`: `Local _ -> Openai_chat_completions` (was `Anthropic_messages`)
- `request_path`: `Local _ -> "/v1/chat/completions"` (was `"/v1/messages"`)
- `capabilities_for_model`: `Local _ -> Capabilities.for_model_id` 기반 (was `anthropic_capabilities` 고정)

### 영향
MASC keeper (Sangsu, dm-keeper 등)가 llama-server를 통해 Qwen3.5에 도구를 **OpenAI 형식으로** 전달.
`tool_calls > 0`이 가능해짐.

## Test plan
- [x] `dune build` 성공
- [x] `test_provider` 17 tests pass (request path/kind 검증 포함)
- [ ] MASC 서버 재시작 후 keeper proactive turn에서 tool_calls > 0 확인
- [ ] llama-server에 실제 tool 포함 요청이 가는지 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)