### PR TITLE
fix: review followup for #531 (coverage off + ENFILE)

### DIFF
--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -53,6 +53,7 @@ let is_local_resource_exhaustion = function
     || has_substr m "no buffer space available"     (* ENOBUFS *)
     || has_substr m "eaddrnotavail"
     || has_substr m "emfile"
+    || has_substr m "enfile"
   | HttpError _ -> false
 
 (* ── Public API ────────────────────────────────────────────── *)
@@ -222,6 +223,7 @@ let inject_stream_param body_str =
   | other -> Yojson.Safe.to_string other
   | exception Yojson.Json_error _ -> body_str
 
+[@@@coverage off]
 (* ── is_local_resource_exhaustion tests ──────────────── *)
 
 let%test "resource exhaustion: EADDRNOTAVAIL via Eio" =
@@ -242,6 +244,11 @@ let%test "resource exhaustion: EMFILE constant" =
 let%test "resource exhaustion: ENOBUFS" =
   is_local_resource_exhaustion (NetworkError {
     message = "No buffer space available"
+  })
+
+let%test "resource exhaustion: ENFILE constant" =
+  is_local_resource_exhaustion (NetworkError {
+    message = "Unix.Unix_error(Unix.ENFILE, \"socket\", \"\")"
   })
 
 let%test "resource exhaustion: normal connection refused is not" =


### PR DESCRIPTION
## Summary

#531 Copilot 리뷰 코멘트 대응:

- `[@@@coverage off]` 추가 — inline test가 bisect_ppx 커버리지에 포함되지 않도록 (기존 컨벤션)
- `enfile` 문자열 감지 추가 — 주석은 ENFILE을 언급했으나 코드에서 누락
- ENFILE 테스트 케이스 1건 추가

`agent_sdk.opam` 버전 불일치 코멘트는 기각 (dune build이 자동 생성, CI Version Consistency 통과).

## Test plan

- [x] `dune build` 통과
- [ ] CI `dune build @runtest` 통과 (CI 위임)

🤖 Generated with [Claude Code](https://claude.com/claude-code)