### PR TITLE
feat(swarm): checkpoint fidelity gate + converged field (v2)

### DIFF
--- a/docs/design/swarm-checkpoint-fidelity-gate.md
+++ b/docs/design/swarm-checkpoint-fidelity-gate.md
@@ -1,0 +1,104 @@
+# Swarm Checkpoint Fidelity Gate
+
+Status: Active
+Related issues: `#487`
+
+## Purpose
+
+Define the loss budget for swarm checkpoint serialization/deserialization.
+Until this gate passes, no swarm-level delta or plan caching work (P3-2, P3-3) may proceed.
+
+## Loss Inventory
+
+Full roundtrip path: `swarm_state` -> `of_state` -> `to_json` -> JSON -> `load` -> `restore` -> `swarm_state`
+
+### Fields with no loss
+
+| Field | Save | Restore | Notes |
+| --- | --- | --- | --- |
+| `current_iteration` | exact | exact | |
+| `best_metric` | exact | exact | |
+| `best_iteration` | exact | exact | |
+| `patience_counter` | exact | exact | |
+| `history[].iteration` | exact | exact | |
+| `history[].metric_value` | exact | exact | |
+| `history[].elapsed` | exact | exact | |
+| `history[].timestamp` | exact | exact | |
+| `config` | snapshot (names) | `base_config` arg | By design: closures not serializable |
+
+### Fields with loss
+
+| Field | Serialized as | Restored as | Impact | Decision |
+| --- | --- | --- | --- | --- |
+| `agent_statuses` | not saved | `create_state` -> all `Idle` | **Medium** | Accept: current statuses are ephemeral runtime state |
+| `converged` | not saved | `create_state` -> `false` | **Medium** | Fix: add to checkpoint, restore on load |
+| `history[].agent_results` status | `show_agent_status` string | all -> `Idle` | **Medium** | Fix: parse `agent_status` from string |
+| `history[].trace_refs` | not saved | `[]` | **Low** | Accept: debug links, no runtime impact |
+
+### Details
+
+**`agent_statuses` (accept)**:
+Current agent statuses (`Idle`, `Working`, `Done_ok`, `Done_error`) are transient runtime state.
+After a swarm is restored and agents re-execute, statuses are set fresh.
+Preserving stale statuses from a previous run would be misleading.
+
+**`converged` (fix required)**:
+The `converged` flag determines whether the convergence loop should continue.
+If a swarm checkpointed after convergence and is restored, `converged = false`
+causes unnecessary re-execution. This is a correctness bug.
+
+**`history[].agent_results` status (fix required)**:
+Historical agent statuses are diagnostic information.
+`Done_ok { elapsed; text; telemetry }` and `Done_error { elapsed; error; telemetry }` carry
+performance data (`elapsed`), result summaries (`text`/`error`), and aggregated telemetry.
+Restoring all as `Idle` loses this diagnostic data.
+
+The fix requires parsing `show_agent_status` output back into the variant.
+Since `show_agent_status` is derived (`[@@deriving show]`), the format is stable.
+However, `Done_ok` and `Done_error` contain nested records with `telemetry: agent_telemetry`.
+A simpler v1 fix: serialize `agent_status` to structured JSON instead of `show` format.
+
+**`history[].trace_refs` (accept)**:
+`Raw_trace.run_ref` contains references to external trace stores.
+These are debugging aids with no runtime behavioral impact.
+Restoring empty trace refs does not change swarm execution.
+
+## Gate conditions
+
+The gate passes when:
+
+1. All **High** impact fields: 0 (none identified)
+2. All **Medium** impact fields: each has an explicit decision (accept or fix)
+   - `agent_statuses`: **accepted** (ephemeral runtime state)
+   - `converged`: **fix required** (correctness bug)
+   - `history[].agent_results` status: **fix required** (diagnostic data loss)
+3. Fixes for `converged` and `agent_results` status must be implemented and tested
+4. Each accepted loss must have documented justification (above)
+
+## Fix plan
+
+### Fix 1: Add `converged` to checkpoint
+
+- Add `converged: bool` to `swarm_checkpoint.t`
+- Save: `cp.converged <- state.converged`
+- Restore: `state.converged <- cp.converged`
+- JSON: `("converged", \`Bool cp.converged)`
+- Bump `checkpoint_version` to 2, accept v1 with `converged = false` default
+- Test: save converged state, restore, verify `converged = true`
+
+### Fix 2: Structured `agent_status` serialization
+
+- Replace `show_agent_status` with structured JSON:
+  ```json
+  {"status": "Done_ok", "elapsed": 1.5, "text": "result", "telemetry": {...}}
+  ```
+- Parse back to the full variant with all nested fields
+- The `telemetry` sub-record needs its own JSON serialization
+- This is a larger change that requires `agent_telemetry_to_json` / `agent_telemetry_of_json`
+- Test: roundtrip each variant (`Idle`, `Working`, `Done_ok`, `Done_error`)
+
+### Sequencing
+
+Fix 1 is small and independent. Fix 2 is medium complexity.
+Both are required before the gate passes.
+P3-2 (swarm plan caching) and P3-3 must wait.

--- a/lib_swarm/swarm_checkpoint.ml
+++ b/lib_swarm/swarm_checkpoint.ml
@@ -27,11 +27,12 @@ type t = {
   best_metric: float option;
   best_iteration: int;
   patience_counter: int;
+  converged: bool;
   history: Swarm_types.iteration_record list;
   created_at: float;
 }
 
-let checkpoint_version = 1
+let checkpoint_version = 2
 
 (* ── Snapshot helpers ────────────────────────────────────────── *)
 
@@ -60,6 +61,7 @@ let of_state (state : Swarm_types.swarm_state) : t =
     best_metric = state.best_metric;
     best_iteration = state.best_iteration;
     patience_counter = state.patience_counter;
+    converged = state.converged;
     history = state.history;
     created_at = Unix.gettimeofday ();
   }
@@ -121,6 +123,7 @@ let to_json (cp : t) : Yojson.Safe.t =
     ("best_metric", match cp.best_metric with Some v -> `Float v | None -> `Null);
     ("best_iteration", `Int cp.best_iteration);
     ("patience_counter", `Int cp.patience_counter);
+    ("converged", `Bool cp.converged);
     ("history", `List (List.map iteration_record_to_json cp.history));
     ("created_at", `Float cp.created_at);
   ]
@@ -148,7 +151,7 @@ let load ~path : (t, Error.sdk_error) result =
       let json = Yojson.Safe.from_string content in
       let open Yojson.Safe.Util in
       let version = json |> member "version" |> to_int in
-      if version <> checkpoint_version then
+      if version <> checkpoint_version && version <> 1 then
         Error (Error.Serialization (VersionMismatch { expected = checkpoint_version; got = version }))
       else
         let cs = json |> member "config_snapshot" in
@@ -166,12 +169,15 @@ let load ~path : (t, Error.sdk_error) result =
           convergence_patience = cs |> member "convergence_patience" |> to_int_option;
         } in
         Ok {
-          version;
+          version = checkpoint_version;
           config_snapshot;
           iteration = json |> member "iteration" |> to_int;
           best_metric = json |> member "best_metric" |> to_float_option;
           best_iteration = json |> member "best_iteration" |> to_int;
           patience_counter = json |> member "patience_counter" |> to_int;
+          converged =
+            json |> member "converged" |> to_bool_option
+            |> Option.value ~default:false;  (* v1 backward compat *)
           history =
             json |> member "history" |> to_list
             |> List.map iteration_record_of_json;
@@ -201,6 +207,7 @@ let restore (cp : t) ~agent_lookup
     state.best_metric <- cp.best_metric;
     state.best_iteration <- cp.best_iteration;
     state.patience_counter <- cp.patience_counter;
+    state.converged <- cp.converged;
     state.history <- cp.history;
     Ok state
 
@@ -235,8 +242,8 @@ let make_iteration ~iteration ?(metric_value=None) ?(agent_results=[])
 
 (* --- checkpoint_version --- *)
 
-let%test "checkpoint_version is 1" =
-  checkpoint_version = 1
+let%test "checkpoint_version is 2" =
+  checkpoint_version = 2
 
 (* --- snapshot_of_config --- *)
 
@@ -363,7 +370,7 @@ let%test "to_json preserves all top-level fields" =
   let cp = of_state state in
   let json = to_json cp in
   let open Yojson.Safe.Util in
-  (json |> member "version" |> to_int) = 1
+  (json |> member "version" |> to_int) = 2
   && (json |> member "iteration" |> to_int) = 7
   && (json |> member "best_iteration" |> to_int) = 5
   && (json |> member "patience_counter" |> to_int) = 2
@@ -565,3 +572,63 @@ let%test "to_json created_at is positive" =
   let json = to_json cp in
   let open Yojson.Safe.Util in
   json |> member "created_at" |> to_float > 0.0
+
+(* --- converged field (v2) --- *)
+
+let%test "of_state: converged false by default" =
+  let cfg = make_config () in
+  let state = Swarm_types.create_state cfg in
+  let cp = of_state state in
+  cp.converged = false
+
+let%test "of_state: converged true preserved" =
+  let cfg = make_config () in
+  let state = Swarm_types.create_state cfg in
+  state.converged <- true;
+  let cp = of_state state in
+  cp.converged = true
+
+let%test "to_json: converged field present" =
+  let cfg = make_config () in
+  let state = Swarm_types.create_state cfg in
+  state.converged <- true;
+  let cp = of_state state in
+  let json = to_json cp in
+  let open Yojson.Safe.Util in
+  json |> member "converged" |> to_bool = true
+
+let%test "restore: converged preserved" =
+  let cfg = make_config () in
+  let state = Swarm_types.create_state cfg in
+  state.converged <- true;
+  let cp = of_state state in
+  let lookup name =
+    if name = "a1" || name = "a2" then Some (make_entry name) else None in
+  match restore cp ~agent_lookup:lookup ~base_config:cfg with
+  | Ok restored -> restored.converged = true
+  | Error _ -> false
+
+let%test "v1 backward compat: converged defaults to false" =
+  (* Simulate a v1 checkpoint JSON without converged field *)
+  let cfg = make_config () in
+  let state = Swarm_types.create_state cfg in
+  let cp = of_state state in
+  let json = to_json cp in
+  (* Remove converged field to simulate v1 *)
+  let json_v1 = match json with
+    | `Assoc pairs ->
+      `Assoc (("version", `Int 1) ::
+        List.filter (fun (k, _) -> k <> "version" && k <> "converged") pairs)
+    | _ -> json
+  in
+  let path = Filename.temp_file "swarm_cp_v1" ".json" in
+  let oc = open_out path in
+  output_string oc (Yojson.Safe.pretty_to_string json_v1);
+  close_out oc;
+  match load ~path with
+  | Ok loaded ->
+    Sys.remove path;
+    loaded.converged = false
+  | Error _ ->
+    Sys.remove path;
+    false

--- a/lib_swarm/swarm_checkpoint.mli
+++ b/lib_swarm/swarm_checkpoint.mli
@@ -30,6 +30,7 @@ type t = {
   best_metric: float option;
   best_iteration: int;
   patience_counter: int;
+  converged: bool;
   history: Swarm_types.iteration_record list;
   created_at: float;
 }


### PR DESCRIPTION
## Summary
- Swarm checkpoint roundtrip 손실 전수 조사 + fidelity gate 문서 (`docs/design/swarm-checkpoint-fidelity-gate.md`)
- Fix 1/2: `converged` 필드 추가 (checkpoint v2, v1 backward compat)
- Gate 조건: P3-2/P3-3 진입 전 Medium impact 필드 모두 수정/수용 결정 필요

## Loss Inventory
| Field | Impact | Decision |
|-------|--------|----------|
| `agent_statuses` | Medium | Accept (ephemeral runtime state) |
| `converged` | Medium | **Fixed in this PR** |
| `history[].agent_results` status | Medium | Fix pending (separate PR) |
| `history[].trace_refs` | Low | Accept (debug links) |

## Test plan
- [x] `dune build --root .` pass (local)
- [ ] CI: Build & Test
- [ ] CI: Lint + Version Consistency
- [x] 5 new inline tests (converged roundtrip, v1 compat)
- [x] Version bump assertion updated (v1 -> v2)

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)