### PR TITLE
[codex] consolidate provider retry backoff

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -601,6 +601,13 @@ let default_retry_config = {
   backoff_multiplier = Constants.Retry.backoff_multiplier;
 }
 
+let shared_retry_config_of_complete (config : retry_config) : Retry.retry_config = {
+  max_retries = config.max_retries;
+  initial_delay = config.initial_delay_sec;
+  max_delay = config.max_delay_sec;
+  backoff_factor = config.backoff_multiplier;
+}
+
 let classify_retry_error = function
   | Http_client.HttpError { code; body } ->
       Some (Retry.classify_error ~status:code ~body)
@@ -623,34 +630,13 @@ let complete_with_retry ~sw ~net ?transport ~clock
     ?runtime_mcp_policy
     ?(retry_config=default_retry_config)
     ?cache ?metrics ?priority () =
-  let jittered delay =
-    let factor = Constants.Retry.jitter_min +. Random.float Constants.Retry.jitter_range in
-    delay *. factor
-  in
-  let sleep_delay_sec ~delay err =
-    match classify_retry_error err with
-    | Some (Retry.RateLimited { retry_after = Some retry_after; _ }) ->
-        retry_after
-    | Some _ | None ->
-        jittered delay
-  in
-  let rec attempt n delay =
-    match
-      complete ~sw ~net ?transport ~config ~messages ~tools
-        ?runtime_mcp_policy ?cache ?metrics ?priority ()
-    with
-    | Ok _ as success -> success
-    | Error err when is_retryable err && n < retry_config.max_retries ->
-        Eio.Time.sleep clock (sleep_delay_sec ~delay err);
-        let next_delay =
-          Float.min
-            (delay *. retry_config.backoff_multiplier)
-            retry_config.max_delay_sec
-        in
-        attempt (n + 1) next_delay
-    | Error _ as fail -> fail
-  in
-  attempt 0 retry_config.initial_delay_sec
+  Retry.with_retry_map_error
+    ~clock
+    ~config:(shared_retry_config_of_complete retry_config)
+    ~classify:classify_retry_error
+    (fun () ->
+       complete ~sw ~net ?transport ~config ~messages ~tools
+         ?runtime_mcp_policy ?cache ?metrics ?priority ())
 
 (* ── Streaming ───────────────────────────────────────── *)
 

--- a/lib/llm_provider/constants.ml
+++ b/lib/llm_provider/constants.ml
@@ -82,11 +82,10 @@ end
 
 (* ── Retry ───────────────────────────────────────── *)
 
-module Retry = struct
+module Retry_common = struct
   let max_retries = 3
-  let initial_delay_sec = 1.0
-  let max_delay_sec = 30.0
   let backoff_multiplier = 2.0
+  let initial_delay_sec = 1.0
 
   (** Jitter range: delay is multiplied by a random factor
       in [jitter_min, jitter_min + jitter_range). *)
@@ -94,15 +93,24 @@ module Retry = struct
   let jitter_range = 1.0
 end
 
+module Retry = struct
+  let max_retries = Retry_common.max_retries
+  let initial_delay_sec = Retry_common.initial_delay_sec
+  let max_delay_sec = 30.0
+  let backoff_multiplier = Retry_common.backoff_multiplier
+  let jitter_min = Retry_common.jitter_min
+  let jitter_range = Retry_common.jitter_range
+end
+
 (* ── Structured retry (retry.ml) ─────────────────── *)
 
 module Structured_retry = struct
-  let max_retries = 3
-  let initial_delay = 1.0
+  let max_retries = Retry_common.max_retries
+  let initial_delay = Retry_common.initial_delay_sec
   let max_delay = 60.0
-  let backoff_factor = 2.0
-  let jitter_min = 0.5
-  let jitter_range = 1.0
+  let backoff_factor = Retry_common.backoff_multiplier
+  let jitter_min = Retry_common.jitter_min
+  let jitter_range = Retry_common.jitter_range
 end
 
 (* ── Sampling ────────────────────────────────────── *)

--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -280,13 +280,10 @@ let calculate_delay config attempt =
     +. Random.float Constants.Structured_retry.jitter_range in
   capped *. jitter
 
-(** Retry a function with exponential backoff.
-    [f] should return [Ok result] on success or [Error api_error] on failure.
-    Uses Eio.Time for sleeping between retries.
-    Non-retryable errors (AuthError, ContextOverflow, and most InvalidRequest)
-    are returned immediately.  InvalidRequest caused by malformed JSON in the
-    model output is treated as retryable. *)
-let with_retry ~clock ?(config=default_config) (f : unit -> ('a, api_error) result) : ('a, api_error) result =
+(** Retry a function with exponential backoff while preserving the original
+    error type. *)
+let with_retry_map_error ~clock ?(config=default_config) ~classify
+    (f : unit -> ('a, 'e) result) : ('a, 'e) result =
   let sleep_for err attempt =
     let delay = match err with
       | RateLimited { retry_after = Some ra; _ } -> ra
@@ -300,17 +297,31 @@ let with_retry ~clock ?(config=default_config) (f : unit -> ('a, api_error) resu
     else
       match f () with
       | Ok _ as success -> success
-      | Error err when is_retryable err ->
-        sleep_for err attempt;
-        loop (attempt + 1) err
-      | Error _ as non_retryable -> non_retryable
+      | Error err ->
+        (match classify err with
+         | Some api_err when is_retryable api_err ->
+           sleep_for api_err attempt;
+           loop (attempt + 1) err
+         | Some _ | None -> Error err)
   in
   match f () with
   | Ok _ as success -> success
-  | Error err when is_retryable err ->
-    sleep_for err 0;
-    loop 1 err
-  | Error _ as non_retryable -> non_retryable
+  | Error err ->
+    (match classify err with
+     | Some api_err when is_retryable api_err ->
+       sleep_for api_err 0;
+       loop 1 err
+     | Some _ | None -> Error err)
+
+(** Retry a function with exponential backoff.
+    [f] should return [Ok result] on success or [Error api_error] on failure.
+    Uses Eio.Time for sleeping between retries.
+    Non-retryable errors (AuthError, ContextOverflow, and most InvalidRequest)
+    are returned immediately.  InvalidRequest caused by malformed JSON in the
+    model output is treated as retryable. *)
+let with_retry ~clock ?config (f : unit -> ('a, api_error) result)
+    : ('a, api_error) result =
+  with_retry_map_error ~clock ?config ~classify:Option.some f
 
 [@@@coverage off]
 

--- a/lib/llm_provider/retry.mli
+++ b/lib/llm_provider/retry.mli
@@ -66,3 +66,15 @@ val with_retry :
   (unit -> ('a, api_error) result) ->
   ('a, api_error) result
 
+(** Retry a function while preserving its original error type.
+    [classify] returns [Some api_error] for errors that should use the shared
+    retry / backoff policy, or [None] to fail fast without retry.
+
+    @stability Internal
+    @since 0.163.0 *)
+val with_retry_map_error :
+  clock:_ Eio.Time.clock ->
+  ?config:retry_config ->
+  classify:('e -> api_error option) ->
+  (unit -> ('a, 'e) result) ->
+  ('a, 'e) result

--- a/test/test_retry.ml
+++ b/test/test_retry.ml
@@ -216,6 +216,47 @@ let test_with_retry_non_retryable_during_loop () =
    | _ -> fail "expected InvalidRequest from loop");
   check int "stopped at 2" 2 !attempt
 
+type mapped_error =
+  | Retryable of Retry.api_error
+  | HardFail of string
+
+let test_with_retry_map_error_succeeds_after_retries () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let attempt = ref 0 in
+  let f () =
+    incr attempt;
+    if !attempt < 3 then
+      Error (Retryable (Retry.ServerError { status = 500; message = "transient" }))
+    else Ok "recovered"
+  in
+  (match
+     Retry.with_retry_map_error ~clock ~config:fast_config
+       ~classify:(function Retryable err -> Some err | HardFail _ -> None)
+       f
+   with
+   | Ok v -> check string "eventual success" "recovered" v
+   | Error _ -> fail "expected recovery after mapped retry");
+  check int "took 3 attempts" 3 !attempt
+
+let test_with_retry_map_error_preserves_original_error () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let attempt = ref 0 in
+  let f () =
+    incr attempt;
+    Error (HardFail "missing transport")
+  in
+  (match
+     Retry.with_retry_map_error ~clock ~config:fast_config
+       ~classify:(function Retryable err -> Some err | HardFail _ -> None)
+       f
+   with
+   | Error (HardFail message) ->
+       check string "original error preserved" "missing transport" message
+   | _ -> fail "expected original HardFail");
+  check int "only 1 attempt" 1 !attempt
+
 let test_with_retry_max_retries_exhausted () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
@@ -265,6 +306,8 @@ let () =
       test_case "rate limited uses retry_after" `Quick test_with_retry_rate_limited_uses_retry_after;
       test_case "non-retryable stops immediately" `Quick test_with_retry_non_retryable_stops;
       test_case "non-retryable during loop" `Quick test_with_retry_non_retryable_during_loop;
+      test_case "map_error retries classified errors" `Quick test_with_retry_map_error_succeeds_after_retries;
+      test_case "map_error preserves original errors" `Quick test_with_retry_map_error_preserves_original_error;
       test_case "max retries exhausted" `Quick test_with_retry_max_retries_exhausted;
     ];
     "providers", [


### PR DESCRIPTION
## What Changed
- moved provider completion retry execution onto `Llm_provider.Retry.with_retry_map_error`
- removed the duplicated backoff/jitter/sleep loop from `Llm_provider.Complete.complete_with_retry`
- preserved `Complete.retry_config` as the public API and mapped it internally to shared retry config
- consolidated duplicated retry constants into a shared common block while keeping the existing 30s vs 60s cap split intact
- added retry helper regression tests for mapped error classification and original error preservation

## Why
Provider HTTP retry and backoff policy was implemented twice inside `llm_provider`, which made `retry_after`, jitter, and retryability behavior easy to drift. This change keeps the behavior in one execution path.

## Impact
- provider completion retry/backoff behavior now flows through one SSOT implementation
- existing `Complete` callers keep the same API surface
- no intended behavior change for non-provider retry loops such as tool correction or workflow retries

## Validation
- `git diff --check`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/refactor-retry-backoff lib/llm_provider test/test_retry.exe test/test_provider_complete.exe test/complete_retry/test_complete_retry.exe`
- `./_build/default/test/test_retry.exe`
- `./_build/default/test/test_provider_complete.exe`
- `./_build/default/test/complete_retry/test_complete_retry.exe`
