### PR TITLE
feat: add shared inference contract to model spec

### DIFF
--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -42,7 +42,6 @@ type model_spec = {
   provider: provider;
   model_id: string;
   api_key_env: string;
-  inference_contract: inference_contract;
   request_kind: request_kind;
   request_path: string;
   capabilities: capabilities;
@@ -93,7 +92,7 @@ let task_of_model_id model_id =
   else if has "imagegen" || has "image-gen" || has "gpt-image" || has "cogview"
           || has "seedream" || has "flux" then
     Some "image_generation"
-  else if has "video-gen" || has "video" || has "veo" || has "kling" then
+  else if has "video-gen" || has "veo" || has "kling" || has "sora" || has "wan" then
     Some "video_generation"
   else
     None
@@ -181,15 +180,6 @@ let request_path = function
 let capabilities_for_config (cfg : config) =
   capabilities_for_model ~provider:cfg.provider ~model_id:cfg.model_id
 
-let inference_contract_of_config (cfg : config) =
-  let capabilities = capabilities_for_config cfg in
-  {
-    provider = cfg.provider;
-    model_id = cfg.model_id;
-    modality = modality_of_capabilities capabilities;
-    task = task_of_model_id cfg.model_id;
-  }
-
 let validate_inference_contract ~capabilities (contract : inference_contract) =
   if modality_supported capabilities contract.modality then Ok ()
   else
@@ -202,17 +192,44 @@ let validate_inference_contract ~capabilities (contract : inference_contract) =
           (modality_to_string contract.modality);
     }))
 
+let build_inference_contract ~provider ~model_id ~(capabilities : capabilities) =
+  let contract = {
+    provider;
+    model_id;
+    modality = modality_of_capabilities capabilities;
+    task = task_of_model_id model_id;
+  } in
+  match validate_inference_contract ~capabilities contract with
+  | Ok () -> contract
+  | Error err ->
+    invalid_arg
+      ("BUG: inferred invalid inference contract: " ^ Error.to_string err)
+
+let inference_contract_of_model_spec (spec : model_spec) =
+  build_inference_contract
+    ~provider:spec.provider
+    ~model_id:spec.model_id
+    ~capabilities:spec.capabilities
+
+let inference_contract_of_config (cfg : config) =
+  let capabilities = capabilities_for_config cfg in
+  build_inference_contract
+    ~provider:cfg.provider
+    ~model_id:cfg.model_id
+    ~capabilities
+
 let model_spec_of_config (cfg : config) =
   let capabilities = capabilities_for_config cfg in
-  {
+  let spec = {
     provider = cfg.provider;
     model_id = cfg.model_id;
     api_key_env = cfg.api_key_env;
-    inference_contract = inference_contract_of_config cfg;
     request_kind = request_kind cfg.provider;
     request_path = request_path cfg.provider;
     capabilities;
-  }
+  } in
+  let _ = inference_contract_of_model_spec spec in
+  spec
 
 let resolve (cfg : config) =
   match cfg.provider with

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -67,7 +67,6 @@ type model_spec = {
   provider: provider;
   model_id: string;
   api_key_env: string;
-  inference_contract: inference_contract;
   request_kind: request_kind;
   request_path: string;
   capabilities: capabilities;
@@ -80,6 +79,7 @@ val modality_of_capabilities : capabilities -> modality
 val default_capabilities : capabilities
 val capabilities_for_model : provider:provider -> model_id:string -> capabilities
 val capabilities_for_config : config -> capabilities
+val inference_contract_of_model_spec : model_spec -> inference_contract
 val inference_contract_of_config : config -> inference_contract
 val validate_inference_contract :
   capabilities:capabilities ->

--- a/test/test_custom_provider.ml
+++ b/test/test_custom_provider.ml
@@ -144,12 +144,13 @@ let test_model_spec_registered () =
   Provider.register_provider impl;
   let cfg = Provider.custom_provider ~name:"spec-test" ~model_id:"my-model" () in
   let spec = Provider.model_spec_of_config cfg in
+  let contract = Provider.inference_contract_of_config cfg in
   Alcotest.(check string) "request_path" "/v1/custom" spec.request_path;
   Alcotest.(check string) "model_id" "my-model" spec.model_id;
   Alcotest.(check string) "contract modality" "text"
-    (Provider.modality_to_string spec.inference_contract.modality);
+    (Provider.modality_to_string contract.modality);
   Alcotest.(check (option string)) "contract task" None
-    spec.inference_contract.task;
+    contract.task;
   Alcotest.(check bool) "supports_tools" true spec.capabilities.supports_tools
 
 (* ── provider_runtime_name ──────────────────────────────── *)

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -139,15 +139,18 @@ let test_model_spec_local_llm_capabilities () =
   Alcotest.(check bool) "supports tools" true spec.capabilities.supports_tools
 
 let test_model_spec_openrouter_capabilities () =
+  let cfg = Provider.openrouter ~model_id:"anthropic/claude-sonnet-4-6" () in
   let spec =
-    Provider.model_spec_of_config
-      (Provider.openrouter ~model_id:"anthropic/claude-sonnet-4-6" ())
+    Provider.model_spec_of_config cfg
+  in
+  let contract =
+    Provider.inference_contract_of_config cfg
   in
   Alcotest.(check string) "request path" "/chat/completions" spec.request_path;
   Alcotest.(check string) "contract modality" "multimodal"
-    (Provider.modality_to_string spec.inference_contract.modality);
+    (Provider.modality_to_string contract.modality);
   Alcotest.(check (option string)) "contract task" None
-    spec.inference_contract.task;
+    contract.task;
   Alcotest.(check bool) "supports tools" true spec.capabilities.supports_tools;
   Alcotest.(check bool) "supports reasoning" false
     spec.capabilities.supports_reasoning;
@@ -166,6 +169,27 @@ let test_inference_contract_local_qwen () =
   Alcotest.(check string) "modality" "text"
     (Provider.modality_to_string contract.modality);
   Alcotest.(check (option string)) "task" None contract.task
+
+let test_inference_contract_anthropic_multimodal () =
+  let contract =
+    Provider.inference_contract_of_config (Provider.anthropic_sonnet ())
+  in
+  Alcotest.(check string) "modality" "multimodal"
+    (Provider.modality_to_string contract.modality)
+
+let test_inference_contract_task_transcription () =
+  let cfg : Provider.config = {
+    provider = OpenAICompat {
+      base_url = "https://api.openai.com/v1";
+      auth_header = Some "Authorization";
+      path = "/audio/transcriptions";
+      static_token = None;
+    };
+    model_id = "whisper-1";
+    api_key_env = "OPENAI_API_KEY";
+  } in
+  let contract = Provider.inference_contract_of_config cfg in
+  Alcotest.(check (option string)) "task" (Some "transcription") contract.task
 
 let test_validate_inference_contract_rejects_unsupported_modality () =
   let cfg : Provider.config = {
@@ -296,6 +320,10 @@ let () =
         test_model_spec_openrouter_capabilities;
       Alcotest.test_case "inference contract local qwen" `Quick
         test_inference_contract_local_qwen;
+      Alcotest.test_case "inference contract anthropic multimodal" `Quick
+        test_inference_contract_anthropic_multimodal;
+      Alcotest.test_case "task inference transcription" `Quick
+        test_inference_contract_task_transcription;
       Alcotest.test_case "invalid modality gets actionable error" `Quick
         test_validate_inference_contract_rejects_unsupported_modality;
       Alcotest.test_case "extended openai capabilities" `Quick


### PR DESCRIPTION
## Summary
- add a shared inference contract to `Provider.model_spec` with `provider`, `model_id`, `modality`, and optional `task`
- infer contract metadata from provider capabilities while preserving existing `model_spec_of_config` callers
- expose validation helpers that return actionable `InvalidConfig` errors for unsupported modality combinations

## Why
- routing across text, image, audio, and video paths was too implicit in provider-level fields alone
- this creates a migration-safe contract that request/response boundaries can share incrementally

## Validation
- `dune build --root . @all`
- `./_build/default/test/test_provider.exe`
- `./_build/default/test/test_custom_provider.exe`

Refs #606