### PR TITLE
feat(tool_retry_policy): contract-first error_class variant (#898)

### DIFF
--- a/lib/tool_retry_policy.ml
+++ b/lib/tool_retry_policy.ml
@@ -21,6 +21,20 @@ type failure = {
   kind: failure_kind;
 }
 
+type error_class =
+  | Transient
+  | Deterministic
+  | Unknown
+
+let classify = function
+  | Validation_error -> Deterministic
+  | Recoverable_tool_error -> Transient
+
+let error_class_to_string = function
+  | Transient -> "transient"
+  | Deterministic -> "deterministic"
+  | Unknown -> "unknown"
+
 type decision =
   | No_retry
   | Retry of {

--- a/lib/tool_retry_policy.mli
+++ b/lib/tool_retry_policy.mli
@@ -21,6 +21,39 @@ type failure = {
   kind: failure_kind;
 }
 
+(** Error class — orthogonal classification over {!failure_kind} that
+    consumers can use to parameterise retry budgets or circuit
+    breakers.
+
+    - [Transient]: retry cheap (e.g. network flake, rate limit).
+    - [Deterministic]: retry futile; escalate instead
+      (e.g. [path_not_found], invalid_arguments).
+    - [Unknown]: no classification available.
+
+    Introduced as a contract-first step toward an
+    error-class-parameterised retry policy (#898). The existing
+    [failure_kind] variants and [retry_on_*] boolean toggles are
+    unchanged — consumers opt in via {!classify}.
+
+    @since 0.161.0 (#898) *)
+type error_class =
+  | Transient
+  | Deterministic
+  | Unknown
+
+(** Pure projection from the legacy [failure_kind] variant:
+    - [Validation_error] -> [Deterministic] (schema violation is not
+      a function of time; the same input fails the same way).
+    - [Recoverable_tool_error] -> [Transient] (tool opted into
+      retry, mirroring the legacy [recoverable: bool] semantics).
+
+    Downstream consumers that want finer classification should tag
+    their errors directly once a structured error surface lands. *)
+val classify : failure_kind -> error_class
+
+(** Stable, lowercase identifier for logs / metric labels. *)
+val error_class_to_string : error_class -> string
+
 type decision =
   | No_retry
   | Retry of {

--- a/test/test_agent_sdk.ml
+++ b/test/test_agent_sdk.ml
@@ -181,6 +181,29 @@ let test_tool_retry_policy_feedback_preserves_positive_limit () =
   Alcotest.(check bool) "shows actual positive limit" true
     (Util.string_contains ~needle:"retry 5/3" text)
 
+(* ── error_class classification (#898) ─────────────────── *)
+
+let test_error_class_classify_validation_error () =
+  match Tool_retry_policy.classify Tool_retry_policy.Validation_error with
+  | Tool_retry_policy.Deterministic -> ()
+  | _ -> Alcotest.fail "expected Validation_error -> Deterministic"
+
+let test_error_class_classify_recoverable () =
+  match Tool_retry_policy.classify Tool_retry_policy.Recoverable_tool_error with
+  | Tool_retry_policy.Transient -> ()
+  | _ -> Alcotest.fail "expected Recoverable_tool_error -> Transient"
+
+let test_error_class_to_string_stable () =
+  Alcotest.(check string) "transient"
+    "transient"
+    (Tool_retry_policy.error_class_to_string Tool_retry_policy.Transient);
+  Alcotest.(check string) "deterministic"
+    "deterministic"
+    (Tool_retry_policy.error_class_to_string Tool_retry_policy.Deterministic);
+  Alcotest.(check string) "unknown"
+    "unknown"
+    (Tool_retry_policy.error_class_to_string Tool_retry_policy.Unknown)
+
 let () =
   run "Agent SDK" [
     "types", [
@@ -219,5 +242,11 @@ let () =
         test_tool_retry_policy_feedback_uses_retry_counts;
       test_case "feedback preserves positive limit" `Quick
         test_tool_retry_policy_feedback_preserves_positive_limit;
+      test_case "classify Validation_error -> Deterministic" `Quick
+        test_error_class_classify_validation_error;
+      test_case "classify Recoverable_tool_error -> Transient" `Quick
+        test_error_class_classify_recoverable;
+      test_case "error_class_to_string stable" `Quick
+        test_error_class_to_string_stable;
     ];
   ]


### PR DESCRIPTION
## Summary
OAS#898 — tool error retry가 blind: `path_not_found` (deterministic)와 network flake (transient)가 같은 retry budget에 들어감. 다운스트림(masc-mcp keeper_failure_circuit_breaker.ml)이 category classifier를 로컬에서 키움.

**Contract-first** 단계로 `error_class = Transient | Deterministic | Unknown` variant + `classify : failure_kind -> error_class` export. 기존 `failure_kind`, `retry_on_*` toggle, `decide`는 **변경 없음** — consumer가 opt-in.

## Changes
- `lib/tool_retry_policy.mli` + `lib/tool_retry_policy.ml`
  - `type error_class = Transient | Deterministic | Unknown` 추가
  - `val classify : failure_kind -> error_class`
    - `Validation_error -> Deterministic` (스키마 위반은 시간 의존 아님)
    - `Recoverable_tool_error -> Transient` (legacy `recoverable: bool` semantics)
  - `val error_class_to_string : error_class -> string` (로그/metric label 용 stable lowercase)
- `test/test_agent_sdk.ml`에 3 cases 추가 (양방향 classify, stable label string)

## Non-goals
- `failure_kind` variants 확장 없음 (기존 consumer 깨지지 않음)
- `t.max_retries`를 `error_class`별로 parameterise하는 policy 변경은 후속 leaf
- Tool 자체가 직접 error class를 태그하는 structured error surface는 별도 design

## Test plan
- [x] `dune build --root .` green
- [x] `dune runtest --root .` green (Agent SDK 20 -> 23 cases, 신규 3 포함)
- [ ] CI 4/4 green 후 사용자 Ready 전환

## Plan mapping
effervescent-mapping-grove Tick 15 / Axis D (Silent Failure) — 분류 없는 일률 retry가 deterministic 실패에 무한 재시도 유도하는 silent futility 패턴을 variant로 고정. masc-mcp#7078 row 5의 category circuit breaker workaround를 OAS 상류 계약으로 대체할 토대.