### PR TITLE
fix(test): use --help=plain to fix help output test

### DIFF
--- a/test/test_cli.ml
+++ b/test/test_cli.ml
@@ -196,7 +196,7 @@ let test_card_with_config () =
 (* ── Help output ────────────────────────────────────────── *)
 
 let test_help () =
-  let cmd = Printf.sprintf "%s --help 2>&1" cli_exe in
+  let cmd = Printf.sprintf "%s --help=plain 2>&1" cli_exe in
   let ic = Unix.open_process_in cmd in
   let output = In_channel.input_all ic in
   let _ = Unix.close_process_in ic in


### PR DESCRIPTION
## Summary

- `test_help`가 `oas --help` 출력에서 "eval" 검색 실패
- 원인: Cmdliner `--help`가 nroff man format으로 출력 — bold 문자가 `c\bc` (backspace overlap)으로 이중 인코딩
- `"eval"` → `"e\be v\bv a\ba l\bl"` 8바이트 → `Str.search_forward` 매칭 불가
- 수정: `--help=plain` 사용으로 plain text 출력

## Test plan
- [x] help test 통과
- [x] 전체 테스트 0 failures
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)