### PR TITLE
docs: clarify 0.190.8 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ original tag dates. `0.100.4` was never tagged or released.
 ## [0.190.8] - 2026-05-05
 
 ### Fixed
-- `test/test_pipeline_deep.ml` orphan stanza rescue. orphan 사유 "(record missing 'enable_thinking')" 가 stale — `Hooks.turn_params` literal 한 곳에 `enable_thinking = None` 추가 후 22 alcotest 케이스 default runtest 신호에 합류. 같은 sprint-b orphan rescue 시리즈 (#1388/#1392/#1394) 의 일부. (#1394)
+- `test/test_pipeline_deep.ml` orphan stanza rescue. `Hooks.turn_params` literal 한 곳에 누락된 `enable_thinking = None` 을 추가해 22 alcotest 케이스가 default runtest 신호에 합류. 같은 sprint-b orphan rescue 시리즈 (#1388/#1392/#1394) 의 일부. (#1394)
 
 ## [0.190.7] - 2026-05-05
 


### PR DESCRIPTION
## Summary
- Clarify the 0.190.8 changelog wording for the test_pipeline_deep rescue.
- Follow-up to Copilot feedback on #1396 after that release PR merged.

## Validation
- scripts/check-tag-drift.sh --strict
- git diff --check origin/main...HEAD