### PR TITLE
feat(retry): add NotFound variant to api_error for HTTP 404

### DIFF
--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -8,6 +8,7 @@ type provider_error = [
   | `Provider_timeout of string
   | `Overloaded
   | `Invalid_request of string
+  | `Not_found of string
   | `Context_overflow of string * int option
 ]
 
@@ -71,6 +72,7 @@ let of_api_error (err : Retry.api_error) : provider_error =
   | Retry.Timeout r -> `Provider_timeout r.message
   | Retry.Overloaded _ -> `Overloaded
   | Retry.InvalidRequest r -> `Invalid_request r.message
+  | Retry.NotFound r -> `Not_found r.message
   | Retry.ContextOverflow r -> `Context_overflow (r.message, r.limit)
 
 let of_sdk_error (err : Error.sdk_error) : sdk_error_poly =
@@ -116,6 +118,7 @@ let provider_to_api : provider_error -> Retry.api_error = function
   | `Provider_timeout msg -> Retry.Timeout { message = msg }
   | `Overloaded -> Retry.Overloaded { message = "overloaded" }
   | `Invalid_request msg -> Retry.InvalidRequest { message = msg }
+  | `Not_found msg -> Retry.NotFound { message = msg }
   | `Context_overflow (msg, limit) -> Retry.ContextOverflow { message = msg; limit }
 
 let to_sdk_error (err : sdk_error_poly) : Error.sdk_error =

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -29,6 +29,7 @@ type provider_error = [
   | `Provider_timeout of string
   | `Overloaded
   | `Invalid_request of string
+  | `Not_found of string
   | `Context_overflow of string * int option
 ]
 

--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -6,6 +6,7 @@ type api_error =
   | ServerError of { status: int; message: string }
   | AuthError of { message: string }
   | InvalidRequest of { message: string }
+  | NotFound of { message: string }
   | ContextOverflow of { message: string; limit: int option }
   | NetworkError of { message: string }
   | Timeout of { message: string }
@@ -30,6 +31,7 @@ let error_message = function
   | ServerError r -> Printf.sprintf "Server error %d: %s" r.status r.message
   | AuthError r -> Printf.sprintf "Auth error: %s" r.message
   | InvalidRequest r -> Printf.sprintf "Invalid request: %s" r.message
+  | NotFound r -> Printf.sprintf "Not found: %s" r.message
   | ContextOverflow r ->
     let limit_str = match r.limit with
       | Some n -> Printf.sprintf " (limit: %d)" n
@@ -132,7 +134,7 @@ let is_retryable = function
   | InvalidRequest { message } ->
     (* Malformed JSON from model output is transient — retry may produce valid JSON. *)
     List.exists (fun needle -> contains_substring_ci ~haystack:message ~needle) malformed_json_indicators
-  | AuthError _ | ContextOverflow _ -> false
+  | AuthError _ | ContextOverflow _ | NotFound _ -> false
 
 let is_hard_quota = function
   | RateLimited { message; _ } -> is_hard_quota_message message
@@ -266,6 +268,7 @@ let classify_error ~status ~body : api_error =
       else parsed_retry_after
     in
     RateLimited { retry_after; message }
+  | 404 -> NotFound { message }
   | 529 -> Overloaded { message }
   | s when s >= 500 -> ServerError { status = s; message }
   | _ -> InvalidRequest { message }

--- a/lib/llm_provider/retry.mli
+++ b/lib/llm_provider/retry.mli
@@ -11,6 +11,7 @@ type api_error =
   | ServerError of { status: int; message: string }
   | AuthError of { message: string }
   | InvalidRequest of { message: string }
+  | NotFound of { message: string }
   | ContextOverflow of { message: string; limit: int option }
   | NetworkError of { message: string }
   | Timeout of { message: string }

--- a/test/test_retry.ml
+++ b/test/test_retry.ml
@@ -61,11 +61,11 @@ let test_classify_error_edge_cases () =
    | Retry.ServerError { message; _ } ->
        check string "raw body fallback" "not json at all" message
    | _ -> fail "expected ServerError with raw body");
-  (* unmapped status (e.g. 404) -> catch-all InvalidRequest *)
+  (* 404 -> NotFound *)
   (match Retry.classify_error ~status:404 ~body:"not found" with
-   | Retry.InvalidRequest { message } ->
-       check string "404 catch-all" "not found" message
-   | _ -> fail "expected InvalidRequest for 404")
+   | Retry.NotFound { message } ->
+       check string "404 not found" "not found" message
+   | _ -> fail "expected NotFound for 404")
 
 let test_is_retryable () =
   check bool "rate limited retryable" true
@@ -81,7 +81,9 @@ let test_is_retryable () =
   check bool "auth not retryable" false
     (Retry.is_retryable (Retry.AuthError { message = "" }));
   check bool "invalid request not retryable" false
-    (Retry.is_retryable (Retry.InvalidRequest { message = "" }))
+    (Retry.is_retryable (Retry.InvalidRequest { message = "" }));
+  check bool "not found not retryable" false
+    (Retry.is_retryable (Retry.NotFound { message = "" }))
 
 let test_error_message_all_variants () =
   let cases = [
@@ -90,6 +92,7 @@ let test_error_message_all_variants () =
     (Retry.ServerError { status = 503; message = "down" }, "Server error 503: down");
     (Retry.AuthError { message = "bad key" }, "Auth error: bad key");
     (Retry.InvalidRequest { message = "wrong" }, "Invalid request: wrong");
+    (Retry.NotFound { message = "no model" }, "Not found: no model");
     (Retry.NetworkError { message = "dns" }, "Network error: dns");
     (Retry.Timeout { message = "10s" }, "Timeout: 10s");
   ] in


### PR DESCRIPTION
## Summary
- Add `NotFound of { message: string }` variant to `api_error` type
- HTTP 404 now maps to `NotFound` instead of catch-all `InvalidRequest`
- `NotFound` is non-retryable (permanent resource absence)
- `error_domain.ml` gains `\`Not_found` polymorphic variant with conversions

## Why
Downstream consumers (masc-mcp `oas_worker_named.ml:544-546`) currently
string-match `"not found"` inside `InvalidRequest.message` to detect 404
errors from OpenAI-compatible providers. This is a "Parse, Don't
Validate" violation — the producer (OAS) has the structured HTTP status
but discards it into a generic string.

With `NotFound` as a distinct variant, consumers can pattern-match on
the type instead of parsing error message text.

## Test plan
- [x] `dune build --root .` — type check passes
- [x] `dune runtest --root .` — all tests pass (16 retry tests + full suite)
- [x] Existing test updated: 404 now expects `NotFound` not `InvalidRequest`
- [x] New assertions: `NotFound` not retryable, `error_message` produces "Not found: ..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)