### PR TITLE
docs: drop dangling cascade_* ocamldoc references

### DIFF
--- a/lib/llm_provider/constants.ml
+++ b/lib/llm_provider/constants.ml
@@ -12,10 +12,11 @@ module Http = struct
   (** HTTP status codes that trigger retry logic in {!Complete}. *)
   let retryable_codes = [429; 500; 502; 503; 529]
 
-  (** HTTP status codes that trigger cascade fallback in {!Cascade_config}.
-      Superset of [retryable_codes]: includes auth/forbidden errors
-      that are not retryable but should cascade to the next provider.
-      498 = Groq Flex tier capacity exceeded. *)
+  (** HTTP status codes that trigger cascade fallback in downstream
+      coordinators (OAS exposes the codes; orchestration lives outside
+      the SDK). Superset of [retryable_codes]: includes auth/forbidden
+      errors that are not retryable but should cascade to the next
+      provider. 498 = Groq Flex tier capacity exceeded. *)
   let cascadable_codes = [401; 403; 429; 498; 500; 502; 503; 529]
 end
 

--- a/lib/llm_provider/provider_registry.mli
+++ b/lib/llm_provider/provider_registry.mli
@@ -1,8 +1,8 @@
 (** Extensible provider registry with capability-aware queries.
 
-    Formalizes the hardcoded provider list from {!Cascade_config} into
-    a mutable registry. Providers can be registered at startup and
-    queried by name or capability predicate.
+    Formalizes the historical hardcoded provider list into a mutable
+    registry. Providers can be registered at startup and queried by
+    name or capability predicate.
 
     @since 0.69.0
 

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -442,7 +442,7 @@ let default_api_key_env_of_kind
   | Glm -> "ZAI_API_KEY"
   | OpenAI_compat | Ollama | Claude_code | Gemini_cli | Codex_cli -> ""
 
-(** Convert a [Provider_config.t] (from Cascade_config) into a
+(** Convert a [Llm_provider.Provider_config.t] into a
     [Provider.config] (for Agent Builder).  Keeps the conversion
     internal to OAS so consumers don't need their own adapters.
 

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -161,9 +161,9 @@ val custom_provider : name:string -> ?model_id:string -> ?api_key_env:string -> 
 val default_api_key_env_of_kind :
   Llm_provider.Provider_config.provider_kind -> string
 
-(** Convert a {!Llm_provider.Provider_config.t} (from Cascade_config)
-    into a {!config}.  Falls back to {!default_api_key_env_of_kind}
-    when [api_key] is empty.
+(** Convert a {!Llm_provider.Provider_config.t} into a {!config}.
+    Falls back to {!default_api_key_env_of_kind} when [api_key] is
+    empty.
     @since 0.84.0
     @since 0.87.0 — env var fallback *)
 val config_of_provider_config : Llm_provider.Provider_config.t -> config

--- a/lib/provider_bridge.ml
+++ b/lib/provider_bridge.ml
@@ -22,8 +22,7 @@ let is_glm_model_or_alias model_id =
   | _ -> false
 
 (** Resolve "auto" / aliases to concrete model IDs for legacy Provider.config
-    input. Previously delegated to {!Llm_provider.Cascade_model_resolve}, now
-    inlined here because cascade orchestration no longer lives in OAS.
+    input. Inlined here because cascade orchestration no longer lives in OAS.
 
     Local providers use {!Llm_provider.Discovery.first_discovered_model_id}
     for "auto"; cloud providers use environment-variable defaults. *)


### PR DESCRIPTION
## Summary
After #944 / #948 removed the cascade_* modules from OAS, five ocamldoc cross-references remained as dangling links and would raise odoc warnings.

Grep on `origin/main`:
```
$ rg 'Cascade_(config|fsm|throttle|health|model_resolve|executor)' lib/
lib/llm_provider/constants.ml:15          {!Cascade_config}
lib/llm_provider/provider_registry.mli:3  {!Cascade_config}
lib/provider.ml:445                       (from Cascade_config)
lib/provider.mli:164                      (from Cascade_config)
lib/provider_bridge.ml:25                 {!Llm_provider.Cascade_model_resolve}
```

All five are **comment-only**; none are code paths.

## Changes
| File | Change |
|------|--------|
| `lib/llm_provider/constants.ml` | Describe cascade fallback behaviour without the dead link |
| `lib/llm_provider/provider_registry.mli` | "hardcoded provider list from {!Cascade_config}" → "historical hardcoded provider list" |
| `lib/provider.ml` | Drop "(from Cascade_config)" in docstring |
| `lib/provider.mli` | Same |
| `lib/provider_bridge.ml` | Keep historical note, drop `{!Llm_provider.Cascade_model_resolve}` |

Post-edit grep returns 0 matches.

## Test plan
- [x] `dune build @lib/all --root .` clean
- [x] No code changes; only docstrings