### PR TITLE
fix(agent_tools): filter non-ToolUse blocks before execution (#327)

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -85,14 +85,20 @@ let find_and_execute_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tra
 
 (** Execute tools in parallel using Eio fibers.
     Applies PreToolUse/PostToolUse hooks and passes context to context-aware handlers.
-    Each fiber catches exceptions to prevent one tool failure from canceling siblings. *)
+    Each fiber catches exceptions to prevent one tool failure from canceling siblings.
+    Non-ToolUse blocks are filtered out before execution. *)
 let execute_tools ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tracer
     ~agent_name ~turn_count ~(usage : Types.usage_stats) ~approval
     ?on_tool_execution_started
     ?on_tool_execution_finished ?on_hook_invoked tool_uses =
-  Eio.Fiber.List.map (fun block ->
+  (* Filter to ToolUse blocks only — prevents bogus result triples for
+     Text/Thinking/etc. blocks that may be present in the input list. *)
+  let tool_use_blocks = List.filter_map (fun block ->
     match block with
-    | ToolUse { id; name; input } ->
+    | ToolUse { id; name; input } -> Some (id, name, input)
+    | _ -> None
+  ) tool_uses in
+  Eio.Fiber.List.map (fun (id, name, input) ->
         (match on_tool_execution_started with
          | Some callback -> callback ~tool_use_id:id ~tool_name:name ~input
          | None -> ());
@@ -159,8 +165,4 @@ let execute_tools ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tracer
              callback ~tool_use_id:id ~tool_name:name ~content ~is_error
          | None -> ());
         triple
-    | _ ->
-        (* Non-ToolUse blocks (Text, Thinking, etc.) are not tool calls.
-           Skip them instead of returning a bogus error triple. *)
-        ("", "", false)
-  ) tool_uses
+  ) tool_use_blocks

--- a/lib/agent/agent_tools.mli
+++ b/lib/agent/agent_tools.mli
@@ -44,6 +44,9 @@ val find_and_execute_tool :
 
 (** Execute tool-use content blocks in parallel using Eio fibers.
 
+    Non-[ToolUse] blocks in the input list are filtered out before
+    execution — only [ToolUse] blocks produce result triples.
+
     For each [ToolUse] block, applies the [PreToolUse] hook before execution.
     Supports approval flow: if the hook returns [ApprovalRequired], the
     [approval] callback is invoked.
@@ -52,8 +55,8 @@ val find_and_execute_tool :
     canceling siblings (except [Out_of_memory], [Stack_overflow],
     [Sys.Break]).
 
-    Returns [(tool_use_id, content, is_error)] triples in the same order
-    as the input. *)
+    Returns [(tool_use_id, content, is_error)] triples, one per [ToolUse]
+    block, in the same relative order as the input. *)
 val execute_tools :
   context:Context.t ->
   tools:Tool.t list ->

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -225,9 +225,10 @@ let update_idle_detection ~idle_state ~tool_uses =
     is_idle = idle;
   }
 
-(** Process tool results into ToolResult content blocks. *)
+(** Process tool results into ToolResult content blocks.
+    All entries are valid ToolUse results — non-ToolUse blocks are filtered
+    upstream in {!Agent_tools.execute_tools}. *)
 let make_tool_results results =
-  List.filter_map (fun (tool_use_id, content, is_error) ->
-    if tool_use_id = "" then None  (* skip non-ToolUse block sentinels *)
-    else Some (ToolResult { tool_use_id; content; is_error })
+  List.map (fun (tool_use_id, content, is_error) ->
+    ToolResult { tool_use_id; content; is_error }
   ) results

--- a/test/test_approval.ml
+++ b/test/test_approval.ml
@@ -137,6 +137,34 @@ let test_skip_override_unaffected () =
     check bool "override not error" false err2
   | _ -> fail "expected exactly two results")
 
+let test_non_tool_use_blocks_filtered () =
+  (* Non-ToolUse blocks (Text, Thinking) must be filtered out, not produce
+     bogus ("", "", false) triples. Regression test for issue #327. *)
+  let hooks = Hooks.empty in
+  let results = run_execute ~hooks [
+    Text "some assistant text";
+    ToolUse { id = "t1"; name = "safe"; input = `String "data" };
+    Thinking { thinking_type = "thinking"; content = "reasoning" };
+    ToolUse { id = "t2"; name = "safe"; input = `String "more" };
+  ] in
+  (* Only the 2 ToolUse blocks should produce results *)
+  check int "result count" 2 (List.length results);
+  let sorted = List.sort (fun (a, _, _) (b, _, _) -> String.compare a b) results in
+  (match sorted with
+  | [(id1, _, _); (id2, _, _)] ->
+    check string "first id" "t1" id1;
+    check string "second id" "t2" id2
+  | _ -> fail "expected exactly two results")
+
+let test_only_non_tool_use_blocks () =
+  (* When all blocks are non-ToolUse, result should be empty *)
+  let hooks = Hooks.empty in
+  let results = run_execute ~hooks [
+    Text "just text";
+    Thinking { thinking_type = "thinking"; content = "thoughts" };
+  ] in
+  check int "empty results" 0 (List.length results)
+
 let () =
   run "Approval" [
     "approval_required", [
@@ -146,5 +174,9 @@ let () =
       test_case "Edit modifies input" `Quick test_approval_edit;
       test_case "selective by tool name" `Quick test_selective_approval;
       test_case "Skip/Override unaffected" `Quick test_skip_override_unaffected;
+    ];
+    "non_tool_use_filtering", [
+      test_case "mixed blocks filtered (#327)" `Quick test_non_tool_use_blocks_filtered;
+      test_case "only non-ToolUse = empty" `Quick test_only_non_tool_use_blocks;
     ];
   ]


### PR DESCRIPTION
## Summary

- Pre-filter `content_block list` input to extract only `ToolUse` blocks before `Eio.Fiber.List.map` in `execute_tools`
- Remove the catch-all `| _ -> ("", "", false)` branch that produced bogus result triples for Text/Thinking/etc. blocks
- Remove the sentinel filter (`tool_use_id = ""`) in `make_tool_results` since only valid triples are produced
- Add 2 regression tests: mixed blocks and all-non-ToolUse input

Closes #327

## Test plan

- [x] `dune build --root .` compiles
- [x] All 8 approval tests pass (6 existing + 2 new)
- [x] All 33 agent_turn tests pass
- [x] All 48 pipeline tests pass
- [x] Full `dune runtest --root .` passes

Generated with [Claude Code](https://claude.com/claude-code)