### PR TITLE
fix(pipeline): derive proactive_context_window from model capabilities

### DIFF
--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -510,8 +510,14 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
     context-window size.  Until an explicit context-window value is
     available from configuration or provider/model capabilities, use a
     conservative default. *)
-let proactive_context_window_tokens _agent =
-  128_000
+let proactive_context_window_tokens agent =
+  match agent.options.provider with
+  | Some cfg ->
+    let caps = Provider.capabilities_for_config cfg in
+    (match caps.max_context_tokens with
+     | Some n when n > 0 -> n
+     | _ -> 128_000)
+  | None -> 128_000
 
 (** Apply proactive compaction when context usage exceeds the configured
     watermark ratio, BEFORE hitting the provider limit.  Uses


### PR DESCRIPTION
## Summary

proactive compaction의 context window를 128K 하드코딩에서 모델 capabilities 기반 동적 조회로 변경.

## Problem

`proactive_context_window_tokens`가 128K로 하드코딩되어 있어서, 262K context 모델(Qwen3.5)에서는 usage ratio가 실제의 절반으로 계산됨. 결과적으로 proactive compact이 발동하지 않아 context가 무한히 커지고, 300KB+ 요청으로 Ollama JSON 파싱 실패 또는 timeout 발생.

## Fix

`Provider.capabilities_for_config`로 실제 모델 context window를 가져오고, 없을 때만 128K fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)