### PR TITLE
chore(test): register orphan test_agent_tool + audit update (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -39,6 +39,10 @@
  (libraries agent_sdk alcotest))
 
 (test
+ (name test_agent_tool)
+ (libraries agent_sdk alcotest yojson))
+
+(test
  (name test_approval)
  (libraries agent_sdk alcotest yojson eio eio_main))
 


### PR DESCRIPTION
## Summary
Incremental orphan test registration per #1025. `test/test_agent_tool.ml` is one of the unregistered files; 7 cases green on current API, no source changes.

## Changes
- `test/dune`: `(test (name test_agent_tool) (libraries agent_sdk alcotest yojson))`

## Audit finding (doc only)
`test/test_agent_card.ml` was also tried in this tick but is STALE: references `Agent_card.agent_info.cascade` which has been removed from the type. Registering as-is would break CI, so it stays orphan until a separate leaf updates the test to the current API.

This confirms the #1025 body's risk note — not all 76+ orphans are registration-only fixes. Some need source updates. Per-file leaves with build-compat check avoid churning CI with bulk failures.

## Orphan registrations in flight
- #1024 test_agent_turn (alongside #896 idle_granularity)
- #1026 test_agent_turn_budget_unit
- #1030 test_agent_config
- this  test_agent_tool

## Note on branch name
Branch created as `fix/oas-1025-test-agent-card` before the card-file turned out stale. Content changed to test_agent_tool; branch name left as-is to avoid push churn.

## Test plan
- [x] `dune build --root .` green
- [x] `dune exec test_agent_tool` → 7/7 green
- [x] `dune runtest --root .` green
- [ ] CI 4/4 green 후 사용자 Ready 전환

## Also filed
#1032 — `Hooks.OnError` is a second dead hook (companion to #1029). Audit of emit sites (OnStop/OnIdle: 1, OnError: 0, OnToolError: 1-after-#1031, PreCompact/PostCompact: 2/2) shows OnError as the only remaining zero-emit production hook. Fix requires design (fire once per run, stage, or Error propagation?); deferred until that's recorded.