### PR TITLE
refactor: simplify review — 6 fixes from 3-agent code review

### DIFF
--- a/lib/correction_pipeline.ml
+++ b/lib/correction_pipeline.ml
@@ -53,8 +53,14 @@ let coercion_stage = {
 
 (* ── Stage 2: Default Injection ─────────────────────────── *)
 
-(** Fills missing optional fields with type-appropriate defaults.
-    Only applies to optional (not required) parameters that are absent. *)
+let default_for_type = function
+  | Types.String -> `String ""
+  | Types.Integer -> `Int 0
+  | Types.Number -> `Float 0.0
+  | Types.Boolean -> `Bool false
+  | Types.Array -> `List []
+  | Types.Object -> `Assoc []
+
 let default_injection_apply (schema : Types.tool_schema) (input : Yojson.Safe.t) : Yojson.Safe.t =
   match input with
   | `Assoc fields ->
@@ -63,31 +69,13 @@ let default_injection_apply (schema : Types.tool_schema) (input : Yojson.Safe.t)
       && not (List.mem_assoc p.name fields)
     ) schema.parameters in
     let defaults = List.map (fun (p : Types.tool_param) ->
-      let default_value = match p.param_type with
-        | Types.String -> `String ""
-        | Types.Integer -> `Int 0
-        | Types.Number -> `Float 0.0
-        | Types.Boolean -> `Bool false
-        | Types.Array -> `List []
-        | Types.Object -> `Assoc []
-      in
-      (p.name, default_value)
+      (p.name, default_for_type p.param_type)
     ) missing_optionals in
     `Assoc (fields @ defaults)
   | `Null ->
-    (* Treat null as empty object with defaults *)
     let defaults = List.filter_map (fun (p : Types.tool_param) ->
       if p.required then None
-      else
-        let default_value = match p.param_type with
-          | Types.String -> `String ""
-          | Types.Integer -> `Int 0
-          | Types.Number -> `Float 0.0
-          | Types.Boolean -> `Bool false
-          | Types.Array -> `List []
-          | Types.Object -> `Assoc []
-        in
-        Some (p.name, default_value)
+      else Some (p.name, default_for_type p.param_type)
     ) schema.parameters in
     `Assoc defaults
   | other -> other
@@ -103,14 +91,17 @@ let default_injection_stage = {
 let format_normalization_apply (_schema : Types.tool_schema) (input : Yojson.Safe.t) : Yojson.Safe.t =
   match input with
   | `Assoc fields ->
+    let changed = ref false in
     let fields' = List.map (fun (k, v) ->
       match v with
       | `String s ->
         let trimmed = String.trim s in
-        (k, `String trimmed)
-      | other -> (k, other)
+        if not (String.equal trimmed s) then
+          (changed := true; (k, `String trimmed))
+        else (k, v)
+      | _ -> (k, v)
     ) fields in
-    `Assoc fields'
+    if !changed then `Assoc fields' else input
   | other -> other
 
 let format_normalization_stage = {

--- a/lib/tool_middleware.ml
+++ b/lib/tool_middleware.ml
@@ -64,20 +64,21 @@ let extract_tool_args ~tool_name (content : Types.content_block list) =
 let heal_tool_call ~tool_name ~schema ~tool_use_id ~args
     ~prior_messages ~llm ?(max_retries = 3) ?on_retry () =
   let rec loop attempt current_args current_id messages =
-    (* Run deterministic correction pipeline on EVERY attempt (idempotent).
-       This catches LLM retries that are still det-fixable. *)
+    (* Correction_pipeline.run validates internally — Fixed means already valid.
+       Only fall through to validate_and_coerce on Still_invalid. *)
     let det_result = Correction_pipeline.run ~schema current_args in
-    let effective_args = match det_result with
-      | Correction_pipeline.Fixed { corrected; _ } -> corrected
-      | Correction_pipeline.Still_invalid _ -> current_args
-    in
-    match validate_and_coerce ~tool_name ~schema effective_args with
+    match det_result with
+    | Correction_pipeline.Fixed { corrected; corrections } ->
+      Ok { value = corrected; attempts = attempt + 1;
+           healed = attempt > 0 || corrections <> [] }
+    | Correction_pipeline.Still_invalid { errors = _; attempted = _ } ->
+    (match validate_and_coerce ~tool_name ~schema current_args with
     | Pass ->
-      Ok { value = effective_args; attempts = attempt + 1;
-           healed = attempt > 0 || not (Yojson.Safe.equal effective_args current_args) }
+      Ok { value = current_args; attempts = attempt + 1;
+           healed = attempt > 0 }
     | Proceed coerced ->
       Ok { value = coerced; attempts = attempt + 1;
-           healed = attempt > 0 || not (Yojson.Safe.equal coerced current_args) }
+           healed = true }
     | Reject { message; _ } ->
       if attempt >= max_retries then
         Error (Exhausted {
@@ -126,7 +127,7 @@ let heal_tool_call ~tool_name ~schema ~tool_use_id ~args
             loop (attempt + 1) new_args new_id
               (retry_messages @ [assistant_msg])
         end
-      end
+      end)
   in
   let initial_assistant : Types.message =
     { role = Assistant;

--- a/lib/tool_schema_gen.mli
+++ b/lib/tool_schema_gen.mli
@@ -15,11 +15,11 @@
       (* parse returns: (string * string option, string) result *)
     ]}
 
-    Each field type is mapped to a specific OCaml type:
-    - String -> string (required) or string option (optional)
-    - Integer -> int (required) or int option (optional)
-    - Number -> float (required) or float option (optional)
-    - Boolean -> bool (required) or bool option (optional)
+    Each field type maps to a single OCaml type with zero-default for optional:
+    - String -> string (optional: [""])
+    - Integer -> int (optional: [0])
+    - Number -> float (optional: [0.0])
+    - Boolean -> bool (optional: [false])
 
     @stability Experimental
     @since 0.120.0 *)

--- a/lib/typed_tool.ml
+++ b/lib/typed_tool.ml
@@ -18,21 +18,20 @@ type ('input, 'output) t = {
 
 (* ── Construction ───────────────────────────────────────── *)
 
+let check_descriptor = function
+  | None -> ()
+  | Some d ->
+    match Tool.validate_descriptor d with
+    | Ok () -> ()
+    | Error msg -> invalid_arg ("Typed_tool: " ^ msg)
+
 let create ~name ~description ~params ~parse ~handler ~encode ?descriptor () =
-  (match descriptor with
-   | None -> ()
-   | Some d -> match Tool.validate_descriptor d with
-     | Ok () -> ()
-     | Error msg -> invalid_arg ("Typed_tool.create: " ^ msg));
+  check_descriptor descriptor;
   let schema : Types.tool_schema = { name; description; parameters = params } in
   { schema; descriptor; parse; handler = Simple handler; encode }
 
 let create_with_context ~name ~description ~params ~parse ~handler ~encode ?descriptor () =
-  (match descriptor with
-   | None -> ()
-   | Some d -> match Tool.validate_descriptor d with
-     | Ok () -> ()
-     | Error msg -> invalid_arg ("Typed_tool.create: " ^ msg));
+  check_descriptor descriptor;
   let schema : Types.tool_schema = { name; description; parameters = params } in
   { schema; descriptor; parse; handler = WithContext handler; encode }
 

--- a/lib/typed_tool_safe.ml
+++ b/lib/typed_tool_safe.ml
@@ -7,18 +7,18 @@ type read_only
 type write
 type destructive
 
-(* The phantom parameter is erased at runtime.
-   The .mli hides the constructor, so callers cannot forge permissions. *)
+type perm_label = Perm_read_only | Perm_write | Perm_destructive
+
 type ('perm, 'input, 'output) t = {
   tool : ('input, 'output) Typed_tool.t;
-  perm_name : string;
+  perm : perm_label;
 }
 
 (* ── Construction ───────────────────────────────────────── *)
 
-let read_only tool = { tool; perm_name = "read_only" }
-let write tool = { tool; perm_name = "write" }
-let destructive tool = { tool; perm_name = "destructive" }
+let read_only tool = { tool; perm = Perm_read_only }
+let write tool = { tool; perm = Perm_write }
+let destructive tool = { tool; perm = Perm_destructive }
 
 (* ── Permission-gated execution ─────────────────────────── *)
 
@@ -48,4 +48,7 @@ let to_untyped safe_tool = Typed_tool.to_untyped safe_tool.tool
 (* ── Introspection ──────────────────────────────────────── *)
 
 let name safe_tool = Typed_tool.name safe_tool.tool
-let permission_name safe_tool = safe_tool.perm_name
+let permission_name safe_tool = match safe_tool.perm with
+  | Perm_read_only -> "read_only"
+  | Perm_write -> "write"
+  | Perm_destructive -> "destructive"


### PR DESCRIPTION
## Summary
3-agent code review (reuse/quality/efficiency)에서 발견된 6개 이슈 수정.

1. `heal_tool_call`: `Fixed` 결과 후 `validate_and_coerce` 중복 제거 (이미 검증된 데이터)
2. `tool_schema_gen.mli`: optional 필드 docs 수정 (option type → zero-default)
3. `typed_tool.ml`: descriptor 검증 copy-paste → `check_descriptor` helper
4. `typed_tool_safe.ml`: `perm_name: string` → `perm: perm_label` ADT
5. `correction_pipeline.ml`: `default_for_type` helper 추출 (2곳 중복)
6. `correction_pipeline.ml`: `format_normalization` unchanged 시 할당 skip

## Test plan
- [x] test_typed_tool — 16/16
- [x] test_correction_pipeline — 12/12
- [x] test_tool_middleware — 20/20
- [x] test_typed_tool_safe — 11/11
- [x] test_tool_schema_gen — 10/10

Generated with [Claude Code](https://claude.com/claude-code)
