### PR TITLE
fix: wrap agent_sdk base library

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -38,6 +38,7 @@
 (** Re-export all modules (dependency-safe order) *)
 module Sdk_version = Sdk_version
 
+module Result_syntax = Result_syntax
 module Types = Types
 module Model_registry = Model_registry
 module Uncertain = Uncertain

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -11,6 +11,7 @@
 (** {1 Core Modules} *)
 
 module Sdk_version = Sdk_version
+module Result_syntax = Result_syntax
 module Types = Types
 module Model_registry = Model_registry
 module Uncertain = Uncertain

--- a/lib/base/dune
+++ b/lib/base/dune
@@ -3,7 +3,7 @@
 (library
  (name agent_sdk_base)
  (public_name agent_sdk.base)
- (wrapped false)
+ (wrapped true)
  (libraries llm_provider yojson eio)
  (inline_tests)
  (preprocess

--- a/lib/dune
+++ b/lib/dune
@@ -5,7 +5,7 @@
  (public_name agent_sdk)
  (libraries
   llm_provider
-  agent_sdk_base
+  (re_export agent_sdk_base)
   eio
   eio_main
   cohttp-eio
@@ -21,6 +21,8 @@
   mcp_protocol
   mcp_protocol.eio
   mcp_protocol.http)
+ (flags
+  (:standard -open Agent_sdk_base))
  (inline_tests)
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.show ppx_inline_test ppx_let))


### PR DESCRIPTION
## Summary

- Wrap `agent_sdk.base` so base modules no longer install global units like `Types`
- Re-export `agent_sdk.base` from the top-level `agent_sdk` library so `Agent_sdk.Types` remains usable downstream

## Why

`masc-mcp` also has an unwrapped `Types` unit. The previous `agent_sdk.base` packaging installed a second global `Types.cmi`, which made downstream builds fail with inconsistent assumptions over interface `Types`.

## Validation

- `env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build @install`
- `ocamlobjinfo` confirms `agent_sdk.cmi` imports `Agent_sdk_base__Types` instead of global `Types`
