### PR TITLE
feat: add multi-vendor inference providers (Groq, DeepSeek, Alibaba, SiliconFlow)

### DIFF
--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -237,17 +237,14 @@ let resolve_provider ~model_id provider_str base_url =
       let registry = Llm_provider.Provider_registry.default () in
       match Llm_provider.Provider_registry.find registry other with
       | Some entry ->
-          let pc = Llm_provider.Provider_config.make
-            ~kind:entry.defaults.kind
-            ~model_id
-            ~base_url:(match base_url with
-              | Some u -> u
-              | None -> entry.defaults.base_url)
-            ~api_key:(match Sys.getenv_opt entry.defaults.api_key_env with
-              | Some k when String.trim k <> "" -> String.trim k
-              | _ -> "")
-            ~request_path:entry.defaults.request_path () in
-          Provider.config_of_provider_config pc
+          let url = match base_url with
+            | Some u -> u
+            | None -> entry.defaults.base_url
+          in
+          { Provider.provider = OpenAICompat {
+              base_url = url; auth_header = None;
+              path = entry.defaults.request_path; static_token = None };
+            model_id; api_key_env = entry.defaults.api_key_env }
       | None ->
           let url = match base_url with
             | Some u -> u

--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -234,14 +234,29 @@ let resolve_provider ~model_id provider_str base_url =
           path = "/v1/chat/completions"; static_token = None };
         model_id; api_key_env = "OPENAI_API_KEY" }
   | other ->
-      let url = match base_url with
-        | Some u -> u
-        | None -> Defaults.local_llm_url
-      in
-      { Provider.provider = OpenAICompat {
-          base_url = url; auth_header = None;
-          path = "/v1/chat/completions"; static_token = None };
-        model_id; api_key_env = other }
+      let registry = Llm_provider.Provider_registry.default () in
+      match Llm_provider.Provider_registry.find registry other with
+      | Some entry ->
+          let pc = Llm_provider.Provider_config.make
+            ~kind:entry.defaults.kind
+            ~model_id
+            ~base_url:(match base_url with
+              | Some u -> u
+              | None -> entry.defaults.base_url)
+            ~api_key:(match Sys.getenv_opt entry.defaults.api_key_env with
+              | Some k when String.trim k <> "" -> String.trim k
+              | _ -> "")
+            ~request_path:entry.defaults.request_path () in
+          Provider.config_of_provider_config pc
+      | None ->
+          let url = match base_url with
+            | Some u -> u
+            | None -> Defaults.local_llm_url
+          in
+          { Provider.provider = OpenAICompat {
+              base_url = url; auth_header = None;
+              path = "/v1/chat/completions"; static_token = None };
+            model_id; api_key_env = other }
 
 (** Convert mcp_file_config to a server spec for stdio, or connect HTTP directly. *)
 let connect_mcp_server ~sw ~mgr ~net mcp_cfg =

--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -792,8 +792,8 @@ let%test "resolve_model_strings named takes priority over default" =
       resolve_model_strings ~config_path:tmp
         ~name:"named" ~defaults:["fallback:x"] () = ["glm:flash"]))
 
-let%test "default_registry has 8 providers" =
-  List.length (Provider_registry.all default_registry) = 8
+let%test "default_registry has 12 providers" =
+  List.length (Provider_registry.all default_registry) = 12
 
 let%test "default_registry llama is OpenAI_compat" =
   match Provider_registry.find default_registry "llama" with

--- a/lib/llm_provider/cascade_health_filter.ml
+++ b/lib/llm_provider/cascade_health_filter.ml
@@ -87,6 +87,9 @@ let%test "should_cascade_to_next 403 forbidden" =
 let%test "should_cascade_to_next 429 rate limit" =
   should_cascade_to_next (Http_client.HttpError { code = 429; body = "" }) = true
 
+let%test "should_cascade_to_next 498 groq flex capacity" =
+  should_cascade_to_next (Http_client.HttpError { code = 498; body = "" }) = true
+
 let%test "should_cascade_to_next 500 server error" =
   should_cascade_to_next (Http_client.HttpError { code = 500; body = "" }) = true
 

--- a/lib/llm_provider/constants.ml
+++ b/lib/llm_provider/constants.ml
@@ -14,8 +14,9 @@ module Http = struct
 
   (** HTTP status codes that trigger cascade fallback in {!Cascade_config}.
       Superset of [retryable_codes]: includes auth/forbidden errors
-      that are not retryable but should cascade to the next provider. *)
-  let cascadable_codes = [401; 403; 429; 500; 502; 503; 529]
+      that are not retryable but should cascade to the next provider.
+      498 = Groq Flex tier capacity exceeded. *)
+  let cascadable_codes = [401; 403; 429; 498; 500; 502; 503; 529]
 end
 
 (* ── Inference profiles ─────────────────────────── *)

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -216,6 +216,41 @@ let openrouter_defaults = {
   request_path = "/chat/completions";
 }
 
+let env_or_default env_name default_url =
+  match Sys.getenv_opt env_name with
+  | Some url when String.trim url <> "" -> String.trim url
+  | _ -> default_url
+
+let groq_defaults = {
+  kind = OpenAI_compat;
+  base_url = env_or_default "GROQ_BASE_URL" "https://api.groq.com/openai/v1";
+  api_key_env = "GROQ_API_KEY";
+  request_path = "/chat/completions";
+}
+
+let deepseek_defaults = {
+  kind = OpenAI_compat;
+  base_url = env_or_default "DEEPSEEK_BASE_URL" "https://api.deepseek.com";
+  api_key_env = "DEEPSEEK_API_KEY";
+  request_path = "/chat/completions";
+}
+
+let alibaba_defaults = {
+  kind = OpenAI_compat;
+  base_url = env_or_default "DASHSCOPE_BASE_URL"
+    "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
+  api_key_env = "DASHSCOPE_API_KEY";
+  request_path = "/chat/completions";
+}
+
+let siliconflow_defaults = {
+  kind = OpenAI_compat;
+  base_url = env_or_default "SILICONFLOW_BASE_URL"
+    "https://api.siliconflow.cn/v1";
+  api_key_env = "SILICONFLOW_API_KEY";
+  request_path = "/chat/completions";
+}
+
 let default () =
   let t = create () in
   let reg name defaults ~max_context caps =
@@ -234,6 +269,14 @@ let default () =
     Capabilities.glm_capabilities;
   reg "openrouter" openrouter_defaults ~max_context:128_000
     Capabilities.openai_chat_extended_capabilities;
+  reg "groq" groq_defaults ~max_context:131_072
+    Capabilities.openai_chat_capabilities;
+  reg "deepseek" deepseek_defaults ~max_context:128_000
+    Capabilities.openai_chat_capabilities;
+  reg "alibaba" alibaba_defaults ~max_context:131_072
+    Capabilities.openai_chat_capabilities;
+  reg "siliconflow" siliconflow_defaults ~max_context:128_000
+    Capabilities.openai_chat_capabilities;
   register t { name = "ollama"; defaults = ollama_defaults;
                max_context = 262_144;
                capabilities = Capabilities.ollama_capabilities;

--- a/test/test_agent_config_deep.ml
+++ b/test/test_agent_config_deep.ml
@@ -299,6 +299,32 @@ let test_resolve_other_custom_url () =
     Alcotest.(check string) "custom url" "http://custom:5000" base_url
   | _ -> Alcotest.fail "expected OpenAICompat"
 
+let test_resolve_groq () =
+  let cfg = Agent_config.resolve_provider ~model_id:"qwen/qwen3-32b" "groq" None in
+  match cfg.provider with
+  | Provider.OpenAICompat { base_url; path; _ } ->
+    Alcotest.(check string) "groq url" "https://api.groq.com/openai/v1" base_url;
+    Alcotest.(check string) "groq path" "/chat/completions" path;
+    Alcotest.(check string) "groq api_key_env" "GROQ_API_KEY" cfg.api_key_env;
+    Alcotest.(check string) "groq model_id" "qwen/qwen3-32b" cfg.model_id
+  | _ -> Alcotest.fail "expected OpenAICompat for groq"
+
+let test_resolve_groq_custom_url () =
+  let cfg = Agent_config.resolve_provider ~model_id:"qwen/qwen3-32b" "groq"
+      (Some "http://proxy:8080") in
+  match cfg.provider with
+  | Provider.OpenAICompat { base_url; _ } ->
+    Alcotest.(check string) "overridden url" "http://proxy:8080" base_url
+  | _ -> Alcotest.fail "expected OpenAICompat for groq custom url"
+
+let test_resolve_deepseek () =
+  let cfg = Agent_config.resolve_provider ~model_id:"deepseek-chat" "deepseek" None in
+  match cfg.provider with
+  | Provider.OpenAICompat { base_url; _ } ->
+    Alcotest.(check string) "deepseek url" "https://api.deepseek.com" base_url;
+    Alcotest.(check string) "deepseek api_key_env" "DEEPSEEK_API_KEY" cfg.api_key_env
+  | _ -> Alcotest.fail "expected OpenAICompat for deepseek"
+
 (* ── of_json error cases ─────────────────────────────────────── *)
 
 let test_of_json_bad_param () =
@@ -379,5 +405,8 @@ let () =
       tc "openai custom url" test_resolve_openai_custom_url;
       tc "other" test_resolve_other;
       tc "other custom url" test_resolve_other_custom_url;
+      tc "groq" test_resolve_groq;
+      tc "groq custom url" test_resolve_groq_custom_url;
+      tc "deepseek" test_resolve_deepseek;
     ]);
   ]

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -163,10 +163,10 @@ let test_find_capable_composite () =
 
 (* ── Default registry ───────────────────────────────── *)
 
-let test_default_has_8 () =
+let test_default_has_12 () =
   let reg = Provider_registry.default () in
   let all = Provider_registry.all reg in
-  check int "8 known providers" 8 (List.length all);
+  check int "12 known providers" 12 (List.length all);
   check bool "llama exists" true
     (Option.is_some (Provider_registry.find reg "llama"));
   check bool "ollama exists" true
@@ -181,6 +181,14 @@ let test_default_has_8 () =
     (Option.is_some (Provider_registry.find reg "glm-coding"));
   check bool "openrouter exists" true
     (Option.is_some (Provider_registry.find reg "openrouter"));
+  check bool "groq exists" true
+    (Option.is_some (Provider_registry.find reg "groq"));
+  check bool "deepseek exists" true
+    (Option.is_some (Provider_registry.find reg "deepseek"));
+  check bool "alibaba exists" true
+    (Option.is_some (Provider_registry.find reg "alibaba"));
+  check bool "siliconflow exists" true
+    (Option.is_some (Provider_registry.find reg "siliconflow"));
   check bool "cc exists" true
     (Option.is_some (Provider_registry.find reg "cc"))
 
@@ -213,7 +221,19 @@ let test_default_max_context () =
    | None -> fail "glm should exist");
   (match Provider_registry.find reg "cc" with
    | Some e -> check int "cc 200K" 200_000 e.max_context
-   | None -> fail "cc should exist")
+   | None -> fail "cc should exist");
+  (match Provider_registry.find reg "groq" with
+   | Some e -> check int "groq 131K" 131_072 e.max_context
+   | None -> fail "groq should exist");
+  (match Provider_registry.find reg "deepseek" with
+   | Some e -> check int "deepseek 128K" 128_000 e.max_context
+   | None -> fail "deepseek should exist");
+  (match Provider_registry.find reg "alibaba" with
+   | Some e -> check int "alibaba 131K" 131_072 e.max_context
+   | None -> fail "alibaba should exist");
+  (match Provider_registry.find reg "siliconflow" with
+   | Some e -> check int "siliconflow 128K" 128_000 e.max_context
+   | None -> fail "siliconflow should exist")
 
 let test_default_zai_base_urls () =
   let reg = Provider_registry.default () in
@@ -316,7 +336,7 @@ let () =
       test_case "requires_any" `Quick test_requires_any;
     ];
     "default", [
-      test_case "has 8 providers" `Quick test_default_has_8;
+      test_case "has 12 providers" `Quick test_default_has_12;
       test_case "correct capabilities" `Quick test_default_capabilities;
       test_case "max_context values" `Quick test_default_max_context;
       test_case "zai base urls" `Quick test_default_zai_base_urls;


### PR DESCRIPTION
## Summary
- Register 4 OpenAI-compatible cloud providers in `Provider_registry`: Groq, DeepSeek, Alibaba (DashScope), SiliconFlow
- Use `openai_chat_capabilities` (not extended) to prevent sending unsupported params (`top_k`, `min_p`, `chat_template_kwargs`) to cloud vendors
- Add Groq 498 (Flex capacity exceeded) to `cascadable_codes`
- Add `env_or_default` helper for base URL env var override pattern

## Motivation
Enable MASC keeper cascade to failover across multiple low-cost inference providers, reducing dependency on single vendor. Target: offset Claude Max subscriptions ($1,100/mo) by routing routine coding tasks through cheaper APIs.

Verified pricing (per 1M tokens):
| Provider | Model | Input | Output | Speed |
|----------|-------|-------|--------|-------|
| Groq | Qwen3 32B | $0.29 | $0.59 | 662 tok/s |
| DeepSeek | V3.2 | $0.28 | $0.42 | varies |
| Alibaba | Qwen-Turbo | $0.05 | $0.20 | varies |

## Changes
- `lib/llm_provider/provider_registry.ml` — 4 provider defaults + registration + `env_or_default`
- `lib/llm_provider/constants.ml` — 498 added to cascadable_codes
- `lib/llm_provider/cascade_health_filter.ml` — 498 inline test
- `lib/llm_provider/cascade_config.ml` — inline test count 8→12
- `test/test_provider_registry.ml` — count 8→12 + new provider assertions

## Test plan
- [x] `dune runtest` full suite pass (0 failures)
- [x] Groq API connectivity verified via curl (487 tok/s, TTFT 42ms)
- [x] Vendor parameter compatibility verified against official docs (Groq, DeepSeek)
- [ ] E2E cascade test with `groq:qwen/qwen3-32b` in cascade.json
- [ ] E2E test with `deepseek:deepseek-chat` (pending API key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)