### PR TITLE
chore(test): register orphan test_mcp_deep (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -417,3 +417,7 @@
 (test
  (name test_mcp_coverage)
  (libraries agent_sdk alcotest unix))
+
+(test
+ (name test_mcp_deep)
+ (libraries agent_sdk alcotest unix mcp_protocol))


### PR DESCRIPTION
## Scope
test/test_mcp_deep.ml (306 LOC, 24 cases)를 test/dune에 등록. **MCP cluster 2/3**.

## 계약 (Contract)
- **A축 (SSOT)**: orphan = 실행되지 않는 계약. dune 등록으로 CI 결과에 고정.
- **E축 (Variant exhaustive)**: `mcp_tool_of_json` 7 variants — input_schema / inputSchema / underscore / no-schema / missing description / numeric name / null fields.

## Coverage 전략
`lib/protocol/mcp.ml`의 **116 uncovered lines (54.33%)** → 80% 목표.
- Tick 62 (#1093, `test_mcp_coverage`): 통합 + Http transport + close_managed.
- **Tick 63 (this, `test_mcp_deep`)**: pure function만 (Eio 불필요) — output_token_budget/truncate_output/text_of_tool_result/mcp_tool_of_json/merge_env.

같은 모듈에 대한 coverage 전략적 분할.

## deps
`agent_sdk alcotest unix mcp_protocol` — `Mcp_protocol.Mcp_types`를 `Sdk_types`로 alias (fork 경계 명시).

## 검증 (24 cases, 5+ suites)
- **output_token_budget** (4): default / valid / negative / non-numeric.
- **truncate_output**: various budgets.
- **text_of_tool_result**: TextContent / EmbeddedResource / mixed.
- **mcp_tool_of_json** (7): variants 열거.
- **merge_env** (3): empty / adds new / overrides.

## Run
```
dune exec --root . test/test_mcp_deep.exe
# Test Successful in 0.005s. 24 tests run.
```

## Non-goals
- 코드 수정 없음 (drift 없음).
- Ready 전환은 수동.
