### PR TITLE
[codex] Surface stdout detail for failing CLI subprocesses

### DIFF
--- a/lib/llm_provider/cli_common_subprocess.ml
+++ b/lib/llm_provider/cli_common_subprocess.ml
@@ -35,6 +35,14 @@ let cwd_wrapper = function
 let default_on_stderr_line ~name line =
   Eio.traceln "[%s stderr] %s" name line
 
+let last_nonempty_line text =
+  text
+  |> String.split_on_char '\n'
+  |> List.fold_left
+       (fun acc line ->
+         if String.trim line = "" then acc else Some line)
+       None
+
 (** Shared core.  Always reads stdout/stderr line-by-line from the live
     pipe, always supports cooperative cancel.  [run_collect] and
     [run_stream_lines] are thin wrappers that differ only in whether
@@ -153,8 +161,13 @@ let run_core ~sw ~(mgr : _ Eio.Process.mgr) ~name ~cwd ~extra_env
     | `Exited 0 ->
       Ok { stdout = stdout_str; stderr = stderr_str; latency_ms }
     | `Exited code ->
-      let detail = if stderr_str <> "" then stderr_str
-        else Printf.sprintf "exit code %d" code in
+      let detail =
+        if stderr_str <> "" then stderr_str
+        else
+          match last_nonempty_line stdout_str with
+          | Some line -> line
+          | None -> Printf.sprintf "exit code %d" code
+      in
       Error (Http_client.NetworkError {
         message = Printf.sprintf "%s exited with code %d: %s" name code detail })
     | `Signaled sig_num ->

--- a/test/test_cli_common_subprocess.ml
+++ b/test/test_cli_common_subprocess.ml
@@ -25,8 +25,22 @@ let test_run_collect_nonzero_exit () =
           [sh; "-c"; "echo oops >&2; exit 3"] with
   | Ok _ -> Alcotest.fail "expected Error for exit 3"
   | Error (Llm_provider.Http_client.NetworkError { message }) ->
-    Alcotest.(check bool) "non-empty error message"
-      true (String.length message > 0)
+    Alcotest.(check string) "stderr detail propagated"
+      "sh exited with code 3: oops\n" message
+  | Error _ ->
+    Alcotest.fail "expected NetworkError"
+
+let test_run_collect_nonzero_exit_falls_back_to_stdout () =
+  Eio_main.run @@ fun env ->
+  let mgr = Eio.Stdenv.process_mgr env in
+  Eio.Switch.run @@ fun sw ->
+  match Llm_provider.Cli_common_subprocess.run_collect ~sw ~mgr
+          ~name:"sh" ~cwd:None ~extra_env:[]
+          [sh; "-c"; "printf 'first\\n{\"error\":\"quota\"}\\n'; exit 7"] with
+  | Ok _ -> Alcotest.fail "expected Error for exit 7"
+  | Error (Llm_provider.Http_client.NetworkError { message }) ->
+    Alcotest.(check string) "stdout fallback uses last non-empty line"
+      "sh exited with code 7: {\"error\":\"quota\"}" message
   | Error _ ->
     Alcotest.fail "expected NetworkError"
 
@@ -142,6 +156,8 @@ let () =
     [ "run_collect",
       [ Alcotest.test_case "ok"   `Quick test_run_collect_ok
       ; Alcotest.test_case "exit" `Quick test_run_collect_nonzero_exit
+      ; Alcotest.test_case "exit falls back to stdout detail"
+          `Quick test_run_collect_nonzero_exit_falls_back_to_stdout
       ; Alcotest.test_case "on_stderr_line forwards per-line"
           `Quick test_on_stderr_line_called_per_line
       ; Alcotest.test_case "scrub_env strips named parent var"


### PR DESCRIPTION
## What changed
- add a helper that extracts the last non-empty stdout line from a subprocess result
- use that stdout line as the error detail when a subprocess exits nonzero with empty stderr
- add regression coverage for stderr detail propagation and stdout fallback behavior

## Why
Some CLI failures return the useful error payload on stdout instead of stderr. Before this change, those failures collapsed to a generic exit-code message and lost the actionable detail.

## Impact
Nonzero subprocess exits now preserve the most useful available failure detail, which makes provider and transport failures easier to diagnose.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/codex-cli-error-detail`
- `/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/codex-cli-error-detail/_build/default/test/test_cli_common_subprocess.exe`