### PR TITLE
diag(complete): log request_path + api_key fingerprint on HTTP 4xx/5xx

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -350,10 +350,24 @@ let complete_http ~sw ~net
                 let _ = Yojson.Safe.from_string body_str in true
               with _ -> false
             in
+            (* Mask api_key to a short fingerprint so log lines distinguish
+               same-provider calls that use different keys (e.g.
+               ZAI_API_KEY vs ZAI_API_KEY_SB for glm vs glm-coding).
+               Empty key renders as "-"; short keys render as "<len:N>"
+               since they cannot be safely sampled. *)
+            let api_key_tag =
+              let k = config.api_key in
+              let len = String.length k in
+              if len = 0 then "-"
+              else if len < 8 then Printf.sprintf "len:%d" len
+              else Printf.sprintf "%s..%s(len:%d)"
+                (String.sub k 0 3) (String.sub k (len - 3) 3) len
+            in
             Diag.warn "complete"
-              "HTTP %d from %s (model=%s base_url=%s): req_body=%d bytes balanced=%b parse_ok=%b resp_body=%s"
+              "HTTP %d from %s (model=%s base_url=%s request_path=%s key=%s): req_body=%d bytes balanced=%b parse_ok=%b resp_body=%s"
               code provider_name config.model_id
               (sanitize_url_for_log config.base_url)
+              config.request_path api_key_tag
               body_len body_balanced parse_ok
               (if String.length body <= 200 then body
                else String.sub body 0 200 ^ "...");


### PR DESCRIPTION
## Summary

Adds two fields to the existing \`[complete] HTTP N from ...\` WARN so consumers can distinguish cascade entries that share a base_url but differ in api_key or request_path. Purely diagnostic — no behavior change, no new log site.

## Changes

\`lib/llm_provider/complete.ml\` (HTTP 4xx/5xx path):

- \`request_path=<path>\` — Provider_config.request_path used for this call (empty for Gemini native, \`/chat/completions\` for OpenAI-compat, etc.)
- \`key=<fingerprint>\` — masked api_key as \`<first3>..<last3>(len:N)\` for keys >= 8 chars, \`len:N\` for shorter, \`-\` for empty. Never leaks the key.

## Product impact

**P3** — operator diagnosis only. Before: two cascade entries bound to the same base_url produced identical-looking error lines. After: fingerprint reveals which entry the failing call came from.

## Evidence

- \`dune build\` clean.
- 72 test suites pass, 0 failures (\`dune runtest --force\`).
- No API surface change (no .mli edit).
- Log line remains a single \`Diag.warn\` call; no new sinks.

## Review evidence

Motivated by downstream issue masc-mcp#8159: several cascade prefixes (\`claude\`, \`gemini\`, \`glm-coding\`) fail at runtime with \`kind=OpenAI_compat\` labeled logs despite the provider registry mapping them to native kinds. The added fields narrow down which caller constructs the eventual Provider_config.t.

## Linked issue

Relates masc-mcp#8159.

## Out of scope

- A stricter \"kind vs model_id prefix\" invariant warning — that belongs in downstream cascade orchestrators; OAS stays model-agnostic (per CLAUDE.md \"Provider Routing\" section: \"Cascade configuration is the responsibility of downstream consumers\").

Generated from /loop 30m session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)