### PR TITLE
refactor: hoist Log.create to module level

### DIFF
--- a/lib/checkpoint.ml
+++ b/lib/checkpoint.ml
@@ -7,6 +7,7 @@
 
 open Types
 
+let _log = Log.create ~module_name:"checkpoint" ()
 let checkpoint_version = 4
 
 type t = {
@@ -873,7 +874,6 @@ let restore_with_delta_fallback ?metrics ~base ~delta ~full_checkpoint () =
     match apply_delta base delta with
     | Ok checkpoint -> Ok { checkpoint; mode = Delta_applied }
     | Error e ->
-      let _log = Log.create ~module_name:"checkpoint" () in
       Log.warn _log "delta application failed, falling back to full restore"
         [Log.S ("error", Error.to_string e);
          Log.S ("base_hash", delta.base_checkpoint_hash)];

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -6,6 +6,8 @@
 
 open Types
 
+let _log = Log.create ~module_name:"orchestrator" ()
+
 (* ── Types ────────────────────────────────────────────────────────── *)
 
 type task = {
@@ -169,7 +171,7 @@ let pipeline ~sw ?clock orch tasks =
 (* ── Utilities ────────────────────────────────────────────────────── *)
 
 let collect_text results =
-  let _log = Log.create ~module_name:"orchestrator" () in
+
   List.filter_map (fun tr ->
     match tr.result with
     | Ok resp -> Some (text_of_response resp)
@@ -299,7 +301,7 @@ type selection_strategy =
 
 (** Select the winning result from a list using the given strategy. *)
 let select_winner strategy results =
-  let _log = Log.create ~module_name:"orchestrator" () in
+
   match strategy with
   | FirstOk ->
     List.find_opt (fun tr ->

--- a/lib/otel_export.ml
+++ b/lib/otel_export.ml
@@ -30,8 +30,9 @@ type export_result =
 
 (* ── TLS helper (self-contained, no llm_provider dep) ───────── *)
 
+let _log = Log.create ~module_name:"otel_export" ()
+
 let make_https () =
-  let _log = Log.create ~module_name:"otel_export" () in
   match Ca_certs.authenticator () with
   | Error (`Msg msg) ->
     Log.warn _log "TLS CA certificate loading failed"

--- a/lib/protocol/a2a_task_store.ml
+++ b/lib/protocol/a2a_task_store.ml
@@ -4,6 +4,8 @@
     Atomic writes via .tmp + rename (same pattern as checkpoint_store.ml).
     In-memory Hashtbl cache for fast lookups; file I/O for durability. *)
 
+let _log = Log.create ~module_name:"a2a_task_store" ()
+
 type t = {
   base_dir: Eio.Fs.dir_ty Eio.Path.t;
   cache: (A2a_task.task_id, A2a_task.task) Hashtbl.t;
@@ -83,7 +85,6 @@ let reload store =
              && String.sub name (len - 5) 5 = ".json"
              && not (len > 9 && String.sub name (len - 9) 9 = ".json.tmp"))
     in
-    let log = Log.create ~module_name:"a2a_task_store" () in
     List.iter (fun filename ->
       let path = Eio.Path.(store.base_dir / filename) in
       try
@@ -92,10 +93,10 @@ let reload store =
         match A2a_task.task_of_yojson json with
         | Ok task -> Hashtbl.replace store.cache task.id task
         | Error e ->
-          Log.warn log "skipping corrupted task file during reload"
+          Log.warn _log "skipping corrupted task file during reload"
             [Log.S ("file", filename); Log.S ("error", e)]
       with (Eio.Io _ | Yojson.Json_error _) as exn ->
-        Log.warn log "skipping unreadable task file during reload"
+        Log.warn _log "skipping unreadable task file during reload"
           [Log.S ("file", filename); Log.S ("error", Printexc.to_string exn)]
     ) json_files;
     Ok ()
@@ -113,7 +114,6 @@ let gc ?(max_age_s = 86400.0) store =
     then id :: acc
     else acc
   ) store.cache [] in
-  let _log = Log.create ~module_name:"a2a_task_store" () in
   let errors = List.filter_map (fun id ->
     match delete_task store id with
     | Ok () -> None

--- a/lib/runtime_server_worker.ml
+++ b/lib/runtime_server_worker.ml
@@ -3,6 +3,7 @@ open Runtime_server_types
 open Runtime_server_resolve
 
 let ( let* ) = Result.bind
+let _log = Log.create ~module_name:"runtime_server_worker" ()
 
 let extract_text (resp : Types.api_response) =
   resp.content
@@ -136,7 +137,7 @@ let run_participant store state session_id
     | Error e ->
       if not !delta_warn_logged then begin
         delta_warn_logged := true;
-        let _log = Log.create ~module_name:"runtime_server_worker" () in
+
         Log.warn _log "output delta emission failed"
           [Log.S ("session_id", session_id);
            Log.S ("participant", detail.participant_name);
@@ -177,7 +178,7 @@ let run_participant store state session_id
                  (Raw_trace.finish_run active ~final_text:(Some full)
                     ~stop_reason:(Some "EndTurn") ~error:None)
            | Error e ->
-               let _log = Log.create ~module_name:"runtime_server_worker" () in
+       
                Log.warn _log "trace start_run failed for mock provider"
                  [Log.S ("session_id", session_id);
                   Log.S ("agent", detail.participant_name);


### PR DESCRIPTION
## Summary
- Move per-function `Log.create` to module-level bindings in 5 files
- Avoids redundant record allocations on each function call
- Follow-up to #688 (silent failure logging)

Files: orchestrator.ml, runtime_server_worker.ml, checkpoint.ml, otel_export.ml, a2a_task_store.ml