### PR TITLE
chore(boundary): keep SDK comments coordinator-agnostic

### DIFF
--- a/lib/durable_event.ml
+++ b/lib/durable_event.ml
@@ -326,7 +326,7 @@ let save_to_file journal path =
   (* Delegate to {!Fs_result.write_file}: unique per-writer tmp +
      fsync + rename + dir fsync. Closes the shared-".tmp" rename race
      that happened when two fibers persisted the same journal path
-     (masc-mcp#9780 family). *)
+     (downstream #9780 family). *)
   let buf = Buffer.create 4096 in
   List.iter (fun event ->
     Buffer.add_string buf (Yojson.Safe.to_string (event_to_json event));

--- a/lib/fs_atomic_eio.ml
+++ b/lib/fs_atomic_eio.ml
@@ -4,13 +4,13 @@
     place, then fsyncs the directory. Unique tmp naming closes the
     concurrent-save race that produced [Eio.Io Fs Not_found
     Unix_error (No such file or directory, "renameat", ...json.tmp)]
-    when two fibers wrote to the same logical id (masc-mcp#9780).
+    when two fibers wrote to the same logical id (downstream #9780).
 
     The fsync pair is best-effort: some filesystems reject fsync on
     directories or on the file itself. Where supported, it closes the
     gap where [rename] succeeds but the kernel has not yet written the
     directory block — a crash in that window can resurrect the old
-    file or leave a partial one (masc-mcp#9749). *)
+    file or leave a partial one (downstream #9749). *)
 
 let unique_counter = Atomic.make 0
 

--- a/lib/fs_atomic_eio.mli
+++ b/lib/fs_atomic_eio.mli
@@ -6,13 +6,13 @@
     Creates a writer-unique tmp file in [dir], writes and fsyncs it,
     then renames into place. Concurrent calls with the same [name]
     never share a tmp path, so [rename] cannot race against a sibling
-    writer's [rename] (masc-mcp#9780).
+    writer's [rename] (downstream #9780).
 
     Fsync of tmp and parent directory is best-effort: failures are
     silently tolerated for filesystems that reject fsync (tmpfs on
     some kernels, SMB). Where supported, fsync closes the crash
     window where [rename] succeeds but is not yet durable
-    (masc-mcp#9749).
+    (downstream #9749).
 
     Returns [Error] via [Fs_result.io_error_of_exn] for any I/O,
     Eio, or Unix error. Re-raises [Eio.Cancel.Cancelled] after

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -43,7 +43,7 @@ type provider_terminal_kind =
       (** Provider's internal turn budget exhausted.  Maps to
           {!Error.MaxTurnsExceeded} at the agent runtime layer.  For
           claude_code 0.x the [limit] equals the CLI default
-          [--max-turns] (currently 31) when the keeper does not
+          [--max-turns] (currently 31) when the caller does not
           override it. *)
   | Other of string
       (** Forward-compatible bucket for unrecognized subtypes

--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -672,7 +672,7 @@ let%test "parse_json_result error" =
   | _ -> false
 
 let%test "parse_json_result error_max_turns becomes ProviderTerminal Max_turns" =
-  (* Pins the structural fix for masc-mcp#10629: claude_code internal
+  (* Pins the structural fix for downstream #10629: claude_code internal
      [error_max_turns] must surface as a structured terminal so the
      agent runtime can graceful-checkpoint instead of the cascade
      treating it as a transient network failure. *)
@@ -785,7 +785,7 @@ let%test "parse_stream_result no messages" =
   | Ok _ -> false
 
 let%test "parse_stream_result error_max_turns becomes ProviderTerminal Max_turns" =
-  (* Sync/stream parity for masc-mcp#10629: the production hits show
+  (* Sync/stream parity for downstream #10629: the production hits show
      this exact JSON shape on stdout when claude_code subprocess exits
      1 due to its internal max_turns CLI default (currently 31). *)
   let lines = [

--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -1106,8 +1106,8 @@ let%test "build_args runtime MCP wires request-scoped server" =
 (* Regression guard: HTTP MCP servers carrying [Authorization: Bearer X] must
    redirect the token through Codex CLI's [bearer_token_env_var] so it never
    appears on the command line ([ps eww] visibility).  Other headers stay in
-   [http_headers={...}].  Pre-fix behaviour leaked the token via argv and
-   triggered upstream omission policies in masc-mcp. *)
+   [http_headers={...}]. Pre-fix behaviour leaked the token via argv and
+   triggered downstream omission policies. *)
 let%test "build_args runtime MCP routes Bearer through env var indirection" =
   (* Use a token whose substring does not collide with any keyword in the
      emitted overrides (e.g. ["tok"] would also match [bearer_token_env_var]). *)

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -192,8 +192,8 @@ let stage_parse ?raw_trace_run agent =
   let prep = prepare_turn_for_agent agent ~turn_params in
   (* TurnReady event — emitted after guardrails + operator policy +
      tool_filter_override + tool_selector have produced the final tool
-     list the LLM will see this turn. Subscribers (e.g. masc-mcp
-     substrate observability) use this to verify deterministically
+     list the LLM will see this turn. Downstream substrate observability
+     subscribers use this to verify deterministically
      which tools the autonomous agent actually has access to, before
      making claims about LLM behaviour from a missing tool call.
      Sibling of TurnStarted (announce) and TurnCompleted (post-LLM). *)


### PR DESCRIPTION
## Summary

- Remove downstream coordinator vocabulary from OAS SDK comments and inline-test notes.
- Keep the same regression context while describing it as generic downstream integration history.

## Why

`scripts/check-sdk-independence.sh` is meant to enforce that OAS stays coordinator-agnostic. The current failures were all comments, not actual runtime imports or API coupling, but they made strict boundary enforcement noisy.

## Validation

- `bash scripts/check-sdk-independence.sh`
- `git diff --check`

Focused Dune build was started, but local Dune was blocked behind another session's long-running `@all` build lock; no OCaml logic changed in this PR.
