### PR TITLE
fix(mock): make provider_mock token counts explicit instead of fake defaults

### DIFF
--- a/lib/provider_mock.ml
+++ b/lib/provider_mock.ml
@@ -40,8 +40,10 @@ let call_count mock = mock.index
 
 (* ── Convenience builders ─────────────────────────────────────── *)
 
-(** Build a simple text response. *)
-let text_response ?(id="mock-id") ?(model="mock-model") text =
+(** Build a simple text response.
+    Token counts default to 0; set explicitly when testing budget/cost logic. *)
+let text_response ?(id="mock-id") ?(model="mock-model")
+    ?(input_tokens=0) ?(output_tokens=0) text =
   fun (_messages : message list) ->
     {
       id;
@@ -49,16 +51,18 @@ let text_response ?(id="mock-id") ?(model="mock-model") text =
       stop_reason = EndTurn;
       content = [Text text];
       usage = Some {
-        input_tokens = 100;
-        output_tokens = 50;
+        input_tokens;
+        output_tokens;
         cache_creation_input_tokens = 0;
         cache_read_input_tokens = 0;
         cost_usd = None
       };
     }
 
-(** Build a tool-use response. *)
+(** Build a tool-use response.
+    Token counts default to 0; set explicitly when testing budget/cost logic. *)
 let tool_use_response ?(id="mock-id") ?(model="mock-model")
+    ?(input_tokens=0) ?(output_tokens=0)
     ~tool_name ~tool_input () =
   fun (_messages : message list) ->
     let tool_use_id = Printf.sprintf "toolu_%s_%d"
@@ -69,8 +73,8 @@ let tool_use_response ?(id="mock-id") ?(model="mock-model")
       stop_reason = StopToolUse;
       content = [ToolUse { id = tool_use_id; name = tool_name; input = tool_input }];
       usage = Some {
-        input_tokens = 150;
-        output_tokens = 80;
+        input_tokens;
+        output_tokens;
         cache_creation_input_tokens = 0;
         cache_read_input_tokens = 0;
         cost_usd = None
@@ -84,8 +88,10 @@ let tool_then_text ~tool_name ~tool_input ~final_text () =
     text_response final_text;
   ]
 
-(** Build a response with thinking block followed by text. *)
+(** Build a response with thinking block followed by text.
+    Token counts default to 0; set explicitly when testing budget/cost logic. *)
 let thinking_response ?(id="mock-id") ?(model="mock-model")
+    ?(input_tokens=0) ?(output_tokens=0)
     ~thinking ~text () =
   fun (_messages : message list) ->
     {
@@ -97,8 +103,8 @@ let thinking_response ?(id="mock-id") ?(model="mock-model")
         Text text;
       ];
       usage = Some {
-        input_tokens = 200;
-        output_tokens = 150;
+        input_tokens;
+        output_tokens;
         cache_creation_input_tokens = 0;
         cache_read_input_tokens = 0;
         cost_usd = None

--- a/lib/provider_mock.mli
+++ b/lib/provider_mock.mli
@@ -32,13 +32,18 @@ val call_count : t -> int
 
 (** {1 Convenience Builders} *)
 
-(** Build a simple text response function. *)
+(** Build a simple text response function.
+    Token counts default to 0; set explicitly when testing budget/cost logic. *)
 val text_response :
-  ?id:string -> ?model:string -> string -> response_fn
+  ?id:string -> ?model:string ->
+  ?input_tokens:int -> ?output_tokens:int ->
+  string -> response_fn
 
-(** Build a tool-use response function. *)
+(** Build a tool-use response function.
+    Token counts default to 0; set explicitly when testing budget/cost logic. *)
 val tool_use_response :
   ?id:string -> ?model:string ->
+  ?input_tokens:int -> ?output_tokens:int ->
   tool_name:string -> tool_input:Yojson.Safe.t ->
   unit -> response_fn
 
@@ -47,9 +52,11 @@ val tool_then_text :
   tool_name:string -> tool_input:Yojson.Safe.t ->
   final_text:string -> unit -> response_fn list
 
-(** Build a thinking + text response function. *)
+(** Build a thinking + text response function.
+    Token counts default to 0; set explicitly when testing budget/cost logic. *)
 val thinking_response :
   ?id:string -> ?model:string ->
+  ?input_tokens:int -> ?output_tokens:int ->
   thinking:string -> text:string ->
   unit -> response_fn
 


### PR DESCRIPTION
## Summary
Token counts default to 0 instead of arbitrary hardcoded values. Callers testing budget/cost pass explicit values. Closes #506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)