### PR TITLE
fix(pipeline): cascade fallback on text-only response when tool_choice=Any

### DIFF
--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -164,7 +164,7 @@ let stage_route ~sw ?clock ~api_strategy agent prep =
            models (e.g. 9B) from "succeeding" with text_response when tools
            were mandatory, starving the fallback provider of a chance. *)
         let accept = match agent.state.config.tool_choice with
-          | Some Types.Any ->
+          | Some (Types.Any | Types.Tool _) ->
             (fun (resp : Types.api_response) ->
               List.exists (function Types.ToolUse _ -> true | _ -> false) resp.content)
           | _ -> fun _ -> true


### PR DESCRIPTION
## Summary

- `tool_choice=Any`(required)일 때 tool call이 없는 응답을 cascade에서 reject
- reject된 응답 → cascade fallback → 다음 모델로 재시도
- 9B(42.9% tool calling rate)가 text_response로 "성공"하여 GLM-5.1 fallback을 차단하던 문제 해결

### 동작 변경

| 상황 | 이전 | 이후 |
|------|------|------|
| 9B가 text_response 반환 + tool_choice=Any | 성공으로 판정, fallback 없음 | **reject → GLM fallback** |
| 9B가 tool_call 반환 + tool_choice=Any | 성공 | 성공 (변경 없음) |
| tool_choice=Auto | 무조건 수락 | 무조건 수락 (변경 없음) |

### 근거

MASC keeper E2E 관찰에서 확인:
- admin, coder: 9B model, 0 tool calls, status_tick (죽은 상태)
- cheolsu, janitor, sangsu: GLM-5.1 fallback, 4-13 tool calls (정상)
- 차이: 9B fallback이 발동된 keeper만 정상 동작

## Test plan

- [ ] tool_choice=Any + text-only response → cascade fallback 발동 확인
- [ ] tool_choice=Any + tool_call response → 정상 수락 확인
- [ ] tool_choice=Auto → 모든 응답 수락 확인 (regression 없음)
- [ ] named_cascade 없는 경로 → 영향 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)