### PR TITLE
feat(ollama): pin keep_alive=-1 by default to prevent model eviction

### DIFF
--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -42,6 +42,26 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
   (* Ollama defaults to stream=true, so always send explicit value *)
   let body = ("stream", `Bool stream) :: body in
 
+  (* keep_alive: controls how long the model stays loaded in memory after
+     the request. Ollama's default is 5 minutes, which causes models to be
+     unloaded between keeper cycles and re-loaded on demand — slow and
+     eviction-prone when other processes ping different models.
+
+     We default to "-1" (permanent) so the caller's pinned model stays
+     resident. Override via OAS_OLLAMA_KEEP_ALIVE env var ("5m", "0",
+     "-1", duration strings — Ollama accepts any of these).
+
+     Empirical rationale: 2026-04-11 incident where masc-mcp's 35b-a3b
+     model was evicted ~every 30 min because each keeper turn reset
+     keep_alive to the 5m default; concurrent probes from other processes
+     then triggered swap-induced JSON truncation errors. *)
+  let keep_alive =
+    match Sys.getenv_opt "OAS_OLLAMA_KEEP_ALIVE" with
+    | Some v when String.trim v <> "" -> v
+    | _ -> "-1"
+  in
+  let body = ("keep_alive", `String keep_alive) :: body in
+
   let body = match tools with
     | [] -> body
     | ts ->
@@ -166,3 +186,31 @@ let parse_ollama_response json_str =
     usage;
     telemetry;
   }
+
+(* ── Inline tests ────────────────────────────────── *)
+
+[@@@coverage off]
+
+let%test "build_request pins keep_alive=-1 by default" =
+  Unix.putenv "OAS_OLLAMA_KEEP_ALIVE" "";
+  let config = Provider_config.make
+    ~kind:Ollama ~model_id:"qwen3.5:35b-a3b-nvfp4"
+    ~base_url:"http://127.0.0.1:11434" () in
+  let messages = [{ role = User; content = [Text "hi"]; name = None; tool_call_id = None }] in
+  let body = build_request ~config ~messages () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  json |> member "keep_alive" |> to_string = "-1"
+
+let%test "build_request honors OAS_OLLAMA_KEEP_ALIVE override" =
+  Unix.putenv "OAS_OLLAMA_KEEP_ALIVE" "30m";
+  let config = Provider_config.make
+    ~kind:Ollama ~model_id:"qwen3.5:35b-a3b-nvfp4"
+    ~base_url:"http://127.0.0.1:11434" () in
+  let messages = [{ role = User; content = [Text "hi"]; name = None; tool_call_id = None }] in
+  let body = build_request ~config ~messages () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  let result = json |> member "keep_alive" |> to_string = "30m" in
+  Unix.putenv "OAS_OLLAMA_KEEP_ALIVE" "";
+  result

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -191,26 +191,48 @@ let parse_ollama_response json_str =
 
 [@@@coverage off]
 
+(** Run [f] with the [OAS_OLLAMA_KEEP_ALIVE] env var set to [value], then
+    restore the caller's original setting. Guaranteed restore on exception. *)
+let with_keep_alive_env value f =
+  let orig = Sys.getenv_opt "OAS_OLLAMA_KEEP_ALIVE" in
+  let restore () =
+    match orig with
+    | None -> Unix.putenv "OAS_OLLAMA_KEEP_ALIVE" ""
+    | Some v -> Unix.putenv "OAS_OLLAMA_KEEP_ALIVE" v
+  in
+  Fun.protect ~finally:restore (fun () ->
+    Unix.putenv "OAS_OLLAMA_KEEP_ALIVE" value;
+    f ())
+
 let%test "build_request pins keep_alive=-1 by default" =
-  Unix.putenv "OAS_OLLAMA_KEEP_ALIVE" "";
-  let config = Provider_config.make
-    ~kind:Ollama ~model_id:"qwen3.5:35b-a3b-nvfp4"
-    ~base_url:"http://127.0.0.1:11434" () in
-  let messages = [{ role = User; content = [Text "hi"]; name = None; tool_call_id = None }] in
-  let body = build_request ~config ~messages () in
-  let json = Yojson.Safe.from_string body in
-  let open Yojson.Safe.Util in
-  json |> member "keep_alive" |> to_string = "-1"
+  with_keep_alive_env "" (fun () ->
+    let config = Provider_config.make
+      ~kind:Ollama ~model_id:"qwen3.5:35b-a3b-nvfp4"
+      ~base_url:"http://127.0.0.1:11434" () in
+    let messages = [{ role = User; content = [Text "hi"]; name = None; tool_call_id = None }] in
+    let body = build_request ~config ~messages () in
+    let json = Yojson.Safe.from_string body in
+    let open Yojson.Safe.Util in
+    json |> member "keep_alive" |> to_string = "-1")
 
 let%test "build_request honors OAS_OLLAMA_KEEP_ALIVE override" =
-  Unix.putenv "OAS_OLLAMA_KEEP_ALIVE" "30m";
-  let config = Provider_config.make
-    ~kind:Ollama ~model_id:"qwen3.5:35b-a3b-nvfp4"
-    ~base_url:"http://127.0.0.1:11434" () in
-  let messages = [{ role = User; content = [Text "hi"]; name = None; tool_call_id = None }] in
-  let body = build_request ~config ~messages () in
-  let json = Yojson.Safe.from_string body in
-  let open Yojson.Safe.Util in
-  let result = json |> member "keep_alive" |> to_string = "30m" in
-  Unix.putenv "OAS_OLLAMA_KEEP_ALIVE" "";
-  result
+  with_keep_alive_env "30m" (fun () ->
+    let config = Provider_config.make
+      ~kind:Ollama ~model_id:"qwen3.5:35b-a3b-nvfp4"
+      ~base_url:"http://127.0.0.1:11434" () in
+    let messages = [{ role = User; content = [Text "hi"]; name = None; tool_call_id = None }] in
+    let body = build_request ~config ~messages () in
+    let json = Yojson.Safe.from_string body in
+    let open Yojson.Safe.Util in
+    json |> member "keep_alive" |> to_string = "30m")
+
+let%test "build_request whitespace-only env falls back to default" =
+  with_keep_alive_env "   " (fun () ->
+    let config = Provider_config.make
+      ~kind:Ollama ~model_id:"qwen3.5:35b-a3b-nvfp4"
+      ~base_url:"http://127.0.0.1:11434" () in
+    let messages = [{ role = User; content = [Text "hi"]; name = None; tool_call_id = None }] in
+    let body = build_request ~config ~messages () in
+    let json = Yojson.Safe.from_string body in
+    let open Yojson.Safe.Util in
+    json |> member "keep_alive" |> to_string = "-1")


### PR DESCRIPTION
## Summary

`Backend_ollama.build_request` now always sends a `keep_alive` field in the Ollama request body. Default is `"-1"` (permanent). Override via the `OAS_OLLAMA_KEEP_ALIVE` env var — any Ollama-accepted value (`"5m"`, `"30m"`, `"0"`, `"-1"`).

## Empirical rationale (2026-04-11 incident)

masc-mcp's keeper policy pins `qwen3.5:35b-a3b-nvfp4` as the resident Ollama model. An operator manually preloaded with `keep_alive=-1`. But every keeper turn that hits Ollama via OAS **reset `keep_alive` to Ollama's 5-minute default** because this backend did not set the field at all.

Within 5 minutes the model became evictable. When any concurrent process (another Claude session probe, a diagnostic script, a local test) pinged a different Ollama model, the resident `35b-a3b-nvfp4` was unloaded. Subsequent keeper requests then hit the swap window, triggering JSON truncation errors that surface downstream as:

```
Invalid request: {"error":"Value looks like object, but can't find closing '}' symbol"}
```

Counts in masc-mcp's `system_log_2026-04-11.jsonl` so far:
- **1319** occurrences of the truncation-shaped error — clustered around eviction events
- A cron-scheduled `ollama-runtime-truth.sh --repair` gate (me#984) detected drift **twice within ~1 hour** even after an operator preload

This patch is the upstream fix. Without it, even a 1-minute cron repair cadence cannot fully cover the drift window because keeper turns continuously reset the timer.

## Diff (49 +, 1 -)

- Add `keep_alive` to the non-streaming Ollama request body. Env-var-driven default is `"-1"`. Empty/whitespace env values fall back to the default.
- 2 new inline tests:
  - `build_request pins keep_alive=-1 by default`
  - `build_request honors OAS_OLLAMA_KEEP_ALIVE override`

## Test plan

- [x] `dune build --root . lib/llm_provider` — clean
- [x] `dune runtest --root .` — exit 0 (full suite)
- [x] Inline tests:
  - [x] Default: `json.keep_alive == "-1"`
  - [x] Override: `OAS_OLLAMA_KEEP_ALIVE=30m` → `json.keep_alive == "30m"`

## Scope

Non-streaming path only (`Backend_ollama.build_request`, `/api/chat` native endpoint). The streaming path for Ollama falls back to OpenAI-compat (`Backend_openai.build_request`) which uses `/v1/chat/completions`. The OpenAI-compat endpoint does not expose `keep_alive` in the same way; that path is out of scope for this PR. If keeper turns go through the streaming path they still suffer the eviction issue — a follow-up PR may teach the streaming Ollama path to use the native endpoint or inject `keep_alive` alongside.

## Downstream impact

- masc-mcp pins its Ollama model via cascade config today. With this fix, every keeper cycle re-asserts the pin, so the model stays resident as long as masc-mcp keeps sending requests. The cron-based `ollama-runtime-truth` gate (me#984) becomes a secondary safety net rather than the sole enforcement mechanism.
- Operators who want the previous behavior (unload after 5 minutes) explicitly set `OAS_OLLAMA_KEEP_ALIVE=5m`.

## Notes

Pure addition. No existing callers rely on the absent `keep_alive` field. Ollama ignores unrecognized fields gracefully in general, but this one is documented and intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
