### PR TITLE
test(dune): batch 3 — register 6 more orphan tests (#1175)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -179,6 +179,36 @@
  (libraries agent_sdk alcotest yojson))
 
 (test
+ (name test_fs_result)
+ (modules test_fs_result)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_log)
+ (modules test_log)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_metrics)
+ (modules test_metrics)
+ (libraries agent_sdk alcotest eio eio_main))
+
+(test
+ (name test_tool_op)
+ (modules test_tool_op)
+ (libraries agent_sdk alcotest qcheck-core qcheck-alcotest))
+
+(test
+ (name test_uncertain)
+ (modules test_uncertain)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_policy)
+ (modules test_policy)
+ (libraries agent_sdk alcotest))
+
+(test
  (name test_tool_schema_gen)
  (modules test_tool_schema_gen)
  (libraries agent_sdk alcotest yojson))


### PR DESCRIPTION
## Summary

Adds dune stanzas for 6 more orphan tests after re-running the sweep on a fresh main. The earlier #1179 list was incomplete — running `find test/*.ml + grep test/dune` post-#1231 surfaced 29 more orphans-with-paired-lib-modules. This PR lands the first low-risk batch.

| Stanza | Lib module | Library deps |
|---|---|---|
| `test_fs_result` | `lib/fs_result.ml` | agent_sdk alcotest |
| `test_log` | `lib/log.ml` | agent_sdk alcotest |
| `test_metrics` | `lib/metrics.ml` | agent_sdk alcotest eio eio_main |
| `test_tool_op` | `lib/tool_op.ml` | agent_sdk alcotest **qcheck-core qcheck-alcotest** |
| `test_uncertain` | `lib/uncertain.ml` | agent_sdk alcotest |
| `test_policy` | `lib/policy.ml` | agent_sdk alcotest |

30 lines, single file (`test/dune`). No test code changes.

## Why batch this size

These six all build clean against current main and pass with no test-code edits — straightforward stanza additions. The remaining 23 orphans likely need partial-match arms / API shape updates / extra deps; they're tracked for separate batches so review stays surgical.

## Verification (cold cache)

| Command | Result |
|---------|--------|
| `dune build --root . test/{6 .exes}` | all green |
| `dune test --root . test/test_tool_op.exe` | **62/62 pass** (unit + 5 QCheck properties) |
| `OCAMLPARAM=\"_,warn-error=+a\" dune build --root . @install --force` | green |

## Cascade

`#1179 → #1224 → #1229 → #1230 → #1231 → this`. With 6 more stanzas the registered-test surface grows by another 6 modules toward the #1175 threshold-raise.

Refs #1175, #1179