### PR TITLE
ci: trigger draft skip on draft conversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   workflow_dispatch: {}
 
 concurrency:


### PR DESCRIPTION
## Summary
- include `converted_to_draft` in the CI pull_request trigger
- let the existing concurrency key cancel an in-flight ready PR CI run when the PR is moved back to draft

## Validation
- git diff --check HEAD~1..HEAD
- ruby YAML parse for .github/workflows/ci.yml