### PR TITLE
fix: narrow catch-all exception handlers in turn budget and succession

### DIFF
--- a/lib/agent/agent_turn_budget.ml
+++ b/lib/agent/agent_turn_budget.ml
@@ -73,11 +73,11 @@ let make_tool ~agent_ref ~budget ?(max_idle_before_extend=2) () =
   let handler input =
     let additional =
       try Yojson.Safe.Util.(member "additional_turns" input |> to_int)
-      with _ -> 5
+      with Yojson.Safe.Util.Type_error _ | Not_found -> 5
     in
     let reason =
       try Yojson.Safe.Util.(member "reason" input |> to_string)
-      with _ -> "no reason given"
+      with Yojson.Safe.Util.Type_error _ | Not_found -> "no reason given"
     in
     (* Check agent-level guardrails *)
     let agent_check =

--- a/lib/succession.ml
+++ b/lib/succession.ml
@@ -240,8 +240,8 @@ let str_list_to_json lst = `List (List.map (fun s -> `String s) lst)
 
 let str_list_of_json json =
   let open Yojson.Safe.Util in
-  try to_list json |> List.filter_map (fun v -> try Some (to_string v) with _ -> None)
-  with _ -> []
+  try to_list json |> List.filter_map (fun v -> try Some (to_string v) with Yojson.Safe.Util.Type_error _ -> None)
+  with Yojson.Safe.Util.Type_error _ -> []
 
 let metrics_to_json m : Yojson.Safe.t =
   `Assoc [
@@ -257,10 +257,10 @@ let metrics_of_json json =
   let open Yojson.Safe.Util in
   { total_turns = json |> member "total_turns" |> to_int_option |> Option.value ~default:0;
     total_tokens_used = json |> member "total_tokens_used" |> to_int_option |> Option.value ~default:0;
-    total_cost_usd = (try json |> member "total_cost_usd" |> to_float with _ -> 0.0);
+    total_cost_usd = (try json |> member "total_cost_usd" |> to_float with Yojson.Safe.Util.Type_error _ | Not_found -> 0.0);
     tasks_completed = json |> member "tasks_completed" |> to_int_option |> Option.value ~default:0;
     errors_encountered = json |> member "errors_encountered" |> to_int_option |> Option.value ~default:0;
-    elapsed_seconds = (try json |> member "elapsed_seconds" |> to_float with _ -> 0.0);
+    elapsed_seconds = (try json |> member "elapsed_seconds" |> to_float with Yojson.Safe.Util.Type_error _ | Not_found -> 0.0);
   }
 
 let dna_to_json dna : Yojson.Safe.t =


### PR DESCRIPTION
## Summary
- `agent_turn_budget.ml`과 `succession.ml`의 `with _ ->` catch-all 패턴을 `Yojson.Safe.Util.Type_error _ | Not_found`로 좁힘
- `Out_of_memory`, `Eio.Cancel.Cancelled` 등 critical 예외가 삼켜지는 문제 방지

## Changes
- `lib/agent/agent_turn_budget.ml`: 2곳 `with _ ->` → `with Type_error _ | Not_found ->`
- `lib/succession.ml`: 4곳 `with _ ->` → 구체적 Yojson 예외

## Test plan
- [x] `dune build` 통과
- [x] `dune runtest` — 10/10 budget 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)