### PR TITLE
feat(glm): structured error classification with semantic HTTP code normalization

### DIFF
--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -12,7 +12,74 @@
 
 open Types
 
-exception Glm_api_error of string
+type glm_error_class =
+  | Glm_quota_exceeded
+  | Glm_rate_limited
+  | Glm_auth_error
+  | Glm_server_error
+  | Glm_invalid_request
+
+type glm_error = {
+  code: string;
+  message: string;
+  error_class: glm_error_class;
+}
+
+let contains_ci ~haystack ~needle =
+  let h = String.lowercase_ascii haystack in
+  let n = String.lowercase_ascii needle in
+  let nlen = String.length n in
+  let hlen = String.length h in
+  if nlen = 0 || nlen > hlen then false
+  else
+    let rec scan i =
+      if i > hlen - nlen then false
+      else if String.sub h i nlen = n then true
+      else scan (i + 1)
+    in
+    scan 0
+
+(** Classify GLM error by code first, message fallback.
+    Code mapping from docs.z.ai/api-reference/api-code:
+    - 1000-1004,1100-1120: auth/account
+    - 1200-1261: parameter/request (non-cascadeable)
+    - 1113: account arrears (quota)
+    - 1300: policy block (non-cascadeable)
+    - 1301: unsafe content (non-cascadeable)
+    - 1302,1303,1305,1312: transient rate/load limit (cascadeable+retryable)
+    - 1304,1308,1310: quota exhausted (cascadeable, not retryable)
+    - 1309,1311,1313: subscription/plan (quota)
+    - 1230,1234,500: server error *)
+let classify_glm_error ~code ~message : glm_error_class =
+  match code with
+  | "1000" | "1001" | "1002" | "1003" | "1004"
+  | "1100" | "1110" | "1111" | "1112" | "1120"
+  | "1220" -> Glm_auth_error
+  | "1302" | "1303" | "1305" | "1312" -> Glm_rate_limited
+  | "1113" | "1304" | "1308" | "1309" | "1310"
+  | "1311" | "1313" -> Glm_quota_exceeded
+  | "1230" | "1234" | "500" -> Glm_server_error
+  | "1300" | "1301" | "1200" | "1210" | "1211"
+  | "1212" | "1213" | "1214" | "1215" | "1231"
+  | "1261" -> Glm_invalid_request
+  | _ ->
+    if contains_ci ~haystack:message ~needle:"usage limit"
+       || contains_ci ~haystack:message ~needle:"quota"
+       || contains_ci ~haystack:message ~needle:"exceeded" then
+      Glm_quota_exceeded
+    else if contains_ci ~haystack:message ~needle:"rate limit" then
+      Glm_rate_limited
+    else
+      Glm_invalid_request
+
+let http_code_of_glm_error_class = function
+  | Glm_quota_exceeded -> 429
+  | Glm_rate_limited -> 429
+  | Glm_auth_error -> 401
+  | Glm_server_error -> 500
+  | Glm_invalid_request -> 400
+
+exception Glm_api_error of glm_error
 
 (* ── Request building ────────────────────────────── *)
 
@@ -58,7 +125,7 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
 (** GLM error responses use string error codes:
     [{"error":{"code":"1305","message":"..."}}]
     Standard OpenAI uses numeric HTTP codes. *)
-let check_glm_error body =
+let check_glm_error body : glm_error option =
   try
     let json = Yojson.Safe.from_string body in
     let open Yojson.Safe.Util in
@@ -73,7 +140,8 @@ let check_glm_error body =
         let message = err |> member "message" |> to_string_option
           |> Option.value ~default:"Unknown GLM API error"
         in
-        Some (Printf.sprintf "GLM error %s: %s" code message)
+        let error_class = classify_glm_error ~code ~message in
+        Some { code; message; error_class }
   with Yojson.Json_error _ -> None
 
 (** Extract reasoning_content from GLM response and prepend as Thinking block.
@@ -97,10 +165,12 @@ let extract_reasoning_content (resp : api_response) body : api_response =
 
 let parse_response body =
   match check_glm_error body with
-  | Some msg -> raise (Glm_api_error msg)
+  | Some err -> raise (Glm_api_error err)
   | None ->
       (match Backend_openai_parse.parse_openai_response_result body with
-       | Error msg -> raise (Glm_api_error msg)
+       | Error msg ->
+           raise (Glm_api_error { code = "parse"; message = msg;
+                                  error_class = Glm_invalid_request })
        | Ok resp -> extract_reasoning_content resp body)
 
 (* ── Streaming ───────────────────────────────────── *)
@@ -163,7 +233,7 @@ let%test "build_request with thinking=false injects disabled" =
 let%test "check_glm_error detects string code" =
   let body = {|{"error":{"code":"1305","message":"service overloaded"}}|} in
   match check_glm_error body with
-  | Some msg -> String.length msg > 0
+  | Some err -> err.code = "1305" && err.error_class = Glm_server_error
   | None -> false
 
 let%test "check_glm_error returns None for valid response" =
@@ -173,8 +243,35 @@ let%test "check_glm_error returns None for valid response" =
 let%test "check_glm_error handles int code" =
   let body = {|{"error":{"code":400,"message":"bad request"}}|} in
   match check_glm_error body with
-  | Some msg -> String.length msg > 0
+  | Some err -> err.code = "400"
   | None -> false
+
+let%test "classify quota exceeded from message" =
+  classify_glm_error ~code:"unknown" ~message:"You have reached your specified API usage limits" = Glm_quota_exceeded
+
+let%test "classify rate limited from code 1113" =
+  classify_glm_error ~code:"1113" ~message:"whatever" = Glm_rate_limited
+
+let%test "classify auth from code 1001" =
+  classify_glm_error ~code:"1001" ~message:"whatever" = Glm_auth_error
+
+let%test "classify quota from code 1304 (daily limit)" =
+  classify_glm_error ~code:"1304" ~message:"whatever" = Glm_quota_exceeded
+
+let%test "classify quota from code 1308 (usage limit)" =
+  classify_glm_error ~code:"1308" ~message:"whatever" = Glm_quota_exceeded
+
+let%test "classify server error from code 1305" =
+  classify_glm_error ~code:"1305" ~message:"whatever" = Glm_rate_limited
+
+let%test "classify invalid request from code 1301 (unsafe content)" =
+  classify_glm_error ~code:"1301" ~message:"whatever" = Glm_invalid_request
+
+let%test "http_code quota maps to 429" =
+  http_code_of_glm_error_class Glm_quota_exceeded = 429
+
+let%test "http_code auth maps to 401" =
+  http_code_of_glm_error_class Glm_auth_error = 401
 
 let%test "extract_reasoning_content prepends thinking block" =
   let resp = { id = "x"; model = "glm-4.7"; stop_reason = EndTurn;

--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -233,7 +233,7 @@ let%test "build_request with thinking=false injects disabled" =
 let%test "check_glm_error detects string code" =
   let body = {|{"error":{"code":"1305","message":"service overloaded"}}|} in
   match check_glm_error body with
-  | Some err -> err.code = "1305" && err.error_class = Glm_server_error
+  | Some err -> err.code = "1305" && err.error_class = Glm_rate_limited
   | None -> false
 
 let%test "check_glm_error returns None for valid response" =
@@ -249,8 +249,8 @@ let%test "check_glm_error handles int code" =
 let%test "classify quota exceeded from message" =
   classify_glm_error ~code:"unknown" ~message:"You have reached your specified API usage limits" = Glm_quota_exceeded
 
-let%test "classify rate limited from code 1113" =
-  classify_glm_error ~code:"1113" ~message:"whatever" = Glm_rate_limited
+let%test "classify quota from code 1113 (arrears)" =
+  classify_glm_error ~code:"1113" ~message:"whatever" = Glm_quota_exceeded
 
 let%test "classify auth from code 1001" =
   classify_glm_error ~code:"1001" ~message:"whatever" = Glm_auth_error
@@ -261,7 +261,7 @@ let%test "classify quota from code 1304 (daily limit)" =
 let%test "classify quota from code 1308 (usage limit)" =
   classify_glm_error ~code:"1308" ~message:"whatever" = Glm_quota_exceeded
 
-let%test "classify server error from code 1305" =
+let%test "classify rate limited from code 1305" =
   classify_glm_error ~code:"1305" ~message:"whatever" = Glm_rate_limited
 
 let%test "classify invalid request from code 1301 (unsafe content)" =

--- a/lib/llm_provider/backend_glm.mli
+++ b/lib/llm_provider/backend_glm.mli
@@ -17,7 +17,31 @@
 
 open Types
 
-exception Glm_api_error of string
+(** Semantic classification of a GLM API error.
+    Determined by error code (structured) with message fallback. *)
+type glm_error_class =
+  | Glm_quota_exceeded
+  | Glm_rate_limited
+  | Glm_auth_error
+  | Glm_server_error
+  | Glm_invalid_request
+
+type glm_error = {
+  code: string;
+  message: string;
+  error_class: glm_error_class;
+}
+
+exception Glm_api_error of glm_error
+
+(** Classify a GLM error code + message into a semantic class.
+    Code-based classification takes priority; message keywords are fallback. *)
+val classify_glm_error : code:string -> message:string -> glm_error_class
+
+(** Map a GLM error class to the equivalent HTTP status code.
+    Used by complete.ml to normalize provider-specific codes
+    into the cascade-compatible error path. *)
+val http_code_of_glm_error_class : glm_error_class -> int
 
 (** Build a GLM chat completion request body.
     Delegates to {!Backend_openai.build_request} and injects

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -325,9 +325,11 @@ let complete_http ~sw ~net
           | Backend_gemini.Gemini_api_error msg ->
               Diag.error "complete" "Gemini API error: %s" msg;
               Error (Http_client.HttpError { code = 400; body = "Gemini API error: " ^ msg })
-          | Backend_glm.Glm_api_error msg ->
-              Diag.error "complete" "GLM API error: %s" msg;
-              Error (Http_client.HttpError { code = 400; body = "GLM API error: " ^ msg })
+          | Backend_glm.Glm_api_error err ->
+              let semantic_code = Backend_glm.http_code_of_glm_error_class err.error_class in
+              let body = Printf.sprintf "GLM error %s: %s" err.code err.message in
+              Diag.error "complete" "GLM API error (code=%s class=%d): %s" err.code semantic_code err.message;
+              Error (Http_client.HttpError { code = semantic_code; body })
           | exn ->
               let exn_str = Printexc.to_string exn in
               Diag.error "complete" "Unexpected parsing exception: %s" exn_str;


### PR DESCRIPTION
## Summary

- Replace `Glm_api_error of string` with structured `glm_error` record: `{ code; message; error_class }`
- `classify_glm_error` uses GLM error code (primary) + message keyword (fallback), based on official ZhipuAI docs
- `complete.ml` maps error class → semantic HTTP code via `http_code_of_glm_error_class` instead of hardcoding 400
- Quota errors (1304/1308/1310) → 429, auth errors → 401, server errors → 500

## Problem

GLM returns HTTP 400 for quota exhaustion ("API usage limits"). OAS previously mapped all `Glm_api_error` to `HttpError { code = 400 }`, which downstream cascade classified as non-cascadeable `InvalidRequest`. Result: 5 candidate models in cascade, 0 fallback attempts, keepers stall.

## Fix (Parse, Don't Validate)

Error classification happens at the source (`backend_glm.ml`) where structured JSON (`{"error":{"code":"1308","message":"..."}}`) is available. Code-based dispatch is deterministic; message keywords are fallback only for unknown codes.

```
[GLM API]  → {"error":{"code":"1308", "message":"usage limit"}}
    ↓ check_glm_error → { code="1308"; error_class=Glm_quota_exceeded }   ← structured
    ↓ complete.ml → HttpError { code=429; body=... }                       ← semantic code
    ↓ retry.ml → RateLimited                                               ← correct variant
    ↓ cascade → fallback to next provider                                  ← working
```

## Test plan

- [x] `dune build` passes
- [x] `dune runtest` passes (all existing tests + 6 new inline tests)
- [ ] Follow-up: MASC pin bump after merge
- [ ] Follow-up: remove body string matching workaround from masc-mcp PR #7599

🤖 Generated with [Claude Code](https://claude.com/claude-code)