### PR TITLE
chore(test): register orphan test_eval_report_full (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -329,3 +329,7 @@
 (test
  (name test_multivendor_events)
  (libraries agent_sdk alcotest yojson eio eio_main))
+
+(test
+ (name test_eval_report_full)
+ (libraries agent_sdk alcotest yojson))


### PR DESCRIPTION
## Summary
test/test_eval_report_full.ml (219 LOC) was absent from test/dune — Eval_report verdict & serialization coverage was silently excluded from CI despite living under the test tree.

## Axes
- **A (SSOT)**: orphan → registered.
- **D (Silent Failure)**: verdict arm coverage.
- **E (Variant completeness)**: Pass / Fail / NoBaseline — all 3 verdict variants exercised.

## Coverage (15 cases)
- `generate` × 4 paths — empty runs → Fail; no baseline → NoBaseline; baseline + high pass_at_k → Pass + comparison; baseline + low score → Fail.
- `to_json` × 5 — 3 verdict variants + full-key completeness + regressions/improvements array shape.
- `to_string` × 3 — contains agent name, with/without comparison sections.

## Why this matters
Eval_report is the top-level CI reporting surface (verdict + JSON for dashboards + human-readable summary). Zero CI coverage meant a verdict-variant regression would slip through — this follows the same pattern as the earlier a2a/eval_baseline/eval ticks where silently-excluded cases hid real serialization arms.

## No library changes
`Eval_report` + `Harness` already re-exported from `agent_sdk` (unlike `Eval_otel_bridge` deferred in Tick 32). Stanza-only diff.

## Test plan
- [x] `dune build test/test_eval_report_full.exe` green.
- [x] `dune exec test/test_eval_report_full.exe` → 15/15 in 0.005s.
- [x] `dune runtest test/` → 15/15 included in aggregate.
- [ ] CI green on PR.

## Do NOT merge
Draft only. User handles Ready/merge manually (per effervescent-mapping-grove plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)