### PR TITLE
[codex] align CLI context windows with capabilities

### DIFF
--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -254,7 +254,13 @@ let siliconflow_defaults = {
 
 let default () =
   let t = create () in
+  let max_context_from_capabilities ~default caps =
+    match caps.Capabilities.max_context_tokens with
+    | Some ctx when ctx > default -> ctx
+    | _ -> default
+  in
   let reg name defaults ~max_context caps =
+    let max_context = max_context_from_capabilities ~default:max_context caps in
     register t { name; defaults; max_context; capabilities = caps;
                  is_available = (fun () -> has_api_key defaults.api_key_env) }
   in
@@ -316,18 +322,23 @@ let default () =
     fun () -> cached
   in
   register t { name = "claude_code"; defaults = claude_code_defaults;
-               max_context = 200_000;
+               max_context = max_context_from_capabilities ~default:200_000
+                   Capabilities.claude_code_capabilities;
                capabilities = Capabilities.claude_code_capabilities;
                is_available = claude_code_available };
-  register t { name = "cc"; defaults = claude_code_defaults; max_context = 200_000;
+  register t { name = "cc"; defaults = claude_code_defaults;
+               max_context = max_context_from_capabilities ~default:200_000
+                   Capabilities.claude_code_capabilities;
                capabilities = Capabilities.claude_code_capabilities;
                is_available = claude_code_available };
   register t { name = "gemini_cli"; defaults = gemini_cli_defaults;
-               max_context = 1_000_000;
+               max_context = max_context_from_capabilities ~default:1_000_000
+                   Capabilities.gemini_cli_capabilities;
                capabilities = Capabilities.gemini_cli_capabilities;
                is_available = gemini_cli_available };
   register t { name = "codex_cli"; defaults = codex_cli_defaults;
-               max_context = 128_000;
+               max_context = max_context_from_capabilities ~default:128_000
+                   Capabilities.codex_cli_capabilities;
                capabilities = Capabilities.codex_cli_capabilities;
                is_available = codex_cli_available };
   t

--- a/test/dune
+++ b/test/dune
@@ -23,6 +23,10 @@
  (libraries agent_sdk alcotest unix str))
 
 (test
+ (name test_provider_registry)
+ (libraries llm_provider alcotest unix))
+
+(test
  (name test_types)
  (libraries agent_sdk alcotest))
 

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -226,7 +226,7 @@ let test_default_max_context () =
    | Some e -> check int "glm 200K" 200_000 e.max_context
    | None -> fail "glm should exist");
   (match Provider_registry.find reg "cc" with
-   | Some e -> check int "cc 200K" 200_000 e.max_context
+   | Some e -> check int "cc 1M" 1_000_000 e.max_context
    | None -> fail "cc should exist");
   (match Provider_registry.find reg "groq" with
    | Some e -> check int "groq 131K" 131_072 e.max_context
@@ -239,7 +239,22 @@ let test_default_max_context () =
    | None -> fail "alibaba should exist");
   (match Provider_registry.find reg "siliconflow" with
    | Some e -> check int "siliconflow 128K" 128_000 e.max_context
-   | None -> fail "siliconflow should exist")
+   | None -> fail "siliconflow should exist");
+  (match Provider_registry.find reg "codex_cli" with
+   | Some e -> check int "codex_cli 1.05M" 1_050_000 e.max_context
+   | None -> fail "codex_cli should exist")
+
+let test_default_max_context_matches_capabilities () =
+  let reg = Provider_registry.default () in
+  Provider_registry.all reg
+  |> List.iter (fun (entry : Provider_registry.entry) ->
+    match entry.capabilities.max_context_tokens with
+    | None -> ()
+    | Some caps_ctx ->
+      check bool
+        (Printf.sprintf "%s registry max_context >= capabilities" entry.name)
+        true
+        (entry.max_context >= caps_ctx))
 
 let test_default_zai_base_urls () =
   let reg = Provider_registry.default () in
@@ -345,6 +360,8 @@ let () =
       test_case "has 15 providers" `Quick test_default_has_15;
       test_case "correct capabilities" `Quick test_default_capabilities;
       test_case "max_context values" `Quick test_default_max_context;
+      test_case "max_context matches capabilities" `Quick
+        test_default_max_context_matches_capabilities;
       test_case "zai base urls" `Quick test_default_zai_base_urls;
       test_case "blank zai base urls fall back" `Quick test_blank_zai_base_urls_fall_back;
     ];


### PR DESCRIPTION
## What changed
- derive provider registry `max_context` from capability `max_context_tokens` when capabilities are larger than the static fallback
- fix `codex_cli` registry context from the stale 128k fallback to the 1.05M capability value
- register `test_provider_registry` in dune and add a regression test that registry context windows do not drift below capabilities

## Why
`masc-mcp` consumes OAS provider registry context windows for cascade/dashboard context accounting. The `codex_cli` capabilities already advertised 1.05M tokens, but the registry entry still exposed 128k, which inflated dashboard CTX ratios by roughly 8x. The same duplicate-number pattern also underreported `claude_code`, so this makes registry construction prefer capability truth instead of keeping stale duplicated numbers.

## Validation
- `env OPAMSWITCH=5.4.1 OPAM_SWITCH_PREFIX=/Users/dancer/.opam/5.4.1 dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix/codex-cli-context-window-20260419`
- `_build/default/test/test_provider_registry.exe`
