### PR TITLE
feat(cascade): add openai:auto model resolution

### DIFF
--- a/lib/llm_provider/cascade_model_resolve.ml
+++ b/lib/llm_provider/cascade_model_resolve.ml
@@ -50,6 +50,9 @@ let resolve_auto_model_id provider_name model_id =
   | "claude" ->
     if model_id = "auto" then env_or "claude-sonnet-4-6-20250514" "ANTHROPIC_DEFAULT_MODEL"
     else model_id
+  | "openai" ->
+    if model_id = "auto" then env_or "gpt-4.1" "OPENAI_DEFAULT_MODEL"
+    else model_id
   | "openrouter" ->
     if model_id = "auto" then env_or model_id "OPENROUTER_DEFAULT_MODEL"
     else model_id


### PR DESCRIPTION
## Summary
- Add `openai:auto` → `OPENAI_DEFAULT_MODEL` env var resolution (fallback: `gpt-4.1`)
- Completes `provider:auto` support for all cloud providers (glm, gemini, claude, openai)

## Why
MASC에서 벤더별 model env vars (MASC_GEMINI_DEFAULT_MODEL 등)를 제거하고
`"provider:auto"` cascade labels로 통합하려면 OAS가 모든 provider의 auto resolve를 지원해야 한다.

## Test plan
- [x] `dune build` 성공
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)