### PR TITLE
feat(cascade): export model alias resolution

### DIFF
--- a/lib/llm_provider/cascade_config.mli
+++ b/lib/llm_provider/cascade_config.mli
@@ -10,6 +10,22 @@
 
     @since 0.59.0 *)
 
+(** {1 Model Alias Resolution} *)
+
+(** Resolve a GLM model alias to the concrete API model ID.
+    - ["auto"] → env var [ZAI_DEFAULT_MODEL] or ["glm-5"]
+    - ["flash"] → ["glm-4.7-flashx"]
+    - ["turbo"] → ["glm-5-turbo"]
+    - ["vision"] → ["glm-4.6v"]
+    - Concrete IDs pass through unchanged.
+    @since 0.89.1 *)
+val resolve_glm_model_id : string -> string
+
+(** Resolve "auto" and aliases to concrete model IDs for any provider.
+    Cloud providers resolve aliases; local providers pass through.
+    @since 0.89.1 *)
+val resolve_auto_model_id : string -> string -> string
+
 (** {1 Model String Parsing} *)
 
 (** Parse a "provider:model_id" string into a {!Provider_config.t}.


### PR DESCRIPTION
## Summary
- `resolve_glm_model_id`와 `resolve_auto_model_id`를 `.mli`에 export
- MASC가 텔레메트리 label에 resolved model_id를 사용할 수 있게 함
- `model=auto` 대신 `model=glm-5`가 로그에 표시됨

## Depends on
- oas#389 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)