### PR TITLE
feat(builder): add with_priority for downstream priority tagging

### DIFF
--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -141,6 +141,7 @@ let with_mcp_clients clients b = { b with mcp_clients = clients }
 let with_guardrails guardrails b = { b with guardrails }
 let with_guardrails_async guardrails_async b = { b with guardrails_async }
 let with_operator_policy policy b = { b with operator_policy = Some policy }
+let with_priority priority b = { b with priority = Some priority }
 let with_contract contract b =
   { b with contract = Contract.merge b.contract contract }
 let with_skill skill b =

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -53,6 +53,11 @@ val with_guardrails_async : Guardrails_async.t -> t -> t
 
     @since 0.94.0 *)
 val with_operator_policy : Guardrails.tool_filter -> t -> t
+
+(** Set scheduling priority for LLM requests made by this agent.
+    @since 0.96.0 *)
+val with_priority : Llm_provider.Request_priority.t -> t -> t
+
 val with_tracer : Tracing.t -> t -> t
 val with_raw_trace : Raw_trace.t -> t -> t
 val with_approval : Hooks.approval_callback -> t -> t


### PR DESCRIPTION
## Summary
- Add `Builder.with_priority` to expose `Request_priority.t` setting on `agent_config`
- Required for MASC Phase 2 (#3820) to tag priority at all 23 LLM call sites

2 files, 6 lines added. Trivial addition to existing builder pattern.

## Test plan
- [x] Build passes (no new logic, just field setter)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)