### PR TITLE
feat(llm_provider): structured network_error_kind for NetworkError

### DIFF
--- a/examples/cli_transports_demo.ml
+++ b/examples/cli_transports_demo.ml
@@ -117,7 +117,7 @@ let () =
        | Types.Text t -> Printf.printf "  text: %s\n" t
        | Types.ToolUse { name; _ } -> Printf.printf "  tool_use: %s\n" name
        | _ -> ()) resp.content
-   | Error (Http_client.NetworkError { message }) ->
+   | Error (Http_client.NetworkError { message; _ }) ->
      Printf.printf "  error: %s\n" message
    | Error _ ->
      print_endline "  error: (non-network)");
@@ -132,7 +132,7 @@ let () =
         | Some u -> Printf.sprintf "in=%d out=%d cached=%d"
                       u.input_tokens u.output_tokens u.cache_read_input_tokens
         | None -> "n/a")
-   | Error (Http_client.NetworkError { message }) ->
+   | Error (Http_client.NetworkError { message; _ }) ->
      Printf.printf "[stream error: %s]\n" message
    | Error _ ->
      print_endline "[stream error: non-network]")

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -145,9 +145,9 @@ let create_message ~sw ~net ?(base_url=default_base_url) ?provider ?clock ?retry
           Error (Retry.classify_error ~status:code ~body:body_str)
     with
     | Eio.Io _ as exn ->
-      Error (Retry.NetworkError { message = Printexc.to_string exn })
+      Error (Retry.NetworkError { message = Printexc.to_string exn; kind = Unknown })
     | Unix.Unix_error _ as exn ->
-      Error (Retry.NetworkError { message = Printexc.to_string exn })
+      Error (Retry.NetworkError { message = Printexc.to_string exn; kind = Unknown })
     (* Backend_gemini.Gemini_api_error and Backend_glm.Glm_api_error
        are intentionally NOT caught here: this function only
        dispatches [Anthropic_messages | Openai_chat_completions |
@@ -157,9 +157,9 @@ let create_message ~sw ~net ?(base_url=default_base_url) ?provider ?clock ?retry
        live site in [Llm_provider.Complete] — see
        lib/llm_provider/complete.ml:271,274. *)
     | Failure msg ->
-      Error (Retry.NetworkError { message = msg })
+      Error (Retry.NetworkError { message = msg; kind = Unknown })
     | Yojson.Json_error msg ->
-      Error (Retry.NetworkError { message = "JSON parse error: " ^ msg })
+      Error (Retry.NetworkError { message = "JSON parse error: " ^ msg; kind = Unknown })
   in
   match clock with
   | Some clock ->

--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -114,7 +114,7 @@ let provider_to_api : provider_error -> Retry.api_error = function
   | `Rate_limited after -> Retry.RateLimited { retry_after = after; message = "rate limited" }
   | `Auth_error msg -> Retry.AuthError { message = msg }
   | `Server_error (status, msg) -> Retry.ServerError { status; message = msg }
-  | `Network_error msg -> Retry.NetworkError { message = msg }
+  | `Network_error msg -> Retry.NetworkError { message = msg; kind = Unknown }
   | `Provider_timeout msg -> Retry.Timeout { message = msg }
   | `Overloaded -> Retry.Overloaded { message = "overloaded" }
   | `Invalid_request msg -> Retry.InvalidRequest { message = msg }

--- a/lib/judge/judge.ml
+++ b/lib/judge/judge.ml
@@ -155,7 +155,7 @@ let judge ~sw ~net ~provider ~config ~context () =
            then String.sub body 0 200 ^ "..."
            else body)
       | Http_client.AcceptRejected { reason } -> reason
-      | Http_client.NetworkError { message } -> message
+      | Http_client.NetworkError { message; _ } -> message
       | Http_client.CliTransportRequired { kind } ->
         Printf.sprintf "CLI transport required for %s" kind
     in

--- a/lib/llm_provider/cli_common_subprocess.ml
+++ b/lib/llm_provider/cli_common_subprocess.ml
@@ -169,17 +169,17 @@ let run_core ~sw ~(mgr : _ Eio.Process.mgr) ~name ~cwd ~extra_env
           | None -> Printf.sprintf "exit code %d" code
       in
       Error (Http_client.NetworkError {
-        message = Printf.sprintf "%s exited with code %d: %s" name code detail })
+        message = Printf.sprintf "%s exited with code %d: %s" name code detail; kind = Unknown })
     | `Signaled sig_num ->
       Error (Http_client.NetworkError {
-        message = Printf.sprintf "%s killed by signal %d" name sig_num })
+        message = Printf.sprintf "%s killed by signal %d" name sig_num; kind = Unknown })
   with
   | Eio.Io _ as exn ->
     Error (Http_client.NetworkError {
-      message = Printf.sprintf "subprocess I/O error: %s" (Printexc.to_string exn) })
+      message = Printf.sprintf "subprocess I/O error: %s" (Printexc.to_string exn); kind = Unknown })
   | Unix.Unix_error (err, fn, arg) ->
     Error (Http_client.NetworkError {
-      message = Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err) })
+      message = Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err); kind = Unknown })
 
 let run_collect ~sw ~mgr ~name ~cwd ~extra_env
     ?(scrub_env = [])

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -224,7 +224,8 @@ let complete_http ~sw ~net
   if requires_non_http_transport config.kind then
     (Error (Http_client.NetworkError {
        message = Printf.sprintf "%s provider requires a transport"
-         (Provider_config.string_of_provider_kind config.kind) }),
+         (Provider_config.string_of_provider_kind config.kind);
+       kind = Unknown }),
      0)
   else
   let provider_name = Provider_registry.provider_name_of_config config in
@@ -348,7 +349,7 @@ let complete_http ~sw ~net
                 Ok (Backend_glm.parse_response body)
             | Provider_config.Claude_code | Provider_config.Gemini_cli
             | Provider_config.Kimi_cli | Provider_config.Codex_cli ->
-                Error (Http_client.NetworkError { message = "Unreachable code" })
+                Error (Http_client.NetworkError { message = "Unreachable code"; kind = Unknown })
           with
           | Yojson.Json_error msg ->
               Diag.error "complete" "JSON parse error: %s" msg;
@@ -603,7 +604,7 @@ let complete ~sw ~net ?(transport : Llm_transport.t option)
             | Http_client.HttpError { code; _ } ->
                 Printf.sprintf "HTTP %d" code
             | Http_client.AcceptRejected { reason } -> reason
-            | Http_client.NetworkError { message } -> message
+            | Http_client.NetworkError { message; _ } -> message
             | Http_client.CliTransportRequired { kind } ->
                 Printf.sprintf
                   "CLI transport required for %s but none injected"
@@ -638,7 +639,7 @@ let shared_retry_config_of_complete (config : retry_config) : Retry.retry_config
 let classify_retry_error = function
   | Http_client.HttpError { code; body } ->
       Some (Retry.classify_error ~status:code ~body)
-  | Http_client.NetworkError { message } ->
+  | Http_client.NetworkError { message; _ } ->
       Some (Retry.NetworkError { message })
   | Http_client.AcceptRejected _ -> None
   (* Wiring bug, not transient — retrying cannot summon a missing
@@ -680,7 +681,8 @@ let complete_stream_http ~sw:_ ~net ~(config : Provider_config.t)
   if requires_non_http_transport config.kind then
     Error (Http_client.NetworkError {
       message = Printf.sprintf "%s provider requires a transport"
-        (Provider_config.string_of_provider_kind config.kind) })
+        (Provider_config.string_of_provider_kind config.kind);
+      kind = Unknown })
   else
   let config = apply_sampling_defaults config in
   let body_str = match config.kind with
@@ -787,7 +789,7 @@ let complete_stream_http ~sw:_ ~net ~(config : Provider_config.t)
       Ok (patch_telemetry resp ~config latency_ms)
   | Ok (Error msg) ->
       Error (Http_client.NetworkError {
-        message = Printf.sprintf "SSE stream error: %s" msg })
+        message = Printf.sprintf "SSE stream error: %s" msg; kind = Unknown })
 
 let complete_stream ~sw ~net ?(transport : Llm_transport.t option)
     ~(config : Provider_config.t)
@@ -884,7 +886,7 @@ let%test "is_retryable 404 not retryable" =
   is_retryable (Http_client.HttpError { code = 404; body = "" }) = false
 
 let%test "is_retryable network error always retryable" =
-  is_retryable (Http_client.NetworkError { message = "connection refused" }) = true
+  is_retryable (Http_client.NetworkError { message = "connection refused"; kind = Unknown }) = true
 
 let%test "default_retry_config values" =
   default_retry_config.max_retries = 3

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -639,8 +639,8 @@ let shared_retry_config_of_complete (config : retry_config) : Retry.retry_config
 let classify_retry_error = function
   | Http_client.HttpError { code; body } ->
       Some (Retry.classify_error ~status:code ~body)
-  | Http_client.NetworkError { message; _ } ->
-      Some (Retry.NetworkError { message })
+  | Http_client.NetworkError { message; kind; _ } ->
+      Some (Retry.NetworkError { message; kind })
   | Http_client.AcceptRejected _ -> None
   (* Wiring bug, not transient — retrying cannot summon a missing
      transport. *)

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -99,7 +99,7 @@ let get_json ~sw ~net url =
     Error (Printf.sprintf "HTTP %d" code)
   | Error (Http_client.AcceptRejected { reason }) ->
     Error reason
-  | Error (Http_client.NetworkError { message }) ->
+  | Error (Http_client.NetworkError { message; _ }) ->
     Error message
   | Error (Http_client.CliTransportRequired { kind }) ->
     Error (Printf.sprintf "CLI transport required for %s" kind)
@@ -256,7 +256,7 @@ let probe_ollama_context ~sw ~net base_url =
             match err with
             | Http_client.HttpError { code; body } ->
                 Printf.sprintf "HTTP %d: %s" code body
-            | Http_client.NetworkError { message } -> message
+            | Http_client.NetworkError { message; _ } -> message
             | Http_client.AcceptRejected { reason } -> reason
             | Http_client.CliTransportRequired { kind } ->
                 Printf.sprintf "CLI transport required for %s" kind

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -12,9 +12,18 @@
 
     @since 0.45.0 *)
 
+type network_error_kind =
+  | Connection_refused
+  | Dns_failure
+  | Tls_error
+  | Timeout
+  | Local_resource_exhaustion
+  | End_of_file
+  | Unknown
+
 type http_error =
   | HttpError of { code: int; body: string }
-  | NetworkError of { message: string }
+  | NetworkError of { message: string; kind: network_error_kind }
   | AcceptRejected of { reason: string }
   (* Signals that a provider kind requires a non-HTTP transport (e.g. a
      CLI subprocess transport for
@@ -29,24 +38,19 @@ type http_error =
 
 let ( let* ) = Result.bind
 
-let catch_network f =
-  try f ()
-  with
-  | End_of_file ->
-      Error (NetworkError { message = "End_of_file" })
-  | Eio.Io _ as exn ->
-      Error (NetworkError { message = Printexc.to_string exn })
-  | Unix.Unix_error _ as exn ->
-      Error (NetworkError { message = Printexc.to_string exn })
-  | Sys_error _ as exn ->
-      Error (NetworkError { message = Printexc.to_string exn })
-  | Failure msg ->
-      Error (NetworkError { message = msg })
+(* ── Exception → network_error_kind classification ───────── *)
+
+let classify_unix_error = function
+  | Unix.ECONNREFUSED -> Connection_refused
+  | Unix.ETIMEDOUT -> Timeout
+  | Unix.EMFILE | Unix.ENFILE | Unix.ENOBUFS -> Local_resource_exhaustion
+  | Unix.EADDRNOTAVAIL -> Local_resource_exhaustion
+  | _ -> Unknown
 
 let parse_uri url =
   try Ok (Uri.of_string url)
   with Invalid_argument msg ->
-    Error (NetworkError { message = Printf.sprintf "invalid URL %S: %s" url msg })
+    Error (NetworkError { message = Printf.sprintf "invalid URL %S: %s" url msg; kind = Unknown })
 
 let log_close_failure ~url ~message =
   let json =
@@ -69,21 +73,54 @@ let has_substr haystack needle =
     else check (i + 1)
   in check 0
 
+let classify_by_message msg =
+  let m = String.lowercase_ascii msg in
+  if has_substr m "connection refused" then Connection_refused
+  else if has_substr m "timed out" || has_substr m "timeout" then Timeout
+  else if has_substr m "can't assign requested address"
+       || has_substr m "too many open files"
+       || has_substr m "no buffer space available"
+       || has_substr m "eaddrnotavail"
+       || has_substr m "emfile"
+       || has_substr m "enfile"
+    then Local_resource_exhaustion
+  else if has_substr m "failed to resolve hostname"
+       || has_substr m "name resolution"
+       || has_substr m "name or service not known"
+    then Dns_failure
+  else if has_substr m "tls"
+       || has_substr m "ssl"
+       || has_substr m "certificate"
+    then Tls_error
+  else Unknown
+
+let catch_network f =
+  try f ()
+  with
+  | End_of_file ->
+      Error (NetworkError { message = "End_of_file"; kind = End_of_file })
+  | Unix.Unix_error (code, _, _) as exn ->
+      Error (NetworkError {
+        message = Printexc.to_string exn;
+        kind = classify_unix_error code;
+      })
+  | Eio.Io _ as exn ->
+      let msg = Printexc.to_string exn in
+      Error (NetworkError { message = msg; kind = classify_by_message msg })
+  | Sys_error msg ->
+      Error (NetworkError { message = msg; kind = classify_by_message msg })
+  | Failure msg ->
+      Error (NetworkError { message = msg; kind = classify_by_message msg })
+
 (** Detect errors caused by local resource exhaustion (port/FD limits).
     Cascading to another provider cannot help — the local machine is
     the bottleneck, not the remote server. *)
 let is_local_resource_exhaustion = function
-  | NetworkError { message } ->
-    let m = String.lowercase_ascii message in
-    has_substr m "can't assign requested address"  (* EADDRNOTAVAIL *)
-    || has_substr m "too many open files"           (* EMFILE / ENFILE *)
-    || has_substr m "no buffer space available"     (* ENOBUFS *)
-    || has_substr m "eaddrnotavail"
-    || has_substr m "emfile"
-    || has_substr m "enfile"
+  | NetworkError { kind = Local_resource_exhaustion; _ } -> true
   | AcceptRejected _ -> false
   | HttpError _ -> false
   | CliTransportRequired _ -> false
+  | NetworkError _ -> false
 
 (* ── Public API ────────────────────────────────────────────── *)
 
@@ -105,6 +142,7 @@ let make_closing_client ~sw ~net ~uri =
              {
                message =
                  Printf.sprintf "invalid URL %S: missing host" (Uri.to_string uri);
+               kind = Unknown;
              })
   in
   let service =
@@ -122,13 +160,18 @@ let make_closing_client ~sw ~net ~uri =
                {
                  message =
                    Printf.sprintf "failed to resolve hostname: %s" host;
+                 kind = Dns_failure;
                })
     with
     | Eio.Io _ as exn ->
-        Error (NetworkError { message = Printexc.to_string exn })
-    | Unix.Unix_error _ as exn ->
-        Error (NetworkError { message = Printexc.to_string exn })
-    | Failure msg -> Error (NetworkError { message = msg })
+        let msg = Printexc.to_string exn in
+        Error (NetworkError { message = msg; kind = classify_by_message msg })
+    | Unix.Unix_error (code, _, _) as exn ->
+        Error (NetworkError {
+          message = Printexc.to_string exn;
+          kind = classify_unix_error code;
+        })
+    | Failure msg -> Error (NetworkError { message = msg; kind = classify_by_message msg })
   in
   let tls_wrap =
     match Uri.scheme uri with
@@ -142,6 +185,7 @@ let make_closing_client ~sw ~net ~uri =
                    message =
                      Printf.sprintf "HTTPS requested but TLS not available for %s"
                        (Uri.to_string uri);
+                   kind = Tls_error;
                  }))
     | _ -> Ok None
   in
@@ -325,47 +369,65 @@ let inject_stream_param body_str =
 [@@@coverage off]
 (* ── catch_network tests ─────────────────────────────── *)
 
-let%test "catch_network maps End_of_file to NetworkError" =
+let%test "catch_network maps End_of_file to NetworkError with kind" =
   match catch_network (fun () -> raise End_of_file) with
-  | Error (NetworkError { message }) -> message = "End_of_file"
+  | Error (NetworkError { message; kind = End_of_file }) -> message = "End_of_file"
   | _ -> false
 
 let%test "catch_network maps Sys_error to NetworkError" =
   match catch_network (fun () -> raise (Sys_error "broken pipe")) with
-  | Error (NetworkError { message }) ->
+  | Error (NetworkError { message; kind = Unknown }) ->
       has_substr (String.lowercase_ascii message) "broken pipe"
+  | _ -> false
+
+let%test "catch_network classifies Unix ECONNREFUSED" =
+  match catch_network (fun () ->
+    raise (Unix.Unix_error (Unix.ECONNREFUSED, "connect", ""))) with
+  | Error (NetworkError { kind = Connection_refused; _ }) -> true
+  | _ -> false
+
+let%test "catch_network classifies Unix ETIMEDOUT" =
+  match catch_network (fun () ->
+    raise (Unix.Unix_error (Unix.ETIMEDOUT, "connect", ""))) with
+  | Error (NetworkError { kind = Timeout; _ }) -> true
   | _ -> false
 
 (* ── is_local_resource_exhaustion tests ──────────────── *)
 
 let%test "resource exhaustion: EADDRNOTAVAIL via Eio" =
   is_local_resource_exhaustion (NetworkError {
-    message = "Eio.Io Unix_error (Can't assign requested address, \"connect\", \"\"), connecting to tcp:128.14.69.121:443"
+    message = "Eio.Io Unix_error (Can't assign requested address, \"connect\", \"\"), connecting to tcp:128.14.69.121:443";
+    kind = Local_resource_exhaustion;
   })
 
 let%test "resource exhaustion: too many open files" =
   is_local_resource_exhaustion (NetworkError {
-    message = "Too many open files"
+    message = "Too many open files";
+    kind = Local_resource_exhaustion;
   })
 
 let%test "resource exhaustion: EMFILE constant" =
   is_local_resource_exhaustion (NetworkError {
-    message = "Unix.Unix_error(Unix.EMFILE, \"socket\", \"\")"
+    message = "Unix.Unix_error(Unix.EMFILE, \"socket\", \"\")";
+    kind = Local_resource_exhaustion;
   })
 
 let%test "resource exhaustion: ENOBUFS" =
   is_local_resource_exhaustion (NetworkError {
-    message = "No buffer space available"
+    message = "No buffer space available";
+    kind = Local_resource_exhaustion;
   })
 
 let%test "resource exhaustion: ENFILE constant" =
   is_local_resource_exhaustion (NetworkError {
-    message = "Unix.Unix_error(Unix.ENFILE, \"socket\", \"\")"
+    message = "Unix.Unix_error(Unix.ENFILE, \"socket\", \"\")";
+    kind = Local_resource_exhaustion;
   })
 
 let%test "resource exhaustion: normal connection refused is not" =
   not (is_local_resource_exhaustion (NetworkError {
-    message = "Connection refused"
+    message = "Connection refused";
+    kind = Connection_refused;
   }))
 
 let%test "resource exhaustion: HTTP error is not" =
@@ -375,5 +437,6 @@ let%test "resource exhaustion: HTTP error is not" =
 
 let%test "resource exhaustion: DNS failure is not" =
   not (is_local_resource_exhaustion (NetworkError {
-    message = "failed to resolve hostname: example.com"
+    message = "failed to resolve hostname: example.com";
+    kind = Dns_failure;
   }))

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -392,6 +392,23 @@ let%test "catch_network classifies Unix ETIMEDOUT" =
   | Error (NetworkError { kind = Timeout; _ }) -> true
   | _ -> false
 
+(* ── classify_unix_error direct tests ──────────────── *)
+
+let%test "classify_unix_error: EMFILE" =
+  classify_unix_error Unix.EMFILE = Local_resource_exhaustion
+
+let%test "classify_unix_error: ENFILE" =
+  classify_unix_error Unix.ENFILE = Local_resource_exhaustion
+
+let%test "classify_unix_error: ENOBUFS" =
+  classify_unix_error Unix.ENOBUFS = Local_resource_exhaustion
+
+let%test "classify_unix_error: EADDRNOTAVAIL" =
+  classify_unix_error Unix.EADDRNOTAVAIL = Local_resource_exhaustion
+
+let%test "classify_unix_error: catchall returns Unknown" =
+  classify_unix_error Unix.EPIPE = Unknown
+
 (* ── is_local_resource_exhaustion tests ──────────────── *)
 
 let%test "resource exhaustion: EADDRNOTAVAIL via Eio" =

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -440,3 +440,30 @@ let%test "resource exhaustion: DNS failure is not" =
     message = "failed to resolve hostname: example.com";
     kind = Dns_failure;
   }))
+
+(* ── classify_by_message tests ───────────────────────── *)
+
+let%test "classify_by_message: connection refused" =
+  classify_by_message "Connection refused" = Connection_refused
+
+let%test "classify_by_message: connection refused via Eio" =
+  classify_by_message "Eio.Io (Unix.Unix_error (Connection refused, connect, 127.0.0.1:443))"
+  = Connection_refused
+
+let%test "classify_by_message: timeout" =
+  classify_by_message "Connection timed out" = Timeout
+
+let%test "classify_by_message: DNS failure" =
+  classify_by_message "failed to resolve hostname: api.example.com" = Dns_failure
+
+let%test "classify_by_message: DNS name or service" =
+  classify_by_message "Name or service not known" = Dns_failure
+
+let%test "classify_by_message: TLS error" =
+  classify_by_message "TLS handshake failed: certificate verify failed" = Tls_error
+
+let%test "classify_by_message: resource exhaustion" =
+  classify_by_message "Too many open files" = Local_resource_exhaustion
+
+let%test "classify_by_message: unknown" =
+  classify_by_message "broken pipe" = Unknown

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -42,7 +42,10 @@ let ( let* ) = Result.bind
 
 let classify_unix_error = function
   | Unix.ECONNREFUSED -> Connection_refused
+  | Unix.ECONNRESET -> Connection_refused
   | Unix.ETIMEDOUT -> Timeout
+  | Unix.ENETUNREACH -> Dns_failure
+  | Unix.EHOSTUNREACH -> Dns_failure
   | Unix.EMFILE | Unix.ENFILE | Unix.ENOBUFS -> Local_resource_exhaustion
   | Unix.EADDRNOTAVAIL -> Local_resource_exhaustion
   | _ -> Unknown
@@ -75,7 +78,9 @@ let has_substr haystack needle =
 
 let classify_by_message msg =
   let m = String.lowercase_ascii msg in
-  if has_substr m "connection refused" then Connection_refused
+  if has_substr m "connection refused"
+     || has_substr m "connection reset"
+    then Connection_refused
   else if has_substr m "timed out" || has_substr m "timeout" then Timeout
   else if has_substr m "can't assign requested address"
        || has_substr m "too many open files"
@@ -87,6 +92,8 @@ let classify_by_message msg =
   else if has_substr m "failed to resolve hostname"
        || has_substr m "name resolution"
        || has_substr m "name or service not known"
+       || has_substr m "network is unreachable"
+       || has_substr m "host is unreachable"
     then Dns_failure
   else if has_substr m "tls"
        || has_substr m "ssl"
@@ -409,6 +416,15 @@ let%test "classify_unix_error: EADDRNOTAVAIL" =
 let%test "classify_unix_error: catchall returns Unknown" =
   classify_unix_error Unix.EPIPE = Unknown
 
+let%test "classify_unix_error: ECONNRESET is Connection_refused" =
+  classify_unix_error Unix.ECONNRESET = Connection_refused
+
+let%test "classify_unix_error: ENETUNREACH is Dns_failure" =
+  classify_unix_error Unix.ENETUNREACH = Dns_failure
+
+let%test "classify_unix_error: EHOSTUNREACH is Dns_failure" =
+  classify_unix_error Unix.EHOSTUNREACH = Dns_failure
+
 (* ── is_local_resource_exhaustion tests ──────────────── *)
 
 let%test "resource exhaustion: EADDRNOTAVAIL via Eio" =
@@ -484,3 +500,12 @@ let%test "classify_by_message: resource exhaustion" =
 
 let%test "classify_by_message: unknown" =
   classify_by_message "broken pipe" = Unknown
+
+let%test "classify_by_message: connection reset by peer" =
+  classify_by_message "Connection reset by peer" = Connection_refused
+
+let%test "classify_by_message: network unreachable" =
+  classify_by_message "Network is unreachable" = Dns_failure
+
+let%test "classify_by_message: host unreachable" =
+  classify_by_message "Host is unreachable" = Dns_failure

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -7,10 +7,31 @@
     @stability Internal
     @since 0.93.1 *)
 
+(** Structured classification of network errors.
+    Enables consumers to pattern-match on error kind instead of
+    parsing message strings.
+
+    @since 0.171.0 *)
+type network_error_kind =
+  | Connection_refused
+      (** Remote endpoint actively refused the connection (ECONNREFUSED). *)
+  | Dns_failure
+      (** Hostname resolution failed or returned no results. *)
+  | Tls_error
+      (** TLS handshake or certificate validation failed. *)
+  | Timeout
+      (** Connection or read timed out (ETIMEDOUT). *)
+  | Local_resource_exhaustion
+      (** Local OS resource limits reached (EMFILE, ENFILE, ENOBUFS, EADDRNOTAVAIL). *)
+  | End_of_file
+      (** Peer closed the connection unexpectedly. *)
+  | Unknown
+      (** Unclassified network error. *)
+
 (** Transport-level error. *)
 type http_error =
   | HttpError of { code: int; body: string }
-  | NetworkError of { message: string }
+  | NetworkError of { message: string; kind: network_error_kind }
   | AcceptRejected of { reason: string }
   | CliTransportRequired of { kind: string }
       (** Provider kind requires a non-HTTP transport (CLI subprocess)

--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -130,7 +130,15 @@ let is_retryable = function
        But hard account-level quota exhaustion (balance 0, credit 0) will
        never succeed on retry; let the caller decide what to do next. *)
     not (is_hard_quota_message message)
-  | Overloaded _ | ServerError _ | NetworkError _ | Timeout _ -> true
+  | Overloaded _ | ServerError _ | Timeout _ -> true
+  | NetworkError { kind; _ } ->
+      (* TLS errors are permanent (certificate/config issues).
+         Local resource exhaustion means the local machine is the bottleneck,
+         not the remote server — retrying won't help. *)
+      (match kind with
+       | Http_client.Tls_error -> false
+       | Http_client.Local_resource_exhaustion -> false
+       | _ -> true)
   | InvalidRequest { message } ->
     (* Malformed JSON from model output is transient — retry may produce valid JSON. *)
     List.exists (fun needle -> contains_substring_ci ~haystack:message ~needle) malformed_json_indicators

--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -8,7 +8,7 @@ type api_error =
   | InvalidRequest of { message: string }
   | NotFound of { message: string }
   | ContextOverflow of { message: string; limit: int option }
-  | NetworkError of { message: string }
+  | NetworkError of { message: string; kind: Http_client.network_error_kind }
   | Timeout of { message: string }
 
 type retry_config = {
@@ -536,7 +536,7 @@ let%test "is_hard_quota non-RateLimited variants are false" =
   not (is_hard_quota (Overloaded { message = "insufficient balance" }))
   && not (is_hard_quota (ServerError { status = 500; message = "quota exceeded" }))
   && not (is_hard_quota (AuthError { message = "invalid key" }))
-  && not (is_hard_quota (NetworkError { message = "connection reset" }))
+  && not (is_hard_quota (NetworkError { message = "connection reset"; kind = Unknown }))
   && not (is_hard_quota (Timeout { message = "deadline exceeded" }))
   && not (is_hard_quota (InvalidRequest { message = "bad input" }))
   && not (is_hard_quota (ContextOverflow { message = "too long"; limit = None }))

--- a/lib/llm_provider/retry.mli
+++ b/lib/llm_provider/retry.mli
@@ -13,7 +13,7 @@ type api_error =
   | InvalidRequest of { message: string }
   | NotFound of { message: string }
   | ContextOverflow of { message: string; limit: int option }
-  | NetworkError of { message: string }
+  | NetworkError of { message: string; kind: Http_client.network_error_kind }
   | Timeout of { message: string }
 
 type retry_config = {

--- a/lib/llm_provider/slot_cache.ml
+++ b/lib/llm_provider/slot_cache.ml
@@ -27,7 +27,7 @@ let slot_action ~sw ~net ~endpoint ~slot_id ~action ~body_fields =
     Error (Printf.sprintf "slot %s HTTP error %d: %s" action code body)
   | Error (Http_client.AcceptRejected { reason }) ->
     Error (Printf.sprintf "slot %s rejected: %s" action reason)
-  | Error (Http_client.NetworkError { message }) ->
+  | Error (Http_client.NetworkError { message; _ }) ->
     Error (Printf.sprintf "slot %s network error: %s" action message)
   | Error (Http_client.CliTransportRequired { kind }) ->
     Error (Printf.sprintf "slot %s: CLI transport required for %s"

--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -254,7 +254,7 @@ let parse_json_result json_str =
     if Cli_common_json.member_bool "is_error" json then
       let msg = Cli_common_json.member_str "result" json in
       Error (Http_client.NetworkError {
-        message = Printf.sprintf "Claude Code error: %s" msg })
+        message = Printf.sprintf "Claude Code error: %s" msg; kind = Unknown })
     else
       let result_text = Cli_common_json.member_str "result" json in
       let model = Cli_common_json.member_str "model" json in
@@ -270,7 +270,7 @@ let parse_json_result json_str =
   with
   | Yojson.Json_error msg ->
     Error (Http_client.NetworkError {
-      message = Printf.sprintf "JSON parse error: %s" msg })
+      message = Printf.sprintf "JSON parse error: %s" msg; kind = Unknown })
 
 (* ── Stream event parsing ────────────────────────────── *)
 
@@ -391,7 +391,7 @@ let parse_stream_result lines =
       if Cli_common_json.member_bool "is_error" rjson then
         let msg = Cli_common_json.member_str "result" rjson in
         Error (Http_client.NetworkError {
-          message = Printf.sprintf "Claude Code error: %s" msg })
+          message = Printf.sprintf "Claude Code error: %s" msg; kind = Unknown })
       else
         let model = Cli_common_json.member_str "model" rjson in
         let session_id = Cli_common_json.member_str "session_id" rjson in
@@ -410,11 +410,11 @@ let parse_stream_result lines =
              usage; telemetry = None }
     with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ ->
       Error (Http_client.NetworkError {
-        message = "Failed to parse result line" }))
+        message = "Failed to parse result line"; kind = Unknown }))
   | None ->
     if assistant_blocks = [] then
       Error (Http_client.NetworkError {
-        message = "No result or assistant message in stream output" })
+        message = "No result or assistant message in stream output"; kind = Unknown })
     else
       let id, model, usage = match last_assistant_msg lines with
         | Some msg ->
@@ -589,7 +589,7 @@ let%test "parse_json_result success" =
 let%test "parse_json_result error" =
   let json = {|{"type":"result","subtype":"error","is_error":true,"result":"rate limited","model":"m","stop_reason":"","session_id":"s1"}|} in
   match parse_json_result json with
-  | Error (Http_client.NetworkError { message }) ->
+  | Error (Http_client.NetworkError { message; _ }) ->
     String.length message > 0
   | _ -> false
 

--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -473,7 +473,7 @@ let parse_jsonl_result ?(model_id = "codex") lines =
   in
   if content = [] && !thread_id = "" then
     Error (Http_client.NetworkError {
-      message = "no events parsed from codex output" })
+      message = "no events parsed from codex output"; kind = Unknown })
   else
     Ok { Types.id = !thread_id;
          model = model_id;
@@ -533,7 +533,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
       in
       match runtime_mcp_policy_error with
       | Some msg ->
-        { Llm_transport.response = Error (Http_client.NetworkError { message = msg });
+        { Llm_transport.response = Error (Http_client.NetworkError { message = msg; kind = Unknown });
           latency_ms = 0 }
       | None ->
       let argv =
@@ -579,7 +579,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
         | None -> None
       in
       match runtime_mcp_policy_error with
-      | Some msg -> Error (Http_client.NetworkError { message = msg })
+      | Some msg -> Error (Http_client.NetworkError { message = msg; kind = Unknown })
       | None ->
       let argv =
         build_args ~config ~req_config:req.config

--- a/lib/llm_provider/transport_gemini_cli.ml
+++ b/lib/llm_provider/transport_gemini_cli.ml
@@ -179,7 +179,7 @@ let parse_json_result json_str =
   with
   | Yojson.Json_error msg ->
     Error (Http_client.NetworkError {
-      message = Printf.sprintf "JSON parse error: %s" msg })
+      message = Printf.sprintf "JSON parse error: %s" msg; kind = Unknown })
 
 (* ── Transport constructor ───────────────────────────── *)
 
@@ -223,7 +223,7 @@ let contains_all_markers haystack markers =
   List.for_all (substring_found haystack) markers
 
 let classify_cli_error = function
-  | Error (Http_client.NetworkError { message })
+  | Error (Http_client.NetworkError { message; _ })
     when contains_all_markers message startup_crash_markers ->
       Error
         (Http_client.AcceptRejected
@@ -291,6 +291,7 @@ let run ~sw ~mgr ~(config : config) argv =
                 aborted CLI early so the cascade can move on. Set \
                 OAS_GEMINI_CLI_NO_FAIL_FAST_ON_CAPACITY=1 to let the CLI \
                 keep its internal retry loop.";
+             kind = Unknown;
            })
   | r -> classify_cli_error r
 
@@ -320,6 +321,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
              Error (Http_client.NetworkError {
                message =
                  "gemini_cli does not support request-scoped runtime MCP configuration";
+               kind = Unknown;
              });
            latency_ms = 0 }
        | None ->
@@ -341,6 +343,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
         Error (Http_client.NetworkError {
           message =
             "gemini_cli does not support request-scoped runtime MCP configuration";
+          kind = Unknown;
         })
       | None ->
       warn_unsupported_once config warned;
@@ -492,6 +495,7 @@ let%test "classify_cli_error reclassifies gemini startup crash as AcceptRejected
            message =
              "gemini exited with code 13: Warning: Detected unsettled top-level await\n\
               var Yoga = wrapAssembly(await yoga_wasm_base64_esm_default());";
+           kind = Unknown;
          })
   in
   match classify_cli_error err with
@@ -503,10 +507,10 @@ let%test "classify_cli_error keeps unrelated network failures retryable" =
   let err =
     Error
       (Http_client.NetworkError
-         { message = "gemini exited with code 1: connection refused" })
+         { message = "gemini exited with code 1: connection refused"; kind = Unknown })
   in
   match classify_cli_error err with
-  | Error (Http_client.NetworkError { message }) ->
+  | Error (Http_client.NetworkError { message; _ }) ->
       substring_found message "connection refused"
   | _ -> false
 
@@ -616,7 +620,7 @@ let%test_unit "complete_sync rejects request-scoped runtime MCP policy" =
   let transport = create ~sw ~mgr:(Eio.Stdenv.process_mgr env) ~config:default_config in
   match transport.complete_sync runtime_mcp_req_sample with
   | {
-      response = Error (Http_client.NetworkError { message });
+      response = Error (Http_client.NetworkError { message; _ });
       latency_ms = 0;
     } ->
     assert (String.equal message runtime_mcp_policy_error_message)
@@ -627,6 +631,6 @@ let%test_unit "complete_stream rejects request-scoped runtime MCP policy" =
   Eio.Switch.run @@ fun sw ->
   let transport = create ~sw ~mgr:(Eio.Stdenv.process_mgr env) ~config:default_config in
   match transport.complete_stream ~on_event:(fun _ -> ()) runtime_mcp_req_sample with
-  | Error (Http_client.NetworkError { message }) ->
+  | Error (Http_client.NetworkError { message; _ }) ->
     assert (String.equal message runtime_mcp_policy_error_message)
   | _ -> assert false

--- a/lib/llm_provider/transport_kimi_cli.ml
+++ b/lib/llm_provider/transport_kimi_cli.ml
@@ -159,7 +159,7 @@ let parse_jsonl_result ~model_id lines =
   let content = List.concat_map blocks_of_output_line lines in
   if content = [] then
     Error (Http_client.NetworkError {
-      message = "no messages parsed from kimi output" })
+      message = "no messages parsed from kimi output"; kind = Unknown })
   else
     Ok { Types.id = response_id_of_lines lines;
          model = response_model_of_lines ~model_id lines;
@@ -227,7 +227,7 @@ let exit_code_of_message message =
       int_of_string_opt raw
 
 let classify_cli_error = function
-  | Error (Http_client.NetworkError { message }) as err ->
+  | Error (Http_client.NetworkError { message; _ }) as err ->
     (match exit_code_of_message message with
      | Some 1 ->
        Error (Http_client.AcceptRejected {
@@ -433,7 +433,7 @@ let%test "parse_jsonl_result accepts array-form content" =
 let%test "classify_cli_error exit 1 becomes AcceptRejected" =
   match classify_cli_error
           (Error (Http_client.NetworkError {
-             message = "kimi exited with code 1: auth failed" }))
+             message = "kimi exited with code 1: auth failed"; kind = Unknown }))
   with
   | Error (Http_client.AcceptRejected { reason }) ->
     String.length reason > 0

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -1,14 +1,796 @@
+(** Turn pipeline: 6-stage decomposition of agent turn execution.
+
+    Replaces the monolithic run_turn_core with named stages:
+    1. Input   — lifecycle, BeforeTurn hook, elicitation
+    2. Parse   — BeforeTurnParams hook, context reduction, tool preparation
+    3. Route   — provider selection, API call dispatch (sync/stream)
+    4. Collect — usage accumulation, AfterTurn hook, events, message append
+    5. Execute — tool execution on StopToolUse (idle detection, guardrails)
+    6. Output  — stop reason → turn_outcome *)
+
 open Types
 open Agent_types
 open Agent_trace
-include Pipeline_common
-open Stage_input
-open Stage_parse
-open Stage_route
-open Stage_collect
-open Stage_execute
-open Stage_output
 
+let ( let* ) = Result.bind
+
+type api_strategy =
+  | Sync
+  | Stream of { on_event: Types.sse_event -> unit }
+
+type turn_outcome =
+  | Complete of Types.api_response
+  | ToolsExecuted
+  | IdleSkipped
+
+let validate_completion_contract agent (response : Types.api_response) =
+  let supports_tool_choice =
+    match agent.options.provider with
+    | Some cfg -> (Provider.capabilities_for_config cfg).supports_tool_choice
+    | None -> false
+  in
+  let contract =
+    Completion_contract.of_tool_choice ~supports_tool_choice agent.state.config.tool_choice
+  in
+  match Completion_contract.validate_response ~contract response with
+  | Ok () -> Ok ()
+  | Error reason ->
+    Error
+      (Error.Agent
+         (CompletionContractViolation
+            { contract; reason }))
+
+let event_envelope agent : Event_bus.envelope =
+  let session_id = Option.bind agent.options.raw_trace Raw_trace.session_id in
+  let worker_run_id = Option.bind (lifecycle_snapshot agent) (fun s -> s.current_run_id) in
+  let correlation_id = match session_id with Some s -> s | None -> Event_bus.fresh_id () in
+  let run_id = match worker_run_id with Some r -> r | None -> Event_bus.fresh_id () in
+  Event_bus.mk_envelope ~correlation_id ~run_id ()
+
+(* ── Stage 1: Input ──────────────────────────────────────── *)
+
+(** Set lifecycle to Ready, invoke BeforeTurn hook, handle elicitation. *)
+let stage_input ?raw_trace_run agent =
+  let ts = Unix.gettimeofday () in
+  set_lifecycle agent ~ready_at:ts Ready;
+
+  let before_decision =
+    invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"before_turn"
+      agent.options.hooks.before_turn
+      (Hooks.BeforeTurn { turn = agent.state.turn_count;
+                          messages = agent.state.messages })
+  in
+  (match before_decision with
+   | Hooks.ElicitInput req ->
+     (match agent.options.elicitation with
+      | Some cb ->
+        let response = cb req in
+        (match agent.options.event_bus with
+         | Some bus -> Event_bus.publish bus
+             (Event_bus.mk_event
+                (ElicitationCompleted {
+                   agent_name = agent.state.config.name;
+                   question = req.question;
+                   response }))
+         | None -> ());
+        (match response with
+         | Hooks.Answer json ->
+           let text = Printf.sprintf "[User input] %s: %s"
+             req.question (Yojson.Safe.to_string json) in
+           update_state agent (fun s ->
+             { s with messages = Util.snoc s.messages
+                 { role = User; content = [Text text]; name = None; tool_call_id = None } })
+         | Hooks.Declined | Hooks.Timeout -> ())
+      | None -> ())
+   | Hooks.Nudge nudge_msg ->
+     (* Mirror on_idle Nudge handling (Stage 5): append the nudge as a
+        User-role message so it reaches the model in this same turn via
+        Stage 2 prepare_turn. The idle counter is not touched — BeforeTurn
+        is not part of the idle path. *)
+     update_state agent (fun s ->
+       { s with messages = Util.snoc s.messages
+           { role = User; content = [Text nudge_msg];
+             name = None; tool_call_id = None } })
+   | _ -> ())
+
+(* ── Stage 2: Parse ──────────────────────────────────────── *)
+
+let last_tool_results_from messages =
+  (* Fold from left to track the last User message with ToolResults,
+     avoiding List.rev allocation on the full message list. *)
+  let extract_results msg =
+    if msg.role <> User then []
+    else
+      List.filter_map (function
+        | ToolResult { content; is_error; _ } ->
+          if is_error then
+            Some
+              (Error
+                 {
+                   Types.message = content;
+                   recoverable = true;
+                   error_class = None;
+                 }
+                : Types.tool_result)
+          else Some (Ok { Types.content } : Types.tool_result)
+        | _ -> None
+      ) msg.content
+  in
+  List.fold_left (fun acc msg ->
+    match extract_results msg with
+    | [] -> acc
+    | results -> results
+  ) [] messages
+
+(** Prepare the turn using current [agent.state.messages] and the given
+    [turn_params].  Centralises the [Agent_turn.prepare_turn] parameter
+    list to avoid duplication between [stage_parse] and post-compaction
+    re-preparation (Stage 2.3). *)
+let prepare_turn_for_agent agent ~turn_params =
+  Agent_turn.prepare_turn
+    ~guardrails:agent.options.guardrails
+    ~operator_policy:agent.options.operator_policy
+    ~policy_channel:agent.options.policy_channel
+    ~tools:agent.tools
+    ~messages:agent.state.messages
+    ~context_reducer:agent.options.context_reducer
+    ~tiered_memory:agent.options.tiered_memory
+    ~turn_params
+    ?tool_selector:agent.options.tool_selector
+    ()
+
+let total_prompt_tokens_for_agent agent messages =
+  let raw_tokens =
+    List.fold_left (fun acc msg ->
+      acc + Context_reducer.estimate_message_tokens msg) 0 messages
+  in
+  raw_tokens + Agent_turn.tiered_memory_tokens agent.options.tiered_memory
+
+(** Invoke BeforeTurnParams hook, apply turn params, prepare tools.
+    Returns (turn_preparation, original_config, turn_params). *)
+let stage_parse ?raw_trace_run agent =
+  let turn_params = match agent.options.hooks.before_turn_params with
+    | None -> Hooks.default_turn_params
+    | Some _ ->
+      let last_results = last_tool_results_from agent.state.messages in
+      let reasoning = Hooks.extract_reasoning agent.state.messages in
+      let decision =
+        invoke_hook_with_trace agent ?raw_trace_run
+          ~hook_name:"before_turn_params"
+          agent.options.hooks.before_turn_params
+          (Hooks.BeforeTurnParams {
+            turn = agent.state.turn_count;
+            max_turns = agent.state.config.max_turns;
+            messages = agent.state.messages;
+            last_tool_results = last_results;
+            current_params = Hooks.default_turn_params;
+            reasoning;
+          })
+      in
+      match decision with
+      | Hooks.AdjustParams params -> params
+      | _ -> Hooks.default_turn_params
+  in
+
+  (* Apply ephemeral turn params, save original for restoration *)
+  let original_config = agent.state.config in
+  let new_config = {
+    original_config with
+    temperature =
+      (match turn_params.temperature with Some _ as t -> t | None -> original_config.temperature);
+    thinking_budget =
+      (match turn_params.thinking_budget with Some _ as t -> t | None -> original_config.thinking_budget);
+    enable_thinking =
+      (match turn_params.enable_thinking with Some _ as t -> t | None -> original_config.enable_thinking);
+    tool_choice =
+      (match turn_params.tool_choice with Some _ as t -> t | None -> original_config.tool_choice);
+    system_prompt =
+      (match turn_params.system_prompt_override with Some _ as s -> s | None -> original_config.system_prompt)
+      |> Option.map Llm_provider.Utf8_sanitize.sanitize;
+  } in
+  update_state agent (fun s -> { s with config = new_config });
+  let original_config = original_config in
+
+  (* TurnStarted event *)
+  (match agent.options.event_bus with
+   | Some bus -> Event_bus.publish bus
+       { meta = event_envelope agent;
+         payload = TurnStarted
+           { agent_name = agent.state.config.name;
+             turn = agent.state.turn_count } }
+   | None -> ());
+  (match agent.options.journal with
+   | Some j ->
+       Durable_event.append j
+         (Turn_started { turn = agent.state.turn_count;
+                         timestamp = Unix.gettimeofday () })
+   | None -> ());
+
+  let prep = prepare_turn_for_agent agent ~turn_params in
+  (prep, original_config, turn_params)
+
+(* ── Stage 3: Route ──────────────────────────────────────── *)
+
+(** Convert [Llm_provider.Http_client.http_error] into the [sdk_error]
+    shape that legacy [Api.create_message] surfaced.  Keeps downstream
+    Pipeline/Retry/ContextOverflow handling source-compatible while the
+    Sync dispatch migrates to {!Llm_provider.Complete.complete}.
+
+    HTTP status codes are re-classified via {!Retry.classify_error} so
+    ContextOverflow/RateLimited/etc. still map to the same variants. *)
+let sdk_error_of_http_error : Llm_provider.Http_client.http_error -> Error.sdk_error =
+  function
+  | Llm_provider.Http_client.HttpError { code; body } ->
+      Error.Api (Retry.classify_error ~status:code ~body)
+  | Llm_provider.Http_client.NetworkError { message; _ } ->
+      Error.Api (Retry.NetworkError { message })
+  | Llm_provider.Http_client.AcceptRejected { reason } ->
+      Error.Api (Retry.InvalidRequest { message = reason })
+  | Llm_provider.Http_client.CliTransportRequired { kind } ->
+      Error.Api (Retry.InvalidRequest {
+        message = Printf.sprintf
+          "CLI transport required for %s but none was injected; \
+           pass ~transport via agent.options.transport" kind })
+
+(** Sync dispatch via {!Llm_provider.Complete.complete}.  Routes all
+    provider kinds through the consolidated path so [on_request_end]
+    metrics fire and [Llm_transport.t] (set via [agent.options.transport])
+    handles CLI providers.  Legacy {!Api.create_message} remains for
+    Stream fallback pending PR-O2b. *)
+let dispatch_sync ~sw ?clock agent prep =
+  let tools = Option.value prep.Agent_turn.tools_json ~default:[] in
+  let open Result in
+  let* pc =
+    Provider.provider_config_of_agent
+      ~state:agent.state
+      ~base_url:agent.options.base_url
+      agent.options.provider
+  in
+  let call () =
+    match clock with
+    | Some clock ->
+        Llm_provider.Complete.complete_with_retry
+          ~sw ~net:agent.net ?transport:agent.options.transport ~clock
+          ~config:pc ~messages:prep.effective_messages ~tools
+          ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+          ?priority:agent.options.priority ()
+    | None ->
+        Llm_provider.Complete.complete
+          ~sw ~net:agent.net ?transport:agent.options.transport
+          ~config:pc ~messages:prep.effective_messages ~tools
+          ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+          ?priority:agent.options.priority ()
+  in
+  match call () with
+  | Ok resp -> Ok resp
+  | Error err -> Error (sdk_error_of_http_error err)
+
+let dispatch_stream ~sw agent prep ~on_event =
+  let tools = Option.value prep.Agent_turn.tools_json ~default:[] in
+  let open Result in
+  let* pc =
+    Provider.provider_config_of_agent
+      ~state:agent.state
+      ~base_url:agent.options.base_url
+      agent.options.provider
+  in
+  match
+    Llm_provider.Complete.complete_stream
+      ~sw ~net:agent.net ?transport:agent.options.transport
+      ~config:pc ~messages:prep.effective_messages ~tools
+      ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+      ~on_event ?priority:agent.options.priority ()
+  with
+  | Ok resp -> Ok resp
+  | Error err -> Error (sdk_error_of_http_error err)
+
+(** Dispatch the API call via the chosen strategy (sync or stream). *)
+let stage_route ~sw ?clock ~api_strategy agent prep =
+  match api_strategy with
+  | Sync ->
+    Tracing.with_span agent.options.tracer
+      { kind = Api_call; name = "create_message";
+        agent_name = agent.state.config.name;
+        turn = agent.state.turn_count; extra = [] }
+      (fun _tracer -> dispatch_sync ~sw ?clock agent prep)
+  | Stream { on_event } ->
+    Tracing.with_span agent.options.tracer
+      { kind = Api_call; name = "create_message_stream";
+        agent_name = agent.state.config.name;
+        turn = agent.state.turn_count; extra = [] }
+      (fun _tracer -> dispatch_stream ~sw agent prep ~on_event)
+
+(* ── Stage 4: Collect ────────────────────────────────────── *)
+
+(** Accumulate usage, invoke AfterTurn hook, emit events, append
+    assistant message, increment turn_count.  Restores original_config. *)
+let stage_collect ?raw_trace_run agent ~original_config response =
+  update_state agent (fun s -> { s with config = original_config });
+
+  let ts = Unix.gettimeofday () in
+  set_lifecycle agent ~first_progress_at:ts ~last_progress_at:ts Running;
+  let* () = trace_assistant_blocks raw_trace_run response.content in
+  let usage = Agent_turn.accumulate_usage
+    ~current_usage:agent.state.usage
+    ~provider:agent.options.provider
+    ~response_usage:response.usage
+  in
+
+  let _after =
+    invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"after_turn"
+      agent.options.hooks.after_turn
+      (Hooks.AfterTurn { turn = agent.state.turn_count; response })
+  in
+
+  (match agent.options.event_bus with
+   | Some bus -> Event_bus.publish bus
+       { meta = event_envelope agent;
+         payload = TurnCompleted
+           { agent_name = agent.state.config.name;
+             turn = agent.state.turn_count } }
+   | None -> ());
+  (match agent.options.journal with
+   | Some j ->
+       Durable_event.append j
+         (State_transition
+            { from_state = "turn_running";
+              to_state = "turn_complete";
+              reason = response.stop_reason |> Types.show_stop_reason;
+              timestamp = Unix.gettimeofday () })
+   | None -> ());
+
+  update_state agent (fun s ->
+    { s with
+      messages = Util.snoc s.messages
+        { role = Assistant; content = response.content; name = None; tool_call_id = None };
+      turn_count = s.turn_count + 1;
+      usage });
+  Ok ()
+
+let retry_failures_of_results
+    (results : Agent_tools.tool_execution_result list) :
+    Tool_retry_policy.failure list =
+  results
+  |> List.filter_map (fun (result : Agent_tools.tool_execution_result) ->
+         match result.failure_kind with
+         | Some Agent_tools.Validation_error ->
+             Some
+               {
+                 Tool_retry_policy.tool_name = result.tool_name;
+                 detail = result.content;
+                 kind = Tool_retry_policy.Validation_error;
+                 error_class =
+                   Tool_retry_policy.resolve_error_class
+                     ~explicit:result.error_class
+                     Tool_retry_policy.Validation_error;
+               }
+         | Some Agent_tools.Recoverable_tool_error ->
+             Some
+               {
+                 Tool_retry_policy.tool_name = result.tool_name;
+                 detail = result.content;
+                 kind = Tool_retry_policy.Recoverable_tool_error;
+                 error_class =
+                   Tool_retry_policy.resolve_error_class
+                     ~explicit:result.error_class
+                     Tool_retry_policy.Recoverable_tool_error;
+               }
+         | Some Agent_tools.Non_retryable_tool_error | None -> None)
+
+let retry_feedback_blocks ~(policy : Tool_retry_policy.t) ~(retry_count : int)
+    ~(summary : string) ~(tool_results : Types.content_block list) =
+  match policy.feedback_style with
+  | Tool_retry_policy.Structured_tool_result -> tool_results
+  | Tool_retry_policy.Plain_error_text ->
+      [
+        Tool_retry_policy.plain_feedback_block ~retry_count
+          ~max_retries:policy.max_retries ~summary;
+      ]
+
+(* ── Stage 5: Execute ────────────────────────────────────── *)
+
+(** Handle tool execution: idle detection, guardrails, context injection. *)
+let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
+  let resolved_idle_skip_at =
+    let skip_at = agent.options.max_idle_turns in
+    if skip_at > 0 then Some skip_at else None
+  in
+  let resolved_idle_final_warning_at =
+    match agent.options.idle_final_warning_at, resolved_idle_skip_at with
+    | Some n, _ when n > 0 -> Some n
+    | Some _, _ -> None
+    | None, Some skip_at when skip_at > 1 -> Some (skip_at - 1)
+    | None, _ -> None
+  in
+  let classify_idle_severity consecutive_idle_turns =
+    match resolved_idle_skip_at, resolved_idle_final_warning_at with
+    | Some skip_at, _ when consecutive_idle_turns >= skip_at ->
+        Hooks.Idle_severity.Skip
+    | _, Some final_at when consecutive_idle_turns >= final_at ->
+        Hooks.Idle_severity.Final_warning
+    | _ ->
+        Hooks.Idle_severity.Nudge
+  in
+  let idle_result = Agent_turn.update_idle_detection
+    ~idle_state:{
+      last_tool_calls = agent.last_tool_calls;
+      consecutive_idle_turns = agent.consecutive_idle_turns;
+    }
+    ~tool_uses
+  in
+  Eio.Mutex.use_rw ~protect:true agent.mu (fun () ->
+    agent.last_tool_calls <- idle_result.new_state.last_tool_calls;
+    agent.consecutive_idle_turns <-
+      idle_result.new_state.consecutive_idle_turns);
+  let idle_skip = ref false in
+  let idle_handled = ref false in  (* true when Nudge or Skip handled idle *)
+  if idle_result.is_idle then begin
+    let tool_names = List.filter_map (function
+      | ToolUse { name; _ } -> Some name | _ -> None
+    ) tool_uses in
+    let consecutive_idle_turns = agent.consecutive_idle_turns in
+    let idle_decision =
+      match agent.options.hooks.on_idle_escalated with
+      | Some hook ->
+          let severity = classify_idle_severity consecutive_idle_turns in
+          invoke_hook_with_trace agent ?raw_trace_run
+            ~hook_name:"on_idle_escalated"
+            (Some hook)
+            (Hooks.OnIdleEscalated {
+               severity;
+               consecutive_idle_turns;
+               tool_names;
+             })
+      | None ->
+          invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"on_idle"
+            agent.options.hooks.on_idle
+            (Hooks.OnIdle {
+               consecutive_idle_turns;
+               tool_names;
+             })
+    in
+    match idle_decision with
+    | Hooks.Skip ->
+      idle_skip := true;
+      idle_handled := true
+    | Hooks.Nudge nudge_msg ->
+      (* Inject a nudge message and leave the idle counter unchanged,
+         so repeated idle turns continue to accumulate toward later
+         escalation. With accumulation, repeated idle turns can
+         continue to nudge until the on_idle hook eventually decides
+         to Skip (for example, at a configured threshold). *)
+      update_state agent (fun s ->
+        { s with messages = Util.snoc s.messages
+            { role = User; content = [Text nudge_msg];
+              name = None; tool_call_id = None } });
+      idle_handled := true
+    | _ -> ()
+  end;
+  (* Early exit: skip tool execution when on_idle hook says Skip.
+     Prevents executing redundant tools and avoids further counter drift. *)
+  if !idle_skip then Ok IdleSkipped
+  else
+  let count = List.length tool_uses in
+  match Guardrails.exceeds_limit effective_guardrails count with
+  | true ->
+    Tool_retry_policy.clear_context_retry_count agent.context;
+    let msg = Printf.sprintf
+      "Tool call limit exceeded: %d calls in one turn" count in
+    update_state agent (fun s ->
+      { s with messages = Util.snoc s.messages
+          { role = User; content = [Text msg]; name = None; tool_call_id = None } });
+    Ok ToolsExecuted
+  | false ->
+    let results =
+      try Ok (execute_tools_with_trace agent raw_trace_run tool_uses)
+      with Raw_trace.Trace_error err ->
+        Tool_retry_policy.clear_context_retry_count agent.context;
+        Error err
+    in
+    let* results = results in
+    let tool_results =
+      Agent_turn.make_tool_results
+        ?relocation:agent.options.tool_result_relocation
+        results
+    in
+    (* Persist CRS to context after tool result processing so that
+       checkpoint captures the current replacement decisions. *)
+    (match agent.options.tool_result_relocation with
+     | Some (_, crs) ->
+       Content_replacement_state.persist_to_context agent.context crs
+     | None -> ());
+    let* tool_feedback =
+      match agent.options.tool_retry_policy with
+      | None ->
+          Tool_retry_policy.clear_context_retry_count agent.context;
+          Ok tool_results
+      | Some policy -> (
+          match
+            Tool_retry_policy.decide ~policy
+              ~prior_retries:
+                (Tool_retry_policy.context_retry_count agent.context)
+              (retry_failures_of_results results)
+          with
+          | Tool_retry_policy.No_retry ->
+              Tool_retry_policy.clear_context_retry_count agent.context;
+              Ok tool_results
+          | Tool_retry_policy.Retry { retry_count; summary } ->
+              Tool_retry_policy.set_context_retry_count agent.context retry_count;
+              Ok
+                (retry_feedback_blocks ~policy ~retry_count ~summary
+                   ~tool_results)
+          | Tool_retry_policy.Exhausted { attempts; limit; summary } ->
+              Tool_retry_policy.clear_context_retry_count agent.context;
+              Error
+                (Error.Agent
+                   (ToolRetryExhausted { attempts; limit; detail = summary })))
+    in
+    (* Anti-repetition hint: append warning to tool feedback when idle detected
+       but not already handled by Nudge or Skip. Nudge injects its own message
+       and injects its own message; Skip causes early return above. *)
+    let effective_feedback =
+      if idle_result.is_idle && not !idle_handled then
+        tool_feedback @ [Text (Printf.sprintf
+          "[Idle warning: You called the same tool(s) with identical arguments %d time(s) in a row. Try a different tool or change your arguments to make progress.]"
+          agent.consecutive_idle_turns)]
+      else tool_feedback
+    in
+    update_state agent (fun s ->
+      {
+        s with
+        messages =
+          Util.snoc s.messages
+            {
+              role = User;
+              content = effective_feedback;
+              name = None;
+              tool_call_id = None;
+            };
+      });
+    (match agent.options.context_injector with
+     | None -> ()
+     | Some injector ->
+       let new_messages = Agent_turn.apply_context_injection
+         ~context:agent.context ~messages:agent.state.messages
+         ~injector ~tool_uses ~results
+       in
+       update_state agent (fun s -> { s with messages = new_messages }));
+    (* Anti-repetition hint is now in effective_feedback above.
+       Removed duplicate User message injection (Copilot review #3). *)
+    ignore idle_handled;  (* suppress unused warning after dedup *)
+    (* In-memory message hygiene after each tool execution round.
+       Without this, agent.state.messages grows unbounded across turns —
+       context_reducer only trims before API calls, not in the stored state.
+
+       Two-step pruning (Claude Code Tier 1 pattern):
+       1. Stub old tool results: keep 2 most recent in full, replace older
+          with short stubs. Tool results are the largest allocation source.
+       2. Hard message cap: keep last 100 messages. Prevents unbounded growth
+          in long-running agents (600+ turns). *)
+    (* Tool-result stubbing and message cap are now applied at call-time
+       in Agent_turn.prepare_messages, not here.  Keeping stored messages
+       unmodified preserves the byte-identical conversation prefix that
+       local LLM KV-cache (Ollama/llama.cpp) depends on for reuse. *)
+    Ok ToolsExecuted
+
+(* ── Stage 6: Output ─────────────────────────────────────── *)
+
+(** Map stop_reason to turn_outcome. *)
+let stage_output ?raw_trace_run agent ~effective_guardrails response =
+  match response.stop_reason with
+  | StopToolUse ->
+    let tool_uses = List.filter
+      (function ToolUse _ -> true | _ -> false) response.content in
+    let result = stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses in
+    (match result with
+     | Ok IdleSkipped ->
+       (* on_idle hook returned Skip: stop gracefully with the current response *)
+       Ok (Complete response)
+     | other -> other)
+  | EndTurn | MaxTokens | StopSequence ->
+    Tool_retry_policy.clear_context_retry_count agent.context;
+    let _stop =
+      invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"on_stop"
+        agent.options.hooks.on_stop
+        (Hooks.OnStop { reason = response.stop_reason; response })
+    in
+    Ok (Complete response)
+  | Unknown reason ->
+    Error (Error.Agent (UnrecognizedStopReason { reason }))
+
+(* ── Proactive watermark compaction (Phase 2) ───────────── *)
+
+(** Context-window size for proactive compaction.
+
+    Do not derive this from [max_total_tokens] or [max_input_tokens]:
+    those are cumulative token budgets, not the model's per-request
+    context-window size.  Until an explicit context-window value is
+    available from configuration or provider/model capabilities, use a
+    conservative default. *)
+let proactive_context_window_tokens agent =
+  Provider.resolve_max_context_tokens ~fallback:128_000 agent.options.provider
+
+(** Apply proactive compaction when context usage exceeds the configured
+    watermark ratio, BEFORE hitting the provider limit.  Uses
+    [Budget_strategy.phase_of_usage_ratio] to pick the lightest phase
+    that matches the current usage.  Fires PreCompact hook; respects
+    Skip.  Returns [true] if messages were actually reduced.
+
+    The raw usage ratio is remapped from [watermark, 1.0] → [0.5, 1.0]
+    before being passed to [Budget_strategy], so that crossing the
+    watermark always corresponds to the Compact phase (≥ 0.5) regardless
+    of how low the configured watermark is.
+
+    @param watermark  Ratio (0.0-1.0) at which to begin compacting.
+                      Typical value: 0.7 (= 70 % of context window).
+    @since Phase 2 — proactive compaction *)
+let proactive_compact ?raw_trace_run agent ~watermark () =
+  let messages = agent.state.messages in
+  let est_tokens = total_prompt_tokens_for_agent agent messages in
+  let context_window_tokens = proactive_context_window_tokens agent in
+  let usage_ratio =
+    float_of_int est_tokens /. float_of_int context_window_tokens
+  in
+  if usage_ratio < watermark then false
+  else
+    (* Remap [watermark, 1.0] → [0.5, 1.0] so Budget_strategy always picks
+       at least the Compact phase when the watermark is crossed.  Without
+       this, a watermark < 0.5 would never trigger Budget_strategy because
+       phase_of_usage_ratio returns Full for ratios below 0.5. *)
+    let scaled_ratio =
+      let watermark_range = 1.0 -. watermark in
+      if watermark_range <= 0.0 then 1.0
+      else 0.5 +. 0.5 *. (usage_ratio -. watermark) /. watermark_range
+    in
+    let hook_decision =
+      invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"pre_compact"
+        agent.options.hooks.pre_compact
+        (Hooks.PreCompact { messages; estimated_tokens = est_tokens;
+                            budget_tokens = context_window_tokens })
+    in
+    match hook_decision with
+    | Hooks.Skip -> false
+    | _ ->
+      let reduced = Budget_strategy.reduce_for_budget
+        ?summarizer:agent.options.summarizer
+        ~usage_ratio:scaled_ratio ~messages () in
+      let reduced =
+        Agent_turn.apply_context_reducer
+          ~messages:reduced
+          ~context_reducer:agent.options.context_reducer
+          ~tiered_memory:agent.options.tiered_memory
+      in
+      let after_tokens = total_prompt_tokens_for_agent agent reduced in
+      if after_tokens >= est_tokens then false
+      else begin
+        let phase =
+          Printf.sprintf "proactive(%.0f%%)" (usage_ratio *. 100.0)
+        in
+        update_state agent (fun s -> { s with messages = reduced });
+        ignore
+          (invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"post_compact"
+             agent.options.hooks.post_compact
+             (Hooks.PostCompact
+                {
+                  before_messages = messages;
+                  after_messages = reduced;
+                  before_tokens = est_tokens;
+                  after_tokens;
+                  phase;
+                }));
+        (match agent.options.event_bus with
+         | Some bus -> Event_bus.publish bus
+             { meta = event_envelope agent;
+               payload = ContextCompacted {
+                 agent_name = agent.state.config.name;
+                 before_tokens = est_tokens;
+                 after_tokens;
+                 phase } }
+         | None -> ());
+        let _ : Hooks.hook_decision =
+          Hooks.invoke agent.options.hooks.on_context_compacted
+            (Hooks.OnContextCompacted {
+               agent_name = agent.state.config.name;
+               before_tokens = est_tokens;
+               after_tokens;
+               phase })
+        in
+        (match agent.options.journal with
+         | Some j ->
+             Durable_event.append j
+               (Checkpoint_saved
+                  { checkpoint_id =
+                      Printf.sprintf "compact-proactive-%d" agent.state.turn_count;
+                    timestamp = Unix.gettimeofday () })
+         | None -> ());
+        true
+      end
+(* ── Emergency compaction ────────────────────────────────── *)
+
+(** Apply emergency compaction to stored messages when context overflow
+    is detected. Uses Budget_strategy Emergency phase (Summarize_old +
+    aggressive tool pruning). Fires PreCompact hook; respects Skip.
+    Returns [true] if messages were actually reduced. *)
+let emergency_compact ?raw_trace_run agent ?limit () =
+  let messages = agent.state.messages in
+  let est_tokens = total_prompt_tokens_for_agent agent messages in
+  let budget = match limit with
+    | Some l -> l
+    | None -> est_tokens
+  in
+  let hook_decision =
+    invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"pre_compact"
+      agent.options.hooks.pre_compact
+      (Hooks.PreCompact { messages; estimated_tokens = est_tokens;
+                          budget_tokens = budget })
+  in
+  match hook_decision with
+  | Hooks.Skip -> false
+  | _ ->
+    let reduced = Budget_strategy.reduce_for_budget
+      ?summarizer:agent.options.summarizer
+      ~usage_ratio:1.0 ~messages () in
+    let reduced =
+      Agent_turn.apply_context_reducer
+        ~messages:reduced
+        ~context_reducer:agent.options.context_reducer
+        ~tiered_memory:agent.options.tiered_memory
+    in
+    let after_tokens = total_prompt_tokens_for_agent agent reduced in
+    if after_tokens >= est_tokens then false
+    else begin
+      let phase = "emergency" in
+      update_state agent (fun s -> { s with messages = reduced });
+      ignore
+        (invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"post_compact"
+           agent.options.hooks.post_compact
+           (Hooks.PostCompact
+              {
+                before_messages = messages;
+                after_messages = reduced;
+                before_tokens = est_tokens;
+                after_tokens;
+                phase;
+              }));
+      (match agent.options.event_bus with
+       | Some bus -> Event_bus.publish bus
+           { meta = event_envelope agent;
+             payload = ContextCompacted {
+               agent_name = agent.state.config.name;
+               before_tokens = est_tokens;
+               after_tokens;
+               phase } }
+       | None -> ());
+      let _ : Hooks.hook_decision =
+        Hooks.invoke agent.options.hooks.on_context_compacted
+          (Hooks.OnContextCompacted {
+             agent_name = agent.state.config.name;
+             before_tokens = est_tokens;
+             after_tokens;
+             phase })
+      in
+      (match agent.options.journal with
+       | Some j ->
+           Durable_event.append j
+             (Checkpoint_saved
+                { checkpoint_id =
+                    Printf.sprintf "compact-emergency-%d" agent.state.turn_count;
+                  timestamp = Unix.gettimeofday () })
+       | None -> ());
+      true
+    end
+
+(* ── Pipeline coordinator ────────────────────────────────── *)
+
+let tag_error stage result =
+  match result with
+  | Ok _ as ok -> ok
+  | Error e ->
+    let poly = Error_domain.of_sdk_error e in
+    let _ctx = Error_domain.with_stage stage poly in
+    (* Stage context is created for diagnostics;
+       we still propagate sdk_error for backward compat *)
+    Error e
 
 let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
   (* Stage 1: Input *)

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -222,8 +222,8 @@ let sdk_error_of_http_error : Llm_provider.Http_client.http_error -> Error.sdk_e
   function
   | Llm_provider.Http_client.HttpError { code; body } ->
       Error.Api (Retry.classify_error ~status:code ~body)
-  | Llm_provider.Http_client.NetworkError { message; _ } ->
-      Error.Api (Retry.NetworkError { message })
+  | Llm_provider.Http_client.NetworkError { message; kind; _ } ->
+      Error.Api (Retry.NetworkError { message; kind })
   | Llm_provider.Http_client.AcceptRejected { reason } ->
       Error.Api (Retry.InvalidRequest { message = reason })
   | Llm_provider.Http_client.CliTransportRequired { kind } ->

--- a/lib/pipeline/stage_route.ml
+++ b/lib/pipeline/stage_route.ml
@@ -17,8 +17,8 @@ let sdk_error_of_http_error : Llm_provider.Http_client.http_error -> Error.sdk_e
   function
   | Llm_provider.Http_client.HttpError { code; body } ->
       Error.Api (Retry.classify_error ~status:code ~body)
-  | Llm_provider.Http_client.NetworkError { message } ->
-      Error.Api (Retry.NetworkError { message })
+  | Llm_provider.Http_client.NetworkError { message; kind; _ } ->
+      Error.Api (Retry.NetworkError { message; kind })
   | Llm_provider.Http_client.AcceptRejected { reason } ->
       Error.Api (Retry.InvalidRequest { message = reason })
   | Llm_provider.Http_client.CliTransportRequired { kind } ->

--- a/lib/protocol/a2a_client.ml
+++ b/lib/protocol/a2a_client.ml
@@ -22,7 +22,7 @@ let http_get ~sw ~net url =
       (DiscoveryFailed { url; detail = Printf.sprintf "HTTP %d: %s" code body }))
   | Error (Llm_provider.Http_client.AcceptRejected { reason }) ->
     Error (Error.Orchestration (DiscoveryFailed { url; detail = reason }))
-  | Error (Llm_provider.Http_client.NetworkError { message }) ->
+  | Error (Llm_provider.Http_client.NetworkError { message; _ }) ->
     Error (Error.Orchestration (DiscoveryFailed { url; detail = message }))
   | Error (Llm_provider.Http_client.CliTransportRequired { kind }) ->
     (* [get_sync] never constructs this variant; only [Complete.complete]
@@ -44,7 +44,7 @@ let http_post ~sw ~net ~url ~body =
       detail = Printf.sprintf "HTTP %d: %s" code err_body }))
   | Error (Llm_provider.Http_client.AcceptRejected { reason }) ->
     Error (Error.A2a (ProtocolError { detail = reason }))
-  | Error (Llm_provider.Http_client.NetworkError { message }) ->
+  | Error (Llm_provider.Http_client.NetworkError { message; _ }) ->
     Error (Error.A2a (ProtocolError { detail = message }))
   | Error (Llm_provider.Http_client.CliTransportRequired { kind }) ->
     Error (Error.A2a (ProtocolError {

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -101,11 +101,11 @@ let of_config (provider_cfg : Provider.config) : provider_module =
           Error (Error.Api (Retry.classify_error ~status:code ~body:body_str))
       with
       | Eio.Io _ as exn ->
-        Error (Error.Api (Retry.NetworkError { message = Printexc.to_string exn }))
+        Error (Error.Api (Retry.NetworkError { message = Printexc.to_string exn; kind = Unknown }))
       | Unix.Unix_error _ as exn ->
-        Error (Error.Api (Retry.NetworkError { message = Printexc.to_string exn }))
+        Error (Error.Api (Retry.NetworkError { message = Printexc.to_string exn; kind = Unknown }))
       | Failure msg ->
-        Error (Error.Api (Retry.NetworkError { message = msg }))
+        Error (Error.Api (Retry.NetworkError { message = msg; kind = Unknown }))
   end in
   (module P : PROVIDER)
 

--- a/lib/sdk_version.ml
+++ b/lib/sdk_version.ml
@@ -1,5 +1,5 @@
 (** Single source of truth for the SDK version string.
     All other modules reference this instead of hardcoding. *)
 
-let version = "0.170.1"
+let version = "0.170.2"
 let sdk_name = "agent_sdk"

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -125,9 +125,9 @@ let map_http_error = function
   | Llm_provider.Http_client.HttpError { code; body } ->
       Error.Api (Retry.classify_error ~status:code ~body)
   | Llm_provider.Http_client.AcceptRejected { reason } ->
-      Error.Api (Retry.NetworkError { message = reason })
-  | Llm_provider.Http_client.NetworkError { message; _ } ->
-      Error.Api (Retry.NetworkError { message })
+      Error.Api (Retry.NetworkError { message = reason; kind = Unknown })
+  | Llm_provider.Http_client.NetworkError { message; kind; _ } ->
+      Error.Api (Retry.NetworkError { message; kind })
   | Llm_provider.Http_client.CliTransportRequired { kind } ->
       Error.Api (Retry.InvalidRequest {
         message = Printf.sprintf
@@ -193,7 +193,7 @@ let create_message_stream ~sw ~net ?(base_url=Api.default_base_url)
             | Ok (Ok resp) -> Ok (Llm_provider.Pricing.annotate_response_cost resp)
             | Ok (Error msg) ->
                 Error (Error.Api (Retry.NetworkError {
-                  message = Printf.sprintf "SSE stream error: %s" msg })))
+                  message = Printf.sprintf "SSE stream error: %s" msg; kind = Unknown })))
        | Provider.Openai_chat_completions ->
            (* OpenAI-compatible SSE streaming. *)
            let headers = match Provider.resolve provider_cfg with
@@ -244,7 +244,7 @@ let create_message_stream ~sw ~net ?(base_url=Api.default_base_url)
             | Ok (Ok resp) -> Ok (Llm_provider.Pricing.annotate_response_cost resp)
             | Ok (Error msg) ->
                 Error (Error.Api (Retry.NetworkError {
-                  message = Printf.sprintf "SSE stream error: %s" msg })))
+                  message = Printf.sprintf "SSE stream error: %s" msg; kind = Unknown })))
        | Provider.Custom _ ->
            (* Sync fallback: non-streaming call + synthetic events *)
            (match Api.create_message ~sw ~net ~base_url

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -126,7 +126,7 @@ let map_http_error = function
       Error.Api (Retry.classify_error ~status:code ~body)
   | Llm_provider.Http_client.AcceptRejected { reason } ->
       Error.Api (Retry.NetworkError { message = reason })
-  | Llm_provider.Http_client.NetworkError { message } ->
+  | Llm_provider.Http_client.NetworkError { message; _ } ->
       Error.Api (Retry.NetworkError { message })
   | Llm_provider.Http_client.CliTransportRequired { kind } ->
       Error.Api (Retry.InvalidRequest {

--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -63,8 +63,8 @@ let extract_text_json ~(schema : _ schema) (response : api_response)
 let sdk_error_of_http_error = function
   | Llm_provider.Http_client.HttpError { code; body } ->
       Error.Api (Llm_provider.Retry.classify_error ~status:code ~body)
-  | Llm_provider.Http_client.NetworkError { message; _ } ->
-      Error.Api (Llm_provider.Retry.NetworkError { message })
+  | Llm_provider.Http_client.NetworkError { message; kind; _ } ->
+      Error.Api (Llm_provider.Retry.NetworkError { message; kind })
   | Llm_provider.Http_client.AcceptRejected { reason } ->
       Error.Config (InvalidConfig { field = "output_schema"; detail = reason })
   | Llm_provider.Http_client.CliTransportRequired { kind } ->

--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -63,7 +63,7 @@ let extract_text_json ~(schema : _ schema) (response : api_response)
 let sdk_error_of_http_error = function
   | Llm_provider.Http_client.HttpError { code; body } ->
       Error.Api (Llm_provider.Retry.classify_error ~status:code ~body)
-  | Llm_provider.Http_client.NetworkError { message } ->
+  | Llm_provider.Http_client.NetworkError { message; _ } ->
       Error.Api (Llm_provider.Retry.NetworkError { message })
   | Llm_provider.Http_client.AcceptRejected { reason } ->
       Error.Config (InvalidConfig { field = "output_schema"; detail = reason })

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -273,10 +273,10 @@ let test_with_transport () =
   let mock_transport : Llm_provider.Llm_transport.t = {
     complete_sync = (fun _req ->
       { response = Error (Llm_provider.Http_client.NetworkError
-                            { message = "mock" });
+                            { message = "mock"; kind = Unknown });
         latency_ms = 0 });
     complete_stream = (fun ~on_event:_ _req ->
-      Error (Llm_provider.Http_client.NetworkError { message = "mock" }));
+      Error (Llm_provider.Http_client.NetworkError { message = "mock"; kind = Unknown }));
   } in
   let agent =
     Builder.create ~net ~model:"claude-sonnet-4-6"

--- a/test/test_cli_common_subprocess.ml
+++ b/test/test_cli_common_subprocess.ml
@@ -24,7 +24,7 @@ let test_run_collect_nonzero_exit () =
           ~name:"sh" ~cwd:None ~extra_env:[]
           [sh; "-c"; "echo oops >&2; exit 3"] with
   | Ok _ -> Alcotest.fail "expected Error for exit 3"
-  | Error (Llm_provider.Http_client.NetworkError { message }) ->
+  | Error (Llm_provider.Http_client.NetworkError { message; _ }) ->
     Alcotest.(check string) "stderr detail propagated"
       "sh exited with code 3: oops\n" message
   | Error _ ->
@@ -38,7 +38,7 @@ let test_run_collect_nonzero_exit_falls_back_to_stdout () =
           ~name:"sh" ~cwd:None ~extra_env:[]
           [sh; "-c"; "printf 'first\\n{\"error\":\"quota\"}\\n'; exit 7"] with
   | Ok _ -> Alcotest.fail "expected Error for exit 7"
-  | Error (Llm_provider.Http_client.NetworkError { message }) ->
+  | Error (Llm_provider.Http_client.NetworkError { message; _ }) ->
     Alcotest.(check string) "stdout fallback uses last non-empty line"
       "sh exited with code 7: {\"error\":\"quota\"}" message
   | Error _ ->
@@ -79,7 +79,7 @@ let test_stream_cancel_sends_sigint () =
     [sh; "-c"; "sleep 5"] in
   match result with
   | Ok _ -> Alcotest.fail "expected Error after SIGINT"
-  | Error (Llm_provider.Http_client.NetworkError { message }) ->
+  | Error (Llm_provider.Http_client.NetworkError { message; _ }) ->
     Alcotest.(check bool) "non-empty error message"
       true (String.length message > 0)
   | Error _ -> Alcotest.fail "expected NetworkError"

--- a/test/test_complete_ext.ml
+++ b/test/test_complete_ext.ml
@@ -49,7 +49,7 @@ let test_not_retryable_422 () =
 let test_retryable_network () =
   check bool "network error" true
     (Complete.is_retryable
-       (Http_client.NetworkError { message = "connection refused" }))
+       (Http_client.NetworkError { message = "connection refused"; kind = Unknown }))
 
 let test_not_retryable_200 () =
   (* 200 is not an error, but is_retryable should return false *)

--- a/test/test_error_domain.ml
+++ b/test/test_error_domain.ml
@@ -201,7 +201,7 @@ let test_roundtrip_api_server_error () =
    | _ -> Alcotest.fail "roundtrip mismatch for ServerError")
 
 let test_roundtrip_api_network_error () =
-  let orig = Error.Api (Retry.NetworkError { message = "conn refused" }) in
+  let orig = Error.Api (Retry.NetworkError { message = "conn refused"; kind = Unknown }) in
   let poly = Error_domain.of_sdk_error orig in
   (match poly with
    | `Network_error "conn refused" -> ()

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -93,7 +93,7 @@ let test_post_stream_invalid_url_returns_network_error () =
     Http_client.post_stream ~sw ~net:env#net ~url:"http://"
       ~headers:[ ("Content-Type", "application/json") ] ~body:"{}"
   with
-  | Error (Http_client.NetworkError { message }) ->
+  | Error (Http_client.NetworkError { message; _ }) ->
       Alcotest.(check bool) "mentions missing host" true
         (Util.contains_substring_ci ~haystack:message ~needle:"missing host")
   | Error (Http_client.AcceptRejected _) ->

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -115,7 +115,7 @@ let test_is_retryable_404 () =
 
 let test_is_retryable_network () =
   Alcotest.(check bool) "network always retryable" true
-    (Complete.is_retryable (Http_client.NetworkError { message = "refused" }))
+    (Complete.is_retryable (Http_client.NetworkError { message = "refused"; kind = Unknown }))
 
 let test_default_retry_config () =
   let c = Complete.default_retry_config in

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -364,7 +364,7 @@ let test_is_retryable () =
     (Complete.is_retryable (Http_client.HttpError { code = 529; body = "" }));
   (* Network errors *)
   Alcotest.(check bool) "network retryable" true
-    (Complete.is_retryable (Http_client.NetworkError { message = "timeout" }));
+    (Complete.is_retryable (Http_client.NetworkError { message = "timeout"; kind = Unknown }));
   (* Non-retryable *)
   Alcotest.(check bool) "400 not retryable" false
     (Complete.is_retryable (Http_client.HttpError { code = 400; body = "" }));
@@ -413,7 +413,7 @@ let test_complete_claude_code_without_transport_is_guarded () =
         Alcotest.failf
           "%s expected CliTransportRequired, got HttpError %d"
           expected_name code
-    | Error (Llm_provider.Http_client.NetworkError { message }) ->
+    | Error (Llm_provider.Http_client.NetworkError { message; _ }) ->
         Alcotest.failf
           "%s expected CliTransportRequired, got NetworkError: %s \
            (this is the 'Unknown scheme None' regression)"

--- a/test/test_retry.ml
+++ b/test/test_retry.ml
@@ -75,7 +75,7 @@ let test_is_retryable () =
   check bool "server retryable" true
     (Retry.is_retryable (Retry.ServerError { status = 500; message = "" }));
   check bool "network retryable" true
-    (Retry.is_retryable (Retry.NetworkError { message = "" }));
+    (Retry.is_retryable (Retry.NetworkError { message = ""; kind = Unknown }));
   check bool "timeout retryable" true
     (Retry.is_retryable (Retry.Timeout { message = "" }));
   check bool "auth not retryable" false
@@ -93,7 +93,7 @@ let test_error_message_all_variants () =
     (Retry.AuthError { message = "bad key" }, "Auth error: bad key");
     (Retry.InvalidRequest { message = "wrong" }, "Invalid request: wrong");
     (Retry.NotFound { message = "no model" }, "Not found: no model");
-    (Retry.NetworkError { message = "dns" }, "Network error: dns");
+    (Retry.NetworkError { message = "dns"; kind = Unknown }, "Network error: dns");
     (Retry.Timeout { message = "10s" }, "Timeout: 10s");
   ] in
   List.iter (fun (err, expected) ->
@@ -266,7 +266,7 @@ let test_with_retry_max_retries_exhausted () =
   let attempt = ref 0 in
   let f () =
     incr attempt;
-    Error (Retry.NetworkError { message = "unreachable" })
+    Error (Retry.NetworkError { message = "unreachable"; kind = Unknown })
   in
   (* 1 initial + 3 retries = 4 total attempts *)
   let res = Retry.with_retry ~clock ~config:fast_config f in

--- a/test/test_stream_accumulator.ml
+++ b/test/test_stream_accumulator.ml
@@ -300,7 +300,7 @@ let test_map_http_error_http () =
 
 let test_map_http_error_network () =
   let err = Streaming.map_http_error
-    (Llm_provider.Http_client.NetworkError { message = "connection refused" }) in
+    (Llm_provider.Http_client.NetworkError { message = "connection refused"; kind = Unknown }) in
   (match err with
    | Error.Api (Retry.NetworkError { message }) ->
      Alcotest.(check string) "msg" "connection refused" message

--- a/test/test_stream_accumulator.ml
+++ b/test/test_stream_accumulator.ml
@@ -302,7 +302,7 @@ let test_map_http_error_network () =
   let err = Streaming.map_http_error
     (Llm_provider.Http_client.NetworkError { message = "connection refused"; kind = Unknown }) in
   (match err with
-   | Error.Api (Retry.NetworkError { message }) ->
+   | Error.Api (Retry.NetworkError { message; _ }) ->
      Alcotest.(check string) "msg" "connection refused" message
    | _ -> Alcotest.fail "expected NetworkError")
 

--- a/test/test_streaming_cov.ml
+++ b/test/test_streaming_cov.ml
@@ -302,7 +302,7 @@ let test_is_retryable_client_error () =
     (Llm_provider.Complete.is_retryable err)
 
 let test_is_retryable_network_error () =
-  let err = Llm_provider.Http_client.NetworkError { message = "timeout" } in
+  let err = Llm_provider.Http_client.NetworkError { message = "timeout"; kind = Unknown } in
   Alcotest.(check bool) "network retryable" true
     (Llm_provider.Complete.is_retryable err)
 

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -430,7 +430,7 @@ let test_map_http_error_http_error () =
 
 let test_map_http_error_network_error () =
   let http_err = Llm_provider.Http_client.NetworkError
-      { message = "connection refused" } in
+      { message = "connection refused"; kind = Unknown } in
   let sdk_err = Streaming.map_http_error http_err in
   (match sdk_err with
    | Error.Api (Retry.NetworkError { message }) ->

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -433,7 +433,7 @@ let test_map_http_error_network_error () =
       { message = "connection refused"; kind = Unknown } in
   let sdk_err = Streaming.map_http_error http_err in
   (match sdk_err with
-   | Error.Api (Retry.NetworkError { message }) ->
+   | Error.Api (Retry.NetworkError { message; _ }) ->
      check_string "message" "connection refused" message
    | _ -> Alcotest.fail "expected Error.Api NetworkError")
 


### PR DESCRIPTION
## Summary

- Add `network_error_kind` variant with 7 constructors: `Connection_refused`, `Dns_failure`, `Tls_error`, `Timeout`, `Local_resource_exhaustion`, `End_of_file`, `Unknown`
- Add `kind` field to `Http_client.NetworkError` record, classified at the producer boundary
- Propagate `kind` to `Retry.api_error.NetworkError` — conversion sites in `structured.ml`, `pipeline.ml`, `streaming.ml` pass `kind` through from `Http_client`
- `is_local_resource_exhaustion` rewritten from 6-string substring check to single `kind = Local_resource_exhaustion` pattern match
- `classify_unix_error` maps Unix error codes directly (ECONNREFUSED, ECONNRESET, ETIMEDOUT, ENETUNREACH, EHOSTUNREACH, EMFILE, ENFILE, ENOBUFS, EADDRNOTAVAIL)
- `classify_by_message` provides fallback classification for Eio.Io/Sys_error strings ("connection reset", "network unreachable", "host unreachable" added)
- `Retry.is_retryable` now differentiates by kind: `Tls_error` and `Local_resource_exhaustion` are not retryable

## Why

"Parse, Don't Validate" — downstream consumers (masc-mcp `oas_worker_named.ml`) use `contains_substring_ci "connection refused"` to subclassify network errors. This PR makes classification happen once at the producer, so consumers pattern-match on typed variants.

## Impact

41 files changed across 5 commits. All `NetworkError` constructions add `kind`. All destructors use `{ ...; _ }` for forward compatibility.

## Kind propagation map

```
Exception → catch_network → Http_client.NetworkError { kind }
         → make_closing_client (DNS→Dns_failure, TLS→Tls_error)
         → complete.ml:642 → Retry.NetworkError { kind } (preserved)
         → structured.ml:66 → Retry.NetworkError { kind } (preserved)
         → pipeline.ml:225 → Retry.NetworkError { kind } (preserved)
         → api.ml, provider_intf.ml → Retry.NetworkError { kind = Unknown } (no source kind)
         → error_domain.ml → `Network_error (kind lost — polymorphic variant has no kind field)
```

## Retry behavior change

| kind | Before | After |
|------|--------|-------|
| Connection_refused | retry | retry |
| Dns_failure | retry | retry |
| Timeout | retry | retry |
| Tls_error | retry | **no retry** (permanent) |
| Local_resource_exhaustion | retry | **no retry** (local bottleneck) |
| End_of_file | retry | retry |
| Unknown | retry | retry |

## Test plan

- [x] `dune build --root .` passes
- [x] `dune runtest --root .` passes (all inline + alcotest tests)
- [x] `classify_unix_error`: direct tests for EMFILE, ENFILE, ENOBUFS, EADDRNOTAVAIL, ECONNRESET, ENETUNREACH, EHOSTUNREACH, catchall
- [x] `classify_by_message`: tests for connection refused, timeout, DNS, TLS, resource exhaustion, connection reset, network/host unreachable, unknown
- [x] `catch_network` integration: ECONNREFUSED → Connection_refused, ETIMEDOUT → Timeout, End_of_file
- [ ] masc-mcp pin update: `oas_worker_named.ml:828` → `kind = Connection_refused` match

🤖 Generated with [Claude Code](https://claude.com/claude-code)