### PR TITLE
style: simplify List.rev_map to List.map in params_to_input_schema

### DIFF
--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -56,7 +56,7 @@ type tool_param = {
 [@@deriving yojson, show]
 
 let params_to_input_schema (params : tool_param list) : Yojson.Safe.t =
-  let properties = List.rev_map (fun (p : tool_param) ->
+  let properties = List.map (fun (p : tool_param) ->
     (p.name, `Assoc [
       ("type", `String (param_type_to_string p.param_type));
       ("description", `String p.description);
@@ -67,7 +67,7 @@ let params_to_input_schema (params : tool_param list) : Yojson.Safe.t =
   ) params in
   `Assoc [
     ("type", `String "object");
-    ("properties", `Assoc (List.rev properties));
+    ("properties", `Assoc properties);
     ("required", `List required);
   ]
 


### PR DESCRIPTION
## Summary
- `List.rev_map` + `List.rev` → `List.map` for readability
- Params lists are 1-4 elements, no performance impact

## Test plan
- [ ] 10/10 schema gen tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)