### PR TITLE
feat(observability): Metrics_event_bridge — cascade_fallback → event_bus (LT-14)

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -65,6 +65,7 @@ module Guardrails = Guardrails
 module Tool_set = Tool_set
 module Log = Log
 module Event_bus = Event_bus
+module Metrics_event_bridge = Metrics_event_bridge
 module Skill = Skill
 module Skill_registry = Skill_registry
 module Contract = Contract

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -39,6 +39,7 @@ module Guardrails = Guardrails
 module Tool_set = Tool_set
 module Log = Log
 module Event_bus = Event_bus
+module Metrics_event_bridge = Metrics_event_bridge
 module Skill = Skill
 module Skill_registry = Skill_registry
 module Contract = Contract

--- a/lib/metrics_event_bridge.ml
+++ b/lib/metrics_event_bridge.ml
@@ -1,0 +1,37 @@
+(** Metrics ↔ Event_bus bridge (LT-14 / observability).
+
+    Lives in [agent_sdk] rather than [agent_sdk.llm_provider] because
+    [Event_bus] is part of [agent_sdk] and the provider layer must not
+    gain a dependency edge back up to the root library. Opt-in: callers
+    who want cascade routing visible on the event bus wrap their
+    existing [Metrics.t] through here at startup; the raw
+    [complete_cascade] path stays unaware of the bus. *)
+
+module M = Llm_provider.Metrics
+
+let compose_with_event_bus
+    ?(correlation_id = "")
+    ?(run_id = "")
+    (bus : Event_bus.t)
+    (base : M.t)
+  : M.t =
+  {
+    base with
+    on_cascade_fallback = (fun ~from_model ~to_model ~reason ->
+      base.on_cascade_fallback ~from_model ~to_model ~reason;
+      let payload =
+        `Assoc [
+          "from_model", `String from_model;
+          "to_model",   `String to_model;
+          "reason",     `String reason;
+        ]
+      in
+      let event =
+        Event_bus.mk_event
+          ~correlation_id
+          ~run_id
+          (Event_bus.Custom ("cascade_fallback", payload))
+      in
+      Event_bus.publish bus event
+    );
+  }

--- a/lib/metrics_event_bridge.mli
+++ b/lib/metrics_event_bridge.mli
@@ -1,0 +1,25 @@
+(** Metrics ↔ Event_bus bridge.
+
+    Wraps an [Llm_provider.Metrics.t] so that cascade routing is also
+    visible on an [Event_bus.t]. Opt-in — [complete_cascade] itself
+    stays unaware of the bus, preserving the layer boundary between
+    the provider library and the agent SDK root.
+
+    @since 0.154.0 *)
+
+(** Compose a metrics sink with event_bus publication. The returned
+    sink invokes [base.on_cascade_fallback] first (preserving existing
+    metrics backend behaviour), then emits a
+    [Custom("cascade_fallback", \{from_model, to_model, reason\})]
+    event on [bus]. All other callbacks are delegated to [base]
+    unchanged.
+
+    [correlation_id] / [run_id] default to empty strings so the emitted
+    envelope is still well-formed when per-run identifiers are unknown.
+    Downstream consumers that know the run context should supply them. *)
+val compose_with_event_bus :
+  ?correlation_id:string ->
+  ?run_id:string ->
+  Event_bus.t ->
+  Llm_provider.Metrics.t ->
+  Llm_provider.Metrics.t

--- a/test/dune
+++ b/test/dune
@@ -225,6 +225,10 @@
  (libraries agent_sdk alcotest yojson eio eio_main))
 
 (test
+ (name test_metrics_event_bridge)
+ (libraries agent_sdk alcotest yojson eio eio_main))
+
+(test
  (name test_otel)
  (libraries agent_sdk alcotest yojson eio eio_main))
 

--- a/test/test_metrics_event_bridge.ml
+++ b/test/test_metrics_event_bridge.ml
@@ -1,0 +1,106 @@
+(** Tests for Metrics_event_bridge — LT-14 opt-in bridge. *)
+
+open Alcotest
+open Agent_sdk
+
+let extract_cascade_payload (ev : Event_bus.event) =
+  match ev.payload with
+  | Event_bus.Custom ("cascade_fallback", `Assoc kvs) -> Some kvs
+  | _ -> None
+
+let string_field kvs key =
+  match List.assoc_opt key kvs with
+  | Some (`String s) -> s
+  | _ -> Alcotest.fail ("missing field " ^ key)
+
+(* ── base callback is preserved ──────────────────────────────────── *)
+
+let test_base_callback_invoked () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let observed = ref [] in
+  let base = {
+    Llm_provider.Metrics.noop with
+    on_cascade_fallback = (fun ~from_model ~to_model ~reason ->
+      observed := (from_model, to_model, reason) :: !observed)
+  } in
+  let wrapped = Agent_sdk.Metrics_event_bridge.compose_with_event_bus bus base in
+  wrapped.on_cascade_fallback
+    ~from_model:"claude" ~to_model:"glm" ~reason:"HTTP 529";
+  check int "base invoked exactly once" 1 (List.length !observed);
+  (match !observed with
+   | (f, t, r) :: _ ->
+     check string "from_model" "claude" f;
+     check string "to_model" "glm" t;
+     check string "reason" "HTTP 529" r
+   | [] -> Alcotest.fail "no base invocation")
+
+(* ── event lands on the bus ──────────────────────────────────────── *)
+
+let test_event_published () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  let wrapped =
+    Agent_sdk.Metrics_event_bridge.compose_with_event_bus bus Llm_provider.Metrics.noop
+  in
+  wrapped.on_cascade_fallback
+    ~from_model:"claude" ~to_model:"glm" ~reason:"HTTP 529";
+  let events = Event_bus.drain sub in
+  check int "one event received" 1 (List.length events);
+  match events with
+  | [ev] ->
+    (match extract_cascade_payload ev with
+     | Some kvs ->
+       check string "from_model" "claude" (string_field kvs "from_model");
+       check string "to_model"   "glm"    (string_field kvs "to_model");
+       check string "reason"     "HTTP 529" (string_field kvs "reason")
+     | None -> Alcotest.fail "payload was not Custom(cascade_fallback, _)")
+  | _ -> Alcotest.fail "wrong event count"
+
+(* ── envelope carries correlation_id + run_id when supplied ──────── *)
+
+let test_envelope_ids_propagated () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  let wrapped =
+    Metrics_event_bridge.compose_with_event_bus
+      ~correlation_id:"corr-xyz"
+      ~run_id:"run-42"
+      bus
+      Llm_provider.Metrics.noop
+  in
+  wrapped.on_cascade_fallback
+    ~from_model:"a" ~to_model:"b" ~reason:"stub";
+  let events = Event_bus.drain sub in
+  match events with
+  | [ev] ->
+    check string "correlation_id on envelope" "corr-xyz" ev.meta.correlation_id;
+    check string "run_id on envelope" "run-42" ev.meta.run_id
+  | _ -> Alcotest.fail "wrong event count"
+
+(* ── other callbacks are untouched ───────────────────────────────── *)
+
+let test_other_callbacks_delegated () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let cache_hits = ref 0 in
+  let base = {
+    Llm_provider.Metrics.noop with
+    on_cache_hit = (fun ~model_id:_ -> incr cache_hits)
+  } in
+  let wrapped = Agent_sdk.Metrics_event_bridge.compose_with_event_bus bus base in
+  wrapped.on_cache_hit ~model_id:"m1";
+  wrapped.on_cache_hit ~model_id:"m2";
+  check int "other callbacks delegated" 2 !cache_hits
+
+let () =
+  run "Metrics_event_bridge" [
+    "compose_with_event_bus", [
+      test_case "base callback still invoked" `Quick test_base_callback_invoked;
+      test_case "Custom event published" `Quick test_event_published;
+      test_case "envelope ids propagated" `Quick test_envelope_ids_propagated;
+      test_case "other callbacks delegated" `Quick test_other_callbacks_delegated;
+    ]
+  ]


### PR DESCRIPTION
## Summary

Closes the first of three OAS silent-FSM blind spots identified in the cross-repo LT-12 design doc (masc-mcp#7689).

Cascade routing was previously only visible through \`Metrics.on_cascade_fallback\` — a consumer-owned callback. Dashboards subscribing to \`Event_bus\` could not see it. This PR adds an **opt-in** bridge so consumers who want the bus view can wrap their existing metrics sink at startup with one call.

## Design — opt-in, not forced

- \`Metrics_event_bridge.compose_with_event_bus bus base\` returns a new \`Metrics.t\` whose \`on_cascade_fallback\` first invokes \`base.on_cascade_fallback\` (preserving backend behaviour) then emits \`Custom("cascade_fallback", {from_model, to_model, reason})\` on the bus. Other callbacks are delegated unchanged.
- **\`complete_cascade\` does not change** — it still only receives a \`Metrics.t\`. The bus wiring happens exactly where consumers already wire metrics.
- Bridge lives in \`agent_sdk\` (not \`agent_sdk.llm_provider\`) because \`Event_bus\` is part of \`agent_sdk\`; a reverse edge from the provider layer back up would cycle.

## Envelope

\`correlation_id\` / \`run_id\` default to empty strings so the emitted envelope is still well-formed when per-run identifiers are unknown. Consumers that know the run context should supply them:

\`\`\`ocaml
let metrics =
  Metrics_event_bridge.compose_with_event_bus
    ~correlation_id:run.session_id
    ~run_id:run.worker_run_id
    bus
    my_prometheus_sink
\`\`\`

## Test plan

4/4 alcotest locally:
- \`base callback still invoked\` — compose preserves backend.
- \`Custom event published\` — payload shape verified.
- \`envelope ids propagated\` — when provided.
- \`other callbacks delegated\` — on_cache_hit, on_error etc. untouched.

\`dune build --root .\` clean.

## Follow-ups (deferred)

| PR    | Scope |
|-------|-------|
| LT-14b | content_replacement freeze event → \`Custom("content_replacement_frozen", ...)\` |
| LT-14c | slot_scheduler queue-depth transitions → \`Custom("slot_scheduler_queue", ...)\` |

## References

- masc-mcp#7689 (LT-12) — design doc §5 OAS silent FSM surface.
- \`lib/event_bus.mli\` — envelope contract.
- \`lib/llm_provider/metrics.ml\` — sink definition (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)