### PR TITLE
feat: preserve GLM provider identity for coding-plan cascades

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -124,18 +124,6 @@ let patch_telemetry (resp : Types.api_response) ~(config : Provider_config.t)
   in
   { resp with telemetry }
 
-(** Internal helper: canonical provider name for metric labels.
-    Kept in sync with the log tag used by the [WARN Complete] line. *)
-let provider_name_of_kind : Provider_config.provider_kind -> string = function
-  | Ollama -> "ollama"
-  | Anthropic -> "anthropic"
-  | OpenAI_compat -> "openai"
-  | Gemini -> "gemini"
-  | Glm -> "glm"
-  | Claude_code -> "claude_code"
-  | Gemini_cli -> "gemini_cli"
-  | Codex_cli -> "codex_cli"
-
 let requires_non_http_transport : Provider_config.provider_kind -> bool = function
   | Claude_code | Gemini_cli | Codex_cli -> true
   | Anthropic | OpenAI_compat | Ollama | Gemini | Glm -> false
@@ -219,10 +207,11 @@ let complete_http ~sw ~net
          (Provider_config.string_of_provider_kind config.kind) }),
      0)
   else
+  let provider_name = Provider_registry.provider_name_of_config config in
   let emit_status code =
     match on_http_status with
     | Some cb ->
-      cb ~provider:(provider_name_of_kind config.kind)
+      cb ~provider:provider_name
         ~model_id:config.model_id ~status:code
     | None -> ()
   in
@@ -257,7 +246,7 @@ let complete_http ~sw ~net
     Diag.error "complete"
       "pre-flight: unbalanced JSON body (%d bytes, first=%C last=%C) for %s %s — request blocked"
       body_len body_str.[0] body_str.[body_len - 1]
-      (provider_name_of_kind config.kind) config.model_id;
+      provider_name config.model_id;
     (* Fail-closed: do not send a body the provider will reject.
        Previously this was WARN-and-continue, which let malformed
        payloads through to produce cryptic server-side errors
@@ -280,7 +269,7 @@ let complete_http ~sw ~net
     |> Option.value ~default:""
     |> String.lowercase_ascii
   in
-  let provider_label = provider_name_of_kind config.kind in
+  let provider_label = provider_name in
   (match debug_request_body with
    | "full" ->
      let ts = Printf.sprintf "%.0f" (Unix.gettimeofday () *. 1000.0) in
@@ -358,7 +347,6 @@ let complete_http ~sw ~net
         else begin
           (* Log request body diagnostics on error responses to help debug
              Ollama "closing '}' symbol" and similar body-rejection errors. *)
-          let provider_name = provider_name_of_kind config.kind in
           if code >= 400 then begin
             (* Strong validation: round-trip parse the body we sent.  The
                cheap balanced=true check only inspects first/last char and
@@ -534,7 +522,7 @@ let complete ~sw ~net ?(transport : Llm_transport.t option)
              URL.  Fail fast with a dedicated variant so cascades and
              downstream consumers can distinguish a wiring bug from a
              transient network failure. *)
-          let kind = provider_name_of_kind config.kind in
+          let kind = Provider_registry.provider_name_of_config config in
           { Llm_transport.response =
               Error (Http_client.CliTransportRequired { kind });
             latency_ms = 0 }
@@ -553,11 +541,11 @@ let complete ~sw ~net ?(transport : Llm_transport.t option)
          match result with
          | Ok _ ->
            m.on_http_status
-             ~provider:(provider_name_of_kind config.kind)
+             ~provider:(Provider_registry.provider_name_of_config config)
              ~model_id ~status:200
          | Error (Http_client.HttpError { code; _ }) ->
            m.on_http_status
-             ~provider:(provider_name_of_kind config.kind)
+             ~provider:(Provider_registry.provider_name_of_config config)
              ~model_id ~status:code
          | Error _ -> ());
       (match result with
@@ -768,7 +756,7 @@ let complete_stream ~sw ~net ?(transport : Llm_transport.t option)
     (* Same rationale as the sync [complete] guard: CLI kinds have
        [base_url = ""] and must not reach cohttp-eio. *)
     Error (Http_client.CliTransportRequired {
-      kind = provider_name_of_kind config.kind })
+      kind = Provider_registry.provider_name_of_config config })
   | None ->
     complete_stream_http ~sw ~net ~config ~messages ~tools ~on_event
   in

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -252,6 +252,19 @@ let siliconflow_defaults = {
   request_path = "/chat/completions";
 }
 
+let normalize_url value =
+  let trimmed = String.trim value in
+  if trimmed = "" then trimmed
+  else
+    let rec strip_trailing_slash s =
+      let len = String.length s in
+      if len > 1 && s.[len - 1] = '/' then
+        strip_trailing_slash (String.sub s 0 (len - 1))
+      else
+        s
+    in
+    strip_trailing_slash trimmed
+
 let default () =
   let t = create () in
   let max_context_from_capabilities ~default caps =
@@ -342,3 +355,31 @@ let default () =
                capabilities = Capabilities.codex_cli_capabilities;
                is_available = codex_cli_available };
   t
+
+let provider_name_of_config (config : Provider_config.t) =
+  match config.kind with
+  | Anthropic -> "claude"
+  | Gemini -> "gemini"
+  | Glm ->
+      if Zai_catalog.is_coding_base_url config.base_url then "glm-coding"
+      else "glm"
+  | Claude_code -> "claude_code"
+  | Gemini_cli -> "gemini_cli"
+  | Codex_cli -> "codex_cli"
+  | Ollama -> "ollama"
+  | OpenAI_compat ->
+      if Provider_config.is_local config then
+        "llama"
+      else
+        let request_path = String.trim config.request_path in
+        let base_url = normalize_url config.base_url in
+        let registry = default () in
+        match
+          all registry
+          |> List.find_opt (fun (entry : entry) ->
+                 entry.defaults.kind = config.kind
+                 && String.equal (normalize_url entry.defaults.base_url) base_url
+                 && String.equal (String.trim entry.defaults.request_path) request_path)
+        with
+        | Some entry -> entry.name
+        | None -> "openai"

--- a/lib/llm_provider/provider_registry.mli
+++ b/lib/llm_provider/provider_registry.mli
@@ -62,6 +62,14 @@ val command_in_path : ?path:string -> string -> bool
     and PATH discovery for CLI transports. *)
 val default : unit -> t
 
+(** Best-effort canonical provider name for a concrete provider config.
+    Unlike [Provider_config.string_of_provider_kind], this keeps
+    registry-level distinctions that share a wire kind but differ by
+    endpoint (for example [glm] vs [glm-coding], or [openai] vs
+    [openrouter]). Falls back to a stable kind-derived label when the
+    config does not match a known registry entry exactly. *)
+val provider_name_of_config : Provider_config.t -> string
+
 (** Initial LLM_ENDPOINTS URLs parsed from the environment at module load.
     For current active endpoints, use [active_llama_endpoints]. *)
 val llama_all_endpoints : string list

--- a/lib/llm_provider/zai_catalog.ml
+++ b/lib/llm_provider/zai_catalog.ml
@@ -84,7 +84,7 @@ let glm_auto_models () =
 let glm_coding_auto_models () =
   match Sys.getenv_opt "ZAI_CODING_AUTO_MODELS" with
   | Some v when String.trim v <> "" -> split_csv v
-  | _ -> [ "glm-4.7"; "glm-5-turbo"; "glm-5.1"; "glm-4.5-air" ]
+  | _ -> [ "glm-5.1"; "glm-5"; "glm-5-turbo"; "glm-4.7"; "glm-4.5-air" ]
 
 let resolve_glm_alias ~default_model model_id =
   match String.lowercase_ascii model_id with

--- a/lib/provider_bridge.ml
+++ b/lib/provider_bridge.ml
@@ -38,7 +38,7 @@ let resolve_glm_model_id model_id =
 
 let resolve_glm_coding_model_id model_id =
   Llm_provider.Zai_catalog.resolve_glm_coding_alias
-    ~default_model:(env_or "glm-4.7" "ZAI_CODING_DEFAULT_MODEL")
+    ~default_model:(env_or "glm-5.1" "ZAI_CODING_DEFAULT_MODEL")
     model_id
 
 let resolve_auto_model_id provider_name model_id =

--- a/test/dune
+++ b/test/dune
@@ -31,6 +31,14 @@
  (libraries llm_provider alcotest unix))
 
 (test
+ (name test_provider_config)
+ (libraries llm_provider alcotest))
+
+(test
+ (name test_provider_bridge)
+ (libraries agent_sdk llm_provider alcotest unix))
+
+(test
  (name test_types)
  (libraries agent_sdk alcotest))
 

--- a/test/test_provider_bridge.ml
+++ b/test/test_provider_bridge.ml
@@ -113,6 +113,12 @@ let test_zai_coding_auto_uses_coding_default_model () =
           Alcotest.(check string) "coding auto model" "glm-4.5-air"
             cfg.model_id))
 
+let test_zai_coding_auto_models_default_order () =
+  with_env "ZAI_CODING_AUTO_MODELS" "" (fun () ->
+    Alcotest.(check (list string)) "coding auto order"
+      [ "glm-5.1"; "glm-5"; "glm-5-turbo"; "glm-4.7"; "glm-4.5-air" ]
+      (Llm_provider.Zai_catalog.glm_coding_auto_models ()))
+
 let () =
   let open Alcotest in
   run "provider_bridge" [
@@ -126,5 +132,7 @@ let () =
         test_zai_glm_becomes_glm_provider_config;
       test_case "zai coding auto uses coding default model" `Quick
         test_zai_coding_auto_uses_coding_default_model;
+      test_case "zai coding auto models default order" `Quick
+        test_zai_coding_auto_models_default_order;
     ];
   ]

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -165,6 +165,35 @@ let test_is_local_localhost_query_true () =
     ~model_id:"m" ~base_url:"http://localhost?foo=bar" () in
   check_bool "localhost query is local" true (Provider_config.is_local cfg)
 
+(* ── provider_name_of_config ─────────────────────────── *)
+
+let test_provider_name_of_config_glm_general () =
+  let cfg = Provider_config.make ~kind:Glm
+    ~model_id:"glm-5.1" ~base_url:Zai_catalog.general_base_url () in
+  check_string "glm general" "glm"
+    (Provider_registry.provider_name_of_config cfg)
+
+let test_provider_name_of_config_glm_coding () =
+  let cfg = Provider_config.make ~kind:Glm
+    ~model_id:"glm-5.1" ~base_url:Zai_catalog.coding_base_url () in
+  check_string "glm coding" "glm-coding"
+    (Provider_registry.provider_name_of_config cfg)
+
+let test_provider_name_of_config_local_openai_compat () =
+  let cfg = Provider_config.make ~kind:OpenAI_compat
+    ~model_id:"local-model" ~base_url:"http://127.0.0.1:8085" () in
+  check_string "local openai compat resolves to llama" "llama"
+    (Provider_registry.provider_name_of_config cfg)
+
+let test_provider_name_of_config_openrouter () =
+  let cfg = Provider_config.make ~kind:OpenAI_compat
+    ~model_id:"openai/gpt-oss-20b"
+    ~base_url:"https://openrouter.ai/api/v1"
+    ~request_path:"/chat/completions"
+    () in
+  check_string "openrouter" "openrouter"
+    (Provider_registry.provider_name_of_config cfg)
+
 (* ── Suite ────────────────────────────────────────────── *)
 
 let () =
@@ -200,5 +229,15 @@ let () =
       Alcotest.test_case "host boundary false" `Quick test_is_local_host_boundary_false;
       Alcotest.test_case "localhost query true" `Quick
         test_is_local_localhost_query_true;
+    ];
+    "provider_name", [
+      Alcotest.test_case "glm general" `Quick
+        test_provider_name_of_config_glm_general;
+      Alcotest.test_case "glm coding" `Quick
+        test_provider_name_of_config_glm_coding;
+      Alcotest.test_case "local openai compat" `Quick
+        test_provider_name_of_config_local_openai_compat;
+      Alcotest.test_case "openrouter" `Quick
+        test_provider_name_of_config_openrouter;
     ];
   ]


### PR DESCRIPTION
## Summary
- add `Provider_registry.provider_name_of_config` so concrete configs keep endpoint-distinct provider identity
- keep `glm` and `glm-coding` distinct in llm completion/status paths
- align `glm-coding:auto` defaults with the coding-plan order and cover it with tests

## Testing
- dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/codex-glm-coding-plan-cascade test/test_provider_config.exe test/test_provider_bridge.exe
- /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/codex-glm-coding-plan-cascade/_build/default/test/test_provider_config.exe
- /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/codex-glm-coding-plan-cascade/_build/default/test/test_provider_bridge.exe

## Notes
- companion `masc-mcp` draft PR will pin to this branch SHA and consume the new helper