### PR TITLE
Add post-compaction hooks to OAS runtime

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -132,7 +132,8 @@ let invoke_hook ?on_hook_invoked ~tracer ~agent_name ~turn_count ~hook_name
               | Hooks.BeforeTurn _ | Hooks.BeforeTurnParams _
               | Hooks.AfterTurn _ | Hooks.OnStop _
               | Hooks.OnIdle _ | Hooks.OnError _
-              | Hooks.OnToolError _ | Hooks.PreCompact _ -> None)
+              | Hooks.OnToolError _ | Hooks.PreCompact _
+              | Hooks.PostCompact _ -> None)
       | None -> ());
       decision)
 

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -127,6 +127,13 @@ type hook_event =
       estimated_tokens: int;
       budget_tokens: int;
     }
+  | PostCompact of {
+      before_messages: message list;
+      after_messages: message list;
+      before_tokens: int;
+      after_tokens: int;
+      phase: string;
+    }
 
 (** Elicitation: structured request for user input during agent execution.
     Inspired by Claude SDK MCP Elicitation pattern. *)
@@ -183,6 +190,7 @@ type hooks = {
   on_error: hook option;
   on_tool_error: hook option;
   pre_compact: hook option;
+  post_compact: hook option;
 }
 
 (** Empty hooks -- no-op default *)
@@ -198,6 +206,7 @@ let empty = {
   on_error = None;
   on_tool_error = None;
   pre_compact = None;
+  post_compact = None;
 }
 
 (** Context injection: data returned by a context_injector after tool execution.
@@ -257,6 +266,7 @@ let stage_of_event = function
   | OnError _ -> "on_error"
   | OnToolError _ -> "on_tool_error"
   | PreCompact _ -> "pre_compact"
+  | PostCompact _ -> "post_compact"
 
 (** Legal decision matrix.
 
@@ -274,6 +284,7 @@ let stage_of_event = function
     on_error             |    Y     |      |          |                  |              |             |
     on_tool_error        |    Y     |      |          |                  |              |             |
     pre_compact          |    Y     |  Y   |          |                  |              |             |
+    post_compact         |    Y     |      |          |                  |              |             |
     v}
 
     Fail-closed: any decision not explicitly listed is rejected. *)
@@ -290,6 +301,7 @@ let legal_decisions_for_stage stage =
   | "on_error"              -> [K_Continue]
   | "on_tool_error"         -> [K_Continue]
   | "pre_compact"           -> [K_Continue; K_Skip]
+  | "post_compact"          -> [K_Continue]
   | _                       -> []   (* unknown stage: nothing is legal *)
 
 (** Validate that a hook_decision is legal for a given stage.
@@ -356,4 +368,5 @@ let compose ~outer ~inner = {
   on_error = compose_hook outer.on_error inner.on_error;
   on_tool_error = compose_hook outer.on_tool_error inner.on_tool_error;
   pre_compact = compose_hook outer.pre_compact inner.pre_compact;
+  post_compact = compose_hook outer.post_compact inner.post_compact;
 }

--- a/lib/hooks.mli
+++ b/lib/hooks.mli
@@ -82,6 +82,13 @@ type hook_event =
       estimated_tokens: int;
       budget_tokens: int;
     }
+  | PostCompact of {
+      before_messages: Types.message list;
+      after_messages: Types.message list;
+      before_tokens: int;
+      after_tokens: int;
+      phase: string;
+    }
 
 (** Elicitation: structured request for user input during agent execution. *)
 type elicitation_request = {
@@ -135,6 +142,7 @@ type hooks = {
   on_error: hook option;
   on_tool_error: hook option;
   pre_compact: hook option;
+  post_compact: hook option;
 }
 
 (** Context injection: data returned by a context_injector after tool execution *)
@@ -170,6 +178,7 @@ val invoke : hook option -> hook_event -> hook_decision
     on_error             |    Y     |      |          |                  |              |
     on_tool_error        |    Y     |      |          |                  |              |
     pre_compact          |    Y     |  Y   |          |                  |              |
+    post_compact         |    Y     |      |          |                  |              |
     v}
 
     Fail-closed: unknown stages reject all decisions. *)

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -552,7 +552,21 @@ let proactive_compact ?raw_trace_run agent ~watermark () =
         acc + Context_reducer.estimate_message_tokens msg) 0 reduced in
       if after_tokens >= est_tokens then false
       else begin
+        let phase =
+          Printf.sprintf "proactive(%.0f%%)" (usage_ratio *. 100.0)
+        in
         update_state agent (fun s -> { s with messages = reduced });
+        ignore
+          (invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"post_compact"
+             agent.options.hooks.post_compact
+             (Hooks.PostCompact
+                {
+                  before_messages = messages;
+                  after_messages = reduced;
+                  before_tokens = est_tokens;
+                  after_tokens;
+                  phase;
+                }));
         (match agent.options.event_bus with
          | Some bus -> Event_bus.publish bus
              { meta = event_envelope agent;
@@ -560,7 +574,7 @@ let proactive_compact ?raw_trace_run agent ~watermark () =
                  agent_name = agent.state.config.name;
                  before_tokens = est_tokens;
                  after_tokens;
-                 phase = Printf.sprintf "proactive(%.0f%%)" (usage_ratio *. 100.0) } }
+                 phase } }
          | None -> ());
         (match agent.options.journal with
          | Some j ->
@@ -606,7 +620,19 @@ let emergency_compact ?raw_trace_run agent ?limit () =
       acc + Context_reducer.estimate_message_tokens msg) 0 reduced in
     if after_tokens >= est_tokens then false
     else begin
+      let phase = "emergency" in
       update_state agent (fun s -> { s with messages = reduced });
+      ignore
+        (invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"post_compact"
+           agent.options.hooks.post_compact
+           (Hooks.PostCompact
+              {
+                before_messages = messages;
+                after_messages = reduced;
+                before_tokens = est_tokens;
+                after_tokens;
+                phase;
+              }));
       (match agent.options.event_bus with
        | Some bus -> Event_bus.publish bus
            { meta = event_envelope agent;
@@ -614,7 +640,7 @@ let emergency_compact ?raw_trace_run agent ?limit () =
                agent_name = agent.state.config.name;
                before_tokens = est_tokens;
                after_tokens;
-               phase = "emergency" } }
+               phase } }
        | None -> ());
       (match agent.options.journal with
        | Some j ->

--- a/lib/proof_capture.ml
+++ b/lib/proof_capture.ml
@@ -187,6 +187,7 @@ let hooks st =
 
     on_tool_error = None;
     pre_compact = None;
+    post_compact = None;
   }
 
 let collect_evidence_refs st =

--- a/test/test_hooks.ml
+++ b/test/test_hooks.ml
@@ -151,6 +151,35 @@ let test_empty_hooks_pre_compact () =
   let hooks = Hooks.empty in
   check bool "pre_compact is None" true (hooks.pre_compact = None)
 
+let test_post_compact_event () =
+  let received_after_tokens = ref 0 in
+  let hook = function
+    | Hooks.PostCompact { after_tokens; phase; _ } ->
+        received_after_tokens := after_tokens;
+        check string "phase propagated" "proactive(75%)" phase;
+        Hooks.Continue
+    | _ -> Hooks.Continue
+  in
+  let msgs =
+    [ Types.{ role = User; content = [ Text "hello" ]; name = None; tool_call_id = None } ]
+  in
+  let _result =
+    Hooks.invoke (Some hook)
+      (Hooks.PostCompact
+         {
+           before_messages = msgs;
+           after_messages = [];
+           before_tokens = 5000;
+           after_tokens = 1200;
+           phase = "proactive(75%)";
+         })
+  in
+  check int "hook received after_tokens" 1200 !received_after_tokens
+
+let test_empty_hooks_post_compact () =
+  let hooks = Hooks.empty in
+  check bool "post_compact is None" true (hooks.post_compact = None)
+
 (* ── Decision matrix tests ────────────────────────────────── *)
 
 let dummy_pre_tool_use =
@@ -217,6 +246,16 @@ let dummy_on_tool_error =
 let dummy_pre_compact =
   Hooks.PreCompact { messages = []; estimated_tokens = 100; budget_tokens = 200 }
 
+let dummy_post_compact =
+  Hooks.PostCompact
+    {
+      before_messages = [];
+      after_messages = [];
+      before_tokens = 200;
+      after_tokens = 100;
+      phase = "emergency";
+    }
+
 (** Test that each (stage, decision) pair in the matrix is accepted. *)
 let test_validate_legal_before_turn () =
   let ok = Hooks.validate_decision ~stage:"before_turn" Hooks.Continue in
@@ -251,10 +290,14 @@ let test_validate_legal_pre_compact () =
   let ok2 = Hooks.validate_decision ~stage:"pre_compact" Hooks.Skip in
   check bool "Skip at pre_compact" true (Result.is_ok ok2)
 
+let test_validate_legal_post_compact () =
+  let ok = Hooks.validate_decision ~stage:"post_compact" Hooks.Continue in
+  check bool "Continue at post_compact" true (Result.is_ok ok)
+
 let test_validate_legal_observe_only_stages () =
   let stages = [
     "after_turn"; "post_tool_use"; "post_tool_use_failure";
-    "on_stop"; "on_idle"; "on_error"; "on_tool_error";
+    "on_stop"; "on_idle"; "on_error"; "on_tool_error"; "post_compact";
   ] in
   List.iter (fun stage ->
     let ok = Hooks.validate_decision ~stage Hooks.Continue in
@@ -304,6 +347,7 @@ let test_stage_of_event () =
     (dummy_on_error, "on_error");
     (dummy_on_tool_error, "on_tool_error");
     (dummy_pre_compact, "pre_compact");
+    (dummy_post_compact, "post_compact");
   ] in
   List.iter (fun (event, expected) ->
     check string
@@ -360,6 +404,7 @@ let test_all_stages_allow_continue () =
     "before_turn"; "before_turn_params"; "after_turn";
     "pre_tool_use"; "post_tool_use"; "post_tool_use_failure";
     "on_stop"; "on_idle"; "on_error"; "on_tool_error"; "pre_compact";
+    "post_compact";
   ] in
   List.iter (fun stage ->
     let legal = Hooks.legal_decisions_for_stage stage in
@@ -373,6 +418,7 @@ let () =
     "empty", [
       test_case "empty hooks" `Quick test_empty_hooks;
       test_case "pre_compact None" `Quick test_empty_hooks_pre_compact;
+      test_case "post_compact None" `Quick test_empty_hooks_post_compact;
     ];
     "invoke", [
       test_case "invoke None" `Quick test_invoke_none;
@@ -389,11 +435,16 @@ let () =
       test_case "receives tokens" `Quick test_pre_compact_event;
       test_case "returns Skip" `Quick test_pre_compact_skip;
     ];
+    "post_compact", [
+      test_case "receives tokens after compaction" `Quick
+        test_post_compact_event;
+    ];
     "decision_matrix", [
       test_case "legal: before_turn" `Quick test_validate_legal_before_turn;
       test_case "legal: before_turn_params" `Quick test_validate_legal_before_turn_params;
       test_case "legal: pre_tool_use" `Quick test_validate_legal_pre_tool_use;
       test_case "legal: pre_compact" `Quick test_validate_legal_pre_compact;
+      test_case "legal: post_compact" `Quick test_validate_legal_post_compact;
       test_case "legal: observe-only stages" `Quick test_validate_legal_observe_only_stages;
       test_case "illegal: Skip at before_turn" `Quick test_validate_illegal_skip_at_before_turn;
       test_case "illegal: AdjustParams at pre_tool_use" `Quick test_validate_illegal_adjust_at_pre_tool_use;


### PR DESCRIPTION
## Summary
- add an observer-only `PostCompact` hook event and `post_compact` slot to OAS hooks
- fire the hook after successful proactive and emergency compaction without changing existing event-bus behavior
- update proof capture, agent tool hook matching, and hook tests for the new lifecycle surface

## Paired Change
- paired MASC consumer work: jeong-sik/masc-mcp#7819

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/feature-runtime-state-consolidation`
- `./_build/default/test/test_hooks.exe`
