### PR TITLE
chore(test): register orphan test_sessions_types_deep (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -401,3 +401,7 @@
 (test
  (name test_sessions_cov2)
  (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_sessions_types_deep)
+ (libraries agent_sdk alcotest yojson))


### PR DESCRIPTION
## Scope
test/test_sessions_types_deep.ml (432 LOC, 15 cases)를 test/dune에 등록.

## 계약 (Contract)
- **A축 (SSOT)**: orphan = 실행되지 않는 계약. dune 등록으로 CI 결과에 고정.
- **E축 (Variant exhaustive)**: ppx-generated to_yojson/of_yojson 전수 round-trip —
  `raw_trace_run`, `raw_trace_summary`, `raw_trace_validation`, `worker_run`의 **6 status variants**, `proof_bundle` 대형 composite.

## Drift 관찰
Tick 58(#1087)과 달리 이 orphan은 **no-drift** — 이미 schema 반영 완료. 같은 module family(sessions)에서도 orphan별 last-touched drift 상태 비대칭. registration 단일 축만으로 통과.

## 검증 (15 cases, 7 suites)
- **raw_trace_run** (3): full / no session_id / json stability.
- **raw_trace_summary** (3): full / empty lists / with error.
- **raw_trace_validation** (3): pass / fail / empty checks.
- **worker_run_statuses** (2): all 6 variants / trace capabilities.
- **validation_check** (1): pass and fail.
- **record_type** (1): all 6 variants.
- **record** (2): tool execution / minimal run_started.

## Run
```
dune exec --root . test/test_sessions_types_deep.exe
# Test Successful in 0.009s. 15 tests run.
```

## Non-goals
- 코드 수정 없음 (drift 없음).
- Ready 전환은 수동.
