### PR TITLE
test(model_meta): commit to gemini-3-* inventory + drift gate

### DIFF
--- a/lib/llm_provider/model_meta.ml
+++ b/lib/llm_provider/model_meta.ml
@@ -105,6 +105,22 @@ let%test "gemini-2.5-flash has 1M context" =
   let m = for_model_id "gemini-2.5-flash" in
   m.context_window = 1_000_000
 
+let%test "gemini-3-flash-preview has 1M context via gemini-3 prefix" =
+  let m = for_model_id "gemini-3-flash-preview" in
+  m.context_window = 1_000_000
+  && m.capabilities.supports_tools
+  && m.capabilities.supports_parallel_tool_calls
+
+let%test "gemini-3.1-pro-preview has 1M context via gemini-3 prefix" =
+  let m = for_model_id "gemini-3.1-pro-preview" in
+  m.context_window = 1_000_000
+  && m.capabilities.supports_tools
+
+let%test "gemini-3.1-flash-lite-preview has 1M context via gemini-3 prefix" =
+  let m = for_model_id "gemini-3.1-flash-lite-preview" in
+  m.context_window = 1_000_000
+  && m.capabilities.supports_tools
+
 let%test "deepseek-v3 can be marked local explicitly" =
   let m = for_model_id ~locality:`Local "deepseek-v3" in
   m.is_local

--- a/scripts/check-model-inventory-truth.sh
+++ b/scripts/check-model-inventory-truth.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# check-model-inventory-truth.sh
+# Drift gate for the Gemini 3 model inventory (PR Cadd, 2026-04-16).
+#
+# Guards three invariants that can silently drift:
+#   1. capabilities.ml retains the `gemini-3` prefix matcher
+#      (without it, gemini-3-* models fall back to default_capabilities).
+#   2. model_meta.ml retains the gemini-3 inline %test block
+#      (proof that gemini-3 IDs actually resolve to 1M context + tool support).
+#   3. Legacy gemini-2.x references in lib/ + test/ do not grow beyond the
+#      baseline captured when this gate was introduced.
+#
+# The baseline is intentionally permissive (equal to the 2026-04-16 count).
+# Follow-up PRs Cdeprecate and Cremove will lower it.
+#
+# Rationale: memory/feedback_policy-runtime-drift-gate.md
+#   "정책 선언만으론 부족. 같은 PR에서 runtime 검증 스크립트를 함께 추가."
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CAPS="$ROOT/lib/llm_provider/capabilities.ml"
+META="$ROOT/lib/llm_provider/model_meta.ml"
+BASELINE_LEGACY=53
+
+fail=0
+
+# ── Invariant 1: gemini-3 prefix matcher present ────────────────
+if ! grep -Fq 'starts_with "gemini-3"' "$CAPS"; then
+  echo "FAIL: gemini-3 prefix matcher missing in $CAPS" >&2
+  fail=1
+fi
+
+# ── Invariant 2: gemini-3 inline tests present ──────────────────
+for id in \
+    "gemini-3-flash-preview" \
+    "gemini-3.1-pro-preview" \
+    "gemini-3.1-flash-lite-preview"; do
+  if ! grep -Fq "$id" "$META"; then
+    echo "FAIL: inline %test for $id missing in $META" >&2
+    fail=1
+  fi
+done
+
+# ── Invariant 3: legacy gemini-2.x count bounded ────────────────
+legacy=$(rg -n 'gemini-2\.[05]' "$ROOT/lib" "$ROOT/test" 2>/dev/null | wc -l | tr -d ' ')
+if [ "$legacy" -gt "$BASELINE_LEGACY" ]; then
+  echo "FAIL: legacy gemini-2.x references grew ($legacy > baseline $BASELINE_LEGACY)" >&2
+  echo "  Run: rg -n 'gemini-2\\.[05]' lib/ test/" >&2
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi
+
+echo "OK: gemini-3 matcher present, inline tests present, legacy count $legacy ≤ baseline $BASELINE_LEGACY"


### PR DESCRIPTION
## Context

원 plan (`~/me/planning/claude-plans/snoopy-singing-bear.md`)의 **PR C Cadd** 구간.
PR 0에서 확인된 사실:

- `Capabilities.for_model_id` 의 `starts_with "gemini-3"` matcher (lib/llm_provider/capabilities.ml:269) 가 이미 존재하므로 `gemini-3-*` 모델은 런타임에서 정상 resolve 된다 (1M context, tool calling, parallel tool calls 상속).
- 그러나 어느 PR도 "우리는 `gemini-3-flash-preview` 를 지원한다"는 contract 를 명시적으로 테스트하지 않는다 → 누군가 prefix matcher 를 실수로 제거/축소하면 silent breakage.

## Changes

**1. `lib/llm_provider/model_meta.ml` — inline `%test` 3건 추가**

기존 `gemini-2.5-flash has 1M context` 테스트 아래에 3-계 preview 모델에 대한 동등 테스트를 추가. `for_model_id` 가 `gemini_capabilities` 를 상속하는지 (context, tools, parallel) 실측.

2026-04-16 기준 공식 Google AI 공개 모델 ID:
- `gemini-3-flash-preview`
- `gemini-3.1-pro-preview`
- `gemini-3.1-flash-lite-preview`

Rolling alias (`gemini-flash-latest`, `gemini-flash-lite-latest`) 은 본 PR 에서 추가하지 않는다 — 공식 changelog 확인 범위 밖. Cdeprecate 단계에서 별도 결정.

**2. `scripts/check-model-inventory-truth.sh` — drift gate 신설**

세 가지 invariant 검증:

1. `capabilities.ml` 에 `starts_with "gemini-3"` matcher 존재.
2. `model_meta.ml` 에 세 preview 모델에 대한 inline test block 존재.
3. `lib/` + `test/` 의 `gemini-2.[05]` 참조 수가 baseline (53, 2026-04-16 측정) 이하.

`memory/feedback_policy-runtime-drift-gate.md` 원칙 — "정책 선언만으론 부족. 같은 PR 에서 runtime 검증 스크립트를 함께."

## No Runtime Behavior Change

본 PR 은 코드 경로를 변경하지 않는다. 3-계 모델은 이미 prefix matcher 로 resolve 되고 있었다. 테스트와 drift gate 가 그 contract 를 codify 할 뿐.

## Verification

- `dune build --root .` → exit 0
- `dune runtest --root . lib/llm_provider` → exit 0 (새 3개 테스트 포함 전체 통과)
- `scripts/check-model-inventory-truth.sh` → `OK: gemini-3 matcher present, inline tests present, legacy count 53 ≤ baseline 53`

## Follow-ups (별도 PR)

- **PR Cdeprecate** — `gemini-2.5-*` / `gemini-2.0-*` 사용 시 one-shot `Eio.traceln` deprecation warn. `check-model-inventory-truth.sh` 의 baseline 을 단계적으로 낮춘다.
- **PR Cremove** — production 9파일 + test fixture 4파일에서 legacy 제거.
- **masc-mcp 쪽** `lib/cascade/cascade_model_resolve.ml:67` 의 `gemini` auto default (현재 `gemini-2.5-flash`) 를 `gemini-3-flash-preview` 로 승격 — 별도 PR, masc-mcp repo.
- Gemini pricing 은 현재 OAS `pricing.ml` 에 등록되어 있지 않음 (2.5 도 없음). 별도 scope.

## 크리틱 대응

`~/me/planning/claude-plans/snoopy-singing-bear.md` 중 Cadd scope 는 원래 "model_meta/capabilities/complete 에 엔트리 추가" 였으나, 실측 결과 **capabilities prefix matcher 로 이미 커버되어 있어** 실제 필요 변경은 최소화됨. dead-code 위험을 코드로 고쳐 재발 방지 장치(drift gate) 로 대체.