### PR TITLE
test(json): rescue lenient JSON suite

### DIFF
--- a/lib/llm_provider/lenient_json.ml
+++ b/lib/llm_provider/lenient_json.ml
@@ -237,12 +237,12 @@ let parse (s : string) : Yojson.Safe.t =
     | exception Yojson.Json_error _ -> None
   in
   (* Unwrap double-stringified JSON: if direct parse yields a string
-     whose content is itself a JSON object or array, parse the inner value.
+     whose content is itself JSON, parse the inner value.
      This handles LLMs that wrap JSON in an extra layer of string escaping. *)
   let maybe_unwrap_string = function
     | `String inner ->
       let t = String.trim inner in
-      if String.length t > 0 && (t.[0] = '{' || t.[0] = '[')
+      if String.length t > 0 && (t.[0] = '{' || t.[0] = '[' || t.[0] = '"')
       then (
         match try_parse t with
         | Some json -> json

--- a/test/dune
+++ b/test/dune
@@ -21,7 +21,6 @@
 ;   - test/test_builder.ml             (with_setters)
 ;   - test/test_cli.ml                 (version/init/card/help/eval)
 ;   - test/test_full_pipeline_cov.ml   (structured JSON parse)
-;   - test/test_lenient_json.ml        (double_stringify union)
 ;
 ; Dune runs tests in sandboxes, so runtime-spawning tests cannot rely on
 ; cwd-relative _build/default/bin/oas_runtime.exe discovery.
@@ -323,3 +322,8 @@
  (name test_llm_provider_cov)
  (modules test_llm_provider_cov)
  (libraries agent_sdk llm_provider alcotest))
+
+(test
+ (name test_lenient_json)
+ (modules test_lenient_json)
+ (libraries agent_sdk alcotest))


### PR DESCRIPTION
Summary:
- wire test_lenient_json back into Dune
- align direct double-stringified JSON string unwrap with the existing recovery transform so escaped JSON strings are parsed consistently

Validation:
- git diff --check
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build test/test_lenient_json.exe
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh exec test/test_lenient_json.exe