### PR TITLE
feat(cascade): expose load_json and resolve_inference_params

### DIFF
--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -199,6 +199,46 @@ let load_profile ~config_path ~name =
         items
     | _ -> []
 
+(* ── Inference parameter resolution ─────────────────────
+   Per-cascade temperature/max_tokens from cascade.json.
+   Enables MASC and other consumers to delegate inference
+   parameter decisions to the same config file. *)
+
+type inference_params = {
+  temperature: float option;
+  max_tokens: int option;
+}
+
+let read_float_field json key =
+  let open Yojson.Safe.Util in
+  match json |> member key with
+  | `Float f -> Some f
+  | `Int i -> Some (float_of_int i)
+  | _ -> None
+
+let read_int_field json key =
+  let open Yojson.Safe.Util in
+  match json |> member key with
+  | `Int i -> Some i
+  | `Float f -> Some (int_of_float f)
+  | _ -> None
+
+let resolve_inference_params ~config_path ~name =
+  match load_json config_path with
+  | Error _ -> { temperature = None; max_tokens = None }
+  | Ok json ->
+    let temp =
+      match read_float_field json (name ^ "_temperature") with
+      | Some _ as v -> v
+      | None -> read_float_field json "default_temperature"
+    in
+    let max_tok =
+      match read_int_field json (name ^ "_max_tokens") with
+      | Some _ as v -> v
+      | None -> read_int_field json "default_max_tokens"
+    in
+    { temperature = temp; max_tokens = max_tok }
+
 (* ── Cascade-level error classification ────────────────── *)
 
 (** Decide whether an error should cascade to the next provider.

--- a/lib/llm_provider/cascade_config.mli
+++ b/lib/llm_provider/cascade_config.mli
@@ -95,6 +95,35 @@ val resolve_model_strings_traced :
   unit ->
   string list * cascade_source
 
+(** {1 Raw JSON Access} *)
+
+(** Load and cache the raw JSON config file.
+    Cached with mtime-based hot-reload.
+    Exposed for consumers needing custom fields beyond model lists
+    (e.g., per-cascade temperature/max_tokens overrides).
+
+    @since 0.89.1 *)
+val load_json : string -> (Yojson.Safe.t, string) result
+
+(** {1 Inference Parameters} *)
+
+(** Per-cascade inference parameter overrides. *)
+type inference_params = {
+  temperature: float option;
+  max_tokens: int option;
+}
+
+(** Resolve inference parameters from cascade.json.
+
+    Resolution order:
+    1. ["{name}_temperature"] / ["{name}_max_tokens"]
+    2. ["default_temperature"] / ["default_max_tokens"]
+    3. [None] (caller uses own defaults)
+
+    @since 0.89.1 *)
+val resolve_inference_params :
+  config_path:string -> name:string -> inference_params
+
 (** {1 Discovery-Aware Health Filtering} *)
 
 (** Filter a provider list by local endpoint health.


### PR DESCRIPTION
## Summary

- Expose `Cascade_config.load_json` for raw JSON config access
- Add `resolve_inference_params` for per-cascade temperature/max_tokens resolution
- Resolution: `{name}_temperature` -> `default_temperature` -> `None`

## Motivation

MASC's `cascade_inference.ml` (100 LOC) duplicates this logic because OAS didn't expose `load_json`. This PR enables MASC to delete that file and use OAS as SSOT.

Part of MASC -> OAS module migration (5 modules, 1,211 LOC total identified).

## Test plan

- [x] Build clean
- [ ] CI green
- [ ] MASC integration test: replace `cascade_inference.ml` with `Cascade_config.resolve_inference_params`

🤖 Generated with [Claude Code](https://claude.com/claude-code)