### PR TITLE
fix(test): rescue test_provider_config orphan (+47 alcotest)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -14,7 +14,6 @@
 ;   - test/test_event_integration.ml   (Unbound module Handoff)
 ;   - test/test_guardrails_async.ml    (pattern shape mismatch vs new return type)
 ;   - test/test_pipeline_deep.ml       (record missing 'enable_thinking')
-;   - test/test_provider_config.ml     (record missing 'reasoning_tokens_estimated')
 ;   - test/test_runtime_worker_integration.ml (type mismatch on participant_run_success)
 ;   - test/test_structured_stream.ml   (build error — see CI log)
 ;
@@ -181,6 +180,7 @@
   test_progressive_tools
   test_proof_store_cross_run
   test_provider
+  test_provider_config
   test_provider_intf
   test_provider_registry
   test_raw_trace

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -487,6 +487,7 @@ let telemetry_with_kind (pk : Provider_config.provider_kind option)
   { system_fingerprint = None
   ; timings = None
   ; reasoning_tokens = None
+  ; reasoning_tokens_estimated = false
   ; request_latency_ms = 0
   ; peak_memory_gb = None
   ; provider_kind = pk


### PR DESCRIPTION
## Summary

`test/dune`의 AUTO-WIRED ORPHANS 비활성화 항목 중 `test_provider_config.ml`을 rescue. 한 줄 record field 추가로 47 alcotest 케이스 활성화.

## Why

`test/dune:17`의 orphan 사유 "(record missing 'reasoning_tokens_estimated')"가 stale. 실제로 `lib/llm_provider/types.mli:182`와 `types.ml:307`에 이미 필드 정의됨. 다른 callsite(`backend_anthropic.ml:49`, `complete.ml:154`, `transport_codex_cli.ml:607`, `backend_ollama.ml:284`, `backend_openai_parse.ml:196`)는 모두 `; reasoning_tokens_estimated = false` 명시하고 있는데, `test_provider_config.ml:487-497`의 `inference_telemetry` record literal만 누락.

본 PR은 이 orphan을 가장 작은 fix로 활성화 — test 파일에 한 필드 추가, dune wire/주석 1줄씩 정리.

## What

```diff
diff --git a/test/dune b/test/dune
@@ -14,7 +14,6 @@
 ;   - test/test_event_integration.ml   (Unbound module Handoff)
 ;   - test/test_guardrails_async.ml    (pattern shape mismatch vs new return type)
 ;   - test/test_pipeline_deep.ml       (record missing 'enable_thinking')
-;   - test/test_provider_config.ml     (record missing 'reasoning_tokens_estimated')
 ;   - test/test_runtime_worker_integration.ml (type mismatch on participant_run_success)
@@ -181,6 +180,7 @@
   test_provider
+  test_provider_config
   test_provider_intf

diff --git a/test/test_provider_config.ml b/test/test_provider_config.ml
@@ -487,6 +487,7 @@
   { system_fingerprint = None
   ; timings = None
   ; reasoning_tokens = None
+  ; reasoning_tokens_estimated = false
   ; request_latency_ms = 0
```

## Verification

- `scripts/dune-local.sh build test/test_provider_config.exe` → 빌드 성공.
- `_build/default/test/test_provider_config.exe` → **"Test Successful in 0.021s. 47 tests run."** (locality, provider_name, kind_of_string, kind_serializers, kind_enumeration, telemetry_wire_format 6 그룹, 47 케이스 전부 OK).
- 변경 영향 범위: test 파일 + dune (`rg "reasoning_tokens_estimated" lib/` 결과는 사전 확인 — 8개 lib callsite 모두 동일 패턴, 기존과 일관).

## Self-review

- [x] **Goal**: oas test/dune의 stale orphan 1개 rescue. 변경 범위 최소화 — lib 무접촉.
- [x] **Files**: test/dune (+1/-1), test/test_provider_config.ml (+1). 총 +2/-1.
- [x] **Local verification**: focused build + executable run 모두 통과.
- [x] **Untested**: 본 PR 외 9개 orphan 항목은 손대지 않음 — 후속 PR로 분리.

## RFC Waiver

`RFC-WAIVED: oas test additive only, no behavior change in lib/. credential / identity / repo / operator / sandbox 무접촉.`

## Cross-refs

- AUTO-WIRED ORPHANS context: `test/dune:1-36` (10 compile-fail + 9 runtime-fail orphan list)
- 동일 record literal 패턴: `lib/llm_provider/backend_anthropic.ml:49`, `lib/llm_provider/complete.ml:154,1127,1611`, `lib/llm_provider/transport_codex_cli.ml:607`, `lib/llm_provider/backend_ollama.ml:284`, `lib/llm_provider/backend_openai_parse.ml:196`
- 후속 후보 (Sprint B 영역, 다른 PR): `test_discovery.ml` ('supports_tools'), `test_pipeline_deep.ml` ('enable_thinking'), `test_structured_stream.ml` (build error)

## Note on Draft

Per memory `feedback_masc_mcp_draft_guard_blocks_agent_ready.md` — agent-authored PR이므로 Draft 유지. 통상 ready_for_review 전환 전 사용자 검토 요청. (oas repo의 별도 정책이 다를 수 있음 — Draft → Ready 전환은 user 결정에 위임.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
