### PR TITLE
feat(discovery): per-endpoint per-slot context tracking

### DIFF
--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -170,6 +170,29 @@ let effective_max_context (entry : Provider_registry.entry)
   | Some n -> n
   | None -> entry.max_context
 
+(** Resolve a model label to the per-slot context of the endpoint
+    that would serve it.  Uses the same resolution logic as
+    [make_registry_config]: [current_llama_endpoint] for "llama:*",
+    parsed URL for "custom:*".  Cloud providers return [None].
+
+    Does NOT advance the round-robin counter — safe to call for
+    prompt sizing before the actual cascade request.
+
+    @since 0.100.8 *)
+let resolve_label_context (label : string) : int option =
+  match split_provider_model (String.trim label) with
+  | None -> None
+  | Some ("custom", model_id) ->
+    let _, url = parse_custom_model model_id in
+    Discovery.discovered_context_for_url url
+  | Some ("llama", _) ->
+    let url = Provider_registry.current_llama_endpoint () in
+    if url = "" then None
+    else Discovery.discovered_context_for_url url
+  | Some (_, _) ->
+    (* Cloud providers: no discovery-based per-slot context *)
+    None
+
 (* ── Capability-aware filtering ─────────────────────────── *)
 
 let filter_by_capabilities ~(pred : Capabilities.capabilities -> bool)

--- a/lib/llm_provider/cascade_config.mli
+++ b/lib/llm_provider/cascade_config.mli
@@ -172,6 +172,20 @@ val filter_healthy :
 val effective_max_context :
   Provider_registry.entry -> Capabilities.capabilities -> int
 
+(** Resolve a model label to the per-slot context of the endpoint
+    that would serve it.
+
+    Uses the same resolution path as [make_registry_config]:
+    - ["llama:*"] → peeks at current round-robin endpoint (no advance)
+    - ["custom:model@url"] → looks up the parsed URL
+    - Cloud providers → [None] (use static {!effective_max_context} instead)
+
+    This is the SSOT for "how much context does this label have?"
+    Consumers should call this instead of guessing from endpoint lists.
+
+    @since 0.100.8 *)
+val resolve_label_context : string -> int option
+
 (** {1 Capability-Aware Filtering} *)
 
 (** Filter providers by a capability predicate.

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -245,9 +245,23 @@ let probe_endpoint ~sw ~net url =
 
 (* ── Shared discovered context state ──────────────────────── *)
 
+(** Per-endpoint per-slot context.  Keyed by base URL. *)
+let _discovered_endpoint_ctxs : (string * int) list Atomic.t = Atomic.make []
+
+(** Legacy: max across all endpoints.  Kept for backward compat. *)
 let _discovered_per_slot_ctx : int option Atomic.t = Atomic.make None
 
 let discovered_per_slot_context () = Atomic.get _discovered_per_slot_ctx
+
+(** Per-endpoint per-slot context map from last probe.
+    Returns [(url, per_slot_ctx)] for each healthy endpoint. *)
+let discovered_endpoint_contexts () = Atomic.get _discovered_endpoint_ctxs
+
+(** Look up per-slot context for a specific endpoint URL.
+    Returns [None] if the endpoint was not probed or has no props. *)
+let discovered_context_for_url (url : string) : int option =
+  let normalized = String.trim url in
+  List.assoc_opt normalized (Atomic.get _discovered_endpoint_ctxs)
 
 let discover ~sw ~net ~endpoints =
   Eio.Fiber.List.map (fun url -> probe_endpoint ~sw ~net url) endpoints
@@ -258,10 +272,12 @@ let refresh_and_sync ~sw ~net ~endpoints =
   let per_slot_contexts = List.filter_map (fun (s : endpoint_status) ->
     match s.props with
     | Some p when p.total_slots > 0 && p.ctx_size > 0 ->
-      Some (p.ctx_size / p.total_slots)
+      Some (s.url, p.ctx_size / p.total_slots)
     | _ -> None
   ) healthy in
-  (match per_slot_contexts with
+  Atomic.set _discovered_endpoint_ctxs per_slot_contexts;
+  let ctx_values = List.map snd per_slot_contexts in
+  (match ctx_values with
    | [] -> ()
    | ctxs -> Atomic.set _discovered_per_slot_ctx (Some (List.fold_left max 0 ctxs)));
   statuses

--- a/lib/llm_provider/discovery.mli
+++ b/lib/llm_provider/discovery.mli
@@ -88,12 +88,24 @@ val scan_local_endpoints :
     [discovered_per_slot_context] to get the effective per-request
     context limit derived from the last successful probe.
 
+    Per-endpoint tracking: [discovered_endpoint_contexts] and
+    [discovered_context_for_url] provide URL-specific context sizes.
+
     @since 0.100.8 *)
 
 val discovered_per_slot_context : unit -> int option
-(** Per-slot context tokens from the last probe.
-    Computed as [ctx_size / total_slots] (conservative: min across
-    all healthy endpoints).  Returns [None] if no probe completed. *)
+(** Max per-slot context tokens across all healthy endpoints.
+    Computed as [ctx_size / total_slots] for each endpoint, then
+    takes the max.  Returns [None] if no probe completed. *)
+
+val discovered_endpoint_contexts : unit -> (string * int) list
+(** Per-endpoint per-slot context from last probe.
+    Returns [(url, per_slot_ctx)] for each healthy endpoint
+    that reported valid slot/context info. *)
+
+val discovered_context_for_url : string -> int option
+(** Look up per-slot context for a specific endpoint URL.
+    URL is trimmed before lookup.  Returns [None] if not found. *)
 
 val refresh_and_sync :
   sw:Eio.Switch.t ->

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -101,6 +101,17 @@ let next_llama_endpoint () =
   let idx = Atomic.fetch_and_add llama_rr_counter 1 mod n in
   endpoints.(idx)
 
+(** Peek at the current llama endpoint without advancing the round-robin.
+    Used by context resolution to match the endpoint that will serve
+    the next request, without side effects. *)
+let current_llama_endpoint () =
+  let endpoints = Atomic.get llama_endpoints_ref in
+  let n = Array.length endpoints in
+  if n = 0 then ""
+  else
+    let idx = Atomic.get llama_rr_counter mod n in
+    endpoints.(idx)
+
 (** Refresh the llama endpoint list by scanning local ports.
     If [LLM_ENDPOINTS] is set, uses that as the source (no scan).
     Otherwise probes ports 8085-8090 and keeps only healthy endpoints.
@@ -140,6 +151,9 @@ let active_llama_endpoints () =
 
 let discovered_max_context () =
   Discovery.discovered_per_slot_context ()
+
+let discovered_endpoint_max_context (url : string) =
+  Discovery.discovered_context_for_url url
 
 let llama_defaults = {
   kind = OpenAI_compat;

--- a/lib/llm_provider/provider_registry.mli
+++ b/lib/llm_provider/provider_registry.mli
@@ -70,6 +70,13 @@ val llama_all_endpoints : string list
     @since 0.78.0 *)
 val next_llama_endpoint : unit -> string
 
+(** Peek at the current llama endpoint without advancing the round-robin.
+    Returns the endpoint that [next_llama_endpoint] will return on its
+    next call, but without the [fetch_and_add] side effect.
+    Returns [""] when no endpoints are configured.
+    @since 0.100.8 *)
+val current_llama_endpoint : unit -> string
+
 (** Refresh the llama endpoint list by scanning local ports 8085-8090.
     If [LLM_ENDPOINTS] env var is set, uses that as source (no scan).
     Otherwise probes ports and keeps only healthy endpoints.
@@ -89,3 +96,8 @@ val active_llama_endpoints : unit -> string list
     Delegates to {!Discovery.discovered_per_slot_context}.
     @since 0.100.8 *)
 val discovered_max_context : unit -> int option
+
+val discovered_endpoint_max_context : string -> int option
+(** Per-slot context for a specific endpoint URL.
+    Delegates to {!Discovery.discovered_context_for_url}.
+    Returns [None] if the endpoint was not probed. *)


### PR DESCRIPTION
## Summary
- Add per-endpoint per-slot context tracking in discovery.ml
- Previously `_discovered_per_slot_ctx` stored only the max across all healthy endpoints (32768)
- When cascade routed to 8086 (8192 per-slot), max_context_of_label returned 32768 → prompt overflow

## Changes
- `discovery.ml`: `_discovered_endpoint_ctxs : (string * int) list Atomic.t` per-endpoint map
- `discovery.mli`: `discovered_endpoint_contexts` + `discovered_context_for_url` API
- `provider_registry.ml/mli`: `discovered_endpoint_max_context` facade
- Legacy `discovered_per_slot_context()` preserved (returns global max)

## Test plan
- [x] `dune test` passes (all existing tests)
- [x] Build succeeds for both OAS and masc-mcp
- [ ] Manual verification: 2 endpoints (8085: 32768, 8086: 8192) return correct per-endpoint values

Depends on masc-mcp PR for `oas_model_resolve.ml` consumer update.