### PR TITLE
feat(event_bus): add InferenceTelemetry event for per-turn timings

### DIFF
--- a/lib/eval_collector.ml
+++ b/lib/eval_collector.ml
@@ -64,6 +64,7 @@ let process_events t =
     | ContentReplacementReplaced _
     | ContentReplacementKept _
     | SlotSchedulerObserved _
+    | InferenceTelemetry _
     | Custom _ -> ()
   ) events
 

--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -62,6 +62,17 @@ type payload =
       queue_length: int;
       state: slot_scheduler_state;
     }
+  | InferenceTelemetry of {
+      agent_name: string;
+      turn: int;
+      provider: string;
+      model: string;
+      prompt_tokens: int option;
+      completion_tokens: int option;
+      prompt_ms: float option;
+      decode_ms: float option;
+      decode_tok_s: float option;
+    }
   | Custom of string * Yojson.Safe.t
 
 (* ── Event type ───────────────────────────────────────────────────── *)
@@ -163,6 +174,7 @@ let filter_agent name : filter = fun event ->
   | ContentReplacementReplaced _
   | ContentReplacementKept _
   | SlotSchedulerObserved _ -> true
+  | InferenceTelemetry r -> r.agent_name = name
   | Custom _ -> true  (* Custom events are not agent-scoped; always pass *)
 
 let filter_tools_only : filter = fun event ->

--- a/lib/event_bus.mli
+++ b/lib/event_bus.mli
@@ -104,6 +104,36 @@ type payload =
       (** Snapshot of the slot scheduler queue state. Promoted from
           [Custom("slot_scheduler_queue", ...)].
           @since 0.154.1 *)
+  | InferenceTelemetry of {
+      agent_name: string;
+      turn: int;
+      provider: string;
+      model: string;
+      prompt_tokens: int option;
+      completion_tokens: int option;
+      prompt_ms: float option;
+      decode_ms: float option;
+      decode_tok_s: float option;
+    }
+      (** Per-turn inference timings & token usage. Emitted alongside
+          {!TurnCompleted} when the provider reported native timings
+          (currently Ollama via [prompt_eval_*] / [eval_*] fields).
+
+          [decode_tok_s] is decode-only throughput, computed as
+          [completion_tokens / (decode_ms / 1000)] when both are
+          available. Distinguishes hardware decode rate from wall-clock
+          [tok/s] (which mixes prefill into the denominator).
+
+          [prompt_ms] is the prefill duration; downstream consumers may
+          classify a turn as "warm" (cache hit) when [prompt_ms] is
+          significantly lower than a recent baseline for the same prefix.
+          Cold/warm classification itself is a heuristic and lives in
+          consumers, not in this event.
+
+          Subscribers should treat absent fields as "backend did not
+          report this metric" — never fabricate a value or substitute
+          a default. Ollama reports all five metrics; OpenAI-compatible
+          backends typically report only token counts. *)
   | Custom of string * Yojson.Safe.t
       (** Extension point.  [name] must be a dot-separated, lowercase,
           snake-case namespaced identifier (e.g. ["mylib.foo_happened"]).

--- a/lib/event_forward.ml
+++ b/lib/event_forward.ml
@@ -64,6 +64,7 @@ let event_type_name (event : Event_bus.event) : string =
   | ContentReplacementReplaced _ -> "content_replacement.replaced"
   | ContentReplacementKept _ -> "content_replacement.kept"
   | SlotSchedulerObserved _ -> "slot_scheduler.observed"
+  | InferenceTelemetry _ -> "inference.telemetry"
   | Custom (name, _) -> name
 
 let agent_name_of_payload : Event_bus.payload -> string option = function
@@ -83,6 +84,7 @@ let agent_name_of_payload : Event_bus.payload -> string option = function
   | ContentReplacementReplaced _
   | ContentReplacementKept _
   | SlotSchedulerObserved _ -> None
+  | InferenceTelemetry r -> Some r.agent_name
   | Custom _ -> None
 
 let agent_name_of_event (event : Event_bus.event) : string option =
@@ -178,6 +180,20 @@ let event_to_payload (event : Event_bus.event) : event_payload =
         ("available", `Int r.available);
         ("queue_length", `Int r.queue_length);
         ("state", `String (slot_scheduler_state_to_string r.state));
+      ]
+    | InferenceTelemetry r ->
+      let opt_int = function Some n -> `Int n | None -> `Null in
+      let opt_float = function Some f -> `Float f | None -> `Null in
+      `Assoc [
+        ("agent_name", `String r.agent_name);
+        ("turn", `Int r.turn);
+        ("provider", `String r.provider);
+        ("model", `String r.model);
+        ("prompt_tokens", opt_int r.prompt_tokens);
+        ("completion_tokens", opt_int r.completion_tokens);
+        ("prompt_ms", opt_float r.prompt_ms);
+        ("decode_ms", opt_float r.decode_ms);
+        ("decode_tok_s", opt_float r.decode_tok_s);
       ]
     | Custom (name, data) ->
       `Assoc [("name", `String name); ("data", data)]

--- a/lib/pipeline/stage_collect.ml
+++ b/lib/pipeline/stage_collect.ml
@@ -33,6 +33,43 @@ let stage_collect ?raw_trace_run agent ~original_config response =
            { agent_name = agent.state.config.name;
              turn = agent.state.turn_count } }
    | None -> ());
+  (* Per-turn inference telemetry. Decoupled from TurnCompleted so subscribers
+     interested only in lifecycle don't pay parsing cost; subscribers tracking
+     decode rate / prefill latency don't have to remember which TurnCompleted
+     carried timings. *)
+  (match agent.options.event_bus, response.telemetry with
+   | Some bus, Some tel ->
+       let timings = tel.timings in
+       let prompt_tokens = Option.bind timings (fun t -> t.Types.prompt_n) in
+       let completion_tokens =
+         Option.bind timings (fun t -> t.Types.predicted_n) in
+       let prompt_ms = Option.bind timings (fun t -> t.Types.prompt_ms) in
+       let decode_ms = Option.bind timings (fun t -> t.Types.predicted_ms) in
+       let decode_tok_s =
+         Option.bind timings (fun t -> t.Types.predicted_per_second) in
+       let any_field =
+         Option.is_some prompt_tokens || Option.is_some completion_tokens
+         || Option.is_some prompt_ms || Option.is_some decode_ms
+         || Option.is_some decode_tok_s
+       in
+       if any_field then
+         let provider = match tel.provider_kind with
+           | Some k -> Llm_provider.Provider_kind.to_string k
+           | None -> "unknown"
+         in
+         Event_bus.publish bus
+           { meta = event_envelope agent;
+             payload = InferenceTelemetry
+               { agent_name = agent.state.config.name;
+                 turn = agent.state.turn_count;
+                 provider;
+                 model = response.model;
+                 prompt_tokens;
+                 completion_tokens;
+                 prompt_ms;
+                 decode_ms;
+                 decode_tok_s } }
+   | _ -> ());
   (match agent.options.journal with
    | Some j ->
        Durable_event.append j

--- a/test/test_event_forward.ml
+++ b/test/test_event_forward.ml
@@ -29,6 +29,12 @@ let test_event_type_name () =
            max_slots = 4; active = 2; available = 2; queue_length = 1;
            state = Event_bus.Queued }),
      "slot_scheduler.observed");
+    (ev (Event_bus.InferenceTelemetry {
+           agent_name = "a"; turn = 1; provider = "ollama"; model = "qwen3";
+           prompt_tokens = Some 100; completion_tokens = Some 50;
+           prompt_ms = Some 200.0; decode_ms = Some 1000.0;
+           decode_tok_s = Some 50.0 }),
+     "inference.telemetry");
     (ev (Event_bus.Custom ("foo", `Null)),
      "foo");
     (ev (Event_bus.ContextOverflowImminent {
@@ -254,6 +260,44 @@ let test_native_telemetry_payloads () =
   Alcotest.(check string) "queue state" "saturated"
     (queue_payload.data |> member "state" |> to_string)
 
+let test_inference_telemetry_payload () =
+  let evt = ev (Event_bus.InferenceTelemetry {
+    agent_name = "worker"; turn = 4; provider = "ollama";
+    model = "qwen3.6:27b-coding-nvfp4";
+    prompt_tokens = Some 172000; completion_tokens = Some 309;
+    prompt_ms = Some 540000.0; decode_ms = Some 8500.0;
+    decode_tok_s = Some 36.4 }) in
+  let p = Event_forward.event_to_payload evt in
+  Alcotest.(check string) "type" "inference.telemetry" p.event_type;
+  Alcotest.(check (option string)) "agent" (Some "worker") p.agent_name;
+  let open Yojson.Safe.Util in
+  Alcotest.(check int) "turn" 4 (p.data |> member "turn" |> to_int);
+  Alcotest.(check string) "provider" "ollama"
+    (p.data |> member "provider" |> to_string);
+  Alcotest.(check string) "model" "qwen3.6:27b-coding-nvfp4"
+    (p.data |> member "model" |> to_string);
+  Alcotest.(check int) "prompt_tokens" 172000
+    (p.data |> member "prompt_tokens" |> to_int);
+  Alcotest.(check int) "completion_tokens" 309
+    (p.data |> member "completion_tokens" |> to_int);
+  Alcotest.(check (float 0.001)) "decode_tok_s" 36.4
+    (p.data |> member "decode_tok_s" |> to_number)
+
+let test_inference_telemetry_partial_fields () =
+  (* OpenAI-compat backends typically only report token counts; absent
+     timing fields must serialize as JSON null, not be omitted or default
+     to 0. Subscribers distinguish "absent" from "zero". *)
+  let evt = ev (Event_bus.InferenceTelemetry {
+    agent_name = "a"; turn = 1; provider = "openai_compat"; model = "gpt-x";
+    prompt_tokens = Some 50; completion_tokens = Some 10;
+    prompt_ms = None; decode_ms = None; decode_tok_s = None }) in
+  let p = Event_forward.event_to_payload evt in
+  let open Yojson.Safe.Util in
+  Alcotest.(check bool) "prompt_ms is null" true
+    (match p.data |> member "prompt_ms" with `Null -> true | _ -> false);
+  Alcotest.(check bool) "decode_tok_s is null" true
+    (match p.data |> member "decode_tok_s" with `Null -> true | _ -> false)
+
 (* ── event_to_payload: remaining event types ──────────────── *)
 
 let test_turn_completed_payload () =
@@ -366,6 +410,10 @@ let () =
       Alcotest.test_case "agent_completed" `Quick test_agent_completed_payload;
       Alcotest.test_case "tool events" `Quick test_tool_events_payload;
       Alcotest.test_case "native telemetry" `Quick test_native_telemetry_payloads;
+      Alcotest.test_case "inference_telemetry full"
+        `Quick test_inference_telemetry_payload;
+      Alcotest.test_case "inference_telemetry absent fields"
+        `Quick test_inference_telemetry_partial_fields;
       Alcotest.test_case "turn_completed" `Quick test_turn_completed_payload;
       Alcotest.test_case "elicitation" `Quick test_elicitation_completed_payload;
       Alcotest.test_case "custom event" `Quick test_custom_event_payload;


### PR DESCRIPTION
## Summary

`InferenceTelemetry` variant을 `Event_bus.payload`에 추가. `backend_ollama` / `streaming`이 이미 파싱하는 `prompt_eval_count` / `prompt_eval_duration` / `eval_count` / `eval_duration` 값을 `stage_collect`에서 emit-only로 노출.

## Why

masc-mcp 대시보드의 `wall tok/s 0.2 / 0.2` 카드 진단 중 발견: OAS가 timings를 파싱하지만 Event_bus로 노출하지 않아 consumer가 자체 metric 추출 코드를 두는 상황. silent protocol downgrade 위험(`feedback_no-silent-protocol-downgrade-for-telemetry.md`).

OAS가 raw inference 측정을 owns하고 (memory `feedback_inference-belongs-in-oas.md`), masc-mcp는 subscriber로 소비.

## Boundary

- emit-only. 기존 subscriber 무영향(variant 추가, 기존 match는 `_` wildcard로 폴스루).
- subscriber가 cold/warm 분류, dashboard 렌더링 등을 결정. 본 PR은 신호만.
- 모든 timing 필드 `option`. 필드 부재 = "백엔드가 보고 안 함" — 0으로 fabricate 금지.

## Implementation

| File | Change |
|------|--------|
| `lib/event_bus.mli` / `.ml` | `InferenceTelemetry` variant + `filter_agent` 매치 |
| `lib/event_forward.ml` | `inference.telemetry` channel name + agent_name + payload JSON |
| `lib/eval_collector.ml` | exhaustive match에 추가 (no-op, lifecycle 계열과 동치) |
| `lib/pipeline/stage_collect.ml` | TurnCompleted 직후 emit (timings present 시) |
| `test/test_event_forward.ml` | full + partial fields 두 케이스 |

## Test plan

- [x] `_build/default/test/test_event_forward.exe` 25/25 pass (신규 2 포함)
- [x] `dune build lib/agent_sdk.cma` 성공
- [x] `dune build test/test_event_bus.exe test/test_slot_scheduler_event_bridge.exe test/test_multivendor_events.exe` 성공 (variant 추가가 기존 wildcard 매치 안 깸)
- [ ] downstream consumer (masc-mcp `model_inference_metrics.ml`)는 별도 PR로 마이그레이션

## Out of scope

- Cold/warm 분류, cache hit ratio 산출 — subscriber 책임
- `InferenceTelemetry` 외 다른 event(예: `ContextOverflowImminent`)에 timings 첨부 — 별도 PR
- `streaming.ml` emit — 현재 streaming 경로는 chunked, per-turn aggregation 별도 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)