### PR TITLE
docs: drop stale Swarm semantics references from autonomy docs

### DIFF
--- a/docs/analysis/AUTONOMY-PRIMITIVES-BOUNDARY.md
+++ b/docs/analysis/AUTONOMY-PRIMITIVES-BOUNDARY.md
@@ -44,5 +44,5 @@ The intended shape is:
 5. On the next attempt, inject retrieved lesson text via
    `Hooks.BeforeTurnParams.extra_system_context` or `Append_instruction`.
 
-That gives consumers a safe autonomy substrate without changing `Agent`,
-`Builder`, or `Swarm` semantics.
+That gives consumers a safe autonomy substrate without changing `Agent`
+or `Builder` semantics.

--- a/examples/autonomy_primitives_demo.ml
+++ b/examples/autonomy_primitives_demo.ml
@@ -1,7 +1,7 @@
 (** Autonomy primitives demo.
 
     Shows how an external orchestrator can compose the new autonomy helpers
-    without changing Agent or Swarm semantics.
+    without changing Agent semantics.
 
     Usage:
       dune exec examples/autonomy_primitives_demo.exe *)


### PR DESCRIPTION
## Summary

`lib_swarm/` was removed from OAS main. Two active docstrings still claimed autonomy primitives "do not change Agent, Builder, or Swarm semantics" — Swarm is no longer an API surface here, so the reference is stale and misleading.

- `docs/analysis/AUTONOMY-PRIMITIVES-BOUNDARY.md`: drop Swarm from the boundary list
- `examples/autonomy_primitives_demo.ml`: same, in the header docstring

## Product impact

Removes a source of confusion for developers reading the autonomy primitives docs. No runtime behavior change.

## Evidence

- `ls lib_swarm/ 2>&1` → directory not found (confirmed removed)
- `git grep "lib_swarm/\|Swarm" examples/ docs/analysis/` → now only the CHANGELOG historical entries remain
- `dune build --root . examples` → green

## Review evidence

None requested. 3 lines changed in comments/prose.

## Linked issue

None specifically. Companion to masc-mcp #8562 (remove `agent_sdk.swarm` ghost dep) and masc-mcp #8565 (delete orphaned lib/swarm/*).

## Out of scope

`CHANGELOG.md` swarm entries are intentionally untouched — they describe historical versions when `lib_swarm/` existed and should remain as a changelog convention.

## Test plan

- [ ] `dune build --root .` green
- [ ] `grep -n Swarm docs/analysis/AUTONOMY-PRIMITIVES-BOUNDARY.md examples/autonomy_primitives_demo.ml` returns no hits (only CHANGELOG.md retains historical mentions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)