### PR TITLE
fix: sync sdk_version.ml to 0.84.1

### DIFF
--- a/lib/sdk_version.ml
+++ b/lib/sdk_version.ml
@@ -1,5 +1,5 @@
 (** Single source of truth for the SDK version string.
     All other modules reference this instead of hardcoding. *)
 
-let version = "0.83.0"
+let version = "0.84.1"
 let sdk_name = "agent_sdk"


### PR DESCRIPTION
## Summary
- Sync sdk_version.ml from 0.83.0 to 0.84.1 to match dune-project and opam

PR #354 bumped dune-project and opam but sdk_version.ml was missed.

Generated with [Claude Code](https://claude.com/claude-code)