### PR TITLE
test(api): rescue API coverage suite

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -17,7 +17,6 @@
 ; ---- (2) pre-existing runtime failures — compile OK, runtest fails ----
 ; The following suites compile but have pre-existing test failures.
 ; They are excluded until the failures are fixed in separate PRs:
-;   - test/test_api.ml                 (with_setters context_thresholds)
 ;   - test/test_builder.ml             (with_setters)
 ;   - test/test_cli.ml                 (version/init/card/help/eval)
 ;   - test/test_full_pipeline_cov.ml   (structured JSON parse)
@@ -326,4 +325,9 @@
 (test
  (name test_lenient_json)
  (modules test_lenient_json)
+ (libraries agent_sdk alcotest))
+
+(test
+ (name test_api)
+ (modules test_api)
  (libraries agent_sdk alcotest))

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -1189,14 +1189,18 @@ let test_parse_sse_error () =
 
 let test_parse_sse_unknown_type () =
   match Streaming.parse_sse_event (Some "future_event") "{}" with
-  | None -> ()
-  | Some _ -> fail "expected None for unknown type"
+  | Some (Types.SSEUnknownEventType { event_type; raw }) ->
+    check string "event_type" "future_event" event_type;
+    check string "raw" "{}" raw
+  | _ -> fail "expected SSEUnknownEventType for unknown type"
 ;;
 
 let test_parse_sse_malformed_json () =
   match Streaming.parse_sse_event (Some "message_start") "not json" with
-  | None -> ()
-  | Some _ -> fail "expected None for malformed JSON"
+  | Some (Types.SSEParseFailed { raw; reason }) ->
+    check string "raw" "not json" raw;
+    check bool "reason present" true (String.length reason > 0)
+  | _ -> fail "expected SSEParseFailed for malformed JSON"
 ;;
 
 (* ------------------------------------------------------------------ *)


### PR DESCRIPTION
Summary:
- wire test_api back into Dune as a standalone suite
- update stale SSE unknown-event and malformed-JSON assertions to expect structured parser errors

Validation:
- git diff --check
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build test/test_api.exe
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh exec test/test_api.exe