### PR TITLE
test: add 21 missing tests for v0.89.0 features

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -789,3 +789,7 @@
 (test
  (name test_durable_event)
  (libraries agent_sdk alcotest yojson unix))
+
+(test
+ (name test_tool_index)
+ (libraries agent_sdk alcotest yojson))

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -407,6 +407,102 @@ let test_summarize_old_all_recent () =
   (* All turns fit in keep_recent, no summarization *)
   Alcotest.(check int) "no change" 2 (List.length result)
 
+(* --- clear_tool_results --- *)
+
+let test_clear_tool_results_clears_old () =
+  (* 3 turns: turn1 has tool result, turn2 has tool result, turn3 is recent *)
+  let msgs = [
+    user_msg "turn1";
+    tool_use_msg "t1" "calc";
+    tool_result_msg "t1" (String.make 200 'x');  (* long result *)
+    asst_msg "r1";
+    user_msg "turn2";
+    tool_use_msg "t2" "search";
+    tool_result_msg "t2" (String.make 300 'y');  (* long result *)
+    asst_msg "r2";
+    user_msg "turn3";
+    asst_msg "r3";
+  ] in
+  let result = Context_reducer.reduce
+    (Context_reducer.clear_tool_results ~keep_recent:1) msgs in
+  (* Old turns' tool results should be cleared *)
+  let old_tool_results = List.filter_map (fun (m : Types.message) ->
+    List.find_map (function
+      | Types.ToolResult { content; _ } -> Some content
+      | _ -> None
+    ) m.content
+  ) result in
+  let cleared = List.filter (fun c ->
+    let len = String.length c in
+    len < 100 (* cleared results are short markers *)
+  ) old_tool_results in
+  Alcotest.(check int) "2 old results cleared" 2 (List.length cleared)
+
+let test_clear_tool_results_preserves_recent () =
+  let msgs = [
+    user_msg "turn1";
+    tool_use_msg "t1" "calc";
+    tool_result_msg "t1" (String.make 200 'x');
+    asst_msg "r1";
+  ] in
+  (* keep_recent:1 means all turns are recent — nothing cleared *)
+  let result = Context_reducer.reduce
+    (Context_reducer.clear_tool_results ~keep_recent:5) msgs in
+  let tool_results = List.filter_map (fun (m : Types.message) ->
+    List.find_map (function
+      | Types.ToolResult { content; _ } -> Some content
+      | _ -> None
+    ) m.content
+  ) result in
+  (match tool_results with
+   | [content] -> Alcotest.(check int) "preserved full length" 200 (String.length content)
+   | _ -> Alcotest.fail "expected 1 tool result")
+
+let test_clear_tool_results_short_untouched () =
+  (* Short tool results (<=50 chars) should NOT be cleared even in old turns *)
+  let msgs = [
+    user_msg "turn1";
+    tool_use_msg "t1" "calc";
+    tool_result_msg "t1" "42";  (* 2 chars, below 50 threshold *)
+    asst_msg "r1";
+    user_msg "turn2";
+    asst_msg "r2";
+  ] in
+  let result = Context_reducer.reduce
+    (Context_reducer.clear_tool_results ~keep_recent:1) msgs in
+  let tool_results = List.filter_map (fun (m : Types.message) ->
+    List.find_map (function
+      | Types.ToolResult { content; _ } -> Some content
+      | _ -> None
+    ) m.content
+  ) result in
+  (match tool_results with
+   | [content] -> Alcotest.(check string) "short preserved" "42" content
+   | _ -> Alcotest.fail "expected 1 tool result")
+
+let test_clear_tool_results_error_marker () =
+  (* Error tool results should get error-specific marker *)
+  let msgs = [
+    user_msg "turn1";
+    Types.{ role = Assistant; content = [ToolUse { id = "t1"; name = "fail"; input = `Null }];
+            name = None; tool_call_id = None };
+    Types.{ role = User; content = [ToolResult { tool_use_id = "t1";
+            content = String.make 100 'E'; is_error = true }];
+            name = None; tool_call_id = None };
+    asst_msg "r1";
+    user_msg "turn2"; asst_msg "r2";
+  ] in
+  let result = Context_reducer.reduce
+    (Context_reducer.clear_tool_results ~keep_recent:1) msgs in
+  let has_error_marker = List.exists (fun (m : Types.message) ->
+    List.exists (function
+      | Types.ToolResult { content; _ } ->
+        content = "[tool error result cleared]"
+      | _ -> false
+    ) m.content
+  ) result in
+  Alcotest.(check bool) "error marker present" true has_error_marker
+
 (* --- prune_tool_args --- *)
 
 (** Helper: build an assistant message with a ToolUse whose input has a long string arg. *)
@@ -628,6 +724,12 @@ let () =
     "summarize_old", [
       Alcotest.test_case "basic summarization" `Quick test_summarize_old_basic;
       Alcotest.test_case "all recent no-op" `Quick test_summarize_old_all_recent;
+    ];
+    "clear_tool_results", [
+      Alcotest.test_case "clears old results" `Quick test_clear_tool_results_clears_old;
+      Alcotest.test_case "preserves recent" `Quick test_clear_tool_results_preserves_recent;
+      Alcotest.test_case "short untouched" `Quick test_clear_tool_results_short_untouched;
+      Alcotest.test_case "error marker" `Quick test_clear_tool_results_error_marker;
     ];
     "prune_tool_args", [
       Alcotest.test_case "short args unchanged" `Quick test_prune_tool_args_short_unchanged;

--- a/test/test_hooks.ml
+++ b/test/test_hooks.ml
@@ -84,10 +84,37 @@ let test_invoke_approval_required () =
     (Hooks.PreToolUse { tool_name = "dangerous"; input = `Null; accumulated_cost_usd = 0.0; turn = 0 }) in
   check bool "hook returns ApprovalRequired" true (result = Hooks.ApprovalRequired)
 
+let test_pre_compact_event () =
+  let received_tokens = ref 0 in
+  let hook = function
+    | Hooks.PreCompact { estimated_tokens; _ } ->
+      received_tokens := estimated_tokens;
+      Hooks.Continue
+    | _ -> Hooks.Continue
+  in
+  let msgs = [Types.{ role = User; content = [Text "hello"]; name = None; tool_call_id = None }] in
+  let _result = Hooks.invoke (Some hook)
+    (Hooks.PreCompact { messages = msgs; estimated_tokens = 5000; budget_tokens = 8000 }) in
+  check int "hook received estimated_tokens" 5000 !received_tokens
+
+let test_pre_compact_skip () =
+  let hook = function
+    | Hooks.PreCompact _ -> Hooks.Skip
+    | _ -> Hooks.Continue
+  in
+  let result = Hooks.invoke (Some hook)
+    (Hooks.PreCompact { messages = []; estimated_tokens = 100; budget_tokens = 200 }) in
+  check bool "hook returns Skip" true (result = Hooks.Skip)
+
+let test_empty_hooks_pre_compact () =
+  let hooks = Hooks.empty in
+  check bool "pre_compact is None" true (hooks.pre_compact = None)
+
 let () =
   run "Hooks" [
     "empty", [
       test_case "empty hooks" `Quick test_empty_hooks;
+      test_case "pre_compact None" `Quick test_empty_hooks_pre_compact;
     ];
     "invoke", [
       test_case "invoke None" `Quick test_invoke_none;
@@ -99,5 +126,9 @@ let () =
       test_case "post_tool_use event" `Quick test_post_tool_use_event;
       test_case "post_tool_use_failure event" `Quick
         test_post_tool_use_failure_event;
+    ];
+    "pre_compact", [
+      test_case "receives tokens" `Quick test_pre_compact_event;
+      test_case "returns Skip" `Quick test_pre_compact_skip;
     ];
   ]

--- a/test/test_tool_index.ml
+++ b/test/test_tool_index.ml
@@ -1,0 +1,166 @@
+(** Tests for Tool_index — BM25-based tool retrieval. *)
+
+open Alcotest
+open Agent_sdk
+
+(* ── Helpers ──────────────────────────────────────── *)
+
+let entry name desc =
+  Tool_index.{ name; description = desc; group = None }
+
+let grouped name desc group =
+  Tool_index.{ name; description = desc; group = Some group }
+
+(* ── Construction ─────────────────────────────────── *)
+
+let test_empty_index () =
+  let idx = Tool_index.build [] in
+  check int "empty size" 0 (Tool_index.size idx);
+  check int "empty vocab" 0 (Tool_index.vocabulary_size idx);
+  check (list pass) "empty query" [] (Tool_index.retrieve idx "anything")
+
+let test_of_tools () =
+  let tool = Tool.create ~name:"read_file" ~description:"Read file contents"
+    ~parameters:[] (fun _ -> Ok { Types.content = "ok" }) in
+  let idx = Tool_index.of_tools [tool] in
+  check int "size 1" 1 (Tool_index.size idx);
+  check bool "vocab > 0" true (Tool_index.vocabulary_size idx > 0)
+
+(* ── Retrieval ────────────────────────────────────── *)
+
+let test_single_tool_match () =
+  let idx = Tool_index.build [
+    entry "read_file" "Read contents of a file from disk";
+  ] in
+  let results = Tool_index.retrieve idx "read file" in
+  check bool "has result" true (List.length results > 0);
+  let (name, score) = List.hd results in
+  check string "correct tool" "read_file" name;
+  check bool "positive score" true (score > 0.0)
+
+let test_ranking_order () =
+  let idx = Tool_index.build [
+    entry "write_file" "Write content to a file";
+    entry "read_file" "Read contents of a file from disk";
+    entry "delete_file" "Delete a file from disk";
+  ] in
+  let results = Tool_index.retrieve_names idx "read file contents" in
+  check bool "read_file is first" true
+    (match results with "read_file" :: _ -> true | _ -> false)
+
+let test_irrelevant_query () =
+  let idx = Tool_index.build [
+    entry "git_commit" "Create a git commit with message";
+  ] in
+  let results = Tool_index.retrieve idx "quantum physics entanglement" in
+  (* Should return results (BM25 may still match on common words)
+     but with low scores *)
+  let high_scoring = List.filter (fun (_, s) -> s > 1.0) results in
+  check int "no high-scoring matches" 0 (List.length high_scoring)
+
+let test_top_k_limit () =
+  let config = Tool_index.{ default_config with top_k = 2 } in
+  let idx = Tool_index.build ~config [
+    entry "tool_a" "first tool for testing";
+    entry "tool_b" "second tool for testing";
+    entry "tool_c" "third tool for testing";
+    entry "tool_d" "fourth tool for testing";
+  ] in
+  let results = Tool_index.retrieve idx "tool testing" in
+  check bool "at most 2" true (List.length results <= 2)
+
+(* ── Group co-retrieval ───────────────────────────── *)
+
+let test_group_retrieval () =
+  let idx = Tool_index.build [
+    grouped "git_commit" "Create a git commit" "git";
+    grouped "git_push" "Push commits to remote" "git";
+    grouped "git_status" "Show working tree status" "git";
+    entry "read_file" "Read a file from disk";
+  ] in
+  let results = Tool_index.retrieve_names idx "commit changes" in
+  (* git_commit should match, and git_push + git_status should be co-retrieved *)
+  check bool "git_commit present" true (List.mem "git_commit" results);
+  check bool "git_push co-retrieved" true (List.mem "git_push" results);
+  check bool "git_status co-retrieved" true (List.mem "git_status" results)
+
+(* ── Confidence gate ──────────────────────────────── *)
+
+let test_confident_true () =
+  let idx = Tool_index.build [
+    entry "search" "Search for files and directories";
+  ] in
+  check bool "confident on match" true
+    (Tool_index.confident idx "search files" ~threshold:0.01)
+
+let test_confident_false () =
+  let idx = Tool_index.build [
+    entry "search" "Search for files";
+  ] in
+  check bool "not confident on unrelated" false
+    (Tool_index.confident idx "zxcvbn asdfgh" ~threshold:10.0)
+
+let test_confident_empty_index () =
+  let idx = Tool_index.build [] in
+  check bool "not confident on empty" false
+    (Tool_index.confident idx "anything" ~threshold:0.0)
+
+(* ── Min score filtering ──────────────────────────── *)
+
+let test_min_score_filter () =
+  let config = Tool_index.{ default_config with min_score = 100.0 } in
+  let idx = Tool_index.build ~config [
+    entry "tool" "a simple tool";
+  ] in
+  let results = Tool_index.retrieve idx "tool" in
+  check int "filtered by min_score" 0 (List.length results)
+
+(* ── Edge cases ───────────────────────────────────── *)
+
+let test_empty_query () =
+  let idx = Tool_index.build [entry "tool" "a tool"] in
+  check (list pass) "empty query" [] (Tool_index.retrieve idx "")
+
+let test_single_char_query () =
+  let idx = Tool_index.build [entry "tool" "a tool"] in
+  (* Single char tokenizes to empty (< 2 chars) *)
+  check (list pass) "single char" [] (Tool_index.retrieve idx "a")
+
+let test_duplicate_names () =
+  let idx = Tool_index.build [
+    entry "tool" "first description";
+    entry "tool" "second description";
+  ] in
+  check int "both indexed" 2 (Tool_index.size idx)
+
+(* ── Suite ────────────────────────────────────────── *)
+
+let () =
+  run "Tool_index" [
+    "construction", [
+      test_case "empty index" `Quick test_empty_index;
+      test_case "of_tools" `Quick test_of_tools;
+    ];
+    "retrieval", [
+      test_case "single match" `Quick test_single_tool_match;
+      test_case "ranking order" `Quick test_ranking_order;
+      test_case "irrelevant query" `Quick test_irrelevant_query;
+      test_case "top_k limit" `Quick test_top_k_limit;
+    ];
+    "groups", [
+      test_case "group co-retrieval" `Quick test_group_retrieval;
+    ];
+    "confidence", [
+      test_case "confident true" `Quick test_confident_true;
+      test_case "confident false" `Quick test_confident_false;
+      test_case "confident empty" `Quick test_confident_empty_index;
+    ];
+    "min_score", [
+      test_case "filtering" `Quick test_min_score_filter;
+    ];
+    "edge_cases", [
+      test_case "empty query" `Quick test_empty_query;
+      test_case "single char" `Quick test_single_char_query;
+      test_case "duplicate names" `Quick test_duplicate_names;
+    ];
+  ]


### PR DESCRIPTION
## Summary

Fills test coverage gaps in v0.89.0 features identified during post-merge review.

| Module | Tests Added | Coverage |
|--------|------------|----------|
| `Clear_tool_results` | 4 (clears old, preserves recent, short threshold, error marker) | New strategy fully covered |
| `PreCompact` hook | 3 (token delivery, Skip decision, empty field) | New hook event fully covered |
| `Tool_index` | 14 (construction, ranking, groups, confidence, edge cases) | Comprehensive alcotest file |

## Test plan

- [x] Context_reducer: 45 tests pass (41 existing + 4 new)
- [x] Hooks: 12 tests pass (9 existing + 3 new)
- [x] Tool_index: 14 tests pass (new file)
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)