### PR TITLE
fix: strip orphaned ToolResult for OpenAI-compat APIs (#913)

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -66,9 +66,10 @@ let should_include_tools ?provider_config (config : agent_state) =
 let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
   let model_str = model_to_string config.config.model in
   let capabilities = capabilities_for_request ?provider_config config in
+  let sanitized_messages = strip_orphaned_tool_results messages in
   let provider_messages =
     system_message_json config
-    @ List.concat_map openai_messages_of_message messages
+    @ List.concat_map openai_messages_of_message sanitized_messages
   in
   let body_assoc =
     [

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -16,6 +16,7 @@ let openai_content_parts_of_blocks = Backend_openai_serialize.openai_content_par
 let openai_messages_of_message = Backend_openai_serialize.openai_messages_of_message
 let tool_choice_to_openai_json = Backend_openai_serialize.tool_choice_to_openai_json
 let build_openai_tool_json = Backend_openai_serialize.build_openai_tool_json
+let strip_orphaned_tool_results = Backend_openai_serialize.strip_orphaned_tool_results
 
 (* ── Re-exports from parsing ──────────────────────────── *)
 

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -66,12 +66,13 @@ let effective_tools (config : Provider_config.t) tools =
 let build_request ?(stream=false) ~(config : Provider_config.t)
     ~(messages : message list) ?(tools : Yojson.Safe.t list = []) () =
   let tools = effective_tools config tools in
+  let sanitized_messages = strip_orphaned_tool_results messages in
   let provider_messages =
     (match config.system_prompt with
      | Some s when not (Api_common.string_is_blank s) ->
          [`Assoc [("role", `String "system"); ("content", `String (Utf8_sanitize.sanitize s))]]
      | _ -> [])
-    @ List.concat_map openai_messages_of_message messages
+    @ List.concat_map openai_messages_of_message sanitized_messages
   in
   (* Look up per-model capabilities once — drives:
      (1) the [max_tokens] clamp below (avoid server 400 on over-cap),
@@ -461,6 +462,28 @@ let%test "openai_messages_of_message user with tool_result" =
   ]; name = None; tool_call_id = None } in
   let result = openai_messages_of_message msg in
   List.length result = 2
+
+let%test "build_request strips orphaned tool results from wire messages" =
+  let cfg = Provider_config.make
+    ~kind:Provider_config.Glm ~model_id:"glm-5.1"
+    ~base_url:Zai_catalog.general_base_url () in
+  let messages = [
+    { role = Assistant; content = [Text "hello"]; name = None; tool_call_id = None };
+    { role = User; content = [
+        Text "follow up";
+        ToolResult { tool_use_id = "orphan-id"; content = "stale"; is_error = false; json = None };
+      ]; name = None; tool_call_id = None };
+  ] in
+  let body =
+    build_request ~config:cfg ~messages ()
+    |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  let roles =
+    body |> member "messages" |> to_list
+    |> List.map (fun json -> json |> member "role" |> to_string)
+  in
+  roles = ["assistant"; "user"]
 
 let%test "openai_messages_of_message assistant with tool_calls" =
   let msg = { role = Assistant; content = [

--- a/lib/llm_provider/backend_openai.mli
+++ b/lib/llm_provider/backend_openai.mli
@@ -11,6 +11,7 @@ val openai_messages_of_message : Types.message -> Yojson.Safe.t list
 val strip_json_markdown_fences : string -> string
 val tool_choice_to_openai_json : Types.tool_choice -> Yojson.Safe.t
 val build_openai_tool_json : Yojson.Safe.t -> Yojson.Safe.t
+val strip_orphaned_tool_results : Types.message list -> Types.message list
 
 (** Parse an OpenAI-compatible JSON response.
     Returns [Ok api_response] on success, [Error msg] on API error. *)

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -151,6 +151,38 @@ let openai_messages_of_message msg =
 let ollama_messages_of_message msg =
   messages_of_message_with ~tool_calls_fn:tool_calls_to_ollama_json msg
 
+(** Strip ToolResult blocks whose tool_use_id has no matching ToolUse
+    in any Assistant message. Occurs after context compaction drops a
+    ToolUse while the corresponding ToolResult survives.
+
+    OpenAI-compatible APIs reject orphaned tool_call_ids; the Anthropic
+    API has its own dangling-tool-call repair, so this is OpenAI-path only.
+
+    Pure function — no I/O, no mutation. *)
+let strip_orphaned_tool_results (messages : message list) : message list =
+  let tool_use_ids =
+    let tbl = Hashtbl.create 16 in
+    List.iter (fun (msg : message) ->
+      if msg.role = Assistant then
+        List.iter (function
+          | ToolUse { id; _ } -> Hashtbl.replace tbl id ()
+          | _ -> ()) msg.content
+    ) messages;
+    tbl
+  in
+  List.map (fun (msg : message) ->
+    match msg.role with
+    | User | Tool ->
+      let filtered = List.filter (function
+        | ToolResult { tool_use_id; _ } ->
+          Hashtbl.mem tool_use_ids tool_use_id
+        | _ -> true) msg.content
+      in
+      if List.length filtered = List.length msg.content then msg
+      else { msg with content = filtered }
+    | _ -> msg
+  ) messages
+
 let tool_choice_to_openai_json = function
   | Auto -> `String "auto"
   | Any -> `String "required"

--- a/lib/llm_provider/backend_openai_serialize.mli
+++ b/lib/llm_provider/backend_openai_serialize.mli
@@ -11,3 +11,9 @@ val openai_messages_of_message : Types.message -> Yojson.Safe.t list
 val ollama_messages_of_message : Types.message -> Yojson.Safe.t list
 val tool_choice_to_openai_json : Types.tool_choice -> Yojson.Safe.t
 val build_openai_tool_json : Yojson.Safe.t -> Yojson.Safe.t
+
+val strip_orphaned_tool_results : Types.message list -> Types.message list
+(** Remove ToolResult blocks whose tool_use_id has no matching ToolUse
+    in any Assistant message. Call before serializing messages for
+    OpenAI-compatible APIs to prevent orphaned tool_call_id errors
+    after context compaction.  @since 0.103.0 *)

--- a/test/test_tool_middleware.ml
+++ b/test/test_tool_middleware.ml
@@ -244,6 +244,58 @@ let test_heal_max_retries_zero () =
     Alcotest.(check int) "attempts" 1 attempts
   | _ -> Alcotest.fail "max_retries=0 should exhaust immediately"
 
+(* ── strip_orphaned_tool_results ──────────────────────────── *)
+
+module Serialize = Llm_provider.Backend_openai_serialize
+
+let mk_msg role content : Types.message =
+  { role; content; name = None; tool_call_id = None }
+
+let test_strip_no_orphans () =
+  let msgs = [
+    mk_msg Assistant [ToolUse { id = "t1"; name = "f"; input = `Null }];
+    mk_msg User [ToolResult { tool_use_id = "t1"; content = "ok"; is_error = false; json = None }];
+  ] in
+  let result = Serialize.strip_orphaned_tool_results msgs in
+  Alcotest.(check int) "same length" 2 (List.length result);
+  let user_msg = List.nth result 1 in
+  Alcotest.(check int) "user blocks preserved" 1 (List.length user_msg.content)
+
+let test_strip_removes_orphan () =
+  let msgs = [
+    mk_msg Assistant [Text "hello"];
+    mk_msg User [
+      Text "input";
+      ToolResult { tool_use_id = "orphan-id"; content = "stale"; is_error = false; json = None };
+    ];
+  ] in
+  let result = Serialize.strip_orphaned_tool_results msgs in
+  let user_msg = List.nth result 1 in
+  Alcotest.(check int) "orphan removed" 1 (List.length user_msg.content);
+  (match List.hd user_msg.content with
+   | Text _ -> ()
+   | _ -> Alcotest.fail "expected Text to survive")
+
+let test_strip_preserves_matched () =
+  let msgs = [
+    mk_msg Assistant [
+      ToolUse { id = "t1"; name = "f"; input = `Null };
+      ToolUse { id = "t2"; name = "g"; input = `Null };
+    ];
+    mk_msg User [
+      ToolResult { tool_use_id = "t1"; content = "ok"; is_error = false; json = None };
+      ToolResult { tool_use_id = "orphan"; content = "bad"; is_error = true; json = None };
+      ToolResult { tool_use_id = "t2"; content = "ok2"; is_error = false; json = None };
+    ];
+  ] in
+  let result = Serialize.strip_orphaned_tool_results msgs in
+  let user_msg = List.nth result 1 in
+  Alcotest.(check int) "orphan stripped, 2 kept" 2 (List.length user_msg.content)
+
+let test_strip_empty () =
+  let result = Serialize.strip_orphaned_tool_results [] in
+  Alcotest.(check int) "empty" 0 (List.length result)
+
 (* ── Runner ──────────────────────────────────────────────── *)
 
 let () =
@@ -275,5 +327,11 @@ let () =
       Alcotest.test_case "LLM error" `Quick test_heal_llm_error;
       Alcotest.test_case "on_retry callback" `Quick test_heal_on_retry_called;
       Alcotest.test_case "max_retries=0" `Quick test_heal_max_retries_zero;
+    ]);
+    ("strip_orphaned_tool_results", [
+      Alcotest.test_case "no orphans" `Quick test_strip_no_orphans;
+      Alcotest.test_case "removes orphaned result" `Quick test_strip_removes_orphan;
+      Alcotest.test_case "preserves matched result" `Quick test_strip_preserves_matched;
+      Alcotest.test_case "empty messages" `Quick test_strip_empty;
     ]);
   ]


### PR DESCRIPTION
## Summary
- context compaction이 Assistant의 ToolUse를 제거하면 User의 ToolResult가 orphaned
- OpenAI-compatible API(GLM, Groq, DeepSeek)는 orphaned `tool_call_id`를 reject
- `strip_orphaned_tool_results`: ToolUse ID 집합 수집 → 매칭 안 되는 ToolResult 제거
- `api_openai.build_openai_body`에서 직렬화 전 자동 적용

## Impact
- GLM cascade 사용 시 context compaction 후 crash 방지
- Anthropic API 경로는 영향 없음 (자체 dangling repair 있음)

## Test plan
- [x] 4 new tests: no orphans, removes orphan, preserves matched, empty
- [x] 24 tool_middleware tests pass
- [x] Full `dune runtest` pass
- [ ] CI green

Closes #913