### PR TITLE
fix(test): rescue test_discovery orphan (+8 alcotest)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -10,7 +10,6 @@
 ;   - test/test_agent_card.ml          (Agent_card.agent_info missing 'cascade')
 ;   - test/test_complete_http.ml       (record missing on_capability_drop etc.)
 ;   - test/test_deep_coverage.ml       (Alcotest.run call commented out, dead body)
-;   - test/test_discovery.ml           (record missing 'supports_tools')
 ;   - test/test_event_integration.ml   (Unbound module Handoff)
 ;   - test/test_guardrails_async.ml    (pattern shape mismatch vs new return type)
 ;   - test/test_pipeline_deep.ml       (record missing 'enable_thinking')
@@ -101,6 +100,7 @@
   test_defaults_unit
   test_direct_evidence
   test_direct_evidence_unit
+  test_discovery
   test_durable
   test_durable_event
   test_e2e_v024

--- a/test/test_discovery.ml
+++ b/test/test_discovery.ml
@@ -168,7 +168,7 @@ let test_refresh_and_sync_updates_context () =
     { url = "http://test"
     ; healthy = true
     ; models = []
-    ; props = Some { total_slots; ctx_size; model = "test" }
+    ; props = Some { total_slots; ctx_size; model = "test"; supports_tools = None }
     ; slots = None
     ; capabilities = Capabilities.default_capabilities
     }


### PR DESCRIPTION
## Summary

`test/dune`의 AUTO-WIRED ORPHANS 비활성화 항목 중 `test_discovery.ml`을 rescue. 한 줄 record field 추가로 8 alcotest 케이스 활성화.

## Why

`test/dune:13`의 orphan 사유 "(record missing 'supports_tools')"가 location-stale. 실제로 line 79의 `endpoint_status` 내 nested `server_props` literal은 이미 완전 (`supports_tools = None` 명시). 그러나 line 171의 `status_with_props` 헬퍼가 record-shorthand 패턴 `{ total_slots; ctx_size; model = "test" }`를 사용하면서 `supports_tools` 누락. lib type `Discovery.server_props.supports_tools : bool option` (lib/llm_provider/discovery.ml:26 정의)에 맞춰 `; supports_tools = None` 한 줄 추가.

이전 PR #1388 (test_provider_config orphan rescue) 패턴과 동일 방식 — dune wire/주석 1줄 + test record literal 1 필드 추가.

## What

```diff
diff --git a/test/dune b/test/dune
@@ -10,7 +10,6 @@
 ;   - test/test_agent_card.ml          (Agent_card.agent_info missing 'cascade')
 ;   - test/test_complete_http.ml       (record missing on_capability_drop etc.)
 ;   - test/test_deep_coverage.ml       (Alcotest.run call commented out, dead body)
-;   - test/test_discovery.ml           (record missing 'supports_tools')
 ;   - test/test_event_integration.ml   (Unbound module Handoff)
@@ -101,6 +100,7 @@
   test_direct_evidence_unit
+  test_discovery
   test_durable

diff --git a/test/test_discovery.ml b/test/test_discovery.ml
@@ -168,7 +168,7 @@
     { url = "http://test"
     ; healthy = true
     ; models = []
-    ; props = Some { total_slots; ctx_size; model = "test" }
+    ; props = Some { total_slots; ctx_size; model = "test"; supports_tools = None }
     ; slots = None
```

## Verification

- `scripts/dune-local.sh build test/test_discovery.exe` → 빌드 성공.
- `_build/default/test/test_discovery.exe` → **"Test Successful in 0.003s. 8 tests run."** (env x2, parsing x1, json x3, discovered_context x2).
- 변경 영향 범위: test 파일 + dune. lib/ 무접촉.

## Self-review

- [x] **Goal**: oas test/dune의 stale orphan 1개 rescue. 변경 범위 최소화 — lib 무접촉.
- [x] **Files**: test/dune (+1/-1), test/test_discovery.ml (+1/-1). 총 +2/-2.
- [x] **Local verification**: focused build + executable run 모두 통과.
- [x] **Untested**: 본 PR 외 8개 orphan 항목은 손대지 않음 — 후속 PR로 분리.

## RFC Waiver

`RFC-WAIVED: oas test additive only, no behavior change in lib/. credential / identity / repo / operator / sandbox 무접촉.`

## Cross-refs

- Prior orphan rescue: PR #1388 (test_provider_config, merged 2026-05-05).
- AUTO-WIRED ORPHANS context: `test/dune:1-36` (8 compile-fail + 9 runtime-fail orphan list 잔여).
- 후속 후보 (Sprint B 영역, 다른 PR): `test_pipeline_deep.ml` ('enable_thinking'), `test_structured_stream.ml` (build error).

## Note on Draft

Per memory `feedback_masc_mcp_draft_guard_blocks_agent_ready` — agent-authored PR이므로 Draft 유지. Draft → Ready 전환은 user 결정에 위임.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
