### PR TITLE
feat(pipeline): lenient tool-use recovery from text content (Samchon Layer 1)

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -122,6 +122,7 @@ module Autonomy_diff_guard = Autonomy_diff_guard
 module Metric_contract = Metric_contract
 module Response_harness = Response_harness
 module Tool_middleware = Tool_middleware
+module Tool_use_recovery = Tool_use_recovery
 module Tool_selector = Tool_selector
 module Lesson_memory = Lesson_memory
 module Event_forward = Event_forward

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -142,6 +142,7 @@ module Tool_retry_policy = Tool_retry_policy
 module Lenient_json = Llm_provider.Lenient_json
 module Tool_input_validation = Tool_input_validation
 module Tool_middleware = Tool_middleware
+module Tool_use_recovery = Tool_use_recovery
 module Response_harness = Response_harness
 module Durable_event = Durable_event
 module Journal_bridge = Journal_bridge

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -757,7 +757,17 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
   | Error e ->
     update_state agent (fun s -> { s with config = original_config });
     Error e
-  | Ok response ->
+  | Ok raw_response ->
+    (* Stage 3.4: Lenient tool-use recovery.
+       Some providers (GLM, smaller Ollama models) return tool-call
+       intent as text content instead of a ToolUse content block.
+       Promote recoverable Text blocks to ToolUse before contract
+       validation so the pipeline proceeds normally.
+       Ref: Samchon harness Layer 1 (dev.to/samchon, Qwen 2025). *)
+    let valid_tool_names = Tool_set.names agent.tools in
+    let response =
+      Tool_use_recovery.recover_response ~valid_tool_names raw_response
+    in
     let* () =
       validate_completion_contract agent response
       |> tag_error "route_contract"

--- a/lib/tool_use_recovery.ml
+++ b/lib/tool_use_recovery.ml
@@ -1,0 +1,210 @@
+(** Tool use recovery — extract ToolUse blocks from text content when the
+    provider returns a tool-call intent as text instead of a proper
+    ToolUse block.
+
+    Motivated by GLM / Ollama providers that receive [tool_choice]
+    parameters but emit the call as JSON inside a Text block (often
+    wrapped in Markdown fences). Without recovery,
+    [validate_completion_contract] raises [require_tool_use] even though
+    the model's intent was correct.
+
+    Pure module: takes a response and a list of valid tool names,
+    returns either the original response (unchanged) or a response with
+    Text blocks promoted to ToolUse blocks.
+
+    Reference: Samchon function calling harness, Layer 1 "Lenient parse"
+    (dev.to/samchon, Qwen Meetup 2025). Delegates JSON normalization to
+    {!Llm_provider.Lenient_json} (markdown fence strip, double-stringify
+    unwrap, trailing comma cleanup, bracket completion).
+
+    @since 0.136.0 *)
+
+open Types
+
+let _log = Log.create ~module_name:"tool_use_recovery" ()
+
+(* ── JSON candidate location ─────────────────────────────── *)
+
+(** Find the first balanced top-level JSON object in a string by
+    scanning for '{' and tracking depth while respecting string
+    literals. Returns [Some (start, length)] or [None]. *)
+let find_json_object (s : string) : (int * int) option =
+  let len = String.length s in
+  let rec find_start i =
+    if i >= len then None
+    else if s.[i] = '{' then Some i
+    else find_start (i + 1)
+  in
+  match find_start 0 with
+  | None -> None
+  | Some start ->
+    let depth = ref 0 in
+    let in_string = ref false in
+    let escaped = ref false in
+    let end_idx = ref (-1) in
+    let i = ref start in
+    while !end_idx = -1 && !i < len do
+      let c = s.[!i] in
+      if !escaped then escaped := false
+      else if c = '\\' && !in_string then escaped := true
+      else if c = '"' then in_string := not !in_string
+      else if not !in_string then begin
+        if c = '{' then incr depth
+        else if c = '}' then begin
+          decr depth;
+          if !depth = 0 then end_idx := !i
+        end
+      end;
+      incr i
+    done;
+    if !end_idx >= 0 then Some (start, !end_idx - start + 1)
+    else None
+
+(** Try to parse a JSON object from a string using {!Lenient_json.parse}
+    after locating a balanced object. Returns [None] only when no
+    object can be located at all (Lenient_json never raises). *)
+let try_parse_json_object (s : string) : Yojson.Safe.t option =
+  (* Lenient_json handles markdown fences, double-stringify, trailing
+     commas, and unclosed brackets. We still locate the first balanced
+     object first, because content blocks may wrap JSON in surrounding
+     prose ("I will call: {...}"). *)
+  let stripped = Llm_provider.Lenient_json.strip_markdown_fence s in
+  match find_json_object stripped with
+  | None ->
+    (* Fall back to lenient_json on the whole input — handles cases
+       where the stream is the JSON itself, possibly truncated. *)
+    let parsed = Llm_provider.Lenient_json.parse stripped in
+    (match parsed with
+     | `Assoc [("raw", `String _)] -> None  (* Sentinel for parse failure *)
+     | other -> Some other)
+  | Some (start, length) ->
+    let candidate = String.sub stripped start length in
+    let parsed = Llm_provider.Lenient_json.parse candidate in
+    (match parsed with
+     | `Assoc [("raw", `String _)] -> None
+     | other -> Some other)
+
+(* ── Tool call shape matching ────────────────────────────── *)
+
+(** Extract [(name, input)] from a JSON value matching one of the
+    common tool-call shapes:
+
+    - Anthropic-style: [{"name": "X", "input": {...}}]
+    - OpenAI function call: [{"name": "X", "arguments": {...}}]
+      where arguments may be a JSON-encoded string (double-stringified)
+    - OpenAI tool_calls wrapper: [{"tool_calls": [{"function": {...}}]}]
+    - Bare function wrapper: [{"function": {"name": ..., ...}}]
+
+    Returns [None] if no recognizable shape is found. *)
+let rec extract_name_and_input (json : Yojson.Safe.t) : (string * Yojson.Safe.t) option =
+  match json with
+  | `Assoc fields ->
+    let name_opt = match List.assoc_opt "name" fields with
+      | Some (`String s) -> Some s
+      | _ -> None
+    in
+    (match name_opt with
+     | Some name ->
+       let input_opt =
+         match List.assoc_opt "input" fields with
+         | Some v -> Some v
+         | None ->
+           match List.assoc_opt "arguments" fields with
+           | Some (`String s) ->
+             (* Double-stringified: arguments is a JSON-encoded string *)
+             let inner = Llm_provider.Lenient_json.parse s in
+             (match inner with
+              | `Assoc [("raw", `String _)] -> Some (`String s)
+              | other -> Some other)
+           | Some v -> Some v
+           | None ->
+             match List.assoc_opt "parameters" fields with
+             | Some v -> Some v
+             | None -> None
+       in
+       Option.map (fun input -> (name, input)) input_opt
+     | None ->
+       match List.assoc_opt "tool_calls" fields with
+       | Some (`List (first :: _)) ->
+         (match first with
+          | `Assoc subfields ->
+            (match List.assoc_opt "function" subfields with
+             | Some inner -> extract_name_and_input inner
+             | None -> extract_name_and_input first)
+          | _ -> None)
+       | _ ->
+         match List.assoc_opt "function" fields with
+         | Some inner -> extract_name_and_input inner
+         | None -> None)
+  | _ -> None
+
+(* ── Tool ID generation ──────────────────────────────────── *)
+
+let next_recovery_id =
+  let counter = ref 0 in
+  fun () ->
+    incr counter;
+    Printf.sprintf "recovered_%d_%d"
+      (int_of_float (Unix.gettimeofday () *. 1000.0)) !counter
+
+(* ── Response-level recovery ─────────────────────────────── *)
+
+(** Scan content blocks; replace recoverable Text blocks with ToolUse.
+    Returns [(new_content, recovered_count)]. *)
+let recover_content_blocks
+    ~(valid_tool_names : string list)
+    (content : content_block list)
+  : content_block list * int =
+  let recovered = ref 0 in
+  let new_content =
+    List.map (fun block ->
+      match block with
+      | Text text ->
+        (match try_parse_json_object text with
+         | None -> block
+         | Some json ->
+           match extract_name_and_input json with
+           | None -> block
+           | Some (name, input) when List.mem name valid_tool_names ->
+             incr recovered;
+             ToolUse { id = next_recovery_id (); name; input }
+           | Some _ -> block)
+      | _ -> block
+    ) content
+  in
+  (new_content, !recovered)
+
+(** Top-level recovery. Promotes Text-embedded tool calls to ToolUse
+    blocks only when:
+    - [valid_tool_names] is non-empty,
+    - the response has no ToolUse blocks,
+    - at least one Text block matches a recognized tool-call shape
+      whose [name] is in [valid_tool_names].
+
+    Otherwise returns the response unchanged. Adjusts [stop_reason]
+    from [EndTurn] to [StopToolUse] when recovery succeeds. *)
+let recover_response
+    ~(valid_tool_names : string list)
+    (response : api_response)
+  : api_response =
+  if valid_tool_names = [] then response
+  else
+    let has_tool_use =
+      List.exists (function ToolUse _ -> true | _ -> false) response.content
+    in
+    if has_tool_use then response
+    else
+      let (new_content, count) =
+        recover_content_blocks ~valid_tool_names response.content
+      in
+      if count = 0 then response
+      else begin
+        Log.info _log
+          "recovered tool use(s) from text content"
+          [ Log.I ("count", count);
+            Log.S ("model", response.model) ];
+        { response with content = new_content;
+          stop_reason = match response.stop_reason with
+            | EndTurn -> StopToolUse
+            | other -> other }
+      end

--- a/lib/tool_use_recovery.mli
+++ b/lib/tool_use_recovery.mli
@@ -1,0 +1,46 @@
+(** Tool use recovery — extract ToolUse blocks from Text content when a
+    provider emits tool-call intent as text instead of a proper ToolUse
+    block.
+
+    Delegates JSON normalization to {!Llm_provider.Lenient_json}.
+
+    @since 0.136.0 *)
+
+open Types
+
+(** Find the first balanced top-level JSON object in a string,
+    respecting string literal escapes. Returns [Some (start, length)]
+    or [None]. Exposed for testing. *)
+val find_json_object : string -> (int * int) option
+
+(** Try to parse a JSON object from a string. Strips markdown fences,
+    locates the first balanced object, and runs {!Lenient_json.parse}
+    for transform-based recovery. Returns [None] if no JSON found. *)
+val try_parse_json_object : string -> Yojson.Safe.t option
+
+(** Match a JSON value against known tool-call shapes and extract
+    [(name, input)]. Handles Anthropic-style [{name, input}], OpenAI
+    [{name, arguments}] (including double-stringified [arguments]),
+    OpenAI [{tool_calls: [...]}] wrapper, and bare [{function: ...}]. *)
+val extract_name_and_input : Yojson.Safe.t -> (string * Yojson.Safe.t) option
+
+(** Scan content blocks and replace recoverable Text blocks with
+    ToolUse. Returns [(new_content, recovered_count)]. *)
+val recover_content_blocks :
+  valid_tool_names:string list ->
+  content_block list ->
+  content_block list * int
+
+(** Top-level recovery. Promotes Text-embedded tool calls to ToolUse
+    blocks only when:
+    - [valid_tool_names] is non-empty,
+    - the response has no ToolUse blocks,
+    - at least one Text block matches a recognized tool-call shape
+      whose [name] is in [valid_tool_names].
+
+    Returns the response unchanged otherwise. Adjusts [stop_reason]
+    from [EndTurn] to [StopToolUse] on recovery. *)
+val recover_response :
+  valid_tool_names:string list ->
+  api_response ->
+  api_response

--- a/test/dune
+++ b/test/dune
@@ -47,6 +47,10 @@
  (libraries agent_sdk alcotest yojson str))
 
 (test
+ (name test_tool_use_recovery)
+ (libraries agent_sdk alcotest yojson))
+
+(test
  (name test_typed_tool_safe)
  (libraries agent_sdk alcotest yojson))
 

--- a/test/test_tool_use_recovery.ml
+++ b/test/test_tool_use_recovery.ml
@@ -1,0 +1,178 @@
+(** Tests for Tool_use_recovery — lenient extraction of ToolUse blocks
+    from Text content. *)
+
+open Alcotest
+open Agent_sdk.Types
+module TUR = Agent_sdk.Tool_use_recovery
+
+(* ── Fixtures ────────────────────────────────────────────── *)
+
+let make_response ?(model = "test") ~content () : api_response =
+  { id = "test_id"
+  ; model
+  ; stop_reason = EndTurn
+  ; content
+  ; usage = None
+  ; telemetry = None
+  }
+
+(* ── find_json_object ────────────────────────────────────── *)
+
+let test_find_object_simple () =
+  match TUR.find_json_object "prefix {\"a\":1} suffix" with
+  | Some (start, len) ->
+    check int "start" 7 start;
+    check int "length" 7 len
+  | None -> fail "expected object"
+
+let test_find_object_nested () =
+  match TUR.find_json_object "{\"outer\": {\"inner\": 42}}" with
+  | Some (start, len) ->
+    check int "start at 0" 0 start;
+    check int "full object length" 24 len
+  | None -> fail "expected object"
+
+let test_find_object_string_with_braces () =
+  (* Braces inside string literals must not affect depth *)
+  match TUR.find_json_object "{\"key\": \"value with } brace\"}" with
+  | Some (start, len) ->
+    check int "start" 0 start;
+    check int "length matches" 29 len
+  | None -> fail "expected object"
+
+let test_find_object_none () =
+  check (option (pair int int)) "no object"
+    None (TUR.find_json_object "no braces here")
+
+(* ── extract_name_and_input ──────────────────────────────── *)
+
+let test_extract_anthropic_style () =
+  let json = `Assoc [
+    ("name", `String "keeper_board_post");
+    ("input", `Assoc [("title", `String "hi")])
+  ] in
+  match TUR.extract_name_and_input json with
+  | Some (name, input) ->
+    check string "name" "keeper_board_post" name;
+    check (option string) "title"
+      (Some "hi")
+      (match input with
+       | `Assoc fs -> (match List.assoc_opt "title" fs with
+                      | Some (`String s) -> Some s | _ -> None)
+       | _ -> None)
+  | None -> fail "expected extraction"
+
+let test_extract_openai_arguments_object () =
+  let json = `Assoc [
+    ("name", `String "tool");
+    ("arguments", `Assoc [("x", `Int 1)])
+  ] in
+  match TUR.extract_name_and_input json with
+  | Some (name, _) -> check string "name" "tool" name
+  | None -> fail "expected extraction"
+
+let test_extract_double_stringified () =
+  (* OpenAI-style: arguments value is a JSON-encoded string *)
+  let json = `Assoc [
+    ("name", `String "tool");
+    ("arguments", `String "{\"x\":42}")
+  ] in
+  match TUR.extract_name_and_input json with
+  | Some (_, input) ->
+    (match input with
+     | `Assoc [("x", `Int 42)] -> ()
+     | _ -> fail "expected decoded {x:42}")
+  | None -> fail "expected extraction"
+
+let test_extract_tool_calls_wrapper () =
+  let json = `Assoc [
+    ("tool_calls", `List [
+      `Assoc [
+        ("function", `Assoc [
+          ("name", `String "foo");
+          ("arguments", `Assoc [("k", `String "v")])
+        ])
+      ]
+    ])
+  ] in
+  match TUR.extract_name_and_input json with
+  | Some (name, _) -> check string "name" "foo" name
+  | None -> fail "expected extraction"
+
+let test_extract_none () =
+  check (option (pair string string)) "no shape"
+    None
+    (Option.map (fun (n, _) -> (n, "")) (TUR.extract_name_and_input (`String "plain")))
+
+(* ── recover_response ────────────────────────────────────── *)
+
+let test_recover_text_to_tool_use () =
+  let text = "```json\n{\"name\": \"my_tool\", \"input\": {\"x\": 1}}\n```" in
+  let response = make_response ~content:[Text text] () in
+  let recovered = TUR.recover_response ~valid_tool_names:["my_tool"] response in
+  match recovered.content with
+  | [ToolUse { name; _ }] ->
+    check string "promoted to ToolUse" "my_tool" name;
+    check bool "stop_reason updated" true
+      (recovered.stop_reason = StopToolUse)
+  | _ -> fail "expected single ToolUse block"
+
+let test_recover_skips_unknown_tool () =
+  let text = "{\"name\": \"unknown_tool\", \"input\": {}}" in
+  let response = make_response ~content:[Text text] () in
+  let recovered = TUR.recover_response ~valid_tool_names:["my_tool"] response in
+  (* Unknown tool name: leave as Text *)
+  match recovered.content with
+  | [Text _] -> ()
+  | _ -> fail "expected Text preserved"
+
+let test_recover_noop_when_tool_use_present () =
+  let response = make_response
+    ~content:[ToolUse { id = "1"; name = "existing"; input = `Null }] ()
+  in
+  let recovered = TUR.recover_response
+    ~valid_tool_names:["existing"; "other"] response
+  in
+  check bool "response unchanged"
+    true (recovered == response)
+
+let test_recover_noop_when_no_tools () =
+  let response = make_response ~content:[Text "{\"name\":\"x\",\"input\":{}}"] () in
+  let recovered = TUR.recover_response ~valid_tool_names:[] response in
+  check bool "no tools configured: passthrough"
+    true (recovered == response)
+
+let test_recover_plain_text_preserved () =
+  let response = make_response ~content:[Text "just a plain answer"] () in
+  let recovered = TUR.recover_response
+    ~valid_tool_names:["any_tool"] response
+  in
+  match recovered.content with
+  | [Text s] -> check string "text preserved" "just a plain answer" s
+  | _ -> fail "expected Text preserved"
+
+(* ── Suite ───────────────────────────────────────────────── *)
+
+let () =
+  run "Tool_use_recovery" [
+    "find_json_object", [
+      test_case "simple" `Quick test_find_object_simple;
+      test_case "nested" `Quick test_find_object_nested;
+      test_case "string braces" `Quick test_find_object_string_with_braces;
+      test_case "none" `Quick test_find_object_none;
+    ];
+    "extract_name_and_input", [
+      test_case "anthropic style" `Quick test_extract_anthropic_style;
+      test_case "openai arguments object" `Quick test_extract_openai_arguments_object;
+      test_case "double stringified" `Quick test_extract_double_stringified;
+      test_case "tool_calls wrapper" `Quick test_extract_tool_calls_wrapper;
+      test_case "no shape" `Quick test_extract_none;
+    ];
+    "recover_response", [
+      test_case "text to tool use" `Quick test_recover_text_to_tool_use;
+      test_case "skip unknown tool" `Quick test_recover_skips_unknown_tool;
+      test_case "noop when tool use present" `Quick test_recover_noop_when_tool_use_present;
+      test_case "noop when no tools" `Quick test_recover_noop_when_no_tools;
+      test_case "plain text preserved" `Quick test_recover_plain_text_preserved;
+    ];
+  ]


### PR DESCRIPTION
## Summary

Closes #899. Adds `Tool_use_recovery` module and pipeline stage 3.4. Promotes Text-embedded tool calls to ToolUse blocks before contract validation, recovering the request when providers (GLM, smaller Ollama) emit the call as text instead of a structured block.

## Problem

Per masc-mcp#7116, GLM cascade keepers were stuck on `require_tool_use` violations even with `tool_choice = Auto`. Investigation showed all static paths produce `Allow_text_or_tool` — but the violation still fired. Most likely cause: the model returned a tool call as Text content (often inside `\`\`\`json ... \`\`\`` fences). OAS only recognized the `ToolUse` content variant, so the call was invisible to `validate_completion_contract`.

## Change

New module `lib/tool_use_recovery.ml`:
- Locates first balanced JSON object in text (string-aware brace counting)
- Delegates JSON cleanup to existing `Llm_provider.Lenient_json` (markdown fence strip, double-stringify unwrap, trailing comma fix, bracket completion)
- Matches one of four tool-call shapes (Anthropic `{name,input}`, OpenAI `{name,arguments}`, `{tool_calls:[{function:...}]}`, bare `{function:...}`)
- Promotes Text → ToolUse only when extracted name is in the agent's tool set

Pipeline stage 3.4 (`pipeline.ml`): after API response, before `validate_completion_contract`, call `Tool_use_recovery.recover_response`. No behavior change when response already has ToolUse blocks or when no Text matches a registered tool.

## Conservativeness

- `valid_tool_names` is empty → passthrough
- response already has ToolUse → passthrough
- extracted tool name not in tool set → leave Text unchanged
- otherwise → promote, stop_reason `EndTurn → StopToolUse`, info log with count

## Test plan

| Suite | Tests | Status |
|-------|-------|--------|
| test_tool_use_recovery (new) | 14 | ✓ |
| test_agent_tool | 7 | ✓ |
| test_agent_turn | 37 | ✓ |
| test_agent_pipeline | 15 | ✓ |
| test_hooks | 30 | ✓ |
| test_turn_params | 13 | ✓ |
| test_tool_middleware | 20 | ✓ |
| test_correction_pipeline | 12 | ✓ |

148 tests, 0 failures. Covers the new module + integration boundary + downstream pipeline stages.

## Samchon harness coverage after this PR

| Layer | OAS module | Status |
|-------|-----------|--------|
| 1. Lenient parse | `Tool_use_recovery` (new) + `Lenient_json` (existing) | **Now wired** |
| 2. Type coercion | `Correction_pipeline` (wired by #902) | ✓ |
| 3. Structured feedback | `build_nondet_feedback` (wired by #902) | ✓ |
| 4. Self-healing loop | `tool_retry_policy` | ✓ |

All four Samchon layers now active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
