### PR TITLE
fix(cli): disable MCP by default in headless transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,43 @@ opam install . --deps-only --with-test --yes
 dune build @all
 ```
 
+## Non-interactive CLI transports and MCP defaults
+
+OAS only owns the runtime policy for headless CLI subprocesses. Upstream CLI tools still have their own:
+
+1. server registry layer (`claude mcp ...`, `codex mcp ...`, `gemini mcp ...`)
+2. persistent config layer (user/project config files)
+3. per-run execution policy layer (what OAS injects for this specific subprocess)
+
+The recent bug lived in layer 3: a machine could have MCP servers registered, but a non-interactive OAS run was supposed to fail closed unless the caller opted back in.
+
+Current headless defaults:
+
+| Transport | Default runtime policy | Opt-back-in path |
+|----------|------------------------|------------------|
+| Claude Code | Always adds `--strict-mcp-config` | Supply `config.mcp_config` or `OAS_CLAUDE_MCP_CONFIG=/abs/path/mcp.json` |
+| Codex CLI | Always prepends `-c mcp_servers={}` | Pass a non-empty `mcp_servers` TOML fragment through `OAS_CODEX_CONFIG` / caller config |
+| Gemini CLI | Always sends an empty `--allowed-mcp-server-names` whitelist | Set `OAS_GEMINI_ALLOWED_MCP=name1,name2` |
+
+Why this can feel hidden:
+
+- Claude exposes MCP registration and runtime policy as separate commands/flags.
+- Codex exposes runtime policy through generic `-c key=value` overrides instead of a dedicated `--no-mcp` flag.
+- Gemini is the clearest: runtime MCP exposure is controlled by `--allowed-mcp-server-names`.
+
+Examples:
+
+```bash
+# Claude Code: keep strict mode, but allow only the config you pass explicitly
+OAS_CLAUDE_MCP_CONFIG=/abs/path/to/mcp.json dune exec ./examples/review_agent.exe -- org/repo 123
+
+# Gemini CLI: allow only named MCP servers for this run
+OAS_GEMINI_ALLOWED_MCP=filesystem,github dune exec ./examples/review_agent.exe -- org/repo 123
+
+# Codex CLI: default remains MCP OFF unless the caller injects a non-empty
+# mcp_servers TOML fragment via OAS_CODEX_CONFIG or equivalent caller wiring.
+```
+
 ## Quickstart
 
 ```ocaml

--- a/README.md
+++ b/README.md
@@ -57,6 +57,29 @@ Why this can feel hidden:
 - Codex exposes runtime policy through generic `-c key=value` overrides instead of a dedicated `--no-mcp` flag.
 - Gemini is the clearest: runtime MCP exposure is controlled by `--allowed-mcp-server-names`.
 
+### Codex sandbox cheat sheet
+
+This is **Codex CLI's own sandbox flag**, not MASC keeper Docker sandbox.
+
+Use these three levels:
+
+- `OAS_CODEX_SANDBOX=read-only`: inspect / grep / diagnosis only
+- `OAS_CODEX_SANDBOX=workspace-write`: normal local coding
+- `OAS_CODEX_SANDBOX=danger-full-access`: last resort
+
+Examples:
+
+```bash
+# safest explicit Codex run
+OAS_CODEX_SANDBOX=read-only dune exec ./examples/review_agent.exe -- org/repo 123
+
+# normal editing run
+OAS_CODEX_SANDBOX=workspace-write dune exec ./examples/review_agent.exe -- org/repo 123
+```
+
+If `OAS_CODEX_SANDBOX` is unset, OAS does not add `-s`; only MCP-off
+(`-c mcp_servers={}`) remains forced by default.
+
 Examples:
 
 ```bash

--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -46,14 +46,15 @@ let default_config = {
 
 (* ── CLI argument building ───────────────────────────── *)
 
-(* Env-driven optional flags (see cli_common_env.mli).  All three are
-   opt-in — unset env means "no flag added", preserving the pre-0.159
-   argument vector.  Intended for callers (e.g. MASC keeper) that want
-   to tighten MCP surface / forbid specific tools without extending the
-   config record.  LSP / hooks / auto-memory stay ON — no --bare here. *)
+(* Non-interactive Claude runs default to MCP OFF by forcing strict MCP
+   config resolution.  When [config.mcp_config] or
+   [OAS_CLAUDE_MCP_CONFIG] is provided, strict mode narrows the runtime
+   to exactly that config; when neither is present, strict mode yields an
+   empty MCP surface.  LSP / hooks / auto-memory stay ON — no --bare. *)
 let env_extra_args ~(config : config) =
   let extras = ref [] in
   let add a = extras := !extras @ a in
+  add ["--strict-mcp-config"];
   (* --mcp-config: only used as fallback when config.mcp_config is None.
      Explicit config wins over env, matching the convention that
      programmatic wiring overrides ambient environment. *)
@@ -64,7 +65,7 @@ let env_extra_args ~(config : config) =
      | Some v -> add ["--mcp-config"; v]
      | None -> ());
   if Cli_common_env.bool "OAS_CLAUDE_STRICT_MCP" then
-    add ["--strict-mcp-config"];
+    ();
   (match Cli_common_env.list "OAS_CLAUDE_DISALLOWED_TOOLS" with
    | None | Some [] -> ()
    | Some tools -> List.iter (fun t -> add ["--disallowedTools"; t]) tools);
@@ -553,13 +554,13 @@ let with_unset k f =
 let sample_req =
   Provider_config.make ~kind:Claude_code ~model_id:"" ~base_url:"" ()
 
-let%test "env: no vars set → no extra flags" =
+let%test "default: strict MCP is always enabled" =
   with_unset "OAS_CLAUDE_STRICT_MCP" (fun () ->
   with_unset "OAS_CLAUDE_MCP_CONFIG" (fun () ->
   with_unset "OAS_CLAUDE_DISALLOWED_TOOLS" (fun () ->
     let args = build_args ~config:default_config ~req_config:sample_req
       ~prompt:"hi" ~stream:false ~system_prompt:None in
-    not (List.mem "--strict-mcp-config" args)
+    List.mem "--strict-mcp-config" args
     && not (List.mem "--disallowedTools" args))))
 
 let%test "env: OAS_CLAUDE_STRICT_MCP=1 appends --strict-mcp-config" =

--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -45,9 +45,10 @@ let default_config = {
 
 (* Codex has no dedicated --no-mcp / --no-hooks flags; every runtime
    toggle goes through [-c key=value] TOML overrides (see
-   `~/.codex/config.toml` schema).  We surface that via env vars so
-   MASC keeper can lock down MCP / tighten sandbox without needing an
-   OAS release.
+   `~/.codex/config.toml` schema).  Non-interactive OAS runs default to
+   MCP OFF by injecting [-c mcp_servers={}] before any caller-provided
+   overrides.  Additional env vars let callers refine sandbox/profile
+   without changing the config record.
 
    OAS_CODEX_CONFIG   "k=v,k2=v2"                → -c k=v -c k2=v2
    OAS_CODEX_SANDBOX  read-only|workspace-write  → -s <value>
@@ -64,6 +65,7 @@ let default_config = {
 let env_extra_args () =
   let extras = ref [] in
   let add a = extras := !extras @ a in
+  add ["-c"; "mcp_servers={}"];
   (match Cli_common_env.kv_pairs "OAS_CODEX_CONFIG" with
    | None | Some [] -> ()
    | Some pairs ->
@@ -247,7 +249,7 @@ let%test "default_config parity fields absent" =
 
 let%test "build_args includes --json flag" =
   let args = build_args ~config:default_config ~prompt:"hello" in
-  args = ["codex"; "exec"; "--json"; "hello"]
+  args = ["codex"; "exec"; "--json"; "-c"; "mcp_servers={}"; "hello"]
 
 let%test "build_args ignores extra parity fields" =
   let config = { default_config with
@@ -257,7 +259,7 @@ let%test "build_args ignores extra parity fields" =
     permission_mode = Some "bypassPermissions";
   } in
   let args = build_args ~config ~prompt:"hi" in
-  args = ["codex"; "exec"; "--json"; "hi"]
+  args = ["codex"; "exec"; "--json"; "-c"; "mcp_servers={}"; "hi"]
 
 let%test "parse_jsonl_result extracts text + usage + thread_id" =
   let lines = [
@@ -353,13 +355,13 @@ let with_unset k f =
     | Some old -> Unix.putenv k old)
     f
 
-let%test "env: no vars → argv is [codex; exec; --json; prompt]" =
+let%test "default: argv disables MCP even with no env" =
   with_unset "OAS_CODEX_CONFIG" (fun () ->
   with_unset "OAS_CODEX_SANDBOX" (fun () ->
   with_unset "OAS_CODEX_PROFILE" (fun () ->
   with_unset "OAS_CODEX_SKIP_GIT" (fun () ->
     build_args ~config:default_config ~prompt:"hi"
-    = ["codex"; "exec"; "--json"; "hi"]))))
+    = ["codex"; "exec"; "--json"; "-c"; "mcp_servers={}"; "hi"]))))
 
 let%test "env: OAS_CODEX_CONFIG emits -c pairs before prompt" =
   with_env "OAS_CODEX_CONFIG" "mcp_servers={},model=o3" (fun () ->

--- a/lib/llm_provider/transport_gemini_cli.ml
+++ b/lib/llm_provider/transport_gemini_cli.ml
@@ -42,7 +42,8 @@ let default_config = {
 
 (* ── CLI argument building ───────────────────────────── *)
 
-(* Env-driven flags.  All opt-in.
+(* Non-interactive Gemini runs default to MCP OFF by passing an empty
+   MCP whitelist.  Explicit allow-lists can opt back in.
 
    OAS_GEMINI_ALLOWED_MCP    "a,b" → --allowed-mcp-server-names a
                                      --allowed-mcp-server-names b
@@ -64,7 +65,7 @@ let env_extra_args () =
     add ["--allowed-mcp-server-names"; ""]
   else
     (match Cli_common_env.list "OAS_GEMINI_ALLOWED_MCP" with
-     | None | Some [] -> ()
+     | None | Some [] -> add ["--allowed-mcp-server-names"; ""]
      | Some names ->
        List.iter (fun n -> add ["--allowed-mcp-server-names"; n]) names);
   (match Cli_common_env.list "OAS_GEMINI_EXTENSIONS" with
@@ -389,14 +390,19 @@ let%test "env: OAS_GEMINI_EXTENSIONS splits on comma" =
       ~prompt:"hi" ~system_prompt:None in
     List.mem "-e" args && List.mem "ext-a" args && List.mem "ext-b" args)
 
-let%test "env: no vars → legacy behavior preserved (yolo kept)" =
+let%test "default: no vars still keeps MCP disabled" =
   with_unset "OAS_GEMINI_ALLOWED_MCP" (fun () ->
   with_unset "OAS_GEMINI_APPROVAL_MODE" (fun () ->
   with_unset "OAS_GEMINI_EXTENSIONS" (fun () ->
   with_unset "OAS_GEMINI_NO_MCP" (fun () ->
     let args = build_args ~config:default_config ~req_config:gemini_req
       ~prompt:"hi" ~system_prompt:None in
+    let rec has_empty_whitelist = function
+      | "--allowed-mcp-server-names" :: "" :: _ -> true
+      | _ :: rest -> has_empty_whitelist rest
+      | [] -> false
+    in
     (* default_config.yolo = true, so --yolo must appear. *)
     List.mem "--yolo" args
     && not (List.mem "--approval-mode" args)
-    && not (List.mem "--allowed-mcp-server-names" args)))))
+    && has_empty_whitelist args))))


### PR DESCRIPTION
## Summary
- make non-interactive Claude Code runs force strict MCP config by default
- make non-interactive Codex runs inject `-c mcp_servers={}` by default
- make non-interactive Gemini runs pass an empty MCP whitelist by default
- update inline tests to lock the new default argv contracts

## Verification
- `dune runtest --root .`
- checked local CLI surfaces against installed versions:
  - `claude --help`
  - `codex exec --help`
  - `gemini --help`
