### PR TITLE
feat: RFC-OAS-002 Phase 1+2 — metric naming + swiss verdict schema

### DIFF
--- a/docs/schemas/swiss-verdict.schema.json
+++ b/docs/schemas/swiss-verdict.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "oas:swiss-verdict:v1",
+  "type": "object",
+  "required": ["schema_version", "all_passed", "coverage", "layer_results"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "all_passed": { "type": "boolean" },
+    "coverage": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+    "layer_results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["layer_name", "passed", "evidence"],
+        "properties": {
+          "layer_name": { "type": "string" },
+          "passed": { "type": "boolean" },
+          "score": { "type": ["number", "null"] },
+          "evidence": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "detail": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "eval_metrics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "value"],
+        "properties": {
+          "name": { "type": "string" },
+          "value": {},
+          "unit": { "type": ["string", "null"] },
+          "tags": {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/checkpoint.ml
+++ b/lib/checkpoint.ml
@@ -387,10 +387,10 @@ let limits_patch_changed (before : t) (after : t) =
 let delta_version = 1
 
 let delta_metrics_names =
-  ( "checkpoint_delta_apply_total",
-    "checkpoint_delta_apply_failures_total",
-    "checkpoint_delta_size_bytes",
-    "checkpoint_full_restore_fallback_total" )
+  ( "oas.checkpoint.delta_apply_total",
+    "oas.checkpoint.delta_apply_failures_total",
+    "oas.checkpoint.delta_size_bytes",
+    "oas.checkpoint.full_restore_fallback_total" )
 
 let is_truthy = function
   | Some ("1" | "true" | "TRUE" | "yes" | "on") -> true

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -386,3 +386,57 @@ let compare_statistical ~(baselines : run_metrics list) ~(candidates : run_metri
     else None
   ) metric_names in
   regressions
+
+(* ── Swiss Verdict JSON export ───────────────────────────────── *)
+
+(** Produce a JSON object conforming to swiss-verdict.schema.json (v1).
+
+    Maps [harness_verdicts] into [layer_results] and [metrics] into
+    [eval_metrics].  Each [Harness.verdict] becomes one layer_result
+    entry using ordinal naming ("verdict_0", "verdict_1", ...). *)
+let run_metrics_to_json (rm : run_metrics) : Yojson.Safe.t =
+  let layer_results =
+    List.mapi (fun i (v : Harness.verdict) ->
+      `Assoc [
+        ("layer_name", `String (Printf.sprintf "verdict_%d" i));
+        ("passed", `Bool v.passed);
+        ("score", match v.score with Some s -> `Float s | None -> `Null);
+        ("evidence", `List (List.map (fun e -> `String e) v.evidence));
+        ("detail", match v.detail with Some d -> `String d | None -> `Null);
+      ]
+    ) rm.harness_verdicts
+  in
+  let all_passed =
+    List.for_all (fun (v : Harness.verdict) -> v.passed) rm.harness_verdicts
+  in
+  let coverage =
+    let total = List.length rm.harness_verdicts in
+    if total = 0 then 1.0
+    else
+      let passed = List.length (List.filter (fun (v : Harness.verdict) -> v.passed) rm.harness_verdicts) in
+      Float.of_int passed /. Float.of_int total
+  in
+  let eval_metrics =
+    List.map (fun (m : metric) ->
+      let base = [
+        ("name", `String m.name);
+        ("value", metric_value_to_yojson m.value);
+      ] in
+      let unit_part = match m.unit_ with
+        | Some u -> [("unit", `String u)]
+        | None -> [("unit", `Null)]
+      in
+      let tags_part = match m.tags with
+        | [] -> []
+        | tags -> [("tags", `Assoc (List.map (fun (k, v) -> (k, `String v)) tags))]
+      in
+      `Assoc (base @ unit_part @ tags_part)
+    ) rm.metrics
+  in
+  `Assoc [
+    ("schema_version", `Int 1);
+    ("all_passed", `Bool all_passed);
+    ("coverage", `Float coverage);
+    ("layer_results", `List layer_results);
+    ("eval_metrics", `List eval_metrics);
+  ]

--- a/lib/eval.mli
+++ b/lib/eval.mli
@@ -159,3 +159,11 @@ val compare_statistical :
   baselines:run_metrics list ->
   candidates:run_metrics list ->
   (string * float option) list
+
+(** {1 Swiss Verdict JSON export} *)
+
+(** Produce a JSON object conforming to
+    [docs/schemas/swiss-verdict.schema.json] (schema_version 1).
+    Maps [harness_verdicts] into [layer_results] (named "verdict_0",
+    "verdict_1", ...) and [metrics] into [eval_metrics]. *)
+val run_metrics_to_json : run_metrics -> Yojson.Safe.t

--- a/lib/harness.ml
+++ b/lib/harness.ml
@@ -557,3 +557,31 @@ module Model_grader = struct
           | Some s -> Some (Printf.sprintf "Score: %.2f (weight: %.2f)" s config.weight)
           | None -> Some "Could not extract score from model response" }
 end
+
+(* ── JSON serialization (Swiss Verdict Schema v1) ──────────── *)
+
+let verdict_to_json (v : verdict) : Yojson.Safe.t =
+  `Assoc [
+    ("passed", `Bool v.passed);
+    ("score", match v.score with Some s -> `Float s | None -> `Null);
+    ("evidence", `List (List.map (fun e -> `String e) v.evidence));
+    ("detail", match v.detail with Some d -> `String d | None -> `Null);
+  ]
+
+let swiss_verdict_to_json (sv : _ swiss_verdict) : Yojson.Safe.t =
+  let layer_result_to_json (lr : _ layer_result) : Yojson.Safe.t =
+    `Assoc [
+      ("layer_name", `String lr.layer_name);
+      ("passed", `Bool lr.layer_passed);
+      ("score", `Null);
+      ("evidence", `List [`String lr.layer_evidence]);
+      ("detail", `Null);
+    ]
+  in
+  `Assoc [
+    ("schema_version", `Int 1);
+    ("all_passed", `Bool sv.all_passed);
+    ("coverage", `Float sv.coverage);
+    ("layer_results",
+      `List (List.map layer_result_to_json sv.layer_results));
+  ]

--- a/lib/harness.mli
+++ b/lib/harness.mli
@@ -196,8 +196,10 @@ end
 (** {1 JSON serialization (Swiss Verdict Schema v1)} *)
 
 (** Serialize a verdict to JSON.
-    Conforms to the layer_result item shape in
-    [docs/schemas/swiss-verdict.schema.json]. *)
+    Emits the shared verdict fields used by Swiss Verdict layer results:
+    [passed], [score], [evidence], and [detail].
+    Callers that need a full schema-conformant [layer_result] object must
+    add [layer_name] separately. *)
 val verdict_to_json : verdict -> Yojson.Safe.t
 
 (** Serialize a swiss_verdict to JSON.

--- a/lib/harness.mli
+++ b/lib/harness.mli
@@ -192,3 +192,16 @@ module Model_grader : sig
     result:string ->
     verdict
 end
+
+(** {1 JSON serialization (Swiss Verdict Schema v1)} *)
+
+(** Serialize a verdict to JSON.
+    Conforms to the layer_result item shape in
+    [docs/schemas/swiss-verdict.schema.json]. *)
+val verdict_to_json : verdict -> Yojson.Safe.t
+
+(** Serialize a swiss_verdict to JSON.
+    Conforms to [docs/schemas/swiss-verdict.schema.json] (schema_version 1).
+    Each [layer_result.layer_evidence] is wrapped in a single-element list
+    to match the schema's [evidence: string array] shape. *)
+val swiss_verdict_to_json : _ swiss_verdict -> Yojson.Safe.t

--- a/test/dune
+++ b/test/dune
@@ -907,3 +907,7 @@
 (test
  (name test_uncertain)
  (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_swiss_verdict_json)
+ (libraries agent_sdk alcotest yojson))

--- a/test/test_checkpoint_delta.ml
+++ b/test/test_checkpoint_delta.ml
@@ -431,16 +431,16 @@ let test_restore_with_delta_fallback_records_failure_metrics () =
         |> Result.get_ok)
   in
   let apply_total =
-    Metrics.counter metrics ~name:"checkpoint_delta_apply_total" ~unit_:"1"
+    Metrics.counter metrics ~name:"oas.checkpoint.delta_apply_total" ~unit_:"1"
   in
   let apply_failures =
-    Metrics.counter metrics ~name:"checkpoint_delta_apply_failures_total" ~unit_:"1"
+    Metrics.counter metrics ~name:"oas.checkpoint.delta_apply_failures_total" ~unit_:"1"
   in
   let fallback_total =
-    Metrics.counter metrics ~name:"checkpoint_full_restore_fallback_total" ~unit_:"1"
+    Metrics.counter metrics ~name:"oas.checkpoint.full_restore_fallback_total" ~unit_:"1"
   in
   let size_histogram =
-    Metrics.histogram metrics ~name:"checkpoint_delta_size_bytes"
+    Metrics.histogram metrics ~name:"oas.checkpoint.delta_size_bytes"
       ~buckets:[ 128.; 512.; 1024.; 4096.; 16384.; 65536. ]
   in
   Alcotest.(check bool) "fallback used" true
@@ -471,10 +471,10 @@ let test_restore_with_delta_fallback_gate_skips_after_failure () =
         |> Result.get_ok)
   in
   let apply_total =
-    Metrics.counter metrics ~name:"checkpoint_delta_apply_total" ~unit_:"1"
+    Metrics.counter metrics ~name:"oas.checkpoint.delta_apply_total" ~unit_:"1"
   in
   let fallback_total =
-    Metrics.counter metrics ~name:"checkpoint_full_restore_fallback_total" ~unit_:"1"
+    Metrics.counter metrics ~name:"oas.checkpoint.full_restore_fallback_total" ~unit_:"1"
   in
   Alcotest.(check bool) "first fallback" true (first.mode = Checkpoint.Full_restore);
   Alcotest.(check bool) "gate fallback" true (second.mode = Checkpoint.Full_restore);

--- a/test/test_swiss_verdict_json.ml
+++ b/test/test_swiss_verdict_json.ml
@@ -1,0 +1,156 @@
+(** Tests for Swiss Verdict JSON serialization (RFC-OAS-002 Phase 2). *)
+
+open Agent_sdk
+
+(* ── Helpers ──────────────────────────────────────────────────── *)
+
+let get_field key json =
+  match json with
+  | `Assoc fields -> List.assoc key fields
+  | _ -> failwith (Printf.sprintf "expected object, got %s" (Yojson.Safe.to_string json))
+
+let get_string key json =
+  match get_field key json with
+  | `String s -> s
+  | j -> failwith (Printf.sprintf "expected string for %s, got %s" key (Yojson.Safe.to_string j))
+
+let get_bool key json =
+  match get_field key json with
+  | `Bool b -> b
+  | j -> failwith (Printf.sprintf "expected bool for %s, got %s" key (Yojson.Safe.to_string j))
+
+let get_int key json =
+  match get_field key json with
+  | `Int i -> i
+  | j -> failwith (Printf.sprintf "expected int for %s, got %s" key (Yojson.Safe.to_string j))
+
+let get_float key json =
+  match get_field key json with
+  | `Float f -> f
+  | j -> failwith (Printf.sprintf "expected float for %s, got %s" key (Yojson.Safe.to_string j))
+
+let get_list key json =
+  match get_field key json with
+  | `List l -> l
+  | j -> failwith (Printf.sprintf "expected list for %s, got %s" key (Yojson.Safe.to_string j))
+
+(* ── verdict_to_json ─────────────────────────────────────────── *)
+
+let test_verdict_to_json_passed () =
+  let v : Harness.verdict = {
+    passed = true; score = Some 0.95;
+    evidence = ["e1"; "e2"]; detail = Some "ok";
+  } in
+  let json = Harness.verdict_to_json v in
+  Alcotest.(check bool) "passed" true (get_bool "passed" json);
+  Alcotest.(check (float 0.001)) "score" 0.95 (get_float "score" json);
+  Alcotest.(check int) "evidence count" 2 (List.length (get_list "evidence" json));
+  Alcotest.(check string) "detail" "ok" (get_string "detail" json)
+
+let test_verdict_to_json_null_fields () =
+  let v : Harness.verdict = {
+    passed = false; score = None;
+    evidence = []; detail = None;
+  } in
+  let json = Harness.verdict_to_json v in
+  Alcotest.(check bool) "passed" false (get_bool "passed" json);
+  (match get_field "score" json with
+   | `Null -> ()
+   | _ -> Alcotest.fail "expected null score");
+  Alcotest.(check int) "evidence count" 0 (List.length (get_list "evidence" json));
+  (match get_field "detail" json with
+   | `Null -> ()
+   | _ -> Alcotest.fail "expected null detail")
+
+(* ── swiss_verdict_to_json ───────────────────────────────────── *)
+
+let test_swiss_verdict_to_json_schema_v1 () =
+  let sv : string Harness.swiss_verdict = {
+    all_passed = true;
+    layer_results = [
+      { layer_name = "layer_a"; layer_passed = true; layer_evidence = "ok" };
+      { layer_name = "layer_b"; layer_passed = true; layer_evidence = "good" };
+    ];
+    coverage = 1.0;
+  } in
+  let json = Harness.swiss_verdict_to_json sv in
+  Alcotest.(check int) "schema_version" 1 (get_int "schema_version" json);
+  Alcotest.(check bool) "all_passed" true (get_bool "all_passed" json);
+  Alcotest.(check (float 0.001)) "coverage" 1.0 (get_float "coverage" json);
+  let layers = get_list "layer_results" json in
+  Alcotest.(check int) "layer count" 2 (List.length layers);
+  let first = List.hd layers in
+  Alcotest.(check string) "layer_name" "layer_a" (get_string "layer_name" first);
+  Alcotest.(check bool) "passed" true (get_bool "passed" first);
+  let evidence = get_list "evidence" first in
+  Alcotest.(check int) "evidence count" 1 (List.length evidence)
+
+let test_swiss_verdict_to_json_partial_pass () =
+  let sv : string Harness.swiss_verdict = {
+    all_passed = false;
+    layer_results = [
+      { layer_name = "l1"; layer_passed = true; layer_evidence = "pass" };
+      { layer_name = "l2"; layer_passed = false; layer_evidence = "fail" };
+    ];
+    coverage = 0.5;
+  } in
+  let json = Harness.swiss_verdict_to_json sv in
+  Alcotest.(check bool) "all_passed" false (get_bool "all_passed" json);
+  Alcotest.(check (float 0.001)) "coverage" 0.5 (get_float "coverage" json)
+
+(* ── run_metrics_to_json ─────────────────────────────────────── *)
+
+let test_run_metrics_to_json_basic () =
+  let rm : Eval.run_metrics = {
+    run_id = "r1"; agent_name = "test"; timestamp = 100.0;
+    metrics = [
+      { Eval.name = "latency"; value = Float_val 42.0;
+        unit_ = Some "ms"; tags = [("env", "test")] };
+    ];
+    harness_verdicts = [
+      { Harness.passed = true; score = Some 1.0;
+        evidence = ["ok"]; detail = None };
+    ];
+    trace_summary = None;
+  } in
+  let json = Eval.run_metrics_to_json rm in
+  Alcotest.(check int) "schema_version" 1 (get_int "schema_version" json);
+  Alcotest.(check bool) "all_passed" true (get_bool "all_passed" json);
+  Alcotest.(check (float 0.001)) "coverage" 1.0 (get_float "coverage" json);
+  let layers = get_list "layer_results" json in
+  Alcotest.(check int) "layer count" 1 (List.length layers);
+  let first_layer = List.hd layers in
+  Alcotest.(check string) "layer_name" "verdict_0" (get_string "layer_name" first_layer);
+  let eval_metrics = get_list "eval_metrics" json in
+  Alcotest.(check int) "eval_metrics count" 1 (List.length eval_metrics);
+  let first_metric = List.hd eval_metrics in
+  Alcotest.(check string) "metric name" "latency" (get_string "name" first_metric)
+
+let test_run_metrics_to_json_empty () =
+  let rm : Eval.run_metrics = {
+    run_id = "r2"; agent_name = "empty"; timestamp = 0.0;
+    metrics = []; harness_verdicts = []; trace_summary = None;
+  } in
+  let json = Eval.run_metrics_to_json rm in
+  Alcotest.(check bool) "all_passed vacuous" true (get_bool "all_passed" json);
+  Alcotest.(check (float 0.001)) "coverage vacuous" 1.0 (get_float "coverage" json);
+  Alcotest.(check int) "no layers" 0 (List.length (get_list "layer_results" json));
+  Alcotest.(check int) "no metrics" 0 (List.length (get_list "eval_metrics" json))
+
+(* ── Runner ───────────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Swiss Verdict JSON" [
+    "verdict_to_json", [
+      Alcotest.test_case "passed verdict" `Quick test_verdict_to_json_passed;
+      Alcotest.test_case "null fields" `Quick test_verdict_to_json_null_fields;
+    ];
+    "swiss_verdict_to_json", [
+      Alcotest.test_case "schema v1" `Quick test_swiss_verdict_to_json_schema_v1;
+      Alcotest.test_case "partial pass" `Quick test_swiss_verdict_to_json_partial_pass;
+    ];
+    "run_metrics_to_json", [
+      Alcotest.test_case "basic" `Quick test_run_metrics_to_json_basic;
+      Alcotest.test_case "empty" `Quick test_run_metrics_to_json_empty;
+    ];
+  ]


### PR DESCRIPTION
## Summary

Implements RFC-OAS-002 Phase 1 (metric naming migration) and Phase 2 (Swiss Verdict JSON schema + serialization).

### Phase 1: Metric Naming Migration
- Renamed 4 checkpoint delta metrics from flat names (`checkpoint_delta_*`) to OTel-standard `oas.*` namespace (`oas.checkpoint.*`)
- Updated all test references to match new metric names
- All 10 checkpoint delta tests pass

### Phase 2: Swiss Verdict JSON Schema
- Added `docs/schemas/swiss-verdict.schema.json` (JSON Schema Draft 2020-12, v1)
- Added `Harness.verdict_to_json` and `Harness.swiss_verdict_to_json` with `.mli` signatures
- Added `Eval.run_metrics_to_json` mapping harness_verdicts to layer_results and metrics to eval_metrics
- 6 new alcotest tests covering passed/null/partial/empty cases

### Files Changed

| File | Change |
|------|--------|
| `lib/checkpoint.ml` | 4 metric names renamed to `oas.*` |
| `lib/harness.ml` + `.mli` | `verdict_to_json`, `swiss_verdict_to_json` |
| `lib/eval.ml` + `.mli` | `run_metrics_to_json` |
| `docs/schemas/swiss-verdict.schema.json` | New schema file (v1) |
| `test/test_checkpoint_delta.ml` | Updated metric names |
| `test/test_swiss_verdict_json.ml` | New test (6 cases) |
| `test/dune` | Test entry for `test_swiss_verdict_json` |

## Test plan

- [x] `dune build --root .` passes
- [x] `test_checkpoint_delta.exe` — 10 tests pass with new metric names
- [x] `test_swiss_verdict_json.exe` — 6 tests pass
- [ ] Full `make test` CI run

## Note

Phase 3 (Eval OTel Bridge) is a separate PR per RFC.

Generated with [Claude Code](https://claude.com/claude-code)