### PR TITLE
refactor: configurable default injection via make_default_injection_stage

### DIFF
--- a/lib/correction_pipeline.ml
+++ b/lib/correction_pipeline.ml
@@ -53,7 +53,7 @@ let coercion_stage = {
 
 (* ── Stage 2: Default Injection ─────────────────────────── *)
 
-let default_for_type = function
+let zero_default = function
   | Types.String -> `String ""
   | Types.Integer -> `Int 0
   | Types.Number -> `Float 0.0
@@ -61,29 +61,26 @@ let default_for_type = function
   | Types.Array -> `List []
   | Types.Object -> `Assoc []
 
-let default_injection_apply (schema : Types.tool_schema) (input : Yojson.Safe.t) : Yojson.Safe.t =
-  match input with
-  | `Assoc fields ->
-    let missing_optionals = List.filter (fun (p : Types.tool_param) ->
-      (not p.required)
-      && not (List.mem_assoc p.name fields)
-    ) schema.parameters in
-    let defaults = List.map (fun (p : Types.tool_param) ->
-      (p.name, default_for_type p.param_type)
-    ) missing_optionals in
-    `Assoc (fields @ defaults)
-  | `Null ->
-    let defaults = List.filter_map (fun (p : Types.tool_param) ->
-      if p.required then None
-      else Some (p.name, default_for_type p.param_type)
-    ) schema.parameters in
-    `Assoc defaults
-  | other -> other
+let make_default_injection_stage
+    ?(default_for = fun (p : Types.tool_param) -> zero_default p.param_type) () =
+  let apply (schema : Types.tool_schema) (input : Yojson.Safe.t) : Yojson.Safe.t =
+    match input with
+    | `Assoc fields ->
+      let missing_optionals = List.filter (fun (p : Types.tool_param) ->
+        (not p.required) && not (List.mem_assoc p.name fields)
+      ) schema.parameters in
+      let defaults = List.map (fun (p : Types.tool_param) -> (p.name, default_for p)) missing_optionals in
+      `Assoc (fields @ defaults)
+    | `Null ->
+      let defaults = List.filter_map (fun (p : Types.tool_param) ->
+        if p.required then None else Some (p.name, default_for p)
+      ) schema.parameters in
+      `Assoc defaults
+    | other -> other
+  in
+  { name = "default_injection"; apply }
 
-let default_injection_stage = {
-  name = "default_injection";
-  apply = default_injection_apply;
-}
+let default_injection_stage = make_default_injection_stage ()
 
 (* ── Stage 3: Format Normalization ──────────────────────── *)
 

--- a/lib/correction_pipeline.mli
+++ b/lib/correction_pipeline.mli
@@ -52,6 +52,14 @@ val coercion_stage : stage
 val default_injection_stage : stage
 val format_normalization_stage : stage
 
+(** Zero-value default for a param_type (e.g. String → [""], Integer → [0]). *)
+val zero_default : Types.param_type -> Yojson.Safe.t
+
+(** Build a default injection stage with custom per-field defaults.
+    [?default_for] receives the full [tool_param] so it can branch on name or type. *)
+val make_default_injection_stage :
+  ?default_for:(Types.tool_param -> Yojson.Safe.t) -> unit -> stage
+
 (** The default pipeline: [coercion; default_injection; format_normalization]. *)
 val default_stages : stage list
 


### PR DESCRIPTION
## Summary
- `make_default_injection_stage ?default_for ()` factory function
- `zero_default` exported for composition
- Default behavior unchanged (zero values)

## Test plan
- [ ] 12/12 correction pipeline tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)