### PR TITLE
chore(test): register orphan test_agent_turn_budget_unit (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -35,6 +35,10 @@
  (libraries agent_sdk alcotest yojson))
 
 (test
+ (name test_agent_turn_budget_unit)
+ (libraries agent_sdk alcotest))
+
+(test
  (name test_approval)
  (libraries agent_sdk alcotest yojson eio eio_main))
 


### PR DESCRIPTION
## Summary
`test/test_agent_turn_budget_unit.ml`이 `test/dune`에 등록되지 않아 `dune runtest`에서 pick up 안 됨 → 12 cases silently skipped in CI.

## Changes
- `test/dune`: `(test (name test_agent_turn_budget_unit) (libraries agent_sdk alcotest))` stanza 추가 (test_hooks 옆)
- 소스 변경 0건 — 기존 12 cases 그대로 pass

## Broader orphan sweep 
본 PR은 **단 1파일** 등록 (leaf 원칙). 전체 감사 결과:
- `test/*.ml`: 151 파일
- `test/dune` `(name test_*)` stanza: 75개
- **실제 CI 실행**: ~72 test 모듈 (`dune runtest --force` 기준)

시스템적 등록 누락이 존재 — `test_a2a*`, `test_agent_*` 계열 상당수, `test_eval_*`, `test_memory_*`, `test_harness_*` 등. 각 orphan이 현재 API로 빌드 가능한지 불명 (오래된 API 참조 가능성). 대량 bulk 등록은 스크립트 검증 필요 — 별도 effort로 tracking.

## Related
- #1024 (`test_agent_turn` 등록) — 같은 패턴, 별도 merge 필요. 본 PR과 파일 영역 겹치지 않아 독립 머지 가능.
- #1025 이슈를 본 PR에서 부분 해결, 나머지 150 orphan은 issue body 업데이트 예정.

## Test plan
- [x] `dune build --root .` green
- [x] `dune exec test_agent_turn_budget_unit` green (12/12 cases)
- [x] `dune runtest --root .` green — 기존 runtest가 이 module을 이제 포함
- [ ] CI 4/4 green 후 사용자 Ready 전환

## Plan mapping
effervescent-mapping-grove Tick 14 — Tick 13(#1024) 발견 orphan housekeeping 후속.