### PR TITLE
chore: sync sdk_version.ml to 0.101.1

### DIFF
--- a/lib/sdk_version.ml
+++ b/lib/sdk_version.ml
@@ -1,5 +1,5 @@
 (** Single source of truth for the SDK version string.
     All other modules reference this instead of hardcoding. *)
 
-let version = "0.101.0"
+let version = "0.101.1"
 let sdk_name = "agent_sdk"


### PR DESCRIPTION
## Summary
- `dune-project` version was bumped to `0.101.1` but `lib/sdk_version.ml` still had `0.101.0`, causing version-consistency CI to fail.
- Updated `sdk_version.ml` to `0.101.1` to match `dune-project` and `agent_sdk.opam`.

## Test plan
- [ ] CI version-consistency check passes
- [ ] `dune build` succeeds (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)