### PR TITLE
chore(release): bump version to 0.132.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Historical note: release notes for `0.100.3`, `0.100.5`, and `0.100.6` were
 backfilled on 2026-04-04 from existing git tags. The dates below reflect the
 original tag dates. `0.100.4` was never tagged or released.
 
+## [0.132.0] - 2026-04-13
+
+### Added
+- `Diag` module in `llm_provider` — pluggable structured diagnostic logging
+  with level filtering and consumer-replaceable sink. Replaces 27 raw
+  `Printf.eprintf` calls across 6 files.
+
 ## [0.131.0] - 2026-04-13
 
 ### Removed

--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,6 @@
 (lang dune 3.11)
 (name agent_sdk)
-(version 0.131.0)
+(version 0.132.0)
 
 (generate_opam_files true)
 

--- a/lib/sdk_version.ml
+++ b/lib/sdk_version.ml
@@ -1,5 +1,5 @@
 (** Single source of truth for the SDK version string.
     All other modules reference this instead of hardcoding. *)
 
-let version = "0.131.0"
+let version = "0.132.0"
 let sdk_name = "agent_sdk"


### PR DESCRIPTION
## Summary
- dune-project, sdk_version.ml: 0.131.0 -> 0.132.0
- CHANGELOG: Diag module entry

## Test plan
- [x] `dune build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)