### PR TITLE
chore(test): register orphan test_agent_pipeline (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -51,6 +51,10 @@
  (libraries agent_sdk alcotest yojson))
 
 (test
+ (name test_agent_pipeline)
+ (libraries agent_sdk alcotest yojson eio eio_main cohttp-eio))
+
+(test
  (name test_approval)
  (libraries agent_sdk alcotest yojson eio eio_main))
 


### PR DESCRIPTION
## Summary
6th orphan leaf. `test/test_agent_pipeline.ml` exercises `Agent.run` through the full mock-HTTP pipeline (stages, api dispatch, tool exec, streaming, hooks, context reducer, guardrails). 15 cases green on current API, no source changes.

**Biggest single orphan so far** — silently skipped integration cases across multiple subsystems. Adds `cohttp-eio` to the stanza (mock HTTP server for canned LLM responses).

## Orphan sweep tally
| PR | File | Cases | Status |
|----|------|-------|--------|
| #1024 | test_agent_turn | 41 | Draft |
| #1026 | test_agent_turn_budget_unit | 12 | **MERGED** |
| #1030 | test_agent_config | 16 | **MERGED** |
| #1033 | test_agent_tool | 7 | Draft |
| #1034 | test_agent_typed | 4 | Draft |
| this  | test_agent_pipeline | 15 | Draft |

Subtotal: **95 silent cases restored** across 6 orphan files.

## Stale orphans not covered
- `test_agent_card`: `Agent_card.agent_info.cascade` field removed — needs source-update leaf.

## Test plan
- [x] `dune build --root .` green
- [x] `dune exec test_agent_pipeline` → 15/15 green
- [x] `dune runtest --root .` green
- [ ] CI 4/4 green 후 사용자 Ready 전환

## Plan mapping
effervescent-mapping-grove Tick 22 — orphan sweep 꾸준한 진행. 최근 #1026/#1030 merge로 sweep이 실제 main에 착륙 중임 확인. per-leaf 원칙이 유효함 재검증.