### PR TITLE
docs: remove remaining MASC consumer references from OAS (sequel to #953)

### DIFF
--- a/lib/judge/judge.mli
+++ b/lib/judge/judge.mli
@@ -6,7 +6,7 @@
 
     Cascade is not OAS's responsibility — callers that need
     multi-provider failover select a single provider per call
-    (e.g. MASC's orchestrator chooses from cascade.json and
+    (e.g. a downstream orchestrator resolves its cascade and
     passes the winning [Provider_config.t] here).
 
     @since 0.78.0

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -61,8 +61,8 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
      and every keeper turn errors out in <2s.
 
      Empirical rationale:
-     - 2026-04-11 incident 1: masc-mcp's 35b-a3b model was evicted ~every
-       30 min because each keeper turn reset keep_alive to the 5m default.
+     - 2026-04-11 incident 1: a 35b-a3b model was evicted ~every 30 min
+       because each consumer turn reset keep_alive to the 5m default.
      - 2026-04-11 incident 2: after pinning keep_alive=-1 (PR #813), every
        ollama request failed with the duration parse error above because
        -1 was serialized as [`String "-1"]. This fix sends an integer for

--- a/lib/llm_provider/diag.mli
+++ b/lib/llm_provider/diag.mli
@@ -1,8 +1,8 @@
 (** Structured diagnostic logging for llm_provider.
 
     Default sink: stderr with structured prefix and level filtering.
-    Consumer (agent_sdk, masc-mcp) can replace the sink at startup
-    to route into their own structured logging pipeline.
+    Consumers can replace the sink at startup to route into their
+    own structured logging pipeline.
 
     Debug-level messages are gated by [OAS_LLM_PROVIDER_DEBUG=1]
     when using the default sink. Consumer sinks receive all levels

--- a/lib/llm_provider/metrics.ml
+++ b/lib/llm_provider/metrics.ml
@@ -23,9 +23,8 @@ let noop = {
 (* ── Global registry ────────────────────────────────── *)
 
 (** Process-wide metrics sink used when a caller does not pass [~metrics]
-    explicitly.  Initialised to [noop].  Consumers (masc-mcp, custom
-    deployments) can install their own instance once at startup via
-    [set_global].
+    explicitly.  Initialised to [noop].  Consumers can install their
+    own instance once at startup via [set_global].
 
     Access is guarded by an atomic so reads from a fiber holding the
     cached reference race-cleanly with a concurrent [set_global]; the

--- a/lib/llm_provider/metrics.mli
+++ b/lib/llm_provider/metrics.mli
@@ -43,7 +43,8 @@ val noop : t
     (before any keeper/agent cascade traffic) to avoid that gap.
 
     Intended to be called once at startup from the host application
-    (e.g. masc-mcp installs a Prometheus-backed instance). Thread-safe:
+    (e.g. a downstream consumer installs a Prometheus-backed instance).
+    Thread-safe:
     a concurrent [set_global] is published atomically via [Atomic.set];
     fibers already holding the previous reference continue to use it
     until their current call returns. *)

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -650,7 +650,8 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
 
      Hard budget gate (OAS-2): when context_compact_ratio is not configured,
      a ratio >= 0.9 still triggers compaction. This prevents the silent
-     pass-through that caused masc-improver CTX 101% (#7083). *)
+     pass-through that caused a downstream consumer's CTX 101% overrun
+     (observed in upstream issue #7083). *)
   let prep =
     let watermark = match agent.state.config.context_compact_ratio with
       | Some w when w > 0.0 && w < 1.0 -> w

--- a/lib/tool_selector.mli
+++ b/lib/tool_selector.mli
@@ -151,7 +151,7 @@ val auto : tools:Tool.t list -> strategy
 
     Cascade is not OAS's responsibility. Callers that want multi-
     provider failover resolve the winning provider externally (e.g.
-    from [cascade.json] in MASC) and pass it here.
+    from a downstream cascade configuration) and pass it here.
 
     Usage:
     {[

--- a/lib/typed_tool_safe.mli
+++ b/lib/typed_tool_safe.mli
@@ -8,7 +8,8 @@
     This is a compile-time-only layer — no runtime cost. The phantom
     parameter is erased by {!to_typed_tool}.
 
-    Inspired by MASC's {!Typed_state} GADT PoC (phantom task status).
+    Phantom-type permission encoding inspired by a typed-state GADT
+    proof of concept (phantom task status).
 
     @stability Evolving
     @since 0.120.0 *)


### PR DESCRIPTION
## Summary

#953 dropped the `masc_data_dir` reference from `tool_result_store.mli`. Eight more consumer-specific MASC mentions remained across `lib/` docstrings and comments. Per the "OAS does not know its consumers" boundary called out in #953's body, replace them with generic phrasing.

## Grep on `origin/main` before this PR

```
lib/judge/judge.mli:9                  "(e.g. MASC's orchestrator ...)"
lib/llm_provider/backend_ollama.ml:64  "masc-mcp's 35b-a3b model..."
lib/llm_provider/diag.mli:4            "Consumer (agent_sdk, masc-mcp)..."
lib/llm_provider/metrics.ml:26         "Consumers (masc-mcp, custom...)"
lib/llm_provider/metrics.mli:46        "(e.g. masc-mcp installs...)"
lib/pipeline/pipeline.ml:653           "pass-through that caused masc-improver CTX 101%"
lib/tool_selector.mli:154              "from [cascade.json] in MASC"
lib/typed_tool_safe.mli:11             "Inspired by MASC's {!Typed_state}..."
```

## Mapping

| File | Before | After |
|------|--------|-------|
| `judge.mli:9` | "e.g. MASC's orchestrator chooses from cascade.json" | "e.g. a downstream orchestrator resolves its cascade" |
| `backend_ollama.ml:64` | "masc-mcp's 35b-a3b model was evicted..." | "a 35b-a3b model was evicted..." |
| `diag.mli:4` | "Consumer (agent_sdk, masc-mcp)" | "Consumers can replace the sink..." |
| `metrics.ml:26` | "Consumers (masc-mcp, custom deployments)" | "Consumers can install their own instance" |
| `metrics.mli:46` | "e.g. masc-mcp installs a Prometheus-backed instance" | "e.g. a downstream consumer installs..." |
| `pipeline.ml:653` | "caused masc-improver CTX 101% (#7083)" | "caused a downstream consumer's CTX 101% overrun (observed in upstream issue #7083)" |
| `tool_selector.mli:154` | "from [cascade.json] in MASC" | "from a downstream cascade configuration" |
| `typed_tool_safe.mli:11` | "Inspired by MASC's {!Typed_state} GADT PoC" | "Phantom-type permission encoding inspired by a typed-state GADT proof of concept" |

Historical PR numbers (`#7083`, `#813`) preserved where they help future readers trace context. The `{!Typed_state}` ocamldoc link was dangling across repos anyway and is now narrative-only.

## Post-edit verification

- `rg -ni 'MASC|masc-mcp|masc-improver|masc_data_dir' lib/` → 0 matches
- `dune build @lib/all --root .` → clean

## Test plan

- [x] No code changes
- [x] Build clean
- [x] 0 remaining MASC refs in `lib/`