### PR TITLE
refactor(test): genericize MCP fixture names in transport tests

### DIFF
--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -872,13 +872,13 @@ let%test "runtime MCP policy overrides legacy tool and MCP config wiring" =
       Llm_transport.empty_runtime_mcp_policy with
       servers = [
         Llm_transport.Http_server {
-          name = "masc";
-          url = "http://127.0.0.1:8935/mcp";
+          name = "example";
+          url = "http://127.0.0.1:9999/mcp";
           headers = [];
         };
       ];
-      allowed_server_names = ["masc"];
-      allowed_tool_names = ["masc_status"];
+      allowed_server_names = ["example"];
+      allowed_tool_names = ["example_status"];
       permission_mode = Some "plan";
       strict = true;
       disable_builtin_tools = true;
@@ -891,12 +891,12 @@ let%test "runtime MCP policy overrides legacy tool and MCP config wiring" =
   List.mem "--tools" args
   && List.mem "" args
   && List.mem "--allowedTools" args
-  && List.mem "mcp__masc__masc_status" args
+  && List.mem "mcp__example__example_status" args
   && List.mem "--permission-mode" args
   && List.mem "plan" args
   && List.mem "--strict-mcp-config" args
   && List.mem
-       {|{"mcpServers":{"masc":{"type":"http","url":"http://127.0.0.1:8935/mcp","headers":{}}}}|}
+       {|{"mcpServers":{"example":{"type":"http","url":"http://127.0.0.1:9999/mcp","headers":{}}}}|}
        args
   && not (List.mem "Bash" args)
   && not (List.mem "/tmp/legacy-mcp.json" args)

--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -753,10 +753,10 @@ let%test "events_of_line command_execution → no events" =
 let%test "events_of_line mcp_tool_call completion emits tool_result block" =
   let state = create_stream_state () in
   let started =
-    {|{"type":"item.started","item":{"id":"call_1","type":"mcp_tool_call","server":"masc","tool":"masc_status","arguments":{"verbose":true}}}|}
+    {|{"type":"item.started","item":{"id":"call_1","type":"mcp_tool_call","server":"example","tool":"example_status","arguments":{"verbose":true}}}|}
   in
   let completed =
-    {|{"type":"item.completed","item":{"id":"call_1","type":"mcp_tool_call","server":"masc","tool":"masc_status","result":{"content":[{"type":"text","text":"ok"}],"isError":false}}}|}
+    {|{"type":"item.completed","item":{"id":"call_1","type":"mcp_tool_call","server":"example","tool":"example_status","result":{"content":[{"type":"text","text":"ok"}],"isError":false}}}|}
   in
   ignore (events_of_line_with_state state started);
   match events_of_line_with_state state completed with
@@ -838,13 +838,13 @@ let%test "build_args runtime MCP wires request-scoped server" =
       Llm_transport.empty_runtime_mcp_policy with
       servers = [
         Llm_transport.Http_server {
-          name = "masc";
-          url = "http://127.0.0.1:8935/mcp";
+          name = "example";
+          url = "http://127.0.0.1:9999/mcp";
           headers = [];
         };
       ];
-      allowed_server_names = ["masc"];
-      allowed_tool_names = ["masc_status"];
+      allowed_server_names = ["example"];
+      allowed_tool_names = ["example_status"];
       disable_builtin_tools = true;
     }
   in
@@ -853,21 +853,21 @@ let%test "build_args runtime MCP wires request-scoped server" =
       ~runtime_mcp_policy:policy
       ()
   in
-  List.mem "mcp_servers.masc.url=\"http://127.0.0.1:8935/mcp\"" args
-  && List.mem "mcp_servers.masc.tools.masc_status.approval_mode=\"approve\"" args
+  List.mem "mcp_servers.example.url=\"http://127.0.0.1:9999/mcp\"" args
+  && List.mem "mcp_servers.example.tools.example_status.approval_mode=\"approve\"" args
   && List.mem "-s" args
   && List.mem "read-only" args
 
 let%test "parse_jsonl_result includes mcp tool call blocks" =
   let lines = [
     {|{"type":"thread.started","thread_id":"abc-123"}|};
-    {|{"type":"item.completed","item":{"id":"call_1","type":"mcp_tool_call","server":"masc","tool":"masc_status","arguments":{"verbose":true},"result":{"content":[{"type":"text","text":"ok"}],"isError":false}}}|};
+    {|{"type":"item.completed","item":{"id":"call_1","type":"mcp_tool_call","server":"example","tool":"example_status","arguments":{"verbose":true},"result":{"content":[{"type":"text","text":"ok"}],"isError":false}}}|};
     {|{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"done"}}|};
   ] in
   match parse_jsonl_result lines with
   | Ok resp ->
     (match resp.content with
-     | Types.ToolUse { name = "mcp__masc__masc_status"; _ }
+     | Types.ToolUse { name = "mcp__example__example_status"; _ }
        :: Types.ToolResult { tool_use_id = "call_1"; content = "ok"; _ }
        :: Types.Text "done" :: [] -> true
      | _ -> false)

--- a/lib/llm_provider/transport_gemini_cli.ml
+++ b/lib/llm_provider/transport_gemini_cli.ml
@@ -594,13 +594,13 @@ let runtime_mcp_policy_sample =
     Llm_transport.empty_runtime_mcp_policy with
     servers = [
       Llm_transport.Http_server {
-        name = "masc";
-        url = "http://127.0.0.1:8935/mcp";
+        name = "example";
+        url = "http://127.0.0.1:9999/mcp";
         headers = [];
       };
     ];
-    allowed_server_names = ["masc"];
-    allowed_tool_names = ["masc_status"];
+    allowed_server_names = ["example"];
+    allowed_tool_names = ["example_status"];
   }
 
 let runtime_mcp_req_sample : Llm_transport.completion_request =


### PR DESCRIPTION
## Summary

OAS는 MASC를 몰라야 한다. 그러나 transport layer 테스트 fixture에서 MASC-specific MCP 서버/툴 이름(`masc`, `masc_status`)을 사용하고 있었다. 이 PR은 테스트 데이터를 generic 이름으로 교체하여 OAS의 MASC 비의존성을 유지한다.

## Changes

| Before | After |
|--------|-------|
| server name `"masc"` | `"example"` |
| tool name `"masc_status"` | `"example_status"` |
| namespaced `"mcp__masc__masc_status"` | `"mcp__example__example_status"` |
| endpoint `http://127.0.0.1:8935/mcp` | `http://127.0.0.1:9999/mcp` |

## Files

- `lib/llm_provider/transport_claude_code.ml`
- `lib/llm_provider/transport_codex_cli.ml`
- `lib/llm_provider/transport_gemini_cli.ml`

## Test Plan

- [x] `dune build --root .` 컴파일 성공
- [ ] `dune runtest` 관련 테스트 통과 (fixture-only 변경, 동작 변경 없음)

## Out of Scope

- 런타임 의존성 변경 없음 (fixture 문자염만 교체)