### PR TITLE
refactor(tool_schema_gen): structured field_error types for parse errors

### DIFF
--- a/lib/tool_input_validation.mli
+++ b/lib/tool_input_validation.mli
@@ -41,7 +41,12 @@ val format_errors : tool_name:string -> field_error list -> string
 val format_errors_inline :
   tool_name:string -> args:Yojson.Safe.t -> field_error list -> string
 
-(** {1 Low-level helpers (for Correction_pipeline)} *)
+(** {1 Low-level helpers (for Correction_pipeline, Tool_schema_gen)} *)
+
+(** Human-readable description of a JSON value for error messages.
+    E.g. [null], [integer(42)], [string("hello")].
+    @since 0.120.0 *)
+val describe_json_value : Yojson.Safe.t -> string
 
 (** Try to coerce a JSON value to the expected param_type.
     Returns [Some coerced] on success, [None] if not coercible.

--- a/lib/tool_schema_gen.ml
+++ b/lib/tool_schema_gen.ml
@@ -12,7 +12,7 @@ type ('a, _) field_spec = {
   param_type : Types.param_type;
   required : bool;
   description : string;
-  extract : Yojson.Safe.t -> ('a, string) result;
+  extract : Yojson.Safe.t -> ('a, Tool_input_validation.field_error) result;
 }
 
 let make_field name ~typ ~required ~desc ~extract =
@@ -25,14 +25,17 @@ let extract_with_coerce ~name ~typ ~required ~default ~unwrap json =
   let raw = member name json in
   match raw with
   | `Null when not required -> Ok default
-  | `Null -> Error (Printf.sprintf "missing required field: %s" name)
+  | `Null -> Error { Tool_input_validation.path = name;
+                     expected = Types.param_type_to_string typ;
+                     actual = "missing" }
   | v ->
     let coerced = match Tool_input_validation.try_coerce typ v with
       | Some c -> c | None -> v in
     match unwrap coerced with
     | Some a -> Ok a
-    | None -> Error (Printf.sprintf "%s: expected %s, got %s" name
-                       (Types.param_type_to_string typ) (Yojson.Safe.to_string v))
+    | None -> Error { Tool_input_validation.path = name;
+                      expected = Types.param_type_to_string typ;
+                      actual = Tool_input_validation.describe_json_value v }
 
 let string_field name ~required ~desc ?(default = "") () =
   make_field name ~typ:Types.String ~required ~desc
@@ -82,30 +85,28 @@ let to_params : type a. a schema -> Types.tool_param list = function
   | Four (a, b, c, d) -> [field_to_param a; field_to_param b; field_to_param c; field_to_param d]
 
 let collect_errors results =
-  let errors = List.filter_map (function Error e -> Some e | Ok _ -> None) results in
-  match errors with
-  | [] -> None
-  | es -> Some (String.concat "; " es)
+  List.filter_map (function Error e -> Some e | Ok _ -> None) results
 
-let parse : type a. a schema -> Yojson.Safe.t -> (a, string) result =
+let parse : type a. a schema -> Yojson.Safe.t -> (a, Tool_input_validation.field_error list) result =
   fun schema json ->
   match schema with
-  | One a -> a.extract json
+  | One a ->
+    a.extract json |> Result.map_error (fun e -> [e])
   | Two (a, b) ->
     let ra = a.extract json and rb = b.extract json in
     (match ra, rb with
      | Ok va, Ok vb -> Ok (va, vb)
-     | _ -> Error (Option.get (collect_errors [Result.map ignore ra; Result.map ignore rb])))
+     | _ -> Error (collect_errors [Result.map ignore ra; Result.map ignore rb]))
   | Three (a, b, c) ->
     let ra = a.extract json and rb = b.extract json and rc = c.extract json in
     (match ra, rb, rc with
      | Ok va, Ok vb, Ok vc -> Ok (va, vb, vc)
-     | _ -> Error (Option.get (collect_errors [Result.map ignore ra; Result.map ignore rb; Result.map ignore rc])))
+     | _ -> Error (collect_errors [Result.map ignore ra; Result.map ignore rb; Result.map ignore rc]))
   | Four (a, b, c, d) ->
     let ra = a.extract json and rb = b.extract json and rc = c.extract json and rd = d.extract json in
     (match ra, rb, rc, rd with
      | Ok va, Ok vb, Ok vc, Ok vd -> Ok (va, vb, vc, vd)
-     | _ -> Error (Option.get (collect_errors [Result.map ignore ra; Result.map ignore rb; Result.map ignore rc; Result.map ignore rd])))
+     | _ -> Error (collect_errors [Result.map ignore ra; Result.map ignore rb; Result.map ignore rc; Result.map ignore rd]))
 
 let to_json_schema : type a. a schema -> Yojson.Safe.t =
   fun schema -> Types.params_to_input_schema (to_params schema)

--- a/lib/tool_schema_gen.mli
+++ b/lib/tool_schema_gen.mli
@@ -12,7 +12,7 @@
 
       let params = Tool_schema_gen.to_params schema
       let parse json = Tool_schema_gen.parse schema json
-      (* parse returns: (string * string option, string) result *)
+      (* parse returns: (string * string option, field_error list) result *)
     ]}
 
     Each field type maps to a single OCaml type with zero-default for optional:
@@ -86,8 +86,8 @@ val to_params : _ schema -> Types.tool_param list
 
 (** Parse JSON input according to schema.
     Required fields must be present; optional fields default to [None]/zero.
-    Returns typed tuple or error string. *)
-val parse : 'a schema -> Yojson.Safe.t -> ('a, string) result
+    Returns typed tuple or structured field errors. *)
+val parse : 'a schema -> Yojson.Safe.t -> ('a, Tool_input_validation.field_error list) result
 
 (** Generate JSON Schema object for MCP tool registration. *)
 val to_json_schema : _ schema -> Yojson.Safe.t

--- a/test/test_tool_schema_gen.ml
+++ b/test/test_tool_schema_gen.ml
@@ -15,13 +15,16 @@ let test_to_params () =
   Alcotest.(check string) "name" "message" p0.name;
   Alcotest.(check bool) "required" true p0.required
 
+let format_errors errs =
+  Tool_input_validation.format_errors ~tool_name:"test" errs
+
 let test_parse_valid () =
   let json = `Assoc [("message", `String "hello"); ("format", `String "compact")] in
   match Tool_schema_gen.parse broadcast_schema json with
   | Ok (msg, fmt) ->
     Alcotest.(check string) "message" "hello" msg;
     Alcotest.(check string) "format" "compact" fmt
-  | Error e -> Alcotest.fail e
+  | Error errs -> Alcotest.fail (format_errors errs)
 
 let test_parse_optional_missing () =
   let json = `Assoc [("message", `String "hello")] in
@@ -29,13 +32,17 @@ let test_parse_optional_missing () =
   | Ok (msg, fmt) ->
     Alcotest.(check string) "message" "hello" msg;
     Alcotest.(check string) "default format" "" fmt
-  | Error e -> Alcotest.fail e
+  | Error errs -> Alcotest.fail (format_errors errs)
 
 let test_parse_required_missing () =
   let json = `Assoc [("format", `String "compact")] in
   match Tool_schema_gen.parse broadcast_schema json with
   | Ok _ -> Alcotest.fail "expected error"
-  | Error e -> Alcotest.(check bool) "mentions message" true (String.length e > 0)
+  | Error errs ->
+    Alcotest.(check bool) "at least one error" true (List.length errs > 0);
+    let e = List.hd errs in
+    Alcotest.(check string) "path" "message" e.Tool_input_validation.path;
+    Alcotest.(check string) "actual" "missing" e.Tool_input_validation.actual
 
 let test_to_json_schema () =
   let schema_json = Tool_schema_gen.to_json_schema broadcast_schema in
@@ -53,12 +60,12 @@ let int_schema = Tool_schema_gen.(one (int_field "count" ~required:true ~desc:"C
 let test_int_parse () =
   match Tool_schema_gen.parse int_schema (`Assoc [("count", `Int 42)]) with
   | Ok n -> Alcotest.(check int) "count" 42 n
-  | Error e -> Alcotest.fail e
+  | Error errs -> Alcotest.fail (format_errors errs)
 
 let test_int_coercion () =
   match Tool_schema_gen.parse int_schema (`Assoc [("count", `String "7")]) with
   | Ok n -> Alcotest.(check int) "coerced" 7 n
-  | Error e -> Alcotest.fail e
+  | Error errs -> Alcotest.fail (format_errors errs)
 
 (* ── Three-field schema ─────────────────────────────────── *)
 
@@ -74,7 +81,7 @@ let test_triple_parse () =
     Alcotest.(check string) "name" "Alice" name;
     Alcotest.(check int) "age" 30 age;
     Alcotest.(check bool) "active" true active
-  | Error e -> Alcotest.fail e
+  | Error errs -> Alcotest.fail (format_errors errs)
 
 let test_triple_params () =
   Alcotest.(check int) "3 params" 3 (List.length (Tool_schema_gen.to_params triple))
@@ -83,7 +90,11 @@ let test_triple_params () =
 
 let test_typed_tool_integration () =
   let params = Tool_schema_gen.to_params broadcast_schema in
-  let parse = Tool_schema_gen.parse broadcast_schema in
+  let parse json =
+    Tool_schema_gen.parse broadcast_schema json
+    |> Result.map_error (fun errs ->
+      Tool_input_validation.format_errors ~tool_name:"gen_broadcast" errs)
+  in
   let tool = Typed_tool.create
     ~name:"gen_broadcast" ~description:"Generated schema"
     ~params


### PR DESCRIPTION
## Summary
- Replace `('a, string) result` with `('a, field_error list) result` in tool_schema_gen parse
- Reuse `Tool_input_validation.field_error` for consistent error structure
- Per-field errors enable better correction pipeline feedback and LLM retry context
- Expose `describe_json_value` in `.mli` for consistent value descriptions

## Test plan
- [x] 10/10 tool_schema_gen tests pass (error assertions updated)
- [x] 25/25 structured tests pass (independent parse type, no changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)