### PR TITLE
feat(durable_event): JSONL file persistence (Phase 4)

### DIFF
--- a/lib/durable_event.ml
+++ b/lib/durable_event.ml
@@ -315,3 +315,57 @@ let journal_of_json json =
     parse [] 0 items
   with
   | Yojson.Safe.Util.Type_error (msg, _) -> Error msg
+
+(* ── Persistence (JSONL) ─────────────────────────── *)
+
+let save_to_file journal path =
+  let tmp_path = path ^ ".tmp" in
+  try
+    let oc = open_out tmp_path in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () ->
+        List.iter (fun event ->
+          output_string oc (Yojson.Safe.to_string (event_to_json event));
+          output_char oc '\n'
+        ) (events journal));
+    Sys.rename tmp_path path;
+    Ok ()
+  with
+  | Sys_error msg ->
+    (try Sys.remove tmp_path with _ -> ());
+    Error (Printf.sprintf "save_to_file: %s" msg)
+
+let load_from_file path =
+  if not (Sys.file_exists path) then Ok { entries = []; size = 0; on_append = None }
+  else
+    try
+      let ic = open_in path in
+      Fun.protect
+        ~finally:(fun () -> close_in_noerr ic)
+        (fun () ->
+          let rec read_lines acc count line_no =
+            match input_line ic with
+            | line ->
+              if String.trim line = "" then
+                read_lines acc count (line_no + 1)
+              else begin
+                let json =
+                  try Ok (Yojson.Safe.from_string line)
+                  with Yojson.Json_error msg ->
+                    Error (Printf.sprintf "line %d: %s" line_no msg)
+                in
+                match json with
+                | Error e -> Error e
+                | Ok j ->
+                  match event_of_json j with
+                  | Ok evt -> read_lines (evt :: acc) (count + 1) (line_no + 1)
+                  | Error e ->
+                    Error (Printf.sprintf "line %d: %s" line_no e)
+              end
+            | exception End_of_file ->
+              Ok { entries = acc; size = count; on_append = None }
+          in
+          read_lines [] 0 1)
+    with
+    | Sys_error msg -> Error (Printf.sprintf "load_from_file: %s" msg)

--- a/lib/durable_event.mli
+++ b/lib/durable_event.mli
@@ -122,6 +122,27 @@ val event_of_json : Yojson.Safe.t -> (event, string) result
 val journal_to_json : journal -> Yojson.Safe.t
 val journal_of_json : Yojson.Safe.t -> (journal, string) result
 
+(** {1 Persistence}
+
+    JSONL-based file persistence for crash recovery.  Each line is a
+    single event's JSON representation, appended in chronological
+    order.  Durable across restarts; atomic dump uses a temp file
+    + rename.
+
+    @since 0.133.0 *)
+
+(** Dump the full journal to [path] as JSONL (one event per line,
+    chronological order).  Writes to [path ^ ".tmp"] first then
+    renames, so a partial write cannot corrupt an existing file.
+    Returns [Error msg] on I/O failure. *)
+val save_to_file : journal -> string -> (unit, string) result
+
+(** Load a journal from a JSONL file produced by {!save_to_file}.
+    Empty or missing file returns an empty journal (not an error).
+    Malformed lines abort the load with [Error msg] identifying the
+    first bad line.  The loaded journal has no [on_append] callback. *)
+val load_from_file : string -> (journal, string) result
+
 (** {1 Queries} *)
 
 (** Events for a specific turn. *)

--- a/test/test_durable_event.ml
+++ b/test/test_durable_event.ml
@@ -154,6 +154,48 @@ let test_no_callback_default () =
   Durable_event.append j (Turn_started { turn = 1; timestamp = ts });
   check int "still appends" 1 (Durable_event.length j)
 
+(* ── Persistence ──────────────────────────────────── *)
+
+let test_save_and_load_roundtrip () =
+  let j = Durable_event.create () in
+  Durable_event.append j (Turn_started { turn = 1; timestamp = ts });
+  Durable_event.append j
+    (Llm_request { turn = 1; model = "q"; input_tokens = 42; timestamp = ts });
+  Durable_event.append j
+    (Error_occurred { turn = 1; error_domain = "Api"; detail = "boom"; timestamp = ts });
+  let path = Filename.temp_file "durable_event" ".jsonl" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      (match Durable_event.save_to_file j path with
+       | Ok () -> ()
+       | Error e -> fail (Printf.sprintf "save failed: %s" e));
+      match Durable_event.load_from_file path with
+      | Error e -> fail (Printf.sprintf "load failed: %s" e)
+      | Ok j' ->
+        check int "length" 3 (Durable_event.length j');
+        let summary = Durable_event.replay_summary j' in
+        check int "total input tokens" 42 summary.total_input_tokens;
+        check int "error count" 1 summary.error_count)
+
+let test_load_missing_file_is_empty () =
+  let missing = "/tmp/definitely-does-not-exist-" ^ string_of_float (Unix.gettimeofday ()) in
+  match Durable_event.load_from_file missing with
+  | Ok j -> check int "empty journal" 0 (Durable_event.length j)
+  | Error e -> fail (Printf.sprintf "expected Ok, got: %s" e)
+
+let test_load_malformed_returns_error () =
+  let path = Filename.temp_file "durable_bad" ".jsonl" in
+  let oc = open_out path in
+  output_string oc "not json\n";
+  close_out oc;
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      match Durable_event.load_from_file path with
+      | Ok _ -> fail "expected Error"
+      | Error _ -> ())
+
 (* ── Suite ────────────────────────────────────────── *)
 
 let () =
@@ -182,5 +224,10 @@ let () =
     ];
     "queries", [
       test_case "tool completions" `Quick test_tool_completions;
+    ];
+    "persistence", [
+      test_case "save/load roundtrip" `Quick test_save_and_load_roundtrip;
+      test_case "missing file empty" `Quick test_load_missing_file_is_empty;
+      test_case "malformed returns error" `Quick test_load_malformed_returns_error;
     ];
   ]


### PR DESCRIPTION
## Summary

`Durable_event.save_to_file` / `load_from_file` 추가.

- JSONL 형식 (한 줄에 한 이벤트, 시간순)
- Atomic write: `<path>.tmp` → rename
- Missing file → empty journal (not error)
- Malformed line → Error with line number
- 3 new tests: roundtrip, missing, malformed

## Context

#889 Phase 4. crash recovery / replay 를 위한 file primitives.
Consumer 가 agent shutdown 시 dump, restart 시 load + `replay_summary` 로 복구.

## Independence

- `#890` (Phase 1a) 위에 직접 올라감
- `#891` (Phase 1b-3b) 과 독립, 어느 쪽이든 먼저 merge 가능

## Test plan

- [x] `dune build --root .` pass
- [x] `dune exec test/test_durable_event.exe` — 14/14 pass
  - persistence: save/load roundtrip, missing file empty, malformed returns error

Refs: #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)