### PR TITLE
fix(http): close all tracked transports + TLS-aware close (fixes MASC EMFILE: 4029 CLOSE_WAIT)

### DIFF
--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -136,32 +136,50 @@ let make_closing_client ~sw ~net ~uri =
   | Error _ as e, _ -> e
   | _, (Error _ as e) -> e
   | Ok addr, Ok tls_wrap ->
-      (* Track the raw socket separately for explicit close.
-         The socket fd is the resource that leaks; closing it releases the fd. *)
-      let last_sock :
-        [ `Generic ] Eio.Net.stream_socket_ty Eio.Resource.t option ref =
-        ref None
+      (* Track every transport returned by [connect] so switch release can
+         close all of them — not just the most recent one.  [cohttp_eio]
+         may call [connect] multiple times per client (keep-alive refresh,
+         retry after transient error, etc.), and any socket we stop
+         referencing leaks its fd and leaves the TCP endpoint in
+         CLOSE_WAIT.
+
+         We also store the TLS-wrapped resource (not the raw socket) so
+         [Eio.Resource.close] triggers TLS close_notify before the TCP
+         layer closes.  Raw-socket close without TLS shutdown causes the
+         peer (e.g. GLM / Cloudflare-fronted endpoints) to interpret the
+         half-close as "keep waiting" and hold the connection in
+         CLOSE_WAIT indefinitely. *)
+      let tracked_transports :
+        [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t list ref =
+        ref []
       in
       let connect ~sw:conn_sw _uri =
         let sock = Eio.Net.connect ~sw:conn_sw net addr in
-        last_sock := Some sock;
-        match tls_wrap with
-        | Some wrap ->
-            (wrap uri sock
-              :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
-        | None -> (sock :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
+        let transport :
+          [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t =
+          match tls_wrap with
+          | Some wrap ->
+              (wrap uri sock
+                :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
+          | None ->
+              (sock
+                :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
+        in
+        tracked_transports := transport :: !tracked_transports;
+        transport
       in
       let client = Cohttp_eio.Client.make_generic connect in
       Eio.Switch.on_release sw (fun () ->
-        match !last_sock with
-        | None -> ()
-        | Some sock ->
-            last_sock := None;
-            (try Eio.Net.close sock with
-             | Eio.Cancel.Cancelled _ as e -> raise e
-             | exn ->
-                 log_close_failure ~url:(Uri.to_string uri)
-                   ~message:(Printexc.to_string exn)));
+        let transports = !tracked_transports in
+        tracked_transports := [];
+        List.iter
+          (fun t ->
+            try Eio.Resource.close t with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+                log_close_failure ~url:(Uri.to_string uri)
+                  ~message:(Printexc.to_string exn))
+          transports);
       Ok client
 
 let get_sync ~sw:_ ~net ~url ~headers =


### PR DESCRIPTION
## Summary

MASC 운영 서버가 오늘 EMFILE 로 사실상 가사 상태 (accept/checkpoint/state.json 전부 실패). 진단 결과 GLM / Zenlayer-fronted endpoint 에 대한 **CLOSE_WAIT 소켓 4029개** 가 누적되어 프로세스 fd limit 소진.

## Linked issue

Fresh production incident, 2026-04-16 08:42 UTC. 근거 dump (masc-mcp pid 37007, 직전 cycle):
``\`
$ lsof -p 37007 | awk '$5=="IPv4"' | wc -l
4102
$ lsof -p 37007 | awk '$5=="IPv4"{for(i=NF;i>=1;i--) if($i ~ /\(.*\)$/) {print $i; break}}' | sort | uniq -c
  4029 (CLOSE_WAIT)
    36 (ESTABLISHED)
    15 (CLOSED)
     3 (LISTEN)
$ host 128.14.69.121 | whois
NetName: ZL-LAX3-004 / OrgName: Zenlayer Inc  (= GLM-fronted CDN)
``\`

## Product impact

- **Before**: cascade 가 GLM 에 몰릴수록 CLOSE_WAIT 선형 증가 → 몇 시간 안에 fd 소진 → 서버 멈춤.
- **After**: 각 요청당 연결이 TLS-graceful-shutdown 으로 정리됨. 동일 트래픽에서 ESTABLISHED ~수십 수준 유지.

## Evidence — two defects in ``make_closing_client``

### 1. Last-socket only tracking

``\`ocaml
let last_sock : stream_socket option ref = ref None in
let connect _ =
  let sock = Eio.Net.connect ~sw:conn_sw net addr in
  last_sock := Some sock;  (* overwritten on every reconnect *)
  ...
``\`

``Cohttp_eio`` 는 keep-alive refresh / transient retry 로 ``connect`` 를 여러 번 호출할 수 있음. 이전 ``sock`` 참조는 덮어쓰기 + 원래 close 호출에 포함 안 됨 → fd leak.

**Fix**: ``tracked_transports : resource list ref`` 로 **모든** connect 결과 누적. switch-release 시 전량 close.

### 2. Raw-socket close skips TLS shutdown

원본 코드가 TLS-wrapped resource 가 아닌 raw ``sock`` 만 저장 + ``Eio.Net.close sock`` 호출. TLS 레이어의 ``close_notify`` handshake 건너뜀 → peer (Cloudflare / GLM edge) 가 abrupt FIN 을 half-close 로 해석 + orderly shutdown 기다리며 CLOSE_WAIT 에 무한 parking.

**Fix**: TLS-wrapped 또는 plain transport resource 를 저장하고 ``Eio.Resource.close`` 호출. TLS 레이어가 close_notify → socket close 순서대로 처리.

## Review evidence

### Build
``dune build --root . lib/llm_provider/`` clean, 0 warnings.

### Tests
``\`
$ dune runtest --root .
... raw_trace       11/11 pass
... runtime         12/12 pass
... (기존 http-adjacent suites 전량 pass)
``\`

### Supersedes
``fix/http-client-fd-leak`` (commit ``93e61c1e``, 2026-03-26). 당시 PR 은 per-request ``Eio.Switch.run`` 을 추가했는데, 이는 scope 레벨 격리로 **필요**했지만 (ref-option 덮어쓰기 + raw-socket close) 두 defect 가 남아 있어서 **충분하지 않았음**. 그래서 GLM cascade 가 429 압력 받을 때 여전히 재발.

## Test plan

- [x] ``dune build --root .`` clean
- [x] ``dune runtest --root .`` 영향 범위 전량 pass
- [ ] Staging deploy + 2 시간 ``lsof CLOSE_WAIT`` 모니터링 (Vincent 님 환경)
- [ ] Ready 전환 전 최종 CI green 확인

## Reason for Draft

Production incident fix 이지만 **프로덕션 cascade 경로** 를 건드리는 만큼 사용자 리뷰 받고 Ready 전환. 재현 evidence 다 있으니 빠른 리뷰 가능.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>