### PR TITLE
[codex] split pipeline prepare, route, and retry stages

### DIFF
--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -50,94 +50,17 @@ let event_envelope agent : Event_bus.envelope =
 (* ── Stage 1: Input ──────────────────────────────────────── *)
 
 (** Set lifecycle to Ready, invoke BeforeTurn hook, handle elicitation. *)
-let stage_input ?raw_trace_run agent =
-  let ts = Unix.gettimeofday () in
-  set_lifecycle agent ~ready_at:ts Ready;
-
-  let before_decision =
-    invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"before_turn"
-      agent.options.hooks.before_turn
-      (Hooks.BeforeTurn { turn = agent.state.turn_count;
-                          messages = agent.state.messages })
-  in
-  (match before_decision with
-   | Hooks.ElicitInput req ->
-     (match agent.options.elicitation with
-      | Some cb ->
-        let response = cb req in
-        (match agent.options.event_bus with
-         | Some bus -> Event_bus.publish bus
-             (Event_bus.mk_event
-                (ElicitationCompleted {
-                   agent_name = agent.state.config.name;
-                   question = req.question;
-                   response }))
-         | None -> ());
-        (match response with
-         | Hooks.Answer json ->
-           let text = Printf.sprintf "[User input] %s: %s"
-             req.question (Yojson.Safe.to_string json) in
-           update_state agent (fun s ->
-             { s with messages = Util.snoc s.messages
-                 { role = User; content = [Text text]; name = None; tool_call_id = None ; metadata = []} })
-         | Hooks.Declined | Hooks.Timeout -> ())
-      | None -> ())
-   | Hooks.Nudge nudge_msg ->
-     (* Mirror on_idle Nudge handling (Stage 5): append the nudge as a
-        User-role message so it reaches the model in this same turn via
-        Stage 2 prepare_turn. The idle counter is not touched — BeforeTurn
-        is not part of the idle path. *)
-     update_state agent (fun s ->
-       { s with messages = Util.snoc s.messages
-           { role = User; content = [Text nudge_msg];
-             name = None; tool_call_id = None ; metadata = []} })
-   | _ -> ())
+let stage_input = Pipeline_stage_prepare.stage_input
 
 (* ── Stage 2: Parse ──────────────────────────────────────── *)
 
-let last_tool_results_from messages =
-  (* Fold from left to track the last User message with ToolResults,
-     avoiding List.rev allocation on the full message list. *)
-  let extract_results msg =
-    if msg.role <> User then []
-    else
-      List.filter_map (function
-        | ToolResult { content; is_error; _ } ->
-          if is_error then
-            Some
-              (Error
-                 {
-                   Types.message = content;
-                   recoverable = true;
-                   error_class = None;
-                 }
-                : Types.tool_result)
-          else Some (Ok { Types.content } : Types.tool_result)
-        | _ -> None
-      ) msg.content
-  in
-  List.fold_left (fun acc msg ->
-    match extract_results msg with
-    | [] -> acc
-    | results -> results
-  ) [] messages
+let last_tool_results_from = Pipeline_stage_prepare.last_tool_results_from
 
 (** Prepare the turn using current [agent.state.messages] and the given
     [turn_params].  Centralises the [Agent_turn.prepare_turn] parameter
     list to avoid duplication between [stage_parse] and post-compaction
     re-preparation (Stage 2.3). *)
-let prepare_turn_for_agent agent ~turn_params =
-  Agent_turn.prepare_turn
-    ~guardrails:agent.options.guardrails
-    ~operator_policy:agent.options.operator_policy
-    ~policy_channel:agent.options.policy_channel
-    ~tools:agent.tools
-    ~messages:agent.state.messages
-    ~context_reducer:agent.options.context_reducer
-    ~tiered_memory:agent.options.tiered_memory
-    ~turn_params
-    ?tool_selector:agent.options.tool_selector
-    ()
+let prepare_turn_for_agent = Pipeline_stage_prepare.prepare_turn_for_agent
 
 let total_prompt_tokens_for_agent agent messages =
   let raw_tokens =
@@ -148,66 +71,7 @@ let total_prompt_tokens_for_agent agent messages =
 
 (** Invoke BeforeTurnParams hook, apply turn params, prepare tools.
     Returns (turn_preparation, original_config, turn_params). *)
-let stage_parse ?raw_trace_run agent =
-  let turn_params = match agent.options.hooks.before_turn_params with
-    | None -> Hooks.default_turn_params
-    | Some _ ->
-      let last_results = last_tool_results_from agent.state.messages in
-      let reasoning = Hooks.extract_reasoning agent.state.messages in
-      let decision =
-        invoke_hook_with_trace agent ?raw_trace_run
-          ~hook_name:"before_turn_params"
-          agent.options.hooks.before_turn_params
-          (Hooks.BeforeTurnParams {
-            turn = agent.state.turn_count;
-            max_turns = agent.state.config.max_turns;
-            messages = agent.state.messages;
-            last_tool_results = last_results;
-            current_params = Hooks.default_turn_params;
-            reasoning;
-          })
-      in
-      match decision with
-      | Hooks.AdjustParams params -> params
-      | _ -> Hooks.default_turn_params
-  in
-
-  (* Apply ephemeral turn params, save original for restoration *)
-  let original_config = agent.state.config in
-  let new_config = {
-    original_config with
-    temperature =
-      (match turn_params.temperature with Some _ as t -> t | None -> original_config.temperature);
-    thinking_budget =
-      (match turn_params.thinking_budget with Some _ as t -> t | None -> original_config.thinking_budget);
-    enable_thinking =
-      (match turn_params.enable_thinking with Some _ as t -> t | None -> original_config.enable_thinking);
-    tool_choice =
-      (match turn_params.tool_choice with Some _ as t -> t | None -> original_config.tool_choice);
-    system_prompt =
-      (match turn_params.system_prompt_override with Some _ as s -> s | None -> original_config.system_prompt)
-      |> Option.map Llm_provider.Utf8_sanitize.sanitize;
-  } in
-  update_state agent (fun s -> { s with config = new_config });
-  let original_config = original_config in
-
-  (* TurnStarted event *)
-  (match agent.options.event_bus with
-   | Some bus -> Event_bus.publish bus
-       { meta = event_envelope agent;
-         payload = TurnStarted
-           { agent_name = agent.state.config.name;
-             turn = agent.state.turn_count } }
-   | None -> ());
-  (match agent.options.journal with
-   | Some j ->
-       Durable_event.append j
-         (Turn_started { turn = agent.state.turn_count;
-                         timestamp = Unix.gettimeofday () })
-   | None -> ());
-
-  let prep = prepare_turn_for_agent agent ~turn_params in
-  (prep, original_config, turn_params)
+let stage_parse = Pipeline_stage_prepare.stage_parse
 
 (* ── Stage 3: Route ──────────────────────────────────────── *)
 
@@ -218,71 +82,16 @@ let stage_parse ?raw_trace_run agent =
 
     HTTP status codes are re-classified via {!Retry.classify_error} so
     ContextOverflow/RateLimited/etc. still map to the same variants. *)
-let sdk_error_of_http_error : Llm_provider.Http_client.http_error -> Error.sdk_error =
-  function
-  | Llm_provider.Http_client.HttpError { code; body } ->
-      Error.Api (Retry.classify_error ~status:code ~body)
-  | Llm_provider.Http_client.NetworkError { message; kind; _ } ->
-      Error.Api (Retry.NetworkError { message; kind })
-  | Llm_provider.Http_client.AcceptRejected { reason } ->
-      Error.Api (Retry.InvalidRequest { message = reason })
-  | Llm_provider.Http_client.CliTransportRequired { kind } ->
-      Error.Api (Retry.InvalidRequest {
-        message = Printf.sprintf
-          "CLI transport required for %s but none was injected; \
-           pass ~transport via agent.options.transport" kind })
+let sdk_error_of_http_error = Pipeline_stage_route.sdk_error_of_http_error
 
 (** Sync dispatch via {!Llm_provider.Complete.complete}.  Routes all
     provider kinds through the consolidated path so [on_request_end]
     metrics fire and [Llm_transport.t] (set via [agent.options.transport])
     handles CLI providers.  Legacy {!Api.create_message} remains for
     Stream fallback pending PR-O2b. *)
-let dispatch_sync ~sw ?clock agent prep =
-  let tools = Option.value prep.Agent_turn.tools_json ~default:[] in
-  let open Result in
-  let* pc =
-    Provider.provider_config_of_agent
-      ~state:agent.state
-      ~base_url:agent.options.base_url
-      agent.options.provider
-  in
-  let call () =
-    match clock with
-    | Some clock ->
-        Llm_provider.Complete.complete_with_retry
-          ~sw ~net:agent.net ?transport:agent.options.transport ~clock
-          ~config:pc ~messages:prep.effective_messages ~tools
-          ?runtime_mcp_policy:agent.options.runtime_mcp_policy
-          ?priority:agent.options.priority ()
-    | None ->
-        Llm_provider.Complete.complete
-          ~sw ~net:agent.net ?transport:agent.options.transport
-          ~config:pc ~messages:prep.effective_messages ~tools
-          ?runtime_mcp_policy:agent.options.runtime_mcp_policy
-          ?priority:agent.options.priority ()
-  in
-  match call () with
-  | Ok resp -> Ok resp
-  | Error err -> Error (sdk_error_of_http_error err)
+let dispatch_sync = Pipeline_stage_route.dispatch_sync
 
-let dispatch_stream ~sw agent prep ~on_event =
-  let tools = Option.value prep.Agent_turn.tools_json ~default:[] in
-  let open Result in
-  let* pc =
-    Provider.provider_config_of_agent
-      ~state:agent.state
-      ~base_url:agent.options.base_url
-      agent.options.provider
-  in
-  match
-    Llm_provider.Complete.complete_stream
-      ~sw ~net:agent.net ?transport:agent.options.transport
-      ~config:pc ~messages:prep.effective_messages ~tools
-      ?runtime_mcp_policy:agent.options.runtime_mcp_policy
-      ~on_event ?priority:agent.options.priority ()
-  with
-  | Ok resp -> Ok resp
-  | Error err -> Error (sdk_error_of_http_error err)
+let dispatch_stream = Pipeline_stage_route.dispatch_stream
 
 (** Dispatch the API call via the chosen strategy (sync or stream). *)
 let stage_route ~sw ?clock ~api_strategy agent prep =
@@ -347,45 +156,9 @@ let stage_collect ?raw_trace_run agent ~original_config response =
       usage });
   Ok ()
 
-let retry_failures_of_results
-    (results : Agent_tools.tool_execution_result list) :
-    Tool_retry_policy.failure list =
-  results
-  |> List.filter_map (fun (result : Agent_tools.tool_execution_result) ->
-         match result.failure_kind with
-         | Some Agent_tools.Validation_error ->
-             Some
-               {
-                 Tool_retry_policy.tool_name = result.tool_name;
-                 detail = result.content;
-                 kind = Tool_retry_policy.Validation_error;
-                 error_class =
-                   Tool_retry_policy.resolve_error_class
-                     ~explicit:result.error_class
-                     Tool_retry_policy.Validation_error;
-               }
-         | Some Agent_tools.Recoverable_tool_error ->
-             Some
-               {
-                 Tool_retry_policy.tool_name = result.tool_name;
-                 detail = result.content;
-                 kind = Tool_retry_policy.Recoverable_tool_error;
-                 error_class =
-                   Tool_retry_policy.resolve_error_class
-                     ~explicit:result.error_class
-                     Tool_retry_policy.Recoverable_tool_error;
-               }
-         | Some Agent_tools.Non_retryable_tool_error | None -> None)
+let retry_failures_of_results = Pipeline_retry.retry_failures_of_results
 
-let retry_feedback_blocks ~(policy : Tool_retry_policy.t) ~(retry_count : int)
-    ~(summary : string) ~(tool_results : Types.content_block list) =
-  match policy.feedback_style with
-  | Tool_retry_policy.Structured_tool_result -> tool_results
-  | Tool_retry_policy.Plain_error_text ->
-      [
-        Tool_retry_policy.plain_feedback_block ~retry_count
-          ~max_retries:policy.max_retries ~summary;
-      ]
+let retry_feedback_blocks = Pipeline_retry.retry_feedback_blocks
 
 (* ── Stage 5: Execute ────────────────────────────────────── *)
 

--- a/lib/pipeline/pipeline_retry.ml
+++ b/lib/pipeline/pipeline_retry.ml
@@ -1,0 +1,39 @@
+let retry_failures_of_results
+    (results : Agent_tools.tool_execution_result list) :
+    Tool_retry_policy.failure list =
+  results
+  |> List.filter_map (fun (result : Agent_tools.tool_execution_result) ->
+         match result.failure_kind with
+         | Some Agent_tools.Validation_error ->
+             Some
+               {
+                 Tool_retry_policy.tool_name = result.tool_name;
+                 detail = result.content;
+                 kind = Tool_retry_policy.Validation_error;
+                 error_class =
+                   Tool_retry_policy.resolve_error_class
+                     ~explicit:result.error_class
+                     Tool_retry_policy.Validation_error;
+               }
+         | Some Agent_tools.Recoverable_tool_error ->
+             Some
+               {
+                 Tool_retry_policy.tool_name = result.tool_name;
+                 detail = result.content;
+                 kind = Tool_retry_policy.Recoverable_tool_error;
+                 error_class =
+                   Tool_retry_policy.resolve_error_class
+                     ~explicit:result.error_class
+                     Tool_retry_policy.Recoverable_tool_error;
+               }
+         | Some Agent_tools.Non_retryable_tool_error | None -> None)
+
+let retry_feedback_blocks ~(policy : Tool_retry_policy.t) ~(retry_count : int)
+    ~(summary : string) ~(tool_results : Types.content_block list) =
+  match policy.feedback_style with
+  | Tool_retry_policy.Structured_tool_result -> tool_results
+  | Tool_retry_policy.Plain_error_text ->
+      [
+        Tool_retry_policy.plain_feedback_block ~retry_count
+          ~max_retries:policy.max_retries ~summary;
+      ]

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -1,0 +1,193 @@
+open Types
+open Agent_types
+open Agent_trace
+
+(** Stage 1/2 helpers extracted from [Pipeline].
+
+    These functions stay internal to the library. [Pipeline] re-exports them
+    via local aliases so existing tests and call sites remain unchanged while
+    the file is split by stage responsibility. *)
+
+let stage_input ?raw_trace_run agent =
+  let ts = Unix.gettimeofday () in
+  set_lifecycle agent ~ready_at:ts Ready;
+
+  let before_decision =
+    invoke_hook_with_trace agent ?raw_trace_run ~hook_name:"before_turn"
+      agent.options.hooks.before_turn
+      (Hooks.BeforeTurn
+         { turn = agent.state.turn_count; messages = agent.state.messages })
+  in
+  match before_decision with
+  | Hooks.ElicitInput req -> (
+      match agent.options.elicitation with
+      | Some cb ->
+          let response = cb req in
+          (match agent.options.event_bus with
+          | Some bus ->
+              Event_bus.publish bus
+                (Event_bus.mk_event
+                   (ElicitationCompleted
+                      {
+                        agent_name = agent.state.config.name;
+                        question = req.question;
+                        response;
+                      }))
+          | None -> ());
+          (match response with
+          | Hooks.Answer json ->
+              let text =
+                Printf.sprintf "[User input] %s: %s" req.question
+                  (Yojson.Safe.to_string json)
+              in
+              update_state agent (fun s ->
+                  {
+                    s with
+                    messages =
+                      Util.snoc s.messages
+                        {
+                          role = User;
+                          content = [ Text text ];
+                          name = None;
+                          tool_call_id = None;
+                          metadata = [];
+                        };
+                  })
+          | Hooks.Declined | Hooks.Timeout -> ())
+      | None -> ())
+  | Hooks.Nudge nudge_msg ->
+      (* Keep BeforeTurn nudge behavior identical to the inlined pipeline path:
+         append it as a User message so it is seen in this same turn. *)
+      update_state agent (fun s ->
+          {
+            s with
+            messages =
+              Util.snoc s.messages
+                {
+                  role = User;
+                  content = [ Text nudge_msg ];
+                  name = None;
+                  tool_call_id = None;
+                  metadata = [];
+                };
+          })
+  | _ -> ()
+
+let last_tool_results_from messages =
+  let extract_results msg =
+    if msg.role <> User then []
+    else
+      List.filter_map
+        (function
+          | ToolResult { content; is_error; _ } ->
+              if is_error then
+                Some
+                  (Error
+                     {
+                       Types.message = content;
+                       recoverable = true;
+                       error_class = None;
+                     }
+                    : Types.tool_result)
+              else Some (Ok { Types.content } : Types.tool_result)
+          | _ -> None)
+        msg.content
+  in
+  List.fold_left
+    (fun acc msg ->
+      match extract_results msg with [] -> acc | results -> results)
+    [] messages
+
+let prepare_turn_for_agent agent ~turn_params =
+  Agent_turn.prepare_turn ~guardrails:agent.options.guardrails
+    ~operator_policy:agent.options.operator_policy
+    ~policy_channel:agent.options.policy_channel ~tools:agent.tools
+    ~messages:agent.state.messages ~context_reducer:agent.options.context_reducer
+    ~tiered_memory:agent.options.tiered_memory
+    ~turn_params ?tool_selector:agent.options.tool_selector ()
+
+let stage_parse ?raw_trace_run agent =
+  let turn_params =
+    match agent.options.hooks.before_turn_params with
+    | None -> Hooks.default_turn_params
+    | Some _ ->
+        let last_results = last_tool_results_from agent.state.messages in
+        let reasoning = Hooks.extract_reasoning agent.state.messages in
+        let decision =
+          invoke_hook_with_trace agent ?raw_trace_run
+            ~hook_name:"before_turn_params"
+            agent.options.hooks.before_turn_params
+            (Hooks.BeforeTurnParams
+               {
+                 turn = agent.state.turn_count;
+                 max_turns = agent.state.config.max_turns;
+                 messages = agent.state.messages;
+                 last_tool_results = last_results;
+                 current_params = Hooks.default_turn_params;
+                 reasoning;
+               })
+        in
+        (match decision with
+        | Hooks.AdjustParams params -> params
+        | _ -> Hooks.default_turn_params)
+  in
+
+  let original_config = agent.state.config in
+  let new_config =
+    {
+      original_config with
+      temperature =
+        (match turn_params.temperature with
+        | Some _ as t -> t
+        | None -> original_config.temperature);
+      thinking_budget =
+        (match turn_params.thinking_budget with
+        | Some _ as t -> t
+        | None -> original_config.thinking_budget);
+      enable_thinking =
+        (match turn_params.enable_thinking with
+        | Some _ as t -> t
+        | None -> original_config.enable_thinking);
+      tool_choice =
+        (match turn_params.tool_choice with
+        | Some _ as t -> t
+        | None -> original_config.tool_choice);
+      system_prompt =
+        (match turn_params.system_prompt_override with
+        | Some _ as s -> s
+        | None -> original_config.system_prompt)
+        |> Option.map Llm_provider.Utf8_sanitize.sanitize;
+    }
+  in
+  update_state agent (fun s -> { s with config = new_config });
+  let original_config = original_config in
+
+  (match agent.options.event_bus with
+  | Some bus ->
+      Event_bus.publish bus
+        {
+          meta =
+            Event_bus.mk_envelope
+              ~correlation_id:
+                (match Option.bind agent.options.raw_trace Raw_trace.session_id with
+                | Some session_id -> session_id
+                | None -> Event_bus.fresh_id ())
+              ~run_id:
+                (match Option.bind (lifecycle_snapshot agent) (fun s -> s.current_run_id) with
+                | Some run_id -> run_id
+                | None -> Event_bus.fresh_id ())
+              ();
+          payload =
+            TurnStarted
+              { agent_name = agent.state.config.name; turn = agent.state.turn_count };
+        }
+  | None -> ());
+  (match agent.options.journal with
+  | Some j ->
+      Durable_event.append j
+        (Turn_started
+           { turn = agent.state.turn_count; timestamp = Unix.gettimeofday () })
+  | None -> ());
+
+  let prep = prepare_turn_for_agent agent ~turn_params in
+  (prep, original_config, turn_params)

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -1,0 +1,63 @@
+open Agent_types
+
+let ( let* ) = Result.bind
+
+let sdk_error_of_http_error : Llm_provider.Http_client.http_error -> Error.sdk_error =
+  function
+  | Llm_provider.Http_client.HttpError { code; body } ->
+      Error.Api (Retry.classify_error ~status:code ~body)
+  | Llm_provider.Http_client.NetworkError { message; kind; _ } ->
+      Error.Api (Retry.NetworkError { message; kind })
+  | Llm_provider.Http_client.AcceptRejected { reason } ->
+      Error.Api (Retry.InvalidRequest { message = reason })
+  | Llm_provider.Http_client.CliTransportRequired { kind } ->
+      Error.Api
+        (Retry.InvalidRequest
+           {
+             message =
+               Printf.sprintf
+                 "CLI transport required for %s but none was injected; \
+                  pass ~transport via agent.options.transport"
+                 kind;
+           })
+
+let dispatch_sync ~sw ?clock agent (prep : Agent_turn.turn_preparation) =
+  let tools = Option.value prep.Agent_turn.tools_json ~default:[] in
+  let* pc =
+    Provider.provider_config_of_agent ~state:agent.state
+      ~base_url:agent.options.base_url agent.options.provider
+  in
+  let call () =
+    match clock with
+    | Some clock ->
+        Llm_provider.Complete.complete_with_retry ~sw ~net:agent.net
+          ?transport:agent.options.transport ~clock ~config:pc
+          ~messages:prep.Agent_turn.effective_messages ~tools
+          ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+          ?priority:agent.options.priority ()
+    | None ->
+        Llm_provider.Complete.complete ~sw ~net:agent.net
+          ?transport:agent.options.transport ~config:pc
+          ~messages:prep.Agent_turn.effective_messages ~tools
+          ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+          ?priority:agent.options.priority ()
+  in
+  match call () with
+  | Ok resp -> Ok resp
+  | Error err -> Error (sdk_error_of_http_error err)
+
+let dispatch_stream ~sw agent (prep : Agent_turn.turn_preparation) ~on_event =
+  let tools = Option.value prep.Agent_turn.tools_json ~default:[] in
+  let* pc =
+    Provider.provider_config_of_agent ~state:agent.state
+      ~base_url:agent.options.base_url agent.options.provider
+  in
+  match
+    Llm_provider.Complete.complete_stream ~sw ~net:agent.net
+      ?transport:agent.options.transport ~config:pc
+      ~messages:prep.Agent_turn.effective_messages ~tools
+      ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+      ~on_event ?priority:agent.options.priority ()
+  with
+  | Ok resp -> Ok resp
+  | Error err -> Error (sdk_error_of_http_error err)

--- a/lib/pipeline/stage_collect.ml
+++ b/lib/pipeline/stage_collect.ml
@@ -46,8 +46,7 @@ let stage_collect ?raw_trace_run agent ~original_config response =
   update_state agent (fun s ->
     { s with
       messages = Util.snoc s.messages
-        { role = Assistant; content = response.content; name = None; tool_call_id = None };
+        { role = Assistant; content = response.content; name = None; tool_call_id = None; metadata = [] };
       turn_count = s.turn_count + 1;
       usage });
   Ok ()
-

--- a/lib/pipeline/stage_execute.ml
+++ b/lib/pipeline/stage_execute.ml
@@ -120,7 +120,7 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
       update_state agent (fun s ->
         { s with messages = Util.snoc s.messages
             { role = User; content = [Text nudge_msg];
-              name = None; tool_call_id = None } });
+              name = None; tool_call_id = None; metadata = [] } });
       idle_handled := true
     | _ -> ()
   end;
@@ -136,7 +136,7 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
       "Tool call limit exceeded: %d calls in one turn" count in
     update_state agent (fun s ->
       { s with messages = Util.snoc s.messages
-          { role = User; content = [Text msg]; name = None; tool_call_id = None } });
+          { role = User; content = [Text msg]; name = None; tool_call_id = None; metadata = [] } });
     Ok ToolsExecuted
   | false ->
     let results =
@@ -203,6 +203,7 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
               content = effective_feedback;
               name = None;
               tool_call_id = None;
+              metadata = [];
             };
       });
     (match agent.options.context_injector with
@@ -230,4 +231,3 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
        unmodified preserves the byte-identical conversation prefix that
        local LLM KV-cache (Ollama/llama.cpp) depends on for reuse. *)
     Ok ToolsExecuted
-

--- a/lib/pipeline/stage_input.ml
+++ b/lib/pipeline/stage_input.ml
@@ -36,7 +36,7 @@ let stage_input ?raw_trace_run agent =
              req.question (Yojson.Safe.to_string json) in
            update_state agent (fun s ->
              { s with messages = Util.snoc s.messages
-                 { role = User; content = [Text text]; name = None; tool_call_id = None } })
+                 { role = User; content = [Text text]; name = None; tool_call_id = None; metadata = [] } })
          | Hooks.Declined | Hooks.Timeout -> ())
       | None -> ())
    | Hooks.Nudge nudge_msg ->
@@ -47,6 +47,5 @@ let stage_input ?raw_trace_run agent =
      update_state agent (fun s ->
        { s with messages = Util.snoc s.messages
            { role = User; content = [Text nudge_msg];
-             name = None; tool_call_id = None } })
+             name = None; tool_call_id = None; metadata = [] } })
    | _ -> ())
-


### PR DESCRIPTION
## What changed
- Split pipeline prepare/parse helpers into `Pipeline_stage_prepare`.
- Split sync/stream route dispatch into `Pipeline_stage_route`.
- Split tool retry classification and feedback helpers into `Pipeline_retry`.

## Why
- The stage split worktree had drifted from current `main`, so the new modules were present but `pipeline.ml` still carried the full inlined implementations.
- Rebased on `main` and rewired `pipeline.ml` to delegate to the extracted stage modules so the split is real and buildable again.

## Impact
- Keeps the current pipeline behavior while reducing the size of `pipeline.ml`.
- Preserves current `main` behavior for before-turn nudges, tiered memory, runtime MCP policy, streaming dispatch, and retry error classification.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/task-062-split-pipeline-stages --build-dir /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/task-062-split-pipeline-stages/_build_pr_check`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/task-062-split-pipeline-stages --build-dir /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/task-062-split-pipeline-stages/_build_pr_verify ./test/test_pipeline_metrics.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/task-062-split-pipeline-stages --build-dir /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/task-062-split-pipeline-stages/_build_api_verify2 ./test/test_api.exe`
