### PR TITLE
feat(transport/claude_code): structured ProviderTerminal for max_turns (masc-mcp#10629)

### DIFF
--- a/lib/judge/judge.ml
+++ b/lib/judge/judge.ml
@@ -158,6 +158,7 @@ let judge ~sw ~net ~provider ~config ~context () =
       | Http_client.NetworkError { message; _ } -> message
       | Http_client.CliTransportRequired { kind } ->
         Printf.sprintf "CLI transport required for %s" kind
+      | Http_client.ProviderTerminal { message; _ } -> message
     in
     Error (Printf.sprintf "Judge LLM call failed: %s" msg)
   | Ok response ->

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -612,6 +612,7 @@ let complete ~sw ~net ?(transport : Llm_transport.t option)
                 Printf.sprintf
                   "CLI transport required for %s but none injected"
                   kind
+            | Http_client.ProviderTerminal { message; _ } -> message
           in
           m.on_error ~model_id ~error:err_str;
           Error err)
@@ -648,6 +649,11 @@ let classify_retry_error = function
   (* Wiring bug, not transient — retrying cannot summon a missing
      transport. *)
   | Http_client.CliTransportRequired _ -> None
+  (* Provider hit its own terminal condition (e.g. claude_code's
+     internal max_turns).  Retry would re-trigger the same
+     deterministic exit, so signal non-retryable and let the agent
+     runtime checkpoint via [Error.Agent (MaxTurnsExceeded ...)]. *)
+  | Http_client.ProviderTerminal _ -> None
 
 let is_retryable = function
   | err ->

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -103,6 +103,11 @@ let get_json ~sw ~net url =
     Error message
   | Error (Http_client.CliTransportRequired { kind }) ->
     Error (Printf.sprintf "CLI transport required for %s" kind)
+  | Error (Http_client.ProviderTerminal { message; _ }) ->
+    (* Discovery hits HTTP endpoints only; CLI subprocess terminals
+       cannot reach this match.  Surface the message defensively so the
+       exhaustive match stays sound. *)
+    Error message
 
 let get_ok ~sw ~net url =
   match Http_client.get_sync ~sw ~net ~url ~headers:[] () with
@@ -260,6 +265,7 @@ let probe_ollama_context ~sw ~net base_url =
             | Http_client.AcceptRejected { reason } -> reason
             | Http_client.CliTransportRequired { kind } ->
                 Printf.sprintf "CLI transport required for %s" kind
+            | Http_client.ProviderTerminal { message; _ } -> message
           in
           warn_probe_failure ~url:base_url ~phase:"ollama_show_http" detail;
           None

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -21,6 +21,14 @@ type network_error_kind =
   | End_of_file
   | Unknown
 
+(* Provider-internal terminal condition reported via structured exit
+   (see .mli for the rationale and the @since note).  Adding a new
+   variant rather than overloading [NetworkError] keeps cascades from
+   counting a provider's own [max_turns] hit as a flaky network. *)
+type provider_terminal_kind =
+  | Max_turns of { turns: int; limit: int }
+  | Other of string
+
 type http_error =
   | HttpError of { code: int; body: string }
   | NetworkError of { message: string; kind: network_error_kind }
@@ -33,6 +41,7 @@ type http_error =
      network failure, and so callers see a clear "configuration/wiring
      bug" rather than a cohttp [Unknown scheme None]. *)
   | CliTransportRequired of { kind: string }
+  | ProviderTerminal of { kind: provider_terminal_kind; message: string }
 
 (* ── Internal helpers ──────────────────────────────────────── *)
 
@@ -144,6 +153,7 @@ let is_local_resource_exhaustion = function
   | HttpError _ -> false
   | CliTransportRequired _ -> false
   | NetworkError _ -> false
+  | ProviderTerminal _ -> false
 
 (* ── Public API ────────────────────────────────────────────── *)
 

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -28,6 +28,29 @@ type network_error_kind =
   | Unknown
       (** Unclassified network error. *)
 
+(** Provider-internal terminal condition reported via structured exit.
+
+    Distinct from {!network_error_kind}: the subprocess/API ran to
+    completion and emitted a structured stop reason on stdout.  Burying
+    these as [NetworkError] loses the information that downstream
+    cascades and per-provider budgets need to handle the condition
+    gracefully (e.g. [Max_turns] should checkpoint and resume on the
+    next cycle rather than fall back to another provider).
+
+    @since 0.178.0 *)
+type provider_terminal_kind =
+  | Max_turns of { turns: int; limit: int }
+      (** Provider's internal turn budget exhausted.  Maps to
+          {!Error.MaxTurnsExceeded} at the agent runtime layer.  For
+          claude_code 0.x the [limit] equals the CLI default
+          [--max-turns] (currently 31) when the keeper does not
+          override it. *)
+  | Other of string
+      (** Forward-compatible bucket for unrecognized subtypes
+          (e.g. [error_during_execution], [error_max_thinking_tokens]).
+          Carries the raw subtype string so consumers can log it
+          without flag day for new variants. *)
+
 (** Transport-level error. *)
 type http_error =
   | HttpError of { code: int; body: string }
@@ -38,6 +61,14 @@ type http_error =
           but the caller did not inject one.  Distinct from
           {!NetworkError} so cascades can treat it as a configuration
           bug rather than a transient failure. *)
+  | ProviderTerminal of { kind: provider_terminal_kind; message: string }
+      (** Provider reported a structured terminal condition on its
+          completion stream.  Distinct from {!NetworkError} so cascades
+          and the agent runtime can map it to the right semantic
+          ({!Error.MaxTurnsExceeded}, {!Retry.InvalidRequest}, …)
+          rather than treat it as a transient network failure.
+
+          @since 0.178.0 *)
 
 (** Default wall-clock timeout (seconds) applied to synchronous HTTP
     operations when a clock is supplied.  Streaming variants use this

--- a/lib/llm_provider/slot_cache.ml
+++ b/lib/llm_provider/slot_cache.ml
@@ -32,6 +32,8 @@ let slot_action ~sw ~net ~endpoint ~slot_id ~action ~body_fields =
   | Error (Http_client.CliTransportRequired { kind }) ->
     Error (Printf.sprintf "slot %s: CLI transport required for %s"
       action kind)
+  | Error (Http_client.ProviderTerminal { message; _ }) ->
+    Error (Printf.sprintf "slot %s: %s" action message)
 
 let save ~sw ~net ~endpoint ~slot_id ~filename =
   slot_action ~sw ~net ~endpoint ~slot_id ~action:"save"

--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -265,14 +265,39 @@ let parse_usage json =
 
 let parse_stop_reason s = Types.stop_reason_of_string s
 
-(** Parse a sync JSON result into api_response. *)
+(** Parse a sync JSON result into api_response.
+
+    Mirrors the [is_error=true] dispatch in {!parse_stream_result} so
+    sync and stream paths agree on classification: structured terminal
+    subtypes (e.g. [error_max_turns]) become {!Http_client.ProviderTerminal},
+    not {!Http_client.NetworkError}.  See {!parse_stream_result} for the
+    reasoning. *)
 let parse_json_result json_str =
   try
     let json = Yojson.Safe.from_string json_str in
     if Cli_common_json.member_bool "is_error" json then
+      let subtype = Cli_common_json.member_str "subtype" json in
       let msg = Cli_common_json.member_str "result" json in
-      Error (Http_client.NetworkError {
-        message = Printf.sprintf "Claude Code error: %s" msg; kind = Unknown })
+      (* Whitelist only structured terminal subtypes for [ProviderTerminal].
+         Unknown/legacy subtypes (e.g. [subtype="error"] for generic API
+         failures, rate limits, network) keep the {!NetworkError} path so
+         they remain retryable through the cascade.  Adding new structured
+         subtypes (e.g. [error_max_thinking_tokens]) is intentionally an
+         explicit code change so we never accidentally promote a transient
+         API failure to "graceful checkpoint". *)
+      (match subtype with
+       | "error_max_turns" ->
+         let turns = Cli_common_json.member_int "num_turns" json in
+         Error (Http_client.ProviderTerminal {
+           kind = Max_turns { turns; limit = turns };
+           message =
+             Printf.sprintf
+               "claude_code internal max_turns reached at %d turns"
+               turns })
+       | _ ->
+         Error (Http_client.NetworkError {
+           message = Printf.sprintf "Claude Code error: %s" msg;
+           kind = Unknown }))
     else
       let result_text = Cli_common_json.member_str "result" json in
       let model = Cli_common_json.member_str "model" json in
@@ -407,9 +432,36 @@ let parse_stream_result lines =
     (try
       let rjson = Yojson.Safe.from_string rline in
       if Cli_common_json.member_bool "is_error" rjson then
+        (* claude_code emits structured [is_error=true] result lines for
+           provider-internal terminal conditions (max_turns, …) alongside
+           generic API errors.  Burying these as [NetworkError] loses the
+           [subtype] field that downstream cascades and the agent runtime
+           need to distinguish "subprocess hit its own turn budget —
+           checkpoint and resume next cycle" from "transient network
+           failure — fall back to next provider".
+
+           Whitelist only structured terminal subtypes for
+           [ProviderTerminal]; unknown/legacy subtypes
+           ([subtype="error"], generic API errors) keep the
+           {!NetworkError} path so they remain retryable.  Adding new
+           subtypes (e.g. [error_max_thinking_tokens]) is intentionally
+           an explicit code change so we never accidentally promote a
+           transient API failure to "graceful checkpoint". *)
+        let subtype = Cli_common_json.member_str "subtype" rjson in
         let msg = Cli_common_json.member_str "result" rjson in
-        Error (Http_client.NetworkError {
-          message = Printf.sprintf "Claude Code error: %s" msg; kind = Unknown })
+        (match subtype with
+         | "error_max_turns" ->
+           let turns = Cli_common_json.member_int "num_turns" rjson in
+           Error (Http_client.ProviderTerminal {
+             kind = Max_turns { turns; limit = turns };
+             message =
+               Printf.sprintf
+                 "claude_code internal max_turns reached at %d turns"
+                 turns })
+         | _ ->
+           Error (Http_client.NetworkError {
+             message = Printf.sprintf "Claude Code error: %s" msg;
+             kind = Unknown }))
       else
         let model = Cli_common_json.member_str "model" rjson in
         let session_id = Cli_common_json.member_str "session_id" rjson in
@@ -619,6 +671,27 @@ let%test "parse_json_result error" =
     String.length message > 0
   | _ -> false
 
+let%test "parse_json_result error_max_turns becomes ProviderTerminal Max_turns" =
+  (* Pins the structural fix for masc-mcp#10629: claude_code internal
+     [error_max_turns] must surface as a structured terminal so the
+     agent runtime can graceful-checkpoint instead of the cascade
+     treating it as a transient network failure. *)
+  let json = {|{"type":"result","subtype":"error_max_turns","is_error":true,"result":"","model":"m","stop_reason":"tool_use","session_id":"s1","num_turns":31}|} in
+  match parse_json_result json with
+  | Error (Http_client.ProviderTerminal { kind = Max_turns r; _ }) ->
+    r.turns = 31 && r.limit = 31
+  | _ -> false
+
+let%test "parse_json_result unknown error subtype stays NetworkError" =
+  (* Whitelist guard: only known structured terminals promote to
+     ProviderTerminal.  Unknown/legacy subtypes keep the retryable
+     NetworkError path so a transient API error never gets silently
+     promoted to "graceful checkpoint". *)
+  let json = {|{"type":"result","subtype":"error_during_execution","is_error":true,"result":"unexpected","model":"m","stop_reason":"","session_id":"s1"}|} in
+  match parse_json_result json with
+  | Error (Http_client.NetworkError _) -> true
+  | _ -> false
+
 let%test "parse_json_result invalid json" =
   match parse_json_result "not json" with
   | Error _ -> true
@@ -710,6 +783,27 @@ let%test "parse_stream_result no messages" =
   match parse_stream_result [] with
   | Error _ -> true
   | Ok _ -> false
+
+let%test "parse_stream_result error_max_turns becomes ProviderTerminal Max_turns" =
+  (* Sync/stream parity for masc-mcp#10629: the production hits show
+     this exact JSON shape on stdout when claude_code subprocess exits
+     1 due to its internal max_turns CLI default (currently 31). *)
+  let lines = [
+    {|{"type":"system","subtype":"init","model":"m","session_id":"33e45115"}|};
+    {|{"type":"result","subtype":"error_max_turns","duration_ms":273722,"duration_api_ms":180417,"is_error":true,"num_turns":31,"stop_reason":"tool_use","session_id":"33e45115"}|};
+  ] in
+  match parse_stream_result lines with
+  | Error (Http_client.ProviderTerminal { kind = Max_turns r; _ }) ->
+    r.turns = 31 && r.limit = 31
+  | _ -> false
+
+let%test "parse_stream_result unknown error subtype stays NetworkError" =
+  let lines = [
+    {|{"type":"result","subtype":"error_unknown_future","is_error":true,"result":"who knows","model":"m","stop_reason":"","session_id":"s1"}|};
+  ] in
+  match parse_stream_result lines with
+  | Error (Http_client.NetworkError _) -> true
+  | _ -> false
 
 let%test "parse_stream_result restores tool_use blocks" =
   let lines = [

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -20,6 +20,13 @@ let sdk_error_of_http_error : Llm_provider.Http_client.http_error -> Error.sdk_e
                   pass ~transport via agent.options.transport"
                  kind;
            })
+  | Llm_provider.Http_client.ProviderTerminal { kind = Max_turns r; _ } ->
+      Error.Agent (MaxTurnsExceeded { turns = r.turns; limit = r.limit })
+  | Llm_provider.Http_client.ProviderTerminal
+      { kind = Other reason; message } ->
+      Error.Api
+        (Retry.InvalidRequest
+           { message = Printf.sprintf "%s: %s" reason message })
 
 let dispatch_sync ~sw ?clock agent (prep : Agent_turn.turn_preparation) =
   let tools = Option.value prep.Agent_turn.tools_json ~default:[] in

--- a/lib/pipeline/stage_route.ml
+++ b/lib/pipeline/stage_route.ml
@@ -26,6 +26,16 @@ let sdk_error_of_http_error : Llm_provider.Http_client.http_error -> Error.sdk_e
         message = Printf.sprintf
           "CLI transport required for %s but none was injected; \
            pass ~transport via agent.options.transport" kind })
+  | Llm_provider.Http_client.ProviderTerminal { kind = Max_turns r; _ } ->
+      (* Map provider-internal max_turns to the agent-runtime variant so
+         the existing [MaxTurnsExceeded] graceful path (checkpoint +
+         [TurnBudgetExhausted] stop_reason) handles it instead of the
+         cascade treating it as a transient API failure. *)
+      Error.Agent (MaxTurnsExceeded { turns = r.turns; limit = r.limit })
+  | Llm_provider.Http_client.ProviderTerminal
+      { kind = Other reason; message } ->
+      Error.Api (Retry.InvalidRequest {
+        message = Printf.sprintf "%s: %s" reason message })
 
 (** Sync dispatch via {!Llm_provider.Complete.complete}.  Routes all
     provider kinds through the consolidated path so [on_request_end]

--- a/lib/protocol/a2a_client.ml
+++ b/lib/protocol/a2a_client.ml
@@ -31,6 +31,11 @@ let http_get ~sw ~net url =
     Error (Error.Orchestration (DiscoveryFailed {
       url;
       detail = Printf.sprintf "CLI transport required for %s" kind }))
+  | Error (Llm_provider.Http_client.ProviderTerminal { message; _ }) ->
+    (* Same defensive note as [CliTransportRequired]: pure HTTP discovery
+       cannot produce a CLI subprocess terminal condition; reduce to
+       message text so the exhaustive match stays sound. *)
+    Error (Error.Orchestration (DiscoveryFailed { url; detail = message }))
 
 let http_post ~sw ~net ~url ~body =
   let headers = [("Content-Type", "application/json")] in
@@ -49,6 +54,11 @@ let http_post ~sw ~net ~url ~body =
   | Error (Llm_provider.Http_client.CliTransportRequired { kind }) ->
     Error (Error.A2a (ProtocolError {
       detail = Printf.sprintf "CLI transport required for %s" kind }))
+  | Error (Llm_provider.Http_client.ProviderTerminal { message; _ }) ->
+    (* Pure HTTP RPC cannot produce a CLI subprocess terminal condition;
+       defensive handling mirrors [http_get] so the exhaustive match
+       stays sound and the message survives for diagnostics. *)
+    Error (Error.A2a (ProtocolError { detail = message }))
 
 (* ── JSON-RPC ─────────────────────────────────────────────────── *)
 

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -132,6 +132,13 @@ let map_http_error = function
       Error.Api (Retry.InvalidRequest {
         message = Printf.sprintf
           "CLI transport required for %s but none was injected" kind })
+  | Llm_provider.Http_client.ProviderTerminal { kind = Max_turns r; _ } ->
+      Error.Agent (MaxTurnsExceeded { turns = r.turns; limit = r.limit })
+  | Llm_provider.Http_client.ProviderTerminal
+      { kind = Other reason; message } ->
+      Error.Api
+        (Retry.InvalidRequest
+           { message = Printf.sprintf "%s: %s" reason message })
 
 (** Streaming variant of create_message.
     Supports Anthropic (native SSE) and OpenAI-compatible (SSE).

--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -74,6 +74,13 @@ let sdk_error_of_http_error = function
             "CLI transport required for %s, but native structured output is only wired for HTTP providers"
             kind;
       })
+  | Llm_provider.Http_client.ProviderTerminal { kind = Max_turns r; _ } ->
+      Error.Agent (MaxTurnsExceeded { turns = r.turns; limit = r.limit })
+  | Llm_provider.Http_client.ProviderTerminal
+      { kind = Other reason; message } ->
+      Error.Api
+        (Llm_provider.Retry.InvalidRequest
+           { message = Printf.sprintf "%s: %s" reason message })
 
 let provider_config_for_schema ~base_url ?provider ~config ~(schema : _ schema) () =
   let state = {

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -422,6 +422,10 @@ let test_complete_claude_code_without_transport_is_guarded () =
         Alcotest.failf
           "%s expected CliTransportRequired, got AcceptRejected: %s"
           expected_name reason
+    | Error (Llm_provider.Http_client.ProviderTerminal { message; _ }) ->
+        Alcotest.failf
+          "%s expected CliTransportRequired, got ProviderTerminal: %s"
+          expected_name message
   ) kinds
 
 let test_complete_rejects_output_schema_for_glm () =


### PR DESCRIPTION
## Why

Pins the [`error_max_turns` → `NetworkError`] miscategorization
documented in [masc-mcp#10629](https://github.com/jeong-sik/masc-mcp/issues/10629) (33 events/day, 2.5x growth) at the OAS transport layer.

claude_code subprocess emits a structured `is_error=true` result with `subtype="error_max_turns"` when its internal CLI `--max-turns` (default 31) is exhausted:

\`\`\`json
{
  "type":"result",
  "subtype":"error_max_turns",
  "duration_ms":273722,
  "is_error":true,
  "num_turns":31,
  "stop_reason":"tool_use",
  "session_id":"33e45115-..."
}
\`\`\`

Old code path (transport_claude_code.ml):

\`\`\`ocaml
if is_error then
  Error (NetworkError { message = "Claude Code error: ..."; kind = Unknown })
\`\`\`

— losing the `subtype`/`num_turns` fields needed to distinguish *"subprocess hit its own turn budget → checkpoint + resume"* from *"transient network failure → fall back to next provider"*.

## Empirical impact

masc-mcp cascade whack-a-mole feedback loop:
- masc-mcp#10554 (codex_cli weight=0) merged → cascade routes more often to claude
- claude `error_max_turns` 13/day → 33/day (2.5x in 24h)
- Each event = wasted keeper turn + context loss

The same class repeats in masc-mcp#10550 (codex `thread not found`, fixed via OAS#1199 `--ephemeral`) and masc-mcp#10493 (per-variant terminal_reason_code, agent-runtime counterpart). This PR closes the structured-terminal half.

## What

### New http_error variant

\`\`\`ocaml
type provider_terminal_kind =
  | Max_turns of { turns: int; limit: int }
  | Other of string  (* forward-compat for new subtypes *)

type http_error =
  | ...
  | ProviderTerminal of { kind: provider_terminal_kind; message: string }
\`\`\`

Distinct from `NetworkError` so cascades and the agent runtime can map to the right semantic.

### Whitelist-based subtype dispatch

Both `parse_json_result` (sync) and `parse_stream_result` (stream) now:

- `subtype="error_max_turns"` → `ProviderTerminal Max_turns`
- everything else (including `subtype="error"` for generic API failures) → `NetworkError` (legacy retryable path)

Adding new structured terminals (e.g. `error_max_thinking_tokens`) is an explicit code change so we never accidentally promote a transient API failure to "graceful checkpoint".

### Consumer mappings

\`stage_route\`, \`pipeline_stage_route\`, \`structured\`, \`streaming\` → `ProviderTerminal Max_turns` to `Error.Agent (MaxTurnsExceeded { turns; limit })`. This means the existing graceful path in masc-mcp `oas_worker_exec.ml:440` (checkpoint + `TurnBudgetExhausted` stop_reason) handles it **with zero consumer changes**.

`judge`, `discovery`, `slot_cache`, `a2a_client`, `http_client.is_local_resource_exhaustion`, `complete.classify_retry_error` get defensive handling — these HTTP-only paths cannot construct `ProviderTerminal` but the exhaustive match must stay sound.

### Retryability

`classify_retry_error` returns `None` for `ProviderTerminal` — retry would re-trigger the same deterministic exit, so cascade fallback is correct only at the agent-runtime layer (graceful checkpoint), not at the per-call retry layer.

## Test

\`\`\`
dune build @lib/runtest
\`\`\`

Green. New tests:

- `parse_json_result error_max_turns becomes ProviderTerminal Max_turns`
- `parse_json_result unknown error subtype stays NetworkError`
- `parse_stream_result error_max_turns becomes ProviderTerminal Max_turns`
- `parse_stream_result unknown error subtype stays NetworkError`

Plus existing `parse_json_result error` (subtype=`error`) still passes — the whitelist guard preserves legacy behavior.

## Follow-up

masc-mcp pin bump + version floor (no consumer code change needed; `Error.Agent (MaxTurnsExceeded)` graceful path already exists at `oas_worker_exec.ml:440`).

## Refs

- masc-mcp#10629 (this issue)
- masc-mcp#10550 (codex thread bug, same class)
- masc-mcp#10554 (whack-a-mole trigger)
- masc-mcp#10493 (per-variant terminal_reason_code)