### PR TITLE
chore(release): restore 0.175.0 release truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,4 +248,4 @@ jobs:
           fetch-depth: 0
 
       - name: Enforce tag drift (strict)
-        run: bash scripts/check-tag-drift.sh --strict
+        run: bash scripts/check-tag-drift.sh --strict --allow-current-untagged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ original tag dates. `0.100.4` was never tagged or released.
 
 ## Unreleased
 
+## [0.175.0] - 2026-04-25
+
+### Added
+
+- **HTTP SSE stream idle timeout parity.** `Complete.complete_stream`
+  now applies `stream_idle_timeout_s` to every HTTP streaming path,
+  including Anthropic, OpenAI-compatible, Gemini, GLM, and Ollama native
+  NDJSON streams. The timeout remains caller-owned and surfaces stalled
+  endpoints as retryable timeout-shaped network errors.
+- **CLI subprocess stdout idle timeout.** Shared non-interactive CLI
+  subprocess execution now accepts `?clock` and
+  `?stdout_idle_timeout_s`, so silent CLI hangs can be interrupted
+  without imposing a total runtime cap.
+
 ### Fixed
 
 - **Pipeline retry honors effective tool contract.** Missing-required-tool retry
@@ -15,6 +29,15 @@ original tag dates. `0.100.4` was never tagged or released.
   resolution) instead of the originally requested contract. Providers that
   intentionally relax unsupported tool requirements no longer enter forced
   retry loops.
+- **Per-response usage is preserved.** Ollama and CLI transports keep
+  usage on each returned response instead of letting aggregate turn
+  accounting overwrite or drop the provider payload.
+- **Runtime participant events preserve raw trace run ids.** Runtime
+  participant lifecycle events now carry `raw_trace_run_id` through to
+  the top-level EventBus `run_id`, keeping generic trace correlation
+  intact for downstream consumers.
+- **Provider pricing entries refreshed again.** Added pricing for
+  `gpt-5.5` alongside the existing current OpenAI model table refresh.
 
 ## [0.173.0] - 2026-04-25
 

--- a/scripts/check-tag-drift.sh
+++ b/scripts/check-tag-drift.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
-# check-tag-drift.sh — verify every CHANGELOG.md version entry has a matching
-# git tag, making release-tag hygiene observable in CI.
+# check-tag-drift.sh — verify release metadata stays coherent: the current
+# dune-project version must have a CHANGELOG entry, and released CHANGELOG
+# entries should have matching git tags.
 #
 # Relationship to peers:
 #   release.sh             — one-shot "cut this release + push tag". Operator tool.
 #   sync-version-truth.sh  — sync 3 in-repo surfaces (dune / opam / sdk_version.ml).
-#   check-tag-drift.sh     — audit the 4th axis: released CHANGELOG entries ↔ git tags.
+#   check-tag-drift.sh     — audit CHANGELOG currentness plus released
+#                            CHANGELOG entries ↔ git tags.
 #
 # Motivation: dune-project / agent_sdk.opam / lib/sdk_version.ml can be bumped,
 # a CHANGELOG entry added, and the release PR merged, all without anyone ever
@@ -16,10 +18,14 @@
 #
 # Usage:
 #   scripts/check-tag-drift.sh           # warn-only: list drift, always exit 0
-#   scripts/check-tag-drift.sh --strict  # fail (exit 1) if any CHANGELOG version
-#                                        # is missing a corresponding tag
-#   scripts/check-tag-drift.sh --limit N # only consider the N most recent
-#                                        # CHANGELOG entries (default: 10)
+#   scripts/check-tag-drift.sh --strict  # fail (exit 1) if current version has
+#                                        # no CHANGELOG entry, or if any scanned
+#                                        # CHANGELOG version is missing a tag
+#   scripts/check-tag-drift.sh --allow-current-untagged
+#                                        # permit the current version's missing
+#                                        # tag during the release-entry PR
+#   scripts/check-tag-drift.sh --limit N # only consider the N most recent tag
+#                                        # checks (default: 10)
 #
 # Exit codes:
 #   0   no drift, or drift present in warn-only mode
@@ -29,15 +35,17 @@
 set -euo pipefail
 
 strict=false
+allow_current_untagged=false
 limit=10
 
 usage() {
-  sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
 while (($# > 0)); do
   case "$1" in
     --strict) strict=true ;;
+    --allow-current-untagged) allow_current_untagged=true ;;
     --limit) shift; limit="${1:-}" ;;
     --limit=*) limit="${1#--limit=}" ;;
     -h|--help) usage; exit 0 ;;
@@ -59,36 +67,87 @@ if [[ ! -f CHANGELOG.md ]]; then
   exit 2
 fi
 
+current_version="$(sed -n 's/^(version \([^)]*\)).*/\1/p' dune-project | head -n1)"
+if [[ -z "${current_version}" ]]; then
+  echo "check-tag-drift: no current version found in dune-project" >&2
+  exit 2
+fi
+
 # Extract CHANGELOG versions in document order (newest first, by convention).
 # A valid entry looks like: `## [0.169.0] - 2026-04-21` — skip unreleased /
 # placeholder headers like `## [Unreleased]`.
-versions=()
+all_versions=()
 while IFS= read -r line; do
-  versions+=("$line")
+  all_versions+=("$line")
 done < <(
-  sed -n 's/^## \[\([0-9][0-9]*\(\.[0-9][0-9]*\)\{1,2\}\)\] .*/\1/p' CHANGELOG.md \
-    | head -n "$limit"
+  sed -n 's/^## \[\([0-9][0-9]*\(\.[0-9][0-9]*\)\{1,2\}\)\] .*/\1/p' CHANGELOG.md
 )
 
-if (( ${#versions[@]} == 0 )); then
+if (( ${#all_versions[@]} == 0 )); then
   echo "check-tag-drift: no CHANGELOG versions found (regex: ^## \\[X.Y(.Z)\\] ...)" >&2
   exit 2
 fi
 
+versions=()
+while IFS= read -r line; do
+  versions+=("$line")
+done < <(
+  printf '%s\n' "${all_versions[@]}" | head -n "$limit"
+)
+
 missing=()
+pending_current=()
 present=()
+current_has_changelog=0
+
+for v in "${all_versions[@]}"; do
+  if [[ "${v}" == "${current_version}" ]]; then
+    current_has_changelog=1
+    break
+  fi
+done
 
 for v in "${versions[@]}"; do
   if git tag -l "v${v}" | grep -qx "v${v}"; then
     present+=("v${v}")
+  elif [[ "${allow_current_untagged}" == true && "${v}" == "${current_version}" ]]; then
+    pending_current+=("v${v}")
   else
     missing+=("v${v}")
   fi
 done
 
+echo "check-tag-drift: current version ${current_version}"
 echo "check-tag-drift: scanned ${#versions[@]} most recent CHANGELOG entries (limit=${limit})"
 echo "  tagged:  ${#present[@]}"
 echo "  missing: ${#missing[@]}"
+if (( ${#pending_current[@]} > 0 )); then
+  echo "  pending current release tag: ${#pending_current[@]}"
+fi
+
+if (( current_has_changelog == 0 )); then
+  echo ""
+  echo "Current version lacks a CHANGELOG entry:"
+  echo "  - dune-project version: ${current_version}"
+  echo "  - expected header: ## [${current_version}] - YYYY-MM-DD"
+  echo ""
+  echo "This blocks scripts/release.sh and should be fixed before cutting a tag."
+
+  if $strict; then
+    exit 1
+  fi
+fi
+
+if (( ${#pending_current[@]} > 0 )); then
+  echo ""
+  echo "Pending current release tag allowed by --allow-current-untagged:"
+  for t in "${pending_current[@]}"; do
+    echo "  - ${t}"
+  done
+  echo ""
+  echo "After the release-entry PR lands on main, run:"
+  echo "  scripts/release.sh --tag"
+fi
 
 if (( ${#missing[@]} > 0 )); then
   echo ""


### PR DESCRIPTION
## What changed

- Add the missing `0.175.0` CHANGELOG release entry covering the current main changes since `v0.173.0`.
- Extend `scripts/check-tag-drift.sh` so strict mode also verifies that the current `dune-project` version has a CHANGELOG entry.
- Add `--allow-current-untagged` and wire CI to use it, so the release-entry PR can pass before `scripts/release.sh --tag` creates `v0.175.0` on merged main.

## Why

The current OAS main reports `0.175.0`, but `scripts/release.sh` fails because CHANGELOG has no `[0.175.0]` header. The existing tag-drift gate also creates a release workflow loop: adding the CHANGELOG entry before tagging makes strict tag drift fail, while release.sh refuses to tag before the entry exists on main.

This keeps the two invariants separate:

- current version must be documented before release
- current version may be temporarily untagged while the release-entry PR is in flight
- after the PR lands, plain strict tag drift still flags `v0.175.0` until `scripts/release.sh --tag` is run

Fixes #1193.

## Validation

- `bash -n scripts/check-tag-drift.sh`
- `bash scripts/check-tag-drift.sh --help`
- `bash scripts/check-tag-drift.sh` (warn-only reports missing `v0.175.0`, exits 0)
- `bash scripts/check-tag-drift.sh --strict` (expected failure until `v0.175.0` is tagged)
- `bash scripts/check-tag-drift.sh --strict --allow-current-untagged`
- `git diff --check`
