### PR TITLE
docs(changelog): backfill entries for 0.170.1 through 0.170.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,109 @@ original tag dates. `0.100.4` was never tagged or released.
   indirectly via the existing `test_checkpoint_store`,
   `test_a2a_task_store`, and `test_memory_file_backend` suites (#1165).
 
+## [0.170.6] - 2026-04-24
+
+### Changed
+
+- **SDK independence boundary now enforced in CI.** The `SDK Independence
+  Gate` job rejects PRs that reintroduce cross-SDK imports, keeping
+  `agent_sdk` consumable without pulling downstream-specific modules
+  (#1160).
+
+## [0.170.5] - 2026-04-24
+
+### Added
+
+- **Truth-layer evidence primitives.** New types and helpers for
+  recording evidence alongside LLM outputs so callers can persist
+  rationale and citations without bespoke serialisers (#1158).
+
+### Fixed
+
+- **KIMI direct API aligned with `KIMI_API_KEY` only.** The provider
+  previously fell back across several env var candidates, so setting
+  the wrong one silently routed traffic to the default key. Routing is
+  now keyed exclusively on `KIMI_API_KEY` (#1159).
+- **kimi CLI session reuse matched to actual CLI contract.** Session
+  IDs are threaded through follow-up turns instead of being dropped
+  after the first turn (#1157).
+- **HTTP MCP reconnect state preserved across transport restarts** —
+  the client no longer loses its resume token when the underlying
+  socket is replaced (#1156).
+
+## [0.170.4] - 2026-04-23
+
+### Fixed
+
+- **`llm_provider` parses usage fields from kimi-cli JSONL output.**
+  Token counts now surface on KIMI CLI responses; previously
+  `prompt_tokens` and `completion_tokens` were dropped (#1155).
+
+### Changed
+
+- **MCP fixture names genericised in transport tests** so new
+  providers can reuse the harness without name collisions (#1154).
+
+## [0.170.3] - 2026-04-22
+
+### Added
+
+- **Native timeout handling for `Agent.run`.** Uses Eio's clock
+  primitives instead of callback-based workarounds, so timeouts
+  compose with the surrounding switch (#1006, #1150).
+- **Structured replay metadata in checkpoints.** Replay flows persist
+  a typed payload instead of free-form strings, enabling downstream
+  tooling to reason about replay provenance (#1149).
+- **Structured `network_error_kind` on `NetworkError`.** The
+  `llm_provider` error surface classifies transport failures
+  (DNS / connect / read / idle) so callers can pick a retry policy
+  without string-matching error messages (#1147).
+
+### Fixed
+
+- **HTTP client drains response body to prevent CLOSE\_WAIT
+  accumulation.** Long-lived cascades had been leaking sockets into
+  CLOSE\_WAIT, eventually exhausting the local port pool (#965,
+  #1148).
+- **Pipeline message constructor drift resolved** — stages no longer
+  produce messages that downstream stages cannot decode after the
+  6-stage split (#1151).
+
+### Changed
+
+- **Pipeline split by stage (prepare / route / retry).** `pipeline.ml`
+  was broken up along the three stages that were already documented in
+  the architecture notes, reducing module size and clarifying
+  responsibilities (#1146, #1152).
+
+## [0.170.2] - 2026-04-22
+
+### Fixed
+
+- **Raw trace generation now flushes gracefully on timeout.** When the
+  surrounding operation cancelled, the trace backend used to lose its
+  in-flight buffer because shutdown raced with cancellation; a typed
+  flush hook now drains before the backend tears down (#1141).
+
+## [0.170.1] - 2026-04-22
+
+### Added
+
+- **`NotFound` variant on `api_error` for HTTP 404.** Callers can now
+  distinguish 404 from generic HTTP failures without string-matching
+  the status code inside error messages (#1139).
+
+### Changed
+
+- **`Otel_tracer` span records made immutable** so they are safe to
+  share across Eio fibers without an owning-fiber lock (#1138).
+
+### Fixed
+
+- **Streamed telemetry populated via non-HTTP transports.** Previously
+  only HTTP-backed streams emitted telemetry; CLI and in-process
+  transports now produce the same span shape (#1140).
+
 ## [0.170.0] - 2026-04-21
 
 ### Added


### PR DESCRIPTION
Closes #1143.

## Why

`scripts/release.sh` asserts every `v<X.Y.Z>` tag has a matching `## [X.Y.Z]` section in `CHANGELOG.md`. Six tags between `v0.170.0` and `v0.170.7` were cut without that section, so `release.sh` failed with:

```
ERROR: No CHANGELOG.md entry found for [0.170.1].
```

This patch retroactively fills the gap so `Release Tag Drift` CI and the operator flow stay aligned.

## What goes where

Entries reconstructed from `git log v0.170.<prev>..v0.170.<this>` and the merged PRs in each range. Grouped by the existing Added / Changed / Fixed taxonomy so adjacent sections render uniformly.

| Version | Summary |
|---------|---------|
| 0.170.1 (2026-04-22) | `NotFound` variant on `api_error`, streamed telemetry via non-HTTP transports, immutable `Otel_tracer` span records (#1138, #1139, #1140). |
| 0.170.2 (2026-04-22) | Graceful flush for raw trace generation on timeout (#1141). |
| 0.170.3 (2026-04-22) | Native `Agent.run` timeouts, structured replay metadata, structured `network_error_kind`, HTTP CLOSE\_WAIT drain fix, pipeline stage split (prepare / route / retry) (#1006, #1146, #1147, #1148, #1149, #1150, #1151, #1152). |
| 0.170.4 (2026-04-23) | kimi-cli usage-field parsing, MCP fixture names genericised (#1154, #1155). |
| 0.170.5 (2026-04-24) | Truth-layer evidence primitives, HTTP MCP reconnect state preserved across restarts, kimi CLI session reuse matched to contract, KIMI direct API keyed only on `KIMI_API_KEY` (#1156, #1157, #1158, #1159). |
| 0.170.6 (2026-04-24) | SDK independence boundary enforced in CI (#1160). |

## Scope

- `CHANGELOG.md` only (+103 / -0). No code / workflow / opam changes.
- Dates taken from tag commit dates in `git log v0.170.<N>`.

## Verification

- `rg '^## \[' CHANGELOG.md` should now list `[0.170.8]` → `[0.170.0]` contiguously (no gaps).
- `scripts/check-doc-truth.sh` (if run) stays green for these versions.
- `scripts/release.sh` on a hypothetical re-tag of any 0.170.x would no longer trip the changelog gate for these versions.

## Related

- #1143 — the issue this PR closes.
- #1167, #1169 — CHANGELOG entries for 0.170.7 and 0.170.8 shipped alongside their respective version bumps; this PR only covers the older backfill gap.
- #1168 — the new `release.sh` pre-flight guards that made the changelog-tag pairing contract enforceable going forward.
