### PR TITLE
chore(test): register orphan test_skill_coverage (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -445,3 +445,7 @@
 (test
  (name test_structured_coverage)
  (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_skill_coverage)
+ (libraries agent_sdk alcotest))


### PR DESCRIPTION
## Scope
test/test_skill_coverage.ml (329 LOC, 39 cases)를 test/dune에 등록.

## 계약 (Contract)
- **A축 (SSOT)**: orphan = 실행되지 않는 계약. dune 등록으로 CI 결과에 고정.
- **F축 (String matching 억제)**: Skill 모듈의 markdown frontmatter 파서 파이프라인(strip_quotes/split_csv/replace_all/parse_frontmatter/scope_of_string)을 각 pure fn 단위로 고립.
- **D축 (Fail-closed)**: `load nonexistent`, mismatched quote, no frontmatter 등 명시적 edge 브랜치 검증.

## 검증 (39 cases, multi-suite)
- **strip_quotes**: double / single / none / mismatched.
- **split_csv**: empty / single / multi / brackets / whitespace 등.
- **replace_all**: edge cases.
- **parse_frontmatter**: various formats.
- **frontmatter_value / frontmatter_values**.
- **scope_of_string**: all variants.
- **of_markdown**: full / no frontmatter / name from path.
- **render_prompt**: no args / `$ARGUMENTS` / `{{arguments}}` / both.
- **supporting_file_paths**: absolute + relative.
- **load**: nonexistent file error.
- **show**: skill show roundtrip.

## Run
```
dune exec --root . test/test_skill_coverage.exe
# Test Successful in 0.005s. 39 tests run.
```

## Non-goals
- 코드 수정 없음 (테스트 등록만).
- Ready 전환은 수동.
