### PR TITLE
feat(agent_tools): differentiate Exclusive_external batch with barrier semantics

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -16,6 +16,7 @@ type scheduled_tool_use = {
 type execution_batch =
   | Parallel_batch of scheduled_tool_use list
   | Sequential_batch of scheduled_tool_use
+  | Exclusive_batch of scheduled_tool_use
 
 let concurrency_class_to_string = function
   | Tool.Parallel_read -> "parallel_read"
@@ -64,19 +65,23 @@ let execution_batches tool_uses =
         match tool_use.concurrency_class with
         | Tool.Parallel_read ->
             build acc (tool_use :: current_parallel) rest
-        | Tool.Sequential_workspace | Tool.Exclusive_external ->
+        | Tool.Sequential_workspace ->
             let acc = flush_parallel acc current_parallel in
-            build (Sequential_batch tool_use :: acc) [] rest)
+            build (Sequential_batch tool_use :: acc) [] rest
+        | Tool.Exclusive_external ->
+            let acc = flush_parallel acc current_parallel in
+            build (Exclusive_batch tool_use :: acc) [] rest)
   in
   build [] [] tool_uses
 
-let hook_schedule_of_tool_use ~batch_index ~batch_size (tool_use : scheduled_tool_use)
-    : Hooks.tool_schedule =
+let hook_schedule_of_tool_use ~batch_index ~batch_size ~batch_kind
+    (tool_use : scheduled_tool_use) : Hooks.tool_schedule =
   {
     planned_index = tool_use.index;
     batch_index;
     batch_size;
     concurrency_class = concurrency_class_to_string tool_use.concurrency_class;
+    batch_kind;
   }
 
 let invoke_hook ?on_hook_invoked ~tracer ~agent_name ~turn_count ~hook_name
@@ -290,7 +295,14 @@ let execute_tools ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tracer
          match batch with
          | Sequential_batch tool_use ->
              let schedule =
-               hook_schedule_of_tool_use ~batch_index ~batch_size:1 tool_use
+               hook_schedule_of_tool_use ~batch_index ~batch_size:1
+                 ~batch_kind:"sequential" tool_use
+             in
+             [ run_one ~schedule tool_use ]
+         | Exclusive_batch tool_use ->
+             let schedule =
+               hook_schedule_of_tool_use ~batch_index ~batch_size:1
+                 ~batch_kind:"exclusive" tool_use
              in
              [ run_one ~schedule tool_use ]
          | Parallel_batch tool_uses ->
@@ -299,7 +311,7 @@ let execute_tools ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tracer
              |> List.map (fun tool_use ->
                     let schedule =
                       hook_schedule_of_tool_use ~batch_index ~batch_size
-                        tool_use
+                        ~batch_kind:"parallel" tool_use
                     in
                     (tool_use, schedule))
              |> Eio.Fiber.List.map (fun (tool_use, schedule) ->

--- a/lib/agent/agent_tools.mli
+++ b/lib/agent/agent_tools.mli
@@ -54,8 +54,11 @@ val find_and_execute_tool :
 
     Scheduling is deterministic:
     - [Tool.Parallel_read] blocks are executed together in a parallel batch.
-    - [Tool.Sequential_workspace] and [Tool.Exclusive_external] blocks run
-      one-at-a-time in input order.
+    - [Tool.Sequential_workspace] blocks run one-at-a-time in input order.
+    - [Tool.Exclusive_external] blocks flush all pending batches before
+      executing and run in complete isolation (no overlap with any other
+      tool call).  The schedule metadata carries [batch_kind = "exclusive"]
+      for audit purposes.
     - Tools without a declared descriptor default to sequential execution.
 
     For each [ToolUse] block, applies the [PreToolUse] hook before execution.

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -45,6 +45,7 @@ type tool_schedule = {
   batch_index: int;
   batch_size: int;
   concurrency_class: string;
+  batch_kind: string;
 }
 
 (** Extract reasoning summary from message list.

--- a/lib/hooks.mli
+++ b/lib/hooks.mli
@@ -25,12 +25,14 @@ type reasoning_summary = {
 val empty_reasoning_summary : reasoning_summary
 val extract_reasoning : Types.message list -> reasoning_summary
 
-(** Deterministic scheduling metadata attached to a tool execution plan. *)
+(** Deterministic scheduling metadata attached to a tool execution plan.
+    [batch_kind] is one of ["parallel"], ["sequential"], or ["exclusive"]. *)
 type tool_schedule = {
   planned_index: int;
   batch_index: int;
   batch_size: int;
   concurrency_class: string;
+  batch_kind: string;
 }
 
 (** Events emitted during agent execution *)

--- a/test/test_approval.ml
+++ b/test/test_approval.ml
@@ -340,6 +340,147 @@ let test_workspace_barrier_splits_parallel_read_batches () =
   | [ (_, "read_before", false); (_, "write_mid", false); (_, "read_after", false) ] -> ()
   | _ -> fail "workspace tool should form a sequential barrier between read batches"
 
+let test_exclusive_external_barrier_isolation () =
+  (* Exclusive_external tools must not overlap with any other tool.
+     Schedule: [read, workspace, exclusive, read_after]
+     Expected batches:
+       Parallel_batch [read]
+       Sequential_batch workspace
+       Exclusive_batch exclusive   (barrier: no overlap before or after)
+       Parallel_batch [read_after]
+     Overlap detection uses mutable flags checked at runtime. *)
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let any_running = ref false in
+  let exclusive_running = ref false in
+  let make_read_tool name =
+    make_echo_tool
+      ~descriptor:
+        (descriptor_with ~mutation_class:"read_only" Tool.Parallel_read)
+      name
+    |> fun tool ->
+    { tool with
+      Tool.handler =
+        Tool.Simple
+          (fun _ ->
+            if !exclusive_running then
+              failwith "read overlapped with exclusive";
+            any_running := true;
+            Eio.Time.sleep clock 0.02;
+            any_running := false;
+            Ok { Types.content = name }) }
+  in
+  let make_workspace_tool name =
+    make_echo_tool
+      ~descriptor:
+        (descriptor_with ~mutation_class:"workspace_mutating"
+           Tool.Sequential_workspace)
+      name
+    |> fun tool ->
+    { tool with
+      Tool.handler =
+        Tool.Simple
+          (fun _ ->
+            if !exclusive_running then
+              failwith "workspace overlapped with exclusive";
+            any_running := true;
+            Eio.Time.sleep clock 0.02;
+            any_running := false;
+            Ok { Types.content = name }) }
+  in
+  let make_exclusive_tool name =
+    make_echo_tool
+      ~descriptor:
+        (descriptor_with ~mutation_class:"external_effect"
+           Tool.Exclusive_external)
+      name
+    |> fun tool ->
+    { tool with
+      Tool.handler =
+        Tool.Simple
+          (fun _ ->
+            if !any_running then
+              failwith "exclusive overlapped with another tool";
+            exclusive_running := true;
+            Eio.Time.sleep clock 0.02;
+            exclusive_running := false;
+            Ok { Types.content = name }) }
+  in
+  let tools =
+    [
+      make_read_tool "read_first";
+      make_workspace_tool "write_mid";
+      make_exclusive_tool "ext_call";
+      make_read_tool "read_last";
+    ]
+  in
+  let results =
+    execute_with_tools_in_env env ~tools ~hooks:Hooks.empty
+      [
+        ToolUse { id = "t1"; name = "read_first"; input = `Null };
+        ToolUse { id = "t2"; name = "write_mid"; input = `Null };
+        ToolUse { id = "t3"; name = "ext_call"; input = `Null };
+        ToolUse { id = "t4"; name = "read_last"; input = `Null };
+      ]
+  in
+  match results with
+  | [ (_, "read_first", false);
+      (_, "write_mid", false);
+      (_, "ext_call", false);
+      (_, "read_last", false) ] -> ()
+  | _ -> fail "exclusive external tool must run in complete isolation"
+
+let test_exclusive_batch_kind_metadata () =
+  (* Verify the schedule.batch_kind field is "exclusive" for Exclusive_external
+     tools. Capture it via the PreToolUse hook. *)
+  Eio_main.run @@ fun env ->
+  let captured_kinds = ref [] in
+  let hooks =
+    { Hooks.empty with
+      pre_tool_use =
+        Some (fun event ->
+          (match event with
+          | Hooks.PreToolUse { tool_name; schedule; _ } ->
+            captured_kinds :=
+              (tool_name, schedule.batch_kind) :: !captured_kinds
+          | _ -> ());
+          Hooks.Continue) }
+  in
+  let read_tool =
+    make_echo_tool
+      ~descriptor:
+        (descriptor_with ~mutation_class:"read_only" Tool.Parallel_read)
+      "reader"
+  in
+  let seq_tool =
+    make_echo_tool
+      ~descriptor:
+        (descriptor_with ~mutation_class:"workspace_mutating"
+           Tool.Sequential_workspace)
+      "writer"
+  in
+  let excl_tool =
+    make_echo_tool
+      ~descriptor:
+        (descriptor_with ~mutation_class:"external_effect"
+           Tool.Exclusive_external)
+      "ext"
+  in
+  let _results =
+    execute_with_tools_in_env env
+      ~tools:[ read_tool; seq_tool; excl_tool ]
+      ~hooks
+      [
+        ToolUse { id = "t1"; name = "reader"; input = `Null };
+        ToolUse { id = "t2"; name = "writer"; input = `Null };
+        ToolUse { id = "t3"; name = "ext"; input = `Null };
+      ]
+  in
+  let kinds = List.rev !captured_kinds in
+  check (list (pair string string)) "batch_kind metadata"
+    [ ("reader", "parallel"); ("writer", "sequential"); ("ext", "exclusive") ]
+    kinds
+
 let () =
   run "Approval" [
     "approval_required", [
@@ -363,5 +504,9 @@ let () =
         test_undeclared_tools_default_to_sequential;
       test_case "workspace barrier splits read batches" `Quick
         test_workspace_barrier_splits_parallel_read_batches;
+      test_case "exclusive external barrier isolation (#589)" `Quick
+        test_exclusive_external_barrier_isolation;
+      test_case "exclusive batch_kind metadata (#589)" `Quick
+        test_exclusive_batch_kind_metadata;
     ];
   ]

--- a/test/test_cdal.ml
+++ b/test/test_cdal.ml
@@ -99,8 +99,8 @@ let test_caps : Cdal_proof.capability_snapshot = {
 }
 
 let default_schedule ?(planned_index = 0) ?(batch_index = 0) ?(batch_size = 1)
-    ?(concurrency_class = "sequential_workspace") () =
-  Hooks.{ planned_index; batch_index; batch_size; concurrency_class }
+    ?(concurrency_class = "sequential_workspace") ?(batch_kind = "sequential") () =
+  Hooks.{ planned_index; batch_index; batch_size; concurrency_class; batch_kind }
 
 let test_mode_resolver_passthrough () =
   let result = Mode_resolver.resolve

--- a/test/test_hooks.ml
+++ b/test/test_hooks.ml
@@ -4,8 +4,8 @@ open Alcotest
 open Agent_sdk
 
 let default_schedule ?(planned_index = 0) ?(batch_index = 0) ?(batch_size = 1)
-    ?(concurrency_class = "sequential_workspace") () =
-  Hooks.{ planned_index; batch_index; batch_size; concurrency_class }
+    ?(concurrency_class = "sequential_workspace") ?(batch_kind = "sequential") () =
+  Hooks.{ planned_index; batch_index; batch_size; concurrency_class; batch_kind }
 
 let test_empty_hooks () =
   let hooks = Hooks.empty in


### PR DESCRIPTION
## Summary
`execution_batches` treated `Exclusive_external` and `Sequential_workspace` identically. Now `Exclusive_external` gets its own `Exclusive_batch` variant with barrier isolation.

### Changes
- `Exclusive_batch` variant in batch type — flushes all pending batches before executing
- `batch_kind` field added to `Hooks.tool_schedule`: `"parallel"` / `"sequential"` / `"exclusive"`
- Barrier test proves no temporal overlap between exclusive and other tools
- Metadata test verifies `batch_kind` values in PreToolUse hook

## Test plan
- [x] 2 new tests: barrier isolation + batch_kind metadata
- [x] All 14 approval tests pass
- [x] Full build passes

Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)