### PR TITLE
fix(llm_provider): sanitize invalid UTF-8 before sending to LLM APIs

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -11,7 +11,7 @@ include Llm_provider.Backend_openai
 let system_message_json (config : agent_state) : Yojson.Safe.t list =
   match config.config.system_prompt with
   | Some s when not (Api_common.string_is_blank s) ->
-      [ `Assoc [("role", `String "system"); ("content", `String s)] ]
+      [ `Assoc [("role", `String "system"); ("content", `String (Llm_provider.Utf8_sanitize.sanitize s))] ]
   | _ -> []
 
 let capabilities_for_request ?provider_config (config : agent_state) =

--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -28,8 +28,8 @@ let string_is_blank s =
 let text_blocks_to_string blocks =
   blocks
   |> List.filter_map (function
-         | Text s -> Some s
-         | Thinking { content = s; _ } -> Some s
+         | Text s -> Some (Utf8_sanitize.sanitize s)
+         | Thinking { content = s; _ } -> Some (Utf8_sanitize.sanitize s)
          | RedactedThinking _ -> None
          | ToolUse _ | ToolResult _ | Image _ | Document _ | Audio _ -> None)
   |> String.concat "\n"
@@ -40,12 +40,12 @@ let json_of_string_or_raw s =
 
 (** Content block <-> JSON *)
 let content_block_to_json = function
-  | Text s -> `Assoc [("type", `String "text"); ("text", `String s)]
+  | Text s -> `Assoc [("type", `String "text"); ("text", `String (Utf8_sanitize.sanitize s))]
   | Thinking { thinking_type; content } ->
       `Assoc [
         ("type", `String "thinking");
         ("signature", `String thinking_type);
-        ("thinking", `String content);
+        ("thinking", `String (Utf8_sanitize.sanitize content));
       ]
   | RedactedThinking data ->
       `Assoc [("type", `String "redacted_thinking"); ("data", `String data)]
@@ -60,7 +60,7 @@ let content_block_to_json = function
       `Assoc [
         ("type", `String "tool_result");
         ("tool_use_id", `String tool_use_id);
-        ("content", `String content);
+        ("content", `String (Utf8_sanitize.sanitize content));
         ("is_error", `Bool is_error);
       ]
   | Image { media_type; data; source_type } ->

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -44,6 +44,7 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
   in
   let body = match config.system_prompt with
     | Some s when not (Api_common.string_is_blank s) ->
+        let s = Utf8_sanitize.sanitize s in
         if config.cache_system_prompt && String.length s >= 3500 then
           (* Anthropic prompt caching: requires ~1024+ tokens (~3500 chars).
              Send system as content block array with cache_control breakpoint. *)

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -32,9 +32,9 @@ let build_tool_id_to_name (messages : message list) : (string, string) Hashtbl.t
 
 let part_of_content_block id_to_name = function
   | Text s ->
-      Some (`Assoc [("text", `String s)])
+      Some (`Assoc [("text", `String (Utf8_sanitize.sanitize s))])
   | Thinking { content; _ } ->
-      Some (`Assoc [("thought", `Bool true); ("text", `String content)])
+      Some (`Assoc [("thought", `Bool true); ("text", `String (Utf8_sanitize.sanitize content))])
   | Image { media_type; data; _ } ->
       Some (`Assoc [
         ("inlineData", `Assoc [
@@ -71,7 +71,7 @@ let part_of_content_block id_to_name = function
       Some (`Assoc [
         ("functionResponse", `Assoc [
           ("name", `String name);
-          ("response", `Assoc [("result", `String content)]);
+          ("response", `Assoc [("result", `String (Utf8_sanitize.sanitize content))]);
         ])
       ])
   | RedactedThinking _ -> None
@@ -134,8 +134,10 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
   (* Prepend system_prompt from config if present *)
   let system_instruction = match config.system_prompt, system_instruction with
     | Some s, None when not (Api_common.string_is_blank s) ->
+        let s = Utf8_sanitize.sanitize s in
         Some (`Assoc [("parts", `List [`Assoc [("text", `String s)]])])
     | Some s, Some (`Assoc fields) when not (Api_common.string_is_blank s) ->
+        let s = Utf8_sanitize.sanitize s in
         let existing_parts = match List.assoc_opt "parts" fields with
           | Some (`List ps) -> ps | _ -> []
         in

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -31,7 +31,7 @@ let openai_content_parts_of_blocks blocks =
   blocks
   |> List.filter_map (function
          | Text s ->
-             Some (`Assoc [("type", `String "text"); ("text", `String s)])
+             Some (`Assoc [("type", `String "text"); ("text", `String (Utf8_sanitize.sanitize s))])
          | Image { media_type; data; source_type = _ } ->
              Some (`Assoc [
                ("type", `String "image_url");
@@ -86,7 +86,7 @@ let openai_messages_of_message (msg : message) : Yojson.Safe.t list =
                         [
                           ("role", `String "tool");
                           ("tool_call_id", `String tool_use_id);
-                          ("content", `String content);
+                          ("content", `String (Utf8_sanitize.sanitize content));
                         ])
                | _ -> None)
       in
@@ -119,7 +119,7 @@ let openai_messages_of_message (msg : message) : Yojson.Safe.t list =
                  Some (`Assoc [
                    ("role", `String "tool");
                    ("tool_call_id", `String tool_use_id);
-                   ("content", `String content);
+                   ("content", `String (Utf8_sanitize.sanitize content));
                  ])
              | _ -> None)
       |> (function
@@ -302,7 +302,7 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
   let provider_messages =
     (match config.system_prompt with
      | Some s when not (Api_common.string_is_blank s) ->
-         [`Assoc [("role", `String "system"); ("content", `String s)]]
+         [`Assoc [("role", `String "system"); ("content", `String (Utf8_sanitize.sanitize s))]]
      | _ -> [])
     @ List.concat_map openai_messages_of_message messages
   in

--- a/lib/llm_provider/utf8_sanitize.ml
+++ b/lib/llm_provider/utf8_sanitize.ml
@@ -1,0 +1,117 @@
+(** Replace invalid UTF-8 bytes with U+FFFD replacement character.
+    Valid UTF-8 is passed through unchanged.  O(n). *)
+
+let replacement = "\xEF\xBF\xBD" (* U+FFFD *)
+
+(** Expected byte length of a UTF-8 sequence given its lead byte.
+    Returns 0 for invalid lead bytes (0x80..0xBF, 0xF8+). *)
+let expected_seq_len byte =
+  if byte < 0x80 then 1
+  else if byte < 0xC0 then 0       (* continuation byte as lead *)
+  else if byte < 0xE0 then 2
+  else if byte < 0xF0 then 3
+  else if byte < 0xF8 then 4
+  else 0                            (* 0xF8+ is invalid *)
+
+(** Check whether [s.[i+1] .. s.[i+n-1]] are all continuation bytes (0x80..0xBF). *)
+let continuations_valid s i n =
+  let len = String.length s in
+  if i + n > len then false
+  else
+    let rec loop j =
+      if j >= n then true
+      else
+        let b = Char.code (String.unsafe_get s (i + j)) in
+        b >= 0x80 && b < 0xC0 && loop (j + 1)
+    in
+    loop 1
+
+(** Fast-path: scan the string and return [true] if it is already valid UTF-8. *)
+let is_valid_utf8 s =
+  let len = String.length s in
+  let rec check i =
+    if i >= len then true
+    else
+      let byte = Char.code (String.unsafe_get s i) in
+      let n = expected_seq_len byte in
+      if n = 0 then false                    (* invalid lead *)
+      else if n = 1 then check (i + 1)      (* ASCII *)
+      else if not (continuations_valid s i n) then false
+      else check (i + n)
+  in
+  check 0
+
+let sanitize s =
+  if is_valid_utf8 s then s                  (* fast path: no allocation *)
+  else
+    let len = String.length s in
+    let buf = Buffer.create len in
+    let rec loop i =
+      if i >= len then Buffer.contents buf
+      else
+        let byte = Char.code (String.unsafe_get s i) in
+        let n = expected_seq_len byte in
+        if n = 0 then begin
+          (* invalid lead byte *)
+          Buffer.add_string buf replacement;
+          loop (i + 1)
+        end else if n = 1 then begin
+          (* ASCII *)
+          Buffer.add_char buf (String.unsafe_get s i);
+          loop (i + 1)
+        end else if not (continuations_valid s i n) then begin
+          (* truncated or bad continuation *)
+          Buffer.add_string buf replacement;
+          loop (i + 1)
+        end else begin
+          Buffer.add_string buf (String.sub s i n);
+          loop (i + n)
+        end
+    in
+    loop 0
+
+(* === Inline tests === *)
+
+let%test "ascii only unchanged" =
+  let s = "Hello, world 123" in
+  sanitize s == s  (* physical equality: no allocation *)
+
+let%test "valid utf8 korean unchanged" =
+  let s = "\xED\x95\x9C\xEA\xB5\xAD\xEC\x96\xB4" in  (* "한국어" *)
+  sanitize s == s
+
+let%test "valid utf8 emoji unchanged" =
+  let s = "\xF0\x9F\x98\x80" in  (* U+1F600 grinning face *)
+  sanitize s == s
+
+let%test "truncated 2-byte replaced" =
+  let s = "abc\xC3" in  (* C3 expects one continuation *)
+  sanitize s = "abc" ^ replacement
+
+let%test "truncated 3-byte replaced" =
+  let s = "x\xE2\x80" in  (* E2 expects two continuations, only one *)
+  sanitize s = "x" ^ replacement ^ replacement
+
+let%test "truncated 4-byte replaced" =
+  let s = "\xF0\x9F\x98" in  (* F0 expects three continuations, only two *)
+  sanitize s = replacement ^ replacement ^ replacement
+
+let%test "invalid continuation byte" =
+  let s = "a\xC3\x00b" in  (* C3 followed by 0x00 instead of 0x80..0xBF *)
+  sanitize s = "a" ^ replacement ^ "\x00b"
+
+let%test "bare continuation byte" =
+  let s = "\x80\x81" in
+  sanitize s = replacement ^ replacement
+
+let%test "mixed valid and invalid" =
+  let s = "ok\xC3\xA9\xFF\xE2\x9C\x93" in  (* "okU+00E9" + 0xFF + U+2713 *)
+  sanitize s = "ok\xC3\xA9" ^ replacement ^ "\xE2\x9C\x93"
+
+let%test "empty string" =
+  let s = "" in
+  sanitize s == s
+
+let%test "0xF8+ lead byte invalid" =
+  let s = "\xF8\x80\x80\x80" in
+  sanitize s = replacement ^ replacement ^ replacement ^ replacement

--- a/lib/llm_provider/utf8_sanitize.mli
+++ b/lib/llm_provider/utf8_sanitize.mli
@@ -1,0 +1,13 @@
+(** Replace invalid UTF-8 bytes with U+FFFD replacement character.
+
+    OCaml strings are byte sequences with no UTF-8 guarantee.
+    When tool results or LLM responses contain truncated multi-byte
+    sequences or raw bytes from file reads, Yojson passes them
+    through without validation.  Some providers (GLM/BigModel)
+    reject the resulting JSON with parse errors.
+
+    Valid UTF-8 is passed through unchanged.  The function runs
+    in O(n) with a fast-path that avoids allocation when the
+    input is already valid. *)
+
+val sanitize : string -> string


### PR DESCRIPTION
## Summary

- Add `Utf8_sanitize.sanitize` module in `lib/llm_provider/` that replaces invalid UTF-8 bytes with U+FFFD (replacement character) in O(n) with a fast-path that avoids allocation when input is already valid
- Apply sanitization at every text-content serialization point across all three backends (OpenAI, Anthropic, Gemini): message content, system prompts, tool results, and thinking blocks
- Fixes GLM (BigModel) API JSON parse errors caused by OCaml strings containing truncated multi-byte sequences or raw bytes from tool results/file reads

## Test plan

- [x] 11 inline tests covering: ASCII passthrough, valid UTF-8 (Korean, emoji), truncated 2/3/4-byte sequences, invalid continuation bytes, bare continuation bytes, mixed valid/invalid, empty string, 0xF8+ lead bytes
- [x] `dune build --root . -j 4` passes
- [x] `dune test --root .` passes (all existing tests unaffected)
- [ ] Manual verification: send a request containing invalid UTF-8 bytes through GLM cascade

🤖 Generated with [Claude Code](https://claude.com/claude-code)