### PR TITLE
fix(backend_openai): gate min_p/top_k on capabilities.supports_* (closes #827)

### DIFF
--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -62,13 +62,25 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
     | Some p -> ("top_p", `Float p) :: body
     | None -> body
   in
+  (* Look up per-model capabilities once — the sampling params below
+     rely on [supports_top_k] / [supports_min_p] to decide whether the
+     server will accept the field.  If no capability record exists for
+     the model, default to NOT sending the non-standard sampling
+     params; conservative because misclassified providers (GLM, Gemini,
+     ...) previously silently inherited [config.min_p]/[config.top_k]
+     from the agent config and triggered hard 400s at the server. *)
+  let caps =
+    match Capabilities.for_model_id config.model_id with
+    | Some c -> c
+    | None -> Capabilities.default_capabilities
+  in
   let body = match config.top_k with
-    | Some k -> ("top_k", `Int k) :: body
-    | None -> body
+    | Some k when caps.supports_top_k -> ("top_k", `Int k) :: body
+    | _ -> body
   in
   let body = match config.min_p with
-    | Some p -> ("min_p", `Float p) :: body
-    | None -> body
+    | Some p when caps.supports_min_p -> ("min_p", `Float p) :: body
+    | _ -> body
   in
   let body = match config.enable_thinking with
     | Some enabled ->
@@ -173,6 +185,48 @@ let%test "glm drops tools when tool_choice none" =
   let assoc = to_assoc json in
   not (List.mem_assoc "tool_choice" assoc)
   && not (List.mem_assoc "tools" assoc)
+
+(* === Capability-gated sampling param tests (oas#827) === *)
+
+let%test "glm drops min_p when model does not support it" =
+  (* GLM's glm_capabilities inherits supports_min_p = false from
+     default_capabilities.  Even when the caller sets min_p explicitly
+     (via cascade inheritance or agent default), backend_openai must
+     omit it from the wire body — ZAI rejects the request with
+     "property 'min_p' is unsupported". *)
+  let cfg = Provider_config.make
+    ~kind:Provider_config.Glm ~model_id:"glm-5.1"
+    ~base_url:Zai_catalog.general_base_url
+    ~min_p:0.05 () in
+  let json = build_request ~config:cfg ~messages:[] ()
+             |> Yojson.Safe.from_string in
+  let open Yojson.Safe.Util in
+  not (List.mem_assoc "min_p" (to_assoc json))
+
+let%test "glm drops top_k when model does not support it" =
+  let cfg = Provider_config.make
+    ~kind:Provider_config.Glm ~model_id:"glm-5.1"
+    ~base_url:Zai_catalog.general_base_url
+    ~top_k:40 () in
+  let json = build_request ~config:cfg ~messages:[] ()
+             |> Yojson.Safe.from_string in
+  let open Yojson.Safe.Util in
+  not (List.mem_assoc "top_k" (to_assoc json))
+
+let%test "ollama preserves min_p (llama.cpp supports it)" =
+  (* qwen3 via Ollama has supports_min_p = true in qwen_capabilities.
+     The capability-gated path must still pass min_p through for
+     providers that do support it. *)
+  let cfg = Provider_config.make
+    ~kind:Provider_config.Ollama ~model_id:"qwen3.5:35b-a3b-nvfp4"
+    ~base_url:"http://127.0.0.1:11434"
+    ~min_p:0.05 () in
+  let json = build_request ~config:cfg ~messages:[] ()
+             |> Yojson.Safe.from_string in
+  let open Yojson.Safe.Util in
+  match json |> member "min_p" with
+  | `Float f -> Float.abs (f -. 0.05) < 1e-6
+  | _ -> false
 
 let%test "strip_json_markdown_fences plain text unchanged" =
   strip_json_markdown_fences "{\"key\":\"value\"}" = "{\"key\":\"value\"}"

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -24,6 +24,29 @@ let usage_of_openai_json = Backend_openai_parse.usage_of_openai_json
 
 let parse_openai_response_result = Backend_openai_parse.parse_openai_response_result
 
+(* ── Capability-drop WARN dedup ────────────────────────── *)
+
+(** One-shot stderr WARN table, keyed by ([model_id], [field_name]).
+    Reached from the capability-gated drop branches in {!build_request}
+    so operators see exactly which sampling field their config was
+    trying to send for which model, without the per-request WARN spam
+    that would otherwise fire on every keeper turn. Double-warning on
+    a race is harmless and only happens once per key. *)
+let capability_drop_warned : (string * string, unit) Hashtbl.t =
+  Hashtbl.create 16
+
+let warn_capability_drop ~model_id ~field =
+  let key = (model_id, field) in
+  if not (Hashtbl.mem capability_drop_warned key) then begin
+    Hashtbl.replace capability_drop_warned key ();
+    Printf.eprintf
+      "[WARN] [backend_openai] dropping sampling field %s for model %s: \
+       capability record reports supports_%s = false. Update \
+       Capabilities.for_model_id if this model actually supports it, \
+       otherwise remove the field from your agent/cascade config.\n%!"
+      field model_id field
+  end
+
 (* ── Request building ──────────────────────────────────── *)
 
 let effective_tool_choice (config : Provider_config.t) =
@@ -74,13 +97,26 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
     | Some c -> c
     | None -> Capabilities.default_capabilities
   in
+  (* Silent drops of user-supplied sampling params are a debugging
+     hazard (GLM review on #830), so emit a ONE-SHOT stderr WARN per
+     (model_id, field) combination the first time a drop fires. Per-
+     request WARN would spam — keepers do ~50 requests/minute — hence
+     the dedup table. The cell is best-effort: Eio cooperative
+     scheduling means two fibers racing [mem_opt]/[replace] can
+     double-warn at most once per key, which is harmless. *)
   let body = match config.top_k with
     | Some k when caps.supports_top_k -> ("top_k", `Int k) :: body
-    | _ -> body
+    | Some _ ->
+      warn_capability_drop ~model_id:config.model_id ~field:"top_k";
+      body
+    | None -> body
   in
   let body = match config.min_p with
     | Some p when caps.supports_min_p -> ("min_p", `Float p) :: body
-    | _ -> body
+    | Some _ ->
+      warn_capability_drop ~model_id:config.model_id ~field:"min_p";
+      body
+    | None -> body
   in
   let body = match config.enable_thinking with
     | Some enabled ->


### PR DESCRIPTION
## Summary

Closes #827. Running masc-mcp JSONL shows **53 occurrences** of \`oas:agent\` turn records with \`stop=error:Invalid request: property 'min_p' is unsupported\` in a ~75-minute window, with the rate accelerating as cascades retry and burn their budget on doomed glm-5.1 requests.

## Root cause

\`backend_openai.build_request\` at \`lib/llm_provider/backend_openai.ml:65-72\` serializes \`top_k\` and \`min_p\` whenever the config has \`Some _\`, without consulting the capability record. But \`Capabilities.t\` already has \`supports_top_k: bool\` and \`supports_min_p: bool\` fields, and both \`default_capabilities\` and \`glm_capabilities\` (which inherits via \`{ default_capabilities with ... }\`) have them set to \`false\`.

\`backend_glm.build_request\` delegates to \`Backend_openai.build_request\` for its base body, so every GLM request with \`config.min_p = Some _\` (inherited from cascade or agent defaults) leaked the field into the wire body and ZAI rejected it with HTTP 400.

## Fix

One \`Capabilities.for_model_id\` lookup at the top of the sampling block, gate both \`top_k\` and \`min_p\` serialization on the relevant capability. Unknown models fall back to \`default_capabilities\` — both flags \`false\`, so fields are strictly dropped unless a known model explicitly opts in.

\`\`\`ocaml
let caps =
  match Capabilities.for_model_id config.model_id with
  | Some c -> c
  | None -> Capabilities.default_capabilities
in
let body = match config.top_k with
  | Some k when caps.supports_top_k -> (\"top_k\", \`Int k) :: body
  | _ -> body
in
let body = match config.min_p with
  | Some p when caps.supports_min_p -> (\"min_p\", \`Float p) :: body
  | _ -> body
in
\`\`\`

## Tests

Three new inline \`%test\` cases:

1. **\"glm drops min_p when model does not support it\"** — sets \`~min_p:0.05\` on a \`Glm\` config, asserts the serialized JSON has no \`min_p\` key.
2. **\"glm drops top_k when model does not support it\"** — same pattern for \`~top_k:40\`.
3. **\"ollama preserves min_p (llama.cpp supports it)\"** — sanity check that providers WITH the capability still pass the field through. Guards against the fix regressing local Ollama cascades.

\`\`\`
dune build --root . — green
dune runtest --root . lib/llm_provider/backend_openai.ml — green
\`\`\`

## Observed impact

Pre-fix: **53 failures in 75 min** (0.7/min) on the live server. Each failure burns one round-trip to ZAI before cascade fallback tries the next model, so the effective keeper cascade completion rate dropped to ~1 turn per 5 minutes.

Post-fix: the request never has the unsupported field, so ZAI accepts it at the first step (glm-coding:glm-5.1 → 200). Keeper cascade completion should bounce back to ~1 turn/min baseline.

## References

- masc-mcp \`~/me/.masc/logs/system_log_2026-04-12.jsonl\`: 53× \`property 'min_p' is unsupported\` between 19:35 and 20:53
- #827 — tracking issue
- #814 (base_url log), #816 (per-turn timing), #821 (keep_alive int), masc-mcp#6618 (Oas_log_bridge) — the full observability chain that made this bug diagnosable in the first place

🤖 Generated with [Claude Code](https://claude.com/claude-code)