### PR TITLE
fix(swarm): log metric eval errors and clarify ignore patterns

### DIFF
--- a/lib_swarm/runner.ml
+++ b/lib_swarm/runner.ml
@@ -198,6 +198,7 @@ let collect_usage acc results =
     match r with
     | Ok (resp : Types.api_response) ->
       (match resp.usage with Some u -> Types.add_usage a u | None -> a)
+    (* Errored agent — no usage data to collect *)
     | Error _ -> a
   ) acc results
 
@@ -248,7 +249,8 @@ let run_streaming_supervisor ~sw ~clock ~callbacks config =
     let channel = Swarm_channel.create ~capacity:64 in
     (* Pre-create mailboxes so broadcast reaches everyone *)
     List.iter (fun (e : agent_entry) ->
-      ignore (Swarm_channel.mailbox channel ~agent_name:e.name)
+      (* Pre-create mailbox for broadcast delivery (return value unused) *)
+      let _ = Swarm_channel.mailbox channel ~agent_name:e.name in ()
     ) (sup :: workers);
     let worker_results = ref [] in
     Eio.Switch.run @@ fun inner_sw ->
@@ -331,7 +333,8 @@ let run_agents_dispatch ~sw ~clock ~callbacks config =
       (* Decentralized streaming: workers write to channel, collect results *)
       let channel = Swarm_channel.create ~capacity:64 in
       List.iter (fun (e : agent_entry) ->
-        ignore (Swarm_channel.mailbox channel ~agent_name:e.name)
+        (* Pre-create mailbox for broadcast delivery (return value unused) *)
+        let _ = Swarm_channel.mailbox channel ~agent_name:e.name in ()
       ) config.entries;
       let run_with_check entry =
         if check_resource config then
@@ -424,7 +427,9 @@ let run_convergence_loop ~sw ~env ~callbacks config conv =
     (* Evaluate metric *)
     let metric_value = match eval_metric ~mgr conv.metric with
       | Ok v -> Some v
-      | Error _ -> None
+      | Error msg ->
+        Printf.eprintf "metric eval failed (iteration %d): %s\n%!" iter msg;
+        None
     in
     let agent_results =
       List.map (fun (name, status, _) -> (name, status)) results


### PR DESCRIPTION
## Summary

- `runner.ml:427`: metric eval 실패 시 error message를 stderr에 출력 (기존: 무시)
- `runner.ml:251,334`: `ignore (Swarm_channel.mailbox ...)` → `let _ = ...` + side-effect 의도를 명시하는 주석
- `runner.ml:201`: `| Error _ -> a`에 "errored agent has no usage" 설명 주석

## Context

OCaml 5.x 감사 Tier 2. convergence loop에서 metric 평가 실패가 무시되면 patience_counter만 증가하여 조기 종료될 수 있었음. 이제 에러가 로깅되어 디버깅 가능.

## Test plan

- [x] `dune build --root . lib_swarm/` 빌드 통과
- [x] `test_swarm.exe` — 33 tests, all pass
- [x] 기존 API 변경 없음

Generated with [Claude Code](https://claude.com/claude-code)