### PR TITLE
feat(provider): add internal_model_rotation_count hint to Provider_config

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -1006,6 +1006,7 @@ let%test "gemini_url sync no api_key" =
     cache_system_prompt = false;
     supports_tool_choice_override = None;
     keep_alive = None;
+    internal_model_rotation_count = None;
     num_ctx = None;
   } in
   let url = gemini_url ~config ~stream:false in
@@ -1026,6 +1027,7 @@ let%test "gemini_url sync with api_key" =
     cache_system_prompt = false;
     supports_tool_choice_override = None;
     keep_alive = None;
+    internal_model_rotation_count = None;
     num_ctx = None;
   } in
   let url = gemini_url ~config ~stream:false in
@@ -1046,6 +1048,7 @@ let%test "gemini_url stream with api_key" =
     cache_system_prompt = false;
     supports_tool_choice_override = None;
     keep_alive = None;
+    internal_model_rotation_count = None;
     num_ctx = None;
   } in
   let url = gemini_url ~config ~stream:true in
@@ -1066,6 +1069,7 @@ let%test "gemini_url stream no api_key" =
     cache_system_prompt = false;
     supports_tool_choice_override = None;
     keep_alive = None;
+    internal_model_rotation_count = None;
     num_ctx = None;
   } in
   let url = gemini_url ~config ~stream:true in

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -43,6 +43,7 @@ type t = {
   cache_system_prompt: bool;
   supports_tool_choice_override: bool option;
   keep_alive: string option;
+  internal_model_rotation_count: int option;
   num_ctx: int option;
 }
 
@@ -59,6 +60,7 @@ let make ~kind ~model_id ~base_url
     ?(cache_system_prompt=false)
     ?supports_tool_choice_override
     ?keep_alive
+    ?internal_model_rotation_count
     ?num_ctx
     () =
   let response_format =
@@ -91,7 +93,7 @@ let make ~kind ~model_id ~base_url
     tool_stream;
     tool_choice; disable_parallel_tool_use; response_format; output_schema;
     cache_system_prompt; supports_tool_choice_override;
-    keep_alive; num_ctx }
+    keep_alive; internal_model_rotation_count; num_ctx }
 
 (** Helpers for [provider_kind]. Implementations live in {!Provider_kind};
     these re-exports keep the call-site [Provider_config.*] namespace

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -76,6 +76,29 @@ type t = {
       can declare its own residency policy without a global env
       variable.
       @since 0.171.0 *)
+  internal_model_rotation_count: int option;
+  (** Number of model attempts the subprocess CLI is configured to
+      cycle through internally before yielding a final response.
+      [None] = SDK has no opinion (the default for non-CLI providers
+      and CLI providers that do not expose rotation visibility).
+
+      Originally surfaced for [Codex_cli], whose vendor binary cycles
+      through 5 candidate models per [codex exec] invocation and
+      returns only the final attempt's outcome. Without this hint a
+      single CLI call appears as one provider attempt to the
+      downstream cascade observer, even though it can take ~180s
+      worst-case (5 model retries with internal backoff). Consumers
+      that want to render the rotation in cascade traces or apply
+      a per-attempt timeout budget can read this hint instead of
+      hard-coding a Codex-specific constant.
+
+      The SDK does not enforce or schedule the rotation; it remains
+      the CLI binary's responsibility. This field is purely
+      declarative metadata so the consumer can reason about the
+      worst-case behaviour of one [Complete.complete] call.
+
+      Honored only as an advisory hint; ignored for non-CLI kinds.
+      @since 0.182.0 *)
   num_ctx: int option;
   (** Ollama [num_ctx] option. Per-request context window allocation
       in tokens. Drives KV cache RAM allocation. [None] leaves the
@@ -114,6 +137,7 @@ val make :
   ?cache_system_prompt:bool ->
   ?supports_tool_choice_override:bool ->
   ?keep_alive:string ->
+  ?internal_model_rotation_count:int ->
   ?num_ctx:int ->
   unit -> t
 


### PR DESCRIPTION
## Summary

Subprocess CLI providers (Codex_cli most notably) cycle through multiple candidate models per invocation and return only the final attempt. A single `Codex_cli` call can take **~180s worst-case** (5 model retries with internal backoff), but appears as **one provider attempt** to downstream cascade observers. Without a declarative hint, consumers either hard-code a Codex-specific constant or hide the rotation cost in an opaque per-call timeout.

Adds `internal_model_rotation_count: int option` to `Provider_config.t` and `?internal_model_rotation_count:int` to `Provider_config.make`. Default `None` = "SDK has no opinion". The SDK does not enforce or schedule the rotation; this field is purely **declarative metadata** so the consumer can reason about worst-case `Complete.complete` behaviour and render the rotation in cascade traces.

Additive; does not change runtime semantics.

## Evidence (downstream consumer)

`jeong-sik/masc-mcp` measured the impact in supporting thread Stage 0:

- 5.1% of `codex_cli` calls hit the 5-rotation worst case (38/746 in 4/26-27 fleet logs)
- Cumulative wall-clock burned: ~38 × 150s = ~95 min/day per fleet
- Memory: `codex_cli_internal_5model_rotation` (vendor binary cycles `gpt-5.3-codex / 5.4-mini / 5.4 / 5.5 / 5.2` per invocation)

Source: `~/me/planning/claude-plans/appendix/masc-mcp-keeper-stage0-C.md` + Sprint 2 Track G in masc-mcp v0.6 Parallel Sprint plan.

## Changes

| File | Change | LOC |
|------|--------|-----|
| `lib/llm_provider/provider_config.mli` | New `internal_model_rotation_count: int option` field with docstring + optional `make` argument | +24 |
| `lib/llm_provider/provider_config.ml` | Same field on the record + optional `?internal_model_rotation_count` in `make` defaulting to `None` | +4 |
| `lib/llm_provider/complete.ml` | All four record-literal sites updated to pass `internal_model_rotation_count = None` | +4 |

Net: +31 / -1 (3 files).

## Test plan

- [x] `dune build --root . lib/` green
- [x] `dune build --root . test/` green
- [ ] Downstream verification: masc-mcp follow-up PR threads the hint into `cascade_strategy_trace` so the dashboard renders rotation hops on the operator-facing card

## Risk

- Additive only — every callsite goes through `Provider_config.make` (which defaults the new field to `None`) **except** the four hand-written record literals in `complete.ml`, all updated in this PR.
- `None` is the documented "SDK has no opinion" sentinel, matching the existing pattern for `keep_alive`, `num_ctx`, `max_tokens`, `max_context`, etc. Consumers that ignore the field see no behavioural change.
- No serializer changes — the field is purely runtime metadata, not part of any wire-format derived yojson record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)