### PR TITLE
fix: Cancel.Cancelled re-raise + cascade fallback on all errors

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -148,6 +148,7 @@ let execute_tools ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tracer
             | Out_of_memory -> raise Out_of_memory
             | Stack_overflow -> raise Stack_overflow
             | Sys.Break -> raise Sys.Break
+            | Eio.Cancel.Cancelled _ as ex -> raise ex
             | exn ->
               let msg = Printf.sprintf "Tool '%s' raised: %s" name (Printexc.to_string exn) in
               (id, msg, true)))

--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -109,7 +109,9 @@ let with_cascade ~clock ?(config=default_config)
     : ('a, api_error) result =
   match with_retry ~clock ~config primary with
   | Ok _ as success -> success
-  | Error primary_err when is_retryable primary_err ->
+  | Error primary_err ->
+    (* Cascade tries all fallbacks on any primary failure, not just retryable ones.
+       A non-retryable error on provider A (e.g., AuthError) should still try provider B. *)
     let rec try_fallbacks = function
       | [] -> Error primary_err
       | fb :: rest ->
@@ -118,4 +120,3 @@ let with_cascade ~clock ?(config=default_config)
         | Error _ -> try_fallbacks rest
     in
     try_fallbacks fallbacks
-  | Error _ as non_retryable -> non_retryable


### PR DESCRIPTION
Closes #325, #326. agent_tools.ml catch-all에 Cancel.Cancelled re-raise 추가. with_cascade에서 non-retryable 에러도 fallback 시도.