### PR TITLE
chore(test): register orphan test_skill_coverage2 (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -409,3 +409,7 @@
 (test
  (name test_trajectory)
  (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_skill_coverage2)
+ (libraries agent_sdk alcotest yojson unix))


### PR DESCRIPTION
## Scope
test/test_skill_coverage2.ml (455 LOC, **36 cases** — 최대 단일 orphan)를 test/dune에 등록.

## 계약 (Contract)
- **A축 (SSOT)**: orphan = 실행되지 않는 계약. dune 등록으로 CI 결과에 고정.
- **E축 (Variant exhaustive)**: `Skill.of_markdown` / `Skill_registry.of_json`의 모든 edge case 전수.

## Skill cluster 완주
| Tick | PR | File | Cases |
|------|----|------|-------|
| 51 | (merged) | test_skill_discovery | 14 |
| 52 | (merged) | test_skill_registry | 17 |
| 54 | (merged) | test_skill_coverage | 15 |
| **61 (this)** | — | **test_skill_coverage2** | **36** |

총 82 cases / 4 files. Skill 모듈 orphan 0.

## 설계 관찰
테스트명이 `parse_frontmatter_blank_lines` / `assoc_replace_duplicate_keys` / `registry_skill_of_json_non-list_tools`처럼 구체적 uncovered path를 targeted. 기존 `test_skill`이 못 커버한 gap을 메우도록 작성 — 저자의 coverage gap analysis 증거.

## 검증 (36 cases, 8+ suites)
- **parse_frontmatter** edge: blank lines before/inside, duplicate keys.
- **of_markdown** variants: scope from arg, allowed-tools + allowed_tools 양 키.
- **render_prompt**: mustache/args 혼합.
- **supporting_file_paths**: path/no_path/missing.
- **Skill_registry**:
  - `of_json`: non-list tools, non-list files, all optional, mixed array, no_skills key.
  - `load_from_dir`: success, with scope.
  - CRUD, JSON roundtrip.

## Run
```
dune exec --root . test/test_skill_coverage2.exe
# Test Successful in 0.028s. 36 tests run.
```

## Non-goals
- 코드 수정 없음 (drift 없음).
- Ready 전환은 수동.
