### PR TITLE
chore(test): register orphan test_a2a_client (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -329,3 +329,7 @@
 (test
  (name test_multivendor_events)
  (libraries agent_sdk alcotest yojson eio eio_main))
+
+(test
+ (name test_a2a_client)
+ (libraries agent_sdk alcotest))


### PR DESCRIPTION
## Summary

`test/test_a2a_client.ml` (163 LOC, 6 cases) existed but was unregistered in `test/dune` — **A2A JSON-RPC protocol roundtrip coverage was silently skipped** by `make test`.

Build-compat verified against current SSOT:
- `Agent_card.agent_card` fields match
- `A2a_server.config` record literal matches
- `A2a_task.create : task_message -> task` signature stable

## Covered cases

- `text_of_task` × 2 (empty, with parts)
- `server_roundtrip` × 4 (agent_card, tasks_send, tasks_get, unknown_method)

## Verification

- `dune exec test/test_a2a_client.exe` — 6 cases green, 0.001s
- `dune runtest test/` — full suite green (12 cases final run)

## Axis

A (SSOT) — orphan test regression. Contract: every test/*.ml must have a `(test (name ...))` stanza; hidden coverage is a silent SSOT violation.

## Context

/loop tick 26, **effervescent-mapping-grove** plan. First a2a cluster entry. Prior ticks registered:
`test_agent_turn` (#1024), `test_agent_turn_budget_unit` (#1026), `test_agent_config` (#1030), `test_agent_tool` (#1033), `test_agent_typed` (#1034), `test_agent_pipeline` (#1036), `test_agent_lifecycle` (#1037), `test_agent_registry` (#1038), `test_durable_event` (#1039).

Next a2a candidates: `test_a2a_client_cov`, `test_a2a_task_store`, `test_a2a_task_unit`, `test_a2a_full`, `test_a2a` — 5 files.

## Test plan

- [x] Stanza added to `test/dune`
- [x] `dune build test/test_a2a_client.exe` clean
- [x] `dune exec test/test_a2a_client.exe` green (6 cases)
- [x] `dune runtest test/` green (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)