### PR TITLE
feat: add ppx_let support with Let_syntax

### DIFF
--- a/agent_sdk.opam
+++ b/agent_sdk.opam
@@ -21,6 +21,7 @@ depends: [
   "yojson" {>= "2.1"}
   "ppx_deriving_yojson" {>= "3.7"}
   "ppx_deriving" {>= "5.2.1"}
+  "ppx_let" {>= "0.17"}
   "uri" {>= "4.4"}
   "mcp_protocol" {>= "1.3.0"}
   "cmdliner" {>= "1.3.0"}

--- a/dune-project
+++ b/dune-project
@@ -25,6 +25,7 @@
   (yojson (>= 2.1))
   (ppx_deriving_yojson (>= 3.7))
   (ppx_deriving (>= 5.2.1))
+  (ppx_let (>= 0.17))
   (uri (>= 4.4))
   (mcp_protocol (>= 1.3.0))
   (cmdliner (>= 1.3.0))

--- a/lib/artifact_service.ml
+++ b/lib/artifact_service.ml
@@ -53,9 +53,9 @@ let save_text_internal store ~session_id ~name ~kind ~content =
       (Runtime_store.artifacts_dir store session_id)
       (Printf.sprintf "%s.%s" artifact_id extension)
   in
-  let* () = Runtime_store.ensure_tree store session_id in
-  let* () = Runtime_store.save_text path content in
-  Ok
+  let%bind () = Runtime_store.ensure_tree store session_id in
+  let%bind () = Runtime_store.save_text path content in
+  Let_syntax.return
     { artifact_id
     ; name
     ; kind
@@ -85,18 +85,18 @@ let persisted_path (artifact : descriptor) =
 ;;
 
 let overwrite_text_internal artifact ~content =
-  let* path = persisted_path artifact in
+  let%bind path = persisted_path artifact in
   Runtime_store.save_text path content
 ;;
 
 let list ?session_root ~session_id () =
-  let* store = make_store ?session_root () in
-  let* session = Runtime_store.load_session store session_id in
-  Ok session.artifacts
+  let%bind store = make_store ?session_root () in
+  let%bind session = Runtime_store.load_session store session_id in
+  Let_syntax.return session.artifacts
 ;;
 
 let find_descriptor ?session_root ~session_id ~artifact_id () =
-  let* artifacts = list ?session_root ~session_id () in
+  let%bind artifacts = list ?session_root ~session_id () in
   match
     List.find_opt
       (fun (artifact : descriptor) -> String.equal artifact.artifact_id artifact_id)
@@ -114,7 +114,7 @@ let find_descriptor ?session_root ~session_id ~artifact_id () =
 ;;
 
 let get_text ?session_root ~session_id ~artifact_id () =
-  let* artifact = find_descriptor ?session_root ~session_id ~artifact_id () in
+  let%bind artifact = find_descriptor ?session_root ~session_id ~artifact_id () in
   match artifact.inline_content, artifact.path with
   | Some content, _ -> Ok content
   | None, Some path -> Runtime_store.load_text path

--- a/lib/base/dune
+++ b/lib/base/dune
@@ -7,6 +7,6 @@
  (libraries llm_provider yojson)
  (inline_tests)
  (preprocess
-  (pps ppx_deriving_yojson ppx_deriving.show ppx_inline_test))
+  (pps ppx_deriving_yojson ppx_deriving.show ppx_inline_test ppx_let))
  (instrumentation
   (backend bisect_ppx)))

--- a/lib/base/result_syntax.ml
+++ b/lib/base/result_syntax.ml
@@ -4,6 +4,9 @@
     the agent_sdk codebase. Open this module in files that use [let*]
     and [let+] for Result-based computation chains.
 
+    Also provides {!Let_syntax} for [ppx_let] support ([let%bind],
+    [let%map], [and%bind]).
+
     @since 0.187.7
     @stability Stable *)
 
@@ -19,3 +22,23 @@ let both a b =
 
 let ( and* ) = both
 let ( and+ ) = both
+
+(** ppx_let integration.
+
+    After [open Result_syntax], [let%bind] and [let%map] are available
+    alongside the built-in [let*] / [let+] operators. Both styles are
+    equivalent; [ppx_let] provides better error messages for nested
+    bindings and supports [and%bind] for parallel composition.
+
+    {[open Result_syntax
+    let compute x =
+      let%bind a = parse x in
+      let%bind b = validate a in
+      let%map c = transform b in
+      c]} *)
+module Let_syntax = struct
+  let return x = Ok x
+  let bind t ~f = Result.bind t f
+  let map t ~f = Result.map f t
+  let both = both
+end

--- a/lib/base/result_syntax.mli
+++ b/lib/base/result_syntax.mli
@@ -1,7 +1,8 @@
 (** Result monadic binding operators.
 
     Open this module in files that use [let*] and [let+] for
-    {!Result}-based computation chains.
+    {!Result}-based computation chains. Also provides {!Let_syntax}
+    for [ppx_let] ([let%bind], [let%map]) support.
 
     {2 Usage}
 
@@ -29,3 +30,14 @@ val ( and* ) : ('a, 'e) result -> ('b, 'e) result -> ('a * 'b, 'e) result
 
 (** Parallel accumulate — both must succeed. *)
 val ( and+ ) : ('a, 'e) result -> ('b, 'e) result -> ('a * 'b, 'e) result
+
+(** ppx_let integration module.
+
+    Provides [bind], [map], [return], and [both] for [let%bind] /
+    [let%map] / [and%bind] expansion. *)
+module Let_syntax : sig
+  val return : 'a -> ('a, 'e) result
+  val bind : ('a, 'e) result -> f:('a -> ('b, 'e) result) -> ('b, 'e) result
+  val map : ('a, 'e) result -> f:('a -> 'b) -> ('b, 'e) result
+  val both : ('a, 'e) result -> ('b, 'e) result -> ('a * 'b, 'e) result
+end

--- a/lib/dune
+++ b/lib/dune
@@ -23,6 +23,6 @@
   mcp_protocol.http)
  (inline_tests)
  (preprocess
-  (pps ppx_deriving_yojson ppx_deriving.show ppx_inline_test))
+  (pps ppx_deriving_yojson ppx_deriving.show ppx_inline_test ppx_let))
  (instrumentation
   (backend bisect_ppx)))


### PR DESCRIPTION
## Summary

- Add `ppx_let (>= 0.17)` dependency to `dune-project`
- Define `Let_syntax` module in `Result_syntax` with `return`, `bind ~f:`, `map ~f:`, `both`
- Enable `let%bind` / `let%map` / `and%bind` alongside existing `let*` / `let+` operators
- Migrate `artifact_service.ml` as first consumer (7 `let*` → `let%bind`)

## Context

PR-A5 (ppx_let introduction) from the B→B+ grade upgrade plan. ppx_let provides:
- Explicit monadic binding syntax (`let%bind`) that's visually distinct from plain `let`
- Better compiler error messages for nested Result chains
- `and%bind` for parallel Result composition
- Jane Street convention compatible `Let_syntax` module

## Migration strategy

Both `let*`/`let+` and `let%bind`/`let%map` work after `open Result_syntax`. Existing code needs zero changes. New code can opt into ppx_let style incrementally.

## Test plan

- [x] `dune build @install` passes
- [x] `dune runtest` passes (no regressions)
- [x] `dune fmt` clean
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)