### PR TITLE
[codex] Add memory prefix query

### DIFF
--- a/lib/memory.ml
+++ b/lib/memory.ml
@@ -124,6 +124,48 @@ let forget t ~tier key =
     Ok ()
 ;;
 
+let take_unique limit entries =
+  if limit <= 0
+  then []
+  else (
+    let seen = Hashtbl.create (limit + 1) in
+    let rec loop remaining acc = function
+      | [] -> List.rev acc
+      | _ when remaining <= 0 -> List.rev acc
+      | (key, value) :: rest ->
+        if Hashtbl.mem seen key
+        then loop remaining acc rest
+        else (
+          Hashtbl.replace seen key ();
+          loop (remaining - 1) ((key, value) :: acc) rest)
+    in
+    loop limit [] entries)
+;;
+
+let query_context t ~tier ~prefix =
+  Context.keys_in_scope t.ctx (scope_of_tier tier)
+  |> List.filter (fun key -> String.starts_with ~prefix key)
+  |> List.filter_map (fun key ->
+    match Context.get_scoped t.ctx (scope_of_tier tier) key with
+    | Some value -> Some (key, value)
+    | None -> None)
+;;
+
+let query t ~tier ~prefix ~limit =
+  if limit <= 0
+  then []
+  else
+    match tier with
+    | Long_term ->
+      let backend_entries =
+        match t.long_term with
+        | Some backend -> backend.query ~prefix ~limit
+        | None -> []
+      in
+      take_unique limit (backend_entries @ query_context t ~tier:Long_term ~prefix)
+    | _ -> take_unique limit (query_context t ~tier ~prefix)
+;;
+
 let promote t key =
   match Context.get_scoped t.ctx (scope_of_tier Scratchpad) key with
   | Some value ->

--- a/lib/memory.mli
+++ b/lib/memory.mli
@@ -77,6 +77,11 @@ val recall_exact : t -> tier:tier -> string -> Yojson.Safe.t option
     Returns [Error reason] if the long-term backend remove fails. *)
 val forget : t -> tier:tier -> string -> (unit, string) result
 
+(** Query entries in a specific tier whose keys start with [prefix], up to
+    [limit].  For [Long_term], backend results are included first and
+    de-duplicated with the in-memory long-term tier. *)
+val query : t -> tier:tier -> prefix:string -> limit:int -> (string * Yojson.Safe.t) list
+
 (** Promote a key from Scratchpad to Working.
     Returns [true] if the key existed in Scratchpad. *)
 val promote : t -> string -> bool

--- a/test/test_memory.ml
+++ b/test/test_memory.ml
@@ -213,6 +213,44 @@ let test_long_term_backend_set_after_create () =
   | _ -> fail "late backend should work"
 ;;
 
+let test_query_long_term_prefix () =
+  let store = Hashtbl.create 4 in
+  let backend : Memory.long_term_backend =
+    { persist =
+        (fun ~key value ->
+          Hashtbl.replace store key value;
+          Ok ())
+    ; retrieve = (fun ~key -> Hashtbl.find_opt store key)
+    ; remove =
+        (fun ~key ->
+          Hashtbl.remove store key;
+          Ok ())
+    ; batch_persist =
+        (fun pairs ->
+          List.iter (fun (k, v) -> Hashtbl.replace store k v) pairs;
+          Ok ())
+    ; query =
+        (fun ~prefix ~limit ->
+          Hashtbl.fold
+            (fun k v acc ->
+              if String.starts_with ~prefix k then (k, v) :: acc else acc)
+            store
+            []
+          |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+          |> List.filteri (fun i _ -> i < limit))
+    }
+  in
+  let mem = Memory.create ~long_term:backend () in
+  ignore (Memory.store mem ~tier:Long_term "world:mission" (json_s "ready"));
+  ignore (Memory.store mem ~tier:Long_term "world:crew" (json_s "awake"));
+  ignore (Memory.store mem ~tier:Long_term "other:key" (json_s "skip"));
+  let results = Memory.query mem ~tier:Long_term ~prefix:"world" ~limit:10 in
+  let keys = List.map fst results in
+  check int "world entries" 2 (List.length results);
+  check bool "mission" true (List.mem "world:mission" keys);
+  check bool "crew" true (List.mem "world:crew" keys)
+;;
+
 (* ── Context access ───────────────────────────────── *)
 
 let test_context_access () =
@@ -257,6 +295,7 @@ let () =
             "set backend after create"
             `Quick
             test_long_term_backend_set_after_create
+        ; test_case "query prefix" `Quick test_query_long_term_prefix
         ] )
     ; "context", [ test_case "context access" `Quick test_context_access ]
     ]


### PR DESCRIPTION
## Summary

Adds a public `Memory.query` API for tier-scoped prefix lookup, including long-term backend results with in-memory de-duplication.

## Why

MASC needs to read user-authored long-term `world*` memory without reaching into OAS internals or hand-scanning context storage. This keeps OAS responsible for the generic memory query primitive while MASC owns the keeper prompt semantics.

## Changes

- Add `Memory.query : t -> tier:tier -> prefix:string -> limit:int -> ...`.
- Query non-long-term tiers from scoped context keys.
- Query long-term memory from the configured backend first, then merge in-memory long-term entries without duplicate keys.
- Cover prefix lookup with `test_query_long_term_prefix`.

## Validation

- `scripts/dune-local.sh build test/test_memory.exe`
- `./_build/default/test/test_memory.exe`
- `git diff --check`