### PR TITLE
[codex] Add Track 7 claim observation contract

### DIFF
--- a/docs/collaboration-substrate-contract.md
+++ b/docs/collaboration-substrate-contract.md
@@ -55,7 +55,7 @@ external collaboration streams, not new OAS native `Event_bus` variants.
 | `collaboration.selection.updated` | Editor cursor or selection projection changed. |
 | `collaboration.graph.snapshot` | A VCS graph snapshot became visible to consumers. |
 | `collaboration.graph.delta` | A VCS graph delta was applied. |
-| `collaboration.todo.claim_observed` | A TODO claim write or verify result was observed. |
+| `collaboration.todo.claim_observed` | A TODO claim write, readback, or verify result was observed. |
 | `collaboration.turn_queue.observed` | A shared turn queue state was observed. |
 
 Downstreams may add more specific names under the same prefix, but should keep
@@ -90,7 +90,7 @@ Optional fields carry implementation details:
 | `document` | CRDT/editor document identifiers, provider, update metadata, and revision. |
 | `transport` | WebSocket or other transport metadata. |
 | `vcs` | Repository/ref/commit identifiers for graph projections. |
-| `todo_claim` | TODO claim observation state, not OAS-owned task semantics. |
+| `todo_claim` | TODO claim observation state, claimant, winner, logical clock, and optional convergence delay; not OAS-owned task semantics. |
 | `turn_queue` | Queue snapshot metadata, not OAS-owned scheduling semantics. |
 | `attributes` | Extra scalar attributes for downstream-specific dimensions. |
 

--- a/docs/schemas/collaboration-event-v1.schema.json
+++ b/docs/schemas/collaboration-event-v1.schema.json
@@ -110,7 +110,9 @@
           "enum": ["observed", "claim_written", "claim_verified", "claim_lost", "released"]
         },
         "claimed_by": { "type": ["string", "null"] },
-        "winner_actor_id": { "type": ["string", "null"] }
+        "winner_actor_id": { "type": ["string", "null"] },
+        "logical_clock": { "type": ["integer", "null"], "minimum": 0 },
+        "convergence_delay_ms": { "type": ["integer", "null"], "minimum": 0 }
       }
     },
     "turn_queue": {

--- a/lib/collaboration.ml
+++ b/lib/collaboration.ml
@@ -57,6 +57,33 @@ type claim_verdict =
   | Claim_closed
 [@@deriving yojson, show]
 
+type claim_observation_state =
+  | Claim_observed
+  | Claim_written
+  | Claim_verified
+  | Claim_lost_observed
+  | Claim_released
+[@@deriving yojson, show]
+
+let claim_observation_state_label = function
+  | Claim_observed -> "observed"
+  | Claim_written -> "claim_written"
+  | Claim_verified -> "claim_verified"
+  | Claim_lost_observed -> "claim_lost"
+  | Claim_released -> "released"
+;;
+
+type claim_observation =
+  { observer_id : participant_id
+  ; item_id : item_id
+  ; state : claim_observation_state
+  ; claimed_by : participant_id option
+  ; winner_actor_id : participant_id option
+  ; logical_clock : logical_clock
+  ; convergence_delay_ms : int option
+  }
+[@@deriving yojson, show]
+
 type merge_error =
   | Subject_mismatch of
       { left : string
@@ -85,6 +112,51 @@ let verify_claim ~actor_id = function
   | { phase = Open; _ } | { phase = Claimed; claimant = None; _ } -> Claim_not_claimed
 ;;
 
+let observe_claim_snapshot ~observer_id ?convergence_delay_ms (snapshot : claim_snapshot) =
+  { observer_id
+  ; item_id = snapshot.item_id
+  ; state = Claim_observed
+  ; claimed_by = snapshot.claimant
+  ; winner_actor_id = None
+  ; logical_clock = snapshot.logical_clock
+  ; convergence_delay_ms
+  }
+;;
+
+let observe_claim_write ~actor_id (snapshot : claim_snapshot) =
+  { observer_id = actor_id
+  ; item_id = snapshot.item_id
+  ; state = Claim_written
+  ; claimed_by = snapshot.claimant
+  ; winner_actor_id = None
+  ; logical_clock = snapshot.logical_clock
+  ; convergence_delay_ms = None
+  }
+;;
+
+let observe_claim_verdict
+      ~actor_id
+      ?convergence_delay_ms
+      (snapshot : claim_snapshot)
+      verdict
+  =
+  let state, winner_actor_id =
+    match verdict with
+    | Claim_won -> Claim_verified, Some actor_id
+    | Claim_lost winner -> Claim_lost_observed, Some winner
+    | Claim_not_claimed -> Claim_observed, None
+    | Claim_closed -> Claim_observed, None
+  in
+  { observer_id = actor_id
+  ; item_id = snapshot.item_id
+  ; state
+  ; claimed_by = snapshot.claimant
+  ; winner_actor_id
+  ; logical_clock = snapshot.logical_clock
+  ; convergence_delay_ms
+  }
+;;
+
 let phase_rank = function
   | Open -> 0
   | Claimed -> 1
@@ -99,7 +171,7 @@ let compare_option_string left right =
   | Some left, Some right -> String.compare left right
 ;;
 
-let compare_claim_snapshot left right =
+let compare_claim_snapshot (left : claim_snapshot) (right : claim_snapshot) =
   let phase_cmp = Int.compare (phase_rank left.phase) (phase_rank right.phase) in
   if phase_cmp <> 0
   then phase_cmp
@@ -110,7 +182,7 @@ let compare_claim_snapshot left right =
     else compare_option_string left.claimant right.claimant)
 ;;
 
-let merge_claim_snapshot left right =
+let merge_claim_snapshot (left : claim_snapshot) (right : claim_snapshot) =
   if not (String.equal left.item_id right.item_id)
   then Error (Subject_mismatch { left = left.item_id; right = right.item_id })
   else if compare_claim_snapshot left right >= 0

--- a/lib/collaboration.mli
+++ b/lib/collaboration.mli
@@ -66,6 +66,31 @@ type claim_verdict =
   | Claim_closed
 [@@deriving yojson, show]
 
+(** Downstream-visible observation state for optimistic claim protocols. *)
+type claim_observation_state =
+  | Claim_observed
+  | Claim_written
+  | Claim_verified
+  | Claim_lost_observed
+  | Claim_released
+[@@deriving yojson, show]
+
+val claim_observation_state_label : claim_observation_state -> string
+
+(** A claim observation records what an actor saw after a write or readback.
+    [claimed_by] reflects the claimant visible in the observed snapshot.
+    [winner_actor_id] is set only when a verify step observed a winner. *)
+type claim_observation =
+  { observer_id : participant_id
+  ; item_id : item_id
+  ; state : claim_observation_state
+  ; claimed_by : participant_id option
+  ; winner_actor_id : participant_id option
+  ; logical_clock : logical_clock
+  ; convergence_delay_ms : int option
+  }
+[@@deriving yojson, show]
+
 type merge_error =
   | Subject_mismatch of
       { left : string
@@ -86,6 +111,24 @@ val claim
 
 (** Verify whether [actor_id] is the converged claimant. *)
 val verify_claim : actor_id:participant_id -> claim_snapshot -> claim_verdict
+
+(** Observe an arbitrary claim snapshot without declaring a winner. *)
+val observe_claim_snapshot
+  :  observer_id:participant_id
+  -> ?convergence_delay_ms:int
+  -> claim_snapshot
+  -> claim_observation
+
+(** Record the optimistic write side of a write-then-verify claim attempt. *)
+val observe_claim_write : actor_id:participant_id -> claim_snapshot -> claim_observation
+
+(** Record the verify/readback side of a write-then-verify claim attempt. *)
+val observe_claim_verdict
+  :  actor_id:participant_id
+  -> ?convergence_delay_ms:int
+  -> claim_snapshot
+  -> claim_verdict
+  -> claim_observation
 
 (** Deterministic merge for two snapshots of the same item.
     [Closed] wins over non-closed phases to preserve monotonic progress.

--- a/test/dune
+++ b/test/dune
@@ -23,6 +23,7 @@
   test_audit
   test_cache
   test_cdal_proof
+  test_collaboration
   test_context
   test_context_reducer
   test_contract

--- a/test/test_collaboration.ml
+++ b/test/test_collaboration.ml
@@ -29,6 +29,43 @@ let test_claim_merge_is_deterministic () =
     Alcotest.fail "expected higher logical clock to win"
 ;;
 
+let test_claim_write_observations () =
+  let snapshot = C.open_claim "item-1" |> C.claim ~actor_id:"actor-a" ~logical_clock:7 in
+  let written = C.observe_claim_write ~actor_id:"actor-a" snapshot in
+  Alcotest.(check string)
+    "write state"
+    "claim_written"
+    (C.claim_observation_state_label written.state);
+  Alcotest.(check (option string)) "written claimant" (Some "actor-a") written.claimed_by;
+  let verdict = C.verify_claim ~actor_id:"actor-a" snapshot in
+  let verified =
+    C.observe_claim_verdict ~actor_id:"actor-a" ~convergence_delay_ms:50 snapshot verdict
+  in
+  Alcotest.(check string)
+    "verified state"
+    "claim_verified"
+    (C.claim_observation_state_label verified.state);
+  Alcotest.(check (option string)) "winner" (Some "actor-a") verified.winner_actor_id;
+  Alcotest.(check int) "clock" 7 verified.logical_clock;
+  Alcotest.(check (option int)) "delay" (Some 50) verified.convergence_delay_ms
+;;
+
+let test_lost_claim_observation_names_winner () =
+  let left = C.open_claim "item-1" |> C.claim ~actor_id:"actor-a" ~logical_clock:1 in
+  let right = C.open_claim "item-1" |> C.claim ~actor_id:"actor-b" ~logical_clock:2 in
+  let merged = C.merge_claim_snapshot left right |> expect_ok in
+  let verdict = C.verify_claim ~actor_id:"actor-a" merged in
+  let observed =
+    C.observe_claim_verdict ~actor_id:"actor-a" ~convergence_delay_ms:50 merged verdict
+  in
+  Alcotest.(check string)
+    "lost state"
+    "claim_lost"
+    (C.claim_observation_state_label observed.state);
+  Alcotest.(check (option string)) "visible claimant" (Some "actor-b") observed.claimed_by;
+  Alcotest.(check (option string)) "winner" (Some "actor-b") observed.winner_actor_id
+;;
+
 let test_closed_claim_preserves_monotonic_progress () =
   let claimed = C.open_claim "item-1" |> C.claim ~actor_id:"actor-a" ~logical_clock:10 in
   let closed : C.claim_snapshot =
@@ -88,6 +125,14 @@ let () =
             "claim deterministic merge"
             `Quick
             test_claim_merge_is_deterministic
+        ; Alcotest.test_case
+            "claim write observations"
+            `Quick
+            test_claim_write_observations
+        ; Alcotest.test_case
+            "lost claim observation"
+            `Quick
+            test_lost_claim_observation_names_winner
         ; Alcotest.test_case
             "closed claim monotonic"
             `Quick


### PR DESCRIPTION
## Summary
- add OAS Collaboration claim_observation types for optimistic write/readback results
- extend collaboration-event v1 todo_claim payload with logical_clock and convergence_delay_ms
- register and cover test_collaboration so the contract is compiled and exercised

## Why
Track 7 needs a provider-neutral way for downstream coordinators to report TODO claim write/verify observations without moving CRDT or task ownership into OAS.

## Validation
- git diff --check
- scripts/dune-local.sh build ./test/test_collaboration.exe
- ./_build/default/test/test_collaboration.exe
