### PR TITLE
refactor(cdal): simplify — Str removal, reuse, violation_kind variant

### DIFF
--- a/lib/cdal_proof.ml
+++ b/lib/cdal_proof.ml
@@ -5,19 +5,23 @@ type result_status =
   | Cancelled
 [@@deriving show]
 
-let result_status_to_yojson = function
-  | Completed -> `String "completed"
-  | Errored -> `String "errored"
-  | Timed_out -> `String "timed_out"
-  | Cancelled -> `String "cancelled"
+let result_status_to_string = function
+  | Completed -> "completed"
+  | Errored -> "errored"
+  | Timed_out -> "timed_out"
+  | Cancelled -> "cancelled"
 
+let result_status_of_string = function
+  | "completed" -> Ok Completed
+  | "errored" -> Ok Errored
+  | "timed_out" -> Ok Timed_out
+  | "cancelled" -> Ok Cancelled
+  | s -> Error (Printf.sprintf "unknown result status: %s" s)
+
+let result_status_to_yojson v = `String (result_status_to_string v)
 let result_status_of_yojson = function
-  | `String "completed" -> Ok Completed
-  | `String "errored" -> Ok Errored
-  | `String "timed_out" -> Ok Timed_out
-  | `String "cancelled" -> Ok Cancelled
-  | j -> Error (Printf.sprintf "unknown result status: %s"
-                  (Yojson.Safe.to_string j))
+  | `String s -> result_status_of_string s
+  | j -> Error (Printf.sprintf "expected string, got %s" (Yojson.Safe.to_string j))
 
 type provider_snapshot = {
   provider_name: string;

--- a/lib/execution_mode.ml
+++ b/lib/execution_mode.ml
@@ -4,18 +4,6 @@ type t =
   | Execute
 [@@deriving show]
 
-let to_yojson = function
-  | Diagnose -> `String "diagnose"
-  | Draft -> `String "draft"
-  | Execute -> `String "execute"
-
-let of_yojson = function
-  | `String "diagnose" -> Ok Diagnose
-  | `String "draft" -> Ok Draft
-  | `String "execute" -> Ok Execute
-  | j -> Error (Printf.sprintf "unknown execution mode: %s"
-                  (Yojson.Safe.to_string j))
-
 let to_string = function
   | Diagnose -> "diagnose"
   | Draft -> "draft"
@@ -26,6 +14,11 @@ let of_string = function
   | "draft" -> Ok Draft
   | "execute" -> Ok Execute
   | s -> Error (Printf.sprintf "unknown execution mode: %s" s)
+
+let to_yojson v = `String (to_string v)
+let of_yojson = function
+  | `String s -> of_string s
+  | j -> Error (Printf.sprintf "expected string, got %s" (Yojson.Safe.to_string j))
 
 let to_int = function
   | Diagnose -> 0

--- a/lib/mode_enforcer.ml
+++ b/lib/mode_enforcer.ml
@@ -3,12 +3,22 @@ type mutation_class =
   | Workspace_mutating
   | External_effect
 
+type violation_kind =
+  | Mutating_in_diagnose
+  | External_in_draft
+  | Scope_violation
+
+let violation_kind_to_string = function
+  | Mutating_in_diagnose -> "mutating_in_diagnose"
+  | External_in_draft -> "external_in_draft"
+  | Scope_violation -> "scope_violation"
+
 type violation = {
   ts: float;
   tool_name: string;
   input_summary: string;
   effective_mode: Execution_mode.t;
-  violation_kind: string;
+  violation_kind: violation_kind;
 }
 
 type token_snapshot = {
@@ -61,53 +71,49 @@ let classify_tool name =
     External_effect
   | _ -> External_effect
 
-let is_bash_read_only (input : Yojson.Safe.t) =
-  match input with
-  | `Assoc fields ->
-    (match List.assoc_opt "command" fields with
-     | Some (`String cmd) ->
-       let cmd_lower = String.lowercase_ascii cmd in
-       let mutating_patterns = [
-         "rm "; "rm\t"; "rmdir "; "mv "; "cp "; "mkdir ";
-         "touch "; "chmod "; "chown "; "dd "; "mkfs";
-         "apt "; "brew "; "pip "; "npm "; "yarn "; "cargo ";
-         "git push"; "git commit"; "git add"; "git reset";
-         "git rebase"; "git merge"; "git checkout";
-         "docker "; "kubectl "; "systemctl ";
-         "curl "; "wget ";
-       ] in
-       let has_redirect =
-         String.contains cmd '>'
-         || (try ignore (Str.search_forward (Str.regexp_string "tee ") cmd 0); true
-             with Not_found -> false)
-       in
-       let has_mutating = List.exists (fun pat ->
-         try ignore (Str.search_forward (Str.regexp_string pat) cmd_lower 0); true
-         with Not_found -> false
-       ) mutating_patterns in
-       not has_mutating && not has_redirect
-     | _ -> false)
-  | _ -> false
+let has_any_pattern patterns haystack =
+  List.exists (fun pat -> Util.string_contains ~needle:pat haystack) patterns
 
-let is_bash_workspace_only (input : Yojson.Safe.t) =
+let mutating_patterns = [
+  "rm "; "rm\t"; "rmdir "; "mv "; "cp "; "mkdir ";
+  "touch "; "chmod "; "chown "; "dd "; "mkfs";
+  "apt "; "brew "; "pip "; "npm "; "yarn "; "cargo ";
+  "git push"; "git commit"; "git add"; "git reset";
+  "git rebase"; "git merge"; "git checkout";
+  "docker "; "kubectl "; "systemctl ";
+  "curl "; "wget ";
+]
+
+let external_patterns = [
+  "curl "; "wget "; "ssh "; "scp "; "rsync ";
+  "git push"; "git fetch"; "git pull"; "git clone";
+  "docker "; "kubectl "; "helm ";
+  "npm publish"; "pip install"; "cargo publish";
+  "systemctl "; "launchctl ";
+]
+
+let extract_bash_command (input : Yojson.Safe.t) =
   match input with
   | `Assoc fields ->
     (match List.assoc_opt "command" fields with
-     | Some (`String cmd) ->
-       let cmd_lower = String.lowercase_ascii cmd in
-       let external_patterns = [
-         "curl "; "wget "; "ssh "; "scp "; "rsync ";
-         "git push"; "git fetch"; "git pull"; "git clone";
-         "docker "; "kubectl "; "helm ";
-         "npm publish"; "pip install"; "cargo publish";
-         "systemctl "; "launchctl ";
-       ] in
-       not (List.exists (fun pat ->
-         try ignore (Str.search_forward (Str.regexp_string pat) cmd_lower 0); true
-         with Not_found -> false
-       ) external_patterns)
-     | _ -> false)
-  | _ -> false
+     | Some (`String cmd) -> Some (String.lowercase_ascii cmd)
+     | _ -> None)
+  | _ -> None
+
+let is_bash_read_only input =
+  match extract_bash_command input with
+  | None -> false
+  | Some cmd ->
+    let has_redirect =
+      String.contains cmd '>'
+      || Util.string_contains ~needle:"tee " cmd
+    in
+    not (has_any_pattern mutating_patterns cmd) && not has_redirect
+
+let is_bash_workspace_only input =
+  match extract_bash_command input with
+  | None -> false
+  | Some cmd -> not (has_any_pattern external_patterns cmd)
 
 let classify_bash_tool input =
   if is_bash_read_only input then Read_only
@@ -135,21 +141,19 @@ let all_workspace_only tools =
 (* ── Enforcement check ───────────────────────────────────────────── *)
 
 let truncate_input input =
-  let s = Yojson.Safe.to_string input in
-  if String.length s > 200 then String.sub s 0 200 ^ "..."
-  else s
+  Util.clip (Yojson.Safe.to_string input) 200
 
 let check_violation st tool_name input =
   let cls = effective_class tool_name input in
   let kind = match st.effective_mode, cls with
     | Execution_mode.Diagnose, (Workspace_mutating | External_effect) ->
-      Some "mutating_in_diagnose"
+      Some Mutating_in_diagnose
     | Execution_mode.Draft, External_effect ->
-      Some "external_in_draft"
+      Some External_in_draft
     | _ ->
       if List.mem "workspace_only" st.allowed_mutations
          && cls = External_effect then
-        Some "scope_violation"
+        Some Scope_violation
       else
         None
   in

--- a/lib/mode_enforcer.mli
+++ b/lib/mode_enforcer.mli
@@ -13,12 +13,19 @@ type mutation_class =
   | Workspace_mutating
   | External_effect
 
+type violation_kind =
+  | Mutating_in_diagnose
+  | External_in_draft
+  | Scope_violation
+
+val violation_kind_to_string : violation_kind -> string
+
 type violation = {
   ts: float;
   tool_name: string;
   input_summary: string;
   effective_mode: Execution_mode.t;
-  violation_kind: string;
+  violation_kind: violation_kind;
 }
 
 type token_snapshot = {

--- a/lib/proof_capture.ml
+++ b/lib/proof_capture.ml
@@ -161,7 +161,7 @@ let collect_evidence_refs st =
           "tool_name", `String v.tool_name;
           "input_summary", `String v.input_summary;
           "effective_mode", Execution_mode.to_yojson v.effective_mode;
-          "violation_kind", `String v.violation_kind;
+          "violation_kind", `String (Mode_enforcer.violation_kind_to_string v.violation_kind);
         ]) violations) in
       Proof_store.write_evidence st.store ~run_id:st.run_id
         ~ref_id:"mode_violations" json;

--- a/lib/risk_class.ml
+++ b/lib/risk_class.ml
@@ -5,20 +5,6 @@ type t =
   | Critical
 [@@deriving show]
 
-let to_yojson = function
-  | Low -> `String "low"
-  | Medium -> `String "medium"
-  | High -> `String "high"
-  | Critical -> `String "critical"
-
-let of_yojson = function
-  | `String "low" -> Ok Low
-  | `String "medium" -> Ok Medium
-  | `String "high" -> Ok High
-  | `String "critical" -> Ok Critical
-  | j -> Error (Printf.sprintf "unknown risk class: %s"
-                  (Yojson.Safe.to_string j))
-
 let to_string = function
   | Low -> "low"
   | Medium -> "medium"
@@ -31,6 +17,11 @@ let of_string = function
   | "high" -> Ok High
   | "critical" -> Ok Critical
   | s -> Error (Printf.sprintf "unknown risk class: %s" s)
+
+let to_yojson v = `String (to_string v)
+let of_yojson = function
+  | `String s -> of_string s
+  | j -> Error (Printf.sprintf "expected string, got %s" (Yojson.Safe.to_string j))
 
 let to_int = function
   | Low -> 0

--- a/test/test_cdal.ml
+++ b/test/test_cdal.ml
@@ -554,7 +554,7 @@ let test_scope_violation () =
     (match d with Hooks.Skip -> true | _ -> false);
   let vs = Mode_enforcer.violations st in
   Alcotest.(check string) "violation kind" "scope_violation"
-    (List.hd vs).violation_kind
+    (Mode_enforcer.violation_kind_to_string (List.hd vs).violation_kind)
 
 let test_violation_records_details () =
   let st = diagnose_enforcer () in
@@ -565,7 +565,8 @@ let test_violation_records_details () =
   Alcotest.(check int) "1 violation" 1 (List.length vs);
   let v = List.hd vs in
   Alcotest.(check string) "tool_name" "edit" v.tool_name;
-  Alcotest.(check string) "kind" "mutating_in_diagnose" v.violation_kind;
+  Alcotest.(check string) "kind" "mutating_in_diagnose"
+    (Mode_enforcer.violation_kind_to_string v.violation_kind);
   Alcotest.(check bool) "ts > 0" true (v.ts > 0.0)
 
 (* ================================================================ *)


### PR DESCRIPTION
## Summary

/simplify 3-agent review에서 발견된 4가지 이슈 수정. Net zero lines (+92/-92).

| Fix | Before | After |
|-----|--------|-------|
| Pattern matching | `Str.search_forward` (fiber-unsafe, per-call compile) | `Util.string_contains` (existing utility) |
| Input truncation | Hand-rolled truncate | `Util.clip` (existing utility) |
| Enum serialization | Parallel to_yojson/to_string (30+ duplicate arms) | `to_yojson v = \`String (to_string v)` |
| violation_kind | `string` ("mutating_in_diagnose") | Variant `Mutating_in_diagnose` |

## Test plan

- [x] 41/41 CDAL tests pass
- [ ] CI 4/4 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)