### PR TITLE
fix: add pricing entries for generic and CLI models

### DIFF
--- a/lib/llm_provider/pricing.ml
+++ b/lib/llm_provider/pricing.ml
@@ -85,6 +85,16 @@ let pricing_for_model_opt model_id =
     else if string_contains ~needle:"gemini-3.1-flash-lite-preview" normalized
          || string_contains ~needle:"gemini-3.1-flash-lite" normalized then
       Some ((0.25, 1.5), no_cache)
+    else if normalized = "auto"
+         || normalized = "gemini"
+         || normalized = "kimi"
+         || normalized = "codex"
+         || normalized = "claude_code"
+         || normalized = "gemini_cli"
+         || normalized = "kimi_cli"
+         || normalized = "codex_cli" then
+      Some ((0.0, 0.0), no_cache)
+
     else if string_contains ~needle:"ollama" normalized
          || string_contains ~needle:"qwen" normalized
          || string_contains ~needle:"llama" normalized then


### PR DESCRIPTION
## Description
Fixes noisy `pricing_catalog_miss` warnings in downstream projects by explicitly returning zero-cost pricing for generic aliases (`auto`, `gemini`, `kimi`, `codex`, `claude_code`) and their CLI specific suffix variants (`gemini_cli`, `kimi_cli`, `codex_cli`).