### PR TITLE
fix(provider): align KIMI direct API env var with KIMI_API_KEY only

### DIFF
--- a/lib/llm_provider/provider_kind.ml
+++ b/lib/llm_provider/provider_kind.ml
@@ -38,7 +38,7 @@ let all : t list =
 
 let default_api_key_env = function
   | Anthropic -> Some "ANTHROPIC_API_KEY"
-  | Kimi -> Some "KIMI_API_KEY_SB"
+  | Kimi -> Some "KIMI_API_KEY"
   | Gemini -> Some "GEMINI_API_KEY"
   | Glm -> Some "ZAI_API_KEY"
   | OpenAI_compat | Ollama | Claude_code | Gemini_cli | Kimi_cli | Codex_cli -> None

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -209,7 +209,7 @@ let kimi_defaults = {
     (match Sys.getenv_opt "KIMI_BASE_URL" with
      | Some url when String.trim url <> "" -> String.trim url
      | _ -> "https://api.kimi.com/coding");
-  api_key_env = "KIMI_API_KEY_SB";
+  api_key_env = "KIMI_API_KEY";
   request_path = "/v1/messages";
 }
 
@@ -305,7 +305,7 @@ let default () =
                    Capabilities.kimi_capabilities;
                capabilities = Capabilities.kimi_capabilities;
                is_available = (fun () ->
-                 has_any_api_key ["KIMI_API_KEY_SB"; "KIMI_API_KEY"]) };
+                 has_any_api_key ["KIMI_API_KEY"]) };
   reg "openrouter" openrouter_defaults ~max_context:128_000
     Capabilities.openai_chat_extended_capabilities;
   reg "groq" groq_defaults ~max_context:131_072

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -198,9 +198,9 @@ let kimi_provider_impl : provider_impl = {
   resolve = (fun cfg ->
     let env_names =
       if String.trim cfg.api_key_env <> "" then
-        [cfg.api_key_env; "KIMI_API_KEY_SB"; "KIMI_API_KEY"]
+        [cfg.api_key_env; "KIMI_API_KEY"]
       else
-        ["KIMI_API_KEY_SB"; "KIMI_API_KEY"]
+        ["KIMI_API_KEY"]
     in
     match first_present_env env_names with
     | Some (_env_name, key) ->
@@ -209,7 +209,7 @@ let kimi_provider_impl : provider_impl = {
         let var_name =
           match env_names with
           | preferred :: _ -> preferred
-          | [] -> "KIMI_API_KEY_SB"
+          | [] -> "KIMI_API_KEY"
         in
         Error (Error.Config (MissingEnvVar { var_name })));
 }

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -423,7 +423,7 @@ let test_config_of_provider_config_kimi_uses_custom_provider () =
   match Provider.config_of_provider_config cfg with
   | { provider = Provider.Custom_registered { name }; api_key_env; _ } ->
       Alcotest.(check string) "provider name" "kimi" name;
-      Alcotest.(check string) "api_key_env" "KIMI_API_KEY_SB" api_key_env
+      Alcotest.(check string) "api_key_env" "KIMI_API_KEY" api_key_env
   | _ ->
       Alcotest.fail "expected kimi config to round-trip through Custom_registered"
 

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -437,11 +437,8 @@ let test_default_api_key_env_known () =
   Alcotest.(check (option string)) "glm"
     (Some "ZAI_API_KEY")
     (Provider_config.default_api_key_env Glm);
-  (* Kimi direct transport: canonical env is KIMI_API_KEY_SB (Second
-     Brain convention); lib/provider.ml also consults the bare
-     KIMI_API_KEY as a fallback, but the SSOT default is the _SB form. *)
   Alcotest.(check (option string)) "kimi"
-    (Some "KIMI_API_KEY_SB")
+    (Some "KIMI_API_KEY")
     (Provider_config.default_api_key_env Kimi)
 
 let test_is_subprocess_cli () =


### PR DESCRIPTION
## Summary
Removes KIMI_API_KEY_SB fallback drift from OAS provider registry.

## Changes
- `provider_registry.ml`: `api_key_env` = \"KIMI_API_KEY\" (was \"KIMI_API_KEY_SB\")
- `provider_registry.ml`: `is_available` checks only KIMI_API_KEY
- `provider_kind.ml`: `default_api_key_env Kimi` = \"KIMI_API_KEY\"
- `provider.ml`: `env_names` fallback uses only KIMI_API_KEY

## Verification
- [x] dune build @install passes
- [x] Cross-repo SSOT verified against masc-mcp provider_adapter.ml