### PR TITLE
fix(lifecycle): allow Running → Ready transition for multi-turn agents

### DIFF
--- a/lib/agent/agent_lifecycle.ml
+++ b/lib/agent/agent_lifecycle.ml
@@ -25,7 +25,7 @@ let is_terminal = function
 let valid_transitions = function
   | Accepted -> [Ready; Failed]
   | Ready    -> [Running; Failed]
-  | Running  -> [Completed; Failed]
+  | Running  -> [Ready; Completed; Failed]
   | Completed -> []
   | Failed    -> []
 

--- a/lib/agent/agent_lifecycle.mli
+++ b/lib/agent/agent_lifecycle.mli
@@ -8,9 +8,12 @@
     The [transition] function enforces a valid state machine:
     - [Accepted] -> [Ready | Failed]
     - [Ready]    -> [Running | Failed]
-    - [Running]  -> [Completed | Failed]
+    - [Running]  -> [Ready | Completed | Failed]
     - [Completed] and [Failed] are terminal (no outgoing transitions).
     - Same-state transitions on non-terminal states are allowed (reaffirm).
+
+    [Running -> Ready] models a multi-turn agent returning to input-wait
+    state between turns (pipeline stage_input sets Ready each turn).
 
     Follows the pattern established by {!A2a_task.transition}.
 


### PR DESCRIPTION
## Summary

- `stage_input`이 매 턴 시작마다 `set_lifecycle Ready`를 호출하지만, 이전 턴의 `stage_parse`에서 `Running`으로 전환된 상태
- `Running → Ready`가 상태 머신에 없어서 매 턴 `[WARN] invalid lifecycle transition` 발생
- `Running → Ready`를 합법 전환으로 추가 — 멀티턴 에이전트의 "실행 완료 → 입력 대기" 사이클을 표현

## Changes

| 파일 | 변경 |
|------|------|
| `lib/agent/agent_lifecycle.ml` | `Running` valid_transitions에 `Ready` 추가 |
| `lib/agent/agent_lifecycle.mli` | 상태 머신 문서 업데이트 |

## Test plan

- [x] `test_agent.exe` — 15/15 pass
- [x] `dune build` — clean

Closes #658 (partially — exposes `max_turns` is separate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)