### PR TITLE
fix: propagate provider clocks to completions

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -259,6 +259,7 @@ let%test "sanitize_url_for_log handles missing path" =
 let complete_http
       ~sw
       ~net
+      ?clock
       ?(on_http_status :
          (provider:string -> model_id:string -> status:int -> unit) option)
       ~(config : Provider_config.t)
@@ -397,7 +398,14 @@ let complete_http
         let t0 = Unix.gettimeofday () in
         let result =
           match
-            Http_client.post_sync ~sw ~net ~url ~headers:config.headers ~body:body_str ()
+            Http_client.post_sync
+              ~sw
+              ~net
+              ?clock
+              ~url
+              ~headers:config.headers
+              ~body:body_str
+              ()
           with
           | Error _ as e -> e
           | Ok (code, body) ->
@@ -638,6 +646,7 @@ let complete_http
 let complete
       ~sw
       ~net
+      ?clock
       ?(transport : Llm_transport.t option)
       ~(config : Provider_config.t)
       ~(messages : Types.message list)
@@ -709,6 +718,7 @@ let complete
              complete_http
                ~sw
                ~net
+               ?clock
                ~on_http_status:m.on_http_status
                ~config
                ~messages
@@ -837,6 +847,7 @@ let complete_with_retry
        complete
          ~sw
          ~net
+         ~clock
          ?transport
          ~config
          ~messages

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -66,6 +66,7 @@ val make_http_transport
 val complete
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> ?clock:_ Eio.Time.clock
   -> ?transport:Llm_transport.t
   -> config:Provider_config.t
   -> messages:Types.message list

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -256,7 +256,7 @@ let stage_route ~sw ?clock ~api_strategy agent prep =
       ; turn = agent.state.turn_count
       ; extra = []
       }
-      (fun _tracer -> dispatch_stream ~sw agent prep ~on_event)
+      (fun _tracer -> dispatch_stream ~sw ?clock agent prep ~on_event)
 ;;
 
 (* ── Stage 4: Collect ────────────────────────────────────── *)

--- a/lib/pipeline/stage_route.ml
+++ b/lib/pipeline/stage_route.ml
@@ -96,7 +96,7 @@ let dispatch_sync ~sw ?clock agent prep =
   | Error err -> Error (sdk_error_of_http_error err)
 ;;
 
-let dispatch_stream ~sw agent prep ~on_event =
+let dispatch_stream ~sw ?clock agent prep ~on_event =
   let tools = Option.value prep.Agent_turn.tools_json ~default:[] in
   let open Result in
   let* pc =
@@ -109,6 +109,7 @@ let dispatch_stream ~sw agent prep ~on_event =
     Llm_provider.Complete.complete_stream
       ~sw
       ~net:agent.net
+      ?clock
       ?transport:agent.options.transport
       ~config:pc
       ~messages:prep.effective_messages
@@ -144,5 +145,5 @@ let stage_route ~sw ?clock ~api_strategy agent prep =
       ; turn = agent.state.turn_count
       ; extra = []
       }
-      (fun _tracer -> dispatch_stream ~sw agent prep ~on_event)
+      (fun _tracer -> dispatch_stream ~sw ?clock agent prep ~on_event)
 ;;

--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -255,7 +255,6 @@ let extract_with_retry
       prompt
   : ('a retry_result, Error.sdk_error) result
   =
-  ignore clock;
   let base_url = Option.value ~default:Api.default_base_url base_url in
   let add_retry_usage acc resp_usage =
     match resp_usage with
@@ -295,6 +294,7 @@ let extract_with_retry
         Llm_provider.Complete.complete
           ~sw
           ~net
+          ?clock
           ~config:provider_cfg
           ~messages
           ~tools:[]
@@ -360,7 +360,6 @@ let extract_stream
       prompt
   : ('a * api_response, Error.sdk_error) result
   =
-  ignore clock;
   let base_url = Option.value ~default:Api.default_base_url base_url in
   let messages =
     [ { role = User
@@ -378,6 +377,7 @@ let extract_stream
        Llm_provider.Complete.complete_stream
          ~sw
          ~net
+         ?clock
          ~config:provider_cfg
          ~messages
          ~tools:[]


### PR DESCRIPTION
## Summary

- Thread `?clock` through `Pipeline.stage_route` stream dispatch.
- Add `?clock` to `Complete.complete` and forward it to `complete_http` / `Http_client.post_sync`.
- Stop ignoring `?clock` in structured extraction retry/stream helpers.

Fixes #1318.

## Why This Matters

MASC treats OAS provider calls as cascade attempts. If a provider lane stalls without a typed timeout, the Keeper turn can consume the reaction instead of failing the current attempt and advancing the cascade.

This patch keeps OAS generic: it does not add MASC task/goal/keeper semantics. It only ensures the caller's clock reaches provider I/O on the built-in HTTP paths and structured helpers.

## Verification

- `git diff --check`
- `scripts/dune-local.sh build test/test_complete_http.exe test/test_structured_coverage.exe test/test_structured_stream.exe`
- `./_build/default/test/test_complete_http.exe`
- `./_build/default/test/test_structured_stream.exe`
- `./_build/default/test/test_structured_coverage.exe`

## MASC Tracking

- Goal: `goal-world-reaction-liveness`
- Task: `task-131`
