### PR TITLE
feat(provider): slot cache API and yield capability

### DIFF
--- a/lib/llm_provider/provider_throttle.ml
+++ b/lib/llm_provider/provider_throttle.ml
@@ -93,6 +93,30 @@ let try_permit ~priority t f = Slot_scheduler.try_with_permit ~priority t.schedu
 let queue_length t = Slot_scheduler.queue_length t.scheduler
 let max_concurrent t = t.max_concurrent
 
+(* ── Turn-Level Yield API ─────────────────────────────── *)
+
+type yield_capability =
+  | Explicit_slot_yield
+  | Prefix_hint_yield
+  | Replay_yield
+
+let yield_capability t =
+  match t.source with
+  | Discovered -> Explicit_slot_yield  (* local llama-server with slot data *)
+  | Fallback -> Replay_yield           (* no slot data = cloud or unknown *)
+
+let acquire_permit ~priority t =
+  Slot_scheduler.acquire_permit ~priority t.scheduler
+
+let yield_permit t permit =
+  Slot_scheduler.yield_permit t.scheduler permit
+
+let resume_permit t permit =
+  Slot_scheduler.resume_permit t.scheduler permit
+
+let release_permit t permit =
+  Slot_scheduler.release_permit t.scheduler permit
+
 [@@@coverage off]
 (* === Inline tests === *)
 

--- a/lib/llm_provider/provider_throttle.mli
+++ b/lib/llm_provider/provider_throttle.mli
@@ -72,3 +72,31 @@ val queue_length : t -> int
 
 val max_concurrent : t -> int
 (** Maximum concurrent permits configured for this throttle. *)
+
+(** {2 Turn-Level Yield API}
+
+    Supports the "Agent exists != LLM slot held" pattern.
+    Agents acquire a permit, yield it during tool execution,
+    then resume before the next LLM turn.
+
+    @since 0.100.0 *)
+
+type yield_capability =
+  | Explicit_slot_yield  (** llama.cpp: KV cache save/restore guaranteed. *)
+  | Prefix_hint_yield    (** vLLM/SGLang: prefix re-send, best-effort cache hit. *)
+  | Replay_yield         (** Ollama/cloud: full history re-send. *)
+
+val yield_capability : t -> yield_capability
+(** Yield capability based on the provider kind. *)
+
+val acquire_permit : priority:Request_priority.t -> t -> Slot_scheduler.permit
+(** Acquire a slot permit at the given priority. *)
+
+val yield_permit : t -> Slot_scheduler.permit -> unit
+(** Yield a held permit (release slot for other agents). *)
+
+val resume_permit : t -> Slot_scheduler.permit -> unit
+(** Re-acquire a yielded permit at [Resume] priority. *)
+
+val release_permit : t -> Slot_scheduler.permit -> unit
+(** Permanently release a permit. *)

--- a/lib/llm_provider/slot_cache.ml
+++ b/lib/llm_provider/slot_cache.ml
@@ -1,0 +1,50 @@
+(** Slot KV cache persistence for local llama-server endpoints.
+
+    @since 0.100.0 *)
+
+let slot_action ~sw ~net ~endpoint ~slot_id ~action ~body_fields =
+  let url =
+    Printf.sprintf "%s/slots/%d?action=%s" endpoint slot_id action
+  in
+  let body =
+    match body_fields with
+    | [] -> "{}"
+    | fields -> Yojson.Safe.to_string (`Assoc fields)
+  in
+  let headers = [("Content-Type", "application/json")] in
+  match Http_client.post_sync ~sw ~net ~url ~headers ~body with
+  | Ok (code, _) when code >= 200 && code < 300 ->
+    Ok ()
+  | Ok (code, resp_body) ->
+    let msg =
+      Printf.sprintf "slot %s HTTP %d: %s" action code
+        (if String.length resp_body > 200
+         then String.sub resp_body 0 200
+         else resp_body)
+    in
+    Error msg
+  | Error (Http_client.HttpError { code; body }) ->
+    Error (Printf.sprintf "slot %s HTTP error %d: %s" action code body)
+  | Error (Http_client.NetworkError { message }) ->
+    Error (Printf.sprintf "slot %s network error: %s" action message)
+
+let save ~sw ~net ~endpoint ~slot_id ~filename =
+  slot_action ~sw ~net ~endpoint ~slot_id ~action:"save"
+    ~body_fields:[("filename", `String filename)]
+
+let restore ~sw ~net ~endpoint ~slot_id ~filename =
+  slot_action ~sw ~net ~endpoint ~slot_id ~action:"restore"
+    ~body_fields:[("filename", `String filename)]
+
+let erase ~sw ~net ~endpoint ~slot_id =
+  slot_action ~sw ~net ~endpoint ~slot_id ~action:"erase"
+    ~body_fields:[]
+
+let cleanup_file ~filename ~save_dir =
+  let path = Filename.concat save_dir filename in
+  if Sys.file_exists path then
+    (try Sys.remove path
+     with Sys_error _ -> ())
+
+let cache_filename ~session_id ~slot_id =
+  Printf.sprintf "slot-%s-%d.bin" session_id slot_id

--- a/lib/llm_provider/slot_cache.mli
+++ b/lib/llm_provider/slot_cache.mli
@@ -1,0 +1,49 @@
+(** Slot KV cache persistence for local llama-server endpoints.
+
+    Wraps llama-server's slot save/restore HTTP API to persist KV cache
+    state across yield/resume cycles. Only applies to local providers
+    with [--slot-save-path] configured.
+
+    Cloud providers are stateless and do not use this module.
+
+    @since 0.100.0 *)
+
+(** Save a slot's KV cache to disk via the llama-server API.
+    Calls [POST /slots/{slot_id}?action=save].
+    Returns [Ok ()] on success, [Error message] on failure. *)
+val save :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  endpoint:string ->
+  slot_id:int ->
+  filename:string ->
+  (unit, string) result
+
+(** Restore a slot's KV cache from disk via the llama-server API.
+    Calls [POST /slots/{slot_id}?action=restore].
+    Failure is expected on first session (no prior save) or model mismatch.
+    Returns [Ok ()] on success, [Error message] on failure. *)
+val restore :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  endpoint:string ->
+  slot_id:int ->
+  filename:string ->
+  (unit, string) result
+
+(** Erase a slot's KV cache on the server (free GPU memory).
+    Calls [POST /slots/{slot_id}?action=erase]. *)
+val erase :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  endpoint:string ->
+  slot_id:int ->
+  (unit, string) result
+
+(** Delete a saved cache file from disk.
+    No-op if the file does not exist. *)
+val cleanup_file : filename:string -> save_dir:string -> unit
+
+(** Generate a stable cache filename for a session.
+    Format: [slot-{session_id}-{slot_id}.bin] *)
+val cache_filename : session_id:string -> slot_id:int -> string


### PR DESCRIPTION
## Summary

Stacked on #536.

- `Slot_cache` 모듈: llama-server `/slots/{id}?action=save|restore|erase` HTTP 래퍼
- `Provider_throttle.yield_capability`: provider별 yield 전략 분류
  - `Explicit_slot_yield` (local llama-server)
  - `Prefix_hint_yield` (vLLM/SGLang, future)
  - `Replay_yield` (cloud)
- `Provider_throttle`에 permit API 위임 (acquire/yield/resume/release)

### Stacked PRs

1. #536: Slot_scheduler permit API + Resume priority
2. **이 PR**: Provider 계층 slot cache + yield capability
3. (next) Pipeline yield 정책 통합

## Test plan

- [x] `dune build --root .`
- [x] `dune runtest --root .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)