### PR TITLE
docs: define collaboration substrate boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ For the full 186-file classification, see `docs/api-stability.md`.
 
 **Evolving** -- API may change between minor versions:
 
-`Streaming`, `Structured`, `Orchestrator`, `Collaboration`, `Memory`, `Policy`, `Proof_store`, `Cdal_proof`
+`Streaming`, `Structured`, `Orchestrator`, `Memory`, `Policy`, `Proof_store`, `Cdal_proof`
 
 **Internal** -- implementation details with no compatibility promise:
 
@@ -314,6 +314,12 @@ OAS is a single-process, single-Eio-domain agent runtime. The following concerns
 | Long-term persistence / vector storage | Embedding application | Session state, memory backends, and embedding indexes are injected via callbacks, not owned by the SDK. |
 
 If you find yourself pulling one of these responsibilities into `agent_sdk`, that is a signal the change belongs in a different repository. OAS does not name any specific downstream coordinator on purpose: anyone wiring OAS into a coordination layer should be free to make their own architectural choices.
+
+For real-time collaboration embeddings, OAS provides only the generic
+observation boundary in
+[`docs/collaboration-substrate-contract.md`](docs/collaboration-substrate-contract.md).
+CRDT/editor/VCS graph/TODO claim/turn queue state remains downstream-owned;
+OAS events are join points for correlation and telemetry.
 
 ## Versioning
 

--- a/docs/EVENT-CATALOG.md
+++ b/docs/EVENT-CATALOG.md
@@ -7,13 +7,13 @@ relate, and the contracts downstream consumers can rely on.
 **Scope**: `agent_sdk` library (`lib/`).
 **Status**: Stable catalog; entries marked *Evolving* may change with
 deprecation notice.
-**Last updated**: v0.154.1.
+**Last updated**: v0.184.0.
 
 ---
 
-## 1. Five event surfaces at a glance
+## 1. Six event surfaces at a glance
 
-OAS carries five independent event surfaces. They are listed here in order
+OAS carries six independent event surfaces. They are listed here in order
 of external relevance.
 
 | # | Surface | Module | Transport | Audience |
@@ -66,6 +66,7 @@ Pattern-matchable OCaml sum type. **Stable across every provider.**
 | `AgentCompleted` | `orchestrator.ml:run_task` (success) | Result type captures success/error |
 | `AgentFailed` | `orchestrator.ml:run_task` (error branch) | Explicit failure companion to `AgentCompleted` |
 | `TurnStarted` | `pipeline/pipeline.ml`, `pipeline/pipeline_input.ml` | Start of a single agent turn |
+| `TurnReady` | `pipeline/pipeline_input.ml` | Tool surface visible to the LLM after guardrails, policy, overrides, and selection |
 | `TurnCompleted` | `pipeline/pipeline.ml`, `pipeline/pipeline_collect.ml` | End of a single agent turn |
 | `ToolCalled` | `agent/agent_tools.ml` | Tool invocation requested by LLM |
 | `ToolCompleted` | `agent/agent_tools.ml` | Tool invocation result available |
@@ -77,6 +78,7 @@ Pattern-matchable OCaml sum type. **Stable across every provider.**
 | `ContextCompacted` | `pipeline/pipeline.ml`, `pipeline/pipeline_compaction.ml` | Compaction completed (before_tokens → after_tokens) |
 | `ContentReplacementReplaced` / `ContentReplacementKept` | `content_replacement_event_bridge.ml` | Tool-result content replacement decision froze |
 | `SlotSchedulerObserved` | `slot_scheduler_event_bridge.ml` | Queue/slot snapshot of the provider scheduler |
+| `InferenceTelemetry` | `pipeline/pipeline_collect.ml` | Per-turn provider timing/token telemetry when reported by the backend |
 | `Custom (name, json)` | anywhere | Extension point — see §2.3 |
 
 **Invariants**:
@@ -102,6 +104,13 @@ identifier.** The following prefixes are reserved:
 purpose telemetry channel for their own domain events.** Create your own
 `Event_bus.t` instance for your events and bridge into OAS's where
 necessary via a forwarder.
+
+For collaboration substrates such as CRDT documents, editor projections,
+VCS graph surfaces, TODO claims, or shared turn queues, keep the events in
+the downstream bus and use the neutral observation payload in
+`docs/collaboration-substrate-contract.md`. Those events can correlate with
+OAS via `correlation_id`, `run_id`, `caused_by`, raw-trace refs, and OTel
+trace/span IDs without becoming OAS-native taxonomy.
 
 ### 2.4 Filters, subscriptions, and draining
 
@@ -350,7 +359,7 @@ string identifier:
 | `AgentStarted` | `agent.started` |
 | `AgentCompleted` | `agent.completed` |
 | `AgentFailed` | `agent.failed` |
-| `TurnStarted` / `TurnCompleted` | `turn.started` / `turn.completed` |
+| `TurnStarted` / `TurnReady` / `TurnCompleted` | `turn.started` / `turn.ready` / `turn.completed` |
 | `ToolCalled` / `ToolCompleted` | `tool.called` / `tool.completed` |
 | `HandoffRequested` / `HandoffCompleted` | `handoff.requested` / `handoff.completed` |
 | `ElicitationCompleted` | `elicitation.completed` |
@@ -358,6 +367,7 @@ string identifier:
 | `ContextCompactStarted` / `ContextCompacted` | `context.compact_started` / `context.compacted` |
 | `ContentReplacementReplaced` / `ContentReplacementKept` | `content_replacement.replaced` / `content_replacement.kept` |
 | `SlotSchedulerObserved` | `slot_scheduler.observed` |
+| `InferenceTelemetry` | `inference.telemetry` |
 | `Custom(name, _)` | `name` (unchanged — the name is already a namespaced identifier) |
 
 ### 9.2 Targets
@@ -377,6 +387,8 @@ string identifier:
    - A replay-relevant record? → `Durable_event` variant.
    - Provider-specific? → `Custom("provider.<name>.<event>", json)`.
    - Downstream domain event? → downstream's own Event_bus, not OAS's.
+     For collaboration substrates, use
+     `docs/collaboration-substrate-contract.md`.
 
 2. **Provider-agnostic check** (native variants only, per I6):
    - Confirm the semantic exists in Anthropic + OpenAI + Gemini.

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -83,10 +83,12 @@ Representative modules:
 
 | Module | File | Reason |
 |--------|------|--------|
-| Collaboration | `lib/collaboration.mli` | Shared collaboration state is still evolving |
 | Memory | `lib/memory.mli` | Memory system is under active development |
 | Policy | `lib/policy.mli` | Rule engine surface is still settling |
 | Proof_store | `lib/proof_store.mli` | CDAL storage API is newly added |
+
+Collaboration substrate guidance is intentionally docs/schema-only; there is
+no public `Collaboration` module in `agent_sdk`.
 
 ### Internal modules
 

--- a/docs/collaboration-substrate-contract.md
+++ b/docs/collaboration-substrate-contract.md
@@ -1,0 +1,132 @@
+# Collaboration Substrate Observation Contract
+
+## Purpose
+
+This document defines the OAS-side contract for downstream applications that
+add a real-time collaboration substrate around OAS agents.
+
+OAS does not own the collaboration substrate. Editors, CRDT documents,
+WebSocket relays, Git graph renderers, shared TODO claims, turn queues,
+operator dashboards, and repo/worktree coordination remain external
+coordinator responsibilities. OAS only guarantees the generic runtime and
+event semantics needed to correlate those downstream observations with agent
+turns, tools, runtime sessions, raw traces, and OpenTelemetry spans.
+
+## Phase 1 Downstream Shape
+
+The expected Phase 1 embedding can use:
+
+| Concern | Downstream implementation | OAS boundary |
+|---------|---------------------------|--------------|
+| Text collaboration | Yjs document updates, usually over y-websocket | Treat CRDT updates as external observations; correlate by `correlation_id`, `run_id`, and optional `caused_by`. |
+| Editor projection | CodeMirror 6 state, selections, decorations | Emit editor observations outside OAS; do not add editor concepts to OAS native events. |
+| Git graph projection | cytoscape.js graph snapshots or deltas | Emit graph observations outside OAS; keep VCS terms in downstream payloads. |
+| TODO claim | Optimistic write, verify-after-sync protocol | Keep claim ownership and winner rules downstream; OAS can expose `turn.ready` and tool events for correlation. |
+| Turn queue | Shared queue or scheduler projected from collaboration state | Keep queue ordering downstream; OAS exposes agent turn lifecycle and slot scheduler observations only. |
+| Telemetry | OpenTelemetry spans/metrics exported by the embedding app | Use OAS trace/span IDs where available and include OAS event IDs as span links or attributes. |
+
+## Event Flow
+
+Downstream collaboration observations should not be published onto OAS's
+default `Event_bus.t` as domain events. Use a downstream bus or forwarder,
+then bridge only the correlation fields needed to join with OAS events.
+
+Recommended flow:
+
+1. OAS emits agent/runtime events through `Event_bus`, `Runtime`, raw trace, or
+   OTel spans.
+2. The downstream collaboration layer observes CRDT/editor/graph/claim/queue
+   state changes.
+3. The downstream layer emits a collaboration observation payload matching
+   `docs/schemas/collaboration-event-v1.schema.json`.
+4. The downstream layer joins both streams by `correlation_id`, `run_id`,
+   `caused_by`, `trace_id`, `span_id`, and optional downstream IDs.
+
+## Event Names
+
+Use dot-separated, lowercase event names. These names are recommendations for
+external collaboration streams, not new OAS native `Event_bus` variants.
+
+| Event type | Meaning |
+|------------|---------|
+| `collaboration.document.synced` | A CRDT document reached a synced state with a peer or relay. |
+| `collaboration.document.update_applied` | A CRDT update was applied locally or received remotely. |
+| `collaboration.presence.updated` | Ephemeral actor presence changed. |
+| `collaboration.selection.updated` | Editor cursor or selection projection changed. |
+| `collaboration.graph.snapshot` | A VCS graph snapshot became visible to consumers. |
+| `collaboration.graph.delta` | A VCS graph delta was applied. |
+| `collaboration.todo.claim_observed` | A TODO claim write or verify result was observed. |
+| `collaboration.turn_queue.observed` | A shared turn queue state was observed. |
+
+Downstreams may add more specific names under the same prefix, but should keep
+the payload schema compatible when they want generic OAS correlation tooling to
+consume the stream.
+
+## Payload Contract
+
+The JSON schema in `docs/schemas/collaboration-event-v1.schema.json` is the
+wire contract. It is intentionally permissive where downstream implementations
+vary, but strict about stable join keys and observation metadata.
+
+Required fields:
+
+| Field | Purpose |
+|-------|---------|
+| `schema_version` | Currently `1`. |
+| `event_type` | Dot-separated event name, for example `collaboration.document.update_applied`. |
+| `observed_at` | Unix epoch seconds when the embedding app observed the state. |
+| `correlation_id` | OAS session-level correlation ID or downstream equivalent. |
+| `run_id` | OAS run ID or downstream actor/run ID. |
+| `substrate.kind` | External substrate family, for example `crdt`, `editor`, `vcs_graph`, `todo_claim`, or `turn_queue`. |
+
+Optional fields carry implementation details:
+
+| Field | Purpose |
+|-------|---------|
+| `event_id` | Stable event identifier for downstream dedupe and span links. |
+| `caused_by` | OAS `run_id`, OAS `correlation_id`, or downstream event ID that triggered this observation. |
+| `trace_id` / `span_id` | OpenTelemetry IDs if the embedding app has an active span. |
+| `actor` | External actor identity and role in the collaboration substrate. |
+| `document` | CRDT/editor document identifiers, provider, update metadata, and revision. |
+| `transport` | WebSocket or other transport metadata. |
+| `vcs` | Repository/ref/commit identifiers for graph projections. |
+| `todo_claim` | TODO claim observation state, not OAS-owned task semantics. |
+| `turn_queue` | Queue snapshot metadata, not OAS-owned scheduling semantics. |
+| `attributes` | Extra scalar attributes for downstream-specific dimensions. |
+
+## OpenTelemetry Mapping
+
+When exporting collaboration observations to OpenTelemetry:
+
+| Payload field | OTel mapping |
+|---------------|-------------|
+| `event_type` | Span event name, or span name for short-lived observation spans. |
+| `event_id` | `event.id` attribute; use as a span link target when supported. |
+| `correlation_id` | `oas.correlation_id` attribute. |
+| `run_id` | `oas.run_id` attribute. |
+| `caused_by` | `oas.caused_by` attribute or span link. |
+| `substrate.kind` | `collaboration.substrate.kind` attribute. |
+| `substrate.provider` | `collaboration.substrate.provider` attribute. |
+| `document.id` | `collaboration.document.id` attribute. |
+| `document.update_bytes` | `collaboration.document.update_bytes` metric attribute/value. |
+| `transport.kind` | `network.transport` or `collaboration.transport.kind` attribute. |
+| `vcs.commit_id` | `vcs.commit.id` attribute. |
+| `todo_claim.state` | `collaboration.todo_claim.state` attribute. |
+| `turn_queue.depth` | `collaboration.turn_queue.depth` metric attribute/value. |
+
+OAS-owned metric names keep the `oas.*` prefix. Collaboration-specific metrics
+should use `collaboration.*` unless the OpenTelemetry spec already defines a
+better semantic-convention attribute.
+
+## Boundary Rules
+
+- Do not add Yjs, y-websocket, CodeMirror, cytoscape, or browser dependencies
+  to `agent_sdk`.
+- Do not add TODO claim or turn queue state machines to OAS.
+- Do not add downstream UI or repo graph payloads as native `Event_bus`
+  variants.
+- Prefer `Event_bus.TurnReady`, `ToolCalled`, `ToolCompleted`,
+  `TurnCompleted`, runtime events, raw-trace refs, and OTel span IDs as join
+  points.
+- Add a native OAS event only when the semantic is provider-agnostic and
+  belongs to the single-agent runtime itself.

--- a/docs/schemas/collaboration-event-v1.schema.json
+++ b/docs/schemas/collaboration-event-v1.schema.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "oas:collaboration-event:v1",
+  "title": "Collaboration Substrate Observation Event v1",
+  "description": "Generic downstream collaboration observation payload correlated with OAS runtime events.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "event_type",
+    "observed_at",
+    "correlation_id",
+    "run_id",
+    "substrate"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "event_id": { "type": "string", "minLength": 1 },
+    "event_type": {
+      "type": "string",
+      "pattern": "^collaboration\\.[a-z0-9_]+(\\.[a-z0-9_]+)+$"
+    },
+    "observed_at": { "type": "number" },
+    "correlation_id": { "type": "string", "minLength": 1 },
+    "run_id": { "type": "string", "minLength": 1 },
+    "caused_by": { "type": ["string", "null"] },
+    "trace_id": {
+      "type": ["string", "null"],
+      "pattern": "^[a-f0-9]{32}$"
+    },
+    "span_id": {
+      "type": ["string", "null"],
+      "pattern": "^[a-f0-9]{16}$"
+    },
+    "substrate": {
+      "type": "object",
+      "required": ["kind"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "crdt",
+            "editor",
+            "presence",
+            "vcs_graph",
+            "todo_claim",
+            "turn_queue",
+            "transport",
+            "other"
+          ]
+        },
+        "provider": { "type": ["string", "null"] },
+        "workspace_id": { "type": ["string", "null"] }
+      }
+    },
+    "actor": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "role": { "type": ["string", "null"] },
+        "display_name": { "type": ["string", "null"] }
+      }
+    },
+    "document": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "path": { "type": ["string", "null"] },
+        "provider": { "type": ["string", "null"] },
+        "revision": { "type": ["string", "integer", "null"] },
+        "update_id": { "type": ["string", "null"] },
+        "update_bytes": { "type": ["integer", "null"], "minimum": 0 },
+        "origin": {
+          "type": ["string", "null"],
+          "enum": ["local", "remote", "replay", null]
+        }
+      }
+    },
+    "transport": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "type": "string" },
+        "peer_id": { "type": ["string", "null"] },
+        "message_bytes": { "type": ["integer", "null"], "minimum": 0 },
+        "latency_ms": { "type": ["number", "null"], "minimum": 0 }
+      }
+    },
+    "vcs": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "repository_id": { "type": ["string", "null"] },
+        "ref_name": { "type": ["string", "null"] },
+        "commit_id": { "type": ["string", "null"] },
+        "node_count": { "type": ["integer", "null"], "minimum": 0 },
+        "edge_count": { "type": ["integer", "null"], "minimum": 0 }
+      }
+    },
+    "todo_claim": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "todo_id": { "type": "string" },
+        "state": {
+          "type": "string",
+          "enum": ["observed", "claim_written", "claim_verified", "claim_lost", "released"]
+        },
+        "claimed_by": { "type": ["string", "null"] },
+        "winner_actor_id": { "type": ["string", "null"] }
+      }
+    },
+    "turn_queue": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "queue_id": { "type": "string" },
+        "depth": { "type": ["integer", "null"], "minimum": 0 },
+        "position": { "type": ["integer", "null"], "minimum": 0 },
+        "head_actor_id": { "type": ["string", "null"] },
+        "state": {
+          "type": ["string", "null"],
+          "enum": ["observed", "queued", "ready", "active", "blocked", "completed", null]
+        }
+      }
+    },
+    "attributes": {
+      "type": ["object", "null"],
+      "additionalProperties": {
+        "type": ["string", "number", "boolean", "null"]
+      }
+    }
+  }
+}


### PR DESCRIPTION

## Summary
- add a generic OAS collaboration substrate observation contract for downstream real-time collaboration embeddings
- add a JSON schema for downstream collaboration observation events
- update the event catalog/API stability docs so CRDT/editor/VCS graph/TODO claim/turn queue state stays downstream-owned

## Verification
- jq empty docs/schemas/collaboration-event-v1.schema.json
- git diff --check
- scripts/check-sdk-independence.sh (fails on pre-existing lib strings: masc_status, keeper_bash, keeper-scale)

## Notes
- Docs/schema-only slice; no Dune build was run.
- OAS remains generic and does not learn MASC-specific dashboard, keeper, branch graph, or CRDT doc semantics.
