### PR TITLE
fix(hooks): emit OnToolError on tool execution failure (#1029)

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -231,6 +231,15 @@ let find_and_execute_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tra
                    error = message;
                    schedule;
                  })
+            : Hooks.hook_decision);
+         (* OnToolError: minimal tool-name/error event for consumers that
+            don't need the PostToolUseFailure context (tool_use_id,
+            schedule). Previously the hook type existed but had no emit
+            site — registering [on_tool_error] was a silent no-op (#1029). *)
+         ignore
+           (invoke_hook ?on_hook_invoked ~tracer ~agent_name ~turn_count
+              ~hook_name:"on_tool_error" hooks.on_tool_error
+              (Hooks.OnToolError { tool_name = name; error = message })
             : Hooks.hook_decision)
      | Ok _ -> ());
     let content, is_error, failure_kind = match result with

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -276,6 +276,67 @@ let test_tool_completed_preserves_non_retryable_flag () =
         completed_meta.run_id
   | _ -> fail "expected tool called/completed events"
 
+(* ── Hooks.OnToolError emit on tool failure (#1029) ─────── *)
+
+let test_on_tool_error_hook_fires_on_tool_failure () =
+  Eio_main.run @@ fun _env ->
+  let context = Context.create () in
+  let bus = Event_bus.create () in
+  let tool =
+    Tool.create ~name:"fail" ~description:"Always fails" ~parameters:[]
+      (fun _ -> Error { Types.message = "boom"; recoverable = false })
+  in
+  let schedule : Hooks.tool_schedule =
+    { planned_index = 0; batch_index = 0; batch_size = 1;
+      concurrency_class = "sequential_workspace";
+      batch_kind = "sequential"; }
+  in
+  let fired = ref [] in
+  let on_tool_error = Some (fun event ->
+    (match event with
+     | Hooks.OnToolError { tool_name; error } ->
+       fired := (tool_name, error) :: !fired
+     | _ -> ());
+    Hooks.Continue)
+  in
+  let hooks = { Hooks.empty with on_tool_error } in
+  let _result =
+    Agent_tools.find_and_execute_tool ~context ~tools:[tool] ~hooks
+      ~event_bus:(Some bus) ~tracer:Tracing.null ~agent_name:"agent"
+      ~turn_count:0 ~correlation_id:"c" ~run_id:"r"
+      ~schedule "fail" (`Assoc []) "tool-1"
+  in
+  match List.rev !fired with
+  | [(tool_name, error)] ->
+    check string "hook fired for failing tool" "fail" tool_name;
+    check string "hook error carries tool message" "boom" error
+  | [] -> fail "on_tool_error hook not fired"
+  | _ -> fail "on_tool_error fired more than once"
+
+let test_on_tool_error_hook_silent_on_success () =
+  Eio_main.run @@ fun _env ->
+  let context = Context.create () in
+  let bus = Event_bus.create () in
+  let tool =
+    Tool.create ~name:"ok" ~description:"" ~parameters:[]
+      (fun _ -> Ok { Types.content = "done" })
+  in
+  let schedule : Hooks.tool_schedule =
+    { planned_index = 0; batch_index = 0; batch_size = 1;
+      concurrency_class = "sequential_workspace";
+      batch_kind = "sequential"; }
+  in
+  let fired = ref 0 in
+  let on_tool_error = Some (fun _event -> incr fired; Hooks.Continue) in
+  let hooks = { Hooks.empty with on_tool_error } in
+  let _ =
+    Agent_tools.find_and_execute_tool ~context ~tools:[tool] ~hooks
+      ~event_bus:(Some bus) ~tracer:Tracing.null ~agent_name:"agent"
+      ~turn_count:0 ~correlation_id:"c" ~run_id:"r"
+      ~schedule "ok" (`Assoc []) "tool-2"
+  in
+  check int "hook not fired on Ok result" 0 !fired
+
 let test_correlation_fields_roundtrip () =
   Eio_main.run @@ fun _env ->
   let bus = Event_bus.create () in
@@ -513,6 +574,10 @@ let () =
         test_tool_completed_preserves_non_retryable_flag;
       test_case "correlation fields roundtrip" `Quick
         test_correlation_fields_roundtrip;
+      test_case "on_tool_error fires on tool failure" `Quick
+        test_on_tool_error_hook_fires_on_tool_failure;
+      test_case "on_tool_error silent on success" `Quick
+        test_on_tool_error_hook_silent_on_success;
     ];
     "envelope", [
       test_case "filter_correlation" `Quick test_filter_correlation;


### PR DESCRIPTION
## Summary
`Hooks.OnToolError` existed as a hook-event variant and `on_tool_error` was part of the `hooks` record, yet **production code never constructed it**. Registering the hook was a silent no-op. Tick 17 탐색 중 발견 → #1029.

Emit `OnToolError` inside `Agent_tools.find_and_execute_tool` in the same Error branch that already fires `PostToolUseFailure`, with the minimal `{ tool_name; error }` shape documented in `hooks.mli`.

## Changes
- `lib/agent/agent_tools.ml`: `invoke_hook` for `Hooks.OnToolError` immediately after `PostToolUseFailure` dispatch in the `Error` branch of `Tool.execute`.
- `test/test_event_bus.ml`: 2 new cases (registered in `fields` group)
  - `on_tool_error fires on tool failure` — registers a hook that captures `(tool_name, error)`, runs a tool that returns `Error`, asserts callback fired exactly once with the right payload.
  - `on_tool_error silent on success` — registers the same hook shape, runs an `Ok` tool, asserts fire count stays at `0`.

## Scope boundaries
- `Validation_error` (pre-execute schema fail) → keep as PostToolUseFailure-only; that's input validation, not tool error.
- `Tool not found` → configuration mistake, not execution; leave for a follow-up leaf. Adding it here would conflate "tool misrouted" with "tool ran and failed".

## Test plan
- [x] `dune build --root .` green
- [x] `dune runtest --root .` green (`test_event_bus` 34→36)
- [ ] CI 4/4 green 후 사용자 Ready 전환

## Plan mapping
effervescent-mapping-grove Tick 18 / Axis D (Silent Failure) — hook contract가 있는데 emit 사이트가 없으면 가장 교묘한 silent failure. PR 본체는 기계적 fix지만, dead-hook 패턴을 **상위 axis D 계약 위반 사례로 기록**.