### PR TITLE
feat(constants): add top_p/top_k/min_p to Inference_profile (#851)

### DIFF
--- a/lib/llm_provider/constants.ml
+++ b/lib/llm_provider/constants.ml
@@ -30,16 +30,40 @@ end
     - [agent_default]: full agent turn execution.
     - [low_variance]: evaluation, judging, deterministic extraction. *)
 module Inference_profile = struct
+  (** Inference parameter profile. Sampling fields ([top_p], [top_k],
+      [min_p]) are [option] because provider support is not uniform
+      (e.g. Anthropic does not accept [min_p]); [None] means the
+      parameter is omitted from the request and the provider's own
+      default applies.
+
+      @since 0.99.0
+      @since 0.161.0 — added top_p, top_k, min_p (#851) *)
   type t = {
     temperature : float;
     max_tokens : int;
+    top_p : float option;
+    top_k : int option;
+    min_p : float option;
   }
 
-  let cascade_default = { temperature = 0.3; max_tokens = 500 }
-  let agent_default   = { temperature = 0.7; max_tokens = 16_384 }
-  let low_variance    = { temperature = 0.1; max_tokens = 2048 }
-  let worker_default  = { temperature = 0.2; max_tokens = 16_384 }
-  let deterministic   = { temperature = 0.0; max_tokens = 4096 }
+  (** Sampling triple unset — convenience base for profiles that do
+      not override [top_p] / [top_k] / [min_p]. Not a standalone
+      profile: [temperature] and [max_tokens] are sentinel zero and
+      must be overridden via record-update. *)
+  let no_sampling_overrides : t =
+    { temperature = 0.0; max_tokens = 0;
+      top_p = None; top_k = None; min_p = None }
+
+  let cascade_default =
+    { no_sampling_overrides with temperature = 0.3; max_tokens = 500 }
+  let agent_default =
+    { no_sampling_overrides with temperature = 0.7; max_tokens = 16_384 }
+  let low_variance =
+    { no_sampling_overrides with temperature = 0.1; max_tokens = 2048 }
+  let worker_default =
+    { no_sampling_overrides with temperature = 0.2; max_tokens = 16_384 }
+  let deterministic =
+    { no_sampling_overrides with temperature = 0.0; max_tokens = 4096 }
 end
 
 (** Backward-compatible aliases — existing callers of

--- a/test/test_budget_strategy.ml
+++ b/test/test_budget_strategy.ml
@@ -238,6 +238,22 @@ let test_deterministic_profile () =
   Alcotest.(check (float 0.001)) "temp" 0.0 p.temperature;
   Alcotest.(check int) "max_tokens" 4096 p.max_tokens
 
+(** Regression for #851: built-in profiles leave sampling params
+    unset ([None]) so consumers opting in explicitly — not inherited
+    hardcoded constants. *)
+let test_builtin_profiles_sampling_unset () =
+  let module IP = Llm_provider.Constants.Inference_profile in
+  List.iter (fun (name, p) ->
+    Alcotest.(check bool) (name ^ " top_p=None") true (p.IP.top_p = None);
+    Alcotest.(check bool) (name ^ " top_k=None") true (p.IP.top_k = None);
+    Alcotest.(check bool) (name ^ " min_p=None") true (p.IP.min_p = None))
+    [ "cascade_default", IP.cascade_default
+    ; "agent_default", IP.agent_default
+    ; "low_variance", IP.low_variance
+    ; "worker_default", IP.worker_default
+    ; "deterministic", IP.deterministic
+    ]
+
 (* --- default_summarizer (exported 0.153.0) --- *)
 
 let test_default_summarizer_empty () =
@@ -320,6 +336,8 @@ let () =
     "inference_profiles", [
       Alcotest.test_case "worker_default" `Quick test_worker_default_profile;
       Alcotest.test_case "deterministic" `Quick test_deterministic_profile;
+      Alcotest.test_case "builtin profiles leave sampling unset (#851)" `Quick
+        test_builtin_profiles_sampling_unset;
     ];
     "default_summarizer", [
       Alcotest.test_case "empty -> No prior context" `Quick test_default_summarizer_empty;


### PR DESCRIPTION
## Why

`Llm_provider.Constants.Inference_profile.t` currently exposes only `temperature` / `max_tokens`, so every downstream consumer (notably MASC `oas_worker_cascade.ml` per Epic #6715) carries its own hardcoded sampling params:

\`\`\`ocaml
let worker_top_p = 0.95
let worker_top_k = 20
let worker_min_p = 0.0
\`\`\`

A-axis (SSOT) drift: three constants defined outside the SDK that consumers re-read independently. To make MASC model-agnostic, the SDK has to own the shape.

## Changes

| File | Change |
|------|--------|
| `lib/llm_provider/constants.ml` | `Inference_profile.t` gains three `option` fields (`top_p`, `top_k`, `min_p`). Built-in profiles are rewritten using a shared `no_sampling_overrides` base + record-update, keeping them one line each and leaving sampling unset (`None`). |
| `test/test_budget_strategy.ml` | New `test_builtin_profiles_sampling_unset` enumerates all five profiles and asserts the three sampling fields default to `None`. |

## Design notes

- `option` is deliberate: Anthropic does not accept `min_p`. `None` = omit from request, let provider default apply.
- Built-in profiles do **not** prescribe sampling values — that's a call-site decision, usually with provider awareness (`openai_compat` vs `anthropic`). This keeps the SDK model-agnostic (`feedback_masc-model-agnostic.md`).
- `Sampling.openai_compat_min_p = 0.05` in the same file stays — consumers can reference it when overriding `min_p` for llama-compatible targets: `{ profile with min_p = Some Sampling.openai_compat_min_p }`.

## Verification

- `dune build --root .` clean.
- `dune runtest --root .` full suite green (no FAIL).
- New test passes; existing `worker_default` / `deterministic` tests still pass (they only read `temperature`/`max_tokens`).

## Downstream (out of scope for this PR)

Once merged, MASC can replace its hardcoded constants:

\`\`\`ocaml
(* before *)
let worker_top_p = 0.95

(* after *)
let profile =
  { Inference_profile.worker_default with top_p = Some 0.95 }
\`\`\`

or, if MASC wants just the defaults, read `Inference_profile.worker_default` directly and extend at call time.

## Related

- Closes #851
- Supports Epic #6715 (Model-Agnostic MASC)
- Tick 5 of `planning/claude-plans/effervescent-mapping-grove.md`, A-axis (SSOT)

## Autonomy note

Draft only — Ready transition requires human review per session protocol.