### PR TITLE
Fix LLM telemetry drops in streaming completions

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,6 @@
 (lang dune 3.22)
 (name agent_sdk)
-(version 0.170.0)
+(version 0.170.1)
 
 (generate_opam_files true)
 

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -799,6 +799,7 @@ let complete_stream ~sw ~net ?(transport : Llm_transport.t option)
   | Error err -> Error err
   | Ok () ->
   let _priority = priority in
+  let t0 = Unix.gettimeofday () in
   let result = match transport with
   | Some t ->
     t.complete_stream ~on_event
@@ -816,7 +817,11 @@ let complete_stream ~sw ~net ?(transport : Llm_transport.t option)
   | None ->
     complete_stream_http ~sw ~net ~config ~messages ~tools ~on_event
   in
-  Result.map (fun resp -> Pricing.annotate_response_cost resp) result
+  Result.map (fun resp ->
+    let latency_ms = int_of_float ((Unix.gettimeofday () -. t0) *. 1000.0) in
+    let resp = Pricing.annotate_response_cost resp in
+    patch_telemetry resp ~config latency_ms
+  ) result
 
 (* ── HTTP Transport constructor ─────────────────────── *)
 


### PR DESCRIPTION
Resolves #9335

### Changes:
- Modified `complete_stream` in `lib/llm_provider/complete.ml` to measure Request latency and explicitly call `patch_telemetry`.
- Previously, streaming operations routed through non-HTTP CLI transports dropped their telemetry because `patch_telemetry` was only invoked inside `complete_stream_http`.
- This ensures `inference_telemetry` is populated correctly for all CLI completions, preventing `masc_after_turn_telemetry_missing_total` from falsely triggering in MASC.
- Bumped version to 0.170.1.