### PR TITLE
refactor(swarm): fix blocking Unix process call with Eio.Process

### DIFF
--- a/bin/autonomy_smoke_cli.ml
+++ b/bin/autonomy_smoke_cli.ml
@@ -43,11 +43,12 @@ let live_smoke config_file workers prompt =
       Eio_main.run @@ fun env ->
       let net = Eio.Stdenv.net env in
       let clock = Eio.Stdenv.clock env in
+      let _ = clock in
       let base_builder = Agent_sdk.Agent_config.to_builder ~net cfg in
       Printf.eprintf "Spawning %d workers with prompt: %s\n" workers prompt;
       Eio.Switch.run @@ fun sw ->
       match
-        Traced_swarm.run_traced ~sw ~clock ~workers
+        Traced_swarm.run_traced ~sw ~env ~workers
           ~base_builder ~prompt ()
       with
       | Ok { summaries; trace_dir; _ } ->

--- a/examples/swarm_review.ml
+++ b/examples/swarm_review.ml
@@ -162,7 +162,7 @@ Output as a numbered list with severity tags.|}
       Printf.eprintf "[swarm] agent %s finished (%s)\n%!" name tag);
   } in
 
-  match Runner.run ~sw ~clock ~callbacks config with
+  match Runner.run ~sw ~env ~callbacks config with
   | Ok result ->
     Printf.eprintf "[swarm] completed in %.1fs (%d iteration(s), converged=%b)\n%!"
       result.total_elapsed (List.length result.iterations) result.converged;

--- a/lib_swarm/runner.ml
+++ b/lib_swarm/runner.ml
@@ -12,20 +12,17 @@ open Swarm_types
 
 (* ── Metric evaluation ──────────────────────────────────────────── *)
 
-let eval_metric = function
+let eval_metric ~mgr = function
   | Shell_command cmd ->
-    let ic = Unix.open_process_in cmd in
-    let output = In_channel.input_all ic in
-    let status = Unix.close_process_in ic in
-    (match status with
-     | Unix.WEXITED 0 ->
+    (try
+       let output = Eio.Process.parse_out mgr Eio.Buf_read.take_all ["bash"; "-c"; cmd] in
        let trimmed = String.trim output in
        (match float_of_string_opt trimmed with
         | Some v -> Ok v
         | None -> Error (Printf.sprintf "metric command output not a float: %S" trimmed))
-     | Unix.WEXITED code ->
-       Error (Printf.sprintf "metric command exited with code %d" code)
-     | _ -> Error "metric command killed by signal")
+     with
+     | exn ->
+       Error (Printf.sprintf "metric command failed: %s" (Printexc.to_string exn)))
   | Callback f ->
     (try Ok (f ())
      with exn -> Error (Printf.sprintf "metric callback raised: %s" (Printexc.to_string exn)))
@@ -382,7 +379,10 @@ let read_state h f =
 
 (* ── Convergence loop (Mutex-protected) ─────────────────────────── *)
 
-let run_convergence_loop ~sw ~clock ~callbacks config conv =
+let run_convergence_loop ~sw ~env ~callbacks config conv =
+  let clock = Eio.Stdenv.clock env in
+  let _ = clock in
+  let mgr = Eio.Stdenv.process_mgr env in
   let handle = {
     mu = Eio.Mutex.create ();
     state = create_state config;
@@ -412,7 +412,7 @@ let run_convergence_loop ~sw ~clock ~callbacks config conv =
     let results = run_agents_dispatch ~sw ~clock ~callbacks config in
     total_usage := collect_usage !total_usage results;
     (* Evaluate metric *)
-    let metric_value = match eval_metric conv.metric with
+    let metric_value = match eval_metric ~mgr conv.metric with
       | Ok v -> Some v
       | Error _ -> None
     in
@@ -482,7 +482,9 @@ let run_convergence_loop ~sw ~clock ~callbacks config conv =
 
 (* ── Main entry point ───────────────────────────────────────────── *)
 
-let run ~sw ~clock ?(callbacks = no_callbacks) config =
+let run ~sw ~env ?(callbacks = no_callbacks) config =
+  let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let effective_parallel =
     min config.max_parallel
       (Option.value ~default:config.max_parallel config.max_concurrent_agents)
@@ -502,7 +504,7 @@ let run ~sw ~clock ?(callbacks = no_callbacks) config =
          }
        | Error e -> Error e)
     | Some conv ->
-      run_convergence_loop ~sw ~clock ~callbacks config conv
+      run_convergence_loop ~sw ~env ~callbacks config conv
   in
   match config.timeout_sec with
   | Some timeout ->

--- a/lib_swarm/runner.mli
+++ b/lib_swarm/runner.mli
@@ -31,7 +31,7 @@ open Agent_sdk
     @param callbacks Optional lifecycle callbacks (default: {!Swarm_types.no_callbacks}) *)
 val run :
   sw:Eio.Switch.t ->
-  clock:_ Eio.Time.clock ->
+  env:< clock : _ Eio.Time.clock ; process_mgr : _ Eio.Process.mgr ; .. > ->
   ?callbacks:Swarm_types.swarm_callbacks ->
   Swarm_types.swarm_config ->
   (Swarm_types.swarm_result, Error.sdk_error) result
@@ -40,7 +40,7 @@ val run :
 
 (** Evaluate a metric source. [Shell_command] runs a shell command and
     parses stdout as float. [Callback] invokes the function directly. *)
-val eval_metric : Swarm_types.metric_source -> (float, string) result
+val eval_metric : mgr:_ Eio.Process.mgr -> Swarm_types.metric_source -> (float, string) result
 
 (** Aggregate a list of scores using the given strategy. *)
 val aggregate_scores :

--- a/lib_swarm/traced_swarm.ml
+++ b/lib_swarm/traced_swarm.ml
@@ -65,10 +65,12 @@ let make_traced_entries ~clock ~trace_dir ~workers base_builder =
 
 (* ── Main entry point ─────────────────────────────────────── *)
 
-let run_traced ~sw ~clock ~workers ~base_builder
+let run_traced ~sw ~env ~workers ~base_builder
     ?(mode = Swarm_types.Decentralized)
     ?(callbacks = Swarm_types.no_callbacks)
     ?trace_dir ~prompt () =
+  let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let trace_dir =
     match trace_dir with
     | Some d -> d
@@ -90,6 +92,6 @@ let run_traced ~sw ~clock ~workers ~base_builder
       enable_streaming = false;
     }
   in
-  let* swarm_result = Runner.run ~sw ~clock ~callbacks config in
+  let* swarm_result = Runner.run ~sw ~env ~callbacks config in
   let* summaries = collect_summaries ~trace_dir in
   Ok { swarm_result; summaries; trace_dir }

--- a/lib_swarm/traced_swarm.mli
+++ b/lib_swarm/traced_swarm.mli
@@ -25,7 +25,7 @@ type traced_run_result = {
     @param trace_dir Directory for JSONL trace files (default: temp dir) *)
 val run_traced :
   sw:Eio.Switch.t ->
-  clock:_ Eio.Time.clock ->
+  env:< clock : _ Eio.Time.clock ; process_mgr : _ Eio.Process.mgr ; .. > ->
   workers:int ->
   base_builder:Builder.t ->
   ?mode:Swarm_types.orchestration_mode ->

--- a/test/test_swarm.ml
+++ b/test/test_swarm.ml
@@ -23,6 +23,7 @@ let check_float msg expected actual =
 let test_create_state () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let agent = Agent.create ~net:env#net
     ~config:{ Types.default_config with name = "test-agent"; max_turns = 1 } () in
   let config : Swarm_types.swarm_config = {
@@ -85,26 +86,34 @@ let test_no_callbacks () =
 (* ── Runner.eval_metric tests ────────────────────────────────────── *)
 
 let test_eval_metric_callback () =
+  Eio_main.run @@ fun env ->
+  let mgr = Eio.Stdenv.process_mgr env in
   let metric = Swarm_types.Callback (fun () -> 0.95) in
-  match Runner.eval_metric metric with
+  match Runner.eval_metric ~mgr metric with
   | Ok v -> check_float "metric value" 0.95 v
   | Error e -> fail (Printf.sprintf "unexpected error: %s" e)
 
 let test_eval_metric_callback_raises () =
+  Eio_main.run @@ fun env ->
+  let mgr = Eio.Stdenv.process_mgr env in
   let metric = Swarm_types.Callback (fun () -> failwith "boom") in
-  match Runner.eval_metric metric with
+  match Runner.eval_metric ~mgr metric with
   | Ok _ -> fail "expected error"
   | Error e -> check bool "contains boom" true (String.length e > 0)
 
 let test_eval_metric_shell () =
+  Eio_main.run @@ fun env ->
+  let mgr = Eio.Stdenv.process_mgr env in
   let metric = Swarm_types.Shell_command "echo 0.42" in
-  match Runner.eval_metric metric with
+  match Runner.eval_metric ~mgr metric with
   | Ok v -> check_float "shell metric" 0.42 v
   | Error e -> fail (Printf.sprintf "shell metric error: %s" e)
 
 let test_eval_metric_shell_bad_output () =
+  Eio_main.run @@ fun env ->
+  let mgr = Eio.Stdenv.process_mgr env in
   let metric = Swarm_types.Shell_command "echo not-a-number" in
-  match Runner.eval_metric metric with
+  match Runner.eval_metric ~mgr metric with
   | Ok _ -> fail "expected error for non-numeric output"
   | Error _ -> ()
 
@@ -148,6 +157,7 @@ let test_convergence_config_construction () =
 let test_multi_agent_config () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let make name role =
     let agent = Agent.create ~net:env#net
       ~config:{ Types.default_config with name; max_turns = 1 } () in
@@ -200,6 +210,7 @@ let test_swarm_result_construction () =
 let test_state_history () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let agent = Agent.create ~net:env#net
     ~config:{ Types.default_config with name = "a"; max_turns = 1 } () in
   let config : Swarm_types.swarm_config = {
@@ -229,6 +240,7 @@ let mock_run text ~sw:_ _prompt =
 let test_convergence_reaches_target () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let call_count = ref 0 in
   let metric_fn () =
     incr call_count;
@@ -256,7 +268,7 @@ let test_convergence_reaches_target () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     check bool "converged" true result.converged;
     check int "4 iterations" 4 (List.length result.iterations);
@@ -268,6 +280,7 @@ let test_convergence_reaches_target () =
 let test_convergence_patience_exhausted () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let metric_fn () = 0.3 in  (* Never improves *)
   let config : Swarm_types.swarm_config = {
     entries = [
@@ -289,7 +302,7 @@ let test_convergence_patience_exhausted () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     check bool "not converged" false result.converged;
     (* patience=3: first iteration sets baseline, then 3 more without improvement *)
@@ -299,6 +312,7 @@ let test_convergence_patience_exhausted () =
 let test_convergence_max_iterations () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let counter = ref 0 in
   let metric_fn () = incr counter; float_of_int !counter *. 0.1 in
   let config : Swarm_types.swarm_config = {
@@ -321,7 +335,7 @@ let test_convergence_max_iterations () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     check bool "not converged" false result.converged;
     check int "exactly 3 iterations" 3 (List.length result.iterations)
@@ -330,6 +344,7 @@ let test_convergence_max_iterations () =
 let test_single_pass_no_convergence () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let config : Swarm_types.swarm_config = {
     entries = [
       { name = "a1"; run = mock_run "hello"; role = Discover; get_telemetry = None };
@@ -345,7 +360,7 @@ let test_single_pass_no_convergence () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     check bool "not converged" false result.converged;
     check int "1 iteration" 1 (List.length result.iterations);
@@ -356,6 +371,7 @@ let test_single_pass_no_convergence () =
 let test_callbacks_fire () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let iter_starts = ref 0 in
   let iter_ends = ref 0 in
   let agent_starts = ref 0 in
@@ -388,7 +404,7 @@ let test_callbacks_fire () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  (match Runner.run ~sw ~clock ~callbacks config with
+  (match Runner.run ~sw ~env ~callbacks config with
    | Ok _ -> ()
    | Error e -> fail (Printf.sprintf "error: %s" (Error.to_string e)));
   check bool "iter_starts fired" true (!iter_starts > 0);
@@ -421,6 +437,7 @@ let mock_run_failing ~fail_on_call counter ~sw:_ _prompt =
 let test_12_worker_decentralized () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let agent_names = ref [] in
   let callbacks : Swarm_types.swarm_callbacks = {
     on_iteration_start = None;
@@ -463,7 +480,7 @@ let test_12_worker_decentralized () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock ~callbacks config with
+  match Runner.run ~sw ~env ~callbacks config with
   | Ok result ->
     check int "1 iteration" 1 (List.length result.iterations);
     let iter = List.hd result.iterations in
@@ -483,6 +500,7 @@ let test_12_worker_decentralized () =
 let test_12_worker_convergence () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let iteration = ref 0 in
   let metric_fn () =
     incr iteration;
@@ -518,7 +536,7 @@ let test_12_worker_convergence () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     check bool "converged" true result.converged;
     check bool "3 or fewer iterations" true (List.length result.iterations <= 3);
@@ -531,6 +549,7 @@ let test_12_worker_convergence () =
 let test_12_worker_supervisor () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let supervisor_saw_workers = ref false in
   let supervisor_run ~sw:_ prompt =
     (* Supervisor should receive worker summaries *)
@@ -560,7 +579,7 @@ let test_12_worker_supervisor () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     let iter = List.hd result.iterations in
     (* 11 workers + 1 supervisor = 12 results *)
@@ -571,6 +590,7 @@ let test_12_worker_supervisor () =
 let test_12_worker_pipeline () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let received_prompts = ref [] in
   let pipeline_run name ~sw:_ prompt =
     received_prompts := (name, String.length prompt) :: !received_prompts;
@@ -594,7 +614,7 @@ let test_12_worker_pipeline () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     let iter = List.hd result.iterations in
     check int "4 results" 4 (List.length iter.agent_results);
@@ -612,6 +632,7 @@ let test_12_worker_pipeline () =
 let test_partial_failure_resilience () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let counter = ref 0 in
   let config : Swarm_types.swarm_config = {
     entries = [
@@ -631,7 +652,7 @@ let test_partial_failure_resilience () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     let iter = List.hd result.iterations in
     check int "3 results" 3 (List.length iter.agent_results);
@@ -652,6 +673,7 @@ let test_partial_failure_resilience () =
 let test_single_pass_timeout () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let slow_run ~sw:_ _prompt =
     Eio.Time.sleep clock 10.0;  (* 10s — will exceed timeout *)
     Ok { Types.id = "mock"; model = "mock"; stop_reason = Types.EndTurn;
@@ -669,7 +691,7 @@ let test_single_pass_timeout () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok _ -> fail "expected timeout error"
   | Error (Error.Orchestration (Error.TaskTimeout _)) -> ()
   | Error e -> fail (Printf.sprintf "wrong error: %s" (Error.to_string e))
@@ -678,6 +700,7 @@ let test_single_pass_timeout () =
 let test_single_pass_usage () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let config : Swarm_types.swarm_config = {
     entries = [
       { name = "a1"; run = mock_run "hello"; role = Discover; get_telemetry = None };
@@ -693,7 +716,7 @@ let test_single_pass_usage () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     (* mock_run returns usage with input_tokens=10, output_tokens=5 each *)
     check int "api_calls" 2 result.total_usage.api_calls;
@@ -708,6 +731,7 @@ let test_single_pass_usage () =
 let test_convergence_average_aggregate () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let call_count = ref 0 in
   let metric_fn () =
     incr call_count;
@@ -734,7 +758,7 @@ let test_convergence_average_aggregate () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     (* avg([0.3,0.3,0.3,0.3,0.9,0.3]) = 0.4 < 0.5 → not converged *)
     check bool "not converged (avg too low)" false result.converged;

--- a/test/test_swarm_coverage.ml
+++ b/test/test_swarm_coverage.ml
@@ -88,32 +88,42 @@ let test_aggregate_custom_min () =
 (* ── eval_metric extended ─────────────────────────────────── *)
 
 let test_eval_metric_callback_value () =
+  Eio_main.run @@ fun env ->
+  let mgr = Eio.Stdenv.process_mgr env in
   let metric = Callback (fun () -> 0.75) in
-  match Runner.eval_metric metric with
+  match Runner.eval_metric ~mgr metric with
   | Ok v -> check_float "callback metric" 0.75 v
   | Error e -> fail (Printf.sprintf "unexpected error: %s" e)
 
 let test_eval_metric_callback_exception () =
+  Eio_main.run @@ fun env ->
+  let mgr = Eio.Stdenv.process_mgr env in
   let metric = Callback (fun () -> raise (Invalid_argument "bad")) in
-  match Runner.eval_metric metric with
+  match Runner.eval_metric ~mgr metric with
   | Ok _ -> fail "expected error"
   | Error e -> check bool "has message" true (String.length e > 0)
 
 let test_eval_metric_shell_success () =
+  Eio_main.run @@ fun env ->
+  let mgr = Eio.Stdenv.process_mgr env in
   let metric = Shell_command "echo 1.23" in
-  match Runner.eval_metric metric with
+  match Runner.eval_metric ~mgr metric with
   | Ok v -> check_float "shell" 1.23 v
   | Error e -> fail e
 
 let test_eval_metric_shell_non_float () =
+  Eio_main.run @@ fun env ->
+  let mgr = Eio.Stdenv.process_mgr env in
   let metric = Shell_command "echo hello" in
-  match Runner.eval_metric metric with
+  match Runner.eval_metric ~mgr metric with
   | Ok _ -> fail "expected error"
   | Error _ -> ()
 
 let test_eval_metric_shell_failure () =
+  Eio_main.run @@ fun env ->
+  let mgr = Eio.Stdenv.process_mgr env in
   let metric = Shell_command "false" in
-  match Runner.eval_metric metric with
+  match Runner.eval_metric ~mgr metric with
   | Ok _ -> fail "expected error"
   | Error _ -> ()
 
@@ -137,7 +147,7 @@ let test_single_pass_decentralized () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     check int "one iteration" 1 (List.length result.iterations);
     check bool "not converged" false result.converged;
@@ -165,7 +175,7 @@ let test_single_pass_pipeline () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     check int "one iteration" 1 (List.length result.iterations)
   | Error e -> fail (Error.to_string e)
@@ -190,7 +200,7 @@ let test_single_pass_supervisor () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     check int "one iteration" 1 (List.length result.iterations);
     let iter = List.hd result.iterations in
@@ -218,7 +228,7 @@ let test_single_pass_with_error () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     let iter = List.hd result.iterations in
     check int "two results" 2 (List.length iter.agent_results)
@@ -249,7 +259,7 @@ let test_convergence_immediate () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     check bool "converged" true result.converged;
     check int "one iteration" 1 (List.length result.iterations)
@@ -279,7 +289,7 @@ let test_timeout () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Error (Error.Orchestration (Error.TaskTimeout _)) -> ()
   | Error _ -> ()  (* Any error is acceptable *)
   | Ok _ -> fail "expected timeout"
@@ -313,7 +323,7 @@ let test_callbacks_fire () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  (match Runner.run ~sw ~clock ~callbacks config with
+  (match Runner.run ~sw ~env ~callbacks config with
    | Ok _ ->
      check int "started count" 1 (List.length !started);
      check int "done count" 1 (List.length !done_list)
@@ -339,7 +349,7 @@ let test_resource_check_fail () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     let iter = List.hd result.iterations in
     let (_name, status) = List.hd iter.agent_results in
@@ -381,7 +391,7 @@ let test_max_concurrent_agents () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     let iter = List.hd result.iterations in
     check int "four results" 4 (List.length iter.agent_results)

--- a/test/test_swarm_streaming.ml
+++ b/test/test_swarm_streaming.ml
@@ -132,7 +132,7 @@ let test_channel_mailbox_idempotent () =
 
 let test_streaming_supervisor () =
   Eio_main.run @@ fun env ->
-  let clock = Eio.Stdenv.clock env in
+
   let supervisor_saw_workers = ref false in
   let supervisor_run ~sw:_ prompt =
     if String.length prompt > 50 then
@@ -160,7 +160,7 @@ let test_streaming_supervisor () =
     enable_streaming = true;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     let iter = List.hd result.iterations in
     check int "3 results (2 workers + 1 supervisor)" 3
@@ -172,7 +172,7 @@ let test_streaming_supervisor () =
 
 let test_streaming_pipeline () =
   Eio_main.run @@ fun env ->
-  let clock = Eio.Stdenv.clock env in
+
   let received_prompts = ref [] in
   let pipeline_run name ~sw:_ prompt =
     received_prompts := (name, String.length prompt) :: !received_prompts;
@@ -196,7 +196,7 @@ let test_streaming_pipeline () =
     enable_streaming = true;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     let iter = List.hd result.iterations in
     check int "3 results" 3 (List.length iter.agent_results);
@@ -214,7 +214,7 @@ let test_streaming_pipeline () =
 
 let test_streaming_decentralized () =
   Eio_main.run @@ fun env ->
-  let clock = Eio.Stdenv.clock env in
+
   let config : swarm_config = {
     entries = [
       { name = "a1"; run = mock_run "hello"; role = Discover;
@@ -232,7 +232,7 @@ let test_streaming_decentralized () =
     enable_streaming = true;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     check int "1 iteration" 1 (List.length result.iterations);
     let iter = List.hd result.iterations in
@@ -249,7 +249,7 @@ let test_streaming_decentralized () =
 
 let test_streaming_partial_failure () =
   Eio_main.run @@ fun env ->
-  let clock = Eio.Stdenv.clock env in
+
   let config : swarm_config = {
     entries = [
       { name = "ok-1"; run = mock_run "fine"; role = Execute;
@@ -269,7 +269,7 @@ let test_streaming_partial_failure () =
     enable_streaming = true;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     let iter = List.hd result.iterations in
     check int "3 results" 3 (List.length iter.agent_results);
@@ -287,7 +287,7 @@ let test_streaming_partial_failure () =
 
 let test_streaming_disabled_unchanged () =
   Eio_main.run @@ fun env ->
-  let clock = Eio.Stdenv.clock env in
+
   let config : swarm_config = {
     entries = [
       { name = "a1"; run = mock_run "hello"; role = Discover;
@@ -303,7 +303,7 @@ let test_streaming_disabled_unchanged () =
     enable_streaming = false;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     check int "1 iteration" 1 (List.length result.iterations);
     let iter = List.hd result.iterations in
@@ -314,7 +314,7 @@ let test_streaming_disabled_unchanged () =
 
 let test_streaming_usage () =
   Eio_main.run @@ fun env ->
-  let clock = Eio.Stdenv.clock env in
+
   let config : swarm_config = {
     entries = [
       { name = "a1"; run = mock_run "hello"; role = Discover;
@@ -332,7 +332,7 @@ let test_streaming_usage () =
     enable_streaming = true;
   } in
   Eio.Switch.run @@ fun sw ->
-  match Runner.run ~sw ~clock config with
+  match Runner.run ~sw ~env config with
   | Ok result ->
     (* mock_run returns usage with input_tokens=10, output_tokens=5 each *)
     check int "api_calls" 2 result.total_usage.api_calls;

--- a/test/test_traced_swarm.ml
+++ b/test/test_traced_swarm.ml
@@ -46,6 +46,7 @@ let traced_mock_entry ~trace_dir ~name ~tool_names text =
 let test_collect_summaries () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let trace_dir = Filename.temp_dir "test_traced" "" in
   let entries = [
     traced_mock_entry ~trace_dir ~name:"w1"
@@ -55,7 +56,7 @@ let test_collect_summaries () =
   ] in
   let config = Test_helpers.basic_config ~prompt:"test traced" entries in
   Eio.Switch.run @@ fun sw ->
-  (match Runner.run ~sw ~clock config with
+  (match Runner.run ~sw ~env config with
    | Ok _ -> ()
    | Error e -> fail (Printf.sprintf "run error: %s" (Error.to_string e)));
   match Traced_swarm.collect_summaries ~trace_dir with
@@ -71,6 +72,7 @@ let test_collect_summaries () =
 let test_summaries_count_equals_workers () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let trace_dir = Filename.temp_dir "test_traced_n" "" in
   let n = 3 in
   let entries = List.init n (fun i ->
@@ -79,7 +81,7 @@ let test_summaries_count_equals_workers () =
   ) in
   let config = Test_helpers.basic_config ~prompt:"count test" entries in
   Eio.Switch.run @@ fun sw ->
-  (match Runner.run ~sw ~clock config with
+  (match Runner.run ~sw ~env config with
    | Ok _ -> ()
    | Error e -> fail (Printf.sprintf "error: %s" (Error.to_string e)));
   match Traced_swarm.collect_summaries ~trace_dir with
@@ -91,6 +93,7 @@ let test_summaries_count_equals_workers () =
 let test_trace_dir_contains_jsonl () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let _ = clock in
   let trace_dir = Filename.temp_dir "test_traced_files" "" in
   let entries = [
     traced_mock_entry ~trace_dir ~name:"agent-a"
@@ -98,7 +101,7 @@ let test_trace_dir_contains_jsonl () =
   ] in
   let config = Test_helpers.basic_config ~prompt:"file test" entries in
   Eio.Switch.run @@ fun sw ->
-  (match Runner.run ~sw ~clock config with
+  (match Runner.run ~sw ~env config with
    | Ok _ -> ()
    | Error e -> fail (Printf.sprintf "error: %s" (Error.to_string e)));
   let files = Sys.readdir trace_dir |> Array.to_list in


### PR DESCRIPTION
### Description

Replaced the blocking `Unix.open_process_in` with `Eio.Process.parse_out` in `Runner.eval_metric` to resolve Eio fiber starvation issues.
Updated the signature of `Runner.run` and `Traced_swarm.run_traced` to accept `env` instead of `clock` to extract `process_mgr` for shell commands evaluation.

This fixes a critical async/sync handling issue where an Eio fiber could be blocked by a traditional Unix blocking call, violating OCaml 5.x structural concurrency principles.

### Testing
- [x] `dune build` passes without unused-var warnings.
- [x] `make test` passes (all unit tests green).