### PR TITLE
docs: remove MASC-specific references from OAS documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ Consumers define named cascade profiles; OAS handles routing.
 ```ocaml
 (* Execute a named cascade: load config, filter health, failover *)
 Cascade_config.complete_named ~sw ~net ~clock
-  ~name:"heartbeat_action"
+  ~name:"primary"
   ~defaults:["llama:qwen3.5-35b"; "glm:auto"]
   ~messages ~temperature:0.3 ~max_tokens:500 ()
 

--- a/docs/rfc/RFC-tool-selector.md
+++ b/docs/rfc/RFC-tool-selector.md
@@ -434,7 +434,7 @@ Selector LLM call (optional, lightweight)
   -> output: tool name list
 
 Main Agent LLM call (existing)
-  -> cascade: "heartbeat_action" or agent's named cascade
+  -> cascade: "primary" or agent's named cascade
   -> input: selected tool schemas only
   -> output: tool_use blocks
 ```

--- a/lib/llm_provider/cascade_config.mli
+++ b/lib/llm_provider/cascade_config.mli
@@ -69,8 +69,8 @@ val parse_model_strings :
 
     The JSON file maps "{name}_models" keys to string arrays:
     {[
-      { "heartbeat_action_models": ["llama:qwen3.5", "glm:auto"],
-        "sentinel_board_models":   ["llama:qwen3.5", "glm:glm-4.5"] }
+      { "primary_models":    ["llama:qwen3.5", "glm:auto"],
+        "evaluation_models": ["llama:qwen3.5", "glm:glm-4.5"] }
     ]}
 
     Results are cached and hot-reloaded when the file mtime changes.

--- a/lib/llm_provider/constants.ml
+++ b/lib/llm_provider/constants.ml
@@ -22,7 +22,7 @@ end
 
 (** Named inference parameter profiles.  Single source of truth for
     temperature / max_tokens defaults used by both the SDK and
-    downstream coordinators (e.g. MASC).
+    downstream coordinators.
 
     - [cascade_default]: lightweight cascade calls (health, routing).
     - [agent_default]: full agent turn execution.


### PR DESCRIPTION
## Summary
- OAS는 범용 Agent SDK이므로 downstream coordinator(MASC) 용어를 참조하면 안 됨
- doc comment과 예시에서 MASC-specific 명칭 3곳 + 추가 2곳(CLAUDE.md, RFC) 수정

## Changes
- `lib/llm_provider/constants.ml:25`: "(e.g. MASC)" 제거
- `lib/llm_provider/cascade_config.mli:72-73`: `heartbeat_action_models` → `primary_models`, `sentinel_board_models` → `evaluation_models`
- `CLAUDE.md:102`: cascade 예시명 변경
- `docs/rfc/RFC-tool-selector.md:437`: cascade 예시명 변경

## Verification
- `rg -i 'masc' lib/` = 0 코드 레벨 히트
- `dune build --root .` 통과

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)