### PR TITLE
docs(tool_result_store): drop MASC reference from docstring example

### DIFF
--- a/lib/tool_result_store.mli
+++ b/lib/tool_result_store.mli
@@ -17,7 +17,7 @@
 
 type config = {
   storage_dir: string;
-    (** Base directory.  Consumer-provided (e.g. [masc_data_dir]). *)
+    (** Base directory.  Consumer-provided (the application's data root). *)
   session_id: string;
     (** Session identifier.  Used as subdirectory name. *)
   threshold_chars: int;


### PR DESCRIPTION
## Summary
- Change `tool_result_store.mli:20` docstring example from `[masc_data_dir]` to a generic phrase
- No code change, no API change

## Why
OAS is a generic SDK. A docstring example naming a consumer-specific identifier (MASC) violates the "OAS does not know its consumers" boundary. Pure cosmetic cleanup.

## Test plan
- [x] `dune build --root .` green (docstring-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)