### PR TITLE
feat(llm_provider): add DeepSeek v4 models (flash, pro)

### DIFF
--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -18,6 +18,7 @@ let glm_messages_of_message = Backend_openai_serialize.glm_messages_of_message
 let tool_choice_to_openai_json = Backend_openai_serialize.tool_choice_to_openai_json
 let build_openai_tool_json = Backend_openai_serialize.build_openai_tool_json
 let strip_orphaned_tool_results = Backend_openai_serialize.strip_orphaned_tool_results
+let strip_thinking_blocks = Backend_openai_serialize.strip_thinking_blocks
 
 (* ── Re-exports from parsing ──────────────────────────── *)
 
@@ -190,8 +191,20 @@ let build_request ?(stream=false) ~(config : Provider_config.t)
   in
   let body = match config.enable_thinking with
     | Some enabled ->
-        ("chat_template_kwargs",
-         `Assoc [("enable_thinking", `Bool enabled)]) :: body
+        if String.starts_with ~prefix:"deepseek-v4" config.model_id then
+          if enabled then
+            let effort = Provider_config.effort_of_thinking_config
+              ~enable_thinking:config.enable_thinking
+              ~thinking_budget:config.thinking_budget
+            in
+            ("reasoning_effort", `String effort)
+            :: ("thinking", `Assoc [("type", `String "enabled")])
+            :: body
+          else
+            ("thinking", `Assoc [("type", `String "disabled")]) :: body
+        else
+          ("chat_template_kwargs",
+           `Assoc [("enable_thinking", `Bool enabled)]) :: body
     | None -> body
   in
   (* tool_choice uses a DIFFERENT unknown-model default than top_k /
@@ -1032,3 +1045,45 @@ let%test "supports_tool_choice_override=Some true forces tool_choice on capabili
   let json = Yojson.Safe.from_string body in
   let open Yojson.Safe.Util in
   json |> member "tool_choice" |> to_string = "required"
+
+let%test "build_request serializes thinking object for deepseek-v4-flash" =
+  let config = Provider_config.make ~kind:OpenAI_compat ~model_id:"deepseek-v4-flash"
+      ~base_url:"https://api.deepseek.com" ~enable_thinking:true ~thinking_budget:2048 () in
+  let body = build_request ~config ~messages:[] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  let thinking = json |> member "thinking" in
+  thinking |> member "type" |> to_string = "enabled"
+  && thinking |> member "reasoning_effort" = `Null
+  && json |> member "reasoning_effort" |> to_string = "low"
+
+let%test "build_request serializes disabled thinking for deepseek-v4-pro" =
+  let config = Provider_config.make ~kind:OpenAI_compat ~model_id:"deepseek-v4-pro"
+      ~base_url:"https://api.deepseek.com" ~enable_thinking:false () in
+  let body = build_request ~config ~messages:[] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  json |> member "thinking" |> member "type" |> to_string = "disabled"
+
+let%test "build_request falls back to chat_template_kwargs for non-deepseek thinking" =
+  let config = Provider_config.make ~kind:OpenAI_compat ~model_id:"llama-3.3-70b"
+      ~base_url:"http://localhost" ~enable_thinking:true () in
+  let body = build_request ~config ~messages:[] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  json |> member "chat_template_kwargs" |> member "enable_thinking" |> to_bool = true
+
+let%test "strip_thinking_blocks removes Thinking from all messages" =
+  let messages = [
+    { role = User; content = [Text "hello"]
+    ; name = None; tool_call_id = None; metadata = [] };
+    { role = Assistant; content = [
+        Text "hi";
+        Thinking { thinking_type = "reasoning"; content = "step 1" }
+      ]
+    ; name = None; tool_call_id = None; metadata = [] }
+  ] in
+  let stripped = strip_thinking_blocks messages in
+  List.for_all (fun (msg : message) ->
+    not (List.exists (function Thinking _ -> true | _ -> false) msg.content)
+  ) stripped

--- a/lib/llm_provider/backend_openai_parse.ml
+++ b/lib/llm_provider/backend_openai_parse.ml
@@ -74,10 +74,13 @@ let usage_of_openai_json json =
       |> Option.value ~default:0
     in
     let cached_tokens =
-      let details = usage |> member "prompt_tokens_details" in
-      if details = `Null
-      then 0
-      else details |> member "cached_tokens" |> to_int_option |> Option.value ~default:0
+      match member_int_fallback usage [ "prompt_cache_hit_tokens" ] with
+      | Some n -> n
+      | None ->
+        let details = usage |> member "prompt_tokens_details" in
+        if details = `Null
+        then 0
+        else details |> member "cached_tokens" |> to_int_option |> Option.value ~default:0
     in
     Some
       { input_tokens = prompt_tokens

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -243,6 +243,28 @@ let strip_orphaned_tool_results (messages : message list) : message list =
     messages
 ;;
 
+(** Strip Thinking blocks from all messages.
+    DeepSeek-compatible APIs reject [reasoning_content] in request
+    messages — it is response-only. Occurs before serialization so
+    theThinking blocks do not leak into the wire format.
+
+    Pure function — no I/O, no mutation. *)
+let strip_thinking_blocks (messages : message list) : message list =
+  List.map
+    (fun (msg : message) ->
+       let filtered =
+         List.filter
+           (function
+             | Thinking _ -> false
+             | _ -> true)
+           msg.content
+       in
+       if List.length filtered = List.length msg.content
+       then msg
+       else { msg with content = filtered })
+    messages
+;;
+
 let tool_choice_to_openai_json = function
   | Auto -> `String "auto"
   | Any -> `String "required"

--- a/lib/llm_provider/backend_openai_serialize.mli
+++ b/lib/llm_provider/backend_openai_serialize.mli
@@ -18,3 +18,9 @@ val build_openai_tool_json : Yojson.Safe.t -> Yojson.Safe.t
     OpenAI-compatible APIs to prevent orphaned tool_call_id errors
     after context compaction.  @since 0.103.0 *)
 val strip_orphaned_tool_results : Types.message list -> Types.message list
+
+(** Remove Thinking blocks from all messages. DeepSeek-compatible APIs
+    reject [reasoning_content] in request messages — it is response-only.
+    Call before serializing messages for OpenAI-compatible APIs.
+    @since 0.184.0 *)
+val strip_thinking_blocks : Types.message list -> Types.message list

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -383,28 +383,33 @@ let for_model_id model_id =
       ; supports_image_input = true
       ; supports_native_streaming = true
       }
-  else if starts_with "deepseek-chat" || starts_with "deepseek-v3"
+  else if starts_with "deepseek-v4-flash"
   then
     Some
       { default_capabilities with
-        max_context_tokens = Some 128_000
-      ; max_output_tokens = Some 8_000
+        max_context_tokens = Some 1_000_000
+      ; max_output_tokens = Some 384_000
       ; supports_tools = true
+      ; supports_tool_choice = true
       ; supports_reasoning = true
+      ; supports_extended_thinking = true
+      ; supports_reasoning_budget = true
       ; supports_response_format_json = true
       ; supports_native_streaming = true
       ; supports_caching = true
       }
-  else if starts_with "deepseek-reasoner" || starts_with "deepseek-r1"
+  else if starts_with "deepseek-v4-pro"
   then
     Some
       { default_capabilities with
-        max_context_tokens = Some 128_000
-      ; max_output_tokens = Some 8_000
-      ; supports_tools = false
-      ; (* R1 does NOT support tools *)
-        supports_reasoning = true
+        max_context_tokens = Some 1_000_000
+      ; max_output_tokens = Some 384_000
+      ; supports_tools = true
+      ; supports_tool_choice = true
+      ; supports_reasoning = true
       ; supports_extended_thinking = true
+      ; supports_reasoning_budget = true
+      ; supports_response_format_json = true
       ; supports_native_streaming = true
       ; supports_caching = true
       }

--- a/lib/llm_provider/model_meta.ml
+++ b/lib/llm_provider/model_meta.ml
@@ -127,9 +127,9 @@ let%test "gemini-3.1-flash-lite-preview has 1M context via gemini-3 prefix" =
   m.context_window = 1_000_000 && m.capabilities.supports_tools
 ;;
 
-let%test "deepseek-v3 can be marked local explicitly" =
-  let m = for_model_id ~locality:`Local "deepseek-v3" in
-  m.is_local && m.context_window = 128_000
+let%test "deepseek-v4-flash can be marked local explicitly" =
+  let m = for_model_id ~locality:`Local "deepseek-v4-flash" in
+  m.is_local && m.context_window = 1_000_000
 ;;
 
 let%test "llama-4-maverick can be marked local explicitly" =

--- a/lib/llm_provider/pricing.ml
+++ b/lib/llm_provider/pricing.ml
@@ -83,6 +83,15 @@ let pricing_for_model_opt model_id =
     else if string_contains ~needle:"o3-mini" normalized
     then
       Some ((1.1, 4.4), no_cache)
+      (* DeepSeek v4. Source: api-docs.deepseek.com, confirmed 2026-04-29.
+       Promotional 75%% discount until 2026-05-31.
+       Cache read rate: flash $0.0028/M (2%% of input), pro $0.003625/M.
+       Cache write is billed at standard input rate (no surcharge). *)
+    else if string_contains ~needle:"deepseek-v4-pro" normalized
+    then Some ((0.435, 0.87), (1.0, 0.008333333333333333))
+    else if string_contains ~needle:"deepseek-v4-flash" normalized
+    then
+      Some ((0.14, 0.28), (1.0, 0.02))
       (* Gemini 3-계 preview. Source: ai.google.dev/gemini-api/docs/pricing,
        confirmed 2026-04-16. Google also exposes context caching with a
        per-hour storage surcharge ($1.00/h flash, $4.50/h pro); the

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -326,10 +326,11 @@ let default () =
     ~max_context:128_000
     Capabilities.openai_chat_extended_capabilities;
   reg "groq" groq_defaults ~max_context:131_072 Capabilities.openai_chat_capabilities;
+  (* DeepSeek v4 series (flash / pro). 1M context, reasoning, tools. *)
   reg
     "deepseek"
     deepseek_defaults
-    ~max_context:128_000
+    ~max_context:1_000_000
     Capabilities.openai_chat_capabilities;
   reg
     "dashscope"

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -111,13 +111,26 @@ let test_lookup_qwen () =
   | None -> fail "should match qwen3"
 ;;
 
-let test_lookup_deepseek_r1 () =
-  match Capabilities.for_model_id "deepseek-r1" with
+let test_lookup_deepseek_v4_flash () =
+  match Capabilities.for_model_id "deepseek-v4-flash" with
   | Some c ->
-    check bool "NO tools" false c.supports_tools;
+    check (option int) "context 1M" (Some 1_000_000) c.max_context_tokens;
+    check (option int) "output 384K" (Some 384_000) c.max_output_tokens;
+    check bool "tools" true c.supports_tools;
     check bool "reasoning" true c.supports_reasoning;
-    check (option int) "output 8K" (Some 8_000) c.max_output_tokens
-  | None -> fail "should match deepseek-r1"
+    check bool "caching" true c.supports_caching
+  | None -> fail "should match deepseek-v4-flash"
+;;
+
+let test_lookup_deepseek_v4_pro () =
+  match Capabilities.for_model_id "deepseek-v4-pro" with
+  | Some c ->
+    check (option int) "context 1M" (Some 1_000_000) c.max_context_tokens;
+    check (option int) "output 384K" (Some 384_000) c.max_output_tokens;
+    check bool "tools" true c.supports_tools;
+    check bool "reasoning" true c.supports_reasoning;
+    check bool "caching" true c.supports_caching
+  | None -> fail "should match deepseek-v4-pro"
 ;;
 
 let test_lookup_grok () =
@@ -204,7 +217,8 @@ let () =
         ; test_case "gpt-5" `Quick test_lookup_gpt5
         ; test_case "gemini" `Quick test_lookup_gemini
         ; test_case "qwen" `Quick test_lookup_qwen
-        ; test_case "deepseek r1 no tools" `Quick test_lookup_deepseek_r1
+        ; test_case "deepseek v4 flash" `Quick test_lookup_deepseek_v4_flash
+        ; test_case "deepseek v4 pro" `Quick test_lookup_deepseek_v4_pro
         ; test_case "grok 2M context" `Quick test_lookup_grok
         ; test_case "glm-5 text only" `Quick test_lookup_glm5_text_only
         ; test_case "glm-5v vision" `Quick test_lookup_glm5v_vision

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -1646,33 +1646,26 @@ let test_for_model_id_llama4_alt () =
   | None -> Alcotest.fail "expected Some for llama4"
 ;;
 
-let test_for_model_id_deepseek_chat () =
-  match Capabilities.for_model_id "deepseek-chat-v3" with
+let test_for_model_id_deepseek_v4_flash () =
+  match Capabilities.for_model_id "deepseek-v4-flash" with
   | Some c ->
+    Alcotest.(check (option int)) "1M context" (Some 1_000_000) c.max_context_tokens;
+    Alcotest.(check (option int)) "384K output" (Some 384_000) c.max_output_tokens;
     Alcotest.(check bool) "tools" true c.supports_tools;
-    Alcotest.(check bool) "reasoning" true c.supports_reasoning
-  | None -> Alcotest.fail "expected Some for deepseek-chat"
-;;
-
-let test_for_model_id_deepseek_v3 () =
-  match Capabilities.for_model_id "deepseek-v3-2025" with
-  | Some c -> Alcotest.(check bool) "tools" true c.supports_tools
-  | None -> Alcotest.fail "expected Some for deepseek-v3"
-;;
-
-let test_for_model_id_deepseek_r1 () =
-  match Capabilities.for_model_id "deepseek-r1-latest" with
-  | Some c ->
-    Alcotest.(check bool) "no tools" false c.supports_tools;
     Alcotest.(check bool) "reasoning" true c.supports_reasoning;
-    Alcotest.(check bool) "extended_thinking" true c.supports_extended_thinking
-  | None -> Alcotest.fail "expected Some for deepseek-r1"
+    Alcotest.(check bool) "caching" true c.supports_caching
+  | None -> Alcotest.fail "expected Some for deepseek-v4-flash"
 ;;
 
-let test_for_model_id_deepseek_reasoner () =
-  match Capabilities.for_model_id "deepseek-reasoner" with
-  | Some c -> Alcotest.(check bool) "no tools" false c.supports_tools
-  | None -> Alcotest.fail "expected Some for deepseek-reasoner"
+let test_for_model_id_deepseek_v4_pro () =
+  match Capabilities.for_model_id "deepseek-v4-pro" with
+  | Some c ->
+    Alcotest.(check (option int)) "1M context" (Some 1_000_000) c.max_context_tokens;
+    Alcotest.(check (option int)) "384K output" (Some 384_000) c.max_output_tokens;
+    Alcotest.(check bool) "tools" true c.supports_tools;
+    Alcotest.(check bool) "reasoning" true c.supports_reasoning;
+    Alcotest.(check bool) "caching" true c.supports_caching
+  | None -> Alcotest.fail "expected Some for deepseek-v4-pro"
 ;;
 
 let test_for_model_id_mistral_large () =
@@ -2003,13 +1996,11 @@ let () =
         ; Alcotest.test_case "qwen3" `Quick test_for_model_id_qwen3
         ; Alcotest.test_case "llama-4" `Quick test_for_model_id_llama4
         ; Alcotest.test_case "llama4" `Quick test_for_model_id_llama4_alt
-        ; Alcotest.test_case "deepseek-chat" `Quick test_for_model_id_deepseek_chat
-        ; Alcotest.test_case "deepseek-v3" `Quick test_for_model_id_deepseek_v3
-        ; Alcotest.test_case "deepseek-r1" `Quick test_for_model_id_deepseek_r1
         ; Alcotest.test_case
-            "deepseek-reasoner"
+            "deepseek-v4-flash"
             `Quick
-            test_for_model_id_deepseek_reasoner
+            test_for_model_id_deepseek_v4_flash
+        ; Alcotest.test_case "deepseek-v4-pro" `Quick test_for_model_id_deepseek_v4_pro
         ; Alcotest.test_case "mistral-large" `Quick test_for_model_id_mistral_large
         ; Alcotest.test_case "mistral-small" `Quick test_for_model_id_mistral_small
         ; Alcotest.test_case "command" `Quick test_for_model_id_command

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -302,7 +302,7 @@ let test_default_max_context () =
    | Some e -> check int "groq 131K" 131_072 e.max_context
    | None -> fail "groq should exist");
   (match Provider_registry.find reg "deepseek" with
-   | Some e -> check int "deepseek 128K" 128_000 e.max_context
+   | Some e -> check int "deepseek 1M" 1_000_000 e.max_context
    | None -> fail "deepseek should exist");
   (match Provider_registry.find reg "dashscope" with
    | Some e -> check int "dashscope 131K" 131_072 e.max_context


### PR DESCRIPTION
## Summary
- register DeepSeek v4 flash/pro model capabilities, pricing, registry metadata, and OpenAI-compatible request/parse handling
- serialize DeepSeek v4 thinking options and preserve cache usage token fields
- strip prior Thinking blocks before OpenAI-path serialization to avoid multi-turn request rejection
- align DeepSeek v4 flash/pro context and max output values with current official DeepSeek API docs

## Verification
- scripts/dune-local.sh build @lib/check
- bash scripts/check-transport-truth.sh
- prior PR CI was green before the rebase; this push reruns CI on the rebased head

## Evidence
- Official DeepSeek pricing/model table checked 2026-04-29: https://api-docs.deepseek.com/quick_start/pricing