### PR TITLE
chore(test): consolidate remaining orphan test registrations (#1025)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -457,3 +457,55 @@
 (test
  (name test_skill_registry)
  (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_skill_discovery)
+ (libraries agent_sdk alcotest eio eio_main))
+
+(test
+ (name test_memory)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_memory_lt_backend)
+ (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_memory_tools)
+ (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_memory_file_backend)
+ (libraries agent_sdk alcotest eio eio_main unix))
+
+(test
+ (name test_memory_access)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_memory_coverage)
+ (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_harness_case)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_harness)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_harness_runner)
+ (libraries agent_sdk alcotest unix))
+
+(test
+ (name test_harness_deep)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_agent_auto_dump)
+ (libraries agent_sdk alcotest eio eio_main))
+
+(test
+ (name test_agent_race)
+ (libraries agent_sdk alcotest eio eio_main yojson))


### PR DESCRIPTION
## Summary
- register the remaining 13 orphan test executables in one replacement PR instead of merging 13 draft PRs that all touch `test/dune`
- keep the change scoped to `test/dune` only
- supersede #1062 #1063 #1066 #1067 #1068 #1069 #1070 #1071 #1072 #1073 #1074 #1075 #1077

## Verification
- `dune build --root . ./test/test_skill_discovery.exe ./test/test_memory.exe ./test/test_memory_lt_backend.exe ./test/test_memory_tools.exe ./test/test_memory_file_backend.exe ./test/test_memory_access.exe ./test/test_memory_coverage.exe ./test/test_harness_case.exe ./test/test_harness.exe ./test/test_harness_runner.exe ./test/test_harness_deep.exe ./test/test_agent_auto_dump.exe ./test/test_agent_race.exe`
- ran each newly registered executable directly from `./_build/default/test/*.exe` and all passed locally

## Notes
- this replaces the per-file draft queue so only one `test/dune` conflict needs to be reviewed and merged
- after merge, the superseded draft PRs should be closed rather than merged
