### PR TITLE
refactor(cdal): replace hardcoded mode_enforcer heuristics with descriptor-driven classification

### DIFF
--- a/lib/mode_enforcer.ml
+++ b/lib/mode_enforcer.ml
@@ -1,7 +1,11 @@
-type mutation_class =
+type tool_effect_class =
   | Read_only
-  | Workspace_mutating
+  | Local_mutation
   | External_effect
+  | Shell_dynamic
+
+(* Backward-compatible alias. *)
+type mutation_class = tool_effect_class
 
 type violation_kind =
   | Mutating_in_diagnose
@@ -67,11 +71,58 @@ type token_snapshot = {
   turn: int;
 }
 
+(* ── Tool classification registry ────────────────────────────────── *)
+
+(** Default tool-name -> effect-class mappings. Data, not inline code. *)
+let default_tool_entries : (string * tool_effect_class) list = [
+  (* Read-only tools *)
+  "read", Read_only;
+  "glob", Read_only;
+  "grep", Read_only;
+  "search", Read_only;
+  "list_dir", Read_only;
+  "find_file", Read_only;
+  "read_file", Read_only;
+  "find_symbol", Read_only;
+  "get_symbols_overview", Read_only;
+  "find_referencing_symbols", Read_only;
+  "search_for_pattern", Read_only;
+  "read_console_messages", Read_only;
+  "read_network_requests", Read_only;
+  "get_page_text", Read_only;
+  "read_page", Read_only;
+  "tabs_context_mcp", Read_only;
+  (* Local-mutation tools *)
+  "write", Local_mutation;
+  "edit", Local_mutation;
+  "create_text_file", Local_mutation;
+  "replace_content", Local_mutation;
+  "rename_symbol", Local_mutation;
+  "insert_after_symbol", Local_mutation;
+  "insert_before_symbol", Local_mutation;
+  "replace_symbol_body", Local_mutation;
+  "notebook_edit", Local_mutation;
+  (* Shell-dynamic tools (require input analysis at runtime) *)
+  "bash", Shell_dynamic;
+  "execute_shell_command", Shell_dynamic;
+]
+
+(** Global mutable registry seeded from [default_tool_entries].
+    Supports runtime extension via [register_tool_class]. *)
+let tool_registry : (string, tool_effect_class) Hashtbl.t =
+  let tbl = Hashtbl.create (List.length default_tool_entries) in
+  List.iter (fun (name, cls) -> Hashtbl.replace tbl name cls)
+    default_tool_entries;
+  tbl
+
+let register_tool_class name cls =
+  Hashtbl.replace tool_registry (String.lowercase_ascii name) cls
+
 type state = {
   effective_mode: Execution_mode.t;
   allowed_mutations: string list;
   review_requirement: string option;
-  tool_classifications: (string * mutation_class) list;
+  tool_classifications: (string * tool_effect_class) list;
   mutable violations: violation list;
   mutable token_snapshots: token_snapshot list;
   mutable review_warning: string option;
@@ -96,42 +147,89 @@ let review_warning st = st.review_warning
 (* ── Tool classification ─────────────────────────────────────────── *)
 
 let classify_tool name =
-  match String.lowercase_ascii name with
-  | "read" | "glob" | "grep" | "search" | "list_dir" | "find_file"
-  | "read_file" | "find_symbol" | "get_symbols_overview"
-  | "find_referencing_symbols" | "search_for_pattern"
-  | "read_console_messages" | "read_network_requests"
-  | "get_page_text" | "read_page" | "tabs_context_mcp" ->
-    Read_only
-  | "write" | "edit" | "create_text_file" | "replace_content"
-  | "rename_symbol" | "insert_after_symbol" | "insert_before_symbol"
-  | "replace_symbol_body" | "notebook_edit" ->
-    Workspace_mutating
-  | n when String.length n > 5
-           && String.sub n 0 5 = "mcp__" ->
-    External_effect
-  | _ -> External_effect
+  let key = String.lowercase_ascii name in
+  match Hashtbl.find_opt tool_registry key with
+  | Some cls -> cls
+  | None ->
+    (* Fail closed: MCP tools and anything unknown -> External_effect *)
+    if String.length key > 5 && String.sub key 0 5 = "mcp__" then
+      External_effect
+    else
+      External_effect
 
-let has_any_pattern patterns haystack =
-  List.exists (fun pat -> Util.string_contains ~needle:pat haystack) patterns
+(** Structured shell-command pattern entries.
+    Each pair maps a substring pattern to the effect class it implies.
+    Order does not matter -- [classify_bash_tool] checks external patterns
+    first (fail closed) and falls back to mutating, then read-only. *)
 
-let mutating_patterns = [
-  "rm "; "rm\t"; "rmdir "; "mv "; "cp "; "mkdir ";
-  "touch "; "chmod "; "chown "; "dd "; "mkfs";
-  "apt "; "brew "; "pip "; "npm "; "yarn "; "cargo ";
-  "git push"; "git commit"; "git add"; "git reset";
-  "git rebase"; "git merge"; "git checkout";
-  "docker "; "kubectl "; "systemctl ";
-  "curl "; "wget ";
+type shell_pattern_entry = {
+  pattern: string;
+  effect_class: tool_effect_class;
+}
+
+let shell_pattern_entries : shell_pattern_entry list = [
+  (* External-effect patterns (network, remote, deploy) *)
+  { pattern = "curl "; effect_class = External_effect };
+  { pattern = "wget "; effect_class = External_effect };
+  { pattern = "ssh "; effect_class = External_effect };
+  { pattern = "scp "; effect_class = External_effect };
+  { pattern = "rsync "; effect_class = External_effect };
+  { pattern = "git push"; effect_class = External_effect };
+  { pattern = "git fetch"; effect_class = External_effect };
+  { pattern = "git pull"; effect_class = External_effect };
+  { pattern = "git clone"; effect_class = External_effect };
+  { pattern = "docker "; effect_class = External_effect };
+  { pattern = "kubectl "; effect_class = External_effect };
+  { pattern = "helm "; effect_class = External_effect };
+  { pattern = "npm publish"; effect_class = External_effect };
+  { pattern = "pip install"; effect_class = External_effect };
+  { pattern = "cargo publish"; effect_class = External_effect };
+  { pattern = "systemctl "; effect_class = External_effect };
+  { pattern = "launchctl "; effect_class = External_effect };
+  (* Local-mutation patterns (filesystem, vcs local, package managers) *)
+  { pattern = "rm "; effect_class = Local_mutation };
+  { pattern = "rm\t"; effect_class = Local_mutation };
+  { pattern = "rmdir "; effect_class = Local_mutation };
+  { pattern = "mv "; effect_class = Local_mutation };
+  { pattern = "cp "; effect_class = Local_mutation };
+  { pattern = "mkdir "; effect_class = Local_mutation };
+  { pattern = "touch "; effect_class = Local_mutation };
+  { pattern = "chmod "; effect_class = Local_mutation };
+  { pattern = "chown "; effect_class = Local_mutation };
+  { pattern = "dd "; effect_class = Local_mutation };
+  { pattern = "mkfs"; effect_class = Local_mutation };
+  { pattern = "apt "; effect_class = Local_mutation };
+  { pattern = "brew "; effect_class = Local_mutation };
+  { pattern = "pip "; effect_class = Local_mutation };
+  { pattern = "npm "; effect_class = Local_mutation };
+  { pattern = "yarn "; effect_class = Local_mutation };
+  { pattern = "cargo "; effect_class = Local_mutation };
+  { pattern = "git commit"; effect_class = Local_mutation };
+  { pattern = "git add"; effect_class = Local_mutation };
+  { pattern = "git reset"; effect_class = Local_mutation };
+  { pattern = "git rebase"; effect_class = Local_mutation };
+  { pattern = "git merge"; effect_class = Local_mutation };
+  { pattern = "git checkout"; effect_class = Local_mutation };
 ]
 
-let external_patterns = [
-  "curl "; "wget "; "ssh "; "scp "; "rsync ";
-  "git push"; "git fetch"; "git pull"; "git clone";
-  "docker "; "kubectl "; "helm ";
-  "npm publish"; "pip install"; "cargo publish";
-  "systemctl "; "launchctl ";
-]
+(** Collect the highest-severity effect class from all matching patterns.
+    External_effect > Local_mutation > Read_only. *)
+let classify_shell_command cmd =
+  let has_redirect =
+    String.contains cmd '>'
+    || Util.string_contains ~needle:"tee " cmd
+  in
+  let max_effect = ref Read_only in
+  List.iter (fun entry ->
+    if Util.string_contains ~needle:entry.pattern cmd then
+      match entry.effect_class, !max_effect with
+      | External_effect, _ -> max_effect := External_effect
+      | Local_mutation, Read_only -> max_effect := Local_mutation
+      | _ -> ()
+  ) shell_pattern_entries;
+  if has_redirect && !max_effect = Read_only then
+    max_effect := Local_mutation;
+  !max_effect
 
 let extract_bash_command (input : Yojson.Safe.t) =
   match input with
@@ -141,39 +239,25 @@ let extract_bash_command (input : Yojson.Safe.t) =
      | _ -> None)
   | _ -> None
 
-let is_bash_read_only input =
-  match extract_bash_command input with
-  | None -> false
-  | Some cmd ->
-    let has_redirect =
-      String.contains cmd '>'
-      || Util.string_contains ~needle:"tee " cmd
-    in
-    not (has_any_pattern mutating_patterns cmd) && not has_redirect
-
-let is_bash_workspace_only input =
-  match extract_bash_command input with
-  | None -> false
-  | Some cmd -> not (has_any_pattern external_patterns cmd)
-
 let classify_bash_tool input =
-  if is_bash_read_only input then Read_only
-  else if is_bash_workspace_only input then Workspace_mutating
-  else External_effect
+  match extract_bash_command input with
+  | None -> External_effect  (* fail closed: unparseable -> external *)
+  | Some cmd -> classify_shell_command cmd
 
 let effective_class tool_name input =
   match classify_tool tool_name with
-  | External_effect
-    when String.lowercase_ascii tool_name = "bash"
-      || String.lowercase_ascii tool_name = "execute_shell_command" ->
-    classify_bash_tool input
+  | Shell_dynamic -> classify_bash_tool input
   | c -> c
 
-let mutation_class_of_string = function
+let tool_effect_class_of_string = function
   | "read_only" -> Some Read_only
-  | "workspace" | "workspace_mutating" -> Some Workspace_mutating
+  | "workspace" | "workspace_mutating" | "local_mutation" -> Some Local_mutation
   | "external" | "external_effect" -> Some External_effect
+  | "shell_dynamic" -> Some Shell_dynamic
   | _ -> None
+
+(* Backward-compatible alias *)
+let mutation_class_of_string = tool_effect_class_of_string
 
 let effective_class_with_hints ~tool_classifications tool_name input =
   match List.assoc_opt tool_name tool_classifications with
@@ -186,8 +270,8 @@ let all_read_only tools =
 let all_workspace_only tools =
   List.for_all (fun name ->
     match classify_tool name with
-    | Read_only | Workspace_mutating -> true
-    | External_effect -> false
+    | Read_only | Local_mutation -> true
+    | External_effect | Shell_dynamic -> false
   ) tools
 
 (* ── Enforcement check ───────────────────────────────────────────── *)
@@ -199,7 +283,7 @@ let check_violation st tool_name input =
   let cls = effective_class_with_hints
       ~tool_classifications:st.tool_classifications tool_name input in
   let kind = match st.effective_mode, cls with
-    | Execution_mode.Diagnose, (Workspace_mutating | External_effect) ->
+    | Execution_mode.Diagnose, (Local_mutation | External_effect) ->
       Some Mutating_in_diagnose
     | Execution_mode.Draft, External_effect ->
       Some External_in_draft

--- a/lib/mode_enforcer.mli
+++ b/lib/mode_enforcer.mli
@@ -3,18 +3,23 @@
     Creates hooks that block tool calls violating the effective execution mode.
     Violations are recorded as evidence for the proof bundle.
 
-    Tool classification:
-    - Read-only: read, glob, grep, search, etc.
-    - Workspace-mutating: write, edit, create_text_file, etc.
-    - External-effect: bash (with input analysis), mcp__*, unknown tools
+    Tool classification uses a descriptor-driven registry:
+    - Read_only: read, glob, grep, search, etc.
+    - Local_mutation: write, edit, create_text_file, etc.
+    - External_effect: mcp__*, unknown tools (fail closed)
+    - Shell_dynamic: bash, execute_shell_command (resolved via input analysis)
 
     @stability Evolving
     @since 0.93.1 *)
 
-type mutation_class =
+type tool_effect_class =
   | Read_only
-  | Workspace_mutating
+  | Local_mutation
   | External_effect
+  | Shell_dynamic
+
+(** Backward-compatible alias for [tool_effect_class]. *)
+type mutation_class = tool_effect_class
 
 type violation_kind =
   | Mutating_in_diagnose
@@ -51,7 +56,7 @@ type state
 val create :
   contract:Risk_contract.t ->
   effective_mode:Execution_mode.t ->
-  ?tool_classifications:(string * mutation_class) list ->
+  ?tool_classifications:(string * tool_effect_class) list ->
   unit ->
   state
 
@@ -63,16 +68,25 @@ val violations : state -> violation list
 val token_snapshots : state -> token_snapshot list
 val review_warning : state -> string option
 
-(** Classify a tool by name. Uses built-in name-based heuristics only. *)
-val classify_tool : string -> mutation_class
+(** Classify a tool by name using the global registry.
+    Returns [Shell_dynamic] for bash/execute_shell_command.
+    Unknown tools default to [External_effect] (fail closed). *)
+val classify_tool : string -> tool_effect_class
 
-(** Parse a mutation_class from a tool descriptor string.
+(** Register or override a tool classification in the global registry. *)
+val register_tool_class : string -> tool_effect_class -> unit
+
+(** Parse a [tool_effect_class] from a descriptor string.
     Accepted values: "read_only", "workspace", "workspace_mutating",
-    "external", "external_effect". *)
+    "local_mutation", "external", "external_effect", "shell_dynamic". *)
+val tool_effect_class_of_string : string -> tool_effect_class option
+
+(** Backward-compatible alias for [tool_effect_class_of_string]. *)
 val mutation_class_of_string : string -> mutation_class option
 
 (** Check if all tools in a list are read-only. *)
 val all_read_only : string list -> bool
 
-(** Check if all tools are at most workspace-mutating (no external effects). *)
+(** Check if all tools are at most local-mutation (no external effects).
+    [Shell_dynamic] tools are treated as potentially external. *)
 val all_workspace_only : string list -> bool

--- a/lib/tool.ml
+++ b/lib/tool.ml
@@ -52,7 +52,7 @@ type t = {
 
 let expected_concurrency_class_of_mutation_class = function
   | "read_only" -> Some Parallel_read
-  | "workspace" | "workspace_mutating" -> Some Sequential_workspace
+  | "workspace" | "workspace_mutating" | "local_mutation" -> Some Sequential_workspace
   | "external" | "external_effect" -> Some Exclusive_external
   | _ -> None
 

--- a/test/test_cdal.ml
+++ b/test/test_cdal.ml
@@ -965,16 +965,67 @@ let test_classify_known_tools () =
     (Mode_enforcer.classify_tool "read" = Mode_enforcer.Read_only);
   Alcotest.(check bool) "glob is Read_only" true
     (Mode_enforcer.classify_tool "glob" = Mode_enforcer.Read_only);
-  Alcotest.(check bool) "write is Workspace_mutating" true
-    (Mode_enforcer.classify_tool "write" = Mode_enforcer.Workspace_mutating);
-  Alcotest.(check bool) "edit is Workspace_mutating" true
-    (Mode_enforcer.classify_tool "edit" = Mode_enforcer.Workspace_mutating);
-  Alcotest.(check bool) "bash is External_effect" true
-    (Mode_enforcer.classify_tool "bash" = Mode_enforcer.External_effect);
+  Alcotest.(check bool) "write is Local_mutation" true
+    (Mode_enforcer.classify_tool "write" = Mode_enforcer.Local_mutation);
+  Alcotest.(check bool) "edit is Local_mutation" true
+    (Mode_enforcer.classify_tool "edit" = Mode_enforcer.Local_mutation);
+  Alcotest.(check bool) "bash is Shell_dynamic" true
+    (Mode_enforcer.classify_tool "bash" = Mode_enforcer.Shell_dynamic);
+  Alcotest.(check bool) "execute_shell_command is Shell_dynamic" true
+    (Mode_enforcer.classify_tool "execute_shell_command" = Mode_enforcer.Shell_dynamic);
   Alcotest.(check bool) "mcp__foo is External_effect" true
     (Mode_enforcer.classify_tool "mcp__foo__bar" = Mode_enforcer.External_effect);
   Alcotest.(check bool) "unknown is External_effect" true
     (Mode_enforcer.classify_tool "deploy_nuke" = Mode_enforcer.External_effect)
+
+let test_classify_via_registry_override () =
+  (* Register a custom tool classification *)
+  Mode_enforcer.register_tool_class "my_custom_tool" Mode_enforcer.Read_only;
+  Alcotest.(check bool) "custom tool is Read_only" true
+    (Mode_enforcer.classify_tool "my_custom_tool" = Mode_enforcer.Read_only);
+  (* Override an existing classification *)
+  Mode_enforcer.register_tool_class "bash" Mode_enforcer.Read_only;
+  Alcotest.(check bool) "overridden bash is Read_only" true
+    (Mode_enforcer.classify_tool "bash" = Mode_enforcer.Read_only);
+  (* Restore original *)
+  Mode_enforcer.register_tool_class "bash" Mode_enforcer.Shell_dynamic
+
+let test_tool_effect_class_of_string () =
+  Alcotest.(check bool) "read_only parses" true
+    (Mode_enforcer.tool_effect_class_of_string "read_only" = Some Mode_enforcer.Read_only);
+  Alcotest.(check bool) "workspace parses (compat)" true
+    (Mode_enforcer.tool_effect_class_of_string "workspace" = Some Mode_enforcer.Local_mutation);
+  Alcotest.(check bool) "workspace_mutating parses (compat)" true
+    (Mode_enforcer.tool_effect_class_of_string "workspace_mutating" = Some Mode_enforcer.Local_mutation);
+  Alcotest.(check bool) "local_mutation parses" true
+    (Mode_enforcer.tool_effect_class_of_string "local_mutation" = Some Mode_enforcer.Local_mutation);
+  Alcotest.(check bool) "external parses" true
+    (Mode_enforcer.tool_effect_class_of_string "external" = Some Mode_enforcer.External_effect);
+  Alcotest.(check bool) "external_effect parses" true
+    (Mode_enforcer.tool_effect_class_of_string "external_effect" = Some Mode_enforcer.External_effect);
+  Alcotest.(check bool) "shell_dynamic parses" true
+    (Mode_enforcer.tool_effect_class_of_string "shell_dynamic" = Some Mode_enforcer.Shell_dynamic);
+  Alcotest.(check bool) "unknown returns None" true
+    (Mode_enforcer.tool_effect_class_of_string "nonsense" = None)
+
+let test_shell_pattern_classification () =
+  (* bash ls -> read-only via shell analysis *)
+  let st = diagnose_enforcer () in
+  let h = Mode_enforcer.hooks st in
+  let input_ls = `Assoc ["command", `String "ls -la /tmp"] in
+  let d1 = Hooks.invoke h.pre_tool_use (make_enforcer_event "bash" input_ls) in
+  Alcotest.(check bool) "bash ls allowed in diagnose" true
+    (match d1 with Hooks.Continue -> true | _ -> false);
+  (* bash rm -> local mutation via shell analysis *)
+  let input_rm = `Assoc ["command", `String "rm -rf /tmp/foo"] in
+  let d2 = Hooks.invoke h.pre_tool_use (make_enforcer_event "bash" input_rm) in
+  Alcotest.(check bool) "bash rm blocked in diagnose" true
+    (match d2 with Hooks.Skip -> true | _ -> false);
+  (* bash curl -> external via shell analysis *)
+  let input_curl = `Assoc ["command", `String "curl https://example.com"] in
+  let d3 = Hooks.invoke h.pre_tool_use (make_enforcer_event "bash" input_curl) in
+  Alcotest.(check bool) "bash curl blocked in diagnose" true
+    (match d3 with Hooks.Skip -> true | _ -> false)
 
 (* ================================================================ *)
 (* Test runner                                                       *)
@@ -1058,5 +1109,8 @@ let () =
     ];
     "Tool classification", [
       Alcotest.test_case "known tools" `Quick test_classify_known_tools;
+      Alcotest.test_case "registry override" `Quick test_classify_via_registry_override;
+      Alcotest.test_case "tool_effect_class_of_string" `Quick test_tool_effect_class_of_string;
+      Alcotest.test_case "shell pattern classification" `Quick test_shell_pattern_classification;
     ];
   ]


### PR DESCRIPTION
## Summary
`mode_enforcer.ml` enforced CDAL boundaries with inline string lists and shell substring matching. This refactoring extracts them into structured, extensible data.

### Changes
- New `tool_effect_class` variant: `Read_only | Local_mutation | External_effect | Shell_dynamic`
- `default_tool_entries` declarative table replaces hardcoded match arms
- `Hashtbl`-based `tool_registry` with `register_tool_class` for runtime extension
- `shell_pattern_entries` structured list replaces separate mutating/external pattern lists
- Single-pass `classify_shell_command` with max-severity semantics
- Fail-closed preserved: unknown tools → `External_effect`

### Not changed (future work)
- `review_requirement` remains a warning (blocking requires broader pipeline changes)

## Test plan
- [x] 3 new tests: registry override, string parsing, shell classification
- [x] All existing CDAL tests pass
- [x] Full build passes

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)