### PR TITLE
feat(llm_provider): live JSONL parsing for Codex CLI + correct Gemini usage

### DIFF
--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -1,15 +1,24 @@
 (** Codex CLI non-interactive transport.
 
+    Uses [codex exec --json] which emits JSONL envelopes on stdout:
+
+    {v
+    {"type":"thread.started","thread_id":"..."}
+    {"type":"turn.started"}
+    {"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"..."}}
+    {"type":"item.{started,completed}","item":{"id":"item_1","type":"command_execution","command":"...","aggregated_output":"...","exit_code":0}}
+    {"type":"turn.completed","usage":{"input_tokens":N,"cached_input_tokens":N,"output_tokens":N}}
+    v}
+
+    [agent_message] items become {!Types.Text} blocks in the aggregate
+    response.  [command_execution] items are Codex's internal shell tool
+    — transparent to the outer agent, tracked via [Eio.traceln] only.
+
     @since 0.133.0 *)
 
 type config = {
   codex_path: string;
   cwd: string option;
-  (* Fields below are accepted for parity with the Claude Code config
-     so callers can target multiple CLI backends with the same
-     structure.  Codex CLI does not yet expose flags for any of
-     them; setting a non-default value produces a one-shot
-     [Eio.traceln] warning and the value is otherwise ignored. *)
   mcp_config: string option;
   allowed_tools: string list;
   max_turns: int option;
@@ -31,49 +40,88 @@ let default_config = {
 (* ── CLI argument building ───────────────────────────── *)
 
 let build_args ~(config : config) ~prompt =
-  [config.codex_path; "exec"; prompt]
+  [config.codex_path; "exec"; "--json"; prompt]
 
-(* ── Output parsing ──────────────────────────────────── *)
+(* ── JSONL envelope parsing ──────────────────────────── *)
 
-(** Try to extract a token count from the last lines of codex output.
-    Codex may append "tokens used\nN" at the end. *)
-let try_extract_tokens (stdout : string) =
-  let lines = String.split_on_char '\n' stdout
-    |> List.filter (fun s -> String.trim s <> "")
-    |> List.rev in
-  match lines with
-  | count_str :: label :: _ when String.lowercase_ascii (String.trim label) = "tokens used" ->
-    (try Some (int_of_string (String.trim count_str))
-     with Failure _ -> None)
+(** Extract usage from a [turn.completed] envelope. *)
+let parse_usage json =
+  let open Yojson.Safe.Util in
+  match json |> member "usage" with
+  | `Assoc _ as u ->
+    Some { Types.input_tokens = Cli_common_json.member_int "input_tokens" u;
+           output_tokens = Cli_common_json.member_int "output_tokens" u;
+           cache_creation_input_tokens = 0;
+           cache_read_input_tokens =
+             Cli_common_json.member_int "cached_input_tokens" u;
+           cost_usd = None }
   | _ -> None
 
-(** Parse raw text output from codex exec into api_response.
-    Content is the full stdout text. Usage is extracted from trailing
-    "tokens used" line if present. *)
-let parse_text_result (stdout : string) =
-  let usage = match try_extract_tokens stdout with
-    | Some total ->
-      Some { Types.input_tokens = 0;
-             output_tokens = total;
-             cache_creation_input_tokens = 0;
-             cache_read_input_tokens = 0;
-             cost_usd = None }
-    | None -> None
-  in
-  Ok { Types.id = "";
-       model = "codex";
-       stop_reason = Types.EndTurn;
-       content = [Text (String.trim stdout)];
-       usage; telemetry = None }
+(** Parse a single envelope into zero or more OAS sse_events.
+    [command_execution] items do not map to an OAS concept — Codex runs
+    them transparently — so we emit no event for them. *)
+let events_of_line line =
+  try
+    let json = Yojson.Safe.from_string line in
+    let typ = Cli_common_json.member_str "type" json in
+    match typ with
+    | "thread.started" ->
+      let id = Cli_common_json.member_str "thread_id" json in
+      [Types.MessageStart { id; model = "codex"; usage = None }]
+    | "item.completed" ->
+      let item = Yojson.Safe.Util.member "item" json in
+      let item_type = Cli_common_json.member_str "type" item in
+      if item_type = "agent_message" then
+        let text = Cli_common_json.member_str "text" item in
+        [Types.ContentBlockStart {
+           index = 0; content_type = "text";
+           tool_id = None; tool_name = None };
+         Types.ContentBlockDelta { index = 0; delta = Types.TextDelta text };
+         Types.ContentBlockStop { index = 0 }]
+      else []  (* command_execution, etc. — no OAS mapping. *)
+    | "turn.completed" ->
+      let usage = parse_usage json in
+      [Types.MessageDelta { stop_reason = Some Types.EndTurn; usage };
+       Types.MessageStop]
+    | _ -> []
+  with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> []
+
+(** Aggregate JSONL envelopes into an [api_response].  Only
+    [agent_message] text contributes to [content]; the terminal
+    [turn.completed] supplies [usage]; [thread.started] supplies [id]. *)
+let parse_jsonl_result lines =
+  let thread_id = ref "" in
+  let texts = ref [] in
+  let usage = ref None in
+  List.iter (fun line ->
+    try
+      let json = Yojson.Safe.from_string line in
+      let typ = Cli_common_json.member_str "type" json in
+      match typ with
+      | "thread.started" ->
+        thread_id := Cli_common_json.member_str "thread_id" json
+      | "item.completed" ->
+        let item = Yojson.Safe.Util.member "item" json in
+        if Cli_common_json.member_str "type" item = "agent_message" then
+          texts := Cli_common_json.member_str "text" item :: !texts
+      | "turn.completed" ->
+        usage := parse_usage json
+      | _ -> ()
+    with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ()
+  ) lines;
+  let content = List.rev_map (fun t -> Types.Text t) !texts in
+  if content = [] && !thread_id = "" then
+    Error (Http_client.NetworkError {
+      message = "no events parsed from codex output" })
+  else
+    Ok { Types.id = !thread_id;
+         model = "codex";
+         stop_reason = Types.EndTurn;
+         content;
+         usage = !usage;
+         telemetry = None }
 
 (* ── Transport constructor ───────────────────────────── *)
-
-let run ~sw ~mgr ~(config : config) argv =
-  Cli_common_subprocess.run_collect ~sw ~mgr
-    ~name:"codex"
-    ~cwd:config.cwd
-    ~extra_env:[]
-    argv
 
 (* Fires once per transport instance when any Claude-only config field
    is set.  Codex CLI has no flag for these yet, so we warn and drop. *)
@@ -99,10 +147,18 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
       let messages = Cli_common_prompt.non_system_messages req.messages in
       let prompt = Cli_common_prompt.prompt_of_messages messages in
       let argv = build_args ~config ~prompt in
-      match run ~sw ~mgr ~config argv with
+      let seen_lines = ref [] in
+      let on_line line =
+        if String.trim line <> "" then
+          seen_lines := line :: !seen_lines
+      in
+      match Cli_common_subprocess.run_stream_lines ~sw ~mgr
+              ~name:"codex" ~cwd:config.cwd ~extra_env:[]
+              ~on_line ~cancel:None
+              argv with
       | Error _ as e -> { Llm_transport.response = e; latency_ms = 0 }
-      | Ok { stdout; stderr = _; latency_ms } ->
-        let response = parse_text_result stdout in
+      | Ok { stdout = _; stderr = _; latency_ms } ->
+        let response = parse_jsonl_result (List.rev !seen_lines) in
         { Llm_transport.response; latency_ms });
 
     complete_stream = (fun ~on_event (req : Llm_transport.completion_request) ->
@@ -110,17 +166,20 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
       let messages = Cli_common_prompt.non_system_messages req.messages in
       let prompt = Cli_common_prompt.prompt_of_messages messages in
       let argv = build_args ~config ~prompt in
-      (* Codex CLI does not support native streaming; replay synthetic events
-         after the sync call completes. *)
-      match run ~sw ~mgr ~config argv with
+      let seen_lines = ref [] in
+      let on_line line =
+        if String.trim line <> "" then begin
+          seen_lines := line :: !seen_lines;
+          List.iter on_event (events_of_line line)
+        end
+      in
+      match Cli_common_subprocess.run_stream_lines ~sw ~mgr
+              ~name:"codex" ~cwd:config.cwd ~extra_env:[]
+              ~on_line ~cancel:None
+              argv with
       | Error _ as e -> e
-      | Ok { stdout; stderr = _; latency_ms = _ } ->
-        let result = parse_text_result stdout in
-        (match result with
-         | Ok resp ->
-           Cli_common_synthetic_events.replay ~on_event resp;
-           Ok resp
-         | Error _ as e -> e));
+      | Ok _ ->
+        parse_jsonl_result (List.rev !seen_lines));
   }
 
 (* ── Inline tests ────────────────────────────────────── *)
@@ -136,6 +195,10 @@ let%test "default_config parity fields absent" =
   && default_config.max_turns = None
   && default_config.permission_mode = None
 
+let%test "build_args includes --json flag" =
+  let args = build_args ~config:default_config ~prompt:"hello" in
+  args = ["codex"; "exec"; "--json"; "hello"]
+
 let%test "build_args ignores extra parity fields" =
   let config = { default_config with
     mcp_config = Some "/tmp/mcp.json";
@@ -144,36 +207,78 @@ let%test "build_args ignores extra parity fields" =
     permission_mode = Some "bypassPermissions";
   } in
   let args = build_args ~config ~prompt:"hi" in
-  (* Codex argv is [codex; exec; prompt] — no flag surface. *)
-  args = ["codex"; "exec"; "hi"]
+  args = ["codex"; "exec"; "--json"; "hi"]
 
-let%test "build_args basic" =
-  let args = build_args ~config:default_config ~prompt:"hello" in
-  args = ["codex"; "exec"; "hello"]
-
-let%test "parse_text_result plain text" =
-  match parse_text_result "hello world\n" with
+let%test "parse_jsonl_result extracts text + usage + thread_id" =
+  let lines = [
+    {|{"type":"thread.started","thread_id":"abc-123"}|};
+    {|{"type":"turn.started"}|};
+    {|{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"hi"}}|};
+    {|{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":5,"output_tokens":3}}|};
+  ] in
+  match parse_jsonl_result lines with
   | Ok resp ->
-    resp.content = [Types.Text "hello world"]
+    resp.id = "abc-123"
+    && resp.content = [Types.Text "hi"]
     && resp.stop_reason = Types.EndTurn
-    && resp.usage = None
-  | Error _ -> false
-
-let%test "parse_text_result with tokens" =
-  let stdout = "some output\ntokens used\n42\n" in
-  match parse_text_result stdout with
-  | Ok resp ->
-    resp.content = [Types.Text (String.trim stdout)]
     && (match resp.usage with
-        | Some u -> u.output_tokens = 42
+        | Some u -> u.input_tokens = 100
+                 && u.output_tokens = 3
+                 && u.cache_read_input_tokens = 5
         | None -> false)
   | Error _ -> false
 
-let%test "try_extract_tokens with valid count" =
-  try_extract_tokens "output\ntokens used\n100\n" = Some 100
+let%test "parse_jsonl_result aggregates multiple agent_messages" =
+  let lines = [
+    {|{"type":"thread.started","thread_id":"t1"}|};
+    {|{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"first"}}|};
+    {|{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"second"}}|};
+    {|{"type":"turn.completed","usage":{"input_tokens":1,"cached_input_tokens":0,"output_tokens":2}}|};
+  ] in
+  match parse_jsonl_result lines with
+  | Ok resp ->
+    resp.content = [Types.Text "first"; Types.Text "second"]
+  | Error _ -> false
 
-let%test "try_extract_tokens no pattern" =
-  try_extract_tokens "just some output\n" = None
+let%test "parse_jsonl_result skips command_execution items" =
+  let lines = [
+    {|{"type":"thread.started","thread_id":"t"}|};
+    {|{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"ls","exit_code":0}}|};
+    {|{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"done"}}|};
+  ] in
+  match parse_jsonl_result lines with
+  | Ok resp ->
+    (* command_execution contributes nothing; only agent_message text. *)
+    resp.content = [Types.Text "done"]
+  | Error _ -> false
 
-let%test "try_extract_tokens invalid number" =
-  try_extract_tokens "output\ntokens used\nnot_a_number\n" = None
+let%test "parse_jsonl_result empty lines → Error" =
+  match parse_jsonl_result [] with
+  | Error _ -> true
+  | Ok _ -> false
+
+let%test "events_of_line thread.started → MessageStart" =
+  let line = {|{"type":"thread.started","thread_id":"abc"}|} in
+  match events_of_line line with
+  | [Types.MessageStart { id = "abc"; model = "codex"; _ }] -> true
+  | _ -> false
+
+let%test "events_of_line agent_message → 3 block events" =
+  let line = {|{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"hi"}}|} in
+  (match events_of_line line with
+   | [Types.ContentBlockStart _; Types.ContentBlockDelta _; Types.ContentBlockStop _] -> true
+   | _ -> false)
+
+let%test "events_of_line command_execution → no events" =
+  let line = {|{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"ls"}}|} in
+  events_of_line line = []
+
+let%test "events_of_line turn.completed → MessageDelta+Stop" =
+  let line = {|{"type":"turn.completed","usage":{"input_tokens":10,"cached_input_tokens":0,"output_tokens":5}}|} in
+  (match events_of_line line with
+   | [Types.MessageDelta { stop_reason = Some Types.EndTurn; _ };
+      Types.MessageStop] -> true
+   | _ -> false)
+
+let%test "events_of_line invalid json → []" =
+  events_of_line "not json" = []

--- a/lib/llm_provider/transport_gemini_cli.ml
+++ b/lib/llm_provider/transport_gemini_cli.ml
@@ -50,28 +50,68 @@ let build_args ~(config : config) ~(req_config : Provider_config.t)
 
 (* ── JSON parsing ────────────────────────────────────── *)
 
-(** Parse usage metadata from Gemini JSON response.
-    Gemini returns: {usageMetadata: {promptTokenCount, candidatesTokenCount, cachedContentTokenCount}} *)
+(** Parse and aggregate usage across [stats.models] entries in a Gemini
+    CLI [--output-format json] response.  The CLI may invoke multiple
+    models for a single prompt (e.g. a utility router + a main model),
+    each with its own per-model token counts:
+
+    {v
+    "stats": {
+      "models": {
+        "gemini-2.5-flash-lite": {
+          "tokens": { "input": N, "candidates": N, "cached": N }
+        },
+        "gemini-3-flash-preview": {
+          "tokens": { ... }
+        }
+      }
+    }
+    v}
+
+    We sum [tokens.input], [tokens.candidates], and [tokens.cached]
+    across every model.  Returns [None] when no [stats.models] object
+    is present. *)
 let parse_usage json =
   let open Yojson.Safe.Util in
-  match json |> member "usageMetadata" with
-  | `Assoc _ as u ->
-    Some { Types.input_tokens = Cli_common_json.member_int "promptTokenCount" u;
-           output_tokens = Cli_common_json.member_int "candidatesTokenCount" u;
+  let models_field =
+    try json |> member "stats" |> member "models"
+    with Type_error _ -> `Null
+  in
+  match models_field with
+  | `Assoc entries when entries <> [] ->
+    let input = ref 0 in
+    let output = ref 0 in
+    let cached = ref 0 in
+    List.iter (fun (_model_name, model_json) ->
+      match model_json |> member "tokens" with
+      | `Assoc _ as t ->
+        input  := !input  + Cli_common_json.member_int "input" t;
+        output := !output + Cli_common_json.member_int "candidates" t;
+        cached := !cached + Cli_common_json.member_int "cached" t
+      | _ -> ()
+    ) entries;
+    Some { Types.input_tokens = !input;
+           output_tokens = !output;
            cache_creation_input_tokens = 0;
-           cache_read_input_tokens =
-             Cli_common_json.member_int "cachedContentTokenCount" u;
+           cache_read_input_tokens = !cached;
            cost_usd = None }
   | _ -> None
 
-(** Parse the Gemini CLI --output-format json result into api_response.
-    Expected format: {"response": "text", "usageMetadata": {...}} *)
+(** Parse the Gemini CLI [--output-format json] result into an
+    [api_response].  Expected shape:
+
+    {v
+    { "session_id": "...",
+      "response": "text",
+      "stats": { "models": { ... } } }
+    v} *)
 let parse_json_result json_str =
   try
     let json = Yojson.Safe.from_string json_str in
     let response_text = Cli_common_json.member_str "response" json in
+    let session_id = Cli_common_json.member_str "session_id" json in
     let usage = parse_usage json in
-    Ok { Types.id = "";
+    Ok { Types.id = session_id;
          model = "gemini";
          stop_reason = Types.EndTurn;
          content = [Text response_text];
@@ -206,15 +246,28 @@ let%test "build_args ignores mcp_config and allowed_tools" =
   && not (List.mem "--permission-mode" args)
   && not (List.mem "/tmp/mcp.json" args)
 
-let%test "parse_json_result success" =
-  let json = {|{"response":"hello world","usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"cachedContentTokenCount":2}}|} in
+let%test "parse_json_result success (single model stats)" =
+  let json = {|{"session_id":"sid","response":"hello world","stats":{"models":{"gemini-2.5-flash":{"tokens":{"input":10,"candidates":5,"cached":2}}}}}|} in
   match parse_json_result json with
   | Ok resp ->
     resp.content = [Types.Text "hello world"]
     && resp.stop_reason = Types.EndTurn
+    && resp.id = "sid"
     && (match resp.usage with
         | Some u -> u.input_tokens = 10 && u.output_tokens = 5 && u.cache_read_input_tokens = 2
         | None -> false)
+  | Error _ -> false
+
+let%test "parse_json_result aggregates across multiple models" =
+  let json = {|{"session_id":"sid","response":"hi","stats":{"models":{"utility":{"tokens":{"input":100,"candidates":7,"cached":0}},"main":{"tokens":{"input":200,"candidates":3,"cached":5}}}}}|} in
+  match parse_json_result json with
+  | Ok resp ->
+    (match resp.usage with
+     | Some u ->
+       u.input_tokens = 300
+       && u.output_tokens = 10
+       && u.cache_read_input_tokens = 5
+     | None -> false)
   | Error _ -> false
 
 let%test "parse_json_result no usage" =


### PR DESCRIPTION
## Summary

Empirical probing of `codex exec` (v0.120.0) and `gemini --output-format json` (v0.37.2) revealed two wire-format mismatches in the existing transports (introduced in #888):

### Codex: wrong output stream, wrong token extraction
- Plain `codex exec` emits prose on stdout — no structured events, no \"tokens used\" line → `api_response.usage` always `None`.
- **Fix**: switch to `codex exec --json`. Binary emits JSONL envelopes (`thread.started`, `item.completed/{agent_message,command_execution}`, `turn.completed`).
- New `parse_jsonl_result` aggregates `agent_message` → `Types.Text`, drops `command_execution` (Codex's internal shell is transparent), extracts `thread_id` → `api_response.id`, usage from `turn.completed.usage.{input_tokens, cached_input_tokens, output_tokens}`.
- `events_of_line` enables native streaming via `run_stream_lines`.

### Gemini: parsing a field that never exists
- `usageMetadata.{promptTokenCount, candidatesTokenCount, cachedContentTokenCount}` doesn't exist in Gemini CLI 0.37's output.
- Actual location: `stats.models.<name>.tokens.{input, candidates, cached}` — possibly multiple model entries (utility router + main).
- **Fix**: `parse_usage` walks `stats.models`, sums per-model tokens. `session_id` surfaced as `api_response.id`.
- Guarded with `Yojson.Safe.Util.Type_error` catch for missing fields.

## Tests

- Codex: 6 new `%test` cases (thread_id + text + usage, multiple agent_messages, command_execution skip, empty → Error, event mapping)
- Gemini: updated `parse_json_result success` to real shape + added multi-model aggregation test

## Test plan
- [x] `dune build --root .` clean
- [x] `dune runtest --root . lib/llm_provider` all pass
- [ ] CI green
- [x] Live probe verified against real binaries (captured samples in /tmp/{codex-json-sample.jsonl, gemini-stats-sample.json})

🤖 Generated with [Claude Code](https://claude.com/claude-code)