### PR TITLE
refactor(subagent): remove stub fields, document runtime-enforced surface

### DIFF
--- a/lib/subagent.ml
+++ b/lib/subagent.ml
@@ -7,11 +7,6 @@ type model_override =
   | Use_model of Types.model
 [@@deriving show]
 
-type isolation =
-  | Shared
-  | Worktree
-[@@deriving show]
-
 type state_isolation =
   | Inherit_all
   | Isolated
@@ -28,11 +23,8 @@ type t = {
   max_turns: int option;
   skill_refs: string list;
   skills: Skill.t list;
-  isolation: isolation;
   state_isolation: state_isolation;
-  background: bool;
   path: string option;
-  metadata: (string * string list) list;
 }
 [@@deriving show]
 
@@ -42,11 +34,6 @@ let model_override_of_string s =
   match String.lowercase_ascii s with
   | "inherit" -> Inherit_model
   | other -> Use_model (Model_registry.resolve_model_id other)
-
-let isolation_of_string s =
-  match String.lowercase_ascii s with
-  | "worktree" -> Worktree
-  | _ -> Shared
 
 let state_isolation_of_string s =
   match String.lowercase_ascii (String.trim s) with
@@ -95,11 +82,6 @@ let of_markdown ?path ?(skills = []) markdown =
     );
     skill_refs = Skill.frontmatter_values fm "skills";
     skills;
-    isolation = (
-      Skill.frontmatter_value fm "isolation"
-      |> Option.map isolation_of_string
-      |> Option.value ~default:Shared
-    );
     state_isolation = (
       let mode =
         Skill.frontmatter_value fm "state-isolation"
@@ -115,12 +97,7 @@ let of_markdown ?path ?(skills = []) markdown =
         Selective keys
       | other -> other
     );
-    background =
-      List.exists
-        (fun v -> String.lowercase_ascii v = "true")
-        (Skill.frontmatter_values fm "background");
     path;
-    metadata = fm;
   }
 
 (* --- File loading with skill resolution --- *)

--- a/lib/subagent.mli
+++ b/lib/subagent.mli
@@ -13,17 +13,31 @@ type model_override =
   | Use_model of Types.model
 [@@deriving show]
 
-type isolation =
-  | Shared
-  | Worktree
-[@@deriving show]
-
 type state_isolation =
   | Inherit_all
   | Isolated
   | Selective of string list
 [@@deriving show]
 
+(** Subagent specification parsed from markdown frontmatter.
+
+    {b Runtime-enforced fields} (these affect agent execution):
+    - [name]: sets the agent identity and handoff target name
+    - [description]: handoff target description shown to the LLM
+    - [prompt]: becomes the sub-agent's system_prompt via {!compose_prompt}
+    - [tools]: tool allowlist applied by {!filter_tools}
+    - [disallowed_tools]: tool blocklist applied by {!filter_tools}
+    - [model]: determines which LLM model the sub-agent uses
+    - [max_turns]: enforced turn limit for the sub-agent run loop
+    - [skill_refs]: resolved to [Skill.t] list during {!load}
+    - [skills]: rendered into the prompt by {!compose_prompt}
+
+    {b Prompt-only fields} (injected into prompt text, not enforced):
+    - [state_isolation]: adds a preamble to the system prompt describing
+      isolation intent; no actual state filtering is performed
+
+    {b Diagnostic fields} (stored for introspection, not consumed at runtime):
+    - [path]: source file path, used for name derivation in {!of_markdown} *)
 type t = {
   name: string;
   description: string option;
@@ -34,18 +48,14 @@ type t = {
   max_turns: int option;
   skill_refs: string list;
   skills: Skill.t list;
-  isolation: isolation;
   state_isolation: state_isolation;
-  background: bool;
   path: string option;
-  metadata: (string * string list) list;
 }
 [@@deriving show]
 
 (** {1 Parsing helpers} *)
 
 val model_override_of_string : string -> model_override
-val isolation_of_string : string -> isolation
 val state_isolation_of_string : string -> state_isolation
 
 (** {1 Constructors} *)

--- a/test/test_subagent.ml
+++ b/test/test_subagent.ml
@@ -65,43 +65,10 @@ let () =
         let spec = Subagent.of_markdown md in
         check (option int) "max_turns" None spec.max_turns);
 
-      test_case "isolation worktree" `Quick (fun () ->
-        let md = "---\nisolation: worktree\n---\nbody" in
-        let spec = Subagent.of_markdown md in
-        check bool "worktree" true (spec.isolation = Subagent.Worktree));
-
-      test_case "isolation shared default" `Quick (fun () ->
-        let spec = Subagent.of_markdown "no isolation" in
-        check bool "shared" true (spec.isolation = Subagent.Shared));
-
-      test_case "isolation unknown -> shared" `Quick (fun () ->
-        let md = "---\nisolation: container\n---\nbody" in
-        let spec = Subagent.of_markdown md in
-        check bool "shared" true (spec.isolation = Subagent.Shared));
-
-      test_case "background" `Quick (fun () ->
-        let md = "---\nbackground: true\n---\nbody" in
-        let spec = Subagent.of_markdown md in
-        check bool "background" true spec.background);
-
-      test_case "background false" `Quick (fun () ->
-        let md = "---\nbackground: false\n---\nbody" in
-        let spec = Subagent.of_markdown md in
-        check bool "not background" false spec.background);
-
-      test_case "background missing" `Quick (fun () ->
-        let spec = Subagent.of_markdown "body" in
-        check bool "not background" false spec.background);
-
       test_case "skill_refs" `Quick (fun () ->
         let md = "---\nskills: helper.md, reviewer.md\n---\nbody" in
         let spec = Subagent.of_markdown md in
         check int "skill_refs" 2 (List.length spec.skill_refs));
-
-      test_case "metadata preserved" `Quick (fun () ->
-        let md = "---\nname: test\ncustom-key: value\n---\nbody" in
-        let spec = Subagent.of_markdown md in
-        check bool "has metadata" true (List.length spec.metadata > 0));
 
       test_case "description None" `Quick (fun () ->
         let spec = Subagent.of_markdown "body" in
@@ -233,21 +200,6 @@ let () =
         | _ -> fail "expected Custom");
     ];
 
-    "isolation_of_string", [
-      test_case "worktree" `Quick (fun () ->
-        check bool "worktree" true
-          (Subagent.isolation_of_string "worktree" = Subagent.Worktree));
-      test_case "Worktree uppercase" `Quick (fun () ->
-        check bool "Worktree" true
-          (Subagent.isolation_of_string "Worktree" = Subagent.Worktree));
-      test_case "other -> Shared" `Quick (fun () ->
-        check bool "shared" true
-          (Subagent.isolation_of_string "anything" = Subagent.Shared));
-      test_case "empty -> Shared" `Quick (fun () ->
-        check bool "shared" true
-          (Subagent.isolation_of_string "" = Subagent.Shared));
-    ];
-
     "state_isolation_of_string", [
       test_case "inherit by default" `Quick (fun () ->
         check bool "inherit" true
@@ -369,11 +321,6 @@ let () =
         let s1 = Subagent.show_model_override Subagent.Inherit_model in
         check bool "non-empty" true (String.length s1 > 0);
         let s2 = Subagent.show_model_override (Subagent.Use_model "claude-sonnet-4-6") in
-        check bool "non-empty" true (String.length s2 > 0));
-      test_case "show_isolation" `Quick (fun () ->
-        let s1 = Subagent.show_isolation Subagent.Shared in
-        check bool "non-empty" true (String.length s1 > 0);
-        let s2 = Subagent.show_isolation Subagent.Worktree in
         check bool "non-empty" true (String.length s2 > 0));
       test_case "show_state_isolation" `Quick (fun () ->
         let s1 = Subagent.show_state_isolation Subagent.Inherit_all in


### PR DESCRIPTION
## Summary
Audit of Subagent fields: 3 stub fields removed, remaining fields classified by enforcement level.

### Removed (never read at runtime)
| Field | Why |
|-------|-----|
| `isolation` (Shared/Worktree) | Parsed from frontmatter but never consumed |
| `background` (bool) | Parsed but never consumed |
| `metadata` (raw frontmatter) | Stored but zero consumers |

### Kept and documented
| Field | Enforcement |
|-------|-------------|
| `name`, `description`, `prompt`, `tools`, `disallowed_tools`, `model`, `max_turns`, `skill_refs`, `skills` | Runtime-enforced |
| `state_isolation` | Prompt-only (injects preamble, no actual isolation) |
| `path` | Diagnostic (name derivation) |

## Test plan
- [x] 11 tests for removed fields/functions deleted
- [x] Remaining 66 subagent tests + 17 handoff tests pass
- [x] Full build passes
- [x] No downstream references to removed fields

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)