### PR TITLE
chore(test): register orphan test_structured_coverage (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -441,3 +441,7 @@
 (test
  (name test_trajectory_unit)
  (libraries agent_sdk alcotest yojson str))
+
+(test
+ (name test_structured_coverage)
+ (libraries agent_sdk alcotest yojson))


### PR DESCRIPTION
## Scope
test/test_structured_coverage.ml (342 LOC, 18 cases)를 test/dune에 등록.

## 계약 (Contract)
- **A축 (SSOT)**: orphan = 실행되지 않는 계약. dune 등록으로 CI 결과에 고정.
- **D축 (Fail-closed)**: json_extractor가 parser raise(Yojson Type_error / Failure)를 `Error`로 변환해 경계 밖으로 새지 않음을 명시적 검증. Tick 53 `test_structured_ext`와 상/하 보완.
- **E축 (Content block variant exhaustive)**: `extract_tool_input_blocks`가 Image/Document/RedactedThinking/Audio 블록을 **ignore** 하고 Tool 블록만 선택.

## 검증 (18 cases, 4 suites)
- **json_extractor** (5): type_error / failure / takes first text / skips non-text / wrong structure.
- **text_extractor** (4): no text content / only non-text / takes first / parse returns None.
- **extract_tool_input_blocks** (6): ignores Image / Document / RedactedThinking / Audio / only wrong-name tools / mixed blocks.
- **schema_to_tool_json** (3): array/object types / single required / all optional.

## Run
```
dune exec --root . test/test_structured_coverage.exe
# Test Successful in 0.002s. 18 tests run.
```

## Non-goals
- 코드 수정 없음 (테스트 등록만).
- Ready 전환은 수동.
