### PR TITLE
feat(cli_common_subprocess): opt-in stdout_recovery on nonzero exit

### DIFF
--- a/lib/llm_provider/cli_common_subprocess.ml
+++ b/lib/llm_provider/cli_common_subprocess.ml
@@ -59,6 +59,7 @@ let run_core ~sw ~(mgr : _ Eio.Process.mgr) ?clock ?stdout_idle_timeout_s
     ~name ~cwd ~extra_env
     ?(scrub_env = [])
     ?stdin_content
+    ?stdout_recovery
     ~on_line ~on_stderr_line ~cancel argv =
   let t0 = Unix.gettimeofday () in
   try
@@ -187,6 +188,31 @@ let run_core ~sw ~(mgr : _ Eio.Process.mgr) ?clock ?stdout_idle_timeout_s
     | `Exited 0 ->
       Ok { stdout = stdout_str; stderr = stderr_str; latency_ms }
     | `Exited code ->
+      (* Some CLI transports complete the LLM response on stdout but exit
+         nonzero on post-response bookkeeping (e.g. codex-cli 0.125.0+
+         races [record_rollout_items] against process exit and emits
+         [thread <UUID> not found] on stderr with [exit code 1] even
+         though the JSONL stream on stdout is structurally complete).
+
+         When the caller supplies [stdout_recovery] and the predicate
+         accepts [stdout_str], we surface the captured stream as a
+         success so the caller can parse a real response instead of
+         being forced into a [NetworkError] retry.  The recovery hook is
+         opt-in; transports that do not pass it keep the strict
+         exit-code semantics. *)
+      let recovered =
+        match stdout_recovery with
+        | Some predicate ->
+          (try predicate stdout_str
+           with exn ->
+             Eio.traceln "cli_common_subprocess: stdout_recovery raised: %s"
+               (Printexc.to_string exn);
+             false)
+        | None -> false
+      in
+      if recovered then
+        Ok { stdout = stdout_str; stderr = stderr_str; latency_ms }
+      else
       let detail =
         if stderr_str <> "" then stderr_str
         else
@@ -211,11 +237,13 @@ let run_collect ~sw ~mgr ?clock ?stdout_idle_timeout_s
     ~name ~cwd ~extra_env
     ?(scrub_env = [])
     ?stdin_content
+    ?stdout_recovery
     ?(on_stderr_line = default_on_stderr_line ~name)
     ?cancel argv =
   run_core ~sw ~mgr ?clock ?stdout_idle_timeout_s
     ~name ~cwd ~extra_env ~scrub_env
     ?stdin_content
+    ?stdout_recovery
     ~on_line:(fun _ -> ())
     ~on_stderr_line
     ~cancel
@@ -225,12 +253,14 @@ let run_stream_lines ~sw ~mgr ?clock ?stdout_idle_timeout_s
     ~name ~cwd ~extra_env
     ?(scrub_env = [])
     ?stdin_content
+    ?stdout_recovery
     ~on_line
     ?(on_stderr_line = default_on_stderr_line ~name)
     ?cancel argv =
   run_core ~sw ~mgr ?clock ?stdout_idle_timeout_s
     ~name ~cwd ~extra_env ~scrub_env
     ?stdin_content
+    ?stdout_recovery
     ~on_line
     ~on_stderr_line
     ~cancel
@@ -251,4 +281,57 @@ let%test "run_collect: stdout_idle_timeout fires when subprocess produces nothin
       [ "sleep"; "5" ]
   with
   | Error (Http_client.NetworkError { kind = Timeout; _ }) -> true
+  | _ -> false
+
+(* ── stdout_recovery test ─────────────────────────────── *)
+
+let%test "run_collect: stdout_recovery rescues nonzero exit when predicate matches" =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let mgr = Eio.Stdenv.process_mgr env in
+  match
+    run_collect ~sw ~mgr
+      ~name:"recover-test"
+      ~cwd:None ~extra_env:[]
+      ~stdout_recovery:(fun s ->
+        (* Predicate accepts any stdout — emulates the codex case where
+           a structurally complete stream was already captured. *)
+        String.length s > 0)
+      ~on_stderr_line:(fun _ -> ())
+      [ "sh"; "-c"; "printf 'turn.completed marker\\n'; exit 1" ]
+  with
+  | Ok { stdout; _ } ->
+    (* The 'turn.completed marker\n' payload should be captured even
+       though the subprocess exited 1. *)
+    String.length stdout > 0
+  | _ -> false
+
+let%test "run_collect: stdout_recovery rejects nonzero exit when predicate refuses" =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let mgr = Eio.Stdenv.process_mgr env in
+  match
+    run_collect ~sw ~mgr
+      ~name:"recover-reject-test"
+      ~cwd:None ~extra_env:[]
+      ~stdout_recovery:(fun _ -> false)
+      ~on_stderr_line:(fun _ -> ())
+      [ "sh"; "-c"; "printf 'partial\\n'; exit 1" ]
+  with
+  | Error (Http_client.NetworkError _) -> true
+  | _ -> false
+
+let%test "run_collect: zero exit ignores stdout_recovery (still Ok)" =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let mgr = Eio.Stdenv.process_mgr env in
+  match
+    run_collect ~sw ~mgr
+      ~name:"recover-zero-test"
+      ~cwd:None ~extra_env:[]
+      ~stdout_recovery:(fun _ -> false)  (* would block, but exit=0 wins *)
+      ~on_stderr_line:(fun _ -> ())
+      [ "sh"; "-c"; "printf 'fine\\n'; exit 0" ]
+  with
+  | Ok _ -> true
   | _ -> false

--- a/lib/llm_provider/cli_common_subprocess.mli
+++ b/lib/llm_provider/cli_common_subprocess.mli
@@ -26,6 +26,7 @@ val run_collect :
   extra_env:(string * string) list ->
   ?scrub_env:string list ->
   ?stdin_content:string ->
+  ?stdout_recovery:(string -> bool) ->
   ?on_stderr_line:(string -> unit) ->
   ?cancel:unit Eio.Promise.t ->
   string list ->
@@ -60,9 +61,18 @@ val run_collect :
       within [stdout_idle_timeout_s] seconds.  Independent of [cancel];
       protects against subprocesses that hang silently with no caller-
       side cancellation token.  The deadline resets after each line.
+    - [stdout_recovery]: opt-in predicate that lets a transport rescue
+      a structurally complete stdout payload from a nonzero exit.  Some
+      CLIs (e.g. codex-cli 0.125.0+) finish the LLM response on stdout
+      but exit nonzero on post-response bookkeeping races.  When the
+      predicate returns [true] for the captured stdout, [run_collect]
+      surfaces [Ok] so the caller can parse a real response instead of
+      retrying the cascade.  The hook is invoked only on nonzero exits
+      and predicate exceptions are caught and logged.
 
-    Returns [Ok { stdout; stderr; latency_ms }] on a zero exit code,
-    or a [NetworkError] describing the failure. *)
+    Returns [Ok { stdout; stderr; latency_ms }] on a zero exit code (or
+    on a nonzero exit when [stdout_recovery] accepts the captured
+    stdout), or a [NetworkError] describing the failure. *)
 
 val run_stream_lines :
   sw:Eio.Switch.t ->
@@ -74,6 +84,7 @@ val run_stream_lines :
   extra_env:(string * string) list ->
   ?scrub_env:string list ->
   ?stdin_content:string ->
+  ?stdout_recovery:(string -> bool) ->
   on_line:(string -> unit) ->
   ?on_stderr_line:(string -> unit) ->
   ?cancel:unit Eio.Promise.t ->

--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -160,6 +160,38 @@ let content_blocks_of_jsonl lines =
   ) lines;
   List.rev !blocks
 
+(* ── stdout recovery on nonzero exit ──────────────────── *)
+
+(** Lightweight structural check used as the [stdout_recovery] hook
+    for [Cli_common_subprocess.run_stream_lines].  A successful codex
+    run always emits a [turn.completed] envelope on its own line; if
+    the captured stdout contains that envelope we treat the run as
+    structurally complete even when the process exited nonzero (e.g.
+    the codex-cli 0.125.0+ [record_rollout_items] race that surfaces
+    [thread <UUID> not found] on stderr after the LLM response is
+    already on stdout).  We scan for the marker substring rather than
+    parse every line — this hook is consulted only on nonzero exits
+    (already a slow path) and the marker does not appear outside the
+    JSONL [type] field in codex output. *)
+let stdout_contains_turn_completed stdout_str =
+  let needle = {|"type":"turn.completed"|} in
+  let m = String.length needle and h = String.length stdout_str in
+  if m > h then false
+  else
+    let rec scan i =
+      if i + m > h then false
+      else
+        let eq = ref true and j = ref 0 in
+        while !eq && !j < m do
+          if String.unsafe_get stdout_str (i + !j)
+             <> String.unsafe_get needle !j
+          then eq := false;
+          incr j
+        done;
+        !eq || scan (i + 1)
+    in
+    scan 0
+
 (* ── CLI argument building ───────────────────────────── *)
 
 (** Threshold at which [build_args] stops passing the prompt as a
@@ -572,6 +604,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
               ~name:"codex" ~cwd:config.cwd ~extra_env:[]
               ~scrub_env:codex_cli_scrub_env
               ?stdin_content:(stdin_for_prompt prompt)
+              ~stdout_recovery:stdout_contains_turn_completed
               ~on_line ?cancel:config.cancel
               argv with
       | Error _ as e -> { Llm_transport.response = e; latency_ms = 0 }
@@ -620,6 +653,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config)
               ~name:"codex" ~cwd:config.cwd ~extra_env:[]
               ~scrub_env:codex_cli_scrub_env
               ?stdin_content:(stdin_for_prompt prompt)
+              ~stdout_recovery:stdout_contains_turn_completed
               ~on_line ?cancel:config.cancel
               argv with
       | Error _ as e -> e
@@ -936,3 +970,29 @@ let%test "parse_jsonl_result includes mcp tool call blocks" =
        :: Types.Text "done" :: [] -> true
      | _ -> false)
   | Error _ -> false
+
+(* ── stdout_recovery validator tests ─────────────────── *)
+
+let%test "stdout_contains_turn_completed: full JSONL stream is recovered" =
+  let stdout =
+    {|{"type":"thread.started","thread_id":"019dc578-02d3"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"hi"}}
+{"type":"turn.completed","usage":{"input_tokens":1,"cached_input_tokens":0,"output_tokens":1}}
+|}
+  in
+  stdout_contains_turn_completed stdout
+
+let%test "stdout_contains_turn_completed: incomplete stream is rejected" =
+  let stdout =
+    {|{"type":"thread.started","thread_id":"019dc578-02d3"}
+{"type":"turn.started"}
+|}
+  in
+  not (stdout_contains_turn_completed stdout)
+
+let%test "stdout_contains_turn_completed: empty stdout is rejected" =
+  not (stdout_contains_turn_completed "")
+
+let%test "stdout_contains_turn_completed: short stdout below needle length" =
+  not (stdout_contains_turn_completed "x")


### PR DESCRIPTION
## Summary

- Adds an opt-in \`?stdout_recovery:(string -> bool)\` predicate to \`Cli_common_subprocess.{run_core, run_collect, run_stream_lines}\`.
- When the predicate accepts the captured stdout on a nonzero exit, the run surfaces \`Ok\` instead of \`Http_client.NetworkError\`, letting the caller parse a real response.
- Wires the hook in \`transport_codex_cli\` with \`stdout_contains_turn_completed\` — a cheap substring scan for the \`{\"type\":\"turn.completed\"}\` envelope codex emits on every successful run.
- Predicate exceptions are caught and traced. Transports that do not pass the hook keep the strict exit-code semantics — **no ABI break for existing callers.**

## Why this matters (paired with #1199)

\`codex-cli\` 0.125.0+ races \`record_rollout_items\` against process exit and emits

> \`ERROR codex_core::session: failed to record rollout items: thread <UUID> not found\`

on stderr together with \`exit code 1\` *after* the LLM response is already on stdout. \`cli_common_subprocess\` previously discarded that stdout because nonzero exit was always classified as \`NetworkError\`.

#1199 (\`--ephemeral\`) removed the stderr noise but did not change the exit code:

| condition | exit | stderr | stdout JSONL |
|--|--|--|--|
| codex \`exec --json\` | 1 | 1 line (rollout error) | structurally complete |
| codex \`exec --json --ephemeral\` (post-#1199) | **1** | 0 lines | structurally complete |

Verified with direct codex 0.125.0 \`exec\` calls in the worktree environment.

So #1199 + this PR together: stderr noise gone, **and** the captured response is no longer thrown away.

## Field measurement (masc-mcp keeper fleet, 2026-04-25)

- 12 OAS turns over 1h15m: **7/12 codex_cli turns** (\`gpt-5.2\`/\`gpt-5.4\`/\`gpt-5.5\`) returned \`stop=error:Network error: codex exited with code 1\`. Cascade rotation wasted ~28s per cycle iterating broken codex models before reaching spark/gemini.
- After #1199 + this PR + a downstream OAS pin bump in \`masc-mcp\`, codex_cli turns should transition to \`stop=end_turn\` instead, recovering the cascade weight already configured for those models.

## Tests

- \`transport_codex_cli\`: 4 new \`let%test\`s verify \`stdout_contains_turn_completed\` (full stream, incomplete, empty, below needle length).
- \`cli_common_subprocess\`: 3 new \`Eio_main.run\` \`let%test\`s spawn real \`sh -c\` subprocesses to exercise:
  - recovery-accepts: \`exit 1\` + matching predicate → \`Ok\`.
  - recovery-rejects: \`exit 1\` + refusing predicate → \`NetworkError\`.
  - zero-exit-ignores-recovery: \`exit 0\` + refusing predicate → \`Ok\` (zero-exit short-circuits).
- \`dune build --root . lib/\` clean. \`dune runtest --root . --force lib/llm_provider/\` all green.
- No callers of \`run_collect\` / \`run_stream_lines\` outside \`transport_codex_cli\` pass the new optional argument; \`gemini\`, \`kimi\`, \`claude_code\` transports keep their existing strict semantics.

## Test plan

- [x] Existing transport_codex_cli tests (29) still pass.
- [x] New stdout_recovery tests (3) pass with \`Eio_main.run\` + real subprocess spawn.
- [x] mli updated; build clean.
- [ ] Live verification on masc-mcp keeper fleet after merge + OAS pin bump in masc-mcp:
  - \`stop=end_turn\` rate for codex_cli models (gpt-5.2/5.4/5.5) should rise from ~0% to a meaningful share.
  - Cascade rotation length should drop on those models.

## Risks

- The predicate is invoked on every nonzero exit, which is a slow path; the codex implementation is a substring scan, so no parsing cost. Other transports do not enable the hook.
- A misimplemented predicate that accepts a partial / corrupt stream would surface a parse error downstream rather than a clean \`NetworkError\`. The codex predicate explicitly checks for the \`turn.completed\` marker, which codex only emits on a real completion envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)