### PR TITLE
fix(discovery): remove double-division of per-slot context size

### DIFF
--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -295,10 +295,14 @@ let discover ~sw ~net ~endpoints =
 let refresh_and_sync ~sw ~net ~endpoints =
   let statuses = discover ~sw ~net ~endpoints in
   let healthy = List.filter (fun (s : endpoint_status) -> s.healthy) statuses in
+  (* llama-server /props reports n_ctx as the per-slot context
+     (server total / n_parallel), not the server total. Do NOT divide
+     by total_slots again — that was a double-division bug that caused
+     context to appear 4x smaller than actual (e.g. 65K → 16K). *)
   let per_slot_contexts = List.filter_map (fun (s : endpoint_status) ->
     match s.props with
-    | Some p when p.total_slots > 0 && p.ctx_size > 0 ->
-      Some (s.url, p.ctx_size / p.total_slots)
+    | Some p when p.ctx_size > 0 ->
+      Some (s.url, p.ctx_size)
     | _ -> None
   ) healthy in
   let ctx_values = List.map snd per_slot_contexts in


### PR DESCRIPTION
## Summary

llama-server `/props`의 `n_ctx`는 이미 per-slot context(total / n_parallel)를 보고한다. 기존 코드가 `n_ctx / total_slots`로 다시 나눠서 context가 실제의 1/N로 축소됨.

**재현**: `-c 131072 -np 4` → `/props` n_ctx=32768 → discovery: 32768/4=**8192** (실제: **32768**)

이 버그로 keeper가 "Input token budget exceeded: 10133/8192" 에러를 발생시켰다. 실제 per-slot은 32K인데 8K로 인식.

## Test Plan

- [x] 8 discovery alcotest pass
- [x] `dune build` clean
- [ ] CI (inline ppx tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)