### PR TITLE
diag(http): add lifecycle logging for transport connect/close (oas#965 investigation)

### DIFF
--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -166,15 +166,25 @@ let make_closing_client ~sw ~net ~uri =
                 :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
         in
         tracked_transports := transport :: !tracked_transports;
+        Diag.debug "http_client"
+          "connect: new transport #%d for %s" (List.length !tracked_transports) (Uri.to_string uri);
         transport
       in
       let client = Cohttp_eio.Client.make_generic connect in
       Eio.Switch.on_release sw (fun () ->
         let transports = !tracked_transports in
         tracked_transports := [];
+        let n = List.length transports in
+        if n > 0 then
+          Diag.debug "http_client"
+            "on_release: closing %d transport(s) for %s" n (Uri.to_string uri);
         List.iter
           (fun t ->
-            try Eio.Resource.close t with
+            try
+              Eio.Resource.close t;
+              Diag.debug "http_client"
+                "transport closed for %s" (Uri.to_string uri)
+            with
             | Eio.Cancel.Cancelled _ as e -> raise e
             | exn ->
                 log_close_failure ~url:(Uri.to_string uri)


### PR DESCRIPTION
## Summary

oas#965 (잔여 CLOSE_WAIT) 진단용 로깅 추가. ``OAS_LLM_PROVIDER_DEBUG=1`` 환경 변수로 활성화.

## Evidence

fd-level 추적 결과:
- 60초 동안 CLOSE_WAIT **해제 0건** (307건 전부 잔존)
- 신규 **+10건** 추가

→ ``Eio.Resource.close`` 가 호출되지 않거나 호출돼도 TCP FIN 미전송. 이 로깅으로 "on_release 미호출" vs "close 호출됐지만 OS 미반응" 판별.

## Test plan
- ``dune build`` clean
- Deploy with ``OAS_LLM_PROVIDER_DEBUG=1`` → 로그에 connect/close 카운트 비교
- CLOSE_WAIT 증가와 "transport closed" 로그 빈도 대조

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>