### PR TITLE
Add priority quota contract

### DIFF
--- a/docs/collaboration-substrate-contract.md
+++ b/docs/collaboration-substrate-contract.md
@@ -118,11 +118,36 @@ OAS-owned metric names keep the `oas.*` prefix. Collaboration-specific metrics
 should use `collaboration.*` unless the OpenTelemetry spec already defines a
 better semantic-convention attribute.
 
+## Priority And Quota Contract
+
+Large multi-agent embeddings need a shared vocabulary for backpressure and
+quota allocation, but OAS must not own the distributed quota manager. The
+domain-neutral contract lives in `Llm_provider.Request_priority`:
+
+| OAS request priority | Quota tier | Default share | Meaning |
+|----------------------|------------|---------------|---------|
+| `Resume`, `Interactive` | `p0_critical` | 40% | User-visible or starvation-sensitive work. |
+| `Proactive`, `Unspecified` | `p1_standard` | 40% | Normal agent turns and scheduled work. |
+| `Background` | `p2_background` | 20% | Heartbeats, maintenance, and low-urgency status work. |
+
+`default_quota_allocations` turns a total request budget into integer
+requests-per-minute allocations while preserving the exact total after
+rounding. The SDK default is 1000 requests/minute, which yields
+400/400/200 for P0/P1/P2.
+
+Downstream systems own the actual counters and policy:
+
+- Distributed quota counters and atomic reservation.
+- Lease expiry after crashed or cancelled agents.
+- Backpressure propagation to child agents after 429 or capacity exhaustion.
+- Adaptive multipliers and product-specific billing/credit semantics.
+
 ## Boundary Rules
 
 - Do not add Yjs, y-websocket, CodeMirror, cytoscape, or browser dependencies
   to `agent_sdk`.
 - Do not add TODO claim or turn queue state machines to OAS.
+- Do not add global quota counters, billing, or product pricing logic to OAS.
 - Do not add downstream UI or repo graph payloads as native `Event_bus`
   variants.
 - Prefer `Event_bus.TurnReady`, `ToolCalled`, `ToolCompleted`,

--- a/lib/llm_provider/request_priority.ml
+++ b/lib/llm_provider/request_priority.ml
@@ -20,6 +20,76 @@ let to_int = function
   | Background -> 2
 ;;
 
+type quota_tier =
+  | P0_critical
+  | P1_standard
+  | P2_background
+[@@deriving show]
+
+type quota_allocation =
+  { tier : quota_tier
+  ; share_percent : int
+  ; requests_per_minute : int
+  }
+[@@deriving show]
+
+type quota_allocation_error = Invalid_total_requests_per_minute of int [@@deriving show]
+
+let default_quota_requests_per_minute = 1000
+
+let quota_tier_label = function
+  | P0_critical -> "p0_critical"
+  | P1_standard -> "p1_standard"
+  | P2_background -> "p2_background"
+;;
+
+let quota_tier_share_percent = function
+  | P0_critical -> 40
+  | P1_standard -> 40
+  | P2_background -> 20
+;;
+
+let quota_tier_of_priority = function
+  | Resume | Interactive -> P0_critical
+  | Proactive | Unspecified -> P1_standard
+  | Background -> P2_background
+;;
+
+let default_quota_tiers = [ P0_critical; P1_standard; P2_background ]
+
+let default_quota_allocations ~total_requests_per_minute =
+  if total_requests_per_minute <= 0
+  then Error (Invalid_total_requests_per_minute total_requests_per_minute)
+  else (
+    let base =
+      List.map
+        (fun tier ->
+           let weighted = total_requests_per_minute * quota_tier_share_percent tier in
+           tier, weighted / 100, weighted mod 100)
+        default_quota_tiers
+    in
+    let remainder =
+      total_requests_per_minute
+      - List.fold_left (fun acc (_, requests, _) -> acc + requests) 0 base
+    in
+    let bonus_tiers =
+      base
+      |> List.sort (fun (tier_a, _, rem_a) (tier_b, _, rem_b) ->
+        let by_remainder = Int.compare rem_b rem_a in
+        if by_remainder <> 0 then by_remainder else compare tier_a tier_b)
+      |> List.filteri (fun idx _ -> idx < remainder)
+      |> List.map (fun (tier, _, _) -> tier)
+    in
+    Ok
+      (List.map
+         (fun (tier, requests, _) ->
+            { tier
+            ; share_percent = quota_tier_share_percent tier
+            ; requests_per_minute = (requests + if List.mem tier bonus_tiers then 1 else 0)
+            })
+         base))
+;;
+
 (* [Unspecified] silently maps to [Proactive]. Previously emitted an
    [Eio.traceln] warning, but that polluted ppx_inline_test stderr capture
    in the [resolve Unspecified returns Proactive] test, causing
@@ -116,6 +186,36 @@ let%test "to_int values" =
   && to_int Proactive = 1
   && to_int Unspecified = 1
   && to_int Background = 2
+;;
+
+let%test "quota tier mapping" =
+  quota_tier_of_priority Resume = P0_critical
+  && quota_tier_of_priority Interactive = P0_critical
+  && quota_tier_of_priority Proactive = P1_standard
+  && quota_tier_of_priority Unspecified = P1_standard
+  && quota_tier_of_priority Background = P2_background
+;;
+
+let%test "default quota allocations preserve Track9 split" =
+  match default_quota_allocations ~total_requests_per_minute:1000 with
+  | Ok
+      [ { tier = P0_critical; share_percent = 40; requests_per_minute = 400 }
+      ; { tier = P1_standard; share_percent = 40; requests_per_minute = 400 }
+      ; { tier = P2_background; share_percent = 20; requests_per_minute = 200 }
+      ] -> true
+  | _ -> false
+;;
+
+let%test "default quota allocations preserve rounded total" =
+  match default_quota_allocations ~total_requests_per_minute:7 with
+  | Ok allocations ->
+    List.fold_left (fun acc a -> acc + a.requests_per_minute) 0 allocations = 7
+  | Error _ -> false
+;;
+
+let%test "default quota allocations reject invalid total" =
+  default_quota_allocations ~total_requests_per_minute:0
+  = Error (Invalid_total_requests_per_minute 0)
 ;;
 
 let%test "resolve Unspecified returns Proactive" =

--- a/lib/llm_provider/request_priority.mli
+++ b/lib/llm_provider/request_priority.mli
@@ -32,5 +32,42 @@ val compare : t -> t -> int
 (** Numeric rank: -1=Resume, 0=Interactive, 1=Proactive, 2=Background, 3=Unspecified. *)
 val to_int : t -> int
 
+(** Product-neutral quota tier for schedulers that coordinate many agents.
+
+    OAS only defines the vocabulary and deterministic allocation helper.
+    Distributed counters, leases, backpressure propagation, billing, and
+    product-specific policy remain downstream coordinator responsibilities. *)
+type quota_tier =
+  | P0_critical (** Critical/user-visible work. Suggested default share: 40%. *)
+  | P1_standard
+  (** Standard agent turns and scheduled work. Suggested default share: 40%. *)
+  | P2_background
+  (** Background maintenance, heartbeat, and status work. Suggested default
+      share: 20%. *)
+[@@deriving show]
+
+type quota_allocation =
+  { tier : quota_tier
+  ; share_percent : int
+  ; requests_per_minute : int
+  }
+[@@deriving show]
+
+type quota_allocation_error = Invalid_total_requests_per_minute of int [@@deriving show]
+
+val default_quota_requests_per_minute : int
+val quota_tier_label : quota_tier -> string
+val quota_tier_share_percent : quota_tier -> int
+
+(** Map request scheduling priority to the Track9 P0/P1/P2 quota vocabulary. *)
+val quota_tier_of_priority : t -> quota_tier
+
+(** Deterministically split [total_requests_per_minute] into the default
+    40/40/20 quota tiers while preserving the exact total after integer
+    rounding. *)
+val default_quota_allocations
+  :  total_requests_per_minute:int
+  -> (quota_allocation list, quota_allocation_error) result
+
 val to_yojson : t -> Yojson.Safe.t
 val of_yojson : Yojson.Safe.t -> (t, string) result

--- a/test/dune
+++ b/test/dune
@@ -192,7 +192,7 @@
  (libraries agent_sdk alcotest qcheck-core qcheck-alcotest))
 
 (tests
- (names test_retry test_slot_scheduler_event_bridge)
+ (names test_request_priority test_retry test_slot_scheduler_event_bridge)
  (libraries agent_sdk llm_provider alcotest yojson eio eio_main))
 
 (tests

--- a/test/test_request_priority.ml
+++ b/test/test_request_priority.ml
@@ -1,0 +1,97 @@
+open Llm_provider
+
+let test_quota_tier_labels () =
+  Alcotest.(check string)
+    "P0 label"
+    "p0_critical"
+    (Request_priority.quota_tier_label Request_priority.P0_critical);
+  Alcotest.(check string)
+    "P1 label"
+    "p1_standard"
+    (Request_priority.quota_tier_label Request_priority.P1_standard);
+  Alcotest.(check string)
+    "P2 label"
+    "p2_background"
+    (Request_priority.quota_tier_label Request_priority.P2_background)
+;;
+
+let test_priority_to_quota_tier () =
+  Alcotest.(check string)
+    "interactive -> P0"
+    "Request_priority.P0_critical"
+    (Request_priority.show_quota_tier
+       (Request_priority.quota_tier_of_priority Request_priority.Interactive));
+  Alcotest.(check string)
+    "proactive -> P1"
+    "Request_priority.P1_standard"
+    (Request_priority.show_quota_tier
+       (Request_priority.quota_tier_of_priority Request_priority.Proactive));
+  Alcotest.(check string)
+    "background -> P2"
+    "Request_priority.P2_background"
+    (Request_priority.show_quota_tier
+       (Request_priority.quota_tier_of_priority Request_priority.Background))
+;;
+
+let test_default_quota_allocation () =
+  match
+    Request_priority.default_quota_allocations
+      ~total_requests_per_minute:Request_priority.default_quota_requests_per_minute
+  with
+  | Error e -> Alcotest.fail (Request_priority.show_quota_allocation_error e)
+  | Ok allocations ->
+    let requests =
+      List.map
+        (fun (a : Request_priority.quota_allocation) -> a.tier, a.requests_per_minute)
+        allocations
+    in
+    Alcotest.(check int)
+      "P0 requests"
+      400
+      (List.assoc Request_priority.P0_critical requests);
+    Alcotest.(check int)
+      "P1 requests"
+      400
+      (List.assoc Request_priority.P1_standard requests);
+    Alcotest.(check int)
+      "P2 requests"
+      200
+      (List.assoc Request_priority.P2_background requests)
+;;
+
+let test_rounded_quota_allocation_preserves_total () =
+  match Request_priority.default_quota_allocations ~total_requests_per_minute:7 with
+  | Error e -> Alcotest.fail (Request_priority.show_quota_allocation_error e)
+  | Ok allocations ->
+    let total =
+      List.fold_left
+        (fun acc (allocation : Request_priority.quota_allocation) ->
+           acc + allocation.requests_per_minute)
+        0
+        allocations
+    in
+    Alcotest.(check int) "rounded total" 7 total
+;;
+
+let test_invalid_quota_allocation () =
+  match Request_priority.default_quota_allocations ~total_requests_per_minute:0 with
+  | Error (Request_priority.Invalid_total_requests_per_minute 0) -> ()
+  | Ok _ -> Alcotest.fail "expected invalid total rejection"
+  | Error e -> Alcotest.fail (Request_priority.show_quota_allocation_error e)
+;;
+
+let () =
+  Alcotest.run
+    "request_priority"
+    [ ( "quota"
+      , [ Alcotest.test_case "tier labels" `Quick test_quota_tier_labels
+        ; Alcotest.test_case "priority mapping" `Quick test_priority_to_quota_tier
+        ; Alcotest.test_case "default allocation" `Quick test_default_quota_allocation
+        ; Alcotest.test_case
+            "rounded allocation preserves total"
+            `Quick
+            test_rounded_quota_allocation_preserves_total
+        ; Alcotest.test_case "invalid total" `Quick test_invalid_quota_allocation
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

Applies the first Track 9 productization/API slice to OAS as a domain-neutral scheduling contract.

- Adds typed P0/P1/P2 quota tiers to `Llm_provider.Request_priority`.
- Maps existing request priorities onto quota tiers without adding product billing or distributed counters to OAS.
- Adds deterministic default quota allocation for a total requests/minute budget, including exact total preservation after rounding.
- Documents the boundary: OAS owns vocabulary/allocation helpers; downstream coordinators own leases, backpressure propagation, counters, and billing policy.

## Validation

- `scripts/dune-local.sh build @fmt`
- `scripts/dune-local.sh build ./test/test_request_priority.exe`
- `./_build/default/test/test_request_priority.exe`
- `git diff --check`