### PR TITLE
fix(agent_config): route resolve_provider through Provider_kind.of_string

### DIFF
--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -211,59 +211,78 @@ let load path =
   | Yojson.Json_error msg ->
     Error (Error.Io (FileOpFailed { op = "load"; path; detail = "JSON error: " ^ msg }))
 
-(** Resolve provider string + optional base_url to a Provider.config. *)
+(** Resolve provider string + optional base_url to a Provider.config.
+
+    Canonical provider kinds ({!Llm_provider.Provider_kind.t}) are dispatched
+    through {!Llm_provider.Provider_kind.of_string}, which accepts the
+    canonical wire forms (["anthropic"], ["openai_compat"], …) plus the
+    documented aliases (["claude"] -> Anthropic,
+    ["openai"] -> OpenAI_compat, ["llama"] -> Ollama), case-insensitively
+    with leading/trailing whitespace trimmed.
+
+    ["local"] remains a first-class routing shorthand (not a Provider_kind
+    variant) and is matched explicitly before the parser so that
+    ["LOCAL"] / [" local "] also reach the Local branch.
+
+    Any kind the parser recognises beyond Anthropic / OpenAI_compat — or
+    anything it does not recognise at all — falls through to the registry
+    lookup path, preserving the legacy [Custom_registered] behaviour that
+    downstream tests and configs depend on. *)
 let resolve_provider ~model_id provider_str base_url =
-  match provider_str with
-  | "local" ->
-      let url = match base_url with
-        | Some u -> u
-        | None -> Defaults.local_llm_url
-      in
-      { Provider.provider = Local { base_url = url };
-        model_id; api_key_env = "" }
-  | "anthropic" ->
-      { Provider.provider = Anthropic;
-        model_id; api_key_env = "ANTHROPIC_API_KEY" }
-  | "openai" ->
-      let url = match base_url with
-        | Some u -> u
-        | None -> "https://api.openai.com"
-      in
-      { Provider.provider = OpenAICompat {
-          base_url = url; auth_header = None;
-          path = "/v1/chat/completions"; static_token = None };
-        model_id; api_key_env = "OPENAI_API_KEY" }
-  | other ->
-      let registry = Llm_provider.Provider_registry.default () in
-      match Llm_provider.Provider_registry.find registry other with
-      | Some entry ->
-          (match base_url with
-           | None ->
-               (* Preserve registry-declared kind (Gemini/Glm/Ollama/etc.)
-                  via Custom_registered. Downstream (provider_config_of_agent,
-                  request_path, Capabilities, resolve) dispatches through
-                  Provider_registry by name, retaining entry.defaults.kind. *)
-               { Provider.provider = Custom_registered { name = other };
-                 model_id; api_key_env = entry.defaults.api_key_env }
-           | Some url ->
-               (* Explicit base_url override: legacy Provider.config variant
-                  cannot carry kind + arbitrary URL simultaneously, so kind
-                  flattens to OpenAI_compat. For kind-preserving override,
-                  construct Llm_provider.Provider_config.t directly via
-                  Provider_config.make. *)
-               { Provider.provider = OpenAICompat {
-                   base_url = url; auth_header = None;
-                   path = entry.defaults.request_path; static_token = None };
-                 model_id; api_key_env = entry.defaults.api_key_env })
-      | None ->
-          let url = match base_url with
-            | Some u -> u
-            | None -> Defaults.local_llm_url
-          in
-          { Provider.provider = OpenAICompat {
-              base_url = url; auth_header = None;
-              path = "/v1/chat/completions"; static_token = None };
-            model_id; api_key_env = other }
+  let normalized = String.lowercase_ascii (String.trim provider_str) in
+  if normalized = "local" then
+    let url = match base_url with
+      | Some u -> u
+      | None -> Defaults.local_llm_url
+    in
+    { Provider.provider = Local { base_url = url };
+      model_id; api_key_env = "" }
+  else
+    match Llm_provider.Provider_kind.of_string provider_str with
+    | Some Anthropic ->
+        { Provider.provider = Anthropic;
+          model_id; api_key_env = "ANTHROPIC_API_KEY" }
+    | Some OpenAI_compat ->
+        let url = match base_url with
+          | Some u -> u
+          | None -> "https://api.openai.com"
+        in
+        { Provider.provider = OpenAICompat {
+            base_url = url; auth_header = None;
+            path = "/v1/chat/completions"; static_token = None };
+          model_id; api_key_env = "OPENAI_API_KEY" }
+    | Some (Ollama | Gemini | Glm | Claude_code | Gemini_cli | Codex_cli)
+    | None ->
+        let registry = Llm_provider.Provider_registry.default () in
+        match Llm_provider.Provider_registry.find registry provider_str with
+        | Some entry ->
+            (match base_url with
+             | None ->
+                 (* Preserve registry-declared kind (Gemini/Glm/Ollama/etc.)
+                    via Custom_registered. Downstream (provider_config_of_agent,
+                    request_path, Capabilities, resolve) dispatches through
+                    Provider_registry by name, retaining entry.defaults.kind. *)
+                 { Provider.provider = Custom_registered { name = provider_str };
+                   model_id; api_key_env = entry.defaults.api_key_env }
+             | Some url ->
+                 (* Explicit base_url override: legacy Provider.config variant
+                    cannot carry kind + arbitrary URL simultaneously, so kind
+                    flattens to OpenAI_compat. For kind-preserving override,
+                    construct Llm_provider.Provider_config.t directly via
+                    Provider_config.make. *)
+                 { Provider.provider = OpenAICompat {
+                     base_url = url; auth_header = None;
+                     path = entry.defaults.request_path; static_token = None };
+                   model_id; api_key_env = entry.defaults.api_key_env })
+        | None ->
+            let url = match base_url with
+              | Some u -> u
+              | None -> Defaults.local_llm_url
+            in
+            { Provider.provider = OpenAICompat {
+                base_url = url; auth_header = None;
+                path = "/v1/chat/completions"; static_token = None };
+              model_id; api_key_env = provider_str }
 
 (** Convert mcp_file_config to a server spec for stdio, or connect HTTP directly. *)
 let connect_mcp_server ~sw ~mgr ~net mcp_cfg =

--- a/test/dune
+++ b/test/dune
@@ -51,6 +51,10 @@
  (libraries agent_sdk alcotest yojson))
 
 (test
+ (name test_agent_config_deep)
+ (libraries agent_sdk alcotest yojson))
+
+(test
  (name test_agent_turn_budget_unit)
  (libraries agent_sdk alcotest))
 

--- a/test/test_agent_config_deep.ml
+++ b/test/test_agent_config_deep.ml
@@ -343,6 +343,67 @@ let test_resolve_gemini_preserves_kind () =
     Alcotest.(check string) "gemini model_id" "gemini-2.5-flash" cfg.model_id
   | _ -> Alcotest.fail "expected Custom_registered for gemini (registered)"
 
+(* ── Provider_kind dispatch (drift-fix regressions) ───────────── *)
+
+let test_resolve_openai_compat_ssot () =
+  (* "openai_compat" is the canonical string emitted by
+     Provider_kind.to_string OpenAI_compat. Before the parser dispatch,
+     it fell through to the registry fallback and ended up with
+     api_key_env = "openai_compat" — a meaningless value. *)
+  let cfg =
+    Agent_config.resolve_provider ~model_id:"gpt-4" "openai_compat" None
+  in
+  match cfg.provider with
+  | Provider.OpenAICompat { base_url; _ } ->
+    Alcotest.(check string) "canonical form reaches openai branch"
+      "https://api.openai.com" base_url;
+    Alcotest.(check string) "api_key_env is OPENAI_API_KEY"
+      "OPENAI_API_KEY" cfg.api_key_env
+  | _ -> Alcotest.fail "expected OpenAICompat for openai_compat"
+
+let test_resolve_anthropic_case_insensitive () =
+  (* The parser trims and lowercases; ["Anthropic"] and [" ANTHROPIC "]
+     both land on the Anthropic branch, not the registry fallback. *)
+  List.iter (fun input ->
+    let cfg =
+      Agent_config.resolve_provider ~model_id:"claude-sonnet" input None
+    in
+    match cfg.provider with
+    | Provider.Anthropic ->
+      Alcotest.(check string)
+        (Printf.sprintf "api_key_env for %S" input)
+        "ANTHROPIC_API_KEY" cfg.api_key_env
+    | _ ->
+      Alcotest.failf "expected Anthropic for %S" input
+  ) [ "Anthropic"; " ANTHROPIC "; "anthropic" ]
+
+let test_resolve_claude_alias_routes_to_anthropic () =
+  (* ["claude"] is a documented Provider_kind alias for Anthropic. Prior
+     to this fix it fell to the registry fallback (Provider_registry
+     has no "claude" entry) and ended up as OpenAICompat with
+     api_key_env = "claude" — broken. *)
+  let cfg =
+    Agent_config.resolve_provider ~model_id:"claude-sonnet" "claude" None
+  in
+  match cfg.provider with
+  | Provider.Anthropic ->
+    Alcotest.(check string) "api_key_env routed to Anthropic"
+      "ANTHROPIC_API_KEY" cfg.api_key_env
+  | _ -> Alcotest.fail "expected Anthropic for claude alias"
+
+let test_resolve_unknown_still_goes_to_registry_fallback () =
+  (* Non-canonical non-alias input should continue to flow through the
+     registry-or-fallback path. This guards against over-eager parser
+     capture when we add more kinds. *)
+  let cfg =
+    Agent_config.resolve_provider ~model_id:"m1" "TOTALLY_BOGUS_KEY" None
+  in
+  match cfg.provider with
+  | Provider.OpenAICompat _ ->
+    Alcotest.(check string) "api_key_env preserves input"
+      "TOTALLY_BOGUS_KEY" cfg.api_key_env
+  | _ -> Alcotest.fail "expected registry fallback OpenAICompat"
+
 (* ── of_json error cases ─────────────────────────────────────── *)
 
 let test_of_json_bad_param () =
@@ -427,5 +488,13 @@ let () =
       tc "groq custom url" test_resolve_groq_custom_url;
       tc "deepseek" test_resolve_deepseek;
       tc "gemini preserves kind (#1003)" test_resolve_gemini_preserves_kind;
+      tc "openai_compat SSOT string"
+        test_resolve_openai_compat_ssot;
+      tc "anthropic case-insensitive"
+        test_resolve_anthropic_case_insensitive;
+      tc "claude alias routes to Anthropic"
+        test_resolve_claude_alias_routes_to_anthropic;
+      tc "unknown still goes to registry fallback"
+        test_resolve_unknown_still_goes_to_registry_fallback;
     ]);
   ]


### PR DESCRIPTION
## Summary

Makes `agent_config.resolve_provider` consume `Provider_kind.of_string` (introduced in the parent PR #1122) so every provider-string drift it was designed to catch actually gets caught.

Stacked on top of [#1122](https://github.com/jeong-sik/oas/pull/1122) — merge that one first; this branch rebases cleanly onto main once #1122 lands.

## Drift symptoms fixed

Each case was identified in the `Provider_kind` audit (see `~/me/planning/ocaml-best-of-best/progress.md` tick 6) and is now covered by a regression test in `test_agent_config_deep.ml`:

1. **`"openai_compat"`** — the canonical string that `Provider_kind.to_string OpenAI_compat` emits — previously fell through to the registry fallback (which has no entry for it) and ended up with `api_key_env = "openai_compat"` plus `Defaults.local_llm_url`. Configs written against the SDK's own SSOT now resolve to the real OpenAI endpoint.
2. **`"claude"`** — a documented `Provider_kind` alias for Anthropic, also listed in `CLAUDE.md` under "Supported providers" — previously fell to the registry fallback (no `"claude"` entry) and ended up as an `OpenAICompat` config with `api_key_env = "claude"`. Now routes to `Provider.Anthropic` with `ANTHROPIC_API_KEY`.
3. **Case / whitespace handling**: `"Anthropic"`, `"ANTHROPIC"`, `" anthropic "` land on the Anthropic branch instead of the registry fallback, matching the symmetry established by the parser.

## Scope guardrails

- `"local"` stays matched explicitly before the parser — it's a routing key, not a `Provider_kind` variant.
- Kinds other than `Anthropic` / `OpenAI_compat` (`Ollama`, `Gemini`, `Glm`, `Claude_code`, `Gemini_cli`, `Codex_cli`) fall through to the existing registry lookup so `test_resolve_groq`, `test_resolve_deepseek`, `test_resolve_gemini_preserves_kind` (#1003 regression) keep passing unchanged.

## Bonus: dune registration

`test/test_agent_config_deep.ml` existed in-tree with 31 cases but was never registered in `test/dune`, so the suite was silently skipped on every CI run. Wiring it in (4-line addition) unblocks 31 pre-existing checks plus the 4 new drift regressions — CI now exercises them on every build.

## Verification

- `dune build --root .` green.
- `dune exec --root . test/test_agent_config_deep.exe` — **35/35** (31 pre-existing + 4 new).
- `dune build --root . @test/runtest` — full oas suite green, with Agent_config deep now running end-to-end.

## Test plan

- [x] `dune build --root .`
- [x] `dune exec --root . test/test_agent_config_deep.exe` (35/35)
- [x] `dune build --root . @test/runtest`
- [ ] CI runs
- [ ] Merge #1122 first, then rebase this branch onto main (or wait for auto-rebase once the parent lands).
