### PR TITLE
chore(ci): move GitHub Actions off Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v3
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload harness eval artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: harness-eval-${{ matrix.ocaml-compiler }}
           path: _build/evals
@@ -109,7 +109,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v3
@@ -147,7 +147,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Verify version strings match
         run: |


### PR DESCRIPTION
## Summary
- upgrade `actions/checkout` from `v4` to `v5` across CI jobs
- upgrade `actions/upload-artifact` from `v4` to `v6` for harness eval uploads
- leave `ocaml/setup-ocaml@v3` unchanged because current CI warnings did not implicate it

## Why
Current CI emits GitHub Actions deprecation warnings because some JavaScript actions still run on Node 20 by default. GitHub says runners begin defaulting to Node 24 on June 2, 2026.

## Verification
- `ruby -e require "yaml"; YAML.load_file(ARGV[0]) .github/workflows/ci.yml`\n\n## References\n- Closes #460\n- GitHub changelog: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/\n- Checkout marketplace: https://github.com/marketplace/actions/checkout