### PR TITLE
refactor: simplify v0.89.0 modules per 3-agent review

### DIFF
--- a/lib/durable_event.ml
+++ b/lib/durable_event.ml
@@ -64,16 +64,18 @@ type event =
 
 type journal = {
   mutable entries: event list;  (** Stored in reverse chronological order *)
+  mutable size: int;
 }
 
-let create () = { entries = [] }
+let create () = { entries = []; size = 0 }
 
 let append journal event =
-  journal.entries <- event :: journal.entries
+  journal.entries <- event :: journal.entries;
+  journal.size <- journal.size + 1
 
 let events journal = List.rev journal.entries
 
-let length journal = List.length journal.entries
+let length journal = journal.size
 
 (* ── Idempotency ──────────────────────────────────── *)
 
@@ -89,7 +91,7 @@ let fnv1a_hash (s : string) : int =
     h := !h lxor (Char.code c);
     h := !h * prime;
   ) s;
-  !h land 0x7FFFFFFF  (* ensure positive *)
+  !h land max_int  (* ensure positive, 63-bit on 64-bit OCaml *)
 
 let make_idempotency_key ~tool_name ~input =
   let input_str = Yojson.Safe.to_string input in
@@ -139,8 +141,8 @@ type replay_summary = {
   error_count: int;
 }
 
+(* Fold over entries directly (reverse chronological) — avoids List.rev allocation *)
 let replay_summary journal =
-  let evts = events journal in
   let last_turn = ref 0 in
   let completed_tools = ref [] in
   let last_state = ref "unknown" in
@@ -150,7 +152,7 @@ let replay_summary journal =
   List.iter (fun event ->
     match event with
     | Turn_started { turn; _ } ->
-      if turn > !last_turn then last_turn := turn
+      last_turn := max !last_turn turn
     | Llm_request { input_tokens = n; _ } ->
       input_tokens := !input_tokens + n
     | Llm_response { output_tokens = n; _ } ->
@@ -162,7 +164,7 @@ let replay_summary journal =
     | Error_occurred _ ->
       incr errors
     | Tool_called _ | Heartbeat _ | Checkpoint_saved _ -> ()
-  ) evts;
+  ) journal.entries;  (* entries is reverse-chronological; order doesn't matter for aggregation *)
   {
     last_turn = !last_turn;
     completed_tools = List.rev !completed_tools;
@@ -341,16 +343,15 @@ let journal_of_json json =
   let open Yojson.Safe.Util in
   try
     let items = to_list json in
-    let rec parse acc = function
+    (* acc accumulates in reverse — matches journal.entries internal format *)
+    let rec parse acc count = function
       | [] ->
-        let j = create () in
-        List.iter (append j) (List.rev acc);
-        Ok j
+        Ok { entries = acc; size = count }
       | item :: rest ->
         match event_of_json item with
-        | Ok evt -> parse (evt :: acc) rest
+        | Ok evt -> parse (evt :: acc) (count + 1) rest
         | Error e -> Error e
     in
-    parse [] items
+    parse [] 0 items
   with
   | Yojson.Safe.Util.Type_error (msg, _) -> Error msg

--- a/lib/reflexion.ml
+++ b/lib/reflexion.ml
@@ -97,19 +97,19 @@ let store_reflection_episode
 
 (** {1 Core loop} *)
 
+let make_run_result acc response passed =
+  let attempts = List.rev acc in
+  Ok { final_response = response; attempts; passed;
+       total_attempts = List.length attempts }
+
 let run ~config ?memory ~run_agent () =
   let max = max 1 config.max_attempts in
   let rec loop attempt_number reflections acc =
     if attempt_number > max then
-      (* Exhausted all attempts — return the last one *)
-      let attempts = List.rev acc in
-      let last = List.hd (List.rev attempts) in
-      Ok {
-        final_response = last.response;
-        attempts;
-        passed = (match last.verdict with Pass -> true | Fail _ -> false);
-        total_attempts = List.length attempts;
-      }
+      (* Exhausted: acc is newest-first, so hd is the last attempt *)
+      let last = List.hd acc in
+      make_run_result acc last.response
+        (match last.verdict with Pass -> true | Fail _ -> false)
     else
       match run_agent ~reflections with
       | Error e -> Error e
@@ -120,7 +120,6 @@ let run ~config ?memory ~run_agent () =
           | Pass -> None
           | Fail _ ->
             let text = format_reflection ~attempt_number verdict in
-            (* Store in episodic memory if available *)
             (match memory with
              | Some mem ->
                store_reflection_episode mem
@@ -130,36 +129,19 @@ let run ~config ?memory ~run_agent () =
              | None -> ());
             Some text
         in
-        let attempt = {
-          attempt_number;
-          response;
-          verdict;
-          reflection_text;
-        } in
+        let attempt = { attempt_number; response; verdict; reflection_text } in
         let acc = attempt :: acc in
         match verdict with
-        | Pass ->
-          let attempts = List.rev acc in
-          Ok {
-            final_response = response;
-            attempts;
-            passed = true;
-            total_attempts = List.length attempts;
-          }
-        | Fail _ ->
+        | Pass -> make_run_result acc response true
+        | Fail { diagnosis; _ } ->
           let new_reflections =
             match reflection_text with
             | Some text ->
               if config.include_critique then reflections @ [text]
               else
-                (* Strip critique, keep only diagnosis.
-                 verdict is always Fail here (Pass exits early above). *)
                 let diag_only =
-                  match verdict with
-                  | Fail { diagnosis; _ } ->
-                    Printf.sprintf "[Reflection from attempt %d]\nDiagnosis: %s"
-                      attempt_number diagnosis
-                  | Pass -> assert false  (* unreachable: Pass exits loop *)
+                  Printf.sprintf "[Reflection from attempt %d]\nDiagnosis: %s"
+                    attempt_number diagnosis
                 in
                 reflections @ [diag_only]
             | None -> reflections

--- a/lib/tool_index.ml
+++ b/lib/tool_index.ml
@@ -170,18 +170,23 @@ let retrieve (idx : t) (query : string) : (string * float) list =
       (* Take top_k *)
       let top = List.filteri (fun i _ -> i < idx.config.top_k) sorted in
       (* Expand groups: if a matched tool has a group, include all tools
-         in that group *)
-      let matched_groups = List.filter_map (fun (entry, _) ->
-        entry.group
-      ) top in
+         in that group. Uses Hashtbl for O(1) lookups instead of List.mem. *)
+      let group_set = Hashtbl.create 8 in
+      let matched_set = Hashtbl.create 16 in
+      List.iter (fun (entry, _) ->
+        Hashtbl.replace matched_set entry.name true;
+        match entry.group with
+        | Some g -> Hashtbl.replace group_set g true
+        | None -> ()
+      ) top;
       let group_additions =
-        if matched_groups = [] then []
+        if Hashtbl.length group_set = 0 then []
         else
           Array.to_list (Array.to_seq idx.docs
             |> Seq.filter (fun doc ->
               match doc.entry.group with
-              | Some g -> List.mem g matched_groups
-                          && not (List.exists (fun (e, _) -> e.name = doc.entry.name) top)
+              | Some g -> Hashtbl.mem group_set g
+                          && not (Hashtbl.mem matched_set doc.entry.name)
               | None -> false)
             |> Array.of_seq)
           |> List.map (fun doc -> (doc.entry, 0.0))

--- a/test/test_reflexion.ml
+++ b/test/test_reflexion.ml
@@ -3,23 +3,10 @@
 open Alcotest
 open Agent_sdk
 
-(* ── String helpers (avoid external deps) ─────────── *)
+(* ── String helpers ────────────────────────────────── *)
 
-let contains_sub ~affix s =
-  let alen = String.length affix and slen = String.length s in
-  if alen = 0 then true
-  else if alen > slen then false
-  else
-    let rec check i =
-      if i > slen - alen then false
-      else if String.sub s i alen = affix then true
-      else check (i + 1)
-    in
-    check 0
-
-let starts_with_sub ~affix s =
-  let alen = String.length affix in
-  String.length s >= alen && String.sub s 0 alen = affix
+let contains_sub ~affix s = Util.string_contains ~needle:affix s
+let starts_with_sub ~affix s = String.starts_with ~prefix:affix s
 
 (* ── Helpers ──────────────────────────────────────── *)
 


### PR DESCRIPTION
## Summary

3-agent parallel review (Reuse + Quality + Efficiency) of v0.89.0 code. 9 findings fixed, -25 net lines.

| Fix | Impact |
|-----|--------|
| `reflexion.ml`: extract `make_run_result`, eliminate double `List.rev` | O(2n) -> O(1) for last element |
| `reflexion.ml`: bind `diagnosis` in outer pattern | Remove dead `assert false` branch |
| `durable_event.ml`: `mutable size` field | O(1) `length` vs O(n) |
| `durable_event.ml`: `land max_int` | 63-bit FNV-1a vs 31-bit |
| `durable_event.ml`: `replay_summary` direct fold | Skip unnecessary `List.rev` |
| `durable_event.ml`: `journal_of_json` direct build | Skip `List.rev` + `List.iter` |
| `tool_index.ml`: Hashtbl for group lookup | O(1) vs O(n) `List.mem` |
| `test_reflexion.ml`: use `Util.string_contains` | Eliminate duplicated helper |

## Test plan

- [x] Reflexion: 11 tests pass
- [x] Durable_event: 14 tests pass
- [x] Tool_index: 14 tests pass
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)