### PR TITLE
feat(provider): add config_of_provider_config for zero-adapter consumption

### DIFF
--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -128,6 +128,8 @@ let with_context_thresholds ~compact_ratio ?prepare_ratio ?handoff_ratio b =
     context_handoff_ratio = handoff_ratio }
 let with_context ctx b = { b with context = Some ctx }
 let with_provider provider b = { b with provider = Some provider }
+let with_provider_config pc b =
+  with_provider (Provider.config_of_provider_config pc) b
 let with_base_url url b = { b with base_url = url }
 let with_mcp_clients clients b = { b with mcp_clients = clients }
 let with_guardrails guardrails b = { b with guardrails }

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -69,6 +69,7 @@ val with_periodic_callbacks : Agent.periodic_callback list -> t -> t
 (** {2 Provider} *)
 
 val with_provider : Provider.config -> t -> t
+val with_provider_config : Llm_provider.Provider_config.t -> t -> t
 val with_base_url : string -> t -> t
 val with_cascade : Provider.cascade -> t -> t
 val with_named_cascade : Api.named_cascade -> t -> t

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -278,3 +278,30 @@ let custom_provider ~name ?(model_id="custom") ?(api_key_env="DUMMY_KEY") () = {
   model_id;
   api_key_env;
 }
+
+(** Convert a [Provider_config.t] (from Cascade_config) into a
+    [Provider.config] (for Agent Builder).  Keeps the conversion
+    internal to OAS so consumers don't need their own adapters. *)
+let config_of_provider_config (pc : Llm_provider.Provider_config.t) : config =
+  let is_local url =
+    let len = String.length url in
+    len >= 16 && (String.sub url 0 16 = "http://127.0.0.1"
+                  || String.sub url 0 (min 16 len) = "http://localhost")
+  in
+  let provider = match pc.kind with
+    | Anthropic -> Anthropic
+    | Gemini ->
+      OpenAICompat { base_url = pc.base_url; auth_header = None;
+                     path = pc.request_path; static_token = None }
+    | Glm ->
+      OpenAICompat { base_url = pc.base_url; auth_header = None;
+                     path = pc.request_path; static_token = None }
+    | OpenAI_compat ->
+      if is_local pc.base_url then Local { base_url = pc.base_url }
+      else OpenAICompat { base_url = pc.base_url; auth_header = None;
+                          path = pc.request_path; static_token = None }
+    | Claude_code ->
+      OpenAICompat { base_url = pc.base_url; auth_header = None;
+                     path = pc.request_path; static_token = None }
+  in
+  { provider; model_id = pc.model_id; api_key_env = pc.api_key }

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -126,3 +126,9 @@ val register_provider : provider_impl -> unit
 val find_provider : string -> provider_impl option
 val registered_providers : unit -> string list
 val custom_provider : name:string -> ?model_id:string -> ?api_key_env:string -> unit -> config
+
+(** Convert a {!Llm_provider.Provider_config.t} (from Cascade_config)
+    into a {!config}.  Use this to avoid building adapter layers in
+    consuming projects (e.g. MASC).
+    @since 0.84.0 *)
+val config_of_provider_config : Llm_provider.Provider_config.t -> config


### PR DESCRIPTION
## Summary
- `Provider.config_of_provider_config`: converts `Provider_config.t` → `Provider.config` internally
- `Builder.with_provider_config`: shorthand for consumers using Cascade_config results
- Eliminates the need for MASC's `oas_type_adapters.provider_config_to_oas` adapter

## Motivation
MASC had to maintain its own adapter because OAS exposed two incompatible provider types:
- `Provider_config.t` (flat record from Cascade_config)
- `Provider.config` (discriminated union for Builder)

This conversion belongs in OAS, not in every consumer.

## Test plan
- [ ] `dune build` passes
- [ ] CI tests pass

Generated with [Claude Code](https://claude.com/claude-code)