### PR TITLE
fix(capabilities): anthropic_capabilities.supports_top_k = true

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -89,6 +89,17 @@ let anthropic_capabilities = {
   supports_native_streaming = true;
   supports_caching = true;
   supports_computer_use = true;
+  (* Anthropic Messages API documents [top_k] as a valid sampling
+     parameter ("Only sample from the top K options for each
+     subsequent token", docs.anthropic.com/en/api/messages body
+     params). [backend_anthropic.build_request] already serializes
+     [config.top_k] unconditionally when [Some]; the capability record
+     must match so cross-layer consumers (the #831 Api_openai gate,
+     the #830 Backend_openai gate, and the capability_filter passes)
+     do not silently drop top_k when the caller routes an Anthropic
+     config through a capability-checking path. [supports_min_p]
+     remains [false] — Anthropic does not accept min_p. *)
+  supports_top_k = true;
 }
 
 let openai_chat_capabilities = {

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -36,6 +36,11 @@ let test_anthropic_capabilities () =
   check bool "has caching" true c.supports_caching;
   check bool "has computer use" true c.supports_computer_use;
   check bool "no audio" false c.supports_audio_input;
+  (* Anthropic Messages API accepts top_k per its documented body
+     params; pin the field so the #830/#831 capability-gated
+     serializer paths do not silently drop it for claude configs. *)
+  check bool "supports top_k" true c.supports_top_k;
+  check bool "no min_p" false c.supports_min_p;
   check bool "context 200K" true (c.max_context_tokens = Some 200_000)
 
 let test_openai_capabilities () =


### PR DESCRIPTION
## Summary

Anthropic Messages API documents `top_k` as a valid sampling parameter (see [docs.anthropic.com/en/api/messages](https://docs.anthropic.com/en/api/messages) body params: *"top_k: Only sample from the top K options for each subsequent token"*). But `anthropic_capabilities` was inheriting `supports_top_k = false` from `default_capabilities`, contradicting:

1. The actual API behavior (top_k is accepted by POST /v1/messages)
2. `backend_anthropic.build_request`, which already serializes `config.top_k` unconditionally when `Some`

The discrepancy was invisible until #830 and #831 added capability-gated drops to the OpenAI-compat serializers. Any cross-layer code path that queries `Provider.capabilities_for_config` on an Anthropic config now resolves to `supports_top_k = false` and silently drops the field — the silent-drop bug this series has been fixing, but from the data-source side.

## Scope

- `lib/llm_provider/capabilities.ml` — 1 field flip in `anthropic_capabilities` + explanatory comment
- `test/test_capabilities.ml` — 2 new assertions in `test_anthropic_capabilities` pinning `supports_top_k = true` and `supports_min_p = false` (the latter stays false because Anthropic does not accept min_p)

## Inheritance impact

The `claude-opus-4` / `claude-sonnet-4` / `claude-haiku-4` entries in `for_model_id` are constructed via `{ anthropic_capabilities with max_context_tokens = Some 1_000_000; max_output_tokens = Some 128_000 }` — they override only context/output, so they transitively inherit the fixed `supports_top_k = true`. Sonnet/Opus 4 agents setting top_k through a capability-checking path no longer get silently dropped.

## Not broken

- No existing test pins `supports_top_k = false` for `anthropic_capabilities`.
- The one `supports_top_k = false` assertion in `test_provider.ml:157` is for an openrouter OpenAICompat fallback where `"anthropic/claude-sonnet-4-6"` misses `for_model_id` and falls back to `default_openai_compat_capabilities`, not `anthropic_capabilities`.
- `dune build` clean, `dune runtest test` full suite green.
