### PR TITLE
test: add 110 tests for 7 untested modules

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -752,3 +752,32 @@
 (test
  (name test_budget_strategy)
  (libraries agent_sdk alcotest yojson str))
+
+(test
+ (name test_contract)
+ (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_progressive_tools)
+ (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_context_offload)
+ (libraries agent_sdk alcotest yojson unix))
+
+(test
+ (name test_fs_result)
+ (libraries agent_sdk alcotest yojson unix))
+
+
+(test
+ (name test_succession)
+ (libraries agent_sdk alcotest yojson unix))
+
+(test
+ (name test_agent_turn_budget_unit)
+ (libraries agent_sdk alcotest yojson unix))
+
+(test
+ (name test_provider_config)
+ (libraries llm_provider alcotest yojson))

--- a/test/test_agent_turn_budget_unit.ml
+++ b/test/test_agent_turn_budget_unit.ml
@@ -1,0 +1,149 @@
+(** Tests for Agent_turn_budget — self-extending turn budget with guardrails. *)
+
+open Agent_sdk
+
+let check_string = Alcotest.(check string)
+let check_int = Alcotest.(check int)
+let check_bool = Alcotest.(check bool)
+
+(* ── create ───────────────────────────────────────────── *)
+
+let test_create_basic () =
+  let b = Agent_turn_budget.create ~initial:10 ~ceiling:50 () in
+  check_int "current_max" 10 (Agent_turn_budget.current_max b)
+
+let test_create_ceiling_at_least_initial () =
+  let b = Agent_turn_budget.create ~initial:100 ~ceiling:50 () in
+  (* ceiling should be max(ceiling, initial) = 100 *)
+  check_int "current_max" 100 (Agent_turn_budget.current_max b)
+
+(* ── try_extend ───────────────────────────────────────── *)
+
+let test_extend_success () =
+  let b = Agent_turn_budget.create ~initial:10 ~ceiling:50 () in
+  match Agent_turn_budget.try_extend b ~additional:5 ~reason:"need more" with
+  | Ok result ->
+    check_int "granted" 5 result.granted;
+    check_int "new_max" 15 result.new_max;
+    check_int "extensions_so_far" 1 result.extensions_so_far;
+    check_string "reason" "need more" result.reason;
+    check_int "current_max after" 15 (Agent_turn_budget.current_max b)
+  | Error _ -> Alcotest.fail "should succeed"
+
+let test_extend_capped_at_ceiling () =
+  let b = Agent_turn_budget.create ~initial:10 ~ceiling:12 () in
+  match Agent_turn_budget.try_extend b ~additional:5 ~reason:"test" with
+  | Ok result ->
+    check_int "granted only 2" 2 result.granted;
+    check_int "new_max at ceiling" 12 result.new_max
+  | Error _ -> Alcotest.fail "should succeed with partial"
+
+let test_extend_at_ceiling () =
+  let b = Agent_turn_budget.create ~initial:10 ~ceiling:10 () in
+  match Agent_turn_budget.try_extend b ~additional:5 ~reason:"test" with
+  | Error Agent_turn_budget.Ceiling_reached -> ()
+  | _ -> Alcotest.fail "should hit ceiling"
+
+let test_extend_exceeds_per_extend () =
+  let b = Agent_turn_budget.create ~initial:10 ~ceiling:100 ~max_per_extend:5 () in
+  match Agent_turn_budget.try_extend b ~additional:10 ~reason:"test" with
+  | Error Agent_turn_budget.Per_extend_cap_exceeded -> ()
+  | _ -> Alcotest.fail "should exceed per-extend cap"
+
+let test_extend_hits_extension_limit () =
+  let b = Agent_turn_budget.create ~initial:10 ~ceiling:100 ~max_extensions:2 () in
+  ignore (Agent_turn_budget.try_extend b ~additional:5 ~reason:"1");
+  ignore (Agent_turn_budget.try_extend b ~additional:5 ~reason:"2");
+  match Agent_turn_budget.try_extend b ~additional:5 ~reason:"3" with
+  | Error Agent_turn_budget.Extension_limit_reached -> ()
+  | _ -> Alcotest.fail "should hit extension limit"
+
+let test_extend_minimum_1 () =
+  let b = Agent_turn_budget.create ~initial:10 ~ceiling:50 () in
+  (* additional=0 should be clamped to 1 *)
+  match Agent_turn_budget.try_extend b ~additional:0 ~reason:"test" with
+  | Ok result -> check_int "granted at least 1" 1 result.granted
+  | Error _ -> Alcotest.fail "should succeed with minimum 1"
+
+(* ── denial_reason_to_string ──────────────────────────── *)
+
+let test_denial_reason_strings () =
+  check_string "ceiling" "ceiling_reached"
+    (Agent_turn_budget.denial_reason_to_string Ceiling_reached);
+  check_string "extension_limit" "extension_limit_reached"
+    (Agent_turn_budget.denial_reason_to_string Extension_limit_reached);
+  check_string "per_extend" "per_extend_cap_exceeded"
+    (Agent_turn_budget.denial_reason_to_string Per_extend_cap_exceeded);
+  check_string "idle" "agent_idle"
+    (Agent_turn_budget.denial_reason_to_string Agent_idle);
+  check_string "cost" "cost_exceeded"
+    (Agent_turn_budget.denial_reason_to_string Cost_exceeded)
+
+(* ── stats_json ───────────────────────────────────────── *)
+
+let test_stats_json () =
+  let b = Agent_turn_budget.create ~initial:10 ~ceiling:50 () in
+  ignore (Agent_turn_budget.try_extend b ~additional:5 ~reason:"r1");
+  let json = Agent_turn_budget.stats_json b in
+  let open Yojson.Safe.Util in
+  check_int "initial" 10 (json |> member "initial" |> to_int);
+  check_int "current_max" 15 (json |> member "current_max" |> to_int);
+  check_int "ceiling" 50 (json |> member "ceiling" |> to_int);
+  check_int "extensions_count" 1 (json |> member "extensions_count" |> to_int);
+  check_int "total_extended" 5 (json |> member "total_extended" |> to_int);
+  let history = json |> member "history" |> to_list in
+  check_int "1 history entry" 1 (List.length history)
+
+let test_stats_json_empty () =
+  let b = Agent_turn_budget.create ~initial:10 ~ceiling:50 () in
+  let json = Agent_turn_budget.stats_json b in
+  let open Yojson.Safe.Util in
+  check_int "0 extensions" 0 (json |> member "extensions_count" |> to_int);
+  check_int "0 total_extended" 0 (json |> member "total_extended" |> to_int);
+  let history = json |> member "history" |> to_list in
+  check_int "0 history" 0 (List.length history)
+
+(* ── multiple extensions accumulate ───────────────────── *)
+
+let test_multiple_extensions () =
+  let b = Agent_turn_budget.create ~initial:10 ~ceiling:100
+    ~max_per_extend:10 ~max_extensions:5 () in
+  ignore (Agent_turn_budget.try_extend b ~additional:5 ~reason:"r1");
+  ignore (Agent_turn_budget.try_extend b ~additional:3 ~reason:"r2");
+  ignore (Agent_turn_budget.try_extend b ~additional:7 ~reason:"r3");
+  check_int "current_max" 25 (Agent_turn_budget.current_max b);
+  let json = Agent_turn_budget.stats_json b in
+  let open Yojson.Safe.Util in
+  check_int "extensions_count" 3 (json |> member "extensions_count" |> to_int);
+  check_int "total_extended" 15 (json |> member "total_extended" |> to_int);
+  let _history = json |> member "history" |> to_list in
+  check_bool "3 history entries" true
+    (List.length _history = 3)
+
+(* ── Suite ────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "agent_turn_budget" [
+    "create", [
+      Alcotest.test_case "basic" `Quick test_create_basic;
+      Alcotest.test_case "ceiling >= initial" `Quick test_create_ceiling_at_least_initial;
+    ];
+    "try_extend", [
+      Alcotest.test_case "success" `Quick test_extend_success;
+      Alcotest.test_case "capped at ceiling" `Quick test_extend_capped_at_ceiling;
+      Alcotest.test_case "at ceiling" `Quick test_extend_at_ceiling;
+      Alcotest.test_case "per_extend cap" `Quick test_extend_exceeds_per_extend;
+      Alcotest.test_case "extension limit" `Quick test_extend_hits_extension_limit;
+      Alcotest.test_case "minimum 1" `Quick test_extend_minimum_1;
+    ];
+    "denial_reason", [
+      Alcotest.test_case "to_string" `Quick test_denial_reason_strings;
+    ];
+    "stats_json", [
+      Alcotest.test_case "with extensions" `Quick test_stats_json;
+      Alcotest.test_case "empty" `Quick test_stats_json_empty;
+    ];
+    "accumulation", [
+      Alcotest.test_case "multiple" `Quick test_multiple_extensions;
+    ];
+  ]

--- a/test/test_context_offload.ml
+++ b/test/test_context_offload.ml
@@ -1,0 +1,136 @@
+(** Tests for Context_offload — offloading large tool results to files. *)
+
+open Agent_sdk
+
+let check_string = Alcotest.(check string)
+let check_bool = Alcotest.(check bool)
+let check_int = Alcotest.(check int)
+
+(* ── default_config ───────────────────────────────────── *)
+
+let test_default_config () =
+  let c = Context_offload.default_config in
+  check_int "threshold" 4096 c.threshold_bytes;
+  check_int "preview_len" 200 c.preview_len;
+  check_bool "output_dir non-empty" true (String.length c.output_dir > 0)
+
+(* ── maybe_offload: below threshold ───────────────────── *)
+
+let test_kept_below_threshold () =
+  let config : Context_offload.config = {
+    threshold_bytes = 100;
+    output_dir = Filename.get_temp_dir_name ();
+    preview_len = 20;
+  } in
+  let content = "short content" in
+  match Context_offload.maybe_offload ~config ~tool_name:"test" content with
+  | Context_offload.Kept c -> check_string "unchanged" content c
+  | Context_offload.Offloaded _ -> Alcotest.fail "should not offload"
+
+let test_kept_at_exact_threshold () =
+  let content = String.make 50 'x' in
+  let config : Context_offload.config = {
+    threshold_bytes = 50;
+    output_dir = Filename.get_temp_dir_name ();
+    preview_len = 10;
+  } in
+  match Context_offload.maybe_offload ~config ~tool_name:"test" content with
+  | Context_offload.Kept _ -> ()
+  | Context_offload.Offloaded _ -> Alcotest.fail "at threshold should keep"
+
+(* ── maybe_offload: above threshold ───────────────────── *)
+
+let test_offloaded_above_threshold () =
+  let content = String.make 200 'z' in
+  let config : Context_offload.config = {
+    threshold_bytes = 50;
+    output_dir = Filename.get_temp_dir_name ();
+    preview_len = 20;
+  } in
+  match Context_offload.maybe_offload ~config ~tool_name:"my_tool" content with
+  | Context_offload.Offloaded { path; preview; original_bytes } ->
+    check_int "original_bytes" 200 original_bytes;
+    check_int "preview length" 20 (String.length preview);
+    check_bool "path contains tool name" true
+      (Util.string_contains ~needle:"my_tool" path);
+    (* Clean up *)
+    (try Sys.remove path with _ -> ())
+  | Context_offload.Kept _ -> Alcotest.fail "should offload"
+
+(* ── maybe_offload: fail-open on bad dir ──────────────── *)
+
+let test_failopen_bad_dir () =
+  let content = String.make 200 'a' in
+  let config : Context_offload.config = {
+    threshold_bytes = 50;
+    output_dir = "/nonexistent/dir/that/does/not/exist";
+    preview_len = 10;
+  } in
+  match Context_offload.maybe_offload ~config ~tool_name:"test" content with
+  | Context_offload.Kept c -> check_int "original content" 200 (String.length c)
+  | Context_offload.Offloaded _ -> Alcotest.fail "should fail open"
+
+(* ── to_context_string ────────────────────────────────── *)
+
+let test_to_context_string_kept () =
+  let result = Context_offload.to_context_string (Kept "hello") in
+  check_string "kept unchanged" "hello" result
+
+let test_to_context_string_offloaded () =
+  let result = Context_offload.to_context_string
+    (Offloaded { path = "/tmp/f.txt"; preview = "prev"; original_bytes = 5000 }) in
+  check_bool "contains path" true (Util.string_contains ~needle:"/tmp/f.txt" result);
+  check_bool "contains bytes" true (Util.string_contains ~needle:"5000" result);
+  check_bool "contains preview" true (Util.string_contains ~needle:"prev" result)
+
+(* ── offload_tool_result (convenience) ────────────────── *)
+
+let test_offload_tool_result_small () =
+  let config : Context_offload.config = {
+    threshold_bytes = 1000;
+    output_dir = Filename.get_temp_dir_name ();
+    preview_len = 50;
+  } in
+  let result = Context_offload.offload_tool_result ~config ~tool_name:"t" "small" in
+  check_string "small unchanged" "small" result
+
+(* ── tool_name sanitization ───────────────────────────── *)
+
+let test_tool_name_with_slash () =
+  let content = String.make 200 'b' in
+  let config : Context_offload.config = {
+    threshold_bytes = 50;
+    output_dir = Filename.get_temp_dir_name ();
+    preview_len = 10;
+  } in
+  match Context_offload.maybe_offload ~config ~tool_name:"ns/tool" content with
+  | Context_offload.Offloaded { path; _ } ->
+    (* slash should be replaced with underscore *)
+    let basename = Filename.basename path in
+    check_bool "no slash in filename" false
+      (Util.string_contains ~needle:"/" basename);
+    (try Sys.remove path with _ -> ())
+  | Context_offload.Kept _ -> Alcotest.fail "should offload"
+
+(* ── Suite ────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "context_offload" [
+    "default_config", [
+      Alcotest.test_case "default values" `Quick test_default_config;
+    ];
+    "maybe_offload", [
+      Alcotest.test_case "below threshold" `Quick test_kept_below_threshold;
+      Alcotest.test_case "at threshold" `Quick test_kept_at_exact_threshold;
+      Alcotest.test_case "above threshold" `Quick test_offloaded_above_threshold;
+      Alcotest.test_case "fail-open bad dir" `Quick test_failopen_bad_dir;
+      Alcotest.test_case "tool name with slash" `Quick test_tool_name_with_slash;
+    ];
+    "to_context_string", [
+      Alcotest.test_case "kept" `Quick test_to_context_string_kept;
+      Alcotest.test_case "offloaded" `Quick test_to_context_string_offloaded;
+    ];
+    "convenience", [
+      Alcotest.test_case "offload_tool_result small" `Quick test_offload_tool_result_small;
+    ];
+  ]

--- a/test/test_contract.ml
+++ b/test/test_contract.ml
@@ -1,0 +1,286 @@
+(** Tests for Contract module — runtime contract helpers. *)
+
+open Agent_sdk
+
+(* ── Helpers ──────────────────────────────────────────── *)
+
+let check_string = Alcotest.(check string)
+let check_bool = Alcotest.(check bool)
+let check_int = Alcotest.(check int)
+
+(* ── empty ────────────────────────────────────────────── *)
+
+let test_empty_contract () =
+  let c = Contract.empty in
+  check_bool "runtime_awareness is None" true (c.runtime_awareness = None);
+  check_bool "trigger is None" true (c.trigger = None);
+  check_int "instruction_layers is empty" 0 (List.length c.instruction_layers);
+  check_int "skills is empty" 0 (List.length c.skills);
+  check_bool "tool_grants is None" true (c.tool_grants = None);
+  check_bool "mcp_tool_allowlist is None" true (c.mcp_tool_allowlist = None)
+
+let test_is_empty_on_empty () =
+  check_bool "empty is empty" true (Contract.is_empty Contract.empty)
+
+let test_is_empty_with_awareness () =
+  let c = Contract.with_runtime_awareness "test" Contract.empty in
+  check_bool "not empty with awareness" false (Contract.is_empty c)
+
+(* ── with_runtime_awareness ───────────────────────────── *)
+
+let test_runtime_awareness_set () =
+  let c = Contract.with_runtime_awareness "aware" Contract.empty in
+  check_bool "awareness set" true (c.runtime_awareness = Some "aware")
+
+let test_runtime_awareness_empty_string () =
+  let c = Contract.with_runtime_awareness "" Contract.empty in
+  check_bool "empty string -> None" true (c.runtime_awareness = None)
+
+let test_runtime_awareness_whitespace () =
+  let c = Contract.with_runtime_awareness "   " Contract.empty in
+  check_bool "whitespace -> None" true (c.runtime_awareness = None)
+
+let test_runtime_awareness_trimmed () =
+  let c = Contract.with_runtime_awareness "  hello  " Contract.empty in
+  check_bool "trimmed" true (c.runtime_awareness = Some "hello")
+
+(* ── with_trigger ─────────────────────────────────────── *)
+
+let test_trigger_basic () =
+  let c = Contract.with_trigger "heartbeat" Contract.empty in
+  match c.trigger with
+  | Some t ->
+    check_string "kind" "heartbeat" t.kind;
+    check_bool "source None" true (t.source = None);
+    check_bool "reason None" true (t.reason = None);
+    check_bool "payload None" true (t.payload = None)
+  | None -> Alcotest.fail "expected trigger"
+
+let test_trigger_with_options () =
+  let c = Contract.with_trigger ~source:"cron" ~reason:"scheduled"
+    ~payload:(`String "data") "heartbeat" Contract.empty in
+  match c.trigger with
+  | Some t ->
+    check_string "kind" "heartbeat" t.kind;
+    check_bool "source" true (t.source = Some "cron");
+    check_bool "reason" true (t.reason = Some "scheduled");
+    check_bool "payload" true (t.payload = Some (`String "data"))
+  | None -> Alcotest.fail "expected trigger"
+
+let test_trigger_empty_kind_ignored () =
+  let c = Contract.with_trigger "" Contract.empty in
+  check_bool "empty kind -> no trigger" true (c.trigger = None)
+
+let test_trigger_whitespace_source_trimmed () =
+  let c = Contract.with_trigger ~source:"  " "test" Contract.empty in
+  match c.trigger with
+  | Some t -> check_bool "source trimmed to None" true (t.source = None)
+  | None -> Alcotest.fail "expected trigger"
+
+(* ── add_instruction_layer ────────────────────────────── *)
+
+let test_instruction_layer () =
+  let c = Contract.add_instruction_layer ~label:"L1" "content1" Contract.empty in
+  check_int "one layer" 1 (List.length c.instruction_layers);
+  let layer = List.hd c.instruction_layers in
+  check_bool "label" true (layer.label = Some "L1");
+  check_string "content" "content1" layer.content
+
+let test_instruction_layer_no_label () =
+  let c = Contract.add_instruction_layer "content" Contract.empty in
+  let layer = List.hd c.instruction_layers in
+  check_bool "no label" true (layer.label = None)
+
+let test_instruction_layer_empty_content () =
+  let c = Contract.add_instruction_layer "" Contract.empty in
+  check_int "empty content -> no layer" 0 (List.length c.instruction_layers)
+
+let test_instruction_layer_stacks () =
+  let c = Contract.empty
+    |> Contract.add_instruction_layer "first"
+    |> Contract.add_instruction_layer "second" in
+  check_int "two layers" 2 (List.length c.instruction_layers)
+
+(* ── normalize_names ──────────────────────────────────── *)
+
+let test_with_tool_grants () =
+  let c = Contract.with_tool_grants ["a"; "b"; "a"; "  c  "; ""] Contract.empty in
+  match c.tool_grants with
+  | Some names ->
+    check_int "deduped + trimmed" 3 (List.length names);
+    check_bool "contains a" true (List.mem "a" names);
+    check_bool "contains b" true (List.mem "b" names);
+    check_bool "contains c" true (List.mem "c" names)
+  | None -> Alcotest.fail "expected tool_grants"
+
+let test_with_mcp_allowlist () =
+  let c = Contract.with_mcp_tool_allowlist ["x"; "y"] Contract.empty in
+  match c.mcp_tool_allowlist with
+  | Some names -> check_int "2 names" 2 (List.length names)
+  | None -> Alcotest.fail "expected allowlist"
+
+(* ── merge ────────────────────────────────────────────── *)
+
+let test_merge_right_wins_awareness () =
+  let left = Contract.with_runtime_awareness "left" Contract.empty in
+  let right = Contract.with_runtime_awareness "right" Contract.empty in
+  let merged = Contract.merge left right in
+  check_bool "right wins" true (merged.runtime_awareness = Some "right")
+
+let test_merge_left_when_right_none () =
+  let left = Contract.with_runtime_awareness "left" Contract.empty in
+  let merged = Contract.merge left Contract.empty in
+  check_bool "left preserved" true (merged.runtime_awareness = Some "left")
+
+let test_merge_instruction_layers_concat () =
+  let left = Contract.add_instruction_layer "a" Contract.empty in
+  let right = Contract.add_instruction_layer "b" Contract.empty in
+  let merged = Contract.merge left right in
+  check_int "layers concatenated" 2 (List.length merged.instruction_layers)
+
+let test_merge_tool_grants_right_wins () =
+  let left = Contract.with_tool_grants ["a"] Contract.empty in
+  let right = Contract.with_tool_grants ["b"] Contract.empty in
+  let merged = Contract.merge left right in
+  match merged.tool_grants with
+  | Some ["b"] -> ()
+  | _ -> Alcotest.fail "right tool_grants should win"
+
+(* ── to_json / compose_system_prompt ──────────────────── *)
+
+let test_to_json_empty () =
+  let json = Contract.to_json Contract.empty in
+  let open Yojson.Safe.Util in
+  check_bool "runtime_awareness null" true
+    (json |> member "runtime_awareness" = `Null);
+  check_bool "trigger null" true
+    (json |> member "trigger" = `Null)
+
+let test_to_json_with_trigger () =
+  let c = Contract.with_trigger ~source:"s" "test" Contract.empty in
+  let json = Contract.to_json c in
+  let trigger_json = Yojson.Safe.Util.member "trigger" json in
+  let kind = Yojson.Safe.Util.(member "kind" trigger_json |> to_string) in
+  check_string "kind" "test" kind
+
+let test_compose_system_prompt_empty () =
+  let result = Contract.compose_system_prompt Contract.empty in
+  check_bool "empty contract -> None" true (result = None)
+
+let test_compose_system_prompt_with_awareness () =
+  let c = Contract.with_runtime_awareness "hello" Contract.empty in
+  match Contract.compose_system_prompt c with
+  | Some s -> check_bool "contains awareness" true
+    (String.length s > 0)
+  | None -> Alcotest.fail "expected prompt"
+
+let test_compose_system_prompt_with_base () =
+  let c = Contract.with_runtime_awareness "extra" Contract.empty in
+  match Contract.compose_system_prompt ~base:"base prompt" c with
+  | Some s ->
+    check_bool "contains base" true
+      (Util.string_contains ~needle:"base prompt" s);
+    check_bool "contains awareness" true
+      (Util.string_contains ~needle:"extra" s)
+  | None -> Alcotest.fail "expected prompt"
+
+let test_compose_system_prompt_with_trigger () =
+  let c = Contract.with_trigger ~source:"cron" ~reason:"timer" "heartbeat" Contract.empty in
+  match Contract.compose_system_prompt c with
+  | Some s ->
+    check_bool "contains trigger" true
+      (Util.string_contains ~needle:"heartbeat" s);
+    check_bool "contains source" true
+      (Util.string_contains ~needle:"cron" s)
+  | None -> Alcotest.fail "expected prompt"
+
+(* ── filter_tools ─────────────────────────────────────── *)
+
+let test_filter_tools_none_grants () =
+  let tools = [
+    Tool.create ~name:"a" ~description:"" ~parameters:[] (fun _ -> Ok { Types.content = "" });
+    Tool.create ~name:"b" ~description:"" ~parameters:[] (fun _ -> Ok { Types.content = "" });
+  ] in
+  let filtered = Contract.filter_tools Contract.empty tools in
+  check_int "no filter -> all tools" 2 (List.length filtered)
+
+let test_filter_tools_with_grants () =
+  let tools = [
+    Tool.create ~name:"a" ~description:"" ~parameters:[] (fun _ -> Ok { Types.content = "" });
+    Tool.create ~name:"b" ~description:"" ~parameters:[] (fun _ -> Ok { Types.content = "" });
+    Tool.create ~name:"c" ~description:"" ~parameters:[] (fun _ -> Ok { Types.content = "" });
+  ] in
+  let c = Contract.with_tool_grants ["a"; "c"] Contract.empty in
+  let filtered = Contract.filter_tools c tools in
+  check_int "filtered to 2" 2 (List.length filtered)
+
+(* ── context_with_contract ────────────────────────────── *)
+
+let test_context_with_contract_empty () =
+  let result = Contract.context_with_contract Contract.empty in
+  check_bool "empty contract -> None" true (result = None)
+
+let test_context_with_contract_non_empty () =
+  let c = Contract.with_runtime_awareness "test" Contract.empty in
+  match Contract.context_with_contract c with
+  | Some ctx ->
+    let value = Context.get ctx Contract.context_key in
+    check_bool "has value" true (value <> None)
+  | None -> Alcotest.fail "expected context"
+
+(* ── Suite ────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "contract" [
+    "empty", [
+      Alcotest.test_case "empty contract" `Quick test_empty_contract;
+      Alcotest.test_case "is_empty on empty" `Quick test_is_empty_on_empty;
+      Alcotest.test_case "is_empty with awareness" `Quick test_is_empty_with_awareness;
+    ];
+    "runtime_awareness", [
+      Alcotest.test_case "set awareness" `Quick test_runtime_awareness_set;
+      Alcotest.test_case "empty string" `Quick test_runtime_awareness_empty_string;
+      Alcotest.test_case "whitespace" `Quick test_runtime_awareness_whitespace;
+      Alcotest.test_case "trimmed" `Quick test_runtime_awareness_trimmed;
+    ];
+    "trigger", [
+      Alcotest.test_case "basic" `Quick test_trigger_basic;
+      Alcotest.test_case "with options" `Quick test_trigger_with_options;
+      Alcotest.test_case "empty kind ignored" `Quick test_trigger_empty_kind_ignored;
+      Alcotest.test_case "whitespace source trimmed" `Quick test_trigger_whitespace_source_trimmed;
+    ];
+    "instruction_layer", [
+      Alcotest.test_case "with label" `Quick test_instruction_layer;
+      Alcotest.test_case "no label" `Quick test_instruction_layer_no_label;
+      Alcotest.test_case "empty content" `Quick test_instruction_layer_empty_content;
+      Alcotest.test_case "stacks" `Quick test_instruction_layer_stacks;
+    ];
+    "tool_grants", [
+      Alcotest.test_case "with_tool_grants" `Quick test_with_tool_grants;
+      Alcotest.test_case "with_mcp_allowlist" `Quick test_with_mcp_allowlist;
+    ];
+    "merge", [
+      Alcotest.test_case "right wins awareness" `Quick test_merge_right_wins_awareness;
+      Alcotest.test_case "left when right None" `Quick test_merge_left_when_right_none;
+      Alcotest.test_case "layers concat" `Quick test_merge_instruction_layers_concat;
+      Alcotest.test_case "tool_grants right wins" `Quick test_merge_tool_grants_right_wins;
+    ];
+    "json", [
+      Alcotest.test_case "to_json empty" `Quick test_to_json_empty;
+      Alcotest.test_case "to_json with trigger" `Quick test_to_json_with_trigger;
+    ];
+    "compose_system_prompt", [
+      Alcotest.test_case "empty" `Quick test_compose_system_prompt_empty;
+      Alcotest.test_case "with awareness" `Quick test_compose_system_prompt_with_awareness;
+      Alcotest.test_case "with base" `Quick test_compose_system_prompt_with_base;
+      Alcotest.test_case "with trigger" `Quick test_compose_system_prompt_with_trigger;
+    ];
+    "filter", [
+      Alcotest.test_case "no grants" `Quick test_filter_tools_none_grants;
+      Alcotest.test_case "with grants" `Quick test_filter_tools_with_grants;
+    ];
+    "context", [
+      Alcotest.test_case "empty contract" `Quick test_context_with_contract_empty;
+      Alcotest.test_case "non-empty contract" `Quick test_context_with_contract_non_empty;
+    ];
+  ]

--- a/test/test_fs_result.ml
+++ b/test/test_fs_result.ml
@@ -1,0 +1,182 @@
+(** Tests for Fs_result — result-based filesystem operations. *)
+
+open Agent_sdk
+
+let check_string = Alcotest.(check string)
+let check_bool = Alcotest.(check bool)
+
+(* ── read_file ────────────────────────────────────────── *)
+
+let test_read_file_success () =
+  let path = Filename.temp_file "fs_test_" ".txt" in
+  let oc = open_out path in
+  output_string oc "hello world";
+  close_out oc;
+  Fun.protect ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      match Fs_result.read_file path with
+      | Ok content -> check_string "content" "hello world" content
+      | Error _ -> Alcotest.fail "should succeed")
+
+let test_read_file_nonexistent () =
+  match Fs_result.read_file "/nonexistent/path/file.txt" with
+  | Error (Error.Io (FileOpFailed { op; _ })) ->
+    check_string "op" "read" op
+  | Error _ -> Alcotest.fail "wrong error type"
+  | Ok _ -> Alcotest.fail "should fail"
+
+(* ── write_file ───────────────────────────────────────── *)
+
+let test_write_file_success () =
+  let dir = Filename.get_temp_dir_name () in
+  let path = Filename.concat dir
+    (Printf.sprintf "fs_write_test_%d.txt" (int_of_float (Unix.gettimeofday () *. 1000.0))) in
+  Fun.protect ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      match Fs_result.write_file path "test content" with
+      | Ok () ->
+        (match Fs_result.read_file path with
+         | Ok content -> check_string "written content" "test content" content
+         | Error _ -> Alcotest.fail "read back failed")
+      | Error _ -> Alcotest.fail "write should succeed")
+
+let test_write_file_creates_dirs () =
+  let base = Filename.get_temp_dir_name () in
+  let nested = Filename.concat base
+    (Printf.sprintf "fs_test_nested_%d/sub" (int_of_float (Unix.gettimeofday () *. 1000.0))) in
+  let path = Filename.concat nested "file.txt" in
+  Fun.protect ~finally:(fun () ->
+    (try Sys.remove path with _ -> ());
+    (try Sys.rmdir nested with _ -> ());
+    (try Sys.rmdir (Filename.dirname nested) with _ -> ()))
+    (fun () ->
+      match Fs_result.write_file path "nested content" with
+      | Ok () ->
+        check_bool "file exists" true (Fs_result.file_exists path)
+      | Error _ -> Alcotest.fail "write should create dirs")
+
+(* ── append_file ──────────────────────────────────────── *)
+
+let test_append_file () =
+  let path = Filename.temp_file "fs_append_" ".txt" in
+  Fun.protect ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      ignore (Fs_result.write_file path "line1\n");
+      ignore (Fs_result.append_file path "line2\n");
+      match Fs_result.read_file path with
+      | Ok content -> check_string "appended" "line1\nline2\n" content
+      | Error _ -> Alcotest.fail "read failed")
+
+(* ── ensure_dir ───────────────────────────────────────── *)
+
+let test_ensure_dir_existing () =
+  match Fs_result.ensure_dir (Filename.get_temp_dir_name ()) with
+  | Ok () -> ()
+  | Error _ -> Alcotest.fail "should succeed for existing dir"
+
+let test_ensure_dir_new () =
+  let path = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "fs_ensure_%d" (int_of_float (Unix.gettimeofday () *. 1000.0))) in
+  Fun.protect ~finally:(fun () -> try Sys.rmdir path with _ -> ())
+    (fun () ->
+      match Fs_result.ensure_dir path with
+      | Ok () -> check_bool "dir exists" true (Sys.file_exists path)
+      | Error _ -> Alcotest.fail "should succeed")
+
+(* ── file_exists ──────────────────────────────────────── *)
+
+let test_file_exists_true () =
+  let path = Filename.temp_file "fs_exists_" ".txt" in
+  Fun.protect ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      check_bool "exists" true (Fs_result.file_exists path))
+
+let test_file_exists_false () =
+  check_bool "not exists" false
+    (Fs_result.file_exists "/nonexistent/path/file.xyz")
+
+let test_file_exists_directory () =
+  check_bool "directory is not file" false
+    (Fs_result.file_exists (Filename.get_temp_dir_name ()))
+
+(* ── remove_file ──────────────────────────────────────── *)
+
+let test_remove_file_success () =
+  let path = Filename.temp_file "fs_remove_" ".txt" in
+  match Fs_result.remove_file path with
+  | Ok () -> check_bool "removed" false (Fs_result.file_exists path)
+  | Error _ -> Alcotest.fail "should succeed"
+
+let test_remove_file_nonexistent () =
+  match Fs_result.remove_file "/nonexistent/file.txt" with
+  | Ok () -> ()  (* remove_file succeeds if file doesn't exist *)
+  | Error _ -> Alcotest.fail "should succeed for nonexistent"
+
+(* ── read_dir ─────────────────────────────────────────── *)
+
+let test_read_dir_success () =
+  let dir = Filename.get_temp_dir_name () in
+  match Fs_result.read_dir dir with
+  | Ok entries -> check_bool "has entries" true (List.length entries >= 0)
+  | Error _ -> Alcotest.fail "should succeed"
+
+let test_read_dir_nonexistent () =
+  match Fs_result.read_dir "/nonexistent/dir" with
+  | Error (Error.Io (FileOpFailed { op; _ })) ->
+    check_string "op" "read_dir" op
+  | Error _ -> Alcotest.fail "wrong error type"
+  | Ok _ -> Alcotest.fail "should fail"
+
+(* ── io_error_of_exn ──────────────────────────────────── *)
+
+let test_io_error_of_exn_sys_error () =
+  match Fs_result.io_error_of_exn ~op:"test" ~path:"/x" (Sys_error "boom") with
+  | Error (Error.Io (FileOpFailed { op; path; detail })) ->
+    check_string "op" "test" op;
+    check_string "path" "/x" path;
+    check_string "detail" "boom" detail
+  | _ -> Alcotest.fail "expected FileOpFailed"
+
+let test_io_error_of_exn_failure () =
+  match Fs_result.io_error_of_exn ~op:"w" ~path:"/y" (Failure "bad") with
+  | Error (Error.Io (FileOpFailed { detail; _ })) ->
+    check_string "detail" "bad" detail
+  | _ -> Alcotest.fail "expected FileOpFailed"
+
+(* ── Suite ────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "fs_result" [
+    "read_file", [
+      Alcotest.test_case "success" `Quick test_read_file_success;
+      Alcotest.test_case "nonexistent" `Quick test_read_file_nonexistent;
+    ];
+    "write_file", [
+      Alcotest.test_case "success" `Quick test_write_file_success;
+      Alcotest.test_case "creates dirs" `Quick test_write_file_creates_dirs;
+    ];
+    "append_file", [
+      Alcotest.test_case "append" `Quick test_append_file;
+    ];
+    "ensure_dir", [
+      Alcotest.test_case "existing" `Quick test_ensure_dir_existing;
+      Alcotest.test_case "new" `Quick test_ensure_dir_new;
+    ];
+    "file_exists", [
+      Alcotest.test_case "true" `Quick test_file_exists_true;
+      Alcotest.test_case "false" `Quick test_file_exists_false;
+      Alcotest.test_case "directory" `Quick test_file_exists_directory;
+    ];
+    "remove_file", [
+      Alcotest.test_case "success" `Quick test_remove_file_success;
+      Alcotest.test_case "nonexistent" `Quick test_remove_file_nonexistent;
+    ];
+    "read_dir", [
+      Alcotest.test_case "success" `Quick test_read_dir_success;
+      Alcotest.test_case "nonexistent" `Quick test_read_dir_nonexistent;
+    ];
+    "io_error_of_exn", [
+      Alcotest.test_case "sys_error" `Quick test_io_error_of_exn_sys_error;
+      Alcotest.test_case "failure" `Quick test_io_error_of_exn_failure;
+    ];
+  ]

--- a/test/test_progressive_tools.ml
+++ b/test/test_progressive_tools.ml
@@ -1,0 +1,149 @@
+(** Tests for Progressive_tools — progressive tool disclosure. *)
+
+open Agent_sdk
+
+let check_int = Alcotest.(check int)
+let check_bool = Alcotest.(check bool)
+
+(* ── Phase_based ──────────────────────────────────────── *)
+
+let test_phase_based_empty_phases () =
+  let strategy = Progressive_tools.Phase_based { phases = [] } in
+  let tools = Progressive_tools.tools_for_turn strategy 0 in
+  check_int "no phases -> empty" 0 (List.length tools)
+
+let test_phase_based_single_phase () =
+  let strategy = Progressive_tools.Phase_based {
+    phases = [(0, ["read"; "search"])]
+  } in
+  let tools = Progressive_tools.tools_for_turn strategy 0 in
+  check_int "turn 0" 2 (List.length tools);
+  let tools5 = Progressive_tools.tools_for_turn strategy 5 in
+  check_int "turn 5 same" 2 (List.length tools5)
+
+let test_phase_based_multi_phase () =
+  let strategy = Progressive_tools.Phase_based {
+    phases = [
+      (0, ["read"]);
+      (3, ["read"; "write"]);
+      (6, ["read"; "write"; "deploy"]);
+    ]
+  } in
+  let t0 = Progressive_tools.tools_for_turn strategy 0 in
+  check_int "turn 0: 1 tool" 1 (List.length t0);
+  let t3 = Progressive_tools.tools_for_turn strategy 3 in
+  check_int "turn 3: 2 tools" 2 (List.length t3);
+  let t6 = Progressive_tools.tools_for_turn strategy 6 in
+  check_int "turn 6: 3 tools" 3 (List.length t6);
+  let t10 = Progressive_tools.tools_for_turn strategy 10 in
+  check_int "turn 10: 3 tools (highest phase)" 3 (List.length t10)
+
+let test_phase_based_below_first_threshold () =
+  let strategy = Progressive_tools.Phase_based {
+    phases = [(5, ["a"; "b"])]
+  } in
+  let tools = Progressive_tools.tools_for_turn strategy 2 in
+  check_int "below threshold -> empty" 0 (List.length tools)
+
+(* ── Gather_act_verify ────────────────────────────────── *)
+
+let test_gav_gather_phase () =
+  let strategy = Progressive_tools.Gather_act_verify {
+    gather_tools = ["search"; "read"];
+    act_tools = ["write"; "execute"];
+    verify_tools = ["test"; "lint"];
+  } in
+  let t1 = Progressive_tools.tools_for_turn strategy 1 in
+  check_int "turn 1: gather only" 2 (List.length t1);
+  check_bool "has search" true (List.mem "search" t1);
+  check_bool "has read" true (List.mem "read" t1)
+
+let test_gav_act_phase () =
+  let strategy = Progressive_tools.Gather_act_verify {
+    gather_tools = ["search"];
+    act_tools = ["write"];
+    verify_tools = ["test"];
+  } in
+  let t3 = Progressive_tools.tools_for_turn strategy 3 in
+  check_int "turn 3: gather + act" 2 (List.length t3);
+  check_bool "has search" true (List.mem "search" t3);
+  check_bool "has write" true (List.mem "write" t3)
+
+let test_gav_verify_phase () =
+  let strategy = Progressive_tools.Gather_act_verify {
+    gather_tools = ["search"];
+    act_tools = ["write"];
+    verify_tools = ["test"];
+  } in
+  let t6 = Progressive_tools.tools_for_turn strategy 6 in
+  check_int "turn 6: all" 3 (List.length t6);
+  check_bool "has test" true (List.mem "test" t6)
+
+let test_gav_boundary_turns () =
+  let strategy = Progressive_tools.Gather_act_verify {
+    gather_tools = ["g"];
+    act_tools = ["a"];
+    verify_tools = ["v"];
+  } in
+  (* turn <= 2 = gather *)
+  let t2 = Progressive_tools.tools_for_turn strategy 2 in
+  check_int "turn 2: gather" 1 (List.length t2);
+  (* turn 3-5 = gather + act *)
+  let t5 = Progressive_tools.tools_for_turn strategy 5 in
+  check_int "turn 5: gather+act" 2 (List.length t5);
+  (* turn 6+ = all *)
+  let t6 = Progressive_tools.tools_for_turn strategy 6 in
+  check_int "turn 6: all" 3 (List.length t6)
+
+(* ── as_hook ──────────────────────────────────────────── *)
+
+let test_as_hook_returns_adjust_params () =
+  let strategy = Progressive_tools.Phase_based {
+    phases = [(0, ["tool_a"])]
+  } in
+  let hook = Progressive_tools.as_hook strategy in
+  let event = Hooks.BeforeTurnParams {
+    turn = 0;
+    messages = [];
+    last_tool_results = [];
+    current_params = Hooks.default_turn_params;
+    reasoning = Hooks.empty_reasoning_summary;
+  } in
+  match hook event with
+  | Hooks.AdjustParams params ->
+    (match params.tool_filter_override with
+     | Some (Guardrails.AllowList lst) ->
+       check_int "1 tool" 1 (List.length lst);
+       check_bool "tool_a" true (List.mem "tool_a" lst)
+     | _ -> Alcotest.fail "expected AllowList")
+  | _ -> Alcotest.fail "expected AdjustParams"
+
+let test_as_hook_non_before_turn_params () =
+  let strategy = Progressive_tools.Phase_based { phases = [] } in
+  let hook = Progressive_tools.as_hook strategy in
+  let event = Hooks.BeforeTurn { turn = 0; messages = [] } in
+  match hook event with
+  | Hooks.Continue -> ()
+  | _ -> Alcotest.fail "expected Continue for non-BeforeTurnParams events"
+
+(* ── Suite ────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "progressive_tools" [
+    "phase_based", [
+      Alcotest.test_case "empty phases" `Quick test_phase_based_empty_phases;
+      Alcotest.test_case "single phase" `Quick test_phase_based_single_phase;
+      Alcotest.test_case "multi phase" `Quick test_phase_based_multi_phase;
+      Alcotest.test_case "below threshold" `Quick test_phase_based_below_first_threshold;
+    ];
+    "gather_act_verify", [
+      Alcotest.test_case "gather phase" `Quick test_gav_gather_phase;
+      Alcotest.test_case "act phase" `Quick test_gav_act_phase;
+      Alcotest.test_case "verify phase" `Quick test_gav_verify_phase;
+      Alcotest.test_case "boundary turns" `Quick test_gav_boundary_turns;
+    ];
+    "as_hook", [
+      Alcotest.test_case "returns AdjustParams" `Quick test_as_hook_returns_adjust_params;
+      Alcotest.test_case "non-BeforeTurnParams" `Quick test_as_hook_non_before_turn_params;
+    ];
+  ]

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -1,0 +1,129 @@
+(** Tests for Provider_config — lightweight provider configuration. *)
+
+open Llm_provider
+
+let check_string = Alcotest.(check string)
+let check_int = Alcotest.(check int)
+let check_bool = Alcotest.(check bool)
+
+(* ── make: defaults ───────────────────────────────────── *)
+
+let test_make_defaults () =
+  let cfg = Provider_config.make ~kind:OpenAI_compat
+    ~model_id:"test" ~base_url:"http://localhost:8080" () in
+  check_string "model_id" "test" cfg.model_id;
+  check_string "base_url" "http://localhost:8080" cfg.base_url;
+  check_string "api_key default empty" "" cfg.api_key;
+  check_int "max_tokens default" 4096 cfg.max_tokens;
+  check_bool "temperature None" true (cfg.temperature = None);
+  check_bool "top_p None" true (cfg.top_p = None);
+  check_bool "top_k None" true (cfg.top_k = None);
+  check_bool "min_p None" true (cfg.min_p = None);
+  check_bool "system_prompt None" true (cfg.system_prompt = None);
+  check_bool "enable_thinking None" true (cfg.enable_thinking = None);
+  check_bool "thinking_budget None" true (cfg.thinking_budget = None);
+  check_bool "tool_choice None" true (cfg.tool_choice = None);
+  check_bool "no parallel tool use" false cfg.disable_parallel_tool_use;
+  check_bool "no json format" false cfg.response_format_json;
+  check_bool "no cache system prompt" false cfg.cache_system_prompt
+
+(* ── make: request_path per kind ──────────────────────── *)
+
+let test_request_path_anthropic () =
+  let cfg = Provider_config.make ~kind:Anthropic
+    ~model_id:"m" ~base_url:"" () in
+  check_string "anthropic path" "/v1/messages" cfg.request_path
+
+let test_request_path_openai () =
+  let cfg = Provider_config.make ~kind:OpenAI_compat
+    ~model_id:"m" ~base_url:"" () in
+  check_string "openai path" "/v1/chat/completions" cfg.request_path
+
+let test_request_path_gemini () =
+  let cfg = Provider_config.make ~kind:Gemini
+    ~model_id:"m" ~base_url:"" () in
+  check_string "gemini path" "" cfg.request_path
+
+let test_request_path_glm () =
+  let cfg = Provider_config.make ~kind:Glm
+    ~model_id:"m" ~base_url:"" () in
+  check_string "glm path" "/chat/completions" cfg.request_path
+
+let test_request_path_claude_code () =
+  let cfg = Provider_config.make ~kind:Claude_code
+    ~model_id:"m" ~base_url:"" () in
+  check_string "claude_code path" "" cfg.request_path
+
+let test_request_path_override () =
+  let cfg = Provider_config.make ~kind:Anthropic
+    ~model_id:"m" ~base_url:"" ~request_path:"/custom/path" () in
+  check_string "custom path" "/custom/path" cfg.request_path
+
+(* ── make: explicit values ────────────────────────────── *)
+
+let test_make_with_all_options () =
+  let cfg = Provider_config.make ~kind:Anthropic
+    ~model_id:"claude-opus" ~base_url:"https://api.anthropic.com"
+    ~api_key:"sk-test"
+    ~headers:[("X-Custom", "val")]
+    ~max_tokens:2048
+    ~temperature:0.7
+    ~top_p:0.9
+    ~top_k:40
+    ~min_p:0.05
+    ~system_prompt:"system"
+    ~enable_thinking:true
+    ~thinking_budget:1000
+    ~disable_parallel_tool_use:true
+    ~response_format_json:true
+    ~cache_system_prompt:true () in
+  check_string "api_key" "sk-test" cfg.api_key;
+  check_int "max_tokens" 2048 cfg.max_tokens;
+  check_bool "temperature" true (cfg.temperature = Some 0.7);
+  check_bool "top_p" true (cfg.top_p = Some 0.9);
+  check_bool "top_k" true (cfg.top_k = Some 40);
+  check_bool "min_p" true (cfg.min_p = Some 0.05);
+  check_bool "system_prompt" true (cfg.system_prompt = Some "system");
+  check_bool "enable_thinking" true (cfg.enable_thinking = Some true);
+  check_bool "thinking_budget" true (cfg.thinking_budget = Some 1000);
+  check_bool "disable_parallel" true cfg.disable_parallel_tool_use;
+  check_bool "json format" true cfg.response_format_json;
+  check_bool "cache prompt" true cfg.cache_system_prompt
+
+(* ── make: headers default ────────────────────────────── *)
+
+let test_default_headers () =
+  let cfg = Provider_config.make ~kind:OpenAI_compat
+    ~model_id:"m" ~base_url:"" () in
+  check_int "1 default header" 1 (List.length cfg.headers);
+  let (k, v) = List.hd cfg.headers in
+  check_string "Content-Type key" "Content-Type" k;
+  check_string "Content-Type val" "application/json" v
+
+let test_custom_headers () =
+  let cfg = Provider_config.make ~kind:OpenAI_compat
+    ~model_id:"m" ~base_url:""
+    ~headers:[("Auth", "Bearer x"); ("X-Custom", "val")] () in
+  check_int "2 custom headers" 2 (List.length cfg.headers)
+
+(* ── Suite ────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "provider_config" [
+    "defaults", [
+      Alcotest.test_case "make defaults" `Quick test_make_defaults;
+      Alcotest.test_case "default headers" `Quick test_default_headers;
+    ];
+    "request_path", [
+      Alcotest.test_case "anthropic" `Quick test_request_path_anthropic;
+      Alcotest.test_case "openai" `Quick test_request_path_openai;
+      Alcotest.test_case "gemini" `Quick test_request_path_gemini;
+      Alcotest.test_case "glm" `Quick test_request_path_glm;
+      Alcotest.test_case "claude_code" `Quick test_request_path_claude_code;
+      Alcotest.test_case "override" `Quick test_request_path_override;
+    ];
+    "explicit_values", [
+      Alcotest.test_case "all options" `Quick test_make_with_all_options;
+      Alcotest.test_case "custom headers" `Quick test_custom_headers;
+    ];
+  ]

--- a/test/test_succession.ml
+++ b/test/test_succession.ml
@@ -1,0 +1,334 @@
+(** Tests for Succession — cross-agent context relay. *)
+
+open Agent_sdk
+
+let check_string = Alcotest.(check string)
+let check_bool = Alcotest.(check bool)
+let check_int = Alcotest.(check int)
+
+let mk_msg role text : Types.message =
+  { role; content = [Types.Text text]; name = None; tool_call_id = None }
+
+(* ── empty_metrics ────────────────────────────────────── *)
+
+let test_empty_metrics () =
+  let m = Succession.empty_metrics in
+  check_int "turns" 0 m.total_turns;
+  check_int "tokens" 0 m.total_tokens_used;
+  check_bool "cost zero" true (m.total_cost_usd = 0.0);
+  check_int "tasks" 0 m.tasks_completed;
+  check_int "errors" 0 m.errors_encountered;
+  check_bool "elapsed zero" true (m.elapsed_seconds = 0.0)
+
+(* ── merge_metrics ────────────────────────────────────── *)
+
+let test_merge_metrics () =
+  let a : Succession.metrics = {
+    total_turns = 5; total_tokens_used = 1000;
+    total_cost_usd = 0.1; tasks_completed = 2;
+    errors_encountered = 1; elapsed_seconds = 30.0;
+  } in
+  let b : Succession.metrics = {
+    total_turns = 3; total_tokens_used = 500;
+    total_cost_usd = 0.05; tasks_completed = 1;
+    errors_encountered = 0; elapsed_seconds = 15.0;
+  } in
+  let merged = Succession.merge_metrics a b in
+  check_int "turns" 8 merged.total_turns;
+  check_int "tokens" 1500 merged.total_tokens_used;
+  check_int "tasks" 3 merged.tasks_completed;
+  check_int "errors" 1 merged.errors_encountered
+
+let test_merge_metrics_identity () =
+  let merged = Succession.merge_metrics Succession.empty_metrics Succession.empty_metrics in
+  check_int "turns 0" 0 merged.total_turns;
+  check_bool "cost 0" true (merged.total_cost_usd = 0.0)
+
+(* ── extract_dna ──────────────────────────────────────── *)
+
+let test_extract_dna_basic () =
+  let msgs = [
+    mk_msg Types.User "build a CLI";
+    mk_msg Types.Assistant "I selected the approach: OCaml";
+  ] in
+  let dna = Succession.extract_dna ~messages:msgs ~goal:"build CLI"
+    ~generation:1 ~trace_id:"t123" () in
+  check_int "generation" 1 dna.generation;
+  check_string "trace_id" "t123" dna.trace_id;
+  check_string "goal" "build CLI" dna.goal;
+  check_bool "has progress" true (String.length dna.progress_summary > 0);
+  check_bool "has context" true (String.length dna.compressed_context > 0)
+
+let test_extract_dna_empty_messages () =
+  let dna = Succession.extract_dna ~messages:[] ~goal:"empty"
+    ~generation:0 ~trace_id:"t0" () in
+  check_int "generation" 0 dna.generation;
+  check_string "goal" "empty" dna.goal;
+  check_string "empty progress" "" dna.progress_summary;
+  check_string "empty context" "" dna.compressed_context;
+  check_int "no pending" 0 (List.length dna.pending_actions);
+  check_int "no decisions" 0 (List.length dna.key_decisions)
+
+let test_extract_dna_with_metrics () =
+  let metrics : Succession.metrics = {
+    total_turns = 10; total_tokens_used = 5000;
+    total_cost_usd = 0.5; tasks_completed = 3;
+    errors_encountered = 1; elapsed_seconds = 120.0;
+  } in
+  let dna = Succession.extract_dna ~messages:[] ~goal:"test"
+    ~generation:2 ~trace_id:"t2" ~metrics () in
+  check_int "metrics turns" 10 dna.metrics.total_turns
+
+let test_extract_dna_with_warnings () =
+  let dna = Succession.extract_dna ~messages:[] ~goal:"test"
+    ~generation:1 ~trace_id:"t1" ~warnings:["w1"; "w2"] () in
+  check_int "2 warnings" 2 (List.length dna.warnings)
+
+let test_extract_dna_captures_decisions () =
+  let msgs = [
+    mk_msg Types.Assistant "I decided to use OCaml for this.";
+    mk_msg Types.Assistant "No special keywords here.";
+    mk_msg Types.Assistant "I have chosen the approach for testing.";
+  ] in
+  let dna = Succession.extract_dna ~messages:msgs ~goal:"test"
+    ~generation:1 ~trace_id:"t1" () in
+  (* "decided" and "chosen" are decision markers *)
+  check_bool "has decisions" true (List.length dna.key_decisions >= 2)
+
+let test_extract_dna_pending_from_last_user () =
+  let msgs = [
+    mk_msg Types.Assistant "response";
+    mk_msg Types.User "do this next please";
+  ] in
+  let dna = Succession.extract_dna ~messages:msgs ~goal:"test"
+    ~generation:1 ~trace_id:"t1" () in
+  check_int "1 pending action" 1 (List.length dna.pending_actions)
+
+(* ── build_successor_system_prompt ────────────────────── *)
+
+let test_successor_prompt () =
+  let dna : Succession.dna = {
+    generation = 3; trace_id = "t1"; goal = "deploy app";
+    progress_summary = "built module"; compressed_context = "ctx";
+    pending_actions = ["run tests"]; key_decisions = ["using Eio"];
+    memory_refs = []; warnings = ["low memory"];
+    metrics = Succession.empty_metrics;
+  } in
+  let prompt = Succession.build_successor_system_prompt dna in
+  check_bool "has generation" true (Util.string_contains ~needle:"generation 3" prompt);
+  check_bool "has goal" true (Util.string_contains ~needle:"deploy app" prompt);
+  check_bool "has progress" true (Util.string_contains ~needle:"built module" prompt);
+  check_bool "has pending" true (Util.string_contains ~needle:"run tests" prompt);
+  check_bool "has decisions" true (Util.string_contains ~needle:"using Eio" prompt);
+  check_bool "has warnings" true (Util.string_contains ~needle:"low memory" prompt);
+  check_bool "has continue" true (Util.string_contains ~needle:"Continue" prompt)
+
+let test_successor_prompt_minimal () =
+  let dna : Succession.dna = {
+    generation = 1; trace_id = "t1"; goal = "g";
+    progress_summary = ""; compressed_context = "";
+    pending_actions = []; key_decisions = [];
+    memory_refs = []; warnings = [];
+    metrics = Succession.empty_metrics;
+  } in
+  let prompt = Succession.build_successor_system_prompt dna in
+  check_bool "has goal" true (Util.string_contains ~needle:"g" prompt);
+  check_bool "has continue" true (Util.string_contains ~needle:"Continue" prompt)
+
+(* ── hydrate_messages ─────────────────────────────────── *)
+
+let test_hydrate_messages () =
+  let dna : Succession.dna = {
+    generation = 1; trace_id = "t1"; goal = "build it";
+    progress_summary = ""; compressed_context = "previous context";
+    pending_actions = []; key_decisions = [];
+    memory_refs = []; warnings = [];
+    metrics = Succession.empty_metrics;
+  } in
+  let msgs = Succession.hydrate_messages dna in
+  check_int "2 messages" 2 (List.length msgs);
+  let first = List.hd msgs in
+  check_bool "first is System" true (first.role = Types.System)
+
+let test_hydrate_messages_no_context () =
+  let dna : Succession.dna = {
+    generation = 1; trace_id = "t1"; goal = "g";
+    progress_summary = ""; compressed_context = "";
+    pending_actions = []; key_decisions = [];
+    memory_refs = []; warnings = [];
+    metrics = Succession.empty_metrics;
+  } in
+  let msgs = Succession.hydrate_messages dna in
+  check_int "1 message (no context)" 1 (List.length msgs);
+  let first = List.hd msgs in
+  check_bool "is User" true (first.role = Types.User)
+
+(* ── normalize_for_model ──────────────────────────────── *)
+
+let test_normalize_strips_thinking () =
+  let msgs = [
+    { Types.role = Types.Assistant;
+      content = [
+        Types.Thinking { thinking_type = "thinking"; content = "hmm" };
+        Types.Text "answer";
+      ];
+      name = None; tool_call_id = None };
+  ] in
+  let normalized = Succession.normalize_for_model msgs ~target_model:"any" in
+  let content = (List.hd normalized).content in
+  check_int "1 block" 1 (List.length content);
+  (match List.hd content with
+   | Types.Text "answer" -> ()
+   | _ -> Alcotest.fail "expected Text only")
+
+let test_normalize_strips_redacted_thinking () =
+  let msgs = [
+    { Types.role = Types.Assistant;
+      content = [
+        Types.RedactedThinking "secret";
+        Types.Text "visible";
+      ];
+      name = None; tool_call_id = None };
+  ] in
+  let normalized = Succession.normalize_for_model msgs ~target_model:"any" in
+  let content = (List.hd normalized).content in
+  check_int "1 block" 1 (List.length content)
+
+let test_normalize_repairs_dangling_tool_calls () =
+  let msgs = [
+    { Types.role = Types.Assistant;
+      content = [
+        Types.ToolUse { id = "t1"; name = "search"; input = `Null };
+      ];
+      name = None; tool_call_id = None };
+    (* No matching ToolResult follows *)
+  ] in
+  let normalized = Succession.normalize_for_model msgs ~target_model:"any" in
+  check_int "2 messages (original + repair)" 2 (List.length normalized);
+  let repair = List.nth normalized 1 in
+  check_bool "repair is Tool role" true (repair.role = Types.Tool)
+
+let test_normalize_preserves_matched_tool_calls () =
+  let msgs = [
+    { Types.role = Types.Assistant;
+      content = [
+        Types.ToolUse { id = "t1"; name = "search"; input = `Null };
+      ];
+      name = None; tool_call_id = None };
+    { Types.role = Types.User;
+      content = [
+        Types.ToolResult { tool_use_id = "t1"; content = "result"; is_error = false };
+      ];
+      name = None; tool_call_id = None };
+  ] in
+  let normalized = Succession.normalize_for_model msgs ~target_model:"any" in
+  check_int "2 messages (no repair needed)" 2 (List.length normalized)
+
+(* ── dna_to_json / dna_of_json roundtrip ──────────────── *)
+
+let test_dna_roundtrip () =
+  let dna : Succession.dna = {
+    generation = 5; trace_id = "tr-123"; goal = "test roundtrip";
+    progress_summary = "some progress";
+    compressed_context = "ctx data";
+    pending_actions = ["action1"; "action2"];
+    key_decisions = ["decision1"];
+    memory_refs = ["ref1"];
+    warnings = ["warn1"];
+    metrics = {
+      total_turns = 10; total_tokens_used = 5000;
+      total_cost_usd = 0.5; tasks_completed = 3;
+      errors_encountered = 1; elapsed_seconds = 120.0;
+    };
+  } in
+  let json = Succession.dna_to_json dna in
+  match Succession.dna_of_json json with
+  | Ok restored ->
+    check_int "generation" 5 restored.generation;
+    check_string "trace_id" "tr-123" restored.trace_id;
+    check_string "goal" "test roundtrip" restored.goal;
+    check_int "pending_actions" 2 (List.length restored.pending_actions);
+    check_int "key_decisions" 1 (List.length restored.key_decisions);
+    check_int "metrics turns" 10 restored.metrics.total_turns
+  | Error msg -> Alcotest.fail ("roundtrip failed: " ^ msg)
+
+let test_dna_of_json_invalid () =
+  match Succession.dna_of_json (`String "not an object") with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "should fail on invalid JSON"
+
+let test_dna_roundtrip_empty () =
+  let dna : Succession.dna = {
+    generation = 0; trace_id = ""; goal = "";
+    progress_summary = ""; compressed_context = "";
+    pending_actions = []; key_decisions = [];
+    memory_refs = []; warnings = [];
+    metrics = Succession.empty_metrics;
+  } in
+  let json = Succession.dna_to_json dna in
+  match Succession.dna_of_json json with
+  | Ok restored ->
+    check_int "generation" 0 restored.generation;
+    check_int "no pending" 0 (List.length restored.pending_actions)
+  | Error msg -> Alcotest.fail ("roundtrip failed: " ^ msg)
+
+(* ── metrics_to_json / metrics_of_json roundtrip ──────── *)
+
+let test_metrics_roundtrip () =
+  let m : Succession.metrics = {
+    total_turns = 42; total_tokens_used = 9999;
+    total_cost_usd = 1.23; tasks_completed = 7;
+    errors_encountered = 2; elapsed_seconds = 300.0;
+  } in
+  let json = Succession.metrics_to_json m in
+  let restored = Succession.metrics_of_json json in
+  check_int "turns" 42 restored.total_turns;
+  check_int "tokens" 9999 restored.total_tokens_used;
+  check_int "tasks" 7 restored.tasks_completed
+
+let test_metrics_of_json_missing_fields () =
+  (* metrics_of_json should default missing fields to 0 *)
+  let json = `Assoc [] in
+  let m = Succession.metrics_of_json json in
+  check_int "turns default 0" 0 m.total_turns;
+  check_int "tokens default 0" 0 m.total_tokens_used
+
+(* ── Suite ────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "succession" [
+    "metrics", [
+      Alcotest.test_case "empty" `Quick test_empty_metrics;
+      Alcotest.test_case "merge" `Quick test_merge_metrics;
+      Alcotest.test_case "merge identity" `Quick test_merge_metrics_identity;
+      Alcotest.test_case "roundtrip" `Quick test_metrics_roundtrip;
+      Alcotest.test_case "missing fields" `Quick test_metrics_of_json_missing_fields;
+    ];
+    "extract_dna", [
+      Alcotest.test_case "basic" `Quick test_extract_dna_basic;
+      Alcotest.test_case "empty messages" `Quick test_extract_dna_empty_messages;
+      Alcotest.test_case "with metrics" `Quick test_extract_dna_with_metrics;
+      Alcotest.test_case "with warnings" `Quick test_extract_dna_with_warnings;
+      Alcotest.test_case "captures decisions" `Quick test_extract_dna_captures_decisions;
+      Alcotest.test_case "pending from last user" `Quick test_extract_dna_pending_from_last_user;
+    ];
+    "successor_prompt", [
+      Alcotest.test_case "full" `Quick test_successor_prompt;
+      Alcotest.test_case "minimal" `Quick test_successor_prompt_minimal;
+    ];
+    "hydrate", [
+      Alcotest.test_case "with context" `Quick test_hydrate_messages;
+      Alcotest.test_case "no context" `Quick test_hydrate_messages_no_context;
+    ];
+    "normalize", [
+      Alcotest.test_case "strips thinking" `Quick test_normalize_strips_thinking;
+      Alcotest.test_case "strips redacted thinking" `Quick test_normalize_strips_redacted_thinking;
+      Alcotest.test_case "repairs dangling tool calls" `Quick test_normalize_repairs_dangling_tool_calls;
+      Alcotest.test_case "preserves matched tool calls" `Quick test_normalize_preserves_matched_tool_calls;
+    ];
+    "serialization", [
+      Alcotest.test_case "dna roundtrip" `Quick test_dna_roundtrip;
+      Alcotest.test_case "dna roundtrip empty" `Quick test_dna_roundtrip_empty;
+      Alcotest.test_case "dna invalid json" `Quick test_dna_of_json_invalid;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- Add dedicated test files for 7 modules that previously had zero test coverage
- 110 new Alcotest test cases across 7 test executables
- All tests pass (189 test suites green, no regressions)

### New test files
| File | Module | Tests |
|------|--------|-------|
| `test_contract.ml` | Contract (runtime contracts) | 31 |
| `test_succession.ml` | Succession (cross-agent DNA relay) | 22 |
| `test_fs_result.ml` | Fs_result (result-based I/O) | 16 |
| `test_agent_turn_budget_unit.ml` | Agent_turn_budget (self-extending budget) | 12 |
| `test_progressive_tools.ml` | Progressive_tools (tool disclosure) | 10 |
| `test_provider_config.ml` | Provider_config (lightweight config) | 10 |
| `test_context_offload.ml` | Context_offload (large result offload) | 9 |

### Coverage areas
- **Contract**: empty/is_empty, runtime_awareness, trigger, instruction_layers, merge, to_json, compose_system_prompt, filter_tools, context_with_contract
- **Succession**: metrics merge, extract_dna (decisions, pending, warnings), successor prompt, hydrate_messages, normalize_for_model (thinking strip, dangling repair), DNA JSON roundtrip
- **Fs_result**: read/write/append/ensure_dir/remove_file/read_dir/file_exists, io_error_of_exn
- **Agent_turn_budget**: create guardrails (ceiling >= initial), try_extend (success/ceiling/cap/limit), denial_reason_to_string, stats_json
- **Progressive_tools**: Phase_based (single/multi/below threshold), Gather_act_verify (3 phases), as_hook integration
- **Provider_config**: make defaults, request_path per provider kind (5 kinds + override), explicit values
- **Context_offload**: threshold logic, fail-open on I/O error, tool name sanitization, to_context_string

## Test plan
- [x] All 7 new test executables build and pass
- [x] Full `dune build @runtest` passes (189 suites)
- [x] No regressions in existing tests


Generated with [Claude Code](https://claude.com/claude-code)