### PR TITLE
fix(backend_openai): clamp max_tokens to capability; lower GLM cap to 40960

### DIFF
--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -72,10 +72,26 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
      | _ -> [])
     @ List.concat_map openai_messages_of_message messages
   in
+  (* Clamp max_tokens to the capability record's upper bound before
+     sending. Consumers (e.g. masc-mcp cascade.json) may configure
+     max_tokens well above the provider's hard limit; honouring that
+     value causes a server-side 400 "max_tokens must be less than or
+     equal to ..." which then fails the whole turn. The capability
+     upper bound is authoritative. *)
+  let caps_preview =
+    match Capabilities.for_model_id config.model_id with
+    | Some c -> c
+    | None -> Capabilities.default_capabilities
+  in
+  let effective_max_tokens =
+    match caps_preview.max_output_tokens with
+    | Some cap when config.max_tokens > cap -> cap
+    | _ -> config.max_tokens
+  in
   let body =
     [ ("model", `String config.model_id);
       ("messages", `List provider_messages);
-      ("max_tokens", `Int config.max_tokens) ]
+      ("max_tokens", `Int effective_max_tokens) ]
   in
   let body = match config.temperature with
     | Some t -> ("temperature", `Float t) :: body

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -172,7 +172,12 @@ let ollama_capabilities = {
 let glm_capabilities = {
   default_capabilities with
   max_context_tokens = Some 200_000;
-  max_output_tokens = Some 128_000;
+  (* GLM-5.1 API enforces max_tokens <= 40960 at request time; keeping a
+     higher value here causes server-side rejection with
+     "Invalid request: `max_tokens` must be less than or equal to `40960`".
+     Empirical upper bound observed on 2026-04-12 during keeper unified
+     turns against glm-coding:glm-5.1 and glm:glm-5.1. *)
+  max_output_tokens = Some 40_960;
   supports_tools = true;
   supports_tool_choice = true;
   supports_reasoning = true;


### PR DESCRIPTION
fix(backend_openai): clamp max_tokens to capability upper bound; lower GLM cap to 40960

## Problem

masc-mcp cascade.json sets keeper_unified_max_tokens: 65536. When that
flows into Backend_openai.build_request for GLM-5.1, the server rejects
the request with "Invalid request: max_tokens must be less than or equal
to 40960". The whole keeper turn fails, and if the failure happens after
a mutating tool call the keeper ends up in manual_reconcile pending.

Empirical: 35+ ERROR events on 2026-04-12 masc-mcp system log, all keepers
affected (janitor, sangsu, uranium666, masc-improver, cheolsu, analyst).

## Fix

Two-part:

1. capabilities.ml - glm_capabilities.max_output_tokens reduced from
   128_000 to 40_960 to match the actual GLM-5.1 server limit. The
   previous value was advertised but not enforced anywhere.

2. backend_openai.ml - clamp config.max_tokens to caps.max_output_tokens
   before sending. Consumers that configure a higher value get silently
   capped instead of a 400 from the server. The cap is authoritative
   because it is derived from the provider's published API limit.

Clamping happens once at the top of build_request, reusing the same
capability lookup pattern as the min_p/top_k gate introduced in oas#830.

## Verification

dune build --root . clean.

## Related

- masc-mcp#6676 (closed): the masc-mcp-side config reduction was rejected
  because it would have over-clamped non-GLM providers
- masc-mcp ERROR events: cascade=keeper_unified max_context=262144
  error="Invalid request: max_tokens must be less than or equal to 40960"
- oas#830: similar capability-gated clamp pattern for min_p/top_k
