### PR TITLE
fix(discovery): detect Ollama endpoints and report actual context size

### DIFF
--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -144,7 +144,7 @@ let probe_ollama_context ~sw ~net base_url =
     match first_name with
     | None -> None
     | Some model_name ->
-      let body = Printf.sprintf {|{"name":"%s"}|} model_name in
+      let body = Yojson.Safe.to_string (`Assoc [("name", `String model_name)]) in
       let headers = [("content-type", "application/json")] in
       match Http_client.post_sync ~sw ~net
               ~url:(base_url ^ "/api/show") ~headers ~body with


### PR DESCRIPTION
## Summary
- Ollama does not serve `/props` (llama.cpp specific), so discovery reported 128K context when actual `num_ctx` was 8192
- Added Ollama fallback: `/api/tags` detection -> `POST /api/show` -> `model_info.general.context_length`
- Health check falls back to `GET /` when `/health` fails (Ollama returns 200 on root)
- `default_scan_ports` now includes 11434 (Ollama default)

## Test plan
- [x] Build passes
- [x] All Discovery inline tests pass including new ones
- [x] `infer_capabilities` correctly uses Ollama-detected ctx_size
- [x] Verified default_scan_ports includes 11434

Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)