### PR TITLE
feat(hooks): add on_idle_escalated severity hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ original tag dates. `0.100.4` was never tagged or released.
 - **Codex CLI transport honors request model IDs.** `transport_codex_cli` now passes a non-empty, non-`auto` `Provider_config.model_id` through `codex exec --model`, matching Claude Code and Gemini CLI behavior while preserving `auto` as "use the user's CLI default".
 - **ApprovalRequired fallback no longer emits an operator-facing WARN without a callback.** The existing fail-open behavior is unchanged, but `agent_tools` now records the fallback at debug level so consumers do not see an unactionable warning on every approval-less tool execution.
 
+### Added
+
+- **`Hooks.on_idle_escalated` adds runtime-computed idle severity.** Callers can opt into a structured idle hook carrying `nudge` / `final_warning` / `skip` severity while keeping the legacy `on_idle` path for compatibility. `skip_at` reuses `max_idle_turns`; `final_at` is configurable per agent via `idle_final_warning_at`.
+
 ## [0.163.0] - 2026-04-20
 
 ### Added

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -18,6 +18,7 @@ type options = Agent_types.options = {
   base_url: string;
   provider: Provider.config option;
   max_idle_turns: int;
+  idle_final_warning_at: int option;
   hooks: Hooks.hooks;
   guardrails: Guardrails.t;
   guardrails_async: Guardrails_async.t;

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -131,7 +131,7 @@ let invoke_hook ?on_hook_invoked ~tracer ~agent_name ~turn_count ~hook_name
               | Hooks.PostToolUseFailure { tool_name; _ } -> Some tool_name
               | Hooks.BeforeTurn _ | Hooks.BeforeTurnParams _
               | Hooks.AfterTurn _ | Hooks.OnStop _
-              | Hooks.OnIdle _ | Hooks.OnError _
+              | Hooks.OnIdle _ | Hooks.OnIdleEscalated _ | Hooks.OnError _
               | Hooks.OnToolError _ | Hooks.PreCompact _
               | Hooks.PostCompact _ | Hooks.OnContextCompacted _ -> None)
       | None -> ());

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -9,6 +9,7 @@ type options = {
   base_url: string;
   provider: Provider.config option;
   max_idle_turns: int;
+  idle_final_warning_at: int option;
   hooks: Hooks.hooks;
   guardrails: Guardrails.t;
   guardrails_async: Guardrails_async.t;
@@ -104,6 +105,7 @@ let default_options = {
   base_url = Api.default_base_url;
   provider = None;
   max_idle_turns = 3;
+  idle_final_warning_at = None;
   hooks = Hooks.empty;
   guardrails = Guardrails.default;
   guardrails_async = Guardrails_async.empty;

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -18,6 +18,10 @@ type options = {
   base_url: string;
   provider: Provider.config option;
   max_idle_turns: int;
+  idle_final_warning_at: int option;
+    (** Threshold for [Hooks.on_idle_escalated] to emit
+        [Hooks.Idle_severity.Final_warning]. When [None], the runtime
+        derives [max_idle_turns - 1] when [max_idle_turns > 1]. *)
   hooks: Hooks.hooks;
   guardrails: Guardrails.t;
   guardrails_async: Guardrails_async.t;

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -30,6 +30,7 @@ type t = {
   base_url: string;
   provider: Provider.config option;
   max_idle_turns: int;
+  idle_final_warning_at: int option;
   hooks: Hooks.hooks;
   guardrails: Guardrails.t;
   guardrails_async: Guardrails_async.t;
@@ -94,6 +95,7 @@ let create ~net ~model =
     base_url = Api.default_base_url;
     provider = None;
     max_idle_turns = 3;
+    idle_final_warning_at = None;
     hooks = Hooks.empty;
     guardrails = Guardrails.default;
     guardrails_async = Guardrails_async.empty;
@@ -240,6 +242,7 @@ let with_yield_on_tool v b = { b with yield_on_tool = v }
 let with_exit_condition pred b = { b with exit_condition = Some pred }
 let with_event_bus bus b = { b with event_bus = Some bus }
 let with_max_idle_turns n b = { b with max_idle_turns = n }
+let with_idle_final_warning_at n b = { b with idle_final_warning_at = Some n }
 let with_context_injector injector b = { b with context_injector = Some injector }
 let with_skill_registry reg b = { b with skill_registry = Some reg }
 let with_progressive_tools strategy b = { b with progressive_tools = Some strategy }
@@ -294,6 +297,7 @@ let build b =
     Agent_types.base_url = b.base_url;
     provider = b.provider;
     max_idle_turns = b.max_idle_turns;
+    idle_final_warning_at = b.idle_final_warning_at;
     hooks = (match b.progressive_tools with
       | None -> b.hooks
       | Some strategy ->

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -111,6 +111,7 @@ val with_context : Context.t -> t -> t
 val with_context_injector : Hooks.context_injector -> t -> t
 val with_event_bus : Event_bus.t -> t -> t
 val with_max_idle_turns : int -> t -> t
+val with_idle_final_warning_at : int -> t -> t
 val with_elicitation : Hooks.elicitation_callback -> t -> t
 val with_description : string -> t -> t
 val with_memory : Memory.t -> t -> t

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -52,6 +52,18 @@ type tool_schedule = {
   batch_kind: string;
 }
 
+module Idle_severity = struct
+  type t =
+    | Nudge
+    | Final_warning
+    | Skip
+
+  let to_string = function
+    | Nudge -> "nudge"
+    | Final_warning -> "final_warning"
+    | Skip -> "skip"
+end
+
 (** Extract reasoning summary from message list.
     Scans for Thinking blocks and heuristically detects uncertainty
     markers like "I'm not sure", "uncertain", "unclear". *)
@@ -120,6 +132,11 @@ type hook_event =
     }
   | OnStop of { reason: stop_reason; response: api_response }
   | OnIdle of { consecutive_idle_turns: int; tool_names: string list }
+  | OnIdleEscalated of {
+      severity: Idle_severity.t;
+      consecutive_idle_turns: int;
+      tool_names: string list;
+    }
   | OnError of { detail: string; context: string }
   | OnToolError of { tool_name: string; error: string }
   | PreCompact of {
@@ -193,6 +210,7 @@ type hooks = {
   post_tool_use_failure: hook option;
   on_stop: hook option;
   on_idle: hook option;
+  on_idle_escalated: hook option;
   on_error: hook option;
   on_tool_error: hook option;
   pre_compact: hook option;
@@ -210,6 +228,7 @@ let empty = {
   post_tool_use_failure = None;
   on_stop = None;
   on_idle = None;
+  on_idle_escalated = None;
   on_error = None;
   on_tool_error = None;
   pre_compact = None;
@@ -271,6 +290,7 @@ let stage_of_event = function
   | PostToolUseFailure _ -> "post_tool_use_failure"
   | OnStop _ -> "on_stop"
   | OnIdle _ -> "on_idle"
+  | OnIdleEscalated _ -> "on_idle_escalated"
   | OnError _ -> "on_error"
   | OnToolError _ -> "on_tool_error"
   | PreCompact _ -> "pre_compact"
@@ -290,6 +310,7 @@ let stage_of_event = function
     post_tool_use_failure|    Y     |      |          |                  |              |             |
     on_stop              |    Y     |      |          |                  |              |             |
     on_idle              |    Y     |  Y   |          |                  |              |             |   Y
+    on_idle_escalated    |    Y     |  Y   |          |                  |              |             |   Y
     on_error             |    Y     |      |          |                  |              |             |
     on_tool_error        |    Y     |      |          |                  |              |             |
     pre_compact          |    Y     |  Y   |          |                  |              |             |
@@ -307,6 +328,7 @@ let legal_decisions_for_stage stage =
   | "post_tool_use_failure" -> [K_Continue]
   | "on_stop"               -> [K_Continue]
   | "on_idle"               -> [K_Continue; K_Skip; K_Nudge]
+  | "on_idle_escalated"     -> [K_Continue; K_Skip; K_Nudge]
   | "on_error"              -> [K_Continue]
   | "on_tool_error"         -> [K_Continue]
   | "pre_compact"           -> [K_Continue; K_Skip]
@@ -375,6 +397,7 @@ let compose ~outer ~inner = {
   post_tool_use_failure = compose_hook outer.post_tool_use_failure inner.post_tool_use_failure;
   on_stop = compose_hook outer.on_stop inner.on_stop;
   on_idle = compose_hook outer.on_idle inner.on_idle;
+  on_idle_escalated = compose_hook outer.on_idle_escalated inner.on_idle_escalated;
   on_error = compose_hook outer.on_error inner.on_error;
   on_tool_error = compose_hook outer.on_tool_error inner.on_tool_error;
   pre_compact = compose_hook outer.pre_compact inner.pre_compact;

--- a/lib/hooks.mli
+++ b/lib/hooks.mli
@@ -37,6 +37,15 @@ type tool_schedule = {
   batch_kind: string;
 }
 
+module Idle_severity : sig
+  type t =
+    | Nudge
+    | Final_warning
+    | Skip
+
+  val to_string : t -> string
+end
+
 (** Events emitted during agent execution *)
 type hook_event =
   | BeforeTurn of { turn: int; messages: Types.message list }
@@ -75,6 +84,11 @@ type hook_event =
     }
   | OnStop of { reason: Types.stop_reason; response: Types.api_response }
   | OnIdle of { consecutive_idle_turns: int; tool_names: string list }
+  | OnIdleEscalated of {
+      severity: Idle_severity.t;
+      consecutive_idle_turns: int;
+      tool_names: string list;
+    }
   | OnError of { detail: string; context: string }
   | OnToolError of { tool_name: string; error: string }
   | PreCompact of {
@@ -150,6 +164,13 @@ type hooks = {
   post_tool_use_failure: hook option;
   on_stop: hook option;
   on_idle: hook option;
+  on_idle_escalated: hook option;
+      (** More structured replacement for [on_idle]. When present, the
+          runtime computes severity from the agent's idle thresholds and
+          calls this hook instead of [on_idle]. [skip_at] reuses
+          [Agent.options.max_idle_turns]; [final_at] comes from
+          [Agent.options.idle_final_warning_at] or defaults to
+          [max_idle_turns - 1] when possible. *)
   on_error: hook option;
   on_tool_error: hook option;
   pre_compact: hook option;
@@ -187,6 +208,7 @@ val invoke : hook option -> hook_event -> hook_decision
     post_tool_use_failure|    Y     |      |          |                  |              |
     on_stop              |    Y     |      |          |                  |              |
     on_idle              |    Y     |  Y   |          |                  |              |             |   Y
+    on_idle_escalated    |    Y     |  Y   |          |                  |              |             |   Y
     on_error             |    Y     |      |          |                  |              |
     on_tool_error        |    Y     |      |          |                  |              |
     pre_compact          |    Y     |  Y   |          |                  |              |

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -371,6 +371,26 @@ let retry_feedback_blocks ~(policy : Tool_retry_policy.t) ~(retry_count : int)
 
 (** Handle tool execution: idle detection, guardrails, context injection. *)
 let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
+  let resolved_idle_skip_at =
+    let skip_at = agent.options.max_idle_turns in
+    if skip_at > 0 then Some skip_at else None
+  in
+  let resolved_idle_final_warning_at =
+    match agent.options.idle_final_warning_at, resolved_idle_skip_at with
+    | Some n, _ when n > 0 -> Some n
+    | Some _, _ -> None
+    | None, Some skip_at when skip_at > 1 -> Some (skip_at - 1)
+    | None, _ -> None
+  in
+  let classify_idle_severity consecutive_idle_turns =
+    match resolved_idle_skip_at, resolved_idle_final_warning_at with
+    | Some skip_at, _ when consecutive_idle_turns >= skip_at ->
+        Hooks.Idle_severity.Skip
+    | _, Some final_at when consecutive_idle_turns >= final_at ->
+        Hooks.Idle_severity.Final_warning
+    | _ ->
+        Hooks.Idle_severity.Nudge
+  in
   let idle_result = Agent_turn.update_idle_detection
     ~idle_state:{
       last_tool_calls = agent.last_tool_calls;
@@ -385,14 +405,29 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
   let idle_skip = ref false in
   let idle_handled = ref false in  (* true when Nudge or Skip handled idle *)
   if idle_result.is_idle then begin
+    let tool_names = List.filter_map (function
+      | ToolUse { name; _ } -> Some name | _ -> None
+    ) tool_uses in
+    let consecutive_idle_turns = agent.consecutive_idle_turns in
     let idle_decision =
-      invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"on_idle"
-        agent.options.hooks.on_idle
-        (Hooks.OnIdle {
-          consecutive_idle_turns = agent.consecutive_idle_turns;
-          tool_names = List.filter_map (function
-            | ToolUse { name; _ } -> Some name | _ -> None
-          ) tool_uses })
+      match agent.options.hooks.on_idle_escalated with
+      | Some hook ->
+          let severity = classify_idle_severity consecutive_idle_turns in
+          invoke_hook_with_trace agent ?raw_trace_run
+            ~hook_name:"on_idle_escalated"
+            (Some hook)
+            (Hooks.OnIdleEscalated {
+               severity;
+               consecutive_idle_turns;
+               tool_names;
+             })
+      | None ->
+          invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"on_idle"
+            agent.options.hooks.on_idle
+            (Hooks.OnIdle {
+               consecutive_idle_turns;
+               tool_names;
+             })
     in
     match idle_decision with
     | Hooks.Skip ->

--- a/lib/proof_capture.ml
+++ b/lib/proof_capture.ml
@@ -178,6 +178,7 @@ let hooks st =
       Continue);
 
     on_idle = None;
+    on_idle_escalated = None;
 
     on_error = Some (fun event ->
       (match event with

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -665,6 +665,8 @@ let test_chain_multiple () =
     |> Builder.with_tool t1
     |> Builder.with_tool t2
     |> Builder.with_base_url "http://test:9090"
+    |> Builder.with_max_idle_turns 3
+    |> Builder.with_idle_final_warning_at 2
     |> Builder.with_enable_thinking true
     |> Builder.with_thinking_budget 5000
     |> Builder.build_safe |> Result.get_ok
@@ -674,6 +676,9 @@ let test_chain_multiple () =
   Alcotest.(check int) "max_turns" 3 (Agent.state agent).config.max_turns;
   Alcotest.(check int) "tool count" 2 (Tool_set.size (Agent.tools agent));
   Alcotest.(check string) "base_url" "http://test:9090" (Agent.options agent).base_url;
+  Alcotest.(check int) "max_idle_turns" 3 (Agent.options agent).max_idle_turns;
+  Alcotest.(check (option int)) "idle_final_warning_at" (Some 2)
+    (Agent.options agent).idle_final_warning_at;
   Alcotest.(check (option int)) "thinking_budget"
     (Some 5000) (Agent.state agent).config.thinking_budget
 

--- a/test/test_hooks.ml
+++ b/test/test_hooks.ml
@@ -15,7 +15,9 @@ let test_empty_hooks () =
   check bool "post_tool_use is None" true (hooks.post_tool_use = None);
   check bool "post_tool_use_failure is None" true
     (hooks.post_tool_use_failure = None);
-  check bool "on_stop is None" true (hooks.on_stop = None)
+  check bool "on_stop is None" true (hooks.on_stop = None);
+  check bool "on_idle_escalated is None" true
+    (hooks.on_idle_escalated = None)
 
 let test_invoke_none () =
   let result = Hooks.invoke None (Hooks.BeforeTurn { turn = 0; messages = [] }) in
@@ -237,6 +239,13 @@ let dummy_on_stop =
 let dummy_on_idle =
   Hooks.OnIdle { consecutive_idle_turns = 1; tool_names = ["t"] }
 
+let dummy_on_idle_escalated =
+  Hooks.OnIdleEscalated {
+    severity = Hooks.Idle_severity.Final_warning;
+    consecutive_idle_turns = 2;
+    tool_names = ["t"];
+  }
+
 let dummy_on_error =
   Hooks.OnError { detail = "d"; context = "c" }
 
@@ -297,7 +306,8 @@ let test_validate_legal_post_compact () =
 let test_validate_legal_observe_only_stages () =
   let stages = [
     "after_turn"; "post_tool_use"; "post_tool_use_failure";
-    "on_stop"; "on_idle"; "on_error"; "on_tool_error"; "post_compact";
+    "on_stop"; "on_idle"; "on_idle_escalated"; "on_error";
+    "on_tool_error"; "post_compact";
   ] in
   List.iter (fun stage ->
     let ok = Hooks.validate_decision ~stage Hooks.Continue in
@@ -344,6 +354,7 @@ let test_stage_of_event () =
     (dummy_post_tool_use_failure, "post_tool_use_failure");
     (dummy_on_stop, "on_stop");
     (dummy_on_idle, "on_idle");
+    (dummy_on_idle_escalated, "on_idle_escalated");
     (dummy_on_error, "on_error");
     (dummy_on_tool_error, "on_tool_error");
     (dummy_pre_compact, "pre_compact");
@@ -403,7 +414,8 @@ let test_all_stages_allow_continue () =
   let stages = [
     "before_turn"; "before_turn_params"; "after_turn";
     "pre_tool_use"; "post_tool_use"; "post_tool_use_failure";
-    "on_stop"; "on_idle"; "on_error"; "on_tool_error"; "pre_compact";
+    "on_stop"; "on_idle"; "on_idle_escalated"; "on_error";
+    "on_tool_error"; "pre_compact";
     "post_compact";
   ] in
   List.iter (fun stage ->

--- a/test/test_hooks_integration.ml
+++ b/test/test_hooks_integration.ml
@@ -30,6 +30,15 @@ let stateful_handler call_count _conn _req body =
   in
   Cohttp_eio.Server.respond_string ~status:`OK ~body:response_body ()
 
+let sequence_handler responses _conn _req body =
+  let _ = Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) in
+  match !responses with
+  | response_body :: rest ->
+      responses := rest;
+      Cohttp_eio.Server.respond_string ~status:`OK ~body:response_body ()
+  | [] ->
+      Cohttp_eio.Server.respond_string ~status:`OK ~body:(text_body "done") ()
+
 let text_only_handler _conn _req body =
   let _ = Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) in
   Cohttp_eio.Server.respond_string ~status:`OK ~body:(text_body "hello") ()
@@ -206,6 +215,75 @@ let test_on_stop_fires () =
      | Ok _ | Error _ -> ());
     Alcotest.(check bool) "on_stop fired" true !stop_fired)
 
+(* ── on_idle_escalated tests ─────────────────────────── *)
+
+let test_on_idle_escalated_final_warning_fires () =
+  let responses = ref [
+    tool_use_body ~tool_name:"echo" ~input_json:{|{"msg":"hi"}|};
+    tool_use_body ~tool_name:"echo" ~input_json:{|{"msg":"hi"}|};
+    text_body "done";
+  ] in
+  with_mock_server ~port:18111 (sequence_handler responses)
+    (fun ~sw ~net ~base_url ->
+      let (tool, _tool_calls) = fresh_echo_tool () in
+      let seen = ref [] in
+      let options = { Agent.default_options with
+        base_url;
+        max_idle_turns = 3;
+        idle_final_warning_at = Some 1;
+        hooks = { Hooks.empty with
+          on_idle_escalated = Some (function
+            | Hooks.OnIdleEscalated
+                {
+                  severity;
+                  consecutive_idle_turns;
+                  tool_names;
+                } ->
+                seen := (severity, consecutive_idle_turns, tool_names) :: !seen;
+                Hooks.Nudge "try a different tool"
+            | _ -> Hooks.Continue) } } in
+      let config = { default_config with max_turns = 4 } in
+      let agent = Agent.create ~net ~config ~options ~tools:[tool] () in
+      (match Agent.run ~sw agent "test" with
+       | Ok _ -> ()
+       | Error e -> Alcotest.fail (Error.to_string e));
+      match List.rev !seen with
+      | [(severity, consecutive_idle_turns, tool_names)] ->
+          Alcotest.(check string) "severity" "final_warning"
+            (Hooks.Idle_severity.to_string severity);
+          Alcotest.(check int) "idle turns" 1 consecutive_idle_turns;
+          Alcotest.(check (list string)) "tool names" ["echo"] tool_names
+      | _ ->
+          Alcotest.fail "expected exactly one on_idle_escalated callback")
+
+let test_on_idle_escalated_skip_short_circuits_execution () =
+  let responses = ref [
+    tool_use_body ~tool_name:"echo" ~input_json:{|{"msg":"hi"}|};
+    tool_use_body ~tool_name:"echo" ~input_json:{|{"msg":"hi"}|};
+  ] in
+  with_mock_server ~port:18112 (sequence_handler responses)
+    (fun ~sw ~net ~base_url ->
+      let (tool, tool_calls) = fresh_echo_tool () in
+      let seen = ref [] in
+      let options = { Agent.default_options with
+        base_url;
+        max_idle_turns = 1;
+        hooks = { Hooks.empty with
+          on_idle_escalated = Some (function
+            | Hooks.OnIdleEscalated { severity; _ } ->
+                seen := severity :: !seen;
+                Hooks.Skip
+            | _ -> Hooks.Continue) } } in
+      let config = { default_config with max_turns = 3 } in
+      let agent = Agent.create ~net ~config ~options ~tools:[tool] () in
+      match Agent.run ~sw agent "test" with
+      | Ok resp ->
+          Alcotest.(check string) "current response preserved" "m2" resp.id;
+          Alcotest.(check int) "tool executed only once" 1 !tool_calls;
+          Alcotest.(check (list string)) "skip severity seen" ["skip"]
+            (List.rev_map Hooks.Idle_severity.to_string !seen)
+      | Error e -> Alcotest.fail (Error.to_string e))
+
 (* ── multiple hooks test ─────────────────────────────── *)
 
 let test_multiple_hooks_all_fire () =
@@ -276,6 +354,12 @@ let () =
     ];
     "on_stop", [
       test_case "fires on completion" `Quick test_on_stop_fires;
+    ];
+    "on_idle_escalated", [
+      test_case "final warning severity fires" `Quick
+        test_on_idle_escalated_final_warning_fires;
+      test_case "skip short-circuits tool execution" `Quick
+        test_on_idle_escalated_skip_short_circuits_execution;
     ];
     "chaining", [
       test_case "multiple hooks all fire" `Quick test_multiple_hooks_all_fire;


### PR DESCRIPTION
## Summary
- add the on_idle_escalated hook with computed idle severity
- expose idle_final_warning_at and builder support for final-warning thresholds
- preserve legacy on_idle behavior when the new hook is unset

## Verification
- env DUNE_BUILD_DIR=/tmp/oas-build-897 dune exec --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix-oas-897-on-idle-escalated ./test/test_hooks.exe
- env DUNE_BUILD_DIR=/tmp/oas-build-897-int dune exec --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix-oas-897-on-idle-escalated ./test/test_hooks_integration.exe -- test 'on_idle_escalated' -v
- /tmp/oas-build-897-builder/default/test/test_builder.exe

## Notes
- direct execution of the full test_hooks_integration binary in this sandbox hit EPERM on loopback bind for unrelated port-based cases, so only the new on_idle_escalated subset was validated here

Closes #897