### PR TITLE
[codex] pin MCP SDK docs to v1.2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,7 @@ cd oas
 
 # Pin fork dependencies (required for OCaml 5.4)
 opam pin add bisect_ppx git+https://github.com/patricoferris/bisect_ppx.git#5.2 --no-action --yes
-opam pin add mcp_protocol git+https://github.com/jeong-sik/mcp-protocol-sdk.git#main --no-action --yes
-opam pin add mcp_protocol_eio git+https://github.com/jeong-sik/mcp-protocol-sdk.git#main --no-action --yes
+opam pin add mcp_protocol git+https://github.com/jeong-sik/mcp-protocol-sdk.git#v1.2.0 --no-action --yes
 
 # Install dependencies
 opam install . --deps-only --with-test --yes
@@ -69,7 +68,7 @@ Two dependencies are pinned to forks. Both are temporary.
 | Package | Fork | Why | Upstream status |
 |---------|------|-----|-----------------|
 | `bisect_ppx` | `patricoferris/bisect_ppx#5.2` | Upstream 2.8.x fails on OCaml 5.4. This fork adds 5.4 compat. | PR pending upstream. Remove pin when bisect_ppx >= 2.9 ships. |
-| `mcp_protocol`, `mcp_protocol_eio` | `jeong-sik/mcp-protocol-sdk#main` | OCaml MCP client bindings not yet on opam. | Same author. Publish to opam when MCP spec stabilizes. |
+| `mcp_protocol` | `jeong-sik/mcp-protocol-sdk#v1.2.0` | OCaml MCP bindings are pinned to the current single-package release line. | Move to opam package releases when installation no longer depends on a git pin. |
 
 These pins are set in CI (`ci.yml`) and in the build instructions above.
 When upstream releases resolve the issue, remove the pin and use the opam version.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ git clone https://github.com/jeong-sik/oas.git && cd oas
 
 # Required fork pins (OCaml 5.4 compat)
 opam pin add bisect_ppx git+https://github.com/patricoferris/bisect_ppx.git#5.2 --no-action --yes
-opam pin add mcp_protocol git+https://github.com/jeong-sik/mcp-protocol-sdk.git#main --no-action --yes
-opam pin add mcp_protocol_eio git+https://github.com/jeong-sik/mcp-protocol-sdk.git#main --no-action --yes
+opam pin add mcp_protocol git+https://github.com/jeong-sik/mcp-protocol-sdk.git#v1.2.0 --no-action --yes
 
 opam install . --deps-only --with-test --yes
 dune build @all


### PR DESCRIPTION
## What changed
- Updated development setup docs to pin `mcp_protocol` to `jeong-sik/mcp-protocol-sdk#v1.2.0`.
- Removed the stale `mcp_protocol_eio` pin from `README.md` and `CONTRIBUTING.md`.

## Why
- `mcp-protocol-sdk` now publishes a single `mcp_protocol` package.
- The old docs still pointed at `#main` and referenced the removed split-package pin, which no longer matches the current release line or CI pin.

## Impact
- Local setup instructions now match the current `v1.2.0` release line and CI's pinned SDK commit.
- Contributors are less likely to pin the wrong package layout when reproducing builds locally.

## Validation
- Confirmed the doc diff only touches `README.md` and `CONTRIBUTING.md`.
- Confirmed no remaining `mcp-protocol-sdk.git#main` or `mcp_protocol_eio` references in those files.
- No code or dependency manifest changes; no build/test run was needed for this doc-only update.
