### PR TITLE
refactor: dedup string_of_param_type → Types.param_type_to_string

### DIFF
--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -31,13 +31,7 @@ let describe_json_value = function
   | `Tuple _ -> "tuple"
   | `Variant _ -> "variant"
 
-let string_of_param_type = function
-  | Types.String -> "string"
-  | Types.Integer -> "integer"
-  | Types.Number -> "number"
-  | Types.Boolean -> "boolean"
-  | Types.Array -> "array"
-  | Types.Object -> "object"
+let string_of_param_type = Types.param_type_to_string
 
 (* ── Type coercion ───────────────────────────────────────── *)
 


### PR DESCRIPTION
## Summary
- Replace 6-arm duplicate match with alias to `Types.param_type_to_string`

## Test plan
- [ ] 20 middleware + 12 correction tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)