### PR TITLE
feat(complete): log base_url + capture body on HTTP 5xx

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -114,6 +114,67 @@ let provider_name_of_kind : Provider_config.provider_kind -> string = function
   | Glm -> "glm"
   | Claude_code -> "claude_code"
 
+(** Strip query string and userinfo from a URL before logging.  Built-in
+    providers use clean URLs, but [custom:model@url] accepts arbitrary
+    user-supplied URLs; a misconfigured one like
+    [https://user:token@api.example.com/v1?token=abc] must not leak the
+    secret to stderr. *)
+let sanitize_url_for_log url =
+  let strip_query s =
+    match String.index_opt s '?' with
+    | Some i -> String.sub s 0 i
+    | None -> s
+  in
+  let strip_userinfo s =
+    (* Only consider the authority segment (between :// and the next /).
+       A literal '@' inside a path is allowed and must not be stripped. *)
+    match String.index_opt s '/' with
+    | None -> s
+    | Some i1 when i1 + 2 > String.length s || s.[i1 + 1] <> '/' -> s
+    | Some i1 ->
+      let authority_start = i1 + 2 in
+      let authority_end =
+        match String.index_from_opt s authority_start '/' with
+        | Some j -> j
+        | None -> String.length s
+      in
+      let authority =
+        String.sub s authority_start (authority_end - authority_start)
+      in
+      (match String.rindex_opt authority '@' with
+       | None -> s
+       | Some k ->
+         let host = String.sub authority (k + 1) (String.length authority - k - 1) in
+         let prefix = String.sub s 0 authority_start in
+         let suffix = String.sub s authority_end (String.length s - authority_end) in
+         prefix ^ host ^ suffix)
+  in
+  strip_query (strip_userinfo url)
+
+let%test "sanitize_url_for_log passthrough plain https" =
+  sanitize_url_for_log "https://api.z.ai/api/coding/paas/v4"
+  = "https://api.z.ai/api/coding/paas/v4"
+
+let%test "sanitize_url_for_log strips query string" =
+  sanitize_url_for_log "https://api.example.com/v1?token=abc"
+  = "https://api.example.com/v1"
+
+let%test "sanitize_url_for_log strips userinfo" =
+  sanitize_url_for_log "https://user:secret@api.example.com/v1"
+  = "https://api.example.com/v1"
+
+let%test "sanitize_url_for_log strips both userinfo and query" =
+  sanitize_url_for_log "https://user:token@api.example.com/v1?key=abc"
+  = "https://api.example.com/v1"
+
+let%test "sanitize_url_for_log preserves path with literal at-sign" =
+  sanitize_url_for_log "https://api.example.com/users/me@org/v1"
+  = "https://api.example.com/users/me@org/v1"
+
+let%test "sanitize_url_for_log handles missing path" =
+  sanitize_url_for_log "https://api.example.com"
+  = "https://api.example.com"
+
 let complete_http ~sw ~net
     ?(on_http_status : (provider:string -> model_id:string -> status:int -> unit) option)
     ~(config : Provider_config.t)
@@ -236,7 +297,8 @@ let complete_http ~sw ~net
             Printf.eprintf
               "[WARN] [Complete] HTTP %d from %s (model=%s base_url=%s): \
                req_body=%d bytes balanced=%b parse_ok=%b resp_body=%s\n%!"
-              code provider_name config.model_id config.base_url
+              code provider_name config.model_id
+              (sanitize_url_for_log config.base_url)
               body_len body_balanced parse_ok
               (if String.length body <= 200 then body
                else String.sub body 0 200 ^ "...");

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -234,9 +234,9 @@ let complete_http ~sw ~net
               with _ -> false
             in
             Printf.eprintf
-              "[WARN] [Complete] HTTP %d from %s (model=%s): \
+              "[WARN] [Complete] HTTP %d from %s (model=%s base_url=%s): \
                req_body=%d bytes balanced=%b parse_ok=%b resp_body=%s\n%!"
-              code provider_name config.model_id
+              code provider_name config.model_id config.base_url
               body_len body_balanced parse_ok
               (if String.length body <= 200 then body
                else String.sub body 0 200 ^ "...");
@@ -262,6 +262,13 @@ let complete_http ~sw ~net
               List.exists (fun n -> contains_substring lower_resp n)
                 ["closing"; "can't find"; "cant find"; "unterminated"; "unexpected character"]
             in
+            (* Any HTTP 5xx is also a strong signal that the request body is
+               worth capturing — the provider accepted the request for
+               parsing but failed to produce a response.  Generic 500s like
+               ZAI's "Operation failed" don't match the parse-complaint
+               substrings above but still indicate content-specific
+               triggers that are only reproducible with the exact payload. *)
+            let server_5xx = code >= 500 && code < 600 in
             (* Body dumps are gated behind an explicit env var because the
                serialized request contains the full prompt + tool context +
                injected memory.  Default OFF — operators must opt in by
@@ -273,7 +280,7 @@ let complete_http ~sw ~net
               | Some v when String.trim v <> "" && String.trim v <> "0" -> true
               | _ -> false
             in
-            if dump_enabled && ((not parse_ok) || server_parse_complaint) then begin
+            if dump_enabled && ((not parse_ok) || server_parse_complaint || server_5xx) then begin
               let now = Unix.gettimeofday () in
               let minute_bucket = int_of_float (now /. 60.0) in
               let safe_model =


### PR DESCRIPTION
## Summary

Two small observability improvements for debugging provider failures.

### 1. `base_url=` in the error log line

`Provider_kind.Glm` collapses `glm-coding` and `glm` registry entries into the same provider label, so the `[WARN] [Complete] HTTP %d from glm (model=...)` line cannot tell an operator whether a failing request went to the Coding Plan endpoint (\`api.z.ai/api/coding/paas/v4\`) or the general endpoint (\`api.z.ai/api/paas/v4\`). Adding `base_url=` makes the distinction immediate.

Observed case: masc-mcp's live `glm-coding:glm-4.7` turns return HTTP 500 \`{\"error\":{\"code\":\"500\",\"message\":\"Operation failed\"}}\`. Disambiguating the endpoint in logs confirms it's coding (and not a 1113 quota on general).

### 2. 5xx opt-in to `OAS_DEBUG_BODY_DUMP`

The dump gate currently fires only when the response body matches \"closing\" / \"can't find\" / \"unterminated\" / \"unexpected character\" — the Ollama JSON-truncation signature. Generic upstream 5xx like the ZAI \"Operation failed\" pass through without dumping, so the request body that triggered the failure is unreachable for offline reproduction.

5xx is a strong content-specific signal: the provider accepted the request for parsing but failed to produce a response. Capturing the body unlocks binary-search root cause analysis for exactly the class of failure this gate was built for.

## Safety envelope (unchanged)

- Still gated on \`OAS_DEBUG_BODY_DUMP\` env var (default OFF).
- Still mode \`0o600\` + \`O_EXCL\` + bounded to one file per provider+model+minute.
- No behaviour change when the env var is unset.

## Test plan

- [x] \`dune build\` — clean.
- [x] \`dune runtest lib/llm_provider\` — green.
- [ ] Post-deploy smoke: enable \`OAS_DEBUG_BODY_DUMP=1\` on a masc-mcp dev instance, trigger a keeper turn, verify \`/tmp/oas-bad-body-glm-glm_4_7-*.json\` appears.

## References

- #794 — original body-dump gate
- masc-mcp#6567 — glm-coding:glm-4.7 HTTP 500 investigation (content-specific trigger, blocked on body capture)
- masc-mcp#6578 — operational fix: drop glm-coding:glm-4.7 from cascade until root cause is confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)