### PR TITLE
[codex] Enforce SDK independence boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,18 @@ jobs:
       - name: Run transport drift gate
         run: bash scripts/check-transport-truth.sh
 
+  sdk-independence:
+    name: SDK Independence Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run SDK independence gate
+        run: bash scripts/check-sdk-independence.sh
+
   tag-drift:
     name: Release Tag Drift
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Why this can feel hidden:
 
 ### Codex sandbox cheat sheet
 
-This is **Codex CLI's own sandbox flag**, not MASC keeper Docker sandbox.
+This is **Codex CLI's own sandbox flag**, not a downstream container sandbox.
 
 Use these three levels:
 
@@ -164,7 +164,7 @@ Layer 1: agent_sdk  (lib/)
             +-- lib/*.ml           Context, Hooks, Guardrails, Orchestrator, etc.
 ```
 
-Anything outside this repository — multi-process coordination, repo-wide task queues, dashboards, persistent room state — is the responsibility of an external coordinator, not of OAS. OAS deliberately knows nothing about any specific coordinator.
+Anything outside this repository — multi-process coordination, repo-wide task queues, dashboards, persistent shared state — is the responsibility of an external coordinator, not of OAS. OAS deliberately knows nothing about any specific coordinator.
 
 ### Layer 1: Agent Runtime (`agent_sdk`)
 
@@ -304,8 +304,8 @@ OAS is a single-process, single-Eio-domain agent runtime. The following concerns
 |------|-------|-------------|
 | Worktree / filesystem coordination | External coordinator | Multi-process file locking and git worktree lifecycle are coordinator concerns, not SDK concerns. |
 | MCP transport implementation | `mcp-protocol-sdk` | OAS consumes `mcp_protocol` as an opam dependency. Transport details (NDJSON framing, stdio management) live there. |
-| Operator dashboard / visibility | External coordinator | Real-time agent status, room views, and supervisor dashboards belong to a layer that aggregates across processes. |
-| Repo-level task and room management | External coordinator | Task queues, claim semantics, and room state are coordination-plane concepts that span multiple agents and sessions. |
+| Operator dashboard / visibility | External coordinator | Real-time agent status, workspace views, and supervisor dashboards belong to a layer that aggregates across processes. |
+| Repo-level task and shared-state management | External coordinator | Task queues, claim semantics, and shared workspace state are coordination-plane concepts that span multiple agents and sessions. |
 | Workflow scheduling / SaaS isolation | Embedding application | Cron triggers, tenant isolation, and multi-user access control are problems for the system that embeds OAS. |
 | Long-term persistence / vector storage | Embedding application | Session state, memory backends, and embedding indexes are injected via callbacks, not owned by the SDK. |
 

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -31,7 +31,7 @@ let parse_openai_response_result = Llm_provider.Backend_openai_parse.parse_opena
 (* Wall-clock latency patch. Parser layers (api_anthropic and backend_ollama)
    leave request_latency_ms at 0 as a sentinel because they only see the JSON
    response body; only the transport layer measures wall time. Without this
-   patch, downstream telemetry (dashboard latency panel, model_inference_metrics
+   patch, downstream telemetry (latency panels, model_inference_metrics
    percentiles) treats every turn as zero-latency and filters it out. *)
 let patch_latency (resp : Types.api_response) (latency_ms : int)
     : Types.api_response =

--- a/lib/event_bus.mli
+++ b/lib/event_bus.mli
@@ -233,7 +233,7 @@ type subscription
 
     - [?filter] — event predicate (default: accept all).
     - [?purpose] — free-form label surfaced in {!subscription_stats}
-      (e.g. ["sse_bridge"], ["keeper_turn"], ["eval_collector"]).
+      (e.g. ["sse_bridge"], ["agent_turn"], ["eval_collector"]).
       Does not affect routing.
 
     @since 0.160.0 [?purpose] parameter added. *)

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -44,7 +44,7 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
 
   (* keep_alive: controls how long the model stays loaded in memory after
      the request. Ollama's default is 5 minutes, which causes models to be
-     unloaded between keeper cycles and re-loaded on demand — slow and
+     unloaded between automated cycles and re-loaded on demand — slow and
      eviction-prone when other processes ping different models.
 
      We default to -1 (permanent) so the caller's pinned model stays
@@ -58,7 +58,7 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
      [time.ParseDuration], which requires a unit suffix — [time.ParseDuration "-1"]
      fails with "missing unit in duration". Sending the plain string "-1"
      therefore produces [Invalid request: time: missing unit in duration "-1"]
-     and every keeper turn errors out in <2s.
+     and every automated turn errors out in <2s.
 
      Empirical rationale:
      - 2026-04-11 incident 1: a 35b-a3b model was evicted ~every 30 min

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -32,7 +32,7 @@ let parse_openai_response_result = Backend_openai_parse.parse_openai_response_re
     Reached from the capability-gated drop branches in {!build_request}
     so operators see exactly which sampling field their config was
     trying to send for which model, without the per-request WARN spam
-    that would otherwise fire on every keeper turn. Double-warning on
+    that would otherwise fire on every automated turn. Double-warning on
     a race is harmless and only happens once per key. *)
 let capability_drop_warned : (string * string, unit) Hashtbl.t =
   Hashtbl.create 16
@@ -170,7 +170,7 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
   (* Silent drops of user-supplied sampling params are a debugging
      hazard (GLM review on #830), so emit a ONE-SHOT stderr WARN per
      (model_id, field) combination the first time a drop fires. Per-
-     request WARN would spam — keepers do ~50 requests/minute — hence
+     request WARN would spam under high-throughput agents — hence
      the dedup table. The cell is best-effort: Eio cooperative
      scheduling means two fibers racing [mem_opt]/[replace] can
      double-warn at most once per key, which is harmless. *)

--- a/lib/llm_provider/backend_openai.mli
+++ b/lib/llm_provider/backend_openai.mli
@@ -35,7 +35,7 @@ val build_request :
     {!build_request} and [Api_openai.build_openai_body] so operators
     who set a non-supported field (e.g. [min_p] on a GLM config) see
     exactly which field was stripped without the per-request WARN
-    spam that would otherwise fire on every keeper turn.
+    spam that would otherwise fire on every automated turn.
 
     Best-effort dedup via an internal [Hashtbl]; a race under Eio
     cooperative scheduling double-warns at most once per key, which

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -177,7 +177,7 @@ let glm_capabilities = {
   (* GLM-5.1 API enforces max_tokens <= 40960 at request time; keeping a
      higher value here causes server-side rejection with
      "Invalid request: `max_tokens` must be less than or equal to `40960`".
-     Empirical upper bound observed on 2026-04-12 during keeper unified
+     Empirical upper bound observed on 2026-04-12 during automated
      turns against glm-coding:glm-5.1 and glm:glm-5.1. *)
   max_output_tokens = Some 40_960;
   supports_tools = true;

--- a/lib/llm_provider/cli_common_subprocess.ml
+++ b/lib/llm_provider/cli_common_subprocess.ml
@@ -52,7 +52,7 @@ let last_nonempty_line text =
     writes [s], and closes the writer so the child sees EOF.  Used by
     transports to bypass the argv/envp [ARG_MAX] ceiling (macOS
     ~1 MiB) for large prompts; see
-    {!Transport_claude_code.keeper_isolation_env} and PR fixing OAS
+    {!Transport_claude_code.subprocess_session_isolation_env} and PR fixing OAS
     #1082 for the original symptom.  When [None] the child's stdin
     follows Eio's default (inherits parent). *)
 let run_core ~sw ~(mgr : _ Eio.Process.mgr) ~name ~cwd ~extra_env

--- a/lib/llm_provider/metrics.mli
+++ b/lib/llm_provider/metrics.mli
@@ -39,7 +39,7 @@ val noop : t
     the new value.  The only window where callers observe [noop] is
     for HTTP calls issued *before* the host has run its startup
     [set_global]; install the sink as early in bootstrap as possible
-    (before any keeper/agent traffic) to avoid that gap.
+    (before any automated agent traffic) to avoid that gap.
 
     Intended to be called once at startup from the host application
     (e.g. a downstream consumer installs a Prometheus-backed instance).

--- a/lib/llm_provider/request_priority.mli
+++ b/lib/llm_provider/request_priority.mli
@@ -10,7 +10,7 @@
 type t =
   | Resume        (** P-1: resuming a yielded slot. Higher than Interactive to prevent starvation. *)
   | Interactive   (** P0: user-facing chat, tool calls. *)
-  | Proactive     (** P1: agent turns, board replies. *)
+  | Proactive     (** P1: agent turns, scheduled replies. *)
   | Background    (** P2: heartbeat, status ticks. *)
   | Unspecified   (** Caller did not set priority. Dispatched as Proactive with warning. *)
 [@@deriving show]

--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -138,7 +138,7 @@ let legacy_env_extra_args ~(config : config) =
 (** Threshold at which [build_args] stops passing the prompt as a
     positional argv entry and expects the caller to feed it via
     stdin instead.  macOS [ARG_MAX] is ~1 MiB for the combined argv
-    + envp block; 512 KiB leaves headroom for env vars (keeper
+    + envp block; 512 KiB leaves headroom for env vars (conversation
     context, OAS_* flags) and the other argv entries added after the
     prompt.  Env override [OAS_CLAUDE_PROMPT_ARGV_THRESHOLD] accepts
     an integer byte count for per-host tuning. *)
@@ -433,13 +433,13 @@ let parse_stream_result lines =
     [ANTHROPIC_API_KEY*]: when set in the parent process, [claude -p]
     authenticates as a metered API client (subject to the org's API
     spend limits) rather than using the user's OAuth/subscription
-    session.  MASC / agent integrations that rely on the subscription
+    session.  Agent integrations that rely on the subscription
     tier must not leak API_KEY env to the CLI.  The three names cover
     the canonical variable plus the conventional [_MAIN] / [_WORK]
     split some callers adopt.
 
     [CODEX_COMPANION_SESSION_ID]: scrubbed so our fresh value injected
-    by {!keeper_isolation_env} wins over whatever the parent shell
+    by {!subprocess_session_isolation_env} wins over whatever the parent shell
     inherited.  See that function's doc for the plugin-hook rationale.
     Key order in [Cli_common_subprocess.build_env] is [extras @ base];
     [execve] preserves duplicates and libuv's env parser takes the
@@ -464,7 +464,7 @@ let claude_cli_scrub_env =
     inside a long-lived parent Claude Code session, they share
     [CODEX_COMPANION_SESSION_ID] via env inheritance.  Each transient
     subprocess's SessionEnd therefore tears down the parent session's
-    broker state and jobs — a silent outage vector for any keeper
+    broker state and jobs — a silent outage vector for any automated
     runtime colocated with an interactive Claude Code session.
 
     Injecting a subprocess-unique id short-circuits the match in the
@@ -472,10 +472,10 @@ let claude_cli_scrub_env =
     with the freshly-minted sessionId, and returns without side
     effects.  The hook still runs (we don't disable it); it just
     becomes a no-op for our subprocess. *)
-let keeper_isolation_counter = Atomic.make 0
+let subprocess_session_isolation_counter = Atomic.make 0
 
-let keeper_isolation_env () =
-  let n = Atomic.fetch_and_add keeper_isolation_counter 1 in
+let subprocess_session_isolation_env () =
+  let n = Atomic.fetch_and_add subprocess_session_isolation_counter 1 in
   [ ( "CODEX_COMPANION_SESSION_ID"
     , Printf.sprintf "oas-claude-%d-%d-%f"
         (Unix.getpid ()) n (Unix.gettimeofday ()) )
@@ -485,7 +485,7 @@ let run ~sw ~mgr ~(config : config) ?stdin_content args =
   Cli_common_subprocess.run_collect ~sw ~mgr
     ~name:"claude"
     ~cwd:config.cwd
-    ~extra_env:(keeper_isolation_env ())
+    ~extra_env:(subprocess_session_isolation_env ())
     ~scrub_env:claude_cli_scrub_env
     ?stdin_content
     ?cancel:config.cancel
@@ -516,7 +516,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
         in
         match Cli_common_subprocess.run_stream_lines ~sw ~mgr
                 ~name:"claude" ~cwd:config.cwd
-                ~extra_env:(keeper_isolation_env ())
+                ~extra_env:(subprocess_session_isolation_env ())
                 ~scrub_env:claude_cli_scrub_env
                 ?stdin_content:(stdin_for_prompt prompt)
                 ~on_line ?cancel:config.cancel
@@ -558,7 +558,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
       match Cli_common_subprocess.run_stream_lines ~sw ~mgr
               ~name:"claude"
               ~cwd:config.cwd
-              ~extra_env:(keeper_isolation_env ())
+              ~extra_env:(subprocess_session_isolation_env ())
               ~scrub_env:claude_cli_scrub_env
               ?stdin_content:(stdin_for_prompt prompt)
               ~on_line
@@ -767,8 +767,8 @@ let%test "default: --strict-mcp-config omitted when no MCP config is available" 
     && not (List.mem "--disallowedTools" args))))
 
 let%test "env: OAS_CLAUDE_STRICT_MCP=1 alone no longer implies --strict-mcp-config" =
-  (* OAS_CLAUDE_STRICT_MCP is a downstream intent marker (MASC uses it to
-     gate SessionEnd hooks), not a trigger for Claude CLI flags.  Without
+  (* OAS_CLAUDE_STRICT_MCP is a legacy downstream intent marker, not a
+     trigger for Claude CLI flags.  Without
      a real config path, --strict-mcp-config must NOT be emitted. *)
   with_unset "OAS_CLAUDE_MCP_CONFIG" (fun () ->
   with_env "OAS_CLAUDE_STRICT_MCP" "1" (fun () ->
@@ -799,8 +799,8 @@ let%test "env: DISALLOWED_TOOLS splits on comma" =
     && List.mem "Bash" args
     && List.mem "Write" args)
 
-let%test "keeper_isolation_env injects fresh CODEX_COMPANION_SESSION_ID" =
-  match keeper_isolation_env () with
+let%test "subprocess_session_isolation_env injects fresh CODEX_COMPANION_SESSION_ID" =
+  match subprocess_session_isolation_env () with
   | [ (k, v) ] ->
     k = "CODEX_COMPANION_SESSION_ID"
     && String.length v > 0
@@ -809,9 +809,9 @@ let%test "keeper_isolation_env injects fresh CODEX_COMPANION_SESSION_ID" =
         && String.sub v 0 (String.length prefix) = prefix)
   | _ -> false
 
-let%test "keeper_isolation_env yields a new id per call" =
-  let a = keeper_isolation_env () in
-  let b = keeper_isolation_env () in
+let%test "subprocess_session_isolation_env yields a new id per call" =
+  let a = subprocess_session_isolation_env () in
+  let b = subprocess_session_isolation_env () in
   let v_of = function
     | [ (_, v) ] -> v
     | _ -> ""

--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -869,15 +869,15 @@ let%test "build_args runtime MCP wires HTTP headers" =
       Llm_transport.empty_runtime_mcp_policy with
       servers = [
         Llm_transport.Http_server {
-          name = "masc";
-          url = "http://127.0.0.1:8935/mcp";
+          name = "agent_tools";
+          url = "http://127.0.0.1:9999/mcp";
           headers = [
             ("Authorization", "Bearer tok");
             ("Accept", "application/json, text/event-stream");
           ];
         };
       ];
-      allowed_server_names = ["masc"];
+      allowed_server_names = ["agent_tools"];
     }
   in
   let args =
@@ -885,9 +885,9 @@ let%test "build_args runtime MCP wires HTTP headers" =
       ~runtime_mcp_policy:policy
       ()
   in
-  List.mem "mcp_servers.masc.url=\"http://127.0.0.1:8935/mcp\"" args
+  List.mem "mcp_servers.agent_tools.url=\"http://127.0.0.1:9999/mcp\"" args
   && List.mem
-       "mcp_servers.masc.http_headers={Authorization=\"Bearer tok\",Accept=\"application/json, text/event-stream\"}"
+       "mcp_servers.agent_tools.http_headers={Authorization=\"Bearer tok\",Accept=\"application/json, text/event-stream\"}"
        args
 
 let%test "parse_jsonl_result includes mcp tool call blocks" =

--- a/lib/llm_provider/transport_gemini_cli.ml
+++ b/lib/llm_provider/transport_gemini_cli.ml
@@ -93,7 +93,7 @@ let build_args ~(config : config) ~(req_config : Provider_config.t)
   let prompt = effective_prompt ~prompt ~system_prompt in
   let args = ref [config.gemini_path; "--output-format"; "json"; "-p"; prompt] in
   let add a = args := !args @ a in
-  (* Approval mode: env var wins over [config.yolo] when set, so keeper
+  (* Approval mode: env var wins over [config.yolo] when set, so callers
      can demote a transport from yolo → plan without a code change. *)
   (match Cli_common_env.get "OAS_GEMINI_APPROVAL_MODE" with
    | Some m -> add ["--approval-mode"; m]

--- a/lib/llm_provider/transport_kimi_cli.ml
+++ b/lib/llm_provider/transport_kimi_cli.ml
@@ -300,7 +300,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
   (* When [session_id] is set we track how many non-system messages have
      already been sent so that subsequent turns can transmit only the delta.
      This avoids re-transmitting the entire conversation history on every
-     turn, which is the primary source of token waste in keeper mode. *)
+     turn, which is the primary source of token waste in session-reuse mode. *)
   let previous_msg_count = ref 0 in
 
   let prepare_prompt_and_messages (req : Llm_transport.completion_request) =

--- a/lib/llm_provider/transport_kimi_cli.mli
+++ b/lib/llm_provider/transport_kimi_cli.mli
@@ -44,7 +44,7 @@ type config = {
         Kimi CLI creates that session if absent and resumes it if present.
         The transport then reuses the CLI's on-disk session state and sends
         only the message delta on later turns, which avoids re-transmitting
-        the entire conversation history in keeper mode. Default [None]. *)
+        the entire conversation history in session-reuse mode. Default [None]. *)
 }
 
 (** Sensible defaults: [kimi] in PATH, [kimi-for-coding], no explicit

--- a/lib/tool_index.ml
+++ b/lib/tool_index.ml
@@ -356,31 +356,31 @@ let%test "tokenize korean preserves ascii behavior" =
 
 let%test "korean query retrieves korean-aliased tool" =
   let idx = build [
-    { name = "board_create_post";
-      description = "Create a new post on the board 게시판 글 올리기 작성";
-      group = Some "board"; aliases = [] };
+    { name = "notice_create_post";
+      description = "Create a new notice 게시판 글 올리기 작성";
+      group = Some "notices"; aliases = [] };
     { name = "fs_read_file";
       description = "Read a file from the project 파일 읽기";
       group = Some "filesystem"; aliases = [] };
   ] in
   let results = retrieve_names idx "게시판에 글 올려줘" in
-  List.mem "board_create_post" results
+  List.mem "notice_create_post" results
 
 let%test "korean group co-retrieval" =
   let idx = build [
-    { name = "board_create_post";
+    { name = "notice_create_post";
       description = "Create post 게시판 글 올리기";
-      group = Some "board"; aliases = [] };
-    { name = "board_add_comment";
+      group = Some "notices"; aliases = [] };
+    { name = "notice_add_comment";
       description = "Add comment 게시판 댓글";
-      group = Some "board"; aliases = [] };
+      group = Some "notices"; aliases = [] };
     { name = "fs_read_file";
       description = "Read file 파일 읽기";
       group = None; aliases = [] };
   ] in
   let results = retrieve_names idx "게시판 글" in
-  List.mem "board_create_post" results
-  && List.mem "board_add_comment" results
+  List.mem "notice_create_post" results
+  && List.mem "notice_add_comment" results
 
 (* ── Scoped retrieval tests ──────────────────────── *)
 
@@ -513,13 +513,13 @@ let%test "remove_entries with nonexistent name is no-op" =
 
 let%test "aliases boost retrieval" =
   let idx = build [
-    { name = "board_post"; description = "Create a post on the board";
+    { name = "notice_post"; description = "Create a notice post";
       group = None; aliases = ["게시판"; "글"; "올리기"] };
     { name = "read_file"; description = "Read a file from disk";
       group = None; aliases = [] };
   ] in
   let results = retrieve_names idx "게시판에 글 올려줘" in
-  List.mem "board_post" results
+  List.mem "notice_post" results
 
 let%test "aliases do not interfere when empty" =
   let idx = build [

--- a/lib/tool_input_validation.mli
+++ b/lib/tool_input_validation.mli
@@ -11,7 +11,7 @@
 
 (** A single field-level validation error. *)
 type field_error = {
-  path: string;      (** JSON path, e.g. ["/room"], ["/interval_seconds"] *)
+  path: string;      (** JSON path, e.g. ["/workspace"], ["/interval_seconds"] *)
   expected: string;  (** Expected type or constraint, e.g. ["integer"], ["required"] *)
   actual: string;    (** What was received, e.g. ["string(\"sixty\")"], [{!missing_actual}] *)
 }

--- a/scripts/check-sdk-independence.sh
+++ b/scripts/check-sdk-independence.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Guard OAS against coordinator-specific vocabulary in public/runtime surfaces.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+TARGETS=(lib bin README.md)
+
+patterns=(
+  '\bmasc\b'
+  'masc_'
+  '\bkeeper\b'
+  'keeper_'
+  '\bboard\b'
+  'board_'
+  '\broom\b'
+  'room_'
+)
+
+fail=0
+for pattern in "${patterns[@]}"; do
+  matches="$(rg -n -i -e "$pattern" "${TARGETS[@]}" || true)"
+  if [[ -n "$matches" ]]; then
+    echo "FAIL: coordinator-specific term matched pattern: $pattern" >&2
+    echo "$matches" >&2
+    fail=1
+  fi
+done
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "SDK independence check failed" >&2
+  exit 1
+fi
+
+echo "OK: SDK independence check passed"


### PR DESCRIPTION
## Summary
- add an OAS-owned SDK independence guard for coordinator-specific vocabulary
- wire the guard into CI as SDK Independence Gate
- remove MASC/keeper/board/room vocabulary from OAS runtime/public surfaces and tests

## Validation
- bash scripts/check-sdk-independence.sh
- bash scripts/check-transport-truth.sh
- dune build --root .
- dune runtest --root .
