### PR TITLE
chore(test): register orphan test_memory_episodic (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -329,3 +329,7 @@
 (test
  (name test_multivendor_events)
  (libraries agent_sdk alcotest yojson eio eio_main))
+
+(test
+ (name test_memory_episodic)
+ (libraries agent_sdk alcotest))


### PR DESCRIPTION
## Summary
test/test_memory_episodic.ml (176 LOC) was absent from test/dune — Memory episodic-layer behaviour silently excluded from CI. **First of 9 memory orphans** identified (sweep proceeds smallest → largest per eval-cluster pattern).

## Axes
- **A (SSOT)**: orphan → registered.
- **D (Silent Failure)**: `recall_episode nonexistent → None` arm explicit.
- **E (Variant)**: `outcome` — `Success "..."` variant exercised.

## Coverage (11 cases)
- `store_recall` × 2 — store & recall, nonexistent → None
- `salience_decay` × 3 — recent boost, min_salience filter, limit cap
- `filter` × 2 — participant match, outcome filter sees decayed salience
- `boost` × 2 — raises salience, caps at 1.0
- `forget_count` × 1 — forget removes episode
- `stats` × 1 — episodic count in stats

## Memory cluster map (this PR = 1/9)
| file | LOC | status |
|------|----:|--------|
| test_memory_episodic.ml | 176 | **this PR** |
| test_memory_procedural.ml | 182 | pending |
| test_memory_advanced.ml | 200 | pending |
| test_memory.ml | 212 | pending |
| test_memory_lt_backend.ml | 213 | pending |
| test_memory_tools.ml | 227 | pending |
| test_memory_file_backend.ml | 264 | pending |
| test_memory_access.ml | 269 | pending |
| test_memory_coverage.ml | 740 | pending |

## Why this matters
Salience decay + `Success`/`Failure` outcome variants are exactly the kinds of silent-drift surfaces where a new variant could bypass filter logic without CI noticing — registering this file is the minimum viable fail-closed.

## No library changes
`Memory` already re-exported from agent_sdk. Stanza-only diff.

## Test plan
- [x] `dune build test/test_memory_episodic.exe` green.
- [x] `dune exec test/test_memory_episodic.exe` → 11/11 in 0.001s.
- [x] `dune runtest test/` → aggregate green.
- [ ] CI green on PR.

## Do NOT merge
Draft only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)