### PR TITLE
refactor(cascade): deduplicate endpoint collection in filter_healthy

### DIFF
--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -206,14 +206,6 @@ let filter_healthy_internal ~sw ~net (providers : Provider_config.t list) =
   in
   if local_providers = [] then
     (providers, [])
-  else if cloud_providers = [] then
-    let endpoints =
-      local_providers
-      |> List.map (fun (cfg : Provider_config.t) -> cfg.base_url)
-      |> List.sort_uniq String.compare
-    in
-    let statuses = Discovery.discover ~sw ~net ~endpoints in
-    (providers, statuses)
   else
     let endpoints =
       local_providers
@@ -221,13 +213,16 @@ let filter_healthy_internal ~sw ~net (providers : Provider_config.t list) =
       |> List.sort_uniq String.compare
     in
     let statuses = Discovery.discover ~sw ~net ~endpoints in
-    let any_healthy =
-      List.exists (fun (s : Discovery.endpoint_status) -> s.healthy) statuses
-    in
-    if any_healthy then
+    if cloud_providers = [] then
       (providers, statuses)
     else
-      (cloud_providers, [])
+      let any_healthy =
+        List.exists (fun (s : Discovery.endpoint_status) -> s.healthy) statuses
+      in
+      if any_healthy then
+        (providers, statuses)
+      else
+        (cloud_providers, [])
 
 let filter_healthy ~sw ~net providers =
   fst (filter_healthy_internal ~sw ~net providers)


### PR DESCRIPTION
## Summary
- `filter_healthy_internal`에서 endpoint 수집 + `Discovery.discover` 호출이 두 분기에 복사-붙여넣기로 중복
- 제어 흐름을 재구조화하여 공통 코드를 1번만 실행하도록 변경
- 논리적으로 동등 (nesting 순서만 변경)

## Before
```
if no_local → (providers, [])
else if no_cloud → collect_endpoints; discover; return
else → collect_endpoints; discover; check_healthy; return
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 중복
```

## After
```
if no_local → (providers, [])
else → collect_endpoints; discover;  ← 1번만
       if no_cloud → return
       else → check_healthy; return
```

## Test plan
- [x] `dune build` 성공
- [x] 14 cascade 테스트 통과
- [x] 33 swarm 테스트 통과
- [ ] CI 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)