### PR TITLE
test(provider): rescue complete HTTP suite

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -8,7 +8,6 @@
 ; The following files are NOT wired here because they fail to compile
 ; against current main.  Bodies untouched per fix scope.  Tracked separately:
 ;   - test/test_agent_card.ml          (Agent_card.agent_info missing 'cascade')
-;   - test/test_complete_http.ml       (record missing on_capability_drop etc.)
 ;   - test/test_deep_coverage.ml       (Alcotest.run call commented out, dead body)
 ;   - test/test_event_integration.ml   (Unbound module Handoff)
 ;   - test/test_guardrails_async.ml    (pattern shape mismatch vs new return type)
@@ -310,4 +309,9 @@
 (test
  (name test_provider_complete)
  (modules test_provider_complete)
+ (libraries agent_sdk llm_provider alcotest eio_main))
+
+(test
+ (name test_complete_http)
+ (modules test_complete_http)
  (libraries agent_sdk llm_provider alcotest eio_main))

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -294,7 +294,8 @@ let test_complete_metrics () =
     let end_count = ref 0 in
     let status_calls = ref [] in
     let metrics : Metrics.t =
-      { on_cache_hit = (fun ~model_id:_ -> incr hit_count)
+      { Metrics.noop with
+        on_cache_hit = (fun ~model_id:_ -> incr hit_count)
       ; on_cache_miss = (fun ~model_id:_ -> incr miss_count)
       ; on_request_start = (fun ~model_id:_ -> incr start_count)
       ; on_request_end = (fun ~model_id:_ ~latency_ms:_ -> incr end_count)
@@ -383,7 +384,8 @@ let test_complete_error_metrics () =
     let error_count = ref 0 in
     let status_calls = ref [] in
     let metrics : Metrics.t =
-      { on_cache_hit = (fun ~model_id:_ -> ())
+      { Metrics.noop with
+        on_cache_hit = (fun ~model_id:_ -> ())
       ; on_cache_miss = (fun ~model_id:_ -> ())
       ; on_request_start = (fun ~model_id:_ -> ())
       ; on_request_end = (fun ~model_id:_ ~latency_ms:_ -> ())


### PR DESCRIPTION
## Summary
- wire test_complete_http as a standalone Dune test
- update stale Metrics.t literals to extend Metrics.noop
- remove test_complete_http from the compile-failure orphan list

## Why
The suite already covers HTTP completion, metrics, retry, transport, and streaming behavior, but it was excluded after Metrics.t gained capability/retry/token callbacks. Extending Metrics.noop preserves the test-specific callback assertions without duplicating every hook field.

## Validation
- git diff --check
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build test/test_complete_http.exe
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh exec test/test_complete_http.exe