### PR TITLE
[codex] fix LLM pricing and stream model labels

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -92,6 +92,9 @@ let patch_telemetry (resp : Types.api_response) ~(config : Provider_config.t)
     (latency_ms : int) : Types.api_response =
   let pk = Some config.kind in
   let re = reasoning_effort_of_config config in
+  let model =
+    if String.trim resp.model = "" then config.model_id else resp.model
+  in
   let base_caps = match config.kind with
   | Ollama -> Capabilities.ollama_capabilities
   | Anthropic -> Capabilities.anthropic_capabilities
@@ -127,7 +130,7 @@ let patch_telemetry (resp : Types.api_response) ~(config : Provider_config.t)
         provider_internal_action_count = None;
       }
   in
-  { resp with telemetry }
+  { resp with model; telemetry }
 
 (** Internal helper: canonical provider name for metric labels.
     Kept in sync with the log tag used by the [WARN Complete] line. *)
@@ -1132,6 +1135,18 @@ let%test "patch_telemetry creates telemetry when None" =
               && t.reasoning_effort = None
               && t.provider_internal_action_count = None
   | None -> false
+
+let%test "patch_telemetry fills blank response model" =
+  let config =
+    Provider_config.make ~kind:OpenAI_compat ~model_id:"gpt-5.4-mini"
+      ~base_url:"https://api.openai.com" ()
+  in
+  let resp = {
+    Types.id = "test"; model = ""; stop_reason = Types.EndTurn;
+    content = []; usage = None; telemetry = None;
+  } in
+  let patched = patch_telemetry resp ~config 100 in
+  patched.model = "gpt-5.4-mini"
 
 let%test "reasoning_effort_of_config Ollama default is none" =
   let config = Provider_config.make ~kind:Ollama ~model_id:"m"

--- a/lib/llm_provider/pricing.ml
+++ b/lib/llm_provider/pricing.ml
@@ -25,8 +25,10 @@ let string_contains ~needle haystack =
 let pricing_for_model_opt model_id =
   let normalized = String.lowercase_ascii (String.trim model_id) in
   (* Anthropic cache pricing: write = 1.25x input, read = 0.1x input.
-     OpenAI/local: no cache pricing (multipliers are 1.0 for no-op). *)
+     Newer OpenAI text models expose cached input at 0.1x input.
+     Local/free models keep no-op cache multipliers. *)
   let anthropic_cache = (1.25, 0.1) in
+  let openai_cached_input = (1.0, 0.1) in
   let no_cache = (1.0, 1.0) in
   let result =
     if string_contains ~needle:"opus-4-6" normalized then
@@ -41,6 +43,19 @@ let pricing_for_model_opt model_id =
       Some ((0.8, 4.0), anthropic_cache)
     else if string_contains ~needle:"claude-3-7-sonnet" normalized then
       Some ((3.0, 15.0), anthropic_cache)
+    (* OpenAI API text-token pricing, confirmed from official model docs
+       2026-04-25. GPT-5.3-Codex-Spark is intentionally not covered here:
+       its Codex rate card labels it research preview with non-final rates. *)
+    else if string_contains ~needle:"gpt-5.3-codex-spark" normalized then
+      None
+    else if string_contains ~needle:"gpt-5.4-mini" normalized then
+      Some ((0.75, 4.5), openai_cached_input)
+    else if string_contains ~needle:"gpt-5.4" normalized then
+      Some ((2.5, 15.0), openai_cached_input)
+    else if string_contains ~needle:"gpt-5.3-codex" normalized then
+      Some ((1.75, 14.0), openai_cached_input)
+    else if string_contains ~needle:"gpt-5.2" normalized then
+      Some ((1.75, 14.0), openai_cached_input)
     else if string_contains ~needle:"gpt-4o-mini" normalized then
       Some ((0.15, 0.6), no_cache)
     else if string_contains ~needle:"gpt-4o" normalized then
@@ -214,6 +229,34 @@ let%test "pricing gpt-4o-mini" =
   && close_enough p.output_per_million 0.6
   && close_enough p.cache_write_multiplier 1.0
   && close_enough p.cache_read_multiplier 1.0
+
+let%test "pricing gpt-5.4-mini" =
+  let p = pricing_for_model "gpt-5.4-mini" in
+  close_enough p.input_per_million 0.75
+  && close_enough p.output_per_million 4.5
+  && close_enough p.cache_write_multiplier 1.0
+  && close_enough p.cache_read_multiplier 0.1
+
+let%test "pricing gpt-5.4" =
+  let p = pricing_for_model "gpt-5.4" in
+  close_enough p.input_per_million 2.5
+  && close_enough p.output_per_million 15.0
+  && close_enough p.cache_read_multiplier 0.1
+
+let%test "pricing gpt-5.3-codex" =
+  let p = pricing_for_model "gpt-5.3-codex" in
+  close_enough p.input_per_million 1.75
+  && close_enough p.output_per_million 14.0
+  && close_enough p.cache_read_multiplier 0.1
+
+let%test "pricing gpt-5.2" =
+  let p = pricing_for_model "gpt-5.2" in
+  close_enough p.input_per_million 1.75
+  && close_enough p.output_per_million 14.0
+  && close_enough p.cache_read_multiplier 0.1
+
+let%test "pricing gpt-5.3-codex-spark remains unknown" =
+  pricing_for_model_opt "gpt-5.3-codex-spark" = None
 
 let%test "pricing gpt-4o (not mini)" =
   let p = pricing_for_model "gpt-4o" in


### PR DESCRIPTION
## Summary
- add pricing entries for current GPT-5.4/GPT-5.3-Codex/GPT-5.2 models from official OpenAI docs
- keep GPT-5.3-Codex-Spark unknown because the official Codex rate card marks research-preview pricing as non-final
- fill blank streamed response.model from configured model_id in patch_telemetry

## Validation
- env DUNE_LOCAL_LOCK=/tmp/oas-pricing-stream-model-20260425.lock scripts/dune-local.sh runtest lib/llm_provider
- git diff --check

## Evidence
- GPT-5.4 docs: https://developers.openai.com/api/docs/models/gpt-5.4
- GPT-5.4 mini docs: https://developers.openai.com/api/docs/models/gpt-5.4-mini/
- GPT-5.3-Codex docs: https://developers.openai.com/api/docs/models/gpt-5.3-codex
- GPT-5.2 docs: https://developers.openai.com/api/docs/models/gpt-5.2
- Codex rate card: https://help.openai.com/en/articles/20001106-codex-rate-card
- Checked 2026-04-25 KST