### PR TITLE
test(registry): every provider_kind must resolve to a registered entry

### DIFF
--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -352,6 +352,93 @@ let test_requires_any () =
     (Capability_filter.requires_any
        [Capability_filter.requires_tools; Capability_filter.requires_streaming] caps)
 
+(* ── Kind ↔ registry integrity ────────────────────────── *)
+
+(** Minimal [Provider_config.t] construction for a given kind, using a
+    localhost base URL so [is_local = true] for [OpenAI_compat] (resolves
+    to the registry's "llama" entry) and a plain (non-coding) URL for
+    [Glm] (resolves to "glm"). *)
+let mk_config_for_kind kind =
+  let base_url = match kind with
+    | Provider_config.OpenAI_compat -> "http://127.0.0.1:8085"
+    | _ -> "https://example.test"
+  in
+  Provider_config.make ~kind ~model_id:"test" ~base_url ()
+
+(** Regression guard for the masc-mcp capability-lookup bug fixed in
+    masc-mcp#9306. That bug passed [Provider_adapter.string_of_provider_kind]
+    (masc canonical_name: "claude-api", "kimi-api", "codex-api", ...) to
+    [Provider_registry.find], but the registry is keyed on the names
+    returned by [Provider_registry.provider_name_of_config] ("claude",
+    "kimi", "llama", "ollama", "claude_code", "gemini_cli", ...). For
+    direct-API kinds the lookup silently fell back to
+    [default_capabilities]; for CLI kinds the masc vocabulary happened
+    to match direct-API entries ("claude" → Anthropic, "gemini" → Gemini,
+    "kimi" → Kimi) and returned the wrong capability matrix.
+
+    Assert here that [provider_name_of_config] is the authoritative key
+    source: every variant in [Provider_config.all_provider_kinds]
+    produces a name that resolves to [Some entry] in the default
+    registry. Adding a variant without a corresponding registry
+    registration fails this test. *)
+let test_every_kind_resolves_in_registry () =
+  let registry = Provider_registry.default () in
+  List.iter
+    (fun kind ->
+      let cfg = mk_config_for_kind kind in
+      let name = Provider_registry.provider_name_of_config cfg in
+      let label =
+        Printf.sprintf "kind=%s name=%s"
+          (Provider_config.string_of_provider_kind kind) name
+      in
+      match Provider_registry.find registry name with
+      | Some entry ->
+          check string
+            (Printf.sprintf "%s: entry.name echoes lookup key" label)
+            name entry.name
+      | None ->
+          failf
+            "%s: provider_name_of_config returned %S but registry has no \
+             entry for it; either register the provider or fix the naming \
+             function" label name)
+    Provider_config.all_provider_kinds
+
+(** Sharper assertion for the two CLI kinds that were the primary
+    wrong-hit victims in masc-mcp#9306: assert their registry entries
+    are CLI-shaped, not direct-API-shaped. If a regression reverts
+    [provider_name_of_config Claude_code] back to ["claude"], this
+    test fails because the resolved entry's [defaults.kind] will be
+    [Anthropic] instead of [Claude_code]. *)
+let test_cli_kinds_resolve_to_cli_entries () =
+  let registry = Provider_registry.default () in
+  let cases = [
+    Provider_config.Claude_code, "claude_code";
+    Provider_config.Gemini_cli, "gemini_cli";
+    Provider_config.Kimi_cli, "kimi_cli";
+    Provider_config.Codex_cli, "codex_cli";
+  ] in
+  List.iter
+    (fun (kind, expected_name) ->
+      let cfg = mk_config_for_kind kind in
+      let name = Provider_registry.provider_name_of_config cfg in
+      check string
+        (Printf.sprintf "%s maps to expected registry key"
+           (Provider_config.string_of_provider_kind kind))
+        expected_name name;
+      (match Provider_registry.find registry name with
+       | Some entry ->
+           (* The entry's defaults.kind must equal the variant we
+              started from; this catches any future renaming that
+              silently points a CLI kind at a direct-API entry. *)
+           check bool
+             (Printf.sprintf "%s → entry.defaults.kind equals source"
+                (Provider_config.string_of_provider_kind kind))
+             true (entry.defaults.kind = kind)
+       | None ->
+           failf "%s: no entry for %S"
+             (Provider_config.string_of_provider_kind kind) name))
+    cases
+
 (* ── Suite ──────────────────────────────────────────── *)
 
 let () =
@@ -381,6 +468,11 @@ let () =
         test_default_max_context_matches_capabilities;
       test_case "zai base urls" `Quick test_default_zai_base_urls;
       test_case "blank zai base urls fall back" `Quick test_blank_zai_base_urls_fall_back;
+    ];
+    "kind_registry_integrity", [
+      test_case "every kind resolves" `Quick test_every_kind_resolves_in_registry;
+      test_case "CLI kinds resolve to CLI entries" `Quick
+        test_cli_kinds_resolve_to_cli_entries;
     ];
     "types_usage", [
       test_case "zero_api_usage" `Quick test_zero_api_usage;


### PR DESCRIPTION
## Summary

Regression guard for the silent capability-lookup bug fixed in [masc-mcp#9306](https://github.com/jeong-sik/masc-mcp/pull/9306), raised into the OAS test suite so it's enforced at the SSOT rather than relying on each downstream consumer to catch it again.

## Background

masc-mcp#9306 fixed a call site that passed `Provider_adapter.string_of_provider_kind` (masc adapter canonical_name: `"claude-api"`, `"kimi-api"`, `"codex-api"`, …) to `Provider_registry.find`. The OAS registry is keyed on the names returned by `Provider_registry.provider_name_of_config` (`"claude"`, `"kimi"`, `"llama"`, `"ollama"`, `"claude_code"`, …). Two failure modes silently coexisted: direct-API kinds *missed* the registry and fell back to `default_capabilities`; CLI kinds *wrong-hit* the direct-API entries (masc mapped `Claude_code` → `"claude"` which collides with the Anthropic entry).

## What changes

Two alcotest cases in `test/test_provider_registry.ml` under a new `kind_registry_integrity` group:

1. **`test_every_kind_resolves_in_registry`** — walks `Provider_config.all_provider_kinds` (the canonical enumeration added in 0.166.0) and asserts `Provider_registry.find` against `Provider_registry.provider_name_of_config` returns `Some` for every variant. Adding a new variant without registering it now fails here rather than silently reaching `default_capabilities` downstream.

2. **`test_cli_kinds_resolve_to_cli_entries`** — targeted assertion that `Claude_code` / `Gemini_cli` / `Kimi_cli` / `Codex_cli` resolve to `"claude_code"` / `"gemini_cli"` / `"kimi_cli"` / `"codex_cli"` and that the resolved entry's `defaults.kind` round-trips to the source variant. This is the *wrong-hit* mode: a regression that reintroduces the collision flips `entry.defaults.kind` to the direct-API variant and the test fails.

No library change.

## Test plan

- [x] `dune build --root .` clean
- [x] `dune exec --root . test/test_provider_registry.exe` — 22/22 green (20 pre-existing + 2 new)
- [ ] CI `Build and Test` green

## Why in OAS and not masc-mcp

`provider_name_of_config` is the SSOT for registry naming. Keeping the regression at the SSOT level means any future downstream consumer — not just masc-mcp — that reintroduces the same pattern is caught by the SDK's own test suite before it ships.
