### PR TITLE
ci: guard draft PR auto-merge state

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -39,27 +39,42 @@ jobs:
             const pr = context.payload.pull_request;
             const pullNumber = pr.number;
 
-            const bypassLabels = (process.env.OAS_DRAFT_GUARD_BYPASS_LABELS || "human-approved-ready")
+            // `allow-auto-merge` is the GitHub-builtin label that simply
+            // *enables* auto-merge — it is not an approval signal. We strip
+            // it from the bypass list so a misconfiguration cannot turn the
+            // builtin into a draft-guard bypass. Operators who want to
+            // bypass the guard must use a distinct label such as
+            // `human-approved-ready`.
+            const RESERVED_BYPASS_LABELS = new Set(["allow-auto-merge"]);
+            const rawBypassLabels = (process.env.OAS_DRAFT_GUARD_BYPASS_LABELS || "human-approved-ready")
               .split(",")
               .map((label) => label.trim().toLowerCase())
-              .filter((label) => label && label !== "allow-auto-merge");
+              .filter(Boolean);
+            const ignoredBypass = rawBypassLabels.filter((label) => RESERVED_BYPASS_LABELS.has(label));
+            if (ignoredBypass.length > 0) {
+              core.warning(
+                `Ignoring reserved label(s) in OAS_DRAFT_GUARD_BYPASS_LABELS: ${ignoredBypass.join(", ")}. ` +
+                  `These are GitHub-builtin and do not signal human approval.`
+              );
+            }
+            const bypassLabels = rawBypassLabels.filter((label) => !RESERVED_BYPASS_LABELS.has(label));
             const hardStopLabels = (process.env.OAS_DRAFT_GUARD_HARD_STOP_LABELS || "do-not-merge")
               .split(",")
               .map((label) => label.trim().toLowerCase())
               .filter(Boolean);
 
+            // GraphQL for PR metadata (id needed for mutations); labels via
+            // REST `paginate` so PRs with >100 labels still see every entry.
             const query = `
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
                   pullRequest(number: $number) {
                     id
                     number
-                    title
                     closed
                     merged
                     isDraft
                     autoMergeRequest { enabledAt }
-                    labels(first: 100) { nodes { name } }
                   }
                 }
               }
@@ -76,7 +91,13 @@ jobs:
               return;
             }
 
-            const labels = live.labels.nodes.map((label) => label.name.toLowerCase());
+            const labelNodes = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner,
+              repo,
+              issue_number: pullNumber,
+              per_page: 100
+            });
+            const labels = labelNodes.map((label) => label.name.toLowerCase());
             const hasBypass = labels.some((label) => bypassLabels.includes(label));
             const hardStops = labels.filter((label) => hardStopLabels.includes(label));
             const hasHardStop = hardStops.length > 0;

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,0 +1,160 @@
+name: PR Automation
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - converted_to_draft
+      - auto_merge_enabled
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: pr-automation-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  draft-automerge-guard:
+    name: Draft Auto-Merge Guard
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.state != 'closed' }}
+    steps:
+      - name: Keep draft PRs draft-only until explicit approval
+        uses: actions/github-script@v9
+        env:
+          OAS_DRAFT_GUARD_BYPASS_LABELS: ${{ vars.OAS_DRAFT_GUARD_BYPASS_LABELS }}
+          OAS_DRAFT_GUARD_HARD_STOP_LABELS: ${{ vars.OAS_DRAFT_GUARD_HARD_STOP_LABELS }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
+            const pullNumber = pr.number;
+
+            const bypassLabels = (process.env.OAS_DRAFT_GUARD_BYPASS_LABELS || "human-approved-ready")
+              .split(",")
+              .map((label) => label.trim().toLowerCase())
+              .filter((label) => label && label !== "allow-auto-merge");
+            const hardStopLabels = (process.env.OAS_DRAFT_GUARD_HARD_STOP_LABELS || "do-not-merge")
+              .split(",")
+              .map((label) => label.trim().toLowerCase())
+              .filter(Boolean);
+
+            const query = `
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    id
+                    number
+                    title
+                    closed
+                    merged
+                    isDraft
+                    autoMergeRequest { enabledAt }
+                    labels(first: 100) { nodes { name } }
+                  }
+                }
+              }
+            `;
+
+            const loadLivePr = async () => {
+              const data = await github.graphql(query, { owner, repo, number: pullNumber });
+              return data.repository.pullRequest;
+            };
+
+            const live = await loadLivePr();
+            if (!live || live.closed || live.merged) {
+              core.info(`PR #${pullNumber} is already closed or merged; skipping.`);
+              return;
+            }
+
+            const labels = live.labels.nodes.map((label) => label.name.toLowerCase());
+            const hasBypass = labels.some((label) => bypassLabels.includes(label));
+            const hardStops = labels.filter((label) => hardStopLabels.includes(label));
+            const hasHardStop = hardStops.length > 0;
+            const actions = [];
+            let violation = false;
+
+            if (live.autoMergeRequest && (hasHardStop || !hasBypass)) {
+              await github.graphql(
+                `mutation($pullRequestId: ID!) {
+                  disablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId }) {
+                    pullRequest { number }
+                  }
+                }`,
+                { pullRequestId: live.id }
+              );
+              actions.push("disabled auto-merge");
+              violation = true;
+            }
+
+            if (!live.isDraft && (hasHardStop || !hasBypass)) {
+              await github.graphql(
+                `mutation($pullRequestId: ID!) {
+                  convertPullRequestToDraft(input: { pullRequestId: $pullRequestId }) {
+                    pullRequest { number }
+                  }
+                }`,
+                { pullRequestId: live.id }
+              );
+              actions.push("converted PR back to draft");
+              violation = true;
+            }
+
+            if (actions.length === 0) {
+              if (hasBypass && !hasHardStop) {
+                core.info(`PR #${pullNumber} has an explicit bypass label; no repair needed.`);
+              } else {
+                core.info(`PR #${pullNumber} is draft-only with no auto-merge request; no repair needed.`);
+              }
+              return;
+            }
+
+            const marker = "<!-- oas-draft-automerge-guard -->";
+            const commentBody = [
+              marker,
+              "Draft PR guard repaired unsafe merge state.",
+              "",
+              `Actions: ${actions.join(", ")}.`,
+              `Bypass labels: ${bypassLabels.join(", ") || "<none>"}.`,
+              hasHardStop ? `Hard-stop labels present: ${hardStops.join(", ")}.` : "",
+              "",
+              "Keep the PR draft-only until a human adds an approved bypass label and required checks are green."
+            ].filter(Boolean).join("\n");
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pullNumber,
+              per_page: 100
+            });
+            const previous = comments.find((comment) =>
+              comment.user?.type === "Bot" && comment.body?.includes(marker)
+            );
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: previous.id,
+                body: commentBody
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pullNumber,
+                body: commentBody
+              });
+            }
+
+            if (violation) {
+              core.setFailed("Draft/auto-merge guard repaired unsafe PR state.");
+            }


### PR DESCRIPTION
## Summary

- Add a `pull_request_target` PR automation guard for draft/auto-merge boundaries.
- Convert PRs back to draft when they become ready without an approved bypass label.
- Disable auto-merge when auto-merge is enabled without the bypass label or while a hard-stop label is present.

## Root Cause

OAS had CI jobs that skip draft PRs, but no separate live-state guard for the PR metadata itself. If external automation flipped a draft PR to ready or enabled auto-merge, the repository relied on convention and branch settings rather than an explicit repair path.

The guard is intentionally narrow: draft PRs with no auto-merge request pass quietly; an approved ready/merge path requires `human-approved-ready` by default; `do-not-merge` is a hard stop.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-automation.yml"); puts "yaml ok"'`
- `git diff --check`

Fixes #1278
