### PR TITLE
build(dune): bump lang 3.11 → 3.22 to match toolchain

### DIFF
--- a/agent_sdk.opam
+++ b/agent_sdk.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/agent-sdk"
 bug-reports: "https://github.com/jeong-sik/agent-sdk/issues"
 depends: [
   "ocaml" {>= "5.1"}
-  "dune" {>= "3.11" & >= "3.11"}
+  "dune" {>= "3.22" & >= "3.22"}
   "eio_main" {>= "0.12"}
   "cohttp-eio" {>= "6.0.0~alpha2"}
   "tls" {>= "0.17.0"}
@@ -45,3 +45,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/jeong-sik/agent-sdk.git"
+x-maintenance-intent: ["(latest)"]

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.11)
+(lang dune 3.22)
 (name agent_sdk)
 (version 0.162.0)
 
@@ -15,7 +15,7 @@
  (description "A native OCaml implementation of the Anthropic Agent SDK using OCaml 5.x Eio for structured concurrency, inspired by Go SDK patterns.")
  (depends
   (ocaml (>= 5.1))
-  (dune (>= 3.11))
+  (dune (>= 3.22))
   (eio_main (>= 0.12))
   (cohttp-eio (>= 6.0.0~alpha2))
   (tls (>= 0.17.0))


### PR DESCRIPTION
## Summary

oas (agent_sdk) `dune-project` 선언을 실측 toolchain에 정렬: `(lang dune 3.11)` → `(lang dune 3.22)`, dune floor `>= 3.11` → `>= 3.22`. `agent_sdk.opam` 자동 재생성.

masc-mcp의 #8784와 대칭 작업.

## 변경

| 파일 | 변경 |
|------|------|
| `dune-project:1` | `(lang dune 3.11)` → `(lang dune 3.22)` |
| `dune-project:18` | `(dune (>= 3.11))` → `(dune (>= 3.22))` |
| `agent_sdk.opam` | auto-regenerated |

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| `(lang dune X)` | 3.11 | 3.22 |
| dune 의존성 floor | 3.11 | 3.22 |
| 실제 dune (로컬) | 3.22.0 | 3.22.0 (동일) |

OCaml floor `(ocaml (>= 5.1))`은 이번 PR에서 건드리지 않음 — consumer 호환성 고려, 별도 PR로 평가.

## 왜 지금

북극성 M-W1.1 대칭 작업. masc-mcp #8784와 쌍을 이룸. dune 3.11 → 3.22는 11 minor versions 간격이지만 backward-compatible lang 바뀜으로 전체 빌드 통과.

## 근거

- `opam exec -- dune --version` → `3.22.0`
- 전체 빌드: `dune build --root=.` ✅ pass

## Anti-goal 자가 체크

- [x] surgical (2 파일, 3 logical line)
- [x] behavior-preserving
- [x] 실측 근거

## Epic/Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (M-W1 oas parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
