### PR TITLE
chore(test): batch register 15 orphan test executables — supersedes 15 PRs

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -333,3 +333,63 @@
 (test
  (name test_memory_advanced)
  (libraries agent_sdk alcotest eio eio_main qcheck-core qcheck-alcotest))
+
+(test
+ (name test_agent_lifecycle)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_agent_registry)
+ (libraries agent_sdk alcotest eio eio_main))
+
+(test
+ (name test_durable_event)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_a2a_client)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_a2a_client_cov)
+ (libraries agent_sdk alcotest eio eio_main cohttp cohttp-eio))
+
+(test
+ (name test_a2a_task_store)
+ (libraries agent_sdk alcotest eio eio_main unix))
+
+(test
+ (name test_a2a_task_unit)
+ (libraries agent_sdk alcotest eio eio_main yojson))
+
+(test
+ (name test_a2a_full)
+ (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_a2a)
+ (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_eval_baseline)
+ (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_eval)
+ (libraries agent_sdk alcotest yojson eio eio_main))
+
+(test
+ (name test_eval_report_full)
+ (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_eval_coverage)
+ (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_memory_episodic)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_memory_procedural)
+ (libraries agent_sdk alcotest))


### PR DESCRIPTION
## Summary

Batch consolidation that supersedes 15 individually-conflicting PRs (#1037, #1038, #1039, #1044, #1046, #1049, #1050, #1051, #1052, #1053, #1054, #1055, #1056, #1057, #1058).

Each of those PRs added exactly one `(test ...)` entry to the **end** of `test/dune` for an orphan test executable from #1025. Whenever any single PR merged, the rest re-entered `CONFLICTING` because all 15 patches modified the same trailing region. Sequential admin-merging yielded only 3 of 18 (#1041 #1043 #1045) before the cascade choked on conflicts.

This single commit appends all 15 entries at once, eliminating the conflict surface.

## Verification

- `dune build --root .` — clean, no warnings.
- All 15 referenced `test/test_*.ml` files already exist on `main`; only the dune registration was missing.

## Follow-up

After merge, the 15 superseded PRs should be closed with a comment pointing here.
