### PR TITLE
feat(discovery): add local endpoint auto-scan and dynamic refresh

### DIFF
--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -192,6 +192,17 @@ let probe_endpoint ~sw ~net url =
 let discover ~sw ~net ~endpoints =
   Eio.Fiber.List.map (fun url -> probe_endpoint ~sw ~net url) endpoints
 
+let default_scan_ports = [ 8085; 8086; 8087; 8088; 8089; 8090 ]
+
+let scan_local_endpoints ?(ports = default_scan_ports) ~sw ~net () =
+  let candidates =
+    List.map (fun p -> Printf.sprintf "http://127.0.0.1:%d" p) ports
+  in
+  let statuses = discover ~sw ~net ~endpoints:candidates in
+  List.filter_map
+    (fun (s : endpoint_status) -> if s.healthy then Some s.url else None)
+    statuses
+
 (* ── JSON serialization ──────────────────────────────────── *)
 
 let model_info_to_json (m : model_info) =

--- a/lib/llm_provider/discovery.mli
+++ b/lib/llm_provider/discovery.mli
@@ -58,3 +58,14 @@ val summary_to_json : endpoint_status list -> Yojson.Safe.t
 (** Extract max context size from endpoint status.
     Returns [ctx_size] from [props] if available, else checks [capabilities.max_context_tokens]. *)
 val max_context_of_status : endpoint_status -> int option
+
+(** Scan local ports for healthy llama-server instances.
+    Probes each port via [/health] and returns URLs of healthy endpoints.
+    Default port range: 8085-8090.
+    @since 0.86.0 *)
+val scan_local_endpoints :
+  ?ports:int list ->
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  unit ->
+  string list

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -49,8 +49,8 @@ let has_api_key env_name =
    | Some s -> String.trim s <> ""
    | None -> false)
 
-(** All LLM_ENDPOINTS URLs, parsed once at module init. *)
-let llama_all_endpoints =
+(** Initial endpoints from LLM_ENDPOINTS env var. *)
+let initial_llama_endpoints =
   match Sys.getenv_opt "LLM_ENDPOINTS" with
   | Some s ->
     let urls = s |> String.split_on_char ',' |> List.map String.trim
@@ -58,16 +58,46 @@ let llama_all_endpoints =
     if urls = [] then ["http://127.0.0.1:8085"] else urls
   | None -> ["http://127.0.0.1:8085"]
 
-(** Round-robin counter for distributing calls across LLM_ENDPOINTS. *)
+(** Mutable endpoint list, protected by atomic snapshot swap.
+    Updated by [refresh_llama_endpoints]. *)
+let llama_endpoints_ref = Atomic.make (Array.of_list initial_llama_endpoints)
+
+let llama_all_endpoints = initial_llama_endpoints
+
+(** Round-robin counter for distributing calls across endpoints. *)
 let llama_rr_counter = Atomic.make 0
 
 (** Pick the next llama endpoint via round-robin.
+    Reads the current endpoint snapshot atomically.
     Called by cascade_config when resolving "llama:*" provider. *)
 let next_llama_endpoint () =
-  let endpoints = Array.of_list llama_all_endpoints in
+  let endpoints = Atomic.get llama_endpoints_ref in
   let n = Array.length endpoints in
   let idx = Atomic.fetch_and_add llama_rr_counter 1 mod n in
   endpoints.(idx)
+
+(** Refresh the llama endpoint list by scanning local ports.
+    If [LLM_ENDPOINTS] is set, uses that as the source (no scan).
+    Otherwise probes ports 8085-8090 and keeps only healthy endpoints.
+    Falls back to default 8085 if no healthy endpoints found.
+    Call this after Eio scheduler is available (e.g. at server startup). *)
+let refresh_llama_endpoints ~sw ~net () =
+  let endpoints =
+    match Sys.getenv_opt "LLM_ENDPOINTS" with
+    | Some s when String.trim s <> "" ->
+        let urls = s |> String.split_on_char ',' |> List.map String.trim
+                   |> List.filter (fun s -> s <> "") in
+        if urls = [] then ["http://127.0.0.1:8085"] else urls
+    | _ ->
+        let found = Discovery.scan_local_endpoints ~sw ~net () in
+        if found = [] then ["http://127.0.0.1:8085"] else found
+  in
+  Atomic.set llama_endpoints_ref (Array.of_list endpoints);
+  endpoints
+
+(** Current active endpoint list (snapshot). *)
+let active_llama_endpoints () =
+  Array.to_list (Atomic.get llama_endpoints_ref)
 
 let llama_defaults = {
   kind = OpenAI_compat;

--- a/lib/llm_provider/provider_registry.mli
+++ b/lib/llm_provider/provider_registry.mli
@@ -54,10 +54,26 @@ val find_capable : t -> (Capabilities.capabilities -> bool) -> entry list
     Availability is determined by checking the API key env var. *)
 val default : unit -> t
 
-(** All LLM_ENDPOINTS URLs parsed from the environment. *)
+(** Initial LLM_ENDPOINTS URLs parsed from the environment at module load.
+    For current active endpoints, use [active_llama_endpoints]. *)
 val llama_all_endpoints : string list
 
-(** Pick the next llama endpoint via round-robin across LLM_ENDPOINTS.
+(** Pick the next llama endpoint via round-robin.
     Distributes load transparently when multiple local servers are running.
+    After [refresh_llama_endpoints], rotates across discovered endpoints.
     @since 0.78.0 *)
 val next_llama_endpoint : unit -> string
+
+(** Refresh the llama endpoint list by scanning local ports 8085-8090.
+    If [LLM_ENDPOINTS] env var is set, uses that as source (no scan).
+    Otherwise probes ports and keeps only healthy endpoints.
+    Returns the new endpoint list. Call after Eio scheduler is available.
+    @since 0.86.0 *)
+val refresh_llama_endpoints :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  unit -> string list
+
+(** Current active endpoint list (snapshot after last refresh).
+    @since 0.86.0 *)
+val active_llama_endpoints : unit -> string list


### PR DESCRIPTION
## Summary
OAS가 local llama-server endpoint를 자동 탐색하도록 확장.

### 변경
- `Discovery.scan_local_endpoints`: 8085-8090 포트 probe, healthy만 반환
- `Provider_registry.refresh_llama_endpoints`: 런타임에 endpoint 목록 갱신
- `Provider_registry.active_llama_endpoints`: 현재 활성 endpoint 조회
- `next_llama_endpoint()`: 갱신된 endpoint 목록에서 round-robin

### 동작 규칙
| 조건 | 동작 |
|------|------|
| `LLM_ENDPOINTS` 설정됨 | env var 사용 (scan 안 함) |
| `LLM_ENDPOINTS` 미설정 | 8085-8090 probe, healthy만 유지 |
| 모두 unhealthy | 8085 기본값 fallback |

### 사용
```ocaml
(* MASC startup 또는 OAS runtime init에서 호출 *)
Eio_main.run @@ fun env ->
Eio.Switch.run @@ fun sw ->
let net = Eio.Stdenv.net env in
let endpoints = Provider_registry.refresh_llama_endpoints ~sw ~net () in
(* 이후 next_llama_endpoint()가 discovered endpoints에서 RR *)
```

## Test plan
- [ ] `dune build --root .` 통과
- [ ] `dune test --root .` 통과
- [ ] 8085/8086/8087 가동 시 3개 발견 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)