### PR TITLE
ci: skip heavy checks for draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch: {}
 
 concurrency:
@@ -14,6 +15,7 @@ concurrency:
 jobs:
   build-and-test:
     name: Build & Test (OCaml ${{ matrix.ocaml-compiler }})
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -148,6 +150,7 @@ jobs:
 
   lint:
     name: Lint
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -186,6 +189,7 @@ jobs:
 
   ocamlformat:
     name: OCaml Format
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -207,6 +211,7 @@ jobs:
 
   version-check:
     name: Version Consistency
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -231,6 +236,7 @@ jobs:
 
   transport-drift:
     name: Transport Drift Gate
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -243,6 +249,7 @@ jobs:
 
   sdk-independence:
     name: SDK Independence Gate
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -258,6 +265,7 @@ jobs:
 
   tag-drift:
     name: Release Tag Drift
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # Enforced gate: fails if any CHANGELOG entry in the default scope


### PR DESCRIPTION
## Summary
- skip heavy OCaml CI jobs while pull requests are still draft
- trigger full CI again when a draft is marked ready for review
- keep push and manual workflow runs fully covered

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'
- actionlint not installed locally