### PR TITLE
fix(backend_ollama): add capability gate for top_k / min_p

### DIFF
--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -85,7 +85,26 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
         ("tools", `List (List.map Backend_openai_serialize.build_openai_tool_json ts)) :: body
   in
 
-  (* Sampling parameters go inside "options" object *)
+  (* Sampling parameters go inside Ollama's "options" object.
+
+     top_k / min_p are now capability-gated — not because native
+     Ollama rejects them (its Options struct has both, llama.cpp
+     samplers support them), but to mirror the #830/#831 contract
+     across every OAS serializer so a future capability record that
+     lowers either flag actually takes effect everywhere in the
+     request-build pipeline.
+
+     For the default ollama_capabilities (inherited from
+     openai_chat_extended_capabilities) both flags are true, so
+     behaviour is byte-identical for the common path. The gate only
+     fires when an operator explicitly sets [supports_min_p = false]
+     or [supports_top_k = false] for a specific Ollama variant — at
+     which point the one-shot WARN from Backend_openai also fires. *)
+  let caps =
+    match Capabilities.for_model_id config.model_id with
+    | Some c -> c
+    | None -> Capabilities.ollama_capabilities
+  in
   let options = ref [] in
   (match config.max_tokens with
    | n -> options := ("num_predict", `Int n) :: !options);
@@ -96,10 +115,18 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
    | Some p -> options := ("top_p", `Float p) :: !options
    | None -> ());
   (match config.top_k with
-   | Some k -> options := ("top_k", `Int k) :: !options
+   | Some k when caps.supports_top_k ->
+     options := ("top_k", `Int k) :: !options
+   | Some _ ->
+     Backend_openai.warn_capability_drop
+       ~model_id:config.model_id ~field:"top_k"
    | None -> ());
   (match config.min_p with
-   | Some p -> options := ("min_p", `Float p) :: !options
+   | Some p when caps.supports_min_p ->
+     options := ("min_p", `Float p) :: !options
+   | Some _ ->
+     Backend_openai.warn_capability_drop
+       ~model_id:config.model_id ~field:"min_p"
    | None -> ());
   let body = ("options", `Assoc !options) :: body in
 


### PR DESCRIPTION
## Summary

Last capability-gate in the #830/#831 series. `backend_ollama.build_request` was the only live request builder still emitting `top_k` / `min_p` unconditionally from `config.*`:

```ocaml
(match config.top_k with
 | Some k -> options := ("top_k", `Int k) :: !options
 | None -> ());
(match config.min_p with
 | Some p -> options := ("min_p", `Float p) :: !options
 | None -> ());
```

After this PR every OAS serializer (`backend_openai`, `api_openai`, `backend_anthropic`, `backend_gemini`, `backend_ollama`) respects `Capabilities.for_model_id` for the sampling fields where the data-source ground truth is now correct (#815/#823/#825/#826/#828/#829/#830/#831/#832/#833/#834/#835).

## Why zero behavioural change for the common path

- `ollama_capabilities` inherits `supports_top_k = true` and `supports_min_p = true` from `openai_chat_extended_capabilities`.
- For the default Ollama + `qwen3*` combination, `for_model_id` returns `{ default_capabilities with supports_top_k = true; supports_min_p = true; ... }`.
- Both paths give `supports_* = true`, so the gate evaluates to the `Some _ when caps.* -> send` branch and the JSON payload is **byte-identical** before and after this PR.

The gate only fires when an operator explicitly **lowers** the capability record for a specific Ollama variant. In that case the one-shot `Backend_openai.warn_capability_drop` WARN fires once per `(model_id, field)` — the same dedup `Hashtbl` is now shared across `backend_openai`, `api_openai`, and `backend_ollama`.

## Relation to #839

#839 proposes flipping `ollama_capabilities.supports_min_p = false` based on a reported Ollama rejection of `min_p`. That flip targets the **wrong** capability record — see [my review on #839](https://github.com/jeong-sik/oas/pull/839#issuecomment-4230464203) for the full analysis. TL;DR:

- The error string `"property 'min_p' is unsupported"` is documented in `backend_openai.ml:232` as the **ZAI GLM** error format, not Ollama.
- Native Ollama's `Options` struct has `MinP`; it cannot raise that exact string.
- The failing path is most likely Ollama configured as `OpenAI_compat` with a qwen3 model, routing through `backend_openai` where `for_model_id "qwen3-*"` says `supports_min_p = true`.
- #839's `ollama_capabilities` flip does not affect the failing path at all.

This PR is independent: it adds the defensive gate on the native path without changing any capability value. If a correct follow-up does flip a capability for a specific Ollama variant, this gate ensures it takes effect on the native path too, not only through `backend_openai`.

## Test plan

- [x] `dune build --root .` clean
- [x] `dune runtest test --root .` — full suite green, 0 failures
- Byte-identical output verified by inspection: default ollama_capabilities → both flags true → gate takes the `when caps.* -> send` branch → exact same JSON as before.

## Scope

- `lib/llm_provider/backend_ollama.ml` — 30 insertions, 3 deletions, adds `caps` lookup + two capability-gated match arms + explanatory comment
- No `.mli` change
- No test change (existing tests use default ollama_capabilities where both flags stay true, so nothing moves)
