### PR TITLE
perf(gemini_cli): fail-fast on MODEL_CAPACITY_EXHAUSTED stderr

### DIFF
--- a/lib/llm_provider/transport_gemini_cli.ml
+++ b/lib/llm_provider/transport_gemini_cli.ml
@@ -189,14 +189,90 @@ let parse_json_result json_str =
 let gemini_cli_scrub_env =
   ["GEMINI_API_KEY"; "GOOGLE_API_KEY"; "GOOGLE_APPLICATION_CREDENTIALS"]
 
+(* Stderr markers the gemini CLI emits when it is looping internally on
+   429 MODEL_CAPACITY_EXHAUSTED from cloudcode-pa.googleapis.com.  Each
+   retry wall-clocks ~8 s (server-timing gfet4t7;dur≥8000) and the CLI
+   typically attempts 5 before giving up, so a single upstream 429 can
+   block a cascade call for 30–60 s.  When we see the first marker, we
+   trip [cancel] so the CLI receives [SIGINT] and the cascade can move
+   on to the next provider immediately. *)
+let capacity_exhausted_markers =
+  [ "MODEL_CAPACITY_EXHAUSTED"
+  ; "RESOURCE_EXHAUSTED"
+  ; "No capacity available"
+  ; "rateLimitExceeded"
+  ]
+
+let substring_found line needle =
+  let hl = String.length line and nl = String.length needle in
+  if nl = 0 || nl > hl then false
+  else
+    let rec scan i =
+      if i + nl > hl then false
+      else if String.sub line i nl = needle then true
+      else scan (i + 1)
+    in
+    scan 0
+
 let run ~sw ~mgr ~(config : config) argv =
-  Cli_common_subprocess.run_collect ~sw ~mgr
-    ~name:"gemini"
-    ~cwd:config.cwd
-    ~extra_env:[]
-    ~scrub_env:gemini_cli_scrub_env
-    ?cancel:config.cancel
-    argv
+  let fail_fast_enabled =
+    not (Cli_common_env.bool "OAS_GEMINI_CLI_NO_FAIL_FAST_ON_CAPACITY")
+  in
+  let capacity_p, capacity_r = Eio.Promise.create () in
+  let capacity_exhausted = ref false in
+  let on_stderr_line line =
+    Cli_common_subprocess.default_on_stderr_line ~name:"gemini" line;
+    if
+      fail_fast_enabled
+      && not !capacity_exhausted
+      && List.exists (substring_found line) capacity_exhausted_markers
+    then begin
+      capacity_exhausted := true;
+      if not (Eio.Promise.is_resolved capacity_p) then
+        Eio.Promise.resolve capacity_r ()
+    end
+  in
+  (* Merge the upstream cancel (if any) with the capacity-exhausted
+     signal so either one triggers a SIGINT on the CLI. *)
+  let merged_cancel =
+    match config.cancel with
+    | None -> Some capacity_p
+    | Some upstream ->
+        let merged_p, merged_r = Eio.Promise.create () in
+        let resolve_once () =
+          if not (Eio.Promise.is_resolved merged_p) then
+            Eio.Promise.resolve merged_r ()
+        in
+        Eio.Fiber.fork ~sw (fun () ->
+          Eio.Promise.await upstream;
+          resolve_once ());
+        Eio.Fiber.fork ~sw (fun () ->
+          Eio.Promise.await capacity_p;
+          resolve_once ());
+        Some merged_p
+  in
+  let result =
+    Cli_common_subprocess.run_collect ~sw ~mgr
+      ~name:"gemini"
+      ~cwd:config.cwd
+      ~extra_env:[]
+      ~scrub_env:gemini_cli_scrub_env
+      ~on_stderr_line
+      ?cancel:merged_cancel
+      argv
+  in
+  match result with
+  | Error _ when !capacity_exhausted ->
+      Error
+        (Http_client.NetworkError
+           {
+             message =
+               "gemini_cli: MODEL_CAPACITY_EXHAUSTED detected on stderr, \
+                aborted CLI early so the cascade can move on. Set \
+                OAS_GEMINI_CLI_NO_FAIL_FAST_ON_CAPACITY=1 to let the CLI \
+                keep its internal retry loop.";
+           })
+  | r -> r
 
 (* Fires once per transport instance when any Claude-only config field
    is set.  Gemini CLI has no flag for these yet, so we warn and drop. *)


### PR DESCRIPTION
## Problem

MASC keeper logs regularly surface bursts like:

\`\`\`
+[gemini stderr] Attempt 3 failed with status 429. Retrying with backoff... _GaxiosError …
+[gemini stderr]   "reason": "MODEL_CAPACITY_EXHAUSTED",
+[gemini stderr]   "metadata": { "model": "gemini-3.1-pro-preview" }
+[gemini stderr] Attempt 5 failed with status 429. Retrying with backoff…
\`\`\`

Each 429 round-trips ~8 s (\`server-timing gfet4t7; dur≥8000\`) and the CLI typically cycles through ~5 retries before giving up. During those 30–60 s the OAS \`complete_cascade\` call is stuck — it cannot move on to the next provider because the gemini subprocess hasn’t exited.

## Root cause

\`lib/llm_provider/transport_gemini_cli.ml\` previously ignored stderr (\`Ok { stdout; stderr = _; … }\`). It had no way to observe that the CLI was looping on capacity exhaustion rather than actually making progress, so it had to wait for the CLI to give up on its own.

## Fix

Stream stderr through an \`on_stderr_line\` hook that scans for one of four markers:

- \`MODEL_CAPACITY_EXHAUSTED\`
- \`RESOURCE_EXHAUSTED\`
- \`No capacity available\`
- \`rateLimitExceeded\`

First match resolves a fresh \`Eio.Promise\` which is merged with any upstream \`config.cancel\` — either signal SIGINTs the CLI. The transport then coerces the error into a clear \`NetworkError\` so the cascade logs the real reason.

Gated by env var:

- **Default (unset or empty)**: fail-fast is **on** — cascade scenarios benefit from ~8 s fail + provider fallback over ~40 s blocking retry.
- \`OAS_GEMINI_CLI_NO_FAIL_FAST_ON_CAPACITY=1\`: revert to pre-patch behaviour (let the CLI keep its internal retry loop). Useful for standalone interactive use where the caller actually wants the retry.

## Tradeoffs

- Gives up ~32 s of potential CLI-internal recovery in exchange for immediate cascade fallback. For downstream MASC keeper cascades this is a win: the next provider picks up within seconds instead of minutes.
- If the first retry would have succeeded, we miss it. Cascade can re-select gemini on the next turn, so this is at worst an extra turn of latency spread across providers, never a lost call.

## Validation

- \`dune build --root . lib/\` ✓ (clean)
- \`.mli\` untouched — new helpers (\`capacity_exhausted_markers\`, \`substring_found\`) are file-local.
- Inline tests unchanged; no test for the behaviour yet — live cascade observation is the verification surface (MASC keeper logs).

## Scope guard

- Does **not** change \`build_args\` or the CLI invocation shape.
- Does **not** add a CLI flag for retry control — gemini CLI does not expose one at 0.38.1.
- Does **not** add any always-on timeout; only aborts on explicit capacity-exhausted stderr.
- Does **not** touch other CLI transports (claude, codex) — those have different retry semantics.

## Related

Observed during masc-mcp CDAL-verification /loop operational monitoring (sibling to masc-mcp#8818 dashboard git cache, masc-mcp#8822 keepers_json perf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)