### PR TITLE
fix(throttle): raise Coding Plan concurrency 1 → 3

### DIFF
--- a/lib/llm_provider/zai_catalog.ml
+++ b/lib/llm_provider/zai_catalog.ml
@@ -124,7 +124,7 @@ let general_concurrency_for_model model_id =
   else if starts_with "glm-ocr" then 2
   else 1
 
-let coding_concurrency_default = 1
+let coding_concurrency_default = 3
 
 let throttle_key_for_chat ~base_url ~model_id =
   match mode_of_base_url base_url with


### PR DESCRIPTION
## Problem

6 keepers × 1 concurrency slot = 5 admission queue timeouts (45s) 매 cycle.

## Fix

`coding_concurrency_default` 1 → 3. API가 429로 자체 제한하므로 pre-throttle 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)