### PR TITLE
feat(structured): expose schema extractors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ original tag dates. `0.100.4` was never tagged or released.
 
 ## Unreleased
 
+### Added
+- `Structured.schema_to_json_schema` exposes the provider-native object schema
+  generated from a typed schema, and `Structured.schema_extractor` lets
+  `run_structured` callers reuse the same fenced-JSON parsing and
+  `schema.parse` validation as direct structured extraction.
+
 ## [0.190.12] - 2026-05-05
 
 ### Changed

--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -152,7 +152,7 @@ let extract ~sw ~net ?base_url ?provider ~config ~(schema : 'a schema) prompt
     Use with {!run_structured} for Agent.t-level structured output. *)
 type 'a extractor = api_response -> ('a, string) result
 
-let schema_json_extractor (schema : 'a schema) : 'a extractor =
+let schema_extractor (schema : 'a schema) : 'a extractor =
   fun response -> extract_text_json ~schema response |> Result.map_error Error.to_string
 ;;
 

--- a/lib/structured.mli
+++ b/lib/structured.mli
@@ -20,6 +20,12 @@ type 'a schema =
 
 val schema_to_tool_json : _ schema -> Yojson.Safe.t
 
+(** Return the object JSON schema used for provider-native structured output.
+
+    This is the same schema shape embedded under [input_schema] by
+    {!schema_to_tool_json}, but without the tool wrapper fields. *)
+val schema_to_json_schema : _ schema -> Yojson.Safe.t
+
 val extract_tool_input
   :  schema:'a schema
   -> content_block list
@@ -42,6 +48,13 @@ val extract
 (** {1 Extractors} *)
 
 type 'a extractor = api_response -> ('a, string) result
+
+(** Build an {!extractor} from a typed schema.
+
+    This is the Agent-level counterpart to {!extract}: it parses the response
+    text as JSON, accepts fenced JSON, and delegates shape validation to
+    [schema.parse]. *)
+val schema_extractor : 'a schema -> 'a extractor
 
 val json_extractor : (Yojson.Safe.t -> 'a) -> 'a extractor
 val text_extractor : (string -> 'a option) -> 'a extractor

--- a/test/test_structured.ml
+++ b/test/test_structured.ml
@@ -61,6 +61,23 @@ let test_schema_to_json_structure () =
   Alcotest.(check bool) "age required" true (List.mem "age" required)
 ;;
 
+let test_schema_to_json_schema_structure () =
+  let json = Structured.schema_to_json_schema person_schema in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "type" "object" (json |> member "type" |> to_string);
+  Alcotest.(check bool)
+    "no tool wrapper name"
+    true
+    (match member "name" json with
+     | `Null -> true
+     | _ -> false);
+  let props = json |> member "properties" in
+  Alcotest.(check string)
+    "name prop type"
+    "string"
+    (props |> member "name" |> member "type" |> to_string)
+;;
+
 (* --- extract_tool_input --- *)
 
 let test_extract_tool_input_success () =
@@ -418,6 +435,24 @@ let test_text_extractor_none () =
   | Ok _ -> Alcotest.fail "expected error"
 ;;
 
+let test_schema_extractor_success () =
+  let extract = Structured.schema_extractor person_schema in
+  let resp = make_response [ Text "```json\n{\"name\":\"Dana\",\"age\":42}\n```" ] in
+  match extract resp with
+  | Ok (name, age) ->
+    Alcotest.(check string) "name" "Dana" name;
+    Alcotest.(check int) "age" 42 age
+  | Error e -> Alcotest.fail e
+;;
+
+let test_schema_extractor_parse_failure () =
+  let extract = Structured.schema_extractor person_schema in
+  let resp = make_response [ Text "{\"name\":123}" ] in
+  match extract resp with
+  | Error e -> Alcotest.(check bool) "has error text" true (String.length e > 0)
+  | Ok _ -> Alcotest.fail "expected schema parse error"
+;;
+
 (* --- extract_with_retry: unit-level logic tests --- *)
 
 (** Test that max_retries=0 means only 1 attempt (no retry).
@@ -499,6 +534,10 @@ let () =
       , [ Alcotest.test_case "structure" `Quick test_schema_to_json_structure
         ; Alcotest.test_case "optional params" `Quick test_schema_optional_params
         ; Alcotest.test_case "tool choice name" `Quick test_schema_tool_choice_name
+        ; Alcotest.test_case
+            "json schema structure"
+            `Quick
+            test_schema_to_json_schema_structure
         ; Alcotest.test_case "empty params" `Quick test_schema_empty_params
         ; Alcotest.test_case "all param types" `Quick test_schema_all_param_types
         ; Alcotest.test_case
@@ -537,6 +576,11 @@ let () =
         ; Alcotest.test_case "json_extractor no text" `Quick test_json_extractor_no_text
         ; Alcotest.test_case "text_extractor success" `Quick test_text_extractor_success
         ; Alcotest.test_case "text_extractor none" `Quick test_text_extractor_none
+        ; Alcotest.test_case "schema_extractor success" `Quick test_schema_extractor_success
+        ; Alcotest.test_case
+            "schema_extractor parse failure"
+            `Quick
+            test_schema_extractor_parse_failure
         ] )
     ; ( "extract_with_retry"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary
- expose Structured.schema_to_json_schema for typed schema introspection
- expose Structured.schema_extractor for Agent.run_structured callers
- add focused coverage for fenced JSON parsing and schema parse failures

## Boundary
- This is OAS-generic structured-output substrate for downstream auto-summary/tagging workflows; it does not add MASC board semantics to OAS.

## Verification
- env DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_structured.exe
- ./_build/default/test/test_structured.exe
- git diff --check