### PR TITLE
feat(log): count records dropped without sinks

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -100,7 +100,8 @@ let base_messages agent =
     test asserts green; see #799).  When no sink is registered the record
     is counted by {!Log.dropped_without_sink_count} and otherwise discarded,
     so hosts can detect missing telemetry wiring without forcing stderr
-    output. *)
+    output. Disabled records below the global log level are filtered before
+    this counter is considered. *)
 let stop_reason_label : Types.stop_reason -> string = function
   | EndTurn -> "end_turn"
   | StopToolUse -> "stop_tool_use"

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -97,11 +97,11 @@ let base_messages agent =
     slow one.  Goes through {!Log.info} rather than [Printf.eprintf]
     so [ppx_inline_test] does not capture the line as an unexpected
     stderr diff (raw eprintf during tests makes CI fail even when every
-    test asserts green; see #799).  When no sink is registered the record
-    is counted by {!Log.dropped_without_sink_count} and otherwise discarded,
-    so hosts can detect missing telemetry wiring without forcing stderr
-    output. Disabled records below the global log level are filtered before
-    this counter is considered. *)
+    test asserts green; see #799).  When no sink is registered the
+    enabled emit attempt is counted by {!Log.dropped_without_sink_count}
+    and dropped without allocating a record, so hosts can detect missing
+    telemetry wiring without forcing stderr output. Disabled records below
+    the global log level are filtered before this counter is considered. *)
 let stop_reason_label : Types.stop_reason -> string = function
   | EndTurn -> "end_turn"
   | StopToolUse -> "stop_tool_use"

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -97,9 +97,10 @@ let base_messages agent =
     slow one.  Goes through {!Log.info} rather than [Printf.eprintf]
     so [ppx_inline_test] does not capture the line as an unexpected
     stderr diff (raw eprintf during tests makes CI fail even when every
-    test asserts green; see #799).  When no sink is registered the call
-    is a no-op, so hosts that do not care about Agent telemetry pay
-    nothing. *)
+    test asserts green; see #799).  When no sink is registered the record
+    is counted by {!Log.dropped_without_sink_count} and otherwise discarded,
+    so hosts can detect missing telemetry wiring without forcing stderr
+    output. *)
 let stop_reason_label : Types.stop_reason -> string = function
   | EndTurn -> "end_turn"
   | StopToolUse -> "stop_tool_use"

--- a/lib/log.ml
+++ b/lib/log.ml
@@ -118,6 +118,7 @@ type sink = record -> unit
    reappear. *)
 let global_level = Atomic.make Info
 let global_sinks : sink list Atomic.t = Atomic.make []
+let dropped_without_sink = Atomic.make 0
 
 let rec atomic_update atom ~f =
   let current = Atomic.get atom in
@@ -127,7 +128,13 @@ let rec atomic_update atom ~f =
 
 let set_global_level level = Atomic.set global_level level
 let add_sink sink = atomic_update global_sinks ~f:(fun sinks -> sink :: sinks)
-let clear_sinks () = Atomic.set global_sinks []
+
+let clear_sinks () =
+  Atomic.set global_sinks [];
+  Atomic.set dropped_without_sink 0
+;;
+
+let dropped_without_sink_count () = Atomic.get dropped_without_sink
 
 (* ── Logger instance ──────────────────────────────────────────── *)
 
@@ -157,7 +164,9 @@ let emit t level message fields =
       ; span_id = t.span_id
       }
     in
-    List.iter (fun sink -> sink record) (Atomic.get global_sinks))
+    match Atomic.get global_sinks with
+    | [] -> ignore (Atomic.fetch_and_add dropped_without_sink 1 : int)
+    | sinks -> List.iter (fun sink -> sink record) sinks)
 ;;
 
 let debug t message fields = emit t Debug message fields

--- a/lib/log.ml
+++ b/lib/log.ml
@@ -112,10 +112,11 @@ type sink = record -> unit
 
 (* Global logger configuration is shared across domains.
    Atomic.t keeps reads lock-free. [add_sink] linearizes through a CAS
-   loop and [clear_sinks] publishes an empty sink set with a single
-   atomic store. When they race, the final sink set reflects whichever
-   operation linearizes last; sinks removed by [clear_sinks] do not
-   reappear. *)
+   loop. [clear_sinks] first resets the no-sink drop counter, then
+   publishes an empty sink set with an atomic store. When [add_sink] and
+   [clear_sinks] race, the final sink set reflects whichever sink-set
+   operation linearizes last; records emitted after the counter reset can
+   still be counted if they observe no sinks. *)
 let global_level = Atomic.make Info
 let global_sinks : sink list Atomic.t = Atomic.make []
 let dropped_without_sink = Atomic.make 0
@@ -130,8 +131,8 @@ let set_global_level level = Atomic.set global_level level
 let add_sink sink = atomic_update global_sinks ~f:(fun sinks -> sink :: sinks)
 
 let clear_sinks () =
-  Atomic.set global_sinks [];
-  Atomic.set dropped_without_sink 0
+  Atomic.set dropped_without_sink 0;
+  Atomic.set global_sinks []
 ;;
 
 let dropped_without_sink_count () = Atomic.get dropped_without_sink

--- a/lib/log.ml
+++ b/lib/log.ml
@@ -154,19 +154,20 @@ let emit t level message fields =
   (* Zero-cost: skip record allocation if level is below threshold *)
   if level_to_int level >= level_to_int (Atomic.get global_level)
   then (
-    let record =
-      { ts = Unix.gettimeofday ()
-      ; level
-      ; module_name = t.module_name
-      ; message
-      ; fields
-      ; trace_id = t.trace_id
-      ; span_id = t.span_id
-      }
-    in
     match Atomic.get global_sinks with
     | [] -> ignore (Atomic.fetch_and_add dropped_without_sink 1 : int)
-    | sinks -> List.iter (fun sink -> sink record) sinks)
+    | sinks ->
+      let record =
+        { ts = Unix.gettimeofday ()
+        ; level
+        ; module_name = t.module_name
+        ; message
+        ; fields
+        ; trace_id = t.trace_id
+        ; span_id = t.span_id
+        }
+      in
+      List.iter (fun sink -> sink record) sinks)
 ;;
 
 let debug t message fields = emit t Debug message fields

--- a/lib/log.mli
+++ b/lib/log.mli
@@ -58,9 +58,11 @@ type sink = record -> unit
 
     Underlying globals use [Atomic.t]. Concurrent sink registration is
     linearized with a CAS loop so [add_sink] does not lose updates
-    across domains. [clear_sinks] publishes an empty sink set with a
-    single atomic store, so a race between [add_sink] and [clear_sinks]
-    resolves to whichever operation linearizes last. *)
+    across domains. [clear_sinks] first resets the no-sink drop counter,
+    then publishes an empty sink set with an atomic store. A race between
+    [add_sink] and [clear_sinks] resolves to whichever sink-set operation
+    linearizes last; records emitted after the counter reset can still be
+    counted if they observe no sinks. *)
 
 val set_global_level : level -> unit
 val add_sink : sink -> unit

--- a/lib/log.mli
+++ b/lib/log.mli
@@ -67,9 +67,10 @@ type sink = record -> unit
 val set_global_level : level -> unit
 val add_sink : sink -> unit
 val clear_sinks : unit -> unit
-val dropped_without_sink_count : unit -> int
+
 (** Number of enabled log records dropped because no sink was registered since
     the last {!clear_sinks}. *)
+val dropped_without_sink_count : unit -> int
 
 (** {2 Logger instance} *)
 

--- a/lib/log.mli
+++ b/lib/log.mli
@@ -65,6 +65,9 @@ type sink = record -> unit
 val set_global_level : level -> unit
 val add_sink : sink -> unit
 val clear_sinks : unit -> unit
+val dropped_without_sink_count : unit -> int
+(** Number of enabled log records dropped because no sink was registered since
+    the last {!clear_sinks}. *)
 
 (** {2 Logger instance} *)
 

--- a/test/test_log.ml
+++ b/test/test_log.ml
@@ -277,6 +277,21 @@ let test_stderr_sink () =
   sink record
 ;;
 
+let test_dropped_without_sink_count () =
+  setup ();
+  Alcotest.(check int) "initial count" 0 (Log.dropped_without_sink_count ());
+  Log.warn log "no sink" [];
+  Log.error log "still no sink" [];
+  Alcotest.(check int) "records without sink" 2 (Log.dropped_without_sink_count ());
+  let sink, get = Log.collector_sink () in
+  Log.add_sink sink;
+  Log.error log "with sink" [];
+  Alcotest.(check int) "count unchanged after sink" 2 (Log.dropped_without_sink_count ());
+  Alcotest.(check int) "sink receives record" 1 (List.length (get ()));
+  Log.clear_sinks ();
+  Alcotest.(check int) "clear resets count" 0 (Log.dropped_without_sink_count ())
+;;
+
 let test_emit_below_level () =
   setup ();
   Log.set_global_level Log.Error;
@@ -341,6 +356,10 @@ let () =
             `Quick
             test_clear_sinks_racing_add_sink_removes_stale_sinks
         ; Alcotest.test_case "stderr sink" `Quick test_stderr_sink
+        ; Alcotest.test_case
+            "dropped without sink count"
+            `Quick
+            test_dropped_without_sink_count
         ] )
     ; "field", [ Alcotest.test_case "to_json" `Quick test_field_to_json ]
     ; ( "record"

--- a/test/test_log.ml
+++ b/test/test_log.ml
@@ -292,6 +292,26 @@ let test_dropped_without_sink_count () =
   Alcotest.(check int) "clear resets count" 0 (Log.dropped_without_sink_count ())
 ;;
 
+let test_dropped_without_sink_ignores_below_level () =
+  setup ();
+  (* Records filtered out by the global level threshold are not "enabled"
+     and must NOT bump the dropped-without-sink counter, even when no sink
+     is attached. *)
+  Log.set_global_level Log.Error;
+  Log.debug log "below threshold" [];
+  Log.info log "below threshold" [];
+  Log.warn log "below threshold" [];
+  Alcotest.(check int)
+    "below-level records do not increment counter"
+    0
+    (Log.dropped_without_sink_count ());
+  Log.error log "above threshold no sink" [];
+  Alcotest.(check int)
+    "enabled record without sink increments counter"
+    1
+    (Log.dropped_without_sink_count ())
+;;
+
 let test_emit_below_level () =
   setup ();
   Log.set_global_level Log.Error;
@@ -360,6 +380,10 @@ let () =
             "dropped without sink count"
             `Quick
             test_dropped_without_sink_count
+        ; Alcotest.test_case
+            "dropped without sink ignores below-level records"
+            `Quick
+            test_dropped_without_sink_ignores_below_level
         ] )
     ; "field", [ Alcotest.test_case "to_json" `Quick test_field_to_json ]
     ; ( "record"


### PR DESCRIPTION
## Summary
- Add `Agent_sdk.Log.dropped_without_sink_count` so hosts can detect enabled log records emitted before any sink is registered.
- Keep no-sink behavior quiet by counting dropped records instead of forcing stderr output.
- `Log.emit` matches `global_sinks` first and only allocates the record on the `sinks` arm, so the no-sink path stays cheap.
- Test coverage proves below-level records do NOT increment the counter (only enabled records that pass the level filter do).

## Why
The Kimi multi-keeper validation plan called out OAS log records being silently dropped when downstream hosts forget to install a sink. This keeps OAS generic while making that host wiring gap observable.

## Note on version metadata
The original PR body advertised a 0.190.10 version bump, but `0.190.10` shipped via #1401 / #1400 before this PR was rebased onto main. A separate `chore: bump 0.190.11` PR will cover this surface as part of the next release window.

## Validation
- `scripts/dune-local.sh build test/test_log.exe`
- `_build/default/test/test_log.exe` — 21/21 pass