### PR TITLE
fix(cascade): add Authorization header to cascade provider configs

### DIFF
--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -9,6 +9,19 @@
 
 let default_registry = Provider_registry.default ()
 
+(* Build headers list with Authorization when api_key is present.
+   Anthropic uses x-api-key; OpenAI-compat (including GLM) uses Bearer. *)
+let headers_with_auth ~(kind : Provider_config.provider_kind) ~api_key =
+  let base = [("Content-Type", "application/json")] in
+  if api_key = "" then base
+  else match kind with
+    | Anthropic ->
+        ("x-api-key", api_key)
+        :: ("anthropic-version", "2023-06-01")
+        :: base
+    | OpenAI_compat | Gemini | Claude_code ->
+        ("Authorization", "Bearer " ^ api_key) :: base
+
 (* ── Model string parsing ──────────────────────────────── *)
 
 let parse_custom_model model_id =
@@ -65,11 +78,12 @@ let parse_model_string ?(temperature = 0.3) ?(max_tokens = 500)
                   Sys.getenv_opt defaults.api_key_env
                   |> Option.value ~default:""
               in
+              let headers = headers_with_auth ~kind:defaults.kind ~api_key in
               Some (Provider_config.make
                       ~kind:defaults.kind
                       ~model_id
                       ~base_url:defaults.base_url
-                      ~api_key
+                      ~api_key ~headers
                       ~request_path:defaults.request_path
                       ~temperature
                       ~max_tokens
@@ -117,9 +131,10 @@ let parse_model_string_exn ?(temperature = 0.3) ?(max_tokens = 500)
                 if defaults.api_key_env = "" then ""
                 else Sys.getenv_opt defaults.api_key_env |> Option.value ~default:""
               in
+              let headers = headers_with_auth ~kind:defaults.kind ~api_key in
               Ok (Provider_config.make
                     ~kind:defaults.kind ~model_id ~base_url:defaults.base_url
-                    ~api_key ~request_path:defaults.request_path
+                    ~api_key ~headers ~request_path:defaults.request_path
                     ~temperature ~max_tokens ?system_prompt ()))
 
 let parse_model_strings ?(temperature = 0.3) ?(max_tokens = 500)


### PR DESCRIPTION
## Summary

- Cascade config에서 `Provider_config.make` 호출 시 `~headers`를 지정하지 않아 기본값 `[Content-Type: application/json]`만 전송
- GLM(ZhipuAI) API가 `Authorization: Bearer` 헤더 없이 요청 받으면 중국어 auth 에러 반환: `Header中未收到Authorization参数，无法进行身份验证。`
- `headers_with_auth` 헬퍼 추가: Anthropic은 `x-api-key`, OpenAI_compat(GLM 포함)은 `Bearer` 사용
- 2곳의 `Provider_config.make` 호출 모두 수정

## Test plan

- [x] `dune build` 성공
- [x] `dune runtest` — 1 pre-existing failure (help CLI)
- [ ] 실제 keeper cascade에서 GLM fallback 정상 동작 확인
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)