### PR TITLE
feat(agent): wire HandoffRequested run_id as caused_by on HandoffCompleted

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -234,14 +234,22 @@ let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
               loop ()
             | Some target ->
               let from_name = agent_with_handoffs.state.config.name in
-              (match agent_with_handoffs.options.event_bus with
-               | Some bus -> Event_bus.publish bus
-                   (Event_bus.mk_event
-                      (HandoffRequested
-                         { from_agent = from_name;
-                           to_agent = target.name;
-                           reason = prompt }))
-               | None -> ());
+              (* HandoffRequested: capture the run_id so HandoffCompleted
+                 can record it as [caused_by], preserving the
+                 request -> completion causation chain (#877). *)
+              let handoff_requested_run_id =
+                match agent_with_handoffs.options.event_bus with
+                | Some bus ->
+                  let run_id = Event_bus.fresh_id () in
+                  Event_bus.publish bus
+                    (Event_bus.mk_event ~run_id
+                       (HandoffRequested
+                          { from_agent = from_name;
+                            to_agent = target.name;
+                            reason = prompt }));
+                  Some run_id
+                | None -> None
+              in
               let handoff_t0 = Unix.gettimeofday () in
               let sub = create ~net:agent.net ~config:target.config
                 ~tools:target.tools ~options:{ default_options with
@@ -252,7 +260,7 @@ let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
               let handoff_elapsed = Unix.gettimeofday () -. handoff_t0 in
               (match agent_with_handoffs.options.event_bus with
                | Some bus -> Event_bus.publish bus
-                   (Event_bus.mk_event
+                   (Event_bus.mk_event ?caused_by:handoff_requested_run_id
                       (HandoffCompleted
                          { from_agent = from_name;
                            to_agent = target.name;

--- a/test/test_event_integration.ml
+++ b/test/test_event_integration.ml
@@ -129,6 +129,24 @@ let test_handoff_emits_request_and_completion () =
           transfer_to_* tool call arguments, not the parent prompt. *)
        check string "reason carries sub-prompt" "sub" reason
      | _ -> fail "expected HandoffRequested payload");
+    (* Causation chain (#877): HandoffCompleted.caused_by must point
+       at the HandoffRequested envelope that opened the handoff.
+       HandoffRequested itself is the chain root. *)
+    let requested =
+      try List.find (fun e ->
+        Event_forward.event_type_name e = "handoff.requested") events
+      with Not_found -> fail "HandoffRequested missing"
+    in
+    let completed =
+      try List.find (fun e ->
+        Event_forward.event_type_name e = "handoff.completed") events
+      with Not_found -> fail "HandoffCompleted missing"
+    in
+    check (option string) "HandoffRequested.caused_by is None (root)"
+      None requested.meta.caused_by;
+    check (option string)
+      "HandoffCompleted.caused_by points at requested.run_id"
+      (Some requested.meta.run_id) completed.meta.caused_by;
     Eio.Switch.fail sw Exit
   with Exit -> ()
 


### PR DESCRIPTION
## Summary
`#1017`의 `envelope.caused_by : string option` 계약, 두 번째 producer fill-in. 첫 번째는 `#1019` (orchestrator `AgentStarted → AgentCompleted/Failed`). 이번에는 `Agent.run_with_handoffs`가 `HandoffRequested`의 `run_id`를 포착해 동일 handoff의 `HandoffCompleted` envelope에 `caused_by = Some requested.run_id`로 기록.

## Changes
- `lib/agent/agent.ml` `run_with_handoffs` loop `Some target` 분기
  - `HandoffRequested` emit 시 `run_id = Event_bus.fresh_id ()` 명시 + 로컬 `handoff_requested_run_id : string option`에 보관 (이벤트 버스 없으면 `None`)
  - `HandoffCompleted`의 `mk_event`에 `?caused_by:handoff_requested_run_id` 전달
  - sub-agent 실행(`run ~sw ?clock sub prompt`)은 변경 없음
- `test/test_event_integration.ml` 기존 `handoff_lifecycle` 테스트에 2 assertion 추가:
  - `HandoffRequested.caused_by is None (root)`
  - `HandoffCompleted.caused_by` = `Some requested.run_id`

## Non-goals
- 남은 producer 사이트들 — pipeline `TurnStarted → TurnCompleted` (여러 함수 분산 state 공유 필요, 별도 설계 필요), `agent_tools` `ToolCalled → ToolCompleted`, context compact pair 등 — 각각 후속 leaf.
- `HandoffRequested` 자체의 `caused_by`는 항상 `None` (handoff 트리거는 tool call이지 이벤트 아님 — 후속 fill-in에서 확장 여지).

## Test plan
- [x] `dune build --root .` green
- [x] `dune runtest --root .` green (event_integration 신규 2 assertion)
- [ ] CI 4/4 green 후 사용자 Ready 전환

## Plan mapping
effervescent-mapping-grove Tick 11 / Axis B (텔레메트리 누락) — #877 계약에 두 번째 실값. 원칙: "contract first, 각 emit pair는 개별 leaf" (Tick 8/10 연속선).