### PR TITLE
fix(async_agent): cancel fiber before resolving future

### DIFF
--- a/lib/async_agent.ml
+++ b/lib/async_agent.ml
@@ -64,10 +64,14 @@ let is_ready future =
 (* ── Cancellation ─────────────────────────────────────────────── *)
 
 let cancel future =
-  resolve_once future (Error (Error.Internal "cancelled"));
-  match future.cancel_fn with
-  | Some f -> (try f () with Eio.Io _ | Unix.Unix_error _ | Failure _ -> ())
-  | None -> ()
+  (* Stop the fiber first, then resolve the future.
+     cancel_fn fails the sub-switch, which causes the fiber to exit
+     with Cancelled.  The fiber's own handler calls resolve_once,
+     but we call it again as a fallback (idempotent). *)
+  (match future.cancel_fn with
+   | Some f -> (try f () with Eio.Io _ | Unix.Unix_error _ | Failure _ -> ())
+   | None -> ());
+  resolve_once future (Error (Error.Internal "cancelled"))
 
 (* ── Combinators ──────────────────────────────────────────────── *)
 

--- a/lib/async_agent.mli
+++ b/lib/async_agent.mli
@@ -40,9 +40,12 @@ val is_ready : 'a future -> bool
 (** {1 Cancellation} *)
 
 (** [cancel future] terminates the agent's execution by:
-    1. Resolving the promise with [Error (Internal "cancelled")]
-    2. Failing the agent's sub-switch, cancelling all in-flight I/O
+    1. Failing the agent's sub-switch, cancelling all in-flight I/O
+    2. Resolving the promise with [Error (Internal "cancelled")] (fallback)
 
+    The fiber is stopped before the future is resolved so that callers
+    observing [is_ready] = [true] can rely on the fiber having received
+    the cancellation signal.
     If the agent has already completed, this is a no-op. *)
 val cancel : 'a future -> unit
 

--- a/test/test_async_agent.ml
+++ b/test/test_async_agent.ml
@@ -110,6 +110,38 @@ let test_cancel () =
      | Error e -> fail (Printf.sprintf "wrong error: %s" (Error.to_string e)))
   with Exit -> ()
 
+(* ── cancel fires cancel_fn before resolving future ──────────────── *)
+
+let test_cancel_fiber_stops_before_resolve () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  try
+    Eio.Switch.run @@ fun sw ->
+    (* Slow server: 5s delay — ensures the fiber is blocked in I/O *)
+    let url =
+      start_mock ~sw ~net:env#net ~clock ~port:18020
+        ~delay_sec:5.0 "slow-cancel"
+    in
+    let agent = make_agent ~net:env#net url "cancel-order-agent" in
+    let future = Async_agent.spawn ~sw ~clock agent "test" in
+    (* Give the fiber time to start and set cancel_fn *)
+    Eio.Time.sleep clock 0.05;
+    (* Cancel: must fire cancel_fn before resolving future.
+       After cancel returns, the fiber should have received the
+       cancellation signal. We verify by yielding once and
+       checking that await returns the cancel error. *)
+    Async_agent.cancel future;
+    Eio.Fiber.yield ();
+    check bool "ready after cancel" true (Async_agent.is_ready future);
+    (match Async_agent.await future with
+     | Ok _ -> fail "expected cancelled error"
+     | Error (Error.Internal msg) ->
+       check string "cancel message" "cancelled" msg;
+       Eio.Switch.fail sw Exit
+     | Error e ->
+       fail (Printf.sprintf "wrong error: %s" (Error.to_string e)))
+  with Exit -> ()
+
 (* ── race (first wins) ────────────────────────────────────────────── *)
 
 let test_race_first_wins () =
@@ -239,6 +271,8 @@ let () =
       test_case "spawn_and_await" `Quick test_spawn_and_await;
       test_case "is_ready" `Quick test_is_ready;
       test_case "cancel" `Quick test_cancel;
+      test_case "cancel_fiber_stops_before_resolve" `Quick
+        test_cancel_fiber_stops_before_resolve;
     ];
     "race", [
       test_case "first_wins" `Quick test_race_first_wins;


### PR DESCRIPTION
## Summary

- `Async_agent.cancel` previously resolved the promise **before** firing `cancel_fn`, allowing callers to observe `is_ready = true` while the fiber was still running
- Swapped the order: fail the sub-switch first (`cancel_fn`), then resolve the future as an idempotent fallback
- Updated `.mli` docstring to reflect the corrected cancellation order
- Added `cancel_fiber_stops_before_resolve` test that spawns a slow agent, waits for the fiber to start, cancels, and verifies readiness after yield

Fixes #330

## Test plan

- [x] `dune exec test/test_async_agent.exe` — 9/9 pass (including new test)
- [x] `dune build` — clean compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)