### PR TITLE
[codex] honor explicit tool error classes in retry policy

### DIFF
--- a/examples/codegen_agent.ml
+++ b/examples/codegen_agent.ml
@@ -28,7 +28,13 @@ let typecheck_tool =
     (fun args ->
       let open Yojson.Safe.Util in
       match args |> member "code" |> to_string_option with
-      | None -> Error { message = "missing code parameter"; recoverable = false }
+      | None ->
+          Error
+            {
+              message = "missing code parameter";
+              recoverable = false;
+              error_class = None;
+            }
       | Some code ->
         let tmp = Filename.temp_file "codegen" ".ml" in
         let oc = open_out tmp in
@@ -59,7 +65,13 @@ let format_tool =
     (fun args ->
       let open Yojson.Safe.Util in
       match args |> member "code" |> to_string_option with
-      | None -> Error { message = "missing code parameter"; recoverable = false }
+      | None ->
+          Error
+            {
+              message = "missing code parameter";
+              recoverable = false;
+              error_class = None;
+            }
       | Some code ->
         let tmp = Filename.temp_file "codegen" ".ml" in
         let oc = open_out tmp in
@@ -91,7 +103,13 @@ let write_file_tool =
       let code = args |> member "code" |> to_string in
       (* Reject path traversal attempts *)
       if String.contains path '\000' || (String.length path > 2 && String.sub path 0 2 = "..") || (try ignore (Str.search_forward (Str.regexp_string "/../") path 0); true with Not_found -> false) then
-        Error { message = Printf.sprintf "Rejected path: %s (path traversal)" path; recoverable = false }
+        Error
+          {
+            message =
+              Printf.sprintf "Rejected path: %s (path traversal)" path;
+            recoverable = false;
+            error_class = None;
+          }
       else
       (try
         let oc = open_out path in
@@ -99,7 +117,14 @@ let write_file_tool =
         close_out oc;
         Ok { content = Printf.sprintf "Written %d bytes to %s" (String.length code) path }
       with exn ->
-        Error { message = Printf.sprintf "Failed to write %s: %s" path (Printexc.to_string exn); recoverable = true }))
+        Error
+          {
+            message =
+              Printf.sprintf "Failed to write %s: %s" path
+                (Printexc.to_string exn);
+            recoverable = true;
+            error_class = None;
+          }))
 
 (* ── System prompt ─────────────────────────────────────────── *)
 

--- a/examples/error_handling.ml
+++ b/examples/error_handling.ml
@@ -29,8 +29,12 @@ let fragile_tool =
        if Sys.file_exists path then
          Ok { content = Printf.sprintf "Contents of %s: [data]" path }
        else
-         Error { message = Printf.sprintf "File not found: %s" path;
-                 recoverable = true })
+         Error
+           {
+             message = Printf.sprintf "File not found: %s" path;
+             recoverable = true;
+             error_class = None;
+           })
 
 (* ── Error logging hook ──────────────────────────────── *)
 

--- a/examples/review_agent.ml
+++ b/examples/review_agent.ml
@@ -44,7 +44,8 @@ let get_pr_info_tool =
       match run_gh_command ["pr"; "view"; pr_num; "--repo"; repo;
         "--json"; "title,body,additions,deletions,changedFiles,labels"] with
       | Ok output -> Ok { content = output }
-      | Error msg -> Error { message = msg; recoverable = true })
+      | Error msg ->
+          Error { message = msg; recoverable = true; error_class = None })
 
 let get_pr_diff_tool =
   Tool.create ~name:"get_pr_diff"
@@ -60,7 +61,8 @@ let get_pr_diff_tool =
       let repo = args |> member "repo" |> to_string in
       let pr_num = args |> member "pr_number" |> to_string in
       (match run_gh_command ["pr"; "diff"; pr_num; "--repo"; repo] with
-      | Error msg -> Error { message = msg; recoverable = true }
+      | Error msg ->
+          Error { message = msg; recoverable = true; error_class = None }
       | Ok output ->
       let filtered = match args |> member "file_filter" |> to_string_option with
         | None -> output
@@ -111,7 +113,8 @@ let post_review_tool =
       Sys.remove tmp;
       match result with
       | Ok output -> Ok { content = Printf.sprintf "Review posted. %s" (String.trim output) }
-      | Error msg -> Error { message = msg; recoverable = true })
+      | Error msg ->
+          Error { message = msg; recoverable = true; error_class = None })
 
 (* ── System prompt ─────────────────────────────────────────── *)
 

--- a/examples/tool_use.ml
+++ b/examples/tool_use.ml
@@ -30,7 +30,13 @@ let calculator_tool =
       let open Yojson.Safe.Util in
       match args |> member "expression" |> to_string_option with
       | Some expr -> Ok { Types.content = Printf.sprintf "Result of '%s': 42" expr }
-      | None -> Error { Types.message = "missing 'expression' parameter"; recoverable = true })
+      | None ->
+          Error
+            {
+              Types.message = "missing 'expression' parameter";
+              recoverable = true;
+              error_class = None;
+            })
 
 let counter_tool =
   Tool.create_with_context ~name:"counter"

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -18,6 +18,7 @@ type tool_execution_result = {
   content: string;
   is_error: bool;
   failure_kind: tool_failure_kind option;
+  error_class: Types.tool_error_class option;
 }
 
 type scheduled_tool_use = {
@@ -206,6 +207,7 @@ let find_and_execute_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tra
         content = msg;
         is_error = true;
         failure_kind = Some Validation_error;
+        error_class = Some Types.Deterministic;
       }
     | Ok coerced_input ->
     let t0 = Unix.gettimeofday () in
@@ -253,15 +255,15 @@ let find_and_execute_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tra
               (Hooks.OnToolError { tool_name = name; error = message })
             : Hooks.hook_decision)
      | Ok _ -> ());
-    let content, is_error, failure_kind = match result with
-      | Ok { content } -> (content, false, None)
-      | Error { message; recoverable } ->
+    let content, is_error, failure_kind, error_class = match result with
+      | Ok { content } -> (content, false, None, None)
+      | Error { message; recoverable; error_class } ->
           let failure_kind =
             Some
               (if recoverable then Recoverable_tool_error
                else Non_retryable_tool_error)
           in
-          (message, true, failure_kind)
+          (message, true, failure_kind, error_class)
     in
     {
       tool_use_id = id;
@@ -269,6 +271,7 @@ let find_and_execute_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tra
       content;
       is_error;
       failure_kind;
+      error_class;
     }
     end (* Tool_middleware validation match *)
   | None ->
@@ -291,6 +294,7 @@ let find_and_execute_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tra
         content = "Tool not found";
         is_error = true;
         failure_kind = Some Non_retryable_tool_error;
+        error_class = Some Types.Deterministic;
       }
   in
   (* ToolCompleted event *)
@@ -304,6 +308,7 @@ let find_and_execute_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus ~tra
            {
              message = output_content;
              recoverable = recoverable_of_failure_kind result.failure_kind;
+             error_class = result.error_class;
            }
        else Ok { content = output_content }
      in
@@ -361,6 +366,7 @@ let execute_scheduled_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus
                 content = "Tool execution skipped by hook";
                 is_error = false;
                 failure_kind = None;
+                error_class = None;
               }
           | Hooks.Override value ->
               {
@@ -369,6 +375,7 @@ let execute_scheduled_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus
                 content = value;
                 is_error = false;
                 failure_kind = None;
+                error_class = None;
               }
           | Hooks.ApprovalRequired -> (
               match approval with
@@ -394,6 +401,7 @@ let execute_scheduled_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus
                         content = "Tool rejected: " ^ reason;
                         is_error = true;
                         failure_kind = Some Non_retryable_tool_error;
+                        error_class = Some Types.Deterministic;
                       }
                   | Hooks.Edit new_input ->
                       find_and_execute_tool ~context ~tools ~hooks ~event_bus
@@ -428,6 +436,7 @@ let execute_scheduled_tool ~context ~tools ~(hooks : Hooks.hooks) ~event_bus
               content = msg;
               is_error = true;
               failure_kind = Some Non_retryable_tool_error;
+              error_class = Some Types.Unknown;
             })
   in
   let duration_ms_tool = (Unix.gettimeofday () -. t0_tool) *. 1000.0 in

--- a/lib/agent/agent_tools.mli
+++ b/lib/agent/agent_tools.mli
@@ -37,6 +37,7 @@ type tool_execution_result = {
   content: string;
   is_error: bool;
   failure_kind: tool_failure_kind option;
+  error_class: Types.tool_error_class option;
 }
 
 (** Find a tool by name and execute it, invoking [PostToolUse] (and

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -203,7 +203,15 @@ let resolve_turn_params ~hooks ~messages ~max_turns ~turn ~invoke_hook =
           if msg.role = User then
             let results = List.filter_map (function
               | ToolResult { content; is_error; _ } ->
-                if is_error then Some (Error { message = content; recoverable = true } : tool_result)
+                if is_error then
+                  Some
+                    (Error
+                       {
+                         message = content;
+                         recoverable = true;
+                         error_class = None;
+                       }
+                      : tool_result)
                 else Some (Ok { content } : tool_result)
               | _ -> None
             ) msg.content in
@@ -264,6 +272,7 @@ let apply_context_injection ~context ~messages ~injector ~tool_uses ~results =
             {
               message = result.content;
               recoverable = recoverable_of_failure_kind result.failure_kind;
+              error_class = result.error_class;
             }
         else Ok { content = result.content }
       in
@@ -494,7 +503,14 @@ let make_tool_results ?(max_result_chars = default_max_tool_result_chars)
 (* === make_tool_results inline tests === *)
 
 let mock_result ?(is_error=false) ~id content : Agent_tools.tool_execution_result =
-  { tool_use_id = id; tool_name = "test"; content; is_error; failure_kind = None }
+  {
+    tool_use_id = id;
+    tool_name = "test";
+    content;
+    is_error;
+    failure_kind = None;
+    error_class = None;
+  }
 
 let%test "make_tool_results: small result passes through unchanged" =
   let results = [mock_result ~id:"t1" "hello world"] in

--- a/lib/agent_tool.ml
+++ b/lib/agent_tool.ml
@@ -45,7 +45,7 @@ let make_handler config : Tool.tool_handler =
       in
       Ok { content = output }
     | Error e ->
-      Error { message = Error.to_string e; recoverable = false }
+      Error { message = Error.to_string e; recoverable = false; error_class = None }
 
 (* ── Construction ────────────────────────────────────────────── *)
 

--- a/lib/handoff.ml
+++ b/lib/handoff.ml
@@ -48,7 +48,12 @@ let target_name_of_tool name =
     by the agent runner before this handler is called. *)
 let make_handoff_tool (target : handoff_target) : Tool.t =
   let handler _input : Types.tool_result =
-    Error { message = "Handoff tools are intercepted by the agent runner"; recoverable = false }
+    Error
+      {
+        message = "Handoff tools are intercepted by the agent runner";
+        recoverable = false;
+        error_class = None;
+      }
   in
   Tool.create
     ~name:(Printf.sprintf "%s%s" handoff_prefix target.name)

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -44,7 +44,17 @@ let param_type_to_string = function
     Defined before content_block/message/api_response to avoid
     field-name shadowing on the [content] record field. *)
 type tool_output = { content: string }
-type tool_error = { message: string; recoverable: bool }
+type tool_error_class =
+  | Transient
+  | Deterministic
+  | Unknown
+[@@deriving yojson, show]
+
+type tool_error = {
+  message: string;
+  recoverable: bool;
+  error_class: tool_error_class option;
+}
 type tool_result = (tool_output, tool_error) result
 
 type tool_param = {

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -28,7 +28,17 @@ val param_type_to_string : param_type -> string
 
 (** Tool execution result types. *)
 type tool_output = { content: string }
-type tool_error = { message: string; recoverable: bool }
+type tool_error_class =
+  | Transient
+  | Deterministic
+  | Unknown
+[@@deriving yojson, show]
+
+type tool_error = {
+  message: string;
+  recoverable: bool;
+  error_class: tool_error_class option;
+}
 type tool_result = (tool_output, tool_error) result
 
 type tool_param = {

--- a/lib/memory_tools.ml
+++ b/lib/memory_tools.ml
@@ -268,7 +268,8 @@ let%test "ok_json wraps as tool result" =
 
 let%test "tool_error returns recoverable error" =
   match tool_error "bad input" with
-  | Error { Types.message = "bad input"; recoverable = true } -> true
+  | Error { Types.message = "bad input"; recoverable = true; error_class = None } ->
+      true
   | _ -> false
 
 (* --- bind --- *)
@@ -277,7 +278,7 @@ let%test "bind ok" =
   Result.bind (Ok 1) (fun x -> Ok (x + 1)) = Ok 2
 
 let%test "bind error propagates" =
-  let err = Error { Types.message = "fail"; recoverable = true } in
+  let err = Error { Types.message = "fail"; recoverable = true; error_class = None } in
   match Result.bind err (fun _ -> Ok 0) with
   | Error { message = "fail"; _ } -> true
   | _ -> false

--- a/lib/memory_tools_parse.ml
+++ b/lib/memory_tools_parse.ml
@@ -6,7 +6,7 @@
     @since 0.92.0 extracted from Memory_tools *)
 
 let tool_error message =
-  Error { Types.message = message; recoverable = true }
+  Error { Types.message = message; recoverable = true; error_class = None }
 
 let parse_string_field json name =
   match Yojson.Safe.Util.member name json with

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -505,7 +505,13 @@ let step_as_tool ~name ~description (step : step) : Tool.t =
       in
       match step text with
       | Ok output -> Ok { content = output }
-      | Error e -> Error { message = Error.to_string e; recoverable = false })
+      | Error e ->
+          Error
+            {
+              message = Error.to_string e;
+              recoverable = false;
+              error_class = None;
+            })
 
 let agent_as_step ~sw ?clock (agent : Agent.t) : step =
   fun prompt ->

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -103,7 +103,15 @@ let last_tool_results_from messages =
     else
       List.filter_map (function
         | ToolResult { content; is_error; _ } ->
-          if is_error then Some (Error { Types.message = content; recoverable = true } : Types.tool_result)
+          if is_error then
+            Some
+              (Error
+                 {
+                   Types.message = content;
+                   recoverable = true;
+                   error_class = None;
+                 }
+                : Types.tool_result)
           else Some (Ok { Types.content } : Types.tool_result)
         | _ -> None
       ) msg.content
@@ -347,6 +355,10 @@ let retry_failures_of_results
                  Tool_retry_policy.tool_name = result.tool_name;
                  detail = result.content;
                  kind = Tool_retry_policy.Validation_error;
+                 error_class =
+                   Tool_retry_policy.resolve_error_class
+                     ~explicit:result.error_class
+                     Tool_retry_policy.Validation_error;
                }
          | Some Agent_tools.Recoverable_tool_error ->
              Some
@@ -354,6 +366,10 @@ let retry_failures_of_results
                  Tool_retry_policy.tool_name = result.tool_name;
                  detail = result.content;
                  kind = Tool_retry_policy.Recoverable_tool_error;
+                 error_class =
+                   Tool_retry_policy.resolve_error_class
+                     ~explicit:result.error_class
+                     Tool_retry_policy.Recoverable_tool_error;
                }
          | Some Agent_tools.Non_retryable_tool_error | None -> None)
 
@@ -973,7 +989,9 @@ let%test "last_tool_results_from finds tool results in last user message" =
       ]; name = None; tool_call_id = None };
   ] in
   match last_tool_results_from msgs with
-  | [Ok { content = "result1" }; Error { message = "error msg"; recoverable = true }] -> true
+  | [ Ok { content = "result1" };
+      Error { message = "error msg"; recoverable = true; error_class = None } ] ->
+      true
   | _ -> false
 
 let%test "last_tool_results_from skips non-tool user messages" =
@@ -1042,7 +1060,8 @@ let%test "last_tool_results_from error tool result" =
       ]; name = None; tool_call_id = None };
   ] in
   match last_tool_results_from msgs with
-  | [Error { message = "fail msg"; recoverable = true }] -> true
+  | [Error { message = "fail msg"; recoverable = true; error_class = None }] ->
+      true
   | _ -> false
 
 let%test "tag_error with Config error" =

--- a/lib/protocol/mcp.ml
+++ b/lib/protocol/mcp.ml
@@ -218,11 +218,12 @@ let call_tool t ~name ~arguments : Types.tool_result =
           message =
             Printf.sprintf "MCP tools/call '%s' failed: %s" name detail;
           recoverable = true;
+          error_class = None;
         }
   | Ok result ->
       let text = text_of_tool_result result in
       if Option.value ~default:false result.Sdk_types.is_error then
-        Error { message = text; recoverable = true }
+        Error { message = text; recoverable = true; error_class = None }
       else Ok { content = text }
 
 (** Convert MCP tools to SDK [Tool.t] list.

--- a/lib/protocol/mcp_http.ml
+++ b/lib/protocol/mcp_http.ml
@@ -55,11 +55,12 @@ let call_tool t ~name ~arguments =
           Types.message =
             Printf.sprintf "MCP tools/call '%s' failed: %s" name detail;
           recoverable = true;
+          error_class = None;
         }
   | Ok result ->
       let content = Mcp.text_of_tool_result result in
       if Option.value ~default:false result.Mcp_schema.Sdk_types.is_error then
-        Error { Types.message = content; recoverable = true }
+        Error { Types.message = content; recoverable = true; error_class = None }
       else Ok { Types.content }
 
 let close t = ignore (Sdk_http_client.close t.client)

--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -237,6 +237,7 @@ let extract_with_retry ~sw ~net ?base_url ?provider ?clock
                         Tool_retry_policy.tool_name = schema.name;
                         detail = error_msg;
                         kind = Tool_retry_policy.Validation_error;
+                        error_class = Tool_retry_policy.Deterministic;
                       };
                     ]
                 in

--- a/lib/tool_retry_policy.ml
+++ b/lib/tool_retry_policy.ml
@@ -19,9 +19,10 @@ type failure = {
   tool_name: string;
   detail: string;
   kind: failure_kind;
+  error_class: Types.tool_error_class;
 }
 
-type error_class =
+type error_class = Types.tool_error_class =
   | Transient
   | Deterministic
   | Unknown
@@ -29,6 +30,11 @@ type error_class =
 let classify = function
   | Validation_error -> Deterministic
   | Recoverable_tool_error -> Transient
+
+let resolve_error_class ~explicit failure_kind =
+  match explicit with
+  | Some error_class -> error_class
+  | None -> classify failure_kind
 
 let error_class_to_string = function
   | Transient -> "transient"
@@ -69,9 +75,13 @@ let set_context_retry_count (context : Context.t) retries =
 let clear_context_retry_count (context : Context.t) =
   Context.delete_scoped context Temp retry_count_key
 
-let failure_enabled (policy : t) = function
+let failure_enabled (policy : t) (failure : failure) =
+  match failure.kind with
   | Validation_error -> policy.retry_on_validation_error
-  | Recoverable_tool_error -> policy.retry_on_recoverable_tool_error
+  | Recoverable_tool_error ->
+      (match failure.error_class with
+       | Deterministic -> false
+       | Transient | Unknown -> policy.retry_on_recoverable_tool_error)
 
 let dedup_preserve_order xs =
   let seen = Hashtbl.create 8 in
@@ -96,7 +106,7 @@ let decide ~policy ~prior_retries failures =
   let max_retries = normalized_max_retries policy.max_retries in
   let retryable =
     failures
-    |> List.filter (fun failure -> failure_enabled policy failure.kind)
+    |> List.filter (failure_enabled policy)
   in
   match retryable with
   | [] -> No_retry

--- a/lib/tool_retry_policy.mli
+++ b/lib/tool_retry_policy.mli
@@ -19,6 +19,7 @@ type failure = {
   tool_name: string;
   detail: string;
   kind: failure_kind;
+  error_class: Types.tool_error_class;
 }
 
 (** Error class — orthogonal classification over {!failure_kind} that
@@ -36,7 +37,7 @@ type failure = {
     unchanged — consumers opt in via {!classify}.
 
     @since 0.161.0 (#898) *)
-type error_class =
+type error_class = Types.tool_error_class =
   | Transient
   | Deterministic
   | Unknown
@@ -50,6 +51,13 @@ type error_class =
     Downstream consumers that want finer classification should tag
     their errors directly once a structured error surface lands. *)
 val classify : failure_kind -> error_class
+
+(** Prefer the explicit error class attached to the tool error channel when
+    available; otherwise fall back to the legacy [failure_kind]-based mapping. *)
+val resolve_error_class :
+  explicit:Types.tool_error_class option ->
+  failure_kind ->
+  error_class
 
 (** Stable, lowercase identifier for logs / metric labels. *)
 val error_class_to_string : error_class -> string

--- a/lib/typed_tool.ml
+++ b/lib/typed_tool.ml
@@ -52,7 +52,7 @@ let execute_parsed ?context tool json =
 let execute ?context tool json =
   match tool.parse json with
   | Error e ->
-    Error { Types.message = e; recoverable = true }
+    Error { Types.message = e; recoverable = true; error_class = None }
   | Ok input ->
     match run_handler ?context tool.handler input with
     | Ok output ->
@@ -60,7 +60,7 @@ let execute ?context tool json =
       let content = Yojson.Safe.to_string json_output in
       Ok { Types.content }
     | Error e ->
-      Error { Types.message = e; recoverable = false }
+      Error { Types.message = e; recoverable = false; error_class = None }
 
 let to_untyped tool =
   let untyped_handler : Tool.handler_kind =

--- a/lib/typed_tool_safe.ml
+++ b/lib/typed_tool_safe.ml
@@ -40,7 +40,7 @@ let execute_with_approval ?context ~approve safe_tool args =
   match approve ~tool_name ~input_desc with
   | Ok () -> Typed_tool.execute ?context safe_tool.tool args
   | Error reason ->
-    Error { Types.message = reason; recoverable = false }
+    Error { Types.message = reason; recoverable = false; error_class = None }
 
 let execute_write ?context ~approve tool args =
   execute_with_approval ?context ~approve tool args

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -354,7 +354,12 @@ let test_agent_run_tool_error () =
         ~description:"Always fails"
         ~parameters:[]
         (fun _input ->
-          Error { Types.message = "tool broke"; recoverable = true })
+          Error
+            {
+              Types.message = "tool broke";
+              recoverable = true;
+              error_class = None;
+            })
     in
     let agent = make_agent ~net:env#net ~tools:[fail_tool] ~max_turns:5 url in
     (match Agent.run ~sw agent "trigger error" with

--- a/test/test_agent_sdk.ml
+++ b/test/test_agent_sdk.ml
@@ -155,6 +155,7 @@ let test_tool_retry_policy_clamps_negative_max_retries () =
       Tool_retry_policy.tool_name = "tool";
       detail = "bad output";
       kind = Tool_retry_policy.Recoverable_tool_error;
+      error_class = Tool_retry_policy.Transient;
     };
   ] in
   match Tool_retry_policy.decide ~policy ~prior_retries:0 failures with
@@ -204,6 +205,27 @@ let test_error_class_to_string_stable () =
     "unknown"
     (Tool_retry_policy.error_class_to_string Tool_retry_policy.Unknown)
 
+let test_explicit_deterministic_error_disables_recoverable_retry () =
+  let policy = Tool_retry_policy.default_internal in
+  let failures =
+    [
+      {
+        Tool_retry_policy.tool_name = "tool";
+        detail = "path_not_found";
+        kind = Tool_retry_policy.Recoverable_tool_error;
+        error_class = Tool_retry_policy.Deterministic;
+      };
+    ]
+  in
+  match Tool_retry_policy.decide ~policy ~prior_retries:0 failures with
+  | Tool_retry_policy.No_retry -> ()
+  | Tool_retry_policy.Retry _ ->
+      Alcotest.fail
+        "deterministic recoverable error should not enter blind retry"
+  | Tool_retry_policy.Exhausted _ ->
+      Alcotest.fail
+        "deterministic recoverable error should stop before retry budget applies"
+
 let () =
   run "Agent SDK" [
     "types", [
@@ -248,5 +270,7 @@ let () =
         test_error_class_classify_recoverable;
       test_case "error_class_to_string stable" `Quick
         test_error_class_to_string_stable;
+      test_case "explicit deterministic class disables recoverable retry"
+        `Quick test_explicit_deterministic_error_disables_recoverable_retry;
     ];
   ]

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -340,6 +340,7 @@ let test_make_tool_results () =
       content = "success output";
       is_error = false;
       failure_kind = None;
+    error_class = None;
     };
     {
       tool_use_id = "t2";
@@ -347,6 +348,7 @@ let test_make_tool_results () =
       content = "error msg";
       is_error = true;
       failure_kind = Some Agent_tools.Recoverable_tool_error;
+    error_class = None;
     };
   ] in
   let blocks = Agent_turn.make_tool_results results in
@@ -523,6 +525,7 @@ let test_apply_context_injection_no_injector () =
         content = "result";
         is_error = false;
         failure_kind = None;
+      error_class = None;
       };
     ]
   in
@@ -544,6 +547,7 @@ let test_apply_context_injection_with_context_update () =
         content = "found it";
         is_error = false;
         failure_kind = None;
+      error_class = None;
       };
     ]
   in
@@ -575,6 +579,7 @@ let test_apply_context_injection_with_extra_messages () =
         content = "result";
         is_error = false;
         failure_kind = None;
+      error_class = None;
       };
     ]
   in
@@ -603,6 +608,7 @@ let test_apply_context_injection_exception_handled () =
         content = "result";
         is_error = false;
         failure_kind = None;
+      error_class = None;
       };
     ]
   in
@@ -630,6 +636,7 @@ let test_apply_context_injection_preserves_non_retryable_error () =
         content = "fatal";
         is_error = true;
         failure_kind = Some Agent_tools.Non_retryable_tool_error;
+        error_class = Some Types.Deterministic;
       };
     ]
   in
@@ -641,9 +648,12 @@ let test_apply_context_injection_preserves_non_retryable_error () =
     ~context ~messages ~injector ~tool_uses ~results
   in
   match !received_output with
-  | Some (Error { message; recoverable }) ->
+  | Some (Error { message; recoverable; error_class }) ->
       Alcotest.(check string) "message" "fatal" message;
-      Alcotest.(check bool) "recoverable false" false recoverable
+      Alcotest.(check bool) "recoverable false" false recoverable;
+      (match error_class with
+       | Some Types.Deterministic -> ()
+       | _ -> Alcotest.fail "expected deterministic error_class")
   | Some (Ok _) -> Alcotest.fail "expected Error output"
   | None -> Alcotest.fail "injector not called"
 

--- a/test/test_cdal.ml
+++ b/test/test_cdal.ml
@@ -665,7 +665,13 @@ let test_proof_capture_multiple_tools () =
          tool_use_id = "tu-edit";
          tool_name = "edit";
          input = `String "b.ml";
-         output = Error { Types.message = "conflict"; recoverable = true };
+         output =
+           Error
+             {
+               Types.message = "conflict";
+               recoverable = true;
+               error_class = None;
+             };
          result_bytes = 0;
          duration_ms = 3.0;
          schedule = default_schedule ~planned_index:2 ~batch_index:2 ();

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -242,7 +242,8 @@ let test_tool_completed_preserves_non_retryable_flag () =
   let sub = Event_bus.subscribe ~filter:Event_bus.filter_tools_only bus in
   let tool =
     Tool.create ~name:"fail" ~description:"Always fails" ~parameters:[]
-      (fun _ -> Error { Types.message = "boom"; recoverable = false })
+      (fun _ ->
+        Error { Types.message = "boom"; recoverable = false; error_class = None })
   in
   let schedule : Hooks.tool_schedule =
     {
@@ -262,7 +263,7 @@ let test_tool_completed_preserves_non_retryable_flag () =
   match Event_bus.drain sub with
   | [ { meta = called_meta; payload = ToolCalled _; _ };
       { meta = completed_meta;
-        payload = ToolCompleted { output = Error { message; recoverable }; _ };
+        payload = ToolCompleted { output = Error { message; recoverable; _ }; _ };
         _ } ] ->
       check string "message" "boom" message;
       check bool "non-retryable preserved" false recoverable;
@@ -292,7 +293,8 @@ let test_on_tool_error_hook_fires_on_tool_failure () =
   let bus = Event_bus.create () in
   let tool =
     Tool.create ~name:"fail" ~description:"Always fails" ~parameters:[]
-      (fun _ -> Error { Types.message = "boom"; recoverable = false })
+      (fun _ ->
+        Error { Types.message = "boom"; recoverable = false; error_class = None })
   in
   let schedule : Hooks.tool_schedule =
     { planned_index = 0; batch_index = 0; batch_size = 1;

--- a/test/test_event_forward.ml
+++ b/test/test_event_forward.ml
@@ -285,7 +285,9 @@ let test_agent_started_payload () =
 let test_tool_completed_error_payload () =
   let evt = ev (Event_bus.ToolCompleted {
     agent_name = "x"; tool_name = "calc";
-    output = Error { Types.message = "fail"; recoverable = false } }) in
+    output =
+      Error { Types.message = "fail"; recoverable = false; error_class = None } })
+  in
   let p = Event_forward.event_to_payload evt in
   Alcotest.(check string) "type" "tool.completed" p.event_type;
   let open Yojson.Safe.Util in

--- a/test/test_full_pipeline_cov.ml
+++ b/test/test_full_pipeline_cov.ml
@@ -280,7 +280,9 @@ let test_tool_error_recovery () =
     let url = start_multi ~sw ~net:env#net ~port:21008 responses in
     let tool = Tool.create ~name:"bad_tool" ~description:"Fails"
         ~parameters:[]
-        (fun _input -> Error { Types.message = "broken"; recoverable = true }) in
+        (fun _input ->
+          Error { Types.message = "broken"; recoverable = true; error_class = None })
+    in
     let agent = make_agent ~net:env#net ~tools:[tool] ~max_turns:5 url in
     (match Agent.run ~sw agent "fail" with
      | Ok resp ->

--- a/test/test_mcp.ml
+++ b/test/test_mcp.ml
@@ -150,7 +150,9 @@ let test_mcp_tool_bridge_error () =
     description = "Always fails";
     input_schema = `Assoc [("type", `String "object"); ("properties", `Assoc [])];
   } in
-  let call_fn _input : Types.tool_result = Error { message = "server error"; recoverable = true } in
+  let call_fn _input : Types.tool_result =
+    Error { message = "server error"; recoverable = true; error_class = None }
+  in
   let sdk_tool = Mcp.mcp_tool_to_sdk_tool ~call_fn mcp_tool in
   let result = Tool.execute sdk_tool (`Assoc []) in
   (match result with

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -350,6 +350,7 @@ let test_make_tool_results_ok () =
       content = "result1";
       is_error = false;
       failure_kind = None;
+    error_class = None;
     };
     {
       tool_use_id = "tu2";
@@ -357,6 +358,7 @@ let test_make_tool_results_ok () =
       content = "result2";
       is_error = false;
       failure_kind = None;
+    error_class = None;
     };
   ] in
   let tool_results = Agent_turn.make_tool_results results in
@@ -376,6 +378,7 @@ let test_make_tool_results_error () =
       content = "failed";
       is_error = true;
       failure_kind = Some Agent_tools.Recoverable_tool_error;
+    error_class = None;
     };
   ] in
   let tool_results = Agent_turn.make_tool_results results in
@@ -393,6 +396,7 @@ let test_make_tool_results_mixed () =
       content = "good";
       is_error = false;
       failure_kind = None;
+    error_class = None;
     };
     {
       tool_use_id = "tu2";
@@ -400,6 +404,7 @@ let test_make_tool_results_mixed () =
       content = "bad";
       is_error = true;
       failure_kind = Some Agent_tools.Recoverable_tool_error;
+    error_class = None;
     };
   ] in
   let tool_results = Agent_turn.make_tool_results results in

--- a/test/test_pipeline_deep.ml
+++ b/test/test_pipeline_deep.ml
@@ -228,7 +228,7 @@ let test_resolve_params_error_tool_results () =
   let _params = Agent_turn.resolve_turn_params ~hooks ~messages ~max_turns:10 ~turn:0 ~invoke_hook in
   Alcotest.(check int) "1 error result" 1 (List.length !captured_results);
   (match List.hd !captured_results with
-   | Error { message; recoverable } ->
+   | Error { message; recoverable; _ } ->
      Alcotest.(check string) "error message" "permission denied" message;
      Alcotest.(check bool) "recoverable" true recoverable
    | Ok _ -> Alcotest.fail "expected Error result")
@@ -278,6 +278,7 @@ let test_context_injection_sets_values () =
         content = "result text";
         is_error = false;
         failure_kind = None;
+      error_class = None;
       };
     ]
   in
@@ -310,6 +311,7 @@ let test_context_injection_none () =
         content = "ok";
         is_error = false;
         failure_kind = None;
+      error_class = None;
       };
     ]
   in
@@ -347,6 +349,7 @@ let test_context_injection_extra_messages () =
         content = "ok";
         is_error = false;
         failure_kind = None;
+      error_class = None;
       };
     ]
   in
@@ -377,13 +380,14 @@ let test_context_injection_error_result () =
         content = "something went wrong";
         is_error = true;
         failure_kind = Some Agent_tools.Recoverable_tool_error;
+      error_class = None;
       };
     ]
   in
   let _new_messages = Agent_turn.apply_context_injection
     ~context ~messages ~injector ~tool_uses ~results in
   (match !received_output with
-   | Some (Error { message; recoverable }) ->
+   | Some (Error { message; recoverable; _ }) ->
      Alcotest.(check string) "error message" "something went wrong" message;
      Alcotest.(check bool) "recoverable" true recoverable
    | Some (Ok _) -> Alcotest.fail "expected Error output"
@@ -409,6 +413,7 @@ let test_context_injection_raises () =
         content = "ok";
         is_error = false;
         failure_kind = None;
+      error_class = None;
       };
     ]
   in

--- a/test/test_raw_trace.ml
+++ b/test/test_raw_trace.ml
@@ -175,7 +175,13 @@ let test_agent_run_stream_append_only_raw_trace () =
                         "source text -> copied"
                  then "PASS"
                  else "FAIL") }
-        else Error { Types.message = "unexpected command: " ^ command; recoverable = true })
+        else
+          Error
+            {
+              Types.message = "unexpected command: " ^ command;
+              recoverable = true;
+              error_class = None;
+            })
   in
   let tools = [ file_read_tool; shell_exec_tool; file_write_tool ] in
   let port = 8094 in

--- a/test/test_tool.ml
+++ b/test/test_tool.ml
@@ -25,7 +25,13 @@ let test_simple_handler_error () =
     ~name:"fail"
     ~description:"Always fails"
     ~parameters:[]
-    (fun _input -> Error { Types.message = "intentional error"; recoverable = true })
+    (fun _input ->
+      Error
+        {
+          Types.message = "intentional error";
+          recoverable = true;
+          error_class = None;
+        })
   in
   let actual = Tool.execute tool `Null in
   match actual with
@@ -40,7 +46,13 @@ let test_context_handler_receives_context () =
     (fun ctx _input ->
       match Context.get ctx "key" with
       | Some (`String v) -> Ok { Types.content = v }
-      | _ -> Error { Types.message = "key not found"; recoverable = true })
+      | _ ->
+          Error
+            {
+              Types.message = "key not found";
+              recoverable = true;
+              error_class = None;
+            })
   in
   let ctx = Context.create () in
   Context.set ctx "key" (`String "ctx_value");

--- a/test/test_tool_result_relocation.ml
+++ b/test/test_tool_result_relocation.ml
@@ -158,10 +158,22 @@ let test_make_tool_results_with_relocation () =
   let store = Tool_result_store.create config |> Result.get_ok in
   let crs = Content_replacement_state.create () in
   let mock_results : Agent_tools.tool_execution_result list = [
-    { tool_use_id = "t1"; tool_name = "read"; content = String.make 200 'x';
-      is_error = false; failure_kind = None };
-    { tool_use_id = "t2"; tool_name = "echo"; content = "small";
-      is_error = false; failure_kind = None };
+    {
+      tool_use_id = "t1";
+      tool_name = "read";
+      content = String.make 200 'x';
+      is_error = false;
+      failure_kind = None;
+      error_class = None;
+    };
+    {
+      tool_use_id = "t2";
+      tool_name = "echo";
+      content = "small";
+      is_error = false;
+      failure_kind = None;
+      error_class = None;
+    };
   ] in
   let blocks = Agent_turn.make_tool_results
     ~relocation:(store, crs) mock_results in
@@ -284,12 +296,30 @@ let test_aggregate_budget_persists_largest () =
   (* 3 results: total = 8000+4000+3000 = 15000, at budget boundary.
      Actually make total > budget: 8000+5000+4000 = 17000 > 15000 *)
   let mock_results : Agent_tools.tool_execution_result list = [
-    { tool_use_id = "t1"; tool_name = "a"; content = String.make 8000 'a';
-      is_error = false; failure_kind = None };
-    { tool_use_id = "t2"; tool_name = "b"; content = String.make 5000 'b';
-      is_error = false; failure_kind = None };
-    { tool_use_id = "t3"; tool_name = "c"; content = String.make 4000 'c';
-      is_error = false; failure_kind = None };
+    {
+      tool_use_id = "t1";
+      tool_name = "a";
+      content = String.make 8000 'a';
+      is_error = false;
+      failure_kind = None;
+      error_class = None;
+    };
+    {
+      tool_use_id = "t2";
+      tool_name = "b";
+      content = String.make 5000 'b';
+      is_error = false;
+      failure_kind = None;
+      error_class = None;
+    };
+    {
+      tool_use_id = "t3";
+      tool_name = "c";
+      content = String.make 4000 'c';
+      is_error = false;
+      failure_kind = None;
+      error_class = None;
+    };
   ] in
   let blocks = Agent_turn.make_tool_results
     ~relocation:(store, crs) mock_results in
@@ -329,8 +359,14 @@ let test_aggregate_budget_disabled () =
   let store = Tool_result_store.create config |> Result.get_ok in
   let crs = Content_replacement_state.create () in
   let mock_results : Agent_tools.tool_execution_result list = [
-    { tool_use_id = "t1"; tool_name = "a"; content = String.make 8000 'x';
-      is_error = false; failure_kind = None };
+    {
+      tool_use_id = "t1";
+      tool_name = "a";
+      content = String.make 8000 'x';
+      is_error = false;
+      failure_kind = None;
+      error_class = None;
+    };
   ] in
   let _blocks = Agent_turn.make_tool_results
     ~relocation:(store, crs) mock_results in


### PR DESCRIPTION
## Summary
- add `Types.tool_error.error_class` so tool implementations can attach deterministic/transient hints without relying only on `recoverable`
- thread the explicit class through agent tool execution, event/tool-result propagation, and `Tool_retry_policy.decide`
- keep legacy validation retry behavior, but stop blind retries when a recoverable tool error is explicitly tagged `Deterministic`

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/issue-898-error-class`
- `./_build/default/test/test_agent_sdk.exe`
- `./_build/default/test/test_agent_turn.exe`
- `./_build/default/test/test_event_bus.exe`
- `./_build/default/test/test_tool_result_relocation.exe`
- `./_build/default/test/test_agent_pipeline.exe`
- `./_build/default/test/test_structured_deep.exe`

Refs #898
