### PR TITLE
feat(hooks): allow Skip in on_idle for early idle termination

### DIFF
--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -278,7 +278,7 @@ let legal_decisions_for_stage stage =
   | "post_tool_use"         -> [K_Continue]
   | "post_tool_use_failure" -> [K_Continue]
   | "on_stop"               -> [K_Continue]
-  | "on_idle"               -> [K_Continue]
+  | "on_idle"               -> [K_Continue; K_Skip]
   | "on_error"              -> [K_Continue]
   | "on_tool_error"         -> [K_Continue]
   | "pre_compact"           -> [K_Continue; K_Skip]

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -299,8 +299,9 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
     agent.last_tool_calls <- idle_result.new_state.last_tool_calls;
     agent.consecutive_idle_turns <-
       idle_result.new_state.consecutive_idle_turns);
+  let idle_stop = ref false in
   if idle_result.is_idle then begin
-    let _idle =
+    let idle_decision =
       invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"on_idle"
         agent.options.hooks.on_idle
         (Hooks.OnIdle {
@@ -309,8 +310,12 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
             | ToolUse { name; _ } -> Some name | _ -> None
           ) tool_uses })
     in
-    ()
+    if idle_decision = Hooks.Skip then idle_stop := true
   end;
+  if !idle_stop then
+    Error (Error.Agent (IdleDetected {
+      consecutive_idle_turns = agent.consecutive_idle_turns }))
+  else
 
   let count = List.length tool_uses in
   match Guardrails.exceeds_limit effective_guardrails count with

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -299,9 +299,8 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
     agent.last_tool_calls <- idle_result.new_state.last_tool_calls;
     agent.consecutive_idle_turns <-
       idle_result.new_state.consecutive_idle_turns);
-  let idle_stop = ref false in
-  if idle_result.is_idle then begin
-    let idle_decision =
+  let idle_decision =
+    if idle_result.is_idle then
       invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"on_idle"
         agent.options.hooks.on_idle
         (Hooks.OnIdle {
@@ -309,10 +308,11 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
           tool_names = List.filter_map (function
             | ToolUse { name; _ } -> Some name | _ -> None
           ) tool_uses })
-    in
-    if idle_decision = Hooks.Skip then idle_stop := true
-  end;
-  if !idle_stop then
+    else Hooks.Continue
+  in
+  (* Skip = hook requests early termination; bypasses tool execution
+     and guardrail checks since the agent is already in an idle loop. *)
+  if idle_decision = Hooks.Skip then
     Error (Error.Agent (IdleDetected {
       consecutive_idle_turns = agent.consecutive_idle_turns }))
   else


### PR DESCRIPTION
## Summary

`on_idle` hook이 기존 `Continue`만 허용해서 관찰 전용이었음. `Skip` 반환을 허용하여 idle loop을 조기 종료할 수 있도록 함.

### 변경

- `hooks.ml`: `on_idle` legal decisions에 `K_Skip` 추가
- `pipeline.ml`: idle hook 결과가 `Skip`이면 즉시 `IdleDetected` 에러 반환

### 동작

| on_idle 반환 | 결과 |
|-------------|------|
| `Continue` (기존) | 로그만, 계속 실행 → max_idle_turns까지 |
| `Skip` (신규) | 즉시 `IdleDetected` 에러 → Agent.run 종료 |

### 동기

MASC keeper 시스템 로그에서 idle loop 21건 관측 (2026-04-04~05). Keeper가 3턴에서 idle 감지하고 warn 로그를 남기지만 `Continue`만 반환 가능 → 5턴까지 무의미하게 실행. 이 변경으로 keeper가 idle 감지 즉시 종료 가능.

## Test plan

- [x] `dune build` 성공
- [x] `test_hooks.exe` 30/30 통과
- [x] `test_pipeline.exe` 48/48 통과
- [ ] CI green

Refs jeong-sik/masc-mcp#5335

🤖 Generated with [Claude Code](https://claude.com/claude-code)