### PR TITLE
feat(runtime): add durable relay delivery primitive

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -133,6 +133,7 @@ module Tool_use_recovery = Tool_use_recovery
 module Tool_selector = Tool_selector
 module Lesson_memory = Lesson_memory
 module Event_forward = Event_forward
+module Relay_delivery = Relay_delivery
 module Metrics = Metrics
 module Progressive_tools = Progressive_tools
 module Autonomy_trace_analyzer = Autonomy_trace_analyzer

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -102,6 +102,7 @@ module Autonomy_diff_guard = Autonomy_diff_guard
 module Metric_contract = Metric_contract
 module Lesson_memory = Lesson_memory
 module Event_forward = Event_forward
+module Relay_delivery = Relay_delivery
 module Metrics = Metrics
 module Progressive_tools = Progressive_tools
 module Autonomy_trace_analyzer = Autonomy_trace_analyzer

--- a/lib/relay_delivery.ml
+++ b/lib/relay_delivery.ml
@@ -129,9 +129,7 @@ let pending t = t.pending
 
 let stats t =
   let retry_total = t.retry_persist_total + t.retry_publish_total in
-  let drop_total =
-    t.drop_persist_total + t.drop_publish_total + t.drop_queue_total
-  in
+  let drop_total = t.drop_persist_total + t.drop_publish_total + t.drop_queue_total in
   { queue_depth = List.length t.pending
   ; retry_total
   ; drop_total

--- a/lib/relay_delivery.ml
+++ b/lib/relay_delivery.ml
@@ -1,0 +1,167 @@
+(** Two-stage event relay delivery. *)
+
+type stage =
+  | Persist
+  | Publish
+  | Queue
+
+type 'a pending =
+  { payload : 'a
+  ; attempts : int
+  ; persisted : bool
+  }
+
+type 'a delivery_result =
+  | Delivered
+  | Retryable_failure of 'a pending * stage * exn
+
+type stats =
+  { queue_depth : int
+  ; retry_total : int
+  ; drop_total : int
+  ; retry_persist_total : int
+  ; retry_publish_total : int
+  ; drop_persist_total : int
+  ; drop_publish_total : int
+  ; drop_queue_total : int
+  }
+
+type 'a t =
+  { max_attempts : int
+  ; max_queue_depth : int
+  ; mutable pending : 'a pending list
+  ; mutable retry_persist_total : int
+  ; mutable retry_publish_total : int
+  ; mutable drop_persist_total : int
+  ; mutable drop_publish_total : int
+  ; mutable drop_queue_total : int
+  }
+
+let stage_to_string = function
+  | Persist -> "persist"
+  | Publish -> "publish"
+  | Queue -> "queue"
+;;
+
+let make_pending payload = { payload; attempts = 0; persisted = false }
+
+let deliver_with ~persist ~publish pending =
+  try
+    let pending =
+      if pending.persisted
+      then pending
+      else (
+        persist pending.payload;
+        { pending with persisted = true })
+    in
+    try
+      publish pending.payload;
+      Delivered
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Retryable_failure (pending, Publish, exn)
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Retryable_failure (pending, Persist, exn)
+;;
+
+let create ?(max_attempts = 3) ?(max_queue_depth = 256) () =
+  { max_attempts = max 1 max_attempts
+  ; max_queue_depth = max 1 max_queue_depth
+  ; pending = []
+  ; retry_persist_total = 0
+  ; retry_publish_total = 0
+  ; drop_persist_total = 0
+  ; drop_publish_total = 0
+  ; drop_queue_total = 0
+  }
+;;
+
+let enqueue t payload =
+  let item = make_pending payload in
+  if List.length t.pending < t.max_queue_depth
+  then (
+    t.pending <- t.pending @ [ item ];
+    None)
+  else (
+    match t.pending with
+    | dropped :: rest ->
+      t.pending <- rest @ [ item ];
+      t.drop_queue_total <- t.drop_queue_total + 1;
+      Some dropped
+    | [] ->
+      t.pending <- [ item ];
+      None)
+;;
+
+let incr_retry t = function
+  | Persist -> t.retry_persist_total <- t.retry_persist_total + 1
+  | Publish -> t.retry_publish_total <- t.retry_publish_total + 1
+  | Queue -> ()
+;;
+
+let incr_drop t = function
+  | Persist -> t.drop_persist_total <- t.drop_persist_total + 1
+  | Publish -> t.drop_publish_total <- t.drop_publish_total + 1
+  | Queue -> t.drop_queue_total <- t.drop_queue_total + 1
+;;
+
+let process_once t ~persist ~publish =
+  let rec loop acc = function
+    | [] -> List.rev acc
+    | pending :: rest ->
+      (match deliver_with ~persist ~publish pending with
+       | Delivered -> loop acc rest
+       | Retryable_failure (pending, stage, _exn) ->
+         let attempts = pending.attempts + 1 in
+         if attempts >= t.max_attempts
+         then (
+           incr_drop t stage;
+           loop acc rest)
+         else (
+           incr_retry t stage;
+           loop ({ pending with attempts } :: acc) rest))
+  in
+  t.pending <- loop [] t.pending
+;;
+
+let pending t = t.pending
+
+let stats t =
+  let retry_total = t.retry_persist_total + t.retry_publish_total in
+  let drop_total =
+    t.drop_persist_total + t.drop_publish_total + t.drop_queue_total
+  in
+  { queue_depth = List.length t.pending
+  ; retry_total
+  ; drop_total
+  ; retry_persist_total = t.retry_persist_total
+  ; retry_publish_total = t.retry_publish_total
+  ; drop_persist_total = t.drop_persist_total
+  ; drop_publish_total = t.drop_publish_total
+  ; drop_queue_total = t.drop_queue_total
+  }
+;;
+
+let health_probe ?checked_at ?(name = "event_relay") stats =
+  let status =
+    if stats.drop_total > 0
+    then Runtime_health.Degraded
+    else if stats.queue_depth > 0 || stats.retry_total > 0
+    then Runtime_health.Degraded
+    else Runtime_health.Status_ok
+  in
+  let detail =
+    Printf.sprintf
+      "queue_depth=%d retry_total=%d drop_total=%d"
+      stats.queue_depth
+      stats.retry_total
+      stats.drop_total
+  in
+  Runtime_health.make_probe
+    ~name:(Runtime_health.Custom name)
+    ~status
+    ~detail
+    ?checked_at
+    ()
+;;

--- a/lib/relay_delivery.mli
+++ b/lib/relay_delivery.mli
@@ -1,0 +1,52 @@
+(** Two-stage event relay delivery.
+
+    This module is a small, domain-neutral state machine for adapters that
+    persist an event before publishing it to a live transport.  If publish
+    fails after persistence succeeds, retrying the returned pending value
+    skips persistence and only retries publish.  This preserves the
+    durable-append invariant without making OAS own any downstream transport
+    or dashboard schema. *)
+
+type stage =
+  | Persist
+  | Publish
+  | Queue
+
+type 'a pending = private
+  { payload : 'a
+  ; attempts : int
+  ; persisted : bool
+  }
+
+type 'a delivery_result =
+  | Delivered
+  | Retryable_failure of 'a pending * stage * exn
+
+type stats =
+  { queue_depth : int
+  ; retry_total : int
+  ; drop_total : int
+  ; retry_persist_total : int
+  ; retry_publish_total : int
+  ; drop_persist_total : int
+  ; drop_publish_total : int
+  ; drop_queue_total : int
+  }
+
+type 'a t
+
+val stage_to_string : stage -> string
+val make_pending : 'a -> 'a pending
+
+val deliver_with
+  :  persist:('a -> unit)
+  -> publish:('a -> unit)
+  -> 'a pending
+  -> 'a delivery_result
+
+val create : ?max_attempts:int -> ?max_queue_depth:int -> unit -> 'a t
+val enqueue : 'a t -> 'a -> 'a pending option
+val process_once : 'a t -> persist:('a -> unit) -> publish:('a -> unit) -> unit
+val pending : 'a t -> 'a pending list
+val stats : 'a t -> stats
+val health_probe : ?checked_at:float -> ?name:string -> stats -> Runtime_health.probe

--- a/test/dune
+++ b/test/dune
@@ -186,6 +186,7 @@
   test_raw_trace
   test_raw_trace_deep
   test_reflexion
+  test_relay_delivery
   test_request_priority
   test_retry
   test_runtime

--- a/test/test_relay_delivery.ml
+++ b/test/test_relay_delivery.ml
@@ -1,0 +1,111 @@
+(** Tests for Relay_delivery. *)
+
+open Alcotest
+open Agent_sdk
+
+let test_publish_failure_retry_does_not_persist_twice () =
+  let persist_count = ref 0 in
+  let publish_count = ref 0 in
+  let pending = Relay_delivery.make_pending "event-1" in
+  let first =
+    Relay_delivery.deliver_with
+      ~persist:(fun _ -> incr persist_count)
+      ~publish:(fun _ ->
+        incr publish_count;
+        failwith "synthetic publish failure")
+      pending
+  in
+  let pending_after_failure =
+    match first with
+    | Relay_delivery.Retryable_failure (pending, Relay_delivery.Publish, _) -> pending
+    | Relay_delivery.Retryable_failure (_, stage, _) ->
+      failf "expected publish failure, got %s" (Relay_delivery.stage_to_string stage)
+    | Relay_delivery.Delivered -> fail "expected first delivery to fail"
+  in
+  check int "persist once before retry" 1 !persist_count;
+  check bool "pending records persisted state" true pending_after_failure.persisted;
+  let second =
+    Relay_delivery.deliver_with
+      ~persist:(fun _ -> incr persist_count)
+      ~publish:(fun _ -> incr publish_count)
+      pending_after_failure
+  in
+  (match second with
+   | Relay_delivery.Delivered -> ()
+   | Relay_delivery.Retryable_failure _ -> fail "expected retry to deliver");
+  check int "retry skips persist" 1 !persist_count;
+  check int "publish retried" 2 !publish_count
+;;
+
+let test_process_once_tracks_retry_queue_health () =
+  let relay = Relay_delivery.create ~max_attempts:3 ~max_queue_depth:4 () in
+  ignore (Relay_delivery.enqueue relay "event-1");
+  let publish_count = ref 0 in
+  Relay_delivery.process_once
+    relay
+    ~persist:(fun _ -> ())
+    ~publish:(fun _ ->
+      incr publish_count;
+      failwith "temporary publish failure");
+  let stats = Relay_delivery.stats relay in
+  check int "queue retains retryable item" 1 stats.queue_depth;
+  check int "publish retry counted" 1 stats.retry_publish_total;
+  let probe = Relay_delivery.health_probe ~checked_at:12.0 stats in
+  check string "health probe name" "event_relay"
+    (Runtime_health.probe_name_to_string probe.name);
+  check string "health degraded" "degraded"
+    (Runtime_health.status_to_string probe.status)
+;;
+
+let test_process_once_drop_after_max_attempts () =
+  let relay = Relay_delivery.create ~max_attempts:1 ~max_queue_depth:4 () in
+  ignore (Relay_delivery.enqueue relay "event-1");
+  Relay_delivery.process_once
+    relay
+    ~persist:(fun _ -> ())
+    ~publish:(fun _ -> failwith "permanent publish failure");
+  let stats = Relay_delivery.stats relay in
+  check int "queue empty after drop" 0 stats.queue_depth;
+  check int "publish drop counted" 1 stats.drop_publish_total;
+  check int "drop total" 1 stats.drop_total
+;;
+
+let test_enqueue_overflow_counts_queue_drop () =
+  let relay = Relay_delivery.create ~max_attempts:3 ~max_queue_depth:1 () in
+  check (option string) "first enqueue no drop" None
+    (Option.map (fun pending -> pending.Relay_delivery.payload)
+       (Relay_delivery.enqueue relay "old"));
+  check (option string) "second enqueue drops old" (Some "old")
+    (Option.map (fun pending -> pending.Relay_delivery.payload)
+       (Relay_delivery.enqueue relay "new"));
+  let stats = Relay_delivery.stats relay in
+  check int "queue keeps newest" 1 stats.queue_depth;
+  check int "queue drop counted" 1 stats.drop_queue_total;
+  match Relay_delivery.pending relay with
+  | [ pending ] -> check string "newest queued" "new" pending.payload
+  | _ -> fail "expected one pending item"
+;;
+
+let () =
+  Alcotest.run
+    "relay-delivery"
+    [ ( "delivery"
+      , [ test_case
+            "publish retry does not repeat persist"
+            `Quick
+            test_publish_failure_retry_does_not_persist_twice
+        ; test_case
+            "retry queue health stats"
+            `Quick
+            test_process_once_tracks_retry_queue_health
+        ; test_case
+            "drops after max attempts"
+            `Quick
+            test_process_once_drop_after_max_attempts
+        ; test_case
+            "queue overflow counts drop"
+            `Quick
+            test_enqueue_overflow_counts_queue_drop
+        ] )
+    ]
+;;

--- a/test/test_relay_delivery.ml
+++ b/test/test_relay_delivery.ml
@@ -51,10 +51,12 @@ let test_process_once_tracks_retry_queue_health () =
   check int "queue retains retryable item" 1 stats.queue_depth;
   check int "publish retry counted" 1 stats.retry_publish_total;
   let probe = Relay_delivery.health_probe ~checked_at:12.0 stats in
-  check string "health probe name" "event_relay"
+  check
+    string
+    "health probe name"
+    "event_relay"
     (Runtime_health.probe_name_to_string probe.name);
-  check string "health degraded" "degraded"
-    (Runtime_health.status_to_string probe.status)
+  check string "health degraded" "degraded" (Runtime_health.status_to_string probe.status)
 ;;
 
 let test_process_once_drop_after_max_attempts () =
@@ -72,11 +74,19 @@ let test_process_once_drop_after_max_attempts () =
 
 let test_enqueue_overflow_counts_queue_drop () =
   let relay = Relay_delivery.create ~max_attempts:3 ~max_queue_depth:1 () in
-  check (option string) "first enqueue no drop" None
-    (Option.map (fun pending -> pending.Relay_delivery.payload)
+  check
+    (option string)
+    "first enqueue no drop"
+    None
+    (Option.map
+       (fun pending -> pending.Relay_delivery.payload)
        (Relay_delivery.enqueue relay "old"));
-  check (option string) "second enqueue drops old" (Some "old")
-    (Option.map (fun pending -> pending.Relay_delivery.payload)
+  check
+    (option string)
+    "second enqueue drops old"
+    (Some "old")
+    (Option.map
+       (fun pending -> pending.Relay_delivery.payload)
        (Relay_delivery.enqueue relay "new"));
   let stats = Relay_delivery.stats relay in
   check int "queue keeps newest" 1 stats.queue_depth;


### PR DESCRIPTION
## Summary

- Add `Relay_delivery`, a neutral two-stage relay primitive for adapters that persist an event before publishing it to a live transport.
- Preserve the durable-append invariant: if publish fails after persistence succeeds, retrying the returned pending value skips persistence and only retries publish.
- Track queue depth, retry totals, drop totals, and expose a `Runtime_health` probe so downstream transport-health surfaces can report relay pressure without scraping private state.

## Root Cause

The OAS boundary exposed event and durable journal primitives, but did not provide a reusable retry state machine for the common `persist -> publish` relay shape. Downstream bridges had to own both retry bookkeeping and durable append idempotence, which is exactly where duplicate append regressions can appear after a publish failure.

This keeps OAS ownership narrow: OAS provides the domain-neutral relay invariant and stats; downstream systems still own actual persistence, SSE/WebSocket transport, and dashboard schema.

## Validation

- `git diff --check`
- `opam exec -- dune exec --root=. ./test/test_relay_delivery.exe`

Fixes #1007
