### PR TITLE
chore(cascade_config): add n > 0 guard to effective_max_context

### DIFF
--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -250,9 +250,13 @@ let filter_healthy = Cascade_health_filter.filter_healthy
 
 let effective_max_context (entry : Provider_registry.entry)
     (caps : Capabilities.capabilities) =
+  (* Defensive unwrap: treat [Some 0] / negative as absent rather than
+     handing a broken value to downstream budget arithmetic. Aligns with
+     the same guard in [Pipeline.proactive_context_window_tokens] (#815)
+     and [Provider.resolve_max_context_tokens] (#823). *)
   match caps.max_context_tokens with
-  | Some n -> n
-  | None -> entry.max_context
+  | Some n when n > 0 -> n
+  | _ -> entry.max_context
 
 (** Resolve a model label to the per-slot context of the endpoint
     that would serve it.  Uses the same resolution logic as
@@ -956,6 +960,30 @@ let%test "effective_max_context falls back to registry entry" =
   } in
   let caps = { Capabilities.default_capabilities with
                max_context_tokens = None } in
+  effective_max_context entry caps = 128_000
+
+let%test "effective_max_context treats Some 0 as absent and falls back" =
+  let entry : Provider_registry.entry = {
+    name = "test"; max_context = 128_000;
+    defaults = { kind = OpenAI_compat; base_url = ""; api_key_env = "";
+                 request_path = "" };
+    capabilities = Capabilities.default_capabilities;
+    is_available = (fun () -> true);
+  } in
+  let caps = { Capabilities.default_capabilities with
+               max_context_tokens = Some 0 } in
+  effective_max_context entry caps = 128_000
+
+let%test "effective_max_context treats negative as absent and falls back" =
+  let entry : Provider_registry.entry = {
+    name = "test"; max_context = 128_000;
+    defaults = { kind = OpenAI_compat; base_url = ""; api_key_env = "";
+                 request_path = "" };
+    capabilities = Capabilities.default_capabilities;
+    is_available = (fun () -> true);
+  } in
+  let caps = { Capabilities.default_capabilities with
+               max_context_tokens = Some (-1) } in
   effective_max_context entry caps = 128_000
 
 let%test "resolve_model_strings_traced returns Named for existing profile" =


### PR DESCRIPTION
## Summary

Minor defensive hardening to align `Cascade_config.effective_max_context` with the same `n > 0` guard used by `Pipeline.proactive_context_window_tokens` (#815) and `Provider.resolve_max_context_tokens` (#823).

## Why

OAS has three functions that unwrap `caps.max_context_tokens : int option` and substitute a fallback when the value is absent or unusable. After #815 and #823, two of them guard against `Some 0` / negative values explicitly:

```ocaml
match caps.max_context_tokens with
| Some n when n > 0 -> n
| _ -> fallback
```

But `Cascade_config.effective_max_context` was still using the looser `Some n -> n` pattern, so a `Some 0` or `Some (-1)` would propagate into downstream budget arithmetic as a broken value. This PR adds the same guard so all three consumers agree on what "unusable" means.

## Diff

```ocaml
 let effective_max_context (entry : Provider_registry.entry)
     (caps : Capabilities.capabilities) =
+  (* Defensive unwrap: treat [Some 0] / negative as absent rather than
+     handing a broken value to downstream budget arithmetic. Aligns with
+     the same guard in [Pipeline.proactive_context_window_tokens] (#815)
+     and [Provider.resolve_max_context_tokens] (#823). *)
   match caps.max_context_tokens with
-  | Some n -> n
-  | None -> entry.max_context
+  | Some n when n > 0 -> n
+  | _ -> entry.max_context
```

## Tests

Two new inline `let%test` cases:

- `effective_max_context treats Some 0 as absent and falls back`
- `effective_max_context treats negative as absent and falls back`

Both pin that the registry entry's `max_context = 128_000` is returned when the capability is unusable. Existing tests (positive value, `None`) still pass unchanged.

## Observable impact

**None for any real capabilities record.** Every entry in `lib/llm_provider/capabilities.ml` (and every entry in the `for_model_id` lookup table) uses either `None` or a positive integer in the 128K–1M range — `Some 0` and negative values never occur in production data today. This PR hardens against an external consumer (or a future refactor) that might inject one.

## Test plan

- [x] `dune build --root .` — clean
- [x] `dune runtest lib/llm_provider --root .` — green

No `.mli` change. No public API shape change.
