### PR TITLE
fix: guard Eio.Cancel.Cancelled in 29 exception handlers

### DIFF
--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -165,7 +165,9 @@ let apply_context_injection ~context ~messages ~injector ~tool_uses ~results =
           in
           if valid_messages <> [] then
             current_messages := Util.snoc_list !current_messages valid_messages
-      with exn ->
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
         Printf.eprintf
           "[oas] context_injector for tool '%s' raised: %s\n%!"
           name (Printexc.to_string exn))

--- a/lib/checkpoint_store.ml
+++ b/lib/checkpoint_store.ml
@@ -19,7 +19,9 @@ let create base_dir =
   try
     Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 base_dir;
     Ok { base_dir }
-  with exn -> io_error_of_exn ~op:"create" ~path:"checkpoint_dir" exn
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> io_error_of_exn ~op:"create" ~path:"checkpoint_dir" exn
 
 let file_path store id = Eio.Path.(store.base_dir / (id ^ ".json"))
 let tmp_path store id = Eio.Path.(store.base_dir / (id ^ ".json.tmp"))
@@ -35,7 +37,9 @@ let save store (cp : Checkpoint.t) =
        Eio.Path.save ~create:(`Or_truncate 0o644) tmp data;
        Eio.Path.rename tmp target;
        Ok ()
-     with exn ->
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
        (* Best-effort cleanup: ignore unlink failure — the primary error is already captured *)
        (try Eio.Path.unlink tmp with Eio.Io _ | Unix.Unix_error _ -> ());
        io_error_of_exn ~op:"save" ~path:cp.session_id exn)
@@ -48,7 +52,9 @@ let load store id =
     (try
        let data = Eio.Path.load path in
        Checkpoint.of_string data
-     with exn -> io_error_of_exn ~op:"load" ~path:id exn)
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn -> io_error_of_exn ~op:"load" ~path:id exn)
 
 let list store =
   try
@@ -61,7 +67,9 @@ let list store =
            && not (len > 9 && String.sub name (len - 9) 9 = ".json.tmp"))
     |> List.map (fun name -> String.sub name 0 (String.length name - 5))
     |> List.sort String.compare)
-  with exn -> io_error_of_exn ~op:"list" ~path:"checkpoint_dir" exn
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> io_error_of_exn ~op:"list" ~path:"checkpoint_dir" exn
 
 let delete store id =
   match validate_session_id id with
@@ -71,7 +79,9 @@ let delete store id =
     (try
        Eio.Path.unlink path;
        Ok ()
-     with exn -> io_error_of_exn ~op:"delete" ~path:id exn)
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn -> io_error_of_exn ~op:"delete" ~path:id exn)
 
 let exists store id =
   match validate_session_id id with

--- a/lib/consumer.ml
+++ b/lib/consumer.ml
@@ -16,7 +16,9 @@ let run_agent ~sw ?clock ?harness agent prompt =
   let t0 = Unix.gettimeofday () in
   let response =
     try Agent.run ~sw ?clock agent prompt
-    with exn -> Error (Error.Internal (Printexc.to_string exn))
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn -> Error (Error.Internal (Printexc.to_string exn))
   in
   let elapsed = Unix.gettimeofday () -. t0 in
   let trace_ref = Agent.last_raw_trace_run agent in

--- a/lib/durable.ml
+++ b/lib/durable.ml
@@ -188,7 +188,9 @@ let journal_entry_of_json json =
     let attempt = json |> member "attempt" |> to_int in
     Ok { step_name; started_at; completed_at; input_json; output_json;
          error; attempt }
-  with exn -> Error (Printexc.to_string exn)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Error (Printexc.to_string exn)
 
 let journal_list_to_json journal =
   `List (List.map journal_entry_to_json journal)
@@ -258,4 +260,6 @@ let execution_state_of_json json =
        | Ok journal -> Ok (Failed { at_step; journal; error })
        | Error e -> Error e)
     | unknown -> Error (Printf.sprintf "unknown execution state: %s" unknown)
-  with exn -> Error (Printexc.to_string exn)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Error (Printexc.to_string exn)

--- a/lib/eval_baseline.ml
+++ b/lib/eval_baseline.ml
@@ -57,7 +57,9 @@ let load ~path : (baseline, string) result =
       let description = json |> member "description" |> to_string_option
         |> Option.value ~default:"" in
       Ok { run_metrics; created_at; description }
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
     Error (Printf.sprintf "Failed to load baseline: %s" (Printexc.to_string exn))
 
 (** Create a baseline from a run. *)

--- a/lib/event_forward.ml
+++ b/lib/event_forward.ml
@@ -146,7 +146,9 @@ let deliver_to_custom t name deliver payloads =
     try
       deliver p;
       t.delivered_count <- t.delivered_count + 1
-    with exn ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
       t.failed_count <- t.failed_count + 1;
       Log.warn t.log "custom delivery failed"
         [Log.S ("target", name); Log.S ("error", Printexc.to_string exn)]
@@ -167,7 +169,9 @@ let deliver_to_webhook t ~sw ~net url headers method_ _timeout_s payloads =
        For now we record success for non-network targets and
        provide the infrastructure for future HTTP delivery. *)
     t.delivered_count <- t.delivered_count + List.length payloads
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
     t.failed_count <- t.failed_count + List.length payloads;
     Log.warn t.log "webhook delivery failed"
       [Log.S ("url", url); Log.S ("error", Printexc.to_string exn)]

--- a/lib/fs_result.ml
+++ b/lib/fs_result.ml
@@ -17,18 +17,23 @@ let io_error_of_exn ~op ~path = function
     Error (Error.Io (FileOpFailed { op; path; detail = msg }))
   | Yojson.Json_error msg ->
     Error (Error.Io (FileOpFailed { op; path; detail = "JSON error: " ^ msg }))
+  | Eio.Cancel.Cancelled _ as e -> raise e
   | exn -> raise exn
 
 let read_file path =
   try Ok (In_channel.with_open_bin path In_channel.input_all)
-  with exn -> io_error_of_exn ~op:"read" ~path exn
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> io_error_of_exn ~op:"read" ~path exn
 
 let ensure_dir path =
   try
     if not (Sys.file_exists path) then
       Sys.mkdir path 0o755;
     Ok ()
-  with exn -> io_error_of_exn ~op:"mkdir" ~path exn
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> io_error_of_exn ~op:"mkdir" ~path exn
 
 let ensure_dir_recursive path =
   let rec aux p =
@@ -39,7 +44,9 @@ let ensure_dir_recursive path =
     end
   in
   try aux path; Ok ()
-  with exn -> io_error_of_exn ~op:"mkdir_p" ~path exn
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> io_error_of_exn ~op:"mkdir_p" ~path exn
 
 let write_file path content =
   try
@@ -49,7 +56,9 @@ let write_file path content =
       Out_channel.output_string oc content);
     Sys.rename tmp_path path;
     Ok ()
-  with exn -> io_error_of_exn ~op:"write" ~path exn
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> io_error_of_exn ~op:"write" ~path exn
 
 let append_file path content =
   try
@@ -59,11 +68,15 @@ let append_file path content =
       ~finally:(fun () -> close_out_noerr oc)
       (fun () -> output_string oc content);
     Ok ()
-  with exn -> io_error_of_exn ~op:"append" ~path exn
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> io_error_of_exn ~op:"append" ~path exn
 
 let read_dir path =
   try Ok (Sys.readdir path |> Array.to_list |> List.sort String.compare)
-  with exn -> io_error_of_exn ~op:"read_dir" ~path exn
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> io_error_of_exn ~op:"read_dir" ~path exn
 
 let file_exists path =
   try Sys.file_exists path && not (Sys.is_directory path)
@@ -73,4 +86,6 @@ let remove_file path =
   try
     if Sys.file_exists path then Sys.remove path;
     Ok ()
-  with exn -> io_error_of_exn ~op:"remove" ~path exn
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> io_error_of_exn ~op:"remove" ~path exn

--- a/lib/plan.ml
+++ b/lib/plan.ml
@@ -183,7 +183,9 @@ let step_of_json json =
         depends_on = json |> member "depends_on" |> to_list
           |> List.map to_string;
       }
-  with exn -> Error (Printexc.to_string exn)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Error (Printexc.to_string exn)
 
 let plan_status_to_json = function
   | Planning -> `Assoc [("status", `String "Planning")]
@@ -230,4 +232,6 @@ let of_json json =
            status;
            created_at = json |> member "created_at" |> to_float;
          })
-  with exn -> Error (Printexc.to_string exn)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Error (Printexc.to_string exn)

--- a/lib/protocol/a2a_task_store.ml
+++ b/lib/protocol/a2a_task_store.ml
@@ -28,7 +28,9 @@ let create base_dir =
   try
     Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 base_dir;
     Ok { base_dir; cache = Hashtbl.create 64 }
-  with exn -> io_error_of_exn ~op:"create" ~path:"task_store_dir" exn
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> io_error_of_exn ~op:"create" ~path:"task_store_dir" exn
 
 let store_task store (task : A2a_task.task) =
   match validate_task_id task.id with
@@ -43,7 +45,9 @@ let store_task store (task : A2a_task.task) =
        Eio.Path.rename tmp target;
        Hashtbl.replace store.cache task.id task;
        Ok ()
-     with exn ->
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
        (try Eio.Path.unlink tmp with Eio.Io _ | Unix.Unix_error _ -> ());
        io_error_of_exn ~op:"store_task" ~path:task.id exn)
 
@@ -62,7 +66,9 @@ let delete_task store id =
        Eio.Path.unlink path;
        Hashtbl.remove store.cache id;
        Ok ()
-     with exn -> io_error_of_exn ~op:"delete_task" ~path:id exn)
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn -> io_error_of_exn ~op:"delete_task" ~path:id exn)
 
 (** Reload all tasks from disk into the cache.
     Skips files that fail to parse (corrupted JSON). *)
@@ -88,7 +94,9 @@ let reload store =
       with Eio.Io _ | Yojson.Json_error _ -> ()  (* skip unreadable/corrupt files *)
     ) json_files;
     Ok ()
-  with exn -> io_error_of_exn ~op:"reload" ~path:"task_store_dir" exn
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> io_error_of_exn ~op:"reload" ~path:"task_store_dir" exn
 
 (** Garbage-collect terminal tasks older than [max_age_s] seconds.
     Returns the number of tasks removed. *)

--- a/lib/protocol/mcp_session.ml
+++ b/lib/protocol/mcp_session.ml
@@ -89,7 +89,9 @@ let env_pair_of_json json =
   try
     Ok (json |> member "key" |> to_string,
         json |> member "value" |> to_string)
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
     Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Invalid env pair: %s" (Printexc.to_string exn) }))
 
 let result_all items =

--- a/lib/succession.ml
+++ b/lib/succession.ml
@@ -291,5 +291,7 @@ let dna_of_json json =
       warnings = str_list_of_json (json |> member "warnings");
       metrics = metrics_of_json (json |> member "metrics");
     }
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
     Error (Printf.sprintf "DNA parse error: %s" (Printexc.to_string exn))


### PR DESCRIPTION
## Summary
- 29 generic `with e ->` catches across 11 files silently swallow `Eio.Cancel.Cancelled`
- Added re-raise guard to all sites, matching existing pattern in the codebase
- Prevents zombie fibers when cancellation is triggered during I/O operations

## Files
| File | Guards |
|------|--------|
| `fs_result.ml` | 8 |
| `checkpoint_store.ml` | 5 |
| `a2a_task_store.ml` | 4 |
| `event_forward.ml` | 2 |
| `durable.ml` | 2 |
| `plan.ml` | 2 |
| Others (5 files) | 1 each |

## Test plan
- [x] `dune build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)