### PR TITLE
[codex] Format memory query follow-up

### DIFF
--- a/lib/memory.ml
+++ b/lib/memory.ml
@@ -154,7 +154,7 @@ let query_context t ~tier ~prefix =
 let query t ~tier ~prefix ~limit =
   if limit <= 0
   then []
-  else
+  else (
     match tier with
     | Long_term ->
       let backend_entries =
@@ -163,7 +163,7 @@ let query t ~tier ~prefix ~limit =
         | None -> []
       in
       take_unique limit (backend_entries @ query_context t ~tier:Long_term ~prefix)
-    | _ -> take_unique limit (query_context t ~tier ~prefix)
+    | _ -> take_unique limit (query_context t ~tier ~prefix))
 ;;
 
 let promote t key =

--- a/test/test_memory.ml
+++ b/test/test_memory.ml
@@ -232,8 +232,7 @@ let test_query_long_term_prefix () =
     ; query =
         (fun ~prefix ~limit ->
           Hashtbl.fold
-            (fun k v acc ->
-              if String.starts_with ~prefix k then (k, v) :: acc else acc)
+            (fun k v acc -> if String.starts_with ~prefix k then (k, v) :: acc else acc)
             store
             []
           |> List.sort (fun (a, _) (b, _) -> String.compare a b)


### PR DESCRIPTION
## Summary

Applies the ocamlformat changes required by the CI format gate after PR #1276.

## Validation

- `scripts/dune-local.sh build @fmt test/test_memory.exe`
- `./_build/default/test/test_memory.exe`
- `git diff --check HEAD~1..HEAD`