### PR TITLE
fix(cascade): accept valid responses on exhaustion by default

### DIFF
--- a/lib/completion_contract.ml
+++ b/lib/completion_contract.ml
@@ -79,10 +79,10 @@ let validator ~(contract : t) (response : api_response) =
 
 let accept_on_exhaustion ~(contract : t) =
   match contract with
-  | Allow_text_or_tool -> false
-  | Require_tool_use -> false
-  | Require_specific_tool _ -> false
-  | Require_no_tool_use -> false
+  | Allow_text_or_tool -> true
+  | Require_tool_use -> true
+  | Require_specific_tool _ -> true
+  | Require_no_tool_use -> true
 
 let resolve_accept ?accept_reason ~(accept : api_response -> bool) =
   match accept_reason with

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -23,7 +23,7 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
      | Some s when not (Api_common.string_is_blank s) ->
          [`Assoc [("role", `String "system"); ("content", `String (Utf8_sanitize.sanitize s))]]
      | _ -> [])
-    @ List.concat_map Backend_openai_serialize.openai_messages_of_message messages
+    @ List.concat_map Backend_openai_serialize.ollama_messages_of_message messages
   in
 
   let body =

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -25,6 +25,27 @@ let tool_calls_to_openai_json blocks =
                   ])
          | _ -> None)
 
+(** Ollama variant: arguments as raw JSON object, not string.
+    Ollama's yyjson parser treats a stringified object as literal text
+    and fails with "can't find closing '}' symbol" on subsequent turns. *)
+let tool_calls_to_ollama_json blocks =
+  blocks
+  |> List.filter_map (function
+         | ToolUse { id; name; input } ->
+             Some
+               (`Assoc
+                  [
+                    ("id", `String id);
+                    ("type", `String "function");
+                    ( "function",
+                      `Assoc
+                        [
+                          ("name", `String name);
+                          ("arguments", input);
+                        ] );
+                  ])
+         | _ -> None)
+
 let openai_content_parts_of_blocks blocks =
   blocks
   |> List.filter_map (function
@@ -54,7 +75,7 @@ let openai_content_parts_of_blocks blocks =
              ])
          | Thinking _ | RedactedThinking _ | ToolUse _ | ToolResult _ -> None)
 
-let openai_messages_of_message (msg : message) : Yojson.Safe.t list =
+let messages_of_message_with ?(tool_calls_fn = tool_calls_to_openai_json) (msg : message) : Yojson.Safe.t list =
   match msg.role with
   | User ->
       let content_parts = openai_content_parts_of_blocks msg.content in
@@ -91,7 +112,7 @@ let openai_messages_of_message (msg : message) : Yojson.Safe.t list =
       user_msgs @ tool_msgs
   | Assistant ->
       let text_content = Api_common.text_blocks_to_string msg.content in
-      let tool_calls = tool_calls_to_openai_json msg.content in
+      let tool_calls = tool_calls_fn msg.content in
       let fields =
         [
           ("role", `String "assistant");
@@ -123,6 +144,12 @@ let openai_messages_of_message (msg : message) : Yojson.Safe.t list =
               let text = Api_common.text_blocks_to_string msg.content in
               [`Assoc [("role", `String "user"); ("content", `String text)]]
           | tool_msgs -> tool_msgs)
+
+let openai_messages_of_message msg =
+  messages_of_message_with ~tool_calls_fn:tool_calls_to_openai_json msg
+
+let ollama_messages_of_message msg =
+  messages_of_message_with ~tool_calls_fn:tool_calls_to_ollama_json msg
 
 let tool_choice_to_openai_json = function
   | Auto -> `String "auto"

--- a/lib/llm_provider/backend_openai_serialize.mli
+++ b/lib/llm_provider/backend_openai_serialize.mli
@@ -8,5 +8,6 @@
 val tool_calls_to_openai_json : Types.content_block list -> Yojson.Safe.t list
 val openai_content_parts_of_blocks : Types.content_block list -> Yojson.Safe.t list
 val openai_messages_of_message : Types.message -> Yojson.Safe.t list
+val ollama_messages_of_message : Types.message -> Yojson.Safe.t list
 val tool_choice_to_openai_json : Types.tool_choice -> Yojson.Safe.t
 val build_openai_tool_json : Yojson.Safe.t -> Yojson.Safe.t


### PR DESCRIPTION
## Summary

`accept_on_exhaustion`을 모든 contract에서 `true`로 변경.

## Problem

GLM이 HTTP 200 + text를 반환했지만 tool call이 없으면 cascade가 reject → Ollama로 fallback → 300KB JSON 파싱 실패. 이미 mutating tool이 커밋된 상태라 `ambiguous_partial_commit` → `manual_reconcile` 반복 발생.

## Fix

cascade의 역할은 "동작하는 provider 찾기"다. response 품질(tool contract)은 agent loop이 판단해야 한다. valid HTTP 200은 cascade가 수용하고, tool_choice 불만족은 agent가 tolerate/retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)