### PR TITLE
chore(test): register orphan test_agent_typed (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -43,6 +43,10 @@
  (libraries agent_sdk alcotest yojson))
 
 (test
+ (name test_agent_typed)
+ (libraries agent_sdk alcotest))
+
+(test
  (name test_approval)
  (libraries agent_sdk alcotest yojson eio eio_main))
 


### PR DESCRIPTION
## Summary
5th incremental orphan-test registration per #1025. `test/test_agent_typed.ml` exercises `Agent_typed` (phantom-type lifecycle state machine). Builds clean, 4 cases green, no source changes.

## Changes
- `test/dune`: `(test (name test_agent_typed) (libraries agent_sdk alcotest))`
  - Drops `yojson` from the libraries stanza — the test doesn't parse/produce JSON, only exercises the phantom-type wrapper.

## Progress on #1025
| PR | File | Cases |
|----|------|-------|
| #1024 | test_agent_turn (alongside #896) | 41 |
| #1026 | test_agent_turn_budget_unit | 12 |
| #1030 | test_agent_config | 16 |
| #1033 | test_agent_tool | 7 |
| this  | test_agent_typed | 4 |

`test_agent_card` still orphan + stale (`Agent_card.agent_info.cascade` removed). Needs a separate source-update leaf.

## Test plan
- [x] `dune build --root .` green
- [x] `dune exec test_agent_typed` → 4/4 green
- [x] `dune runtest --root .` green
- [ ] CI 4/4 green 후 사용자 Ready 전환

## Plan mapping
effervescent-mapping-grove Tick 20 — orphan sweep 꾸준한 per-leaf 진행. 각 파일의 build-compat를 등록 전에 확인하는 원칙 유지 (`test_agent_card` 실패 사례에서 학습).