### PR TITLE
fix(http-client): close all sockets + TLS wrapper, not just the last one

### DIFF
--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -136,32 +136,53 @@ let make_closing_client ~sw ~net ~uri =
   | Error _ as e, _ -> e
   | _, (Error _ as e) -> e
   | Ok addr, Ok tls_wrap ->
-      (* Track the raw socket separately for explicit close.
-         The socket fd is the resource that leaks; closing it releases the fd. *)
-      let last_sock :
-        [ `Generic ] Eio.Net.stream_socket_ty Eio.Resource.t option ref =
-        ref None
+      (* Track every resource handed to cohttp-eio so we can close it on
+         switch release. Cohttp-eio 6.1.1 does not reliably close the
+         underlying TCP fd on macOS even when the connect scope exits
+         (issue #3221), so we keep the authoritative reference here.
+
+         Two design changes vs the prior single-slot version:
+
+         1. List, not option. When cohttp-eio redials under the same
+            switch — redirect, retry, or any future pool reuse — every
+            new connection must be tracked. The previous
+            [last_sock : _ option ref] retained only the last socket
+            and leaked N-1 fds per switch lifetime.
+
+         2. Store the TLS wrapper (not the raw sock) on the HTTPS path.
+            Closing the wrapper propagates an orderly close down to the
+            raw socket, matching the shutdown the wrapper itself would
+            try to run at its own on_release. Closing the raw sock
+            directly bypasses the wrapper and can leave the TLS flow
+            with a dangling reference. *)
+      let sockets :
+        [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t list ref =
+        ref []
       in
       let connect ~sw:conn_sw _uri =
         let sock = Eio.Net.connect ~sw:conn_sw net addr in
-        last_sock := Some sock;
-        match tls_wrap with
-        | Some wrap ->
-            (wrap uri sock
-              :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
-        | None -> (sock :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
+        let resource :
+          [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t =
+          match tls_wrap with
+          | Some wrap ->
+              (wrap uri sock
+                :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
+          | None ->
+              (sock :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
+        in
+        sockets := resource :: !sockets;
+        resource
       in
       let client = Cohttp_eio.Client.make_generic connect in
       Eio.Switch.on_release sw (fun () ->
-        match !last_sock with
-        | None -> ()
-        | Some sock ->
-            last_sock := None;
-            (try Eio.Net.close sock with
-             | Eio.Cancel.Cancelled _ as e -> raise e
-             | exn ->
-                 log_close_failure ~url:(Uri.to_string uri)
-                   ~message:(Printexc.to_string exn)));
+        let to_close = !sockets in
+        sockets := [];
+        List.iter (fun resource ->
+          try Eio.Flow.close resource with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+              log_close_failure ~url:(Uri.to_string uri)
+                ~message:(Printexc.to_string exn)) to_close);
       Ok client
 
 let get_sync ~sw:_ ~net ~url ~headers =


### PR DESCRIPTION
Related to jeong-sik/masc-mcp#7490.

## Symptom

Live masc-mcp server (PID 37007, observed 2026-04-16) accumulated **4083 open IPv4 sockets** out of 4103 total FDs (99.5%), nearly all to \`api.z.ai\` (GLM provider). The process returned \`500 Internal Server Error: Sys_error(\"Too many open files\")\` and could no longer open outbound HTTPS connections.

## Root cause

Two interlocking bugs in \`lib/llm_provider/http_client.ml :: make_closing_client\`:

### 1. Single-slot socket tracking leaks N-1 sockets per switch

\`let last_sock : _ option ref = ref None\` records only the **most recently opened** socket. Cohttp-eio's \`connect\` callback can fire more than once per switch lifetime (redirects, retries, any future connection pool), and only the latest is handed to the \`on_release\` closer. Everything before it silently leaked.

Replaced with \`let sockets : _ list ref = ref []\` + \`List.iter Eio.Flow.close\` on release.

### 2. Storing raw socket on the TLS path bypasses the wrapper's shutdown

On the HTTPS branch the code passed \`wrap uri sock\` (the TLS-wrapped flow) to cohttp-eio but stored the raw \`sock\` for close. \`Eio.Net.close sock\` on the raw socket skips the TLS wrapper's own shutdown sequence. When the wrapper's \`on_release\` runs it finds a dangling inner-flow reference and the fd is never properly released.

Switched to storing the TLS wrapper itself and calling \`Eio.Flow.close\` on it — closing the wrapper propagates an orderly close down to the raw socket, which is the path that actually releases the fd.

## Diff

One file, \`+41 / -20\`:

\`\`\`
 lib/llm_provider/http_client.ml | 61 +++++++++++++++++++++++++++--------------
 1 file changed, 41 insertions(+), 20 deletions(-)
\`\`\`

## Verification

- \`dune build --root .\` exits 0
- \`dune test --root .\` exits 0 (all existing suites pass; no regressions)
- No new dependencies
- Live leak reproduction steps documented in jeong-sik/masc-mcp#7490

## Non-scope

- **FD leak regression test**: needs a mock HTTPS server + N-request loop. Non-trivial for this PR; tracked as follow-up.
- **Direct \`Cohttp_eio.Client.make\` call sites elsewhere in OAS** (\`otel_export.ml\`, \`api.ml\`, \`agent_registry.ml\`, \`provider_intf.ml\`) need the same treatment. Separate PR so the fix is surgical and reviewable.
- Upstream cohttp-eio macOS socket-close bug — workaround stays here; upstream fix separate.

## Why this unblocks masc-mcp

The GLM cascade is the hot path for roughly half the keeper fleet. Every one of their streaming or completion calls goes through \`make_closing_client\`. With the fix landed and the OAS pin bumped in masc-mcp, the \`Too many open files\` error class stops occurring even without an operator restart cadence.

## Test plan

- [x] local build green
- [x] local \`dune test\` green
- [ ] CI green
- [ ] After OAS pin lands in masc-mcp, observe \`lsof -p $(pid) | awk '\$5==\"IPv4\"' | wc -l\` for 1 hour under normal keeper load; expect the count to stay flat instead of climbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)