### PR TITLE
fix: repair all CI failures — mock format + version + routing test

### DIFF
--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -8,15 +8,25 @@ open Alcotest
 
 (* ── Mock server: stateful, multi-response ──────────── *)
 
-let anthropic_text_response ?(id = "msg-1") text =
+(* OpenAI Chat Completions format — Local provider routes through this since PR #308 *)
+let openai_text_response ?(id = "chatcmpl-1") text =
   Printf.sprintf
-    {|{"id":"%s","type":"message","role":"assistant","model":"mock","content":[{"type":"text","text":"%s"}],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}|}
+    {|{"id":"%s","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}|}
     id text
 
-let anthropic_tool_use_response tool_name input_json =
+let escape_json_string s =
+  let buf = Buffer.create (String.length s) in
+  String.iter (fun c ->
+    match c with
+    | '"' -> Buffer.add_string buf "\\\""
+    | '\\' -> Buffer.add_string buf "\\\\"
+    | _ -> Buffer.add_char buf c) s;
+  Buffer.contents buf
+
+let openai_tool_use_response tool_name input_json =
   Printf.sprintf
-    {|{"id":"msg-t","type":"message","role":"assistant","model":"mock","content":[{"type":"tool_use","id":"toolu_1","name":"%s","input":%s}],"stop_reason":"tool_use","usage":{"input_tokens":15,"output_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}|}
-    tool_name input_json
+    {|{"id":"chatcmpl-t","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"%s","arguments":"%s"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":15,"completion_tokens":10,"total_tokens":25}}|}
+    tool_name (escape_json_string input_json)
 
 (** Multi-response mock: returns responses in order, cycling. *)
 let start_multi_mock ~sw ~net ~port (responses : string list) =
@@ -69,7 +79,7 @@ let test_agent_run_simple () =
   try
     Eio.Switch.run @@ fun sw ->
     let url = start_multi_mock ~sw ~net:env#net ~port:20001
-        [anthropic_text_response "hello pipeline"] in
+        [openai_text_response "hello pipeline"] in
     let agent = make_agent ~net:env#net url in
     (match Agent.run ~sw agent "test prompt" with
      | Ok resp ->
@@ -86,9 +96,9 @@ let test_agent_run_tool_use () =
     Eio.Switch.run @@ fun sw ->
     let responses = [
       (* Turn 1: model calls a tool *)
-      anthropic_tool_use_response "get_time" {|{"timezone": "UTC"}|};
+      openai_tool_use_response "get_time" {|{"timezone": "UTC"}|};
       (* Turn 2: model responds with text after tool result *)
-      anthropic_text_response "The time is 12:00 UTC";
+      openai_text_response "The time is 12:00 UTC";
     ] in
     let url = start_multi_mock ~sw ~net:env#net ~port:20002 responses in
     (* Define the tool *)
@@ -117,7 +127,7 @@ let test_agent_run_max_turns () =
     Eio.Switch.run @@ fun sw ->
     (* Always return tool_use → agent loops until max_turns *)
     let url = start_multi_mock ~sw ~net:env#net ~port:20003
-        [anthropic_tool_use_response "loop_tool" {|{}|}] in
+        [openai_tool_use_response "loop_tool" {|{}|}] in
     let loop_tool = Tool.create
         ~name:"loop_tool"
         ~description:"Always called"
@@ -142,7 +152,7 @@ let test_agent_run_with_hooks () =
   try
     Eio.Switch.run @@ fun sw ->
     let url = start_multi_mock ~sw ~net:env#net ~port:20004
-        [anthropic_text_response "hooked"] in
+        [openai_text_response "hooked"] in
     let before_count = ref 0 in
     let after_count = ref 0 in
     let hooks = { Hooks.empty with
@@ -166,7 +176,7 @@ let test_agent_run_with_reducer () =
   try
     Eio.Switch.run @@ fun sw ->
     let url = start_multi_mock ~sw ~net:env#net ~port:20005
-        [anthropic_text_response "reduced"] in
+        [openai_text_response "reduced"] in
     let reducer = Context_reducer.compose [
       Context_reducer.repair_dangling_tool_calls;
       Context_reducer.drop_thinking;
@@ -181,9 +191,9 @@ let test_agent_run_with_reducer () =
 
 (* ── Test 6: Agent.run_stream ────────────────────────── *)
 
-let anthropic_sse text =
+let openai_sse text =
   Printf.sprintf
-    "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"s1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"mock\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"%s\"}}\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+    "data: {\"id\":\"chatcmpl-s1\",\"object\":\"chat.completion.chunk\",\"model\":\"mock\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"},\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-s1\",\"object\":\"chat.completion.chunk\",\"model\":\"mock\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"%s\"},\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-s1\",\"object\":\"chat.completion.chunk\",\"model\":\"mock\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"
     text
 
 let start_sse_mock ~sw ~net ~port sse_body =
@@ -206,7 +216,7 @@ let test_agent_run_stream () =
   try
     Eio.Switch.run @@ fun sw ->
     let url = start_sse_mock ~sw ~net:env#net ~port:20006
-        (anthropic_sse "stream pipeline") in
+        (openai_sse "stream pipeline") in
     let agent = make_agent ~net:env#net url in
     let events = ref [] in
     (match Agent.run_stream ~sw
@@ -226,8 +236,8 @@ let test_agent_run_tool_error () =
   try
     Eio.Switch.run @@ fun sw ->
     let responses = [
-      anthropic_tool_use_response "fail_tool" {|{}|};
-      anthropic_text_response "recovered from tool error";
+      openai_tool_use_response "fail_tool" {|{}|};
+      openai_text_response "recovered from tool error";
     ] in
     let url = start_multi_mock ~sw ~net:env#net ~port:20007 responses in
     let fail_tool = Tool.create
@@ -252,8 +262,8 @@ let test_agent_run_pre_tool_hook () =
   try
     Eio.Switch.run @@ fun sw ->
     let responses = [
-      anthropic_tool_use_response "blocked_tool" {|{}|};
-      anthropic_text_response "after block";
+      openai_tool_use_response "blocked_tool" {|{}|};
+      openai_text_response "after block";
     ] in
     let url = start_multi_mock ~sw ~net:env#net ~port:20008 responses in
     let blocked_tool = Tool.create
@@ -313,7 +323,7 @@ let test_agent_run_guardrails () =
   try
     Eio.Switch.run @@ fun sw ->
     let url = start_multi_mock ~sw ~net:env#net ~port:20010
-        [anthropic_text_response "guarded"] in
+        [openai_text_response "guarded"] in
     let guardrails = {
       Guardrails.tool_filter = Guardrails.AllowAll;
       max_tool_calls_per_turn = Some 5;

--- a/test/test_cli.ml
+++ b/test/test_cli.ml
@@ -26,7 +26,7 @@ let cli_exe =
 
 let quick_response text =
   Printf.sprintf
-    {|{"id":"m","type":"message","role":"assistant","model":"m","content":[{"type":"text","text":"%s"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}|}
+    {|{"id":"chatcmpl-m","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}|}
     text
 
 let start_mock ~sw ~net ~clock ~port response_text =

--- a/test/test_coverage_hotspots_srt.ml
+++ b/test/test_coverage_hotspots_srt.ml
@@ -33,116 +33,187 @@ let unwrap label = function
   | Ok value -> value
   | Error err -> fail (Printf.sprintf "%s: %s" label (Error.to_string err))
 
-let response_usage ?(input_tokens = 10) ?(output_tokens = 5) () =
+let response_usage ?(prompt_tokens = 10) ?(completion_tokens = 5) () =
   `Assoc
     [
-      ("input_tokens", `Int input_tokens);
-      ("output_tokens", `Int output_tokens);
-      ("cache_creation_input_tokens", `Int 0);
-      ("cache_read_input_tokens", `Int 0);
+      ("prompt_tokens", `Int prompt_tokens);
+      ("completion_tokens", `Int completion_tokens);
+      ("total_tokens", `Int (prompt_tokens + completion_tokens));
     ]
 
-let anthropic_text_response ?(id = "msg-1") ?(model = "mock")
-    ?(stop_reason = "end_turn") ?(input_tokens = 10) ?(output_tokens = 5) text =
+let openai_text_response ?(id = "chatcmpl-1") ?(model = "mock")
+    ?(finish_reason = "stop") ?(prompt_tokens = 10) ?(completion_tokens = 5) text =
   Yojson.Safe.to_string
     (`Assoc
        [
          ("id", `String id);
-         ("type", `String "message");
-         ("role", `String "assistant");
+         ("object", `String "chat.completion");
          ("model", `String model);
-         ( "content",
-           `List [ `Assoc [ ("type", `String "text"); ("text", `String text) ] ]
-         );
-         ("stop_reason", `String stop_reason);
-         ("usage", response_usage ~input_tokens ~output_tokens ());
-       ])
-
-let anthropic_tool_use_response ?(id = "msg-tool") ?(model = "mock")
-    ?(tool_id = "toolu_1") ?(input_tokens = 10) ?(output_tokens = 5)
-    ~tool_name ~tool_input () =
-  Yojson.Safe.to_string
-    (`Assoc
-       [
-         ("id", `String id);
-         ("type", `String "message");
-         ("role", `String "assistant");
-         ("model", `String model);
-         ( "content",
+         ( "choices",
            `List
              [
                `Assoc
                  [
-                   ("type", `String "tool_use");
-                   ("id", `String tool_id);
-                   ("name", `String tool_name);
-                   ("input", tool_input);
+                   ("index", `Int 0);
+                   ( "message",
+                     `Assoc
+                       [
+                         ("role", `String "assistant");
+                         ("content", `String text);
+                       ] );
+                   ("finish_reason", `String finish_reason);
                  ];
              ] );
-         ("stop_reason", `String "tool_use");
-         ("usage", response_usage ~input_tokens ~output_tokens ());
+         ("usage", response_usage ~prompt_tokens ~completion_tokens ());
        ])
 
-let sse_event event_name payload =
-  Printf.sprintf "event: %s\ndata: %s\n\n" event_name
-    (Yojson.Safe.to_string payload)
+let openai_tool_use_response ?(id = "chatcmpl-tool") ?(model = "mock")
+    ?(tool_id = "call_1") ?(prompt_tokens = 10) ?(completion_tokens = 5)
+    ~tool_name ~tool_input () =
+  let arguments = Yojson.Safe.to_string tool_input in
+  Yojson.Safe.to_string
+    (`Assoc
+       [
+         ("id", `String id);
+         ("object", `String "chat.completion");
+         ("model", `String model);
+         ( "choices",
+           `List
+             [
+               `Assoc
+                 [
+                   ("index", `Int 0);
+                   ( "message",
+                     `Assoc
+                       [
+                         ("role", `String "assistant");
+                         ("content", `Null);
+                         ( "tool_calls",
+                           `List
+                             [
+                               `Assoc
+                                 [
+                                   ("id", `String tool_id);
+                                   ("type", `String "function");
+                                   ( "function",
+                                     `Assoc
+                                       [
+                                         ("name", `String tool_name);
+                                         ("arguments", `String arguments);
+                                       ] );
+                                 ];
+                             ] );
+                       ] );
+                   ("finish_reason", `String "tool_calls");
+                 ];
+             ] );
+         ("usage", response_usage ~prompt_tokens ~completion_tokens ());
+       ])
 
-let anthropic_sse_tool_use_body ?(tool_id = "toolu_stream")
+let openai_sse_tool_use_body ?(tool_id = "call_stream")
     ?(tool_name = "extract_person") tool_input =
-  let partial_json = Yojson.Safe.to_string tool_input in
+  let arguments = Yojson.Safe.to_string tool_input in
   String.concat ""
     [
-      sse_event "message_start"
-        (`Assoc
-           [
-             ("type", `String "message_start");
-             ( "message",
-               `Assoc
-                 [
-                   ("id", `String "msg-stream");
-                   ("type", `String "message");
-                   ("role", `String "assistant");
-                   ("model", `String "mock");
-                   ("content", `List []);
-                   ("stop_reason", `Null);
-                   ("usage", response_usage ~input_tokens:12 ~output_tokens:0 ());
-                 ] );
-           ]);
-      sse_event "content_block_start"
-        (`Assoc
-           [
-             ("type", `String "content_block_start");
-             ("index", `Int 0);
-             ( "content_block",
-               `Assoc
-                 [
-                   ("type", `String "tool_use");
-                   ("id", `String tool_id);
-                   ("name", `String tool_name);
-                 ] );
-           ]);
-      sse_event "content_block_delta"
-        (`Assoc
-           [
-             ("type", `String "content_block_delta");
-             ("index", `Int 0);
-             ( "delta",
-               `Assoc
-                 [
-                   ("type", `String "input_json_delta");
-                   ("partial_json", `String partial_json);
-                 ] );
-           ]);
-      sse_event "content_block_stop"
-        (`Assoc [ ("type", `String "content_block_stop"); ("index", `Int 0) ]);
-      sse_event "message_delta"
-        (`Assoc
-           [
-             ("type", `String "message_delta");
-             ("delta", `Assoc [ ("stop_reason", `String "tool_use") ]);
-             ("usage", response_usage ~input_tokens:0 ~output_tokens:8 ());
-           ]);
-      sse_event "message_stop" (`Assoc [ ("type", `String "message_stop") ]);
+      Printf.sprintf "data: %s\n\n"
+        (Yojson.Safe.to_string
+           (`Assoc
+              [
+                ("id", `String "chatcmpl-stream");
+                ("object", `String "chat.completion.chunk");
+                ("model", `String "mock");
+                ( "choices",
+                  `List
+                    [
+                      `Assoc
+                        [
+                          ("index", `Int 0);
+                          ( "delta",
+                            `Assoc
+                              [
+                                ("role", `String "assistant");
+                                ("content", `Null);
+                                ( "tool_calls",
+                                  `List
+                                    [
+                                      `Assoc
+                                        [
+                                          ("index", `Int 0);
+                                          ("id", `String tool_id);
+                                          ("type", `String "function");
+                                          ( "function",
+                                            `Assoc
+                                              [
+                                                ("name", `String tool_name);
+                                                ("arguments", `String "");
+                                              ] );
+                                        ];
+                                    ] );
+                              ] );
+                          ("finish_reason", `Null);
+                        ];
+                    ] );
+              ]));
+      Printf.sprintf "data: %s\n\n"
+        (Yojson.Safe.to_string
+           (`Assoc
+              [
+                ("id", `String "chatcmpl-stream");
+                ("object", `String "chat.completion.chunk");
+                ("model", `String "mock");
+                ( "choices",
+                  `List
+                    [
+                      `Assoc
+                        [
+                          ("index", `Int 0);
+                          ( "delta",
+                            `Assoc
+                              [
+                                ( "tool_calls",
+                                  `List
+                                    [
+                                      `Assoc
+                                        [
+                                          ("index", `Int 0);
+                                          ( "function",
+                                            `Assoc
+                                              [
+                                                ("arguments", `String arguments);
+                                              ] );
+                                        ];
+                                    ] );
+                              ] );
+                          ("finish_reason", `Null);
+                        ];
+                    ] );
+              ]));
+      Printf.sprintf "data: %s\n\n"
+        (Yojson.Safe.to_string
+           (`Assoc
+              [
+                ("id", `String "chatcmpl-stream");
+                ("object", `String "chat.completion.chunk");
+                ("model", `String "mock");
+                ( "choices",
+                  `List
+                    [
+                      `Assoc
+                        [
+                          ("index", `Int 0);
+                          ("delta", `Assoc []);
+                          ("finish_reason", `String "tool_calls");
+                        ];
+                    ] );
+                ( "usage",
+                  `Assoc
+                    [
+                      ("prompt_tokens", `Int 12);
+                      ("completion_tokens", `Int 8);
+                      ("total_tokens", `Int 20);
+                    ] );
+              ]));
+      "data: [DONE]\n\n";
     ]
 
 let start_sequence_mock ~sw ~net ~port responses =
@@ -241,7 +312,7 @@ let test_structured_extract_success () =
   try
     Eio.Switch.run @@ fun sw ->
     let body =
-      anthropic_tool_use_response ~tool_name:"extract_person"
+      openai_tool_use_response ~tool_name:"extract_person"
         ~tool_input:(`Assoc [ ("name", `String "Alice"); ("age", `Int 30) ])
         ()
     in
@@ -262,7 +333,7 @@ let test_structured_extract_requires_tool_use () =
   Eio_main.run @@ fun env ->
   try
     Eio.Switch.run @@ fun sw ->
-    let body = anthropic_text_response "not structured" in
+    let body = openai_text_response "not structured" in
     let url = start_sequence_mock ~sw ~net:env#net ~port:21302 [ body ] in
     let provider = local_provider url in
     match
@@ -283,11 +354,11 @@ let test_structured_extract_with_retry_success () =
     Eio.Switch.run @@ fun sw ->
     let responses =
       [
-        anthropic_tool_use_response ~input_tokens:7 ~output_tokens:3
+        openai_tool_use_response ~prompt_tokens:7 ~completion_tokens:3
           ~tool_name:"extract_person"
           ~tool_input:(`Assoc [ ("name", `String "Bob"); ("age", `String "oops") ])
           ();
-        anthropic_tool_use_response ~input_tokens:11 ~output_tokens:5
+        openai_tool_use_response ~prompt_tokens:11 ~completion_tokens:5
           ~tool_name:"extract_person"
           ~tool_input:(`Assoc [ ("name", `String "Bob"); ("age", `Int 41) ])
           ();
@@ -323,7 +394,7 @@ let test_structured_extract_with_retry_exhausted () =
   try
     Eio.Switch.run @@ fun sw ->
     let body =
-      anthropic_tool_use_response ~tool_name:"extract_person"
+      openai_tool_use_response ~tool_name:"extract_person"
         ~tool_input:(`Assoc [ ("name", `String "Eve"); ("age", `String "bad") ])
         ()
     in
@@ -347,7 +418,7 @@ let test_structured_run_structured_success () =
   Eio_main.run @@ fun env ->
   try
     Eio.Switch.run @@ fun sw ->
-    let body = anthropic_text_response {|{"answer":42}|} in
+    let body = openai_text_response {|{"answer":42}|} in
     let url = start_sequence_mock ~sw ~net:env#net ~port:21305 [ body ] in
     let agent = make_agent ~net:env#net url in
     let extract =
@@ -366,7 +437,7 @@ let test_structured_extract_stream_success () =
   try
     Eio.Switch.run @@ fun sw ->
     let body =
-      anthropic_sse_tool_use_body
+      openai_sse_tool_use_body
         (`Assoc [ ("name", `String "Dana"); ("age", `Int 27) ])
     in
     let url = start_sse_mock ~sw ~net:env#net ~port:21306 body in

--- a/test/test_evidence_pipeline_cov.ml
+++ b/test/test_evidence_pipeline_cov.ml
@@ -7,9 +7,9 @@ open Alcotest
 
 (* ── Mock server ──────────────────────────────────────────────── *)
 
-let anthropic_response text =
+let openai_response text =
   Printf.sprintf
-    {|{"id":"msg-ev","type":"message","role":"assistant","model":"mock","content":[{"type":"text","text":"%s"}],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}|}
+    {|{"id":"chatcmpl-ev","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}|}
     text
 
 let start_mock ~sw ~net ~port response =
@@ -63,7 +63,7 @@ let test_get_worker_run () =
   try
     Eio.Switch.run @@ fun sw ->
     let url = start_mock ~sw ~net:env#net ~port:21101
-        (anthropic_response "evidence test") in
+        (openai_response "evidence test") in
     let agent, raw_trace = make_agent ~net:env#net url in
     (match Agent.run ~sw agent "test" with
      | Ok _ ->
@@ -131,7 +131,7 @@ let test_persist_after_run () =
   try
     Eio.Switch.run @@ fun sw ->
     let url = start_mock ~sw ~net:env#net ~port:21104
-        (anthropic_response "persist test") in
+        (openai_response "persist test") in
     let agent, raw_trace = make_agent ~net:env#net url in
     (match Agent.run ~sw agent "test persist" with
      | Ok _ ->
@@ -168,7 +168,7 @@ let test_conformance_from_agent () =
   try
     Eio.Switch.run @@ fun sw ->
     let url = start_mock ~sw ~net:env#net ~port:21105
-        (anthropic_response "conformance test") in
+        (openai_response "conformance test") in
     let agent, raw_trace = make_agent ~net:env#net url in
     (match Agent.run ~sw agent "test conformance" with
      | Ok _ ->

--- a/test/test_full_pipeline_cov.ml
+++ b/test/test_full_pipeline_cov.ml
@@ -10,29 +10,38 @@ open Alcotest
 
 (* ── Mock server helpers ──────────────────────────────────────── *)
 
-let anthropic_response ?(id = "msg-1") ?(stop = "end_turn") text =
-  Printf.sprintf
-    {|{"id":"%s","type":"message","role":"assistant","model":"mock","content":[{"type":"text","text":"%s"}],"stop_reason":"%s","usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}|}
-    id text stop
+let escape_json_string s =
+  let buf = Buffer.create (String.length s) in
+  String.iter (fun c ->
+    match c with
+    | '"' -> Buffer.add_string buf "\\\""
+    | '\\' -> Buffer.add_string buf "\\\\"
+    | _ -> Buffer.add_char buf c) s;
+  Buffer.contents buf
 
-let anthropic_tool_use ?(id = "msg-t") tool_name input_json =
+let openai_text_response ?(id = "chatcmpl-1") text =
   Printf.sprintf
-    {|{"id":"%s","type":"message","role":"assistant","model":"mock","content":[{"type":"tool_use","id":"toolu_1","name":"%s","input":%s}],"stop_reason":"tool_use","usage":{"input_tokens":15,"output_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}|}
-    id tool_name input_json
+    {|{"id":"%s","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}|}
+    id text
 
-let anthropic_multi_content tool_name input_json text =
+let openai_tool_use ?(id = "chatcmpl-t") tool_name input_json =
   Printf.sprintf
-    {|{"id":"msg-m","type":"message","role":"assistant","model":"mock","content":[{"type":"text","text":"%s"},{"type":"tool_use","id":"toolu_2","name":"%s","input":%s}],"stop_reason":"tool_use","usage":{"input_tokens":20,"output_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}|}
-    text tool_name input_json
+    {|{"id":"%s","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"%s","arguments":"%s"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":15,"completion_tokens":10,"total_tokens":25}}|}
+    id tool_name (escape_json_string input_json)
+
+let openai_multi_content tool_name input_json text =
+  Printf.sprintf
+    {|{"id":"chatcmpl-m","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s","tool_calls":[{"id":"call_2","type":"function","function":{"name":"%s","arguments":"%s"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":20,"completion_tokens":15,"total_tokens":35}}|}
+    text tool_name (escape_json_string input_json)
 
 let openai_response text =
   Printf.sprintf
     {|{"id":"chatcmpl-1","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}|}
     text
 
-let anthropic_sse text =
+let openai_sse text =
   Printf.sprintf
-    "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"s1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"mock\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"%s\"}}\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+    "data: {\"id\":\"chatcmpl-s1\",\"object\":\"chat.completion.chunk\",\"model\":\"mock\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"%s\"},\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-s1\",\"object\":\"chat.completion.chunk\",\"model\":\"mock\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n\ndata: [DONE]\n\n"
     text
 
 (** Multi-response mock server cycling through responses. *)
@@ -130,7 +139,7 @@ let test_basic_text () =
   try
     Eio.Switch.run @@ fun sw ->
     let url = start_multi ~sw ~net:env#net ~port:21001
-        [anthropic_response "hello coverage"] in
+        [openai_text_response "hello coverage"] in
     let agent = make_agent ~net:env#net url in
     (match Agent.run ~sw agent "hi" with
      | Ok resp ->
@@ -146,8 +155,8 @@ let test_tool_call_loop () =
   try
     Eio.Switch.run @@ fun sw ->
     let responses = [
-      anthropic_tool_use "calc" {|{"x":42}|};
-      anthropic_response "result is 42";
+      openai_tool_use "calc" {|{"x":42}|};
+      openai_text_response "result is 42";
     ] in
     let url = start_multi ~sw ~net:env#net ~port:21002 responses in
     let tool = Tool.create ~name:"calc" ~description:"Calculate"
@@ -171,8 +180,8 @@ let test_multi_content_tool () =
   try
     Eio.Switch.run @@ fun sw ->
     let responses = [
-      anthropic_multi_content "greet" {|{"name":"test"}|} "thinking...";
-      anthropic_response "done";
+      openai_multi_content "greet" {|{"name":"test"}|} "thinking...";
+      openai_text_response "done";
     ] in
     let url = start_multi ~sw ~net:env#net ~port:21003 responses in
     let tool = Tool.create ~name:"greet" ~description:"Greet"
@@ -194,7 +203,7 @@ let test_streaming_sse () =
   try
     Eio.Switch.run @@ fun sw ->
     let url = start_sse ~sw ~net:env#net ~port:21004
-        (anthropic_sse "streamed text") in
+        (openai_sse "streamed text") in
     let agent = make_agent ~net:env#net url in
     let events = ref [] in
     (match Agent.run_stream ~sw
@@ -259,8 +268,8 @@ let test_tool_error_recovery () =
   try
     Eio.Switch.run @@ fun sw ->
     let responses = [
-      anthropic_tool_use "bad_tool" {|{}|};
-      anthropic_response "recovered";
+      openai_tool_use "bad_tool" {|{}|};
+      openai_text_response "recovered";
     ] in
     let url = start_multi ~sw ~net:env#net ~port:21008 responses in
     let tool = Tool.create ~name:"bad_tool" ~description:"Fails"
@@ -281,7 +290,7 @@ let test_max_turns () =
   try
     Eio.Switch.run @@ fun sw ->
     let url = start_multi ~sw ~net:env#net ~port:21009
-        [anthropic_tool_use "loop" {|{}|}] in
+        [openai_tool_use "loop" {|{}|}] in
     let tool = Tool.create ~name:"loop" ~description:"loops"
         ~parameters:[]
         (fun _input -> Ok { Types.content = "again" }) in
@@ -298,7 +307,7 @@ let test_hooks_turn () =
   try
     Eio.Switch.run @@ fun sw ->
     let url = start_multi ~sw ~net:env#net ~port:21010
-        [anthropic_response "hooked"] in
+        [openai_text_response "hooked"] in
     let before_count = ref 0 in
     let after_count = ref 0 in
     let hooks = { Hooks.empty with
@@ -321,7 +330,7 @@ let test_context_reducer () =
   try
     Eio.Switch.run @@ fun sw ->
     let url = start_multi ~sw ~net:env#net ~port:21011
-        [anthropic_response "reduced"] in
+        [openai_text_response "reduced"] in
     let reducer = Context_reducer.compose [
       Context_reducer.repair_dangling_tool_calls;
       Context_reducer.drop_thinking;
@@ -341,7 +350,7 @@ let test_guardrails_filter () =
   try
     Eio.Switch.run @@ fun sw ->
     let url = start_multi ~sw ~net:env#net ~port:21012
-        [anthropic_response "guarded"] in
+        [openai_text_response "guarded"] in
     let guardrails = {
       Guardrails.tool_filter = Guardrails.AllowAll;
       max_tool_calls_per_turn = Some 3;
@@ -361,8 +370,8 @@ let test_pre_tool_skip () =
   try
     Eio.Switch.run @@ fun sw ->
     let responses = [
-      anthropic_tool_use "skipped" {|{}|};
-      anthropic_response "skipped result";
+      openai_tool_use "skipped" {|{}|};
+      openai_text_response "skipped result";
     ] in
     let url = start_multi ~sw ~net:env#net ~port:21013 responses in
     let tool = Tool.create ~name:"skipped" ~description:"Skip me"
@@ -415,7 +424,7 @@ let test_agent_clone_run () =
   try
     Eio.Switch.run @@ fun sw ->
     let url = start_multi ~sw ~net:env#net ~port:21015
-        [anthropic_response "cloned"] in
+        [openai_text_response "cloned"] in
     let agent = make_agent ~net:env#net url in
     let cloned = Agent.clone agent in
     (match Agent.run ~sw cloned "test clone" with
@@ -431,8 +440,8 @@ let test_structured_extract () =
   Eio_main.run @@ fun env ->
   try
     Eio.Switch.run @@ fun sw ->
-    let tool_resp = Printf.sprintf
-        {|{"id":"msg-s","type":"message","role":"assistant","model":"mock","content":[{"type":"tool_use","id":"toolu_s","name":"get_info","input":{"name":"test","age":25}}],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}|}
+    let tool_resp =
+        {|{"id":"chatcmpl-s","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call_s","type":"function","function":{"name":"get_info","arguments":"{\"name\":\"test\",\"age\":25}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":10,"total_tokens":20}}|}
     in
     let url = start_multi ~sw ~net:env#net ~port:21016 [tool_resp] in
     let schema : (string * int) Structured.schema = {
@@ -514,8 +523,8 @@ let test_context_tool () =
   try
     Eio.Switch.run @@ fun sw ->
     let responses = [
-      anthropic_tool_use "ctx_tool" {|{"key":"val"}|};
-      anthropic_response "ctx done";
+      openai_tool_use "ctx_tool" {|{"key":"val"}|};
+      openai_text_response "ctx done";
     ] in
     let url = start_multi ~sw ~net:env#net ~port:21020 responses in
     let tool = Tool.create_with_context

--- a/test/test_handoff.ml
+++ b/test/test_handoff.ml
@@ -77,34 +77,32 @@ let response_for_message body_str =
   let json = Yojson.Safe.from_string body_str in
   let messages = json |> member "messages" |> to_list in
   let last_msg = List.hd (List.rev messages) in
-  let content_items = last_msg |> member "content" |> to_list in
-  match content_items with
-  | [] ->
-      {|{"id":"empty","type":"message","role":"assistant","model":"c","content":[{"type":"text","text":"empty"}],"stop_reason":"end_turn","usage":{"input_tokens":0,"output_tokens":0}}|}
-  | item :: _ ->
-      let item_type = item |> member "type" |> to_string_option |> Option.value ~default:"" in
-      match item_type with
-      | "text" ->
-          let text = item |> member "text" |> to_string_option |> Option.value ~default:"" in
-          if text = "delegate" then
-            {|{"id":"handoff-tool","type":"message","role":"assistant","model":"c","content":[{"type":"tool_use","id":"handoff-1","name":"transfer_to_researcher","input":{"prompt":"sub_prompt"}}],"stop_reason":"tool_use","usage":{"input_tokens":1,"output_tokens":1}}|}
-          else if text = "delegate_unknown" then
-            {|{"id":"handoff-unknown-tool","type":"message","role":"assistant","model":"c","content":[{"type":"tool_use","id":"handoff-2","name":"transfer_to_unknown","input":{"prompt":"sub_prompt"}}],"stop_reason":"tool_use","usage":{"input_tokens":1,"output_tokens":1}}|}
-          else if text = "sub_prompt" then
-            {|{"id":"handoff-child","type":"message","role":"assistant","model":"c","content":[{"type":"text","text":"delegated response"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}|}
-          else
-            {|{"id":"handoff-fallback","type":"message","role":"assistant","model":"c","content":[{"type":"text","text":"unexpected"}],"stop_reason":"end_turn","usage":{"input_tokens":0,"output_tokens":0}}|}
-      | "tool_result" ->
-          let content = item |> member "content" |> to_string_option |> Option.value ~default:"" in
-          Printf.sprintf
-            {|{"id":"handoff-final","type":"message","role":"assistant","model":"c","content":[{"type":"text","text":"handoff complete: %s"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}|}
-            content
-      | _ ->
-          {|{"id":"handoff-unknown","type":"message","role":"assistant","model":"c","content":[{"type":"text","text":"unknown"}],"stop_reason":"end_turn","usage":{"input_tokens":0,"output_tokens":0}}|}
+  let role = last_msg |> member "role" |> to_string_option |> Option.value ~default:"" in
+  match role with
+  | "tool" ->
+      (* OpenAI tool result message *)
+      let content = last_msg |> member "content" |> to_string_option |> Option.value ~default:"" in
+      Printf.sprintf
+        {|{"id":"chatcmpl-final","object":"chat.completion","model":"c","choices":[{"index":0,"message":{"role":"assistant","content":"handoff complete: %s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}|}
+        content
+  | _ ->
+      (* OpenAI user message — content is a plain string *)
+      let text = last_msg |> member "content" |> to_string_option |> Option.value ~default:"" in
+      if text = "delegate" then
+        {|{"id":"chatcmpl-handoff","object":"chat.completion","model":"c","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"handoff-1","type":"function","function":{"name":"transfer_to_researcher","arguments":"{\"prompt\":\"sub_prompt\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}|}
+      else if text = "delegate_unknown" then
+        {|{"id":"chatcmpl-handoff-unknown","object":"chat.completion","model":"c","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"handoff-2","type":"function","function":{"name":"transfer_to_unknown","arguments":"{\"prompt\":\"sub_prompt\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}|}
+      else if text = "sub_prompt" then
+        {|{"id":"chatcmpl-child","object":"chat.completion","model":"c","choices":[{"index":0,"message":{"role":"assistant","content":"delegated response"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}|}
+      else if text = "" then
+        (* Empty content — could be system or other message, check deeper *)
+        {|{"id":"chatcmpl-empty","object":"chat.completion","model":"c","choices":[{"index":0,"message":{"role":"assistant","content":"empty"},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}|}
+      else
+        {|{"id":"chatcmpl-fallback","object":"chat.completion","model":"c","choices":[{"index":0,"message":{"role":"assistant","content":"unexpected"},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}|}
 
 let handoff_mock_handler _conn req body =
   match Uri.path (Cohttp.Request.uri req) with
-  | "/v1/messages" ->
+  | "/v1/chat/completions" ->
       let body_str = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
       let response_body = response_for_message body_str in
       Cohttp_eio.Server.respond_string ~status:`OK ~body:response_body ()
@@ -130,7 +128,11 @@ let test_run_with_handoffs_intercepts_tool_use () =
         config = { default_config with name = "researcher" };
         tools = [];
       } in
-      let options = { Agent.default_options with base_url } in
+      let provider : Provider.config = {
+        provider = Provider.Local { base_url };
+        model_id = "mock"; api_key_env = "";
+      } in
+      let options = { Agent.default_options with base_url; provider = Some provider } in
       let agent = Agent.create ~net:env#net ~options () in
       match Agent.run_with_handoffs ~sw agent ~targets:[target] "delegate" with
       | Ok response ->
@@ -164,7 +166,11 @@ let test_run_with_handoffs_reports_unknown_target () =
         config = { default_config with name = "researcher" };
         tools = [];
       } in
-      let options = { Agent.default_options with base_url } in
+      let provider : Provider.config = {
+        provider = Provider.Local { base_url };
+        model_id = "mock"; api_key_env = "";
+      } in
+      let options = { Agent.default_options with base_url; provider = Some provider } in
       let agent = Agent.create ~net:env#net ~options () in
       match Agent.run_with_handoffs ~sw agent ~targets:[target] "delegate_unknown" with
       | Ok response ->

--- a/test/test_integration.ml
+++ b/test/test_integration.ml
@@ -1,36 +1,39 @@
 open Agent_sdk
 open Types
 
-(** Mock Server Logic *)
+(** Mock Server Logic — OpenAI Chat Completions format *)
 let mock_handler _conn req body =
   let path = Uri.path (Cohttp.Request.uri req) in
   match path with
-  | "/v1/messages" ->
+  | "/v1/chat/completions" ->
       let body_str = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
       let json = Yojson.Safe.from_string body_str in
-      
+
       let messages = Yojson.Safe.Util.(json |> member "messages" |> to_list) in
       let last_msg = List.hd (List.rev messages) in
-      let content_list = Yojson.Safe.Util.(last_msg |> member "content" |> to_list) in
-      let text = 
-        match content_list with
-        | [] -> "No content"
-        | item :: _ -> 
-            let open Yojson.Safe.Util in
-            match item |> member "text" |> to_string_option with
-            | Some t -> t
-            | None -> item |> member "content" |> to_string_option |> Option.value ~default:"unknown"
+      let text =
+        let open Yojson.Safe.Util in
+        match last_msg |> member "content" with
+        | `String s -> s
+        | `List items ->
+            (match items with
+             | [] -> "No content"
+             | item :: _ ->
+                 (match item |> member "text" |> to_string_option with
+                  | Some t -> t
+                  | None -> item |> member "content" |> to_string_option |> Option.value ~default:"unknown"))
+        | _ -> "No content"
       in
-      
-      let response_body = 
+
+      let response_body =
         if text = "ping" then
-          {|{"id":"m1","type":"message","role":"assistant","model":"c","content":[{"type":"text","text":"pong"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}|}
+          {|{"id":"chatcmpl-1","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"pong"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}|}
         else if text = "use_tool" then
-          {|{"id":"m2","type":"message","role":"assistant","model":"c","content":[{"type":"tool_use","id":"t1","name":"calculator","input":{"a":1,"b":2}}],"stop_reason":"tool_use","usage":{"input_tokens":1,"output_tokens":1}}|}
+          {|{"id":"chatcmpl-2","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"calculator","arguments":"{\"a\":1,\"b\":2}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}|}
         else if text = "3" then
-          {|{"id":"m3","type":"message","role":"assistant","model":"c","content":[{"type":"text","text":"The result is 3"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}|}
+          {|{"id":"chatcmpl-3","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"The result is 3"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}|}
         else
-          {|{"id":"me","type":"message","role":"assistant","model":"c","content":[{"type":"text","text":"err"}],"stop_reason":"end_turn","usage":{"input_tokens":0,"output_tokens":0}}|}
+          {|{"id":"chatcmpl-e","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"err"},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}|}
       in
       Cohttp_eio.Server.respond_string ~status:`OK ~body:response_body ()
   | _ ->
@@ -39,7 +42,7 @@ let mock_handler _conn req body =
 let test_simple_conversation () =
   let port = 8081 in
   let base_url = Printf.sprintf "http://127.0.0.1:%d" port in
-  
+
   Eio_main.run @@ fun env ->
   try
     Eio.Switch.run @@ fun sw ->
@@ -47,7 +50,11 @@ let test_simple_conversation () =
       let server = Cohttp_eio.Server.make ~callback:mock_handler () in
       Eio.Fiber.fork ~sw (fun () -> Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
 
-      let options = { Agent.default_options with base_url } in
+      let provider : Provider.config = {
+        provider = Provider.Local { base_url };
+        model_id = "mock"; api_key_env = "";
+      } in
+      let options = { Agent.default_options with base_url; provider = Some provider } in
       let agent = Agent.create ~net:env#net ~options () in
       match Agent.run ~sw agent "ping" with
       | Ok response ->
@@ -60,7 +67,7 @@ let test_simple_conversation () =
 let test_tool_use () =
   let port = 8082 in
   let base_url = Printf.sprintf "http://127.0.0.1:%d" port in
-  
+
   Eio_main.run @@ fun env ->
   try
     Eio.Switch.run @@ fun sw ->
@@ -73,7 +80,11 @@ let test_tool_use () =
          let b = Yojson.Safe.Util.(input |> member "b" |> to_int) in
          Ok { Types.content = string_of_int (a + b) }) in
 
-      let options = { Agent.default_options with base_url } in
+      let provider : Provider.config = {
+        provider = Provider.Local { base_url };
+        model_id = "mock"; api_key_env = "";
+      } in
+      let options = { Agent.default_options with base_url; provider = Some provider } in
       let agent = Agent.create ~net:env#net ~tools:[calc_tool] ~options () in
       match Agent.run ~sw agent "use_tool" with
       | Ok response ->
@@ -84,7 +95,7 @@ let test_tool_use () =
   with Exit -> ()
 
 let () =
-  (* Mock server tests need a key in env but don't use it *)
+  (* Agent.create resolves api_key_env even for Local provider; set a dummy *)
   if Sys.getenv_opt "ANTHROPIC_API_KEY" = None then
     Unix.putenv "ANTHROPIC_API_KEY" "test-mock-key";
   let open Alcotest in

--- a/test/test_provider_bridge.ml
+++ b/test/test_provider_bridge.ml
@@ -26,7 +26,7 @@ let test_local_provider_bridge () =
   | Ok cfg ->
       Alcotest.(check string) "model" "default"
         cfg.model_id;
-      Alcotest.(check string) "path" "/v1/messages" cfg.request_path
+      Alcotest.(check string) "path" "/v1/chat/completions" cfg.request_path
 
 let test_cascade_bridge () =
   let primary = Agent_sdk.Provider.local_llm () in


### PR DESCRIPTION
## Summary
Combined fix for all CI failures blocking main. Supersedes #315 and #317.

1. **Mock format migration** (9 test files): PR #308 changed Local provider from Anthropic Messages to OpenAI Chat Completions, but test mocks were not updated. All mock responses, SSE streams, and route assertions now use OpenAI format.

2. **Version consistency**: `sdk_version.ml` 0.78.0 → 0.81.0 to match `dune-project`.

3. **Routing test**: Local provider `request_kind` assertion `"anthropic"` → `"openai"`.

## Test results
- All tests pass except 1 pre-existing `help output` failure (exists on main too)
- 200+ tests across 10+ test executables

## Closes
- Supersedes #315 and #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)