### PR TITLE
chore: remove deprecated providers, vote mechanism, and stale aliases

### DIFF
--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -323,10 +323,6 @@ let local_llm () = {
   api_key_env = "DUMMY_KEY";
 }
 
-(* Backward-compatible aliases — use local_llm instead *)
-let local_qwen () = local_llm ()
-let local_mlx () = local_llm ()
-
 let anthropic_sonnet () = {
   provider = Anthropic;
   model_id = "claude-sonnet-4-6";

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -113,12 +113,6 @@ val anthropic_haiku : unit -> config
 val anthropic_opus : unit -> config
 val openrouter : ?model_id:string -> unit -> config
 
-(** @deprecated Use {!local_llm} instead *)
-val local_qwen : unit -> config
-
-(** @deprecated Use {!local_llm} instead. MLX removed. *)
-val local_mlx : unit -> config
-
 (** {2 Cascade: multi-provider failover} *)
 
 type cascade = {

--- a/lib/runtime.ml
+++ b/lib/runtime.ml
@@ -55,15 +55,6 @@ type artifact = {
 }
 [@@deriving yojson, show]
 
-type vote = {
-  topic: string;
-  options: string list;
-  choice: string;
-  actor: string option;
-  created_at: float;
-}
-[@@deriving yojson, show]
-
 (** Runtime session — wire protocol record. *)
 type session = {
   session_id: string;
@@ -178,14 +169,6 @@ type attach_artifact_request = {
 }
 [@@deriving yojson, show]
 
-type vote_request = {
-  topic: string;
-  options: string list;
-  choice: string;
-  actor: string option;
-}
-[@@deriving yojson, show]
-
 type checkpoint_request = {
   label: string option;
 }
@@ -201,7 +184,6 @@ type command =
   | Spawn_agent of spawn_agent_request
   | Update_session_settings of update_settings_request
   | Attach_artifact of attach_artifact_request
-  | Vote of vote_request
   | Checkpoint of checkpoint_request
   | Request_finalize of finalize_request
 [@@deriving yojson, show]
@@ -274,7 +256,6 @@ type event_kind =
   | Agent_completed of participant_event
   | Agent_failed of participant_event
   | Artifact_attached of artifact_event
-  | Vote_recorded of vote
   | Checkpoint_saved of checkpoint_event
   | Finalize_requested of finalize_request
   | Session_completed of completion_event

--- a/lib/runtime.ml
+++ b/lib/runtime.ml
@@ -82,7 +82,6 @@ type session = {
   planned_participants: string list;
   participants: participant list;
   artifacts: artifact list;
-  votes: vote list; [@default []]     (** Deprecated. Wire-compat: kept with default for decode. *)
   turn_count: int;
   last_seq: int;
   outcome: string option;

--- a/lib/runtime.mli
+++ b/lib/runtime.mli
@@ -61,15 +61,6 @@ type artifact = {
 }
 [@@deriving yojson, show]
 
-type vote = {
-  topic: string;
-  options: string list;
-  choice: string;
-  actor: string option;
-  created_at: float;
-}
-[@@deriving yojson, show]
-
 (** Runtime session — wire protocol record. *)
 type session = {
   session_id: string;
@@ -179,14 +170,6 @@ type spawn_agent_request = {
 type attach_artifact_request = { name: string; kind: string; content: string }
 [@@deriving yojson, show]
 
-type vote_request = {
-  topic: string;
-  options: string list;
-  choice: string;
-  actor: string option;
-}
-[@@deriving yojson, show]
-
 type checkpoint_request = { label: string option }
 [@@deriving yojson, show]
 
@@ -198,7 +181,6 @@ type command =
   | Spawn_agent of spawn_agent_request
   | Update_session_settings of update_settings_request
   | Attach_artifact of attach_artifact_request
-  | Vote of vote_request
   | Checkpoint of checkpoint_request
   | Request_finalize of finalize_request
 [@@deriving yojson, show]
@@ -259,7 +241,6 @@ type event_kind =
   | Agent_completed of participant_event
   | Agent_failed of participant_event
   | Artifact_attached of artifact_event
-  | Vote_recorded of vote
   | Checkpoint_saved of checkpoint_event
   | Finalize_requested of finalize_request
   | Session_completed of completion_event

--- a/lib/runtime.mli
+++ b/lib/runtime.mli
@@ -88,7 +88,6 @@ type session = {
   planned_participants: string list;
   participants: participant list;
   artifacts: artifact list;
-  votes: vote list; (** Deprecated. Wire-compat: kept with default for decode. *)
   turn_count: int;
   last_seq: int;
   outcome: string option;

--- a/lib/runtime_evidence.ml
+++ b/lib/runtime_evidence.ml
@@ -139,7 +139,6 @@ let participant_and_detail_of_event = function
       (Some detail.participant_name, detail.error)
   | Artifact_attached detail ->
       (None, Some (detail.name ^ ":" ^ detail.kind))
-  | Vote_recorded vote -> (vote.actor, Some vote.topic)
   | Checkpoint_saved detail -> (None, detail.label)
   | Finalize_requested detail -> (None, detail.reason)
   | Session_completed detail -> (None, detail.outcome)
@@ -162,7 +161,6 @@ let event_name_of_kind = function
   | Agent_completed _ -> "agent_completed"
   | Agent_failed _ -> "agent_failed"
   | Artifact_attached _ -> "artifact_attached"
-  | Vote_recorded _ -> "vote_recorded"
   | Checkpoint_saved _ -> "checkpoint_saved"
   | Finalize_requested _ -> "finalize_requested"
   | Session_completed _ -> "session_completed"
@@ -203,8 +201,6 @@ let structured_fields_of_event = function
         Some detail.kind,
         None,
         None )
-  | Vote_recorded vote ->
-      (vote.actor, None, None, None, None, None, None, None, None)
   | Checkpoint_saved detail ->
       (None, None, None, None, None, None, None, detail.label, None)
   | Finalize_requested _ ->

--- a/lib/runtime_projection.ml
+++ b/lib/runtime_projection.ml
@@ -56,7 +56,6 @@ let initial_session (request : start_request) =
     planned_participants = request.participants;
     participants = List.map make_planned_participant request.participants;
     artifacts = [];
-    votes = [];
     turn_count = 0;
     last_seq = 0;
     outcome = None;

--- a/lib/runtime_projection.ml
+++ b/lib/runtime_projection.ml
@@ -272,11 +272,6 @@ let apply_event (session : session) (event : event) =
         }
       in
       Ok { session with artifacts = Util.snoc session.artifacts artifact }
-  | Vote_recorded _ ->
-      (* Vote events are intentionally ignored in projection;
-         vote state is handled by downstream consumers. *)
-      let* session = ensure_active_phase session in
-      Ok session
   | Checkpoint_saved _ ->
       let* session = ensure_active_phase session in
       Ok session

--- a/lib/runtime_server.ml
+++ b/lib/runtime_server.ml
@@ -280,18 +280,6 @@ let apply_command ~sw state store (session : session) command =
              })
       in
       Ok (Command_applied session)
-  | Vote detail ->
-      let vote =
-        {
-          topic = detail.topic;
-          options = detail.options;
-          choice = detail.choice;
-          actor = detail.actor;
-          created_at = Unix.gettimeofday ();
-        }
-      in
-      let* session, _ = persist_event store state session_id (Vote_recorded vote) in
-      Ok (Command_applied session)
   | Checkpoint detail ->
       let path =
         Runtime_store.snapshot_path store session.session_id
@@ -548,17 +536,6 @@ let%test "request roundtrip: Apply_command with Record_turn" =
       session_id = "s123" && actor = Some "alice" && message = "hello"
   | _ -> false
 
-let%test "request roundtrip: Apply_command with Vote" =
-  let req = Apply_command {
-    session_id = "s1";
-    command = Vote { topic = "color"; options = ["red"; "blue"]; choice = "red"; actor = Some "bob" }
-  } in
-  let json_str = request_to_string req in
-  match request_of_string json_str with
-  | Ok (Apply_command { command = Vote { topic; options; choice; _ }; _ }) ->
-      topic = "color" && options = ["red"; "blue"] && choice = "red"
-  | _ -> false
-
 (* --- response serialization roundtrip --- *)
 
 let%test "response roundtrip: Shutdown_ack" =
@@ -690,15 +667,6 @@ let%test "event roundtrip: Artifact_attached" =
   let json = event_to_yojson event in
   match event_of_yojson json with
   | Ok e -> (match e.kind with Artifact_attached { artifact_id = "art-1"; size_bytes = 1234; _ } -> true | _ -> false)
-  | Error _ -> false
-
-let%test "event roundtrip: Vote_recorded" =
-  let event = { seq = 5; ts = 400.0;
-                kind = Vote_recorded { topic = "color"; options = ["red"; "blue"];
-                  choice = "red"; actor = Some "bob"; created_at = 400.0 } } in
-  let json = event_to_yojson event in
-  match event_of_yojson json with
-  | Ok e -> (match e.kind with Vote_recorded { topic = "color"; _ } -> true | _ -> false)
   | Error _ -> false
 
 let%test "event roundtrip: Checkpoint_saved" =

--- a/lib/runtime_server_resolve.ml
+++ b/lib/runtime_server_resolve.ml
@@ -42,7 +42,7 @@ let resolve_provider ?provider ?model () =
     | "mock" | "echo" ->
         let* () = ensure_test_provider_enabled selected in
         Ok None
-    | "local" | "local-qwen" -> Ok (Some (Provider.local_llm ()))
+    | "local" -> Ok (Some (Provider.local_llm ()))
     | "sonnet" -> Ok (Some (Provider.anthropic_sonnet ()))
     | "haiku" -> Ok (Some (Provider.anthropic_haiku ()))
     | "opus" -> Ok (Some (Provider.anthropic_opus ()))
@@ -50,7 +50,7 @@ let resolve_provider ?provider ?model () =
     | other ->
         unsupported_provider
           (Printf.sprintf
-             "unknown provider %S; valid: local, local-qwen, sonnet, haiku, opus, openrouter%s"
+             "unknown provider %S; valid: local, sonnet, haiku, opus, openrouter%s"
              other
              (if Defaults.allow_test_providers ()
               then ", mock, echo"

--- a/lib/sessions_store_parsers.ml
+++ b/lib/sessions_store_parsers.ml
@@ -102,7 +102,6 @@ let infer_event_name_from_kind kind =
       ("Agent_completed", "agent_completed");
       ("Agent_failed", "agent_failed");
       ("Artifact_attached", "artifact_attached");
-      ("Vote_recorded", "vote_recorded");
       ("Checkpoint_saved", "checkpoint_saved");
       ("Finalize_requested", "finalize_requested");
       ("Session_completed", "session_completed");

--- a/test/test_conformance_cov2.ml
+++ b/test/test_conformance_cov2.ml
@@ -16,7 +16,7 @@ let make_session ?(session_id = "sess-c2") ?(goal = "cov2") () : Runtime.session
     provider = None; model = None; system_prompt = None;
     max_turns = 10; workdir = None;
     planned_participants = []; participants = [];
-    artifacts = []; votes = []; turn_count = 0;
+    artifacts = []; turn_count = 0;
     last_seq = 0; outcome = None;
   }
 

--- a/test/test_conformance_pure.ml
+++ b/test/test_conformance_pure.ml
@@ -21,7 +21,6 @@ let make_session ?(session_id = "sess-001") ?(goal = "test")
     planned_participants = [];
     participants;
     artifacts = [];
-    votes = [];
     turn_count = 0;
     last_seq = 0;
     outcome = None;

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -158,18 +158,6 @@ let test_model_spec_openrouter_capabilities () =
   Alcotest.(check bool) "supports json response" true
     spec.capabilities.supports_response_format_json
 
-let test_inference_contract_local_qwen () =
-  let cfg : Provider.config = {
-    provider = Local { base_url = "http://127.0.0.1:8085" };
-    model_id = "qwen3.5-35b-a3b-ud-q8-xl";
-    api_key_env = "DUMMY_KEY";
-  } in
-  let contract = Provider.inference_contract_of_config cfg in
-  Alcotest.(check string) "model_id" "qwen3.5-35b-a3b-ud-q8-xl" contract.model_id;
-  Alcotest.(check string) "modality" "text"
-    (Provider.modality_to_string contract.modality);
-  Alcotest.(check (option string)) "task" None contract.task
-
 let test_inference_contract_anthropic_multimodal () =
   let contract =
     Provider.inference_contract_of_config (Provider.anthropic_sonnet ())
@@ -479,8 +467,6 @@ let () =
         test_model_spec_local_llm_capabilities;
       Alcotest.test_case "openrouter model spec capabilities" `Quick
         test_model_spec_openrouter_capabilities;
-      Alcotest.test_case "inference contract local qwen" `Quick
-        test_inference_contract_local_qwen;
       Alcotest.test_case "inference contract anthropic multimodal" `Quick
         test_inference_contract_anthropic_multimodal;
       Alcotest.test_case "task inference transcription" `Quick

--- a/test/test_retry.ml
+++ b/test/test_retry.ml
@@ -240,11 +240,6 @@ let test_provider_constructors () =
   check string "anthropic_haiku" "claude-haiku-4-5-20251001" p.model_id;
   let p = Provider.anthropic_opus () in
   check string "anthropic_opus" "claude-opus-4-6" p.model_id;
-  (* deprecated aliases still work *)
-  let p = (Provider.local_qwen [@alert "-deprecated"]) () in
-  check string "local_qwen deprecated alias" "default" p.model_id;
-  let p = (Provider.local_mlx [@alert "-deprecated"]) () in
-  check string "local_mlx deprecated alias" "default" p.model_id;
   let p = Provider.openrouter () in
   check string "openrouter default" "anthropic/claude-sonnet-4-6" p.model_id;
   let p = Provider.openrouter ~model_id:"google/gemini-2.5-pro" () in

--- a/test/test_runtime_evidence.ml
+++ b/test/test_runtime_evidence.ml
@@ -18,7 +18,6 @@ let base_session : Runtime.session =
     planned_participants = [ "worker" ];
     participants = [];
     artifacts = [];
-    votes = [];
     turn_count = 1;
     last_seq = 3;
     outcome = Some "done";

--- a/test/test_runtime_projection_cov2.ml
+++ b/test/test_runtime_projection_cov2.ml
@@ -30,7 +30,6 @@ let mk_session
     ?(phase = Runtime.Running)
     ?(participants = [])
     ?(artifacts = [])
-    ?(votes = [])
     ?(outcome = None)
     ?(turn_count = 0)
     ?(last_seq = 0)
@@ -43,7 +42,7 @@ let mk_session
     system_prompt = Some "sys"; max_turns = 10;
     workdir = Some "/tmp";
     planned_participants = List.map (fun (p : Runtime.participant) -> p.name) participants;
-    participants; artifacts; votes;
+    participants; artifacts;
     turn_count; last_seq; outcome;
   }
 

--- a/test/test_runtime_projection_cov2.ml
+++ b/test/test_runtime_projection_cov2.ml
@@ -277,19 +277,6 @@ let test_apply_artifact_attached () =
     Alcotest.(check string) "id" "art-1" a.artifact_id
   | Error e -> Alcotest.fail (Error.to_string e)
 
-(* ── apply_event: Vote_recorded ───────────────────────── *)
-
-let test_apply_vote_recorded () =
-  let session = mk_session () in
-  let vote : Runtime.vote = {
-    topic = "ready"; options = ["yes"; "no"]; choice = "yes";
-    actor = Some "alice"; created_at = 100.0;
-  } in
-  let event = mk_event (Vote_recorded vote) in
-  match Runtime_projection.apply_event session event with
-  | Ok s -> Alcotest.(check int) "turn_count unchanged" 0 s.turn_count
-  | Error e -> Alcotest.fail (Error.to_string e)
-
 (* ── apply_event: Checkpoint_saved ────────────────────── *)
 
 let test_apply_checkpoint_saved () =
@@ -506,7 +493,6 @@ let () =
       Alcotest.test_case "Completed" `Quick test_apply_agent_completed;
       Alcotest.test_case "Failed" `Quick test_apply_agent_failed;
       Alcotest.test_case "Artifact_attached" `Quick test_apply_artifact_attached;
-      Alcotest.test_case "Vote_recorded" `Quick test_apply_vote_recorded;
       Alcotest.test_case "Checkpoint_saved" `Quick test_apply_checkpoint_saved;
       Alcotest.test_case "Finalize_requested" `Quick test_apply_finalize_requested;
       Alcotest.test_case "Session_completed" `Quick test_apply_session_completed;

--- a/test/test_runtime_server_resolve.ml
+++ b/test/test_runtime_server_resolve.ml
@@ -129,14 +129,6 @@ let test_resolve_provider_local () =
       | _ -> Alcotest.fail "expected local provider")
   | _ -> Alcotest.fail "expected Ok (Some cfg)"
 
-let test_resolve_provider_local_qwen () =
-  match Runtime_server_resolve.resolve_provider ~provider:"local-qwen" () with
-  | Ok (Some cfg) -> (
-      match cfg.Provider.provider with
-      | Provider.Local _ -> ()
-      | _ -> Alcotest.fail "expected local provider")
-  | _ -> Alcotest.fail "expected Ok (Some cfg)"
-
 let test_resolve_provider_sonnet () =
   match Runtime_server_resolve.resolve_provider ~provider:"sonnet" () with
   | Ok (Some cfg) -> Alcotest.(check bool) "anthropic" true (cfg.Provider.provider = Provider.Anthropic)
@@ -301,8 +293,6 @@ let () =
             test_resolve_provider_mock_rejected_by_default;
           Alcotest.test_case "local returns Local provider" `Quick
             test_resolve_provider_local;
-          Alcotest.test_case "local-qwen returns Local provider" `Quick
-            test_resolve_provider_local_qwen;
           Alcotest.test_case "sonnet returns Anthropic" `Quick
             test_resolve_provider_sonnet;
           Alcotest.test_case "haiku returns Anthropic" `Quick

--- a/test/test_runtime_server_resolve.ml
+++ b/test/test_runtime_server_resolve.ml
@@ -28,7 +28,6 @@ let dummy_session : Runtime.session =
     planned_participants = [];
     participants = [];
     artifacts = [];
-    votes = [];
     turn_count = 0;
     last_seq = 0;
     outcome = None;

--- a/test/test_runtime_server_worker.ml
+++ b/test/test_runtime_server_worker.ml
@@ -18,7 +18,6 @@ let dummy_session : Runtime.session =
     planned_participants = [];
     participants = [];
     artifacts = [];
-    votes = [];
     turn_count = 0;
     last_seq = 5;
     outcome = None;

--- a/test/test_runtime_store_unit.ml
+++ b/test/test_runtime_store_unit.ml
@@ -120,7 +120,6 @@ let mk_session ?(session_id = "test-sess") () : Runtime.session =
     planned_participants = ["agent-1"];
     participants = [];
     artifacts = [];
-    votes = [];
     turn_count = 0;
     last_seq = 0;
     outcome = None }

--- a/test/test_runtime_types.ml
+++ b/test/test_runtime_types.ml
@@ -111,7 +111,6 @@ let test_session () =
       last_error = None;
     }];
     artifacts = [];
-    votes = [];
     turn_count = 0; last_seq = 0;
     outcome = None;
   } in

--- a/test/test_runtime_types.ml
+++ b/test/test_runtime_types.ml
@@ -75,18 +75,6 @@ let test_artifact () =
     ~show:Runtime.show_artifact
     ~name:"artifact" v
 
-let test_vote () =
-  let v : Runtime.vote = {
-    topic = "approve changes"; options = ["yes"; "no"];
-    choice = "yes"; actor = Some "reviewer";
-    created_at = 1.7e9;
-  } in
-  roundtrip
-    ~to_yojson:Runtime.vote_to_yojson
-    ~of_yojson:Runtime.vote_of_yojson
-    ~show:Runtime.show_vote
-    ~name:"vote" v
-
 let test_session () =
   let v : Runtime.session = {
     session_id = "sess-rt"; goal = "test runtime";
@@ -235,15 +223,6 @@ let test_attach_artifact_request () =
     ~of_yojson:Runtime.attach_artifact_request_of_yojson
     ~show:Runtime.show_attach_artifact_request ~name:"attach_artifact" v
 
-let test_vote_request () =
-  let v : Runtime.vote_request = {
-    topic = "merge?"; options = ["yes"; "no"];
-    choice = "yes"; actor = Some "reviewer";
-  } in
-  roundtrip ~to_yojson:Runtime.vote_request_to_yojson
-    ~of_yojson:Runtime.vote_request_of_yojson
-    ~show:Runtime.show_vote_request ~name:"vote_request" v
-
 let test_command () =
   let variants = [
     Runtime.Record_turn { actor = Some "user"; message = "hello" };
@@ -253,7 +232,6 @@ let test_command () =
     };
     Runtime.Update_session_settings { model = Some "opus"; permission_mode = None };
     Runtime.Attach_artifact { name = "r.txt"; kind = "text"; content = "data" };
-    Runtime.Vote { topic = "ok?"; options = ["yes"]; choice = "yes"; actor = None };
     Runtime.Checkpoint { label = Some "mid" };
     Runtime.Request_finalize { reason = Some "done" };
   ] in
@@ -279,10 +257,6 @@ let test_event_kind () =
     Runtime.Artifact_attached {
       artifact_id = "a1"; name = "r.json"; kind = "json";
       mime_type = "application/json"; path = "/tmp/r.json"; size_bytes = 10;
-    };
-    Runtime.Vote_recorded {
-      topic = "approve"; options = ["yes"; "no"]; choice = "yes";
-      actor = Some "user"; created_at = 1.7e9;
     };
     Runtime.Checkpoint_saved { label = Some "mid"; path = "/tmp/cp" };
     Runtime.Session_completed { outcome = Some "success" };
@@ -331,7 +305,6 @@ let () =
     "records", [
       Alcotest.test_case "participant" `Quick test_participant;
       Alcotest.test_case "artifact" `Quick test_artifact;
-      Alcotest.test_case "vote" `Quick test_vote;
       Alcotest.test_case "session" `Quick test_session;
       Alcotest.test_case "report" `Quick test_report;
       Alcotest.test_case "proof" `Quick test_proof;
@@ -345,7 +318,6 @@ let () =
       Alcotest.test_case "spawn_agent" `Quick test_spawn_agent_request;
       Alcotest.test_case "update_settings" `Quick test_update_settings;
       Alcotest.test_case "attach_artifact" `Quick test_attach_artifact_request;
-      Alcotest.test_case "vote_request" `Quick test_vote_request;
       Alcotest.test_case "permission_response" `Quick test_permission_response;
       Alcotest.test_case "hook_response" `Quick test_hook_response;
     ];

--- a/test/test_runtime_worker_integration.ml
+++ b/test/test_runtime_worker_integration.ml
@@ -198,9 +198,6 @@ let test_make_event_various_kinds () =
     Artifact_attached {
       artifact_id = "a1"; name = "n"; kind = "k";
       mime_type = "text/plain"; path = "/p"; size_bytes = 10 };
-    Vote_recorded {
-      topic = "t"; options = ["a";"b"]; choice = "a";
-      actor = Some "v"; created_at = 0.0 };
     Checkpoint_saved { label = Some "cp"; path = "/cp" };
     Finalize_requested { reason = Some "done" };
     Session_completed { outcome = Some "ok" };

--- a/test/test_sessions_proof_unit.ml
+++ b/test/test_sessions_proof_unit.ml
@@ -56,7 +56,6 @@ let make_session ?(session_id = "sess-001") ?(goal = "test")
     planned_participants = [];
     participants;
     artifacts = [];
-    votes = [];
     turn_count = 0;
     last_seq = 0;
     outcome = None;


### PR DESCRIPTION
## Summary
- Remove deprecated `Provider.local_qwen` / `Provider.local_mlx` aliases (use `local_llm`)
- Remove dead vote subsystem: `vote` type, `vote_request`, `Vote` command, `Vote_recorded` event, handler, projection arm, parser mapping
- Remove `"local-qwen"` resolver string alias (use `"local"`)
- Remove trivial `test_inference_contract_local_qwen` test
- Clean up all 21 affected files (-179 lines, net deletion only)

The vote mechanism was never used in practice: projection explicitly ignored `Vote_recorded` events, `session.votes` was never populated, and MASC has its own separate Board voting system.

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` passes (0 failures)
- [x] grep confirms no remaining references to removed types/functions
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)