### PR TITLE
fix(capabilities): gemini_capabilities.supports_top_k = true

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -200,6 +200,16 @@ let gemini_capabilities = {
   supports_native_streaming = true;
   supports_caching = true;
   supports_code_execution = true;
+  (* Google Gemini's generateContent API documents [topK] as part of
+     generationConfig (ai.google.dev/api/generate-content). The
+     [backend_gemini.build_request] serializer already emits it at
+     lib/llm_provider/backend_gemini.ml:162-164, so the capability
+     record must match. Same discrepancy story as anthropic_capabilities
+     (#832) — OpenAI-compat consumers that route a Gemini config
+     through a capability-checking path were silently dropping top_k.
+     [supports_min_p] stays false; Gemini's generationConfig has no
+     min_p field. *)
+  supports_top_k = true;
 }
 
 let claude_code_capabilities = {

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -1123,6 +1123,10 @@ let test_gemini_capabilities () =
   Alcotest.(check bool) "audio" true c.supports_audio_input;
   Alcotest.(check bool) "video" true c.supports_video_input;
   Alcotest.(check bool) "code_execution" true c.supports_code_execution;
+  (* Gemini generationConfig accepts topK — pin so capability-gated
+     consumers do not silently drop it for Gemini configs. *)
+  Alcotest.(check bool) "top_k" true c.supports_top_k;
+  Alcotest.(check bool) "no min_p" false c.supports_min_p;
   Alcotest.(check (option int)) "max_context" (Some 1_000_000) c.max_context_tokens;
   Alcotest.(check (option int)) "max_output" (Some 65_000) c.max_output_tokens
 


### PR DESCRIPTION
## Summary

Follow-up to #832, same capability-record discrepancy on a different provider.

Google Gemini's `generateContent` API documents `topK` as part of `generationConfig` ([ai.google.dev/api/generate-content](https://ai.google.dev/api/generate-content)). The `backend_gemini.build_request` serializer emits it at `lib/llm_provider/backend_gemini.ml:162-164` unconditionally when `config.top_k = Some _`:

```ocaml
(match config.top_k with
 | Some k -> gen_config := ("topK", `Int k) :: !gen_config
 | None -> ());
```

But `gemini_capabilities` was inheriting `supports_top_k = false` from `default_capabilities`, so any cross-layer code path that routes a Gemini config through a capability-checking serializer (the #830 `Backend_openai` gate, the #831 `Api_openai` gate) silently dropped the field.

Same pattern as #832 for Anthropic:

| PR | Provider | Wire sends top_k? | Capability had supports_top_k = ? |
|----|----------|-------------------|------------------------------------|
| #832 | Anthropic | yes (backend_anthropic.ml) | false (wrong) → true |
| **#833** | Gemini | yes (backend_gemini.ml) | false (wrong) → true |

## Scope

- `lib/llm_provider/capabilities.ml` — `supports_top_k = true` in `gemini_capabilities` + explanatory comment linking to the Google API docs
- `test/test_llm_provider_cov.ml` — extend `test_gemini_capabilities` to pin `supports_top_k = true` and `supports_min_p = false` (Gemini's `generationConfig` has no `min_p` field)

## Not broken

- No existing test pinned `gemini_capabilities.supports_top_k = false`.
- `backend_gemini.build_request` behavior is unchanged — it already sent `topK` unconditionally.
- Only cross-layer capability consumers change: they now accept `top_k` instead of silently dropping.
- `dune build --root .` clean, `dune runtest test --root .` full suite green.
