### PR TITLE
refactor(llm_provider): consolidate local endpoint defaults, fix 8080/8085 drift

### DIFF
--- a/lib/defaults.ml
+++ b/lib/defaults.ml
@@ -20,14 +20,7 @@ let float_env_or default var =
     | Some v when v > 0.0 -> v | _ -> default)
   | None -> default
 
-let local_llm_url =
-  (* Backward compat: OAS_LOCAL_QWEN_URL still works as fallback *)
-  let primary = Sys.getenv_opt "OAS_LOCAL_LLM_URL" in
-  let legacy = Sys.getenv_opt "OAS_LOCAL_QWEN_URL" in
-  match primary, legacy with
-  | Some v, _ when String.trim v <> "" -> String.trim v
-  | _, Some v when String.trim v <> "" -> String.trim v
-  | _ -> "http://127.0.0.1:8085"
+let local_llm_url = Llm_provider.Discovery.default_endpoint
 
 let fallback_provider =
   env_or "local" "OAS_FALLBACK_PROVIDER"

--- a/lib/llm_provider/cascade_model_resolve.ml
+++ b/lib/llm_provider/cascade_model_resolve.ml
@@ -68,6 +68,6 @@ let parse_custom_model model_id =
     let url =
       match Sys.getenv_opt "CUSTOM_LLM_BASE_URL" with
       | Some u -> u
-      | None -> "http://127.0.0.1:8080"
+      | None -> Discovery.default_endpoint
     in
     (model_id, url)

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -28,7 +28,13 @@ type endpoint_status = {
   capabilities: Capabilities.capabilities;
 }
 
-let default_endpoint = "http://127.0.0.1:8085"
+let default_endpoint =
+  let primary = Sys.getenv_opt "OAS_LOCAL_LLM_URL" in
+  let legacy = Sys.getenv_opt "OAS_LOCAL_QWEN_URL" in
+  match primary, legacy with
+  | Some v, _ when String.trim v <> "" -> String.trim v
+  | _, Some v when String.trim v <> "" -> String.trim v
+  | _ -> "http://127.0.0.1:8085"
 
 let endpoints_from_env () =
   match Sys.getenv_opt "LLM_ENDPOINTS" with

--- a/lib/llm_provider/discovery.mli
+++ b/lib/llm_provider/discovery.mli
@@ -48,8 +48,14 @@ val discover :
   endpoints:string list ->
   endpoint_status list
 
-(** Parse LLM_ENDPOINTS env var (comma-separated) or return default
-    [["http://127.0.0.1:8085"]]. *)
+(** Canonical local LLM endpoint default.
+    Reads OAS_LOCAL_LLM_URL / OAS_LOCAL_QWEN_URL env vars,
+    falls back to ["http://127.0.0.1:8085"].
+    All local endpoint defaults in llm_provider reference this value. *)
+val default_endpoint : string
+
+(** Parse LLM_ENDPOINTS env var (comma-separated) or return
+    [[default_endpoint]]. *)
 val endpoints_from_env : unit -> string list
 
 (** JSON serialization for endpoint_status. *)

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -80,8 +80,8 @@ let initial_llama_endpoints =
   | Some s ->
     let urls = s |> String.split_on_char ',' |> List.map String.trim
                |> List.filter (fun s -> s <> "") in
-    if urls = [] then ["http://127.0.0.1:8085"] else urls
-  | None -> ["http://127.0.0.1:8085"]
+    if urls = [] then [Discovery.default_endpoint] else urls
+  | None -> [Discovery.default_endpoint]
 
 (** Mutable endpoint list, protected by atomic snapshot swap.
     Updated by [refresh_llama_endpoints]. *)
@@ -112,10 +112,10 @@ let refresh_llama_endpoints ~sw ~net () =
     | Some s when String.trim s <> "" ->
         let urls = s |> String.split_on_char ',' |> List.map String.trim
                    |> List.filter (fun s -> s <> "") in
-        if urls = [] then ["http://127.0.0.1:8085"] else urls
+        if urls = [] then [Discovery.default_endpoint] else urls
     | _ ->
         let found = Discovery.scan_local_endpoints ~sw ~net () in
-        if found = [] then ["http://127.0.0.1:8085"] else found
+        if found = [] then [Discovery.default_endpoint] else found
   in
   Atomic.set llama_endpoints_ref (Array.of_list endpoints);
   endpoints

--- a/lib/llm_provider/transport_openai_compat.ml
+++ b/lib/llm_provider/transport_openai_compat.ml
@@ -12,7 +12,7 @@ type config = {
 }
 
 let default_config = {
-  base_url = "http://127.0.0.1:8085";
+  base_url = Discovery.default_endpoint;
   api_key = "";
   model_id = "";
   request_path = "/v1/chat/completions";


### PR DESCRIPTION
## Summary
- Local LLM endpoint `http://127.0.0.1:8085` was hardcoded in 6 files, with `cascade_model_resolve.ml` using `:8080` (drift)
- Consolidated to `Discovery.default_endpoint` as SSOT with `OAS_LOCAL_LLM_URL` / `OAS_LOCAL_QWEN_URL` env var support
- `Defaults.local_llm_url` now delegates to `Discovery.default_endpoint`
- `:8080` drift in custom model fallback path is eliminated

### Files changed
| File | Change |
|------|--------|
| `discovery.ml` + `.mli` | Env var logic moved here, exported as SSOT |
| `provider_registry.ml` | 4 literals → `Discovery.default_endpoint` |
| `transport_openai_compat.ml` | 1 literal → `Discovery.default_endpoint` |
| `cascade_model_resolve.ml` | `:8080` → `Discovery.default_endpoint` (drift fix) |
| `defaults.ml` | Delegates to `Discovery.default_endpoint` |

## Test plan
- [x] Full build passes
- [x] Full test suite passes (0 FAIL)
- [x] Existing `default_endpoint is localhost:8085` inline test still validates the canonical value

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)