### PR TITLE
chore(test): register orphan test_skill_registry (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -453,3 +453,7 @@
 (test
  (name test_structured_ext)
  (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_skill_registry)
+ (libraries agent_sdk alcotest yojson))


### PR DESCRIPTION
## Scope
test/test_skill_registry.ml (201 LOC, 16 cases)를 test/dune에 등록.

## 계약 (Contract)
- **A축 (SSOT)**: orphan = 실행되지 않는 계약. dune 등록으로 CI 결과에 고정.
- **D축 (Fail-closed)**: `of_json invalid`, `bad skill json`, `missing dir` 명시적 실패 브랜치 검증.
- **C축 (경계, parse-don't-validate)**: JSON ↔ in-memory round-trip identity (rich + bare + empty).

## 검증 (16 cases, 3 suites)
- **crud** (8): create empty / register and find / find missing / register multiple / register overwrite / remove / remove nonexistent / list sorted.
- **json** (7): roundtrip / to_json structure / of_json invalid / rich skill roundtrip / bare skill roundtrip / bad skill json / empty skills.
- **load** (1): missing dir — filesystem loader fail-closed.

## Run
```
dune exec --root . test/test_skill_registry.exe
# Test Successful in 0.009s. 16 tests run.
```

## Non-goals
- 코드 수정 없음 (테스트 등록만).
- Ready 전환은 수동.
