### PR TITLE
feat(metrics): add process-wide global registry for Metrics.t

### DIFF
--- a/lib/api.ml
+++ b/lib/api.ml
@@ -13,7 +13,7 @@ type named_cascade = {
 type response_accept = Types.api_response -> (unit, string) result
 
 let named_cascade ?config_path ?metrics ?provider_filter ~name ~defaults () =
-  let metrics = match metrics with Some m -> m | None -> Llm_provider.Metrics.noop in
+  let metrics = match metrics with Some m -> m | None -> Llm_provider.Metrics.get_global () in
   { name; defaults; config_path; metrics; provider_filter }
 
 (* Re-export Api_common *)

--- a/lib/llm_provider/cascade_executor.ml
+++ b/lib/llm_provider/cascade_executor.ml
@@ -124,7 +124,7 @@ let complete_cascade_with_accept ~sw ~net ?clock ?cache ?metrics
     ?throttle ?priority ?(accept_on_exhaustion = false)
     ~accept (providers : Provider_config.t list)
     ~(messages : Types.message list) ~(tools : Yojson.Safe.t list) =
-  let m = match metrics with Some m -> m | None -> Metrics.noop in
+  let m = match metrics with Some m -> m | None -> Metrics.get_global () in
   diag "debug" "cascade_accept_start"
     [("providers", string_of_int (List.length providers));
      ("accept_on_exhaustion", string_of_bool accept_on_exhaustion)];
@@ -269,7 +269,7 @@ let complete_cascade_stream ~sw ~net ?(metrics : Metrics.t option)
     (providers : Provider_config.t list)
     ~(messages : Types.message list) ~(tools : Yojson.Safe.t list)
     ~(on_event : Types.sse_event -> unit) =
-  let m = match metrics with Some m -> m | None -> Metrics.noop in
+  let m = match metrics with Some m -> m | None -> Metrics.get_global () in
   let try_one ~is_last (cfg : Provider_config.t) =
     let call () =
       Complete.complete_stream ~sw ~net ~config:cfg

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -315,7 +315,7 @@ let complete ~sw ~net ?(transport : Llm_transport.t option)
     ?(cache : Cache.t option) ?(metrics : Metrics.t option)
     ?(priority : Request_priority.t option) () =
   let _priority = priority in
-  let m = match metrics with Some m -> m | None -> Metrics.noop in
+  let m = match metrics with Some m -> m | None -> Metrics.get_global () in
   let model_id = config.model_id in
   (* Cache lookup *)
   (* Compute fingerprint once; reuse for both lookup and store *)
@@ -442,7 +442,7 @@ let complete_cascade ~sw ~net ?transport ?clock ?retry_config:_
     ~(cascade : cascade)
     ~(messages : Types.message list) ?(tools=[])
     ?cache ?metrics ?priority () =
-  let m = match metrics with Some m -> m | None -> Metrics.noop in
+  let m = match metrics with Some m -> m | None -> Metrics.get_global () in
   let try_provider cfg =
     match clock with
     | Some clock ->
@@ -618,7 +618,7 @@ let complete_stream_cascade ~sw ~net ?transport
     ~(on_event : Types.sse_event -> unit)
     ?(metrics : Metrics.t option)
     ?(priority : Request_priority.t option) () =
-  let m = match metrics with Some m -> m | None -> Metrics.noop in
+  let m = match metrics with Some m -> m | None -> Metrics.get_global () in
   let try_provider cfg =
     complete_stream ~sw ~net ?transport ~config:cfg ~messages ~tools ~on_event ?priority ()
   in

--- a/lib/llm_provider/metrics.ml
+++ b/lib/llm_provider/metrics.ml
@@ -19,3 +19,19 @@ let noop = {
   on_cascade_fallback = (fun ~from_model:_ ~to_model:_ ~reason:_ -> ());
   on_http_status = (fun ~provider:_ ~model_id:_ ~status:_ -> ());
 }
+
+(* ── Global registry ────────────────────────────────── *)
+
+(** Process-wide metrics sink used when a caller does not pass [~metrics]
+    explicitly.  Initialised to [noop].  Consumers (masc-mcp, custom
+    deployments) can install their own instance once at startup via
+    [set_global].
+
+    Access is guarded by an atomic so reads from a fiber holding the
+    cached reference race-cleanly with a concurrent [set_global]; the
+    reference itself is immutable once published. *)
+let _global : t Atomic.t = Atomic.make noop
+
+let set_global (m : t) : unit = Atomic.set _global m
+
+let get_global () : t = Atomic.get _global

--- a/lib/llm_provider/metrics.mli
+++ b/lib/llm_provider/metrics.mli
@@ -29,3 +29,18 @@ type t = {
 
 (** No-op metrics — all callbacks do nothing. *)
 val noop : t
+
+(** Install a process-wide metrics sink.  When a caller invokes
+    {!Complete.complete} (or a wrapper) without passing [~metrics]
+    explicitly, the value installed here is used instead of {!noop}.
+
+    Intended to be called once at startup from the host application
+    (e.g. masc-mcp installs a Prometheus-backed instance). Thread-safe:
+    a concurrent [set_global] is published atomically; fibers already
+    holding the previous reference continue to use it until their
+    current call returns. *)
+val set_global : t -> unit
+
+(** Read the current process-wide metrics sink.  Returns {!noop}
+    unless {!set_global} has been called. *)
+val get_global : unit -> t

--- a/lib/llm_provider/metrics.mli
+++ b/lib/llm_provider/metrics.mli
@@ -34,11 +34,19 @@ val noop : t
     {!Complete.complete} (or a wrapper) without passing [~metrics]
     explicitly, the value installed here is used instead of {!noop}.
 
+    Initialization ordering: {!Complete.complete} resolves
+    [get_global ()] at call time, so each call re-reads whatever sink
+    is currently installed — subsequent calls after [set_global] see
+    the new value.  The only window where callers observe [noop] is
+    for HTTP calls issued *before* the host has run its startup
+    [set_global]; install the sink as early in bootstrap as possible
+    (before any keeper/agent cascade traffic) to avoid that gap.
+
     Intended to be called once at startup from the host application
     (e.g. masc-mcp installs a Prometheus-backed instance). Thread-safe:
-    a concurrent [set_global] is published atomically; fibers already
-    holding the previous reference continue to use it until their
-    current call returns. *)
+    a concurrent [set_global] is published atomically via [Atomic.set];
+    fibers already holding the previous reference continue to use it
+    until their current call returns. *)
 val set_global : t -> unit
 
 (** Read the current process-wide metrics sink.  Returns {!noop}

--- a/lib/sdk_version.ml
+++ b/lib/sdk_version.ml
@@ -1,5 +1,5 @@
 (** Single source of truth for the SDK version string.
     All other modules reference this instead of hardcoding. *)
 
-let version = "0.119.2"
+let version = "0.120.0"
 let sdk_name = "agent_sdk"

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -322,6 +322,58 @@ let test_complete_error_metrics () =
        Eio.Switch.fail sw Exit)
   with Exit -> ()
 
+(* ── Global metrics registry ──────────────────────────── *)
+
+let test_metrics_global_default_is_noop () =
+  let g = Metrics.get_global () in
+  (* Default state: the noop callbacks should not raise and should be
+     distinguishable by reference from a custom instance below. *)
+  g.on_cache_hit ~model_id:"m";
+  g.on_request_end ~model_id:"m" ~latency_ms:1;
+  g.on_http_status ~provider:"ollama" ~model_id:"m" ~status:200;
+  (* No side effects observable. *)
+  check bool "default global accepts noop calls" true true
+
+let test_metrics_global_set_and_get () =
+  let hits = ref 0 in
+  let previous = Metrics.get_global () in
+  let custom : Metrics.t = {
+    Metrics.noop with
+    on_http_status = (fun ~provider:_ ~model_id:_ ~status:_ -> incr hits);
+  } in
+  Metrics.set_global custom;
+  let g = Metrics.get_global () in
+  g.on_http_status ~provider:"ollama" ~model_id:"m" ~status:429;
+  g.on_http_status ~provider:"glm" ~model_id:"m" ~status:429;
+  check int "global metric fired twice" 2 !hits;
+  (* Restore to noop so other tests in the same process see a clean slate. *)
+  Metrics.set_global previous
+
+let test_metrics_global_used_when_no_per_call_metrics () =
+  Eio_main.run @@ fun env ->
+  try
+    Eio.Switch.run @@ fun sw ->
+    let url = start_mock_server ~sw ~net:env#net
+        (anthropic_response "global metrics test") in
+    let config = make_config url in
+    let status_calls = ref [] in
+    let previous = Metrics.get_global () in
+    let bridge : Metrics.t = {
+      Metrics.noop with
+      on_http_status = (fun ~provider ~model_id ~status ->
+        status_calls := (provider, model_id, status) :: !status_calls);
+    } in
+    Metrics.set_global bridge;
+    Fun.protect ~finally:(fun () -> Metrics.set_global previous)
+      (fun () ->
+        (* Deliberately do NOT pass ~metrics — global should take effect. *)
+        match Complete.complete ~sw ~net:env#net ~config ~messages () with
+        | Ok _ ->
+          check int "global on_http_status fired once" 1 (List.length !status_calls);
+          Eio.Switch.fail sw Exit
+        | Error _ -> fail "expected Ok")
+  with Exit -> ()
+
 (* ── complete_stream: SSE ─────────────────────────────── *)
 
 let anthropic_sse_response text =
@@ -592,6 +644,10 @@ let () =
     "metrics", [
       test_case "callbacks" `Quick test_complete_metrics;
       test_case "error callback" `Quick test_complete_error_metrics;
+      test_case "global default is noop" `Quick test_metrics_global_default_is_noop;
+      test_case "global set and get" `Quick test_metrics_global_set_and_get;
+      test_case "global used when no per-call metrics" `Quick
+        test_metrics_global_used_when_no_per_call_metrics;
     ];
     "retry", [
       test_case "first try ok" `Quick test_retry_first_try;

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -337,17 +337,20 @@ let test_metrics_global_default_is_noop () =
 let test_metrics_global_set_and_get () =
   let hits = ref 0 in
   let previous = Metrics.get_global () in
-  let custom : Metrics.t = {
-    Metrics.noop with
-    on_http_status = (fun ~provider:_ ~model_id:_ ~status:_ -> incr hits);
-  } in
-  Metrics.set_global custom;
-  let g = Metrics.get_global () in
-  g.on_http_status ~provider:"ollama" ~model_id:"m" ~status:429;
-  g.on_http_status ~provider:"glm" ~model_id:"m" ~status:429;
-  check int "global metric fired twice" 2 !hits;
-  (* Restore to noop so other tests in the same process see a clean slate. *)
-  Metrics.set_global previous
+  (* Fun.protect guarantees the global is restored even if a check
+     assertion raises inside the body, preventing cross-test pollution
+     through the shared process-wide sink. *)
+  Fun.protect ~finally:(fun () -> Metrics.set_global previous)
+    (fun () ->
+      let custom : Metrics.t = {
+        Metrics.noop with
+        on_http_status = (fun ~provider:_ ~model_id:_ ~status:_ -> incr hits);
+      } in
+      Metrics.set_global custom;
+      let g = Metrics.get_global () in
+      g.on_http_status ~provider:"ollama" ~model_id:"m" ~status:429;
+      g.on_http_status ~provider:"glm" ~model_id:"m" ~status:429;
+      check int "global metric fired twice" 2 !hits)
 
 let test_metrics_global_used_when_no_per_call_metrics () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary
- Add `Metrics.set_global` / `Metrics.get_global` — a process-wide Metrics.t sink installed once at startup
- Any call to `Complete.complete`, `Cascade_executor.complete_cascade_*`, or `Api.named_cascade` that doesn't pass `~metrics` explicitly now falls back to `get_global ()` instead of `noop`
- Default is `noop` — existing callers see no behaviour change
- 3 new tests (default noop, set/get round-trip, end-to-end complete flow without per-call metrics)

## Why
[#804](https://github.com/jeong-sik/oas/pull/804) added `on_http_status` to `Metrics.t` so consumers can count HTTP responses by `{provider, model, status}`. But the callback only fires when the caller threads `~metrics` explicitly through to `Complete.complete`.

Deep call chains — specifically masc-mcp's keeper cascade path, which goes `Keeper_agent_run.run` → OAS `Agent.run` → … → `Complete.complete` — do **not** currently propagate a Metrics.t argument. Without this PR, the only way for masc-mcp to capture keeper-driven HTTP noise is to refactor OAS Agent to accept `?metrics` throughout the turn pipeline.

This registry pattern avoids that refactor. masc-mcp calls `Metrics.set_global Metric_bridge.instance` at server startup, and every HTTP response — including ones from deep keeper call chains — emits the counter.

## Design notes
- Storage is `Atomic.t`, matching the existing `_discovered_ctx` atomic in `discovery.ml`.
- Concurrent `set_global` publishes atomically; fibers already holding the previous reference continue using it until their current call returns — no partial updates mid-flight.
- Callers that explicitly pass `~metrics:Metrics.noop` (tests, benchmarks) bypass the global entirely. The global is never consulted when a per-call value is provided.

## Wiring touchpoints
| File | Change |
|---|---|
| `lib/llm_provider/metrics.ml` / `.mli` | new `set_global` / `get_global` + `_global : t Atomic.t` |
| `lib/llm_provider/complete.ml` | 3 fallback sites: `None -> Metrics.noop` → `None -> Metrics.get_global ()` |
| `lib/llm_provider/cascade_executor.ml` | 2 fallback sites, same pattern |
| `lib/api.ml` `named_cascade` | 1 fallback site |

## Test plan
- [x] `dune build --root .` clean
- [x] `dune exec --root . test/test_complete_http.exe` → **22/22 tests pass** (3 new)
- [x] `default global is noop` — calls on the default instance don't raise
- [x] `global set and get` — custom instance captures 2 `on_http_status` calls
- [x] `global used when no per-call metrics` — end-to-end `Complete.complete` without `~metrics` fires the globally-registered callback exactly once with `status=200`

## Follow-up
masc-mcp consumer PR will:
- bump OAS pin to the commit that includes this PR
- register `masc_llm_provider_http_status_total{provider,model,status}` Prometheus counter
- call `Metrics.set_global Metric_bridge.instance` at server startup
- add a dashboard panel

## Risk
- Shared mutable global state. Normal concerns (test isolation, reentrancy) are addressed by atomic storage + `Fun.protect` in the end-to-end test. Tests that care about global state must save/restore around their block.
- If two host libraries both install their own global, last write wins. Acceptable — OAS is embedded in one host per process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
