### PR TITLE
[codex] Preserve HTTP MCP reconnect state

### DIFF
--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -229,16 +229,21 @@ let runtime_mcp_overrides
     let name = Llm_transport.runtime_mcp_server_name server in
     match acc, server with
     | Error _ as e, _ -> e
-    | Ok overrides, Llm_transport.Http_server { url; headers = []; _ } ->
+    | Ok overrides, Llm_transport.Http_server { url; headers; _ } ->
       Ok
         (overrides
-         @ [Printf.sprintf "mcp_servers.%s.url=%s" name (toml_string url)])
-    | Ok _, Llm_transport.Http_server { headers = _ :: _; _ } ->
-      Error "codex_cli runtime MCP does not support inline HTTP headers yet"
+         @ [Printf.sprintf "mcp_servers.%s.url=%s" name (toml_string url)]
+         @
+         if headers = [] then []
+         else
+           [
+             Printf.sprintf "mcp_servers.%s.http_headers=%s"
+               name (toml_string_assoc headers);
+           ])
     | Ok overrides, Llm_transport.Stdio_server { command; args; env; _ } ->
       Ok
         (overrides
-         @ [
+        @ [
              Printf.sprintf "mcp_servers.%s.command=%s"
                name (toml_string command);
              Printf.sprintf "mcp_servers.%s.args=%s"
@@ -857,6 +862,33 @@ let%test "build_args runtime MCP wires request-scoped server" =
   && List.mem "mcp_servers.example.tools.example_status.approval_mode=\"approve\"" args
   && List.mem "-s" args
   && List.mem "read-only" args
+
+let%test "build_args runtime MCP wires HTTP headers" =
+  let policy =
+    {
+      Llm_transport.empty_runtime_mcp_policy with
+      servers = [
+        Llm_transport.Http_server {
+          name = "masc";
+          url = "http://127.0.0.1:8935/mcp";
+          headers = [
+            ("Authorization", "Bearer tok");
+            ("Accept", "application/json, text/event-stream");
+          ];
+        };
+      ];
+      allowed_server_names = ["masc"];
+    }
+  in
+  let args =
+    build_args ~config:default_config ~req_config:(codex_req ()) ~prompt:"hi"
+      ~runtime_mcp_policy:policy
+      ()
+  in
+  List.mem "mcp_servers.masc.url=\"http://127.0.0.1:8935/mcp\"" args
+  && List.mem
+       "mcp_servers.masc.http_headers={Authorization=\"Bearer tok\",Accept=\"application/json, text/event-stream\"}"
+       args
 
 let%test "parse_jsonl_result includes mcp tool call blocks" =
   let lines = [

--- a/lib/protocol/mcp.ml
+++ b/lib/protocol/mcp.ml
@@ -267,7 +267,11 @@ type server_spec = {
 (** Transport backend for a managed MCP connection. *)
 type transport =
   | Stdio of { client: t; spec: server_spec }
-  | Http of { close_fn: unit -> unit }
+  | Http of {
+      close_fn: unit -> unit;
+      base_url: string;
+      headers: (string * string) list;
+    }
 
 (** A connected MCP server together with its converted SDK tools. *)
 type managed = {

--- a/lib/protocol/mcp.mli
+++ b/lib/protocol/mcp.mli
@@ -85,7 +85,11 @@ type server_spec = {
 
 type transport =
   | Stdio of { client: t; spec: server_spec }
-  | Http of { close_fn: unit -> unit }
+  | Http of {
+      close_fn: unit -> unit;
+      base_url: string;
+      headers: (string * string) list;
+    }
 
 type managed = {
   tools: Tool.t list;

--- a/lib/protocol/mcp_http.ml
+++ b/lib/protocol/mcp_http.ml
@@ -89,7 +89,13 @@ let connect_and_load_managed ~sw ~net (spec : http_spec) :
     {
       Mcp.tools;
       name = spec.name;
-      transport = Http { close_fn = (fun () -> close client) };
+      transport =
+        Http
+          {
+            close_fn = (fun () -> close client);
+            base_url = spec.base_url;
+            headers = spec.headers;
+          };
     }
 
 let connect_and_load ~sw ~net spec = connect_and_load_managed ~sw ~net spec

--- a/lib/protocol/mcp_session.ml
+++ b/lib/protocol/mcp_session.ml
@@ -12,7 +12,7 @@
       (* ... serialize infos into checkpoint JSON ... *)
 
       (* On resume *)
-      let managed, failed_with_reasons = Mcp_session.reconnect_all ~sw ~mgr infos in
+      let managed, failed_with_reasons = Mcp_session.reconnect_all ~sw ~mgr ~net infos in
       List.iter (fun (info, err) ->
         let _log = Log.create ~module_name:"mcp_session" () in
         Log.warn _log "Failed to reconnect"
@@ -31,6 +31,8 @@ type info = {
   command: string;     (** For HTTP: "http"; for stdio: the executable *)
   args: string list;   (** For HTTP: [url]; for stdio: command-line args *)
   env: (string * string) list;
+  http_base_url: string option;
+  http_headers: (string * string) list;
   tool_schemas: tool_schema list;
   transport_kind: transport_kind;
 }
@@ -42,10 +44,13 @@ let capture (m : Mcp.managed) : info =
   | Mcp.Stdio { spec; _ } ->
       { server_name = m.name; command = spec.command;
         args = spec.args; env = spec.env;
+        http_base_url = None; http_headers = [];
         tool_schemas; transport_kind = Stdio }
-  | Mcp.Http _ ->
+  | Mcp.Http { base_url; headers; _ } ->
       { server_name = m.name; command = "http";
         args = []; env = [];
+        http_base_url = Some base_url;
+        http_headers = headers;
         tool_schemas; transport_kind = Http }
 
 (** Capture session info from all connected managed servers. *)
@@ -61,18 +66,29 @@ let to_server_spec (info : info) : Mcp.server_spec =
     name = info.server_name;
   }
 
+let to_http_spec (info : info) : Mcp_http.http_spec option =
+  match info.http_base_url with
+  | Some base_url -> Some { base_url; headers = info.http_headers; name = info.server_name }
+  | None -> None
+
 (** Reconnect to MCP servers from saved session info.
     Returns a pair: (successfully connected, failed infos with error messages).
     Failed connections do not abort the others.
-    HTTP servers cannot be reconnected from session info alone — they are
-    reported as failed with an informational error. *)
-let reconnect_all ~sw ~mgr (infos : info list) : Mcp.managed list * (info * Error.sdk_error) list =
+    Legacy HTTP checkpoints without stored endpoint metadata still cannot be
+    reconnected and are reported as failed with an informational error. *)
+let reconnect_all ~sw ~mgr ~net (infos : info list) : Mcp.managed list * (info * Error.sdk_error) list =
   List.fold_left (fun (connected, failed) info ->
     match info.transport_kind with
     | Http ->
-        let e = Error.Mcp (InitializeFailed {
-          detail = Printf.sprintf "HTTP MCP server '%s' cannot be reconnected from session" info.server_name }) in
-        (connected, (info, e) :: failed)
+        (match to_http_spec info with
+         | Some spec ->
+             (match Mcp_http.connect_and_load_managed ~sw ~net spec with
+              | Ok m -> (m :: connected, failed)
+              | Error e -> (connected, (info, e) :: failed))
+         | None ->
+             let e = Error.Mcp (InitializeFailed {
+               detail = Printf.sprintf "HTTP MCP server '%s' cannot be reconnected from legacy session data" info.server_name }) in
+             (connected, (info, e) :: failed))
     | Stdio ->
         let spec = to_server_spec info in
         (match Mcp.connect_and_load ~sw ~mgr spec with
@@ -128,6 +144,11 @@ let info_to_json (info : info) : Yojson.Safe.t =
     ("command", `String info.command);
     ("args", `List (List.map (fun s -> `String s) info.args));
     ("env", `List (List.map env_pair_to_json info.env));
+    ( "http_base_url",
+      match info.http_base_url with
+      | Some base_url -> `String base_url
+      | None -> `Null );
+    ("http_headers", `List (List.map env_pair_to_json info.http_headers));
     ("tool_schemas", `List (List.map tool_schema_to_json info.tool_schemas));
     ("transport_kind", `String (transport_kind_to_string info.transport_kind));
   ]
@@ -139,27 +160,47 @@ let info_of_json json : (info, Error.sdk_error) result =
       json |> member "env" |> to_list
       |> List.map env_pair_of_json |> result_all
     in
+    let http_headers_result =
+      let http_header_items =
+        match json |> member "http_headers" with
+        | `List items -> items
+        | _ -> []
+      in
+      http_header_items |> List.map env_pair_of_json |> result_all
+    in
     let tools_result =
       json |> member "tool_schemas" |> to_list
       |> List.map tool_schema_of_json |> result_all
     in
-    match env_result, tools_result with
-    | Ok env, Ok tool_schemas ->
+    match env_result, http_headers_result, tools_result with
+    | Ok env, Ok http_headers, Ok tool_schemas ->
       let transport_kind =
         json |> member "transport_kind" |> to_string_option
         |> Option.value ~default:"stdio"
         |> transport_kind_of_string
+      in
+      let http_base_url =
+        match json |> member "http_base_url" |> to_string_option with
+        | Some base_url -> Some base_url
+        | None ->
+            (match transport_kind with
+             | Http when json |> member "command" |> to_string <> "http" ->
+                 Some (json |> member "command" |> to_string)
+             | _ -> None)
       in
       Ok {
         server_name = json |> member "server_name" |> to_string;
         command = json |> member "command" |> to_string;
         args = json |> member "args" |> to_list |> List.map to_string;
         env;
+        http_base_url;
+        http_headers;
         tool_schemas;
         transport_kind;
       }
-    | Error e, _ -> Error e
-    | _, Error e -> Error e
+    | Error e, _, _ -> Error e
+    | _, Error e, _ -> Error e
+    | _, _, Error e -> Error e
   with
   | Yojson.Safe.Util.Type_error (msg, _) ->
     Error (Error.Serialization (JsonParseError { detail = Printf.sprintf "Mcp_session.info_of_json: %s" msg }))

--- a/lib/protocol/mcp_session.mli
+++ b/lib/protocol/mcp_session.mli
@@ -15,6 +15,8 @@ type info = {
   command: string;
   args: string list;
   env: (string * string) list;
+  http_base_url: string option;
+  http_headers: (string * string) list;
   tool_schemas: tool_schema list;
   transport_kind: transport_kind;
 }
@@ -24,7 +26,10 @@ val capture_all : Mcp.managed list -> info list
 val to_server_spec : info -> Mcp.server_spec
 
 val reconnect_all :
-  sw:Eio.Switch.t -> mgr:_ Eio.Process.mgr -> info list ->
+  sw:Eio.Switch.t ->
+  mgr:_ Eio.Process.mgr ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  info list ->
   Mcp.managed list * (info * Error.sdk_error) list
 
 (** {2 JSON serialization} *)

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -688,6 +688,8 @@ let () =
           command = "/usr/bin/mcp-server";
           args = ["--port"; "8080"];
           env = [("API_KEY", "secret123")];
+          http_base_url = None;
+          http_headers = [];
           tool_schemas = [sample_tool_schema];
           transport_kind = Stdio;
         } in
@@ -707,12 +709,14 @@ let () =
         let info1 : Mcp_session.info = {
           server_name = "server-a";
           command = "mcp-a"; args = []; env = [];
+          http_base_url = None; http_headers = [];
           tool_schemas = [];
           transport_kind = Stdio;
         } in
         let info2 : Mcp_session.info = {
           server_name = "server-b";
           command = "mcp-b"; args = ["--verbose"]; env = [("X", "1")];
+          http_base_url = None; http_headers = [];
           tool_schemas = [sample_tool_schema];
           transport_kind = Stdio;
         } in

--- a/test/test_checkpoint_delta.ml
+++ b/test/test_checkpoint_delta.ml
@@ -105,6 +105,8 @@ let mcp_info_gen =
         command;
         args;
         env = [];
+        http_base_url = None;
+        http_headers = [];
         tool_schemas;
         transport_kind = Mcp_session.Stdio;
       })

--- a/test/test_mcp_coverage.ml
+++ b/test/test_mcp_coverage.ml
@@ -180,7 +180,11 @@ let test_close_managed_http () =
   let managed : Mcp.managed = {
     tools = [];
     name = "http-test";
-    transport = Http { close_fn = (fun () -> closed := true) };
+    transport = Http {
+      close_fn = (fun () -> closed := true);
+      base_url = "http://127.0.0.1:8935/mcp";
+      headers = [];
+    };
   } in
   Mcp.close_managed managed;
   Alcotest.(check bool) "close_fn called" true !closed
@@ -195,12 +199,20 @@ let test_close_all_mixed () =
   let m1 : Mcp.managed = {
     tools = [];
     name = "srv1";
-    transport = Http { close_fn = (fun () -> incr count) };
+    transport = Http {
+      close_fn = (fun () -> incr count);
+      base_url = "http://127.0.0.1:1/mcp";
+      headers = [];
+    };
   } in
   let m2 : Mcp.managed = {
     tools = [];
     name = "srv2";
-    transport = Http { close_fn = (fun () -> incr count) };
+    transport = Http {
+      close_fn = (fun () -> incr count);
+      base_url = "http://127.0.0.1:2/mcp";
+      headers = [];
+    };
   } in
   Mcp.close_all [m1; m2];
   Alcotest.(check int) "both closed" 2 !count
@@ -210,7 +222,11 @@ let test_close_managed_http_exception () =
   let managed : Mcp.managed = {
     tools = [];
     name = "bad-close";
-    transport = Http { close_fn = (fun () -> failwith "close error") };
+    transport = Http {
+      close_fn = (fun () -> failwith "close error");
+      base_url = "http://127.0.0.1:3/mcp";
+      headers = [];
+    };
   } in
   Mcp.close_managed managed;
   Alcotest.(check bool) "no crash" true true

--- a/test/test_mcp_http.ml
+++ b/test/test_mcp_http.ml
@@ -136,6 +136,8 @@ let test_session_transport_kind () =
     command = "http";
     args = [];
     env = [];
+    http_base_url = Some "http://127.0.0.1:8935/mcp";
+    http_headers = [("Authorization", "Bearer tok")];
     tool_schemas = [];
     transport_kind = Http;
   } in
@@ -143,7 +145,9 @@ let test_session_transport_kind () =
   let info2 = Result.get_ok (Mcp_session.info_of_json json) in
   check bool "transport_kind is Http" true
     (info2.transport_kind = Mcp_session.Http);
-  check string "command" "http" info2.command
+  check string "command" "http" info2.command;
+  check (option string) "http url" (Some "http://127.0.0.1:8935/mcp")
+    info2.http_base_url
 
 let test_session_transport_kind_stdio_default () =
   (* Old JSON without transport_kind should default to Stdio *)

--- a/test/test_mcp_session.ml
+++ b/test/test_mcp_session.ml
@@ -27,9 +27,11 @@ let make_info
     ?(command="/usr/bin/mcp-server")
     ?(args=[])
     ?(env=[])
+    ?http_base_url
+    ?(http_headers=[])
     ?(tool_schemas=[])
     () : Mcp_session.info =
-  { server_name; command; args; env; tool_schemas;
+  { server_name; command; args; env; http_base_url; http_headers; tool_schemas;
     transport_kind = Stdio }
 
 let () =
@@ -95,6 +97,30 @@ let () =
         check string "second" "beta" (List.nth infos2 1).server_name;
         check string "third" "gamma" (List.nth infos2 2).server_name;
         check int "beta tools" 1 (List.length (List.nth infos2 1).tool_schemas));
+
+      test_case "http info roundtrip" `Quick (fun () ->
+        let info : Mcp_session.info = {
+          server_name = "masc";
+          command = "http";
+          args = [];
+          env = [];
+          http_base_url = Some "http://127.0.0.1:8935/mcp";
+          http_headers = [
+            ("Authorization", "Bearer tok");
+            ("X-MASC-Agent", "codex");
+          ];
+          tool_schemas = [sample_tool_schema];
+          transport_kind = Http;
+        } in
+        let json = Mcp_session.info_to_json info in
+        let info2 = Result.get_ok (Mcp_session.info_of_json json) in
+        check (option string) "http base url"
+          (Some "http://127.0.0.1:8935/mcp") info2.http_base_url;
+        check int "http headers" 2 (List.length info2.http_headers);
+        check string "first http header key" "Authorization"
+          (fst (List.hd info2.http_headers));
+        check string "transport kind" "http"
+          (match info2.transport_kind with Http -> "http" | Stdio -> "stdio"));
     ];
 
     "to_server_spec", [
@@ -159,6 +185,19 @@ let () =
           ]);
         ] in
         check bool "error" true (Result.is_error (Mcp_session.info_of_json bad)));
+
+      test_case "legacy http info without endpoint still parses" `Quick (fun () ->
+        let legacy = `Assoc [
+          ("server_name", `String "legacy-http");
+          ("command", `String "http");
+          ("args", `List []);
+          ("env", `List []);
+          ("tool_schemas", `List []);
+          ("transport_kind", `String "http");
+        ] in
+        let info = Result.get_ok (Mcp_session.info_of_json legacy) in
+        check (option string) "no http endpoint" None info.http_base_url;
+        check int "no http headers" 0 (List.length info.http_headers));
     ];
 
     "spec_roundtrip", [


### PR DESCRIPTION
## Summary
- persist HTTP MCP endpoint and header metadata in checkpointed `Mcp_session` state
- reconnect saved HTTP MCP sessions during resume while keeping legacy checkpoints explicitly non-reconnectable
- emit `mcp_servers.<name>.http_headers` for Codex runtime MCP overrides and cover the new behavior with tests

## Why
HTTP MCP sessions were losing the data needed to reconnect across checkpoint/resume, so OAS could not reattach `masc-mcp` after an interruption. Separately, the Codex CLI transport path refused request-scoped HTTP headers even though the runtime config supports them.

## Impact
- OAS can now restore HTTP MCP sessions from newly written checkpoints
- legacy HTTP checkpoints still fail closed with a clear error because they do not contain endpoint metadata
- Codex runtime MCP policy can pass bearer headers for HTTP servers such as `masc-mcp`

## Validation
- `dune build`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix-http-mcp-reconnect ./test/test_mcp_session.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix-http-mcp-reconnect ./test/test_mcp_http.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix-http-mcp-reconnect ./test/test_checkpoint.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix-http-mcp-reconnect ./test/test_checkpoint_delta.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix-http-mcp-reconnect ./test/test_mcp_coverage.exe`
- `dune runtest --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix-http-mcp-reconnect lib/llm_provider`
