### PR TITLE
[codex] restrict runtime anomaly marker parsing

### DIFF
--- a/lib/runtime_evidence.ml
+++ b/lib/runtime_evidence.ml
@@ -145,6 +145,13 @@ let participant_and_detail_of_event = function
   | Session_completed detail -> (None, detail.outcome)
   | Session_failed detail -> (None, detail.outcome)
 
+let anomaly_fields_of_event = function
+  | Agent_completed detail ->
+      (dropped_output_deltas_of_text detail.summary, None)
+  | Agent_failed detail ->
+      (None, persistence_failure_phase_of_text detail.error)
+  | _ -> (None, None)
+
 let event_name_of_kind = function
   | Session_started _ -> "session_started"
   | Session_settings_updated _ -> "session_settings_updated"
@@ -234,8 +241,9 @@ let build_telemetry_report (session : session) (events : event list) =
             checkpoint_label, outcome =
           structured_fields_of_event event.kind
         in
-        let dropped_output_deltas = dropped_output_deltas_of_text detail in
-        let persistence_failure_phase = persistence_failure_phase_of_text detail in
+        let dropped_output_deltas, persistence_failure_phase =
+          anomaly_fields_of_event event.kind
+        in
         {
           seq = event.seq;
           ts = event.ts;

--- a/test/test_runtime_evidence.ml
+++ b/test/test_runtime_evidence.ml
@@ -60,6 +60,32 @@ let telemetry_events : Runtime.event list =
     };
   ]
 
+let false_positive_events : Runtime.event list =
+  [
+    {
+      seq = 1;
+      ts = 1.0;
+      kind =
+        Runtime.Turn_recorded
+          {
+            actor = Some "user";
+            message =
+              "please explain [runtime telemetry] dropped_output_deltas=7";
+          };
+    };
+    {
+      seq = 2;
+      ts = 2.0;
+      kind =
+        Runtime.Agent_output_delta
+          {
+            participant_name = "worker";
+            delta =
+              "[runtime_persist_failure phase=agent_completed] echoed user text";
+          };
+    };
+  ]
+
 let test_build_telemetry_report_surfaces_runtime_anomalies () =
   let report = Runtime_evidence.build_telemetry_report base_session telemetry_events in
   Alcotest.(check int) "dropped_output_deltas" 2 report.dropped_output_deltas;
@@ -101,6 +127,23 @@ let test_telemetry_report_json_includes_anomaly_fields () =
         (failed |> member "persistence_failure_phase" |> to_string)
   | _ -> Alcotest.fail "expected exactly two telemetry steps"
 
+let test_build_telemetry_report_ignores_non_runtime_marker_text () =
+  let report =
+    Runtime_evidence.build_telemetry_report base_session false_positive_events
+  in
+  Alcotest.(check int) "report dropped_output_deltas" 0
+    report.dropped_output_deltas;
+  Alcotest.(check int) "report persistence_failure_count" 0
+    report.persistence_failure_count;
+  match report.steps with
+  | turn_recorded :: output_delta :: [] ->
+      Alcotest.(check (option int)) "turn_recorded dropped delta count" None
+        turn_recorded.dropped_output_deltas;
+      Alcotest.(check (option string))
+        "output_delta persistence failure phase" None
+        output_delta.persistence_failure_phase
+  | _ -> Alcotest.fail "expected exactly two false-positive guard steps"
+
 let () =
   Alcotest.run "Runtime_evidence"
     [
@@ -110,5 +153,7 @@ let () =
             test_build_telemetry_report_surfaces_runtime_anomalies;
           Alcotest.test_case "json includes anomaly fields" `Quick
             test_telemetry_report_json_includes_anomaly_fields;
+          Alcotest.test_case "ignores non-runtime marker text" `Quick
+            test_build_telemetry_report_ignores_non_runtime_marker_text;
         ] );
     ]


### PR DESCRIPTION
## Summary
- restrict telemetry anomaly parsing to the event fields where the runtime itself injects markers
- stop scanning generic event detail text for anomaly markers
- add a regression test proving user/model-controlled text does not create false anomaly reports

## Why
PR #770 left one unresolved review thread: `Runtime_evidence.build_telemetry_report` could misclassify marker-like text inside generic event details as runtime anomalies. This follow-up narrows the parsing boundary to the actual runtime-owned fields.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix/runtime-evidence-marker-boundary @all`
- `./_build/default/test/test_runtime_evidence.exe`
- `env OCAMLPARAM='_,warn-error=+a' dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix/runtime-evidence-marker-boundary @install --force`