### PR TITLE
test(capabilities): flip 4 CLI emits_usage_tokens assertions post-#1342

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -866,21 +866,27 @@ let%test "emits_usage_tokens: claude_code reports usage" =
   claude_code_capabilities.emits_usage_tokens
 ;;
 
-let%test "emits_usage_tokens: gemini_cli strips usage" =
-  not gemini_cli_capabilities.emits_usage_tokens
+(* P7 (#1342) restored CJK-aware usage estimation for the CLI wrapper
+   transports, so the three CLI provider capability records now report
+   [emits_usage_tokens = true].  These tests previously asserted the
+   pre-#1342 behaviour ([not ... emits_usage_tokens]) and should have
+   been flipped alongside the capability change; sweep miss caught
+   here. *)
+let%test "emits_usage_tokens: gemini_cli reports usage (P7)" =
+  gemini_cli_capabilities.emits_usage_tokens
 ;;
 
-let%test "emits_usage_tokens: kimi_cli strips usage" =
-  not kimi_cli_capabilities.emits_usage_tokens
+let%test "emits_usage_tokens: kimi_cli reports usage (P7)" =
+  kimi_cli_capabilities.emits_usage_tokens
 ;;
 
-let%test "emits_usage_tokens: codex_cli strips usage" =
-  not codex_cli_capabilities.emits_usage_tokens
+let%test "emits_usage_tokens: codex_cli reports usage (P7)" =
+  codex_cli_capabilities.emits_usage_tokens
 ;;
 
-let%test "capabilities_for_provider_label: kimi_cli" =
+let%test "capabilities_for_provider_label: kimi_cli reports usage (P7)" =
   match capabilities_for_provider_label "kimi_cli" with
-  | Some c -> not c.emits_usage_tokens
+  | Some c -> c.emits_usage_tokens
   | None -> false
 ;;
 


### PR DESCRIPTION
## Why

PR #1342 (P7 — CJK-aware usage restoration for CLI wrappers) flipped three CLI capability records to emits_usage_tokens=true:

- gemini_cli_capabilities.emits_usage_tokens = true (capabilities.ml line 314)
- kimi_cli_capabilities.emits_usage_tokens = true (line 328)
- codex_cli_capabilities.emits_usage_tokens = true (in surrounding block)

But four inline tests in the same file still assert the pre-P7 behaviour:

```
let%test "emits_usage_tokens: gemini_cli strips usage" =
  not gemini_cli_capabilities.emits_usage_tokens   (* asserts false now *)
;;
```

The test names ("strips usage") and assertions (`not ... emits_usage_tokens`) both contradict the current capability record values. Under `dune runtest` with ppx_inline_test enabled these would fail; presumably they have been silently passing because the runtime config skips inline test evaluation in normal CI flow.

## What

Flip the four assertions and rename for accuracy:

| line | before | after |
| --- | --- | --- |
| 869 | "gemini_cli strips usage" / `not ...` | "gemini_cli reports usage (P7)" / positive |
| 873 | "kimi_cli strips usage" / `not ...` | "kimi_cli reports usage (P7)" / positive |
| 877 | "codex_cli strips usage" / `not ...` | "codex_cli reports usage (P7)" / positive |
| 881 | capabilities_for_provider_label kimi_cli inline match | inline match flipped from `not c.emits_usage_tokens` to `c.emits_usage_tokens` |

Added a block comment recording the P7 sweep miss history so the next reader understands why the names changed.

## Risk

- 1 file, +14 -8 lines.  Test code only, no production behaviour change.
- `dune build lib/llm_provider/` passes (clean output).
- Race-check: only PR #1336 (deterministic seed) is open in capabilities area; different concern, no overlap with these test lines.

## References

- #1342 (P7 usage restoration that introduced the capability flip but missed the test sweep)
- #1337 P0-P7 mega-merge (introduced the surrounding capability block)
- 2026-05-02 LLM Provider Compatibility report sec04 §4.3.1 (Gemini CLI), §4.3.5 (Kimi CLI) — under-declaration gap analysis that surfaced this