### PR TITLE
[codex] fix Kimi CLI stdin prompts and runtime tool surface

### DIFF
--- a/lib/llm_provider/transport_kimi_cli.ml
+++ b/lib/llm_provider/transport_kimi_cli.ml
@@ -34,7 +34,11 @@ let default_config =
 
 (* ── CLI argument building ───────────────────────────── *)
 
-let default_prompt_argv_threshold = 512 * 1024
+(* Kimi CLI imports setproctitle before it starts the request. On macOS,
+   long/non-ASCII argv payloads can make setproctitle.getproctitle raise a
+   UnicodeDecodeError before the provider sees the prompt. Keep argv small
+   and send keeper-scale prompts through stdin instead. *)
+let default_prompt_argv_threshold = 32 * 1024
 
 let prompt_argv_threshold () =
   match Sys.getenv_opt "OAS_KIMI_PROMPT_ARGV_THRESHOLD" with
@@ -530,6 +534,12 @@ let%test "build_args uses request model over default" =
 
 let%test "build_args routes large prompt via stdin" =
   let big = String.make (1 * 1024 * 1024) 'x' in
+  let args = build_args ~config:default_config ~req_config:(kimi_req ()) ~prompt:big in
+  (not (List.mem big args)) && not (List.mem "-p" args)
+;;
+
+let%test "build_args routes keeper-scale prompt via stdin" =
+  let big = String.make (70 * 1024) 'x' in
   let args = build_args ~config:default_config ~req_config:(kimi_req ()) ~prompt:big in
   (not (List.mem big args)) && not (List.mem "-p" args)
 ;;

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -112,6 +112,43 @@ let prepare_turn_for_agent agent ~turn_params =
     ()
 ;;
 
+let dedupe_preserve_order xs =
+  let seen = Hashtbl.create (List.length xs) in
+  List.filter
+    (fun x ->
+       if x = "" || Hashtbl.mem seen x
+       then false
+       else (
+         Hashtbl.replace seen x ();
+         true))
+    xs
+;;
+
+let turn_ready_tool_names_from_policy ?runtime_mcp_policy visible_tool_names =
+  let runtime_tool_names =
+    match runtime_mcp_policy with
+    | None -> []
+    | Some policy -> policy.Llm_provider.Llm_transport.allowed_tool_names
+  in
+  dedupe_preserve_order (visible_tool_names @ runtime_tool_names)
+;;
+
+let turn_ready_tool_names agent (prep : Agent_turn.turn_preparation) =
+  turn_ready_tool_names_from_policy
+    ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+    prep.visible_tool_names
+;;
+
+let%test "turn_ready_tool_names includes runtime MCP policy names" =
+  let runtime_mcp_policy =
+    { Llm_provider.Llm_transport.empty_runtime_mcp_policy with
+      allowed_tool_names = [ "masc_status"; "keeper_bash"; "inline_tool" ]
+    }
+  in
+  turn_ready_tool_names_from_policy ~runtime_mcp_policy [ "inline_tool" ]
+  = [ "inline_tool"; "masc_status"; "keeper_bash" ]
+;;
+
 let stage_parse ?raw_trace_run agent =
   let turn_params =
     match agent.options.hooks.before_turn_params with
@@ -195,9 +232,12 @@ let stage_parse ?raw_trace_run agent =
        (Turn_started { turn = agent.state.turn_count; timestamp = Unix.gettimeofday () })
    | None -> ());
   let prep = prepare_turn_for_agent agent ~turn_params in
+  let ready_tool_names = turn_ready_tool_names agent prep in
   (* TurnReady event — emitted after guardrails + operator policy +
      tool_filter_override + tool_selector have produced the final tool
-     list the LLM will see this turn. Downstream substrate observability
+     list the LLM will see this turn. CLI runtime-MCP tools are included
+     from the request-scoped runtime policy because those tools bypass
+     inline Tool.t schemas. Downstream substrate observability
      subscribers use this to verify deterministically
      which tools the autonomous agent actually has access to, before
      making claims about LLM behaviour from a missing tool call.
@@ -223,7 +263,7 @@ let stage_parse ?raw_trace_run agent =
            TurnReady
              { agent_name = agent.state.config.name
              ; turn = agent.state.turn_count
-             ; tool_names = prep.visible_tool_names
+             ; tool_names = ready_tool_names
              }
        }
    | None -> ());


### PR DESCRIPTION

## Summary

This fixes two OAS-side issues exposed by the 2026-04-30 keeper logs.

- Route keeper-scale Kimi CLI prompts through stdin at 32 KiB instead of passing large prompts through argv.
- Preserve runtime MCP policy tool names in `TurnReady` so tool-surface telemetry no longer reports an empty surface for CLI runtime-MCP lanes.
- Add focused inline tests for large Kimi prompt routing and runtime MCP tool-name propagation.

## Operator impact

The Kimi CLI crash happened before any provider request, while macOS process-title handling inspected a very large argv payload and hit a decode failure. Sending large prompts through stdin avoids that path. The tool-surface fix makes the logs tell the truth: runtime MCP tools supplied by policy should be visible in turn telemetry even when inline tool definitions are empty.

## Validation

- `git diff --check`
- `scripts/dune-local.sh runtest lib`

Note: a broad `scripts/dune-local.sh build @runtest` attempt was intentionally not used as validation because unrelated network-binding tests hit sandbox `EPERM`; the scoped `lib` runtest covers these changes and passed.
