### PR TITLE
fix(ollama): serialize keep_alive=-1 as JSON int, not string

### DIFF
--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -55,12 +55,28 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
      model was evicted ~every 30 min because each keeper turn reset
      keep_alive to the 5m default; concurrent probes from other processes
      then triggered swap-induced JSON truncation errors. *)
-  let keep_alive =
+  let keep_alive_raw =
     match Sys.getenv_opt "OAS_OLLAMA_KEEP_ALIVE" with
-    | Some v when String.trim v <> "" -> v
+    | Some v when String.trim v <> "" -> String.trim v
     | _ -> "-1"
   in
-  let body = ("keep_alive", `String keep_alive) :: body in
+  (* Ollama accepts either a bare integer (seconds; -1 = forever, 0 =
+     unload immediately) or a duration string ("30m", "5m0s", ...).
+     The Go server parses string values via [time.ParseDuration], which
+     REJECTS bare integers-as-strings like "-1" with
+     [time: missing unit in duration "-1"] — the exact error we saw
+     1149 times/day in masc-mcp after oas#813 landed.
+
+     So serialise integer-parseable values as JSON ints (including the
+     negative path), and everything else as strings.  Preserves
+     compatibility for "30m"/"5m" etc. while keeping "-1" / "0" /
+     "300" working. *)
+  let keep_alive_json =
+    match int_of_string_opt keep_alive_raw with
+    | Some n -> `Int n
+    | None -> `String keep_alive_raw
+  in
+  let body = ("keep_alive", keep_alive_json) :: body in
 
   let body = match tools with
     | [] -> body
@@ -204,7 +220,7 @@ let with_keep_alive_env value f =
     Unix.putenv "OAS_OLLAMA_KEEP_ALIVE" value;
     f ())
 
-let%test "build_request pins keep_alive=-1 by default" =
+let%test "build_request pins keep_alive=-1 as JSON int by default" =
   with_keep_alive_env "" (fun () ->
     let config = Provider_config.make
       ~kind:Ollama ~model_id:"qwen3.5:35b-a3b-nvfp4"
@@ -213,9 +229,9 @@ let%test "build_request pins keep_alive=-1 by default" =
     let body = build_request ~config ~messages () in
     let json = Yojson.Safe.from_string body in
     let open Yojson.Safe.Util in
-    json |> member "keep_alive" |> to_string = "-1")
+    json |> member "keep_alive" |> to_int = -1)
 
-let%test "build_request honors OAS_OLLAMA_KEEP_ALIVE override" =
+let%test "build_request honors OAS_OLLAMA_KEEP_ALIVE duration string override" =
   with_keep_alive_env "30m" (fun () ->
     let config = Provider_config.make
       ~kind:Ollama ~model_id:"qwen3.5:35b-a3b-nvfp4"
@@ -226,7 +242,18 @@ let%test "build_request honors OAS_OLLAMA_KEEP_ALIVE override" =
     let open Yojson.Safe.Util in
     json |> member "keep_alive" |> to_string = "30m")
 
-let%test "build_request whitespace-only env falls back to default" =
+let%test "build_request honors OAS_OLLAMA_KEEP_ALIVE integer override as JSON int" =
+  with_keep_alive_env "300" (fun () ->
+    let config = Provider_config.make
+      ~kind:Ollama ~model_id:"qwen3.5:35b-a3b-nvfp4"
+      ~base_url:"http://127.0.0.1:11434" () in
+    let messages = [{ role = User; content = [Text "hi"]; name = None; tool_call_id = None }] in
+    let body = build_request ~config ~messages () in
+    let json = Yojson.Safe.from_string body in
+    let open Yojson.Safe.Util in
+    json |> member "keep_alive" |> to_int = 300)
+
+let%test "build_request whitespace-only env falls back to default (-1 as int)" =
   with_keep_alive_env "   " (fun () ->
     let config = Provider_config.make
       ~kind:Ollama ~model_id:"qwen3.5:35b-a3b-nvfp4"
@@ -235,4 +262,4 @@ let%test "build_request whitespace-only env falls back to default" =
     let body = build_request ~config ~messages () in
     let json = Yojson.Safe.from_string body in
     let open Yojson.Safe.Util in
-    json |> member "keep_alive" |> to_string = "-1")
+    json |> member "keep_alive" |> to_int = -1)


### PR DESCRIPTION
## Summary

\`#813\` pinned \`keep_alive=-1\` by default to stop the model from being evicted — right intent. But it serialises the value as **\`String \"-1\"\`**, which Ollama's Go server parses via \`time.ParseDuration\` and rejects:

\`\`\`
Invalid request: time: missing unit in duration \"-1\"
\`\`\`

Masc-mcp's JSONL log today shows **1149 occurrences** of this exact error — every single keeper turn that cascades to \`ollama:qwen3.5:35b-a3b-nvfp4\` fails at request-parse time. The intermittent JSON-truncation bug #813 was written to prevent (\`Value looks like object, but can't find closing '}' symbol\`) has **0 occurrences** today — because the request never reaches the model at all.

Net effect of #813 on current main: turned an occasional eviction bug into a deterministic 100% failure for the Ollama cascade branch.

## Change

One branching point in \`lib/llm_provider/backend_ollama.ml\`. \`int_of_string_opt\` distinguishes:

- \`\"-1\"\`, \`\"0\"\`, \`\"300\"\` → JSON int (Ollama interprets as seconds; \`-1\` = forever)
- \`\"30m\"\`, \`\"5m0s\"\`, \`\"90s\"\` → JSON string (Ollama parses via time.ParseDuration)

Both shapes are documented Ollama API inputs, so this preserves the operator intent from #813 (\"pin permanently\") while landing on the parser branch that actually works.

\`\`\`ocaml
let keep_alive_json =
  match int_of_string_opt keep_alive_raw with
  | Some n -> \`Int n
  | None -> \`String keep_alive_raw
in
let body = (\"keep_alive\", keep_alive_json) :: body in
\`\`\`

## Tests

Updated inline \`%test\` cases in \`backend_ollama.ml\` (4 total):

- default (\`OAS_OLLAMA_KEEP_ALIVE\` unset) → JSON int \`-1\`
- default (whitespace-only env) → JSON int \`-1\`
- override \`\"30m\"\` → JSON string \`\"30m\"\`
- override \`\"300\"\` → JSON int \`300\` (new case, covers positive int path)

Verification:

- [x] \`dune build\` green
- [x] \`dune runtest lib/llm_provider/backend_ollama.ml\` green
- [ ] Post-deploy: masc-mcp log \`grep 'missing unit in duration' system_log_*.jsonl\` should drop from 1149/day to 0

## References

- #813 — initial pin keep_alive=-1 (introduced the string serialization)
- masc-mcp JSONL \`system_log_2026-04-12.jsonl\`: 1149× \"missing unit in duration '-1'\" vs 0× \"can't find closing '}' symbol\"
- Ollama API docs: \`keep_alive\` accepts bare integer (seconds) or duration string

🤖 Generated with [Claude Code](https://claude.com/claude-code)