### PR TITLE
refactor: extract Str_match.contains to deduplicate regex boolean checks

### DIFF
--- a/lib/approval.ml
+++ b/lib/approval.ml
@@ -114,15 +114,12 @@ let reject_dangerous_patterns (patterns : (string * string) list) : approval_sta
   evaluate = (fun ctx ->
     let matches = List.exists (fun (name_pat, input_pat) ->
       let name_match =
-        try ignore (Str.search_forward (Str.regexp name_pat) ctx.tool_name 0); true
-        with Not_found -> false
+        Str_match.contains (Str.regexp name_pat) ctx.tool_name
       in
       let input_str = Yojson.Safe.to_string ctx.input in
       let input_match =
         if input_pat = "" then true
-        else
-          try ignore (Str.search_forward (Str.regexp input_pat) input_str 0); true
-          with Not_found -> false
+        else Str_match.contains (Str.regexp input_pat) input_str
       in
       name_match && input_match
     ) patterns in

--- a/lib/harness.ml
+++ b/lib/harness.ml
@@ -212,8 +212,7 @@ module Adversarial = struct
     | ErrorContains needle ->
       let passed = match obs.error_message with
         | Some msg ->
-          (try let _ = Str.search_forward (Str.regexp_string needle) msg 0 in true
-           with Not_found -> false)
+          Str_match.contains (Str.regexp_string needle) msg
         | None -> false
       in
       {

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -56,16 +56,14 @@ let extract_reasoning (messages : message list) : reasoning_summary =
     "might be wrong"; "unsure"; "probably"; "I think";
   ] in
   let has_uncertainty = List.exists (fun marker ->
-    try let _ = Str.search_forward (Str.regexp_string_case_fold marker) all_text 0 in true
-    with Not_found -> false
+    Str_match.contains (Str.regexp_string_case_fold marker) all_text
   ) uncertainty_markers in
   let tool_rationale =
     (* Look for the last thinking block that mentions tool selection *)
     let tool_markers = ["tool"; "function"; "call"; "use"] in
     List.find_map (fun block ->
       if List.exists (fun marker ->
-        try let _ = Str.search_forward (Str.regexp_string_case_fold marker) block 0 in true
-        with Not_found -> false
+        Str_match.contains (Str.regexp_string_case_fold marker) block
       ) tool_markers then Some block
       else None
     ) (List.rev thinking_blocks)

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -222,8 +222,7 @@ let rec eval_condition (last_result : task_result option) cond =
     (match last_result with
      | Some { result = Ok resp; _ } ->
        let text = text_of_response resp in
-       (try let _ = Str.search_forward (Str.regexp_string needle) text 0 in true
-        with Not_found -> false)
+       Str_match.contains (Str.regexp_string needle) text
      | _ -> false)
   | Custom_cond pred ->
     (match last_result with

--- a/lib/str_match.ml
+++ b/lib/str_match.ml
@@ -1,0 +1,3 @@
+let contains re str =
+  try ignore (Str.search_forward re str 0); true
+  with Not_found -> false

--- a/lib/str_match.mli
+++ b/lib/str_match.mli
@@ -1,0 +1,6 @@
+(** Thin wrapper around [Str.search_forward] for boolean matching. *)
+
+val contains : Str.regexp -> string -> bool
+(** [contains re str] returns [true] if [re] matches anywhere in [str].
+    Equivalent to [try ignore (Str.search_forward re str 0); true
+    with Not_found -> false]. *)


### PR DESCRIPTION
## Summary
- `try Str.search_forward ... true with Not_found -> false` 패턴이 4개 파일 6곳에서 반복
- `Str_match.contains` 함수로 추출하고 .mli 계약 추가
- 호출부 코드가 1줄로 간결해짐

## Before
```ocaml
try ignore (Str.search_forward (Str.regexp name_pat) ctx.tool_name 0); true
with Not_found -> false
```

## After
```ocaml
Str_match.contains (Str.regexp name_pat) ctx.tool_name
```

## 변경 파일
| 파일 | 교체 건수 |
|------|----------|
| `approval.ml` | 2 |
| `hooks.ml` | 2 |
| `orchestrator.ml` | 1 |
| `harness.ml` | 1 |

## Test plan
- [x] `dune build` 성공
- [x] harness 테스트 14개 통과
- [x] hooks 테스트 12개 통과
- [ ] CI 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)