### PR TITLE
fix(cdal): proof_capture tests, error logging, minor hardening

### DIFF
--- a/lib/contract_runner.ml
+++ b/lib/contract_runner.ml
@@ -39,7 +39,8 @@ let run ~sw ?clock ?(store = Proof_store.default_config)
     let now = Unix.gettimeofday () in
     let proof : Cdal_proof.t = {
       schema_version = Cdal_proof.schema_version_current;
-      run_id = Printf.sprintf "cdal-rejected-%d" (int_of_float (now *. 1000.0));
+      run_id = Printf.sprintf "cdal-rejected-%d-%06x"
+        (int_of_float (now *. 1000.0)) (Random.bits () land 0xFFFFFF);
       contract_id = Risk_contract.contract_id contract;
       requested_execution_mode = requested;
       effective_execution_mode = Execution_mode.Diagnose;

--- a/lib/mode_resolver.ml
+++ b/lib/mode_resolver.ml
@@ -6,6 +6,7 @@ type decision = {
 let min_mode a b =
   if Execution_mode.compare a b <= 0 then a else b
 
+(* TODO: use capabilities for tool-based mode downgrade (e.g. no-exec tools -> Diagnose) *)
 let resolve ~requested ~risk_class ~capabilities:_ =
   match Risk_class.max_mode risk_class with
   | None ->

--- a/lib/proof_capture.ml
+++ b/lib/proof_capture.ml
@@ -147,8 +147,11 @@ let hooks st =
 
 let finalize st ~result_status =
   complete_pending_tool st ~output:None ~error:None;
+  let now = Unix.gettimeofday () in
+  if st.started_at = 0.0 then
+    st.started_at <- now;
   if st.ended_at = 0.0 then
-    st.ended_at <- Unix.gettimeofday ();
+    st.ended_at <- now;
   let tool_trace_refs =
     List.init st.trace_count (fun i ->
       Proof_store.make_ref ~run_id:st.run_id

--- a/lib/proof_store.ml
+++ b/lib/proof_store.ml
@@ -17,34 +17,35 @@ let manifest_path config ~run_id =
 let contract_path config ~run_id =
   Filename.concat (run_dir config ~run_id) "contract.json"
 
-let ignore_error = function
+let log_error context = function
   | Ok () -> ()
-  | Error _ -> ()
+  | Error err ->
+    Printf.eprintf "[proof_store] %s: %s\n%!" context (Error.to_string err)
 
 let init_run config ~run_id =
-  ignore_error (Fs_result.ensure_dir (traces_dir config ~run_id));
-  ignore_error (Fs_result.ensure_dir (evidence_dir config ~run_id))
+  log_error "mkdir traces" (Fs_result.ensure_dir (traces_dir config ~run_id));
+  log_error "mkdir evidence" (Fs_result.ensure_dir (evidence_dir config ~run_id))
 
-let write_json path json =
+let write_json context path json =
   let content = Yojson.Safe.pretty_to_string json ^ "\n" in
-  ignore_error (Fs_result.write_file path content)
+  log_error context (Fs_result.write_file path content)
 
 let write_manifest config ~run_id proof =
-  write_json (manifest_path config ~run_id) (Cdal_proof.to_json proof)
+  write_json "write manifest" (manifest_path config ~run_id) (Cdal_proof.to_json proof)
 
 let write_contract config ~run_id contract =
-  write_json (contract_path config ~run_id) (Risk_contract.to_yojson contract)
+  write_json "write contract" (contract_path config ~run_id) (Risk_contract.to_yojson contract)
 
 let append_tool_trace config ~run_id ~trace_id json =
   let path = Filename.concat (traces_dir config ~run_id)
       (trace_id ^ ".jsonl") in
   let line = Yojson.Safe.to_string json ^ "\n" in
-  ignore_error (Fs_result.append_file path line)
+  log_error "append trace" (Fs_result.append_file path line)
 
 let write_evidence config ~run_id ~ref_id json =
   let path = Filename.concat (evidence_dir config ~run_id)
       (ref_id ^ ".json") in
-  write_json path json
+  write_json "write evidence" path json
 
 let make_ref ~run_id ~subpath =
   Printf.sprintf "proof-store://%s/%s" run_id subpath

--- a/test/test_cdal.ml
+++ b/test/test_cdal.ml
@@ -341,6 +341,117 @@ let test_proof_json_enum_fields () =
     (field "result_status")
 
 (* ================================================================ *)
+(* Proof_capture integration tests                                   *)
+(* ================================================================ *)
+
+let test_contract = make_contract ~mode:Execution_mode.Draft ~risk:Risk_class.Medium ()
+
+let test_mode_decision : Mode_resolver.decision = {
+  effective_mode = Execution_mode.Draft;
+  source = "passthrough";
+}
+
+let make_test_store () =
+  let tmpdir = Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "oas-test-capture-%d" (Random.bits () land 0xFFFF)) in
+  (Proof_store.{ root = tmpdir }, tmpdir)
+
+let mock_response model : Types.api_response = {
+  id = "msg-test"; model;
+  stop_reason = Types.EndTurn;
+  content = [Types.Text "done"];
+  usage = None;
+}
+
+let test_proof_capture_lifecycle () =
+  let store, tmpdir = make_test_store () in
+  let state = Proof_capture.create
+      ~store ~contract:test_contract
+      ~mode_decision:test_mode_decision
+      ~capability_snapshot:test_caps in
+  let h = Proof_capture.hooks state in
+  (* Simulate: BeforeTurn 1, PreToolUse, PostToolUse, AfterTurn, OnStop *)
+  let _ = Hooks.invoke h.before_turn
+      (BeforeTurn { turn = 1; messages = [] }) in
+  let _ = Hooks.invoke h.pre_tool_use
+      (PreToolUse { tool_name = "bash"; input = `String "ls";
+                    accumulated_cost_usd = 0.0; turn = 1 }) in
+  let _ = Hooks.invoke h.post_tool_use
+      (PostToolUse { tool_name = "bash"; input = `String "ls";
+                     output = Ok { Types.content = "file.txt" };
+                     result_bytes = 8 }) in
+  let resp = mock_response "claude-test" in
+  let _ = Hooks.invoke h.after_turn
+      (AfterTurn { turn = 1; response = resp }) in
+  let _ = Hooks.invoke h.on_stop
+      (OnStop { reason = Types.EndTurn; response = resp }) in
+  let proof = Proof_capture.finalize state ~result_status:Cdal_proof.Completed in
+  (* Verify bundle fields *)
+  Alcotest.(check int) "schema_version" 1 proof.schema_version;
+  Alcotest.(check string) "mode source" "passthrough" proof.mode_decision_source;
+  Alcotest.(check string) "model captured" "claude-test" proof.provider_snapshot.model_id;
+  Alcotest.(check bool) "started_at > 0" true (proof.started_at > 0.0);
+  Alcotest.(check bool) "ended_at >= started_at" true (proof.ended_at >= proof.started_at);
+  Alcotest.(check int) "1 tool trace" 1 (List.length proof.tool_trace_refs);
+  Alcotest.(check bool) "trace ref has prefix" true
+    (String.length (List.hd proof.tool_trace_refs) > 15);
+  (* Verify files on disk *)
+  let manifest_path = Proof_store.manifest_path store ~run_id:proof.run_id in
+  Alcotest.(check bool) "manifest written" true (Sys.file_exists manifest_path);
+  ignore (Sys.command (Printf.sprintf "rm -rf %s" tmpdir))
+
+let test_proof_capture_no_hooks_fired () =
+  let store, tmpdir = make_test_store () in
+  let state = Proof_capture.create
+      ~store ~contract:test_contract
+      ~mode_decision:test_mode_decision
+      ~capability_snapshot:test_caps in
+  (* Finalize without firing any hooks -- tests started_at guard *)
+  let proof = Proof_capture.finalize state ~result_status:Cdal_proof.Cancelled in
+  Alcotest.(check bool) "started_at > 0 (guarded)" true (proof.started_at > 0.0);
+  Alcotest.(check bool) "ended_at > 0 (guarded)" true (proof.ended_at > 0.0);
+  Alcotest.(check int) "0 tool traces" 0 (List.length proof.tool_trace_refs);
+  Alcotest.(check string) "provider unknown" "unknown" proof.provider_snapshot.model_id;
+  ignore (Sys.command (Printf.sprintf "rm -rf %s" tmpdir))
+
+let test_proof_capture_multiple_tools () =
+  let store, tmpdir = make_test_store () in
+  let state = Proof_capture.create
+      ~store ~contract:test_contract
+      ~mode_decision:test_mode_decision
+      ~capability_snapshot:test_caps in
+  let h = Proof_capture.hooks state in
+  let _ = Hooks.invoke h.before_turn
+      (BeforeTurn { turn = 1; messages = [] }) in
+  (* Tool 1: success *)
+  let _ = Hooks.invoke h.pre_tool_use
+      (PreToolUse { tool_name = "read"; input = `String "a.ml";
+                    accumulated_cost_usd = 0.0; turn = 1 }) in
+  let _ = Hooks.invoke h.post_tool_use
+      (PostToolUse { tool_name = "read"; input = `String "a.ml";
+                     output = Ok { Types.content = "code" };
+                     result_bytes = 4 }) in
+  (* Tool 2: failure *)
+  let _ = Hooks.invoke h.pre_tool_use
+      (PreToolUse { tool_name = "bash"; input = `String "rm /";
+                    accumulated_cost_usd = 0.01; turn = 1 }) in
+  let _ = Hooks.invoke h.post_tool_use_failure
+      (PostToolUseFailure { tool_name = "bash"; input = `String "rm /";
+                            error = "permission denied" }) in
+  (* Tool 3: error result *)
+  let _ = Hooks.invoke h.pre_tool_use
+      (PreToolUse { tool_name = "edit"; input = `String "b.ml";
+                    accumulated_cost_usd = 0.02; turn = 1 }) in
+  let _ = Hooks.invoke h.post_tool_use
+      (PostToolUse { tool_name = "edit"; input = `String "b.ml";
+                     output = Error { Types.message = "conflict"; recoverable = true };
+                     result_bytes = 0 }) in
+  let proof = Proof_capture.finalize state ~result_status:Cdal_proof.Completed in
+  Alcotest.(check int) "3 tool traces" 3 (List.length proof.tool_trace_refs);
+  ignore (Sys.command (Printf.sprintf "rm -rf %s" tmpdir))
+
+(* ================================================================ *)
 (* Test runner                                                       *)
 (* ================================================================ *)
 
@@ -384,5 +495,10 @@ let () =
       Alcotest.test_case "risk_class lowercase" `Quick test_risk_class_json_lowercase;
       Alcotest.test_case "result_status lowercase" `Quick test_result_status_json_lowercase;
       Alcotest.test_case "proof bundle enum fields" `Quick test_proof_json_enum_fields;
+    ];
+    "Proof_capture", [
+      Alcotest.test_case "full lifecycle" `Quick test_proof_capture_lifecycle;
+      Alcotest.test_case "no hooks fired (guard)" `Quick test_proof_capture_no_hooks_fired;
+      Alcotest.test_case "multiple tools" `Quick test_proof_capture_multiple_tools;
     ];
   ]


### PR DESCRIPTION
## Summary

Post-merge review에서 발견된 P1~P3 이슈 일괄 수정.

**P1 (integration tests)**:
- `Proof_capture` 통합 테스트 3개 추가: full lifecycle, no-hooks guard, multiple tools
- hook event → state 축적 → finalize → bundle 필드 검증 + 디스크 검증

**P2 (error visibility)**:
- `proof_store`의 `ignore_error` → `log_error` (stderr에 context + Error.to_string)
- API signature 변경 없음, silent failure 방지

**P3 (minor hardening)**:
- `proof_capture.finalize`: `started_at=0.0` guard 추가 (ended_at과 대칭)
- `contract_runner`: rejected run_id에 random suffix 추가 (collision 방지)
- `mode_resolver`: unused `capabilities` parameter에 TODO 주석

## Test plan

- [x] 기존 21 tests pass
- [x] 신규 3 Proof_capture tests pass (24 total)
- [ ] CI 4/4 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)