### PR TITLE
fix(glm): strip chat_template_kwargs from GLM request body

### DIFF
--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -158,6 +158,7 @@ let%test "build_request with thinking=false injects disabled" =
   let open Yojson.Safe.Util in
   let thinking = json |> member "thinking" in
   thinking |> member "type" |> to_string = "disabled"
+  && json |> member "chat_template_kwargs" = `Null
 
 let%test "check_glm_error detects string code" =
   let body = {|{"error":{"code":"1305","message":"service overloaded"}}|} in

--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -37,6 +37,13 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
             ("thinking", thinking) :: fields
         | None -> fields
       in
+      (* Strip chat_template_kwargs leaked from Backend_openai.
+         GLM does not recognize this llama.cpp/Ollama-specific field and
+         returns "Invalid API parameter" when present.  GLM thinking is
+         handled above via the native [thinking] parameter. *)
+      let fields =
+        List.filter (fun (k, _) -> k <> "chat_template_kwargs") fields
+      in
       let fields =
         if stream && config.tool_stream then
           ("tool_stream", `Bool true) :: fields
@@ -189,6 +196,18 @@ let%test "parse_stream_chunk delegates to openai" =
   match parse_stream_chunk data with
   | Some chunk -> chunk.delta_content = Some "hi"
   | None -> false
+
+let%test "build_request strips chat_template_kwargs from GLM body" =
+  let config = Provider_config.make
+    ~kind:Glm ~model_id:"glm-5.1"
+    ~base_url:"https://api.z.ai/api/coding/paas/v4"
+    ~enable_thinking:true () in
+  let messages = [{ role = User; content = [Text "hi"]; name = None; tool_call_id = None }] in
+  let body = build_request ~config ~messages () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  json |> member "chat_template_kwargs" = `Null
+  && json |> member "thinking" |> member "type" |> to_string = "enabled"
 
 let%test "build_request adds tool_stream when enabled" =
   let config = Provider_config.make


### PR DESCRIPTION
## Summary
- `Backend_openai.build_request` unconditionally adds `chat_template_kwargs` when `enable_thinking` is configured
- This is an llama.cpp/Ollama-specific field that GLM does not recognize
- GLM returns "Invalid API parameter, please check the documentation" (352+ events in 6h)
- Fix: strip `chat_template_kwargs` in `Backend_glm.build_request` since GLM thinking uses the native `thinking` parameter

## Changes
- `lib/llm_provider/backend_glm.ml`: add `List.filter` to remove `chat_template_kwargs` before serializing
- 1 new inline test verifying the field is stripped while `thinking` is preserved

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` passes
- [ ] Deploy to masc-mcp and verify GLM "Invalid API parameter" drops to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)