### PR TITLE
ci: force EIO_BACKEND=posix for bisect Coverage step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,14 @@ jobs:
         if: matrix.ocaml-compiler == '5.4.1'
         env:
           BISECT_ENABLE: "yes"
+          # Force Eio's posix/epoll backend so bisect-instrumented tests do
+          # not initialise io_uring rings. GitHub-hosted runners cap
+          # RLIMIT_MEMLOCK at 8 MiB for unprivileged users and
+          # `ulimit -l unlimited` is silently denied, so each extra
+          # io_uring_queue_init under bisect eventually returns ENOMEM and
+          # fails the step.
+          EIO_BACKEND: "posix"
         run: |
-          # Raise memlock limit for io_uring — bisect-instrumented tests
-          # create more io_uring instances, exhausting the default limit.
-          ulimit -l unlimited || true
           opam exec -- dune clean
           opam exec -- dune runtest --force
           COVERAGE=$(opam exec -- bisect-ppx-report summary 2>/dev/null | grep -oP '\d+\.\d+(?=%)' | head -1 || echo "0")


### PR DESCRIPTION
Closes #1166.

## Why

`Build & Test (OCaml 5.4.1)` → `Coverage report` step fails at exit 1 even when every alcotest case reports `[OK]`. The log always ends with a burst of:

```
[exception] Unix.Unix_error(Unix.ENOMEM, "io_uring_queue_init", "")
...
Test Successful in 6.183s. 12 tests run.
##[error]Process completed with exit code 1.
```

Bisect-instrumented `dune runtest` spins up many `Eio_main.run` calls in sequence. Each one opens an io_uring ring, which pins a small amount of memory via `RLIMIT_MEMLOCK`. GitHub-hosted runners cap that limit at ~8 MiB for unprivileged users, and the existing workaround (`ulimit -l unlimited || true`) is silently denied because the runner's bash has no `CAP_SYS_RESOURCE`. After enough ring initialisations the next `io_uring_queue_init` returns `ENOMEM`, and the failing test binary flips the step to nonzero even after alcotest has already reported success.

## Change

Single env var on the Coverage step:

```yaml
env:
  BISECT_ENABLE: "yes"
  EIO_BACKEND: "posix"
```

`Eio_main.run` picks its backend based on this variable; `posix` uses epoll and standard syscalls so no io_uring ring is allocated at all. The `ulimit -l` line is removed (it never worked).

## Why posix is safe here

`rg -n 'io_uring|Eio_linux|submit_sqe|Linux\.' lib/ test/` on the OAS tree returns only two explanatory comments and zero io_uring-specific call sites. The suite is scheduler-agnostic — `Eio.Path.save`, `Eio.Flow`, timers, file rename, etc. all work identically on the posix backend.

## Scope

- `.github/workflows/ci.yml` only.
- Default backend is unchanged for the regular `Test` step (non-bisect path still exercises io_uring on Linux).
- The `test_atomic_write_race` bisect gate added in #1165 is kept as-is in this PR; once CI is green for a few runs it can be lifted in a follow-up so Coverage exercises that test too.

## Verification

- Local `dune runtest` unaffected (no env change).
- Post-merge signal: #1165's Coverage failures under bisect should stop recurring. If they do, root cause is not memlock and this PR should be reverted.

## Related

- #1165 — atomic-write rename race fix whose Coverage runs surfaced the ENOMEM pattern.
- masc-mcp #9869 — adjacent keeper nofile ulimit work (unrelated sandbox resource).
