### PR TITLE
fix(agent): protect Agent.t mutable fields with Eio.Mutex (#324)

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -66,8 +66,8 @@ let base_messages agent =
 
 let run_loop ~sw ?clock ~api_strategy agent user_prompt =
   let user_msg = { role = User; content = [Text user_prompt]; name = None; tool_call_id = None } in
-  agent.state <- { agent.state with
-    messages = Util.snoc (base_messages agent) user_msg };
+  update_state agent (fun s ->
+    { s with messages = Util.snoc (base_messages agent) user_msg });
   with_raw_trace_run agent user_prompt @@ fun raw_trace_run ->
   let rec loop () =
     match check_loop_guard agent with
@@ -126,8 +126,8 @@ let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
   let agent_with_handoffs = { agent with tools = all_tools } in
 
   let user_msg = { role = User; content = [Text user_prompt]; name = None; tool_call_id = None } in
-  agent_with_handoffs.state <- { agent_with_handoffs.state with
-    messages = Util.snoc (base_messages agent_with_handoffs) user_msg };
+  update_state agent_with_handoffs (fun s ->
+    { s with messages = Util.snoc (base_messages agent_with_handoffs) user_msg });
 
   with_raw_trace_run agent_with_handoffs user_prompt @@ fun raw_trace_run ->
   let rec loop () =
@@ -149,12 +149,10 @@ let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
             | None ->
               let err_msg = Printf.sprintf
                 "Unknown handoff target: %s" target_name in
-              agent_with_handoffs.state <-
-                { agent_with_handoffs.state with
-                  messages =
-                    replace_tool_result
-                      agent_with_handoffs.state.messages
-                      ~tool_id ~content:err_msg ~is_error:true };
+              update_state agent_with_handoffs (fun s ->
+                { s with messages =
+                    replace_tool_result s.messages
+                      ~tool_id ~content:err_msg ~is_error:true });
               loop ()
             | Some target ->
               let sub = create ~net:agent.net ~config:target.config
@@ -166,12 +164,10 @@ let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
                  let err_msg = Printf.sprintf
                    "Handoff to %s failed: %s"
                    target_name (Error.to_string e) in
-                 agent_with_handoffs.state <-
-                   { agent_with_handoffs.state with
-                     messages =
-                       replace_tool_result
-                         agent_with_handoffs.state.messages
-                         ~tool_id ~content:err_msg ~is_error:true };
+                 update_state agent_with_handoffs (fun s ->
+                   { s with messages =
+                       replace_tool_result s.messages
+                         ~tool_id ~content:err_msg ~is_error:true });
                  loop ()
                | Ok sub_response ->
                  let text = List.fold_left (fun acc block ->
@@ -180,12 +176,10 @@ let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
                      if acc = "" then s else acc ^ "\n" ^ s
                    | _ -> acc
                  ) "" sub_response.content in
-                 agent_with_handoffs.state <-
-                   { agent_with_handoffs.state with
-                     messages =
-                       replace_tool_result
-                         agent_with_handoffs.state.messages
-                         ~tool_id ~content:text ~is_error:false };
+                 update_state agent_with_handoffs (fun s ->
+                   { s with messages =
+                       replace_tool_result s.messages
+                         ~tool_id ~content:text ~is_error:false });
                  loop ()))
          | None -> loop ())
   in
@@ -198,7 +192,8 @@ let resume ~net ~(checkpoint : Checkpoint.t) ?(tools=[]) ?context
   let { Agent_checkpoint.state; context = ctx } =
     Agent_checkpoint.build_resume ~checkpoint ?config ?context ()
   in
-  { state; lifecycle = None; last_tool_calls = None;
+  { mu = Eio.Mutex.create ();
+    state; lifecycle = None; last_tool_calls = None;
     consecutive_idle_turns = 0; named_cascade;
     tools = Tool_set.of_list tools; net; context = ctx; options }
 

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -140,6 +140,20 @@ val lifecycle_snapshot : t -> lifecycle_snapshot option
 (** {1 Internal (testing only -- do not use in production code)} *)
 
 val set_state : t -> Types.agent_state -> unit
+val update_state : t -> (Types.agent_state -> Types.agent_state) -> unit
 val set_consecutive_idle_turns : t -> int -> unit
+val set_lifecycle :
+  t ->
+  ?current_run_id:string ->
+  ?worker_id:string ->
+  ?runtime_actor:string ->
+  ?last_error:string ->
+  ?accepted_at:float ->
+  ?ready_at:float ->
+  ?first_progress_at:float ->
+  ?started_at:float ->
+  ?last_progress_at:float ->
+  ?finished_at:float ->
+  Agent_lifecycle.lifecycle_status -> unit
 val base_messages : t -> Types.message list
 val check_loop_guard : t -> Error.sdk_error option

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -82,6 +82,7 @@ let default_options = {
 type tool_call_fingerprint = Agent_turn.tool_call_fingerprint
 
 type t = {
+  mu: Eio.Mutex.t;
   mutable state: agent_state;
   mutable lifecycle: lifecycle_snapshot option;
   mutable last_tool_calls: tool_call_fingerprint list option;
@@ -100,8 +101,24 @@ let tools t = t.tools
 let context t = t.context
 let options t = t.options
 let net t = t.net
-let set_state t s = t.state <- s
-let set_consecutive_idle_turns t n = t.consecutive_idle_turns <- n
+
+(** Mutex-protected write to [state].  All mutations of [t.state] should
+    go through this function to prevent lost-update races when parallel
+    tool-execution fibers or periodic callbacks yield between read and
+    write. *)
+let set_state t s =
+  Eio.Mutex.use_rw ~protect:false t.mu (fun () -> t.state <- s)
+
+(** Read-modify-write [state] under the mutex.  Callers pass a pure
+    function [f : agent_state -> agent_state]; the read + write happen
+    inside a single critical section so no concurrent update is lost. *)
+let update_state t f =
+  Eio.Mutex.use_rw ~protect:false t.mu (fun () -> t.state <- f t.state)
+
+let set_consecutive_idle_turns t n =
+  Eio.Mutex.use_rw ~protect:false t.mu (fun () ->
+    t.consecutive_idle_turns <- n)
+
 let description t = t.options.description
 let memory t = t.options.memory
 
@@ -121,17 +138,23 @@ let card t =
     skill_registry = t.options.skill_registry;
   }
 
+(** Mutex-protected lifecycle update.  Multiple parallel tool-execution
+    fibers call this concurrently via [on_tool_execution_started] /
+    [on_tool_execution_finished] callbacks.  Without the mutex the
+    read of [agent.lifecycle] (for [?previous]) and the subsequent
+    write could interleave, losing an update. *)
 let set_lifecycle agent ?current_run_id ?worker_id ?runtime_actor ?last_error
     ?accepted_at ?ready_at ?first_progress_at ?started_at ?last_progress_at
     ?finished_at status =
-  agent.lifecycle <- Some (Agent_lifecycle.build_snapshot
-    ~agent_name:agent.state.config.name
-    ~provider:agent.options.provider
-    ~model:agent.state.config.model
-    ?previous:agent.lifecycle
-    ?current_run_id ?worker_id ?runtime_actor ?last_error
-    ?accepted_at ?ready_at ?first_progress_at ?started_at
-    ?last_progress_at ?finished_at status)
+  Eio.Mutex.use_rw ~protect:false agent.mu (fun () ->
+    agent.lifecycle <- Some (Agent_lifecycle.build_snapshot
+      ~agent_name:agent.state.config.name
+      ~provider:agent.options.provider
+      ~model:agent.state.config.model
+      ?previous:agent.lifecycle
+      ?current_run_id ?worker_id ?runtime_actor ?last_error
+      ?accepted_at ?ready_at ?first_progress_at ?started_at
+      ?last_progress_at ?finished_at status))
 
 let create ~net ?(config=default_config) ?(tools=[]) ?context ?named_cascade
     ?(options=default_options) () =
@@ -144,7 +167,8 @@ let create ~net ?(config=default_config) ?(tools=[]) ?context ?named_cascade
     | Some c -> c
     | None -> Context.create ()
   in
-  { state; lifecycle = None; last_tool_calls = None; consecutive_idle_turns = 0;
+  { mu = Eio.Mutex.create ();
+    state; lifecycle = None; last_tool_calls = None; consecutive_idle_turns = 0;
     named_cascade;
     tools = all_tools; net; context = ctx; options }
 
@@ -157,7 +181,8 @@ let clone ?(copy_context=false) agent =
     turn_count = agent.state.turn_count;
     usage = agent.state.usage;
   } in
-  { state; lifecycle = agent.lifecycle; last_tool_calls = None;
+  { mu = Eio.Mutex.create ();
+    state; lifecycle = agent.lifecycle; last_tool_calls = None;
     consecutive_idle_turns = 0; tools = agent.tools; net = agent.net;
     named_cascade = agent.named_cascade;
     context = ctx; options = agent.options }

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -67,8 +67,14 @@ type lifecycle_snapshot = Agent_lifecycle.lifecycle_snapshot = {
 type tool_call_fingerprint = Agent_turn.tool_call_fingerprint
 
 (** Mutable agent record — library-internal only.
-    External code must use [Agent.t] (abstract) and its accessors. *)
+    External code must use [Agent.t] (abstract) and its accessors.
+
+    All mutable fields are protected by [mu].  Use [set_state],
+    [update_state], [set_lifecycle], etc. rather than direct assignment
+    to prevent lost-update races from parallel tool-execution fibers or
+    periodic callbacks. *)
 type t = {
+  mu: Eio.Mutex.t;
   mutable state: Types.agent_state;
   mutable lifecycle: lifecycle_snapshot option;
   mutable last_tool_calls: tool_call_fingerprint list option;
@@ -93,6 +99,7 @@ val context : t -> Context.t
 val options : t -> options
 val net : t -> [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
 val set_state : t -> Types.agent_state -> unit
+val update_state : t -> (Types.agent_state -> Types.agent_state) -> unit
 val set_consecutive_idle_turns : t -> int -> unit
 val description : t -> string option
 val memory : t -> Memory.t option

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -51,9 +51,9 @@ let stage_input ?raw_trace_run agent =
          | Hooks.Answer json ->
            let text = Printf.sprintf "[User input] %s: %s"
              req.question (Yojson.Safe.to_string json) in
-           agent.state <- { agent.state with
-             messages = Util.snoc agent.state.messages
-               { role = User; content = [Text text]; name = None; tool_call_id = None } }
+           update_state agent (fun s ->
+             { s with messages = Util.snoc s.messages
+                 { role = User; content = [Text text]; name = None; tool_call_id = None } })
          | Hooks.Declined | Hooks.Timeout -> ())
       | None -> ())
    | _ -> ())
@@ -115,7 +115,7 @@ let stage_parse ?raw_trace_run agent =
     tool_choice =
       (match turn_params.tool_choice with Some _ as t -> t | None -> original_config.tool_choice);
   } in
-  agent.state <- { agent.state with config = new_config };
+  update_state agent (fun s -> { s with config = new_config });
   let original_config = original_config in
 
   (* TurnStarted event *)
@@ -213,7 +213,7 @@ let stage_route ~sw ?clock ~api_strategy agent prep =
 (** Accumulate usage, invoke AfterTurn hook, emit events, append
     assistant message, increment turn_count.  Restores original_config. *)
 let stage_collect ?raw_trace_run agent ~original_config response =
-  agent.state <- { agent.state with config = original_config };
+  update_state agent (fun s -> { s with config = original_config });
 
   let ts = Unix.gettimeofday () in
   set_lifecycle agent ~first_progress_at:ts ~last_progress_at:ts Running;
@@ -236,12 +236,12 @@ let stage_collect ?raw_trace_run agent ~original_config response =
                         turn = agent.state.turn_count })
    | None -> ());
 
-  agent.state <- { agent.state with
-    messages = Util.snoc agent.state.messages
-      { role = Assistant; content = response.content; name = None; tool_call_id = None };
-    turn_count = agent.state.turn_count + 1;
-    usage;
-  };
+  update_state agent (fun s ->
+    { s with
+      messages = Util.snoc s.messages
+        { role = Assistant; content = response.content; name = None; tool_call_id = None };
+      turn_count = s.turn_count + 1;
+      usage });
   Ok ()
 
 (* ── Stage 5: Execute ────────────────────────────────────── *)
@@ -255,9 +255,10 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
     }
     ~tool_uses
   in
-  agent.last_tool_calls <- idle_result.new_state.last_tool_calls;
-  agent.consecutive_idle_turns <-
-    idle_result.new_state.consecutive_idle_turns;
+  Eio.Mutex.use_rw ~protect:false agent.mu (fun () ->
+    agent.last_tool_calls <- idle_result.new_state.last_tool_calls;
+    agent.consecutive_idle_turns <-
+      idle_result.new_state.consecutive_idle_turns);
   if idle_result.is_idle then begin
     let _idle =
       invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"on_idle"
@@ -276,9 +277,9 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
   | true ->
     let msg = Printf.sprintf
       "Tool call limit exceeded: %d calls in one turn" count in
-    agent.state <- { agent.state with
-      messages = Util.snoc agent.state.messages
-        { role = User; content = [Text msg]; name = None; tool_call_id = None } };
+    update_state agent (fun s ->
+      { s with messages = Util.snoc s.messages
+          { role = User; content = [Text msg]; name = None; tool_call_id = None } });
     Ok ToolsExecuted
   | false ->
     let results =
@@ -287,9 +288,9 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
     in
     let* results = results in
     let tool_results = Agent_turn.make_tool_results results in
-    agent.state <- { agent.state with
-      messages = Util.snoc agent.state.messages
-        { role = User; content = tool_results; name = None; tool_call_id = None } };
+    update_state agent (fun s ->
+      { s with messages = Util.snoc s.messages
+          { role = User; content = tool_results; name = None; tool_call_id = None } });
     (match agent.options.context_injector with
      | None -> ()
      | Some injector ->
@@ -297,7 +298,7 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
          ~context:agent.context ~messages:agent.state.messages
          ~injector ~tool_uses ~results
        in
-       agent.state <- { agent.state with messages = new_messages });
+       update_state agent (fun s -> { s with messages = new_messages }));
     Ok ToolsExecuted
 
 (* ── Stage 6: Output ─────────────────────────────────────── *)
@@ -343,7 +344,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
   (match Guardrails_async.run_input async_guard.input_validators
            prep.Agent_turn.effective_messages with
    | Guardrails_async.Fail { validator_name; reason } ->
-     agent.state <- { agent.state with config = original_config };
+     update_state agent (fun s -> { s with config = original_config });
      Error (Error.Agent (GuardrailViolation {
        validator = validator_name; reason }))
    | Guardrails_async.Pass ->
@@ -355,13 +356,13 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
   (* Stage 4+5+6: Collect, Execute/Output *)
   match api_result with
   | Error e ->
-    agent.state <- { agent.state with config = original_config };
+    update_state agent (fun s -> { s with config = original_config });
     Error e
   | Ok response ->
     (* Stage 3.5: Async output validation *)
     (match Guardrails_async.run_output async_guard.output_validators response with
      | Guardrails_async.Fail { validator_name; reason } ->
-       agent.state <- { agent.state with config = original_config };
+       update_state agent (fun s -> { s with config = original_config });
        Error (Error.Agent (GuardrailViolation {
          validator = validator_name; reason }))
      | Guardrails_async.Pass ->

--- a/test/dune
+++ b/test/dune
@@ -267,6 +267,10 @@
  (libraries agent_sdk alcotest yojson))
 
 (test
+ (name test_agent_race)
+ (libraries agent_sdk alcotest yojson eio eio_main))
+
+(test
  (name test_skill_registry)
  (libraries agent_sdk alcotest yojson))
 

--- a/test/test_agent_race.ml
+++ b/test/test_agent_race.ml
@@ -1,0 +1,140 @@
+(** Tests for Agent.t mutable-field race condition fix.
+
+    Verifies that concurrent access to Agent.t mutable fields
+    (state, lifecycle, last_tool_calls, consecutive_idle_turns)
+    via the Eio.Mutex is safe under parallel Eio fibers. *)
+
+open Agent_sdk
+
+(* ── Helpers ──────────────────────────────────────────────── *)
+
+let make_agent env =
+  let tools = [
+    Tool.create ~name:"echo" ~description:"echo" ~parameters:[]
+      (fun input -> Ok { Types.content = Yojson.Safe.to_string input });
+  ] in
+  Agent.create ~net:(Eio.Stdenv.net env) ~tools ()
+
+(* ── Test: concurrent set_lifecycle from parallel fibers ── *)
+
+let test_concurrent_set_lifecycle () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let agent = make_agent env in
+  let n = 50 in
+  (* Fork N fibers that all call set_lifecycle concurrently.
+     Without the mutex, the read-modify-write of agent.lifecycle
+     could lose updates (earlier timestamps overwritten). *)
+  let done_count = Atomic.make 0 in
+  for i = 1 to n do
+    Eio.Fiber.fork ~sw (fun () ->
+      let ts = Float.of_int i in
+      Agent.set_lifecycle agent ~last_progress_at:ts Running;
+      Atomic.incr done_count)
+  done;
+  (* All fibers complete within the switch scope *)
+  Alcotest.(check int) "all fibers completed" n (Atomic.get done_count);
+  (* Lifecycle should exist *)
+  let lc = Agent.lifecycle agent in
+  Alcotest.(check bool) "lifecycle present" true (Option.is_some lc);
+  let snap = Option.get lc in
+  Alcotest.(check bool) "status Running" true (snap.status = Running);
+  (* last_progress_at should be one of the written values (not None) *)
+  Alcotest.(check bool) "last_progress_at set" true
+    (Option.is_some snap.last_progress_at)
+
+(* ── Test: concurrent update_state from parallel fibers ── *)
+
+let test_concurrent_update_state () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let agent = make_agent env in
+  let n = 100 in
+  (* Each fiber increments turn_count by 1 via update_state.
+     Without the mutex, concurrent read-modify-write would lose
+     increments. *)
+  for _ = 1 to n do
+    Eio.Fiber.fork ~sw (fun () ->
+      Agent.update_state agent (fun s ->
+        { s with turn_count = s.turn_count + 1 }))
+  done;
+  (* With Eio cooperative scheduling the fibers may not all interleave,
+     but the mutex guarantees correctness regardless. *)
+  let st = Agent.state agent in
+  Alcotest.(check int) "turn_count after concurrent increments" n st.turn_count
+
+(* ── Test: set_state is mutex-protected ─────────────────── *)
+
+let test_set_state_protected () =
+  Eio_main.run @@ fun env ->
+  let agent = make_agent env in
+  let st = Agent.state agent in
+  Agent.set_state agent { st with turn_count = 42 };
+  Alcotest.(check int) "turn_count set" 42 (Agent.state agent).turn_count
+
+(* ── Test: set_consecutive_idle_turns is protected ──────── *)
+
+let test_set_consecutive_idle_protected () =
+  Eio_main.run @@ fun env ->
+  let agent = make_agent env in
+  Agent.set_consecutive_idle_turns agent 5;
+  (* Read back through check_loop_guard which checks consecutive_idle_turns.
+     With max_idle_turns=3 (default) and consecutive_idle_turns=5,
+     it should fire the idle guard. *)
+  let guard = Agent.check_loop_guard agent in
+  match guard with
+  | Some (Error.Agent (Error.IdleDetected _)) -> ()
+  | _ ->
+    Alcotest.fail "expected IdleDetected after setting consecutive_idle_turns=5"
+
+(* ── Test: lifecycle transitions are ordered ────────────── *)
+
+let test_lifecycle_transition_order () =
+  Eio_main.run @@ fun env ->
+  let agent = make_agent env in
+  Agent.set_lifecycle agent ~accepted_at:1.0 Accepted;
+  Agent.set_lifecycle agent ~ready_at:2.0 Ready;
+  Agent.set_lifecycle agent ~started_at:3.0 Running;
+  Agent.set_lifecycle agent ~finished_at:4.0 Completed;
+  let snap = Option.get (Agent.lifecycle agent) in
+  Alcotest.(check (option (float 0.001))) "accepted_at preserved"
+    (Some 1.0) snap.accepted_at;
+  Alcotest.(check (option (float 0.001))) "ready_at preserved"
+    (Some 2.0) snap.ready_at;
+  Alcotest.(check (option (float 0.001))) "started_at preserved"
+    (Some 3.0) snap.started_at;
+  Alcotest.(check (option (float 0.001))) "finished_at set"
+    (Some 4.0) snap.finished_at;
+  Alcotest.(check bool) "status Completed" true (snap.status = Completed)
+
+(* ── Test: clone creates independent state ──────────────── *)
+
+let test_clone_independent_state () =
+  Eio_main.run @@ fun env ->
+  let agent = make_agent env in
+  Agent.set_lifecycle agent Running;
+  let cloned = Agent.clone agent in
+  (* Mutating the clone should not affect the original *)
+  Agent.set_state cloned { (Agent.state cloned) with turn_count = 99 };
+  Alcotest.(check int) "original unchanged" 0 (Agent.state agent).turn_count;
+  Alcotest.(check int) "clone updated" 99 (Agent.state cloned).turn_count
+
+(* ── Runner ───────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Agent race condition" [
+    "mutex protection", [
+      Alcotest.test_case "concurrent set_lifecycle" `Quick
+        test_concurrent_set_lifecycle;
+      Alcotest.test_case "concurrent update_state" `Quick
+        test_concurrent_update_state;
+      Alcotest.test_case "set_state protected" `Quick
+        test_set_state_protected;
+      Alcotest.test_case "set_consecutive_idle protected" `Quick
+        test_set_consecutive_idle_protected;
+      Alcotest.test_case "lifecycle transition order" `Quick
+        test_lifecycle_transition_order;
+      Alcotest.test_case "clone independent state" `Quick
+        test_clone_independent_state;
+    ];
+  ]


### PR DESCRIPTION
## Summary

- Add `Eio.Mutex.t` to `Agent_types.t` to protect the 4 mutable fields (`state`, `lifecycle`, `last_tool_calls`, `consecutive_idle_turns`) from concurrent access by parallel tool-execution fibers, periodic callback fibers, and lifecycle trace callbacks.
- Replace all direct `agent.state <- { agent.state with ... }` patterns with `update_state agent (fun s -> { s with ... })` which performs the read-modify-write under the mutex.
- Protect `set_lifecycle` (called concurrently from `Eio.Fiber.List.map` in `execute_tools`) with the mutex.

### Issue #324 status

| Item | Description | Status |
|------|-------------|--------|
| 1 | Agent.t mutable fields unprotected | Fixed in this PR |
| 2 | Cancel.Cancelled swallowed in context_injector | Already fixed (agent_turn.ml:169) |
| 3 | with_cascade skips fallbacks on non-retryable error | Already fixed in #336 + #345 |
| 4 | bogus result for non-ToolUse blocks | Already fixed in #344 |

## Test plan

- [x] New `test_agent_race.ml` with 6 tests: concurrent `set_lifecycle` (50 fibers), concurrent `update_state` (100 fibers), `set_state` protection, `set_consecutive_idle_turns` protection, lifecycle transition ordering, clone independence
- [x] All existing tests pass (`dune runtest`, 0 failures)
- [x] Build clean (`dune build`)

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)