### PR TITLE
fix(llm_provider): use Diag.warn in CLI transports (F02)

### DIFF
--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -279,8 +279,9 @@ let parse_usage json =
     if plausible_single_response_usage usage
     then Some usage
     else (
-      Diag.warn "transport_claude_code"
-        "usage dropped: input_tokens=%d exceeds single-response ceiling=%d"
+      Diag.warn
+        "transport_claude_code"
+          "usage dropped: input_tokens=%d exceeds single-response ceiling=%d"
         usage.input_tokens
         claude_code_max_single_response_input_tokens;
       None)

--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -279,9 +279,8 @@ let parse_usage json =
     if plausible_single_response_usage usage
     then Some usage
     else (
-      Eio.traceln
-        "[warn] claude_code usage dropped: input_tokens=%d exceeds single-response \
-         ceiling=%d"
+      Diag.warn "transport_claude_code"
+        "usage dropped: input_tokens=%d exceeds single-response ceiling=%d"
         usage.input_tokens
         claude_code_max_single_response_input_tokens;
       None)

--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -631,7 +631,8 @@ let warn_unsupported_once (config : config) warned =
   else (
     warned := true;
     let warn field =
-      Eio.traceln "[warn] %s is not supported by codex_cli, ignoring" field
+      Diag.warn "transport_codex_cli"
+        "%s is not supported by codex_cli, ignoring" field
     in
     if Option.is_some config.mcp_config then warn "mcp_config";
     if config.allowed_tools <> [] then warn "allowed_tools";

--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -631,8 +631,7 @@ let warn_unsupported_once (config : config) warned =
   else (
     warned := true;
     let warn field =
-      Diag.warn "transport_codex_cli"
-        "%s is not supported by codex_cli, ignoring" field
+      Diag.warn "transport_codex_cli" "%s is not supported by codex_cli, ignoring" field
     in
     if Option.is_some config.mcp_config then warn "mcp_config";
     if config.allowed_tools <> [] then warn "allowed_tools";

--- a/lib/llm_provider/transport_gemini_cli.ml
+++ b/lib/llm_provider/transport_gemini_cli.ml
@@ -459,7 +459,8 @@ let warn_unsupported_once (config : config) warned =
   else (
     warned := true;
     let warn field =
-      Eio.traceln "[warn] %s is not supported by gemini_cli, ignoring" field
+      Diag.warn "transport_gemini_cli"
+        "%s is not supported by gemini_cli, ignoring" field
     in
     if Option.is_some config.mcp_config then warn "mcp_config";
     if config.allowed_tools <> [] then warn "allowed_tools";

--- a/lib/llm_provider/transport_gemini_cli.ml
+++ b/lib/llm_provider/transport_gemini_cli.ml
@@ -354,8 +354,7 @@ let provider_failure_of_stderr_line ?model line =
   else if List.exists (substring_found line) terminal_quota_markers
   then
     Some
-      (Http_client.Hard_quota
-         { retry_after = retry_after_seconds_of_retry_delay_ms line })
+      (Http_client.Hard_quota { retry_after = retry_after_seconds_of_retry_delay_ms line })
   else if List.exists (substring_found line) capacity_exhausted_markers
   then
     Some
@@ -459,8 +458,7 @@ let warn_unsupported_once (config : config) warned =
   else (
     warned := true;
     let warn field =
-      Diag.warn "transport_gemini_cli"
-        "%s is not supported by gemini_cli, ignoring" field
+      Diag.warn "transport_gemini_cli" "%s is not supported by gemini_cli, ignoring" field
     in
     if Option.is_some config.mcp_config then warn "mcp_config";
     if config.allowed_tools <> [] then warn "allowed_tools";

--- a/lib/llm_provider/transport_kimi_cli.ml
+++ b/lib/llm_provider/transport_kimi_cli.ml
@@ -340,10 +340,11 @@ let warn_external_tools_once warned tools =
   then ()
   else (
     warned := true;
-    Diag.warn "transport_kimi_cli"
-      "kimi_cli print mode ignores OAS req.tools. Provider-native built-in tools \
-       and configured MCP servers remain available; external OAS tool callbacks require \
-       a future wire-mode transport.")
+    Diag.warn
+      "transport_kimi_cli"
+      "kimi_cli print mode ignores OAS req.tools. Provider-native built-in tools and \
+       configured MCP servers remain available; external OAS tool callbacks require a \
+       future wire-mode transport.")
 ;;
 
 (* Drop the first [n] elements of a list.  O(n) but n is the delta between

--- a/lib/llm_provider/transport_kimi_cli.ml
+++ b/lib/llm_provider/transport_kimi_cli.ml
@@ -340,8 +340,8 @@ let warn_external_tools_once warned tools =
   then ()
   else (
     warned := true;
-    Eio.traceln
-      "[warn] kimi_cli print mode ignores OAS req.tools. Provider-native built-in tools \
+    Diag.warn "transport_kimi_cli"
+      "kimi_cli print mode ignores OAS req.tools. Provider-native built-in tools \
        and configured MCP servers remain available; external OAS tool callbacks require \
        a future wire-mode transport.")
 ;;


### PR DESCRIPTION
## Summary
- Replace `Eio.traceln` with `Diag.warn` in `transport_codex_cli.ml` and `transport_gemini_cli.ml` `warn_unsupported_once` functions
- CLI transport warnings now flow through the structured diagnostic pipeline (Atomic sink, level filtering, ctx tags) instead of bypassing it

## Anti-pattern addressed
- **F02** from LLM compatibility analysis: CLI transports used raw `Eio.traceln` for config field warnings, bypassing the OAS diagnostic infrastructure

## Analysis notes
- Reviewed S06 (supports_min_p): already capability-based, resolved
- Reviewed S07 (unknown model tool_choice): intentional permissive default with documented rationale
- Reviewed S10/F01 (GLM tool_choice coerce): intentional capability-based coerce per Z.AI docs, tests validate behavior
- Only F02 was a genuine anti-pattern requiring a fix

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` passes (all 4 tests)
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)