### PR TITLE
chore(test): register orphan test_eval_baseline (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -329,3 +329,7 @@
 (test
  (name test_multivendor_events)
  (libraries agent_sdk alcotest yojson eio eio_main))
+
+(test
+ (name test_eval_baseline)
+ (libraries agent_sdk alcotest yojson))


### PR DESCRIPTION
## Summary

`test/test_eval_baseline.ml` (196 LOC, 15 cases) was unregistered — **regression detection** + **pass@k** + **baseline roundtrip** all zero-gated in CI.

First eval cluster entry. **a2a cluster (6 files, 116 cases) now fully registered** via #1044/#1046/#1049/#1050/#1051/#1052.

## Covered cases

- `baseline` × 2 (save/load roundtrip, load missing file)
- `compare` × 4 (no regression, with regression, added metric, removed metric)
- `pass_at_k` × 4 (all pass, some fail, empty, skips unscored runs)
- `report` × 4 (with baseline, no baseline, to_json, to_string)
- `display` × 1 (show_diff)

## Context (contract issue discovered)

Attempted `test_eval_otel_bridge.ml` (62 LOC) first — failed build. **`Eval_otel_bridge` is NOT re-exported from `lib/agent_sdk.ml`** (while sibling `Otel_tracer` is, line 96). Decision needed in a separate tick:

- **Option A**: add `module Eval_otel_bridge = Eval_otel_bridge` to `lib/agent_sdk.ml` + `.mli` (public API extension)
- **Option B**: delete the stale orphan file (module is lib-internal only)

Not bundled here — pure registration tick, contract decision belongs to its own leaf.

## Verification

- `dune exec test/test_eval_baseline.exe` — 15 cases green, 0.161s
- `dune runtest test/` — full suite green

## Axes

- A (SSOT) — orphan test regression
- D (Silent Failure) — regression detection path re-gated

/loop tick 32, **effervescent-mapping-grove** plan.

Remaining eval cluster: `test_eval` (225), `test_eval_coverage` (553), `test_eval_report_full` (219) — 3 files. Plus pending contract decision for `test_eval_otel_bridge`.

## Test plan

- [x] Stanza added to `test/dune`
- [x] `dune build test/test_eval_baseline.exe` clean
- [x] `dune exec test/test_eval_baseline.exe` green (15 cases)
- [x] `dune runtest test/` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)