### PR TITLE
feat(agent): add options.summarizer + Builder.with_summarizer

### DIFF
--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -46,6 +46,7 @@ type options = Agent_types.options = {
   tool_result_relocation:
     (Tool_result_store.t * Content_replacement_state.t) option;
   journal: Durable_event.journal option;
+  summarizer: (Types.message list -> string) option;
 }
 
 type lifecycle_status = Agent_lifecycle.lifecycle_status =

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -50,6 +50,16 @@ type options = {
         [Event_bus] publishes, enabling offline replay via
         {!Durable_event.replay_summary}.
         @since 0.133.0 *)
+  summarizer: (message list -> string) option;
+    (** Optional custom extractive summarizer used by
+        {!Budget_strategy.reduce_for_budget} when the Emergency phase
+        triggers [Summarize_old].  When [None], the built-in
+        [Budget_strategy.default_summarizer] is used (first text block
+        of each message, truncated to 100 chars).  Consumers that embed
+        domain-specific structured markers in message bodies (e.g., MASC's
+        [STATE] blocks) can supply a summarizer that strips or transforms
+        those markers before they are re-injected as compacted history.
+        @since 0.150.0 *)
 }
 
 (* Re-export lifecycle types from Agent_lifecycle.
@@ -111,6 +121,7 @@ let default_options = {
   on_run_complete = None;
   tool_result_relocation = None;
   journal = None;
+  summarizer = None;
 }
 
 type tool_call_fingerprint = Agent_turn.tool_call_fingerprint

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -81,6 +81,15 @@ type options = {
         [Event_bus] publishes, enabling offline replay via
         {!Durable_event.replay_summary}.
         @since 0.133.0 *)
+  summarizer: (Types.message list -> string) option;
+    (** Optional custom extractive summarizer used by
+        {!Budget_strategy.reduce_for_budget} when the Emergency phase
+        triggers [Summarize_old].  When [None], the built-in
+        {!Budget_strategy.default_summarizer} is used.  Consumers can
+        supply a domain-aware summarizer to strip or transform
+        application-specific markers before they are re-injected as
+        compacted history.
+        @since 0.150.0 *)
 }
 
 (** {1 Lifecycle re-exports} *)

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -63,6 +63,7 @@ type t = {
     (Tool_result_store.t * Content_replacement_state.t) option;
   journal: Durable_event.journal option;
   policy_channel: Policy_channel.t option;
+  summarizer: (Types.message list -> string) option;
 }
 
 let create ~net ~model =
@@ -124,12 +125,18 @@ let create ~net ~model =
     tool_result_relocation = None;
     journal = None;
     policy_channel = None;
+    summarizer = None;
   }
 
 let with_tool_result_relocation ~store ~state b =
   { b with tool_result_relocation = Some (store, state) }
 
 let with_journal journal b = { b with journal = Some journal }
+
+(** Override the Budget_strategy Emergency-phase summarizer with a
+    domain-aware function.  Leave unset to use the OAS built-in
+    [Budget_strategy.default_summarizer]. *)
+let with_summarizer summarizer b = { b with summarizer = Some summarizer }
 
 let with_auto_dump_journal ~path b =
   let journal =
@@ -332,6 +339,7 @@ let build b =
     on_run_complete = b.on_run_complete;
     tool_result_relocation = b.tool_result_relocation;
     journal = b.journal;
+    summarizer = b.summarizer;
   } in
   Agent.create ~net:b.net ~config ~tools:(Tool_set.to_list tools) ?context
     ~options ()

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -208,6 +208,14 @@ val with_tool_result_relocation :
     @since 0.133.0 *)
 val with_journal : Durable_event.journal -> t -> t
 
+(** Override the Budget_strategy Emergency-phase summarizer with a
+    domain-aware function.  Routed into [Agent.options.summarizer] and
+    forwarded to {!Budget_strategy.reduce_for_budget} when compaction
+    triggers.  Leave unset to use the built-in
+    {!Budget_strategy.default_summarizer}.
+    @since 0.150.0 *)
+val with_summarizer : (Types.message list -> string) -> t -> t
+
 (** Install an [on_run_complete] callback that persists the journal
     to [path] whenever the agent run finishes (success or failure).
     Equivalent to attaching a journal and then calling

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -542,6 +542,7 @@ let proactive_compact ?raw_trace_run agent ~watermark () =
     | Hooks.Skip -> false
     | _ ->
       let reduced = Budget_strategy.reduce_for_budget
+        ?summarizer:agent.options.summarizer
         ~usage_ratio:scaled_ratio ~messages () in
       let reduced = match agent.options.context_reducer with
         | Some reducer -> Context_reducer.reduce reducer reduced
@@ -595,6 +596,7 @@ let emergency_compact ?raw_trace_run agent ?limit () =
   | Hooks.Skip -> false
   | _ ->
     let reduced = Budget_strategy.reduce_for_budget
+      ?summarizer:agent.options.summarizer
       ~usage_ratio:1.0 ~messages () in
     let reduced = match agent.options.context_reducer with
       | Some reducer -> Context_reducer.reduce reducer reduced

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -219,6 +219,28 @@ let test_with_context_reducer () =
   Alcotest.(check bool) "context_reducer set" true
     (Option.is_some (Agent.options agent).context_reducer)
 
+(* --- 13b. with_summarizer --- *)
+
+let test_with_summarizer () =
+  with_net @@ fun net ->
+  let marker = "<<SUMMARIZER_MARKER>>" in
+  let custom : Types.message list -> string = fun _ -> marker in
+  let agent =
+    Builder.create ~net ~model:"claude-sonnet-4-6"
+    |> Builder.with_summarizer custom
+    |> Builder.build_safe |> Result.get_ok
+  in
+  let opts = Agent.options agent in
+  Alcotest.(check bool) "summarizer set" true
+    (Option.is_some opts.summarizer);
+  (* Apply the stored summarizer and confirm it's the one we registered. *)
+  let applied =
+    match opts.summarizer with
+    | Some s -> s []
+    | None -> ""
+  in
+  Alcotest.(check string) "summarizer identity" marker applied
+
 (* --- 13. with_context --- *)
 
 let test_with_context () =
@@ -729,6 +751,7 @@ let () =
       Alcotest.test_case "approval" `Quick test_with_approval;
       Alcotest.test_case "tool retry policy" `Quick test_with_tool_retry_policy;
       Alcotest.test_case "context_reducer" `Quick test_with_context_reducer;
+      Alcotest.test_case "summarizer" `Quick test_with_summarizer;
       Alcotest.test_case "context" `Quick test_with_context;
       Alcotest.test_case "provider" `Quick test_with_provider;
       Alcotest.test_case "base_url" `Quick test_with_base_url;


### PR DESCRIPTION
## Motivation

`Budget_strategy.reduce_for_budget` already accepts an optional `?summarizer` callback but `pipeline.ml` calls it without one, so `default_summarizer` is always used. `agent.options` has no field for a summarizer either, leaving downstream SDK consumers no way to inject a domain-aware summary function.

Concrete driver — MASC keeper resonance loop (jeong-sik/masc-mcp#7612 thread):
- Keeper agents write `[STATE]...[/STATE]` blocks into assistant messages as a structured state marker.
- Under Emergency-phase compaction, `default_summarizer` takes the first 100 chars of each old message, which preserves `[STATE]\nDONE: ...` prefixes verbatim.
- Those preserved fragments land in the next-turn prompt as `[Summary of N earlier messages]\n[Assistant] [STATE]\n...`, and the keeper re-reads its own stale narrative — resonance.
- MASC cannot fix this cleanly today: `Agent_types.options` has no summarizer knob, and registering a custom `context_reducer` runs **after** `reduce_for_budget`, by which point the `[Summary of N earlier messages]` string is already materialized.

Per the OAS/MASC boundary rule ("OAS must not know about MASC markers"), the fix is an OAS-side API addition: expose the summarizer callback so downstream consumers can supply their own.

## Change

`agent_types.options` gains a new field:

```ocaml
summarizer: (Types.message list -> string) option;
```

- Default `None` — unchanged behavior (`Budget_strategy.default_summarizer` used).
- `Builder.with_summarizer` setter registers a custom callback.
- `pipeline.ml:544, 597` (`proactive_compact` + `emergency_compact`) thread `?summarizer:agent.options.summarizer` into `Budget_strategy.reduce_for_budget`.

### Files (7, +62 lines)

- `lib/agent/agent_types.ml` — record field + default_options entry
- `lib/agent/agent_types.mli` — mirror
- `lib/agent/agent.mli` — re-exported options type mirror
- `lib/agent/builder.ml` — builder record field + `with_summarizer` + build propagation
- `lib/agent/builder.mli` — signature
- `lib/pipeline/pipeline.ml` — thread the callback into the 2 `reduce_for_budget` sites
- `test/test_builder.ml` — round-trip test

### Test

`test/test_builder.ml:test_with_summarizer`: registers a custom callback returning a recognizable sentinel string, builds the agent, fetches `Agent.options`, applies the retrieved callback, and asserts the sentinel comes back. Adds to the `with_setters` suite.

```
dune exec --root . test/test_builder.exe
  ...
  [OK]  with_setters  13  summarizer.
  ...
  Test Successful in 0.022s. 41 tests run.
```

Full `dune build --root .` clean.

## Compatibility

- Field is optional (`... option`). Existing builders and `default_options` users get the same behavior (`None` → `default_summarizer`).
- Structural typing is preserved — no renames, no reorderings that affect downstream.
- Existing `test_budget_strategy.ml:test_reduce_custom_summarizer` continues to exercise the direct `?summarizer` path.

## Non-Goals

- No change to `Budget_strategy` semantics or `default_summarizer`.
- No change to OAS/MASC boundary — OAS still knows nothing about `[STATE]` markers; the consumer supplies the logic.
- Downstream adoption (MASC registering a `[STATE]`-aware summarizer) is a follow-up on masc-mcp after an OAS pin bump.

## Version

Proposing `0.150.0` (minor bump — API surface addition). Will apply via `scripts/sync-version-truth.sh` before merging once maintainer confirms the target version.
