### PR TITLE
test(events): rescue event integration suite

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -7,7 +7,6 @@
 ; ---- (1) compile failures — not wired until bodies are fixed ----
 ; The following files are NOT wired here because they fail to compile
 ; against current main.  Bodies untouched per fix scope.  Tracked separately:
-;   - test/test_event_integration.ml   (Unbound module Handoff)
 ;   - test/test_guardrails_async.ml    (pattern shape mismatch vs new return type)
 ;   - test/test_runtime_worker_integration.ml (type mismatch on participant_run_success)
 ;   - test/test_structured_stream.ml   (build error — see CI log)
@@ -348,4 +347,9 @@
 (test
  (name test_full_pipeline_cov)
  (modules test_full_pipeline_cov)
+ (libraries agent_sdk alcotest cohttp-eio eio eio_main unix yojson))
+
+(test
+ (name test_event_integration)
+ (modules test_event_integration)
  (libraries agent_sdk alcotest cohttp-eio eio eio_main unix yojson))

--- a/test/test_event_integration.ml
+++ b/test/test_event_integration.ml
@@ -152,12 +152,12 @@ let test_handoff_emits_request_and_completion () =
       Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
     let bus = Event_bus.create () in
     let sub = Event_bus.subscribe bus in
-    let target : Handoff.handoff_target =
-      { name = "researcher"
-      ; description = "Research specialist"
-      ; config = { Types.default_config with name = "researcher" }
-      ; tools = []
-      }
+    let target =
+      Subagent.to_handoff_target
+        ~parent_config:Types.default_config
+        ~base_tools:[]
+        (Subagent.of_markdown
+           "---\nname: researcher\ndescription: Research specialist\n---\nResearch.")
     in
     let provider : Provider.config =
       { provider = Provider.Local { base_url }; model_id = "mock"; api_key_env = "" }


### PR DESCRIPTION
## Summary
- wire test_event_integration as a standalone suite with its Eio/Cohttp dependencies
- replace the stale private Handoff type reference with the public Subagent.to_handoff_target helper
- remove test_event_integration from the compile-failure orphan list

## Validation
- git diff --check origin/main...HEAD
- ocamlformat --check test/test_event_integration.ml
- dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/test-event-integration-orphan-rescue-0506 -j 1 @fmt
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build test/test_event_integration.exe
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh exec test/test_event_integration.exe (5 tests)