### PR TITLE
[codex] register official CLI runtime labels in OAS

### DIFF
--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -1017,8 +1017,16 @@ let%test "resolve_model_strings named takes priority over default" =
       resolve_model_strings ~config_path:tmp
         ~name:"named" ~defaults:["fallback:x"] () = ["glm:flash"]))
 
-let%test "default_registry has 12 providers" =
-  List.length (Provider_registry.all default_registry) = 12
+let%test "default_registry includes official cli providers" =
+  List.mem "claude_code"
+    (List.map (fun (e : Provider_registry.entry) -> e.name)
+       (Provider_registry.all default_registry))
+  && List.mem "gemini_cli"
+       (List.map (fun (e : Provider_registry.entry) -> e.name)
+          (Provider_registry.all default_registry))
+  && List.mem "codex_cli"
+       (List.map (fun (e : Provider_registry.entry) -> e.name)
+          (Provider_registry.all default_registry))
 
 let%test "default_registry llama is OpenAI_compat" =
   match Provider_registry.find default_registry "llama" with
@@ -1031,6 +1039,22 @@ let%test "default_registry claude is Anthropic" =
 let%test "default_registry gemini is Gemini" =
   match Provider_registry.find default_registry "gemini" with
   | Some e -> e.defaults.kind = Gemini | None -> false
+
+let%test "default_registry claude_code is Claude_code" =
+  match Provider_registry.find default_registry "claude_code" with
+  | Some e -> e.defaults.kind = Claude_code | None -> false
+
+let%test "default_registry cc remains Claude_code compat alias" =
+  match Provider_registry.find default_registry "cc" with
+  | Some e -> e.defaults.kind = Claude_code | None -> false
+
+let%test "default_registry gemini_cli is Gemini_cli" =
+  match Provider_registry.find default_registry "gemini_cli" with
+  | Some e -> e.defaults.kind = Gemini_cli | None -> false
+
+let%test "default_registry codex_cli is Codex_cli" =
+  match Provider_registry.find default_registry "codex_cli" with
+  | Some e -> e.defaults.kind = Codex_cli | None -> false
 
 let%test "parse_model_string trims whitespace" =
   match parse_model_string "  llama : qwen3.5  " with

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -281,18 +281,52 @@ let default () =
                max_context = 262_144;
                capabilities = Capabilities.ollama_capabilities;
                is_available = (fun () -> true) };
-  (* Claude Code subprocess — always available if claude is in PATH *)
-  let cc_defaults = {
+  (* CLI subprocess providers. Exposed under explicit provider labels so
+     cascade/model specs can opt into the non-interactive transports
+     without reusing the direct API names. *)
+  let claude_code_defaults = {
     kind = Claude_code;
     base_url = "";
     api_key_env = "";
     request_path = "";
   } in
-  let cc_available =
+  let claude_code_available =
     let cached = command_in_path "claude" in
     fun () -> cached
   in
-  register t { name = "cc"; defaults = cc_defaults; max_context = 200_000;
+  let gemini_cli_defaults = {
+    kind = Gemini_cli;
+    base_url = "";
+    api_key_env = "";
+    request_path = "";
+  } in
+  let gemini_cli_available =
+    let cached = command_in_path "gemini" in
+    fun () -> cached
+  in
+  let codex_cli_defaults = {
+    kind = Codex_cli;
+    base_url = "";
+    api_key_env = "";
+    request_path = "";
+  } in
+  let codex_cli_available =
+    let cached = command_in_path "codex" in
+    fun () -> cached
+  in
+  register t { name = "claude_code"; defaults = claude_code_defaults;
+               max_context = 200_000;
                capabilities = Capabilities.claude_code_capabilities;
-               is_available = cc_available };
+               is_available = claude_code_available };
+  register t { name = "cc"; defaults = claude_code_defaults; max_context = 200_000;
+               capabilities = Capabilities.claude_code_capabilities;
+               is_available = claude_code_available };
+  register t { name = "gemini_cli"; defaults = gemini_cli_defaults;
+               max_context = 1_000_000;
+               capabilities = Capabilities.gemini_cli_capabilities;
+               is_available = gemini_cli_available };
+  register t { name = "codex_cli"; defaults = codex_cli_defaults;
+               max_context = 128_000;
+               capabilities = Capabilities.codex_cli_capabilities;
+               is_available = codex_cli_available };
   t

--- a/lib/llm_provider/provider_registry.mli
+++ b/lib/llm_provider/provider_registry.mli
@@ -55,9 +55,11 @@ val find_capable : t -> (Capabilities.capabilities -> bool) -> entry list
 (** Check whether a command is discoverable from PATH without shelling out. *)
 val command_in_path : ?path:string -> string -> bool
 
-(** Default registry pre-populated with known providers
-    (llama, claude, gemini, glm, openrouter).
-    Availability is determined by checking the API key env var. *)
+(** Default registry pre-populated with known direct providers plus
+    non-interactive CLI transports ([claude_code], [gemini_cli],
+    [codex_cli], and compat alias [cc]).
+    Availability is determined by API-key env vars for direct providers
+    and PATH discovery for CLI transports. *)
 val default : unit -> t
 
 (** Initial LLM_ENDPOINTS URLs parsed from the environment at module load.

--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -76,10 +76,10 @@ let build_args ~(config : config) ~(req_config : Provider_config.t)
   let add a = args := !args @ a in
   add ["--output-format"; if stream then "stream-json" else "json"];
   if stream then add ["--verbose"];
-  (* Model: prefer req_config.model_id, then config.model *)
-  let model = match req_config.model_id with
-    | "" -> config.model
-    | m -> Some m
+  (* "auto" means "use the CLI's configured default", so omit [--model]. *)
+  let model = match String.trim req_config.model_id |> String.lowercase_ascii with
+    | "" | "auto" -> config.model
+    | _ -> Some req_config.model_id
   in
   (match model with Some m -> add ["--model"; m] | None -> ());
   (match system_prompt with Some s -> add ["--system-prompt"; s] | None -> ());
@@ -361,6 +361,12 @@ let%test "non_system_messages filters system" =
   ] in
   let filtered = non_system_messages msgs in
   List.length filtered = 1
+
+let%test "build_args omits auto model override" =
+  let args = build_args ~config:default_config
+    ~req_config:(Provider_config.make ~kind:Claude_code ~model_id:"auto" ~base_url:"" ())
+    ~prompt:"hello" ~stream:false ~system_prompt:None in
+  not (List.mem "--model" args)
 
 let%test "parse_json_result success" =
   let json = {|{"type":"result","subtype":"success","is_error":false,"result":"hello world","model":"claude-sonnet-4","stop_reason":"end_turn","session_id":"s1","duration_api_ms":100}|} in

--- a/lib/llm_provider/transport_gemini_cli.ml
+++ b/lib/llm_provider/transport_gemini_cli.ml
@@ -69,10 +69,10 @@ let build_args ~(config : config) ~(req_config : Provider_config.t)
   let args = ref [config.gemini_path; "--output-format"; "json"; "-p"; prompt] in
   let add a = args := !args @ a in
   if config.yolo then add ["--yolo"];
-  (* Model: prefer req_config.model_id, then config.model *)
-  let model = match req_config.model_id with
-    | "" -> config.model
-    | m -> Some m
+  (* "auto" means "use the CLI's configured default", so omit [--model]. *)
+  let model = match String.trim req_config.model_id |> String.lowercase_ascii with
+    | "" | "auto" -> config.model
+    | _ -> Some req_config.model_id
   in
   (match model with Some m -> add ["--model"; m] | None -> ());
   (match system_prompt with Some s -> add ["--system-prompt"; s] | None -> ());
@@ -302,6 +302,12 @@ let%test "build_args with model" =
   List.mem "--model" args
   && List.mem "gemini-2.5-pro" args
   && List.mem "--system-prompt" args
+
+let%test "build_args omits auto model override" =
+  let args = build_args ~config:default_config
+    ~req_config:(Provider_config.make ~kind:Claude_code ~model_id:"auto" ~base_url:"" ())
+    ~prompt:"hello" ~system_prompt:None in
+  not (List.mem "--model" args)
 
 let%test "parse_json_result success" =
   let json = {|{"response":"hello world","usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"cachedContentTokenCount":2}}|} in

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -163,10 +163,10 @@ let test_find_capable_composite () =
 
 (* ── Default registry ───────────────────────────────── *)
 
-let test_default_has_12 () =
+let test_default_has_15 () =
   let reg = Provider_registry.default () in
   let all = Provider_registry.all reg in
-  check int "12 known providers" 12 (List.length all);
+  check int "15 known providers" 15 (List.length all);
   check bool "llama exists" true
     (Option.is_some (Provider_registry.find reg "llama"));
   check bool "ollama exists" true
@@ -189,8 +189,14 @@ let test_default_has_12 () =
     (Option.is_some (Provider_registry.find reg "alibaba"));
   check bool "siliconflow exists" true
     (Option.is_some (Provider_registry.find reg "siliconflow"));
+  check bool "claude_code exists" true
+    (Option.is_some (Provider_registry.find reg "claude_code"));
   check bool "cc exists" true
-    (Option.is_some (Provider_registry.find reg "cc"))
+    (Option.is_some (Provider_registry.find reg "cc"));
+  check bool "gemini_cli exists" true
+    (Option.is_some (Provider_registry.find reg "gemini_cli"));
+  check bool "codex_cli exists" true
+    (Option.is_some (Provider_registry.find reg "codex_cli"))
 
 let test_default_capabilities () =
   let reg = Provider_registry.default () in
@@ -336,7 +342,7 @@ let () =
       test_case "requires_any" `Quick test_requires_any;
     ];
     "default", [
-      test_case "has 12 providers" `Quick test_default_has_12;
+      test_case "has 15 providers" `Quick test_default_has_15;
       test_case "correct capabilities" `Quick test_default_capabilities;
       test_case "max_context values" `Quick test_default_max_context;
       test_case "zai base urls" `Quick test_default_zai_base_urls;


### PR DESCRIPTION
## Summary
This promotes the non-interactive CLI transports to official OAS provider labels.

## What Changed
- register `claude_code`, `gemini_cli`, and `codex_cli` in the default provider registry
- keep `cc` as a Claude Code compatibility alias
- treat `auto` as "use the CLI default" in Claude/Gemini transport arg builders by omitting `--model`
- add registry/transport tests that lock the new label contract

## Why
MASC is being split so CLI runtimes and direct APIs are distinct boundary concepts. OAS needs first-class CLI labels instead of relying on compat-only or implicit naming.

## Impact
- cascade/model specs can now target official CLI runtime labels directly
- CLI transports no longer receive a literal `auto` model override
- downstream integrations can distinguish CLI substrate from direct API substrate more cleanly

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/codex/cli-boundary-20260415 @default`
- `./_build/default/test/test_provider_bridge.exe`
- `./_build/default/test/test_complete_http.exe`
- `./_build/default/test/test_cascade_config_ext.exe`

## Notes
Companion change for the matching `masc-mcp` provider/runtime boundary PR.