### PR TITLE
fix: log tool violations and serialize mutation_class in evidence

### DIFF
--- a/lib/direct_evidence.ml
+++ b/lib/direct_evidence.ml
@@ -123,12 +123,18 @@ let tool_contracts_to_json tools =
            |> Option.map (fun (d : Tool.descriptor) -> d.examples)
            |> Option.value ~default:[]
          in
+         let mutation_class =
+           match Option.bind descriptor (fun d -> d.mutation_class) with
+           | Some value -> `String value
+           | None -> `Null
+         in
          `Assoc
            [
              ("name", `String tool.schema.name);
              ("description", `String tool.schema.description);
              ("origin", `String "local");
              ("kind", kind);
+             ("mutation_class", mutation_class);
              ("shell", shell);
              ("notes", `List (List.map (fun v -> `String v) notes));
              ("examples", `List (List.map (fun v -> `String v) examples));

--- a/lib/mode_enforcer.ml
+++ b/lib/mode_enforcer.ml
@@ -245,7 +245,13 @@ let hooks st =
       match event with
       | PreToolUse { tool_name; input; _ } ->
         (match check_violation st tool_name input with
-         | Some _ -> Skip
+         | Some v ->
+           Format.eprintf
+             "[mode_enforcer] SKIP tool=%s kind=%s mode=%s@."
+             tool_name
+             (violation_kind_to_string v.violation_kind)
+             (Execution_mode.to_string v.effective_mode);
+           Skip
          | None -> Continue)
       | _ -> Continue);
 


### PR DESCRIPTION
## Summary
- `mode_enforcer.ml` — `pre_tool_use` hook에서 violation Skip 시 `Format.eprintf`로 tool name, violation kind, effective mode를 stderr에 출력. 기존에는 완전 silent skip이라 차단된 도구를 추적할 수 없었음.
- `direct_evidence.ml` — `tool_contracts_to_json`에 `mutation_class` 필드 추가. consumer가 선언한 tool classification이 evidence 출력에 반영됨.

Follows up on #511 (tool_classifications + mutation_class descriptor).

## Test plan
- [x] `dune build --root .` pass
- [x] 49 tests pass
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)