### PR TITLE
feat(cascade): selection trace + health snapshot API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ Historical note: release notes for `0.100.3`, `0.100.5`, and `0.100.6` were
 backfilled on 2026-04-04 from existing git tags. The dates below reflect the
 original tag dates. `0.100.4` was never tagged or released.
 
+## [0.139.0] - 2026-04-15
+
+### Added
+- `Cascade_config.resolve_model_strings_with_trace` — structured selection
+  trace for cascade decisions. Returns the ordered model list plus a
+  `selection_trace` with per-candidate `config_weight`, `effective_weight`,
+  `success_rate`, and `in_cooldown`. Enables dashboards/telemetry to
+  surface *why* a provider was chosen first without re-deriving state.
+- `Cascade_health_tracker.provider_info` / `all_providers` — structured
+  snapshot API for the rolling-window health tracker. Returns
+  `provider_info` records (key, success rate, consecutive failures,
+  cooldown state + expiry, events in window). Complements the existing
+  string-based `provider_summary`.
+
+### Notes
+- No breaking changes. Existing consumers of `resolve_model_strings_traced`
+  and `provider_summary` are unaffected.
+
+## [0.138.0] - 2026-04-15
+
+### Fixed
+- `Context_reducer` now strips orphaned `ToolResult` blocks before the API
+  call so compacted contexts do not trip `tool_call_id` validation on
+  OpenAI-compatible providers (#917).
+- `Utf8_sanitize` strips disallowed control characters to prevent
+  downstream JSON serialization faults (#916).
+
 ## [0.137.0] - 2026-04-15
 
 ### Added

--- a/lib/llm_provider/cascade_config.ml
+++ b/lib/llm_provider/cascade_config.ml
@@ -439,6 +439,86 @@ let resolve_model_strings_traced ?config_path ~name ~defaults () =
 let resolve_model_strings ?config_path ~name ~defaults () =
   fst (resolve_model_strings_traced ?config_path ~name ~defaults ())
 
+(* ── Selection trace (observability) ─────────────────── *)
+
+type candidate_info = {
+  model_string : string;
+  config_weight : int;
+  effective_weight : int;
+  success_rate : float;
+  in_cooldown : bool;
+}
+
+type selection_trace = {
+  candidates : candidate_info list;
+  source : cascade_source;
+}
+
+(** Extract the provider_key the health tracker uses for a "provider:model"
+    string. Mirrors the derivation in {!order_weighted_entries}. *)
+let provider_key_of_model_string s =
+  match String.split_on_char ':' s with
+  | _ :: rest when rest <> [] -> String.concat ":" rest
+  | _ -> s
+
+(** Build a [candidate_info] for a model string given its config weight.
+    Reads current health tracker state for [success_rate] / [in_cooldown]
+    / [effective_weight], so the trace reflects state at call time. *)
+let candidate_info_of_weighted (e : Cascade_config_loader.weighted_entry) =
+  let health = Cascade_health_tracker.global in
+  let key = provider_key_of_model_string e.model in
+  let success_rate = Cascade_health_tracker.success_rate health ~provider_key:key in
+  let in_cooldown = Cascade_health_tracker.is_in_cooldown health ~provider_key:key in
+  let effective_weight =
+    Cascade_health_tracker.effective_weight health
+      ~provider_key:key ~config_weight:e.weight
+  in
+  {
+    model_string = e.model;
+    config_weight = e.weight;
+    effective_weight;
+    success_rate;
+    in_cooldown;
+  }
+
+let resolve_model_strings_with_trace ?config_path ~name ~defaults () =
+  match config_path with
+  | Some path ->
+    let from_file_weighted =
+      Cascade_config_loader.load_profile_weighted ~config_path:path ~name in
+    if from_file_weighted <> [] then
+      let ordered = order_weighted_entries from_file_weighted in
+      let models = List.map
+          (fun (e : Cascade_config_loader.weighted_entry) -> e.model) ordered in
+      let candidates = List.map candidate_info_of_weighted ordered in
+      (models, { candidates; source = Named })
+    else
+      let fallback_weighted =
+        Cascade_config_loader.load_profile_weighted
+          ~config_path:path ~name:"default" in
+      if fallback_weighted <> [] then
+        let ordered = order_weighted_entries fallback_weighted in
+        let models = List.map
+            (fun (e : Cascade_config_loader.weighted_entry) -> e.model) ordered in
+        let candidates = List.map candidate_info_of_weighted ordered in
+        (models, { candidates; source = Default_fallback })
+      else
+        let candidates =
+          List.map (fun m ->
+            candidate_info_of_weighted
+              { Cascade_config_loader.model = m; weight = 1 })
+            defaults
+        in
+        (defaults, { candidates; source = Hardcoded_defaults })
+  | None ->
+    let candidates =
+      List.map (fun m ->
+        candidate_info_of_weighted
+          { Cascade_config_loader.model = m; weight = 1 })
+        defaults
+    in
+    (defaults, { candidates; source = Hardcoded_defaults })
+
 let dedupe_stable (items : string list) =
   let rec loop seen acc = function
     | [] -> List.rev acc

--- a/lib/llm_provider/cascade_config.mli
+++ b/lib/llm_provider/cascade_config.mli
@@ -149,6 +149,55 @@ val resolve_model_strings_traced :
   unit ->
   string list * cascade_source
 
+(** Per-candidate info in a weighted selection decision.
+
+    Captures the state that influenced a single candidate's ordering
+    at decision time: its declared weight, health-adjusted effective
+    weight, and current health signals.
+
+    @since 0.139.0 *)
+type candidate_info = {
+  model_string : string;        (** "provider:model_id" as written in config *)
+  config_weight : int;          (** Weight from [cascade.json] ([1] when absent) *)
+  effective_weight : int;       (** Weight after health adjustment; [0] = cooled-down *)
+  success_rate : float;         (** Rolling-window success rate, [0.0]–[1.0] *)
+  in_cooldown : bool;           (** Provider currently skipped by cooldown *)
+}
+
+(** Full trace of a cascade selection decision.
+
+    Consumers can use this to surface, in dashboards/telemetry,
+    why a particular provider was attempted first and what signals
+    were considered.
+
+    [candidates] is in final attempt order — the first entry is the
+    provider the cascade will try first.
+
+    When the profile has no weights (every entry is [weight=1]), no
+    probabilistic shuffle happens and [effective_weight = config_weight = 1]
+    for each entry.
+
+    @since 0.139.0 *)
+type selection_trace = {
+  candidates : candidate_info list;
+  source : cascade_source;
+}
+
+(** Like {!resolve_model_strings_traced} but also returns per-candidate
+    health signals that influenced the ordering. Useful for rendering
+    the cascade decision in dashboards without re-deriving state.
+
+    Non-breaking: callers who only need the ordered model list can
+    continue using {!resolve_model_strings} or {!resolve_model_strings_traced}.
+
+    @since 0.139.0 *)
+val resolve_model_strings_with_trace :
+  ?config_path:string ->
+  name:string ->
+  defaults:string list ->
+  unit ->
+  string list * selection_trace
+
 (** {1 Raw JSON Access} *)
 
 (** Load and cache the raw JSON config file.

--- a/lib/llm_provider/cascade_health_tracker.ml
+++ b/lib/llm_provider/cascade_health_tracker.ml
@@ -172,6 +172,52 @@ let provider_summary t ~provider_key =
         (if total > 0 then 100.0 *. float_of_int successes /. float_of_int total else 100.0)
         state.consecutive_failures in_cd)
 
+(** Structured provider snapshot — shared by [provider_info] and [all_providers].
+    Built inside the mutex so the snapshot is consistent. *)
+type provider_info = {
+  provider_key : string;
+  success_rate : float;
+  consecutive_failures : int;
+  in_cooldown : bool;
+  cooldown_expires_at : float option;
+  events_in_window : int;
+}
+
+let build_info_locked ~now ~key state =
+  let recent = prune_old_events now state.events in
+  let total = List.length recent in
+  let successes = List.length
+      (List.filter (fun e -> e.outcome = Success) recent) in
+  let rate =
+    if total = 0 then 1.0
+    else float_of_int successes /. float_of_int total
+  in
+  let in_cd = state.cooldown_until > now in
+  {
+    provider_key = key;
+    success_rate = rate;
+    consecutive_failures = state.consecutive_failures;
+    in_cooldown = in_cd;
+    cooldown_expires_at = (if in_cd then Some state.cooldown_until else None);
+    events_in_window = total;
+  }
+
+let provider_info t ~provider_key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.providers provider_key with
+    | None -> None
+    | Some state ->
+      Some (build_info_locked ~now:(Unix.gettimeofday ()) ~key:provider_key state))
+
+let all_providers t =
+  with_lock t (fun () ->
+    let now = Unix.gettimeofday () in
+    Hashtbl.fold
+      (fun key state acc -> build_info_locked ~now ~key state :: acc)
+      t.providers
+      []
+    |> List.sort (fun a b -> String.compare a.provider_key b.provider_key))
+
 (* ── Global singleton ─────────────────────────── *)
 
 (** Global health tracker shared across all cascade calls in this process.
@@ -253,3 +299,55 @@ let%test "old events pruned from window" =
   (* Old failure should be pruned; only recent success counts *)
   let rate = success_rate t ~provider_key:"a" in
   Float.equal rate 1.0
+
+(* ── provider_info / all_providers ──────────────────── *)
+
+let%test "provider_info returns None for unknown provider" =
+  let t = create () in
+  Option.is_none (provider_info t ~provider_key:"unknown")
+
+let%test "provider_info reflects current state" =
+  let t = create () in
+  let now = Unix.gettimeofday () in
+  record t ~provider_key:"p" ~outcome:Success ~now;
+  record t ~provider_key:"p" ~outcome:Failure ~now;
+  match provider_info t ~provider_key:"p" with
+  | None -> false
+  | Some info ->
+    info.provider_key = "p"
+    && info.events_in_window = 2
+    && info.consecutive_failures = 1
+    && not info.in_cooldown
+    && Option.is_none info.cooldown_expires_at
+    && abs_float (info.success_rate -. 0.5) < 0.01
+
+let%test "provider_info exposes cooldown expiry" =
+  let t = create () in
+  let now = Unix.gettimeofday () in
+  for _ = 1 to cooldown_threshold do
+    record t ~provider_key:"p" ~outcome:Failure ~now
+  done;
+  match provider_info t ~provider_key:"p" with
+  | Some info ->
+    info.in_cooldown
+    && (match info.cooldown_expires_at with
+        | Some exp -> exp > now
+        | None -> false)
+  | None -> false
+
+let%test "all_providers returns sorted snapshot" =
+  let t = create () in
+  let now = Unix.gettimeofday () in
+  record t ~provider_key:"zeta" ~outcome:Success ~now;
+  record t ~provider_key:"alpha" ~outcome:Success ~now;
+  record t ~provider_key:"mid" ~outcome:Failure ~now;
+  match all_providers t with
+  | [a; b; c] ->
+    a.provider_key = "alpha"
+    && b.provider_key = "mid"
+    && c.provider_key = "zeta"
+  | _ -> false
+
+let%test "all_providers empty for fresh tracker" =
+  let t = create () in
+  all_providers t = []

--- a/lib/llm_provider/cascade_health_tracker.mli
+++ b/lib/llm_provider/cascade_health_tracker.mli
@@ -40,6 +40,27 @@ val effective_weight : t -> provider_key:string -> config_weight:int -> int
 (** Human-readable summary for debugging/telemetry. *)
 val provider_summary : t -> provider_key:string -> string
 
+(** Structured summary for telemetry/dashboard consumption.
+
+    @since 0.139.0 *)
+type provider_info = {
+  provider_key : string;
+  success_rate : float;               (** 0.0 to 1.0, 1.0 if unknown *)
+  consecutive_failures : int;
+  in_cooldown : bool;
+  cooldown_expires_at : float option; (** Unix timestamp, Some iff [in_cooldown] *)
+  events_in_window : int;             (** Events retained in rolling window *)
+}
+
+(** Structured info for a single provider. Returns [None] if untracked.
+    @since 0.139.0 *)
+val provider_info : t -> provider_key:string -> provider_info option
+
+(** Snapshot of all tracked providers.
+    Useful for dashboards and telemetry endpoints.
+    @since 0.139.0 *)
+val all_providers : t -> provider_info list
+
 (** Global singleton tracker shared across all cascade calls.
     Use this for production; use {!create} for isolated tests. *)
 val global : t

--- a/test/test_cascade_config.ml
+++ b/test/test_cascade_config.ml
@@ -388,6 +388,59 @@ let test_zai_base_url_respects_override_host () =
        check bool "override host still rejected for general path" false
          (Zai_catalog.is_zai_base_url "https://proxy.example.com/api/paas/v4"))
 
+(* ── resolve_model_strings_with_trace ─────────────────── *)
+
+let test_trace_hardcoded_no_config () =
+  let (models, trace) =
+    Cascade_config.resolve_model_strings_with_trace
+      ~name:"test" ~defaults:["llama:auto"; "glm:auto"] () in
+  check (list string) "models" ["llama:auto"; "glm:auto"] models;
+  check int "candidate count" 2 (List.length trace.candidates);
+  (* With no weights, config_weight and effective_weight are 1 *)
+  let first = List.hd trace.candidates in
+  check string "first candidate model" "llama:auto" first.model_string;
+  check int "first config_weight" 1 first.config_weight;
+  check int "first effective_weight" 1 first.effective_weight
+
+let test_trace_named_profile_plain () =
+  Eio_main.run @@ fun _env ->
+  with_temp_json
+    {|{"traced_models": ["glm:flash", "llama:qwen3.5"]}|}
+    (fun path ->
+       let (_models, trace) =
+         Cascade_config.resolve_model_strings_with_trace
+           ~config_path:path ~name:"traced" ~defaults:[] ()
+       in
+       check int "candidate count" 2 (List.length trace.candidates);
+       let first = List.hd trace.candidates in
+       check int "weight 1 for plain entry" 1 first.config_weight)
+
+let test_trace_weighted_profile () =
+  Eio_main.run @@ fun _env ->
+  with_temp_json
+    {|{"weighted_models": [
+        {"model": "glm:a", "weight": 60},
+        {"model": "llama:b", "weight": 30},
+        {"model": "ollama:c", "weight": 10}
+      ]}|}
+    (fun path ->
+       let (models, trace) =
+         Cascade_config.resolve_model_strings_with_trace
+           ~config_path:path ~name:"weighted" ~defaults:[] ()
+       in
+       check int "model list size" 3 (List.length models);
+       check int "candidate list size" 3 (List.length trace.candidates);
+       (* First candidate in trace matches first model in ordered list *)
+       let first_model = List.hd models in
+       let first_candidate = List.hd trace.candidates in
+       check string "trace first == ordered first"
+         first_model first_candidate.model_string;
+       (* Weights preserved from config *)
+       let total_weight = List.fold_left
+         (fun acc (c : Cascade_config.candidate_info) -> acc + c.config_weight)
+         0 trace.candidates in
+       check int "total config_weight preserved" 100 total_weight)
+
 (* ── Suite ────────────────────────────────────────────── *)
 
 let () =
@@ -438,5 +491,10 @@ let () =
       test_case "empty passthrough" `Quick test_filter_empty_passthrough;
       test_case "context overflow 400 cascades" `Quick
         test_context_overflow_bad_request_cascades;
+    ];
+    "selection_trace", [
+      test_case "hardcoded no config" `Quick test_trace_hardcoded_no_config;
+      test_case "named profile plain" `Quick test_trace_named_profile_plain;
+      test_case "weighted profile" `Quick test_trace_weighted_profile;
     ];
   ]


### PR DESCRIPTION
## Summary
Add observability hooks so cascade consumers can surface **why** a given provider was selected first. Prior APIs returned only the ordered model list; the per-candidate weight and health signals that produced that ordering lived inside `order_weighted_entries`.

Motivation: a downstream dashboard wants to show cascade config ↔ runtime metrics in one view (MASC issue). Without a structured trace, the dashboard would have to re-derive selection logic, which duplicates the policy.

## Changes
- **`Cascade_config.resolve_model_strings_with_trace`** — returns `string list * selection_trace`. The `selection_trace` carries `candidate_info` records with `config_weight`, `effective_weight`, `success_rate`, `in_cooldown`, plus the existing `cascade_source` tag.
- **`Cascade_health_tracker.provider_info` / `all_providers`** — structured snapshot API. Complements the string-based `provider_summary`. Dashboards can consume fields directly rather than parsing a string.
- Version bump: `0.138.0` → `0.139.0` (minor, additive).
- CHANGELOG entry.

## Non-breaking
Existing `resolve_model_strings_traced` and `provider_summary` callers are unaffected. All new surface is additive.

## Test plan
- [x] `dune exec test/test_cascade_config.exe` — 36 tests pass (3 new `selection_trace` cases)
- [x] `dune build @runtest` — inline tests for `provider_info`/`all_providers` pass (5 new `let%test`)
- [x] `dune build` — full project builds clean
- [ ] CI green

## Next steps (separate PRs)
- MASC will consume these APIs in `try_cascade` + add `/api/v1/cascade/config` and `/api/v1/cascade/health` endpoints
- Dashboard Cascade Config panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)