### PR TITLE
test(cli): rescue CLI coverage suite

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -17,7 +17,6 @@
 ; ---- (2) pre-existing runtime failures — compile OK, runtest fails ----
 ; The following suites compile but have pre-existing test failures.
 ; They are excluded until the failures are fixed in separate PRs:
-;   - test/test_cli.ml                 (version/init/card/help/eval)
 ;   - test/test_full_pipeline_cov.ml   (structured JSON parse)
 ;
 ; Dune runs tests in sandboxes, so runtime-spawning tests cannot rely on
@@ -335,3 +334,14 @@
  (name test_builder)
  (modules test_builder)
  (libraries agent_sdk alcotest eio_main))
+
+(test
+ (name test_cli)
+ (modules test_cli)
+ (libraries agent_sdk alcotest cohttp-eio eio eio_main str unix yojson)
+ (deps ../bin/oas_cli.exe %{bin:oas-runtime})
+ (action
+  (setenv
+   OAS_RUNTIME_PATH
+   %{bin:oas-runtime}
+   (run %{test}))))


### PR DESCRIPTION
## Summary
- wire test/test_cli.ml as a standalone Dune test
- declare the local CLI executable and runtime deps so sandboxed runtest can find binaries
- remove test_cli from the runtime orphan list

## Verification
- git diff --check origin/main...HEAD
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build bin/oas_cli.exe test/test_cli.exe
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh exec test/test_cli.exe