### PR TITLE
ci: pin mcp-protocol-sdk to 1.0.1 SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Pin fork packages
         run: |
-          SDK_REF=63200cf423245b8f2db1c696e23fcd7aa1451d88
+          SDK_REF=079844bcaf651f95f0a9b99c15eb10dfa072a030
           # bisect_ppx fork only needed for 5.4.x (coverage); skip on 5.1.x
           # to avoid dependency resolution failures
           if [ "${{ matrix.ocaml-compiler }}" = "5.4.x" ]; then
@@ -121,7 +121,7 @@ jobs:
 
       - name: Pin fork packages
         run: |
-          SDK_REF=63200cf423245b8f2db1c696e23fcd7aa1451d88
+          SDK_REF=079844bcaf651f95f0a9b99c15eb10dfa072a030
           opam pin add bisect_ppx git+https://github.com/patricoferris/bisect_ppx.git#5.2 --no-action --yes
           opam pin add mcp_protocol git+https://github.com/jeong-sik/mcp-protocol-sdk.git#${SDK_REF} --no-action --yes
           opam pin add mcp_protocol_eio git+https://github.com/jeong-sik/mcp-protocol-sdk.git#${SDK_REF} --no-action --yes


### PR DESCRIPTION
## Summary
- update the CI mcp-protocol-sdk pin from `63200cf423245b8f2db1c696e23fcd7aa1451d88` to `079844bcaf651f95f0a9b99c15eb10dfa072a030`
- keep `mcp_protocol`, `mcp_protocol_eio`, and `mcp_protocol_http` lower bounds at `>= 0.15.0`
- separate this CI validation change from PR #428 so dependency policy and CI pinning are reviewed independently

## Why
- `main` already absorbed the `_meta` compatibility fix in #427 via `tool_result_of_yojson` helpers
- raising minimum MCP dependency versions is not required to validate current compatibility and would narrow consumer support unnecessarily
- this PR only asks CI to exercise the current code against the newer pinned SDK commit

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/chore/ci-pin-mcp-sdk-1.0.1 @all`
- `./_build/default/test/test_mcp.exe`
- `./_build/default/test/test_mcp_deep.exe`
- `./_build/default/test/test_mcp_coverage.exe`