### PR TITLE
refactor: deduplicate utilities and optimize token_overlap_ratio

### DIFF
--- a/lib/checkpoint_validation.ml
+++ b/lib/checkpoint_validation.ml
@@ -7,20 +7,7 @@
 
 (* ── Text utilities ────────────────────────────────────────────── *)
 
-let contains_substring_ci ~haystack ~needle =
-  let h = String.lowercase_ascii haystack in
-  let n = String.lowercase_ascii needle in
-  let lh = String.length h in
-  let ln = String.length n in
-  if ln = 0 then true
-  else if ln > lh then false
-  else
-    let rec loop i =
-      if i + ln > lh then false
-      else if String.sub h i ln = n then true
-      else loop (i + 1)
-    in
-    loop 0
+let contains_substring_ci = Util.contains_substring_ci
 
 let normalize_for_overlap s =
   let b = Buffer.create (String.length s) in
@@ -43,9 +30,11 @@ let token_overlap_ratio ~source ~target =
   | [] -> 1.0
   | _ ->
     let target_tokens = tokenize target in
+    let target_set = Hashtbl.create (List.length target_tokens) in
+    List.iter (fun tok -> Hashtbl.replace target_set tok ()) target_tokens;
     let matched =
       List.fold_left (fun acc tok ->
-        if List.mem tok target_tokens then acc + 1 else acc
+        if Hashtbl.mem target_set tok then acc + 1 else acc
       ) 0 source_tokens
     in
     Float.of_int matched /. Float.of_int (List.length source_tokens)
@@ -110,9 +99,7 @@ let validate_dna dna =
 
 (* ── Continuity regression check ───────────────────────────────── *)
 
-let safe_sub s start len =
-  let actual_len = min len (String.length s - start) in
-  if actual_len <= 0 then "" else String.sub s start actual_len
+let safe_sub = Util.safe_sub
 
 let continuity_check ~full_context ~compressed_context =
   let goal_hint = extract_prefixed_line ~prefix:"goal:" full_context in

--- a/lib/succession.ml
+++ b/lib/succession.ml
@@ -55,8 +55,7 @@ type dna = {
 (* Helpers                                                          *)
 (* ================================================================ *)
 
-let clip s max_len =
-  if String.length s > max_len then String.sub s 0 max_len ^ "..." else s
+let clip = Util.clip
 
 
 (* ================================================================ *)

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -41,3 +41,28 @@ let result_traverse ~f items =
       | Error e -> Error e
   in
   loop [] items
+
+(** Truncate string to [max_len], appending "..." if truncated. *)
+let clip s max_len =
+  if String.length s > max_len then String.sub s 0 max_len ^ "..." else s
+
+(** Safe substring: returns "" if start is past end or len is negative. *)
+let safe_sub s start len =
+  let actual_len = min len (String.length s - start) in
+  if actual_len <= 0 then "" else String.sub s start actual_len
+
+(** Case-insensitive substring search. *)
+let contains_substring_ci ~haystack ~needle =
+  let h = String.lowercase_ascii haystack in
+  let n = String.lowercase_ascii needle in
+  let lh = String.length h in
+  let ln = String.length n in
+  if ln = 0 then true
+  else if ln > lh then false
+  else
+    let rec loop i =
+      if i + ln > lh then false
+      else if String.sub h i ln = n then true
+      else loop (i + 1)
+    in
+    loop 0

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -27,3 +27,12 @@ val snoc_list : 'a list -> 'a list -> 'a list
 (** Traverse a list with [f], collecting [Ok] values.
     Short-circuits on first [Error]. *)
 val result_traverse : f:('a -> ('b, 'e) result) -> 'a list -> ('b list, 'e) result
+
+(** Truncate string to [max_len], appending "..." if truncated. *)
+val clip : string -> int -> string
+
+(** Safe substring: returns "" if start is past end or len is negative. *)
+val safe_sub : string -> int -> int -> string
+
+(** Case-insensitive substring search. *)
+val contains_substring_ci : haystack:string -> needle:string -> bool


### PR DESCRIPTION
## Summary
- Move `clip`, `safe_sub`, `contains_substring_ci` to `Util` module (SSOT)
- `succession.ml`: `clip` → `Util.clip` delegate
- `checkpoint_validation.ml`: `contains_substring_ci` → `Util.contains_substring_ci`, `safe_sub` → `Util.safe_sub`
- Optimize `token_overlap_ratio` from O(n*m) (List.mem) to O(n+m) (Hashtbl set)

## Test plan
- [x] `dune build` passes
- [x] No new test failures vs main

🤖 Generated with [Claude Code](https://claude.com/claude-code)