### PR TITLE
feat(llm_provider): surface typed provider failures

### DIFF
--- a/lib/judge/judge.ml
+++ b/lib/judge/judge.ml
@@ -199,6 +199,8 @@ let judge ~sw ~net ~provider ~config ~context () =
       | Http_client.CliTransportRequired { kind } ->
         Printf.sprintf "CLI transport required for %s" kind
       | Http_client.ProviderTerminal { message; _ } -> message
+      | Http_client.ProviderFailure { kind; message } ->
+        Http_client.provider_failure_to_string ~kind ~message
     in
     Error (Printf.sprintf "Judge LLM call failed: %s" msg)
   | Ok response ->

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -756,6 +756,8 @@ let complete
             | Http_client.CliTransportRequired { kind } ->
               Printf.sprintf "CLI transport required for %s but none injected" kind
             | Http_client.ProviderTerminal { message; _ } -> message
+            | Http_client.ProviderFailure { kind; message } ->
+              Http_client.provider_failure_to_string ~kind ~message
           in
           m.on_error ~model_id ~error:err_str;
           Error err))
@@ -799,6 +801,10 @@ let classify_retry_error = function
      deterministic exit, so signal non-retryable and let the agent
      runtime checkpoint via [Error.Agent (MaxTurnsExceeded ...)]. *)
   | Http_client.ProviderTerminal _ -> None
+  (* Provider/runtime failures are semantic cascade inputs, not local
+     retry inputs.  Retrying the same CLI/API lane would hide the typed
+     reason from downstream policy. *)
+  | Http_client.ProviderFailure _ -> None
 ;;
 
 let is_retryable = function
@@ -1217,6 +1223,20 @@ let%test "is_retryable network error always retryable" =
   is_retryable
     (Http_client.NetworkError { message = "connection refused"; kind = Unknown })
   = true
+;;
+
+let%test "is_retryable provider capacity failure is false" =
+  not
+    (is_retryable
+       (Http_client.ProviderFailure
+          { kind =
+              Http_client.Capacity_exhausted
+                { scope = Http_client.Failure_scope_model
+                ; retry_after = None
+                ; model = Some "gemini-2.5-pro"
+                }
+          ; message = "capacity exhausted"
+          }))
 ;;
 
 let%test "default_retry_config values" =

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -111,6 +111,8 @@ let get_json ~sw ~net url =
        cannot reach this match.  Surface the message defensively so the
        exhaustive match stays sound. *)
     Error message
+  | Error (Http_client.ProviderFailure { kind; message }) ->
+    Error (Http_client.provider_failure_to_string ~kind ~message)
 ;;
 
 let get_ok ~sw ~net url =
@@ -293,6 +295,8 @@ let probe_ollama_context ~sw ~net base_url =
             | Http_client.CliTransportRequired { kind } ->
               Printf.sprintf "CLI transport required for %s" kind
             | Http_client.ProviderTerminal { message; _ } -> message
+            | Http_client.ProviderFailure { kind; message } ->
+              Http_client.provider_failure_to_string ~kind ~message
           in
           warn_probe_failure ~url:base_url ~phase:"ollama_show_http" detail;
           None))

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -32,6 +32,29 @@ type provider_terminal_kind =
       }
   | Other of string
 
+type provider_failure_scope =
+  | Failure_scope_model
+  | Failure_scope_account
+  | Failure_scope_region
+  | Failure_scope_provider
+  | Failure_scope_unknown
+
+type provider_failure_kind =
+  | Capacity_exhausted of
+      { scope : provider_failure_scope
+      ; retry_after : float option
+      ; model : string option
+      }
+  | Hard_quota of { retry_after : float option }
+  | Capability_mismatch of { capability : string option }
+  | Cli_policy_invalid of
+      { tool_name : string option
+      ; rule : int option
+      }
+  | Cli_startup_failed of { reason : string }
+  | Provider_parse_error of { parser : string option }
+  | Unknown_provider_failure of { reason : string option }
+
 type http_error =
   | HttpError of
       { code : int
@@ -54,10 +77,50 @@ type http_error =
       { kind : provider_terminal_kind
       ; message : string
       }
+  | ProviderFailure of
+      { kind : provider_failure_kind
+      ; message : string
+      }
 
 (* ── Internal helpers ──────────────────────────────────────── *)
 
 let ( let* ) = Result.bind
+
+let provider_failure_scope_to_string = function
+  | Failure_scope_model -> "model"
+  | Failure_scope_account -> "account"
+  | Failure_scope_region -> "region"
+  | Failure_scope_provider -> "provider"
+  | Failure_scope_unknown -> "unknown"
+;;
+
+let provider_failure_kind_to_string = function
+  | Capacity_exhausted { scope; _ } ->
+    Printf.sprintf "capacity_exhausted:%s" (provider_failure_scope_to_string scope)
+  | Hard_quota _ -> "hard_quota"
+  | Capability_mismatch { capability = Some capability } ->
+    Printf.sprintf "capability_mismatch:%s" capability
+  | Capability_mismatch { capability = None } -> "capability_mismatch"
+  | Cli_policy_invalid { tool_name = Some tool_name; rule = Some rule } ->
+    Printf.sprintf "cli_policy_invalid:rule_%d:%s" rule tool_name
+  | Cli_policy_invalid { tool_name = Some tool_name; rule = None } ->
+    Printf.sprintf "cli_policy_invalid:%s" tool_name
+  | Cli_policy_invalid { tool_name = None; rule = Some rule } ->
+    Printf.sprintf "cli_policy_invalid:rule_%d" rule
+  | Cli_policy_invalid { tool_name = None; rule = None } -> "cli_policy_invalid"
+  | Cli_startup_failed _ -> "cli_startup_failed"
+  | Provider_parse_error { parser = Some parser } ->
+    Printf.sprintf "provider_parse_error:%s" parser
+  | Provider_parse_error { parser = None } -> "provider_parse_error"
+  | Unknown_provider_failure { reason = Some reason } ->
+    Printf.sprintf "unknown_provider_failure:%s" reason
+  | Unknown_provider_failure { reason = None } -> "unknown_provider_failure"
+;;
+
+let provider_failure_to_string ~kind ~message =
+  let name = provider_failure_kind_to_string kind in
+  if String.trim message = "" then name else Printf.sprintf "%s: %s" name message
+;;
 
 (** Default wall-clock timeout applied to synchronous HTTP operations
     when a clock is supplied ([get_sync], [post_sync]).  Streaming
@@ -174,6 +237,7 @@ let is_local_resource_exhaustion = function
   | CliTransportRequired _ -> false
   | NetworkError _ -> false
   | ProviderTerminal _ -> false
+  | ProviderFailure _ -> false
 ;;
 
 (* ── Public API ────────────────────────────────────────────── *)

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -49,6 +49,38 @@ type provider_terminal_kind =
           Carries the raw subtype string so consumers can log it
           without flag day for new variants. *)
 
+(** Scope attached to provider failure classifications.
+
+    This is deliberately about the failed lane, not about retry policy.
+    Retry/cascade policy lives above this transport layer. *)
+type provider_failure_scope =
+  | Failure_scope_model
+  | Failure_scope_account
+  | Failure_scope_region
+  | Failure_scope_provider
+  | Failure_scope_unknown
+
+(** Provider/runtime failure surfaced by a transport after it has parsed
+    provider-specific HTTP/CLI details at the edge.
+
+    Downstream code should pattern-match on this type instead of parsing
+    stderr, HTTP bodies, or vendor-specific status strings. *)
+type provider_failure_kind =
+  | Capacity_exhausted of
+      { scope : provider_failure_scope
+      ; retry_after : float option
+      ; model : string option
+      }
+  | Hard_quota of { retry_after : float option }
+  | Capability_mismatch of { capability : string option }
+  | Cli_policy_invalid of
+      { tool_name : string option
+      ; rule : int option
+      }
+  | Cli_startup_failed of { reason : string }
+  | Provider_parse_error of { parser : string option }
+  | Unknown_provider_failure of { reason : string option }
+
 (** Transport-level error. *)
 type http_error =
   | HttpError of
@@ -76,6 +108,17 @@ type http_error =
           rather than treat it as a transient network failure.
 
           @since 0.178.0 *)
+  | ProviderFailure of
+      { kind : provider_failure_kind
+      ; message : string
+      }
+  (** Provider/runtime failure classified at the transport edge.
+      Examples: model capacity exhaustion from a CLI stderr stream,
+      invalid CLI policy, or a request that requires a capability the
+      transport cannot provide. *)
+
+val provider_failure_kind_to_string : provider_failure_kind -> string
+val provider_failure_to_string : kind:provider_failure_kind -> message:string -> string
 
 (** Default wall-clock timeout (seconds) applied to synchronous HTTP
     operations when a clock is supplied.  Streaming variants use this

--- a/lib/llm_provider/slot_cache.ml
+++ b/lib/llm_provider/slot_cache.ml
@@ -31,6 +31,12 @@ let slot_action ~sw ~net ~endpoint ~slot_id ~action ~body_fields =
     Error (Printf.sprintf "slot %s: CLI transport required for %s" action kind)
   | Error (Http_client.ProviderTerminal { message; _ }) ->
     Error (Printf.sprintf "slot %s: %s" action message)
+  | Error (Http_client.ProviderFailure { kind; message }) ->
+    Error
+      (Printf.sprintf
+         "slot %s: %s"
+         action
+         (Http_client.provider_failure_to_string ~kind ~message))
 ;;
 
 let save ~sw ~net ~endpoint ~slot_id ~filename =

--- a/lib/llm_provider/transport_gemini_cli.ml
+++ b/lib/llm_provider/transport_gemini_cli.ml
@@ -90,6 +90,12 @@ let effective_prompt ~prompt ~system_prompt =
   | Some sp -> Printf.sprintf "[System]\n%s\n\n[User]\n%s" sp prompt
 ;;
 
+let selected_model ~(config : config) ~(req_config : Provider_config.t) =
+  match String.trim req_config.model_id |> String.lowercase_ascii with
+  | "" | "auto" -> config.model
+  | _ -> Some req_config.model_id
+;;
+
 let build_args ~(config : config) ~(req_config : Provider_config.t) ~prompt ~system_prompt
   =
   let prompt = effective_prompt ~prompt ~system_prompt in
@@ -101,11 +107,7 @@ let build_args ~(config : config) ~(req_config : Provider_config.t) ~prompt ~sys
    | Some m -> add [ "--approval-mode"; m ]
    | None -> if config.yolo then add [ "--yolo" ]);
   (* "auto" means "use the CLI's configured default", so omit [--model]. *)
-  let model =
-    match String.trim req_config.model_id |> String.lowercase_ascii with
-    | "" | "auto" -> config.model
-    | _ -> Some req_config.model_id
-  in
+  let model = selected_model ~config ~req_config in
   (match model with
    | Some m -> add [ "--model"; m ]
    | None -> ());
@@ -239,8 +241,74 @@ let substring_found line needle =
     scan 0)
 ;;
 
+let find_substring line needle =
+  let hl = String.length line
+  and nl = String.length needle in
+  if nl = 0 || nl > hl
+  then None
+  else (
+    let rec scan i =
+      if i + nl > hl
+      then None
+      else if String.sub line i nl = needle
+      then Some i
+      else scan (i + 1)
+    in
+    scan 0)
+;;
+
+let quoted_after line prefix =
+  match find_substring line prefix with
+  | None -> None
+  | Some prefix_idx ->
+    let start = prefix_idx + String.length prefix in
+    let rec find_close i =
+      if i >= String.length line
+      then None
+      else if line.[i] = '"'
+      then Some i
+      else find_close (i + 1)
+    in
+    find_close start |> Option.map (fun stop -> String.sub line start (stop - start))
+;;
+
+let rule_after line =
+  match find_substring line "Rule #" with
+  | None -> None
+  | Some idx ->
+    let start = idx + String.length "Rule #" in
+    let rec scan_digits i =
+      if i >= String.length line
+      then i
+      else (
+        match line.[i] with
+        | '0' .. '9' -> scan_digits (i + 1)
+        | _ -> i)
+    in
+    let stop = scan_digits start in
+    if stop = start
+    then None
+    else String.sub line start (stop - start) |> int_of_string_opt
+;;
+
 let contains_all_markers haystack markers =
   List.for_all (substring_found haystack) markers
+;;
+
+let provider_failure_of_stderr_line ?model line =
+  if substring_found line "Unrecognized tool name"
+  then
+    Some
+      (Http_client.Cli_policy_invalid
+         { tool_name = quoted_after line "Unrecognized tool name \""
+         ; rule = rule_after line
+         })
+  else if List.exists (substring_found line) capacity_exhausted_markers
+  then
+    Some
+      (Http_client.Capacity_exhausted
+         { scope = Http_client.Failure_scope_model; retry_after = None; model })
+  else None
 ;;
 
 let classify_cli_error = function
@@ -256,27 +324,32 @@ let classify_cli_error = function
   | other -> other
 ;;
 
-let run ~sw ~mgr ~(config : config) argv =
+let run ~sw ~mgr ~(config : config) ?model argv =
   let fail_fast_enabled =
     not (Cli_common_env.bool "OAS_GEMINI_CLI_NO_FAIL_FAST_ON_CAPACITY")
   in
-  let capacity_p, capacity_r = Eio.Promise.create () in
-  let capacity_exhausted = ref false in
+  let failure_p, failure_r = Eio.Promise.create () in
+  let provider_failure = ref None in
+  let set_provider_failure kind =
+    match !provider_failure with
+    | Some _ -> ()
+    | None ->
+      provider_failure := Some kind;
+      if not (Eio.Promise.is_resolved failure_p) then Eio.Promise.resolve failure_r ()
+  in
   let on_stderr_line line =
     Cli_common_subprocess.default_on_stderr_line ~name:"gemini" line;
-    if
-      fail_fast_enabled
-      && (not !capacity_exhausted)
-      && List.exists (substring_found line) capacity_exhausted_markers
-    then (
-      capacity_exhausted := true;
-      if not (Eio.Promise.is_resolved capacity_p) then Eio.Promise.resolve capacity_r ())
+    match provider_failure_of_stderr_line ?model line with
+    | Some (Http_client.Capacity_exhausted _ as kind) ->
+      if fail_fast_enabled then set_provider_failure kind
+    | Some kind -> set_provider_failure kind
+    | None -> ()
   in
-  (* Merge the upstream cancel (if any) with the capacity-exhausted
-     signal so either one triggers a SIGINT on the CLI. *)
+  (* Merge the upstream cancel (if any) with the provider-failure signal
+     so either one triggers a SIGINT on the CLI. *)
   let merged_cancel =
     match config.cancel with
-    | None -> Some capacity_p
+    | None -> Some failure_p
     | Some upstream ->
       let merged_p, merged_r = Eio.Promise.create () in
       let resolve_once () =
@@ -286,7 +359,7 @@ let run ~sw ~mgr ~(config : config) argv =
         Eio.Promise.await upstream;
         resolve_once ());
       Eio.Fiber.fork ~sw (fun () ->
-        Eio.Promise.await capacity_p;
+        Eio.Promise.await failure_p;
         resolve_once ());
       Some merged_p
   in
@@ -302,17 +375,16 @@ let run ~sw ~mgr ~(config : config) argv =
       ?cancel:merged_cancel
       argv
   in
-  match result with
-  | Error _ when !capacity_exhausted ->
+  match result, !provider_failure with
+  | _, Some kind ->
     Error
-      (Http_client.NetworkError
-         { message =
-             "gemini_cli: MODEL_CAPACITY_EXHAUSTED detected on stderr, aborted CLI early \
-              so the cascade can move on. Set OAS_GEMINI_CLI_NO_FAIL_FAST_ON_CAPACITY=1 \
-              to let the CLI keep its internal retry loop."
-         ; kind = Unknown
+      (Http_client.ProviderFailure
+         { kind
+         ; message =
+             "gemini_cli stderr reported a provider/runtime failure; aborted early so \
+              the cascade can move on."
          })
-  | r -> classify_cli_error r
+  | r, None -> classify_cli_error r
 ;;
 
 (* Fires once per transport instance when any Claude-only config field
@@ -339,11 +411,13 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
         | Some _ ->
           { Llm_transport.response =
               Error
-                (Http_client.NetworkError
-                   { message =
+                (Http_client.ProviderFailure
+                   { kind =
+                       Http_client.Capability_mismatch
+                         { capability = Some "request_scoped_runtime_mcp" }
+                   ; message =
                        "gemini_cli does not support request-scoped runtime MCP \
                         configuration"
-                   ; kind = Unknown
                    })
           ; latency_ms = 0
           }
@@ -355,7 +429,8 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
             Cli_common_prompt.system_prompt_of ~req_config:req.config req.messages
           in
           let argv = build_args ~config ~req_config:req.config ~prompt ~system_prompt in
-          (match run ~sw ~mgr ~config argv with
+          let model = selected_model ~config ~req_config:req.config in
+          (match run ~sw ~mgr ~config ?model argv with
            | Error _ as e -> { Llm_transport.response = e; latency_ms = 0 }
            | Ok { stdout; stderr = _; latency_ms } ->
              let response = parse_json_result (String.trim stdout) in
@@ -365,10 +440,12 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
         match req.runtime_mcp_policy with
         | Some _ ->
           Error
-            (Http_client.NetworkError
-               { message =
+            (Http_client.ProviderFailure
+               { kind =
+                   Http_client.Capability_mismatch
+                     { capability = Some "request_scoped_runtime_mcp" }
+               ; message =
                    "gemini_cli does not support request-scoped runtime MCP configuration"
-               ; kind = Unknown
                })
         | None ->
           warn_unsupported_once config warned;
@@ -378,9 +455,10 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
             Cli_common_prompt.system_prompt_of ~req_config:req.config req.messages
           in
           let argv = build_args ~config ~req_config:req.config ~prompt ~system_prompt in
+          let model = selected_model ~config ~req_config:req.config in
           (* Gemini CLI does not support native streaming; replay synthetic events
          after the sync call completes. *)
-          (match run ~sw ~mgr ~config argv with
+          (match run ~sw ~mgr ~config ?model argv with
            | Error _ as e -> e
            | Ok { stdout; stderr = _; latency_ms = _ } ->
              let result = parse_json_result (String.trim stdout) in
@@ -583,6 +661,29 @@ let%test "classify_cli_error keeps unrelated network failures retryable" =
   | _ -> false
 ;;
 
+let%test "provider_failure_of_stderr_line detects model capacity" =
+  match
+    provider_failure_of_stderr_line
+      ~model:"gemini-2.5-pro"
+      {|Attempt 1 failed with status 429. "reason": "MODEL_CAPACITY_EXHAUSTED"|}
+  with
+  | Some
+      (Http_client.Capacity_exhausted
+         { scope = Http_client.Failure_scope_model; model = Some "gemini-2.5-pro"; _ }) ->
+    true
+  | _ -> false
+;;
+
+let%test "provider_failure_of_stderr_line extracts invalid policy tool" =
+  match
+    provider_failure_of_stderr_line
+      {|Rule #248: Unrecognized tool name "glm". Did you mean one of: "glob"?|}
+  with
+  | Some (Http_client.Cli_policy_invalid { tool_name = Some "glm"; rule = Some 248 }) ->
+    true
+  | _ -> false
+;;
+
 (* ── env-driven extra args ──────────────────────────── *)
 
 let with_env k v f =
@@ -722,8 +823,16 @@ let%test_unit "complete_sync rejects request-scoped runtime MCP policy" =
   @@ fun sw ->
   let transport = create ~sw ~mgr:(Eio.Stdenv.process_mgr env) ~config:default_config in
   match transport.complete_sync runtime_mcp_req_sample with
-  | { response = Error (Http_client.NetworkError { message; _ }); latency_ms = 0 } ->
-    assert (String.equal message runtime_mcp_policy_error_message)
+  | { response =
+        Error
+          (Http_client.ProviderFailure
+             { kind =
+                 Http_client.Capability_mismatch
+                   { capability = Some "request_scoped_runtime_mcp" }
+             ; message
+             })
+    ; latency_ms = 0
+    } -> assert (String.equal message runtime_mcp_policy_error_message)
   | _ -> assert false
 ;;
 
@@ -734,7 +843,12 @@ let%test_unit "complete_stream rejects request-scoped runtime MCP policy" =
   @@ fun sw ->
   let transport = create ~sw ~mgr:(Eio.Stdenv.process_mgr env) ~config:default_config in
   match transport.complete_stream ~on_event:(fun _ -> ()) runtime_mcp_req_sample with
-  | Error (Http_client.NetworkError { message; _ }) ->
-    assert (String.equal message runtime_mcp_policy_error_message)
+  | Error
+      (Http_client.ProviderFailure
+         { kind =
+             Http_client.Capability_mismatch
+               { capability = Some "request_scoped_runtime_mcp" }
+         ; message
+         }) -> assert (String.equal message runtime_mcp_policy_error_message)
   | _ -> assert false
 ;;

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -24,6 +24,19 @@ let sdk_error_of_http_error : Llm_provider.Http_client.http_error -> Error.sdk_e
     Error.Agent (MaxTurnsExceeded { turns = r.turns; limit = r.limit })
   | Llm_provider.Http_client.ProviderTerminal { kind = Other reason; message } ->
     Error.Api (Retry.InvalidRequest { message = Printf.sprintf "%s: %s" reason message })
+  | Llm_provider.Http_client.ProviderFailure { kind; message } ->
+    let message = Llm_provider.Http_client.provider_failure_to_string ~kind ~message in
+    (match kind with
+     | Llm_provider.Http_client.Capacity_exhausted _ ->
+       Error.Api (Retry.Overloaded { message })
+     | Llm_provider.Http_client.Hard_quota { retry_after } ->
+       Error.Api (Retry.RateLimited { retry_after; message })
+     | Llm_provider.Http_client.Capability_mismatch _
+     | Llm_provider.Http_client.Cli_policy_invalid _
+     | Llm_provider.Http_client.Cli_startup_failed _
+     | Llm_provider.Http_client.Provider_parse_error _
+     | Llm_provider.Http_client.Unknown_provider_failure _ ->
+       Error.Api (Retry.InvalidRequest { message }))
 ;;
 
 let dispatch_sync ~sw ?clock agent (prep : Agent_turn.turn_preparation) =

--- a/lib/pipeline/stage_route.ml
+++ b/lib/pipeline/stage_route.ml
@@ -36,6 +36,19 @@ let sdk_error_of_http_error : Llm_provider.Http_client.http_error -> Error.sdk_e
     Error.Agent (MaxTurnsExceeded { turns = r.turns; limit = r.limit })
   | Llm_provider.Http_client.ProviderTerminal { kind = Other reason; message } ->
     Error.Api (Retry.InvalidRequest { message = Printf.sprintf "%s: %s" reason message })
+  | Llm_provider.Http_client.ProviderFailure { kind; message } ->
+    let message = Llm_provider.Http_client.provider_failure_to_string ~kind ~message in
+    (match kind with
+     | Llm_provider.Http_client.Capacity_exhausted _ ->
+       Error.Api (Retry.Overloaded { message })
+     | Llm_provider.Http_client.Hard_quota { retry_after } ->
+       Error.Api (Retry.RateLimited { retry_after; message })
+     | Llm_provider.Http_client.Capability_mismatch _
+     | Llm_provider.Http_client.Cli_policy_invalid _
+     | Llm_provider.Http_client.Cli_startup_failed _
+     | Llm_provider.Http_client.Provider_parse_error _
+     | Llm_provider.Http_client.Unknown_provider_failure _ ->
+       Error.Api (Retry.InvalidRequest { message }))
 ;;
 
 (** Sync dispatch via {!Llm_provider.Complete.complete}.  Routes all

--- a/lib/protocol/a2a_client.ml
+++ b/lib/protocol/a2a_client.ml
@@ -39,6 +39,13 @@ let http_get ~sw ~net url =
        cannot produce a CLI subprocess terminal condition; reduce to
        message text so the exhaustive match stays sound. *)
     Error (Error.Orchestration (DiscoveryFailed { url; detail = message }))
+  | Error (Llm_provider.Http_client.ProviderFailure { kind; message }) ->
+    Error
+      (Error.Orchestration
+         (DiscoveryFailed
+            { url
+            ; detail = Llm_provider.Http_client.provider_failure_to_string ~kind ~message
+            }))
 ;;
 
 let http_post ~sw ~net ~url ~body =
@@ -64,6 +71,12 @@ let http_post ~sw ~net ~url ~body =
        defensive handling mirrors [http_get] so the exhaustive match
        stays sound and the message survives for diagnostics. *)
     Error (Error.A2a (ProtocolError { detail = message }))
+  | Error (Llm_provider.Http_client.ProviderFailure { kind; message }) ->
+    Error
+      (Error.A2a
+         (ProtocolError
+            { detail = Llm_provider.Http_client.provider_failure_to_string ~kind ~message
+            }))
 ;;
 
 (* ── JSON-RPC ─────────────────────────────────────────────────── *)

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -181,6 +181,19 @@ let map_http_error = function
     Error.Agent (MaxTurnsExceeded { turns = r.turns; limit = r.limit })
   | Llm_provider.Http_client.ProviderTerminal { kind = Other reason; message } ->
     Error.Api (Retry.InvalidRequest { message = Printf.sprintf "%s: %s" reason message })
+  | Llm_provider.Http_client.ProviderFailure { kind; message } ->
+    let message = Llm_provider.Http_client.provider_failure_to_string ~kind ~message in
+    (match kind with
+     | Llm_provider.Http_client.Capacity_exhausted _ ->
+       Error.Api (Retry.Overloaded { message })
+     | Llm_provider.Http_client.Hard_quota { retry_after } ->
+       Error.Api (Retry.RateLimited { retry_after; message })
+     | Llm_provider.Http_client.Capability_mismatch _
+     | Llm_provider.Http_client.Cli_policy_invalid _
+     | Llm_provider.Http_client.Cli_startup_failed _
+     | Llm_provider.Http_client.Provider_parse_error _
+     | Llm_provider.Http_client.Unknown_provider_failure _ ->
+       Error.Api (Retry.InvalidRequest { message }))
 ;;
 
 (** Streaming variant of create_message.

--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -83,6 +83,21 @@ let sdk_error_of_http_error = function
       Error.Api
         (Llm_provider.Retry.InvalidRequest
            { message = Printf.sprintf "%s: %s" reason message })
+  | Llm_provider.Http_client.ProviderFailure { kind; message } ->
+      let message =
+        Llm_provider.Http_client.provider_failure_to_string ~kind ~message
+      in
+      (match kind with
+       | Llm_provider.Http_client.Capacity_exhausted _ ->
+           Error.Api (Llm_provider.Retry.Overloaded { message })
+       | Llm_provider.Http_client.Hard_quota { retry_after } ->
+           Error.Api (Llm_provider.Retry.RateLimited { retry_after; message })
+       | Llm_provider.Http_client.Capability_mismatch _
+       | Llm_provider.Http_client.Cli_policy_invalid _
+       | Llm_provider.Http_client.Cli_startup_failed _
+       | Llm_provider.Http_client.Provider_parse_error _
+       | Llm_provider.Http_client.Unknown_provider_failure _ ->
+           Error.Api (Llm_provider.Retry.InvalidRequest { message }))
 
 let provider_config_for_schema ~base_url ?provider ~config ~(schema : _ schema) () =
   let state = {

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -124,6 +124,8 @@ let test_post_stream_invalid_url_returns_network_error () =
     Alcotest.fail "expected NetworkError for invalid URL, not CliTransportRequired"
   | Error (Http_client.ProviderTerminal _) ->
     Alcotest.fail "expected NetworkError for invalid URL, not ProviderTerminal"
+  | Error (Http_client.ProviderFailure _) ->
+    Alcotest.fail "expected NetworkError for invalid URL, not ProviderFailure"
   | Ok _ -> Alcotest.fail "expected invalid URL to fail before opening a stream"
 ;;
 

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -607,7 +607,12 @@ let test_complete_claude_code_without_transport_is_guarded () =
          Alcotest.failf
            "%s expected CliTransportRequired, got ProviderTerminal: %s"
            expected_name
-           message)
+           message
+       | Error (Llm_provider.Http_client.ProviderFailure { kind; message }) ->
+         Alcotest.failf
+           "%s expected CliTransportRequired, got ProviderFailure: %s"
+           expected_name
+           (Llm_provider.Http_client.provider_failure_to_string ~kind ~message))
     kinds
 ;;
 


### PR DESCRIPTION
## Summary

Adds a typed `ProviderFailure` transport error surface so downstream cascade/runtime code can consume provider/runtime failures without parsing stderr or vendor-specific strings.

## Why This Matters

Gemini CLI capacity exhaustion and policy warnings were previously collapsed into `NetworkError Unknown`, which makes persistent keepers look idle/stale and forces MASC-side cascade code to infer semantics from message text. This PR moves those classifications to the OAS transport edge.

## Changes

- Add `Http_client.ProviderFailure` with typed failure kinds for capacity, quota, capability mismatch, CLI policy invalid, startup failure, parse failure, and unknown provider failure.
- Classify Gemini CLI `MODEL_CAPACITY_EXHAUSTED` stderr as `Capacity_exhausted` with model scope.
- Classify Gemini CLI `Unrecognized tool name "glm"` policy warnings as `Cli_policy_invalid` with extracted tool/rule metadata.
- Classify request-scoped runtime MCP rejection as `Capability_mismatch`.
- Update SDK error adapters and defensive matches for the new variant.

## Review Focus

- The taxonomy shape in `Http_client`.
- Gemini CLI stderr edge parsing boundaries.
- Whether downstream compatibility mappings should stay as `Overloaded` / `InvalidRequest` until MASC consumes `ProviderFailure` directly.

## Verification

- `scripts/dune-local.sh build lib/llm_provider test/test_retry.exe test/test_provider_complete.exe test/test_http_client.exe`
- `_build/default/test/test_retry.exe` 16 tests
- `_build/default/test/test_provider_complete.exe` 31 tests
- `_build/default/test/test_http_client.exe` 15 tests
- `scripts/dune-local.sh runtest lib/llm_provider`
- `git diff --check`
- `ocamlformat --check` on touched files except `lib/structured.ml`, which has a pre-existing unattached docstring warning outside this change

## Follow-up

After this lands and MASC bumps the OAS pin, MASC `oas_compat` should consume `ProviderFailure` directly and delete message-string classification for capacity / policy / capability cases.