### PR TITLE
fix: remove shell lookup from provider registry

### DIFF
--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -49,6 +49,31 @@ let has_api_key env_name =
    | Some s -> String.trim s <> ""
    | None -> false)
 
+let path_entries ?path () =
+  match path with
+  | Some value -> String.split_on_char ':' value
+  | None ->
+      (match Sys.getenv_opt "PATH" with
+       | Some value -> String.split_on_char ':' value
+       | None -> [])
+  |> List.filter (fun entry -> String.trim entry <> "")
+
+let command_candidates ~name =
+  if Filename.check_suffix name ".exe" then
+    [ name ]
+  else
+    [ name; name ^ ".exe" ]
+
+let is_runnable_path path =
+  Sys.file_exists path && not (Sys.is_directory path)
+
+let command_in_path ?path name =
+  path_entries ?path ()
+  |> List.exists (fun dir ->
+         command_candidates ~name
+         |> List.exists (fun candidate ->
+                is_runnable_path (Filename.concat dir candidate)))
+
 (** Initial endpoints from LLM_ENDPOINTS env var. *)
 let initial_llama_endpoints =
   match Sys.getenv_opt "LLM_ENDPOINTS" with
@@ -165,12 +190,7 @@ let default () =
   } in
   let cc_available =
     let cached = lazy (
-      try
-        let ic = Unix.open_process_in "which claude 2>/dev/null" in
-        let result = try input_line ic with End_of_file -> "" in
-        ignore (Unix.close_process_in ic);
-        String.length (String.trim result) > 0
-      with Unix.Unix_error _ | End_of_file -> false
+      command_in_path "claude"
     ) in
     fun () -> Lazy.force cached
   in

--- a/lib/llm_provider/provider_registry.mli
+++ b/lib/llm_provider/provider_registry.mli
@@ -49,6 +49,9 @@ val available : t -> entry list
 (** Providers whose capabilities satisfy the given predicate. *)
 val find_capable : t -> (Capabilities.capabilities -> bool) -> entry list
 
+(** Check whether a command is discoverable from PATH without shelling out. *)
+val command_in_path : ?path:string -> string -> bool
+
 (** Default registry pre-populated with known providers
     (llama, claude, gemini, glm, openrouter).
     Availability is determined by checking the API key env var. *)

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -87,6 +87,33 @@ let test_available_filter () =
   check int "only 1 available" 1 (List.length avail);
   check string "the up one" "up" (List.hd avail).name
 
+let test_command_in_path_finds_binary () =
+  let tmp = Filename.temp_file "provider-registry" ".bin" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove tmp with Sys_error _ -> ())
+    (fun () ->
+      let dir = Filename.dirname tmp in
+      let name = Filename.basename tmp in
+      check bool "binary found" true
+        (Provider_registry.command_in_path ~path:dir name))
+
+let test_command_in_path_rejects_directory () =
+  let dir = Filename.temp_file "provider-registry" ".dir" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () -> try Unix.rmdir dir with Unix.Unix_error _ -> ())
+    (fun () ->
+      let parent = Filename.dirname dir in
+      let name = Filename.basename dir in
+      check bool "directory is not runnable" false
+        (Provider_registry.command_in_path ~path:parent name))
+
+let test_command_in_path_misses_unknown_binary () =
+  let dir = Filename.get_temp_dir_name () in
+  check bool "missing binary" false
+    (Provider_registry.command_in_path ~path:dir "provider-registry-missing-binary")
+
 (* ── Capability queries ─────────────────────────────── *)
 
 let test_find_capable_tools () =
@@ -236,6 +263,9 @@ let () =
     ];
     "availability", [
       test_case "filter" `Quick test_available_filter;
+      test_case "command_in_path finds binary" `Quick test_command_in_path_finds_binary;
+      test_case "command_in_path rejects directory" `Quick test_command_in_path_rejects_directory;
+      test_case "command_in_path misses unknown binary" `Quick test_command_in_path_misses_unknown_binary;
     ];
     "capabilities", [
       test_case "find with tools" `Quick test_find_capable_tools;


### PR DESCRIPTION
## Summary
- replace shell-based `which claude` discovery with direct PATH lookup
- add focused tests for binary discovery behavior

## Linked issue
- relates to #396

## Validation
- `DUNE_CONFIG__GLOBAL_LOCK=disabled dune exec --root . test/test_provider_registry.exe`

## Cross-model review
- pending: will add review evidence after PR creation
