### PR TITLE
ci(tag-drift): flip Release Tag Drift job from warn-only to --strict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,9 +179,13 @@ jobs:
     name: Release Tag Drift
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Non-blocking warn-only: reports CHANGELOG entries that lack a matching
-    # git tag. Flip to --strict in a follow-up PR once the existing backlog
-    # (v0.155.1, v0.160.0, v0.161.0, v0.163.0, v0.164.0) is back-tagged.
+    # Enforced gate: fails if any CHANGELOG entry in the default scope
+    # (--limit 10) lacks a matching `v<version>` git tag. The backlog
+    # surfaced when #1130 landed (v0.155.1, v0.160.0, v0.161.0,
+    # v0.163.0, v0.164.0) was back-tagged in the same session, so the
+    # default scope is drift-free. Widening --limit further surfaces a
+    # deeper backlog (duplicate `[0.154.0]`, out-of-order `[0.155.0]`)
+    # that needs CHANGELOG cleanup before the scope is raised.
 
     steps:
       - name: Checkout
@@ -190,5 +194,5 @@ jobs:
           # Need full tag history for `git tag -l` to see released versions.
           fetch-depth: 0
 
-      - name: Run tag drift audit (warn-only)
-        run: bash scripts/check-tag-drift.sh
+      - name: Enforce tag drift (strict)
+        run: bash scripts/check-tag-drift.sh --strict


### PR DESCRIPTION
## Summary

Follow-up to #1130. Flips the `Release Tag Drift` CI job from warn-only to `--strict`.

## Why now

#1130 landed the gate in warn-only mode to avoid turning CI red while the existing backlog was cleaned up. In the same session, the five missing tags the audit surfaced (`v0.155.1`, `v0.160.0`, `v0.161.0`, `v0.163.0`, `v0.164.0`) were back-tagged against the release-cut commit on each version's `dune-project` bump:

| version | commit |
|---------|--------|
| v0.164.0 | `99a70b6d` |
| v0.163.0 | `36490371` |
| v0.161.0 | `1d455cd0` |
| v0.160.0 | `e5ec2d1a` |
| v0.155.1 | `ce1910bf` |

Current main in the default `--limit 10` scope:

```
check-tag-drift: scanned 10 most recent CHANGELOG entries (limit=10)
  tagged:  10
  missing: 0
```

## What changes

One file, nine-line diff in `.github/workflows/ci.yml`: the step runs `bash scripts/check-tag-drift.sh --strict` instead of no flag. No script change.

## Scope deliberately left at --limit 10

Widening to `--limit 15` surfaces a deeper CHANGELOG backlog: `## [0.154.0]` appears twice (lines 137 and 196), and `## [0.155.0]` sits below `## [0.155.1]` (out of semver order). That needs a CHANGELOG-hygiene PR before the gate scope is raised — separating code-edit hygiene from gate-policy changes.

## Test plan

- [x] `bash scripts/check-tag-drift.sh --strict` exits 0 on current main
- [ ] CI `Release Tag Drift` green on this PR (first strict run)
- [ ] Next release PR bumping dune-project without a follow-up tag will fail this check (negative test is naturally deferred to the next release cycle)
