### PR TITLE
fix(capability_filter): fail closed on unknown limits instead of permissive

### DIFF
--- a/lib/llm_provider/capability_filter.ml
+++ b/lib/llm_provider/capability_filter.ml
@@ -21,15 +21,27 @@ let requires_system_prompt (c : Capabilities.capabilities) = c.supports_system_p
 
 (* ── Limit checks ────────────────────────────────────── *)
 
-let fits_context ~tokens (c : Capabilities.capabilities) =
-  match c.max_context_tokens with
-  | None -> true  (* unknown = assume fits *)
-  | Some max -> tokens <= max
+type fit_result = Fits | Does_not_fit | Unknown_limit
 
-let fits_output ~tokens (c : Capabilities.capabilities) =
+let check_context ~tokens (c : Capabilities.capabilities) =
+  match c.max_context_tokens with
+  | None -> Unknown_limit
+  | Some max -> if tokens <= max then Fits else Does_not_fit
+
+let check_output ~tokens (c : Capabilities.capabilities) =
   match c.max_output_tokens with
-  | None -> true
-  | Some max -> tokens <= max
+  | None -> Unknown_limit
+  | Some max -> if tokens <= max then Fits else Does_not_fit
+
+let fits_context ~tokens c =
+  match check_context ~tokens c with
+  | Fits -> true
+  | Does_not_fit | Unknown_limit -> false
+
+let fits_output ~tokens c =
+  match check_output ~tokens c with
+  | Fits -> true
+  | Does_not_fit | Unknown_limit -> false
 
 (* ── Combinators ─────────────────────────────────────── *)
 

--- a/lib/llm_provider/capability_filter.mli
+++ b/lib/llm_provider/capability_filter.mli
@@ -26,10 +26,21 @@ val requires_system_prompt : Capabilities.capabilities -> bool
 
 (** {2 Limit checks} *)
 
-(** Does the model's context window fit the given token count? *)
+(** Result of a limit check against capability metadata. *)
+type fit_result = Fits | Does_not_fit | Unknown_limit
+
+(** Check context window fit with explicit unknown representation. *)
+val check_context : tokens:int -> Capabilities.capabilities -> fit_result
+
+(** Check output limit fit with explicit unknown representation. *)
+val check_output : tokens:int -> Capabilities.capabilities -> fit_result
+
+(** Fail-closed context check: unknown limits return [false].
+    Use {!check_context} when callers need to handle uncertainty. *)
 val fits_context : tokens:int -> Capabilities.capabilities -> bool
 
-(** Does the model's output limit fit the given token count? *)
+(** Fail-closed output check: unknown limits return [false].
+    Use {!check_output} when callers need to handle uncertainty. *)
 val fits_output : tokens:int -> Capabilities.capabilities -> bool
 
 (** {2 Combinators} *)

--- a/test/test_capabilities_wiring.ml
+++ b/test/test_capabilities_wiring.ml
@@ -53,7 +53,7 @@ let test_filter_fits_context () =
     (Capability_filter.fits_context ~tokens:100_000 caps);
   check bool "exceeds 128K" false
     (Capability_filter.fits_context ~tokens:200_000 caps);
-  check bool "unknown = fits" true
+  check bool "unknown = fail closed" false
     (Capability_filter.fits_context ~tokens:999_999
        Capabilities.default_capabilities)
 

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -999,7 +999,7 @@ let test_requires_system_prompt () =
     (Capability_filter.requires_system_prompt Capabilities.default_capabilities)
 
 let test_fits_context_none () =
-  Alcotest.(check bool) "None -> fits" true
+  Alcotest.(check bool) "None -> fail closed" false
     (Capability_filter.fits_context ~tokens:999999 Capabilities.default_capabilities)
 
 let test_fits_context_within () =
@@ -1011,7 +1011,7 @@ let test_fits_context_over () =
     (Capability_filter.fits_context ~tokens:999999 Capabilities.anthropic_capabilities)
 
 let test_fits_output_none () =
-  Alcotest.(check bool) "None -> fits" true
+  Alcotest.(check bool) "None -> fail closed" false
     (Capability_filter.fits_output ~tokens:999999 Capabilities.default_capabilities)
 
 let test_fits_output_within () =
@@ -1021,6 +1021,35 @@ let test_fits_output_within () =
 let test_fits_output_over () =
   Alcotest.(check bool) "over limit" false
     (Capability_filter.fits_output ~tokens:999999 Capabilities.anthropic_capabilities)
+
+let fit_result_testable =
+  let pp fmt = function
+    | Capability_filter.Fits -> Format.pp_print_string fmt "Fits"
+    | Capability_filter.Does_not_fit -> Format.pp_print_string fmt "Does_not_fit"
+    | Capability_filter.Unknown_limit -> Format.pp_print_string fmt "Unknown_limit"
+  in
+  let eq a b = a = b in
+  Alcotest.testable pp eq
+
+let test_check_context_unknown () =
+  Alcotest.(check fit_result_testable) "None -> Unknown_limit"
+    Capability_filter.Unknown_limit
+    (Capability_filter.check_context ~tokens:999999 Capabilities.default_capabilities)
+
+let test_check_context_fits () =
+  Alcotest.(check fit_result_testable) "within -> Fits"
+    Capability_filter.Fits
+    (Capability_filter.check_context ~tokens:100000 Capabilities.anthropic_capabilities)
+
+let test_check_context_over () =
+  Alcotest.(check fit_result_testable) "over -> Does_not_fit"
+    Capability_filter.Does_not_fit
+    (Capability_filter.check_context ~tokens:999999 Capabilities.anthropic_capabilities)
+
+let test_check_output_unknown () =
+  Alcotest.(check fit_result_testable) "None -> Unknown_limit"
+    Capability_filter.Unknown_limit
+    (Capability_filter.check_output ~tokens:999999 Capabilities.default_capabilities)
 
 (* requires_code_execution helper -- not exported from Capability_filter *)
 let requires_code_execution (c : Capabilities.capabilities) = c.supports_code_execution
@@ -1410,6 +1439,10 @@ let () =
       Alcotest.test_case "fits_output none" `Quick test_fits_output_none;
       Alcotest.test_case "fits_output within" `Quick test_fits_output_within;
       Alcotest.test_case "fits_output over" `Quick test_fits_output_over;
+      Alcotest.test_case "check_context unknown" `Quick test_check_context_unknown;
+      Alcotest.test_case "check_context fits" `Quick test_check_context_fits;
+      Alcotest.test_case "check_context over" `Quick test_check_context_over;
+      Alcotest.test_case "check_output unknown" `Quick test_check_output_unknown;
     ]);
     ("capability_filter.combinators", [
       Alcotest.test_case "requires_all" `Quick test_requires_all;


### PR DESCRIPTION
## Summary
- `fits_context`/`fits_output` returned `true` when limits were `None`, treating missing metadata as "fits any request"
- Added `fit_result` variant type (`Fits | Does_not_fit | Unknown_limit`) for explicit uncertainty representation
- Added `check_context`/`check_output` returning `fit_result` for callers that need to handle uncertainty
- `fits_context`/`fits_output` now fail closed: unknown limits return `false`

## Test plan
- [x] Updated `test_fits_context_none` and `test_fits_output_none` to expect `false`
- [x] New tests for `check_context`/`check_output` verify `Unknown_limit` for absent metadata
- [x] Updated `test_capabilities_wiring.ml` for fail-closed behavior
- [x] Full build and test pass (0 related FAIL)

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)