### PR TITLE
chore(test): register orphan test_durable_event (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -51,6 +51,10 @@
  (libraries agent_sdk alcotest yojson))
 
 (test
+ (name test_durable_event)
+ (libraries agent_sdk alcotest))
+
+(test
  (name test_approval)
  (libraries agent_sdk alcotest yojson eio eio_main))
 


### PR DESCRIPTION
## Summary
9th orphan leaf, pivoting from the `agent_*` cluster (exhausted apart from stale `test_agent_card`) to the event-sourcing surface. `test/test_durable_event.ml` covers `Durable_event` — append, replay, malformed-file handling, and persistence semantics. 16 cases green on current API, no source changes.

## Changes
- `test/dune`: `(test (name test_durable_event) (libraries agent_sdk alcotest))` — minimal deps.

## Orphan sweep cumulative
agent_* cluster (8 leaves): **134 cases** (merged: #1024/#1026/#1030/#1033/#1034; draft: #1036/#1037/#1038)
this: `test_durable_event` — **16 cases**

Subtotal: **150 silent cases restored** across 9 orphan files.

## Next candidates
Per the #1025 audit, remaining clusters worth sweeping:
- `test_a2a*` (6 files, A2A protocol)
- `test_eval*` (5 files, eval harness)
- `test_memory_*` (7+ files, memory backends)
- `test_harness_*` (4 files, test harness infra)

Each orphan will be tried per-leaf with a build-compat check first.

## Test plan
- [x] `dune build --root .` green
- [x] `dune exec test_durable_event` → 16/16 green
- [x] `dune runtest --root .` green
- [ ] CI 4/4 green 후 사용자 Ready 전환

## Plan mapping
effervescent-mapping-grove Tick 25 — agent_* cluster 이후 non-agent orphan 진입. `Durable_event`는 세션 resume / crash recovery의 기반 모듈이라 실버 cases가 특히 유해했을 가능성(persistence 계약 drift를 CI가 못 잡음).