### PR TITLE
[codex] Throttle local Dune workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,11 @@ examples/   →  사용 예제
 ## Build
 
 ```bash
-dune build --root .          # 빌드
-make test                    # 전체 테스트
+scripts/dune-local.sh build <target>  # 로컬 focused 빌드, lock + 낮은 병렬도
+make test                           # 로컬 throttled 테스트
 ```
+
+Full `dune build @all` / `dune runtest`는 CI 또는 명시적인 수동 검증에서만 실행한다.
 
 ## Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,20 @@
 .PHONY: build test coverage coverage-html coverage-clean
 
 build:
-	dune build
+	scripts/dune-local.sh build
 
 test:
-	dune runtest
+	scripts/dune-local.sh runtest
 
 # Coverage pipeline — generates summary + per-file report
 coverage: coverage-clean
-	BISECT_FILE=$(CURDIR)/bisect dune runtest --instrument-with bisect_ppx --force
+	BISECT_FILE=$(CURDIR)/bisect scripts/dune-local.sh runtest --instrument-with bisect_ppx --force
 	bisect-ppx-report summary --coverage-path=$(CURDIR) --per-file
 	@echo "---"
 	@echo "For HTML report: make coverage-html"
 
 coverage-html: coverage-clean
-	BISECT_FILE=$(CURDIR)/bisect dune runtest --instrument-with bisect_ppx --force
+	BISECT_FILE=$(CURDIR)/bisect scripts/dune-local.sh runtest --instrument-with bisect_ppx --force
 	bisect-ppx-report html --coverage-path=$(CURDIR)
 	@echo "HTML report: _coverage/index.html"
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ opam pin add bisect_ppx git+https://github.com/patricoferris/bisect_ppx.git#5.2 
 opam pin add mcp_protocol "git+${MCP_SDK_URL}#${MCP_SDK_SHA}" --no-action --yes
 
 opam install . --deps-only --with-test --yes
-dune build @all
+scripts/dune-local.sh build @all
 ```
 
 ## Non-interactive CLI transports and MCP defaults
@@ -262,8 +262,12 @@ let guardrails = {
 ## Build and test
 
 ```bash
-dune build @all
-dune runtest
+scripts/dune-local.sh build <target>
+make test
+
+# Full CI parity only when explicitly needed
+scripts/dune-local.sh build @all
+scripts/dune-local.sh runtest
 
 # Coverage report
 make coverage

--- a/scripts/check-local-pins.sh
+++ b/scripts/check-local-pins.sh
@@ -50,7 +50,7 @@ check_pin "mcp_protocol" "$MCP_SDK_SHA" "mcp_protocol"
 if [[ $drift -ne 0 ]]; then
   echo ""
   echo -e "${RED}Pin drift detected.${NC} Local build may behave differently from CI."
-  echo "Run the fix commands above, then: dune clean && dune build"
+  echo "Run the fix commands above, then: dune clean && scripts/dune-local.sh build"
   exit 1
 fi
 

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+lock_path="${DUNE_LOCAL_LOCK:-/tmp/me-dune-local.lock}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/dune-local.sh [dune-subcommand] [args...]
+
+Local Dune wrapper for multi-agent development:
+  - serializes local Dune invocations with a machine-wide lock
+  - defaults local concurrency to DUNE_LOCAL_JOBS, or 2
+  - injects --root <repo-root> unless --root is already present
+
+Set MASC_DUNE_THROTTLE=0 to bypass the local lock.
+Set MASC_DUNE_DRY_RUN=1 to print the command without running it.
+USAGE
+}
+
+args=("$@")
+if [[ "${#args[@]}" -eq 0 ]]; then
+  args=(build)
+fi
+
+case "${args[0]}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+esac
+
+has_root=0
+for arg in "${args[@]}"; do
+  case "$arg" in
+    --root|--root=*)
+      has_root=1
+      break
+      ;;
+  esac
+done
+if [[ -n "${DUNE_ROOT:-}" ]]; then
+  has_root=1
+fi
+
+cmd=(dune)
+if [[ "$has_root" -eq 0 && "${args[0]}" != -* ]]; then
+  cmd+=("${args[0]}" --root "$repo_root")
+  if [[ "${#args[@]}" -gt 1 ]]; then
+    cmd+=("${args[@]:1}")
+  fi
+else
+  cmd+=("${args[@]}")
+fi
+
+if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
+  export DUNE_JOBS="${DUNE_JOBS:-${DUNE_LOCAL_JOBS:-2}}"
+  export DUNE_BUILD_DIR="${DUNE_BUILD_DIR:-$repo_root/_build}"
+fi
+
+printf '[dune-local] DUNE_JOBS=%s DUNE_BUILD_DIR=%s\n' \
+  "${DUNE_JOBS:-auto}" "${DUNE_BUILD_DIR:-_build}" >&2
+printf '[dune-local] command:' >&2
+printf ' %q' "${cmd[@]}" >&2
+printf '\n' >&2
+
+if [[ "${MASC_DUNE_DRY_RUN:-0}" = "1" ]]; then
+  exit 0
+fi
+
+if [[ "${GITHUB_ACTIONS:-}" = "true" || "${MASC_DUNE_THROTTLE:-1}" = "0" ]]; then
+  exec "${cmd[@]}"
+fi
+
+printf '[dune-local] waiting for lock %s\n' "$lock_path" >&2
+if command -v lockf >/dev/null 2>&1; then
+  exec lockf "$lock_path" "${cmd[@]}"
+elif command -v flock >/dev/null 2>&1; then
+  exec flock "$lock_path" "${cmd[@]}"
+else
+  printf '[dune-local] warning: neither lockf nor flock found; running unlocked\n' >&2
+  exec "${cmd[@]}"
+fi

--- a/scripts/sync-version-truth.sh
+++ b/scripts/sync-version-truth.sh
@@ -113,12 +113,12 @@ if ! $apply; then
 fi
 
 if $opam_drift; then
-  info "running: dune build ${opam_file}"
+  info "running: scripts/dune-local.sh build ${opam_file}"
   # stderr intentionally NOT redirected: when dune fails (lock contention,
   # missing deps, syntax error in dune-project), the operator needs the
   # real diagnostic to troubleshoot, not a generic "failed" message.
-  if ! dune build --root . "$opam_file"; then
-    echo "sync-version-truth: 'dune build ${opam_file}' failed" >&2
+  if ! scripts/dune-local.sh build "$opam_file"; then
+    echo "sync-version-truth: 'scripts/dune-local.sh build ${opam_file}' failed" >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary
- add `scripts/dune-local.sh` for local Dune locking and low concurrency
- route Makefile build/test/coverage and version/pin helpers through the wrapper
- update docs to prefer focused local checks and leave full Dune runs to CI/manual parity

## Validation
- `bash -n scripts/dune-local.sh scripts/sync-version-truth.sh scripts/check-local-pins.sh`
- `MASC_DUNE_DRY_RUN=1 scripts/dune-local.sh build @all`
- `MASC_DUNE_DRY_RUN=1 scripts/dune-local.sh runtest`
- `make -n build test coverage`
- `git diff --check`
