### PR TITLE
fix(anthropic): return Some telemetry for provider consistency

### DIFF
--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -29,7 +29,11 @@ let parse_response json =
              cost_usd = None }
   in
   let stop_reason = stop_reason_of_string stop_reason_str in
-  { id; model; stop_reason; content; usage; telemetry = None }
+  { id; model; stop_reason; content; usage;
+    telemetry = Some { Types.system_fingerprint = None; timings = None;
+      reasoning_tokens = None; request_latency_ms = 0;
+      provider_kind = None; reasoning_effort = None;
+      canonical_model_id = None; effective_context_window = None } }
 
 (** Build Anthropic Messages API request body from {!Provider_config.t}.
     Returns a JSON string ready for HTTP POST. *)

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -54,6 +54,25 @@ let test_anthropic_stream_flag () =
   Alcotest.(check bool) "stream" true
     (json |> member "stream" |> to_bool)
 
+let test_anthropic_parse_response_initializes_telemetry () =
+  let json = Yojson.Safe.from_string {|{
+    "id": "msg_test",
+    "model": "claude-sonnet-4-6-20250514",
+    "stop_reason": "end_turn",
+    "content": [
+      {"type": "text", "text": "Hello there."}
+    ],
+    "usage": {"input_tokens": 100, "output_tokens": 50}
+  }|} in
+  let resp = BA.parse_response json in
+  match resp.telemetry with
+  | Some t ->
+      Alcotest.(check int) "request_latency_ms defaults to zero" 0 t.request_latency_ms;
+      Alcotest.(check (option string)) "provider_kind placeholder" None t.provider_kind;
+      Alcotest.(check (option string)) "canonical model placeholder" None t.canonical_model_id
+  | None ->
+      Alcotest.fail "expected telemetry placeholder"
+
 (* ── OpenAI build_request ────────────────────────────── *)
 
 let test_openai_basic_body () =
@@ -306,6 +325,8 @@ let () =
       test_case "with system" `Quick test_anthropic_with_system;
       test_case "with thinking" `Quick test_anthropic_with_thinking;
       test_case "stream flag" `Quick test_anthropic_stream_flag;
+      test_case "parse response initializes telemetry" `Quick
+        test_anthropic_parse_response_initializes_telemetry;
     ];
     "openai_build_request", [
       test_case "basic body" `Quick test_openai_basic_body;


### PR DESCRIPTION
## Summary
- Anthropic backend만 telemetry = None 반환하던 비일관성 수정
- Ollama/OpenAI-compat 패턴과 동일하게 Some { all None fields } 반환
- patch_telemetry가 None -> Some 보정하므로 데이터 손실은 없었음 (cosmetic fix)

## Changes
- `lib/llm_provider/backend_anthropic.ml`: telemetry = None → Some { ... }

## Test plan
- [ ] `dune build` 통과
- [ ] `dune runtest` 기존 테스트 통과
- [ ] patch_telemetry 기존 테스트 "creates telemetry when None" 동작 영향 없음 확인