### PR TITLE
ci: pin OAS_RUNTIME_PATH for sandbox-isolated runtest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,13 @@ jobs:
       - name: Test
         env:
           ALCOTEST_QUICK_TESTS: "1"
+          # Test stanzas wired in `test/dune` may exercise `Transport.find_runtime`,
+          # which searches `_build/default/bin/oas_runtime.exe` relative to the test's
+          # cwd. Under `dune runtest` each binary runs from a sandbox dir whose cwd
+          # is NOT the repo root, so the relative search misses the freshly-built
+          # runtime. Pin an absolute path so wired runtime/transport/sdk tests can
+          # locate the binary regardless of sandbox cwd.
+          OAS_RUNTIME_PATH: ${{ github.workspace }}/_build/default/bin/oas_runtime.exe
         run: opam exec -- dune runtest
 
       - name: Upload harness eval artifacts
@@ -85,6 +92,10 @@ jobs:
           # io_uring_queue_init under bisect eventually returns ENOMEM and
           # fails the step.
           EIO_BACKEND: "posix"
+          # See note on the Test step: dune sandbox cwd is not the repo root,
+          # so `Transport.find_runtime` cannot resolve the runtime via the
+          # default relative search. Pin the absolute path here too.
+          OAS_RUNTIME_PATH: ${{ github.workspace }}/_build/default/bin/oas_runtime.exe
         run: |
           mkdir -p _coverage
           # Pin coverage file location outside dune's per-test sandboxes.
@@ -95,6 +106,11 @@ jobs:
           # library to write files at a stable absolute prefix instead.
           export BISECT_FILE="$PWD/_coverage/bisect"
           opam exec -- dune clean
+          # Rebuild the runtime binary up-front so test stanzas that use
+          # `Transport.find_runtime` via `OAS_RUNTIME_PATH` find it. Without
+          # this explicit build, the runtest step below only rebuilds
+          # test-reachable targets and the bin/oas_runtime.exe path is empty.
+          opam exec -- dune build bin/oas_runtime.exe
           # `--instrument-with bisect_ppx` activates the
           # `(instrumentation (backend bisect_ppx))` stanza declared in
           # lib/dune. Without this flag dune ignores the stanza and no


### PR DESCRIPTION
## 배경

#1374 (test wiring) 의 CI 가 30+ 테스트 실패. 패턴 분석:

\`\`\`
FAIL File find_runtime failed on oas_runtime: No runtime binary found.
     Set OAS_RUNTIME_PATH or build bin/oas_runtime.exe.
\`\`\`

## 본질 진단

- `lib/transport.ml::find_runtime` (line 63-98) 가 cwd 기준 `_build/default/bin/oas_runtime.exe` 를 탐색.
- `dune runtest` 는 각 테스트 binary 를 sandbox 디렉토리(`_build/.sandbox/...`) 에서 실행 → cwd 가 repo root 가 아님 → 상대 경로 탐색 실패.
- main 에서는 runtime 의존 test stanza 들이 wired 안 돼있어 노출되지 않았던 사전 인프라 누락.

## 변경

`.github/workflows/ci.yml` 두 곳에 `OAS_RUNTIME_PATH=\${{ github.workspace }}/_build/default/bin/oas_runtime.exe` 환경변수 export:
1. **Test step** (line 64-67) — 일반 runtest
2. **Coverage step** (line 86+) — bisect_ppx instrumented runtest. `dune clean` 후이므로 `dune build bin/oas_runtime.exe` 도 같이 추가.

## 안전성

- main 의 현재 test/dune 에 wired 된 stanza 중 `find_runtime` 의존 항목이 없음 → 본 PR 단독 머지 시 동작 변화 0건.
- 효과 발휘는 follow-up PR (#1374 wiring) 머지 후. 그때 #1374 의 30+ 실패가 해소될 것으로 예상.

## Test plan
- [ ] CI green (현재 main 흐름 그대로)
- [ ] 머지 후 #1374 의 conflict resolve 브랜치에서 main rebase → 30+ 실패 감소 확인