### PR TITLE
feat(observability): Content_replacement_event_bridge — CRS freeze → event_bus (LT-14b)

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -143,6 +143,7 @@ module Cost_tracker = Cost_tracker
 module Context_offload = Context_offload
 module Tool_result_store = Tool_result_store
 module Content_replacement_state = Content_replacement_state
+module Content_replacement_event_bridge = Content_replacement_event_bridge
 module Memory = Memory
 module Memory_file_backend = Memory_file_backend
 module Memory_access = Memory_access

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -113,6 +113,7 @@ module Cost_tracker = Cost_tracker
 module Context_offload = Context_offload
 module Tool_result_store = Tool_result_store
 module Content_replacement_state = Content_replacement_state
+module Content_replacement_event_bridge = Content_replacement_event_bridge
 module Memory = Memory
 module Memory_file_backend = Memory_file_backend
 module Memory_access = Memory_access

--- a/lib/content_replacement_event_bridge.ml
+++ b/lib/content_replacement_event_bridge.ml
@@ -1,0 +1,55 @@
+(** Content_replacement_state ↔ Event_bus bridge (LT-14b / observability).
+
+    Lives in [agent_sdk] alongside {!Metrics_event_bridge}. Pattern is
+    identical: wrap the mutator, delegate first (preserving the raise
+    contract), then publish on success. On [Invalid_argument] the event
+    is suppressed because no state transition occurred. *)
+
+module S = Content_replacement_state
+
+let event_topic = "content_replacement_frozen"
+
+let publish_event ~bus ~correlation_id ~run_id payload =
+  let event =
+    Event_bus.mk_event
+      ~correlation_id
+      ~run_id
+      (Event_bus.Custom (event_topic, payload))
+  in
+  Event_bus.publish bus event
+
+let record_replacement_with_events
+    ?(correlation_id = "")
+    ?(run_id = "")
+    (bus : Event_bus.t)
+    (state : S.t)
+    (r : S.replacement)
+  : unit =
+  S.record_replacement state r;
+  let payload =
+    `Assoc [
+      "tool_use_id",      `String r.tool_use_id;
+      "action",           `String "replaced";
+      "preview",          `String r.preview;
+      "original_chars",   `Int r.original_chars;
+      "seen_count_after", `Int (S.seen_count state);
+    ]
+  in
+  publish_event ~bus ~correlation_id ~run_id payload
+
+let record_kept_with_events
+    ?(correlation_id = "")
+    ?(run_id = "")
+    (bus : Event_bus.t)
+    (state : S.t)
+    (tool_use_id : string)
+  : unit =
+  S.record_kept state tool_use_id;
+  let payload =
+    `Assoc [
+      "tool_use_id",      `String tool_use_id;
+      "action",           `String "kept";
+      "seen_count_after", `Int (S.seen_count state);
+    ]
+  in
+  publish_event ~bus ~correlation_id ~run_id payload

--- a/lib/content_replacement_event_bridge.mli
+++ b/lib/content_replacement_event_bridge.mli
@@ -1,0 +1,59 @@
+(** Content_replacement_state ↔ Event_bus bridge.
+
+    Opt-in wrappers around [Content_replacement_state.record_replacement]
+    and [record_kept]. Each call delegates to the original mutator, then
+    publishes a [Custom("content_replacement_frozen", ...)] event on the
+    supplied bus.
+
+    The raw [Content_replacement_state] module itself stays free of any
+    event-bus dependency so the "silent FSM" boundary between pure state
+    and observability is preserved.
+
+    {1 Payload shape}
+
+    {[
+      {
+        "tool_use_id": "toolu_xxx",
+        "action":       "replaced" | "kept",
+        "preview":      "..."     (* present only when action = "replaced" *),
+        "original_chars": 9000    (* present only when action = "replaced" *),
+        "seen_count_after": 3
+      }
+    ]}
+
+    [action] is the discriminator that lets downstream subscribers
+    separate the two freeze variants without looking for optional keys.
+
+    @since 0.154.0 *)
+
+(** Wrap [Content_replacement_state.record_replacement]: record the
+    replacement decision, then publish a [Custom("content_replacement_frozen",
+    {action = "replaced"; ...})] event.
+
+    [correlation_id] / [run_id] default to empty strings, matching the
+    {!Metrics_event_bridge} convention for callers that do not yet have
+    per-run identifiers wired.
+
+    @raise Invalid_argument if the [tool_use_id] is already frozen; the
+    event is not published in that case. *)
+val record_replacement_with_events :
+  ?correlation_id:string ->
+  ?run_id:string ->
+  Event_bus.t ->
+  Content_replacement_state.t ->
+  Content_replacement_state.replacement ->
+  unit
+
+(** Wrap [Content_replacement_state.record_kept]: record the kept
+    decision, then publish a [Custom("content_replacement_frozen",
+    {action = "kept"; ...})] event.
+
+    @raise Invalid_argument if the [tool_use_id] is already frozen; the
+    event is not published in that case. *)
+val record_kept_with_events :
+  ?correlation_id:string ->
+  ?run_id:string ->
+  Event_bus.t ->
+  Content_replacement_state.t ->
+  string ->
+  unit

--- a/test/dune
+++ b/test/dune
@@ -229,6 +229,10 @@
  (libraries agent_sdk alcotest yojson eio eio_main))
 
 (test
+ (name test_content_replacement_event_bridge)
+ (libraries agent_sdk alcotest yojson eio eio_main))
+
+(test
  (name test_otel)
  (libraries agent_sdk alcotest yojson eio eio_main))
 

--- a/test/test_content_replacement_event_bridge.ml
+++ b/test/test_content_replacement_event_bridge.ml
@@ -1,0 +1,150 @@
+(** Tests for Content_replacement_event_bridge — LT-14b opt-in bridge. *)
+
+open Alcotest
+open Agent_sdk
+
+module Bridge = Content_replacement_event_bridge
+module S = Content_replacement_state
+
+let extract_freeze_payload (ev : Event_bus.event) =
+  match ev.payload with
+  | Event_bus.Custom ("content_replacement_frozen", `Assoc kvs) -> Some kvs
+  | _ -> None
+
+let string_field kvs key =
+  match List.assoc_opt key kvs with
+  | Some (`String s) -> s
+  | _ -> Alcotest.fail ("missing string field " ^ key)
+
+let int_field kvs key =
+  match List.assoc_opt key kvs with
+  | Some (`Int n) -> n
+  | _ -> Alcotest.fail ("missing int field " ^ key)
+
+let has_key kvs key = List.mem_assoc key kvs
+
+(* ── record_replacement emits action="replaced" with full detail ─── *)
+
+let test_replacement_event () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  let state = S.create () in
+  Bridge.record_replacement_with_events bus state
+    { tool_use_id = "toolu_01"; preview = "short preview"; original_chars = 9000 };
+  check bool "state was mutated" true (S.is_frozen state "toolu_01");
+  let events = Event_bus.drain sub in
+  check int "one event published" 1 (List.length events);
+  match events with
+  | [ev] ->
+    (match extract_freeze_payload ev with
+     | Some kvs ->
+       check string "action=replaced" "replaced" (string_field kvs "action");
+       check string "tool_use_id" "toolu_01"   (string_field kvs "tool_use_id");
+       check string "preview"     "short preview" (string_field kvs "preview");
+       check int    "original_chars" 9000       (int_field kvs "original_chars");
+       check int    "seen_count_after" 1        (int_field kvs "seen_count_after")
+     | None -> Alcotest.fail "payload not Custom(content_replacement_frozen, _)")
+  | _ -> Alcotest.fail "wrong event count"
+
+(* ── record_kept emits action="kept" without replacement fields ──── *)
+
+let test_kept_event () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  let state = S.create () in
+  Bridge.record_kept_with_events bus state "toolu_02";
+  check bool "state was mutated" true (S.is_frozen state "toolu_02");
+  check (option string) "no replacement recorded" None
+    (Option.map (fun (r : S.replacement) -> r.preview)
+       (S.lookup_replacement state "toolu_02"));
+  let events = Event_bus.drain sub in
+  match events with
+  | [ev] ->
+    (match extract_freeze_payload ev with
+     | Some kvs ->
+       check string "action=kept" "kept" (string_field kvs "action");
+       check string "tool_use_id" "toolu_02" (string_field kvs "tool_use_id");
+       check int    "seen_count_after" 1     (int_field kvs "seen_count_after");
+       check bool   "no preview key" false (has_key kvs "preview");
+       check bool   "no original_chars key" false (has_key kvs "original_chars")
+     | None -> Alcotest.fail "payload not Custom(content_replacement_frozen, _)")
+  | _ -> Alcotest.fail "wrong event count"
+
+(* ── envelope carries correlation_id + run_id when supplied ─────── *)
+
+let test_envelope_ids_propagated () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  let state = S.create () in
+  Bridge.record_replacement_with_events
+    ~correlation_id:"corr-crs"
+    ~run_id:"run-77"
+    bus state
+    { tool_use_id = "toolu_03"; preview = "p"; original_chars = 10 };
+  let events = Event_bus.drain sub in
+  match events with
+  | [ev] ->
+    check string "correlation_id on envelope" "corr-crs" ev.meta.correlation_id;
+    check string "run_id on envelope" "run-77" ev.meta.run_id
+  | _ -> Alcotest.fail "wrong event count"
+
+(* ── double-freeze raises Invalid_argument and does NOT publish ──── *)
+
+let test_double_freeze_no_event () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  let state = S.create () in
+  Bridge.record_kept_with_events bus state "toolu_04";
+  let _ = Event_bus.drain sub in  (* consume the first (legitimate) event *)
+  let raised =
+    try
+      Bridge.record_replacement_with_events bus state
+        { tool_use_id = "toolu_04"; preview = "p"; original_chars = 1 };
+      false
+    with Invalid_argument _ -> true
+  in
+  check bool "second freeze raised" true raised;
+  let events_after = Event_bus.drain sub in
+  check int "no extra event on raised path" 0 (List.length events_after);
+  check int "seen_count unchanged" 1 (S.seen_count state)
+
+(* ── seen_count_after reflects post-state across multiple freezes ── *)
+
+let test_seen_count_growth () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  let state = S.create () in
+  Bridge.record_kept_with_events bus state "a";
+  Bridge.record_replacement_with_events bus state
+    { tool_use_id = "b"; preview = "bb"; original_chars = 100 };
+  Bridge.record_kept_with_events bus state "c";
+  let events = Event_bus.drain sub in
+  check int "three events" 3 (List.length events);
+  let counts =
+    List.map (fun ev ->
+      match extract_freeze_payload ev with
+      | Some kvs -> int_field kvs "seen_count_after"
+      | None -> Alcotest.fail "bad payload"
+    ) events
+  in
+  check (list int) "counts increase 1,2,3" [1; 2; 3] counts
+
+let () =
+  run "Content_replacement_event_bridge" [
+    "bridge", [
+      test_case "record_replacement_with_events publishes replaced"
+        `Quick test_replacement_event;
+      test_case "record_kept_with_events publishes kept"
+        `Quick test_kept_event;
+      test_case "envelope ids propagated" `Quick test_envelope_ids_propagated;
+      test_case "double-freeze raises and suppresses event"
+        `Quick test_double_freeze_no_event;
+      test_case "seen_count_after matches post-state"
+        `Quick test_seen_count_growth;
+    ]
+  ]


### PR DESCRIPTION
## Summary

Stacks on top of #981 (LT-14, `feat/cascade-fallback-event`).

Second bridge in the OAS "silent FSM → Event_bus" series identified by the MASC-side composite-FSM spec audit (LT-12 design doc). Adds opt-in wrappers around `Content_replacement_state.record_replacement` and `record_kept` that publish a `Custom("content_replacement_frozen", …)` event after the state is successfully mutated.

### Payload shape

```json
{
  "tool_use_id": "toolu_xxx",
  "action":       "replaced" | "kept",
  "preview":      "...",          // present only when action = "replaced"
  "original_chars": 9000,         // present only when action = "replaced"
  "seen_count_after": 3
}
```

The `action` discriminator lets downstream subscribers separate the two freeze variants without probing for optional keys (LLM-readable contract, consistent with the MASC gate-response feedback).

### Boundary

`Content_replacement_state` itself stays free of Event_bus. The bridge lives in `lib/content_replacement_event_bridge.ml` — the same layering decision as `Metrics_event_bridge` (LT-14). Agent_turn.ml callsite wiring is deliberately **not** part of this PR — the unit of this change is the bridge module itself.

### Raise semantics

On double-freeze, `record_replacement_with_events` / `record_kept_with_events` raise `Invalid_argument` exactly like the originals **and do not publish** an event (test `double-freeze raises and suppresses event` asserts this). Publish-only-on-success keeps the event stream aligned with actual state transitions.

### Why stacked

#981 introduces the Event_bus-bridge pattern and wires up the first payload (`cascade_fallback`). This PR extends the same pattern to the content-replacement freeze FSM, so reviewing them as a stack keeps the bridge-shape consistency visible in one place.

## Test plan

- [x] `dune exec test/test_content_replacement_event_bridge.exe` — 5/5 pass
- [x] LT-14 regression — `test_metrics_event_bridge.exe` 4/4 pass
- [ ] CI green
- [ ] Downstream consumer wiring (agent_turn.ml callsites) — separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
