### PR TITLE
feat(tool_selector): add select_with_index for pre-built index reuse

### DIFF
--- a/lib/tool_selector.ml
+++ b/lib/tool_selector.ml
@@ -59,11 +59,8 @@ let filter_by_names names tools =
 
 let select_all tools = tools
 
-let select_llm ~k ~bm25_prefilter_n ~always_include ~confidence_threshold
-    ~rerank_fn ~context ~tools =
-  if tools = [] then []
-  else
-    let index = Tool_index.of_tools tools in
+let select_llm_core ~k ~bm25_prefilter_n ~always_include ~confidence_threshold
+    ~rerank_fn ~context ~index ~tools =
     let retrieved = Tool_index.retrieve index context in
     let top_score = match retrieved with
       | (_, s) :: _ -> s
@@ -109,11 +106,8 @@ let select_llm ~k ~bm25_prefilter_n ~always_include ~confidence_threshold
       let selected = merge_names ~always_include ~top_names in
       filter_by_names selected tools
 
-let select_bm25 ~k ~always_include ~confidence_threshold ~fallback_tools
-    ~context ~tools =
-  if tools = [] then []
-  else
-    let index = Tool_index.of_tools tools in
+let select_bm25_core ~k ~always_include ~confidence_threshold ~fallback_tools
+    ~context ~index ~tools =
     let retrieved = Tool_index.retrieve index context in
     let top_score = match retrieved with
       | (_, s) :: _ -> s
@@ -130,6 +124,24 @@ let select_bm25 ~k ~always_include ~confidence_threshold ~fallback_tools
     let extra = if use_fallback then fallback_tools else [] in
     let selected_names = merge_names ~always_include ~top_names:(top_names @ extra) in
     filter_by_names selected_names tools
+
+(* ── Convenience wrappers (build index internally) ───────── *)
+
+let select_llm ~k ~bm25_prefilter_n ~always_include ~confidence_threshold
+    ~rerank_fn ~context ~tools =
+  if tools = [] then []
+  else
+    let index = Tool_index.of_tools tools in
+    select_llm_core ~k ~bm25_prefilter_n ~always_include ~confidence_threshold
+      ~rerank_fn ~context ~index ~tools
+
+let select_bm25 ~k ~always_include ~confidence_threshold ~fallback_tools
+    ~context ~tools =
+  if tools = [] then []
+  else
+    let index = Tool_index.of_tools tools in
+    select_bm25_core ~k ~always_include ~confidence_threshold ~fallback_tools
+      ~context ~index ~tools
 
 (* ── Public API ──────────────────────────────────────────── *)
 
@@ -168,9 +180,30 @@ let select ~strategy ~context ~tools =
       let selected_names = merge_names ~always_include ~top_names:group_tool_names in
       filter_by_names selected_names tools
 
+let select_with_index ~strategy ~index ~context ~tools =
+  match strategy with
+  | All -> select_all tools
+  | TopK_bm25 { k; always_include; confidence_threshold; fallback_tools } ->
+    if tools = [] then []
+    else select_bm25_core ~k ~always_include ~confidence_threshold ~fallback_tools
+      ~context ~index ~tools
+  | TopK_llm { k; bm25_prefilter_n; always_include; confidence_threshold;
+               rerank_fn } ->
+    if tools = [] then []
+    else select_llm_core ~k ~bm25_prefilter_n ~always_include ~confidence_threshold
+      ~rerank_fn ~context ~index ~tools
+  | Categorical _ ->
+    (* Categorical builds its own group index; the tool index is not useful.
+       Fall through to the standard select path. *)
+    select ~strategy ~context ~tools
+
 let select_names ~strategy ~context ~tools =
   List.map (fun (t : Tool.t) -> t.schema.name)
     (select ~strategy ~context ~tools)
+
+let select_names_with_index ~strategy ~index ~context ~tools =
+  List.map (fun (t : Tool.t) -> t.schema.name)
+    (select_with_index ~strategy ~index ~context ~tools)
 
 let auto ~tools =
   if List.length tools <= 15 then All

--- a/lib/tool_selector.mli
+++ b/lib/tool_selector.mli
@@ -108,6 +108,33 @@ val select_names :
   tools:Tool.t list ->
   string list
 
+(** Like {!select} but accepts a pre-built {!Tool_index.t}.
+
+    Avoids rebuilding the BM25 index on every call. Callers that
+    invoke selection per-turn with the same tool set should build
+    the index once via {!Tool_index.of_tools} (or {!Tool_index.build}
+    for alias support) and reuse it.
+
+    For [All] and [Categorical] strategies the index is ignored
+    (they either return everything or build their own group index).
+
+    @since 0.136.1 *)
+val select_with_index :
+  strategy:strategy ->
+  index:Tool_index.t ->
+  context:string ->
+  tools:Tool.t list ->
+  Tool.t list
+
+(** Like {!select_names} but accepts a pre-built index.
+    @since 0.136.1 *)
+val select_names_with_index :
+  strategy:strategy ->
+  index:Tool_index.t ->
+  context:string ->
+  tools:Tool.t list ->
+  string list
+
 (** Default strategy based on tool count.
     - [<= 15] tools -> [All]
     - [> 15] tools  -> [TopK_bm25 { k = 5; always_include = \[\] }] *)


### PR DESCRIPTION
## Summary

- Add `select_with_index` and `select_names_with_index` that accept a pre-built `Tool_index.t`
- Refactor internals into `_core` variants shared by both paths
- Existing `select`/`select_names` unchanged (backward compatible)

## Motivation

Consumers calling `select` per-turn with the same tool set (30-60 tools) rebuild the BM25 index from scratch every time. Pre-building via `Tool_index.of_tools` once and reusing across turns avoids this redundant O(n) work.

## Test plan

- [x] `dune build --root .` green
- [x] `dune runtest --root .` green (all existing tests pass)
- [x] Backward compatible: `select` continues to build index internally

Fixes #905.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>