### PR TITLE
docs(backend_ollama): correct min_p capability comment drift

### DIFF
--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -113,12 +113,19 @@ let build_request
      lowers either flag actually takes effect everywhere in the
      request-build pipeline.
 
-     For the default ollama_capabilities (inherited from
-     openai_chat_extended_capabilities) both flags are true, so
-     behaviour is byte-identical for the common path. The gate only
-     fires when an operator explicitly sets [supports_min_p = false]
-     or [supports_top_k = false] for a specific Ollama variant — at
-     which point the one-shot WARN from Backend_openai also fires. *)
+     For the default [ollama_capabilities] (capabilities.ml around
+     line 215): [supports_top_k] is inherited from
+     [openai_chat_extended_capabilities] = true, but [supports_min_p]
+     is explicitly overridden to false because docs.ollama.com does
+     not document min_p as a first-class option (the parameter is
+     silently dropped by some Ollama versions when sent inside
+     [options]).  So out of the box, [top_k] flows through and
+     [min_p] is dropped with a one-shot WARN from
+     Backend_openai.warn_capability_drop.
+
+     The gate also fires when an operator explicitly flips either
+     flag for a specific Ollama variant (overriding [for_model_id]
+     in capabilities.ml). *)
   let caps =
     match Capabilities.for_model_id config.model_id with
     | Some c -> c


### PR DESCRIPTION
## Why

The block comment at `lib/llm_provider/backend_ollama.ml:107-117` stated:

> *"For the default ollama_capabilities (inherited from openai_chat_extended_capabilities) both flags are true"*

This is wrong: `capabilities.ml` around line 215 explicitly overrides `supports_min_p` to `false` while leaving `supports_top_k` inherited (true).

```ocaml
(* lib/llm_provider/capabilities.ml around 215 *)
let ollama_capabilities =
  { openai_chat_extended_capabilities with
    supports_tool_choice = false
  ; supports_min_p = false           (* ← explicit override *)
  ; thinking_control_format = Chat_template_kwargs
  ; is_ollama = true
  }
```

So out of the box: `top_k` flows through, `min_p` is dropped with a one-shot WARN from `Backend_openai.warn_capability_drop`.  The comment said the opposite for `min_p`, misleading any operator reading the source about default behaviour.

## What

Replace the misleading paragraph with the correct distinction between `top_k` (inherited true) and `min_p` (overridden false), and explain *why* min_p is gated (docs.ollama.com does not document it as a first-class option, the parameter is silently dropped by some Ollama versions).

## Validation

- `dune build lib/llm_provider/` passes (clean output) — comment-only change.
- The two pre-existing `examples/.cmi` errors on the broader `@check` are an unrelated main blocker, not a regression caused by this PR (race-check confirms no related open PR).

## References

- 2026-05-02 LLM Provider Compatibility report §2.4.3 — flagged this comment/code drift as the second-highest-impact "improvement opportunity" after `thinking_control_format` capability addition (which was completed in #1337).