### PR TITLE
refactor: replace perm_label with Tool.permission

### DIFF
--- a/lib/typed_tool_safe.ml
+++ b/lib/typed_tool_safe.ml
@@ -6,33 +6,28 @@ type read_only
 type write
 type destructive
 
-type perm_label = Perm_read_only | Perm_write | Perm_destructive
-
 type ('perm, 'input, 'output) t = {
   tool : ('input, 'output) Typed_tool.t;
-  perm : perm_label;
+  perm : Tool.permission;
 }
-
-(* ── Construction ───────────────────────────────────────── *)
 
 let check_perm_compat ~expected tool =
   match Typed_tool.descriptor tool with
   | None -> ()
   | Some d ->
-    match d.Tool.permission, expected with
-    | None, _ | Some Tool.ReadOnly, Perm_read_only
-    | Some Tool.Write, Perm_write | Some Tool.Destructive, Perm_destructive -> ()
-    | Some actual, _ ->
+    match d.Tool.permission with
+    | None -> ()
+    | Some actual when actual = expected -> ()
+    | Some actual ->
       invalid_arg (Printf.sprintf
         "Typed_tool_safe: tool %s descriptor permission %s incompatible with %s"
-        (Typed_tool.name tool) (Tool.show_permission actual)
-        (match expected with
-         | Perm_read_only -> "read_only" | Perm_write -> "write"
-         | Perm_destructive -> "destructive"))
+        (Typed_tool.name tool)
+        (Tool.show_permission actual)
+        (Tool.show_permission expected))
 
-let read_only tool = check_perm_compat ~expected:Perm_read_only tool; { tool; perm = Perm_read_only }
-let write tool = check_perm_compat ~expected:Perm_write tool; { tool; perm = Perm_write }
-let destructive tool = check_perm_compat ~expected:Perm_destructive tool; { tool; perm = Perm_destructive }
+let read_only tool = check_perm_compat ~expected:Tool.ReadOnly tool; { tool; perm = Tool.ReadOnly }
+let write tool = check_perm_compat ~expected:Tool.Write tool; { tool; perm = Tool.Write }
+let destructive tool = check_perm_compat ~expected:Tool.Destructive tool; { tool; perm = Tool.Destructive }
 
 (* ── Permission-gated execution ─────────────────────────── *)
 
@@ -62,6 +57,6 @@ let to_untyped safe_tool = Typed_tool.to_untyped safe_tool.tool
 
 let name safe_tool = Typed_tool.name safe_tool.tool
 let permission_name safe_tool = match safe_tool.perm with
-  | Perm_read_only -> "read_only"
-  | Perm_write -> "write"
-  | Perm_destructive -> "destructive"
+  | Tool.ReadOnly -> "read_only"
+  | Tool.Write -> "write"
+  | Tool.Destructive -> "destructive"


### PR DESCRIPTION
## Summary
- Remove parallel `perm_label` enum, use `Tool.permission` directly
- `check_perm_compat` simplified — no more manual label-to-permission mapping
- 11/11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)