### PR TITLE
[codex] wire native structured outputs

### DIFF
--- a/lib/judge/judge.ml
+++ b/lib/judge/judge.ml
@@ -142,6 +142,7 @@ let judge ~sw ~net ~provider ~config ~context () =
     provider with
     Provider_config.temperature = Some config.temperature;
     max_tokens = Some config.max_tokens;
+    output_schema = config.output_schema;
   } in
   match
     Complete.complete ~sw ~net ~config:provider_cfg ~messages ~tools:[] ()

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -87,6 +87,18 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
           ("budget_tokens", `Int budget)]) :: body
     | _ -> body
   in
+  let body = match config.output_schema with
+    | Some schema ->
+        ("output_config",
+         `Assoc [
+           ("format",
+            `Assoc [
+              ("type", `String "json_schema");
+              ("schema", schema);
+            ]);
+         ]) :: body
+    | None -> body
+  in
   let body = match tools with
     | [] -> body
     | ts ->

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -174,12 +174,22 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
            ("includeThoughts", `Bool true);
          ]) :: !gen_config
    | _ -> ());
-  (* JSON mode *)
-  (match config.response_format with
-   | Types.JsonMode ->
+  let structured_schema =
+    match config.output_schema, config.response_format with
+    | Some schema, _ -> Some schema
+    | None, Types.JsonSchema schema -> Some schema
+    | None, Types.JsonMode | None, Types.Off -> None
+  in
+  (* JSON mode / native structured output *)
+  (match structured_schema with
+   | Some schema ->
        gen_config :=
-         ("responseMimeType", `String "application/json") :: !gen_config
-   | Types.JsonSchema _ | Types.Off -> ());
+         ("responseJsonSchema", schema)
+         :: ("responseMimeType", `String "application/json")
+         :: !gen_config
+   | None when config.response_format = Types.JsonMode ->
+       gen_config := ("responseMimeType", `String "application/json") :: !gen_config
+   | None -> ());
   let body = ("generationConfig", `Assoc !gen_config) :: body in
   (* Tools *)
   let body = match tools with

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -79,6 +79,14 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
   in
   let body = ("keep_alive", keep_alive_json) :: body in
 
+  let body =
+    match config.output_schema, config.response_format with
+    | Some schema, _ -> ("format", schema) :: body
+    | None, Types.JsonSchema schema -> ("format", schema) :: body
+    | None, Types.JsonMode -> ("format", `String "json") :: body
+    | None, Types.Off -> body
+  in
+
   let body = match tools with
     | [] -> body
     | ts ->

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -61,6 +61,33 @@ let effective_tools (config : Provider_config.t) tools =
   | Provider_config.Glm, Some None_ -> []
   | _ -> tools
 
+let structured_schema_of_config (config : Provider_config.t) =
+  match config.output_schema, config.response_format with
+  | Some schema, _ -> Some schema
+  | None, JsonSchema schema -> Some schema
+  | None, JsonMode | None, Off -> None
+
+let response_format_of_config (config : Provider_config.t) =
+  match structured_schema_of_config config with
+  | Some schema ->
+      Some
+        (`Assoc
+           [
+             ("type", `String "json_schema");
+             ( "json_schema",
+               `Assoc
+                 [
+                   ( "name",
+                     `String
+                       (Provider_config.structured_output_name_of_schema schema) );
+                   ("schema", schema);
+                   ("strict", `Bool true);
+                 ] );
+           ])
+  | None when config.response_format = JsonMode ->
+      Some (`Assoc [("type", `String "json_object")])
+  | None -> None
+
 (** Build OpenAI Chat Completions request body from {!Provider_config.t}.
     Returns a JSON string ready for HTTP POST. *)
 let build_request ?(stream=false) ~(config : Provider_config.t)
@@ -185,11 +212,9 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
     else body
   in
   let body =
-    match config.response_format with
-    | Types.JsonMode ->
-        ("response_format",
-         `Assoc [("type", `String "json_object")]) :: body
-    | Types.JsonSchema _ | Types.Off -> body
+    match response_format_of_config config with
+    | Some response_format -> ("response_format", response_format) :: body
+    | None -> body
   in
   let body =
     if stream then ("stream", `Bool true) :: body
@@ -841,6 +866,41 @@ let%test "build_request omits tool_choice when tool_choice=None" =
   match json with
   | `Assoc fields -> not (List.exists (fun (k, _) -> k = "tool_choice") fields)
   | _ -> false
+
+let%test "build_request uses json_schema response_format when output_schema is set" =
+  let schema =
+    `Assoc
+      [
+        ("title", `String "Math Response");
+        ("type", `String "object");
+        ("properties", `Assoc [("answer", `Assoc [("type", `String "string")])]);
+        ("required", `List [`String "answer"]);
+      ]
+  in
+  let config =
+    Provider_config.make ~kind:OpenAI_compat ~model_id:"gpt-4o"
+      ~base_url:"https://api.openai.com/v1" ~output_schema:schema ()
+  in
+  let body = build_request ~config ~messages:[] () |> Yojson.Safe.from_string in
+  let open Yojson.Safe.Util in
+  body |> member "response_format" |> member "type" |> to_string = "json_schema"
+  && body |> member "response_format" |> member "json_schema"
+     |> member "name" |> to_string = "math_response"
+  && body |> member "response_format" |> member "json_schema"
+     |> member "schema" = schema
+  && body |> member "response_format" |> member "json_schema"
+     |> member "strict" |> to_bool
+
+let%test "build_request prefers output_schema over json_object mode" =
+  let schema = `Assoc [("type", `String "object")] in
+  let config =
+    Provider_config.make ~kind:OpenAI_compat ~model_id:"gpt-4o"
+      ~base_url:"https://api.openai.com/v1"
+      ~response_format_json:true ~output_schema:schema ()
+  in
+  let body = build_request ~config ~messages:[] () |> Yojson.Safe.from_string in
+  let open Yojson.Safe.Util in
+  body |> member "response_format" |> member "type" |> to_string = "json_schema"
 
 let%test "supports_tool_choice_override=Some false drops tool_choice on unknown model" =
   (* Unknown model_id defaults to supports_tool_choice=true. Override

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -84,6 +84,7 @@ let anthropic_capabilities = {
   supports_reasoning = true;
   supports_extended_thinking = true;
   supports_reasoning_budget = true;
+  supports_structured_output = true;
   supports_multimodal_inputs = true;
   supports_image_input = true;
   supports_native_streaming = true;
@@ -185,7 +186,6 @@ let glm_capabilities = {
   supports_reasoning = true;
   supports_extended_thinking = true;
   supports_response_format_json = true;
-  supports_structured_output = true;
   supports_native_streaming = true;
 }
 
@@ -224,6 +224,7 @@ let claude_code_capabilities = {
   anthropic_capabilities with
   max_context_tokens = Some 1_000_000;  (* 1M context via Claude Code *)
   max_output_tokens = Some 64_000;
+  supports_structured_output = false;
   supports_computer_use = true;
   supports_code_execution = true;
 }
@@ -371,7 +372,6 @@ let for_model_id model_id =
            max_output_tokens = Some 16_384;
            supports_tools = true;
            supports_tool_choice = true;
-           supports_structured_output = true;
            supports_response_format_json = true;
            supports_native_streaming = true }
   (* GLM 5-turbo: tool-calling optimized, fast, reasoning but no extended thinking *)
@@ -382,7 +382,6 @@ let for_model_id model_id =
            supports_tools = true;
            supports_tool_choice = true;
            supports_reasoning = true;
-           supports_structured_output = true;
            supports_response_format_json = true;
            supports_native_streaming = true }
   else if starts_with "glm-5v-turbo" then
@@ -393,7 +392,6 @@ let for_model_id model_id =
            supports_tool_choice = true;
            supports_reasoning = true;
            supports_extended_thinking = true;
-           supports_structured_output = true;
            supports_response_format_json = true;
            supports_multimodal_inputs = true;
            supports_image_input = true;
@@ -426,7 +424,6 @@ let for_model_id model_id =
            supports_tool_choice = true;
            supports_reasoning = true;
            supports_extended_thinking = true;
-           supports_structured_output = true;
            supports_response_format_json = true;
            supports_native_streaming = true }
   else if starts_with "glm-4-flash" then

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -140,6 +140,11 @@ let requires_non_http_transport : Provider_config.provider_kind -> bool = functi
   | Claude_code | Gemini_cli | Codex_cli -> true
   | Anthropic | OpenAI_compat | Ollama | Gemini | Glm -> false
 
+let validate_output_schema_request (config : Provider_config.t) =
+  match Provider_config.validate_output_schema_request config with
+  | Ok () -> Ok ()
+  | Error reason -> Error (Http_client.AcceptRejected { reason })
+
 (** Strip query string and userinfo from a URL before logging.  Built-in
     providers use clean URLs, but [custom:model@url] accepts arbitrary
     user-supplied URLs; a misconfigured one like
@@ -205,6 +210,9 @@ let complete_http ~sw ~net
     ?(on_http_status : (provider:string -> model_id:string -> status:int -> unit) option)
     ~(config : Provider_config.t)
     ~(messages : Types.message list) ~tools () =
+  match validate_output_schema_request config with
+  | Error err -> (Error err, 0)
+  | Ok () ->
   if requires_non_http_transport config.kind then
     (Error (Http_client.NetworkError {
        message = Printf.sprintf "%s provider requires a transport"
@@ -481,6 +489,9 @@ let complete ~sw ~net ?(transport : Llm_transport.t option)
     ~(messages : Types.message list) ?(tools=[])
     ?(cache : Cache.t option) ?(metrics : Metrics.t option)
     ?(priority : Request_priority.t option) () =
+  match validate_output_schema_request config with
+  | Error err -> Error err
+  | Ok () ->
   let _priority = priority in
   let m = match metrics with Some m -> m | None -> Metrics.get_global () in
   let model_id = config.model_id in
@@ -550,31 +561,31 @@ let complete ~sw ~net ?(transport : Llm_transport.t option)
              ~model_id ~status:code
          | Error _ -> ());
       (match result with
-       | Ok resp ->
-           let resp = Pricing.annotate_response_cost resp in
-           let resp = patch_telemetry resp ~config latency_ms in
-           m.on_request_end ~model_id ~latency_ms;
-           (* Cache store — reuse pre-computed key *)
-           (match cache, cache_key with
-            | Some c, Some key ->
-                let json = Cache.response_to_json resp in
-                (try c.set ~key ~ttl_sec:Constants.Cache.default_ttl_sec json
-                 with Eio.Io _ | Sys_error _ -> ())
-            | _, _ -> ());
-           Ok resp
-       | Error err ->
-           let err_str = match err with
-             | Http_client.HttpError { code; _ } ->
-                 Printf.sprintf "HTTP %d" code
-             | Http_client.AcceptRejected { reason } -> reason
-             | Http_client.NetworkError { message } -> message
-             | Http_client.CliTransportRequired { kind } ->
-                 Printf.sprintf
-                   "CLI transport required for %s but none injected"
-                   kind
-           in
-           m.on_error ~model_id ~error:err_str;
-           Error err)
+      | Ok resp ->
+          let resp = Pricing.annotate_response_cost resp in
+          let resp = patch_telemetry resp ~config latency_ms in
+          m.on_request_end ~model_id ~latency_ms;
+          (* Cache store — reuse pre-computed key *)
+          (match cache, cache_key with
+          | Some c, Some key ->
+              let json = Cache.response_to_json resp in
+              (try c.set ~key ~ttl_sec:Constants.Cache.default_ttl_sec json
+               with Eio.Io _ | Sys_error _ -> ())
+          | _, _ -> ());
+          Ok resp
+      | Error err ->
+          let err_str = match err with
+            | Http_client.HttpError { code; _ } ->
+                Printf.sprintf "HTTP %d" code
+            | Http_client.AcceptRejected { reason } -> reason
+            | Http_client.NetworkError { message } -> message
+            | Http_client.CliTransportRequired { kind } ->
+                Printf.sprintf
+                  "CLI transport required for %s but none injected"
+                  kind
+          in
+          m.on_error ~model_id ~error:err_str;
+          Error err)
 
 (* ── Retry ───────────────────────────────────────────── *)
 
@@ -634,6 +645,9 @@ include Complete_stream_acc
 let complete_stream_http ~sw:_ ~net ~(config : Provider_config.t)
     ~(messages : Types.message list) ~tools
     ~(on_event : Types.sse_event -> unit) =
+  match validate_output_schema_request config with
+  | Error err -> Error err
+  | Ok () ->
   if requires_non_http_transport config.kind then
     Error (Http_client.NetworkError {
       message = Printf.sprintf "%s provider requires a transport"
@@ -743,6 +757,9 @@ let complete_stream ~sw ~net ?(transport : Llm_transport.t option)
     ~(messages : Types.message list) ?(tools=[])
     ~(on_event : Types.sse_event -> unit)
     ?(priority : Request_priority.t option) () =
+  match validate_output_schema_request config with
+  | Error err -> Error err
+  | Ok () ->
   let _priority = priority in
   let result = match transport with
   | Some t ->
@@ -823,7 +840,8 @@ let%test "gemini_url sync no api_key" =
     enable_thinking = None; thinking_budget = None;
     clear_thinking = None; tool_stream = false;
     tool_choice = None; disable_parallel_tool_use = false;
-    response_format = Types.Off; cache_system_prompt = false;
+    response_format = Types.Off; output_schema = None;
+    cache_system_prompt = false;
     supports_tool_choice_override = None;
   } in
   let url = gemini_url ~config ~stream:false in
@@ -840,7 +858,8 @@ let%test "gemini_url sync with api_key" =
     enable_thinking = None; thinking_budget = None;
     clear_thinking = None; tool_stream = false;
     tool_choice = None; disable_parallel_tool_use = false;
-    response_format = Types.Off; cache_system_prompt = false;
+    response_format = Types.Off; output_schema = None;
+    cache_system_prompt = false;
     supports_tool_choice_override = None;
   } in
   let url = gemini_url ~config ~stream:false in
@@ -857,7 +876,8 @@ let%test "gemini_url stream with api_key" =
     enable_thinking = None; thinking_budget = None;
     clear_thinking = None; tool_stream = false;
     tool_choice = None; disable_parallel_tool_use = false;
-    response_format = Types.Off; cache_system_prompt = false;
+    response_format = Types.Off; output_schema = None;
+    cache_system_prompt = false;
     supports_tool_choice_override = None;
   } in
   let url = gemini_url ~config ~stream:true in
@@ -874,7 +894,8 @@ let%test "gemini_url stream no api_key" =
     enable_thinking = None; thinking_budget = None;
     clear_thinking = None; tool_stream = false;
     tool_choice = None; disable_parallel_tool_use = false;
-    response_format = Types.Off; cache_system_prompt = false;
+    response_format = Types.Off; output_schema = None;
+    cache_system_prompt = false;
     supports_tool_choice_override = None;
   } in
   let url = gemini_url ~config ~stream:true in

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -32,6 +32,7 @@ type t = {
   tool_choice: Types.tool_choice option;
   disable_parallel_tool_use: bool;
   response_format: Types.response_format;
+  output_schema: Yojson.Safe.t option;
   cache_system_prompt: bool;
   supports_tool_choice_override: bool option;
 }
@@ -45,12 +46,20 @@ let make ~kind ~model_id ~base_url
     ?tool_choice ?(disable_parallel_tool_use=false)
     ?response_format
     ?(response_format_json=false)
+    ?output_schema
     ?(cache_system_prompt=false)
     ?supports_tool_choice_override () =
   let response_format =
-    match response_format with
-    | Some value -> value
-    | None -> Types.response_format_of_json_mode response_format_json
+    match response_format, output_schema with
+    | Some value, _ -> value
+    | None, Some schema -> Types.JsonSchema schema
+    | None, None -> Types.response_format_of_json_mode response_format_json
+  in
+  let output_schema =
+    match output_schema, response_format with
+    | Some schema, _ -> Some schema
+    | None, Types.JsonSchema schema -> Some schema
+    | None, Types.JsonMode | None, Types.Off -> None
   in
   let request_path = match request_path with
     | Some p -> p
@@ -66,7 +75,7 @@ let make ~kind ~model_id ~base_url
     max_tokens; max_context; temperature; top_p; top_k; min_p;
     system_prompt; enable_thinking; thinking_budget; clear_thinking;
     tool_stream;
-    tool_choice; disable_parallel_tool_use; response_format;
+    tool_choice; disable_parallel_tool_use; response_format; output_schema;
     cache_system_prompt; supports_tool_choice_override }
 
 (** Lowercase string representation of the wire-format kind.
@@ -107,6 +116,87 @@ let reasoning_effort_of_config (config : t) : string option =
                       ~enable_thinking:config.enable_thinking
                       ~thinking_budget:config.thinking_budget)
   | _ -> None
+
+let structured_output_name_of_schema (schema : Yojson.Safe.t) : string =
+  let default_name = "structured_output" in
+  let raw_name =
+    match schema with
+    | `Assoc fields ->
+        (match List.assoc_opt "title" fields with
+         | Some (`String s) when String.trim s <> "" -> s
+         | _ -> default_name)
+    | _ -> default_name
+  in
+  let normalized =
+    let buf = Buffer.create (String.length raw_name) in
+    let last_was_sep = ref false in
+    let push_sep () =
+      if Buffer.length buf > 0 && not !last_was_sep then begin
+        Buffer.add_char buf '_';
+        last_was_sep := true
+      end
+    in
+    String.iter (fun ch ->
+      match ch with
+      | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' ->
+          Buffer.add_char buf (Char.lowercase_ascii ch);
+          last_was_sep := false
+      | '_' | '-' ->
+          Buffer.add_char buf ch;
+          last_was_sep := true
+      | _ -> push_sep ()
+    ) raw_name;
+    Buffer.contents buf
+  in
+  let rec trim_bounds s =
+    let len = String.length s in
+    if len = 0 then default_name
+    else
+      let first = s.[0] and last = s.[len - 1] in
+      if first = '_' || first = '-' then
+        trim_bounds (String.sub s 1 (len - 1))
+      else if last = '_' || last = '-' then
+        trim_bounds (String.sub s 0 (len - 1))
+      else s
+  in
+  let trimmed = trim_bounds normalized in
+  if trimmed = "" then default_name else trimmed
+
+let openai_host_supports_output_schema base_url =
+  match Uri.of_string base_url |> Uri.host with
+  | Some host -> String.lowercase_ascii host = "api.openai.com"
+  | None -> false
+
+let validate_output_schema_request (config : t) =
+  match config.output_schema with
+  | None -> Ok ()
+  | Some _ ->
+      match config.kind with
+      | Gemini | Anthropic | Ollama -> Ok ()
+      | OpenAI_compat ->
+          let caps =
+            match Capabilities.for_model_id config.model_id with
+            | Some c -> c
+            | None -> Capabilities.default_capabilities
+          in
+          if not caps.supports_structured_output then
+            Error
+              (Printf.sprintf
+                 "model %s does not advertise native structured output"
+                 config.model_id)
+          else if openai_host_supports_output_schema config.base_url then
+            Ok ()
+          else
+            Error
+              (Printf.sprintf
+                 "native structured output is only wired for official OpenAI hosts, got %s"
+                 config.base_url)
+      | Glm ->
+          Error "GLM is currently wired for JSON mode only; native json_schema is not enabled"
+      | Claude_code | Gemini_cli | Codex_cli ->
+          Error
+            (Printf.sprintf "%s does not expose provider-native structured output in OAS"
+               (string_of_provider_kind config.kind))
 
 let has_host_prefix ~url ~prefix =
   let prefix_len = String.length prefix in

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -40,6 +40,7 @@ type t = {
   tool_choice: Types.tool_choice option;
   disable_parallel_tool_use: bool;
   response_format: Types.response_format;
+  output_schema: Yojson.Safe.t option;  (** Provider-native JSON schema output request. @since 0.163.0 *)
   cache_system_prompt: bool;
   supports_tool_choice_override: bool option;
   (** Override the registry default for [supports_tool_choice].
@@ -85,6 +86,7 @@ val make :
   ?disable_parallel_tool_use:bool ->
   ?response_format:Types.response_format ->
   ?response_format_json:bool ->
+  ?output_schema:Yojson.Safe.t ->
   ?cache_system_prompt:bool ->
   ?supports_tool_choice_override:bool ->
   unit -> t
@@ -105,6 +107,25 @@ val effort_of_thinking_config :
     Returns [None] for non-Ollama providers.
     @since 0.114.0 *)
 val reasoning_effort_of_config : t -> string option
+
+(** Derive a provider-safe schema name for native structured-output APIs
+    that require one (for example OpenAI's [json_schema.name]). *)
+val structured_output_name_of_schema : Yojson.Safe.t -> string
+
+(** Validate whether [output_schema] can be sent natively for this config.
+    Returns [Ok ()] when no schema was requested or when the provider kind
+    is wired for native schema output. Returns [Error reason] for
+    unsupported provider/model combinations so callers can fail fast
+    before making an HTTP request.
+
+    Conservative policy:
+    - [OpenAI_compat] is accepted only for official OpenAI hosts with a
+      model capability record that reports [supports_structured_output].
+    - [Gemini], [Anthropic], and [Ollama] are accepted.
+    - [Glm] and CLI kinds are rejected.
+
+    @since 0.163.0 *)
+val validate_output_schema_request : t -> (unit, string) result
 
 (** Whether the provider config points at a local loopback endpoint.
     This is the SSOT for locality checks derived from runtime configuration. *)

--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -1,11 +1,10 @@
-(** Structured output via tool_use pattern.
+(** Structured output helpers.
 
-    Anthropic does not have a native json_schema response_format.
-    Instead, we use tool_choice=Tool(name) to force the model to call a
-    specific tool, then extract the input JSON as structured output.
-
-    This module provides a typed schema + extraction function that
-    abstracts this pattern. *)
+    This module keeps the legacy tool-use helpers ([schema_to_tool_json],
+    [extract_tool_input]) for callers that still want forced tool calls,
+    but the direct extraction APIs now prefer provider-native JSON schema
+    output via {!Llm_provider.Complete}. Unsupported providers fail fast
+    instead of silently falling back to prompt-only JSON mode. *)
 
 open Types
 
@@ -24,6 +23,9 @@ let schema_to_tool_json (s : _ schema) : Yojson.Safe.t =
     ("input_schema", Types.params_to_input_schema s.params);
   ]
 
+let schema_to_json_schema (s : _ schema) : Yojson.Safe.t =
+  Types.params_to_input_schema s.params
+
 (** Extract a tool_use input JSON from an API response's content blocks.
     Returns the first ToolUse matching the schema name, or an error. *)
 let extract_tool_input ~(schema : _ schema) (content : content_block list) =
@@ -35,25 +37,77 @@ let extract_tool_input ~(schema : _ schema) (content : content_block list) =
   | Some json -> schema.parse json |> Result.map_error (fun e -> Error.Serialization (JsonParseError { detail = e }))
   | None -> Error (Error.Internal (Printf.sprintf "No tool_use block for '%s' in response" schema.name))
 
-(** Extract structured output from a prompt using the Anthropic API.
-    Forces tool_choice=Tool(schema.name), sends the prompt, and parses
-    the resulting tool_use input as the structured value.
+(** Extract structured output from the response text JSON. *)
+let extract_text_json ~(schema : _ schema) (response : api_response)
+    : ('a, Error.sdk_error) result =
+  let text =
+    response
+    |> Types.text_of_response
+    |> Llm_provider.Backend_openai.strip_json_markdown_fences
+    |> String.trim
+  in
+  if text = "" then
+    Error (Error.Serialization (JsonParseError {
+      detail = "structured output response did not contain text JSON";
+    }))
+  else
+    try
+      let json = Yojson.Safe.from_string text in
+      schema.parse json
+      |> Result.map_error (fun e ->
+        Error.Serialization (JsonParseError { detail = e }))
+    with
+    | Yojson.Json_error detail ->
+        Error (Error.Serialization (JsonParseError { detail }))
 
-    Requires Eio context (sw, net) and an agent_state for config. *)
+let sdk_error_of_http_error = function
+  | Llm_provider.Http_client.HttpError { code; body } ->
+      Error.Api (Llm_provider.Retry.classify_error ~status:code ~body)
+  | Llm_provider.Http_client.NetworkError { message } ->
+      Error.Api (Llm_provider.Retry.NetworkError { message })
+  | Llm_provider.Http_client.AcceptRejected { reason } ->
+      Error.Config (InvalidConfig { field = "output_schema"; detail = reason })
+  | Llm_provider.Http_client.CliTransportRequired { kind } ->
+      Error.Config (UnsupportedProvider {
+        detail =
+          Printf.sprintf
+            "CLI transport required for %s, but native structured output is only wired for HTTP providers"
+            kind;
+      })
+
+let provider_config_for_schema ~base_url ?provider ~config ~(schema : _ schema) () =
+  let state = {
+    config;
+    messages = [];
+    turn_count = 0;
+    usage = empty_usage;
+  } in
+  match Provider.provider_config_of_agent ~state ~base_url provider with
+  | Error _ as err -> err
+  | Ok provider_cfg ->
+      Ok {
+        provider_cfg with
+        Llm_provider.Provider_config.tool_choice = None;
+        response_format = Types.JsonSchema (schema_to_json_schema schema);
+        output_schema = Some (schema_to_json_schema schema);
+      }
+
+(** Extract structured output from a prompt using provider-native JSON
+    schema output when available. Unsupported providers fail fast. *)
 let extract ~sw ~net ?base_url ?provider ~config ~(schema : 'a schema) prompt
     : ('a, Error.sdk_error) result =
-  let config_with_tool = { config with
-    tool_choice = Some (Tool schema.name);
-  } in
-  let state = { config = config_with_tool; messages = []; turn_count = 0; usage = empty_usage } in
+  let base_url = Option.value ~default:Api.default_base_url base_url in
+  let provider_cfg_result =
+    provider_config_for_schema ~base_url ?provider ~config ~schema ()
+  in
   let messages = [{ role = User; content = [Text prompt]; name = None; tool_call_id = None }] in
-  let tools = [schema_to_tool_json schema] in
-  match Api.create_message ~sw ~net ?base_url ?provider ~config:state ~messages ~tools () with
+  match provider_cfg_result with
   | Error e -> Error e
-  | Ok response ->
-    (match extract_tool_input ~schema response.content with
-     | Ok v -> Ok v
-     | Error e -> Error e)
+  | Ok provider_cfg ->
+    (match Llm_provider.Complete.complete ~sw ~net ~config:provider_cfg
+             ~messages ~tools:[] () with
+     | Error e -> Error (sdk_error_of_http_error e)
+     | Ok response -> extract_text_json ~schema response)
 
 (* ── Extractors ────────────────────────────────────────────────── *)
 
@@ -61,7 +115,14 @@ let extract ~sw ~net ?base_url ?provider ~config ~(schema : 'a schema) prompt
     Use with {!run_structured} for Agent.t-level structured output. *)
 type 'a extractor = api_response -> ('a, string) result
 
-(** Extract a JSON value from the first text block and parse it. *)
+let schema_json_extractor (schema : 'a schema) : 'a extractor =
+  fun response ->
+    match extract_text_json ~schema response with
+    | Ok value -> Ok value
+    | Error e -> Error (Error.to_string e)
+
+(* NOTE: keep [json_extractor] / [text_extractor] for callers who parse
+   free-form responses themselves. *)
 let json_extractor (parse : Yojson.Safe.t -> 'a) : 'a extractor =
   fun resp ->
     let texts =
@@ -101,6 +162,11 @@ let run_structured ~sw ?clock agent prompt ~(extract : 'a extractor) =
      | Error detail ->
        Error (Error.Serialization (JsonParseError { detail })))
 
+let validation_feedback_message ~summary ~error_msg =
+  Printf.sprintf
+    "The previous response did not satisfy the required JSON schema.\nValidation error: %s\nPlease return only valid JSON that matches the schema.\n%s"
+    error_msg summary
+
 (** Extract structured output with validation retry (Instructor pattern).
 
     On parse/extraction failure, feeds the error message back to the LLM
@@ -120,10 +186,8 @@ let extract_with_retry ~sw ~net ?base_url ?provider ?clock
     ~config ~(schema : 'a schema) ?(max_retries=2)
     ?(on_validation_error : (int -> string -> unit) option)
     prompt : ('a retry_result, Error.sdk_error) result =
-  let config_with_tool = { config with
-    tool_choice = Some (Tool schema.name);
-  } in
-  let tools = [schema_to_tool_json schema] in
+  ignore clock;
+  let base_url = Option.value ~default:Api.default_base_url base_url in
   let add_usage acc resp_usage =
     match acc, resp_usage with
     | None, u -> u
@@ -150,110 +214,79 @@ let extract_with_retry ~sw ~net ?base_url ?provider ?clock
       Tool_retry_policy.max_retries = max_retries;
       retry_on_validation_error = true;
       retry_on_recoverable_tool_error = false;
-      feedback_style = Tool_retry_policy.Structured_tool_result;
+      feedback_style = Tool_retry_policy.Plain_error_text;
     }
   in
-  let rec attempt n acc_usage messages =
-    let state = { config = config_with_tool; messages = []; turn_count = 0;
-                  usage = empty_usage } in
-    match Api.create_message ~sw ~net ?base_url ?provider ?clock
-            ~config:state ~messages ~tools () with
-    | Error e -> Error e
-    | Ok response ->
-        let total = add_usage acc_usage response.usage in
-        match extract_tool_input ~schema response.content with
-        | Ok v -> Ok { value = v; total_usage = total; attempts = n + 1 }
-        | Error e ->
-            let error_msg = Error.to_string e in
-            let decision =
-              Tool_retry_policy.decide ~policy:retry_policy ~prior_retries:n
-                [
-                  {
-                    Tool_retry_policy.tool_name = schema.name;
-                    detail = error_msg;
-                    kind = Tool_retry_policy.Validation_error;
-                  };
-                ]
-            in
-            (match decision with
-             | Tool_retry_policy.Retry { retry_count; summary } ->
-                 (match on_validation_error with
-                  | Some cb -> cb retry_count error_msg
-                  | None -> ());
-                 let tool_use_id =
-                   List.find_map
-                     (function
-                       | ToolUse { id; name; _ } when name = schema.name ->
-                           Some id
-                       | _ -> None)
-                     response.content
-                   |> Option.value ~default:"structured_retry"
-                 in
-                 let retry_messages =
-                   [
-                     initial_message;
-                     {
-                       role = Assistant;
-                       content = response.content;
-                       name = None;
-                       tool_call_id = None;
-                     };
-                     {
-                       role = User;
-                       content =
-                         [
-                           Tool_retry_policy.structured_feedback_block
-                             ~tool_use_id ~retry_count
-                             ~max_retries:retry_policy.max_retries ~summary;
-                         ];
-                       name = None;
-                       tool_call_id = None;
-                     };
-                   ]
-                 in
-                 attempt retry_count total retry_messages
-             | Tool_retry_policy.Exhausted _
-             | Tool_retry_policy.No_retry -> Error e)
-  in
-  let initial_messages = [ initial_message ] in
-  attempt 0 None initial_messages
+  match provider_config_for_schema ~base_url ?provider ~config ~schema () with
+  | Error e -> Error e
+  | Ok provider_cfg ->
+      let rec attempt n acc_usage messages =
+        match Llm_provider.Complete.complete ~sw ~net ~config:provider_cfg
+                ~messages ~tools:[] () with
+        | Error e -> Error (sdk_error_of_http_error e)
+        | Ok response ->
+            let total = add_usage acc_usage response.usage in
+            match extract_text_json ~schema response with
+            | Ok v -> Ok { value = v; total_usage = total; attempts = n + 1 }
+            | Error e ->
+                let error_msg = Error.to_string e in
+                let decision =
+                  Tool_retry_policy.decide ~policy:retry_policy ~prior_retries:n
+                    [
+                      {
+                        Tool_retry_policy.tool_name = schema.name;
+                        detail = error_msg;
+                        kind = Tool_retry_policy.Validation_error;
+                      };
+                    ]
+                in
+                (match decision with
+                 | Tool_retry_policy.Retry { retry_count; summary } ->
+                     (match on_validation_error with
+                      | Some cb -> cb retry_count error_msg
+                      | None -> ());
+                     let retry_messages =
+                       messages @ [
+                         {
+                           role = Assistant;
+                           content = response.content;
+                           name = None;
+                           tool_call_id = None;
+                         };
+                         {
+                           role = User;
+                           content = [
+                             Text (validation_feedback_message ~summary ~error_msg);
+                           ];
+                           name = None;
+                           tool_call_id = None;
+                         };
+                       ]
+                     in
+                     attempt retry_count total retry_messages
+                 | Tool_retry_policy.Exhausted _
+                 | Tool_retry_policy.No_retry -> Error e)
+      in
+      let initial_messages = [ initial_message ] in
+      attempt 0 None initial_messages
 
 (** Extract structured output with SSE streaming.
-    Like [extract] but uses [Streaming.create_message_stream] to receive
-    incremental SSE events.  Calls [on_event] for each event.
-    Falls back to sync API + synthetic events for non-Anthropic providers. *)
+    Like [extract] but streams via {!Llm_provider.Complete.complete_stream}. *)
 let extract_stream ~sw ~net ?base_url ?provider ?clock ~config ~(schema : 'a schema)
     ~on_event prompt : ('a * api_response, Error.sdk_error) result =
-  let config_with_tool = { config with
-    tool_choice = Some (Tool schema.name);
-  } in
-  let state = { config = config_with_tool; messages = []; turn_count = 0; usage = empty_usage } in
+  ignore clock;
+  let base_url = Option.value ~default:Api.default_base_url base_url in
   let messages = [{ role = User; content = [Text prompt]; name = None; tool_call_id = None }] in
-  let tools = [schema_to_tool_json schema] in
-  let api_result =
-    let stream_result =
-      Streaming.create_message_stream ~sw ~net ?base_url ?provider
-        ~config:state ~messages ~tools ~on_event ()
-    in
-    match stream_result with
-    | Ok _ -> stream_result
-    | Error (Error.Config (UnsupportedProvider _)) ->
-        (* Non-Anthropic: fallback to sync + synthetic events *)
-        let sync_result = Api.create_message ~sw ~net ?base_url ?provider
-          ?clock ~config:state ~messages ~tools () in
-        (match sync_result with
-         | Ok response ->
-           Streaming.emit_synthetic_events response on_event;
-           Ok response
-         | Error _ -> sync_result)
-    | Error _ -> stream_result
-  in
-  match api_result with
+  match provider_config_for_schema ~base_url ?provider ~config ~schema () with
   | Error e -> Error e
-  | Ok response ->
-    (match extract_tool_input ~schema response.content with
-     | Ok value -> Ok (value, response)
-     | Error e -> Error e)
+  | Ok provider_cfg ->
+      (match Llm_provider.Complete.complete_stream ~sw ~net ~config:provider_cfg
+               ~messages ~tools:[] ~on_event () with
+       | Error e -> Error (sdk_error_of_http_error e)
+       | Ok response ->
+           match extract_text_json ~schema response with
+           | Ok value -> Ok (value, response)
+           | Error e -> Error e)
 
 [@@@coverage off]
 (* === Inline tests === *)

--- a/lib/structured.mli
+++ b/lib/structured.mli
@@ -1,7 +1,8 @@
-(** Structured output via tool_use pattern.
+(** Structured output helpers.
 
-    Uses tool_choice=Tool(name) to force the model to call a specific tool,
-    then extracts the input JSON as structured output.
+    Direct extraction prefers provider-native JSON schema output via
+    {!Llm_provider.Complete}. The legacy tool-use helpers remain available
+    for callers that still want forced tool calls.
 
     @stability Evolving
     @since 0.93.1 *)
@@ -31,6 +32,8 @@ val extract :
   schema:'a schema ->
   string ->
   ('a, Error.sdk_error) result
+(** Uses provider-native JSON schema output when the resolved provider kind
+    is wired for it. Unsupported providers fail fast. *)
 
 (** {1 Extractors} *)
 

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -4,7 +4,7 @@ open Llm_provider
 (* ── Helpers ────────────────────────────────────────── *)
 
 let gemini_config ?(thinking=false) ?(budget=10000) ?(tools=[])
-    ?(json_mode=false) ?(system="") () =
+    ?(json_mode=false) ?output_schema ?(system="") () =
   ignore tools;
   Provider_config.make
     ~kind:Gemini
@@ -17,6 +17,7 @@ let gemini_config ?(thinking=false) ?(budget=10000) ?(tools=[])
     ?enable_thinking:(if thinking then Some true else None)
     ?thinking_budget:(if thinking then Some budget else None)
     ~response_format_json:json_mode
+    ?output_schema
     ?system_prompt:(if system = "" then None else Some system)
     ()
 
@@ -153,6 +154,26 @@ let test_json_mode () =
   let gen = json |> member "generationConfig" in
   check string "responseMimeType" "application/json"
     (gen |> member "responseMimeType" |> to_string)
+
+let test_output_schema () =
+  let schema =
+    `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("answer", `Assoc [("type", `String "string")])
+      ]);
+      ("required", `List [`String "answer"]);
+    ]
+  in
+  let config = gemini_config ~output_schema:schema () in
+  let messages = [Types.user_msg "Return structured JSON."] in
+  let body = Backend_gemini.build_request ~config ~messages () in
+  let json = parse_body body in
+  let gen = json |> member "generationConfig" in
+  check string "responseMimeType" "application/json"
+    (gen |> member "responseMimeType" |> to_string);
+  check bool "responseJsonSchema copied" true
+    (gen |> member "responseJsonSchema" = schema)
 
 let test_role_mapping () =
   let config = gemini_config () in
@@ -628,6 +649,7 @@ let () =
       test_case "tools" `Quick test_tools;
       test_case "tool result" `Quick test_tool_result;
       test_case "json mode" `Quick test_json_mode;
+      test_case "output schema" `Quick test_output_schema;
       test_case "role mapping" `Quick test_role_mapping;
       test_case "tool choice" `Quick test_tool_choice_mapping;
       test_case "thinking part roundtrip" `Quick test_thinking_part_roundtrip;

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -35,6 +35,7 @@ let test_anthropic_capabilities () =
   check bool "has image" true c.supports_image_input;
   check bool "has caching" true c.supports_caching;
   check bool "has computer use" true c.supports_computer_use;
+  check bool "has structured output" true c.supports_structured_output;
   check bool "no audio" false c.supports_audio_input;
   (* Anthropic Messages API accepts top_k per its documented body
      params; pin the field so the #830/#831 capability-gated
@@ -127,7 +128,8 @@ let test_lookup_glm5_text_only () =
   match Capabilities.for_model_id "glm-5" with
   | Some c ->
     check bool "no image input" false c.supports_image_input;
-    check bool "reasoning" true c.supports_reasoning
+    check bool "reasoning" true c.supports_reasoning;
+    check bool "structured output disabled" false c.supports_structured_output
   | None -> fail "should match glm-5"
 
 let test_lookup_glm5v_vision () =

--- a/test/test_coverage_hotspots_srt.ml
+++ b/test/test_coverage_hotspots_srt.ml
@@ -1,6 +1,10 @@
 open Agent_sdk
 
 let () = Unix.putenv "OAS_ALLOW_TEST_PROVIDERS" "1"
+let () =
+  if Sys.getenv_opt "ANTHROPIC_API_KEY" = None then
+    Unix.putenv "ANTHROPIC_API_KEY" "test-mock-key"
+
 open Alcotest
 
 let runtime_path () =
@@ -67,6 +71,28 @@ let openai_text_response ?(id = "chatcmpl-1") ?(model = "mock")
                  ];
              ] );
          ("usage", response_usage ~prompt_tokens ~completion_tokens ());
+       ])
+
+let anthropic_text_response ?(id = "msg-1") ?(model = "mock")
+    ?(stop_reason = "end_turn") ?(input_tokens = 10) ?(output_tokens = 5)
+    text =
+  Yojson.Safe.to_string
+    (`Assoc
+       [
+         ("id", `String id);
+         ("type", `String "message");
+         ("role", `String "assistant");
+         ("model", `String model);
+         ("content", `List [`Assoc [("type", `String "text"); ("text", `String text)]]);
+         ("stop_reason", `String stop_reason);
+         ( "usage",
+           `Assoc
+             [
+               ("input_tokens", `Int input_tokens);
+               ("output_tokens", `Int output_tokens);
+               ("cache_creation_input_tokens", `Int 0);
+               ("cache_read_input_tokens", `Int 0);
+             ] );
        ])
 
 let openai_tool_use_response ?(id = "chatcmpl-tool") ?(model = "mock")
@@ -218,6 +244,65 @@ let openai_sse_tool_use_body ?(tool_id = "call_stream")
       "data: [DONE]\n\n";
     ]
 
+let anthropic_sse_text_body ?(id = "msg-stream") ?(model = "mock")
+    ?(input_tokens = 12) ?(output_tokens = 8) text =
+  String.concat ""
+    [
+      Printf.sprintf "event: message_start\ndata: %s\n\n"
+        (Yojson.Safe.to_string
+           (`Assoc
+              [
+                ("type", `String "message_start");
+                ( "message",
+                  `Assoc
+                    [
+                      ("id", `String id);
+                      ("model", `String model);
+                      ( "usage",
+                        `Assoc
+                          [
+                            ("input_tokens", `Int input_tokens);
+                            ("cache_creation_input_tokens", `Int 0);
+                            ("cache_read_input_tokens", `Int 0);
+                          ] );
+                    ] );
+              ]));
+      "event: content_block_start\ndata: "
+      ^ Yojson.Safe.to_string
+          (`Assoc
+             [
+               ("type", `String "content_block_start");
+               ("index", `Int 0);
+               ("content_block", `Assoc [("type", `String "text"); ("text", `String "")]);
+             ])
+      ^ "\n\n";
+      Printf.sprintf "event: content_block_delta\ndata: %s\n\n"
+        (Yojson.Safe.to_string
+           (`Assoc
+              [
+                ("type", `String "content_block_delta");
+                ("index", `Int 0);
+                ("delta", `Assoc [("type", `String "text_delta"); ("text", `String text)]);
+              ]));
+      "event: content_block_stop\ndata: "
+      ^ Yojson.Safe.to_string
+          (`Assoc
+             [
+               ("type", `String "content_block_stop");
+               ("index", `Int 0);
+             ])
+      ^ "\n\n";
+      Printf.sprintf "event: message_delta\ndata: %s\n\n"
+        (Yojson.Safe.to_string
+           (`Assoc
+              [
+                ("type", `String "message_delta");
+                ("delta", `Assoc [("stop_reason", `String "end_turn")]);
+                ("usage", `Assoc [("output_tokens", `Int output_tokens)]);
+              ]));
+      "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
+    ]
+
 let start_sequence_mock ~sw ~net ~port responses =
   let index = Atomic.make 0 in
   let handler _conn _req body =
@@ -313,15 +398,10 @@ let test_structured_extract_success () =
   Eio_main.run @@ fun env ->
   try
     Eio.Switch.run @@ fun sw ->
-    let body =
-      openai_tool_use_response ~tool_name:"extract_person"
-        ~tool_input:(`Assoc [ ("name", `String "Alice"); ("age", `Int 30) ])
-        ()
-    in
+    let body = anthropic_text_response {|{"name":"Alice","age":30}|} in
     let url = start_sequence_mock ~sw ~net:env#net ~port:21301 [ body ] in
-    let provider = local_provider url in
     match
-      Structured.extract ~sw ~net:env#net ~provider
+      Structured.extract ~sw ~net:env#net ~base_url:url
         ~config:(agent_config ()) ~schema:person_schema "extract"
     with
     | Ok (name, age) ->
@@ -335,17 +415,14 @@ let test_structured_extract_requires_tool_use () =
   Eio_main.run @@ fun env ->
   try
     Eio.Switch.run @@ fun sw ->
-    let body = openai_text_response "not structured" in
+    let body = anthropic_text_response "not structured" in
     let url = start_sequence_mock ~sw ~net:env#net ~port:21302 [ body ] in
-    let provider = local_provider url in
     match
-      Structured.extract ~sw ~net:env#net ~provider
+      Structured.extract ~sw ~net:env#net ~base_url:url
         ~config:(agent_config ()) ~schema:person_schema "extract"
     with
     | Ok _ -> fail "expected structured extraction error"
-    | Error (Error.Internal detail) ->
-        check bool "mentions missing tool_use" true
-          (contains_substring ~sub:"No tool_use block" detail);
+    | Error (Error.Serialization _) ->
         Eio.Switch.fail sw Exit
     | Error err -> fail (Error.to_string err)
   with Exit -> ()
@@ -356,21 +433,16 @@ let test_structured_extract_with_retry_success () =
     Eio.Switch.run @@ fun sw ->
     let responses =
       [
-        openai_tool_use_response ~prompt_tokens:7 ~completion_tokens:3
-          ~tool_name:"extract_person"
-          ~tool_input:(`Assoc [ ("name", `String "Bob"); ("age", `String "oops") ])
-          ();
-        openai_tool_use_response ~prompt_tokens:11 ~completion_tokens:5
-          ~tool_name:"extract_person"
-          ~tool_input:(`Assoc [ ("name", `String "Bob"); ("age", `Int 41) ])
-          ();
+        anthropic_text_response ~input_tokens:7 ~output_tokens:3
+          {|{"name":"Bob","age":"oops"}|};
+        anthropic_text_response ~input_tokens:11 ~output_tokens:5
+          {|{"name":"Bob","age":41}|};
       ]
     in
     let url = start_sequence_mock ~sw ~net:env#net ~port:21303 responses in
-    let provider = local_provider url in
     let callbacks = ref [] in
     match
-      Structured.extract_with_retry ~sw ~net:env#net ~provider
+      Structured.extract_with_retry ~sw ~net:env#net ~base_url:url
         ~config:(agent_config ()) ~schema:person_schema
         ~on_validation_error:(fun attempt detail ->
           callbacks := (attempt, detail) :: !callbacks)
@@ -395,16 +467,11 @@ let test_structured_extract_with_retry_exhausted () =
   Eio_main.run @@ fun env ->
   try
     Eio.Switch.run @@ fun sw ->
-    let body =
-      openai_tool_use_response ~tool_name:"extract_person"
-        ~tool_input:(`Assoc [ ("name", `String "Eve"); ("age", `String "bad") ])
-        ()
-    in
+    let body = anthropic_text_response {|{"name":"Eve","age":"bad"}|} in
     let url = start_sequence_mock ~sw ~net:env#net ~port:21304 [ body ] in
-    let provider = local_provider url in
     let callback_count = ref 0 in
     match
-      Structured.extract_with_retry ~sw ~net:env#net ~provider
+      Structured.extract_with_retry ~sw ~net:env#net ~base_url:url
         ~config:(agent_config ()) ~schema:person_schema ~max_retries:1
         ~on_validation_error:(fun _ _ -> incr callback_count)
         "retry fail"
@@ -438,15 +505,11 @@ let test_structured_extract_stream_success () =
   Eio_main.run @@ fun env ->
   try
     Eio.Switch.run @@ fun sw ->
-    let body =
-      openai_sse_tool_use_body
-        (`Assoc [ ("name", `String "Dana"); ("age", `Int 27) ])
-    in
+    let body = anthropic_sse_text_body {|{"name":"Dana","age":27}|} in
     let url = start_sse_mock ~sw ~net:env#net ~port:21306 body in
-    let provider = local_provider url in
     let events = ref 0 in
     match
-      Structured.extract_stream ~sw ~net:env#net ~provider
+      Structured.extract_stream ~sw ~net:env#net ~base_url:url
         ~config:(agent_config ()) ~schema:person_schema
         ~on_event:(fun _ -> incr events)
         "stream"

--- a/test/test_full_pipeline_cov.ml
+++ b/test/test_full_pipeline_cov.ml
@@ -24,6 +24,12 @@ let openai_text_response ?(id = "chatcmpl-1") text =
     {|{"id":"%s","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}|}
     id text
 
+let anthropic_text_response ?(id = "msg-1") ?(model = "mock")
+    ?(stop_reason = "end_turn") text =
+  Printf.sprintf
+    {|{"id":"%s","type":"message","role":"assistant","model":"%s","content":[{"type":"text","text":"%s"}],"stop_reason":"%s","usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}|}
+    id model text stop_reason
+
 let openai_tool_use ?(id = "chatcmpl-t") tool_name input_json =
   Printf.sprintf
     {|{"id":"%s","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"%s","arguments":"%s"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":15,"completion_tokens":10,"total_tokens":25}}|}
@@ -434,16 +440,14 @@ let test_agent_clone_run () =
      | Error e -> fail (Error.to_string e))
   with Exit -> ()
 
-(* ── 16. Structured output via tool_use pattern ───────────────── *)
+(* ── 16. Structured output via provider-native JSON schema ────── *)
 
 let test_structured_extract () =
   Eio_main.run @@ fun env ->
   try
     Eio.Switch.run @@ fun sw ->
-    let tool_resp =
-        {|{"id":"chatcmpl-s","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call_s","type":"function","function":{"name":"get_info","arguments":"{\"name\":\"test\",\"age\":25}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":10,"total_tokens":20}}|}
-    in
-    let url = start_multi ~sw ~net:env#net ~port:21016 [tool_resp] in
+    let body = anthropic_text_response {|{"name":"test","age":25}|} in
+    let url = start_multi ~sw ~net:env#net ~port:21016 [body] in
     let schema : (string * int) Structured.schema = {
       name = "get_info";
       description = "Get info";
@@ -461,12 +465,8 @@ let test_structured_extract () =
     let config = { Types.default_config with
       name = "struct-agent"; max_turns = 1;
     } in
-    let provider : Provider.config = {
-      provider = Provider.Local { base_url = url };
-      model_id = "mock"; api_key_env = "";
-    } in
     (match Structured.extract ~sw ~net:env#net ~base_url:url
-             ~provider ~config ~schema "extract" with
+             ~config ~schema "extract" with
      | Ok (name, age) ->
        check string "name" "test" name;
        check int "age" 25 age;

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -1098,6 +1098,7 @@ let test_anthropic_capabilities () =
   Alcotest.(check bool) "parallel tools" true c.supports_parallel_tool_calls;
   Alcotest.(check bool) "reasoning" true c.supports_reasoning;
   Alcotest.(check bool) "extended_thinking" true c.supports_extended_thinking;
+  Alcotest.(check bool) "structured output" true c.supports_structured_output;
   Alcotest.(check bool) "multimodal" true c.supports_multimodal_inputs;
   Alcotest.(check bool) "streaming" true c.supports_native_streaming;
   Alcotest.(check bool) "caching" true c.supports_caching;
@@ -1142,6 +1143,7 @@ let test_glm_capabilities () =
      Regression guard added after 2026-04-18 incident (8+ violations in
      a single MASC session against glm-5-turbo / glm-4.7 / glm-5.1). *)
   Alcotest.(check bool) "supports_tool_choice relaxed" false c.supports_tool_choice;
+  Alcotest.(check bool) "structured output disabled" false c.supports_structured_output;
   Alcotest.(check (option int)) "200K context" (Some 200_000) c.max_context_tokens;
   Alcotest.(check (option int)) "40960 output cap" (Some 40_960) c.max_output_tokens
 

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -3,7 +3,18 @@
 module PC = Llm_provider.Provider_config
 module BA = Llm_provider.Backend_anthropic
 module BO = Llm_provider.Backend_openai
+module BOL = Llm_provider.Backend_ollama
 open Llm_provider.Types
+
+let contains_substring ~sub text =
+  let sub_len = String.length sub in
+  let text_len = String.length text in
+  let rec loop idx =
+    if idx + sub_len > text_len then false
+    else if String.sub text idx sub_len = sub then true
+    else loop (idx + 1)
+  in
+  if sub_len = 0 then true else loop 0
 
 (* ── Anthropic build_request ─────────────────────────── *)
 
@@ -53,6 +64,24 @@ let test_anthropic_stream_flag () =
   let open Yojson.Safe.Util in
   Alcotest.(check bool) "stream" true
     (json |> member "stream" |> to_bool)
+
+let test_anthropic_output_schema () =
+  let schema =
+    `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [("answer", `Assoc [("type", `String "string")])]);
+      ("required", `List [`String "answer"]);
+    ]
+  in
+  let config = PC.make ~kind:Anthropic ~model_id:"claude-sonnet-4-6"
+    ~base_url:"" ~output_schema:schema () in
+  let body = BA.build_request ~config ~messages:[user_msg "hi"] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "output_config type" "json_schema"
+    (json |> member "output_config" |> member "format" |> member "type" |> to_string);
+  Alcotest.(check bool) "schema copied" true
+    (json |> member "output_config" |> member "format" |> member "schema" = schema)
 
 let test_anthropic_parse_response_initializes_telemetry () =
   let json = Yojson.Safe.from_string {|{
@@ -127,6 +156,22 @@ let test_openai_stream_flag () =
   let open Yojson.Safe.Util in
   Alcotest.(check bool) "stream" true
     (json |> member "stream" |> to_bool)
+
+let test_ollama_output_schema () =
+  let schema =
+    `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [("answer", `Assoc [("type", `String "string")])]);
+      ("required", `List [`String "answer"]);
+    ]
+  in
+  let config = PC.make ~kind:Ollama ~model_id:"qwen3.5:9b"
+    ~base_url:"http://localhost:11434" ~output_schema:schema () in
+  let body = BOL.build_request ~config ~messages:[user_msg "hi"] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  Alcotest.(check bool) "format copied" true
+    (json |> member "format" = schema)
 
 (* ── Provider_config.make ────────────────────────────── *)
 
@@ -221,6 +266,22 @@ let test_complete_claude_code_without_transport_is_guarded () =
           "%s expected CliTransportRequired, got AcceptRejected: %s"
           expected_name reason
   ) kinds
+
+let test_complete_rejects_output_schema_for_glm () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let config = PC.make ~kind:Glm ~model_id:"glm-5"
+    ~base_url:"https://api.z.ai/api/coding/paas/v4"
+    ~output_schema:(`Assoc [("type", `String "object")]) () in
+  match Llm_provider.Complete.complete ~sw ~net ~config
+          ~messages:[user_msg "hi"] () with
+  | Error (Llm_provider.Http_client.AcceptRejected { reason }) ->
+      Alcotest.(check bool) "mentions glm json mode" true
+        (contains_substring ~sub:"json mode only"
+           (String.lowercase_ascii reason))
+  | Ok _ -> Alcotest.fail "expected AcceptRejected for glm output_schema"
+  | Error _ -> Alcotest.fail "expected AcceptRejected for glm output_schema"
 
 let test_annotate_response_cost () =
   let response : api_response = {
@@ -358,6 +419,7 @@ let () =
       test_case "basic body" `Quick test_anthropic_basic_body;
       test_case "with system" `Quick test_anthropic_with_system;
       test_case "with thinking" `Quick test_anthropic_with_thinking;
+      test_case "with output schema" `Quick test_anthropic_output_schema;
       test_case "stream flag" `Quick test_anthropic_stream_flag;
       test_case "parse response initializes telemetry" `Quick
         test_anthropic_parse_response_initializes_telemetry;
@@ -367,6 +429,7 @@ let () =
       test_case "with system" `Quick test_openai_with_system;
       test_case "with tools" `Quick test_openai_with_tools;
       test_case "stream flag" `Quick test_openai_stream_flag;
+      test_case "ollama output schema" `Quick test_ollama_output_schema;
     ];
     "provider_config", [
       test_case "default paths" `Quick test_config_default_paths;
@@ -379,6 +442,8 @@ let () =
     "cli_transport_guard", [
       test_case "complete refuses HTTP fallback for CLI kinds"
         `Quick test_complete_claude_code_without_transport_is_guarded;
+      test_case "glm output schema rejected before request"
+        `Quick test_complete_rejects_output_schema_for_glm;
     ];
     "cost", [
       test_case "annotate response cost" `Quick test_annotate_response_cost;

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -27,6 +27,7 @@ let test_make_defaults () =
   check_bool "tool_choice None" true (cfg.tool_choice = None);
   check_bool "no parallel tool use" false cfg.disable_parallel_tool_use;
   check_bool "response format off" true (cfg.response_format = Types.Off);
+  check_bool "no output schema" true (Option.is_none cfg.output_schema);
   check_bool "no cache system prompt" false cfg.cache_system_prompt
 
 (* ── make: request_path per kind ──────────────────────── *)
@@ -80,6 +81,7 @@ let test_make_with_all_options () =
     ~tool_stream:true
     ~disable_parallel_tool_use:true
     ~response_format_json:true
+    ~output_schema:(`Assoc [("type", `String "object")])
     ~cache_system_prompt:true () in
   check_string "api_key" "sk-test" cfg.api_key;
   check_bool "max_tokens" true (cfg.max_tokens = Some 2048);
@@ -93,8 +95,32 @@ let test_make_with_all_options () =
   check_bool "clear_thinking" true (cfg.clear_thinking = Some false);
   check_bool "tool_stream" true cfg.tool_stream;
   check_bool "disable_parallel" true cfg.disable_parallel_tool_use;
-  check_bool "json mode" true (cfg.response_format = Types.JsonMode);
+  let expected_schema = `Assoc [("type", `String "object")] in
+  check_bool "json schema mode" true
+    (cfg.response_format = Types.JsonSchema expected_schema);
+  check_bool "has output schema" true (Option.is_some cfg.output_schema);
   check_bool "cache prompt" true cfg.cache_system_prompt
+
+let test_validate_output_schema_openai_official () =
+  let cfg = Provider_config.make ~kind:OpenAI_compat
+    ~model_id:"gpt-4o" ~base_url:"https://api.openai.com/v1"
+    ~output_schema:(`Assoc [("type", `String "object")]) () in
+  check_bool "official openai accepted" true
+    (Result.is_ok (Provider_config.validate_output_schema_request cfg))
+
+let test_validate_output_schema_openai_compat_rejected () =
+  let cfg = Provider_config.make ~kind:OpenAI_compat
+    ~model_id:"gpt-4o" ~base_url:"https://openrouter.ai/api/v1"
+    ~output_schema:(`Assoc [("type", `String "object")]) () in
+  check_bool "generic compat rejected" true
+    (Result.is_error (Provider_config.validate_output_schema_request cfg))
+
+let test_validate_output_schema_glm_rejected () =
+  let cfg = Provider_config.make ~kind:Glm
+    ~model_id:"glm-5" ~base_url:"https://api.z.ai/api/coding/paas/v4"
+    ~output_schema:(`Assoc [("type", `String "object")]) () in
+  check_bool "glm rejected" true
+    (Result.is_error (Provider_config.validate_output_schema_request cfg))
 
 (* ── make: headers default ────────────────────────────── *)
 
@@ -158,6 +184,14 @@ let () =
     "explicit_values", [
       Alcotest.test_case "all options" `Quick test_make_with_all_options;
       Alcotest.test_case "custom headers" `Quick test_custom_headers;
+    ];
+    "output_schema", [
+      Alcotest.test_case "official openai" `Quick
+        test_validate_output_schema_openai_official;
+      Alcotest.test_case "generic compat rejected" `Quick
+        test_validate_output_schema_openai_compat_rejected;
+      Alcotest.test_case "glm rejected" `Quick
+        test_validate_output_schema_glm_rejected;
     ];
     "locality", [
       Alcotest.test_case "loopback ip" `Quick test_is_local_loopback_ip;


### PR DESCRIPTION
## Summary
- wire provider-native structured output schema support through provider config and complete flow
- add native serializer paths for OpenAI, Gemini, Anthropic, and Ollama
- fail fast for unsupported native schema providers and update structured-output tests

## Validation
- dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/feat/structured-native
- dune runtest --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/feat/structured-native lib lib/llm_provider
- ./_build/default/test/test_provider_complete.exe
- ./_build/default/test/test_structured.exe
- ./_build/default/test/test_context_intent.exe
- ./_build/default/test/test_provider.exe
- git diff --check