### PR TITLE
[codex] Add Kimi Code direct and CLI support

### DIFF
--- a/examples/cli_transports_demo.ml
+++ b/examples/cli_transports_demo.ml
@@ -1,13 +1,14 @@
 (** Subprocess CLI transport demo.
 
-    Shows how to wire up the three non-interactive CLI transports
+    Shows how to wire up the four non-interactive CLI transports
     ([Transport_claude_code], [Transport_gemini_cli],
-    [Transport_codex_cli]), invoke a single completion through both
-    [complete_sync] and [complete_stream], and observe the new
-    [cancel] / [on_stderr_line] knobs added in v0.148.0+.
+    [Transport_kimi_cli], [Transport_codex_cli]), invoke a single
+    completion through both [complete_sync] and [complete_stream], and
+    observe the new [cancel] / [on_stderr_line] knobs added in
+    v0.148.0+.
 
     Prerequisites:
-    - At least one of [claude] / [gemini] / [codex] in [PATH]
+    - At least one of [claude] / [gemini] / [kimi] / [codex] in [PATH]
     - For real runs the CLI must be already authenticated (this demo
       makes a tiny "say hi" call that consumes a few tokens)
 
@@ -15,6 +16,7 @@
       dune exec examples/cli_transports_demo.exe                # auto-pick
       OAS_CLI_DEMO=claude dune exec examples/cli_transports_demo.exe
       OAS_CLI_DEMO=gemini dune exec examples/cli_transports_demo.exe
+      OAS_CLI_DEMO=kimi   dune exec examples/cli_transports_demo.exe
       OAS_CLI_DEMO=codex  dune exec examples/cli_transports_demo.exe
 *)
 
@@ -22,7 +24,7 @@ open Llm_provider
 
 let prompt = "Reply with a single word: hi"
 
-let make_request () : Llm_transport.completion_request =
+let make_request ~kind () : Llm_transport.completion_request =
   let messages : Types.message list =
     [ { role = User
       ; content = [ Text prompt ]
@@ -32,7 +34,7 @@ let make_request () : Llm_transport.completion_request =
   in
   let config =
     Provider_config.make
-      ~kind:Claude_code
+      ~kind
       ~model_id:""
       ~base_url:""
       ()
@@ -67,36 +69,43 @@ let pick_transport ~sw ~mgr =
     ignore on_stderr_line;  (* default already routes to traceln *)
     Transport_claude_code.create ~sw ~mgr
       ~config:Transport_claude_code.default_config,
-    "claude"
+    "claude", Provider_config.Claude_code
   in
   let gemini () =
     Transport_gemini_cli.create ~sw ~mgr
       ~config:Transport_gemini_cli.default_config,
-    "gemini"
+    "gemini", Provider_config.Gemini_cli
+  in
+  let kimi () =
+    Transport_kimi_cli.create ~sw ~mgr
+      ~config:Transport_kimi_cli.default_config,
+    "kimi", Provider_config.Kimi_cli
   in
   let codex () =
     Transport_codex_cli.create ~sw ~mgr
       ~config:Transport_codex_cli.default_config,
-    "codex"
+    "codex", Provider_config.Codex_cli
   in
   match env with
   | Some "claude" -> claude ()
   | Some "gemini" -> gemini ()
+  | Some "kimi"   -> kimi ()
   | Some "codex"  -> codex ()
   | _ ->
     if in_path "claude" then claude ()
     else if in_path "gemini" then gemini ()
+    else if in_path "kimi" then kimi ()
     else if in_path "codex" then codex ()
     else (
-      prerr_endline "No claude/gemini/codex binary in PATH; nothing to demo.";
+      prerr_endline "No claude/gemini/kimi/codex binary in PATH; nothing to demo.";
       exit 0)
 
 let () =
   Eio_main.run @@ fun env ->
   let mgr = Eio.Stdenv.process_mgr env in
   Eio.Switch.run @@ fun sw ->
-  let transport, name = pick_transport ~sw ~mgr in
-  let req = make_request () in
+  let transport, name, kind = pick_transport ~sw ~mgr in
+  let req = make_request ~kind () in
 
   Printf.printf "==> sync via %s\n" name;
   let { Llm_transport.response; latency_ms } = transport.complete_sync req in

--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -251,7 +251,7 @@ let resolve_provider ~model_id provider_str base_url =
             base_url = url; auth_header = None;
             path = "/v1/chat/completions"; static_token = None };
           model_id; api_key_env = "OPENAI_API_KEY" }
-    | Some (Ollama | Gemini | Glm | Claude_code | Gemini_cli | Codex_cli)
+    | Some (Kimi | Ollama | Gemini | Glm | Claude_code | Gemini_cli | Kimi_cli | Codex_cli)
     | None ->
         let registry = Llm_provider.Provider_registry.default () in
         match Llm_provider.Provider_registry.find registry provider_str with

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -53,7 +53,7 @@ type options = {
         @since 0.133.0 *)
   transport: Llm_provider.Llm_transport.t option;
     (** Optional non-HTTP transport override.  Required for CLI provider
-        kinds ([Claude_code], [Codex_cli], [Gemini_cli]) which cannot be
+        kinds ([Claude_code], [Codex_cli], [Gemini_cli], [Kimi_cli]) which cannot be
         reached over HTTP.  When [Some t], {!Pipeline.stage_route}
         dispatches via {!Llm_provider.Complete.complete} with this
         transport; when [None], the HTTP path is used.

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -87,8 +87,8 @@ type options = {
         @since 0.133.0 *)
   transport: Llm_provider.Llm_transport.t option;
     (** Optional non-HTTP transport override.  Required for CLI provider
-        kinds ([Claude_code], [Codex_cli], [Gemini_cli]) which cannot be
-        reached over HTTP.  When [Some t], {!Pipeline.stage_route}
+        kinds ([Claude_code], [Codex_cli], [Gemini_cli], [Kimi_cli])
+        which cannot be reached over HTTP.  When [Some t], {!Pipeline.stage_route}
         dispatches via {!Llm_provider.Complete.complete} with this
         transport; when [None], the HTTP path is used.
         @since 0.156.0 *)

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -128,7 +128,8 @@ val with_base_url : string -> t -> t
 
 (** Inject an {!Llm_provider.Llm_transport.t} for non-HTTP providers.
     Required for CLI provider kinds ([Claude_code], [Codex_cli],
-    [Gemini_cli]) which are reached via subprocess rather than HTTP.
+    [Gemini_cli], [Kimi_cli]) which are reached via subprocess rather
+    than HTTP.
     For HTTP kinds (Anthropic/Gemini/Glm/Ollama/OpenAI_compat) the
     transport is unused and can be left unset.
 

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -18,7 +18,8 @@ let make_https = Api_common.make_https
 
 (* Re-export Api_anthropic *)
 let parse_response = Api_anthropic.parse_response
-let build_body_assoc = Api_anthropic.build_body_assoc
+let build_body_assoc ~config ~messages ?tools ~stream () =
+  Api_anthropic.build_body_assoc ~config ~messages ?tools ~stream ()
 
 (* Re-export Api_openai *)
 let openai_messages_of_message = Api_openai.openai_messages_of_message

--- a/lib/api_anthropic.ml
+++ b/lib/api_anthropic.ml
@@ -10,12 +10,13 @@ open Types
 let parse_response = Llm_provider.Backend_anthropic.parse_response
 
 (** Build request body assoc list shared between stream and non-stream calls *)
-let build_body_assoc ~config ~messages ?tools ~stream () =
+let build_body_assoc ~config ~messages
+    ?(message_to_json=Api_common.message_to_json) ?tools ~stream () =
   let model_str = model_to_string config.config.model in
   let body_assoc = [
     ("model", `String model_str);
     ("max_tokens", `Int (Option.value ~default:4096 config.config.max_tokens));
-    ("messages", `List (List.map Api_common.message_to_json messages));
+    ("messages", `List (List.map message_to_json messages));
     ("stream", `Bool stream);
   ] in
   (* Anthropic requires ~1024+ tokens for cache_control to take effect.

--- a/lib/api_anthropic.mli
+++ b/lib/api_anthropic.mli
@@ -10,6 +10,7 @@ val parse_response : Yojson.Safe.t -> Types.api_response
 val build_body_assoc :
   config:Types.agent_state ->
   messages:Types.message list ->
+  ?message_to_json:(Types.message -> Yojson.Safe.t) ->
   ?tools:Yojson.Safe.t list ->
   stream:bool ->
   unit -> (string * Yojson.Safe.t) list

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -49,11 +49,11 @@ let effective_tool_choice_json (capabilities : Provider.capabilities)
     ?provider_config (config : agent_state) =
   let is_glm = is_glm_request ?provider_config config in
   match config.config.tool_choice with
+  | Some Types.None_ when is_glm -> None
+  | Some (Types.Auto | Types.Any | Types.Tool _) when is_glm ->
+      Some (tool_choice_to_openai_json Types.Auto)
   | Some Types.Auto when capabilities.supports_tool_choice ->
       Some (tool_choice_to_openai_json Types.Auto)
-  | Some (Types.Any | Types.Tool _) when is_glm && capabilities.supports_tool_choice ->
-      Some (tool_choice_to_openai_json Types.Auto)
-  | Some Types.None_ when is_glm -> None
   | Some choice when capabilities.supports_tool_choice ->
       Some (tool_choice_to_openai_json choice)
   | _ -> None
@@ -68,8 +68,14 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
   let capabilities = capabilities_for_request ?provider_config config in
   let sanitized_messages = strip_orphaned_tool_results messages in
   let provider_messages =
+    let message_serializer =
+      if is_glm_request ?provider_config config then
+        Llm_provider.Backend_openai_serialize.glm_messages_of_message
+      else
+        openai_messages_of_message
+    in
     system_message_json config
-    @ List.concat_map openai_messages_of_message sanitized_messages
+    @ List.concat_map message_serializer sanitized_messages
   in
   let body_assoc =
     [

--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -36,8 +36,12 @@ let text_blocks_to_string blocks =
 
 let json_of_string_or_raw s = Lenient_json.parse s
 
+type tool_result_content_style =
+  | Tool_result_content_string
+  | Tool_result_content_text_blocks
+
 (** Content block <-> JSON *)
-let content_block_to_json = function
+let content_block_to_json_with ~(tool_result_content_style : tool_result_content_style) = function
   | Text s -> `Assoc [("type", `String "text"); ("text", `String (Utf8_sanitize.sanitize s))]
   | Thinking { thinking_type; content } ->
       `Assoc [
@@ -55,10 +59,22 @@ let content_block_to_json = function
         ("input", input);
       ]
   | ToolResult { tool_use_id; content; is_error; _ } ->
+      let content_json =
+        match tool_result_content_style with
+        | Tool_result_content_string ->
+            `String (Utf8_sanitize.sanitize content)
+        | Tool_result_content_text_blocks ->
+            `List [
+              `Assoc [
+                ("type", `String "text");
+                ("text", `String (Utf8_sanitize.sanitize content));
+              ];
+            ]
+      in
       `Assoc [
         ("type", `String "tool_result");
         ("tool_use_id", `String tool_use_id);
-        ("content", `String (Utf8_sanitize.sanitize content));
+        ("content", content_json);
         ("is_error", `Bool is_error);
       ]
   | Image { media_type; data; source_type } ->
@@ -88,6 +104,9 @@ let content_block_to_json = function
           ("data", `String data);
         ]);
       ]
+
+let content_block_to_json =
+  content_block_to_json_with ~tool_result_content_style:Tool_result_content_string
 
 let content_block_of_json json =
   let open Yojson.Safe.Util in
@@ -141,6 +160,21 @@ let message_to_json (msg : message) =
   `Assoc [
     ("role", `String role_str);
     ("content", `List (List.map content_block_to_json msg.content));
+  ]
+
+let kimi_message_to_json (msg : message) =
+  let role_str = match msg.role with
+    | User | System | Tool -> "user"
+    | Assistant -> "assistant"
+  in
+  `Assoc [
+    ("role", `String role_str);
+    ("content",
+     `List
+       (List.map
+          (content_block_to_json_with
+             ~tool_result_content_style:Tool_result_content_text_blocks)
+          msg.content));
   ]
 
 (** Create HTTPS upgrade function using tls-eio *)

--- a/lib/llm_provider/api_common.mli
+++ b/lib/llm_provider/api_common.mli
@@ -18,6 +18,7 @@ val json_of_string_or_raw : string -> Yojson.Safe.t
 val content_block_to_json : Types.content_block -> Yojson.Safe.t
 val content_block_of_json : Yojson.Safe.t -> Types.content_block option
 val message_to_json : Types.message -> Yojson.Safe.t
+val kimi_message_to_json : Types.message -> Yojson.Safe.t
 
 (** {2 TLS} *)
 

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -41,8 +41,13 @@ let parse_response json =
     Returns a JSON string ready for HTTP POST. *)
 let build_request ?(stream=false) ~(config : Provider_config.t)
     ~(messages : message list) ?(tools : Yojson.Safe.t list = []) () =
+  let message_to_json =
+    match config.kind with
+    | Provider_config.Kimi -> Api_common.kimi_message_to_json
+    | _ -> Api_common.message_to_json
+  in
   let msgs_json =
-    List.map Api_common.message_to_json messages in
+    List.map message_to_json messages in
   let body =
     [ ("model", `String config.model_id);
       ("max_tokens", `Int (Option.value ~default:4096 config.max_tokens));

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -14,6 +14,7 @@ open Types
 let tool_calls_to_openai_json = Backend_openai_serialize.tool_calls_to_openai_json
 let openai_content_parts_of_blocks = Backend_openai_serialize.openai_content_parts_of_blocks
 let openai_messages_of_message = Backend_openai_serialize.openai_messages_of_message
+let glm_messages_of_message = Backend_openai_serialize.glm_messages_of_message
 let tool_choice_to_openai_json = Backend_openai_serialize.tool_choice_to_openai_json
 let build_openai_tool_json = Backend_openai_serialize.build_openai_tool_json
 let strip_orphaned_tool_results = Backend_openai_serialize.strip_orphaned_tool_results
@@ -53,6 +54,7 @@ let warn_capability_drop ~model_id ~field =
 let effective_tool_choice (config : Provider_config.t) =
   match config.kind, config.tool_choice with
   | Provider_config.Glm, Some None_ -> None
+  | Provider_config.Glm, Some _ -> Some (tool_choice_to_openai_json Auto)
   | _, Some choice -> Some (tool_choice_to_openai_json choice)
   | _, None -> None
 
@@ -106,11 +108,20 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
   let tools = effective_tools config tools in
   let sanitized_messages = strip_orphaned_tool_results messages in
   let provider_messages =
+    let message_serializer =
+      match config.kind with
+      | Provider_config.Glm -> glm_messages_of_message
+      | Provider_config.Anthropic | Provider_config.Kimi
+      | Provider_config.OpenAI_compat | Provider_config.Ollama
+      | Provider_config.Gemini | Provider_config.Claude_code
+      | Provider_config.Gemini_cli | Provider_config.Kimi_cli
+      | Provider_config.Codex_cli -> openai_messages_of_message
+    in
     (match config.system_prompt with
      | Some s when not (Api_common.string_is_blank s) ->
          [`Assoc [("role", `String "system"); ("content", `String (Utf8_sanitize.sanitize s))]]
      | _ -> [])
-    @ List.concat_map openai_messages_of_message sanitized_messages
+    @ List.concat_map message_serializer sanitized_messages
   in
   (* Look up per-model capabilities once — drives:
      (1) the [max_tokens] clamp below (avoid server 400 on over-cap),
@@ -207,6 +218,8 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
        | None -> true)
   in
   let body = match effective_tool_choice config with
+    | Some choice_json when config.kind = Provider_config.Glm ->
+        ("tool_choice", choice_json) :: body
     | Some choice_json when supports_tool_choice ->
         ("tool_choice", choice_json) :: body
     | None -> body
@@ -251,26 +264,19 @@ let%test "tool_choice_to_openai_json Tool name" =
   result |> member "type" |> to_string = "function"
   && result |> member "function" |> member "name" |> to_string = "my_tool"
 
-let%test "glm preserves named tool_choice" =
+let%test "glm coerces named tool_choice to auto" =
   let cfg = Provider_config.make
     ~kind:Provider_config.Glm ~model_id:"glm-5"
     ~base_url:Zai_catalog.general_base_url
     ~tool_choice:(Tool "calculator") () in
-  match effective_tool_choice cfg with
-  | Some (`Assoc _ as json) ->
-    let open Yojson.Safe.Util in
-    json |> member "type" |> to_string = "function"
-    && json |> member "function" |> member "name" |> to_string = "calculator"
-  | _ -> false
+  effective_tool_choice cfg = Some (`String "auto")
 
-let%test "glm preserves tool_choice any as required" =
+let%test "glm coerces tool_choice any to auto" =
   let cfg = Provider_config.make
     ~kind:Provider_config.Glm ~model_id:"glm-5"
     ~base_url:Zai_catalog.general_base_url
     ~tool_choice:Any () in
-  match effective_tool_choice cfg with
-  | Some (`String "required") -> true
-  | _ -> false
+  effective_tool_choice cfg = Some (`String "auto")
 
 let%test "glm drops tool_choice none" =
   let cfg = Provider_config.make
@@ -570,6 +576,29 @@ let%test "openai_messages_of_message assistant text only" =
   let json = List.hd result in
   let open Yojson.Safe.Util in
   json |> member "content" |> to_string = "hello"
+
+let%test "openai_messages_of_message assistant excludes reasoning from content" =
+  let msg = { role = Assistant; content = [
+    Thinking { thinking_type = "reasoning"; content = "hidden chain of thought" };
+    Text "final answer";
+  ]; name = None; tool_call_id = None } in
+  let result = openai_messages_of_message msg in
+  let json = List.hd result in
+  let open Yojson.Safe.Util in
+  json |> member "content" |> to_string = "final answer"
+  && json |> member "reasoning_content" = `Null
+
+let%test "glm_messages_of_message preserves reasoning_content separately" =
+  let msg = { role = Assistant; content = [
+    Thinking { thinking_type = "reasoning"; content = "step one" };
+    ToolUse { id = "tc1"; name = "calc"; input = `Assoc [("expr", `String "2+2")] };
+  ]; name = None; tool_call_id = None } in
+  let result = glm_messages_of_message msg in
+  let json = List.hd result in
+  let open Yojson.Safe.Util in
+  json |> member "content" |> to_string = ""
+  && json |> member "reasoning_content" |> to_string = "step one"
+  && json |> member "tool_calls" |> to_list |> List.length = 1
 
 let%test "openai_messages_of_message assistant blank text with tool_calls" =
   let msg = { role = Assistant; content = [
@@ -922,6 +951,30 @@ let%test "build_request omits tool_choice when tool_choice=None" =
   | `Assoc fields -> not (List.exists (fun (k, _) -> k = "tool_choice") fields)
   | _ -> false
 
+let%test "glm build_request coerces explicit tool_choice to auto" =
+  let config = Provider_config.make ~kind:Provider_config.Glm ~model_id:"glm-5.1"
+      ~base_url:Zai_catalog.coding_base_url ~tool_choice:(Tool "calc") () in
+  let body = build_request ~config ~messages:[] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  json |> member "tool_choice" |> to_string = "auto"
+
+let%test "glm build_request replays reasoning_content without leaking it into content" =
+  let config = Provider_config.make ~kind:Provider_config.Glm ~model_id:"glm-5.1"
+      ~base_url:Zai_catalog.coding_base_url () in
+  let messages = [
+    { role = Assistant; content = [
+        Thinking { thinking_type = "reasoning"; content = "use calculator" };
+        ToolUse { id = "call_1"; name = "calc";
+                  input = `Assoc [("expr", `String "2+2")] };
+      ]; name = None; tool_call_id = None };
+  ] in
+  let body = build_request ~config ~messages () |> Yojson.Safe.from_string in
+  let open Yojson.Safe.Util in
+  let assistant = body |> member "messages" |> index 0 in
+  assistant |> member "content" |> to_string = ""
+  && assistant |> member "reasoning_content" |> to_string = "use calculator"
+
 let%test "build_request uses json_schema response_format when output_schema is set" =
   let schema =
     `Assoc
@@ -970,10 +1023,8 @@ let%test "supports_tool_choice_override=Some false drops tool_choice on unknown 
   | _ -> false
 
 let%test "supports_tool_choice_override=Some true forces tool_choice on capability-false model" =
-  (* min-p-disabled glm-5.1 has supports_tool_choice=true in its capability
-     record, so override flipping the other direction needs a model where
-     the capability record says false. Use mystery model with override
-     to simulate a verified-supports-it scenario. *)
+  (* Use an unknown model whose capability record defaults to
+     supports_tool_choice=false, then force-enable it via override. *)
   let config = Provider_config.make ~kind:OpenAI_compat ~model_id:"mystery-xyz-v1"
       ~base_url:"http://localhost" ~tool_choice:Any
       ~supports_tool_choice_override:true () in

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -75,7 +75,26 @@ let openai_content_parts_of_blocks blocks =
              ])
          | Thinking _ | RedactedThinking _ | ToolUse _ | ToolResult _ -> None)
 
-let messages_of_message_with ?(tool_calls_fn = tool_calls_to_openai_json) (msg : message) : Yojson.Safe.t list =
+let assistant_text_content_of_blocks blocks =
+  blocks
+  |> List.filter_map (function
+         | Text s -> Some (Utf8_sanitize.sanitize s)
+         | Thinking _ | RedactedThinking _ | ToolUse _ | ToolResult _
+         | Image _ | Document _ | Audio _ -> None)
+  |> String.concat "\n"
+
+let assistant_reasoning_content_of_blocks blocks =
+  blocks
+  |> List.filter_map (function
+         | Thinking { content; _ } when not (Api_common.string_is_blank content) ->
+             Some (Utf8_sanitize.sanitize content)
+         | Thinking _ -> None
+         | Text _ | RedactedThinking _ | ToolUse _ | ToolResult _
+         | Image _ | Document _ | Audio _ -> None)
+  |> String.concat ""
+
+let messages_of_message_with ?(tool_calls_fn = tool_calls_to_openai_json)
+    ?(include_reasoning_content = false) (msg : message) : Yojson.Safe.t list =
   match msg.role with
   | User ->
       let content_parts = openai_content_parts_of_blocks msg.content in
@@ -111,16 +130,32 @@ let messages_of_message_with ?(tool_calls_fn = tool_calls_to_openai_json) (msg :
       in
       user_msgs @ tool_msgs
   | Assistant ->
-      let text_content = Api_common.text_blocks_to_string msg.content in
+      let text_content = assistant_text_content_of_blocks msg.content in
+      let reasoning_content =
+        if include_reasoning_content then
+          assistant_reasoning_content_of_blocks msg.content
+        else
+          ""
+      in
       let tool_calls = tool_calls_fn msg.content in
       let fields =
         [
           ("role", `String "assistant");
-          ( if Api_common.string_is_blank text_content && tool_calls <> [] then
+          ( if include_reasoning_content then
+              ("content", `String text_content)
+            else if Api_common.string_is_blank text_content && tool_calls <> [] then
               ("content", `Null)
             else
               ("content", `String text_content) );
         ]
+      in
+      let fields =
+        if include_reasoning_content
+           && not (Api_common.string_is_blank reasoning_content)
+        then
+          ("reasoning_content", `String reasoning_content) :: fields
+        else
+          fields
       in
       let fields =
         if tool_calls = [] then fields else ("tool_calls", `List tool_calls) :: fields
@@ -147,6 +182,10 @@ let messages_of_message_with ?(tool_calls_fn = tool_calls_to_openai_json) (msg :
 
 let openai_messages_of_message msg =
   messages_of_message_with ~tool_calls_fn:tool_calls_to_openai_json msg
+
+let glm_messages_of_message msg =
+  messages_of_message_with ~tool_calls_fn:tool_calls_to_openai_json
+    ~include_reasoning_content:true msg
 
 let ollama_messages_of_message msg =
   messages_of_message_with ~tool_calls_fn:tool_calls_to_ollama_json msg

--- a/lib/llm_provider/backend_openai_serialize.mli
+++ b/lib/llm_provider/backend_openai_serialize.mli
@@ -8,6 +8,7 @@
 val tool_calls_to_openai_json : Types.content_block list -> Yojson.Safe.t list
 val openai_content_parts_of_blocks : Types.content_block list -> Yojson.Safe.t list
 val openai_messages_of_message : Types.message -> Yojson.Safe.t list
+val glm_messages_of_message : Types.message -> Yojson.Safe.t list
 val ollama_messages_of_message : Types.message -> Yojson.Safe.t list
 val tool_choice_to_openai_json : Types.tool_choice -> Yojson.Safe.t
 val build_openai_tool_json : Yojson.Safe.t -> Yojson.Safe.t

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -107,6 +107,17 @@ let anthropic_capabilities = {
   supports_top_k = true;
 }
 
+let kimi_capabilities = {
+  default_capabilities with
+  max_context_tokens = Some 262_144;
+  max_output_tokens = Some 32_768;
+  supports_tools = true;
+  supports_tool_choice = true;
+  supports_reasoning = true;
+  supports_system_prompt = true;
+  supports_code_execution = true;
+}
+
 let openai_chat_capabilities = {
   default_capabilities with
   max_context_tokens = Some 128_000;
@@ -170,22 +181,14 @@ let glm_capabilities = {
      turns against glm-coding:glm-5.1 and glm:glm-5.1. *)
   max_output_tokens = Some 40_960;
   supports_tools = true;
-  (* GLM does not reliably honor tool_choice=required/Any — it frequently
-     returns a text-only response even when the caller sets the field.
-     Observed empirically on 2026-04-18 (MASC cascade vendor_mix_balanced
-     8+ CompletionContractViolation events in a single session against
-     glm-5-turbo / glm-4.7 / glm-5.1 via both glm: and glm-coding: prefix).
-     Cross-reference: BFCL tool-calling benchmarks rank GLM-4.5 at 77 and
-     local ~GLM families at 67 — tool routing works but is unreliable.
-
-     Flipping this to [false] causes
-     [Completion_contract.of_tool_choice ~supports_tool_choice:false]
-     to relax any tool_choice contract to [Allow_text_or_tool], so a
-     text response is accepted without raising
-     [CompletionContractViolation].  [supports_tools = true] remains
-     unchanged — tool DESCRIPTIONS are sent and the model may still
-     emit tool_use blocks when it decides to; we just don't error when
-     it picks text for a request that asked for a forced tool call. *)
+  (* Z.AI's function-calling docs currently document [tool_choice]
+     as default [auto] and "only supports auto". OAS therefore treats
+     GLM as "tools supported, forced tool_choice unsupported":
+     callers may still send tools and OAS may coerce an explicit
+     tool_choice request to [auto], but the completion contract must
+     stay relaxed so direct GLM text replies do not count as contract
+     violations. Ref checked 2026-04-21:
+     https://docs.z.ai/guides/capabilities/function-calling *)
   supports_tool_choice = false;
   supports_reasoning = true;
   supports_extended_thinking = true;
@@ -245,6 +248,17 @@ let gemini_cli_capabilities = {
   supports_system_prompt = true;
 }
 
+let kimi_cli_capabilities = {
+  default_capabilities with
+  max_context_tokens = Some 262_144;
+  max_output_tokens = Some 32_768;
+  supports_tools = true;
+  supports_tool_choice = false;
+  supports_reasoning = true;
+  supports_system_prompt = true;
+  supports_code_execution = true;
+}
+
 let codex_cli_capabilities = {
   default_capabilities with
   max_context_tokens = Some 1_050_000;
@@ -293,6 +307,8 @@ let for_model_id model_id =
            max_output_tokens = Some 16_384 }
   else if starts_with "gemini-3" || starts_with "gemini-2.5" then
     Some gemini_capabilities
+  else if starts_with "kimi-for-coding" then
+    Some kimi_capabilities
   else if starts_with "qwen3" then
     Some { default_capabilities with
            max_context_tokens = Some 262_144;
@@ -379,7 +395,7 @@ let for_model_id model_id =
            max_context_tokens = Some 128_000;
            max_output_tokens = Some 16_384;
            supports_tools = true;
-           supports_tool_choice = true;
+           supports_tool_choice = false;
            supports_response_format_json = true;
            supports_native_streaming = true }
   (* GLM 5-turbo: tool-calling optimized, fast, reasoning but no extended thinking *)
@@ -388,7 +404,7 @@ let for_model_id model_id =
            max_context_tokens = Some 128_000;
            max_output_tokens = Some 16_384;
            supports_tools = true;
-           supports_tool_choice = true;
+           supports_tool_choice = false;
            supports_reasoning = true;
            supports_response_format_json = true;
            supports_native_streaming = true }
@@ -397,7 +413,7 @@ let for_model_id model_id =
            max_context_tokens = Some 200_000;
            max_output_tokens = Some 128_000;
            supports_tools = true;
-           supports_tool_choice = true;
+           supports_tool_choice = false;
            supports_reasoning = true;
            supports_extended_thinking = true;
            supports_response_format_json = true;
@@ -416,7 +432,7 @@ let for_model_id model_id =
            max_context_tokens = Some 128_000;
            max_output_tokens = Some 32_768;
            supports_tools = true;
-           supports_tool_choice = true;
+           supports_tool_choice = false;
            supports_reasoning = true;
            supports_extended_thinking = true;
            supports_multimodal_inputs = true;
@@ -429,7 +445,7 @@ let for_model_id model_id =
            max_context_tokens = Some 200_000;
            max_output_tokens = Some 128_000;
            supports_tools = true;
-           supports_tool_choice = true;
+           supports_tool_choice = false;
            supports_reasoning = true;
            supports_extended_thinking = true;
            supports_response_format_json = true;
@@ -453,7 +469,7 @@ let for_model_id model_id =
            max_context_tokens = Some 128_000;
            max_output_tokens = Some 4_096;
            supports_tools = true;
-           supports_tool_choice = true;
+           supports_tool_choice = false;
            supports_native_streaming = true }
   else
     None

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -44,6 +44,7 @@ type capabilities = {
 
 val default_capabilities : capabilities
 val anthropic_capabilities : capabilities
+val kimi_capabilities : capabilities
 val openai_chat_capabilities : capabilities
 val openai_chat_extended_capabilities : capabilities
 val gemini_capabilities : capabilities
@@ -51,6 +52,7 @@ val ollama_capabilities : capabilities
 val glm_capabilities : capabilities
 val claude_code_capabilities : capabilities
 val gemini_cli_capabilities : capabilities
+val kimi_cli_capabilities : capabilities
 val codex_cli_capabilities : capabilities
 
 (** Lookup capabilities for a known model_id.

--- a/lib/llm_provider/cli_common_synthetic_events.ml
+++ b/lib/llm_provider/cli_common_synthetic_events.ml
@@ -5,15 +5,24 @@ let replay ~on_event (resp : Types.api_response) =
     let content_type = match block with
       | Types.Text _ -> "text"
       | Types.Thinking _ -> "thinking"
+      | Types.ToolUse _ -> "tool_use"
+      | Types.ToolResult _ -> "tool_result"
       | _ -> "text"
     in
-    let delta = match block with
+    let tool_id, tool_name, delta = match block with
       | Types.Text t -> Types.TextDelta t
-      | Types.Thinking { content; _ } -> Types.ThinkingDelta content
-      | _ -> Types.TextDelta ""
+        |> fun delta -> None, None, delta
+      | Types.Thinking { content; _ } ->
+        None, None, Types.ThinkingDelta content
+      | Types.ToolUse { id; name; input } ->
+        Some id, Some name,
+        Types.InputJsonDelta (Yojson.Safe.to_string input)
+      | Types.ToolResult { tool_use_id; content; _ } ->
+        Some tool_use_id, None, Types.TextDelta content
+      | _ -> None, None, Types.TextDelta ""
     in
     on_event (Types.ContentBlockStart {
-      index = idx; content_type; tool_id = None; tool_name = None });
+      index = idx; content_type; tool_id; tool_name });
     on_event (Types.ContentBlockDelta { index = idx; delta });
     on_event (Types.ContentBlockStop { index = idx })
   ) resp.content;
@@ -41,3 +50,18 @@ let%test "replay emits no block events for empty content" =
   replay ~on_event resp;
   (* MessageStart + MessageDelta + MessageStop = 3 *)
   List.length !events = 3
+
+let%test "replay preserves tool_use metadata" =
+  let events = ref [] in
+  let on_event e = events := e :: !events in
+  let resp : Types.api_response =
+    { id = "x"; model = "m"; stop_reason = EndTurn;
+      content = [ToolUse {
+        id = "tu_1"; name = "calc"; input = `Assoc [("x", `Int 1)] }];
+      usage = None; telemetry = None } in
+  replay ~on_event resp;
+  List.exists (function
+    | Types.ContentBlockStart {
+        content_type = "tool_use"; tool_id = Some "tu_1";
+        tool_name = Some "calc"; _ } -> true
+    | _ -> false) !events

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -44,7 +44,7 @@ let provider_sampling_defaults (kind : Provider_config.provider_kind) : sampling
   | Provider_config.Ollama ->
     { default_min_p = None;
       default_top_p = None; default_top_k = None }
-  | Provider_config.Anthropic ->
+  | Provider_config.Anthropic | Provider_config.Kimi ->
     { default_min_p = None; default_top_p = None; default_top_k = None }
   | Provider_config.Gemini ->
     { default_min_p = None; default_top_p = None; default_top_k = None }
@@ -52,7 +52,8 @@ let provider_sampling_defaults (kind : Provider_config.provider_kind) : sampling
     { default_min_p = None; default_top_p = None; default_top_k = None }
   | Provider_config.Claude_code ->
     { default_min_p = None; default_top_p = None; default_top_k = None }
-  | Provider_config.Gemini_cli | Provider_config.Codex_cli ->
+  | Provider_config.Gemini_cli | Provider_config.Kimi_cli
+  | Provider_config.Codex_cli ->
     { default_min_p = None; default_top_p = None; default_top_k = None }
 
 let openai_compat_should_default_min_p (config : Provider_config.t) : bool =
@@ -90,13 +91,15 @@ let patch_telemetry (resp : Types.api_response) ~(config : Provider_config.t)
   let pk = Some config.kind in
   let re = reasoning_effort_of_config config in
   let base_caps = match config.kind with
-    | Ollama -> Capabilities.ollama_capabilities
-    | Anthropic -> Capabilities.anthropic_capabilities
-    | Glm -> Capabilities.glm_capabilities
-    | Gemini -> Capabilities.gemini_capabilities
+  | Ollama -> Capabilities.ollama_capabilities
+  | Anthropic -> Capabilities.anthropic_capabilities
+  | Kimi -> Capabilities.kimi_capabilities
+  | Glm -> Capabilities.glm_capabilities
+  | Gemini -> Capabilities.gemini_capabilities
     | OpenAI_compat -> Capabilities.openai_chat_capabilities
     | Claude_code -> Capabilities.claude_code_capabilities
     | Gemini_cli -> Capabilities.gemini_cli_capabilities
+    | Kimi_cli -> Capabilities.kimi_cli_capabilities
     | Codex_cli -> Capabilities.codex_cli_capabilities
   in
   let caps = match Capabilities.for_model_id config.model_id with
@@ -124,9 +127,22 @@ let patch_telemetry (resp : Types.api_response) ~(config : Provider_config.t)
   in
   { resp with telemetry }
 
+(** Internal helper: canonical provider name for metric labels.
+    Kept in sync with the log tag used by the [WARN Complete] line. *)
+let provider_name_of_kind : Provider_config.provider_kind -> string = function
+  | Ollama -> "ollama"
+  | Anthropic -> "anthropic"
+  | Kimi -> "kimi"
+  | OpenAI_compat -> "openai"
+  | Gemini -> "gemini"
+  | Glm -> "glm"
+  | Claude_code -> "claude_code"
+  | Gemini_cli -> "gemini_cli"
+  | Kimi_cli -> "kimi_cli"
+  | Codex_cli -> "codex_cli"
 let requires_non_http_transport : Provider_config.provider_kind -> bool = function
-  | Claude_code | Gemini_cli | Codex_cli -> true
-  | Anthropic | OpenAI_compat | Ollama | Gemini | Glm -> false
+  | Claude_code | Gemini_cli | Kimi_cli | Codex_cli -> true
+  | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm -> false
 
 let validate_output_schema_request (config : Provider_config.t) =
   match Provider_config.validate_output_schema_request config with
@@ -219,6 +235,8 @@ let complete_http ~sw ~net
   let body_str = match config.kind with
     | Provider_config.Anthropic ->
         Backend_anthropic.build_request ~config ~messages ~tools ()
+    | Provider_config.Kimi ->
+        Backend_anthropic.build_request ~config ~messages ~tools ()
     | Provider_config.Ollama ->
         Backend_ollama.build_request ~config ~messages ~tools ()
     | Provider_config.OpenAI_compat ->
@@ -227,7 +245,8 @@ let complete_http ~sw ~net
         Backend_gemini.build_request ~config ~messages ~tools ()
     | Provider_config.Glm ->
         Backend_glm.build_request ~config ~messages ~tools ()
-    | Provider_config.Claude_code | Provider_config.Gemini_cli | Provider_config.Codex_cli -> "" (* guarded above *)
+    | Provider_config.Claude_code | Provider_config.Gemini_cli
+    | Provider_config.Kimi_cli | Provider_config.Codex_cli -> "" (* guarded above *)
   in
   let url = match config.kind with
     | Provider_config.Gemini -> gemini_url ~config ~stream:false
@@ -305,6 +324,9 @@ let complete_http ~sw ~net
             | Provider_config.Anthropic ->
                 Ok (Backend_anthropic.parse_response
                       (Yojson.Safe.from_string body))
+            | Provider_config.Kimi ->
+                Ok (Backend_anthropic.parse_response
+                      (Yojson.Safe.from_string body))
             | Provider_config.Ollama ->
                 (match Backend_ollama.parse_ollama_response body with
                  | Ok resp -> Ok resp
@@ -320,7 +342,8 @@ let complete_http ~sw ~net
                       (Yojson.Safe.from_string body))
             | Provider_config.Glm ->
                 Ok (Backend_glm.parse_response body)
-            | Provider_config.Claude_code | Provider_config.Gemini_cli | Provider_config.Codex_cli ->
+            | Provider_config.Claude_code | Provider_config.Gemini_cli
+            | Provider_config.Kimi_cli | Provider_config.Codex_cli ->
                 Error (Http_client.NetworkError { message = "Unreachable code" })
           with
           | Yojson.Json_error msg ->
@@ -524,7 +547,7 @@ let complete ~sw ~net ?(transport : Llm_transport.t option)
               runtime_mcp_policy;
             }
         | None when requires_non_http_transport config.kind ->
-          (* CLI subprocess providers (claude_code/codex_cli/gemini_cli)
+          (* CLI subprocess providers (claude_code/codex_cli/gemini_cli/kimi_cli)
              register with [base_url = ""] on purpose.  Without a CLI
              transport wired by the caller, falling through to
              [complete_http] would let cohttp-eio raise
@@ -659,6 +682,8 @@ let complete_stream_http ~sw:_ ~net ~(config : Provider_config.t)
   let body_str = match config.kind with
     | Provider_config.Anthropic ->
         Backend_anthropic.build_request ~stream:true ~config ~messages ~tools ()
+    | Provider_config.Kimi ->
+        Backend_anthropic.build_request ~stream:true ~config ~messages ~tools ()
     | Provider_config.Ollama ->
         (* DIVERGENCE: Ollama streaming uses OpenAI compat format + endpoint
            (/v1/chat/completions with SSE), while non-streaming uses the native
@@ -682,7 +707,8 @@ let complete_stream_http ~sw:_ ~net ~(config : Provider_config.t)
         Backend_gemini.build_request ~stream:true ~config ~messages ~tools ()
     | Provider_config.Glm ->
         Backend_glm.build_request ~stream:true ~config ~messages ~tools ()
-    | Provider_config.Claude_code | Provider_config.Gemini_cli | Provider_config.Codex_cli -> ""
+    | Provider_config.Claude_code | Provider_config.Gemini_cli
+    | Provider_config.Kimi_cli | Provider_config.Codex_cli -> ""
   in
   (* Ollama streaming: uses OpenAI compat body format, so must hit
      the OpenAI compat endpoint (/v1/chat/completions), not native
@@ -705,6 +731,10 @@ let complete_stream_http ~sw:_ ~net ~(config : Provider_config.t)
             Http_client.read_sse ~reader ~on_data:(fun ~event_type data ->
               let events = match config.kind with
                 | Provider_config.Anthropic ->
+                    (match Streaming.parse_sse_event event_type data with
+                     | Some evt -> [evt]
+                     | None -> [])
+                | Provider_config.Kimi ->
                     (match Streaming.parse_sse_event event_type data with
                      | Some evt -> [evt]
                      | None -> [])
@@ -738,7 +768,8 @@ let complete_stream_http ~sw:_ ~net ~(config : Provider_config.t)
                     (match Backend_glm.parse_stream_chunk data with
                      | Some chunk -> Streaming.openai_chunk_to_events state chunk
                      | None -> [])
-                | Provider_config.Claude_code | Provider_config.Gemini_cli | Provider_config.Codex_cli -> []
+                | Provider_config.Claude_code | Provider_config.Gemini_cli
+                | Provider_config.Kimi_cli | Provider_config.Codex_cli -> []
               in
               List.iter (fun evt ->
                 on_event evt;

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -108,7 +108,7 @@ let finalize_stream_acc (acc : stream_acc) =
              tool_use_id;
              content = text;
              is_error;
-             json = None;
+             json = if is_error then None else Types.try_parse_json text;
            })
     | _ -> None
   ) indices in
@@ -356,6 +356,22 @@ let%test "finalize_stream_acc tool_use missing id/name defaults to empty" =
     (match result.content with
     | [Types.ToolUse { id = ""; name = ""; _ }] -> true
     | _ -> false)
+
+let%test "finalize_stream_acc assembles tool_result block" =
+  let acc = create_stream_acc () in
+  Hashtbl.replace acc.block_types 0 "tool_result";
+  Hashtbl.replace acc.block_tool_ids 0 "tu_1";
+  let buf = Buffer.create 16 in
+  Buffer.add_string buf "{\"ok\":true}";
+  Hashtbl.replace acc.block_texts 0 buf;
+  match finalize_stream_acc acc with
+  | Error _ -> false
+  | Ok result ->
+    (match result.content with
+     | [Types.ToolResult {
+          tool_use_id = "tu_1"; content = "{\"ok\":true}";
+          json = Some (`Assoc [("ok", `Bool true)]); _ }] -> true
+     | _ -> false)
 
 let%test "finalize_stream_acc block with no text buffer produces empty text" =
   let acc = create_stream_acc () in

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -17,7 +17,8 @@ type http_error =
   | NetworkError of { message: string }
   | AcceptRejected of { reason: string }
   (* Signals that a provider kind requires a non-HTTP transport (e.g. a
-     CLI subprocess transport for [Claude_code]/[Codex_cli]/[Gemini_cli])
+     CLI subprocess transport for
+     [Claude_code]/[Codex_cli]/[Gemini_cli]/[Kimi_cli])
      but the caller did not wire one.  Distinct from [NetworkError] so
      cascades can skip the candidate without counting it as a flaky
      network failure, and so callers see a clear "configuration/wiring

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -7,12 +7,14 @@
     can be shared with {!Types} without creating a module dependency cycle. *)
 type provider_kind = Provider_kind.t =
   | Anthropic
+  | Kimi
   | OpenAI_compat
   | Ollama
   | Gemini
   | Glm
   | Claude_code
   | Gemini_cli
+  | Kimi_cli
   | Codex_cli
 
 type t = {
@@ -69,11 +71,12 @@ let make ~kind ~model_id ~base_url
     | Some p -> p
     | None -> match kind with
       | Anthropic -> "/v1/messages"
+      | Kimi -> "/v1/messages"
       | OpenAI_compat -> "/v1/chat/completions"
       | Ollama -> "/api/chat"
       | Gemini -> ""
       | Glm -> "/chat/completions"
-      | Claude_code | Gemini_cli | Codex_cli -> ""
+      | Claude_code | Gemini_cli | Kimi_cli | Codex_cli -> ""
   in
   { kind; model_id; base_url; api_key; headers; request_path;
     max_tokens; max_context; temperature; top_p; top_k; min_p;
@@ -174,6 +177,9 @@ let validate_output_schema_request (config : t) =
   | Some _ ->
       match config.kind with
       | Gemini | Anthropic | Ollama -> Ok ()
+      | Kimi ->
+          Error
+            "Kimi direct API native json_schema output is not verified yet in OAS"
       | OpenAI_compat ->
           let caps =
             match Capabilities.for_model_id config.model_id with
@@ -194,7 +200,7 @@ let validate_output_schema_request (config : t) =
                  config.base_url)
       | Glm ->
           Error "GLM is currently wired for JSON mode only; native json_schema is not enabled"
-      | Claude_code | Gemini_cli | Codex_cli ->
+      | Claude_code | Gemini_cli | Kimi_cli | Codex_cli ->
           Error
             (Printf.sprintf "%s does not expose provider-native structured output in OAS"
                (string_of_provider_kind config.kind))

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -14,12 +14,14 @@
     it can be shared with {!Types} without creating a dependency cycle. *)
 type provider_kind = Provider_kind.t =
   | Anthropic
+  | Kimi  (** Kimi Code direct API: Anthropic-compatible [/v1/messages]. @since 0.169.0 *)
   | OpenAI_compat
   | Ollama  (** Ollama: OpenAI compat wire format + reasoning_effort + no tool_choice. @since 0.112.0 *)
   | Gemini
   | Glm  (** ZhipuAI GLM native: OpenAI wire format + JWT auth + GLM error parsing. @since 0.83.0 *)
   | Claude_code  (** Subprocess transport via [claude -p]. @since 0.78.0 *)
   | Gemini_cli  (** Subprocess transport via [gemini -p]. @since 0.133.0 *)
+  | Kimi_cli  (** Subprocess transport via [kimi --print]. @since 0.169.0 *)
   | Codex_cli   (** Subprocess transport via [codex exec]. @since 0.133.0 *)
 
 type t = {
@@ -161,6 +163,7 @@ val structured_output_name_of_schema : Yojson.Safe.t -> string
     - [OpenAI_compat] is accepted only for official OpenAI hosts with a
       model capability record that reports [supports_structured_output].
     - [Gemini], [Anthropic], and [Ollama] are accepted.
+    - [Kimi] is rejected until native json_schema support is verified.
     - [Glm] and CLI kinds are rejected.
 
     @since 0.163.0 *)

--- a/lib/llm_provider/provider_kind.ml
+++ b/lib/llm_provider/provider_kind.ml
@@ -10,33 +10,39 @@
 
 type t =
   | Anthropic
+  | Kimi
   | OpenAI_compat
   | Ollama
   | Gemini
   | Glm
   | Claude_code
   | Gemini_cli
+  | Kimi_cli
   | Codex_cli
 
 let to_string = function
   | Anthropic -> "anthropic"
+  | Kimi -> "kimi"
   | OpenAI_compat -> "openai_compat"
   | Ollama -> "ollama"
   | Gemini -> "gemini"
   | Glm -> "glm"
   | Claude_code -> "claude_code"
   | Gemini_cli -> "gemini_cli"
+  | Kimi_cli -> "kimi_cli"
   | Codex_cli -> "codex_cli"
 
 let of_string raw =
   match String.lowercase_ascii (String.trim raw) with
   | "anthropic" | "claude" -> Some Anthropic
+  | "kimi" -> Some Kimi
   | "openai_compat" | "openai" -> Some OpenAI_compat
   | "ollama" | "llama" -> Some Ollama
   | "gemini" -> Some Gemini
   | "glm" -> Some Glm
   | "claude_code" -> Some Claude_code
   | "gemini_cli" -> Some Gemini_cli
+  | "kimi_cli" -> Some Kimi_cli
   | "codex_cli" -> Some Codex_cli
   | _ -> None
 

--- a/lib/llm_provider/provider_kind.mli
+++ b/lib/llm_provider/provider_kind.mli
@@ -10,12 +10,14 @@
 
 type t =
   | Anthropic
+  | Kimi
   | OpenAI_compat
   | Ollama
   | Gemini
   | Glm
   | Claude_code
   | Gemini_cli
+  | Kimi_cli
   | Codex_cli
 
 val to_string : t -> string

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -49,6 +49,9 @@ let has_api_key env_name =
    | Some s -> String.trim s <> ""
    | None -> false)
 
+let has_any_api_key env_names =
+  List.exists has_api_key env_names
+
 let path_entries ?path () =
   match path with
   | Some value -> String.split_on_char ':' value
@@ -200,6 +203,16 @@ let glm_coding_defaults = {
   request_path = "/chat/completions";
 }
 
+let kimi_defaults = {
+  kind = Kimi;
+  base_url =
+    (match Sys.getenv_opt "KIMI_BASE_URL" with
+     | Some url when String.trim url <> "" -> String.trim url
+     | _ -> "https://api.kimi.com/coding");
+  api_key_env = "KIMI_API_KEY_SB";
+  request_path = "/v1/messages";
+}
+
 let ollama_defaults = {
   kind = Ollama;
   base_url =
@@ -287,6 +300,12 @@ let default () =
     Capabilities.glm_capabilities;
   reg "glm-coding" glm_coding_defaults ~max_context:200_000
     Capabilities.glm_capabilities;
+  register t { name = "kimi"; defaults = kimi_defaults;
+               max_context = max_context_from_capabilities ~default:262_144
+                   Capabilities.kimi_capabilities;
+               capabilities = Capabilities.kimi_capabilities;
+               is_available = (fun () ->
+                 has_any_api_key ["KIMI_API_KEY_SB"; "KIMI_API_KEY"]) };
   reg "openrouter" openrouter_defaults ~max_context:128_000
     Capabilities.openai_chat_extended_capabilities;
   reg "groq" groq_defaults ~max_context:131_072
@@ -324,6 +343,16 @@ let default () =
     let cached = command_in_path "gemini" in
     fun () -> cached
   in
+  let kimi_cli_defaults = {
+    kind = Kimi_cli;
+    base_url = "";
+    api_key_env = "";
+    request_path = "";
+  } in
+  let kimi_cli_available =
+    let cached = command_in_path "kimi" in
+    fun () -> cached
+  in
   let codex_cli_defaults = {
     kind = Codex_cli;
     base_url = "";
@@ -349,6 +378,11 @@ let default () =
                    Capabilities.gemini_cli_capabilities;
                capabilities = Capabilities.gemini_cli_capabilities;
                is_available = gemini_cli_available };
+  register t { name = "kimi_cli"; defaults = kimi_cli_defaults;
+               max_context = max_context_from_capabilities ~default:262_144
+                   Capabilities.kimi_cli_capabilities;
+               capabilities = Capabilities.kimi_cli_capabilities;
+               is_available = kimi_cli_available };
   register t { name = "codex_cli"; defaults = codex_cli_defaults;
                max_context = max_context_from_capabilities ~default:128_000
                    Capabilities.codex_cli_capabilities;
@@ -359,12 +393,14 @@ let default () =
 let provider_name_of_config (config : Provider_config.t) =
   match config.kind with
   | Anthropic -> "claude"
+  | Kimi -> "kimi"
   | Gemini -> "gemini"
   | Glm ->
       if Zai_catalog.is_coding_base_url config.base_url then "glm-coding"
       else "glm"
   | Claude_code -> "claude_code"
   | Gemini_cli -> "gemini_cli"
+  | Kimi_cli -> "kimi_cli"
   | Codex_cli -> "codex_cli"
   | Ollama -> "ollama"
   | OpenAI_compat ->

--- a/lib/llm_provider/provider_registry.mli
+++ b/lib/llm_provider/provider_registry.mli
@@ -57,7 +57,7 @@ val command_in_path : ?path:string -> string -> bool
 
 (** Default registry pre-populated with known direct providers plus
     non-interactive CLI transports ([claude_code], [gemini_cli],
-    [codex_cli], and compat alias [cc]).
+    [kimi], [kimi_cli], [codex_cli], and compat alias [cc]).
     Availability is determined by API-key env vars for direct providers
     and PATH discovery for CLI transports. *)
 val default : unit -> t

--- a/lib/llm_provider/provider_throttle.ml
+++ b/lib/llm_provider/provider_throttle.ml
@@ -89,13 +89,15 @@ let default_for_kind (kind : Provider_config.provider_kind) =
     create ~max_concurrent:4 ~provider_name:"local"
   | Provider_config.Anthropic ->
     create ~max_concurrent:5 ~provider_name:"anthropic"
+  | Provider_config.Kimi ->
+    create ~max_concurrent:5 ~provider_name:"kimi"
   | Provider_config.Gemini ->
     create ~max_concurrent:10 ~provider_name:"gemini"
   | Provider_config.Glm ->
     create ~max_concurrent:10 ~provider_name:"glm"
   | Provider_config.Claude_code ->
     create ~max_concurrent:2 ~provider_name:"claude_code"
-  | Provider_config.Gemini_cli | Provider_config.Codex_cli ->
+  | Provider_config.Gemini_cli | Provider_config.Kimi_cli | Provider_config.Codex_cli ->
     create ~max_concurrent:2 ~provider_name:"cli_subprocess"
 
 (* ── Capacity Query ────────────────────────────────────── *)

--- a/lib/llm_provider/transport_kimi_cli.ml
+++ b/lib/llm_provider/transport_kimi_cli.ml
@@ -1,0 +1,440 @@
+(** Kimi CLI non-interactive transport.
+
+    @since 0.169.0 *)
+
+type config = {
+  kimi_path: string;
+  model: string option;
+  cwd: string option;
+  mcp_config_files: string list;
+  mcp_config_json: string list;
+  forward_tool_results: bool;
+  cancel: unit Eio.Promise.t option;
+}
+
+let default_config = {
+  kimi_path = "kimi";
+  model = Some "kimi-for-coding";
+  cwd = None;
+  mcp_config_files = [];
+  mcp_config_json = [];
+  forward_tool_results = true;
+  cancel = None;
+}
+
+(* Prompt shaping, JSON helpers, and subprocess orchestration live in the
+   shared [Cli_common_*] modules. *)
+
+(* ── CLI argument building ───────────────────────────── *)
+
+let default_prompt_argv_threshold = 512 * 1024
+
+let prompt_argv_threshold () =
+  match Sys.getenv_opt "OAS_KIMI_PROMPT_ARGV_THRESHOLD" with
+  | Some raw ->
+    (match int_of_string_opt (String.trim raw) with
+     | Some v when v >= 0 -> v
+     | _ -> default_prompt_argv_threshold)
+  | None -> default_prompt_argv_threshold
+
+let prompt_exceeds_argv_budget prompt =
+  String.length prompt >= prompt_argv_threshold ()
+
+let stdin_for_prompt prompt =
+  if prompt_exceeds_argv_budget prompt then Some prompt else None
+
+let cli_model_override ~(config : config) ~(req_config : Provider_config.t) =
+  match String.trim req_config.model_id |> String.lowercase_ascii with
+  | "" | "auto" -> config.model
+  | _ -> Some (String.trim req_config.model_id)
+
+let build_args ~(config : config) ~(req_config : Provider_config.t) ~prompt =
+  let prompt_via_stdin = prompt_exceeds_argv_budget prompt in
+  let args = ref [config.kimi_path; "--print"; "--output-format"; "stream-json"] in
+  let add a = args := !args @ a in
+  if not prompt_via_stdin then add ["-p"; prompt];
+  (match cli_model_override ~config ~req_config with
+   | Some m -> add ["--model"; m]
+   | None -> ());
+  (match config.cwd with
+   | Some dir when String.trim dir <> "" -> add ["--work-dir"; dir]
+   | _ -> ());
+  List.iter (fun path -> add ["--mcp-config-file"; path]) config.mcp_config_files;
+  List.iter (fun json -> add ["--mcp-config"; json]) config.mcp_config_json;
+  (match req_config.enable_thinking with
+   | Some true -> add ["--thinking"]
+   | Some false -> add ["--no-thinking"]
+   | None -> ());
+  !args
+
+(* ── JSON parsing ────────────────────────────────────── *)
+
+let json_of_argument_string = function
+  | None | Some "" -> `Assoc []
+  | Some s ->
+    try Yojson.Safe.from_string s
+    with Yojson.Json_error _ -> `Assoc []
+
+let blocks_of_message_content json =
+  match json with
+  | `String s when String.trim s = "" -> []
+  | `String s -> [Types.Text s]
+  | `List items -> List.filter_map Api_common.content_block_of_json items
+  | `Null -> []
+  | other -> [Types.Text (Yojson.Safe.to_string other)]
+
+let tool_use_of_json json =
+  let open Yojson.Safe.Util in
+  try
+    let fn = json |> member "function" in
+    let id = Cli_common_json.member_str "id" json in
+    let name = Cli_common_json.member_str "name" fn in
+    let args = fn |> member "arguments" |> to_string_option |> json_of_argument_string in
+    Some (Types.ToolUse { id; name; input = args })
+  with Type_error _ -> None
+
+let tool_result_of_json json =
+  let open Yojson.Safe.Util in
+  match json |> member "tool_call_id" |> to_string_option with
+  | Some tool_use_id ->
+    let content_json = json |> member "content" in
+    let content, parsed_json =
+      match content_json with
+      | `String s -> s, Types.try_parse_json s
+      | `Null -> "", None
+      | other -> Yojson.Safe.to_string other, Some other
+    in
+    Some (Types.ToolResult { tool_use_id; content; is_error = false;
+                             json = parsed_json })
+  | None -> None
+
+let blocks_of_output_line line =
+  let open Yojson.Safe.Util in
+  try
+    let json = Yojson.Safe.from_string line in
+    match json |> member "role" |> to_string_option with
+    | Some "assistant" ->
+      let content = blocks_of_message_content (json |> member "content") in
+      let tool_uses =
+        match json |> member "tool_calls" with
+        | `List calls -> List.filter_map tool_use_of_json calls
+        | _ -> []
+      in
+      content @ tool_uses
+    | Some "tool" ->
+      (match tool_result_of_json json with
+       | Some block -> [block]
+       | None -> [])
+    | _ -> []
+  with Yojson.Json_error _ | Type_error _ -> []
+
+let response_id_of_lines lines =
+  let open Yojson.Safe.Util in
+  let find_id line =
+    try
+      let json = Yojson.Safe.from_string line in
+      match json |> member "id" |> to_string_option with
+      | Some id when String.trim id <> "" -> Some id
+      | _ ->
+        (match json |> member "session_id" |> to_string_option with
+         | Some id when String.trim id <> "" -> Some id
+         | _ -> None)
+    with Yojson.Json_error _ | Type_error _ -> None
+  in
+  List.find_map find_id lines |> Option.value ~default:"kimi-print"
+
+let response_model_of_lines ~model_id lines =
+  let open Yojson.Safe.Util in
+  let find_model line =
+    try
+      let json = Yojson.Safe.from_string line in
+      match json |> member "model" |> to_string_option with
+      | Some m when String.trim m <> "" -> Some m
+      | _ -> None
+    with Yojson.Json_error _ | Type_error _ -> None
+  in
+  List.find_map find_model lines |> Option.value ~default:model_id
+
+let parse_jsonl_result ~model_id lines =
+  let content = List.concat_map blocks_of_output_line lines in
+  if content = [] then
+    Error (Http_client.NetworkError {
+      message = "no messages parsed from kimi output" })
+  else
+    Ok { Types.id = response_id_of_lines lines;
+         model = response_model_of_lines ~model_id lines;
+         stop_reason = Types.EndTurn;
+         content;
+         usage = None;
+         telemetry = None }
+
+(* ── Stream events ───────────────────────────────────── *)
+
+let events_of_block ~index = function
+  | Types.Text text ->
+    [Types.ContentBlockStart {
+       index; content_type = "text"; tool_id = None; tool_name = None };
+     Types.ContentBlockDelta { index; delta = Types.TextDelta text };
+     Types.ContentBlockStop { index }]
+  | Types.Thinking { content; _ } ->
+    [Types.ContentBlockStart {
+       index; content_type = "thinking"; tool_id = None; tool_name = None };
+     Types.ContentBlockDelta { index; delta = Types.ThinkingDelta content };
+     Types.ContentBlockStop { index }]
+  | Types.ToolUse { id; name; input } ->
+    [Types.ContentBlockStart {
+       index; content_type = "tool_use";
+       tool_id = Some id; tool_name = Some name };
+     Types.ContentBlockDelta {
+       index; delta = Types.InputJsonDelta (Yojson.Safe.to_string input) };
+     Types.ContentBlockStop { index }]
+  | Types.ToolResult { tool_use_id; content; _ } ->
+    [Types.ContentBlockStart {
+       index; content_type = "tool_result";
+       tool_id = Some tool_use_id; tool_name = None };
+     Types.ContentBlockDelta { index; delta = Types.TextDelta content };
+     Types.ContentBlockStop { index }]
+  | Types.RedactedThinking _ | Types.Image _ | Types.Document _ | Types.Audio _ ->
+    []
+
+let emit_blocks ~on_event ~start_index blocks =
+  List.fold_left (fun index block ->
+    match events_of_block ~index block with
+    | [] -> index
+    | events ->
+      List.iter on_event events;
+      index + 1
+  ) start_index blocks
+
+(* ── Error classification ────────────────────────────── *)
+
+let starts_with s prefix =
+  let lp = String.length prefix in
+  String.length s >= lp && String.sub s 0 lp = prefix
+
+let exit_code_of_message message =
+  let prefix = "kimi exited with code " in
+  if not (starts_with message prefix) then None
+  else
+    match String.index_from_opt message (String.length prefix) ':' with
+    | None -> None
+    | Some colon ->
+      let raw =
+        String.sub message (String.length prefix)
+          (colon - String.length prefix)
+        |> String.trim
+      in
+      int_of_string_opt raw
+
+let classify_cli_error = function
+  | Error (Http_client.NetworkError { message }) as err ->
+    (match exit_code_of_message message with
+     | Some 1 ->
+       Error (Http_client.AcceptRejected {
+         reason =
+           "kimi_cli rejected the request (exit 1). "
+           ^ "This is usually a permanent auth/config/model error rather "
+           ^ "than a transient transport failure. "
+           ^ message;
+       })
+     | _ -> err)
+  | other -> other
+
+(* ── Transport constructor ───────────────────────────── *)
+
+let warn_external_tools_once warned tools =
+  if !warned || tools = [] then ()
+  else begin
+    warned := true;
+    Eio.traceln
+      "[warn] kimi_cli print mode ignores OAS req.tools. \
+       Provider-native built-in tools and configured MCP servers remain \
+       available; external OAS tool callbacks require a future wire-mode \
+       transport."
+  end
+
+let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
+  : Llm_transport.t =
+  let warned = ref false in
+  {
+    complete_sync = (fun (req : Llm_transport.completion_request) ->
+      warn_external_tools_once warned req.tools;
+      let messages = Cli_common_prompt.non_system_messages req.messages in
+      let system_prompt =
+        Cli_common_prompt.system_prompt_of ~req_config:req.config req.messages in
+      let prompt =
+        Cli_common_prompt.prompt_of_messages
+          ~include_tool_blocks:config.forward_tool_results messages
+        |> fun prompt ->
+        Cli_common_prompt.prompt_with_system_prompt ~prompt ~system_prompt
+      in
+      let model_id =
+        Option.value ~default:"kimi-for-coding"
+          (cli_model_override ~config ~req_config:req.config)
+      in
+      let argv = build_args ~config ~req_config:req.config ~prompt in
+      let seen_lines = ref [] in
+      let on_line line =
+        if String.trim line <> "" then
+          seen_lines := line :: !seen_lines
+      in
+      match Cli_common_subprocess.run_stream_lines ~sw ~mgr
+              ~name:"kimi" ~cwd:config.cwd ~extra_env:[]
+              ?stdin_content:(stdin_for_prompt prompt)
+              ~on_line ?cancel:config.cancel
+              argv with
+      | Error _ as e ->
+        { Llm_transport.response = classify_cli_error e; latency_ms = 0 }
+      | Ok { latency_ms; _ } ->
+        let response = parse_jsonl_result ~model_id (List.rev !seen_lines) in
+        { Llm_transport.response; latency_ms });
+
+    complete_stream = (fun ~on_event (req : Llm_transport.completion_request) ->
+      warn_external_tools_once warned req.tools;
+      let messages = Cli_common_prompt.non_system_messages req.messages in
+      let system_prompt =
+        Cli_common_prompt.system_prompt_of ~req_config:req.config req.messages in
+      let prompt =
+        Cli_common_prompt.prompt_of_messages
+          ~include_tool_blocks:config.forward_tool_results messages
+        |> fun prompt ->
+        Cli_common_prompt.prompt_with_system_prompt ~prompt ~system_prompt
+      in
+      let model_id =
+        Option.value ~default:"kimi-for-coding"
+          (cli_model_override ~config ~req_config:req.config)
+      in
+      let argv = build_args ~config ~req_config:req.config ~prompt in
+      let seen_lines = ref [] in
+      let next_index = ref 0 in
+      let started = ref false in
+      let ensure_started () =
+        if not !started then begin
+          started := true;
+          on_event (Types.MessageStart {
+            id = "kimi-print";
+            model = model_id;
+            usage = None;
+          })
+        end
+      in
+      let on_line line =
+        if String.trim line <> "" then begin
+          seen_lines := line :: !seen_lines;
+          let blocks = blocks_of_output_line line in
+          if blocks <> [] then begin
+            ensure_started ();
+            next_index := emit_blocks ~on_event ~start_index:!next_index blocks
+          end
+        end
+      in
+      match classify_cli_error
+              (Cli_common_subprocess.run_stream_lines ~sw ~mgr
+                 ~name:"kimi" ~cwd:config.cwd ~extra_env:[]
+                 ?stdin_content:(stdin_for_prompt prompt)
+                 ~on_line ?cancel:config.cancel
+                 argv)
+      with
+      | Error _ as e -> e
+      | Ok _ ->
+        match parse_jsonl_result ~model_id (List.rev !seen_lines) with
+        | Error _ as e -> e
+        | Ok resp as ok ->
+          if !started then begin
+            on_event (Types.MessageDelta {
+              stop_reason = Some resp.stop_reason;
+              usage = resp.usage;
+            });
+            on_event Types.MessageStop
+          end else
+            Cli_common_synthetic_events.replay ~on_event resp;
+          ok);
+  }
+
+(* ── Inline tests ────────────────────────────────────── *)
+
+[@@@coverage off]
+
+let kimi_req ?(model_id = "auto") ?enable_thinking () =
+  Provider_config.make ~kind:Provider_config.Kimi_cli ~model_id ~base_url:""
+    ?enable_thinking ()
+
+let%test "default_config uses kimi-for-coding" =
+  default_config.model = Some "kimi-for-coding"
+
+let%test "build_args basic" =
+  let args =
+    build_args ~config:default_config ~req_config:(kimi_req ()) ~prompt:"hi"
+  in
+  args =
+  ["kimi"; "--print"; "--output-format"; "stream-json";
+   "-p"; "hi"; "--model"; "kimi-for-coding"]
+
+let%test "build_args with work dir, mcp, and thinking" =
+  let config = {
+    default_config with
+    cwd = Some "/tmp/work";
+    mcp_config_files = ["/tmp/mcp.json"];
+    mcp_config_json = ["{\"mcpServers\":{}}"];
+  } in
+  let args =
+    build_args ~config ~req_config:(kimi_req ~enable_thinking:true ()) ~prompt:"hi"
+  in
+  List.mem "--work-dir" args
+  && List.mem "/tmp/work" args
+  && List.mem "--mcp-config-file" args
+  && List.mem "/tmp/mcp.json" args
+  && List.mem "--mcp-config" args
+  && List.mem "{\"mcpServers\":{}}" args
+  && List.mem "--thinking" args
+
+let%test "build_args uses request model over default" =
+  let args =
+    build_args ~config:default_config
+      ~req_config:(kimi_req ~model_id:"kimi-k2.6" ()) ~prompt:"hi"
+  in
+  List.mem "--model" args
+  && List.mem "kimi-k2.6" args
+  && not (List.mem "kimi-for-coding" args)
+
+let%test "build_args routes large prompt via stdin" =
+  let big = String.make (1 * 1024 * 1024) 'x' in
+  let args =
+    build_args ~config:default_config ~req_config:(kimi_req ()) ~prompt:big
+  in
+  not (List.mem big args)
+  && not (List.mem "-p" args)
+
+let%test "parse_jsonl_result restores tool trace" =
+  let lines = [
+    {|{"role":"assistant","content":"Checking files","tool_calls":[{"type":"function","id":"tc_1","function":{"name":"Shell","arguments":"{\"command\":\"ls\"}"}}]}|};
+    {|{"role":"tool","tool_call_id":"tc_1","content":"README.md"}|};
+    {|{"role":"assistant","content":"Done"}|};
+  ] in
+  match parse_jsonl_result ~model_id:"kimi-for-coding" lines with
+  | Ok resp ->
+    (match resp.content with
+     | [Types.Text "Checking files";
+        Types.ToolUse { id = "tc_1"; name = "Shell"; input };
+        Types.ToolResult { tool_use_id = "tc_1"; content = "README.md"; _ };
+        Types.Text "Done"] ->
+       input = `Assoc [("command", `String "ls")]
+     | _ -> false)
+  | Error _ -> false
+
+let%test "parse_jsonl_result accepts array-form content" =
+  let lines = [
+    {|{"role":"assistant","content":[{"type":"text","text":"hello"}]}|};
+  ] in
+  match parse_jsonl_result ~model_id:"kimi-for-coding" lines with
+  | Ok resp -> resp.content = [Types.Text "hello"]
+  | Error _ -> false
+
+let%test "classify_cli_error exit 1 becomes AcceptRejected" =
+  match classify_cli_error
+          (Error (Http_client.NetworkError {
+             message = "kimi exited with code 1: auth failed" }))
+  with
+  | Error (Http_client.AcceptRejected { reason }) ->
+    String.length reason > 0
+  | _ -> false

--- a/lib/llm_provider/transport_kimi_cli.mli
+++ b/lib/llm_provider/transport_kimi_cli.mli
@@ -1,0 +1,61 @@
+(** Kimi CLI non-interactive transport.
+
+    Implements {!Llm_transport.t} by spawning [kimi --print]
+    subprocesses. Uses [--output-format stream-json] so tool calls and
+    tool results survive as structured content blocks.
+
+    @since 0.169.0
+
+    @stability Internal *)
+
+(** Configuration for the Kimi CLI subprocess. *)
+type config = {
+  kimi_path: string;
+    (** Path to the [kimi] executable. Default ["kimi"]. *)
+  model: string option;
+    (** [--model] override. [None] uses the CLI-configured default.
+        Default is [Some "kimi-for-coding"] so the coding plan model is
+        selected unless the request provides a concrete model id. *)
+  cwd: string option;
+    (** Working directory for the subprocess. *)
+  mcp_config_files: string list;
+    (** Additional [--mcp-config-file] paths. Empty preserves the CLI's
+        default MCP discovery (including [~/.kimi/mcp.json] when it
+        exists). *)
+  mcp_config_json: string list;
+    (** Additional [--mcp-config] JSON strings. Empty means no extra
+        inline MCP config is injected. *)
+  forward_tool_results: bool;
+    (** When [true] (default), prior [ToolUse]/[ToolResult] content
+        blocks in the conversation history are flattened back into the
+        prompt so later turns keep the provider-native tool trace. *)
+  cancel: unit Eio.Promise.t option;
+    (** When [Some p] and [p] resolves mid-run, the [kimi] subprocess
+        receives [SIGINT] via [Eio.Process.signal].
+        Default [None]. *)
+}
+
+(** Sensible defaults: [kimi] in PATH, [kimi-for-coding], no explicit
+    MCP overrides. *)
+val default_config : config
+
+(** Create a Kimi CLI transport.
+
+    The returned {!Llm_transport.t} spawns a fresh [kimi --print]
+    process for each completion request. System prompt and messages from
+    the {!Llm_transport.completion_request} are flattened into a single
+    prompt string; Kimi's stream-JSON output is then re-expanded into
+    {!Types.Text}, {!Types.ToolUse}, and {!Types.ToolResult} blocks.
+
+    External OAS tool schemas in [req.tools] are not bridged through
+    print mode; provider-native built-in tools and configured MCP
+    servers remain available. Full external-tool callback support would
+    require a future Wire-mode transport.
+
+    @param sw Eio switch controlling subprocess lifetime.
+    @param mgr Eio process manager for spawning. *)
+val create :
+  sw:Eio.Switch.t ->
+  mgr:_ Eio.Process.mgr ->
+  config:config ->
+  Llm_transport.t

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -147,13 +147,91 @@ let register_provider impl =
   Eio.Mutex.use_rw ~protect:true registry_mu (fun () ->
     Hashtbl.replace registry impl.name impl)
 
+let find_builtin_provider name = function
+  | impl :: rest ->
+      let rec loop current remaining =
+        if current.name = name then Some current
+        else
+          match remaining with
+          | next :: tail -> loop next tail
+          | [] -> None
+      in
+      loop impl rest
+  | [] -> None
+
+let first_present_env env_names =
+  let rec loop = function
+    | [] -> None
+    | env_name :: rest ->
+        (match Sys.getenv_opt env_name with
+         | Some value when String.trim value <> "" -> Some (env_name, String.trim value)
+         | _ -> loop rest)
+  in
+  loop env_names
+
+let kimi_direct_base_url () =
+  match Sys.getenv_opt "KIMI_BASE_URL" with
+  | Some url when String.trim url <> "" -> String.trim url
+  | _ -> "https://api.kimi.com/coding"
+
+let kimi_direct_request_path = "/v1/messages"
+
+let kimi_direct_headers key = [
+  ("Content-Type", "application/json");
+  ("x-api-key", key);
+  ("anthropic-version", "2023-06-01");
+]
+
+let kimi_provider_impl : provider_impl = {
+  name = "kimi";
+  request_kind = Anthropic_messages;
+  request_path = kimi_direct_request_path;
+  capabilities = Llm_provider.Capabilities.kimi_capabilities;
+  build_body = (fun ~config ~messages ?tools () ->
+    Yojson.Safe.to_string
+      (`Assoc
+         (Api_anthropic.build_body_assoc ~config ~messages
+            ~message_to_json:Llm_provider.Api_common.kimi_message_to_json
+            ?tools ~stream:false ())));
+  parse_response = (fun body_str ->
+    Api_anthropic.parse_response (Yojson.Safe.from_string body_str));
+  resolve = (fun cfg ->
+    let env_names =
+      if String.trim cfg.api_key_env <> "" then
+        [cfg.api_key_env; "KIMI_API_KEY_SB"; "KIMI_API_KEY"]
+      else
+        ["KIMI_API_KEY_SB"; "KIMI_API_KEY"]
+    in
+    match first_present_env env_names with
+    | Some (_env_name, key) ->
+        Ok (kimi_direct_base_url (), key, kimi_direct_headers key)
+    | None ->
+        let var_name =
+          match env_names with
+          | preferred :: _ -> preferred
+          | [] -> "KIMI_API_KEY_SB"
+        in
+        Error (Error.Config (MissingEnvVar { var_name })));
+}
+
+let builtin_provider_impls = [kimi_provider_impl]
+
 let find_provider name =
-  Eio.Mutex.use_ro registry_mu (fun () ->
-    Hashtbl.find_opt registry name)
+  match find_builtin_provider name builtin_provider_impls with
+  | Some impl -> Some impl
+  | None ->
+      Eio.Mutex.use_ro registry_mu (fun () ->
+        Hashtbl.find_opt registry name)
 
 let registered_providers () =
-  Eio.Mutex.use_ro registry_mu (fun () ->
-    Hashtbl.fold (fun name _ acc -> name :: acc) registry [])
+  let dynamic =
+    Eio.Mutex.use_ro registry_mu (fun () ->
+      Hashtbl.fold (fun name _ acc -> name :: acc) registry [])
+  in
+  builtin_provider_impls
+  |> List.fold_left (fun acc impl ->
+       if List.mem impl.name acc then acc else impl.name :: acc)
+       dynamic
 
 let capabilities_for_model ~(provider : provider) ~(model_id : string) =
   match provider with
@@ -438,9 +516,10 @@ let default_api_key_env_of_kind
     (kind : Llm_provider.Provider_config.provider_kind) : string =
   match kind with
   | Anthropic -> "ANTHROPIC_API_KEY"
+  | Kimi -> "KIMI_API_KEY_SB"
   | Gemini -> "GEMINI_API_KEY"
   | Glm -> "ZAI_API_KEY"
-  | OpenAI_compat | Ollama | Claude_code | Gemini_cli | Codex_cli -> ""
+  | OpenAI_compat | Ollama | Claude_code | Gemini_cli | Kimi_cli | Codex_cli -> ""
 
 (** Convert a [Llm_provider.Provider_config.t] into a
     [Provider.config] (for Agent Builder).  Keeps the conversion
@@ -460,6 +539,8 @@ let config_of_provider_config (pc : Llm_provider.Provider_config.t) : config =
   let static_token = if has_key then Some pc.api_key else None in
   let provider = match pc.kind with
     | Anthropic -> Anthropic
+    | Kimi ->
+      Custom_registered { name = "kimi" }
     | Gemini ->
       OpenAICompat { base_url = pc.base_url; auth_header;
                      path = pc.request_path; static_token }
@@ -474,7 +555,7 @@ let config_of_provider_config (pc : Llm_provider.Provider_config.t) : config =
     | Claude_code ->
       OpenAICompat { base_url = pc.base_url; auth_header;
                      path = pc.request_path; static_token }
-    | Gemini_cli | Codex_cli ->
+    | Gemini_cli | Kimi_cli | Codex_cli ->
       OpenAICompat { base_url = pc.base_url; auth_header;
                      path = pc.request_path; static_token }
   in
@@ -565,20 +646,32 @@ let provider_config_of_agent
                               "Custom_registered provider '%s' not found in Provider_registry.default"
                               name;
                         }))
-            | Some entry ->
-                let api_key =
-                  if entry.defaults.api_key_env = "" then ""
-                  else
-                    match Sys.getenv_opt entry.defaults.api_key_env with
-                    | Some k -> k
-                    | None -> ""
-                in
-                build ~kind:entry.defaults.kind
-                  ~resolved_base_url:entry.defaults.base_url
-                  ~api_key
-                  ~headers:[]
-                  ~request_path:entry.defaults.request_path
-                  ~model_id:p.model_id)
+           | Some entry ->
+                (match find_provider name with
+                 | Some impl ->
+                     (match impl.resolve p with
+                      | Error e -> Error e
+                      | Ok (resolved_base_url, api_key, headers) ->
+                          build ~kind:entry.defaults.kind
+                            ~resolved_base_url
+                            ~api_key
+                            ~headers
+                            ~request_path:entry.defaults.request_path
+                            ~model_id:p.model_id)
+                 | None ->
+                     let api_key =
+                       if entry.defaults.api_key_env = "" then ""
+                       else
+                         match Sys.getenv_opt entry.defaults.api_key_env with
+                         | Some k -> k
+                         | None -> ""
+                     in
+                     build ~kind:entry.defaults.kind
+                       ~resolved_base_url:entry.defaults.base_url
+                       ~api_key
+                       ~headers:[]
+                       ~request_path:entry.defaults.request_path
+                       ~model_id:p.model_id))
        | Anthropic | Local _ | OpenAICompat _ ->
            (match resolve p with
             | Error e -> Error e

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -158,7 +158,8 @@ val registered_providers : unit -> string list
 val custom_provider : name:string -> ?model_id:string -> ?api_key_env:string -> unit -> config
 
 (** Well-known env var name for a provider kind.
-    Returns empty string for providers that don't need auth (Local, Claude_code).
+    Returns empty string for providers that don't need auth
+    (Local and the CLI transports).
     @since 0.87.0 *)
 val default_api_key_env_of_kind :
   Llm_provider.Provider_config.provider_kind -> string

--- a/lib/provider_bridge.ml
+++ b/lib/provider_bridge.ml
@@ -21,6 +21,25 @@ let is_glm_model_or_alias model_id =
   | "ocr" -> true
   | _ -> false
 
+let is_kimi_coding_base_url base_url =
+  match Uri.of_string base_url with
+  | exception _ -> false
+  | uri ->
+      let host_matches =
+        match Uri.host uri with
+        | Some host -> String.lowercase_ascii host = "api.kimi.com"
+        | None -> false
+      in
+      let path = Uri.path uri |> String.lowercase_ascii in
+      host_matches
+      && (path = "/coding" || path = "/coding/"
+         || Util.string_contains ~needle:"/coding/" path)
+
+(** Resolve "auto" / aliases to concrete model IDs for legacy Provider.config
+    input. Inlined here because higher-level routing lives outside OAS.
+
+    Local providers use {!Llm_provider.Discovery.first_discovered_model_id}
+    for "auto"; cloud providers use environment-variable defaults. *)
 let env_or default var =
   match Sys.getenv_opt var with
   | Some v when String.trim v <> "" -> String.trim v
@@ -52,28 +71,34 @@ let resolve_auto_model_id
   match kind with
   | Ollama | OpenAI_compat ->
       (* Local llama-server and OpenAI-compatible endpoints share the
-         "auto" → discovery → OLLAMA_DEFAULT_MODEL fallback. Cloud-only
-         OpenAI-compatible backends (e.g. OpenRouter) still traverse this
-         branch; splitting them into a dedicated subkind is future work. *)
+         "auto" -> discovery -> OLLAMA_DEFAULT_MODEL fallback. Cloud-only
+         OpenAI-compatible backends still traverse this branch. *)
       if model_id = "auto" then
         match Llm_provider.Discovery.first_discovered_model_id () with
         | Some id -> id
         | None -> env_or model_id "OLLAMA_DEFAULT_MODEL"
       else model_id
   | Glm ->
-      if Llm_provider.Zai_catalog.is_coding_base_url base_url
-      then resolve_glm_coding_model_id model_id
-      else resolve_glm_model_id model_id
+      if Llm_provider.Zai_catalog.is_coding_base_url base_url then
+        resolve_glm_coding_model_id model_id
+      else
+        resolve_glm_model_id model_id
   | Gemini ->
-      if model_id = "auto" then env_or "gemini-2.5-flash" "GEMINI_DEFAULT_MODEL"
+      if model_id = "auto" then
+        env_or "gemini-2.5-flash" "GEMINI_DEFAULT_MODEL"
+      else model_id
+  | Kimi ->
+      if model_id = "auto" then
+        env_or "kimi-for-coding" "KIMI_DEFAULT_MODEL"
       else model_id
   | Anthropic | Claude_code ->
-      if model_id = "auto"
-      then env_or "claude-sonnet-4-6-20250514" "ANTHROPIC_DEFAULT_MODEL"
+      if model_id = "auto" then
+        env_or "claude-sonnet-4-6-20250514" "ANTHROPIC_DEFAULT_MODEL"
       else model_id
-  | Gemini_cli | Codex_cli -> model_id
+  | Gemini_cli | Kimi_cli | Codex_cli -> model_id
 
-let to_provider_config (legacy : Provider.config) : (Llm_provider.Provider_config.t, Error.sdk_error) result =
+let to_provider_config (legacy : Provider.config) :
+    (Llm_provider.Provider_config.t, Error.sdk_error) result =
   match Provider.resolve legacy with
   | Error e -> Error e
   | Ok (base_url, api_key, headers) ->
@@ -81,30 +106,26 @@ let to_provider_config (legacy : Provider.config) : (Llm_provider.Provider_confi
       let is_gemini_model =
         String.length m_lower >= 6 && String.sub m_lower 0 6 = "gemini"
       in
-      let is_glm_model =
-        is_glm_model_or_alias m_lower
-      in
-      let is_zai_provider =
-        Llm_provider.Zai_catalog.is_zai_base_url base_url
-      in
-      let kind = match Provider.request_kind legacy.provider with
+      let is_glm_model = is_glm_model_or_alias m_lower in
+      let is_zai_provider = Llm_provider.Zai_catalog.is_zai_base_url base_url in
+      let is_kimi_provider = is_kimi_coding_base_url base_url in
+      let kind =
+        match Provider.request_kind legacy.provider with
         | Provider.Anthropic_messages ->
-            Llm_provider.Provider_config.Anthropic
+            if is_kimi_provider then Llm_provider.Provider_config.Kimi
+            else Llm_provider.Provider_config.Anthropic
         | Provider.Openai_chat_completions
         | Provider.Custom _ ->
             if is_gemini_model then Llm_provider.Provider_config.Gemini
-            else if is_zai_provider && is_glm_model then Llm_provider.Provider_config.Glm
-            else Llm_provider.Provider_config.OpenAI_compat
+            else if is_zai_provider && is_glm_model then
+              Llm_provider.Provider_config.Glm
+            else
+              Llm_provider.Provider_config.OpenAI_compat
       in
       let request_path = Provider.request_path legacy.provider in
       let resolved_model_id =
         resolve_auto_model_id ~base_url kind legacy.model_id
       in
-      Ok (Llm_provider.Provider_config.make
-            ~kind
-            ~model_id:resolved_model_id
-            ~base_url
-            ~api_key
-            ~headers
-            ~request_path
-            ())
+      Ok
+        (Llm_provider.Provider_config.make ~kind ~model_id:resolved_model_id
+           ~base_url ~api_key ~headers ~request_path ())

--- a/scripts/check-transport-truth.sh
+++ b/scripts/check-transport-truth.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # check-transport-truth.sh
-# Drift gate for OAS CLI transports (transport_{claude_code,gemini_cli,codex_cli}).
+# Drift gate for OAS CLI transports
+# (transport_{claude_code,gemini_cli,kimi_cli,codex_cli}).
 #
 # Background
 # ----------
@@ -45,6 +46,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TRANSPORTS=(
   "claude_code:lib/llm_provider/transport_claude_code"
   "gemini_cli:lib/llm_provider/transport_gemini_cli"
+  "kimi_cli:lib/llm_provider/transport_kimi_cli"
   "codex_cli:lib/llm_provider/transport_codex_cli"
 )
 
@@ -95,4 +97,4 @@ if [[ $fail -ne 0 ]]; then
   exit 1
 fi
 
-echo "OK: transport drift gate passed (3 transports, invariants 1–2)"
+echo "OK: transport drift gate passed (4 transports, invariants 1–2)"

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -75,6 +75,36 @@ let test_unknown_type_returns_none () =
   | None -> ()
   | Some _ -> fail "expected None for unknown type"
 
+let test_kimi_message_to_json_tool_result_uses_text_blocks () =
+  let msg = {
+    Types.role = Tool;
+    content = [
+      Types.ToolResult {
+        tool_use_id = "tu_001";
+        content = "5";
+        is_error = false;
+        json = Some (`Int 5);
+      };
+    ];
+    name = None;
+    tool_call_id = None;
+  } in
+  let json = Llm_provider.Api_common.kimi_message_to_json msg in
+  let open Yojson.Safe.Util in
+  let block = json |> member "content" |> index 0 in
+  let nested = block |> member "content" |> to_list in
+  check string "role serialized as user" "user"
+    (json |> member "role" |> to_string);
+  check string "tool_result type" "tool_result"
+    (block |> member "type" |> to_string);
+  check string "tool_use_id" "tu_001"
+    (block |> member "tool_use_id" |> to_string);
+  check int "nested content count" 1 (List.length nested);
+  check string "nested text block type" "text"
+    (List.hd nested |> member "type" |> to_string);
+  check string "nested text block text" "5"
+    (List.hd nested |> member "text" |> to_string)
+
 (* ------------------------------------------------------------------ *)
 (* build_body_assoc                                                     *)
 (* ------------------------------------------------------------------ *)
@@ -357,6 +387,58 @@ let test_build_openai_body_uses_glm_thinking_and_auto_tool_choice () =
   check bool "clear_thinking default true" true
     (thinking |> member "clear_thinking" |> to_bool);
   check string "glm tool choice coerced" "auto"
+    (json |> member "tool_choice" |> to_string)
+
+let test_build_openai_body_glm_preserves_reasoning_content () =
+  let provider_config = {
+    Provider.provider = Provider.OpenAICompat {
+      base_url = Llm_provider.Zai_catalog.general_base_url;
+      auth_header = None;
+      path = "/chat/completions";
+      static_token = None;
+    };
+    model_id = "glm-5";
+    api_key_env = "";
+  } in
+  let messages = [
+    { Types.role = Types.Assistant;
+      content = [
+        Types.Thinking {
+          thinking_type = "reasoning";
+          content = "I should call the calculator.";
+        };
+        Types.ToolUse {
+          id = "call_1";
+          name = "calculator";
+          input = `Assoc [("expr", `String "2+2")];
+        };
+      ];
+      name = None;
+      tool_call_id = None;
+    };
+  ] in
+  let state = {
+    Types.config = {
+      Types.default_config with
+      model = provider_config.model_id;
+      tool_choice = Some (Types.Tool "calculator");
+    };
+    messages = [];
+    turn_count = 0;
+    usage = Types.empty_usage;
+  } in
+  let json =
+    Api.build_openai_body ~provider_config ~config:state ~messages ()
+    |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  let assistant = json |> member "messages" |> index 0 in
+  check string "content kept empty" ""
+    (assistant |> member "content" |> to_string);
+  check string "reasoning_content replayed"
+    "I should call the calculator."
+    (assistant |> member "reasoning_content" |> to_string);
+  check string "tool choice still auto" "auto"
     (json |> member "tool_choice" |> to_string)
 
 let test_build_openai_body_does_not_treat_non_zai_glm_as_glm () =
@@ -1037,6 +1119,8 @@ let () =
         test_build_openai_body_omits_qwen_only_fields_for_generic_compat;
       test_case "glm thinking + auto tool choice" `Quick
         test_build_openai_body_uses_glm_thinking_and_auto_tool_choice;
+      test_case "glm preserved reasoning replay" `Quick
+        test_build_openai_body_glm_preserves_reasoning_content;
       test_case "non-zai glm avoids glm path" `Quick
         test_build_openai_body_does_not_treat_non_zai_glm_as_glm;
       test_case "glm none tool_choice omits tools" `Quick
@@ -1090,6 +1174,8 @@ let () =
       test_case "string_is_blank" `Quick test_string_is_blank;
       test_case "json_of_string_or_raw valid" `Quick test_json_of_string_or_raw_valid;
       test_case "json_of_string_or_raw invalid" `Quick test_json_of_string_or_raw_invalid;
+      test_case "kimi tool_result uses text blocks" `Quick
+        test_kimi_message_to_json_tool_result_uses_text_blocks;
       test_case "disable_parallel_tool_use" `Quick test_build_body_disable_parallel;
     ];
   ]

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -412,6 +412,21 @@ let test_config_of_provider_config_localhost_query_delegates_to_ssot () =
   | _ ->
       Alcotest.fail "expected localhost query config to resolve as local"
 
+let test_config_of_provider_config_kimi_uses_custom_provider () =
+  let cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Kimi
+      ~model_id:"kimi-for-coding"
+      ~base_url:"https://api.kimi.com/coding"
+      ()
+  in
+  match Provider.config_of_provider_config cfg with
+  | { provider = Provider.Custom_registered { name }; api_key_env; _ } ->
+      Alcotest.(check string) "provider name" "kimi" name;
+      Alcotest.(check string) "api_key_env" "KIMI_API_KEY_SB" api_key_env
+  | _ ->
+      Alcotest.fail "expected kimi config to round-trip through Custom_registered"
+
 let test_openai_compat_static_token () =
   let cfg : Provider.config = {
     provider = OpenAICompat {
@@ -595,6 +610,28 @@ let test_provider_config_of_agent_custom_registered_preserves_kind () =
   | Error e ->
     Alcotest.fail (Printf.sprintf "unexpected error: %s" (Error.to_string e))
 
+let test_provider_config_of_agent_custom_registered_kimi_preserves_headers () =
+  let env_var = "KIMI_PROVIDER_TEST_KEY" in
+  Unix.putenv env_var "kimi-provider-test-key";
+  let cfg : Provider.config = {
+    provider = Custom_registered { name = "kimi" };
+    model_id = "kimi-for-coding";
+    api_key_env = env_var;
+  } in
+  let state = agent_state_with_params () in
+  match Provider.provider_config_of_agent ~state
+          ~base_url:"unused-fallback" (Some cfg) with
+  | Ok pc ->
+      Alcotest.(check bool) "kind preserves Kimi" true
+        (pc.kind = Llm_provider.Provider_config.Kimi);
+      Alcotest.(check string) "request_path" "/v1/messages" pc.request_path;
+      Alcotest.(check bool) "x-api-key header present" true
+        (List.mem ("x-api-key", "kimi-provider-test-key") pc.headers);
+      Alcotest.(check bool) "anthropic-version header present" true
+        (List.mem ("anthropic-version", "2023-06-01") pc.headers)
+  | Error e ->
+      Alcotest.fail (Printf.sprintf "unexpected error: %s" (Error.to_string e))
+
 let test_provider_config_of_agent_custom_registered_unknown_name () =
   let cfg : Provider.config = {
     provider = Custom_registered { name = "nonexistent-provider-xyz" };
@@ -660,6 +697,8 @@ let () =
         test_config_of_provider_config_uppercase_localhost_delegates_to_ssot;
       Alcotest.test_case "provider_config localhost query" `Quick
         test_config_of_provider_config_localhost_query_delegates_to_ssot;
+      Alcotest.test_case "provider_config kimi custom" `Quick
+        test_config_of_provider_config_kimi_uses_custom_provider;
     ];
     "openai_compat", [
       Alcotest.test_case "static token" `Quick test_openai_compat_static_token;
@@ -678,6 +717,8 @@ let () =
         test_provider_config_of_agent_local_strips_dummy_key;
       Alcotest.test_case "custom registered preserves kind (#1003)" `Quick
         test_provider_config_of_agent_custom_registered_preserves_kind;
+      Alcotest.test_case "custom registered kimi preserves headers" `Quick
+        test_provider_config_of_agent_custom_registered_kimi_preserves_headers;
       Alcotest.test_case "custom registered unknown name errors" `Quick
         test_provider_config_of_agent_custom_registered_unknown_name;
     ];

--- a/test/test_provider_bridge.ml
+++ b/test/test_provider_bridge.ml
@@ -60,11 +60,13 @@ let test_non_zai_glm_stays_openai_compat () =
         (match cfg.kind with
          | Llm_provider.Provider_config.OpenAI_compat -> "openai_compat"
          | Anthropic -> "anthropic"
+         | Kimi -> "kimi"
          | Gemini -> "gemini"
          | Glm -> "glm"
          | Ollama -> "ollama"
          | Claude_code -> "claude_code"
          | Gemini_cli -> "gemini_cli"
+         | Kimi_cli -> "kimi_cli"
          | Codex_cli -> "codex_cli")
 
 let test_zai_glm_becomes_glm_provider_config () =
@@ -86,11 +88,13 @@ let test_zai_glm_becomes_glm_provider_config () =
         (match cfg.kind with
          | Llm_provider.Provider_config.OpenAI_compat -> "openai_compat"
          | Anthropic -> "anthropic"
+         | Kimi -> "kimi"
          | Gemini -> "gemini"
          | Glm -> "glm"
          | Ollama -> "ollama"
          | Claude_code -> "claude_code"
          | Gemini_cli -> "gemini_cli"
+         | Kimi_cli -> "kimi_cli"
          | Codex_cli -> "codex_cli")
 
 let test_zai_coding_auto_uses_coding_default_model () =
@@ -113,6 +117,24 @@ let test_zai_coding_auto_uses_coding_default_model () =
           Alcotest.(check string) "coding auto model" "glm-4.5-air"
             cfg.model_id))
 
+let test_kimi_custom_registered_becomes_kimi_provider_config () =
+  let env_var = "KIMI_PROVIDER_BRIDGE_TEST_KEY" in
+  with_env env_var "kimi-test-key" (fun () ->
+    let legacy = {
+      Agent_sdk.Provider.provider = Custom_registered { name = "kimi" };
+      model_id = "auto";
+      api_key_env = env_var;
+    } in
+    match Agent_sdk.Provider_bridge.to_provider_config legacy with
+    | Error e ->
+        Alcotest.fail (Printf.sprintf "kimi custom provider should resolve: %s"
+          (Agent_sdk.Error.to_string e))
+    | Ok cfg ->
+        Alcotest.(check string) "kind becomes kimi" "kimi"
+          (Llm_provider.Provider_config.string_of_provider_kind cfg.kind);
+        Alcotest.(check string) "auto model" "kimi-for-coding" cfg.model_id;
+        Alcotest.(check string) "path" "/v1/messages" cfg.request_path)
+
 let test_zai_coding_auto_models_default_order () =
   with_env "ZAI_CODING_AUTO_MODELS" "" (fun () ->
     Alcotest.(check (list string)) "coding auto order"
@@ -132,6 +154,8 @@ let () =
         test_zai_glm_becomes_glm_provider_config;
       test_case "zai coding auto uses coding default model" `Quick
         test_zai_coding_auto_uses_coding_default_model;
+      test_case "kimi custom provider becomes kimi" `Quick
+        test_kimi_custom_registered_becomes_kimi_provider_config;
       test_case "zai coding auto models default order" `Quick
         test_zai_coding_auto_models_default_order;
     ];

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -3,8 +3,9 @@
 module PC = Llm_provider.Provider_config
 module BA = Llm_provider.Backend_anthropic
 module BO = Llm_provider.Backend_openai
+module BGlm = Llm_provider.Backend_glm
 module BOL = Llm_provider.Backend_ollama
-module BG = Llm_provider.Backend_gemini
+module BGemini = Llm_provider.Backend_gemini
 open Llm_provider.Types
 
 let contains_substring ~sub text =
@@ -219,7 +220,7 @@ let test_gemini_with_json_schema () =
       ~base_url:"https://generativelanguage.googleapis.com/v1beta"
       ~api_key:"test-key" ~response_format:(JsonSchema schema) ()
   in
-  let body = BG.build_request ~config ~messages:[user_msg "Return JSON."] () in
+  let body = BGemini.build_request ~config ~messages:[user_msg "Return JSON."] () in
   let json = Yojson.Safe.from_string body in
   let open Yojson.Safe.Util in
   let generation_config = json |> member "generationConfig" in
@@ -231,12 +232,109 @@ let test_gemini_with_json_schema () =
     (generation_config |> member "responseJsonSchema" |> member "required" |> to_list
      |> List.hd |> to_string)
 
+let test_kimi_direct_with_tools_and_thinking () =
+  let config = PC.make ~kind:Kimi ~model_id:"kimi-for-coding"
+    ~base_url:"https://api.kimi.com/coding" ~enable_thinking:true () in
+  let tool = `Assoc [
+    ("name", `String "shell");
+    ("description", `String "run shell command");
+    ("input_schema", `Assoc [("type", `String "object")]);
+  ] in
+  let body = BA.build_request ~config ~messages:[user_msg "inspect repo"]
+    ~tools:[tool] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  let tools = json |> member "tools" |> to_list in
+  let thinking = json |> member "thinking" in
+  Alcotest.(check string) "model" "kimi-for-coding"
+    (json |> member "model" |> to_string);
+  Alcotest.(check int) "tool count" 1 (List.length tools);
+  Alcotest.(check string) "thinking type" "enabled"
+    (thinking |> member "type" |> to_string)
+
+let test_kimi_direct_tool_result_uses_text_blocks () =
+  let config = PC.make ~kind:Kimi ~model_id:"kimi-for-coding"
+    ~base_url:"https://api.kimi.com/coding" () in
+  let messages = [
+    { role = Assistant; content = [
+        Thinking { thinking_type = "sig_1";
+                   content = "I should call the calculator." };
+        ToolUse { id = "tool_1"; name = "calculator";
+                  input = `Assoc [("a", `Int 2); ("b", `Int 3)] };
+      ]; name = None; tool_call_id = None };
+    { role = Tool; content = [
+        ToolResult {
+          tool_use_id = "tool_1";
+          content = "5";
+          is_error = false;
+          json = Some (`Int 5);
+        };
+      ]; name = None; tool_call_id = None };
+  ] in
+  let body = BA.build_request ~config ~messages () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  let replay = json |> member "messages" |> index 1 in
+  let block = replay |> member "content" |> index 0 in
+  let content_blocks = block |> member "content" |> to_list in
+  Alcotest.(check string) "tool result role serialized as user" "user"
+    (replay |> member "role" |> to_string);
+  Alcotest.(check string) "tool_result type" "tool_result"
+    (block |> member "type" |> to_string);
+  Alcotest.(check string) "tool_use id preserved" "tool_1"
+    (block |> member "tool_use_id" |> to_string);
+  Alcotest.(check int) "tool_result content block count" 1
+    (List.length content_blocks);
+  Alcotest.(check string) "nested text block type" "text"
+    (List.hd content_blocks |> member "type" |> to_string);
+  Alcotest.(check string) "nested text block content" "5"
+    (List.hd content_blocks |> member "text" |> to_string)
+
+let test_glm_preserved_reasoning_replay_and_auto_tool_choice () =
+  let config = PC.make ~kind:Glm ~model_id:"glm-5.1"
+    ~base_url:"https://api.z.ai/api/coding/paas/v4"
+    ~enable_thinking:true ~clear_thinking:false
+    ~tool_stream:true ~tool_choice:(Tool "calculator") () in
+  let messages = [
+    { role = Assistant; content = [
+        Thinking { thinking_type = "reasoning";
+                   content = "I need the calculator result." };
+        ToolUse { id = "call_1"; name = "calculator";
+                  input = `Assoc [("expr", `String "2+2")] };
+      ]; name = None; tool_call_id = None };
+    { role = Tool; content = [
+        ToolResult {
+          tool_use_id = "call_1";
+          content = "{\"value\":4}";
+          is_error = false;
+          json = Some (`Assoc [("value", `Int 4)]);
+        };
+      ]; name = None; tool_call_id = None };
+  ] in
+  let body = BGlm.build_request ~stream:true ~config ~messages () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  let assistant = json |> member "messages" |> index 0 in
+  Alcotest.(check string) "glm tool_choice coerced" "auto"
+    (json |> member "tool_choice" |> to_string);
+  Alcotest.(check string) "assistant content remains text channel" ""
+    (assistant |> member "content" |> to_string);
+  Alcotest.(check string) "reasoning replayed separately"
+    "I need the calculator result."
+    (assistant |> member "reasoning_content" |> to_string);
+  Alcotest.(check bool) "clear_thinking false preserved" true
+    (json |> member "thinking" |> member "clear_thinking" |> to_bool = false);
+  Alcotest.(check bool) "tool_stream enabled" true
+    (json |> member "tool_stream" |> to_bool)
 (* ── Provider_config.make ────────────────────────────── *)
 
 let test_config_default_paths () =
   let anth = PC.make ~kind:Anthropic ~model_id:"m" ~base_url:"" () in
   Alcotest.(check string) "anthropic path" "/v1/messages"
     anth.request_path;
+  let kimi = PC.make ~kind:Kimi ~model_id:"m" ~base_url:"" () in
+  Alcotest.(check string) "kimi path" "/v1/messages"
+    kimi.request_path;
   let oai = PC.make ~kind:OpenAI_compat ~model_id:"m" ~base_url:"" () in
   Alcotest.(check string) "openai path" "/v1/chat/completions"
     oai.request_path
@@ -286,13 +384,14 @@ let test_complete_claude_code_without_transport_is_guarded () =
      typed [CliTransportRequired] so cascades and callers can
      distinguish a wiring bug from a transient network failure.
 
-     Covers the full matrix (Claude_code, Gemini_cli, Codex_cli). *)
+     Covers the full matrix (Claude_code, Gemini_cli, Kimi_cli, Codex_cli). *)
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   let net = Eio.Stdenv.net env in
   let kinds =
     [ PC.Claude_code,  "claude_code";
       PC.Gemini_cli,   "gemini_cli";
+      PC.Kimi_cli,     "kimi_cli";
       PC.Codex_cli,    "codex_cli" ]
   in
   List.iter (fun (kind, expected_name) ->
@@ -486,9 +585,15 @@ let () =
       test_case "basic body" `Quick test_openai_basic_body;
       test_case "with system" `Quick test_openai_with_system;
       test_case "with tools" `Quick test_openai_with_tools;
+      test_case "kimi direct tools + thinking" `Quick
+        test_kimi_direct_with_tools_and_thinking;
+      test_case "kimi direct tool_result uses text blocks" `Quick
+        test_kimi_direct_tool_result_uses_text_blocks;
       test_case "stream flag" `Quick test_openai_stream_flag;
       test_case "with json schema" `Quick test_openai_with_json_schema;
       test_case "ollama output schema" `Quick test_ollama_output_schema;
+      test_case "glm preserved reasoning replay" `Quick
+        test_glm_preserved_reasoning_replay_and_auto_tool_choice;
     ];
     "gemini_build_request", [
       test_case "with json schema" `Quick test_gemini_with_json_schema;

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -37,6 +37,11 @@ let test_request_path_anthropic () =
     ~model_id:"m" ~base_url:"" () in
   check_string "anthropic path" "/v1/messages" cfg.request_path
 
+let test_request_path_kimi () =
+  let cfg = Provider_config.make ~kind:Kimi
+    ~model_id:"m" ~base_url:"" () in
+  check_string "kimi path" "/v1/messages" cfg.request_path
+
 let test_request_path_openai () =
   let cfg = Provider_config.make ~kind:OpenAI_compat
     ~model_id:"m" ~base_url:"" () in
@@ -56,6 +61,11 @@ let test_request_path_claude_code () =
   let cfg = Provider_config.make ~kind:Claude_code
     ~model_id:"m" ~base_url:"" () in
   check_string "claude_code path" "" cfg.request_path
+
+let test_request_path_kimi_cli () =
+  let cfg = Provider_config.make ~kind:Kimi_cli
+    ~model_id:"m" ~base_url:"" () in
+  check_string "kimi_cli path" "" cfg.request_path
 
 let test_request_path_override () =
   let cfg = Provider_config.make ~kind:Anthropic
@@ -120,6 +130,13 @@ let test_validate_output_schema_glm_rejected () =
     ~model_id:"glm-5" ~base_url:"https://api.z.ai/api/coding/paas/v4"
     ~output_schema:(`Assoc [("type", `String "object")]) () in
   check_bool "glm rejected" true
+    (Result.is_error (Provider_config.validate_output_schema_request cfg))
+
+let test_validate_output_schema_kimi_rejected () =
+  let cfg = Provider_config.make ~kind:Kimi
+    ~model_id:"kimi-for-coding" ~base_url:"https://api.kimi.com/coding"
+    ~output_schema:(`Assoc [("type", `String "object")]) () in
+  check_bool "kimi rejected" true
     (Result.is_error (Provider_config.validate_output_schema_request cfg))
 
 (* ── make: headers default ────────────────────────────── *)
@@ -398,10 +415,12 @@ let () =
     ];
     "request_path", [
       Alcotest.test_case "anthropic" `Quick test_request_path_anthropic;
+      Alcotest.test_case "kimi" `Quick test_request_path_kimi;
       Alcotest.test_case "openai" `Quick test_request_path_openai;
       Alcotest.test_case "gemini" `Quick test_request_path_gemini;
       Alcotest.test_case "glm" `Quick test_request_path_glm;
       Alcotest.test_case "claude_code" `Quick test_request_path_claude_code;
+      Alcotest.test_case "kimi_cli" `Quick test_request_path_kimi_cli;
       Alcotest.test_case "override" `Quick test_request_path_override;
     ];
     "explicit_values", [
@@ -415,6 +434,8 @@ let () =
         test_validate_output_schema_openai_compat_rejected;
       Alcotest.test_case "glm rejected" `Quick
         test_validate_output_schema_glm_rejected;
+      Alcotest.test_case "kimi rejected" `Quick
+        test_validate_output_schema_kimi_rejected;
     ];
     "locality", [
       Alcotest.test_case "loopback ip" `Quick test_is_local_loopback_ip;

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -163,10 +163,10 @@ let test_find_capable_composite () =
 
 (* ── Default registry ───────────────────────────────── *)
 
-let test_default_has_15 () =
+let test_default_has_17 () =
   let reg = Provider_registry.default () in
   let all = Provider_registry.all reg in
-  check int "15 known providers" 15 (List.length all);
+  check int "17 known providers" 17 (List.length all);
   check bool "llama exists" true
     (Option.is_some (Provider_registry.find reg "llama"));
   check bool "ollama exists" true
@@ -179,6 +179,8 @@ let test_default_has_15 () =
     (Option.is_some (Provider_registry.find reg "glm"));
   check bool "glm-coding exists" true
     (Option.is_some (Provider_registry.find reg "glm-coding"));
+  check bool "kimi exists" true
+    (Option.is_some (Provider_registry.find reg "kimi"));
   check bool "openrouter exists" true
     (Option.is_some (Provider_registry.find reg "openrouter"));
   check bool "groq exists" true
@@ -195,6 +197,8 @@ let test_default_has_15 () =
     (Option.is_some (Provider_registry.find reg "cc"));
   check bool "gemini_cli exists" true
     (Option.is_some (Provider_registry.find reg "gemini_cli"));
+  check bool "kimi_cli exists" true
+    (Option.is_some (Provider_registry.find reg "kimi_cli"));
   check bool "codex_cli exists" true
     (Option.is_some (Provider_registry.find reg "codex_cli"))
 
@@ -225,6 +229,9 @@ let test_default_max_context () =
   (match Provider_registry.find reg "glm" with
    | Some e -> check int "glm 200K" 200_000 e.max_context
    | None -> fail "glm should exist");
+  (match Provider_registry.find reg "kimi" with
+   | Some e -> check int "kimi 262K" 262_144 e.max_context
+   | None -> fail "kimi should exist");
   (match Provider_registry.find reg "cc" with
    | Some e -> check int "cc 1M" 1_000_000 e.max_context
    | None -> fail "cc should exist");
@@ -242,7 +249,10 @@ let test_default_max_context () =
    | None -> fail "siliconflow should exist");
   (match Provider_registry.find reg "codex_cli" with
    | Some e -> check int "codex_cli 1.05M" 1_050_000 e.max_context
-   | None -> fail "codex_cli should exist")
+   | None -> fail "codex_cli should exist");
+  (match Provider_registry.find reg "kimi_cli" with
+   | Some e -> check int "kimi_cli 262K" 262_144 e.max_context
+   | None -> fail "kimi_cli should exist")
 
 let test_default_max_context_matches_capabilities () =
   let reg = Provider_registry.default () in
@@ -267,7 +277,14 @@ let test_default_zai_base_urls () =
    | Some e ->
        check string "glm-coding base_url" Zai_catalog.coding_base_url
          e.defaults.base_url
-   | None -> fail "glm-coding should exist")
+   | None -> fail "glm-coding should exist");
+  (match Provider_registry.find reg "kimi" with
+   | Some e ->
+       check string "kimi base_url" "https://api.kimi.com/coding"
+         e.defaults.base_url;
+       check string "kimi request_path" "/v1/messages"
+         e.defaults.request_path
+   | None -> fail "kimi should exist")
 
 let test_blank_zai_base_urls_fall_back () =
   let prev_general = Sys.getenv_opt "ZAI_BASE_URL" in
@@ -357,7 +374,7 @@ let () =
       test_case "requires_any" `Quick test_requires_any;
     ];
     "default", [
-      test_case "has 15 providers" `Quick test_default_has_15;
+      test_case "has 17 providers" `Quick test_default_has_17;
       test_case "correct capabilities" `Quick test_default_capabilities;
       test_case "max_context values" `Quick test_default_max_context;
       test_case "max_context matches capabilities" `Quick


### PR DESCRIPTION
## What changed
- add first-class `kimi` direct provider support for the Kimi Code Anthropic-compatible `/v1/messages` API
- add `kimi_cli` non-interactive transport based on `kimi --print --output-format stream-json`
- preserve tool and reasoning replay semantics needed by Kimi direct and GLM coding flows
- tighten provider registry, bridge, config, and tests for the new provider kinds

## Why
- `oas` already supported GLM direct and other CLI transports, but Kimi Code still required out-of-tree experiments
- Kimi direct and CLI need provider-specific wiring rather than generic OpenAI-compatible fallback
- GLM coding also needed replay/tool-choice hardening in the same provider surface

## Impact
- callers can use `kimi` for direct coding-endpoint requests
- callers can use `kimi_cli` for tool-heavy local CLI/MCP workflows
- GLM coding requests keep preserved reasoning replay and conservative tool-choice semantics

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/feat-kimi-code-provider`
- `./_build/default/test/test_provider_config.exe`
- `./_build/default/test/test_provider_registry.exe`
- `./_build/default/test/test_provider_bridge.exe`
- `./_build/default/test/test_provider.exe`
- `./_build/default/test/test_provider_complete.exe`
- `./_build/default/test/test_api.exe`
- `./scripts/check-transport-truth.sh`
- live smoke: `curl https://api.kimi.com/coding/v1/messages ...` -> `OK`
- live smoke: `KIMI_BASE_URL=... kimi --print ...` -> `OK`
- live smoke: `sb glm-text "Say exactly OK and nothing else."` -> `OK`
