### PR TITLE
ci(transport): add drift gate for CLI transport config fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,3 +162,15 @@ jobs:
           fi
 
           echo "Version consistency check passed: $DUNE_VER"
+
+  transport-drift:
+    name: Transport Drift Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run transport drift gate
+        run: bash scripts/check-transport-truth.sh

--- a/scripts/check-transport-truth.sh
+++ b/scripts/check-transport-truth.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# check-transport-truth.sh
+# Drift gate for OAS CLI transports (transport_{claude_code,gemini_cli,codex_cli}).
+#
+# Background
+# ----------
+# Each CLI transport exposes a `type config = { ... }` record in its .mli.
+# The corresponding .ml is expected to either:
+#   - wire the field to a CLI flag in build_args, OR
+#   - mark it as a parity-only field and warn via warn_unsupported_once.
+#
+# Prior audits (see planning/task-118/origin-report.md, 2026-04-16) found
+# that transport_gemini_cli.mli and transport_codex_cli.mli declared
+# fields (max_turns / allowed_tools / mcp_config / permission_mode) whose
+# behavior only existed as a warn-and-drop. The .mli comments claimed
+# "Gemini has no equivalent flag" — a claim that was false by 2026-04
+# (Gemini CLI 0.38+ exposes --allowed-mcp-server-names, --approval-mode,
+# etc.). This drift gate aims to prevent re-introduction of silent drops.
+#
+# Invariants
+# ----------
+# 1. Every field declared in `type config = { ... }` of a transport .mli
+#    must be referenced at least once in the corresponding .ml. A field
+#    that disappears entirely from the implementation is silent drift.
+#
+# 2. If a transport's .mli contains the phrase "Accepted for parity",
+#    the .ml must contain a `warn_unsupported_once` function. A parity
+#    claim without a warning is a silent drop dressed as a contract.
+#
+# Scope limitations
+# -----------------
+# This gate does NOT verify that a field is actually wired to a CLI flag
+# in build_args; it only checks that the field is referenced somewhere.
+# A semantic check (wired vs. warn-only vs. deprecated) is left to
+# per-transport integration tests.
+#
+# See memory/feedback_policy-runtime-drift-gate.md —
+# "정책 선언만으론 부족. 같은 PR 에서 runtime 검증 스크립트를 함께."
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# transport name : path prefix (relative to ROOT, without .ml/.mli suffix)
+TRANSPORTS=(
+  "claude_code:lib/llm_provider/transport_claude_code"
+  "gemini_cli:lib/llm_provider/transport_gemini_cli"
+  "codex_cli:lib/llm_provider/transport_codex_cli"
+)
+
+# Extract field names from `type config = { ... }` block. BSD/GNU awk compat.
+extract_config_fields() {
+  awk '/^type config = \{/,/^\}/' "$1" \
+    | sed -n 's/^[[:space:]]*\([a-z_][a-zA-Z0-9_]*\)[[:space:]]*:.*/\1/p'
+}
+
+fail=0
+for spec in "${TRANSPORTS[@]}"; do
+  name="${spec%%:*}"
+  prefix="${spec#*:}"
+  mli="$ROOT/$prefix.mli"
+  ml="$ROOT/$prefix.ml"
+
+  if [[ ! -f "$mli" || ! -f "$ml" ]]; then
+    echo "FAIL: $name: .mli or .ml missing ($mli, $ml)" >&2
+    fail=1
+    continue
+  fi
+
+  fields=$(extract_config_fields "$mli")
+  if [[ -z "$fields" ]]; then
+    echo "FAIL: $name: no config fields extracted from $mli" >&2
+    fail=1
+    continue
+  fi
+
+  # Invariant 1: each field referenced in .ml
+  for f in $fields; do
+    if ! grep -qE "\\b$f\\b" "$ml"; then
+      echo "FAIL: $name: field '$f' declared in .mli but not referenced in .ml" >&2
+      fail=1
+    fi
+  done
+
+  # Invariant 2: "Accepted for parity" → warn_unsupported_once
+  if grep -q "Accepted for parity" "$mli"; then
+    if ! grep -q "warn_unsupported_once" "$ml"; then
+      echo "FAIL: $name: .mli claims 'Accepted for parity' but .ml has no warn_unsupported_once" >&2
+      fail=1
+    fi
+  fi
+done
+
+if [[ $fail -ne 0 ]]; then
+  exit 1
+fi
+
+echo "OK: transport drift gate passed (3 transports, invariants 1–2)"


### PR DESCRIPTION
## Context

\`planning/task-118/origin-report.md\` (2026-04-16) 에서 \`transport_gemini_cli.mli:21-37\` 의 주석 **"Gemini binary has no MCP flag"** 가 2026-04 기준 거짓임이 확인되었다 (Gemini CLI 0.38 은 \`--allowed-mcp-server-names\`, \`--approval-mode\`, \`-e\`, \`gemini mcp add/list\` 를 공식 지원).

이는 단순한 오기록이 아니라 **.mli 가 실제 .ml 구현보다 먼저 낙후되는 drift 패턴**이다 (\`memory/feedback_policy-runtime-drift-gate.md\`). 동일한 drift 가 다시 생기지 않도록 runtime 검증 스크립트를 CI 에 꽂는다.

## Changes

**1. \`scripts/check-transport-truth.sh\` 신설**

\`transport_{claude_code,gemini_cli,codex_cli}\` 3 종에 대해 2 개 invariant 검증:

- **Invariant 1**: \`.mli\` 의 \`type config = { ... }\` 에서 선언된 **모든 필드** 는 \`.ml\` 에서 최소 1회 참조되어야 한다. (완전히 참조되지 않는 필드는 silent drift.)
- **Invariant 2**: \`.mli\` 에 "Accepted for parity" 표현이 있으면 \`.ml\` 은 \`warn_unsupported_once\` 함수를 포함해야 한다. (parity claim 만 있고 warn 없으면 silent drop.)

BSD/GNU awk 호환. 의존성 없음 (bash + grep + awk + sed 만).

**2. \`.github/workflows/ci.yml\` 에 \`Transport Drift Gate\` job 추가**

기존 3 job (build-and-test / lint / version-check) 옆에 병렬로. \`runs-on: ubuntu-latest\`, \`timeout-minutes: 5\`. OCaml setup 불필요.

## Scope Limitation

이 gate 는 의도적으로 보수적이다:

- **검증**: 필드가 어딘가 참조되는지, parity claim 시 warn 함수 존재 여부
- **미검증**: 필드가 실제로 \`build_args\` 에 wire 되었는지 (warn-only vs. wired 구분 안 함)

따라서 현재 \`transport_gemini_cli.ml\` / \`transport_codex_cli.ml\` 의 **4 개 parity 필드 silent drop** (\`max_turns\` / \`allowed_tools\` / \`permission_mode\` / \`mcp_config\`) 은 이 gate 로 잡히지 않는다 (\`warn_unsupported_once\` 가 해당 필드를 모두 참조하고 있어서 Invariant 1 통과). 그 문제를 고치는 것은 후속 PR A (flag wiring) 의 몫.

## Verification

- \`bash scripts/check-transport-truth.sh\` → exit 0 ("OK: transport drift gate passed (3 transports, invariants 1–2)")
- 로컬 실행 결과 3 transport 모두 두 invariant 통과 — ratchet 으로 작동 (regression 방지, 현 상태 locked-in)

## Related

- OAS PR [#968](https://github.com/jeong-sik/oas/pull/968) (PR C Cadd) — \`check-model-inventory-truth.sh\` 도입. 동일 CI job 패턴을 따로 적용. 향후 두 gate 를 \`drift-checks\` job 으로 묶을 수 있음.
- planning \`~/me/planning/claude-plans/snoopy-singing-bear.md\` — PR A-drift 트랙.

## Follow-ups

- **PR A (full wiring)** — flag wiring 실제 구현. dead code 우선순위 낮으나 drift 제거 완결성 차원에서 후속. 본 PR 이 먼저 머지되어 regression gate 가 있는 상태에서 진행.
- **Model inventory gate CI wiring** — \`check-model-inventory-truth.sh\` 는 #968 에서 스크립트만 추가했고 CI 에 아직 없음. 동일 \`ci.yml\` 에 job 추가 가능.
- **Invariant 3 (선택)** — \`build_args\` 와 \`warn_unsupported_once\` 의 필드 references 를 구별하는 semantic check. OCaml PPX 또는 전용 linter 필요.