### PR TITLE
fix(discovery): sync model_endpoints before cascade parsing

### DIFF
--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -270,6 +270,16 @@ let complete_named ~sw ~net ?clock ?config_path
                   | Hardcoded_defaults -> "hardcoded_defaults")
       })
   else
+  (* Sync discovery state before parsing so that endpoint_for_model can
+     route llama:model_id to the correct endpoint. Without this, the
+     model_endpoints atomic is empty and all llama models fall back to
+     round-robin, which may route to a server without that model. #677 *)
+  let _discovery_statuses =
+    let endpoints = Discovery.endpoints_from_env () in
+    if endpoints <> [] then
+      Discovery.refresh_and_sync ~sw ~net ~endpoints
+    else []
+  in
   let providers =
     parse_model_strings ~temperature ~max_tokens ?system_prompt model_strings
   in

--- a/lib/llm_provider/cascade_health_filter.ml
+++ b/lib/llm_provider/cascade_health_filter.ml
@@ -63,7 +63,11 @@ let filter_healthy_internal ~sw ~net (providers : Provider_config.t list) =
       |> List.map (fun (cfg : Provider_config.t) -> cfg.base_url)
       |> List.sort_uniq String.compare
     in
-    let statuses = Discovery.discover ~sw ~net ~endpoints in
+    (* Use refresh_and_sync instead of discover so that the shared
+       model_endpoints index is populated. Without this, endpoint_for_model
+       always returns None and model-specific routing in
+       make_registry_config falls back to round-robin. See #677. *)
+    let statuses = Discovery.refresh_and_sync ~sw ~net ~endpoints in
     if cloud_providers = [] then
       (providers, statuses)
     else


### PR DESCRIPTION
## Summary
- `complete_named()`에서 `parse_model_strings` 전에 `Discovery.refresh_and_sync`를 호출하여 `model_endpoints` atomic state를 미리 populate
- `filter_healthy_internal`에서 `discover()` → `refresh_and_sync()`로 변경하여 health check 시에도 model index가 갱신되도록 수정

## Root Cause
`endpoint_for_model()`이 `_discovered_ctx.model_endpoints`를 조회하지만, `complete_named` 실행 시점에 이 atomic이 비어 있었음. `discover()`는 프로브만 하고 atomic state를 업데이트하지 않고, `refresh_and_sync()`만 업데이트함.

실행 순서 문제:
1. `parse_model_strings` → `endpoint_for_model` 호출 (비어있음 → round-robin fallback)
2. `filter_healthy_internal` → `discover()` (프로브만, state 미갱신)

## Test plan
- [x] `dune build` clean
- [x] `dune runtest` all pass (27 lifecycle + inline tests)
- [ ] CI green

Closes #677