### PR TITLE
test(pipeline): rescue full pipeline coverage suite

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -17,7 +17,6 @@
 ; ---- (2) pre-existing runtime failures — compile OK, runtest fails ----
 ; The following suites compile but have pre-existing test failures.
 ; They are excluded until the failures are fixed in separate PRs:
-;   - test/test_full_pipeline_cov.ml   (structured JSON parse)
 ;
 ; Dune runs tests in sandboxes, so runtime-spawning tests cannot rely on
 ; cwd-relative _build/default/bin/oas_runtime.exe discovery.
@@ -345,3 +344,8 @@
    OAS_RUNTIME_PATH
    %{bin:oas-runtime}
    (run %{test}))))
+
+(test
+ (name test_full_pipeline_cov)
+ (modules test_full_pipeline_cov)
+ (libraries agent_sdk alcotest cohttp-eio eio eio_main unix yojson))

--- a/test/test_full_pipeline_cov.ml
+++ b/test/test_full_pipeline_cov.ml
@@ -26,7 +26,7 @@ let openai_text_response ?(id = "chatcmpl-1") text =
   Printf.sprintf
     {|{"id":"%s","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}|}
     id
-    text
+    (escape_json_string text)
 ;;
 
 let anthropic_text_response
@@ -39,7 +39,7 @@ let anthropic_text_response
     {|{"id":"%s","type":"message","role":"assistant","model":"%s","content":[{"type":"text","text":"%s"}],"stop_reason":"%s","usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}|}
     id
     model
-    text
+    (escape_json_string text)
     stop_reason
 ;;
 
@@ -54,7 +54,7 @@ let openai_tool_use ?(id = "chatcmpl-t") tool_name input_json =
 let openai_multi_content tool_name input_json text =
   Printf.sprintf
     {|{"id":"chatcmpl-m","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s","tool_calls":[{"id":"call_2","type":"function","function":{"name":"%s","arguments":"%s"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":20,"completion_tokens":15,"total_tokens":35}}|}
-    text
+    (escape_json_string text)
     tool_name
     (escape_json_string input_json)
 ;;
@@ -62,7 +62,7 @@ let openai_multi_content tool_name input_json text =
 let openai_response text =
   Printf.sprintf
     {|{"id":"chatcmpl-1","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}|}
-    text
+    (escape_json_string text)
 ;;
 
 let openai_sse text =
@@ -72,7 +72,7 @@ let openai_sse text =
      data: \
      {\"id\":\"chatcmpl-s1\",\"object\":\"chat.completion.chunk\",\"model\":\"mock\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n\n\
      data: [DONE]\n\n"
-    text
+    (escape_json_string text)
 ;;
 
 (** Multi-response mock server cycling through responses. *)


### PR DESCRIPTION
## Summary
- wire test/test_full_pipeline_cov.ml as a standalone Dune test
- escape canned mock provider response text before embedding it in JSON
- remove full_pipeline_cov from the runtime orphan list

## Verification
- git diff --check origin/main...HEAD
- ocamlformat --check test/test_full_pipeline_cov.ml
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build test/test_full_pipeline_cov.exe
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh exec test/test_full_pipeline_cov.exe