### PR TITLE
fix(retry): classify admin-disabled and account-suspended 429s as hard quota

### DIFF
--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -131,7 +131,10 @@ let malformed_json_indicators =
     - Google / Gemini: "Resource exhausted"
     - Mistral: "insufficient_quota"
     - Together.ai: "insufficient_funds"
-    - z.ai CJK: "余额不足" / "额度不足" *)
+    - z.ai CJK: "余额不足" / "额度不足"
+    - z.ai / GLM admin disable: "Your usage allocation has been disabled
+      by your admin"
+    - Generic: "account suspended", "account has been disabled" *)
 let hard_quota_indicators =
   [ "insufficient balance"
   ; "insufficient credit"
@@ -145,6 +148,10 @@ let hard_quota_indicators =
   ; "resource_exhausted"
   ; "余额不足"
   ; "额度不足"
+  ; "disabled by your admin"
+  ; "usage allocation has been disabled"
+  ; "account suspended"
+  ; "account has been disabled"
   ]
 ;;
 
@@ -677,6 +684,9 @@ let%test "is_hard_quota_message positive cases" =
   && is_hard_quota_message "insufficient_quota"
   && is_hard_quota_message "resource exhausted"
   && is_hard_quota_message "余额不足"
+  && is_hard_quota_message "Your usage allocation has been disabled by your admin"
+  && is_hard_quota_message "Account suspended"
+  && is_hard_quota_message "Account has been disabled"
 ;;
 
 let%test "is_hard_quota_message negative cases" =


### PR DESCRIPTION
## Summary
- Add 4 new `hard_quota_indicators` to `retry.ml`: "disabled by your admin", "usage allocation has been disabled", "account suspended", "account has been disabled"
- GLM returns 429 with "Your usage allocation has been disabled by your admin" for permanent account-level disables. Without matching, the cascade treated these as transient rate limits, burning `max_retries` per turn
- Keeper episode buffers accumulated phantom failures because `is_retryable` returned `true` for permanently disabled providers
- With this fix: `is_hard_quota=true` → cascade returns `Hard_quota` immediately → keeper can classify provider as Dead

## Root Cause
The user observed keeper lanes (`analyst`) persistently retrying a GLM provider that had been admin-disabled. The 429 status code alone doesn't distinguish transient rate limiting from permanent account disable. The error message "usage allocation has been disabled by your admin" is permanent — retrying will never succeed.

## Test plan
- [x] Inline tests (`let%test`) in `retry.ml` pass with new positive cases
- [x] `dune runtest` all green
- [ ] CI: Build & Test, Lint, OCaml Format
- [ ] Verify no regression in transient 429 handling (existing negative test cases still pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)