### PR TITLE
refactor(judge): inline cascade steps, drop complete_named dep

### DIFF
--- a/lib/judge/judge.ml
+++ b/lib/judge/judge.ml
@@ -143,10 +143,32 @@ let judge ~sw ~net ?clock ?config_path ~config ~context () =
     { role = User; content = [Text context]; name = None; tool_call_id = None };
   ] in
   let defaults = ["llama:qwen3.5-35b"; "glm:auto"] in
-  match Cascade_config.complete_named ~sw ~net ?clock ?config_path
-          ~name:config.cascade_name ~defaults ~messages
-          ~temperature:config.temperature ~max_tokens:config.max_tokens
-          ~tools:[] ()
+  (* Resolve cascade.json → ordered model strings → provider configs.
+     Inlined here so we no longer depend on the [Cascade_config.complete_named]
+     wrapper, which is slated for removal. The four steps below mirror what
+     the wrapper did internally. *)
+  let model_strings =
+    Cascade_config.resolve_model_strings ?config_path
+      ~name:config.cascade_name ~defaults ()
+    |> Cascade_config.expand_model_strings_for_execution
+  in
+  let providers =
+    Cascade_config.parse_model_strings
+      ~temperature:config.temperature
+      ~max_tokens:config.max_tokens
+      model_strings
+  in
+  let healthy = Cascade_config.filter_healthy ~sw ~net providers in
+  if healthy = [] then
+    Error (Printf.sprintf
+             "Judge: no callable models for cascade '%s'"
+             config.cascade_name)
+  else
+  match
+    Cascade_executor.complete_cascade_with_accept
+      ~sw ~net ?clock
+      ~accept:(fun _ -> Ok ())
+      healthy ~messages ~tools:[]
   with
   | Error err ->
     let msg = match err with


### PR DESCRIPTION
## Summary

PR 4b of the cascade orchestration cleanup series. Removes \`Judge\`'s reliance on \`Cascade_config.complete_named\` (slated for removal in PR 4d). Inlines the four steps the wrapper performed.

## What changes

\`lib/judge/judge.ml\` — the LLM call site only:

\`\`\`diff
- match Cascade_config.complete_named ~sw ~net ?clock ?config_path
-         ~name:config.cascade_name ~defaults ~messages
-         ~temperature:config.temperature ~max_tokens:config.max_tokens
-         ~tools:[] ()

+ let model_strings =
+     Cascade_config.resolve_model_strings ?config_path
+       ~name:config.cascade_name ~defaults ()
+     |> Cascade_config.expand_model_strings_for_execution in
+ let providers =
+     Cascade_config.parse_model_strings ~temperature ~max_tokens model_strings in
+ let healthy = Cascade_config.filter_healthy ~sw ~net providers in
+ if healthy = [] then Error \"...\" else
+ match Cascade_executor.complete_cascade_with_accept
+         ~sw ~net ?clock ~accept:(fun _ -> Ok ())
+         healthy ~messages ~tools:[]
\`\`\`

The four inlined steps mirror exactly what \`complete_named\` did internally — no behavior change. Judge always accepts the first non-error response (single-turn semantics preserved).

## Why

Two-PR sequence to deprecate the \`complete_named\` named-cascade convenience wrapper. \`Cascade_executor.complete_cascade_with_accept\` is the underlying primitive callers can now use directly:
- PR 4b (this PR) — judge.ml inlines the four steps
- PR 4c (next) — tool_selector.ml inlines the four steps
- PR 4d (final) — \`Cascade_config.complete_named*\` deletion

## Test plan

- [x] \`dune build @lib/all\` → pass
- [x] \`dune exec test/test_judge.exe\` → 17/17 pass (all pure parse_judgment tests)
- [ ] CI build & lint

## Risk

Low — semantically equivalent to the wrapper. Same cascade FSM, same provider list, same accept behavior, same error formatting.