### PR TITLE
test: Eio cancellation regression guard for HTTP body reads

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -4,6 +4,11 @@
  (libraries agent_sdk alcotest yojson eio eio_main))
 
 (test
+ (name test_eio_cancellability)
+ (modules test_eio_cancellability)
+ (libraries alcotest eio eio_main eio.unix unix))
+
+(test
  (name test_sdk_client_types)
  (modules test_sdk_client_types)
  (libraries agent_sdk alcotest))

--- a/test/test_eio_cancellability.ml
+++ b/test/test_eio_cancellability.ml
@@ -1,0 +1,210 @@
+(** Regression guard for OAS HTTP cancellation assumption.
+
+    OAS streaming code (lib/llm_provider/http_client.ml [read_sse],
+    [read_ndjson], [post_sync], [with_post_stream]) relies on
+    [Eio.Time.with_timeout_exn] to interrupt slow / hung HTTP body reads.
+    For that to actually work, [Eio.Buf_read.line] / [Buf_read.take_all]
+    on top of [Eio.Net]-backed flows must propagate cancellation into
+    the underlying socket [single_read].
+
+    A 2026-04-27 forensic investigation produced reproducers (originally
+    at /tmp/oas-cancel-research/repro/) that confirmed cancellation is
+    intact across four scenarios.  This test ports those reproducers
+    so a future Eio/cohttp-eio dependency bump that breaks cancellation
+    fails CI immediately, instead of silently regressing into 3585s
+    keeper hangs in masc-mcp.
+
+    Cross-ref: planning/claude-plans/oas-execution-cancellability.md
+                (in jeong-sik/me) — falsified self-confession comment in
+                masc-mcp [keeper_llm_bridge.ml:35-39].
+
+    All four cases use a 2.0s timeout budget; overshoot must stay under
+    [overshoot_tolerance_s].  CI jitter is bounded by [tolerance];
+    raise it only if you understand why. *)
+
+let timeout_budget_s = 2.0
+let overshoot_tolerance_s = 0.5
+
+(* In-process slow line server. Sends initial HTTP/1.1 200 response with
+   a large Content-Length, then drips lines (or bytes) on a fixed cadence
+   forever. Closes when client disconnects. *)
+let line_server ~sw ~net port ~gap_ms ~payload =
+  let addr = `Tcp (Eio.Net.Ipaddr.V4.loopback, port) in
+  let socket = Eio.Net.listen ~sw ~backlog:5 ~reuse_addr:true net addr in
+  Eio.Fiber.fork ~sw (fun () ->
+    let rec accept_loop () =
+      Eio.Net.accept_fork ~sw socket
+        ~on_error:(fun _ -> ())
+        (fun flow _addr ->
+          let buf = Eio.Buf_read.of_flow flow ~max_size:8192 in
+          (try
+            let rec consume () =
+              let line = Eio.Buf_read.line buf in
+              if line = "" then () else consume ()
+            in
+            consume ()
+           with _ -> ());
+          let resp =
+            "HTTP/1.1 200 OK\r\n\
+             Content-Length: 1000000\r\n\
+             Content-Type: text/event-stream\r\n\
+             Connection: close\r\n\
+             \r\n"
+          in
+          (try
+            Eio.Flow.copy_string resp flow;
+            for _ = 1 to 100_000 do
+              Eio.Flow.copy_string payload flow;
+              Eio_unix.sleep (float_of_int gap_ms /. 1000.0)
+            done
+           with _ -> ()));
+      accept_loop ()
+    in
+    try accept_loop () with _ -> ())
+
+let connect_and_consume_headers ~sw ~net port =
+  let saddr = `Tcp (Eio.Net.Ipaddr.V4.loopback, port) in
+  let conn = Eio.Net.connect ~sw net saddr in
+  let req =
+    "GET /drip HTTP/1.1\r\n\
+     Host: localhost\r\n\
+     Connection: close\r\n\
+     \r\n"
+  in
+  Eio.Flow.copy_string req conn;
+  let reader = Eio.Buf_read.of_flow conn ~max_size:1_000_000 in
+  let rec drain () =
+    let line = Eio.Buf_read.line reader in
+    if line = "" then () else drain ()
+  in
+  drain ();
+  reader
+
+(* OAS read_sse loop structure (mirrors lib/llm_provider/http_client.ml). *)
+let read_sse_loop reader ~on_data =
+  let rec loop () =
+    match Eio.Buf_read.line reader with
+    | line ->
+      let len = String.length line in
+      if len > 6 && String.sub line 0 6 = "data: " then
+        on_data (String.sub line 6 (len - 6));
+      loop ()
+    | exception End_of_file -> ()
+  in
+  loop ()
+
+(* Run [f] inside [with_timeout_exn budget]; return elapsed wall time
+   on Eio.Time.Timeout.  Fails the test if any other outcome occurs. *)
+let measure_timeout ~clock ~budget ~label fn =
+  let t0 = Eio.Time.now clock in
+  let outcome =
+    try
+      Eio.Time.with_timeout_exn clock budget fn;
+      `Completed
+    with
+    | Eio.Time.Timeout -> `Timeout
+    | Eio.Cancel.Cancelled exn -> `Cancelled exn
+    | exn -> `Other exn
+  in
+  let elapsed = Eio.Time.now clock -. t0 in
+  (match outcome with
+   | `Timeout -> ()
+   | `Completed ->
+     Alcotest.failf "[%s] expected timeout, got completion in %.3fs" label elapsed
+   | `Cancelled exn ->
+     Alcotest.failf "[%s] expected Eio.Time.Timeout, got Cancelled(%s) in %.3fs"
+       label (Printexc.to_string exn) elapsed
+   | `Other exn ->
+     Alcotest.failf "[%s] expected Eio.Time.Timeout, got %s in %.3fs"
+       label (Printexc.to_string exn) elapsed);
+  let overshoot = elapsed -. budget in
+  if overshoot > overshoot_tolerance_s then
+    Alcotest.failf
+      "[%s] cancellation regression: elapsed=%.3fs budget=%.3fs \
+       overshoot=%.3fs > tolerance=%.3fs"
+      label elapsed budget overshoot overshoot_tolerance_s
+
+(* Test 1: slow drip server, 1 byte/sec, no newline.
+   Mirrors a server that holds the connection but produces nothing
+   useful.  [Buf_read.line] blocks in [ensure_slow_path] -> [Flow.single_read]. *)
+let test_buf_read_line_cancellable () =
+  Eio_main.run @@ fun env ->
+  let net = env#net in
+  let clock = env#clock in
+  Eio.Switch.run (fun sw ->
+    line_server ~sw ~net 18741 ~gap_ms:1000 ~payload:"x";
+    Eio_unix.sleep 0.2;
+    Eio.Switch.run (fun sw ->
+      let reader = connect_and_consume_headers ~sw ~net 18741 in
+      measure_timeout ~clock ~budget:timeout_budget_s
+        ~label:"buf_read.line + slow drip"
+        (fun () -> ignore (Eio.Buf_read.line reader)));
+    raise Exit)
+
+let run_with_server ~port ~payload ~gap_ms ~label callback =
+  Eio_main.run @@ fun env ->
+  let net = env#net in
+  let clock = env#clock in
+  Eio.Switch.run (fun sw ->
+    line_server ~sw ~net port ~gap_ms ~payload;
+    Eio_unix.sleep 0.2;
+    Eio.Switch.run (fun inner_sw ->
+      let reader = connect_and_consume_headers ~sw:inner_sw ~net port in
+      callback ~clock ~reader ~label);
+    raise Exit)
+
+(* Test 2: fast SSE-style stream + trivial on_data.
+   Simulates a provider sending lines every 100ms forever. *)
+let test_read_sse_fast_stream_cancellable () =
+  try
+    run_with_server ~port:18742 ~payload:"data: x\n" ~gap_ms:100
+      ~label:"read_sse + fast stream + trivial"
+      (fun ~clock ~reader ~label ->
+        measure_timeout ~clock ~budget:timeout_budget_s ~label
+          (fun () -> read_sse_loop reader ~on_data:(fun _ -> ())))
+  with Exit -> ()
+
+(* Test 3: fast stream + on_data sleeps via Eio_unix.sleep (cooperative). *)
+let test_read_sse_sleeping_callback_cancellable () =
+  try
+    run_with_server ~port:18743 ~payload:"data: x\n" ~gap_ms:100
+      ~label:"read_sse + fast stream + sleep callback"
+      (fun ~clock ~reader ~label ->
+        measure_timeout ~clock ~budget:timeout_budget_s ~label
+          (fun () ->
+            read_sse_loop reader ~on_data:(fun _ -> Eio_unix.sleep 0.05)))
+  with Exit -> ()
+
+(* Test 4: fast stream + on_data does CPU-bound work without yielding.
+   The next [Buf_read.line] call provides the cancel point. *)
+let test_read_sse_cpu_callback_cancellable () =
+  try
+    run_with_server ~port:18744 ~payload:"data: x\n" ~gap_ms:100
+      ~label:"read_sse + fast stream + cpu callback"
+      (fun ~clock ~reader ~label ->
+        measure_timeout ~clock ~budget:timeout_budget_s ~label
+          (fun () ->
+            read_sse_loop reader ~on_data:(fun _ ->
+              let t_end = Unix.gettimeofday () +. 0.05 in
+              while Unix.gettimeofday () < t_end do () done)))
+  with Exit -> ()
+
+let () =
+  let open Alcotest in
+  run "eio_cancellability"
+    [ ( "http_body_read_cancellation"
+      , [ test_case "buf_read.line + slow drip"
+            `Quick
+            (fun () ->
+              try test_buf_read_line_cancellable () with Exit -> ())
+        ; test_case "read_sse + fast stream + trivial callback"
+            `Quick
+            test_read_sse_fast_stream_cancellable
+        ; test_case "read_sse + fast stream + sleep callback"
+            `Quick
+            test_read_sse_sleeping_callback_cancellable
+        ; test_case "read_sse + fast stream + cpu callback"
+            `Quick
+            test_read_sse_cpu_callback_cancellable
+        ] )
+    ]


### PR DESCRIPTION
## Summary

OAS streaming code (`lib/llm_provider/http_client.ml`: `read_sse`, `read_ndjson`, `post_sync`, `with_post_stream`) 가 의존하는 *cancellation propagation* 가정에 대한 회귀 가드. raw TCP + `Eio.Buf_read` + read_sse 패턴이 `Eio.Time.with_timeout_exn`에 의해 정확히 interrupted 되는지 4개 시나리오로 측정.

## Why

masc-mcp keeper turn이 OAS HTTP execution에서 **3585s까지 hung** 되는 production 현상 forensic 결과:

- masc-mcp `lib/keeper/keeper_llm_bridge.ml:35-39`의 자백 주석 ("uncancellable region: native HTTP bulk read, syscall, non-yielding loop")은 실측에서 **falsified** — 모든 시나리오에서 1-2ms overshoot으로 cancellable.
- 자백을 그대로 신뢰해 read_sse 또는 Buf_read에 yield point 삽입 PR을 깔 뻔한 상태에서 측정이 그 판단을 막음.
- 진짜 hung mechanism은 다른 layer (caller on_event / take_all + connection-not-closed / Switch cleanup / TLS) — *prod stack dump 대기 중*.
- 이 PR은 *현재 cancellable 상태*를 회귀 가드로 정착 — 미래 Eio/cohttp-eio dep bump가 cancellation을 깨면 **CI에서 즉시 실패**, masc-mcp에서 silent multi-thousand-second hang으로 regression되지 않음.

## What

`test/test_eio_cancellability.ml` (새 파일) + `test/dune` (1 entry 추가):

| 시나리오 | 측정 결과 |
|---------|---------|
| raw TCP + `Buf_read.line` + slow drip (1byte/sec, no newline) | budget 2.0s, overshoot < 500ms tolerance |
| read_sse 패턴 + fast stream (100ms gap) + trivial on_data | 동일 |
| 위 + on_data sleeps via `Eio_unix.sleep` | 동일 |
| 위 + on_data does CPU-bound work (no Eio yield) | 동일 |

In-process slow line server + raw TCP client. agent_sdk dep 0 (순수 Eio assumption test).

## Test plan

- [x] `dune build test/test_eio_cancellability.exe` 통과
- [x] `./_build/default/test/test_eio_cancellability.exe` — 4/4 OK in 8.9s (4 × ~2s budget + setup)
- [ ] CI green
- [ ] 미래에 Eio dep bump 시 이 테스트가 cancellation 회귀를 잡는지 확인 (회귀 가드 본질)

## Cross-ref

- jeong-sik/me planning: `claude-plans/oas-execution-cancellability.md` (측정 결과, falsified/surviving 가설 정리)
- jeong-sik/me PR #1071: `scripts/oas-hung-keeper-dump.sh` (prod hung stack dump 도구 — 다음 cycle evidence 수집용)
- 사용자 원칙 memory: `feedback_no_timeout_as_bandaid_for_root_cause.md`, `feedback_self_confession_comments_must_be_measured.md`

## Out of scope

- OAS code 변경 (forensic이 *evidence-blocked* 상태)
- `wall_clock_timeout_s` 옵션 추가 (masc-mcp 자체 적용 중인 패턴과 동일하면 효과 zero)
- TLS layer 통합 reproducer (외부 cert 비용 큼, source는 thin wrap이라 priority 낮음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)