### PR TITLE
test(dune): register orphan test_tool_set with qcheck deps (#1179)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -129,6 +129,11 @@
  (libraries agent_sdk alcotest yojson))
 
 (test
+ (name test_tool_set)
+ (modules test_tool_set)
+ (libraries agent_sdk alcotest qcheck-core qcheck-alcotest))
+
+(test
  (name test_typed_tool_safe)
  (modules test_typed_tool_safe)
  (libraries agent_sdk alcotest yojson))


### PR DESCRIPTION
## Summary

- Adds the missing `(test (name test_tool_set) ...)` stanza in `test/dune`
- Closes the last remaining orphan `.ml` from issue #1179 (the others were already cleared via the #1025 series)
- Stanza brings in `qcheck-core` / `qcheck-alcotest` so the property tests in `test_tool_set.ml` actually compile

## Why

`test_tool_set.ml` was committed without a paired dune stanza. Cold-cache builds had nothing in scope for `QCheck`, so any fresh `dune build @check` died with:
```
Error: Unbound module QCheck
```
Warm-cache CI runs masked it because stale `.cmi` artefacts survived between jobs.

## Verification (local, cold cache)

| Command | Result |
|---------|--------|
| `rm -rf _build && opam exec -- dune build --root . test/test_tool_set.exe` | ok |
| `opam exec -- dune test --root . test/test_tool_set.exe` | 12/12 pass (7 unit + 5 QCheck) |
| `rm -rf _build && opam exec -- dune build --root .` | ok, **0 test/ errors** |

## Out of scope (follow-up candidates)

Cold `dune build @check` still surfaces `Unbound module Agent_sdk` errors for `examples/*.ml`. Those exist on `origin/main` independent of this PR. Tracking suggestion: file a separate issue for the example-build ordering on `@check` alias.

## Test plan
- [x] Local cold-cache build of `test_tool_set.exe`
- [x] Local `dune test` of `test_tool_set.exe` — 12/12 green
- [x] Default `dune build --root .` cold-cache passes
- [ ] CI green (build/test/lint)

Closes #1179