### PR TITLE
fix(ollama): disable min_p for Ollama provider (unsupported parameter)

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -165,6 +165,7 @@ let ollama_supports_tool_choice_default =
 let ollama_capabilities = {
   openai_chat_extended_capabilities with
   supports_tool_choice = ollama_supports_tool_choice_default;
+  supports_min_p = false;
   is_ollama = true;
 }
 

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -38,8 +38,11 @@ type sampling_defaults = {
 
 let provider_sampling_defaults (kind : Provider_config.provider_kind) : sampling_defaults =
   match kind with
-  | Provider_config.OpenAI_compat | Provider_config.Ollama ->
+  | Provider_config.OpenAI_compat ->
     { default_min_p = Some Constants.Sampling.openai_compat_min_p;
+      default_top_p = None; default_top_k = None }
+  | Provider_config.Ollama ->
+    { default_min_p = None;
       default_top_p = None; default_top_k = None }
   | Provider_config.Anthropic ->
     { default_min_p = None; default_top_p = None; default_top_k = None }


### PR DESCRIPTION
## Summary
- Ollama rejects `min_p` with `"property 'min_p' is unsupported"`, causing keeper turns to hard-fail
- Set `supports_min_p = false` in `ollama_capabilities`
- Remove Ollama from OpenAI_compat `min_p=0.05` default — Ollama gets `None`
- OpenAI_compat (non-Ollama) still gets the 0.05 default

## Root cause
`ollama_capabilities` inherited `supports_min_p = true` from `openai_chat_extended_capabilities`. Ollama's `/api/chat` endpoint does not accept `min_p` in the `options` object.

## Test plan
- [x] Library builds clean
- [ ] Deploy and verify keeper `analyst` stops failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)