### PR TITLE
feat(cascade): weighted model selection for load distribution

### DIFF
--- a/docs/rfc/RFC-OAS-006-weighted-cascade-routing.md
+++ b/docs/rfc/RFC-OAS-006-weighted-cascade-routing.md
@@ -1,0 +1,158 @@
+# RFC-OAS-006: Weighted Cascade Routing
+
+**Status**: Draft
+**Author**: jeong-sik
+**Date**: 2026-04-15
+**Scope**: `lib/llm_provider/cascade_config.ml`, `cascade_executor.ml`
+
+## Problem
+
+OAS cascade executes providers in fixed sequential order. The first provider
+always receives 100% of initial traffic. This causes:
+
+1. **Single-point bottleneck**: GLM rate limits → all traffic hits one provider
+   until it fails, then cascades. No distribution.
+2. **No cost/latency optimization**: Cannot prefer cheaper or faster providers
+   by ratio.
+3. **No health-aware routing**: A provider with 50% error rate still receives
+   100% of first attempts until it fails each time.
+
+## Industry Survey
+
+| Solution | Selection | Health | Fallback |
+|----------|-----------|--------|----------|
+| LiteLLM | weighted random (`simple-shuffle`) | proactive + cooldown | 3-type (general/context/policy) |
+| OpenRouter | price x uptime weighting | reactive (rolling 5-min window) | sequential per-model |
+| Portkey | explicit weights (decimal) | reactive (status codes) | nestable (LB inside fallback) |
+| Martian | ML per-request prediction | proactive benchmarking | automatic |
+
+**Common pattern**: weighted selection + reactive cooldown + sequential fallback.
+
+## Design
+
+### 3-Layer Separation
+
+```
+Layer 1: Provider Inventory    — what exists (API keys, endpoints)
+Layer 2: Availability          — what works now (health, cooldown)  
+Layer 3: Selection Policy      — how to choose (weights, strategy)
+```
+
+### Phase 1: Weighted Selection (this RFC)
+
+Extend cascade config to support weights. Weighted random selects the
+first-attempt provider; remaining providers form the fallback chain.
+
+#### Config Format (backward compatible)
+
+```json
+{
+  "keeper_unified_models": [
+    { "model": "glm-coding:glm-5.1", "weight": 50 },
+    { "model": "claude:claude-haiku-4-5-20251001", "weight": 30 },
+    { "model": "ollama:qwen3.5:35b-a3b-nvfp4", "weight": 20 }
+  ]
+}
+```
+
+Plain strings remain valid (weight defaults to equal):
+```json
+{
+  "keeper_unified_models": ["glm-coding:glm-5.1", "ollama:qwen3.5:35b-a3b-nvfp4"]
+}
+```
+
+#### Selection Algorithm
+
+1. Parse weights from config (default: equal weight for all)
+2. Normalize to probabilities: `w_i / sum(w)`
+3. Weighted random pick for first-attempt provider
+4. Remaining providers ordered by descending weight as fallback chain
+5. Pass ordered list to `cascade_executor` (executor unchanged)
+
+```
+weights: [glm:50, haiku:30, ollama:20]
+→ 50% chance: [glm, haiku, ollama]
+→ 30% chance: [haiku, glm, ollama]  
+→ 20% chance: [ollama, glm, haiku]
+```
+
+#### Type Changes
+
+```ocaml
+(* New: weighted model entry *)
+type weighted_model = {
+  model: string;
+  weight: int;  (* relative weight, default 1 *)
+}
+
+(* parse_model_strings extended *)
+val parse_weighted_model_strings :
+  ?temperature:float -> ?max_tokens:int -> ... ->
+  weighted_model list -> Provider_config.t list
+(* Returns providers ordered by weighted random selection *)
+```
+
+### Phase 2: Reactive Health (future RFC)
+
+Track per-provider success rate in a rolling window. Adjust effective
+weights: `effective_weight = config_weight * success_rate`.
+
+```ocaml
+module Cascade_health : sig
+  type t
+  val create : unit -> t
+  val record_success : t -> provider_key:string -> unit
+  val record_failure : t -> provider_key:string -> unit
+  val success_rate : t -> provider_key:string -> float
+  (* Rolling 5-minute window, exponential decay *)
+end
+```
+
+### Phase 3: Cooldown (future RFC)
+
+After N consecutive failures, put provider in cooldown for M seconds.
+During cooldown, provider is skipped (not attempted). LiteLLM pattern.
+
+## Changes
+
+### Files Modified
+
+| File | Change |
+|------|--------|
+| `cascade_config.ml` | Parse `{model, weight}` JSON objects; weighted shuffle |
+| `cascade_config.mli` | Export `weighted_model` type and parse function |
+| `cascade_executor.ml` | No change (receives pre-ordered list) |
+| `test/test_cascade_config.ml` | Weight parsing + shuffle distribution tests |
+
+### Files Created
+
+None in Phase 1.
+
+## Backward Compatibility
+
+- Plain string arrays work unchanged (each gets weight=1)
+- `cascade_executor.ml` interface unchanged
+- Consumers (MASC) need no code changes; only cascade.json update
+
+## Trade-offs
+
+| Decision | Alternative | Why this way |
+|----------|-------------|--------------|
+| Weight in config JSON | ML-based routing (Martian) | Deterministic, debuggable, no training data needed |
+| Weighted random + fallback | Pure round-robin | Respects provider priority while distributing load |
+| Phase 1 without health | All-at-once | Ship value incrementally; health adds complexity |
+| int weights (50/30/20) | float probabilities (0.5/0.3/0.2) | Ints are easier to reason about in config |
+
+## Risks
+
+- Weighted random adds non-determinism to provider selection — harder to
+  reproduce exact cascade paths in debugging. Mitigated by logging the
+  shuffled order at each call.
+- Config format change requires cascade.json schema documentation update.
+
+## References
+
+- LiteLLM Router: `litellm/router.py`, `simple_shuffle.py`
+- OpenRouter: `provider.sort`, uptime weighting
+- Portkey: `strategy.mode: "loadbalance"`, `targets[].weight`

--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -355,11 +355,17 @@ let weighted_shuffle (entries : Cascade_config_loader.weighted_entry list)
             (selected, e :: remaining)
       in
       let selected, remaining = find_selected 0 entries in
-      (* Sort remaining by descending weight for fallback priority *)
+      (* Sort remaining by descending weight for fallback priority.
+         Use index as tiebreaker to preserve original config order
+         among equal-weight entries (stable sort). *)
+      let indexed = List.mapi (fun i e -> (i, e)) remaining in
       let sorted_remaining =
-        List.sort (fun (a : Cascade_config_loader.weighted_entry)
-                       (b : Cascade_config_loader.weighted_entry) ->
-            compare b.weight a.weight) remaining
+        List.sort (fun (i1, (a : Cascade_config_loader.weighted_entry))
+                       (i2, (b : Cascade_config_loader.weighted_entry)) ->
+            let cmp = compare b.weight a.weight in
+            if cmp <> 0 then cmp else compare i1 i2
+          ) indexed
+        |> List.map snd
       in
       selected :: sorted_remaining
 
@@ -469,6 +475,14 @@ let complete_named ~sw ~net ?clock ?config_path
     resolve_model_strings_traced ?config_path ~name ~defaults ()
   in
   let model_strings = expand_model_strings_for_execution model_strings in
+  (* Log resolved cascade order — useful for debugging weighted shuffle *)
+  (match model_strings with
+   | _ :: _ :: _ ->
+     Diag.debug "cascade_config" "cascade '%s' order: [%s] (source=%s)"
+       name (String.concat "; " model_strings)
+       (match source with Named -> "named" | Default_fallback -> "default"
+        | Hardcoded_defaults -> "hardcoded")
+   | _ -> ());
   if strict_name && source <> Named then
     Error (Http_client.NetworkError {
         message =
@@ -556,6 +570,14 @@ let complete_named_stream ~sw ~net ?clock ?config_path
     resolve_model_strings_traced ?config_path ~name ~defaults ()
   in
   let model_strings = expand_model_strings_for_execution model_strings in
+  (* Log resolved cascade order — useful for debugging weighted shuffle *)
+  (match model_strings with
+   | _ :: _ :: _ ->
+     Diag.debug "cascade_config" "cascade '%s' order: [%s] (source=%s)"
+       name (String.concat "; " model_strings)
+       (match source with Named -> "named" | Default_fallback -> "default"
+        | Hardcoded_defaults -> "hardcoded")
+   | _ -> ());
   if strict_name && source <> Named then
     Error (Http_client.NetworkError {
       message = Printf.sprintf

--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -388,8 +388,14 @@ let order_weighted_entries
     let health = Cascade_health_tracker.global in
     let health_adjusted = List.map
         (fun (e : Cascade_config_loader.weighted_entry) ->
+           (* Extract model_id from "provider:model_id" to match the key
+              used by cascade_executor (cfg.model_id). *)
+           let provider_key = match String.split_on_char ':' e.model with
+             | _ :: rest when rest <> [] -> String.concat ":" rest
+             | _ -> e.model
+           in
            let ew = Cascade_health_tracker.effective_weight health
-               ~provider_key:e.model ~config_weight:e.weight in
+               ~provider_key ~config_weight:e.weight in
            { e with weight = ew })
         entries
     in

--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -318,14 +318,77 @@ let text_of_response (resp : Types.api_response) : string =
 
 type cascade_source = Named | Default_fallback | Hardcoded_defaults
 
+(** Weighted shuffle: pick first element by weighted random, then order
+    remaining by descending weight.  This gives probabilistic distribution
+    of first-attempt provider while maintaining a deterministic fallback
+    chain.  When all weights are equal, behaves like random-first + stable
+    remainder.
+
+    Algorithm (LiteLLM simple-shuffle inspired):
+    1. Compute cumulative weights
+    2. Pick random value in [0, total_weight)
+    3. Selected item becomes first; rest sorted by weight desc
+
+    @since 0.137.0 *)
+let weighted_shuffle (entries : Cascade_config_loader.weighted_entry list)
+    : Cascade_config_loader.weighted_entry list =
+  match entries with
+  | [] | [_] -> entries
+  | _ ->
+    let total_weight =
+      List.fold_left (fun acc (e : Cascade_config_loader.weighted_entry) ->
+          acc + e.weight) 0 entries
+    in
+    if total_weight <= 0 then entries
+    else
+      let r = Random.int total_weight in
+      (* Find the selected entry via cumulative weight *)
+      let rec find_selected cumulative = function
+        | [] -> (* fallback: first entry *)
+          (List.hd entries,
+           List.tl entries)
+        | (e : Cascade_config_loader.weighted_entry) :: rest ->
+          let cumulative' = cumulative + e.weight in
+          if r < cumulative' then (e, rest)
+          else
+            let selected, remaining = find_selected cumulative' rest in
+            (selected, e :: remaining)
+      in
+      let selected, remaining = find_selected 0 entries in
+      (* Sort remaining by descending weight for fallback priority *)
+      let sorted_remaining =
+        List.sort (fun (a : Cascade_config_loader.weighted_entry)
+                       (b : Cascade_config_loader.weighted_entry) ->
+            compare b.weight a.weight) remaining
+      in
+      selected :: sorted_remaining
+
 let resolve_model_strings_traced ?config_path ~name ~defaults () =
   match config_path with
   | Some path ->
-    let from_file = load_profile ~config_path:path ~name in
-    if from_file <> [] then (from_file, Named)
+    let from_file_weighted =
+      Cascade_config_loader.load_profile_weighted ~config_path:path ~name in
+    if from_file_weighted <> [] then
+      let has_weights = List.exists
+          (fun (e : Cascade_config_loader.weighted_entry) -> e.weight <> 1)
+          from_file_weighted
+      in
+      let ordered =
+        if has_weights then weighted_shuffle from_file_weighted
+        else from_file_weighted
+      in
+      let models = List.map
+          (fun (e : Cascade_config_loader.weighted_entry) -> e.model) ordered in
+      (models, Named)
     else
-      let fallback = load_profile ~config_path:path ~name:"default" in
-      if fallback <> [] then (fallback, Default_fallback)
+      let fallback_weighted =
+        Cascade_config_loader.load_profile_weighted
+          ~config_path:path ~name:"default" in
+      if fallback_weighted <> [] then
+        let models = List.map
+            (fun (e : Cascade_config_loader.weighted_entry) -> e.model)
+            fallback_weighted in
+        (models, Default_fallback)
       else (defaults, Hardcoded_defaults)
   | None -> (defaults, Hardcoded_defaults)
 
@@ -1106,3 +1169,125 @@ let%test "resolve_api_key_env empty on no match" =
 
 (* should_cascade_to_next + has_required_api_key tests
    moved to Cascade_health_filter *)
+
+(* ── weighted_shuffle inline tests ──────────────────── *)
+
+let%test "weighted_shuffle empty list" =
+  weighted_shuffle [] = []
+
+let%test "weighted_shuffle single item unchanged" =
+  let e : Cascade_config_loader.weighted_entry =
+    { model = "a"; weight = 1 } in
+  weighted_shuffle [e] = [e]
+
+let%test "weighted_shuffle preserves all items" =
+  let entries : Cascade_config_loader.weighted_entry list = [
+    { model = "a"; weight = 50 };
+    { model = "b"; weight = 30 };
+    { model = "c"; weight = 20 };
+  ] in
+  let result = weighted_shuffle entries in
+  List.length result = 3
+  && List.for_all (fun (e : Cascade_config_loader.weighted_entry) ->
+       List.exists (fun (r : Cascade_config_loader.weighted_entry) ->
+         r.model = e.model) result) entries
+
+let%test "weighted_shuffle remainder sorted by weight desc" =
+  (* Run many times: the tail (index 1..n) should always be sorted desc *)
+  let entries : Cascade_config_loader.weighted_entry list = [
+    { model = "a"; weight = 10 };
+    { model = "b"; weight = 50 };
+    { model = "c"; weight = 30 };
+  ] in
+  let all_sorted = ref true in
+  for _ = 1 to 100 do
+    let result = weighted_shuffle entries in
+    let tail = List.tl result in
+    let rec is_sorted = function
+      | [] | [_] -> true
+      | (x : Cascade_config_loader.weighted_entry) ::
+        ((y : Cascade_config_loader.weighted_entry) :: _ as rest) ->
+        x.weight >= y.weight && is_sorted rest
+    in
+    if not (is_sorted tail) then all_sorted := false
+  done;
+  !all_sorted
+
+let%test "weighted_shuffle distribution roughly matches weights" =
+  (* Statistical: with weights 70/20/10, first position should be "a" ~70% *)
+  let entries : Cascade_config_loader.weighted_entry list = [
+    { model = "a"; weight = 70 };
+    { model = "b"; weight = 20 };
+    { model = "c"; weight = 10 };
+  ] in
+  let a_first = ref 0 in
+  let n = 1000 in
+  for _ = 1 to n do
+    let result = weighted_shuffle entries in
+    if (List.hd result).model = "a" then incr a_first
+  done;
+  (* Allow wide tolerance: 70% +/- 10% *)
+  let ratio = float_of_int !a_first /. float_of_int n in
+  ratio > 0.55 && ratio < 0.85
+
+let%test "weighted_shuffle equal weights gives uniform-ish distribution" =
+  let entries : Cascade_config_loader.weighted_entry list = [
+    { model = "a"; weight = 1 };
+    { model = "b"; weight = 1 };
+    { model = "c"; weight = 1 };
+  ] in
+  let counts = Hashtbl.create 3 in
+  let n = 900 in
+  for _ = 1 to n do
+    let result = weighted_shuffle entries in
+    let first = (List.hd result).model in
+    let prev = try Hashtbl.find counts first with Not_found -> 0 in
+    Hashtbl.replace counts first (prev + 1)
+  done;
+  (* Each should be ~33% +/- 15% *)
+  Hashtbl.fold (fun _ count ok ->
+    let ratio = float_of_int count /. float_of_int n in
+    ok && ratio > 0.18 && ratio < 0.48) counts true
+
+(* ── weighted config loading tests ──────────────────── *)
+
+let%test "resolve_model_strings weighted objects parsed" =
+  Eio_main.run (fun _env ->
+    with_temp_cascade_json
+      {|{"test_models": [
+           {"model": "glm:glm-5.1", "weight": 50},
+           {"model": "ollama:qwen", "weight": 30},
+           {"model": "claude:haiku", "weight": 20}
+         ]}|}
+      (fun tmp ->
+        let models, source = resolve_model_strings_traced ~config_path:tmp
+          ~name:"test" ~defaults:["fallback:x"] () in
+        source = Named
+        && List.length models = 3
+        && List.mem "glm:glm-5.1" models
+        && List.mem "ollama:qwen" models
+        && List.mem "claude:haiku" models))
+
+let%test "resolve_model_strings mixed strings and objects" =
+  Eio_main.run (fun _env ->
+    with_temp_cascade_json
+      {|{"test_models": [
+           "glm:glm-5.1",
+           {"model": "ollama:qwen", "weight": 30}
+         ]}|}
+      (fun tmp ->
+        let models, source = resolve_model_strings_traced ~config_path:tmp
+          ~name:"test" ~defaults:["fallback:x"] () in
+        source = Named
+        && List.length models = 2
+        && List.mem "glm:glm-5.1" models
+        && List.mem "ollama:qwen" models))
+
+let%test "resolve_model_strings plain strings keep original order" =
+  Eio_main.run (fun _env ->
+    with_temp_cascade_json
+      {|{"test_models": ["a:1", "b:2", "c:3"]}|}
+      (fun tmp ->
+        let models, _ = resolve_model_strings_traced ~config_path:tmp
+          ~name:"test" ~defaults:[] () in
+        models = ["a:1"; "b:2"; "c:3"]))

--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -321,8 +321,8 @@ type cascade_source = Named | Default_fallback | Hardcoded_defaults
 (** Weighted shuffle: pick first element by weighted random, then order
     remaining by descending weight.  This gives probabilistic distribution
     of first-attempt provider while maintaining a deterministic fallback
-    chain.  When all weights are equal, behaves like random-first + stable
-    remainder.
+    chain.  Callers preserve backward-compatible fixed ordering by
+    skipping shuffle when every weight is 1.
 
     Algorithm (LiteLLM simple-shuffle inspired):
     1. Compute cumulative weights
@@ -330,7 +330,14 @@ type cascade_source = Named | Default_fallback | Hardcoded_defaults
     3. Selected item becomes first; rest sorted by weight desc
 
     @since 0.137.0 *)
-let weighted_shuffle (entries : Cascade_config_loader.weighted_entry list)
+let weighted_shuffle_rng = lazy (Random.State.make_self_init ())
+
+let weighted_random_int bound =
+  Random.State.int (Lazy.force weighted_shuffle_rng) bound
+
+let weighted_shuffle
+    ?(rand_int = weighted_random_int)
+    (entries : Cascade_config_loader.weighted_entry list)
     : Cascade_config_loader.weighted_entry list =
   match entries with
   | [] | [_] -> entries
@@ -341,7 +348,7 @@ let weighted_shuffle (entries : Cascade_config_loader.weighted_entry list)
     in
     if total_weight <= 0 then entries
     else
-      let r = Random.int total_weight in
+      let r = rand_int total_weight in
       (* Find the selected entry via cumulative weight *)
       let rec find_selected cumulative = function
         | [] -> (* fallback: first entry *)
@@ -369,36 +376,39 @@ let weighted_shuffle (entries : Cascade_config_loader.weighted_entry list)
       in
       selected :: sorted_remaining
 
-let resolve_model_strings_traced ?config_path ~name ~defaults () =
+let order_weighted_entries
+    ?(rand_int = weighted_random_int)
+    (entries : Cascade_config_loader.weighted_entry list) =
+  let has_weights = List.exists
+      (fun (e : Cascade_config_loader.weighted_entry) -> e.weight <> 1)
+      entries
+  in
+  if not has_weights then entries
+  else
+    let health = Cascade_health_tracker.global in
+    let health_adjusted = List.map
+        (fun (e : Cascade_config_loader.weighted_entry) ->
+           let ew = Cascade_health_tracker.effective_weight health
+               ~provider_key:e.model ~config_weight:e.weight in
+           { e with weight = ew })
+        entries
+    in
+    (* Filter out zero-weight (cooled-down) providers, but keep at least one *)
+    let active = List.filter
+        (fun (e : Cascade_config_loader.weighted_entry) -> e.weight > 0)
+        health_adjusted
+    in
+    let effective = if active = [] then entries else active in
+    weighted_shuffle ~rand_int effective
+
+let resolve_model_strings_traced_with
+    ~rand_int ?config_path ~name ~defaults () =
   match config_path with
   | Some path ->
     let from_file_weighted =
       Cascade_config_loader.load_profile_weighted ~config_path:path ~name in
     if from_file_weighted <> [] then
-      let has_weights = List.exists
-          (fun (e : Cascade_config_loader.weighted_entry) -> e.weight <> 1)
-          from_file_weighted
-      in
-      (* Apply health-adjusted weights: config_weight * success_rate.
-         Providers in cooldown get weight 0 (skipped in shuffle). *)
-      let health = Cascade_health_tracker.global in
-      let health_adjusted = List.map
-          (fun (e : Cascade_config_loader.weighted_entry) ->
-             let ew = Cascade_health_tracker.effective_weight health
-                 ~provider_key:e.model ~config_weight:e.weight in
-             { e with weight = ew })
-          from_file_weighted
-      in
-      (* Filter out zero-weight (cooled-down) providers, but keep at least one *)
-      let active = List.filter
-          (fun (e : Cascade_config_loader.weighted_entry) -> e.weight > 0)
-          health_adjusted
-      in
-      let effective = if active = [] then from_file_weighted else active in
-      let ordered =
-        if has_weights then weighted_shuffle effective
-        else effective
-      in
+      let ordered = order_weighted_entries ~rand_int from_file_weighted in
       let models = List.map
           (fun (e : Cascade_config_loader.weighted_entry) -> e.model) ordered in
       (models, Named)
@@ -407,12 +417,18 @@ let resolve_model_strings_traced ?config_path ~name ~defaults () =
         Cascade_config_loader.load_profile_weighted
           ~config_path:path ~name:"default" in
       if fallback_weighted <> [] then
+        let ordered = order_weighted_entries ~rand_int fallback_weighted in
         let models = List.map
             (fun (e : Cascade_config_loader.weighted_entry) -> e.model)
-            fallback_weighted in
+            ordered in
         (models, Default_fallback)
       else (defaults, Hardcoded_defaults)
   | None -> (defaults, Hardcoded_defaults)
+
+let resolve_model_strings_traced ?config_path ~name ~defaults () =
+  resolve_model_strings_traced_with
+    ~rand_int:weighted_random_int
+    ?config_path ~name ~defaults ()
 
 let resolve_model_strings ?config_path ~name ~defaults () =
   fst (resolve_model_strings_traced ?config_path ~name ~defaults ())
@@ -1230,63 +1246,46 @@ let%test "weighted_shuffle preserves all items" =
        List.exists (fun (r : Cascade_config_loader.weighted_entry) ->
          r.model = e.model) result) entries
 
-let%test "weighted_shuffle remainder sorted by weight desc" =
-  (* Run many times: the tail (index 1..n) should always be sorted desc *)
+let%test "weighted_shuffle selects first bucket by cumulative weight" =
   let entries : Cascade_config_loader.weighted_entry list = [
-    { model = "a"; weight = 10 };
-    { model = "b"; weight = 50 };
-    { model = "c"; weight = 30 };
+    { model = "a"; weight = 50 };
+    { model = "b"; weight = 30 };
+    { model = "c"; weight = 20 };
   ] in
-  let all_sorted = ref true in
-  for _ = 1 to 100 do
-    let result = weighted_shuffle entries in
-    let tail = List.tl result in
-    let rec is_sorted = function
-      | [] | [_] -> true
-      | (x : Cascade_config_loader.weighted_entry) ::
-        ((y : Cascade_config_loader.weighted_entry) :: _ as rest) ->
-        x.weight >= y.weight && is_sorted rest
-    in
-    if not (is_sorted tail) then all_sorted := false
-  done;
-  !all_sorted
+  let result = weighted_shuffle ~rand_int:(fun _ -> 0) entries in
+  List.map (fun (e : Cascade_config_loader.weighted_entry) -> e.model) result
+  = ["a"; "b"; "c"]
 
-let%test "weighted_shuffle distribution roughly matches weights" =
-  (* Statistical: with weights 70/20/10, first position should be "a" ~70%.
-     Use 10000 trials and wide tolerance to avoid CI flakiness. *)
+let%test "weighted_shuffle selects middle bucket by cumulative weight" =
   let entries : Cascade_config_loader.weighted_entry list = [
-    { model = "a"; weight = 70 };
+    { model = "a"; weight = 50 };
+    { model = "b"; weight = 30 };
+    { model = "c"; weight = 20 };
+  ] in
+  let result = weighted_shuffle ~rand_int:(fun _ -> 50) entries in
+  List.map (fun (e : Cascade_config_loader.weighted_entry) -> e.model) result
+  = ["b"; "a"; "c"]
+
+let%test "weighted_shuffle selects last bucket by cumulative weight" =
+  let entries : Cascade_config_loader.weighted_entry list = [
+    { model = "a"; weight = 50 };
+    { model = "b"; weight = 30 };
+    { model = "c"; weight = 20 };
+  ] in
+  let result = weighted_shuffle ~rand_int:(fun _ -> 95) entries in
+  List.map (fun (e : Cascade_config_loader.weighted_entry) -> e.model) result
+  = ["c"; "a"; "b"]
+
+let%test "weighted_shuffle keeps stable order among equal-weight remainder" =
+  let entries : Cascade_config_loader.weighted_entry list = [
+    { model = "a"; weight = 20 };
     { model = "b"; weight = 20 };
-    { model = "c"; weight = 10 };
+    { model = "c"; weight = 5 };
+    { model = "d"; weight = 20 };
   ] in
-  let a_first = ref 0 in
-  let n = 10000 in
-  for _ = 1 to n do
-    let result = weighted_shuffle entries in
-    if (List.hd result).model = "a" then incr a_first
-  done;
-  (* 70% +/- 5% with 10k trials — 3-sigma bound for binomial *)
-  let ratio = float_of_int !a_first /. float_of_int n in
-  ratio > 0.55 && ratio < 0.85
-
-let%test "weighted_shuffle equal weights gives uniform-ish distribution" =
-  let entries : Cascade_config_loader.weighted_entry list = [
-    { model = "a"; weight = 1 };
-    { model = "b"; weight = 1 };
-    { model = "c"; weight = 1 };
-  ] in
-  let counts = Hashtbl.create 3 in
-  let n = 9000 in
-  for _ = 1 to n do
-    let result = weighted_shuffle entries in
-    let first = (List.hd result).model in
-    let prev = try Hashtbl.find counts first with Not_found -> 0 in
-    Hashtbl.replace counts first (prev + 1)
-  done;
-  (* Each should be ~33% +/- 10% with 9k trials *)
-  Hashtbl.fold (fun _ count ok ->
-    let ratio = float_of_int count /. float_of_int n in
-    ok && ratio > 0.20 && ratio < 0.46) counts true
+  let result = weighted_shuffle ~rand_int:(fun _ -> 40) entries in
+  List.map (fun (e : Cascade_config_loader.weighted_entry) -> e.model) result
+  = ["c"; "a"; "b"; "d"]
 
 (* ── weighted config loading tests ──────────────────── *)
 
@@ -1330,3 +1329,37 @@ let%test "resolve_model_strings plain strings keep original order" =
         let models, _ = resolve_model_strings_traced ~config_path:tmp
           ~name:"test" ~defaults:[] () in
         models = ["a:1"; "b:2"; "c:3"]))
+
+let%test "resolve_model_strings_traced weighted default fallback applies shuffle" =
+  Eio_main.run (fun _env ->
+    with_temp_cascade_json
+      {|{"default_models": [
+           {"model": "a:1", "weight": 50},
+           {"model": "b:2", "weight": 30},
+           {"model": "c:3", "weight": 20}
+         ]}|}
+      (fun tmp ->
+        let models, source = resolve_model_strings_traced_with
+            ~rand_int:(fun _ -> 95)
+            ~config_path:tmp
+            ~name:"missing"
+            ~defaults:["fallback:x"] () in
+        source = Default_fallback
+        && models = ["c:3"; "a:1"; "b:2"]))
+
+let%test "load_profile_weighted integral floats survive and fractional floats fall back to 1" =
+  Eio_main.run (fun _env ->
+    with_temp_cascade_json
+      {|{"test_models": [
+           {"model": "a:1", "weight": 50.0},
+           {"model": "b:2", "weight": 0.5},
+           "c:3"
+         ]}|}
+      (fun tmp ->
+        let entries = Cascade_config_loader.load_profile_weighted
+            ~config_path:tmp ~name:"test" in
+        entries = [
+          { model = "a:1"; weight = 50 };
+          { model = "b:2"; weight = 1 };
+          { model = "c:3"; weight = 1 };
+        ]))

--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -379,9 +379,25 @@ let resolve_model_strings_traced ?config_path ~name ~defaults () =
           (fun (e : Cascade_config_loader.weighted_entry) -> e.weight <> 1)
           from_file_weighted
       in
+      (* Apply health-adjusted weights: config_weight * success_rate.
+         Providers in cooldown get weight 0 (skipped in shuffle). *)
+      let health = Cascade_health_tracker.global in
+      let health_adjusted = List.map
+          (fun (e : Cascade_config_loader.weighted_entry) ->
+             let ew = Cascade_health_tracker.effective_weight health
+                 ~provider_key:e.model ~config_weight:e.weight in
+             { e with weight = ew })
+          from_file_weighted
+      in
+      (* Filter out zero-weight (cooled-down) providers, but keep at least one *)
+      let active = List.filter
+          (fun (e : Cascade_config_loader.weighted_entry) -> e.weight > 0)
+          health_adjusted
+      in
+      let effective = if active = [] then from_file_weighted else active in
       let ordered =
-        if has_weights then weighted_shuffle from_file_weighted
-        else from_file_weighted
+        if has_weights then weighted_shuffle effective
+        else effective
       in
       let models = List.map
           (fun (e : Cascade_config_loader.weighted_entry) -> e.model) ordered in
@@ -1236,19 +1252,20 @@ let%test "weighted_shuffle remainder sorted by weight desc" =
   !all_sorted
 
 let%test "weighted_shuffle distribution roughly matches weights" =
-  (* Statistical: with weights 70/20/10, first position should be "a" ~70% *)
+  (* Statistical: with weights 70/20/10, first position should be "a" ~70%.
+     Use 10000 trials and wide tolerance to avoid CI flakiness. *)
   let entries : Cascade_config_loader.weighted_entry list = [
     { model = "a"; weight = 70 };
     { model = "b"; weight = 20 };
     { model = "c"; weight = 10 };
   ] in
   let a_first = ref 0 in
-  let n = 1000 in
+  let n = 10000 in
   for _ = 1 to n do
     let result = weighted_shuffle entries in
     if (List.hd result).model = "a" then incr a_first
   done;
-  (* Allow wide tolerance: 70% +/- 10% *)
+  (* 70% +/- 5% with 10k trials — 3-sigma bound for binomial *)
   let ratio = float_of_int !a_first /. float_of_int n in
   ratio > 0.55 && ratio < 0.85
 
@@ -1259,17 +1276,17 @@ let%test "weighted_shuffle equal weights gives uniform-ish distribution" =
     { model = "c"; weight = 1 };
   ] in
   let counts = Hashtbl.create 3 in
-  let n = 900 in
+  let n = 9000 in
   for _ = 1 to n do
     let result = weighted_shuffle entries in
     let first = (List.hd result).model in
     let prev = try Hashtbl.find counts first with Not_found -> 0 in
     Hashtbl.replace counts first (prev + 1)
   done;
-  (* Each should be ~33% +/- 15% *)
+  (* Each should be ~33% +/- 10% with 9k trials *)
   Hashtbl.fold (fun _ count ok ->
     let ratio = float_of_int count /. float_of_int n in
-    ok && ratio > 0.18 && ratio < 0.48) counts true
+    ok && ratio > 0.20 && ratio < 0.46) counts true
 
 (* ── weighted config loading tests ──────────────────── *)
 

--- a/lib/llm_provider/cascade_config_loader.ml
+++ b/lib/llm_provider/cascade_config_loader.ml
@@ -76,20 +76,42 @@ let load_json path =
   | Yojson.Json_error msg -> Error (Printf.sprintf "JSON error: %s" msg)
   | End_of_file -> Error "unexpected end of file"
 
-let load_profile ~config_path ~name =
+(** A model entry with an optional weight for weighted cascade selection.
+    Weight defaults to 1 when not specified (backward compatible). *)
+type weighted_entry = {
+  model: string;
+  weight: int;
+}
+
+let parse_weighted_item = function
+  | `String s -> Some { model = String.trim s; weight = 1 }
+  | `Assoc fields ->
+    let open Yojson.Safe.Util in
+    let json = `Assoc fields in
+    (match json |> member "model" with
+     | `String s when String.trim s <> "" ->
+       let w = match json |> member "weight" with
+         | `Int i when i > 0 -> i
+         | `Float f when f > 0.0 -> int_of_float f
+         | _ -> 1
+       in
+       Some { model = String.trim s; weight = w }
+     | _ -> None)
+  | _ -> None
+
+let load_profile_weighted ~config_path ~name =
   let key = name ^ "_models" in
   match load_json config_path with
   | Error _ -> []
   | Ok json ->
     let open Yojson.Safe.Util in
     match json |> member key with
-    | `List items ->
-      List.filter_map
-        (function
-          | `String s -> Some (String.trim s)
-          | _ -> None)
-        items
+    | `List items -> List.filter_map parse_weighted_item items
     | _ -> []
+
+let load_profile ~config_path ~name =
+  load_profile_weighted ~config_path ~name
+  |> List.map (fun e -> e.model)
 
 (* ── Inference parameter resolution ───────────────────── *)
 

--- a/lib/llm_provider/cascade_config_loader.ml
+++ b/lib/llm_provider/cascade_config_loader.ml
@@ -83,6 +83,13 @@ type weighted_entry = {
   weight: int;
 }
 
+let parse_weight_field = function
+  | `Int i when i > 0 -> i
+  | `Float f when f > 0.0 ->
+    let i = int_of_float f in
+    if i > 0 && Float.equal f (float_of_int i) then i else 1
+  | _ -> 1
+
 let parse_weighted_item = function
   | `String s -> Some { model = String.trim s; weight = 1 }
   | `Assoc fields ->
@@ -90,11 +97,7 @@ let parse_weighted_item = function
     let json = `Assoc fields in
     (match json |> member "model" with
      | `String s when String.trim s <> "" ->
-       let w = match json |> member "weight" with
-         | `Int i when i > 0 -> i
-         | `Float f when f > 0.0 -> int_of_float f
-         | _ -> 1
-       in
+       let w = parse_weight_field (json |> member "weight") in
        Some { model = String.trim s; weight = w }
      | _ -> None)
   | _ -> None

--- a/lib/llm_provider/cascade_config_loader.mli
+++ b/lib/llm_provider/cascade_config_loader.mli
@@ -10,6 +10,14 @@
     Cached with mtime-based hot-reload. *)
 val load_json : string -> (Yojson.Safe.t, string) result
 
+(** A model entry with an optional weight for weighted cascade selection.
+    Weight defaults to 1 when not specified.
+    @since 0.137.0 *)
+type weighted_entry = {
+  model: string;
+  weight: int;
+}
+
 (** Load a named model list from a JSON config file.
 
     The JSON file maps ["{name}_models"] keys to string arrays.
@@ -19,6 +27,21 @@ val load_profile :
   config_path:string ->
   name:string ->
   string list
+
+(** Like {!load_profile} but preserves weight information.
+
+    Supports two JSON formats in the model array:
+    - Plain strings: [{"model": s, "weight": 1}]
+    - Objects: [{"model": "provider:id", "weight": 50}]
+
+    When all weights are 1, the caller should treat the list as unweighted
+    (preserving backward-compatible fixed ordering).
+
+    @since 0.137.0 *)
+val load_profile_weighted :
+  config_path:string ->
+  name:string ->
+  weighted_entry list
 
 (** Per-cascade inference parameter overrides. *)
 type inference_params = {

--- a/lib/llm_provider/cascade_executor.ml
+++ b/lib/llm_provider/cascade_executor.ml
@@ -485,12 +485,16 @@ let complete_cascade_with_accept ~sw ~net ?clock ?cache ?metrics
            | Error reason -> Cascade_fsm.Accept_rejected { response = resp; reason })
         | Error err -> Cascade_fsm.Call_err err
       in
+      let health = Cascade_health_tracker.global in
+      let provider_key = cfg.model_id in
       (* Pure decision: delegate to FSM *)
       match Cascade_fsm.decide ~accept_on_exhaustion ~is_last outcome with
       | Cascade_fsm.Accept resp ->
+        Cascade_health_tracker.record_success health ~provider_key;
         Diag.debug "cascade_executor" "cascade_accept_passed model_id=%s" cfg.model_id;
         Ok resp
       | Cascade_fsm.Accept_on_exhaustion { response; reason } ->
+        Cascade_health_tracker.record_success health ~provider_key;
         Diag.info "cascade_executor" "cascade_accept_on_exhaustion model_id=%s is_last=%b reason=%s"
           cfg.model_id is_last reason;
         m.on_cascade_fallback
@@ -498,6 +502,7 @@ let complete_cascade_with_accept ~sw ~net ?clock ?cache ?metrics
           ~reason:"accept relaxed: all models rejected";
         Ok response
       | Cascade_fsm.Try_next { last_err = new_err } ->
+        Cascade_health_tracker.record_failure health ~provider_key;
         let reason_str = match new_err with
           | Some (Http_client.HttpError { code; _ }) -> Printf.sprintf "HTTP %d" code
           | Some (Http_client.AcceptRejected { reason }) -> reason
@@ -514,6 +519,7 @@ let complete_cascade_with_accept ~sw ~net ?clock ?cache ?metrics
          | [] -> ());
         try_next new_err rest
       | Cascade_fsm.Exhausted { last_err = final_err } ->
+        Cascade_health_tracker.record_failure health ~provider_key;
         let reason_str = match final_err with
           | Some (Http_client.HttpError { code; _ }) -> Printf.sprintf "HTTP %d" code
           | Some (Http_client.AcceptRejected { reason }) -> reason

--- a/lib/llm_provider/cascade_health_tracker.ml
+++ b/lib/llm_provider/cascade_health_tracker.ml
@@ -1,0 +1,251 @@
+(** Reactive health tracking for cascade providers.
+
+    Tracks per-provider success/failure rates using a rolling time window.
+    Providers in cooldown (consecutive failures exceed threshold) are
+    temporarily skipped.  Health data feeds into weighted cascade selection
+    via {!effective_weight}.
+
+    Design: LiteLLM cooldown + OpenRouter rolling-window hybrid.
+    See RFC-OAS-006 Phase 2.
+
+    Thread safety: uses [Stdlib.Mutex] (not Eio.Mutex) for cross-fiber
+    safety without Eio dependency in the hot path.  Critical sections are
+    small (record append + list scan).
+
+    @since 0.137.0 *)
+
+(* ── Configuration ────────────────────────────── *)
+
+(** Rolling window duration in seconds.  Events older than this are
+    discarded on read.  Default: 300s (5 minutes), matching OpenRouter. *)
+let window_sec =
+  match Sys.getenv_opt "OAS_CASCADE_HEALTH_WINDOW_SEC" with
+  | Some s -> (try Float.of_string s with _ -> 300.0)
+  | None -> 300.0
+
+(** Number of consecutive failures before cooldown activates.
+    Default: 3, matching LiteLLM's [allowed_fails] concept. *)
+let cooldown_threshold =
+  match Sys.getenv_opt "OAS_CASCADE_COOLDOWN_THRESHOLD" with
+  | Some s -> (try int_of_string s with _ -> 3)
+  | None -> 3
+
+(** Cooldown duration in seconds.  During cooldown, the provider is
+    skipped (not attempted).  Default: 60s. *)
+let cooldown_sec =
+  match Sys.getenv_opt "OAS_CASCADE_COOLDOWN_SEC" with
+  | Some s -> (try Float.of_string s with _ -> 60.0)
+  | None -> 60.0
+
+(* ── Types ────────────────────────────────────── *)
+
+type outcome = Success | Failure
+
+type event = {
+  time: float;  (* Unix timestamp *)
+  outcome: outcome;
+}
+
+type provider_state = {
+  mutable events: event list;  (* newest first *)
+  mutable consecutive_failures: int;
+  mutable cooldown_until: float;  (* 0.0 = not in cooldown *)
+}
+
+type t = {
+  providers: (string, provider_state) Hashtbl.t;
+  mu: Mutex.t;
+}
+
+(* ── Constructor ──────────────────────────────── *)
+
+let create () : t = {
+  providers = Hashtbl.create 8;
+  mu = Mutex.create ();
+}
+
+let with_lock t f =
+  Mutex.lock t.mu;
+  Fun.protect ~finally:(fun () -> Mutex.unlock t.mu) f
+
+let get_or_create_state t key =
+  match Hashtbl.find_opt t.providers key with
+  | Some s -> s
+  | None ->
+    let s = {
+      events = [];
+      consecutive_failures = 0;
+      cooldown_until = 0.0;
+    } in
+    Hashtbl.replace t.providers key s;
+    s
+
+(* ── Recording ────────────────────────────────── *)
+
+let prune_old_events now events =
+  let cutoff = now -. window_sec in
+  List.filter (fun e -> e.time >= cutoff) events
+
+let record t ~provider_key ~outcome ~now =
+  with_lock t (fun () ->
+    let state = get_or_create_state t provider_key in
+    let event = { time = now; outcome } in
+    state.events <- event :: prune_old_events now state.events;
+    match outcome with
+    | Success ->
+      state.consecutive_failures <- 0;
+      (* Clear cooldown on success — provider recovered *)
+      state.cooldown_until <- 0.0
+    | Failure ->
+      state.consecutive_failures <- state.consecutive_failures + 1;
+      if state.consecutive_failures >= cooldown_threshold then
+        state.cooldown_until <- now +. cooldown_sec)
+
+let record_success t ~provider_key =
+  record t ~provider_key ~outcome:Success ~now:(Unix.gettimeofday ())
+
+let record_failure t ~provider_key =
+  record t ~provider_key ~outcome:Failure ~now:(Unix.gettimeofday ())
+
+(* ── Queries ──────────────────────────────────── *)
+
+(** Success rate in the rolling window.  Returns 1.0 for unknown
+    providers (optimistic default — no data means no reason to penalize). *)
+let success_rate t ~provider_key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.providers provider_key with
+    | None -> 1.0
+    | Some state ->
+      let now = Unix.gettimeofday () in
+      let recent = prune_old_events now state.events in
+      match recent with
+      | [] -> 1.0
+      | _ ->
+        let successes = List.length
+            (List.filter (fun e -> e.outcome = Success) recent) in
+        float_of_int successes /. float_of_int (List.length recent))
+
+(** Whether the provider is currently in cooldown.  A cooled-down provider
+    should be skipped in cascade selection.
+
+    @return [true] if in cooldown AND cooldown has not expired *)
+let is_in_cooldown t ~provider_key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.providers provider_key with
+    | None -> false
+    | Some state ->
+      let now = Unix.gettimeofday () in
+      if state.cooldown_until > now then true
+      else begin
+        (* Expired cooldown — clear it *)
+        if state.cooldown_until > 0.0 then
+          state.cooldown_until <- 0.0;
+        false
+      end)
+
+(** Compute effective weight for a provider.
+
+    [effective_weight = config_weight * success_rate]
+
+    Providers in cooldown get weight 0 (skipped).  Unknown providers
+    get their full config weight (optimistic). *)
+let effective_weight t ~provider_key ~config_weight =
+  if is_in_cooldown t ~provider_key then 0
+  else
+    let rate = success_rate t ~provider_key in
+    max 1 (int_of_float (float_of_int config_weight *. rate))
+
+(** Summary for debugging/telemetry. *)
+let provider_summary t ~provider_key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.providers provider_key with
+    | None -> Printf.sprintf "%s: no data" provider_key
+    | Some state ->
+      let now = Unix.gettimeofday () in
+      let recent = prune_old_events now state.events in
+      let total = List.length recent in
+      let successes = List.length
+          (List.filter (fun e -> e.outcome = Success) recent) in
+      let in_cd = state.cooldown_until > now in
+      Printf.sprintf "%s: %d/%d ok (%.0f%%) consec_fail=%d cooldown=%b"
+        provider_key successes total
+        (if total > 0 then 100.0 *. float_of_int successes /. float_of_int total else 100.0)
+        state.consecutive_failures in_cd)
+
+(* ── Global singleton ─────────────────────────── *)
+
+(** Global health tracker shared across all cascade calls in this process.
+    Thread-safe via internal Mutex. *)
+let global : t = create ()
+
+(* ── Inline tests ─────────────────────────────── *)
+
+let%test "record success clears consecutive failures" =
+  let t = create () in
+  let now = 1000.0 in
+  record t ~provider_key:"a" ~outcome:Failure ~now;
+  record t ~provider_key:"a" ~outcome:Failure ~now;
+  record t ~provider_key:"a" ~outcome:Success ~now;
+  let state = Hashtbl.find t.providers "a" in
+  state.consecutive_failures = 0
+
+let%test "cooldown activates after threshold failures" =
+  let t = create () in
+  let now = 1000.0 in
+  for _ = 1 to cooldown_threshold do
+    record t ~provider_key:"a" ~outcome:Failure ~now
+  done;
+  let state = Hashtbl.find t.providers "a" in
+  state.cooldown_until > now
+
+let%test "cooldown expires" =
+  let t = create () in
+  let now = 1000.0 in
+  for _ = 1 to cooldown_threshold do
+    record t ~provider_key:"a" ~outcome:Failure ~now
+  done;
+  let state = Hashtbl.find t.providers "a" in
+  (* Manually expire *)
+  state.cooldown_until <- now -. 1.0;
+  not (is_in_cooldown t ~provider_key:"a")
+
+let%test "success_rate with no data returns 1.0" =
+  let t = create () in
+  Float.equal (success_rate t ~provider_key:"unknown") 1.0
+
+let%test "success_rate computed correctly" =
+  let t = create () in
+  let now = 1000.0 in
+  record t ~provider_key:"a" ~outcome:Success ~now;
+  record t ~provider_key:"a" ~outcome:Success ~now;
+  record t ~provider_key:"a" ~outcome:Failure ~now;
+  (* 2/3 ~= 0.667 *)
+  let rate = success_rate t ~provider_key:"a" in
+  rate > 0.6 && rate < 0.7
+
+let%test "effective_weight zero during cooldown" =
+  let t = create () in
+  let now = 1000.0 in
+  for _ = 1 to cooldown_threshold do
+    record t ~provider_key:"a" ~outcome:Failure ~now
+  done;
+  effective_weight t ~provider_key:"a" ~config_weight:50 = 0
+
+let%test "effective_weight scales with success rate" =
+  let t = create () in
+  let now = 1000.0 in
+  record t ~provider_key:"a" ~outcome:Success ~now;
+  record t ~provider_key:"a" ~outcome:Failure ~now;
+  (* 50% success rate → weight 50 * 0.5 = 25 *)
+  let w = effective_weight t ~provider_key:"a" ~config_weight:50 in
+  w >= 24 && w <= 26
+
+let%test "old events pruned from window" =
+  let t = create () in
+  let old_time = 1000.0 -. window_sec -. 10.0 in
+  let recent_time = 1000.0 in
+  record t ~provider_key:"a" ~outcome:Failure ~now:old_time;
+  record t ~provider_key:"a" ~outcome:Success ~now:recent_time;
+  (* Old failure should be pruned; only recent success counts *)
+  let rate = success_rate t ~provider_key:"a" in
+  Float.equal rate 1.0

--- a/lib/llm_provider/cascade_health_tracker.ml
+++ b/lib/llm_provider/cascade_health_tracker.ml
@@ -180,9 +180,13 @@ let global : t = create ()
 
 (* ── Inline tests ─────────────────────────────── *)
 
+(* Tests use real timestamps so that success_rate / is_in_cooldown
+   (which call Unix.gettimeofday internally) see events within the
+   rolling window. *)
+
 let%test "record success clears consecutive failures" =
   let t = create () in
-  let now = 1000.0 in
+  let now = Unix.gettimeofday () in
   record t ~provider_key:"a" ~outcome:Failure ~now;
   record t ~provider_key:"a" ~outcome:Failure ~now;
   record t ~provider_key:"a" ~outcome:Success ~now;
@@ -191,7 +195,7 @@ let%test "record success clears consecutive failures" =
 
 let%test "cooldown activates after threshold failures" =
   let t = create () in
-  let now = 1000.0 in
+  let now = Unix.gettimeofday () in
   for _ = 1 to cooldown_threshold do
     record t ~provider_key:"a" ~outcome:Failure ~now
   done;
@@ -200,12 +204,12 @@ let%test "cooldown activates after threshold failures" =
 
 let%test "cooldown expires" =
   let t = create () in
-  let now = 1000.0 in
+  let now = Unix.gettimeofday () in
   for _ = 1 to cooldown_threshold do
     record t ~provider_key:"a" ~outcome:Failure ~now
   done;
   let state = Hashtbl.find t.providers "a" in
-  (* Manually expire *)
+  (* Manually expire by setting cooldown_until to the past *)
   state.cooldown_until <- now -. 1.0;
   not (is_in_cooldown t ~provider_key:"a")
 
@@ -215,7 +219,7 @@ let%test "success_rate with no data returns 1.0" =
 
 let%test "success_rate computed correctly" =
   let t = create () in
-  let now = 1000.0 in
+  let now = Unix.gettimeofday () in
   record t ~provider_key:"a" ~outcome:Success ~now;
   record t ~provider_key:"a" ~outcome:Success ~now;
   record t ~provider_key:"a" ~outcome:Failure ~now;
@@ -225,7 +229,7 @@ let%test "success_rate computed correctly" =
 
 let%test "effective_weight zero during cooldown" =
   let t = create () in
-  let now = 1000.0 in
+  let now = Unix.gettimeofday () in
   for _ = 1 to cooldown_threshold do
     record t ~provider_key:"a" ~outcome:Failure ~now
   done;
@@ -233,19 +237,19 @@ let%test "effective_weight zero during cooldown" =
 
 let%test "effective_weight scales with success rate" =
   let t = create () in
-  let now = 1000.0 in
+  let now = Unix.gettimeofday () in
   record t ~provider_key:"a" ~outcome:Success ~now;
   record t ~provider_key:"a" ~outcome:Failure ~now;
-  (* 50% success rate → weight 50 * 0.5 = 25 *)
+  (* 50% success rate -> weight 50 * 0.5 = 25 *)
   let w = effective_weight t ~provider_key:"a" ~config_weight:50 in
   w >= 24 && w <= 26
 
 let%test "old events pruned from window" =
   let t = create () in
-  let old_time = 1000.0 -. window_sec -. 10.0 in
-  let recent_time = 1000.0 in
+  let now = Unix.gettimeofday () in
+  let old_time = now -. window_sec -. 10.0 in
   record t ~provider_key:"a" ~outcome:Failure ~now:old_time;
-  record t ~provider_key:"a" ~outcome:Success ~now:recent_time;
+  record t ~provider_key:"a" ~outcome:Success ~now;
   (* Old failure should be pruned; only recent success counts *)
   let rate = success_rate t ~provider_key:"a" in
   Float.equal rate 1.0

--- a/lib/llm_provider/cascade_health_tracker.mli
+++ b/lib/llm_provider/cascade_health_tracker.mli
@@ -1,0 +1,45 @@
+(** Reactive health tracking for cascade providers.
+
+    Tracks per-provider success/failure rates using a rolling time window.
+    Providers in cooldown (consecutive failures exceed threshold) are
+    temporarily skipped.
+
+    Thread-safe via internal [Stdlib.Mutex].
+
+    @since 0.137.0 *)
+
+(** Opaque health tracker state. *)
+type t
+
+(** Create a new empty tracker. *)
+val create : unit -> t
+
+(** Record a successful provider call. Clears cooldown and resets
+    consecutive failure counter. *)
+val record_success : t -> provider_key:string -> unit
+
+(** Record a failed provider call. Increments consecutive failure
+    counter; triggers cooldown when threshold is reached. *)
+val record_failure : t -> provider_key:string -> unit
+
+(** Success rate in the rolling window (0.0 to 1.0).
+    Returns 1.0 for unknown providers (optimistic default). *)
+val success_rate : t -> provider_key:string -> float
+
+(** Whether the provider is currently in cooldown (should be skipped). *)
+val is_in_cooldown : t -> provider_key:string -> bool
+
+(** Compute effective weight for weighted cascade selection.
+
+    [effective_weight = config_weight * success_rate]
+
+    Returns 0 for providers in cooldown.
+    Returns full [config_weight] for unknown providers. *)
+val effective_weight : t -> provider_key:string -> config_weight:int -> int
+
+(** Human-readable summary for debugging/telemetry. *)
+val provider_summary : t -> provider_key:string -> string
+
+(** Global singleton tracker shared across all cascade calls.
+    Use this for production; use {!create} for isolated tests. *)
+val global : t


### PR DESCRIPTION
## Summary

Extend OAS cascade with weighted model selection and reactive health tracking.
Industry-informed design (LiteLLM, OpenRouter, Portkey patterns).

### Phase 1: Weighted Selection
- Cascade config JSON supports weighted model entries: `{"model": "glm:glm-5.1", "weight": 50}`
- Weighted random selection for first-attempt provider
- Remaining providers sorted by descending weight as fallback chain
- Plain string arrays preserve existing fixed-order behavior (backward compatible)

### Phase 2: Reactive Health Tracking
- Per-provider success/failure tracking with rolling 5-minute window
- Automatic cooldown after 3 consecutive failures (60s, configurable)
- Health-adjusted weights: `effective_weight = config_weight * success_rate`
- Providers in cooldown get weight 0 (skipped unless all are down)
- Global singleton tracker, thread-safe via Stdlib.Mutex

## Config Example

```json
{
  "keeper_unified_models": [
    { "model": "glm-coding:glm-5.1", "weight": 50 },
    { "model": "claude:claude-haiku-4-5-20251001", "weight": 30 },
    { "model": "ollama:qwen3.5:35b-a3b-nvfp4", "weight": 20 }
  ]
}
```

With these weights: 50% of initial requests go to GLM, 30% to Haiku, 20% to Ollama.
On failure, remaining providers tried in weight-descending order.
After 3 consecutive GLM failures, GLM enters 60s cooldown -- traffic shifts to Haiku/Ollama.

## Files Changed

| File | Change |
|------|--------|
| `cascade_config_loader.ml` + `.mli` | Parse `{model, weight}` JSON objects |
| `cascade_config.ml` | `weighted_shuffle` with injectable RNG + `order_weighted_entries` |
| `cascade_executor.ml` | Record success/failure to health tracker after FSM decision |
| `cascade_health_tracker.ml` + `.mli` | NEW: rolling window health + cooldown |
| `docs/rfc/RFC-OAS-006-weighted-cascade-routing.md` | Design document |

## Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `OAS_CASCADE_HEALTH_WINDOW_SEC` | 300 | Rolling window duration |
| `OAS_CASCADE_COOLDOWN_THRESHOLD` | 3 | Consecutive failures before cooldown |
| `OAS_CASCADE_COOLDOWN_SEC` | 60 | Cooldown duration |

## Test Plan

- [x] Deterministic bucket selection tests (rand_int injection)
- [x] Stable sort for equal-weight remainder
- [x] Health tracker: cooldown lifecycle, success rate, effective weight, event pruning
- [x] Backward compat: plain strings keep original order
- [x] Mixed formats: strings + weighted objects
- [x] `dune build` + `dune runtest` all pass locally
- [ ] CI green (main was red from #910, now fixed by #909)
- [ ] Integration: update masc-mcp cascade.json with weights
