### PR TITLE
feat(agent_turn): opt-in idle_granularity variant for is_idle (#896)

### DIFF
--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -23,12 +23,30 @@ let compute_fingerprints tool_uses =
     | _ -> None
   ) tool_uses
 
-let is_idle (prev : tool_call_fingerprint list option) current =
+type idle_granularity =
+  | Exact
+  | Name_only
+  | Name_and_subset of string list
+
+(* Key used to compare two fingerprints under the given granularity.
+   For [Name_and_subset _], the [keys] list is accepted for typecheck
+   stability but not yet consulted — this variant currently behaves
+   as [Name_only]. JSON field extraction is deferred to a follow-up
+   leaf (#896). *)
+let fingerprint_key granularity fp =
+  match granularity with
+  | Exact -> fp.fp_name ^ "\x00" ^ fp.fp_input
+  | Name_only -> fp.fp_name
+  | Name_and_subset _keys -> fp.fp_name
+
+let is_idle ?(granularity = Exact)
+    (prev : tool_call_fingerprint list option) current =
   match prev with
   | None -> false
   | Some prev_fps ->
     List.length current = List.length prev_fps &&
-    List.for_all2 (fun a b -> a.fp_name = b.fp_name && a.fp_input = b.fp_input)
+    List.for_all2 (fun a b ->
+        fingerprint_key granularity a = fingerprint_key granularity b)
       current prev_fps
 
 (* ── Turn preparation ─────────────────────────────────────────── *)

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -18,11 +18,37 @@ type tool_call_fingerprint = {
   fp_input: string;
 }
 
+(** Granularity at which two fingerprints are considered the "same"
+    for idle detection.
+
+    - [Exact] (default, pre-0.161 behaviour): both [fp_name] and
+      [fp_input] must match byte-for-byte.
+    - [Name_only]: only [fp_name] is compared. Catches polling loops
+      that alternate arguments (e.g. [status(x)] -> [status(y)] ->
+      [status(x)]) and cross-tool polls at the tool-name level.
+    - [Name_and_subset keys]: placeholder for future argument-subset
+      matching — currently behaves as [Name_only]. The [keys] list is
+      carried through for typecheck stability, but its semantics
+      (JSON field extraction) are left for a follow-up leaf. See #896.
+
+    @since 0.161.0 *)
+type idle_granularity =
+  | Exact
+  | Name_only
+  | Name_and_subset of string list
+
 (** Compute fingerprints from content blocks containing [ToolUse]. *)
 val compute_fingerprints : Types.content_block list -> tool_call_fingerprint list
 
-(** Return [true] when [current] fingerprints match [prev] exactly. *)
-val is_idle : tool_call_fingerprint list option -> tool_call_fingerprint list -> bool
+(** Return [true] when [current] fingerprints match [prev] at the
+    given granularity. Default [?granularity] is [Exact] — preserves
+    the pre-0.161 semantics for every existing caller.
+    @since 0.161.0 [?granularity] added (#896). *)
+val is_idle :
+  ?granularity:idle_granularity ->
+  tool_call_fingerprint list option ->
+  tool_call_fingerprint list ->
+  bool
 
 (** {1 Turn preparation} *)
 

--- a/test/dune
+++ b/test/dune
@@ -47,6 +47,10 @@
  (libraries agent_sdk alcotest))
 
 (test
+ (name test_agent_turn)
+ (libraries agent_sdk alcotest yojson))
+
+(test
  (name test_approval)
  (libraries agent_sdk alcotest yojson eio eio_main))
 

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -236,6 +236,49 @@ let test_idle_different_calls () =
   Alcotest.(check bool) "not idle" false second.is_idle;
   Alcotest.(check int) "consecutive reset" 0 second.new_state.consecutive_idle_turns
 
+(* ── is_idle ~granularity tests (#896) ───────────────────── *)
+
+let fp name input_str =
+  { Agent_turn.fp_name = name;
+    fp_input = Yojson.Safe.to_string (Yojson.Safe.from_string input_str) }
+
+let test_is_idle_exact_distinguishes_inputs () =
+  let a = [fp "search" {|{"q":"a"}|}] in
+  let b = [fp "search" {|{"q":"b"}|}] in
+  Alcotest.(check bool) "Exact: differing inputs -> not idle"
+    false (Agent_turn.is_idle (Some a) b);
+  Alcotest.(check bool) "Exact: identical -> idle"
+    true (Agent_turn.is_idle (Some a) a)
+
+let test_is_idle_name_only_collapses_inputs () =
+  let a = [fp "masc_status" {|{"token":"x"}|}] in
+  let b = [fp "masc_status" {|{"token":"y"}|}] in
+  Alcotest.(check bool) "Name_only: same name, different input -> idle"
+    true (Agent_turn.is_idle ~granularity:Agent_turn.Name_only (Some a) b);
+  let c = [fp "masc_heartbeat" {|{"token":"x"}|}] in
+  Alcotest.(check bool) "Name_only: different name -> not idle"
+    false (Agent_turn.is_idle ~granularity:Agent_turn.Name_only (Some a) c)
+
+let test_is_idle_name_and_subset_placeholder_matches_name_only () =
+  let a = [fp "masc_status" {|{"token":"x","verbose":true}|}] in
+  let b = [fp "masc_status" {|{"token":"y","verbose":false}|}] in
+  (* Placeholder semantics: keys list is currently ignored; behaves
+     as Name_only. Locking this in a test so future leaves that wire
+     up real subset matching will break loudly here. *)
+  Alcotest.(check bool)
+    "Name_and_subset placeholder: same name -> idle"
+    true
+    (Agent_turn.is_idle
+       ~granularity:(Agent_turn.Name_and_subset ["token"])
+       (Some a) b)
+
+let test_is_idle_prev_none_never_idle () =
+  let current = [fp "search" {|{"q":"a"}|}] in
+  Alcotest.(check bool) "Exact + prev=None"
+    false (Agent_turn.is_idle None current);
+  Alcotest.(check bool) "Name_only + prev=None"
+    false (Agent_turn.is_idle ~granularity:Agent_turn.Name_only None current)
+
 (* ── filter_valid_messages tests ─────────────────────────── *)
 
 let test_filter_valid_empty () =
@@ -659,6 +702,14 @@ let () =
       Alcotest.test_case "different calls" `Quick test_idle_different_calls;
       Alcotest.test_case "multiple tools" `Quick test_idle_multiple_tools;
       Alcotest.test_case "non-tool ignored" `Quick test_idle_non_tool_use_ignored;
+      Alcotest.test_case "granularity=Exact distinguishes inputs" `Quick
+        test_is_idle_exact_distinguishes_inputs;
+      Alcotest.test_case "granularity=Name_only collapses inputs" `Quick
+        test_is_idle_name_only_collapses_inputs;
+      Alcotest.test_case "granularity=Name_and_subset placeholder" `Quick
+        test_is_idle_name_and_subset_placeholder_matches_name_only;
+      Alcotest.test_case "granularity: prev=None never idle" `Quick
+        test_is_idle_prev_none_never_idle;
     ];
     "filter_valid_messages", [
       Alcotest.test_case "empty base" `Quick test_filter_valid_empty;


### PR DESCRIPTION
## Summary
OAS#896 — `is_idle`가 `{fp_name, fp_input}` 바이트 일치로만 idle을 판정해, polling loop가 args만 바꾸면(예: `masc_status(x) → masc_status(y) → masc_status(x)`) 영원히 "not idle". 다운스트림이 category classifier workaround를 키우는 원인(masc-mcp#7073/#7081/#7078).

Opt-in `idle_granularity` variant 추가 — 기본 `Exact` 유지, consumer가 필요 시 `Name_only`/`Name_and_subset`로 coarse-grain 가능.

## Changes
- `lib/agent/agent_turn.mli` + `lib/agent/agent_turn.ml`
  - `type idle_granularity = Exact | Name_only | Name_and_subset of string list` export
  - `is_idle`에 `?granularity:idle_granularity` (기본 `Exact`) 추가 — pre-0.161 시맨틱 그대로
  - `fingerprint_key` internal helper (granularity에 따라 비교 키 생성)
  - `Name_and_subset _keys`는 **placeholder** — 현재 Name_only와 동일 동작. `keys` 페이로드만 typecheck 안정성 확보.
- `test/dune`: `test_agent_turn` stanza 추가 — 기존 파일이 orphan 상태였음(37 cases never ran)
- `test/test_agent_turn.ml`: 4 신규 case (Exact distinguishes / Name_only collapses / Name_and_subset placeholder locks semantic / prev=None never idle)

## Orphan test note
`test/test_agent_turn_budget_unit.ml`도 dune 미등록 orphan. 본 PR에서는 scope 최소화를 위해 `test_agent_turn`만 등록 — 별도 housekeeping issue로 기록 예정.

## Non-goals
- 기본 granularity 변경 금지 (Exact 유지)
- `Agent_config` / `Agent.options`에 per-agent selector 노출 — 후속 leaf
- `Name_and_subset`의 실제 JSON 필드 추출 — 후속 leaf (현재 placeholder를 regression test로 고정)

## Test plan
- [x] `dune build --root .` green
- [x] `dune runtest --root .` green; Agent_turn 4 신규 + 37 기존 total 41 tests
- [ ] CI 4/4 green 후 사용자 Ready 전환

## Plan mapping
effervescent-mapping-grove Tick 13 / Axis E (Variant 누락) — sound partial 확장. Heuristic category classifier를 OAS 레벨에서 계약으로 대체해 `feedback_no-heuristic-category.md` 원칙을 상류에 고정.