### PR TITLE
fix(fmt): ocamlformat compliance followup for #1324

### DIFF
--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -218,24 +218,24 @@ let build_request
   in
   let body =
     match config.enable_thinking with
-    | Some enabled -> (
-      match caps.thinking_control_format with
-      | Thinking_object ->
-        if enabled
-        then (
-          let effort =
-            Provider_config.effort_of_thinking_config
-              ~enable_thinking:config.enable_thinking
-              ~thinking_budget:config.thinking_budget
-          in
-          ("reasoning_effort", `String effort)
-          :: ("thinking", `Assoc [ "type", `String "enabled" ])
-          :: body)
-        else ("thinking", `Assoc [ "type", `String "disabled" ]) :: body
-      | Chat_template_kwargs ->
-        ("chat_template_kwargs", `Assoc [ "enable_thinking", `Bool enabled ])
-        :: body
-      | No_thinking_control -> body)
+    | Some enabled ->
+      (match caps.thinking_control_format with
+       | Thinking_object ->
+         if enabled
+         then (
+           let effort =
+             Provider_config.effort_of_thinking_config
+               ~enable_thinking:config.enable_thinking
+               ~thinking_budget:config.thinking_budget
+           in
+           ("reasoning_effort", `String effort)
+           :: ("thinking", `Assoc [ "type", `String "enabled" ])
+           :: body)
+         else ("thinking", `Assoc [ "type", `String "disabled" ]) :: body
+       | Chat_template_kwargs ->
+         ("chat_template_kwargs", `Assoc [ "enable_thinking", `Bool enabled ])
+         :: body
+       | No_thinking_control -> body)
     | None -> body
   in
   (* tool_choice uses a DIFFERENT unknown-model default than top_k /

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -33,11 +33,11 @@ type capabilities =
   ; supports_extended_thinking : bool (** budget_tokens / reasoning_effort *)
   ; supports_reasoning_budget : bool (** Controllable reasoning depth *)
   ; thinking_control_format : thinking_control_format
-  (** Wire-format for thinking control on OpenAI-compat backends.
-      Determines which JSON shape the backend emits for enable_thinking.
-      Only meaningful when [supports_reasoning] or [supports_extended_thinking]
-      is true and the request goes through backend_openai.
-      @since 0.184.0 *)
+    (** Wire-format for thinking control on OpenAI-compat backends.
+        Determines which JSON shape the backend emits for enable_thinking.
+        Only meaningful when [supports_reasoning] or [supports_extended_thinking]
+        is true and the request goes through backend_openai.
+        @since 0.184.0 *)
   ; (* ── Output format ─────────────────────────────────── *)
     supports_response_format_json : bool (** JSON mode *)
   ; supports_structured_output : bool (** JSON schema 100% guarantee *)

--- a/lib/llm_provider/metrics.ml
+++ b/lib/llm_provider/metrics.ml
@@ -8,7 +8,7 @@ type t =
   ; on_error : model_id:string -> error:string -> unit
   ; on_http_status : provider:string -> model_id:string -> status:int -> unit
   ; on_capability_drop : model_id:string -> field:string -> unit
-  (** Fired when a request parameter is silently dropped because the
+    (** Fired when a request parameter is silently dropped because the
       model's capability record reports it as unsupported.
       Consumers can use this to increment a Prometheus counter or emit
       a structured log event for alerting on misconfigured agents.


### PR DESCRIPTION
## Summary
- Fix remaining ocamlformat violations merged in #1324
- `backend_openai.ml`: nested match paren placement
- `capabilities.ml`: doc comment 4-space indent
- `metrics.ml`: doc comment 4-space indent

## Test plan
- [ ] CI Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)