### PR TITLE
feat(observability): Slot_scheduler_event_bridge — queue-depth FSM → event_bus (LT-14c)

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -144,6 +144,7 @@ module Context_offload = Context_offload
 module Tool_result_store = Tool_result_store
 module Content_replacement_state = Content_replacement_state
 module Content_replacement_event_bridge = Content_replacement_event_bridge
+module Slot_scheduler_event_bridge = Slot_scheduler_event_bridge
 module Memory = Memory
 module Memory_file_backend = Memory_file_backend
 module Memory_access = Memory_access

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -114,6 +114,7 @@ module Context_offload = Context_offload
 module Tool_result_store = Tool_result_store
 module Content_replacement_state = Content_replacement_state
 module Content_replacement_event_bridge = Content_replacement_event_bridge
+module Slot_scheduler_event_bridge = Slot_scheduler_event_bridge
 module Memory = Memory
 module Memory_file_backend = Memory_file_backend
 module Memory_access = Memory_access

--- a/lib/slot_scheduler_event_bridge.ml
+++ b/lib/slot_scheduler_event_bridge.ml
@@ -1,0 +1,49 @@
+(** Slot_scheduler ↔ Event_bus publisher (LT-14c / observability).
+
+    Third member of the OAS silent-FSM-to-event-bus series after
+    {!Metrics_event_bridge} (cascade_fallback) and
+    {!Content_replacement_event_bridge} (content_replacement_frozen).
+
+    Shape difference: slot_scheduler already exposes a read-only
+    [snapshot] API so this module is a pure publisher rather than a
+    mutator wrapper — no Invalid_argument-suppression logic needed. *)
+
+module Sched = Llm_provider.Slot_scheduler
+
+let event_topic = "slot_scheduler_queue"
+
+let derive_state (snap : Sched.snapshot) : string =
+  if snap.available = 0 && snap.queue_length > 0 then "saturated"
+  else if snap.queue_length > 0 then "queued"
+  else "idle"
+
+let payload_of_snap (snap : Sched.snapshot) : Yojson.Safe.t =
+  `Assoc [
+    "max_slots",    `Int snap.max_slots;
+    "active",       `Int snap.active;
+    "available",    `Int snap.available;
+    "queue_length", `Int snap.queue_length;
+    "state",        `String (derive_state snap);
+  ]
+
+let publish_snap
+    ?(correlation_id = "")
+    ?(run_id = "")
+    (bus : Event_bus.t)
+    (snap : Sched.snapshot)
+  : unit =
+  let event =
+    Event_bus.mk_event
+      ~correlation_id
+      ~run_id
+      (Event_bus.Custom (event_topic, payload_of_snap snap))
+  in
+  Event_bus.publish bus event
+
+let publish_snapshot
+    ?(correlation_id = "")
+    ?(run_id = "")
+    (bus : Event_bus.t)
+    (scheduler : Sched.t)
+  : unit =
+  publish_snap ~correlation_id ~run_id bus (Sched.snapshot scheduler)

--- a/lib/slot_scheduler_event_bridge.mli
+++ b/lib/slot_scheduler_event_bridge.mli
@@ -1,0 +1,69 @@
+(** Slot_scheduler ↔ Event_bus publisher.
+
+    Projects a {!Llm_provider.Slot_scheduler} snapshot onto the supplied
+    {!Event_bus} as a [Custom("slot_scheduler_queue", ...)] event. Unlike
+    {!Metrics_event_bridge} and {!Content_replacement_event_bridge}, this
+    module does NOT wrap a mutator — the scheduler is read-only from our
+    perspective. Callers decide when to publish (typically on grant,
+    release, or a periodic tick).
+
+    {1 Payload shape}
+
+    {[
+      {
+        "max_slots":    int,
+        "active":       int,
+        "available":    int,
+        "queue_length": int,
+        "state":        "idle" | "queued" | "saturated"
+      }
+    ]}
+
+    [state] is a derived discriminator — see {!derive_state}.
+
+    {1 Edge detection}
+
+    This module is deliberately level-based. If a subscriber only cares
+    about transitions, it must diff against the previous event on its own
+    side. Keeping the bridge stateless avoids having to reason about a
+    second mutex/ref inside the scheduler layer.
+
+    @since 0.154.0 *)
+
+(** Derive a three-state discriminator from a scheduler snapshot.
+
+    - ["saturated"] when [available = 0 && queue_length > 0]
+      — all slots in use AND at least one fiber waiting.
+    - ["queued"]    when [queue_length > 0]
+      — waiters exist but capacity is not necessarily exhausted (rare but
+      possible during grant race). Treated as a softer congestion signal.
+    - ["idle"]      otherwise — either slack capacity OR all slots used
+      with no waiters.
+
+    Pure function — safe to call in tests without a real scheduler. *)
+val derive_state :
+  Llm_provider.Slot_scheduler.snapshot ->
+  string
+
+(** Publish a given snapshot to [bus] as a
+    [Custom("slot_scheduler_queue", ...)] event. Separated from
+    {!publish_snapshot} so tests can drive deterministic snapshots
+    without creating a live scheduler.
+
+    [correlation_id] / [run_id] default to empty strings, matching the
+    convention established by {!Metrics_event_bridge}. *)
+val publish_snap :
+  ?correlation_id:string ->
+  ?run_id:string ->
+  Event_bus.t ->
+  Llm_provider.Slot_scheduler.snapshot ->
+  unit
+
+(** Take a fresh snapshot of [scheduler] and publish it.
+    Equivalent to [publish_snap bus (Slot_scheduler.snapshot scheduler)]. *)
+val publish_snapshot :
+  ?correlation_id:string ->
+  ?run_id:string ->
+  Event_bus.t ->
+  Llm_provider.Slot_scheduler.t ->
+  unit

--- a/test/dune
+++ b/test/dune
@@ -233,6 +233,10 @@
  (libraries agent_sdk alcotest yojson eio eio_main))
 
 (test
+ (name test_slot_scheduler_event_bridge)
+ (libraries agent_sdk llm_provider alcotest yojson eio eio_main))
+
+(test
  (name test_otel)
  (libraries agent_sdk alcotest yojson eio eio_main))
 

--- a/test/test_slot_scheduler_event_bridge.ml
+++ b/test/test_slot_scheduler_event_bridge.ml
@@ -1,0 +1,118 @@
+(** Tests for Slot_scheduler_event_bridge — LT-14c publisher. *)
+
+open Alcotest
+open Agent_sdk
+
+module Bridge = Slot_scheduler_event_bridge
+module Sched = Llm_provider.Slot_scheduler
+
+let extract_queue_payload (ev : Event_bus.event) =
+  match ev.payload with
+  | Event_bus.Custom ("slot_scheduler_queue", `Assoc kvs) -> Some kvs
+  | _ -> None
+
+let string_field kvs key =
+  match List.assoc_opt key kvs with
+  | Some (`String s) -> s
+  | _ -> Alcotest.fail ("missing string field " ^ key)
+
+let int_field kvs key =
+  match List.assoc_opt key kvs with
+  | Some (`Int n) -> n
+  | _ -> Alcotest.fail ("missing int field " ^ key)
+
+let mk_snap ~max_slots ~active ~queue_length : Sched.snapshot =
+  { max_slots; active; available = max_slots - active; queue_length }
+
+(* ── derive_state: pure three-branch discriminator ─────────────── *)
+
+let test_derive_state_idle () =
+  let snap = mk_snap ~max_slots:4 ~active:0 ~queue_length:0 in
+  check string "all free is idle" "idle" (Bridge.derive_state snap);
+  let snap2 = mk_snap ~max_slots:4 ~active:4 ~queue_length:0 in
+  check string "saturated-without-queue is idle" "idle" (Bridge.derive_state snap2)
+
+let test_derive_state_queued () =
+  (* available > 0 but queue_length > 0: rare grant-race window *)
+  let snap = mk_snap ~max_slots:4 ~active:2 ~queue_length:1 in
+  check string "waiters + slack → queued" "queued" (Bridge.derive_state snap)
+
+let test_derive_state_saturated () =
+  let snap = mk_snap ~max_slots:4 ~active:4 ~queue_length:3 in
+  check string "full + waiters → saturated" "saturated" (Bridge.derive_state snap)
+
+(* ── publish_snap: level-based event emission ──────────────────── *)
+
+let test_publish_snap_fields () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  let snap = mk_snap ~max_slots:8 ~active:5 ~queue_length:2 in
+  Bridge.publish_snap bus snap;
+  let events = Event_bus.drain sub in
+  check int "one event" 1 (List.length events);
+  match events with
+  | [ev] ->
+    (match extract_queue_payload ev with
+     | Some kvs ->
+       check int "max_slots"    8 (int_field kvs "max_slots");
+       check int "active"       5 (int_field kvs "active");
+       check int "available"    3 (int_field kvs "available");
+       check int "queue_length" 2 (int_field kvs "queue_length");
+       check string "state=queued" "queued" (string_field kvs "state")
+     | None -> Alcotest.fail "payload not Custom(slot_scheduler_queue, _)")
+  | _ -> Alcotest.fail "wrong event count"
+
+(* ── envelope carries correlation_id + run_id ──────────────────── *)
+
+let test_envelope_ids_propagated () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  Bridge.publish_snap
+    ~correlation_id:"corr-slot"
+    ~run_id:"run-99"
+    bus
+    (mk_snap ~max_slots:1 ~active:0 ~queue_length:0);
+  let events = Event_bus.drain sub in
+  match events with
+  | [ev] ->
+    check string "correlation_id" "corr-slot" ev.meta.correlation_id;
+    check string "run_id" "run-99" ev.meta.run_id
+  | _ -> Alcotest.fail "wrong event count"
+
+(* ── publish_snapshot: live scheduler round-trip ───────────────── *)
+
+let test_publish_snapshot_live_scheduler () =
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  let scheduler = Sched.create ~max_slots:4 in
+  (* Fresh scheduler: all slots available, no waiters → idle. *)
+  Bridge.publish_snapshot bus scheduler;
+  let events = Event_bus.drain sub in
+  match events with
+  | [ev] ->
+    (match extract_queue_payload ev with
+     | Some kvs ->
+       check string "state=idle" "idle" (string_field kvs "state");
+       check int    "active=0"    0      (int_field kvs "active");
+       check int    "available=4" 4      (int_field kvs "available");
+       check int    "queue=0"     0      (int_field kvs "queue_length");
+       check int    "max=4"       4      (int_field kvs "max_slots")
+     | None -> Alcotest.fail "payload not Custom(slot_scheduler_queue, _)")
+  | _ -> Alcotest.fail "wrong event count"
+
+let () =
+  run "Slot_scheduler_event_bridge" [
+    "derive_state", [
+      test_case "idle"      `Quick test_derive_state_idle;
+      test_case "queued"    `Quick test_derive_state_queued;
+      test_case "saturated" `Quick test_derive_state_saturated;
+    ];
+    "publish", [
+      test_case "publish_snap carries all fields"     `Quick test_publish_snap_fields;
+      test_case "envelope ids propagated"             `Quick test_envelope_ids_propagated;
+      test_case "publish_snapshot on fresh scheduler" `Quick test_publish_snapshot_live_scheduler;
+    ];
+  ]


### PR DESCRIPTION
## Summary

Third bridge in the OAS silent-FSM-to-event-bus series.

Stacks on #982 (LT-14b, `feat/content-replacement-event`), which stacks on #981 (LT-14, `feat/cascade-fallback-event`).

Unlike LT-14 (cascade_fallback, `Metrics.t` callback wrap) and LT-14b (CRS freeze, mutator wrap), `slot_scheduler` already exposes a read-only `snapshot` API, so this module is a **pure level-based publisher** rather than a mutator wrapper. The scheduler itself is not modified.

## Payload shape

```json
{
  "max_slots":    4,
  "active":       2,
  "available":    2,
  "queue_length": 1,
  "state":        "idle" | "queued" | "saturated"
}
```

### Derivation rule

`state` is a pure 3-branch discriminator:

- `"saturated"` when `available = 0 AND queue_length > 0`
- `"queued"` when `queue_length > 0` (covers rare grant-race window where available > 0 but waiters linger)
- `"idle"` otherwise

Exposed as `derive_state : Slot_scheduler.snapshot -> string` so tests and downstream subscribers can classify snapshots without a live scheduler.

## Design: level-based, not edge-triggered

`publish_snap` and `publish_snapshot` emit *whatever the scheduler reports at call time*. Callers decide the emit cadence (typical callsites: after grant, after release, or on a periodic tick). Edge detection is the subscriber's responsibility.

**Why level-based?** Keeping the bridge stateless avoids adding a second mutex/ref on the scheduler hot path. The alternative (stateful bridge that stores previous state) would double the synchronisation surface for no real gain.

## Test plan

- [x] `dune exec test/test_slot_scheduler_event_bridge.exe` — 6/6 pass
  - derive_state: idle / queued / saturated
  - publish_snap field correctness + envelope ids
  - publish_snapshot on a fresh live scheduler (idle path)
- [x] LT-14 regression — `test_metrics_event_bridge.exe` 4/4
- [x] LT-14b regression — `test_content_replacement_event_bridge.exe` 5/5
- [ ] CI green
- [ ] Downstream `emit_snapshot` wiring (agent_turn / complete_cascade callsites) — separate PR

## Stack

```
main
  ↑ #981 (LT-14,  cascade_fallback)       feat/cascade-fallback-event
    ↑ #982 (LT-14b, content_replacement)  feat/content-replacement-event
      ↑ THIS  (LT-14c, slot_scheduler)    feat/slot-scheduler-event
```

PRs in this stack should be reviewed bottom-up. The bridge shape consistency (wrapper vs publisher) is visible across all three when reviewed together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
