### PR TITLE
test(llm_provider/error): cover provider_error.to_string variants (#1175)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -586,6 +586,11 @@
  (libraries agent_sdk llm_provider alcotest yojson))
 
 (test
+ (name test_llm_provider_error)
+ (modules test_llm_provider_error)
+ (libraries llm_provider alcotest))
+
+(test
  (name test_error_domain)
  (modules test_error_domain)
  (libraries agent_sdk llm_provider alcotest yojson))

--- a/test/test_llm_provider_error.ml
+++ b/test/test_llm_provider_error.ml
@@ -1,0 +1,59 @@
+(** Coverage for [Llm_provider.Error.provider_error] and its
+    [to_string] formatter (oas#1175 — file at 0% coverage in the
+    initial coverage measurement (`66.42%`, run `24887636744`)).
+
+    The module is 5 line-counted regions and the formatter has one
+    case per variant; one test per variant brings the file from 0%
+    to 100% with no behavior change. *)
+
+open Alcotest
+open Llm_provider
+
+let test_missing_api_key () =
+  check string "MissingApiKey format"
+    "Missing API key env var: OPENAI_API_KEY"
+    (Error.to_string
+       (Error.MissingApiKey { var_name = "OPENAI_API_KEY" }))
+
+let test_invalid_config () =
+  check string "InvalidConfig format"
+    "Invalid config 'temperature': must be in [0, 2]"
+    (Error.to_string
+       (Error.InvalidConfig
+          { field = "temperature"; detail = "must be in [0, 2]" }))
+
+let test_parse_error () =
+  check string "ParseError format"
+    "Parse error: unexpected token at line 3"
+    (Error.to_string
+       (Error.ParseError { detail = "unexpected token at line 3" }))
+
+let test_unknown_variant () =
+  check string "UnknownVariant format"
+    "Unknown stop_reason variant: max_tokens_exceeded"
+    (Error.to_string
+       (Error.UnknownVariant
+          { type_name = "stop_reason"; value = "max_tokens_exceeded" }))
+
+let test_provider_unavailable () =
+  check string "ProviderUnavailable format"
+    "Provider 'anthropic' unavailable: HTTP 503 retry-after exhausted"
+    (Error.to_string
+       (Error.ProviderUnavailable
+          {
+            provider = "anthropic";
+            detail = "HTTP 503 retry-after exhausted";
+          }))
+
+let () =
+  run "llm_provider_error"
+    [
+      ( "to_string",
+        [
+          test_case "MissingApiKey" `Quick test_missing_api_key;
+          test_case "InvalidConfig" `Quick test_invalid_config;
+          test_case "ParseError" `Quick test_parse_error;
+          test_case "UnknownVariant" `Quick test_unknown_variant;
+          test_case "ProviderUnavailable" `Quick test_provider_unavailable;
+        ] );
+    ]


### PR DESCRIPTION
## 컨텍스트

oas#1175 — coverage threshold 66.42% → 80% 점진 인상. 첫 0% 파일 진입.

`lib/llm_provider/error.ml` 은 5 line 의 ADT + 5-arm string formatter. 플레인 모듈이 0% coverage 였음 (initial ratcheted measurement, run `24887636744`).

## 변경

신규 `test/test_llm_provider_error.ml` (64 LOC) — `provider_error.to_string` 의 5 variant 각각 1 test:

- `MissingApiKey { var_name }` → `"Missing API key env var: %s"`
- `InvalidConfig { field; detail }` → `"Invalid config '%s': %s"`
- `ParseError { detail }` → `"Parse error: %s"`
- `UnknownVariant { type_name; value }` → `"Unknown %s variant: %s"`
- `ProviderUnavailable { provider; detail }` → `"Provider '%s' unavailable: %s"`

`test/dune` 에 새 alcotest binary 등록.

## 가치

- file 0% → 100%
- printf-style format 의 회귀 차단 — 향후 i18n / structured logging 으로 전환 시 message shape 변경이 test failure 로 표면화

## 검증

```
$ dune build --root . test/test_llm_provider_error.exe
$ ./_build/default/test/test_llm_provider_error.exe
Testing `llm_provider_error'.
This run has ID `ON85FFXF'.
  [OK]  to_string  0  MissingApiKey.
  [OK]  to_string  1  InvalidConfig.
  [OK]  to_string  2  ParseError.
  [OK]  to_string  3  UnknownVariant.
  [OK]  to_string  4  ProviderUnavailable.
Test Successful in 0.001s. 5 tests run.
```

## Cross-ref

- #1175 (parent — coverage ratchet plan)
- #1171 (CI step that surfaced the initial measurement)
- #250 (original 80% aspiration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
