### PR TITLE
feat(swarm): add extensions field to agent_entry for consumer metadata

### DIFF
--- a/lib_swarm/swarm_checkpoint.ml
+++ b/lib_swarm/swarm_checkpoint.ml
@@ -215,7 +215,7 @@ let mock_run _text ~sw:_ _prompt =
 
 let make_entry name =
   { Swarm_types.name; run = mock_run "ok"; role = Swarm_types.Execute;
-    get_telemetry = None }
+    get_telemetry = None; extensions = [] }
 
 let make_config ?(entries=[make_entry "a1"; make_entry "a2"])
     ?(mode=Swarm_types.Pipeline_mode)

--- a/lib_swarm/swarm_types.ml
+++ b/lib_swarm/swarm_types.ml
@@ -64,12 +64,13 @@ type agent_entry = {
   run: sw:Eio.Switch.t -> string -> (Types.api_response, Error.sdk_error) result;
   role: agent_role;
   get_telemetry: (unit -> agent_telemetry) option;
+  extensions: (string * Yojson.Safe.t) list;
 }
 
 
 (** Wrap an [Agent.t] into an [agent_entry]. Clock is captured via closure.
     Automatically wires [get_telemetry] to extract [Agent.last_raw_trace_run]. *)
-let make_entry ~name ~role ~(clock : _ Eio.Time.clock) (agent : Agent.t) =
+let make_entry ~name ~role ?(extensions = []) ~(clock : _ Eio.Time.clock) (agent : Agent.t) =
   { name;
     run = (fun ~sw prompt -> Agent.run ~sw ~clock agent prompt);
     role;
@@ -77,7 +78,8 @@ let make_entry ~name ~role ~(clock : _ Eio.Time.clock) (agent : Agent.t) =
       let state = Agent.state agent in
       { trace_ref = Agent.last_raw_trace_run agent;
         usage = Some state.usage;
-        turn_count = state.turn_count }) }
+        turn_count = state.turn_count });
+    extensions }
 
 type resource_budget = {
   max_total_tokens: int option;

--- a/lib_swarm/swarm_types.mli
+++ b/lib_swarm/swarm_types.mli
@@ -63,12 +63,16 @@ val empty_telemetry : agent_telemetry
 
 (** Closure-based agent entry. [run] captures the agent and clock
     so that the swarm runner only needs [sw] and [prompt].
-    [get_telemetry] optionally extracts Layer 1 telemetry after each run. *)
+    [get_telemetry] optionally extracts Layer 1 telemetry after each run.
+    [extensions] carries consumer-specific metadata that OAS does not
+    interpret — e.g. execution scope, routing hints, worker class.
+    Consumers populate it during projection; OAS passes it through. *)
 type agent_entry = {
   name: string;
   run: sw:Eio.Switch.t -> string -> (Types.api_response, Error.sdk_error) result;
   role: agent_role;
   get_telemetry: (unit -> agent_telemetry) option;
+  extensions: (string * Yojson.Safe.t) list;
 }
 
 (** Wrap an {!Agent.t} into an {!agent_entry}.
@@ -76,6 +80,7 @@ type agent_entry = {
 val make_entry :
   name:string ->
   role:agent_role ->
+  ?extensions:(string * Yojson.Safe.t) list ->
   clock:_ Eio.Time.clock ->
   Agent.t ->
   agent_entry

--- a/lib_swarm/test_helpers.ml
+++ b/lib_swarm/test_helpers.ml
@@ -25,6 +25,7 @@ let mock_entry ~name ?(role = Swarm_types.Execute) text : Swarm_types.agent_entr
     run = (fun ~sw:_ _prompt -> text_response text);
     role;
     get_telemetry = None;
+    extensions = [];
   }
 
 (** Create a mock agent_entry that fails with the given message. *)
@@ -33,6 +34,7 @@ let failing_entry ~name ?(role = Swarm_types.Execute) msg : Swarm_types.agent_en
     run = (fun ~sw:_ _prompt -> Error (Error.Internal msg));
     role;
     get_telemetry = None;
+    extensions = [];
   }
 
 (** Create a mock agent_entry with a counter (tracks call count). *)
@@ -44,6 +46,7 @@ let counting_entry ~name ?(role = Swarm_types.Execute) text
     run = (fun ~sw:_ _prompt -> incr count; text_response text);
     role;
     get_telemetry = None;
+    extensions = [];
   } in
   (entry, fun () -> !count)
 

--- a/test/test_review_agent.ml
+++ b/test/test_review_agent.ml
@@ -23,7 +23,7 @@ let test_review_mock_flow () =
       Ok { Types.id = "m2"; model = "mock"; stop_reason = EndTurn;
            content = [Text "Review complete."]; usage = None }
   in
-  let entry = { Swarm_types.name = "reviewer"; run = mock_run; role = Execute; get_telemetry = None } in
+  let entry = { Swarm_types.name = "reviewer"; run = mock_run; role = Execute; get_telemetry = None; extensions = [] } in
   let config = Test_helpers.basic_config ~prompt:"Review PR #1 in test/repo" [entry] in
   let state = Swarm_types.create_state config in
   check int "initial iteration" 0 state.current_iteration;

--- a/test/test_swarm.ml
+++ b/test/test_swarm.ml
@@ -267,7 +267,7 @@ let test_convergence_reaches_target () =
   in
   let config : Swarm_types.swarm_config = {
     entries = [
-      { name = "worker-1"; run = mock_run "result-1"; role = Execute; get_telemetry = None };
+      { name = "worker-1"; run = mock_run "result-1"; role = Execute; get_telemetry = None; extensions = [] };
     ];
     mode = Decentralized;
     convergence = Some {
@@ -301,7 +301,7 @@ let test_convergence_patience_exhausted () =
   let metric_fn () = 0.3 in  (* Never improves *)
   let config : Swarm_types.swarm_config = {
     entries = [
-      { name = "stuck"; run = mock_run "stuck"; role = Execute; get_telemetry = None };
+      { name = "stuck"; run = mock_run "stuck"; role = Execute; get_telemetry = None; extensions = [] };
     ];
     mode = Decentralized;
     convergence = Some {
@@ -334,7 +334,7 @@ let test_convergence_max_iterations () =
   let metric_fn () = incr counter; float_of_int !counter *. 0.1 in
   let config : Swarm_types.swarm_config = {
     entries = [
-      { name = "w"; run = mock_run "x"; role = Execute; get_telemetry = None };
+      { name = "w"; run = mock_run "x"; role = Execute; get_telemetry = None; extensions = [] };
     ];
     mode = Decentralized;
     convergence = Some {
@@ -364,8 +364,8 @@ let test_single_pass_no_convergence () =
   let _ = clock in
   let config : Swarm_types.swarm_config = {
     entries = [
-      { name = "a1"; run = mock_run "hello"; role = Discover; get_telemetry = None };
-      { name = "a2"; run = mock_run "world"; role = Verify; get_telemetry = None };
+      { name = "a1"; run = mock_run "hello"; role = Discover; get_telemetry = None; extensions = [] };
+      { name = "a2"; run = mock_run "world"; role = Verify; get_telemetry = None; extensions = [] };
     ];
     mode = Decentralized;
     convergence = None;
@@ -403,7 +403,7 @@ let test_callbacks_fire () =
   } in
   let config : Swarm_types.swarm_config = {
     entries = [
-      { name = "cb-agent"; run = mock_run "ok"; role = Execute; get_telemetry = None };
+      { name = "cb-agent"; run = mock_run "ok"; role = Execute; get_telemetry = None; extensions = [] };
     ];
     mode = Decentralized;
     convergence = Some {
@@ -470,7 +470,7 @@ let test_12_worker_decentralized () =
     { Swarm_types.name;
       run = mock_run_with_latency ~clock ~latency_ms:latency
               (Printf.sprintf "output-%s" name);
-      role; get_telemetry = None }
+      role; get_telemetry = None; extensions = [] }
   in
   let config : Swarm_types.swarm_config = {
     entries = [
@@ -528,7 +528,7 @@ let test_12_worker_convergence () =
     let name = Printf.sprintf "w%d" i in
     { Swarm_types.name;
       run = mock_run_with_latency ~clock ~latency_ms:5 (Printf.sprintf "r%d" i);
-      role; get_telemetry = None }
+      role; get_telemetry = None; extensions = [] }
   in
   let config : Swarm_types.swarm_config = {
     entries = List.init 12 (fun i ->
@@ -580,11 +580,11 @@ let test_12_worker_supervisor () =
     { Swarm_types.name = Printf.sprintf "worker-%d" i;
       run = mock_run_with_latency ~clock ~latency_ms:5
               (Printf.sprintf "worker-%d output" i);
-      role = Execute; get_telemetry = None }
+      role = Execute; get_telemetry = None; extensions = [] }
   in
   let config : Swarm_types.swarm_config = {
     entries =
-      { name = "supervisor"; run = supervisor_run; role = Summarize; get_telemetry = None }
+      { name = "supervisor"; run = supervisor_run; role = Summarize; get_telemetry = None; extensions = [] }
       :: List.init 11 (fun i -> make_worker (i + 1));
     mode = Supervisor;
     convergence = None;
@@ -620,7 +620,7 @@ let test_12_worker_pipeline () =
       let name = Printf.sprintf "stage-%d" i in
       { Swarm_types.name;
         run = pipeline_run name;
-        role = Execute; get_telemetry = None });
+        role = Execute; get_telemetry = None; extensions = [] });
     mode = Pipeline_mode;
     convergence = None;
     max_parallel = 1;
@@ -653,11 +653,11 @@ let test_partial_failure_resilience () =
   let counter = ref 0 in
   let config : Swarm_types.swarm_config = {
     entries = [
-      { name = "ok-1"; run = mock_run "fine"; role = Execute; get_telemetry = None };
+      { name = "ok-1"; run = mock_run "fine"; role = Execute; get_telemetry = None; extensions = [] };
       { name = "fail-1";
         run = mock_run_failing ~fail_on_call:1 counter;
-        role = Execute; get_telemetry = None };
-      { name = "ok-2"; run = mock_run "also-fine"; role = Execute; get_telemetry = None };
+        role = Execute; get_telemetry = None; extensions = [] };
+      { name = "ok-2"; run = mock_run "also-fine"; role = Execute; get_telemetry = None; extensions = [] };
     ];
     mode = Decentralized;
     convergence = None;
@@ -697,7 +697,7 @@ let test_single_pass_timeout () =
          content = [Types.Text "late"]; usage = None }
   in
   let config : Swarm_types.swarm_config = {
-    entries = [{ name = "slow"; run = slow_run; role = Execute; get_telemetry = None }];
+    entries = [{ name = "slow"; run = slow_run; role = Execute; get_telemetry = None; extensions = [] }];
     mode = Decentralized;
     convergence = None;
     max_parallel = 1;
@@ -720,8 +720,8 @@ let test_single_pass_usage () =
   let _ = clock in
   let config : Swarm_types.swarm_config = {
     entries = [
-      { name = "a1"; run = mock_run "hello"; role = Discover; get_telemetry = None };
-      { name = "a2"; run = mock_run "world"; role = Verify; get_telemetry = None };
+      { name = "a1"; run = mock_run "hello"; role = Discover; get_telemetry = None; extensions = [] };
+      { name = "a2"; run = mock_run "world"; role = Verify; get_telemetry = None; extensions = [] };
     ];
     mode = Decentralized;
     convergence = None;
@@ -757,7 +757,7 @@ let test_convergence_average_aggregate () =
   in
   let config : Swarm_types.swarm_config = {
     entries = [
-      { name = "w"; run = mock_run "x"; role = Execute; get_telemetry = None };
+      { name = "w"; run = mock_run "x"; role = Execute; get_telemetry = None; extensions = [] };
     ];
     mode = Decentralized;
     convergence = Some {

--- a/test/test_swarm_streaming.ml
+++ b/test/test_swarm_streaming.ml
@@ -144,11 +144,11 @@ let test_streaming_supervisor () =
   let config : swarm_config = {
     entries = [
       { name = "supervisor"; run = supervisor_run; role = Summarize;
-        get_telemetry = None };
+        get_telemetry = None; extensions = [] };
       { name = "w1"; run = mock_run "worker-1-output"; role = Execute;
-        get_telemetry = None };
+        get_telemetry = None; extensions = [] };
       { name = "w2"; run = mock_run "worker-2-output"; role = Execute;
-        get_telemetry = None };
+        get_telemetry = None; extensions = [] };
     ];
     mode = Supervisor;
     convergence = None;
@@ -185,7 +185,7 @@ let test_streaming_pipeline () =
       let name = Printf.sprintf "stage-%d" i in
       { Swarm_types.name;
         run = pipeline_run name;
-        role = Execute; get_telemetry = None });
+        role = Execute; get_telemetry = None; extensions = [] });
     mode = Pipeline_mode;
     convergence = None;
     max_parallel = 1;
@@ -218,9 +218,9 @@ let test_streaming_decentralized () =
   let config : swarm_config = {
     entries = [
       { name = "a1"; run = mock_run "hello"; role = Discover;
-        get_telemetry = None };
+        get_telemetry = None; extensions = [] };
       { name = "a2"; run = mock_run "world"; role = Verify;
-        get_telemetry = None };
+        get_telemetry = None; extensions = [] };
     ];
     mode = Decentralized;
     convergence = None;
@@ -253,11 +253,11 @@ let test_streaming_partial_failure () =
   let config : swarm_config = {
     entries = [
       { name = "ok-1"; run = mock_run "fine"; role = Execute;
-        get_telemetry = None };
+        get_telemetry = None; extensions = [] };
       { name = "fail-1"; run = mock_run_err "boom"; role = Execute;
-        get_telemetry = None };
+        get_telemetry = None; extensions = [] };
       { name = "ok-2"; run = mock_run "also-fine"; role = Execute;
-        get_telemetry = None };
+        get_telemetry = None; extensions = [] };
     ];
     mode = Decentralized;
     convergence = None;
@@ -291,7 +291,7 @@ let test_streaming_disabled_unchanged () =
   let config : swarm_config = {
     entries = [
       { name = "a1"; run = mock_run "hello"; role = Discover;
-        get_telemetry = None };
+        get_telemetry = None; extensions = [] };
     ];
     mode = Decentralized;
     convergence = None;
@@ -318,9 +318,9 @@ let test_streaming_usage () =
   let config : swarm_config = {
     entries = [
       { name = "a1"; run = mock_run "hello"; role = Discover;
-        get_telemetry = None };
+        get_telemetry = None; extensions = [] };
       { name = "a2"; run = mock_run "world"; role = Verify;
-        get_telemetry = None };
+        get_telemetry = None; extensions = [] };
     ];
     mode = Decentralized;
     convergence = None;

--- a/test/test_traced_swarm.ml
+++ b/test/test_traced_swarm.ml
@@ -38,6 +38,7 @@ let traced_mock_entry ~trace_dir ~name ~tool_names text =
            content = [Text text]; usage = None });
     role = Execute;
     get_telemetry = None;
+    extensions = [];
   }
 
 (* ── Tests ────────────────────────────────────────────────── *)


### PR DESCRIPTION
## Summary

- `agent_entry`에 `extensions: (string * Yojson.Safe.t) list` 필드 추가
- `make_entry`에 optional `~extensions` 파라미터 추가 (default `[]`)
- 기존 모든 생성자/테스트에 `extensions = []` 추가 (8 파일)

## 설계 근거

소비자(MASC 등)가 `planned_worker`의 20개 필드를 `agent_entry`에 전달할 경로가 없어서 implicit metadata bag에 넣고 있었다. `extensions` 필드를 추가하여:

1. 확장 가능성이 **타입 시그니처에 명시**됨 (`.mli`에 보임)
2. 생성 시 빠뜨리면 **컴파일 에러** (implicit bag은 silent)
3. 미래에 typed accessor module을 extensions 위에 구축 가능

OAS는 extensions를 해석하지 않고 pass-through.

## Test plan

- [x] `dune build --root .` 통과
- [x] 33개 swarm 테스트 전부 통과

Refs #455
