### PR TITLE
refactor: configurable defaults — remove hardcoding from Phase 2-4

### DIFF
--- a/lib/correction_pipeline.ml
+++ b/lib/correction_pipeline.ml
@@ -7,7 +7,7 @@
 type correction = {
   stage : string;
   field : string;
-  from_value : string;
+  from_value : string option;
   to_value : string;
 }
 
@@ -129,14 +129,14 @@ let diff_corrections ~stage_name (original : Yojson.Safe.t) (corrected : Yojson.
         Some {
           stage = stage_name;
           field = k;
-          from_value = Yojson.Safe.to_string old_v;
+          from_value = Some (Yojson.Safe.to_string old_v);
           to_value = Yojson.Safe.to_string new_v;
         }
       | None ->
         Some {
           stage = stage_name;
           field = k;
-          from_value = "(missing)";
+          from_value = None;
           to_value = Yojson.Safe.to_string new_v;
         }
       | _ -> None
@@ -169,7 +169,8 @@ let build_nondet_feedback ~tool_name ~args ~still_invalid ~attempted =
   if attempted = [] then base_errors
   else
     let correction_lines = List.map (fun c ->
-      Printf.sprintf "  [%s] %s: %s -> %s" c.stage c.field c.from_value c.to_value
+      let from = match c.from_value with Some v -> v | None -> "(added)" in
+      Printf.sprintf "  [%s] %s: %s -> %s" c.stage c.field from c.to_value
     ) attempted in
     Printf.sprintf "%s\n\nDeterministic corrections attempted (still insufficient):\n%s"
       base_errors (String.concat "\n" correction_lines)

--- a/lib/correction_pipeline.mli
+++ b/lib/correction_pipeline.mli
@@ -20,7 +20,7 @@
 type correction = {
   stage : string;     (** Which correction stage applied *)
   field : string;     (** Which field was corrected *)
-  from_value : string;  (** Original value description *)
+  from_value : string option;  (** Original value, or [None] if field was missing *)
   to_value : string;    (** Corrected value description *)
 }
 

--- a/lib/tool_schema_gen.ml
+++ b/lib/tool_schema_gen.ml
@@ -34,24 +34,24 @@ let extract_with_coerce ~name ~typ ~required ~default ~unwrap json =
     | None -> Error (Printf.sprintf "%s: expected %s, got %s" name
                        (Types.param_type_to_string typ) (Yojson.Safe.to_string v))
 
-let string_field name ~required ~desc =
+let string_field name ~required ~desc ?(default = "") () =
   make_field name ~typ:Types.String ~required ~desc
-    ~extract:(extract_with_coerce ~name ~typ:Types.String ~required ~default:""
+    ~extract:(extract_with_coerce ~name ~typ:Types.String ~required ~default
       ~unwrap:(function `String s -> Some s | _ -> None))
 
-let int_field name ~required ~desc =
+let int_field name ~required ~desc ?(default = 0) () =
   make_field name ~typ:Types.Integer ~required ~desc
-    ~extract:(extract_with_coerce ~name ~typ:Types.Integer ~required ~default:0
+    ~extract:(extract_with_coerce ~name ~typ:Types.Integer ~required ~default
       ~unwrap:(function `Int i -> Some i | _ -> None))
 
-let float_field name ~required ~desc =
+let float_field name ~required ~desc ?(default = 0.0) () =
   make_field name ~typ:Types.Number ~required ~desc
-    ~extract:(extract_with_coerce ~name ~typ:Types.Number ~required ~default:0.0
+    ~extract:(extract_with_coerce ~name ~typ:Types.Number ~required ~default
       ~unwrap:(function `Float f -> Some f | `Int i -> Some (float_of_int i) | _ -> None))
 
-let bool_field name ~required ~desc =
+let bool_field name ~required ~desc ?(default = false) () =
   make_field name ~typ:Types.Boolean ~required ~desc
-    ~extract:(extract_with_coerce ~name ~typ:Types.Boolean ~required ~default:false
+    ~extract:(extract_with_coerce ~name ~typ:Types.Boolean ~required ~default
       ~unwrap:(function `Bool b -> Some b | _ -> None))
 
 (* ── Schema type ────────────────────────────────────────── *)

--- a/lib/tool_schema_gen.mli
+++ b/lib/tool_schema_gen.mli
@@ -36,19 +36,19 @@ type done_t
 
 val string_field :
   string -> required:bool -> desc:string ->
-  (string, 'rest) field_spec
+  ?default:string -> unit -> (string, 'rest) field_spec
 
 val int_field :
   string -> required:bool -> desc:string ->
-  (int, 'rest) field_spec
+  ?default:int -> unit -> (int, 'rest) field_spec
 
 val float_field :
   string -> required:bool -> desc:string ->
-  (float, 'rest) field_spec
+  ?default:float -> unit -> (float, 'rest) field_spec
 
 val bool_field :
   string -> required:bool -> desc:string ->
-  (bool, 'rest) field_spec
+  ?default:bool -> unit -> (bool, 'rest) field_spec
 
 (** {1 Schema construction} *)
 

--- a/lib/typed_tool_safe.ml
+++ b/lib/typed_tool_safe.ml
@@ -42,11 +42,10 @@ let execute_read_only ?context safe_tool args =
 let execute_with_approval ?context ~approve safe_tool args =
   let tool_name = Typed_tool.name safe_tool.tool in
   let input_desc = lazy (Yojson.Safe.to_string args) in
-  if approve ~tool_name ~input_desc then
-    Typed_tool.execute ?context safe_tool.tool args
-  else
-    Error { Types.message = "Approval denied for " ^ tool_name;
-            recoverable = false }
+  match approve ~tool_name ~input_desc with
+  | Ok () -> Typed_tool.execute ?context safe_tool.tool args
+  | Error reason ->
+    Error { Types.message = reason; recoverable = false }
 
 let execute_write ?context ~approve tool args =
   execute_with_approval ?context ~approve tool args

--- a/lib/typed_tool_safe.mli
+++ b/lib/typed_tool_safe.mli
@@ -55,11 +55,11 @@ val execute_read_only :
     Passing a [read_only] tool here is a compile error —
     use {!execute_read_only} instead.
 
-    @param approve Called before execution. Returns [true] to proceed,
-                   [false] to reject with "approval denied" error. *)
+    @param approve Called before execution. Returns [Ok ()] to proceed,
+                   [Error reason] to reject with the given reason. *)
 val execute_write :
   ?context:Context.t ->
-  approve:(tool_name:string -> input_desc:string Lazy.t -> bool) ->
+  approve:(tool_name:string -> input_desc:string Lazy.t -> (unit, string) result) ->
   (write, 'input, 'output) t ->
   Yojson.Safe.t ->
   Types.tool_result
@@ -68,7 +68,7 @@ val execute_write :
     Same as {!execute_write} but semantically distinct for auditing. *)
 val execute_destructive :
   ?context:Context.t ->
-  approve:(tool_name:string -> input_desc:string Lazy.t -> bool) ->
+  approve:(tool_name:string -> input_desc:string Lazy.t -> (unit, string) result) ->
   (destructive, 'input, 'output) t ->
   Yojson.Safe.t ->
   Types.tool_result

--- a/test/test_correction_pipeline.ml
+++ b/test/test_correction_pipeline.ml
@@ -148,7 +148,7 @@ let test_nondet_feedback () =
   ] in
   let attempted = [
     { Correction_pipeline.stage = "coercion"; field = "count";
-      from_value = "\"abc\""; to_value = "(failed)" }
+      from_value = Some "\"abc\""; to_value = "(failed)" }
   ] in
   let feedback = Correction_pipeline.build_nondet_feedback
     ~tool_name:"test" ~args:(`Assoc [("count", `String "abc")])

--- a/test/test_tool_schema_gen.ml
+++ b/test/test_tool_schema_gen.ml
@@ -5,8 +5,8 @@ open Agent_sdk
 (* ── Two-field schema (broadcast-like) ──────────────────── *)
 
 let broadcast_schema = Tool_schema_gen.(two
-  (string_field "message" ~required:true ~desc:"Content")
-  (string_field "format" ~required:false ~desc:"Output format"))
+  (string_field "message" ~required:true ~desc:"Content" ())
+  (string_field "format" ~required:false ~desc:"Output format" ()))
 
 let test_to_params () =
   let params = Tool_schema_gen.to_params broadcast_schema in
@@ -48,7 +48,7 @@ let test_to_json_schema () =
 
 (* ── Single-field schema ────────────────────────────────── *)
 
-let int_schema = Tool_schema_gen.(one (int_field "count" ~required:true ~desc:"Count"))
+let int_schema = Tool_schema_gen.(one (int_field "count" ~required:true ~desc:"Count" ()))
 
 let test_int_parse () =
   match Tool_schema_gen.parse int_schema (`Assoc [("count", `Int 42)]) with
@@ -63,9 +63,9 @@ let test_int_coercion () =
 (* ── Three-field schema ─────────────────────────────────── *)
 
 let triple = Tool_schema_gen.(three
-  (string_field "name" ~required:true ~desc:"Name")
-  (int_field "age" ~required:true ~desc:"Age")
-  (bool_field "active" ~required:false ~desc:"Active"))
+  (string_field "name" ~required:true ~desc:"Name" ())
+  (int_field "age" ~required:true ~desc:"Age" ())
+  (bool_field "active" ~required:false ~desc:"Active" ()))
 
 let test_triple_parse () =
   let json = `Assoc [("name", `String "Alice"); ("age", `Int 30); ("active", `Bool true)] in

--- a/test/test_typed_tool_safe.ml
+++ b/test/test_typed_tool_safe.ml
@@ -44,7 +44,7 @@ let test_read_only_permission_name () =
 
 let test_write_approved () =
   let safe = Typed_tool_safe.write base_tool in
-  let approve ~tool_name:_ ~input_desc:(_:_ Lazy.t) = true in
+  let approve ~tool_name:_ ~input_desc:(_:_ Lazy.t) = Ok () in
   match Typed_tool_safe.execute_write ~approve safe valid_input with
   | Ok { content } ->
     let json = Yojson.Safe.from_string content in
@@ -54,7 +54,7 @@ let test_write_approved () =
 
 let test_write_denied () =
   let safe = Typed_tool_safe.write base_tool in
-  let approve ~tool_name:_ ~input_desc:(_:_ Lazy.t) = false in
+  let approve ~tool_name:_ ~input_desc:(_:_ Lazy.t) = Error "denied by test" in
   match Typed_tool_safe.execute_write ~approve safe valid_input with
   | Ok _ -> Alcotest.fail "expected denial"
   | Error e ->
@@ -70,14 +70,14 @@ let test_write_permission_name () =
 
 let test_destructive_approved () =
   let safe = Typed_tool_safe.destructive base_tool in
-  let approve ~tool_name:_ ~input_desc:(_:_ Lazy.t) = true in
+  let approve ~tool_name:_ ~input_desc:(_:_ Lazy.t) = Ok () in
   match Typed_tool_safe.execute_destructive ~approve safe valid_input with
   | Ok _ -> ()
   | Error e -> Alcotest.fail e.message
 
 let test_destructive_denied () =
   let safe = Typed_tool_safe.destructive base_tool in
-  let approve ~tool_name:_ ~input_desc:(_:_ Lazy.t) = false in
+  let approve ~tool_name:_ ~input_desc:(_:_ Lazy.t) = Error "denied by test" in
   match Typed_tool_safe.execute_destructive ~approve safe valid_input with
   | Ok _ -> Alcotest.fail "expected denial"
   | Error e ->


### PR DESCRIPTION
## Summary
- Field constructors accept `?default` (e.g. `int_field ~default:30`)
- Approval callback returns `(unit, string) result` with denial reason
- Correction `from_value` is `string option` instead of `"(missing)"` sentinel

## Test plan
- [ ] 49/49 soundness tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)