### PR TITLE
fix(llm_provider): honor ~cwd at OS level via env -C prefix (#964)

### DIFF
--- a/lib/llm_provider/cli_common_subprocess.ml
+++ b/lib/llm_provider/cli_common_subprocess.ml
@@ -19,6 +19,16 @@ let build_env ~cwd ~extra_env ?(scrub_env = []) () =
   in
   Array.of_list (cwd_prefix @ extras @ base)
 
+(** Argv prefix that changes the child's OS-level working directory.
+    Mirrors [autonomy_exec.ml]'s approach: prepend [env -C dir] to argv
+    so [chdir(dir)] runs before the target binary execs. Returns [[]]
+    when [cwd] is [None] or blank. [PWD] env var is still set
+    separately by [build_env] for shell-facing callers that read it. *)
+let cwd_wrapper = function
+  | None -> []
+  | Some dir when String.trim dir = "" -> []
+  | Some dir -> ["/usr/bin/env"; "-C"; dir]
+
 (** Default stderr-line handler: route to [Eio.traceln] with a
     transport-name prefix.  Transports that want silence pass
     [~on_stderr_line:ignore]. *)
@@ -37,11 +47,12 @@ let run_core ~sw ~(mgr : _ Eio.Process.mgr) ~name ~cwd ~extra_env
     let r_stdout, w_stdout = Eio_unix.pipe sw in
     let r_stderr, w_stderr = Eio_unix.pipe sw in
     let env = build_env ~cwd ~extra_env ~scrub_env () in
+    let final_argv = cwd_wrapper cwd @ argv in
     let proc = Eio.Process.spawn ~sw mgr
       ~stdout:(w_stdout :> Eio.Flow.sink_ty Eio.Resource.t)
       ~stderr:(w_stderr :> Eio.Flow.sink_ty Eio.Resource.t)
       ~env
-      argv
+      final_argv
     in
     Eio.Flow.close w_stdout;
     Eio.Flow.close w_stderr;

--- a/lib/llm_provider/cli_common_subprocess.mli
+++ b/lib/llm_provider/cli_common_subprocess.mli
@@ -32,10 +32,12 @@ val run_collect :
 
     - [name] is used in error messages and the default
       [on_stderr_line] prefix.
-    - [cwd]: when [Some dir], [PWD=dir] is prepended to the env. The
-      CLI still launches from the parent's CWD; callers relying on
-      process CWD should embed an explicit [--cwd]-like flag in
-      [argv].
+    - [cwd]: when [Some dir], the child runs with [dir] as its OS-level
+      working directory (via an [env -C dir] argv prefix) and with
+      [PWD=dir] in its environment. Child tools that resolve project
+      config from cwd (e.g. claude / codex / gemini discovering
+      [.claude/] / [.codex/] / [.gemini/]) see [dir], not the parent's
+      cwd. Blank strings are treated as [None].
     - [extra_env]: additional [KEY=VAL] pairs prepended to the env.
     - [on_stderr_line]: called for every stderr line as it arrives.
       Defaults to {!default_on_stderr_line}, which forwards to

--- a/test/test_cli_common_subprocess.ml
+++ b/test/test_cli_common_subprocess.ml
@@ -107,6 +107,36 @@ let test_scrub_env_removes_parent_var () =
       "UNSET\n" stdout
   | Error _ -> Alcotest.fail "scrub path should succeed"
 
+let test_cwd_sets_os_level_working_dir () =
+  Eio_main.run @@ fun env ->
+  let mgr = Eio.Stdenv.process_mgr env in
+  Eio.Switch.run @@ fun sw ->
+  (* /tmp is stable on macOS/Linux; on macOS it is a symlink to
+     /private/tmp, so compare against realpath. *)
+  let expected = Unix.realpath "/tmp" in
+  match Llm_provider.Cli_common_subprocess.run_collect ~sw ~mgr
+          ~name:"sh" ~cwd:(Some "/tmp") ~extra_env:[]
+          [sh; "-c"; "pwd -P"] with
+  | Ok { stdout; _ } ->
+    Alcotest.(check string) "child cwd follows ~cwd at OS level"
+      expected (String.trim stdout)
+  | Error _ -> Alcotest.fail "expected Ok"
+
+let test_cwd_blank_treated_as_none () =
+  Eio_main.run @@ fun env ->
+  let mgr = Eio.Stdenv.process_mgr env in
+  Eio.Switch.run @@ fun sw ->
+  (* Blank cwd must not inject a bogus "env -C " prefix that would
+     either fail or chdir somewhere unexpected. Parent cwd is inherited. *)
+  let parent = Unix.realpath (Unix.getcwd ()) in
+  match Llm_provider.Cli_common_subprocess.run_collect ~sw ~mgr
+          ~name:"sh" ~cwd:(Some "   ") ~extra_env:[]
+          [sh; "-c"; "pwd -P"] with
+  | Ok { stdout; _ } ->
+    Alcotest.(check string) "blank cwd == None (inherit parent)"
+      parent (String.trim stdout)
+  | Error _ -> Alcotest.fail "expected Ok"
+
 let () =
   Alcotest.run "cli_common_subprocess"
     [ "run_collect",
@@ -116,6 +146,10 @@ let () =
           `Quick test_on_stderr_line_called_per_line
       ; Alcotest.test_case "scrub_env strips named parent var"
           `Quick test_scrub_env_removes_parent_var
+      ; Alcotest.test_case "cwd sets OS-level working directory"
+          `Quick test_cwd_sets_os_level_working_dir
+      ; Alcotest.test_case "blank cwd treated as None"
+          `Quick test_cwd_blank_treated_as_none
       ]
     ; "run_stream_lines",
       [ Alcotest.test_case "emits lines live" `Quick test_stream_emits_lines_live


### PR DESCRIPTION
## Summary
OAS#964 — `cli_common_subprocess.run_{collect,stream_lines}`의 `~cwd` 인자가 OS 레벨 working directory를 실제로 변경하지 않아, claude / codex / gemini CLI가 `.claude/` / `.codex/` / `.gemini/` project config를 부모 프로세스의 cwd에서 로드하던 버그.

## Changes
- `lib/llm_provider/cli_common_subprocess.ml`: 순수 helper `cwd_wrapper : string option -> string list` 추가. `run_core`에서 `cwd_wrapper cwd @ argv`로 argv 앞에 prepend.
  - `autonomy_exec.ml:96-102`이 이미 쓰는 `/usr/bin/env -C dir` 패턴 그대로.
  - 빈 문자열 / `None` → `[]` (no-op).
  - 기존 `PWD=` 환경 변수 세팅은 유지 (shell-facing 도구가 `$PWD`를 읽을 수 있음).
- `lib/llm_provider/cli_common_subprocess.mli`: `~cwd` 문서를 "PWD env only / callers must embed flag in argv"에서 "OS-level chdir + PWD env"로 교정.
- `test/test_cli_common_subprocess.ml`: 2건 추가
  - `cwd sets OS-level working directory`: `~cwd:(Some "/tmp")` 경로로 `pwd -P` 결과가 `Unix.realpath "/tmp"`와 일치.
  - `blank cwd treated as None`: 공백 cwd에서 parent cwd 상속.

## Impact
`transport_claude_code` / `transport_codex_cli` / `transport_gemini_cli` 3개 transport 전부 `run_core` 경유 — 한 곳 수정으로 모두 해결.

## Test plan
- [x] `dune build --root .` green
- [x] `dune runtest --root .` green (신규 2 테스트 포함)
- [ ] CI 4/4 green 후 사용자 Ready 전환

## Plan mapping
effervescent-mapping-grove Tick 7 / Axis G (결정론 가정): "PWD=만 세팅하면 OS도 바뀔 것"이라는 암묵적 가정 제거 → 타입/테스트로 계약 고정.