### PR TITLE
fix(provider): pass resolved api_key as static_token in config_of_provider_config

### DIFF
--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -462,25 +462,31 @@ let default_api_key_env_of_kind
     When [api_key] is empty, falls back to the well-known env var
     name for the provider kind (e.g. [ANTHROPIC_API_KEY]). *)
 let config_of_provider_config (pc : Llm_provider.Provider_config.t) : config =
+  (* When pc.api_key is non-empty it is the *resolved* API key value
+     (not an env var name).  Pass it via static_token + auth_header
+     so that resolve() includes it in the Authorization header without
+     a second Sys.getenv_opt lookup (which would fail because the
+     value is not an env var name).  When pc.api_key is empty, fall
+     back to api_key_env so resolve() can look up the env var. *)
+  let has_key = pc.api_key <> "" in
+  let auth_header = if has_key then Some "Authorization" else None in
+  let static_token = if has_key then Some pc.api_key else None in
   let provider = match pc.kind with
     | Anthropic -> Anthropic
     | Gemini ->
-      OpenAICompat { base_url = pc.base_url; auth_header = None;
-                     path = pc.request_path; static_token = None }
+      OpenAICompat { base_url = pc.base_url; auth_header;
+                     path = pc.request_path; static_token }
     | Glm ->
-      OpenAICompat { base_url = pc.base_url; auth_header = None;
-                     path = pc.request_path; static_token = None }
+      OpenAICompat { base_url = pc.base_url; auth_header;
+                     path = pc.request_path; static_token }
     | OpenAI_compat | Ollama ->
       if Llm_provider.Provider_config.is_local pc
       then Local { base_url = pc.base_url }
-      else OpenAICompat { base_url = pc.base_url; auth_header = None;
-                          path = pc.request_path; static_token = None }
+      else OpenAICompat { base_url = pc.base_url; auth_header;
+                          path = pc.request_path; static_token }
     | Claude_code ->
-      OpenAICompat { base_url = pc.base_url; auth_header = None;
-                     path = pc.request_path; static_token = None }
+      OpenAICompat { base_url = pc.base_url; auth_header;
+                     path = pc.request_path; static_token }
   in
-  let api_key_env =
-    if pc.api_key <> "" then pc.api_key
-    else default_api_key_env_of_kind pc.kind
-  in
+  let api_key_env = default_api_key_env_of_kind pc.kind in
   { provider; model_id = pc.model_id; api_key_env }


### PR DESCRIPTION
## Problem

After MASC Phase 2 cascade FSM (#6776) started using `Provider.config_of_provider_config` for all cascade providers, GLM calls fail with:
```
Auth error: Authentication parameter not received in Header, unable to authenticate
```

Root cause: `config_of_provider_config` puts `pc.api_key` (the resolved key **value**, e.g. `"aa9f..."`) into `api_key_env` (which expects an env var **name**). `resolve()` then calls `Sys.getenv_opt "aa9f..."` → `None` → no Authorization header sent.

## Fix

When `pc.api_key` is non-empty (already resolved by `make_registry_config`), pass it as `static_token` with `auth_header = Some "Authorization"`. `resolve()` picks up `static_token` directly via the first branch of the match, without a second `getenv` lookup.

| pc.api_key | Before | After |
|------------|--------|-------|
| `"aa9f..."` (resolved) | `api_key_env = "aa9f..."` → `getenv "aa9f..."` → None → no auth | `static_token = Some "aa9f..."` → `Authorization: Bearer aa9f...` |
| `""` (missing) | Falls through to `default_api_key_env_of_kind` | Same (unchanged) |

## Scope

1 file (`lib/provider.ml`), 18 lines changed. Affects all cloud providers converted via `config_of_provider_config`.

## Test plan

- [x] `dune build` green
- [x] `dune runtest` all tests pass
- [ ] CI green
- [ ] After masc-mcp pin bump: GLM auth passes, keeper turns succeed on GLM primary

🤖 Generated with [Claude Code](https://claude.com/claude-code)