### PR TITLE
fix(agent): add idle/budget guard to run_with_handoffs

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -38,6 +38,24 @@ let run_turn_with_trace ~sw ?clock ?raw_trace_run agent =
 
 let check_token_budget = Agent_turn.check_token_budget
 
+(* ── Shared loop guard (max_turns + idle + budget) ─────────── *)
+
+(** Check max_turns, idle detection, and token/cost budget.
+    Returns [Some error] when any guard fires, [None] to proceed. *)
+let check_loop_guard agent =
+  if agent.state.turn_count >= agent.state.config.max_turns then
+    Some (Error.Agent (Error.MaxTurnsExceeded {
+      turns = agent.state.turn_count;
+      limit = agent.state.config.max_turns }))
+  else if agent.consecutive_idle_turns >= agent.options.max_idle_turns
+          && agent.options.max_idle_turns > 0 then
+    Some (Error.Agent (Error.IdleDetected {
+      consecutive_idle_turns = agent.consecutive_idle_turns }))
+  else
+    match check_token_budget agent.state.config agent.state.usage with
+    | Some _ as err -> err
+    | None -> Cost_tracker.check_budget agent.state.config agent.state.usage
+
 (* ── Unified run loop ────────────────────────────────────────── *)
 
 (** Prepend initial_messages on first run (when messages are empty). *)
@@ -52,27 +70,13 @@ let run_loop ~sw ?clock ~api_strategy agent user_prompt =
     messages = Util.snoc (base_messages agent) user_msg };
   with_raw_trace_run agent user_prompt @@ fun raw_trace_run ->
   let rec loop () =
-    if agent.state.turn_count >= agent.state.config.max_turns then
-      Error (Error.Agent (MaxTurnsExceeded {
-        turns = agent.state.turn_count;
-        limit = agent.state.config.max_turns }))
-    else if agent.consecutive_idle_turns >= agent.options.max_idle_turns
-            && agent.options.max_idle_turns > 0 then
-      Error (Error.Agent (IdleDetected {
-        consecutive_idle_turns = agent.consecutive_idle_turns }))
-    else
-      let budget_err =
-        match check_token_budget agent.state.config agent.state.usage with
-        | Some _ as err -> err
-        | None -> Cost_tracker.check_budget agent.state.config agent.state.usage
-      in
-      match budget_err with
-      | Some err -> Error err
-      | None ->
-        match run_turn_core ~sw ?clock ~api_strategy ?raw_trace_run agent with
-        | Error e -> Error e
-        | Ok `Complete response -> Ok response
-        | Ok `ToolsExecuted -> loop ()
+    match check_loop_guard agent with
+    | Some err -> Error err
+    | None ->
+      match run_turn_core ~sw ?clock ~api_strategy ?raw_trace_run agent with
+      | Error e -> Error e
+      | Ok `Complete response -> Ok response
+      | Ok `ToolsExecuted -> loop ()
   in
   loop ()
 
@@ -127,12 +131,9 @@ let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
 
   with_raw_trace_run agent_with_handoffs user_prompt @@ fun raw_trace_run ->
   let rec loop () =
-    if agent_with_handoffs.state.turn_count >=
-       agent_with_handoffs.state.config.max_turns then
-      Error (Error.Agent (MaxTurnsExceeded {
-        turns = agent.state.turn_count;
-        limit = agent.state.config.max_turns }))
-    else
+    match check_loop_guard agent_with_handoffs with
+    | Some err -> Error err
+    | None ->
       match run_turn_with_trace ~sw ?clock ?raw_trace_run
               agent_with_handoffs with
       | Error e -> Error e

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -140,4 +140,6 @@ val lifecycle_snapshot : t -> lifecycle_snapshot option
 (** {1 Internal (testing only -- do not use in production code)} *)
 
 val set_state : t -> Types.agent_state -> unit
+val set_consecutive_idle_turns : t -> int -> unit
 val base_messages : t -> Types.message list
+val check_loop_guard : t -> Error.sdk_error option

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -101,6 +101,7 @@ let context t = t.context
 let options t = t.options
 let net t = t.net
 let set_state t s = t.state <- s
+let set_consecutive_idle_turns t n = t.consecutive_idle_turns <- n
 let description t = t.options.description
 let memory t = t.options.memory
 

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -93,6 +93,7 @@ val context : t -> Context.t
 val options : t -> options
 val net : t -> [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
 val set_state : t -> Types.agent_state -> unit
+val set_consecutive_idle_turns : t -> int -> unit
 val description : t -> string option
 val memory : t -> Memory.t option
 

--- a/test/test_handoff.ml
+++ b/test/test_handoff.ml
@@ -185,6 +185,65 @@ let test_run_with_handoffs_reports_unknown_target () =
           fail (Error.to_string e)
   with Exit -> ()
 
+(* ── check_loop_guard unit tests ──────────────────────────────── *)
+
+let make_agent_for_guard () =
+  Eio_main.run @@ fun env ->
+  Agent.create ~net:env#net ()
+
+let test_guard_none_when_fresh () =
+  let agent = make_agent_for_guard () in
+  check (option reject) "no guard fires on fresh agent" None
+    (Agent.check_loop_guard agent)
+
+let test_guard_max_turns () =
+  let agent = make_agent_for_guard () in
+  let st = Agent.state agent in
+  Agent.set_state agent { st with turn_count = st.config.max_turns };
+  match Agent.check_loop_guard agent with
+  | Some (Error.Agent (Error.MaxTurnsExceeded _)) -> ()
+  | _ -> fail "expected MaxTurnsExceeded"
+
+let test_guard_idle_detected () =
+  let agent = make_agent_for_guard () in
+  let max_idle = (Agent.options agent).max_idle_turns in
+  Agent.set_consecutive_idle_turns agent max_idle;
+  match Agent.check_loop_guard agent with
+  | Some (Error.Agent (Error.IdleDetected r)) ->
+    check int "idle turns" max_idle r.consecutive_idle_turns
+  | _ -> fail "expected IdleDetected"
+
+let test_guard_idle_disabled () =
+  (* max_idle_turns = 0 disables the idle guard *)
+  Eio_main.run @@ fun env ->
+  let options = { Agent.default_options with max_idle_turns = 0 } in
+  let agent = Agent.create ~net:env#net ~options () in
+  Agent.set_consecutive_idle_turns agent 999;
+  check (option reject) "idle guard disabled" None
+    (Agent.check_loop_guard agent)
+
+let test_guard_token_budget () =
+  Eio_main.run @@ fun env ->
+  let config = { Types.default_config with max_total_tokens = Some 100 } in
+  let agent = Agent.create ~net:env#net ~config () in
+  let st = Agent.state agent in
+  Agent.set_state agent { st with usage =
+    { st.usage with total_input_tokens = 50; total_output_tokens = 60 } };
+  match Agent.check_loop_guard agent with
+  | Some (Error.Agent (Error.TokenBudgetExceeded _)) -> ()
+  | _ -> fail "expected TokenBudgetExceeded"
+
+let test_guard_cost_budget () =
+  Eio_main.run @@ fun env ->
+  let config = { Types.default_config with max_cost_usd = Some 1.0 } in
+  let agent = Agent.create ~net:env#net ~config () in
+  let st = Agent.state agent in
+  Agent.set_state agent { st with usage =
+    { st.usage with estimated_cost_usd = 1.5 } };
+  match Agent.check_loop_guard agent with
+  | Some (Error.Agent (Error.CostBudgetExceeded _)) -> ()
+  | _ -> fail "expected CostBudgetExceeded"
+
 let () =
   (* Mock server tests need a key in env but don't use it *)
   if Sys.getenv_opt "ANTHROPIC_API_KEY" = None then
@@ -208,5 +267,13 @@ let () =
         test_run_with_handoffs_intercepts_tool_use;
       test_case "reports unknown target" `Quick
         test_run_with_handoffs_reports_unknown_target;
+    ];
+    "loop_guard", [
+      test_case "none on fresh agent" `Quick test_guard_none_when_fresh;
+      test_case "max_turns fires" `Quick test_guard_max_turns;
+      test_case "idle detected fires" `Quick test_guard_idle_detected;
+      test_case "idle disabled when 0" `Quick test_guard_idle_disabled;
+      test_case "token budget fires" `Quick test_guard_token_budget;
+      test_case "cost budget fires" `Quick test_guard_cost_budget;
     ];
   ]


### PR DESCRIPTION
## Summary
- `run_with_handoffs` was missing idle detection and token/cost budget guards that `run_loop` had, allowing infinite loops on handoff failure
- Extracted `check_loop_guard` shared function to DRY the max_turns + idle + budget checks between both loops
- Fixed minor bug where `MaxTurnsExceeded` error in `run_with_handoffs` referenced `agent.state` instead of `agent_with_handoffs.state`

Closes #329

## Test plan
- [x] 6 new `check_loop_guard` unit tests (fresh/max_turns/idle/idle_disabled/token_budget/cost_budget)
- [x] All 17 handoff tests pass
- [x] Full `dune runtest` passes (0 failures)

Generated with [Claude Code](https://claude.com/claude-code)