### PR TITLE
docs(skill): clarify discovery vs runtime skill paths with tests

### DIFF
--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -30,6 +30,8 @@ type options = Agent_types.options = {
   mcp_clients: Mcp.managed list;
   event_bus: Event_bus.t option;
   skill_registry: Skill_registry.t option;
+      (** Discovery/metadata path only.  Surfaced via {!Agent.card} for
+          A2A negotiation.  Does not affect runtime prompt composition. *)
   elicitation: Hooks.elicitation_callback option;
   description: string option;
   periodic_callbacks: periodic_callback list;

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -30,6 +30,8 @@ type options = {
   mcp_clients: Mcp.managed list;
   event_bus: Event_bus.t option;
   skill_registry: Skill_registry.t option;
+      (** Discovery/metadata path only.  Surfaced via {!Agent.card} for
+          A2A negotiation.  Does not affect runtime prompt composition. *)
   elicitation: Hooks.elicitation_callback option;
   description: string option;
   periodic_callbacks: periodic_callback list;

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -106,8 +106,20 @@ val with_fallback : Provider.config -> t -> t
 (** {2 Contract} *)
 
 val with_contract : Contract.t -> t -> t
+
+(** {3 Runtime skill composition}
+
+    Skills added via [with_skill] / [with_skills] are composed into the
+    agent's system prompt at build time.  Each skill body is rendered as
+    a [\[Skill: <name>\]] section appended to the base system prompt.
+
+    This is the {b runtime path}: it affects what the LLM sees on every
+    turn.  For metadata-only registration (Agent Card export, A2A
+    discovery, skill inventory) use {!with_skill_registry} instead. *)
+
 val with_skill : Skill.t -> t -> t
 val with_skills : Skill.t list -> t -> t
+
 val with_tool_grants : string list -> t -> t
 val with_mcp_tool_allowlist : string list -> t -> t
 
@@ -116,6 +128,19 @@ val with_mcp_tool_allowlist : string list -> t -> t
 val with_log_level : Log.level -> t -> t
 val with_log_sink : Log.sink -> t -> t
 val with_event_targets : Event_forward.target list -> t -> t
+
+(** {3 Discovery / metadata skill registry}
+
+    Attach a {!Skill_registry.t} for discovery and metadata export only.
+    Skills in the registry are surfaced via {!Agent.card} (Agent Card)
+    for A2A negotiation, capability queries, and skill inventory.
+
+    {b Does NOT affect runtime prompt composition.}  The registry
+    contents are never injected into the agent's system prompt.  To make
+    a skill influence LLM behavior, use {!with_skill} / {!with_skills}.
+
+    An agent can use both paths simultaneously: registry skills for
+    external discovery, and contract skills for prompt composition. *)
 val with_skill_registry : Skill_registry.t -> t -> t
 
 (** Set progressive tool disclosure strategy.

--- a/lib/contract.mli
+++ b/lib/contract.mli
@@ -37,8 +37,19 @@ val empty : t
 val with_runtime_awareness : string -> t -> t
 val with_trigger : ?source:string -> ?reason:string -> ?payload:Yojson.Safe.t -> string -> t -> t
 val add_instruction_layer : ?label:string -> string -> t -> t
+
+(** Add a skill to the contract for {b runtime prompt composition}.
+    The skill body is rendered as a [\[Skill: <name>\]] section inside the
+    system prompt produced by {!compose_system_prompt}.
+
+    This is distinct from {!Skill_registry.t}, which holds skills for
+    discovery/metadata export only and never touches the system prompt. *)
 val with_skill : Skill.t -> t -> t
+
+(** Batch variant of {!with_skill}.  All skills are appended (deduped by
+    path or name) and rendered into the system prompt. *)
 val with_skills : Skill.t list -> t -> t
+
 val with_tool_grants : string list -> t -> t
 val with_mcp_tool_allowlist : string list -> t -> t
 

--- a/lib/protocol/agent_card.mli
+++ b/lib/protocol/agent_card.mli
@@ -60,6 +60,9 @@ type agent_info = {
   mcp_clients_count: int;
   has_elicitation: bool;
   skill_registry: Skill_registry.t option;
+      (** Discovery-only skill source.  When present, skills from the
+          registry are listed in the generated agent card.  These skills
+          are {b not} composed into the system prompt. *)
 }
 
 val provider_name : Provider.config -> string

--- a/lib/skill_registry.mli
+++ b/lib/skill_registry.mli
@@ -1,4 +1,10 @@
-(** Runtime skill registry — discover and manage skills at runtime.
+(** Skill registry for discovery and metadata export.
+
+    Holds skills for Agent Card generation, A2A capability negotiation,
+    and skill inventory queries.  Skills in the registry are {b not}
+    injected into the agent's system prompt — they exist purely as
+    metadata.  To compose a skill into the runtime prompt, use
+    {!Contract.with_skill} (or {!Builder.with_skill}).
 
     Wraps a [Hashtbl.t] keyed by skill name.  Unlike {!Skill} which is
     pure data, the registry provides CRUD, bulk loading from a directory,

--- a/test/dune
+++ b/test/dune
@@ -841,3 +841,7 @@
 (test
  (name test_lenient_json)
  (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_skill_discovery)
+ (libraries agent_sdk alcotest yojson eio eio_main))

--- a/test/test_skill_discovery.ml
+++ b/test/test_skill_discovery.ml
@@ -1,0 +1,182 @@
+(** Tests for skill discovery vs runtime prompt separation (issue #520).
+
+    Verifies that:
+    - [with_skill_registry] does NOT inject skills into the system prompt.
+    - [with_skill] / [with_skills] DOES inject skills into the system prompt.
+    - Both paths coexist on the same agent without interference. *)
+
+open Agent_sdk
+
+let with_net f =
+  Eio_main.run @@ fun env ->
+  f (Eio.Stdenv.net env)
+
+let contains ~needle haystack =
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  if nlen = 0 then true
+  else
+    let rec loop i =
+      if i + nlen > hlen then false
+      else if String.sub haystack i nlen = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+
+(* ── Helpers ─────────────────────────────────────────────── *)
+
+let make_skill name body =
+  Skill.of_markdown
+    (Printf.sprintf "---\nname: %s\ndescription: %s skill\n---\n%s" name name body)
+
+let get_system_prompt agent =
+  (Agent.state agent).config.system_prompt
+
+(* ── 1. Registry skills do NOT appear in system prompt ──── *)
+
+let test_registry_does_not_inject_prompt () =
+  with_net @@ fun net ->
+  let reg = Skill_registry.create () in
+  Skill_registry.register reg (make_skill "discovery-only" "This is metadata content.");
+  let agent =
+    Builder.create ~net ~model:"claude-sonnet-4-6"
+    |> Builder.with_system_prompt "Base prompt."
+    |> Builder.with_skill_registry reg
+    |> Builder.build_safe |> Result.get_ok
+  in
+  let prompt = match get_system_prompt agent with
+    | Some p -> p
+    | None -> Alcotest.fail "expected system prompt"
+  in
+  Alcotest.(check bool)
+    "registry skill body absent from prompt" false
+    (contains ~needle:"This is metadata content." prompt);
+  Alcotest.(check bool)
+    "registry skill label absent from prompt" false
+    (contains ~needle:"[Skill: discovery-only]" prompt);
+  (* But the skill is in the agent card *)
+  let card = Agent.card agent in
+  Alcotest.(check bool) "card has discovery-only skill" true
+    (Agent_card.has_skill card "discovery-only")
+
+(* ── 2. Contract skills DO appear in system prompt ──────── *)
+
+let test_contract_skill_injects_prompt () =
+  with_net @@ fun net ->
+  let skill = make_skill "runtime-skill" "Apply this rule at runtime." in
+  let agent =
+    Builder.create ~net ~model:"claude-sonnet-4-6"
+    |> Builder.with_system_prompt "Base prompt."
+    |> Builder.with_skill skill
+    |> Builder.build_safe |> Result.get_ok
+  in
+  let prompt = match get_system_prompt agent with
+    | Some p -> p
+    | None -> Alcotest.fail "expected system prompt"
+  in
+  Alcotest.(check bool)
+    "contract skill label present in prompt" true
+    (contains ~needle:"[Skill: runtime-skill]" prompt);
+  Alcotest.(check bool)
+    "contract skill body present in prompt" true
+    (contains ~needle:"Apply this rule at runtime." prompt)
+
+(* ── 3. with_skills (batch) also injects into prompt ────── *)
+
+let test_with_skills_batch_injects_prompt () =
+  with_net @@ fun net ->
+  let s1 = make_skill "skill-a" "Content A." in
+  let s2 = make_skill "skill-b" "Content B." in
+  let agent =
+    Builder.create ~net ~model:"claude-sonnet-4-6"
+    |> Builder.with_system_prompt "Base."
+    |> Builder.with_skills [s1; s2]
+    |> Builder.build_safe |> Result.get_ok
+  in
+  let prompt = match get_system_prompt agent with
+    | Some p -> p
+    | None -> Alcotest.fail "expected system prompt"
+  in
+  Alcotest.(check bool) "skill-a in prompt" true
+    (contains ~needle:"[Skill: skill-a]" prompt);
+  Alcotest.(check bool) "skill-b in prompt" true
+    (contains ~needle:"[Skill: skill-b]" prompt)
+
+(* ── 4. Both paths coexist without interference ─────────── *)
+
+let test_both_paths_coexist () =
+  with_net @@ fun net ->
+  let runtime_skill = make_skill "runtime" "Runtime behavior." in
+  let reg = Skill_registry.create () in
+  Skill_registry.register reg (make_skill "catalog" "Catalog description.");
+  let agent =
+    Builder.create ~net ~model:"claude-sonnet-4-6"
+    |> Builder.with_system_prompt "Base prompt."
+    |> Builder.with_skill runtime_skill
+    |> Builder.with_skill_registry reg
+    |> Builder.build_safe |> Result.get_ok
+  in
+  let prompt = match get_system_prompt agent with
+    | Some p -> p
+    | None -> Alcotest.fail "expected system prompt"
+  in
+  (* Runtime skill IS in the prompt *)
+  Alcotest.(check bool)
+    "runtime skill in prompt" true
+    (contains ~needle:"[Skill: runtime]" prompt);
+  Alcotest.(check bool)
+    "runtime skill body in prompt" true
+    (contains ~needle:"Runtime behavior." prompt);
+  (* Registry skill is NOT in the prompt *)
+  Alcotest.(check bool)
+    "registry skill body absent from prompt" false
+    (contains ~needle:"Catalog description." prompt);
+  Alcotest.(check bool)
+    "registry skill label absent from prompt" false
+    (contains ~needle:"[Skill: catalog]" prompt);
+  (* Agent card has the registry skill *)
+  let card = Agent.card agent in
+  Alcotest.(check bool) "card has catalog" true
+    (Agent_card.has_skill card "catalog")
+
+(* ── 5. Registry-only agent: prompt unchanged ───────────── *)
+
+let test_registry_only_preserves_base_prompt () =
+  with_net @@ fun net ->
+  let reg = Skill_registry.create () in
+  Skill_registry.register reg (make_skill "meta" "Should not leak.");
+  let agent =
+    Builder.create ~net ~model:"claude-sonnet-4-6"
+    |> Builder.with_system_prompt "Exactly this."
+    |> Builder.with_skill_registry reg
+    |> Builder.build_safe |> Result.get_ok
+  in
+  let prompt = match get_system_prompt agent with
+    | Some p -> p
+    | None -> Alcotest.fail "expected system prompt"
+  in
+  Alcotest.(check string)
+    "base prompt preserved verbatim" "Exactly this." prompt
+
+(* ── Test runner ─────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Skill discovery vs runtime" [
+    "separation", [
+      Alcotest.test_case
+        "registry does not inject into prompt"
+        `Quick test_registry_does_not_inject_prompt;
+      Alcotest.test_case
+        "contract skill injects into prompt"
+        `Quick test_contract_skill_injects_prompt;
+      Alcotest.test_case
+        "with_skills batch injects into prompt"
+        `Quick test_with_skills_batch_injects_prompt;
+      Alcotest.test_case
+        "both paths coexist"
+        `Quick test_both_paths_coexist;
+      Alcotest.test_case
+        "registry-only preserves base prompt"
+        `Quick test_registry_only_preserves_base_prompt;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- `with_skill_registry` (discovery/metadata) and `with_skill`/`with_skills` (runtime prompt) had no clear documentation boundary
- Added explicit doc comments to 6 .mli files distinguishing the two paths
- Added new test suite `test_skill_discovery.ml` with 5 tests proving the separation

### Two skill paths
| Path | Function | Effect |
|------|----------|--------|
| Runtime | `with_skill`, `with_skills` | Composed into agent system prompt |
| Discovery | `with_skill_registry` | Agent Card export, A2A discovery only |

## Test plan
- [x] 5 new tests: registry-not-in-prompt, contract-in-prompt, batch-skills, coexistence, base-prompt-preserved
- [x] Full build and test pass

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)