### PR TITLE
chore(test): register orphan test_memory_access (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -397,3 +397,7 @@
 (test
  (name test_memory_procedural)
  (libraries agent_sdk alcotest))
+
+(test
+ (name test_memory_access)
+ (libraries agent_sdk alcotest))


### PR DESCRIPTION
## Summary

- Register orphan `test/test_memory_access.ml` (269 LOC, 16 cases) in `test/dune`
- Unblocks CI coverage of `Memory_access` ACL layer

## Impact

- `deny_by_default` × 2 — store/recall both fail closed without grant
- `grant_revoke` × 3 — grant, revoke, revoke_all paths
- `permission_levels` × 2 — read-only rejects writes, write-only rejects reads
- `key_patterns` × 1 — prefix pattern matching on wildcard ACL entries
- `episodic_procedural` × 3 — tier-specific access including `find_procedure`
- `check_utility` × 1 — `Memory_access.check` boolean API
- `error_format` × 2 — `Error.to_string` stability for `Denied` / `Backend_failed`
- `backend_failure` × 2 — **store/forget propagate inner backend errors** (not swallowed)

## Axis

- **A (SSOT)**: orphan silent
- **D (Silent failure)**: ACL error variant `Denied | Backend_failed` exhaustive; neither path collapses to `Ok`
- **E (Variant)**: permission variant closed-type tested at both ends (read-only × write, write-only × read)
- **G (Determinism)**: deny-by-default → explicit grant required. No implicit capability elevation

## Test plan

- [x] `dune build test/test_memory_access.exe`
- [x] `dune exec test/test_memory_access.exe` — 16/16 green, 0.002s
- [ ] CI re-verify (full suite)

## Rules

- Draft only — Ready/merge 수동 (effervescent-mapping-grove plan)