### PR TITLE
feat(ollama): surface inference timings + per-turn enable_thinking override

### DIFF
--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -13,6 +13,7 @@ open Types
 type turn_params = {
   temperature: float option;
   thinking_budget: int option;
+  enable_thinking: bool option;
   tool_choice: tool_choice option;
   extra_system_context: string option;
   system_prompt_override: string option;
@@ -22,6 +23,7 @@ type turn_params = {
 let default_turn_params = {
   temperature = None;
   thinking_budget = None;
+  enable_thinking = None;
   tool_choice = None;
   extra_system_context = None;
   system_prompt_override = None;

--- a/lib/hooks.mli
+++ b/lib/hooks.mli
@@ -8,6 +8,7 @@
 type turn_params = {
   temperature: float option;
   thinking_budget: int option;
+  enable_thinking: bool option;
   tool_choice: Types.tool_choice option;
   extra_system_context: string option;
   system_prompt_override: string option;

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -215,7 +215,39 @@ let parse_ollama_response json_str =
 
   let telemetry =
     let system_fingerprint = None in
-    let timings = None in
+    (* Ollama reports durations in nanoseconds. Surface them as
+       inference_timings so downstream can distinguish hardware
+       decode rate from wall-clock tok/s. *)
+    let timings =
+      let prompt_n = json |> member "prompt_eval_count" |> to_int_option in
+      let prompt_ns = json |> member "prompt_eval_duration" |> to_int_option in
+      let predicted_n = json |> member "eval_count" |> to_int_option in
+      let predicted_ns = json |> member "eval_duration" |> to_int_option in
+      let any_set =
+        Option.is_some prompt_n || Option.is_some prompt_ns
+        || Option.is_some predicted_n || Option.is_some predicted_ns
+      in
+      if not any_set then None
+      else
+        let ms_of_ns ns_opt =
+          Option.map (fun ns -> float_of_int ns /. 1e6) ns_opt
+        in
+        let per_second n_opt ns_opt =
+          match n_opt, ns_opt with
+          | Some n, Some ns when ns > 0 ->
+              Some (float_of_int n /. (float_of_int ns /. 1e9))
+          | _ -> None
+        in
+        Some
+          { Types.prompt_n
+          ; prompt_ms = ms_of_ns prompt_ns
+          ; prompt_per_second = per_second prompt_n prompt_ns
+          ; predicted_n
+          ; predicted_ms = ms_of_ns predicted_ns
+          ; predicted_per_second = per_second predicted_n predicted_ns
+          ; cache_n = None
+          }
+    in
     let reasoning_tokens = None in
     Some { Types.system_fingerprint; timings; reasoning_tokens; request_latency_ms = 0;
             provider_kind = None; reasoning_effort = None;
@@ -304,3 +336,53 @@ let%test "build_request whitespace-only env falls back to default integer" =
     let json = Yojson.Safe.from_string body in
     let open Yojson.Safe.Util in
     json |> member "keep_alive" |> to_int = -1)
+
+let%test "parse_ollama_response populates timings from eval_count/eval_duration" =
+  let json =
+    {|{"model":"qwen3.5:35b-a3b-nvfp4","done":true,"done_reason":"stop",
+       "message":{"role":"assistant","content":"hi"},
+       "prompt_eval_count":100,"prompt_eval_duration":200000000,
+       "eval_count":120,"eval_duration":2000000000}|}
+  in
+  match parse_ollama_response json with
+  | Error _ -> false
+  | Ok resp ->
+    (match resp.telemetry with
+     | Some { timings = Some t; _ } ->
+       t.predicted_n = Some 120
+       && (match t.predicted_per_second with
+           | Some v -> abs_float (v -. 60.0) < 0.001
+           | None -> false)
+       && t.prompt_n = Some 100
+       && (match t.prompt_per_second with
+           | Some v -> abs_float (v -. 500.0) < 0.001
+           | None -> false)
+     | _ -> false)
+
+let%test "parse_ollama_response guards zero eval_duration" =
+  let json =
+    {|{"model":"qwen3.5:35b-a3b-nvfp4","done":true,"done_reason":"stop",
+       "message":{"role":"assistant","content":"hi"},
+       "eval_count":10,"eval_duration":0}|}
+  in
+  match parse_ollama_response json with
+  | Error _ -> false
+  | Ok resp ->
+    (match resp.telemetry with
+     | Some { timings = Some t; _ } ->
+       (* eval_count present → timings record exists,
+          but predicted_per_second is None because duration is 0. *)
+       t.predicted_n = Some 10 && t.predicted_per_second = None
+     | _ -> false)
+
+let%test "parse_ollama_response returns timings=None when no timing fields present" =
+  let json =
+    {|{"model":"qwen3.5:35b-a3b-nvfp4","done":true,"done_reason":"stop",
+       "message":{"role":"assistant","content":"hi"}}|}
+  in
+  match parse_ollama_response json with
+  | Error _ -> false
+  | Ok resp ->
+    (match resp.telemetry with
+     | Some { timings = None; _ } -> true
+     | _ -> false)

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -154,6 +154,8 @@ let stage_parse ?raw_trace_run agent =
       (match turn_params.temperature with Some _ as t -> t | None -> original_config.temperature);
     thinking_budget =
       (match turn_params.thinking_budget with Some _ as t -> t | None -> original_config.thinking_budget);
+    enable_thinking =
+      (match turn_params.enable_thinking with Some _ as t -> t | None -> original_config.enable_thinking);
     tool_choice =
       (match turn_params.tool_choice with Some _ as t -> t | None -> original_config.tool_choice);
     system_prompt =

--- a/test/test_turn_params.ml
+++ b/test/test_turn_params.ml
@@ -8,9 +8,20 @@ let test_default_turn_params () =
   let p = Hooks.default_turn_params in
   Alcotest.(check (option (float 0.01))) "no temperature" None p.temperature;
   Alcotest.(check (option int)) "no thinking_budget" None p.thinking_budget;
+  Alcotest.(check (option bool)) "no enable_thinking" None p.enable_thinking;
   Alcotest.(check bool) "no extra context" true (p.extra_system_context = None);
   Alcotest.(check bool) "no system prompt override" true (p.system_prompt_override = None);
   Alcotest.(check bool) "no tool filter" true (p.tool_filter_override = None)
+
+let test_enable_thinking_override () =
+  let p = { Hooks.default_turn_params with
+    enable_thinking = Some false;
+  } in
+  Alcotest.(check (option bool)) "enable_thinking=false override" (Some false) p.enable_thinking;
+  let q = { Hooks.default_turn_params with
+    enable_thinking = Some true;
+  } in
+  Alcotest.(check (option bool)) "enable_thinking=true override" (Some true) q.enable_thinking
 
 (* ── Reasoning extraction ────────────────────────────────────── *)
 
@@ -196,6 +207,7 @@ let () =
   Alcotest.run "turn_params" [
     ("turn_params", [
       Alcotest.test_case "default" `Quick test_default_turn_params;
+      Alcotest.test_case "enable_thinking_override" `Quick test_enable_thinking_override;
       Alcotest.test_case "before_turn_params_event" `Quick test_before_turn_params_event;
       Alcotest.test_case "adjust_params_decision" `Quick test_adjust_params_decision;
       Alcotest.test_case "system_prompt_override" `Quick test_adjust_params_system_prompt_override;


### PR DESCRIPTION
## Summary

Two linked additions so consumers (downstream keeper loops, dashboards) can:
1. See the true hardware decode rate from Ollama (`eval_count / eval_duration`), distinct from wall-clock tok/s.
2. Override `enable_thinking` per turn via the existing `before_turn_params` hook, without rebuilding the Agent.

## Context

Empirical on qwen3.5:35b-a3b-nvfp4 via Ollama 0.20.7 (M3 Max, single request, no contention):

| Scenario | tok/s |
|---|---|
| Raw decode (eval_count / eval_duration) | ~59 |
| Tool call, think=false | 0.57s wall |
| Tool call, think=true | 1.33s wall (~2.3x slower, same correct tool call) |

Before this PR:
- `backend_ollama.ml:218` hardcoded `let timings = None`, so `inference_timings.predicted_per_second` was always `None` — the hardware number never reached downstream.
- `Hooks.turn_params` had `thinking_budget` but no `enable_thinking`, so callers couldn't flip reasoning on/off per turn without rebuilding the Agent.

## Changes

- **`lib/llm_provider/backend_ollama.ml`**: populate `Types.inference_timings` from `eval_count`, `eval_duration` (ns), `prompt_eval_count`, `prompt_eval_duration` (ns). Guard zero-duration before division (fall through to `predicted_per_second = None`). Absent all four timing fields → `timings = None`.
- **`lib/hooks.ml` / `lib/hooks.mli`**: add `enable_thinking: bool option` to `turn_params`; update `default_turn_params` to `None`.
- **`lib/pipeline/pipeline.ml:stage_parse`**: merge `turn_params.enable_thinking` onto `original_config.enable_thinking` using the same `Some _ as t / None -> fallback` pattern as `thinking_budget`. `backend_ollama:36-40` already reads `config.enable_thinking` into the wire `"think"` field, so no further plumbing is needed.

## Tests

- `backend_ollama.ml` inline tests (3 new):
  - populates `predicted_per_second = 60.0` from canned `eval_count: 120, eval_duration: 2_000_000_000`;
  - `predicted_per_second = None` when `eval_duration = 0`;
  - `timings = None` when all four timing fields absent.
- `test/test_turn_params.ml`: new `enable_thinking_override` case exercises `Some true` / `Some false`. Existing `default_turn_params` test extended to assert the new field defaults to `None`.
- `dune runtest --root .` green locally.

## Test plan

- [ ] CI green
- [ ] Reviewer sanity-checks the ns → ms / ns → 1e9 conversion idiom matches existing usage (cf. `tool_local_runtime_probe.ml:63` downstream)
- [ ] Smoke: caller sets `enable_thinking = Some false` in a `before_turn_params` hook, request JSON body shows `"think": false`

## Non-goals

- Anthropic/OpenAI native `think` plumbing — this PR only wires the Ollama backend path. Anthropic already has `reasoning_effort` via a separate channel; OpenAI thinking models use their own format. A unified `thinking_mode` enum can follow once there is a second consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)