### PR TITLE
feat(agent): add tiered recall prompt assembly

### DIFF
--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -14,6 +14,12 @@ type periodic_callback = Agent_types.periodic_callback = {
   callback: unit -> unit;
 }
 
+type tiered_memory = Types.tiered_memory = {
+  long_term: string option;
+  mid_term: string option;
+  short_term: string option;
+}
+
 type options = Agent_types.options = {
   base_url: string;
   provider: Provider.config option;
@@ -27,6 +33,7 @@ type options = Agent_types.options = {
   approval: Hooks.approval_callback option;
   tool_retry_policy: Tool_retry_policy.t option;
   context_reducer: Context_reducer.t option;
+  tiered_memory: tiered_memory option;
   context_injector: Hooks.context_injector option;
   mcp_clients: Mcp.managed list;
   event_bus: Event_bus.t option;

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -51,6 +51,12 @@ let is_idle ?(granularity = Exact)
 
 (* ── Turn preparation ─────────────────────────────────────────── *)
 
+type tiered_memory = Types.tiered_memory = {
+  long_term: string option;
+  mid_term: string option;
+  short_term: string option;
+}
+
 type turn_preparation = {
   tools_json: Yojson.Safe.t list option;
   effective_messages: message list;
@@ -130,7 +136,82 @@ let prepare_tools ~guardrails ~operator_policy ~policy_channel ~(tools : Tool_se
   let tools_json = if tool_schemas = [] then None else Some tool_schemas in
   (tools_json, effective_guardrails)
 
-let prepare_messages ~messages ~context_reducer ~turn_params =
+let normalize_tier_content = function
+  | None -> None
+  | Some text ->
+    let trimmed = String.trim text in
+    if trimmed = "" then None else Some trimmed
+
+let render_tiered_memory_message = function
+  | None -> None
+  | Some (tiered_memory : tiered_memory) ->
+    let sections =
+      List.filter_map (fun (header, content) ->
+        Option.map (fun text -> header ^ "\n" ^ text) content)
+        [
+          ("[LONG-TERM MEMORY]", normalize_tier_content tiered_memory.long_term);
+          ("[MID-TERM MEMORY]", normalize_tier_content tiered_memory.mid_term);
+          ("[SHORT-TERM MEMORY]", normalize_tier_content tiered_memory.short_term);
+        ]
+    in
+    match sections with
+    | [] -> None
+    | _ ->
+      Some {
+        role = User;
+        content = [Text (String.concat "\n\n" sections)];
+        name = None;
+        tool_call_id = None;
+      }
+
+let tiered_memory_tokens tiered_memory =
+  match render_tiered_memory_message tiered_memory with
+  | None -> 0
+  | Some recall -> Context_reducer.estimate_message_tokens recall
+
+let rec reserve_strategy_budget ~reserved_tokens strategy =
+  match strategy with
+  | Context_reducer.Token_budget budget ->
+    Context_reducer.Token_budget (Int.max 0 (budget - reserved_tokens))
+  | Context_reducer.Compose strategies ->
+    Context_reducer.Compose
+      (List.map (reserve_strategy_budget ~reserved_tokens) strategies)
+  | Context_reducer.Dynamic selector ->
+    Context_reducer.Dynamic (fun ~turn ~messages ->
+      reserve_strategy_budget ~reserved_tokens (selector ~turn ~messages))
+  | other -> other
+
+let reserve_context_reducer ~tiered_memory = function
+  | None -> None
+  | Some reducer as original ->
+    let reserved_tokens = tiered_memory_tokens tiered_memory in
+    if reserved_tokens <= 0 then original
+    else
+      let reserved_strategy =
+        reserve_strategy_budget ~reserved_tokens reducer.Context_reducer.strategy
+      in
+      Some { Context_reducer.strategy = reserved_strategy }
+
+let apply_context_reducer ~messages ~context_reducer ~tiered_memory =
+  match reserve_context_reducer ~tiered_memory context_reducer with
+  | None -> messages
+  | Some reducer -> Context_reducer.reduce reducer messages
+
+let split_leading_system_messages messages =
+  let rec loop leading = function
+    | ({ role = System; _ } as msg) :: rest -> loop (msg :: leading) rest
+    | rest -> (List.rev leading, rest)
+  in
+  loop [] messages
+
+let inject_tiered_memory_message ~tiered_memory messages =
+  match render_tiered_memory_message tiered_memory with
+  | None -> messages
+  | Some recall ->
+    let leading_system, rest = split_leading_system_messages messages in
+    leading_system @ (recall :: rest)
+
+let prepare_messages ~messages ~context_reducer ~tiered_memory ~turn_params =
   (* Apply call-time stubbing: older tool results are replaced with
      short stubs before sending to the LLM.  This is done here (not in
      state.messages) so the stored conversation prefix stays byte-identical
@@ -140,10 +221,10 @@ let prepare_messages ~messages ~context_reducer ~turn_params =
     Context_reducer.keep_last 100;
   ] in
   let pruned = Context_reducer.reduce call_time_pruner messages in
-  let effective = match context_reducer with
-    | None -> pruned
-    | Some reducer -> Context_reducer.reduce reducer pruned
+  let effective =
+    apply_context_reducer ~messages:pruned ~context_reducer ~tiered_memory
   in
+  let effective = inject_tiered_memory_message ~tiered_memory effective in
   match turn_params.Hooks.extra_system_context with
   | None -> effective
   | Some ctx ->
@@ -156,14 +237,14 @@ let prepare_messages ~messages ~context_reducer ~turn_params =
     let system_msg = { role = User; content = [Text ("[system context] " ^ ctx)]; name = None; tool_call_id = None } in
     effective @ [system_msg]
 
-let prepare_turn ~guardrails ~operator_policy ~policy_channel ~tools ~messages ~context_reducer ~turn_params
+let prepare_turn ~guardrails ~operator_policy ~policy_channel ~tools ~messages ~context_reducer ~tiered_memory ~turn_params
     ?tool_selector () =
   let tools_json, effective_guardrails =
     prepare_tools ~guardrails ~operator_policy ~policy_channel ~tools ~turn_params
       ?tool_selector ~messages ()
   in
   let effective_messages =
-    prepare_messages ~messages ~context_reducer ~turn_params
+    prepare_messages ~messages ~context_reducer ~tiered_memory ~turn_params
   in
   { tools_json; effective_messages; effective_guardrails }
 

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -52,6 +52,12 @@ val is_idle :
 
 (** {1 Turn preparation} *)
 
+type tiered_memory = Types.tiered_memory = {
+  long_term: string option;
+  mid_term: string option;
+  short_term: string option;
+}
+
 (** Pre-processed inputs for an LLM turn. *)
 type turn_preparation = {
   tools_json: Yojson.Safe.t list option;
@@ -83,9 +89,18 @@ val prepare_tools :
   Yojson.Safe.t list option * Guardrails.t
 
 (** Reduce messages and inject extra system context. *)
+val tiered_memory_tokens : tiered_memory option -> int
+
+val apply_context_reducer :
+  messages:Types.message list ->
+  context_reducer:Context_reducer.t option ->
+  tiered_memory:tiered_memory option ->
+  Types.message list
+
 val prepare_messages :
   messages:Types.message list ->
   context_reducer:Context_reducer.t option ->
+  tiered_memory:tiered_memory option ->
   turn_params:Hooks.turn_params ->
   Types.message list
 
@@ -100,6 +115,7 @@ val prepare_turn :
   tools:Tool_set.t ->
   messages:Types.message list ->
   context_reducer:Context_reducer.t option ->
+  tiered_memory:tiered_memory option ->
   turn_params:Hooks.turn_params ->
   ?tool_selector:Tool_selector.strategy ->
   unit ->

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -5,6 +5,12 @@ type periodic_callback = {
   callback: unit -> unit;
 }
 
+type tiered_memory = Types.tiered_memory = {
+  long_term: string option;
+  mid_term: string option;
+  short_term: string option;
+}
+
 type options = {
   base_url: string;
   provider: Provider.config option;
@@ -18,6 +24,7 @@ type options = {
   approval: Hooks.approval_callback option;
   tool_retry_policy: Tool_retry_policy.t option;
   context_reducer: Context_reducer.t option;
+  tiered_memory: tiered_memory option;
   context_injector: Hooks.context_injector option;
   mcp_clients: Mcp.managed list;
   event_bus: Event_bus.t option;
@@ -120,6 +127,7 @@ let default_options = {
   approval = None;
   tool_retry_policy = None;
   context_reducer = Some Defaults.default_context_reducer;
+  tiered_memory = None;
   context_injector = None;
   mcp_clients = [];
   event_bus = None;

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -14,6 +14,12 @@ type periodic_callback = {
   callback: unit -> unit;
 }
 
+type tiered_memory = Types.tiered_memory = {
+  long_term: string option;
+  mid_term: string option;
+  short_term: string option;
+}
+
 type options = {
   base_url: string;
   provider: Provider.config option;
@@ -30,6 +36,11 @@ type options = {
   approval: Hooks.approval_callback option;
   tool_retry_policy: Tool_retry_policy.t option;
   context_reducer: Context_reducer.t option;
+  tiered_memory: tiered_memory option;
+    (** Optional pre-computed recall tiers injected into the prompt as a
+        pinned summary block. OAS only assembles and budgets these
+        tiers; generation/persistence is handled by the caller.
+        @since 0.166.0 *)
   context_injector: Hooks.context_injector option;
   mcp_clients: Mcp.managed list;
   event_bus: Event_bus.t option;

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -39,6 +39,7 @@ type t = {
   approval: Hooks.approval_callback option;
   tool_retry_policy: Tool_retry_policy.t option;
   context_reducer: Context_reducer.t option;
+  tiered_memory: Agent.tiered_memory option;
   context_compact_ratio: float option;
   context_prepare_ratio: float option;
   context_handoff_ratio: float option;
@@ -106,6 +107,7 @@ let create ~net ~model =
     approval = None;
     tool_retry_policy = None;
     context_reducer = None;
+    tiered_memory = None;
     context_compact_ratio = None;
     context_prepare_ratio = None;
     context_handoff_ratio = None;
@@ -180,6 +182,7 @@ let with_approval approval b = { b with approval = Some approval }
 let with_tool_retry_policy tool_retry_policy b =
   { b with tool_retry_policy = Some tool_retry_policy }
 let with_context_reducer reducer b = { b with context_reducer = Some reducer }
+let with_tiered_memory tiered_memory b = { b with tiered_memory = Some tiered_memory }
 let with_context_thresholds ~compact_ratio ?context_window_tokens ?prepare_ratio ?handoff_ratio b =
   (* Resolution chain for the context window used by the reducer:
      1. explicit [?context_window_tokens] argument (caller knows the
@@ -337,6 +340,7 @@ let build b =
     approval = b.approval;
     tool_retry_policy = b.tool_retry_policy;
     context_reducer = b.context_reducer;
+    tiered_memory = b.tiered_memory;
     context_injector = b.context_injector;
     mcp_clients;
     event_bus = b.event_bus;

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -89,6 +89,7 @@ val with_raw_trace : Raw_trace.t -> t -> t
 val with_approval : Hooks.approval_callback -> t -> t
 val with_tool_retry_policy : Tool_retry_policy.t -> t -> t
 val with_context_reducer : Context_reducer.t -> t -> t
+val with_tiered_memory : Agent.tiered_memory -> t -> t
 
 (** Set context reduction thresholds.
     [compact_ratio] determines when to compact (default 0.8).

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -133,9 +133,18 @@ let prepare_turn_for_agent agent ~turn_params =
     ~policy_channel:agent.options.policy_channel
     ~tools:agent.tools
     ~messages:agent.state.messages
-    ~context_reducer:agent.options.context_reducer ~turn_params
+    ~context_reducer:agent.options.context_reducer
+    ~tiered_memory:agent.options.tiered_memory
+    ~turn_params
     ?tool_selector:agent.options.tool_selector
     ()
+
+let total_prompt_tokens_for_agent agent messages =
+  let raw_tokens =
+    List.fold_left (fun acc msg ->
+      acc + Context_reducer.estimate_message_tokens msg) 0 messages
+  in
+  raw_tokens + Agent_turn.tiered_memory_tokens agent.options.tiered_memory
 
 (** Invoke BeforeTurnParams hook, apply turn params, prepare tools.
     Returns (turn_preparation, original_config, turn_params). *)
@@ -617,8 +626,7 @@ let proactive_context_window_tokens agent =
     @since Phase 2 — proactive compaction *)
 let proactive_compact ?raw_trace_run agent ~watermark () =
   let messages = agent.state.messages in
-  let est_tokens = List.fold_left (fun acc msg ->
-    acc + Context_reducer.estimate_message_tokens msg) 0 messages in
+  let est_tokens = total_prompt_tokens_for_agent agent messages in
   let context_window_tokens = proactive_context_window_tokens agent in
   let usage_ratio =
     float_of_int est_tokens /. float_of_int context_window_tokens
@@ -646,12 +654,13 @@ let proactive_compact ?raw_trace_run agent ~watermark () =
       let reduced = Budget_strategy.reduce_for_budget
         ?summarizer:agent.options.summarizer
         ~usage_ratio:scaled_ratio ~messages () in
-      let reduced = match agent.options.context_reducer with
-        | Some reducer -> Context_reducer.reduce reducer reduced
-        | None -> reduced
+      let reduced =
+        Agent_turn.apply_context_reducer
+          ~messages:reduced
+          ~context_reducer:agent.options.context_reducer
+          ~tiered_memory:agent.options.tiered_memory
       in
-      let after_tokens = List.fold_left (fun acc msg ->
-        acc + Context_reducer.estimate_message_tokens msg) 0 reduced in
+      let after_tokens = total_prompt_tokens_for_agent agent reduced in
       if after_tokens >= est_tokens then false
       else begin
         let phase =
@@ -704,8 +713,7 @@ let proactive_compact ?raw_trace_run agent ~watermark () =
     Returns [true] if messages were actually reduced. *)
 let emergency_compact ?raw_trace_run agent ?limit () =
   let messages = agent.state.messages in
-  let est_tokens = List.fold_left (fun acc msg ->
-    acc + Context_reducer.estimate_message_tokens msg) 0 messages in
+  let est_tokens = total_prompt_tokens_for_agent agent messages in
   let budget = match limit with
     | Some l -> l
     | None -> est_tokens
@@ -722,12 +730,13 @@ let emergency_compact ?raw_trace_run agent ?limit () =
     let reduced = Budget_strategy.reduce_for_budget
       ?summarizer:agent.options.summarizer
       ~usage_ratio:1.0 ~messages () in
-    let reduced = match agent.options.context_reducer with
-      | Some reducer -> Context_reducer.reduce reducer reduced
-      | None -> reduced
+    let reduced =
+      Agent_turn.apply_context_reducer
+        ~messages:reduced
+        ~context_reducer:agent.options.context_reducer
+        ~tiered_memory:agent.options.tiered_memory
     in
-    let after_tokens = List.fold_left (fun acc msg ->
-      acc + Context_reducer.estimate_message_tokens msg) 0 reduced in
+    let after_tokens = total_prompt_tokens_for_agent agent reduced in
     if after_tokens >= est_tokens then false
     else begin
       let phase = "emergency" in
@@ -805,8 +814,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
       | Some w when w > 0.0 && w < 1.0 -> w
       | _ -> 0.9  (* hard floor: compact before 90% regardless of config *)
     in
-    let est_tokens = List.fold_left (fun acc msg ->
-      acc + Context_reducer.estimate_message_tokens msg) 0 agent.state.messages in
+    let est_tokens = total_prompt_tokens_for_agent agent agent.state.messages in
     let context_window = proactive_context_window_tokens agent in
     let ratio = float_of_int est_tokens /. float_of_int context_window in
     if ratio >= watermark then begin
@@ -854,8 +862,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
       | Some w when w > 0.0 && w < 1.0 -> w
       | _ -> 0.9
     in
-    let est_tokens = List.fold_left (fun acc msg ->
-      acc + Context_reducer.estimate_message_tokens msg) 0 agent.state.messages in
+    let est_tokens = total_prompt_tokens_for_agent agent agent.state.messages in
     let context_window = proactive_context_window_tokens agent in
     let ratio = float_of_int est_tokens /. float_of_int context_window in
     if ratio >= watermark then begin

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -82,6 +82,12 @@ type model = string
     Delegates to {!Model_registry.resolve_model_id}. *)
 let model_to_string = Model_registry.resolve_model_id
 
+type tiered_memory = {
+  long_term: string option;
+  mid_term: string option;
+  short_term: string option;
+}
+
 (** Agent configuration *)
 type agent_config = {
   name: string;

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -31,6 +31,12 @@ type model = string
 (** Resolve a model alias to its canonical API model ID. *)
 val model_to_string : model -> string
 
+type tiered_memory = {
+  long_term: string option;
+  mid_term: string option;
+  short_term: string option;
+}
+
 (** Agent configuration *)
 type agent_config = {
   name: string;

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -525,6 +525,101 @@ let test_agent_run_guardrails () =
      | Error e -> fail (Error.to_string e))
   with Exit -> ()
 
+let prompt_token_estimate messages =
+  List.fold_left (fun acc msg ->
+    acc + Context_reducer.estimate_message_tokens msg) 0 messages
+
+let test_agent_run_tiered_memory_triggers_proactive_compaction () =
+  Eio_main.run @@ fun env ->
+  try
+    Eio.Switch.run @@ fun sw ->
+    let url = start_multi_mock ~sw ~net:env#net ~port:20011
+        [openai_text_response "compacted"] in
+    let provider : Provider.config = {
+      provider = Provider.Local { base_url = url };
+      model_id = "mock-model";
+      api_key_env = "";
+    } in
+    let tiered_memory : Agent.tiered_memory = {
+      long_term = Some (String.make 220 'r');
+      mid_term = None;
+      short_term = None;
+    } in
+    let estimated_tokens_seen = ref None in
+    let hooks = {
+      Hooks.empty with
+      pre_compact = Some (function
+        | Hooks.PreCompact info ->
+          estimated_tokens_seen := Some info.estimated_tokens;
+          Hooks.Continue
+        | _ -> Hooks.Continue);
+    } in
+    let config = {
+      Types.default_config with
+      name = "tiered-memory-compaction";
+      max_turns = 3;
+      context_compact_ratio = Some 0.0022;
+    } in
+    let options = {
+      Agent.default_options with
+      base_url = url;
+      provider = Some provider;
+      hooks;
+      tiered_memory = Some tiered_memory;
+    } in
+    let agent = Agent.create ~net:env#net ~config ~options () in
+    let raw_messages = [
+      { Types.role = User; content = [Text "search logs"]; name = None; tool_call_id = None };
+      { Types.role = Assistant;
+        content = [ToolUse { id = "tool_1"; name = "search"; input = `Assoc [("q", `String "errors")] }];
+        name = None;
+        tool_call_id = None };
+      { Types.role = User;
+        content = [ToolResult {
+          tool_use_id = "tool_1";
+          content = String.make 1000 'x';
+          is_error = false;
+          json = None;
+        }];
+        name = None;
+        tool_call_id = None };
+    ] in
+    Agent.update_state agent (fun state -> { state with messages = raw_messages });
+    let prompt = "continue" in
+    let raw_with_prompt_tokens =
+      prompt_token_estimate
+        (raw_messages @ [{ Types.role = User; content = [Text prompt]; name = None; tool_call_id = None }])
+    in
+    let watermark_tokens =
+      int_of_float
+        (0.0022 *. float_of_int
+           (Provider.resolve_max_context_tokens ~fallback:128_000 (Some provider)))
+    in
+    check bool "raw history stays below watermark" true
+      (raw_with_prompt_tokens < watermark_tokens);
+    (match Agent.run ~sw agent prompt with
+     | Ok resp ->
+       check string "final text" "compacted" (extract_text resp);
+       (match !estimated_tokens_seen with
+        | Some estimated_tokens ->
+          check bool "recall pushed estimated tokens higher" true
+            (estimated_tokens > raw_with_prompt_tokens)
+        | None -> fail "expected pre_compact hook to fire");
+       let tool_result_lengths =
+         Agent.state agent |> fun state ->
+         List.concat_map (fun (msg : Types.message) ->
+           List.filter_map (function
+             | Types.ToolResult { content; _ } -> Some (String.length content)
+             | _ -> None)
+             msg.content)
+           state.messages
+       in
+       check bool "tool result was compacted" true
+         (List.exists (fun len -> len < 1000) tool_result_lengths);
+       Eio.Switch.fail sw Exit
+     | Error e -> fail (Error.to_string e))
+  with Exit -> ()
+
 (* ── Runner ──────────────────────────────────────────── *)
 
 let () =
@@ -553,6 +648,8 @@ let () =
     "hooks_and_reducers", [
       test_case "hooks" `Quick test_agent_run_with_hooks;
       test_case "context reducer" `Quick test_agent_run_with_reducer;
+      test_case "tiered memory triggers compaction" `Quick
+        test_agent_run_tiered_memory_triggers_proactive_compaction;
       test_case "guardrails" `Quick test_agent_run_guardrails;
     ];
   ]

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -12,6 +12,7 @@ let test_prepare_turn_empty_tools () =
     ~tools:Tool_set.empty
     ~messages:[]
     ~context_reducer:None
+    ~tiered_memory:None
     ~turn_params:Hooks.default_turn_params
     ()
   in
@@ -32,6 +33,7 @@ let test_prepare_turn_with_tools () =
     ~tools:(Tool_set.of_list [tool])
     ~messages:[]
     ~context_reducer:None
+    ~tiered_memory:None
     ~turn_params:Hooks.default_turn_params
     ()
   in
@@ -52,6 +54,7 @@ let test_prepare_turn_with_guardrails_filter () =
     ~tools:(Tool_set.of_list [tool_a; tool_b])
     ~messages:[]
     ~context_reducer:None
+    ~tiered_memory:None
     ~turn_params:Hooks.default_turn_params
     ()
   in
@@ -66,6 +69,7 @@ let test_prepare_messages_no_reducer () =
   ] in
   let result = Agent_turn.prepare_messages
     ~messages:msgs ~context_reducer:None
+    ~tiered_memory:None
     ~turn_params:Hooks.default_turn_params
   in
   Alcotest.(check int) "same count" 1 (List.length result)
@@ -79,7 +83,7 @@ let test_prepare_messages_extra_context () =
     extra_system_context = Some "You are in test mode.";
   } in
   let result = Agent_turn.prepare_messages
-    ~messages:msgs ~context_reducer:None ~turn_params
+    ~messages:msgs ~context_reducer:None ~tiered_memory:None ~turn_params
   in
   Alcotest.(check int) "prepended system msg" 2 (List.length result);
   let first = List.hd result in
@@ -99,7 +103,7 @@ let test_prepare_messages_system_prompt_override_noop () =
     system_prompt_override = Some "Custom system prompt";
   } in
   let result = Agent_turn.prepare_messages
-    ~messages:msgs ~context_reducer:None ~turn_params
+    ~messages:msgs ~context_reducer:None ~tiered_memory:None ~turn_params
   in
   (* system_prompt_override is handled in pipeline stage_parse, not
      in prepare_messages. Message count should remain unchanged. *)
@@ -115,7 +119,7 @@ let test_prepare_messages_both_override_and_extra_context () =
     system_prompt_override = Some "You are a reviewer.";
   } in
   let result = Agent_turn.prepare_messages
-    ~messages:msgs ~context_reducer:None ~turn_params
+    ~messages:msgs ~context_reducer:None ~tiered_memory:None ~turn_params
   in
   (* extra_system_context injects a User message; system_prompt_override
      is applied separately in pipeline. So only extra_system_context
@@ -126,6 +130,113 @@ let test_prepare_messages_both_override_and_extra_context () =
   match first.content with
   | [Types.Text _] -> ()
   | _ -> Alcotest.fail "expected single Text block"
+
+let starts_with ~prefix s =
+  let prefix_len = String.length prefix in
+  String.length s >= prefix_len
+  && String.sub s 0 prefix_len = prefix
+
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    if needle_len = 0 then true
+    else if idx + needle_len > haystack_len then false
+    else if String.sub haystack idx needle_len = needle then true
+    else loop (idx + 1)
+  in
+  loop 0
+
+let message_text_exn (msg : Types.message) =
+  match msg.content with
+  | [Types.Text text] -> text
+  | _ -> Alcotest.fail "expected single text message"
+
+let is_tiered_recall_message msg =
+  starts_with ~prefix:"[LONG-TERM MEMORY]" (message_text_exn msg)
+  || starts_with ~prefix:"[MID-TERM MEMORY]" (message_text_exn msg)
+  || starts_with ~prefix:"[SHORT-TERM MEMORY]" (message_text_exn msg)
+
+let test_prepare_messages_with_tiered_memory_after_system () =
+  let msgs = [
+    { Types.role = Types.System; content = [Types.Text "obey system prompt"]; name = None; tool_call_id = None };
+    { Types.role = Types.User; content = [Types.Text "hello"]; name = None; tool_call_id = None };
+  ] in
+  let tiered_memory : Agent_turn.tiered_memory = {
+    long_term = Some "User prefers concise answers.";
+    mid_term = Some "Working on memory architecture.";
+    short_term = Some "Investigating compaction regressions.";
+  } in
+  let result = Agent_turn.prepare_messages
+    ~messages:msgs ~context_reducer:None
+    ~tiered_memory:(Some tiered_memory) ~turn_params:Hooks.default_turn_params
+  in
+  Alcotest.(check int) "system + recall + raw" 3 (List.length result);
+  let first = List.nth result 0 in
+  let second = List.nth result 1 in
+  let third = List.nth result 2 in
+  Alcotest.(check bool) "system stays first" true (first.role = Types.System);
+  Alcotest.(check bool) "recall inserted second" true (is_tiered_recall_message second);
+  let recall_text = message_text_exn second in
+  Alcotest.(check bool) "contains long term" true
+    (contains_substring ~needle:"[LONG-TERM MEMORY]" recall_text);
+  Alcotest.(check bool) "contains mid term" true
+    (contains_substring ~needle:"[MID-TERM MEMORY]" recall_text);
+  Alcotest.(check bool) "contains short term" true
+    (contains_substring ~needle:"[SHORT-TERM MEMORY]" recall_text);
+  Alcotest.(check string) "raw message preserved" "hello" (message_text_exn third)
+
+let test_prepare_messages_omits_blank_tiered_memory () =
+  let msgs = [
+    { Types.role = Types.User; content = [Types.Text "hello"]; name = None; tool_call_id = None };
+  ] in
+  let tiered_memory : Agent_turn.tiered_memory = {
+    long_term = Some "   ";
+    mid_term = None;
+    short_term = Some "\n";
+  } in
+  let result = Agent_turn.prepare_messages
+    ~messages:msgs ~context_reducer:None
+    ~tiered_memory:(Some tiered_memory) ~turn_params:Hooks.default_turn_params
+  in
+  Alcotest.(check int) "blank recall omitted" 1 (List.length result);
+  Alcotest.(check string) "original message unchanged" "hello"
+    (message_text_exn (List.hd result))
+
+let test_prepare_messages_tiered_memory_reserves_token_budget () =
+  let mk_user text =
+    { Types.role = Types.User; content = [Types.Text text]; name = None; tool_call_id = None }
+  in
+  let msgs = [
+    mk_user (String.make 100 'a');
+    mk_user (String.make 100 'b');
+    mk_user (String.make 100 'c');
+  ] in
+  let reducer = Some (Context_reducer.token_budget 70) in
+  let baseline = Agent_turn.prepare_messages
+    ~messages:msgs ~context_reducer:reducer
+    ~tiered_memory:None
+    ~turn_params:Hooks.default_turn_params
+  in
+  let tiered_memory : Agent_turn.tiered_memory = {
+    long_term = Some (String.make 200 'r');
+    mid_term = None;
+    short_term = None;
+  } in
+  let with_recall = Agent_turn.prepare_messages
+    ~messages:msgs ~context_reducer:reducer
+    ~tiered_memory:(Some tiered_memory) ~turn_params:Hooks.default_turn_params
+  in
+  let baseline_raw =
+    List.filter (fun msg -> not (is_tiered_recall_message msg)) baseline
+  in
+  let recall_raw =
+    List.filter (fun msg -> not (is_tiered_recall_message msg)) with_recall
+  in
+  Alcotest.(check int) "baseline keeps two raw turns" 2 (List.length baseline_raw);
+  Alcotest.(check int) "reserved budget keeps one raw turn" 1 (List.length recall_raw);
+  Alcotest.(check bool) "recall message present" true
+    (List.exists is_tiered_recall_message with_recall)
 
 (* ── accumulate_usage tests ──────────────────────────────── *)
 
@@ -377,6 +488,7 @@ let test_prepare_turn_filter_override () =
     ~tools:(Tool_set.of_list [tool_a; tool_b])
     ~messages:[]
     ~context_reducer:None
+    ~tiered_memory:None
     ~turn_params
     ()
   in
@@ -697,6 +809,12 @@ let () =
         test_prepare_messages_system_prompt_override_noop;
       Alcotest.test_case "both override and extra_context" `Quick
         test_prepare_messages_both_override_and_extra_context;
+      Alcotest.test_case "tiered memory after system" `Quick
+        test_prepare_messages_with_tiered_memory_after_system;
+      Alcotest.test_case "blank tiered memory omitted" `Quick
+        test_prepare_messages_omits_blank_tiered_memory;
+      Alcotest.test_case "tiered memory reserves token budget" `Quick
+        test_prepare_messages_tiered_memory_reserves_token_budget;
     ];
     "accumulate_usage", [
       Alcotest.test_case "with response" `Quick test_accumulate_usage_with_response;

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -219,7 +219,32 @@ let test_with_context_reducer () =
   Alcotest.(check bool) "context_reducer set" true
     (Option.is_some (Agent.options agent).context_reducer)
 
-(* --- 13b. with_summarizer --- *)
+(* --- 13b. with_tiered_memory --- *)
+
+let test_with_tiered_memory () =
+  with_net @@ fun net ->
+  let tiered_memory : Agent.tiered_memory = {
+    long_term = Some "Knows the operator preferences.";
+    mid_term = None;
+    short_term = Some "Working on context compaction.";
+  } in
+  let agent =
+    Builder.create ~net ~model:"claude-sonnet-4-6"
+    |> Builder.with_tiered_memory tiered_memory
+    |> Builder.build_safe |> Result.get_ok
+  in
+  let opts = Agent.options agent in
+  Alcotest.(check bool) "tiered_memory set" true
+    (Option.is_some opts.tiered_memory);
+  match opts.tiered_memory with
+  | Some actual ->
+    Alcotest.(check (option string)) "long_term"
+      tiered_memory.long_term actual.long_term;
+    Alcotest.(check (option string)) "short_term"
+      tiered_memory.short_term actual.short_term
+  | None -> Alcotest.fail "expected tiered_memory"
+
+(* --- 13c. with_summarizer --- *)
 
 let test_with_summarizer () =
   with_net @@ fun net ->
@@ -241,7 +266,7 @@ let test_with_summarizer () =
   in
   Alcotest.(check string) "summarizer identity" marker applied
 
-(* --- 13c. with_transport --- *)
+(* --- 13d. with_transport --- *)
 
 let test_with_transport () =
   with_net @@ fun net ->
@@ -778,6 +803,7 @@ let () =
       Alcotest.test_case "approval" `Quick test_with_approval;
       Alcotest.test_case "tool retry policy" `Quick test_with_tool_retry_policy;
       Alcotest.test_case "context_reducer" `Quick test_with_context_reducer;
+      Alcotest.test_case "tiered_memory" `Quick test_with_tiered_memory;
       Alcotest.test_case "summarizer" `Quick test_with_summarizer;
       Alcotest.test_case "transport" `Quick test_with_transport;
       Alcotest.test_case "context" `Quick test_with_context;

--- a/test/test_builder_coverage.ml
+++ b/test/test_builder_coverage.ml
@@ -184,6 +184,7 @@ let test_agent_default_options () =
   Alcotest.(check bool) "no event_bus" true (opts.event_bus = None);
   Alcotest.(check bool) "no skill_registry" true (opts.skill_registry = None);
   Alcotest.(check bool) "no memory" true (opts.memory = None);
+  Alcotest.(check bool) "no tiered_memory" true (opts.tiered_memory = None);
   Alcotest.(check int) "max_idle_turns" 3 opts.max_idle_turns;
   Alcotest.(check int) "empty mcp" 0 (List.length opts.mcp_clients)
 

--- a/test/test_operator_policy.ml
+++ b/test/test_operator_policy.ml
@@ -150,6 +150,7 @@ let test_full_prepare_turn_with_operator () =
     ~tools
     ~messages:[]
     ~context_reducer:None
+    ~tiered_memory:None
     ~turn_params:Hooks.default_turn_params
     ()
   in

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -103,6 +103,7 @@ let test_agent_turn_preparation () =
     ~policy_channel:None
     ~tools ~messages
     ~context_reducer:None
+    ~tiered_memory:None
     ~turn_params:Hooks.default_turn_params () in
   (* tools_json should be Some with 2 tools *)
   (match prep.tools_json with
@@ -273,6 +274,7 @@ let test_prepare_turn_no_tools () =
     ~policy_channel:None
     ~tools:Tool_set.empty ~messages
     ~context_reducer:None
+    ~tiered_memory:None
     ~turn_params:Hooks.default_turn_params () in
   (match prep.tools_json with
    | None -> ()
@@ -291,6 +293,7 @@ let test_prepare_turn_preserves_messages () =
     ~policy_channel:None
     ~tools:Tool_set.empty ~messages
     ~context_reducer:None
+    ~tiered_memory:None
     ~turn_params:Hooks.default_turn_params () in
   Alcotest.(check int) "3 messages" 3 (List.length prep.effective_messages)
 
@@ -526,6 +529,7 @@ let test_prepare_turn_extra_context () =
     ~policy_channel:None
     ~tools:Tool_set.empty ~messages
     ~context_reducer:None
+    ~tiered_memory:None
     ~turn_params () in
   (* Extra context is appended at the end to preserve prefix for KV cache *)
   Alcotest.(check int) "2 messages (original + context)" 2
@@ -555,6 +559,7 @@ let test_prepare_turn_tool_filter_override () =
     ~policy_channel:None
     ~tools ~messages
     ~context_reducer:None
+    ~tiered_memory:None
     ~turn_params () in
   match prep.tools_json with
   | Some tools_json ->


### PR DESCRIPTION
## Summary
- add typed tiered_memory options and builder wiring
- assemble a pinned tiered recall block before raw history and reserve its token budget in reducers
- count recall tokens in compaction watermarks and add regression tests for assembly and proactive compaction

Closes #792

## Testing
- dune build
- ./_build/default/test/test_builder.exe
- ./_build/default/test/test_agent_turn.exe
- ./_build/default/test/test_agent_pipeline.exe
- ./_build/default/test/test_context_reducer.exe
- ./_build/default/test/test_agent_turn_budget_unit.exe
- ./_build/default/test/test_types.exe