### PR TITLE
fix(contract): preserve Context.t identity in context_with_contract

### DIFF
--- a/lib/contract.ml
+++ b/lib/contract.ml
@@ -243,7 +243,7 @@ let context_with_contract ?context contract =
   else
     let ctx =
       match context with
-      | Some value -> Context.copy value
+      | Some value -> value
       | None -> Context.create ()
     in
     Context.set ctx context_key (to_json contract);

--- a/test/test_contract.ml
+++ b/test/test_contract.ml
@@ -228,6 +228,22 @@ let test_context_with_contract_non_empty () =
     check_bool "has value" true (value <> None)
   | None -> Alcotest.fail "expected context"
 
+let test_context_with_contract_preserves_identity () =
+  let original = Context.create () in
+  Context.set original "user_data" (`String "hello");
+  let c = Contract.with_runtime_awareness "test" Contract.empty in
+  match Contract.context_with_contract ~context:original c with
+  | Some ctx ->
+    (* returned context IS the original, not a copy *)
+    Context.set ctx "injected" (`String "world");
+    let from_original = Context.get original "injected" in
+    check_bool "write to returned ctx visible in original"
+      true (from_original = Some (`String "world"));
+    let from_ctx = Context.get ctx "user_data" in
+    check_bool "original data in returned ctx"
+      true (from_ctx = Some (`String "hello"))
+  | None -> Alcotest.fail "expected context"
+
 (* ── Suite ────────────────────────────────────────────── *)
 
 let () =
@@ -282,5 +298,6 @@ let () =
     "context", [
       Alcotest.test_case "empty contract" `Quick test_context_with_contract_empty;
       Alcotest.test_case "non-empty contract" `Quick test_context_with_contract_non_empty;
+      Alcotest.test_case "preserves identity" `Quick test_context_with_contract_preserves_identity;
     ];
   ]


### PR DESCRIPTION
## Summary
- `Context.copy`가 `context_with_contract`에서 새 인스턴스를 생성하여 shared_context identity 깨뜨림
- keeper hook이 원본 context를 읽지만 Agent는 복사본에 쓰므로 temporal data가 전달 안 됨
- copy 제거: contract key를 원본 context에 직접 set

## Test plan
- [x] `test_context_with_contract_preserves_identity` 추가 — 반환된 ctx에 write하면 original에서 읽힘
- [x] 기존 32개 contract 테스트 통과
- [x] context, agent 테스트 통과
- [ ] masc-mcp keeper에서 temporal data 도달 확인 (통합)

Closes #675
Fixes jeong-sik/masc-mcp#5576

🤖 Generated with [Claude Code](https://claude.com/claude-code)