### PR TITLE
chore(release): bump version to 0.187.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ original tag dates. `0.100.4` was never tagged or released.
 
 ## Unreleased
 
+## [0.187.1] - 2026-04-30
+
+### Changed
+
+- Version bump only (post-CI gate merge).
+
 ## [0.187.0] - 2026-04-30
 
 ### Added

--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,6 @@
 (lang dune 3.22)
 (name agent_sdk)
-(version 0.187.0)
+(version 0.187.1)
 
 (generate_opam_files true)
 

--- a/lib/sdk_version.ml
+++ b/lib/sdk_version.ml
@@ -1,5 +1,5 @@
 (** Single source of truth for the SDK version string.
     All other modules reference this instead of hardcoding. *)
 
-let version = "0.187.0"
+let version = "0.187.1"
 let sdk_name = "agent_sdk"


### PR DESCRIPTION
Bump OAS version from 0.187.0 to 0.187.1.

- `dune-project`: `(version 0.187.1)`
- `lib/sdk_version.ml`: `let version = "0.187.1"`

Post-merge follow-up to #1268.