### PR TITLE
feat: add lifecycle transition guards (A2A pattern)

### DIFF
--- a/lib/agent/agent_lifecycle.ml
+++ b/lib/agent/agent_lifecycle.ml
@@ -12,6 +12,41 @@ type lifecycle_status =
   | Failed
 [@@deriving show]
 
+(* ── Transition guards ─────────────────────────── *)
+
+type transition_error =
+  | InvalidTransition of { from_status: lifecycle_status; to_status: lifecycle_status }
+  | AlreadyTerminal of { status: lifecycle_status }
+
+let is_terminal = function
+  | Completed | Failed -> true
+  | Accepted | Ready | Running -> false
+
+let valid_transitions = function
+  | Accepted -> [Ready; Failed]
+  | Ready    -> [Running; Failed]
+  | Running  -> [Completed; Failed]
+  | Completed -> []
+  | Failed    -> []
+
+let transition ~from ~to_ =
+  if from = to_ && not (is_terminal from) then
+    Ok to_
+  else if is_terminal from then
+    Error (AlreadyTerminal { status = from })
+  else if List.mem to_ (valid_transitions from) then
+    Ok to_
+  else
+    Error (InvalidTransition { from_status = from; to_status = to_ })
+
+let transition_error_to_string = function
+  | InvalidTransition { from_status; to_status } ->
+    Printf.sprintf "invalid lifecycle transition: %s -> %s"
+      (show_lifecycle_status from_status) (show_lifecycle_status to_status)
+  | AlreadyTerminal { status } ->
+    Printf.sprintf "lifecycle already terminal: %s"
+      (show_lifecycle_status status)
+
 type lifecycle_snapshot = {
   current_run_id: string option;
   agent_name: string;

--- a/lib/agent/agent_lifecycle.mli
+++ b/lib/agent/agent_lifecycle.mli
@@ -1,10 +1,22 @@
-(** Lifecycle types and pure helpers for the Agent module.
+(** Lifecycle types, transition guards, and pure helpers for the Agent module.
 
     Extracted from agent.ml to reduce file size.  No dependency on
     [Agent.t] — all functions take explicit parameters.
 
+    {2 Transition Guards}
+
+    The [transition] function enforces a valid state machine:
+    - [Accepted] -> [Ready | Failed]
+    - [Ready]    -> [Running | Failed]
+    - [Running]  -> [Completed | Failed]
+    - [Completed] and [Failed] are terminal (no outgoing transitions).
+    - Same-state transitions on non-terminal states are allowed (reaffirm).
+
+    Follows the pattern established by {!A2a_task.transition}.
+
     @stability Evolving
-    @since 0.93.1 *)
+    @since 0.93.1
+    @since 0.105.0 transition guards *)
 
 (** {1 Lifecycle status} *)
 
@@ -15,6 +27,31 @@ type lifecycle_status =
   | Completed
   | Failed
 [@@deriving show]
+
+(** {1 Transition guards} *)
+
+type transition_error =
+  | InvalidTransition of { from_status: lifecycle_status; to_status: lifecycle_status }
+  | AlreadyTerminal of { status: lifecycle_status }
+
+(** [is_terminal status] returns [true] for [Completed] and [Failed]. *)
+val is_terminal : lifecycle_status -> bool
+
+(** [valid_transitions status] returns the list of statuses reachable
+    from [status]. Terminal states return the empty list. *)
+val valid_transitions : lifecycle_status -> lifecycle_status list
+
+(** [transition ~from ~to_] validates a state transition.
+    Returns [Ok to_] on success, [Error _] on invalid transition.
+    Same-state transitions on non-terminal states return [Ok] (reaffirm). *)
+val transition :
+  from:lifecycle_status -> to_:lifecycle_status ->
+  (lifecycle_status, transition_error) result
+
+(** Human-readable description of a transition error. *)
+val transition_error_to_string : transition_error -> string
+
+(** {1 Snapshot} *)
 
 (** Snapshot of an agent's lifecycle at a given moment. *)
 type lifecycle_snapshot = {

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -156,11 +156,25 @@ let card t =
     fibers call this concurrently via [on_tool_execution_started] /
     [on_tool_execution_finished] callbacks.  Without the mutex the
     read of [agent.lifecycle] (for [?previous]) and the subsequent
-    write could interleave, losing an update. *)
+    write could interleave, losing an update.
+
+    Validates the transition against {!Agent_lifecycle.valid_transitions}.
+    Invalid transitions log a warning but still proceed for backward
+    compatibility.  Callers that need strict enforcement should use
+    {!Agent_lifecycle.transition} directly. *)
 let set_lifecycle agent ?current_run_id ?worker_id ?runtime_actor ?last_error
     ?accepted_at ?ready_at ?first_progress_at ?started_at ?last_progress_at
     ?finished_at status =
   Eio.Mutex.use_rw ~protect:true agent.mu (fun () ->
+    (match agent.lifecycle with
+     | Some prev ->
+       (match Agent_lifecycle.transition ~from:prev.status ~to_:status with
+        | Error e ->
+          Printf.eprintf "[WARN] %s (agent=%s)\n%!"
+            (Agent_lifecycle.transition_error_to_string e)
+            agent.state.config.name
+        | Ok _ -> ())
+     | None -> ());
     agent.lifecycle <- Some (Agent_lifecycle.build_snapshot
       ~agent_name:agent.state.config.name
       ~provider:agent.options.provider

--- a/test/test_agent_lifecycle.ml
+++ b/test/test_agent_lifecycle.ml
@@ -125,6 +125,109 @@ let test_hook_decision_strings () =
   Alcotest.(check string) "skip" "skip"
     (Agent_lifecycle.hook_decision_to_string Hooks.Skip)
 
+(* ── transition guard tests ───────────────────────────── *)
+
+let check_ok msg = function
+  | Ok _ -> ()
+  | Error e ->
+    Alcotest.fail (Printf.sprintf "%s: unexpected error: %s"
+      msg (Agent_lifecycle.transition_error_to_string e))
+
+let check_error msg = function
+  | Error _ -> ()
+  | Ok s ->
+    Alcotest.fail (Printf.sprintf "%s: expected error but got Ok %s"
+      msg (Agent_lifecycle.show_lifecycle_status s))
+
+let test_transition_accepted_to_ready () =
+  check_ok "Accepted->Ready"
+    (Agent_lifecycle.transition ~from:Accepted ~to_:Ready)
+
+let test_transition_ready_to_running () =
+  check_ok "Ready->Running"
+    (Agent_lifecycle.transition ~from:Ready ~to_:Running)
+
+let test_transition_running_to_completed () =
+  check_ok "Running->Completed"
+    (Agent_lifecycle.transition ~from:Running ~to_:Completed)
+
+let test_transition_running_to_failed () =
+  check_ok "Running->Failed"
+    (Agent_lifecycle.transition ~from:Running ~to_:Failed)
+
+let test_transition_accepted_to_failed () =
+  check_ok "Accepted->Failed"
+    (Agent_lifecycle.transition ~from:Accepted ~to_:Failed)
+
+let test_transition_self_running () =
+  check_ok "Running->Running (self)"
+    (Agent_lifecycle.transition ~from:Running ~to_:Running)
+
+let test_transition_self_accepted () =
+  check_ok "Accepted->Accepted (self)"
+    (Agent_lifecycle.transition ~from:Accepted ~to_:Accepted)
+
+let test_transition_invalid_accepted_to_running () =
+  check_error "Accepted->Running (skip Ready)"
+    (Agent_lifecycle.transition ~from:Accepted ~to_:Running)
+
+let test_transition_invalid_accepted_to_completed () =
+  check_error "Accepted->Completed (skip Ready,Running)"
+    (Agent_lifecycle.transition ~from:Accepted ~to_:Completed)
+
+let test_transition_invalid_ready_to_completed () =
+  check_error "Ready->Completed (skip Running)"
+    (Agent_lifecycle.transition ~from:Ready ~to_:Completed)
+
+let test_transition_terminal_completed () =
+  let r = Agent_lifecycle.transition ~from:Completed ~to_:Running in
+  (match r with
+   | Error (AlreadyTerminal { status }) ->
+     Alcotest.(check bool) "terminal status" true
+       (status = Agent_lifecycle.Completed)
+   | _ -> Alcotest.fail "expected AlreadyTerminal")
+
+let test_transition_terminal_failed () =
+  let r = Agent_lifecycle.transition ~from:Failed ~to_:Accepted in
+  (match r with
+   | Error (AlreadyTerminal { status }) ->
+     Alcotest.(check bool) "terminal status" true
+       (status = Agent_lifecycle.Failed)
+   | _ -> Alcotest.fail "expected AlreadyTerminal")
+
+let test_transition_terminal_self () =
+  check_error "Completed->Completed (terminal self)"
+    (Agent_lifecycle.transition ~from:Completed ~to_:Completed)
+
+let test_is_terminal () =
+  Alcotest.(check bool) "Completed" true (Agent_lifecycle.is_terminal Completed);
+  Alcotest.(check bool) "Failed" true (Agent_lifecycle.is_terminal Failed);
+  Alcotest.(check bool) "Accepted" false (Agent_lifecycle.is_terminal Accepted);
+  Alcotest.(check bool) "Ready" false (Agent_lifecycle.is_terminal Ready);
+  Alcotest.(check bool) "Running" false (Agent_lifecycle.is_terminal Running)
+
+let test_valid_transitions_exhaustive () =
+  Alcotest.(check int) "Accepted has 2" 2
+    (List.length (Agent_lifecycle.valid_transitions Accepted));
+  Alcotest.(check int) "Ready has 2" 2
+    (List.length (Agent_lifecycle.valid_transitions Ready));
+  Alcotest.(check int) "Running has 2" 2
+    (List.length (Agent_lifecycle.valid_transitions Running));
+  Alcotest.(check int) "Completed has 0" 0
+    (List.length (Agent_lifecycle.valid_transitions Completed));
+  Alcotest.(check int) "Failed has 0" 0
+    (List.length (Agent_lifecycle.valid_transitions Failed))
+
+let test_transition_error_to_string () =
+  let s = Agent_lifecycle.transition_error_to_string
+    (InvalidTransition { from_status = Accepted; to_status = Running }) in
+  Alcotest.(check bool) "contains 'invalid'" true
+    (String.length s > 0);
+  let s2 = Agent_lifecycle.transition_error_to_string
+    (AlreadyTerminal { status = Completed }) in
+  Alcotest.(check bool) "contains 'terminal'" true
+    (String.length s2 > 0)
+
 (* ── Test runner ────────────────────────────────────────── *)
 
 let () =
@@ -144,5 +247,23 @@ let () =
     ];
     "hook_decision", [
       Alcotest.test_case "string conversion" `Quick test_hook_decision_strings;
+    ];
+    "transition_guards", [
+      Alcotest.test_case "Accepted -> Ready" `Quick test_transition_accepted_to_ready;
+      Alcotest.test_case "Ready -> Running" `Quick test_transition_ready_to_running;
+      Alcotest.test_case "Running -> Completed" `Quick test_transition_running_to_completed;
+      Alcotest.test_case "Running -> Failed" `Quick test_transition_running_to_failed;
+      Alcotest.test_case "Accepted -> Failed" `Quick test_transition_accepted_to_failed;
+      Alcotest.test_case "self Running -> Running" `Quick test_transition_self_running;
+      Alcotest.test_case "self Accepted -> Accepted" `Quick test_transition_self_accepted;
+      Alcotest.test_case "invalid Accepted -> Running" `Quick test_transition_invalid_accepted_to_running;
+      Alcotest.test_case "invalid Accepted -> Completed" `Quick test_transition_invalid_accepted_to_completed;
+      Alcotest.test_case "invalid Ready -> Completed" `Quick test_transition_invalid_ready_to_completed;
+      Alcotest.test_case "terminal Completed -> Running" `Quick test_transition_terminal_completed;
+      Alcotest.test_case "terminal Failed -> Accepted" `Quick test_transition_terminal_failed;
+      Alcotest.test_case "terminal self Completed" `Quick test_transition_terminal_self;
+      Alcotest.test_case "is_terminal" `Quick test_is_terminal;
+      Alcotest.test_case "valid_transitions exhaustive" `Quick test_valid_transitions_exhaustive;
+      Alcotest.test_case "error_to_string" `Quick test_transition_error_to_string;
     ];
   ]


### PR DESCRIPTION
## Summary

- `Agent_lifecycle`에 `valid_transitions`, `transition`, `is_terminal` 추가
- A2A task의 전이 가드 패턴을 lifecycle state machine에 적용
- `set_lifecycle` 내부에서 validation 수행, 무효 전이 시 warning 로그 (후방 호환 유지)
- 16개 transition guard 테스트 추가

## 동기

OAS의 7개 state machine 중 `a2a_task.ml`만 전이 가드를 갖고 있었다.
`set_lifecycle`은 `Completed→Running` 같은 무효 전이를 조용히 허용하여
zombie agent 가능성이 있었다.

## 전이 그래프

```
Accepted → [Ready, Failed]
Ready    → [Running, Failed]
Running  → [Completed, Failed]
Completed → [] (terminal)
Failed    → [] (terminal)
```

Same-state 전이는 non-terminal에서 허용 (Running→Running: tool exec callback).

## Test plan

- [x] 16개 transition guard 테스트 (valid/invalid/terminal/self)
- [x] 기존 10개 테스트 통과
- [x] `dune runtest` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)