### PR TITLE
chore(telemetry): add observability to cascade health filter and event forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Historical note: release notes for `0.100.3`, `0.100.5`, and `0.100.6` were
 backfilled on 2026-04-04 from existing git tags. The dates below reflect the
 original tag dates. `0.100.4` was never tagged or released.
 
+## [0.131.0] - 2026-04-13
+
+### Removed
+- `Provider.local_qwen`, `Provider.local_mlx` deprecated aliases.
+- `vote` type, `vote_request`, `Vote` command, `Vote_recorded` event
+  (dead code: projection ignored votes, field never populated).
+- `"local-qwen"` provider resolver string alias.
+- `session.votes` field from runtime session record.
+
+### Added
+- Diagnostic logging in `cascade_health_filter.ml` for provider
+  filtering decisions (API key drops, cloud-only fallback).
+- Debug log on `event_forward.ml` event_bus unsubscribe failure.
+
 ## [0.126.0] - 2026-04-13
 
 ### Added

--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,6 @@
 (lang dune 3.11)
 (name agent_sdk)
-(version 0.130.0)
+(version 0.131.0)
 
 (generate_opam_files true)
 

--- a/lib/event_forward.ml
+++ b/lib/event_forward.ml
@@ -193,7 +193,9 @@ let start ~sw ~(net : _ Eio.Net.t) ~bus t =
       Fun.protect
         ~finally:(fun () ->
           Atomic.set t.running false;
-          (try Event_bus.unsubscribe bus sub with _ -> ()))
+          (try Event_bus.unsubscribe bus sub with exn ->
+            Log.debug t.log
+              (Printf.sprintf "event_bus unsubscribe failed: %s" (Printexc.to_string exn)) []))
         (fun () ->
           try
             let batch = ref [] in

--- a/lib/llm_provider/cascade_health_filter.ml
+++ b/lib/llm_provider/cascade_health_filter.ml
@@ -63,11 +63,18 @@ let has_required_api_key (cfg : Provider_config.t) =
 
 (** Internal: filter healthy + return discovery statuses for throttle. *)
 let filter_healthy_internal ~sw ~net (providers : Provider_config.t list) =
+  let initial_count = List.length providers in
   (* Step 0: Remove cloud providers missing required API keys *)
   let providers =
     let with_keys = List.filter has_required_api_key providers in
     if with_keys = [] then providers  (* keep all rather than empty *)
-    else with_keys
+    else begin
+      let dropped = initial_count - List.length with_keys in
+      if dropped > 0 then
+        Printf.eprintf "[cascade_health_filter] dropped %d provider(s) missing API keys\n%!"
+          dropped;
+      with_keys
+    end
   in
   let local_providers =
     List.filter is_local_provider providers
@@ -96,8 +103,12 @@ let filter_healthy_internal ~sw ~net (providers : Provider_config.t list) =
       in
       if any_healthy then
         (providers, statuses)
-      else
+      else begin
+        Printf.eprintf
+          "[cascade_health_filter] all %d local endpoint(s) unhealthy, falling back to %d cloud provider(s)\n%!"
+          (List.length local_providers) (List.length cloud_providers);
         (cloud_providers, [])
+      end
 
 let filter_healthy ~sw ~net providers =
   fst (filter_healthy_internal ~sw ~net providers)

--- a/lib/sdk_version.ml
+++ b/lib/sdk_version.ml
@@ -1,5 +1,5 @@
 (** Single source of truth for the SDK version string.
     All other modules reference this instead of hardcoding. *)
 
-let version = "0.130.0"
+let version = "0.131.0"
 let sdk_name = "agent_sdk"


### PR DESCRIPTION
## Summary
- Add diagnostic logging to `cascade_health_filter.ml` for two previously invisible decisions:
  - Providers dropped due to missing API keys
  - Cloud-only fallback when all local endpoints are unhealthy
- Replace silent catch-all in `event_forward.ml` event_bus unsubscribe with debug log

## Why
These were telemetry blind spots identified during a cross-repo boundary audit. The health filter makes critical cascade routing decisions that were completely invisible to operators.

`llm_provider` uses `Printf.eprintf` (not `Log.t`) because it is a separate library without access to the `agent_sdk.Log` module.

## Test plan
- [x] `dune build` passes
- [x] No new dependencies introduced
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)