### PR TITLE
test(eval): expose Eval_otel_bridge from Agent_sdk + register orphan test (#1175 family closure)

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -119,6 +119,7 @@ module Harness_report = Harness_report
 module Harness_runner = Harness_runner
 module Eval = Eval
 module Eval_collector = Eval_collector
+module Eval_otel_bridge = Eval_otel_bridge
 module Trajectory = Trajectory
 module Sandbox_runner = Sandbox_runner
 module Autonomy_exec = Autonomy_exec

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -93,6 +93,7 @@ module Harness_report = Harness_report
 module Harness_runner = Harness_runner
 module Eval = Eval
 module Eval_collector = Eval_collector
+module Eval_otel_bridge = Eval_otel_bridge
 module Trajectory = Trajectory
 module Sandbox_runner = Sandbox_runner
 module Autonomy_exec = Autonomy_exec

--- a/test/dune
+++ b/test/dune
@@ -204,6 +204,11 @@
  (libraries agent_sdk alcotest))
 
 (test
+ (name test_eval_otel_bridge)
+ (modules test_eval_otel_bridge)
+ (libraries agent_sdk alcotest yojson))
+
+(test
  (name test_guardrail_llm)
  (modules test_guardrail_llm)
  (libraries agent_sdk alcotest))


### PR DESCRIPTION
## Summary

Closes the orphan-test family from #1179 by:

1. Adding `module Eval_otel_bridge = Eval_otel_bridge` to `lib/agent_sdk.ml` + `lib/agent_sdk.mli` (parallel to the existing `Eval` / `Eval_collector` / `Eval_baseline` / `Eval_report` re-exports)
2. Registering `(test (name test_eval_otel_bridge) ...)` in `test/dune` (the stanza that was deferred from #1234)

## Why

`#1234` tried to register all 17 remaining orphans but skipped this one because `test_eval_otel_bridge.ml` failed with:

```
File \"test/test_eval_otel_bridge.ml\", line 29:
Error: Unbound module Eval_otel_bridge
```

The test does `open Agent_sdk` then `Eval_otel_bridge.extract rm` — and `Agent_sdk.Eval_otel_bridge` literally didn't exist on the public surface. The lib module is fine; the re-export was just missing. Two-line gap-fill.

## Verification (cold cache)

| Command | Result |
|---------|--------|
| `dune build --root . test/test_eval_otel_bridge.exe` | green |
| `dune test --root . test/test_eval_otel_bridge.exe` | **3/3 pass** (extract accessible, metric list count, json export) |
| `OCAMLPARAM=\"_,warn-error=+a\" dune build --root . @install --force` | green |

## Orphan-test family — closed

`#1179 → #1224 → #1229 → #1230 → #1231 → #1232 → #1233 → #1234 → here`. After this lands, every `test_*.ml` in `test/` with a paired `lib/*.ml` module has a stanza. The 539-orphan symptom block from #1179 is resolved at the source: the registration mechanism, not just the listed examples.

## Files

- `lib/agent_sdk.ml` (+1 line)
- `lib/agent_sdk.mli` (+1 line)
- `test/dune` (+5 lines)

Closes the orphan-test thread of #1175. Refs #1179.