### PR TITLE
fix(transport): parse_stop_reason maps unknown to Unknown, not EndTurn

### DIFF
--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -176,12 +176,7 @@ let parse_usage json =
            cache_read_input_tokens = member_int "cache_read_input_tokens" u }
   | _ -> None
 
-let parse_stop_reason s =
-  match s with
-  | "end_turn" -> Types.EndTurn
-  | "tool_use" -> Types.StopToolUse
-  | "max_tokens" -> Types.MaxTokens
-  | _ -> Types.EndTurn
+let parse_stop_reason s = Types.stop_reason_of_string s
 
 (** Parse a sync JSON result into api_response. *)
 let parse_json_result json_str =
@@ -432,7 +427,8 @@ let%test "parse_stop_reason variants" =
   parse_stop_reason "end_turn" = Types.EndTurn
   && parse_stop_reason "tool_use" = Types.StopToolUse
   && parse_stop_reason "max_tokens" = Types.MaxTokens
-  && parse_stop_reason "unknown" = Types.EndTurn
+  && parse_stop_reason "stop_sequence" = Types.StopSequence
+  && parse_stop_reason "unknown" = Types.Unknown "unknown"
 
 let%test "parse_stream_result from result line" =
   let lines = [


### PR DESCRIPTION
## Summary
- `transport_claude_code.ml:parse_stop_reason` mapped all unrecognized stop_reason strings to `EndTurn`, violating the canonical `Types.stop_reason_of_string` contract that uses `Unknown(string)`.
- Replaced the local implementation with a direct delegation to `Types.stop_reason_of_string`.
- Added `StopSequence` coverage to the inline test; updated the `"unknown"` assertion to expect `Unknown "unknown"`.

## Impact
Without this fix, unrecognized stop reasons from Claude Code transport were silently treated as successful completions (`EndTurn`), bypassing the `pipeline.ml:317` error path that surfaces `UnrecognizedStopReason` errors.

## Test plan
- [x] `dune build --root .` passes
- [x] `dune test --root .` passes (84 tests)
- [x] Inline `%test "parse_stop_reason variants"` covers EndTurn, StopToolUse, MaxTokens, StopSequence, and Unknown

Closes #328

Generated with [Claude Code](https://claude.com/claude-code)