### PR TITLE
feat(judge): add LLM judge module for evaluation and scoring

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -143,6 +143,7 @@ module Policy = Policy
 module Audit = Audit
 module Plan = Plan
 module Checkpoint_validation = Checkpoint_validation
+module Judge = Judge
 
 (** Quick start: create an agent with default config *)
 let create_agent ~net ?name ?model ?system_prompt ?max_tokens ?max_turns

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -114,6 +114,7 @@ module Policy = Policy
 module Audit = Audit
 module Plan = Plan
 module Checkpoint_validation = Checkpoint_validation
+module Judge = Judge
 
 (** {1 Quick Start} *)
 

--- a/lib/judge/judge.ml
+++ b/lib/judge/judge.ml
@@ -1,0 +1,179 @@
+(** LLM-based evaluation and scoring.
+
+    Provides a single-turn judgment call via a named cascade.
+    The LLM receives a system prompt and context, and returns
+    a structured JSON response parsed into a {!judgment} record.
+
+    @since 0.78.0 *)
+
+open Llm_provider
+
+(* ── Types ──────────────────────────────────────────────── *)
+
+type risk_level = Low | Medium | High | Critical
+[@@deriving yojson, show]
+
+type judgment = {
+  score: float;
+  confidence: float;
+  risk: risk_level;
+  summary: string;
+  evidence: string list;
+  recommended_action: string option;
+}
+[@@deriving yojson, show]
+
+type judge_config = {
+  cascade_name: string;
+  system_prompt: string;
+  temperature: float;
+  max_tokens: int;
+  max_turns: int;
+  output_schema: Yojson.Safe.t option;
+}
+[@@deriving show]
+
+let default_config () = {
+  cascade_name = "judge";
+  system_prompt = "You are a precise evaluator. Analyze the given context and return a JSON object with: score (0.0-1.0), confidence (0.0-1.0), risk (low/medium/high/critical), summary (string), evidence (string array), recommended_action (string or null).";
+  temperature = 0.2;
+  max_tokens = 2048;
+  max_turns = 1;
+  output_schema = None;
+}
+
+(* ── Risk derivation ────────────────────────────────────── *)
+
+let risk_of_score score =
+  if score < 0.3 then Low
+  else if score < 0.6 then Medium
+  else if score < 0.8 then High
+  else Critical
+
+(* ── JSON parsing helpers ───────────────────────────────── *)
+
+let risk_level_of_string = function
+  | "low" -> Low
+  | "medium" -> Medium
+  | "high" -> High
+  | "critical" -> Critical
+  | _ -> Low  (* conservative default *)
+
+let clamp_01 v =
+  Float.max 0.0 (Float.min 1.0 v)
+
+(** Extract the first JSON object from a string that may contain
+    markdown fencing or surrounding prose. *)
+let extract_json_substring text =
+  (* Try to find JSON object boundaries *)
+  match String.index_opt text '{' with
+  | None -> None
+  | Some start ->
+    (* Walk forward to find matching close brace *)
+    let len = String.length text in
+    let depth = ref 0 in
+    let in_string = ref false in
+    let escape = ref false in
+    let found = ref None in
+    let i = ref start in
+    while !i < len && Option.is_none !found do
+      let c = text.[!i] in
+      if !escape then
+        escape := false
+      else if c = '\\' && !in_string then
+        escape := true
+      else if c = '"' then
+        in_string := not !in_string
+      else if not !in_string then begin
+        if c = '{' then incr depth
+        else if c = '}' then begin
+          decr depth;
+          if !depth = 0 then
+            found := Some (String.sub text start (!i - start + 1))
+        end
+      end;
+      incr i
+    done;
+    !found
+
+let parse_judgment text =
+  let json_str = match extract_json_substring text with
+    | Some s -> s
+    | None -> text
+  in
+  try
+    let json = Yojson.Safe.from_string json_str in
+    let open Yojson.Safe.Util in
+    let score = clamp_01 (json |> member "score" |> to_float) in
+    let confidence = clamp_01
+        (try json |> member "confidence" |> to_float
+         with _ -> 0.5) in
+    let risk =
+      try json |> member "risk" |> to_string |> String.lowercase_ascii |> risk_level_of_string
+      with _ -> risk_of_score score
+    in
+    let summary =
+      try json |> member "summary" |> to_string
+      with _ -> "No summary provided"
+    in
+    let evidence =
+      try json |> member "evidence" |> to_list |> List.filter_map (fun j ->
+        try Some (to_string j) with _ -> None)
+      with _ -> []
+    in
+    let recommended_action =
+      try
+        match json |> member "recommended_action" with
+        | `Null -> None
+        | j -> Some (to_string j)
+      with _ -> None
+    in
+    Ok { score; confidence; risk; summary; evidence; recommended_action }
+  with
+  | Yojson.Json_error msg ->
+    Error (Printf.sprintf "JSON parse error: %s" msg)
+  | exn ->
+    Error (Printf.sprintf "Parse error: %s" (Printexc.to_string exn))
+
+(* ── LLM call ───────────────────────────────────────────── *)
+
+let judge ~sw ~net ?clock ?config_path ~config ~context () =
+  let messages : Types.message list = [
+    { role = System; content = [Text config.system_prompt]; name = None; tool_call_id = None };
+    { role = User; content = [Text context]; name = None; tool_call_id = None };
+  ] in
+  let defaults = ["llama:qwen3.5-35b"; "glm:auto"] in
+  match Cascade_config.complete_named ~sw ~net ?clock ?config_path
+          ~name:config.cascade_name ~defaults ~messages
+          ~temperature:config.temperature ~max_tokens:config.max_tokens
+          ~tools:[] ()
+  with
+  | Error err ->
+    let msg = match err with
+      | Http_client.HttpError { code; body } ->
+        Printf.sprintf "HTTP %d: %s" code
+          (if String.length body > 200
+           then String.sub body 0 200 ^ "..."
+           else body)
+      | Http_client.NetworkError { message } -> message
+    in
+    Error (Printf.sprintf "Judge LLM call failed: %s" msg)
+  | Ok response ->
+    let text = Cascade_config.text_of_response response in
+    if String.length text = 0 then
+      Error "Judge LLM returned empty response"
+    else
+      match parse_judgment text with
+      | Ok j -> Ok j
+      | Error _parse_err ->
+        (* Fallback: create low-confidence judgment from raw text *)
+        Ok {
+          score = 0.5;
+          confidence = 0.1;
+          risk = Medium;
+          summary = (if String.length text > 200
+                     then String.sub text 0 200 ^ "..."
+                     else text);
+          evidence = [];
+          recommended_action = Some "Manual review recommended (structured parse failed)";
+        }

--- a/lib/judge/judge.mli
+++ b/lib/judge/judge.mli
@@ -1,0 +1,68 @@
+(** LLM-based evaluation and scoring.
+
+    Provides a single-turn judgment call via a named cascade.
+    The LLM receives a system prompt and context, and returns
+    a structured JSON response parsed into a {!judgment} record.
+
+    Designed to absorb MASC's inline governance/operator judge logic
+    into a reusable OAS module.
+
+    @since 0.78.0 *)
+
+(** Risk classification derived from score. *)
+type risk_level = Low | Medium | High | Critical
+[@@deriving yojson, show]
+
+(** Result of an LLM judgment. *)
+type judgment = {
+  score: float;                     (** 0.0-1.0 *)
+  confidence: float;                (** 0.0-1.0 *)
+  risk: risk_level;
+  summary: string;
+  evidence: string list;
+  recommended_action: string option;
+}
+[@@deriving yojson, show]
+
+(** Configuration for a judge call. *)
+type judge_config = {
+  cascade_name: string;
+  system_prompt: string;
+  temperature: float;               (** Default 0.2 for deterministic evaluation *)
+  max_tokens: int;                   (** Default 2048 *)
+  max_turns: int;                    (** Default 1, single-turn judgment *)
+  output_schema: Yojson.Safe.t option;  (** JSON schema hint for structured output *)
+}
+[@@deriving show]
+
+(** Default configuration: cascade "judge", temperature 0.2, max_tokens 2048. *)
+val default_config : unit -> judge_config
+
+(** Derive risk level from a 0.0-1.0 score.
+    - [< 0.3] = Low
+    - [< 0.6] = Medium
+    - [< 0.8] = High
+    - [>= 0.8] = Critical *)
+val risk_of_score : float -> risk_level
+
+(** Parse LLM output text into a judgment.
+    Expects JSON with at least [score], [confidence], [risk], [summary] fields.
+    Returns [Error msg] on parse failure. *)
+val parse_judgment : string -> (judgment, string) result
+
+(** Execute a single judgment.
+
+    Calls {!Cascade_config.complete_named} with [config.system_prompt] as the
+    system message and [context] as the user message.  Parses the structured
+    JSON response into a {!judgment}.
+
+    If JSON parsing fails, creates a low-confidence judgment from raw text. *)
+val judge :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?clock:_ Eio.Time.clock ->
+  ?config_path:string ->
+  config:judge_config ->
+  context:string ->
+  unit ->
+  (judgment, string) result

--- a/test/dune
+++ b/test/dune
@@ -744,3 +744,7 @@
 (test
  (name test_turn_budget)
  (libraries agent_sdk alcotest yojson str))
+
+(test
+ (name test_judge)
+ (libraries agent_sdk alcotest yojson))

--- a/test/test_judge.ml
+++ b/test/test_judge.ml
@@ -1,0 +1,245 @@
+(** Tests for Judge module -- LLM-based evaluation and scoring. *)
+
+open Agent_sdk
+
+(* ── Alcotest testable for risk_level ────────────────────── *)
+
+let risk_level_eq (a : Judge.risk_level) (b : Judge.risk_level) =
+  match a, b with
+  | Low, Low | Medium, Medium | High, High | Critical, Critical -> true
+  | _ -> false
+
+let risk_level_pp fmt (r : Judge.risk_level) =
+  Format.pp_print_string fmt (match r with
+    | Low -> "Low" | Medium -> "Medium"
+    | High -> "High" | Critical -> "Critical")
+
+let risk_testable = Alcotest.testable risk_level_pp risk_level_eq
+
+(* ── parse_judgment: valid JSON ──────────────────────────── *)
+
+let test_parse_valid_json () =
+  let json = {|{
+    "score": 0.75,
+    "confidence": 0.9,
+    "risk": "high",
+    "summary": "Potential security issue detected",
+    "evidence": ["SQL injection pattern", "Unsanitized input"],
+    "recommended_action": "Review input validation"
+  }|} in
+  match Judge.parse_judgment json with
+  | Error e -> Alcotest.fail (Printf.sprintf "Expected Ok, got Error: %s" e)
+  | Ok j ->
+    Alcotest.(check (float 0.001)) "score" 0.75 j.score;
+    Alcotest.(check (float 0.001)) "confidence" 0.9 j.confidence;
+    Alcotest.check risk_testable "risk" Judge.High j.risk;
+    Alcotest.(check string) "summary" "Potential security issue detected" j.summary;
+    Alcotest.(check int) "evidence count" 2 (List.length j.evidence);
+    Alcotest.(check (option string)) "action"
+      (Some "Review input validation") j.recommended_action
+
+(* ── parse_judgment: minimal JSON ────────────────────────── *)
+
+let test_parse_minimal_json () =
+  let json = {|{"score": 0.2}|} in
+  match Judge.parse_judgment json with
+  | Error e -> Alcotest.fail (Printf.sprintf "Expected Ok, got Error: %s" e)
+  | Ok j ->
+    Alcotest.(check (float 0.001)) "score" 0.2 j.score;
+    (* confidence defaults to 0.5 when missing *)
+    Alcotest.(check (float 0.001)) "confidence" 0.5 j.confidence;
+    (* risk derived from score: 0.2 < 0.3 = Low *)
+    Alcotest.check risk_testable "risk" Judge.Low j.risk
+
+(* ── parse_judgment: malformed JSON returns Error ────────── *)
+
+let test_parse_malformed_json () =
+  let text = "This is not JSON at all" in
+  match Judge.parse_judgment text with
+  | Ok _ -> Alcotest.fail "Expected Error for non-JSON input"
+  | Error msg ->
+    Alcotest.(check bool) "has error message" true
+      (String.length msg > 0)
+
+(* ── parse_judgment: JSON with markdown fencing ──────────── *)
+
+let test_parse_json_with_fencing () =
+  let text = "```json\n{\"score\": 0.4, \"confidence\": 0.8, \"risk\": \"medium\", \"summary\": \"ok\"}\n```" in
+  match Judge.parse_judgment text with
+  | Error e -> Alcotest.fail (Printf.sprintf "Expected Ok, got Error: %s" e)
+  | Ok j ->
+    Alcotest.(check (float 0.001)) "score" 0.4 j.score;
+    Alcotest.(check (float 0.001)) "confidence" 0.8 j.confidence
+
+(* ── parse_judgment: score clamped to 0-1 ────────────────── *)
+
+let test_parse_clamps_score () =
+  let json = {|{"score": 1.5, "confidence": -0.3}|} in
+  match Judge.parse_judgment json with
+  | Error e -> Alcotest.fail (Printf.sprintf "Expected Ok, got Error: %s" e)
+  | Ok j ->
+    Alcotest.(check (float 0.001)) "score clamped" 1.0 j.score;
+    Alcotest.(check (float 0.001)) "confidence clamped" 0.0 j.confidence
+
+(* ── parse_judgment: null recommended_action ─────────────── *)
+
+let test_parse_null_action () =
+  let json = {|{"score": 0.5, "recommended_action": null}|} in
+  match Judge.parse_judgment json with
+  | Error e -> Alcotest.fail (Printf.sprintf "Expected Ok, got Error: %s" e)
+  | Ok j ->
+    Alcotest.(check (option string)) "null action" None j.recommended_action
+
+(* ── default_config values ───────────────────────────────── *)
+
+let test_default_config () =
+  let cfg = Judge.default_config () in
+  Alcotest.(check string) "cascade_name" "judge" cfg.cascade_name;
+  Alcotest.(check (float 0.001)) "temperature" 0.2 cfg.temperature;
+  Alcotest.(check int) "max_tokens" 2048 cfg.max_tokens;
+  Alcotest.(check int) "max_turns" 1 cfg.max_turns;
+  Alcotest.(check bool) "output_schema is None"
+    true (Option.is_none cfg.output_schema)
+
+(* ── risk_of_score derivation ────────────────────────────── *)
+
+let test_risk_of_score_low () =
+  Alcotest.check risk_testable "0.0" Judge.Low (Judge.risk_of_score 0.0);
+  Alcotest.check risk_testable "0.29" Judge.Low (Judge.risk_of_score 0.29)
+
+let test_risk_of_score_medium () =
+  Alcotest.check risk_testable "0.3" Judge.Medium (Judge.risk_of_score 0.3);
+  Alcotest.check risk_testable "0.59" Judge.Medium (Judge.risk_of_score 0.59)
+
+let test_risk_of_score_high () =
+  Alcotest.check risk_testable "0.6" Judge.High (Judge.risk_of_score 0.6);
+  Alcotest.check risk_testable "0.79" Judge.High (Judge.risk_of_score 0.79)
+
+let test_risk_of_score_critical () =
+  Alcotest.check risk_testable "0.8" Judge.Critical (Judge.risk_of_score 0.8);
+  Alcotest.check risk_testable "1.0" Judge.Critical (Judge.risk_of_score 1.0)
+
+(* ── judgment yojson roundtrip ───────────────────────────── *)
+
+let test_judgment_roundtrip () =
+  let j : Judge.judgment = {
+    score = 0.65;
+    confidence = 0.85;
+    risk = Judge.High;
+    summary = "Test summary";
+    evidence = ["evidence1"; "evidence2"];
+    recommended_action = Some "Fix it";
+  } in
+  let json = Judge.judgment_to_yojson j in
+  match Judge.judgment_of_yojson json with
+  | Error e -> Alcotest.fail (Printf.sprintf "Roundtrip failed: %s" e)
+  | Ok j2 ->
+    Alcotest.(check (float 0.001)) "score" j.score j2.score;
+    Alcotest.(check (float 0.001)) "confidence" j.confidence j2.confidence;
+    Alcotest.check risk_testable "risk" j.risk j2.risk;
+    Alcotest.(check string) "summary" j.summary j2.summary;
+    Alcotest.(check int) "evidence count" (List.length j.evidence) (List.length j2.evidence);
+    Alcotest.(check (option string)) "action" j.recommended_action j2.recommended_action
+
+let test_judgment_roundtrip_no_action () =
+  let j : Judge.judgment = {
+    score = 0.1;
+    confidence = 0.95;
+    risk = Judge.Low;
+    summary = "All clear";
+    evidence = [];
+    recommended_action = None;
+  } in
+  let json = Judge.judgment_to_yojson j in
+  match Judge.judgment_of_yojson json with
+  | Error e -> Alcotest.fail (Printf.sprintf "Roundtrip failed: %s" e)
+  | Ok j2 ->
+    Alcotest.(check (float 0.001)) "score" j.score j2.score;
+    Alcotest.(check (option string)) "action" None j2.recommended_action
+
+(* ── risk_level yojson roundtrip ─────────────────────────── *)
+
+let test_risk_level_roundtrip () =
+  let levels = [Judge.Low; Medium; High; Critical] in
+  List.iter (fun r ->
+    let json = Judge.risk_level_to_yojson r in
+    match Judge.risk_level_of_yojson json with
+    | Error e -> Alcotest.fail (Printf.sprintf "risk roundtrip failed: %s" e)
+    | Ok r2 ->
+      Alcotest.check risk_testable "risk level" r r2
+  ) levels
+
+(* ── parse_judgment: evidence with non-string items ──────── *)
+
+let test_parse_evidence_filters_non_strings () =
+  let json = {|{"score": 0.5, "evidence": ["valid", 42, "also valid", null]}|} in
+  match Judge.parse_judgment json with
+  | Error e -> Alcotest.fail (Printf.sprintf "Expected Ok, got Error: %s" e)
+  | Ok j ->
+    Alcotest.(check int) "evidence filtered" 2 (List.length j.evidence)
+
+(* ── parse_judgment: risk string variants ────────────────── *)
+
+let test_parse_risk_string_variants () =
+  let cases = [
+    ({|{"score": 0.5, "risk": "LOW"}|}, Judge.Low);
+    ({|{"score": 0.5, "risk": "Medium"}|}, Judge.Medium);
+    ({|{"score": 0.5, "risk": "HIGH"}|}, Judge.High);
+    ({|{"score": 0.5, "risk": "CRITICAL"}|}, Judge.Critical);
+  ] in
+  List.iter (fun (json, expected_risk) ->
+    match Judge.parse_judgment json with
+    | Error e -> Alcotest.fail (Printf.sprintf "Expected Ok for %s, got Error: %s" json e)
+    | Ok j ->
+      Alcotest.check risk_testable (Printf.sprintf "risk for input") expected_risk j.risk
+  ) cases
+
+(* ── parse_judgment: score boundary values ───────────────── *)
+
+let test_parse_score_boundaries () =
+  (* Exactly at boundary: 0.3 -> Medium *)
+  let json = {|{"score": 0.3}|} in
+  (match Judge.parse_judgment json with
+   | Error e -> Alcotest.fail e
+   | Ok j -> Alcotest.check risk_testable "0.3" Judge.Medium j.risk);
+  (* Exactly at boundary: 0.6 -> High *)
+  let json = {|{"score": 0.6}|} in
+  (match Judge.parse_judgment json with
+   | Error e -> Alcotest.fail e
+   | Ok j -> Alcotest.check risk_testable "0.6" Judge.High j.risk);
+  (* Exactly at boundary: 0.8 -> Critical *)
+  let json = {|{"score": 0.8}|} in
+  (match Judge.parse_judgment json with
+   | Error e -> Alcotest.fail e
+   | Ok j -> Alcotest.check risk_testable "0.8" Judge.Critical j.risk)
+
+(* ── Test suite ──────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Judge" [
+    "parse_judgment", [
+      Alcotest.test_case "valid JSON" `Quick test_parse_valid_json;
+      Alcotest.test_case "minimal JSON" `Quick test_parse_minimal_json;
+      Alcotest.test_case "malformed JSON" `Quick test_parse_malformed_json;
+      Alcotest.test_case "JSON with fencing" `Quick test_parse_json_with_fencing;
+      Alcotest.test_case "clamps score/confidence" `Quick test_parse_clamps_score;
+      Alcotest.test_case "null action" `Quick test_parse_null_action;
+      Alcotest.test_case "evidence filters non-strings" `Quick test_parse_evidence_filters_non_strings;
+      Alcotest.test_case "risk string variants" `Quick test_parse_risk_string_variants;
+      Alcotest.test_case "score boundaries" `Quick test_parse_score_boundaries;
+    ];
+    "default_config", [
+      Alcotest.test_case "values" `Quick test_default_config;
+    ];
+    "risk_of_score", [
+      Alcotest.test_case "low" `Quick test_risk_of_score_low;
+      Alcotest.test_case "medium" `Quick test_risk_of_score_medium;
+      Alcotest.test_case "high" `Quick test_risk_of_score_high;
+      Alcotest.test_case "critical" `Quick test_risk_of_score_critical;
+    ];
+    "serialization", [
+      Alcotest.test_case "judgment roundtrip" `Quick test_judgment_roundtrip;
+      Alcotest.test_case "judgment roundtrip no action" `Quick test_judgment_roundtrip_no_action;
+      Alcotest.test_case "risk_level roundtrip" `Quick test_risk_level_roundtrip;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- Add `lib/judge/` module with `Judge.judge`, `Judge.parse_judgment`, and `Judge.risk_of_score`
- Single-turn LLM evaluation via named cascades (`Cascade_config.complete_named`)
- Structured JSON parsing with automatic fallback (low-confidence judgment from raw text)
- 17 unit tests: JSON parsing (valid/minimal/malformed/fenced), score clamping, risk derivation boundaries, yojson roundtrips

## Context
Per "Inference belongs in OAS" principle, absorbs MASC's `dashboard_governance_judge.ml` and `dashboard_operator_judge.ml` inline evaluation logic into a reusable OAS module.

Closes #357

## Test plan
- [x] `dune build --root .` passes
- [x] `dune exec test/test_judge.exe` — 17/17 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)