### PR TITLE
feat(agent): add ?working_context to Agent.checkpoint

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -197,8 +197,8 @@ let resume ~net ~(checkpoint : Checkpoint.t) ?(tools=[]) ?context
     consecutive_idle_turns = 0; named_cascade;
     tools = Tool_set.of_list tools; net; context = ctx; options }
 
-let checkpoint ?(session_id="") agent =
-  Agent_checkpoint.build_checkpoint ~session_id ~state:agent.state
+let checkpoint ?(session_id="") ?working_context agent =
+  Agent_checkpoint.build_checkpoint ~session_id ?working_context ~state:agent.state
     ~tools:agent.tools ~context:agent.context
     ~mcp_clients:agent.options.mcp_clients ()
 

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -131,7 +131,7 @@ val resume :
   ?config:Types.agent_config ->
   unit -> t
 
-val checkpoint : ?session_id:string -> t -> Checkpoint.t
+val checkpoint : ?session_id:string -> ?working_context:Yojson.Safe.t -> t -> Checkpoint.t
 
 (** {1 Lifecycle} *)
 

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -670,5 +670,26 @@ let () =
           () in
         let cp = Agent.checkpoint agent in
         check int "no mcp sessions" 0 (List.length cp.mcp_sessions));
+
+      test_case "Agent.checkpoint passes working_context" `Quick (fun () ->
+        Eio_main.run @@ fun env ->
+        let net = Eio.Stdenv.net env in
+        let agent = Agent.create ~net
+          ~config:{ Types.default_config with name = "wc-test" }
+          () in
+        let wc = `Assoc [("kind", `String "keeper_v1"); ("max_tokens", `Int 4096)] in
+        let cp = Agent.checkpoint ~working_context:wc agent in
+        check (option (testable Yojson.Safe.pp Yojson.Safe.equal))
+          "working_context roundtrip" (Some wc) cp.working_context);
+
+      test_case "Agent.checkpoint omits working_context by default" `Quick (fun () ->
+        Eio_main.run @@ fun env ->
+        let net = Eio.Stdenv.net env in
+        let agent = Agent.create ~net
+          ~config:{ Types.default_config with name = "wc-none" }
+          () in
+        let cp = Agent.checkpoint agent in
+        check (option (testable Yojson.Safe.pp Yojson.Safe.equal))
+          "working_context absent" None cp.working_context);
     ];
   ]


### PR DESCRIPTION
## Summary
- Thread `?working_context:Yojson.Safe.t` through `Agent.checkpoint` to the existing `Agent_checkpoint.build_checkpoint` parameter
- MASC main is broken because PR jeong-sik/masc-mcp#2734 calls `Agent.checkpoint ~session_id ?working_context:... agent` but OAS did not expose the parameter
- This unblocks all MASC CI

## Test plan
- [x] 50 checkpoint tests pass (48 existing + 2 new)
- [x] `working_context` roundtrip test: inject JSON sidecar, verify in checkpoint
- [x] Default behavior test: no `working_context` → `None` in checkpoint
- [ ] MASC pin update after merge to verify CI recovery

Generated with [Claude Code](https://claude.com/claude-code)