### PR TITLE
test(dune): register 4 orphan tests + 2 missing partial-match arms (#1175 / #1179 family)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -129,6 +129,26 @@
  (libraries agent_sdk alcotest yojson))
 
 (test
+ (name test_http_client)
+ (modules test_http_client)
+ (libraries agent_sdk llm_provider alcotest yojson))
+
+(test
+ (name test_sse_parser)
+ (modules test_sse_parser)
+ (libraries agent_sdk llm_provider alcotest eio eio_main))
+
+(test
+ (name test_stream_accumulator)
+ (modules test_stream_accumulator)
+ (libraries agent_sdk llm_provider alcotest))
+
+(test
+ (name test_streaming_coverage)
+ (modules test_streaming_coverage)
+ (libraries agent_sdk llm_provider alcotest))
+
+(test
  (name test_tool_set)
  (modules test_tool_set)
  (libraries agent_sdk alcotest qcheck-core qcheck-alcotest))

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -100,6 +100,10 @@ let test_post_stream_invalid_url_returns_network_error () =
       Alcotest.fail "expected invalid URL to fail before headers are accepted"
   | Error (Http_client.HttpError _) ->
       Alcotest.fail "expected network error for invalid URL"
+  | Error (Http_client.CliTransportRequired _) ->
+      Alcotest.fail "expected NetworkError for invalid URL, not CliTransportRequired"
+  | Error (Http_client.ProviderTerminal _) ->
+      Alcotest.fail "expected NetworkError for invalid URL, not ProviderTerminal"
   | Ok _ ->
       Alcotest.fail "expected invalid URL to fail before opening a stream"
 


### PR DESCRIPTION
## Summary

Closes the test-orphan family from #1179 by registering the four remaining files that #1224 (test_tool_set) and #1229 (test_policy_channel) didn't touch.

| Stanza added | Module under test |
|---|---|
| `test_http_client` | `lib/llm_provider/http_client.ml` |
| `test_sse_parser` | `lib/llm_provider/sse_parser.ml` |
| `test_stream_accumulator` | `lib/streaming.ml` (accumulator helpers) |
| `test_streaming_coverage` | `lib/streaming.ml` (`map_http_error` + finalize edge cases) |

## Why root-fix

These were committed-but-not-wired tests (the same anti-pattern that #1179 surfaced for `test_tool_set`). Cold `dune build @check` walks the whole tree, so an orphan that compiles silently sits at 0% coverage and is invisible to the bisect floor in #1175 — both observability problems collapse into the same fix: register the stanza.

Same family: #1179 → #1224 (test_tool_set) → #1229 (test_policy_channel) → this PR.

## Partial-match arm fix in `test_http_client`

`Http_client.http_error` extended with `CliTransportRequired` / `ProviderTerminal` since this test was last touched. The invalid-URL match only knew about `NetworkError`/`AcceptRejected`/`HttpError`, so `warn-error=+a` flagged it. Added two explicit `Alcotest.fail` arms naming the new variants — keeps any *future* variant addition a hard build break instead of a silent fallthrough.

## Verification (cold cache)

| Command | Result |
|---------|--------|
| `dune build --root . test/test_http_client.exe ...` (all 4) | green |
| `dune test --root . test/test_http_client.exe` | 15/15 pass |
| `OCAMLPARAM=\"_,warn-error=+a\" dune build --root . @install --force` | green |

## Files

- `test/dune` (+20 lines: 4 new stanzas)
- `test/test_http_client.ml` (+4 lines: explicit arms for new error variants)

## Test plan

- [x] All 4 `.exe` build clean
- [x] test_http_client runtime: 15/15 pass
- [x] Lint-equivalent build green
- [ ] CI green (Build + Lint)

Refs #1179, #1175