### PR TITLE
refactor(otel): replace blocking /dev/urandom with Random PRNG

### DIFF
--- a/lib/otel_tracer.ml
+++ b/lib/otel_tracer.ml
@@ -69,24 +69,23 @@ type instance = {
 
 (* -- Random hex ID generation ----------------------------------------- *)
 
+(* Trace/span IDs need uniqueness, not cryptographic strength.
+   OCaml 5.x Random is domain-safe and self-seeded from OS entropy,
+   so we avoid opening /dev/urandom on every span start. *)
+
 let hex_chars = "0123456789abcdef"
 
-let hex_of_random n =
-  let ic = open_in_bin "/dev/urandom" in
-  Fun.protect
-    ~finally:(fun () -> close_in_noerr ic)
-    (fun () ->
-      let raw = Bytes.create n in
-      really_input ic raw 0 n;
-      let hex = Buffer.create (n * 2) in
-      Bytes.iter (fun c ->
-        let byte = Char.code c in
-        Buffer.add_char hex hex_chars.[byte lsr 4];
-        Buffer.add_char hex hex_chars.[byte land 0x0f]) raw;
-      Buffer.contents hex)
+let hex_of_prng n =
+  let buf = Buffer.create (n * 2) in
+  for _ = 1 to n do
+    let byte = Random.int 256 in
+    Buffer.add_char buf hex_chars.[byte lsr 4];
+    Buffer.add_char buf hex_chars.[byte land 0x0f]
+  done;
+  Buffer.contents buf
 
-let gen_trace_id () = hex_of_random 16  (* 32-char hex = 128-bit *)
-let gen_span_id () = hex_of_random 8    (* 16-char hex = 64-bit *)
+let gen_trace_id () = hex_of_prng 16  (* 32-char hex = 128-bit *)
+let gen_span_id () = hex_of_prng 8    (* 16-char hex = 64-bit *)
 
 (* -- Timestamp -------------------------------------------------------- *)
 

--- a/test/test_otel.ml
+++ b/test/test_otel.ml
@@ -440,5 +440,27 @@ let () =
         let msg = json |> member "status" |> member "message" |> to_string in
         check int "error code 2" 2 code;
         check string "error message" "error" msg));
+
+      test_case "generated IDs are valid hex" `Quick (with_reset (fun () ->
+        let is_hex_char c = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') in
+        for _ = 1 to 20 do
+          let s = Otel_tracer.start_span (default_attrs ()) in
+          check int "trace_id length" 32 (String.length s.trace_id);
+          check int "span_id length" 16 (String.length s.span_id);
+          String.iter (fun c ->
+            check bool "trace_id hex char" true (is_hex_char c)) s.trace_id;
+          String.iter (fun c ->
+            check bool "span_id hex char" true (is_hex_char c)) s.span_id;
+          Otel_tracer.end_span s ~ok:true
+        done));
+
+      test_case "generated IDs are unique" `Quick (with_reset (fun () ->
+        let ids = List.init 50 (fun _ ->
+          let s = Otel_tracer.start_span (default_attrs ()) in
+          let id = s.span_id in
+          Otel_tracer.end_span s ~ok:true;
+          id) in
+        let unique = List.sort_uniq String.compare ids in
+        check int "all span_ids unique" (List.length ids) (List.length unique)));
     ];
   ]


### PR DESCRIPTION
## Summary
- Replace `hex_of_random` (opens `/dev/urandom` per call) with `hex_of_prng` using `Random.int` for trace/span ID generation
- Trace IDs need uniqueness, not cryptographic strength; OCaml 5.x `Random` is domain-safe and self-seeded from OS entropy
- Removes blocking I/O that can stall the Eio scheduler on every span start
- Add 2 tests: hex format validation (20 iterations) and uniqueness check (50 IDs)

## Test plan
- [x] `dune build` passes
- [x] All 41 OTel tracer tests pass (39 existing + 2 new)
- [ ] Verify trace IDs remain valid in OTLP JSON consumers

Generated with [Claude Code](https://claude.com/claude-code)