### PR TITLE
fix(transport/codex): pass --ephemeral to suppress session race

### DIFF
--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -309,7 +309,18 @@ let build_args ~(config : config) ~(req_config : Provider_config.t)
     | None -> []
     | Some model -> ["--model"; model]
   in
-  [config.codex_path; "exec"; "--json"]
+  (* [--ephemeral] suppresses Codex CLI session/rollout persistence.  Without
+     it, codex-cli 0.125.0+ records each invocation under
+     [$CODEX_HOME/sessions/], and an asynchronous record_rollout_items step
+     can race process exit, surfacing
+       [ERROR codex_core::session: failed to record rollout items:
+        thread <UUID> not found]
+     on stderr together with [exit code 1].  OAS' [cli_common_subprocess]
+     classifies any nonzero exit as [NetworkError], discarding the otherwise
+     valid stdout JSONL.  We never call [codex resume]/[fork] from this
+     transport, so persisted sessions are dead weight; opting into ephemeral
+     mode removes the race entirely. *)
+  [config.codex_path; "exec"; "--json"; "--ephemeral"]
   @ (match runtime_mcp_policy with
      | Some policy -> (
          match runtime_mcp_overrides policy with
@@ -638,7 +649,25 @@ let%test "build_args includes --json flag" =
   let args =
     build_args ~config:default_config ~req_config:(codex_req ()) ~prompt:"hello" ()
   in
-  args = ["codex"; "exec"; "--json"; "-c"; "mcp_servers={}"; "hello"]
+  args = ["codex"; "exec"; "--json"; "--ephemeral"; "-c"; "mcp_servers={}"; "hello"]
+
+let%test "build_args includes --ephemeral right after --json" =
+  (* Regression guard: --ephemeral must precede config overrides and the
+     prompt so codex-cli 0.125.0+ skips session/rollout persistence even
+     when callers add custom -c flags. *)
+  let args =
+    build_args ~config:default_config ~req_config:(codex_req ()) ~prompt:"hello" ()
+  in
+  let rec idx_of x = function
+    | [] -> -1
+    | hd :: _ when hd = x -> 0
+    | _ :: tl ->
+      let r = idx_of x tl in
+      if r < 0 then r else r + 1
+  in
+  let json_idx = idx_of "--json" args in
+  let ephemeral_idx = idx_of "--ephemeral" args in
+  json_idx >= 0 && ephemeral_idx = json_idx + 1
 
 let%test "build_args ignores extra parity fields" =
   let config = { default_config with
@@ -648,7 +677,7 @@ let%test "build_args ignores extra parity fields" =
     permission_mode = Some "bypassPermissions";
   } in
   let args = build_args ~config ~req_config:(codex_req ()) ~prompt:"hi" () in
-  args = ["codex"; "exec"; "--json"; "-c"; "mcp_servers={}"; "hi"]
+  args = ["codex"; "exec"; "--json"; "--ephemeral"; "-c"; "mcp_servers={}"; "hi"]
 
 let%test "build_args with requested model" =
   let args =
@@ -658,14 +687,14 @@ let%test "build_args with requested model" =
       ()
   in
   args =
-  ["codex"; "exec"; "--json"; "-c"; "mcp_servers={}";
+  ["codex"; "exec"; "--json"; "--ephemeral"; "-c"; "mcp_servers={}";
    "--model"; "gpt-5.4"; "hi"]
 
 let%test "build_args with config default model for auto request" =
   let config = { default_config with model = Some "gpt-5.2-codex" } in
   let args = build_args ~config ~req_config:(codex_req ()) ~prompt:"hi" () in
   args =
-  ["codex"; "exec"; "--json"; "-c"; "mcp_servers={}";
+  ["codex"; "exec"; "--json"; "--ephemeral"; "-c"; "mcp_servers={}";
    "--model"; "gpt-5.2-codex"; "hi"]
 
 let%test "prompt_exceeds_argv_budget: small prompt stays in argv" =
@@ -812,7 +841,7 @@ let%test "default: argv disables MCP even with no env" =
   with_unset "OAS_CODEX_PROFILE" (fun () ->
   with_unset "OAS_CODEX_SKIP_GIT" (fun () ->
     build_args ~config:default_config ~req_config:(codex_req ()) ~prompt:"hi" ()
-    = ["codex"; "exec"; "--json"; "-c"; "mcp_servers={}"; "hi"]))))
+    = ["codex"; "exec"; "--json"; "--ephemeral"; "-c"; "mcp_servers={}"; "hi"]))))
 
 let%test "env: OAS_CODEX_CONFIG emits -c pairs before prompt" =
   with_env "OAS_CODEX_CONFIG" "mcp_servers={},model=o3" (fun () ->


### PR DESCRIPTION
## Summary

- Codex CLI 0.125.0+ records each invocation under \`\$CODEX_HOME/sessions/\` via an asynchronous \`record_rollout_items\` step that races process exit on short turns (4–7s).
- Race surfaces \`ERROR codex_core::session: failed to record rollout items: thread <UUID> not found\` on stderr together with \`exit code 1\`.
- \`cli_common_subprocess\` classifies any nonzero exit as \`Http_client.NetworkError\` and discards the otherwise valid stdout JSONL — the turn fails despite a successful LLM response.
- This transport never calls \`codex resume\`/\`fork\`, so persisted sessions are dead weight. \`--ephemeral\` suppresses disk persistence and removes the race entirely.

## Why this matters (field measurement)

Captured from masc-mcp keeper fleet, 2026-04-25:

- 12 OAS turns over 1h15m: **7/12 codex_cli turns** (\`gpt-5.2\`, \`gpt-5.4\`, \`gpt-5.5\`) failed with the stderr above; only \`gpt-5.3-codex-spark\`, \`gemini\`, \`gpt-5.4-mini\` reached \`stop=end_turn\`.
- Cascade rotation wasted ~28s per cycle iterating broken codex models before reaching a working fallback.
- Fleet error rate 50% (24-Apr) → 37% (25-Apr) was driven primarily by an upstream cascade weight rebalance toward spark; this PR removes the underlying cause so all codex models can carry their weight.

## Verification done

- \`dune build --root . lib/\` clean.
- \`dune runtest --root . --force lib/llm_provider/\` 29/29 pass after updating five existing \`build_args\` expectations and adding the regression guard.

## Test plan

- [x] Existing \`let%test\` cases updated to expect \`[..., \"--json\"; \"--ephemeral\"; \"-c\"; \"mcp_servers={}\"; ...]\`.
- [x] New \`build_args includes --ephemeral right after --json\` walks the arg list and asserts position invariant — survives future runtime_mcp_overrides reordering.
- [ ] Live verification on masc-mcp keeper fleet: after merge + OAS pin bump in masc-mcp, observe codex_cli turns transition from \`stop=error:Network error: codex exited with code 1\` to \`stop=end_turn\`.

## Risks

- \`--ephemeral\` disables \`codex resume\`/\`codex fork\` for sessions started through this transport. We never invoke either, but document this so future transport changes don't silently rely on session persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)