### PR TITLE
chore: bump sdk_version.ml to 0.119.2 (follow-up to #800)

### DIFF
--- a/lib/sdk_version.ml
+++ b/lib/sdk_version.ml
@@ -1,5 +1,5 @@
 (** Single source of truth for the SDK version string.
     All other modules reference this instead of hardcoding. *)
 
-let version = "0.119.1"
+let version = "0.119.2"
 let sdk_name = "agent_sdk"


### PR DESCRIPTION
## Summary
- bump `lib/sdk_version.ml` from `0.119.1` to `0.119.2` to match `dune-project` and `agent_sdk.opam`

## Why
PR #800 (`chore: bump version to 0.119.2`) updated `dune-project` and `agent_sdk.opam` but left `lib/sdk_version.ml` at `0.119.1`. The Version Consistency CI job compares the two and exits non-zero:

```
dune-project version: 0.119.2
sdk_version.ml version: 0.119.1
ERROR: dune-project (0.119.2) != agent_sdk.ml (0.119.1)
```

Every PR opened after `726b7e6` now fails the merge-commit Version Consistency check on first CI run. Observed in flight on #798.

## Scope
One-character change. No logic affected. `lib/sdk_version.ml` is the single source of truth for the runtime version string, imported by everything else that reports version.

## Test plan
- [x] `dune build --root .` clean
- [ ] Version Consistency CI: pass after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
