### PR TITLE
feat(builder): add with_policy_channel setter

### DIFF
--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -62,6 +62,7 @@ type t = {
   tool_result_relocation:
     (Tool_result_store.t * Content_replacement_state.t) option;
   journal: Durable_event.journal option;
+  policy_channel: Policy_channel.t option;
 }
 
 let create ~net ~model =
@@ -122,6 +123,7 @@ let create ~net ~model =
     on_run_complete = None;
     tool_result_relocation = None;
     journal = None;
+    policy_channel = None;
   }
 
 let with_tool_result_relocation ~store ~state b =
@@ -231,6 +233,7 @@ let with_context_injector injector b = { b with context_injector = Some injector
 let with_skill_registry reg b = { b with skill_registry = Some reg }
 let with_progressive_tools strategy b = { b with progressive_tools = Some strategy }
 let with_tool_selector strategy b = { b with tool_selector = Some strategy }
+let with_policy_channel ch b = { b with policy_channel = Some ch }
 let with_elicitation cb b = { b with elicitation = Some cb }
 let with_description desc b = { b with description = Some desc }
 let with_memory mem b = { b with memory = Some mem }
@@ -333,7 +336,7 @@ let build b =
     memory = b.memory;
     allowed_paths = b.allowed_paths;
     operator_policy = b.operator_policy;
-    policy_channel = None;
+    policy_channel = b.policy_channel;
     tool_selector = b.tool_selector;
     priority = b.priority;
     slot_id = b.slot_id;

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -182,6 +182,12 @@ val with_progressive_tools : Progressive_tools.disclosure_strategy -> t -> t
     @since 0.100.0 *)
 val with_tool_selector : Tool_selector.strategy -> t -> t
 
+(** Set a shared policy channel for lazy tool policy propagation.
+    Children that share the same channel pick up parent policy changes
+    at their next turn boundary via lock-free polling.
+    @since 0.136.1 *)
+val with_policy_channel : Policy_channel.t -> t -> t
+
 (** {2 Run lifecycle} *)
 
 (** Set a callback invoked when a run finishes.  Receives [true] on


### PR DESCRIPTION
## Summary

- Expose existing `Policy_channel.t` through `Builder.with_policy_channel`
- `Agent.options.policy_channel` field existed but Builder hardcoded `None` with no setter
- Backward compatible: defaults to `None` when not called

## Motivation

`Policy_channel` enables lazy tool policy propagation from parent to child agents via lock-free polling. The module and type are fully implemented — only the Builder entry point was missing.

## Test plan

- [x] `dune build --root .` green
- [x] `dune runtest --root .` green (all existing tests pass)

Fixes #906.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>