### PR TITLE
chore(test): register orphan test_agent_config (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -31,6 +31,10 @@
  (libraries agent_sdk alcotest yojson))
 
 (test
+ (name test_agent_config)
+ (libraries agent_sdk alcotest yojson))
+
+(test
  (name test_approval)
  (libraries agent_sdk alcotest yojson eio eio_main))
 


### PR DESCRIPTION
## Summary
Incremental orphan test registration per #1025. `test/test_agent_config.ml` is one of 76+ `.ml` files that existed in tree but were never added to `test/dune` — CI silently skipped all 16 of its cases.

## Changes
- `test/dune`: add `(test (name test_agent_config) (libraries agent_sdk alcotest yojson))` next to `test_hooks`.
- No source changes. All 16 existing cases pass against the current API.

## Related
- #1024 registered `test_agent_turn`
- #1026 registered `test_agent_turn_budget_unit`
- This PR registers `test_agent_config`
- Remaining orphans catalogued on #1025; each will land as a separate leaf after a build-compat check.

## Why one file per leaf?
Bulk register + prune would risk mixing live-against-current-API orphans with stale ones that no longer compile. Per-file leaves keep the signal clean and each PR atomic. Script-assisted bulk sweep is tracked separately on #1025.

## Test plan
- [x] `dune build --root .` green
- [x] `dune exec test_agent_config` → 16/16 green
- [x] `dune runtest --root .` green
- [ ] CI 4/4 green 후 사용자 Ready 전환

## Plan mapping
effervescent-mapping-grove Tick 17 — housekeeping leaf. Branch name (`fix/oas-error-class-surface`)은 원래 의도와 다름: `error_class`를 event_forward에 노출하려던 leaf는 `#1027`(tool_retry_policy) 머지 후로 연기. 대신 orphan sweep 후속.

## Note: dead hook `OnToolError`
Tick 17 탐색 중 `Hooks.OnToolError`가 **어디에서도 emit되지 않는다**는 사실 발견. 별도 이슈 #1029로 기록 (본 PR scope 밖).