### PR TITLE
refactor(text_estimate): extract canonical CJK-aware estimator to llm_provider

### DIFF
--- a/lib/context_reducer.ml
+++ b/lib/context_reducer.ml
@@ -35,23 +35,13 @@ type t = { strategy : strategy }
 type importance_scorer = index:int -> total:int -> message -> float
 type importance_boost = message -> float option
 
-(** CJK-aware token estimation.
-    ASCII: ~4 chars per token. Multi-byte (CJK, emoji, etc.): ~2/3 token per character.
-    Walks the string byte-by-byte using UTF-8 lead-byte classification. O(n), no allocation. *)
-let estimate_char_tokens (s : string) : int =
-  let len = String.length s in
-  let rec loop i ascii multi =
-    if i >= len then max 1 ((ascii + 3) / 4 + (multi * 2 + 2) / 3)
-    else
-      let byte = Char.code (String.unsafe_get s i) in
-      if byte < 0x80 then loop (i + 1) (ascii + 1) multi
-      else
-        let skip = if byte >= 0xF0 then 4
-                   else if byte >= 0xE0 then 3 else 2 in
-        loop (i + skip) ascii (multi + 1)
-  in
-  if len = 0 then 1
-  else loop 0 0 0
+(** CJK-aware token estimation. Delegates to
+    {!Llm_provider.Text_estimate.estimate_char_tokens}, which is the
+    canonical implementation shared with [Cascade_executor] and
+    [Mcp.truncate_output]. Kept as a top-level binding here so existing
+    call sites like [Context_reducer.estimate_char_tokens] continue to
+    work without renaming. *)
+let estimate_char_tokens = Llm_provider.Text_estimate.estimate_char_tokens
 
 (** Estimate tokens for a single content block.
     Uses CJK-aware estimation for text-based blocks. *)

--- a/lib/llm_provider/cascade_executor.ml
+++ b/lib/llm_provider/cascade_executor.ml
@@ -102,24 +102,12 @@ let default_image_max_tokens = 1600
 let default_document_max_tokens = 3000
 let default_audio_max_tokens = 5000
 
-(** CJK-aware token estimation for a string.  Mirrors
-    [Context_reducer.estimate_char_tokens] — duplicated here because
-    [llm_provider] cannot depend on [agent_sdk] (lib/).
-    ASCII: ~4 chars/token.  Multi-byte (CJK, emoji): ~2/3 token/char. *)
-let estimate_char_tokens (s : string) : int =
-  let len = String.length s in
-  let rec loop i ascii multi =
-    if i >= len then max 1 ((ascii + 3) / 4 + (multi * 2 + 2) / 3)
-    else
-      let byte = Char.code (String.unsafe_get s i) in
-      if byte < 0x80 then loop (i + 1) (ascii + 1) multi
-      else
-        let skip = if byte >= 0xF0 then 4
-                   else if byte >= 0xE0 then 3 else 2 in
-        loop (i + skip) ascii (multi + 1)
-  in
-  if len = 0 then 1
-  else loop 0 0 0
+(** CJK-aware token estimation. Delegates to the canonical
+    implementation in [Text_estimate], same llm_provider library.
+    Shared with [Context_reducer] (lib/) and [Mcp.truncate_output]
+    (lib/protocol/) so every OAS budget calculator uses the same
+    heuristic. *)
+let estimate_char_tokens = Text_estimate.estimate_char_tokens
 
 (** Estimate tokens for a single content block. *)
 let estimate_block_tokens = function

--- a/lib/llm_provider/text_estimate.ml
+++ b/lib/llm_provider/text_estimate.ml
@@ -1,0 +1,79 @@
+(** Text → token count estimation.
+
+    Canonical CJK-aware approximation shared by every OAS subsystem that
+    needs to size a text budget without invoking an actual tokenizer:
+
+    - [Context_reducer] (lib/): message-level budget reduction
+    - [Cascade_executor] (lib/llm_provider/): per-request context trimming
+    - [Mcp.truncate_output] (lib/protocol/): tool-output cap
+
+    Lives in [lib/llm_provider/] so both [agent_sdk] (lib/) and
+    [llm_provider] (lib/llm_provider/) modules can reference the same
+    implementation without duplicating it across the dune library
+    boundary. Prior to this module the function existed as two
+    byte-for-byte identical copies, one in each library.
+
+    @since 0.123.0 *)
+
+(** CJK-aware token estimation.
+
+    ASCII: ~4 chars per token (standard "1 token ≈ 4 characters" rule
+    for English/Latin text).
+    Multi-byte (CJK, emoji, Cyrillic, etc.): ~2/3 token per character
+    (tuned from empirical measurements against real tokenizers — Korean
+    Hangul and CJK ideographs typically tokenize to 1-2 tokens per
+    visible character).
+
+    Walks the input string byte-by-byte, classifying each UTF-8 lead
+    byte by its high bits:
+    - [< 0x80] → ASCII (1-byte sequence)
+    - [>= 0xC0 && < 0xE0] → 2-byte sequence
+    - [>= 0xE0 && < 0xF0] → 3-byte sequence
+    - [>= 0xF0] → 4-byte sequence
+
+    Continuation bytes ([0x80-0xBF]) are not counted separately because
+    the leading byte's [skip] value already advances past them.
+
+    Complexity: O(n) with no allocation. Returns [>= 1] for any
+    non-empty input; empty input returns 1 (avoid zero in downstream
+    divisions). *)
+let estimate_char_tokens (s : string) : int =
+  let len = String.length s in
+  let rec loop i ascii multi =
+    if i >= len then max 1 ((ascii + 3) / 4 + (multi * 2 + 2) / 3)
+    else
+      let byte = Char.code (String.unsafe_get s i) in
+      if byte < 0x80 then loop (i + 1) (ascii + 1) multi
+      else
+        let skip = if byte >= 0xF0 then 4
+                   else if byte >= 0xE0 then 3 else 2 in
+        loop (i + skip) ascii (multi + 1)
+  in
+  if len = 0 then 1
+  else loop 0 0 0
+
+let%test "estimate_char_tokens empty string returns 1" =
+  estimate_char_tokens "" = 1
+
+let%test "estimate_char_tokens pure ASCII rounds up per 4 chars" =
+  (* "hello world" is 11 chars, (11 + 3) / 4 = 3 *)
+  estimate_char_tokens "hello world" = 3
+
+let%test "estimate_char_tokens pure Hangul 5 chars" =
+  (* 안녕하세요: 5 Hangul chars, each 3 bytes. (5 * 2 + 2) / 3 = 4. *)
+  estimate_char_tokens "\xEC\x95\x88\xEB\x85\x95\xED\x95\x98\xEC\x84\xB8\xEC\x9A\x94" = 4
+
+let%test "estimate_char_tokens mixed ASCII and Hangul" =
+  (* "hello " (6 ASCII) + 안녕 (2 Hangul): ascii=6, multi=2.
+     (6+3)/4 + (2*2+2)/3 = 2 + 2 = 4. *)
+  estimate_char_tokens "hello \xEC\x95\x88\xEB\x85\x95" = 4
+
+let%test "estimate_char_tokens 4-byte emoji" =
+  (* 😀😀 two 4-byte emoji, multi=2. (0+3)/4 + (2*2+2)/3 = 0 + 2 = 2. *)
+  estimate_char_tokens "\xF0\x9F\x98\x80\xF0\x9F\x98\x80" = 2
+
+let%test "estimate_char_tokens single ASCII >= 1" =
+  estimate_char_tokens "a" >= 1
+
+let%test "estimate_char_tokens 100 ASCII chars" =
+  estimate_char_tokens (String.make 100 'x') = 25

--- a/lib/llm_provider/text_estimate.mli
+++ b/lib/llm_provider/text_estimate.mli
@@ -1,0 +1,13 @@
+(** CJK-aware text → token count estimation (shared).
+
+    See [text_estimate.ml] for the rationale behind the approximation.
+
+    @since 0.123.0 *)
+
+(** Estimate the token count of a UTF-8 text.
+
+    ASCII characters count at ~4 chars/token; multi-byte UTF-8
+    sequences (CJK, emoji, …) count at ~2/3 token/char. Walks the
+    string once in O(n) time with no allocation. Returns [>= 1] for
+    any input including the empty string. *)
+val estimate_char_tokens : string -> int


### PR DESCRIPTION
## Summary

Third cleanup in the "all budget calculators should share one token estimator" series (#815 → #823 → #826 → #828). Prior to this PR the CJK-aware `estimate_char_tokens` function existed as **two byte-for-byte identical copies**:

- `lib/context_reducer.ml:41` (in `agent_sdk` library)
- `lib/llm_provider/cascade_executor.ml:109` (in `llm_provider` library)

The cascade_executor.ml version explicitly documented the duplication in its own comment:

> "Mirrors [Context_reducer.estimate_char_tokens] — duplicated here because [llm_provider] cannot depend on [agent_sdk] (lib/)."

The right fix is to push the function **down the dependency graph** into the shared `llm_provider` library where both consumers can reference it.

## Changes

### New files

- `lib/llm_provider/text_estimate.ml` — canonical `estimate_char_tokens` + 7 inline tests (pure ASCII, pure Hangul, mixed ASCII/Hangul, 4-byte emoji, 100-char scaling, empty, single char).
- `lib/llm_provider/text_estimate.mli` — `val estimate_char_tokens : string -> int` exported to `Llm_provider.Text_estimate`.

### Edits

- `lib/context_reducer.ml` — `let estimate_char_tokens = Llm_provider.Text_estimate.estimate_char_tokens`. The `Context_reducer.estimate_char_tokens` name is preserved so every existing call site keeps working.
- `lib/llm_provider/cascade_executor.ml` — `let estimate_char_tokens = Text_estimate.estimate_char_tokens`. Same-library reference, no cross-library dependency.

### Not changed

- `lib/protocol/mcp.ml` (from #828) already calls `Context_reducer.estimate_char_tokens`, which now transitively uses `Text_estimate` via the delegation. No source change needed in mcp.ml — the refactor is fully backward-compatible at every existing call site.

## The dependency diagram now

```
lib/llm_provider/text_estimate.ml        ← canonical
   │
   ├── lib/llm_provider/cascade_executor.ml
   ├── lib/context_reducer.ml             (re-exports under same name)
   │      │
   │      └── lib/protocol/mcp.ml         (via Context_reducer.estimate_char_tokens)
```

All three OAS budget calculators now agree on a single 20-line implementation instead of two copies + one indirect caller. The drift risk called out in the original `cascade_executor` comment is eliminated.

## Test plan

- [x] `dune build --root .` — clean
- [x] `dune runtest test --root .` — full suite green
- [x] `test_context_reducer.ml` — 47/47 (including the pure-ASCII / pure-CJK / mixed / emoji test cases that were the regression pins for this function)
- [x] `test_mcp_deep.ml` — 24/24 (the truncate_output tests that exercise the full estimate → truncate pipeline)
- [x] `test_mcp.ml` — 23/23
- [x] `test_mcp_coverage.ml` — 22/22
- [x] `text_estimate.ml` — 7 new inline tests

Total: ~123 test cases exercising the estimator directly or transitively, all green.
