### PR TITLE
test(event-bus): keep custom fixture downstream-neutral

### DIFF
--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -206,7 +206,8 @@ let test_payload_kind_canonical_labels () =
       , "handoff_requested" )
     ; ( Event_bus.HandoffCompleted { from_agent = "a"; to_agent = "b"; elapsed = 0.0 }
       , "handoff_completed" )
-    ; Event_bus.Custom ("masc.keeper.lifecycle", `Null), "custom:masc.keeper.lifecycle"
+    ; ( Event_bus.Custom ("downstream.agent.lifecycle", `Null)
+      , "custom:downstream.agent.lifecycle" )
     ]
   in
   List.iter


### PR DESCRIPTION
Summary
- Replace a MASC-specific Event_bus.Custom fixture name with a neutral downstream namespace.
- Keep OAS event-bus tests from presenting MASC keeper lifecycle terminology as canonical OAS surface.

Validation
- scripts/dune-local.sh build test/test_event_bus.exe
- ./_build/default/test/test_event_bus.exe
- git diff --check

Context
- Read-only boundary audit found no justified OAS SNS feature slice. MASC owns board/SNS semantics; OAS remains a generic runtime/proof/correlation substrate.