### PR TITLE
fix: narrow catch-all to Type_error in plan.ml/durable.ml

### DIFF
--- a/lib/durable.ml
+++ b/lib/durable.ml
@@ -190,7 +190,7 @@ let journal_entry_of_json json =
          error; attempt }
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn -> Error (Printexc.to_string exn)
+  | Yojson.Safe.Util.Type_error (msg, _) -> Error msg
 
 let journal_list_to_json journal =
   `List (List.map journal_entry_to_json journal)
@@ -262,4 +262,4 @@ let execution_state_of_json json =
     | unknown -> Error (Printf.sprintf "unknown execution state: %s" unknown)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn -> Error (Printexc.to_string exn)
+  | Yojson.Safe.Util.Type_error (msg, _) -> Error msg

--- a/lib/plan.ml
+++ b/lib/plan.ml
@@ -185,7 +185,7 @@ let step_of_json json =
       }
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn -> Error (Printexc.to_string exn)
+  | Yojson.Safe.Util.Type_error (msg, _) -> Error msg
 
 let plan_status_to_json = function
   | Planning -> `Assoc [("status", `String "Planning")]
@@ -234,4 +234,4 @@ let of_json json =
          })
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn -> Error (Printexc.to_string exn)
+  | Yojson.Safe.Util.Type_error (msg, _) -> Error msg


### PR DESCRIPTION
## Summary
- Narrow `| exn -> Error (Printexc.to_string exn)` to `| Yojson.Safe.Util.Type_error (msg, _) -> Error msg` in 4 locations across `plan.ml` and `durable.ml`.
- Aligns with the convention already used in `session.ml`, `succession.ml`, `cache.ml`, and `harness_case.ml`.
- Unexpected (non-Yojson) exceptions now propagate instead of being silently converted to parse errors.

## Test plan
- [x] `dune build` passes
- [x] `test_plan.exe` 20/20 pass (including "invalid json" case)
- [x] `test_durable.exe` 20/20 pass (including "invalid json" case)

Generated with [Claude Code](https://claude.com/claude-code)