### PR TITLE
[codex] add runtime MCP policy for CLI transports

### DIFF
--- a/examples/cli_transports_demo.ml
+++ b/examples/cli_transports_demo.ml
@@ -37,7 +37,7 @@ let make_request () : Llm_transport.completion_request =
       ~base_url:""
       ()
   in
-  { config; messages; tools = [] }
+  { config; messages; tools = []; runtime_mcp_policy = None }
 
 (** Stream demo: print every text delta as it arrives + a marker per
     event kind. *)

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -48,6 +48,8 @@ type options = Agent_types.options = {
     (Tool_result_store.t * Content_replacement_state.t) option;
   journal: Durable_event.journal option;
   transport: Llm_provider.Llm_transport.t option;
+  runtime_mcp_policy:
+    Llm_provider.Llm_transport.runtime_mcp_policy option;
   summarizer: (Types.message list -> string) option;
 }
 

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -58,6 +58,12 @@ type options = {
         dispatches via {!Llm_provider.Complete.complete} with this
         transport; when [None], the HTTP path is used.
         @since 0.156.0 *)
+  runtime_mcp_policy:
+    Llm_provider.Llm_transport.runtime_mcp_policy option;
+    (** Optional request-scoped MCP exposure policy for CLI transports.
+        When [Some], the transport may expose runtime MCP tools without
+        relying on inline [Tool.t] schemas.
+        @since 0.164.0 *)
   summarizer: (message list -> string) option;
     (** Optional custom extractive summarizer used by
         {!Budget_strategy.reduce_for_budget} when the Emergency phase
@@ -132,6 +138,7 @@ let default_options = {
   tool_result_relocation = None;
   journal = None;
   transport = None;
+  runtime_mcp_policy = None;
   summarizer = None;
 }
 

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -92,6 +92,12 @@ type options = {
         dispatches via {!Llm_provider.Complete.complete} with this
         transport; when [None], the HTTP path is used.
         @since 0.156.0 *)
+  runtime_mcp_policy:
+    Llm_provider.Llm_transport.runtime_mcp_policy option;
+    (** Optional request-scoped MCP exposure policy for CLI transports.
+        When [Some], the transport may expose runtime MCP tools without
+        relying on inline [Tool.t] schemas.
+        @since 0.164.0 *)
   summarizer: (Types.message list -> string) option;
     (** Optional custom extractive summarizer used by
         {!Budget_strategy.reduce_for_budget} when the Emergency phase

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -66,6 +66,8 @@ type t = {
   policy_channel: Policy_channel.t option;
   summarizer: (Types.message list -> string) option;
   transport: Llm_provider.Llm_transport.t option;
+  runtime_mcp_policy:
+    Llm_provider.Llm_transport.runtime_mcp_policy option;
 }
 
 let create ~net ~model =
@@ -130,6 +132,7 @@ let create ~net ~model =
     policy_channel = None;
     summarizer = None;
     transport = None;
+    runtime_mcp_policy = None;
   }
 
 let with_tool_result_relocation ~store ~state b =
@@ -143,6 +146,8 @@ let with_journal journal b = { b with journal = Some journal }
 let with_summarizer summarizer b = { b with summarizer = Some summarizer }
 
 let with_transport transport b = { b with transport = Some transport }
+let with_runtime_mcp_policy runtime_mcp_policy b =
+  { b with runtime_mcp_policy = Some runtime_mcp_policy }
 
 let with_auto_dump_journal ~path b =
   let journal =
@@ -350,6 +355,7 @@ let build b =
     tool_result_relocation = b.tool_result_relocation;
     journal = b.journal;
     transport = b.transport;
+    runtime_mcp_policy = b.runtime_mcp_policy;
     summarizer = b.summarizer;
   } in
   Agent.create ~net:b.net ~config ~tools:(Tool_set.to_list tools) ?context

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -136,6 +136,14 @@ val with_base_url : string -> t -> t
     @since 0.156.0 *)
 val with_transport : Llm_provider.Llm_transport.t -> t -> t
 
+(** Inject a request-scoped runtime MCP policy for CLI transports.
+    This is orthogonal to inline [Tool.t] schemas: transports such as
+    Claude Code and Codex CLI can expose MCP tools directly from the
+    subprocess runtime.
+    @since 0.164.0 *)
+val with_runtime_mcp_policy :
+  Llm_provider.Llm_transport.runtime_mcp_policy -> t -> t
+
 (** {2 Contract} *)
 
 val with_contract : Contract.t -> t -> t

--- a/lib/llm_provider/cache.ml
+++ b/lib/llm_provider/cache.ml
@@ -14,11 +14,16 @@ let message_fingerprint (m : Types.message) : Yojson.Safe.t =
   ]
 
 let request_fingerprint ~(config : Provider_config.t)
-    ~(messages : Types.message list) ?(tools=[]) () =
+    ~(messages : Types.message list) ?(tools=[])
+    ?runtime_mcp_policy () =
   let json = `Assoc [
     ("model_id", `String config.model_id);
     ("messages", `List (List.map message_fingerprint messages));
     ("tools", `List tools);
+    ("runtime_mcp_policy",
+     match runtime_mcp_policy with
+     | Some policy -> Llm_transport.runtime_mcp_policy_to_yojson policy
+     | None -> `Null);
   ] in
   let canonical = Yojson.Safe.to_string json in
   Digest.string canonical |> Digest.to_hex

--- a/lib/llm_provider/cache.mli
+++ b/lib/llm_provider/cache.mli
@@ -23,6 +23,7 @@ val request_fingerprint :
   config:Provider_config.t ->
   messages:Types.message list ->
   ?tools:Yojson.Safe.t list ->
+  ?runtime_mcp_policy:Llm_transport.runtime_mcp_policy ->
   unit -> string
 
 (** Serialize an [api_response] to JSON for caching. *)

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -16,6 +16,8 @@ type capabilities = {
   supports_tools: bool;
   supports_tool_choice: bool;
   supports_parallel_tool_calls: bool;
+  supports_runtime_mcp_tools: bool;
+  supports_runtime_tool_events: bool;
 
   (* ── Thinking / reasoning ──────────────────────────── *)
   supports_reasoning: bool;             (** Any form of reasoning/thinking *)
@@ -55,6 +57,8 @@ let default_capabilities = {
   supports_tools = false;
   supports_tool_choice = false;
   supports_parallel_tool_calls = false;
+  supports_runtime_mcp_tools = false;
+  supports_runtime_tool_events = false;
   supports_reasoning = false;
   supports_extended_thinking = false;
   supports_reasoning_budget = false;
@@ -227,6 +231,8 @@ let claude_code_capabilities = {
   supports_structured_output = false;
   supports_computer_use = true;
   supports_code_execution = true;
+  supports_runtime_mcp_tools = true;
+  supports_runtime_tool_events = true;
 }
 
 let gemini_cli_capabilities = {
@@ -247,6 +253,8 @@ let codex_cli_capabilities = {
   supports_tool_choice = false;
   supports_native_streaming = false;
   supports_system_prompt = true;
+  supports_runtime_mcp_tools = true;
+  supports_runtime_tool_events = true;
 }
 
 (* ── Model-specific overrides (lookup table) ─────────── *)

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -14,6 +14,8 @@ type capabilities = {
   supports_tools: bool;
   supports_tool_choice: bool;
   supports_parallel_tool_calls: bool;
+  supports_runtime_mcp_tools: bool;
+  supports_runtime_tool_events: bool;
   (* Thinking / reasoning *)
   supports_reasoning: bool;
   supports_extended_thinking: bool;

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -487,6 +487,7 @@ let complete_http ~sw ~net
 let complete ~sw ~net ?(transport : Llm_transport.t option)
     ~(config : Provider_config.t)
     ~(messages : Types.message list) ?(tools=[])
+    ?runtime_mcp_policy
     ?(cache : Cache.t option) ?(metrics : Metrics.t option)
     ?(priority : Request_priority.t option) () =
   match validate_output_schema_request config with
@@ -498,7 +499,10 @@ let complete ~sw ~net ?(transport : Llm_transport.t option)
   (* Cache lookup *)
   (* Compute fingerprint once; reuse for both lookup and store *)
   let cache_key = match cache with
-    | Some _ -> Some (Cache.request_fingerprint ~config ~messages ~tools ())
+    | Some _ ->
+      Some
+        (Cache.request_fingerprint ~config ~messages ~tools
+           ?runtime_mcp_policy ())
     | None -> None
   in
   let cached = match cache, cache_key with
@@ -524,7 +528,13 @@ let complete ~sw ~net ?(transport : Llm_transport.t option)
       let { Llm_transport.response = result; latency_ms } =
         match transport with
         | Some t ->
-          t.complete_sync { Llm_transport.config; messages; tools }
+          t.complete_sync
+            {
+              Llm_transport.config;
+              messages;
+              tools;
+              runtime_mcp_policy;
+            }
         | None when requires_non_http_transport config.kind ->
           (* CLI subprocess providers (claude_code/codex_cli/gemini_cli)
              register with [base_url = ""] on purpose.  Without a CLI
@@ -615,6 +625,7 @@ let is_retryable = function
 let complete_with_retry ~sw ~net ?transport ~clock
     ~(config : Provider_config.t)
     ~(messages : Types.message list) ?(tools=[])
+    ?runtime_mcp_policy
     ?(retry_config=default_retry_config)
     ?cache ?metrics ?priority () =
   let jittered delay =
@@ -622,7 +633,10 @@ let complete_with_retry ~sw ~net ?transport ~clock
     delay *. factor
   in
   let rec attempt n delay =
-    match complete ~sw ~net ?transport ~config ~messages ~tools ?cache ?metrics ?priority () with
+    match
+      complete ~sw ~net ?transport ~config ~messages ~tools
+        ?runtime_mcp_policy ?cache ?metrics ?priority ()
+    with
     | Ok _ as success -> success
     | Error err when is_retryable err && n < retry_config.max_retries ->
         Eio.Time.sleep clock (jittered delay);
@@ -755,6 +769,7 @@ let complete_stream_http ~sw:_ ~net ~(config : Provider_config.t)
 let complete_stream ~sw ~net ?(transport : Llm_transport.t option)
     ~(config : Provider_config.t)
     ~(messages : Types.message list) ?(tools=[])
+    ?runtime_mcp_policy
     ~(on_event : Types.sse_event -> unit)
     ?(priority : Request_priority.t option) () =
   match validate_output_schema_request config with
@@ -763,7 +778,13 @@ let complete_stream ~sw ~net ?(transport : Llm_transport.t option)
   let _priority = priority in
   let result = match transport with
   | Some t ->
-    t.complete_stream ~on_event { Llm_transport.config; messages; tools }
+    t.complete_stream ~on_event
+      {
+        Llm_transport.config;
+        messages;
+        tools;
+        runtime_mcp_policy;
+      }
   | None when requires_non_http_transport config.kind ->
     (* Same rationale as the sync [complete] guard: CLI kinds have
        [base_url = ""] and must not reach cohttp-eio. *)

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -71,6 +71,7 @@ val complete :
   config:Provider_config.t ->
   messages:Types.message list ->
   ?tools:Yojson.Safe.t list ->
+  ?runtime_mcp_policy:Llm_transport.runtime_mcp_policy ->
   ?cache:Cache.t ->
   ?metrics:Metrics.t ->
   ?priority:Request_priority.t ->
@@ -104,6 +105,7 @@ val complete_with_retry :
   config:Provider_config.t ->
   messages:Types.message list ->
   ?tools:Yojson.Safe.t list ->
+  ?runtime_mcp_policy:Llm_transport.runtime_mcp_policy ->
   ?retry_config:retry_config ->
   ?cache:Cache.t ->
   ?metrics:Metrics.t ->
@@ -132,6 +134,7 @@ val complete_stream :
   config:Provider_config.t ->
   messages:Types.message list ->
   ?tools:Yojson.Safe.t list ->
+  ?runtime_mcp_policy:Llm_transport.runtime_mcp_policy ->
   on_event:(Types.sse_event -> unit) ->
   ?priority:Request_priority.t ->
   unit ->

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -92,6 +92,24 @@ let finalize_stream_acc (acc : stream_acc) =
         let input = try Yojson.Safe.from_string text
           with Yojson.Json_error _ -> `Assoc [] in
         Some (Types.ToolUse { id; name; input })
+    | Some "tool_result" | Some "tool_result_error" ->
+        let tool_use_id =
+          match Hashtbl.find_opt acc.block_tool_ids idx with
+          | Some s -> s
+          | None -> ""
+        in
+        let is_error =
+          match Hashtbl.find_opt acc.block_types idx with
+          | Some "tool_result_error" -> true
+          | _ -> false
+        in
+        Some
+          (Types.ToolResult {
+             tool_use_id;
+             content = text;
+             is_error;
+             json = None;
+           })
     | _ -> None
   ) indices in
   Ok { Types.id = !(acc.id);

--- a/lib/llm_provider/llm_transport.ml
+++ b/lib/llm_provider/llm_transport.ml
@@ -2,11 +2,85 @@
 
     @since 0.78.0 *)
 
+type runtime_mcp_server =
+  | Stdio_server of {
+      name: string;
+      command: string;
+      args: string list;
+      env: (string * string) list;
+    }
+  | Http_server of {
+      name: string;
+      url: string;
+      headers: (string * string) list;
+    }
+
+type runtime_mcp_policy = {
+  servers: runtime_mcp_server list;
+  allowed_server_names: string list;
+  allowed_tool_names: string list;
+  permission_mode: string option;
+  approval_mode: string option;
+  strict: bool;
+  disable_builtin_tools: bool;
+}
+
 type completion_request = {
   config: Provider_config.t;
   messages: Types.message list;
   tools: Yojson.Safe.t list;
+  runtime_mcp_policy: runtime_mcp_policy option;
 }
+
+let empty_runtime_mcp_policy = {
+  servers = [];
+  allowed_server_names = [];
+  allowed_tool_names = [];
+  permission_mode = None;
+  approval_mode = None;
+  strict = true;
+  disable_builtin_tools = false;
+}
+
+let runtime_mcp_server_name = function
+  | Stdio_server { name; _ } | Http_server { name; _ } -> name
+
+let runtime_mcp_policy_to_yojson (policy : runtime_mcp_policy) =
+  let server_to_yojson = function
+    | Stdio_server { name; command; args; env } ->
+      `Assoc [
+        ("kind", `String "stdio");
+        ("name", `String name);
+        ("command", `String command);
+        ("args", `List (List.map (fun arg -> `String arg) args));
+        ("env",
+         `Assoc (List.map (fun (k, v) -> (k, `String v)) env));
+      ]
+    | Http_server { name; url; headers } ->
+      `Assoc [
+        ("kind", `String "http");
+        ("name", `String name);
+        ("url", `String url);
+        ("headers",
+         `Assoc (List.map (fun (k, v) -> (k, `String v)) headers));
+      ]
+  in
+  let string_list xs = `List (List.map (fun x -> `String x) xs) in
+  `Assoc [
+    ("servers", `List (List.map server_to_yojson policy.servers));
+    ("allowed_server_names", string_list policy.allowed_server_names);
+    ("allowed_tool_names", string_list policy.allowed_tool_names);
+    ("permission_mode",
+     match policy.permission_mode with
+     | Some mode -> `String mode
+     | None -> `Null);
+    ("approval_mode",
+     match policy.approval_mode with
+     | Some mode -> `String mode
+     | None -> `Null);
+    ("strict", `Bool policy.strict);
+    ("disable_builtin_tools", `Bool policy.disable_builtin_tools);
+  ]
 
 type sync_result = {
   response: (Types.api_response, Http_client.http_error) result;

--- a/lib/llm_provider/llm_transport.mli
+++ b/lib/llm_provider/llm_transport.mli
@@ -8,11 +8,40 @@
     @stability Internal
     @since 0.93.1 *)
 
+(** Request-scoped MCP server declaration for CLI transports. *)
+type runtime_mcp_server =
+  | Stdio_server of {
+      name: string;
+      command: string;
+      args: string list;
+      env: (string * string) list;
+    }
+  | Http_server of {
+      name: string;
+      url: string;
+      headers: (string * string) list;
+    }
+
+type runtime_mcp_policy = {
+  servers: runtime_mcp_server list;
+  allowed_server_names: string list;
+  allowed_tool_names: string list;
+  permission_mode: string option;
+  approval_mode: string option;
+  strict: bool;
+  disable_builtin_tools: bool;
+}
+
+val empty_runtime_mcp_policy : runtime_mcp_policy
+val runtime_mcp_server_name : runtime_mcp_server -> string
+val runtime_mcp_policy_to_yojson : runtime_mcp_policy -> Yojson.Safe.t
+
 (** A completion request: everything needed to produce a response. *)
 type completion_request = {
   config: Provider_config.t;
   messages: Types.message list;
   tools: Yojson.Safe.t list;
+  runtime_mcp_policy: runtime_mcp_policy option;
 }
 
 (** Result of a sync completion. *)

--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -44,6 +44,54 @@ let default_config = {
 (* Prompt shaping, JSON helpers, and subprocess orchestration live in the
    shared [Cli_common_*] modules to deduplicate logic across CLI transports. *)
 
+let json_of_string_pairs pairs =
+  `Assoc (List.map (fun (k, v) -> (k, `String v)) pairs)
+
+let json_of_runtime_mcp_server = function
+  | Llm_transport.Stdio_server { name = _; command; args; env } ->
+    `Assoc [
+      ("command", `String command);
+      ("args", `List (List.map (fun arg -> `String arg) args));
+      ("env", json_of_string_pairs env);
+    ]
+  | Llm_transport.Http_server { name = _; url; headers } ->
+    `Assoc [
+      ("type", `String "http");
+      ("url", `String url);
+      ("headers", json_of_string_pairs headers);
+    ]
+
+let mcp_config_json_of_policy
+    (policy : Llm_transport.runtime_mcp_policy) : Yojson.Safe.t option =
+  match policy.servers with
+  | [] -> None
+  | servers ->
+    let entries =
+      List.map (fun server ->
+        (Llm_transport.runtime_mcp_server_name server,
+         json_of_runtime_mcp_server server))
+        servers
+    in
+    Some (`Assoc [("mcpServers", `Assoc entries)])
+
+let claude_allowed_tools_of_policy
+    (policy : Llm_transport.runtime_mcp_policy) : string list =
+  let server_names =
+    match policy.allowed_server_names with
+    | [] ->
+      List.map Llm_transport.runtime_mcp_server_name policy.servers
+    | names -> names
+  in
+  match policy.allowed_tool_names with
+  | [] ->
+    List.map (fun server_name -> "mcp__" ^ server_name) server_names
+  | tool_names ->
+    List.concat_map (fun server_name ->
+      List.map
+        (fun tool_name -> Printf.sprintf "mcp__%s__%s" server_name tool_name)
+        tool_names
+    ) server_names
+
 (* ── CLI argument building ───────────────────────────── *)
 
 (* Non-interactive Claude runs default to MCP OFF by forcing strict MCP
@@ -51,7 +99,7 @@ let default_config = {
    [OAS_CLAUDE_MCP_CONFIG] is provided, strict mode narrows the runtime
    to exactly that config; when neither is present, strict mode yields an
    empty MCP surface.  LSP / hooks / auto-memory stay ON — no --bare. *)
-let env_extra_args ~(config : config) =
+let legacy_env_extra_args ~(config : config) =
   let extras = ref [] in
   let add a = extras := !extras @ a in
   (* Determine whether an MCP config path is actually available (either
@@ -122,7 +170,8 @@ let stdin_for_prompt prompt =
   if prompt_exceeds_argv_budget prompt then Some prompt else None
 
 let build_args ~(config : config) ~(req_config : Provider_config.t)
-    ~prompt ~stream ~system_prompt =
+    ?runtime_mcp_policy
+    ~prompt ~stream ~system_prompt () =
   (* When the prompt is too big for argv, omit it from the positional
      slot. Claude CLI (`--input-format text`, the default) then reads
      the prompt from stdin via [--print] / [-p]. We still pass [-p]
@@ -143,10 +192,41 @@ let build_args ~(config : config) ~(req_config : Provider_config.t)
   (match model with Some m -> add ["--model"; m] | None -> ());
   (match system_prompt with Some s -> add ["--system-prompt"; s] | None -> ());
   (match config.max_turns with Some n -> add ["--max-turns"; string_of_int n] | None -> ());
-  List.iter (fun t -> add ["--allowedTools"; t]) config.allowed_tools;
-  (match config.permission_mode with Some m -> add ["--permission-mode"; m] | None -> ());
-  (match config.mcp_config with Some c -> add ["--mcp-config"; c] | None -> ());
-  add (env_extra_args ~config);
+  (match runtime_mcp_policy with
+   | Some (policy : Llm_transport.runtime_mcp_policy) ->
+     let emitted_mcp_config = ref false in
+     if policy.disable_builtin_tools then
+       add ["--tools"; ""];
+     List.iter
+       (fun tool_name -> add ["--allowedTools"; tool_name])
+       (claude_allowed_tools_of_policy policy);
+     (match policy.permission_mode with
+      | Some mode -> add ["--permission-mode"; mode]
+      | None ->
+        (match config.permission_mode with
+         | Some mode -> add ["--permission-mode"; mode]
+         | None -> ()));
+     (match mcp_config_json_of_policy policy with
+      | Some json ->
+        emitted_mcp_config := true;
+        add ["--mcp-config"; Yojson.Safe.to_string json]
+      | None ->
+        (match config.mcp_config with
+         | Some c ->
+           emitted_mcp_config := true;
+           add ["--mcp-config"; c]
+         | None -> ()));
+     if policy.strict && !emitted_mcp_config then
+       add ["--strict-mcp-config"];
+     (match Cli_common_env.list "OAS_CLAUDE_DISALLOWED_TOOLS" with
+      | None | Some [] -> ()
+      | Some tools ->
+        List.iter (fun t -> add ["--disallowedTools"; t]) tools)
+   | None ->
+     List.iter (fun t -> add ["--allowedTools"; t]) config.allowed_tools;
+     (match config.permission_mode with Some m -> add ["--permission-mode"; m] | None -> ());
+     (match config.mcp_config with Some c -> add ["--mcp-config"; c] | None -> ());
+     add (legacy_env_extra_args ~config));
   !args
 
 (* ── JSON parsing ────────────────────────────────────── *)
@@ -418,14 +498,16 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
       let messages = Cli_common_prompt.non_system_messages req.messages in
       let prompt = Cli_common_prompt.prompt_of_messages
         ~include_tool_blocks:config.forward_tool_results messages in
-      let system_prompt =
-        Cli_common_prompt.system_prompt_of ~req_config:req.config req.messages in
-      if config.tool_use_via_stream_json then
+        let system_prompt =
+          Cli_common_prompt.system_prompt_of ~req_config:req.config req.messages in
+        if config.tool_use_via_stream_json then
         (* Use stream-json internally so we can aggregate tool_use /
            thinking blocks.  [--output-format json] flattens these into
            the [result] string and we'd lose them. *)
         let args = build_args ~config ~req_config:req.config
-          ~prompt ~stream:true ~system_prompt in
+          ?runtime_mcp_policy:req.runtime_mcp_policy
+          ~prompt ~stream:true ~system_prompt ()
+        in
         let argv = config.claude_path :: args in
         let seen_lines = ref [] in
         let on_line line =
@@ -445,7 +527,9 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
           { Llm_transport.response; latency_ms }
       else
         let args = build_args ~config ~req_config:req.config
-          ~prompt ~stream:false ~system_prompt in
+          ?runtime_mcp_policy:req.runtime_mcp_policy
+          ~prompt ~stream:false ~system_prompt ()
+        in
         match run ~sw ~mgr ~config
                 ?stdin_content:(stdin_for_prompt prompt) args with
         | Error _ as e -> { Llm_transport.response = e; latency_ms = 0 }
@@ -460,7 +544,9 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
       let system_prompt =
         Cli_common_prompt.system_prompt_of ~req_config:req.config req.messages in
       let args = build_args ~config ~req_config:req.config
-        ~prompt ~stream:true ~system_prompt in
+        ?runtime_mcp_policy:req.runtime_mcp_policy
+        ~prompt ~stream:true ~system_prompt ()
+      in
       let argv = config.claude_path :: args in
       let seen_lines = ref [] in
       let on_line line =
@@ -539,13 +625,15 @@ let%test "events_of_line invalid json" =
 let%test "build_args basic" =
   let args = build_args ~config:default_config
     ~req_config:(Provider_config.make ~kind:Anthropic ~model_id:"" ~base_url:"" ())
-    ~prompt:"hello" ~stream:false ~system_prompt:None in
+    ~prompt:"hello" ~stream:false ~system_prompt:None ()
+  in
   List.mem "-p" args && List.mem "json" args
 
 let%test "build_args with model" =
   let args = build_args ~config:default_config
     ~req_config:(Provider_config.make ~kind:Anthropic ~model_id:"claude-sonnet-4" ~base_url:"" ())
-    ~prompt:"hello" ~stream:true ~system_prompt:(Some "be helpful") in
+    ~prompt:"hello" ~stream:true ~system_prompt:(Some "be helpful") ()
+  in
   List.mem "--model" args
   && List.mem "claude-sonnet-4" args
   && List.mem "--system-prompt" args
@@ -555,7 +643,8 @@ let%test "build_args with model" =
 let%test "build_args omits auto model override" =
   let args = build_args ~config:default_config
     ~req_config:(Provider_config.make ~kind:Claude_code ~model_id:"auto" ~base_url:"" ())
-    ~prompt:"hello" ~stream:false ~system_prompt:None in
+    ~prompt:"hello" ~stream:false ~system_prompt:None ()
+  in
   not (List.mem "--model" args)
 
 (* Strict-MCP/mcp-config pairing invariants are exercised by the
@@ -672,7 +761,7 @@ let%test "default: --strict-mcp-config omitted when no MCP config is available" 
   with_unset "OAS_CLAUDE_MCP_CONFIG" (fun () ->
   with_unset "OAS_CLAUDE_DISALLOWED_TOOLS" (fun () ->
     let args = build_args ~config:default_config ~req_config:sample_req
-      ~prompt:"hi" ~stream:false ~system_prompt:None in
+      ~prompt:"hi" ~stream:false ~system_prompt:None () in
     (not (List.mem "--strict-mcp-config" args))
     && not (List.mem "--mcp-config" args)
     && not (List.mem "--disallowedTools" args))))
@@ -684,16 +773,18 @@ let%test "env: OAS_CLAUDE_STRICT_MCP=1 alone no longer implies --strict-mcp-conf
   with_unset "OAS_CLAUDE_MCP_CONFIG" (fun () ->
   with_env "OAS_CLAUDE_STRICT_MCP" "1" (fun () ->
     let args = build_args ~config:default_config ~req_config:sample_req
-      ~prompt:"hi" ~stream:false ~system_prompt:None in
+      ~prompt:"hi" ~stream:false ~system_prompt:None () in
     not (List.mem "--strict-mcp-config" args)))
 
 let%test "env: MCP_CONFIG fallback only when config.mcp_config is None" =
   with_env "OAS_CLAUDE_MCP_CONFIG" "/tmp/mcp.json" (fun () ->
     let args_default = build_args ~config:default_config ~req_config:sample_req
-      ~prompt:"hi" ~stream:false ~system_prompt:None in
+      ~prompt:"hi" ~stream:false ~system_prompt:None ()
+    in
     let explicit_cfg = { default_config with mcp_config = Some "/tmp/explicit.json" } in
     let args_explicit = build_args ~config:explicit_cfg ~req_config:sample_req
-      ~prompt:"hi" ~stream:false ~system_prompt:None in
+      ~prompt:"hi" ~stream:false ~system_prompt:None ()
+    in
     List.mem "/tmp/mcp.json" args_default
     && List.mem "/tmp/explicit.json" args_explicit
     && not (List.mem "/tmp/mcp.json" args_explicit))
@@ -701,7 +792,8 @@ let%test "env: MCP_CONFIG fallback only when config.mcp_config is None" =
 let%test "env: DISALLOWED_TOOLS splits on comma" =
   with_env "OAS_CLAUDE_DISALLOWED_TOOLS" "Bash,Write" (fun () ->
     let args = build_args ~config:default_config ~req_config:sample_req
-      ~prompt:"hi" ~stream:false ~system_prompt:None in
+      ~prompt:"hi" ~stream:false ~system_prompt:None ()
+    in
     (* Each token emits its own --disallowedTools flag. *)
     List.mem "--disallowedTools" args
     && List.mem "Bash" args
@@ -752,7 +844,7 @@ let%test "stdin_for_prompt: Some when over budget, None under" =
 let%test "build_args omits positional prompt when routing via stdin" =
   let big = String.make (1 * 1024 * 1024) 'x' in
   let args = build_args ~config:default_config ~req_config:sample_req
-    ~prompt:big ~stream:false ~system_prompt:None in
+    ~prompt:big ~stream:false ~system_prompt:None () in
   (* First two argv entries should be ["-p"; "--output-format"], NOT
      ["-p"; <big>] — the prompt must not appear anywhere in argv. *)
   not (List.mem big args)
@@ -762,8 +854,50 @@ let%test "build_args omits positional prompt when routing via stdin" =
 
 let%test "build_args keeps positional prompt when small" =
   let args = build_args ~config:default_config ~req_config:sample_req
-    ~prompt:"hello" ~stream:false ~system_prompt:None in
+    ~prompt:"hello" ~stream:false ~system_prompt:None () in
   List.mem "hello" args
   && (match args with
       | "-p" :: "hello" :: _ -> true
       | _ -> false)
+
+let%test "runtime MCP policy overrides legacy tool and MCP config wiring" =
+  let config = {
+    default_config with
+    allowed_tools = ["Bash"];
+    permission_mode = Some "bypassPermissions";
+    mcp_config = Some "/tmp/legacy-mcp.json";
+  } in
+  let policy =
+    {
+      Llm_transport.empty_runtime_mcp_policy with
+      servers = [
+        Llm_transport.Http_server {
+          name = "masc";
+          url = "http://127.0.0.1:8935/mcp";
+          headers = [];
+        };
+      ];
+      allowed_server_names = ["masc"];
+      allowed_tool_names = ["masc_status"];
+      permission_mode = Some "plan";
+      strict = true;
+      disable_builtin_tools = true;
+    }
+  in
+  let args = build_args ~config ~req_config:sample_req
+    ~runtime_mcp_policy:policy
+    ~prompt:"hi" ~stream:false ~system_prompt:None ()
+  in
+  List.mem "--tools" args
+  && List.mem "" args
+  && List.mem "--allowedTools" args
+  && List.mem "mcp__masc__masc_status" args
+  && List.mem "--permission-mode" args
+  && List.mem "plan" args
+  && List.mem "--strict-mcp-config" args
+  && List.mem
+       {|{"mcpServers":{"masc":{"type":"http","url":"http://127.0.0.1:8935/mcp","headers":{}}}}|}
+       args
+  && not (List.mem "Bash" args)
+  && not (List.mem "/tmp/legacy-mcp.json" args)
+  && not (List.mem "bypassPermissions" args)

--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -43,6 +43,119 @@ let default_config = {
 (* Prompt shaping, JSON helpers, and subprocess orchestration live in the
    shared [Cli_common_*] modules. *)
 
+type stream_state = {
+  next_index: int ref;
+  item_indices: (string, int) Hashtbl.t;
+  item_result_indices: (string, int) Hashtbl.t;
+}
+
+let create_stream_state () = {
+  next_index = ref 0;
+  item_indices = Hashtbl.create 8;
+  item_result_indices = Hashtbl.create 8;
+}
+
+let index_for_item (state : stream_state) item_id =
+  match Hashtbl.find_opt state.item_indices item_id with
+  | Some idx -> idx
+  | None ->
+    let idx = !(state.next_index) in
+    state.next_index := idx + 1;
+    Hashtbl.replace state.item_indices item_id idx;
+    idx
+
+let result_index_for_item (state : stream_state) item_id =
+  match Hashtbl.find_opt state.item_result_indices item_id with
+  | Some idx -> idx
+  | None ->
+    let idx = !(state.next_index) in
+    state.next_index := idx + 1;
+    Hashtbl.replace state.item_result_indices item_id idx;
+    idx
+
+let toml_string value = Yojson.Safe.to_string (`String value)
+
+let toml_string_list values =
+  "[" ^ String.concat "," (List.map toml_string values) ^ "]"
+
+let toml_string_assoc entries =
+  let body =
+    entries
+    |> List.map (fun (key, value) -> Printf.sprintf "%s=%s" key (toml_string value))
+    |> String.concat ","
+  in
+  "{" ^ body ^ "}"
+
+let server_tool_name ~server ~tool =
+  Printf.sprintf "mcp__%s__%s" server tool
+
+let text_of_mcp_result_json json =
+  let open Yojson.Safe.Util in
+  match json |> member "content" with
+  | `List blocks ->
+    let texts =
+      blocks
+      |> List.filter_map (fun block ->
+        match block |> member "type" |> to_string_option with
+        | Some "text" -> block |> member "text" |> to_string_option
+        | _ -> None)
+    in
+    if texts <> [] then String.concat "\n" texts
+    else Yojson.Safe.to_string json
+  | _ -> Yojson.Safe.to_string json
+
+let is_error_mcp_result_json json =
+  let open Yojson.Safe.Util in
+  (json |> member "is_error" |> to_bool_option |> Option.value ~default:false)
+  || (json |> member "isError" |> to_bool_option |> Option.value ~default:false)
+
+let content_blocks_of_jsonl lines =
+  let blocks = ref [] in
+  List.iter (fun line ->
+    try
+      let json = Yojson.Safe.from_string line in
+      match Cli_common_json.member_str "type" json with
+      | "item.completed" ->
+        let item = Yojson.Safe.Util.member "item" json in
+        let item_type = Cli_common_json.member_str "type" item in
+        if item_type = "agent_message" then
+          blocks := Types.Text (Cli_common_json.member_str "text" item) :: !blocks
+        else if item_type = "mcp_tool_call" then
+          let id = Cli_common_json.member_str "id" item in
+          let server = Cli_common_json.member_str "server" item in
+          let tool = Cli_common_json.member_str "tool" item in
+          let input =
+            match Yojson.Safe.Util.member "arguments" item with
+            | `Null -> `Assoc []
+            | json -> json
+          in
+          let name = server_tool_name ~server ~tool in
+          let result_json =
+            match Yojson.Safe.Util.member "result" item with
+            | `Null -> None
+            | json -> Some json
+          in
+          let tool_blocks =
+            match result_json with
+            | Some result_json ->
+              [
+                Types.ToolUse { id; name; input };
+                Types.ToolResult {
+                  tool_use_id = id;
+                  content = text_of_mcp_result_json result_json;
+                  is_error = is_error_mcp_result_json result_json;
+                  json = Some result_json;
+                };
+              ]
+            | None ->
+              [Types.ToolUse { id; name; input }]
+          in
+          blocks := List.rev_append tool_blocks !blocks
+      | _ -> ()
+    with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ()
+  ) lines;
+  List.rev !blocks
+
 (* ── CLI argument building ───────────────────────────── *)
 
 (** Threshold at which [build_args] stops passing the prompt as a
@@ -86,7 +199,7 @@ let stdin_for_prompt prompt =
    config fields have never had Codex equivalents and are still unused
    here.  Callers wanting those knobs should emit [-c ...] overrides
    via OAS_CODEX_CONFIG. *)
-let env_extra_args () =
+let legacy_env_extra_args () =
   let extras = ref [] in
   let add a = extras := !extras @ a in
   add ["-c"; "mcp_servers={}"];
@@ -109,7 +222,76 @@ let cli_model_override ~(config : config) ~(req_config : Provider_config.t) =
   | "" | "auto" -> config.model
   | _ -> Some (String.trim req_config.model_id)
 
-let build_args ~(config : config) ~(req_config : Provider_config.t) ~prompt =
+let runtime_mcp_overrides
+    (policy : Llm_transport.runtime_mcp_policy) :
+    (string list, string) result =
+  let add_server acc server =
+    let name = Llm_transport.runtime_mcp_server_name server in
+    match acc, server with
+    | Error _ as e, _ -> e
+    | Ok overrides, Llm_transport.Http_server { url; headers = []; _ } ->
+      Ok
+        (overrides
+         @ [Printf.sprintf "mcp_servers.%s.url=%s" name (toml_string url)])
+    | Ok _, Llm_transport.Http_server { headers = _ :: _; _ } ->
+      Error "codex_cli runtime MCP does not support inline HTTP headers yet"
+    | Ok overrides, Llm_transport.Stdio_server { command; args; env; _ } ->
+      Ok
+        (overrides
+         @ [
+             Printf.sprintf "mcp_servers.%s.command=%s"
+               name (toml_string command);
+             Printf.sprintf "mcp_servers.%s.args=%s"
+               name (toml_string_list args);
+           ]
+         @
+         if env = [] then []
+         else
+           [
+             Printf.sprintf "mcp_servers.%s.env=%s"
+               name (toml_string_assoc env);
+           ])
+  in
+  let server_overrides =
+    List.fold_left add_server (Ok ["mcp_servers={}"]) policy.servers
+  in
+  match server_overrides with
+  | Error _ as e -> e
+  | Ok overrides ->
+    let server_names =
+      match policy.allowed_server_names with
+      | [] ->
+        List.map Llm_transport.runtime_mcp_server_name policy.servers
+      | names -> names
+    in
+    let tool_overrides =
+      match policy.allowed_tool_names with
+      | [] -> []
+      | tool_names ->
+        List.concat_map (fun server_name ->
+          List.map (fun tool_name ->
+            Printf.sprintf "mcp_servers.%s.tools.%s.approval_mode=%s"
+              server_name tool_name (toml_string "approve")
+          ) tool_names
+        ) server_names
+    in
+    Ok (overrides @ tool_overrides)
+
+let non_mcp_env_extra_args () =
+  let extras = ref [] in
+  let add a = extras := !extras @ a in
+  (match Cli_common_env.get "OAS_CODEX_SANDBOX" with
+   | Some v -> add ["-s"; v]
+   | None -> ());
+  (match Cli_common_env.get "OAS_CODEX_PROFILE" with
+   | Some v -> add ["-p"; v]
+   | None -> ());
+  if Cli_common_env.bool "OAS_CODEX_SKIP_GIT" then
+    add ["--skip-git-repo-check"];
+  !extras
+
+let build_args ~(config : config) ~(req_config : Provider_config.t)
+    ?runtime_mcp_policy ~prompt () =
   let prompt_via_stdin = prompt_exceeds_argv_budget prompt in
   (* Order: exec-level flags come before the positional prompt.  When the
      prompt is too large for argv, pass "-" so Codex reads it from stdin. *)
@@ -119,9 +301,23 @@ let build_args ~(config : config) ~(req_config : Provider_config.t) ~prompt =
     | Some model -> ["--model"; model]
   in
   [config.codex_path; "exec"; "--json"]
-  @ env_extra_args ()
+  @ (match runtime_mcp_policy with
+     | Some policy -> (
+         match runtime_mcp_overrides policy with
+         | Ok overrides ->
+           List.concat_map (fun override -> ["-c"; override]) overrides
+         | Error _ -> [])
+     | None -> legacy_env_extra_args ())
   @ model_args
-  @ (if prompt_via_stdin then ["-"] else [prompt])
+  @ (match runtime_mcp_policy with
+     | Some (policy : Llm_transport.runtime_mcp_policy) ->
+       (match Cli_common_env.get "OAS_CODEX_SANDBOX" with
+        | Some _ -> non_mcp_env_extra_args ()
+        | None when policy.disable_builtin_tools ->
+          ["-s"; "read-only"] @ non_mcp_env_extra_args ()
+        | None -> non_mcp_env_extra_args ())
+     | None -> [])
+  @ [if prompt_via_stdin then "-" else prompt]
 
 (* ── JSONL envelope parsing ──────────────────────────── *)
 
@@ -140,9 +336,8 @@ let parse_usage json =
 
 (** Parse a single envelope into zero or more OAS sse_events.
     [command_execution] items do not map to an OAS concept — Codex runs
-    them transparently — so we emit no event for them and track them only
-    in inference telemetry. *)
-let events_of_line line =
+    them transparently — so we emit no event for them. *)
+let events_of_line_with_state (state : stream_state) line =
   try
     let json = Yojson.Safe.from_string line in
     let typ = Cli_common_json.member_str "type" json in
@@ -150,16 +345,79 @@ let events_of_line line =
     | "thread.started" ->
       let id = Cli_common_json.member_str "thread_id" json in
       [Types.MessageStart { id; model = "codex"; usage = None }]
+    | "item.started" ->
+      let item = Yojson.Safe.Util.member "item" json in
+      let item_type = Cli_common_json.member_str "type" item in
+      if item_type = "mcp_tool_call" then
+        let item_id = Cli_common_json.member_str "id" item in
+        let index = index_for_item state item_id in
+        let server = Cli_common_json.member_str "server" item in
+        let tool = Cli_common_json.member_str "tool" item in
+        let tool_name = server_tool_name ~server ~tool in
+        let arguments =
+          match Yojson.Safe.Util.member "arguments" item with
+          | `Null -> "{}"
+          | json -> Yojson.Safe.to_string json
+        in
+        [
+          Types.ContentBlockStart {
+            index;
+            content_type = "tool_use";
+            tool_id = Some item_id;
+            tool_name = Some tool_name;
+          };
+          Types.ContentBlockDelta {
+            index;
+            delta = Types.InputJsonDelta arguments;
+          };
+        ]
+      else []
     | "item.completed" ->
       let item = Yojson.Safe.Util.member "item" json in
       let item_type = Cli_common_json.member_str "type" item in
       if item_type = "agent_message" then
+        let item_id = Cli_common_json.member_str "id" item in
+        let index = index_for_item state item_id in
         let text = Cli_common_json.member_str "text" item in
-        [Types.ContentBlockStart {
-           index = 0; content_type = "text";
-           tool_id = None; tool_name = None };
-         Types.ContentBlockDelta { index = 0; delta = Types.TextDelta text };
-         Types.ContentBlockStop { index = 0 }]
+        [
+          Types.ContentBlockStart {
+            index;
+            content_type = "text";
+            tool_id = None;
+            tool_name = None;
+          };
+          Types.ContentBlockDelta { index; delta = Types.TextDelta text };
+          Types.ContentBlockStop { index };
+        ]
+      else if item_type = "mcp_tool_call" then
+        let item_id = Cli_common_json.member_str "id" item in
+        let tool_use_index = index_for_item state item_id in
+        let tool_result_events =
+          match Yojson.Safe.Util.member "result" item with
+          | `Null -> []
+          | result_json ->
+            let index = result_index_for_item state item_id in
+            let content_type =
+              if is_error_mcp_result_json result_json then
+                "tool_result_error"
+              else
+                "tool_result"
+            in
+            [
+              Types.ContentBlockStart {
+                index;
+                content_type;
+                tool_id = Some item_id;
+                tool_name = None;
+              };
+              Types.ContentBlockDelta {
+                index;
+                delta = Types.TextDelta (text_of_mcp_result_json result_json);
+              };
+              Types.ContentBlockStop { index };
+            ]
+        in
+        Types.ContentBlockStop { index = tool_use_index } :: tool_result_events
       else []  (* command_execution, etc. — no OAS mapping. *)
     | "turn.completed" ->
       let usage = parse_usage json in
@@ -175,7 +433,6 @@ let events_of_line line =
     actions rather than surfaced as OAS tool calls. *)
 let parse_jsonl_result ?(model_id = "codex") lines =
   let thread_id = ref "" in
-  let texts = ref [] in
   let usage = ref None in
   let provider_internal_action_count = ref 0 in
   List.iter (fun line ->
@@ -188,8 +445,6 @@ let parse_jsonl_result ?(model_id = "codex") lines =
       | "item.completed" ->
         let item = Yojson.Safe.Util.member "item" json in
         (match Cli_common_json.member_str "type" item with
-         | "agent_message" ->
-           texts := Cli_common_json.member_str "text" item :: !texts
          | "command_execution" ->
            incr provider_internal_action_count
          | _ -> ())
@@ -198,7 +453,7 @@ let parse_jsonl_result ?(model_id = "codex") lines =
       | _ -> ()
     with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ()
   ) lines;
-  let content = List.rev_map (fun t -> Types.Text t) !texts in
+  let content = content_blocks_of_jsonl lines in
   let telemetry =
     if !provider_internal_action_count > 0 then
       Some {
@@ -268,7 +523,23 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
         Option.value ~default:"codex"
           (cli_model_override ~config ~req_config:req.config)
       in
-      let argv = build_args ~config ~req_config:req.config ~prompt in
+      let runtime_mcp_policy_error =
+        match req.runtime_mcp_policy with
+        | Some policy -> (
+            match runtime_mcp_overrides policy with
+            | Ok _ -> None
+            | Error msg -> Some msg)
+        | None -> None
+      in
+      match runtime_mcp_policy_error with
+      | Some msg ->
+        { Llm_transport.response = Error (Http_client.NetworkError { message = msg });
+          latency_ms = 0 }
+      | None ->
+      let argv =
+        build_args ~config ~req_config:req.config
+          ?runtime_mcp_policy:req.runtime_mcp_policy ~prompt ()
+      in
       let seen_lines = ref [] in
       let on_line line =
         if String.trim line <> "" then
@@ -299,12 +570,27 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
         Option.value ~default:"codex"
           (cli_model_override ~config ~req_config:req.config)
       in
-      let argv = build_args ~config ~req_config:req.config ~prompt in
+      let runtime_mcp_policy_error =
+        match req.runtime_mcp_policy with
+        | Some policy -> (
+            match runtime_mcp_overrides policy with
+            | Ok _ -> None
+            | Error msg -> Some msg)
+        | None -> None
+      in
+      match runtime_mcp_policy_error with
+      | Some msg -> Error (Http_client.NetworkError { message = msg })
+      | None ->
+      let argv =
+        build_args ~config ~req_config:req.config
+          ?runtime_mcp_policy:req.runtime_mcp_policy ~prompt ()
+      in
+      let state = create_stream_state () in
       let seen_lines = ref [] in
       let on_line line =
         if String.trim line <> "" then begin
           seen_lines := line :: !seen_lines;
-          List.iter on_event (events_of_line line)
+          List.iter on_event (events_of_line_with_state state line)
         end
       in
       match Cli_common_subprocess.run_stream_lines ~sw ~mgr
@@ -338,7 +624,7 @@ let%test "default_config parity fields absent" =
 
 let%test "build_args includes --json flag" =
   let args =
-    build_args ~config:default_config ~req_config:(codex_req ()) ~prompt:"hello"
+    build_args ~config:default_config ~req_config:(codex_req ()) ~prompt:"hello" ()
   in
   args = ["codex"; "exec"; "--json"; "-c"; "mcp_servers={}"; "hello"]
 
@@ -349,7 +635,7 @@ let%test "build_args ignores extra parity fields" =
     max_turns = Some 5;
     permission_mode = Some "bypassPermissions";
   } in
-  let args = build_args ~config ~req_config:(codex_req ()) ~prompt:"hi" in
+  let args = build_args ~config ~req_config:(codex_req ()) ~prompt:"hi" () in
   args = ["codex"; "exec"; "--json"; "-c"; "mcp_servers={}"; "hi"]
 
 let%test "build_args with requested model" =
@@ -357,6 +643,7 @@ let%test "build_args with requested model" =
     build_args ~config:default_config
       ~req_config:(codex_req ~model_id:"gpt-5.4" ())
       ~prompt:"hi"
+      ()
   in
   args =
   ["codex"; "exec"; "--json"; "-c"; "mcp_servers={}";
@@ -364,7 +651,7 @@ let%test "build_args with requested model" =
 
 let%test "build_args with config default model for auto request" =
   let config = { default_config with model = Some "gpt-5.2-codex" } in
-  let args = build_args ~config ~req_config:(codex_req ()) ~prompt:"hi" in
+  let args = build_args ~config ~req_config:(codex_req ()) ~prompt:"hi" () in
   args =
   ["codex"; "exec"; "--json"; "-c"; "mcp_servers={}";
    "--model"; "gpt-5.2-codex"; "hi"]
@@ -382,7 +669,7 @@ let%test "stdin_for_prompt: Some when over budget, None under" =
 let%test "build_args uses stdin sentinel when prompt is too large" =
   let big = String.make (1 * 1024 * 1024) 'x' in
   let args =
-    build_args ~config:default_config ~req_config:(codex_req ()) ~prompt:big
+    build_args ~config:default_config ~req_config:(codex_req ()) ~prompt:big ()
   in
   not (List.mem big args)
   && List.nth args (List.length args - 1) = "-"
@@ -445,30 +732,51 @@ let%test "parse_jsonl_result empty lines → Error" =
   | Ok _ -> false
 
 let%test "events_of_line thread.started → MessageStart" =
+  let state = create_stream_state () in
   let line = {|{"type":"thread.started","thread_id":"abc"}|} in
-  match events_of_line line with
+  match events_of_line_with_state state line with
   | [Types.MessageStart { id = "abc"; model = "codex"; _ }] -> true
   | _ -> false
 
 let%test "events_of_line agent_message → 3 block events" =
+  let state = create_stream_state () in
   let line = {|{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"hi"}}|} in
-  (match events_of_line line with
+  (match events_of_line_with_state state line with
    | [Types.ContentBlockStart _; Types.ContentBlockDelta _; Types.ContentBlockStop _] -> true
    | _ -> false)
 
 let%test "events_of_line command_execution → no events" =
+  let state = create_stream_state () in
   let line = {|{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"ls"}}|} in
-  events_of_line line = []
+  events_of_line_with_state state line = []
+
+let%test "events_of_line mcp_tool_call completion emits tool_result block" =
+  let state = create_stream_state () in
+  let started =
+    {|{"type":"item.started","item":{"id":"call_1","type":"mcp_tool_call","server":"masc","tool":"masc_status","arguments":{"verbose":true}}}|}
+  in
+  let completed =
+    {|{"type":"item.completed","item":{"id":"call_1","type":"mcp_tool_call","server":"masc","tool":"masc_status","result":{"content":[{"type":"text","text":"ok"}],"isError":false}}}|}
+  in
+  ignore (events_of_line_with_state state started);
+  match events_of_line_with_state state completed with
+  | [Types.ContentBlockStop _;
+     Types.ContentBlockStart { content_type = "tool_result"; _ };
+     Types.ContentBlockDelta { delta = Types.TextDelta "ok"; _ };
+     Types.ContentBlockStop _] -> true
+  | _ -> false
 
 let%test "events_of_line turn.completed → MessageDelta+Stop" =
+  let state = create_stream_state () in
   let line = {|{"type":"turn.completed","usage":{"input_tokens":10,"cached_input_tokens":0,"output_tokens":5}}|} in
-  (match events_of_line line with
+  (match events_of_line_with_state state line with
    | [Types.MessageDelta { stop_reason = Some Types.EndTurn; _ };
       Types.MessageStop] -> true
    | _ -> false)
 
 let%test "events_of_line invalid json → []" =
-  events_of_line "not json" = []
+  let state = create_stream_state () in
+  events_of_line_with_state state "not json" = []
 
 (* ── env-driven extra args ──────────────────────────── *)
 
@@ -495,13 +803,13 @@ let%test "default: argv disables MCP even with no env" =
   with_unset "OAS_CODEX_SANDBOX" (fun () ->
   with_unset "OAS_CODEX_PROFILE" (fun () ->
   with_unset "OAS_CODEX_SKIP_GIT" (fun () ->
-    build_args ~config:default_config ~req_config:(codex_req ()) ~prompt:"hi"
+    build_args ~config:default_config ~req_config:(codex_req ()) ~prompt:"hi" ()
     = ["codex"; "exec"; "--json"; "-c"; "mcp_servers={}"; "hi"]))))
 
 let%test "env: OAS_CODEX_CONFIG emits -c pairs before prompt" =
   with_env "OAS_CODEX_CONFIG" "mcp_servers={},model=o3" (fun () ->
     let args =
-      build_args ~config:default_config ~req_config:(codex_req ()) ~prompt:"hi"
+      build_args ~config:default_config ~req_config:(codex_req ()) ~prompt:"hi" ()
     in
     (* must emit -c mcp_servers={} and -c model=o3, and prompt stays last *)
     List.mem "-c" args
@@ -513,7 +821,7 @@ let%test "env: OAS_CODEX_SANDBOX and OAS_CODEX_SKIP_GIT" =
   with_env "OAS_CODEX_SANDBOX" "read-only" (fun () ->
   with_env "OAS_CODEX_SKIP_GIT" "true" (fun () ->
     let args =
-      build_args ~config:default_config ~req_config:(codex_req ()) ~prompt:"hi"
+      build_args ~config:default_config ~req_config:(codex_req ()) ~prompt:"hi" ()
     in
     List.mem "-s" args
     && List.mem "read-only" args
@@ -523,3 +831,44 @@ let%test "prompt_exceeds_argv_budget: OAS_CODEX_PROMPT_ARGV_THRESHOLD override" 
   with_env "OAS_CODEX_PROMPT_ARGV_THRESHOLD" "100" (fun () ->
     prompt_exceeds_argv_budget (String.make 200 'x')
     && not (prompt_exceeds_argv_budget (String.make 50 'x')))
+
+let%test "build_args runtime MCP wires request-scoped server" =
+  let policy =
+    {
+      Llm_transport.empty_runtime_mcp_policy with
+      servers = [
+        Llm_transport.Http_server {
+          name = "masc";
+          url = "http://127.0.0.1:8935/mcp";
+          headers = [];
+        };
+      ];
+      allowed_server_names = ["masc"];
+      allowed_tool_names = ["masc_status"];
+      disable_builtin_tools = true;
+    }
+  in
+  let args =
+    build_args ~config:default_config ~req_config:(codex_req ()) ~prompt:"hi"
+      ~runtime_mcp_policy:policy
+      ()
+  in
+  List.mem "mcp_servers.masc.url=\"http://127.0.0.1:8935/mcp\"" args
+  && List.mem "mcp_servers.masc.tools.masc_status.approval_mode=\"approve\"" args
+  && List.mem "-s" args
+  && List.mem "read-only" args
+
+let%test "parse_jsonl_result includes mcp tool call blocks" =
+  let lines = [
+    {|{"type":"thread.started","thread_id":"abc-123"}|};
+    {|{"type":"item.completed","item":{"id":"call_1","type":"mcp_tool_call","server":"masc","tool":"masc_status","arguments":{"verbose":true},"result":{"content":[{"type":"text","text":"ok"}],"isError":false}}}|};
+    {|{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"done"}}|};
+  ] in
+  match parse_jsonl_result lines with
+  | Ok resp ->
+    (match resp.content with
+     | Types.ToolUse { name = "mcp__masc__masc_status"; _ }
+       :: Types.ToolResult { tool_use_id = "call_1"; content = "ok"; _ }
+       :: Types.Text "done" :: [] -> true
+     | _ -> false)
+  | Error _ -> false

--- a/lib/llm_provider/transport_gemini_cli.ml
+++ b/lib/llm_provider/transport_gemini_cli.ml
@@ -314,6 +314,15 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
   let warned = ref false in
   {
     complete_sync = (fun (req : Llm_transport.completion_request) ->
+      (match req.runtime_mcp_policy with
+       | Some _ ->
+         { Llm_transport.response =
+             Error (Http_client.NetworkError {
+               message =
+                 "gemini_cli does not support request-scoped runtime MCP configuration";
+             });
+           latency_ms = 0 }
+       | None ->
       warn_unsupported_once config warned;
       let messages = Cli_common_prompt.non_system_messages req.messages in
       let prompt = Cli_common_prompt.prompt_of_messages messages in
@@ -324,9 +333,16 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
       | Error _ as e -> { Llm_transport.response = e; latency_ms = 0 }
       | Ok { stdout; stderr = _; latency_ms } ->
         let response = parse_json_result (String.trim stdout) in
-        { Llm_transport.response; latency_ms });
+        { Llm_transport.response; latency_ms }));
 
     complete_stream = (fun ~on_event (req : Llm_transport.completion_request) ->
+      match req.runtime_mcp_policy with
+      | Some _ ->
+        Error (Http_client.NetworkError {
+          message =
+            "gemini_cli does not support request-scoped runtime MCP configuration";
+        })
+      | None ->
       warn_unsupported_once config warned;
       let messages = Cli_common_prompt.non_system_messages req.messages in
       let prompt = Cli_common_prompt.prompt_of_messages messages in
@@ -568,3 +584,49 @@ let%test "default: no vars still keeps MCP disabled via sentinel" =
     && not (List.mem "--approval-mode" args)
     && has_sentinel_whitelist args
     && not (List.mem "" args)))))
+
+let runtime_mcp_policy_sample =
+  {
+    Llm_transport.empty_runtime_mcp_policy with
+    servers = [
+      Llm_transport.Http_server {
+        name = "masc";
+        url = "http://127.0.0.1:8935/mcp";
+        headers = [];
+      };
+    ];
+    allowed_server_names = ["masc"];
+    allowed_tool_names = ["masc_status"];
+  }
+
+let runtime_mcp_req_sample : Llm_transport.completion_request =
+  {
+    config = gemini_req;
+    messages = [];
+    tools = [];
+    runtime_mcp_policy = Some runtime_mcp_policy_sample;
+  }
+
+let runtime_mcp_policy_error_message =
+  "gemini_cli does not support request-scoped runtime MCP configuration"
+
+let%test_unit "complete_sync rejects request-scoped runtime MCP policy" =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let transport = create ~sw ~mgr:(Eio.Stdenv.process_mgr env) ~config:default_config in
+  match transport.complete_sync runtime_mcp_req_sample with
+  | {
+      response = Error (Http_client.NetworkError { message });
+      latency_ms = 0;
+    } ->
+    assert (String.equal message runtime_mcp_policy_error_message)
+  | _ -> assert false
+
+let%test_unit "complete_stream rejects request-scoped runtime MCP policy" =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let transport = create ~sw ~mgr:(Eio.Stdenv.process_mgr env) ~config:default_config in
+  match transport.complete_stream ~on_event:(fun _ -> ()) runtime_mcp_req_sample with
+  | Error (Http_client.NetworkError { message }) ->
+    assert (String.equal message runtime_mcp_policy_error_message)
+  | _ -> assert false

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -243,14 +243,35 @@ let dispatch_sync ~sw ?clock agent prep =
         Llm_provider.Complete.complete_with_retry
           ~sw ~net:agent.net ?transport:agent.options.transport ~clock
           ~config:pc ~messages:prep.effective_messages ~tools
+          ?runtime_mcp_policy:agent.options.runtime_mcp_policy
           ?priority:agent.options.priority ()
     | None ->
         Llm_provider.Complete.complete
           ~sw ~net:agent.net ?transport:agent.options.transport
           ~config:pc ~messages:prep.effective_messages ~tools
+          ?runtime_mcp_policy:agent.options.runtime_mcp_policy
           ?priority:agent.options.priority ()
   in
   match call () with
+  | Ok resp -> Ok resp
+  | Error err -> Error (sdk_error_of_http_error err)
+
+let dispatch_stream ~sw agent prep ~on_event =
+  let tools = Option.value prep.Agent_turn.tools_json ~default:[] in
+  let open Result in
+  let* pc =
+    Provider.provider_config_of_agent
+      ~state:agent.state
+      ~base_url:agent.options.base_url
+      agent.options.provider
+  in
+  match
+    Llm_provider.Complete.complete_stream
+      ~sw ~net:agent.net ?transport:agent.options.transport
+      ~config:pc ~messages:prep.effective_messages ~tools
+      ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+      ~on_event ?priority:agent.options.priority ()
+  with
   | Ok resp -> Ok resp
   | Error err -> Error (sdk_error_of_http_error err)
 
@@ -268,33 +289,7 @@ let stage_route ~sw ?clock ~api_strategy agent prep =
       { kind = Api_call; name = "create_message_stream";
         agent_name = agent.state.config.name;
         turn = agent.state.turn_count; extra = [] }
-      (fun _tracer ->
-        let can_stream = match agent.options.provider with
-            | Some p -> Provider_intf.supports_streaming p
-            | None -> false  (* Default Anthropic supports streaming *)
-          in
-          if can_stream then
-            Streaming.create_message_stream ~sw ~net:agent.net
-              ~base_url:agent.options.base_url
-              ?provider:agent.options.provider
-              ~config:agent.state ~messages:prep.effective_messages
-              ?tools:prep.tools_json ~on_event ()
-          else
-            (* Provider does not support native streaming —
-               fall back to sync call + synthetic SSE events. *)
-            let sync_result =
-              Api.create_message ~sw ~net:agent.net
-                ~base_url:agent.options.base_url
-                ?provider:agent.options.provider ?clock
-                ~config:agent.state
-                ~messages:prep.effective_messages
-                ?tools:prep.tools_json ()
-            in
-            (match sync_result with
-             | Ok response ->
-               Streaming.emit_synthetic_events response on_event;
-               Ok response
-             | Error _ -> sync_result))
+      (fun _tracer -> dispatch_stream ~sw agent prep ~on_event)
 
 (* ── Stage 4: Collect ────────────────────────────────────── *)
 

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -38,6 +38,8 @@ type capabilities = {
   supports_tools: bool;
   supports_tool_choice: bool;
   supports_parallel_tool_calls: bool;
+  supports_runtime_mcp_tools: bool;
+  supports_runtime_tool_events: bool;
   supports_reasoning: bool;
   supports_extended_thinking: bool;
   supports_reasoning_budget: bool;


### PR DESCRIPTION
## What changed
Add request-scoped runtime MCP support for non-interactive CLI transports.

- introduce `runtime_mcp_policy` and request-scoped MCP server declarations in the transport layer
- split provider capability flags so runtime MCP tool lanes are distinct from inline tool support
- thread runtime MCP policy through agent, builder, pipeline, complete, and cache paths
- wire Claude Code to request-scoped `--mcp-config` and MCP tool allowlists
- wire Codex CLI to request-scoped MCP server overrides and restore MCP tool events in the stream parser
- keep Gemini CLI fail-closed when request-scoped runtime MCP is requested
- add regression coverage for Claude request-scoped arg wiring, Codex MCP event parsing, and Gemini fail-closed behavior

## Why
The previous transport contract only modeled inline/API tools. That prevented non-interactive CLI providers from using the public MCP surface in a request-scoped, observable way.

## Impact
CLI providers can now participate in a public MCP lane without pretending to support inline tools, while preserving structured tool-use/tool-result observability where supported.

## Validation
- `dune build --root .`
- `dune runtest --root .`