### PR TITLE
chore(test): register orphan test_agent_registry (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -47,6 +47,10 @@
  (libraries agent_sdk alcotest))
 
 (test
+ (name test_agent_registry)
+ (libraries agent_sdk alcotest eio eio_main))
+
+(test
  (name test_approval)
  (libraries agent_sdk alcotest yojson eio eio_main))
 


### PR DESCRIPTION
## Summary
8th orphan leaf. `test/test_agent_registry.ml` covers `Agent_registry` — capability-based multi-agent discovery (HTTP discovery, card fetch, capability matching). 12 cases green on current API, no source changes.

## Changes
- `test/dune`: `(test (name test_agent_registry) (libraries agent_sdk alcotest eio eio_main))` — Eio-based mock HTTP switches, no Cohttp/Yojson.

## Orphan sweep cumulative
| PR | File | Cases | Status |
|----|------|-------|--------|
| #1024 | test_agent_turn | 41 | Draft |
| #1026 | test_agent_turn_budget_unit | 12 | **MERGED** |
| #1030 | test_agent_config | 16 | **MERGED** |
| #1033 | test_agent_tool | 7 | **MERGED** |
| #1034 | test_agent_typed | 4 | **MERGED** |
| #1036 | test_agent_pipeline | 15 | Draft |
| #1037 | test_agent_lifecycle | 27 | Draft |
| this  | test_agent_registry | 12 | Draft |

Subtotal: **134 silent cases** across 8 orphan files. `agent_*` cluster nearly exhausted — only `test_agent_card` remains, still stale on `cascade` field removal (needs source-update leaf).

## Test plan
- [x] `dune build --root .` green
- [x] `dune exec test_agent_registry` → 12/12 green
- [x] `dune runtest --root .` green
- [ ] CI 4/4 green 후 사용자 Ready 전환

## Plan mapping
effervescent-mapping-grove Tick 24 — agent_* orphan cluster 실질 종결. 다음 tick부터 non-agent orphan(test_a2a_*, test_eval_*, test_memory_*, test_harness_* 등) 탐색 예상.