### PR TITLE
fix(provider): register dashscope alias for DashScope kind

### DIFF
--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -314,6 +314,8 @@ let default () =
     Capabilities.openai_chat_capabilities;
   reg "alibaba" alibaba_defaults ~max_context:131_072
     Capabilities.dashscope_capabilities;
+  reg "dashscope" alibaba_defaults ~max_context:131_072
+    Capabilities.dashscope_capabilities;
   reg "siliconflow" siliconflow_defaults ~max_context:128_000
     Capabilities.openai_chat_capabilities;
   register t { name = "ollama"; defaults = ollama_defaults;

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -163,10 +163,10 @@ let test_find_capable_composite () =
 
 (* ── Default registry ───────────────────────────────── *)
 
-let test_default_has_17 () =
+let test_default_has_18 () =
   let reg = Provider_registry.default () in
   let all = Provider_registry.all reg in
-  check int "17 known providers" 17 (List.length all);
+  check int "18 known providers" 18 (List.length all);
   check bool "llama exists" true
     (Option.is_some (Provider_registry.find reg "llama"));
   check bool "ollama exists" true
@@ -189,6 +189,8 @@ let test_default_has_17 () =
     (Option.is_some (Provider_registry.find reg "deepseek"));
   check bool "alibaba exists" true
     (Option.is_some (Provider_registry.find reg "alibaba"));
+  check bool "dashscope exists" true
+    (Option.is_some (Provider_registry.find reg "dashscope"));
   check bool "siliconflow exists" true
     (Option.is_some (Provider_registry.find reg "siliconflow"));
   check bool "claude_code exists" true
@@ -461,7 +463,7 @@ let () =
       test_case "requires_any" `Quick test_requires_any;
     ];
     "default", [
-      test_case "has 17 providers" `Quick test_default_has_17;
+      test_case "has 18 providers" `Quick test_default_has_18;
       test_case "correct capabilities" `Quick test_default_capabilities;
       test_case "max_context values" `Quick test_default_max_context;
       test_case "max_context matches capabilities" `Quick


### PR DESCRIPTION
## Summary
- `provider_name_of_config` maps `DashScope` kind → `"dashscope"` string, but the registry only had `"alibaba"` registered
- This caused `kind_registry_integrity` test to fail because the reverse lookup couldn't find a registry entry for the DashScope kind
- Added `"dashscope"` as an alias pointing to the same `alibaba_defaults`

## Test plan
- [x] `dune runtest test/test_provider_registry.ml` — 22/22 pass including `kind_registry_integrity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)