### PR TITLE
feat(guardrails_async): add per-validator deadline to prevent silent stall

### DIFF
--- a/lib/guardrails_async.ml
+++ b/lib/guardrails_async.ml
@@ -52,11 +52,29 @@ let exception_reason ~validator_name = function
     "validator raised"
 ;;
 
-let run_validator ~validator_name f =
-  try
+(* Per-validator deadline. When supplied the validator is wrapped in
+   [Eio.Time.with_timeout_exn], so a stuck validator turns into
+   [Fail "validator timed out"] instead of blocking sibling fibers and
+   the rest of the turn pipeline. The audit (Kimi 1-3) flagged the
+   unguarded [Eio.Fiber.all] as a Silent Failure path: one validator
+   hanging would block the entire turn. Default is [None] for backward
+   compatibility — call sites opt in by passing [~deadline]. *)
+type deadline =
+  { clock : float Eio.Time.clock_ty Eio.Resource.t
+  ; timeout_sec : float
+  }
+
+let run_validator ?deadline ~validator_name f =
+  let invoke () =
     match f () with
     | Ok () -> Pass
     | Error reason -> Fail { validator_name; reason }
+  in
+  try
+    match deadline with
+    | Some { clock; timeout_sec } when timeout_sec > 0.0 ->
+      Eio.Time.with_timeout_exn clock timeout_sec invoke
+    | _ -> invoke ()
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | Out_of_memory -> raise Out_of_memory
@@ -70,7 +88,10 @@ let run_validator ~validator_name f =
     Creates a dedicated [Eio.Switch] for parallel execution.
     Returns the first failure found, or [Pass] if all succeed.
     Cancellation exceptions propagate correctly. *)
-let run_input (validators : input_validator list) (messages : message list)
+let run_input
+      ?deadline
+      (validators : input_validator list)
+      (messages : message list)
   : validation_result
   =
   match validators with
@@ -82,7 +103,10 @@ let run_input (validators : input_validator list) (messages : message list)
         (fun i (v : input_validator) ->
            fun () ->
            results.(i)
-           <- run_validator ~validator_name:v.name (fun () -> v.validate messages))
+           <- run_validator
+                ?deadline
+                ~validator_name:v.name
+                (fun () -> v.validate messages))
         validators
     in
     Eio.Switch.run ~name:"input_validators" (fun _sw -> Eio.Fiber.all fns);
@@ -96,7 +120,10 @@ let run_input (validators : input_validator list) (messages : message list)
 (** Run all output validators concurrently.
 
     Same parallel execution pattern as {!run_input}. *)
-let run_output (validators : output_validator list) (response : api_response)
+let run_output
+      ?deadline
+      (validators : output_validator list)
+      (response : api_response)
   : validation_result
   =
   match validators with
@@ -108,7 +135,10 @@ let run_output (validators : output_validator list) (response : api_response)
         (fun i (v : output_validator) ->
            fun () ->
            results.(i)
-           <- run_validator ~validator_name:v.name (fun () -> v.validate response))
+           <- run_validator
+                ?deadline
+                ~validator_name:v.name
+                (fun () -> v.validate response))
         validators
     in
     Eio.Switch.run ~name:"output_validators" (fun _sw -> Eio.Fiber.all fns);
@@ -124,18 +154,20 @@ let run_output (validators : output_validator list) (response : api_response)
     If input validation fails, the action is not executed.
     Returns [Ok response] on success, [Error validation_result] on failure. *)
 let guarded
+      ?deadline
       ~(config : t)
       ~(messages : message list)
       ~(action : unit -> (api_response, 'e) Result.t)
+      ()
   : (api_response, [ `Validation of validation_result | `Action of 'e ]) Result.t
   =
-  match run_input config.input_validators messages with
+  match run_input ?deadline config.input_validators messages with
   | Fail _ as f -> Error (`Validation f)
   | Pass ->
     (match action () with
      | Error e -> Error (`Action e)
      | Ok response ->
-       (match run_output config.output_validators response with
+       (match run_output ?deadline config.output_validators response with
         | Fail _ as f -> Error (`Validation f)
         | Pass -> Ok response))
 ;;

--- a/lib/guardrails_async.ml
+++ b/lib/guardrails_async.ml
@@ -88,10 +88,7 @@ let run_validator ?deadline ~validator_name f =
     Creates a dedicated [Eio.Switch] for parallel execution.
     Returns the first failure found, or [Pass] if all succeed.
     Cancellation exceptions propagate correctly. *)
-let run_input
-      ?deadline
-      (validators : input_validator list)
-      (messages : message list)
+let run_input ?deadline (validators : input_validator list) (messages : message list)
   : validation_result
   =
   match validators with
@@ -103,10 +100,8 @@ let run_input
         (fun i (v : input_validator) ->
            fun () ->
            results.(i)
-           <- run_validator
-                ?deadline
-                ~validator_name:v.name
-                (fun () -> v.validate messages))
+           <- run_validator ?deadline ~validator_name:v.name (fun () ->
+                v.validate messages))
         validators
     in
     Eio.Switch.run ~name:"input_validators" (fun _sw -> Eio.Fiber.all fns);
@@ -120,10 +115,7 @@ let run_input
 (** Run all output validators concurrently.
 
     Same parallel execution pattern as {!run_input}. *)
-let run_output
-      ?deadline
-      (validators : output_validator list)
-      (response : api_response)
+let run_output ?deadline (validators : output_validator list) (response : api_response)
   : validation_result
   =
   match validators with
@@ -135,10 +127,8 @@ let run_output
         (fun i (v : output_validator) ->
            fun () ->
            results.(i)
-           <- run_validator
-                ?deadline
-                ~validator_name:v.name
-                (fun () -> v.validate response))
+           <- run_validator ?deadline ~validator_name:v.name (fun () ->
+                v.validate response))
         validators
     in
     Eio.Switch.run ~name:"output_validators" (fun _sw -> Eio.Fiber.all fns);

--- a/lib/guardrails_async.mli
+++ b/lib/guardrails_async.mli
@@ -36,18 +36,43 @@ type t =
 
 val empty : t
 
-(** Run input validators concurrently. Returns first failure or [Pass]. *)
-val run_input : input_validator list -> Types.message list -> validation_result
+(** Per-validator deadline. When passed to {!run_input} / {!run_output}
+    each validator is wrapped in [Eio.Time.with_timeout_exn], so a
+    stuck validator returns [Fail "validator timed out"] instead of
+    blocking sibling fibers and the rest of the turn. *)
+type deadline =
+  { clock : float Eio.Time.clock_ty Eio.Resource.t
+  ; timeout_sec : float
+  }
 
-(** Run output validators concurrently. Returns first failure or [Pass]. *)
-val run_output : output_validator list -> Types.api_response -> validation_result
+(** Run input validators concurrently. Returns first failure or [Pass].
+
+    When [?deadline] is provided each validator gets a hard deadline
+    via [Eio.Time.with_timeout_exn]. *)
+val run_input
+  :  ?deadline:deadline
+  -> input_validator list
+  -> Types.message list
+  -> validation_result
+
+(** Run output validators concurrently. Returns first failure or [Pass].
+
+    Same [?deadline] semantics as {!run_input}. *)
+val run_output
+  :  ?deadline:deadline
+  -> output_validator list
+  -> Types.api_response
+  -> validation_result
 
 (** Run input validation, action, output validation in sequence.
-    Input failure skips the action. *)
+    Input failure skips the action. [?deadline] is forwarded to both
+    {!run_input} and {!run_output}. *)
 val guarded
-  :  config:t
+  :  ?deadline:deadline
+  -> config:t
   -> messages:Types.message list
   -> action:(unit -> (Types.api_response, 'e) Result.t)
+  -> unit
   -> (Types.api_response, [ `Validation of validation_result | `Action of 'e ]) Result.t
 
 val result_to_string : validation_result -> string


### PR DESCRIPTION
## Summary
- audit Kimi 1-3 (Silent Failure: validator hangs → 전체 turn block) 차단
- `Guardrails_async`에 per-validator deadline 도입 — `?deadline:{ clock; timeout_sec }` 추가
- timeout 시 `Eio.Time.with_timeout_exn`이 `Eio.Time.Timeout` 예외 발생 → 기존 `exception_reason` 핸들러가 `Fail "validator timed out"` 으로 변환 (이미 코드에 있던 핸들러 활용)
- default 동작 유지: deadline 미전달 시 기존과 동일하게 raw `f ()` 호출 (caller 마이그레이션 옵션)
- `run_input` / `run_output` / `guarded` 모두 `?deadline` 흡수
- `guarded`는 모든 named arg 뒤에 `()` unit 추가 (OCaml 16 warning erasable-optional 회피). **breaking change** (외부 caller 시그니처 영향)

## RFC
RFC-WAIVED: lib/guardrails_async.ml은 lib/keeper/credential_*, lib/repo_manager/, lib/operator/operator_control*, dashboard/credential, .claude/hooks/, instructions/workflow* 어느 RFC subsystem에도 해당하지 않음. guardrail은 정책 표면이지 credential/identity surface는 아님.

## 호환성
- internal caller 0건 (`pipeline.ml`/test에서 `run_input`/`run_output`만 사용, `guarded`는 사용처 없음)
- external `guarded` caller가 있다면: `Guardrails_async.guarded ~config ~messages ~action` → `Guardrails_async.guarded ~config ~messages ~action ()` 로 unit 추가 필요

## Test plan
- [x] `dune build @lib/check` 통과
- [ ] CI 전체 통과 확인 (외부 caller 영향 시 컴파일 에러 발생 가능성)
- [ ] 후속 PR(별건): `pipeline.ml`이 turn별 clock + 적절한 timeout (예: 30s) 으로 deadline 전달

## 출처
- /Users/dancer/Downloads/Kimi_Agent_코드 숨김 탐지/final_report.md 1-3
- Plan: Tier C C-3

## Note
Draft. ready 전환은 `human-approved-ready` 라벨 부여 후 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
