### PR TITLE
feat(context): add reusable intent classification core

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -49,6 +49,7 @@ module Error_domain = Error_domain
 module Hooks = Hooks
 module Tracing = Tracing
 module Context_reducer = Context_reducer
+module Context_intent = Context_intent
 module Budget_strategy = Budget_strategy
 module Tool = Tool
 module Mcp = Mcp

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -20,6 +20,7 @@ module Error_domain = Error_domain
 module Hooks = Hooks
 module Tracing = Tracing
 module Context_reducer = Context_reducer
+module Context_intent = Context_intent
 module Budget_strategy = Budget_strategy
 module Tool = Tool
 module Mcp = Mcp

--- a/lib/context_intent.ml
+++ b/lib/context_intent.ml
@@ -1,0 +1,313 @@
+(** Reusable query intent classification for OAS consumers. *)
+
+open Types
+
+type intent =
+  | Conversational
+  | Task_command
+  | Status_check
+  | Knowledge_query
+  | Coordination
+[@@deriving yojson, show]
+
+type retrieval_depth =
+  | Skip
+  | Light
+  | Full
+[@@deriving yojson, show]
+
+type classification = {
+  intent : intent;
+  depth : retrieval_depth;
+  confidence : float;
+  rationale : string option;
+}
+[@@deriving yojson, show]
+
+let intent_to_string = function
+  | Conversational -> "conversational"
+  | Task_command -> "task_command"
+  | Status_check -> "status_check"
+  | Knowledge_query -> "knowledge_query"
+  | Coordination -> "coordination"
+
+let normalize_label raw =
+  raw
+  |> String.trim
+  |> String.lowercase_ascii
+  |> String.map (function
+       | '-' | ' ' -> '_'
+       | c -> c)
+
+let intent_of_string raw =
+  match normalize_label raw with
+  | "conversational" | "conversation" -> Ok Conversational
+  | "task_command" | "task" | "command" -> Ok Task_command
+  | "status_check" | "status" | "progress" -> Ok Status_check
+  | "knowledge_query" | "knowledge" | "query" | "question" -> Ok Knowledge_query
+  | "coordination" | "coordinate" | "handoff" -> Ok Coordination
+  | other ->
+      Error
+        (Printf.sprintf
+           "unknown intent '%s' (expected conversational, task_command, status_check, knowledge_query, coordination)"
+           other)
+
+let depth_for_intent = function
+  | Conversational | Task_command -> Skip
+  | Status_check | Coordination -> Light
+  | Knowledge_query -> Full
+
+let clamp_unit value =
+  if value < 0.0 then 0.0 else if value > 1.0 then 1.0 else value
+
+let starts_with_any ~prefixes text =
+  List.exists
+    (fun prefix ->
+      let lp = String.length prefix in
+      String.length text >= lp && String.sub text 0 lp = prefix)
+    prefixes
+
+let matched_keywords keywords text =
+  List.filter
+    (fun keyword -> Util.contains_substring_ci ~haystack:text ~needle:keyword)
+    keywords
+
+let string_of_signals intent signals =
+  match signals with
+  | [] -> intent_to_string intent ^ ": default fallback"
+  | _ ->
+      Printf.sprintf "%s: matched %s" (intent_to_string intent)
+        (String.concat ", " signals)
+
+let heuristic_classify query =
+  let text = String.trim query in
+  let lowered = String.lowercase_ascii text in
+  let len = String.length lowered in
+  let short = len > 0 && len <= 48 in
+  let asks_question =
+    Util.string_contains ~needle:"?" lowered
+    || starts_with_any ~prefixes:
+         [
+           "what";
+           "why";
+           "how";
+           "when";
+           "where";
+           "which";
+           "who";
+           "can you";
+           "could you";
+           "would you";
+           "tell me";
+           "show me";
+           "explain";
+         ]
+         lowered
+  in
+  let starts_with_action =
+    starts_with_any ~prefixes:
+      [
+        "fix";
+        "add";
+        "remove";
+        "update";
+        "refactor";
+        "write";
+        "create";
+        "open";
+        "close";
+        "merge";
+        "review";
+        "run";
+        "implement";
+        "build";
+        "test";
+        "check";
+      ]
+      lowered
+  in
+  let conversational_hits =
+    matched_keywords
+      [ "hello"; "hi"; "hey"; "thanks"; "thank you"; "good morning"; "good evening" ]
+      lowered
+  in
+  let task_hits =
+    matched_keywords
+      [
+        "fix";
+        "add";
+        "remove";
+        "update";
+        "refactor";
+        "write";
+        "create";
+        "open";
+        "close";
+        "merge";
+        "review";
+        "run";
+        "implement";
+        "build";
+        "test";
+      ]
+      lowered
+  in
+  let status_hits =
+    matched_keywords
+      [ "status"; "progress"; "remaining"; "pending"; "blocked"; "current"; "state"; "what changed"; "what's open"; "open issue" ]
+      lowered
+  in
+  let knowledge_hits =
+    matched_keywords
+      [ "explain"; "how"; "why"; "what is"; "docs"; "document"; "search"; "find"; "lookup"; "understand"; "compare"; "analyze" ]
+      lowered
+  in
+  let coordination_hits =
+    matched_keywords
+      [ "assign"; "delegate"; "handoff"; "broadcast"; "room"; "agent"; "swarm"; "keeper"; "coordinate"; "sync"; "claim"; "parallel" ]
+      lowered
+  in
+  let conversational_score =
+    (float_of_int (List.length conversational_hits) *. 0.45)
+    +. if short && not asks_question then 0.20 else 0.0
+  in
+  let task_score =
+    (float_of_int (List.length task_hits) *. 0.40)
+    +. if starts_with_action then 0.25 else 0.0
+    +. if not asks_question && len > 0 then 0.05 else 0.0
+  in
+  let status_score =
+    (float_of_int (List.length status_hits) *. 0.50)
+    +. if asks_question then 0.05 else 0.0
+  in
+  let knowledge_score =
+    (float_of_int (List.length knowledge_hits) *. 0.35)
+    +. if asks_question then 0.25 else 0.0
+    +. if starts_with_any
+         ~prefixes:[ "what"; "why"; "how"; "when"; "where"; "which"; "who" ]
+         lowered
+      then 0.15
+      else 0.0
+  in
+  let coordination_score =
+    (float_of_int (List.length coordination_hits) *. 0.50)
+    +. if starts_with_any
+         ~prefixes:[ "assign"; "delegate"; "handoff"; "coordinate"; "sync"; "claim" ]
+         lowered
+      then 0.20
+      else 0.0
+  in
+  let scored =
+    [
+      (Coordination, coordination_score, coordination_hits);
+      (Status_check, status_score, status_hits);
+      (Task_command, task_score, task_hits);
+      (Knowledge_query, knowledge_score, knowledge_hits);
+      (Conversational, conversational_score, conversational_hits);
+    ]
+  in
+  let total_score =
+    List.fold_left (fun acc (_, score, _) -> acc +. score) 0.0 scored
+  in
+  let intent, score, signals =
+    if total_score <= 0.0 then
+      if asks_question then (Knowledge_query, 0.55, [ "question_fallback" ])
+      else if short then (Conversational, 0.60, [ "short_message_fallback" ])
+      else (Task_command, 0.55, [ "imperative_fallback" ])
+    else
+      List.fold_left
+        (fun ((_, best_score, _) as best) candidate ->
+          let _, candidate_score, _ = candidate in
+          if Float.compare candidate_score best_score > 0 then candidate else best)
+        (Conversational, neg_infinity, [])
+        scored
+  in
+  let confidence =
+    if total_score <= 0.0 then score
+    else clamp_unit (max 0.50 (score /. total_score))
+  in
+  {
+    intent;
+    depth = depth_for_intent intent;
+    confidence;
+    rationale = Some (string_of_signals intent signals);
+  }
+
+let parse_model_json json =
+  let open Yojson.Safe.Util in
+  match json |> member "intent" |> to_string_option with
+  | None -> Error "missing required field 'intent'"
+  | Some intent_raw -> (
+      match intent_of_string intent_raw with
+      | Error _ as err -> err
+      | Ok intent -> (
+          match json |> member "confidence" |> to_float_option with
+          | None -> Error "missing required field 'confidence'"
+          | Some confidence when confidence < 0.0 || confidence > 1.0 ->
+              Error "confidence must be between 0.0 and 1.0"
+          | Some confidence ->
+              let rationale = json |> member "rationale" |> to_string_option in
+              Ok
+                {
+                  intent;
+                  depth = depth_for_intent intent;
+                  confidence;
+                  rationale;
+                }))
+
+let schema =
+  {
+    Structured.name = "classify_context_intent";
+    description =
+      "Classify a user query into exactly one normalized intent for context routing.";
+    params =
+      [
+        {
+          name = "intent";
+          description =
+            "One of: conversational, task_command, status_check, knowledge_query, coordination.";
+          param_type = String;
+          required = true;
+        };
+        {
+          name = "confidence";
+          description = "Confidence score from 0.0 to 1.0.";
+          param_type = Number;
+          required = true;
+        };
+        {
+          name = "rationale";
+          description = "Optional short explanation for the classification.";
+          param_type = String;
+          required = false;
+        };
+      ];
+    parse = parse_model_json;
+  }
+
+let prompt_for_query query =
+  Printf.sprintf
+    "Classify the following user query into exactly one intent category.\n\n\
+     Categories:\n\
+     - conversational: casual chat, greeting, thanks, or social exchange.\n\
+     - task_command: a direct request to do, change, run, create, fix, review, or update something.\n\
+     - status_check: asks about current state, progress, remaining work, or what is open/blocked.\n\
+     - knowledge_query: asks for explanation, lookup, facts, docs, or analysis.\n\
+     - coordination: asks to assign, delegate, hand off, sync, broadcast, or coordinate across agents/actors.\n\n\
+     Return only the tool input.\n\
+     Set confidence to a number between 0.0 and 1.0.\n\n\
+     Query:\n%s"
+    query
+
+let classify_model ~sw ~net ?base_url ?provider ?clock ~config ?(max_retries = 2) query =
+  Structured.extract_with_retry ~sw ~net ?base_url ?provider ?clock ~config
+    ~schema ~max_retries (prompt_for_query query)
+
+let classify_hybrid ~sw ~net ?base_url ?provider ?clock ~config
+    ?(max_retries = 2) query =
+  match
+    classify_model ~sw ~net ?base_url ?provider ?clock ~config ~max_retries
+      query
+  with
+  | Ok result -> Ok result.value
+  | Error _ -> Ok (heuristic_classify query)

--- a/lib/context_intent.mli
+++ b/lib/context_intent.mli
@@ -1,0 +1,68 @@
+(** Reusable query intent classification for OAS consumers.
+
+    This module owns the normalized intent taxonomy, retrieval-depth mapping,
+    strict model-output parsing, and lightweight heuristic/model helpers.
+    Consumer-specific policy can stay outside OAS. *)
+
+type intent =
+  | Conversational
+  | Task_command
+  | Status_check
+  | Knowledge_query
+  | Coordination
+[@@deriving yojson, show]
+
+type retrieval_depth =
+  | Skip
+  | Light
+  | Full
+[@@deriving yojson, show]
+
+type classification = {
+  intent : intent;
+  depth : retrieval_depth;
+  confidence : float;
+  rationale : string option;
+}
+[@@deriving yojson, show]
+
+val intent_to_string : intent -> string
+val intent_of_string : string -> (intent, string) result
+val depth_for_intent : intent -> retrieval_depth
+
+(** Fast zero-network classifier suitable for default routing gates. *)
+val heuristic_classify : string -> classification
+
+(** Strict parser for model-produced JSON. *)
+val parse_model_json : Yojson.Safe.t -> (classification, string) result
+
+(** Structured-output schema for model-assisted classification. *)
+val schema : classification Structured.schema
+
+(** Prompt template used by {!classify_model}. *)
+val prompt_for_query : string -> string
+
+(** Run model-assisted classification using OAS structured output. *)
+val classify_model :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?base_url:string ->
+  ?provider:Provider.config ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  config:Types.agent_config ->
+  ?max_retries:int ->
+  string ->
+  (classification Structured.retry_result, Error.sdk_error) result
+
+(** Try model-assisted classification first, then fall back to heuristics on
+    any model/path failure. *)
+val classify_hybrid :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?base_url:string ->
+  ?provider:Provider.config ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  config:Types.agent_config ->
+  ?max_retries:int ->
+  string ->
+  (classification, Error.sdk_error) result

--- a/test/dune
+++ b/test/dune
@@ -132,6 +132,10 @@
  (libraries agent_sdk alcotest yojson))
 
 (test
+ (name test_context_intent)
+ (libraries agent_sdk alcotest yojson))
+
+(test
  (name test_mcp)
  (libraries agent_sdk alcotest yojson mcp_protocol))
 

--- a/test/test_context_intent.ml
+++ b/test/test_context_intent.ml
@@ -1,0 +1,112 @@
+open Alcotest
+open Agent_sdk
+
+let test_intent_of_string_accepts_aliases () =
+  match Context_intent.intent_of_string "status-check" with
+  | Ok Context_intent.Status_check -> ()
+  | Ok other ->
+      failf "expected status_check, got %s"
+        (Context_intent.show_intent other)
+  | Error detail -> fail detail
+
+let test_parse_model_json_valid () =
+  let json =
+    `Assoc
+      [
+        ("intent", `String "knowledge_query");
+        ("confidence", `Float 0.82);
+        ("rationale", `String "asks for explanation");
+      ]
+  in
+  match Context_intent.parse_model_json json with
+  | Ok parsed ->
+      check string "intent" "knowledge_query"
+        (Context_intent.intent_to_string parsed.intent);
+      check bool "depth" true (parsed.depth = Context_intent.Full);
+      check (float 0.0001) "confidence" 0.82 parsed.confidence
+  | Error detail -> fail detail
+
+let test_parse_model_json_rejects_out_of_range_confidence () =
+  let json =
+    `Assoc [ ("intent", `String "coordination"); ("confidence", `Float 1.5) ]
+  in
+  match Context_intent.parse_model_json json with
+  | Ok _ -> fail "expected parse failure"
+  | Error detail ->
+      check bool "mentions confidence" true
+        (Util.contains_substring_ci ~haystack:detail ~needle:"confidence")
+
+let test_heuristic_conversational () =
+  let classified = Context_intent.heuristic_classify "hello and thanks" in
+  check string "intent" "conversational"
+    (Context_intent.intent_to_string classified.intent);
+  check bool "depth" true (classified.depth = Context_intent.Skip)
+
+let test_heuristic_task_command () =
+  let classified =
+    Context_intent.heuristic_classify "fix the failing test and open a PR"
+  in
+  check string "intent" "task_command"
+    (Context_intent.intent_to_string classified.intent);
+  check bool "depth" true (classified.depth = Context_intent.Skip)
+
+let test_heuristic_status_check () =
+  let classified =
+    Context_intent.heuristic_classify "what is the current status of issue 415?"
+  in
+  check string "intent" "status_check"
+    (Context_intent.intent_to_string classified.intent);
+  check bool "depth" true (classified.depth = Context_intent.Light)
+
+let test_heuristic_knowledge_query () =
+  let classified =
+    Context_intent.heuristic_classify
+      "explain how context reduction works in the SDK"
+  in
+  check string "intent" "knowledge_query"
+    (Context_intent.intent_to_string classified.intent);
+  check bool "depth" true (classified.depth = Context_intent.Full)
+
+let test_heuristic_coordination () =
+  let classified =
+    Context_intent.heuristic_classify
+      "delegate this to another agent and leave a handoff note"
+  in
+  check string "intent" "coordination"
+    (Context_intent.intent_to_string classified.intent);
+  check bool "depth" true (classified.depth = Context_intent.Light)
+
+let test_prompt_mentions_all_categories () =
+  let prompt = Context_intent.prompt_for_query "status?" in
+  List.iter
+    (fun needle ->
+      check bool needle true
+        (Util.contains_substring_ci ~haystack:prompt ~needle))
+    [
+      "conversational";
+      "task_command";
+      "status_check";
+      "knowledge_query";
+      "coordination";
+    ]
+
+let () =
+  run "Context_intent"
+    [
+      ( "parsing",
+        [
+          test_case "intent aliases" `Quick test_intent_of_string_accepts_aliases;
+          test_case "valid model json" `Quick test_parse_model_json_valid;
+          test_case "confidence bounds" `Quick
+            test_parse_model_json_rejects_out_of_range_confidence;
+        ] );
+      ( "heuristics",
+        [
+          test_case "conversational" `Quick test_heuristic_conversational;
+          test_case "task command" `Quick test_heuristic_task_command;
+          test_case "status check" `Quick test_heuristic_status_check;
+          test_case "knowledge query" `Quick test_heuristic_knowledge_query;
+          test_case "coordination" `Quick test_heuristic_coordination;
+        ] );
+      ("prompt", [ test_case "mentions categories" `Quick test_prompt_mentions_all_categories ]);
+    ]


### PR DESCRIPTION
## Summary
- add `Context_intent` as an OAS-owned normalized query intent boundary
- provide heuristic classification, retrieval-depth mapping, strict model-output parsing, and structured-output helper entrypoints
- re-export the module from `Agent_sdk` and cover the new surface with focused tests

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/feat/415-context-intent ./test/test_context_intent.exe`
- `./_build/default/test/test_context_intent.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/feat/415-context-intent @install ./test/test_context_intent.exe ./test/test_context_reducer.exe`
- `./_build/default/test/test_context_reducer.exe`

Closes #415