### PR TITLE
fix: bound cascade provider attempts

### DIFF
--- a/lib/llm_provider/complete_cascade.ml
+++ b/lib/llm_provider/complete_cascade.ml
@@ -33,6 +33,17 @@ type cascade_result =
       ; error : Http_client.http_error
       }
 
+let attempt_timeout_error ~model_id ~timeout_s =
+  Http_client.NetworkError
+    { kind = Http_client.Timeout
+    ; message =
+        Printf.sprintf
+          "cascade provider attempt for %s exceeded attempt_timeout_s %.1fs"
+          model_id
+          timeout_s
+    }
+;;
+
 (* --- Per-provider health tracking (Mutex-guarded) --- *)
 
 type provider_entry =
@@ -115,6 +126,7 @@ let complete_cascade
       ?cache
       ?metrics
       ?retry_config
+      ?attempt_timeout_s
       ?(cascade_config = default_cascade_config)
       ?(health = create_health ~clock ())
       ~steps
@@ -135,7 +147,7 @@ let complete_cascade
           errors
           ((config, Circuit_breaker_open { provider = key }) :: skipped)
       else (
-        let result =
+        let attempt () =
           Complete.complete_with_retry
             ~sw
             ~net
@@ -148,6 +160,19 @@ let complete_cascade
             ~messages
             ?tools
             ()
+        in
+        let result =
+          let timeout_s =
+            match attempt_timeout_s with
+            | Some timeout_s -> Some timeout_s
+            | None -> Provider_config.default_attempt_timeout_s config.kind
+          in
+          match timeout_s with
+          | None -> attempt ()
+          | Some timeout_s ->
+            (try Eio.Time.with_timeout_exn clock timeout_s attempt with
+             | Eio.Time.Timeout ->
+               Error (attempt_timeout_error ~model_id:config.model_id ~timeout_s))
         in
         match result with
         | Ok response ->

--- a/lib/llm_provider/complete_cascade.ml
+++ b/lib/llm_provider/complete_cascade.ml
@@ -38,7 +38,7 @@ let attempt_timeout_error ~model_id ~timeout_s =
     { kind = Http_client.Timeout
     ; message =
         Printf.sprintf
-          "cascade provider attempt for %s exceeded attempt_timeout_s %.1fs"
+          "cascade provider attempt for %s exceeded attempt_timeout_s %gs"
           model_id
           timeout_s
     }
@@ -162,9 +162,15 @@ let complete_cascade
             ()
         in
         let result =
+          (* Sentinel: [Some t] with [t <= 0.0] disables the cascade-level
+             timeout for this call, even when the provider default would
+             otherwise apply. Required so callers can opt out for
+             long-running local models without losing the per-kind default
+             for everyone else. *)
           let timeout_s =
             match attempt_timeout_s with
-            | Some timeout_s -> Some timeout_s
+            | Some t when t <= 0.0 -> None
+            | Some t -> Some t
             | None -> Provider_config.default_attempt_timeout_s config.kind
           in
           match timeout_s with

--- a/lib/llm_provider/complete_cascade.mli
+++ b/lib/llm_provider/complete_cascade.mli
@@ -90,8 +90,17 @@ type cascade_result =
     5. On other error, record failure and try next step
 
     [?attempt_timeout_s] caps one provider step, including its internal
-    retry loop. When omitted, provider-specific defaults from
-    {!Provider_config.default_attempt_timeout_s} are used when present.
+    retry loop:
+    - omitted (no argument): provider-specific defaults from
+      {!Provider_config.default_attempt_timeout_s} apply when present
+      (Ollama, Claude_code, Kimi_cli, Gemini_cli have positive defaults;
+      others have none).
+    - [Some t] with [t > 0.0]: use [t] seconds for this call, regardless
+      of the provider default.
+    - [Some t] with [t <= 0.0]: disable the cascade-level timeout for
+      this call. Use this to opt out for long-running local models
+      (e.g. an Ollama instance loading a large MoE) where the provider
+      default is too aggressive.
 
     When [health] is [None], a fresh tracker is created per call.
     Pass a shared tracker to maintain circuit state across calls. *)

--- a/lib/llm_provider/complete_cascade.mli
+++ b/lib/llm_provider/complete_cascade.mli
@@ -89,6 +89,10 @@ type cascade_result =
     4. On hard quota error, record failure and return [Hard_quota]
     5. On other error, record failure and try next step
 
+    [?attempt_timeout_s] caps one provider step, including its internal
+    retry loop. When omitted, provider-specific defaults from
+    {!Provider_config.default_attempt_timeout_s} are used when present.
+
     When [health] is [None], a fresh tracker is created per call.
     Pass a shared tracker to maintain circuit state across calls. *)
 val complete_cascade
@@ -99,6 +103,7 @@ val complete_cascade
   -> ?cache:Cache.t
   -> ?metrics:Metrics.t
   -> ?retry_config:Complete.retry_config
+  -> ?attempt_timeout_s:float
   -> ?cascade_config:cascade_config
   -> ?health:provider_health
   -> steps:Provider_config.t list

--- a/test/dune
+++ b/test/dune
@@ -11,7 +11,7 @@
 (test
  (name test_complete_cascade)
  (modules test_complete_cascade)
- (libraries agent_sdk alcotest))
+ (libraries agent_sdk alcotest eio_main))
 
 (test
  (name test_capabilities)

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -197,6 +197,7 @@ let test_attempt_timeout_fast_paths_without_retrying_same_step () =
       ~base_url:"http://localhost:11434"
       ()
   in
+  let started_at = Unix.gettimeofday () in
   let result =
     Complete_cascade.complete_cascade
       ~sw
@@ -208,12 +209,67 @@ let test_attempt_timeout_fast_paths_without_retrying_same_step () =
       ~messages:[]
       ()
   in
+  let elapsed_s = Unix.gettimeofday () -. started_at in
   check int "single provider attempt" 1 (Atomic.get calls);
+  (* Fast-path property the test name advertises: the call must NOT wait
+     for the full 5s sleep before returning. Use a generous 1s ceiling so
+     CI scheduling jitter does not flake; a broken implementation that
+     waited for the underlying transport would clock in around 5s. *)
+  check
+    bool
+    (Printf.sprintf "elapsed %.3fs < 1.0s (timeout fast-path)" elapsed_s)
+    true
+    (elapsed_s < 1.0);
   match result with
   | Complete_cascade.All_failed
       { errors = [ (_, Http_client.NetworkError { kind; _ }) ]; _ } ->
     check bool "timeout classified" true (kind = Http_client.Timeout)
   | _ -> fail "expected timeout All_failed"
+;;
+
+let test_attempt_timeout_disable_via_nonpositive_sentinel () =
+  (* `?attempt_timeout_s:(Some 0.0)` (or any negative) opts out of the
+     cascade-level timeout, so a transport that takes longer than the
+     provider's default still runs to completion. Without this escape
+     hatch, callers depending on long-running local models could not
+     opt out individually once provider defaults landed. *)
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let transport : Llm_transport.t =
+    { complete_sync =
+        (fun _ ->
+          Eio.Time.sleep clock 0.05;
+          { Llm_transport.response = Ok dummy_response; latency_ms = 50 })
+    ; complete_stream =
+        (fun ~on_event:_ _ ->
+          Eio.Time.sleep clock 0.05;
+          Ok dummy_response)
+    }
+  in
+  let config =
+    Provider_config.make
+      ~kind:Ollama
+      ~model_id:"local"
+      ~base_url:"http://localhost:11434"
+      ()
+  in
+  let result =
+    Complete_cascade.complete_cascade
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~clock
+      ~transport
+      ~attempt_timeout_s:0.0
+      ~steps:[ config ]
+      ~messages:[]
+      ()
+  in
+  match result with
+  | Complete_cascade.Success _ -> ()
+  | _ -> fail "expected Success when timeout disabled by sentinel"
 ;;
 
 (* ── Test suite ───────────────────────────────────────── *)

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -170,6 +170,52 @@ let test_skip_reason_variant () =
     check string "provider" "test@localhost" provider
 ;;
 
+let test_attempt_timeout_fast_paths_without_retrying_same_step () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let calls = Atomic.make 0 in
+  let transport : Llm_transport.t =
+    { complete_sync =
+        (fun _ ->
+          Atomic.incr calls;
+          Eio.Time.sleep clock 5.0;
+          { Llm_transport.response = Ok dummy_response; latency_ms = 5000 })
+    ; complete_stream =
+        (fun ~on_event:_ _ ->
+          Atomic.incr calls;
+          Eio.Time.sleep clock 5.0;
+          Ok dummy_response)
+    }
+  in
+  let config =
+    Provider_config.make
+      ~kind:Ollama
+      ~model_id:"slow"
+      ~base_url:"http://localhost:11434"
+      ()
+  in
+  let result =
+    Complete_cascade.complete_cascade
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~clock
+      ~transport
+      ~attempt_timeout_s:0.01
+      ~steps:[ config ]
+      ~messages:[]
+      ()
+  in
+  check int "single provider attempt" 1 (Atomic.get calls);
+  match result with
+  | Complete_cascade.All_failed
+      { errors = [ (_, Http_client.NetworkError { kind; _ }) ]; _ } ->
+    check bool "timeout classified" true (kind = Http_client.Timeout)
+  | _ -> fail "expected timeout All_failed"
+;;
+
 (* ── Test suite ───────────────────────────────────────── *)
 
 let suite =
@@ -184,6 +230,9 @@ let suite =
   ; "result_all_failed", `Quick, test_result_all_failed_variant
   ; "result_hard_quota", `Quick, test_result_hard_quota_variant
   ; "skip_reason", `Quick, test_skip_reason_variant
+  ; ( "attempt_timeout_fast_path"
+    , `Quick
+    , test_attempt_timeout_fast_paths_without_retrying_same_step )
   ]
 ;;
 


### PR DESCRIPTION
## Summary
- apply cascade-level provider attempt deadlines around `Complete.complete_with_retry`
- use `Provider_config.default_attempt_timeout_s` by default, with `?attempt_timeout_s` override for tests/callers
- add a regression test proving a hung provider attempt is cut off once and reported as a timeout

## Why
A single provider step could hold the cascade through its full internal retry/rotation path. OAS already had provider-specific attempt timeout metadata, but `complete_cascade` did not enforce it. This turns that metadata into a fast-path guard so the cascade can move on instead of waiting on a stuck lane.

## Validation
- `scripts/dune-local.sh build test/test_complete_cascade.exe`
- `./_build/default/test/test_complete_cascade.exe`
