### PR TITLE
fix(hooks): demote approval fallback log to debug (#956)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ original tag dates. `0.100.4` was never tagged or released.
 ### Fixed
 
 - **Codex CLI transport honors request model IDs.** `transport_codex_cli` now passes a non-empty, non-`auto` `Provider_config.model_id` through `codex exec --model`, matching Claude Code and Gemini CLI behavior while preserving `auto` as "use the user's CLI default".
+- **ApprovalRequired fallback no longer emits an operator-facing WARN without a callback.** The existing fail-open behavior is unchanged, but `agent_tools` now records the fallback at debug level so consumers do not see an unactionable warning on every approval-less tool execution.
 
 ## [0.163.0] - 2026-04-20
 

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -373,7 +373,7 @@ let execute_scheduled_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus
           | Hooks.ApprovalRequired -> (
               match approval with
               | None ->
-                  Log.warn _log
+                  Log.debug _log
                     "ApprovalRequired but no approval callback — executing"
                     [Log.S ("tool", name); Log.S ("agent", agent_name)];
                   find_and_execute_tool ~context ~tools ~hooks ~event_bus

--- a/lib/hooks.mli
+++ b/lib/hooks.mli
@@ -123,7 +123,7 @@ type hook_decision =
   | ApprovalRequired
       (** Signals that the tool needs external approval.  If an
           {!approval_callback} is registered the callback is invoked;
-          otherwise the tool is executed with a warning log. *)
+          otherwise the tool is executed and a debug log is emitted. *)
   | AdjustParams of turn_params
   | ElicitInput of elicitation_request
   | Nudge of string  (** OnIdle and BeforeTurn: inject message as User-role into the conversation, continue execution. On OnIdle the idle counter is preserved. On BeforeTurn the nudge is appended before tool preparation. *)


### PR DESCRIPTION
## Summary
- keep the documented fail-open `ApprovalRequired` fallback behavior unchanged
- demote the no-callback log from WARN to debug to remove unactionable operator noise
- update the hook docs and changelog to match the new log level

## Verification
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix-oas-956-approval-log ./test/test_approval.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix-oas-956-approval-log ./test/test_approval.exe`

Closes #956