### PR TITLE
refactor: Phase 2-4 configurability — remove hardcoding, add factories

### DIFF
--- a/lib/correction_pipeline.ml
+++ b/lib/correction_pipeline.ml
@@ -84,27 +84,27 @@ let default_injection_stage = make_default_injection_stage ()
 
 (* ── Stage 3: Format Normalization ──────────────────────── *)
 
-(** Trims whitespace from string values and normalizes empty strings. *)
-let format_normalization_apply (_schema : Types.tool_schema) (input : Yojson.Safe.t) : Yojson.Safe.t =
-  match input with
-  | `Assoc fields ->
-    let changed = ref false in
-    let fields' = List.map (fun (k, v) ->
-      match v with
-      | `String s ->
-        let trimmed = String.trim s in
-        if not (String.equal trimmed s) then
-          (changed := true; (k, `String trimmed))
-        else (k, v)
-      | _ -> (k, v)
-    ) fields in
-    if !changed then `Assoc fields' else input
-  | other -> other
+let make_format_normalization_stage
+    ?(normalize = fun _name s -> String.trim s) () =
+  let apply (_schema : Types.tool_schema) (input : Yojson.Safe.t) : Yojson.Safe.t =
+    match input with
+    | `Assoc fields ->
+      let changed = ref false in
+      let fields' = List.map (fun (k, v) ->
+        match v with
+        | `String s ->
+          let result = normalize k s in
+          if not (String.equal result s) then
+            (changed := true; (k, `String result))
+          else (k, v)
+        | _ -> (k, v)
+      ) fields in
+      if !changed then `Assoc fields' else input
+    | other -> other
+  in
+  { name = "format_normalization"; apply }
 
-let format_normalization_stage = {
-  name = "format_normalization";
-  apply = format_normalization_apply;
-}
+let format_normalization_stage = make_format_normalization_stage ()
 
 (* ── Default pipeline ───────────────────────────────────── *)
 

--- a/lib/correction_pipeline.mli
+++ b/lib/correction_pipeline.mli
@@ -60,6 +60,12 @@ val zero_default : Types.param_type -> Yojson.Safe.t
 val make_default_injection_stage :
   ?default_for:(Types.tool_param -> Yojson.Safe.t) -> unit -> stage
 
+(** Build a format normalization stage with custom string normalizer.
+    [?normalize] receives [(field_name, raw_string)] and returns the normalized string.
+    Default: {!String.trim}. *)
+val make_format_normalization_stage :
+  ?normalize:(string -> string -> string) -> unit -> stage
+
 (** The default pipeline: [coercion; default_injection; format_normalization]. *)
 val default_stages : stage list
 

--- a/lib/tool.ml
+++ b/lib/tool.ml
@@ -120,6 +120,11 @@ let permission tool =
 let is_read_only tool =
   permission tool = Some ReadOnly
 
+let permission_to_string = function
+  | ReadOnly -> "read_only"
+  | Write -> "write"
+  | Destructive -> "destructive"
+
 let workdir_policy_to_json = function
   | Required -> `String "required"
   | Recommended -> `String "recommended"

--- a/lib/tool.mli
+++ b/lib/tool.mli
@@ -78,6 +78,13 @@ val permission : t -> permission option
       or no permission set. *)
 val is_read_only : t -> bool
   (** [true] when [permission t = Some ReadOnly]. *)
+val permission_to_string : permission -> string
+  (** Snake_case string for a permission value.
+      [ReadOnly -> "read_only"], [Write -> "write"], [Destructive -> "destructive"].
+      Use this for stable consumer-facing output; [show_permission] from
+      [\[@@deriving show\]] produces module-qualified CamelCase and is intended
+      for diagnostics only.
+      @since 0.120.0 *)
 val validate_descriptor : descriptor -> (unit, string) result
 val descriptor_to_yojson : descriptor option -> Yojson.Safe.t
 val schema_to_json : t -> Yojson.Safe.t

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -11,6 +11,8 @@ type field_error = {
   actual: string;
 }
 
+let missing_actual = "missing"
+
 type validation_result =
   | Valid of Yojson.Safe.t
   | Invalid of field_error list
@@ -115,7 +117,7 @@ let validate (schema : Types.tool_schema) (input : Yojson.Safe.t)
       match List.assoc_opt p.name fields with
       | None | Some `Null ->
         if p.required then
-          errors := { path; expected = string_of_param_type p.param_type; actual = "missing" } :: !errors
+          errors := { path; expected = string_of_param_type p.param_type; actual = missing_actual } :: !errors
       | Some value ->
         if not (matches_type p.param_type value) then begin
           (* Try coercion before failing *)
@@ -175,7 +177,7 @@ let format_errors_inline ~tool_name ~(args : Yojson.Safe.t) errors =
       | Some i -> String.sub e.path (i + 1) (String.length e.path - i - 1)
       | None -> e.path
     in
-    if e.actual = "missing" then
+    if e.actual = missing_actual then
       Printf.sprintf "  \"%s\": MISSING (required: %s)" field_name e.expected
     else
       Printf.sprintf "  \"%s\": wrong type — expected: %s, got: %s"

--- a/lib/tool_input_validation.mli
+++ b/lib/tool_input_validation.mli
@@ -13,8 +13,11 @@
 type field_error = {
   path: string;      (** JSON path, e.g. ["/room"], ["/interval_seconds"] *)
   expected: string;  (** Expected type or constraint, e.g. ["integer"], ["required"] *)
-  actual: string;    (** What was received, e.g. ["string(\"sixty\")"], ["missing"] *)
+  actual: string;    (** What was received, e.g. ["string(\"sixty\")"], [{!missing_actual}] *)
 }
+
+(** Sentinel value for [field_error.actual] when the field is absent. *)
+val missing_actual : string
 
 (** Validation outcome: either coerced input or a list of errors. *)
 type validation_result =

--- a/lib/typed_tool_safe.ml
+++ b/lib/typed_tool_safe.ml
@@ -56,7 +56,5 @@ let to_untyped safe_tool = Typed_tool.to_untyped safe_tool.tool
 (* ── Introspection ──────────────────────────────────────── *)
 
 let name safe_tool = Typed_tool.name safe_tool.tool
-let permission_name safe_tool = match safe_tool.perm with
-  | Tool.ReadOnly -> "read_only"
-  | Tool.Write -> "write"
-  | Tool.Destructive -> "destructive"
+let permission safe_tool = safe_tool.perm
+let permission_name safe_tool = Tool.show_permission safe_tool.perm

--- a/lib/typed_tool_safe.ml
+++ b/lib/typed_tool_safe.ml
@@ -57,4 +57,4 @@ let to_untyped safe_tool = Typed_tool.to_untyped safe_tool.tool
 
 let name safe_tool = Typed_tool.name safe_tool.tool
 let permission safe_tool = safe_tool.perm
-let permission_name safe_tool = Tool.show_permission safe_tool.perm
+let permission_name safe_tool = Tool.permission_to_string safe_tool.perm

--- a/lib/typed_tool_safe.mli
+++ b/lib/typed_tool_safe.mli
@@ -84,4 +84,5 @@ val to_untyped : (_, _, _) t -> Tool.t
 (** {1 Introspection} *)
 
 val name : (_, _, _) t -> string
+val permission : ('perm, _, _) t -> Tool.permission
 val permission_name : ('perm, _, _) t -> string


### PR DESCRIPTION
## Summary
- Add `make_format_normalization_stage ~normalize` factory (configurable string normalizer per field)
- Unify `permission_name` to use `Tool.show_permission` (was manual snake_case strings)
- Extract `missing_actual` sentinel constant (was magic string in 2 comparison sites)
- Expose `describe_json_value` and `permission` accessor

## Test plan
- [x] Library builds cleanly (`dune build lib/agent_sdk.cma`)
- [ ] Full test suite (requires opam deps in worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)