### PR TITLE
feat(orchestrator): wire AgentStarted run_id as caused_by on {Completed,Failed}

### DIFF
--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -97,18 +97,23 @@ let run_agent_with_timeout ~sw ?clock ~task_id config agent prompt =
 
 let run_task ~sw ?clock orch task =
   Option.iter (fun cb -> cb task) orch.config.on_task_start;
-  (* AgentStarted event *)
-  (match orch.config.event_bus with
-   | Some bus ->
-     let correlation_id = match find_agent orch task.agent_name with
-       | Some agent -> orch_correlation_id agent
-       | None -> task.id
-     in
-     let run_id = Event_bus.fresh_id () in
-     Event_bus.publish bus
-       (Event_bus.mk_event ~correlation_id ~run_id
-          (AgentStarted { agent_name = task.agent_name; task_id = task.id }))
-   | None -> ());
+  (* AgentStarted event — capture the started run_id so AgentCompleted
+     and AgentFailed can record it as caused_by, preserving the event
+     causation chain (#877). *)
+  let started_run_id =
+    match orch.config.event_bus with
+    | Some bus ->
+      let correlation_id = match find_agent orch task.agent_name with
+        | Some agent -> orch_correlation_id agent
+        | None -> task.id
+      in
+      let run_id = Event_bus.fresh_id () in
+      Event_bus.publish bus
+        (Event_bus.mk_event ~correlation_id ~run_id
+           (AgentStarted { agent_name = task.agent_name; task_id = task.id }));
+      Some run_id
+    | None -> None
+  in
   let t0 = Unix.gettimeofday () in
   let result =
     match find_agent orch task.agent_name with
@@ -135,7 +140,7 @@ let run_task ~sw ?clock orch task =
        | None -> Event_bus.fresh_id ()
      in
      Event_bus.publish bus
-       (Event_bus.mk_event ~correlation_id ~run_id
+       (Event_bus.mk_event ~correlation_id ~run_id ?caused_by:started_run_id
           (AgentCompleted
              { agent_name = task.agent_name;
                task_id = task.id;
@@ -147,7 +152,7 @@ let run_task ~sw ?clock orch task =
      (match result with
       | Error err ->
         Event_bus.publish bus
-          (Event_bus.mk_event ~correlation_id ~run_id
+          (Event_bus.mk_event ~correlation_id ~run_id ?caused_by:started_run_id
              (AgentFailed
                 { agent_name = task.agent_name;
                   task_id = task.id;

--- a/test/test_event_integration.ml
+++ b/test/test_event_integration.ml
@@ -42,7 +42,27 @@ let test_orchestrator_error_emits_agent_failed () =
      check string "agent_name" "ghost" agent_name;
      check string "task_id" "t-err" task_id;
      check bool "elapsed non-negative" true (elapsed >= 0.0)
-   | _ -> fail "expected AgentFailed payload")
+   | _ -> fail "expected AgentFailed payload");
+  (* Causation chain (#877): AgentCompleted / AgentFailed must carry
+     [caused_by = Some started.run_id], i.e. point back at the
+     AgentStarted envelope that opened this task. AgentStarted itself
+     is the chain root (caused_by = None). *)
+  let started =
+    try List.find (fun e ->
+      Event_forward.event_type_name e = "agent.started") events
+    with Not_found -> fail "AgentStarted missing"
+  in
+  let completed =
+    try List.find (fun e ->
+      Event_forward.event_type_name e = "agent.completed") events
+    with Not_found -> fail "AgentCompleted missing"
+  in
+  check (option string) "AgentStarted.caused_by is None (root)"
+    None started.meta.caused_by;
+  check (option string) "AgentCompleted.caused_by points at started.run_id"
+    (Some started.meta.run_id) completed.meta.caused_by;
+  check (option string) "AgentFailed.caused_by points at started.run_id"
+    (Some started.meta.run_id) (List.hd failed_events).meta.caused_by
 
 (* ── B. run_with_handoffs emits Handoff{Requested,Completed} ──── *)
 


### PR DESCRIPTION
## Summary
#1017 (merged)에서 `envelope.caused_by : string option` 계약을 추가. 이 PR은 그 첫 producer fill-in — `Orchestrator.run_task`가 `AgentStarted`의 `run_id`를 포착해 동일 task의 `AgentCompleted` / `AgentFailed` envelope에 `caused_by = Some started.run_id`로 기록.

## Changes
- `lib/orchestrator.ml` `run_task`
  - `AgentStarted` emit 시 반환되는 `run_id`를 로컬 `started_run_id : string option`에 보관 (이벤트 버스가 없으면 `None`)
  - `AgentCompleted` / `AgentFailed` 두 `mk_event` 호출에 `?caused_by:started_run_id` 전달
  - run_id 선택 로직(`orch_run_id agent`/`fresh_id`)은 변경 없음 — `caused_by`는 별도 채널
- `test/test_event_integration.ml` 기존 `orchestrator_failure` 테스트에 3 assertion 추가:
  - `AgentStarted.caused_by is None (root)`
  - `AgentCompleted.caused_by` = `Some started.run_id`
  - `AgentFailed.caused_by`    = `Some started.run_id`

## Non-goals
- 다른 producer 사이트들(pipeline turn events, agent_tools.ml tool_called/completed, handoff events 등)에서의 fill-in은 각각 별도 leaf. 본 PR은 orchestrator **1 emit 사이트**만 수정.
- `AgentStarted` 자체의 `caused_by`는 항상 `None` — task 발생 트리거(run_task 호출자)가 이벤트가 아니므로 root로 고정.

## Test plan
- [x] `dune build --root .` green
- [x] `dune runtest --root .` green (event_integration 2→5 assertions; 3 신규)
- [ ] CI 4/4 green 후 사용자 Ready 전환

## Plan mapping
effervescent-mapping-grove Tick 10 / Axis B (텔레메트리 누락) — #877 계약에 첫 실값을 채움. 근본 원칙: "contract first, producer fill-in은 follow-up leaf" (Tick 8 노트 참조).