### PR TITLE
test(dune): register 3 more orphan tests — checkpoint_validation / judge / tool_selector (#1175)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -159,6 +159,21 @@
  (libraries agent_sdk alcotest qcheck-core qcheck-alcotest))
 
 (test
+ (name test_checkpoint_validation)
+ (modules test_checkpoint_validation)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_judge)
+ (modules test_judge)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_tool_selector)
+ (modules test_tool_selector)
+ (libraries agent_sdk alcotest))
+
+(test
  (name test_typed_tool_safe)
  (modules test_typed_tool_safe)
  (libraries agent_sdk alcotest yojson))


### PR DESCRIPTION
## Summary

Adds `(test ...)` stanzas for the last three #1175 0%-coverage modules whose tests were already on disk but never wired in.

| Stanza | Module under test |
|---|---|
| `test_checkpoint_validation` | `lib/checkpoint_validation.ml` (DNA continuity / regression checks) |
| `test_judge` | `lib/judge/judge.ml` (LLM-eval + risk_level scoring) |
| `test_tool_selector` | `lib/tool_selector.ml` (2-stage tool routing) |

15 lines, single file (`test/dune`), no test code touched.

## Why this is the cleanup PR for the orphan-test family

`#1179 → #1224 → #1229 → #1230 → this` closes the cascade. After this lands, every `test_*.ml` in `test/` that has a paired `lib/*.ml` module has a stanza and is visible to bisect.

That removes the silent-orphan blind spot that #1175 specifically called out as the structural reason coverage couldn't be measured honestly.

## Verification (cold cache)

| Command | Result |
|---------|--------|
| `dune build --root . test/{test_checkpoint_validation,test_judge,test_tool_selector}.exe` | all green |
| `dune test --root . test/test_tool_selector.exe` | 23/23 pass (topk_llm + stubs + categorical_bm25 groups) |
| `OCAMLPARAM=\"_,warn-error=+a\" dune build --root . @install --force` | green |

## Test plan

- [x] All 3 .exe build clean
- [x] test_tool_selector runtime: 23/23 pass
- [x] Lint-equivalent build green
- [ ] CI green

Refs #1175, #1179