### PR TITLE
[codex] codex cli internal-action telemetry

### DIFF
--- a/lib/api.ml
+++ b/lib/api.ml
@@ -47,7 +47,8 @@ let patch_latency (resp : Types.api_response) (latency_ms : int)
           provider_kind = None;
           reasoning_effort = None;
           canonical_model_id = None;
-          effective_context_window = None }
+          effective_context_window = None;
+          provider_internal_action_count = None }
   in
   { resp with telemetry }
 
@@ -336,6 +337,7 @@ let%test "patch_latency overwrites existing request_latency_ms" =
     reasoning_effort = None;
     canonical_model_id = Some "claude-4-sonnet";
     effective_context_window = Some 200_000;
+    provider_internal_action_count = None;
   } in
   let resp : Types.api_response = {
     id = "r2"; model = "m"; stop_reason = Types.EndTurn;

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -34,7 +34,8 @@ let parse_response json =
       reasoning_tokens = None; request_latency_ms = 0;
       peak_memory_gb = None;
       provider_kind = None; reasoning_effort = None;
-      canonical_model_id = None; effective_context_window = None } }
+      canonical_model_id = None; effective_context_window = None;
+      provider_internal_action_count = None } }
 
 (** Build Anthropic Messages API request body from {!Provider_config.t}.
     Returns a JSON string ready for HTTP POST. *)

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -252,7 +252,8 @@ let parse_ollama_response json_str =
     Some { Types.system_fingerprint; timings; reasoning_tokens; request_latency_ms = 0;
             peak_memory_gb = None;
             provider_kind = None; reasoning_effort = None;
-            canonical_model_id = None; effective_context_window = None }
+            canonical_model_id = None; effective_context_window = None;
+            provider_internal_action_count = None }
   in
 
   Ok {

--- a/lib/llm_provider/backend_openai_parse.ml
+++ b/lib/llm_provider/backend_openai_parse.ml
@@ -181,7 +181,8 @@ let telemetry_of_openai_json json =
   Some { Types.system_fingerprint; timings; reasoning_tokens; request_latency_ms = 0;
          peak_memory_gb;
          provider_kind = None; reasoning_effort = None;
-         canonical_model_id = None; effective_context_window = None }
+         canonical_model_id = None; effective_context_window = None;
+         provider_internal_action_count = None }
 
 (** Parse an OpenAI-compatible JSON response string into an [api_response].
     Returns [Error msg] when the response body contains an API error. *)

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -119,6 +119,7 @@ let patch_telemetry (resp : Types.api_response) ~(config : Provider_config.t)
         reasoning_effort = re;
         canonical_model_id = canonical;
         effective_context_window = ctx_window;
+        provider_internal_action_count = None;
       }
   in
   { resp with telemetry }
@@ -965,6 +966,7 @@ let%test "patch_telemetry fills latency and provider on existing telemetry" =
       peak_memory_gb = None;
       provider_kind = None; reasoning_effort = None;
       canonical_model_id = None; effective_context_window = None;
+      provider_internal_action_count = None;
     };
   } in
   let patched = patch_telemetry resp ~config 42 in
@@ -976,6 +978,7 @@ let%test "patch_telemetry fills latency and provider on existing telemetry" =
               && t.reasoning_effort = Some "none"
               && t.canonical_model_id = Some "qwen3.5:9b"
               && t.effective_context_window = Some 262_144
+              && t.provider_internal_action_count = None
   | None -> false
 
 let%test "patch_telemetry creates telemetry when None" =
@@ -992,6 +995,7 @@ let%test "patch_telemetry creates telemetry when None" =
               && t.canonical_model_id = Some "gpt-4"
               && t.effective_context_window = Some 128_000
               && t.reasoning_effort = None
+              && t.provider_internal_action_count = None
   | None -> false
 
 let%test "reasoning_effort_of_config Ollama default is none" =

--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -170,7 +170,6 @@ let events_of_line line =
 
 (** Aggregate JSONL envelopes into an [api_response].  Only
     [agent_message] text contributes to [content]; the terminal
-    [turn.completed] supplies [usage]; [thread.started] supplies [id]. *)
     [turn.completed] supplies [usage]; [thread.started] supplies [id].
     [command_execution] items are counted as provider-native internal
     actions rather than surfaced as OAS tool calls. *)

--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -206,6 +206,7 @@ let parse_jsonl_result ?(model_id = "codex") lines =
         timings = None;
         reasoning_tokens = None;
         request_latency_ms = 0;
+        peak_memory_gb = None;
         provider_kind = None;
         reasoning_effort = None;
         canonical_model_id = None;

--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -140,7 +140,8 @@ let parse_usage json =
 
 (** Parse a single envelope into zero or more OAS sse_events.
     [command_execution] items do not map to an OAS concept — Codex runs
-    them transparently — so we emit no event for them. *)
+    them transparently — so we emit no event for them and track them only
+    in inference telemetry. *)
 let events_of_line line =
   try
     let json = Yojson.Safe.from_string line in
@@ -170,10 +171,14 @@ let events_of_line line =
 (** Aggregate JSONL envelopes into an [api_response].  Only
     [agent_message] text contributes to [content]; the terminal
     [turn.completed] supplies [usage]; [thread.started] supplies [id]. *)
+    [turn.completed] supplies [usage]; [thread.started] supplies [id].
+    [command_execution] items are counted as provider-native internal
+    actions rather than surfaced as OAS tool calls. *)
 let parse_jsonl_result ?(model_id = "codex") lines =
   let thread_id = ref "" in
   let texts = ref [] in
   let usage = ref None in
+  let provider_internal_action_count = ref 0 in
   List.iter (fun line ->
     try
       let json = Yojson.Safe.from_string line in
@@ -183,14 +188,34 @@ let parse_jsonl_result ?(model_id = "codex") lines =
         thread_id := Cli_common_json.member_str "thread_id" json
       | "item.completed" ->
         let item = Yojson.Safe.Util.member "item" json in
-        if Cli_common_json.member_str "type" item = "agent_message" then
-          texts := Cli_common_json.member_str "text" item :: !texts
+        (match Cli_common_json.member_str "type" item with
+         | "agent_message" ->
+           texts := Cli_common_json.member_str "text" item :: !texts
+         | "command_execution" ->
+           incr provider_internal_action_count
+         | _ -> ())
       | "turn.completed" ->
         usage := parse_usage json
       | _ -> ()
     with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ()
   ) lines;
   let content = List.rev_map (fun t -> Types.Text t) !texts in
+  let telemetry =
+    if !provider_internal_action_count > 0 then
+      Some {
+        Types.system_fingerprint = None;
+        timings = None;
+        reasoning_tokens = None;
+        request_latency_ms = 0;
+        provider_kind = None;
+        reasoning_effort = None;
+        canonical_model_id = None;
+        effective_context_window = None;
+        provider_internal_action_count = Some !provider_internal_action_count;
+      }
+    else
+      None
+  in
   if content = [] && !thread_id = "" then
     Error (Http_client.NetworkError {
       message = "no events parsed from codex output" })
@@ -200,7 +225,7 @@ let parse_jsonl_result ?(model_id = "codex") lines =
          stop_reason = Types.EndTurn;
          content;
          usage = !usage;
-         telemetry = None }
+         telemetry }
 
 (* ── Transport constructor ───────────────────────────── *)
 

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -240,6 +240,7 @@ type inference_telemetry = {
   reasoning_effort: string option;
   canonical_model_id: string option;
   effective_context_window: int option;
+  provider_internal_action_count: int option;
 }
 [@@deriving show, yojson]
 

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -137,6 +137,7 @@ type inference_telemetry = {
   reasoning_effort: string option;     (** e.g. "none", "low", "medium", "high" — as sent to provider *)
   canonical_model_id: string option;   (** Model ID used for the API request after alias resolution (e.g. "glm-4.7") *)
   effective_context_window: int option; (** Model's context window in tokens, from capabilities *)
+  provider_internal_action_count: int option; (** Telemetry-only count of provider-native actions that are not surfaced as OAS tool calls. *)
 }
 [@@deriving show, yojson]
 


### PR DESCRIPTION
## Summary
- add provider_internal_action_count to inference telemetry
- classify Codex CLI command_execution events as provider-internal actions instead of external tool calls
- initialize the new telemetry field across provider backends

## Validation
- dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/codex-tool-routing-telemetry @install