### PR TITLE
feat: add Collaboration and Plan transition guards

### DIFF
--- a/lib/collaboration.ml
+++ b/lib/collaboration.ml
@@ -132,16 +132,46 @@ let add_contribution t c =
 
 (* --- Phase and outcome --- *)
 
-let set_phase t phase =
-  { t with phase } |> touch
-
-let set_outcome t outcome =
-  { t with outcome = Some outcome } |> touch
-
 let is_terminal t =
   match t.phase with
   | Completed | Failed | Cancelled -> true
   | Bootstrapping | Active | Waiting_on_participants | Finalizing -> false
+
+type phase_transition_error =
+  | InvalidPhaseTransition of { from_phase: phase; to_phase: phase }
+  | PhaseAlreadyTerminal of { phase: phase }
+
+let valid_phase_transitions = function
+  | Bootstrapping           -> [Active; Failed; Cancelled]
+  | Active                  -> [Waiting_on_participants; Finalizing; Failed; Cancelled]
+  | Waiting_on_participants -> [Active; Failed; Cancelled]
+  | Finalizing              -> [Completed; Failed; Cancelled]
+  | Completed | Failed | Cancelled -> []
+
+let transition_phase t new_phase =
+  if t.phase = new_phase then Ok (touch t)
+  else if is_terminal t then Error (PhaseAlreadyTerminal { phase = t.phase })
+  else if List.mem new_phase (valid_phase_transitions t.phase) then
+    Ok ({ t with phase = new_phase } |> touch)
+  else Error (InvalidPhaseTransition { from_phase = t.phase; to_phase = new_phase })
+
+let phase_transition_error_to_string = function
+  | InvalidPhaseTransition { from_phase; to_phase } ->
+    Printf.sprintf "invalid phase transition: %s -> %s"
+      (show_phase from_phase) (show_phase to_phase)
+  | PhaseAlreadyTerminal { phase } ->
+    Printf.sprintf "phase already terminal: %s" (show_phase phase)
+
+let set_phase t phase =
+  (match transition_phase t phase with
+   | Error e ->
+     Printf.eprintf "[WARN] Collaboration: %s\n%!"
+       (phase_transition_error_to_string e)
+   | Ok _ -> ());
+  { t with phase } |> touch
+
+let set_outcome t outcome =
+  { t with outcome = Some outcome } |> touch
 
 (* --- Serialization --- *)
 

--- a/lib/collaboration.mli
+++ b/lib/collaboration.mli
@@ -122,6 +122,16 @@ val set_phase : t -> phase -> t
 val set_outcome : t -> string -> t
 val is_terminal : t -> bool
 
+(** {1 Phase transition guards} *)
+
+type phase_transition_error =
+  | InvalidPhaseTransition of { from_phase: phase; to_phase: phase }
+  | PhaseAlreadyTerminal of { phase: phase }
+
+val valid_phase_transitions : phase -> phase list
+val transition_phase : t -> phase -> (t, phase_transition_error) result
+val phase_transition_error_to_string : phase_transition_error -> string
+
 (** {1 Timestamp} *)
 
 val touch : t -> t

--- a/lib/plan.ml
+++ b/lib/plan.ml
@@ -75,11 +75,73 @@ let replan t ~new_steps =
   ) t.steps in
   { t with steps = kept @ new_steps; status = Replanning }
 
+(* ── Status to string (needed by transition guards and serialization) ── *)
+
+let plan_status_to_string = function
+  | Planning -> "Planning"
+  | Executing -> "Executing"
+  | Replanning -> "Replanning"
+  | Completed -> "Completed"
+  | Abandoned reason -> Printf.sprintf "Abandoned(%s)" reason
+
+(* ── Transition guards ────────────────────────────── *)
+
+type plan_transition_error =
+  | InvalidPlanTransition of { from_status: plan_status; to_status: plan_status }
+  | PlanAlreadyTerminal of { status: plan_status }
+
+let is_terminal_status = function
+  | Completed | Abandoned _ -> true
+  | Planning | Executing | Replanning -> false
+
+let valid_plan_transitions = function
+  | Planning   -> [Executing]
+  | Executing  -> [Replanning; Completed]
+  | Replanning -> [Executing]
+  | Completed  -> []
+  | Abandoned _ -> []
+
+let can_transition_to from to_ =
+  if is_terminal_status from then false
+  else match to_ with
+  | Abandoned _ ->
+    not (is_terminal_status from)
+  | other -> List.mem other (valid_plan_transitions from)
+
+let transition_plan t new_status =
+  if is_terminal_status t.status then
+    Error (PlanAlreadyTerminal { status = t.status })
+  else if can_transition_to t.status new_status then
+    Ok { t with status = new_status }
+  else
+    Error (InvalidPlanTransition { from_status = t.status; to_status = new_status })
+
+let plan_transition_error_to_string = function
+  | InvalidPlanTransition { from_status; to_status } ->
+    Printf.sprintf "invalid plan transition: %s -> %s"
+      (plan_status_to_string from_status) (plan_status_to_string to_status)
+  | PlanAlreadyTerminal { status } ->
+    Printf.sprintf "plan already terminal: %s" (plan_status_to_string status)
+
 (* ── Lifecycle ────────────────────────────────────── *)
 
-let start t = { t with status = Executing }
-let finish t = { t with status = Completed }
-let abandon t ~reason = { t with status = Abandoned reason }
+let start t =
+  (match transition_plan t Executing with
+   | Error e -> Printf.eprintf "[WARN] Plan: %s\n%!" (plan_transition_error_to_string e)
+   | Ok _ -> ());
+  { t with status = Executing }
+
+let finish t =
+  (match transition_plan t Completed with
+   | Error e -> Printf.eprintf "[WARN] Plan: %s\n%!" (plan_transition_error_to_string e)
+   | Ok _ -> ());
+  { t with status = Completed }
+
+let abandon t ~reason =
+  (match transition_plan t (Abandoned reason) with
+   | Error e -> Printf.eprintf "[WARN] Plan: %s\n%!" (plan_transition_error_to_string e)
+   | Ok _ -> ());
+  { t with status = Abandoned reason }
 
 (* ── Queries ──────────────────────────────────────── *)
 
@@ -134,12 +196,7 @@ let step_status_to_string = function
   | Failed reason -> Printf.sprintf "Failed(%s)" reason
   | Skipped -> "Skipped"
 
-let plan_status_to_string = function
-  | Planning -> "Planning"
-  | Executing -> "Executing"
-  | Replanning -> "Replanning"
-  | Completed -> "Completed"
-  | Abandoned reason -> Printf.sprintf "Abandoned(%s)" reason
+(* plan_status_to_string is defined above transition guards *)
 
 let step_status_to_json = function
   | Pending -> `Assoc [("status", `String "Pending")]

--- a/lib/plan.mli
+++ b/lib/plan.mli
@@ -73,6 +73,18 @@ val skip_step : t -> string -> t
     Plan status transitions to [Replanning] then back to [Executing]. *)
 val replan : t -> new_steps:step list -> t
 
+(** {1 Plan transition guards} *)
+
+type plan_transition_error =
+  | InvalidPlanTransition of { from_status: plan_status; to_status: plan_status }
+  | PlanAlreadyTerminal of { status: plan_status }
+
+val is_terminal_status : plan_status -> bool
+val valid_plan_transitions : plan_status -> plan_status list
+val can_transition_to : plan_status -> plan_status -> bool
+val transition_plan : t -> plan_status -> (t, plan_transition_error) result
+val plan_transition_error_to_string : plan_transition_error -> string
+
 (** {1 Plan lifecycle} *)
 
 (** Transition plan to Executing. *)

--- a/test/dune
+++ b/test/dune
@@ -423,7 +423,7 @@
 
 (test
  (name test_collaboration)
- (libraries agent_sdk alcotest yojson eio eio_main))
+ (libraries agent_sdk alcotest yojson eio eio_main str))
 
 (test
  (name test_collaboration_bridge)
@@ -718,7 +718,7 @@
 
 (test
  (name test_plan)
- (libraries agent_sdk alcotest yojson unix))
+ (libraries agent_sdk alcotest yojson unix str))
 
 (test
  (name test_memory_coverage)

--- a/test/test_collaboration.ml
+++ b/test/test_collaboration.ml
@@ -339,6 +339,163 @@ let () =
           (Result.is_error (Collaboration.of_json bad)));
     ];
 
+    "transition_guards", [
+      test_case "valid: Bootstrapping -> Active" `Quick (fun () ->
+        let c = Collaboration.create ~goal:"test" () in
+        match Collaboration.transition_phase c Active with
+        | Ok c2 -> check bool "is Active" true (c2.phase = Collaboration.Active)
+        | Error _ -> Alcotest.fail "expected Ok");
+
+      test_case "valid: Bootstrapping -> Failed" `Quick (fun () ->
+        let c = Collaboration.create ~goal:"test" () in
+        match Collaboration.transition_phase c Failed with
+        | Ok c2 -> check bool "is Failed" true (c2.phase = Collaboration.Failed)
+        | Error _ -> Alcotest.fail "expected Ok");
+
+      test_case "valid: Bootstrapping -> Cancelled" `Quick (fun () ->
+        let c = Collaboration.create ~goal:"test" () in
+        match Collaboration.transition_phase c Cancelled with
+        | Ok c2 -> check bool "is Cancelled" true (c2.phase = Collaboration.Cancelled)
+        | Error _ -> Alcotest.fail "expected Ok");
+
+      test_case "valid: Active -> Waiting_on_participants" `Quick (fun () ->
+        let c = Collaboration.create ~goal:"test" () in
+        let c = Collaboration.set_phase c Active in
+        match Collaboration.transition_phase c Waiting_on_participants with
+        | Ok c2 -> check bool "is Waiting" true (c2.phase = Collaboration.Waiting_on_participants)
+        | Error _ -> Alcotest.fail "expected Ok");
+
+      test_case "valid: Active -> Finalizing" `Quick (fun () ->
+        let c = Collaboration.create ~goal:"test" () in
+        let c = Collaboration.set_phase c Active in
+        match Collaboration.transition_phase c Finalizing with
+        | Ok c2 -> check bool "is Finalizing" true (c2.phase = Collaboration.Finalizing)
+        | Error _ -> Alcotest.fail "expected Ok");
+
+      test_case "valid: Active -> Failed" `Quick (fun () ->
+        let c = Collaboration.create ~goal:"test" () in
+        let c = Collaboration.set_phase c Active in
+        match Collaboration.transition_phase c Failed with
+        | Ok c2 -> check bool "is Failed" true (c2.phase = Collaboration.Failed)
+        | Error _ -> Alcotest.fail "expected Ok");
+
+      test_case "valid: Active -> Cancelled" `Quick (fun () ->
+        let c = Collaboration.create ~goal:"test" () in
+        let c = Collaboration.set_phase c Active in
+        match Collaboration.transition_phase c Cancelled with
+        | Ok c2 -> check bool "is Cancelled" true (c2.phase = Collaboration.Cancelled)
+        | Error _ -> Alcotest.fail "expected Ok");
+
+      test_case "valid: Waiting_on_participants -> Active" `Quick (fun () ->
+        let c = Collaboration.create ~goal:"test" () in
+        let c = Collaboration.set_phase c Waiting_on_participants in
+        match Collaboration.transition_phase c Active with
+        | Ok c2 -> check bool "is Active" true (c2.phase = Collaboration.Active)
+        | Error _ -> Alcotest.fail "expected Ok");
+
+      test_case "valid: Finalizing -> Completed" `Quick (fun () ->
+        let c = Collaboration.create ~goal:"test" () in
+        let c = Collaboration.set_phase c Finalizing in
+        match Collaboration.transition_phase c Completed with
+        | Ok c2 -> check bool "is Completed" true (c2.phase = Collaboration.Completed)
+        | Error _ -> Alcotest.fail "expected Ok");
+
+      test_case "invalid: Bootstrapping -> Completed" `Quick (fun () ->
+        let c = Collaboration.create ~goal:"test" () in
+        match Collaboration.transition_phase c Completed with
+        | Ok _ -> Alcotest.fail "expected Error"
+        | Error (InvalidPhaseTransition { from_phase; to_phase }) ->
+          check bool "from" true (from_phase = Collaboration.Bootstrapping);
+          check bool "to" true (to_phase = Collaboration.Completed)
+        | Error _ -> Alcotest.fail "expected InvalidPhaseTransition");
+
+      test_case "invalid: Bootstrapping -> Finalizing" `Quick (fun () ->
+        let c = Collaboration.create ~goal:"test" () in
+        match Collaboration.transition_phase c Finalizing with
+        | Ok _ -> Alcotest.fail "expected Error"
+        | Error (InvalidPhaseTransition _) -> ()
+        | Error _ -> Alcotest.fail "expected InvalidPhaseTransition");
+
+      test_case "invalid: Waiting_on_participants -> Completed" `Quick (fun () ->
+        let c = Collaboration.create ~goal:"test" () in
+        let c = Collaboration.set_phase c Waiting_on_participants in
+        match Collaboration.transition_phase c Completed with
+        | Ok _ -> Alcotest.fail "expected Error"
+        | Error (InvalidPhaseTransition _) -> ()
+        | Error _ -> Alcotest.fail "expected InvalidPhaseTransition");
+
+      test_case "terminal: Completed rejects transition" `Quick (fun () ->
+        let c = Collaboration.create ~goal:"test" () in
+        let c = Collaboration.set_phase c Completed in
+        match Collaboration.transition_phase c Active with
+        | Ok _ -> Alcotest.fail "expected Error"
+        | Error (PhaseAlreadyTerminal { phase }) ->
+          check bool "phase" true (phase = Collaboration.Completed)
+        | Error _ -> Alcotest.fail "expected PhaseAlreadyTerminal");
+
+      test_case "terminal: Failed rejects transition" `Quick (fun () ->
+        let c = Collaboration.create ~goal:"test" () in
+        let c = Collaboration.set_phase c Failed in
+        match Collaboration.transition_phase c Active with
+        | Ok _ -> Alcotest.fail "expected Error"
+        | Error (PhaseAlreadyTerminal _) -> ()
+        | Error _ -> Alcotest.fail "expected PhaseAlreadyTerminal");
+
+      test_case "terminal: Cancelled rejects transition" `Quick (fun () ->
+        let c = Collaboration.create ~goal:"test" () in
+        let c = Collaboration.set_phase c Cancelled in
+        match Collaboration.transition_phase c Active with
+        | Ok _ -> Alcotest.fail "expected Error"
+        | Error (PhaseAlreadyTerminal _) -> ()
+        | Error _ -> Alcotest.fail "expected PhaseAlreadyTerminal");
+
+      test_case "same-state transition returns Ok" `Quick (fun () ->
+        let c = Collaboration.create ~goal:"test" () in
+        match Collaboration.transition_phase c Bootstrapping with
+        | Ok c2 -> check bool "still Bootstrapping" true (c2.phase = Collaboration.Bootstrapping)
+        | Error _ -> Alcotest.fail "same-state should return Ok");
+
+      test_case "same-state Active returns Ok" `Quick (fun () ->
+        let c = Collaboration.create ~goal:"test" () in
+        let c = Collaboration.set_phase c Active in
+        match Collaboration.transition_phase c Active with
+        | Ok c2 -> check bool "still Active" true (c2.phase = Collaboration.Active)
+        | Error _ -> Alcotest.fail "same-state should return Ok");
+
+      test_case "error message format: InvalidPhaseTransition" `Quick (fun () ->
+        let err = Collaboration.InvalidPhaseTransition
+          { from_phase = Bootstrapping; to_phase = Completed } in
+        let msg = Collaboration.phase_transition_error_to_string err in
+        check bool "contains 'invalid'" true
+          (String.length msg > 0
+           && try ignore (Str.search_forward (Str.regexp "invalid phase transition") msg 0); true
+              with Not_found -> false));
+
+      test_case "error message format: PhaseAlreadyTerminal" `Quick (fun () ->
+        let err = Collaboration.PhaseAlreadyTerminal { phase = Completed } in
+        let msg = Collaboration.phase_transition_error_to_string err in
+        check bool "contains 'terminal'" true
+          (String.length msg > 0
+           && try ignore (Str.search_forward (Str.regexp "terminal") msg 0); true
+              with Not_found -> false));
+
+      test_case "valid_phase_transitions exhaustive" `Quick (fun () ->
+        check int "Bootstrapping has 3" 3
+          (List.length (Collaboration.valid_phase_transitions Bootstrapping));
+        check int "Active has 4" 4
+          (List.length (Collaboration.valid_phase_transitions Active));
+        check int "Waiting has 3" 3
+          (List.length (Collaboration.valid_phase_transitions Waiting_on_participants));
+        check int "Finalizing has 3" 3
+          (List.length (Collaboration.valid_phase_transitions Finalizing));
+        check int "Completed has 0" 0
+          (List.length (Collaboration.valid_phase_transitions Completed));
+        check int "Failed has 0" 0
+          (List.length (Collaboration.valid_phase_transitions Failed));
+        check int "Cancelled has 0" 0
+          (List.length (Collaboration.valid_phase_transitions Cancelled)));
+    ];
+
     "edge_cases", [
       test_case "duplicate participant name — find returns first" `Quick (fun () ->
         let c = Collaboration.create ~goal:"test" () in

--- a/test/test_plan.ml
+++ b/test/test_plan.ml
@@ -247,6 +247,169 @@ let test_status_strings () =
   check string "Abandoned" "Abandoned(x)"
     (Plan.plan_status_to_string (Abandoned "x"))
 
+(* ── Transition guards ──────────────────────────────── *)
+
+let test_valid_planning_to_executing () =
+  let p = Plan.create ~goal:"g" ~planner:"a" () in
+  match Plan.transition_plan p Executing with
+  | Ok p2 ->
+    (match Plan.status p2 with
+     | Executing -> ()
+     | _ -> fail "expected Executing")
+  | Error _ -> fail "expected Ok"
+
+let test_valid_executing_to_replanning () =
+  let p = Plan.create ~goal:"g" ~planner:"a" () |> Plan.start in
+  match Plan.transition_plan p Replanning with
+  | Ok p2 ->
+    (match Plan.status p2 with
+     | Replanning -> ()
+     | _ -> fail "expected Replanning")
+  | Error _ -> fail "expected Ok"
+
+let test_valid_executing_to_completed () =
+  let p = Plan.create ~goal:"g" ~planner:"a" () |> Plan.start in
+  match Plan.transition_plan p Completed with
+  | Ok p2 ->
+    (match Plan.status p2 with
+     | Completed -> ()
+     | _ -> fail "expected Completed")
+  | Error _ -> fail "expected Ok"
+
+let test_valid_replanning_to_executing () =
+  let p = Plan.create ~goal:"g" ~planner:"a" ()
+    |> Plan.start
+    |> fun p -> Plan.replan p ~new_steps:[] in
+  match Plan.transition_plan p Executing with
+  | Ok p2 ->
+    (match Plan.status p2 with
+     | Executing -> ()
+     | _ -> fail "expected Executing")
+  | Error _ -> fail "expected Ok"
+
+let test_valid_abandon_from_planning () =
+  let p = Plan.create ~goal:"g" ~planner:"a" () in
+  match Plan.transition_plan p (Abandoned "changed mind") with
+  | Ok p2 ->
+    (match Plan.status p2 with
+     | Abandoned "changed mind" -> ()
+     | _ -> fail "expected Abandoned")
+  | Error _ -> fail "expected Ok"
+
+let test_valid_abandon_from_executing () =
+  let p = Plan.create ~goal:"g" ~planner:"a" () |> Plan.start in
+  match Plan.transition_plan p (Abandoned "budget") with
+  | Ok p2 ->
+    (match Plan.status p2 with
+     | Abandoned "budget" -> ()
+     | _ -> fail "expected Abandoned")
+  | Error _ -> fail "expected Ok"
+
+let test_valid_abandon_from_replanning () =
+  let p = Plan.create ~goal:"g" ~planner:"a" ()
+    |> Plan.start
+    |> fun p -> Plan.replan p ~new_steps:[] in
+  match Plan.transition_plan p (Abandoned "stale") with
+  | Ok p2 ->
+    (match Plan.status p2 with
+     | Abandoned "stale" -> ()
+     | _ -> fail "expected Abandoned")
+  | Error _ -> fail "expected Ok"
+
+let test_invalid_planning_to_completed () =
+  let p = Plan.create ~goal:"g" ~planner:"a" () in
+  match Plan.transition_plan p Completed with
+  | Ok _ -> fail "expected Error"
+  | Error (InvalidPlanTransition { from_status; to_status }) ->
+    (match from_status, to_status with
+     | Planning, Completed -> ()
+     | _ -> fail "wrong error fields")
+  | Error _ -> fail "expected InvalidPlanTransition"
+
+let test_invalid_planning_to_replanning () =
+  let p = Plan.create ~goal:"g" ~planner:"a" () in
+  match Plan.transition_plan p Replanning with
+  | Ok _ -> fail "expected Error"
+  | Error (InvalidPlanTransition _) -> ()
+  | Error _ -> fail "expected InvalidPlanTransition"
+
+let test_invalid_executing_to_planning () =
+  let p = Plan.create ~goal:"g" ~planner:"a" () |> Plan.start in
+  match Plan.transition_plan p Planning with
+  | Ok _ -> fail "expected Error"
+  | Error (InvalidPlanTransition _) -> ()
+  | Error _ -> fail "expected InvalidPlanTransition"
+
+let test_terminal_completed_rejects () =
+  let p = Plan.create ~goal:"g" ~planner:"a" () |> Plan.start |> Plan.finish in
+  match Plan.transition_plan p Executing with
+  | Ok _ -> fail "expected Error"
+  | Error (PlanAlreadyTerminal { status }) ->
+    (match status with Completed -> () | _ -> fail "wrong status")
+  | Error _ -> fail "expected PlanAlreadyTerminal"
+
+let test_terminal_abandoned_rejects () =
+  let p = Plan.create ~goal:"g" ~planner:"a" ()
+    |> fun p -> Plan.abandon p ~reason:"done" in
+  match Plan.transition_plan p Executing with
+  | Ok _ -> fail "expected Error"
+  | Error (PlanAlreadyTerminal _) -> ()
+  | Error _ -> fail "expected PlanAlreadyTerminal"
+
+let test_terminal_abandoned_rejects_abandon () =
+  let p = Plan.create ~goal:"g" ~planner:"a" ()
+    |> fun p -> Plan.abandon p ~reason:"first" in
+  match Plan.transition_plan p (Abandoned "second") with
+  | Ok _ -> fail "expected Error"
+  | Error (PlanAlreadyTerminal _) -> ()
+  | Error _ -> fail "expected PlanAlreadyTerminal"
+
+let test_is_terminal_status () =
+  check bool "Planning not terminal" false (Plan.is_terminal_status Planning);
+  check bool "Executing not terminal" false (Plan.is_terminal_status Executing);
+  check bool "Replanning not terminal" false (Plan.is_terminal_status Replanning);
+  check bool "Completed terminal" true (Plan.is_terminal_status Completed);
+  check bool "Abandoned terminal" true (Plan.is_terminal_status (Abandoned "x"))
+
+let test_valid_plan_transitions_exhaustive () =
+  check int "Planning has 1" 1
+    (List.length (Plan.valid_plan_transitions Planning));
+  check int "Executing has 2" 2
+    (List.length (Plan.valid_plan_transitions Executing));
+  check int "Replanning has 1" 1
+    (List.length (Plan.valid_plan_transitions Replanning));
+  check int "Completed has 0" 0
+    (List.length (Plan.valid_plan_transitions Completed));
+  check int "Abandoned has 0" 0
+    (List.length (Plan.valid_plan_transitions (Abandoned "x")))
+
+let test_can_transition_to () =
+  check bool "Planning->Executing" true
+    (Plan.can_transition_to Planning Executing);
+  check bool "Planning->Completed" false
+    (Plan.can_transition_to Planning Completed);
+  check bool "Planning->Abandoned" true
+    (Plan.can_transition_to Planning (Abandoned "x"));
+  check bool "Completed->Executing" false
+    (Plan.can_transition_to Completed Executing);
+  check bool "Abandoned->Executing" false
+    (Plan.can_transition_to (Abandoned "x") Executing)
+
+let test_plan_error_message_invalid () =
+  let err = Plan.InvalidPlanTransition
+    { from_status = Planning; to_status = Completed } in
+  let msg = Plan.plan_transition_error_to_string err in
+  check bool "contains invalid" true
+    (try ignore (Str.search_forward (Str.regexp "invalid plan transition") msg 0); true
+     with Not_found -> false)
+
+let test_plan_error_message_terminal () =
+  let err = Plan.PlanAlreadyTerminal { status = Completed } in
+  let msg = Plan.plan_transition_error_to_string err in
+  check bool "contains terminal" true
+    (try ignore (Str.search_forward (Str.regexp "terminal") msg 0); true
+     with Not_found -> false)
+
 (* ── Suite ────────────────────────────────────────── *)
 
 let () =
@@ -284,5 +447,25 @@ let () =
       test_case "abandoned" `Quick test_serialization_abandoned;
       test_case "invalid json" `Quick test_deserialization_invalid;
       test_case "status strings" `Quick test_status_strings;
+    ];
+    "transition_guards", [
+      test_case "valid: Planning -> Executing" `Quick test_valid_planning_to_executing;
+      test_case "valid: Executing -> Replanning" `Quick test_valid_executing_to_replanning;
+      test_case "valid: Executing -> Completed" `Quick test_valid_executing_to_completed;
+      test_case "valid: Replanning -> Executing" `Quick test_valid_replanning_to_executing;
+      test_case "valid: abandon from Planning" `Quick test_valid_abandon_from_planning;
+      test_case "valid: abandon from Executing" `Quick test_valid_abandon_from_executing;
+      test_case "valid: abandon from Replanning" `Quick test_valid_abandon_from_replanning;
+      test_case "invalid: Planning -> Completed" `Quick test_invalid_planning_to_completed;
+      test_case "invalid: Planning -> Replanning" `Quick test_invalid_planning_to_replanning;
+      test_case "invalid: Executing -> Planning" `Quick test_invalid_executing_to_planning;
+      test_case "terminal: Completed rejects" `Quick test_terminal_completed_rejects;
+      test_case "terminal: Abandoned rejects" `Quick test_terminal_abandoned_rejects;
+      test_case "terminal: Abandoned rejects abandon" `Quick test_terminal_abandoned_rejects_abandon;
+      test_case "is_terminal_status" `Quick test_is_terminal_status;
+      test_case "valid_plan_transitions exhaustive" `Quick test_valid_plan_transitions_exhaustive;
+      test_case "can_transition_to" `Quick test_can_transition_to;
+      test_case "error message: InvalidPlanTransition" `Quick test_plan_error_message_invalid;
+      test_case "error message: PlanAlreadyTerminal" `Quick test_plan_error_message_terminal;
     ];
   ]


### PR DESCRIPTION
## Summary

- `Collaboration`에 `valid_phase_transitions`, `transition_phase` 추가 (7-state phase machine)
- `Plan`에 `valid_plan_transitions`, `transition_plan` 추가 (5-state plan machine)
- `set_phase`/`start`/`finish`/`abandon` 내부 validation + warning 로그 (후방 호환)
- 38개 transition guard 테스트 추가

## 동기

Collaboration의 `set_phase`와 Plan의 `start`/`finish`/`abandon`이 무가드 상태.
`Completed→Bootstrapping` 같은 무효 전이를 조용히 허용.
oas#650 (Lifecycle 가드)에 이어 A2A 패턴을 나머지 state machine에 적용.

## 전이 그래프

**Collaboration:**
```
Bootstrapping → [Active, Failed, Cancelled]
Active → [Waiting_on_participants, Finalizing, Failed, Cancelled]
Waiting_on_participants → [Active, Failed, Cancelled]
Finalizing → [Completed, Failed, Cancelled]
Completed/Failed/Cancelled → [] (terminal)
```

**Plan:**
```
Planning → [Executing, Abandoned]
Executing → [Replanning, Completed, Abandoned]
Replanning → [Executing, Abandoned]
Completed/Abandoned → [] (terminal)
```

## Test plan

- [x] Collaboration: 20개 transition tests + 기존 42개 통과 (62 total)
- [x] Plan: 18개 transition tests + 기존 20개 통과 (38 total)
- [x] `dune runtest` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)