### PR TITLE
chore: SSOT for MCP SDK pin + local drift checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,13 @@ jobs:
 
       - name: Pin fork packages
         run: |
-          SDK_REF=e8fb2dc066c9ae008db2261db65811beeded477d
+          source scripts/mcp-sdk-pin.sh
           # bisect_ppx fork only needed for 5.4.x (coverage); skip on 5.1.x
           # to avoid dependency resolution failures
           if [ "${{ matrix.ocaml-compiler }}" = "5.4.x" ]; then
             opam pin add bisect_ppx git+https://github.com/patricoferris/bisect_ppx.git#5.2 --no-action --yes
           fi
-          opam pin add mcp_protocol git+https://github.com/jeong-sik/mcp-protocol-sdk.git#${SDK_REF} --no-action --yes
+          opam pin add mcp_protocol "git+${MCP_SDK_URL}#${MCP_SDK_SHA}" --no-action --yes
 
       - name: Install dependencies
         run: |
@@ -119,9 +119,9 @@ jobs:
 
       - name: Pin fork packages
         run: |
-          SDK_REF=e8fb2dc066c9ae008db2261db65811beeded477d
+          source scripts/mcp-sdk-pin.sh
           opam pin add bisect_ppx git+https://github.com/patricoferris/bisect_ppx.git#5.2 --no-action --yes
-          opam pin add mcp_protocol git+https://github.com/jeong-sik/mcp-protocol-sdk.git#${SDK_REF} --no-action --yes
+          opam pin add mcp_protocol "git+${MCP_SDK_URL}#${MCP_SDK_SHA}" --no-action --yes
 
       - name: Install dependencies
         run: |

--- a/scripts/check-local-pins.sh
+++ b/scripts/check-local-pins.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Detect opam pin drift: compare local pins against SSOT.
+# Run before build to catch CI/local divergence early.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/mcp-sdk-pin.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+drift=0
+
+check_pin() {
+  local pkg="$1" expected_sha="$2" label="$3"
+  local local_info
+  local_info="$(opam pin list 2>/dev/null | grep "^${pkg}\." || true)"
+
+  if [[ -z "$local_info" ]]; then
+    echo -e "${YELLOW}[WARN]${NC} ${label}: not pinned locally (opam default)"
+    return
+  fi
+
+  if echo "$local_info" | grep -q "$expected_sha"; then
+    echo -e "${GREEN}[OK]${NC} ${label}: ${expected_sha:0:12}"
+  else
+    local actual
+    actual="$(echo "$local_info" | grep -oE 'at [a-f0-9]+' | head -1 | sed 's/at //')"
+    echo -e "${RED}[DRIFT]${NC} ${label}"
+    echo "  expected: ${expected_sha:0:12} (from scripts/mcp-sdk-pin.sh)"
+    echo "  local:    ${actual:-unknown}"
+    echo "  fix: opam pin ${pkg} \"git+${MCP_SDK_URL}#${expected_sha}\" --yes"
+    drift=1
+  fi
+}
+
+echo "Checking local opam pins against SSOT..."
+check_pin "mcp_protocol" "$MCP_SDK_SHA" "mcp_protocol"
+
+if [[ $drift -ne 0 ]]; then
+  echo ""
+  echo -e "${RED}Pin drift detected.${NC} Local build may behave differently from CI."
+  echo "Run the fix commands above, then: dune clean && dune build"
+  exit 1
+fi
+
+echo -e "${GREEN}All pins match CI.${NC}"

--- a/scripts/mcp-sdk-pin.sh
+++ b/scripts/mcp-sdk-pin.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# SSOT for MCP Protocol SDK pin.
+# CI reads this; local dev scripts validate against it.
+
+readonly MCP_SDK_URL="https://github.com/jeong-sik/mcp-protocol-sdk.git"
+readonly MCP_SDK_TAG="v1.2.0"
+readonly MCP_SDK_SHA="e8fb2dc066c9ae008db2261db65811beeded477d"
+readonly MCP_SDK_MIN_VERSION="1.2.0"


### PR DESCRIPTION
## Summary

CI와 로컬의 opam pin drift를 방지하는 구조.

**문제**: CI는 `ci.yml`에 hardcoded SHA로 mcp_protocol을 pin. 로컬은 `opam pin`으로 별도 관리. drift가 발생하면 로컬에서만 테스트 실패하고 "CI green이니까 OK"로 넘어감.

**해결**:
- `scripts/mcp-sdk-pin.sh`: SHA SSOT (CI + local 공통)
- `scripts/check-local-pins.sh`: drift 탐지 (OK/DRIFT 출력)
- CI가 SSOT를 source하여 hardcoded SHA 제거

```bash
$ scripts/check-local-pins.sh
Checking local opam pins against SSOT...
[OK] mcp_protocol: e8fb2dc066c9
All pins match CI.
```

## Test plan

- [x] drift checker 동작 확인 (correct pin → OK)
- [ ] CI green (SSOT source 동작)

🤖 Generated with [Claude Code](https://claude.com/claude-code)