### PR TITLE
ci(coverage): raise floor 66 → 71 (#1175, post orphan-test sweep)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,13 +123,17 @@ jobs:
           opam exec -- bisect-ppx-report summary --per-file --coverage-path=_coverage || true
 
           # Baseline, not aspiration. #250 set this to 80% but the parser
-          # bug (fixed in this PR) meant the gate never actually fired, so
+          # bug (fixed in #1171) meant the gate never actually fired, so
           # the 80% number was always hypothetical. First real measurement
-          # under correct instrumentation is 66.42% (run 24887636744). We
-          # ratchet-pin the floor to 66% and require non-regression only;
-          # raising the floor is tracked as a separate follow-up so this
-          # PR remains a pure measurement fix.
-          THRESHOLD=66
+          # under correct instrumentation was 66.42% (run 24887636744).
+          #
+          # 2026-04-28: orphan-test sweep (#1224 → #1229 → #1230 → #1231 →
+          # #1232 → #1233 → #1234 → #1235) registered 37 previously
+          # 0%-covered modules. Coverage on run 25039242435 (sha 755c04b0,
+          # batch-5 merge) measured 72.47%. Floor raised to 71 per #1175
+          # plan ("After each step, raise THRESHOLD to floor(measured - 1)
+          # to prevent regression without blocking noise").
+          THRESHOLD=71
           if [ "$(echo "$COVERAGE < $THRESHOLD" | bc -l)" -eq 1 ]; then
             echo "::error::Coverage ${COVERAGE}% is below threshold ${THRESHOLD}%"
             exit 1


### PR DESCRIPTION
## Summary

Ratchets the coverage floor in `ci.yml` from **66** to **71** following the orphan-test sweep that landed today.

## Measurement

| Reference | Coverage | Source |
|---|---|---|
| Pre-sweep baseline (was floor) | 66.42% | run 24887636744 |
| Post-batch-5 (sha `755c04b0`, #1234) | **72.47%** | run [25039242435](https://github.com/jeong-sik/oas/actions/runs/25039242435) |

That's a **+6.05 point** gain from registering 37 previously orphan tests against their paired `lib/` modules.

## Why 71 (not 72)

#1175 explicitly states:
> After each step, raise THRESHOLD in ci.yml to `floor(measured - 1)` to prevent regression without blocking noise.

72.47 − 1 = 71.47 → `floor(71.47) = 71`. Conservative 1-point buffer keeps small per-run fluctuation (typically <1pt) below the failure threshold so the gate doesn't flap.

## Cascade context

8-PR orphan-test sweep landed today:
`#1179 → #1224 → #1229 → #1230 → #1231 → #1232 → #1233 → #1234 → #1235`

37 modules went from 0% to covered. This is the natural ratchet step that #1175 prescribed but explicitly deferred from #1171 (the measurement-bug fix).

## Files

- `.github/workflows/ci.yml` (1 number + comment)

## Test plan

- [ ] CI green at the new floor (Build & Test job's Coverage step prints "Coverage 72.47% meets threshold 71%")

Refs #1175