### PR TITLE
feat(manifest): carry provider health evidence

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -190,6 +190,7 @@ module Vcs_graph_snapshot = Vcs_graph_snapshot
 module Execution_mode = Execution_mode
 module Risk_class = Risk_class
 module Risk_contract = Risk_contract
+module Execution_manifest = Execution_manifest
 module Cdal_proof = Cdal_proof
 module Mode_resolver = Mode_resolver
 module Effect_evidence = Effect_evidence

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -164,6 +164,7 @@ module Vcs_graph_snapshot = Vcs_graph_snapshot
 module Execution_mode = Execution_mode
 module Risk_class = Risk_class
 module Risk_contract = Risk_contract
+module Execution_manifest = Execution_manifest
 module Cdal_proof = Cdal_proof
 module Mode_resolver = Mode_resolver
 module Effect_evidence = Effect_evidence

--- a/lib/effect_evidence.ml
+++ b/lib/effect_evidence.ml
@@ -31,6 +31,8 @@ type t =
   ; input_summary : string
   ; sandbox : string option
   ; workdir : string option
+  ; source_path : string option
+  ; source_line : int option
   ; started_at : float
   ; ended_at : float option
   ; result_status : result_status
@@ -107,6 +109,8 @@ let make
       ?input_summary
       ?sandbox
       ?workdir
+      ?source_path
+      ?source_line
       ?ended_at
       ?(result_status = Pending)
       ?violation_kind
@@ -132,6 +136,8 @@ let make
       Option.value input_summary ~default:(clip (Yojson.Safe.to_string input))
   ; sandbox
   ; workdir
+  ; source_path
+  ; source_line
   ; started_at
   ; ended_at
   ; result_status
@@ -158,6 +164,8 @@ let to_json t =
     ; "input_summary", `String t.input_summary
     ; "sandbox", option_to_json (fun v -> `String v) t.sandbox
     ; "workdir", option_to_json (fun v -> `String v) t.workdir
+    ; "source_path", option_to_json (fun v -> `String v) t.source_path
+    ; "source_line", option_to_json (fun v -> `Int v) t.source_line
     ; "started_at", `Float t.started_at
     ; "ended_at", option_to_json (fun v -> `Float v) t.ended_at
     ; "result_status", `String (result_status_to_string t.result_status)
@@ -237,6 +245,8 @@ let of_json = function
     let* input_summary = string_field "input_summary" fields in
     let* sandbox = option_string_field "sandbox" fields in
     let* workdir = option_string_field "workdir" fields in
+    let* source_path = option_string_field "source_path" fields in
+    let* source_line = option_int_field "source_line" fields in
     let* started_at = float_field "started_at" fields in
     let* ended_at = option_float_field "ended_at" fields in
     let* result_status =
@@ -257,6 +267,8 @@ let of_json = function
       ; input_summary
       ; sandbox
       ; workdir
+      ; source_path
+      ; source_line
       ; started_at
       ; ended_at
       ; result_status

--- a/lib/effect_evidence.mli
+++ b/lib/effect_evidence.mli
@@ -37,6 +37,8 @@ type t =
   ; input_summary : string
   ; sandbox : string option
   ; workdir : string option
+  ; source_path : string option
+  ; source_line : int option
   ; started_at : float
   ; ended_at : float option
   ; result_status : result_status
@@ -60,6 +62,8 @@ val make
   -> ?input_summary:string
   -> ?sandbox:string
   -> ?workdir:string
+  -> ?source_path:string
+  -> ?source_line:int
   -> ?ended_at:float
   -> ?result_status:result_status
   -> ?violation_kind:string

--- a/lib/execution_manifest.ml
+++ b/lib/execution_manifest.ml
@@ -1,5 +1,26 @@
+type provider_health_score = string * float
+
+type cascade_config =
+  { circuit_threshold : int
+  ; circuit_cooldown_s : float
+  }
+
 type t =
   { contract : Contract.t
   ; mode : Execution_mode.t
   ; risk_class : Risk_class.t
+  ; provider_health : provider_health_score list
+  ; cascade_config : cascade_config option
   }
+
+let make ?(provider_health = []) ?cascade_config ~contract ~mode ~risk_class () =
+  { contract; mode; risk_class; provider_health; cascade_config }
+;;
+
+let cascade_config_of_complete_cascade
+      (config : Llm_provider.Complete_cascade.cascade_config)
+  =
+  { circuit_threshold = config.circuit_threshold
+  ; circuit_cooldown_s = config.circuit_cooldown_s
+  }
+;;

--- a/lib/execution_manifest.mli
+++ b/lib/execution_manifest.mli
@@ -1,7 +1,30 @@
 (** Execution Manifest: The single point of intersection between the coordinator and OAS. *)
 
+(** Provider key and normalized health score in [0.0, 1.0]. *)
+type provider_health_score = string * float
+
+type cascade_config =
+  { circuit_threshold : int
+  ; circuit_cooldown_s : float
+  }
+
 type t =
   { contract : Contract.t
   ; mode : Execution_mode.t
   ; risk_class : Risk_class.t
+  ; provider_health : provider_health_score list
+  ; cascade_config : cascade_config option
   }
+
+val make
+  :  ?provider_health:provider_health_score list
+  -> ?cascade_config:cascade_config
+  -> contract:Contract.t
+  -> mode:Execution_mode.t
+  -> risk_class:Risk_class.t
+  -> unit
+  -> t
+
+val cascade_config_of_complete_cascade
+  :  Llm_provider.Complete_cascade.cascade_config
+  -> cascade_config

--- a/lib/llm_provider/complete_cascade.ml
+++ b/lib/llm_provider/complete_cascade.ml
@@ -14,7 +14,7 @@ type cascade_config =
   ; circuit_cooldown_s : float
   }
 
-let default_cascade_config = { circuit_threshold = 3; circuit_cooldown_s = 60.0 }
+let default_cascade_config = { circuit_threshold = 3; circuit_cooldown_s = 30.0 }
 
 type skip_reason = Circuit_breaker_open of { provider : string }
 
@@ -92,19 +92,71 @@ let record_failure health key =
     Hashtbl.replace health.entries key entry)
 ;;
 
+let circuit_open_and_remaining health ~ccfg entry =
+  if entry.consecutive_failures < ccfg.circuit_threshold
+  then false, None
+  else (
+    match entry.last_failure_time with
+    | None -> true, None
+    | Some t ->
+      let elapsed = health.time_fn () -. t in
+      let remaining = ccfg.circuit_cooldown_s -. elapsed in
+      if remaining > 0.0 then true, Some remaining else false, Some 0.0)
+;;
+
 let is_circuit_open health ~ccfg key =
   with_mutex health (fun () ->
     match Hashtbl.find_opt health.entries key with
     | None -> false
+    | Some entry -> fst (circuit_open_and_remaining health ~ccfg entry))
+;;
+
+type provider_health_info =
+  { provider_key : string
+  ; health_score : float
+  ; consecutive_failures : int
+  ; circuit_open : bool
+  ; cooldown_remaining_s : float option
+  }
+
+let health_score ~ccfg ~circuit_open consecutive_failures =
+  if circuit_open
+  then 0.0
+  else (
+    let threshold = max 1 ccfg.circuit_threshold in
+    let ratio = float_of_int consecutive_failures /. float_of_int threshold in
+    Float.max 0.0 (Float.min 1.0 (1.0 -. ratio)))
+;;
+
+let provider_health_info health ~cascade_config ~provider_key =
+  with_mutex health (fun () ->
+    match Hashtbl.find_opt health.entries provider_key with
+    | None ->
+      { provider_key
+      ; health_score = 1.0
+      ; consecutive_failures = 0
+      ; circuit_open = false
+      ; cooldown_remaining_s = None
+      }
     | Some entry ->
-      if entry.consecutive_failures < ccfg.circuit_threshold
-      then false
-      else (
-        match entry.last_failure_time with
-        | None -> true
-        | Some t ->
-          let elapsed = health.time_fn () -. t in
-          elapsed < ccfg.circuit_cooldown_s))
+      let circuit_open, cooldown_remaining_s =
+        circuit_open_and_remaining health ~ccfg:cascade_config entry
+      in
+      { provider_key
+      ; health_score =
+          health_score ~ccfg:cascade_config ~circuit_open entry.consecutive_failures
+      ; consecutive_failures = entry.consecutive_failures
+      ; circuit_open
+      ; cooldown_remaining_s
+      })
+;;
+
+let provider_health_scores health ~cascade_config ~provider_keys =
+  List.map
+    (fun provider_key ->
+       let info = provider_health_info health ~cascade_config ~provider_key in
+       provider_key, info.health_score)
+    provider_keys
 ;;
 
 (* --- Error classification --- *)

--- a/lib/llm_provider/complete_cascade.ml
+++ b/lib/llm_provider/complete_cascade.ml
@@ -101,7 +101,7 @@ let circuit_open_and_remaining health ~ccfg entry =
     | Some t ->
       let elapsed = health.time_fn () -. t in
       let remaining = ccfg.circuit_cooldown_s -. elapsed in
-      if remaining > 0.0 then true, Some remaining else false, Some 0.0)
+      if remaining > 0.0 then true, Some remaining else false, None)
 ;;
 
 let is_circuit_open health ~ccfg key =

--- a/lib/llm_provider/complete_cascade.mli
+++ b/lib/llm_provider/complete_cascade.mli
@@ -55,6 +55,12 @@ type provider_health_info =
   ; consecutive_failures : int
   ; circuit_open : bool
   ; cooldown_remaining_s : float option
+    (** [Some t] (where [t > 0.0]) when [circuit_open = true]: seconds remaining
+        until the circuit may close. [None] when the circuit is closed — either
+        because the consecutive failure count is below the threshold or because
+        the cooldown has already elapsed. Consumers can therefore treat
+        [None] as "no active cooldown" without having to special-case
+        [Some 0.0]. *)
   }
 
 val provider_health_info

--- a/lib/llm_provider/complete_cascade.mli
+++ b/lib/llm_provider/complete_cascade.mli
@@ -16,10 +16,10 @@ type cascade_config =
         Default: 3. *)
   ; circuit_cooldown_s : float
     (** Seconds before a circuit-broken provider is retried (half-open).
-        Default: 60.0. *)
+        Default: 30.0. *)
   }
 
-(** Default cascade config: circuit_threshold=3, circuit_cooldown_s=60.0. *)
+(** Default cascade config: circuit_threshold=3, circuit_cooldown_s=30.0. *)
 val default_cascade_config : cascade_config
 
 (** {1 Health Tracking} *)
@@ -45,6 +45,29 @@ val record_success : provider_health -> string -> unit
     Increments the consecutive failure count and updates the timestamp.
     After [circuit_threshold] consecutive failures, the circuit opens. *)
 val record_failure : provider_health -> string -> unit
+
+(** Provider health snapshot derived from the circuit-breaker state. *)
+type provider_health_info =
+  { provider_key : string
+  ; health_score : float
+    (** [0.0, 1.0], where [1.0] means no active failures and [0.0] means the
+        provider has reached the circuit threshold. *)
+  ; consecutive_failures : int
+  ; circuit_open : bool
+  ; cooldown_remaining_s : float option
+  }
+
+val provider_health_info
+  :  provider_health
+  -> cascade_config:cascade_config
+  -> provider_key:string
+  -> provider_health_info
+
+val provider_health_scores
+  :  provider_health
+  -> cascade_config:cascade_config
+  -> provider_keys:string list
+  -> (string * float) list
 
 (** {1 Result} *)
 

--- a/lib/mode_enforcer.ml
+++ b/lib/mode_enforcer.ml
@@ -415,7 +415,7 @@ let record_effect_evidence
       ~decision_source:"mode_enforcer"
       ~input
       ~input_summary:(truncate_input input)
-      ~source_path:__FILE__
+      ~source_path:(Filename.basename __FILE__)
       ~source_line:__LINE__
       ~started_at:ts
       ~ended_at:ts

--- a/lib/mode_enforcer.ml
+++ b/lib/mode_enforcer.ml
@@ -415,6 +415,8 @@ let record_effect_evidence
       ~decision_source:"mode_enforcer"
       ~input
       ~input_summary:(truncate_input input)
+      ~source_path:__FILE__
+      ~source_line:__LINE__
       ~started_at:ts
       ~ended_at:ts
       ~result_status

--- a/test/dune
+++ b/test/dune
@@ -292,3 +292,14 @@
    OAS_RUNTIME_PATH
    %{bin:oas-runtime}
    (run %{test}))))
+
+(test
+ (name test_execution_manifest)
+ (modules test_execution_manifest)
+ (libraries agent_sdk llm_provider alcotest)
+ (deps %{bin:oas-runtime})
+ (action
+  (setenv
+   OAS_RUNTIME_PATH
+   %{bin:oas-runtime}
+   (run %{test}))))

--- a/test/test_cdal.ml
+++ b/test/test_cdal.ml
@@ -203,6 +203,8 @@ let test_effect_evidence_roundtrip () =
       ~result_status:Effect_evidence.Pending
       ~sandbox:"docker"
       ~workdir:"/workspace"
+      ~source_path:"lib/mode_enforcer.ml"
+      ~source_line:410
       ~turn:4
       ~execution_mode:"draft"
       ()
@@ -219,7 +221,12 @@ let test_effect_evidence_roundtrip () =
       "decision"
       "approval_required"
       (Effect_evidence.decision_to_string decoded.decision);
-    Alcotest.(check (option string)) "sandbox" (Some "docker") decoded.sandbox
+    Alcotest.(check (option string)) "sandbox" (Some "docker") decoded.sandbox;
+    Alcotest.(check (option string))
+      "source_path"
+      (Some "lib/mode_enforcer.ml")
+      decoded.source_path;
+    Alcotest.(check (option int)) "source_line" (Some 410) decoded.source_line
 ;;
 
 let test_runtime_health_roundtrip () =
@@ -1100,7 +1107,17 @@ let test_mode_enforcer_records_effect_evidence () =
     Alcotest.(check (option string))
       "violation"
       (Some "mutating_in_diagnose")
-      edit_effect.violation_kind
+      edit_effect.violation_kind;
+    Alcotest.(check bool)
+      "source path"
+      true
+      (match edit_effect.source_path with
+       | Some path -> contains_substring ~sub:"mode_enforcer.ml" path
+       | None -> false);
+    Alcotest.(check bool)
+      "source line recorded"
+      true
+      (Option.value ~default:0 edit_effect.source_line > 0)
   | _ -> Alcotest.fail "unexpected effect evidence order"
 ;;
 
@@ -1443,7 +1460,13 @@ let test_evidence_effects_in_proof () =
              "mode"
              (Some "diagnose")
              evidence.execution_mode;
-           Alcotest.(check (option int)) "turn" (Some 2) evidence.turn
+           Alcotest.(check (option int)) "turn" (Some 2) evidence.turn;
+           Alcotest.(check bool)
+             "source path"
+             true
+             (match evidence.source_path with
+              | Some path -> contains_substring ~sub:"mode_enforcer.ml" path
+              | None -> false)
          | Error e -> Alcotest.fail e)
       | Ok other ->
         Alcotest.fail

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -138,16 +138,20 @@ let test_provider_health_info_scores_failures () =
 let test_provider_health_scores_list () =
   let health = Complete_cascade.create_health () in
   let ccfg = Complete_cascade.default_cascade_config in
-  Complete_cascade.record_failure health "anthropic";
+  (* Use canonical [model_id@base_url] keys so the test reflects how
+     [provider_health] is keyed in production via [Complete_cascade.provider_key]. *)
+  let anthropic_key = "claude-3-5-sonnet@https://api.anthropic.com" in
+  let moonshot_key = "kimi-k2@https://api.moonshot.ai" in
+  Complete_cascade.record_failure health anthropic_key;
   let scores =
     Complete_cascade.provider_health_scores
       health
       ~cascade_config:ccfg
-      ~provider_keys:[ "anthropic"; "moonshot" ]
+      ~provider_keys:[ anthropic_key; moonshot_key ]
   in
   check int "score count" 2 (List.length scores);
-  check (float 0.001) "anthropic degraded" (2.0 /. 3.0) (List.assoc "anthropic" scores);
-  check (float 0.001) "moonshot optimistic" 1.0 (List.assoc "moonshot" scores)
+  check (float 0.001) "anthropic degraded" (2.0 /. 3.0) (List.assoc anthropic_key scores);
+  check (float 0.001) "moonshot optimistic" 1.0 (List.assoc moonshot_key scores)
 ;;
 
 (* ── cascade_config defaults ──────────────────────────── *)

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -101,12 +101,61 @@ let test_health_success_resets () =
   check bool "success reset then failure" true true
 ;;
 
+let test_provider_health_info_scores_failures () =
+  let health = Complete_cascade.create_health () in
+  let config =
+    Provider_config.make
+      ~kind:Ollama
+      ~model_id:"test"
+      ~base_url:"http://localhost:11434"
+      ()
+  in
+  let key = Complete_cascade.provider_key config in
+  let ccfg = Complete_cascade.default_cascade_config in
+  let initial =
+    Complete_cascade.provider_health_info health ~cascade_config:ccfg ~provider_key:key
+  in
+  check (float 0.001) "unknown provider score" 1.0 initial.health_score;
+  check int "unknown provider failures" 0 initial.consecutive_failures;
+  Complete_cascade.record_failure health key;
+  let one =
+    Complete_cascade.provider_health_info health ~cascade_config:ccfg ~provider_key:key
+  in
+  check (float 0.001) "one failure score" (2.0 /. 3.0) one.health_score;
+  check bool "one failure circuit closed" false one.circuit_open;
+  Complete_cascade.record_failure health key;
+  Complete_cascade.record_failure health key;
+  let open_ =
+    Complete_cascade.provider_health_info health ~cascade_config:ccfg ~provider_key:key
+  in
+  check (float 0.001) "open circuit score" 0.0 open_.health_score;
+  check bool "three failures open circuit" true open_.circuit_open;
+  match open_.cooldown_remaining_s with
+  | Some remaining -> check bool "cooldown remaining is positive" true (remaining > 0.0)
+  | None -> fail "expected cooldown_remaining_s"
+;;
+
+let test_provider_health_scores_list () =
+  let health = Complete_cascade.create_health () in
+  let ccfg = Complete_cascade.default_cascade_config in
+  Complete_cascade.record_failure health "anthropic";
+  let scores =
+    Complete_cascade.provider_health_scores
+      health
+      ~cascade_config:ccfg
+      ~provider_keys:[ "anthropic"; "moonshot" ]
+  in
+  check int "score count" 2 (List.length scores);
+  check (float 0.001) "anthropic degraded" (2.0 /. 3.0) (List.assoc "anthropic" scores);
+  check (float 0.001) "moonshot optimistic" 1.0 (List.assoc "moonshot" scores)
+;;
+
 (* ── cascade_config defaults ──────────────────────────── *)
 
 let test_default_config () =
   let cfg = Complete_cascade.default_cascade_config in
   check int "circuit_threshold" 3 cfg.Complete_cascade.circuit_threshold;
-  check (float 0.01) "circuit_cooldown_s" 60.0 cfg.Complete_cascade.circuit_cooldown_s
+  check (float 0.01) "circuit_cooldown_s" 30.0 cfg.Complete_cascade.circuit_cooldown_s
 ;;
 
 (* ── cascade_result variant construction ──────────────── *)
@@ -281,6 +330,8 @@ let suite =
   ; "health_create", `Quick, test_health_create_no_crash
   ; "health_failures", `Quick, test_record_failure_accumulates
   ; "health_success_reset", `Quick, test_health_success_resets
+  ; "provider_health_info_scores", `Quick, test_provider_health_info_scores_failures
+  ; "provider_health_scores_list", `Quick, test_provider_health_scores_list
   ; "default_config", `Quick, test_default_config
   ; "result_success", `Quick, test_result_success_variant
   ; "result_all_failed", `Quick, test_result_all_failed_variant

--- a/test/test_execution_manifest.ml
+++ b/test/test_execution_manifest.ml
@@ -1,0 +1,62 @@
+open Alcotest
+module EM = Agent_sdk.Execution_manifest
+
+let test_make_defaults () =
+  let manifest =
+    EM.make
+      ~contract:Agent_sdk.Contract.empty
+      ~mode:Agent_sdk.Execution_mode.Diagnose
+      ~risk_class:Agent_sdk.Risk_class.Low
+      ()
+  in
+  check int "provider_health defaults empty" 0 (List.length manifest.provider_health);
+  check
+    bool
+    "cascade_config defaults absent"
+    true
+    (Option.is_none manifest.cascade_config)
+;;
+
+let test_make_carries_provider_health_and_cascade_config () =
+  let cascade_config =
+    EM.cascade_config_of_complete_cascade
+      Llm_provider.Complete_cascade.default_cascade_config
+  in
+  let manifest =
+    EM.make
+      ~contract:Agent_sdk.Contract.empty
+      ~mode:Agent_sdk.Execution_mode.Draft
+      ~risk_class:Agent_sdk.Risk_class.High
+      ~provider_health:[ "anthropic", 0.0; "moonshot", 1.0 ]
+      ~cascade_config
+      ()
+  in
+  check
+    (float 0.001)
+    "anthropic health"
+    0.0
+    (List.assoc "anthropic" manifest.provider_health);
+  check
+    (float 0.001)
+    "moonshot health"
+    1.0
+    (List.assoc "moonshot" manifest.provider_health);
+  match manifest.cascade_config with
+  | None -> fail "expected cascade_config"
+  | Some cfg ->
+    check int "circuit_threshold" 3 cfg.circuit_threshold;
+    check (float 0.001) "circuit_cooldown_s" 30.0 cfg.circuit_cooldown_s
+;;
+
+let () =
+  run
+    "execution_manifest"
+    [ ( "manifest"
+      , [ test_case "make defaults" `Quick test_make_defaults
+        ; test_case
+            "make carries provider health and cascade config"
+            `Quick
+            test_make_carries_provider_health_and_cascade_config
+        ] )
+    ]
+;;


### PR DESCRIPTION
## What changed

- Adds provider health score snapshots/helpers to OAS complete-cascade types.
- Extends execution manifests with `provider_health` and optional `cascade_config`.
- Re-exports `Execution_manifest` through `Agent_sdk`.
- Adds `source_path` and `source_line` to effect evidence and populates them from `Mode_enforcer`.

## Why it matters

MASC can consume provider health from the OAS execution contract instead of inferring it from provider-specific logs. Effect evidence also carries the code source location at the enforcement boundary, which improves runtime cause tracking when an action is blocked or recorded.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build test/test_complete_cascade.exe test/test_execution_manifest.exe test/test_cdal.exe`
- `_build/default/test/test_complete_cascade.exe` — 14 tests
- `_build/default/test/test_execution_manifest.exe` — 2 tests
- `_build/default/test/test_cdal.exe` — 59 tests
