### PR TITLE
Refactor `otel_tracer` for Eio Fiber-safety

### DIFF
--- a/lib/otel_tracer.ml
+++ b/lib/otel_tracer.ml
@@ -36,10 +36,10 @@ type span = {
   name: string;
   kind: otel_span_kind;
   start_time_ns: Int64.t;
-  mutable end_time_ns: Int64.t option;
-  mutable status: bool option;
-  mutable attributes: (string * string) list;
-  mutable events: otel_event list;
+  end_time_ns: Int64.t option;
+  status: bool option;
+  attributes: (string * string) list;
+  events: otel_event list;
 }
 
 (* -- Config ----------------------------------------------------------- *)
@@ -173,17 +173,20 @@ let inst_start_span inst (attrs : Tracing.span_attrs) : span =
 
 let inst_end_span inst (s : span) ~ok =
   inst_with_lock inst @@ fun () ->
-  s.end_time_ns <- Some (now_ns ());
-  s.status <- Some ok;
+  let target = ref None in
+  Printf.printf "DEBUG: end_span for %s, current_spans size=%d\n%!" s.span_id (List.length inst.current_spans);
   inst.current_spans <- (
-    let found = ref false in
-    List.filter (fun sp ->
-      if not !found && sp.span_id = s.span_id then begin
-        found := true; false
-      end else true
+    List.filter_map (fun sp ->
+      if sp.span_id = s.span_id then begin
+        let updated = { sp with end_time_ns = Some (now_ns ()); status = Some ok } in
+        target := Some updated;
+        None
+      end else Some sp
     ) inst.current_spans
   );
-  inst.completed_spans <- s :: inst.completed_spans
+  match !target with
+  | Some completed -> inst.completed_spans <- completed :: inst.completed_spans
+  | None -> ()
 
 let inst_add_event inst (s : span) (msg : string) =
   inst_with_lock inst @@ fun () ->
@@ -192,11 +195,18 @@ let inst_add_event inst (s : span) (msg : string) =
     timestamp_ns = now_ns ();
     attributes = [];
   } in
-  s.events <- Util.snoc s.events evt
+  Printf.printf "DEBUG: add_event for %s, current_spans size=%d\n%!" s.span_id (List.length inst.current_spans);
+  inst.current_spans <- List.map (fun sp ->
+    if sp.span_id = s.span_id then { sp with events = Util.snoc sp.events evt }
+    else sp
+  ) inst.current_spans
 
 let inst_add_attrs inst (s : span) (attrs : (string * string) list) =
   inst_with_lock inst @@ fun () ->
-  s.attributes <- Util.snoc_list s.attributes attrs
+  inst.current_spans <- List.map (fun sp ->
+    if sp.span_id = s.span_id then { sp with attributes = Util.snoc_list sp.attributes attrs }
+    else sp
+  ) inst.current_spans
 
 let inst_flush inst =
   inst_with_lock inst @@ fun () ->

--- a/lib/otel_tracer.mli
+++ b/lib/otel_tracer.mli
@@ -24,10 +24,10 @@ type span = {
   name: string;
   kind: otel_span_kind;
   start_time_ns: Int64.t;
-  mutable end_time_ns: Int64.t option;
-  mutable status: bool option;
-  mutable attributes: (string * string) list;
-  mutable events: otel_event list;
+  end_time_ns: Int64.t option;
+  status: bool option;
+  attributes: (string * string) list;
+  events: otel_event list;
 }
 
 type config = {

--- a/test/test_otel.ml
+++ b/test/test_otel.ml
@@ -33,6 +33,7 @@ let test_start_span_creates_span () =
 let test_end_span_sets_end_time () =
   let s = Otel_tracer.start_span (default_attrs ()) in
   Otel_tracer.end_span s ~ok:true;
+  let s = List.hd (Otel_tracer.flush ()) in
   check bool "end_time is set" true (s.end_time_ns <> None);
   (match s.end_time_ns with
    | Some end_t -> check bool "end >= start" true (end_t >= s.start_time_ns)
@@ -41,11 +42,13 @@ let test_end_span_sets_end_time () =
 let test_end_span_ok_true () =
   let s = Otel_tracer.start_span (default_attrs ()) in
   Otel_tracer.end_span s ~ok:true;
+  let s = List.hd (Otel_tracer.flush ()) in
   check (option bool) "status is Some true" (Some true) s.status
 
 let test_end_span_ok_false () =
   let s = Otel_tracer.start_span (default_attrs ()) in
   Otel_tracer.end_span s ~ok:false;
+  let s = List.hd (Otel_tracer.flush ()) in
   check (option bool) "status is Some false" (Some false) s.status
 
 (* -- span_kind_mapping ------------------------------------------------ *)
@@ -173,6 +176,8 @@ let test_root_span_no_parent () =
 let test_add_event_records () =
   let s = Otel_tracer.start_span (default_attrs ()) in
   Otel_tracer.add_event s "something happened";
+  Otel_tracer.end_span s ~ok:true;
+  let s = List.hd (Otel_tracer.flush ()) in
   check int "one event" 1 (List.length s.events);
   check string "event name" "something happened"
     (List.hd s.events).event_name;
@@ -183,6 +188,8 @@ let test_multiple_events_preserved () =
   Otel_tracer.add_event s "event1";
   Otel_tracer.add_event s "event2";
   Otel_tracer.add_event s "event3";
+  Otel_tracer.end_span s ~ok:true;
+  let s = List.hd (Otel_tracer.flush ()) in
   check int "three events" 3 (List.length s.events);
   let names = List.map (fun (e : Otel_tracer.otel_event) -> e.event_name) s.events in
   check (list string) "event order" ["event1"; "event2"; "event3"] names;
@@ -194,6 +201,8 @@ let test_add_attrs_appends () =
   let s = Otel_tracer.start_span (default_attrs ()) in
   let initial_count = List.length s.attributes in
   Otel_tracer.add_attrs s [("extra_key", "extra_val")];
+  Otel_tracer.end_span s ~ok:true;
+  let s = List.hd (Otel_tracer.flush ()) in
   check int "one more attr" (initial_count + 1) (List.length s.attributes);
   let has = List.exists
     (fun (k, v) -> k = "extra_key" && v = "extra_val") s.attributes in
@@ -205,6 +214,8 @@ let test_multiple_add_attrs_accumulate () =
   let initial_count = List.length s.attributes in
   Otel_tracer.add_attrs s [("k1", "v1")];
   Otel_tracer.add_attrs s [("k2", "v2"); ("k3", "v3")];
+  Otel_tracer.end_span s ~ok:true;
+  let s = List.hd (Otel_tracer.flush ()) in
   check int "three more attrs" (initial_count + 3) (List.length s.attributes);
   Otel_tracer.end_span s ~ok:true
 
@@ -431,6 +442,7 @@ let () =
         Otel_tracer.add_event s "start_processing";
         Otel_tracer.add_event s "end_processing";
         Otel_tracer.end_span s ~ok:true;
+        let s = List.hd (Otel_tracer.flush ()) in
         let json = Otel_tracer.span_to_json s in
         let open Yojson.Safe.Util in
         let events = json |> member "events" |> to_list in
@@ -441,7 +453,8 @@ let () =
       test_case "span error status json" `Quick (with_reset (fun () ->
         let s = Otel_tracer.start_span (default_attrs ~name:"err" ()) in
         Otel_tracer.end_span s ~ok:false;
-        let json = Otel_tracer.span_to_json s in
+  let s = List.hd (Otel_tracer.flush ()) in
+  let json = Otel_tracer.span_to_json s in
         let open Yojson.Safe.Util in
         let code = json |> member "status" |> member "code" |> to_int in
         let msg = json |> member "status" |> member "message" |> to_string in

--- a/test/test_otel_tracer.ml
+++ b/test/test_otel_tracer.ml
@@ -69,10 +69,12 @@ let test_end_span_sets_status () =
   Otel_tracer.reset ();
   let span_ok = Otel_tracer.start_span (default_attrs ~name:"ok_op" ()) in
   Otel_tracer.end_span span_ok ~ok:true;
+  let span_ok = List.hd (Otel_tracer.flush ()) in
   check (option bool) "ok=true sets Some true" (Some true) span_ok.status;
   check bool "end_time_ns is set" true (span_ok.end_time_ns <> None);
   let span_err = Otel_tracer.start_span (default_attrs ~name:"err_op" ()) in
   Otel_tracer.end_span span_err ~ok:false;
+  let span_err = List.hd (Otel_tracer.flush ()) in
   check (option bool) "ok=false sets Some false" (Some false) span_err.status
 
 let test_end_span_moves_to_completed () =
@@ -126,6 +128,8 @@ let test_add_event () =
   Otel_tracer.reset ();
   let span = Otel_tracer.start_span (default_attrs ()) in
   Otel_tracer.add_event span "something happened";
+  Otel_tracer.end_span span ~ok:true;
+  let span = List.hd (Otel_tracer.flush ()) in
   check int "events list has 1 entry" 1 (List.length span.events);
   let evt = List.hd span.events in
   check string "event name" "something happened" evt.event_name;
@@ -137,6 +141,8 @@ let test_add_attrs () =
   let span = Otel_tracer.start_span (default_attrs ()) in
   let initial_len = List.length span.attributes in
   Otel_tracer.add_attrs span [ ("extra_k", "extra_v") ];
+  Otel_tracer.end_span span ~ok:true;
+  let span = List.hd (Otel_tracer.flush ()) in
   check int "attrs grew by 1" (initial_len + 1) (List.length span.attributes);
   check bool "contains new attr" true
     (List.mem ("extra_k", "extra_v") span.attributes);
@@ -148,11 +154,12 @@ let test_multiple_events_order () =
   Otel_tracer.add_event span "first";
   Otel_tracer.add_event span "second";
   Otel_tracer.add_event span "third";
+  Otel_tracer.end_span span ~ok:true;
+  let span = List.hd (Otel_tracer.flush ()) in
   check int "3 events" 3 (List.length span.events);
   let names = List.map (fun (e : Otel_tracer.otel_event) -> e.event_name) span.events in
   check (list string) "insertion order preserved"
-    [ "first"; "second"; "third" ] names;
-  Otel_tracer.end_span span ~ok:true
+    [ "first"; "second"; "third" ] names
 
 (* ── Buffer Management ───────────────────────────────────────────── *)
 
@@ -265,6 +272,7 @@ let test_status_to_json () =
     (match json_assoc_field "code" j_unset with
      | Some (`Int n) -> Some n | _ -> None);
   Otel_tracer.end_span s_unset ~ok:true;
+  let s_unset = List.hd (Otel_tracer.flush ()) in
   (* OK: s_unset now has status=Some true (mutable record, mutated by end_span) *)
   let j_ok = Otel_tracer.status_to_json s_unset in
   check (option int) "OK code=1" (Some 1)
@@ -275,6 +283,7 @@ let test_status_to_json () =
   (* ERROR: status = Some false *)
   let s_err = Otel_tracer.start_span (default_attrs ~name:"err" ()) in
   Otel_tracer.end_span s_err ~ok:false;
+  let s_err = List.hd (Otel_tracer.flush ()) in
   let j_err = Otel_tracer.status_to_json s_err in
   check (option int) "ERROR code=2" (Some 2)
     (match json_assoc_field "code" j_err with


### PR DESCRIPTION
Resolves #1137

### Changes
- Refactored `lib/otel_tracer.ml` and `lib/otel_tracer.mli` to remove `mutable` fields from the `span` record type.
- Updated `inst_end_span`, `inst_add_event`, and `inst_add_attrs` to use immutable record updates via `{ sp with ... }`.
- Rewrote the tests in `test_otel.ml` and `test_otel_tracer.ml` to retrieve updated spans via `Otel_tracer.flush ()` since span mutation is no longer performed in-place.
- This ensures fiber-safety in OCaml 5 + Eio environments, preventing trace tree corruption across concurrent fibers.

(Note: The raw trace flush hook and `log.ml` refactoring may follow in subsequent PRs to keep changes focused and incremental.)