### PR TITLE
fix(api_openai): route silent capability drops through backend_openai warn helper

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -92,14 +92,20 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
     | Some top_k when capabilities.supports_top_k ->
         ("top_k", `Int top_k) :: body_assoc
     | None -> body_assoc
-    | Some _ -> body_assoc
+    | Some _ ->
+        Llm_provider.Backend_openai.warn_capability_drop
+          ~model_id:model_str ~field:"top_k";
+        body_assoc
   in
   let body_assoc =
     match config.config.min_p with
     | Some min_p when capabilities.supports_min_p ->
         ("min_p", `Float min_p) :: body_assoc
     | None -> body_assoc
-    | Some _ -> body_assoc
+    | Some _ ->
+        Llm_provider.Backend_openai.warn_capability_drop
+          ~model_id:model_str ~field:"min_p";
+        body_assoc
   in
   let body_assoc =
     match config.config.enable_thinking with

--- a/lib/llm_provider/backend_openai.mli
+++ b/lib/llm_provider/backend_openai.mli
@@ -25,3 +25,19 @@ val build_request :
   ?tools:Yojson.Safe.t list ->
   unit ->
   string
+
+(** Emit a one-shot stderr WARN the first time a capability-gated
+    sampling field is dropped for a given [(model_id, field)] pair.
+
+    Called from the silent-drop branches of the capability gates in
+    {!build_request} and [Api_openai.build_openai_body] so operators
+    who set a non-supported field (e.g. [min_p] on a GLM config) see
+    exactly which field was stripped without the per-request WARN
+    spam that would otherwise fire on every keeper turn.
+
+    Best-effort dedup via an internal [Hashtbl]; a race under Eio
+    cooperative scheduling double-warns at most once per key, which
+    is harmless.
+
+    @since 0.123.0 *)
+val warn_capability_drop : model_id:string -> field:string -> unit


### PR DESCRIPTION
## Summary

#830 fixed the capability gate on `top_k` / `min_p` in the **llm_provider-layer** serializer (`lib/llm_provider/backend_openai.ml`), but there is a **second** OpenAI-compat serializer one layer up in `lib/api_openai.ml`'s `build_openai_body` that was *also* capability-gated — and still dropped silently.

Both call paths are live:

| Caller | File | Entry point |
|---|---|---|
| Base agent send | `lib/api.ml:94` | `Api_openai.build_openai_body` |
| Streaming send | `lib/streaming.ml:201` | `Api_openai.build_openai_body` |
| Provider-intf wiring | `lib/provider_intf.ml:63` | `Api_openai.build_openai_body` |

Effect: an agent configured with `min_p=0.05` would have the field stripped silently at the agent_sdk layer, with no operator-visible WARN. The #830 fix therefore only covered half of the OpenAI-compat request path.

## Fix

1. **Expose** `Llm_provider.Backend_openai.warn_capability_drop` in `backend_openai.mli` so cross-layer callers can emit the same one-shot WARN.
2. **Call** it from `Api_openai.build_openai_body`'s drop branches for `top_k` and `min_p`, passing the resolved `model_str` as `~model_id`.

Both serializers now share **one** dedup `Hashtbl` (the helper is a module-level binding in `Backend_openai`), so an operator hitting the same bug through either path sees exactly one stderr line per `(model, field)` for the lifetime of the process. There is no per-serializer rate limit — the dedup is by key, not by caller.

## What did NOT change

- Accept-branch semantics — serialized JSON for well-supported fields is byte-identical.
- The `Backend_openai.build_request` implementation of the helper itself.
- Any existing test pin on `test_api_openai` / `test_mcp` / `test_context_reducer`.

## Test plan

- [x] `dune build --root .` — clean
- [x] `dune runtest test --root .` — full suite green

Behavioral verification path (manual, not in CI): run a masc-mcp keeper with `agent.options.min_p = Some 0.05` while forcing the cascade onto `glm-5.1`. Expected: **one** stderr WARN at first turn reading `[WARN] [backend_openai] dropping sampling field min_p for model glm-5.1: ...`, then subsequent turns are silent. Both the agent_sdk entry point (`Api_openai.build_openai_body`) and the llm_provider direct path (`Backend_openai.build_request`) share the dedup, so hitting the same model via either path does not re-warn.

## Scope

- `lib/llm_provider/backend_openai.mli` — adds one val
- `lib/api_openai.ml` — 2 match branches call the helper
- No `.ml` in llm_provider, no new tests
