### PR TITLE
feat(llm_provider): native streaming for Claude Code transport

### DIFF
--- a/lib/llm_provider/cli_common_subprocess.ml
+++ b/lib/llm_provider/cli_common_subprocess.ml
@@ -63,3 +63,79 @@ let run_collect ~sw ~(mgr : _ Eio.Process.mgr) ~name ~cwd ~extra_env argv =
   | Unix.Unix_error (err, fn, arg) ->
     Error (Http_client.NetworkError {
       message = Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err) })
+
+let run_stream_lines ~sw ~(mgr : _ Eio.Process.mgr) ~name ~cwd ~extra_env
+    ~on_line ~cancel argv =
+  let t0 = Unix.gettimeofday () in
+  try
+    let r_stdout, w_stdout = Eio_unix.pipe sw in
+    let r_stderr, w_stderr = Eio_unix.pipe sw in
+    let env = build_env ~cwd ~extra_env in
+    let proc = Eio.Process.spawn ~sw mgr
+      ~stdout:(w_stdout :> Eio.Flow.sink_ty Eio.Resource.t)
+      ~stderr:(w_stderr :> Eio.Flow.sink_ty Eio.Resource.t)
+      ~env
+      argv
+    in
+    Eio.Flow.close w_stdout;
+    Eio.Flow.close w_stderr;
+    let stdout_buf = Buffer.create 4096 in
+    let stderr_buf = Buffer.create 256 in
+    let done_p, done_r = Eio.Promise.create () in
+    let read_stdout () =
+      let reader = Eio.Buf_read.of_flow
+        (r_stdout :> _ Eio.Flow.source) ~max_size:(16 * 1024 * 1024) in
+      (try while true do
+         let line = Eio.Buf_read.line reader in
+         Buffer.add_string stdout_buf line;
+         Buffer.add_char stdout_buf '\n';
+         (try on_line line
+          with exn ->
+            Eio.traceln "cli_common_subprocess: on_line raised: %s"
+              (Printexc.to_string exn))
+       done with End_of_file -> ())
+    in
+    let watch_cancel () =
+      match cancel with
+      | None -> Eio.Promise.await done_p
+      | Some cancel_p ->
+        Eio.Fiber.first
+          (fun () -> Eio.Promise.await done_p)
+          (fun () ->
+            Eio.Promise.await cancel_p;
+            (try Eio.Process.signal proc Sys.sigint
+             with _ -> ());
+            (* Let the process drain; [done_p] will fire when pipes close. *)
+            Eio.Promise.await done_p)
+    in
+    Eio.Fiber.all [
+      (fun () ->
+        Eio.Fiber.both
+          read_stdout
+          (fun () ->
+            read_all_lines (r_stderr :> _ Eio.Flow.source) stderr_buf);
+        Eio.Promise.resolve done_r ());
+      watch_cancel;
+    ];
+    let status = Eio.Process.await proc in
+    let latency_ms = int_of_float ((Unix.gettimeofday () -. t0) *. 1000.0) in
+    let stdout_str = Buffer.contents stdout_buf in
+    let stderr_str = Buffer.contents stderr_buf in
+    match status with
+    | `Exited 0 ->
+      Ok { stdout = stdout_str; stderr = stderr_str; latency_ms }
+    | `Exited code ->
+      let detail = if stderr_str <> "" then stderr_str
+        else Printf.sprintf "exit code %d" code in
+      Error (Http_client.NetworkError {
+        message = Printf.sprintf "%s exited with code %d: %s" name code detail })
+    | `Signaled sig_num ->
+      Error (Http_client.NetworkError {
+        message = Printf.sprintf "%s killed by signal %d" name sig_num })
+  with
+  | Eio.Io _ as exn ->
+    Error (Http_client.NetworkError {
+      message = Printf.sprintf "subprocess I/O error: %s" (Printexc.to_string exn) })
+  | Unix.Unix_error (err, fn, arg) ->
+    Error (Http_client.NetworkError {
+      message = Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err) })

--- a/lib/llm_provider/cli_common_subprocess.mli
+++ b/lib/llm_provider/cli_common_subprocess.mli
@@ -32,3 +32,28 @@ val run_collect :
     Returns [Ok { stdout; stderr; latency_ms }] on a zero exit code,
     or a [NetworkError] describing the failure (non-zero exit code,
     signal, or I/O error). *)
+
+val run_stream_lines :
+  sw:Eio.Switch.t ->
+  mgr:_ Eio.Process.mgr ->
+  name:string ->
+  cwd:string option ->
+  extra_env:(string * string) list ->
+  on_line:(string -> unit) ->
+  cancel:unit Eio.Promise.t option ->
+  string list ->
+  (collect_result, Http_client.http_error) result
+(** Streaming variant of {!run_collect}. Calls [on_line line] for every
+    newline-terminated chunk written to stdout while the process is still
+    running — enabling true live streaming rather than post-exit splitting.
+    The full stdout is still accumulated and returned in [collect_result]
+    for callers that also need the aggregate.
+
+    - [cancel]: when [Some p] and [p] is resolved mid-run, [SIGINT] is
+      sent to the subprocess. The process is still drained to completion
+      after the signal.
+    - Exceptions raised by [on_line] are caught and traced via
+      [Eio.traceln]; they do not abort the run.
+
+    Stderr is drained concurrently but not forwarded line-by-line; it is
+    available in the returned [collect_result.stderr]. *)

--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -209,18 +209,25 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
         Cli_common_prompt.system_prompt_of ~req_config:req.config req.messages in
       let args = build_args ~config ~req_config:req.config
         ~prompt ~stream:true ~system_prompt in
-      match run ~sw ~mgr ~config args with
+      let argv = config.claude_path :: args in
+      let seen_lines = ref [] in
+      let on_line line =
+        if String.trim line <> "" then begin
+          seen_lines := line :: !seen_lines;
+          List.iter on_event (events_of_line line)
+        end
+      in
+      match Cli_common_subprocess.run_stream_lines ~sw ~mgr
+              ~name:"claude"
+              ~cwd:config.cwd
+              ~extra_env:[]
+              ~on_line
+              ~cancel:None
+              argv with
       | Error _ as e -> e
-      | Ok { stdout; stderr = _; latency_ms = _ } ->
-        let lines = String.split_on_char '\n' stdout
-          |> List.filter (fun s -> String.trim s <> "") in
-        (* Emit events for each line *)
-        List.iter (fun line ->
-          let events = events_of_line line in
-          List.iter on_event events
-        ) lines;
-        (* Parse final response from result line *)
-        parse_stream_result lines);
+      | Ok _ ->
+        (* Final response is built from whatever lines we saw. *)
+        parse_stream_result (List.rev !seen_lines));
   }
 
 (* ── Inline tests ────────────────────────────────────── *)

--- a/test/dune
+++ b/test/dune
@@ -936,3 +936,7 @@
 (test
  (name test_agent_auto_dump)
  (libraries agent_sdk alcotest eio eio_main))
+
+(test
+ (name test_cli_common_subprocess)
+ (libraries llm_provider alcotest eio eio_main))

--- a/test/test_cli_common_subprocess.ml
+++ b/test/test_cli_common_subprocess.ml
@@ -1,0 +1,83 @@
+(* Integration tests for Cli_common_subprocess.
+   Depend on /bin/sh being available in the test environment. *)
+
+let sh = "/bin/sh"
+
+let test_run_collect_ok () =
+  Eio_main.run @@ fun env ->
+  let mgr = Eio.Stdenv.process_mgr env in
+  Eio.Switch.run @@ fun sw ->
+  match Llm_provider.Cli_common_subprocess.run_collect ~sw ~mgr
+          ~name:"sh" ~cwd:None ~extra_env:[]
+          [sh; "-c"; "printf a; printf b >&2"] with
+  | Ok { stdout; stderr; latency_ms } ->
+    Alcotest.(check string) "stdout" "a\n" stdout;
+    Alcotest.(check string) "stderr" "b\n" stderr;
+    Alcotest.(check bool) "latency non-negative" true (latency_ms >= 0)
+  | Error _ -> Alcotest.fail "expected Ok"
+
+let test_run_collect_nonzero_exit () =
+  Eio_main.run @@ fun env ->
+  let mgr = Eio.Stdenv.process_mgr env in
+  Eio.Switch.run @@ fun sw ->
+  match Llm_provider.Cli_common_subprocess.run_collect ~sw ~mgr
+          ~name:"sh" ~cwd:None ~extra_env:[]
+          [sh; "-c"; "echo oops >&2; exit 3"] with
+  | Ok _ -> Alcotest.fail "expected Error for exit 3"
+  | Error (Llm_provider.Http_client.NetworkError { message }) ->
+    Alcotest.(check bool) "non-empty error message"
+      true (String.length message > 0)
+  | Error _ ->
+    Alcotest.fail "expected NetworkError"
+
+let test_stream_emits_lines_live () =
+  Eio_main.run @@ fun env ->
+  let mgr = Eio.Stdenv.process_mgr env in
+  Eio.Switch.run @@ fun sw ->
+  let seen = ref [] in
+  let on_line line = seen := line :: !seen in
+  match Llm_provider.Cli_common_subprocess.run_stream_lines ~sw ~mgr
+          ~name:"sh" ~cwd:None ~extra_env:[]
+          ~on_line ~cancel:None
+          [sh; "-c"; "printf '1\\n2\\n3\\n'"] with
+  | Ok { stdout; _ } ->
+    Alcotest.(check (list string)) "lines" ["1"; "2"; "3"] (List.rev !seen);
+    Alcotest.(check string) "aggregate" "1\n2\n3\n" stdout
+  | Error _ -> Alcotest.fail "expected Ok"
+
+let test_stream_cancel_sends_sigint () =
+  Eio_main.run @@ fun env ->
+  let mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let cancel_p, cancel_r = Eio.Promise.create () in
+  let seen = ref [] in
+  let on_line line = seen := line :: !seen in
+  (* Fire cancel shortly after spawn. *)
+  Eio.Fiber.fork ~sw (fun () ->
+    Eio.Time.sleep clock 0.1;
+    Eio.Promise.resolve cancel_r ());
+  let result = Llm_provider.Cli_common_subprocess.run_stream_lines ~sw ~mgr
+    ~name:"sh" ~cwd:None ~extra_env:[]
+    ~on_line ~cancel:(Some cancel_p)
+    (* "trap '' INT" would swallow SIGINT, so use default handler. The
+       default sh behaviour on SIGINT is to exit with status 130 (signal). *)
+    [sh; "-c"; "sleep 5"] in
+  match result with
+  | Ok _ -> Alcotest.fail "expected Error after SIGINT"
+  | Error (Llm_provider.Http_client.NetworkError { message }) ->
+    Alcotest.(check bool) "non-empty error message"
+      true (String.length message > 0)
+  | Error _ -> Alcotest.fail "expected NetworkError"
+
+let () =
+  Alcotest.run "cli_common_subprocess"
+    [ "run_collect",
+      [ Alcotest.test_case "ok"   `Quick test_run_collect_ok
+      ; Alcotest.test_case "exit" `Quick test_run_collect_nonzero_exit
+      ]
+    ; "run_stream_lines",
+      [ Alcotest.test_case "emits lines live" `Quick test_stream_emits_lines_live
+      ; Alcotest.test_case "cancel"            `Quick test_stream_cancel_sends_sigint
+      ]
+    ]


### PR DESCRIPTION
## Summary

`Transport_claude_code.complete_stream` used to call `run_collect`, wait for the `claude -p` process to exit, then split the aggregated stdout into lines and replay them through `on_event`. Callers got all the stream-json events in one burst after the model finished generating — defeating the point of streaming.

## Changes

**New in `Cli_common_subprocess`:**
- `run_stream_lines ~on_line ~cancel` — reads stdout line-by-line off the live pipe, calls `on_line line` for each chunk as it arrives, still aggregates the full stdout in the returned `collect_result`.
- Optional `cancel : unit Eio.Promise.t option` — when resolved mid-run, sends `SIGINT` via `Eio.Process.signal`. The process is then drained to completion so the structured error reflects the real exit.

**Wire-up:**
- `Transport_claude_code.complete_stream` now calls `run_stream_lines` with `~cancel:None`. Claude's stream-json lines reach `on_event` in real-time.
- Gemini and Codex stay on `run_collect` + `Cli_common_synthetic_events.replay` — their binaries are sync-only.

## Base

Stacked on [#927](https://github.com/jeong-sik/oas/pull/927) (cli-common helpers). Review and merge that first.

## Test plan
- [x] `dune exec test/test_cli_common_subprocess.exe` — 4/4 pass in 0.12s (stdout/stderr collect, non-zero exit, live line emission, SIGINT cancel via `/bin/sh -c 'sleep 5'`)
- [x] `dune runtest --root . lib/llm_provider` — no regression on existing inline tests
- [x] `dune build --root .` — full tree clean
- [ ] CI: Build & Test (OCaml 5.4.1), Lint, Version Consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)