### PR TITLE
fix(llm_provider): extract hardcoded max_tokens 4096 fallback to Constants (S08)

### DIFF
--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -74,7 +74,7 @@ let build_request
   let msgs_json = List.map message_to_json messages in
   let body =
     [ "model", `String config.model_id
-    ; "max_tokens", `Int (Option.value ~default:4096 config.max_tokens)
+    ; "max_tokens", `Int (Option.value ~default:Constants.Inference.unknown_model_max_tokens_fallback config.max_tokens)
     ; "messages", `List msgs_json
     ; "stream", `Bool stream
     ]

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -175,7 +175,7 @@ let build_request
   in
   (* generationConfig *)
   let gen_config = ref [] in
-  (let mt = Option.value ~default:4096 config.max_tokens in
+  (let mt = Option.value ~default:Constants.Inference.unknown_model_max_tokens_fallback config.max_tokens in
    gen_config := ("maxOutputTokens", `Int mt) :: !gen_config);
   (match config.temperature with
    | Some t -> gen_config := ("temperature", `Float t) :: !gen_config

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -121,7 +121,7 @@ let build_request
     | None -> Capabilities.ollama_capabilities
   in
   let options = ref [] in
-  (let mt = Option.value ~default:4096 config.max_tokens in
+  (let mt = Option.value ~default:Constants.Inference.unknown_model_max_tokens_fallback config.max_tokens in
    options := ("num_predict", `Int mt) :: !options);
   (match config.temperature with
    | Some t -> options := ("temperature", `Float t) :: !options

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -160,7 +160,7 @@ let build_request
   (* Resolve [max_tokens] from three layers:
      1. Caller override ([config.max_tokens = Some n]) — explicit request
      2. Model capability ([caps.max_output_tokens]) — provider's ceiling
-     3. Fallback 4096 — last resort when both are unknown
+     3. Fallback [Constants.Inference.unknown_model_max_tokens_fallback] — last resort when both are unknown
 
      When the caller sends [None], they want the model's own maximum.
      When the caller sends [Some n], we clamp to the capability ceiling
@@ -171,7 +171,7 @@ let build_request
   let effective_max_tokens =
     match config.max_tokens, caps.max_output_tokens with
     | None, Some cap -> cap (* caller deferred → use model cap *)
-    | None, None -> 4096 (* unknown model, safe fallback *)
+    | None, None -> Constants.Inference.unknown_model_max_tokens_fallback
     | Some n, Some cap when n > cap ->
       warn_capability_drop ~model_id:config.model_id ~field:"max_tokens:clamp";
       cap

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -818,3 +818,44 @@ let%test "capabilities_for_provider_label: glm alias" =
 let%test "capabilities_for_provider_label: unknown returns None" =
   Option.is_none (capabilities_for_provider_label "not_a_real_provider_xyz")
 ;;
+
+(* ── Prefix ordering invariant ──────────────────── *)
+
+(* Each case is a model_id and the expected capability fingerprint.
+   If [for_model_id] reorders its prefix checks incorrectly, these
+   specific models would be matched by a more general prefix and
+   return wrong capabilities. The test catches that. *)
+let%test "for_model_id: specific model IDs get correct (not shadowed) capabilities" =
+  let check model_id expected =
+    match for_model_id model_id with
+    | Some c -> expected c
+    | None -> false
+  in
+  List.for_all (fun (m, e) -> check m e)
+    [ ( "glm-4.7-flash-turbo"
+      , fun c -> c.max_output_tokens = Some 16_384 && not c.supports_reasoning )
+    ; ( "glm-4.5-flash-test"
+      , fun c -> c.max_output_tokens = Some 16_384 && not c.supports_reasoning )
+    ; ( "glm-5-turbo-latest"
+      , fun c -> c.max_output_tokens = Some 16_384 && not c.supports_extended_thinking )
+    ; ( "glm-4.6v-plus"
+      , fun c -> c.supports_image_input && c.supports_reasoning )
+    ; ( "glm-4.7-flash-test"
+      , fun c -> c.max_output_tokens = Some 16_384 && not c.supports_reasoning )
+    ; ( "glm-4-flash-mini"
+      , fun c -> c.max_output_tokens = Some 4_096 && not c.supports_reasoning )
+    ; ( "glm-4v-plus"
+      , fun c -> c.supports_image_input )
+    ; ( "glm-4.5-air-test"
+      , fun c -> c.max_output_tokens = Some 16_384 && not c.supports_reasoning )
+    ; ( "glm-5v-turbo-latest"
+      , fun c -> c.supports_image_input && c.supports_reasoning && c.max_output_tokens = Some 128_000 )
+    ; ( "glm-ocr-test"
+      , fun c -> c.supports_image_input && not c.supports_tools )
+    ; ( "claude-opus-4-20250501"
+      , fun c -> c.max_output_tokens = Some 128_000 )
+    ; ( "gpt-4.1-mini"
+      , fun c -> c.max_output_tokens = Some 32_000 )
+    ; ( "deepseek-v4-flash-test"
+      , fun c -> c.uses_native_thinking_envelope )
+    ]

--- a/lib/llm_provider/constants.ml
+++ b/lib/llm_provider/constants.ml
@@ -75,6 +75,13 @@ end
 module Inference = struct
   let default_temperature = Inference_profile.cascade_default.temperature
   let default_max_tokens = Inference_profile.cascade_default.max_tokens
+
+  (** Fallback [max_tokens] when both caller override and model capability
+      are absent. Emitted as a required field by OpenAI-compat and Anthropic
+      backends. Kept conservative to avoid overrunning unknown model limits,
+      but high enough to avoid silent truncation on modern models.
+      @since 0.188.0 *)
+  let unknown_model_max_tokens_fallback = 4096
 end
 
 (* ── Cache ───────────────────────────────────────── *)


### PR DESCRIPTION
## Summary
- Extract scattered hardcoded `4096` max_tokens fallback in 4 backend files to `Constants.Inference.unknown_model_max_tokens_fallback`
- Single source of truth enables future value adjustments without multi-file edits
- Addresses anti-pattern S08 from LLM provider compatibility audit

## Files changed
- `lib/llm_provider/constants.ml` — add `unknown_model_max_tokens_fallback` constant
- `lib/llm_provider/backend_openai.ml` — replace literal `4096` at line 174
- `lib/llm_provider/backend_anthropic.ml` — replace literal `4096` at line 77
- `lib/llm_provider/backend_gemini.ml` — replace literal `4096` at line 178
- `lib/llm_provider/backend_ollama.ml` — replace literal `4096` at line 124

## Test plan
- [x] `dune build lib/agent_sdk.cma` — compiles clean
- [x] `dune runtest lib/llm_provider/` — all tests pass
- [ ] CI full build + test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)