### PR TITLE
fix(api): fall back to named_cascade.metrics when ?metrics is None (P1-1b)

### DIFF
--- a/lib/api.ml
+++ b/lib/api.ml
@@ -194,11 +194,19 @@ let create_message_named ~sw ~net ?clock ~(named_cascade : named_cascade)
     | Some _ -> system_prompt
     | None -> config.config.system_prompt
   in
+  (* Fall back to named_cascade.metrics when caller does not provide ?metrics.
+     This lets downstream consumers (e.g. MASC oas_worker) wire Prometheus
+     counters once via named_cascade and get cache hit/miss callbacks
+     without threading ?metrics through every call site. *)
+  let metrics = match metrics with
+    | Some m -> m
+    | None -> named_cascade.metrics
+  in
   match
     Llm_provider.Cascade_config.complete_named ~sw ~net ?clock
       ?config_path:named_cascade.config_path ~name:named_cascade.name
       ~defaults:named_cascade.defaults ~messages ?tools ~temperature
-      ~max_tokens ?system_prompt ~accept ?timeout_sec ?metrics ?priority ()
+      ~max_tokens ?system_prompt ~accept ?timeout_sec ~metrics ?priority ()
   with
   | Ok response -> Ok response
   | Error err -> Error (map_named_cascade_error err)
@@ -212,11 +220,15 @@ let create_message_named_stream ~sw ~net ?clock
     | Some _ -> system_prompt
     | None -> config.config.system_prompt
   in
+  let metrics = match metrics with
+    | Some m -> m
+    | None -> named_cascade.metrics
+  in
   match
     Llm_provider.Cascade_config.complete_named_stream ~sw ~net ?clock
       ?config_path:named_cascade.config_path ~name:named_cascade.name
       ~defaults:named_cascade.defaults ~messages ?tools ~temperature
-      ~max_tokens ?system_prompt ?timeout_sec ?metrics ~on_event ?priority ()
+      ~max_tokens ?system_prompt ?timeout_sec ~metrics ~on_event ?priority ()
   with
   | Ok response -> Ok response
   | Error err -> Error (map_named_cascade_error err)


### PR DESCRIPTION
## Summary

- **P1-1b (Delta-Context Architecture)**: `create_message_named` (sync) + `create_message_named_stream` 양쪽에서 `?metrics`가 None일 때 `named_cascade.metrics`를 fallback으로 사용
- downstream consumer (MASC oas_worker)가 `named_cascade` 생성 시 Prometheus-connected Metrics.t를 한 번만 설정하면 모든 call에 전파됨
- 1-file, 14-line 변경. 기존 동작 유지 (명시 metrics 전달 시 해당 값 사용)

## Test plan
- [x] `test_api.exe` 50/50 passed
- [x] `dune build` clean
- [ ] CI checks

Refs: #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)