### PR TITLE
feat(provider_kind): lift is_subprocess_cli to the sum type module

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -140,9 +140,11 @@ let provider_name_of_kind : Provider_config.provider_kind -> string = function
   | Gemini_cli -> "gemini_cli"
   | Kimi_cli -> "kimi_cli"
   | Codex_cli -> "codex_cli"
-let requires_non_http_transport : Provider_config.provider_kind -> bool = function
-  | Claude_code | Gemini_cli | Kimi_cli | Codex_cli -> true
-  | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm -> false
+(* Delegate to the sum-type-owning module. The name stays local because
+   several guard clauses in this file reference it; renaming is a
+   separate concern. Replacing the hand-maintained match removes the
+   drift risk when a new subprocess-transported kind is added. *)
+let requires_non_http_transport = Provider_config.is_subprocess_cli
 
 let validate_output_schema_request (config : Provider_config.t) =
   match Provider_config.validate_output_schema_request config with

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -92,6 +92,7 @@ let string_of_provider_kind = Provider_kind.to_string
 let provider_kind_of_string = Provider_kind.of_string
 let all_provider_kinds = Provider_kind.all
 let default_api_key_env = Provider_kind.default_api_key_env
+let is_subprocess_cli = Provider_kind.is_subprocess_cli
 let pp_provider_kind = Provider_kind.pp
 let show_provider_kind = Provider_kind.show
 let provider_kind_to_yojson = Provider_kind.to_yojson

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -115,6 +115,12 @@ val all_provider_kinds : provider_kind list
     @since 0.166.0 *)
 val default_api_key_env : provider_kind -> string option
 
+(** Re-export of {!Provider_kind.is_subprocess_cli}. [true] for the
+    four CLI-subprocess kinds (Claude_code, Gemini_cli, Kimi_cli,
+    Codex_cli); [false] for direct-HTTP kinds.
+    @since 0.170.0 *)
+val is_subprocess_cli : provider_kind -> bool
+
 (** Canonical inverse of {!string_of_provider_kind}.
 
     Accepts every lowercase form produced by {!string_of_provider_kind} plus

--- a/lib/llm_provider/provider_kind.ml
+++ b/lib/llm_provider/provider_kind.ml
@@ -43,6 +43,10 @@ let default_api_key_env = function
   | Glm -> Some "ZAI_API_KEY"
   | OpenAI_compat | Ollama | Claude_code | Gemini_cli | Kimi_cli | Codex_cli -> None
 
+let is_subprocess_cli = function
+  | Claude_code | Gemini_cli | Kimi_cli | Codex_cli -> true
+  | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm -> false
+
 let of_string raw =
   match String.lowercase_ascii (String.trim raw) with
   | "anthropic" | "claude" -> Some Anthropic

--- a/lib/llm_provider/provider_kind.mli
+++ b/lib/llm_provider/provider_kind.mli
@@ -35,6 +35,15 @@ val default_api_key_env : t -> string option
     ({!Claude_code}, {!Gemini_cli}, {!Codex_cli}), or shares a space where
     OAS does not dictate the env name ({!OpenAI_compat}). *)
 
+val is_subprocess_cli : t -> bool
+(** [true] for kinds whose transport is a subprocess CLI
+    ({!Claude_code}, {!Gemini_cli}, {!Kimi_cli}, {!Codex_cli}) rather
+    than a direct HTTP request. Centralizes a discrimination that used
+    to live as an inline [match _ with Claude_code | … -> true | _ ->
+    false] in several modules; lifting it here makes future variant
+    additions force an explicit categorization in the compiler.
+    @since 0.170.0 *)
+
 val to_string : t -> string
 (** Canonical lowercase wire form (e.g. [Anthropic -> "anthropic"]).
     Exhaustive — adding a new variant forces a compile error. *)

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -444,6 +444,40 @@ let test_default_api_key_env_known () =
     (Some "KIMI_API_KEY_SB")
     (Provider_config.default_api_key_env Kimi)
 
+let test_is_subprocess_cli () =
+  List.iter (fun (label, k) ->
+    Alcotest.(check bool) ("subprocess: " ^ label) true
+      (Provider_config.is_subprocess_cli k)
+  ) [
+    "claude_code", Provider_config.Claude_code;
+    "gemini_cli",  Provider_config.Gemini_cli;
+    "kimi_cli",    Provider_config.Kimi_cli;
+    "codex_cli",   Provider_config.Codex_cli;
+  ];
+  List.iter (fun (label, k) ->
+    Alcotest.(check bool) ("http: " ^ label) false
+      (Provider_config.is_subprocess_cli k)
+  ) [
+    "anthropic",     Provider_config.Anthropic;
+    "kimi",          Provider_config.Kimi;
+    "openai_compat", Provider_config.OpenAI_compat;
+    "ollama",        Provider_config.Ollama;
+    "gemini",        Provider_config.Gemini;
+    "glm",           Provider_config.Glm;
+  ]
+
+(* Partition property: every variant is either a subprocess CLI or
+   direct-HTTP, never both, never neither. Verifies the predicate is
+   total over [all] and catches future variants that slip past the
+   compiler's exhaustive match (defensive runtime check). *)
+let test_subprocess_partitions_all () =
+  let xs = Provider_config.all_provider_kinds in
+  let sub, http = List.partition Provider_config.is_subprocess_cli xs in
+  Alcotest.(check int) "four subprocess kinds" 4 (List.length sub);
+  Alcotest.(check int) "six http-direct kinds" 6 (List.length http);
+  Alcotest.(check int) "partition sums to all" (List.length xs)
+    (List.length sub + List.length http)
+
 let test_default_api_key_env_none_for_others () =
   (* Local / transport-mediated / OpenAI-compatible share: OAS does not
      dictate a single env var; callers supply their own. *)
@@ -557,6 +591,10 @@ let () =
         test_default_api_key_env_known;
       Alcotest.test_case "default_api_key_env None for others" `Quick
         test_default_api_key_env_none_for_others;
+      Alcotest.test_case "is_subprocess_cli partitions variants" `Quick
+        test_is_subprocess_cli;
+      Alcotest.test_case "subprocess + http partition covers all" `Quick
+        test_subprocess_partitions_all;
     ];
     "telemetry_wire_format", [
       Alcotest.test_case "kind emitted as lowercase canonical string" `Quick


### PR DESCRIPTION
## Summary

Lift the "is this kind a CLI subprocess transport?" discrimination into `Provider_kind.is_subprocess_cli : t -> bool`, re-export as `Provider_config.is_subprocess_cli`, and have `Complete.requires_non_http_transport` delegate to it.

```ocaml
val is_subprocess_cli : t -> bool
(** [true] for Claude_code, Gemini_cli, Kimi_cli, Codex_cli;
    [false] for Anthropic, Kimi, OpenAI_compat, Ollama, Gemini, Glm. *)
```

## Why

Before this PR the same match lived in six places:

- `lib/llm_provider/complete.ml:143` — named helper `requires_non_http_transport`.
- `lib/llm_provider/complete.ml:55, 248-249, 345-346, 710-711, 771-772` — five inline patterns that pass through / return `""` / `[]` for the four subprocess kinds.

A new subprocess-transport kind added to the sum type would have silently defaulted to the `false` arm at every inline site. Centralising the predicate on `Provider_kind` makes the decision exhaustive in the compiler — new variants force a `true` / `false` choice in one place.

## Changes

- `lib/llm_provider/provider_kind.ml` / `.mli` — new `is_subprocess_cli` with exhaustive match on all 10 variants.
- `lib/llm_provider/provider_config.ml` / `.mli` — re-export as `Provider_config.is_subprocess_cli`.
- `lib/llm_provider/complete.ml` — `requires_non_http_transport` becomes a one-line delegation.
- `test/test_provider_config.ml` — two new cases in `kind_enumeration` group (predicate value per variant + partition covers `all_provider_kinds`).

Net 63 insertions, 3 deletions across 6 files.

## Behavior preservation

- `requires_non_http_transport` has identical truth table to the delegated `Provider_config.is_subprocess_cli`.
- The five inline patterns in `complete.ml` are unchanged in this PR — each one has a different right-hand side (pass-through vs `""` vs `[]`), so a mechanical replacement would distort intent. Follow-ups can decide case by case whether they become `if is_subprocess_cli kind then … else …`.
- No wire-format change.

## Test plan

- [x] `dune build --root .` clean
- [x] `dune exec --root . test/test_provider_config.exe` — 46/46 pass (+2 over 44)
- [x] `dune build --root . @test/runtest` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
