### PR TITLE
fix(api_anthropic): serialize temperature/top_p/top_k in build_body_assoc

### DIFF
--- a/lib/api_anthropic.ml
+++ b/lib/api_anthropic.ml
@@ -81,4 +81,28 @@ let build_body_assoc ~config ~messages ?tools ~stream () =
         ("thinking", `Assoc [("type", `String "enabled"); ("budget_tokens", `Int budget)]) :: body_assoc
     | None -> body_assoc
   in
+  (* Sampling parameters were previously omitted entirely from the
+     Anthropic agent_sdk request path — any [temperature], [top_p],
+     or [top_k] the caller set on the agent config was silently
+     dropped, so Anthropic defaulted to temperature = 1.0 + top_p = 1.
+     Serialise them here so Claude agents honour deterministic
+     configs (e.g. temperature = 0.0 for coding assistants).
+
+     Anthropic Messages API body params (docs.anthropic.com/en/api/
+     messages): [temperature] float 0-1, [top_p] float 0-1, [top_k]
+     int >= 1. No [min_p] field — we intentionally do not serialise
+     it so a caller who sets [min_p] on a cross-provider config gets
+     the same silent-omit behaviour Anthropic itself enforces. *)
+  let body_assoc = match config.config.temperature with
+    | Some t -> ("temperature", `Float t) :: body_assoc
+    | None -> body_assoc
+  in
+  let body_assoc = match config.config.top_p with
+    | Some p -> ("top_p", `Float p) :: body_assoc
+    | None -> body_assoc
+  in
+  let body_assoc = match config.config.top_k with
+    | Some k -> ("top_k", `Int k) :: body_assoc
+    | None -> body_assoc
+  in
   body_assoc

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -137,6 +137,46 @@ let test_build_body_with_tools () =
   let tools = json |> member "tools" |> to_list in
   check int "1 tool" 1 (List.length tools)
 
+let test_build_body_sampling_params_anthropic () =
+  (* Regression: the Anthropic agent_sdk request path previously omitted
+     temperature/top_p/top_k entirely, silently defaulting every Claude
+     agent to Anthropic's server-side temperature = 1.0 + top_p = 1. *)
+  let state = {
+    Types.config = {
+      Types.default_config with
+      temperature = Some 0.3;
+      top_p = Some 0.85;
+      top_k = Some 20;
+    };
+    messages = [];
+    turn_count = 0;
+    usage = Types.empty_usage;
+  } in
+  let assoc = Api.build_body_assoc ~config:state ~messages:[] ~stream:false () in
+  let json = `Assoc assoc in
+  let open Yojson.Safe.Util in
+  check (float 1e-6) "temperature 0.3" 0.3
+    (json |> member "temperature" |> to_number);
+  check (float 1e-6) "top_p 0.85" 0.85
+    (json |> member "top_p" |> to_number);
+  check int "top_k 20" 20
+    (json |> member "top_k" |> to_int)
+
+let test_build_body_sampling_params_omitted_when_none () =
+  (* When the caller does not set a sampling param, the Anthropic body
+     must not carry the key at all — relying on Anthropic's server-side
+     defaults rather than encoding some OAS-layer default. *)
+  let state = make_state () in
+  let assoc = Api.build_body_assoc ~config:state ~messages:[] ~stream:false () in
+  check bool "no temperature key" false
+    (List.exists (fun (k, _) -> k = "temperature") assoc);
+  check bool "no top_p key" false
+    (List.exists (fun (k, _) -> k = "top_p") assoc);
+  check bool "no top_k key" false
+    (List.exists (fun (k, _) -> k = "top_k") assoc);
+  check bool "no min_p key" false
+    (List.exists (fun (k, _) -> k = "min_p") assoc)
+
 let test_build_openai_body_with_qwen_sampling () =
   let state = {
     Types.config = {
@@ -919,6 +959,10 @@ let () =
       test_case "without thinking" `Quick test_build_body_without_thinking;
       test_case "with tool_choice" `Quick test_build_body_with_tool_choice;
       test_case "with tools" `Quick test_build_body_with_tools;
+      test_case "anthropic sampling params serialized" `Quick
+        test_build_body_sampling_params_anthropic;
+      test_case "anthropic sampling params omitted when None" `Quick
+        test_build_body_sampling_params_omitted_when_none;
       test_case "with qwen sampling" `Quick test_build_openai_body_with_qwen_sampling;
       test_case "generic compat omits qwen-only fields" `Quick
         test_build_openai_body_omits_qwen_only_fields_for_generic_compat;


### PR DESCRIPTION
## Summary

**Real user-visible bug.** The Anthropic agent_sdk request path in `lib/api_anthropic.ml:build_body_assoc` was omitting **all** sampling parameters from the wire body — any Claude agent configured with `temperature=0.0` (e.g. a deterministic coding assistant) was silently running at Anthropic's server-side default of `temperature=1.0` / `top_p=1`.

## Root cause

`build_body_assoc` produced only:

```
model / max_tokens / messages / stream / system / tools / tool_choice / thinking
```

No `temperature`, `top_p`, `top_k`, or `min_p`. Both hot paths end up here:

| Caller | File | Mode |
|---|---|---|
| Base dispatch | `lib/api.ml:92` | non-streaming |
| Streaming dispatch | `lib/streaming.ml:170` | streaming |

Meanwhile the sibling OpenAI-compat path (`Api_openai.build_openai_body`) serializes all four, so switching providers on an otherwise-identical agent would silently change the effective sampling behaviour.

## Fix

Four new match arms appended at the end of `build_body_assoc`:

```ocaml
let body_assoc = match config.config.temperature with
  | Some t -> ("temperature", `Float t) :: body_assoc
  | None -> body_assoc
in
let body_assoc = match config.config.top_p with
  | Some p -> ("top_p", `Float p) :: body_assoc
  | None -> body_assoc
in
let body_assoc = match config.config.top_k with
  | Some k -> ("top_k", `Int k) :: body_assoc
  | None -> body_assoc
in
```

`min_p` is intentionally **not** serialized: Anthropic Messages API has no `min_p` body parameter (docs.anthropic.com/en/api/messages), so emitting one would be an ignored field. Dropping it matches what the endpoint actually accepts, same behaviour as the pre-#830 era for fields the server silently ignores.

## Why None stays omitted

When the caller does not set a sampling field, the body must **not** carry the key at all — we rely on Anthropic's server-side defaults rather than encoding an OAS-layer default. The new `test_build_body_sampling_params_omitted_when_none` test pins this invariant so a future refactor can't regress it.

## Tests

1. `test_build_body_sampling_params_anthropic` — pins that `temperature=0.3 / top_p=0.85 / top_k=20` land on the body keys in the expected numeric form.
2. `test_build_body_sampling_params_omitted_when_none` — pins that None-valued fields are strictly absent from the assoc (not `null`, not default, not present at all).

## Verification

- [x] `dune build --root .` clean
- [x] `dune exec test/test_api.exe` — 59/59 (57 existing + 2 new)
- [x] `dune runtest test --root .` — full suite green, 0 failures

## Loop theme alignment

This is exactly the "SDK의 본연의 기능을 제대로" mandate: the SDK wasn't honouring one of the most basic user-facing config fields for one of its two main providers. Silent drops like this cause user-reproducible output-quality issues that only surface when someone sets temperature and wonders why the model still sounds creative.
