### PR TITLE
fix(context_reducer): remove orphaned ToolResult blocks before API call

### DIFF
--- a/lib/context_reducer.ml
+++ b/lib/context_reducer.ml
@@ -19,6 +19,7 @@ type strategy =
   | Prune_tool_outputs of { max_output_len: int }
   | Prune_tool_args of { max_arg_len: int; keep_recent: int }
   | Repair_dangling_tool_calls
+  | Repair_orphaned_tool_results
   | Merge_contiguous
   | Drop_thinking
   | Keep_first_and_last of { first_n: int; last_n: int }
@@ -244,6 +245,31 @@ let apply_repair_dangling_tool_calls messages =
         aux (List.rev_append repairs (msg :: acc)) rest
   in
   aux [] messages
+
+(** Repair orphaned tool results: remove ToolResult blocks whose
+    tool_use_id has no matching ToolUse in the message list.
+    OpenAI-compatible APIs (GLM, Groq, etc.) return 400 on orphan
+    ToolResult, so this prevents errors. Complement of
+    [apply_repair_dangling_tool_calls]. *)
+let apply_repair_orphaned_tool_results messages =
+  let use_ids =
+    List.fold_left (fun acc (msg : message) ->
+      List.fold_left (fun acc block ->
+        match block with
+        | ToolUse { id; _ } -> id :: acc
+        | _ -> acc
+      ) acc msg.content
+    ) [] messages
+  in
+  List.filter_map (fun (msg : message) ->
+    let content = List.filter (fun block ->
+      match block with
+      | ToolResult { tool_use_id; _ } -> List.mem tool_use_id use_ids
+      | _ -> true
+    ) msg.content in
+    if content = [] then None
+    else Some { msg with content }
+  ) messages
 
 (** Merge contiguous messages with the same role.
     Concatenates content blocks. Respects ToolUse/ToolResult pairing
@@ -533,6 +559,7 @@ and apply_strategy strategy messages =
   | Prune_tool_outputs { max_output_len } -> apply_prune_tool_outputs ~max_output_len messages
   | Prune_tool_args { max_arg_len; keep_recent } -> apply_prune_tool_args ~max_arg_len ~keep_recent messages
   | Repair_dangling_tool_calls -> apply_repair_dangling_tool_calls messages
+  | Repair_orphaned_tool_results -> apply_repair_orphaned_tool_results messages
   | Merge_contiguous -> apply_merge_contiguous messages
   | Drop_thinking -> apply_drop_thinking messages
   | Keep_first_and_last { first_n; last_n } ->
@@ -564,6 +591,7 @@ let prune_tool_outputs ~max_output_len = { strategy = Prune_tool_outputs { max_o
 let prune_tool_args ~max_arg_len ?(keep_recent=20) () =
   { strategy = Prune_tool_args { max_arg_len; keep_recent } }
 let repair_dangling_tool_calls = { strategy = Repair_dangling_tool_calls }
+let repair_orphaned_tool_results = { strategy = Repair_orphaned_tool_results }
 let merge_contiguous = { strategy = Merge_contiguous }
 let drop_thinking = { strategy = Drop_thinking }
 let keep_first_and_last ~first_n ~last_n =
@@ -621,6 +649,7 @@ let from_capabilities ?(margin=0.8) (caps : Llm_provider.Capabilities.capabiliti
     Some (compose [
       drop_thinking;
       repair_dangling_tool_calls;
+      repair_orphaned_tool_results;
       token_budget budget;
     ])
 

--- a/lib/context_reducer.mli
+++ b/lib/context_reducer.mli
@@ -21,6 +21,7 @@ type strategy =
   | Prune_tool_outputs of { max_output_len: int }
   | Prune_tool_args of { max_arg_len: int; keep_recent: int }
   | Repair_dangling_tool_calls
+  | Repair_orphaned_tool_results
   | Merge_contiguous
   | Drop_thinking
   | Keep_first_and_last of { first_n: int; last_n: int }
@@ -103,6 +104,13 @@ val token_budget : int -> t
 val prune_tool_outputs : max_output_len:int -> t
 val prune_tool_args : max_arg_len:int -> ?keep_recent:int -> unit -> t
 val repair_dangling_tool_calls : t
+
+(** Remove ToolResult blocks whose tool_use_id has no matching ToolUse.
+    OpenAI-compatible APIs (GLM, Groq, etc.) reject orphaned ToolResults.
+    Complement of [repair_dangling_tool_calls].
+    @since 0.99.2 *)
+val repair_orphaned_tool_results : t
+
 val merge_contiguous : t
 val drop_thinking : t
 val keep_first_and_last : first_n:int -> last_n:int -> t
@@ -154,14 +162,16 @@ val dynamic : (turn:int -> messages:message list -> strategy) -> t
 
 (** Create a reducer from provider capabilities.
     Uses [max_context_tokens * margin] as the token budget (default 80%),
-    composed with [drop_thinking] and [repair_dangling_tool_calls].
+    composed with [drop_thinking], [repair_dangling_tool_calls],
+    and [repair_orphaned_tool_results].
     Returns [None] if [max_context_tokens] is unknown. *)
 val from_capabilities :
   ?margin:float -> Llm_provider.Capabilities.capabilities -> t option
 
 (** Create a reducer from an explicit context budget with configurable thresholds.
     Uses [max_tokens * compact_ratio] as the token budget (default 80%),
-    composed with [drop_thinking] and [repair_dangling_tool_calls].
+    composed with [drop_thinking], [repair_dangling_tool_calls],
+    and [repair_orphaned_tool_results].
 
     @since 0.79.0 *)
 val from_context_config :

--- a/lib/defaults.ml
+++ b/lib/defaults.ml
@@ -67,6 +67,7 @@ let allow_test_providers () =
 let default_context_reducer =
   Context_reducer.compose [
     Context_reducer.repair_dangling_tool_calls;
+    Context_reducer.repair_orphaned_tool_results;
     Context_reducer.prune_tool_args ~max_arg_len:2000 ();
     Context_reducer.drop_thinking;
   ]

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -717,6 +717,63 @@ let test_repair_partial_orphan () =
   (* Only t2 is orphan → 1 synthetic ToolResult *)
   Alcotest.(check int) "repaired (+1)" 5 (List.length result)
 
+(* --- repair_orphaned_tool_results --- *)
+
+let test_orphaned_results_no_orphans () =
+  let msgs = [
+    user_msg "q";
+    tool_use_msg "t1" "calc";
+    tool_result_msg "t1" "42";
+    asst_msg "done";
+  ] in
+  let result = Context_reducer.reduce Context_reducer.repair_orphaned_tool_results msgs in
+  Alcotest.(check int) "no change" (List.length msgs) (List.length result)
+
+let test_orphaned_results_single () =
+  (* ToolResult without matching ToolUse — orphaned *)
+  let msgs = [
+    user_msg "q";
+    tool_result_msg "t1" "42";
+    asst_msg "done";
+  ] in
+  let result = Context_reducer.reduce Context_reducer.repair_orphaned_tool_results msgs in
+  (* The orphaned ToolResult message should be removed entirely *)
+  Alcotest.(check int) "orphan removed" 2 (List.length result);
+  (match List.hd result with
+   | { Types.content = [Types.Text t]; _ } ->
+     Alcotest.(check string) "first is user" "q" t
+   | _ -> Alcotest.fail "expected user text")
+
+let test_orphaned_results_mixed () =
+  (* User message with both Text and orphaned ToolResult *)
+  let msgs = [
+    user_msg "q";
+    tool_use_msg "t1" "calc";
+    Types.{ role = User; content = [
+      ToolResult { tool_use_id = "t1"; content = "ok"; is_error = false; json = None };
+      ToolResult { tool_use_id = "t2"; content = "orphan"; is_error = false; json = None };
+    ]; name = None; tool_call_id = None };
+    asst_msg "done";
+  ] in
+  let result = Context_reducer.reduce Context_reducer.repair_orphaned_tool_results msgs in
+  Alcotest.(check int) "msg count same" 4 (List.length result);
+  (* The mixed message should only keep t1's result *)
+  (match List.nth result 2 with
+   | { Types.content = [Types.ToolResult { tool_use_id; _ }]; _ } ->
+     Alcotest.(check string) "kept t1" "t1" tool_use_id
+   | _ -> Alcotest.fail "expected single tool result for t1")
+
+let test_orphaned_results_after_compaction () =
+  (* Simulate: compaction dropped ToolUse but left ToolResult *)
+  let msgs = [
+    user_msg "q";
+    asst_msg "I will use a tool";  (* ToolUse was here but got dropped *)
+    tool_result_msg "t1" "result data";
+    asst_msg "based on that result";
+  ] in
+  let result = Context_reducer.reduce Context_reducer.repair_orphaned_tool_results msgs in
+  Alcotest.(check int) "orphan removed" 3 (List.length result)
+
 let () =
   Alcotest.run "Context_reducer" [
     "keep_last_n", [
@@ -795,6 +852,12 @@ let () =
       Alcotest.test_case "single orphan repaired" `Quick test_repair_single_orphan;
       Alcotest.test_case "multiple orphans repaired" `Quick test_repair_multiple_orphans;
       Alcotest.test_case "partial orphan repaired" `Quick test_repair_partial_orphan;
+    ];
+    "repair_orphaned_tool_results", [
+      Alcotest.test_case "no orphans unchanged" `Quick test_orphaned_results_no_orphans;
+      Alcotest.test_case "single orphan removed" `Quick test_orphaned_results_single;
+      Alcotest.test_case "mixed kept and orphan" `Quick test_orphaned_results_mixed;
+      Alcotest.test_case "after compaction" `Quick test_orphaned_results_after_compaction;
     ];
     "edge_cases", [
       Alcotest.test_case "empty messages" `Quick test_empty;


### PR DESCRIPTION
## Summary

- Add `Repair_orphaned_tool_results` strategy to context_reducer
- Removes ToolResult blocks whose tool_use_id has no matching ToolUse
- Composed into default reducers alongside `repair_dangling_tool_calls`

## Problem

Context compaction can drop ToolUse blocks from assistant messages while leaving corresponding ToolResult blocks orphaned. OpenAI-compatible APIs (GLM, Groq, DeepSeek) reject these requests. The Anthropic API path already had `repair_dangling_tool_calls` for the inverse case.

## Changes

- `lib/context_reducer.ml`: new strategy + implementation (24 lines)
- `lib/context_reducer.mli`: expose `repair_orphaned_tool_results`
- `lib/defaults.ml`: add to default reducer composition
- `test/test_context_reducer.ml`: 4 new tests (51 total, all pass)

Closes #913
