### PR TITLE
feat(agent): native timeout handling for Agent.run (#1006)

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -180,17 +180,27 @@ let start_periodic_callbacks ~sw ?clock (cbs : periodic_callback list) =
     ) cbs in
     fun () -> List.iter (fun stop -> stop ()) stops
 
+let with_optional_timeout ?clock agent f =
+  match agent.options.max_execution_time_s, clock with
+  | Some timeout_s, Some clock ->
+    (try Eio.Time.with_timeout_exn clock timeout_s f
+     with Eio.Time.Timeout ->
+       Error (Error.Api (Llm_provider.Retry.Timeout { message = Printf.sprintf "Agent execution exceeded max_execution_time_s (%f)" timeout_s })))
+  | _ -> f ()
+
 let run ~sw ?clock ?on_yield ?on_resume agent user_prompt =
   let stop = start_periodic_callbacks ~sw ?clock agent.options.periodic_callbacks in
-  Fun.protect
-    ~finally:stop
-    (fun () -> run_loop ~sw ?clock ~api_strategy:Sync ?on_yield ?on_resume agent user_prompt)
+  with_optional_timeout ?clock agent (fun () ->
+    Fun.protect
+      ~finally:stop
+      (fun () -> run_loop ~sw ?clock ~api_strategy:Sync ?on_yield ?on_resume agent user_prompt))
 
 let run_stream ~sw ?clock ~on_event ?on_yield ?on_resume agent user_prompt =
   let stop = start_periodic_callbacks ~sw ?clock agent.options.periodic_callbacks in
-  Fun.protect
-    ~finally:stop
-    (fun () -> run_loop ~sw ?clock ~api_strategy:(Stream { on_event }) ?on_yield ?on_resume agent user_prompt)
+  with_optional_timeout ?clock agent (fun () ->
+    Fun.protect
+      ~finally:stop
+      (fun () -> run_loop ~sw ?clock ~api_strategy:(Stream { on_event }) ?on_yield ?on_resume agent user_prompt))
 
 (* ── Handoff support ─────────────────────────────────────────── *)
 
@@ -318,7 +328,8 @@ let checkpoint ?(session_id="") ?working_context agent =
     ~mcp_clients:agent.options.mcp_clients ()
 
 let run_turn_stream ~sw ?clock ~on_event agent =
-  run_turn_core ~sw ?clock ~api_strategy:(Stream { on_event }) agent
+  with_optional_timeout ?clock agent (fun () ->
+    run_turn_core ~sw ?clock ~api_strategy:(Stream { on_event }) agent)
 
 let save_journal agent path =
   match agent.options.journal with

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -23,6 +23,7 @@ type tiered_memory = Types.tiered_memory = {
 type options = Agent_types.options = {
   base_url: string;
   provider: Provider.config option;
+  max_execution_time_s: float option;
   max_idle_turns: int;
   idle_final_warning_at: int option;
   hooks: Hooks.hooks;

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -14,6 +14,7 @@ type tiered_memory = Types.tiered_memory = {
 type options = {
   base_url: string;
   provider: Provider.config option;
+  max_execution_time_s: float option;
   max_idle_turns: int;
   idle_final_warning_at: int option;
   hooks: Hooks.hooks;
@@ -117,6 +118,7 @@ type lifecycle_snapshot = Agent_lifecycle.lifecycle_snapshot = {
 let default_options = {
   base_url = Api.default_base_url;
   provider = None;
+  max_execution_time_s = None;
   max_idle_turns = 3;
   idle_final_warning_at = None;
   hooks = Hooks.empty;

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -23,6 +23,9 @@ type tiered_memory = Types.tiered_memory = {
 type options = {
   base_url: string;
   provider: Provider.config option;
+  max_execution_time_s: float option;
+    (** Maximum allowed execution time for the entire agent run (including all turns and tool calls).
+        If exceeded, the run terminates safely and returns a Timeout error. *)
   max_idle_turns: int;
   idle_final_warning_at: int option;
     (** Threshold for [Hooks.on_idle_escalated] to emit

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -29,6 +29,7 @@ type t = {
   context: Context.t option;
   base_url: string;
   provider: Provider.config option;
+  max_execution_time_s: float option;
   max_idle_turns: int;
   idle_final_warning_at: int option;
   hooks: Hooks.hooks;
@@ -97,6 +98,7 @@ let create ~net ~model =
     context = None;
     base_url = Api.default_base_url;
     provider = None;
+    max_execution_time_s = None;
     max_idle_turns = 3;
     idle_final_warning_at = None;
     hooks = Hooks.empty;
@@ -251,6 +253,7 @@ let with_cache_extended_ttl v b = { b with cache_extended_ttl = v }
 let with_yield_on_tool v b = { b with yield_on_tool = v }
 let with_exit_condition pred b = { b with exit_condition = Some pred }
 let with_event_bus bus b = { b with event_bus = Some bus }
+let with_max_execution_time s b = { b with max_execution_time_s = Some s }
 let with_max_idle_turns n b = { b with max_idle_turns = n }
 let with_idle_final_warning_at n b = { b with idle_final_warning_at = Some n }
 let with_context_injector injector b = { b with context_injector = Some injector }
@@ -306,6 +309,7 @@ let build b =
   let options = {
     Agent_types.base_url = b.base_url;
     provider = b.provider;
+    max_execution_time_s = b.max_execution_time_s;
     max_idle_turns = b.max_idle_turns;
     idle_final_warning_at = b.idle_final_warning_at;
     hooks = (match b.progressive_tools with

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -112,6 +112,7 @@ val with_context_thresholds :
 val with_context : Context.t -> t -> t
 val with_context_injector : Hooks.context_injector -> t -> t
 val with_event_bus : Event_bus.t -> t -> t
+val with_max_execution_time : float -> t -> t
 val with_max_idle_turns : int -> t -> t
 val with_idle_final_warning_at : int -> t -> t
 val with_elicitation : Hooks.elicitation_callback -> t -> t


### PR DESCRIPTION
Fixes #1006 by adding max_execution_time_s to agent options and natively wrapping execution paths in Eio.Time.with_timeout_exn.