### PR TITLE
fix(hooks): emit OnError on tool-not-found dispatch failure (#1032)

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -272,6 +272,19 @@ let find_and_execute_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tra
     }
     end (* Tool_middleware validation match *)
   | None ->
+      (* Tool dispatch failure (the LLM asked for a tool that isn't
+         registered). Distinct from OnToolError — that fires when a
+         tool actually ran and returned Error. This is a configuration
+         / routing mistake, so it belongs on the general OnError
+         channel. First production emit site for Hooks.OnError (#1032). *)
+      ignore
+        (invoke_hook ?on_hook_invoked ~tracer ~agent_name ~turn_count
+           ~hook_name:"on_error" hooks.on_error
+           (Hooks.OnError {
+              detail = Printf.sprintf "Tool not found: %s" name;
+              context = "agent_tools.find_and_execute_tool";
+            })
+         : Hooks.hook_decision);
       {
         tool_use_id = id;
         tool_name = name;

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -345,6 +345,71 @@ let test_on_tool_error_hook_silent_on_success () =
   in
   check int "hook not fired on Ok result" 0 !fired
 
+(* ── Hooks.OnError emit on tool-not-found (#1032) ──────── *)
+
+let test_on_error_fires_on_tool_not_found () =
+  Eio_main.run @@ fun _env ->
+  let context = Context.create () in
+  let bus = Event_bus.create () in
+  let schedule : Hooks.tool_schedule =
+    { planned_index = 0; batch_index = 0; batch_size = 1;
+      concurrency_class = "sequential_workspace";
+      batch_kind = "sequential"; }
+  in
+  let fired = ref [] in
+  let on_error = Some (fun event ->
+    (match event with
+     | Hooks.OnError { detail; context } ->
+       fired := (detail, context) :: !fired
+     | _ -> ());
+    Hooks.Continue)
+  in
+  let hooks = { Hooks.empty with on_error } in
+  (* No tools registered -> dispatch falls to the None branch. *)
+  let _result =
+    Agent_tools.find_and_execute_tool ~context ~tools:[] ~hooks
+      ~event_bus:(Some bus) ~tracer:Tracing.null ~agent_name:"agent"
+      ~turn_count:0 ~correlation_id:"c" ~run_id:"r"
+      ~schedule "ghost_tool" (`Assoc []) "tool-1"
+  in
+  match List.rev !fired with
+  | [(detail, ctx)] ->
+    check bool "detail mentions tool name" true
+      (String.length detail > 0
+       && String.length detail >= String.length "ghost_tool"
+       && (try
+             let _ = Str.search_forward (Str.regexp_string "ghost_tool") detail 0 in
+             true
+           with Not_found -> false));
+    check string "context labels dispatch site"
+      "agent_tools.find_and_execute_tool" ctx
+  | [] -> fail "on_error hook not fired"
+  | _ -> fail "on_error fired more than once"
+
+let test_on_error_silent_on_successful_dispatch () =
+  Eio_main.run @@ fun _env ->
+  let context = Context.create () in
+  let bus = Event_bus.create () in
+  let tool =
+    Tool.create ~name:"ok" ~description:"" ~parameters:[]
+      (fun _ -> Ok { Types.content = "done" })
+  in
+  let schedule : Hooks.tool_schedule =
+    { planned_index = 0; batch_index = 0; batch_size = 1;
+      concurrency_class = "sequential_workspace";
+      batch_kind = "sequential"; }
+  in
+  let fired = ref 0 in
+  let on_error = Some (fun _ -> incr fired; Hooks.Continue) in
+  let hooks = { Hooks.empty with on_error } in
+  let _ =
+    Agent_tools.find_and_execute_tool ~context ~tools:[tool] ~hooks
+      ~event_bus:(Some bus) ~tracer:Tracing.null ~agent_name:"agent"
+      ~turn_count:0 ~correlation_id:"c" ~run_id:"r"
+      ~schedule "ok" (`Assoc []) "tool-2"
+  in
+  check int "on_error not fired on success" 0 !fired
+
 let test_correlation_fields_roundtrip () =
   Eio_main.run @@ fun _env ->
   let bus = Event_bus.create () in
@@ -586,6 +651,10 @@ let () =
         test_on_tool_error_hook_fires_on_tool_failure;
       test_case "on_tool_error silent on success" `Quick
         test_on_tool_error_hook_silent_on_success;
+      test_case "on_error fires on tool-not-found" `Quick
+        test_on_error_fires_on_tool_not_found;
+      test_case "on_error silent on successful dispatch" `Quick
+        test_on_error_silent_on_successful_dispatch;
     ];
     "envelope", [
       test_case "filter_correlation" `Quick test_filter_correlation;


### PR DESCRIPTION
## Summary
`Hooks.OnError`가 Tick 19 audit 이후 유일한 zero-emit 상태(다른 hook event 모두 ≥ 1 emit). `#1032`의 첫 emit 사이트 — `Agent_tools.find_and_execute_tool`의 **tool-not-found** 분기.

## Why tool-not-found is the right starting emit
- `OnToolError` 영역이 아님 (Tick 18 #1031 scope boundary 준수: tool이 실제로 실행됐는데 `Error` 반환한 경우)
- 이 분기는 **dispatch / routing mistake** — LLM이 등록 안 된 tool 이름 요청
- `OnError`의 description("general error dispatch")에 맞음

```ocaml
Hooks.OnError {
  detail  = Printf.sprintf "Tool not found: %s" name;
  context = "agent_tools.find_and_execute_tool";
}
```

## Changes
- `lib/agent/agent_tools.ml`: tool-not-found `None` 분기에 `invoke_hook … Hooks.OnError …` 추가. 기존 return record는 그대로.
- `test/test_event_bus.ml`: 2 regression cases
  - `on_error fires on tool-not-found` — payload `detail` contains tool name + `context` exact match
  - `on_error silent on successful dispatch` — ensures hook doesn't fire on happy path

## Non-goals
- LLM/API errors (pipeline `stage_route` 등)에서의 `OnError` emit — emit 정책 결정 필요 (per-run/per-stage/per-propagation) — 후속 leaf
- agent lifecycle error — 같은 설계 의존

## Test plan
- [x] `dune build --root .` green
- [x] `dune runtest --root .` green (`test_event_bus` 34→36)
- [ ] CI 4/4 green 후 사용자 Ready 전환

## Plan mapping
effervescent-mapping-grove Tick 21 / Axis D (Silent Failure) — hook audit 시리즈 3번째 leaf. #1031 OnToolError, 본 PR OnError tool-not-found, 후속: OnError LLM error path. 매번 emit policy 설계 scope 고정.