### PR TITLE
feat(agent_tools): wire ToolCalled run_id as caused_by on ToolCompleted

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -142,12 +142,23 @@ let invoke_hook ?on_hook_invoked ~tracer ~agent_name ~turn_count ~hook_name
 let find_and_execute_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tracer
     ~agent_name ~turn_count ?correlation_id ?run_id ?on_hook_invoked
     ~schedule name input id =
-  (* ToolCalled event *)
-  (match event_bus with
-   | Some bus -> Event_bus.publish bus
-       (Event_bus.mk_event ?correlation_id ?run_id
-          (ToolCalled { agent_name; tool_name = name; input }))
-   | None -> ());
+  (* ToolCalled event — capture the published envelope's run_id so the
+     matching ToolCompleted records it as caused_by, preserving the
+     call -> completion causation chain per tool invocation (#877).
+     Using [ev.meta.run_id] works whether the caller supplies
+     [~run_id] explicitly or we fall back to the fresh id minted by
+     [mk_event]. *)
+  let tool_called_run_id =
+    match event_bus with
+    | Some bus ->
+      let ev =
+        Event_bus.mk_event ?correlation_id ?run_id
+          (ToolCalled { agent_name; tool_name = name; input })
+      in
+      Event_bus.publish bus ev;
+      Some ev.meta.run_id
+    | None -> None
+  in
   let tool_opt = List.find_opt (fun (tool: Tool.t) -> tool.schema.name = name) tools in
   let result = match tool_opt with
   | Some tool ->
@@ -276,6 +287,7 @@ let find_and_execute_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tra
      in
      Event_bus.publish bus
        (Event_bus.mk_event ?correlation_id ?run_id
+          ?caused_by:tool_called_run_id
           (ToolCompleted { agent_name; tool_name = name; output }))
    | None -> ());
   result

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -273,7 +273,15 @@ let test_tool_completed_preserves_non_retryable_flag () =
       check string "tool_completed correlation_id" "sess-event"
         completed_meta.correlation_id;
       check string "tool_completed run_id" "run-event"
-        completed_meta.run_id
+        completed_meta.run_id;
+      (* Causation chain (#877): ToolCalled is the chain root for this
+         tool invocation; ToolCompleted.caused_by must point at
+         called_meta.run_id. *)
+      check (option string) "tool_called.caused_by is None (root)"
+        None called_meta.caused_by;
+      check (option string)
+        "tool_completed.caused_by points at called.run_id"
+        (Some called_meta.run_id) completed_meta.caused_by
   | _ -> fail "expected tool called/completed events"
 
 let test_correlation_fields_roundtrip () =


### PR DESCRIPTION
## Summary
`#1017`의 `envelope.caused_by : string option` 계약, 세 번째 producer fill-in. `find_and_execute_tool` 내부 `ToolCalled → ToolCompleted` 인과 체인.

## Changes
- `lib/agent/agent_tools.ml` `find_and_execute_tool`
  - `ToolCalled` emit을 `mk_event → publish`로 나누고 `ev.meta.run_id`를 로컬 `tool_called_run_id : string option`에 포착
  - `ToolCompleted`의 `mk_event`에 `?caused_by:tool_called_run_id` 전달
- `test/test_event_bus.ml` `test_tool_completed_failure_non_retryable`에 2 assertion 추가
  - `called.caused_by is None (root)`
  - `completed.caused_by = Some called.run_id`

## Why this pattern differs from #1019/#1020
이전 두 fill-in은 fresh_id를 명시적으로 생성해 전달. 이번에는 `find_and_execute_tool` 호출자들이 `?correlation_id ?run_id`를 명시적으로 넘기는 사이트가 여러 개(pipeline 경로 6 호출)라, caller가 넘긴 `run_id`를 존중해야 함. `mk_event`가 생성한 envelope의 `ev.meta.run_id`를 직접 포착하면 caller-provided든 fresh든 모두 작동 — 기존 testcase(`run_id:"run-event"`) 깨지지 않음을 추가 assertion으로 재확인.

## Non-goals
- pipeline `TurnStarted/TurnCompleted` pair는 여전히 별도 leaf (여러 함수 분산, state 공유 필요)
- context compact pair (`ContextCompactStarted/ContextCompacted`) 후속
- `ContentReplacement*` (변이 1개 아니라 Replaced vs Kept로 분기)

## Test plan
- [x] `dune build --root .` green
- [x] `dune runtest --root .` green (event_bus 32+2+causation 2 assertion; tool_completed_failure 확장)
- [ ] CI 4/4 green 후 사용자 Ready 전환

## Plan mapping
effervescent-mapping-grove Tick 12 / Axis B (텔레메트리 누락) — #877 계약의 세 번째 실값. pattern-variant 추가: "호출자 제공 id 존중 + causation도 fill-in" (handoff/orchestrator 패턴과 상호 보완).