### PR TITLE
build(test): pass runtime path to wired tests

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -30,6 +30,10 @@
 ;   - test/test_provider_bridge.ml     (to_provider_config zai coding auto)
 ;   - test/test_provider_complete.ml   (openai_build_request glm reasoning)
 ;   - test/test_streaming.ml           (parse_sse_event unknown/malformed)
+;
+; Dune runs tests in sandboxes, so runtime-spawning tests cannot rely on
+; cwd-relative _build/default/bin/oas_runtime.exe discovery.
+; Point all wired suites at the locally built public runtime binary.
 
 (tests
  (names
@@ -246,7 +250,13 @@
   test_v024_fixes
   test_vcs_graph_snapshot
   test_verified_output)
- (libraries agent_sdk alcotest))
+ (libraries agent_sdk alcotest)
+ (deps %{bin:oas-runtime})
+ (action
+  (setenv
+   OAS_RUNTIME_PATH
+   %{bin:oas-runtime}
+   (run %{test}))))
 
 ; QCheck-based property tests
 
@@ -259,7 +269,13 @@
   test_property_advanced
   test_tool_op
   test_tool_set)
- (libraries agent_sdk alcotest qcheck-core qcheck-alcotest))
+ (libraries agent_sdk alcotest qcheck-core qcheck-alcotest)
+ (deps %{bin:oas-runtime})
+ (action
+  (setenv
+   OAS_RUNTIME_PATH
+   %{bin:oas-runtime}
+   (run %{test}))))
 
 ; Tests with extra dependencies — kept as individual stanzas
 ; so the grouped (tests (names ...)) above does not need to pull
@@ -268,4 +284,10 @@
 (test
  (name test_complete_cascade)
  (modules test_complete_cascade)
- (libraries agent_sdk alcotest eio_main))
+ (libraries agent_sdk alcotest eio_main)
+ (deps %{bin:oas-runtime})
+ (action
+  (setenv
+   OAS_RUNTIME_PATH
+   %{bin:oas-runtime}
+   (run %{test}))))


### PR DESCRIPTION
## Summary

Follow-up to #1374 and #1377. #1377 pins OAS_RUNTIME_PATH in GitHub CI, but local `dune runtest` still depends on the caller remembering that environment variable. This makes the wired `test/dune` stanzas self-contained: each test action sets OAS_RUNTIME_PATH to Dune’s local `oas-runtime` binary and declares the binary as a dependency.

This keeps runtime/transport/sdk tests from relying on cwd-relative `_build/default/bin/oas_runtime.exe` discovery inside Dune sandboxes.

## Verification

- `opam exec -- dune format-dune-file test/dune | diff -u test/dune -`
- `opam exec -- dune describe workspace --root . > /tmp/oas-dune-describe-1378.txt`
- `git diff --check origin/main...HEAD`

## Notes

Local full `dune runtest` is not included because the shared host Dune lock is occupied by long-running MASC Dune jobs; CI should be the runtime proof surface for this follow-up.