### PR TITLE
docs(api): add stability tier annotations to all 186 .mli files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # OAS — OCaml Agent SDK
 
-OCaml 5.x + Eio 기반 에이전트 SDK. v0.90.0.
+OCaml 5.x + Eio 기반 에이전트 SDK. v0.93.1.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -140,18 +140,20 @@ Layer 1: agent_sdk  (lib/)
 ## Module stability tiers
 
 Not all modules are equally stable. Use this to gauge risk when depending on a module.
+Every `.mli` now carries an explicit `@stability` tag and `@since` marker.
+For the full 186-file classification, see `docs/api-stability.md`.
 
 **Stable** -- safe to depend on, breaking changes only on minor version bumps:
 
-`Types`, `Error`, `Provider`, `Api`, `Agent`, `Tool`, `Tool_set`, `Hooks`, `Guardrails`, `Context`, `Builder`, `Log`
+`Types`, `Error`, `Agent`, `Builder`, `Tool`, `Tool_set`, `Hooks`, `Provider`, `Guardrails`, `Raw_trace`, `Checkpoint`, `Checkpoint_store`, `Context`, `Context_reducer`
 
 **Evolving** -- API may change between minor versions:
 
-`Streaming`, `Structured`, `Orchestrator`, `Checkpoint`, `Mcp`, `Session`, `Skill`, `Subagent`, `Handoff`, `Contract`, `Context_reducer`, `Event_bus`, `Pipeline`, `Error_domain`, `Provider_intf`, `Memory`, `Memory_access`, `Collaboration`
+`Streaming`, `Structured`, `Orchestrator`, `Collaboration`, `Memory`, `Policy`, `Proof_store`, `Cdal_proof`, `Swarm_types`, `Runner`
 
-**Experimental** -- may be redesigned or removed:
+**Internal** -- implementation details with no compatibility promise:
 
-`Runtime`, `Transport`, `Client`, `Sessions`, `Conformance`, `Direct_evidence`, `Raw_trace`, `Otel_tracer`, `Checkpoint_store`, `Swarm_checkpoint`, `Verified_output`, `Policy`, `Audit`, `Durable`, `Plan`, `Autonomy_exec`, `Autonomy_diff_guard`, `Metric_contract`, `Lesson_memory`
+`lib/agent/*` submodules, `lib/protocol/*`, `lib/llm_provider/*` backends, parser/transport helpers, and other implementation-specific support modules
 
 ## Tool definition
 

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -39,7 +39,7 @@ Every `.mli` file has a top-level doc comment with the `@stability` tag:
 (** Context management for agent conversations.
 
     @stability Stable
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 ```
 
 Rules:
@@ -51,7 +51,12 @@ Rules:
 
 ## Current classification
 
-As of v0.93.1, MASC imports 32 OAS modules. Classification:
+As of v0.93.1, all 186 `.mli` files in `lib/` and `lib_swarm/` carry an
+explicit stability tier:
+
+- Stable: 14
+- Evolving: 94
+- Internal: 78
 
 ### Stable (14 modules)
 
@@ -74,35 +79,29 @@ Core types and interfaces that MASC and external consumers depend on.
 | Context | `lib/context.mli` |
 | Context_reducer | `lib/context_reducer.mli` |
 
-### Evolving (18 modules)
+### Evolving (94 modules)
 
-Actively developed modules with external consumers. API may change.
+Public modules with downstream consumers that are still settling. This tier
+includes most top-level SDK surfaces outside the stable core and selected swarm
+interfaces.
+
+Representative modules:
 
 | Module | File | Reason |
 |--------|------|--------|
-| Collaboration | `lib/collaboration.mli` | Swarm collaboration, actively evolving |
-| Memory | `lib/memory.mli` | Memory system under development |
-| Lesson_memory | `lib/lesson_memory.mli` | Lesson extraction, new feature |
-| Event_bus | `lib/event_bus.mli` | Event routing, evolving |
-| Execution_mode | `lib/execution_mode.mli` | Execution modes, evolving |
-| Harness | `lib/harness.mli` | Testing harness, evolving |
-| Policy | `lib/policy.mli` | Policy system, evolving |
-| Swarm_types | `lib_swarm/swarm_types.mli` | Swarm types, evolving |
-| Runner | `lib_swarm/runner.mli` | Swarm runner, evolving |
-| Autonomy_diff_guard | `lib/autonomy_diff_guard.mli` | Autonomy, new feature |
-| Autonomy_exec | `lib/autonomy_exec.mli` | Autonomy, new feature |
-| Cdal_proof | `lib/cdal_proof.mli` | CDAL proof system, new |
-| Metric_contract | `lib/metric_contract.mli` | Metric contracts, new |
-| Proof_store | `lib/proof_store.mli` | Proof storage, new |
-| Risk_class | `lib/risk_class.mli` | Risk classification, new |
-| Risk_contract | `lib/risk_contract.mli` | Risk contracts, new |
-| Agent_checkpoint | `lib/agent/agent_checkpoint.mli` | Agent checkpoint, evolving |
-| Consumer | `lib/consumer.mli` | Consumer bridge, evolving |
+| Collaboration | `lib/collaboration.mli` | Shared collaboration state is still evolving |
+| Memory | `lib/memory.mli` | Memory system is under active development |
+| Policy | `lib/policy.mli` | Rule engine surface is still settling |
+| Proof_store | `lib/proof_store.mli` | CDAL storage API is newly added |
+| Swarm_types | `lib_swarm/swarm_types.mli` | Swarm API remains consumer-facing but not stable |
+| Runner | `lib_swarm/runner.mli` | Orchestration behavior is still being refined |
 
-### Internal (154 modules)
+### Internal (78 modules)
 
-All remaining `.mli` files. Implementation details of the SDK.
-Consumers should use Stable or Evolving modules instead.
+Implementation-detail modules with no compatibility promise. Most entries in
+this tier live under internal subdirectories such as `lib/agent/`,
+`lib/protocol/`, and `lib/llm_provider/`, plus parser/transport helpers that
+external consumers should not depend on directly.
 
 ## Verification
 

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -5,7 +5,7 @@
     library-internal code via [Agent_types.t].
 
     @stability Stable
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Types (re-exported from Agent_types)} *)
 

--- a/lib/agent/agent_checkpoint.mli
+++ b/lib/agent/agent_checkpoint.mli
@@ -4,7 +4,7 @@
     The caller wraps results into [Agent.t].
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Resume} *)
 

--- a/lib/agent/agent_config.mli
+++ b/lib/agent/agent_config.mli
@@ -4,7 +4,7 @@
     and connects MCP servers.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type tool_file_config = {
   name: string;

--- a/lib/agent/agent_handoff.mli
+++ b/lib/agent/agent_handoff.mli
@@ -5,7 +5,7 @@
     dependency on [Agent.t].
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Handoff detection} *)
 

--- a/lib/agent/agent_lifecycle.mli
+++ b/lib/agent/agent_lifecycle.mli
@@ -4,7 +4,7 @@
     [Agent.t] — all functions take explicit parameters.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Lifecycle status} *)
 

--- a/lib/agent/agent_tools.mli
+++ b/lib/agent/agent_tools.mli
@@ -5,7 +5,7 @@
     [Agent]).
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Hook invocation} *)
 

--- a/lib/agent/agent_trace.mli
+++ b/lib/agent/agent_trace.mli
@@ -4,7 +4,7 @@
     tracing.  These functions depend on [Agent_types.t] (mutable state).
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 open Agent_types
 

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -8,7 +8,7 @@
     [Agent_turn -> Agent] is not.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Idle detection} *)
 

--- a/lib/agent/agent_turn_budget.mli
+++ b/lib/agent/agent_turn_budget.mli
@@ -13,7 +13,7 @@
     @since 0.78.0
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type extension_result = {
   granted: int;

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -5,7 +5,7 @@
     accessor functions instead.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Configuration} *)
 

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -4,7 +4,7 @@
     [Agent.create] params. Use [build_safe] for validated construction.
 
     @stability Stable
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type t
 

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -6,7 +6,7 @@
     in dependency-safe order.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Core Modules} *)
 

--- a/lib/agent_typed.mli
+++ b/lib/agent_typed.mli
@@ -15,7 +15,7 @@
       (* Agent_typed.run ~sw completed "again"  -- TYPE ERROR
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
     ]}
 
     @since 0.55.0 *)

--- a/lib/api.mli
+++ b/lib/api.mli
@@ -1,7 +1,7 @@
 (** API dispatch — routes requests to provider-specific backends.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Named cascade} *)
 

--- a/lib/api_anthropic.mli
+++ b/lib/api_anthropic.mli
@@ -1,7 +1,7 @@
 (** Anthropic Claude API request building and response parsing.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Parse Anthropic API response JSON. *)
 val parse_response : Yojson.Safe.t -> Types.api_response

--- a/lib/api_common.mli
+++ b/lib/api_common.mli
@@ -1,5 +1,5 @@
 (** Re-export from {!Llm_provider.Api_common} for backward compatibility.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 include module type of Llm_provider.Api_common

--- a/lib/api_openai.mli
+++ b/lib/api_openai.mli
@@ -3,7 +3,7 @@
     Includes re-exports from {!Llm_provider.Backend_openai}.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 include module type of Llm_provider.Backend_openai
 

--- a/lib/append_instruction.mli
+++ b/lib/append_instruction.mli
@@ -8,7 +8,7 @@
     @since 0.55.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Instruction source — where to read instruction text from. *)
 type instruction_source =

--- a/lib/approval.mli
+++ b/lib/approval.mli
@@ -4,7 +4,7 @@
     If all stages return {!Pass}, the default is {!Hooks.Approve}.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Types} *)
 

--- a/lib/artifact_service.mli
+++ b/lib/artifact_service.mli
@@ -1,7 +1,7 @@
 (** Artifact service.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type descriptor = Runtime.artifact
 

--- a/lib/async_agent.mli
+++ b/lib/async_agent.mli
@@ -10,7 +10,7 @@
     @since 0.55.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Future type} *)
 

--- a/lib/audit.mli
+++ b/lib/audit.mli
@@ -6,7 +6,7 @@
     @since 0.76.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Audit entries} *)
 

--- a/lib/autonomy_diff_guard.mli
+++ b/lib/autonomy_diff_guard.mli
@@ -7,7 +7,7 @@
     @since 0.92.1
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type issue =
   | Empty_patch

--- a/lib/autonomy_exec.mli
+++ b/lib/autonomy_exec.mli
@@ -8,7 +8,7 @@
     @since 0.92.1
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type backend =
   | Direct

--- a/lib/autonomy_trace_analyzer.mli
+++ b/lib/autonomy_trace_analyzer.mli
@@ -6,7 +6,7 @@
     values produced by {!Raw_trace_query.summarize_run}.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {2 Metrics} *)
 

--- a/lib/cdal_proof.mli
+++ b/lib/cdal_proof.mli
@@ -10,7 +10,7 @@
     entirely by middleware hooking into the agent lifecycle.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type result_status =
   | Completed   (** Agent reached EndTurn *)

--- a/lib/checkpoint.mli
+++ b/lib/checkpoint.mli
@@ -5,7 +5,7 @@
     only; file I/O is left to the caller.
 
     @stability Stable
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Version} *)
 

--- a/lib/checkpoint_store.mli
+++ b/lib/checkpoint_store.mli
@@ -4,7 +4,7 @@
     Atomic writes via [.tmp] + rename.
 
     @stability Stable
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Types} *)
 

--- a/lib/checkpoint_validation.mli
+++ b/lib/checkpoint_validation.mli
@@ -7,7 +7,7 @@
     @since 0.78.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 DNA Validation} *)
 

--- a/lib/client.mli
+++ b/lib/client.mli
@@ -4,7 +4,7 @@
     Re-exports types from {!Sdk_client_types} for convenience.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Types (re-exported from Sdk_client_types)} *)
 

--- a/lib/collaboration.mli
+++ b/lib/collaboration.mli
@@ -7,7 +7,7 @@
     mutable component (it is a {!Context.t} reference, documented).
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Phase lifecycle} *)
 

--- a/lib/conformance.mli
+++ b/lib/conformance.mli
@@ -5,7 +5,7 @@
     and resolution.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type check = {
   code: string;

--- a/lib/consumer.mli
+++ b/lib/consumer.mli
@@ -7,7 +7,7 @@
     @since 0.55.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Result of running an agent with telemetry collection. *)
 type run_result = {

--- a/lib/context.mli
+++ b/lib/context.mli
@@ -3,7 +3,7 @@
     serializability.
 
     @stability Stable
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type t
 type scope =

--- a/lib/context/budget_strategy.mli
+++ b/lib/context/budget_strategy.mli
@@ -13,7 +13,7 @@
     @since 0.78.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Compression phase, ordered from lightest to heaviest. *)
 type compression_phase =

--- a/lib/context_intent.mli
+++ b/lib/context_intent.mli
@@ -5,7 +5,7 @@
     Consumer-specific policy can stay outside OAS.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type intent =
   | Conversational

--- a/lib/context_offload.mli
+++ b/lib/context_offload.mli
@@ -8,7 +8,7 @@
     @since 0.62.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Offload configuration. *)
 type config = {

--- a/lib/context_reducer.mli
+++ b/lib/context_reducer.mli
@@ -8,7 +8,7 @@
     ~2/3 token per character for multi-byte (CJK, emoji).
 
     @stability Stable
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 open Types
 

--- a/lib/contract.mli
+++ b/lib/contract.mli
@@ -4,7 +4,7 @@
     and skill bundles into a first-class contract.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Types} *)
 

--- a/lib/contract_runner.mli
+++ b/lib/contract_runner.mli
@@ -6,7 +6,7 @@
     When not called, agent runs proceed with zero overhead.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type run_result = {
   response: (Types.api_response, Error.sdk_error) result;

--- a/lib/cost_tracker.mli
+++ b/lib/cost_tracker.mli
@@ -3,7 +3,7 @@
     @since 0.62.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Structured cost report. *)
 type cost_report = {

--- a/lib/defaults.mli
+++ b/lib/defaults.mli
@@ -4,7 +4,7 @@
     corresponding [OAS_*] environment variable is unset or empty.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Read an environment variable, falling back to [default]
     if the variable is unset or empty. *)

--- a/lib/direct_evidence.mli
+++ b/lib/direct_evidence.mli
@@ -4,7 +4,7 @@
     reports from a live {!Agent.t} and its {!Raw_trace.t}.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type options = {
   session_root: string option;

--- a/lib/durable.mli
+++ b/lib/durable.mli
@@ -11,7 +11,7 @@
     @since 0.76.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Journal} *)
 

--- a/lib/durable_event.mli
+++ b/lib/durable_event.mli
@@ -16,7 +16,7 @@
     @since 0.89.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Event types} *)
 

--- a/lib/error.mli
+++ b/lib/error.mli
@@ -5,7 +5,7 @@
     and [is_retryable] for automated retry decisions.
 
     @stability Stable
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Domain error types} *)
 

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -8,7 +8,7 @@
       (* Provider function: only produces provider errors
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
       val create_message : ... -> (api_response, [> provider_error]) result
 
       (* Callers only handle relevant variants *)

--- a/lib/eval.mli
+++ b/lib/eval.mli
@@ -4,7 +4,7 @@
     thresholds for regression detection.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Metric value} *)
 

--- a/lib/eval_baseline.mli
+++ b/lib/eval_baseline.mli
@@ -3,7 +3,7 @@
     @since 0.68.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type baseline = {
   run_metrics: Eval.run_metrics;

--- a/lib/eval_collector.mli
+++ b/lib/eval_collector.mli
@@ -10,7 +10,7 @@
       (* ... run agent ...
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
       let metrics = Eval_collector.finalize collector
     ]} *)
 

--- a/lib/eval_report.mli
+++ b/lib/eval_report.mli
@@ -3,7 +3,7 @@
     @since 0.68.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type t = {
   agent_name: string;

--- a/lib/eval_stats.mli
+++ b/lib/eval_stats.mli
@@ -6,7 +6,7 @@
     @since 0.79.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Summary statistics for a sample. *)
 type stats = {

--- a/lib/event_bus.mli
+++ b/lib/event_bus.mli
@@ -5,7 +5,7 @@
     internal to [t] -- no globals.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {2 Event types} *)
 

--- a/lib/event_forward.mli
+++ b/lib/event_forward.mli
@@ -7,7 +7,7 @@
     Runs in a separate Eio fiber (non-blocking to agent).
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Payload} *)
 

--- a/lib/execution_mode.mli
+++ b/lib/execution_mode.mli
@@ -4,7 +4,7 @@
     Ordering: [Diagnose < Draft < Execute].
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type t =
   | Diagnose  (** Read-only analysis, no mutations *)

--- a/lib/fs_result.mli
+++ b/lib/fs_result.mli
@@ -7,7 +7,7 @@
     @raises only truly non-recoverable exceptions
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Core I/O} *)
 

--- a/lib/guardrails.mli
+++ b/lib/guardrails.mli
@@ -1,7 +1,7 @@
 (** Guardrails for tool filtering and execution limits.
 
     @stability Stable
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Tool filter: controls which tools are visible to the LLM *)
 type tool_filter =

--- a/lib/guardrails_async.mli
+++ b/lib/guardrails_async.mli
@@ -6,7 +6,7 @@
     @since 0.67.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Input validator: checks messages before the LLM call. *)
 type input_validator = {

--- a/lib/handoff.mli
+++ b/lib/handoff.mli
@@ -8,7 +8,7 @@
     defines types and builders.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Types} *)
 

--- a/lib/harness.mli
+++ b/lib/harness.mli
@@ -5,7 +5,7 @@
     modes. Compose layers via {!Swiss_cheese} for multi-layer checks.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Common types} *)
 

--- a/lib/harness_case.mli
+++ b/lib/harness_case.mli
@@ -1,7 +1,7 @@
 (** First-class harness cases for fixture and trace-derived evals.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type kind =
   | Fixture

--- a/lib/harness_dataset.mli
+++ b/lib/harness_dataset.mli
@@ -1,7 +1,7 @@
 (** JSONL-backed harness datasets.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type t = Harness_case.t list
 

--- a/lib/harness_report.mli
+++ b/lib/harness_report.mli
@@ -1,7 +1,7 @@
 (** Structured reports for harness runs.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type case_status =
   | Pass

--- a/lib/harness_runner.mli
+++ b/lib/harness_runner.mli
@@ -1,7 +1,7 @@
 (** Execute harness cases against fresh agents and emit structured reports.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 val grade_case :
   agent_name:string ->

--- a/lib/hooks.mli
+++ b/lib/hooks.mli
@@ -1,7 +1,7 @@
 (** Lifecycle hooks for agent execution.
 
     @stability Stable
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Per-turn adjustable parameters.
     Returned via [AdjustParams] from [BeforeTurnParams] hook. *)

--- a/lib/internal_client.mli
+++ b/lib/internal_client.mli
@@ -4,7 +4,7 @@
     and disconnects. Used by {!Query.query}.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Execute a single query against the runtime.
     Connects, sends the prompt, finalizes, and returns all

--- a/lib/internal_message_parser.mli
+++ b/lib/internal_message_parser.mli
@@ -3,7 +3,7 @@
     Converts runtime types into {!Sdk_client_types.message} values.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 val status : Runtime.session -> Sdk_client_types.message
 val events : Runtime.event list -> Sdk_client_types.message

--- a/lib/internal_query_engine.mli
+++ b/lib/internal_query_engine.mli
@@ -4,7 +4,7 @@
     and permission/hook callbacks. Used by {!Client} and {!Internal_client}.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type t = {
   runtime: Runtime_client.t;

--- a/lib/judge/judge.mli
+++ b/lib/judge/judge.mli
@@ -9,7 +9,7 @@
     @since 0.78.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Risk classification derived from score. *)
 type risk_level = Low | Medium | High | Critical

--- a/lib/lesson_memory.mli
+++ b/lib/lesson_memory.mli
@@ -6,7 +6,7 @@
     @since 0.92.1
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type failure_record = {
   pattern: string;

--- a/lib/llm_provider/api_common.mli
+++ b/lib/llm_provider/api_common.mli
@@ -1,7 +1,7 @@
 (** Shared helpers, constants, and content-block serialization.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 val default_base_url : string
 val api_version : string

--- a/lib/llm_provider/backend_anthropic.mli
+++ b/lib/llm_provider/backend_anthropic.mli
@@ -3,7 +3,7 @@
     Pure functions operating on {!Llm_provider.Types}.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 val parse_response : Yojson.Safe.t -> Types.api_response
 

--- a/lib/llm_provider/backend_gemini.mli
+++ b/lib/llm_provider/backend_gemini.mli
@@ -9,7 +9,7 @@
     @since 0.72.0
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 exception Gemini_api_error of string
 

--- a/lib/llm_provider/backend_glm.mli
+++ b/lib/llm_provider/backend_glm.mli
@@ -13,7 +13,7 @@
     @since 0.83.0
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 open Types
 

--- a/lib/llm_provider/backend_openai.mli
+++ b/lib/llm_provider/backend_openai.mli
@@ -3,7 +3,7 @@
     Pure functions operating on {!Llm_provider.Types}.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 val tool_calls_to_openai_json : Types.content_block list -> Yojson.Safe.t list
 val openai_content_parts_of_blocks : Types.content_block list -> Yojson.Safe.t list

--- a/lib/llm_provider/backend_openai_parse.mli
+++ b/lib/llm_provider/backend_openai_parse.mli
@@ -3,7 +3,7 @@
     @since 0.92.0 extracted from Backend_openai
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 val strip_json_markdown_fences : string -> string
 val usage_of_openai_json : Yojson.Safe.t -> Types.api_usage option

--- a/lib/llm_provider/backend_openai_serialize.mli
+++ b/lib/llm_provider/backend_openai_serialize.mli
@@ -3,7 +3,7 @@
     @since 0.92.0 extracted from Backend_openai
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 val tool_calls_to_openai_json : Types.content_block list -> Yojson.Safe.t list
 val openai_content_parts_of_blocks : Types.content_block list -> Yojson.Safe.t list

--- a/lib/llm_provider/cache.mli
+++ b/lib/llm_provider/cache.mli
@@ -6,7 +6,7 @@
     @since 0.54.0
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Cache backend interface. Implementations must be fiber-safe. *)
 type t = {

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -4,7 +4,7 @@
     @since 0.72.0 — added numeric limits, parallel tool calls, thinking split
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type capabilities = {
   (* Numeric limits *)

--- a/lib/llm_provider/capability_filter.mli
+++ b/lib/llm_provider/capability_filter.mli
@@ -7,7 +7,7 @@
     @since 0.72.0 — added limit checks, thinking, structured output
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {2 Feature predicates} *)
 

--- a/lib/llm_provider/cascade_config.mli
+++ b/lib/llm_provider/cascade_config.mli
@@ -11,7 +11,7 @@
     @since 0.59.0
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Model Alias Resolution} *)
 

--- a/lib/llm_provider/cascade_config_loader.mli
+++ b/lib/llm_provider/cascade_config_loader.mli
@@ -4,7 +4,7 @@
     @since 0.92.0 extracted from Cascade_config
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Load and cache a raw JSON config file.
     Cached with mtime-based hot-reload. *)

--- a/lib/llm_provider/cascade_model_resolve.mli
+++ b/lib/llm_provider/cascade_model_resolve.mli
@@ -5,7 +5,7 @@
     @since 0.92.0 extracted from Cascade_config
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Resolve a GLM model alias to the concrete API model ID.
     - ["auto"] -> env var [ZAI_DEFAULT_MODEL] or ["glm-5"]

--- a/lib/llm_provider/cascade_throttle.mli
+++ b/lib/llm_provider/cascade_throttle.mli
@@ -7,7 +7,7 @@
     @since 0.92.0 extracted from Cascade_config
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Update the throttle table from discovery probe results.
     Creates entries for healthy endpoints with slot data.

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -9,7 +9,7 @@
     @since 0.78.0  Transport abstraction
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Gemini URL Construction} *)
 

--- a/lib/llm_provider/complete_stream_acc.mli
+++ b/lib/llm_provider/complete_stream_acc.mli
@@ -5,7 +5,7 @@
     @since 0.79.0
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Mutable accumulator that collects SSE stream events into content blocks.
     Use {!create_stream_acc} to create, {!accumulate_event} to feed events,

--- a/lib/llm_provider/discovery.mli
+++ b/lib/llm_provider/discovery.mli
@@ -7,7 +7,7 @@
     @since 0.53.0
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Model info from /v1/models *)
 type model_info = {

--- a/lib/llm_provider/error.mli
+++ b/lib/llm_provider/error.mli
@@ -3,7 +3,7 @@
     Independent of the OAS [Error.sdk_error] hierarchy.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type provider_error =
   | MissingApiKey of { var_name: string }

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -5,7 +5,7 @@
     so callers do not need [try/with] around HTTP operations.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Transport-level error. *)
 type http_error =

--- a/lib/llm_provider/llm_transport.mli
+++ b/lib/llm_provider/llm_transport.mli
@@ -6,7 +6,7 @@
     @since 0.78.0
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** A completion request: everything needed to produce a response. *)
 type completion_request = {

--- a/lib/llm_provider/metrics.mli
+++ b/lib/llm_provider/metrics.mli
@@ -6,7 +6,7 @@
     @since 0.54.0
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Metrics callback interface. All callbacks are optional — provide [noop]
     as a default that does nothing. *)

--- a/lib/llm_provider/pricing.mli
+++ b/lib/llm_provider/pricing.mli
@@ -1,7 +1,7 @@
 (** Per-model cost estimation.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type pricing = {
   input_per_million: float;

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -6,7 +6,7 @@
     @since 0.46.0
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Provider kind determines request/response wire format. *)
 type provider_kind =

--- a/lib/llm_provider/provider_registry.mli
+++ b/lib/llm_provider/provider_registry.mli
@@ -7,7 +7,7 @@
     @since 0.69.0
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Provider defaults: how to connect to a provider. *)
 type provider_defaults = {

--- a/lib/llm_provider/provider_throttle.mli
+++ b/lib/llm_provider/provider_throttle.mli
@@ -6,7 +6,7 @@
     @since 0.84.0
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type t
 

--- a/lib/llm_provider/retry.mli
+++ b/lib/llm_provider/retry.mli
@@ -1,7 +1,7 @@
 (** Structured API errors and retry logic with exponential backoff + jitter.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Error types} *)
 

--- a/lib/llm_provider/sse_parser.mli
+++ b/lib/llm_provider/sse_parser.mli
@@ -4,7 +4,7 @@
     blank line = dispatch.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type raw_sse_event = {
   event_type: string option;

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -3,7 +3,7 @@
     Pure functions — no I/O or agent_sdk coupling.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 open Types
 

--- a/lib/llm_provider/transport_claude_code.mli
+++ b/lib/llm_provider/transport_claude_code.mli
@@ -8,7 +8,7 @@
     @since 0.78.0
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Configuration for the Claude Code subprocess. *)
 type config = {

--- a/lib/llm_provider/transport_openai_compat.mli
+++ b/lib/llm_provider/transport_openai_compat.mli
@@ -10,7 +10,7 @@
     @since 0.86.0
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Configuration for an OpenAI-compatible endpoint. *)
 type config = {

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -6,7 +6,7 @@
     @since 0.42.0
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Message Types} *)
 

--- a/lib/llm_provider/utf8_sanitize.mli
+++ b/lib/llm_provider/utf8_sanitize.mli
@@ -11,6 +11,6 @@
     input is already valid.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 val sanitize : string -> string

--- a/lib/log.mli
+++ b/lib/log.mli
@@ -8,7 +8,7 @@
     - Disabled levels skip record allocation entirely.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {2 Level} *)
 

--- a/lib/memory.mli
+++ b/lib/memory.mli
@@ -13,7 +13,7 @@
     @since 0.75.0 (5-tier: Episodic + Procedural)
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Tiers} *)
 

--- a/lib/memory_access.mli
+++ b/lib/memory_access.mli
@@ -17,7 +17,7 @@
       (* alice can write
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
       Memory_access.store acl ~agent:"alice" ~tier:Working "shared_goal" value;  (* Ok *)
       (* bob can only read *)
       Memory_access.store acl ~agent:"bob" ~tier:Working "shared_goal" value;  (* Error *)

--- a/lib/memory_episodic.mli
+++ b/lib/memory_episodic.mli
@@ -4,7 +4,7 @@
     @since 0.92.0 extracted from Memory
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type outcome =
   | Success of string

--- a/lib/memory_procedural.mli
+++ b/lib/memory_procedural.mli
@@ -4,7 +4,7 @@
     @since 0.92.0 extracted from Memory
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type procedure = {
   id: string;

--- a/lib/memory_tools.mli
+++ b/lib/memory_tools.mli
@@ -13,7 +13,7 @@
     spoof an agent identity through tool parameters.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Plain memory factories} *)
 

--- a/lib/memory_tools_parse.mli
+++ b/lib/memory_tools_parse.mli
@@ -3,7 +3,7 @@
     @since 0.92.0 extracted from Memory_tools
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 val tool_error : string -> ('a, Types.tool_error) result
 

--- a/lib/metric_contract.mli
+++ b/lib/metric_contract.mli
@@ -3,7 +3,7 @@
     @since 0.92.1
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type metric = {
   name: string;

--- a/lib/metrics.mli
+++ b/lib/metrics.mli
@@ -11,7 +11,7 @@
       Metrics.to_otlp_json m  (* export all collected metrics
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
     ]} *)
 
 (** {1 Types} *)

--- a/lib/mode_enforcer.mli
+++ b/lib/mode_enforcer.mli
@@ -9,7 +9,7 @@
     - External-effect: bash (with input analysis), mcp__*, unknown tools
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type mutation_class =
   | Read_only

--- a/lib/mode_resolver.mli
+++ b/lib/mode_resolver.mli
@@ -5,7 +5,7 @@
     + [capabilities]. Never upgrades beyond requested mode.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type decision = {
   effective_mode: Execution_mode.t;

--- a/lib/model_registry.mli
+++ b/lib/model_registry.mli
@@ -4,7 +4,7 @@
     New models are added here only.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** The default model ID, overridable via OAS_DEFAULT_MODEL env var. *)
 val default_model_id : string

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -5,7 +5,7 @@
     FanOut, Pipeline); the LLM does not participate in routing.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {2 Core types} *)
 

--- a/lib/otel_tracer.mli
+++ b/lib/otel_tracer.mli
@@ -5,7 +5,7 @@
     and Eio.Mutex backends.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Types} *)
 

--- a/lib/pipeline/pipeline.mli
+++ b/lib/pipeline/pipeline.mli
@@ -7,7 +7,7 @@
     replaces the monolithic [run_turn_core] in agent.ml.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type api_strategy =
   | Sync

--- a/lib/plan.mli
+++ b/lib/plan.mli
@@ -10,7 +10,7 @@
     @since 0.77.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Step status} *)
 

--- a/lib/policy.mli
+++ b/lib/policy.mli
@@ -9,7 +9,7 @@
     @since 0.76.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Decision points} *)
 

--- a/lib/progressive_tools.mli
+++ b/lib/progressive_tools.mli
@@ -10,7 +10,7 @@
     @since 0.43.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Strategy} *)
 

--- a/lib/proof_capture.mli
+++ b/lib/proof_capture.mli
@@ -7,7 +7,7 @@
     Call [finalize] after agent run to write manifest and return proof.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type state
 (** Opaque mutable accumulator. One per agent run, not shared. *)

--- a/lib/proof_store.mli
+++ b/lib/proof_store.mli
@@ -5,7 +5,7 @@
     and evidence artifacts under [{root}/proofs/{run_id}/].
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type config = {
   root: string;  (** Default: [~/.oas] *)

--- a/lib/protocol/a2a_client.mli
+++ b/lib/protocol/a2a_client.mli
@@ -7,7 +7,7 @@
     @since 0.55.0
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** A discovered remote agent endpoint. *)
 type remote_agent = {

--- a/lib/protocol/a2a_server.mli
+++ b/lib/protocol/a2a_server.mli
@@ -4,7 +4,7 @@
     task lifecycle via callback functions.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type config = {
   port: int;

--- a/lib/protocol/a2a_task.mli
+++ b/lib/protocol/a2a_task.mli
@@ -5,7 +5,7 @@
     Illegal transitions return [Error].
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 State machine} *)
 

--- a/lib/protocol/a2a_task_store.mli
+++ b/lib/protocol/a2a_task_store.mli
@@ -4,7 +4,7 @@
     Atomic writes via .tmp + rename. In-memory Hashtbl cache for fast lookups.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type t
 

--- a/lib/protocol/agent_card.mli
+++ b/lib/protocol/agent_card.mli
@@ -3,7 +3,7 @@
     Inspired by the A2A (Agent-to-Agent) protocol.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Capability} *)
 

--- a/lib/protocol/agent_registry.mli
+++ b/lib/protocol/agent_registry.mli
@@ -4,7 +4,7 @@
     capability-based lookup for orchestration routing.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type agent_entry =
   | Local of { agent: Agent.t; card: Agent_card.agent_card }

--- a/lib/protocol/mcp.mli
+++ b/lib/protocol/mcp.mli
@@ -5,7 +5,7 @@
     and prompt fetching.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Re-exported schema types} *)
 

--- a/lib/protocol/mcp_http.mli
+++ b/lib/protocol/mcp_http.mli
@@ -1,7 +1,7 @@
 (** Thin OAS facade over {!Mcp_protocol_http.Http_client}.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type config = {
   base_url: string;

--- a/lib/protocol/mcp_schema.mli
+++ b/lib/protocol/mcp_schema.mli
@@ -1,7 +1,7 @@
 (** MCP schema bridge — converts between MCP SDK types and OAS types.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 module Sdk_types = Mcp_protocol.Mcp_types
 

--- a/lib/protocol/mcp_session.mli
+++ b/lib/protocol/mcp_session.mli
@@ -4,7 +4,7 @@
     for checkpoint/resume cycles.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 open Types
 

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -1,7 +1,7 @@
 (** LLM Provider abstraction.
 
     @stability Stable
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type provider =
   | Local of { base_url: string }

--- a/lib/provider_bridge.mli
+++ b/lib/provider_bridge.mli
@@ -7,7 +7,7 @@
     @since 0.53.0
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Convert a single legacy provider config.
     Calls {!Provider.resolve} to obtain base_url, api_key, and headers.

--- a/lib/provider_intf.mli
+++ b/lib/provider_intf.mli
@@ -4,7 +4,7 @@
     for compile-time capability checking.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 module type PROVIDER = sig
   type t

--- a/lib/provider_mock.mli
+++ b/lib/provider_mock.mli
@@ -4,7 +4,7 @@
     list is exhausted the mock cycles back to the beginning.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Types} *)
 

--- a/lib/query.mli
+++ b/lib/query.mli
@@ -3,7 +3,7 @@
     Alias for {!Internal_client.process_query}.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 val query :
   sw:Eio.Switch.t ->

--- a/lib/raw_trace.mli
+++ b/lib/raw_trace.mli
@@ -1,7 +1,7 @@
 (** Raw trace.
 
     @stability Stable
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type record_type =
   | Run_started

--- a/lib/raw_trace_query.mli
+++ b/lib/raw_trace_query.mli
@@ -5,7 +5,7 @@
     written by {!Raw_trace} and return structured results.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Run Discovery} *)
 

--- a/lib/reflexion.mli
+++ b/lib/reflexion.mli
@@ -12,7 +12,7 @@
     @since 0.89.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Verdict} *)
 

--- a/lib/retry.mli
+++ b/lib/retry.mli
@@ -1,6 +1,6 @@
 (** Re-export from {!Llm_provider.Retry} for backward compatibility.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 include module type of Llm_provider.Retry

--- a/lib/risk_class.mli
+++ b/lib/risk_class.mli
@@ -4,7 +4,7 @@
     Three-axis model: blast_radius x irreversibility x recovery_cost.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type t =
   | Low       (** Small radius, easy rollback, low recovery cost *)

--- a/lib/risk_contract.mli
+++ b/lib/risk_contract.mli
@@ -7,7 +7,7 @@
     - [eval_criteria]: opaque passthrough carried to the proof bundle
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Runtime constraints enforced by OAS. *)
 type runtime_constraints = {

--- a/lib/runtime.mli
+++ b/lib/runtime.mli
@@ -11,7 +11,7 @@
     @since 0.50.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Session State} *)
 

--- a/lib/runtime_client.mli
+++ b/lib/runtime_client.mli
@@ -1,7 +1,7 @@
 (** Client for the runtime protocol over stdio transport.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Options} *)
 

--- a/lib/runtime_evidence.mli
+++ b/lib/runtime_evidence.mli
@@ -4,7 +4,7 @@
     collects file-level evidence with MD5 checksums.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type telemetry_step = {
   seq: int;

--- a/lib/runtime_projection.mli
+++ b/lib/runtime_projection.mli
@@ -8,7 +8,7 @@
     and {!Collaboration.t} (12 fields) for the ongoing migration.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Session lifecycle} *)
 

--- a/lib/runtime_query.mli
+++ b/lib/runtime_query.mli
@@ -1,7 +1,7 @@
 (** Convenience wrapper for one-shot runtime protocol queries.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 val query :
   sw:Eio.Switch.t ->

--- a/lib/runtime_server.mli
+++ b/lib/runtime_server.mli
@@ -5,7 +5,7 @@
     {!Runtime_server_worker} for request handling.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 open Runtime
 open Runtime_server_types

--- a/lib/runtime_server_resolve.mli
+++ b/lib/runtime_server_resolve.mli
@@ -1,7 +1,7 @@
 (** Provider resolution for the runtime server.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type execution_resolution = {
   selected_provider: string;

--- a/lib/runtime_server_types.mli
+++ b/lib/runtime_server_types.mli
@@ -1,7 +1,7 @@
 (** Server-side state and helpers for the runtime server.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type state = {
   net: [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t;

--- a/lib/runtime_server_worker.mli
+++ b/lib/runtime_server_worker.mli
@@ -1,7 +1,7 @@
 (** Runtime server worker — agent execution and event persistence.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 open Runtime_server_types
 open Runtime_server_resolve

--- a/lib/runtime_store.mli
+++ b/lib/runtime_store.mli
@@ -4,7 +4,7 @@
     sessions, events, artifacts, reports, and proofs.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Store handle wrapping a root directory. *)
 type t = { root: string }

--- a/lib/sandbox_runner.mli
+++ b/lib/sandbox_runner.mli
@@ -8,7 +8,7 @@
     fresh-agent harness execution use {!Harness_runner}.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Configuration} *)
 

--- a/lib/sdk_client_types.mli
+++ b/lib/sdk_client_types.mli
@@ -4,7 +4,7 @@
     used by {!Client} and {!Internal_query_engine}.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Permission Mode} *)
 

--- a/lib/sdk_version.mli
+++ b/lib/sdk_version.mli
@@ -1,7 +1,7 @@
 (** Single source of truth for the SDK version string.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 val version : string
 val sdk_name : string

--- a/lib/session.mli
+++ b/lib/session.mli
@@ -5,7 +5,7 @@
     resume lineage.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Session type} *)
 

--- a/lib/sessions.mli
+++ b/lib/sessions.mli
@@ -5,7 +5,7 @@
     This module is the single entry point for session access.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 include module type of Sessions_types
 include module type of Sessions_store

--- a/lib/sessions_proof.mli
+++ b/lib/sessions_proof.mli
@@ -5,7 +5,7 @@
     the complete {!Sessions_types.proof_bundle}.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 open Sessions_types
 

--- a/lib/sessions_store.mli
+++ b/lib/sessions_store.mli
@@ -4,7 +4,7 @@
     with the typed Sessions domain.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 open Sessions_types
 

--- a/lib/sessions_store_parsers.mli
+++ b/lib/sessions_store_parsers.mli
@@ -4,7 +4,7 @@
     {!Sessions_types} records.  No file I/O or store access.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Generic JSON parsing} *)
 

--- a/lib/sessions_types.mli
+++ b/lib/sessions_types.mli
@@ -3,7 +3,7 @@
     All types carry [@@deriving yojson, show] for serialisation.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type trace_capability =
   | Raw [@name "raw"]

--- a/lib/skill.mli
+++ b/lib/skill.mli
@@ -4,7 +4,7 @@
     and extracts the body for prompt composition.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Types} *)
 

--- a/lib/skill_registry.mli
+++ b/lib/skill_registry.mli
@@ -8,7 +8,7 @@
     The registry is always owned by a single {!Agent.t} instance.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Types} *)
 

--- a/lib/sse_parser.mli
+++ b/lib/sse_parser.mli
@@ -1,6 +1,6 @@
 (** Re-export from {!Llm_provider.Sse_parser} for backward compatibility.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 include module type of Llm_provider.Sse_parser

--- a/lib/streaming.mli
+++ b/lib/streaming.mli
@@ -6,7 +6,7 @@
     due to agent_state/Provider/Error coupling.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Re-exported Pure Functions} *)
 

--- a/lib/structured.mli
+++ b/lib/structured.mli
@@ -4,7 +4,7 @@
     then extracts the input JSON as structured output.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 open Types
 

--- a/lib/subagent.mli
+++ b/lib/subagent.mli
@@ -4,7 +4,7 @@
     them into {!Handoff.handoff_target} values for the agent runner.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Types} *)
 

--- a/lib/succession.mli
+++ b/lib/succession.mli
@@ -10,7 +10,7 @@
     @since 0.79.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Metrics} *)
 

--- a/lib/tool.mli
+++ b/lib/tool.mli
@@ -1,7 +1,7 @@
 (** Tool definition and execution.
 
     @stability Stable
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type tool_handler = Yojson.Safe.t -> Types.tool_result
 type context_tool_handler = Context.t -> Yojson.Safe.t -> Types.tool_result

--- a/lib/tool_index.mli
+++ b/lib/tool_index.mli
@@ -10,7 +10,7 @@
     @since 0.89.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Index} *)
 

--- a/lib/tool_set.mli
+++ b/lib/tool_set.mli
@@ -11,7 +11,7 @@
     - [merge s s = s]                               (idempotence)
 
     @stability Stable
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type t
 

--- a/lib/trace_eval.mli
+++ b/lib/trace_eval.mli
@@ -4,7 +4,7 @@
     tracer.  Used by {!Eval} to attach trace summaries to run metrics.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Types} *)
 

--- a/lib/tracing.mli
+++ b/lib/tracing.mli
@@ -7,7 +7,7 @@
     Uses first-class modules for runtime tracer selection.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Types} *)
 

--- a/lib/trajectory.mli
+++ b/lib/trajectory.mli
@@ -4,7 +4,7 @@
     inspired by Deep Agents Harbor evaluation framework.
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Tool Call} *)
 

--- a/lib/transport.mli
+++ b/lib/transport.mli
@@ -6,7 +6,7 @@
     All mutable state is protected by [Eio.Mutex].
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** {1 Configuration} *)
 

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -4,7 +4,7 @@
     {!Llm_provider.Types}. Agent-specific types remain local.
 
     @stability Stable
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (* ================================================================ *)
 (* Re-export all LLM provider types                                  *)

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -4,7 +4,7 @@
     duplication.
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 (** Return [a] if [Some], otherwise [b]. *)
 val first_some : 'a option -> 'a option -> 'a option

--- a/lib/verified_output.mli
+++ b/lib/verified_output.mli
@@ -15,7 +15,7 @@
       (* Producer creates unverified output
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
       let raw = Verified_output.of_response ~producer:"alice" response in
 
       (* Verifier checks and marks as verified *)

--- a/lib_swarm/runner.mli
+++ b/lib_swarm/runner.mli
@@ -17,7 +17,7 @@
     @since 0.42.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 open Agent_sdk
 

--- a/lib_swarm/selection.mli
+++ b/lib_swarm/selection.mli
@@ -3,7 +3,7 @@
     @since 0.60.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 type 'a strategy =
   | RoundRobin

--- a/lib_swarm/swarm_channel.mli
+++ b/lib_swarm/swarm_channel.mli
@@ -10,7 +10,7 @@
     @since 0.91.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 open Agent_sdk
 

--- a/lib_swarm/swarm_checkpoint.mli
+++ b/lib_swarm/swarm_checkpoint.mli
@@ -6,7 +6,7 @@
     @since 0.43.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 open Agent_sdk
 

--- a/lib_swarm/swarm_types.mli
+++ b/lib_swarm/swarm_types.mli
@@ -5,7 +5,7 @@
     @since 0.42.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 open Agent_sdk
 

--- a/lib_swarm/test_helpers.mli
+++ b/lib_swarm/test_helpers.mli
@@ -6,7 +6,7 @@
     @since 0.43.0
 
     @stability Internal
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 open Agent_sdk
 

--- a/lib_swarm/traced_swarm.mli
+++ b/lib_swarm/traced_swarm.mli
@@ -8,7 +8,7 @@
     @since 0.51.0
 
     @stability Evolving
-    @since 0.93.0 *)
+    @since 0.93.1 *)
 
 open Agent_sdk
 

--- a/scripts/annotate_stability.py
+++ b/scripts/annotate_stability.py
@@ -16,7 +16,7 @@ import sys
 from pathlib import Path
 
 VALID_TIERS = {"Stable", "Evolving", "Internal"}
-SINCE_VERSION = "0.93.0"
+SINCE_VERSION = "0.93.1"
 
 
 def add_annotation(filepath: Path, tier: str) -> bool:


### PR DESCRIPTION
## Summary

- 186개 `.mli` 파일에 `@stability` annotation 추가 (Stable 14 / Evolving 94 / Internal 78)
- `docs/api-stability.md` — 3-tier 정의, 분류 기준, 변경 정책 문서화
- `scripts/annotate_stability.py` — 향후 annotation 자동화 스크립트
- MASC 실제 import 32개 모듈 기반으로 분류 (추정이 아닌 `rg` 검증)

## 분류 기준

| Tier | 기준 | Count |
|------|------|-------|
| **Stable** | MASC 핵심 의존: Types, Error, Agent, Builder, Tool, Provider, Hooks 등 | 14 |
| **Evolving** | 외부 API surface이지만 아직 안정화되지 않은 모듈 | 94 |
| **Internal** | llm_provider/*, protocol/*, agent/* sub-modules, internal helpers | 78 |

## Test plan

- [x] `dune build --root .` 통과
- [x] 33개 swarm 테스트 전부 통과
- [x] annotation 수 검증: `186 == 14 + 94 + 78`

Refs #455
