### PR TITLE
feat(agent): save_journal + Builder.with_auto_dump_journal (Phase 5)

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -291,3 +291,8 @@ let checkpoint ?(session_id="") ?working_context agent =
 
 let run_turn_stream ~sw ?clock ~on_event agent =
   run_turn_core ~sw ?clock ~api_strategy:(Stream { on_event }) agent
+
+let save_journal agent path =
+  match agent.options.journal with
+  | Some j -> Durable_event.save_to_file j path
+  | None -> Error "no journal"

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -202,3 +202,10 @@ val set_lifecycle :
   Agent_lifecycle.lifecycle_status -> unit
 val base_messages : t -> Types.message list
 val check_loop_guard : t -> Error.sdk_error option
+
+(** Dump the agent's Durable_event journal to [path] as JSONL.
+    Returns [Error "no journal"] when the agent was built without
+    {!Builder.with_journal}.  Thin wrapper over
+    {!Durable_event.save_to_file}.
+    @since 0.135.0 *)
+val save_journal : t -> string -> (unit, string) result

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -129,6 +129,19 @@ let with_tool_result_relocation ~store ~state b =
 
 let with_journal journal b = { b with journal = Some journal }
 
+let with_auto_dump_journal ~path b =
+  let journal =
+    match b.journal with
+    | Some j -> j
+    | None -> Durable_event.create ()
+  in
+  let dump _ok =
+    match Durable_event.save_to_file journal path with
+    | Ok () -> ()
+    | Error _ -> ()  (* Best-effort; consumer can provide a stricter callback. *)
+  in
+  { b with journal = Some journal; on_run_complete = Some dump }
+
 let with_system_prompt prompt b = { b with system_prompt = Some prompt }
 let with_name name b = { b with name }
 let with_max_tokens n b = { b with max_tokens = Some n }

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -203,6 +203,17 @@ val with_tool_result_relocation :
     @since 0.133.0 *)
 val with_journal : Durable_event.journal -> t -> t
 
+(** Install an [on_run_complete] callback that persists the journal
+    to [path] whenever the agent run finishes (success or failure).
+    Equivalent to attaching a journal and then calling
+    {!Agent.save_journal} in a callback, but bundled so consumers
+    declare the intent in one line.
+
+    If a journal is not explicitly attached, this builder also
+    creates a fresh one so the dump is non-empty.
+    @since 0.135.0 *)
+val with_auto_dump_journal : path:string -> t -> t
+
 (** {2 Build} *)
 
 (** Build the agent. May raise on invalid config.

--- a/test/dune
+++ b/test/dune
@@ -928,3 +928,7 @@
 ;(test
 ; (name test_eval_otel_bridge)
 ; (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_agent_auto_dump)
+ (libraries agent_sdk alcotest eio eio_main))

--- a/test/test_agent_auto_dump.ml
+++ b/test/test_agent_auto_dump.ml
@@ -1,0 +1,84 @@
+(** Tests for Agent.save_journal and Builder.with_auto_dump_journal. *)
+
+open Alcotest
+open Agent_sdk
+
+let ts = 1711234567.0
+
+let test_save_journal_writes_jsonl () =
+  Eio_main.run @@ fun env ->
+  let journal = Durable_event.create () in
+  Durable_event.append journal
+    (Turn_started { turn = 1; timestamp = ts });
+  Durable_event.append journal
+    (Llm_request { turn = 1; model = "m"; input_tokens = 10; timestamp = ts });
+  let path = Filename.temp_file "auto_dump" ".jsonl" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      let net = Eio.Stdenv.net env in
+      let agent =
+        Builder.create ~net ~model:"test"
+        |> Builder.with_journal journal
+        |> Builder.build
+      in
+      match Agent.save_journal agent path with
+      | Error e -> fail (Printf.sprintf "save_journal failed: %s" e)
+      | Ok () ->
+        match Durable_event.load_from_file path with
+        | Error e -> fail (Printf.sprintf "load failed: %s" e)
+        | Ok j' ->
+          check int "length" 2 (Durable_event.length j'))
+
+let test_save_journal_no_journal_returns_error () =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  let agent =
+    Builder.create ~net ~model:"test"
+    |> Builder.build
+  in
+  match Agent.save_journal agent "/tmp/should-never-exist" with
+  | Ok () -> fail "expected Error when agent has no journal"
+  | Error msg -> check string "error message" "no journal" msg
+
+let test_auto_dump_installs_callback () =
+  Eio_main.run @@ fun env ->
+  let path = Filename.temp_file "auto_dump_cb" ".jsonl" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      let net = Eio.Stdenv.net env in
+      let agent =
+        Builder.create ~net ~model:"test"
+        |> Builder.with_auto_dump_journal ~path
+        |> Builder.build
+      in
+      let opts = Agent.options agent in
+      check bool "journal attached" true (Option.is_some opts.journal);
+      check bool "on_run_complete set" true
+        (Option.is_some opts.on_run_complete);
+      (* Simulate run completion — append an event then invoke callback. *)
+      (match opts.journal with
+       | Some j ->
+         Durable_event.append j (Turn_started { turn = 1; timestamp = ts })
+       | None -> fail "journal missing");
+      (match opts.on_run_complete with
+       | Some cb -> cb true
+       | None -> fail "callback missing");
+      (* File should now exist with the event. *)
+      match Durable_event.load_from_file path with
+      | Error e -> fail (Printf.sprintf "load failed: %s" e)
+      | Ok j' -> check int "length" 1 (Durable_event.length j'))
+
+let () =
+  run "Agent auto-dump" [
+    "save_journal", [
+      test_case "writes journal to file" `Quick test_save_journal_writes_jsonl;
+      test_case "errors without journal" `Quick
+        test_save_journal_no_journal_returns_error;
+    ];
+    "with_auto_dump_journal", [
+      test_case "installs on_run_complete callback" `Quick
+        test_auto_dump_installs_callback;
+    ];
+  ]


### PR DESCRIPTION
## Summary

- `Agent.save_journal t path` — thin wrapper over `Durable_event.save_to_file` using `agent.options.journal`.
- `Builder.with_auto_dump_journal ~path b` — installs an `on_run_complete` callback that dumps the journal on every run completion.

## Context

#889 Phase 5. Closes the loop from Phases 1-4 (integration → fan-out → persistence → auto-dump).

Usage:
\`\`\`ocaml
let agent = Builder.create ~net ~model
  |> Builder.with_auto_dump_journal ~path:\"/var/masc/agent.jsonl\"
  |> Builder.build
\`\`\`

## Test plan

- [x] \`dune build --root .\` pass
- [x] \`test/test_agent_auto_dump.exe\` 3/3 pass
  - save_journal writes journal to file
  - save_journal errors without journal
  - with_auto_dump_journal installs on_run_complete callback