### PR TITLE
feat(provider): add provider_config_of_agent forward adapter

### DIFF
--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -487,16 +487,20 @@ let config_of_provider_config (pc : Llm_provider.Provider_config.t) : config =
     {!Llm_provider.Complete.complete} surface.
 
     Sampling params, tool_choice, thinking controls are pulled from
-    [state.config].  Provider kind, model_id, api_key are resolved from
-    [provider_opt] + env vars.  When [provider_opt] is [None], falls
-    back to Anthropic using [ANTHROPIC_API_KEY] (matching
-    {!create_message}'s existing default).
+    [state.config].  Provider kind, model_id, headers, request_path,
+    and api_key are resolved from [provider_opt] + env vars.  When
+    [provider_opt] is [None], falls back to Anthropic using
+    [ANTHROPIC_API_KEY] (matching {!create_message}'s existing default).
 
     [OpenAICompat] provider collapses to [OpenAI_compat] kind — the
     legacy {!config} variant does not distinguish Gemini/Glm/Ollama/
     Claude_code from generic OpenAI-compatible endpoints.  Callers that
     require a specific kind should construct {!Llm_provider.Provider_config.t}
     directly via {!Llm_provider.Provider_config.make}.
+
+    [Custom_registered] is intentionally rejected: the custom provider
+    registry can define request/parse semantics that the consolidated
+    {!Llm_provider.Complete.complete} surface cannot represent safely.
 
     @since 0.155.0 *)
 let provider_config_of_agent
@@ -505,13 +509,15 @@ let provider_config_of_agent
     (provider_opt : config option)
   : (Llm_provider.Provider_config.t, Error.sdk_error) result =
   let cfg = state.config in
-  let build ~kind ~resolved_base_url ~api_key ~model_id =
+  let build ~kind ~resolved_base_url ~api_key ~headers ~request_path ~model_id =
     Ok
       (Llm_provider.Provider_config.make
          ~kind
          ~model_id
          ~base_url:resolved_base_url
          ~api_key
+         ~headers
+         ~request_path
          ?max_tokens:cfg.max_tokens
          ?temperature:cfg.temperature
          ?top_p:cfg.top_p
@@ -528,21 +534,48 @@ let provider_config_of_agent
   in
   match provider_opt with
   | Some p ->
-      (match resolve p with
-       | Error e -> Error e
-       | Ok (url, api_key, _headers) ->
-           let kind : Llm_provider.Provider_config.provider_kind =
-             match p.provider with
-             | Anthropic -> Anthropic
-             | Local _ | OpenAICompat _ | Custom_registered _ -> OpenAI_compat
-           in
-           build ~kind ~resolved_base_url:url ~api_key
-             ~model_id:p.model_id)
+      (match p.provider with
+       | Custom_registered { name } ->
+           Error
+             (Error.Config
+                (InvalidConfig
+                   {
+                     field = "provider";
+                     detail =
+                       Printf.sprintf
+                         "provider_config_of_agent does not support Custom_registered provider '%s'; construct Provider_config.t directly"
+                         name;
+                   }))
+       | Anthropic | Local _ | OpenAICompat _ ->
+           (match resolve p with
+            | Error e -> Error e
+            | Ok (url, api_key, headers) ->
+                let kind : Llm_provider.Provider_config.provider_kind =
+                  match p.provider with
+                  | Anthropic -> Anthropic
+                  | Local _ | OpenAICompat _ -> OpenAI_compat
+                  | Custom_registered _ -> assert false
+                in
+                let sanitized_api_key =
+                  match p.provider with
+                  | Local _ -> ""
+                  | Anthropic | OpenAICompat _ -> api_key
+                  | Custom_registered _ -> assert false
+                in
+                build ~kind ~resolved_base_url:url ~api_key:sanitized_api_key
+                  ~headers ~request_path:(request_path p.provider)
+                  ~model_id:p.model_id))
   | None ->
-      (match Sys.getenv_opt "ANTHROPIC_API_KEY" with
-       | Some key ->
+      let fallback_provider : config =
+        {
+          provider = Anthropic;
+          model_id = Types.model_to_string cfg.model;
+          api_key_env = "ANTHROPIC_API_KEY";
+        }
+      in
+      (match resolve fallback_provider with
+       | Error e -> Error e
+       | Ok (_resolved_url, api_key, headers) ->
            build ~kind:Anthropic ~resolved_base_url:base_url
-             ~api_key:key
-             ~model_id:(Types.model_to_string cfg.model)
-       | None ->
-           Error (Error.Config (MissingEnvVar { var_name = "ANTHROPIC_API_KEY" })))
+             ~api_key ~headers ~request_path:(request_path Anthropic)
+             ~model_id:(Types.model_to_string cfg.model))

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -480,3 +480,69 @@ let config_of_provider_config (pc : Llm_provider.Provider_config.t) : config =
   in
   let api_key_env = default_api_key_env_of_kind pc.kind in
   { provider; model_id = pc.model_id; api_key_env }
+
+(** Forward adapter: build a {!Llm_provider.Provider_config.t} from an
+    agent state and optional {!config}.  Used when a caller needs to
+    bridge the legacy {!create_message} surface to the consolidated
+    {!Llm_provider.Complete.complete} surface.
+
+    Sampling params, tool_choice, thinking controls are pulled from
+    [state.config].  Provider kind, model_id, api_key are resolved from
+    [provider_opt] + env vars.  When [provider_opt] is [None], falls
+    back to Anthropic using [ANTHROPIC_API_KEY] (matching
+    {!create_message}'s existing default).
+
+    [OpenAICompat] provider collapses to [OpenAI_compat] kind — the
+    legacy {!config} variant does not distinguish Gemini/Glm/Ollama/
+    Claude_code from generic OpenAI-compatible endpoints.  Callers that
+    require a specific kind should construct {!Llm_provider.Provider_config.t}
+    directly via {!Llm_provider.Provider_config.make}.
+
+    @since 0.155.0 *)
+let provider_config_of_agent
+    ~(state : Types.agent_state)
+    ~(base_url : string)
+    (provider_opt : config option)
+  : (Llm_provider.Provider_config.t, Error.sdk_error) result =
+  let cfg = state.config in
+  let build ~kind ~resolved_base_url ~api_key ~model_id =
+    Ok
+      (Llm_provider.Provider_config.make
+         ~kind
+         ~model_id
+         ~base_url:resolved_base_url
+         ~api_key
+         ?max_tokens:cfg.max_tokens
+         ?temperature:cfg.temperature
+         ?top_p:cfg.top_p
+         ?top_k:cfg.top_k
+         ?min_p:cfg.min_p
+         ?enable_thinking:cfg.enable_thinking
+         ?thinking_budget:cfg.thinking_budget
+         ?tool_choice:cfg.tool_choice
+         ?system_prompt:cfg.system_prompt
+         ~disable_parallel_tool_use:cfg.disable_parallel_tool_use
+         ~response_format_json:cfg.response_format_json
+         ~cache_system_prompt:cfg.cache_system_prompt
+         ())
+  in
+  match provider_opt with
+  | Some p ->
+      (match resolve p with
+       | Error e -> Error e
+       | Ok (url, api_key, _headers) ->
+           let kind : Llm_provider.Provider_config.provider_kind =
+             match p.provider with
+             | Anthropic -> Anthropic
+             | Local _ | OpenAICompat _ | Custom_registered _ -> OpenAI_compat
+           in
+           build ~kind ~resolved_base_url:url ~api_key
+             ~model_id:p.model_id)
+  | None ->
+      (match Sys.getenv_opt "ANTHROPIC_API_KEY" with
+       | Some key ->
+           build ~kind:Anthropic ~resolved_base_url:base_url
+             ~api_key:key
+             ~model_id:(Types.model_to_string cfg.model)
+       | None ->
+           Error (Error.Config (MissingEnvVar { var_name = "ANTHROPIC_API_KEY" })))

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -170,15 +170,19 @@ val config_of_provider_config : Llm_provider.Provider_config.t -> config
 
 (** Forward adapter: build a {!Llm_provider.Provider_config.t} from an
     agent state and optional {!config}.  Sampling params, tool_choice,
-    thinking controls come from [state.config]; provider kind and
-    api_key come from [provider_opt] (or the [ANTHROPIC_API_KEY]
-    fallback when [None]).
+    thinking controls come from [state.config]; provider kind,
+    headers, request_path, and api_key come from [provider_opt]
+    (or the [ANTHROPIC_API_KEY] fallback when [None]).
 
     [OpenAICompat] provider collapses to [OpenAI_compat] kind: the
     legacy {!config} variant does not distinguish Gemini/Glm/Ollama/
     Claude_code from generic OpenAI-compatible endpoints.  Callers
     needing a specific kind should use
     {!Llm_provider.Provider_config.make} directly.
+
+    [Custom_registered] providers are rejected: the custom registry can
+    define request/parse semantics that {!Llm_provider.Complete.complete}
+    cannot preserve through this adapter.
 
     @since 0.155.0 *)
 val provider_config_of_agent :

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -167,3 +167,22 @@ val default_api_key_env_of_kind :
     @since 0.84.0
     @since 0.87.0 — env var fallback *)
 val config_of_provider_config : Llm_provider.Provider_config.t -> config
+
+(** Forward adapter: build a {!Llm_provider.Provider_config.t} from an
+    agent state and optional {!config}.  Sampling params, tool_choice,
+    thinking controls come from [state.config]; provider kind and
+    api_key come from [provider_opt] (or the [ANTHROPIC_API_KEY]
+    fallback when [None]).
+
+    [OpenAICompat] provider collapses to [OpenAI_compat] kind: the
+    legacy {!config} variant does not distinguish Gemini/Glm/Ollama/
+    Claude_code from generic OpenAI-compatible endpoints.  Callers
+    needing a specific kind should use
+    {!Llm_provider.Provider_config.make} directly.
+
+    @since 0.155.0 *)
+val provider_config_of_agent :
+  state:Types.agent_state ->
+  base_url:string ->
+  config option ->
+  (Llm_provider.Provider_config.t, Error.sdk_error) result

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -478,6 +478,11 @@ let test_provider_config_of_agent_anthropic () =
       (Llm_provider.Provider_config.string_of_provider_kind pc.kind);
     Alcotest.(check string) "model_id" "claude-sonnet-4-20250514" pc.model_id;
     Alcotest.(check string) "api_key" "sk-ant-adapter-test" pc.api_key;
+    Alcotest.(check string) "request_path" "/v1/messages" pc.request_path;
+    Alcotest.(check bool) "x-api-key header present" true
+      (List.mem ("x-api-key", "sk-ant-adapter-test") pc.headers);
+    Alcotest.(check bool) "anthropic-version header present" true
+      (List.mem ("anthropic-version", "2023-06-01") pc.headers);
     Alcotest.(check (option int)) "max_tokens" (Some 4096) pc.max_tokens;
     Alcotest.(check (option (float 0.001))) "temperature" (Some 0.7) pc.temperature;
     Alcotest.(check (option (float 0.001))) "top_p" (Some 0.9) pc.top_p;
@@ -509,6 +514,10 @@ let test_provider_config_of_agent_openai_compat_collapses () =
       (Llm_provider.Provider_config.string_of_provider_kind pc.kind);
     Alcotest.(check string) "base_url from resolve"
       "https://generativelanguage.googleapis.com/v1beta/openai" pc.base_url;
+    Alcotest.(check string) "request_path preserved"
+      "/chat/completions" pc.request_path;
+    Alcotest.(check bool) "authorization header preserved" true
+      (List.mem ("Authorization", "Bearer sk-oai-adapter-test") pc.headers);
     Alcotest.(check string) "model_id" "gemini-2.5-flash" pc.model_id
   | Error e -> Alcotest.fail (Error.to_string e)
 
@@ -538,8 +547,48 @@ let test_provider_config_of_agent_none_fallback () =
     Alcotest.(check string) "defaults to anthropic" "anthropic"
       (Llm_provider.Provider_config.string_of_provider_kind pc.kind);
     Alcotest.(check string) "uses fallback key" "sk-ant-default-fallback"
-      pc.api_key
+      pc.api_key;
+    Alcotest.(check string) "preserves caller base_url"
+      "https://api.anthropic.com" pc.base_url;
+    Alcotest.(check string) "request_path" "/v1/messages" pc.request_path;
+    Alcotest.(check bool) "x-api-key header present" true
+      (List.mem ("x-api-key", "sk-ant-default-fallback") pc.headers)
   | Error e -> Alcotest.fail (Error.to_string e)
+
+let test_provider_config_of_agent_local_strips_dummy_key () =
+  let cfg : Provider.config = {
+    provider = Local { base_url = "http://127.0.0.1:11434" };
+    model_id = "qwen3.5";
+    api_key_env = "IGNORED";
+  } in
+  let state = agent_state_with_params () in
+  match Provider.provider_config_of_agent ~state
+          ~base_url:"unused-fallback" (Some cfg) with
+  | Ok pc ->
+    Alcotest.(check string) "kind" "openai_compat"
+      (Llm_provider.Provider_config.string_of_provider_kind pc.kind);
+    Alcotest.(check string) "request_path" "/v1/chat/completions" pc.request_path;
+    Alcotest.(check string) "local strips dummy api_key" "" pc.api_key;
+    Alcotest.(check (list (pair string string))) "headers"
+      [("Content-Type", "application/json")] pc.headers
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+let test_provider_config_of_agent_rejects_custom_registered () =
+  let cfg : Provider.config = {
+    provider = Custom_registered { name = "my-provider" };
+    model_id = "custom-model";
+    api_key_env = "IGNORED";
+  } in
+  let state = agent_state_with_params () in
+  match Provider.provider_config_of_agent ~state
+          ~base_url:"unused-fallback" (Some cfg) with
+  | Error (Error.Config (InvalidConfig { field; detail })) ->
+    Alcotest.(check string) "field" "provider" field;
+    Alcotest.(check bool) "detail mentions unsupported custom provider" true
+      (String.length detail > 0 && Util.contains_substring_ci ~haystack:detail ~needle:"Custom_registered")
+  | Error e ->
+    Alcotest.fail (Printf.sprintf "unexpected error: %s" (Error.to_string e))
+  | Ok _ -> Alcotest.fail "should reject Custom_registered"
 
 let () =
   Alcotest.run "Provider" [
@@ -603,5 +652,9 @@ let () =
         test_provider_config_of_agent_missing_env;
       Alcotest.test_case "none falls back to ANTHROPIC_API_KEY" `Quick
         test_provider_config_of_agent_none_fallback;
+      Alcotest.test_case "local strips dummy key" `Quick
+        test_provider_config_of_agent_local_strips_dummy_key;
+      Alcotest.test_case "custom registered rejected" `Quick
+        test_provider_config_of_agent_rejects_custom_registered;
     ];
   ]

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -444,6 +444,103 @@ let test_openai_compat_no_auth () =
     Alcotest.(check string) "empty key" "" key
   | Error e -> Alcotest.fail (Error.to_string e)
 
+(** Forward adapter — Provider.config + agent_state → Provider_config.t *)
+
+let agent_state_with_params () : Types.agent_state =
+  let cfg = { Types.default_config with
+    model = "claude-test";
+    max_tokens = Some 4096;
+    temperature = Some 0.7;
+    top_p = Some 0.9;
+    top_k = Some 40;
+    tool_choice = None;
+    disable_parallel_tool_use = false;
+    response_format_json = false;
+    cache_system_prompt = true;
+    system_prompt = Some "you are a tester";
+  } in
+  { config = cfg; usage = Types.empty_usage; turn_count = 0;
+    messages = [] }
+
+let test_provider_config_of_agent_anthropic () =
+  let env_var = "AGENT_SDK_TEST_ADAPTER_KEY_anth" in
+  Unix.putenv env_var "sk-ant-adapter-test";
+  let cfg : Provider.config = {
+    provider = Anthropic;
+    model_id = "claude-sonnet-4-20250514";
+    api_key_env = env_var;
+  } in
+  let state = agent_state_with_params () in
+  match Provider.provider_config_of_agent ~state
+          ~base_url:"https://api.anthropic.com" (Some cfg) with
+  | Ok pc ->
+    Alcotest.(check string) "kind" "anthropic"
+      (Llm_provider.Provider_config.string_of_provider_kind pc.kind);
+    Alcotest.(check string) "model_id" "claude-sonnet-4-20250514" pc.model_id;
+    Alcotest.(check string) "api_key" "sk-ant-adapter-test" pc.api_key;
+    Alcotest.(check (option int)) "max_tokens" (Some 4096) pc.max_tokens;
+    Alcotest.(check (option (float 0.001))) "temperature" (Some 0.7) pc.temperature;
+    Alcotest.(check (option (float 0.001))) "top_p" (Some 0.9) pc.top_p;
+    Alcotest.(check (option int)) "top_k" (Some 40) pc.top_k;
+    Alcotest.(check bool) "cache_system_prompt" true pc.cache_system_prompt;
+    Alcotest.(check (option string)) "system_prompt"
+      (Some "you are a tester") pc.system_prompt
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+let test_provider_config_of_agent_openai_compat_collapses () =
+  (* OpenAICompat collapses to OpenAI_compat (lossy — documented limitation) *)
+  let env_var = "AGENT_SDK_TEST_ADAPTER_KEY_oai" in
+  Unix.putenv env_var "sk-oai-adapter-test";
+  let cfg : Provider.config = {
+    provider = OpenAICompat {
+      base_url = "https://generativelanguage.googleapis.com/v1beta/openai";
+      auth_header = Some "Authorization";
+      path = "/chat/completions";
+      static_token = None;
+    };
+    model_id = "gemini-2.5-flash";
+    api_key_env = env_var;
+  } in
+  let state = agent_state_with_params () in
+  match Provider.provider_config_of_agent ~state
+          ~base_url:"unused-fallback" (Some cfg) with
+  | Ok pc ->
+    Alcotest.(check string) "kind collapses to openai_compat" "openai_compat"
+      (Llm_provider.Provider_config.string_of_provider_kind pc.kind);
+    Alcotest.(check string) "base_url from resolve"
+      "https://generativelanguage.googleapis.com/v1beta/openai" pc.base_url;
+    Alcotest.(check string) "model_id" "gemini-2.5-flash" pc.model_id
+  | Error e -> Alcotest.fail (Error.to_string e)
+
+let test_provider_config_of_agent_missing_env () =
+  let cfg : Provider.config = {
+    provider = Anthropic;
+    model_id = "claude-test";
+    api_key_env = "AGENT_SDK_TEST_ADAPTER_NONEXISTENT_zzz";
+  } in
+  let state = agent_state_with_params () in
+  match Provider.provider_config_of_agent ~state
+          ~base_url:"https://api.anthropic.com" (Some cfg) with
+  | Error (Error.Config (MissingEnvVar { var_name })) ->
+    Alcotest.(check string) "propagates env var name"
+      "AGENT_SDK_TEST_ADAPTER_NONEXISTENT_zzz" var_name
+  | Error e ->
+    Alcotest.fail (Printf.sprintf "unexpected error: %s" (Error.to_string e))
+  | Ok _ -> Alcotest.fail "should fail when env var missing"
+
+let test_provider_config_of_agent_none_fallback () =
+  (* None provider with ANTHROPIC_API_KEY present = Anthropic default *)
+  Unix.putenv "ANTHROPIC_API_KEY" "sk-ant-default-fallback";
+  let state = agent_state_with_params () in
+  match Provider.provider_config_of_agent ~state
+          ~base_url:"https://api.anthropic.com" None with
+  | Ok pc ->
+    Alcotest.(check string) "defaults to anthropic" "anthropic"
+      (Llm_provider.Provider_config.string_of_provider_kind pc.kind);
+    Alcotest.(check string) "uses fallback key" "sk-ant-default-fallback"
+      pc.api_key
+  | Error e -> Alcotest.fail (Error.to_string e)
+
 let () =
   Alcotest.run "Provider" [
     "resolve", [
@@ -496,5 +593,15 @@ let () =
     "openai_compat", [
       Alcotest.test_case "static token" `Quick test_openai_compat_static_token;
       Alcotest.test_case "no auth" `Quick test_openai_compat_no_auth;
+    ];
+    "provider_config_of_agent", [
+      Alcotest.test_case "anthropic maps fields" `Quick
+        test_provider_config_of_agent_anthropic;
+      Alcotest.test_case "openai_compat kind collapses" `Quick
+        test_provider_config_of_agent_openai_compat_collapses;
+      Alcotest.test_case "missing env propagates" `Quick
+        test_provider_config_of_agent_missing_env;
+      Alcotest.test_case "none falls back to ANTHROPIC_API_KEY" `Quick
+        test_provider_config_of_agent_none_fallback;
     ];
   ]


### PR DESCRIPTION
## Summary

- Forward adapter `Provider.provider_config_of_agent : state -> base_url -> config option -> (Provider_config.t, sdk_error) result`.
- Sampling params, tool_choice, thinking controls from `state.config`; provider kind + api_key from the optional `Provider.config` (with `ANTHROPIC_API_KEY` fallback when `None`).
- Completes the round-trip with the existing reverse adapter at `lib/provider.ml:451` (`config_of_provider_config`).

## Why

The legacy `Api.create_message` surface does not emit `metrics.on_request_end`; the consolidated `Llm_provider.Complete.complete` surface does. A future PR will switch Pipeline.stage_route to `Complete.complete`, but that requires a `Provider_config.t`. This PR adds the adapter only — no callers changed.

## Known limitation (documented in docstring)

`OpenAICompat` provider collapses to `OpenAI_compat` kind. The legacy variant does not distinguish Gemini/Glm/Ollama/Claude_code from generic OpenAI-compatible endpoints. Callers needing a specific kind should construct `Provider_config.t` directly via `make`.

## Test plan

- [x] `dune build` clean
- [x] `dune exec test/test_provider.exe` — 33/33 (4 new)
- [x] Anthropic round-trip mapping
- [x] OpenAICompat kind collapse
- [x] Missing env var error propagation
- [x] `None` provider Anthropic fallback

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>