### PR TITLE
chore(test): register orphan test_memory_procedural (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -329,3 +329,7 @@
 (test
  (name test_multivendor_events)
  (libraries agent_sdk alcotest yojson eio eio_main))
+
+(test
+ (name test_memory_procedural)
+ (libraries agent_sdk alcotest))


### PR DESCRIPTION
## Summary
test/test_memory_procedural.ml (182 LOC) was absent from test/dune — Memory procedural-layer behaviour (pattern match, confidence-based selection, success/failure outcome updates) silently excluded from CI.

## Axes
- **A (SSOT)**: orphan → registered.
- **D (Silent Failure)**: `best_procedure no match → None` arm explicit.
- **E (Variant)**: record_outcome Success / Failure paths both exercised.

## Coverage (11 cases)
- `store_recall` × 1 — store & recall with confidence
- `matching` × 5 — substring match / min_confidence filter / no-match None / filter narrows / find_procedure applies filter+sort
- `record_outcome` × 3 — record_success, record_failure, best_procedure touch updates last_used
- `forget_count` × 1, `stats` × 1

## Memory cluster map (this PR = 2/9)
| file | LOC | status |
|------|----:|--------|
| test_memory_episodic.ml | 176 | #1057 |
| **test_memory_procedural.ml** | **182** | **this PR** |
| test_memory_advanced.ml | 200 | pending |
| test_memory.ml | 212 | pending |
| test_memory_lt_backend.ml | 213 | pending |
| test_memory_tools.ml | 227 | pending |
| test_memory_file_backend.ml | 264 | pending |
| test_memory_access.ml | 269 | pending |
| test_memory_coverage.ml | 740 | pending |

## Why this matters
`confidence = success_count / (success + failure)` + `last_used` touch-on-recall — these are the same "learned behavior" selection heuristics a silent regression could quietly flip (e.g. confidence threshold off-by-one). Registration fixes the surface.

## No library changes
`Memory` already re-exported from agent_sdk.

## Test plan
- [x] `dune build test/test_memory_procedural.exe` green.
- [x] `dune exec` → 11/11 in 0.002s.
- [x] `dune runtest test/` → aggregate green.
- [ ] CI green on PR.

## Do NOT merge
Draft only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)