### PR TITLE
feat(checkpoint): allow sidecar working context

### DIFF
--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -131,7 +131,11 @@ val resume :
   ?config:Types.agent_config ->
   unit -> t
 
-val checkpoint : ?session_id:string -> ?working_context:Yojson.Safe.t -> t -> Checkpoint.t
+val checkpoint :
+  ?session_id:string ->
+  ?working_context:Yojson.Safe.t ->
+  t ->
+  Checkpoint.t
 
 (** {1 Lifecycle} *)
 

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -355,6 +355,28 @@ let () =
           (match cp.tool_choice with
            | Some Types.Auto -> Some "auto"
            | _ -> None));
+
+      test_case "Agent.checkpoint preserves working_context sidecar" `Quick
+        (fun () ->
+          Eio_main.run @@ fun env ->
+          let net = Eio.Stdenv.net env in
+          let agent = Agent.create ~net () in
+          let sidecar =
+            `Assoc
+              [
+                ("kind", `String "keeper_context_v1");
+                ("max_tokens", `Int 4096);
+                ("generation", `Int 3);
+              ]
+          in
+          let cp =
+            Agent.checkpoint ~session_id:"sess-sidecar"
+              ~working_context:sidecar agent
+          in
+          Alcotest.(check bool) "sidecar preserved" true
+            (match cp.working_context with
+             | Some json -> json = sidecar
+             | None -> false));
     ];
 
     "build_resume", [


### PR DESCRIPTION
## Summary
- allow `Agent.checkpoint` callers to attach a sidecar `working_context` payload
- cover the sidecar roundtrip in checkpoint tests
- keep the `Checkpoint.t` schema backward compatible

## Downstream
- unblocks `jeong-sik/masc-mcp#2738`, which depends on `Agent.checkpoint ?working_context`

## Testing
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix-oas-boundary-cleanup ./test/test_checkpoint.exe`
