### PR TITLE
feat(pipeline): in-memory tool result pruning + message cap

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,6 @@
 (lang dune 3.11)
 (name agent_sdk)
-(version 0.100.3)
+(version 0.100.4)
 
 (generate_opam_files true)
 

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -302,6 +302,22 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
          ~injector ~tool_uses ~results
        in
        update_state agent (fun s -> { s with messages = new_messages }));
+    (* In-memory message hygiene after each tool execution round.
+       Without this, agent.state.messages grows unbounded across turns —
+       context_reducer only trims before API calls, not in the stored state.
+
+       Two-step pruning (Claude Code Tier 1 pattern):
+       1. Stub old tool results: keep 2 most recent in full, replace older
+          with short stubs. Tool results are the largest allocation source.
+       2. Hard message cap: keep last 100 messages. Prevents unbounded growth
+          in long-running agents (600+ turns). *)
+    let pruner = Context_reducer.compose [
+      Context_reducer.stub_tool_results ~keep_recent:2;
+      Context_reducer.keep_last 100;
+    ] in
+    update_state agent (fun s ->
+      { s with messages =
+          Context_reducer.reduce pruner s.messages });
     Ok ToolsExecuted
 
 (* ── Stage 6: Output ─────────────────────────────────────── *)

--- a/lib/sdk_version.ml
+++ b/lib/sdk_version.ml
@@ -1,5 +1,5 @@
 (** Single source of truth for the SDK version string.
     All other modules reference this instead of hardcoding. *)
 
-let version = "0.100.3"
+let version = "0.100.4"
 let sdk_name = "agent_sdk"


### PR DESCRIPTION
## Summary

- Turn 간 in-memory message pruning 추가 (tool 실행 후)
- Claude Code Tier 1 패턴: 최근 2개 tool result만 유지, 나머지 stub
- 100 message hard cap

## Problem

`agent.state.messages`가 Agent.run() 중 무한 누적. Context reducer는 API 호출 전에만 적용되고 in-memory에는 적용 안 됨. 600+ turn keeper에서 multi-GB 성장.

## Solution

기존 `Context_reducer.stub_tool_results` + `keep_last`를 tool 실행 후에 적용:
```ocaml
let pruner = Context_reducer.compose [
  Context_reducer.stub_tool_results ~keep_recent:2;
  Context_reducer.keep_last 100;
] in
update_state agent (fun s ->
  { s with messages = Context_reducer.reduce pruner s.messages });
```

새 코드 0줄 — 기존 strategy를 올바른 시점에 적용.

## Test plan

- [x] `dune build` pass
- [x] `@runtest` 전체 pass
- [ ] CI

Closes #569 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)