### PR TITLE
feat(constants): add Inference_profile SSOT for inference defaults

### DIFF
--- a/lib/llm_provider/constants.ml
+++ b/lib/llm_provider/constants.ml
@@ -18,11 +18,32 @@ module Http = struct
   let cascadable_codes = [401; 403; 429; 500; 502; 503; 529]
 end
 
-(* ── Inference defaults ──────────────────────────── *)
+(* ── Inference profiles ─────────────────────────── *)
 
+(** Named inference parameter profiles.  Single source of truth for
+    temperature / max_tokens defaults used by both the SDK and
+    downstream coordinators (e.g. MASC).
+
+    - [cascade_default]: lightweight cascade calls (health, routing).
+    - [agent_default]: full agent turn execution.
+    - [low_variance]: evaluation, judging, deterministic extraction. *)
+module Inference_profile = struct
+  type t = {
+    temperature : float;
+    max_tokens : int;
+  }
+
+  let cascade_default = { temperature = 0.3; max_tokens = 500 }
+  let agent_default   = { temperature = 0.7; max_tokens = 4096 }
+  let low_variance    = { temperature = 0.1; max_tokens = 2048 }
+end
+
+(** Backward-compatible aliases — existing callers of
+    [Constants.Inference.default_temperature] continue to compile.
+    New code should prefer {!Inference_profile}. *)
 module Inference = struct
-  let default_temperature = 0.3
-  let default_max_tokens = 500
+  let default_temperature = Inference_profile.cascade_default.temperature
+  let default_max_tokens  = Inference_profile.cascade_default.max_tokens
 end
 
 (* ── Cache ───────────────────────────────────────── *)


### PR DESCRIPTION
## Summary
- `Constants.Inference_profile` 모듈 추가: `cascade_default`, `agent_default`, `low_variance` 3개 프로파일
- 기존 `Constants.Inference` 모듈은 `cascade_default`의 alias로 유지 (역호환)
- MASC가 자체 `default_temperature=0.7 / default_max_tokens=4096`를 유지하는 대신 OAS의 `agent_default`를 참조할 수 있도록 함

## Context
Det/NonDet 경계 재정립 작업의 Phase 1. 추론 기본값의 이중 정의(OAS: 0.3/500, MASC: 0.7/4096)를 단일 SSOT로 통합.

## Test plan
- [x] `dune build` 성공 (순수 추가, 기존 API 변경 없음)
- [ ] `dune test` 전체 통과 확인
- [ ] MASC 측 후속 PR에서 참조 교체 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)