### PR TITLE
test(streaming): rescue SSE parser suite

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -24,7 +24,6 @@
 ;   - test/test_full_pipeline_cov.ml   (structured JSON parse)
 ;   - test/test_lenient_json.ml        (double_stringify union)
 ;   - test/test_llm_provider_cov.ml    (backend_gemini thinking default)
-;   - test/test_streaming.ml           (parse_sse_event unknown/malformed)
 ;
 ; Dune runs tests in sandboxes, so runtime-spawning tests cannot rely on
 ; cwd-relative _build/default/bin/oas_runtime.exe discovery.
@@ -301,6 +300,11 @@
    OAS_RUNTIME_PATH
    %{bin:oas-runtime}
    (run %{test}))))
+
+(test
+ (name test_streaming)
+ (modules test_streaming)
+ (libraries agent_sdk alcotest))
 
 (test
  (name test_provider_bridge)

--- a/test/test_streaming.ml
+++ b/test/test_streaming.ml
@@ -225,15 +225,21 @@ let test_parse_error_event () =
 
 let test_parse_invalid_json () =
   match Agent_sdk.Streaming.parse_sse_event None "not json at all" with
-  | None -> ()
-  | Some _ -> Alcotest.fail "expected None for invalid JSON"
+  | Some (SSEParseFailed { raw; reason }) ->
+    Alcotest.(check string) "raw" "not json at all" raw;
+    Alcotest.(check bool) "reason is present" true (String.length reason > 0)
+  | Some _ -> Alcotest.fail "expected SSEParseFailed for invalid JSON"
+  | None -> Alcotest.fail "parse returned None"
 ;;
 
 let test_parse_unknown_event_type () =
   let data = {|{"type":"unknown_future_event","data":"x"}|} in
   match Agent_sdk.Streaming.parse_sse_event None data with
-  | None -> ()
-  | Some _ -> Alcotest.fail "expected None for unknown event type"
+  | Some (SSEUnknownEventType { event_type; raw }) ->
+    Alcotest.(check string) "event_type" "unknown_future_event" event_type;
+    Alcotest.(check string) "raw" data raw
+  | Some _ -> Alcotest.fail "expected SSEUnknownEventType"
+  | None -> Alcotest.fail "parse returned None"
 ;;
 
 let test_parse_message_start_with_cache () =


### PR DESCRIPTION
## Summary
- wire test_streaming back into Dune as a focused test
- update stale parse_sse_event assertions for malformed JSON and unknown event types
- remove test_streaming from the runtime-failure orphan list

## Why
The streaming parser no longer silently drops malformed or unknown SSE chunks. It emits SSEParseFailed / SSEUnknownEventType so downstream accumulators can mark the stream as corrupted instead of producing phantom completions. The orphan test still expected the old None behavior.

## Validation
- git diff --check
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build test/test_streaming.exe
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh exec test/test_streaming.exe