### PR TITLE
test(builder): rescue builder coverage suite

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -17,7 +17,6 @@
 ; ---- (2) pre-existing runtime failures — compile OK, runtest fails ----
 ; The following suites compile but have pre-existing test failures.
 ; They are excluded until the failures are fixed in separate PRs:
-;   - test/test_builder.ml             (with_setters)
 ;   - test/test_cli.ml                 (version/init/card/help/eval)
 ;   - test/test_full_pipeline_cov.ml   (structured JSON parse)
 ;
@@ -331,3 +330,8 @@
  (name test_api)
  (modules test_api)
  (libraries agent_sdk alcotest))
+
+(test
+ (name test_builder)
+ (modules test_builder)
+ (libraries agent_sdk alcotest eio_main))

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -674,17 +674,30 @@ let test_with_max_total_tokens () =
     (Agent.state agent).config.max_total_tokens
 ;;
 
-(** Extract the Token_budget value from a Compose strategy produced by
+(** Probe message large enough to push [from_context_config]'s dynamic strategy
+    into its budgeted branch for the context sizes covered below. *)
+let context_budget_probe_messages =
+  [ { Types.role = Types.User
+    ; content = [ Types.Text (String.make 1_200_000 'x') ]
+    ; name = None
+    ; tool_call_id = None
+    ; metadata = []
+    }
+  ]
+;;
+
+(** Extract the [Token_budget] value from reducer strategies produced by
     [Context_reducer.from_context_config]. Returns [None] if not found. *)
 let extract_token_budget reducer =
-  match reducer.Context_reducer.strategy with
-  | Context_reducer.Compose strategies ->
-    List.find_map
-      (function
-        | Context_reducer.Token_budget n -> Some n
-        | _ -> None)
-      strategies
-  | _ -> None
+  let rec loop strategy =
+    match strategy with
+    | Context_reducer.Token_budget n -> Some n
+    | Context_reducer.Dynamic selector ->
+      loop (selector ~turn:1 ~messages:context_budget_probe_messages)
+    | Context_reducer.Compose strategies -> List.find_map loop strategies
+    | _ -> None
+  in
+  loop reducer.Context_reducer.strategy
 ;;
 
 (* --- 26. with_context_thresholds: explicit context_window_tokens --- *)


### PR DESCRIPTION
Summary:
- wire test_builder back into Dune as a standalone Eio-enabled suite
- update the context-threshold budget helper to inspect the current dynamic reducer strategy shape

Validation:
- git diff --check
- ocamlformat --check test/test_builder.ml
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build test/test_builder.exe
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh exec test/test_builder.exe