### PR TITLE
feat(specs): TLA+ spec for Agent lifecycle FSM (#1212)

### DIFF
--- a/specs/AgentLifecycle-buggy.cfg
+++ b/specs/AgentLifecycle-buggy.cfg
@@ -1,0 +1,9 @@
+\* Bug model: BugTerminalResurrection forces Failed -> Running.
+\* TerminalIsStable SHOULD be violated.
+\* This proves the invariant is enforced by the FSM (not vacuously true).
+SPECIFICATION SpecBuggy
+CONSTANTS
+    MaxTurns = 3
+INVARIANT TypeOK
+INVARIANT TerminalIsStableMustHold
+CHECK_DEADLOCK FALSE

--- a/specs/AgentLifecycle.cfg
+++ b/specs/AgentLifecycle.cfg
@@ -1,0 +1,13 @@
+\* Clean model: 3-turn bound, no illegal transitions.
+\* All safety invariants should hold.
+SPECIFICATION Spec
+CONSTANTS
+    MaxTurns = 3
+INVARIANT TypeOK
+INVARIANT PrevNotEqualStatus
+INVARIANT TerminalIsStable
+INVARIANT NoIllegalTransition
+INVARIANT RunningRequiresReady
+INVARIANT CompletedRequiresRunning
+INVARIANT NoTransitionIntoAccepted
+CHECK_DEADLOCK FALSE

--- a/specs/AgentLifecycle.tla
+++ b/specs/AgentLifecycle.tla
@@ -1,0 +1,165 @@
+---- MODULE AgentLifecycle ----
+\* Models lib/agent/agent_lifecycle.mli FSM directly.
+\*
+\* States:
+\*   Accepted, Ready, Running, Completed, Failed
+\*
+\* Allowed transitions (per .mli docstring):
+\*   Accepted  -> Ready | Failed
+\*   Ready     -> Running | Failed
+\*   Running   -> Ready | Completed | Failed
+\*   Completed -> (terminal)
+\*   Failed    -> (terminal)
+\* Same-state reaffirm allowed on non-terminal states.
+\*
+\* Verifies:
+\*   1. TypeOK
+\*   2. TerminalIsStable: terminal status never transitions
+\*   3. NoIllegalTransition: declared transitions are exhaustive
+\*   4. RunningRequiresReady: Running entered only from Ready or via reaffirm
+\*   5. CompletedRequiresRunning: Completed reached only from Running
+\*   6. NoTransitionIntoAccepted: prev != Accepted -> status != Accepted
+\*
+\* Maps 1:1 to OCaml types:
+\*   lifecycle_status = Accepted | Ready | Running | Completed | Failed
+\*
+\* Cancellation absorption is NOT modeled here — cancellation lives at the
+\* fiber/Switch layer (agent_turn, runtime), not in the lifecycle FSM.
+\* A separate spec (AgentCancellation.tla) should model that.
+\*
+\* Design note: state representation uses (status, prev_status, turn_count)
+\* — bounded — instead of a history sequence to keep the state space finite.
+\*
+\* @since (issue #1212)
+
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+    MaxTurns        \* Bound on Ready<->Running cycles
+
+VARIABLES
+    status,         \* Current lifecycle state
+    prev_status,    \* Status that immediately preceded `status` ("None" before any transition)
+    turn_count      \* Number of completed Ready->Running cycles
+
+vars == <<status, prev_status, turn_count>>
+
+States       == {"Accepted", "Ready", "Running", "Completed", "Failed"}
+StatesOrNone == States \cup {"None"}
+
+NonTerminal == {"Accepted", "Ready", "Running"}
+Terminal    == {"Completed", "Failed"}
+
+TypeOK ==
+    /\ status \in States
+    /\ prev_status \in StatesOrNone
+    /\ turn_count \in 0..MaxTurns
+
+\* ── Helpers ──────────────────────────────────
+IsTerminal(s) == s \in Terminal
+
+\* Allowed next-state set per .mli (excluding same-state reaffirm).
+AllowedNext(s) ==
+    CASE s = "Accepted"  -> {"Ready", "Failed"}
+      [] s = "Ready"     -> {"Running", "Failed"}
+      [] s = "Running"   -> {"Ready", "Completed", "Failed"}
+      [] s = "Completed" -> {}
+      [] s = "Failed"    -> {}
+
+\* ── Initial state ────────────────────────────
+Init ==
+    /\ status = "Accepted"
+    /\ prev_status = "None"
+    /\ turn_count = 0
+
+\* ── Transition actions ───────────────────────
+\* Forward transition to a different state.
+Transition(to_) ==
+    /\ ~IsTerminal(status)
+    /\ to_ # status                                  \* not a reaffirm — Reaffirm action handles that
+    /\ to_ \in AllowedNext(status)
+    \* Bound Ready->Running cycles to keep state space finite.
+    /\ ~(status = "Ready" /\ to_ = "Running" /\ turn_count >= MaxTurns)
+    /\ prev_status' = status
+    /\ status' = to_
+    /\ turn_count' =
+        IF status = "Ready" /\ to_ = "Running"
+        THEN turn_count + 1
+        ELSE turn_count
+
+\* Same-state reaffirm: allowed on non-terminal states (per .mli line 13–14).
+\* Idempotent — does not change observable state.
+Reaffirm ==
+    /\ ~IsTerminal(status)
+    /\ UNCHANGED vars
+
+\* Stutter on terminal states.
+StutterTerminal ==
+    /\ IsTerminal(status)
+    /\ UNCHANGED vars
+
+Next ==
+    \/ \E to_ \in States : Transition(to_)
+    \/ Reaffirm
+    \/ StutterTerminal
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(\E to_ \in States : Transition(to_))
+
+\* ── Safety Invariants ────────────────────────
+
+\* 1. PrevNotEqualStatus: prev_status differs from status (when set).
+\*    Enforced by Transition action (to_ # status); validates the model.
+PrevNotEqualStatus ==
+    prev_status # "None" => prev_status # status
+
+\* 2. TerminalIsStable: once terminal, status never changes.
+\*    Expressed as: if prev_status is terminal, current status equals prev_status.
+\*    (Terminal has no outgoing transitions, so the next-state must be reaffirm/stutter.)
+TerminalIsStable ==
+    IsTerminal(prev_status) => status = prev_status
+
+\* 3. NoIllegalTransition: every transition arrow is declared.
+NoIllegalTransition ==
+    prev_status # "None" =>
+        status \in AllowedNext(prev_status)
+
+\* 4. RunningRequiresReady: Running can only be reached from Ready
+\*    (since Reaffirm doesn't change status, prev_status holds the actual predecessor).
+RunningRequiresReady ==
+    status = "Running" =>
+        (prev_status = "None" \/ prev_status = "Ready")
+
+\* 5. CompletedRequiresRunning: Completed reachable only from Running.
+CompletedRequiresRunning ==
+    status = "Completed" => prev_status = "Running"
+
+\* 6. NoTransitionIntoAccepted: AllowedNext never produces Accepted.
+\*    So once we leave Accepted, we cannot return.
+NoTransitionIntoAccepted ==
+    (status = "Accepted") => (prev_status \in {"None", "Accepted"})
+
+\* ── Bug Model: Terminal Resurrection ───────────
+\* Models a regression where a terminal status (Failed) is incorrectly
+\* re-transitioned to Running — e.g. a buggy checkpoint restore that
+\* ignores `is_terminal`.
+\*
+\* SHOULD violate TerminalIsStable.
+
+BugTerminalResurrection ==
+    /\ status = "Failed"
+    /\ prev_status' = "Failed"
+    /\ status' = "Running"
+    /\ UNCHANGED turn_count
+
+NextBuggy ==
+    \/ \E to_ \in States : Transition(to_)
+    \/ Reaffirm
+    \/ StutterTerminal
+    \/ BugTerminalResurrection
+
+SpecBuggy == Init /\ [][NextBuggy]_vars /\ WF_vars(\E to_ \in States : Transition(to_))
+
+\* Invariant SHOULD be violated under SpecBuggy.
+TerminalIsStableMustHold == TerminalIsStable
+
+====


### PR DESCRIPTION
## 요약

`lib/agent/agent_lifecycle.mli`의 5-state FSM (Accepted/Ready/Running/Completed/Failed) 을 TLA+ 로 모델링. CascadeFSM/ContentReplacement/EventBusCausality 에 이은 4번째 spec.

근거 plan: `~/me/planning/claude-plans/steady-seeking-goose.md` (Bucket A · A2)
근거 issue: #1212 (Plan A2: TLA+ spec 커버리지 확장)

## TLC 검증 결과

| Spec | 결과 | 상세 |
|------|------|------|
| **Clean** (`AgentLifecycle.cfg`) | ✅ PASS | 38 states generated, **19 distinct**, 0 errors |
| **Buggy** (`AgentLifecycle-buggy.cfg`) | ✅ violation 검출 | `TerminalIsStableMustHold` violated in 6 steps under `BugTerminalResurrection` (Failed→Running) |

Mutation test 의미: clean 통과 + buggy violation 검출 → invariant 가 *vacuously true* 가 아니라 실제로 강제됨을 기계적으로 증명.

## 검증된 invariants

1. `TypeOK` — type 안전성
2. `PrevNotEqualStatus` — Transition 은 same-state 가 아님 (Reaffirm 분리)
3. `TerminalIsStable` — `IsTerminal(prev_status) => status = prev_status`
4. `NoIllegalTransition` — declared transition 만 발생
5. `RunningRequiresReady` — Running 은 Ready 또는 None 에서만
6. `CompletedRequiresRunning` — Completed 는 Running 에서만
7. `NoTransitionIntoAccepted` — Accepted 는 초기 또는 reaffirm 으로만

## 설계 결정

**State representation**: `(status, prev_status, turn_count)` — bounded — 사용. 초기 prototype 은 `history: Seq(States)` 변수로 trace 저장 → unbounded → TLC 8.5M states 후 무한 진행. 재설계로 19 distinct states 유한 모델.

**MaxTurns=3**: Ready↔Running 사이클 bound. 실제 multi-turn agent 는 더 많이 cycle 가능하지만 model checking 목적상 충분 (모든 distinct transition path 커버).

## Out of scope

**Cancellation absorption** (`Eio.Cancel.Cancelled` 흡수) 는 여기서 다루지 않음. cancellation 은 fiber/Switch layer (`agent_turn`, runtime) 의 책임으로, lifecycle FSM 의 외부.
- 별도 spec `AgentCancellation.tla` (미래 issue)에서 모델링 권장
- 운영 데이터: jeong-sik/masc-mcp memory `oas_execution_uncancellable_mid_turn`

## 재현

```bash
cd specs
java -cp ~/me/tools/tla2tools.jar tlc2.TLC -config AgentLifecycle.cfg AgentLifecycle.tla
java -cp ~/me/tools/tla2tools.jar tlc2.TLC -config AgentLifecycle-buggy.cfg AgentLifecycle.tla
```

## Test plan

- [x] TLC clean.cfg PASS (38 states, 19 distinct, 0 errors)
- [x] TLC buggy.cfg `TerminalIsStableMustHold` violation 검출
- [ ] 리뷰어 로컬 재검증 (선택)

## 후속

- #1212 의 ContextWindowExhaustion.tla 는 본 PR 별도 처리 (PR 분리 — `audit-bucket-cascade-pattern` 회피)
- AgentCancellation.tla 는 별도 issue 후 작성

🤖 Generated with [Claude Code](https://claude.com/claude-code)