### PR TITLE
fix(resilience): guard Fiber.fork against exception leaks (#406)

### DIFF
--- a/lib/event_forward.ml
+++ b/lib/event_forward.ml
@@ -195,27 +195,34 @@ let start ~sw ~(net : _ Eio.Net.t) ~bus t =
     t.running <- true;
     let sub = Event_bus.subscribe bus in
     Eio.Fiber.fork ~sw (fun () ->
-      let batch = ref [] in
-      let batch_len = ref 0 in
-      while t.running do
-        (* Drain available events *)
-        let events = Event_bus.drain sub in
-        let payloads = List.map event_to_payload events in
-        batch := !batch @ payloads;
-        batch_len := !batch_len + List.length payloads;
-        (* Flush if batch is full — O(1) check via counter *)
-        if !batch_len >= t.batch_size then begin
-          deliver_batch t ~sw ~net !batch;
-          batch := [];
-          batch_len := 0
-        end;
-        (* Small yield to avoid busy-spinning *)
-        Eio.Fiber.yield ()
-      done;
-      (* Flush remaining *)
-      if !batch <> [] then
-        deliver_batch t ~sw ~net !batch;
-      Event_bus.unsubscribe bus sub
+      Fun.protect
+        ~finally:(fun () ->
+          t.running <- false;
+          (try Event_bus.unsubscribe bus sub with _ -> ()))
+        (fun () ->
+          try
+            let batch = ref [] in
+            let batch_len = ref 0 in
+            while t.running do
+              let events = Event_bus.drain sub in
+              let payloads = List.map event_to_payload events in
+              batch := !batch @ payloads;
+              batch_len := !batch_len + List.length payloads;
+              (* Flush if batch is full — O(1) check via counter *)
+              if !batch_len >= t.batch_size then begin
+                deliver_batch t ~sw ~net !batch;
+                batch := [];
+                batch_len := 0
+              end;
+              Eio.Fiber.yield ()
+            done;
+            if !batch <> [] then
+              deliver_batch t ~sw ~net !batch
+          with
+          | Eio.Cancel.Cancelled _ as ex -> raise ex
+          | exn ->
+            Log.warn t.log "event forward loop crashed"
+              [Log.S ("error", Printexc.to_string exn)])
     )
   end
 

--- a/lib/runtime_server.ml
+++ b/lib/runtime_server.ml
@@ -156,49 +156,55 @@ let apply_command ~sw state store (session : session) command =
       else
         let participant_name = detail.participant_name in
         Eio.Fiber.fork ~sw (fun () ->
-          ignore
-            (match
-               persist_event store state session_id
-                 (Agent_became_live
-                    {
-                      participant_name;
-                      summary = Some "runtime-started";
-                      provider = resolution.resolved_provider;
-                      model = resolution.resolved_model;
-                      error = None;
-                    })
-             with
-             | Error _ -> Ok ()
-             | Ok _ -> (
-                 match
-                   run_participant store state session_id resolution detail
-                 with
-                 | Ok summary ->
-                     let* _session, _ =
-                       persist_event store state session_id
-                         (Agent_completed
-                            {
-                              participant_name;
-                              summary = Some summary;
-                              provider = resolution.resolved_provider;
-                              model = resolution.resolved_model;
-                              error = None;
-                            })
-                     in
-                     Ok ()
-                 | Error err ->
-                     let* _session, _ =
-                       persist_event store state session_id
-                         (Agent_failed
-                            {
-                              participant_name;
-                              summary = None;
-                              provider = resolution.resolved_provider;
-                              model = resolution.resolved_model;
-                              error = Some (Error.to_string err);
-                            })
-                     in
-                     Ok ())));
+          try
+            ignore
+              (match
+                 persist_event store state session_id
+                   (Agent_became_live
+                      {
+                        participant_name;
+                        summary = Some "runtime-started";
+                        provider = resolution.resolved_provider;
+                        model = resolution.resolved_model;
+                        error = None;
+                      })
+               with
+               | Error _ -> Ok ()
+               | Ok _ -> (
+                   match
+                     run_participant store state session_id resolution detail
+                   with
+                   | Ok summary ->
+                       let* _session, _ =
+                         persist_event store state session_id
+                           (Agent_completed
+                              {
+                                participant_name;
+                                summary = Some summary;
+                                provider = resolution.resolved_provider;
+                                model = resolution.resolved_model;
+                                error = None;
+                              })
+                       in
+                       Ok ()
+                   | Error err ->
+                       let* _session, _ =
+                         persist_event store state session_id
+                           (Agent_failed
+                              {
+                                participant_name;
+                                summary = None;
+                                provider = resolution.resolved_provider;
+                                model = resolution.resolved_model;
+                                error = Some (Error.to_string err);
+                              })
+                       in
+                       Ok ()))
+          with
+          | Eio.Cancel.Cancelled _ as ex -> raise ex
+          | exn ->
+            Eio.traceln "Runtime_server: participant %s fork failed: %s"
+              participant_name (Printexc.to_string exn));
         Ok (Command_applied session)
   | Attach_artifact detail ->
       let* artifact =


### PR DESCRIPTION
## Summary

`Fiber.fork` 내 예외가 보호되지 않으면 Switch 전체를 취소시켜 형제 fiber까지 연쇄 종료됩니다. 보호되지 않은 2개 fork 사이트에 예외 경계를 추가합니다.

### 변경 내용

| 파일 | 위험도 | 수정 |
|------|--------|------|
| `event_forward.ml` | 높음 (백그라운드 루프) | `Fun.protect` + `try-with` — 예외 시 로그 후 graceful shutdown, cleanup 보장 |
| `runtime_server.ml` | 중간 (participant fork) | `try-with` — 예외 시 `Eio.traceln`으로 participant명과 에러 로그 |

### 기존 보호 상태 (변경 없음)

| 파일 | 상태 |
|------|------|
| `agent/agent.ml` | 이중 try-with, Cancel 재발생 |
| `async_agent.ml` | Switch.run + 포괄적 try-with |
| `lib_swarm/runner.ml` | inner Switch (구조적 동시성으로 의도적 전파) |

Closes #406

## Test plan
- [x] `test_event_forward` 20 tests pass
- [x] `test_runtime` 12 tests pass
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)