### PR TITLE
chore(test): register orphan test_mcp_http (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -421,3 +421,7 @@
 (test
  (name test_mcp_deep)
  (libraries agent_sdk alcotest unix mcp_protocol))
+
+(test
+ (name test_mcp_http)
+ (libraries agent_sdk alcotest eio eio_main))


### PR DESCRIPTION
## Scope
test/test_mcp_http.ml (185 LOC, 11 cases)를 test/dune에 등록. **MCP cluster 3/3 완주**.

## MCP cluster 완주
| Tick | PR | File | Cases | Focus |
|------|----|------|-------|-------|
| 62 | #1093 | test_mcp_coverage | 22 | 통합 + transport |
| 63 | #1094 | test_mcp_deep | 24 | pure function (54%→80%) |
| **64** | **this** | **test_mcp_http** | **11** | HTTP transport boundary |

총 57 cases / 3 files. MCP orphan 0.

## 계약 (Contract)
- **A축 (SSOT)**: orphan = 실행되지 않는 계약.
- **E축 (Variant)**: `transport_kind` roundtrip (Stdio/Http).
- **D축 (Fail-open boundary)**: unreachable port(19999) 투입 → `connect`는 `Ok`, `initialize`에서 실패. 2-phase 프로토콜의 경계 검증.

## 검증 (11 cases, 4 suites)
- **config** (1): defaults (base_url / headers).
- **connect** (7): Ok / initialize unreachable / list_tools unreachable / call_tool unreachable / close safe / connect_and_load unreachable / returns Mcp.managed.
- **errors** (1): http transport error.
- **session** (2): transport_kind roundtrip / default stdio.

## deps
`agent_sdk alcotest eio eio_main` — Eio network for real TCP connect.

## 관찰
1.060s runtime — Tick 62(0.050s)/63(0.005s) 대비 현저히 느림. Eio TCP timeout이 dominate. 실제 네트워크 테스트는 필연적 slow — 별도 suite 분리는 후속 검토.

## Run
```
dune exec --root . test/test_mcp_http.exe
# Test Successful in 1.060s. 11 tests run.
```

## Non-goals
- 코드 수정 없음 (drift 없음).
- Ready 전환은 수동.
