### PR TITLE
fix(http): isolate outbound connections to prevent fd leak

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -268,7 +268,7 @@ let complete_cascade ~sw ~net ?transport ?clock ?retry_config
 include Complete_stream_acc
 
 (* Internal: HTTP-specific streaming implementation. *)
-let complete_stream_http ~sw ~net ~(config : Provider_config.t)
+let complete_stream_http ~sw:_ ~net ~(config : Provider_config.t)
     ~(messages : Types.message list) ~tools
     ~(on_event : Types.sse_event -> unit) =
   if config.kind = Provider_config.Claude_code then
@@ -295,61 +295,60 @@ let complete_stream_http ~sw ~net ~(config : Provider_config.t)
     | Provider_config.Gemini -> body_str
     | _ -> Http_client.inject_stream_param body_str
   in
-  match Http_client.post_stream ~sw ~net ~url
-          ~headers:config.headers ~body:body_with_stream with
+  match Http_client.with_post_stream ~net ~url
+          ~headers:config.headers ~body:body_with_stream
+          ~f:(fun reader ->
+            let acc = create_stream_acc () in
+            let openai_state = ref None in
+            Http_client.read_sse ~reader ~on_data:(fun ~event_type data ->
+              let events = match config.kind with
+                | Provider_config.Anthropic ->
+                    (match Streaming.parse_sse_event event_type data with
+                     | Some evt -> [evt]
+                     | None -> [])
+                | Provider_config.OpenAI_compat ->
+                    let state = match !openai_state with
+                      | Some s -> s
+                      | None ->
+                          let s = Streaming.create_openai_stream_state () in
+                          openai_state := Some s; s
+                    in
+                    (match Streaming.parse_openai_sse_chunk data with
+                     | Some chunk -> Streaming.openai_chunk_to_events state chunk
+                     | None -> [])
+                | Provider_config.Gemini ->
+                    let state = match !openai_state with
+                      | Some s -> s
+                      | None ->
+                          let s = Streaming.create_openai_stream_state () in
+                          openai_state := Some s; s
+                    in
+                    (match Streaming.parse_gemini_sse_chunk data with
+                     | Some chunk -> Streaming.gemini_chunk_to_events state chunk
+                     | None -> [])
+                | Provider_config.Glm ->
+                    let state = match !openai_state with
+                      | Some s -> s
+                      | None ->
+                          let s = Streaming.create_openai_stream_state () in
+                          openai_state := Some s; s
+                    in
+                    (match Backend_glm.parse_stream_chunk data with
+                     | Some chunk -> Streaming.openai_chunk_to_events state chunk
+                     | None -> [])
+                | Provider_config.Claude_code -> []
+              in
+              List.iter (fun evt ->
+                on_event evt;
+                accumulate_event acc evt
+              ) events
+            ) ();
+            finalize_stream_acc acc) with
   | Error _ as e -> e
-  | Ok reader ->
-      let acc = create_stream_acc () in
-      let openai_state = ref None in
-      Http_client.read_sse ~reader ~on_data:(fun ~event_type data ->
-        let events = match config.kind with
-          | Provider_config.Anthropic ->
-              (match Streaming.parse_sse_event event_type data with
-               | Some evt -> [evt]
-               | None -> [])
-          | Provider_config.OpenAI_compat ->
-              let state = match !openai_state with
-                | Some s -> s
-                | None ->
-                    let s = Streaming.create_openai_stream_state () in
-                    openai_state := Some s; s
-              in
-              (match Streaming.parse_openai_sse_chunk data with
-               | Some chunk -> Streaming.openai_chunk_to_events state chunk
-               | None -> [])
-          | Provider_config.Gemini ->
-              let state = match !openai_state with
-                | Some s -> s
-                | None ->
-                    let s = Streaming.create_openai_stream_state () in
-                    openai_state := Some s; s
-              in
-              (match Streaming.parse_gemini_sse_chunk data with
-               | Some chunk -> Streaming.gemini_chunk_to_events state chunk
-               | None -> [])
-          | Provider_config.Glm ->
-              (* GLM uses OpenAI-compatible SSE format *)
-              let state = match !openai_state with
-                | Some s -> s
-                | None ->
-                    let s = Streaming.create_openai_stream_state () in
-                    openai_state := Some s; s
-              in
-              (match Backend_glm.parse_stream_chunk data with
-               | Some chunk -> Streaming.openai_chunk_to_events state chunk
-               | None -> [])
-          | Provider_config.Claude_code -> []  (* guarded above *)
-        in
-        List.iter (fun evt ->
-          on_event evt;
-          accumulate_event acc evt
-        ) events
-      ) ();
-      match finalize_stream_acc acc with
-      | Ok resp -> Ok resp
-      | Error msg ->
-          Error (Http_client.NetworkError {
-            message = Printf.sprintf "SSE stream error: %s" msg })
+  | Ok (Ok resp) -> Ok resp
+  | Ok (Error msg) ->
+      Error (Http_client.NetworkError {
+        message = Printf.sprintf "SSE stream error: %s" msg })
 
 let complete_stream ~sw ~net ?(transport : Llm_transport.t option)
     ~(config : Provider_config.t)

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -3,6 +3,13 @@
     Wraps Eio + cohttp-eio with TLS. All network and HTTP-level errors
     are captured as {!http_error} so callers do not need [try/with].
 
+    Each synchronous request runs inside its own [Eio.Switch.run] scope
+    so the underlying TCP connection and its file descriptor are released
+    as soon as the response body is fully consumed.  Without this,
+    connections accumulate for the lifetime of the caller's switch —
+    typically the server's main switch — eventually exhausting OS file
+    descriptors.
+
     @since 0.45.0 *)
 
 type http_error =
@@ -27,11 +34,66 @@ let catch_network f =
 
 (* ── Public API ────────────────────────────────────────────── *)
 
-let get_sync ~sw ~net ~url ~headers =
+let add_connection_close headers =
+  ("connection", "close") :: headers
+
+(** Client wrapper that tracks the socket for explicit close.
+    cohttp-eio's [Eio.Switch] cleanup does not reliably call
+    [Unix.close] on the underlying socket fd (observed on macOS,
+    cohttp-eio 6.1.1).  We intercept the connection factory via
+    [make_generic] to capture the socket, then close it explicitly
+    when the switch exits. *)
+let make_closing_client ~sw ~net =
+  let net = (net :> [ `Generic ] Eio.Net.ty Eio.Resource.t) in
+  let https = Api_common.make_https () in
+  (* Track the raw socket separately for explicit close.
+     The socket fd is the resource that leaks; closing it releases the fd. *)
+  let last_sock :
+    [ `Generic ] Eio.Net.stream_socket_ty Eio.Resource.t option ref =
+    ref None
+  in
+  let connect ~sw:conn_sw uri =
+    let service =
+      match Uri.port uri with
+      | Some port -> Int.to_string port
+      | _ -> Uri.scheme uri |> Option.value ~default:"http"
+    in
+    let addr =
+      match
+        Eio.Net.getaddrinfo_stream ~service net
+          (Uri.host_with_default ~default:"localhost" uri)
+      with
+      | ip :: _ -> ip
+      | [] -> failwith "failed to resolve hostname"
+    in
+    let sock = Eio.Net.connect ~sw:conn_sw net addr in
+    last_sock := Some sock;
+    let result : Eio.Flow.two_way_ty Eio.Resource.t =
+      match Uri.scheme uri with
+      | Some "https" -> (
+          match https with
+          | Some wrap ->
+              (wrap uri sock :> Eio.Flow.two_way_ty Eio.Resource.t)
+          | None -> failwith "HTTPS not enabled")
+      | _ -> (sock :> Eio.Flow.two_way_ty Eio.Resource.t)
+    in
+    result
+  in
+  let client = Cohttp_eio.Client.make_generic connect in
+  Eio.Switch.on_release sw (fun () ->
+    match !last_sock with
+    | None -> ()
+    | Some sock ->
+        last_sock := None;
+        (try Eio.Net.close sock with _ -> ()));
+  client
+
+let get_sync ~sw:_ ~net ~url ~headers =
   catch_network (fun () ->
+    Eio.Switch.run @@ fun sw ->
+    let client = make_closing_client ~sw ~net in
     let uri = Uri.of_string url in
-    let client = make_client ~net in
-    let hdr = Http.Header.of_list headers in
+    let hdr = Http.Header.of_list (add_connection_close headers) in
     let resp, resp_body =
       Cohttp_eio.Client.get ~sw client ~headers:hdr uri
     in
@@ -42,11 +104,12 @@ let get_sync ~sw ~net ~url ~headers =
                        resp_body |> take_all) in
     Ok (code, body_str))
 
-let post_sync ~sw ~net ~url ~headers ~body =
+let post_sync ~sw:_ ~net ~url ~headers ~body =
   catch_network (fun () ->
+    Eio.Switch.run @@ fun sw ->
+    let client = make_closing_client ~sw ~net in
     let uri = Uri.of_string url in
-    let client = make_client ~net in
-    let hdr = Http.Header.of_list headers in
+    let hdr = Http.Header.of_list (add_connection_close headers) in
     let resp, resp_body =
       Cohttp_eio.Client.post ~sw client ~headers:hdr
         ~body:(Cohttp_eio.Body.of_string body) uri
@@ -70,6 +133,29 @@ let post_stream ~sw ~net ~url ~headers ~body =
     match Cohttp.Response.status resp with
     | `OK ->
         Ok (Eio.Buf_read.of_flow ~max_size:Api_common.max_response_body resp_body)
+    | status ->
+        let code = Cohttp.Code.code_of_status status in
+        let body_str =
+          Eio.Buf_read.(of_flow ~max_size:Api_common.max_response_body
+                           resp_body |> take_all) in
+        Error (HttpError { code; body = body_str }))
+
+let with_post_stream ~net ~url ~headers ~body ~f =
+  catch_network (fun () ->
+    Eio.Switch.run @@ fun sw ->
+    let client = make_closing_client ~sw ~net in
+    let uri = Uri.of_string url in
+    let hdr = Http.Header.of_list (add_connection_close headers) in
+    let resp, resp_body =
+      Cohttp_eio.Client.post ~sw client ~headers:hdr
+        ~body:(Cohttp_eio.Body.of_string body) uri
+    in
+    match Cohttp.Response.status resp with
+    | `OK ->
+        let reader =
+          Eio.Buf_read.of_flow ~max_size:Api_common.max_response_body resp_body
+        in
+        Ok (f reader)
     | status ->
         let code = Cohttp.Code.code_of_status status in
         let body_str =

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -30,7 +30,10 @@ val post_sync :
 
 (** POST JSON body for SSE/NDJSON streaming.
     Returns [Ok reader] on HTTP 200 (10 MB buffer).
-    Returns [Error] on non-200 or network failure. *)
+    Returns [Error] on non-200 or network failure.
+
+    The connection is bound to [sw]; prefer {!with_post_stream} to
+    ensure the connection fd is released when the stream is consumed. *)
 val post_stream :
   sw:Eio.Switch.t ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
@@ -38,6 +41,17 @@ val post_stream :
   headers:(string * string) list ->
   body:string ->
   (Eio.Buf_read.t, http_error) result
+
+(** Like {!post_stream} but manages connection lifetime internally.
+    [f] receives the reader; when [f] returns the connection is closed
+    and its fd is released immediately. *)
+val with_post_stream :
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  url:string ->
+  headers:(string * string) list ->
+  body:string ->
+  f:(Eio.Buf_read.t -> 'a) ->
+  ('a, http_error) result
 
 (** Read SSE-formatted lines from a reader.
     Strips [data: ] prefixes and passes the payload to [on_data].

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -168,25 +168,25 @@ let create_message_stream ~sw ~net ?(base_url=Api.default_base_url)
                ~stream:true () in
            let body = Yojson.Safe.to_string (`Assoc body_assoc) in
            let url = base_url ^ "/v1/messages" in
-           (match Llm_provider.Http_client.post_stream
-                    ~sw ~net ~url ~headers ~body with
+           (match Llm_provider.Http_client.with_post_stream
+                    ~net ~url ~headers ~body
+                    ~f:(fun reader ->
+                      let acc = create_stream_acc () in
+                      Llm_provider.Http_client.read_sse ~reader
+                        ~on_data:(fun ~event_type data ->
+                          if data <> "[DONE]" then
+                            match parse_sse_event event_type data with
+                            | None -> ()
+                            | Some evt ->
+                                on_event evt; accumulate_event acc evt
+                        ) ();
+                      on_event MessageStop;
+                      finalize_stream_acc acc) with
             | Error e -> Error (map_http_error e)
-            | Ok reader ->
-                let acc = create_stream_acc () in
-                Llm_provider.Http_client.read_sse ~reader
-                  ~on_data:(fun ~event_type data ->
-                    if data <> "[DONE]" then
-                      match parse_sse_event event_type data with
-                      | None -> ()
-                      | Some evt ->
-                          on_event evt; accumulate_event acc evt
-                  ) ();
-                on_event MessageStop;
-                (match finalize_stream_acc acc with
-                | Ok resp -> Ok resp
-                | Error msg ->
-                    Error (Error.Api (Retry.NetworkError {
-                      message = Printf.sprintf "SSE stream error: %s" msg }))))
+            | Ok (Ok resp) -> Ok resp
+            | Ok (Error msg) ->
+                Error (Error.Api (Retry.NetworkError {
+                  message = Printf.sprintf "SSE stream error: %s" msg })))
        | Provider.Openai_chat_completions ->
            (* OpenAI-compatible SSE streaming. *)
            let headers = match Provider.resolve provider_cfg with
@@ -201,43 +201,43 @@ let create_message_stream ~sw ~net ?(base_url=Api.default_base_url)
              |> Llm_provider.Http_client.inject_stream_param
            in
            let url = base_url ^ stream_path in
-           (match Llm_provider.Http_client.post_stream
-                    ~sw ~net ~url ~headers ~body with
+           (match Llm_provider.Http_client.with_post_stream
+                    ~net ~url ~headers ~body
+                    ~f:(fun reader ->
+                      let acc = create_stream_acc () in
+                      let oai_state =
+                        Llm_provider.Streaming.create_openai_stream_state () in
+                      let msg_started = ref false in
+                      Llm_provider.Http_client.read_sse ~reader
+                        ~on_data:(fun ~event_type:_ data ->
+                          if data = "[DONE]" then ()
+                          else
+                            match Llm_provider.Streaming.parse_openai_sse_chunk
+                                    data with
+                            | None -> ()
+                            | Some chunk ->
+                                if not !msg_started then begin
+                                  msg_started := true;
+                                  let evt = MessageStart {
+                                    id = chunk.chunk_id;
+                                    model = chunk.chunk_model;
+                                    usage = None } in
+                                  on_event evt;
+                                  accumulate_event acc evt
+                                end;
+                                List.iter (fun evt ->
+                                  on_event evt;
+                                  accumulate_event acc evt
+                                ) (Llm_provider.Streaming.openai_chunk_to_events
+                                     oai_state chunk)
+                        ) ();
+                      on_event MessageStop;
+                      finalize_stream_acc acc) with
             | Error e -> Error (map_http_error e)
-            | Ok reader ->
-                let acc = create_stream_acc () in
-                let oai_state =
-                  Llm_provider.Streaming.create_openai_stream_state () in
-                let msg_started = ref false in
-                Llm_provider.Http_client.read_sse ~reader
-                  ~on_data:(fun ~event_type:_ data ->
-                    if data = "[DONE]" then ()
-                    else
-                      match Llm_provider.Streaming.parse_openai_sse_chunk
-                              data with
-                      | None -> ()
-                      | Some chunk ->
-                          if not !msg_started then begin
-                            msg_started := true;
-                            let evt = MessageStart {
-                              id = chunk.chunk_id;
-                              model = chunk.chunk_model;
-                              usage = None } in
-                            on_event evt;
-                            accumulate_event acc evt
-                          end;
-                          List.iter (fun evt ->
-                            on_event evt;
-                            accumulate_event acc evt
-                          ) (Llm_provider.Streaming.openai_chunk_to_events
-                               oai_state chunk)
-                  ) ();
-                on_event MessageStop;
-                (match finalize_stream_acc acc with
-                | Ok resp -> Ok resp
-                | Error msg ->
-                    Error (Error.Api (Retry.NetworkError {
-                      message = Printf.sprintf "SSE stream error: %s" msg }))))
+            | Ok (Ok resp) -> Ok resp
+            | Ok (Error msg) ->
+                Error (Error.Api (Retry.NetworkError {
+                  message = Printf.sprintf "SSE stream error: %s" msg })))
        | Provider.Custom _ ->
            (* Sync fallback: non-streaming call + synthetic events *)
            (match Api.create_message ~sw ~net ~base_url


### PR DESCRIPTION
## Summary
- `get_sync`/`post_sync`: per-request `Eio.Switch.run` + `Connection: close` 헤더
- `make_closing_client`: socket tracking + explicit close on switch release
- `with_post_stream`: callback 패턴으로 streaming connection 수명 관리

## Background
MASC-MCP 서버에서 OAS HTTP client를 통한 llama-server 호출 시 TCP connection fd가 CLOSED 상태로 누적. 8시간 후 3,613개 fd → `Too many open files` → 서버 사망.

근본 원인: cohttp-eio 6.1.1이 `Eio.Switch` cleanup 시 socket fd를 `Unix.close()` 하지 않음.
`Eio.Switch.run`, `Eio.Flow.shutdown`, `Eio.Net.close` 모두 fd 해제 실패 확인.

## Test plan
- [x] `dune build` + `dune runtest` 통과
- [x] MASC-MCP 라이브 서버에서 fd 추이 관찰
- [ ] cohttp-eio upstream 이슈 보고 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)