### PR TITLE
test(guardrails): rescue async guardrails suite

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -7,7 +7,6 @@
 ; ---- (1) compile failures — not wired until bodies are fixed ----
 ; The following files are NOT wired here because they fail to compile
 ; against current main.  Bodies untouched per fix scope.  Tracked separately:
-;   - test/test_guardrails_async.ml    (pattern shape mismatch vs new return type)
 ;   - test/test_runtime_worker_integration.ml (type mismatch on participant_run_success)
 ;   - test/test_structured_stream.ml   (build error — see CI log)
 ;
@@ -353,3 +352,8 @@
  (name test_event_integration)
  (modules test_event_integration)
  (libraries agent_sdk alcotest cohttp-eio eio eio_main unix yojson))
+
+(test
+ (name test_guardrails_async)
+ (modules test_guardrails_async)
+ (libraries agent_sdk alcotest eio eio_main))

--- a/test/test_guardrails_async.ml
+++ b/test/test_guardrails_async.ml
@@ -187,7 +187,7 @@ let test_guarded_all_pass () =
     { input_validators = [ pass_input ]; output_validators = [ pass_output ] }
   in
   let action () = Ok (make_response "result") in
-  match Guardrails_async.guarded ~config ~messages:dummy_messages ~action with
+  match Guardrails_async.guarded ~config ~messages:dummy_messages ~action () with
   | Ok resp ->
     check
       string
@@ -210,7 +210,7 @@ let test_guarded_input_blocks () =
     action_called := true;
     Ok (make_response "should not reach")
   in
-  match Guardrails_async.guarded ~config ~messages:dummy_messages ~action with
+  match Guardrails_async.guarded ~config ~messages:dummy_messages ~action () with
   | Error (`Validation (Fail { reason = "banned"; _ })) ->
     check bool "action not called" false !action_called
   | _ -> fail "should have been blocked by input"
@@ -223,7 +223,7 @@ let test_guarded_output_rejects () =
     { input_validators = [ pass_input ]; output_validators = [ fail_output "unsafe" ] }
   in
   let action () = Ok (make_response "raw") in
-  match Guardrails_async.guarded ~config ~messages:dummy_messages ~action with
+  match Guardrails_async.guarded ~config ~messages:dummy_messages ~action () with
   | Error (`Validation (Fail { reason = "unsafe"; _ })) -> ()
   | _ -> fail "should have been rejected by output"
 ;;
@@ -235,7 +235,7 @@ let test_guarded_action_error () =
     { input_validators = [ pass_input ]; output_validators = [ pass_output ] }
   in
   let action () = Error "api down" in
-  match Guardrails_async.guarded ~config ~messages:dummy_messages ~action with
+  match Guardrails_async.guarded ~config ~messages:dummy_messages ~action () with
   | Error (`Action "api down") -> ()
   | _ -> fail "should propagate action error"
 ;;


### PR DESCRIPTION
## Summary
- wire test_guardrails_async as a standalone focused suite
- update guarded-call tests for the current final-unit API
- remove test_guardrails_async from the compile-failure orphan list

## Validation
- git diff --check origin/main...HEAD
- ocamlformat --check test/test_guardrails_async.ml
- dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/test-guardrails-async-orphan-rescue-0506 -j 1 @fmt
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build test/test_guardrails_async.exe
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh exec test/test_guardrails_async.exe (14 tests)