### PR TITLE
chore(test): register orphan test_eval_coverage (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -329,3 +329,7 @@
 (test
  (name test_multivendor_events)
  (libraries agent_sdk alcotest yojson eio eio_main))
+
+(test
+ (name test_eval_coverage)
+ (libraries agent_sdk alcotest yojson))


### PR DESCRIPTION
## Summary
test/test_eval_coverage.ml (553 LOC) was absent from test/dune — Eval + Eval_report + Eval_baseline **extended-coverage** tests (error paths, formatters, numeric edge cases) were silently excluded from CI. Largest orphan in the eval cluster; closes the eval sweep.

## Axes
- **A (SSOT)**: orphan → registered.
- **D (Silent Failure)**: 8+ explicit error/edge arms verified (Yojson type mismatches, zero baseline, non-numeric values, missing metrics).
- **E (Variant completeness)**: `Eval_baseline.show_diff` all 4 variants — Unchanged / Improved / Added / Removed — now exercised.

## Coverage (48 cases)
| Group | Count | Notes |
|-------|------:|-------|
| metric_value_of_yojson error paths | 2 | list, null |
| show_metric_value arms | 3 | int, bool false, string |
| formatters (pp_*, show_*) | 5 | metric_value / metric / run_metrics |
| metric_of_yojson | 3 | type error, bad value, minimal |
| metric_to_yojson | 2 | full, minimal |
| run_metrics_of_yojson | 2 | type error, bad metric |
| run_metrics_to_yojson | 3 | verdicts, score None, trace summary |
| trace_summary | 1 | set_trace_summary |
| find_metric_value | 2 | found, missing |
| compute_delta edge cases | 6 | baseline zero / both zero / zero→neg / non-numeric / custom threshold / bool |
| compare_extra | 2 | missing candidate, string metric |
| threshold_extra | 4 | no match / non-numeric / both pass / both fail min |
| baseline show_diff | 4 | unchanged / improved / added / removed |
| baseline compare_extra | 5 | near zero / near zero both / non-numeric equal / non-numeric changed / custom tolerance |
| eval_report_extra | 2 | pass_at_k boundary, unchanged-filter to_string |
| eval_collector_extra | 2 | agent completed / error |

## Why this matters
These are exactly the **"unhappy path" arms** a silent-failure axis demands coverage for: Yojson type-error branches, zero-division in compute_delta, show_diff variant drops. Without registration each new Eval variant could silently skip this file's protection.

## No library changes
All 4 modules (Eval, Eval_report, Eval_baseline, Harness) already re-exported from agent_sdk. Stanza-only diff.

## Test plan
- [x] `dune build test/test_eval_coverage.exe` green.
- [x] `dune exec test/test_eval_coverage.exe` → 48/48 in 0.009s.
- [x] `dune runtest test/` → aggregate green.
- [ ] CI green on PR.

## Do NOT merge
Draft only. User handles Ready/merge manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)