### PR TITLE
test(dune): batch 5 — register 16 final orphan tests (#1175 family closure)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -179,6 +179,86 @@
  (libraries agent_sdk alcotest yojson))
 
 (test
+ (name test_async_agent)
+ (modules test_async_agent)
+ (libraries agent_sdk alcotest eio eio_main cohttp-eio yojson))
+
+(test
+ (name test_contract)
+ (modules test_contract)
+ (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_contract_runner)
+ (modules test_contract_runner)
+ (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_cost_tracker)
+ (modules test_cost_tracker)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_durable)
+ (modules test_durable)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_guardrail_llm)
+ (modules test_guardrail_llm)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_guardrail_tripwire)
+ (modules test_guardrail_tripwire)
+ (libraries agent_sdk alcotest eio eio_main))
+
+(test
+ (name test_guardrails_async)
+ (modules test_guardrails_async)
+ (libraries agent_sdk alcotest eio eio_main))
+
+(test
+ (name test_otel_export)
+ (modules test_otel_export)
+ (libraries agent_sdk alcotest yojson))
+
+(test
+ (name test_pipeline)
+ (modules test_pipeline)
+ (libraries agent_sdk alcotest eio eio_main yojson))
+
+(test
+ (name test_plan)
+ (modules test_plan)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_progressive_tools)
+ (modules test_progressive_tools)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_reflexion)
+ (modules test_reflexion)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_succession)
+ (modules test_succession)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_verified_output)
+ (modules test_verified_output)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_append_instruction)
+ (modules test_append_instruction)
+ (libraries agent_sdk alcotest))
+
+(test
  (name test_consumer)
  (modules test_consumer)
  (libraries agent_sdk alcotest eio eio_main cohttp-eio yojson))


### PR DESCRIPTION
## Summary

Final installment in the orphan-test sweep (`#1179 → #1224 → #1229 → #1230 → #1231 → #1232 → #1233 → here`). Sixteen more `test_*.ml` files registered against their paired `lib/*.ml` modules.

| Stanza | Coverage target |
|---|---|
| `test_async_agent` | `lib/agent/agent_async.ml` |
| `test_contract` | `lib/contract.ml` |
| `test_contract_runner` | `lib/contract_runner.ml` |
| `test_cost_tracker` | `lib/cost_tracker.ml` |
| `test_durable` | `lib/durable.ml` |
| `test_guardrail_llm` | `lib/guardrail_llm.ml` |
| `test_guardrail_tripwire` | `lib/guardrail_tripwire.ml` |
| `test_guardrails_async` | `lib/guardrails_async.ml` |
| `test_otel_export` | `lib/otel_export.ml` |
| `test_pipeline` | `lib/pipeline/*` |
| `test_plan` | `lib/plan.ml` |
| `test_progressive_tools` | `lib/progressive_tools.ml` |
| `test_reflexion` | `lib/reflexion.ml` |
| `test_succession` | `lib/succession.ml` |
| `test_verified_output` | `lib/verified_output.ml` |
| `test_append_instruction` | `lib/append_instruction.ml` |

80 lines, single file (`test/dune`). No test code touched.

## Excluded

**`test_eval_otel_bridge`** — references `Eval_otel_bridge` which is unbound on current main:
```
File \"test/test_eval_otel_bridge.ml\", line 29:
Error: Unbound module Eval_otel_bridge
```
Module appears renamed/removed since the test was written. Needs separate follow-up that restores the reference or migrates to the replacement API.

## Verification (cold cache)

| Command | Result |
|---------|--------|
| `dune build --root . test/{16 .exes}` | all green |
| `dune test --root . test/test_verified_output.exe` | 9/9 pass |
| `OCAMLPARAM=\"_,warn-error=+a\" dune build --root . @install --force` | green |

## Family closure

After this lands, the 29-orphan list from the post-#1231 sweep is reduced to **1** (`test_eval_otel_bridge`, blocked on unbound module). Every other `test_*.ml` with a paired lib module now has a stanza.

Refs #1175, #1179