### PR TITLE
feat(tool_index): accept custom tokenizer for BM25 index

### DIFF
--- a/lib/tool_index.ml
+++ b/lib/tool_index.ml
@@ -87,6 +87,7 @@ type doc = {
 
 type t = {
   config: config;
+  tokenizer: string -> string list;
   docs: doc array;
   avg_dl: float;              (** Average document length *)
   idf: (string, float) Hashtbl.t;  (** Inverse document frequency *)
@@ -125,10 +126,10 @@ let compute_idf (docs : doc array) : (string, float) Hashtbl.t =
 
 (* ── Build ────────────────────────────────────────── *)
 
-let build ?(config = default_config) (entries : entry list) : t =
+let build ?(config = default_config) ?(tokenizer = tokenize) (entries : entry list) : t =
   let docs = Array.of_list (List.map (fun entry ->
     let text = entry.name ^ " " ^ entry.description in
-    let tokens = tokenize text in
+    let tokens = tokenizer text in
     { entry; tokens; token_count = List.length tokens }
   ) entries) in
   let total_docs = Array.length docs in
@@ -143,15 +144,15 @@ let build ?(config = default_config) (entries : entry list) : t =
   in
   let idf = compute_idf docs in
   let vocab_size = Hashtbl.length idf in
-  { config; docs; avg_dl; idf; total_docs; vocab_size }
+  { config; tokenizer; docs; avg_dl; idf; total_docs; vocab_size }
 
-let of_tools ?(config = default_config) (tools : Tool.t list) : t =
+let of_tools ?(config = default_config) ?tokenizer (tools : Tool.t list) : t =
   let entries = List.map (fun (tool : Tool.t) ->
     { name = tool.schema.name;
       description = tool.schema.description;
       group = None }
   ) tools in
-  build ~config entries
+  build ~config ?tokenizer entries
 
 (* ── BM25 scoring ─────────────────────────────────── *)
 
@@ -179,7 +180,7 @@ let score_doc (idx : t) (query_tokens : string list) (doc : doc) : float =
 let retrieve (idx : t) (query : string) : (string * float) list =
   if idx.total_docs = 0 then []
   else
-    let query_tokens = tokenize query in
+    let query_tokens = idx.tokenizer query in
     if query_tokens = [] then []
     else
       (* Score all documents *)

--- a/lib/tool_index.mli
+++ b/lib/tool_index.mli
@@ -36,14 +36,23 @@ type config = {
 
 val default_config : config
 
+(** {1 Tokenization} *)
+
+(** Default tokenizer: UTF-8 aware, splits on whitespace/punctuation,
+    lowercases ASCII, min-length 2 for ASCII tokens.
+    Exposed so callers can compose: [fun s -> tokenize s |> my_filter]. *)
+val tokenize : string -> string list
+
 (** {1 Construction} *)
 
 (** Build an index from a list of tool entries.
-    Tokenizes descriptions and computes IDF for each term. *)
-val build : ?config:config -> entry list -> t
+    Tokenizes descriptions and computes IDF for each term.
+    Pass [~tokenizer] to override the default tokenizer (e.g. for
+    language-specific stemming or particle stripping). *)
+val build : ?config:config -> ?tokenizer:(string -> string list) -> entry list -> t
 
 (** Build from [Tool.t list], extracting name and description from schemas. *)
-val of_tools : ?config:config -> Tool.t list -> t
+val of_tools : ?config:config -> ?tokenizer:(string -> string list) -> Tool.t list -> t
 
 (** {1 Query} *)
 


### PR DESCRIPTION
## Summary

`Tool_index.build`와 `of_tools`에 optional `~tokenizer` parameter 추가. 기본값은 기존 `tokenize` (동작 변경 없음).

## Motivation

BM25 tokenizer는 language-agnostic이지만, 한국어 등 교착어(agglutinative language)에서는 조사가 단어에 붙어 exact match가 실패한다. OAS에 특정 언어 로직을 넣는 대신, 소비자가 자기 tokenizer를 주입할 수 있게 한다.

## Changes

- `Tool_index.build`: `?tokenizer:(string -> string list)` 추가
- `Tool_index.of_tools`: 동일
- `Tool_index.tokenize`: `.mli`에 노출 (compose용)
- `t` 타입에 `tokenizer` 필드 저장 → `retrieve` 시 동일 tokenizer 사용

## Usage (downstream)

```ocaml
let korean_tokenizer s =
  Tool_index.tokenize s
  |> List.concat_map (fun tok ->
    match strip_korean_particle tok with
    | Some stem -> [tok; stem]
    | None -> [tok])

let idx = Tool_index.build ~config ~tokenizer:korean_tokenizer entries
```

## Test plan

- [x] 기존 inline 테스트 + alcotest 전부 pass
- [x] `tokenizer` 미전달 시 기존 동작과 동일 (backward compatible)

Generated with [Claude Code](https://claude.com/claude-code)