### PR TITLE
feat(event_bus): add caused_by to envelope for causation tracing (#877)

### DIFF
--- a/docs/EVENT-CATALOG.md
+++ b/docs/EVENT-CATALOG.md
@@ -42,15 +42,19 @@ Every event carries a common envelope:
 
 ```ocaml
 type envelope = {
-  correlation_id: string;  (* session-level, stable across a run *)
-  run_id: string;          (* per-run identifier *)
-  ts: float;               (* Unix epoch seconds *)
+  correlation_id: string;       (* session-level, stable across a run *)
+  run_id: string;               (* per-run identifier *)
+  ts: float;                    (* Unix epoch seconds *)
+  caused_by: string option;     (* optional causation link (#877) *)
 }
 ```
 
 **Contract**: `correlation_id` is constant for all events belonging to the
-same logical session. `run_id` is unique per agent run. Envelopes are
-filled by producers, never rewritten by subscribers.
+same logical session. `run_id` is unique per agent run. `caused_by`, when
+`Some id`, points at the prior `run_id` (or `correlation_id`) that
+causally triggered this event — enabling A→B→C cascade reconstruction
+within a session. Root events and legacy producers set `caused_by =
+None`. Envelopes are filled by producers, never rewritten by subscribers.
 
 ### 2.2 Native payload variants
 

--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -15,6 +15,7 @@ type envelope = {
   correlation_id: string;
   run_id: string;
   ts: float;
+  caused_by: string option;
 }
 
 (* ── Payload type ─────────────────────────────────────────────────── *)
@@ -77,13 +78,13 @@ let fresh_id () =
   let now_us = Int.of_float (Unix.gettimeofday () *. 1e6) in
   Printf.sprintf "%x-%x-%x" (Unix.getpid ()) now_us n
 
-let mk_envelope ?correlation_id ?run_id () =
+let mk_envelope ?correlation_id ?run_id ?caused_by () =
   let correlation_id = match correlation_id with Some id -> id | None -> fresh_id () in
   let run_id = match run_id with Some id -> id | None -> fresh_id () in
-  { correlation_id; run_id; ts = Unix.gettimeofday () }
+  { correlation_id; run_id; ts = Unix.gettimeofday (); caused_by }
 
-let mk_event ?correlation_id ?run_id payload =
-  { meta = mk_envelope ?correlation_id ?run_id (); payload }
+let mk_event ?correlation_id ?run_id ?caused_by payload =
+  { meta = mk_envelope ?correlation_id ?run_id ?caused_by (); payload }
 
 (* ── Subscription ─────────────────────────────────────────────────── *)
 

--- a/lib/event_bus.mli
+++ b/lib/event_bus.mli
@@ -15,6 +15,16 @@ type envelope = {
   correlation_id: string;  (** Session-level correlation (formerly session_id). *)
   run_id: string;          (** Per-run identifier (formerly worker_run_id). *)
   ts: float;               (** Event timestamp (Unix epoch). *)
+  caused_by: string option;
+    (** ID of the event that causally triggered this one. Distinct from
+        [correlation_id] (same-session scoping): [caused_by] points at a
+        specific prior [run_id] or [correlation_id] to reconstruct
+        A→B→C cascades within a session. [None] means "no known parent
+        event" (root of a causation chain). Convention:
+        [caused_by = Some parent.run_id] when the trigger is a concrete
+        event; [caused_by = Some parent.correlation_id] when the
+        trigger is the session as a whole. Anthropic Multi-Agent
+        Pattern 4 (Message Bus). @since 0.161.0 (#877) *)
 }
 
 (** {2 Payload types} *)
@@ -119,11 +129,24 @@ type event = {
 (** Generate a fresh unique identifier (pid-timestamp-counter). *)
 val fresh_id : unit -> string
 
-(** Create an envelope with optional correlation/run IDs (defaults to fresh). *)
-val mk_envelope : ?correlation_id:string -> ?run_id:string -> unit -> envelope
+(** Create an envelope with optional correlation/run IDs (defaults to fresh)
+    and an optional causation link.
+    @since 0.161.0 [?caused_by] added. *)
+val mk_envelope :
+  ?correlation_id:string ->
+  ?run_id:string ->
+  ?caused_by:string ->
+  unit ->
+  envelope
 
-(** Create an event by wrapping a payload in a fresh envelope. *)
-val mk_event : ?correlation_id:string -> ?run_id:string -> payload -> event
+(** Create an event by wrapping a payload in a fresh envelope.
+    @since 0.161.0 [?caused_by] added. *)
+val mk_event :
+  ?correlation_id:string ->
+  ?run_id:string ->
+  ?caused_by:string ->
+  payload ->
+  event
 
 (** {2 Bus} *)
 

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -326,12 +326,26 @@ let test_mk_envelope_defaults () =
   let env = Event_bus.mk_envelope () in
   check bool "correlation_id non-empty" true (String.length env.correlation_id > 0);
   check bool "run_id non-empty" true (String.length env.run_id > 0);
-  check bool "ts > 0" true (env.ts > 0.0)
+  check bool "ts > 0" true (env.ts > 0.0);
+  check (option string) "caused_by defaults to None" None env.caused_by
 
 let test_mk_envelope_explicit () =
   let env = Event_bus.mk_envelope ~correlation_id:"c" ~run_id:"r" () in
   check string "correlation_id" "c" env.correlation_id;
-  check string "run_id" "r" env.run_id
+  check string "run_id" "r" env.run_id;
+  check (option string) "caused_by omitted stays None" None env.caused_by
+
+let test_mk_envelope_with_caused_by () =
+  let env = Event_bus.mk_envelope ~caused_by:"run-42" () in
+  check (option string) "caused_by propagated" (Some "run-42") env.caused_by
+
+let test_mk_event_propagates_caused_by () =
+  let ev =
+    Event_bus.mk_event ~correlation_id:"s" ~run_id:"r"
+      ~caused_by:"parent-7" (Custom ("x", `Null))
+  in
+  check (option string) "event.meta.caused_by"
+    (Some "parent-7") ev.meta.caused_by
 
 (* ── Backpressure policy ──────────────────────────────────────────── *)
 
@@ -506,6 +520,9 @@ let () =
       test_case "fresh_id unique" `Quick test_fresh_id_unique;
       test_case "mk_envelope defaults" `Quick test_mk_envelope_defaults;
       test_case "mk_envelope explicit" `Quick test_mk_envelope_explicit;
+      test_case "mk_envelope with caused_by" `Quick test_mk_envelope_with_caused_by;
+      test_case "mk_event propagates caused_by"
+        `Quick test_mk_event_propagates_caused_by;
     ];
     "purpose", [
       test_case "subscribe ~purpose surfaces in stats" `Quick


### PR DESCRIPTION
## Summary
OAS#877 — Anthropic Multi-Agent Pattern 4 (Message Bus). `envelope`은 이미 `correlation_id`(session 경계)와 `run_id`(run unique)를 가지지만, "이 이벤트를 유발한 이벤트"를 가리키는 포인터가 없어 A→B→C cascade 재구성이 timestamp 추정에 의존. `caused_by : string option`을 추가해 계약 레벨로 고정.

## Changes
- `lib/event_bus.mli` + `lib/event_bus.ml`: `envelope`에 `caused_by : string option` 필드 추가. `mk_envelope` / `mk_event`에 `?caused_by:string` 선택 인자 추가. 기본 `None` — 기존 호출자는 코드 수정 불필요.
- `docs/EVENT-CATALOG.md` §2.1: 필드 추가 + 컨벤션 문서화 (event-triggered → `Some parent.run_id`, session-level → `Some parent.correlation_id`, root/legacy → `None`).
- `test/test_event_bus.ml`: 2건 추가
  - `mk_envelope with caused_by`: `~caused_by:"run-42"` 전달 시 envelope에 보존
  - `mk_event propagates caused_by`: `mk_event`가 값을 `event.meta.caused_by`로 전파

기존 `mk_envelope defaults` / `mk_envelope explicit` 테스트에도 `caused_by = None` 기본 검증 assertion 추가.

## Non-goals
- producer 사이트들(orchestrator, pipeline, agent_tools 등)이 실제로 `caused_by`를 채우는 작업은 본 PR scope 밖. 본 PR은 **envelope 계약 확장**만 수행 — 소비자가 구독 파이프라인에서 의존할 수 있는 타입을 먼저 고정.
- 후속 PR들이 이 필드를 채워가는 점진적 방식이 bottom-up 원칙에 부합. 각 emit 지점 수정은 별도 leaf.

## Impact
- envelope record literal: `lib/event_bus.ml:83` 1곳만 존재 (모든 사용자가 `mk_envelope` 경유). `rg '\{ correlation_id'` 전수 스캔으로 확인 — 드리프트 안전.
- 기존 33 파일의 `mk_envelope`/`mk_event` 호출 모두 backward-compat (optional 인자 생략).

## Test plan
- [x] `dune build --root .` green
- [x] `dune runtest --root .` green (event_bus 34 tests, 신규 2건 포함)
- [ ] CI 4/4 green 후 사용자 Ready 전환

## Plan mapping
effervescent-mapping-grove Tick 8 / Axis B (텔레메트리 누락): "로그만 있으면 추적 가능"이라는 가정을 덜어내고 causation을 구조화. feedback_masc-oas-layer-boundary.md 준수 — OAS가 raw 인프라(causation id) 소유.