### PR TITLE
test(dune): batch 4 — register 6 more orphan tests (#1175)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -179,6 +179,36 @@
  (libraries agent_sdk alcotest yojson))
 
 (test
+ (name test_consumer)
+ (modules test_consumer)
+ (libraries agent_sdk alcotest eio eio_main cohttp-eio yojson))
+
+(test
+ (name test_context_offload)
+ (modules test_context_offload)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_provider_intf)
+ (modules test_provider_intf)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_tool_index)
+ (modules test_tool_index)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_tool_input_validation)
+ (modules test_tool_input_validation)
+ (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_tool_middleware)
+ (modules test_tool_middleware)
+ (libraries agent_sdk alcotest yojson))
+
+(test
  (name test_fs_result)
  (modules test_fs_result)
  (libraries agent_sdk alcotest))


### PR DESCRIPTION
## Summary

Sixth installment in the orphan-test sweep (`#1179 → #1224 → #1229 → #1230 → #1231 → #1232 → here`). Six more `test_*.ml` files registered against their paired `lib/*.ml` modules.

| Stanza | Lib module | Function |
|---|---|---|
| `test_consumer` | `lib/consumer.ml` | high-level `Agent.run` + telemetry harness |
| `test_context_offload` | `lib/context_offload.ml` | offload large tool results to files |
| `test_provider_intf` | `lib/provider_intf.ml` | module type satisfaction + dispatch |
| `test_tool_index` | `lib/tool_index.ml` | BM25-based tool retrieval |
| `test_tool_input_validation` | `lib/tool_input_validation.ml` | deterministic schema checking |
| `test_tool_middleware` | `lib/tool_middleware.ml` | validation/coercion primitives |

30 lines, single file (`test/dune`). Test code unchanged.

## Verification (cold cache)

| Command | Result |
|---------|--------|
| `dune build --root . test/{6 exes}` | all 6 green first try |
| `dune test --root . test/test_tool_middleware.exe` | 24/24 pass |
| `OCAMLPARAM=\"_,warn-error=+a\" dune build --root . @install --force` | green |

## Remaining orphans (~17)

`test_async_agent, test_contract, test_contract_runner, test_cost_tracker, test_durable, test_eval_otel_bridge, test_guardrail_llm, test_guardrail_tripwire, test_guardrails_async, test_otel_export, test_pipeline, test_plan, test_progressive_tools, test_reflexion, test_succession, test_verified_output, test_append_instruction`

These will need per-file inspection (likely partial-match arms or library shape adjustments after intervening API changes), so they don't get bundled here. Tracked for follow-up batches.

Refs #1175, #1179