### PR TITLE
test(runtime): rescue worker integration suite

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -7,7 +7,6 @@
 ; ---- (1) compile failures — not wired until bodies are fixed ----
 ; The following files are NOT wired here because they fail to compile
 ; against current main.  Bodies untouched per fix scope.  Tracked separately:
-;   - test/test_runtime_worker_integration.ml (type mismatch on participant_run_success)
 ;   - test/test_structured_stream.ml   (build error — see CI log)
 ;
 ; ---- (2) pre-existing runtime failures — compile OK, runtest fails ----
@@ -357,3 +356,8 @@
  (name test_guardrails_async)
  (modules test_guardrails_async)
  (libraries agent_sdk alcotest eio eio_main))
+
+(test
+ (name test_runtime_worker_integration)
+ (modules test_runtime_worker_integration)
+ (libraries agent_sdk alcotest eio eio_main unix))

--- a/test/test_runtime_worker_integration.ml
+++ b/test/test_runtime_worker_integration.ml
@@ -767,12 +767,16 @@ let test_run_participant_mock () =
     match
       Runtime_server_worker.run_participant store state session_id resolution detail
     with
-    | Ok text ->
-      Alcotest.(check bool) "mock response non-empty" true (String.length text > 0);
+    | Ok result ->
+      Alcotest.(check bool)
+        "mock response non-empty"
+        true
+        (String.length result.summary > 0);
       let expected = "Mock runtime response for alice: say hello" in
-      Alcotest.(check string) "mock response content" expected text
-    | Error e ->
-      Alcotest.fail (Printf.sprintf "run_participant mock failed: %s" (Error.to_string e)))
+      Alcotest.(check string) "mock response content" expected result.summary
+    | Error failure ->
+      Alcotest.fail
+        (Printf.sprintf "run_participant mock failed: %s" (Error.to_string failure.error)))
 ;;
 
 let test_run_participant_echo () =
@@ -813,12 +817,13 @@ let test_run_participant_echo () =
     match
       Runtime_server_worker.run_participant store state session_id resolution detail
     with
-    | Ok text ->
-      Alcotest.(check bool) "echo text non-empty" true (String.length text > 0);
+    | Ok result ->
+      Alcotest.(check bool) "echo text non-empty" true (String.length result.summary > 0);
       let expected = "Mock runtime response for bob: echo this message" in
-      Alcotest.(check string) "echo response content" expected text
-    | Error e ->
-      Alcotest.fail (Printf.sprintf "run_participant echo failed: %s" (Error.to_string e)))
+      Alcotest.(check string) "echo response content" expected result.summary
+    | Error failure ->
+      Alcotest.fail
+        (Printf.sprintf "run_participant echo failed: %s" (Error.to_string failure.error)))
 ;;
 
 (* ── persist_event with agent lifecycle events ────────────────── *)


### PR DESCRIPTION
## Summary
- wire test_runtime_worker_integration as a focused Dune suite
- update run_participant assertions for participant_run_success / participant_run_failure
- remove the suite from the compile-failure orphan list

## Validation
- git diff --check origin/main...HEAD
- ocamlformat --check test/test_runtime_worker_integration.ml
- dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/test-runtime-worker-integration-orphan-rescue-0506 -j 1 @fmt
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build test/test_runtime_worker_integration.exe
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh exec test/test_runtime_worker_integration.exe