### PR TITLE
fix(eval): tag otel metric json exports

### DIFF
--- a/lib/eval_otel_bridge.ml
+++ b/lib/eval_otel_bridge.ml
@@ -180,6 +180,9 @@ let emit_run_metrics (inst : Otel_tracer.instance) (rm : Eval.run_metrics) : uni
 
 let to_metrics_json (snap : metrics_snapshot) : Yojson.Safe.t =
   let metrics = to_metric_list snap in
+  let tags =
+    `Assoc [ "agent_name", `String snap.agent_name; "run_id", `String snap.run_id ]
+  in
   `List
     (List.map
        (fun (m : otel_metric) ->
@@ -187,6 +190,7 @@ let to_metrics_json (snap : metrics_snapshot) : Yojson.Safe.t =
             [ "name", `String m.name
             ; "value", `Float m.value
             ; "type", `String m.metric_type
+            ; "tags", tags
             ])
        metrics)
 ;;
@@ -384,5 +388,25 @@ let%test "to_metrics_json produces valid JSON array" =
   let json = to_metrics_json (extract rm) in
   match json with
   | `List items -> List.length items = 3
+  | _ -> false
+;;
+
+let%test "to_metrics_json carries run correlation tags" =
+  let rm : Eval.run_metrics =
+    { run_id = "run-json"
+    ; agent_name = "agent-json"
+    ; timestamp = 0.0
+    ; metrics = []
+    ; harness_verdicts = []
+    ; trace_summary = None
+    }
+  in
+  match to_metrics_json (extract rm) with
+  | `List (`Assoc fields :: _) -> (
+    match List.assoc_opt "tags" fields with
+    | Some (`Assoc tags) ->
+      List.assoc_opt "run_id" tags = Some (`String "run-json")
+      && List.assoc_opt "agent_name" tags = Some (`String "agent-json")
+    | _ -> false)
   | _ -> false
 ;;

--- a/lib/eval_otel_bridge.mli
+++ b/lib/eval_otel_bridge.mli
@@ -55,7 +55,8 @@ val emit_run_metrics : Otel_tracer.instance -> Eval.run_metrics -> unit
 (** {1 JSON export} *)
 
 (** Produce a JSON array of metric objects for external consumption.
-    Each object has [name], [value], and [type] fields. *)
+    Each object has [name], [value], [type], and correlation [tags]
+    containing [agent_name] and [run_id]. *)
 val to_metrics_json : metrics_snapshot -> Yojson.Safe.t
 
 (** Convert snapshot to a flat list of [otel_metric] records. *)

--- a/test/test_eval_otel_bridge.ml
+++ b/test/test_eval_otel_bridge.ml
@@ -46,7 +46,13 @@ let () =
       check int "3 metrics" 3 (List.length items);
       let first = List.hd items in
       let name = Yojson.Safe.Util.(first |> member "name" |> to_string) in
-      check string "first name" "oas.eval.verdict_passed_total" name
+      check string "first name" "oas.eval.verdict_passed_total" name;
+      let run_id = Yojson.Safe.Util.(first |> member "tags" |> member "run_id" |> to_string) in
+      let agent_name =
+        Yojson.Safe.Util.(first |> member "tags" |> member "agent_name" |> to_string)
+      in
+      check string "run id tag" "test-run-1" run_id;
+      check string "agent name tag" "test-agent" agent_name
     | _ -> fail "expected JSON list"
   in
   run


### PR DESCRIPTION
## Summary

Adds stable correlation tags to `Eval_otel_bridge.to_metrics_json` output. Each exported metric row now keeps the existing `name`, `value`, and `type` fields and adds `tags.agent_name` plus `tags.run_id` so dashboards and report consumers can join JSON metrics back to the originating eval run without out-of-band context.

## Why

The native OTel path already records run correlation on the summary span, but the direct JSON export dropped that context. That made the JSON export hard to consume safely in downstream dashboards or reports once multiple eval runs were aggregated.

## Validation

- `git diff --check origin/main...HEAD`
- `ocamlc -stop-after parsing lib/eval_otel_bridge.ml`
- `ocamlc -stop-after parsing test/test_eval_otel_bridge.ml`
- `scripts/dune-local.sh build test/test_eval_otel_bridge.exe`
- `_build/default/test/test_eval_otel_bridge.exe`

Note: `scripts/dune-local.sh exec ./test/test_eval_otel_bridge.exe` was queued behind the shared Dune lock, so I stopped only that queued waiter and ran the already-built executable directly.