### PR TITLE
fix: narrow catch-all exceptions to specific types

### DIFF
--- a/lib/harness_case.ml
+++ b/lib/harness_case.ml
@@ -125,7 +125,7 @@ let to_json (case_ : t) =
 let parse_string_list json =
   let open Yojson.Safe.Util in
   try Ok (json |> to_list |> List.map to_string)
-  with _ -> Error (Util.json_parse_error "expected string list")
+  with Yojson.Safe.Util.Type_error _ -> Error (Util.json_parse_error "expected string list")
 
 let response_assertion_of_json json =
   let open Yojson.Safe.Util in

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -126,7 +126,7 @@ let default () =
         let result = try input_line ic with End_of_file -> "" in
         ignore (Unix.close_process_in ic);
         String.length (String.trim result) > 0
-      with _ -> false
+      with Unix.Unix_error _ | End_of_file -> false
     ) in
     fun () -> Lazy.force cached
   in

--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -250,7 +250,7 @@ let events_of_line line =
     | "result" ->
       [Types.MessageStop]
     | _ -> []  (* skip rate_limit_event etc. *)
-  with _ -> []
+  with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> []
 
 (** Parse stream output: extract final api_response from "result" line. *)
 let parse_stream_result lines =
@@ -258,7 +258,7 @@ let parse_stream_result lines =
     try
       let json = Yojson.Safe.from_string line in
       member_str "type" json = "result"
-    with _ -> false
+    with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> false
   ) lines in
   match result_line with
   | Some line -> parse_json_result line
@@ -268,7 +268,7 @@ let parse_stream_result lines =
       try
         let json = Yojson.Safe.from_string line in
         member_str "type" json = "assistant"
-      with _ -> false
+      with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> false
     ) lines in
     (match assistant_line with
      | Some line ->
@@ -287,7 +287,7 @@ let parse_stream_result lines =
          let model = member_str "model" msg in
          let id = member_str "id" msg in
          Ok { Types.id; model; stop_reason = EndTurn; content; usage = parse_usage msg }
-       with _ ->
+       with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ ->
          Error (Http_client.NetworkError {
            message = "Failed to parse assistant message" }))
      | None ->

--- a/lib/protocol/mcp_http.ml
+++ b/lib/protocol/mcp_http.ml
@@ -90,7 +90,7 @@ let parse_response_body ~content_type resp_body =
     | None -> false
   in
   if is_sse then parse_sse_body resp_body
-  else (try Some (Yojson.Safe.from_string resp_body) with _ -> None)
+  else (try Some (Yojson.Safe.from_string resp_body) with Yojson.Json_error _ -> None)
 
 (** Send a JSON-RPC request via HTTP POST and parse the response.
     Handles both plain JSON and SSE response formats. *)


### PR DESCRIPTION
## Summary
- Replace 7 `with _ ->` catch-all patterns with specific exception types
- `provider_registry.ml`: `Unix.Unix_error | End_of_file` (process spawn)
- `transport_claude_code.ml`: `Yojson.Json_error | Type_error` (5 JSON parse sites)
- `mcp_http.ml`: `Yojson.Json_error` (JSON parse)
- `harness_case.ml`: `Yojson.Safe.Util.Type_error` (JSON parse)

Prevents silent swallowing of unexpected exceptions (Out_of_memory, Stack_overflow, etc.).

## Test plan
- [x] `dune build` passes
- [x] No new test failures vs main (same failure set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)