### PR TITLE
Enforce completion contracts for tool-required turns

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -59,6 +59,7 @@ module Mcp_session = Mcp_session
 module Sse_parser = Sse_parser
 module Guardrails = Guardrails
 module Tool_set = Tool_set
+module Completion_contract = Completion_contract
 module Log = Log
 module Event_bus = Event_bus
 module Skill = Skill

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -59,7 +59,6 @@ module Mcp_session = Mcp_session
 module Sse_parser = Sse_parser
 module Guardrails = Guardrails
 module Tool_set = Tool_set
-module Completion_contract = Completion_contract
 module Log = Log
 module Event_bus = Event_bus
 module Skill = Skill

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -38,11 +38,19 @@ let openai_content_parts_of_blocks = Api_openai.openai_content_parts_of_blocks
 let build_openai_body = Api_openai.build_openai_body
 let parse_openai_response_result = Llm_provider.Backend_openai_parse.parse_openai_response_result
 
-let map_named_cascade_error = function
+let map_named_cascade_error ~(contract : Completion_contract.t) = function
   | Llm_provider.Http_client.HttpError { code; body } ->
       Error.Api (Retry.classify_error ~status:code ~body)
   | Llm_provider.Http_client.NetworkError { message } ->
       Error.Api (Retry.NetworkError { message })
+  | Llm_provider.Http_client.AcceptRejected { reason } ->
+      (match contract with
+       | Completion_contract.Allow_text_or_tool ->
+         Error.Api (Retry.NetworkError { message = reason })
+       | _ ->
+         Error.Agent
+           (CompletionContractViolation
+              { contract = Completion_contract.to_string contract; reason }))
 
 (** Send a non-streaming message to the API, dispatching by provider *)
 let create_message ~sw ~net ?(base_url=default_base_url) ?provider ?clock ?retry_config ~config ~messages ?tools ?slot_id () =
@@ -206,8 +214,16 @@ let create_message_named ~sw ~net ?clock ~(named_cascade : named_cascade)
     | Some m -> m
     | None -> named_cascade.metrics
   in
-  let accept_result =
+  let completion_contract =
+    Completion_contract.of_tool_choice config.config.tool_choice
+  in
+  let caller_accept =
     Completion_contract.resolve_accept ~accept ?accept_reason
+  in
+  let accept_result response =
+    match Completion_contract.validate_response ~contract:completion_contract response with
+    | Error reason -> Error reason
+    | Ok () -> caller_accept response
   in
   match
     Llm_provider.Cascade_config.complete_named ~sw ~net ?clock
@@ -218,7 +234,7 @@ let create_message_named ~sw ~net ?clock ~(named_cascade : named_cascade)
       ?provider_filter:named_cascade.provider_filter ()
   with
   | Ok response -> Ok response
-  | Error err -> Error (map_named_cascade_error err)
+  | Error err -> Error (map_named_cascade_error ~contract:completion_contract err)
 
 let create_message_named_stream ~sw ~net ?clock
     ~(named_cascade : named_cascade) ~config ~messages ?tools
@@ -233,6 +249,9 @@ let create_message_named_stream ~sw ~net ?clock
     | Some m -> m
     | None -> named_cascade.metrics
   in
+  let completion_contract =
+    Completion_contract.of_tool_choice config.config.tool_choice
+  in
   match
     Llm_provider.Cascade_config.complete_named_stream ~sw ~net ?clock
       ?config_path:named_cascade.config_path ~name:named_cascade.name
@@ -242,7 +261,7 @@ let create_message_named_stream ~sw ~net ?clock
       ?provider_filter:named_cascade.provider_filter ()
   with
   | Ok response -> Ok response
-  | Error err -> Error (map_named_cascade_error err)
+  | Error err -> Error (map_named_cascade_error ~contract:completion_contract err)
 
 [@@@coverage off]
 (* === Inline tests === *)
@@ -257,14 +276,21 @@ let%test "named_cascade with config_path" =
 
 let%test "map_named_cascade_error HttpError" =
   let err = Llm_provider.Http_client.HttpError { code = 429; body = "rate limited" } in
-  match map_named_cascade_error err with
+  match map_named_cascade_error ~contract:Completion_contract.Allow_text_or_tool err with
   | Error.Api _ -> true
   | _ -> false
 
 let%test "map_named_cascade_error NetworkError" =
   let err = Llm_provider.Http_client.NetworkError { message = "timeout" } in
-  match map_named_cascade_error err with
+  match map_named_cascade_error ~contract:Completion_contract.Allow_text_or_tool err with
   | Error.Api (Retry.NetworkError { message }) -> message = "timeout"
+  | _ -> false
+
+let%test "map_named_cascade_error AcceptRejected with tool contract" =
+  let err = Llm_provider.Http_client.AcceptRejected { reason = "validator rejected" } in
+  match map_named_cascade_error ~contract:Completion_contract.Require_tool_use err with
+  | Error.Agent (CompletionContractViolation { contract; reason }) ->
+    contract = "require_tool_use" && reason = "validator rejected"
   | _ -> false
 
 let%test "re-exported default_base_url is non-empty" =
@@ -324,13 +350,13 @@ let%test "text_blocks_to_string joins text" =
 
 let%test "map_named_cascade_error HttpError 500" =
   let err = Llm_provider.Http_client.HttpError { code = 500; body = "server error" } in
-  match map_named_cascade_error err with
+  match map_named_cascade_error ~contract:Completion_contract.Allow_text_or_tool err with
   | Error.Api _ -> true
   | _ -> false
 
 let%test "map_named_cascade_error HttpError 429" =
   let err = Llm_provider.Http_client.HttpError { code = 429; body = "rate limit" } in
-  match map_named_cascade_error err with
+  match map_named_cascade_error ~contract:Completion_contract.Allow_text_or_tool err with
   | Error.Api _ -> true
   | _ -> false
 

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -206,21 +206,15 @@ let create_message_named ~sw ~net ?clock ~(named_cascade : named_cascade)
     | Some m -> m
     | None -> named_cascade.metrics
   in
-  let accept =
-    match accept_reason with
-    | Some validator -> validator
-    | None ->
-      fun response ->
-        if accept response
-        then Ok ()
-        else Error "response rejected by accept validator"
+  let accept_result =
+    Completion_contract.resolve_accept ~accept ?accept_reason
   in
   match
     Llm_provider.Cascade_config.complete_named ~sw ~net ?clock
       ?config_path:named_cascade.config_path ~name:named_cascade.name
       ~defaults:named_cascade.defaults ~messages ?tools ~temperature
       ~max_tokens ?system_prompt ?tool_choice:config.config.tool_choice
-      ~accept_reason:accept ~accept_on_exhaustion ?timeout_sec ~metrics ?priority
+      ~accept_reason:accept_result ~accept_on_exhaustion ?timeout_sec ~metrics ?priority
       ?provider_filter:named_cascade.provider_filter ()
   with
   | Ok response -> Ok response

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -10,6 +10,8 @@ type named_cascade = {
   provider_filter : string list option;
 }
 
+type response_accept = Types.api_response -> (unit, string) result
+
 let named_cascade ?config_path ?metrics ?provider_filter ~name ~defaults () =
   let metrics = match metrics with Some m -> m | None -> Llm_provider.Metrics.noop in
   { name; defaults; config_path; metrics; provider_filter }
@@ -188,7 +190,7 @@ let create_message_cascade ~sw ~net ?clock ?retry_config
 let create_message_named ~sw ~net ?clock ~(named_cascade : named_cascade)
     ~config ~messages ?tools ?(temperature = 0.3)
     ?(max_tokens = config.config.max_tokens)
-    ?system_prompt ?(accept = fun _ -> true) ?(accept_on_exhaustion = false)
+    ?system_prompt ?(accept = fun _ -> Ok ()) ?(accept_on_exhaustion = false)
     ?timeout_sec ?metrics ?priority () =
   let system_prompt =
     match system_prompt with

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -190,7 +190,8 @@ let create_message_cascade ~sw ~net ?clock ?retry_config
 let create_message_named ~sw ~net ?clock ~(named_cascade : named_cascade)
     ~config ~messages ?tools ?(temperature = 0.3)
     ?(max_tokens = config.config.max_tokens)
-    ?system_prompt ?(accept = fun _ -> Ok ()) ?(accept_on_exhaustion = false)
+    ?system_prompt ?(accept = fun _ -> true) ?accept_reason
+    ?(accept_on_exhaustion = false)
     ?timeout_sec ?metrics ?priority () =
   let system_prompt =
     match system_prompt with
@@ -205,12 +206,21 @@ let create_message_named ~sw ~net ?clock ~(named_cascade : named_cascade)
     | Some m -> m
     | None -> named_cascade.metrics
   in
+  let accept =
+    match accept_reason with
+    | Some validator -> validator
+    | None ->
+      fun response ->
+        if accept response
+        then Ok ()
+        else Error "response rejected by accept validator"
+  in
   match
     Llm_provider.Cascade_config.complete_named ~sw ~net ?clock
       ?config_path:named_cascade.config_path ~name:named_cascade.name
       ~defaults:named_cascade.defaults ~messages ?tools ~temperature
       ~max_tokens ?system_prompt ?tool_choice:config.config.tool_choice
-      ~accept ~accept_on_exhaustion ?timeout_sec ~metrics ?priority
+      ~accept_reason:accept ~accept_on_exhaustion ?timeout_sec ~metrics ?priority
       ?provider_filter:named_cascade.provider_filter ()
   with
   | Ok response -> Ok response

--- a/lib/api.mli
+++ b/lib/api.mli
@@ -13,6 +13,8 @@ type named_cascade = {
   provider_filter : string list option;
 }
 
+type response_accept = Types.api_response -> (unit, string) result
+
 val named_cascade :
   ?config_path:string -> ?metrics:Llm_provider.Metrics.t ->
   ?provider_filter:string list ->
@@ -104,7 +106,7 @@ val create_message_named :
   ?temperature:float ->
   ?max_tokens:int ->
   ?system_prompt:string ->
-  ?accept:(Types.api_response -> bool) ->
+  ?accept:response_accept ->
   ?accept_on_exhaustion:bool ->
   ?timeout_sec:int ->
   ?metrics:Llm_provider.Metrics.t ->

--- a/lib/api.mli
+++ b/lib/api.mli
@@ -106,7 +106,8 @@ val create_message_named :
   ?temperature:float ->
   ?max_tokens:int ->
   ?system_prompt:string ->
-  ?accept:response_accept ->
+  ?accept:(Types.api_response -> bool) ->
+  ?accept_reason:response_accept ->
   ?accept_on_exhaustion:bool ->
   ?timeout_sec:int ->
   ?metrics:Llm_provider.Metrics.t ->

--- a/lib/completion_contract.ml
+++ b/lib/completion_contract.ml
@@ -32,6 +32,15 @@ let accept_on_exhaustion ~(contract : t) =
   | Allow_text_or_tool -> false
   | Require_tool_use -> false
 
+let resolve_accept ?accept_reason ~(accept : api_response -> bool) =
+  match accept_reason with
+  | Some validator -> validator
+  | None ->
+    fun response ->
+      if accept response
+      then Ok ()
+      else Error "response rejected by accept validator"
+
 let%test "of_tool_choice requires tools for Any" =
   match of_tool_choice (Some Any) with
   | Require_tool_use -> true

--- a/lib/completion_contract.ml
+++ b/lib/completion_contract.ml
@@ -37,6 +37,26 @@ let%test "of_tool_choice requires tools for Any" =
   | Require_tool_use -> true
   | Allow_text_or_tool -> false
 
+let%test "of_tool_choice allows text for None and Auto and explicit none" =
+  of_tool_choice None = Allow_text_or_tool
+  && of_tool_choice (Some Auto) = Allow_text_or_tool
+  && of_tool_choice (Some None_) = Allow_text_or_tool
+
+let%test "of_tool_choice requires tools for explicit Tool" =
+  of_tool_choice (Some (Tool "calculator")) = Require_tool_use
+
+let%test "validate_response allows text for Allow_text_or_tool" =
+  validate_response
+    ~contract:Allow_text_or_tool
+    { id = "r";
+      model = "m";
+      stop_reason = EndTurn;
+      content = [ Text "hello" ];
+      usage = None;
+      telemetry = None;
+    }
+  = Ok ()
+
 let%test "validate_response accepts ToolUse for Require_tool_use" =
   validate_response
     ~contract:Require_tool_use

--- a/lib/completion_contract.ml
+++ b/lib/completion_contract.ml
@@ -86,10 +86,9 @@ let%test "of_tool_choice requires tools for Any" =
   | Require_tool_use -> true
   | Allow_text_or_tool | Require_specific_tool _ | Require_no_tool_use -> false
 
-let%test "of_tool_choice allows text for None and Auto and explicit none" =
+let%test "of_tool_choice allows text for None and Auto" =
   of_tool_choice None = Allow_text_or_tool
   && of_tool_choice (Some Auto) = Allow_text_or_tool
-  && of_tool_choice (Some None_) = Allow_text_or_tool
 
 let%test "of_tool_choice requires tools for explicit Tool" =
   of_tool_choice (Some (Tool "calculator")) = Require_specific_tool "calculator"

--- a/lib/completion_contract.ml
+++ b/lib/completion_contract.ml
@@ -1,0 +1,73 @@
+open Types
+
+type t =
+  | Allow_text_or_tool
+  | Require_tool_use
+
+let to_string = function
+  | Allow_text_or_tool -> "allow_text_or_tool"
+  | Require_tool_use -> "require_tool_use"
+
+let of_tool_choice = function
+  | Some (Any | Tool _) -> Require_tool_use
+  | Some Auto | Some None_ | None -> Allow_text_or_tool
+
+let validate_response ~(contract : t) (response : api_response) :
+    (unit, string) result =
+  match contract with
+  | Allow_text_or_tool -> Ok ()
+  | Require_tool_use ->
+    if List.exists (function ToolUse _ -> true | _ -> false) response.content
+    then Ok ()
+    else
+      Error
+        "required tool contract unsatisfied: tool_choice requested tool use, \
+         but the model returned no ToolUse block"
+
+let validator ~(contract : t) (response : api_response) =
+  validate_response ~contract response
+
+let accept_on_exhaustion ~(contract : t) =
+  match contract with
+  | Allow_text_or_tool -> false
+  | Require_tool_use -> false
+
+let%test "of_tool_choice requires tools for Any" =
+  match of_tool_choice (Some Any) with
+  | Require_tool_use -> true
+  | Allow_text_or_tool -> false
+
+let%test "validate_response accepts ToolUse for Require_tool_use" =
+  validate_response
+    ~contract:Require_tool_use
+    { id = "r";
+      model = "m";
+      stop_reason = StopToolUse;
+      content =
+        [ ToolUse
+            { id = "call-1";
+              name = "calculator";
+              input = `Assoc [];
+            }
+        ];
+      usage = None;
+      telemetry = None;
+    }
+  = Ok ()
+
+let%test "validate_response rejects text-only for Require_tool_use" =
+  match
+    validate_response
+      ~contract:Require_tool_use
+      { id = "r";
+        model = "m";
+        stop_reason = EndTurn;
+        content = [ Text "hello" ];
+        usage = None;
+        telemetry = None;
+      }
+  with
+  | Error msg ->
+    String.contains msg 't'
+    && String.length msg > 10
+  | Ok () -> false

--- a/lib/completion_contract.ml
+++ b/lib/completion_contract.ml
@@ -3,26 +3,64 @@ open Types
 type t =
   | Allow_text_or_tool
   | Require_tool_use
+  | Require_specific_tool of string
+  | Require_no_tool_use
 
 let to_string = function
   | Allow_text_or_tool -> "allow_text_or_tool"
   | Require_tool_use -> "require_tool_use"
+  | Require_specific_tool name -> Printf.sprintf "require_specific_tool(%s)" name
+  | Require_no_tool_use -> "require_no_tool_use"
 
 let of_tool_choice = function
-  | Some (Any | Tool _) -> Require_tool_use
-  | Some Auto | Some None_ | None -> Allow_text_or_tool
+  | Some Any -> Require_tool_use
+  | Some (Tool name) -> Require_specific_tool name
+  | Some None_ -> Require_no_tool_use
+  | Some Auto | None -> Allow_text_or_tool
+
+let tool_use_names (response : api_response) =
+  List.filter_map
+    (function
+      | ToolUse { name; _ } -> Some name
+      | _ -> None)
+    response.content
 
 let validate_response ~(contract : t) (response : api_response) :
     (unit, string) result =
   match contract with
   | Allow_text_or_tool -> Ok ()
   | Require_tool_use ->
-    if List.exists (function ToolUse _ -> true | _ -> false) response.content
+    if tool_use_names response <> []
     then Ok ()
     else
       Error
         "required tool contract unsatisfied: tool_choice requested tool use, \
          but the model returned no ToolUse block"
+  | Require_specific_tool name ->
+    (match tool_use_names response with
+     | [] ->
+       Error
+         (Printf.sprintf
+            "required tool contract unsatisfied: tool_choice requested tool \
+             '%s', but the model returned no ToolUse block"
+            name)
+     | tool_names when List.mem name tool_names -> Ok ()
+     | tool_names ->
+       Error
+         (Printf.sprintf
+            "required tool contract unsatisfied: tool_choice requested tool \
+             '%s', but the model called [%s]"
+            name
+            (String.concat ", " tool_names)))
+  | Require_no_tool_use ->
+    (match tool_use_names response with
+     | [] -> Ok ()
+     | tool_names ->
+       Error
+         (Printf.sprintf
+            "required no-tool contract unsatisfied: tool_choice disabled tools, \
+             but the model called [%s]"
+            (String.concat ", " tool_names)))
 
 let validator ~(contract : t) (response : api_response) =
   validate_response ~contract response
@@ -31,6 +69,8 @@ let accept_on_exhaustion ~(contract : t) =
   match contract with
   | Allow_text_or_tool -> false
   | Require_tool_use -> false
+  | Require_specific_tool _ -> false
+  | Require_no_tool_use -> false
 
 let resolve_accept ?accept_reason ~(accept : api_response -> bool) =
   match accept_reason with
@@ -44,7 +84,7 @@ let resolve_accept ?accept_reason ~(accept : api_response -> bool) =
 let%test "of_tool_choice requires tools for Any" =
   match of_tool_choice (Some Any) with
   | Require_tool_use -> true
-  | Allow_text_or_tool -> false
+  | Allow_text_or_tool | Require_specific_tool _ | Require_no_tool_use -> false
 
 let%test "of_tool_choice allows text for None and Auto and explicit none" =
   of_tool_choice None = Allow_text_or_tool
@@ -52,7 +92,10 @@ let%test "of_tool_choice allows text for None and Auto and explicit none" =
   && of_tool_choice (Some None_) = Allow_text_or_tool
 
 let%test "of_tool_choice requires tools for explicit Tool" =
-  of_tool_choice (Some (Tool "calculator")) = Require_tool_use
+  of_tool_choice (Some (Tool "calculator")) = Require_specific_tool "calculator"
+
+let%test "of_tool_choice requires no tool use for None_" =
+  of_tool_choice (Some None_) = Require_no_tool_use
 
 let%test "validate_response allows text for Allow_text_or_tool" =
   validate_response
@@ -83,6 +126,66 @@ let%test "validate_response accepts ToolUse for Require_tool_use" =
       telemetry = None;
     }
   = Ok ()
+
+let%test "validate_response accepts matching ToolUse for Require_specific_tool" =
+  validate_response
+    ~contract:(Require_specific_tool "calculator")
+    { id = "r";
+      model = "m";
+      stop_reason = StopToolUse;
+      content =
+        [ ToolUse
+            { id = "call-1";
+              name = "calculator";
+              input = `Assoc [];
+            }
+        ];
+      usage = None;
+      telemetry = None;
+    }
+  = Ok ()
+
+let%test "validate_response rejects different ToolUse for Require_specific_tool" =
+  match
+    validate_response
+      ~contract:(Require_specific_tool "calculator")
+      { id = "r";
+        model = "m";
+        stop_reason = StopToolUse;
+        content =
+          [ ToolUse
+              { id = "call-1";
+                name = "search";
+                input = `Assoc [];
+              }
+          ];
+        usage = None;
+        telemetry = None;
+      }
+  with
+  | Error msg -> String.contains msg 'c' && String.contains msg 's'
+  | Ok () -> false
+
+let%test "validate_response rejects ToolUse for Require_no_tool_use" =
+  match
+    validate_response
+      ~contract:Require_no_tool_use
+      { id = "r";
+        model = "m";
+        stop_reason = StopToolUse;
+        content =
+          [ ToolUse
+              { id = "call-1";
+                name = "search";
+                input = `Assoc [];
+              }
+          ];
+        usage = None;
+        telemetry = None;
+      }
+  with
+  | Error msg -> String.contains msg 'n' && String.contains msg 's'
+  | Ok () -> false
 
 let%test "validate_response rejects text-only for Require_tool_use" =
   match

--- a/lib/error.ml
+++ b/lib/error.ml
@@ -20,6 +20,7 @@ type agent_error =
   | UnrecognizedStopReason of { reason: string }
   | IdleDetected of { consecutive_idle_turns: int }
   | ToolRetryExhausted of { attempts: int; limit: int; detail: string }
+  | CompletionContractViolation of { contract: string; reason: string }
   | GuardrailViolation of { validator: string; reason: string }
   | TripwireViolation of { tripwire: string; reason: string }
   | ExitConditionMet of { turn: int }
@@ -91,6 +92,9 @@ let agent_error_to_string = function
   | ToolRetryExhausted r ->
     Printf.sprintf "Tool retry budget exhausted after %d/%d retries: %s"
       r.attempts r.limit r.detail
+  | CompletionContractViolation r ->
+    Printf.sprintf "Completion contract [%s] violated: %s"
+      r.contract r.reason
   | GuardrailViolation r ->
     Printf.sprintf "Guardrail violation [%s]: %s" r.validator r.reason
   | TripwireViolation r ->

--- a/lib/error.mli
+++ b/lib/error.mli
@@ -19,6 +19,7 @@ type agent_error =
   | UnrecognizedStopReason of { reason: string }
   | IdleDetected of { consecutive_idle_turns: int }
   | ToolRetryExhausted of { attempts: int; limit: int; detail: string }
+  | CompletionContractViolation of { contract: string; reason: string }
   | GuardrailViolation of { validator: string; reason: string }
   | TripwireViolation of { tripwire: string; reason: string }
   | ExitConditionMet of { turn: int }

--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -22,6 +22,7 @@ type agent_error = [
   | `Cost_budget_exceeded
   | `Idle_detected of int
   | `Tool_retry_exhausted of int * int * string
+  | `Completion_contract_violation of string * string
   | `Guardrail_violation of string * string
   | `Tripwire_violation of string * string
   | `Unrecognized_stop_reason of string
@@ -81,6 +82,8 @@ let of_sdk_error (err : Error.sdk_error) : sdk_error_poly =
   | Error.Agent (IdleDetected r) -> `Idle_detected r.consecutive_idle_turns
   | Error.Agent (ToolRetryExhausted r) ->
       `Tool_retry_exhausted (r.attempts, r.limit, r.detail)
+  | Error.Agent (CompletionContractViolation r) ->
+      `Completion_contract_violation (r.contract, r.reason)
   | Error.Agent (GuardrailViolation r) -> `Guardrail_violation (r.validator, r.reason)
   | Error.Agent (TripwireViolation r) -> `Tripwire_violation (r.tripwire, r.reason)
   | Error.Agent (UnrecognizedStopReason r) -> `Unrecognized_stop_reason r.reason
@@ -128,6 +131,8 @@ let to_sdk_error (err : sdk_error_poly) : Error.sdk_error =
     Error.Agent (IdleDetected { consecutive_idle_turns = n })
   | `Tool_retry_exhausted (attempts, limit, detail) ->
     Error.Agent (ToolRetryExhausted { attempts; limit; detail })
+  | `Completion_contract_violation (contract, reason) ->
+    Error.Agent (CompletionContractViolation { contract; reason })
   | `Guardrail_violation (validator, reason) ->
     Error.Agent (GuardrailViolation { validator; reason })
   | `Tripwire_violation (tripwire, reason) ->

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -47,6 +47,7 @@ type agent_error = [
   | `Cost_budget_exceeded
   | `Idle_detected of int  (** consecutive_idle_turns *)
   | `Tool_retry_exhausted of int * int * string  (** attempts, limit, detail *)
+  | `Completion_contract_violation of string * string  (** contract, reason *)
   | `Guardrail_violation of string * string  (** validator, reason *)
   | `Tripwire_violation of string * string  (** tripwire, reason *)
   | `Unrecognized_stop_reason of string

--- a/lib/judge/judge.ml
+++ b/lib/judge/judge.ml
@@ -155,6 +155,7 @@ let judge ~sw ~net ?clock ?config_path ~config ~context () =
           (if String.length body > 200
            then String.sub body 0 200 ^ "..."
            else body)
+      | Http_client.AcceptRejected { reason } -> reason
       | Http_client.NetworkError { message } -> message
     in
     Error (Printf.sprintf "Judge LLM call failed: %s" msg)

--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -331,7 +331,7 @@ let complete_named ~sw ~net ?clock ?config_path
     ?(tools = [])
     ?(temperature = Constants.Inference.default_temperature)
     ?(max_tokens = Constants.Inference.default_max_tokens)
-    ?system_prompt ?tool_choice ?(accept = fun _ -> true) ?(strict_name = false)
+    ?system_prompt ?tool_choice ?(accept = fun _ -> Ok ()) ?(strict_name = false)
     ?(accept_on_exhaustion = false)
     ?timeout_sec ?cache ?metrics ?throttle ?priority ?provider_filter () =
   let model_strings, source =

--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -331,9 +331,19 @@ let complete_named ~sw ~net ?clock ?config_path
     ?(tools = [])
     ?(temperature = Constants.Inference.default_temperature)
     ?(max_tokens = Constants.Inference.default_max_tokens)
-    ?system_prompt ?tool_choice ?(accept = fun _ -> Ok ()) ?(strict_name = false)
+    ?system_prompt ?tool_choice ?(accept = fun _ -> true) ?accept_reason
+    ?(strict_name = false)
     ?(accept_on_exhaustion = false)
     ?timeout_sec ?cache ?metrics ?throttle ?priority ?provider_filter () =
+  let accept =
+    match accept_reason with
+    | Some validator -> validator
+    | None ->
+      fun response ->
+        if accept response
+        then Ok ()
+        else Error "response rejected by accept validator"
+  in
   let model_strings, source =
     resolve_model_strings_traced ?config_path ~name ~defaults ()
   in

--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -335,7 +335,7 @@ let complete_named ~sw ~net ?clock ?config_path
     ?(strict_name = false)
     ?(accept_on_exhaustion = false)
     ?timeout_sec ?cache ?metrics ?throttle ?priority ?provider_filter () =
-  let accept =
+  let accept_result =
     match accept_reason with
     | Some validator -> validator
     | None ->
@@ -401,7 +401,7 @@ let complete_named ~sw ~net ?clock ?config_path
     else
       let run () =
         complete_cascade_with_accept ~sw ~net ?clock ?cache ?metrics
-          ?throttle ?priority ~accept ~accept_on_exhaustion
+          ?throttle ?priority ~accept:accept_result ~accept_on_exhaustion
           healthy_providers ~messages ~tools
       in
       match clock, timeout_sec with

--- a/lib/llm_provider/cascade_config.mli
+++ b/lib/llm_provider/cascade_config.mli
@@ -267,7 +267,7 @@ val complete_named :
   ?max_tokens:int ->
   ?system_prompt:string ->
   ?tool_choice:Types.tool_choice ->
-  ?accept:(Types.api_response -> bool) ->
+  ?accept:(Types.api_response -> (unit, string) result) ->
   ?strict_name:bool ->
   ?accept_on_exhaustion:bool ->
   ?timeout_sec:int ->

--- a/lib/llm_provider/cascade_config.mli
+++ b/lib/llm_provider/cascade_config.mli
@@ -267,7 +267,8 @@ val complete_named :
   ?max_tokens:int ->
   ?system_prompt:string ->
   ?tool_choice:Types.tool_choice ->
-  ?accept:(Types.api_response -> (unit, string) result) ->
+  ?accept:(Types.api_response -> bool) ->
+  ?accept_reason:(Types.api_response -> (unit, string) result) ->
   ?strict_name:bool ->
   ?accept_on_exhaustion:bool ->
   ?timeout_sec:int ->

--- a/lib/llm_provider/cascade_executor.ml
+++ b/lib/llm_provider/cascade_executor.ml
@@ -151,12 +151,16 @@ let complete_cascade_with_accept ~sw ~net ?clock ?cache ?metrics
             (if String.length body > Constants.Truncation.max_error_body_length
              then String.sub body 0 Constants.Truncation.max_error_body_length ^ "..."
              else body)
+        | Some (Http_client.AcceptRejected { reason }) -> reason
         | Some (Http_client.NetworkError { message }) -> message
         | None -> "No providers available"
       in
-      Error (Http_client.NetworkError {
-          message = Printf.sprintf "All models failed: %s" msg
-        })
+      (match last_err with
+       | Some (Http_client.AcceptRejected _ as err) -> Error err
+       | _ ->
+         Error (Http_client.NetworkError {
+             message = Printf.sprintf "All models failed: %s" msg
+           }))
     | (cfg : Provider_config.t) :: rest ->
       let is_last = rest = [] in
       (match try_one ~is_last cfg with
@@ -199,15 +203,14 @@ let complete_cascade_with_accept ~sw ~net ?clock ?cache ?metrics
                ~from_model:cfg.model_id ~to_model:"next"
                ~reason);
           try_next
-            (Some (Http_client.NetworkError {
-                 message = reason
-               }))
+            (Some (Http_client.AcceptRejected { reason }))
             rest
         end)
       | Error err ->
         let err_str = match err with
           | Http_client.HttpError { code; _ } ->
             Printf.sprintf "HTTP %d" code
+          | Http_client.AcceptRejected { reason } -> reason
           | Http_client.NetworkError { message } -> message
         in
         let should_cascade = Cascade_health_filter.should_cascade_to_next err in
@@ -263,6 +266,7 @@ let complete_cascade_stream ~sw ~net ?(metrics : Metrics.t option)
             (if String.length body > Constants.Truncation.max_error_body_length
              then String.sub body 0 Constants.Truncation.max_error_body_length ^ "..."
              else body)
+        | Some (Http_client.AcceptRejected { reason }) -> reason
         | Some (Http_client.NetworkError { message }) -> message
         | None -> "No providers available"
       in
@@ -276,6 +280,7 @@ let complete_cascade_stream ~sw ~net ?(metrics : Metrics.t option)
         let err_str = match err with
           | Http_client.HttpError { code; _ } ->
             Printf.sprintf "HTTP %d" code
+          | Http_client.AcceptRejected { reason } -> reason
           | Http_client.NetworkError { message } -> message
         in
         (match rest with

--- a/lib/llm_provider/cascade_executor.ml
+++ b/lib/llm_provider/cascade_executor.ml
@@ -161,15 +161,17 @@ let complete_cascade_with_accept ~sw ~net ?clock ?cache ?metrics
       let is_last = rest = [] in
       (match try_one ~is_last cfg with
       | Ok resp ->
-        if accept resp then begin
+        (match accept resp with
+        | Ok () -> begin
           diag "debug" "cascade_accept_passed"
             [("model_id", cfg.model_id)];
           Ok resp
         end
-        else if is_last && accept_on_exhaustion then begin
+        | Error reason when is_last && accept_on_exhaustion -> begin
           diag "info" "cascade_accept_on_exhaustion"
             [("model_id", cfg.model_id);
-             ("is_last", string_of_bool is_last)];
+             ("is_last", string_of_bool is_last);
+             ("reason", reason)];
           (* Graceful degradation: all models rejected by accept.
              Return the last valid response rather than failing.
              Based on constrained decoding fallback pattern:
@@ -181,11 +183,12 @@ let complete_cascade_with_accept ~sw ~net ?clock ?cache ?metrics
             ~reason:"accept relaxed: all models rejected";
           Ok resp
         end
-        else begin
+        | Error reason -> begin
           diag "warn" "cascade_accept_rejected"
             [("model_id", cfg.model_id);
              ("is_last", string_of_bool is_last);
-             ("accept_on_exhaustion", string_of_bool accept_on_exhaustion)];
+             ("accept_on_exhaustion", string_of_bool accept_on_exhaustion);
+             ("reason", reason)];
           (match last_err with
            | Some (Http_client.HttpError { code; _ }) ->
              m.on_cascade_fallback
@@ -194,13 +197,13 @@ let complete_cascade_with_accept ~sw ~net ?clock ?cache ?metrics
            | _ ->
              m.on_cascade_fallback
                ~from_model:cfg.model_id ~to_model:"next"
-               ~reason:"rejected by accept validator");
+               ~reason);
           try_next
             (Some (Http_client.NetworkError {
-                 message = "response rejected by accept validator"
+                 message = reason
                }))
             rest
-        end
+        end)
       | Error err ->
         let err_str = match err with
           | Http_client.HttpError { code; _ } ->

--- a/lib/llm_provider/cascade_health_filter.ml
+++ b/lib/llm_provider/cascade_health_filter.ml
@@ -19,6 +19,7 @@ let should_cascade_to_next err =
     true
   | Http_client.HttpError { code; _ } ->
     List.mem code Constants.Http.cascadable_codes
+  | Http_client.AcceptRejected _ -> false
   | Http_client.NetworkError _ -> true
 
 (* ── Local provider detection ──────────────────────────── *)

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -253,6 +253,7 @@ let complete ~sw ~net ?(transport : Llm_transport.t option)
            let err_str = match err with
              | Http_client.HttpError { code; _ } ->
                  Printf.sprintf "HTTP %d" code
+             | Http_client.AcceptRejected { reason } -> reason
              | Http_client.NetworkError { message } -> message
            in
            m.on_error ~model_id ~error:err_str;
@@ -277,6 +278,7 @@ let default_retry_config = {
 let is_retryable = function
   | Http_client.HttpError { code; _ } ->
       List.mem code Constants.Http.retryable_codes
+  | Http_client.AcceptRejected _ -> false
   | Http_client.NetworkError _ -> true
 
 let complete_with_retry ~sw ~net ?transport ~clock
@@ -334,6 +336,7 @@ let complete_cascade ~sw ~net ?transport ?clock ?retry_config
               let err_str = match last_err with
                 | Http_client.HttpError { code; _ } ->
                     Printf.sprintf "HTTP %d" code
+                | Http_client.AcceptRejected { reason } -> reason
                 | Http_client.NetworkError { message } -> message
               in
               m.on_cascade_fallback
@@ -501,6 +504,7 @@ let complete_stream_cascade ~sw ~net ?transport
         let err_str = match last_err with
           | Http_client.HttpError { code; _ } ->
             Printf.sprintf "HTTP %d" code
+          | Http_client.AcceptRejected { reason } -> reason
           | Http_client.NetworkError { message } -> message
         in
         m.on_cascade_fallback

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -65,6 +65,8 @@ let get_json ~sw ~net url =
   | Ok (code, _) -> Error (Printf.sprintf "HTTP %d" code)
   | Error (Http_client.HttpError { code; _ }) ->
     Error (Printf.sprintf "HTTP %d" code)
+  | Error (Http_client.AcceptRejected { reason }) ->
+    Error reason
   | Error (Http_client.NetworkError { message }) ->
     Error message
 

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -15,6 +15,7 @@
 type http_error =
   | HttpError of { code: int; body: string }
   | NetworkError of { message: string }
+  | AcceptRejected of { reason: string }
 
 (* ── Internal helpers ──────────────────────────────────────── *)
 
@@ -54,6 +55,7 @@ let is_local_resource_exhaustion = function
     || has_substr m "eaddrnotavail"
     || has_substr m "emfile"
     || has_substr m "enfile"
+  | AcceptRejected _ -> false
   | HttpError _ -> false
 
 (* ── Public API ────────────────────────────────────────────── *)

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -11,6 +11,7 @@
 type http_error =
   | HttpError of { code: int; body: string }
   | NetworkError of { message: string }
+  | AcceptRejected of { reason: string }
 
 (** GET a URL synchronously, returning the full response.
     Returns [(status_code, body_string)] on success. *)

--- a/lib/llm_provider/slot_cache.ml
+++ b/lib/llm_provider/slot_cache.ml
@@ -25,6 +25,8 @@ let slot_action ~sw ~net ~endpoint ~slot_id ~action ~body_fields =
     Error msg
   | Error (Http_client.HttpError { code; body }) ->
     Error (Printf.sprintf "slot %s HTTP error %d: %s" action code body)
+  | Error (Http_client.AcceptRejected { reason }) ->
+    Error (Printf.sprintf "slot %s rejected: %s" action reason)
   | Error (Http_client.NetworkError { message }) ->
     Error (Printf.sprintf "slot %s network error: %s" action message)
 

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -23,6 +23,18 @@ type turn_outcome =
   | ToolsExecuted
   | IdleSkipped
 
+let validate_completion_contract agent (response : Types.api_response) =
+  let contract =
+    Completion_contract.of_tool_choice agent.state.config.tool_choice
+  in
+  match Completion_contract.validate_response ~contract response with
+  | Ok () -> Ok ()
+  | Error reason ->
+    Error
+      (Error.Agent
+         (CompletionContractViolation
+            { contract = Completion_contract.to_string contract; reason }))
+
 (* ── Stage 1: Input ──────────────────────────────────────── *)
 
 (** Set lifecycle to Ready, invoke BeforeTurn hook, handle elicitation. *)
@@ -159,17 +171,20 @@ let stage_route ~sw ?clock ~api_strategy agent prep =
         agent_name = agent.state.config.name;
         turn = agent.state.turn_count; extra = [] }
       (fun _tracer ->
-        (* When tool_choice=Any (required), reject text-only responses so
-           the cascade falls back to the next provider.  This prevents weak
-           models (e.g. 9B) from "succeeding" with text_response when tools
-           were mandatory, starving the fallback provider of a chance. *)
-        let accept, accept_on_exhaustion =
-          match agent.state.config.tool_choice with
-          | Some (Types.Any | Types.Tool _) ->
-            (fun (resp : Types.api_response) ->
-              List.exists (function Types.ToolUse _ -> true | _ -> false) resp.content),
-            true  (* accept text on exhaustion rather than hard-fail *)
-          | _ -> (fun _ -> true), false
+        (* Enforce the semantic contract of tool_choice at the cascade layer.
+           When tool_choice requires tools, text-only responses are rejected
+           so the next provider gets a chance. If every provider violates the
+           contract, the turn fails with the last rejection reason instead of
+           being silently relaxed. *)
+        let completion_contract =
+          Completion_contract.of_tool_choice agent.state.config.tool_choice
+        in
+        let accept =
+          Completion_contract.validator ~contract:completion_contract
+        in
+        let accept_on_exhaustion =
+          Completion_contract.accept_on_exhaustion
+            ~contract:completion_contract
         in
         match agent.named_cascade with
         | Some named ->
@@ -677,6 +692,10 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
     update_state agent (fun s -> { s with config = original_config });
     Error e
   | Ok response ->
+    let* () =
+      validate_completion_contract agent response
+      |> tag_error "route_contract"
+    in
     (* Stage 3.5: Async output validation *)
     (match Guardrails_async.run_output async_guard.output_validators response with
      | Guardrails_async.Fail { validator_name; reason } ->

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -192,7 +192,7 @@ let stage_route ~sw ?clock ~api_strategy agent prep =
             ~named_cascade:named ~config:agent.state
             ~messages:prep.Agent_turn.effective_messages
             ?tools:prep.tools_json ~metrics:named.metrics
-            ~accept ~accept_on_exhaustion ?priority ()
+            ~accept_reason:accept ~accept_on_exhaustion ?priority ()
         | None ->
           (match agent.options.cascade with
            | Some casc ->

--- a/lib/protocol/a2a_client.ml
+++ b/lib/protocol/a2a_client.ml
@@ -20,6 +20,8 @@ let http_get ~sw ~net url =
   | Error (Llm_provider.Http_client.HttpError { code; body }) ->
     Error (Error.Orchestration
       (DiscoveryFailed { url; detail = Printf.sprintf "HTTP %d: %s" code body }))
+  | Error (Llm_provider.Http_client.AcceptRejected { reason }) ->
+    Error (Error.Orchestration (DiscoveryFailed { url; detail = reason }))
   | Error (Llm_provider.Http_client.NetworkError { message }) ->
     Error (Error.Orchestration (DiscoveryFailed { url; detail = message }))
 
@@ -33,6 +35,8 @@ let http_post ~sw ~net ~url ~body =
   | Error (Llm_provider.Http_client.HttpError { code; body = err_body }) ->
     Error (Error.A2a (ProtocolError {
       detail = Printf.sprintf "HTTP %d: %s" code err_body }))
+  | Error (Llm_provider.Http_client.AcceptRejected { reason }) ->
+    Error (Error.A2a (ProtocolError { detail = reason }))
   | Error (Llm_provider.Http_client.NetworkError { message }) ->
     Error (Error.A2a (ProtocolError { detail = message }))
 

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -124,6 +124,8 @@ let finalize_stream_acc (acc : stream_acc) =
 let map_http_error = function
   | Llm_provider.Http_client.HttpError { code; body } ->
       Error.Api (Retry.classify_error ~status:code ~body)
+  | Llm_provider.Http_client.AcceptRejected { reason } ->
+      Error.Api (Retry.NetworkError { message = reason })
   | Llm_provider.Http_client.NetworkError { message } ->
       Error.Api (Retry.NetworkError { message })
 

--- a/test/dune
+++ b/test/dune
@@ -264,7 +264,7 @@
 
 (test
  (name test_api_dispatch)
- (libraries agent_sdk alcotest yojson))
+ (libraries agent_sdk alcotest yojson unix))
 
 (test
  (name test_property_advanced)

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -165,6 +165,66 @@ let test_agent_run_requires_tool_use_when_tool_choice_is_any () =
      | Error e -> fail (Error.to_string e))
   with Exit -> ()
 
+let test_agent_run_requires_specific_tool_when_tool_choice_is_tool () =
+  Eio_main.run @@ fun env ->
+  try
+    Eio.Switch.run @@ fun sw ->
+    let url = start_multi_mock ~sw ~net:env#net ~port:20014
+        [openai_tool_use_response "other_tool" {|{}|}] in
+    let requested_tool = Tool.create
+        ~name:"get_time"
+        ~description:"Get current time"
+        ~parameters:[]
+        (fun _input -> Ok { Types.content = "12:00 UTC" })
+    in
+    let other_tool = Tool.create
+        ~name:"other_tool"
+        ~description:"Other tool"
+        ~parameters:[]
+        (fun _input -> Ok { Types.content = "other" })
+    in
+    let agent =
+      make_agent ~net:env#net ~tools:[requested_tool; other_tool]
+        ~tool_choice:(Types.Tool "get_time") url
+    in
+    (match Agent.run ~sw agent "what time is it?" with
+     | Ok _ -> fail "expected specific-tool contract failure"
+     | Error (Error.Agent (Error.CompletionContractViolation { contract; reason })) ->
+       check string "contract" "require_specific_tool(get_time)" contract;
+       check bool "reason mentions requested tool" true
+         (contains_substring ~needle:"get_time" reason);
+       check bool "reason mentions called tool" true
+         (contains_substring ~needle:"other_tool" reason);
+       Eio.Switch.fail sw Exit
+     | Error e -> fail (Error.to_string e))
+  with Exit -> ()
+
+let test_agent_run_rejects_tool_use_when_tool_choice_is_none () =
+  Eio_main.run @@ fun env ->
+  try
+    Eio.Switch.run @@ fun sw ->
+    let url = start_multi_mock ~sw ~net:env#net ~port:20015
+        [openai_tool_use_response "other_tool" {|{}|}] in
+    let other_tool = Tool.create
+        ~name:"other_tool"
+        ~description:"Other tool"
+        ~parameters:[]
+        (fun _input -> Ok { Types.content = "other" })
+    in
+    let agent =
+      make_agent ~net:env#net ~tools:[other_tool]
+        ~tool_choice:Types.None_ url
+    in
+    (match Agent.run ~sw agent "do not use tools" with
+     | Ok _ -> fail "expected no-tool contract failure"
+     | Error (Error.Agent (Error.CompletionContractViolation { contract; reason })) ->
+       check string "contract" "require_no_tool_use" contract;
+       check bool "reason mentions called tool" true
+         (contains_substring ~needle:"other_tool" reason);
+       Eio.Switch.fail sw Exit
+     | Error e -> fail (Error.to_string e))
+  with Exit -> ()
+
 (* ── Test 3: Max turns exhaustion ────────────────────── *)
 
 let test_agent_run_max_turns () =
@@ -470,6 +530,10 @@ let () =
       test_case "tool use cycle" `Quick test_agent_run_tool_use;
       test_case "tool_choice any requires tool use" `Quick
         test_agent_run_requires_tool_use_when_tool_choice_is_any;
+      test_case "tool_choice tool requires specific tool" `Quick
+        test_agent_run_requires_specific_tool_when_tool_choice_is_tool;
+      test_case "tool_choice none rejects tool use" `Quick
+        test_agent_run_rejects_tool_use_when_tool_choice_is_none;
       test_case "tool error" `Quick test_agent_run_tool_error;
       test_case "validation retry success" `Quick test_agent_run_validation_retry_success;
       test_case "validation retry exhausted" `Quick test_agent_run_validation_retry_exhausted;

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -63,9 +63,9 @@ let start_multi_mock ~sw ~net ~port (responses : string list) =
   Printf.sprintf "http://127.0.0.1:%d" port
 
 let make_agent ~net ?(max_turns = 3) ?(tools = []) ?hooks ?context_reducer
-    ?guardrails ?tool_retry_policy base_url =
+    ?guardrails ?tool_retry_policy ?tool_choice base_url =
   let config = { Types.default_config with
-    name = "test-agent"; max_turns;
+    name = "test-agent"; max_turns; tool_choice;
   } in
   let provider : Provider.config = {
     provider = Provider.Local { base_url };
@@ -131,6 +131,36 @@ let test_agent_run_tool_use () =
     (match Agent.run ~sw agent "what time is it?" with
      | Ok resp ->
        check string "final text" "The time is 12:00 UTC" (extract_text resp);
+       Eio.Switch.fail sw Exit
+     | Error e -> fail (Error.to_string e))
+  with Exit -> ()
+
+let test_agent_run_requires_tool_use_when_tool_choice_is_any () =
+  Eio_main.run @@ fun env ->
+  try
+    Eio.Switch.run @@ fun sw ->
+    let url = start_multi_mock ~sw ~net:env#net ~port:20013
+        [openai_text_response "I ignored the tool requirement"] in
+    let time_tool = Tool.create
+        ~name:"get_time"
+        ~description:"Get current time"
+        ~parameters:[
+          { name = "timezone"; param_type = Types.String;
+            description = "tz"; required = true };
+        ]
+        (fun _input -> Ok { Types.content = "12:00 UTC" })
+    in
+    let agent =
+      make_agent ~net:env#net ~tools:[time_tool]
+        ~tool_choice:Types.Any url
+    in
+    (match Agent.run ~sw agent "what time is it?" with
+     | Ok _ -> fail "expected required tool contract failure"
+     | Error (Error.Agent (Error.CompletionContractViolation { contract; reason })) ->
+       check string "contract" "require_tool_use" contract;
+       check bool "reason mentions tool contract" true
+         (contains_substring
+            ~needle:"required tool contract unsatisfied" reason);
        Eio.Switch.fail sw Exit
      | Error e -> fail (Error.to_string e))
   with Exit -> ()
@@ -438,6 +468,8 @@ let () =
     ];
     "tools", [
       test_case "tool use cycle" `Quick test_agent_run_tool_use;
+      test_case "tool_choice any requires tool use" `Quick
+        test_agent_run_requires_tool_use_when_tool_choice_is_any;
       test_case "tool error" `Quick test_agent_run_tool_error;
       test_case "validation retry success" `Quick test_agent_run_validation_retry_success;
       test_case "validation retry exhausted" `Quick test_agent_run_validation_retry_exhausted;

--- a/test/test_api_dispatch.ml
+++ b/test/test_api_dispatch.ml
@@ -34,6 +34,36 @@ let json_get key json =
   | `Assoc pairs -> List.assoc_opt key pairs
   | _ -> None
 
+let openai_text_response text =
+  Printf.sprintf
+    {|{"id":"chatcmpl-1","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}|}
+    text
+
+let find_free_port () =
+  let sock = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close sock)
+    (fun () ->
+      Unix.bind sock (Unix.ADDR_INET (Unix.inet_addr_loopback, 0));
+      match Unix.getsockname sock with
+      | Unix.ADDR_INET (_, port) -> port
+      | Unix.ADDR_UNIX _ -> fail "expected INET socket")
+
+let start_mock_server ~sw ~net body =
+  let port = find_free_port () in
+  let handler _conn _req req_body =
+    let _ = Eio.Buf_read.(of_flow ~max_size:max_int req_body |> take_all) in
+    Cohttp_eio.Server.respond_string ~status:`OK ~body ()
+  in
+  let socket =
+    Eio.Net.listen net ~sw ~backlog:8 ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  let server = Cohttp_eio.Server.make ~callback:handler () in
+  Eio.Fiber.fork ~sw (fun () ->
+    Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+  Printf.sprintf "http://127.0.0.1:%d" port
+
 (* ── Anthropic body shape ────────────────────────────────────── *)
 
 let test_anthropic_body_shape () =
@@ -161,6 +191,40 @@ let test_named_cascade_no_models () =
   | Ok _ -> fail "expected missing named cascade models to fail"
   | Error err ->
       fail ("unexpected error: " ^ Error.to_string err)
+
+let test_named_cascade_contract_rejection_maps_to_agent_error () =
+  with_net @@ fun net ->
+  try
+    Eio.Switch.run @@ fun sw ->
+    let url =
+      start_mock_server ~sw ~net (openai_text_response "no tool call")
+    in
+    let named =
+      Api.named_cascade
+        ~name:"contract"
+        ~defaults:[Printf.sprintf "custom:r@%s" url]
+        ()
+    in
+    let config =
+      { base_state with
+        Types.config =
+          { base_state.config with tool_choice = Some Types.Any }
+      }
+    in
+    (match
+       Api.create_message_named ~sw ~net ~named_cascade:named ~config
+         ~messages:base_state.messages ()
+     with
+     | Error
+         (Error.Agent
+            (Error.CompletionContractViolation { contract; reason })) ->
+       check string "contract" "require_tool_use" contract;
+       check bool "reason mentions tool contract" true
+         (String.length reason > 0);
+       Eio.Switch.fail sw Exit
+     | Ok _ -> fail "expected completion contract violation"
+     | Error err -> fail ("unexpected error: " ^ Error.to_string err))
+  with Exit -> ()
 
 let test_named_cascade_stream_no_models () =
   with_net @@ fun net ->
@@ -300,6 +364,8 @@ let () =
     "routing", [
       test_case "request_kind" `Quick test_request_kind_routing;
       test_case "named cascade no models" `Quick test_named_cascade_no_models;
+      test_case "named cascade contract rejection maps to agent error" `Quick
+        test_named_cascade_contract_rejection_maps_to_agent_error;
       test_case "named cascade stream no models" `Quick
         test_named_cascade_stream_no_models;
     ];

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -18,6 +18,21 @@ let openai_response text =
     {|{"id":"chatcmpl-1","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}|}
     text
 
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    if needle_len = 0 then
+      true
+    else if idx + needle_len > haystack_len then
+      false
+    else if String.sub haystack idx needle_len = needle then
+      true
+    else
+      loop (idx + 1)
+  in
+  loop 0
+
 let fresh_port () =
   let s = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
   Unix.setsockopt s Unix.SO_REUSEADDR true;
@@ -437,13 +452,20 @@ let test_complete_named_reject () =
       Printf.sprintf "custom:r@%s" url
     ] in
     (* Reject all responses *)
-    let accept _resp = false in
+    let accept _resp = Error "intentional reject from test validator" in
     (match Cascade_config.complete_named ~sw ~net:env#net ~clock
              ~name:"reject" ~defaults
              ~messages ~accept () with
      | Ok _ -> fail "expected rejection"
-     | Error _ ->
-       Eio.Switch.fail sw Exit)
+     | Error (Http_client.NetworkError { message }) ->
+       check bool "reason preserved" true
+         (String.starts_with ~prefix:"All models failed:" message);
+       check bool "validator reason preserved" true
+         (contains_substring
+            ~needle:"intentional reject from test validator"
+            message);
+       Eio.Switch.fail sw Exit
+     | Error _ -> fail "expected NetworkError")
   with Exit -> ()
 
 (* ── cascade_config.complete_named: config file ──────── *)

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -459,11 +459,15 @@ let test_complete_named_reject () =
      | Ok _ -> fail "expected rejection"
      | Error (Http_client.NetworkError { message }) ->
        check bool "reason preserved" true
-         (String.starts_with ~prefix:"All models failed:" message);
+         (message = "intentional reject from test validator");
        check bool "validator reason preserved" true
          (contains_substring
             ~needle:"intentional reject from test validator"
             message);
+       Eio.Switch.fail sw Exit
+     | Error (Http_client.AcceptRejected { reason }) ->
+       check string "reject reason" "intentional reject from test validator"
+         reason;
        Eio.Switch.fail sw Exit
      | Error _ -> fail "expected NetworkError")
   with Exit -> ()
@@ -488,6 +492,12 @@ let test_complete_named_reject_legacy_bool_accept () =
          (contains_substring
             ~needle:"response rejected by accept validator"
             message);
+       Eio.Switch.fail sw Exit
+     | Error (Http_client.AcceptRejected { reason }) ->
+       check bool "legacy reject reason preserved" true
+         (contains_substring
+            ~needle:"response rejected by accept validator"
+            reason);
        Eio.Switch.fail sw Exit
      | Error _ -> fail "expected NetworkError")
   with Exit -> ()

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -452,10 +452,10 @@ let test_complete_named_reject () =
       Printf.sprintf "custom:r@%s" url
     ] in
     (* Reject all responses *)
-    let accept _resp = Error "intentional reject from test validator" in
+    let accept_reason _resp = Error "intentional reject from test validator" in
     (match Cascade_config.complete_named ~sw ~net:env#net ~clock
              ~name:"reject" ~defaults
-             ~messages ~accept () with
+             ~messages ~accept_reason () with
      | Ok _ -> fail "expected rejection"
      | Error (Http_client.NetworkError { message }) ->
        check bool "reason preserved" true
@@ -463,6 +463,30 @@ let test_complete_named_reject () =
        check bool "validator reason preserved" true
          (contains_substring
             ~needle:"intentional reject from test validator"
+            message);
+       Eio.Switch.fail sw Exit
+     | Error _ -> fail "expected NetworkError")
+  with Exit -> ()
+
+let test_complete_named_reject_legacy_bool_accept () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  try
+    Eio.Switch.run @@ fun sw ->
+    let url = start_mock_server ~sw ~net:env#net
+        (openai_response "rejected") in
+    let defaults = [
+      Printf.sprintf "custom:r@%s" url
+    ] in
+    let accept _resp = false in
+    (match Cascade_config.complete_named ~sw ~net:env#net ~clock
+             ~name:"reject-legacy" ~defaults
+             ~messages ~accept () with
+     | Ok _ -> fail "expected rejection"
+     | Error (Http_client.NetworkError { message }) ->
+       check bool "generic legacy reason" true
+         (contains_substring
+            ~needle:"response rejected by accept validator"
             message);
        Eio.Switch.fail sw Exit
      | Error _ -> fail "expected NetworkError")
@@ -558,6 +582,8 @@ let () =
       test_case "no providers" `Quick test_complete_named_no_providers;
       test_case "timeout" `Quick test_complete_named_timeout;
       test_case "reject" `Quick test_complete_named_reject;
+      test_case "reject legacy bool accept" `Quick
+        test_complete_named_reject_legacy_bool_accept;
       test_case "from config" `Quick test_complete_named_from_config;
       test_case "stream" `Quick test_complete_named_stream_ok;
     ];

--- a/test/test_error.ml
+++ b/test/test_error.ml
@@ -35,6 +35,16 @@ let test_agent_stop_reason () =
   check string "stop reason" "Unrecognized stop_reason from API: unknown_42"
     (Error.to_string err)
 
+let test_agent_completion_contract_violation () =
+  let err =
+    Error.Agent
+      (CompletionContractViolation
+         { contract = "require_tool_use"; reason = "no ToolUse block" })
+  in
+  check string "completion contract"
+    "Completion contract [require_tool_use] violated: no ToolUse block"
+    (Error.to_string err)
+
 let test_mcp_server_start () =
   let err = Error.Mcp (ServerStartFailed { command = "npx"; detail = "not found" }) in
   check string "mcp start" "Failed to start MCP server 'npx': not found"
@@ -155,6 +165,8 @@ let () =
       test_case "Api AuthError" `Quick test_api_auth_error;
       test_case "Agent MaxTurnsExceeded" `Quick test_agent_max_turns;
       test_case "Agent TokenBudgetExceeded" `Quick test_agent_token_budget;
+      test_case "Agent CompletionContractViolation" `Quick
+        test_agent_completion_contract_violation;
       test_case "Agent UnrecognizedStopReason" `Quick test_agent_stop_reason;
       test_case "Mcp ServerStartFailed" `Quick test_mcp_server_start;
       test_case "Mcp InitializeFailed" `Quick test_mcp_init_failed;

--- a/test/test_error_domain.ml
+++ b/test/test_error_domain.ml
@@ -107,6 +107,7 @@ let test_to_string_each_variant () =
     `Max_turns_exceeded (20, 10);
     `Token_budget_exceeded (5000, 4000);
     `Idle_detected 5;
+    `Completion_contract_violation ("require_tool_use", "no ToolUse block");
     `Unrecognized_stop_reason "weird";
     `Missing_env_var "SECRET";
     `Unsupported_provider "unknown_llm";
@@ -147,6 +148,7 @@ let test_all_variants_convert () =
     `Max_turns_exceeded (1, 2);
     `Token_budget_exceeded (100, 50);
     `Idle_detected 3;
+    `Completion_contract_violation ("require_tool_use", "no ToolUse block");
     `Unrecognized_stop_reason "x";
     `Missing_env_var "X";
     `Unsupported_provider "x";
@@ -287,6 +289,23 @@ let test_roundtrip_agent_idle_detected () =
   (match back with
    | Error.Agent (IdleDetected { consecutive_idle_turns = 3 }) -> ()
    | _ -> Alcotest.fail "roundtrip mismatch for IdleDetected")
+
+let test_roundtrip_agent_completion_contract_violation () =
+  let orig =
+    Error.Agent
+      (CompletionContractViolation
+         { contract = "require_tool_use"; reason = "no ToolUse block" })
+  in
+  let poly = Error_domain.of_sdk_error orig in
+  (match poly with
+   | `Completion_contract_violation ("require_tool_use", "no ToolUse block") -> ()
+   | _ -> Alcotest.fail "expected Completion_contract_violation");
+  let back = Error_domain.to_sdk_error poly in
+  (match back with
+   | Error.Agent
+       (CompletionContractViolation
+          { contract = "require_tool_use"; reason = "no ToolUse block" }) -> ()
+   | _ -> Alcotest.fail "roundtrip mismatch for CompletionContractViolation")
 
 let test_roundtrip_agent_unrecognized_stop () =
   let orig = Error.Agent (UnrecognizedStopReason { reason = "weird" }) in
@@ -583,6 +602,8 @@ let () =
       Alcotest.test_case "agent max_turns" `Quick test_roundtrip_agent_max_turns;
       Alcotest.test_case "agent token_budget" `Quick test_roundtrip_agent_token_budget;
       Alcotest.test_case "agent idle_detected" `Quick test_roundtrip_agent_idle_detected;
+      Alcotest.test_case "agent completion_contract_violation" `Quick
+        test_roundtrip_agent_completion_contract_violation;
       Alcotest.test_case "agent unrecognized_stop" `Quick test_roundtrip_agent_unrecognized_stop;
       Alcotest.test_case "config missing_env" `Quick test_roundtrip_config_missing_env;
       Alcotest.test_case "config unsupported_provider" `Quick test_roundtrip_config_unsupported_provider;


### PR DESCRIPTION
## Summary
- introduce a typed OAS completion contract derived from `tool_choice`
- enforce the contract in the pipeline and named-cascade path without exhaustion relaxation
- preserve validator rejection reasons and expose contract failures as a first-class agent error

## Why
`tool_choice=Any|Tool(_)` was being treated as a soft convention. Named cascade could still relax on exhaustion, and direct provider/plain cascade paths relied on downstream consumers to detect text-only completions. This allowed tool-required turns to succeed incorrectly.

## What changed
- add `Completion_contract` to interpret `tool_choice` semantically
- change accept validators to return structured rejection reasons instead of `bool`
- enforce contract validation after route completion for all pipeline paths
- add `CompletionContractViolation` as a typed agent error and error-domain variant
- add regression coverage for direct provider and named-cascade rejection reason preservation

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix/completion-contract`
- `./_build/default/test/test_error.exe`
- `./_build/default/test/test_error_domain.exe`
- `./_build/default/test/test_agent_pipeline.exe`
- `./_build/default/test/test_complete_http.exe`

## Product impact
- tool-required turns now fail deterministically when the model returns no `ToolUse`
- named cascade fallback keeps the concrete contract rejection reason instead of generic validator failure text
- downstream consumers can branch on a typed completion-contract failure instead of string matching

## Review evidence
- pending: cross-model review will be added after PR creation