### PR TITLE
fix(cascade): remove is_retryable guard from clockless fallback path (#326)

### DIFF
--- a/lib/api.ml
+++ b/lib/api.ml
@@ -136,7 +136,7 @@ let create_message ~sw ~net ?(base_url=default_base_url) ?provider ?clock ?retry
        | Error err -> Error (Error.Api err))
 
 (** Send a message with cascade failover across providers.
-    Tries primary provider first (with retries); on retryable failure,
+    Tries primary provider first (with retries); on any failure,
     tries each fallback provider in order. *)
 let create_message_cascade ~sw ~net ?clock ?retry_config
     ~cascade:(casc : Provider.cascade) ~config ~messages ?tools () =
@@ -159,26 +159,19 @@ let create_message_cascade ~sw ~net ?clock ?retry_config
      | Error err -> Error (Error.Api err))
   | None ->
     (* Without a clock, retries are disabled but we still try fallbacks
-       sequentially on retryable errors. *)
-    let rec try_providers = function
-      | [] -> fun last_err -> Error (Error.Api last_err)
+       sequentially on any error.  A non-retryable error on provider A
+       (e.g. AuthError) should still attempt provider B — the key may be
+       valid there.  Matches Retry.with_cascade semantics (PR #336). *)
+    let rec try_providers primary_err = function
+      | [] -> Error (Error.Api primary_err)
       | provider :: rest ->
-        fun _prev_err ->
           match make_f provider () with
           | Ok _ as success -> success
-          | Error err ->
-            if Retry.is_retryable err then
-              (try_providers rest) err
-            else
-              Error (Error.Api err)
+          | Error _err -> try_providers primary_err rest
     in
     (match make_f casc.primary () with
      | Ok _ as success -> success
-     | Error err ->
-       if Retry.is_retryable err && casc.fallbacks <> [] then
-         (try_providers casc.fallbacks) err
-       else
-         Error (Error.Api err))
+     | Error err -> try_providers err casc.fallbacks)
 
 let create_message_named ~sw ~net ?clock ~(named_cascade : named_cascade)
     ~config ~messages ?tools ?(temperature = 0.3)

--- a/test/test_bug_hunt.ml
+++ b/test/test_bug_hunt.ml
@@ -45,8 +45,10 @@ let test_b1_injector_exception_caught () =
   ()
 
 (* ── B2: cascade fallback with clock=None — FIXED ────────────── *)
-(* Before fix: clock=None → only primary tried, fallbacks ignored.
-   After fix: fallbacks are tried sequentially on retryable errors. *)
+(* Before fix: clock=None → non-retryable errors (AuthError, InvalidRequest)
+   stopped the cascade, skipping fallback providers.
+   After fix (issue #326): fallbacks are tried on any error, matching
+   Retry.with_cascade semantics from PR #336. *)
 
 let test_b2_cascade_fallback_structure () =
   let primary_cfg : Provider.config = {
@@ -63,8 +65,8 @@ let test_b2_cascade_fallback_structure () =
   check bool "cascade has fallback" true (List.length casc.fallbacks > 0);
   check string "primary is fake" "fake-primary" casc.primary.model_id;
   check string "fallback is fake" "fake-fallback" (List.hd casc.fallbacks).model_id;
-  (* Fix verified: api.ml clock=None branch now contains try_providers
-     recursive function that iterates fallbacks on retryable errors. *)
+  (* Fix verified: api.ml clock=None branch's try_providers no longer
+     checks is_retryable — all errors cascade to the next provider. *)
   ()
 
 (* ── B3: injection role alternation — FIXED ───────────────────── *)

--- a/test/test_cascade.ml
+++ b/test/test_cascade.ml
@@ -96,6 +96,27 @@ let test_cascade_all_fail_returns_primary_error () =
       check string "primary error preserved" "bad key" message
   | Error _ -> fail "expected primary AuthError"
 
+let test_cascade_invalid_request_tries_all_fallbacks () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let call_log = ref [] in
+  let make_provider name result () =
+    call_log := name :: !call_log;
+    result
+  in
+  let primary = make_provider "primary"
+    (Error (Retry.InvalidRequest { message = "bad param" })) in
+  let fb1 = make_provider "fb1"
+    (Error (Retry.AuthError { message = "no key" })) in
+  let fb2 = make_provider "fb2" (Ok "fb2_result") in
+  let config = { Retry.max_retries = 0; initial_delay = 0.01; max_delay = 0.1; backoff_factor = 2.0 } in
+  match Retry.with_cascade ~clock ~config ~primary ~fallbacks:[fb1; fb2] () with
+  | Ok v ->
+    check string "reached fb2" "fb2_result" v;
+    (* All three providers were attempted *)
+    check int "all providers called" 3 (List.length !call_log)
+  | Error _ -> fail "expected fb2 to succeed"
+
 (* ── Builder cascade tests ───────────────────────────────────── *)
 
 let test_builder_with_fallback () =
@@ -137,6 +158,7 @@ let () =
       test_case "falls through to fallback" `Quick test_cascade_retry_falls_through;
       test_case "non-retryable tries fallback" `Quick test_cascade_non_retryable_tries_fallback;
       test_case "all fail returns primary error" `Quick test_cascade_all_fail_returns_primary_error;
+      test_case "InvalidRequest cascades through all fallbacks" `Quick test_cascade_invalid_request_tries_all_fallbacks;
     ];
     "builder", [
       test_case "with_fallback" `Quick test_builder_with_fallback;


### PR DESCRIPTION
## Summary

- `api.ml` `create_message_cascade`의 clock=None 경로에서 `is_retryable` guard가 남아있어 `AuthError`/`InvalidRequest` 시 fallback provider를 시도하지 않는 버그 수정
- PR #336에서 `Retry.with_cascade`는 수정되었으나, `api.ml`의 clockless fallback 경로에 동일 버그가 잔존
- `try_providers` 재귀 함수를 단순화하여 모든 에러에서 다음 provider로 cascade

## Changes

| File | Change |
|------|--------|
| `lib/api.ml` | Remove `is_retryable` guard from clockless cascade path, simplify `try_providers` |
| `test/test_cascade.ml` | Add `InvalidRequest cascades through all fallbacks` test |
| `test/test_bug_hunt.ml` | Update B2 test comment to reflect non-retryable cascade fix |

## Test plan

- [x] `dune exec test/test_cascade.exe` -- 14 tests pass (including new test)
- [x] `dune exec test/test_bug_hunt.exe` -- 7 tests pass
- [x] `dune runtest --root .` -- full suite passes (exit 0)

Closes #326

Generated with [Claude Code](https://claude.com/claude-code)