### PR TITLE
fix(anthropic): Messages API conformance — tool_choice nesting + thinking gate

### DIFF
--- a/lib/api_anthropic.ml
+++ b/lib/api_anthropic.ml
@@ -76,10 +76,31 @@ let build_body_assoc ~config ~messages ?tools ~stream () =
         else
           body_assoc
   in
-  let body_assoc = match config.config.thinking_budget with
-    | Some budget ->
-        ("thinking", `Assoc [("type", `String "enabled"); ("budget_tokens", `Int budget)]) :: body_assoc
-    | None -> body_assoc
+  (* Thinking gate keys on [enable_thinking], not on [thinking_budget].
+     Previously the match was on [thinking_budget = Some _], which
+     meant:
+       (a) [enable_thinking = Some true, thinking_budget = None]
+           → no thinking block emitted (wrong — operator asked for
+             thinking, got none)
+       (b) [enable_thinking = Some false, thinking_budget = Some n]
+           → thinking block emitted anyway (wrong — operator disabled
+             thinking but a stray budget turned it back on)
+     Match the llm_provider backend's semantics from
+     lib/llm_provider/backend_anthropic.ml:75-83: gate on
+     [enable_thinking = Some true] and fall back to a 10_000-token
+     default budget if the caller did not specify one. *)
+  let body_assoc = match config.config.enable_thinking with
+    | Some true ->
+      let budget =
+        match config.config.thinking_budget with
+        | Some b -> b
+        | None -> 10_000
+      in
+      ("thinking", `Assoc [
+        ("type", `String "enabled");
+        ("budget_tokens", `Int budget)
+      ]) :: body_assoc
+    | _ -> body_assoc
   in
   (* Sampling parameters were previously omitted entirely from the
      Anthropic agent_sdk request path — any [temperature], [top_p],

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -101,14 +101,41 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
         else
           ("tools", `List ts) :: body
   in
+  (* Anthropic Messages API nests [disable_parallel_tool_use] INSIDE
+     the [tool_choice] object — it is NOT a top-level body field.
+     See docs.anthropic.com/en/api/messages body params:
+       tool_choice.disable_parallel_tool_use: boolean
+
+     The previous implementation emitted [disable_parallel_tool_use]
+     as a top-level key, which Anthropic silently ignores, so any
+     cascade-path agent with [disable_parallel_tool_use = true] and
+     tools was still receiving parallel tool calls. Same class of
+     silent-drop bug as #834 but for a different field; also fixes
+     the drift with the agent_sdk path in lib/api_anthropic.ml which
+     already nests correctly. *)
+  let tool_choice_json_with_disable choice =
+    let base = tool_choice_to_json choice in
+    if config.disable_parallel_tool_use then
+      match base with
+      | `Assoc fields ->
+        `Assoc (("disable_parallel_tool_use", `Bool true) :: fields)
+      | other -> other
+    else base
+  in
   let body = match config.tool_choice with
     | Some choice ->
-        ("tool_choice", tool_choice_to_json choice) :: body
-    | None -> body
-  in
-  let body =
-    if config.disable_parallel_tool_use && tools <> [] then
-      ("disable_parallel_tool_use", `Bool true) :: body
-    else body
+      ("tool_choice", tool_choice_json_with_disable choice) :: body
+    | None ->
+      if config.disable_parallel_tool_use && tools <> [] then
+        (* No explicit tool_choice but caller still wants to disable
+           parallel tool use — synthesize an [auto] choice to carry
+           the flag, matching the agent_sdk path at
+           lib/api_anthropic.ml. *)
+        let tc = `Assoc [
+          ("type", `String "auto");
+          ("disable_parallel_tool_use", `Bool true);
+        ] in
+        ("tool_choice", tc) :: body
+      else body
   in
   Yojson.Safe.to_string (`Assoc body)

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -79,11 +79,12 @@ let test_unknown_type_returns_none () =
 (* build_body_assoc                                                     *)
 (* ------------------------------------------------------------------ *)
 
-let make_state ?thinking_budget ?tool_choice () =
+let make_state ?thinking_budget ?tool_choice ?enable_thinking () =
   let config = { Types.default_config with
     system_prompt = Some "You are helpful.";
     thinking_budget;
     tool_choice;
+    enable_thinking;
   } in
   { Types.config; messages = []; turn_count = 0; usage = Types.empty_usage }
 
@@ -100,7 +101,10 @@ let test_build_body_basic () =
     (json |> member "system" |> to_string)
 
 let test_build_body_with_thinking_budget () =
-  let config = make_state ~thinking_budget:1024 () in
+  (* Thinking is gated on [enable_thinking = Some true]; a budget
+     without enable_thinking must NOT emit a thinking block.
+     Matches backend_anthropic.build_request semantics. *)
+  let config = make_state ~enable_thinking:true ~thinking_budget:1024 () in
   let assoc = Api.build_body_assoc ~config ~messages:[] ~stream:false () in
   let json = `Assoc assoc in
   let open Yojson.Safe.Util in
@@ -109,6 +113,29 @@ let test_build_body_with_thinking_budget () =
     (thinking |> member "type" |> to_string);
   check int "budget_tokens" 1024
     (thinking |> member "budget_tokens" |> to_int)
+
+let test_build_body_with_enable_thinking_default_budget () =
+  (* enable_thinking = true without an explicit budget should still
+     emit a thinking block, using the 10_000-token default budget
+     that matches backend_anthropic. Regression for the old gate
+     that required thinking_budget = Some _ to activate. *)
+  let config = make_state ~enable_thinking:true () in
+  let assoc = Api.build_body_assoc ~config ~messages:[] ~stream:false () in
+  let json = `Assoc assoc in
+  let open Yojson.Safe.Util in
+  let thinking = json |> member "thinking" in
+  check string "thinking type" "enabled"
+    (thinking |> member "type" |> to_string);
+  check int "default budget_tokens 10_000" 10_000
+    (thinking |> member "budget_tokens" |> to_int)
+
+let test_build_body_enable_thinking_false_drops_thinking () =
+  (* enable_thinking = false must NOT emit a thinking block, even if
+     a budget was left in the config from a previous state. *)
+  let config = make_state ~enable_thinking:false ~thinking_budget:5000 () in
+  let assoc = Api.build_body_assoc ~config ~messages:[] ~stream:false () in
+  check bool "no thinking key when disabled" false
+    (List.exists (fun (k, _) -> k = "thinking") assoc)
 
 let test_build_body_without_thinking () =
   let config = make_state () in
@@ -956,6 +983,10 @@ let () =
     "build_body_assoc", [
       test_case "basic" `Quick test_build_body_basic;
       test_case "with thinking_budget" `Quick test_build_body_with_thinking_budget;
+      test_case "enable_thinking default budget" `Quick
+        test_build_body_with_enable_thinking_default_budget;
+      test_case "enable_thinking false drops thinking" `Quick
+        test_build_body_enable_thinking_false_drops_thinking;
       test_case "without thinking" `Quick test_build_body_without_thinking;
       test_case "with tool_choice" `Quick test_build_body_with_tool_choice;
       test_case "with tools" `Quick test_build_body_with_tools;


### PR DESCRIPTION
## Summary

Two correctness bugs surfaced by the #834 audit of the two parallel Anthropic serializers (`lib/api_anthropic.ml` + `lib/llm_provider/backend_anthropic.ml`). Both had drifted away from the documented Anthropic Messages API shape in *different* ways.

## Bug 1: `backend_anthropic.build_request` — `disable_parallel_tool_use` wrong placement

Anthropic Messages API nests `disable_parallel_tool_use` **inside** the `tool_choice` object, not as a top-level body field ([docs](https://docs.anthropic.com/en/api/messages) body params: `tool_choice.disable_parallel_tool_use: boolean`).

**Before**:
```ocaml
let body =
  if config.disable_parallel_tool_use && tools <> [] then
    ("disable_parallel_tool_use", `Bool true) :: body  (* top-level — ignored *)
  else body
in
```

Anthropic silently discards the top-level field, so any cascade-path agent with `disable_parallel_tool_use = true` was still receiving parallel tool calls.

**After**: nest inside `tool_choice`, matching the agent_sdk path in `lib/api_anthropic.ml`, and synthesize a `{type: auto, disable_parallel_tool_use: true}` choice if the caller wanted the flag without setting `tool_choice`.

## Bug 2: `api_anthropic.build_body_assoc` — thinking gate keyed on `thinking_budget`

Previously:
```ocaml
let body_assoc = match config.config.thinking_budget with
  | Some budget -> ("thinking", ...) :: body_assoc
  | None -> body_assoc
```

Which meant:

| enable_thinking | thinking_budget | old behaviour | correct |
|---|---|---|---|
| `Some true` | `None` | no thinking block | thinking with default budget |
| `Some false` | `Some 5000` | thinking enabled anyway | no thinking block |

**After**: gate on `enable_thinking = Some true` with a `10_000`-token default budget when `thinking_budget` is `None`. Matches `backend_anthropic.build_request:75-83` exactly — the two serializers now agree.

## Tests

- `make_state` now accepts `?enable_thinking` so callers can specify it.
- `test_build_body_with_thinking_budget` updated to pass both `enable_thinking:true` and `thinking_budget:1024` (the old test pinned the bug — thinking was firing without `enable_thinking`).
- **New**: `test_build_body_with_enable_thinking_default_budget` — `enable_thinking:true` + no budget → thinking block with default `10_000 budget_tokens`.
- **New**: `test_build_body_enable_thinking_false_drops_thinking` — `enable_thinking:false` + stray `thinking_budget` → no thinking block.

## Why these are real bugs

- **Bug 1**: operators explicitly opt into disabling parallel tool use (usually for serialized execution with side effects). Silent drop means their agent runs multiple tools in parallel against the intent.
- **Bug 2**: operators using `enable_thinking:true` without setting a budget received *no* thinking — because the old gate required a budget to activate. The documented default budget was never applied.

Both fit the same family as #834 (silent config drop on Anthropic path).

## Verification

- [x] `dune build --root .` clean
- [x] `dune runtest test --root .` — full suite green, 0 failures
- [x] Both serializers now emit identical thinking / tool_choice shapes for the same config input
