### PR TITLE
chore(test): register orphan test_agent_lifecycle (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -51,6 +51,10 @@
  (libraries agent_sdk alcotest yojson))
 
 (test
+ (name test_agent_lifecycle)
+ (libraries agent_sdk alcotest))
+
+(test
  (name test_approval)
  (libraries agent_sdk alcotest yojson eio eio_main))
 


### PR DESCRIPTION
## Summary
7th orphan leaf. `test/test_agent_lifecycle.ml` covers `Agent_lifecycle` — snapshot building, runtime names, `valid_transitions` exhaustiveness, transition guard error handling. 27 cases green on current API, no source changes.

## Changes
- `test/dune`: `(test (name test_agent_lifecycle) (libraries agent_sdk alcotest))` — minimal deps (no JSON/Eio/Cohttp).

## Orphan sweep cumulative
| PR | File | Cases | Status |
|----|------|-------|--------|
| #1024 | test_agent_turn | 41 | Draft |
| #1026 | test_agent_turn_budget_unit | 12 | **MERGED** |
| #1030 | test_agent_config | 16 | **MERGED** |
| #1033 | test_agent_tool | 7 | **MERGED** |
| #1034 | test_agent_typed | 4 | Draft |
| #1036 | test_agent_pipeline | 15 | Draft |
| this  | test_agent_lifecycle | 27 | Draft |

Subtotal: **122 silent cases** across 7 orphan files.

Confirmed Tick 22's merge signal — the sweep is actively landing on main.

## Stale orphans
- `test_agent_card`: `Agent_card.agent_info.cascade` field removed — needs a source-update leaf, not just dune registration.

## Test plan
- [x] `dune build --root .` green
- [x] `dune exec test_agent_lifecycle` → 27/27 green
- [x] `dune runtest --root .` green
- [ ] CI 4/4 green 후 사용자 Ready 전환

## Plan mapping
effervescent-mapping-grove Tick 23 — orphan sweep 꾸준 진행. Axis 다양성은 Tick 15/18/21에서 D축에 대한 hook-emit 시리즈로 충족. 이번 tick은 housekeeping으로 누적 커버리지 확보.