### PR TITLE
feat: Durable_event journal integration Phases 1b-3b

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -264,14 +264,26 @@ let find_and_execute_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tra
   result
 
 let execute_scheduled_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus
+    ?journal
     ~tracer ~agent_name ~turn_count ~(usage : Types.usage_stats) ~approval
     ?correlation_id ?run_id
     ?on_tool_execution_started ?on_tool_execution_finished ?on_hook_invoked
     ~schedule (tool_use : scheduled_tool_use) =
   let { index; id; name; input; _ } = tool_use in
+  let idem_key = Durable_event.make_idempotency_key ~tool_name:name ~input in
+  (match journal with
+   | Some j ->
+       Durable_event.append j
+         (Tool_called
+            { turn = turn_count; tool_name = name;
+              idempotency_key = idem_key;
+              input_hash = Digest.string (Yojson.Safe.to_string input);
+              timestamp = Unix.gettimeofday () })
+   | None -> ());
   (match on_tool_execution_started with
    | Some callback -> callback ~tool_use_id:id ~tool_name:name ~input ~schedule
    | None -> ());
+  let t0_tool = Unix.gettimeofday () in
   let triple =
     Tracing.with_span tracer
       { kind = Tool_exec; name; agent_name; turn = turn_count; extra = [] }
@@ -368,6 +380,18 @@ let execute_scheduled_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus
               failure_kind = Some Non_retryable_tool_error;
             })
   in
+  let duration_ms_tool = (Unix.gettimeofday () -. t0_tool) *. 1000.0 in
+  (match journal with
+   | Some j ->
+       Durable_event.append j
+         (Tool_completed
+            { turn = turn_count; tool_name = name;
+              idempotency_key = idem_key;
+              output_json = `String triple.content;
+              is_error = triple.is_error;
+              duration_ms = duration_ms_tool;
+              timestamp = Unix.gettimeofday () })
+   | None -> ());
   (match on_tool_execution_finished with
    | Some callback ->
        callback ~tool_use_id:id ~tool_name:name ~content:triple.content
@@ -375,13 +399,12 @@ let execute_scheduled_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus
    | None -> ());
   (index, triple)
 
-let execute_tools ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tracer
+let execute_tools ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ?journal
+    ~tracer
     ~agent_name ~turn_count ~(usage : Types.usage_stats) ~approval
     ?correlation_id ?run_id
     ?on_tool_execution_started
     ?on_tool_execution_finished ?on_hook_invoked tool_uses =
-  (* Filter to ToolUse blocks only — prevents bogus result triples for
-     Text/Thinking/etc. blocks that may be present in the input list. *)
   let tool_use_blocks = List.filter_map (fun block ->
     match block with
     | ToolUse { id; name; input } -> Some (id, name, input)
@@ -391,7 +414,7 @@ let execute_tools ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tracer
     List.mapi (schedule_tool_use ~tools) tool_use_blocks
   in
   let run_one =
-    execute_scheduled_tool ~context ~tools ~hooks ~event_bus ~tracer
+    execute_scheduled_tool ~context ~tools ~hooks ~event_bus ?journal ~tracer
       ~agent_name ~turn_count ~usage ~approval ?correlation_id ?run_id
       ?on_tool_execution_started ?on_tool_execution_finished ?on_hook_invoked
   in

--- a/lib/agent/agent_tools.mli
+++ b/lib/agent/agent_tools.mli
@@ -90,6 +90,7 @@ val execute_tools :
   tools:Tool.t list ->
   hooks:Hooks.hooks ->
   event_bus:Event_bus.t option ->
+  ?journal:Durable_event.journal ->
   tracer:Tracing.t ->
   agent_name:string ->
   turn_count:int ->

--- a/lib/agent/agent_trace.ml
+++ b/lib/agent/agent_trace.ml
@@ -61,6 +61,7 @@ let execute_tools_with_trace agent active_run tool_uses =
   Agent_tools.execute_tools
     ~context:agent.context ~tools:(Tool_set.to_list agent.tools)
     ~hooks:agent.options.hooks ~event_bus:agent.options.event_bus
+    ?journal:agent.options.journal
     ~tracer:agent.options.tracer ~agent_name:agent.state.config.name
     ~turn_count:agent.state.turn_count ~usage:agent.state.usage
     ~approval:agent.options.approval ?correlation_id ?run_id

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -170,6 +170,7 @@ module Tool_retry_policy = Tool_retry_policy
 module Lenient_json = Llm_provider.Lenient_json
 module Tool_input_validation = Tool_input_validation
 module Durable_event = Durable_event
+module Journal_bridge = Journal_bridge
 module Checkpoint_validation = Checkpoint_validation
 module Judge = Judge
 

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -144,6 +144,7 @@ module Tool_input_validation = Tool_input_validation
 module Tool_middleware = Tool_middleware
 module Response_harness = Response_harness
 module Durable_event = Durable_event
+module Journal_bridge = Journal_bridge
 module Checkpoint_validation = Checkpoint_validation
 module Judge = Judge
 

--- a/lib/durable_event.ml
+++ b/lib/durable_event.ml
@@ -60,13 +60,17 @@ type event =
 type journal = {
   mutable entries: event list;  (** Stored in reverse chronological order *)
   mutable size: int;
+  on_append: (event -> unit) option;
+    (** Optional fan-out callback invoked after every append.
+        Used to project journal events onto Event_bus or other sinks. *)
 }
 
-let create () = { entries = []; size = 0 }
+let create ?on_append () = { entries = []; size = 0; on_append }
 
 let append journal event =
   journal.entries <- event :: journal.entries;
-  journal.size <- journal.size + 1
+  journal.size <- journal.size + 1;
+  Option.iter (fun f -> f event) journal.on_append
 
 let events journal = List.rev journal.entries
 
@@ -302,7 +306,7 @@ let journal_of_json json =
     (* acc accumulates in reverse — matches journal.entries internal format *)
     let rec parse acc count = function
       | [] ->
-        Ok { entries = acc; size = count }
+        Ok { entries = acc; size = count; on_append = None }
       | item :: rest ->
         match event_of_json item with
         | Ok evt -> parse (evt :: acc) (count + 1) rest

--- a/lib/durable_event.mli
+++ b/lib/durable_event.mli
@@ -73,8 +73,12 @@ type event =
 
 type journal
 
-(** Create an empty journal. *)
-val create : unit -> journal
+(** Create an empty journal.
+    When [~on_append] is provided, it is called after every
+    {!append} with the event just recorded.  Intended for
+    projecting journal events onto {!Event_bus} or other sinks.
+    @since 0.133.0 *)
+val create : ?on_append:(event -> unit) -> unit -> journal
 
 (** Append an event to the journal. *)
 val append : journal -> event -> unit

--- a/lib/journal_bridge.ml
+++ b/lib/journal_bridge.ml
@@ -1,0 +1,85 @@
+(** Bridge Durable_event journal events to Event_bus.
+
+    Provides an [on_append] callback factory that projects each
+    {!Durable_event.event} onto {!Event_bus.Custom} with a stable
+    [durable:<kind>] name.  This lets existing Event_bus subscribers
+    observe the full journal stream without any Event_bus payload
+    schema changes.
+
+    Typical use:
+    {[
+      let journal =
+        Durable_event.create ~on_append:(Journal_bridge.make ~bus) ()
+      in
+      ...
+    ]}
+
+    @since 0.133.0 *)
+
+let projection_of_event (evt : Durable_event.event) :
+    string * Yojson.Safe.t =
+  match evt with
+  | Turn_started { turn; timestamp } ->
+    ( "durable:turn_started",
+      `Assoc
+        [ ("turn", `Int turn);
+          ("timestamp", `Float timestamp) ] )
+  | Llm_request { turn; model; input_tokens; timestamp } ->
+    ( "durable:llm_request",
+      `Assoc
+        [ ("turn", `Int turn);
+          ("model", `String model);
+          ("input_tokens", `Int input_tokens);
+          ("timestamp", `Float timestamp) ] )
+  | Llm_response { turn; output_tokens; stop_reason; duration_ms; timestamp } ->
+    ( "durable:llm_response",
+      `Assoc
+        [ ("turn", `Int turn);
+          ("output_tokens", `Int output_tokens);
+          ("stop_reason", `String stop_reason);
+          ("duration_ms", `Float duration_ms);
+          ("timestamp", `Float timestamp) ] )
+  | Tool_called { turn; tool_name; idempotency_key; input_hash; timestamp } ->
+    ( "durable:tool_called",
+      `Assoc
+        [ ("turn", `Int turn);
+          ("tool_name", `String tool_name);
+          ("idempotency_key", `String idempotency_key);
+          ("input_hash", `String input_hash);
+          ("timestamp", `Float timestamp) ] )
+  | Tool_completed { turn; tool_name; idempotency_key; output_json;
+                     is_error; duration_ms; timestamp } ->
+    ( "durable:tool_completed",
+      `Assoc
+        [ ("turn", `Int turn);
+          ("tool_name", `String tool_name);
+          ("idempotency_key", `String idempotency_key);
+          ("output_json", output_json);
+          ("is_error", `Bool is_error);
+          ("duration_ms", `Float duration_ms);
+          ("timestamp", `Float timestamp) ] )
+  | State_transition { from_state; to_state; reason; timestamp } ->
+    ( "durable:state_transition",
+      `Assoc
+        [ ("from_state", `String from_state);
+          ("to_state", `String to_state);
+          ("reason", `String reason);
+          ("timestamp", `Float timestamp) ] )
+  | Checkpoint_saved { checkpoint_id; timestamp } ->
+    ( "durable:checkpoint_saved",
+      `Assoc
+        [ ("checkpoint_id", `String checkpoint_id);
+          ("timestamp", `Float timestamp) ] )
+  | Error_occurred { turn; error_domain; detail; timestamp } ->
+    ( "durable:error_occurred",
+      `Assoc
+        [ ("turn", `Int turn);
+          ("error_domain", `String error_domain);
+          ("detail", `String detail);
+          ("timestamp", `Float timestamp) ] )
+
+let make ~bus : Durable_event.event -> unit =
+  fun evt ->
+    let (name, payload) = projection_of_event evt in
+    Event_bus.publish bus
+      (Event_bus.mk_event (Custom (name, payload)))

--- a/lib/journal_bridge.mli
+++ b/lib/journal_bridge.mli
@@ -1,0 +1,18 @@
+(** Bridge Durable_event journal events to Event_bus.
+
+    Each journal event is projected onto {!Event_bus.Custom} with a
+    stable [durable:<kind>] name (e.g. [durable:turn_started],
+    [durable:llm_request]).  Subscribers observe these via the normal
+    Event_bus subscription — no payload schema change required.
+
+    @since 0.133.0 *)
+
+(** Serialize a journal event into the [(name, payload)] shape used by
+    {!Event_bus.Custom}.  Exposed for testing and custom relays. *)
+val projection_of_event :
+  Durable_event.event -> string * Yojson.Safe.t
+
+(** Build an [on_append] callback suitable for {!Durable_event.create}
+    that publishes every journal event to [bus] as an
+    {!Event_bus.Custom} payload. *)
+val make : bus:Event_bus.t -> Durable_event.event -> unit

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -576,6 +576,14 @@ let proactive_compact ?raw_trace_run agent ~watermark () =
                  after_tokens;
                  phase = Printf.sprintf "proactive(%.0f%%)" (usage_ratio *. 100.0) } }
          | None -> ());
+        (match agent.options.journal with
+         | Some j ->
+             Durable_event.append j
+               (Checkpoint_saved
+                  { checkpoint_id =
+                      Printf.sprintf "compact-proactive-%d" agent.state.turn_count;
+                    timestamp = Unix.gettimeofday () })
+         | None -> ());
         true
       end
 (* ── Emergency compaction ────────────────────────────────── *)
@@ -620,6 +628,14 @@ let emergency_compact ?raw_trace_run agent ?limit () =
                before_tokens = est_tokens;
                after_tokens;
                phase = "emergency" } }
+       | None -> ());
+      (match agent.options.journal with
+       | Some j ->
+           Durable_event.append j
+             (Checkpoint_saved
+                { checkpoint_id =
+                    Printf.sprintf "compact-emergency-%d" agent.state.turn_count;
+                  timestamp = Unix.gettimeofday () })
        | None -> ());
       true
     end

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -700,8 +700,44 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
 
   (* Stage 3: Route — with compact-and-retry on context overflow *)
   let rec attempt_route ~prep ~compact_attempts =
+    let est_input =
+      List.fold_left (fun acc msg ->
+        acc + Context_reducer.estimate_message_tokens msg)
+        0 prep.Agent_turn.effective_messages
+    in
+    (match agent.options.journal with
+     | Some j ->
+         Durable_event.append j
+           (Llm_request
+              { turn = agent.state.turn_count;
+                model = agent.state.config.model;
+                input_tokens = est_input;
+                timestamp = Unix.gettimeofday () })
+     | None -> ());
+    let t0 = Unix.gettimeofday () in
     let api_result = stage_route ~sw ?clock ~api_strategy agent prep
       |> tag_error "route" in
+    let duration_ms = (Unix.gettimeofday () -. t0) *. 1000.0 in
+    (match agent.options.journal, api_result with
+     | Some j, Ok response ->
+         let out_tokens = match response.usage with
+           | Some u -> u.output_tokens | None -> 0
+         in
+         Durable_event.append j
+           (Llm_response
+              { turn = agent.state.turn_count;
+                output_tokens = out_tokens;
+                stop_reason = Types.show_stop_reason response.stop_reason;
+                duration_ms;
+                timestamp = Unix.gettimeofday () })
+     | Some j, Error err ->
+         Durable_event.append j
+           (Error_occurred
+              { turn = agent.state.turn_count;
+                error_domain = "Api";
+                detail = Error.to_string err;
+                timestamp = Unix.gettimeofday () })
+     | None, _ -> ());
     match api_result with
     | Error (Error.Api (Retry.ContextOverflow { limit; _ }))
       when compact_attempts < 2 ->

--- a/test/dune
+++ b/test/dune
@@ -825,6 +825,10 @@
  (libraries agent_sdk alcotest yojson unix))
 
 (test
+ (name test_journal_bridge)
+ (libraries agent_sdk alcotest yojson eio eio_main))
+
+(test
  (name test_tool_index)
  (libraries agent_sdk alcotest yojson))
 

--- a/test/test_durable_event.ml
+++ b/test/test_durable_event.ml
@@ -138,6 +138,22 @@ let test_tool_completions () =
   let completions = Durable_event.tool_completions j in
   check int "2 completions" 2 (List.length completions)
 
+(* ── on_append callback ───────────────────────────── *)
+
+let test_on_append_fires () =
+  let captured = ref [] in
+  let j = Durable_event.create ~on_append:(fun evt ->
+    captured := evt :: !captured) () in
+  Durable_event.append j (Turn_started { turn = 1; timestamp = ts });
+  Durable_event.append j (Llm_request { turn = 1; model = "m"; input_tokens = 10; timestamp = ts });
+  check int "callback count" 2 (List.length !captured);
+  check int "journal length" 2 (Durable_event.length j)
+
+let test_no_callback_default () =
+  let j = Durable_event.create () in
+  Durable_event.append j (Turn_started { turn = 1; timestamp = ts });
+  check int "still appends" 1 (Durable_event.length j)
+
 (* ── Suite ────────────────────────────────────────── *)
 
 let () =
@@ -146,6 +162,10 @@ let () =
       test_case "empty" `Quick test_empty_journal;
       test_case "append and events" `Quick test_append_and_events;
       test_case "last_timestamp" `Quick test_last_timestamp;
+    ];
+    "on_append", [
+      test_case "callback fires" `Quick test_on_append_fires;
+      test_case "no callback default" `Quick test_no_callback_default;
     ];
     "idempotency", [
       test_case "deterministic key" `Quick test_idempotency_key_deterministic;

--- a/test/test_journal_bridge.ml
+++ b/test/test_journal_bridge.ml
@@ -1,0 +1,116 @@
+(** Tests for Journal_bridge — Durable_event → Event_bus projection. *)
+
+open Alcotest
+open Agent_sdk
+
+let ts = 1711234567.0
+
+let projection_name evt =
+  let (name, _) = Journal_bridge.projection_of_event evt in
+  name
+
+let projection_payload evt =
+  let (_, payload) = Journal_bridge.projection_of_event evt in
+  payload
+
+(* ── Projection: name and payload shape ─────────────── *)
+
+let test_turn_started_projection () =
+  let evt = Durable_event.Turn_started { turn = 3; timestamp = ts } in
+  check string "name" "durable:turn_started" (projection_name evt);
+  match projection_payload evt with
+  | `Assoc fields ->
+    check int "turn" 3
+      (match List.assoc_opt "turn" fields with
+       | Some (`Int n) -> n | _ -> -1)
+  | _ -> fail "expected Assoc"
+
+let test_llm_request_projection () =
+  let evt = Durable_event.Llm_request {
+    turn = 1; model = "qwen"; input_tokens = 500; timestamp = ts } in
+  check string "name" "durable:llm_request" (projection_name evt);
+  match projection_payload evt with
+  | `Assoc fields ->
+    check int "input_tokens" 500
+      (match List.assoc_opt "input_tokens" fields with
+       | Some (`Int n) -> n | _ -> -1);
+    check string "model" "qwen"
+      (match List.assoc_opt "model" fields with
+       | Some (`String s) -> s | _ -> "")
+  | _ -> fail "expected Assoc"
+
+let test_tool_completed_projection () =
+  let evt = Durable_event.Tool_completed {
+    turn = 2; tool_name = "read"; idempotency_key = "k1";
+    output_json = `String "ok"; is_error = false; duration_ms = 12.5;
+    timestamp = ts } in
+  check string "name" "durable:tool_completed" (projection_name evt);
+  match projection_payload evt with
+  | `Assoc fields ->
+    check bool "is_error" false
+      (match List.assoc_opt "is_error" fields with
+       | Some (`Bool b) -> b | _ -> true)
+  | _ -> fail "expected Assoc"
+
+let test_all_variants_project () =
+  let variants = [
+    Durable_event.Turn_started { turn = 1; timestamp = ts };
+    Llm_request { turn = 1; model = "m"; input_tokens = 10; timestamp = ts };
+    Llm_response { turn = 1; output_tokens = 5; stop_reason = "end_turn";
+                   duration_ms = 100.0; timestamp = ts };
+    Tool_called { turn = 1; tool_name = "t"; idempotency_key = "k";
+                  input_hash = "h"; timestamp = ts };
+    Tool_completed { turn = 1; tool_name = "t"; idempotency_key = "k";
+                     output_json = `Null; is_error = false;
+                     duration_ms = 1.0; timestamp = ts };
+    State_transition { from_state = "a"; to_state = "b";
+                       reason = "r"; timestamp = ts };
+    Checkpoint_saved { checkpoint_id = "c"; timestamp = ts };
+    Error_occurred { turn = 1; error_domain = "Api";
+                     detail = "d"; timestamp = ts };
+  ] in
+  List.iter (fun evt ->
+    let (name, _) = Journal_bridge.projection_of_event evt in
+    check bool (Printf.sprintf "name has durable: prefix: %s" name)
+      true (String.length name > 8 &&
+            String.sub name 0 8 = "durable:")
+  ) variants
+
+(* ── End-to-end: bridge via on_append ──────────────── *)
+
+let test_make_publishes_to_bus () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  let journal =
+    Durable_event.create ~on_append:(Journal_bridge.make ~bus) ()
+  in
+  Durable_event.append journal
+    (Turn_started { turn = 1; timestamp = ts });
+  Durable_event.append journal
+    (Error_occurred { turn = 1; error_domain = "Api";
+                      detail = "boom"; timestamp = ts });
+  let events = Event_bus.drain sub in
+  check int "published count" 2 (List.length events);
+  let names = List.map (fun (e : Event_bus.event) ->
+    match e.payload with
+    | Custom (n, _) -> n
+    | _ -> "non-custom"
+  ) events in
+  check (list string) "names"
+    ["durable:turn_started"; "durable:error_occurred"]
+    names
+
+let () =
+  run "Journal_bridge" [
+    "projection", [
+      test_case "turn_started" `Quick test_turn_started_projection;
+      test_case "llm_request" `Quick test_llm_request_projection;
+      test_case "tool_completed" `Quick test_tool_completed_projection;
+      test_case "all variants have durable: prefix" `Quick
+        test_all_variants_project;
+    ];
+    "bridge", [
+      test_case "make publishes to bus" `Quick test_make_publishes_to_bus;
+    ];
+  ]


### PR DESCRIPTION
## Summary

#890 merge 후 누락된 5 commits 복구. Phase 1a 머지 시점에 squash 되면서 이후 phase들이 main에 도달하지 못했음.

- **Phase 1b** (d11c820): pipeline.ml — Checkpoint_saved on context compaction
- **Phase 2** (7209b24): pipeline.ml — Llm_request/Response/Error_occurred
- **Phase 1c** (6464191): agent_tools — Tool_called/Completed with idempotency_key
- **Phase 3a** (aa4a842): durable_event — on_append callback
- **Phase 3b** (c9c3050): journal_bridge — Event_bus.Custom projection

## Context

#889 로드맵의 1b-3b 페이즈 연속 구현.
Durable_event 8 variants 전부 runtime 연결 완료 + Event_bus 투영 infrastructure 제공.

Consumer 사용 예:
```ocaml
let journal =
  Durable_event.create ~on_append:(Journal_bridge.make ~bus) ()
in
let agent = Builder.create ~net ~model
  |> Builder.with_journal journal
  |> Builder.with_event_bus bus
  |> Builder.build
```
이러면 journal 이벤트가 자동으로 `Custom("durable:<kind>")` 로 Event_bus 에 투영됨.

## Files changed

- `lib/durable_event.{ml,mli}` — on_append 옵션
- `lib/journal_bridge.{ml,mli}` — 신규 (Event_bus 투영)
- `lib/pipeline/pipeline.ml` — Phase 1b/2 append 지점 6건
- `lib/agent/agent_tools.{ml,mli}` — Phase 1c tool append
- `lib/agent/agent_trace.ml` — journal threading
- `lib/agent_sdk.{ml,mli}` — Journal_bridge export
- `test/test_durable_event.ml` — on_append 2 테스트 추가
- `test/test_journal_bridge.ml` — 신규 5 테스트
- `test/dune` — new test target

## Test plan

- [x] `dune build --root .` pass
- [x] `dune runtest --root .` — all tests pass (Durable_event 13, Journal_bridge 5)

Refs: #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)