### PR TITLE
Fix: Implement graceful shutdown hooks for raw trace and lock-free test logger

### DIFF
--- a/lib/agent/agent_trace.ml
+++ b/lib/agent/agent_trace.ml
@@ -154,4 +154,11 @@ let with_raw_trace_run agent user_prompt f =
               ~last_error:(Error.to_string err) Failed;
             Error err
       in
-      finalize (f (Some active))
+      match f (Some active) with
+      | result -> finalize result
+      | exception exn ->
+          let error_msg = Printf.sprintf "Unhandled exception: %s" (Printexc.to_string exn) in
+          let _ = Raw_trace.finish_run active ~final_text:None ~stop_reason:None ~error:(Some error_msg) in
+          set_lifecycle agent ~finished_at:(Unix.gettimeofday ())
+            ~last_error:error_msg Failed;
+          raise exn

--- a/lib/log.ml
+++ b/lib/log.ml
@@ -197,7 +197,7 @@ let stderr_sink () : sink = fun record ->
 (* ── Collector sink (for testing) ─────────────────────────────── *)
 
 let collector_sink () : sink * (unit -> record list) =
-  let records = ref [] in
-  let sink record = records := record :: !records in
-  let get () = List.rev !records in
+  let records = Atomic.make [] in
+  let sink record = atomic_update records ~f:(fun rs -> record :: rs) in
+  let get () = List.rev (Atomic.get records) in
   (sink, get)


### PR DESCRIPTION
This PR completes the remaining items from #1137.

### Changes
- **`log.ml`**: Refactored `collector_sink` to use `Atomic.make` and `compare_and_set` logic instead of an unsafe mutable `ref`, ensuring true fiber-safety during test collections.
- **`agent_trace.ml`**: Modified `with_raw_trace_run` to catch unhandled exceptions (such as timeouts, cancellations, or crashes). It now correctly flushes a `Run_finished` event to the raw trace containing the error message, and safely updates the agent's lifecycle before re-raising the exception.

This fixes the scenario where `conformance.ml` reports a missing raw trace simply because an agent was unexpectedly terminated and the trace file was never closed properly.