### PR TITLE
refactor: dedup tool_param/schema JSON — extract to Types from checkpoint + mcp_session

### DIFF
--- a/lib/checkpoint.ml
+++ b/lib/checkpoint.ml
@@ -133,6 +133,14 @@ let usage_of_json json =
        | _ -> 0.0);
   }
 
+let tool_schema_to_json = Types.tool_schema_to_json
+
+let map_str_err r =
+  Result.map_error (fun s ->
+    Error.Serialization (UnknownVariant { type_name = "param_type"; value = s })) r
+
+let tool_schema_of_json json = map_str_err (Types.tool_schema_of_json json)
+
 let result_all items =
   let rec loop acc = function
     | [] -> Ok (List.rev acc)
@@ -140,58 +148,6 @@ let result_all items =
     | Error e :: _ -> Error e
   in
   loop [] items
-
-let tool_param_to_json (p : tool_param) =
-  `Assoc [
-    ("name", `String p.name);
-    ("description", `String p.description);
-    ("param_type", `String (param_type_to_string p.param_type));
-    ("required", `Bool p.required);
-  ]
-
-let tool_param_of_json json =
-  let open Yojson.Safe.Util in
-  let type_str = json |> member "param_type" |> to_string in
-  let param_type =
-    match type_str with
-    | "string" -> Ok String
-    | "integer" -> Ok Integer
-    | "number" -> Ok Number
-    | "boolean" -> Ok Boolean
-    | "array" -> Ok Array
-    | "object" -> Ok Object
-    | other -> Error (Error.Serialization (UnknownVariant { type_name = "param_type"; value = other }))
-  in
-  Result.map
-    (fun param_type ->
-      {
-        name = json |> member "name" |> to_string;
-        description = json |> member "description" |> to_string;
-        param_type;
-        required = json |> member "required" |> to_bool;
-      })
-    param_type
-
-let tool_schema_to_json (s : tool_schema) =
-  `Assoc [
-    ("name", `String s.name);
-    ("description", `String s.description);
-    ("parameters", `List (List.map tool_param_to_json s.parameters));
-  ]
-
-let tool_schema_of_json json =
-  let open Yojson.Safe.Util in
-  let parameters =
-    json |> member "parameters" |> to_list |> List.map tool_param_of_json |> result_all
-  in
-  Result.map
-    (fun parameters ->
-      {
-        name = json |> member "name" |> to_string;
-        description = json |> member "description" |> to_string;
-        parameters;
-      })
-    parameters
 
 let content_block_of_json_strict json =
   try

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -55,6 +55,29 @@ type tool_param = {
 }
 [@@deriving yojson, show]
 
+let param_type_of_string = function
+  | "string" -> Ok String | "integer" -> Ok Integer
+  | "number" -> Ok Number | "boolean" -> Ok Boolean
+  | "array" -> Ok Array  | "object" -> Ok Object
+  | other -> Error other
+
+let tool_param_to_json (p : tool_param) : Yojson.Safe.t =
+  `Assoc [
+    ("name", `String p.name);
+    ("description", `String p.description);
+    ("param_type", `String (param_type_to_string p.param_type));
+    ("required", `Bool p.required);
+  ]
+
+let tool_param_of_json (json : Yojson.Safe.t) : (tool_param, string) result =
+  let open Yojson.Safe.Util in
+  match param_type_of_string (json |> member "param_type" |> to_string) with
+  | Error s -> Error (Printf.sprintf "unknown param_type: %s" s)
+  | Ok param_type ->
+    Ok { name = json |> member "name" |> to_string;
+         description = json |> member "description" |> to_string;
+         param_type; required = json |> member "required" |> to_bool }
+
 let params_to_input_schema (params : tool_param list) : Yojson.Safe.t =
   let properties = List.map (fun (p : tool_param) ->
     (p.name, `Assoc [
@@ -78,6 +101,31 @@ type tool_schema = {
   parameters: tool_param list;
 }
 [@@deriving yojson, show]
+
+let tool_schema_to_json (s : tool_schema) : Yojson.Safe.t =
+  `Assoc [
+    ("name", `String s.name);
+    ("description", `String s.description);
+    ("parameters", `List (List.map tool_param_to_json s.parameters));
+  ]
+
+let result_all items =
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | Ok item :: rest -> loop (item :: acc) rest
+    | Error e :: _ -> Error e
+  in
+  loop [] items
+
+let tool_schema_of_json (json : Yojson.Safe.t) : (tool_schema, string) result =
+  let open Yojson.Safe.Util in
+  match json |> member "parameters" |> to_list
+        |> List.map tool_param_of_json |> result_all with
+  | Error e -> Error e
+  | Ok parameters ->
+    Ok { name = json |> member "name" |> to_string;
+         description = json |> member "description" |> to_string;
+         parameters }
 
 (** Tool choice mode *)
 type tool_choice =

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -39,6 +39,9 @@ type tool_param = {
 }
 [@@deriving yojson, show]
 
+val param_type_of_string : string -> (param_type, string) result
+val tool_param_to_json : tool_param -> Yojson.Safe.t
+val tool_param_of_json : Yojson.Safe.t -> (tool_param, string) result
 val params_to_input_schema : tool_param list -> Yojson.Safe.t
 
 type tool_schema = {
@@ -47,6 +50,10 @@ type tool_schema = {
   parameters: tool_param list;
 }
 [@@deriving yojson, show]
+
+val tool_schema_to_json : tool_schema -> Yojson.Safe.t
+val tool_schema_of_json : Yojson.Safe.t -> (tool_schema, string) result
+val result_all : ('a, 'e) result list -> ('a list, 'e) result
 
 type tool_choice =
   | Auto

--- a/lib/protocol/mcp_session.ml
+++ b/lib/protocol/mcp_session.ml
@@ -96,6 +96,14 @@ let env_pair_of_json json =
   | exn ->
     Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Invalid env pair: %s" (Printexc.to_string exn) }))
 
+let tool_schema_to_json = Types.tool_schema_to_json
+
+let map_str_err r =
+  Result.map_error (fun s ->
+    Error.Serialization (UnknownVariant { type_name = "param_type"; value = s })) r
+
+let tool_schema_of_json json = map_str_err (Types.tool_schema_of_json json)
+
 let result_all items =
   let rec loop acc = function
     | [] -> Ok (List.rev acc)
@@ -103,51 +111,6 @@ let result_all items =
     | Error e :: _ -> Error e
   in
   loop [] items
-
-(* ── Tool schema serialization (self-contained to avoid Checkpoint cycle) ── *)
-
-let tool_param_to_json (p : tool_param) =
-  `Assoc [
-    ("name", `String p.name);
-    ("description", `String p.description);
-    ("param_type", `String (param_type_to_string p.param_type));
-    ("required", `Bool p.required);
-  ]
-
-let tool_param_of_json json =
-  let open Yojson.Safe.Util in
-  let type_str = json |> member "param_type" |> to_string in
-  let param_type =
-    match type_str with
-    | "string" -> Ok String | "integer" -> Ok Integer
-    | "number" -> Ok Number | "boolean" -> Ok Boolean
-    | "array" -> Ok Array  | "object" -> Ok Object
-    | other -> Error (Error.Serialization (UnknownVariant { type_name = "param_type"; value = other }))
-  in
-  Result.map (fun param_type ->
-    { name = json |> member "name" |> to_string;
-      description = json |> member "description" |> to_string;
-      param_type; required = json |> member "required" |> to_bool })
-    param_type
-
-let tool_schema_to_json (s : tool_schema) =
-  `Assoc [
-    ("name", `String s.name);
-    ("description", `String s.description);
-    ("parameters", `List (List.map tool_param_to_json s.parameters));
-  ]
-
-let tool_schema_of_json json =
-  let open Yojson.Safe.Util in
-  let parameters =
-    json |> member "parameters" |> to_list
-    |> List.map tool_param_of_json |> result_all
-  in
-  Result.map (fun parameters ->
-    { name = json |> member "name" |> to_string;
-      description = json |> member "description" |> to_string;
-      parameters })
-    parameters
 
 (* ── info JSON ─────────────────────────────────────────────────── *)
 


### PR DESCRIPTION
## Summary
- Extract 5 identical JSON serialization functions from checkpoint.ml and mcp_session.ml to Types
- Original duplication comment said "self-contained to avoid Checkpoint cycle" — cycle no longer exists
- 51 checkpoint tests pass

## Test plan
- [ ] 51/51 checkpoint tests pass
- [ ] `dune build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)