### PR TITLE
fix(builder): derive context_thresholds fallback from provider capabilities

### DIFF
--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -143,23 +143,14 @@ let with_context_thresholds ~compact_ratio ?context_window_tokens ?prepare_ratio
         per-agent override),
      2. builder's [max_input_tokens] (whole-run input cap),
      3. builder's [max_total_tokens] (whole-run total cap),
-     4. provider capabilities for [b.provider] when set
-        (e.g. claude-opus-4-6 → 1_000_000, glm → 200_000) — this mirrors
-        the [Pipeline.proactive_context_window_tokens] resolution chain
-        added in #815 so the reducer budget agrees with the compaction
-        watermark for the same agent.
-     5. conservative 200_000 literal as final fallback when nothing is
-        known — better to under-report than to assume a giant window
+     4. [Provider.resolve_max_context_tokens] on [b.provider] when set
+        (e.g. a [qwen3*] model_id → 262_144) — this shares the
+        "provider → capabilities → max_context_tokens" resolution with
+        [Pipeline.proactive_context_window_tokens] so the reducer budget
+        and the compaction watermark agree for the same agent.
+     5. conservative 200_000 literal as the final fallback when nothing
+        is known — better to under-report than to assume a giant window
         and skip compaction. *)
-  let from_provider () =
-    match b.provider with
-    | Some cfg ->
-      let caps = Provider.capabilities_for_config cfg in
-      (match caps.max_context_tokens with
-       | Some n when n > 0 -> n
-       | _ -> 200_000)
-    | None -> 200_000
-  in
   let effective_max = match context_window_tokens with
     | Some n when n > 0 -> n
     | _ ->
@@ -168,7 +159,8 @@ let with_context_thresholds ~compact_ratio ?context_window_tokens ?prepare_ratio
       | _ ->
         match b.max_total_tokens with
         | Some n when n > 0 -> n
-        | _ -> from_provider ()
+        | _ ->
+          Provider.resolve_max_context_tokens ~fallback:200_000 b.provider
   in
   let reducer = Context_reducer.from_context_config ~compact_ratio
     ~max_tokens:effective_max () in

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -138,6 +138,28 @@ let with_tool_retry_policy tool_retry_policy b =
   { b with tool_retry_policy = Some tool_retry_policy }
 let with_context_reducer reducer b = { b with context_reducer = Some reducer }
 let with_context_thresholds ~compact_ratio ?context_window_tokens ?prepare_ratio ?handoff_ratio b =
+  (* Resolution chain for the context window used by the reducer:
+     1. explicit [?context_window_tokens] argument (caller knows the
+        per-agent override),
+     2. builder's [max_input_tokens] (whole-run input cap),
+     3. builder's [max_total_tokens] (whole-run total cap),
+     4. provider capabilities for [b.provider] when set
+        (e.g. claude-opus-4-6 → 1_000_000, glm → 200_000) — this mirrors
+        the [Pipeline.proactive_context_window_tokens] resolution chain
+        added in #815 so the reducer budget agrees with the compaction
+        watermark for the same agent.
+     5. conservative 200_000 literal as final fallback when nothing is
+        known — better to under-report than to assume a giant window
+        and skip compaction. *)
+  let from_provider () =
+    match b.provider with
+    | Some cfg ->
+      let caps = Provider.capabilities_for_config cfg in
+      (match caps.max_context_tokens with
+       | Some n when n > 0 -> n
+       | _ -> 200_000)
+    | None -> 200_000
+  in
   let effective_max = match context_window_tokens with
     | Some n when n > 0 -> n
     | _ ->
@@ -146,7 +168,7 @@ let with_context_thresholds ~compact_ratio ?context_window_tokens ?prepare_ratio
       | _ ->
         match b.max_total_tokens with
         | Some n when n > 0 -> n
-        | _ -> 200_000
+        | _ -> from_provider ()
   in
   let reducer = Context_reducer.from_context_config ~compact_ratio
     ~max_tokens:effective_max () in

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -511,13 +511,7 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
     available from configuration or provider/model capabilities, use a
     conservative default. *)
 let proactive_context_window_tokens agent =
-  match agent.options.provider with
-  | Some cfg ->
-    let caps = Provider.capabilities_for_config cfg in
-    (match caps.max_context_tokens with
-     | Some n when n > 0 -> n
-     | _ -> 128_000)
-  | None -> 128_000
+  Provider.resolve_max_context_tokens ~fallback:128_000 agent.options.provider
 
 (** Apply proactive compaction when context usage exceeds the configured
     watermark ratio, BEFORE hitting the provider limit.  Uses

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -198,6 +198,24 @@ let request_path = function
 let capabilities_for_config (cfg : config) =
   capabilities_for_model ~provider:cfg.provider ~model_id:cfg.model_id
 
+(** Resolve a positive [max_context_tokens] from an optional provider
+    config, falling back to [fallback] when the config is [None] or
+    the capability reports [None]/[<= 0]. Shared by
+    [Pipeline.proactive_context_window_tokens] and
+    [Builder.with_context_thresholds] so both call sites agree on the
+    "provider → capabilities → max_context_tokens" resolution step.
+    Callers still own the literal fallback value because the two sites
+    disagree on it intentionally (Pipeline uses a stricter 128K; Builder
+    uses a looser 200K that plays well with broader token caps). *)
+let resolve_max_context_tokens ~fallback (cfg_opt : config option) =
+  match cfg_opt with
+  | Some cfg ->
+    let caps = capabilities_for_config cfg in
+    (match caps.max_context_tokens with
+     | Some n when n > 0 -> n
+     | _ -> fallback)
+  | None -> fallback
+
 let validate_inference_contract ~capabilities (contract : inference_contract) =
   if modality_supported capabilities contract.modality then Ok ()
   else

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -81,6 +81,20 @@ val modality_of_capabilities : capabilities -> modality
 val default_capabilities : capabilities
 val capabilities_for_model : provider:provider -> model_id:string -> capabilities
 val capabilities_for_config : config -> capabilities
+
+(** Resolve the provider's declared context window from an optional
+    [config], falling back to [~fallback] when the config is [None] or
+    the capability reports [None]/[<= 0].
+
+    Shared by [Pipeline.proactive_context_window_tokens] and
+    [Builder.with_context_thresholds] so both agree on the
+    "provider → capabilities → max_context_tokens" step. The two call
+    sites pass different [~fallback] values intentionally (Pipeline is
+    stricter at 128K, Builder more permissive at 200K).
+
+    @since 0.123.0 *)
+val resolve_max_context_tokens : fallback:int -> config option -> int
+
 val inference_contract_of_model_spec : model_spec -> inference_contract
 val inference_contract_of_config : config -> inference_contract
 val validate_inference_contract :

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -539,9 +539,40 @@ let test_with_context_thresholds_default_fallback () =
     |> Builder.build_safe |> Result.get_ok
   in
   let reducer = Option.get (Agent.options agent).context_reducer in
-  (* budget = 200_000 * 0.5 = 100_000 *)
+  (* No provider set and no explicit tokens — falls through to the
+     literal 200_000 final fallback. budget = 200_000 * 0.5 = 100_000 *)
   Alcotest.(check (option int)) "default fallback 200_000 budget"
     (Some 100_000) (extract_token_budget reducer)
+
+(* --- 30b. with_context_thresholds: fallback via provider capabilities --- *)
+
+let test_with_context_thresholds_fallback_from_provider () =
+  with_net @@ fun net ->
+  (* Construct a Provider.config whose model_id triggers a distinctive
+     max_context_tokens via [Llm_provider.Capabilities.for_model_id].
+     [Local] + [qwen3-35b] routes through the Local branch of
+     [Provider.capabilities_for_model], which calls [for_model_id] and
+     returns [max_context_tokens = Some 262_144] for any [qwen3*]
+     prefix. We deliberately avoid the [Anthropic] branch because it
+     returns the base [anthropic_capabilities] record regardless of
+     [model_id] (separate issue — see capabilities_for_model). *)
+  let provider : Provider.config = {
+    provider = Local { base_url = "http://localhost:11434" };
+    model_id = "qwen3-35b";
+    api_key_env = "DUMMY";
+  } in
+  let agent =
+    Builder.create ~net ~model:"claude-sonnet-4-6"
+    |> Builder.with_provider provider
+    |> Builder.with_context_thresholds ~compact_ratio:0.5
+    |> Builder.build_safe |> Result.get_ok
+  in
+  let reducer = Option.get (Agent.options agent).context_reducer in
+  (* No explicit input/total tokens on the builder, so resolution
+     falls through to the provider-capability branch. qwen3 →
+     max_context_tokens = 262_144, budget = 262_144 * 0.5 = 131_072 *)
+  Alcotest.(check (option int)) "provider-derived fallback budget"
+    (Some 131_072) (extract_token_budget reducer)
 
 (* --- 31. with_context_thresholds: zero/negative context_window_tokens ignored --- *)
 
@@ -732,6 +763,7 @@ let () =
       Alcotest.test_case "context_thresholds input beats total" `Quick test_with_context_thresholds_input_beats_total;
       Alcotest.test_case "context_thresholds fallback max_total" `Quick test_with_context_thresholds_fallback_max_total;
       Alcotest.test_case "context_thresholds default fallback" `Quick test_with_context_thresholds_default_fallback;
+      Alcotest.test_case "context_thresholds fallback from provider" `Quick test_with_context_thresholds_fallback_from_provider;
       Alcotest.test_case "context_thresholds invalid ignored" `Quick test_with_context_thresholds_invalid_ignored;
     ];
     "build", [


### PR DESCRIPTION
## Summary

`Builder.with_context_thresholds` ended its resolution chain with a hardcoded `200_000` literal when none of `context_window_tokens` / `max_input_tokens` / `max_total_tokens` were set. This is the same anti-pattern that #815 addressed in `Pipeline.proactive_context_window_tokens` — a conservative default that silently under-reports the window for any model with a larger context, causing the **reducer budget** to disagree with the **compaction watermark** that #815 already derives from `Provider.capabilities_for_config`.

The disagreement matters: the pipeline decides to compact based on one view of the window, and the reducer trims to a different budget. In practice this means the reducer's target is always 200K (100K after the 0.5 compact ratio) for any agent that didn't set explicit token caps — even when the underlying provider advertises a 262K or 1M window.

## Resolution chain

Before:

1. `?context_window_tokens`
2. `b.max_input_tokens`
3. `b.max_total_tokens`
4. **`200_000` literal** ← regression target

After:

1. `?context_window_tokens`
2. `b.max_input_tokens`
3. `b.max_total_tokens`
4. **`Provider.capabilities_for_config b.provider |> max_context_tokens`** when `b.provider` is set and returns a positive value (mirrors the Pipeline#815 chain)
5. `200_000` literal as the final fallback — only reached when nothing at all is known about the model's window

## Tests

- Existing test 30 (no provider, no tokens → `200_000`) still passes because the final literal is unchanged for that scenario.
- New test 30b uses a `Local` + `qwen3-35b` config, whose `Llm_provider.Capabilities.for_model_id` returns `max_context_tokens = Some 262_144`, and verifies the reducer budget = `262_144 * 0.5 = 131_072`.

## Side observation (not fixed here)

While writing the test I hit a separate latent bug: `Provider.capabilities_for_model` for the `Anthropic` branch returns the base `anthropic_capabilities` record regardless of `model_id`, bypassing the `Llm_provider.Capabilities.for_model_id` lookup. That means `claude-opus-4-6` and `claude-sonnet-4-6` via `Provider.anthropic_{opus,sonnet} ()` currently resolve to `max_context_tokens = 200_000` in the resolver chain even though their real window is `1_000_000`.

This is why the new test uses `Local` + `qwen3-35b` instead of `Provider.anthropic_opus ()` — the Anthropic path would return the same 200K the literal fallback would, making the test unable to distinguish the branches. Worth a separate follow-up PR to make `capabilities_for_model` consult `for_model_id` for the Anthropic branch too (it already does for `Local` and `OpenAICompat`).

## Test plan

- [x] `dune build --root .` — clean
- [x] `dune exec --root . test/test_builder.exe` — 41/41 (40 existing + 1 new)
- [x] `dune runtest test --root .` — full suite green
