### PR TITLE
docs(claude-md): bump version stamp v0.99.1 -> v0.149.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # OAS — OCaml Agent SDK
 
-OCaml 5.x + Eio 기반 에이전트 SDK. v0.99.1.
+OCaml 5.x + Eio 기반 에이전트 SDK. v0.149.0.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
CLAUDE.md header cited `v0.99.1` while `dune-project` / latest tag are `v0.149.0` (via #949). ~50 minor version drift, pure docs.

## Verification
- `git show origin/main:dune-project | grep version` → `(version 0.149.0)`
- `git tag -l 'v*' --sort=-v:refname | head -1` → `v0.149.0`

## Test plan
- [x] No code changes
- [x] Diff limited to one CLAUDE.md line