### PR TITLE
chore(oas): add warning suppression to api_openai.mli

### DIFF
--- a/lib/api_openai.mli
+++ b/lib/api_openai.mli
@@ -1,9 +1,11 @@
+[@@@warning "-49"]
+
 (** OpenAI-compatible API request building and response parsing.
 
     Includes re-exports from {!Llm_provider.Backend_openai}.
 
     @stability Internal
-    @since 0.93.1 *)
+    @since 0.93.1 *))
 
 include module type of Llm_provider.Backend_openai
 


### PR DESCRIPTION
Add [@@@warning "-49"] to suppress module-type-subtyping warning from include module type of Llm_provider.Backend_openai. CI enforces warn-error=+a.