### PR TITLE
fix(cascade): fast failover with retry 1 and 30s model timeout

### DIFF
--- a/lib/llm_provider/cascade_executor.ml
+++ b/lib/llm_provider/cascade_executor.ml
@@ -22,8 +22,16 @@
 
 let cascade_model_timeout_sec : float =
   match Sys.getenv_opt "OAS_CASCADE_MODEL_TIMEOUT_SEC" with
-  | Some s -> (try Float.of_string s with _ -> 1200.0)
-  | None -> 1200.0
+  | Some s -> (try Float.of_string s with _ -> 30.0)
+  | None -> 30.0
+
+(* Cascade uses minimal retries — the next provider IS the retry. *)
+let cascade_retry_config : Complete.retry_config = {
+  max_retries = 1;
+  initial_delay_sec = 0.5;
+  max_delay_sec = 2.0;
+  backoff_multiplier = 2.0;
+}
 
 (* ── Shared cloud throttle table ─────────────────────── *)
 
@@ -125,7 +133,8 @@ let complete_cascade_with_accept ~sw ~net ?clock ?cache ?metrics
       match clock with
       | Some clock ->
         Complete.complete_with_retry ~sw ~net ~clock ~config:cfg
-          ~messages ~tools ?cache ?metrics ?priority ()
+          ~messages ~tools ~retry_config:cascade_retry_config
+          ?cache ?metrics ?priority ()
       | None ->
         Complete.complete ~sw ~net ~config:cfg
           ~messages ~tools ?cache ?metrics ?priority ()

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -312,7 +312,14 @@ type cascade = {
   fallbacks: Provider_config.t list;
 }
 
-let complete_cascade ~sw ~net ?transport ?clock ?retry_config
+let cascade_retry_config = {
+  max_retries = 1;
+  initial_delay_sec = 0.5;
+  max_delay_sec = 2.0;
+  backoff_multiplier = 2.0;
+}
+
+let complete_cascade ~sw ~net ?transport ?clock ?retry_config:_
     ~(cascade : cascade)
     ~(messages : Types.message list) ?(tools=[])
     ?cache ?metrics ?priority () =
@@ -321,7 +328,8 @@ let complete_cascade ~sw ~net ?transport ?clock ?retry_config
     match clock with
     | Some clock ->
         complete_with_retry ~sw ~net ?transport ~clock ~config:cfg
-          ~messages ~tools ?retry_config ?cache ?metrics ?priority ()
+          ~messages ~tools ~retry_config:cascade_retry_config
+          ?cache ?metrics ?priority ()
     | None ->
         complete ~sw ~net ?transport ~config:cfg ~messages ~tools ?cache ?metrics ?priority ()
   in


### PR DESCRIPTION
## Summary
Cascade was blocking 84+ seconds on GLM retries before reaching local fallback. Fix: retry 1 + 30s timeout per model in cascade.

## Problem
- 3 GLM models × 3 retries × backoff (1+2+4s) = 63s minimum before Ollama
- Per-model timeout was 1200s (20 min)
- GLM 500/429 during outage = all keepers blocked for minutes

## Changes
- `cascade_model_timeout_sec`: 1200s → 30s
- `cascade_retry_config.max_retries`: 3 → 1
- Standalone retry unchanged (still 3)

## Test plan
- [x] `dune build` + `dune runtest` all pass
- [ ] Verify cascade reaches Ollama within ~35s during GLM outage

🤖 Generated with [Claude Code](https://claude.com/claude-code)