### PR TITLE
refactor: migrate raw eprintf to structured Log module

### DIFF
--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -269,7 +269,10 @@ let connect_mcp_servers_best_effort ~sw ~mgr ~net mcp_cfgs =
           | Stdio_mcp { name; _ } -> name
           | Http_mcp { name; _ } -> name
         in
-        Printf.eprintf "[oas] MCP server '%s' failed: %s\n%!" name (Error.to_string e);
+        let _log = Log.create ~module_name:"agent_config" () in
+        Log.warn _log
+          "MCP server failed"
+          [S ("server", name); S ("error", Error.to_string e)];
         acc
   ) [] mcp_cfgs
   |> List.rev

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -168,9 +168,10 @@ let apply_context_injection ~context ~messages ~injector ~tool_uses ~results =
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
-        Printf.eprintf
-          "[oas] context_injector for tool '%s' raised: %s\n%!"
-          name (Printexc.to_string exn))
+        let _log = Log.create ~module_name:"agent_turn" () in
+        Log.warn _log
+          "context_injector raised"
+          [S ("tool", name); S ("error", Printexc.to_string exn)])
     | _ -> ()
   ) tool_uses results;
   !current_messages

--- a/lib/append_instruction.ml
+++ b/lib/append_instruction.ml
@@ -32,8 +32,9 @@ let render_source ?context ~turn = function
     (match Fs_result.read_file path with
      | Ok content -> Some content
      | Error err ->
-       let _ = Printf.eprintf "[append_instruction] FromFile %s failed: %s\n%!"
-         path (Error.to_string err) in
+       let _log = Log.create ~module_name:"append_instruction" () in
+       Log.warn _log "FromFile failed"
+         [S ("path", path); S ("error", Error.to_string err)];
        None)
   | Dynamic f -> f turn
 

--- a/lib/protocol/mcp_session.ml
+++ b/lib/protocol/mcp_session.ml
@@ -14,7 +14,9 @@
       (* On resume *)
       let managed, failed_with_reasons = Mcp_session.reconnect_all ~sw ~mgr infos in
       List.iter (fun (info, err) ->
-        Printf.eprintf "Failed to reconnect %s: %s\n" info.server_name err
+        let _log = Log.create ~module_name:"mcp_session" () in
+        Log.warn _log "Failed to reconnect"
+          [S ("server", info.server_name); S ("error", err)]
       ) failed_with_reasons;
     ]} *)
 


### PR DESCRIPTION
## Summary
- Replace 4 raw `Printf.eprintf` calls with `Log.warn` using structured fields
- Files: `agent_turn.ml`, `agent_config.ml`, `mcp_session.ml`, `append_instruction.ml`
- `lib/log.ml` (the logger itself) is untouched; only its internal `stderr_sink` remains as the sole `eprintf` in `lib/`

## Test plan
- [x] `dune build --root .` passes
- [x] No remaining `Printf.eprintf` in `lib/` outside `log.ml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)