### PR TITLE
refactor: simplify soundness — enforce phantom safety, fix silent defaults

### DIFF
--- a/lib/correction_pipeline.ml
+++ b/lib/correction_pipeline.ml
@@ -146,15 +146,16 @@ let diff_corrections ~stage_name (original : Yojson.Safe.t) (corrected : Yojson.
 (* ── Pipeline execution ─────────────────────────────────── *)
 
 let run ~schema ?(stages = default_stages) input =
-  (* Apply all stages sequentially, collecting corrections *)
-  let corrected, all_corrections =
-    List.fold_left (fun (current_input, acc_corrections) stage ->
+  let corrected, rev_corrections =
+    List.fold_left (fun (current_input, acc_rev) stage ->
       let result = stage.apply schema current_input in
-      let new_corrections = diff_corrections ~stage_name:stage.name current_input result in
-      (result, acc_corrections @ new_corrections)
+      if result == current_input then (result, acc_rev)
+      else
+        let new_corrections = diff_corrections ~stage_name:stage.name current_input result in
+        (result, List.rev_append new_corrections acc_rev)
     ) (input, []) stages
   in
-  (* Validate the corrected input *)
+  let all_corrections = List.rev rev_corrections in
   match Tool_input_validation.validate schema corrected with
   | Tool_input_validation.Valid final ->
     Fixed { corrected = final; corrections = all_corrections }

--- a/lib/tool_schema_gen.ml
+++ b/lib/tool_schema_gen.ml
@@ -98,25 +98,31 @@ let to_params : type a. a schema -> Types.tool_param list = function
   | Three (a, b, c) -> [field_to_param a; field_to_param b; field_to_param c]
   | Four (a, b, c, d) -> [field_to_param a; field_to_param b; field_to_param c; field_to_param d]
 
+let collect_errors results =
+  let errors = List.filter_map (function Error e -> Some e | Ok _ -> None) results in
+  match errors with
+  | [] -> None
+  | es -> Some (String.concat "; " es)
+
 let parse : type a. a schema -> Yojson.Safe.t -> (a, string) result =
   fun schema json ->
   match schema with
-  | One a ->
-    (match a.extract json with
-     | Ok va -> Ok va
-     | Error e -> Error e)
+  | One a -> a.extract json
   | Two (a, b) ->
-    (match a.extract json, b.extract json with
+    let ra = a.extract json and rb = b.extract json in
+    (match ra, rb with
      | Ok va, Ok vb -> Ok (va, vb)
-     | Error e, _ | _, Error e -> Error e)
+     | _ -> Error (Option.get (collect_errors [Result.map ignore ra; Result.map ignore rb])))
   | Three (a, b, c) ->
-    (match a.extract json, b.extract json, c.extract json with
+    let ra = a.extract json and rb = b.extract json and rc = c.extract json in
+    (match ra, rb, rc with
      | Ok va, Ok vb, Ok vc -> Ok (va, vb, vc)
-     | Error e, _, _ | _, Error e, _ | _, _, Error e -> Error e)
+     | _ -> Error (Option.get (collect_errors [Result.map ignore ra; Result.map ignore rb; Result.map ignore rc])))
   | Four (a, b, c, d) ->
-    (match a.extract json, b.extract json, c.extract json, d.extract json with
+    let ra = a.extract json and rb = b.extract json and rc = c.extract json and rd = d.extract json in
+    (match ra, rb, rc, rd with
      | Ok va, Ok vb, Ok vc, Ok vd -> Ok (va, vb, vc, vd)
-     | Error e, _, _, _ | _, Error e, _, _ | _, _, Error e, _ | _, _, _, Error e -> Error e)
+     | _ -> Error (Option.get (collect_errors [Result.map ignore ra; Result.map ignore rb; Result.map ignore rc; Result.map ignore rd])))
 
 let to_json_schema : type a. a schema -> Yojson.Safe.t =
   fun schema ->

--- a/lib/typed_tool.ml
+++ b/lib/typed_tool.ml
@@ -16,8 +16,6 @@ type ('input, 'output) t = {
   encode : 'output -> Yojson.Safe.t;
 }
 
-(* ── Construction ───────────────────────────────────────── *)
-
 let check_descriptor = function
   | None -> ()
   | Some d ->
@@ -35,18 +33,14 @@ let create_with_context ~name ~description ~params ~parse ~handler ~encode ?desc
   let schema : Types.tool_schema = { name; description; parameters = params } in
   { schema; descriptor; parse; handler = WithContext handler; encode }
 
-(* ── Execution ──────────────────────────────────────────── *)
-
 let run_handler : type i o. ?context:Context.t -> (i, o) handler_kind -> i -> (o, string) result =
   fun ?context handler input ->
   match handler with
   | Simple f -> f input
   | WithContext f ->
-    let ctx = match context with
-      | Some c -> c
-      | None -> Context.create ()
-    in
-    f ctx input
+    match context with
+    | Some c -> f c input
+    | None -> Error "WithContext handler requires a context argument"
 
 let execute_parsed ?context tool json =
   match tool.parse json with
@@ -68,8 +62,6 @@ let execute ?context tool json =
     | Error e ->
       Error { Types.message = e; recoverable = false }
 
-(* ── Backward compatibility ─────────────────────────────── *)
-
 let to_untyped tool =
   let untyped_handler : Tool.handler_kind =
     match tool.handler with
@@ -81,8 +73,6 @@ let to_untyped tool =
   { Tool.schema = tool.schema;
     descriptor = tool.descriptor;
     handler = untyped_handler }
-
-(* ── Introspection ──────────────────────────────────────── *)
 
 let schema tool = tool.schema
 let name tool = tool.schema.name

--- a/lib/typed_tool_safe.ml
+++ b/lib/typed_tool_safe.ml
@@ -2,7 +2,6 @@
 
     @since 0.120.0 *)
 
-(* Phantom types — no runtime representation *)
 type read_only
 type write
 type destructive
@@ -16,9 +15,24 @@ type ('perm, 'input, 'output) t = {
 
 (* ── Construction ───────────────────────────────────────── *)
 
-let read_only tool = { tool; perm = Perm_read_only }
-let write tool = { tool; perm = Perm_write }
-let destructive tool = { tool; perm = Perm_destructive }
+let check_perm_compat ~expected tool =
+  match Typed_tool.descriptor tool with
+  | None -> ()
+  | Some d ->
+    match d.Tool.permission, expected with
+    | None, _ | Some Tool.ReadOnly, Perm_read_only
+    | Some Tool.Write, Perm_write | Some Tool.Destructive, Perm_destructive -> ()
+    | Some actual, _ ->
+      invalid_arg (Printf.sprintf
+        "Typed_tool_safe: tool %s descriptor permission %s incompatible with %s"
+        (Typed_tool.name tool) (Tool.show_permission actual)
+        (match expected with
+         | Perm_read_only -> "read_only" | Perm_write -> "write"
+         | Perm_destructive -> "destructive"))
+
+let read_only tool = check_perm_compat ~expected:Perm_read_only tool; { tool; perm = Perm_read_only }
+let write tool = check_perm_compat ~expected:Perm_write tool; { tool; perm = Perm_write }
+let destructive tool = check_perm_compat ~expected:Perm_destructive tool; { tool; perm = Perm_destructive }
 
 (* ── Permission-gated execution ─────────────────────────── *)
 
@@ -27,7 +41,7 @@ let execute_read_only ?context safe_tool args =
 
 let execute_with_approval ?context ~approve safe_tool args =
   let tool_name = Typed_tool.name safe_tool.tool in
-  let input_desc = Yojson.Safe.to_string args in
+  let input_desc = lazy (Yojson.Safe.to_string args) in
   if approve ~tool_name ~input_desc then
     Typed_tool.execute ?context safe_tool.tool args
   else

--- a/lib/typed_tool_safe.mli
+++ b/lib/typed_tool_safe.mli
@@ -59,7 +59,7 @@ val execute_read_only :
                    [false] to reject with "approval denied" error. *)
 val execute_write :
   ?context:Context.t ->
-  approve:(tool_name:string -> input_desc:string -> bool) ->
+  approve:(tool_name:string -> input_desc:string Lazy.t -> bool) ->
   (write, 'input, 'output) t ->
   Yojson.Safe.t ->
   Types.tool_result
@@ -68,7 +68,7 @@ val execute_write :
     Same as {!execute_write} but semantically distinct for auditing. *)
 val execute_destructive :
   ?context:Context.t ->
-  approve:(tool_name:string -> input_desc:string -> bool) ->
+  approve:(tool_name:string -> input_desc:string Lazy.t -> bool) ->
   (destructive, 'input, 'output) t ->
   Yojson.Safe.t ->
   Types.tool_result

--- a/test/test_typed_tool.ml
+++ b/test/test_typed_tool.ml
@@ -173,11 +173,9 @@ let test_context_handler () =
 let test_context_handler_no_context () =
   let input = `Assoc [("name", `String "Admin")] in
   match Typed_tool.execute greet_ctx_tool input with
-  | Ok { content } ->
-    let json = Yojson.Safe.from_string content in
-    let greeting = Yojson.Safe.Util.(json |> member "greeting" |> to_string) in
-    Alcotest.(check string) "no prefix" "Hello, Admin" greeting
-  | Error e -> Alcotest.fail e.message
+  | Ok _ -> Alcotest.fail "expected error when context missing"
+  | Error e ->
+    Alcotest.(check bool) "not recoverable" false e.recoverable
 
 let test_to_untyped_context_bridge () =
   let untyped = Typed_tool.to_untyped greet_ctx_tool in

--- a/test/test_typed_tool_safe.ml
+++ b/test/test_typed_tool_safe.ml
@@ -44,7 +44,7 @@ let test_read_only_permission_name () =
 
 let test_write_approved () =
   let safe = Typed_tool_safe.write base_tool in
-  let approve ~tool_name:_ ~input_desc:_ = true in
+  let approve ~tool_name:_ ~input_desc:(_:_ Lazy.t) = true in
   match Typed_tool_safe.execute_write ~approve safe valid_input with
   | Ok { content } ->
     let json = Yojson.Safe.from_string content in
@@ -54,7 +54,7 @@ let test_write_approved () =
 
 let test_write_denied () =
   let safe = Typed_tool_safe.write base_tool in
-  let approve ~tool_name:_ ~input_desc:_ = false in
+  let approve ~tool_name:_ ~input_desc:(_:_ Lazy.t) = false in
   match Typed_tool_safe.execute_write ~approve safe valid_input with
   | Ok _ -> Alcotest.fail "expected denial"
   | Error e ->
@@ -70,14 +70,14 @@ let test_write_permission_name () =
 
 let test_destructive_approved () =
   let safe = Typed_tool_safe.destructive base_tool in
-  let approve ~tool_name:_ ~input_desc:_ = true in
+  let approve ~tool_name:_ ~input_desc:(_:_ Lazy.t) = true in
   match Typed_tool_safe.execute_destructive ~approve safe valid_input with
   | Ok _ -> ()
   | Error e -> Alcotest.fail e.message
 
 let test_destructive_denied () =
   let safe = Typed_tool_safe.destructive base_tool in
-  let approve ~tool_name:_ ~input_desc:_ = false in
+  let approve ~tool_name:_ ~input_desc:(_:_ Lazy.t) = false in
   match Typed_tool_safe.execute_destructive ~approve safe valid_input with
   | Ok _ -> Alcotest.fail "expected denial"
   | Error e ->
@@ -112,7 +112,7 @@ let test_name () =
 
    (* ERROR: read_only tool cannot use execute_write *)
    let _ = Typed_tool_safe.execute_write
-     ~approve:(fun ~tool_name:_ ~input_desc:_ -> true)
+     ~approve:(fun ~tool_name:_ ~input_desc:(_:_ Lazy.t) -> true)
      (Typed_tool_safe.read_only base_tool)
      valid_input
 


### PR DESCRIPTION
## Summary
- Phantom type constructors now validate descriptor permission at construction (mismatch = `invalid_arg`)
- `WithContext` handler returns `Error` when context missing (was silently creating empty `Context.t`)
- Lazy JSON serialization in approval callback (avoids hot-path `Yojson.Safe.to_string`)
- Correction pipeline: `List.rev_append` + physical equality skip replaces quadratic `@`
- Schema gen: accumulates all field errors instead of returning only the first
- Remove section divider comments

## Test plan
- [ ] 49/49 OAS soundness tests pass locally
- [ ] `dune build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)