### PR TITLE
feat(provider): make max_tokens optional — None defers to model capability

### DIFF
--- a/examples/cascade_failover.ml
+++ b/examples/cascade_failover.ml
@@ -51,7 +51,7 @@ let () =
      Printf.printf "   temperature: %s\n"
        (match cfg.temperature with
         | Some t -> Printf.sprintf "%.1f" t | None -> "default");
-     Printf.printf "   max_tokens: %d\n" cfg.max_tokens
+     Printf.printf "   max_tokens: %s\n" (match cfg.max_tokens with Some n -> string_of_int n | None -> "auto")
    | None ->
      Printf.printf "   (not available)\n");
 

--- a/examples/streaming.ml
+++ b/examples/streaming.ml
@@ -41,7 +41,7 @@ let () =
       default_config with
       model = provider.model_id;
       system_prompt = Some "You are a helpful assistant.";
-      max_tokens = 1024;
+      max_tokens = Some 1024;
     }
   in
   let messages =

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -8,7 +8,7 @@ type t = {
   model: model;
   name: string;
   system_prompt: string option;
-  max_tokens: int;
+  max_tokens: int option;
   max_turns: int;
   temperature: float option;
   top_p: float option;
@@ -121,7 +121,7 @@ let create ~net ~model =
 
 let with_system_prompt prompt b = { b with system_prompt = Some prompt }
 let with_name name b = { b with name }
-let with_max_tokens n b = { b with max_tokens = n }
+let with_max_tokens n b = { b with max_tokens = Some n }
 let with_max_turns n b = { b with max_turns = n }
 let with_temperature t b = { b with temperature = Some t }
 let with_top_p p b = { b with top_p = Some p }
@@ -324,12 +324,13 @@ let build_safe b =
       field = "max_turns";
       detail = Printf.sprintf "must be > 0, got %d" b.max_turns;
     }))
-  else if b.max_tokens <= 0 then
+  else match b.max_tokens with
+  | Some n when n <= 0 ->
     Error (Error.Config (Error.InvalidConfig {
       field = "max_tokens";
-      detail = Printf.sprintf "must be > 0, got %d" b.max_tokens;
+      detail = Printf.sprintf "must be > 0, got %d" n;
     }))
-  else
+  | _ ->
     match b.thinking_budget, b.enable_thinking with
     | Some _, (None | Some false) ->
         Error (Error.Config (Error.InvalidConfig {

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -190,7 +190,7 @@ let create_agent ~net ?name ?model ?system_prompt ?max_tokens ?max_turns
     name = Option.value name ~default:default_config.name;
     model = Option.value model ~default:default_config.model;
     system_prompt;
-    max_tokens = Option.value max_tokens ~default:default_config.max_tokens;
+    max_tokens;
     max_turns = Option.value max_turns ~default:default_config.max_turns;
     temperature = default_config.temperature;
     top_p = default_config.top_p;

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -201,7 +201,7 @@ let create_message_cascade ~sw ~net ?clock ?retry_config
 
 let create_message_named ~sw ~net ?clock ~(named_cascade : named_cascade)
     ~config ~messages ?tools ?(temperature = 0.3)
-    ?(max_tokens = config.config.max_tokens)
+    ?(max_tokens = Option.value ~default:4096 config.config.max_tokens)
     ?system_prompt ?(accept = fun _ -> true) ?accept_reason
     ?(accept_on_exhaustion = false)
     ?timeout_sec ?metrics ?priority () =
@@ -242,7 +242,7 @@ let create_message_named ~sw ~net ?clock ~(named_cascade : named_cascade)
 
 let create_message_named_stream ~sw ~net ?clock
     ~(named_cascade : named_cascade) ~config ~messages ?tools
-    ?(temperature = 0.3) ?(max_tokens = config.config.max_tokens)
+    ?(temperature = 0.3) ?(max_tokens = Option.value ~default:4096 config.config.max_tokens)
     ?system_prompt ?timeout_sec ?metrics ~on_event ?priority () =
   let system_prompt =
     match system_prompt with

--- a/lib/api_anthropic.ml
+++ b/lib/api_anthropic.ml
@@ -14,7 +14,7 @@ let build_body_assoc ~config ~messages ?tools ~stream () =
   let model_str = model_to_string config.config.model in
   let body_assoc = [
     ("model", `String model_str);
-    ("max_tokens", `Int config.config.max_tokens);
+    ("max_tokens", `Int (Option.value ~default:4096 config.config.max_tokens));
     ("messages", `List (List.map Api_common.message_to_json messages));
     ("stream", `Bool stream);
   ] in

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -74,7 +74,7 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
     [
       ("model", `String model_str);
       ("messages", `List provider_messages);
-      ("max_tokens", `Int config.config.max_tokens);
+      ("max_tokens", `Int (Option.value ~default:4096 config.config.max_tokens));
     ]
   in
   let body_assoc =

--- a/lib/contract_runner.ml
+++ b/lib/contract_runner.ml
@@ -11,7 +11,7 @@ let extract_capability_snapshot (agent : Agent.t) : Cdal_proof.capability_snapsh
     tools = tool_names;
     mcp_servers = [];
     max_turns = config.max_turns;
-    max_tokens = Some config.max_tokens;
+    max_tokens = config.max_tokens;
     thinking_enabled = config.enable_thinking;
   }
 

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -39,7 +39,7 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
     List.map Api_common.message_to_json messages in
   let body =
     [ ("model", `String config.model_id);
-      ("max_tokens", `Int config.max_tokens);
+      ("max_tokens", `Int (Option.value ~default:4096 config.max_tokens));
       ("messages", `List msgs_json);
       ("stream", `Bool stream) ]
   in

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -152,7 +152,8 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
   in
   (* generationConfig *)
   let gen_config = ref [] in
-  gen_config := ("maxOutputTokens", `Int config.max_tokens) :: !gen_config;
+  (let mt = Option.value ~default:4096 config.max_tokens in
+   gen_config := ("maxOutputTokens", `Int mt) :: !gen_config);
   (match config.temperature with
    | Some t -> gen_config := ("temperature", `Float t) :: !gen_config
    | None -> ());

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -106,8 +106,8 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
     | None -> Capabilities.ollama_capabilities
   in
   let options = ref [] in
-  (match config.max_tokens with
-   | n -> options := ("num_predict", `Int n) :: !options);
+  (let mt = Option.value ~default:4096 config.max_tokens in
+   options := ("num_predict", `Int mt) :: !options);
   (match config.temperature with
    | Some t -> options := ("temperature", `Float t) :: !options
    | None -> ());

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -83,19 +83,25 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
     | Some c -> c
     | None -> Capabilities.default_capabilities
   in
-  (* Clamp [max_tokens] to [caps.max_output_tokens] when the cap is
-     known. The advertised cap is the upper bound the backend will
-     accept; exceeding it returns a 400 and — for callers that run
-     mutating tools inside the turn — corrupts partial-commit state,
-     because tool side effects persist even though the LLM final
-     response fails. [None] = "unknown model" → pass through rather
-     than imposing an arbitrary ceiling. *)
+  (* Resolve [max_tokens] from three layers:
+     1. Caller override ([config.max_tokens = Some n]) — explicit request
+     2. Model capability ([caps.max_output_tokens]) — provider's ceiling
+     3. Fallback 4096 — last resort when both are unknown
+
+     When the caller sends [None], they want the model's own maximum.
+     When the caller sends [Some n], we clamp to the capability ceiling
+     to avoid 400 errors that corrupt partial-commit state.
+
+     The resolved value is always emitted — Anthropic and most
+     OpenAI-compat endpoints REQUIRE the field. *)
   let effective_max_tokens =
-    match caps.max_output_tokens with
-    | Some cap when config.max_tokens > cap ->
+    match config.max_tokens, caps.max_output_tokens with
+    | None, Some cap -> cap  (* caller deferred → use model cap *)
+    | None, None -> 4096     (* unknown model, safe fallback *)
+    | Some n, Some cap when n > cap ->
       warn_capability_drop ~model_id:config.model_id ~field:"max_tokens:clamp";
       cap
-    | _ -> config.max_tokens
+    | Some n, _ -> n         (* caller explicit, within cap or cap unknown *)
   in
   let body =
     [ ("model", `String config.model_id);

--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -740,7 +740,7 @@ let%test "parse_model_string custom with empty model after @" =
 
 let%test "parse_model_string temperature and max_tokens forwarded" =
   match parse_model_string ~temperature:0.7 ~max_tokens:100 "llama:m1" with
-  | Some cfg -> cfg.temperature = Some 0.7 && cfg.max_tokens = 100
+  | Some cfg -> cfg.temperature = Some 0.7 && cfg.max_tokens = Some 100
   | None -> false
 
 let%test "parse_model_string system_prompt forwarded" =

--- a/lib/llm_provider/cascade_executor.ml
+++ b/lib/llm_provider/cascade_executor.ml
@@ -325,10 +325,16 @@ let truncate_tools
       | Some c -> c
       | None -> Capabilities.default_capabilities
     in
+    let output_reserve =
+      match cfg.max_tokens, caps.max_output_tokens with
+      | None, Some cap -> cap
+      | None, None -> 4096
+      | Some n, Some cap -> min n cap
+      | Some n, None -> n
+    in
     match caps.max_context_tokens with
     | None -> tools  (* unknown context window → don't truncate *)
     | Some max_ctx ->
-      let output_reserve = cfg.max_tokens in
       let message_tokens =
         List.fold_left
           (fun acc msg -> acc + estimate_message_tokens msg)
@@ -809,3 +815,18 @@ let%test "truncate_within_turn result tokens within budget" =
      in the fallback case *)
   result_tokens <= budget
   || List.length result = 3  (* fallback: preamble + last round *)
+
+let%test "truncate_tools resolves None max_tokens from model capability" =
+  let cfg = make_cfg "gpt-4o-mini" in
+  let msgs = [make_msg (String.make 450_000 'x')] in
+  let tools = [`Assoc [("name", `String "tool-a")]] in
+  truncate_tools cfg msgs tools = []
+
+let%test "truncate_tools clamps explicit max_tokens to capability ceiling" =
+  let cfg =
+    Provider_config.make ~kind:OpenAI_compat ~model_id:"gpt-4o-mini"
+      ~base_url:"http://test" ~max_tokens:20_000 ()
+  in
+  let msgs = [make_msg (String.make 447_000 'x')] in
+  let tools = [`Assoc [("name", `String "tool-a")]] in
+  truncate_tools cfg msgs tools = []

--- a/lib/llm_provider/cascade_executor.ml
+++ b/lib/llm_provider/cascade_executor.ml
@@ -314,6 +314,14 @@ let truncate_to_context ?(context_margin = default_context_margin)
     - Tools list is empty
 
     @since 0.123.0 *)
+let effective_output_reserve (cfg : Provider_config.t)
+    (caps : Capabilities.capabilities) =
+  match cfg.max_tokens, caps.max_output_tokens with
+  | None, Some cap -> cap
+  | None, None -> 4096
+  | Some n, Some cap -> min n cap
+  | Some n, None -> n
+
 let truncate_tools
     (cfg : Provider_config.t)
     (effective_messages : Types.message list)
@@ -325,13 +333,7 @@ let truncate_tools
       | Some c -> c
       | None -> Capabilities.default_capabilities
     in
-    let output_reserve =
-      match cfg.max_tokens, caps.max_output_tokens with
-      | None, Some cap -> cap
-      | None, None -> 4096
-      | Some n, Some cap -> min n cap
-      | Some n, None -> n
-    in
+    let output_reserve = effective_output_reserve cfg caps in
     match caps.max_context_tokens with
     | None -> tools  (* unknown context window → don't truncate *)
     | Some max_ctx ->
@@ -601,6 +603,9 @@ let make_assistant_msg text : Types.message =
 let make_cfg ?max_context model_id : Provider_config.t =
   Provider_config.make ~kind:OpenAI_compat ~model_id ~base_url:"http://test" ?max_context ()
 
+let caps_with ?max_context_tokens ?max_output_tokens () =
+  { Capabilities.default_capabilities with max_context_tokens; max_output_tokens }
+
 (* --- estimate_message_tokens --- *)
 
 let%test "estimate_message_tokens ASCII text" =
@@ -822,11 +827,13 @@ let%test "truncate_tools resolves None max_tokens from model capability" =
   let tools = [`Assoc [("name", `String "tool-a")]] in
   truncate_tools cfg msgs tools = []
 
-let%test "truncate_tools clamps explicit max_tokens to capability ceiling" =
+let%test "effective_output_reserve uses capability when max_tokens absent" =
+  let cfg = make_cfg "m" in
+  effective_output_reserve cfg (caps_with ~max_output_tokens:16_384 ()) = 16_384
+
+let%test "effective_output_reserve clamps explicit max_tokens to capability ceiling" =
   let cfg =
-    Provider_config.make ~kind:OpenAI_compat ~model_id:"gpt-4o-mini"
+    Provider_config.make ~kind:OpenAI_compat ~model_id:"m"
       ~base_url:"http://test" ~max_tokens:20_000 ()
   in
-  let msgs = [make_msg (String.make 447_000 'x')] in
-  let tools = [`Assoc [("name", `String "tool-a")]] in
-  truncate_tools cfg msgs tools = []
+  effective_output_reserve cfg (caps_with ~max_output_tokens:16_384 ()) = 16_384

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -836,7 +836,7 @@ let%test "gemini_url sync no api_key" =
     model_id = "gemini-2.5-flash";
     base_url = "https://gen.googleapis.com/v1beta";
     api_key = ""; request_path = ""; headers = [];
-    system_prompt = None; temperature = None; max_tokens = 1024;
+    system_prompt = None; temperature = None; max_tokens = Some 1024;
     max_context = None;
     top_p = None; top_k = None; min_p = None;
     enable_thinking = None; thinking_budget = None;
@@ -852,7 +852,7 @@ let%test "gemini_url sync with api_key" =
     kind = Gemini; model_id = "gemini-2.5-flash";
     base_url = "https://gen.googleapis.com/v1beta";
     api_key = "mykey"; request_path = ""; headers = [];
-    system_prompt = None; temperature = None; max_tokens = 1024;
+    system_prompt = None; temperature = None; max_tokens = Some 1024;
     max_context = None;
     top_p = None; top_k = None; min_p = None;
     enable_thinking = None; thinking_budget = None;
@@ -868,7 +868,7 @@ let%test "gemini_url stream with api_key" =
     kind = Gemini; model_id = "gemini-2.5-flash";
     base_url = "https://gen.googleapis.com/v1beta";
     api_key = "mykey"; request_path = ""; headers = [];
-    system_prompt = None; temperature = None; max_tokens = 1024;
+    system_prompt = None; temperature = None; max_tokens = Some 1024;
     max_context = None;
     top_p = None; top_k = None; min_p = None;
     enable_thinking = None; thinking_budget = None;
@@ -884,7 +884,7 @@ let%test "gemini_url stream no api_key" =
     kind = Gemini; model_id = "gemini-2.5-flash";
     base_url = "https://gen.googleapis.com/v1beta";
     api_key = ""; request_path = ""; headers = [];
-    system_prompt = None; temperature = None; max_tokens = 1024;
+    system_prompt = None; temperature = None; max_tokens = Some 1024;
     max_context = None;
     top_p = None; top_k = None; min_p = None;
     enable_thinking = None; thinking_budget = None;

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -16,7 +16,7 @@ type t = {
   api_key: string;
   headers: (string * string) list;
   request_path: string;
-  max_tokens: int;
+  max_tokens: int option;
   max_context: int option;
   temperature: float option;
   top_p: float option;
@@ -35,7 +35,7 @@ type t = {
 
 let make ~kind ~model_id ~base_url
     ?(api_key="") ?(headers=[("Content-Type", "application/json")])
-    ?request_path ?(max_tokens=4096) ?max_context
+    ?request_path ?max_tokens ?max_context
     ?temperature ?top_p ?top_k ?min_p
     ?system_prompt ?enable_thinking ?thinking_budget
     ?clear_thinking ?(tool_stream=false)

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -24,7 +24,7 @@ type t = {
   api_key: string;
   headers: (string * string) list;
   request_path: string;
-  max_tokens: int;
+  max_tokens: int option;  (** [None] = resolve from model capabilities at request time. @since 0.123.0 *)
   max_context: int option;  (** Provider's context window limit in tokens. When set, cascade executor truncates messages to fit before dispatch. @since 0.120.0 *)
   temperature: float option;
   top_p: float option;

--- a/lib/llm_provider/transport_openai_compat.ml
+++ b/lib/llm_provider/transport_openai_compat.ml
@@ -47,8 +47,9 @@ let merge_config ~(transport_cfg : config)
     else transport_cfg.request_path
   in
   let max_tokens =
-    if req_cfg.max_tokens > 0 then req_cfg.max_tokens
-    else transport_cfg.max_tokens
+    match req_cfg.max_tokens with
+    | Some n when n > 0 -> Some n
+    | _ -> Some transport_cfg.max_tokens
   in
   (* Always append transport extra_headers after request headers. *)
   let headers = req_cfg.headers @ transport_cfg.extra_headers in
@@ -87,7 +88,7 @@ let%test "default_config request_path" =
   default_config.request_path = "/v1/chat/completions"
 
 let%test "default_config max_tokens" =
-  default_config.max_tokens = 4096
+  default_config.max_tokens = 4096  (* transport config is int, not option *)
 
 let%test "default_config api_key empty" =
   default_config.api_key = ""
@@ -184,14 +185,14 @@ let%test "merge_config uses transport max_tokens when req zero" =
   let req_cfg = Provider_config.make
     ~kind:OpenAI_compat ~model_id:"m" ~base_url:"" ~max_tokens:0 () in
   let merged = merge_config ~transport_cfg req_cfg in
-  merged.max_tokens = 8192
+  merged.max_tokens = Some 8192
 
 let%test "merge_config preserves req max_tokens when positive" =
   let transport_cfg = { default_config with max_tokens = 8192 } in
   let req_cfg = Provider_config.make
     ~kind:OpenAI_compat ~model_id:"m" ~base_url:"" ~max_tokens:2048 () in
   let merged = merge_config ~transport_cfg req_cfg in
-  merged.max_tokens = 2048
+  merged.max_tokens = Some 2048
 
 let%test "merge_config preserves req temperature" =
   let transport_cfg = default_config in

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -47,7 +47,7 @@ type agent_config = {
   name: string;
   model: model;
   system_prompt: string option;
-  max_tokens: int;
+  max_tokens: int option;  (** [None] = resolve from model capabilities at request time *)
   max_turns: int;
   temperature: float option;
   top_p: float option;
@@ -76,7 +76,7 @@ let default_config = {
   name = "agent";
   model = Model_registry.default_model_id;
   system_prompt = None;
-  max_tokens = 4096;
+  max_tokens = None;
   max_turns = 10;
   temperature = None;
   top_p = None;

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -34,7 +34,7 @@ type agent_config = {
   name: string;
   model: model;
   system_prompt: string option;
-  max_tokens: int;
+  max_tokens: int option;
   max_turns: int;
   temperature: float option;
   top_p: float option;

--- a/test/test_agent_sdk.ml
+++ b/test/test_agent_sdk.ml
@@ -104,7 +104,7 @@ let test_create_agent_with_name_model () =
   Alcotest.(check string) "name" "test-agent" config.name;
   Alcotest.(check string) "model" "claude-haiku-4-5" config.model;
   Alcotest.(check (option string)) "prompt" (Some "You are helpful.") config.system_prompt;
-  Alcotest.(check int) "max_tokens" 2048 config.max_tokens;
+  Alcotest.(check (option int)) "max_tokens" (Some 2048) config.max_tokens;
   Alcotest.(check int) "max_turns" 5 config.max_turns
 
 let test_create_agent_with_provider () =

--- a/test/test_api_dispatch.ml
+++ b/test/test_api_dispatch.ml
@@ -17,7 +17,7 @@ let base_state = {
     name = "test-dispatch";
     model = "test-model";
     system_prompt = Some "You are a test assistant.";
-    max_tokens = 1024;
+    max_tokens = Some 1024;
   };
   messages = [{ Types.role = User; content = [Text "Hello"]; name = None; tool_call_id = None }];
   turn_count = 0;

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -713,7 +713,7 @@ let test_build_minimal_required_only () =
     Builder.create ~net ~model:"claude-3-7-sonnet" |> Builder.build_safe |> Result.get_ok in
   check_model "model" "claude-3-7-sonnet-20250219" (Agent.state agent).config.model;
   Alcotest.(check string) "name" "agent" (Agent.state agent).config.name;
-  Alcotest.(check (option int)) "max_tokens" (Some 4096) (Agent.state agent).config.max_tokens;
+  Alcotest.(check (option int)) "max_tokens" None (Agent.state agent).config.max_tokens;
   Alcotest.(check int) "max_turns" 10 (Agent.state agent).config.max_turns;
   Alcotest.(check int) "tools" 0 (Tool_set.size (Agent.tools agent));
   Alcotest.(check string) "base_url"

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -71,7 +71,7 @@ let test_with_max_tokens () =
     |> Builder.with_max_tokens 8192
     |> Builder.build_safe |> Result.get_ok
   in
-  Alcotest.(check int) "max_tokens" 8192 (Agent.state agent).config.max_tokens
+  Alcotest.(check (option int)) "max_tokens" (Some 8192) (Agent.state agent).config.max_tokens
 
 (* --- 5. with_max_turns --- *)
 
@@ -608,7 +608,7 @@ let test_build_produces_valid_agent () =
   check_model "model" "claude-opus-4-5-20251101" cfg.model;
   Alcotest.(check (option string)) "system_prompt"
     (Some "Be concise.") cfg.system_prompt;
-  Alcotest.(check int) "max_tokens" 2048 cfg.max_tokens;
+  Alcotest.(check (option int)) "max_tokens" (Some 2048) cfg.max_tokens;
   Alcotest.(check int) "max_turns" 5 cfg.max_turns;
   Alcotest.(check (option (float 0.001))) "temperature"
     (Some 0.3) cfg.temperature;
@@ -638,7 +638,7 @@ let test_chain_multiple () =
     |> Builder.build_safe |> Result.get_ok
   in
   Alcotest.(check string) "name" "chained" (Agent.state agent).config.name;
-  Alcotest.(check int) "max_tokens" 1024 (Agent.state agent).config.max_tokens;
+  Alcotest.(check (option int)) "max_tokens" (Some 1024) (Agent.state agent).config.max_tokens;
   Alcotest.(check int) "max_turns" 3 (Agent.state agent).config.max_turns;
   Alcotest.(check int) "tool count" 2 (Tool_set.size (Agent.tools agent));
   Alcotest.(check string) "base_url" "http://test:9090" (Agent.options agent).base_url;
@@ -668,7 +668,7 @@ let test_defaults_match_agent_create () =
   check_model "model" dc.model bc.model;
   Alcotest.(check (option string)) "system_prompt"
     dc.system_prompt bc.system_prompt;
-  Alcotest.(check int) "max_tokens" dc.max_tokens bc.max_tokens;
+  Alcotest.(check (option int)) "max_tokens" dc.max_tokens bc.max_tokens;
   Alcotest.(check int) "max_turns" dc.max_turns bc.max_turns;
   Alcotest.(check (option (float 0.001))) "temperature"
     dc.temperature bc.temperature;
@@ -713,7 +713,7 @@ let test_build_minimal_required_only () =
     Builder.create ~net ~model:"claude-3-7-sonnet" |> Builder.build_safe |> Result.get_ok in
   check_model "model" "claude-3-7-sonnet-20250219" (Agent.state agent).config.model;
   Alcotest.(check string) "name" "agent" (Agent.state agent).config.name;
-  Alcotest.(check int) "max_tokens" 4096 (Agent.state agent).config.max_tokens;
+  Alcotest.(check (option int)) "max_tokens" (Some 4096) (Agent.state agent).config.max_tokens;
   Alcotest.(check int) "max_turns" 10 (Agent.state agent).config.max_turns;
   Alcotest.(check int) "tools" 0 (Tool_set.size (Agent.tools agent));
   Alcotest.(check string) "base_url"

--- a/test/test_builder_coverage.ml
+++ b/test/test_builder_coverage.ml
@@ -30,7 +30,7 @@ let test_builder_chain () =
   | Ok agent ->
     let st = Agent.state agent in
     Alcotest.(check string) "name" "test-chain" st.config.name;
-    Alcotest.(check int) "max_tokens" 200 st.config.max_tokens;
+    Alcotest.(check (option int)) "max_tokens" (Some 200) st.config.max_tokens;
     Alcotest.(check int) "max_turns" 3 st.config.max_turns;
     (match Agent.description agent with
      | Some d -> Alcotest.(check string) "desc" "A test builder" d

--- a/test/test_cascade.ml
+++ b/test/test_cascade.ml
@@ -143,7 +143,7 @@ let test_builder_with_fallback () =
    Avoids parse_model_strings dependency on API key env vars in CI. *)
 let mock_provider kind model_id : Llm_provider.Provider_config.t =
   { kind; model_id; base_url = ""; api_key = ""; headers = [];
-    request_path = ""; max_tokens = 4096; max_context = None;
+    request_path = ""; max_tokens = Some 4096; max_context = None;
     temperature = None;
     top_p = None; top_k = None; min_p = None; system_prompt = None;
     enable_thinking = None; thinking_budget = None;

--- a/test/test_cascade_config.ml
+++ b/test/test_cascade_config.ml
@@ -57,7 +57,7 @@ let test_parse_with_temperature () =
   | Some cfg ->
     check (float 0.01) "temperature" 0.7
       (Option.value ~default:0.0 cfg.temperature);
-    check int "max_tokens" 1000 cfg.max_tokens
+    check (option int) "max_tokens" (Some 1000) cfg.max_tokens
   | None -> fail "expected Some"
 
 let test_parse_model_strings () =

--- a/test/test_cascade_config_ext.ml
+++ b/test/test_cascade_config_ext.ml
@@ -119,7 +119,7 @@ let test_parse_with_params () =
   | Some cfg ->
     check (float 0.01) "temperature" 0.7
       (Option.value ~default:0.0 cfg.temperature);
-    check int "max_tokens" 1000 cfg.max_tokens;
+    check (option int) "max_tokens" (Some 1000) cfg.max_tokens;
     check (option string) "system" (Some "You are helpful") cfg.system_prompt
   | None -> fail "expected Some"
 

--- a/test/test_cascade_deep.ml
+++ b/test/test_cascade_deep.ml
@@ -60,7 +60,7 @@ let test_parse_llama_with_temperature () =
   match r with
   | None -> Alcotest.fail "expected Some"
   | Some cfg ->
-    Alcotest.(check int) "max_tokens" 1024 cfg.max_tokens;
+    Alcotest.(check (option int)) "max_tokens" (Some 1024) cfg.max_tokens;
     Alcotest.(check (option (float 0.01))) "temperature" (Some 0.7) cfg.temperature
 
 let test_parse_llama_with_system_prompt () =
@@ -151,7 +151,7 @@ let test_parse_model_strings_with_params () =
       ["llama:m1"; "llama:m2"] in
   Alcotest.(check int) "two valid" 2 (List.length r);
   List.iter (fun (cfg : Provider_config.t) ->
-    Alcotest.(check int) "max_tokens" 200 cfg.max_tokens;
+    Alcotest.(check (option int)) "max_tokens" (Some 200) cfg.max_tokens;
     Alcotest.(check (option (float 0.01))) "temp" (Some 0.5) cfg.temperature;
     Alcotest.(check (option string)) "system_prompt" (Some "test") cfg.system_prompt
   ) r

--- a/test/test_deep_coverage.ml
+++ b/test/test_deep_coverage.ml
@@ -988,7 +988,7 @@ let test_builder_chaining () =
   | Ok agent ->
     let state = Agent.state agent in
     check string "name" "chained" state.config.name;
-    check int "max_tokens" 2048 state.config.max_tokens;
+    check (option int) "max_tokens" (Some 2048) state.config.max_tokens;
     check int "max_turns" 5 state.config.max_turns;
     check bool "thinking" true (state.config.enable_thinking = Some true)
   | Error e ->

--- a/test/test_e2e_v024.ml
+++ b/test/test_e2e_v024.ml
@@ -23,7 +23,7 @@ let base_url = "http://127.0.0.1:8085"
 
 let local_model = provider.model_id
 
-let qwen_config ?(system_prompt=None) ?(max_tokens=200) ?(max_turns=5) name = {
+let qwen_config ?(system_prompt=None) ?(max_tokens=Some 200) ?(max_turns=5) name = {
   default_config with
   name;
   model = local_model;

--- a/test/test_llm_call.ml
+++ b/test/test_llm_call.ml
@@ -21,7 +21,7 @@ let () =
     model = provider.model_id;
     system_prompt = Some "You are a helpful assistant. Reply in one sentence.";
     max_turns = 1;
-    max_tokens = 100;
+    max_tokens = Some 100;
   } in
   let messages = [{ Types.role = Types.User; content = [Types.Text "Say hello in exactly 5 words."]; name = None; tool_call_id = None }] in
   Printf.printf "Sending request...\n%!";

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -171,7 +171,7 @@ let test_parse_model_string_temperature () =
   match Cascade_config.parse_model_string ~temperature:0.7 ~max_tokens:100 "llama:m1" with
   | Some cfg ->
     Alcotest.(check (option (float 0.01))) "temp" (Some 0.7) cfg.temperature;
-    Alcotest.(check int) "max_tokens" 100 cfg.max_tokens
+    Alcotest.(check (option int)) "max_tokens" (Some 100) cfg.max_tokens
   | None -> Alcotest.fail "expected Some"
 
 let test_parse_model_string_system_prompt () =

--- a/test/test_local_llm.ml
+++ b/test/test_local_llm.ml
@@ -42,7 +42,7 @@ let test_simple_chat () =
   Printf.printf "\n=== Test 1: Simple chat ===\n%!";
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
-  let config = qwen_config "test-agent" None 100 1 in
+  let config = qwen_config "test-agent" None (Some 100) 1 in
   let agent = Agent.create ~net:env#net ~config ~options () in
   match Agent.run ~sw agent "What is 2+3? Answer with just the number." with
   | Ok response ->
@@ -67,7 +67,7 @@ let test_tool_calling () =
   let config =
     qwen_config "tool-agent"
       (Some "You are a helpful assistant. Use the provided tools to answer questions.")
-      200 3
+      (Some 200) 3
   in
   let calc_tool = Tool.create
     ~name:"calculator"
@@ -101,7 +101,7 @@ let test_multi_tool () =
   let config =
     qwen_config "multi-tool-agent"
       (Some "You have access to tools. Use read_file to check file contents.")
-      300 5
+      (Some 300) 5
   in
   let read_file_tool = Tool.create
     ~name:"read_file"

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -14,7 +14,7 @@ let test_make_defaults () =
   check_string "model_id" "test" cfg.model_id;
   check_string "base_url" "http://localhost:8080" cfg.base_url;
   check_string "api_key default empty" "" cfg.api_key;
-  check_int "max_tokens default" 4096 cfg.max_tokens;
+  check_bool "max_tokens default None" true (cfg.max_tokens = None);
   check_bool "temperature None" true (cfg.temperature = None);
   check_bool "top_p None" true (cfg.top_p = None);
   check_bool "top_k None" true (cfg.top_k = None);
@@ -82,7 +82,7 @@ let test_make_with_all_options () =
     ~response_format_json:true
     ~cache_system_prompt:true () in
   check_string "api_key" "sk-test" cfg.api_key;
-  check_int "max_tokens" 2048 cfg.max_tokens;
+  check_bool "max_tokens" true (cfg.max_tokens = Some 2048);
   check_bool "temperature" true (cfg.temperature = Some 0.7);
   check_bool "top_p" true (cfg.top_p = Some 0.9);
   check_bool "top_k" true (cfg.top_k = Some 40);

--- a/test/test_session_resume.ml
+++ b/test/test_session_resume.ml
@@ -252,7 +252,7 @@ let test_resume_custom_options () =
 let test_resume_with_config_override () =
   with_net @@ fun net ->
   let cp = make_checkpoint ~agent_name:"cp-name" () in
-  let cfg = { Types.default_config with max_turns = 50; max_tokens = 8192 } in
+  let cfg = { Types.default_config with max_turns = 50; max_tokens = Some 8192 } in
   let agent = Agent.resume ~net ~checkpoint:cp ~config:cfg () in
   (* checkpoint fields override config *)
   Alcotest.(check string) "name from checkpoint"
@@ -260,7 +260,7 @@ let test_resume_with_config_override () =
   (* config fields not in checkpoint are preserved *)
   Alcotest.(check int) "max_turns from config" 50
     (Agent.state agent).config.max_turns;
-  Alcotest.(check int) "max_tokens from config" 8192
+  Alcotest.(check (option int)) "max_tokens from config" (Some 8192)
     (Agent.state agent).config.max_tokens
 
 let test_resume_empty_checkpoint () =

--- a/test/test_streaming_e2e.ml
+++ b/test/test_streaming_e2e.ml
@@ -15,7 +15,7 @@ let test_stream_basic () =
     model = provider.model_id;
     system_prompt = Some "You are a helpful assistant. Reply briefly.";
     max_turns = 1;
-    max_tokens = 200;
+    max_tokens = Some 200;
   } in
   let messages = [
     { Types.role = Types.User;
@@ -78,7 +78,7 @@ let test_stream_event_sequence () =
     model = provider.model_id;
     system_prompt = Some "Reply with one word only.";
     max_turns = 1;
-    max_tokens = 50;
+    max_tokens = Some 50;
   } in
   let messages = [
     { Types.role = Types.User;

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -118,7 +118,7 @@ let test_add_usage_accumulates () =
 let test_default_config () =
   let c = Types.default_config in
   Alcotest.(check string) "name" "agent" c.name;
-  Alcotest.(check (option int)) "max_tokens" (Some 4096) c.max_tokens;
+  Alcotest.(check (option int)) "max_tokens" None c.max_tokens;
   Alcotest.(check int) "max_turns" 10 c.max_turns;
   Alcotest.(check bool) "no system prompt" true (c.system_prompt = None);
   Alcotest.(check bool) "no top_p" true (c.top_p = None);

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -118,7 +118,7 @@ let test_add_usage_accumulates () =
 let test_default_config () =
   let c = Types.default_config in
   Alcotest.(check string) "name" "agent" c.name;
-  Alcotest.(check int) "max_tokens" 4096 c.max_tokens;
+  Alcotest.(check (option int)) "max_tokens" (Some 4096) c.max_tokens;
   Alcotest.(check int) "max_turns" 10 c.max_turns;
   Alcotest.(check bool) "no system prompt" true (c.system_prompt = None);
   Alcotest.(check bool) "no top_p" true (c.top_p = None);


### PR DESCRIPTION
## Summary

`Provider_config.t.max_tokens`, `Types.agent_config.max_tokens`, and `Builder.t.max_tokens` are now `int option` instead of `int`.

- `None` = "defer to model capability" — resolved at request time via `Capabilities.for_model_id`
- `Some n` = "caller override, clamped to model cap when known"

## Why

masc-mcp hardcoded `keeper_unified_max_tokens = 65536` (mislabeled "OpenHands default" — OpenHands actually defaults to None/model-specific per issue #13565). GLM coding caps at 40960, Groq at 40960. The 65536 caused HTTP 400 → `ambiguous_partial_commit` → `manual_reconcile` deadlock on every keeper turn.

Emergency patches in the last 24h:
- #6681 removed providers from cascade
- #6687 lowered to 32768
- #6693 lowered to 16384

Each was an arbitrary number with no empirical basis. The correct fix: stop hardcoding, let the capability system resolve.

## Resolution logic (backend_openai.ml)

```ocaml
match config.max_tokens, caps.max_output_tokens with
| None, Some cap -> cap      (* defer → model ceiling *)
| None, None     -> 4096     (* unknown model fallback *)
| Some n, Some cap when n > cap -> cap  (* clamp + warn *)
| Some n, _      -> n        (* explicit, pass through *)
```

Other backends (Anthropic, Gemini, Ollama) use `Option.value ~default:4096` since their APIs require the field.

## API change

```ocaml
(* Before *)
Builder.with_max_tokens : int -> t -> t  (* mandatory *)

(* After *)
Builder.with_max_tokens : int -> t -> t  (* wraps in Some internally *)
(* Not calling with_max_tokens = None = dynamic resolution *)
```

Callers that want "use the model's own ceiling" simply don't call `with_max_tokens`. The default is `None`.

## Scope

36 files (19 lib + 2 examples + 15 tests). All mechanical `int → int option` propagation. Core semantic change is in `backend_openai.ml` (4-branch resolution) and `Provider_config.make` (default None).

## Test plan

- [x] `dune build --root .` → 0 errors
- [x] `dune runtest --root .` → all tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
