### PR TITLE
feat(context): budget-aware compression strategy

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -49,6 +49,7 @@ module Error_domain = Error_domain
 module Hooks = Hooks
 module Tracing = Tracing
 module Context_reducer = Context_reducer
+module Budget_strategy = Budget_strategy
 module Tool = Tool
 module Mcp = Mcp
 module Mcp_http = Mcp_http

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -20,6 +20,7 @@ module Error_domain = Error_domain
 module Hooks = Hooks
 module Tracing = Tracing
 module Context_reducer = Context_reducer
+module Budget_strategy = Budget_strategy
 module Tool = Tool
 module Mcp = Mcp
 module Mcp_http = Mcp_http

--- a/lib/context/budget_strategy.ml
+++ b/lib/context/budget_strategy.ml
@@ -1,0 +1,81 @@
+(** Budget-aware context compression strategy.
+
+    Maps token budget usage ratios to progressively aggressive
+    context reduction strategies. Designed for integration with
+    external budget managers (e.g. MASC context_budget_manager). *)
+
+open Types
+
+type compression_phase =
+  | Full
+  | Compact
+  | Aggressive
+  | Emergency
+
+let show_phase = function
+  | Full -> "Full"
+  | Compact -> "Compact"
+  | Aggressive -> "Aggressive"
+  | Emergency -> "Emergency"
+
+(** Default extractive summarizer: takes the first text block from each
+    message and joins them, prefixed with role. Keeps output short. *)
+let default_summarizer (messages : message list) : string =
+  let lines = List.filter_map (fun (msg : message) ->
+    let role_str = match msg.role with
+      | User -> "User"
+      | Assistant -> "Assistant"
+      | System -> "System"
+      | Tool -> "Tool"
+    in
+    let first_text = List.find_map (fun block ->
+      match block with
+      | Text s when String.length s > 0 ->
+        let truncated = if String.length s > 100
+          then String.sub s 0 100 ^ "..."
+          else s in
+        Some truncated
+      | _ -> None
+    ) msg.content in
+    match first_text with
+    | Some t -> Some (Printf.sprintf "[%s] %s" role_str t)
+    | None -> None
+  ) messages in
+  match lines with
+  | [] -> "[No prior context]"
+  | _ ->
+    let summary = String.concat "\n" lines in
+    Printf.sprintf "[Summary of %d earlier messages]\n%s" (List.length messages) summary
+
+let phase_of_usage_ratio (ratio : float) : compression_phase =
+  let r = Float.max 0.0 (Float.min 1.0 ratio) in
+  if r < 0.5 then Full
+  else if r < 0.7 then Compact
+  else if r < 0.85 then Aggressive
+  else Emergency
+
+let strategies_for_phase ?(summarizer = default_summarizer) (phase : compression_phase)
+    : Context_reducer.strategy list =
+  match phase with
+  | Full -> []
+  | Compact ->
+    [ Prune_tool_outputs { max_output_len = 500 } ]
+  | Aggressive ->
+    [ Prune_tool_outputs { max_output_len = 200 };
+      Drop_thinking;
+      Merge_contiguous ]
+  | Emergency ->
+    [ Summarize_old { keep_recent = 4; summarizer };
+      Prune_tool_outputs { max_output_len = 100 };
+      Drop_thinking;
+      Merge_contiguous ]
+
+let reduce_for_budget ?(summarizer = default_summarizer) ~usage_ratio
+    ~messages () : message list =
+  let phase = phase_of_usage_ratio usage_ratio in
+  let strategies = strategies_for_phase ~summarizer phase in
+  match strategies with
+  | [] -> messages
+  | _ ->
+    let reducer = { Context_reducer.strategy = Compose strategies } in
+    Context_reducer.reduce reducer messages

--- a/lib/context/budget_strategy.mli
+++ b/lib/context/budget_strategy.mli
@@ -1,0 +1,64 @@
+(** Budget-aware context compression strategy.
+
+    Maps token budget usage ratios to progressively aggressive
+    context reduction strategies. Designed for integration with
+    external budget managers (e.g. MASC context_budget_manager).
+
+    Phase thresholds:
+    - 0.0-0.5  Full: no compression
+    - 0.5-0.7  Compact: prune tool outputs
+    - 0.7-0.85 Aggressive: prune + merge + drop thinking
+    - 0.85+    Emergency: summarize old + all aggressive strategies
+
+    @since 0.78.0 *)
+
+(** Compression phase, ordered from lightest to heaviest. *)
+type compression_phase =
+  | Full        (** No compression needed. *)
+  | Compact     (** Light: prune tool outputs only. *)
+  | Aggressive  (** Medium: prune outputs + drop thinking + merge contiguous. *)
+  | Emergency   (** Heavy: summarize old + all aggressive strategies. *)
+
+(** Map a compression phase to the appropriate reducer strategies.
+
+    - [Full] returns an empty list (no reduction).
+    - [Compact] returns [[PruneToolOutputs]].
+    - [Aggressive] returns [[PruneToolOutputs; Drop_thinking; Merge_contiguous]].
+    - [Emergency] returns [[Summarize_old; PruneToolOutputs; Drop_thinking; Merge_contiguous]].
+
+    The [summarizer] parameter is used only for [Emergency] phase.
+    If not provided, a default extractive summarizer is used. *)
+val strategies_for_phase :
+  ?summarizer:(Types.message list -> string) ->
+  compression_phase ->
+  Context_reducer.strategy list
+
+(** Determine compression phase from budget usage ratio (0.0-1.0).
+
+    - [0.0, 0.5)   -> [Full]
+    - [0.5, 0.7)   -> [Compact]
+    - [0.7, 0.85)  -> [Aggressive]
+    - [0.85, 1.0+]  -> [Emergency]
+
+    Values outside [0.0, 1.0] are clamped. *)
+val phase_of_usage_ratio : float -> compression_phase
+
+(** Convenience: determine phase from ratio, build composed reducer, apply.
+
+    Equivalent to:
+    {[
+      let phase = phase_of_usage_ratio usage_ratio in
+      let strategies = strategies_for_phase ?summarizer phase in
+      (* apply Compose strategies to messages *)
+    ]}
+
+    Returns messages unchanged when phase is [Full]. *)
+val reduce_for_budget :
+  ?summarizer:(Types.message list -> string) ->
+  usage_ratio:float ->
+  messages:Types.message list ->
+  unit ->
+  Types.message list
+
+(** String representation of a compression phase for logging. *)
+val show_phase : compression_phase -> string

--- a/test/dune
+++ b/test/dune
@@ -748,3 +748,7 @@
 (test
  (name test_judge)
  (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_budget_strategy)
+ (libraries agent_sdk alcotest yojson str))

--- a/test/test_budget_strategy.ml
+++ b/test/test_budget_strategy.ml
@@ -1,0 +1,256 @@
+(** Tests for Budget_strategy — pure functions, no Eio needed. *)
+
+open Agent_sdk
+
+let user_msg text =
+  Types.{ role = User; content = [Text text]; name = None; tool_call_id = None }
+
+let asst_msg text =
+  Types.{ role = Assistant; content = [Text text]; name = None; tool_call_id = None }
+
+let tool_use_msg id name =
+  Types.{ role = Assistant;
+          content = [ToolUse { id; name; input = `Null }];
+          name = None; tool_call_id = None }
+
+let tool_result_msg id content =
+  Types.{ role = User;
+          content = [ToolResult { tool_use_id = id; content; is_error = false }];
+          name = None; tool_call_id = None }
+
+(* --- phase_of_usage_ratio boundary tests --- *)
+
+let test_phase_full_at_zero () =
+  let phase = Budget_strategy.phase_of_usage_ratio 0.0 in
+  Alcotest.(check string) "0.0 -> Full"
+    "Full" (Budget_strategy.show_phase phase)
+
+let test_phase_full_below_half () =
+  let phase = Budget_strategy.phase_of_usage_ratio 0.49 in
+  Alcotest.(check string) "0.49 -> Full"
+    "Full" (Budget_strategy.show_phase phase)
+
+let test_phase_compact_at_half () =
+  let phase = Budget_strategy.phase_of_usage_ratio 0.5 in
+  Alcotest.(check string) "0.5 -> Compact"
+    "Compact" (Budget_strategy.show_phase phase)
+
+let test_phase_compact_below_70 () =
+  let phase = Budget_strategy.phase_of_usage_ratio 0.69 in
+  Alcotest.(check string) "0.69 -> Compact"
+    "Compact" (Budget_strategy.show_phase phase)
+
+let test_phase_aggressive_at_70 () =
+  let phase = Budget_strategy.phase_of_usage_ratio 0.7 in
+  Alcotest.(check string) "0.7 -> Aggressive"
+    "Aggressive" (Budget_strategy.show_phase phase)
+
+let test_phase_aggressive_below_85 () =
+  let phase = Budget_strategy.phase_of_usage_ratio 0.84 in
+  Alcotest.(check string) "0.84 -> Aggressive"
+    "Aggressive" (Budget_strategy.show_phase phase)
+
+let test_phase_emergency_at_85 () =
+  let phase = Budget_strategy.phase_of_usage_ratio 0.85 in
+  Alcotest.(check string) "0.85 -> Emergency"
+    "Emergency" (Budget_strategy.show_phase phase)
+
+let test_phase_emergency_at_one () =
+  let phase = Budget_strategy.phase_of_usage_ratio 1.0 in
+  Alcotest.(check string) "1.0 -> Emergency"
+    "Emergency" (Budget_strategy.show_phase phase)
+
+let test_phase_clamp_negative () =
+  let phase = Budget_strategy.phase_of_usage_ratio (-0.5) in
+  Alcotest.(check string) "negative clamped to Full"
+    "Full" (Budget_strategy.show_phase phase)
+
+let test_phase_clamp_over_one () =
+  let phase = Budget_strategy.phase_of_usage_ratio 1.5 in
+  Alcotest.(check string) "1.5 clamped to Emergency"
+    "Emergency" (Budget_strategy.show_phase phase)
+
+(* --- strategies_for_phase --- *)
+
+let test_strategies_full_empty () =
+  let strats = Budget_strategy.strategies_for_phase Budget_strategy.Full in
+  Alcotest.(check int) "Full -> 0 strategies" 0 (List.length strats)
+
+let test_strategies_compact_has_prune () =
+  let strats = Budget_strategy.strategies_for_phase Budget_strategy.Compact in
+  Alcotest.(check int) "Compact -> 1 strategy" 1 (List.length strats);
+  match strats with
+  | [Context_reducer.Prune_tool_outputs _] -> ()
+  | _ -> Alcotest.fail "expected PruneToolOutputs"
+
+let test_strategies_aggressive_count () =
+  let strats = Budget_strategy.strategies_for_phase Budget_strategy.Aggressive in
+  Alcotest.(check int) "Aggressive -> 3 strategies" 3 (List.length strats)
+
+let test_strategies_emergency_count () =
+  let strats = Budget_strategy.strategies_for_phase Budget_strategy.Emergency in
+  Alcotest.(check int) "Emergency -> 4 strategies" 4 (List.length strats)
+
+let test_strategies_emergency_starts_with_summarize () =
+  let strats = Budget_strategy.strategies_for_phase Budget_strategy.Emergency in
+  match strats with
+  | Context_reducer.Summarize_old _ :: _ -> ()
+  | _ -> Alcotest.fail "Emergency should start with Summarize_old"
+
+(* --- reduce_for_budget --- *)
+
+let test_reduce_empty_messages () =
+  let result = Budget_strategy.reduce_for_budget
+    ~usage_ratio:0.9 ~messages:[] () in
+  Alcotest.(check int) "empty in -> empty out" 0 (List.length result)
+
+let test_reduce_full_phase_identity () =
+  let msgs = [user_msg "hello"; asst_msg "hi"] in
+  let result = Budget_strategy.reduce_for_budget
+    ~usage_ratio:0.3 ~messages:msgs () in
+  Alcotest.(check int) "Full phase preserves all"
+    (List.length msgs) (List.length result)
+
+let test_reduce_compact_truncates_tool_output () =
+  let long_output = String.make 1000 'x' in
+  let msgs = [
+    user_msg "query";
+    tool_use_msg "t1" "search";
+    tool_result_msg "t1" long_output;
+    asst_msg "done";
+  ] in
+  let result = Budget_strategy.reduce_for_budget
+    ~usage_ratio:0.6 ~messages:msgs () in
+  (* Compact phase truncates tool outputs to 500 chars *)
+  let tool_result_len = List.fold_left (fun acc (msg : Types.message) ->
+    List.fold_left (fun acc block ->
+      match block with
+      | Types.ToolResult { content; _ } -> acc + String.length content
+      | _ -> acc
+    ) acc msg.content
+  ) 0 result in
+  Alcotest.(check bool) "tool output truncated"
+    true (tool_result_len < 1000)
+
+let test_reduce_aggressive_drops_thinking () =
+  let msgs = [
+    user_msg "turn1";
+    { Types.role = Assistant;
+      content = [
+        Types.Thinking { thinking_type = "thinking"; content = "long thought" };
+        Types.Text "answer"
+      ];
+      name = None; tool_call_id = None };
+    user_msg "turn2";
+    asst_msg "response";
+  ] in
+  let result = Budget_strategy.reduce_for_budget
+    ~usage_ratio:0.75 ~messages:msgs () in
+  (* Aggressive phase drops thinking blocks from older messages *)
+  let has_thinking = List.exists (fun (msg : Types.message) ->
+    List.exists (fun block ->
+      match block with
+      | Types.Thinking _ -> true
+      | _ -> false
+    ) msg.content
+  ) result in
+  (* Drop_thinking preserves last 2 messages, so thinking in earlier messages is dropped *)
+  Alcotest.(check bool) "thinking dropped from old messages"
+    false has_thinking
+
+let test_reduce_emergency_summarizes () =
+  (* Build enough turns that Summarize_old has old messages to summarize *)
+  let msgs = List.concat (List.init 10 (fun i ->
+    [ user_msg (Printf.sprintf "question %d" i);
+      asst_msg (Printf.sprintf "answer %d" i) ]
+  )) in
+  let result = Budget_strategy.reduce_for_budget
+    ~usage_ratio:0.9 ~messages:msgs () in
+  (* Emergency: Summarize_old keeps 4 recent turns, replaces rest with summary.
+     So result should be shorter than original 20 messages.
+     Subsequent Merge_contiguous may merge the summary User msg with the
+     next User msg, so we check the summary text is present somewhere. *)
+  Alcotest.(check bool) "message count reduced"
+    true (List.length result < List.length msgs);
+  (* Summary text should appear in some message *)
+  let has_summary = List.exists (fun (msg : Types.message) ->
+    List.exists (fun block ->
+      match block with
+      | Types.Text t ->
+        (try let _ = Str.search_forward (Str.regexp_string "[Summary of") t 0 in true
+         with Not_found -> false)
+      | _ -> false
+    ) msg.content
+  ) result in
+  Alcotest.(check bool) "contains summary marker"
+    true has_summary
+
+let test_reduce_custom_summarizer () =
+  let custom_sum _msgs = "CUSTOM SUMMARY" in
+  let msgs = List.concat (List.init 10 (fun i ->
+    [ user_msg (Printf.sprintf "q%d" i);
+      asst_msg (Printf.sprintf "a%d" i) ]
+  )) in
+  let result = Budget_strategy.reduce_for_budget
+    ~summarizer:custom_sum ~usage_ratio:0.9 ~messages:msgs () in
+  (* Custom summary text should appear in some message
+     (Merge_contiguous may combine it with adjacent User messages) *)
+  let has_custom = List.exists (fun (msg : Types.message) ->
+    List.exists (fun block ->
+      match block with
+      | Types.Text t ->
+        (try let _ = Str.search_forward (Str.regexp_string "CUSTOM SUMMARY") t 0 in true
+         with Not_found -> false)
+      | _ -> false
+    ) msg.content
+  ) result in
+  Alcotest.(check bool) "contains custom summary"
+    true has_custom
+
+(* --- show_phase --- *)
+
+let test_show_phase_values () =
+  Alcotest.(check string) "Full" "Full"
+    (Budget_strategy.show_phase Budget_strategy.Full);
+  Alcotest.(check string) "Compact" "Compact"
+    (Budget_strategy.show_phase Budget_strategy.Compact);
+  Alcotest.(check string) "Aggressive" "Aggressive"
+    (Budget_strategy.show_phase Budget_strategy.Aggressive);
+  Alcotest.(check string) "Emergency" "Emergency"
+    (Budget_strategy.show_phase Budget_strategy.Emergency)
+
+(* --- Test suite --- *)
+
+let () =
+  Alcotest.run "Budget_strategy" [
+    "phase_of_usage_ratio", [
+      Alcotest.test_case "0.0 -> Full" `Quick test_phase_full_at_zero;
+      Alcotest.test_case "0.49 -> Full" `Quick test_phase_full_below_half;
+      Alcotest.test_case "0.5 -> Compact" `Quick test_phase_compact_at_half;
+      Alcotest.test_case "0.69 -> Compact" `Quick test_phase_compact_below_70;
+      Alcotest.test_case "0.7 -> Aggressive" `Quick test_phase_aggressive_at_70;
+      Alcotest.test_case "0.84 -> Aggressive" `Quick test_phase_aggressive_below_85;
+      Alcotest.test_case "0.85 -> Emergency" `Quick test_phase_emergency_at_85;
+      Alcotest.test_case "1.0 -> Emergency" `Quick test_phase_emergency_at_one;
+      Alcotest.test_case "clamp negative" `Quick test_phase_clamp_negative;
+      Alcotest.test_case "clamp >1" `Quick test_phase_clamp_over_one;
+    ];
+    "strategies_for_phase", [
+      Alcotest.test_case "Full -> empty" `Quick test_strategies_full_empty;
+      Alcotest.test_case "Compact -> prune" `Quick test_strategies_compact_has_prune;
+      Alcotest.test_case "Aggressive -> 3" `Quick test_strategies_aggressive_count;
+      Alcotest.test_case "Emergency -> 4" `Quick test_strategies_emergency_count;
+      Alcotest.test_case "Emergency starts with Summarize" `Quick test_strategies_emergency_starts_with_summarize;
+    ];
+    "reduce_for_budget", [
+      Alcotest.test_case "empty messages" `Quick test_reduce_empty_messages;
+      Alcotest.test_case "Full phase identity" `Quick test_reduce_full_phase_identity;
+      Alcotest.test_case "Compact truncates tool output" `Quick test_reduce_compact_truncates_tool_output;
+      Alcotest.test_case "Aggressive drops thinking" `Quick test_reduce_aggressive_drops_thinking;
+      Alcotest.test_case "Emergency summarizes" `Quick test_reduce_emergency_summarizes;
+      Alcotest.test_case "custom summarizer" `Quick test_reduce_custom_summarizer;
+    ];
+    "show_phase", [
+      Alcotest.test_case "all values" `Quick test_show_phase_values;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- Add `Budget_strategy` module (`lib/context/budget_strategy.ml`) that maps token budget usage ratios to progressively aggressive `Context_reducer` strategies
- 4 compression phases: Full (0-50%) -> Compact (50-70%) -> Aggressive (70-85%) -> Emergency (85%+)
- Includes default extractive summarizer for Emergency phase, with optional custom summarizer injection

## Details

Closes #357.

| Phase | Strategies | Trigger |
|-------|-----------|---------|
| Full | none | usage < 50% |
| Compact | PruneToolOutputs(500) | 50-70% |
| Aggressive | PruneToolOutputs(200), Drop_thinking, Merge_contiguous | 70-85% |
| Emergency | Summarize_old(keep=4), PruneToolOutputs(100), Drop_thinking, Merge_contiguous | 85%+ |

Note: The issue spec referenced `DropLowImportance` which does not exist in OAS. Adapted to use available strategies (`Drop_thinking`, `Merge_contiguous`).

## Test plan
- [x] 10 boundary tests for `phase_of_usage_ratio` (exact thresholds + clamping)
- [x] 5 tests for `strategies_for_phase` (count + type verification)
- [x] 6 tests for `reduce_for_budget` (empty, identity, each phase, custom summarizer)
- [x] 1 test for `show_phase`
- [x] `dune build --root .` passes
- [x] All 22 tests pass

Generated with [Claude Code](https://claude.com/claude-code)