### PR TITLE
chore(test): register orphan test_skill_discovery (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -339,6 +339,10 @@
  (libraries agent_sdk alcotest eio eio_main qcheck-core qcheck-alcotest))
 
 (test
+ (name test_skill_discovery)
+ (libraries agent_sdk alcotest eio eio_main))
+
+(test
  (name test_agent_lifecycle)
  (libraries agent_sdk alcotest))
 


### PR DESCRIPTION
## Scope
test/test_skill_discovery.ml (182 LOC, 5 cases)를 test/dune에 등록.

## 계약 (Contract)
- **A축 (SSOT)**: orphan 테스트 = "실행되지 않는 계약". dune 등록으로 CI 결과에 고정.
- **C축 (경계)**: Skill discovery(메타) vs runtime(system prompt inject) 분리 — issue #520.

## 검증 (Swiss Cheese)
1. registry does not inject into prompt — `with_skill_registry`만으로는 prompt 주입 없음.
2. contract skill injects into prompt — `with_skill`은 prompt에 주입.
3. with_skills batch injects into prompt — 복수 skill 주입.
4. both paths coexist — registry+contract 동시 사용 시 간섭 없음.
5. registry-only preserves base prompt — registry만 쓰면 base prompt 원형 유지.

## Run
```
dune exec --root . test/test_skill_discovery.exe
# Test Successful in 0.033s. 5 tests run.
```

## Non-goals
- 코드 수정 없음 (테스트 등록만).
- Ready 전환은 수동.
