### PR TITLE
fix(usage): keep api usage per response

### DIFF
--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -439,6 +439,23 @@ let%test "parse_ollama_response populates timings from eval_count/eval_duration"
            | None -> false)
      | _ -> false)
 
+let%test "parse_ollama_response maps prompt/eval counts to usage" =
+  let json =
+    {|{"model":"qwen3.5:35b-a3b-nvfp4","done":true,"done_reason":"stop",
+       "message":{"role":"assistant","content":"hi"},
+       "prompt_eval_count":17,"eval_count":23}|}
+  in
+  match parse_ollama_response json with
+  | Error _ -> false
+  | Ok resp ->
+    (match resp.usage with
+     | Some usage ->
+       usage.input_tokens = 17
+       && usage.output_tokens = 23
+       && usage.cache_creation_input_tokens = 0
+       && usage.cache_read_input_tokens = 0
+     | None -> false)
+
 let%test "parse_ollama_response guards zero eval_duration" =
   let json =
     {|{"model":"qwen3.5:35b-a3b-nvfp4","done":true,"done_reason":"stop",

--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -231,18 +231,36 @@ let build_args ~(config : config) ~(req_config : Provider_config.t)
 
 (* ── JSON parsing ────────────────────────────────────── *)
 
+(** Claude Code reports per-response usage for normal turns, but older
+    fleet data has shown impossible session-scale counters leaking through
+    this field. Keep [api_usage] as single-response telemetry by dropping
+    values above Claude Code's declared 1M input window. *)
+let claude_code_max_single_response_input_tokens = 1_000_000
+
+let plausible_single_response_usage (u : Types.api_usage) =
+  u.input_tokens <= claude_code_max_single_response_input_tokens
+
 (** Parse the [usage] object from a result or assistant message. *)
 let parse_usage json =
   let open Yojson.Safe.Util in
   match json |> member "usage" with
   | `Assoc _ as u ->
-    Some { Types.input_tokens = Cli_common_json.member_int "input_tokens" u;
-           output_tokens = Cli_common_json.member_int "output_tokens" u;
-           cache_creation_input_tokens =
-             Cli_common_json.member_int "cache_creation_input_tokens" u;
-           cache_read_input_tokens =
-             Cli_common_json.member_int "cache_read_input_tokens" u;
-           cost_usd = None }
+    let usage =
+      { Types.input_tokens = Cli_common_json.member_int "input_tokens" u;
+        output_tokens = Cli_common_json.member_int "output_tokens" u;
+        cache_creation_input_tokens =
+          Cli_common_json.member_int "cache_creation_input_tokens" u;
+        cache_read_input_tokens =
+          Cli_common_json.member_int "cache_read_input_tokens" u;
+        cost_usd = None }
+    in
+    if plausible_single_response_usage usage then Some usage
+    else begin
+      Eio.traceln
+        "[warn] claude_code usage dropped: input_tokens=%d exceeds single-response ceiling=%d"
+        usage.input_tokens claude_code_max_single_response_input_tokens;
+      None
+    end
   | _ -> None
 
 let parse_stop_reason s = Types.stop_reason_of_string s
@@ -584,6 +602,14 @@ let%test "parse_json_result success" =
     resp.model = "claude-sonnet-4"
     && resp.content = [Types.Text "hello world"]
     && resp.stop_reason = Types.EndTurn
+  | Error _ -> false
+
+let%test "parse_json_result drops impossible cumulative usage" =
+  let json =
+    {|{"type":"result","subtype":"success","is_error":false,"result":"hello","model":"claude-sonnet-4","stop_reason":"end_turn","session_id":"s1","usage":{"input_tokens":3690186,"output_tokens":42}}|}
+  in
+  match parse_json_result json with
+  | Ok resp -> resp.usage = None
   | Error _ -> false
 
 let%test "parse_json_result error" =

--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -13,6 +13,10 @@
     [agent_message] items become {!Types.Text} blocks in the aggregate
     response.  [command_execution] items are Codex's internal shell tool
     — transparent to the outer agent, tracked via [Eio.traceln] only.
+    The CLI may print raw usage counters, but this transport does not
+    surface them as {!Types.api_usage}: Codex CLI is declared
+    [emits_usage_tokens = false], and observed counters can be cumulative
+    across the CLI thread instead of a single OAS response.
 
     @since 0.133.0 *)
 
@@ -326,7 +330,9 @@ let build_args ~(config : config) ~(req_config : Provider_config.t)
 
 (* ── JSONL envelope parsing ──────────────────────────── *)
 
-(** Extract usage from a [turn.completed] envelope. *)
+(** Extract raw usage from a [turn.completed] envelope. The transport keeps
+    this private and does not put it on [api_response.usage] because Codex
+    CLI counters are not a stable per-response contract. *)
 let parse_usage json =
   let open Yojson.Safe.Util in
   match json |> member "usage" with
@@ -425,20 +431,20 @@ let events_of_line_with_state (state : stream_state) line =
         Types.ContentBlockStop { index = tool_use_index } :: tool_result_events
       else []  (* command_execution, etc. — no OAS mapping. *)
     | "turn.completed" ->
-      let usage = parse_usage json in
-      [Types.MessageDelta { stop_reason = Some Types.EndTurn; usage };
+      let _raw_usage = parse_usage json in
+      [Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None };
        Types.MessageStop]
     | _ -> []
   with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> []
 
 (** Aggregate JSONL envelopes into an [api_response].  Only
-    [agent_message] text contributes to [content]; the terminal
-    [turn.completed] supplies [usage]; [thread.started] supplies [id].
+    [agent_message] text contributes to [content]; [thread.started]
+    supplies [id]. Raw [turn.completed.usage] is intentionally ignored
+    because Codex CLI usage is not a stable per-response contract.
     [command_execution] items are counted as provider-native internal
     actions rather than surfaced as OAS tool calls. *)
 let parse_jsonl_result ?(model_id = "codex") lines =
   let thread_id = ref "" in
-  let usage = ref None in
   let provider_internal_action_count = ref 0 in
   List.iter (fun line ->
     try
@@ -454,7 +460,8 @@ let parse_jsonl_result ?(model_id = "codex") lines =
            incr provider_internal_action_count
          | _ -> ())
       | "turn.completed" ->
-        usage := parse_usage json
+        let _raw_usage = parse_usage json in
+        ()
       | _ -> ()
     with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ()
   ) lines;
@@ -484,7 +491,7 @@ let parse_jsonl_result ?(model_id = "codex") lines =
          model = model_id;
          stop_reason = Types.EndTurn;
          content;
-         usage = !usage;
+         usage = None;
          telemetry }
 
 (* ── Transport constructor ───────────────────────────── *)
@@ -679,7 +686,7 @@ let%test "build_args uses stdin sentinel when prompt is too large" =
   not (List.mem big args)
   && List.nth args (List.length args - 1) = "-"
 
-let%test "parse_jsonl_result extracts text + usage + thread_id" =
+let%test "parse_jsonl_result extracts text + thread_id and suppresses usage" =
   let lines = [
     {|{"type":"thread.started","thread_id":"abc-123"}|};
     {|{"type":"turn.started"}|};
@@ -691,11 +698,7 @@ let%test "parse_jsonl_result extracts text + usage + thread_id" =
     resp.id = "abc-123"
     && resp.content = [Types.Text "hi"]
     && resp.stop_reason = Types.EndTurn
-    && (match resp.usage with
-        | Some u -> u.input_tokens = 100
-                 && u.output_tokens = 3
-                 && u.cache_read_input_tokens = 5
-        | None -> false)
+    && resp.usage = None
   | Error _ -> false
 
 let%test "parse_jsonl_result aggregates multiple agent_messages" =
@@ -775,7 +778,7 @@ let%test "events_of_line turn.completed → MessageDelta+Stop" =
   let state = create_stream_state () in
   let line = {|{"type":"turn.completed","usage":{"input_tokens":10,"cached_input_tokens":0,"output_tokens":5}}|} in
   (match events_of_line_with_state state line with
-   | [Types.MessageDelta { stop_reason = Some Types.EndTurn; _ };
+   | [Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None };
       Types.MessageStop] -> true
    | _ -> false)
 

--- a/lib/llm_provider/transport_codex_cli.mli
+++ b/lib/llm_provider/transport_codex_cli.mli
@@ -1,8 +1,10 @@
 (** Codex CLI non-interactive transport.
 
     Implements {!Llm_transport.t} by spawning [codex exec] subprocesses.
-    Codex outputs raw text (not JSON). Token usage is extracted from
-    the trailing output lines when available.
+    Codex outputs JSONL envelopes. Text and tool events are projected into
+    OAS response/content events; raw CLI usage counters are intentionally
+    not surfaced because this provider is declared [emits_usage_tokens=false]
+    and the counters can be cumulative rather than per-response.
 
     @since 0.133.0
 

--- a/lib/llm_provider/transport_kimi_cli.ml
+++ b/lib/llm_provider/transport_kimi_cli.ml
@@ -199,7 +199,10 @@ let parse_jsonl_result ~model_id lines =
          model = response_model_of_lines ~model_id lines;
          stop_reason = Types.EndTurn;
          content;
-         usage = usage_of_lines lines;
+         (* Kimi CLI is declared [emits_usage_tokens=false]. If the CLI
+            prints a usage object, do not promote it to [api_usage] unless
+            the provider contract becomes explicitly per-response. *)
+         usage = None;
          telemetry = None }
 
 (* ── Stream events ───────────────────────────────────── *)
@@ -553,16 +556,13 @@ let%test "usage_of_lines finds usage across lines" =
   | Some u -> u.input_tokens = 1 && u.output_tokens = 2
   | None -> false
 
-let%test "parse_jsonl_result includes usage when present" =
+let%test "parse_jsonl_result suppresses CLI usage when present" =
   let lines = [
     {|{"role":"assistant","content":"hello"}|};
     {|{"usage":{"input_tokens":10,"output_tokens":20}}|};
   ] in
   match parse_jsonl_result ~model_id:"kimi-for-coding" lines with
-  | Ok resp ->
-    (match resp.usage with
-     | Some u -> u.input_tokens = 10 && u.output_tokens = 20
-     | None -> false)
+  | Ok resp -> resp.usage = None
   | Error _ -> false
 
 let%test "parse_jsonl_result keeps None when usage absent" =

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -118,6 +118,8 @@ type stop_reason =
 
 val stop_reason_of_string : string -> stop_reason
 
+(** API usage from a single provider response. Accumulated multi-call usage
+    belongs in agent-level usage stats. *)
 type api_usage = {
   input_tokens: int;
   output_tokens: int;

--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -175,10 +175,11 @@ let validation_feedback_message ~summary ~error_msg =
 
     [max_retries] defaults to 2 (so up to 3 total attempts).
     [on_validation_error] is called on each retry for observability. *)
-(** Result of [extract_with_retry] — includes total usage across all attempts. *)
+(** Result of [extract_with_retry] — includes accumulated usage across all
+    attempts. [api_usage] stays reserved for a single provider response. *)
 type 'a retry_result = {
   value: 'a;
-  total_usage: api_usage option;
+  total_usage: usage_stats;
   attempts: int;
 }
 
@@ -188,23 +189,23 @@ let extract_with_retry ~sw ~net ?base_url ?provider ?clock
     prompt : ('a retry_result, Error.sdk_error) result =
   ignore clock;
   let base_url = Option.value ~default:Api.default_base_url base_url in
-  let add_usage acc resp_usage =
-    match acc, resp_usage with
-    | None, u -> u
-    | Some _, None -> acc
-    | Some a, Some u ->
-      Some { input_tokens = a.input_tokens + u.input_tokens;
-             output_tokens = a.output_tokens + u.output_tokens;
-             cache_creation_input_tokens =
-               a.cache_creation_input_tokens + u.cache_creation_input_tokens;
-             cache_read_input_tokens =
-               a.cache_read_input_tokens + u.cache_read_input_tokens;
-             cost_usd =
-               (match a.cost_usd, u.cost_usd with
-                | Some left, Some right -> Some (left +. right)
-                | Some left, None -> Some left
-                | None, Some right -> Some right
-                | None, None -> None) }
+  let add_retry_usage acc resp_usage =
+    match resp_usage with
+    | None -> acc
+    | Some u ->
+      {
+        total_input_tokens = acc.total_input_tokens + u.input_tokens;
+        total_output_tokens = acc.total_output_tokens + u.output_tokens;
+        total_cache_creation_input_tokens =
+          acc.total_cache_creation_input_tokens
+          + u.cache_creation_input_tokens;
+        total_cache_read_input_tokens =
+          acc.total_cache_read_input_tokens + u.cache_read_input_tokens;
+        api_calls = acc.api_calls + 1;
+        estimated_cost_usd =
+          acc.estimated_cost_usd
+          +. Option.value ~default:0.0 u.cost_usd;
+      }
   in
   let initial_message =
     { role = User; content = [Text prompt]; name = None; tool_call_id = None ; metadata = []}
@@ -225,7 +226,7 @@ let extract_with_retry ~sw ~net ?base_url ?provider ?clock
                 ~messages ~tools:[] () with
         | Error e -> Error (sdk_error_of_http_error e)
         | Ok response ->
-            let total = add_usage acc_usage response.usage in
+            let total = add_retry_usage acc_usage response.usage in
             match extract_text_json ~schema response with
             | Ok v -> Ok { value = v; total_usage = total; attempts = n + 1 }
             | Error e ->
@@ -269,7 +270,7 @@ let extract_with_retry ~sw ~net ?base_url ?provider ?clock
                  | Tool_retry_policy.No_retry -> Error e)
       in
       let initial_messages = [ initial_message ] in
-      attempt 0 None initial_messages
+      attempt 0 empty_usage initial_messages
 
 (** Extract structured output with SSE streaming.
     Like [extract] but streams via {!Llm_provider.Complete.complete_stream}. *)

--- a/lib/structured.mli
+++ b/lib/structured.mli
@@ -56,7 +56,7 @@ val run_structured :
 
 type 'a retry_result = {
   value: 'a;
-  total_usage: api_usage option;
+  total_usage: usage_stats;
   attempts: int;
 }
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -148,7 +148,8 @@ let default_config = {
   exit_condition = None;
 }
 
-(* Usage tracking *)
+(** Usage tracking accumulated across provider calls. Per-response usage stays
+    in [Llm_provider.Types.api_usage]. *)
 type usage_stats = {
   total_input_tokens: int;
   total_output_tokens: int;

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -75,7 +75,8 @@ type agent_config = {
 
 val default_config : agent_config
 
-(** Usage tracking *)
+(** Usage tracking accumulated across provider calls. Per-response usage stays
+    in {!Llm_provider.Types.api_usage}. *)
 type usage_stats = {
   total_input_tokens: int;
   total_output_tokens: int;

--- a/test/test_coverage_hotspots_srt.ml
+++ b/test/test_coverage_hotspots_srt.ml
@@ -454,11 +454,9 @@ let test_structured_extract_with_retry_success () =
         check int "age" 41 age;
         check int "attempts" 2 result.attempts;
         check int "validation callback count" 1 (List.length !callbacks);
-        (match result.total_usage with
-        | Some usage ->
-            check int "input tokens summed" 18 usage.input_tokens;
-            check int "output tokens summed" 8 usage.output_tokens
-        | None -> fail "expected accumulated usage");
+        check int "input tokens summed" 18 result.total_usage.total_input_tokens;
+        check int "output tokens summed" 8 result.total_usage.total_output_tokens;
+        check int "api calls counted" 2 result.total_usage.api_calls;
         Eio.Switch.fail sw Exit
     | Error err -> fail (Error.to_string err)
   with Exit -> ()

--- a/test/test_structured_deep.ml
+++ b/test/test_structured_deep.ml
@@ -313,34 +313,37 @@ let test_extract_deeply_nested_input () =
 let test_retry_result_type () =
   let result : string Structured.retry_result = {
     value = "test";
-    total_usage = Some {
-      input_tokens = 100;
-      output_tokens = 50;
-      cache_creation_input_tokens = 10;
-      cache_read_input_tokens = 5;
-      cost_usd = None
+    total_usage = {
+      total_input_tokens = 100;
+      total_output_tokens = 50;
+      total_cache_creation_input_tokens = 10;
+      total_cache_read_input_tokens = 5;
+      api_calls = 2;
+      estimated_cost_usd = 0.0;
     };
     attempts = 2;
   } in
   Alcotest.(check string) "value" "test" result.value;
   Alcotest.(check int) "attempts" 2 result.attempts;
-  (match result.total_usage with
-   | Some u ->
-     Alcotest.(check int) "input_tokens" 100 u.input_tokens;
-     Alcotest.(check int) "output_tokens" 50 u.output_tokens;
-     Alcotest.(check int) "cache_creation" 10 u.cache_creation_input_tokens;
-     Alcotest.(check int) "cache_read" 5 u.cache_read_input_tokens
-   | None -> Alcotest.fail "expected Some usage")
+  Alcotest.(check int) "input_tokens" 100
+    result.total_usage.total_input_tokens;
+  Alcotest.(check int) "output_tokens" 50
+    result.total_usage.total_output_tokens;
+  Alcotest.(check int) "cache_creation" 10
+    result.total_usage.total_cache_creation_input_tokens;
+  Alcotest.(check int) "cache_read" 5
+    result.total_usage.total_cache_read_input_tokens;
+  Alcotest.(check int) "api_calls" 2 result.total_usage.api_calls
 
 let test_retry_result_no_usage () =
   let result : int Structured.retry_result = {
     value = 42;
-    total_usage = None;
+    total_usage = Types.empty_usage;
     attempts = 1;
   } in
   Alcotest.(check int) "value" 42 result.value;
   Alcotest.(check int) "attempts" 1 result.attempts;
-  Alcotest.(check bool) "no usage" true (Option.is_none result.total_usage)
+  Alcotest.(check int) "no api calls" 0 result.total_usage.api_calls
 
 (* ── Suite ──────────────────────────────────────────────────── *)
 


### PR DESCRIPTION
## Summary

- keep `api_usage` as a single-response contract by changing structured retry totals to accumulated `usage_stats`
- stop promoting untrusted `codex_cli` and `kimi_cli` raw counters into `api_response.usage`
- drop impossible Claude Code usage values above the declared 1M single-response input ceiling
- add Ollama regression coverage for `prompt_eval_count` / `eval_count` usage mapping

## Why this matters

MASC keeper metrics pass through `OAS api_response.usage`. When OAS surfaces cumulative or unsupported CLI counters as per-response usage, dashboards report impossible per-turn input values and downstream context/compaction metrics become untrustworthy.

This PR makes unsupported provider usage visible as `usage=None` instead of a false zero/huge token count, while preserving real per-response usage for providers with a stable contract.

Fixes #1181.
Downstream: jeong-sik/masc-mcp#9959.

## Validation

- `scripts/dune-local.sh build test/test_structured.exe test/test_structured_deep.exe test/test_provider.exe test/test_provider_config.exe test/test_provider_complete.exe test/test_streaming_openai.exe`
- `./_build_api_usage_contract_1181/default/test/test_structured.exe`
- `./_build_api_usage_contract_1181/default/test/test_structured_deep.exe`
- `./_build_api_usage_contract_1181/default/test/test_provider.exe`
- `./_build_api_usage_contract_1181/default/test/test_provider_config.exe`
- `./_build_api_usage_contract_1181/default/test/test_provider_complete.exe`
- `./_build_api_usage_contract_1181/default/test/test_streaming_openai.exe`
- `scripts/dune-local.sh runtest lib/llm_provider`
- `scripts/dune-local.sh runtest lib`
- `scripts/dune-local.sh build test/test_event_bus.exe test/test_event_forward.exe test/test_raw_trace.exe test/test_runtime_server_worker.exe test/test_provider_config.exe test/test_structured.exe`
- `./_build_api_usage_contract_1181/default/test/test_event_bus.exe`
- `./_build_api_usage_contract_1181/default/test/test_event_forward.exe`
- `./_build_api_usage_contract_1181/default/test/test_runtime_server_worker.exe`
- `./_build_api_usage_contract_1181/default/test/test_raw_trace.exe` (rerun outside sandbox after sandbox `EPERM bind`)
