### PR TITLE
fix(gemini_cli): use sentinel MCP name instead of empty string (Gemini 0.38 PolicyEngine crash)

### DIFF
--- a/lib/llm_provider/transport_gemini_cli.ml
+++ b/lib/llm_provider/transport_gemini_cli.ml
@@ -42,30 +42,35 @@ let default_config = {
 
 (* ── CLI argument building ───────────────────────────── *)
 
-(* Non-interactive Gemini runs default to MCP OFF by passing an empty
-   MCP whitelist.  Explicit allow-lists can opt back in.
+(* Non-interactive Gemini runs default to MCP OFF by passing a sentinel
+   MCP whitelist that will never match a real server.  Explicit
+   allow-lists can opt back in.
 
    OAS_GEMINI_ALLOWED_MCP    "a,b" → --allowed-mcp-server-names a
                                      --allowed-mcp-server-names b
-   OAS_GEMINI_NO_MCP         1     → --allowed-mcp-server-names ""
-                                     (whitelist = empty ⇒ all MCP OFF;
+   OAS_GEMINI_NO_MCP         1     → --allowed-mcp-server-names __oas_no_mcp__
+                                     (sentinel ⇒ all MCP OFF;
                                       takes precedence over the list)
    OAS_GEMINI_APPROVAL_MODE  default|auto_edit|yolo|plan
                                    → --approval-mode <v>
                                      (when set, supersedes [config.yolo])
    OAS_GEMINI_EXTENSIONS     "a,b" → -e a -e b
 
-   Gemini CLI has no runtime flag to disable hooks — hook lifecycle is
-   controlled via the [gemini hooks] subcommand, outside transport
-   scope. *)
+   Gemini CLI 0.38+ PolicyEngine rejects empty strings in
+   [--allowed-mcp-server-names] ("mcpName is required if specified").
+   The sentinel is a non-existent server name that satisfies the
+   validator while matching nothing, giving us the same "all MCP OFF"
+   semantics without crashing the CLI. *)
+let no_mcp_sentinel = "__oas_no_mcp__"
+
 let env_extra_args () =
   let extras = ref [] in
   let add a = extras := !extras @ a in
   if Cli_common_env.bool "OAS_GEMINI_NO_MCP" then
-    add ["--allowed-mcp-server-names"; ""]
+    add ["--allowed-mcp-server-names"; no_mcp_sentinel]
   else
     (match Cli_common_env.list "OAS_GEMINI_ALLOWED_MCP" with
-     | None | Some [] -> add ["--allowed-mcp-server-names"; ""]
+     | None | Some [] -> add ["--allowed-mcp-server-names"; no_mcp_sentinel]
      | Some names ->
        List.iter (fun n -> add ["--allowed-mcp-server-names"; n]) names);
   (match Cli_common_env.list "OAS_GEMINI_EXTENSIONS" with
@@ -398,16 +403,18 @@ let%test "env: approval-mode supersedes config.yolo" =
     && List.mem "plan" args
     && not (List.mem "--yolo" args))
 
-let%test "env: OAS_GEMINI_NO_MCP disables all MCP via empty whitelist" =
+let%test "env: OAS_GEMINI_NO_MCP disables all MCP via sentinel whitelist" =
   with_env "OAS_GEMINI_NO_MCP" "1" (fun () ->
     let args = build_args ~config:default_config ~req_config:gemini_req
       ~prompt:"hi" ~system_prompt:None in
     let rec has_pair = function
-      | "--allowed-mcp-server-names" :: "" :: _ -> true
+      | "--allowed-mcp-server-names" :: name :: _
+        when name = no_mcp_sentinel -> true
       | _ :: rest -> has_pair rest
       | [] -> false
     in
-    has_pair args)
+    has_pair args
+    && not (List.mem "" args))
 
 let%test "env: OAS_GEMINI_ALLOWED_MCP whitelist" =
   with_env "OAS_GEMINI_ALLOWED_MCP" "alpha,beta" (fun () ->
@@ -421,19 +428,21 @@ let%test "env: OAS_GEMINI_EXTENSIONS splits on comma" =
       ~prompt:"hi" ~system_prompt:None in
     List.mem "-e" args && List.mem "ext-a" args && List.mem "ext-b" args)
 
-let%test "default: no vars still keeps MCP disabled" =
+let%test "default: no vars still keeps MCP disabled via sentinel" =
   with_unset "OAS_GEMINI_ALLOWED_MCP" (fun () ->
   with_unset "OAS_GEMINI_APPROVAL_MODE" (fun () ->
   with_unset "OAS_GEMINI_EXTENSIONS" (fun () ->
   with_unset "OAS_GEMINI_NO_MCP" (fun () ->
     let args = build_args ~config:default_config ~req_config:gemini_req
       ~prompt:"hi" ~system_prompt:None in
-    let rec has_empty_whitelist = function
-      | "--allowed-mcp-server-names" :: "" :: _ -> true
-      | _ :: rest -> has_empty_whitelist rest
+    let rec has_sentinel_whitelist = function
+      | "--allowed-mcp-server-names" :: name :: _
+        when name = no_mcp_sentinel -> true
+      | _ :: rest -> has_sentinel_whitelist rest
       | [] -> false
     in
     (* default_config.yolo = true, so --yolo must appear. *)
     List.mem "--yolo" args
     && not (List.mem "--approval-mode" args)
-    && has_empty_whitelist args))))
+    && has_sentinel_whitelist args
+    && not (List.mem "" args)))))


### PR DESCRIPTION
## Problem

Gemini CLI 0.38 added a PolicyEngine that validates each entry of
`--allowed-mcp-server-names` and rejects empty strings:

```
An unexpected critical error occurred:
Error: Invalid policy rule: mcpName is required if specified (cannot be empty).
Rule source: Settings (MCP Allowed)
    at new PolicyEngine (...)
    at new Config (...)
    at loadCliConfig (...)
```

OAS passes `--allowed-mcp-server-names ""` when `OAS_GEMINI_NO_MCP=1`
(or no allow-list is supplied) to get "all MCP OFF" semantics. On 0.38+
this crashes before any request is made and cascades fall through to
the next provider:

```
[Keeper] keeper <name> applied OAS env OAS_GEMINI_NO_MCP=1
+[gemini stderr] ...Invalid policy rule: mcpName is required if specified...
[Misc] [cascade-fallback] cascade vendor_mix_balanced: auto failed
```

Observed in masc-mcp keeper runtime (2026-04-19).

## Fix

Pass a non-existent sentinel server name (`__oas_no_mcp__`) instead of `""`:

- Non-empty -> passes PolicyEngine
- Guaranteed not to match any real MCP server -> preserves "MCP OFF"

Only the stringified value changes; the semantic contract (no MCP
servers reachable) is identical.

## Verification

Local reproduction with gemini 0.38.1:

| Args | Result |
|------|--------|
| --allowed-mcp-server-names "" | PolicyEngine crash |
| --allowed-mcp-server-names __oas_no_mcp__ | accepted |

Tests updated to pin the sentinel and assert the empty string never
appears in built args (regression guard).

## Scope guard

- Only lib/llm_provider/transport_gemini_cli.ml changed.
- OAS_GEMINI_ALLOWED_MCP explicit-list path unchanged (still supported).
- No behaviour change for Gemini 0.37 and earlier.