### PR TITLE
feat(cascade): per-entry api_key_env override in cascade config

### DIFF
--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -28,6 +28,7 @@ type inference_params = Cascade_config_loader.inference_params = {
 }
 
 let resolve_inference_params = Cascade_config_loader.resolve_inference_params
+let resolve_api_key_env = Cascade_config_loader.resolve_api_key_env
 
 (* ── Provider registry (SSOT: Provider_registry) ─────── *)
 
@@ -81,13 +82,34 @@ let make_custom_config ~temperature ~max_tokens ?system_prompt model_id =
                ?system_prompt
                ())
 
+(** Resolve the effective API key env var name for a provider.
+
+    Checks [api_key_env_overrides] first (wildcard ["*"] then provider name),
+    then falls back to the provider registry default. *)
+let resolve_effective_api_key_env
+    ~(api_key_env_overrides : (string * string) list)
+    ~(provider_name : string)
+    ~(registry_default : string) =
+  match List.assoc_opt provider_name api_key_env_overrides with
+  | Some env -> env
+  | None ->
+    match List.assoc_opt "*" api_key_env_overrides with
+    | Some env -> env
+    | None -> registry_default
+
 (** Build a {!Provider_config.t} from a registry entry. *)
 let make_registry_config ~temperature ~max_tokens ?system_prompt
+    ?(api_key_env_overrides=[])
     ~provider_name ~model_id (entry : Provider_registry.entry) =
   let defaults = entry.defaults in
+  let effective_api_key_env =
+    resolve_effective_api_key_env
+      ~api_key_env_overrides ~provider_name
+      ~registry_default:defaults.api_key_env
+  in
   let api_key =
-    if defaults.api_key_env = "" then ""
-    else Sys.getenv_opt defaults.api_key_env |> Option.value ~default:""
+    if effective_api_key_env = "" then ""
+    else Sys.getenv_opt effective_api_key_env |> Option.value ~default:""
   in
   let headers = headers_with_auth ~kind:defaults.kind ~api_key in
   (* For local providers, resolve "auto" before endpoint selection so that
@@ -198,14 +220,39 @@ let expand_auto_models (strs : string list) : string list =
     | _ -> [ trimmed ]
   ) strs
 
+(** Internal: parse model string with api_key_env override support.
+    Used by cascade execution paths that have resolved overrides from config. *)
+let parse_model_string_with_overrides
+    ~(api_key_env_overrides : (string * string) list)
+    ~temperature ~max_tokens ?system_prompt (s : string)
+    : Provider_config.t option =
+  match split_provider_model (String.trim s) with
+  | None -> None
+  | Some ("custom", model_id) ->
+    make_custom_config ~temperature ~max_tokens ?system_prompt model_id
+  | Some (provider_name, model_id) ->
+    match Provider_registry.find default_registry provider_name with
+    | None -> None
+    | Some entry when not (entry.is_available ()) -> None
+    | Some entry ->
+      Some (make_registry_config ~temperature ~max_tokens ?system_prompt
+              ~api_key_env_overrides ~provider_name ~model_id entry)
+
 let parse_model_strings
     ?(temperature = Constants.Inference.default_temperature)
     ?(max_tokens = Constants.Inference.default_max_tokens)
-    ?system_prompt (strs : string list) : Provider_config.t list =
+    ?system_prompt ?(api_key_env_overrides=[])
+    (strs : string list) : Provider_config.t list =
   let expanded = expand_auto_models strs in
-  List.filter_map
-    (parse_model_string ~temperature ~max_tokens ?system_prompt)
-    expanded
+  if api_key_env_overrides = [] then
+    List.filter_map
+      (parse_model_string ~temperature ~max_tokens ?system_prompt)
+      expanded
+  else
+    List.filter_map
+      (parse_model_string_with_overrides ~api_key_env_overrides
+         ~temperature ~max_tokens ?system_prompt)
+      expanded
 
 (* Health filtering (extracted to Cascade_health_filter) *)
 let is_local_provider = Cascade_health_filter.is_local_provider
@@ -388,8 +435,15 @@ let complete_named ~sw ~net ?clock ?config_path
       Discovery.refresh_and_sync ~sw ~net ~endpoints
     else []
   in
+  (* Resolve per-cascade api_key_env overrides from config *)
+  let api_key_env_overrides =
+    match config_path with
+    | Some path -> resolve_api_key_env ~config_path:path ~name
+    | None -> []
+  in
   let providers =
-    let parsed = parse_model_strings ~temperature ~max_tokens ?system_prompt model_strings in
+    let parsed = parse_model_strings ~temperature ~max_tokens ?system_prompt
+        ~api_key_env_overrides model_strings in
     (* Propagate tool_choice to each provider config so it reaches the
        HTTP body (e.g. "tool_choice": "required" for OpenAI-compatible).
        Without this, tool_choice from Agent hooks is lost in cascade. *)
@@ -456,8 +510,15 @@ let complete_named_stream ~sw ~net ?clock ?config_path
               | Default_fallback -> "default_fallback"
               | Hardcoded_defaults -> "hardcoded_defaults") })
   else
+  (* Resolve per-cascade api_key_env overrides from config *)
+  let api_key_env_overrides =
+    match config_path with
+    | Some path -> resolve_api_key_env ~config_path:path ~name
+    | None -> []
+  in
   let providers =
-    let parsed = parse_model_strings ~temperature ~max_tokens ?system_prompt model_strings in
+    let parsed = parse_model_strings ~temperature ~max_tokens ?system_prompt
+        ~api_key_env_overrides model_strings in
     let with_tc = match tool_choice with
       | Some tc -> List.map (fun (p : Provider_config.t) -> { p with tool_choice = Some tc }) parsed
       | None -> parsed
@@ -897,6 +958,76 @@ let%test "resolve_model_strings_traced returns Hardcoded_defaults on empty confi
       let (_models, source) = resolve_model_strings_traced ~config_path:tmp
         ~name:"missing" ~defaults:["fallback:x"] () in
       source = Hardcoded_defaults))
+
+(* ── resolve_effective_api_key_env inline tests ──────── *)
+
+let%test "resolve_effective_api_key_env provider match" =
+  resolve_effective_api_key_env
+    ~api_key_env_overrides:[("glm", "CUSTOM_KEY")]
+    ~provider_name:"glm"
+    ~registry_default:"ZAI_API_KEY"
+  = "CUSTOM_KEY"
+
+let%test "resolve_effective_api_key_env wildcard match" =
+  resolve_effective_api_key_env
+    ~api_key_env_overrides:[("*", "WILDCARD_KEY")]
+    ~provider_name:"glm"
+    ~registry_default:"ZAI_API_KEY"
+  = "WILDCARD_KEY"
+
+let%test "resolve_effective_api_key_env provider over wildcard" =
+  resolve_effective_api_key_env
+    ~api_key_env_overrides:[("glm", "SPECIFIC"); ("*", "WILDCARD")]
+    ~provider_name:"glm"
+    ~registry_default:"DEFAULT"
+  = "SPECIFIC"
+
+let%test "resolve_effective_api_key_env no match uses registry default" =
+  resolve_effective_api_key_env
+    ~api_key_env_overrides:[("claude", "CLAUDE_KEY")]
+    ~provider_name:"glm"
+    ~registry_default:"ZAI_API_KEY"
+  = "ZAI_API_KEY"
+
+let%test "resolve_effective_api_key_env empty overrides uses registry default" =
+  resolve_effective_api_key_env
+    ~api_key_env_overrides:[]
+    ~provider_name:"glm"
+    ~registry_default:"ZAI_API_KEY"
+  = "ZAI_API_KEY"
+
+let%test "parse_model_strings with empty overrides same as without" =
+  let with_ov = parse_model_strings ~api_key_env_overrides:[] ["llama:qwen"] in
+  let without = parse_model_strings ["llama:qwen"] in
+  List.length with_ov = List.length without
+
+let%test "resolve_api_key_env string format" =
+  Eio_main.run (fun _env ->
+    with_temp_cascade_json {|{"test_api_key_env": "MY_KEY"}|} (fun tmp ->
+      let overrides = resolve_api_key_env ~config_path:tmp ~name:"test" in
+      overrides = [("*", "MY_KEY")]))
+
+let%test "resolve_api_key_env object format" =
+  Eio_main.run (fun _env ->
+    with_temp_cascade_json
+      {|{"test_api_key_env": {"glm": "GLM_KEY", "claude": "CLAUDE_KEY"}}|}
+      (fun tmp ->
+        let overrides = resolve_api_key_env ~config_path:tmp ~name:"test" in
+        List.length overrides = 2
+        && List.assoc_opt "glm" overrides = Some "GLM_KEY"
+        && List.assoc_opt "claude" overrides = Some "CLAUDE_KEY"))
+
+let%test "resolve_api_key_env falls back to default" =
+  Eio_main.run (fun _env ->
+    with_temp_cascade_json {|{"default_api_key_env": "FALLBACK"}|} (fun tmp ->
+      let overrides = resolve_api_key_env ~config_path:tmp ~name:"missing" in
+      overrides = [("*", "FALLBACK")]))
+
+let%test "resolve_api_key_env empty on no match" =
+  Eio_main.run (fun _env ->
+    with_temp_cascade_json {|{"other_field": "x"}|} (fun tmp ->
+      let overrides = resolve_api_key_env ~config_path:tmp ~name:"test" in
+      overrides = []))
 
 (* should_cascade_to_next + has_required_api_key tests
    moved to Cascade_health_filter *)

--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -84,16 +84,25 @@ let make_custom_config ~temperature ~max_tokens ?system_prompt model_id =
 
 (** Resolve the effective API key env var name for a provider.
 
-    Checks [api_key_env_overrides] first (wildcard ["*"] then provider name),
-    then falls back to the provider registry default. *)
+    Checks [api_key_env_overrides] first (exact provider name, then
+    wildcard ["*"]), then falls back to the provider registry default.
+
+    Empty-string entries are treated as absent so a user-provided
+    [{"glm": ""}] falls through to the wildcard and registry default
+    instead of silently disabling auth. *)
 let resolve_effective_api_key_env
     ~(api_key_env_overrides : (string * string) list)
     ~(provider_name : string)
     ~(registry_default : string) =
-  match List.assoc_opt provider_name api_key_env_overrides with
+  let find_non_empty key =
+    match List.assoc_opt key api_key_env_overrides with
+    | Some v when v <> "" -> Some v
+    | _ -> None
+  in
+  match find_non_empty provider_name with
   | Some env -> env
   | None ->
-    match List.assoc_opt "*" api_key_env_overrides with
+    match find_non_empty "*" with
     | Some env -> env
     | None -> registry_default
 
@@ -165,7 +174,8 @@ let make_registry_config ~temperature ~max_tokens ?system_prompt
 let parse_model_string
     ?(temperature = Constants.Inference.default_temperature)
     ?(max_tokens = Constants.Inference.default_max_tokens)
-    ?system_prompt (s : string) : Provider_config.t option =
+    ?system_prompt ?(api_key_env_overrides = [])
+    (s : string) : Provider_config.t option =
   match split_provider_model (String.trim s) with
   | None -> None
   | Some ("custom", model_id) ->
@@ -176,7 +186,7 @@ let parse_model_string
     | Some entry when not (entry.is_available ()) -> None
     | Some entry ->
       Some (make_registry_config ~temperature ~max_tokens ?system_prompt
-              ~provider_name ~model_id entry)
+              ~api_key_env_overrides ~provider_name ~model_id entry)
 
 let parse_model_string_exn
     ?(temperature = Constants.Inference.default_temperature)
@@ -220,39 +230,16 @@ let expand_auto_models (strs : string list) : string list =
     | _ -> [ trimmed ]
   ) strs
 
-(** Internal: parse model string with api_key_env override support.
-    Used by cascade execution paths that have resolved overrides from config. *)
-let parse_model_string_with_overrides
-    ~(api_key_env_overrides : (string * string) list)
-    ~temperature ~max_tokens ?system_prompt (s : string)
-    : Provider_config.t option =
-  match split_provider_model (String.trim s) with
-  | None -> None
-  | Some ("custom", model_id) ->
-    make_custom_config ~temperature ~max_tokens ?system_prompt model_id
-  | Some (provider_name, model_id) ->
-    match Provider_registry.find default_registry provider_name with
-    | None -> None
-    | Some entry when not (entry.is_available ()) -> None
-    | Some entry ->
-      Some (make_registry_config ~temperature ~max_tokens ?system_prompt
-              ~api_key_env_overrides ~provider_name ~model_id entry)
-
 let parse_model_strings
     ?(temperature = Constants.Inference.default_temperature)
     ?(max_tokens = Constants.Inference.default_max_tokens)
-    ?system_prompt ?(api_key_env_overrides=[])
+    ?system_prompt ?(api_key_env_overrides = [])
     (strs : string list) : Provider_config.t list =
   let expanded = expand_auto_models strs in
-  if api_key_env_overrides = [] then
-    List.filter_map
-      (parse_model_string ~temperature ~max_tokens ?system_prompt)
-      expanded
-  else
-    List.filter_map
-      (parse_model_string_with_overrides ~api_key_env_overrides
-         ~temperature ~max_tokens ?system_prompt)
-      expanded
+  List.filter_map
+    (parse_model_string ~temperature ~max_tokens ?system_prompt
+       ~api_key_env_overrides)
+    expanded
 
 (* Health filtering (extracted to Cascade_health_filter) *)
 let is_local_provider = Cascade_health_filter.is_local_provider
@@ -992,6 +979,27 @@ let%test "resolve_effective_api_key_env no match uses registry default" =
 let%test "resolve_effective_api_key_env empty overrides uses registry default" =
   resolve_effective_api_key_env
     ~api_key_env_overrides:[]
+    ~provider_name:"glm"
+    ~registry_default:"ZAI_API_KEY"
+  = "ZAI_API_KEY"
+
+let%test "resolve_effective_api_key_env empty-string provider override falls through to wildcard" =
+  resolve_effective_api_key_env
+    ~api_key_env_overrides:[("glm", ""); ("*", "WILDCARD_KEY")]
+    ~provider_name:"glm"
+    ~registry_default:"ZAI_API_KEY"
+  = "WILDCARD_KEY"
+
+let%test "resolve_effective_api_key_env empty-string wildcard falls through to registry default" =
+  resolve_effective_api_key_env
+    ~api_key_env_overrides:[("*", "")]
+    ~provider_name:"glm"
+    ~registry_default:"ZAI_API_KEY"
+  = "ZAI_API_KEY"
+
+let%test "resolve_effective_api_key_env both empty falls through to registry default" =
+  resolve_effective_api_key_env
+    ~api_key_env_overrides:[("glm", ""); ("*", "")]
     ~provider_name:"glm"
     ~registry_default:"ZAI_API_KEY"
   = "ZAI_API_KEY"

--- a/lib/llm_provider/cascade_config.mli
+++ b/lib/llm_provider/cascade_config.mli
@@ -62,11 +62,19 @@ val parse_model_string_exn :
 val expand_auto_models : string list -> string list
 
 (** Parse multiple model strings, skipping unavailable ones.
-    Internally calls {!expand_auto_models} before parsing. *)
+    Internally calls {!expand_auto_models} before parsing.
+
+    When [api_key_env_overrides] is provided, it overrides the default
+    API key env var for matching providers. The list maps provider names
+    (or ["*"] for all) to env var names. Used by cascade execution paths
+    to apply per-cascade key configuration from cascade.json.
+
+    @since 0.122.0 api_key_env_overrides parameter added *)
 val parse_model_strings :
   ?temperature:float ->
   ?max_tokens:int ->
   ?system_prompt:string ->
+  ?api_key_env_overrides:(string * string) list ->
   string list -> Provider_config.t list
 
 (** {1 JSON Config Loading} *)
@@ -162,6 +170,20 @@ type inference_params = {
     @since 0.89.1 *)
 val resolve_inference_params :
   config_path:string -> name:string -> inference_params
+
+(** Resolve per-cascade API key env var overrides from cascade.json.
+
+    Supports two formats:
+    - String: applies to all providers.
+      [{"{name}_api_key_env": "ZAI_API_KEY_SB"}]
+    - Object: per-provider mapping.
+      [{"{name}_api_key_env": {"glm": "ZAI_API_KEY_SB", "glm-coding": "ZAI_API_KEY_SB"}}]
+
+    Falls back to ["default_api_key_env"], then empty list (use registry defaults).
+
+    @since 0.122.0 *)
+val resolve_api_key_env :
+  config_path:string -> name:string -> (string * string) list
 
 (** {1 Discovery-Aware Health Filtering} *)
 

--- a/lib/llm_provider/cascade_config.mli
+++ b/lib/llm_provider/cascade_config.mli
@@ -42,7 +42,14 @@ val parse_model_string :
   ?temperature:float ->
   ?max_tokens:int ->
   ?system_prompt:string ->
+  ?api_key_env_overrides:(string * string) list ->
   string -> Provider_config.t option
+(** [api_key_env_overrides] defaults to [[]]. When non-empty, it overrides
+    the registry default API key env var for matching providers; see
+    {!parse_model_strings} for format details. Empty-string entries fall
+    through to the next level of the resolution chain.
+
+    @since 0.122.0 api_key_env_overrides parameter added *)
 
 (** Like {!parse_model_string} but returns a [Result] with a diagnostic
     error message explaining why parsing failed (unknown provider, missing

--- a/lib/llm_provider/cascade_config_loader.ml
+++ b/lib/llm_provider/cascade_config_loader.ml
@@ -114,3 +114,36 @@ let resolve_inference_params ~config_path ~name =
       | None -> read_int_field json "default_max_tokens"
     in
     { temperature = temp; max_tokens = max_tok }
+
+(* ── Per-cascade API key env override ────────────────── *)
+
+(** Read an api_key_env override object from JSON.
+
+    The JSON value can be:
+    - A string: applies to all providers in the cascade.
+      [{"{name}_api_key_env": "ZAI_API_KEY_SB"}]
+    - An object mapping provider names to env var names:
+      [{"{name}_api_key_env": {"glm": "ZAI_API_KEY_SB", "glm-coding": "ZAI_API_KEY_SB"}}]
+
+    Returns an association list of [(provider_name, env_var_name)].
+    The special key ["*"] means "all providers". *)
+let read_api_key_env_field json key =
+  let open Yojson.Safe.Util in
+  match json |> member key with
+  | `String s when String.trim s <> "" -> [("*", String.trim s)]
+  | `Assoc pairs ->
+    List.filter_map (fun (k, v) ->
+      match v with
+      | `String s when String.trim s <> "" ->
+        Some (String.lowercase_ascii (String.trim k), String.trim s)
+      | _ -> None
+    ) pairs
+  | _ -> []
+
+let resolve_api_key_env ~config_path ~name =
+  match load_json config_path with
+  | Error _ -> []
+  | Ok json ->
+    match read_api_key_env_field json (name ^ "_api_key_env") with
+    | [] -> read_api_key_env_field json "default_api_key_env"
+    | overrides -> overrides

--- a/lib/llm_provider/cascade_config_loader.mli
+++ b/lib/llm_provider/cascade_config_loader.mli
@@ -34,3 +34,17 @@ type inference_params = {
     3. [None] (caller uses own defaults) *)
 val resolve_inference_params :
   config_path:string -> name:string -> inference_params
+
+(** Resolve per-cascade API key env var overrides from cascade.json.
+
+    Resolution order:
+    1. ["{name}_api_key_env"] from [config_path]
+    2. ["default_api_key_env"] from [config_path]
+    3. Empty list (use provider registry defaults)
+
+    The JSON value can be a string (applies to all providers via ["*"] key)
+    or an object mapping provider names to env var names.
+
+    @since 0.122.0 *)
+val resolve_api_key_env :
+  config_path:string -> name:string -> (string * string) list

--- a/test/test_cascade_config_ext.ml
+++ b/test/test_cascade_config_ext.ml
@@ -193,6 +193,124 @@ let test_load_profile_invalid_json () =
     let models = Cascade_config.load_profile ~config_path:path ~name:"x" in
     check int "invalid json" 0 (List.length models))
 
+(* ── resolve_api_key_env ─────────────────────────────── *)
+
+let test_resolve_api_key_env_string () =
+  Eio_main.run @@ fun _env ->
+  with_temp_file
+    {|{"coding_api_key_env": "ZAI_API_KEY_SB"}|}
+    (fun path ->
+       let overrides =
+         Cascade_config.resolve_api_key_env ~config_path:path ~name:"coding"
+       in
+       check int "one wildcard entry" 1 (List.length overrides);
+       check string "wildcard key" "*" (fst (List.hd overrides));
+       check string "env var" "ZAI_API_KEY_SB" (snd (List.hd overrides)))
+
+let test_resolve_api_key_env_object () =
+  Eio_main.run @@ fun _env ->
+  with_temp_file
+    {|{"coding_api_key_env": {"glm": "ZAI_API_KEY_SB", "glm-coding": "ZAI_API_KEY_CODING"}}|}
+    (fun path ->
+       let overrides =
+         Cascade_config.resolve_api_key_env ~config_path:path ~name:"coding"
+       in
+       check int "two entries" 2 (List.length overrides);
+       check (option string) "glm override" (Some "ZAI_API_KEY_SB")
+         (List.assoc_opt "glm" overrides);
+       check (option string) "glm-coding override" (Some "ZAI_API_KEY_CODING")
+         (List.assoc_opt "glm-coding" overrides))
+
+let test_resolve_api_key_env_fallback_default () =
+  Eio_main.run @@ fun _env ->
+  with_temp_file
+    {|{"default_api_key_env": "MY_DEFAULT_KEY"}|}
+    (fun path ->
+       let overrides =
+         Cascade_config.resolve_api_key_env ~config_path:path ~name:"nonexistent"
+       in
+       check int "falls back to default" 1 (List.length overrides);
+       check string "wildcard" "*" (fst (List.hd overrides));
+       check string "env var" "MY_DEFAULT_KEY" (snd (List.hd overrides)))
+
+let test_resolve_api_key_env_named_priority () =
+  Eio_main.run @@ fun _env ->
+  with_temp_file
+    {|{"coding_api_key_env": "SPECIFIC_KEY", "default_api_key_env": "DEFAULT_KEY"}|}
+    (fun path ->
+       let overrides =
+         Cascade_config.resolve_api_key_env ~config_path:path ~name:"coding"
+       in
+       check string "named takes priority" "SPECIFIC_KEY" (snd (List.hd overrides)))
+
+let test_resolve_api_key_env_empty () =
+  Eio_main.run @@ fun _env ->
+  with_temp_file
+    {|{"other_field": "value"}|}
+    (fun path ->
+       let overrides =
+         Cascade_config.resolve_api_key_env ~config_path:path ~name:"coding"
+       in
+       check int "empty when no match" 0 (List.length overrides))
+
+let test_resolve_api_key_env_nonexistent_file () =
+  Eio_main.run @@ fun _env ->
+  let overrides =
+    Cascade_config.resolve_api_key_env ~config_path:"/nonexistent.json" ~name:"x"
+  in
+  check int "empty on missing file" 0 (List.length overrides)
+
+let test_resolve_api_key_env_empty_string_ignored () =
+  Eio_main.run @@ fun _env ->
+  with_temp_file
+    {|{"coding_api_key_env": ""}|}
+    (fun path ->
+       let overrides =
+         Cascade_config.resolve_api_key_env ~config_path:path ~name:"coding"
+       in
+       check int "empty string ignored" 0 (List.length overrides))
+
+let test_resolve_api_key_env_object_empty_values () =
+  Eio_main.run @@ fun _env ->
+  with_temp_file
+    {|{"coding_api_key_env": {"glm": "", "claude": "VALID_KEY"}}|}
+    (fun path ->
+       let overrides =
+         Cascade_config.resolve_api_key_env ~config_path:path ~name:"coding"
+       in
+       check int "filters empty values" 1 (List.length overrides);
+       check (option string) "claude present" (Some "VALID_KEY")
+         (List.assoc_opt "claude" overrides))
+
+(* ── parse_model_strings with api_key_env_overrides ──── *)
+
+let test_parse_with_wildcard_override () =
+  (* Set a test env var *)
+  Unix.putenv "TEST_OVERRIDE_KEY_1" "test-key-value";
+  let results = Cascade_config.parse_model_strings
+      ~api_key_env_overrides:[("*", "TEST_OVERRIDE_KEY_1")]
+      ["llama:qwen3.5"] in
+  check int "one result" 1 (List.length results);
+  let cfg = List.hd results in
+  (* llama doesn't use api_key, so this is a passthrough test.
+     The key mechanism is tested by the api_key on glm-like providers
+     but we verify the parse itself works with overrides present. *)
+  check string "model_id preserved" "qwen3.5" cfg.model_id
+
+let test_parse_with_provider_override () =
+  Unix.putenv "TEST_OVERRIDE_KEY_2" "provider-specific-key";
+  let results = Cascade_config.parse_model_strings
+      ~api_key_env_overrides:[("llama", "TEST_OVERRIDE_KEY_2")]
+      ["llama:qwen3.5"] in
+  check int "one result" 1 (List.length results);
+  check string "model_id preserved" "qwen3.5" (List.hd results).model_id
+
+let test_parse_empty_overrides_same_as_none () =
+  let with_overrides = Cascade_config.parse_model_strings
+      ~api_key_env_overrides:[] ["llama:qwen"] in
+  let without_overrides = Cascade_config.parse_model_strings ["llama:qwen"] in
+  check int "same length" (List.length without_overrides) (List.length with_overrides)
+
 (* ── Runner ──────────────────────────────────────────── *)
 
 let () =
@@ -229,5 +347,20 @@ let () =
       test_case "non-string items" `Quick test_load_profile_non_string_items;
       test_case "not a list" `Quick test_load_profile_not_list;
       test_case "invalid json" `Quick test_load_profile_invalid_json;
+    ];
+    "resolve_api_key_env", [
+      test_case "string value" `Quick test_resolve_api_key_env_string;
+      test_case "object value" `Quick test_resolve_api_key_env_object;
+      test_case "fallback to default" `Quick test_resolve_api_key_env_fallback_default;
+      test_case "named priority" `Quick test_resolve_api_key_env_named_priority;
+      test_case "empty when no match" `Quick test_resolve_api_key_env_empty;
+      test_case "nonexistent file" `Quick test_resolve_api_key_env_nonexistent_file;
+      test_case "empty string ignored" `Quick test_resolve_api_key_env_empty_string_ignored;
+      test_case "object empty values" `Quick test_resolve_api_key_env_object_empty_values;
+    ];
+    "parse_with_overrides", [
+      test_case "wildcard override" `Quick test_parse_with_wildcard_override;
+      test_case "provider override" `Quick test_parse_with_provider_override;
+      test_case "empty overrides same as none" `Quick test_parse_empty_overrides_same_as_none;
     ];
   ]


### PR DESCRIPTION
## Summary
- Add `api_key_env` override per cascade entry — separate API keys for different tiers (e.g., Coding Plan vs metered)
- Two JSON formats: string (wildcard `*`) or object (per-provider mapping)
- Resolution priority: `{name}_api_key_env` > `default_api_key_env` > registry default
- Env var **name** only, never raw secrets in config files
- 11 alcotest + 9 inline tests

Closes #790

## Config example
```json
{
  "api_key_env": "MY_CUSTOM_KEY",
  "api_key_env": { "glm": "GLM_CODING_KEY", "*": "ZAI_API_KEY" }
}
```

## Test plan
- [x] 36/36 alcotest pass (25 existing + 11 new)
- [x] All inline tests pass
- [x] Library builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)