### PR TITLE
chore(test): register orphan test_harness_runner (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -397,3 +397,7 @@
 (test
  (name test_memory_procedural)
  (libraries agent_sdk alcotest))
+
+(test
+ (name test_harness_runner)
+ (libraries agent_sdk alcotest unix))


### PR DESCRIPTION
## Summary

- Register orphan `test/test_harness_runner.ml` (319 LOC, 7 cases) — harness cluster 3/4
- `Harness_runner` 채점 + `Harness_report` 보고 + fixture/trace 이중 디스패치 계약

## Impact

- `grade_case.fixture` — fixture 기반 채점 (실제 LLM 호출)
- `grade_case.trace replay` — 기록된 trace를 offline 재평가
- `grade_case.from_trace_file` — ndjson trace 파일 로드
- **`rejects fixture in trace mode`** — mode/kind 불일치를 `Error`로 전파 (silent fallback 없음)
- **`rejects negative tolerance`** — 도메인 제약 위반을 input validation으로 차단
- `mixed dataset dispatches by kind` — dataset kind에 따라 fixture vs trace 자동 선택
- `mixed dataset without fixture runner` — fixture runner 부재 시 명시적 error

## Axis

- **A (SSOT)**: orphan silent
- **D (Silent failure)**: `rejects fixture in trace mode` + `without fixture runner` = mode/kind 불일치를 swallow하지 않고 Error 전파
- **E (Variant)**: dataset kind(`Fixture | Trace`) closed dispatch — unknown은 reject
- **G (Determinism)**: `rejects negative tolerance` = 입력 제약을 타입/계약으로 고정

## Test plan

- [x] `dune build test/test_harness_runner.exe`
- [x] `dune exec test/test_harness_runner.exe` — 7/7 green, 0.003s

## Rules

- Draft only — Ready/merge 수동
- Harness cluster 3/4 (remaining: test_harness_deep 585 LOC — 최대)