### PR TITLE
refactor(agent_turn): externalize call_time_pruner magic numbers

### DIFF
--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -247,14 +247,28 @@ let inject_tiered_memory_message ~tiered_memory messages =
     leading_system @ (recall :: rest)
 ;;
 
-let prepare_messages ~messages ~context_reducer ~tiered_memory ~turn_params =
+let prepare_messages ?config ~messages ~context_reducer ~tiered_memory ~turn_params () =
   (* Apply call-time stubbing: older tool results are replaced with
      short stubs before sending to the LLM.  This is done here (not in
      state.messages) so the stored conversation prefix stays byte-identical
-     across turns — enabling local LLM prefix KV-cache reuse. *)
+     across turns — enabling local LLM prefix KV-cache reuse.
+
+     The two knobs ([keep_recent], [keep_last]) come from the agent
+     config when one is supplied; otherwise we fall back to the
+     historical defaults (2 / 100) so legacy callers stay unchanged. *)
+  let keep_recent, keep_last =
+    match config with
+    | Some (c : Types.agent_config) ->
+      c.call_time_pruner_keep_recent, c.call_time_pruner_keep_last
+    | None ->
+      ( Types.default_config.call_time_pruner_keep_recent
+      , Types.default_config.call_time_pruner_keep_last )
+  in
   let call_time_pruner =
     Context_reducer.compose
-      [ Context_reducer.stub_tool_results ~keep_recent:2; Context_reducer.keep_last 100 ]
+      [ Context_reducer.stub_tool_results ~keep_recent
+      ; Context_reducer.keep_last keep_last
+      ]
   in
   let pruned = Context_reducer.reduce call_time_pruner messages in
   let effective =
@@ -282,6 +296,7 @@ let prepare_messages ~messages ~context_reducer ~tiered_memory ~turn_params =
 ;;
 
 let prepare_turn
+      ?config
       ~guardrails
       ~operator_policy
       ~policy_channel
@@ -305,7 +320,7 @@ let prepare_turn
       ()
   in
   let effective_messages =
-    prepare_messages ~messages ~context_reducer ~tiered_memory ~turn_params
+    prepare_messages ?config ~messages ~context_reducer ~tiered_memory ~turn_params ()
   in
   { tools_json; effective_messages; effective_guardrails; visible_tool_names }
 ;;

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -116,18 +116,25 @@ val apply_context_reducer
   -> Types.message list
 
 val prepare_messages
-  :  messages:Types.message list
+  :  ?config:Types.agent_config
+  -> messages:Types.message list
   -> context_reducer:Context_reducer.t option
   -> tiered_memory:tiered_memory option
   -> turn_params:Hooks.turn_params
+  -> unit
   -> Types.message list
 
 (** Full turn preparation: tools + messages + guardrails.
 
     @since 0.94.0 added [operator_policy] parameter
-    @since 0.100.0 added [tool_selector] parameter *)
+    @since 0.100.0 added [tool_selector] parameter
+    @since 0.185.0 added optional [config] parameter so the call-time
+      pruner can read [call_time_pruner_keep_recent] /
+      [call_time_pruner_keep_last] from the agent configuration.
+      Omitting it preserves the historical defaults [2] / [100]. *)
 val prepare_turn
-  :  guardrails:Guardrails.t
+  :  ?config:Types.agent_config
+  -> guardrails:Guardrails.t
   -> operator_policy:Guardrails.tool_filter option
   -> policy_channel:Policy_channel.t option
   -> tools:Tool_set.t

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -354,10 +354,8 @@ let build b =
     ; priority = b.priority
     ; yield_on_tool = b.yield_on_tool
     ; exit_condition = b.exit_condition
-    ; call_time_pruner_keep_recent =
-        Types.default_config.call_time_pruner_keep_recent
-    ; call_time_pruner_keep_last =
-        Types.default_config.call_time_pruner_keep_last
+    ; call_time_pruner_keep_recent = Types.default_config.call_time_pruner_keep_recent
+    ; call_time_pruner_keep_last = Types.default_config.call_time_pruner_keep_last
     }
   in
   let options =

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -354,6 +354,10 @@ let build b =
     ; priority = b.priority
     ; yield_on_tool = b.yield_on_tool
     ; exit_condition = b.exit_condition
+    ; call_time_pruner_keep_recent =
+        Types.default_config.call_time_pruner_keep_recent
+    ; call_time_pruner_keep_last =
+        Types.default_config.call_time_pruner_keep_last
     }
   in
   let options =

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -238,6 +238,8 @@ let create_agent
     ; priority = default_config.priority
     ; yield_on_tool = default_config.yield_on_tool
     ; exit_condition = default_config.exit_condition
+    ; call_time_pruner_keep_recent = default_config.call_time_pruner_keep_recent
+    ; call_time_pruner_keep_last = default_config.call_time_pruner_keep_last
     }
   in
   let options =

--- a/lib/base/types.ml
+++ b/lib/base/types.ml
@@ -124,6 +124,12 @@ type agent_config =
     (** Release LLM slot during tool execution, re-acquire before next turn. @since 0.100.0 *)
   ; exit_condition : ((int -> bool)[@opaque]) option
     (** Custom exit predicate called with turn_count after each turn. @since 0.115.0 *)
+  ; call_time_pruner_keep_recent : int
+    (** Number of most recent turns whose tool results are NOT stubbed by the
+        call-time pruner in [Agent_turn.prepare_messages].  Default 2. *)
+  ; call_time_pruner_keep_last : int
+    (** Maximum number of most recent turns retained by the call-time pruner
+        in [Agent_turn.prepare_messages].  Default 100. *)
   }
 [@@deriving show]
 
@@ -154,6 +160,8 @@ let default_config =
   ; priority = None
   ; yield_on_tool = false
   ; exit_condition = None
+  ; call_time_pruner_keep_recent = 2
+  ; call_time_pruner_keep_last = 100
   }
 ;;
 

--- a/lib/base/types.mli
+++ b/lib/base/types.mli
@@ -71,6 +71,12 @@ type agent_config =
   ; yield_on_tool : bool (** Release LLM slot during tool execution. @since 0.100.0 *)
   ; exit_condition : ((int -> bool)[@opaque]) option
     (** Custom exit predicate called with turn_count after each turn. When it returns true the agent loop exits cleanly. @since 0.115.0 *)
+  ; call_time_pruner_keep_recent : int
+    (** Number of most recent turns whose tool results are NOT stubbed by the
+        call-time pruner in {!Agent_turn.prepare_messages}.  Default [2]. *)
+  ; call_time_pruner_keep_last : int
+    (** Maximum number of most recent turns retained by the call-time pruner
+        in {!Agent_turn.prepare_messages}.  Default [100]. *)
   }
 [@@deriving show]
 

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -100,6 +100,7 @@ let last_tool_results_from messages =
 
 let prepare_turn_for_agent agent ~turn_params =
   Agent_turn.prepare_turn
+    ~config:agent.state.config
     ~guardrails:agent.options.guardrails
     ~operator_policy:agent.options.operator_policy
     ~policy_channel:agent.options.policy_channel

--- a/lib/pipeline/stage_parse.ml
+++ b/lib/pipeline/stage_parse.ml
@@ -37,6 +37,7 @@ let last_tool_results_from messages =
     re-preparation (Stage 2.3). *)
 let prepare_turn_for_agent agent ~turn_params =
   Agent_turn.prepare_turn
+    ~config:agent.state.config
     ~guardrails:agent.options.guardrails
     ~operator_policy:agent.options.operator_policy
     ~policy_channel:agent.options.policy_channel

--- a/test/dune
+++ b/test/dune
@@ -17,3 +17,8 @@
  (name test_capabilities)
  (modules test_capabilities)
  (libraries agent_sdk alcotest))
+
+(test
+ (name test_call_time_pruner_config)
+ (modules test_call_time_pruner_config)
+ (libraries agent_sdk alcotest))

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -150,6 +150,7 @@ let test_prepare_messages_no_reducer () =
       ~context_reducer:None
       ~tiered_memory:None
       ~turn_params:Hooks.default_turn_params
+      ()
   in
   Alcotest.(check int) "same count" 1 (List.length result)
 ;;
@@ -173,6 +174,7 @@ let test_prepare_messages_extra_context () =
       ~context_reducer:None
       ~tiered_memory:None
       ~turn_params
+      ()
   in
   Alcotest.(check int) "prepended system msg" 2 (List.length result);
   let first = List.hd result in
@@ -205,6 +207,7 @@ let test_prepare_messages_system_prompt_override_noop () =
       ~context_reducer:None
       ~tiered_memory:None
       ~turn_params
+      ()
   in
   (* system_prompt_override is handled in pipeline stage_parse, not
      in prepare_messages. Message count should remain unchanged. *)
@@ -233,6 +236,7 @@ let test_prepare_messages_both_override_and_extra_context () =
       ~context_reducer:None
       ~tiered_memory:None
       ~turn_params
+      ()
   in
   (* extra_system_context injects a User message; system_prompt_override
      is applied separately in pipeline. So only extra_system_context
@@ -305,6 +309,7 @@ let test_prepare_messages_with_tiered_memory_after_system () =
       ~context_reducer:None
       ~tiered_memory:(Some tiered_memory)
       ~turn_params:Hooks.default_turn_params
+      ()
   in
   Alcotest.(check int) "system + recall + raw" 3 (List.length result);
   let first = List.nth result 0 in
@@ -347,6 +352,7 @@ let test_prepare_messages_omits_blank_tiered_memory () =
       ~context_reducer:None
       ~tiered_memory:(Some tiered_memory)
       ~turn_params:Hooks.default_turn_params
+      ()
   in
   Alcotest.(check int) "blank recall omitted" 1 (List.length result);
   Alcotest.(check string)
@@ -377,6 +383,7 @@ let test_prepare_messages_tiered_memory_reserves_token_budget () =
       ~context_reducer:reducer
       ~tiered_memory:None
       ~turn_params:Hooks.default_turn_params
+      ()
   in
   let tiered_memory : Agent_turn.tiered_memory =
     { long_term = Some (String.make 200 'r'); mid_term = None; short_term = None }
@@ -387,6 +394,7 @@ let test_prepare_messages_tiered_memory_reserves_token_budget () =
       ~context_reducer:reducer
       ~tiered_memory:(Some tiered_memory)
       ~turn_params:Hooks.default_turn_params
+      ()
   in
   let baseline_raw =
     List.filter (fun msg -> not (is_tiered_recall_message msg)) baseline

--- a/test/test_call_time_pruner_config.ml
+++ b/test/test_call_time_pruner_config.ml
@@ -1,0 +1,144 @@
+(** Tests for the call-time pruner config knobs added to
+    [Types.agent_config] (B-3 partial: magic-number extraction).
+
+    The pruner runs in [Agent_turn.prepare_messages] and stubs older
+    tool results / trims old turns before the LLM call.  Two new
+    fields control its aggressiveness:
+
+    - [call_time_pruner_keep_recent] (default 2) — turns whose tool
+      results are NOT stubbed.
+    - [call_time_pruner_keep_last]   (default 100) — max turns kept.
+
+    These tests exercise both the default path and a custom
+    override, ensuring the values flow from config into the reducer
+    composition. *)
+
+open Agent_sdk
+
+let mk_user text =
+  { Types.role = Types.User
+  ; content = [ Types.Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+let mk_assistant text =
+  { Types.role = Types.Assistant
+  ; content = [ Types.Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+(** Default values match the pre-extraction literals at
+    [agent_turn.ml]: [~keep_recent:2 ~keep_last:100]. *)
+let test_defaults_match_legacy_literals () =
+  Alcotest.(check int)
+    "default keep_recent = 2"
+    2
+    Types.default_config.call_time_pruner_keep_recent;
+  Alcotest.(check int)
+    "default keep_last = 100"
+    100
+    Types.default_config.call_time_pruner_keep_last
+;;
+
+(** Omitting [?config] preserves historical behaviour: with 10
+    messages, all survive because the default [keep_last] is 100. *)
+let test_default_config_keeps_all_short_history () =
+  let msgs =
+    [ mk_user "u1"
+    ; mk_assistant "a1"
+    ; mk_user "u2"
+    ; mk_assistant "a2"
+    ; mk_user "u3"
+    ; mk_assistant "a3"
+    ; mk_user "u4"
+    ; mk_assistant "a4"
+    ; mk_user "u5"
+    ; mk_assistant "a5"
+    ]
+  in
+  let result =
+    Agent_turn.prepare_messages
+      ~messages:msgs
+      ~context_reducer:None
+      ~tiered_memory:None
+      ~turn_params:Hooks.default_turn_params
+      ()
+  in
+  Alcotest.(check int)
+    "default keep_last=100 retains all 10 messages"
+    10
+    (List.length result)
+;;
+
+(** With a tight override, fewer messages survive — proving the
+    config field is actually consulted, not just stored. *)
+let test_override_keep_last_trims_more () =
+  let msgs =
+    [ mk_user "u1"
+    ; mk_assistant "a1"
+    ; mk_user "u2"
+    ; mk_assistant "a2"
+    ; mk_user "u3"
+    ; mk_assistant "a3"
+    ; mk_user "u4"
+    ; mk_assistant "a4"
+    ; mk_user "u5"
+    ; mk_assistant "a5"
+    ]
+  in
+  let baseline =
+    Agent_turn.prepare_messages
+      ~messages:msgs
+      ~context_reducer:None
+      ~tiered_memory:None
+      ~turn_params:Hooks.default_turn_params
+      ()
+  in
+  let tight_config =
+    { Types.default_config with
+      call_time_pruner_keep_recent = 1
+    ; call_time_pruner_keep_last = 2
+    }
+  in
+  let trimmed =
+    Agent_turn.prepare_messages
+      ~config:tight_config
+      ~messages:msgs
+      ~context_reducer:None
+      ~tiered_memory:None
+      ~turn_params:Hooks.default_turn_params
+      ()
+  in
+  Alcotest.(check bool)
+    "tight keep_last=2 trims more aggressively than default keep_last=100"
+    true
+    (List.length trimmed < List.length baseline)
+;;
+
+let () =
+  Alcotest.run
+    "call_time_pruner_config"
+    [ ( "defaults"
+      , [ Alcotest.test_case
+            "default values match legacy literals (2, 100)"
+            `Quick
+            test_defaults_match_legacy_literals
+        ; Alcotest.test_case
+            "default config keeps all messages in short history"
+            `Quick
+            test_default_config_keeps_all_short_history
+        ] )
+    ; ( "override"
+      , [ Alcotest.test_case
+            "override keep_last trims more aggressively"
+            `Quick
+            test_override_keep_last_trims_more
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

External audit (Tier B item B-3, partial) flagged `lib/agent/agent_turn.ml::call_time_pruner` for hardcoding `~keep_recent:2 ~keep_last:100`. These are policy knobs (depend on agent capability and conversation shape), not implementation constants — they belong in the agent config so capability-aware downstream code can tune them without editing the function body.

This PR extracts those two magic numbers into the agent config:

- `Types.agent_config.call_time_pruner_keep_recent` (default `2`)
- `Types.agent_config.call_time_pruner_keep_last`   (default `100`)

Field placement follows the existing flat-record style of `agent_config` (no nested record). Defaults match the previous literals so behaviour is unchanged for every existing caller.

`Agent_turn.prepare_messages` / `Agent_turn.prepare_turn` accept an optional `?config` and fall back to `Types.default_config` when omitted, keeping legacy callers source-compatible. The two pipeline entry points that call `prepare_turn` (`pipeline_stage_prepare.ml`, `stage_parse.ml`) now thread `~config:agent.state.config` so the pruner reads the live values.

## Scope

- Scoped strictly to the magic-number extraction.
- The full B-3 audit item also asked to remove the `idle_state` mutable record, but the existing pattern is caller-managed thread state across 8+ sites (not hidden module-level state). That surface deserves its own RFC and is explicitly deferred to a follow-up.

`RFC-WAIVED: lib/agent/agent_turn.ml is policy surface, not credential / identity / repo_manager / operator / sandbox / hooks / workflow*.`

## Test plan

- [x] `dune build --root .` clean
- [x] `dune build --root . @runtest` clean (no regressions)
- [x] New test file `test/test_call_time_pruner_config.ml` registered in `test/dune` — 3 cases pass:
  - default values match legacy literals (`2`, `100`)
  - default config keeps all messages in a short history (10 msgs survive `keep_last=100`)
  - tight override (`keep_recent=1`, `keep_last=2`) trims more aggressively than the default — proving the config field is actually consumed, not just stored

## Files

- `lib/base/types.ml` / `lib/base/types.mli` — two new fields on `agent_config`
- `lib/agent/agent_turn.ml` / `lib/agent/agent_turn.mli` — read fields in `prepare_messages`, optional `?config` plumbed through `prepare_turn`
- `lib/agent_sdk.ml` / `lib/agent/builder.ml` — populate the new fields from defaults so existing constructors compile
- `lib/pipeline/pipeline_stage_prepare.ml` / `lib/pipeline/stage_parse.ml` — pass `~config:agent.state.config` to `prepare_turn`
- `test/dune`, `test/test_call_time_pruner_config.ml` — new test
- `test/test_agent_turn.ml` — adds trailing `()` to existing `prepare_messages` calls so the (currently unregistered) file remains source-compatible with the new optional `?config`

Note: Draft. ready 전환은 `human-approved-ready` 라벨 부여 후 부탁드립니다.
