### PR TITLE
fix(runtime): reject unknown provider names instead of silent Local coercion

### DIFF
--- a/lib/runtime_server.ml
+++ b/lib/runtime_server.ml
@@ -135,7 +135,21 @@ let apply_command ~sw state store (session : session) command =
         | Hook_response result -> (result.continue_, result.message)
         | Permission_response _ -> (true, None)
       in
-      let resolution = resolve_execution session detail in
+      begin match resolve_execution session detail with
+      | Error err ->
+        let* session, _ =
+          persist_event store state session_id
+            (Agent_failed
+               {
+                 participant_name = detail.participant_name;
+                 summary = None;
+                 provider = detail.provider;
+                 model = detail.model;
+                 error = Some (Error.to_string err);
+               })
+        in
+        Ok (Command_applied session)
+      | Ok resolution ->
       if not permission_allowed || not hook_allowed then
         let* session, _ =
           persist_event store state session_id
@@ -206,6 +220,7 @@ let apply_command ~sw state store (session : session) command =
             Eio.traceln "Runtime_server: participant %s fork failed: %s"
               participant_name (Printexc.to_string exn));
         Ok (Command_applied session)
+      end
   | Attach_artifact detail ->
       let* artifact =
         Artifact_service.save_text_internal store ~session_id:session.session_id

--- a/lib/runtime_server_resolve.ml
+++ b/lib/runtime_server_resolve.ml
@@ -26,29 +26,28 @@ let resolve_provider ?provider ?model () =
   in
   let base =
     match selected with
-    | "mock" | "echo" -> None
-    | "local" | "local-qwen" -> Some (Provider.local_llm ())
-    | "sonnet" -> Some (Provider.anthropic_sonnet ())
-    | "haiku" -> Some (Provider.anthropic_haiku ())
-    | "opus" -> Some (Provider.anthropic_opus ())
-    | "openrouter" -> Some (Provider.openrouter ())
+    | "mock" | "echo" -> Ok None
+    | "local" | "local-qwen" -> Ok (Some (Provider.local_llm ()))
+    | "sonnet" -> Ok (Some (Provider.anthropic_sonnet ()))
+    | "haiku" -> Ok (Some (Provider.anthropic_haiku ()))
+    | "opus" -> Ok (Some (Provider.anthropic_opus ()))
+    | "openrouter" -> Ok (Some (Provider.openrouter ()))
     | other ->
-        Some
-          {
-            Provider.provider = Local { base_url = Defaults.local_llm_url };
-            model_id = other;
-            api_key_env = "LOCAL_LLM_KEY";
-          }
+        Error (Error.Config
+          (Error.UnsupportedProvider
+            { detail = Printf.sprintf "unknown provider %S; valid: local, \
+              local-qwen, sonnet, haiku, opus, openrouter, mock, echo" other }))
   in
   match base with
-  | None -> None
-  | Some cfg ->
-      Some
+  | Error _ as e -> e
+  | Ok None -> Ok None
+  | Ok (Some cfg) ->
+      Ok (Some
         {
           cfg with
           model_id =
             (match model with Some value when String.trim value <> "" -> value | _ -> cfg.model_id);
-        }
+        })
 
 let resolve_execution (session : session) (detail : spawn_agent_request) =
   let first_some = Util.first_some in
@@ -69,7 +68,7 @@ let resolve_execution (session : session) (detail : spawn_agent_request) =
   in
   match selected_provider with
   | "mock" | "echo" ->
-      {
+      Ok {
         selected_provider;
         requested_model;
         resolved_provider = Some selected_provider;
@@ -77,21 +76,21 @@ let resolve_execution (session : session) (detail : spawn_agent_request) =
         provider_cfg = None;
       }
   | _ ->
-      let provider_cfg =
-        resolve_provider ~provider:selected_provider
-          ?model:(first_some requested_model session.model) ()
-      in
-      {
-        selected_provider;
-        requested_model;
-        resolved_provider =
-          Some (provider_runtime_name selected_provider provider_cfg);
-        resolved_model =
-          (match provider_cfg with
-          | Some cfg -> Some cfg.model_id
-          | None -> first_some requested_model session.model);
-        provider_cfg;
-      }
+      match resolve_provider ~provider:selected_provider
+              ?model:(first_some requested_model session.model) () with
+      | Error _ as e -> e
+      | Ok provider_cfg ->
+        Ok {
+          selected_provider;
+          requested_model;
+          resolved_provider =
+            Some (provider_runtime_name selected_provider provider_cfg);
+          resolved_model =
+            (match provider_cfg with
+            | Some cfg -> Some cfg.model_id
+            | None -> first_some requested_model session.model);
+          provider_cfg;
+        }
 
 [@@@coverage off]
 (* === Inline tests === *)
@@ -125,70 +124,72 @@ let%test "provider_runtime_name: Custom_registered provider" =
 
 (* --- resolve_provider --- *)
 
-let%test "resolve_provider: mock returns None" =
-  resolve_provider ~provider:"mock" () = None
+let%test "resolve_provider: mock returns Ok None" =
+  resolve_provider ~provider:"mock" () = Ok None
 
-let%test "resolve_provider: echo returns None" =
-  resolve_provider ~provider:"echo" () = None
+let%test "resolve_provider: echo returns Ok None" =
+  resolve_provider ~provider:"echo" () = Ok None
 
 let%test "resolve_provider: local returns Local provider" =
   match resolve_provider ~provider:"local" () with
-  | Some cfg -> (match cfg.provider with Provider.Local _ -> true | _ -> false)
-  | None -> false
+  | Ok (Some cfg) -> (match cfg.provider with Provider.Local _ -> true | _ -> false)
+  | _ -> false
 
 let%test "resolve_provider: local-qwen returns Local provider" =
   match resolve_provider ~provider:"local-qwen" () with
-  | Some cfg -> (match cfg.provider with Provider.Local _ -> true | _ -> false)
-  | None -> false
+  | Ok (Some cfg) -> (match cfg.provider with Provider.Local _ -> true | _ -> false)
+  | _ -> false
 
 let%test "resolve_provider: sonnet returns Anthropic" =
   match resolve_provider ~provider:"sonnet" () with
-  | Some cfg -> cfg.provider = Provider.Anthropic
-  | None -> false
+  | Ok (Some cfg) -> cfg.provider = Provider.Anthropic
+  | _ -> false
 
 let%test "resolve_provider: haiku returns Anthropic" =
   match resolve_provider ~provider:"haiku" () with
-  | Some cfg -> cfg.provider = Provider.Anthropic
-  | None -> false
+  | Ok (Some cfg) -> cfg.provider = Provider.Anthropic
+  | _ -> false
 
 let%test "resolve_provider: opus returns Anthropic" =
   match resolve_provider ~provider:"opus" () with
-  | Some cfg -> cfg.provider = Provider.Anthropic
-  | None -> false
+  | Ok (Some cfg) -> cfg.provider = Provider.Anthropic
+  | _ -> false
 
 let%test "resolve_provider: openrouter returns OpenAICompat" =
   match resolve_provider ~provider:"openrouter" () with
-  | Some cfg -> (match cfg.provider with Provider.OpenAICompat _ -> true | _ -> false)
-  | None -> false
+  | Ok (Some cfg) -> (match cfg.provider with Provider.OpenAICompat _ -> true | _ -> false)
+  | _ -> false
 
-let%test "resolve_provider: unknown falls back to Local" =
+let%test "resolve_provider: unknown returns UnsupportedProvider error" =
   match resolve_provider ~provider:"unknown-provider" () with
-  | Some cfg -> (match cfg.provider with Provider.Local _ -> true | _ -> false)
-  | None -> false
+  | Error (Error.Config (Error.UnsupportedProvider _)) -> true
+  | _ -> false
 
-let%test "resolve_provider: unknown uses name as model_id" =
-  match resolve_provider ~provider:"unknown-provider" () with
-  | Some cfg -> cfg.model_id = "unknown-provider"
-  | None -> false
+let%test "resolve_provider: typoed provider returns error" =
+  match resolve_provider ~provider:"openriauter" () with
+  | Error (Error.Config (Error.UnsupportedProvider _)) -> true
+  | _ -> false
 
 let%test "resolve_provider: empty provider uses fallback" =
   (* Empty string triggers fallback_provider *)
-  resolve_provider ~provider:"  " () <> None
+  match resolve_provider ~provider:"  " () with
+  | Ok (Some _) -> true
+  | _ -> false
 
 let%test "resolve_provider: model override applied" =
   match resolve_provider ~provider:"sonnet" ~model:"my-custom-model" () with
-  | Some cfg -> cfg.model_id = "my-custom-model"
-  | None -> false
+  | Ok (Some cfg) -> cfg.model_id = "my-custom-model"
+  | _ -> false
 
 let%test "resolve_provider: empty model uses default" =
   match resolve_provider ~provider:"sonnet" ~model:"  " () with
-  | Some cfg -> cfg.model_id <> ""
-  | None -> false
+  | Ok (Some cfg) -> cfg.model_id <> ""
+  | _ -> false
 
 let%test "resolve_provider: trimmed and lowercased" =
   match resolve_provider ~provider:"  MOCK  " () with
-  | None -> true  (* mock returns None *)
-  | Some _ -> false
+  | Ok None -> true  (* mock returns Ok None *)
+  | _ -> false
 
 (* --- resolve_execution --- *)
 
@@ -227,56 +228,71 @@ let dummy_spawn : Runtime.spawn_agent_request = {
 
 let%test "resolve_execution: mock provider has no provider_cfg" =
   let detail = { dummy_spawn with provider = Some "mock" } in
-  let res = resolve_execution dummy_session detail in
-  res.selected_provider = "mock"
-  && res.provider_cfg = None
-  && res.resolved_provider = Some "mock"
+  match resolve_execution dummy_session detail with
+  | Ok res ->
+    res.selected_provider = "mock"
+    && res.provider_cfg = None
+    && res.resolved_provider = Some "mock"
+  | Error _ -> false
 
 let%test "resolve_execution: echo provider has no provider_cfg" =
   let detail = { dummy_spawn with provider = Some "echo" } in
-  let res = resolve_execution dummy_session detail in
-  res.selected_provider = "echo"
-  && res.provider_cfg = None
+  match resolve_execution dummy_session detail with
+  | Ok res -> res.selected_provider = "echo" && res.provider_cfg = None
+  | Error _ -> false
 
 let%test "resolve_execution: detail provider takes priority over session" =
   let session = { dummy_session with provider = Some "sonnet" } in
   let detail = { dummy_spawn with provider = Some "mock" } in
-  let res = resolve_execution session detail in
-  res.selected_provider = "mock"
+  match resolve_execution session detail with
+  | Ok res -> res.selected_provider = "mock"
+  | Error _ -> false
 
 let%test "resolve_execution: session provider used when detail is None" =
   let session = { dummy_session with provider = Some "haiku" } in
-  let res = resolve_execution session dummy_spawn in
-  res.selected_provider = "haiku"
+  match resolve_execution session dummy_spawn with
+  | Ok res -> res.selected_provider = "haiku"
+  | Error _ -> false
 
 let%test "resolve_execution: fallback when both None" =
-  let res = resolve_execution dummy_session dummy_spawn in
-  res.selected_provider = Defaults.fallback_provider
+  match resolve_execution dummy_session dummy_spawn with
+  | Ok res -> res.selected_provider = Defaults.fallback_provider
+  | Error _ -> false
 
 let%test "resolve_execution: requested_model from detail" =
   let detail = { dummy_spawn with model = Some "my-model" } in
-  let res = resolve_execution dummy_session detail in
-  res.requested_model = Some "my-model"
+  match resolve_execution dummy_session detail with
+  | Ok res -> res.requested_model = Some "my-model"
+  | Error _ -> false
 
 let%test "resolve_execution: requested_model None when detail empty" =
   let detail = { dummy_spawn with model = Some "  " } in
-  let res = resolve_execution dummy_session detail in
-  res.requested_model = None
+  match resolve_execution dummy_session detail with
+  | Ok res -> res.requested_model = None
+  | Error _ -> false
 
 let%test "resolve_execution: non-mock has provider_cfg" =
   let detail = { dummy_spawn with provider = Some "sonnet" } in
-  let res = resolve_execution dummy_session detail in
-  res.provider_cfg <> None
-  && res.resolved_provider = Some "anthropic"
+  match resolve_execution dummy_session detail with
+  | Ok res -> res.provider_cfg <> None && res.resolved_provider = Some "anthropic"
+  | Error _ -> false
+
+let%test "resolve_execution: unknown provider returns error" =
+  let detail = { dummy_spawn with provider = Some "bogus-provider" } in
+  match resolve_execution dummy_session detail with
+  | Error (Error.Config (Error.UnsupportedProvider _)) -> true
+  | _ -> false
 
 let%test "resolve_execution: mock resolved_model uses session model" =
   let session = { dummy_session with model = Some "sess-model" } in
   let detail = { dummy_spawn with provider = Some "mock" } in
-  let res = resolve_execution session detail in
-  res.resolved_model = Some "sess-model"
+  match resolve_execution session detail with
+  | Ok res -> res.resolved_model = Some "sess-model"
+  | Error _ -> false
 
 let%test "resolve_execution: mock requested_model takes priority" =
   let session = { dummy_session with model = Some "sess-model" } in
   let detail = { dummy_spawn with provider = Some "mock"; model = Some "req-model" } in
-  let res = resolve_execution session detail in
-  res.resolved_model = Some "req-model"
+  match resolve_execution session detail with
+  | Ok res -> res.resolved_model = Some "req-model"
+  | Error _ -> false

--- a/lib/runtime_server_resolve.mli
+++ b/lib/runtime_server_resolve.mli
@@ -16,8 +16,8 @@ val provider_runtime_name :
 
 val resolve_provider :
   ?provider:string -> ?model:string -> unit ->
-  Provider.config option
+  (Provider.config option, Error.sdk_error) result
 
 val resolve_execution :
   Runtime.session -> Runtime.spawn_agent_request ->
-  execution_resolution
+  (execution_resolution, Error.sdk_error) result


### PR DESCRIPTION
## Summary
- `resolve_provider` silently mapped unknown provider strings (e.g. typo `"openriauter"`) to `Local` with the unknown name as `model_id`
- Now returns `Error (Config (UnsupportedProvider ...))` for unrecognized provider names
- `resolve_execution` propagates the error via `result` return type
- `runtime_server.ml` emits `Agent_failed` event with structured error message on unknown provider
- Valid providers: `local`, `local-qwen`, `sonnet`, `haiku`, `opus`, `openrouter`, `mock`, `echo`

## Test plan
- [x] Existing valid provider tests pass (mock, echo, local, sonnet, haiku, opus, openrouter)
- [x] New test: unknown provider returns `UnsupportedProvider` error
- [x] New test: typoed provider (`"openriauter"`) returns error
- [x] New test: `resolve_execution` with unknown provider returns error
- [x] Full `dune build @runtest` passes (0 FAIL)

Closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)