### PR TITLE
fix(streaming): propagate SSEError from finalize_stream_acc via result type

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -322,12 +322,11 @@ let complete_stream_http ~sw ~net ~(config : Provider_config.t)
           accumulate_event acc evt
         ) events
       ) ();
-      match !(acc.sse_error) with
-      | Some msg ->
+      match finalize_stream_acc acc with
+      | Ok resp -> Ok resp
+      | Error msg ->
           Error (Http_client.NetworkError {
             message = Printf.sprintf "SSE stream error: %s" msg })
-      | None ->
-          Ok (finalize_stream_acc acc)
 
 let complete_stream ~sw ~net ?(transport : Llm_transport.t option)
     ~(config : Provider_config.t)

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -69,6 +69,9 @@ let accumulate_event (acc : stream_acc) = function
   | Types.MessageStop | Types.Ping -> ()
 
 let finalize_stream_acc (acc : stream_acc) =
+  match !(acc.sse_error) with
+  | Some msg -> Error msg
+  | None ->
   let indices =
     Hashtbl.fold (fun k _ acc -> k :: acc) acc.block_types []
     |> List.sort compare
@@ -91,7 +94,7 @@ let finalize_stream_acc (acc : stream_acc) =
         Some (Types.ToolUse { id; name; input })
     | _ -> None
   ) indices in
-  { Types.id = !(acc.id);
+  Ok { Types.id = !(acc.id);
     model = !(acc.model);
     stop_reason = !(acc.stop_reason);
     content;
@@ -159,10 +162,12 @@ let%test "finalize_stream_acc assembles text block" =
   let buf = Buffer.create 16 in
   Buffer.add_string buf "Hello world";
   Hashtbl.replace acc.block_texts 0 buf;
-  let result = finalize_stream_acc acc in
-  result.id = "test-id"
-  && result.model = "test-model"
-  && result.content = [Types.Text "Hello world"]
+  match finalize_stream_acc acc with
+  | Error _ -> false
+  | Ok result ->
+    result.id = "test-id"
+    && result.model = "test-model"
+    && result.content = [Types.Text "Hello world"]
 
 let%test "finalize_stream_acc assembles tool_use block" =
   let acc = create_stream_acc () in
@@ -172,11 +177,13 @@ let%test "finalize_stream_acc assembles tool_use block" =
   let buf = Buffer.create 16 in
   Buffer.add_string buf "{\"key\":\"val\"}";
   Hashtbl.replace acc.block_texts 0 buf;
-  let result = finalize_stream_acc acc in
-  match result.content with
-  | [Types.ToolUse { id = "tool-id-1"; name = "my_tool"; input }] ->
-    input = `Assoc [("key", `String "val")]
-  | _ -> false
+  match finalize_stream_acc acc with
+  | Error _ -> false
+  | Ok result ->
+    (match result.content with
+    | [Types.ToolUse { id = "tool-id-1"; name = "my_tool"; input }] ->
+      input = `Assoc [("key", `String "val")]
+    | _ -> false)
 
 let%test "finalize_stream_acc assembles thinking block" =
   let acc = create_stream_acc () in
@@ -184,10 +191,12 @@ let%test "finalize_stream_acc assembles thinking block" =
   let buf = Buffer.create 16 in
   Buffer.add_string buf "reasoning...";
   Hashtbl.replace acc.block_texts 0 buf;
-  let result = finalize_stream_acc acc in
-  match result.content with
-  | [Types.Thinking { thinking_type = "thinking"; content = "reasoning..." }] -> true
-  | _ -> false
+  match finalize_stream_acc acc with
+  | Error _ -> false
+  | Ok result ->
+    (match result.content with
+    | [Types.Thinking { thinking_type = "thinking"; content = "reasoning..." }] -> true
+    | _ -> false)
 
 let%test "finalize_stream_acc multiple blocks ordered by index" =
   let acc = create_stream_acc () in
@@ -197,8 +206,9 @@ let%test "finalize_stream_acc multiple blocks ordered by index" =
   let buf1 = Buffer.create 16 in Buffer.add_string buf1 "say";
   Hashtbl.replace acc.block_texts 0 buf0;
   Hashtbl.replace acc.block_texts 1 buf1;
-  let result = finalize_stream_acc acc in
-  List.length result.content = 2
+  match finalize_stream_acc acc with
+  | Error _ -> false
+  | Ok result -> List.length result.content = 2
 
 let%test "finalize_stream_acc includes usage" =
   let acc = create_stream_acc () in
@@ -206,12 +216,14 @@ let%test "finalize_stream_acc includes usage" =
   acc.output_tokens := 50;
   acc.cache_creation := 10;
   acc.cache_read := 20;
-  let result = finalize_stream_acc acc in
-  match result.usage with
-  | Some u ->
-    u.input_tokens = 100 && u.output_tokens = 50
-    && u.cache_creation_input_tokens = 10 && u.cache_read_input_tokens = 20
-  | None -> false
+  match finalize_stream_acc acc with
+  | Error _ -> false
+  | Ok result ->
+    (match result.usage with
+    | Some u ->
+      u.input_tokens = 100 && u.output_tokens = 50
+      && u.cache_creation_input_tokens = 10 && u.cache_read_input_tokens = 20
+    | None -> false)
 
 (* --- accumulate_event edge cases --- *)
 
@@ -286,8 +298,9 @@ let%test "accumulate_event SSEError records error" =
 
 let%test "finalize_stream_acc empty produces empty content" =
   let acc = create_stream_acc () in
-  let result = finalize_stream_acc acc in
-  result.content = []
+  match finalize_stream_acc acc with
+  | Error _ -> false
+  | Ok result -> result.content = []
 
 let%test "finalize_stream_acc unknown block type filtered out" =
   let acc = create_stream_acc () in
@@ -295,8 +308,9 @@ let%test "finalize_stream_acc unknown block type filtered out" =
   let buf = Buffer.create 16 in
   Buffer.add_string buf "data";
   Hashtbl.replace acc.block_texts 0 buf;
-  let result = finalize_stream_acc acc in
-  result.content = []
+  match finalize_stream_acc acc with
+  | Error _ -> false
+  | Ok result -> result.content = []
 
 let%test "finalize_stream_acc tool_use with invalid json falls back to empty assoc" =
   let acc = create_stream_acc () in
@@ -304,10 +318,12 @@ let%test "finalize_stream_acc tool_use with invalid json falls back to empty ass
   let buf = Buffer.create 16 in
   Buffer.add_string buf "not valid json";
   Hashtbl.replace acc.block_texts 0 buf;
-  let result = finalize_stream_acc acc in
-  match result.content with
-  | [Types.ToolUse { input = `Assoc []; _ }] -> true
-  | _ -> false
+  match finalize_stream_acc acc with
+  | Error _ -> false
+  | Ok result ->
+    (match result.content with
+    | [Types.ToolUse { input = `Assoc []; _ }] -> true
+    | _ -> false)
 
 let%test "finalize_stream_acc tool_use missing id/name defaults to empty" =
   let acc = create_stream_acc () in
@@ -315,19 +331,35 @@ let%test "finalize_stream_acc tool_use missing id/name defaults to empty" =
   let buf = Buffer.create 16 in
   Buffer.add_string buf "{}";
   Hashtbl.replace acc.block_texts 0 buf;
-  let result = finalize_stream_acc acc in
-  match result.content with
-  | [Types.ToolUse { id = ""; name = ""; _ }] -> true
-  | _ -> false
+  match finalize_stream_acc acc with
+  | Error _ -> false
+  | Ok result ->
+    (match result.content with
+    | [Types.ToolUse { id = ""; name = ""; _ }] -> true
+    | _ -> false)
 
 let%test "finalize_stream_acc block with no text buffer produces empty text" =
   let acc = create_stream_acc () in
   Hashtbl.replace acc.block_types 0 "text";
   (* No buffer added for index 0 *)
-  let result = finalize_stream_acc acc in
-  match result.content with
-  | [Types.Text ""] -> true
-  | _ -> false
+  match finalize_stream_acc acc with
+  | Error _ -> false
+  | Ok result ->
+    (match result.content with
+    | [Types.Text ""] -> true
+    | _ -> false)
+
+let%test "finalize_stream_acc returns Error when sse_error is set" =
+  let acc = create_stream_acc () in
+  acc.id := "partial-id";
+  Hashtbl.replace acc.block_types 0 "text";
+  let buf = Buffer.create 16 in
+  Buffer.add_string buf "partial content";
+  Hashtbl.replace acc.block_texts 0 buf;
+  acc.sse_error := Some "server overloaded";
+  match finalize_stream_acc acc with
+  | Error msg -> msg = "server overloaded"
+  | Ok _ -> false
 
 let%test "accumulate_event multiple MessageDelta accumulates tokens" =
   let acc = create_stream_acc () in

--- a/lib/llm_provider/complete_stream_acc.mli
+++ b/lib/llm_provider/complete_stream_acc.mli
@@ -30,5 +30,6 @@ val create_stream_acc : unit -> stream_acc
 val accumulate_event : stream_acc -> Types.sse_event -> unit
 
 (** Produce the final {!Types.api_response} from the accumulated state.
-    Content blocks are ordered by their stream index. *)
-val finalize_stream_acc : stream_acc -> Types.api_response
+    Returns [Error msg] if an SSE error was recorded during the stream;
+    content blocks are ordered by their stream index. *)
+val finalize_stream_acc : stream_acc -> (Types.api_response, string) result

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -78,6 +78,9 @@ let accumulate_event (acc : stream_acc) = function
   | _ -> ()
 
 let finalize_stream_acc (acc : stream_acc) =
+  match !(acc.sse_error) with
+  | Some msg -> Error msg
+  | None ->
   let content =
     Hashtbl.fold (fun index ctype items ->
       let text = match Hashtbl.find_opt acc.block_texts index with
@@ -112,7 +115,7 @@ let finalize_stream_acc (acc : stream_acc) =
                 cache_read_input_tokens = !(acc.cache_read) }
     else None
   in
-  { id = !(acc.msg_id); model = !(acc.msg_model);
+  Ok { id = !(acc.msg_id); model = !(acc.msg_model);
     stop_reason = !(acc.stop_reason); content; usage }
 
 (* ── HTTP error mapping ─────────────────────────────────────── *)
@@ -179,11 +182,11 @@ let create_message_stream ~sw ~net ?(base_url=Api.default_base_url)
                           on_event evt; accumulate_event acc evt
                   ) ();
                 on_event MessageStop;
-                match !(acc.sse_error) with
-                | Some msg ->
+                (match finalize_stream_acc acc with
+                | Ok resp -> Ok resp
+                | Error msg ->
                     Error (Error.Api (Retry.NetworkError {
-                      message = Printf.sprintf "SSE stream error: %s" msg }))
-                | None -> Ok (finalize_stream_acc acc))
+                      message = Printf.sprintf "SSE stream error: %s" msg }))))
        | Provider.Openai_chat_completions ->
            (* OpenAI-compatible SSE streaming. *)
            let headers = match Provider.resolve provider_cfg with
@@ -230,11 +233,11 @@ let create_message_stream ~sw ~net ?(base_url=Api.default_base_url)
                                oai_state chunk)
                   ) ();
                 on_event MessageStop;
-                match !(acc.sse_error) with
-                | Some msg ->
+                (match finalize_stream_acc acc with
+                | Ok resp -> Ok resp
+                | Error msg ->
                     Error (Error.Api (Retry.NetworkError {
-                      message = Printf.sprintf "SSE stream error: %s" msg }))
-                | None -> Ok (finalize_stream_acc acc))
+                      message = Printf.sprintf "SSE stream error: %s" msg }))))
        | Provider.Custom _ ->
            (* Sync fallback: non-streaming call + synthetic events *)
            (match Api.create_message ~sw ~net ~base_url

--- a/lib/streaming.mli
+++ b/lib/streaming.mli
@@ -38,8 +38,9 @@ val create_stream_acc : unit -> stream_acc
 (** Feed a single SSE event into the accumulator. *)
 val accumulate_event : stream_acc -> Types.sse_event -> unit
 
-(** Finalize the accumulator into a complete API response. *)
-val finalize_stream_acc : stream_acc -> Types.api_response
+(** Finalize the accumulator into a complete API response.
+    Returns [Error msg] if an SSE error was recorded during the stream. *)
+val finalize_stream_acc : stream_acc -> (Types.api_response, string) result
 
 (** {1 HTTP Error Mapping} *)
 

--- a/test/test_stream_accumulator.ml
+++ b/test/test_stream_accumulator.ml
@@ -172,19 +172,21 @@ let test_finalize_text_response () =
     MessageDelta { stop_reason = Some EndTurn;
                    usage = Some (make_usage 0 50) };
   ];
-  let resp = Streaming.finalize_stream_acc acc in
-  Alcotest.(check string) "id" "msg_f" resp.id;
-  Alcotest.(check string) "model" "test" resp.model;
-  (match resp.stop_reason with EndTurn -> () | _ -> Alcotest.fail "expected EndTurn");
-  Alcotest.(check int) "1 content block" 1 (List.length resp.content);
-  (match List.hd resp.content with
-   | Text s -> Alcotest.(check string) "text" "hello world" s
-   | _ -> Alcotest.fail "expected Text");
-  (match resp.usage with
-   | Some u ->
-     Alcotest.(check int) "input" 100 u.input_tokens;
-     Alcotest.(check int) "output" 50 u.output_tokens
-   | None -> Alcotest.fail "expected usage")
+  (match Streaming.finalize_stream_acc acc with
+  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Ok resp ->
+    Alcotest.(check string) "id" "msg_f" resp.id;
+    Alcotest.(check string) "model" "test" resp.model;
+    (match resp.stop_reason with EndTurn -> () | _ -> Alcotest.fail "expected EndTurn");
+    Alcotest.(check int) "1 content block" 1 (List.length resp.content);
+    (match List.hd resp.content with
+     | Text s -> Alcotest.(check string) "text" "hello world" s
+     | _ -> Alcotest.fail "expected Text");
+    (match resp.usage with
+     | Some u ->
+       Alcotest.(check int) "input" 100 u.input_tokens;
+       Alcotest.(check int) "output" 50 u.output_tokens
+     | None -> Alcotest.fail "expected usage"))
 
 let test_finalize_thinking_block () =
   let acc = Streaming.create_stream_acc () in
@@ -195,11 +197,13 @@ let test_finalize_thinking_block () =
     ContentBlockDelta { index = 0; delta = ThinkingDelta "reasoning here" };
     MessageDelta { stop_reason = Some EndTurn; usage = None };
   ];
-  let resp = Streaming.finalize_stream_acc acc in
-  (match List.hd resp.content with
-   | Thinking { content; _ } ->
-     Alcotest.(check string) "thinking" "reasoning here" content
-   | _ -> Alcotest.fail "expected Thinking")
+  (match Streaming.finalize_stream_acc acc with
+  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Ok resp ->
+    (match List.hd resp.content with
+     | Thinking { content; _ } ->
+       Alcotest.(check string) "thinking" "reasoning here" content
+     | _ -> Alcotest.fail "expected Thinking"))
 
 let test_finalize_tool_use () =
   let acc = Streaming.create_stream_acc () in
@@ -210,14 +214,16 @@ let test_finalize_tool_use () =
     ContentBlockDelta { index = 0; delta = InputJsonDelta "{\"x\":42}" };
     MessageDelta { stop_reason = Some StopToolUse; usage = None };
   ];
-  let resp = Streaming.finalize_stream_acc acc in
-  (match List.hd resp.content with
-   | ToolUse { id; name; input } ->
-     Alcotest.(check string) "tool_id" "tu_1" id;
-     Alcotest.(check string) "tool_name" "calc" name;
-     Alcotest.(check string) "input" "{\"x\":42}"
-       (Yojson.Safe.to_string input)
-   | _ -> Alcotest.fail "expected ToolUse")
+  (match Streaming.finalize_stream_acc acc with
+  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Ok resp ->
+    (match List.hd resp.content with
+     | ToolUse { id; name; input } ->
+       Alcotest.(check string) "tool_id" "tu_1" id;
+       Alcotest.(check string) "tool_name" "calc" name;
+       Alcotest.(check string) "input" "{\"x\":42}"
+         (Yojson.Safe.to_string input)
+     | _ -> Alcotest.fail "expected ToolUse"))
 
 let test_finalize_tool_use_invalid_json () =
   let acc = Streaming.create_stream_acc () in
@@ -228,10 +234,12 @@ let test_finalize_tool_use_invalid_json () =
     ContentBlockDelta { index = 0; delta = InputJsonDelta "not json{" };
     MessageDelta { stop_reason = Some EndTurn; usage = None };
   ];
-  let resp = Streaming.finalize_stream_acc acc in
-  (match List.hd resp.content with
-   | Text s -> Alcotest.(check string) "fallback to text" "not json{" s
-   | _ -> Alcotest.fail "expected Text fallback for invalid JSON")
+  (match Streaming.finalize_stream_acc acc with
+  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Ok resp ->
+    (match List.hd resp.content with
+     | Text s -> Alcotest.(check string) "fallback to text" "not json{" s
+     | _ -> Alcotest.fail "expected Text fallback for invalid JSON"))
 
 let test_finalize_multi_block_ordering () =
   let acc = Streaming.create_stream_acc () in
@@ -245,11 +253,13 @@ let test_finalize_multi_block_ordering () =
     ContentBlockDelta { index = 1; delta = TextDelta "answer" };
     MessageDelta { stop_reason = Some EndTurn; usage = None };
   ];
-  let resp = Streaming.finalize_stream_acc acc in
-  Alcotest.(check int) "2 blocks" 2 (List.length resp.content);
-  (match resp.content with
-   | [Thinking _; Text "answer"] -> ()
-   | _ -> Alcotest.fail "expected [Thinking; Text] in order")
+  (match Streaming.finalize_stream_acc acc with
+  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Ok resp ->
+    Alcotest.(check int) "2 blocks" 2 (List.length resp.content);
+    (match resp.content with
+     | [Thinking _; Text "answer"] -> ()
+     | _ -> Alcotest.fail "expected [Thinking; Text] in order"))
 
 let test_finalize_no_usage () =
   let acc = Streaming.create_stream_acc () in
@@ -260,8 +270,10 @@ let test_finalize_no_usage () =
     ContentBlockDelta { index = 0; delta = TextDelta "x" };
     MessageDelta { stop_reason = Some EndTurn; usage = None };
   ];
-  let resp = Streaming.finalize_stream_acc acc in
-  Alcotest.(check bool) "no usage" true (Option.is_none resp.usage)
+  (match Streaming.finalize_stream_acc acc with
+  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Ok resp ->
+    Alcotest.(check bool) "no usage" true (Option.is_none resp.usage))
 
 let test_finalize_unknown_block_type_skipped () =
   let acc = Streaming.create_stream_acc () in
@@ -272,8 +284,10 @@ let test_finalize_unknown_block_type_skipped () =
     ContentBlockDelta { index = 0; delta = TextDelta "data" };
     MessageDelta { stop_reason = Some EndTurn; usage = None };
   ];
-  let resp = Streaming.finalize_stream_acc acc in
-  Alcotest.(check int) "unknown type skipped" 0 (List.length resp.content)
+  (match Streaming.finalize_stream_acc acc with
+  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Ok resp ->
+    Alcotest.(check int) "unknown type skipped" 0 (List.length resp.content))
 
 (* ── map_http_error ───────────────────────────────────────── *)
 

--- a/test/test_streaming_cov.ml
+++ b/test/test_streaming_cov.ml
@@ -11,6 +11,12 @@
 
 open Agent_sdk
 
+(** Unwrap finalize result or fail the test. *)
+let finalize_ok acc =
+  match Streaming.finalize_stream_acc acc with
+  | Ok resp -> resp
+  | Error msg -> Alcotest.fail ("unexpected SSE error: " ^ msg)
+
 (* ── stream_acc creation ──────────────────────────────────── *)
 
 let test_create_stream_acc () =
@@ -157,7 +163,7 @@ let test_finalize_text_only () =
       tool_id = None; tool_name = None });
   Streaming.accumulate_event acc
     (Types.ContentBlockDelta { index = 0; delta = Types.TextDelta "hello" });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   Alcotest.(check string) "id" "m1" resp.id;
   Alcotest.(check string) "model" "model" resp.model;
   Alcotest.(check int) "one content" 1 (List.length resp.content);
@@ -176,7 +182,7 @@ let test_finalize_with_tool_use () =
   Streaming.accumulate_event acc
     (Types.ContentBlockDelta {
       index = 0; delta = Types.InputJsonDelta {|{"path":"/tmp"}|} });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.content with
    | [Types.ToolUse { id; name; _ }] ->
      Alcotest.(check string) "tool id" "tu_1" id;
@@ -193,7 +199,7 @@ let test_finalize_with_thinking () =
       tool_id = None; tool_name = None });
   Streaming.accumulate_event acc
     (Types.ContentBlockDelta { index = 0; delta = Types.ThinkingDelta "I think..." });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.content with
    | [Types.Thinking { content; _ }] ->
      Alcotest.(check string) "thinking" "I think..." content
@@ -214,7 +220,7 @@ let test_finalize_with_usage () =
       usage = Some { input_tokens = 0; output_tokens = 50;
                      cache_creation_input_tokens = 0;
                      cache_read_input_tokens = 0 } });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.usage with
    | Some u ->
      Alcotest.(check int) "input" 100 u.input_tokens;
@@ -223,7 +229,7 @@ let test_finalize_with_usage () =
 
 let test_finalize_no_usage () =
   let acc = Streaming.create_stream_acc () in
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   Alcotest.(check bool) "no usage" true (resp.usage = None)
 
 let test_finalize_unknown_content_type () =
@@ -234,7 +240,7 @@ let test_finalize_unknown_content_type () =
       tool_id = None; tool_name = None });
   Streaming.accumulate_event acc
     (Types.ContentBlockDelta { index = 0; delta = Types.TextDelta "data" });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   Alcotest.(check int) "unknown skipped" 0 (List.length resp.content)
 
 let test_finalize_invalid_tool_json () =
@@ -245,7 +251,7 @@ let test_finalize_invalid_tool_json () =
       tool_id = Some "t1"; tool_name = Some "tool" });
   Streaming.accumulate_event acc
     (Types.ContentBlockDelta { index = 0; delta = Types.InputJsonDelta "not json{" });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (* Invalid JSON falls back to Text *)
   (match resp.content with
    | [Types.Text _] -> ()
@@ -263,7 +269,7 @@ let test_finalize_multiple_blocks () =
       index = 1; content_type = "text"; tool_id = None; tool_name = None });
   Streaming.accumulate_event acc
     (Types.ContentBlockDelta { index = 1; delta = Types.TextDelta "second" });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   Alcotest.(check int) "two blocks" 2 (List.length resp.content)
 
 (* ── Complete module tests ────────────────────────────────── *)

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -13,11 +13,17 @@ let check_string = Alcotest.(check string)
 let check_int = Alcotest.(check int)
 let check_bool = Alcotest.(check bool)
 
+(** Unwrap finalize result or fail the test. *)
+let finalize_ok acc =
+  match Streaming.finalize_stream_acc acc with
+  | Ok resp -> resp
+  | Error msg -> Alcotest.fail ("unexpected SSE error: " ^ msg)
+
 (* ── create_stream_acc + finalize empty ─────────────────────────── *)
 
 let test_empty_acc_finalize () =
   let acc = Streaming.create_stream_acc () in
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   check_string "empty id" "" resp.id;
   check_string "empty model" "" resp.model;
   Alcotest.(check int) "no content" 0 (List.length resp.content);
@@ -34,7 +40,7 @@ let test_acc_message_start_with_usage () =
                      cache_read_input_tokens = 10 } in
   Streaming.accumulate_event acc
     (MessageStart { id = "msg_1"; model = "claude-test"; usage });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   check_string "id" "msg_1" resp.id;
   check_string "model" "claude-test" resp.model;
   (match resp.usage with
@@ -48,7 +54,7 @@ let test_acc_message_start_no_usage () =
   let acc = Streaming.create_stream_acc () in
   Streaming.accumulate_event acc
     (MessageStart { id = "msg_2"; model = "test"; usage = None });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   check_string "id" "msg_2" resp.id;
   (match resp.usage with
    | None -> ()
@@ -65,7 +71,7 @@ let test_acc_content_block_start_text () =
     (ContentBlockDelta { index = 0; delta = TextDelta "hello " });
   Streaming.accumulate_event acc
     (ContentBlockDelta { index = 0; delta = TextDelta "world" });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.content with
    | [Text s] -> check_string "text" "hello world" s
    | _ -> Alcotest.fail "expected single Text block")
@@ -79,7 +85,7 @@ let test_acc_content_block_start_tool_use () =
   Streaming.accumulate_event acc
     (ContentBlockDelta { index = 0;
                          delta = InputJsonDelta {|{"x": 42}|} });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.content with
    | [ToolUse { id; name; input }] ->
      check_string "tool_id" "tu_1" id;
@@ -96,7 +102,7 @@ let test_acc_content_block_start_thinking () =
   Streaming.accumulate_event acc
     (ContentBlockDelta { index = 0;
                          delta = ThinkingDelta "let me think..." });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.content with
    | [Thinking { content; _ }] ->
      check_string "thinking content" "let me think..." content
@@ -112,7 +118,7 @@ let test_acc_delta_creates_buffer_on_missing_index () =
   (* The buffer should be created on demand.
      But without a block_type, finalize won't produce content for it.
      This tests the None branch of Hashtbl.find_opt in accumulate_event. *)
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (* No block_type registered for index 5, so content stays empty *)
   check_int "no content (no block_type)" 0 (List.length resp.content)
 
@@ -122,7 +128,7 @@ let test_acc_message_delta_stop_reason () =
   let acc = Streaming.create_stream_acc () in
   Streaming.accumulate_event acc
     (MessageDelta { stop_reason = Some StopToolUse; usage = None });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.stop_reason with
    | StopToolUse -> ()
    | _ -> Alcotest.fail "expected StopToolUse")
@@ -131,7 +137,7 @@ let test_acc_message_delta_none_stop_reason () =
   let acc = Streaming.create_stream_acc () in
   Streaming.accumulate_event acc
     (MessageDelta { stop_reason = None; usage = None });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (* Default is EndTurn *)
   (match resp.stop_reason with
    | EndTurn -> ()
@@ -144,7 +150,7 @@ let test_acc_message_delta_with_usage () =
                      cache_read_input_tokens = 15 } in
   Streaming.accumulate_event acc
     (MessageDelta { stop_reason = Some EndTurn; usage });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.usage with
    | Some u ->
      check_int "output" 200 u.output_tokens;
@@ -159,7 +165,7 @@ let test_acc_message_delta_with_zero_cache () =
                      cache_read_input_tokens = 0 } in
   Streaming.accumulate_event acc
     (MessageDelta { stop_reason = Some EndTurn; usage });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.usage with
    | Some u ->
      (* Zero cache values should not overwrite prior values *)
@@ -172,7 +178,7 @@ let test_acc_message_delta_none_usage () =
   let acc = Streaming.create_stream_acc () in
   Streaming.accumulate_event acc
     (MessageDelta { stop_reason = Some EndTurn; usage = None });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.usage with
    | None -> ()
    | Some _ -> Alcotest.fail "expected no usage")
@@ -182,26 +188,27 @@ let test_acc_message_delta_none_usage () =
 let test_acc_ignores_ping () =
   let acc = Streaming.create_stream_acc () in
   Streaming.accumulate_event acc Ping;
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   check_string "empty id" "" resp.id;
   check_int "no content" 0 (List.length resp.content)
 
 let test_acc_ignores_message_stop () =
   let acc = Streaming.create_stream_acc () in
   Streaming.accumulate_event acc MessageStop;
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   check_string "empty id" "" resp.id
 
-let test_acc_ignores_sse_error () =
+let test_acc_sse_error_propagated () =
   let acc = Streaming.create_stream_acc () in
   Streaming.accumulate_event acc (SSEError "overloaded");
-  let resp = Streaming.finalize_stream_acc acc in
-  check_string "empty id" "" resp.id
+  (match Streaming.finalize_stream_acc acc with
+   | Error msg -> check_string "error msg" "overloaded" msg
+   | Ok _ -> Alcotest.fail "expected Error from SSEError")
 
 let test_acc_ignores_content_block_stop () =
   let acc = Streaming.create_stream_acc () in
   Streaming.accumulate_event acc (ContentBlockStop { index = 0 });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   check_int "no content" 0 (List.length resp.content)
 
 (* ── finalize: multi-block ordering ─────────────────────────────── *)
@@ -226,7 +233,7 @@ let test_finalize_multi_block_ordered () =
                          tool_id = None; tool_name = None });
   Streaming.accumulate_event acc
     (ContentBlockDelta { index = 1; delta = TextDelta "second" });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   check_int "3 blocks" 3 (List.length resp.content);
   (match resp.content with
    | [Text a; Text b; Text c] ->
@@ -246,7 +253,7 @@ let test_finalize_tool_use_invalid_json () =
   Streaming.accumulate_event acc
     (ContentBlockDelta { index = 0;
                          delta = InputJsonDelta "not valid json{{{" });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (* Invalid JSON in tool_use should fall back to Text *)
   (match resp.content with
    | [Text s] -> check_bool "contains raw text" true
@@ -263,7 +270,7 @@ let test_finalize_tool_use_missing_ids () =
   Streaming.accumulate_event acc
     (ContentBlockDelta { index = 0;
                          delta = InputJsonDelta {|{"ok": true}|} });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.content with
    | [ToolUse { id; name; _ }] ->
      check_string "default tool_id" "" id;
@@ -278,7 +285,7 @@ let test_finalize_text_block_no_delta () =
     (ContentBlockStart { index = 0; content_type = "text";
                          tool_id = None; tool_name = None });
   (* No delta events for this block *)
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.content with
    | [Text s] -> check_string "empty text" "" s
    | _ -> Alcotest.fail "expected empty Text block")
@@ -292,7 +299,7 @@ let test_finalize_unknown_content_type () =
                          tool_id = None; tool_name = None });
   Streaming.accumulate_event acc
     (ContentBlockDelta { index = 0; delta = TextDelta "ignored" });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   check_int "unknown type skipped" 0 (List.length resp.content)
 
 (* ── finalize: usage thresholds ─────────────────────────────────── *)
@@ -300,7 +307,7 @@ let test_finalize_unknown_content_type () =
 let test_finalize_usage_all_zero () =
   let acc = Streaming.create_stream_acc () in
   (* No usage-carrying events -> usage should be None *)
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.usage with
    | None -> ()
    | Some _ -> Alcotest.fail "expected None usage when all zero")
@@ -312,7 +319,7 @@ let test_finalize_usage_only_cache_creation () =
                      cache_read_input_tokens = 0 } in
   Streaming.accumulate_event acc
     (MessageStart { id = "m"; model = "m"; usage });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.usage with
    | Some u -> check_int "cache_creation" 50 u.cache_creation_input_tokens
    | None -> Alcotest.fail "expected usage with cache_creation only")
@@ -324,7 +331,7 @@ let test_finalize_usage_only_cache_read () =
                      cache_read_input_tokens = 20 } in
   Streaming.accumulate_event acc
     (MessageStart { id = "m"; model = "m"; usage });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.usage with
    | Some u -> check_int "cache_read" 20 u.cache_read_input_tokens
    | None -> Alcotest.fail "expected usage with cache_read only")
@@ -354,7 +361,7 @@ let test_full_anthropic_sequence () =
     MessageStop;
   ] in
   List.iter (Streaming.accumulate_event acc) events;
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   check_string "id" "msg_full" resp.id;
   check_string "model" "claude-sonnet-4" resp.model;
   check_int "2 content blocks" 2 (List.length resp.content);
@@ -398,7 +405,7 @@ let test_full_tool_use_sequence () =
     MessageStop;
   ] in
   List.iter (Streaming.accumulate_event acc) events;
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   check_int "2 blocks" 2 (List.length resp.content);
   (match resp.content with
    | [Text t; ToolUse { name; input; _ }] ->
@@ -463,7 +470,7 @@ let test_acc_message_delta_cache_update_nonzero () =
                     usage = Some { input_tokens = 0; output_tokens = 100;
                                    cache_creation_input_tokens = 20;
                                    cache_read_input_tokens = 15 } });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.usage with
    | Some u ->
      check_int "input" 50 u.input_tokens;
@@ -480,7 +487,7 @@ let test_acc_multiple_message_deltas () =
     (MessageDelta { stop_reason = Some MaxTokens; usage = None });
   Streaming.accumulate_event acc
     (MessageDelta { stop_reason = Some EndTurn; usage = None });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.stop_reason with
    | EndTurn -> ()
    | _ -> Alcotest.fail "expected last stop_reason to win (EndTurn)")
@@ -495,7 +502,7 @@ let test_acc_partial_tool_metadata () =
   Streaming.accumulate_event acc
     (ContentBlockDelta { index = 0;
                          delta = InputJsonDelta {|{}|} });
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.content with
    | [ToolUse { id; name; _ }] ->
      check_string "default id" "" id;
@@ -510,7 +517,7 @@ let test_finalize_thinking_empty_content () =
     (ContentBlockStart { index = 0; content_type = "thinking";
                          tool_id = None; tool_name = None });
   (* No delta -> empty thinking *)
-  let resp = Streaming.finalize_stream_acc acc in
+  let resp = finalize_ok acc in
   (match resp.content with
    | [Thinking { content; _ }] ->
      check_string "empty thinking" "" content
@@ -555,8 +562,8 @@ let () =
       Alcotest.test_case "ignores Ping" `Quick test_acc_ignores_ping;
       Alcotest.test_case "ignores MessageStop" `Quick
         test_acc_ignores_message_stop;
-      Alcotest.test_case "ignores SSEError" `Quick
-        test_acc_ignores_sse_error;
+      Alcotest.test_case "SSEError propagated" `Quick
+        test_acc_sse_error_propagated;
       Alcotest.test_case "ignores ContentBlockStop" `Quick
         test_acc_ignores_content_block_stop;
     ];


### PR DESCRIPTION
## Summary
- Changed `finalize_stream_acc` return type from `Types.api_response` to `(Types.api_response, string) result` in both `complete_stream_acc.ml` and `streaming.ml`
- When `sse_error` is set (e.g. mid-stream Anthropic 500), `finalize_stream_acc` now returns `Error msg` instead of silently returning partial content as `Ok`
- Updated all 3 call sites (`complete.ml`, `streaming.ml` x2) and all test files to handle the new result type

## Test plan
- [x] `dune build --root .` passes
- [x] `dune runtest --root . --force` passes (all streaming/accumulator tests green)
- [x] New inline test: `finalize_stream_acc returns Error when sse_error is set`
- [x] Updated `test_acc_ignores_sse_error` -> `test_acc_sse_error_propagated` to verify Error propagation

Closes #331

Generated with [Claude Code](https://claude.com/claude-code)