### PR TITLE
fix(cdal): lowercase string JSON for enum types

### DIFF
--- a/lib/cdal_proof.ml
+++ b/lib/cdal_proof.ml
@@ -3,7 +3,21 @@ type result_status =
   | Errored
   | Timed_out
   | Cancelled
-[@@deriving yojson, show]
+[@@deriving show]
+
+let result_status_to_yojson = function
+  | Completed -> `String "completed"
+  | Errored -> `String "errored"
+  | Timed_out -> `String "timed_out"
+  | Cancelled -> `String "cancelled"
+
+let result_status_of_yojson = function
+  | `String "completed" -> Ok Completed
+  | `String "errored" -> Ok Errored
+  | `String "timed_out" -> Ok Timed_out
+  | `String "cancelled" -> Ok Cancelled
+  | j -> Error (Printf.sprintf "unknown result status: %s"
+                  (Yojson.Safe.to_string j))
 
 type provider_snapshot = {
   provider_name: string;

--- a/lib/execution_mode.ml
+++ b/lib/execution_mode.ml
@@ -2,7 +2,19 @@ type t =
   | Diagnose
   | Draft
   | Execute
-[@@deriving yojson, show]
+[@@deriving show]
+
+let to_yojson = function
+  | Diagnose -> `String "diagnose"
+  | Draft -> `String "draft"
+  | Execute -> `String "execute"
+
+let of_yojson = function
+  | `String "diagnose" -> Ok Diagnose
+  | `String "draft" -> Ok Draft
+  | `String "execute" -> Ok Execute
+  | j -> Error (Printf.sprintf "unknown execution mode: %s"
+                  (Yojson.Safe.to_string j))
 
 let to_string = function
   | Diagnose -> "diagnose"

--- a/lib/risk_class.ml
+++ b/lib/risk_class.ml
@@ -3,7 +3,21 @@ type t =
   | Medium
   | High
   | Critical
-[@@deriving yojson, show]
+[@@deriving show]
+
+let to_yojson = function
+  | Low -> `String "low"
+  | Medium -> `String "medium"
+  | High -> `String "high"
+  | Critical -> `String "critical"
+
+let of_yojson = function
+  | `String "low" -> Ok Low
+  | `String "medium" -> Ok Medium
+  | `String "high" -> Ok High
+  | `String "critical" -> Ok Critical
+  | j -> Error (Printf.sprintf "unknown risk class: %s"
+                  (Yojson.Safe.to_string j))
 
 let to_string = function
   | Low -> "low"

--- a/test/test_cdal.ml
+++ b/test/test_cdal.ml
@@ -275,6 +275,72 @@ let test_contract_id_empty_eval_criteria () =
   Alcotest.(check bool) "non-empty id" true (String.length id > 4)
 
 (* ================================================================ *)
+(* JSON schema conformance -- enum values must be lowercase strings  *)
+(* ================================================================ *)
+
+let assert_json_string msg expected json =
+  match json with
+  | `String s -> Alcotest.(check string) msg expected s
+  | other -> Alcotest.fail
+      (Printf.sprintf "%s: expected string, got %s" msg
+         (Yojson.Safe.to_string other))
+
+let test_execution_mode_json_lowercase () =
+  assert_json_string "diagnose" "diagnose" (Execution_mode.to_yojson Diagnose);
+  assert_json_string "draft" "draft" (Execution_mode.to_yojson Draft);
+  assert_json_string "execute" "execute" (Execution_mode.to_yojson Execute)
+
+let test_risk_class_json_lowercase () =
+  assert_json_string "low" "low" (Risk_class.to_yojson Low);
+  assert_json_string "medium" "medium" (Risk_class.to_yojson Medium);
+  assert_json_string "high" "high" (Risk_class.to_yojson High);
+  assert_json_string "critical" "critical" (Risk_class.to_yojson Critical)
+
+let test_result_status_json_lowercase () =
+  assert_json_string "completed" "completed"
+    (Cdal_proof.result_status_to_yojson Completed);
+  assert_json_string "errored" "errored"
+    (Cdal_proof.result_status_to_yojson Errored);
+  assert_json_string "timed_out" "timed_out"
+    (Cdal_proof.result_status_to_yojson Timed_out);
+  assert_json_string "cancelled" "cancelled"
+    (Cdal_proof.result_status_to_yojson Cancelled)
+
+let test_proof_json_enum_fields () =
+  let proof : Cdal_proof.t = {
+    schema_version = 1;
+    run_id = "test-enum";
+    contract_id = "md5:abc";
+    requested_execution_mode = Execution_mode.Execute;
+    effective_execution_mode = Execution_mode.Draft;
+    mode_decision_source = "risk_class_downgrade";
+    risk_class = Risk_class.High;
+    provider_snapshot = {
+      provider_name = "test"; model_id = "m"; api_version = None;
+    };
+    capability_snapshot = test_caps;
+    tool_trace_refs = [];
+    raw_evidence_refs = [];
+    checkpoint_ref = None;
+    result_status = Cdal_proof.Completed;
+    started_at = 1000.0;
+    ended_at = 1001.0;
+  } in
+  let json = Cdal_proof.to_json proof in
+  let field name = match json with
+    | `Assoc fields -> List.assoc name fields
+    | _ -> Alcotest.fail "proof json is not an object"
+  in
+  assert_json_string "requested mode in proof" "execute"
+    (field "requested_execution_mode");
+  assert_json_string "effective mode in proof" "draft"
+    (field "effective_execution_mode");
+  assert_json_string "risk class in proof" "high"
+    (field "risk_class");
+  assert_json_string "result status in proof" "completed"
+    (field "result_status")
+
+(* ================================================================ *)
 (* Test runner                                                       *)
 (* ================================================================ *)
 
@@ -312,5 +378,11 @@ let () =
     ];
     "Risk_contract edge", [
       Alcotest.test_case "empty eval_criteria" `Quick test_contract_id_empty_eval_criteria;
+    ];
+    "JSON schema conformance", [
+      Alcotest.test_case "execution_mode lowercase" `Quick test_execution_mode_json_lowercase;
+      Alcotest.test_case "risk_class lowercase" `Quick test_risk_class_json_lowercase;
+      Alcotest.test_case "result_status lowercase" `Quick test_result_status_json_lowercase;
+      Alcotest.test_case "proof bundle enum fields" `Quick test_proof_json_enum_fields;
     ];
   ]


### PR DESCRIPTION
## Summary

- `ppx_deriving_yojson`이 variant constructor를 `["Diagnose"]` (array + PascalCase)로 직렬화하지만, cross-repo JSON schema (`cdal-proof-bundle-v1.json`)는 `"diagnose"` (string + lowercase)을 기대함
- `execution_mode`, `risk_class`, `result_status` 3개 enum 타입에 manual `to_yojson`/`of_yojson` 구현
- Schema conformance test 4개 추가 (enum 직렬화 형식 검증)

## Problem

```
OCaml output: {"requested_execution_mode": ["Diagnose"], "risk_class": ["High"], ...}
Schema expects: {"requested_execution_mode": "diagnose", "risk_class": "high", ...}
```

MASC consumer가 이 JSON을 schema로 validate하면 즉시 실패.

## Test plan

- [x] 기존 17 tests 전부 pass
- [x] 신규 4 schema conformance tests pass (21 total)
- [ ] CI 4/4 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)