### PR TITLE
Add collaboration performance budgets

### DIFF
--- a/docs/collaboration-substrate-contract.md
+++ b/docs/collaboration-substrate-contract.md
@@ -142,6 +142,23 @@ Downstream systems own the actual counters and policy:
 - Backpressure propagation to child agents after 429 or capacity exhaustion.
 - Adaptive multipliers and product-specific billing/credit semantics.
 
+## Performance Budget Contract
+
+Track 8 performance runners remain downstream-owned. k6, Locust,
+crdt-benchmarks, Lighthouse, and browser RUM should emit observations using
+stable metric names from `Agent_sdk.Collaboration`. OAS exposes only the budget
+vocabulary and pass/fail evaluation helpers.
+
+| Metric label | Budget | Tool hint |
+|--------------|--------|-----------|
+| `ws_connecting_duration.p95_ms` | <= 500 ms | k6 WebSocket |
+| `sync.latency.p95_ms` | <= 100 ms | k6 / OpenTelemetry |
+| `checks.success_rate` | >= 0.99 | k6 checks |
+| `crdt.ops_per_sec` | >= 1000 ops/sec | CRDT benchmark |
+| `crdt.single_insert.mean_ms` | <= 1 ms | CRDT benchmark |
+| `crdt.serialize_under_10mb.ms` | <= 50 ms | CRDT benchmark |
+| `crdt.merge_12_docs.ms` | <= 100 ms | CRDT benchmark |
+
 ## Boundary Rules
 
 - Do not add Yjs, y-websocket, CodeMirror, cytoscape, or browser dependencies

--- a/lib/collaboration.ml
+++ b/lib/collaboration.ml
@@ -91,6 +91,124 @@ type merge_error =
       }
 [@@deriving yojson, show]
 
+type performance_metric =
+  | Ws_connecting_duration_p95_ms
+  | Sync_latency_p95_ms
+  | Checks_success_rate
+  | Crdt_ops_per_sec
+  | Crdt_single_insert_mean_ms
+  | Crdt_serialize_under_10mb_ms
+  | Crdt_merge_12_docs_ms
+[@@deriving yojson, show]
+
+let performance_metric_label = function
+  | Ws_connecting_duration_p95_ms -> "ws_connecting_duration.p95_ms"
+  | Sync_latency_p95_ms -> "sync.latency.p95_ms"
+  | Checks_success_rate -> "checks.success_rate"
+  | Crdt_ops_per_sec -> "crdt.ops_per_sec"
+  | Crdt_single_insert_mean_ms -> "crdt.single_insert.mean_ms"
+  | Crdt_serialize_under_10mb_ms -> "crdt.serialize_under_10mb.ms"
+  | Crdt_merge_12_docs_ms -> "crdt.merge_12_docs.ms"
+;;
+
+type budget_direction =
+  | Below
+  | At_most
+  | Above
+  | At_least
+[@@deriving yojson, show]
+
+let budget_direction_label = function
+  | Below -> "below"
+  | At_most -> "at_most"
+  | Above -> "above"
+  | At_least -> "at_least"
+;;
+
+type performance_budget =
+  { metric : performance_metric
+  ; direction : budget_direction
+  ; threshold : float
+  ; unit : string
+  ; tool_hint : string
+  }
+[@@deriving yojson, show]
+
+type performance_measurement =
+  { metric : performance_metric
+  ; value : float
+  ; observed_at : float option
+  }
+[@@deriving yojson, show]
+
+type performance_budget_error =
+  | Metric_mismatch of
+      { budget_metric : performance_metric
+      ; measurement_metric : performance_metric
+      }
+[@@deriving yojson, show]
+
+type performance_budget_result =
+  { metric : performance_metric
+  ; passed : bool
+  ; value : float
+  ; threshold : float
+  ; direction : budget_direction
+  ; unit : string
+  }
+[@@deriving yojson, show]
+
+let budget metric direction threshold unit tool_hint =
+  { metric; direction; threshold; unit; tool_hint }
+;;
+
+let default_performance_budgets =
+  [ budget Ws_connecting_duration_p95_ms Below 500.0 "ms" "k6 websocket"
+  ; budget Sync_latency_p95_ms Below 100.0 "ms" "k6/OpenTelemetry"
+  ; budget Checks_success_rate Above 0.99 "rate" "k6 checks"
+  ; budget Crdt_ops_per_sec Above 1000.0 "ops/sec" "crdt benchmark"
+  ; budget Crdt_single_insert_mean_ms Below 1.0 "ms" "crdt benchmark"
+  ; budget Crdt_serialize_under_10mb_ms Below 50.0 "ms" "crdt benchmark"
+  ; budget Crdt_merge_12_docs_ms Below 100.0 "ms" "crdt benchmark"
+  ]
+;;
+
+let find_performance_budget metric (budgets : performance_budget list) =
+  List.find_opt (fun (budget : performance_budget) -> budget.metric = metric) budgets
+;;
+
+let passes_budget direction ~threshold ~value =
+  match direction with
+  | Below -> value < threshold
+  | At_most -> value <= threshold
+  | Above -> value > threshold
+  | At_least -> value >= threshold
+;;
+
+let evaluate_performance_budget
+      (budget : performance_budget)
+      (measurement : performance_measurement)
+  =
+  if budget.metric <> measurement.metric
+  then
+    Error
+      (Metric_mismatch
+         { budget_metric = budget.metric; measurement_metric = measurement.metric })
+  else
+    Ok
+      { metric = budget.metric
+      ; passed =
+          passes_budget
+            budget.direction
+            ~threshold:budget.threshold
+            ~value:measurement.value
+      ; value = measurement.value
+      ; threshold = budget.threshold
+      ; direction = budget.direction
+      ; unit = budget.unit
+      }
+;;
+
 let open_claim item_id = { item_id; phase = Open; claimant = None; logical_clock = 0 }
 
 let is_claimable = function

--- a/lib/collaboration.mli
+++ b/lib/collaboration.mli
@@ -98,6 +98,82 @@ type merge_error =
       }
 [@@deriving yojson, show]
 
+(** {1 Performance budgets}
+
+    These budget names are generic collaboration-substrate measurements.
+    Downstream systems own the actual k6/Locust/OpenTelemetry/Lighthouse
+    runners; OAS only provides stable names and budget evaluation semantics
+    so observations can be correlated with runtime traces. *)
+
+type performance_metric =
+  | Ws_connecting_duration_p95_ms
+  | Sync_latency_p95_ms
+  | Checks_success_rate
+  | Crdt_ops_per_sec
+  | Crdt_single_insert_mean_ms
+  | Crdt_serialize_under_10mb_ms
+  | Crdt_merge_12_docs_ms
+[@@deriving yojson, show]
+
+type budget_direction =
+  | Below
+  | At_most
+  | Above
+  | At_least
+[@@deriving yojson, show]
+
+type performance_budget =
+  { metric : performance_metric
+  ; direction : budget_direction
+  ; threshold : float
+  ; unit : string
+  ; tool_hint : string
+  }
+[@@deriving yojson, show]
+
+type performance_measurement =
+  { metric : performance_metric
+  ; value : float
+  ; observed_at : float option
+  }
+[@@deriving yojson, show]
+
+type performance_budget_error =
+  | Metric_mismatch of
+      { budget_metric : performance_metric
+      ; measurement_metric : performance_metric
+      }
+[@@deriving yojson, show]
+
+type performance_budget_result =
+  { metric : performance_metric
+  ; passed : bool
+  ; value : float
+  ; threshold : float
+  ; direction : budget_direction
+  ; unit : string
+  }
+[@@deriving yojson, show]
+
+val performance_metric_label : performance_metric -> string
+val budget_direction_label : budget_direction -> string
+
+(** Track 8 baseline budgets from the collaboration performance plan:
+    WebSocket connection p95 <500ms, sync latency p95 <100ms, checks
+    success rate >0.99, CRDT throughput >1000 ops/sec, single insert mean
+    <1ms, serialize <50ms for <10MB documents, and 12-document merge <100ms. *)
+val default_performance_budgets : performance_budget list
+
+val find_performance_budget
+  :  performance_metric
+  -> performance_budget list
+  -> performance_budget option
+
+val evaluate_performance_budget
+  :  performance_budget
+  -> performance_measurement
+  -> (performance_budget_result, performance_budget_error) result
+
 val open_claim : item_id -> claim_snapshot
 val is_claimable : claim_snapshot -> bool
 

--- a/test/test_collaboration.ml
+++ b/test/test_collaboration.ml
@@ -116,6 +116,78 @@ let test_shared_state_merge_lww () =
   Alcotest.(check string) "value" "\"right\"" (Yojson.Safe.to_string merged.value)
 ;;
 
+let expect_budget_ok = function
+  | Ok value -> value
+  | Error _ -> Alcotest.fail "expected budget evaluation to match metric"
+;;
+
+let test_default_performance_budgets_include_track8_targets () =
+  let assert_budget metric direction threshold =
+    match C.find_performance_budget metric C.default_performance_budgets with
+    | Some budget ->
+      Alcotest.(check string)
+        "direction"
+        (C.budget_direction_label direction)
+        (C.budget_direction_label budget.direction);
+      Alcotest.(check (float 0.0001)) "threshold" threshold budget.threshold
+    | None -> Alcotest.fail ("missing budget for " ^ C.performance_metric_label metric)
+  in
+  assert_budget C.Ws_connecting_duration_p95_ms C.Below 500.0;
+  assert_budget C.Sync_latency_p95_ms C.Below 100.0;
+  assert_budget C.Checks_success_rate C.Above 0.99;
+  assert_budget C.Crdt_ops_per_sec C.Above 1000.0;
+  assert_budget C.Crdt_single_insert_mean_ms C.Below 1.0;
+  assert_budget C.Crdt_serialize_under_10mb_ms C.Below 50.0;
+  assert_budget C.Crdt_merge_12_docs_ms C.Below 100.0
+;;
+
+let test_evaluate_performance_budget_directions () =
+  let sync_budget =
+    C.find_performance_budget C.Sync_latency_p95_ms C.default_performance_budgets
+    |> Option.get
+  in
+  let sync_result =
+    C.evaluate_performance_budget
+      sync_budget
+      { metric = C.Sync_latency_p95_ms; value = 99.9; observed_at = Some 1.0 }
+    |> expect_budget_ok
+  in
+  Alcotest.(check bool) "sync under p95 budget" true sync_result.passed;
+  let checks_budget =
+    C.find_performance_budget C.Checks_success_rate C.default_performance_budgets
+    |> Option.get
+  in
+  let checks_result =
+    C.evaluate_performance_budget
+      checks_budget
+      { metric = C.Checks_success_rate; value = 0.98; observed_at = None }
+    |> expect_budget_ok
+  in
+  Alcotest.(check bool) "checks rate below threshold fails" false checks_result.passed
+;;
+
+let test_evaluate_performance_budget_rejects_metric_mismatch () =
+  let budget =
+    C.find_performance_budget C.Crdt_merge_12_docs_ms C.default_performance_budgets
+    |> Option.get
+  in
+  match
+    C.evaluate_performance_budget
+      budget
+      { metric = C.Sync_latency_p95_ms; value = 80.0; observed_at = None }
+  with
+  | Error (C.Metric_mismatch { budget_metric; measurement_metric }) ->
+    Alcotest.(check string)
+      "budget metric"
+      "crdt.merge_12_docs.ms"
+      (C.performance_metric_label budget_metric);
+    Alcotest.(check string)
+      "measurement metric"
+      "sync.latency.p95_ms"
+      (C.performance_metric_label measurement_metric)
+  | Ok _ -> Alcotest.fail "expected metric mismatch"
+;;
+
 let () =
   Alcotest.run
     "collaboration"
@@ -139,6 +211,18 @@ let () =
             test_closed_claim_preserves_monotonic_progress
         ; Alcotest.test_case "turn queue ordering" `Quick test_turn_queue_ordering
         ; Alcotest.test_case "shared state LWW" `Quick test_shared_state_merge_lww
+        ; Alcotest.test_case
+            "default performance budgets"
+            `Quick
+            test_default_performance_budgets_include_track8_targets
+        ; Alcotest.test_case
+            "performance budget directions"
+            `Quick
+            test_evaluate_performance_budget_directions
+        ; Alcotest.test_case
+            "performance budget metric mismatch"
+            `Quick
+            test_evaluate_performance_budget_rejects_metric_mismatch
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

Applies Track 8's performance and monitoring budget slice to the generic OAS collaboration substrate.

- Adds typed collaboration performance metrics, budget directions, measurements, and evaluation results.
- Defines default budgets for WebSocket connect p95, sync latency p95, checks success rate, and CRDT operation budgets.
- Documents the generic budget contract in the collaboration substrate contract.
- Keeps runtime runners and dashboard/browser-specific budgets out of OAS; those remain downstream responsibilities.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build @fmt`
- `scripts/dune-local.sh build ./test/test_collaboration.exe`
- `./_build/default/test/test_collaboration.exe`