### PR TITLE
feat(context): add importance-scored reducer helper

### DIFF
--- a/lib/context_reducer.ml
+++ b/lib/context_reducer.ml
@@ -31,6 +31,9 @@ type strategy =
 
 type t = { strategy : strategy }
 
+type importance_scorer = index:int -> total:int -> message -> float
+type importance_boost = message -> float option
+
 (** CJK-aware token estimation.
     ASCII: ~4 chars per token. Multi-byte (CJK, emoji, etc.): ~2/3 token per character.
     Walks the string byte-by-byte using UTF-8 lead-byte classification. O(n), no allocation. *)
@@ -398,6 +401,24 @@ let clear_tool_results ~keep_recent =
   { strategy = Clear_tool_results { keep_recent } }
 let compose strategies = { strategy = Compose (List.map (fun r -> r.strategy) strategies) }
 let custom f = { strategy = Custom f }
+let clamp_score score = Float.min 1.0 (Float.max 0.0 score)
+
+let importance_scored ?(threshold=0.3) ?boost ~scorer () =
+  let threshold = clamp_score threshold in
+  custom (fun messages ->
+    let total = List.length messages in
+    List.filteri (fun index message ->
+      let base_score = clamp_score (scorer ~index ~total message) in
+      let final_score =
+        match boost with
+        | None -> base_score
+        | Some boost ->
+          (match boost message with
+           | None -> base_score
+           | Some boosted -> Float.max base_score (clamp_score boosted))
+      in
+      final_score >= threshold
+    ) messages)
 
 (** Dynamic strategy: selects a strategy per turn based on conversation state.
     Example: early turns get full context, later turns use token budget.

--- a/lib/context_reducer.mli
+++ b/lib/context_reducer.mli
@@ -31,6 +31,17 @@ type strategy =
 (** A configured reducer wrapping a strategy. *)
 type t = { strategy : strategy }
 
+(** Score a message for importance-aware filtering.
+    [index] is the zero-based position in the original list and [total]
+    is the list length. Return a score in [0.0, 1.0]; out-of-range values
+    are clamped. *)
+type importance_scorer = index:int -> total:int -> message -> float
+
+(** Optionally raise a message to a minimum importance score.
+    Return [Some score] to boost a message, or [None] to leave the
+    base score unchanged. Out-of-range values are clamped. *)
+type importance_boost = message -> float option
+
 (** {1 Token estimation} *)
 
 (** CJK-aware character-level token estimation.
@@ -73,6 +84,11 @@ val summarize_old : keep_recent:int -> summarizer:(message list -> string) -> t
 val clear_tool_results : keep_recent:int -> t
 val compose : t list -> t
 val custom : (message list -> message list) -> t
+val importance_scored :
+  ?threshold:float ->
+  ?boost:importance_boost ->
+  scorer:importance_scorer ->
+  unit -> t
 
 (** Dynamic strategy: selects a strategy per turn based on
     conversation state. *)

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -187,6 +187,54 @@ let test_custom () =
    | { Types.role = Types.Assistant; _ } :: _ -> ()
    | _ -> Alcotest.fail "expected reversed order")
 
+let test_importance_scored_drops_low_scores () =
+  let msgs = [
+    user_msg "goal";
+    asst_msg "low-value";
+    asst_msg "keep-me";
+  ] in
+  let reducer =
+    Context_reducer.importance_scored
+      ~threshold:0.5
+      ~scorer:(fun ~index ~total:_ _msg ->
+        match index with
+        | 0 -> 0.9
+        | 1 -> 0.2
+        | _ -> 0.8)
+      ()
+  in
+  let result = Context_reducer.reduce reducer msgs in
+  Alcotest.(check int) "drops one message" 2 (List.length result);
+  match result with
+  | [first; second] ->
+    Alcotest.(check string) "first kept" "goal" (Types.text_of_message first);
+    Alcotest.(check string) "second kept" "keep-me" (Types.text_of_message second)
+  | _ -> Alcotest.fail "unexpected filtered result"
+
+let test_importance_scored_boost_preserves_message () =
+  let msgs = [
+    user_msg "goal";
+    asst_msg "[KEEP] anchor";
+    asst_msg "low-value";
+  ] in
+  let reducer =
+    Context_reducer.importance_scored
+      ~threshold:0.5
+      ~scorer:(fun ~index:_ ~total:_ _msg -> 0.2)
+      ~boost:(fun msg ->
+        if Util.string_contains ~needle:"[KEEP]" (Types.text_of_message msg) then
+          Some 0.95
+        else
+          None)
+      ()
+  in
+  let result = Context_reducer.reduce reducer msgs in
+  Alcotest.(check int) "boost preserves one low score message" 1 (List.length result);
+  match result with
+  | [msg] ->
+    Alcotest.(check string) "boosted text kept" "[KEEP] anchor" (Types.text_of_message msg)
+  | _ -> Alcotest.fail "unexpected boosted result"
+
 (* --- edge cases --- *)
 
 let test_empty () =
@@ -697,6 +745,10 @@ let () =
     ];
     "custom", [
       Alcotest.test_case "custom fn called" `Quick test_custom;
+    ];
+    "importance_scored", [
+      Alcotest.test_case "drops low scores" `Quick test_importance_scored_drops_low_scores;
+      Alcotest.test_case "boost preserves message" `Quick test_importance_scored_boost_preserves_message;
     ];
     "prune_tool_outputs", [
       Alcotest.test_case "short outputs unchanged" `Quick test_prune_short_outputs;


### PR DESCRIPTION
## Summary
- add `Context_reducer.importance_scored` as a consumer-facing helper for score-based message compaction
- expose scorer and boost function types in the public `Context_reducer` interface
- add reducer tests for threshold filtering and boost-based preservation

## Why
- `#416` asks OAS to own the reusable importance-scored compaction primitive instead of forcing each consumer to rebuild the same scoring+filter loop with `Custom`
- this keeps reducer mechanics in OAS while still letting consumers tune scoring and boost rules
- MASC can use this shape to shrink the local `DropLowImportance` closure in `context_compact_oas.ml`

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/feat/416-importance-scored-reducer ./test/test_context_reducer.exe`
- `./_build/default/test/test_context_reducer.exe`

Closes #416