### PR TITLE
chore(release): add 0.176.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ original tag dates. `0.100.4` was never tagged or released.
 
 ## Unreleased
 
+## [0.176.0] - 2026-04-25
+
+### Added
+
+- **Agent-level stream idle timeout control.** `Agent.options` and
+  `Builder.t` now expose `stream_idle_timeout_s`, with
+  `Builder.with_stream_idle_timeout` for callers that need bounded
+  streaming turns. `Pipeline_stage_route.dispatch_stream` forwards the
+  value into `Complete.complete_stream`, so downstream consumers can opt
+  into retryable idle timeout failures across HTTP SSE, Ollama NDJSON,
+  and CLI subprocess streaming paths.
+
 ## [0.175.0] - 2026-04-25
 
 ### Added


### PR DESCRIPTION
## Summary

- add the missing `CHANGELOG.md` release entry for `0.176.0`
- keep the current release tag pending until the release-entry PR lands on `main`

## Why

PR #1195 bumped the SDK version to `0.176.0` for the new agent-facing stream idle timeout API, but `main` did not yet have a matching changelog header. That makes `scripts/check-tag-drift.sh --strict` and `scripts/release.sh` reject the release cut.

## Validation

- `scripts/check-tag-drift.sh --strict --allow-current-untagged`
- `git diff --check`

Note: `scripts/release.sh` intentionally refuses non-`main` branches; run it after this PR lands, then run `scripts/release.sh --tag`.
