### PR TITLE
feat(llm_provider): expose cancel promise and per-line stderr callback on CLI transports

### DIFF
--- a/lib/llm_provider/cli_common_subprocess.ml
+++ b/lib/llm_provider/cli_common_subprocess.ml
@@ -13,59 +13,18 @@ let build_env ~cwd ~extra_env =
   in
   Array.of_list (cwd_prefix @ extras @ base)
 
-let read_all_lines flow buf =
-  let reader = Eio.Buf_read.of_flow flow ~max_size:(16 * 1024 * 1024) in
-  try
-    while true do
-      Buffer.add_string buf (Eio.Buf_read.line reader);
-      Buffer.add_char buf '\n'
-    done
-  with End_of_file -> ()
+(** Default stderr-line handler: route to [Eio.traceln] with a
+    transport-name prefix.  Transports that want silence pass
+    [~on_stderr_line:ignore]. *)
+let default_on_stderr_line ~name line =
+  Eio.traceln "[%s stderr] %s" name line
 
-let run_collect ~sw ~(mgr : _ Eio.Process.mgr) ~name ~cwd ~extra_env argv =
-  let t0 = Unix.gettimeofday () in
-  try
-    let r_stdout, w_stdout = Eio_unix.pipe sw in
-    let r_stderr, w_stderr = Eio_unix.pipe sw in
-    let env = build_env ~cwd ~extra_env in
-    let proc = Eio.Process.spawn ~sw mgr
-      ~stdout:(w_stdout :> Eio.Flow.sink_ty Eio.Resource.t)
-      ~stderr:(w_stderr :> Eio.Flow.sink_ty Eio.Resource.t)
-      ~env
-      argv
-    in
-    Eio.Flow.close w_stdout;
-    Eio.Flow.close w_stderr;
-    let stdout_buf = Buffer.create 4096 in
-    let stderr_buf = Buffer.create 256 in
-    Eio.Fiber.both
-      (fun () -> read_all_lines (r_stdout :> _ Eio.Flow.source) stdout_buf)
-      (fun () -> read_all_lines (r_stderr :> _ Eio.Flow.source) stderr_buf);
-    let status = Eio.Process.await proc in
-    let latency_ms = int_of_float ((Unix.gettimeofday () -. t0) *. 1000.0) in
-    let stdout_str = Buffer.contents stdout_buf in
-    let stderr_str = Buffer.contents stderr_buf in
-    match status with
-    | `Exited 0 ->
-      Ok { stdout = stdout_str; stderr = stderr_str; latency_ms }
-    | `Exited code ->
-      let detail = if stderr_str <> "" then stderr_str
-        else Printf.sprintf "exit code %d" code in
-      Error (Http_client.NetworkError {
-        message = Printf.sprintf "%s exited with code %d: %s" name code detail })
-    | `Signaled sig_num ->
-      Error (Http_client.NetworkError {
-        message = Printf.sprintf "%s killed by signal %d" name sig_num })
-  with
-  | Eio.Io _ as exn ->
-    Error (Http_client.NetworkError {
-      message = Printf.sprintf "subprocess I/O error: %s" (Printexc.to_string exn) })
-  | Unix.Unix_error (err, fn, arg) ->
-    Error (Http_client.NetworkError {
-      message = Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err) })
-
-let run_stream_lines ~sw ~(mgr : _ Eio.Process.mgr) ~name ~cwd ~extra_env
-    ~on_line ~cancel argv =
+(** Shared core.  Always reads stdout/stderr line-by-line from the live
+    pipe, always supports cooperative cancel.  [run_collect] and
+    [run_stream_lines] are thin wrappers that differ only in whether
+    they expose [on_line] to the caller. *)
+let run_core ~sw ~(mgr : _ Eio.Process.mgr) ~name ~cwd ~extra_env
+    ~on_line ~on_stderr_line ~cancel argv =
   let t0 = Unix.gettimeofday () in
   try
     let r_stdout, w_stdout = Eio_unix.pipe sw in
@@ -95,6 +54,19 @@ let run_stream_lines ~sw ~(mgr : _ Eio.Process.mgr) ~name ~cwd ~extra_env
               (Printexc.to_string exn))
        done with End_of_file -> ())
     in
+    let read_stderr () =
+      let reader = Eio.Buf_read.of_flow
+        (r_stderr :> _ Eio.Flow.source) ~max_size:(1024 * 1024) in
+      (try while true do
+         let line = Eio.Buf_read.line reader in
+         Buffer.add_string stderr_buf line;
+         Buffer.add_char stderr_buf '\n';
+         (try on_stderr_line line
+          with exn ->
+            Eio.traceln "cli_common_subprocess: on_stderr_line raised: %s"
+              (Printexc.to_string exn))
+       done with End_of_file -> ())
+    in
     let watch_cancel () =
       match cancel with
       | None -> Eio.Promise.await done_p
@@ -110,10 +82,7 @@ let run_stream_lines ~sw ~(mgr : _ Eio.Process.mgr) ~name ~cwd ~extra_env
     in
     Eio.Fiber.all [
       (fun () ->
-        Eio.Fiber.both
-          read_stdout
-          (fun () ->
-            read_all_lines (r_stderr :> _ Eio.Flow.source) stderr_buf);
+        Eio.Fiber.both read_stdout read_stderr;
         Eio.Promise.resolve done_r ());
       watch_cancel;
     ];
@@ -139,3 +108,22 @@ let run_stream_lines ~sw ~(mgr : _ Eio.Process.mgr) ~name ~cwd ~extra_env
   | Unix.Unix_error (err, fn, arg) ->
     Error (Http_client.NetworkError {
       message = Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err) })
+
+let run_collect ~sw ~mgr ~name ~cwd ~extra_env
+    ?(on_stderr_line = default_on_stderr_line ~name)
+    ?cancel argv =
+  run_core ~sw ~mgr ~name ~cwd ~extra_env
+    ~on_line:(fun _ -> ())
+    ~on_stderr_line
+    ~cancel
+    argv
+
+let run_stream_lines ~sw ~mgr ~name ~cwd ~extra_env
+    ~on_line
+    ?(on_stderr_line = default_on_stderr_line ~name)
+    ?cancel argv =
+  run_core ~sw ~mgr ~name ~cwd ~extra_env
+    ~on_line
+    ~on_stderr_line
+    ~cancel
+    argv

--- a/lib/llm_provider/cli_common_subprocess.mli
+++ b/lib/llm_provider/cli_common_subprocess.mli
@@ -11,27 +11,42 @@ type collect_result = {
   latency_ms: int;
 }
 
+val default_on_stderr_line : name:string -> string -> unit
+(** Default stderr-line handler used when [~on_stderr_line] is
+    omitted.  Routes each line to [Eio.traceln] with a
+    [\[NAME stderr\]] prefix. *)
+
 val run_collect :
   sw:Eio.Switch.t ->
   mgr:_ Eio.Process.mgr ->
   name:string ->
   cwd:string option ->
   extra_env:(string * string) list ->
+  ?on_stderr_line:(string -> unit) ->
+  ?cancel:unit Eio.Promise.t ->
   string list ->
   (collect_result, Http_client.http_error) result
-(** [run_collect ~sw ~mgr ~name ~cwd ~extra_env argv] spawns [argv]
-    and waits for it to exit.
+(** Spawn [argv] and wait for exit, returning the full captured
+    streams.
 
-    - [name] is used only in error messages (e.g. [claude], [gemini]).
+    - [name] is used in error messages and the default
+      [on_stderr_line] prefix.
     - [cwd]: when [Some dir], [PWD=dir] is prepended to the env. The
-      CLI is still launched from the parent's working directory;
-      callers relying on process CWD should embed an explicit
-      [--cwd]-like flag in [argv].
+      CLI still launches from the parent's CWD; callers relying on
+      process CWD should embed an explicit [--cwd]-like flag in
+      [argv].
     - [extra_env]: additional [KEY=VAL] pairs prepended to the env.
+    - [on_stderr_line]: called for every stderr line as it arrives.
+      Defaults to {!default_on_stderr_line}, which forwards to
+      [Eio.traceln].  Exceptions raised by the callback are caught
+      and traced; they do not abort the run.
+    - [cancel]: when resolved mid-run, [SIGINT] is delivered to the
+      subprocess via [Eio.Process.signal].  The process is still
+      drained to completion so the structured error reflects the
+      real exit status.
 
     Returns [Ok { stdout; stderr; latency_ms }] on a zero exit code,
-    or a [NetworkError] describing the failure (non-zero exit code,
-    signal, or I/O error). *)
+    or a [NetworkError] describing the failure. *)
 
 val run_stream_lines :
   sw:Eio.Switch.t ->
@@ -40,20 +55,19 @@ val run_stream_lines :
   cwd:string option ->
   extra_env:(string * string) list ->
   on_line:(string -> unit) ->
-  cancel:unit Eio.Promise.t option ->
+  ?on_stderr_line:(string -> unit) ->
+  ?cancel:unit Eio.Promise.t ->
   string list ->
   (collect_result, Http_client.http_error) result
-(** Streaming variant of {!run_collect}. Calls [on_line line] for every
-    newline-terminated chunk written to stdout while the process is still
-    running — enabling true live streaming rather than post-exit splitting.
-    The full stdout is still accumulated and returned in [collect_result]
-    for callers that also need the aggregate.
+(** Streaming variant of {!run_collect}.  Calls [on_line line] for
+    every newline-terminated chunk written to stdout while the
+    process is still running — enabling true live streaming rather
+    than post-exit splitting.  The full stdout is still accumulated
+    and returned in [collect_result] for callers that also need the
+    aggregate.
 
-    - [cancel]: when [Some p] and [p] is resolved mid-run, [SIGINT] is
-      sent to the subprocess. The process is still drained to completion
-      after the signal.
-    - Exceptions raised by [on_line] are caught and traced via
-      [Eio.traceln]; they do not abort the run.
-
-    Stderr is drained concurrently but not forwarded line-by-line; it is
-    available in the returned [collect_result.stderr]. *)
+    - [on_line] is required and called per stdout line as it arrives.
+      Exceptions raised by [on_line] are caught and traced; they do
+      not abort the run.
+    - [on_stderr_line] and [cancel] behave identically to
+      {!run_collect}. *)

--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -22,6 +22,10 @@ type config = {
        next turn sees the tool exchange.  Default [false] — the agent
        loop typically resolves tools itself and feeds only fresh text
        to the CLI. *)
+  cancel: unit Eio.Promise.t option;
+    (* When [Some p] and [p] is resolved mid-run, the [claude]
+       subprocess receives [SIGINT].  Applied to every call served
+       by the transport instance.  Default [None]. *)
 }
 
 let default_config = {
@@ -34,6 +38,7 @@ let default_config = {
   cwd = None;
   tool_use_via_stream_json = true;
   forward_tool_results = false;
+  cancel = None;
 }
 
 (* Prompt shaping, JSON helpers, and subprocess orchestration live in the
@@ -264,6 +269,7 @@ let run ~sw ~mgr ~(config : config) args =
     ~name:"claude"
     ~cwd:config.cwd
     ~extra_env:[]
+    ?cancel:config.cancel
     (config.claude_path :: args)
 
 let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
@@ -289,7 +295,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
         in
         match Cli_common_subprocess.run_stream_lines ~sw ~mgr
                 ~name:"claude" ~cwd:config.cwd ~extra_env:[]
-                ~on_line ~cancel:None
+                ~on_line ?cancel:config.cancel
                 argv with
         | Error _ as e -> { Llm_transport.response = e; latency_ms = 0 }
         | Ok { stdout = _; stderr = _; latency_ms } ->
@@ -325,7 +331,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
               ~cwd:config.cwd
               ~extra_env:[]
               ~on_line
-              ~cancel:None
+              ?cancel:config.cancel
               argv with
       | Error _ as e -> e
       | Ok _ ->

--- a/lib/llm_provider/transport_claude_code.mli
+++ b/lib/llm_provider/transport_claude_code.mli
@@ -43,6 +43,13 @@ type config = {
         fresh text to the CLI.
 
         @since 0.146.0 *)
+  cancel: unit Eio.Promise.t option;
+    (** When [Some p] and [p] resolves mid-run, the [claude]
+        subprocess receives [SIGINT] via [Eio.Process.signal].
+        Applied to every call served by this transport instance.
+        Default [None].
+
+        @since 0.148.0 *)
 }
 
 (** Sensible defaults: [claude] in PATH, no overrides. *)

--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -23,6 +23,9 @@ type config = {
   allowed_tools: string list;
   max_turns: int option;
   permission_mode: string option;
+  cancel: unit Eio.Promise.t option;
+    (* When [Some p] and [p] resolves mid-run, the [codex]
+       subprocess receives [SIGINT].  Default [None]. *)
 }
 
 let default_config = {
@@ -32,6 +35,7 @@ let default_config = {
   allowed_tools = [];
   max_turns = None;
   permission_mode = None;
+  cancel = None;
 }
 
 (* Prompt shaping, JSON helpers, and subprocess orchestration live in the
@@ -154,7 +158,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
       in
       match Cli_common_subprocess.run_stream_lines ~sw ~mgr
               ~name:"codex" ~cwd:config.cwd ~extra_env:[]
-              ~on_line ~cancel:None
+              ~on_line ?cancel:config.cancel
               argv with
       | Error _ as e -> { Llm_transport.response = e; latency_ms = 0 }
       | Ok { stdout = _; stderr = _; latency_ms } ->
@@ -175,7 +179,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
       in
       match Cli_common_subprocess.run_stream_lines ~sw ~mgr
               ~name:"codex" ~cwd:config.cwd ~extra_env:[]
-              ~on_line ~cancel:None
+              ~on_line ?cancel:config.cancel
               argv with
       | Error _ as e -> e
       | Ok _ ->

--- a/lib/llm_provider/transport_codex_cli.mli
+++ b/lib/llm_provider/transport_codex_cli.mli
@@ -32,6 +32,12 @@ type config = {
   permission_mode: string option;
     (** Accepted for parity; no equivalent flag on [codex].
         @since 0.140.0 *)
+  cancel: unit Eio.Promise.t option;
+    (** When [Some p] and [p] resolves mid-run, the [codex]
+        subprocess receives [SIGINT] via [Eio.Process.signal].
+        Default [None].
+
+        @since 0.148.0 *)
 }
 
 (** Sensible defaults: [codex] in PATH, no overrides. *)

--- a/lib/llm_provider/transport_gemini_cli.ml
+++ b/lib/llm_provider/transport_gemini_cli.ml
@@ -16,6 +16,9 @@ type config = {
   allowed_tools: string list;
   max_turns: int option;
   permission_mode: string option;
+  cancel: unit Eio.Promise.t option;
+    (* When [Some p] and [p] resolves mid-run, the [gemini]
+       subprocess receives [SIGINT].  Default [None]. *)
 }
 
 let default_config = {
@@ -27,6 +30,7 @@ let default_config = {
   allowed_tools = [];
   max_turns = None;
   permission_mode = None;
+  cancel = None;
 }
 
 (* Prompt shaping, JSON helpers, and subprocess orchestration live in the
@@ -128,6 +132,7 @@ let run ~sw ~mgr ~(config : config) argv =
     ~name:"gemini"
     ~cwd:config.cwd
     ~extra_env:[]
+    ?cancel:config.cancel
     argv
 
 (* Fires once per transport instance when any Claude-only config field

--- a/lib/llm_provider/transport_gemini_cli.mli
+++ b/lib/llm_provider/transport_gemini_cli.mli
@@ -35,6 +35,12 @@ type config = {
   permission_mode: string option;
     (** Accepted for parity; no equivalent flag on [gemini].
         @since 0.140.0 *)
+  cancel: unit Eio.Promise.t option;
+    (** When [Some p] and [p] resolves mid-run, the [gemini]
+        subprocess receives [SIGINT] via [Eio.Process.signal].
+        Default [None].
+
+        @since 0.148.0 *)
 }
 
 (** Sensible defaults: [gemini] in PATH, yolo enabled, no overrides. *)

--- a/test/dune
+++ b/test/dune
@@ -258,3 +258,7 @@
  (name test_raw_trace)
  (libraries agent_sdk alcotest yojson unix eio eio_main cohttp-eio))
 
+(test
+ (name test_cli_common_subprocess)
+ (libraries llm_provider alcotest eio eio_main))
+

--- a/test/test_cli_common_subprocess.ml
+++ b/test/test_cli_common_subprocess.ml
@@ -38,7 +38,7 @@ let test_stream_emits_lines_live () =
   let on_line line = seen := line :: !seen in
   match Llm_provider.Cli_common_subprocess.run_stream_lines ~sw ~mgr
           ~name:"sh" ~cwd:None ~extra_env:[]
-          ~on_line ~cancel:None
+          ~on_line
           [sh; "-c"; "printf '1\\n2\\n3\\n'"] with
   | Ok { stdout; _ } ->
     Alcotest.(check (list string)) "lines" ["1"; "2"; "3"] (List.rev !seen);
@@ -59,7 +59,7 @@ let test_stream_cancel_sends_sigint () =
     Eio.Promise.resolve cancel_r ());
   let result = Llm_provider.Cli_common_subprocess.run_stream_lines ~sw ~mgr
     ~name:"sh" ~cwd:None ~extra_env:[]
-    ~on_line ~cancel:(Some cancel_p)
+    ~on_line ~cancel:cancel_p
     (* "trap '' INT" would swallow SIGINT, so use default handler. The
        default sh behaviour on SIGINT is to exit with status 130 (signal). *)
     [sh; "-c"; "sleep 5"] in
@@ -70,11 +70,29 @@ let test_stream_cancel_sends_sigint () =
       true (String.length message > 0)
   | Error _ -> Alcotest.fail "expected NetworkError"
 
+let test_on_stderr_line_called_per_line () =
+  Eio_main.run @@ fun env ->
+  let mgr = Eio.Stdenv.process_mgr env in
+  Eio.Switch.run @@ fun sw ->
+  let err_lines = ref [] in
+  let on_stderr_line line = err_lines := line :: !err_lines in
+  match Llm_provider.Cli_common_subprocess.run_collect ~sw ~mgr
+          ~name:"sh" ~cwd:None ~extra_env:[]
+          ~on_stderr_line
+          [sh; "-c"; "printf 'warn1\\nwarn2\\n' >&2; printf ok"] with
+  | Ok { stdout; _ } ->
+    Alcotest.(check string) "stdout" "ok\n" stdout;
+    Alcotest.(check (list string)) "stderr lines forwarded"
+      ["warn1"; "warn2"] (List.rev !err_lines)
+  | Error _ -> Alcotest.fail "expected Ok"
+
 let () =
   Alcotest.run "cli_common_subprocess"
     [ "run_collect",
       [ Alcotest.test_case "ok"   `Quick test_run_collect_ok
       ; Alcotest.test_case "exit" `Quick test_run_collect_nonzero_exit
+      ; Alcotest.test_case "on_stderr_line forwards per-line"
+          `Quick test_on_stderr_line_called_per_line
       ]
     ; "run_stream_lines",
       [ Alcotest.test_case "emits lines live" `Quick test_stream_emits_lines_live


### PR DESCRIPTION
## Summary

Two orthogonal runtime/observability improvements to `Cli_common_subprocess` + the three transports:

### Cancel propagation (previously internal, now exposed)
`run_stream_lines` had cancel wiring from day one but transports hard-coded `~cancel:None`, so callers had no way to interrupt a long-running `claude`/`gemini`/`codex` subprocess.

- Add `cancel: unit Eio.Promise.t option` to each transport `config` (default `None`).
- Threads through every `run_collect` / `run_stream_lines` call.
- `run_collect` gains the same `?cancel` support — factored `run_core` shares the spawn + fiber topology.

### Stderr visibility (previously discarded)
stderr was captured into a buffer and silently dropped on success. Diagnostics from `claude` (`[WARN]`), `gemini` (`[YOLO mode]`), and `codex` (MCP errors) disappeared.

- Add `?on_stderr_line:(string -> unit)` to both collectors.
- Default: `default_on_stderr_line ~name` → `Eio.traceln "[NAME stderr] %s"`.
- Callers opt into silence via `~on_stderr_line:ignore` or plug a custom sink.

## Signature change
`run_stream_lines` used to require `~cancel: _ option`; now `?cancel: _` (optional labelled). Internal callers drop `~cancel:None`; the cancel test passes `~cancel:p` unwrapped.

## Tests
- New `on_stderr_line forwards per-line` verifies each stderr line reaches the callback in order
- Existing collect / exit / streaming / cancel tests pass unchanged (5/5)

## Test plan
- [x] `dune build --root .` clean
- [x] `dune runtest --root .` all pass
- [x] `dune exec test/test_cli_common_subprocess.exe` — 5/5 in 0.15s
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)