### PR TITLE
docs(rfc): RFC-OAS-002 OTel Metric Naming + RFC-OAS-004 Code Snippet Strategy

### DIFF
--- a/docs/rfc/RFC-OAS-002-otel-metric-naming-eval-feed.md
+++ b/docs/rfc/RFC-OAS-002-otel-metric-naming-eval-feed.md
@@ -120,7 +120,10 @@ OpenTelemetry GenAI SIG attribute는 span attribute로 유지:
           "layer_name": { "type": "string" },
           "passed": { "type": "boolean" },
           "score": { "type": ["number", "null"] },
-          "evidence": { "type": "string" },
+          "evidence": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
           "detail": { "type": ["string", "null"] }
         }
       }
@@ -179,7 +182,7 @@ val emit_run_metrics : Otel_tracer.t -> run_metrics -> unit
 - `docs/schemas/swiss-verdict.schema.json` 생성
 - `harness.ml`에 `swiss_verdict_to_json` 함수 추가 (schema 준수 보장)
 - `eval.ml`에 `run_metrics_to_json` 함수 추가
-- dune rule: schema validation test
+- dune rule: `ppx_deriving_yojson`로 생성된 `to_yojson`과 schema를 cross-check하는 테스트. OCaml 타입이 source-of-truth, schema는 파생물.
 
 ### Phase 3: Eval OTel Bridge (1 PR)
 - `eval_otel_bridge.ml` 신규 모듈
@@ -191,6 +194,7 @@ val emit_run_metrics : Otel_tracer.t -> run_metrics -> unit
 | Risk | Mitigation |
 |------|------------|
 | Metric rename이 기존 Grafana 대시보드를 깨뜨림 | Phase 1에서 1 cycle 동안 dual-emit. MASC dashboard 먼저 migration |
+| Dual-emit으로 metric cardinality 2배 증가 | Feature flag로 구이름 emit 대상을 선택적으로 제한. 전체 metric이 아닌 downstream consumer가 실제 사용하는 구이름만 dual-emit |
 | JSON Schema와 OCaml 타입 drift | dune rule로 CI에서 schema↔type 동기 검증 |
 | OTel GenAI SIG convention 변경 시 재작업 | `gen_ai.*`는 attribute만 사용, metric name은 `oas.*` 자체 namespace이므로 SIG 변경에 독립 |
 

--- a/docs/rfc/RFC-OAS-002-otel-metric-naming-eval-feed.md
+++ b/docs/rfc/RFC-OAS-002-otel-metric-naming-eval-feed.md
@@ -1,0 +1,203 @@
+# RFC-OAS-002: OTel Metric Naming Convention & Eval Feed Schema
+
+**Status**: Draft
+**Date**: 2026-04-13
+**Scope**: `lib/otel_tracer.ml`, `lib/eval.ml`, `lib/harness.ml`, `lib/llm_provider/metrics.ml`
+**One sentence**: OAS가 방출하는 OTel metric/span 이름을 `oas.*` namespace로 표준화하고, harness swiss_verdict를 JSON schema로 공개하여 외부 consumer(MASC dashboard, Grafana, CI)가 안정적으로 소비할 수 있게 한다.
+
+## Related Documents
+
+- PR #841 (merged 2026-04-12) — event bus에 `session_id`/`worker_run_id` correlation 추가
+- Issue #484 (open, Epic) — Delta-Context Architecture, checkpoint delta protocol
+- `lib/otel_tracer.ml` — 현재 OTel tracer (W3C trace/span ID, OTLP JSON export)
+- `lib/eval.ml` — `run_metrics`, `metric_value` 타입
+- `lib/harness.ml` — swiss_verdict, verdict, layer 타입
+- `lib/eval_baseline.ml` — regression detection (`Unchanged | Improved | Regressed | Added | Removed`)
+- `lib/checkpoint.ml` — delta metric names (`checkpoint_delta_*`)
+- `lib/llm_provider/metrics.ml` — provider-level event hooks
+- `lib/raw_trace.ml` — JSONL trace format (v1, 6 record types)
+- `docs/sdk-independence-principle.md` — MASC 어휘 역주입 금지
+
+## Problem Statement
+
+### 1. OTel Metric 이름 비표준
+
+현재 OAS는 OTel semantic attribute(`gen_ai.agent.name`, `gen_ai.turn`)와 자체 metric name(`checkpoint_delta_apply_total`)을 혼용한다. 문제:
+
+- **Namespace 충돌 위험**: `checkpoint_delta_*`는 OAS 고유이나 `gen_ai.*`는 OpenTelemetry GenAI SIG 공식 convention. OAS 자체 metric이 `gen_ai` 아래로 분류될 근거가 없음.
+- **Consumer 파편화**: MASC dashboard, Grafana, CI 각각이 metric name을 하드코딩. OAS가 이름을 바꾸면 downstream 전부 깨짐.
+- **검색 불가**: `oas`라는 prefix가 없어 OTel collector에서 OAS 메트릭만 필터링하기 어려움.
+
+### 2. Harness Verdict 스키마 비공개
+
+`harness.ml`의 `swiss_verdict`는 OCaml 타입으로만 정의되어 있다:
+
+```ocaml
+type verdict = { passed: bool; score: float option; evidence: string list; detail: string option }
+type 'obs swiss_verdict = { all_passed: bool; layer_results: 'obs layer_result list; coverage: float }
+```
+
+외부 consumer(MASC dashboard, CI reporter)가 이 구조를 안정적으로 파싱하려면 JSON Schema가 필요하다. 현재는 OCaml 소스를 읽어야 하고, 필드 추가/변경 시 downstream이 무예고로 깨진다.
+
+### 3. Eval Metric 표준화 부재
+
+`eval.ml`의 `metric_value`는 4-variant union(`Int_val | Float_val | Bool_val | String_val`)이지만, OTel metric으로 emit하는 경로가 없다. `run_metrics`가 수집하는 harness verdict와 trace summary도 OTel pipeline에 연결되지 않아 관측 불가.
+
+## Design
+
+### Part A: OTel Metric Naming Convention
+
+모든 OAS-emitted metric은 `oas.` prefix를 사용한다. OpenTelemetry GenAI SIG convention(`gen_ai.*`)은 semantic attribute로만 사용하고 metric name에는 쓰지 않는다.
+
+#### Naming Rules
+
+```
+oas.<subsystem>.<metric_name>[.<unit>]
+```
+
+| Rule | Example | Rationale |
+|------|---------|-----------|
+| Subsystem prefix | `oas.agent.turns_total` | OTel collector에서 `oas.*` 필터 가능 |
+| Snake_case | `oas.checkpoint.delta_apply_total` | OTel metric naming convention 준수 |
+| Unit suffix (선택) | `oas.llm.request_duration_seconds` | OTel unit convention |
+| Counter suffix `_total` | `oas.tool.calls_total` | Prometheus convention 호환 |
+
+#### Migration Table
+
+| 현재 이름 | 새 이름 | 타입 |
+|-----------|---------|------|
+| `checkpoint_delta_apply_total` | `oas.checkpoint.delta_apply_total` | counter |
+| `checkpoint_delta_apply_failures_total` | `oas.checkpoint.delta_apply_failures_total` | counter |
+| `checkpoint_delta_size_bytes` | `oas.checkpoint.delta_size_bytes` | histogram |
+| `checkpoint_full_restore_fallback_total` | `oas.checkpoint.full_restore_fallback_total` | counter |
+| (신규) | `oas.agent.turns_total` | counter |
+| (신규) | `oas.agent.run_duration_seconds` | histogram |
+| (신규) | `oas.tool.calls_total` | counter |
+| (신규) | `oas.tool.errors_total` | counter |
+| (신규) | `oas.tool.duration_seconds` | histogram |
+| (신규) | `oas.llm.requests_total` | counter |
+| (신규) | `oas.llm.tokens_input_total` | counter |
+| (신규) | `oas.llm.tokens_output_total` | counter |
+| (신규) | `oas.llm.cost_usd` | counter (monotonic) |
+| (신규) | `oas.llm.cache_hit_total` | counter |
+| (신규) | `oas.context.compaction_total` | counter |
+| (신규) | `oas.eval.verdict_passed_total` | counter |
+| (신규) | `oas.eval.verdict_failed_total` | counter |
+| (신규) | `oas.eval.coverage` | gauge (0.0-1.0) |
+
+#### Semantic Attributes (변경 없음)
+
+OpenTelemetry GenAI SIG attribute는 span attribute로 유지:
+- `gen_ai.agent.name` — agent 식별
+- `gen_ai.turn` — turn 번호
+- `gen_ai.operation.name` — operation 식별
+- `gen_ai.request.model` — (신규 권장) 요청 모델명
+
+### Part B: Swiss Verdict JSON Schema
+
+`harness.ml`의 verdict를 JSON Schema Draft 2020-12로 공개한다.
+
+#### Schema 파일
+
+`docs/schemas/swiss-verdict.schema.json`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "oas:swiss-verdict:v1",
+  "type": "object",
+  "required": ["schema_version", "all_passed", "coverage", "layer_results"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "all_passed": { "type": "boolean" },
+    "coverage": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+    "layer_results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["layer_name", "passed", "evidence"],
+        "properties": {
+          "layer_name": { "type": "string" },
+          "passed": { "type": "boolean" },
+          "score": { "type": ["number", "null"] },
+          "evidence": { "type": "string" },
+          "detail": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "eval_metrics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "value"],
+        "properties": {
+          "name": { "type": "string" },
+          "value": {},
+          "unit": { "type": ["string", "null"] },
+          "tags": {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### Versioning Contract
+
+- `schema_version` 필드로 하위호환 관리. 현재 v1.
+- 필드 추가 = minor bump (하위호환). 필드 제거/타입 변경 = major bump (breaking).
+- JSON Schema 파일은 `docs/schemas/`에 체크인. `dune` rule로 OCaml 타입과 schema 동기 검증.
+
+### Part C: Eval Metrics OTel Bridge
+
+`eval.ml`의 `run_metrics`를 OTel metric으로 emit하는 bridge를 추가한다.
+
+```ocaml
+(* eval_otel_bridge.ml *)
+val emit_run_metrics : Otel_tracer.t -> run_metrics -> unit
+(** run_metrics의 harness_verdicts → oas.eval.* counters,
+    trace_summary → oas.agent.* metrics로 변환 후 emit *)
+```
+
+동작:
+1. `harness_verdicts` iterate → `oas.eval.verdict_passed_total` / `oas.eval.verdict_failed_total` increment
+2. `coverage` → `oas.eval.coverage` gauge set
+3. `trace_summary` → `oas.agent.turns_total`, `oas.tool.calls_total` 등
+
+## Implementation Phases
+
+### Phase 1: Metric Naming Migration (1 PR)
+- `otel_tracer.ml`: `oas.*` namespace prefix 적용
+- `checkpoint.ml`: 4개 delta metric 이름 변경
+- `llm_provider/metrics.ml`: event hook metric을 `oas.llm.*`로 emit
+- 하위호환: 1 release cycle 동안 구이름/새이름 동시 emit, deprecated 경고
+
+### Phase 2: Swiss Verdict JSON Schema (1 PR)
+- `docs/schemas/swiss-verdict.schema.json` 생성
+- `harness.ml`에 `swiss_verdict_to_json` 함수 추가 (schema 준수 보장)
+- `eval.ml`에 `run_metrics_to_json` 함수 추가
+- dune rule: schema validation test
+
+### Phase 3: Eval OTel Bridge (1 PR)
+- `eval_otel_bridge.ml` 신규 모듈
+- `agent.ml`의 run 종료 시점에서 `emit_run_metrics` 호출
+- Integration test: mock tracer로 metric name/value 검증
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Metric rename이 기존 Grafana 대시보드를 깨뜨림 | Phase 1에서 1 cycle 동안 dual-emit. MASC dashboard 먼저 migration |
+| JSON Schema와 OCaml 타입 drift | dune rule로 CI에서 schema↔type 동기 검증 |
+| OTel GenAI SIG convention 변경 시 재작업 | `gen_ai.*`는 attribute만 사용, metric name은 `oas.*` 자체 namespace이므로 SIG 변경에 독립 |
+
+## Scope Exclusion
+
+- `Agent.replay_from()` API (Issue #484 Epic 범위)
+- Checkpoint delta protocol 변경 (Issue #484 Epic 범위)
+- Raw trace format 변경 (v1 유지)
+- MASC dashboard 코드 변경 (MASC 측 별도 작업, RFC-MASC-005에서 다룸)
+- Cost tracking OTel emit 세부 구현 (Phase 3에서 다루되 cost_tracker.ml 내부 로직 변경은 없음)

--- a/docs/rfc/RFC-OAS-004-code-snippet-tool-strategy.md
+++ b/docs/rfc/RFC-OAS-004-code-snippet-tool-strategy.md
@@ -85,6 +85,8 @@ type sandbox_mode =
         가장 안전하지만 활용 범위가 좁다. *)
   | Subprocess_sandbox of { timeout_s: float; memory_limit_mb: int }
     (** 별도 프로세스에서 실행. timeout + memory 제한.
+        DSL이 Turing-incomplete이므로 이론적으로 무한루프 불가이나,
+        tool callback의 I/O 지연이나 파서 버그에 대한 방어적 timeout.
         OAS가 직접 spawn하므로 MASC playground 불필요. *)
 ```
 
@@ -101,10 +103,9 @@ type snippet = {
 }
 
 type snippet_result =
-  | Success of { output: string; tool_calls_made: int; tokens_saved_estimate: int }
+  | Success of { output: string; tool_calls_made: int }
   | Parse_error of string
   | Sandbox_violation of string
-  | Timeout
 
 val parse : raw:string -> (snippet, string) result
 (** LLM 응답에서 code block을 추출하고 AST-level 검증.
@@ -168,6 +169,7 @@ type comparison = {
   json_mode: { turns: int; llm_calls: int; tokens: int; passed: bool };
   snippet_mode: { turns: int; llm_calls: int; tokens: int; passed: bool };
   call_reduction_pct: float;  (** (json - snippet) / json * 100 *)
+  tokens_saved: int;          (** json.tokens - snippet.tokens *)
 }
 
 val run_comparison :
@@ -178,7 +180,7 @@ val run_comparison :
     두 모드 모두 harness verdict를 통과해야 유효한 비교. *)
 ```
 
-**채택 기준**: 10+ task에서 평균 call_reduction_pct >= 25% AND snippet_mode.passed >= json_mode.passed.
+**채택 기준**: 10+ task에서 평균 call_reduction_pct >= 25% AND SUM(snippet_mode.passed) >= SUM(json_mode.passed) across all tasks.
 
 ## Implementation Phases
 
@@ -209,6 +211,7 @@ val run_comparison :
 |------|------------|
 | DSL이 너무 제한적이어서 LLM이 활용하지 못함 | Phase 3 eval에서 드러남. DSL 확장은 별도 RFC |
 | LLM이 DSL 대신 자연어/JSON으로 응답 | Fallback: JSON tool call 경로로 자동 전환 (기존 동작) |
+| LLM이 거의 맞지만 문법 오류가 있는 DSL 생성 (syntax hallucination) | 연속 Parse_error 2회 시 해당 turn을 JSON tool call로 강제 전환. 무한 retry 방지 |
 | Sandbox escape | DSL이 Turing-incomplete이므로 구조적 불가. Subprocess sandbox는 timeout+memory 하드 리밋 |
 | 실험 코드가 본 코드에 복잡도 추가 | env var guard + 별도 모듈 격리. 재현 실패 시 삭제 |
 | Smolagents의 30% 수치가 특정 모델/task에 특화 | OAS 자체 task set으로 독립 평가. Smolagents 수치를 목표가 아닌 참조만으로 사용 |

--- a/docs/rfc/RFC-OAS-004-code-snippet-tool-strategy.md
+++ b/docs/rfc/RFC-OAS-004-code-snippet-tool-strategy.md
@@ -1,0 +1,222 @@
+# RFC-OAS-004: Code-Snippet Tool Strategy (Experimental)
+
+**Status**: Draft
+**Date**: 2026-04-13
+**Scope**: `lib/tool_selector.ml`, `lib/tool_middleware.ml`, `lib/agent/agent.ml`
+**One sentence**: Smolagents가 주장하는 "code snippet으로 tool을 조합하면 JSON tool call 대비 LLM call 30% 감소" 가설을 OAS에서 재현 가능한 실험 프레임워크로 구현하고, trajectory eval로 재현 여부를 판정한다.
+
+## Related Documents
+
+- Smolagents (HuggingFace): code-based tool composition
+- `lib/tool_selector.mli` — 현재 4 strategy (`All`, `TopK_bm25`, `TopK_llm`, `Categorical`)
+- `lib/tool_middleware.ml` — tool execution pipeline, `heal_tool_call`
+- `lib/agent/agent.ml` — turn loop, tool dispatch
+- `lib/harness.ml` — trajectory eval, swiss_verdict
+- `lib/eval_baseline.ml` — regression detection
+- RFC-OAS-002 — OTel metric naming (eval metrics 표준화)
+
+## Problem Statement
+
+### 현재 상태
+
+OAS의 tool 실행 모델은 JSON-based tool call이다:
+1. LLM이 `tool_use` content block(JSON)을 생성
+2. OAS가 해당 tool을 dispatch하고 결과를 `tool_result`로 반환
+3. LLM이 결과를 보고 다음 행동 결정
+
+이 모델에서 **N개의 tool을 순차적으로 사용하려면 최소 N번의 LLM turn이 필요하다**(concurrent tool call 제외). 각 turn마다 전체 context를 LLM에 전송하므로 token 소비가 선형 증가한다.
+
+### Smolagents 가설
+
+Smolagents는 LLM이 JSON 대신 **code snippet을 생성**하여 여러 tool call을 하나의 코드 블록으로 조합할 수 있다고 주장한다:
+
+```python
+# JSON tool call: 3 turns 필요
+# Turn 1: search_files("auth")
+# Turn 2: read_file(results[0])
+# Turn 3: edit_file(results[0], patch)
+
+# Code snippet: 1 turn
+results = search_files("auth")
+content = read_file(results[0])
+edit_file(results[0], apply_patch(content, fix))
+```
+
+주장되는 이점: LLM call 30% 감소, context window 소비 감소.
+
+### 검증이 필요한 이유
+
+1. **재현 가능한 벤치마크가 없다**: Smolagents 공개 수치는 특정 task set에서의 결과. OAS agent의 실제 tool usage 패턴에서도 동일한 효과가 나는지 불명.
+2. **안전성 우려**: LLM이 생성한 코드를 실행하는 것은 sandbox 없이 위험. blast radius가 크다.
+3. **결정론 경계 붕괴**: code snippet은 본질적으로 비결정론적. determinism wrapper 내에서 실행해도 코드 자체의 side effect는 제어 불가.
+
+## Design
+
+### Principle: Experiment-First, Adopt-on-Evidence
+
+이 RFC는 **실험 프레임워크**를 구현한다. 채택은 trajectory eval에서 30% LLM call 감소가 재현될 때만. 재현 실패 시 RFC를 종결(Close)한다.
+
+### Part A: `CodeSnippet` Strategy Variant
+
+`tool_selector.ml`에 5번째 strategy를 추가한다:
+
+```ocaml
+type strategy =
+  | All
+  | TopK_bm25 of { ... }
+  | TopK_llm of { ... }
+  | Categorical of { ... }
+  | CodeSnippet of {
+      allowed_tools: string list;
+      (** Code snippet에서 호출 가능한 tool 이름 whitelist.
+          빈 리스트면 모든 tool 허용 (위험). *)
+      sandbox: sandbox_mode;
+      (** 실행 격리 수준. *)
+      max_snippet_lines: int;
+      (** 코드 블록 최대 줄 수. 기본 30. *)
+      experimental: bool;
+      (** true면 OAS_EXPERIMENTAL_CODE_SNIPPET env var 필요.
+          false면 항상 활성화 (채택 후에만). *)
+    }
+
+type sandbox_mode =
+  | Deterministic_only
+    (** Pure function만 허용. I/O tool 호출 시 즉시 abort.
+        가장 안전하지만 활용 범위가 좁다. *)
+  | Subprocess_sandbox of { timeout_s: float; memory_limit_mb: int }
+    (** 별도 프로세스에서 실행. timeout + memory 제한.
+        OAS가 직접 spawn하므로 MASC playground 불필요. *)
+```
+
+### Part B: Code Snippet Execution Engine
+
+`code_snippet_engine.ml` 신규 모듈:
+
+```ocaml
+(** LLM이 생성한 code snippet을 파싱하고 실행하는 엔진. *)
+
+type snippet = {
+  code: string;
+  tool_calls: string list;  (** 코드에서 참조하는 tool 이름 *)
+}
+
+type snippet_result =
+  | Success of { output: string; tool_calls_made: int; tokens_saved_estimate: int }
+  | Parse_error of string
+  | Sandbox_violation of string
+  | Timeout
+
+val parse : raw:string -> (snippet, string) result
+(** LLM 응답에서 code block을 추출하고 AST-level 검증.
+    허용되지 않는 구문(import, exec, eval 등)은 reject. *)
+
+val execute :
+  sandbox:sandbox_mode ->
+  tools:(string -> Yojson.Safe.t -> string) ->
+  snippet ->
+  snippet_result
+(** Snippet을 실행. tools 함수는 tool_name → input → output 매핑.
+    sandbox_mode에 따라 격리 수준 결정. *)
+```
+
+### Part C: DSL 설계 (JSON이 아닌 제한된 언어)
+
+LLM에게 OCaml이나 Python을 생성하도록 요청하는 것은 위험하다. 대신 **제한된 DSL**을 정의한다:
+
+```
+// Tool Composition DSL (v1)
+// 변수 바인딩, tool call, 조건분기만 허용
+
+let results = search_files("auth", limit=5)
+let first = results[0]
+let content = read_file(first.path)
+if contains(content, "deprecated") then
+  report("found deprecated auth")
+else
+  noop()
+```
+
+DSL 제약:
+- **허용**: `let` 바인딩, tool call, `if/then/else`, string literal, integer, array index
+- **금지**: loop(`for`, `while`), function 정의, import, system call, 변수 재할당
+- **타입**: string, int, bool, array, tool_result (opaque)
+- **파서**: 직접 구현 (OCaml parser combinator). 외부 인터프리터 의존 없음.
+
+이 제약으로 Turing-complete가 아니므로 무한 루프/자원 고갈 위험이 구조적으로 불가.
+
+### Part D: Turn Loop 통합
+
+`agent.ml` turn loop에 CodeSnippet 분기를 추가:
+
+```
+Turn Start
+  → Tool Selection (strategy = CodeSnippet)
+  → LLM에 DSL prompt 주입 ("다음 도구들을 조합하여 code snippet으로 응답하세요")
+  → LLM 응답 파싱
+    → JSON tool_use block이면: 기존 경로 (단일 tool dispatch)
+    → Code snippet block이면: DSL 파싱 → Sandbox 실행 → 결과를 tool_result로 반환
+  → 다음 turn (또는 종료)
+```
+
+### Part E: Trajectory Eval 프레임워크
+
+```ocaml
+(** code_snippet_eval.ml *)
+
+type comparison = {
+  task_name: string;
+  json_mode: { turns: int; llm_calls: int; tokens: int; passed: bool };
+  snippet_mode: { turns: int; llm_calls: int; tokens: int; passed: bool };
+  call_reduction_pct: float;  (** (json - snippet) / json * 100 *)
+}
+
+val run_comparison :
+  task:(Agent.t -> unit) ->
+  tools:Tool.t list ->
+  comparison
+(** 동일 task를 JSON mode와 CodeSnippet mode로 실행하여 비교.
+    두 모드 모두 harness verdict를 통과해야 유효한 비교. *)
+```
+
+**채택 기준**: 10+ task에서 평균 call_reduction_pct >= 25% AND snippet_mode.passed >= json_mode.passed.
+
+## Implementation Phases
+
+### Phase 1: DSL Parser + Sandbox (1 PR)
+- `code_snippet_dsl.ml` — parser combinator 기반 DSL 파서
+- `code_snippet_engine.ml` — `Deterministic_only` sandbox만 구현
+- Unit test: 정상 snippet 파싱, 금지 구문 reject, sandbox violation
+
+### Phase 2: Strategy Variant + Turn Loop 통합 (1 PR)
+- `tool_selector.ml`에 `CodeSnippet` variant 추가
+- `agent.ml` turn loop에 snippet 분기 추가
+- `OAS_EXPERIMENTAL_CODE_SNIPPET=true` env var guard
+- Integration test: mock tool로 snippet 실행 검증
+
+### Phase 3: Trajectory Eval (1 PR)
+- `code_snippet_eval.ml` — comparison 프레임워크
+- 최소 10개 task set 정의 (기존 harness 기반)
+- eval 실행 + 결과 보고서 생성
+
+### Phase 4: 판정 (코드 아님)
+- Phase 3 결과 분석
+- 25%+ call reduction 재현 시 → experimental flag 제거, `auto` 함수에 통합 검토
+- 재현 실패 시 → RFC 종결, Phase 1-3 코드는 `experimental/` 이동 또는 삭제
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| DSL이 너무 제한적이어서 LLM이 활용하지 못함 | Phase 3 eval에서 드러남. DSL 확장은 별도 RFC |
+| LLM이 DSL 대신 자연어/JSON으로 응답 | Fallback: JSON tool call 경로로 자동 전환 (기존 동작) |
+| Sandbox escape | DSL이 Turing-incomplete이므로 구조적 불가. Subprocess sandbox는 timeout+memory 하드 리밋 |
+| 실험 코드가 본 코드에 복잡도 추가 | env var guard + 별도 모듈 격리. 재현 실패 시 삭제 |
+| Smolagents의 30% 수치가 특정 모델/task에 특화 | OAS 자체 task set으로 독립 평가. Smolagents 수치를 목표가 아닌 참조만으로 사용 |
+
+## Scope Exclusion
+
+- Python/OCaml 코드 직접 실행 (DSL만 허용)
+- Loop 구문 (Turing-completeness 의도적 배제)
+- MASC keeper에서의 CodeSnippet 사용 (MASC는 OAS consumer이므로 별도 결정)
+- Subprocess sandbox의 Docker isolation (RFC-OAS-003C 범위)
+- Production 채택 (Phase 4 판정 이전까지 experimental only)


### PR DESCRIPTION
## Summary

- **RFC-OAS-002**: `oas.*` namespace로 OTel metric 표준화 + swiss_verdict JSON schema 공개 + eval OTel bridge
- **RFC-OAS-004**: Smolagents 30% LLM call reduction 가설 검증용 experimental code-snippet tool strategy (Turing-incomplete DSL)

## RFC Files

- `docs/rfc/RFC-OAS-002-otel-metric-naming-eval-feed.md` → #860
- `docs/rfc/RFC-OAS-004-code-snippet-tool-strategy.md` → #862

## Test plan

- [ ] RFC 내용 검토
- [ ] 교차 모델 리뷰 (GLM-5.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)