### PR TITLE
docs(complete): consolidate stream_idle_timeout doc, align terminology

### DIFF
--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -126,7 +126,15 @@ include module type of Complete_stream_acc
     Returns the final assembled {!Types.api_response} after the stream ends.
 
     Supports both Anthropic native SSE and OpenAI-compatible SSE formats,
-    dispatched by {!Provider_config.t.kind}. *)
+    dispatched by {!Provider_config.t.kind}.
+
+    [clock] and [stream_idle_timeout_s] together bound inter-line idle
+    on the Ollama native NDJSON path (see {!Http_client.read_ndjson}).
+    The deadline resets after each successful line, so this does not
+    cap total stream duration.  A stalled endpoint surfaces as
+    [NetworkError { kind = Timeout; _ }] which cascade/retry layers
+    treat as retryable.  Non-Ollama paths currently ignore
+    [stream_idle_timeout_s]. *)
 val complete_stream :
   sw:Eio.Switch.t ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
@@ -141,9 +149,3 @@ val complete_stream :
   ?priority:Request_priority.t ->
   unit ->
   (Types.api_response, Http_client.http_error) result
-(** [clock] and [stream_idle_timeout_s] together bound inter-chunk idle
-    time on the Ollama native NDJSON path. The deadline resets after
-    each successful chunk, so this does not cap total stream duration.
-    A stalled endpoint surfaces as [NetworkError { kind = Timeout; _ }]
-    which cascade/retry layers treat as retryable. Non-Ollama paths
-    currently ignore [stream_idle_timeout_s]. *)


### PR DESCRIPTION
Follow-up to #1185. Two small docs-only fixes flagged by /simplify review:

1. **Doc placement**: `complete_stream` had its `?stream_idle_timeout_s` description in a second paragraph after the `val` signature. The convention in `complete.mli` is a single doc block before the signature (`complete` and `complete_with_retry` both follow this). Folded the new paragraph into the main block.

2. **Terminology alignment**: `http_client.mli` documents `read_ndjson` in terms of `line` / `inter-line idle`, but `complete.mli` was using `chunk` / `inter-chunk idle` for the same primitive. Switched to `line` and added a cross-reference to `{!Http_client.read_ndjson}` so readers can find the SSOT.

No code, no signature change, no version bump. Build clean.