### PR TITLE
fix(retry): stop cascade on account usage limit

### DIFF
--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -128,6 +128,8 @@ let malformed_json_indicators =
     - Anthropic: "You have insufficient credits"; "billing_hard_limit"
     - OpenAI: "You exceeded your current quota, please check your plan
       and billing details"
+    - Provider account-limit variants: "Your account has exceeded the
+      API usage limit"
     - Google / Gemini: "Resource exhausted"
     - Mistral: "insufficient_quota"
     - Together.ai: "insufficient_funds"
@@ -141,6 +143,7 @@ let hard_quota_indicators =
   ; "insufficient_quota"
   ; "insufficient_funds"
   ; "exceeded your current quota"
+  ; "exceeded the api usage limit"
   ; "no resource package"
   ; "quota exceeded"
   ; "billing_hard_limit"
@@ -680,6 +683,7 @@ let%test "is_hard_quota_message positive cases" =
   is_hard_quota_message "Insufficient balance"
   && is_hard_quota_message "insufficient credit balance"
   && is_hard_quota_message "You exceeded your current quota"
+  && is_hard_quota_message "Your account has exceeded the API usage limit."
   && is_hard_quota_message "quota exceeded"
   && is_hard_quota_message "insufficient_quota"
   && is_hard_quota_message "resource exhausted"

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -1,7 +1,5 @@
-(** Tests for Complete_cascade: health tracking, circuit breaking, result types.
-
-    Only tests pure logic (no HTTP/Eio). End-to-end cascade tests require
-    transport mocking and live in integration tests. *)
+(** Tests for Complete_cascade: health tracking, circuit breaking, result types,
+    and mocked transport control-flow guards. No live HTTP is used here. *)
 
 open Alcotest
 open Llm_provider
@@ -287,6 +285,71 @@ let test_circuit_open_skips_provider_and_falls_back () =
   | _ -> fail "expected fallback Success"
 ;;
 
+let test_hard_quota_stops_without_calling_fallback () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let primary =
+    Provider_config.make
+      ~kind:Anthropic
+      ~model_id:"claude-sonnet-4-20250514"
+      ~base_url:"https://api.anthropic.com"
+      ()
+  in
+  let fallback =
+    Provider_config.make
+      ~kind:Kimi
+      ~model_id:"moonshot-v1"
+      ~base_url:"https://api.moonshot.cn"
+      ()
+  in
+  let called_models = ref [] in
+  let hard_quota_error =
+    Http_client.HttpError
+      { code = 429
+      ; body =
+          "{\"error\":{\"type\":\"error\",\"message\":\"Your account has exceeded the \
+           API usage limit.\"}}"
+      }
+  in
+  let transport : Llm_transport.t =
+    { complete_sync =
+        (fun (req : Llm_transport.completion_request) ->
+          called_models := req.config.model_id :: !called_models;
+          let response =
+            if String.equal req.config.model_id primary.model_id
+            then Error hard_quota_error
+            else Ok dummy_response
+          in
+          { Llm_transport.response; latency_ms = 25 })
+    ; complete_stream =
+        (fun ~on_event:_ (req : Llm_transport.completion_request) ->
+          called_models := req.config.model_id :: !called_models;
+          if String.equal req.config.model_id primary.model_id
+          then Error hard_quota_error
+          else Ok dummy_response)
+    }
+  in
+  let result =
+    Complete_cascade.complete_cascade
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~clock
+      ~transport
+      ~steps:[ primary; fallback ]
+      ~messages:[]
+      ()
+  in
+  check (list string) "only primary provider called" [ primary.model_id ] !called_models;
+  match result with
+  | Complete_cascade.Hard_quota { config; error } ->
+    check string "hard quota provider" primary.model_id config.model_id;
+    check bool "preserves hard quota error" true (error = hard_quota_error)
+  | _ -> fail "expected Hard_quota without fallback"
+;;
+
 let test_attempt_timeout_fast_paths_without_retrying_same_step () =
   Eio_main.run
   @@ fun env ->
@@ -406,9 +469,15 @@ let suite =
   ; "result_hard_quota", `Quick, test_result_hard_quota_variant
   ; "skip_reason", `Quick, test_skip_reason_variant
   ; "circuit_open_fallback", `Quick, test_circuit_open_skips_provider_and_falls_back
+  ; ( "hard_quota_stops_without_fallback"
+    , `Quick
+    , test_hard_quota_stops_without_calling_fallback )
   ; ( "attempt_timeout_fast_path"
     , `Quick
     , test_attempt_timeout_fast_paths_without_retrying_same_step )
+  ; ( "attempt_timeout_disable_nonpositive"
+    , `Quick
+    , test_attempt_timeout_disable_via_nonpositive_sentinel )
   ]
 ;;
 


### PR DESCRIPTION
## What changed

- Treat the provider message `Your account has exceeded the API usage limit` as hard account-level quota exhaustion.
- Add a cascade regression proving hard quota stops immediately without calling fallback providers.
- Wire the existing nonpositive `attempt_timeout_s` sentinel regression into the `complete_cascade` Alcotest suite.
- Update the cascade test header to reflect its current mocked-transport coverage.

## Why it matters

This closes a retry/cascade gap in the OAS cancellation/fast-path track: an account-level quota 429 was being handled like a transient rate limit, so OAS could burn retries on the same dead provider and then continue into fallback work instead of surfacing the terminal quota state immediately.

Related: jeong-sik/masc-mcp#11929

## Validation

- `git diff --check HEAD~1..HEAD`
- `ocamlformat --check lib/llm_provider/retry.ml test/test_complete_cascade.ml`
- `ocamlc -stop-after parsing lib/llm_provider/retry.ml test/test_complete_cascade.ml`
- `scripts/dune-local.sh build test/test_complete_cascade.exe test/complete_retry/test_complete_retry.exe`
- `./_build/default/test/test_complete_cascade.exe` (17 tests)
- `./_build/default/test/complete_retry/test_complete_retry.exe` (4 tests)
