### PR TITLE
fix(lifecycle): support multi-turn cycle, block invalid transitions

### DIFF
--- a/lib/agent/agent_lifecycle.ml
+++ b/lib/agent/agent_lifecycle.ml
@@ -25,7 +25,7 @@ let is_terminal = function
 let valid_transitions = function
   | Accepted -> [Ready; Failed]
   | Ready    -> [Running; Failed]
-  | Running  -> [Completed; Failed]
+  | Running  -> [Ready; Completed; Failed]
   | Completed -> []
   | Failed    -> []
 

--- a/lib/agent/agent_lifecycle.mli
+++ b/lib/agent/agent_lifecycle.mli
@@ -8,9 +8,11 @@
     The [transition] function enforces a valid state machine:
     - [Accepted] -> [Ready | Failed]
     - [Ready]    -> [Running | Failed]
-    - [Running]  -> [Completed | Failed]
+    - [Running]  -> [Ready | Completed | Failed]
     - [Completed] and [Failed] are terminal (no outgoing transitions).
     - Same-state transitions on non-terminal states are allowed (reaffirm).
+    [Running -> Ready] supports multi-turn agent loops where each turn
+    cycles through [Ready -> Running -> Ready -> ...] before terminating.
 
     Follows the pattern established by {!A2a_task.transition}.
 

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -159,30 +159,32 @@ let card t =
     write could interleave, losing an update.
 
     Validates the transition against {!Agent_lifecycle.valid_transitions}.
-    Invalid transitions log a warning but still proceed for backward
-    compatibility.  Callers that need strict enforcement should use
-    {!Agent_lifecycle.transition} directly. *)
+    Invalid transitions are rejected: the state is not updated and an
+    error is logged to stderr. *)
 let set_lifecycle agent ?current_run_id ?worker_id ?runtime_actor ?last_error
     ?accepted_at ?ready_at ?first_progress_at ?started_at ?last_progress_at
     ?finished_at status =
   Eio.Mutex.use_rw ~protect:true agent.mu (fun () ->
-    (match agent.lifecycle with
-     | Some prev ->
-       (match Agent_lifecycle.transition ~from:prev.status ~to_:status with
-        | Error e ->
-          Printf.eprintf "[WARN] %s (agent=%s)\n%!"
-            (Agent_lifecycle.transition_error_to_string e)
-            agent.state.config.name
-        | Ok _ -> ())
-     | None -> ());
-    agent.lifecycle <- Some (Agent_lifecycle.build_snapshot
-      ~agent_name:agent.state.config.name
-      ~provider:agent.options.provider
-      ~model:agent.state.config.model
-      ?previous:agent.lifecycle
-      ?current_run_id ?worker_id ?runtime_actor ?last_error
-      ?accepted_at ?ready_at ?first_progress_at ?started_at
-      ?last_progress_at ?finished_at status))
+    let allowed = match agent.lifecycle with
+      | Some prev ->
+        (match Agent_lifecycle.transition ~from:prev.status ~to_:status with
+         | Error e ->
+           Printf.eprintf "[ERROR] %s (agent=%s)\n%!"
+             (Agent_lifecycle.transition_error_to_string e)
+             agent.state.config.name;
+           false
+         | Ok _ -> true)
+      | None -> true
+    in
+    if allowed then
+      agent.lifecycle <- Some (Agent_lifecycle.build_snapshot
+        ~agent_name:agent.state.config.name
+        ~provider:agent.options.provider
+        ~model:agent.state.config.model
+        ?previous:agent.lifecycle
+        ?current_run_id ?worker_id ?runtime_actor ?last_error
+        ?accepted_at ?ready_at ?first_progress_at ?started_at
+        ?last_progress_at ?finished_at status))
 
 let create ~net ?(config=default_config) ?(tools=[]) ?context ?named_cascade
     ?(options=default_options) () =

--- a/test/test_agent_lifecycle.ml
+++ b/test/test_agent_lifecycle.ml
@@ -147,6 +147,10 @@ let test_transition_ready_to_running () =
   check_ok "Ready->Running"
     (Agent_lifecycle.transition ~from:Ready ~to_:Running)
 
+let test_transition_running_to_ready () =
+  check_ok "Running->Ready (multi-turn)"
+    (Agent_lifecycle.transition ~from:Running ~to_:Ready)
+
 let test_transition_running_to_completed () =
   check_ok "Running->Completed"
     (Agent_lifecycle.transition ~from:Running ~to_:Completed)
@@ -211,7 +215,7 @@ let test_valid_transitions_exhaustive () =
     (List.length (Agent_lifecycle.valid_transitions Accepted));
   Alcotest.(check int) "Ready has 2" 2
     (List.length (Agent_lifecycle.valid_transitions Ready));
-  Alcotest.(check int) "Running has 2" 2
+  Alcotest.(check int) "Running has 3" 3
     (List.length (Agent_lifecycle.valid_transitions Running));
   Alcotest.(check int) "Completed has 0" 0
     (List.length (Agent_lifecycle.valid_transitions Completed));
@@ -251,6 +255,7 @@ let () =
     "transition_guards", [
       Alcotest.test_case "Accepted -> Ready" `Quick test_transition_accepted_to_ready;
       Alcotest.test_case "Ready -> Running" `Quick test_transition_ready_to_running;
+      Alcotest.test_case "Running -> Ready (multi-turn)" `Quick test_transition_running_to_ready;
       Alcotest.test_case "Running -> Completed" `Quick test_transition_running_to_completed;
       Alcotest.test_case "Running -> Failed" `Quick test_transition_running_to_failed;
       Alcotest.test_case "Accepted -> Failed" `Quick test_transition_accepted_to_failed;


### PR DESCRIPTION
## Summary
- FSM rejected `Running -> Ready` which is the normal multi-turn cycle transition, causing `[WARN]` on every turn
- Added `Ready` to valid transitions from `Running` to model the multi-turn loop: `Ready -> Running -> Ready -> Running -> ... -> Completed`
- Promoted invalid transitions from `[WARN]` to `[ERROR]` and now block state mutation (was silently applied despite the warning)

## Changes
| File | Change |
|------|--------|
| `agent_lifecycle.ml` | `Running -> [Ready; Completed; Failed]` |
| `agent_lifecycle.mli` | Updated doc comment |
| `agent_types.ml` | `set_lifecycle` blocks state change on invalid transition, `[ERROR]` |
| `test_agent_lifecycle.ml` | `Running -> Ready` test, exhaustive count 2->3 |

## Observed symptom
```
[WARN] invalid lifecycle transition: Agent_lifecycle.Running -> Agent_lifecycle.Ready (agent=oas-keeper_unified)
```
Logged on every turn of every multi-turn agent.

## Test plan
- [x] `test_agent_lifecycle.exe` — 27 tests pass
- [x] `dune build` clean
- [ ] CI

Generated with [Claude Code](https://claude.com/claude-code)