### PR TITLE
fix: promote ppx_inline_test to unconditional dep

### DIFF
--- a/agent_sdk.opam
+++ b/agent_sdk.opam
@@ -28,7 +28,7 @@ depends: [
   "qcheck-core" {with-test & >= "0.21"}
   "qcheck-alcotest" {with-test & >= "0.21"}
   "bisect_ppx" {with-test & >= "2.8"}
-  "ppx_inline_test" {with-test & >= "0.17"}
+  "ppx_inline_test" {>= "0.17"}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -32,4 +32,4 @@
   (qcheck-core (and :with-test (>= 0.21)))
   (qcheck-alcotest (and :with-test (>= 0.21)))
   (bisect_ppx (and :with-test (>= 2.8)))
-  (ppx_inline_test (and :with-test (>= 0.17)))))
+  (ppx_inline_test (>= 0.17))))


### PR DESCRIPTION
## Summary
- `ppx_inline_test`는 `lib/dune`, `lib/llm_provider/dune`, `lib_swarm/dune`에서 preprocess로 사용 (라이브러리 빌드 시 필요)
- opam에서 `{with-test}`로 선언되어 있어, masc-mcp CI에서 agent_sdk install 시 ppx_inline_test 미설치 → 빌드 실패
- `with-test` guard 제거하여 항상 설치되도록 변경

## Root cause
opam은 transitive dependency의 with-test deps를 설치하지 않음. masc-mcp가 `opam install . --deps-only --with-test`를 하더라도, pin된 agent_sdk의 빌드 시에는 agent_sdk 자체의 with-test deps가 포함 안 됨.

## Impact
masc-mcp main 포함 모든 브랜치의 CI "Build and Test" 실패 해소.