### PR TITLE
feat(agent): public make_extend_turns_tool API

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -219,6 +219,9 @@ let resume ~net ~(checkpoint : Checkpoint.t) ?(tools=[]) ?context
     consecutive_idle_turns = 0; named_cascade;
     tools = Tool_set.of_list tools; net; context = ctx; options }
 
+let make_extend_turns_tool ~agent_ref ~budget ?max_idle_before_extend () =
+  Agent_turn_budget.make_tool ~agent_ref ~budget ?max_idle_before_extend ()
+
 let checkpoint ?(session_id="") ?working_context agent =
   Agent_checkpoint.build_checkpoint ~session_id ?working_context ~state:agent.state
     ~tools:agent.tools ~context:agent.context

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -157,6 +157,23 @@ val checkpoint :
   t ->
   Checkpoint.t
 
+(** {1 Turn Budget} *)
+
+(** Build an [extend_turns] tool for external consumers.
+
+    Wraps {!Agent_turn_budget.make_tool} with the public [Agent.t] type
+    so downstream coordinators (MASC, etc.) can use it without accessing
+    the internal [Agent_types.t].
+
+    @param agent_ref Set to [Some agent] after {!run} begins.
+    @param budget Created via {!Agent_turn_budget.create}.
+    @since 0.109.0 *)
+val make_extend_turns_tool :
+  agent_ref:t option ref ->
+  budget:Agent_turn_budget.t ->
+  ?max_idle_before_extend:int ->
+  unit -> Tool.t
+
 (** {1 Lifecycle} *)
 
 val last_raw_trace_run : t -> Raw_trace.run_ref option


### PR DESCRIPTION
## Summary
- `Agent_turn_budget.make_tool`은 internal `Agent_types.t`를 받아 external consumer가 abstract `Agent.t`와 함께 사용 불가
- `Agent.make_extend_turns_tool`을 추가하여 public `Agent.t option ref`를 받도록 wrapping
- MASC keeper가 `Agent.set_state` (internal, testing-only) 대신 이 API를 사용할 수 있게 됨

## Test plan
- [x] `dune build` 통과
- [x] `test_agent` 15/15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)