### PR TITLE
feat(event_bus): add TurnReady event with effective tool list

### DIFF
--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -61,6 +61,7 @@ type turn_preparation = {
   tools_json: Yojson.Safe.t list option;
   effective_messages: message list;
   effective_guardrails: Guardrails.t;
+  visible_tool_names: string list;
 }
 
 (* ── Extract last user text from messages (for Tool_selector context) ── *)
@@ -134,7 +135,10 @@ let prepare_tools ~guardrails ~operator_policy ~policy_channel ~(tools : Tool_se
   in
   let tool_schemas = List.map Tool.schema_to_json selected in
   let tools_json = if tool_schemas = [] then None else Some tool_schemas in
-  (tools_json, effective_guardrails)
+  let visible_tool_names =
+    List.map (fun (t : Tool.t) -> t.schema.name) selected
+  in
+  (tools_json, visible_tool_names, effective_guardrails)
 
 let normalize_tier_content = function
   | None -> None
@@ -239,14 +243,14 @@ let prepare_messages ~messages ~context_reducer ~tiered_memory ~turn_params =
 
 let prepare_turn ~guardrails ~operator_policy ~policy_channel ~tools ~messages ~context_reducer ~tiered_memory ~turn_params
     ?tool_selector () =
-  let tools_json, effective_guardrails =
+  let tools_json, visible_tool_names, effective_guardrails =
     prepare_tools ~guardrails ~operator_policy ~policy_channel ~tools ~turn_params
       ?tool_selector ~messages ()
   in
   let effective_messages =
     prepare_messages ~messages ~context_reducer ~tiered_memory ~turn_params
   in
-  { tools_json; effective_messages; effective_guardrails }
+  { tools_json; effective_messages; effective_guardrails; visible_tool_names }
 
 (* ── Usage accumulation ───────────────────────────────────────── *)
 

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -63,6 +63,19 @@ type turn_preparation = {
   tools_json: Yojson.Safe.t list option;
   effective_messages: Types.message list;
   effective_guardrails: Guardrails.t;
+  visible_tool_names: string list;
+    (** Names of the tools that survived guardrails + operator policy
+        + tool_filter_override + tool_selector. This is exactly the
+        list the LLM sees this turn — not the agent's full tool
+        registry. Useful for [Event_bus.TurnReady] subscribers and
+        deterministic substrate observability. Empty list when no
+        tools are presented to the LLM.
+
+        Order matches [tools_json]: tool_selector ordering is
+        preserved when present, otherwise the guardrail-filtered
+        order from [Tool_set.to_list].
+
+        @since 0.162.0 *)
 }
 
 (** Prepare tool schemas, applying operator policy and optional
@@ -86,7 +99,12 @@ val prepare_tools :
   ?tool_selector:Tool_selector.strategy ->
   ?messages:Types.message list ->
   unit ->
-  Yojson.Safe.t list option * Guardrails.t
+  Yojson.Safe.t list option * string list * Guardrails.t
+(** Returns [(tools_json, visible_tool_names, effective_guardrails)].
+    [visible_tool_names] mirrors the order of [tools_json] and is empty
+    when no tools survive filtering.
+
+    @since 0.162.0 third tuple element added (visible_tool_names) *)
 
 (** Reduce messages and inject extra system context. *)
 val tiered_memory_tokens : tiered_memory option -> int

--- a/lib/eval_collector.ml
+++ b/lib/eval_collector.ml
@@ -54,6 +54,7 @@ let process_events t =
     (* Lifecycle events — observed but not metered here.
        Downstream consumers can subscribe for richer metrics. *)
     | AgentStarted _
+    | TurnReady _
     | TurnCompleted _
     | HandoffRequested _
     | HandoffCompleted _

--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -37,6 +37,8 @@ type payload =
   | ToolCompleted of { agent_name: string; tool_name: string;
                        output: Types.tool_result }
   | TurnStarted of { agent_name: string; turn: int }
+  | TurnReady of { agent_name: string; turn: int;
+                   tool_names: string list }
   | TurnCompleted of { agent_name: string; turn: int }
   | HandoffRequested of { from_agent: string; to_agent: string; reason: string }
   | HandoffCompleted of { from_agent: string; to_agent: string; elapsed: float }
@@ -164,6 +166,7 @@ let filter_agent name : filter = fun event ->
   | ToolCalled r -> r.agent_name = name
   | ToolCompleted r -> r.agent_name = name
   | TurnStarted r -> r.agent_name = name
+  | TurnReady r -> r.agent_name = name
   | TurnCompleted r -> r.agent_name = name
   | HandoffRequested r -> r.from_agent = name || r.to_agent = name
   | HandoffCompleted r -> r.from_agent = name || r.to_agent = name

--- a/lib/event_bus.mli
+++ b/lib/event_bus.mli
@@ -56,6 +56,21 @@ type payload =
   | ToolCompleted of { agent_name: string; tool_name: string;
                        output: Types.tool_result }
   | TurnStarted of { agent_name: string; turn: int }
+  | TurnReady of { agent_name: string; turn: int;
+                   tool_names: string list }
+      (** Emitted between [TurnStarted] and the LLM call, after
+          guardrails + operator policy + tool_filter_override +
+          tool_selector have been applied to the agent's tool registry.
+          [tool_names] is exactly the list of tools the LLM sees this
+          turn (deterministic, ordered). Empty list when no tools are
+          presented to the LLM.
+
+          Subscribers can use this to observe the substrate the
+          autonomous agent operates on — e.g., to verify that an
+          expected tool is actually exposed before drawing conclusions
+          about LLM behaviour from a missing tool call.
+
+          @since 0.162.0 *)
   | TurnCompleted of { agent_name: string; turn: int }
   | HandoffRequested of { from_agent: string; to_agent: string; reason: string }
       (** Agent-to-agent handoff has been requested. Emitted when an

--- a/lib/event_forward.ml
+++ b/lib/event_forward.ml
@@ -54,6 +54,7 @@ let event_type_name (event : Event_bus.event) : string =
   | ToolCalled _ -> "tool.called"
   | ToolCompleted _ -> "tool.completed"
   | TurnStarted _ -> "turn.started"
+  | TurnReady _ -> "turn.ready"
   | TurnCompleted _ -> "turn.completed"
   | HandoffRequested _ -> "handoff.requested"
   | HandoffCompleted _ -> "handoff.completed"
@@ -74,6 +75,7 @@ let agent_name_of_payload : Event_bus.payload -> string option = function
   | ToolCalled r -> Some r.agent_name
   | ToolCompleted r -> Some r.agent_name
   | TurnStarted r -> Some r.agent_name
+  | TurnReady r -> Some r.agent_name
   | TurnCompleted r -> Some r.agent_name
   | HandoffRequested r -> Some r.from_agent
   | HandoffCompleted r -> Some r.from_agent
@@ -124,6 +126,13 @@ let event_to_payload (event : Event_bus.event) : event_payload =
       ]
     | TurnStarted r ->
       `Assoc [("agent_name", `String r.agent_name); ("turn", `Int r.turn)]
+    | TurnReady r ->
+      `Assoc [
+        ("agent_name", `String r.agent_name);
+        ("turn", `Int r.turn);
+        ("tool_names", `List (List.map (fun n -> `String n) r.tool_names));
+        ("tool_count", `Int (List.length r.tool_names));
+      ]
     | TurnCompleted r ->
       `Assoc [("agent_name", `String r.agent_name); ("turn", `Int r.turn)]
     | HandoffRequested r ->

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -190,4 +190,35 @@ let stage_parse ?raw_trace_run agent =
   | None -> ());
 
   let prep = prepare_turn_for_agent agent ~turn_params in
+  (* TurnReady event — emitted after guardrails + operator policy +
+     tool_filter_override + tool_selector have produced the final tool
+     list the LLM will see this turn. Subscribers (e.g. masc-mcp
+     substrate observability) use this to verify deterministically
+     which tools the autonomous agent actually has access to, before
+     making claims about LLM behaviour from a missing tool call.
+     Sibling of TurnStarted (announce) and TurnCompleted (post-LLM). *)
+  (match agent.options.event_bus with
+  | Some bus ->
+      Event_bus.publish bus
+        {
+          meta =
+            Event_bus.mk_envelope
+              ~correlation_id:
+                (match Option.bind agent.options.raw_trace Raw_trace.session_id with
+                | Some session_id -> session_id
+                | None -> Event_bus.fresh_id ())
+              ~run_id:
+                (match Option.bind (lifecycle_snapshot agent) (fun s -> s.current_run_id) with
+                | Some run_id -> run_id
+                | None -> Event_bus.fresh_id ())
+              ();
+          payload =
+            TurnReady
+              {
+                agent_name = agent.state.config.name;
+                turn = agent.state.turn_count;
+                tool_names = prep.visible_tool_names;
+              };
+        }
+  | None -> ());
   (prep, original_config, turn_params)

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -59,7 +59,45 @@ let test_prepare_turn_with_guardrails_filter () =
     ()
   in
   let count = match prep.tools_json with Some l -> List.length l | None -> 0 in
-  Alcotest.(check int) "only tool a" 1 count
+  Alcotest.(check int) "only tool a" 1 count;
+  Alcotest.(check (list string)) "visible_tool_names matches filter"
+    ["a"] prep.visible_tool_names
+
+(* visible_tool_names mirrors the tool list the LLM actually sees this
+   turn — exposed via Event_bus.TurnReady for substrate observability.
+   Empty when no tools survive filtering. *)
+let test_prepare_turn_visible_tool_names_empty () =
+  let prep = Agent_turn.prepare_turn
+    ~guardrails:Guardrails.default
+    ~operator_policy:None
+    ~policy_channel:None
+    ~tools:Tool_set.empty
+    ~messages:[]
+    ~context_reducer:None
+    ~tiered_memory:None
+    ~turn_params:Hooks.default_turn_params
+    ()
+  in
+  Alcotest.(check (list string)) "empty when no tools"
+    [] prep.visible_tool_names
+
+let test_prepare_turn_visible_tool_names_preserves_order () =
+  let make n = Tool.create ~name:n ~description:n ~parameters:[]
+    (fun _ -> Ok { Types.content = "" }) in
+  let tools = Tool_set.of_list [make "Bash"; make "Read"; make "Edit"] in
+  let prep = Agent_turn.prepare_turn
+    ~guardrails:Guardrails.default
+    ~operator_policy:None
+    ~policy_channel:None
+    ~tools
+    ~messages:[]
+    ~context_reducer:None
+    ~tiered_memory:None
+    ~turn_params:Hooks.default_turn_params
+    ()
+  in
+  Alcotest.(check (list string)) "registry order preserved"
+    ["Bash"; "Read"; "Edit"] prep.visible_tool_names
 
 (* ── prepare_messages tests ────────────────────────────────── *)
 
@@ -800,6 +838,10 @@ let () =
       Alcotest.test_case "empty tools" `Quick test_prepare_turn_empty_tools;
       Alcotest.test_case "with tools" `Quick test_prepare_turn_with_tools;
       Alcotest.test_case "guardrails filter" `Quick test_prepare_turn_with_guardrails_filter;
+      Alcotest.test_case "visible_tool_names empty"
+        `Quick test_prepare_turn_visible_tool_names_empty;
+      Alcotest.test_case "visible_tool_names preserves order"
+        `Quick test_prepare_turn_visible_tool_names_preserves_order;
       Alcotest.test_case "filter override" `Quick test_prepare_turn_filter_override;
     ];
     "prepare_messages", [

--- a/test/test_event_forward.ml
+++ b/test/test_event_forward.ml
@@ -306,6 +306,39 @@ let test_turn_completed_payload () =
   Alcotest.(check string) "type" "turn.completed" p.event_type;
   Alcotest.(check (option string)) "agent" (Some "worker") p.agent_name
 
+let test_turn_ready_payload () =
+  let evt = ev (Event_bus.TurnReady {
+    agent_name = "worker"; turn = 7;
+    tool_names = ["Bash"; "Read"; "Edit"] }) in
+  let p = Event_forward.event_to_payload evt in
+  Alcotest.(check string) "type" "turn.ready" p.event_type;
+  Alcotest.(check (option string)) "agent" (Some "worker") p.agent_name;
+  let json = Event_forward.payload_to_json p in
+  let open Yojson.Safe.Util in
+  let data = json |> member "data" in
+  Alcotest.(check int) "tool_count" 3
+    (data |> member "tool_count" |> to_int);
+  Alcotest.(check int) "turn" 7
+    (data |> member "turn" |> to_int);
+  let names = data |> member "tool_names" |> to_list
+              |> List.map to_string in
+  Alcotest.(check (list string)) "tool_names ordered"
+    ["Bash"; "Read"; "Edit"] names
+
+let test_turn_ready_empty_tools () =
+  (* Empty list is the well-defined "no tools presented to LLM" state. *)
+  let evt = ev (Event_bus.TurnReady {
+    agent_name = "agent"; turn = 0; tool_names = [] }) in
+  let p = Event_forward.event_to_payload evt in
+  Alcotest.(check string) "type" "turn.ready" p.event_type;
+  let json = Event_forward.payload_to_json p in
+  let open Yojson.Safe.Util in
+  Alcotest.(check int) "tool_count = 0" 0
+    (json |> member "data" |> member "tool_count" |> to_int);
+  Alcotest.(check (list string)) "empty tool_names" []
+    (json |> member "data" |> member "tool_names"
+     |> to_list |> List.map to_string)
+
 let test_elicitation_completed_payload () =
   let evt = ev (Event_bus.ElicitationCompleted {
     agent_name = "agent"; question = "confirm?";
@@ -415,6 +448,9 @@ let () =
       Alcotest.test_case "inference_telemetry absent fields"
         `Quick test_inference_telemetry_partial_fields;
       Alcotest.test_case "turn_completed" `Quick test_turn_completed_payload;
+      Alcotest.test_case "turn_ready" `Quick test_turn_ready_payload;
+      Alcotest.test_case "turn_ready empty tools"
+        `Quick test_turn_ready_empty_tools;
       Alcotest.test_case "elicitation" `Quick test_elicitation_completed_payload;
       Alcotest.test_case "custom event" `Quick test_custom_event_payload;
       Alcotest.test_case "agent_started" `Quick test_agent_started_payload;

--- a/test/test_operator_policy.ml
+++ b/test/test_operator_policy.ml
@@ -65,7 +65,7 @@ let test_operator_restricts_allow_all () =
   let tool_b = make_tool "b" in
   let tool_c = make_tool "c" in
   let tools = Tool_set.of_list [tool_a; tool_b; tool_c] in
-  let tools_json, _ = Agent_turn.prepare_tools
+  let tools_json, _, _ = Agent_turn.prepare_tools
     ~guardrails:Guardrails.default
     ~operator_policy:(Some (Guardrails.AllowList ["a"]))
     ~policy_channel:None
@@ -79,7 +79,7 @@ let test_operator_restricts_allow_all () =
 let test_operator_denylist_on_allowall () =
   (* Agent: AllowAll, Operator: DenyList ["b"] -> "a", "c" visible *)
   let tools = Tool_set.of_list [make_tool "a"; make_tool "b"; make_tool "c"] in
-  let tools_json, _ = Agent_turn.prepare_tools
+  let tools_json, _, _ = Agent_turn.prepare_tools
     ~guardrails:Guardrails.default
     ~operator_policy:(Some (Guardrails.DenyList ["b"]))
     ~policy_channel:None
@@ -95,7 +95,7 @@ let test_no_operator_is_noop () =
   let guardrails = { Guardrails.default with
     tool_filter = Guardrails.AllowList ["a"] } in
   let tools = Tool_set.of_list [make_tool "a"; make_tool "b"] in
-  let tools_json, _ = Agent_turn.prepare_tools
+  let tools_json, _, _ = Agent_turn.prepare_tools
     ~guardrails
     ~operator_policy:None
     ~policy_channel:None
@@ -112,7 +112,7 @@ let test_turn_override_intersects_operator () =
   let tools = Tool_set.of_list [make_tool "a"; make_tool "b"; make_tool "c"] in
   let turn_params = { Hooks.default_turn_params with
     tool_filter_override = Some (Guardrails.AllowList ["b"; "c"]) } in
-  let tools_json, _ = Agent_turn.prepare_tools
+  let tools_json, _, _ = Agent_turn.prepare_tools
     ~guardrails:Guardrails.default
     ~operator_policy:(Some (Guardrails.AllowList ["a"; "b"]))
     ~policy_channel:None
@@ -129,7 +129,7 @@ let test_turn_override_cannot_widen_operator () =
   let tools = Tool_set.of_list [make_tool "a"; make_tool "b"; make_tool "c"] in
   let turn_params = { Hooks.default_turn_params with
     tool_filter_override = Some (Guardrails.AllowList ["b"]) } in
-  let tools_json, _ = Agent_turn.prepare_tools
+  let tools_json, _, _ = Agent_turn.prepare_tools
     ~guardrails:Guardrails.default
     ~operator_policy:(Some (Guardrails.AllowList ["a"]))
     ~policy_channel:None

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -111,7 +111,10 @@ let test_agent_turn_preparation () =
      Alcotest.(check int) "2 tools in json" 2 (List.length tools_json)
    | None -> Alcotest.fail "expected tools_json");
   (* effective_messages should contain our user message *)
-  Alcotest.(check int) "1 message" 1 (List.length prep.effective_messages)
+  Alcotest.(check int) "1 message" 1 (List.length prep.effective_messages);
+  (* visible_tool_names mirrors tools_json — exact list LLM sees *)
+  Alcotest.(check (list string)) "visible_tool_names matches"
+    ["a"; "b"] prep.visible_tool_names
 
 let test_agent_turn_idle_detection () =
   let tool_uses = [
@@ -279,7 +282,10 @@ let test_prepare_turn_no_tools () =
   (match prep.tools_json with
    | None -> ()
    | Some _ -> Alcotest.fail "expected no tools_json for empty tool set");
-  Alcotest.(check int) "1 message" 1 (List.length prep.effective_messages)
+  Alcotest.(check int) "1 message" 1 (List.length prep.effective_messages);
+  (* visible_tool_names is empty when no tools survive filtering *)
+  Alcotest.(check (list string)) "empty visible_tool_names"
+    [] prep.visible_tool_names
 
 let test_prepare_turn_preserves_messages () =
   let messages = [

--- a/test/test_policy_channel.ml
+++ b/test/test_policy_channel.ml
@@ -63,7 +63,7 @@ let test_channel_restricts_tools () =
   let ch = Policy_channel.create () in
   Policy_channel.push ch (Tool_op.Remove ["shell"]);
   let tools = Tool_set.of_list [make_tool "read"; make_tool "shell"; make_tool "write"] in
-  let tools_json, _ = Agent_turn.prepare_tools
+  let tools_json, _, _ = Agent_turn.prepare_tools
     ~guardrails:Guardrails.default
     ~operator_policy:None
     ~policy_channel:(Some ch)
@@ -76,7 +76,7 @@ let test_channel_restricts_tools () =
 
 let test_channel_none_is_noop () =
   let tools = Tool_set.of_list [make_tool "a"; make_tool "b"] in
-  let tools_json, _ = Agent_turn.prepare_tools
+  let tools_json, _, _ = Agent_turn.prepare_tools
     ~guardrails:Guardrails.default
     ~operator_policy:None
     ~policy_channel:None
@@ -90,7 +90,7 @@ let test_channel_none_is_noop () =
 let test_channel_empty_is_noop () =
   let ch = Policy_channel.create () in
   let tools = Tool_set.of_list [make_tool "a"; make_tool "b"] in
-  let tools_json, _ = Agent_turn.prepare_tools
+  let tools_json, _, _ = Agent_turn.prepare_tools
     ~guardrails:Guardrails.default
     ~operator_policy:None
     ~policy_channel:(Some ch)
@@ -108,7 +108,7 @@ let test_channel_overrides_operator_policy () =
   let ch = Policy_channel.create () in
   Policy_channel.push ch (Tool_op.Intersect_with ["a"]);
   let tools = Tool_set.of_list [make_tool "a"; make_tool "b"; make_tool "c"] in
-  let tools_json, _ = Agent_turn.prepare_tools
+  let tools_json, _, _ = Agent_turn.prepare_tools
     ~guardrails:Guardrails.default
     ~operator_policy:(Some (Guardrails.AllowList ["a"; "b"]))
     ~policy_channel:(Some ch)
@@ -131,7 +131,7 @@ let test_multiple_updates_compose_correctly () =
     make_tool "read"; make_tool "write";
     make_tool "shell"; make_tool "deploy"
   ] in
-  let tools_json, _ = Agent_turn.prepare_tools
+  let tools_json, _, _ = Agent_turn.prepare_tools
     ~guardrails:Guardrails.default
     ~operator_policy:None
     ~policy_channel:(Some ch)


### PR DESCRIPTION
## Summary

Add `Event_bus.TurnReady` payload — emitted between `TurnStarted` and the LLM call, carrying the **exact list of tool names the LLM will see this turn** after guardrails / operator policy / tool_filter_override / tool_selector have all been applied.

Closes a deterministic-observability gap: until now, downstream consumers (e.g. `masc-mcp` autonomous keepers) had no way to query the post-filter tool list — `prepare_turn` computes it but never exposes it via the bus, so operators were forced to grep logs to distinguish "LLM chose not to use tool X" from "tool X was filtered before the LLM ever saw it".

## Why this is the right shape (claude-code reference)

| Concern | claude-code pattern | This PR |
|---|---|---|
| What does the LLM actually see? | `assembleToolPool()` + `filterToolsByDenyRules()` produce a final list (`src/tools.ts:179-251`) | `prepare_turn` already filters internally; this PR exposes the result |
| How do consumers observe? | Hooks (`PreToolUse`, `PermissionRequest`) | Event_bus subscriber (`TurnReady`) |
| Empty-set semantics | Empty array means "no tools presented" | Empty `tool_names` means "no tools presented" — present, not absent |

Calling out the *negative space*: this PR does **not** add a permission rule grammar, a custom risk taxonomy, or any vocabulary canonicalization. Those are intentionally deferred — see "Boundary respected" below.

## What this PR adds

- `Event_bus.TurnReady { agent_name; turn; tool_names: string list }` — variant addition only, backwards-compat for any subscriber using `| _ -> ...`. Exhaustive consumers (`eval_collector`) handled in this commit.
- `Agent_turn.turn_preparation.visible_tool_names: string list` — new record field; `prepare_tools` returns `(json, names, guardrails)` (was 2-tuple).
- `event_forward.ml` JSON serialization with `tool_names` and `tool_count` fields for downstream log shipping.
- Emission point: `pipeline_stage_prepare.ml` right after `prepare_turn_for_agent` — same envelope semantics as `TurnStarted`.

## Boundary respected

This PR is the **OAS half of a two-repo change** (`OAS-PR-2` in the masc-mcp Plan v5). The MASC-side consumer (`PR-L`) subscribes to `TurnReady` to emit `[substrate:tool_surface]` logs + Prometheus metrics. By keeping the *event* in OAS and the *interpretation* in MASC, we honor the project's MASC↔OAS layer rules:

- OAS owns the deterministic substrate signal (one tool list per turn).
- MASC owns the operational interpretation (is `git_clone` exposed? is the substrate clean enough to attribute LLM behaviour?).

A future `OAS-PR-1` will add a declarative permission rule grammar (Claude Code's `Bash(git clone *)` style); that is **not** in this PR — separated to keep review scope tight.

## Tests

```
test_event_forward: 25/25 OK   (incl. 2 new TurnReady cases)
test_agent_turn:    46/46 OK   (incl. 2 new visible_tool_names cases)
dune build @check:  clean (full library + every registered test)
```

End-to-end emission via `Eio_main.run` + `Agent.run` is **intentionally deferred** to the masc-mcp consumer PR. Rationale: the emission point is a single `Event_bus.publish` immediately following `prepare_turn_for_agent`; the upstream computation (`visible_tool_names`) and the downstream serialization (`turn.ready` JSON) are pinned by the unit tests above; an end-to-end test would require exposing internal pipeline modules through `agent_sdk.ml`, which is a larger boundary change than is justified for this single emission.

## Migration impact for consumers

| Pattern | Action required |
|---|---|
| `match payload with \| _ -> ...` | None |
| Exhaustive payload match | Add a `TurnReady _` arm |
| Reads `prepare_tools` 2-tuple | Update to `(json, names, guardrails)` (3 sites in this repo handled) |

## Plan v5 reference

`~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-k-wise-pudding.md` § 2.7 (OAS boundary mapping → "신규 OAS PR" → OAS-PR-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
