### PR TITLE
[codex] classify completion retries by api error

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -603,14 +603,21 @@ let default_retry_config = {
   backoff_multiplier = Constants.Retry.backoff_multiplier;
 }
 
-let is_retryable = function
-  | Http_client.HttpError { code; _ } ->
-      List.mem code Constants.Http.retryable_codes
-  | Http_client.AcceptRejected _ -> false
-  | Http_client.NetworkError _ -> true
+let classify_retry_error = function
+  | Http_client.HttpError { code; body } ->
+      Some (Retry.classify_error ~status:code ~body)
+  | Http_client.NetworkError { message } ->
+      Some (Retry.NetworkError { message })
+  | Http_client.AcceptRejected _ -> None
   (* Wiring bug, not transient — retrying cannot summon a missing
      transport. *)
-  | Http_client.CliTransportRequired _ -> false
+  | Http_client.CliTransportRequired _ -> None
+
+let is_retryable = function
+  | err ->
+      (match classify_retry_error err with
+       | Some api_err -> Retry.is_retryable api_err
+       | None -> false)
 
 let complete_with_retry ~sw ~net ?transport ~clock
     ~(config : Provider_config.t)
@@ -621,11 +628,18 @@ let complete_with_retry ~sw ~net ?transport ~clock
     let factor = Constants.Retry.jitter_min +. Random.float Constants.Retry.jitter_range in
     delay *. factor
   in
+  let sleep_delay_sec ~delay err =
+    match classify_retry_error err with
+    | Some (Retry.RateLimited { retry_after = Some retry_after; _ }) ->
+        retry_after
+    | Some _ | None ->
+        jittered delay
+  in
   let rec attempt n delay =
     match complete ~sw ~net ?transport ~config ~messages ~tools ?cache ?metrics ?priority () with
     | Ok _ as success -> success
     | Error err when is_retryable err && n < retry_config.max_retries ->
-        Eio.Time.sleep clock (jittered delay);
+        Eio.Time.sleep clock (sleep_delay_sec ~delay err);
         let next_delay =
           Float.min
             (delay *. retry_config.backoff_multiplier)
@@ -796,6 +810,15 @@ let make_http_transport ~sw ~net : Llm_transport.t = {
 let%test "is_retryable 429 rate limit" =
   is_retryable (Http_client.HttpError { code = 429; body = "" }) = true
 
+let%test "is_retryable 429 hard quota is false" =
+  not
+    (is_retryable
+       (Http_client.HttpError {
+          code = 429;
+          body =
+            {|{"error":{"message":"Insufficient balance or no resource package. Please recharge.","retry_after":5.0}}|};
+        }))
+
 let%test "is_retryable 500 server error" =
   is_retryable (Http_client.HttpError { code = 500; body = "" }) = true
 
@@ -810,6 +833,14 @@ let%test "is_retryable 529 overloaded" =
 
 let%test "is_retryable 400 not retryable" =
   is_retryable (Http_client.HttpError { code = 400; body = "" }) = false
+
+let%test "is_retryable 400 malformed json is true" =
+  is_retryable
+    (Http_client.HttpError {
+       code = 400;
+       body =
+         {|{"error":"Value looks like object, but can't find closing '}' symbol"}|};
+     })
 
 let%test "is_retryable 401 not retryable" =
   is_retryable (Http_client.HttpError { code = 401; body = "" }) = false

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -90,8 +90,8 @@ type retry_config = {
 val default_retry_config : retry_config
 
 (** Classify whether an HTTP error is worth retrying.
-    Retryable: 429 (rate limit), 500, 502, 503, 529,
-    and all network errors. *)
+    Uses {!Retry.classify_error} for HTTP bodies, so hard-quota 429s
+    fail fast while malformed-JSON 400s remain retryable. *)
 val is_retryable : Http_client.http_error -> bool
 
 (** Completion with exponential backoff retry.

--- a/test/complete_retry/dune
+++ b/test/complete_retry/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_complete_retry)
+ (libraries llm_provider alcotest eio eio_main))

--- a/test/complete_retry/test_complete_retry.ml
+++ b/test/complete_retry/test_complete_retry.ml
@@ -1,0 +1,131 @@
+open Alcotest
+open Llm_provider
+
+let mock_response text : Types.api_response =
+  {
+    id = "resp-1";
+    model = "mock";
+    stop_reason = Types.EndTurn;
+    content = [Types.Text text];
+    usage = None;
+    telemetry = None;
+  }
+
+let scripted_transport scripted_responses request_count : Llm_transport.t =
+  let responses = ref scripted_responses in
+  {
+    complete_sync =
+      (fun _req ->
+        incr request_count;
+        match !responses with
+        | next :: rest ->
+            responses := rest;
+            { Llm_transport.response = next; latency_ms = 1 }
+        | [] ->
+            failwith "scripted transport exhausted");
+    complete_stream =
+      (fun ~on_event:_ _req ->
+        failwith "stream transport not used in this test");
+  }
+
+let make_config base_url =
+  Provider_config.make ~kind:Provider_config.Anthropic
+    ~model_id:"test-model" ~base_url ~request_path:"/v1/messages"
+    ~temperature:0.0 ~max_tokens:100 ()
+
+let messages = [Types.user_msg "hello"]
+
+let fast_retry_config : Complete.retry_config = {
+  max_retries = 2;
+  initial_delay_sec = 0.001;
+  max_delay_sec = 0.002;
+  backoff_multiplier = 2.0;
+}
+
+let hard_quota_body =
+  {|{"error":{"message":"Insufficient balance or no resource package. Please recharge.","retry_after":5.0}}|}
+
+let malformed_json_body =
+  {|{"error":"Value looks like object, but can't find closing '}' symbol"}|}
+
+let test_is_retryable_hard_quota_429 () =
+  check bool "hard quota 429 is not retryable" false
+    (Complete.is_retryable
+       (Http_client.HttpError { code = 429; body = hard_quota_body }))
+
+let test_is_retryable_malformed_json_400 () =
+  check bool "malformed json 400 is retryable" true
+    (Complete.is_retryable
+       (Http_client.HttpError { code = 400; body = malformed_json_body }))
+
+let test_complete_with_retry_stops_on_hard_quota_429 () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  try
+    Eio.Switch.run @@ fun sw ->
+    let request_count = ref 0 in
+    let transport =
+      scripted_transport
+        [
+          Error (Http_client.HttpError { code = 429; body = hard_quota_body });
+        ]
+        request_count
+    in
+    let config = make_config "http://unused.test" in
+    (match Complete.complete_with_retry ~sw ~net:env#net ~transport ~clock
+             ~config ~messages ~retry_config:fast_retry_config () with
+     | Ok _ -> fail "expected hard quota failure"
+     | Error (Http_client.HttpError { code; _ }) ->
+       check int "status" 429 code;
+       check int "single request" 1 !request_count;
+       Eio.Switch.fail sw Exit
+     | Error _ -> fail "expected HttpError");
+  with Exit -> ()
+
+let test_complete_with_retry_retries_malformed_json_400 () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  try
+    Eio.Switch.run @@ fun sw ->
+    let request_count = ref 0 in
+    let transport =
+      scripted_transport
+        [
+          Error (Http_client.HttpError { code = 400; body = malformed_json_body });
+          Ok (mock_response "recovered after retry");
+        ]
+        request_count
+    in
+    let config = make_config "http://unused.test" in
+    (match Complete.complete_with_retry ~sw ~net:env#net ~transport ~clock
+             ~config ~messages ~retry_config:fast_retry_config () with
+     | Ok resp ->
+       let text =
+         List.filter_map
+           (function Types.Text s -> Some s | _ -> None)
+           resp.content
+         |> String.concat ""
+       in
+       check string "response text" "recovered after retry" text;
+       check int "two requests" 2 !request_count;
+       Eio.Switch.fail sw Exit
+     | Error _ -> fail "expected recovery after malformed json")
+  with Exit -> ()
+
+let () =
+  run "complete_retry"
+    [
+      ( "classification",
+        [
+          test_case "hard quota 429" `Quick test_is_retryable_hard_quota_429;
+          test_case "malformed json 400" `Quick
+            test_is_retryable_malformed_json_400;
+        ] );
+      ( "retry loop",
+        [
+          test_case "hard quota stops immediately" `Quick
+            test_complete_with_retry_stops_on_hard_quota_429;
+          test_case "malformed json retries same provider" `Quick
+            test_complete_with_retry_retries_malformed_json_400;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- make  use  instead of raw status codes
- stop retrying hard-quota 429 responses while still retrying malformed-json 400 responses
- add focused retry regression tests under 

## Validation
- 
- 
- Testing `[1mcomplete_retry[0m'.
[2mThis run has ID `3P83PCNO'.

[0m  [32m[OK][0m          [36mclassification[0m          0   hard quota 429.
  [32m[OK][0m          [36mclassification[0m          1   malformed json 400.
  [32m[OK][0m          [36mretry loop[0m              0   hard quota stops immediately.
  [32m[OK][0m          [36mretry loop[0m              1   malformed json retries same provi...

Full test results in `[36m~/me/workspace/yousleepwhen/oas/.worktrees/issue-693-retry-categorization/_build/_tests/complete_retry[0m'.
[32mTest Successful[0m in 0.003s. 4 tests run.
- 

Closes #693