### PR TITLE
test(policy_channel): register orphan test_policy_channel + fix tuple destructuring (#1175)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -124,6 +124,11 @@
  (libraries agent_sdk llm_provider alcotest eio eio_main))
 
 (test
+ (name test_policy_channel)
+ (modules test_policy_channel)
+ (libraries agent_sdk alcotest))
+
+(test
  (name test_tool_use_recovery)
  (modules test_tool_use_recovery)
  (libraries agent_sdk alcotest yojson))

--- a/test/test_policy_channel.ml
+++ b/test/test_policy_channel.ml
@@ -148,7 +148,7 @@ let test_shared_channel_between_agents () =
   let ch = Policy_channel.create () in
   let tools = Tool_set.of_list [make_tool "read"; make_tool "shell"] in
   (* Before push: child sees all *)
-  let tools_json_before, _ = Agent_turn.prepare_tools
+  let tools_json_before, _, _ = Agent_turn.prepare_tools
     ~guardrails:Guardrails.default
     ~operator_policy:None
     ~policy_channel:(Some ch)
@@ -161,7 +161,7 @@ let test_shared_channel_between_agents () =
   (* Parent pushes Remove ["shell"] *)
   Policy_channel.push ch (Tool_op.Remove ["shell"]);
   (* After push: child sees reduced set *)
-  let tools_json_after, _ = Agent_turn.prepare_tools
+  let tools_json_after, _, _ = Agent_turn.prepare_tools
     ~guardrails:Guardrails.default
     ~operator_policy:None
     ~policy_channel:(Some ch)


### PR DESCRIPTION
## Summary

- Adds the missing `(test (name test_policy_channel) ...)` stanza in `test/dune` so the existing 197-line test file actually runs
- Fixes a 2-tuple → 3-tuple destructuring bug at two `Agent_turn.prepare_tools` call sites (the signature gained a third element — `visible_tool_names` — in v0.162.0)

## Why this counts toward #1175

`lib/policy_channel.ml` (37 lines, 4 functions: `create` / `push` / `poll` / `version`) was listed at **0% coverage** in #1175. Tests had been written but never wired in. After this PR they run as 11 cases (5 basic + 6 `prepare_tools` integration), bringing the module to full surface coverage.

## Verification (cold cache)

| Command | Result |
|---------|--------|
| `dune build --root . test/test_policy_channel.exe` | ok |
| `dune test --root . test/test_policy_channel.exe` | 11/11 pass |
| `OCAMLPARAM=\"_,warn-error=+a\" dune build --root . @install --force` (= CI Lint) | green |

## Files

- `test/dune` (+5 lines: new stanza)
- `test/test_policy_channel.ml` (2 lines: tuple fix)

## Same family as #1179 / #1224

This is the third orphan test file from the broader `#1025` series of misfiled tests. Pattern is consistent: file on disk, no stanza, no cold-`@check` exposure. Other orphans tracked separately.

## Test plan

- [x] Local cold-cache build green
- [x] All 11 cases pass
- [x] Lint-equivalent build green
- [ ] CI green