### PR TITLE
fix(ci): widen connect type for cohttp-eio 6.2 + sync sdk_version

### DIFF
--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -68,16 +68,15 @@ let make_closing_client ~sw ~net =
     in
     let sock = Eio.Net.connect ~sw:conn_sw net addr in
     last_sock := Some sock;
-    let result : Eio.Flow.two_way_ty Eio.Resource.t =
-      match Uri.scheme uri with
-      | Some "https" -> (
-          match https with
-          | Some wrap ->
-              (wrap uri sock :> Eio.Flow.two_way_ty Eio.Resource.t)
-          | None -> failwith "HTTPS not enabled")
-      | _ -> (sock :> Eio.Flow.two_way_ty Eio.Resource.t)
-    in
-    result
+    (* Return type must include `Close for cohttp-eio >= 6.2 make_generic *)
+    match Uri.scheme uri with
+    | Some "https" -> (
+        match https with
+        | Some wrap ->
+            (wrap uri sock
+              :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
+        | None -> failwith "HTTPS not enabled")
+    | _ -> (sock :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
   in
   let client = Cohttp_eio.Client.make_generic connect in
   Eio.Switch.on_release sw (fun () ->

--- a/lib/sdk_version.ml
+++ b/lib/sdk_version.ml
@@ -1,5 +1,5 @@
 (** Single source of truth for the SDK version string.
     All other modules reference this instead of hardcoding. *)
 
-let version = "0.91.0"
+let version = "0.91.1"
 let sdk_name = "agent_sdk"


### PR DESCRIPTION
## Summary
- cohttp-eio 6.2.1에서 `make_generic`이 `Close` capability를 요구하도록 변경됨
- `connect` 함수의 반환 타입을 `two_way_ty`에서 `[ \`Close | \`Flow | \`R | \`Shutdown | \`W ]`로 확장
- `sdk_version.ml`을 `dune-project`(0.91.1)과 동기화

## Test plan
- [x] 로컬 빌드 통과
- [x] 로컬 테스트 통과
- [ ] CI 5.1.x + 5.4.x 빌드/테스트
- [ ] Version Consistency 체크