### PR TITLE
[codex] improve runtime health boundaries and evidence integrity

### DIFF
--- a/lib/artifact_service.ml
+++ b/lib/artifact_service.ml
@@ -74,9 +74,11 @@ let persisted_path (artifact : descriptor) =
         (Error.Io
            (FileOpFailed
               {
-                op = "read";
+                op = "persisted_path";
                 path = artifact.artifact_id;
-                detail = "Artifact has no persisted file path";
+                detail =
+                  Printf.sprintf "Artifact %S (%s) has no persisted file path"
+                    artifact.name artifact.artifact_id;
               }))
 
 let overwrite_text_internal artifact ~content =

--- a/lib/artifact_service.ml
+++ b/lib/artifact_service.ml
@@ -66,6 +66,23 @@ let save_text_internal store ~session_id ~name ~kind ~content =
       created_at = Unix.gettimeofday ();
     }
 
+let persisted_path (artifact : descriptor) =
+  match artifact.path with
+  | Some path -> Ok path
+  | None ->
+      Error
+        (Error.Io
+           (FileOpFailed
+              {
+                op = "read";
+                path = artifact.artifact_id;
+                detail = "Artifact has no persisted file path";
+              }))
+
+let overwrite_text_internal artifact ~content =
+  let* path = persisted_path artifact in
+  Runtime_store.save_text path content
+
 let list ?session_root ~session_id () =
   let* store = make_store ?session_root () in
   let* session = Runtime_store.load_session store session_id in

--- a/lib/artifact_service.mli
+++ b/lib/artifact_service.mli
@@ -16,6 +16,11 @@ val save_text_internal :
   content:string ->
   (descriptor, Error.sdk_error) result
 
+val persisted_path : descriptor -> (string, Error.sdk_error) result
+
+val overwrite_text_internal :
+  descriptor -> content:string -> (unit, Error.sdk_error) result
+
 val list :
   ?session_root:string ->
   session_id:string ->

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -68,7 +68,7 @@ type t = Internal_query_engine.t
 
 let default_options = Sdk_client_types.default_options
 
-let connect ~sw ~mgr = Internal_query_engine.connect ~sw ~mgr
+let connect ~sw ?clock ~mgr = Internal_query_engine.connect ~sw ?clock ~mgr
 let query = Internal_query_engine.query_turn
 let has_pending_messages = Internal_query_engine.has_pending_messages
 let receive_messages = Internal_query_engine.receive_messages

--- a/lib/client.mli
+++ b/lib/client.mli
@@ -87,6 +87,7 @@ val default_options : options
 (** Connect to an OAS runtime process. *)
 val connect :
   sw:Eio.Switch.t ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   mgr:_ Eio.Process.mgr ->
   ?options:options ->
   unit ->

--- a/lib/context_intent.ml
+++ b/lib/context_intent.ml
@@ -304,10 +304,10 @@ let classify_model ~sw ~net ?base_url ?provider ?clock ~config ?(max_retries = 2
     ~schema ~max_retries (prompt_for_query query)
 
 let classify_hybrid ~sw ~net ?base_url ?provider ?clock ~config
-    ?(max_retries = 2) query =
+    ?(max_retries = 2) ~fallback query =
   match
     classify_model ~sw ~net ?base_url ?provider ?clock ~config ~max_retries
       query
   with
   | Ok result -> Ok result.value
-  | Error _ -> Ok (heuristic_classify query)
+  | Error _ -> Ok (fallback query)

--- a/lib/context_intent.mli
+++ b/lib/context_intent.mli
@@ -1,8 +1,8 @@
 (** Reusable query intent classification for OAS consumers.
 
     This module owns the normalized intent taxonomy, retrieval-depth mapping,
-    strict model-output parsing, and lightweight heuristic/model helpers.
-    Consumer-specific policy can stay outside OAS.
+    strict model-output parsing, and explicit model/fallback routing helpers.
+    Consumer-specific policy stays outside OAS.
 
     @stability Evolving
     @since 0.93.1 *)
@@ -33,7 +33,8 @@ val intent_to_string : intent -> string
 val intent_of_string : string -> (intent, string) result
 val depth_for_intent : intent -> retrieval_depth
 
-(** Fast zero-network classifier suitable for default routing gates. *)
+(** Explicit zero-network classifier suitable when the caller intentionally
+    wants heuristic routing without model assistance. *)
 val heuristic_classify : string -> classification
 
 (** Strict parser for model-produced JSON. *)
@@ -57,8 +58,9 @@ val classify_model :
   string ->
   (classification Structured.retry_result, Error.sdk_error) result
 
-(** Try model-assisted classification first, then fall back to heuristics on
-    any model/path failure. *)
+(** Try model-assisted classification first, then use a caller-supplied
+    fallback on any model/path failure. This function no longer applies
+    heuristic fallback implicitly. *)
 val classify_hybrid :
   sw:Eio.Switch.t ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
@@ -67,5 +69,6 @@ val classify_hybrid :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   config:Types.agent_config ->
   ?max_retries:int ->
+  fallback:(string -> classification) ->
   string ->
   (classification, Error.sdk_error) result

--- a/lib/defaults.ml
+++ b/lib/defaults.ml
@@ -3,6 +3,14 @@
     Each value falls back to the compile-time default when the
     corresponding OAS_* environment variable is unset or empty. *)
 
+let _log = Log.create ~module_name:"defaults" ()
+
+let warn_invalid_env ~var ~raw ~expected =
+  Log.warn _log "invalid environment override; using default"
+    [ Log.S ("var", var);
+      Log.S ("raw", raw);
+      Log.S ("expected", expected) ]
+
 let env_or default var =
   match Sys.getenv_opt var with
   | Some v when String.trim v <> "" -> String.trim v
@@ -10,20 +18,48 @@ let env_or default var =
 
 let int_env_or default var =
   match Sys.getenv_opt var with
-  | Some raw -> (match int_of_string_opt (String.trim raw) with
-    | Some v when v > 0 -> v | _ -> default)
+  | Some raw ->
+      let trimmed = String.trim raw in
+      (match int_of_string_opt trimmed with
+       | Some v when v > 0 -> v
+       | _ ->
+           if trimmed <> "" then
+             warn_invalid_env ~var ~raw:trimmed ~expected:"positive integer";
+           default)
   | None -> default
 
 let float_env_or default var =
   match Sys.getenv_opt var with
-  | Some raw -> (match float_of_string_opt (String.trim raw) with
-    | Some v when v > 0.0 -> v | _ -> default)
+  | Some raw ->
+      let trimmed = String.trim raw in
+      (match float_of_string_opt trimmed with
+       | Some v when v > 0.0 -> v
+       | _ ->
+           if trimmed <> "" then
+             warn_invalid_env ~var ~raw:trimmed ~expected:"positive float";
+           default)
+  | None -> default
+
+let bool_env_or default var =
+  match Sys.getenv_opt var with
+  | Some raw ->
+      let trimmed = String.trim raw in
+      (match String.lowercase_ascii trimmed with
+       | "1" | "true" | "yes" | "on" -> true
+       | "0" | "false" | "no" | "off" -> false
+       | _ ->
+           if trimmed <> "" then
+             warn_invalid_env ~var ~raw:trimmed ~expected:"boolean";
+           default)
   | None -> default
 
 let local_llm_url = Llm_provider.Discovery.default_endpoint
 
 let fallback_provider =
   env_or "local" "OAS_FALLBACK_PROVIDER"
+
+let allow_test_providers () =
+  bool_env_or false "OAS_ALLOW_TEST_PROVIDERS"
 
 (** Default context reducer: repair dangling tool calls + prune old tool args.
     Applied automatically unless the user provides a custom reducer.

--- a/lib/defaults.mli
+++ b/lib/defaults.mli
@@ -18,6 +18,10 @@ val int_env_or : int -> string -> int
     if the variable is unset, empty, non-numeric, or non-positive. *)
 val float_env_or : float -> string -> float
 
+(** Read a boolean environment variable, falling back to [default]
+    if the variable is unset, empty, or invalid. *)
+val bool_env_or : bool -> string -> bool
+
 (** Local LLM server URL.
     Reads [OAS_LOCAL_LLM_URL], falling back to [OAS_LOCAL_QWEN_URL],
     then {!Llm_provider.Constants.Endpoints.default_url}. *)
@@ -26,6 +30,10 @@ val local_llm_url : string
 (** Fallback provider name.
     Reads [OAS_FALLBACK_PROVIDER], defaults to ["local"]. *)
 val fallback_provider : string
+
+(** Explicit gate for runtime-only test providers such as ["mock"] and ["echo"].
+    Disabled by default; tests must opt in via [OAS_ALLOW_TEST_PROVIDERS]. *)
+val allow_test_providers : unit -> bool
 
 (** Default context reducer: repair dangling tool calls, prune old
     tool args, and drop thinking blocks. *)

--- a/lib/direct_evidence.ml
+++ b/lib/direct_evidence.ml
@@ -308,6 +308,27 @@ let apply_events initial_session (events : event list) =
 
 let make_event seq ts kind = { seq; ts; kind }
 
+let artifact_attached_event (artifact : Runtime.artifact) =
+  Artifact_attached
+    {
+      artifact_id = artifact.artifact_id;
+      name = artifact.name;
+      kind = artifact.kind;
+      mime_type = artifact.mime_type;
+      path = Option.value ~default:"" artifact.path;
+      size_bytes = artifact.size_bytes;
+    }
+
+let base_evidence_file_specs store session_id =
+  [
+    ("session_json", Runtime_store.session_path store session_id);
+    ("events_jsonl", Runtime_store.events_path store session_id);
+    ("report_json", Runtime_store.report_json_path store session_id);
+    ("report_md", Runtime_store.report_md_path store session_id);
+    ("proof_json", Runtime_store.proof_json_path store session_id);
+    ("proof_md", Runtime_store.proof_md_path store session_id);
+  ]
+
 let persist ~agent ~raw_trace ~(options : options) () =
   let cfg = (Agent.state agent).config in
   let snapshot = lifecycle_snapshot_or_default agent in
@@ -503,16 +524,24 @@ let persist ~agent ~raw_trace ~(options : options) () =
         Artifact_service.save_text_internal store ~session_id:options.session_id
           ~name:"tool-catalog" ~kind:"json" ~content:tool_catalog_json
       in
+      let* telemetry_json_path =
+        Artifact_service.persisted_path telemetry_json_artifact
+      in
+      let* telemetry_md_path =
+        Artifact_service.persisted_path telemetry_md_artifact
+      in
+      let* tool_catalog_path =
+        Artifact_service.persisted_path tool_catalog_artifact
+      in
       let evidence =
         Runtime_evidence.build_evidence_bundle ~session_id:options.session_id
-          [
-            ("session_json", Runtime_store.session_path store options.session_id);
-            ("events_jsonl", Runtime_store.events_path store options.session_id);
-            ("report_json", Runtime_store.report_json_path store options.session_id);
-            ("report_md", Runtime_store.report_md_path store options.session_id);
-            ("proof_json", Runtime_store.proof_json_path store options.session_id);
-            ("proof_md", Runtime_store.proof_md_path store options.session_id);
-          ]
+          (base_evidence_file_specs store options.session_id
+           @
+           [
+             ("telemetry_json", telemetry_json_path);
+             ("telemetry_md", telemetry_md_path);
+             ("tool_catalog_json", tool_catalog_path);
+           ])
       in
       let evidence_json =
         Runtime_evidence.evidence_bundle_to_json evidence
@@ -532,24 +561,52 @@ let persist ~agent ~raw_trace ~(options : options) () =
         |> List.mapi (fun index (artifact : Runtime.artifact) ->
                make_event (8 + List.length deltas + index)
                  (finished_at +. 0.003 +. (float_of_int index *. 0.001))
-                 (Artifact_attached
-                    {
-                      artifact_id = artifact.artifact_id;
-                      name = artifact.name;
-                      kind = artifact.kind;
-                      mime_type = artifact.mime_type;
-                      path = Option.value ~default:"" artifact.path;
-                      size_bytes = artifact.size_bytes;
-                    }))
+                 (artifact_attached_event artifact))
       in
       let all_events = base_events @ artifact_events in
       let* final_session = apply_events initial_session all_events in
       let final_report = Runtime_projection.build_report final_session all_events in
       let final_proof = Runtime_projection.build_proof final_session all_events in
+      let final_telemetry =
+        Runtime_evidence.build_telemetry_report final_session all_events
+      in
+      let final_telemetry_json =
+        Runtime_evidence.telemetry_report_to_json final_telemetry
+        |> Yojson.Safe.pretty_to_string
+      in
+      let final_telemetry_md =
+        Runtime_evidence.telemetry_report_to_markdown final_telemetry
+      in
       let* () = Runtime_store.save_session store final_session in
       let* () = save_events store options.session_id all_events in
       let* () = Runtime_store.save_report store final_report in
       let* () = Runtime_store.save_proof store final_proof in
+      let* () =
+        Artifact_service.overwrite_text_internal telemetry_json_artifact
+          ~content:final_telemetry_json
+      in
+      let* () =
+        Artifact_service.overwrite_text_internal telemetry_md_artifact
+          ~content:final_telemetry_md
+      in
+      let final_evidence =
+        Runtime_evidence.build_evidence_bundle ~session_id:options.session_id
+          (base_evidence_file_specs store options.session_id
+           @
+           [
+             ("telemetry_json", telemetry_json_path);
+             ("telemetry_md", telemetry_md_path);
+             ("tool_catalog_json", tool_catalog_path);
+           ])
+      in
+      let final_evidence_json =
+        Runtime_evidence.evidence_bundle_to_json final_evidence
+        |> Yojson.Safe.pretty_to_string
+      in
+      let* () =
+        Artifact_service.overwrite_text_internal evidence_artifact
+          ~content:final_evidence_json
+      in
         Sessions.get_proof_bundle ?session_root:options.session_root
           ~session_id:options.session_id ()
 

--- a/lib/direct_evidence.ml
+++ b/lib/direct_evidence.ml
@@ -308,27 +308,6 @@ let apply_events initial_session (events : event list) =
 
 let make_event seq ts kind = { seq; ts; kind }
 
-let artifact_attached_event (artifact : Runtime.artifact) =
-  Artifact_attached
-    {
-      artifact_id = artifact.artifact_id;
-      name = artifact.name;
-      kind = artifact.kind;
-      mime_type = artifact.mime_type;
-      path = Option.value ~default:"" artifact.path;
-      size_bytes = artifact.size_bytes;
-    }
-
-let base_evidence_file_specs store session_id =
-  [
-    ("session_json", Runtime_store.session_path store session_id);
-    ("events_jsonl", Runtime_store.events_path store session_id);
-    ("report_json", Runtime_store.report_json_path store session_id);
-    ("report_md", Runtime_store.report_md_path store session_id);
-    ("proof_json", Runtime_store.proof_json_path store session_id);
-    ("proof_md", Runtime_store.proof_md_path store session_id);
-  ]
-
 let persist ~agent ~raw_trace ~(options : options) () =
   let cfg = (Agent.state agent).config in
   let snapshot = lifecycle_snapshot_or_default agent in
@@ -535,7 +514,7 @@ let persist ~agent ~raw_trace ~(options : options) () =
       in
       let evidence =
         Runtime_evidence.build_evidence_bundle ~session_id:options.session_id
-          (base_evidence_file_specs store options.session_id
+          (Runtime_evidence.base_evidence_file_specs store options.session_id
            @
            [
              ("telemetry_json", telemetry_json_path);
@@ -561,7 +540,7 @@ let persist ~agent ~raw_trace ~(options : options) () =
         |> List.mapi (fun index (artifact : Runtime.artifact) ->
                make_event (8 + List.length deltas + index)
                  (finished_at +. 0.003 +. (float_of_int index *. 0.001))
-                 (artifact_attached_event artifact))
+                 (Runtime_evidence.artifact_attached_event artifact))
       in
       let all_events = base_events @ artifact_events in
       let* final_session = apply_events initial_session all_events in
@@ -591,7 +570,7 @@ let persist ~agent ~raw_trace ~(options : options) () =
       in
       let final_evidence =
         Runtime_evidence.build_evidence_bundle ~session_id:options.session_id
-          (base_evidence_file_specs store options.session_id
+          (Runtime_evidence.base_evidence_file_specs store options.session_id
            @
            [
              ("telemetry_json", telemetry_json_path);

--- a/lib/internal_query_engine.ml
+++ b/lib/internal_query_engine.ml
@@ -123,7 +123,10 @@ let wait_for_messages ?timeout state =
                  | None ->
                      if Unix.gettimeofday () >= deadline then []
                      else (
-                       Unix.sleepf 0.01;
+                       (* No Eio clock was supplied, so fall back to a
+                          cooperative poll instead of blocking the runtime
+                          thread with Unix.sleepf. *)
+                       Eio.Fiber.yield ();
                        await_without_clock ())
                in
                await_without_clock ()))

--- a/lib/internal_query_engine.ml
+++ b/lib/internal_query_engine.ml
@@ -1,5 +1,6 @@
 type t = {
   runtime: Runtime_client.t;
+  clock: float Eio.Time.clock_ty Eio.Resource.t option;
   mutable options: Sdk_client_types.options;
   mutable session_id: string option;
   mutable last_event_seq: int;
@@ -37,11 +38,12 @@ let runtime_options options =
     cwd = options.cwd;
   }
 
-let connect ~sw ~mgr ?(options = Sdk_client_types.default_options) () =
+let connect ~sw ?clock ~mgr ?(options = Sdk_client_types.default_options) () =
   let* runtime = Runtime_client.connect ~sw ~mgr ~options:(runtime_options options) () in
   let state =
     {
       runtime;
+      clock;
       options;
       session_id = None;
       last_event_seq = 0;
@@ -83,6 +85,15 @@ let has_pending_messages state =
   Eio.Mutex.use_ro state.message_mu (fun () ->
     state.buffered_messages <> [])
 
+let wait_blocking state =
+  Eio.Mutex.use_rw ~protect:true state.message_mu (fun () ->
+    while state.buffered_messages = [] do
+      Eio.Condition.await state.message_cv state.message_mu
+    done;
+    let messages = state.buffered_messages in
+    state.buffered_messages <- [];
+    messages)
+
 let wait_for_messages ?timeout state =
   let drain_if_any () =
     Eio.Mutex.use_rw ~protect:true state.message_mu (fun () ->
@@ -95,26 +106,27 @@ let wait_for_messages ?timeout state =
   | Some messages -> messages
   | None -> (
       match timeout with
-      | None ->
-          Eio.Mutex.use_rw ~protect:true state.message_mu (fun () ->
-            while state.buffered_messages = [] do
-              Eio.Condition.await state.message_cv state.message_mu
-            done;
-            let messages = state.buffered_messages in
-            state.buffered_messages <- [];
-            messages)
+      | None -> wait_blocking state
+      | Some timeout_s when timeout_s <= 0.0 -> []
       | Some timeout_s ->
-          let deadline = Unix.gettimeofday () +. max 0.0 timeout_s in
-          let rec loop () =
-            match drain_if_any () with
-            | Some messages -> messages
-            | None ->
-                if Unix.gettimeofday () >= deadline then []
-                else (
-                  Eio.Fiber.yield ();
-                  loop ())
-          in
-          loop ())
+          (match state.clock with
+           | Some clock -> (
+               try
+                 Eio.Time.with_timeout_exn clock timeout_s (fun () ->
+                   wait_blocking state)
+               with Eio.Time.Timeout -> [])
+           | None ->
+               let deadline = Unix.gettimeofday () +. timeout_s in
+               let rec await_without_clock () =
+                 match drain_if_any () with
+                 | Some messages -> messages
+                 | None ->
+                     if Unix.gettimeofday () >= deadline then []
+                     else (
+                       Unix.sleepf 0.01;
+                       await_without_clock ())
+               in
+               await_without_clock ()))
 
 let current_session_id state = state.session_id
 

--- a/lib/internal_query_engine.mli
+++ b/lib/internal_query_engine.mli
@@ -8,6 +8,7 @@
 
 type t = {
   runtime: Runtime_client.t;
+  clock: float Eio.Time.clock_ty Eio.Resource.t option;
   mutable options: Sdk_client_types.options;
   mutable session_id: string option;
   mutable last_event_seq: int;
@@ -22,6 +23,7 @@ type t = {
 
 val connect :
   sw:Eio.Switch.t ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   mgr:_ Eio.Process.mgr ->
   ?options:Sdk_client_types.options ->
   unit ->

--- a/lib/llm_provider/cascade_health_filter.ml
+++ b/lib/llm_provider/cascade_health_filter.ml
@@ -25,16 +25,7 @@ let should_cascade_to_next err =
 (* ── Local provider detection ──────────────────────────── *)
 
 let is_local_provider (cfg : Provider_config.t) =
-  let url = String.lowercase_ascii cfg.base_url in
-  let len = String.length url in
-  let starts_with prefix =
-    let plen = String.length prefix in
-    len >= plen && String.sub url 0 plen = prefix
-  in
-  starts_with "http://127.0.0.1"
-  || starts_with "http://localhost:"
-  || starts_with "http://localhost/"
-  || url = "http://localhost"
+  Provider_config.is_local cfg
 
 (** Check whether a provider has credentials when required. *)
 let has_required_api_key (cfg : Provider_config.t) =

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -2,6 +2,18 @@
 
     @since 0.53.0 *)
 
+let warn_probe_failure ~url ~phase detail =
+  let json =
+    `Assoc
+      [
+        ("event", `String "llm_provider_discovery_probe_failed");
+        ("url", `String url);
+        ("phase", `String phase);
+        ("detail", `String detail);
+      ]
+  in
+  Printf.eprintf "%s\n%!" (Yojson.Safe.to_string json)
+
 type model_info = {
   id: string;
   owned_by: string;
@@ -174,7 +186,9 @@ let find_context_length (model_info : Yojson.Safe.t) : int =
     via /api/show. Returns synthetic server_props on success. *)
 let probe_ollama_context ~sw ~net base_url =
   match get_json ~sw ~net (base_url ^ "/api/tags") with
-  | Error _ -> None
+  | Error detail ->
+    warn_probe_failure ~url:base_url ~phase:"ollama_tags" detail;
+    None
   | Ok tags_json ->
     let open Yojson.Safe.Util in
     let models = match member "models" tags_json with
@@ -200,9 +214,30 @@ let probe_ollama_context ~sw ~net base_url =
            let ctx = find_context_length model_info in
            if ctx > 0 then
              Some { total_slots = 1; ctx_size = ctx; model = model_name }
-           else None
-         with _ -> None)
-      | _ -> None
+           else (
+             warn_probe_failure ~url:base_url ~phase:"ollama_show"
+               "model_info contained no usable context length";
+             None)
+         with
+         | Yojson.Json_error msg ->
+             warn_probe_failure ~url:base_url ~phase:"ollama_show_json" msg;
+             None
+         | Yojson.Safe.Util.Type_error (msg, _) ->
+             warn_probe_failure ~url:base_url ~phase:"ollama_show_parse" msg;
+             None)
+      | Ok (code, _) ->
+          warn_probe_failure ~url:base_url ~phase:"ollama_show_http"
+            (Printf.sprintf "HTTP %d" code);
+          None
+      | Error err ->
+          let detail =
+            match err with
+            | Http_client.HttpError { code; body } ->
+                Printf.sprintf "HTTP %d: %s" code body
+            | Http_client.NetworkError { message } -> message
+          in
+          warn_probe_failure ~url:base_url ~phase:"ollama_show_http" detail;
+          None
 
 (* ── Capability inference ────────────────────────────────── *)
 
@@ -249,6 +284,16 @@ let infer_capabilities models props =
 
 let probe_endpoint ~sw ~net url =
   let base = String.trim url in
+  let warn phase detail =
+    warn_probe_failure ~url:base ~phase detail
+  in
+  let capture_json phase parse target =
+    match get_json ~sw ~net target with
+    | Ok json -> parse json
+    | Error detail ->
+        warn phase detail;
+        None
+  in
   (* Try /health first (llama.cpp), fall back to / (Ollama returns 200) *)
   let healthy =
     get_ok ~sw ~net (base ^ "/health")
@@ -265,14 +310,16 @@ let probe_endpoint ~sw ~net url =
     let slots_ref = ref None in
     Eio.Fiber.all [
       (fun () ->
-        models_ref := match get_json ~sw ~net (base ^ "/v1/models") with
-          | Ok json -> parse_models json | Error _ -> []);
+        models_ref :=
+          (match get_json ~sw ~net (base ^ "/v1/models") with
+           | Ok json -> parse_models json
+           | Error detail ->
+               warn "models" detail;
+               []));
       (fun () ->
-        props_ref := match get_json ~sw ~net (base ^ "/props") with
-          | Ok json -> parse_props json | Error _ -> None);
+        props_ref := capture_json "props" parse_props (base ^ "/props"));
       (fun () ->
-        slots_ref := match get_json ~sw ~net (base ^ "/slots") with
-          | Ok json -> parse_slots json | Error _ -> None);
+        slots_ref := capture_json "slots" parse_slots (base ^ "/slots"));
     ];
     let models = !models_ref in
     let slots = !slots_ref in

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -235,6 +235,7 @@ let probe_ollama_context ~sw ~net base_url =
             | Http_client.HttpError { code; body } ->
                 Printf.sprintf "HTTP %d: %s" code body
             | Http_client.NetworkError { message } -> message
+            | Http_client.AcceptRejected { reason } -> reason
           in
           warn_probe_failure ~url:base_url ~phase:"ollama_show_http" detail;
           None

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -19,9 +19,7 @@ type http_error =
 
 (* ── Internal helpers ──────────────────────────────────────── *)
 
-let make_client ~net =
-  let https = Api_common.make_https () in
-  Cohttp_eio.Client.make ~https net
+let ( let* ) = Result.bind
 
 let catch_network f =
   try f ()
@@ -32,6 +30,22 @@ let catch_network f =
       Error (NetworkError { message = Printexc.to_string exn })
   | Failure msg ->
       Error (NetworkError { message = msg })
+
+let parse_uri url =
+  try Ok (Uri.of_string url)
+  with Invalid_argument msg ->
+    Error (NetworkError { message = Printf.sprintf "invalid URL %S: %s" url msg })
+
+let log_close_failure ~url ~message =
+  let json =
+    `Assoc
+      [
+        ("event", `String "http_client_socket_close_failed");
+        ("url", `String url);
+        ("error", `String message);
+      ]
+  in
+  Printf.eprintf "%s\n%!" (Yojson.Safe.to_string json)
 
 (* Substring check on already-lowered strings. *)
 let has_substr haystack needle =
@@ -64,70 +78,97 @@ let add_connection_close headers =
   ("connection", "close") :: headers
 
 (** Client wrapper that tracks the socket for explicit close.
-    cohttp-eio's [Eio.Switch] cleanup does not reliably call
-    [Unix.close] on the underlying socket fd (observed on macOS,
-    cohttp-eio 6.1.1).  We intercept the connection factory via
-    [make_generic] to capture the socket, then close it explicitly
-    when the switch exits. *)
-let make_closing_client ~sw ~net =
+    The caller provides the concrete URI so host resolution and TLS
+    availability can be checked up front and reported as typed errors. *)
+let make_closing_client ~sw ~net ~uri =
   let net = (net :> [ `Generic ] Eio.Net.ty Eio.Resource.t) in
   let https = Api_common.make_https () in
-  (* Track the raw socket separately for explicit close.
-     The socket fd is the resource that leaks; closing it releases the fd. *)
-  let last_sock :
-    [ `Generic ] Eio.Net.stream_socket_ty Eio.Resource.t option ref =
-    ref None
+  let* host =
+    match Uri.host uri with
+    | Some host when String.trim host <> "" -> Ok host
+    | _ ->
+        Error
+          (NetworkError
+             {
+               message =
+                 Printf.sprintf "invalid URL %S: missing host" (Uri.to_string uri);
+             })
   in
-  let connect ~sw:conn_sw uri =
-    let service =
-      match Uri.port uri with
-      | Some port -> Int.to_string port
-      | _ -> Uri.scheme uri |> Option.value ~default:"http"
-    in
-    let addr =
-      match
-        Eio.Net.getaddrinfo_stream ~service net
-          (Uri.host_with_default ~default:"localhost" uri)
-      with
-      | ip :: _ -> ip
+  let service =
+    match Uri.port uri with
+    | Some port -> Int.to_string port
+    | None -> Uri.scheme uri |> Option.value ~default:"http"
+  in
+  let addr =
+    try
+      match Eio.Net.getaddrinfo_stream ~service net host with
+      | ip :: _ -> Ok ip
       | [] ->
-        (* Raised inside connect callback; caught by catch_network at
-           the public API boundary and converted to Error NetworkError. *)
-        failwith ("failed to resolve hostname: "
-          ^ Uri.host_with_default ~default:"(none)" uri)
-    in
-    let sock = Eio.Net.connect ~sw:conn_sw net addr in
-    last_sock := Some sock;
-    (* Return type must include `Close for cohttp-eio >= 6.2 make_generic *)
+          Error
+            (NetworkError
+               {
+                 message =
+                   Printf.sprintf "failed to resolve hostname: %s" host;
+               })
+    with
+    | Eio.Io _ as exn ->
+        Error (NetworkError { message = Printexc.to_string exn })
+    | Unix.Unix_error _ as exn ->
+        Error (NetworkError { message = Printexc.to_string exn })
+    | Failure msg -> Error (NetworkError { message = msg })
+  in
+  let tls_wrap =
     match Uri.scheme uri with
     | Some "https" -> (
         match https with
+        | Some wrap -> Ok (Some wrap)
+        | None ->
+            Error
+              (NetworkError
+                 {
+                   message =
+                     Printf.sprintf "HTTPS requested but TLS not available for %s"
+                       (Uri.to_string uri);
+                 }))
+    | _ -> Ok None
+  in
+  match addr, tls_wrap with
+  | Error _ as e, _ -> e
+  | _, (Error _ as e) -> e
+  | Ok addr, Ok tls_wrap ->
+      (* Track the raw socket separately for explicit close.
+         The socket fd is the resource that leaks; closing it releases the fd. *)
+      let last_sock :
+        [ `Generic ] Eio.Net.stream_socket_ty Eio.Resource.t option ref =
+        ref None
+      in
+      let connect ~sw:conn_sw _uri =
+        let sock = Eio.Net.connect ~sw:conn_sw net addr in
+        last_sock := Some sock;
+        match tls_wrap with
         | Some wrap ->
             (wrap uri sock
               :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
-        | None ->
-          (* Raised inside connect callback; caught by catch_network. *)
-          failwith ("HTTPS requested but TLS not available for "
-            ^ Uri.to_string uri))
-    | _ -> (sock :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
-  in
-  let client = Cohttp_eio.Client.make_generic connect in
-  Eio.Switch.on_release sw (fun () ->
-    match !last_sock with
-    | None -> ()
-    | Some sock ->
-        last_sock := None;
-        (try Eio.Net.close sock with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | _exn -> (* Socket close failure is non-fatal but logged for FD leak diagnosis. *)
-           ()));
-  client
+        | None -> (sock :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
+      in
+      let client = Cohttp_eio.Client.make_generic connect in
+      Eio.Switch.on_release sw (fun () ->
+        match !last_sock with
+        | None -> ()
+        | Some sock ->
+            last_sock := None;
+            (try Eio.Net.close sock with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | exn ->
+                 log_close_failure ~url:(Uri.to_string uri)
+                   ~message:(Printexc.to_string exn)));
+      Ok client
 
 let get_sync ~sw:_ ~net ~url ~headers =
   catch_network (fun () ->
     Eio.Switch.run @@ fun sw ->
-    let client = make_closing_client ~sw ~net in
-    let uri = Uri.of_string url in
+    let* uri = parse_uri url in
+    let* client = make_closing_client ~sw ~net ~uri in
     let hdr = Http.Header.of_list (add_connection_close headers) in
     let resp, resp_body =
       Cohttp_eio.Client.get ~sw client ~headers:hdr uri
@@ -142,8 +183,8 @@ let get_sync ~sw:_ ~net ~url ~headers =
 let post_sync ~sw:_ ~net ~url ~headers ~body =
   catch_network (fun () ->
     Eio.Switch.run @@ fun sw ->
-    let client = make_closing_client ~sw ~net in
-    let uri = Uri.of_string url in
+    let* uri = parse_uri url in
+    let* client = make_closing_client ~sw ~net ~uri in
     (* Explicitly set Content-Length to prevent chunked transfer encoding.
        Ollama's yyjson parser rejects chunked bodies with
        "Value looks like object, but can't find closing '}' symbol". *)
@@ -165,9 +206,13 @@ let post_sync ~sw:_ ~net ~url ~headers ~body =
 
 let post_stream ~sw ~net ~url ~headers ~body =
   catch_network (fun () ->
-    let uri = Uri.of_string url in
-    let client = make_client ~net in
-    let hdr = Http.Header.of_list headers in
+    let* uri = parse_uri url in
+    let* client = make_closing_client ~sw ~net ~uri in
+    let headers_with_length =
+      ("content-length", string_of_int (String.length body))
+      :: add_connection_close headers
+    in
+    let hdr = Http.Header.of_list headers_with_length in
     let resp, resp_body =
       Cohttp_eio.Client.post ~sw client ~headers:hdr
         ~body:(Cohttp_eio.Body.of_string body) uri
@@ -185,8 +230,8 @@ let post_stream ~sw ~net ~url ~headers ~body =
 let with_post_stream ~net ~url ~headers ~body ~f =
   catch_network (fun () ->
     Eio.Switch.run @@ fun sw ->
-    let client = make_closing_client ~sw ~net in
-    let uri = Uri.of_string url in
+    let* uri = parse_uri url in
+    let* client = make_closing_client ~sw ~net ~uri in
     let headers_with_length =
       ("content-length", string_of_int (String.length body))
       :: add_connection_close headers

--- a/lib/llm_provider/model_meta.ml
+++ b/lib/llm_provider/model_meta.ml
@@ -14,27 +14,13 @@ type t = {
   cost_per_1k_output : float;
 }
 
-(* ── Locality heuristic ──────────────────────────────── *)
-
-(** Known local model name fragments.
-    A model is considered local when its pricing is zero AND its
-    name matches one of these prefixes/fragments.  Unknown models
-    with zero pricing default to [false] (conservative). *)
-let local_model_fragments =
-  [ "qwen"; "llama"; "ollama"; "deepseek"; "phi-"; "mistral";
-    "gemma"; "yi-"; "internlm"; "codestral" ]
-
-let is_local_heuristic ~pricing model_id =
-  (* Must have zero cost (both directions) AND match a known local fragment *)
-  pricing.Pricing.input_per_million = 0.0 &&
-  pricing.Pricing.output_per_million = 0.0 &&
-  let id = String.lowercase_ascii model_id in
-  List.exists (fun frag -> Pricing.string_contains ~needle:frag id)
-    local_model_fragments
+let is_local = function
+  | `Local -> true
+  | `Remote -> false
 
 (* ── Constructors ────────────────────────────────────── *)
 
-let for_model_id model_id =
+let for_model_id ?(locality = `Remote) model_id =
   let caps = match Capabilities.for_model_id model_id with
     | Some c -> c
     | None -> Capabilities.default_capabilities
@@ -51,16 +37,22 @@ let for_model_id model_id =
   { model_id;
     capabilities = caps;
     pricing;
-    is_local = is_local_heuristic ~pricing model_id;
+    is_local = is_local locality;
     context_window;
     max_output_tokens;
     cost_per_1k_input = pricing.input_per_million /. 1000.0;
     cost_per_1k_output = pricing.output_per_million /. 1000.0;
   }
 
-let for_model_id_with_ctx model_id ~ctx_size =
+let for_provider_config (config : Provider_config.t) =
+  let locality =
+    if Provider_config.is_local config then `Local else `Remote
+  in
+  for_model_id ~locality config.model_id
+
+let for_model_id_with_ctx ?(locality = `Remote) model_id ~ctx_size =
   let ctx_size = max 1 ctx_size in  (* guard against zero/negative *)
-  let meta = for_model_id model_id in
+  let meta = for_model_id ~locality model_id in
   let max_out = min meta.max_output_tokens ctx_size in
   { meta with context_window = ctx_size;
               max_output_tokens = max_out;
@@ -82,8 +74,14 @@ let%test "claude-opus-4-6 is cloud with 1M context" =
   && not m.is_local
   && m.cost_per_1k_input > 0.0
 
-let%test "qwen3.5-35b is local with 262K context" =
+let%test "locality defaults to remote even for local-looking model ids" =
   let m = for_model_id "qwen3.5-35b" in
+  m.context_window = 262_144
+  && not m.is_local
+  && m.cost_per_1k_input = 0.0
+
+let%test "qwen3.5-35b can be marked local explicitly" =
+  let m = for_model_id ~locality:`Local "qwen3.5-35b" in
   m.context_window = 262_144
   && m.is_local
   && m.cost_per_1k_input = 0.0
@@ -107,17 +105,35 @@ let%test "gemini-2.5-flash has 1M context" =
   let m = for_model_id "gemini-2.5-flash" in
   m.context_window = 1_000_000
 
-let%test "deepseek-v3 is local" =
-  let m = for_model_id "deepseek-v3" in
+let%test "deepseek-v3 can be marked local explicitly" =
+  let m = for_model_id ~locality:`Local "deepseek-v3" in
   m.is_local
   && m.context_window = 128_000
 
-let%test "llama-4-maverick is local" =
-  let m = for_model_id "llama-4-maverick" in
+let%test "llama-4-maverick can be marked local explicitly" =
+  let m = for_model_id ~locality:`Local "llama-4-maverick" in
   m.is_local
 
+let%test "for_provider_config uses provider locality" =
+  let config =
+    Provider_config.make ~kind:OpenAI_compat ~model_id:"qwen3.5-35b"
+      ~base_url:Constants.Endpoints.default_url ()
+  in
+  let meta = for_provider_config config in
+  meta.is_local
+
+let%test "for_provider_config keeps remote local-looking model ids remote" =
+  let config =
+    Provider_config.make ~kind:OpenAI_compat ~model_id:"qwen3.5-35b"
+      ~base_url:"https://api.example.com" ()
+  in
+  let meta = for_provider_config config in
+  not meta.is_local
+
 let%test "for_model_id_with_ctx overrides context_window" =
-  let m = for_model_id_with_ctx "qwen3.5-35b" ~ctx_size:131_072 in
+  let m =
+    for_model_id_with_ctx ~locality:`Local "qwen3.5-35b" ~ctx_size:131_072
+  in
   m.context_window = 131_072
   && m.capabilities.max_context_tokens = Some 131_072
 
@@ -135,5 +151,5 @@ let%test "for_model_id_with_ctx clamps max_output" =
   && m.max_output_tokens <= 2000
 
 let%test "for_model_id_with_ctx guards zero" =
-  let m = for_model_id_with_ctx "qwen3.5-35b" ~ctx_size:0 in
+  let m = for_model_id_with_ctx ~locality:`Local "qwen3.5-35b" ~ctx_size:0 in
   m.context_window = 1

--- a/lib/llm_provider/model_meta.mli
+++ b/lib/llm_provider/model_meta.mli
@@ -12,10 +12,9 @@ type t = {
   capabilities : Capabilities.capabilities;
   pricing : Pricing.pricing;
   is_local : bool;
-    (** Whether the model likely runs locally (llama.cpp, Ollama, etc.).
-        Determined by known local model name fragments (substring match)
-        AND zero pricing (both input and output).
-        Unknown models default to [false] (conservative). *)
+    (** Whether the caller explicitly identified this model as local.
+        Model IDs alone do not imply locality. The default is [false]
+        unless the caller passes [~locality:`Local]. *)
   context_window : int;
     (** Effective context window in tokens. Resolved from
         [capabilities.max_context_tokens], falling back to 100_000. *)
@@ -28,11 +27,17 @@ type t = {
     (** USD per 1K output tokens. *)
 }
 
-val for_model_id : string -> t
+val for_model_id : ?locality:[ `Local | `Remote ] -> string -> t
 (** Resolve model metadata by model ID.
-    Always succeeds — unknown models get conservative defaults. *)
+    Always succeeds — unknown models get conservative defaults.
+    [locality] defaults to [`Remote] because model IDs alone are not a
+    trustworthy source of deployment locality. *)
 
-val for_model_id_with_ctx : string -> ctx_size:int -> t
+val for_provider_config : Provider_config.t -> t
+(** Resolve model metadata using provider-config locality as the SSOT. *)
+
+val for_model_id_with_ctx :
+  ?locality:[ `Local | `Remote ] -> string -> ctx_size:int -> t
 (** Like [for_model_id] but overrides [context_window] with a
     Discovery-provided [ctx_size] (e.g. from [GET /props]). *)
 

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -90,3 +90,19 @@ let reasoning_effort_of_config (config : t) : string option =
                       ~enable_thinking:config.enable_thinking
                       ~thinking_budget:config.thinking_budget)
   | _ -> None
+
+let has_host_prefix ~url ~prefix =
+  let prefix_len = String.length prefix in
+  String.length url >= prefix_len
+  && String.sub url 0 prefix_len = prefix
+  &&
+  let next_index = prefix_len in
+  String.length url = prefix_len
+  || match url.[next_index] with
+     | ':' | '/' -> true
+     | _ -> false
+
+let is_local (config : t) =
+  let url = String.lowercase_ascii (String.trim config.base_url) in
+  has_host_prefix ~url ~prefix:Constants.Endpoints.local_prefix
+  || has_host_prefix ~url ~prefix:Constants.Endpoints.localhost_prefix

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -99,7 +99,7 @@ let has_host_prefix ~url ~prefix =
   let next_index = prefix_len in
   String.length url = prefix_len
   || match url.[next_index] with
-     | ':' | '/' -> true
+     | ':' | '/' | '?' | '#' -> true
      | _ -> false
 
 let is_local (config : t) =

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -77,3 +77,7 @@ val effort_of_thinking_config :
     Returns [None] for non-Ollama providers.
     @since 0.114.0 *)
 val reasoning_effort_of_config : t -> string option
+
+(** Whether the provider config points at a local loopback endpoint.
+    This is the SSOT for locality checks derived from runtime configuration. *)
+val is_local : t -> bool

--- a/lib/memory_file_backend.ml
+++ b/lib/memory_file_backend.ml
@@ -6,6 +6,14 @@
 
 type t = { base_dir: Eio.Fs.dir_ty Eio.Path.t }
 
+let _log = Log.create ~module_name:"memory_file_backend" ()
+
+let warn_backend_issue ~op ~path exn =
+  Log.warn _log "memory backend operation failed"
+    [ Log.S ("op", op);
+      Log.S ("path", path);
+      Log.S ("error", Printexc.to_string exn) ]
+
 (* ── Key encoding ────────────────────────────────────────────── *)
 
 (** Encode a key as a hex string for filesystem safety.
@@ -74,7 +82,17 @@ let retrieve t ~key =
     let data = Eio.Path.load path in
     Some (Yojson.Safe.from_string data)
   with
-  | _ -> None
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | Eio.Io (Eio.Fs.E (Not_found _), _) -> None
+  | Yojson.Json_error _ as exn ->
+      warn_backend_issue ~op:"retrieve_parse" ~path:key exn;
+      None
+  | Eio.Io _ as exn ->
+      warn_backend_issue ~op:"retrieve" ~path:key exn;
+      None
+  | Unix.Unix_error _ as exn ->
+      warn_backend_issue ~op:"retrieve" ~path:key exn;
+      None
 
 let remove t ~key =
   let path = file_path t key in
@@ -126,7 +144,11 @@ let query t ~prefix ~limit =
         in
         take limit [] lst
       else lst)
-  with _ -> []
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      warn_backend_issue ~op:"query" ~path:prefix exn;
+      []
 
 (* ── Backend conversion ──────────────────────────────────────── *)
 
@@ -152,18 +174,42 @@ let keys t =
         hex_decode (String.sub name 0 (len - 5))
       else None)
     |> List.sort String.compare
-  with _ -> []
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      warn_backend_issue ~op:"keys" ~path:"memory_dir" exn;
+      []
 
 let entry_count t = List.length (keys t)
 
 let clear t =
   try
     let entries = Eio.Path.read_dir t.base_dir in
-    List.iter (fun name ->
-      let path = Eio.Path.(t.base_dir / name) in
-      (try Eio.Path.unlink path with _ -> ())
-    ) entries;
-    Ok ()
+    let failures =
+      List.filter_map
+        (fun name ->
+          let path = Eio.Path.(t.base_dir / name) in
+          try
+            Eio.Path.unlink path;
+            None
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+              warn_backend_issue ~op:"clear_entry" ~path:name exn;
+              Some (Printf.sprintf "%s: %s" name (Printexc.to_string exn)))
+        entries
+    in
+    (match failures with
+     | [] -> Ok ()
+     | errs ->
+         Error
+           (Error.Io
+              (FileOpFailed
+                 {
+                   op = "clear";
+                   path = "memory_dir";
+                   detail = String.concat "; " errs;
+                 })))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -415,14 +415,6 @@ let default_api_key_env_of_kind
     When [api_key] is empty, falls back to the well-known env var
     name for the provider kind (e.g. [ANTHROPIC_API_KEY]). *)
 let config_of_provider_config (pc : Llm_provider.Provider_config.t) : config =
-  let is_local url =
-    let starts p =
-      String.length url >= String.length p
-      && String.sub url 0 (String.length p) = p
-    in
-    starts Llm_provider.Constants.Endpoints.local_prefix
-    || starts Llm_provider.Constants.Endpoints.localhost_prefix
-  in
   let provider = match pc.kind with
     | Anthropic -> Anthropic
     | Gemini ->
@@ -432,7 +424,8 @@ let config_of_provider_config (pc : Llm_provider.Provider_config.t) : config =
       OpenAICompat { base_url = pc.base_url; auth_header = None;
                      path = pc.request_path; static_token = None }
     | OpenAI_compat | Ollama ->
-      if is_local pc.base_url then Local { base_url = pc.base_url }
+      if Llm_provider.Provider_config.is_local pc
+      then Local { base_url = pc.base_url }
       else OpenAICompat { base_url = pc.base_url; auth_header = None;
                           path = pc.request_path; static_token = None }
     | Claude_code ->

--- a/lib/runtime_evidence.ml
+++ b/lib/runtime_evidence.ml
@@ -52,6 +52,34 @@ type evidence_bundle = {
 
 let now () = Unix.gettimeofday ()
 
+let encode_persist_failure_detail ~phase message =
+  Printf.sprintf "%s%s] %s" runtime_persist_failure_prefix phase message
+
+let append_dropped_output_deltas_summary ~summary ~dropped_output_deltas =
+  Printf.sprintf "%s\n\n%s%d" summary dropped_output_deltas_marker
+    dropped_output_deltas
+
+let artifact_attached_event (artifact : Runtime.artifact) =
+  Artifact_attached
+    {
+      artifact_id = artifact.artifact_id;
+      name = artifact.name;
+      kind = artifact.kind;
+      mime_type = artifact.mime_type;
+      path = Option.value ~default:"" artifact.path;
+      size_bytes = artifact.size_bytes;
+    }
+
+let base_evidence_file_specs store session_id =
+  [
+    ("session_json", Runtime_store.session_path store session_id);
+    ("events_jsonl", Runtime_store.events_path store session_id);
+    ("report_json", Runtime_store.report_json_path store session_id);
+    ("report_md", Runtime_store.report_md_path store session_id);
+    ("proof_json", Runtime_store.proof_json_path store session_id);
+    ("proof_md", Runtime_store.proof_md_path store session_id);
+  ]
+
 let find_last_substring_index ~needle haystack =
   let needle_len = String.length needle in
   let haystack_len = String.length haystack in

--- a/lib/runtime_evidence.ml
+++ b/lib/runtime_evidence.ml
@@ -1,5 +1,8 @@
 open Runtime
 
+let runtime_persist_failure_prefix = "[runtime_persist_failure phase="
+let dropped_output_deltas_marker = "[runtime telemetry] dropped_output_deltas="
+
 type telemetry_step = {
   seq: int;
   ts: float;
@@ -16,6 +19,8 @@ type telemetry_step = {
   artifact_kind: string option;
   checkpoint_label: string option;
   outcome: string option;
+  dropped_output_deltas: int option;
+  persistence_failure_phase: string option;
 }
 
 type telemetry_report = {
@@ -24,6 +29,10 @@ type telemetry_report = {
   step_count: int;
   event_counts: (string * int) list;
   event_name_counts: (string * int) list;
+  dropped_output_deltas: int;
+  persistence_failure_count: int;
+  participants_with_dropped_output_deltas: string list;
+  participants_with_persistence_failures: string list;
   steps: telemetry_step list;
 }
 
@@ -42,6 +51,49 @@ type evidence_bundle = {
 }
 
 let now () = Unix.gettimeofday ()
+
+let find_last_substring_index ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    if idx < 0 then None
+    else if String.sub haystack idx needle_len = needle then Some idx
+    else loop (idx - 1)
+  in
+  if needle_len = 0 || haystack_len < needle_len then None
+  else loop (haystack_len - needle_len)
+
+let dropped_output_deltas_of_text = function
+  | None -> None
+  | Some text ->
+      let text = String.trim text in
+      begin match find_last_substring_index ~needle:dropped_output_deltas_marker text with
+      | None -> None
+      | Some idx ->
+          let start = idx + String.length dropped_output_deltas_marker in
+          if start >= String.length text then None
+          else
+            let raw =
+              String.sub text start (String.length text - start) |> String.trim
+            in
+            match int_of_string_opt raw with
+            | Some n when n > 0 -> Some n
+            | _ -> None
+      end
+
+let persistence_failure_phase_of_text = function
+  | None -> None
+  | Some text ->
+      let text = String.trim text in
+      if not (String.starts_with ~prefix:runtime_persist_failure_prefix text)
+      then None
+      else
+        let start = String.length runtime_persist_failure_prefix in
+        match String.index_from_opt text start ']' with
+        | None -> None
+        | Some stop when stop > start ->
+            Some (String.sub text start (stop - start))
+        | Some _ -> None
 
 let participant_and_detail_of_event = function
   | Session_started _ -> (None, Some "session_started")
@@ -154,6 +206,8 @@ let build_telemetry_report (session : session) (events : event list) =
             checkpoint_label, outcome =
           structured_fields_of_event event.kind
         in
+        let dropped_output_deltas = dropped_output_deltas_of_text detail in
+        let persistence_failure_phase = persistence_failure_phase_of_text detail in
         {
           seq = event.seq;
           ts = event.ts;
@@ -170,8 +224,40 @@ let build_telemetry_report (session : session) (events : event list) =
           artifact_kind;
           checkpoint_label;
           outcome;
+          dropped_output_deltas;
+          persistence_failure_phase;
         })
       events
+  in
+  let dropped_output_deltas =
+    List.fold_left
+      (fun acc (step : telemetry_step) ->
+        acc + Option.value step.dropped_output_deltas ~default:0)
+      0 steps
+  in
+  let participants_with_dropped_output_deltas =
+    steps
+    |> List.filter_map (fun (step : telemetry_step) ->
+         match step.participant, step.dropped_output_deltas with
+         | Some participant, Some n when n > 0 -> Some participant
+         | _ -> None)
+    |> List.sort_uniq String.compare
+  in
+  let participants_with_persistence_failures =
+    steps
+    |> List.filter_map (fun (step : telemetry_step) ->
+         match step.participant, step.persistence_failure_phase with
+         | Some participant, Some _ -> Some participant
+         | _ -> None)
+    |> List.sort_uniq String.compare
+  in
+  let persistence_failure_count =
+    List.fold_left
+      (fun acc (step : telemetry_step) ->
+        match step.persistence_failure_phase with
+        | Some _ -> acc + 1
+        | None -> acc)
+      0 steps
   in
   {
     session_id = session.session_id;
@@ -179,6 +265,10 @@ let build_telemetry_report (session : session) (events : event list) =
     step_count = List.length steps;
     event_counts;
     event_name_counts;
+    dropped_output_deltas;
+    persistence_failure_count;
+    participants_with_dropped_output_deltas;
+    participants_with_persistence_failures;
     steps;
   }
 
@@ -188,6 +278,18 @@ let telemetry_report_to_json (report : telemetry_report) =
       ("session_id", `String report.session_id);
       ("generated_at", `Float report.generated_at);
       ("step_count", `Int report.step_count);
+      ("dropped_output_deltas", `Int report.dropped_output_deltas);
+      ("persistence_failure_count", `Int report.persistence_failure_count);
+      ( "participants_with_dropped_output_deltas",
+        `List
+          (List.map
+             (fun participant -> `String participant)
+             report.participants_with_dropped_output_deltas) );
+      ( "participants_with_persistence_failures",
+        `List
+          (List.map
+             (fun participant -> `String participant)
+             report.participants_with_persistence_failures) );
       ( "event_counts",
         `Assoc
           (List.map (fun (name, count) -> (name, `Int count)) report.event_counts)
@@ -256,6 +358,14 @@ let telemetry_report_to_json (report : telemetry_report) =
                      match step.outcome with
                      | Some value -> `String value
                      | None -> `Null );
+                   ( "dropped_output_deltas",
+                     match step.dropped_output_deltas with
+                     | Some value -> `Int value
+                     | None -> `Null );
+                   ( "persistence_failure_phase",
+                     match step.persistence_failure_phase with
+                     | Some value -> `String value
+                     | None -> `Null );
                  ])
              report.steps) );
     ]
@@ -279,9 +389,38 @@ let telemetry_report_to_markdown (report : telemetry_report) =
              | Some value when String.trim value <> "" -> value
              | _ -> "-"
            in
-           Printf.sprintf "- #%d %s participant=%s detail=%s"
-             step.seq step.kind participant detail)
+           let anomalies =
+             [
+               (match step.dropped_output_deltas with
+                | Some count ->
+                    Some (Printf.sprintf " dropped_output_deltas=%d" count)
+                | None -> None);
+               (match step.persistence_failure_phase with
+                | Some phase ->
+                    Some (Printf.sprintf " persistence_failure_phase=%s" phase)
+                | None -> None);
+             ]
+             |> List.filter_map (fun item -> item)
+             |> String.concat ""
+           in
+           Printf.sprintf "- #%d %s participant=%s detail=%s%s"
+             step.seq step.kind participant detail anomalies)
     |> String.concat "\n"
+  in
+  let anomaly_lines =
+    [
+      Printf.sprintf "- Dropped Output Deltas: %d" report.dropped_output_deltas;
+      Printf.sprintf "- Persistence Failures: %d"
+        report.persistence_failure_count;
+    ]
+    @
+    (report.participants_with_dropped_output_deltas
+    |> List.map (fun participant ->
+           Printf.sprintf "- dropped_output_deltas participant=%s" participant))
+    @
+    (report.participants_with_persistence_failures
+    |> List.map (fun participant ->
+           Printf.sprintf "- persistence_failure participant=%s" participant))
   in
   String.concat "\n"
     [
@@ -289,6 +428,9 @@ let telemetry_report_to_markdown (report : telemetry_report) =
       "";
       Printf.sprintf "- Session ID: %s" report.session_id;
       Printf.sprintf "- Step Count: %d" report.step_count;
+      "";
+      "## Anomalies";
+      String.concat "\n" anomaly_lines;
       "";
       "## Event Name Counts";
       (report.event_name_counts

--- a/lib/runtime_evidence.mli
+++ b/lib/runtime_evidence.mli
@@ -54,6 +54,14 @@ type evidence_bundle = {
 }
 
 val now : unit -> float
+val runtime_persist_failure_prefix : string
+val dropped_output_deltas_marker : string
+val encode_persist_failure_detail : phase:string -> string -> string
+val append_dropped_output_deltas_summary :
+  summary:string -> dropped_output_deltas:int -> string
+val artifact_attached_event : Runtime.artifact -> Runtime.event_kind
+val base_evidence_file_specs :
+  Runtime_store.t -> string -> (string * string) list
 val build_telemetry_report : Runtime.session -> Runtime.event list -> telemetry_report
 val telemetry_report_to_json : telemetry_report -> Yojson.Safe.t
 val telemetry_report_to_markdown : telemetry_report -> string

--- a/lib/runtime_evidence.mli
+++ b/lib/runtime_evidence.mli
@@ -22,6 +22,8 @@ type telemetry_step = {
   artifact_kind: string option;
   checkpoint_label: string option;
   outcome: string option;
+  dropped_output_deltas: int option;
+  persistence_failure_phase: string option;
 }
 
 type telemetry_report = {
@@ -30,6 +32,10 @@ type telemetry_report = {
   step_count: int;
   event_counts: (string * int) list;
   event_name_counts: (string * int) list;
+  dropped_output_deltas: int;
+  persistence_failure_count: int;
+  participants_with_dropped_output_deltas: string list;
+  participants_with_persistence_failures: string list;
   steps: telemetry_step list;
 }
 

--- a/lib/runtime_server.ml
+++ b/lib/runtime_server.ml
@@ -6,6 +6,36 @@ open Runtime_server_worker
 let ( let* ) = Result.bind
 
 let first_some = Util.first_some
+let _log = Log.create ~module_name:"runtime_server" ()
+let runtime_persist_failure_prefix = "[runtime_persist_failure phase="
+
+let encode_persist_failure_detail ~phase message =
+  Printf.sprintf "%s%s] %s" runtime_persist_failure_prefix phase message
+
+let log_participant_persist_failure ~session_id ~participant_name ~phase err =
+  Log.error _log "participant event persistence failed"
+    [ Log.S ("session_id", session_id);
+      Log.S ("participant", participant_name);
+      Log.S ("phase", phase);
+      Log.S ("error", Error.to_string err) ]
+
+let persist_participant_failure store state ~session_id ~participant_name
+    ~provider ~model ~detail =
+  match
+    persist_event store state session_id
+      (Agent_failed
+         {
+           participant_name;
+           summary = None;
+           provider;
+           model;
+           error = Some detail;
+         })
+  with
+  | Ok _ -> ()
+  | Error err ->
+      log_participant_persist_failure ~session_id ~participant_name
+        ~phase:"agent_failed" err
 
 let rec read_control_response state control_id =
   match input_line stdin with
@@ -171,54 +201,69 @@ let apply_command ~sw state store (session : session) command =
         let participant_name = detail.participant_name in
         Eio.Fiber.fork ~sw (fun () ->
           try
-            ignore
-              (match
-                 persist_event store state session_id
-                   (Agent_became_live
-                      {
-                        participant_name;
-                        summary = Some "runtime-started";
-                        provider = resolution.resolved_provider;
-                        model = resolution.resolved_model;
-                        error = None;
-                      })
-               with
-               | Error _ -> Ok ()
-               | Ok _ -> (
-                   match
-                     run_participant store state session_id resolution detail
-                   with
-                   | Ok summary ->
-                       let* _session, _ =
-                         persist_event store state session_id
-                           (Agent_completed
-                              {
-                                participant_name;
-                                summary = Some summary;
-                                provider = resolution.resolved_provider;
-                                model = resolution.resolved_model;
-                                error = None;
-                              })
-                       in
-                       Ok ()
-                   | Error err ->
-                       let* _session, _ =
-                         persist_event store state session_id
-                           (Agent_failed
-                              {
-                                participant_name;
-                                summary = None;
-                                provider = resolution.resolved_provider;
-                                model = resolution.resolved_model;
-                                error = Some (Error.to_string err);
-                              })
-                       in
-                       Ok ()))
+            (match
+               persist_event store state session_id
+                 (Agent_became_live
+                    {
+                      participant_name;
+                      summary = Some "runtime-started";
+                      provider = resolution.resolved_provider;
+                      model = resolution.resolved_model;
+                      error = None;
+                    })
+             with
+             | Error err ->
+                 let detail =
+                   encode_persist_failure_detail ~phase:"agent_became_live"
+                     (Printf.sprintf "failed to persist runtime-started event: %s"
+                        (Error.to_string err))
+                 in
+                 log_participant_persist_failure ~session_id ~participant_name
+                   ~phase:"agent_became_live" err;
+                 persist_participant_failure store state ~session_id
+                   ~participant_name ~provider:resolution.resolved_provider
+                   ~model:resolution.resolved_model ~detail
+             | Ok _ -> (
+                 match run_participant store state session_id resolution detail with
+                 | Ok summary -> (
+                     match
+                       persist_event store state session_id
+                         (Agent_completed
+                            {
+                              participant_name;
+                              summary = Some summary;
+                              provider = resolution.resolved_provider;
+                              model = resolution.resolved_model;
+                              error = None;
+                            })
+                     with
+                     | Ok _ -> ()
+                     | Error err ->
+                         let detail =
+                           encode_persist_failure_detail ~phase:"agent_completed"
+                             (Printf.sprintf
+                                "participant completed but completion event could not be persisted: %s"
+                                (Error.to_string err))
+                         in
+                         log_participant_persist_failure ~session_id
+                           ~participant_name ~phase:"agent_completed" err;
+                         persist_participant_failure store state ~session_id
+                           ~participant_name
+                           ~provider:resolution.resolved_provider
+                           ~model:resolution.resolved_model ~detail)
+                 | Error err ->
+                     persist_participant_failure store state ~session_id
+                       ~participant_name ~provider:resolution.resolved_provider
+                       ~model:resolution.resolved_model
+                       ~detail:(Error.to_string err)))
           with
           | Eio.Cancel.Cancelled _ as ex -> raise ex
           | exn ->
-            Eio.traceln "Runtime_server: participant %s fork failed: %s"
-              participant_name (Printexc.to_string exn));
+              persist_participant_failure store state ~session_id
+                ~participant_name ~provider:resolution.resolved_provider
+                ~model:resolution.resolved_model
+                ~detail:(Printf.sprintf "participant fiber crashed: %s"
+                           (Printexc.to_string exn)));
         Ok (Command_applied session)
       end
   | Attach_artifact detail ->

--- a/lib/runtime_server.ml
+++ b/lib/runtime_server.ml
@@ -7,10 +7,6 @@ let ( let* ) = Result.bind
 
 let first_some = Util.first_some
 let _log = Log.create ~module_name:"runtime_server" ()
-let runtime_persist_failure_prefix = "[runtime_persist_failure phase="
-
-let encode_persist_failure_detail ~phase message =
-  Printf.sprintf "%s%s] %s" runtime_persist_failure_prefix phase message
 
 let log_participant_persist_failure ~session_id ~participant_name ~phase err =
   Log.error _log "participant event persistence failed"
@@ -214,7 +210,7 @@ let apply_command ~sw state store (session : session) command =
              with
              | Error err ->
                  let detail =
-                   encode_persist_failure_detail ~phase:"agent_became_live"
+                   Runtime_evidence.encode_persist_failure_detail ~phase:"agent_became_live"
                      (Printf.sprintf "failed to persist runtime-started event: %s"
                         (Error.to_string err))
                  in
@@ -240,7 +236,7 @@ let apply_command ~sw state store (session : session) command =
                      | Ok _ -> ()
                      | Error err ->
                          let detail =
-                           encode_persist_failure_detail ~phase:"agent_completed"
+                           Runtime_evidence.encode_persist_failure_detail ~phase:"agent_completed"
                              (Printf.sprintf
                                 "participant completed but completion event could not be persisted: %s"
                                 (Error.to_string err))

--- a/lib/runtime_server_resolve.ml
+++ b/lib/runtime_server_resolve.ml
@@ -1,5 +1,7 @@
 open Runtime
 
+let ( let* ) = Result.bind
+
 type execution_resolution = {
   selected_provider: string;
   requested_model: string option;
@@ -7,6 +9,17 @@ type execution_resolution = {
   resolved_model: string option;
   provider_cfg: Provider.config option;
 }
+
+let unsupported_provider detail =
+  Error (Error.Config (Error.UnsupportedProvider { detail }))
+
+let ensure_test_provider_enabled selected =
+  if Defaults.allow_test_providers () then Ok ()
+  else
+    unsupported_provider
+      (Printf.sprintf
+         "provider %S is test-only; set OAS_ALLOW_TEST_PROVIDERS=1 to enable it explicitly"
+         selected)
 
 let provider_runtime_name selected (cfg : Provider.config option) =
   match cfg with
@@ -26,17 +39,22 @@ let resolve_provider ?provider ?model () =
   in
   let base =
     match selected with
-    | "mock" | "echo" -> Ok None
+    | "mock" | "echo" ->
+        let* () = ensure_test_provider_enabled selected in
+        Ok None
     | "local" | "local-qwen" -> Ok (Some (Provider.local_llm ()))
     | "sonnet" -> Ok (Some (Provider.anthropic_sonnet ()))
     | "haiku" -> Ok (Some (Provider.anthropic_haiku ()))
     | "opus" -> Ok (Some (Provider.anthropic_opus ()))
     | "openrouter" -> Ok (Some (Provider.openrouter ()))
     | other ->
-        Error (Error.Config
-          (Error.UnsupportedProvider
-            { detail = Printf.sprintf "unknown provider %S; valid: local, \
-              local-qwen, sonnet, haiku, opus, openrouter, mock, echo" other }))
+        unsupported_provider
+          (Printf.sprintf
+             "unknown provider %S; valid: local, local-qwen, sonnet, haiku, opus, openrouter%s"
+             other
+             (if Defaults.allow_test_providers ()
+              then ", mock, echo"
+              else ""))
   in
   match base with
   | Error _ as e -> e
@@ -68,6 +86,7 @@ let resolve_execution (session : session) (detail : spawn_agent_request) =
   in
   match selected_provider with
   | "mock" | "echo" ->
+      let* () = ensure_test_provider_enabled selected_provider in
       Ok {
         selected_provider;
         requested_model;
@@ -91,208 +110,3 @@ let resolve_execution (session : session) (detail : spawn_agent_request) =
             | None -> first_some requested_model session.model);
           provider_cfg;
         }
-
-[@@@coverage off]
-(* === Inline tests === *)
-
-(* --- provider_runtime_name --- *)
-
-let%test "provider_runtime_name: None cfg returns selected" =
-  provider_runtime_name "my-provider" None = "my-provider"
-
-let%test "provider_runtime_name: Local provider" =
-  let cfg = Some { Provider.provider = Local { base_url = Llm_provider.Constants.Endpoints.default_url_localhost };
-                   model_id = "test"; api_key_env = "K" } in
-  provider_runtime_name "local" cfg = "local"
-
-let%test "provider_runtime_name: Anthropic provider" =
-  let cfg = Some { Provider.provider = Anthropic;
-                   model_id = "claude-sonnet-4-6"; api_key_env = "K" } in
-  provider_runtime_name "anthropic" cfg = "anthropic"
-
-let%test "provider_runtime_name: OpenAICompat provider" =
-  let cfg = Some { Provider.provider = OpenAICompat {
-    base_url = "https://api.openai.com"; auth_header = None;
-    path = "/v1/chat/completions"; static_token = None };
-    model_id = "gpt-4o"; api_key_env = "K" } in
-  provider_runtime_name "openai" cfg = "openai-compat"
-
-let%test "provider_runtime_name: Custom_registered provider" =
-  let cfg = Some { Provider.provider = Custom_registered { name = "myvendor" };
-                   model_id = "test"; api_key_env = "K" } in
-  provider_runtime_name "custom" cfg = "custom:myvendor"
-
-(* --- resolve_provider --- *)
-
-let%test "resolve_provider: mock returns Ok None" =
-  resolve_provider ~provider:"mock" () = Ok None
-
-let%test "resolve_provider: echo returns Ok None" =
-  resolve_provider ~provider:"echo" () = Ok None
-
-let%test "resolve_provider: local returns Local provider" =
-  match resolve_provider ~provider:"local" () with
-  | Ok (Some cfg) -> (match cfg.provider with Provider.Local _ -> true | _ -> false)
-  | _ -> false
-
-let%test "resolve_provider: local-qwen returns Local provider" =
-  match resolve_provider ~provider:"local-qwen" () with
-  | Ok (Some cfg) -> (match cfg.provider with Provider.Local _ -> true | _ -> false)
-  | _ -> false
-
-let%test "resolve_provider: sonnet returns Anthropic" =
-  match resolve_provider ~provider:"sonnet" () with
-  | Ok (Some cfg) -> cfg.provider = Provider.Anthropic
-  | _ -> false
-
-let%test "resolve_provider: haiku returns Anthropic" =
-  match resolve_provider ~provider:"haiku" () with
-  | Ok (Some cfg) -> cfg.provider = Provider.Anthropic
-  | _ -> false
-
-let%test "resolve_provider: opus returns Anthropic" =
-  match resolve_provider ~provider:"opus" () with
-  | Ok (Some cfg) -> cfg.provider = Provider.Anthropic
-  | _ -> false
-
-let%test "resolve_provider: openrouter returns OpenAICompat" =
-  match resolve_provider ~provider:"openrouter" () with
-  | Ok (Some cfg) -> (match cfg.provider with Provider.OpenAICompat _ -> true | _ -> false)
-  | _ -> false
-
-let%test "resolve_provider: unknown returns UnsupportedProvider error" =
-  match resolve_provider ~provider:"unknown-provider" () with
-  | Error (Error.Config (Error.UnsupportedProvider _)) -> true
-  | _ -> false
-
-let%test "resolve_provider: typoed provider returns error" =
-  match resolve_provider ~provider:"openriauter" () with
-  | Error (Error.Config (Error.UnsupportedProvider _)) -> true
-  | _ -> false
-
-let%test "resolve_provider: empty provider uses fallback" =
-  (* Empty string triggers fallback_provider *)
-  match resolve_provider ~provider:"  " () with
-  | Ok (Some _) -> true
-  | _ -> false
-
-let%test "resolve_provider: model override applied" =
-  match resolve_provider ~provider:"sonnet" ~model:"my-custom-model" () with
-  | Ok (Some cfg) -> cfg.model_id = "my-custom-model"
-  | _ -> false
-
-let%test "resolve_provider: empty model uses default" =
-  match resolve_provider ~provider:"sonnet" ~model:"  " () with
-  | Ok (Some cfg) -> cfg.model_id <> ""
-  | _ -> false
-
-let%test "resolve_provider: trimmed and lowercased" =
-  match resolve_provider ~provider:"  MOCK  " () with
-  | Ok None -> true  (* mock returns Ok None *)
-  | _ -> false
-
-(* --- resolve_execution --- *)
-
-let dummy_session : Runtime.session = {
-  session_id = "test-sess";
-  goal = "test";
-  title = None;
-  tag = None;
-  permission_mode = None;
-  phase = Running;
-  created_at = 0.0;
-  updated_at = 0.0;
-  provider = None;
-  model = None;
-  system_prompt = None;
-  max_turns = 10;
-  workdir = None;
-  planned_participants = [];
-  participants = [];
-  artifacts = [];
-  votes = [];
-  turn_count = 0;
-  last_seq = 0;
-  outcome = None;
-}
-
-let dummy_spawn : Runtime.spawn_agent_request = {
-  participant_name = "agent-1";
-  role = Some "execute";
-  prompt = "do something";
-  provider = None;
-  model = None;
-  system_prompt = None;
-  max_turns = None;
-}
-
-let%test "resolve_execution: mock provider has no provider_cfg" =
-  let detail = { dummy_spawn with provider = Some "mock" } in
-  match resolve_execution dummy_session detail with
-  | Ok res ->
-    res.selected_provider = "mock"
-    && res.provider_cfg = None
-    && res.resolved_provider = Some "mock"
-  | Error _ -> false
-
-let%test "resolve_execution: echo provider has no provider_cfg" =
-  let detail = { dummy_spawn with provider = Some "echo" } in
-  match resolve_execution dummy_session detail with
-  | Ok res -> res.selected_provider = "echo" && res.provider_cfg = None
-  | Error _ -> false
-
-let%test "resolve_execution: detail provider takes priority over session" =
-  let session = { dummy_session with provider = Some "sonnet" } in
-  let detail = { dummy_spawn with provider = Some "mock" } in
-  match resolve_execution session detail with
-  | Ok res -> res.selected_provider = "mock"
-  | Error _ -> false
-
-let%test "resolve_execution: session provider used when detail is None" =
-  let session = { dummy_session with provider = Some "haiku" } in
-  match resolve_execution session dummy_spawn with
-  | Ok res -> res.selected_provider = "haiku"
-  | Error _ -> false
-
-let%test "resolve_execution: fallback when both None" =
-  match resolve_execution dummy_session dummy_spawn with
-  | Ok res -> res.selected_provider = Defaults.fallback_provider
-  | Error _ -> false
-
-let%test "resolve_execution: requested_model from detail" =
-  let detail = { dummy_spawn with model = Some "my-model" } in
-  match resolve_execution dummy_session detail with
-  | Ok res -> res.requested_model = Some "my-model"
-  | Error _ -> false
-
-let%test "resolve_execution: requested_model None when detail empty" =
-  let detail = { dummy_spawn with model = Some "  " } in
-  match resolve_execution dummy_session detail with
-  | Ok res -> res.requested_model = None
-  | Error _ -> false
-
-let%test "resolve_execution: non-mock has provider_cfg" =
-  let detail = { dummy_spawn with provider = Some "sonnet" } in
-  match resolve_execution dummy_session detail with
-  | Ok res -> res.provider_cfg <> None && res.resolved_provider = Some "anthropic"
-  | Error _ -> false
-
-let%test "resolve_execution: unknown provider returns error" =
-  let detail = { dummy_spawn with provider = Some "bogus-provider" } in
-  match resolve_execution dummy_session detail with
-  | Error (Error.Config (Error.UnsupportedProvider _)) -> true
-  | _ -> false
-
-let%test "resolve_execution: mock resolved_model uses session model" =
-  let session = { dummy_session with model = Some "sess-model" } in
-  let detail = { dummy_spawn with provider = Some "mock" } in
-  match resolve_execution session detail with
-  | Ok res -> res.resolved_model = Some "sess-model"
-  | Error _ -> false
-
-let%test "resolve_execution: mock requested_model takes priority" =
-  let session = { dummy_session with model = Some "sess-model" } in
-  let detail = { dummy_spawn with provider = Some "mock"; model = Some "req-model" } in
-  match resolve_execution session detail with
-  | Ok res -> res.resolved_model = Some "req-model"
-  | Error _ -> false

--- a/lib/runtime_server_worker.ml
+++ b/lib/runtime_server_worker.ml
@@ -4,6 +4,17 @@ open Runtime_server_resolve
 
 let ( let* ) = Result.bind
 let _log = Log.create ~module_name:"runtime_server_worker" ()
+let dropped_output_deltas_marker = "[runtime telemetry] dropped_output_deltas="
+
+let unsupported_test_provider provider =
+  Error.Config
+    (Error.UnsupportedProvider
+       {
+         detail =
+           Printf.sprintf
+             "provider %S is test-only; set OAS_ALLOW_TEST_PROVIDERS=1 to enable it explicitly"
+             provider;
+       })
 
 let extract_text (resp : Types.api_response) =
   resp.content
@@ -20,6 +31,27 @@ let make_event (session : session) kind =
 let with_store_lock state f =
   Eio.Mutex.use_rw ~protect:true state.store_mu f
 
+let artifact_attached_event (artifact : Runtime.artifact) =
+  Artifact_attached
+    {
+      artifact_id = artifact.artifact_id;
+      name = artifact.name;
+      kind = artifact.kind;
+      mime_type = artifact.mime_type;
+      path = Option.value ~default:"" artifact.path;
+      size_bytes = artifact.size_bytes;
+    }
+
+let base_evidence_file_specs store session_id =
+  [
+    ("session_json", Runtime_store.session_path store session_id);
+    ("events_jsonl", Runtime_store.events_path store session_id);
+    ("report_json", Runtime_store.report_json_path store session_id);
+    ("report_md", Runtime_store.report_md_path store session_id);
+    ("proof_json", Runtime_store.proof_json_path store session_id);
+    ("proof_md", Runtime_store.proof_md_path store session_id);
+  ]
+
 let persist_event_locked store state (session : session) kind =
   let event = make_event session kind in
   let* projected = Runtime_projection.apply_event session event in
@@ -32,6 +64,17 @@ let persist_event store state session_id kind =
   with_store_lock state (fun () ->
       let* session = Runtime_store.load_session store session_id in
       persist_event_locked store state session kind)
+
+let persist_artifact_events_locked store state session
+    (artifacts : Runtime.artifact list) =
+  List.fold_left
+    (fun acc artifact ->
+      let* session = acc in
+      let* session, _ =
+        persist_event_locked store state session (artifact_attached_event artifact)
+      in
+      Ok session)
+    (Ok session) artifacts
 
 let generate_report_and_proof store state session_id =
   with_store_lock state (fun () ->
@@ -51,21 +94,6 @@ let generate_report_and_proof store state session_id =
       let telemetry_md =
         Runtime_evidence.telemetry_report_to_markdown telemetry
       in
-      let evidence =
-        Runtime_evidence.build_evidence_bundle ~session_id
-          [
-            ("session_json", Runtime_store.session_path store session_id);
-            ("events_jsonl", Runtime_store.events_path store session_id);
-            ("report_json", Runtime_store.report_json_path store session_id);
-            ("report_md", Runtime_store.report_md_path store session_id);
-            ("proof_json", Runtime_store.proof_json_path store session_id);
-            ("proof_md", Runtime_store.proof_md_path store session_id);
-          ]
-      in
-      let evidence_json =
-        Runtime_evidence.evidence_bundle_to_json evidence
-        |> Yojson.Safe.pretty_to_string
-      in
       let* telemetry_json_artifact =
         Artifact_service.save_text_internal store ~session_id
           ~name:"runtime-telemetry-json" ~kind:"json"
@@ -76,48 +104,81 @@ let generate_report_and_proof store state session_id =
           ~name:"runtime-telemetry" ~kind:"markdown"
           ~content:telemetry_md
       in
+      let* telemetry_json_path =
+        Artifact_service.persisted_path telemetry_json_artifact
+      in
+      let* telemetry_md_path =
+        Artifact_service.persisted_path telemetry_md_artifact
+      in
+      let evidence =
+        Runtime_evidence.build_evidence_bundle ~session_id
+          (base_evidence_file_specs store session_id
+           @
+           [
+             ("telemetry_json", telemetry_json_path);
+             ("telemetry_md", telemetry_md_path);
+           ])
+      in
+      let evidence_json =
+        Runtime_evidence.evidence_bundle_to_json evidence
+        |> Yojson.Safe.pretty_to_string
+      in
       let* evidence_artifact =
         Artifact_service.save_text_internal store ~session_id
           ~name:"runtime-evidence" ~kind:"json"
           ~content:evidence_json
       in
-      let* session, _ =
-        persist_event_locked store state session
-          (Artifact_attached
-             {
-               artifact_id = telemetry_json_artifact.artifact_id;
-               name = telemetry_json_artifact.name;
-               kind = telemetry_json_artifact.kind;
-               mime_type = telemetry_json_artifact.mime_type;
-               path = Option.value ~default:"" telemetry_json_artifact.path;
-               size_bytes = telemetry_json_artifact.size_bytes;
-             })
+      let artifacts =
+        [ telemetry_json_artifact; telemetry_md_artifact; evidence_artifact ]
       in
-      let* session, _ =
-        persist_event_locked store state session
-          (Artifact_attached
-             {
-               artifact_id = telemetry_md_artifact.artifact_id;
-               name = telemetry_md_artifact.name;
-               kind = telemetry_md_artifact.kind;
-               mime_type = telemetry_md_artifact.mime_type;
-               path = Option.value ~default:"" telemetry_md_artifact.path;
-               size_bytes = telemetry_md_artifact.size_bytes;
-             })
+      let* final_session =
+        persist_artifact_events_locked store state session artifacts
       in
-      let* session, _ =
-        persist_event_locked store state session
-          (Artifact_attached
-             {
-               artifact_id = evidence_artifact.artifact_id;
-               name = evidence_artifact.name;
-               kind = evidence_artifact.kind;
-               mime_type = evidence_artifact.mime_type;
-               path = Option.value ~default:"" evidence_artifact.path;
-               size_bytes = evidence_artifact.size_bytes;
-             })
+      let* final_events = Runtime_store.read_events store session_id () in
+      let final_report =
+        Runtime_projection.build_report final_session final_events
       in
-      Ok (session, report, proof))
+      let final_proof =
+        Runtime_projection.build_proof final_session final_events
+      in
+      let final_telemetry =
+        Runtime_evidence.build_telemetry_report final_session final_events
+      in
+      let final_telemetry_json =
+        Runtime_evidence.telemetry_report_to_json final_telemetry
+        |> Yojson.Safe.pretty_to_string
+      in
+      let final_telemetry_md =
+        Runtime_evidence.telemetry_report_to_markdown final_telemetry
+      in
+      let* () = Runtime_store.save_report store final_report in
+      let* () = Runtime_store.save_proof store final_proof in
+      let* () =
+        Artifact_service.overwrite_text_internal telemetry_json_artifact
+          ~content:final_telemetry_json
+      in
+      let* () =
+        Artifact_service.overwrite_text_internal telemetry_md_artifact
+          ~content:final_telemetry_md
+      in
+      let final_evidence =
+        Runtime_evidence.build_evidence_bundle ~session_id
+          (base_evidence_file_specs store session_id
+           @
+           [
+             ("telemetry_json", telemetry_json_path);
+             ("telemetry_md", telemetry_md_path);
+           ])
+      in
+      let final_evidence_json =
+        Runtime_evidence.evidence_bundle_to_json final_evidence
+        |> Yojson.Safe.pretty_to_string
+      in
+      let* () =
+        Artifact_service.overwrite_text_internal evidence_artifact
+          ~content:final_evidence_json
+      in
+      Ok (final_session, final_report, final_proof))
 
 let emit_output_delta store state session_id participant_name delta =
   if String.trim delta = "" then Ok ()
@@ -131,10 +192,12 @@ let emit_output_delta store state session_id participant_name delta =
 let run_participant store state session_id
     (resolution : execution_resolution) (detail : spawn_agent_request) =
   let delta_warn_logged = ref false in
+  let delta_error_count = ref 0 in
   let emit_delta_text text =
     match emit_output_delta store state session_id detail.participant_name text with
     | Ok () -> ()
     | Error e ->
+      incr delta_error_count;
       if not !delta_warn_logged then begin
         delta_warn_logged := true;
 
@@ -158,8 +221,17 @@ let run_participant store state session_id
          Log.S ("error", Error.to_string e)];
       None
   in
+  let finalize_summary summary =
+    if !delta_error_count = 0 then summary
+    else
+      Printf.sprintf "%s\n\n%s%d" summary dropped_output_deltas_marker
+        !delta_error_count
+  in
   match resolution.selected_provider with
   | "mock" | "echo" ->
+      if not (Defaults.allow_test_providers ()) then
+        Error (unsupported_test_provider resolution.selected_provider)
+      else
       let full =
         Printf.sprintf "Mock runtime response for %s: %s" detail.participant_name
           detail.prompt
@@ -187,7 +259,12 @@ let run_participant store state session_id
       let half = String.length full / 2 in
       emit_delta_text (String.sub full 0 half);
       emit_delta_text (String.sub full half (String.length full - half));
-      Ok full
+      if !delta_error_count > 0 then
+        Log.warn _log "participant completed with dropped output deltas"
+          [ Log.S ("session_id", session_id);
+            Log.S ("participant", detail.participant_name);
+            Log.I ("dropped_output_deltas", !delta_error_count) ];
+      Ok (finalize_summary full)
   | _ ->
       Eio.Switch.run @@ fun sw ->
       match Runtime_store.load_session store session_id with
@@ -225,84 +302,11 @@ let run_participant store state session_id
         | _ -> ()
       in
       match Agent.run_stream ~sw ~on_event agent detail.prompt with
-      | Ok response -> Ok (extract_text response)
+      | Ok response ->
+          if !delta_error_count > 0 then
+            Log.warn _log "participant completed with dropped output deltas"
+              [ Log.S ("session_id", session_id);
+                Log.S ("participant", detail.participant_name);
+                Log.I ("dropped_output_deltas", !delta_error_count) ];
+          Ok (finalize_summary (extract_text response))
       | Error err -> Error err
-
-[@@@coverage off]
-(* === Inline tests === *)
-
-(* --- extract_text --- *)
-
-let%test "extract_text: empty content" =
-  let resp = { Types.id = "r1"; model = "m"; stop_reason = Types.EndTurn;
-               content = []; usage = None; telemetry = None } in
-  extract_text resp = ""
-
-let%test "extract_text: single Text block" =
-  let resp = { Types.id = "r1"; model = "m"; stop_reason = Types.EndTurn;
-               content = [Types.Text "hello"]; usage = None; telemetry = None } in
-  extract_text resp = "hello"
-
-let%test "extract_text: multiple Text blocks joined by newline" =
-  let resp = { Types.id = "r1"; model = "m"; stop_reason = Types.EndTurn;
-               content = [Types.Text "hello"; Types.Text "world"]; usage = None; telemetry = None } in
-  extract_text resp = "hello\nworld"
-
-let%test "extract_text: non-Text blocks filtered out" =
-  let resp = { Types.id = "r1"; model = "m"; stop_reason = Types.EndTurn;
-               content = [
-                 Types.Text "before";
-                 Types.ToolUse { id = "t1"; name = "fn"; input = `Null };
-                 Types.Text "after";
-               ]; usage = None; telemetry = None } in
-  extract_text resp = "before\nafter"
-
-let%test "extract_text: only non-Text blocks returns empty" =
-  let resp = { Types.id = "r1"; model = "m"; stop_reason = Types.EndTurn;
-               content = [
-                 Types.ToolUse { id = "t1"; name = "fn"; input = `Null };
-                 Types.Thinking { thinking_type = "thinking"; content = "hmm" };
-               ]; usage = None; telemetry = None } in
-  extract_text resp = ""
-
-(* --- make_event --- *)
-
-let dummy_session : Runtime.session = {
-  session_id = "s1";
-  goal = "test";
-  title = None;
-  tag = None;
-  permission_mode = None;
-  phase = Runtime.Running;
-  created_at = 0.0;
-  updated_at = 0.0;
-  provider = None;
-  model = None;
-  system_prompt = None;
-  max_turns = 10;
-  workdir = None;
-  planned_participants = [];
-  participants = [];
-  artifacts = [];
-  votes = [];
-  turn_count = 0;
-  last_seq = 5;
-  outcome = None;
-}
-
-let%test "make_event: seq is last_seq + 1" =
-  let event = make_event dummy_session
-    (Session_started { goal = "test"; participants = [] }) in
-  event.seq = 6
-
-let%test "make_event: ts is positive" =
-  let event = make_event dummy_session
-    (Session_started { goal = "test"; participants = [] }) in
-  event.ts > 0.0
-
-let%test "make_event: kind is preserved" =
-  let event = make_event dummy_session
-    (Turn_recorded { actor = Some "alice"; message = "hi" }) in
-  match event.kind with
-  | Turn_recorded { actor = Some "alice"; message = "hi" } -> true
-  | _ -> false

--- a/lib/runtime_server_worker.ml
+++ b/lib/runtime_server_worker.ml
@@ -4,7 +4,6 @@ open Runtime_server_resolve
 
 let ( let* ) = Result.bind
 let _log = Log.create ~module_name:"runtime_server_worker" ()
-let dropped_output_deltas_marker = "[runtime telemetry] dropped_output_deltas="
 
 let unsupported_test_provider provider =
   Error.Config
@@ -31,27 +30,6 @@ let make_event (session : session) kind =
 let with_store_lock state f =
   Eio.Mutex.use_rw ~protect:true state.store_mu f
 
-let artifact_attached_event (artifact : Runtime.artifact) =
-  Artifact_attached
-    {
-      artifact_id = artifact.artifact_id;
-      name = artifact.name;
-      kind = artifact.kind;
-      mime_type = artifact.mime_type;
-      path = Option.value ~default:"" artifact.path;
-      size_bytes = artifact.size_bytes;
-    }
-
-let base_evidence_file_specs store session_id =
-  [
-    ("session_json", Runtime_store.session_path store session_id);
-    ("events_jsonl", Runtime_store.events_path store session_id);
-    ("report_json", Runtime_store.report_json_path store session_id);
-    ("report_md", Runtime_store.report_md_path store session_id);
-    ("proof_json", Runtime_store.proof_json_path store session_id);
-    ("proof_md", Runtime_store.proof_md_path store session_id);
-  ]
-
 let persist_event_locked store state (session : session) kind =
   let event = make_event session kind in
   let* projected = Runtime_projection.apply_event session event in
@@ -71,7 +49,8 @@ let persist_artifact_events_locked store state session
     (fun acc artifact ->
       let* session = acc in
       let* session, _ =
-        persist_event_locked store state session (artifact_attached_event artifact)
+        persist_event_locked store state session
+          (Runtime_evidence.artifact_attached_event artifact)
       in
       Ok session)
     (Ok session) artifacts
@@ -112,7 +91,7 @@ let generate_report_and_proof store state session_id =
       in
       let evidence =
         Runtime_evidence.build_evidence_bundle ~session_id
-          (base_evidence_file_specs store session_id
+          (Runtime_evidence.base_evidence_file_specs store session_id
            @
            [
              ("telemetry_json", telemetry_json_path);
@@ -163,7 +142,7 @@ let generate_report_and_proof store state session_id =
       in
       let final_evidence =
         Runtime_evidence.build_evidence_bundle ~session_id
-          (base_evidence_file_specs store session_id
+          (Runtime_evidence.base_evidence_file_specs store session_id
            @
            [
              ("telemetry_json", telemetry_json_path);
@@ -224,8 +203,8 @@ let run_participant store state session_id
   let finalize_summary summary =
     if !delta_error_count = 0 then summary
     else
-      Printf.sprintf "%s\n\n%s%d" summary dropped_output_deltas_marker
-        !delta_error_count
+      Runtime_evidence.append_dropped_output_deltas_summary ~summary
+        ~dropped_output_deltas:!delta_error_count
   in
   match resolution.selected_provider with
   | "mock" | "echo" ->

--- a/test/dune
+++ b/test/dune
@@ -141,6 +141,18 @@
 
 (test
  (name test_context_intent)
+ (libraries agent_sdk alcotest yojson eio eio_main))
+
+(test
+ (name test_runtime_server_resolve)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_runtime_server_worker)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_runtime_evidence)
  (libraries agent_sdk alcotest yojson))
 
 (test

--- a/test/test_conformance.ml
+++ b/test/test_conformance.ml
@@ -1,5 +1,7 @@
 open Agent_sdk
 
+let () = Unix.putenv "OAS_ALLOW_TEST_PROVIDERS" "1"
+
 let runtime_path () =
   match Sys.getenv_opt "OAS_RUNTIME_PATH" with
   | Some value when String.trim value <> "" -> String.trim value

--- a/test/test_context_intent.ml
+++ b/test/test_context_intent.ml
@@ -117,6 +117,43 @@ let test_prompt_mentions_all_categories () =
       "coordination";
     ]
 
+let test_classify_hybrid_requires_explicit_fallback () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let provider =
+    {
+      Provider.provider =
+        Provider.OpenAICompat
+          {
+            base_url = "http://";
+            auth_header = None;
+            path = "/v1/chat/completions";
+            static_token = None;
+          };
+      model_id = "gpt-4.1";
+      api_key_env = "";
+    }
+  in
+  let fallback _query =
+    {
+      Context_intent.intent = Context_intent.Coordination;
+      depth = Context_intent.Light;
+      confidence = 0.37;
+      rationale = Some "explicit fallback";
+    }
+  in
+  match
+    Context_intent.classify_hybrid ~sw ~net:env#net ~provider
+      ~config:Types.default_config ~fallback "status?"
+  with
+  | Ok classified ->
+      check string "intent" "coordination"
+        (Context_intent.intent_to_string classified.intent);
+      check (float 0.0001) "confidence" 0.37 classified.confidence;
+      check (option string) "rationale" (Some "explicit fallback")
+        classified.rationale
+  | Error detail -> fail (Error.to_string detail)
+
 let () =
   run "Context_intent"
     [
@@ -138,5 +175,11 @@ let () =
           test_case "coordination generic" `Quick test_heuristic_coordination_generic;
           test_case "no reserved keywords" `Quick test_no_reserved_keywords_in_heuristic;
         ] );
-      ("prompt", [ test_case "mentions categories" `Quick test_prompt_mentions_all_categories ]);
+      ( "prompt",
+        [
+          test_case "mentions categories" `Quick
+            test_prompt_mentions_all_categories;
+          test_case "explicit fallback required" `Quick
+            test_classify_hybrid_requires_explicit_fallback;
+        ] );
     ]

--- a/test/test_coverage_hotspots_srt.ml
+++ b/test/test_coverage_hotspots_srt.ml
@@ -1,4 +1,6 @@
 open Agent_sdk
+
+let () = Unix.putenv "OAS_ALLOW_TEST_PROVIDERS" "1"
 open Alcotest
 
 let runtime_path () =

--- a/test/test_direct_evidence.ml
+++ b/test/test_direct_evidence.ml
@@ -177,6 +177,27 @@ let test_direct_evidence_materializes_bundle () =
        (fun (hook : Sessions.hook_summary) ->
          String.equal hook.hook_name "on_stop")
        bundle.hook_summary);
+  Alcotest.(check bool) "structured telemetry tracks tool catalog artifact" true
+    (List.exists
+       (fun (step : Sessions.structured_telemetry_step) ->
+         String.equal step.event_name "artifact_attached"
+         && step.artifact_name = Some "tool-catalog")
+       bundle.structured_telemetry.steps);
+  Alcotest.(check bool) "evidence includes telemetry_json" true
+    (List.exists
+       (fun (file : Sessions.evidence_file) ->
+         String.equal file.label "telemetry_json")
+       bundle.evidence.files);
+  Alcotest.(check bool) "evidence includes telemetry_md" true
+    (List.exists
+       (fun (file : Sessions.evidence_file) ->
+         String.equal file.label "telemetry_md")
+       bundle.evidence.files);
+  Alcotest.(check bool) "evidence includes tool_catalog_json" true
+    (List.exists
+       (fun (file : Sessions.evidence_file) ->
+         String.equal file.label "tool_catalog_json")
+       bundle.evidence.files);
   let report =
     unwrap (Direct_evidence.get_conformance ~agent ~raw_trace ~options:(direct_options root) ())
   in

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -96,6 +96,8 @@ let test_post_stream_invalid_url_returns_network_error () =
   | Error (Http_client.NetworkError { message }) ->
       Alcotest.(check bool) "mentions missing host" true
         (Util.contains_substring_ci ~haystack:message ~needle:"missing host")
+  | Error (Http_client.AcceptRejected _) ->
+      Alcotest.fail "expected invalid URL to fail before headers are accepted"
   | Error (Http_client.HttpError _) ->
       Alcotest.fail "expected network error for invalid URL"
   | Ok _ ->

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -86,6 +86,21 @@ let test_read_sse_done_marker () =
   Alcotest.(check int) "1 event (DONE)" 1 (List.length !events);
   Alcotest.(check string) "data is DONE" "[DONE]" (snd (List.hd !events))
 
+let test_post_stream_invalid_url_returns_network_error () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  match
+    Http_client.post_stream ~sw ~net:env#net ~url:"http://"
+      ~headers:[ ("Content-Type", "application/json") ] ~body:"{}"
+  with
+  | Error (Http_client.NetworkError { message }) ->
+      Alcotest.(check bool) "mentions missing host" true
+        (Util.contains_substring_ci ~haystack:message ~needle:"missing host")
+  | Error (Http_client.HttpError _) ->
+      Alcotest.fail "expected network error for invalid URL"
+  | Ok _ ->
+      Alcotest.fail "expected invalid URL to fail before opening a stream"
+
 let test_api_common_string_is_blank () =
   Alcotest.(check bool) "empty is blank" true (Api_common.string_is_blank "");
   Alcotest.(check bool) "spaces is blank" true (Api_common.string_is_blank "   ");
@@ -189,6 +204,8 @@ let () =
       Alcotest.test_case "basic events" `Quick test_read_sse_basic;
       Alcotest.test_case "empty lines" `Quick test_read_sse_empty_lines;
       Alcotest.test_case "DONE marker" `Quick test_read_sse_done_marker;
+      Alcotest.test_case "invalid url returns network error" `Quick
+        test_post_stream_invalid_url_returns_network_error;
     ]);
     ("api_common", [
       Alcotest.test_case "string_is_blank" `Quick test_api_common_string_is_blank;

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -263,6 +263,50 @@ let test_estimate_cost () =
     ~cache_read_input_tokens:200_000 () in
   Alcotest.(check bool) "cost > 0" true (cost > 0.0)
 
+let test_config_of_provider_config_localhost_boundary () =
+  let cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"test-model"
+      ~base_url:"http://localhostevil.com:8080"
+      ()
+  in
+  match Provider.config_of_provider_config cfg with
+  | { provider = Provider.OpenAICompat _; _ } -> ()
+  | { provider = Provider.Local _; _ } ->
+      Alcotest.fail "localhostevil.com must not be treated as local"
+  | _ ->
+      Alcotest.fail "unexpected provider kind"
+
+let test_config_of_provider_config_local_ollama_delegates_to_ssot () =
+  let cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Ollama
+      ~model_id:"test-model"
+      ~base_url:"http://localhost:11434"
+      ()
+  in
+  match Provider.config_of_provider_config cfg with
+  | { provider = Provider.Local { base_url }; _ } ->
+      Alcotest.(check string) "base_url" "http://localhost:11434" base_url
+  | _ ->
+      Alcotest.fail "expected localhost ollama config to resolve as local"
+
+let test_config_of_provider_config_uppercase_localhost_delegates_to_ssot () =
+  let cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"test-model"
+      ~base_url:"  HTTP://LOCALHOST:11434/v1  "
+      ()
+  in
+  match Provider.config_of_provider_config cfg with
+  | { provider = Provider.Local { base_url }; _ } ->
+      Alcotest.(check string) "base_url preserved" "  HTTP://LOCALHOST:11434/v1  "
+        base_url
+  | _ ->
+      Alcotest.fail "expected uppercase localhost config to resolve as local"
+
 let test_openai_compat_static_token () =
   let cfg : Provider.config = {
     provider = OpenAICompat {
@@ -334,6 +378,12 @@ let () =
       Alcotest.test_case "local free" `Quick test_pricing_local;
       Alcotest.test_case "unknown model" `Quick test_pricing_unknown;
       Alcotest.test_case "estimate cost" `Quick test_estimate_cost;
+      Alcotest.test_case "provider_config localhost boundary" `Quick
+        test_config_of_provider_config_localhost_boundary;
+      Alcotest.test_case "provider_config local ollama" `Quick
+        test_config_of_provider_config_local_ollama_delegates_to_ssot;
+      Alcotest.test_case "provider_config uppercase localhost" `Quick
+        test_config_of_provider_config_uppercase_localhost_delegates_to_ssot;
     ];
     "openai_compat", [
       Alcotest.test_case "static token" `Quick test_openai_compat_static_token;

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -307,6 +307,21 @@ let test_config_of_provider_config_uppercase_localhost_delegates_to_ssot () =
   | _ ->
       Alcotest.fail "expected uppercase localhost config to resolve as local"
 
+let test_config_of_provider_config_localhost_query_delegates_to_ssot () =
+  let cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"test-model"
+      ~base_url:"http://localhost?foo=bar"
+      ()
+  in
+  match Provider.config_of_provider_config cfg with
+  | { provider = Provider.Local { base_url }; _ } ->
+      Alcotest.(check string) "base_url preserved" "http://localhost?foo=bar"
+        base_url
+  | _ ->
+      Alcotest.fail "expected localhost query config to resolve as local"
+
 let test_openai_compat_static_token () =
   let cfg : Provider.config = {
     provider = OpenAICompat {
@@ -384,6 +399,8 @@ let () =
         test_config_of_provider_config_local_ollama_delegates_to_ssot;
       Alcotest.test_case "provider_config uppercase localhost" `Quick
         test_config_of_provider_config_uppercase_localhost_delegates_to_ssot;
+      Alcotest.test_case "provider_config localhost query" `Quick
+        test_config_of_provider_config_localhost_query_delegates_to_ssot;
     ];
     "openai_compat", [
       Alcotest.test_case "static token" `Quick test_openai_compat_static_token;

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -106,6 +106,28 @@ let test_custom_headers () =
     ~headers:[("Auth", "Bearer x"); ("X-Custom", "val")] () in
   check_int "2 custom headers" 2 (List.length cfg.headers)
 
+(* ── locality ────────────────────────────────────────── *)
+
+let test_is_local_loopback_ip () =
+  let cfg = Provider_config.make ~kind:OpenAI_compat
+    ~model_id:"m" ~base_url:"http://127.0.0.1:8085" () in
+  check_bool "loopback ip is local" true (Provider_config.is_local cfg)
+
+let test_is_local_localhost () =
+  let cfg = Provider_config.make ~kind:OpenAI_compat
+    ~model_id:"m" ~base_url:"http://localhost/v1" () in
+  check_bool "localhost is local" true (Provider_config.is_local cfg)
+
+let test_is_local_remote_false () =
+  let cfg = Provider_config.make ~kind:OpenAI_compat
+    ~model_id:"m" ~base_url:"https://api.example.com" () in
+  check_bool "remote is not local" false (Provider_config.is_local cfg)
+
+let test_is_local_host_boundary_false () =
+  let cfg = Provider_config.make ~kind:OpenAI_compat
+    ~model_id:"m" ~base_url:"http://localhostevil.com" () in
+  check_bool "hostname boundary respected" false (Provider_config.is_local cfg)
+
 (* ── Suite ────────────────────────────────────────────── *)
 
 let () =
@@ -125,5 +147,11 @@ let () =
     "explicit_values", [
       Alcotest.test_case "all options" `Quick test_make_with_all_options;
       Alcotest.test_case "custom headers" `Quick test_custom_headers;
+    ];
+    "locality", [
+      Alcotest.test_case "loopback ip" `Quick test_is_local_loopback_ip;
+      Alcotest.test_case "localhost" `Quick test_is_local_localhost;
+      Alcotest.test_case "remote false" `Quick test_is_local_remote_false;
+      Alcotest.test_case "host boundary false" `Quick test_is_local_host_boundary_false;
     ];
   ]

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -128,6 +128,11 @@ let test_is_local_host_boundary_false () =
     ~model_id:"m" ~base_url:"http://localhostevil.com" () in
   check_bool "hostname boundary respected" false (Provider_config.is_local cfg)
 
+let test_is_local_localhost_query_true () =
+  let cfg = Provider_config.make ~kind:OpenAI_compat
+    ~model_id:"m" ~base_url:"http://localhost?foo=bar" () in
+  check_bool "localhost query is local" true (Provider_config.is_local cfg)
+
 (* ── Suite ────────────────────────────────────────────── *)
 
 let () =
@@ -153,5 +158,7 @@ let () =
       Alcotest.test_case "localhost" `Quick test_is_local_localhost;
       Alcotest.test_case "remote false" `Quick test_is_local_remote_false;
       Alcotest.test_case "host boundary false" `Quick test_is_local_host_boundary_false;
+      Alcotest.test_case "localhost query true" `Quick
+        test_is_local_localhost_query_true;
     ];
   ]

--- a/test/test_runtime.ml
+++ b/test/test_runtime.ml
@@ -1,5 +1,7 @@
 open Agent_sdk
 
+let () = Unix.putenv "OAS_ALLOW_TEST_PROVIDERS" "1"
+
 let runtime_path () =
   match Sys.getenv_opt "OAS_RUNTIME_PATH" with
   | Some value when String.trim value <> "" -> String.trim value

--- a/test/test_runtime_evidence.ml
+++ b/test/test_runtime_evidence.ml
@@ -1,0 +1,114 @@
+open Agent_sdk
+
+let base_session : Runtime.session =
+  {
+    session_id = "session-1";
+    goal = "goal";
+    title = None;
+    tag = None;
+    permission_mode = None;
+    phase = Runtime.Completed;
+    created_at = 0.0;
+    updated_at = 3.0;
+    provider = Some "ollama";
+    model = Some "qwen";
+    system_prompt = None;
+    max_turns = 8;
+    workdir = None;
+    planned_participants = [ "worker" ];
+    participants = [];
+    artifacts = [];
+    votes = [];
+    turn_count = 1;
+    last_seq = 3;
+    outcome = Some "done";
+  }
+
+let completion_summary =
+  "final answer\n\n[runtime telemetry] dropped_output_deltas=2"
+
+let persistence_failure_detail =
+  "[runtime_persist_failure phase=agent_completed] failed to persist completion event: disk full"
+
+let telemetry_events : Runtime.event list =
+  [
+    {
+      seq = 1;
+      ts = 1.0;
+      kind =
+        Runtime.Agent_completed
+          {
+            participant_name = "worker";
+            summary = Some completion_summary;
+            provider = Some "ollama";
+            model = Some "qwen";
+            error = None;
+          };
+    };
+    {
+      seq = 2;
+      ts = 2.0;
+      kind =
+        Runtime.Agent_failed
+          {
+            participant_name = "worker";
+            summary = None;
+            provider = Some "ollama";
+            model = Some "qwen";
+            error = Some persistence_failure_detail;
+          };
+    };
+  ]
+
+let test_build_telemetry_report_surfaces_runtime_anomalies () =
+  let report = Runtime_evidence.build_telemetry_report base_session telemetry_events in
+  Alcotest.(check int) "dropped_output_deltas" 2 report.dropped_output_deltas;
+  Alcotest.(check int) "persistence_failure_count" 1
+    report.persistence_failure_count;
+  Alcotest.(check (list string))
+    "participants_with_dropped_output_deltas"
+    [ "worker" ] report.participants_with_dropped_output_deltas;
+  Alcotest.(check (list string))
+    "participants_with_persistence_failures"
+    [ "worker" ] report.participants_with_persistence_failures;
+  match report.steps with
+  | completed :: failed :: [] ->
+      Alcotest.(check (option int)) "completed dropped delta count"
+        (Some 2) completed.dropped_output_deltas;
+      Alcotest.(check (option string)) "completed persistence failure phase"
+        None completed.persistence_failure_phase;
+      Alcotest.(check (option int)) "failed dropped delta count"
+        None failed.dropped_output_deltas;
+      Alcotest.(check (option string)) "failed persistence failure phase"
+        (Some "agent_completed") failed.persistence_failure_phase
+  | _ -> Alcotest.fail "expected exactly two telemetry steps"
+
+let test_telemetry_report_json_includes_anomaly_fields () =
+  let report = Runtime_evidence.build_telemetry_report base_session telemetry_events in
+  let open Yojson.Safe.Util in
+  let json = Runtime_evidence.telemetry_report_to_json report in
+  Alcotest.(check int) "json dropped_output_deltas" 2
+    (json |> member "dropped_output_deltas" |> to_int);
+  Alcotest.(check int) "json persistence_failure_count" 1
+    (json |> member "persistence_failure_count" |> to_int);
+  let steps = json |> member "steps" |> to_list in
+  match steps with
+  | completed :: failed :: [] ->
+      Alcotest.(check int) "json step dropped_output_deltas" 2
+        (completed |> member "dropped_output_deltas" |> to_int);
+      Alcotest.(check string) "json step persistence_failure_phase"
+        "agent_completed"
+        (failed |> member "persistence_failure_phase" |> to_string)
+  | _ -> Alcotest.fail "expected exactly two telemetry steps"
+
+let () =
+  Alcotest.run "Runtime_evidence"
+    [
+      ( "telemetry",
+        [
+          Alcotest.test_case "surfaces runtime anomalies" `Quick
+            test_build_telemetry_report_surfaces_runtime_anomalies;
+          Alcotest.test_case "json includes anomaly fields" `Quick
+            test_telemetry_report_json_includes_anomaly_fields;
+        ] );
+    ]

--- a/test/test_runtime_server_resolve.ml
+++ b/test/test_runtime_server_resolve.ml
@@ -1,0 +1,353 @@
+open Agent_sdk
+
+let with_test_providers_enabled f =
+  let previous = Sys.getenv_opt "OAS_ALLOW_TEST_PROVIDERS" in
+  Unix.putenv "OAS_ALLOW_TEST_PROVIDERS" "1";
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some value -> Unix.putenv "OAS_ALLOW_TEST_PROVIDERS" value
+      | None -> Unix.putenv "OAS_ALLOW_TEST_PROVIDERS" "")
+    f
+
+let dummy_session : Runtime.session =
+  {
+    session_id = "test-sess";
+    goal = "test";
+    title = None;
+    tag = None;
+    permission_mode = None;
+    phase = Runtime.Running;
+    created_at = 0.0;
+    updated_at = 0.0;
+    provider = None;
+    model = None;
+    system_prompt = None;
+    max_turns = 10;
+    workdir = None;
+    planned_participants = [];
+    participants = [];
+    artifacts = [];
+    votes = [];
+    turn_count = 0;
+    last_seq = 0;
+    outcome = None;
+  }
+
+let dummy_spawn : Runtime.spawn_agent_request =
+  {
+    participant_name = "agent-1";
+    role = Some "execute";
+    prompt = "do something";
+    provider = None;
+    model = None;
+    system_prompt = None;
+    max_turns = None;
+  }
+
+let test_provider_runtime_name_none_cfg () =
+  Alcotest.(check string) "selected" "my-provider"
+    (Runtime_server_resolve.provider_runtime_name "my-provider" None)
+
+let test_provider_runtime_name_local () =
+  let cfg =
+    Some
+      {
+        Provider.provider =
+          Provider.Local { base_url = Llm_provider.Constants.Endpoints.default_url_localhost };
+        model_id = "test";
+        api_key_env = "K";
+      }
+  in
+  Alcotest.(check string) "local" "local"
+    (Runtime_server_resolve.provider_runtime_name "local" cfg)
+
+let test_provider_runtime_name_anthropic () =
+  let cfg =
+    Some
+      {
+        Provider.provider = Provider.Anthropic;
+        model_id = "claude-sonnet-4-6";
+        api_key_env = "K";
+      }
+  in
+  Alcotest.(check string) "anthropic" "anthropic"
+    (Runtime_server_resolve.provider_runtime_name "anthropic" cfg)
+
+let test_provider_runtime_name_openai_compat () =
+  let cfg =
+    Some
+      {
+        Provider.provider =
+          Provider.OpenAICompat
+            {
+              base_url = "https://api.openai.com";
+              auth_header = None;
+              path = "/v1/chat/completions";
+              static_token = None;
+            };
+        model_id = "gpt-4o";
+        api_key_env = "K";
+      }
+  in
+  Alcotest.(check string) "openai-compat" "openai-compat"
+    (Runtime_server_resolve.provider_runtime_name "openai" cfg)
+
+let test_provider_runtime_name_custom_registered () =
+  let cfg =
+    Some
+      {
+        Provider.provider = Provider.Custom_registered { name = "myvendor" };
+        model_id = "test";
+        api_key_env = "K";
+      }
+  in
+  Alcotest.(check string) "custom:myvendor" "custom:myvendor"
+    (Runtime_server_resolve.provider_runtime_name "custom" cfg)
+
+let test_resolve_provider_mock () =
+  with_test_providers_enabled (fun () ->
+    match Runtime_server_resolve.resolve_provider ~provider:"mock" () with
+    | Ok None -> ()
+    | _ -> Alcotest.fail "expected Ok None")
+
+let test_resolve_provider_echo () =
+  with_test_providers_enabled (fun () ->
+    match Runtime_server_resolve.resolve_provider ~provider:"echo" () with
+    | Ok None -> ()
+    | _ -> Alcotest.fail "expected Ok None")
+
+let test_resolve_provider_mock_rejected_by_default () =
+  match Runtime_server_resolve.resolve_provider ~provider:"mock" () with
+  | Error (Error.Config (Error.UnsupportedProvider _)) -> ()
+  | _ -> Alcotest.fail "expected test-only provider rejection"
+
+let test_resolve_provider_local () =
+  match Runtime_server_resolve.resolve_provider ~provider:"local" () with
+  | Ok (Some cfg) -> (
+      match cfg.Provider.provider with
+      | Provider.Local _ -> ()
+      | _ -> Alcotest.fail "expected local provider")
+  | _ -> Alcotest.fail "expected Ok (Some cfg)"
+
+let test_resolve_provider_local_qwen () =
+  match Runtime_server_resolve.resolve_provider ~provider:"local-qwen" () with
+  | Ok (Some cfg) -> (
+      match cfg.Provider.provider with
+      | Provider.Local _ -> ()
+      | _ -> Alcotest.fail "expected local provider")
+  | _ -> Alcotest.fail "expected Ok (Some cfg)"
+
+let test_resolve_provider_sonnet () =
+  match Runtime_server_resolve.resolve_provider ~provider:"sonnet" () with
+  | Ok (Some cfg) -> Alcotest.(check bool) "anthropic" true (cfg.Provider.provider = Provider.Anthropic)
+  | _ -> Alcotest.fail "expected Ok (Some cfg)"
+
+let test_resolve_provider_haiku () =
+  match Runtime_server_resolve.resolve_provider ~provider:"haiku" () with
+  | Ok (Some cfg) -> Alcotest.(check bool) "anthropic" true (cfg.Provider.provider = Provider.Anthropic)
+  | _ -> Alcotest.fail "expected Ok (Some cfg)"
+
+let test_resolve_provider_opus () =
+  match Runtime_server_resolve.resolve_provider ~provider:"opus" () with
+  | Ok (Some cfg) -> Alcotest.(check bool) "anthropic" true (cfg.Provider.provider = Provider.Anthropic)
+  | _ -> Alcotest.fail "expected Ok (Some cfg)"
+
+let test_resolve_provider_openrouter () =
+  match Runtime_server_resolve.resolve_provider ~provider:"openrouter" () with
+  | Ok (Some cfg) -> (
+      match cfg.Provider.provider with
+      | Provider.OpenAICompat _ -> ()
+      | _ -> Alcotest.fail "expected OpenAICompat")
+  | _ -> Alcotest.fail "expected Ok (Some cfg)"
+
+let test_resolve_provider_unknown () =
+  match Runtime_server_resolve.resolve_provider ~provider:"unknown-provider" () with
+  | Error (Error.Config (Error.UnsupportedProvider _)) -> ()
+  | _ -> Alcotest.fail "expected UnsupportedProvider"
+
+let test_resolve_provider_typoed () =
+  match Runtime_server_resolve.resolve_provider ~provider:"openriauter" () with
+  | Error (Error.Config (Error.UnsupportedProvider _)) -> ()
+  | _ -> Alcotest.fail "expected UnsupportedProvider"
+
+let test_resolve_provider_empty_uses_fallback () =
+  match Runtime_server_resolve.resolve_provider ~provider:"  " () with
+  | Ok (Some _) -> ()
+  | _ -> Alcotest.fail "expected fallback provider"
+
+let test_resolve_provider_model_override () =
+  match Runtime_server_resolve.resolve_provider ~provider:"sonnet" ~model:"my-custom-model" () with
+  | Ok (Some cfg) ->
+      Alcotest.(check string) "model override" "my-custom-model" cfg.Provider.model_id
+  | _ -> Alcotest.fail "expected Ok (Some cfg)"
+
+let test_resolve_provider_empty_model_uses_default () =
+  match Runtime_server_resolve.resolve_provider ~provider:"sonnet" ~model:"  " () with
+  | Ok (Some cfg) ->
+      Alcotest.(check bool) "non-empty" true (String.length cfg.Provider.model_id > 0)
+  | _ -> Alcotest.fail "expected Ok (Some cfg)"
+
+let test_resolve_provider_trimmed_lowercased () =
+  with_test_providers_enabled (fun () ->
+    match Runtime_server_resolve.resolve_provider ~provider:"  MOCK  " () with
+    | Ok None -> ()
+    | _ -> Alcotest.fail "expected mock alias to resolve to None")
+
+let test_resolve_execution_mock_provider () =
+  with_test_providers_enabled (fun () ->
+    let detail = { dummy_spawn with provider = Some "mock" } in
+    match Runtime_server_resolve.resolve_execution dummy_session detail with
+    | Ok res ->
+        Alcotest.(check string) "selected" "mock" res.selected_provider;
+        Alcotest.(check bool) "no provider cfg" true (Option.is_none res.provider_cfg);
+        Alcotest.(check (option string)) "resolved provider" (Some "mock") res.resolved_provider
+    | Error _ -> Alcotest.fail "expected Ok")
+
+let test_resolve_execution_requested_model_from_detail () =
+  let detail = { dummy_spawn with model = Some "my-model" } in
+  match Runtime_server_resolve.resolve_execution dummy_session detail with
+  | Ok res -> Alcotest.(check (option string)) "requested model" (Some "my-model") res.requested_model
+  | Error _ -> Alcotest.fail "expected Ok"
+
+let test_resolve_execution_requested_model_none_when_detail_empty () =
+  let detail = { dummy_spawn with model = Some "  " } in
+  match Runtime_server_resolve.resolve_execution dummy_session detail with
+  | Ok res -> Alcotest.(check bool) "requested model none" true (Option.is_none res.requested_model)
+  | Error _ -> Alcotest.fail "expected Ok"
+
+let test_resolve_execution_non_mock_has_provider_cfg () =
+  let detail = { dummy_spawn with provider = Some "sonnet" } in
+  match Runtime_server_resolve.resolve_execution dummy_session detail with
+  | Ok res ->
+      Alcotest.(check bool) "has provider cfg" true (Option.is_some res.provider_cfg);
+      Alcotest.(check (option string)) "resolved provider" (Some "anthropic")
+        res.resolved_provider
+  | Error _ -> Alcotest.fail "expected Ok"
+
+let test_resolve_execution_unknown_provider_returns_error () =
+  let detail = { dummy_spawn with provider = Some "bogus-provider" } in
+  match Runtime_server_resolve.resolve_execution dummy_session detail with
+  | Error (Error.Config (Error.UnsupportedProvider _)) -> ()
+  | _ -> Alcotest.fail "expected UnsupportedProvider"
+
+let test_resolve_execution_mock_resolved_model_uses_session_model () =
+  with_test_providers_enabled (fun () ->
+    let session = { dummy_session with model = Some "sess-model" } in
+    let detail = { dummy_spawn with provider = Some "mock" } in
+    match Runtime_server_resolve.resolve_execution session detail with
+    | Ok res -> Alcotest.(check (option string)) "session model" (Some "sess-model") res.resolved_model
+    | Error _ -> Alcotest.fail "expected Ok")
+
+let test_resolve_execution_mock_requested_model_takes_priority () =
+  with_test_providers_enabled (fun () ->
+    let session = { dummy_session with model = Some "sess-model" } in
+    let detail = { dummy_spawn with provider = Some "mock"; model = Some "req-model" } in
+    match Runtime_server_resolve.resolve_execution session detail with
+    | Ok res -> Alcotest.(check (option string)) "requested model" (Some "req-model") res.resolved_model
+    | Error _ -> Alcotest.fail "expected Ok")
+
+let test_resolve_execution_echo_provider () =
+  with_test_providers_enabled (fun () ->
+    let detail = { dummy_spawn with provider = Some "echo" } in
+    match Runtime_server_resolve.resolve_execution dummy_session detail with
+    | Ok res ->
+        Alcotest.(check string) "selected" "echo" res.selected_provider;
+        Alcotest.(check bool) "no provider cfg" true (Option.is_none res.provider_cfg)
+    | Error _ -> Alcotest.fail "expected Ok")
+
+let test_resolve_execution_detail_priority () =
+  with_test_providers_enabled (fun () ->
+    let session = { dummy_session with provider = Some "sonnet" } in
+    let detail = { dummy_spawn with provider = Some "mock" } in
+    match Runtime_server_resolve.resolve_execution session detail with
+    | Ok res -> Alcotest.(check string) "priority" "mock" res.selected_provider
+    | Error _ -> Alcotest.fail "expected Ok")
+
+let test_resolve_execution_session_provider () =
+  let session = { dummy_session with provider = Some "haiku" } in
+  match Runtime_server_resolve.resolve_execution session dummy_spawn with
+  | Ok res -> Alcotest.(check string) "session provider" "haiku" res.selected_provider
+  | Error _ -> Alcotest.fail "expected Ok"
+
+let test_resolve_execution_fallback () =
+  match Runtime_server_resolve.resolve_execution dummy_session dummy_spawn with
+  | Ok res ->
+      Alcotest.(check string) "fallback" Defaults.fallback_provider res.selected_provider
+  | Error _ -> Alcotest.fail "expected Ok"
+
+let () =
+  Alcotest.run "Runtime_server_resolve"
+    [
+      ( "provider_runtime_name",
+        [
+          Alcotest.test_case "None cfg returns selected" `Quick
+            test_provider_runtime_name_none_cfg;
+          Alcotest.test_case "Local provider" `Quick
+            test_provider_runtime_name_local;
+          Alcotest.test_case "Anthropic provider" `Quick
+            test_provider_runtime_name_anthropic;
+          Alcotest.test_case "OpenAICompat provider" `Quick
+            test_provider_runtime_name_openai_compat;
+          Alcotest.test_case "Custom_registered provider" `Quick
+            test_provider_runtime_name_custom_registered;
+        ] );
+      ( "resolve_provider",
+        [
+          Alcotest.test_case "mock returns Ok None" `Quick
+            test_resolve_provider_mock;
+          Alcotest.test_case "echo returns Ok None" `Quick
+            test_resolve_provider_echo;
+          Alcotest.test_case "mock rejected by default" `Quick
+            test_resolve_provider_mock_rejected_by_default;
+          Alcotest.test_case "local returns Local provider" `Quick
+            test_resolve_provider_local;
+          Alcotest.test_case "local-qwen returns Local provider" `Quick
+            test_resolve_provider_local_qwen;
+          Alcotest.test_case "sonnet returns Anthropic" `Quick
+            test_resolve_provider_sonnet;
+          Alcotest.test_case "haiku returns Anthropic" `Quick
+            test_resolve_provider_haiku;
+          Alcotest.test_case "opus returns Anthropic" `Quick
+            test_resolve_provider_opus;
+          Alcotest.test_case "openrouter returns OpenAICompat" `Quick
+            test_resolve_provider_openrouter;
+          Alcotest.test_case "unknown returns UnsupportedProvider error" `Quick
+            test_resolve_provider_unknown;
+          Alcotest.test_case "typoed provider returns error" `Quick
+            test_resolve_provider_typoed;
+          Alcotest.test_case "empty provider uses fallback" `Quick
+            test_resolve_provider_empty_uses_fallback;
+          Alcotest.test_case "model override applied" `Quick
+            test_resolve_provider_model_override;
+          Alcotest.test_case "empty model uses default" `Quick
+            test_resolve_provider_empty_model_uses_default;
+          Alcotest.test_case "trimmed and lowercased" `Quick
+            test_resolve_provider_trimmed_lowercased;
+        ] );
+      ( "resolve_execution",
+        [
+          Alcotest.test_case "mock provider has no provider_cfg" `Quick
+            test_resolve_execution_mock_provider;
+          Alcotest.test_case "requested_model from detail" `Quick
+            test_resolve_execution_requested_model_from_detail;
+          Alcotest.test_case "requested_model None when detail empty" `Quick
+            test_resolve_execution_requested_model_none_when_detail_empty;
+          Alcotest.test_case "non-mock has provider_cfg" `Quick
+            test_resolve_execution_non_mock_has_provider_cfg;
+          Alcotest.test_case "unknown provider returns error" `Quick
+            test_resolve_execution_unknown_provider_returns_error;
+          Alcotest.test_case "mock resolved_model uses session model" `Quick
+            test_resolve_execution_mock_resolved_model_uses_session_model;
+          Alcotest.test_case "mock requested_model takes priority" `Quick
+            test_resolve_execution_mock_requested_model_takes_priority;
+          Alcotest.test_case "echo provider has no provider_cfg" `Quick
+            test_resolve_execution_echo_provider;
+          Alcotest.test_case "detail provider takes priority over session" `Quick
+            test_resolve_execution_detail_priority;
+          Alcotest.test_case "session provider used when detail is None" `Quick
+            test_resolve_execution_session_provider;
+          Alcotest.test_case "fallback when both None" `Quick
+            test_resolve_execution_fallback;
+        ] );
+    ]

--- a/test/test_runtime_server_worker.ml
+++ b/test/test_runtime_server_worker.ml
@@ -1,0 +1,148 @@
+open Agent_sdk
+
+let dummy_session : Runtime.session =
+  {
+    session_id = "s1";
+    goal = "test";
+    title = None;
+    tag = None;
+    permission_mode = None;
+    phase = Runtime.Running;
+    created_at = 0.0;
+    updated_at = 0.0;
+    provider = None;
+    model = None;
+    system_prompt = None;
+    max_turns = 10;
+    workdir = None;
+    planned_participants = [];
+    participants = [];
+    artifacts = [];
+    votes = [];
+    turn_count = 0;
+    last_seq = 5;
+    outcome = None;
+  }
+
+let test_extract_text_empty_content () =
+  let resp =
+    {
+      Types.id = "r1";
+      model = "m";
+      stop_reason = Types.EndTurn;
+      content = [];
+      usage = None;
+      telemetry = None;
+    }
+  in
+  Alcotest.(check string) "empty" "" (Runtime_server_worker.extract_text resp)
+
+let test_extract_text_single_text_block () =
+  let resp =
+    {
+      Types.id = "r1";
+      model = "m";
+      stop_reason = Types.EndTurn;
+      content = [ Types.Text "hello" ];
+      usage = None;
+      telemetry = None;
+    }
+  in
+  Alcotest.(check string) "single" "hello"
+    (Runtime_server_worker.extract_text resp)
+
+let test_extract_text_multiple_text_blocks () =
+  let resp =
+    {
+      Types.id = "r1";
+      model = "m";
+      stop_reason = Types.EndTurn;
+      content = [ Types.Text "hello"; Types.Text "world" ];
+      usage = None;
+      telemetry = None;
+    }
+  in
+  Alcotest.(check string) "joined" "hello\nworld"
+    (Runtime_server_worker.extract_text resp)
+
+let test_extract_text_filters_non_text_blocks () =
+  let resp =
+    {
+      Types.id = "r1";
+      model = "m";
+      stop_reason = Types.EndTurn;
+      content =
+        [
+          Types.Text "before";
+          Types.ToolUse { id = "t1"; name = "fn"; input = `Null };
+          Types.Text "after";
+        ];
+      usage = None;
+      telemetry = None;
+    }
+  in
+  Alcotest.(check string) "filtered" "before\nafter"
+    (Runtime_server_worker.extract_text resp)
+
+let test_extract_text_only_non_text_blocks () =
+  let resp =
+    {
+      Types.id = "r1";
+      model = "m";
+      stop_reason = Types.EndTurn;
+      content =
+        [
+          Types.ToolUse { id = "t1"; name = "fn"; input = `Null };
+          Types.Thinking { thinking_type = "thinking"; content = "hmm" };
+        ];
+      usage = None;
+      telemetry = None;
+    }
+  in
+  Alcotest.(check string) "empty" "" (Runtime_server_worker.extract_text resp)
+
+let test_make_event_seq_is_incremented () =
+  let event =
+    Runtime_server_worker.make_event dummy_session
+      (Runtime.Session_started { goal = "test"; participants = [] })
+  in
+  Alcotest.(check int) "seq" 6 event.seq
+
+let test_make_event_ts_is_positive () =
+  let event =
+    Runtime_server_worker.make_event dummy_session
+      (Runtime.Session_started { goal = "test"; participants = [] })
+  in
+  Alcotest.(check bool) "positive timestamp" true (event.ts > 0.0)
+
+let test_make_event_kind_is_preserved () =
+  let kind = Runtime.Turn_recorded { actor = Some "alice"; message = "hi" } in
+  let event = Runtime_server_worker.make_event dummy_session kind in
+  Alcotest.(check bool) "kind preserved" true (event.kind = kind)
+
+let () =
+  Alcotest.run "Runtime_server_worker"
+    [
+      ( "extract_text",
+        [
+          Alcotest.test_case "empty content" `Quick
+            test_extract_text_empty_content;
+          Alcotest.test_case "single Text block" `Quick
+            test_extract_text_single_text_block;
+          Alcotest.test_case "multiple Text blocks joined by newline" `Quick
+            test_extract_text_multiple_text_blocks;
+          Alcotest.test_case "non-Text blocks filtered out" `Quick
+            test_extract_text_filters_non_text_blocks;
+          Alcotest.test_case "only non-Text blocks returns empty" `Quick
+            test_extract_text_only_non_text_blocks;
+        ] );
+      ( "make_event",
+        [
+          Alcotest.test_case "seq is last_seq + 1" `Quick
+            test_make_event_seq_is_incremented;
+          Alcotest.test_case "ts is positive" `Quick
+            test_make_event_ts_is_positive;
+          Alcotest.test_case "kind is preserved" `Quick
+            test_make_event_kind_is_preserved;
+        ] );
+    ]

--- a/test/test_runtime_worker_integration.ml
+++ b/test/test_runtime_worker_integration.ml
@@ -18,6 +18,8 @@
 
 open Agent_sdk
 
+let () = Unix.putenv "OAS_ALLOW_TEST_PROVIDERS" "1"
+
 (* ── Temp dir helper ───────────────────────────────────────────── *)
 
 let with_temp_dir f =
@@ -464,7 +466,39 @@ let test_generate_report_and_proof_basic () =
       Alcotest.(check bool) "session has artifacts"
         true (List.length final_session.artifacts > 0);
       Alcotest.(check bool) "at least 3 artifacts"
-        true (List.length final_session.artifacts >= 3)
+        true (List.length final_session.artifacts >= 3);
+      let structured =
+        match Sessions.get_telemetry_structured ~session_root:dir ~session_id () with
+        | Ok telemetry -> telemetry
+        | Error e ->
+          Alcotest.fail
+            (Printf.sprintf "structured telemetry failed: %s"
+               (Error.to_string e))
+      in
+      Alcotest.(check bool) "telemetry tracks telemetry artifact attachment"
+        true
+        (List.exists
+           (fun (step : Sessions.structured_telemetry_step) ->
+             String.equal step.event_name "artifact_attached"
+             && step.artifact_name = Some "runtime-telemetry-json")
+           structured.steps);
+      let evidence =
+        match Sessions.get_evidence ~session_root:dir ~session_id () with
+        | Ok bundle -> bundle
+        | Error e ->
+          Alcotest.fail
+            (Printf.sprintf "evidence read failed: %s" (Error.to_string e))
+      in
+      Alcotest.(check bool) "evidence includes telemetry_json" true
+        (List.exists
+           (fun (file : Sessions.evidence_file) ->
+             String.equal file.label "telemetry_json")
+           evidence.files);
+      Alcotest.(check bool) "evidence includes telemetry_md" true
+        (List.exists
+           (fun (file : Sessions.evidence_file) ->
+             String.equal file.label "telemetry_md")
+           evidence.files)
     | Error e ->
       Alcotest.fail
         (Printf.sprintf "generate_report_and_proof failed: %s"

--- a/test/test_transport_integration.ml
+++ b/test/test_transport_integration.ml
@@ -7,6 +7,8 @@
     start_session, apply_command, status, events, finalize, close. *)
 
 open Agent_sdk
+
+let () = Unix.putenv "OAS_ALLOW_TEST_PROVIDERS" "1"
 open Alcotest
 
 let runtime_path () =


### PR DESCRIPTION
## Summary
- harden runtime error boundaries by removing hidden fallbacks, tightening provider locality SSOT usage, and surfacing previously silent runtime/storage failures
- make runtime and direct evidence generation self-consistent by rewriting telemetry/evidence artifacts from the final persisted event set
- expand regression coverage around runtime server resolution/worker behavior, runtime evidence anomalies, provider locality, HTTP client parsing, and explicit fallback handling

## Why
The runtime path had several health issues at once: silent failure edges, heuristic or duplicated boundary logic, and evidence artifacts that could disagree with the final persisted session state. This made debugging and conformance evidence less trustworthy than it should be.

## Impact
- runtime evidence artifacts now reflect the final persisted event stream instead of a stale pre-attachment snapshot
- local-provider classification stays aligned with `Provider_config.is_local`
- runtime/test-only provider gating, memory backend failures, discovery probe failures, and HTTP URI parsing are exercised by explicit regression tests
- hidden heuristic fallback in hybrid context classification is removed in favor of explicit caller fallback

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/refactor/oas-health-pass1 --display short @runtest`
- `./_build/default/test/test_runtime_server_worker.exe`
- `./_build/default/test/test_runtime_worker_integration.exe`
- `./_build/default/test/test_direct_evidence.exe`
- `./_build/default/test/test_runtime.exe`
- `./_build/default/test/test_provider.exe`

## Follow-up
- the next slice should move runtime anomaly reporting such as dropped output deltas from string-encoded summaries into typed runtime payloads