### PR TITLE
feat: OAS Execution Manifest 고도화 및 Rate Limit Quota (P0~P1)

### DIFF
--- a/.gitignore.bak
+++ b/.gitignore.bak
@@ -1,0 +1,48 @@
+_build/
+_build_*/
+.worktrees/
+
+# OCaml / opam
+*.install
+*.merlin
+.merlin
+_opam/
+
+# Editor
+*.swp
+*.swo
+*~
+.vscode/
+.idea/
+
+# TLA+ / TLC artifacts
+specs/states/
+specs/*_TTrace_*.tla
+specs/*_TTrace_*.bin
+*.toolbox/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Coverage
+_coverage/
+*.coverage
+
+# Environment
+.env
+.env.*
+
+# TLA+ generated state files
+specs/states/
+
+# Local working documents and one-off scripts (operator scratch)
+REFACTORING-PLAN*.md
+ISSUE_OCAML_*.md
+CDAL-ENHANCEMENT*.md
+TODO.md
+add_logs.py
+apply_fix.py
+fix_*.py
+patch_*.py
+.mcp.json

--- a/lib/llm_provider/transport_gemini_cli.ml.orig
+++ b/lib/llm_provider/transport_gemini_cli.ml.orig
@@ -1,0 +1,854 @@
+(** Gemini CLI non-interactive transport.
+
+    @since 0.133.0 *)
+
+type config =
+  { gemini_path : string
+  ; model : string option
+  ; yolo : bool
+  ; cwd : string option
+  ; (* Fields below are accepted for parity with the Claude Code config
+     so callers can target multiple CLI backends with the same
+     structure.  As of Gemini CLI 0.8+, real flags exist for
+     [mcp_config] (via [--allowed-mcp-server-names]) and for the
+     approval surface (via [--approval-mode]); however we deliberately
+     do not bridge these config fields directly — that would silently
+     reinterpret existing callers.  Instead, opt-in env vars in
+     [env_extra_args] below expose the new flags.  The four fields
+     here are still unused and keep their legacy warning semantics. *)
+    mcp_config : string option
+  ; allowed_tools : string list
+  ; max_turns : int option
+  ; permission_mode : string option
+  ; cancel : unit Eio.Promise.t option
+    (* When [Some p] and [p] resolves mid-run, the [gemini]
+       subprocess receives [SIGINT].  Default [None]. *)
+  }
+
+let default_config =
+  { gemini_path = "gemini"
+  ; model = None
+  ; yolo = true
+  ; cwd = None
+  ; mcp_config = None
+  ; allowed_tools = []
+  ; max_turns = None
+  ; permission_mode = None
+  ; cancel = None
+  }
+;;
+
+(* Prompt shaping, JSON helpers, and subprocess orchestration live in the
+   shared [Cli_common_*] modules. *)
+
+(* ── CLI argument building ───────────────────────────── *)
+
+(* Non-interactive Gemini runs default to MCP OFF by passing a sentinel
+   MCP whitelist that will never match a real server.  Explicit
+   allow-lists can opt back in.
+
+   OAS_GEMINI_ALLOWED_MCP    "a,b" → --allowed-mcp-server-names a
+                                     --allowed-mcp-server-names b
+   OAS_GEMINI_NO_MCP         1     → --allowed-mcp-server-names __oas_no_mcp__
+                                     (sentinel ⇒ all MCP OFF;
+                                      takes precedence over the list)
+   OAS_GEMINI_APPROVAL_MODE  default|auto_edit|yolo|plan
+                                   → --approval-mode <v>
+                                     (when set, supersedes [config.yolo])
+   OAS_GEMINI_EXTENSIONS     "a,b" → -e a -e b
+
+   Gemini CLI 0.38+ PolicyEngine rejects empty strings in
+   [--allowed-mcp-server-names] ("mcpName is required if specified").
+   The sentinel is a non-existent server name that satisfies the
+   validator while matching nothing, giving us the same "all MCP OFF"
+   semantics without crashing the CLI. *)
+let no_mcp_sentinel = "__oas_no_mcp__"
+
+let env_extra_args () =
+  let extras = ref [] in
+  let add a = extras := !extras @ a in
+  if Cli_common_env.bool "OAS_GEMINI_NO_MCP"
+  then add [ "--allowed-mcp-server-names"; no_mcp_sentinel ]
+  else (
+    match Cli_common_env.list "OAS_GEMINI_ALLOWED_MCP" with
+    | None | Some [] -> add [ "--allowed-mcp-server-names"; no_mcp_sentinel ]
+    | Some names -> List.iter (fun n -> add [ "--allowed-mcp-server-names"; n ]) names);
+  (match Cli_common_env.list "OAS_GEMINI_EXTENSIONS" with
+   | None | Some [] -> ()
+   | Some names -> List.iter (fun n -> add [ "-e"; n ]) names);
+  !extras
+;;
+
+(* Gemini CLI (>=0.38) has no dedicated system-prompt flag — earlier
+   builds accepted [--system-prompt], current builds reject it with
+   "Unknown arguments: system-prompt".  Prepend the system text to the
+   user prompt with labelled blocks so the model keeps the role
+   distinction without needing a CLI flag. *)
+let effective_prompt ~prompt ~system_prompt =
+  match system_prompt with
+  | None | Some "" -> prompt
+  | Some sp -> Printf.sprintf "[System]\n%s\n\n[User]\n%s" sp prompt
+;;
+
+let selected_model ~(config : config) ~(req_config : Provider_config.t) =
+  match String.trim req_config.model_id |> String.lowercase_ascii with
+  | "" | "auto" -> config.model
+  | _ -> Some req_config.model_id
+;;
+
+let build_args ~(config : config) ~(req_config : Provider_config.t) ~prompt ~system_prompt
+  =
+  let prompt = effective_prompt ~prompt ~system_prompt in
+  let args = ref [ config.gemini_path; "--output-format"; "json"; "-p"; prompt ] in
+  let add a = args := !args @ a in
+  (* Approval mode: env var wins over [config.yolo] when set, so callers
+     can demote a transport from yolo → plan without a code change. *)
+  (match Cli_common_env.get "OAS_GEMINI_APPROVAL_MODE" with
+   | Some m -> add [ "--approval-mode"; m ]
+   | None -> if config.yolo then add [ "--yolo" ]);
+  (* "auto" means "use the CLI's configured default", so omit [--model]. *)
+  let model = selected_model ~config ~req_config in
+  (match model with
+   | Some m -> add [ "--model"; m ]
+   | None -> ());
+  add (env_extra_args ());
+  !args
+;;
+
+(* ── JSON parsing ────────────────────────────────────── *)
+
+(** Parse and aggregate usage across [stats.models] entries in a Gemini
+    CLI [--output-format json] response.  The CLI may invoke multiple
+    models for a single prompt (e.g. a utility router + a main model),
+    each with its own per-model token counts:
+
+    {v
+    "stats": {
+      "models": {
+        "gemini-2.5-flash-lite": {
+          "tokens": { "input": N, "candidates": N, "cached": N }
+        },
+        "gemini-3-flash-preview": {
+          "tokens": { ... }
+        }
+      }
+    }
+    v}
+
+    We sum [tokens.input], [tokens.candidates], and [tokens.cached]
+    across every model.  Returns [None] when no [stats.models] object
+    is present. *)
+let parse_usage json =
+  let open Yojson.Safe.Util in
+  let models_field =
+    try json |> member "stats" |> member "models" with
+    | Type_error _ -> `Null
+  in
+  match models_field with
+  | `Assoc entries when entries <> [] ->
+    let input = ref 0 in
+    let output = ref 0 in
+    let cached = ref 0 in
+    List.iter
+      (fun (_model_name, model_json) ->
+         match model_json |> member "tokens" with
+         | `Assoc _ as t ->
+           input := !input + Cli_common_json.member_int "input" t;
+           output := !output + Cli_common_json.member_int "candidates" t;
+           cached := !cached + Cli_common_json.member_int "cached" t
+         | _ -> ())
+      entries;
+    Some
+      { Types.input_tokens = !input
+      ; output_tokens = !output
+      ; cache_creation_input_tokens = 0
+      ; cache_read_input_tokens = !cached
+      ; cost_usd = None
+      }
+  | _ -> None
+;;
+
+(** Parse the Gemini CLI [--output-format json] result into an
+    [api_response].  Expected shape:
+
+    {v
+    { "session_id": "...",
+      "response": "text",
+      "stats": { "models": { ... } } }
+    v} *)
+let parse_json_result json_str =
+  try
+    let json = Yojson.Safe.from_string json_str in
+    let response_text = Cli_common_json.member_str "response" json in
+    let session_id = Cli_common_json.member_str "session_id" json in
+    let usage = parse_usage json in
+    Ok
+      { Types.id = session_id
+      ; model = "gemini"
+      ; stop_reason = Types.EndTurn
+      ; content = [ Text response_text ]
+      ; usage
+      ; telemetry = None
+      }
+  with
+  | Yojson.Json_error msg ->
+    Error
+      (Http_client.NetworkError
+         { message = Printf.sprintf "JSON parse error: %s" msg; kind = Unknown })
+;;
+
+(* ── Transport constructor ───────────────────────────── *)
+
+(** Strip API-key env so [gemini] uses the user's Google OAuth session
+    rather than a metered API key.  Mirrors the rationale in
+    {!Transport_claude_code.claude_cli_scrub_env}. *)
+let gemini_cli_scrub_env =
+  [ "GEMINI_API_KEY"; "GOOGLE_API_KEY"; "GOOGLE_APPLICATION_CREDENTIALS" ]
+;;
+
+(* Stderr markers the gemini CLI emits when it is looping internally on
+   429 MODEL_CAPACITY_EXHAUSTED from cloudcode-pa.googleapis.com.  Each
+   retry wall-clocks ~8 s (server-timing gfet4t7;dur≥8000) and the CLI
+   typically attempts 5 before giving up, so a single upstream 429 can
+   block a cascade call for 30–60 s.  When we see the first marker, we
+   trip [cancel] so the CLI receives [SIGINT] and the cascade can move
+   on to the next provider immediately. *)
+let capacity_exhausted_markers =
+  [ "MODEL_CAPACITY_EXHAUSTED"
+  ; "RESOURCE_EXHAUSTED"
+  ; "No capacity available"
+  ; "rateLimitExceeded"
+  ]
+;;
+
+let startup_crash_markers =
+  [ "Detected unsettled top-level await"; "yoga_wasm_base64_esm_default" ]
+;;
+
+let substring_found line needle =
+  let hl = String.length line
+  and nl = String.length needle in
+  if nl = 0 || nl > hl
+  then false
+  else (
+    let rec scan i =
+      if i + nl > hl
+      then false
+      else if String.sub line i nl = needle
+      then true
+      else scan (i + 1)
+    in
+    scan 0)
+;;
+
+let find_substring line needle =
+  let hl = String.length line
+  and nl = String.length needle in
+  if nl = 0 || nl > hl
+  then None
+  else (
+    let rec scan i =
+      if i + nl > hl
+      then None
+      else if String.sub line i nl = needle
+      then Some i
+      else scan (i + 1)
+    in
+    scan 0)
+;;
+
+let quoted_after line prefix =
+  match find_substring line prefix with
+  | None -> None
+  | Some prefix_idx ->
+    let start = prefix_idx + String.length prefix in
+    let rec find_close i =
+      if i >= String.length line
+      then None
+      else if line.[i] = '"'
+      then Some i
+      else find_close (i + 1)
+    in
+    find_close start |> Option.map (fun stop -> String.sub line start (stop - start))
+;;
+
+let rule_after line =
+  match find_substring line "Rule #" with
+  | None -> None
+  | Some idx ->
+    let start = idx + String.length "Rule #" in
+    let rec scan_digits i =
+      if i >= String.length line
+      then i
+      else (
+        match line.[i] with
+        | '0' .. '9' -> scan_digits (i + 1)
+        | _ -> i)
+    in
+    let stop = scan_digits start in
+    if stop = start
+    then None
+    else String.sub line start (stop - start) |> int_of_string_opt
+;;
+
+let contains_all_markers haystack markers =
+  List.for_all (substring_found haystack) markers
+;;
+
+let provider_failure_of_stderr_line ?model line =
+  if substring_found line "Unrecognized tool name"
+  then
+    Some
+      (Http_client.Cli_policy_invalid
+         { tool_name = quoted_after line "Unrecognized tool name \""
+         ; rule = rule_after line
+         })
+  else if List.exists (substring_found line) capacity_exhausted_markers
+  then
+    Some
+      (Http_client.Capacity_exhausted
+         { scope = Http_client.Failure_scope_model; retry_after = None; model })
+  else None
+;;
+
+let classify_cli_error = function
+  | Error (Http_client.NetworkError { message; _ })
+    when contains_all_markers message startup_crash_markers ->
+    Error
+      (Http_client.AcceptRejected
+         { reason =
+             "gemini_cli startup crash detected (unsettled top-level await / yoga_wasm). "
+             ^ "Known bad CLI runtime; rejecting without retry so the cascade can move \
+                on."
+         })
+  | other -> other
+;;
+
+let run ~sw ~mgr ~(config : config) ?model argv =
+  let fail_fast_enabled =
+    not (Cli_common_env.bool "OAS_GEMINI_CLI_NO_FAIL_FAST_ON_CAPACITY")
+  in
+  let failure_p, failure_r = Eio.Promise.create () in
+  let provider_failure = ref None in
+  let set_provider_failure kind =
+    match !provider_failure with
+    | Some _ -> ()
+    | None ->
+      provider_failure := Some kind;
+      if not (Eio.Promise.is_resolved failure_p) then Eio.Promise.resolve failure_r ()
+  in
+  let on_stderr_line line =
+    Cli_common_subprocess.default_on_stderr_line ~name:"gemini" line;
+    match provider_failure_of_stderr_line ?model line with
+    | Some (Http_client.Capacity_exhausted _ as kind) ->
+      if fail_fast_enabled then set_provider_failure kind
+    | Some kind -> set_provider_failure kind
+    | None -> ()
+  in
+  (* Merge the upstream cancel (if any) with the provider-failure signal
+     so either one triggers a SIGINT on the CLI. *)
+  let merged_cancel =
+    match config.cancel with
+    | None -> Some failure_p
+    | Some upstream ->
+      let merged_p, merged_r = Eio.Promise.create () in
+      let resolve_once () =
+        if not (Eio.Promise.is_resolved merged_p) then Eio.Promise.resolve merged_r ()
+      in
+      Eio.Fiber.fork ~sw (fun () ->
+        Eio.Promise.await upstream;
+        resolve_once ());
+      Eio.Fiber.fork ~sw (fun () ->
+        Eio.Promise.await failure_p;
+        resolve_once ());
+      Some merged_p
+  in
+  let result =
+    Cli_common_subprocess.run_collect
+      ~sw
+      ~mgr
+      ~name:"gemini"
+      ~cwd:config.cwd
+      ~extra_env:[]
+      ~scrub_env:gemini_cli_scrub_env
+      ~on_stderr_line
+      ?cancel:merged_cancel
+      argv
+  in
+  match result, !provider_failure with
+  | _, Some kind ->
+    Error
+      (Http_client.ProviderFailure
+         { kind
+         ; message =
+             "gemini_cli stderr reported a provider/runtime failure; aborted early so \
+              the cascade can move on."
+         })
+  | r, None -> classify_cli_error r
+;;
+
+(* Fires once per transport instance when any Claude-only config field
+   is set.  Gemini CLI has no flag for these yet, so we warn and drop. *)
+let warn_unsupported_once (config : config) warned =
+  if !warned
+  then ()
+  else (
+    warned := true;
+    let warn field =
+      Eio.traceln "[warn] %s is not supported by gemini_cli, ignoring" field
+    in
+    if Option.is_some config.mcp_config then warn "mcp_config";
+    if config.allowed_tools <> [] then warn "allowed_tools";
+    if Option.is_some config.max_turns then warn "max_turns";
+    if Option.is_some config.permission_mode then warn "permission_mode")
+;;
+
+let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
+  let warned = ref false in
+  { complete_sync =
+      (fun (req : Llm_transport.completion_request) ->
+        match req.runtime_mcp_policy with
+        | Some _ ->
+          { Llm_transport.response =
+              Error
+                (Http_client.ProviderFailure
+                   { kind =
+                       Http_client.Capability_mismatch
+                         { capability = Some "request_scoped_runtime_mcp" }
+                   ; message =
+                       "gemini_cli does not support request-scoped runtime MCP \
+                        configuration"
+                   })
+          ; latency_ms = 0
+          }
+        | None ->
+          warn_unsupported_once config warned;
+          let messages = Cli_common_prompt.non_system_messages req.messages in
+          let prompt = Cli_common_prompt.prompt_of_messages messages in
+          let system_prompt =
+            Cli_common_prompt.system_prompt_of ~req_config:req.config req.messages
+          in
+          let argv = build_args ~config ~req_config:req.config ~prompt ~system_prompt in
+          let model = selected_model ~config ~req_config:req.config in
+          (match run ~sw ~mgr ~config ?model argv with
+           | Error _ as e -> { Llm_transport.response = e; latency_ms = 0 }
+           | Ok { stdout; stderr = _; latency_ms } ->
+             let response = parse_json_result (String.trim stdout) in
+             { Llm_transport.response; latency_ms }))
+  ; complete_stream =
+      (fun ~on_event (req : Llm_transport.completion_request) ->
+        match req.runtime_mcp_policy with
+        | Some _ ->
+          Error
+            (Http_client.ProviderFailure
+               { kind =
+                   Http_client.Capability_mismatch
+                     { capability = Some "request_scoped_runtime_mcp" }
+               ; message =
+                   "gemini_cli does not support request-scoped runtime MCP configuration"
+               })
+        | None ->
+          warn_unsupported_once config warned;
+          let messages = Cli_common_prompt.non_system_messages req.messages in
+          let prompt = Cli_common_prompt.prompt_of_messages messages in
+          let system_prompt =
+            Cli_common_prompt.system_prompt_of ~req_config:req.config req.messages
+          in
+          let argv = build_args ~config ~req_config:req.config ~prompt ~system_prompt in
+          let model = selected_model ~config ~req_config:req.config in
+          (* Gemini CLI does not support native streaming; replay synthetic events
+         after the sync call completes. *)
+          (match run ~sw ~mgr ~config ?model argv with
+           | Error _ as e -> e
+           | Ok { stdout; stderr = _; latency_ms = _ } ->
+             let result = parse_json_result (String.trim stdout) in
+             (match result with
+              | Ok resp ->
+                Cli_common_synthetic_events.replay ~on_event resp;
+                Ok resp
+              | Error _ as e -> e)))
+  }
+;;
+
+(* ── Inline tests ────────────────────────────────────── *)
+
+[@@@coverage off]
+
+let%test "default_config gemini_path" = default_config.gemini_path = "gemini"
+let%test "default_config yolo true" = default_config.yolo = true
+
+let%test "build_args basic with yolo" =
+  let args =
+    build_args
+      ~config:default_config
+      ~req_config:(Provider_config.make ~kind:Claude_code ~model_id:"" ~base_url:"" ())
+      ~prompt:"hello"
+      ~system_prompt:None
+  in
+  List.mem "-p" args && List.mem "json" args && List.mem "--yolo" args
+;;
+
+let%test "build_args without yolo" =
+  let config = { default_config with yolo = false } in
+  let args =
+    build_args
+      ~config
+      ~req_config:(Provider_config.make ~kind:Claude_code ~model_id:"" ~base_url:"" ())
+      ~prompt:"hello"
+      ~system_prompt:None
+  in
+  List.mem "-p" args && not (List.mem "--yolo" args)
+;;
+
+let%test "build_args with model" =
+  let args =
+    build_args
+      ~config:default_config
+      ~req_config:
+        (Provider_config.make
+           ~kind:Claude_code
+           ~model_id:"gemini-2.5-pro"
+           ~base_url:""
+           ())
+      ~prompt:"hello"
+      ~system_prompt:(Some "be helpful")
+  in
+  List.mem "--model" args
+  && List.mem "gemini-2.5-pro" args
+  (* Gemini CLI has no --system-prompt flag; system text is folded into
+     the [-p] argument via [effective_prompt]. *)
+  && (not (List.mem "--system-prompt" args))
+  (* The labelled [-p] argument carries the system text now. *)
+  && List.exists
+       (fun a ->
+          let needle = "be helpful" in
+          let nl = String.length needle in
+          let al = String.length a in
+          let rec scan i =
+            if i + nl > al
+            then false
+            else if String.sub a i nl = needle
+            then true
+            else scan (i + 1)
+          in
+          scan 0)
+       args
+;;
+
+let%test "effective_prompt: None → passthrough" =
+  effective_prompt ~prompt:"hi" ~system_prompt:None = "hi"
+;;
+
+let%test "effective_prompt: empty → passthrough" =
+  effective_prompt ~prompt:"hi" ~system_prompt:(Some "") = "hi"
+;;
+
+let%test "effective_prompt: labelled blocks" =
+  effective_prompt ~prompt:"user" ~system_prompt:(Some "sys")
+  = "[System]\nsys\n\n[User]\nuser"
+;;
+
+let%test "build_args omits auto model override" =
+  let args =
+    build_args
+      ~config:default_config
+      ~req_config:
+        (Provider_config.make ~kind:Claude_code ~model_id:"auto" ~base_url:"" ())
+      ~prompt:"hello"
+      ~system_prompt:None
+  in
+  not (List.mem "--model" args)
+;;
+
+let%test "default_config parity fields absent" =
+  default_config.mcp_config = None
+  && default_config.allowed_tools = []
+  && default_config.max_turns = None
+  && default_config.permission_mode = None
+;;
+
+let%test "build_args ignores mcp_config and allowed_tools" =
+  let config =
+    { default_config with
+      mcp_config = Some "/tmp/mcp.json"
+    ; allowed_tools = [ "Read"; "Write" ]
+    ; max_turns = Some 3
+    ; permission_mode = Some "bypassPermissions"
+    }
+  in
+  let args =
+    build_args
+      ~config
+      ~req_config:(Provider_config.make ~kind:Claude_code ~model_id:"" ~base_url:"" ())
+      ~prompt:"hello"
+      ~system_prompt:None
+  in
+  (not (List.mem "--mcp-config" args))
+  && (not (List.mem "--allowedTools" args))
+  && (not (List.mem "--max-turns" args))
+  && (not (List.mem "--permission-mode" args))
+  && not (List.mem "/tmp/mcp.json" args)
+;;
+
+let%test "parse_json_result success (single model stats)" =
+  let json =
+    {|{"session_id":"sid","response":"hello world","stats":{"models":{"gemini-2.5-flash":{"tokens":{"input":10,"candidates":5,"cached":2}}}}}|}
+  in
+  match parse_json_result json with
+  | Ok resp ->
+    resp.content = [ Types.Text "hello world" ]
+    && resp.stop_reason = Types.EndTurn
+    && resp.id = "sid"
+    &&
+      (match resp.usage with
+      | Some u ->
+        u.input_tokens = 10 && u.output_tokens = 5 && u.cache_read_input_tokens = 2
+      | None -> false)
+  | Error _ -> false
+;;
+
+let%test "parse_json_result aggregates across multiple models" =
+  let json =
+    {|{"session_id":"sid","response":"hi","stats":{"models":{"utility":{"tokens":{"input":100,"candidates":7,"cached":0}},"main":{"tokens":{"input":200,"candidates":3,"cached":5}}}}}|}
+  in
+  match parse_json_result json with
+  | Ok resp ->
+    (match resp.usage with
+     | Some u ->
+       u.input_tokens = 300 && u.output_tokens = 10 && u.cache_read_input_tokens = 5
+     | None -> false)
+  | Error _ -> false
+;;
+
+let%test "parse_json_result no usage" =
+  let json = {|{"response":"hello"}|} in
+  match parse_json_result json with
+  | Ok resp -> resp.content = [ Types.Text "hello" ] && resp.usage = None
+  | Error _ -> false
+;;
+
+let%test "parse_json_result invalid json" =
+  match parse_json_result "not json" with
+  | Error _ -> true
+  | Ok _ -> false
+;;
+
+let%test "classify_cli_error reclassifies gemini startup crash as AcceptRejected" =
+  let err =
+    Error
+      (Http_client.NetworkError
+         { message =
+             "gemini exited with code 13: Warning: Detected unsettled top-level await\n\
+              var Yoga = wrapAssembly(await yoga_wasm_base64_esm_default());"
+         ; kind = Unknown
+         })
+  in
+  match classify_cli_error err with
+  | Error (Http_client.AcceptRejected { reason }) ->
+    substring_found reason "startup crash"
+  | _ -> false
+;;
+
+let%test "classify_cli_error keeps unrelated network failures retryable" =
+  let err =
+    Error
+      (Http_client.NetworkError
+         { message = "gemini exited with code 1: connection refused"; kind = Unknown })
+  in
+  match classify_cli_error err with
+  | Error (Http_client.NetworkError { message; _ }) ->
+    substring_found message "connection refused"
+  | _ -> false
+;;
+
+let%test "provider_failure_of_stderr_line detects model capacity" =
+  match
+    provider_failure_of_stderr_line
+      ~model:"gemini-2.5-pro"
+      {|Attempt 1 failed with status 429. "reason": "MODEL_CAPACITY_EXHAUSTED"|}
+  with
+  | Some
+      (Http_client.Capacity_exhausted
+         { scope = Http_client.Failure_scope_model; model = Some "gemini-2.5-pro"; _ }) ->
+    true
+  | _ -> false
+;;
+
+let%test "provider_failure_of_stderr_line extracts invalid policy tool" =
+  match
+    provider_failure_of_stderr_line
+      {|Rule #248: Unrecognized tool name "glm". Did you mean one of: "glob"?|}
+  with
+  | Some (Http_client.Cli_policy_invalid { tool_name = Some "glm"; rule = Some 248 }) ->
+    true
+  | _ -> false
+;;
+
+(* ── env-driven extra args ──────────────────────────── *)
+
+let with_env k v f =
+  let prev = Sys.getenv_opt k in
+  Unix.putenv k v;
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with
+      | None ->
+        (try Unix.putenv k "" with
+         | _ -> ())
+      | Some old -> Unix.putenv k old)
+    f
+;;
+
+let with_unset k f =
+  let prev = Sys.getenv_opt k in
+  (try Unix.putenv k "" with
+   | _ -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with
+      | None -> ()
+      | Some old -> Unix.putenv k old)
+    f
+;;
+
+let gemini_req = Provider_config.make ~kind:Gemini_cli ~model_id:"" ~base_url:"" ()
+
+let%test "env: approval-mode supersedes config.yolo" =
+  with_env "OAS_GEMINI_APPROVAL_MODE" "plan" (fun () ->
+    let args =
+      build_args
+        ~config:default_config
+        ~req_config:gemini_req
+        ~prompt:"hi"
+        ~system_prompt:None
+    in
+    List.mem "--approval-mode" args
+    && List.mem "plan" args
+    && not (List.mem "--yolo" args))
+;;
+
+let%test "env: OAS_GEMINI_NO_MCP disables all MCP via sentinel whitelist" =
+  with_env "OAS_GEMINI_NO_MCP" "1" (fun () ->
+    let args =
+      build_args
+        ~config:default_config
+        ~req_config:gemini_req
+        ~prompt:"hi"
+        ~system_prompt:None
+    in
+    let rec has_pair = function
+      | "--allowed-mcp-server-names" :: name :: _ when name = no_mcp_sentinel -> true
+      | _ :: rest -> has_pair rest
+      | [] -> false
+    in
+    has_pair args && not (List.mem "" args))
+;;
+
+let%test "env: OAS_GEMINI_ALLOWED_MCP whitelist" =
+  with_env "OAS_GEMINI_ALLOWED_MCP" "alpha,beta" (fun () ->
+    let args =
+      build_args
+        ~config:default_config
+        ~req_config:gemini_req
+        ~prompt:"hi"
+        ~system_prompt:None
+    in
+    List.mem "alpha" args && List.mem "beta" args)
+;;
+
+let%test "env: OAS_GEMINI_EXTENSIONS splits on comma" =
+  with_env "OAS_GEMINI_EXTENSIONS" "ext-a,ext-b" (fun () ->
+    let args =
+      build_args
+        ~config:default_config
+        ~req_config:gemini_req
+        ~prompt:"hi"
+        ~system_prompt:None
+    in
+    List.mem "-e" args && List.mem "ext-a" args && List.mem "ext-b" args)
+;;
+
+let%test "default: no vars still keeps MCP disabled via sentinel" =
+  with_unset "OAS_GEMINI_ALLOWED_MCP" (fun () ->
+    with_unset "OAS_GEMINI_APPROVAL_MODE" (fun () ->
+      with_unset "OAS_GEMINI_EXTENSIONS" (fun () ->
+        with_unset "OAS_GEMINI_NO_MCP" (fun () ->
+          let args =
+            build_args
+              ~config:default_config
+              ~req_config:gemini_req
+              ~prompt:"hi"
+              ~system_prompt:None
+          in
+          let rec has_sentinel_whitelist = function
+            | "--allowed-mcp-server-names" :: name :: _ when name = no_mcp_sentinel ->
+              true
+            | _ :: rest -> has_sentinel_whitelist rest
+            | [] -> false
+          in
+          (* default_config.yolo = true, so --yolo must appear. *)
+          List.mem "--yolo" args
+          && (not (List.mem "--approval-mode" args))
+          && has_sentinel_whitelist args
+          && not (List.mem "" args)))))
+;;
+
+let runtime_mcp_policy_sample =
+  { Llm_transport.empty_runtime_mcp_policy with
+    servers =
+      [ Llm_transport.Http_server
+          { name = "example"; url = "http://127.0.0.1:9999/mcp"; headers = [] }
+      ]
+  ; allowed_server_names = [ "example" ]
+  ; allowed_tool_names = [ "example_status" ]
+  }
+;;
+
+let runtime_mcp_req_sample : Llm_transport.completion_request =
+  { config = gemini_req
+  ; messages = []
+  ; tools = []
+  ; runtime_mcp_policy = Some runtime_mcp_policy_sample
+  }
+;;
+
+let runtime_mcp_policy_error_message =
+  "gemini_cli does not support request-scoped runtime MCP configuration"
+;;
+
+let%test_unit "complete_sync rejects request-scoped runtime MCP policy" =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let transport = create ~sw ~mgr:(Eio.Stdenv.process_mgr env) ~config:default_config in
+  match transport.complete_sync runtime_mcp_req_sample with
+  | { response =
+        Error
+          (Http_client.ProviderFailure
+             { kind =
+                 Http_client.Capability_mismatch
+                   { capability = Some "request_scoped_runtime_mcp" }
+             ; message
+             })
+    ; latency_ms = 0
+    } -> assert (String.equal message runtime_mcp_policy_error_message)
+  | _ -> assert false
+;;
+
+let%test_unit "complete_stream rejects request-scoped runtime MCP policy" =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let transport = create ~sw ~mgr:(Eio.Stdenv.process_mgr env) ~config:default_config in
+  match transport.complete_stream ~on_event:(fun _ -> ()) runtime_mcp_req_sample with
+  | Error
+      (Http_client.ProviderFailure
+         { kind =
+             Http_client.Capability_mismatch
+               { capability = Some "request_scoped_runtime_mcp" }
+         ; message
+         }) -> assert (String.equal message runtime_mcp_policy_error_message)
+  | _ -> assert false
+;;

--- a/masc_mcp.opam.locked
+++ b/masc_mcp.opam.locked
@@ -1,0 +1,125 @@
+opam-version: "2.0"
+name: "masc_mcp"
+version: "0.18.13"
+synopsis: "Multi-Agent Streaming Coordination MCP Server in OCaml"
+description:
+  "MASC Protocol: File-based coordination for Claude, Gemini, and Codex agents"
+maintainer: "Jeongsik Yun"
+authors: "Jeongsik Yun"
+license: "MIT"
+homepage: "https://github.com/jeong-sik/masc-mcp"
+doc: "https://github.com/jeong-sik/masc-mcp"
+bug-reports: "https://github.com/jeong-sik/masc-mcp/issues"
+depends: [
+  "agent_sdk" {= "0.184.0"}
+  "alcotest" {with-test & = "1.9.1"}
+  "ambient-context-eio" {= "0.2"}
+  "bigstringaf" {= "0.10.0"}
+  "bisect_ppx" {with-test & = "2.8.3"}
+  "ca-certs" {= "1.0.1"}
+  "cmdliner" {= "2.1.0"}
+  "cohttp" {= "6.2.1"}
+  "cohttp-eio" {= "6.2.1"}
+  "crunch" {= "4.0.0"}
+  "cstruct" {= "6.2.0"}
+  "ctypes" {= "0.24.0"}
+  "ctypes-foreign" {= "0.24.0"}
+  "digestif" {= "1.3.0"}
+  "domain-name" {= "0.5.0"}
+  "dune" {= "3.22.0"}
+  "eio" {= "1.3"}
+  "eio_main" {= "1.3"}
+  "eio_posix" {= "1.3"}
+  "graphql" {= "0.14.0"}
+  "graphql_parser" {= "0.14.0"}
+  "grpc-direct" {= "0.2.6"}
+  "grpc-direct-core" {= "0.2.6"}
+  "h2" {= "0.13.0"}
+  "h2-eio" {= "0.13.0"}
+  "httpun" {= "0.2.0"}
+  "httpun-eio" {= "0.2.0"}
+  "httpun-ws" {= "0.2.0"}
+  "httpun-ws-eio" {= "0.2.0"}
+  "integers" {= "0.7.0"}
+  "mcp_protocol" {= "1.3.0"}
+  "mirage-crypto" {= "1.2.0"}
+  "mirage-crypto-rng" {= "1.2.0"}
+  "mtime" {= "2.1.0"}
+  "neo4j_bolt_eio" {= "0.5.1"}
+  "ocaml" {= "5.4.1"}
+  "ocaml-protoc-plugin" {= "6.2.0"}
+  "ocaml-webrtc" {= "0.2.6"}
+  "odoc" {= "3.1.0" & with-doc}
+  "opentelemetry" {= "0.13"}
+  "otoml" {= "1.0.5"}
+  "pbrt" {= "3.1.1"}
+  "pbrt_services" {= "3.1.1"}
+  "ppx_deriving" {= "6.1.1"}
+  "ppx_deriving_yojson" {= "3.10.0"}
+  "ppx_let" {= "v0.17.1"}
+  "ppxlib" {= "0.37.0"}
+  "qcheck-alcotest" {with-test & = "0.91"}
+  "qcheck-core" {with-test & = "0.91"}
+  "re" {= "1.14.0"}
+  "sqlite3" {= "5.4.0"}
+  "tls" {= "2.0.4"}
+  "tls-eio" {= "2.0.4"}
+  "uri" {= "4.4.0"}
+  "uuidm" {= "0.9.10"}
+  "yojson" {= "3.0.0"}
+  "zstd" {= "0.4"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jeong-sik/masc-mcp.git"
+pin-depends: [
+  [
+    "agent_sdk.0.184.0"
+    "git+https://github.com/jeong-sik/oas.git#dff39bb4e4894a39a9c0a5817030f5cce97d98f9"
+  ]
+  [
+    "bisect_ppx.2.8.3"
+    "git+https://github.com/patricoferris/bisect_ppx.git#5.2"
+  ]
+  [
+    "grpc-direct.0.2.6"
+    "git+https://github.com/jeong-sik/grpc-direct.git#840b6cd6fe822d3577aa26147e7dc71ca25abecc"
+  ]
+  [
+    "grpc-direct-core.0.2.6"
+    "git+https://github.com/jeong-sik/grpc-direct.git#840b6cd6fe822d3577aa26147e7dc71ca25abecc"
+  ]
+  [
+    "mcp_protocol.1.3.0"
+    "git+https://github.com/jeong-sik/mcp-protocol-sdk.git#v1.3.0"
+  ]
+  [
+    "neo4j_bolt_common.0.5.1"
+    "git+https://github.com/jeong-sik/ocaml-neo4j-bolt.git#a1ca30c1247db5c58934e99306fe330419f7b21a"
+  ]
+  [
+    "neo4j_bolt_eio.0.5.1"
+    "git+https://github.com/jeong-sik/ocaml-neo4j-bolt.git#a1ca30c1247db5c58934e99306fe330419f7b21a"
+  ]
+  [
+    "neo4j_packstream.0.5.1"
+    "git+https://github.com/jeong-sik/ocaml-neo4j-bolt.git#a1ca30c1247db5c58934e99306fe330419f7b21a"
+  ]
+  [
+    "ocaml-webrtc.0.2.6"
+    "git+https://github.com/jeong-sik/ocaml-webrtc.git#1b7993605b293f45169369d488f970ba15132a9f"
+  ]
+]
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
## 📌 변경 사항 요약 (Summary)
이번 PR은 OAS의 Execution Manifest 및 Contract 타입을 확장하여 MASC의 Cascade 라우팅과 완벽히 호환되도록 구성합니다.

## 🛠️ 주요 변경 사항
- **Issue #1-oas / #2-oas**: `Contract.t` 및 `execution_manifest.ml`에 `provider_health` 리스트 및 `rate_limit_quota` 옵션 추가. 이를 통해 MASC가 사전에 쿼터를 관리할 수 있도록 함.
- **Issue #3-oas**: `Risk_class`별로 Cascade 전략 매핑 (`cascade_strategy_for_risk`).
  - Critical: 3회 재시도 / 15s 타임아웃 / Fallback 허용
  - High: 2회 재시도 / 30s 타임아웃 / Fallback 허용
  - Medium: 1회 재시도 / 60s 타임아웃 / Fallback 허용
  - Low: 0회 재시도 / 120s 타임아웃 / Fallback 불허