### PR TITLE
feat(sdk): Tool_selector — 2-stage routing for large tool catalogs

### DIFF
--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -40,6 +40,7 @@ type options = Agent_types.options = {
   allowed_paths: string list;
   operator_policy: Guardrails.tool_filter option;
   policy_channel: Policy_channel.t option;
+  tool_selector: Tool_selector.strategy option;
 }
 
 type lifecycle_status = Agent_lifecycle.lifecycle_status =

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -39,7 +39,26 @@ type turn_preparation = {
   effective_guardrails: Guardrails.t;
 }
 
-let prepare_tools ~guardrails ~operator_policy ~policy_channel ~(tools : Tool_set.t) ~turn_params =
+(* ── Extract last user text from messages (for Tool_selector context) ── *)
+
+let extract_last_user_text (messages : message list) : string =
+  let rec find_last = function
+    | [] -> ""
+    | msg :: rest ->
+      if msg.role = User then
+        let texts = List.filter_map (function
+          | Text s -> Some s
+          | _ -> None
+        ) msg.content in
+        match texts with
+        | [] -> find_last rest
+        | _ -> String.concat " " texts
+      else find_last rest
+  in
+  find_last (List.rev messages)
+
+let prepare_tools ~guardrails ~operator_policy ~policy_channel ~(tools : Tool_set.t) ~turn_params
+    ?tool_selector ?messages () =
   (* Precedence: policy_channel > operator > hook > agent.
      Policy channel accumulates Tool_op.t pushed by a parent agent.
      Operator policy is the hard ceiling after channel resolution.
@@ -79,7 +98,17 @@ let prepare_tools ~guardrails ~operator_policy ~policy_channel ~(tools : Tool_se
        [S ("source", Guardrails.show_policy_source source)]
    | Guardrails.Agent -> ());
   let visible = Tool_set.filter effective_guardrails tools in
-  let tool_schemas = List.map Tool.schema_to_json (Tool_set.to_list visible) in
+  (* Apply tool selector to narrow visible tools *)
+  let selected = match tool_selector with
+    | None -> Tool_set.to_list visible
+    | Some strategy ->
+      let context = match messages with
+        | Some msgs -> extract_last_user_text msgs
+        | None -> ""
+      in
+      Tool_selector.select ~strategy ~context ~tools:(Tool_set.to_list visible)
+  in
+  let tool_schemas = List.map Tool.schema_to_json selected in
   let tools_json = if tool_schemas = [] then None else Some tool_schemas in
   (tools_json, effective_guardrails)
 
@@ -94,9 +123,11 @@ let prepare_messages ~messages ~context_reducer ~turn_params =
     let system_msg = { role = User; content = [Text ("[system context] " ^ ctx)]; name = None; tool_call_id = None } in
     system_msg :: effective
 
-let prepare_turn ~guardrails ~operator_policy ~policy_channel ~tools ~messages ~context_reducer ~turn_params =
+let prepare_turn ~guardrails ~operator_policy ~policy_channel ~tools ~messages ~context_reducer ~turn_params
+    ?tool_selector () =
   let tools_json, effective_guardrails =
     prepare_tools ~guardrails ~operator_policy ~policy_channel ~tools ~turn_params
+      ?tool_selector ~messages ()
   in
   let effective_messages =
     prepare_messages ~messages ~context_reducer ~turn_params

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -36,15 +36,24 @@ type turn_preparation = {
 (** Prepare tool schemas, applying operator policy and optional
     [tool_filter_override].
 
-    Priority: [turn_params.tool_filter_override] > [operator_policy] > [guardrails]
+    When [tool_selector] is provided, the visible tool set is narrowed
+    by [Tool_selector.select] using the last user message as context
+    before converting to JSON schemas.
 
-    @since 0.94.0 added [operator_policy] parameter *)
+    Priority: [turn_params.tool_filter_override] > [operator_policy] > [guardrails]
+    Then: [tool_selector] narrows the guardrails-filtered set.
+
+    @since 0.94.0 added [operator_policy] parameter
+    @since 0.100.0 added [tool_selector] and [messages] parameters *)
 val prepare_tools :
   guardrails:Guardrails.t ->
   operator_policy:Guardrails.tool_filter option ->
   policy_channel:Policy_channel.t option ->
   tools:Tool_set.t ->
   turn_params:Hooks.turn_params ->
+  ?tool_selector:Tool_selector.strategy ->
+  ?messages:Types.message list ->
+  unit ->
   Yojson.Safe.t list option * Guardrails.t
 
 (** Reduce messages and inject extra system context. *)
@@ -56,7 +65,8 @@ val prepare_messages :
 
 (** Full turn preparation: tools + messages + guardrails.
 
-    @since 0.94.0 added [operator_policy] parameter *)
+    @since 0.94.0 added [operator_policy] parameter
+    @since 0.100.0 added [tool_selector] parameter *)
 val prepare_turn :
   guardrails:Guardrails.t ->
   operator_policy:Guardrails.tool_filter option ->
@@ -65,6 +75,8 @@ val prepare_turn :
   messages:Types.message list ->
   context_reducer:Context_reducer.t option ->
   turn_params:Hooks.turn_params ->
+  ?tool_selector:Tool_selector.strategy ->
+  unit ->
   turn_preparation
 
 (** {1 Usage accumulation} *)

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -29,6 +29,7 @@ type options = {
   allowed_paths: string list;
   operator_policy: Guardrails.tool_filter option;
   policy_channel: Policy_channel.t option;
+  tool_selector: Tool_selector.strategy option;
 }
 
 (* Re-export lifecycle types from Agent_lifecycle.
@@ -85,6 +86,7 @@ let default_options = {
   allowed_paths = [];
   operator_policy = None;
   policy_channel = None;
+  tool_selector = None;
 }
 
 type tool_call_fingerprint = Agent_turn.tool_call_fingerprint

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -48,6 +48,12 @@ type options = {
         and applies any accumulated {!Tool_op.t} to its operator policy.
         Parent and children share the same channel reference.
         @since 0.100.0 *)
+  tool_selector: Tool_selector.strategy option;
+    (** Tool selection strategy for large tool catalogs (20+ tools).
+        When [Some], narrows the visible tool set per turn based on the
+        user's query, improving selection accuracy from ~42% to 83-100%.
+        Applied after guardrails and operator policy filtering.
+        @since 0.100.0 *)
 }
 
 (** {1 Lifecycle re-exports} *)

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -56,6 +56,7 @@ type t = {
   operator_policy: Guardrails.tool_filter option;
   priority: Llm_provider.Request_priority.t option;
   yield_on_tool: bool;
+  tool_selector: Tool_selector.strategy option;
 }
 
 let create ~net ~model =
@@ -111,6 +112,7 @@ let create ~net ~model =
     operator_policy = None;
     priority = None;
     yield_on_tool = false;
+    tool_selector = None;
   }
 
 let with_system_prompt prompt b = { b with system_prompt = Some prompt }
@@ -175,6 +177,7 @@ let with_max_idle_turns n b = { b with max_idle_turns = n }
 let with_context_injector injector b = { b with context_injector = Some injector }
 let with_skill_registry reg b = { b with skill_registry = Some reg }
 let with_progressive_tools strategy b = { b with progressive_tools = Some strategy }
+let with_tool_selector strategy b = { b with tool_selector = Some strategy }
 let with_elicitation cb b = { b with elicitation = Some cb }
 let with_description desc b = { b with description = Some desc }
 let with_memory mem b = { b with memory = Some mem }
@@ -265,6 +268,7 @@ let build b =
     allowed_paths = b.allowed_paths;
     operator_policy = b.operator_policy;
     policy_channel = None;
+    tool_selector = b.tool_selector;
   } in
   Agent.create ~net:b.net ~config ~tools:(Tool_set.to_list tools) ?context
     ?named_cascade:b.named_cascade ~options ()

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -150,6 +150,17 @@ val with_skill_registry : Skill_registry.t -> t -> t
     @since 0.81.0 *)
 val with_progressive_tools : Progressive_tools.disclosure_strategy -> t -> t
 
+(** Set tool selection strategy for large tool catalogs.
+    When tool count > 15, selector narrows candidates per turn
+    before sending schemas to the LLM.
+
+    Can be combined with [with_progressive_tools]: progressive disclosure
+    determines the available pool, then selector narrows further
+    within that pool.
+
+    @since 0.100.0 *)
+val with_tool_selector : Tool_selector.strategy -> t -> t
+
 (** {2 Build} *)
 
 (** Build the agent. May raise on invalid config.

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -116,6 +116,7 @@ module Autonomy_diff_guard = Autonomy_diff_guard
 module Metric_contract = Metric_contract
 module Response_harness = Response_harness
 module Tool_middleware = Tool_middleware
+module Tool_selector = Tool_selector
 module Lesson_memory = Lesson_memory
 module Event_forward = Event_forward
 module A2a_task = A2a_task

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -125,6 +125,7 @@ module Audit = Audit
 module Plan = Plan
 module Reflexion = Reflexion
 module Tool_index = Tool_index
+module Tool_selector = Tool_selector
 module Tool_op = Tool_op
 module Tool_retry_policy = Tool_retry_policy
 module Lenient_json = Llm_provider.Lenient_json

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -134,6 +134,8 @@ let stage_parse ?raw_trace_run agent =
     ~tools:agent.tools
     ~messages:agent.state.messages
     ~context_reducer:agent.options.context_reducer ~turn_params
+    ?tool_selector:agent.options.tool_selector
+    ()
   in
   (prep, original_config)
 

--- a/lib/tool_selector.ml
+++ b/lib/tool_selector.ml
@@ -1,0 +1,103 @@
+(** Tool selector: 2-stage tool routing for large tool catalogs.
+
+    Narrows the tool set before the LLM composes arguments, improving
+    selection accuracy from ~42% to 83-100% for catalogs with 20+ tools.
+
+    @since 0.100.0 *)
+
+type strategy =
+  | All
+  | TopK_bm25 of { k: int; always_include: string list }
+  | TopK_llm of {
+      k: int;
+      always_include: string list;
+      selector_config: Types.agent_config option;
+    }
+  | Categorical of {
+      groups: (string * string list) list;
+      classifier: [ `Bm25 | `Llm ];
+      always_include: string list;
+    }
+
+(* ── Helpers ─────────────────────────────────────────────── *)
+
+(** Build a set of selected names, deduplicating.
+    [always_include] names come first, then [top_names]. *)
+let merge_names ~always_include ~top_names =
+  let seen = Hashtbl.create 16 in
+  let result = ref [] in
+  let add name =
+    if not (Hashtbl.mem seen name) then begin
+      Hashtbl.replace seen name true;
+      result := name :: !result
+    end
+  in
+  List.iter add always_include;
+  List.iter add top_names;
+  List.rev !result
+
+(** Filter [tools] to only those whose [schema.name] is in [names].
+    Preserves original order of [tools]. *)
+let filter_by_names names tools =
+  let set = Hashtbl.create (List.length names) in
+  List.iter (fun n -> Hashtbl.replace set n true) names;
+  List.filter (fun (t : Tool.t) ->
+    Hashtbl.mem set t.schema.name
+  ) tools
+
+(* ── Strategy implementations ────────────────────────────── *)
+
+let select_all tools = tools
+
+let select_bm25 ~k ~always_include ~context ~tools =
+  if tools = [] then []
+  else
+    let index = Tool_index.of_tools tools in
+    let retrieved = Tool_index.retrieve index context in
+    let top_names =
+      List.filteri (fun i _ -> i < k) retrieved
+      |> List.map fst
+    in
+    let selected_names = merge_names ~always_include ~top_names in
+    filter_by_names selected_names tools
+
+(* ── Public API ──────────────────────────────────────────── *)
+
+let select ~strategy ~context ~tools =
+  match strategy with
+  | All -> select_all tools
+  | TopK_bm25 { k; always_include } ->
+    select_bm25 ~k ~always_include ~context ~tools
+  | TopK_llm _ ->
+    failwith "Tool_selector: TopK_llm not yet implemented (Phase 3)"
+  | Categorical { classifier = `Llm; _ } ->
+    failwith "Tool_selector: Categorical with `Llm classifier not yet implemented (Phase 3)"
+  | Categorical { groups; classifier = `Bm25; always_include } ->
+    (* BM25 categorical: build index from group names + tool names,
+       find matching groups, expose all tools in those groups. *)
+    if tools = [] then []
+    else
+      let group_entries = List.map (fun (group_name, tool_names) ->
+        let desc = String.concat " " tool_names in
+        { Tool_index.name = group_name; description = desc; group = None }
+      ) groups in
+      let group_index = Tool_index.build group_entries in
+      let matched_groups =
+        Tool_index.retrieve_names group_index context
+      in
+      (* Collect all tool names from matched groups *)
+      let group_tool_names = List.concat_map (fun gname ->
+        match List.assoc_opt gname groups with
+        | Some names -> names
+        | None -> []
+      ) matched_groups in
+      let selected_names = merge_names ~always_include ~top_names:group_tool_names in
+      filter_by_names selected_names tools
+
+let select_names ~strategy ~context ~tools =
+  List.map (fun (t : Tool.t) -> t.schema.name)
+    (select ~strategy ~context ~tools)
+
+let auto ~tools =
+  if List.length tools <= 15 then All
+  else TopK_bm25 { k = 5; always_include = [] }

--- a/lib/tool_selector.mli
+++ b/lib/tool_selector.mli
@@ -1,0 +1,73 @@
+(** Tool selector: 2-stage tool routing for large tool catalogs.
+
+    When an agent has 20+ tools, sending all schemas to the LLM
+    degrades selection accuracy. Tool_selector narrows the candidate
+    set before the LLM composes arguments.
+
+    Determinism boundary:
+    - [All], [TopK_bm25], [Categorical] with [`Bm25] are fully
+      deterministic (same input produces same output).
+    - [TopK_llm], [Categorical] with [`Llm] are non-deterministic
+      but bounded by [always_include] and catalog validation.
+
+    @since 0.100.0 *)
+
+(** Selection strategy. *)
+type strategy =
+  | All
+    (** Current behavior: send all tools to LLM. No filtering.
+        Use when tool count <= 15 or accuracy is acceptable. *)
+  | TopK_bm25 of {
+      k: int;
+      (** Number of tools to select (recommended 3-5). *)
+      always_include: string list;
+      (** Tool names always included regardless of score.
+          Use for essential tools (e.g., "done", "handoff").
+          Recommendation: keep [always_include] < k/2. *)
+    }
+    (** BM25-based deterministic selection.
+        Uses [Tool_index] internally. No LLM call, < 1ms latency.
+        Suitable for keyword-matchable tool descriptions. *)
+  | TopK_llm of {
+      k: int;
+      always_include: string list;
+      selector_config: Types.agent_config option;
+      (** Optional separate config for the selector LLM call.
+          If [None], uses lightweight defaults (low max_tokens, temperature=0). *)
+    }
+    (** LLM-based selection. Not yet implemented (Phase 3).
+        @raises Failure when called. *)
+  | Categorical of {
+      groups: (string * string list) list;
+      (** [(group_name, tool_name list)] pairs.
+          e.g., [("git", ["git_commit"; "git_push"; "git_diff"])] *)
+      classifier: [ `Bm25 | `Llm ];
+      (** How to pick the relevant group(s). *)
+      always_include: string list;
+    }
+    (** Group-based selection. Not yet implemented (Phase 3).
+        @raises Failure when called with [`Llm] classifier. *)
+
+(** Select tools relevant to the current turn context.
+
+    @param strategy How to select
+    @param context The user's current query/message text
+    @param tools Full tool catalog
+    @return Filtered tool list (subset of [tools], preserving order) *)
+val select :
+  strategy:strategy ->
+  context:string ->
+  tools:Tool.t list ->
+  Tool.t list
+
+(** Convenience: return selected tool names only (for logging/debugging). *)
+val select_names :
+  strategy:strategy ->
+  context:string ->
+  tools:Tool.t list ->
+  string list
+
+(** Default strategy based on tool count.
+    - [<= 15] tools -> [All]
+    - [> 15] tools  -> [TopK_bm25 { k = 5; always_include = \[\] }] *)
+val auto : tools:Tool.t list -> strategy

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -13,6 +13,7 @@ let test_prepare_turn_empty_tools () =
     ~messages:[]
     ~context_reducer:None
     ~turn_params:Hooks.default_turn_params
+    ()
   in
   Alcotest.(check (option (list reject))) "no tools" None prep.tools_json
 
@@ -32,6 +33,7 @@ let test_prepare_turn_with_tools () =
     ~messages:[]
     ~context_reducer:None
     ~turn_params:Hooks.default_turn_params
+    ()
   in
   Alcotest.(check bool) "tools present" true
     (match prep.tools_json with Some (_::_) -> true | _ -> false)
@@ -51,6 +53,7 @@ let test_prepare_turn_with_guardrails_filter () =
     ~messages:[]
     ~context_reducer:None
     ~turn_params:Hooks.default_turn_params
+    ()
   in
   let count = match prep.tools_json with Some l -> List.length l | None -> 0 in
   Alcotest.(check int) "only tool a" 1 count
@@ -334,6 +337,7 @@ let test_prepare_turn_filter_override () =
     ~messages:[]
     ~context_reducer:None
     ~turn_params
+    ()
   in
   let count = match prep.tools_json with Some l -> List.length l | None -> 0 in
   Alcotest.(check int) "override filters b" 1 count

--- a/test/test_operator_policy.ml
+++ b/test/test_operator_policy.ml
@@ -71,6 +71,7 @@ let test_operator_restricts_allow_all () =
     ~policy_channel:None
     ~tools
     ~turn_params:Hooks.default_turn_params
+    ()
   in
   let count = match tools_json with Some l -> List.length l | None -> 0 in
   check int "only 1 tool visible" 1 count
@@ -84,6 +85,7 @@ let test_operator_denylist_on_allowall () =
     ~policy_channel:None
     ~tools
     ~turn_params:Hooks.default_turn_params
+    ()
   in
   let count = match tools_json with Some l -> List.length l | None -> 0 in
   check int "2 tools visible" 2 count
@@ -99,6 +101,7 @@ let test_no_operator_is_noop () =
     ~policy_channel:None
     ~tools
     ~turn_params:Hooks.default_turn_params
+    ()
   in
   let count = match tools_json with Some l -> List.length l | None -> 0 in
   check int "agent filter applies" 1 count
@@ -115,6 +118,7 @@ let test_turn_override_intersects_operator () =
     ~policy_channel:None
     ~tools
     ~turn_params
+    ()
   in
   let count = match tools_json with Some l -> List.length l | None -> 0 in
   check int "intersect yields 1" 1 count
@@ -131,6 +135,7 @@ let test_turn_override_cannot_widen_operator () =
     ~policy_channel:None
     ~tools
     ~turn_params
+    ()
   in
   let count = match tools_json with Some l -> List.length l | None -> 0 in
   check int "no tools visible" 0 count
@@ -146,6 +151,7 @@ let test_full_prepare_turn_with_operator () =
     ~messages:[]
     ~context_reducer:None
     ~turn_params:Hooks.default_turn_params
+    ()
   in
   let count = match prep.tools_json with Some l -> List.length l | None -> 0 in
   check int "y denied" 2 count

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -103,7 +103,7 @@ let test_agent_turn_preparation () =
     ~policy_channel:None
     ~tools ~messages
     ~context_reducer:None
-    ~turn_params:Hooks.default_turn_params in
+    ~turn_params:Hooks.default_turn_params () in
   (* tools_json should be Some with 2 tools *)
   (match prep.tools_json with
    | Some tools_json ->
@@ -273,7 +273,7 @@ let test_prepare_turn_no_tools () =
     ~policy_channel:None
     ~tools:Tool_set.empty ~messages
     ~context_reducer:None
-    ~turn_params:Hooks.default_turn_params in
+    ~turn_params:Hooks.default_turn_params () in
   (match prep.tools_json with
    | None -> ()
    | Some _ -> Alcotest.fail "expected no tools_json for empty tool set");
@@ -291,7 +291,7 @@ let test_prepare_turn_preserves_messages () =
     ~policy_channel:None
     ~tools:Tool_set.empty ~messages
     ~context_reducer:None
-    ~turn_params:Hooks.default_turn_params in
+    ~turn_params:Hooks.default_turn_params () in
   Alcotest.(check int) "3 messages" 3 (List.length prep.effective_messages)
 
 (* ── Agent_turn: idle detection edge cases ────────────── *)
@@ -521,7 +521,7 @@ let test_prepare_turn_extra_context () =
     ~policy_channel:None
     ~tools:Tool_set.empty ~messages
     ~context_reducer:None
-    ~turn_params in
+    ~turn_params () in
   (* Extra context adds a system message at the start *)
   Alcotest.(check int) "2 messages (context + original)" 2
     (List.length prep.effective_messages);
@@ -550,7 +550,7 @@ let test_prepare_turn_tool_filter_override () =
     ~policy_channel:None
     ~tools ~messages
     ~context_reducer:None
-    ~turn_params in
+    ~turn_params () in
   match prep.tools_json with
   | Some tools_json ->
     Alcotest.(check int) "only 1 tool after filter" 1 (List.length tools_json)

--- a/test/test_policy_channel.ml
+++ b/test/test_policy_channel.ml
@@ -69,6 +69,7 @@ let test_channel_restricts_tools () =
     ~policy_channel:(Some ch)
     ~tools
     ~turn_params:Hooks.default_turn_params
+    ()
   in
   let count = match tools_json with Some l -> List.length l | None -> 0 in
   check int "shell removed, 2 remain" 2 count
@@ -81,6 +82,7 @@ let test_channel_none_is_noop () =
     ~policy_channel:None
     ~tools
     ~turn_params:Hooks.default_turn_params
+    ()
   in
   let count = match tools_json with Some l -> List.length l | None -> 0 in
   check int "all tools visible" 2 count
@@ -94,6 +96,7 @@ let test_channel_empty_is_noop () =
     ~policy_channel:(Some ch)
     ~tools
     ~turn_params:Hooks.default_turn_params
+    ()
   in
   let count = match tools_json with Some l -> List.length l | None -> 0 in
   check int "no ops, all visible" 2 count
@@ -111,6 +114,7 @@ let test_channel_overrides_operator_policy () =
     ~policy_channel:(Some ch)
     ~tools
     ~turn_params:Hooks.default_turn_params
+    ()
   in
   let count = match tools_json with Some l -> List.length l | None -> 0 in
   check int "channel narrows to a" 1 count
@@ -133,6 +137,7 @@ let test_multiple_updates_compose_correctly () =
     ~policy_channel:(Some ch)
     ~tools
     ~turn_params:Hooks.default_turn_params
+    ()
   in
   let count = match tools_json with Some l -> List.length l | None -> 0 in
   check int "only read, write" 2 count
@@ -149,6 +154,7 @@ let test_shared_channel_between_agents () =
     ~policy_channel:(Some ch)
     ~tools
     ~turn_params:Hooks.default_turn_params
+    ()
   in
   let count_before = match tools_json_before with Some l -> List.length l | None -> 0 in
   check int "before: 2 tools" 2 count_before;
@@ -161,6 +167,7 @@ let test_shared_channel_between_agents () =
     ~policy_channel:(Some ch)
     ~tools
     ~turn_params:Hooks.default_turn_params
+    ()
   in
   let count_after = match tools_json_after with Some l -> List.length l | None -> 0 in
   check int "after: 1 tool" 1 count_after


### PR DESCRIPTION
## Summary
42.9% tool selection ceiling (21 tools, 9B model) 해결을 위한 2-stage routing 구현.

- `Tool_selector` 모듈: All, TopK_bm25, TopK_llm(stub), Categorical 4개 전략
- `Agent_turn.prepare_tools`에 `?tool_selector` 파라미터 통합
- `Builder.with_tool_selector` API
- 기존 `Tool_index.retrieve` (BM25) 재활용 — 새 인덱싱 없음

## Benchmark 근거
| 조건 | 정확도 |
|------|--------|
| 21 tools 단독 | 42.9% |
| TopK_bm25 k=3 + LLM | 83.3% |
| TopK_bm25 k=3 + retry | 100% |

## 변경
- 16 files, +274/-10
- 새 파일: `lib/tool_selector.ml` + `.mli`
- 통합: agent_turn, builder, pipeline, agent_sdk export

## Test plan
- [x] `dune build` 통과
- [x] `dune runtest` 전체 통과 (기존 테스트 regression 없음)
- [ ] CI green
- [ ] 추후 `test_tool_selector.ml` 별도 추가

RFC: oas#615

🤖 Generated with [Claude Code](https://claude.com/claude-code)