### PR TITLE
refactor: extract Types.params_to_input_schema — deduplicate 3 sites

### DIFF
--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -55,6 +55,22 @@ type tool_param = {
 }
 [@@deriving yojson, show]
 
+let params_to_input_schema (params : tool_param list) : Yojson.Safe.t =
+  let properties = List.rev_map (fun (p : tool_param) ->
+    (p.name, `Assoc [
+      ("type", `String (param_type_to_string p.param_type));
+      ("description", `String p.description);
+    ])
+  ) params in
+  let required = List.filter_map (fun (p : tool_param) ->
+    if p.required then Some (`String p.name) else None
+  ) params in
+  `Assoc [
+    ("type", `String "object");
+    ("properties", `Assoc (List.rev properties));
+    ("required", `List required);
+  ]
+
 (** Tool definition *)
 type tool_schema = {
   name: string;

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -39,6 +39,8 @@ type tool_param = {
 }
 [@@deriving yojson, show]
 
+val params_to_input_schema : tool_param list -> Yojson.Safe.t
+
 type tool_schema = {
   name: string;
   description: string;

--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -18,24 +18,10 @@ type 'a schema = {
 
 (** Build the tool_schema JSON for an extraction schema *)
 let schema_to_tool_json (s : _ schema) : Yojson.Safe.t =
-  let properties = List.fold_left (fun acc param ->
-    let prop = `Assoc [
-      ("type", `String (param_type_to_string param.param_type));
-      ("description", `String param.description);
-    ] in
-    (param.name, prop) :: acc
-  ) [] s.params in
-  let required = List.filter_map (fun p ->
-    if p.required then Some (`String p.name) else None
-  ) s.params in
   `Assoc [
     ("name", `String s.name);
     ("description", `String s.description);
-    ("input_schema", `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc (List.rev properties));
-      ("required", `List required);
-    ]);
+    ("input_schema", Types.params_to_input_schema s.params);
   ]
 
 (** Extract a tool_use input JSON from an API response's content blocks.

--- a/lib/tool.ml
+++ b/lib/tool.ml
@@ -176,24 +176,10 @@ let descriptor_to_yojson = function
 
 (** Schema to JSON *)
 let schema_to_json tool =
-  let properties = List.fold_left (fun acc param ->
-    let prop = `Assoc [
-      ("type", `String (param_type_to_string param.param_type));
-      ("description", `String param.description);
-    ] in
-    (param.name, prop) :: acc
-  ) [] tool.schema.parameters in
-  let required = List.filter_map (fun p ->
-    if p.required then Some (`String p.name) else None
-  ) tool.schema.parameters in
   `Assoc [
     ("name", `String tool.schema.name);
     ("description", `String tool.schema.description);
-    ("input_schema", `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc (List.rev properties));
-      ("required", `List required);
-    ]);
+    ("input_schema", Types.params_to_input_schema tool.schema.parameters);
   ]
 
 (** Wrap a tool to inject default arguments when not provided by the LLM.

--- a/lib/tool_schema_gen.ml
+++ b/lib/tool_schema_gen.ml
@@ -125,19 +125,4 @@ let parse : type a. a schema -> Yojson.Safe.t -> (a, string) result =
      | _ -> Error (Option.get (collect_errors [Result.map ignore ra; Result.map ignore rb; Result.map ignore rc; Result.map ignore rd])))
 
 let to_json_schema : type a. a schema -> Yojson.Safe.t =
-  fun schema ->
-  let params = to_params schema in
-  let properties = List.map (fun (p : Types.tool_param) ->
-    (p.name, `Assoc [
-      ("type", `String (Types.param_type_to_string p.param_type));
-      ("description", `String p.description);
-    ])
-  ) params in
-  let required = List.filter_map (fun (p : Types.tool_param) ->
-    if p.required then Some (`String p.name) else None
-  ) params in
-  `Assoc [
-    ("type", `String "object");
-    ("properties", `Assoc properties);
-    ("required", `List required);
-  ]
+  fun schema -> Types.params_to_input_schema (to_params schema)


### PR DESCRIPTION
## Summary
- Extract `Types.params_to_input_schema` from 3 identical JSON schema builders
- `tool.ml`, `structured.ml`, `tool_schema_gen.ml` now call the shared utility
- Net -25 lines, zero behavior change

## Test plan
- [ ] 49/49 soundness tests pass
- [ ] `dune build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)