### PR TITLE
fix(llm_provider): remove anti-patterns across 6 LLM backends

### DIFF
--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -121,7 +121,7 @@ let build_request
       let budget =
         match config.thinking_budget with
         | Some b -> b
-        | None -> 10000
+        | None -> Constants.Thinking.default_budget
       in
       ("thinking", `Assoc [ "type", `String "enabled"; "budget_tokens", `Int budget ])
       :: body

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -60,7 +60,12 @@ let part_of_content_block id_to_name = function
     let name =
       match Hashtbl.find_opt id_to_name tool_use_id with
       | Some n -> n
-      | None -> tool_use_id
+      | None ->
+        Diag.warn "backend_gemini"
+          "ToolResult tool_use_id '%s' has no matching ToolUse; \
+           using UUID as functionResponse name (Gemini API requires name)"
+          tool_use_id;
+        tool_use_id
     in
     Some
       (`Assoc
@@ -187,7 +192,7 @@ let build_request
      let budget =
        match config.thinking_budget with
        | Some b -> b
-       | None -> 10000
+       | None -> Constants.Thinking.default_budget
      in
      gen_config
      := ( "thinkingConfig"

--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -23,6 +23,7 @@ type glm_error =
   { code : string
   ; message : string
   ; error_class : glm_error_class
+  ; is_retryable : bool
   }
 
 let contains_ci ~haystack ~needle =
@@ -54,7 +55,7 @@ let contains_ci ~haystack ~needle =
     - 1304,1308,1310: quota exhausted (cascadeable, not retryable)
     - 1309,1311,1313: subscription/plan (quota)
     - 1230,1234,500: server error *)
-let classify_glm_error ~code ~message : glm_error_class =
+let classify_glm_error ~code ~message : glm_error_class * bool =
   match code with
   | "1000"
   | "1001"
@@ -66,10 +67,11 @@ let classify_glm_error ~code ~message : glm_error_class =
   | "1111"
   | "1112"
   | "1120"
-  | "1220" -> Glm_auth_error
-  | "1302" | "1303" | "1305" | "1312" -> Glm_rate_limited
-  | "1113" | "1304" | "1308" | "1309" | "1310" | "1311" | "1313" -> Glm_quota_exceeded
-  | "1230" | "1234" | "500" -> Glm_server_error
+  | "1220" -> (Glm_auth_error, false)
+  | "1302" | "1303" | "1305" | "1312" -> (Glm_rate_limited, true)
+  | "1113" | "1304" | "1308" | "1309" | "1310" | "1311" | "1313" ->
+    (Glm_quota_exceeded, false)
+  | "1230" | "1234" | "500" -> (Glm_server_error, true)
   | "1300"
   | "1301"
   | "1200"
@@ -80,16 +82,16 @@ let classify_glm_error ~code ~message : glm_error_class =
   | "1214"
   | "1215"
   | "1231"
-  | "1261" -> Glm_invalid_request
+  | "1261" -> (Glm_invalid_request, false)
   | _ ->
     if
       contains_ci ~haystack:message ~needle:"usage limit"
       || contains_ci ~haystack:message ~needle:"quota"
       || contains_ci ~haystack:message ~needle:"exceeded"
-    then Glm_quota_exceeded
+    then (Glm_quota_exceeded, false)
     else if contains_ci ~haystack:message ~needle:"rate limit"
-    then Glm_rate_limited
-    else Glm_invalid_request
+    then (Glm_rate_limited, true)
+    else (Glm_invalid_request, false)
 ;;
 
 let http_code_of_glm_error_class = function
@@ -127,11 +129,6 @@ let build_request
         ("thinking", thinking) :: fields
       | None -> fields
     in
-    (* Strip chat_template_kwargs leaked from Backend_openai.
-         GLM does not recognize this llama.cpp/Ollama-specific field and
-         returns "Invalid API parameter" when present.  GLM thinking is
-         handled above via the native [thinking] parameter. *)
-    let fields = List.filter (fun (k, _) -> k <> "chat_template_kwargs") fields in
     let fields =
       if stream && config.tool_stream
       then ("tool_stream", `Bool true) :: fields
@@ -165,8 +162,8 @@ let check_glm_error body : glm_error option =
         |> to_string_option
         |> Option.value ~default:"Unknown GLM API error"
       in
-      let error_class = classify_glm_error ~code ~message in
-      Some { code; message; error_class }
+      let error_class, is_retryable = classify_glm_error ~code ~message in
+      Some { code; message; error_class; is_retryable }
   with
   | Yojson.Json_error _ -> None
 ;;
@@ -200,7 +197,7 @@ let parse_response body =
      | Error msg ->
        raise
          (Glm_api_error
-            { code = "parse"; message = msg; error_class = Glm_invalid_request })
+            { code = "parse"; message = msg; error_class = Glm_invalid_request; is_retryable = false })
      | Ok resp -> extract_reasoning_content resp body)
 ;;
 
@@ -338,31 +335,31 @@ let%test "classify quota exceeded from message" =
   classify_glm_error
     ~code:"unknown"
     ~message:"You have reached your specified API usage limits"
-  = Glm_quota_exceeded
+  = (Glm_quota_exceeded, false)
 ;;
 
 let%test "classify quota from code 1113 (arrears)" =
-  classify_glm_error ~code:"1113" ~message:"whatever" = Glm_quota_exceeded
+  classify_glm_error ~code:"1113" ~message:"whatever" = (Glm_quota_exceeded, false)
 ;;
 
 let%test "classify auth from code 1001" =
-  classify_glm_error ~code:"1001" ~message:"whatever" = Glm_auth_error
+  classify_glm_error ~code:"1001" ~message:"whatever" = (Glm_auth_error, false)
 ;;
 
 let%test "classify quota from code 1304 (daily limit)" =
-  classify_glm_error ~code:"1304" ~message:"whatever" = Glm_quota_exceeded
+  classify_glm_error ~code:"1304" ~message:"whatever" = (Glm_quota_exceeded, false)
 ;;
 
 let%test "classify quota from code 1308 (usage limit)" =
-  classify_glm_error ~code:"1308" ~message:"whatever" = Glm_quota_exceeded
+  classify_glm_error ~code:"1308" ~message:"whatever" = (Glm_quota_exceeded, false)
 ;;
 
 let%test "classify rate limited from code 1305" =
-  classify_glm_error ~code:"1305" ~message:"whatever" = Glm_rate_limited
+  classify_glm_error ~code:"1305" ~message:"whatever" = (Glm_rate_limited, true)
 ;;
 
 let%test "classify invalid request from code 1301 (unsafe content)" =
-  classify_glm_error ~code:"1301" ~message:"whatever" = Glm_invalid_request
+  classify_glm_error ~code:"1301" ~message:"whatever" = (Glm_invalid_request, false)
 ;;
 
 let%test "http_code quota maps to 429" =

--- a/lib/llm_provider/backend_glm.mli
+++ b/lib/llm_provider/backend_glm.mli
@@ -30,13 +30,14 @@ type glm_error =
   { code : string
   ; message : string
   ; error_class : glm_error_class
+  ; is_retryable : bool
   }
 
 exception Glm_api_error of glm_error
 
 (** Classify a GLM error code + message into a semantic class.
     Code-based classification takes priority; message keywords are fallback. *)
-val classify_glm_error : code:string -> message:string -> glm_error_class
+val classify_glm_error : code:string -> message:string -> glm_error_class * bool
 
 (** Map a GLM error class to the equivalent HTTP status code.
     Used by complete.ml to normalize provider-specific codes

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -218,7 +218,7 @@ let build_request
   let body =
     match config.enable_thinking with
     | Some enabled ->
-      if String.starts_with ~prefix:"deepseek-v4" config.model_id
+      if caps.uses_native_thinking_envelope
       then
         if enabled
         then (
@@ -231,6 +231,10 @@ let build_request
           :: ("thinking", `Assoc [ "type", `String "enabled" ])
           :: body)
         else ("thinking", `Assoc [ "type", `String "disabled" ]) :: body
+      else if config.kind = Glm
+      then body
+      (* GLM injects its own native [thinking] parameter in
+         backend_glm.ml; do not add chat_template_kwargs here. *)
       else ("chat_template_kwargs", `Assoc [ "enable_thinking", `Bool enabled ]) :: body
     | None -> body
   in

--- a/lib/llm_provider/backend_tool_call_harness.ml
+++ b/lib/llm_provider/backend_tool_call_harness.ml
@@ -1,0 +1,267 @@
+(** Tool-calling verification harness for LLM provider backends.
+
+    Validates that parsed API responses contain well-formed tool calls,
+    correct stop reasons, and no silently dropped content blocks.
+    Pure functions — no Eio, no network.
+
+    @since 0.187.7 *)
+
+open Types
+
+type tool_call_check =
+  { name : string
+  ; arguments_valid : bool
+  }
+
+type validation_result =
+  { tool_calls_found : tool_call_check list
+  ; stop_reason_correct : bool
+  ; all_tools_declared : bool
+  ; dropped_content_blocks : int
+  }
+
+let empty_result =
+  { tool_calls_found = []
+  ; stop_reason_correct = true
+  ; all_tools_declared = true
+  ; dropped_content_blocks = 0
+  }
+;;
+
+(** Validate a parsed {!api_response} against a set of declared tool names.
+
+    Checks:
+    - Every {!ToolUse} block has a name present in [declared_tools]
+    - Every {!ToolUse} block has parseable input (valid Yojson)
+    - [stop_reason] is {!StopToolUse} when tool calls exist, {!EndTurn} otherwise
+    - No content blocks were silently dropped during parse (heuristic: empty text) *)
+let validate_response ~declared_tools (resp : api_response) : validation_result =
+  let tool_calls =
+    List.filter_map
+      (function
+         | ToolUse { name; input; _ } ->
+           let arguments_valid = true (* any Yojson.t is valid JSON *) in
+           Some { name; arguments_valid }
+         | _ -> None)
+      resp.content
+  in
+  let has_tool_calls = tool_calls <> [] in
+  let stop_reason_correct =
+    match has_tool_calls, resp.stop_reason with
+    | true, StopToolUse -> true
+    | false, (EndTurn | MaxTokens | StopSequence) -> true
+    | _ -> false
+  in
+  let declared_set = List.sort_uniq String.compare declared_tools in
+  let all_tools_declared =
+    List.for_all
+      (fun (tc : tool_call_check) -> List.mem tc.name declared_set)
+      tool_calls
+  in
+  let dropped_content_blocks =
+    List.length
+      (List.filter
+         (function
+            | Text s when String.trim s = "" -> true
+            | _ -> false)
+         resp.content)
+  in
+  { tool_calls_found = tool_calls
+  ; stop_reason_correct
+  ; all_tools_declared
+  ; dropped_content_blocks
+  }
+;;
+
+let validate_anthropic_response ~declared_tools json =
+  validate_response ~declared_tools (Backend_anthropic.parse_response json)
+;;
+
+let validate_gemini_response ~declared_tools json =
+  validate_response ~declared_tools (Backend_gemini.parse_response json)
+;;
+
+let validate_openai_response ~declared_tools json =
+  let json_str = Yojson.Safe.to_string json in
+  match Backend_openai_parse.parse_openai_response_result json_str with
+  | Ok resp -> validate_response ~declared_tools resp
+  | Error _ -> empty_result
+;;
+
+(* ── Inline Tests ─────────────────────────────────────── *)
+
+let%test "anthropic tool_use response validates correctly" =
+  let json =
+    `Assoc
+      [ "id", `String "msg_123"
+      ; "model", `String "claude-4-sonnet"
+      ; "stop_reason", `String "tool_use"
+      ; "content",
+        `List
+          [ `Assoc
+              [ "type", `String "tool_use"
+              ; "id", `String "tu_001"
+              ; "name", `String "get_weather"
+              ; "input", `Assoc [ "city", `String "Seoul" ]
+              ]
+          ]
+      ; "usage",
+        `Assoc
+          [ "input_tokens", `Int 100
+          ; "output_tokens", `Int 50
+          ; "cache_creation_input_tokens", `Int 0
+          ; "cache_read_input_tokens", `Int 0
+          ]
+      ]
+  in
+  let result = validate_anthropic_response ~declared_tools:[ "get_weather" ] json in
+  result.stop_reason_correct
+  && result.all_tools_declared
+  && List.length result.tool_calls_found = 1
+  && (List.hd result.tool_calls_found).name = "get_weather"
+;;
+
+let%test "anthropic undeclared tool fails validation" =
+  let json =
+    `Assoc
+      [ "id", `String "msg_456"
+      ; "model", `String "claude-4-sonnet"
+      ; "stop_reason", `String "tool_use"
+      ; "content",
+        `List
+          [ `Assoc
+              [ "type", `String "tool_use"
+              ; "id", `String "tu_002"
+              ; "name", `String "unknown_tool"
+              ; "input", `Assoc []
+              ]
+          ]
+      ; "usage",
+        `Assoc
+          [ "input_tokens", `Int 10
+          ; "output_tokens", `Int 5
+          ; "cache_creation_input_tokens", `Int 0
+          ; "cache_read_input_tokens", `Int 0
+          ]
+      ]
+  in
+  let result = validate_anthropic_response ~declared_tools:[ "get_weather" ] json in
+  result.stop_reason_correct && not result.all_tools_declared
+;;
+
+let%test "gemini functionCall response validates correctly" =
+  let json =
+    `Assoc
+      [ "candidates",
+        `List
+          [ `Assoc
+              [ "content",
+                `Assoc
+                  [ "parts",
+                    `List
+                      [ `Assoc
+                          [ "functionCall",
+                            `Assoc
+                              [ "name", `String "search"
+                              ; "args", `Assoc [ "query", `String "OCaml 5" ]
+                              ]
+                          ]
+                      ]
+                  ]
+              ; "finishReason", `String "STOP"
+              ]
+          ]
+      ]
+  in
+  let result = validate_gemini_response ~declared_tools:[ "search" ] json in
+  result.stop_reason_correct
+  && result.all_tools_declared
+  && List.length result.tool_calls_found = 1
+;;
+
+let%test "openai tool_calls response validates correctly" =
+  let json =
+    `Assoc
+      [ "id", `String "chatcmpl-123"
+      ; "model", `String "gpt-4o"
+      ; "choices",
+        `List
+          [ `Assoc
+              [ "message",
+                `Assoc
+                  [ "role", `String "assistant"
+                  ; "content", `Null
+                  ; "tool_calls",
+                    `List
+                      [ `Assoc
+                          [ "id", `String "call_001"
+                          ; "type", `String "function"
+                          ; "function",
+                            `Assoc
+                              [ "name", `String "read_file"
+                              ; "arguments",
+                                `String {|{"path": "/etc/hosts"}|}
+                              ]
+                          ]
+                      ]
+                  ]
+              ; "finish_reason", `String "tool_calls"
+              ]
+          ]
+      ; "usage", `Assoc [ "prompt_tokens", `Int 50; "completion_tokens", `Int 20; "total_tokens", `Int 70 ]
+      ]
+  in
+  let result = validate_openai_response ~declared_tools:[ "read_file" ] json in
+  result.stop_reason_correct
+  && result.all_tools_declared
+  && List.length result.tool_calls_found = 1
+  && (List.hd result.tool_calls_found).name = "read_file"
+;;
+
+let%test "wrong stop_reason for tool calls fails validation" =
+  let json =
+    `Assoc
+      [ "id", `String "msg_bad"
+      ; "model", `String "claude-4-sonnet"
+      ; "stop_reason", `String "end_turn"
+      ; "content",
+        `List
+          [ `Assoc
+              [ "type", `String "tool_use"
+              ; "id", `String "tu_003"
+              ; "name", `String "test"
+              ; "input", `Assoc []
+              ]
+          ]
+      ; "usage",
+        `Assoc
+          [ "input_tokens", `Int 10
+          ; "output_tokens", `Int 5
+          ; "cache_creation_input_tokens", `Int 0
+          ; "cache_read_input_tokens", `Int 0
+          ]
+      ]
+  in
+  let result = validate_anthropic_response ~declared_tools:[ "test" ] json in
+  not result.stop_reason_correct
+;;
+
+let%test "text-only response passes validation" =
+  let json =
+    `Assoc
+      [ "id", `String "msg_text"
+      ; "model", `String "claude-4-sonnet"
+      ; "stop_reason", `String "end_turn"
+      ; "content", `List [ `Assoc [ "type", `String "text"; "text", `String "Hello" ] ]
+      ; "usage",
+        `Assoc
+          [ "input_tokens", `Int 10
+          ; "output_tokens", `Int 5
+          ; "cache_creation_input_tokens", `Int 0
+          ; "cache_read_input_tokens", `Int 0
+          ]
+      ]
+  in
+  let result = validate_anthropic_response ~declared_tools:[] json in
+  result.stop_reason_correct && result.all_tools_declared && result.tool_calls_found = []
+;;

--- a/lib/llm_provider/backend_tool_call_harness.mli
+++ b/lib/llm_provider/backend_tool_call_harness.mli
@@ -1,0 +1,35 @@
+(** Tool-calling verification harness for LLM provider backends.
+
+    Validates that parsed API responses contain well-formed tool calls,
+    correct stop reasons, and no silently dropped content blocks.
+    Pure functions — no Eio, no network.
+
+    @since 0.187.7 *)
+
+open Types
+
+type tool_call_check =
+  { name : string
+  ; arguments_valid : bool
+  }
+
+type validation_result =
+  { tool_calls_found : tool_call_check list
+  ; stop_reason_correct : bool
+  ; all_tools_declared : bool
+  ; dropped_content_blocks : int
+  }
+
+val empty_result : validation_result
+
+val validate_response :
+  declared_tools:string list -> api_response -> validation_result
+
+val validate_anthropic_response :
+  declared_tools:string list -> Yojson.Safe.t -> validation_result
+
+val validate_gemini_response :
+  declared_tools:string list -> Yojson.Safe.t -> validation_result
+
+val validate_openai_response :
+  declared_tools:string list -> Yojson.Safe.t -> validation_result

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -39,6 +39,12 @@ type capabilities =
   ; (* ── Advanced modalities ───────────────────────────── *)
     supports_computer_use : bool
   ; supports_code_execution : bool
+  ; (* ── Thinking wire format ────────────────────────────── *)
+    uses_native_thinking_envelope : bool
+  (** True when the provider's chat completions endpoint accepts a
+      native [thinking] parameter (e.g., DeepSeek V4's [type: enabled]).
+      False when thinking must be passed via a non-standard field like
+      Ollama's [chat_template_kwargs.enable_thinking]. *)
   ; (* ── Provider identity ───────────────────────────────── *)
     is_ollama : bool
   ; (* ── Usage reporting ─────────────────────────────────── *)
@@ -79,6 +85,7 @@ let default_capabilities =
   ; supports_min_p = false
   ; supports_computer_use = false
   ; supports_code_execution = false
+  ; uses_native_thinking_envelope = false
   ; is_ollama = false
   ; emits_usage_tokens = true (* stricter default: most providers report usage *)
   }
@@ -397,6 +404,7 @@ let for_model_id model_id =
       ; supports_response_format_json = true
       ; supports_native_streaming = true
       ; supports_caching = true
+      ; uses_native_thinking_envelope = true
       }
   else if starts_with "deepseek-v4-pro"
   then
@@ -412,6 +420,7 @@ let for_model_id model_id =
       ; supports_response_format_json = true
       ; supports_native_streaming = true
       ; supports_caching = true
+      ; uses_native_thinking_envelope = true
       }
   else if starts_with "mistral-large"
   then

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -38,6 +38,12 @@ type capabilities =
   ; (* Advanced modalities *)
     supports_computer_use : bool
   ; supports_code_execution : bool
+  ; (* Thinking wire format *)
+    uses_native_thinking_envelope : bool
+  (** True when the provider accepts a native [thinking] parameter.
+      False when thinking must go through [chat_template_kwargs] or
+      similar non-standard fields (e.g., Ollama).
+      @since 0.188.0 *)
   ; (* Provider identity *)
     is_ollama : bool
   ; (* Usage reporting *)

--- a/lib/llm_provider/constants.ml
+++ b/lib/llm_provider/constants.ml
@@ -148,6 +148,14 @@ module Endpoints = struct
   let localhost_prefix = "http://localhost"
 end
 
+(* ── Thinking ────────────────────────────────────── *)
+
+module Thinking = struct
+  (** Default extended thinking budget when not specified by caller.
+      Used by Anthropic and Gemini backends. *)
+  let default_budget = 10000
+end
+
 (* ── Anthropic ──────────────────────────────────── *)
 
 module Anthropic = struct

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -56,6 +56,8 @@ type capabilities =
   ; supports_min_p : bool
   ; supports_computer_use : bool
   ; supports_code_execution : bool
+  ; (* Thinking wire format *)
+    uses_native_thinking_envelope : bool
   ; (* Provider identity *)
     is_ollama : bool
   ; (* Usage reporting *)


### PR DESCRIPTION
## Summary

- **Step 0**: Add `backend_tool_call_harness` module — pure function validation for tool calling round-trips without live API calls
- **Step 1**: Extract hardcoded `10000` thinking budget to `Constants.Thinking.default_budget` (Anthropic + Gemini)
- **Step 2**: Add `Diag.warn` for Gemini orphaned ToolResult instead of silent UUID-as-name fallback
- **Step 3**: Add `is_retryable : bool` to GLM error classification — 20+ error codes now carry explicit retryability
- **Step 4**: Replace `String.starts_with ~prefix:"deepseek-v4"` with `uses_native_thinking_envelope` capability field
- **Step 5**: Prevent `chat_template_kwargs` from being added for GLM upstream, remove post-hoc `List.filter` strip

## Files changed (11)

| File | Change |
|------|--------|
| `backend_tool_call_harness.ml/mli` | New — tool calling round-trip harness |
| `constants.ml` | Add `Constants.Thinking.default_budget` |
| `backend_anthropic.ml` | Use `Constants.Thinking.default_budget` |
| `backend_gemini.ml` | Use constant + Diag.warn for orphaned ToolResult |
| `backend_glm.ml/mli` | `is_retryable` field, updated `classify_glm_error` return type |
| `backend_openai.ml` | Capability-based thinking path + GLM `chat_template_kwargs` prevention |
| `capabilities.ml/mli` | Add `uses_native_thinking_envelope` field |
| `provider.mli` | Sync capabilities type |

## Test plan

- [x] `dune build --root . --only-packages agent_sdk` — clean
- [x] `dune runtest --root . --only-packages agent_sdk lib/llm_provider/` — all inline tests pass
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)