### PR TITLE
feat(pipeline,event_bus,cascade): context overflow prevention (OAS-1+2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Historical note: release notes for `0.100.3`, `0.100.5`, and `0.100.6` were
 backfilled on 2026-04-04 from existing git tags. The dates below reflect the
 original tag dates. `0.100.4` was never tagged or released.
 
+## [0.136.0] - 2026-04-14
+
+### Added
+- `Event_bus.ContextOverflowImminent` payload — proactive warning emitted
+  before context overflow occurs, with `estimated_tokens`, `limit_tokens`,
+  and `ratio` fields (#901).
+- `Event_bus.ContextCompactStarted` payload — marks compaction start with
+  a `trigger` field (`proactive`, `emergency`, or `operator`) (#901).
+- `Context_reducer.estimate_next_turn_overhead` — estimates fixed overhead
+  (system prompt + tool descriptions + output reserve) for budget projection
+  before the next turn (#901).
+- `Cascade_executor.truncate_to_context_strict` — strict variant of
+  `truncate_to_context` that returns `Error (\`Over_budget (est, budget))`
+  instead of silently passing over-budget content. Original function
+  unchanged for backward compatibility (#901).
+
 ## [0.135.0] - 2026-04-14
 
 ### Added

--- a/lib/context_reducer.ml
+++ b/lib/context_reducer.ml
@@ -637,6 +637,48 @@ let from_context_config ?(compact_ratio=0.8) ~max_tokens () =
     token_budget budget;
   ]
 
+(** Estimate fixed-overhead tokens for the next turn.
+
+    Components:
+    - System prompt tokens (if provided).
+    - Tool description tokens (JSON serialization of each tool schema).
+    - Output reserve (tokens held back for the model's response).
+
+    This is intentionally a rough upper bound — it over-counts rather than
+    under-counts so callers can make conservative budget decisions. *)
+let estimate_next_turn_overhead
+    ?(system_prompt = "")
+    ?(tools : Yojson.Safe.t list = [])
+    ?(output_reserve = 4096)
+    () : int =
+  let system_tokens =
+    if String.length system_prompt = 0 then 0
+    else estimate_char_tokens system_prompt
+  in
+  let tool_tokens =
+    List.fold_left
+      (fun acc tool ->
+         acc + estimate_char_tokens (Yojson.Safe.to_string tool))
+      0 tools
+  in
+  (* Per-turn framing overhead: role tokens, separators, API envelope.
+     Conservative fixed constant. *)
+  let framing = 100 in
+  system_tokens + tool_tokens + output_reserve + framing
+
+let%test "estimate_next_turn_overhead empty" =
+  let overhead = estimate_next_turn_overhead () in
+  overhead = 4096 + 100
+
+let%test "estimate_next_turn_overhead with system prompt" =
+  let overhead = estimate_next_turn_overhead ~system_prompt:"You are a helpful assistant." () in
+  overhead > 4096 + 100
+
+let%test "estimate_next_turn_overhead with tools" =
+  let tool = `Assoc [("name", `String "get_weather"); ("description", `String "Get weather for a location")] in
+  let overhead = estimate_next_turn_overhead ~tools:[tool] () in
+  overhead > 4096 + 100
+
 let%test "from_context_config default compact_ratio 0.8" =
   let reducer = from_context_config ~max_tokens:10000 () in
   match reducer.strategy with

--- a/lib/context_reducer.mli
+++ b/lib/context_reducer.mli
@@ -64,6 +64,24 @@ val estimate_block_tokens : content_block -> int
 (** Estimate tokens for a message. *)
 val estimate_message_tokens : message -> int
 
+(** {1 Overhead estimation} *)
+
+(** Estimate the fixed-overhead tokens for the next turn: system prompt,
+    tool descriptions, and output reserve.  This lets the caller project
+    whether adding one more turn will exceed the context budget without
+    actually building the prompt.
+
+    @param system_prompt  System prompt text (if any).
+    @param tools          Tool JSON descriptions sent to the provider.
+    @param output_reserve Tokens reserved for model output (default: 4096).
+    @return Estimated overhead in tokens.
+    @since 0.136.0 *)
+val estimate_next_turn_overhead :
+  ?system_prompt:string ->
+  ?tools:Yojson.Safe.t list ->
+  ?output_reserve:int ->
+  unit -> int
+
 (** {1 Turn grouping} *)
 
 (** Group messages into turns.

--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -33,6 +33,10 @@ type payload =
   | TaskStateChanged of { task_id: string; from_state: string; to_state: string }
   | ContextCompacted of { agent_name: string; before_tokens: int;
                           after_tokens: int; phase: string }
+  | ContextOverflowImminent of { agent_name: string;
+                                  estimated_tokens: int; limit_tokens: int;
+                                  ratio: float }
+  | ContextCompactStarted of { agent_name: string; trigger: string }
   | Custom of string * Yojson.Safe.t
 
 (* ── Event type ───────────────────────────────────────────────────── *)
@@ -99,6 +103,8 @@ let filter_agent name : filter = fun event ->
   | TurnCompleted r -> r.agent_name = name
   | ElicitationCompleted r -> r.agent_name = name
   | ContextCompacted r -> r.agent_name = name
+  | ContextOverflowImminent r -> r.agent_name = name
+  | ContextCompactStarted r -> r.agent_name = name
   | TaskStateChanged _ -> true  (* Task events are not agent-scoped *)
   | Custom _ -> true  (* Custom events are not agent-scoped; always pass *)
 

--- a/lib/event_bus.mli
+++ b/lib/event_bus.mli
@@ -33,6 +33,16 @@ type payload =
   | TaskStateChanged of { task_id: string; from_state: string; to_state: string }
   | ContextCompacted of { agent_name: string; before_tokens: int;
                           after_tokens: int; phase: string }
+  | ContextOverflowImminent of { agent_name: string;
+                                  estimated_tokens: int; limit_tokens: int;
+                                  ratio: float }
+      (** Proactive warning: next turn is projected to exceed context budget.
+          Emitted before compaction is attempted.
+          @since 0.136.0 *)
+  | ContextCompactStarted of { agent_name: string; trigger: string }
+      (** Compaction has begun (before [ContextCompacted] which signals completion).
+          [trigger] is one of ["proactive"], ["emergency"], ["operator"].
+          @since 0.136.0 *)
   | Custom of string * Yojson.Safe.t
 
 (** {2 Event} *)

--- a/lib/event_forward.ml
+++ b/lib/event_forward.ml
@@ -47,6 +47,8 @@ let event_type_name (event : Event_bus.event) : string =
   | ElicitationCompleted _ -> "elicitation.completed"
   | TaskStateChanged _ -> "task.state_changed"
   | ContextCompacted _ -> "context.compacted"
+  | ContextOverflowImminent _ -> "context.overflow_imminent"
+  | ContextCompactStarted _ -> "context.compact_started"
   | Custom (name, _) -> "custom." ^ name
 
 let agent_name_of_payload : Event_bus.payload -> string option = function
@@ -58,6 +60,8 @@ let agent_name_of_payload : Event_bus.payload -> string option = function
   | TurnCompleted r -> Some r.agent_name
   | ElicitationCompleted r -> Some r.agent_name
   | ContextCompacted r -> Some r.agent_name
+  | ContextOverflowImminent r -> Some r.agent_name
+  | ContextCompactStarted r -> Some r.agent_name
   | TaskStateChanged _ -> None
   | Custom _ -> None
 
@@ -107,6 +111,18 @@ let event_to_payload (event : Event_bus.event) : event_payload =
         ("before_tokens", `Int r.before_tokens);
         ("after_tokens", `Int r.after_tokens);
         ("phase", `String r.phase);
+      ]
+    | ContextOverflowImminent r ->
+      `Assoc [
+        ("agent_name", `String r.agent_name);
+        ("estimated_tokens", `Int r.estimated_tokens);
+        ("limit_tokens", `Int r.limit_tokens);
+        ("ratio", `Float r.ratio);
+      ]
+    | ContextCompactStarted r ->
+      `Assoc [
+        ("agent_name", `String r.agent_name);
+        ("trigger", `String r.trigger);
       ]
     | Custom (name, data) ->
       `Assoc [("name", `String name); ("data", data)]

--- a/lib/llm_provider/cascade_executor.ml
+++ b/lib/llm_provider/cascade_executor.ml
@@ -299,6 +299,42 @@ let truncate_to_context ?(context_margin = default_context_margin)
       result
     end
 
+(** Strict variant of {!truncate_to_context}.
+
+    Returns [Ok messages] when within budget, or
+    [Error (`Over_budget (estimated, budget))] when truncation cannot bring
+    the messages within budget.  Unlike {!truncate_to_context}, this function
+    never silently passes over-budget content through.
+
+    Intended for OAS-2's [ensure_within_budget] gate — the caller decides
+    whether to compact, handoff, or fail.
+
+    @since 0.136.0 *)
+let truncate_to_context_strict ?(context_margin = default_context_margin)
+    (cfg : Provider_config.t)
+    (messages : Types.message list)
+    : (Types.message list, [`Over_budget of int * int]) result =
+  match cfg.max_context with
+  | None -> Ok messages
+  | Some max_ctx ->
+    let budget = int_of_float (float_of_int max_ctx *. context_margin) in
+    let estimated =
+      List.fold_left
+        (fun acc msg -> acc + estimate_message_tokens msg) 0 messages
+    in
+    if estimated <= budget then Ok messages
+    else begin
+      let result = apply_token_budget budget messages in
+      let result_tokens =
+        List.fold_left
+          (fun acc msg -> acc + estimate_message_tokens msg) 0 result
+      in
+      if result_tokens > budget then
+        Error (`Over_budget (result_tokens, budget))
+      else
+        Ok result
+    end
+
 (** Truncate tools to fit within the remaining context budget after
     messages and output reserve are accounted for. Tools are kept in
     order (front = highest relevance from the caller's Tool_selector)

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -663,14 +663,45 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
      Runs before async input validation so that validators operate on the
      already-compacted message set.  Re-prepares the turn via
      Agent_turn.prepare_turn directly (not stage_parse) to avoid emitting
-     TurnStarted a second time or re-invoking before_turn_params. *)
-  let prep = match agent.state.config.context_compact_ratio with
-    | Some watermark when watermark > 0.0 && watermark < 1.0 ->
+     TurnStarted a second time or re-invoking before_turn_params.
+
+     Hard budget gate (OAS-2): when context_compact_ratio is not configured,
+     a ratio >= 0.9 still triggers compaction. This prevents the silent
+     pass-through that caused masc-improver CTX 101% (#7083). *)
+  let prep =
+    let watermark = match agent.state.config.context_compact_ratio with
+      | Some w when w > 0.0 && w < 1.0 -> w
+      | _ -> 0.9  (* hard floor: compact before 90% regardless of config *)
+    in
+    let est_tokens = List.fold_left (fun acc msg ->
+      acc + Context_reducer.estimate_message_tokens msg) 0 agent.state.messages in
+    let context_window = proactive_context_window_tokens agent in
+    let ratio = float_of_int est_tokens /. float_of_int context_window in
+    if ratio >= watermark then begin
+      (* Emit ContextOverflowImminent before compaction *)
+      (match agent.options.event_bus with
+       | Some bus -> Event_bus.publish bus
+           { meta = event_envelope agent;
+             payload = ContextOverflowImminent {
+               agent_name = agent.state.config.name;
+               estimated_tokens = est_tokens;
+               limit_tokens = context_window;
+               ratio } }
+       | None -> ());
+      (* Emit ContextCompactStarted *)
+      (match agent.options.event_bus with
+       | Some bus -> Event_bus.publish bus
+           { meta = event_envelope agent;
+             payload = ContextCompactStarted {
+               agent_name = agent.state.config.name;
+               trigger = "proactive" } }
+       | None -> ());
       let compacted = proactive_compact ?raw_trace_run agent ~watermark () in
       if compacted then
         prepare_turn_for_agent agent ~turn_params
       else prep
-    | _ -> prep
+    end
+    else prep
   in
 
   (* Stage 2.5: Async input validation *)
@@ -683,19 +714,27 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
        validator = validator_name; reason }))
    | Guardrails_async.Pass ->
 
-  (* Stage 2.7: Proactive watermark compaction — compact before overflow.
-     When context_compact_ratio is configured, check current usage and
-     apply Budget_strategy-based compaction if over the watermark.
-     Re-parses prep after compaction to reflect reduced messages. *)
-  let prep = match agent.state.config.context_compact_ratio with
-    | Some watermark when watermark > 0.0 && watermark < 1.0 ->
+  (* Stage 2.7: Proactive watermark compaction — post-validation pass.
+     Same hard budget gate as 2.3 — if context still exceeds watermark
+     after validation (validators can inject messages), compact again. *)
+  let prep =
+    let watermark = match agent.state.config.context_compact_ratio with
+      | Some w when w > 0.0 && w < 1.0 -> w
+      | _ -> 0.9
+    in
+    let est_tokens = List.fold_left (fun acc msg ->
+      acc + Context_reducer.estimate_message_tokens msg) 0 agent.state.messages in
+    let context_window = proactive_context_window_tokens agent in
+    let ratio = float_of_int est_tokens /. float_of_int context_window in
+    if ratio >= watermark then begin
       let compacted = proactive_compact ?raw_trace_run agent ~watermark () in
       if compacted then begin
         update_state agent (fun s -> { s with config = original_config });
         let (prep', _, _) = stage_parse ?raw_trace_run agent in
         prep'
       end else prep
-    | _ -> prep
+    end
+    else prep
   in
 
   (* Stage 3: Route — with compact-and-retry on context overflow *)
@@ -741,6 +780,13 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
     match api_result with
     | Error (Error.Api (Retry.ContextOverflow { limit; _ }))
       when compact_attempts < 2 ->
+      (match agent.options.event_bus with
+       | Some bus -> Event_bus.publish bus
+           { meta = event_envelope agent;
+             payload = ContextCompactStarted {
+               agent_name = agent.state.config.name;
+               trigger = "emergency" } }
+       | None -> ());
       let compacted = emergency_compact ?raw_trace_run agent ?limit () in
       if not compacted then api_result
       else begin

--- a/test/test_event_forward.ml
+++ b/test/test_event_forward.ml
@@ -24,6 +24,13 @@ let test_event_type_name () =
      "tool.called");
     (ev (Event_bus.Custom ("foo", `Null)),
      "custom.foo");
+    (ev (Event_bus.ContextOverflowImminent {
+           agent_name = "a"; estimated_tokens = 95000;
+           limit_tokens = 100000; ratio = 0.95 }),
+     "context.overflow_imminent");
+    (ev (Event_bus.ContextCompactStarted {
+           agent_name = "a"; trigger = "proactive" }),
+     "context.compact_started");
   ] in
   List.iter (fun (event, expected) ->
     Alcotest.(check string) "event_type"


### PR DESCRIPTION
## Summary

- Add `ContextOverflowImminent` + `ContextCompactStarted` event_bus payloads
- Add `estimate_next_turn_overhead` to context_reducer (budget projection)
- Add `truncate_to_context_strict` to cascade_executor (Result-based)
- **Hard budget gate**: when `context_compact_ratio` is not configured, a 0.9 floor triggers proactive compaction
- **Event emission**: `ContextOverflowImminent` before compaction, `ContextCompactStarted` for both proactive and emergency paths

## Context

Part of the Keeper Context Overflow plan. MASC-1 (masc-mcp#7083, merged) added FSM observability, MASC-2 (masc-mcp#7115, merged) added operator tools. This PR addresses the OAS primary path — proactive prevention so overflow never reaches MASC.

## Key design decisions

- Hard floor 0.9: conservative — fires late enough to avoid unnecessary compaction on healthy sessions, early enough to prevent provider-rejected prompts.
- `truncate_to_context_strict` returns `Error (\`Over_budget (est, budget))` instead of silent pass-through. Original `truncate_to_context` unchanged.
- `estimate_next_turn_overhead` intentionally over-counts for conservative budget decisions.
- Event payloads follow existing envelope pattern.

## Test plan

- [x] `dune build` passes
- [x] All 22 tests pass (including complete_http cascade tests)
- [x] 3 inline tests for `estimate_next_turn_overhead`
- [x] 2 event_forward roundtrip tests for new payloads
- [x] CI: Build, Lint, Version Consistency all green

## Files changed (8)

| File | Change |
|------|--------|
| `lib/event_bus.{ml,mli}` | 2 new payload variants |
| `lib/event_forward.ml` | Exhaustive match for new variants |
| `lib/context_reducer.{ml,mli}` | `estimate_next_turn_overhead` |
| `lib/llm_provider/cascade_executor.ml` | `truncate_to_context_strict` |
| `lib/pipeline/pipeline.ml` | Hard budget gate + event emission |
| `test/test_event_forward.ml` | Roundtrip tests |
| `dune-project` + `agent_sdk.opam` | Version bump to 0.136.0 |
| `CHANGELOG.md` | Release notes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)