### PR TITLE
fix(cascade): restore timeout wrapper for type-safe Eio.with_timeout

### DIFF
--- a/lib/llm_provider/cascade_executor.ml
+++ b/lib/llm_provider/cascade_executor.ml
@@ -80,8 +80,13 @@ let complete_cascade_with_accept ~sw ~net ?clock ?cache ?metrics
     let call_with_timeout () =
       match clock with
       | Some clock when not is_last && cascade_model_timeout_sec > 0.0 ->
-        (match Eio.Time.with_timeout clock cascade_model_timeout_sec call with
-         | Ok result -> result
+        let wrapped () =
+          match call () with
+          | Ok v -> Ok (Ok v)
+          | Error e -> Ok (Error e)
+        in
+        (match Eio.Time.with_timeout clock cascade_model_timeout_sec wrapped with
+         | Ok inner -> inner
          | Error `Timeout ->
            Error (Http_client.NetworkError {
                message = Printf.sprintf "timeout after %.0fs, cascading to next provider"


### PR DESCRIPTION
## Summary
- Reverts the broken simplification from #684 that removed the `wrapped` function
- `Eio.Time.with_timeout` requires `[> \`Timeout]` in the error variant, but `Http_client.http_error` is a closed variant — the wrapper lifts the result into `Ok` so `with_timeout` sees a plain value

## Root cause
#684 was merged without CI (OAS has no required checks). The type error was only caught when MASC CI tried to build against this SHA.

## Test plan
- [x] `dune build --root .` passes locally
- [ ] MASC CI green after pin update

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>