### PR TITLE
chore: remove str_match.ml wrapper, fold into Util.regex_match

### DIFF
--- a/lib/approval.ml
+++ b/lib/approval.ml
@@ -114,12 +114,12 @@ let reject_dangerous_patterns (patterns : (string * string) list) : approval_sta
   evaluate = (fun ctx ->
     let matches = List.exists (fun (name_pat, input_pat) ->
       let name_match =
-        Str_match.contains (Str.regexp name_pat) ctx.tool_name
+        Util.regex_match (Str.regexp name_pat) ctx.tool_name
       in
       let input_str = Yojson.Safe.to_string ctx.input in
       let input_match =
         if input_pat = "" then true
-        else Str_match.contains (Str.regexp input_pat) input_str
+        else Util.regex_match (Str.regexp input_pat) input_str
       in
       name_match && input_match
     ) patterns in

--- a/lib/harness.ml
+++ b/lib/harness.ml
@@ -212,7 +212,7 @@ module Adversarial = struct
     | ErrorContains needle ->
       let passed = match obs.error_message with
         | Some msg ->
-          Str_match.contains (Str.regexp_string needle) msg
+          Util.regex_match (Str.regexp_string needle) msg
         | None -> false
       in
       {

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -80,14 +80,14 @@ let extract_reasoning (messages : message list) : reasoning_summary =
     "might be wrong"; "unsure"; "probably"; "I think";
   ] in
   let has_uncertainty = List.exists (fun marker ->
-    Str_match.contains (Str.regexp_string_case_fold marker) all_text
+    Util.regex_match (Str.regexp_string_case_fold marker) all_text
   ) uncertainty_markers in
   let tool_rationale =
     (* Look for the last thinking block that mentions tool selection *)
     let tool_markers = ["tool"; "function"; "call"; "use"] in
     List.find_map (fun block ->
       if List.exists (fun marker ->
-        Str_match.contains (Str.regexp_string_case_fold marker) block
+        Util.regex_match (Str.regexp_string_case_fold marker) block
       ) tool_markers then Some block
       else None
     ) (List.rev thinking_blocks)

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -278,7 +278,7 @@ let rec eval_condition (last_result : task_result option) cond =
     (match last_result with
      | Some { result = Ok resp; _ } ->
        let text = text_of_response resp in
-       Str_match.contains (Str.regexp_string needle) text
+       Util.regex_match (Str.regexp_string needle) text
      | _ -> false)
   | Custom_cond pred ->
     (match last_result with

--- a/lib/str_match.ml
+++ b/lib/str_match.ml
@@ -1,3 +1,0 @@
-let contains re str =
-  try ignore (Str.search_forward re str 0); true
-  with Not_found -> false

--- a/lib/str_match.mli
+++ b/lib/str_match.mli
@@ -1,6 +1,0 @@
-(** Thin wrapper around [Str.search_forward] for boolean matching. *)
-
-val contains : Str.regexp -> string -> bool
-(** [contains re str] returns [true] if [re] matches anywhere in [str].
-    Equivalent to [try ignore (Str.search_forward re str 0); true
-    with Not_found -> false]. *)

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -66,3 +66,7 @@ let contains_substring_ci ~haystack ~needle =
       else loop (i + 1)
     in
     loop 0
+
+let regex_match re str =
+  try ignore (Str.search_forward re str 0); true
+  with Not_found -> false

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -39,3 +39,6 @@ val safe_sub : string -> int -> int -> string
 
 (** Case-insensitive substring search. *)
 val contains_substring_ci : haystack:string -> needle:string -> bool
+
+(** [regex_match re s] returns [true] if regex [re] matches anywhere in [s]. *)
+val regex_match : Str.regexp -> string -> bool


### PR DESCRIPTION
## Summary

Kimi Audit O7 (#1221): `str_match.ml` 4줄 wrapper를 제거하고 `Util.regex_match`로 통합.

## 변경 내용

**제거**: `lib/str_match.ml` (4줄, `Str.search_forward` wrapper)

**추가**: `Util.regex_match` (`util.ml` + `util.mli`)
```ocaml
let regex_match re str =
  try ignore (Str.search_forward re str 0); true
  with Not_found -> false
```

**교체**: 4파일 6라인
- `orchestrator.ml:281` — `Str_match.contains` → `Util.regex_match`
- `approval.ml:117, 122` — 동일
- `hooks.ml:83, 90` — 동일
- `harness.ml:215` — 동일

## 이유

`str_match.ml`은 4줄짜리 trivial wrapper. `Util` 모듈이 이미 `string_contains`, `contains_substring_ci` 등 유사 helper를 모으고 있어 자연스러운 위치.

## 검증

- `agent_sdk.ml/.mli`에서 `Str_match` re-export 없음 (외부 노출 0)
- `Str_match` 직접 참조 0건 확인 (`rg "Str_match" lib/ test/` after change)
- 동작 동일 (단순 함수 이동)

Closes #1221
