### PR TITLE
chore(test): register orphan test_structured_ext (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -449,3 +449,7 @@
 (test
  (name test_skill_coverage)
  (libraries agent_sdk alcotest))
+
+(test
+ (name test_structured_ext)
+ (libraries agent_sdk alcotest yojson))


### PR DESCRIPTION
## Scope
test/test_structured_ext.ml (238 LOC, 14 cases, 4 suites)를 test/dune에 등록.

## 계약 (Contract)
- **A축 (SSOT)**: orphan = 실행되지 않는 계약. dune 등록으로 CI 결과에 고정.
- **D축 (Fail-closed)**: json_extractor의 4-way 실패 브랜치(valid/invalid_json/empty_content/type_error)로 "unknown → permissive default" 차단.
- **E축 (Variant/Option boundary)**: text_extractor의 `some/none/empty` 3-경계. 빈 문자열 vs None 명시적 구분.

## 검증 (14 cases, 4 suites)
- **schema_to_tool_json** (3): basic / no required / empty params.
- **extract_tool_input** (4): found / not found / wrong name / parse error.
- **json_extractor** (4): valid / invalid json / empty content / type error.
- **text_extractor** (3): some / none / empty.

## Run
```
dune exec --root . test/test_structured_ext.exe
# Test Successful in 0.008s. 14 tests run.
```

## Non-goals
- 코드 수정 없음 (테스트 등록만).
- Ready 전환은 수동.
