### PR TITLE
fix(cascade): apply per-model timeout to last provider

### DIFF
--- a/lib/llm_provider/cascade_executor.ml
+++ b/lib/llm_provider/cascade_executor.ml
@@ -10,13 +10,19 @@
     sit idle.  The last provider in the list falls back to blocking to avoid
     an immediate "all failed" error when the system is simply at capacity.
 
-    Per-model timeout: non-last providers are cancelled after
-    [OAS_CASCADE_MODEL_TIMEOUT_SEC] (default 1200s / 20 min) to prevent
-    a single slow model from blocking the entire cascade for hours.
+    Per-model timeout: every provider — including the last — is cancelled
+    after [OAS_CASCADE_MODEL_TIMEOUT_SEC] (default 30s) to prevent a single
+    slow model from blocking the entire cascade. The last provider used to
+    be exempt under the assumption that it was the "final fallback", but
+    that allowed silent hangs of up to the outer adaptive timeout (~1113s
+    for 262K context) when the last provider stalled at the TCP layer. The
+    consumer should set its own wall-clock as the safety net, not rely on
+    the cascade to wait forever.
 
     @since 0.99.5
     @since 0.100.3 slot-full fallthrough for load distribution
-    @since 0.101.0 per-model timeout for non-last providers *)
+    @since 0.101.0 per-model timeout for non-last providers
+    @since 0.119.3 per-model timeout extended to last provider *)
 
 (* ── Per-model timeout ──────────────────────────────────── *)
 
@@ -273,12 +279,20 @@ let complete_cascade_with_accept ~sw ~net ?clock ?cache ?metrics
         Complete.complete ~sw ~net ~config:cfg
           ~messages:effective_messages ~tools ?cache ?metrics ?priority ()
     in
-    (* Wrap non-last providers with a timeout to prevent a single slow
-       model from blocking the cascade for hours.  Last provider has no
-       timeout — it is the final fallback. *)
+    (* Wrap every provider — including the last — with a per-model
+       timeout. The last provider used to be exempt on the theory that
+       it was the "final fallback" and should be allowed to take its
+       time, but in practice an Ollama TCP stall on the last rung
+       blocked masc-mcp keepers for ~1113s (the outer adaptive OAS
+       timeout) before the consumer's wall-clock could fire, producing
+       hundreds of silent 1200s "Turn wall-clock timeout" errors per
+       day. Fast-failing on the last rung surfaces the failure as a
+       cascade NetworkError instead of a 20-minute hang. Set
+       OAS_CASCADE_MODEL_TIMEOUT_SEC=0 to opt out. [is_last] is still
+       used below for the throttle blocking-vs-try-permit decision. *)
     let call_with_timeout () =
       match clock with
-      | Some clock when not is_last && cascade_model_timeout_sec > 0.0 ->
+      | Some clock when cascade_model_timeout_sec > 0.0 ->
         let wrapped () =
           match call () with
           | Ok v -> Ok (Ok v)


### PR DESCRIPTION
## TL;DR

\`oas/lib/llm_provider/cascade_executor.ml:147\` exempts the last provider in any cascade from the \`OAS_CASCADE_MODEL_TIMEOUT_SEC\` enforcement. When the last provider hangs (e.g., Ollama TCP stall, model loading delay, GPU contention), the cascade waits up to the outer adaptive OAS timeout (~1113s for 262K context) before any visible failure. This is the dominant root cause of the masc-mcp keeper \"Turn wall-clock timeout after 1200s\" failures (379 occurrences in 13h).

## Empirical evidence

From \`~/me/.masc/logs/system_log_2026-04-11.jsonl\` running with base path \`/Users/dancer/me\`:

\`\`\`
keeper_llm_bridge: OAS execution cancelled
example: transient network error cascade=keeper_unified retry=2/2 backoff=2s: Timeout: Execution cancelled after 1113.2s
example: Turn wall-clock timeout after 1200s (MASC_KEEPER_TURN_TIMEOUT_SEC)
example: unified turn FAILED cascade=keeper_unified latency=1200051ms
\`\`\`

The 1113s is not a constant — it's masc-mcp's \`env_config_keeper.ml:299-314\` adaptive formula:
\`base(120) + context_time(262 × 1.5 = 393) + turn_time(20 × 30 = 600) = 1113s\`

The 1200s is masc-mcp's \`MASC_KEEPER_TURN_TIMEOUT_SEC\` wall-clock safety net.

After masc-mcp PR #6475 reordered the cascade to \`[glm-coding:4.7, glm-coding:5.1, ollama:35b-a3b]\`, keepers actually reach Ollama on fall-through. Ollama is healthy in synthetic probes (2.79s for 21-tool keeper-shape requests) but in production hangs at the TCP layer often enough to dominate failure stats.

## Root cause

\`\`\`ocaml
(* lib/llm_provider/cascade_executor.ml:147 *)
| Some clock when not is_last && cascade_model_timeout_sec > 0.0 ->
\`\`\`

The \`not is_last\` guard was added in v0.101.0 with the intent \"last provider is the final fallback, let it take its time\". In practice the assumption is wrong:

1. \"Final fallback\" sounds principled but a hung final fallback is worse than no fallback — silent loop vs visible error
2. The cascade has no escape mechanism after the last provider; the consumer (masc-mcp keeper) provides the wall-clock safety net
3. With the wall-clock at 1200s, the system experiences 20-minute hangs followed by brief recovery windows — exactly the pattern users report as \"keeper boots, heartbeats once, then silence\"

## Fix

Drop the \`not is_last\` guard. Every provider now respects \`OAS_CASCADE_MODEL_TIMEOUT_SEC\` (default 30s).

\`\`\`diff
- | Some clock when not is_last && cascade_model_timeout_sec > 0.0 ->
+ | Some clock when cascade_model_timeout_sec > 0.0 ->
\`\`\`

The variable \`is_last\` is still used downstream at line ~165 for the throttle's blocking-vs-try-permit decision, so the binding stays.

## Trade-off

A legitimately slow last provider (large model, slow hardware) will now fast-fail instead of waiting indefinitely. The fast-fail surfaces as a \`NetworkError\` (\"timeout after 30s, cascading to next provider\") and the cascade's retry budget (1) takes one more attempt before propagating to the caller. Worst case: ~60s instead of indefinite hang.

Consumers that genuinely need unbounded wait time can set \`OAS_CASCADE_MODEL_TIMEOUT_SEC=0\` to opt out.

## Tests

\`lib/runtest\` passes. Cascade-relevant suites verified explicitly:
- \`test_cascade\`: 17/17 ✓
- \`test_complete_http\`: 19/19 ✓ (incl. \`named_cascade.{llama, no providers, timeout, reject, from config, stream}\`)
- \`test_api_dispatch\`: 17/17 ✓

No test asserted the \"last provider has no timeout\" behavior, so no test breaks.

## Impact on related work

This PR is independent of and complements:
- masc-mcp PR #6475 (cascade reorder to glm-coding first) — already merged, fixed routing
- OAS PR #795 (\`fix(retry): extract flat error strings\`) — already merged, fixed GLM body parser
- OAS PR #799 (this PR's sibling) — separately scoped to \`request_priority.ml\` ppx_inline_test cleanup
- The keeper-side require_tool_use violations (273, frozen) require a separate Strategy B/C/D fix not addressed here

After this PR merges + masc-mcp bumps the OAS pin + masc-mcp server restart:
- Wall-clock 1200s timeouts should drop to near-zero
- Failed Ollama calls should fast-fail in 30s instead of 1113s
- Recovery oscillations should compress from 20-minute cycles to 30-second cycles

## Test plan

- [x] \`dune build --root .\` clean
- [x] \`dune build --root . @lib/runtest\` exit 0
- [x] cascade/complete_http/api_dispatch suites verified
- [ ] CI green
- [ ] After merge: bump masc-mcp OAS pin + observe \`Turn wall-clock timeout\` count drop in keeper logs

🤖 Generated with [Claude Code](https://claude.com/claude-code) (loop cycle 4)