### PR TITLE
fix(agent_tools): drop printf tokens from correction_pipeline log

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -160,7 +160,7 @@ let find_and_execute_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tra
       match Correction_pipeline.run ~schema:tool.schema input with
       | Correction_pipeline.Fixed { corrected; corrections } ->
         if corrections <> [] then
-          Log.info _log "tool %s: correction_pipeline fixed %d field(s)"
+          Log.info _log "correction_pipeline fixed tool input fields"
             [ Log.S ("tool", name);
               Log.I ("fixes", List.length corrections) ];
         Ok corrected


### PR DESCRIPTION
## 증상

masc-mcp stdout tail (2026-04-16 02:24:00 KST):

```
[INFO] [oas:agent_tools] tool %s: correction_pipeline fixed %d field(s)
```

`%s`/`%d`가 리터럴로 출력되어 tool 이름과 수정 필드 수가 로그 본문에 보이지 않음. structured field(tool, fixes)에는 정상적으로 남아있어 sink가 JSON일 때만 제대로 읽힘.

## 원인

`Log.info _log : string -> field list -> unit` — 첫 인자는 static **message**이지 printf format string이 아님. `lib/agent/agent_tools.ml:163`에서 printf 관용(\`"tool %s: …"\`)을 그대로 둔 회귀.

다른 호출 (`tool_use_recovery.ml:202`, `completion_contract.ml:28`)은 static message 관용을 이미 따르고 있음.

## 변경

message를 `\"correction_pipeline fixed tool input fields\"`로 고정. tool 이름과 수정 개수는 기존 \`Log.S\`/\`Log.I\` 필드에서 그대로 노출됨 (중복 제거).

## 유입

- #902 (correction pipeline wiring)에서 해당 라인 도입.

## Test plan
- [x] \`dune build\` 통과
- [ ] stderr sink에서 \"correction_pipeline fixed tool input fields\" 형태로 출력되는지 다음 masc-mcp 실행에서 확인 (관측 기반)