### PR TITLE
feat(pricing): add Gemini 3-계 preview pricing entries

### DIFF
--- a/lib/llm_provider/pricing.ml
+++ b/lib/llm_provider/pricing.ml
@@ -49,6 +49,25 @@ let pricing_for_model_opt model_id =
       Some ((2.0, 8.0), no_cache)
     else if string_contains ~needle:"o3-mini" normalized then
       Some ((1.1, 4.4), no_cache)
+    (* Gemini 3-계 preview. Source: ai.google.dev/gemini-api/docs/pricing,
+       confirmed 2026-04-16. Google also exposes context caching with a
+       per-hour storage surcharge ($1.00/h flash, $4.50/h pro); the
+       pricing record cannot represent time-based storage, so we keep
+       cache multipliers at no_cache and rely on provider-reported
+       cost_usd for exact billing. Estimates here are an upper bound on
+       input/output token cost only. *)
+    else if string_contains ~needle:"gemini-3-flash-preview" normalized then
+      Some ((0.50, 3.0), no_cache)
+    else if string_contains ~needle:"gemini-3.1-pro-preview" normalized
+         || string_contains ~needle:"gemini-3.1-pro" normalized then
+      (* Standard tier (input <= 200k tokens). Above 200k Google charges
+         2x ($4 input / $18 output). The pricing record has no context
+         window size field, so cost for >200k inputs is underestimated
+         by 2x. Follow-up: extend the record with tiered pricing. *)
+      Some ((2.0, 12.0), no_cache)
+    else if string_contains ~needle:"gemini-3.1-flash-lite-preview" normalized
+         || string_contains ~needle:"gemini-3.1-flash-lite" normalized then
+      Some ((0.25, 1.5), no_cache)
     else if string_contains ~needle:"ollama" normalized
          || string_contains ~needle:"qwen" normalized
          || string_contains ~needle:"llama" normalized then
@@ -210,6 +229,33 @@ let%test "pricing o3-mini" =
   let p = pricing_for_model "o3-mini" in
   close_enough p.input_per_million 1.1
   && close_enough p.output_per_million 4.4
+
+(* --- pricing_for_model: Gemini 3-계 preview (2026-04-16) --- *)
+
+let%test "pricing gemini-3-flash-preview" =
+  let p = pricing_for_model "gemini-3-flash-preview" in
+  close_enough p.input_per_million 0.50
+  && close_enough p.output_per_million 3.0
+
+let%test "pricing gemini-3.1-pro-preview" =
+  let p = pricing_for_model "gemini-3.1-pro-preview" in
+  close_enough p.input_per_million 2.0
+  && close_enough p.output_per_million 12.0
+
+let%test "pricing gemini-3.1-pro (bare id)" =
+  let p = pricing_for_model "gemini-3.1-pro" in
+  close_enough p.input_per_million 2.0
+  && close_enough p.output_per_million 12.0
+
+let%test "pricing gemini-3.1-flash-lite-preview" =
+  let p = pricing_for_model "gemini-3.1-flash-lite-preview" in
+  close_enough p.input_per_million 0.25
+  && close_enough p.output_per_million 1.5
+
+let%test "pricing_for_model_opt returns Some for gemini-3-flash-preview" =
+  match pricing_for_model_opt "gemini-3-flash-preview" with
+  | Some p -> p.input_per_million > 0.0
+  | None -> false
 
 (* --- pricing_for_model: local/free models --- *)
 


### PR DESCRIPTION
## Context

PR C Cadd 트랙의 OAS #968 가 Gemini 3-계 preview IDs 를 capability 인벤토리에 등록했다. 그러나 \`pricing.ml\` 에는 **Gemini 계열이 전혀 없다** (2.5 포함). 결과: \`estimate_usage_cost ~model_id:"gemini-3-flash-preview"\` 가 \$0 을 반환, \`pricing_for_model_opt\` 가 \`None\` 을 반환.

\`pricing_for_model_opt\` 가 \`None\` 이면 \`annotate_usage_cost\` 는 \`cost_usd\` 를 채우지 않고 지나가므로 cost dashboard 에서 Gemini 호출이 **보이지 않는다**.

## Changes

\`lib/llm_provider/pricing.ml\` 의 \`pricing_for_model_opt\` chain 에 o3-mini 와 ollama/qwen/llama 사이에 3 개 needle 추가. 인라인 \`%test\` 5 개.

| model | input /1M | output /1M |
|-------|----------|-----------|
| \`gemini-3-flash-preview\` | \$0.50 | \$3.00 |
| \`gemini-3.1-pro-preview\` (≤200k) | \$2.00 | \$12.00 |
| \`gemini-3.1-flash-lite-preview\` | \$0.25 | \$1.50 |

**Source**: [ai.google.dev/gemini-api/docs/pricing](https://ai.google.dev/gemini-api/docs/pricing) — 확인일시 **2026-04-16**.

## Scope Limits

의도적으로 단순화 (\`pricing\` 레코드 확장은 별도 PR):

- **Context-tiered pricing 미지원**: \`gemini-3.1-pro-preview\` 는 입력 200k 초과 시 **2x 가격** (\$4 input / \$18 output). 현재 \`pricing\` 레코드에 context-size 필드가 없어 고맥락 호출은 2x 저평가됨. 인라인 주석으로 flag + follow-up 으로 이관.
- **Context caching 시간제 과금 미지원**: Google 은 per-hour storage 과금 (\$1/h flash, \$4.50/h pro) 을 부과. \`pricing\` 레코드의 \`cache_read_multiplier\` / \`cache_write_multiplier\` 로 표현 불가. \`no_cache\` 로 두고 provider 가 보고하는 \`cost_usd\` 에 위임.
- **Gemini 2.5 는 그대로 \$0**: 2.5 는 Cdeprecate/Cremove 트랙이므로 pricing 을 추가하지 않는다. 본 PR 이전 상태 유지 (regression 아님).

## Verification

- \`dune build --root .\` → exit 0
- \`dune runtest --root . lib/llm_provider\` → exit 0, 새 5 개 인라인 테스트 포함 전체 통과

## Related

- OAS [#968](https://github.com/jeong-sik/oas/pull/968) — Cadd capability inventory
- OAS [#969](https://github.com/jeong-sik/oas/pull/969) — transport drift gate
- masc-mcp [#7610](https://github.com/jeong-sik/masc-mcp/pull/7610) — cascade default bump to \`gemini-3-flash-preview\`
- plan: \`~/me/planning/claude-plans/snoopy-singing-bear.md\`

## Follow-ups

- \`pricing\` 레코드에 \`input_per_million_high_context: (threshold * float) option\` 같은 필드 추가해 \`gemini-3.1-pro-preview\` 의 200k tier 를 표현.
- Context caching storage surcharge 표현: per-hour 를 per-call 로 환산하는 별도 API. 현재는 provider cost_usd 로 우회.