### PR TITLE
test(agent-card): rescue agent card coverage suite

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -7,7 +7,6 @@
 ; ---- (1) compile failures — not wired until bodies are fixed ----
 ; The following files are NOT wired here because they fail to compile
 ; against current main.  Bodies untouched per fix scope.  Tracked separately:
-;   - test/test_agent_card.ml          (Agent_card.agent_info missing 'cascade')
 ;   - test/test_deep_coverage.ml       (Alcotest.run call commented out, dead body)
 ;   - test/test_event_integration.ml   (Unbound module Handoff)
 ;   - test/test_guardrails_async.ml    (pattern shape mismatch vs new return type)
@@ -28,6 +27,7 @@
   test_capabilities
   test_call_time_pruner_config
   test_agent
+  test_agent_card
   test_agent_auto_dump
   test_agent_config
   test_agent_config_deep

--- a/test/test_agent_card.ml
+++ b/test/test_agent_card.ml
@@ -23,7 +23,6 @@ let base_info : Agent_card.agent_info =
         }
       ]
   ; provider = None
-  ; cascade = None
   ; mcp_clients_count = 0
   ; has_elicitation = false
   ; skill_registry = None


### PR DESCRIPTION
## Summary
- wire test_agent_card back into test/dune
- remove the stale cascade field from the Agent_card.agent_info fixture

## Root cause
Agent_card.agent_info no longer exposes cascade, but the orphaned test fixture still populated that removed field.

## Validation
- git diff --check origin/main...HEAD
- ocamlformat --check test/test_agent_card.ml
- focused Dune build/test was attempted locally but the shared Dune lock was held by other active jobs for over ten minutes; GitHub CI is the full build/test gate for this PR