### PR TITLE
fix(contract_runner): sync execution state back to original agent

### DIFF
--- a/lib/contract_runner.ml
+++ b/lib/contract_runner.ml
@@ -87,6 +87,10 @@ let run ~sw ?clock ?(store = Proof_store.default_config)
         ~context ?named_cascade:(Agent.named_cascade agent)
         ~options:new_opts () in
     let response = Agent.run ~sw ?clock new_agent prompt in
+    (* Sync execution state back to the original agent so that
+       downstream checkpoint capture sees the post-run messages,
+       turn_count, and usage — not the pre-run empty state. *)
+    Agent.set_state agent (Agent.state new_agent);
     let result_status = map_result_status response in
     let proof = Proof_capture.finalize capture_state ~result_status in
     { response; proof }


### PR DESCRIPTION
## Summary

- `Contract_runner.run`이 새 agent를 생성하여 실행하지만, 실행 후 state(messages, turn_count, usage)를 원래 agent에 반영하지 않았다.
- 결과: 다운스트림 `oas_worker.build_checkpoint`가 원래 agent의 pre-run 빈 state를 캡처하여, checkpoint에 현재 턴의 user 메시지 1개만 저장되고 turn_count=0이 됨.
- MASC keeper가 매 턴 이전 대화를 잃어버리는 직접 원인.

## Root Cause Trace

```
oas_worker.run:
  agent = build(config)              # state.messages = []
  Contract_runner.run(agent, goal)
    new_agent = Agent.create(...)     # fresh agent
    Agent.run(new_agent, goal)        # new_agent.state updated
    return {response, proof}          # new_agent discarded ← BUG
  build_checkpoint(agent)             # agent.state still empty
```

## Fix

```ocaml
Agent.set_state agent (Agent.state new_agent);
```

1줄. Agent.run 직후, proof finalize 전에 원래 agent의 state를 new_agent의 post-run state로 교체.

## Evidence

masc-mcp의 deterministic-purist keeper (37턴, trace-1774685090914-05e0c):

```
# 모든 checkpoint에 messages=1, turn_count=0
$ python3 -c "import json; d=json.load(open('oas-keeper_turn-*.json')); print(len(d['messages']), d['turn_count'])"
1 0

# history.jsonl에는 전체 대화 보존
$ wc -l history.jsonl
86
```

## Test plan

- [x] 기존 47개 테스트 통과 (0 regression)
- [ ] MASC keeper 2턴 대화 후 checkpoint messages 누적 확인
- [ ] 30턴 이상 대화 후 checkpoint messages = 30 (keep_last_30 reducer)

Refs: jeong-sik/masc-mcp#3630, jeong-sik/masc-mcp#3632

Generated with [Claude Code](https://claude.com/claude-code)