### PR TITLE
feat(event_forward): surface envelope.caused_by on delivery payload (#877)

### DIFF
--- a/lib/event_forward.ml
+++ b/lib/event_forward.ml
@@ -17,6 +17,7 @@ type event_payload = {
   agent_name: string option;
   correlation_id: string;
   run_id: string;
+  caused_by: string option;
   data: Yojson.Safe.t;
 }
 
@@ -32,7 +33,11 @@ let payload_to_json p =
     | Some n -> [("agent_name", `String n)]
     | None -> []
   in
-  `Assoc (base @ agent)
+  let caused_by = match p.caused_by with
+    | Some id -> [("caused_by", `String id)]
+    | None -> []
+  in
+  `Assoc (base @ agent @ caused_by)
 
 (* ── Event to payload ─────────────────────────────────────────── *)
 
@@ -182,6 +187,7 @@ let event_to_payload (event : Event_bus.event) : event_payload =
     agent_name;
     correlation_id = event.meta.correlation_id;
     run_id = event.meta.run_id;
+    caused_by = event.meta.caused_by;
     data }
 
 (* ── Targets ──────────────────────────────────────────────────── *)

--- a/lib/event_forward.mli
+++ b/lib/event_forward.mli
@@ -18,6 +18,11 @@ type event_payload = {
   agent_name: string option;
   correlation_id: string;
   run_id: string;
+  caused_by: string option;
+    (** Causation link copied from [Event_bus.envelope.caused_by].
+        Serialised as a [caused_by: <run_id>] JSON field only when
+        [Some] — [None] omits the field, preserving the legacy JSON
+        shape for subscribers that never opt in. @since 0.161.0 (#877) *)
   data: Yojson.Safe.t;
 }
 

--- a/test/test_deep_coverage.ml
+++ b/test/test_deep_coverage.ml
@@ -745,7 +745,8 @@ let test_event_forward_agent_name_some_cases () =
 let test_event_forward_payload_no_agent () =
   let p : Event_forward.event_payload = {
     event_type = "test"; timestamp = 0.0;
-    agent_name = None; correlation_id = "c1"; run_id = "r1"; data = `Null;
+    agent_name = None; correlation_id = "c1"; run_id = "r1";
+    caused_by = None; data = `Null;
   } in
   let json = Event_forward.payload_to_json p in
   let keys = match json with
@@ -757,7 +758,8 @@ let test_event_forward_payload_no_agent () =
 let test_event_forward_payload_with_agent () =
   let p : Event_forward.event_payload = {
     event_type = "test"; timestamp = 0.0;
-    agent_name = Some "alice"; correlation_id = "c1"; run_id = "r1"; data = `Null;
+    agent_name = Some "alice"; correlation_id = "c1"; run_id = "r1";
+    caused_by = None; data = `Null;
   } in
   let json = Event_forward.payload_to_json p in
   let keys = match json with

--- a/test/test_event_forward.ml
+++ b/test/test_event_forward.ml
@@ -63,6 +63,7 @@ let test_payload_to_json () =
     agent_name = Some "alice";
     correlation_id = "c1";
     run_id = "r1";
+    caused_by = None;
     data = `Assoc [("key", `String "val")];
   } in
   let json = Event_forward.payload_to_json p in
@@ -294,7 +295,7 @@ let test_tool_completed_error_payload () =
 let test_payload_to_json_no_agent () =
   let p : Event_forward.event_payload = {
     event_type = "test"; timestamp = 1.0; agent_name = None;
-    correlation_id = "c1"; run_id = "r1";
+    correlation_id = "c1"; run_id = "r1"; caused_by = None;
     data = `Assoc [("x", `Int 1)]; } in
   let json = Event_forward.payload_to_json p in
   let open Yojson.Safe.Util in
@@ -305,12 +306,50 @@ let test_payload_to_json_no_agent () =
 let test_payload_to_json_with_agent () =
   let p : Event_forward.event_payload = {
     event_type = "test"; timestamp = 1.0; agent_name = Some "bot";
-    correlation_id = "c1"; run_id = "r1";
+    correlation_id = "c1"; run_id = "r1"; caused_by = None;
     data = `Null; } in
   let json = Event_forward.payload_to_json p in
   let open Yojson.Safe.Util in
   Alcotest.(check string) "agent" "bot"
     (json |> member "agent_name" |> to_string)
+
+(* ── caused_by roundtrip (#877) ─────────────────────────── *)
+
+let test_payload_caused_by_none_omitted () =
+  let p : Event_forward.event_payload = {
+    event_type = "test"; timestamp = 1.0; agent_name = None;
+    correlation_id = "c1"; run_id = "r1"; caused_by = None;
+    data = `Null; } in
+  let json = Event_forward.payload_to_json p in
+  let open Yojson.Safe.Util in
+  let keys = json |> to_assoc |> List.map fst in
+  Alcotest.(check bool) "caused_by omitted when None"
+    false (List.mem "caused_by" keys)
+
+let test_payload_caused_by_some_present () =
+  let p : Event_forward.event_payload = {
+    event_type = "test"; timestamp = 1.0; agent_name = None;
+    correlation_id = "c1"; run_id = "r1";
+    caused_by = Some "parent-42";
+    data = `Null; } in
+  let json = Event_forward.payload_to_json p in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "caused_by serialised"
+    "parent-42" (json |> member "caused_by" |> to_string)
+
+let test_event_to_payload_copies_caused_by () =
+  (* Construct an event whose envelope has caused_by = Some "p" and
+     verify the forwarding payload preserves it. *)
+  let ev =
+    Event_bus.mk_event
+      ~correlation_id:"sess-1" ~run_id:"run-child"
+      ~caused_by:"run-parent"
+      (Event_bus.TurnStarted { agent_name = "a"; turn = 1 })
+  in
+  let p = Event_forward.event_to_payload ev in
+  Alcotest.(check (option string))
+    "payload.caused_by mirrors envelope"
+    (Some "run-parent") p.caused_by
 
 (* ── Runner ───────────────────────────────────────────────────── *)
 
@@ -332,6 +371,12 @@ let () =
       Alcotest.test_case "tool_completed error" `Quick test_tool_completed_error_payload;
       Alcotest.test_case "payload no agent" `Quick test_payload_to_json_no_agent;
       Alcotest.test_case "payload with agent" `Quick test_payload_to_json_with_agent;
+      Alcotest.test_case "caused_by=None omitted from JSON"
+        `Quick test_payload_caused_by_none_omitted;
+      Alcotest.test_case "caused_by=Some serialised"
+        `Quick test_payload_caused_by_some_present;
+      Alcotest.test_case "event_to_payload copies caused_by"
+        `Quick test_event_to_payload_copies_caused_by;
     ];
     "file_target", [
       Alcotest.test_case "append" `Quick test_file_append_target;


### PR DESCRIPTION
## Summary
`#1017`에서 `envelope.caused_by`를 추가하고 `#1019/#1020/#1021`가 producer를 채웠지만, **외부 delivery 경로(file append, Custom_target, SSE/OTel bridges)가 이를 drop**. `event_forward.event_payload`에 `caused_by : string option` 필드를 추가해 envelope이 외부까지 mirror되도록.

## Changes
- `lib/event_forward.mli` + `lib/event_forward.ml`
  - `event_payload` record에 `caused_by : string option` 필드 추가
  - `event_to_payload`: `event.meta.caused_by` 그대로 복사
  - `payload_to_json`: `Some id`일 때만 `"caused_by": id` 직렬화 — `None`은 **필드 자체 생략**. 기존 JSON shape 깨지지 않음 (legacy subscriber 영향 0)
- `test/test_event_forward.ml`: 3 신규 + 3 기존 record literal에 `caused_by = None` 추가
  - `caused_by=None omitted from JSON`
  - `caused_by=Some serialised`
  - `event_to_payload copies caused_by` (end-to-end 포함)
- `test/test_deep_coverage.ml`: 2 기존 record literal 업데이트

## Why field-omit instead of `"caused_by": null`?
기존 `agent_name : string option` 패턴과 동일 — None이면 key 생략. JSON shape 일관성 + wire 공간 절약 + legacy consumer 영향 0.

## Test plan
- [x] `dune build --root .` green
- [x] `dune runtest --root .` green (Event_forward 20→23 cases)
- [ ] CI 4/4 green 후 사용자 Ready 전환

## Plan mapping
effervescent-mapping-grove Tick 16 / Axis B — causation chain 시리즈. 
#877 (envelope 계약) → #1019/#1020/#1021 (producer fill-in) → #1027 (본 PR — delivery surface mirror).
OTel GenAI / span 기반 trace 툴이 이제 caused_by를 직접 관찰 가능.