### PR TITLE
feat: Durable_event journal integration Phase 1a

### DIFF
--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -46,6 +46,7 @@ type options = Agent_types.options = {
   on_run_complete: (bool -> unit) option;
   tool_result_relocation:
     (Tool_result_store.t * Content_replacement_state.t) option;
+  journal: Durable_event.journal option;
 }
 
 type lifecycle_status = Agent_lifecycle.lifecycle_status =

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -45,6 +45,12 @@ type options = {
         and replaces them with previews.  The [Content_replacement_state]
         freezes replacement decisions for prompt cache stability.
         @since 0.128.0 *)
+  journal: Durable_event.journal option;
+    (** Optional event-sourced journal for crash recovery and replay.
+        When provided, lifecycle events are appended alongside
+        [Event_bus] publishes, enabling offline replay via
+        {!Durable_event.replay_summary}.
+        @since 0.133.0 *)
 }
 
 (* Re-export lifecycle types from Agent_lifecycle.
@@ -106,6 +112,7 @@ let default_options = {
   slot_id = None;
   on_run_complete = None;
   tool_result_relocation = None;
+  journal = None;
 }
 
 type tool_call_fingerprint = Agent_turn.tool_call_fingerprint

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -76,6 +76,12 @@ type options = {
         and replaces them with previews.  The {!Content_replacement_state}
         freezes replacement decisions for prompt cache stability.
         @since 0.128.0 *)
+  journal: Durable_event.journal option;
+    (** Optional event-sourced journal for crash recovery and replay.
+        When provided, lifecycle events are appended alongside
+        [Event_bus] publishes, enabling offline replay via
+        {!Durable_event.replay_summary}.
+        @since 0.133.0 *)
 }
 
 (** {1 Lifecycle re-exports} *)

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -61,6 +61,7 @@ type t = {
   on_run_complete: (bool -> unit) option;
   tool_result_relocation:
     (Tool_result_store.t * Content_replacement_state.t) option;
+  journal: Durable_event.journal option;
 }
 
 let create ~net ~model =
@@ -120,10 +121,13 @@ let create ~net ~model =
     slot_id = None;
     on_run_complete = None;
     tool_result_relocation = None;
+    journal = None;
   }
 
 let with_tool_result_relocation ~store ~state b =
   { b with tool_result_relocation = Some (store, state) }
+
+let with_journal journal b = { b with journal = Some journal }
 
 let with_system_prompt prompt b = { b with system_prompt = Some prompt }
 let with_name name b = { b with name }
@@ -322,6 +326,7 @@ let build b =
     slot_id = b.slot_id;
     on_run_complete = b.on_run_complete;
     tool_result_relocation = b.tool_result_relocation;
+    journal = b.journal;
   } in
   Agent.create ~net:b.net ~config ~tools:(Tool_set.to_list tools) ?context
     ~options ()

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -199,6 +199,10 @@ val with_tool_result_relocation :
   state:Content_replacement_state.t ->
   t -> t
 
+(** Attach an event-sourced journal for crash recovery and replay.
+    @since 0.133.0 *)
+val with_journal : Durable_event.journal -> t -> t
+
 (** {2 Build} *)
 
 (** Build the agent. May raise on invalid config.

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -171,6 +171,12 @@ let stage_parse ?raw_trace_run agent =
            { agent_name = agent.state.config.name;
              turn = agent.state.turn_count } }
    | None -> ());
+  (match agent.options.journal with
+   | Some j ->
+       Durable_event.append j
+         (Turn_started { turn = agent.state.turn_count;
+                         timestamp = Unix.gettimeofday () })
+   | None -> ());
 
   let prep = prepare_turn_for_agent agent ~turn_params in
   (prep, original_config, turn_params)
@@ -266,6 +272,15 @@ let stage_collect ?raw_trace_run agent ~original_config response =
          payload = TurnCompleted
            { agent_name = agent.state.config.name;
              turn = agent.state.turn_count } }
+   | None -> ());
+  (match agent.options.journal with
+   | Some j ->
+       Durable_event.append j
+         (State_transition
+            { from_state = "turn_running";
+              to_state = "turn_complete";
+              reason = response.stop_reason |> Types.show_stop_reason;
+              timestamp = Unix.gettimeofday () })
    | None -> ());
 
   update_state agent (fun s ->


### PR DESCRIPTION
## Summary

- `agent_types.options`에 `journal: Durable_event.journal option` 추가
- `Builder.with_journal` setter 추가
- Pipeline의 `TurnStarted` / `TurnCompleted` 지점에서 journal append 연결
- 기존 Event_bus publish와 **병행** (fan-out 전환은 Phase 2)

## Context

RFC #889: Durable_event module이 존재하지만 runtime에서 호출 0건 (dormant).
이 PR은 첫 번째 activatation step — turn lifecycle 2개 지점만 연결하여 journal이 실제로 생성되는지 검증.

## Phase Roadmap (RFC #889)

| Phase | Scope | Status |
|---|---|---|
| **1a** | journal field + Turn_started/State_transition (this PR) | **here** |
| 1b | 나머지 8개 Event_bus.publish 지점 연결 | next |
| 2 | Llm_request/Response append | planned |
| 3 | Durable_event.append → Event_bus fan-out (SSOT 전환) | planned |
| 4 | JSONL persistence + replay path | planned |

## Files changed

- `lib/agent/agent_types.{ml,mli}` — journal field
- `lib/agent/agent.mli` — re-export
- `lib/agent/builder.{ml,mli}` — with_journal
- `lib/pipeline/pipeline.ml` — 2개 append 지점

## Test plan

- [x] `dune build` pass
- [x] `dune runtest` — all existing tests pass (212+ tests)
- [ ] Phase 1b에서 journal integration test 추가 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)