### PR TITLE
fix(transport/claude): route large prompts through stdin (closes #1082)

### DIFF
--- a/lib/llm_provider/cli_common_subprocess.ml
+++ b/lib/llm_provider/cli_common_subprocess.ml
@@ -38,9 +38,18 @@ let default_on_stderr_line ~name line =
 (** Shared core.  Always reads stdout/stderr line-by-line from the live
     pipe, always supports cooperative cancel.  [run_collect] and
     [run_stream_lines] are thin wrappers that differ only in whether
-    they expose [on_line] to the caller. *)
+    they expose [on_line] to the caller.
+
+    [?stdin_content]: when [Some s], opens a pipe to the child's stdin,
+    writes [s], and closes the writer so the child sees EOF.  Used by
+    transports to bypass the argv/envp [ARG_MAX] ceiling (macOS
+    ~1 MiB) for large prompts; see
+    {!Transport_claude_code.keeper_isolation_env} and PR fixing OAS
+    #1082 for the original symptom.  When [None] the child's stdin
+    follows Eio's default (inherits parent). *)
 let run_core ~sw ~(mgr : _ Eio.Process.mgr) ~name ~cwd ~extra_env
     ?(scrub_env = [])
+    ?stdin_content
     ~on_line ~on_stderr_line ~cancel argv =
   let t0 = Unix.gettimeofday () in
   try
@@ -48,12 +57,44 @@ let run_core ~sw ~(mgr : _ Eio.Process.mgr) ~name ~cwd ~extra_env
     let r_stderr, w_stderr = Eio_unix.pipe sw in
     let env = build_env ~cwd ~extra_env ~scrub_env () in
     let final_argv = cwd_wrapper cwd @ argv in
-    let proc = Eio.Process.spawn ~sw mgr
-      ~stdout:(w_stdout :> Eio.Flow.sink_ty Eio.Resource.t)
-      ~stderr:(w_stderr :> Eio.Flow.sink_ty Eio.Resource.t)
-      ~env
-      final_argv
+    let stdin_pipe =
+      match stdin_content with
+      | None -> None
+      | Some _ -> Some (Eio_unix.pipe sw)
     in
+    let stdin_flow =
+      match stdin_pipe with
+      | None -> None
+      | Some (r_stdin, _) ->
+        Some (r_stdin :> Eio.Flow.source_ty Eio.Resource.t)
+    in
+    let proc =
+      match stdin_flow with
+      | None ->
+        Eio.Process.spawn ~sw mgr
+          ~stdout:(w_stdout :> Eio.Flow.sink_ty Eio.Resource.t)
+          ~stderr:(w_stderr :> Eio.Flow.sink_ty Eio.Resource.t)
+          ~env
+          final_argv
+      | Some stdin ->
+        Eio.Process.spawn ~sw mgr
+          ~stdin
+          ~stdout:(w_stdout :> Eio.Flow.sink_ty Eio.Resource.t)
+          ~stderr:(w_stderr :> Eio.Flow.sink_ty Eio.Resource.t)
+          ~env
+          final_argv
+    in
+    (match stdin_pipe, stdin_content with
+     | Some (r_stdin, w_stdin), Some s ->
+       (* Close the read end here — the child already holds its copy. *)
+       Eio.Flow.close r_stdin;
+       (try
+          Eio.Flow.copy_string s (w_stdin :> Eio.Flow.sink_ty Eio.Resource.t)
+        with exn ->
+          Eio.traceln "cli_common_subprocess: stdin write raised: %s"
+            (Printexc.to_string exn));
+       Eio.Flow.close w_stdin
+     | _ -> ());
     Eio.Flow.close w_stdout;
     Eio.Flow.close w_stderr;
     let stdout_buf = Buffer.create 4096 in
@@ -129,9 +170,11 @@ let run_core ~sw ~(mgr : _ Eio.Process.mgr) ~name ~cwd ~extra_env
 
 let run_collect ~sw ~mgr ~name ~cwd ~extra_env
     ?(scrub_env = [])
+    ?stdin_content
     ?(on_stderr_line = default_on_stderr_line ~name)
     ?cancel argv =
   run_core ~sw ~mgr ~name ~cwd ~extra_env ~scrub_env
+    ?stdin_content
     ~on_line:(fun _ -> ())
     ~on_stderr_line
     ~cancel
@@ -139,10 +182,12 @@ let run_collect ~sw ~mgr ~name ~cwd ~extra_env
 
 let run_stream_lines ~sw ~mgr ~name ~cwd ~extra_env
     ?(scrub_env = [])
+    ?stdin_content
     ~on_line
     ?(on_stderr_line = default_on_stderr_line ~name)
     ?cancel argv =
   run_core ~sw ~mgr ~name ~cwd ~extra_env ~scrub_env
+    ?stdin_content
     ~on_line
     ~on_stderr_line
     ~cancel

--- a/lib/llm_provider/cli_common_subprocess.mli
+++ b/lib/llm_provider/cli_common_subprocess.mli
@@ -23,6 +23,7 @@ val run_collect :
   cwd:string option ->
   extra_env:(string * string) list ->
   ?scrub_env:string list ->
+  ?stdin_content:string ->
   ?on_stderr_line:(string -> unit) ->
   ?cancel:unit Eio.Promise.t ->
   string list ->
@@ -39,6 +40,11 @@ val run_collect :
       [.claude/] / [.codex/] / [.gemini/]) see [dir], not the parent's
       cwd. Blank strings are treated as [None].
     - [extra_env]: additional [KEY=VAL] pairs prepended to the env.
+    - [stdin_content]: when [Some s], opens a pipe to the child's
+      stdin, writes [s], and closes it.  Used by transports to
+      bypass the argv/envp [ARG_MAX] ceiling (macOS ~1 MiB) for
+      large prompts that cannot fit in argv.  When [None], the
+      child's stdin follows Eio's default (inherits parent's).
     - [on_stderr_line]: called for every stderr line as it arrives.
       Defaults to {!default_on_stderr_line}, which forwards to
       [Eio.traceln].  Exceptions raised by the callback are caught
@@ -58,6 +64,7 @@ val run_stream_lines :
   cwd:string option ->
   extra_env:(string * string) list ->
   ?scrub_env:string list ->
+  ?stdin_content:string ->
   on_line:(string -> unit) ->
   ?on_stderr_line:(string -> unit) ->
   ?cancel:unit Eio.Promise.t ->

--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -87,9 +87,51 @@ let env_extra_args ~(config : config) =
    | Some tools -> List.iter (fun t -> add ["--disallowedTools"; t]) tools);
   !extras
 
+(** Threshold at which [build_args] stops passing the prompt as a
+    positional argv entry and expects the caller to feed it via
+    stdin instead.  macOS [ARG_MAX] is ~1 MiB for the combined argv
+    + envp block; 512 KiB leaves headroom for env vars (keeper
+    context, OAS_* flags) and the other argv entries added after the
+    prompt.  Env override [OAS_CLAUDE_PROMPT_ARGV_THRESHOLD] accepts
+    an integer byte count for per-host tuning. *)
+let default_prompt_argv_threshold = 512 * 1024
+
+let prompt_argv_threshold () =
+  match Sys.getenv_opt "OAS_CLAUDE_PROMPT_ARGV_THRESHOLD" with
+  | Some raw ->
+    (match int_of_string_opt (String.trim raw) with
+     | Some v when v >= 0 -> v
+     | _ -> default_prompt_argv_threshold)
+  | None -> default_prompt_argv_threshold
+
+(** Decide whether the prompt must be routed via stdin.  Callers that
+    observe a [true] result should:
+      1. call [build_args] which returns [-p <empty>] (or omits the
+         prompt entirely, see below);
+      2. pass the prompt as [~stdin_content] to the subprocess.
+    Returning the threshold here keeps the decision co-located with
+    argv construction, so any future argv-budget change lives in one
+    place. *)
+let prompt_exceeds_argv_budget prompt =
+  String.length prompt >= prompt_argv_threshold ()
+
+(** Caller-side helper: wrap [prompt] in [Some] when it must go via
+    stdin, [None] when argv is fine.  Saves the three call sites
+    from duplicating the budget check alongside [build_args]. *)
+let stdin_for_prompt prompt =
+  if prompt_exceeds_argv_budget prompt then Some prompt else None
+
 let build_args ~(config : config) ~(req_config : Provider_config.t)
     ~prompt ~stream ~system_prompt =
-  let args = ref ["-p"; prompt] in
+  (* When the prompt is too big for argv, omit it from the positional
+     slot. Claude CLI (`--input-format text`, the default) then reads
+     the prompt from stdin via [--print] / [-p]. We still pass [-p]
+     to select non-interactive mode; the CLI concatenates stdin onto
+     the empty positional. *)
+  let prompt_via_stdin = prompt_exceeds_argv_budget prompt in
+  let args =
+    ref (if prompt_via_stdin then ["-p"] else ["-p"; prompt])
+  in
   let add a = args := !args @ a in
   add ["--output-format"; if stream then "stream-json" else "json"];
   if stream then add ["--verbose"];
@@ -359,12 +401,13 @@ let keeper_isolation_env () =
         (Unix.getpid ()) n (Unix.gettimeofday ()) )
   ]
 
-let run ~sw ~mgr ~(config : config) args =
+let run ~sw ~mgr ~(config : config) ?stdin_content args =
   Cli_common_subprocess.run_collect ~sw ~mgr
     ~name:"claude"
     ~cwd:config.cwd
     ~extra_env:(keeper_isolation_env ())
     ~scrub_env:claude_cli_scrub_env
+    ?stdin_content
     ?cancel:config.cancel
     (config.claude_path :: args)
 
@@ -393,6 +436,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
                 ~name:"claude" ~cwd:config.cwd
                 ~extra_env:(keeper_isolation_env ())
                 ~scrub_env:claude_cli_scrub_env
+                ?stdin_content:(stdin_for_prompt prompt)
                 ~on_line ?cancel:config.cancel
                 argv with
         | Error _ as e -> { Llm_transport.response = e; latency_ms = 0 }
@@ -402,7 +446,8 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
       else
         let args = build_args ~config ~req_config:req.config
           ~prompt ~stream:false ~system_prompt in
-        match run ~sw ~mgr ~config args with
+        match run ~sw ~mgr ~config
+                ?stdin_content:(stdin_for_prompt prompt) args with
         | Error _ as e -> { Llm_transport.response = e; latency_ms = 0 }
         | Ok { stdout; stderr = _; latency_ms } ->
           let response = parse_json_result (String.trim stdout) in
@@ -429,6 +474,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
               ~cwd:config.cwd
               ~extra_env:(keeper_isolation_env ())
               ~scrub_env:claude_cli_scrub_env
+              ?stdin_content:(stdin_for_prompt prompt)
               ~on_line
               ?cancel:config.cancel
               argv with
@@ -687,3 +733,37 @@ let%test "claude_cli_scrub_env keeps ANTHROPIC_API_KEY entries" =
   List.mem "ANTHROPIC_API_KEY" claude_cli_scrub_env
   && List.mem "ANTHROPIC_API_KEY_MAIN" claude_cli_scrub_env
   && List.mem "ANTHROPIC_API_KEY_WORK" claude_cli_scrub_env
+
+let%test "prompt_exceeds_argv_budget: small prompt stays in argv" =
+  not (prompt_exceeds_argv_budget "hello")
+
+let%test "prompt_exceeds_argv_budget: 1 MiB prompt routes to stdin" =
+  prompt_exceeds_argv_budget (String.make (1 * 1024 * 1024) 'x')
+
+let%test "prompt_exceeds_argv_budget: OAS_CLAUDE_PROMPT_ARGV_THRESHOLD override" =
+  with_env "OAS_CLAUDE_PROMPT_ARGV_THRESHOLD" "100" (fun () ->
+    prompt_exceeds_argv_budget (String.make 200 'x')
+    && not (prompt_exceeds_argv_budget (String.make 50 'x')))
+
+let%test "stdin_for_prompt: Some when over budget, None under" =
+  let over = String.make (1 * 1024 * 1024) 'x' in
+  stdin_for_prompt "hi" = None && stdin_for_prompt over = Some over
+
+let%test "build_args omits positional prompt when routing via stdin" =
+  let big = String.make (1 * 1024 * 1024) 'x' in
+  let args = build_args ~config:default_config ~req_config:sample_req
+    ~prompt:big ~stream:false ~system_prompt:None in
+  (* First two argv entries should be ["-p"; "--output-format"], NOT
+     ["-p"; <big>] — the prompt must not appear anywhere in argv. *)
+  not (List.mem big args)
+  && (match args with
+      | "-p" :: "--output-format" :: _ -> true
+      | _ -> false)
+
+let%test "build_args keeps positional prompt when small" =
+  let args = build_args ~config:default_config ~req_config:sample_req
+    ~prompt:"hello" ~stream:false ~system_prompt:None in
+  List.mem "hello" args
+  && (match args with
+      | "-p" :: "hello" :: _ -> true
+      | _ -> false)


### PR DESCRIPTION
## Summary

Closes #1082. `Transport_claude_code.build_args` unconditionally put the prompt in argv, so keepers with large accumulated context hit `execve` `E2BIG` (macOS `ARG_MAX` ~1 MiB) on every call. The error is non-cascadable; keeper cycles fail with no retry path.

This PR adds an optional stdin path. When the prompt crosses `OAS_CLAUDE_PROMPT_ARGV_THRESHOLD` (default 512 KiB, 50 % of ARG_MAX for env/argv headroom), `build_args` drops the positional prompt and the subprocess receives the prompt via stdin instead.

## Product impact

2026-04-20 fleet log recorded 40 × `Failure("execve: Argument list too long")` in a 45-minute window, all on `oas-resilient_breaker`. Removes the last top WARN signature from the triage. Two sibling PRs already merged:
- `#1076` — emit `--strict-mcp-config` only with a real config
- `#1080` — isolate `CODEX_COMPANION_SESSION_ID` per subprocess

## Evidence

- `lib/llm_provider/transport_claude_code.ml:76` previously wrote `["-p"; prompt]` unconditionally
- `lib/llm_provider/cli_common_subprocess.ml:51` `Eio.Process.spawn` had no stdin wiring — Eio's default is inherit-from-parent, which also blocks stdin redirection from consumers
- Fleet log sample (OAS issue #1082 linked for full trace)

## Design

- `?stdin_content:string` added to `run_collect` / `run_stream_lines` / `run_core` in `Cli_common_subprocess`. Optional so every existing caller stays source-compatible.
- Threshold + budget decision live next to `build_args` (single place to adjust):
  - `default_prompt_argv_threshold = 512 * 1024`
  - `prompt_argv_threshold ()` — env override
  - `prompt_exceeds_argv_budget` / `stdin_for_prompt` — pure predicates
- Three spawn sites (sync non-stream, sync stream-json, `complete_stream`) each wire `?stdin_content:(stdin_for_prompt prompt)`. Small prompts pay no pipe cost.
- `.mli` updated for both wrappers.

## Review evidence

- `dune build --root . lib/llm_provider` passes
- `dune runtest --root . lib/llm_provider` passes — 6 new inline tests + existing 28
  - small prompt → argv; 1 MiB prompt → stdin
  - `OAS_CLAUDE_PROMPT_ARGV_THRESHOLD` env override honoured
  - `stdin_for_prompt` correct for small and large
  - `build_args` omits positional prompt when routing via stdin
  - `build_args` keeps positional prompt when small (regression guard)

## Linked

Closes #1082.

🤖 Generated with [Claude Code](https://claude.com/claude-code)