### PR TITLE
test(provider): rescue LLM provider coverage suite

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -22,7 +22,6 @@
 ;   - test/test_cli.ml                 (version/init/card/help/eval)
 ;   - test/test_full_pipeline_cov.ml   (structured JSON parse)
 ;   - test/test_lenient_json.ml        (double_stringify union)
-;   - test/test_llm_provider_cov.ml    (backend_gemini thinking default)
 ;
 ; Dune runs tests in sandboxes, so runtime-spawning tests cannot rely on
 ; cwd-relative _build/default/bin/oas_runtime.exe discovery.
@@ -319,3 +318,8 @@
  (name test_complete_http)
  (modules test_complete_http)
  (libraries agent_sdk llm_provider alcotest eio_main))
+
+(test
+ (name test_llm_provider_cov)
+ (modules test_llm_provider_cov)
+ (libraries agent_sdk llm_provider alcotest))

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -707,7 +707,7 @@ let test_build_request_with_thinking_default_budget () =
   let tc = gc |> member "thinkingConfig" in
   Alcotest.(check int)
     "default thinkingBudget"
-    10000
+    (Constants.Thinking.gemini_budget ())
     (tc |> member "thinkingBudget" |> to_int)
 ;;
 


### PR DESCRIPTION
## Summary
- wire test_llm_provider_cov back into Dune
- update Gemini thinking default assertion to follow Constants.Thinking.gemini_budget ()
- remove test_llm_provider_cov from the runtime-failure orphan list

## Why
Gemini thinking default budget is now resolved through the shared thinking-budget constants, including environment overrides. The orphan suite still asserted the old hard-coded 10000 value, so it drifted from the implementation contract.

## Validation
- git diff --check origin/main...HEAD
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build test/test_llm_provider_cov.exe
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh exec test/test_llm_provider_cov.exe