### PR TITLE
chore(discovery): drop legacy OAS_LOCAL_QWEN_URL env fallback

### DIFF
--- a/lib/defaults.mli
+++ b/lib/defaults.mli
@@ -23,8 +23,8 @@ val float_env_or : float -> string -> float
 val bool_env_or : bool -> string -> bool
 
 (** Local LLM server URL.
-    Reads [OAS_LOCAL_LLM_URL], falling back to [OAS_LOCAL_QWEN_URL],
-    then {!Llm_provider.Constants.Endpoints.default_url}. *)
+    Reads [OAS_LOCAL_LLM_URL], falling back to
+    {!Llm_provider.Constants.Endpoints.default_url}. *)
 val local_llm_url : string
 
 (** Fallback provider name.

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -41,11 +41,8 @@ type endpoint_status = {
 }
 
 let default_endpoint =
-  let primary = Sys.getenv_opt "OAS_LOCAL_LLM_URL" in
-  let legacy = Sys.getenv_opt "OAS_LOCAL_QWEN_URL" in
-  match primary, legacy with
-  | Some v, _ when String.trim v <> "" -> String.trim v
-  | _, Some v when String.trim v <> "" -> String.trim v
+  match Sys.getenv_opt "OAS_LOCAL_LLM_URL" with
+  | Some v when String.trim v <> "" -> String.trim v
   | _ -> Constants.Endpoints.default_url
 
 let ollama_endpoint =

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -40,6 +40,24 @@ type endpoint_status = {
   capabilities: Capabilities.capabilities;
 }
 
+(* [OAS_LOCAL_QWEN_URL] was the original model-specific name for this
+   knob. It was superseded by [OAS_LOCAL_LLM_URL] (same shape, neutral
+   name). If a deployment still has the legacy var set we emit a
+   one-time migration warning to stderr at module-init time so the
+   operator sees it on the next process start, but we do not route to
+   the legacy URL — that would couple the public SDK contract to a
+   model name that isn't part of the endpoint's meaning. Operators
+   should rename their env var; the migration is mechanical. *)
+let () =
+  match Sys.getenv_opt "OAS_LOCAL_QWEN_URL" with
+  | Some v when String.trim v <> "" ->
+    Printf.eprintf
+      "[WARN] [Discovery] OAS_LOCAL_QWEN_URL is set (%s) but has been \
+       removed in favor of OAS_LOCAL_LLM_URL. The legacy value will be \
+       ignored. Rename the env var to migrate.\n%!"
+      (String.trim v)
+  | _ -> ()
+
 let default_endpoint =
   match Sys.getenv_opt "OAS_LOCAL_LLM_URL" with
   | Some v when String.trim v <> "" -> String.trim v

--- a/lib/llm_provider/discovery.mli
+++ b/lib/llm_provider/discovery.mli
@@ -49,8 +49,8 @@ val discover :
   endpoint_status list
 
 (** Canonical local LLM endpoint default.
-    Reads OAS_LOCAL_LLM_URL / OAS_LOCAL_QWEN_URL env vars,
-    falls back to {!Constants.Endpoints.default_url}.
+    Reads [OAS_LOCAL_LLM_URL], falls back to
+    {!Constants.Endpoints.default_url}.
     All local endpoint defaults in llm_provider reference this value. *)
 val default_endpoint : string
 

--- a/test/test_defaults_unit.ml
+++ b/test/test_defaults_unit.ml
@@ -45,9 +45,9 @@ let () =
     "local_llm_url", [
       test_case "default value is localhost:8085" `Quick (fun () ->
         (* local_llm_url is evaluated at module load time, so we check
-           the default value assuming OAS_LOCAL_LLM_URL and OAS_LOCAL_QWEN_URL
-           are not set in the test environment. If they are, this test
-           verifies the actual resolved value is non-empty. *)
+           the default value assuming OAS_LOCAL_LLM_URL is not set in
+           the test environment. If it is, this test verifies the
+           actual resolved value is non-empty. *)
         let url = Defaults.local_llm_url in
         check bool "non-empty" true (String.length url > 0);
         (* Verify it looks like a URL *)


### PR DESCRIPTION
## Summary

Drop `OAS_LOCAL_QWEN_URL` — a legacy model-specific env var name that was kept as a documented fallback in `Discovery.default_endpoint` after `OAS_LOCAL_LLM_URL` superseded it.

## Why this belongs in the cleanup loop

`OAS_LOCAL_QWEN_URL` is exactly the kind of pattern the loop mandate calls out:

1. **Hardcoded model name in a generic knob.** The env var hardcodes "QWEN" into an endpoint config that has nothing to do with which model the server is hosting. A deployment running Gemma or Llama on the same local endpoint would be reading an env var named after a different model family.
2. **Dual env var shape violates the "one knob per concern" principle.** `default_endpoint` was reading two env vars and picking whichever had a non-empty value. The replacement is a single knob with a clear meaning.
3. **Dead surface area in a public SDK.** OAS is a library — every env var it reads is part of its external config contract. Keeping a legacy var around just to avoid breaking a zero-user compat chain bloats that contract.

## Changes

- `lib/llm_provider/discovery.ml` — `default_endpoint` now reads only `OAS_LOCAL_LLM_URL`. The fallback chain is `OAS_LOCAL_LLM_URL → Constants.Endpoints.default_url`.
- `lib/llm_provider/discovery.mli` — doc updated.
- `lib/defaults.mli` — doc updated. The runtime binding at `defaults.ml:56` already delegates to `Discovery.default_endpoint`, so no `.ml` change is needed there.
- `test/test_defaults_unit.ml` — comment updated.

## Scope verification

`rg OAS_LOCAL_QWEN_URL` across the repo before the change returned exactly 4 matches, all of which are in this PR. No docs, no CHANGELOG, no deploy manifests, no shell scripts reference it.

## Test plan

- [x] `dune build --root .` — clean
- [x] `dune runtest test --root .` — green (all test suites pass, including `defaults_unit`)
- [x] `dune runtest lib/llm_provider --root .` — green (inline tests pass)
