### PR TITLE
chore(test): register orphan test_a2a_client_cov (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -329,3 +329,7 @@
 (test
  (name test_multivendor_events)
  (libraries agent_sdk alcotest yojson eio eio_main))
+
+(test
+ (name test_a2a_client_cov)
+ (libraries agent_sdk alcotest eio eio_main cohttp cohttp-eio))


### PR DESCRIPTION
## Summary

`test/test_a2a_client_cov.ml` (337 LOC, 11 cases) was unregistered in `test/dune`. This covers **A2A client HTTP-layer paths** (error branches, JSON parsing, cancel) via cohttp-eio mock server — complements #1044 which only covered JSON-RPC protocol roundtrip.

## Covered cases

- `discover` × 3 (success, http error, bad json)
- `tasks` × 5 (send, get, cancel, rpc error, send http error)
- `text_of_task` × 3 (multi messages, file-only, data-only)

## Libraries

`agent_sdk alcotest eio eio_main cohttp cohttp-eio` (same shape as `test_event_integration`).

## Verification

- `dune exec test/test_a2a_client_cov.exe` — 11 cases green, 0.941s
- `dune runtest test/` — full suite green

## Axis

A (SSOT) — orphan test regression. /loop tick 27, **effervescent-mapping-grove** plan.

Prior orphan registrations: #1024/1026/1030/1033/1034/1036/1037/1038/1039/1044.

Remaining a2a cluster: `test_a2a_task_store`, `test_a2a_task_unit`, `test_a2a_full`, `test_a2a` — 4 files, 1,653 LOC.

## Test plan

- [x] Stanza added to `test/dune`
- [x] `dune build test/test_a2a_client_cov.exe` clean
- [x] `dune exec test/test_a2a_client_cov.exe` green (11 cases)
- [x] `dune runtest test/` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)