### PR TITLE
feat(hooks): add Nudge decision for on_idle — graduated idle recovery

### DIFF
--- a/lib/agent/agent_lifecycle.ml
+++ b/lib/agent/agent_lifecycle.ml
@@ -48,6 +48,7 @@ let hook_decision_to_string = function
   | Hooks.ApprovalRequired -> "approval_required"
   | Hooks.AdjustParams _ -> "adjust_params"
   | Hooks.ElicitInput _ -> "elicit_input"
+  | Hooks.Nudge _ -> "nudge"
 
 (** Build a new lifecycle snapshot, merging with a previous one.
     Pure function — caller handles the mutation on Agent.t. *)

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -324,7 +324,7 @@ let execute_scheduled_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus
           | Hooks.AdjustParams _ ->
               find_and_execute_tool ~context ~tools ~hooks ~event_bus ~tracer
                 ~agent_name ~turn_count ?on_hook_invoked ~schedule name input id
-          | Hooks.ElicitInput _ ->
+          | Hooks.ElicitInput _ | Hooks.Nudge _ ->
               find_and_execute_tool ~context ~tools ~hooks ~event_bus ~tracer
                 ~agent_name ~turn_count ?on_hook_invoked ~schedule name input id
         with

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -150,6 +150,7 @@ type hook_decision =
   | ApprovalRequired  (** PreToolUse only: signals that tool needs approval before execution *)
   | AdjustParams of turn_params  (** BeforeTurnParams only: override params for this turn *)
   | ElicitInput of elicitation_request  (** Request user input before proceeding *)
+  | Nudge of string  (** OnIdle only: inject a nudge message into conversation, reset idle counter, continue execution *)
 
 (** Decision from approval callback *)
 type approval_decision =
@@ -219,6 +220,7 @@ type hook_decision_kind =
   | K_ApprovalRequired
   | K_AdjustParams
   | K_ElicitInput
+  | K_Nudge
 
 let classify_decision = function
   | Continue -> K_Continue
@@ -227,6 +229,7 @@ let classify_decision = function
   | ApprovalRequired -> K_ApprovalRequired
   | AdjustParams _ -> K_AdjustParams
   | ElicitInput _ -> K_ElicitInput
+  | Nudge _ -> K_Nudge
 
 let decision_kind_to_string = function
   | K_Continue -> "Continue"
@@ -235,6 +238,7 @@ let decision_kind_to_string = function
   | K_ApprovalRequired -> "ApprovalRequired"
   | K_AdjustParams -> "AdjustParams"
   | K_ElicitInput -> "ElicitInput"
+  | K_Nudge -> "Nudge"
 
 (** Extract a stage name string from a hook_event. *)
 let stage_of_event = function
@@ -253,19 +257,19 @@ let stage_of_event = function
 (** Legal decision matrix.
 
     {v
-    Stage                | Continue | Skip | Override | ApprovalRequired | AdjustParams | ElicitInput
-    ---------------------+----------+------+----------+------------------+--------------+------------
-    before_turn          |    Y     |      |          |                  |              |      Y
-    before_turn_params   |    Y     |      |          |                  |      Y       |
-    after_turn           |    Y     |      |          |                  |              |
-    pre_tool_use         |    Y     |  Y   |    Y     |        Y         |              |
-    post_tool_use        |    Y     |      |          |                  |              |
-    post_tool_use_failure|    Y     |      |          |                  |              |
-    on_stop              |    Y     |      |          |                  |              |
-    on_idle              |    Y     |  Y   |          |                  |              |
-    on_error             |    Y     |      |          |                  |              |
-    on_tool_error        |    Y     |      |          |                  |              |
-    pre_compact          |    Y     |  Y   |          |                  |              |
+    Stage                | Continue | Skip | Override | ApprovalRequired | AdjustParams | ElicitInput | Nudge
+    ---------------------+----------+------+----------+------------------+--------------+-------------+-------
+    before_turn          |    Y     |      |          |                  |              |      Y      |
+    before_turn_params   |    Y     |      |          |                  |      Y       |             |
+    after_turn           |    Y     |      |          |                  |              |             |
+    pre_tool_use         |    Y     |  Y   |    Y     |        Y         |              |             |
+    post_tool_use        |    Y     |      |          |                  |              |             |
+    post_tool_use_failure|    Y     |      |          |                  |              |             |
+    on_stop              |    Y     |      |          |                  |              |             |
+    on_idle              |    Y     |  Y   |          |                  |              |             |   Y
+    on_error             |    Y     |      |          |                  |              |             |
+    on_tool_error        |    Y     |      |          |                  |              |             |
+    pre_compact          |    Y     |  Y   |          |                  |              |             |
     v}
 
     Fail-closed: any decision not explicitly listed is rejected. *)
@@ -278,7 +282,7 @@ let legal_decisions_for_stage stage =
   | "post_tool_use"         -> [K_Continue]
   | "post_tool_use_failure" -> [K_Continue]
   | "on_stop"               -> [K_Continue]
-  | "on_idle"               -> [K_Continue; K_Skip]
+  | "on_idle"               -> [K_Continue; K_Skip; K_Nudge]
   | "on_error"              -> [K_Continue]
   | "on_tool_error"         -> [K_Continue]
   | "pre_compact"           -> [K_Continue; K_Skip]

--- a/lib/hooks.mli
+++ b/lib/hooks.mli
@@ -102,6 +102,7 @@ type hook_decision =
   | ApprovalRequired
   | AdjustParams of turn_params
   | ElicitInput of elicitation_request
+  | Nudge of string  (** OnIdle only: inject message, reset idle counter, continue *)
 
 (** Decision from approval callback *)
 type approval_decision =
@@ -150,8 +151,8 @@ val invoke : hook option -> hook_event -> hook_decision
     Returning an unlisted decision is a programming error.
 
     {v
-    Stage                | Continue | Skip | Override | ApprovalRequired | AdjustParams | ElicitInput
-    ---------------------+----------+------+----------+------------------+--------------+------------
+    Stage                | Continue | Skip | Override | ApprovalRequired | AdjustParams | ElicitInput | Nudge
+    ---------------------+----------+------+----------+------------------+--------------+-------------+-------
     before_turn          |    Y     |      |          |                  |              |      Y
     before_turn_params   |    Y     |      |          |                  |      Y       |
     after_turn           |    Y     |      |          |                  |              |
@@ -159,7 +160,7 @@ val invoke : hook option -> hook_event -> hook_decision
     post_tool_use        |    Y     |      |          |                  |              |
     post_tool_use_failure|    Y     |      |          |                  |              |
     on_stop              |    Y     |      |          |                  |              |
-    on_idle              |    Y     |  Y   |          |                  |              |
+    on_idle              |    Y     |  Y   |          |                  |              |             |   Y
     on_error             |    Y     |      |          |                  |              |
     on_tool_error        |    Y     |      |          |                  |              |
     pre_compact          |    Y     |  Y   |          |                  |              |
@@ -175,6 +176,7 @@ type hook_decision_kind =
   | K_ApprovalRequired
   | K_AdjustParams
   | K_ElicitInput
+  | K_Nudge
 
 (** Extract the kind tag from a decision value. *)
 val classify_decision : hook_decision -> hook_decision_kind

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -313,6 +313,15 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
     in
     match idle_decision with
     | Hooks.Skip -> idle_skip := true
+    | Hooks.Nudge nudge_msg ->
+      (* Inject a nudge message into conversation and reset idle counter
+         so the model gets a chance to try a different approach. *)
+      update_state agent (fun s ->
+        { s with messages = Util.snoc s.messages
+            { role = User; content = [Text nudge_msg];
+              name = None; tool_call_id = None } });
+      Eio.Mutex.use_rw ~protect:true agent.mu (fun () ->
+        agent.consecutive_idle_turns <- 0)
     | _ -> ()
   end;
 


### PR DESCRIPTION
## Summary
- `on_idle` hook에 `Nudge of string` decision 추가
- idle 감지 시 모델에게 "반복하고 있다, 다른 접근을 시도하라"는 메시지를 conversation에 주입
- idle 카운터를 0으로 리셋하여 `max_idle_turns`만큼 추가 시도 기회 부여
- `max_turns`가 outer bound로 작동하여 무한 루프 방지

## Problem
현재 `on_idle` hook의 선택지:
- `Continue` → 무시 → 같은 도구 반복 → `IdleDetected` 에러로 강제 종료
- `Skip` → 즉시 포기

MASC keeper가 "5 consecutive identical tool call turns"으로 100% 사망하는 근본 원인.
Prompt-level 우회(masc-mcp#5377)는 증상 완화이고, 이것이 근본 치료.

## Design
```
on_idle hook decisions:
  Continue  — 무시 (기존)
  Skip      — 정상 종료 (기존)
  Nudge msg — 메시지 주입 + idle 리셋 + 계속 (신규)
```

Pipeline 동작:
1. Nudge 메시지를 User role로 conversation에 append
2. `consecutive_idle_turns`를 0으로 리셋
3. 도구 실행은 정상 진행

## MASC 소비 예시 (후속 PR)
```ocaml
on_idle = Some (fun event ->
  match event with
  | OnIdle { consecutive_idle_turns; tool_names; _ } ->
    if consecutive_idle_turns >= 3 then Skip  (* give up *)
    else Nudge (Printf.sprintf
      "You are repeating the same tools (%s). Try a different approach: \
       post to the Board, search memories, or interact with a peer keeper."
      (String.concat ", " tool_names))
  | _ -> Continue)
```

## Changes
| 파일 | 변경 |
|------|------|
| `lib/hooks.ml` | `Nudge of string` variant, `K_Nudge` kind, legal matrix |
| `lib/hooks.mli` | 동일 |
| `lib/pipeline/pipeline.ml` | `Nudge` → message inject + idle reset |
| `lib/agent/agent_lifecycle.ml` | `hook_decision_to_string` exhaustive |
| `lib/agent/agent_tools.ml` | pre_tool_use exhaustive match |

## Test plan
- [x] `dune build` 성공
- [ ] 기존 테스트 통과 확인
- [ ] MASC에서 Nudge 소비 후 keeper idle death 빈도 감소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)