### PR TITLE
fix(structured): satisfy ocamlformat gate

### DIFF
--- a/test/test_structured.ml
+++ b/test/test_structured.ml
@@ -576,7 +576,10 @@ let () =
         ; Alcotest.test_case "json_extractor no text" `Quick test_json_extractor_no_text
         ; Alcotest.test_case "text_extractor success" `Quick test_text_extractor_success
         ; Alcotest.test_case "text_extractor none" `Quick test_text_extractor_none
-        ; Alcotest.test_case "schema_extractor success" `Quick test_schema_extractor_success
+        ; Alcotest.test_case
+            "schema_extractor success"
+            `Quick
+            test_schema_extractor_success
         ; Alcotest.test_case
             "schema_extractor parse failure"
             `Quick


### PR DESCRIPTION
## Summary
- apply ocamlformat 0.29.0 wrapping to the schema extractor test case registration
- unblock the post-merge OAS OCaml Format failure from #1405

## Root Cause
- #1405 added the schema extractor Alcotest case on one line; CI's `dune build @fmt` rewrites it to a multi-line form.

## Validation
- `opam exec -- ocamlformat --version` -> 0.29.0
- `opam exec -- ocamlformat --check test/test_structured.ml`
- `git diff --check`