### PR TITLE
fix(provider): preserve registry-declared kind via Custom_registered (#1003)

### DIFF
--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -237,14 +237,24 @@ let resolve_provider ~model_id provider_str base_url =
       let registry = Llm_provider.Provider_registry.default () in
       match Llm_provider.Provider_registry.find registry other with
       | Some entry ->
-          let url = match base_url with
-            | Some u -> u
-            | None -> entry.defaults.base_url
-          in
-          { Provider.provider = OpenAICompat {
-              base_url = url; auth_header = None;
-              path = entry.defaults.request_path; static_token = None };
-            model_id; api_key_env = entry.defaults.api_key_env }
+          (match base_url with
+           | None ->
+               (* Preserve registry-declared kind (Gemini/Glm/Ollama/etc.)
+                  via Custom_registered. Downstream (provider_config_of_agent,
+                  request_path, Capabilities, resolve) dispatches through
+                  Provider_registry by name, retaining entry.defaults.kind. *)
+               { Provider.provider = Custom_registered { name = other };
+                 model_id; api_key_env = entry.defaults.api_key_env }
+           | Some url ->
+               (* Explicit base_url override: legacy Provider.config variant
+                  cannot carry kind + arbitrary URL simultaneously, so kind
+                  flattens to OpenAI_compat. For kind-preserving override,
+                  construct Llm_provider.Provider_config.t directly via
+                  Provider_config.make. *)
+               { Provider.provider = OpenAICompat {
+                   base_url = url; auth_header = None;
+                   path = entry.defaults.request_path; static_token = None };
+                 model_id; api_key_env = entry.defaults.api_key_env })
       | None ->
           let url = match base_url with
             | Some u -> u

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -493,16 +493,21 @@ let config_of_provider_config (pc : Llm_provider.Provider_config.t) : config =
     [ANTHROPIC_API_KEY] (matching {!create_message}'s existing default).
 
     [OpenAICompat] provider collapses to [OpenAI_compat] kind — the
-    legacy {!config} variant does not distinguish Gemini/Glm/Ollama/
-    Claude_code from generic OpenAI-compatible endpoints.  Callers that
-    require a specific kind should construct {!Llm_provider.Provider_config.t}
-    directly via {!Llm_provider.Provider_config.make}.
+    legacy {!config} variant does not distinguish arbitrary
+    OpenAI-compatible endpoints from named providers carrying their
+    own kind.  Callers that require kind + arbitrary URL should
+    construct {!Llm_provider.Provider_config.t} directly via
+    {!Llm_provider.Provider_config.make}.
 
-    [Custom_registered] is intentionally rejected: the custom provider
-    registry can define request/parse semantics that the consolidated
-    {!Llm_provider.Complete.complete} surface cannot represent safely.
+    [Custom_registered {name}] preserves the registry-declared
+    {!Llm_provider.Provider_config.provider_kind}
+    (Gemini/Glm/Ollama/Claude_code/etc.) by looking [name] up in
+    {!Llm_provider.Provider_registry.default} and using
+    [entry.defaults.kind] and [entry.defaults.request_path].
+    Returns [Error InvalidConfig] when [name] is not registered.
 
-    @since 0.155.0 *)
+    @since 0.155.0
+    @since 0.161.0 — Custom_registered kind preservation *)
 let provider_config_of_agent
     ~(state : Types.agent_state)
     ~(base_url : string)
@@ -536,16 +541,44 @@ let provider_config_of_agent
   | Some p ->
       (match p.provider with
        | Custom_registered { name } ->
-           Error
-             (Error.Config
-                (InvalidConfig
-                   {
-                     field = "provider";
-                     detail =
-                       Printf.sprintf
-                         "provider_config_of_agent does not support Custom_registered provider '%s'; construct Provider_config.t directly"
-                         name;
-                   }))
+           (* Preserve the registry-declared provider_kind
+              (Gemini/Glm/Ollama/Claude_code/etc.) instead of flattening
+              to OpenAI_compat.
+
+              Source of truth is {!Llm_provider.Provider_registry.default},
+              which carries [entry.defaults.{kind, base_url, api_key_env,
+              request_path}] per registered name. We read api_key from
+              env directly rather than going through {!resolve}, because
+              [resolve] dispatches via a separate {!Provider.registry}
+              Hashtbl that is not guaranteed to contain the registry
+              entries defined in {!Llm_provider.Provider_registry}. *)
+           let registry = Llm_provider.Provider_registry.default () in
+           (match Llm_provider.Provider_registry.find registry name with
+            | None ->
+                Error
+                  (Error.Config
+                     (InvalidConfig
+                        {
+                          field = "provider";
+                          detail =
+                            Printf.sprintf
+                              "Custom_registered provider '%s' not found in Provider_registry.default"
+                              name;
+                        }))
+            | Some entry ->
+                let api_key =
+                  if entry.defaults.api_key_env = "" then ""
+                  else
+                    match Sys.getenv_opt entry.defaults.api_key_env with
+                    | Some k -> k
+                    | None -> ""
+                in
+                build ~kind:entry.defaults.kind
+                  ~resolved_base_url:entry.defaults.base_url
+                  ~api_key
+                  ~headers:[]
+                  ~request_path:entry.defaults.request_path
+                  ~model_id:p.model_id)
        | Anthropic | Local _ | OpenAICompat _ ->
            (match resolve p with
             | Error e -> Error e

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -175,16 +175,20 @@ val config_of_provider_config : Llm_provider.Provider_config.t -> config
     (or the [ANTHROPIC_API_KEY] fallback when [None]).
 
     [OpenAICompat] provider collapses to [OpenAI_compat] kind: the
-    legacy {!config} variant does not distinguish Gemini/Glm/Ollama/
-    Claude_code from generic OpenAI-compatible endpoints.  Callers
-    needing a specific kind should use
+    legacy {!config} variant does not distinguish arbitrary
+    OpenAI-compatible endpoints from named providers carrying their own
+    kind.  Callers needing kind + arbitrary URL should construct
+    {!Llm_provider.Provider_config.t} via
     {!Llm_provider.Provider_config.make} directly.
 
-    [Custom_registered] providers are rejected: the custom registry can
-    define request/parse semantics that {!Llm_provider.Complete.complete}
-    cannot preserve through this adapter.
+    [Custom_registered {name}] preserves the registry-declared
+    {!Llm_provider.Provider_config.provider_kind} by looking [name] up
+    in {!Llm_provider.Provider_registry.default} and using
+    [entry.defaults.kind].  Errors with [InvalidConfig] when [name] is
+    not registered.
 
-    @since 0.155.0 *)
+    @since 0.155.0
+    @since 0.161.0 — Custom_registered kind preservation *)
 val provider_config_of_agent :
   state:Types.agent_state ->
   base_url:string ->

--- a/test/test_agent_config_deep.ml
+++ b/test/test_agent_config_deep.ml
@@ -300,14 +300,17 @@ let test_resolve_other_custom_url () =
   | _ -> Alcotest.fail "expected OpenAICompat"
 
 let test_resolve_groq () =
+  (* With base_url=None, resolve_provider now returns Custom_registered
+     so that downstream can look up the registry-declared kind.
+     entry.defaults (url, path, api_key_env) are carried via the
+     registry, not embedded in the Provider.config variant. *)
   let cfg = Agent_config.resolve_provider ~model_id:"qwen/qwen3-32b" "groq" None in
   match cfg.provider with
-  | Provider.OpenAICompat { base_url; path; _ } ->
-    Alcotest.(check string) "groq url" "https://api.groq.com/openai/v1" base_url;
-    Alcotest.(check string) "groq path" "/chat/completions" path;
+  | Provider.Custom_registered { name } ->
+    Alcotest.(check string) "groq name" "groq" name;
     Alcotest.(check string) "groq api_key_env" "GROQ_API_KEY" cfg.api_key_env;
     Alcotest.(check string) "groq model_id" "qwen/qwen3-32b" cfg.model_id
-  | _ -> Alcotest.fail "expected OpenAICompat for groq"
+  | _ -> Alcotest.fail "expected Custom_registered for groq (registered)"
 
 let test_resolve_groq_custom_url () =
   let cfg = Agent_config.resolve_provider ~model_id:"qwen/qwen3-32b" "groq"
@@ -318,12 +321,27 @@ let test_resolve_groq_custom_url () =
   | _ -> Alcotest.fail "expected OpenAICompat for groq custom url"
 
 let test_resolve_deepseek () =
+  (* base_url=None: Custom_registered preserves kind lookup via registry. *)
   let cfg = Agent_config.resolve_provider ~model_id:"deepseek-chat" "deepseek" None in
   match cfg.provider with
-  | Provider.OpenAICompat { base_url; _ } ->
-    Alcotest.(check string) "deepseek url" "https://api.deepseek.com" base_url;
+  | Provider.Custom_registered { name } ->
+    Alcotest.(check string) "deepseek name" "deepseek" name;
     Alcotest.(check string) "deepseek api_key_env" "DEEPSEEK_API_KEY" cfg.api_key_env
-  | _ -> Alcotest.fail "expected OpenAICompat for deepseek"
+  | _ -> Alcotest.fail "expected Custom_registered for deepseek (registered)"
+
+let test_resolve_gemini_preserves_kind () =
+  (* Regression for #1003: registered providers with non-OpenAI kind
+     (e.g. Gemini) must route through Custom_registered so downstream
+     preserves entry.defaults.kind. Previously resolve_provider
+     returned OpenAICompat, flattening kind to OpenAI_compat and
+     producing 404 against the Gemini endpoint. *)
+  let cfg = Agent_config.resolve_provider ~model_id:"gemini-2.5-flash" "gemini" None in
+  match cfg.provider with
+  | Provider.Custom_registered { name } ->
+    Alcotest.(check string) "gemini name" "gemini" name;
+    Alcotest.(check string) "gemini api_key_env" "GEMINI_API_KEY" cfg.api_key_env;
+    Alcotest.(check string) "gemini model_id" "gemini-2.5-flash" cfg.model_id
+  | _ -> Alcotest.fail "expected Custom_registered for gemini (registered)"
 
 (* ── of_json error cases ─────────────────────────────────────── *)
 
@@ -408,5 +426,6 @@ let () =
       tc "groq" test_resolve_groq;
       tc "groq custom url" test_resolve_groq_custom_url;
       tc "deepseek" test_resolve_deepseek;
+      tc "gemini preserves kind (#1003)" test_resolve_gemini_preserves_kind;
     ]);
   ]

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -573,10 +573,32 @@ let test_provider_config_of_agent_local_strips_dummy_key () =
       [("Content-Type", "application/json")] pc.headers
   | Error e -> Alcotest.fail (Error.to_string e)
 
-let test_provider_config_of_agent_rejects_custom_registered () =
+let test_provider_config_of_agent_custom_registered_preserves_kind () =
+  (* Regression for #1003: Custom_registered must preserve the
+     registry-declared provider_kind (e.g. Gemini) rather than
+     flattening to OpenAI_compat, which would route Gemini requests
+     through the OpenAI wire format and produce 404 against the
+     Gemini base URL. *)
   let cfg : Provider.config = {
-    provider = Custom_registered { name = "my-provider" };
-    model_id = "custom-model";
+    provider = Custom_registered { name = "gemini" };
+    model_id = "gemini-2.5-flash";
+    api_key_env = "GEMINI_API_KEY";
+  } in
+  let state = agent_state_with_params () in
+  Unix.putenv "GEMINI_API_KEY" "fake-gemini-key";
+  match Provider.provider_config_of_agent ~state
+          ~base_url:"unused-fallback" (Some cfg) with
+  | Ok pc ->
+    Alcotest.(check bool) "kind preserves Gemini" true
+      (pc.kind = Llm_provider.Provider_config.Gemini);
+    Alcotest.(check string) "model_id" "gemini-2.5-flash" pc.model_id
+  | Error e ->
+    Alcotest.fail (Printf.sprintf "unexpected error: %s" (Error.to_string e))
+
+let test_provider_config_of_agent_custom_registered_unknown_name () =
+  let cfg : Provider.config = {
+    provider = Custom_registered { name = "nonexistent-provider-xyz" };
+    model_id = "m";
     api_key_env = "IGNORED";
   } in
   let state = agent_state_with_params () in
@@ -584,11 +606,11 @@ let test_provider_config_of_agent_rejects_custom_registered () =
           ~base_url:"unused-fallback" (Some cfg) with
   | Error (Error.Config (InvalidConfig { field; detail })) ->
     Alcotest.(check string) "field" "provider" field;
-    Alcotest.(check bool) "detail mentions unsupported custom provider" true
-      (String.length detail > 0 && Util.contains_substring_ci ~haystack:detail ~needle:"Custom_registered")
+    Alcotest.(check bool) "detail mentions not found" true
+      (Util.contains_substring_ci ~haystack:detail ~needle:"not found")
   | Error e ->
     Alcotest.fail (Printf.sprintf "unexpected error: %s" (Error.to_string e))
-  | Ok _ -> Alcotest.fail "should reject Custom_registered"
+  | Ok _ -> Alcotest.fail "should error on unregistered name"
 
 let () =
   Alcotest.run "Provider" [
@@ -654,7 +676,9 @@ let () =
         test_provider_config_of_agent_none_fallback;
       Alcotest.test_case "local strips dummy key" `Quick
         test_provider_config_of_agent_local_strips_dummy_key;
-      Alcotest.test_case "custom registered rejected" `Quick
-        test_provider_config_of_agent_rejects_custom_registered;
+      Alcotest.test_case "custom registered preserves kind (#1003)" `Quick
+        test_provider_config_of_agent_custom_registered_preserves_kind;
+      Alcotest.test_case "custom registered unknown name errors" `Quick
+        test_provider_config_of_agent_custom_registered_unknown_name;
     ];
   ]


### PR DESCRIPTION
## Why

`resolve_provider` (lib/agent/agent_config.ml) flattened every registered non-hardcoded provider to `OpenAICompat`, discarding `entry.defaults.kind` from `Llm_provider.Provider_registry`. `provider_config_of_agent` then explicitly rejected `Custom_registered`, so even a kind-preserving construction could not reach the adapter.

Net effect: Gemini/Glm/Ollama agents saw `kind=OpenAI_compat` at HTTP dispatch → OpenAI wire format routed against the registered base_url (e.g. `https://generativelanguage.googleapis.com/v1beta`) → 404.

## Changes

| File | Change |
|------|--------|
| `lib/agent/agent_config.ml` | `resolve_provider`: when registry hit + `base_url=None`, return `Custom_registered { name }` preserving kind. Explicit `base_url` override still flattens (legacy config limitation; callers needing kind+URL should use `Provider_config.make` directly). |
| `lib/provider.ml` | `provider_config_of_agent`: accept `Custom_registered { name }`, look up `Llm_provider.Provider_registry.default` by name, read api_key directly from `entry.defaults.api_key_env`. Bypasses local `Provider.registry` Hashtbl because the two registries are separate surfaces. |
| `lib/provider.mli` | Docstring updated: `Custom_registered` no longer rejected. |
| `test/test_provider.ml` | Replaced `rejects_custom_registered` with `preserves_kind` (Gemini) + `unknown_name` (error path). |
| `test/test_agent_config_deep.ml` | Updated `resolve_groq`, `resolve_deepseek` to expect `Custom_registered`. Added `resolve_gemini_preserves_kind` explicit regression. |

## Verification

- `dune build --root .` — clean
- `dune runtest --root .` — full suite green (no FAIL in 600s budget)
- `test_provider.exe` — 36/36 including 2 new Custom_registered cases
- `test_deep_coverage.exe` — 81/81 including `gemini preserves kind (#1003)`

## Scope notes

- Backward compat: callers providing explicit `base_url` keep the legacy `OpenAICompat` flattening, so existing deployments using custom proxies do not change behavior. Only the default path (registered name + no override) switches to kind-preserving routing.
- Two separate "registries" (`Provider.registry` Hashtbl vs `Llm_provider.Provider_registry`) remain — not consolidated here, scope-kept. Follow-up issue may track unification.

## Related

- Closes #1003
- Unblocks masc-mcp#8159 (Gemini cascade 404 root cause moved to OAS)

## Autonomy note

Draft only — Ready transition requires human review per session protocol (see `planning/claude-plans/effervescent-mapping-grove.md`).