### PR TITLE
chore(test): register orphan test_eval (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -329,3 +329,7 @@
 (test
  (name test_multivendor_events)
  (libraries agent_sdk alcotest yojson eio eio_main))
+
+(test
+ (name test_eval)
+ (libraries agent_sdk alcotest yojson eio eio_main))


### PR DESCRIPTION
## Summary

`test/test_eval.ml` (225 LOC, 15 cases) was unregistered — **core Eval framework coverage** silently skipped. Covers metric variants (Int/Float/Bool/Str), comparison (regression/improvement), threshold fail-closed semantics.

Second eval cluster entry after #1053 (baseline). Same tick style: pure registration, no source changes.

## Covered cases

- `metric_value` × 2 (yojson roundtrip [Int_val/Float_val/Bool_val/Str_val], to_float)
- `metric` × 1 (yojson roundtrip)
- `collector` × 2 (basic, verdict)
- `comparison` × 4 (regression, improvement, unchanged, spec higher better)
- `threshold` × 3 (pass, **fail max**, **fail min**)
- `lookup` × 1 (find_metric)
- `serialization` × 1 (run_metrics yojson)
- `eval_collector` × 1 (basic auto-collect)

## Axes

- A (SSOT) — orphan test regression
- D (Silent Failure) — threshold fail_max/fail_min paths re-gated
- E (Variant) — `metric_value` Int/Float/Bool/Str arm coverage

## Libraries

`agent_sdk alcotest yojson eio eio_main` (collector test uses `Eio_main.run`).

## Verification

- `dune exec test/test_eval.exe` — 15 cases green, 0.003s
- `dune runtest test/` — full suite green

/loop tick 33, **effervescent-mapping-grove** plan.

Remaining eval cluster: `test_eval_coverage` (553), `test_eval_report_full` (219), `test_eval_otel_bridge` (62, pending contract decision — module not re-exported).

## Test plan

- [x] Stanza added to `test/dune`
- [x] `dune build test/test_eval.exe` clean
- [x] `dune exec test/test_eval.exe` green (15 cases)
- [x] `dune runtest test/` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)