### PR TITLE
fix(runtime): preserve raw trace run id on events

### DIFF
--- a/lib/runtime_server_types.ml
+++ b/lib/runtime_server_types.ml
@@ -56,10 +56,38 @@ let custom_name_of_kind = function
   | Session_completed _         -> "runtime.session_completed"
   | Session_failed _            -> "runtime.session_failed"
 
+let event_bus_run_id_of_event (event : event) =
+  let participant_run_id (participant : participant_event) =
+    match participant.raw_trace_run_id with
+    | Some run_id when String.trim run_id <> "" -> Some run_id
+    | _ -> None
+  in
+  match event.kind with
+  | Agent_became_live participant
+  | Agent_completed participant
+  | Agent_failed participant ->
+      participant_run_id participant
+  | Session_started _
+  | Session_settings_updated _
+  | Turn_recorded _
+  | Agent_spawn_requested _
+  | Agent_output_delta _
+  | Artifact_attached _
+  | Checkpoint_saved _
+  | Finalize_requested _
+  | Session_completed _
+  | Session_failed _ ->
+      None
+
 let emit_event state session_id (event : event) =
   let name = custom_name_of_kind event.kind in
+  let payload = Event_bus.Custom (name, event |> event_to_yojson) in
+  let event_bus_event =
+    match event_bus_run_id_of_event event with
+    | Some run_id -> Event_bus.mk_event ~correlation_id:session_id ~run_id payload
+    | None -> Event_bus.mk_event ~correlation_id:session_id payload
+  in
   Event_bus.publish state.event_bus
-    (Event_bus.mk_event ~correlation_id:session_id
-       (Custom (name, event |> event_to_yojson)));
+    event_bus_event;
   write_protocol_message state
     (Event_message { session_id = Some session_id; event })

--- a/lib/runtime_server_types.mli
+++ b/lib/runtime_server_types.mli
@@ -28,5 +28,8 @@ val write_protocol_message :
 
 val next_control_id : state -> string
 
+val event_bus_run_id_of_event :
+  Runtime.event -> string option
+
 val emit_event :
   state -> string -> Runtime.event -> unit

--- a/test/test_runtime_server_types.ml
+++ b/test/test_runtime_server_types.ml
@@ -35,6 +35,48 @@ let test_next_control_id_unique_across_domains () =
   Alcotest.(check int) "all ids unique" (workers * per_worker)
     (S.cardinal uniq)
 
+let participant_event ?raw_trace_run_id () : Runtime.participant_event =
+  {
+    participant_name = "worker-1";
+    summary = None;
+    provider = None;
+    model = None;
+    error = None;
+    raw_trace_run_id;
+    stop_reason = None;
+    completion_anomaly = None;
+    failure_cause = None;
+  }
+
+let runtime_event kind : Runtime.event =
+  { seq = 1; ts = 1.0; kind }
+
+let test_event_bus_run_id_uses_participant_raw_trace_run_id () =
+  let event =
+    runtime_event
+      (Runtime.Agent_completed
+         (participant_event ~raw_trace_run_id:"raw-run-1" ()))
+  in
+  Alcotest.(check (option string)) "run_id" (Some "raw-run-1")
+    (Runtime_server_types.event_bus_run_id_of_event event)
+
+let test_event_bus_run_id_ignores_blank_raw_trace_run_id () =
+  let event =
+    runtime_event
+      (Runtime.Agent_failed
+         (participant_event ~raw_trace_run_id:"   " ()))
+  in
+  Alcotest.(check (option string)) "run_id" None
+    (Runtime_server_types.event_bus_run_id_of_event event)
+
+let test_event_bus_run_id_omits_session_events () =
+  let event =
+    runtime_event
+      (Runtime.Session_started { goal = "test"; participants = [] })
+  in
+  Alcotest.(check (option string)) "run_id" None
+    (Runtime_server_types.event_bus_run_id_of_event event)
+
 let () =
   Alcotest.run "Runtime_server_types"
     [
@@ -44,5 +86,14 @@ let () =
             test_next_control_id_sequential;
           Alcotest.test_case "unique across domains" `Quick
             test_next_control_id_unique_across_domains;
+        ] );
+      ( "event bus run correlation",
+        [
+          Alcotest.test_case "uses participant raw trace run id" `Quick
+            test_event_bus_run_id_uses_participant_raw_trace_run_id;
+          Alcotest.test_case "ignores blank raw trace run id" `Quick
+            test_event_bus_run_id_ignores_blank_raw_trace_run_id;
+          Alcotest.test_case "omits session events" `Quick
+            test_event_bus_run_id_omits_session_events;
         ] );
     ]


### PR DESCRIPTION
## What changed

- Preserve the runtime participant raw trace run id as the top-level EventBus envelope run_id for runtime participant lifecycle events.
- Leave session-level events on the existing fresh EventBus run_id behavior.
- Add runtime-server type tests for participant run correlation, blank run ids, and non-participant events.

## Why

Runtime reports and raw traces already carry generic run/correlation fields, but EventBus forwarding was generating a fresh run_id for runtime participant events. That made top-level EventBus consumers lose the generic raw trace correlation even though the wire event payload still contained it.

This patch does not add MASC-specific fields to OAS. It only preserves the existing generic raw_trace_run_id -> EventBus run_id boundary.

## Validation

- env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=2 DUNE_CACHE=disabled DUNE_BUILD_DIR=/tmp/oas-runtime-event-corr-build scripts/dune-local.sh build --cache=disabled test/test_runtime_server_types.exe test/test_event_bus.exe test/test_event_forward.exe test/test_raw_trace.exe test/test_runtime_server_worker.exe test/test_runtime_evidence.exe test/test_provider_config.exe test/test_structured.exe
- /tmp/oas-runtime-event-corr-build/default/test/test_runtime_server_types.exe
- /tmp/oas-runtime-event-corr-build/default/test/test_event_bus.exe
- /tmp/oas-runtime-event-corr-build/default/test/test_event_forward.exe
- /tmp/oas-runtime-event-corr-build/default/test/test_raw_trace.exe (outside sandbox because the test binds a local listener)
- /tmp/oas-runtime-event-corr-build/default/test/test_runtime_server_worker.exe
- /tmp/oas-runtime-event-corr-build/default/test/test_runtime_evidence.exe
- /tmp/oas-runtime-event-corr-build/default/test/test_provider_config.exe
- /tmp/oas-runtime-event-corr-build/default/test/test_structured.exe
- git diff --check
