### PR TITLE
refactor(provider_config): extract output_schema_of_response_format helper

### DIFF
--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -33,6 +33,21 @@ let request_path_default_for_kind = function
   | Claude_code | Gemini_cli | Kimi_cli | Codex_cli -> ""
 ;;
 
+(** [output_schema] derived from [response_format] when no explicit
+    schema is supplied. Centralised so [make] and direct record-literal
+    callers stay aligned: a config that carries
+    [response_format = JsonSchema s] always exposes
+    [output_schema = Some s], and any other [response_format] leaves
+    [output_schema = None]. The optional [override] argument keeps the
+    legacy semantics of [make] (an explicit [output_schema] wins
+    regardless of [response_format]). *)
+let output_schema_of_response_format ?override (response_format : Types.response_format) =
+  match override, response_format with
+  | Some schema, _ -> Some schema
+  | None, Types.JsonSchema schema -> Some schema
+  | None, Types.JsonMode | None, Types.Off -> None
+;;
+
 type t =
   { kind : provider_kind
   ; model_id : string
@@ -101,10 +116,7 @@ let make
     | None, None -> Types.response_format_of_json_mode response_format_json
   in
   let output_schema =
-    match output_schema, response_format with
-    | Some schema, _ -> Some schema
-    | None, Types.JsonSchema schema -> Some schema
-    | None, Types.JsonMode | None, Types.Off -> None
+    output_schema_of_response_format ?override:output_schema response_format
   in
   let request_path =
     match request_path with

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -34,6 +34,18 @@ type provider_kind = Provider_kind.t =
     helper to avoid the two fields drifting out of sync. *)
 val request_path_default_for_kind : provider_kind -> string
 
+(** Derive [output_schema] from a [response_format].
+    Returns [Some schema] when [response_format = JsonSchema schema]
+    and [None] otherwise. With [?override:(Some s)] the helper
+    short-circuits to [Some s], preserving the legacy semantics of
+    [make]'s explicit schema argument. Use this helper to keep the
+    [response_format] / [output_schema] pair consistent in record
+    literals built outside [make]. *)
+val output_schema_of_response_format
+  :  ?override:Yojson.Safe.t
+  -> Types.response_format
+  -> Yojson.Safe.t option
+
 type t =
   { kind : provider_kind
   ; model_id : string


### PR DESCRIPTION
## Summary
- `provider_config.output_schema` 의 `response_format` 기반 도출 로직을 `output_schema_of_response_format` helper 로 추출
- record 필드는 유지 — backend_gemini/ollama/openai/structured/complete 가 모두 `config.output_schema` 를 직접 읽고, complete.ml 이 record literal로 `output_schema = None` 을 명시. 단순 필드 제거는 surgical change 위반.
- mli에 helper val 추가. 후속 PR에서 record literal site 들이 helper 호출로 마이그레이션 가능
- B-2a (request_path) 와 같은 패턴

## RFC
RFC-WAIVED: provider_config는 lib/keeper/credential_*, lib/repo_manager/, lib/operator/operator_control*, dashboard/credential, .claude/hooks/, instructions/workflow* 어느 RFC subsystem에도 해당하지 않음.

## Test plan
- [x] `dune build @lib/check` 통과 (helper 추가 + make 내부에서 helper 호출 = surface 호환)
- [ ] CI 전체 통과 확인
- [ ] 후속 PR(별건): record literal callers (`complete.ml`의 `output_schema = None` 등)을 helper 호출로 마이그레이션

## 출처
- /Users/dancer/Downloads/audit_derived_state.md #22
- Plan: Tier B B-2b

## Note
Draft. ready 전환은 `human-approved-ready` 라벨 부여 후 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
