### PR TITLE
chore(api): drop dead Gemini/GLM exception catches in create_message

### DIFF
--- a/lib/api.ml
+++ b/lib/api.ml
@@ -138,10 +138,14 @@ let create_message ~sw ~net ?(base_url=default_base_url) ?provider ?clock ?retry
       Error (Retry.NetworkError { message = Printexc.to_string exn })
     | Unix.Unix_error _ as exn ->
       Error (Retry.NetworkError { message = Printexc.to_string exn })
-    | Llm_provider.Backend_gemini.Gemini_api_error msg ->
-      Error (Retry.InvalidRequest { message = msg })
-    | Llm_provider.Backend_glm.Glm_api_error msg ->
-      Error (Retry.InvalidRequest { message = msg })
+    (* Backend_gemini.Gemini_api_error and Backend_glm.Glm_api_error
+       are intentionally NOT caught here: this function only
+       dispatches [Anthropic_messages | Openai_chat_completions |
+       Custom] (see the match on [kind] above), so the Gemini/GLM
+       response parsers are never invoked on this path and those
+       exceptions cannot reach here. They are caught at their real
+       live site in [Llm_provider.Complete] — see
+       lib/llm_provider/complete.ml:271,274. *)
     | Failure msg ->
       Error (Retry.NetworkError { message = msg })
     | Yojson.Json_error msg ->


### PR DESCRIPTION
## Summary

`lib/api.ml:141-144` had catch arms for `Llm_provider.Backend_gemini.Gemini_api_error` and `Llm_provider.Backend_glm.Glm_api_error`, but `create_message` only dispatches three request kinds via `Provider.request_kind`:

```ocaml
| Provider.Anthropic_messages -> ...
| Provider.Openai_chat_completions -> ...
| Provider.Custom name -> ...
```

Gemini and GLM do **not** appear in `Provider.provider` at all — they live in the separate `Provider_config.provider_kind` type and are routed through `Llm_provider.Complete.complete_http`, which has the real live catch at `lib/llm_provider/complete.ml:271,274`.

## Verification that these are dead

Neither the Anthropic response parser, the OpenAI-compat response parser, nor `Llm_provider.Pricing.annotate_response_cost` calls into `Backend_gemini` or `Backend_glm`. Verified by:

```
rg 'Backend_gemini|Backend_glm' lib/llm_provider/pricing.ml              # no matches
rg 'Backend_gemini|Backend_glm' lib/llm_provider/backend_openai.ml       # no matches
rg 'Backend_gemini|Backend_glm' lib/llm_provider/backend_anthropic.ml    # no matches
```

So nothing on the `api.ml` request path can raise either exception. The catch arms have been silently dead since they were added.

## Fix

Replace the two catch arms with a comment block pointing at the live handler location:

```ocaml
(* Backend_gemini.Gemini_api_error and Backend_glm.Glm_api_error
   are intentionally NOT caught here: this function only
   dispatches [Anthropic_messages | Openai_chat_completions |
   Custom] (see the match on [kind] above), so the Gemini/GLM
   response parsers are never invoked on this path and those
   exceptions cannot reach here. They are caught at their real
   live site in [Llm_provider.Complete] — see
   lib/llm_provider/complete.ml:271,274. *)
```

Keeping the comment (instead of a silent removal) so a future reader who wonders "why isn't this caught here?" gets a direct answer and is pointed at the live handler, preventing the same dead code from being re-added reflexively.

## Test plan

- [x] `dune build --root .` clean
- [x] `dune runtest test --root .` — full suite green
- No semantic change — the dead handler never fired so removing it cannot regress runtime behavior.

## Loop theme alignment

"어거지 구현 청소" — dead defensive handlers for events that cannot occur are exactly the kind of speculative-scaffolding the loop is supposed to clean up. The replacement comment converts the noise into a signal.
