### PR TITLE
fix(capabilities): surface manifest load diagnostics

### DIFF
--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -39,7 +39,7 @@ let json_kind = function
   | `Null -> "null"
   | `Bool _ -> "bool"
   | `Int _ -> "int"
-  | `Intlit _ -> "int"
+  | `Intlit _ -> "intlit"
   | `Float _ -> "float"
   | `String _ -> "string"
   | `Assoc _ -> "object"
@@ -71,6 +71,16 @@ let member_bool key json =
 let member_int key json =
   match Yojson.Safe.Util.member key json with
   | `Int n -> Some n
+  | `Intlit s ->
+    (match int_of_string_opt s with
+     | Some n -> Some n
+     | None ->
+       Diag.warn
+         "capability_manifest"
+         "ignoring field %S: integer literal %S out of native int range"
+         key
+         s;
+       None)
   | actual ->
     warn_type_mismatch key ~expected:"int" actual;
     None

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -35,22 +35,53 @@ type t = entry list
 
 (* ── JSON parsing helpers ───────────────────────────────── *)
 
+let json_kind = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "int"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+;;
+
+let warn_type_mismatch key ~expected actual =
+  match actual with
+  | `Null -> ()
+  | _ ->
+    Diag.warn
+      "capability_manifest"
+      "ignoring field %S: expected %s, got %s"
+      key
+      expected
+      (json_kind actual)
+;;
+
 let member_bool key json =
   match Yojson.Safe.Util.member key json with
   | `Bool b -> Some b
-  | _ -> None
+  | actual ->
+    warn_type_mismatch key ~expected:"bool" actual;
+    None
 ;;
 
 let member_int key json =
   match Yojson.Safe.Util.member key json with
   | `Int n -> Some n
-  | _ -> None
+  | actual ->
+    warn_type_mismatch key ~expected:"int" actual;
+    None
 ;;
 
 let member_string_opt key json =
   match Yojson.Safe.Util.member key json with
   | `String s -> Some s
-  | _ -> None
+  | actual ->
+    warn_type_mismatch key ~expected:"string" actual;
+    None
 ;;
 
 let parse_entry json =
@@ -134,6 +165,20 @@ let load_file path =
   Result.bind read_result of_json
 ;;
 
+let load_runtime_file path =
+  match load_file path with
+  | Ok manifest ->
+    Diag.info
+      "capability_manifest"
+      "loaded %d entries from %s"
+      (List.length manifest)
+      path;
+    Some manifest
+  | Error msg ->
+    Diag.warn "capability_manifest" "failed to load %s: %s" path msg;
+    None
+;;
+
 (* ── Lookup ─────────────────────────────────────────────── *)
 
 let lookup (t : t) model_id =
@@ -152,18 +197,7 @@ let global_manifest : t option Lazy.t =
   lazy
     (match Cli_common_env.get "OAS_CAPABILITY_MANIFEST" with
      | None -> None
-     | Some path ->
-       (match load_file path with
-        | Ok manifest ->
-          Diag.debug
-            "capability_manifest"
-            "loaded %d entries from %s"
-            (List.length manifest)
-            path;
-          Some manifest
-        | Error msg ->
-          Diag.warn "capability_manifest" "failed to load %s: %s" path msg;
-          None))
+     | Some path -> load_runtime_file path)
 ;;
 
 let global () = Lazy.force global_manifest

--- a/lib/llm_provider/capability_manifest.mli
+++ b/lib/llm_provider/capability_manifest.mli
@@ -87,6 +87,10 @@ val of_json : Yojson.Safe.t -> (t, string) result
     path.  Returns [Error msg] on I/O or JSON parse errors. *)
 val load_file : string -> (t, string) result
 
+(** [load_runtime_file path] reads a manifest for runtime use and emits
+    operator diagnostics for success or failure. *)
+val load_runtime_file : string -> t option
+
 (** [lookup t model_id] returns the first entry whose [id_prefix] is a
     case-insensitive prefix of [model_id].  Returns [None] when no
     entry matches. *)

--- a/lib/llm_provider/diag.ml
+++ b/lib/llm_provider/diag.ml
@@ -23,6 +23,12 @@ let default_sink (lvl : level) ~ctx msg =
 
 let _sink : (level -> ctx:string -> string -> unit) Atomic.t = Atomic.make default_sink
 let set_sink s = Atomic.set _sink s
+let with_sink sink f =
+  let previous = Atomic.get _sink in
+  Atomic.set _sink sink;
+  Fun.protect ~finally:(fun () -> Atomic.set _sink previous) f
+;;
+
 let emit lvl ctx fmt = Printf.ksprintf (fun msg -> (Atomic.get _sink) lvl ~ctx msg) fmt
 let debug ctx fmt = emit Debug ctx fmt
 let info ctx fmt = emit Info ctx fmt

--- a/lib/llm_provider/diag.ml
+++ b/lib/llm_provider/diag.ml
@@ -23,6 +23,7 @@ let default_sink (lvl : level) ~ctx msg =
 
 let _sink : (level -> ctx:string -> string -> unit) Atomic.t = Atomic.make default_sink
 let set_sink s = Atomic.set _sink s
+
 let with_sink sink f =
   let previous = Atomic.get _sink in
   Atomic.set _sink sink;

--- a/lib/llm_provider/diag.mli
+++ b/lib/llm_provider/diag.mli
@@ -23,7 +23,15 @@ val level_to_string : level -> string
 val set_sink : (level -> ctx:string -> string -> unit) -> unit
 
 (** Temporarily replace the global diagnostic sink while [f] runs.
-    The previous sink is restored even if [f] raises. *)
+    The previous sink is restored even if [f] raises.
+
+    Concurrency: the swap-and-restore is intended for tests and
+    single-threaded bootstrap. The sink is global, so during [f]
+    diagnostics from other threads/domains are also routed through
+    [sink]; a concurrent [set_sink] from another thread can be
+    overwritten when the previous sink is restored on return. Do not
+    use in production code paths that may run alongside other
+    diagnostic producers. *)
 val with_sink : (level -> ctx:string -> string -> unit) -> (unit -> 'a) -> 'a
 
 (** Emit diagnostics at the given level.

--- a/lib/llm_provider/diag.mli
+++ b/lib/llm_provider/diag.mli
@@ -22,6 +22,10 @@ val level_to_string : level -> string
     Thread-safe via [Atomic.t]. *)
 val set_sink : (level -> ctx:string -> string -> unit) -> unit
 
+(** Temporarily replace the global diagnostic sink while [f] runs.
+    The previous sink is restored even if [f] raises. *)
+val with_sink : (level -> ctx:string -> string -> unit) -> (unit -> 'a) -> 'a
+
 (** Emit diagnostics at the given level.
     [ctx] is the module/subsystem name (e.g. "cascade_executor"). *)
 val debug : string -> ('a, unit, string, unit) format4 -> 'a

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -26,10 +26,13 @@ let check_contains label s sub =
 let with_temp_manifest contents f =
   let path = Filename.temp_file "oas-capability-manifest" ".json" in
   let oc = open_out path in
-  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
-    output_string oc contents);
   Fun.protect
-    ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ())
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc contents);
+  Fun.protect
+    ~finally:(fun () ->
+      try Sys.remove path with
+      | Sys_error _ -> ())
     (fun () -> f path)
 ;;
 
@@ -402,6 +405,67 @@ let test_manifest_wrong_type_fields_warn_and_ignore () =
   check bool "warned for supports_tools" true (has_warning "supports_tools" "bool")
 ;;
 
+let test_manifest_intlit_in_range_accepted () =
+  (* Yojson.Safe represents large literals as `Intlit s. Build the JSON value
+     directly to exercise the Intlit branch deterministically. *)
+  let json =
+    `Assoc
+      [ "schema_version", `Int 1
+      ; ( "models"
+        , `List
+            [ `Assoc
+                [ "id_prefix", `String "intlit-ok"
+                ; "max_context_tokens", `Intlit "131072"
+                ]
+            ] )
+      ]
+  in
+  match Capability_manifest.of_json json with
+  | Ok [ entry ] ->
+    check (option int) "intlit accepted" (Some 131_072) entry.max_context_tokens
+  | Ok _ -> Alcotest.fail "expected one manifest entry"
+  | Error msg -> Alcotest.failf "unexpected parse error: %s" msg
+;;
+
+let test_manifest_intlit_out_of_range_warns () =
+  let warnings = ref [] in
+  let huge = "99999999999999999999999999" in
+  let json =
+    `Assoc
+      [ "schema_version", `Int 1
+      ; ( "models"
+        , `List
+            [ `Assoc
+                [ "id_prefix", `String "intlit-overflow"
+                ; "max_context_tokens", `Intlit huge
+                ]
+            ] )
+      ]
+  in
+  let manifest =
+    Diag.with_sink
+      (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
+      (fun () -> Capability_manifest.of_json json)
+  in
+  let entry =
+    match manifest with
+    | Ok [ entry ] -> entry
+    | Ok _ -> Alcotest.fail "expected one manifest entry"
+    | Error msg -> Alcotest.failf "unexpected parse error: %s" msg
+  in
+  check (option int) "out-of-range intlit ignored" None entry.max_context_tokens;
+  let has_warning =
+    List.exists
+      (fun (level, ctx, msg) ->
+         level = Diag.Warn
+         && String.equal ctx "capability_manifest"
+         && string_contains_sub msg "max_context_tokens"
+         && string_contains_sub msg "out of native int range")
+      !warnings
+  in
+  check bool "warned about overflow" true has_warning
+;;
+
 let test_manifest_load_file_missing_returns_error () =
   let path = Filename.temp_file "oas-capability-manifest-missing" ".json" in
   Sys.remove path;
@@ -432,7 +496,8 @@ let test_manifest_load_runtime_file_success_logs_info () =
            (fun () -> Capability_manifest.load_runtime_file path)
        in
        (match manifest with
-        | Some [ entry ] -> check string "loaded id_prefix" "runtime-visible" entry.id_prefix
+        | Some [ entry ] ->
+          check string "loaded id_prefix" "runtime-visible" entry.id_prefix
         | Some _ -> Alcotest.fail "expected one runtime manifest entry"
         | None -> Alcotest.fail "expected runtime manifest to load");
        let has_info =
@@ -609,6 +674,14 @@ let () =
             "wrong-type fields warn and ignore"
             `Quick
             test_manifest_wrong_type_fields_warn_and_ignore
+        ; test_case
+            "intlit in range accepted"
+            `Quick
+            test_manifest_intlit_in_range_accepted
+        ; test_case
+            "intlit out of range warns"
+            `Quick
+            test_manifest_intlit_out_of_range_warns
         ; test_case
             "missing manifest file errors"
             `Quick

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -3,6 +3,36 @@
 open Alcotest
 open Llm_provider
 
+let string_contains_sub s sub =
+  let s_len = String.length s in
+  let sub_len = String.length sub in
+  let rec loop i =
+    if sub_len = 0
+    then true
+    else if i + sub_len > s_len
+    then false
+    else if String.sub s i sub_len = sub
+    then true
+    else loop (i + 1)
+  in
+  loop 0
+;;
+
+let check_contains label s sub =
+  if not (string_contains_sub s sub)
+  then Alcotest.failf "%s: expected %S to contain %S" label s sub
+;;
+
+let with_temp_manifest contents f =
+  let path = Filename.temp_file "oas-capability-manifest" ".json" in
+  let oc = open_out path in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+    output_string oc contents);
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ())
+    (fun () -> f path)
+;;
+
 (* ── Default capabilities ────────────────────────────── *)
 
 let test_default_no_limits () =
@@ -338,6 +368,85 @@ let test_apply_manifest_entry_all_none_uses_base () =
   check bool "caching matches base" base.supports_caching caps.supports_caching
 ;;
 
+let test_manifest_wrong_type_fields_warn_and_ignore () =
+  let warnings = ref [] in
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"typed","base":17,"max_context_tokens":"131072","supports_tools":"yes"}]}|}
+  in
+  let manifest =
+    Diag.with_sink
+      (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
+      (fun () -> Capability_manifest.of_json json)
+  in
+  let entry =
+    match manifest with
+    | Ok [ entry ] -> entry
+    | Ok _ -> Alcotest.fail "expected one manifest entry"
+    | Error msg -> Alcotest.failf "unexpected parse error: %s" msg
+  in
+  check (option string) "wrong-type base ignored" None entry.base_label;
+  check (option int) "wrong-type int ignored" None entry.max_context_tokens;
+  check (option bool) "wrong-type bool ignored" None entry.supports_tools;
+  let has_warning field expected =
+    List.exists
+      (fun (level, ctx, msg) ->
+         level = Diag.Warn
+         && String.equal ctx "capability_manifest"
+         && string_contains_sub msg (Printf.sprintf "field %S" field)
+         && string_contains_sub msg (Printf.sprintf "expected %s" expected))
+      !warnings
+  in
+  check bool "warned for base" true (has_warning "base" "string");
+  check bool "warned for max_context_tokens" true (has_warning "max_context_tokens" "int");
+  check bool "warned for supports_tools" true (has_warning "supports_tools" "bool")
+;;
+
+let test_manifest_load_file_missing_returns_error () =
+  let path = Filename.temp_file "oas-capability-manifest-missing" ".json" in
+  Sys.remove path;
+  match Capability_manifest.load_file path with
+  | Error msg ->
+    check_contains "mentions cannot read" msg "cannot read capability manifest";
+    check_contains "mentions path" msg path
+  | Ok _ -> Alcotest.fail "expected missing manifest path to fail"
+;;
+
+let test_manifest_load_file_malformed_returns_error () =
+  with_temp_manifest {|{"schema_version":1,"models":[|} (fun path ->
+    match Capability_manifest.load_file path with
+    | Error msg ->
+      check_contains "mentions JSON parse" msg "capability manifest JSON parse error";
+      check_contains "mentions path" msg path
+    | Ok _ -> Alcotest.fail "expected malformed manifest JSON to fail")
+;;
+
+let test_manifest_load_runtime_file_success_logs_info () =
+  let logs = ref [] in
+  with_temp_manifest
+    {|{"schema_version":1,"models":[{"id_prefix":"runtime-visible","supports_tools":true}] }|}
+    (fun path ->
+       let manifest =
+         Diag.with_sink
+           (fun level ~ctx msg -> logs := (level, ctx, msg) :: !logs)
+           (fun () -> Capability_manifest.load_runtime_file path)
+       in
+       (match manifest with
+        | Some [ entry ] -> check string "loaded id_prefix" "runtime-visible" entry.id_prefix
+        | Some _ -> Alcotest.fail "expected one runtime manifest entry"
+        | None -> Alcotest.fail "expected runtime manifest to load");
+       let has_info =
+         List.exists
+           (fun (level, ctx, msg) ->
+              level = Diag.Info
+              && String.equal ctx "capability_manifest"
+              && string_contains_sub msg "loaded 1 entries"
+              && string_contains_sub msg path)
+           !logs
+       in
+       check bool "logs info load success" true has_info)
+;;
+
 (* ── DashScope preset ────────────────────────────────── *)
 
 let test_dashscope_capabilities () =
@@ -496,6 +605,22 @@ let () =
             "all-None entry matches base"
             `Quick
             test_apply_manifest_entry_all_none_uses_base
+        ; test_case
+            "wrong-type fields warn and ignore"
+            `Quick
+            test_manifest_wrong_type_fields_warn_and_ignore
+        ; test_case
+            "missing manifest file errors"
+            `Quick
+            test_manifest_load_file_missing_returns_error
+        ; test_case
+            "malformed manifest file errors"
+            `Quick
+            test_manifest_load_file_malformed_returns_error
+        ; test_case
+            "runtime manifest load logs success"
+            `Quick
+            test_manifest_load_runtime_file_success_logs_info
         ] )
     ; ( "prefix_ordering"
       , [ test_case


### PR DESCRIPTION
## Summary

- Promote successful `OAS_CAPABILITY_MANIFEST` runtime loads to an `INFO` diagnostic so operators can confirm the override layer is active without debug flags.
- Warn when manifest fields have the wrong JSON type instead of silently treating them as unset.
- Add focused coverage for wrong-type fields, missing files, malformed JSON, and the success diagnostic.

## Root Cause

The manifest parser used permissive helper functions that returned `None` for type mismatches, which made operator typos look identical to intentionally omitted fields. The global manifest loader also emitted its success path at `DEBUG`, so production startup had no visible confirmation that the manifest file loaded.

## Validation

- `git diff --check`
- `opam exec -- dune exec --root=. ./test/test_capabilities.exe`

Fixes #1372
