### PR TITLE
[codex] add provider constraint guards for CLI transports

### DIFF
--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -146,6 +146,34 @@ let show_provider_kind = Provider_kind.show
 let provider_kind_to_yojson = Provider_kind.to_yojson
 let provider_kind_of_yojson = Provider_kind.of_yojson
 
+let max_turns_hard_cap = function
+  | Claude_code -> Some 30
+  | Anthropic
+  | Kimi
+  | OpenAI_compat
+  | Ollama
+  | Gemini
+  | Glm
+  | DashScope
+  | Gemini_cli
+  | Kimi_cli
+  | Codex_cli -> None
+;;
+
+let clamp_max_turns kind requested =
+  match max_turns_hard_cap kind with
+  | Some cap -> min requested cap
+  | None -> requested
+;;
+
+let default_attempt_timeout_s = function
+  | Ollama -> Some 300.0
+  | Claude_code -> Some 120.0
+  | Kimi_cli -> Some 60.0
+  | Gemini_cli -> Some 180.0
+  | Anthropic | Kimi | OpenAI_compat | Gemini | Glm | DashScope | Codex_cli -> None
+;;
+
 (** Map thinking configuration to reasoning_effort string.
     Four levels: "none", "low" (≤2048), "medium" (≤8192), "high" (>8192).
     Shared by Ollama backends and api_openai request building.

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -209,6 +209,19 @@ val provider_kind_of_yojson
   :  Yojson.Safe.t
   -> provider_kind Ppx_deriving_yojson_runtime.error_or
 
+(** Provider-internal hard cap for subprocess/native turn budgets.
+    Returns [None] when OAS has no provider-specific hard ceiling. *)
+val max_turns_hard_cap : provider_kind -> int option
+
+(** Clamp a requested per-provider turn budget to the provider's hard cap.
+    Providers without a hard cap return the requested value unchanged. *)
+val clamp_max_turns : provider_kind -> int -> int
+
+(** Provider-specific wall-clock budget hint for one provider attempt.
+    This is advisory metadata for cascade/orchestration layers; transports
+    still apply their own lower-level connect/body/idle timeouts. *)
+val default_attempt_timeout_s : provider_kind -> float option
+
 (** Map thinking configuration fields to reasoning_effort string.
     Returns "none", "low", "medium", or "high".
     @since 0.114.0 *)

--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -42,6 +42,12 @@ let default_config =
   }
 ;;
 
+let effective_max_turns config =
+  Option.map
+    (Provider_config.clamp_max_turns Provider_config.Claude_code)
+    config.max_turns
+;;
+
 (* Prompt shaping, JSON helpers, and subprocess orchestration live in the
    shared [Cli_common_*] modules to deduplicate logic across CLI transports. *)
 
@@ -205,7 +211,7 @@ let build_args
   (match system_prompt with
    | Some s -> add [ "--system-prompt"; s ]
    | None -> ());
-  (match config.max_turns with
+  (match effective_max_turns config with
    | Some n -> add [ "--max-turns"; string_of_int n ]
    | None -> ());
   (match runtime_mcp_policy with
@@ -891,6 +897,26 @@ let%test "build_args omits auto model override" =
       ()
   in
   not (List.mem "--model" args)
+;;
+
+let%test "build_args clamps claude max_turns to provider hard cap" =
+  let config = { default_config with max_turns = Some 39 } in
+  let args =
+    build_args
+      ~config
+      ~req_config:
+        (Provider_config.make ~kind:Claude_code ~model_id:"auto" ~base_url:"" ())
+      ~prompt:"hello"
+      ~stream:false
+      ~system_prompt:None
+      ()
+  in
+  let rec has_clamped_flag = function
+    | "--max-turns" :: "30" :: _ -> true
+    | _ :: rest -> has_clamped_flag rest
+    | [] -> false
+  in
+  has_clamped_flag args
 ;;
 
 (* Strict-MCP/mcp-config pairing invariants are exercised by the

--- a/lib/llm_provider/transport_kimi_cli.ml
+++ b/lib/llm_provider/transport_kimi_cli.ml
@@ -50,9 +50,22 @@ let prompt_argv_threshold () =
 ;;
 
 let prompt_exceeds_argv_budget prompt = String.length prompt >= prompt_argv_threshold ()
+let sanitize_for_kimi prompt = Utf8_sanitize.sanitize prompt
+
+let prompt_contains_non_ascii prompt =
+  let rec loop idx =
+    idx < String.length prompt && (Char.code prompt.[idx] > 0x7f || loop (idx + 1))
+  in
+  loop 0
+;;
+
+let prompt_needs_stdin prompt =
+  prompt_exceeds_argv_budget prompt || prompt_contains_non_ascii prompt
+;;
 
 let stdin_for_prompt prompt =
-  if prompt_exceeds_argv_budget prompt then Some prompt else None
+  let prompt = sanitize_for_kimi prompt in
+  if prompt_needs_stdin prompt then Some prompt else None
 ;;
 
 let prompt_for_cli prompt = Utf8_sanitize.sanitize prompt
@@ -64,7 +77,8 @@ let cli_model_override ~(config : config) ~(req_config : Provider_config.t) =
 ;;
 
 let build_args ~(config : config) ~(req_config : Provider_config.t) ~prompt =
-  let prompt_via_stdin = prompt_exceeds_argv_budget prompt in
+  let prompt = sanitize_for_kimi prompt in
+  let prompt_via_stdin = prompt_needs_stdin prompt in
   let args = ref [ config.kimi_path; "--print"; "--output-format"; "stream-json" ] in
   let add a = args := !args @ a in
   if not prompt_via_stdin then add [ "-p"; prompt ];
@@ -134,10 +148,12 @@ let tool_result_of_json json =
   | None -> None
 ;;
 
+let parse_json_line line = Yojson.Safe.from_string (Utf8_sanitize.sanitize line)
+
 let blocks_of_output_line line =
   let open Yojson.Safe.Util in
   try
-    let json = Yojson.Safe.from_string line in
+    let json = parse_json_line line in
     match json |> member "role" |> to_string_option with
     | Some "assistant" ->
       let content = blocks_of_message_content (json |> member "content") in
@@ -160,7 +176,7 @@ let response_id_of_lines lines =
   let open Yojson.Safe.Util in
   let find_id line =
     try
-      let json = Yojson.Safe.from_string line in
+      let json = parse_json_line line in
       match json |> member "id" |> to_string_option with
       | Some id when String.trim id <> "" -> Some id
       | _ ->
@@ -177,7 +193,7 @@ let response_model_of_lines ~model_id lines =
   let open Yojson.Safe.Util in
   let find_model line =
     try
-      let json = Yojson.Safe.from_string line in
+      let json = parse_json_line line in
       match json |> member "model" |> to_string_option with
       | Some m when String.trim m <> "" -> Some m
       | _ -> None
@@ -206,7 +222,7 @@ let usage_of_lines lines =
   let find_usage line =
     let open Yojson.Safe.Util in
     try
-      let json = Yojson.Safe.from_string line in
+      let json = parse_json_line line in
       parse_usage json
     with
     | Yojson.Json_error _ | Type_error _ -> None
@@ -388,6 +404,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
       (fun (req : Llm_transport.completion_request) ->
         warn_external_tools_once warned req.tools;
         let prompt, _resume_existing_session = prepare_prompt_and_messages req in
+        let prompt = sanitize_for_kimi prompt in
         let model_id =
           Option.value
             ~default:"kimi-for-coding"
@@ -419,6 +436,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
       (fun ~on_event (req : Llm_transport.completion_request) ->
         warn_external_tools_once warned req.tools;
         let prompt, _resume_existing_session = prepare_prompt_and_messages req in
+        let prompt = sanitize_for_kimi prompt in
         let model_id =
           Option.value
             ~default:"kimi-for-coding"
@@ -553,6 +571,12 @@ let%test "build_args routes large prompt via stdin" =
   (not (List.mem big args)) && not (List.mem "-p" args)
 ;;
 
+let%test "build_args sanitizes broken utf8 prompt before argv" =
+  let bad = "prefix\x80suffix" in
+  let args = build_args ~config:default_config ~req_config:(kimi_req ()) ~prompt:bad in
+  (not (List.mem bad args)) && not (List.mem "-p" args)
+;;
+
 let%test "build_args adds session id when configured" =
   let config = { default_config with session_id = Some "sess-abc" } in
   let args = build_args ~config ~req_config:(kimi_req ()) ~prompt:"next" in
@@ -591,6 +615,13 @@ let%test "parse_jsonl_result accepts array-form content" =
   match parse_jsonl_result ~model_id:"kimi-for-coding" lines with
   | Ok resp -> resp.content = [ Types.Text "hello" ]
   | Error _ -> false
+;;
+
+let%test "parse_jsonl_result sanitizes broken utf8 output lines" =
+  let lines = [ "{\"role\":\"assistant\",\"content\":\"hello\x80\"}" ] in
+  match parse_jsonl_result ~model_id:"kimi-for-coding" lines with
+  | Ok { content = [ Types.Text text ]; _ } -> text = "hello\xEF\xBF\xBD"
+  | _ -> false
 ;;
 
 let%test "classify_cli_error exit 1 becomes AcceptRejected" =


### PR DESCRIPTION
## What changed

- Add provider constraint helpers for hard max-turn caps and default attempt timeout hints.
- Clamp Claude Code `--max-turns` to the provider hard cap before building CLI args.
- Sanitize Kimi CLI prompts before argv/stdin routing and completion execution.
- Sanitize Kimi JSONL output lines before parsing usage, response ids, models, and assistant blocks.
- Add inline tests for Claude max-turn clamping and Kimi broken UTF-8 handling.

## Why

Downstream MASC needs OAS transports to enforce provider constraints locally as well as at orchestration boundaries. These guards make the Claude and Kimi failure cases deterministic and test-covered instead of relying on callers to avoid provider-specific invalid inputs.

## Validation

- `git diff --check HEAD~1`
- `scripts/dune-local.sh runtest lib/llm_provider`