### PR TITLE
fix(release): refuse to tag from non-main or stale main

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,10 +6,44 @@ set -euo pipefail
 # Usage:
 #   ./scripts/release.sh          # dry-run (verify only)
 #   ./scripts/release.sh --tag    # verify + create tag + push
+#
+# IMPORTANT: Must run on the post-merge `main` branch.
+# `git tag -a vX.Y.Z` places the tag on the current HEAD. Running this
+# from a feature branch (before the release PR is merged) leaves the
+# tag on a commit that is no longer on `main` after GitHub's rebase
+# merge rewrites the SHA (#1135, #1136). The checks below refuse to
+# run unless `main` is checked out and synced with origin/main.
 
 TAG_MODE=false
 if [[ "${1:-}" == "--tag" ]]; then
   TAG_MODE=true
+fi
+
+# Check -1: running on `main` synced with origin/main.
+# Rationale: tag lands on HEAD, so a non-main HEAD (or a stale main)
+# produces an orphaned tag after PR merge rebases the SHA.
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "ERROR: release.sh must run on 'main', current branch is '$CURRENT_BRANCH'."
+  echo ""
+  echo "PR rebase merge rewrites the release-cut commit SHA. Tagging before"
+  echo "merge leaves the tag on a commit that no longer exists on main."
+  echo ""
+  echo "Fix:"
+  echo "  git checkout main && git pull --ff-only"
+  echo "  scripts/release.sh --tag"
+  exit 1
+fi
+
+git fetch origin main --quiet
+LOCAL_MAIN=$(git rev-parse HEAD)
+ORIGIN_MAIN=$(git rev-parse origin/main)
+if [[ "$LOCAL_MAIN" != "$ORIGIN_MAIN" ]]; then
+  echo "ERROR: local main ($LOCAL_MAIN) is not in sync with origin/main ($ORIGIN_MAIN)."
+  echo "Tag would land on a stale commit."
+  echo ""
+  echo "Fix: git pull --ff-only"
+  exit 1
 fi
 
 # Extract versions from canonical sources


### PR DESCRIPTION
Closes #1136, #1135.

## Why

`scripts/release.sh --tag` was safe in spirit but not in execution. The script calls `git tag -a vX.Y.Z` against the current `HEAD`, so the tag lands on whichever commit happens to be checked out. The historical flow (described in #1136) was to tag **before** merging so the `Release Tag Drift` check would pass, which meant the tag was always placed on a feature-branch commit. GitHub's PR rebase merge then rewrote that commit's SHA, leaving the tag pointing to a commit that is not on the integration branch.

`v0.170.0^{}` = `10a92a4c9737ae4a4b4fdb217e863b2f91cc04c5` while the post-merge integration HEAD moved to `7f79cfa92dd00b2ab10f4f7e5db0a2137e44a8b7`. Same tree, different SHA; every downstream audit or SHA-pin has to reason about that gap.

## Change

Two pre-flight guards added at the top of `scripts/release.sh`:

1. **Branch check.** `git rev-parse --abbrev-ref HEAD` must equal the integration branch. Any other branch (release-cut feature branches, worktree experiments) fails fast with an inline remediation.
2. **Sync check.** After a quiet `git fetch`, local HEAD must equal `origin/<integration>`. Stale-local scenarios (rebase in progress, partial pull) are rejected before any tag is pushed.

Both guards run in the dry-run path as well, so release-cut PR reviewers see the same error as the tag-pushing operator and the two paths cannot diverge.

The implicit flow becomes **merge → switch to integration → pull → tag**, which forces the tag onto the exact post-merge commit SHA. The `Release Tag Drift` CI check is unaffected — it only verifies CHANGELOG entries against existing tags.

## Scope

Script-only change. Version bump and CHANGELOG for 0.170.8 deliberately land in a follow-up PR that is merged under this new contract, so the first tag produced under the new contract is the one that proves it. Shipping the bump in this PR would re-introduce the old chicken-and-egg (CHANGELOG entry present, tag missing → Drift CI red before the script can even be merged).

## Verification

```
$ git rev-parse --abbrev-ref HEAD
fix/release-post-merge-only

$ bash scripts/release.sh
ERROR: release.sh must run on 'main', current branch is 'fix/release-post-merge-only'.

PR rebase merge rewrites the release-cut commit SHA. Tagging before
merge leaves the tag on a commit that no longer exists on main.

Fix:
  git checkout main && git pull --ff-only
  scripts/release.sh --tag
```

On a clean, synced integration branch the existing dune / opam / sdk_version / CHANGELOG / working-tree checks run unchanged.

## Follow-up

`#1135` is a duplicate of `#1136` with escape-broken rendering; it is closed by this PR's `Closes` keyword.
