### PR TITLE
feat(hooks): allow Skip in on_idle for graceful idle exit

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -27,6 +27,9 @@ let run_turn_core ~sw ?clock ~api_strategy ?raw_trace_run agent =
   match Pipeline.run_turn ~sw ?clock ~api_strategy:api_strat ?raw_trace_run agent with
   | Ok Pipeline.Complete response -> Ok (`Complete response)
   | Ok Pipeline.ToolsExecuted -> Ok `ToolsExecuted
+  | Ok Pipeline.IdleSkipped -> Ok (`Complete {
+      Types.id = "idle-skipped"; model = ""; stop_reason = EndTurn;
+      content = []; usage = None })
   | Error e -> Error e
 
 (* Original run_turn_core implementation removed — now in Pipeline.run_turn.

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -145,7 +145,7 @@ type elicitation_callback =
 (** Decision returned by a hook *)
 type hook_decision =
   | Continue
-  | Skip           (** PreToolUse only: skip this tool execution *)
+  | Skip           (** PreToolUse: skip this tool execution; OnIdle: gracefully stop the agent run *)
   | Override of string  (** PreToolUse only: return this value instead *)
   | ApprovalRequired  (** PreToolUse only: signals that tool needs approval before execution *)
   | AdjustParams of turn_params  (** BeforeTurnParams only: override params for this turn *)
@@ -262,7 +262,7 @@ let stage_of_event = function
     post_tool_use        |    Y     |      |          |                  |              |
     post_tool_use_failure|    Y     |      |          |                  |              |
     on_stop              |    Y     |      |          |                  |              |
-    on_idle              |    Y     |      |          |                  |              |
+    on_idle              |    Y     |  Y   |          |                  |              |
     on_error             |    Y     |      |          |                  |              |
     on_tool_error        |    Y     |      |          |                  |              |
     pre_compact          |    Y     |  Y   |          |                  |              |
@@ -278,7 +278,7 @@ let legal_decisions_for_stage stage =
   | "post_tool_use"         -> [K_Continue]
   | "post_tool_use_failure" -> [K_Continue]
   | "on_stop"               -> [K_Continue]
-  | "on_idle"               -> [K_Continue]
+  | "on_idle"               -> [K_Continue; K_Skip]
   | "on_error"              -> [K_Continue]
   | "on_tool_error"         -> [K_Continue]
   | "pre_compact"           -> [K_Continue; K_Skip]

--- a/lib/hooks.mli
+++ b/lib/hooks.mli
@@ -159,7 +159,7 @@ val invoke : hook option -> hook_event -> hook_decision
     post_tool_use        |    Y     |      |          |                  |              |
     post_tool_use_failure|    Y     |      |          |                  |              |
     on_stop              |    Y     |      |          |                  |              |
-    on_idle              |    Y     |      |          |                  |              |
+    on_idle              |    Y     |  Y   |          |                  |              |
     on_error             |    Y     |      |          |                  |              |
     on_tool_error        |    Y     |      |          |                  |              |
     pre_compact          |    Y     |  Y   |          |                  |              |

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -21,6 +21,7 @@ type api_strategy =
 type turn_outcome =
   | Complete of Types.api_response
   | ToolsExecuted
+  | IdleSkipped
 
 (* ── Stage 1: Input ──────────────────────────────────────── *)
 
@@ -299,8 +300,9 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
     agent.last_tool_calls <- idle_result.new_state.last_tool_calls;
     agent.consecutive_idle_turns <-
       idle_result.new_state.consecutive_idle_turns);
+  let idle_skip = ref false in
   if idle_result.is_idle then begin
-    let _idle =
+    let idle_decision =
       invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"on_idle"
         agent.options.hooks.on_idle
         (Hooks.OnIdle {
@@ -309,7 +311,9 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
             | ToolUse { name; _ } -> Some name | _ -> None
           ) tool_uses })
     in
-    ()
+    match idle_decision with
+    | Hooks.Skip -> idle_skip := true
+    | _ -> ()
   end;
 
   let count = List.length tool_uses in
@@ -321,7 +325,7 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
     update_state agent (fun s ->
       { s with messages = Util.snoc s.messages
           { role = User; content = [Text msg]; name = None; tool_call_id = None } });
-    Ok ToolsExecuted
+    Ok (if !idle_skip then IdleSkipped else ToolsExecuted)
   | false ->
     let results =
       try Ok (execute_tools_with_trace agent raw_trace_run tool_uses)
@@ -393,7 +397,7 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
     update_state agent (fun s ->
       { s with messages =
           Context_reducer.reduce pruner s.messages });
-    Ok ToolsExecuted
+    Ok (if !idle_skip then IdleSkipped else ToolsExecuted)
 
 (* ── Stage 6: Output ─────────────────────────────────────── *)
 
@@ -403,7 +407,12 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
   | StopToolUse ->
     let tool_uses = List.filter
       (function ToolUse _ -> true | _ -> false) response.content in
-    stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses
+    let result = stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses in
+    (match result with
+     | Ok IdleSkipped ->
+       (* on_idle hook returned Skip: stop gracefully with the current response *)
+       Ok (Complete response)
+     | other -> other)
   | EndTurn | MaxTokens | StopSequence ->
     Tool_retry_policy.clear_context_retry_count agent.context;
     let _stop =

--- a/lib/pipeline/pipeline.mli
+++ b/lib/pipeline/pipeline.mli
@@ -16,6 +16,8 @@ type api_strategy =
 type turn_outcome =
   | Complete of Types.api_response
   | ToolsExecuted
+  | IdleSkipped
+      (** on_idle hook returned Skip — agent should stop gracefully. *)
 
 (** Run a single agent turn through the 6-stage pipeline.
     Equivalent to the previous [run_turn_core]. *)


### PR DESCRIPTION
## Summary

`on_idle` hook에서 `Skip` 결정을 허용하여 idle 감지 시 graceful exit 가능.

**Before**: on_idle → Continue만 가능 → max_idle_turns 도달 → IdleDetected error → turn failure
**After**: on_idle → Skip 반환 가능 → 현재 turn 정상 완료 → agent run 종료 (에러 아님)

keeper agent가 할 일이 없을 때 에러로 죽는 대신 정상 종료하는 데 필수.

5 files, +23/-9 lines.

## Test Plan

- [x] `dune build` clean
- [x] Existing tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)