### PR TITLE
feat(metrics): add on_http_status hook for provider response counters

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -87,13 +87,32 @@ let patch_telemetry (resp : Types.api_response) ~(config : Provider_config.t)
   in
   { resp with telemetry }
 
-let complete_http ~sw ~net ~(config : Provider_config.t)
-    ~(messages : Types.message list) ~tools =
+(** Internal helper: canonical provider name for metric labels.
+    Kept in sync with the log tag used by the [WARN Complete] line. *)
+let provider_name_of_kind : Provider_config.provider_kind -> string = function
+  | Ollama -> "ollama"
+  | Anthropic -> "anthropic"
+  | OpenAI_compat -> "openai"
+  | Gemini -> "gemini"
+  | Glm -> "glm"
+  | Claude_code -> "claude_code"
+
+let complete_http ~sw ~net
+    ?(on_http_status : (provider:string -> model_id:string -> status:int -> unit) option)
+    ~(config : Provider_config.t)
+    ~(messages : Types.message list) ~tools () =
   if config.kind = Provider_config.Claude_code then
     (Error (Http_client.NetworkError {
        message = "Claude_code provider requires a transport (use Transport_claude_code.create)" }),
      0)
   else
+  let emit_status code =
+    match on_http_status with
+    | Some cb ->
+      cb ~provider:(provider_name_of_kind config.kind)
+        ~model_id:config.model_id ~status:code
+    | None -> ()
+  in
   let config = apply_sampling_defaults config in
   let body_str = match config.kind with
     | Provider_config.Anthropic ->
@@ -126,13 +145,19 @@ let complete_http ~sw ~net ~(config : Provider_config.t)
       "[WARN] [Complete] pre-flight: unbalanced JSON body (%d bytes, \
        first=%C last=%C) for %s %s\n%!"
       body_len body_str.[0] body_str.[body_len - 1]
-      (match config.kind with Ollama -> "ollama" | Anthropic -> "anthropic" | OpenAI_compat -> "openai" | Gemini -> "gemini" | Glm -> "glm" | Claude_code -> "claude_code") config.model_id;
+      (provider_name_of_kind config.kind) config.model_id;
   let t0 = Unix.gettimeofday () in
   let result =
     match Http_client.post_sync ~sw ~net ~url
             ~headers:config.headers ~body:body_str with
     | Error _ as e -> e
     | Ok (code, body) ->
+        (* Emit status counter as soon as we have a raw HTTP code from
+           the provider, before any body-parse or retry decision. This
+           gives downstream metrics an accurate count of provider
+           responses (success and failure) without inflating from
+           internal retries or body-parse fallbacks. *)
+        emit_status code;
         if code >= 200 && code < 300 then
           try
             match config.kind with
@@ -178,11 +203,7 @@ let complete_http ~sw ~net ~(config : Provider_config.t)
         else begin
           (* Log request body diagnostics on error responses to help debug
              Ollama "closing '}' symbol" and similar body-rejection errors. *)
-          let provider_name = match config.kind with
-            | Ollama -> "ollama" | Anthropic -> "anthropic"
-            | OpenAI_compat -> "openai" | Gemini -> "gemini"
-            | Glm -> "glm" | Claude_code -> "claude_code"
-          in
+          let provider_name = provider_name_of_kind config.kind in
           if code >= 400 then begin
             (* Strong validation: round-trip parse the body we sent.  The
                cheap balanced=true check only inspects first/last char and
@@ -327,7 +348,11 @@ let complete ~sw ~net ?(transport : Llm_transport.t option)
         | Some t ->
           t.complete_sync { Llm_transport.config; messages; tools }
         | None ->
-          let (resp, lat) = complete_http ~sw ~net ~config ~messages ~tools in
+          let (resp, lat) =
+            complete_http ~sw ~net
+              ~on_http_status:m.on_http_status
+              ~config ~messages ~tools ()
+          in
           { Llm_transport.response = resp; latency_ms = lat }
       in
       (match result with
@@ -571,7 +596,7 @@ let make_http_transport ~sw ~net : Llm_transport.t = {
   complete_sync = (fun (req : Llm_transport.completion_request) ->
     let (response, latency_ms) =
       complete_http ~sw ~net ~config:req.config
-        ~messages:req.messages ~tools:req.tools
+        ~messages:req.messages ~tools:req.tools ()
     in
     { Llm_transport.response; latency_ms });
   complete_stream = (fun ~on_event (req : Llm_transport.completion_request) ->

--- a/lib/llm_provider/metrics.ml
+++ b/lib/llm_provider/metrics.ml
@@ -7,6 +7,7 @@ type t = {
   on_request_end: model_id:string -> latency_ms:int -> unit;
   on_error: model_id:string -> error:string -> unit;
   on_cascade_fallback: from_model:string -> to_model:string -> reason:string -> unit;
+  on_http_status: provider:string -> model_id:string -> status:int -> unit;
 }
 
 let noop = {
@@ -16,4 +17,5 @@ let noop = {
   on_request_end = (fun ~model_id:_ ~latency_ms:_ -> ());
   on_error = (fun ~model_id:_ ~error:_ -> ());
   on_cascade_fallback = (fun ~from_model:_ ~to_model:_ ~reason:_ -> ());
+  on_http_status = (fun ~provider:_ ~model_id:_ ~status:_ -> ());
 }

--- a/lib/llm_provider/metrics.mli
+++ b/lib/llm_provider/metrics.mli
@@ -9,7 +9,14 @@
     @since 0.93.1 *)
 
 (** Metrics callback interface. All callbacks are optional — provide [noop]
-    as a default that does nothing. *)
+    as a default that does nothing.
+
+    [on_http_status] fires once per HTTP response from a provider,
+    regardless of whether the call ultimately succeeds or fails, so
+    operators can plot request volume broken down by
+    [{provider, model, status}]. Network/timeout errors that never
+    produced a status do NOT fire this callback — those still surface
+    through [on_error] as before. *)
 type t = {
   on_cache_hit: model_id:string -> unit;
   on_cache_miss: model_id:string -> unit;
@@ -17,6 +24,7 @@ type t = {
   on_request_end: model_id:string -> latency_ms:int -> unit;
   on_error: model_id:string -> error:string -> unit;
   on_cascade_fallback: from_model:string -> to_model:string -> reason:string -> unit;
+  on_http_status: provider:string -> model_id:string -> status:int -> unit;
 }
 
 (** No-op metrics — all callbacks do nothing. *)

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -176,6 +176,7 @@ let test_complete_metrics () =
     let miss_count = ref 0 in
     let start_count = ref 0 in
     let end_count = ref 0 in
+    let status_calls = ref [] in
     let metrics : Metrics.t = {
       on_cache_hit = (fun ~model_id:_ -> incr hit_count);
       on_cache_miss = (fun ~model_id:_ -> incr miss_count);
@@ -183,6 +184,8 @@ let test_complete_metrics () =
       on_request_end = (fun ~model_id:_ ~latency_ms:_ -> incr end_count);
       on_error = (fun ~model_id:_ ~error:_ -> ());
       on_cascade_fallback = (fun ~from_model:_ ~to_model:_ ~reason:_ -> ());
+      on_http_status = (fun ~provider ~model_id ~status ->
+        status_calls := (provider, model_id, status) :: !status_calls);
     } in
     (* No cache provided → on_cache_miss not called *)
     (match Complete.complete ~sw ~net:env#net ~config ~messages ~metrics () with
@@ -191,6 +194,11 @@ let test_complete_metrics () =
        check int "start" 1 !start_count;
        check int "end" 1 !end_count;
        check int "no hit" 0 !hit_count;
+       (* on_http_status fired once with the actual 200 code *)
+       check int "status callback count" 1 (List.length !status_calls);
+       (match !status_calls with
+        | [(_, _, code)] -> check int "status code" 200 code
+        | _ -> fail "expected exactly one status call");
        Eio.Switch.fail sw Exit
      | Error _ -> fail "expected Ok")
   with Exit -> ()
@@ -290,6 +298,7 @@ let test_complete_error_metrics () =
         ~status:`Bad_request "bad" in
     let config = make_config url in
     let error_count = ref 0 in
+    let status_calls = ref [] in
     let metrics : Metrics.t = {
       on_cache_hit = (fun ~model_id:_ -> ());
       on_cache_miss = (fun ~model_id:_ -> ());
@@ -297,11 +306,19 @@ let test_complete_error_metrics () =
       on_request_end = (fun ~model_id:_ ~latency_ms:_ -> ());
       on_error = (fun ~model_id:_ ~error:_ -> incr error_count);
       on_cascade_fallback = (fun ~from_model:_ ~to_model:_ ~reason:_ -> ());
+      on_http_status = (fun ~provider ~model_id ~status ->
+        status_calls := (provider, model_id, status) :: !status_calls);
     } in
     (match Complete.complete ~sw ~net:env#net ~config ~messages ~metrics () with
      | Ok _ -> fail "expected Error"
      | Error _ ->
        check int "error callback" 1 !error_count;
+       (* 400 HTTP response must also emit on_http_status before error fires *)
+       check int "status callback count" 1 (List.length !status_calls);
+       (match !status_calls with
+        | [(_, _, 400)] -> ()
+        | [(_, _, code)] -> fail (Printf.sprintf "expected 400, got %d" code)
+        | _ -> fail "expected exactly one status call");
        Eio.Switch.fail sw Exit)
   with Exit -> ()
 


### PR DESCRIPTION
## Summary
- Add `on_http_status: provider:string -> model_id:string -> status:int -> unit` to `Metrics.t`
- Fire once per HTTP response from a provider, before any body parse or retry decision
- Factor `provider_name_of_kind` out of two existing log sites (no more duplicated match over `Provider_config.provider_kind`)
- Thread the callback through `complete_http` as an optional param
- Backward-compat: `Metrics.noop` includes a noop for the new field; existing callers that don't construct Metrics.t directly are unaffected

## Why
The existing `Metrics.t` exposes `on_request_end` + `on_error` but has no way to count HTTP responses by status code. That makes it impossible to plot "GLM 429 per minute" or "ollama 400 per minute" from a dashboard — exactly the signal needed to validate #793 / #794 / #798 in production.

Currently the only way to know how many 4xx the cascade hit is to grep stderr:

```
[WARN] [Complete] HTTP 429 from glm (model=glm-5.1): req_body=316424 bytes ...
[WARN] [Complete] HTTP 400 from ollama (model=qwen3.5:35b-a3b-nvfp4): ...
```

After this PR, any consumer can register a callback that increments a Prometheus counter labelled by `{provider, model, status}`.

## Scope
- **OAS side only.** This PR exposes the hook and wires it in `complete_http`. It does not construct a Prometheus counter or write to any metric registry — that belongs to the consumer (masc-mcp in our case).
- Follow-up masc-mcp PR will register a `Metrics.t` impl that emits `masc_llm_provider_http_status_total{provider, model, status}` and add a dashboard panel.

## Callback semantics
- Fires **once per HTTP response** received from a provider, including 2xx successes.
- Fires **before** retry decision, so retried requests count multiple times (intentional — operators want to see retry storms).
- Does **NOT** fire on transport errors that never produced an HTTP status (NetworkError, timeout). Those still surface via `on_error` as before.
- `provider` uses the canonical name from the log tag (`ollama`, `anthropic`, `openai`, `gemini`, `glm`, `claude_code`).
- `model_id` is the resolved `Provider_config.model_id`, not a cascade alias.

## Test plan
- [x] `dune build --root .` clean
- [x] `dune exec --root . test/test_complete_http.exe` → 19/19 tests pass
- [x] New assertions in existing metrics tests:
  - successful complete: exactly 1 `on_http_status` call with `status=200`
  - HTTP 400 error: exactly 1 `on_http_status` call with `status=400`, fired before `on_error`
- [ ] After merge + masc-mcp consumer PR: dashboard shows per-provider 4xx count

## Risk
- Every existing `Metrics.t` construction site must add the new field. Search showed exactly two in `test/test_complete_http.ml`; both updated in this PR. If there are downstream consumers outside this repo (unlikely), they will get a compile error and need a trivial one-line fix.
- The `()` final unit arg on `complete_http` changes its signature. Two internal call sites updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
