### PR TITLE
feat(cdal): mode enforcement, capability downgrade, evidence enrichment

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -163,6 +163,7 @@ module Mode_resolver = Mode_resolver
 module Proof_store = Proof_store
 module Proof_capture = Proof_capture
 module Contract_runner = Contract_runner
+module Mode_enforcer = Mode_enforcer
 
 (** Quick start: create an agent with default config *)
 let create_agent ~net ?name ?model ?system_prompt ?max_tokens ?max_turns

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -135,6 +135,7 @@ module Mode_resolver = Mode_resolver
 module Proof_store = Proof_store
 module Proof_capture = Proof_capture
 module Contract_runner = Contract_runner
+module Mode_enforcer = Mode_enforcer
 
 (** {1 Quick Start} *)
 

--- a/lib/contract_runner.ml
+++ b/lib/contract_runner.ml
@@ -68,9 +68,15 @@ let run ~sw ?clock ?(store = Proof_store.default_config)
   | Ok mode_decision ->
     let capture_state = Proof_capture.create
         ~store ~contract ~mode_decision ~capability_snapshot:capabilities in
+    let enforcer_state = Mode_enforcer.create
+        ~contract ~effective_mode:mode_decision.effective_mode in
+    Proof_capture.set_enforcer capture_state enforcer_state;
+    let enforcement_hooks = Mode_enforcer.hooks enforcer_state in
     let proof_hooks = Proof_capture.hooks capture_state in
     let user_hooks = (Agent.options agent).hooks in
-    let composed_hooks = Hooks.compose ~outer:proof_hooks ~inner:user_hooks in
+    let composed_hooks =
+      Hooks.compose ~outer:enforcement_hooks
+        ~inner:(Hooks.compose ~outer:proof_hooks ~inner:user_hooks) in
     let opts = Agent.options agent in
     let new_opts = { opts with hooks = composed_hooks } in
     let config = (Agent.state agent).config in

--- a/lib/mode_enforcer.ml
+++ b/lib/mode_enforcer.ml
@@ -1,0 +1,210 @@
+type mutation_class =
+  | Read_only
+  | Workspace_mutating
+  | External_effect
+
+type violation = {
+  ts: float;
+  tool_name: string;
+  input_summary: string;
+  effective_mode: Execution_mode.t;
+  violation_kind: string;
+}
+
+type token_snapshot = {
+  input_tokens: int;
+  output_tokens: int;
+  cost_usd: float option;
+  turn: int;
+}
+
+type state = {
+  effective_mode: Execution_mode.t;
+  allowed_mutations: string list;
+  review_requirement: string option;
+  mutable violations: violation list;
+  mutable token_snapshots: token_snapshot list;
+  mutable review_warning: string option;
+}
+
+let create ~contract ~effective_mode =
+  let rc = contract.Risk_contract.runtime_constraints in
+  {
+    effective_mode;
+    allowed_mutations = rc.allowed_mutations;
+    review_requirement = rc.review_requirement;
+    violations = [];
+    token_snapshots = [];
+    review_warning = None;
+  }
+
+let violations st = List.rev st.violations
+let token_snapshots st = List.rev st.token_snapshots
+let review_warning st = st.review_warning
+
+(* ── Tool classification ─────────────────────────────────────────── *)
+
+let classify_tool name =
+  match String.lowercase_ascii name with
+  | "read" | "glob" | "grep" | "search" | "list_dir" | "find_file"
+  | "read_file" | "find_symbol" | "get_symbols_overview"
+  | "find_referencing_symbols" | "search_for_pattern"
+  | "read_console_messages" | "read_network_requests"
+  | "get_page_text" | "read_page" | "tabs_context_mcp" ->
+    Read_only
+  | "write" | "edit" | "create_text_file" | "replace_content"
+  | "rename_symbol" | "insert_after_symbol" | "insert_before_symbol"
+  | "replace_symbol_body" | "notebook_edit" ->
+    Workspace_mutating
+  | n when String.length n > 5
+           && String.sub n 0 5 = "mcp__" ->
+    External_effect
+  | _ -> External_effect
+
+let is_bash_read_only (input : Yojson.Safe.t) =
+  match input with
+  | `Assoc fields ->
+    (match List.assoc_opt "command" fields with
+     | Some (`String cmd) ->
+       let cmd_lower = String.lowercase_ascii cmd in
+       let mutating_patterns = [
+         "rm "; "rm\t"; "rmdir "; "mv "; "cp "; "mkdir ";
+         "touch "; "chmod "; "chown "; "dd "; "mkfs";
+         "apt "; "brew "; "pip "; "npm "; "yarn "; "cargo ";
+         "git push"; "git commit"; "git add"; "git reset";
+         "git rebase"; "git merge"; "git checkout";
+         "docker "; "kubectl "; "systemctl ";
+         "curl "; "wget ";
+       ] in
+       let has_redirect =
+         String.contains cmd '>'
+         || (try ignore (Str.search_forward (Str.regexp_string "tee ") cmd 0); true
+             with Not_found -> false)
+       in
+       let has_mutating = List.exists (fun pat ->
+         try ignore (Str.search_forward (Str.regexp_string pat) cmd_lower 0); true
+         with Not_found -> false
+       ) mutating_patterns in
+       not has_mutating && not has_redirect
+     | _ -> false)
+  | _ -> false
+
+let is_bash_workspace_only (input : Yojson.Safe.t) =
+  match input with
+  | `Assoc fields ->
+    (match List.assoc_opt "command" fields with
+     | Some (`String cmd) ->
+       let cmd_lower = String.lowercase_ascii cmd in
+       let external_patterns = [
+         "curl "; "wget "; "ssh "; "scp "; "rsync ";
+         "git push"; "git fetch"; "git pull"; "git clone";
+         "docker "; "kubectl "; "helm ";
+         "npm publish"; "pip install"; "cargo publish";
+         "systemctl "; "launchctl ";
+       ] in
+       not (List.exists (fun pat ->
+         try ignore (Str.search_forward (Str.regexp_string pat) cmd_lower 0); true
+         with Not_found -> false
+       ) external_patterns)
+     | _ -> false)
+  | _ -> false
+
+let classify_bash_tool input =
+  if is_bash_read_only input then Read_only
+  else if is_bash_workspace_only input then Workspace_mutating
+  else External_effect
+
+let effective_class tool_name input =
+  match classify_tool tool_name with
+  | External_effect
+    when String.lowercase_ascii tool_name = "bash"
+      || String.lowercase_ascii tool_name = "execute_shell_command" ->
+    classify_bash_tool input
+  | c -> c
+
+let all_read_only tools =
+  List.for_all (fun name -> classify_tool name = Read_only) tools
+
+let all_workspace_only tools =
+  List.for_all (fun name ->
+    match classify_tool name with
+    | Read_only | Workspace_mutating -> true
+    | External_effect -> false
+  ) tools
+
+(* ── Enforcement check ───────────────────────────────────────────── *)
+
+let truncate_input input =
+  let s = Yojson.Safe.to_string input in
+  if String.length s > 200 then String.sub s 0 200 ^ "..."
+  else s
+
+let check_violation st tool_name input =
+  let cls = effective_class tool_name input in
+  let kind = match st.effective_mode, cls with
+    | Execution_mode.Diagnose, (Workspace_mutating | External_effect) ->
+      Some "mutating_in_diagnose"
+    | Execution_mode.Draft, External_effect ->
+      Some "external_in_draft"
+    | _ ->
+      if List.mem "workspace_only" st.allowed_mutations
+         && cls = External_effect then
+        Some "scope_violation"
+      else
+        None
+  in
+  match kind with
+  | None -> None
+  | Some violation_kind ->
+    let v = {
+      ts = Unix.gettimeofday ();
+      tool_name;
+      input_summary = truncate_input input;
+      effective_mode = st.effective_mode;
+      violation_kind;
+    } in
+    st.violations <- v :: st.violations;
+    Some v
+
+(* ── Hooks ───────────────────────────────────────────────────────── *)
+
+let hooks st =
+  let open Hooks in
+  {
+    empty with
+
+    before_turn = Some (fun event ->
+      (match event with
+       | BeforeTurn { turn = 1; _ } ->
+         (match st.review_requirement, st.effective_mode with
+          | Some req, Execution_mode.Execute ->
+            st.review_warning <- Some (Printf.sprintf
+              "review_requirement '%s' active but running in Execute mode" req)
+          | _ -> ())
+       | _ -> ());
+      Continue);
+
+    pre_tool_use = Some (fun event ->
+      match event with
+      | PreToolUse { tool_name; input; _ } ->
+        (match check_violation st tool_name input with
+         | Some _ -> Skip
+         | None -> Continue)
+      | _ -> Continue);
+
+    after_turn = Some (fun event ->
+      (match event with
+       | AfterTurn { turn; response; _ } ->
+         (match response.Types.usage with
+          | Some u ->
+            let snap = {
+              input_tokens = u.input_tokens;
+              output_tokens = u.output_tokens;
+              cost_usd = u.cost_usd;
+              turn;
+            } in
+            st.token_snapshots <- snap :: st.token_snapshots
+          | None -> ())
+       | _ -> ());
+      Continue);
+  }

--- a/lib/mode_enforcer.mli
+++ b/lib/mode_enforcer.mli
@@ -1,0 +1,53 @@
+(** Mode enforcement middleware for CDAL.
+
+    Creates hooks that block tool calls violating the effective execution mode.
+    Violations are recorded as evidence for the proof bundle.
+
+    Tool classification:
+    - Read-only: read, glob, grep, search, etc.
+    - Workspace-mutating: write, edit, create_text_file, etc.
+    - External-effect: bash (with input analysis), mcp__*, unknown tools *)
+
+type mutation_class =
+  | Read_only
+  | Workspace_mutating
+  | External_effect
+
+type violation = {
+  ts: float;
+  tool_name: string;
+  input_summary: string;
+  effective_mode: Execution_mode.t;
+  violation_kind: string;
+}
+
+type token_snapshot = {
+  input_tokens: int;
+  output_tokens: int;
+  cost_usd: float option;
+  turn: int;
+}
+
+type state
+
+val create :
+  contract:Risk_contract.t ->
+  effective_mode:Execution_mode.t ->
+  state
+
+(** Returns hooks that enforce mode constraints.
+    PreToolUse returns [Hooks.Skip] on violation. *)
+val hooks : state -> Hooks.hooks
+
+val violations : state -> violation list
+val token_snapshots : state -> token_snapshot list
+val review_warning : state -> string option
+
+(** Classify a tool by name. Exported for Mode_resolver reuse. *)
+val classify_tool : string -> mutation_class
+
+(** Check if all tools in a list are read-only. *)
+val all_read_only : string list -> bool
+
+(** Check if all tools are at most workspace-mutating (no external effects). *)
+val all_workspace_only : string list -> bool

--- a/lib/mode_resolver.ml
+++ b/lib/mode_resolver.ml
@@ -6,15 +6,26 @@ type decision = {
 let min_mode a b =
   if Execution_mode.compare a b <= 0 then a else b
 
-(* TODO: use capabilities for tool-based mode downgrade (e.g. no-exec tools -> Diagnose) *)
-let resolve ~requested ~risk_class ~capabilities:_ =
+let capability_cap (capabilities : Cdal_proof.capability_snapshot) =
+  if Mode_enforcer.all_read_only capabilities.tools then
+    Execution_mode.Diagnose
+  else if Mode_enforcer.all_workspace_only capabilities.tools then
+    Execution_mode.Draft
+  else
+    Execution_mode.Execute
+
+let resolve ~requested ~risk_class ~capabilities =
   match Risk_class.max_mode risk_class with
   | None ->
     Error (Printf.sprintf "risk class %s forbids all execution"
              (Risk_class.to_string risk_class))
-  | Some cap ->
-    let effective = min_mode requested cap in
+  | Some risk_cap ->
+    let cap_limit = capability_cap capabilities in
+    let combined_cap = min_mode risk_cap cap_limit in
+    let effective = min_mode requested combined_cap in
     if Execution_mode.equal effective requested then
       Ok { effective_mode = effective; source = "passthrough" }
+    else if Execution_mode.compare cap_limit risk_cap < 0 then
+      Ok { effective_mode = effective; source = "capability_limit" }
     else
       Ok { effective_mode = effective; source = "risk_class_downgrade" }

--- a/lib/proof_capture.ml
+++ b/lib/proof_capture.ml
@@ -18,6 +18,7 @@ type state = {
   mutable provider_snapshot: Cdal_proof.provider_snapshot;
   mutable pending_tool: (float * string * Yojson.Safe.t) option;
   mutable trace_count: int;
+  mutable enforcer: Mode_enforcer.state option;
 }
 
 let generate_run_id () =
@@ -43,9 +44,11 @@ let create ~store ~contract ~mode_decision ~capability_snapshot =
     };
     pending_tool = None;
     trace_count = 0;
+    enforcer = None;
   }
 
 let run_id st = st.run_id
+let set_enforcer st e = st.enforcer <- Some e
 
 let flush_trace st entry =
   st.trace_count <- st.trace_count + 1;
@@ -145,6 +148,54 @@ let hooks st =
     pre_compact = None;
   }
 
+let collect_evidence_refs st =
+  match st.enforcer with
+  | None -> []
+  | Some enforcer ->
+    let refs = ref [] in
+    let violations = Mode_enforcer.violations enforcer in
+    if violations <> [] then begin
+      let json = `List (List.map (fun (v : Mode_enforcer.violation) ->
+        `Assoc [
+          "ts", `Float v.ts;
+          "tool_name", `String v.tool_name;
+          "input_summary", `String v.input_summary;
+          "effective_mode", Execution_mode.to_yojson v.effective_mode;
+          "violation_kind", `String v.violation_kind;
+        ]) violations) in
+      Proof_store.write_evidence st.store ~run_id:st.run_id
+        ~ref_id:"mode_violations" json;
+      refs := Proof_store.make_ref ~run_id:st.run_id
+        ~subpath:"evidence/mode_violations.json" :: !refs
+    end;
+    let snapshots = Mode_enforcer.token_snapshots enforcer in
+    if snapshots <> [] then begin
+      let json = `List (List.map (fun (s : Mode_enforcer.token_snapshot) ->
+        `Assoc [
+          "turn", `Int s.turn;
+          "input_tokens", `Int s.input_tokens;
+          "output_tokens", `Int s.output_tokens;
+          "cost_usd", (match s.cost_usd with Some c -> `Float c | None -> `Null);
+        ]) snapshots) in
+      Proof_store.write_evidence st.store ~run_id:st.run_id
+        ~ref_id:"token_usage" json;
+      refs := Proof_store.make_ref ~run_id:st.run_id
+        ~subpath:"evidence/token_usage.json" :: !refs
+    end;
+    (match Mode_enforcer.review_warning enforcer with
+     | Some warning ->
+       let json = `Assoc [
+         "warning", `String warning;
+         "effective_mode", Execution_mode.to_yojson
+           st.mode_decision.effective_mode;
+       ] in
+       Proof_store.write_evidence st.store ~run_id:st.run_id
+         ~ref_id:"review_warning" json;
+       refs := Proof_store.make_ref ~run_id:st.run_id
+         ~subpath:"evidence/review_warning.json" :: !refs
+     | None -> ());
+    List.rev !refs
+
 let finalize st ~result_status =
   complete_pending_tool st ~output:None ~error:None;
   let now = Unix.gettimeofday () in
@@ -169,7 +220,7 @@ let finalize st ~result_status =
     provider_snapshot = st.provider_snapshot;
     capability_snapshot = st.capability_snapshot;
     tool_trace_refs;
-    raw_evidence_refs = [];
+    raw_evidence_refs = collect_evidence_refs st;
     checkpoint_ref = None;
     result_status;
     started_at = st.started_at;

--- a/lib/proof_capture.mli
+++ b/lib/proof_capture.mli
@@ -28,3 +28,6 @@ val finalize :
   Cdal_proof.t
 
 val run_id : state -> string
+
+(** Attach an enforcer state for evidence enrichment at finalize time. *)
+val set_enforcer : state -> Mode_enforcer.state -> unit

--- a/test/test_cdal.ml
+++ b/test/test_cdal.ml
@@ -452,6 +452,289 @@ let test_proof_capture_multiple_tools () =
   ignore (Sys.command (Printf.sprintf "rm -rf %s" tmpdir))
 
 (* ================================================================ *)
+(* Mode_enforcer tests                                               *)
+(* ================================================================ *)
+
+let make_enforcer_event tool_name input =
+  Hooks.PreToolUse { tool_name; input; accumulated_cost_usd = 0.0; turn = 1 }
+
+let diagnose_enforcer () =
+  let contract = make_contract ~mode:Execution_mode.Diagnose ~risk:Risk_class.Low () in
+  Mode_enforcer.create ~contract ~effective_mode:Execution_mode.Diagnose
+
+let draft_enforcer () =
+  let contract = make_contract ~mode:Execution_mode.Draft ~risk:Risk_class.Low () in
+  Mode_enforcer.create ~contract ~effective_mode:Execution_mode.Draft
+
+let execute_enforcer () =
+  let contract = Risk_contract.{
+    runtime_constraints = {
+      requested_execution_mode = Execution_mode.Execute;
+      risk_class = Risk_class.Low;
+      allowed_mutations = [];
+      review_requirement = None;
+    };
+    eval_criteria = `Null;
+  } in
+  Mode_enforcer.create ~contract ~effective_mode:Execution_mode.Execute
+
+let test_diagnose_blocks_write () =
+  let st = diagnose_enforcer () in
+  let h = Mode_enforcer.hooks st in
+  let d = Hooks.invoke h.pre_tool_use (make_enforcer_event "write" `Null) in
+  Alcotest.(check bool) "write blocked in diagnose" true
+    (match d with Hooks.Skip -> true | _ -> false);
+  Alcotest.(check int) "1 violation" 1 (List.length (Mode_enforcer.violations st))
+
+let test_diagnose_blocks_bash_rm () =
+  let st = diagnose_enforcer () in
+  let h = Mode_enforcer.hooks st in
+  let input = `Assoc ["command", `String "rm -rf /tmp/foo"] in
+  let d = Hooks.invoke h.pre_tool_use (make_enforcer_event "bash" input) in
+  Alcotest.(check bool) "bash rm blocked in diagnose" true
+    (match d with Hooks.Skip -> true | _ -> false)
+
+let test_diagnose_allows_read () =
+  let st = diagnose_enforcer () in
+  let h = Mode_enforcer.hooks st in
+  let d = Hooks.invoke h.pre_tool_use (make_enforcer_event "read" `Null) in
+  Alcotest.(check bool) "read allowed in diagnose" true
+    (match d with Hooks.Continue -> true | _ -> false);
+  Alcotest.(check int) "0 violations" 0 (List.length (Mode_enforcer.violations st))
+
+let test_diagnose_allows_bash_ls () =
+  let st = diagnose_enforcer () in
+  let h = Mode_enforcer.hooks st in
+  let input = `Assoc ["command", `String "ls -la /tmp"] in
+  let d = Hooks.invoke h.pre_tool_use (make_enforcer_event "bash" input) in
+  Alcotest.(check bool) "bash ls allowed in diagnose" true
+    (match d with Hooks.Continue -> true | _ -> false)
+
+let test_draft_allows_write () =
+  let st = draft_enforcer () in
+  let h = Mode_enforcer.hooks st in
+  let d = Hooks.invoke h.pre_tool_use (make_enforcer_event "edit" `Null) in
+  Alcotest.(check bool) "edit allowed in draft" true
+    (match d with Hooks.Continue -> true | _ -> false)
+
+let test_draft_blocks_bash_curl () =
+  let st = draft_enforcer () in
+  let h = Mode_enforcer.hooks st in
+  let input = `Assoc ["command", `String "curl https://example.com/api"] in
+  let d = Hooks.invoke h.pre_tool_use (make_enforcer_event "bash" input) in
+  Alcotest.(check bool) "bash curl blocked in draft" true
+    (match d with Hooks.Skip -> true | _ -> false)
+
+let test_execute_allows_all () =
+  let st = execute_enforcer () in
+  let h = Mode_enforcer.hooks st in
+  let d1 = Hooks.invoke h.pre_tool_use (make_enforcer_event "write" `Null) in
+  let input = `Assoc ["command", `String "curl https://example.com"] in
+  let d2 = Hooks.invoke h.pre_tool_use (make_enforcer_event "bash" input) in
+  Alcotest.(check bool) "write allowed" true
+    (match d1 with Hooks.Continue -> true | _ -> false);
+  Alcotest.(check bool) "bash curl allowed" true
+    (match d2 with Hooks.Continue -> true | _ -> false)
+
+let test_scope_violation () =
+  let contract = Risk_contract.{
+    runtime_constraints = {
+      requested_execution_mode = Execution_mode.Execute;
+      risk_class = Risk_class.Low;
+      allowed_mutations = ["workspace_only"];
+      review_requirement = None;
+    };
+    eval_criteria = `Null;
+  } in
+  let st = Mode_enforcer.create ~contract ~effective_mode:Execution_mode.Execute in
+  let h = Mode_enforcer.hooks st in
+  let input = `Assoc ["command", `String "curl https://api.example.com"] in
+  let d = Hooks.invoke h.pre_tool_use (make_enforcer_event "bash" input) in
+  Alcotest.(check bool) "scope violation" true
+    (match d with Hooks.Skip -> true | _ -> false);
+  let vs = Mode_enforcer.violations st in
+  Alcotest.(check string) "violation kind" "scope_violation"
+    (List.hd vs).violation_kind
+
+let test_violation_records_details () =
+  let st = diagnose_enforcer () in
+  let h = Mode_enforcer.hooks st in
+  let _ = Hooks.invoke h.pre_tool_use
+      (make_enforcer_event "edit" (`String "file.ml")) in
+  let vs = Mode_enforcer.violations st in
+  Alcotest.(check int) "1 violation" 1 (List.length vs);
+  let v = List.hd vs in
+  Alcotest.(check string) "tool_name" "edit" v.tool_name;
+  Alcotest.(check string) "kind" "mutating_in_diagnose" v.violation_kind;
+  Alcotest.(check bool) "ts > 0" true (v.ts > 0.0)
+
+(* ================================================================ *)
+(* Mode_resolver capability tests                                    *)
+(* ================================================================ *)
+
+let test_resolver_read_only_tools () =
+  let caps : Cdal_proof.capability_snapshot = {
+    tools = ["read"; "glob"; "grep"];
+    mcp_servers = []; max_turns = 10;
+    max_tokens = Some 4096; thinking_enabled = None;
+  } in
+  match Mode_resolver.resolve ~requested:Execution_mode.Execute
+          ~risk_class:Risk_class.Low ~capabilities:caps with
+  | Ok d ->
+    Alcotest.(check string) "downgraded to diagnose"
+      "diagnose" (Execution_mode.to_string d.effective_mode);
+    Alcotest.(check string) "source" "capability_limit" d.source
+  | Error e -> Alcotest.fail e
+
+let test_resolver_workspace_only_tools () =
+  let caps : Cdal_proof.capability_snapshot = {
+    tools = ["read"; "write"; "edit"];
+    mcp_servers = []; max_turns = 10;
+    max_tokens = Some 4096; thinking_enabled = None;
+  } in
+  match Mode_resolver.resolve ~requested:Execution_mode.Execute
+          ~risk_class:Risk_class.Low ~capabilities:caps with
+  | Ok d ->
+    Alcotest.(check string) "capped at draft"
+      "draft" (Execution_mode.to_string d.effective_mode);
+    Alcotest.(check string) "source" "capability_limit" d.source
+  | Error e -> Alcotest.fail e
+
+let test_resolver_mixed_tools () =
+  let caps : Cdal_proof.capability_snapshot = {
+    tools = ["read"; "write"; "bash"];
+    mcp_servers = []; max_turns = 10;
+    max_tokens = Some 4096; thinking_enabled = None;
+  } in
+  match Mode_resolver.resolve ~requested:Execution_mode.Execute
+          ~risk_class:Risk_class.Low ~capabilities:caps with
+  | Ok d ->
+    Alcotest.(check string) "stays execute"
+      "execute" (Execution_mode.to_string d.effective_mode);
+    Alcotest.(check string) "source" "passthrough" d.source
+  | Error e -> Alcotest.fail e
+
+let test_resolver_capability_vs_risk () =
+  (* High risk caps at Draft, read-only tools caps at Diagnose -> Diagnose wins *)
+  let caps : Cdal_proof.capability_snapshot = {
+    tools = ["read"; "grep"];
+    mcp_servers = []; max_turns = 10;
+    max_tokens = Some 4096; thinking_enabled = None;
+  } in
+  match Mode_resolver.resolve ~requested:Execution_mode.Execute
+          ~risk_class:Risk_class.High ~capabilities:caps with
+  | Ok d ->
+    Alcotest.(check string) "diagnose (capability tighter)"
+      "diagnose" (Execution_mode.to_string d.effective_mode);
+    Alcotest.(check string) "source" "capability_limit" d.source
+  | Error e -> Alcotest.fail e
+
+(* ================================================================ *)
+(* Evidence enrichment tests                                         *)
+(* ================================================================ *)
+
+let test_evidence_violations_in_proof () =
+  let store, tmpdir = make_test_store () in
+  let contract = make_contract ~mode:Execution_mode.Diagnose ~risk:Risk_class.Low () in
+  let mode_decision : Mode_resolver.decision = {
+    effective_mode = Execution_mode.Diagnose; source = "passthrough";
+  } in
+  let state = Proof_capture.create
+      ~store ~contract ~mode_decision ~capability_snapshot:test_caps in
+  let enforcer = Mode_enforcer.create
+      ~contract ~effective_mode:Execution_mode.Diagnose in
+  Proof_capture.set_enforcer state enforcer;
+  (* Fire enforcement hook that blocks a write *)
+  let eh = Mode_enforcer.hooks enforcer in
+  let _ = Hooks.invoke eh.pre_tool_use
+      (Hooks.PreToolUse { tool_name = "write"; input = `Null;
+                          accumulated_cost_usd = 0.0; turn = 1 }) in
+  let proof = Proof_capture.finalize state ~result_status:Cdal_proof.Completed in
+  Alcotest.(check bool) "raw_evidence_refs non-empty" true
+    (List.length proof.raw_evidence_refs > 0);
+  Alcotest.(check bool) "has violations ref" true
+    (List.exists (fun r -> try ignore (Str.search_forward
+       (Str.regexp_string "mode_violations") r 0); true
+       with Not_found -> false) proof.raw_evidence_refs);
+  ignore (Sys.command (Printf.sprintf "rm -rf %s" tmpdir))
+
+let test_evidence_token_usage () =
+  let store, tmpdir = make_test_store () in
+  let state = Proof_capture.create
+      ~store ~contract:test_contract
+      ~mode_decision:test_mode_decision
+      ~capability_snapshot:test_caps in
+  let enforcer = Mode_enforcer.create
+      ~contract:test_contract ~effective_mode:Execution_mode.Draft in
+  Proof_capture.set_enforcer state enforcer;
+  let eh = Mode_enforcer.hooks enforcer in
+  let resp : Types.api_response = {
+    id = "msg-1"; model = "test-model"; stop_reason = Types.EndTurn;
+    content = [Types.Text "done"];
+    usage = Some { input_tokens = 100; output_tokens = 50;
+                   cache_creation_input_tokens = 0; cache_read_input_tokens = 0;
+                   cost_usd = Some 0.001 };
+  } in
+  let _ = Hooks.invoke eh.after_turn (Hooks.AfterTurn { turn = 1; response = resp }) in
+  let proof = Proof_capture.finalize state ~result_status:Cdal_proof.Completed in
+  Alcotest.(check bool) "has token_usage ref" true
+    (List.exists (fun r -> try ignore (Str.search_forward
+       (Str.regexp_string "token_usage") r 0); true
+       with Not_found -> false) proof.raw_evidence_refs);
+  ignore (Sys.command (Printf.sprintf "rm -rf %s" tmpdir))
+
+let test_evidence_review_warning () =
+  let contract = Risk_contract.{
+    runtime_constraints = {
+      requested_execution_mode = Execution_mode.Execute;
+      risk_class = Risk_class.Low;
+      allowed_mutations = [];
+      review_requirement = Some "human_review";
+    };
+    eval_criteria = `Null;
+  } in
+  let store, tmpdir = make_test_store () in
+  let mode_decision : Mode_resolver.decision = {
+    effective_mode = Execution_mode.Execute; source = "passthrough";
+  } in
+  let state = Proof_capture.create
+      ~store ~contract ~mode_decision ~capability_snapshot:test_caps in
+  let enforcer = Mode_enforcer.create
+      ~contract ~effective_mode:Execution_mode.Execute in
+  Proof_capture.set_enforcer state enforcer;
+  let eh = Mode_enforcer.hooks enforcer in
+  let _ = Hooks.invoke eh.before_turn
+      (Hooks.BeforeTurn { turn = 1; messages = [] }) in
+  Alcotest.(check bool) "review warning set" true
+    (Mode_enforcer.review_warning enforcer <> None);
+  let proof = Proof_capture.finalize state ~result_status:Cdal_proof.Completed in
+  Alcotest.(check bool) "has review_warning ref" true
+    (List.exists (fun r -> try ignore (Str.search_forward
+       (Str.regexp_string "review_warning") r 0); true
+       with Not_found -> false) proof.raw_evidence_refs);
+  ignore (Sys.command (Printf.sprintf "rm -rf %s" tmpdir))
+
+(* ================================================================ *)
+(* Tool classification tests                                         *)
+(* ================================================================ *)
+
+let test_classify_known_tools () =
+  Alcotest.(check bool) "read is Read_only" true
+    (Mode_enforcer.classify_tool "read" = Mode_enforcer.Read_only);
+  Alcotest.(check bool) "glob is Read_only" true
+    (Mode_enforcer.classify_tool "glob" = Mode_enforcer.Read_only);
+  Alcotest.(check bool) "write is Workspace_mutating" true
+    (Mode_enforcer.classify_tool "write" = Mode_enforcer.Workspace_mutating);
+  Alcotest.(check bool) "edit is Workspace_mutating" true
+    (Mode_enforcer.classify_tool "edit" = Mode_enforcer.Workspace_mutating);
+  Alcotest.(check bool) "bash is External_effect" true
+    (Mode_enforcer.classify_tool "bash" = Mode_enforcer.External_effect);
+  Alcotest.(check bool) "mcp__foo is External_effect" true
+    (Mode_enforcer.classify_tool "mcp__foo__bar" = Mode_enforcer.External_effect);
+  Alcotest.(check bool) "unknown is External_effect" true
+    (Mode_enforcer.classify_tool "deploy_nuke" = Mode_enforcer.External_effect)
+
+(* ================================================================ *)
 (* Test runner                                                       *)
 (* ================================================================ *)
 
@@ -500,5 +783,30 @@ let () =
       Alcotest.test_case "full lifecycle" `Quick test_proof_capture_lifecycle;
       Alcotest.test_case "no hooks fired (guard)" `Quick test_proof_capture_no_hooks_fired;
       Alcotest.test_case "multiple tools" `Quick test_proof_capture_multiple_tools;
+    ];
+    "Mode_enforcer", [
+      Alcotest.test_case "diagnose blocks write" `Quick test_diagnose_blocks_write;
+      Alcotest.test_case "diagnose blocks bash rm" `Quick test_diagnose_blocks_bash_rm;
+      Alcotest.test_case "diagnose allows read" `Quick test_diagnose_allows_read;
+      Alcotest.test_case "diagnose allows bash ls" `Quick test_diagnose_allows_bash_ls;
+      Alcotest.test_case "draft allows write" `Quick test_draft_allows_write;
+      Alcotest.test_case "draft blocks bash curl" `Quick test_draft_blocks_bash_curl;
+      Alcotest.test_case "execute allows all" `Quick test_execute_allows_all;
+      Alcotest.test_case "scope violation" `Quick test_scope_violation;
+      Alcotest.test_case "violation records details" `Quick test_violation_records_details;
+    ];
+    "Mode_resolver capability", [
+      Alcotest.test_case "read-only tools" `Quick test_resolver_read_only_tools;
+      Alcotest.test_case "workspace-only tools" `Quick test_resolver_workspace_only_tools;
+      Alcotest.test_case "mixed tools" `Quick test_resolver_mixed_tools;
+      Alcotest.test_case "capability vs risk" `Quick test_resolver_capability_vs_risk;
+    ];
+    "Evidence enrichment", [
+      Alcotest.test_case "violations in proof" `Quick test_evidence_violations_in_proof;
+      Alcotest.test_case "token usage" `Quick test_evidence_token_usage;
+      Alcotest.test_case "review warning" `Quick test_evidence_review_warning;
+    ];
+    "Tool classification", [
+      Alcotest.test_case "known tools" `Quick test_classify_known_tools;
     ];
   ]


### PR DESCRIPTION
## Summary

PoC-1.5: Contract-Driven Agent Loop에 runtime enforcement layer 추가.

- **Mode_enforcer**: 3-layer hook composition으로 tool call을 execution mode에 따라 차단
  - Diagnose: read-only만 허용, 나머지 Skip
  - Draft: workspace-local까지 허용, external effect Skip
  - Execute: 전부 허용 (scope restriction 적용 가능)
- **Mode_resolver**: dead `capabilities:_` 제거, tool set 기반 자동 downgrade
- **Evidence enrichment**: `raw_evidence_refs`에 violations, token_usage, review_warning 기록
- Bash command 분석: heuristic prefix matching으로 mutating/external 패턴 탐지

## Architecture

```
Contract_runner.run
  enforcement_hooks (outermost) -- can return Skip
    proof_capture_hooks (middle) -- always Continue, observes
      user_hooks (inner)
```

## Changes

| File | Change |
|------|--------|
| `lib/mode_enforcer.mli` + `.ml` | New: 180 lines, enforcement hooks + tool classification |
| `lib/mode_resolver.ml` | Capability-based downgrade (was dead param) |
| `lib/proof_capture.ml` + `.mli` | set_enforcer + evidence collection in finalize |
| `lib/contract_runner.ml` | 3-layer composition wiring |
| `lib/agent_sdk.ml` + `.mli` | Mode_enforcer re-export |
| `test/test_cdal.ml` | +308 lines, 17 new tests (41 total) |

## Test plan

- [x] 기존 24 tests pass (regression)
- [x] 17 new tests pass (41 total)
- [x] Full `dune runtest` all suites pass
- [ ] CI 4/4 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)