### PR TITLE
fix(approval): propagate risk_level from risk_classifier to downstream stages

### DIFF
--- a/lib/approval.ml
+++ b/lib/approval.ml
@@ -37,6 +37,7 @@ type approval_context = {
 type stage_result =
   | Decided of Hooks.approval_decision
   | Pass
+  | Pass_with_context of approval_context
 
 (* ── Approval stage ──────────────────────────────────────── *)
 
@@ -84,6 +85,8 @@ let evaluate t ~tool_name ~input ~agent_name ~turn =
         decision
       | Pass ->
         go ctx_acc rest
+      | Pass_with_context updated_ctx ->
+        go updated_ctx rest
   in
   go ctx t.stages
 
@@ -132,14 +135,13 @@ let reject_dangerous_patterns (patterns : (string * string) list) : approval_sta
 }
 
 (** Classify risk level for downstream stages.
-    Does not make approval decisions itself — just updates context. *)
+    Does not make approval decisions itself — updates context for
+    downstream stages via [Pass_with_context]. *)
 let risk_classifier (classify : string -> Yojson.Safe.t -> risk_level) : approval_stage = {
   name = "risk_classifier";
   evaluate = (fun ctx ->
-    let _level = classify ctx.tool_name ctx.input in
-    (* Risk classification is informational for now.
-       Future: pass risk_level through context for downstream stages. *)
-    Pass);
+    let level = classify ctx.tool_name ctx.input in
+    Pass_with_context { ctx with risk_level = level });
   timeout_s = None;
 }
 

--- a/lib/approval.mli
+++ b/lib/approval.mli
@@ -20,6 +20,9 @@ type approval_context = {
 type stage_result =
   | Decided of Hooks.approval_decision
   | Pass
+  | Pass_with_context of approval_context
+      (** Like [Pass] but replaces the context for downstream stages.
+          Used by context-enriching stages such as [risk_classifier]. *)
 
 type approval_stage = {
   name: string;

--- a/test/test_approval_pipeline.ml
+++ b/test/test_approval_pipeline.ml
@@ -126,7 +126,7 @@ let test_always_reject () =
   | Hooks.Reject r -> check string "reason" "locked down" r
   | _ -> fail "should reject"
 
-(* ── Risk classifier (passthrough) ──────────────────────── *)
+(* ── Risk classifier (context propagation) ─────────────── *)
 
 let test_risk_classifier () =
   let classify _name _input = Approval.High in
@@ -138,6 +138,31 @@ let test_risk_classifier () =
     ~tool_name:"test" ~input:(`Assoc [])
     ~agent_name:"a" ~turn:0 in
   match d with Hooks.Approve -> () | _ -> fail "should approve"
+
+(** Verify risk_classifier propagates the classified level to downstream stages. *)
+let test_risk_classifier_propagates_level () =
+  let classify _name _input = Approval.Critical in
+  (* Downstream stage rejects if risk_level = Critical *)
+  let reject_critical : Approval.approval_stage = {
+    name = "reject_critical";
+    evaluate = (fun ctx ->
+      if ctx.risk_level = Critical then
+        Approval.Decided (Hooks.Reject "critical risk")
+      else
+        Approval.Pass);
+    timeout_s = None;
+  } in
+  let pipeline = Approval.create [
+    Approval.risk_classifier classify;
+    reject_critical;
+    Approval.always_approve;
+  ] in
+  let d = Approval.evaluate pipeline
+    ~tool_name:"test" ~input:(`Assoc [])
+    ~agent_name:"a" ~turn:0 in
+  match d with
+  | Hooks.Reject r -> check string "critical propagated" "critical risk" r
+  | _ -> fail "should reject based on propagated risk level"
 
 (* ── as_callback compat ─────────────────────────────────── *)
 
@@ -187,6 +212,7 @@ let () =
       test_case "multi stage" `Quick test_multi_stage;
       test_case "first decided wins" `Quick test_first_decided_wins;
       test_case "risk classifier" `Quick test_risk_classifier;
+      test_case "risk classifier propagates level" `Quick test_risk_classifier_propagates_level;
     ];
     "human callback", [
       test_case "approve" `Quick test_human_callback;


### PR DESCRIPTION
## Summary
- `risk_classifier` stage computed a risk level but discarded it (`_level`), so downstream stages always saw the default `Low` risk regardless of classification
- Added `Pass_with_context` variant to `stage_result`, enabling context-enriching stages to thread updated `approval_context` through the pipeline
- `risk_classifier` now returns `Pass_with_context { ctx with risk_level = level }` so downstream stages can make decisions based on the classified risk

## Test plan
- [x] Existing `risk_classifier` test still passes
- [x] New `risk_classifier_propagates_level` test verifies a downstream stage sees the updated risk level
- [x] Full test suite passes (13/13 approval pipeline tests)
- [x] `dune build` clean

Generated with [Claude Code](https://claude.com/claude-code)