### PR TITLE
chore(test): register orphan test_sessions_cov2 + fix schema drift (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -397,3 +397,7 @@
 (test
  (name test_memory_procedural)
  (libraries agent_sdk alcotest))
+
+(test
+ (name test_sessions_cov2)
+ (libraries agent_sdk alcotest yojson))

--- a/test/test_sessions_cov2.ml
+++ b/test/test_sessions_cov2.ml
@@ -191,7 +191,9 @@ let test_structured_telemetry_full () =
                actor = None; role = None; provider = None; model = None;
                artifact_id = None; artifact_name = None;
                artifact_kind = None; checkpoint_label = None;
-               outcome = None }];
+               outcome = None;
+               raw_trace_run_id = None; stop_reason = None;
+               dropped_output_deltas = None; persistence_failure_phase = None }];
   } in
   roundtrip
     ~to_yojson:Sessions.structured_telemetry_to_yojson


### PR DESCRIPTION
## Scope
test/test_sessions_cov2.ml (417 LOC, 20 cases)를 test/dune에 등록.

**추가 fix**: 등록 시 compile error 발생 → orphan 테스트가 `Sessions.structured_telemetry_step`의 최근 추가 필드 4개(`raw_trace_run_id`, `stop_reason`, `dropped_output_deltas`, `persistence_failure_phase`)를 반영하지 못한 schema drift 발견. line 189-194에 `None` 4개 추가.

## 계약 (Contract)
- **A축 (SSOT)**: orphan = 실행되지 않는 계약. dune 등록으로 CI 결과에 고정 + **drift 즉시 catch**.
- **E축 (Variant/Record exhaustive)**: ppx-generated to_yojson/of_yojson 전수 round-trip — `Every constructor of variant types + Every record type`.
- **D축 (Fail-closed)**: `invalid` cases (trace_capability/worker_status) + Error variant 명시적 검증.

## 드리프트 감지 의의
이 PR은 **"orphan 테스트 ≠ 무의미"**의 실증: 등록 안 된 테스트는 실제로 schema 변경을 따라오지 못해 silent하게 outdated됐다. dune 등록 = 자동 compile time verification 복구.

## 검증 (20 cases, 9 suites)
- **trace_capability** (2): all variants / invalid.
- **worker_status** (2): all variants / invalid.
- **session_info** (2): edge values / all phases.
- **telemetry** (3): event_count / step / full.
- **structured_telemetry** (3): event_count / step / full.
- **evidence** (3): file / missing / bundle.
- **hook_summary** (1): roundtrip.
- **tool_contract** (1): roundtrip.
- **worker_run** (2): all statuses / minimal.
- **evidence_capabilities** (1): roundtrip.

## Run
```
dune exec --root . test/test_sessions_cov2.exe
# Test Successful in 0.008s. 20 tests run.
```

## Non-goals
- schema drift 외 코드 수정 없음.
- Ready 전환은 수동.
