### PR TITLE
fix(scripts): transport drift gate broken after .ocamlformat janestreet profile

### DIFF
--- a/scripts/check-transport-truth.sh
+++ b/scripts/check-transport-truth.sh
@@ -51,9 +51,10 @@ TRANSPORTS=(
 )
 
 # Extract field names from `type config = { ... }` block. BSD/GNU awk compat.
+# Robust against ocamlformat splitting `type config =` and `{` across lines.
 extract_config_fields() {
-  awk '/^type config = \{/,/^\}/' "$1" \
-    | sed -n 's/^[[:space:]]*\([a-z_][a-zA-Z0-9_]*\)[[:space:]]*:.*/\1/p'
+  awk '/^type config[[:space:]]*=$/,/^[[:space:]]*}$/' "$1" \
+    | sed -n 's/^[[:space:];{]*[[:space:]]*\([a-z_][a-zA-Z0-9_]*\)[[:space:]]*:.*/\1/p'
 }
 
 fail=0


### PR DESCRIPTION
## Problem

PR #1251 added `.ocamlformat` with the janestreet profile and reformatted 703 files. The transport drift gate (`scripts/check-transport-truth.sh`) was not updated to match the new syntax shape, causing **main breakage**:

```
FAIL: claude_code: no config fields extracted
FAIL: gemini_cli: no config fields extracted
FAIL: kimi_cli: no config fields extracted
FAIL: codex_cli: no config fields extracted
```

### Root cause

The janestreet profile splits `type config = {` across lines:

```ocaml
type config =
  { gemini_path : string
  ; model : string option
  ; ...
  }
```

The old awk pattern `/^type config = \{/,/^\}/` no longer matches because `{` moved to the next line. The sed pattern also failed because field lines now start with `; `.

## Fix

- awk: match `type config =` (with optional trailing space) as start, `}` (with optional leading whitespace) as end.
- sed: tolerate `;`, `{`, and whitespace before field names.

## Verification

```bash
$ bash scripts/check-transport-truth.sh
OK: transport drift gate passed (4 transports, invariants 1–2)
```

## Merge priority

This is a **main breakage fix**. All CI runs that invoke the transport drift gate will fail until this is merged.