### PR TITLE
fix(pricing): add gpt-5.5 rates

### DIFF
--- a/lib/llm_provider/pricing.ml
+++ b/lib/llm_provider/pricing.ml
@@ -48,6 +48,8 @@ let pricing_for_model_opt model_id =
        its Codex rate card labels it research preview with non-final rates. *)
     else if string_contains ~needle:"gpt-5.3-codex-spark" normalized then
       None
+    else if string_contains ~needle:"gpt-5.5" normalized then
+      Some ((5.0, 30.0), openai_cached_input)
     else if string_contains ~needle:"gpt-5.4-mini" normalized then
       Some ((0.75, 4.5), openai_cached_input)
     else if string_contains ~needle:"gpt-5.4" normalized then
@@ -229,6 +231,13 @@ let%test "pricing gpt-4o-mini" =
   && close_enough p.output_per_million 0.6
   && close_enough p.cache_write_multiplier 1.0
   && close_enough p.cache_read_multiplier 1.0
+
+let%test "pricing gpt-5.5" =
+  let p = pricing_for_model "gpt-5.5" in
+  close_enough p.input_per_million 5.0
+  && close_enough p.output_per_million 30.0
+  && close_enough p.cache_write_multiplier 1.0
+  && close_enough p.cache_read_multiplier 0.1
 
 let%test "pricing gpt-5.4-mini" =
   let p = pricing_for_model "gpt-5.4-mini" in

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -446,8 +446,10 @@ let zero_pricing =
 let pricing_for_model_opt model_id =
   let normalized = String.lowercase_ascii (String.trim model_id) in
   (* Anthropic cache pricing: write = 1.25x input, read = 0.1x input.
-     OpenAI/local: no cache pricing (multipliers are 1.0 and 1.0 for no-op). *)
+     Newer OpenAI text models expose cached input at 0.1x input.
+     Local/free models keep no-op cache multipliers. *)
   let anthropic_cache = (1.25, 0.1) in
+  let openai_cached_input = (1.0, 0.1) in
   let no_cache = (1.0, 1.0) in
   let result =
     if string_contains ~needle:"opus-4-6" normalized then
@@ -462,6 +464,21 @@ let pricing_for_model_opt model_id =
       Some ((0.8, 4.0), anthropic_cache)
     else if string_contains ~needle:"claude-3-7-sonnet" normalized then
       Some ((3.0, 15.0), anthropic_cache)
+    (* OpenAI API text-token pricing, confirmed from official model docs
+       2026-04-25. GPT-5.3-Codex-Spark is intentionally not covered here:
+       its Codex rate card labels it research preview with non-final rates. *)
+    else if string_contains ~needle:"gpt-5.3-codex-spark" normalized then
+      None
+    else if string_contains ~needle:"gpt-5.5" normalized then
+      Some ((5.0, 30.0), openai_cached_input)
+    else if string_contains ~needle:"gpt-5.4-mini" normalized then
+      Some ((0.75, 4.5), openai_cached_input)
+    else if string_contains ~needle:"gpt-5.4" normalized then
+      Some ((2.5, 15.0), openai_cached_input)
+    else if string_contains ~needle:"gpt-5.3-codex" normalized then
+      Some ((1.75, 14.0), openai_cached_input)
+    else if string_contains ~needle:"gpt-5.2" normalized then
+      Some ((1.75, 14.0), openai_cached_input)
     else if string_contains ~needle:"gpt-4o-mini" normalized then
       Some ((0.15, 0.6), no_cache)
     else if string_contains ~needle:"gpt-4o" normalized then

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -334,6 +334,13 @@ let test_pricing_sonnet () =
   Alcotest.(check (float 0.001)) "cache_write" 1.25 p.cache_write_multiplier;
   Alcotest.(check (float 0.001)) "cache_read" 0.1 p.cache_read_multiplier
 
+let test_pricing_gpt55 () =
+  let p = Provider.pricing_for_model "gpt-5.5" in
+  Alcotest.(check (float 0.001)) "input/M" 5.0 p.input_per_million;
+  Alcotest.(check (float 0.001)) "output/M" 30.0 p.output_per_million;
+  Alcotest.(check (float 0.001)) "cache_write" 1.0 p.cache_write_multiplier;
+  Alcotest.(check (float 0.001)) "cache_read" 0.1 p.cache_read_multiplier
+
 let test_pricing_local () =
   let p = Provider.pricing_for_provider
     ~provider:(Local { base_url = "http://127.0.0.1:8085" })
@@ -686,6 +693,7 @@ let () =
     ];
     "pricing", [
       Alcotest.test_case "sonnet pricing" `Quick test_pricing_sonnet;
+      Alcotest.test_case "gpt-5.5 pricing" `Quick test_pricing_gpt55;
       Alcotest.test_case "local free" `Quick test_pricing_local;
       Alcotest.test_case "unknown model" `Quick test_pricing_unknown;
       Alcotest.test_case "estimate cost" `Quick test_estimate_cost;

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -460,6 +460,26 @@ let test_annotate_response_cost () =
       Alcotest.(check bool) "annotated cost" true (cost > 0.0)
   | _ -> Alcotest.fail "expected annotated response cost"
 
+let test_annotate_response_cost_gpt55 () =
+  let response : api_response = {
+    id = "resp-gpt55";
+    model = "gpt-5.5";
+    stop_reason = EndTurn;
+    content = [Text "ok"];
+    usage = Some {
+      input_tokens = 1_000_000;
+      output_tokens = 1_000_000;
+      cache_creation_input_tokens = 0;
+      cache_read_input_tokens = 0;
+      cost_usd = None;
+    };
+    telemetry = None;
+  } in
+  match Llm_provider.Pricing.annotate_response_cost response with
+  | { usage = Some { cost_usd = Some cost; _ }; _ } ->
+      Alcotest.(check (float 0.001)) "gpt-5.5 cost" 35.0 cost
+  | _ -> Alcotest.fail "expected gpt-5.5 annotated response cost"
+
 (* ── Stream accumulator ──────────────────────────────── *)
 
 let test_stream_acc_text () =
@@ -614,6 +634,8 @@ let () =
     ];
     "cost", [
       test_case "annotate response cost" `Quick test_annotate_response_cost;
+      test_case "annotate gpt-5.5 response cost" `Quick
+        test_annotate_response_cost_gpt55;
     ];
     "stream_acc", [
       test_case "text events" `Quick test_stream_acc_text;


### PR DESCRIPTION
## Summary
- add GPT-5.5 pricing to Llm_provider.Pricing so OAS can annotate cost_usd instead of treating the model as an unknown zero-cost miss
- keep the legacy Provider pricing table aligned for older call paths
- add focused tests for Provider pricing and Llm_provider.Pricing response cost annotation

## Evidence
- OpenAI latest model guide lists latestModelInfo.model as gpt-5.5: https://developers.openai.com/api/docs/guides/latest-model.md (checked 2026-04-25 Asia/Seoul, confidence High)
- OpenAI API pricing lists GPT-5.5 at input .00, cached input /bin/zsh.50, output .00 per 1M tokens: https://openai.com/api/pricing/ (checked 2026-04-25 Asia/Seoul, confidence High)
- Existing Gemini 3.1 pricing remains aligned with Google official Gemini API pricing: https://ai.google.dev/gemini-api/docs/pricing (checked 2026-04-25 Asia/Seoul, confidence High)

## Validation
- scripts/dune-local.sh build test/test_provider.exe
- ./_build/default/test/test_provider.exe
- scripts/dune-local.sh build test/test_provider_complete.exe
- ./_build/default/test/test_provider_complete.exe
- git diff --check