### PR TITLE
refactor(provider_config): extract request_path_default_for_kind helper

### DIFF
--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -18,6 +18,21 @@ type provider_kind = Provider_kind.t =
   | Kimi_cli
   | Codex_cli
 
+(** Default [request_path] for a given provider kind. Centralised so that
+    [make] and any caller building a record literal stay aligned with the
+    same wire-format defaults. CLI variants and Gemini return [""] because
+    they don't dispatch over an HTTP path. *)
+let request_path_default_for_kind = function
+  | Anthropic -> "/v1/messages"
+  | Kimi -> "/v1/messages"
+  | OpenAI_compat -> "/v1/chat/completions"
+  | Ollama -> "/api/chat"
+  | Gemini -> ""
+  | Glm -> "/chat/completions"
+  | DashScope -> "/chat/completions"
+  | Claude_code | Gemini_cli | Kimi_cli | Codex_cli -> ""
+;;
+
 type t =
   { kind : provider_kind
   ; model_id : string
@@ -94,16 +109,7 @@ let make
   let request_path =
     match request_path with
     | Some p -> p
-    | None ->
-      (match kind with
-       | Anthropic -> "/v1/messages"
-       | Kimi -> "/v1/messages"
-       | OpenAI_compat -> "/v1/chat/completions"
-       | Ollama -> "/api/chat"
-       | Gemini -> ""
-       | Glm -> "/chat/completions"
-       | DashScope -> "/chat/completions"
-       | Claude_code | Gemini_cli | Kimi_cli | Codex_cli -> "")
+    | None -> request_path_default_for_kind kind
   in
   { kind
   ; model_id

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -27,6 +27,13 @@ type provider_kind = Provider_kind.t =
   | Kimi_cli (** Subprocess transport via [kimi --print]. @since 0.169.0 *)
   | Codex_cli (** Subprocess transport via [codex exec]. @since 0.133.0 *)
 
+(** Default HTTP request path for a given provider kind, returning
+    [""] for CLI subprocess kinds that do not dispatch over a path.
+    Single source of truth shared by [make] and direct record-literal
+    callers; pin the [kind] and the [request_path] together via this
+    helper to avoid the two fields drifting out of sync. *)
+val request_path_default_for_kind : provider_kind -> string
+
 type t =
   { kind : provider_kind
   ; model_id : string


### PR DESCRIPTION
## Summary
- provider_config 의 request_path inline default match를 `request_path_default_for_kind` helper 로 추출
- record 필드는 유지 — caller surface 보호 (provider.ml/provider_bridge.ml/complete.ml 등 record literal 또는 ~request_path override 사용처가 다수). 단순 필드 제거는 surgical change 위반.
- mli에 helper val 추가. 후속 PR로 record literal callers (complete.ml의 `request_path = ""` 등) 를 helper 호출로 마이그레이션 가능.

## RFC
RFC-WAIVED: provider_config는 lib/keeper/credential_*, lib/repo_manager/, lib/operator/operator_control*, dashboard/credential, .claude/hooks/, instructions/workflow* 어느 RFC subsystem에도 해당하지 않음.

## Test plan
- [x] `dune build @lib/check` 통과 (helper 추가만, surface 호환)
- [x] `bash ~/me/scripts/pr-rfc-check.sh --pr-body /tmp/pr-body-b2a.md` PASS
- [ ] CI 전체 통과 확인
- [ ] 후속 PR(별건): complete.ml 의 record literal에서 `request_path = ""` 패턴을 helper 호출로 마이그레이션 (no-op behaviour change)

## Note
Draft. ready 전환은 `human-approved-ready` 라벨 부여 후 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
