### PR TITLE
fix: repair CI — routing test + version consistency

### DIFF
--- a/lib/sdk_version.ml
+++ b/lib/sdk_version.ml
@@ -1,5 +1,5 @@
 (** Single source of truth for the SDK version string.
     All other modules reference this instead of hardcoding. *)
 
-let version = "0.78.0"
+let version = "0.81.0"
 let sdk_name = "agent_sdk"

--- a/test/test_api_dispatch.ml
+++ b/test/test_api_dispatch.ml
@@ -141,7 +141,7 @@ let test_request_kind_routing () =
        | Provider.Openai_chat_completions -> "openai"
        | Provider.Custom name -> "custom:" ^ name)
   in
-  check_kind "local" "anthropic" (Provider.Local { base_url = "http://x" });
+  check_kind "local" "openai" (Provider.Local { base_url = "http://x" });
   check_kind "anthropic" "anthropic" Provider.Anthropic;
   check_kind "openai" "openai"
     (Provider.OpenAICompat { base_url = "http://x"; auth_header = None;


### PR DESCRIPTION
## Summary
Fixes two CI failures blocking all PRs on main:

1. **routing test** (`test_api_dispatch.ml:144`): PR #308 changed `Local` provider from `Anthropic_messages` to `Openai_chat_completions`, but the test expectation was not updated. Fix: `"anthropic"` → `"openai"`.

2. **version consistency**: `dune-project` is 0.81.0 but `sdk_version.ml` was still 0.78.0. Fix: sync to 0.81.0.

## Test plan
- [x] `dune exec test/test_api_dispatch.exe` — 16/16 pass
- [x] `dune build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)