### PR TITLE
fix(completion_contract): accept no-ToolUse when stop_reason is resumable (Haiku 4.5 pause_turn)

### DIFF
--- a/lib/completion_contract.ml
+++ b/lib/completion_contract.ml
@@ -37,6 +37,20 @@ let tool_use_names (response : api_response) =
       | _ -> None)
     response.content
 
+(* A response whose stop_reason signals the model was cut off mid-turn rather
+   than cleanly deciding not to call a tool. Surfacing a
+   [CompletionContractViolation] in that case is misleading — the caller can
+   continue the turn (or raise max_tokens) instead. Observed on Anthropic
+   Haiku 4.5 where extended thinking consumes the 8192 output budget before
+   a ToolUse block emits: Anthropic returns [pause_turn] which currently
+   parses to [Unknown "pause_turn"] since it is not yet a first-class
+   [stop_reason] variant. *)
+let stop_reason_is_resumable (sr : stop_reason) : bool =
+  match sr with
+  | MaxTokens -> true
+  | Unknown "pause_turn" -> true
+  | EndTurn | StopToolUse | StopSequence | Unknown _ -> false
+
 let validate_response ~(contract : t) (response : api_response) :
     (unit, string) result =
   match contract with
@@ -44,12 +58,15 @@ let validate_response ~(contract : t) (response : api_response) :
   | Require_tool_use ->
     if tool_use_names response <> []
     then Ok ()
+    else if stop_reason_is_resumable response.stop_reason
+    then Ok ()
     else
       Error
         "required tool contract unsatisfied: tool_choice requested tool use, \
          but the model returned no ToolUse block"
   | Require_specific_tool name ->
     (match tool_use_names response with
+     | [] when stop_reason_is_resumable response.stop_reason -> Ok ()
      | [] ->
        Error
          (Printf.sprintf
@@ -246,3 +263,101 @@ let%test "text-only response passes when contract relaxed for unsupported provid
       telemetry = None;
     }
   = Ok ()
+
+(* --- stop_reason resumability tests (extended-thinking / budget cut-off) --- *)
+
+let%test "Require_tool_use accepts no-ToolUse response when stop_reason is MaxTokens" =
+  validate_response
+    ~contract:Require_tool_use
+    { id = "r";
+      model = "claude-haiku-4-5-20251001";
+      stop_reason = MaxTokens;
+      content = [ Text "partial thinking output" ];
+      usage = None;
+      telemetry = None;
+    }
+  = Ok ()
+
+let%test "Require_tool_use accepts no-ToolUse response when stop_reason is Unknown pause_turn" =
+  validate_response
+    ~contract:Require_tool_use
+    { id = "r";
+      model = "claude-haiku-4-5-20251001";
+      stop_reason = Unknown "pause_turn";
+      content = [ Text "thinking..." ];
+      usage = None;
+      telemetry = None;
+    }
+  = Ok ()
+
+let%test "Require_tool_use still rejects no-ToolUse response when stop_reason is EndTurn" =
+  match
+    validate_response
+      ~contract:Require_tool_use
+      { id = "r";
+        model = "m";
+        stop_reason = EndTurn;
+        content = [ Text "I decline to call tools" ];
+        usage = None;
+        telemetry = None;
+      }
+  with
+  | Error _ -> true
+  | Ok () -> false
+
+let%test "Require_tool_use still rejects no-ToolUse response when stop_reason is Unknown refusal" =
+  match
+    validate_response
+      ~contract:Require_tool_use
+      { id = "r";
+        model = "m";
+        stop_reason = Unknown "refusal";
+        content = [ Text "..." ];
+        usage = None;
+        telemetry = None;
+      }
+  with
+  | Error _ -> true
+  | Ok () -> false
+
+let%test "Require_specific_tool accepts no-ToolUse response when stop_reason is MaxTokens" =
+  validate_response
+    ~contract:(Require_specific_tool "calculator")
+    { id = "r";
+      model = "m";
+      stop_reason = MaxTokens;
+      content = [ Text "partial" ];
+      usage = None;
+      telemetry = None;
+    }
+  = Ok ()
+
+let%test "Require_specific_tool still rejects wrong-tool response when stop_reason is MaxTokens" =
+  match
+    validate_response
+      ~contract:(Require_specific_tool "calculator")
+      { id = "r";
+        model = "m";
+        stop_reason = MaxTokens;
+        content =
+          [ ToolUse
+              { id = "call-1";
+                name = "search";
+                input = `Assoc [];
+              }
+          ];
+        usage = None;
+        telemetry = None;
+      }
+  with
+  | Error _ -> true
+  | Ok () -> false
+
+let%test "stop_reason_is_resumable classification" =
+  stop_reason_is_resumable MaxTokens
+  && stop_reason_is_resumable (Unknown "pause_turn")
+  && not (stop_reason_is_resumable EndTurn)
+  && not (stop_reason_is_resumable StopToolUse)
+  && not (stop_reason_is_resumable StopSequence)
+  && not (stop_reason_is_resumable (Unknown "refusal"))
+  && not (stop_reason_is_resumable (Unknown "anything-else"))


### PR DESCRIPTION
## Summary

Closes #1000.

`completion_contract.validate_response` returns `Error` whenever `Require_tool_use` / `Require_specific_tool` is active and the response carries no `ToolUse` block. That is correct when the model cleanly decided not to call a tool, but wrong when the turn was **cut off mid-emission** — the model may have been about to emit a tool_use. Surfacing `CompletionContractViolation` in that case exhausts the cascade on what is really a continuation signal.

Observed on MASC keeper `vendor_mix_balanced` cascade 2026-04-18 against `claude-haiku-4-5-20251001`: the Haiku 4.5 8192 output budget plus extended thinking produce a `pause_turn` stop_reason with no ToolUse, and every tier in the cascade then fails identically.

## Change

`lib/completion_contract.ml` only. Adds `stop_reason_is_resumable`:

\`\`\`ocaml
let stop_reason_is_resumable (sr : stop_reason) : bool =
  match sr with
  | MaxTokens -> true
  | Unknown \"pause_turn\" -> true
  | EndTurn | StopToolUse | StopSequence | Unknown _ -> false
\`\`\`

Used in:

- `Require_tool_use` → accept no-ToolUse response when stop is resumable.
- `Require_specific_tool` → same, on the empty-tool branch.
- `Require_no_tool_use` → **unchanged** (presence of ToolUse there is always a violation; absence is always Ok).
- `EndTurn` + no ToolUse → **still** a violation (model explicitly declined).

## Why surgical string match, not a new variant

Adding a `PauseTurn` variant to `Types.stop_reason` forces exhaustive pattern updates in `pipeline/pipeline.ml:stage_output`, `contract_runner.map_result_status`, `tool_use_recovery`, `runtime_evidence`, and both copies of `stop_reason_of_string` (`types.ml`, `cache.ml`). Each of those has its own semantics for the new variant — \"is paused a completed step?\" \"does cache store it?\" \"does CDAL proof treat it as Completed or Errored?\" — and answering them belongs in a separate PR. The string-level match on `Unknown \"pause_turn\"` documents the contract-local meaning without cross-layer impact. The comment points at the variant path for future consolidation.

## Tests

`lib/completion_contract.ml` inline `let%test` suite:

| Case | stop_reason | contract | content | expected |
|------|-------------|----------|---------|----------|
| new | MaxTokens | Require_tool_use | Text | Ok |
| new | Unknown \"pause_turn\" | Require_tool_use | Text | Ok |
| new | EndTurn | Require_tool_use | Text | Error (still) |
| new | Unknown \"refusal\" | Require_tool_use | Text | Error (still) |
| new | MaxTokens | Require_specific_tool \"calc\" | Text | Ok |
| new | MaxTokens | Require_specific_tool \"calc\" | ToolUse \"search\" | Error (wrong tool still) |
| new | — | — | `stop_reason_is_resumable` classification table | Ok |

Existing 17 tests unchanged. \`dune build @runtest\` green in worktree.

## Test plan

- [x] \`dune build --root .\` green
- [x] \`dune build @runtest\` green (all tests including non-contract)
- [ ] CI: Build and Test / Lint / TLA+
- [ ] Consumer verification: MASC `vendor_mix_balanced` cascade no longer exits `all tiers failed` under the reproduced log pattern.

## Out of scope

- Whether Anthropic backend should surface `pause_turn` as a first-class variant and how pipeline `stage_output` should handle it (currently `Unknown` → `UnrecognizedStopReason` error, which is its own bug but separate from the cascade-failure symptom this PR fixes).
- Thinking-budget clamp on Haiku 4.5 (Tier 2 from #1000).
- MASC-side cascade config review (Tier 3 from #1000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)