### PR TITLE
fix(cascade): use Eio mutex for provider health

### DIFF
--- a/lib/llm_provider/complete_cascade.ml
+++ b/lib/llm_provider/complete_cascade.ml
@@ -44,7 +44,7 @@ let attempt_timeout_error ~model_id ~timeout_s =
     }
 ;;
 
-(* --- Per-provider health tracking (Mutex-guarded) --- *)
+(* --- Per-provider health tracking (Eio.Mutex-guarded) --- *)
 
 type provider_entry =
   { consecutive_failures : int
@@ -53,7 +53,7 @@ type provider_entry =
 
 type provider_health =
   { entries : (string, provider_entry) Hashtbl.t
-  ; mutex : Mutex.t
+  ; mutex : Eio.Mutex.t
   ; time_fn : unit -> float
   }
 
@@ -63,7 +63,7 @@ let create_health ?clock () =
     | Some c -> fun () -> Eio.Time.now c
     | None -> fun () -> Unix.time ()
   in
-  { entries = Hashtbl.create 8; mutex = Mutex.create (); time_fn }
+  { entries = Hashtbl.create 8; mutex = Eio.Mutex.create (); time_fn }
 ;;
 
 let provider_key (config : Provider_config.t) =
@@ -71,8 +71,18 @@ let provider_key (config : Provider_config.t) =
 ;;
 
 let with_mutex health f =
-  Mutex.lock health.mutex;
-  Fun.protect ~finally:(fun () -> Mutex.unlock health.mutex) f
+  (* Avoid [use_rw ~protect:true] here: health snapshots are also used by
+     pure tests/callers outside an Eio cancellation context.  The protected
+     block is synchronous Hashtbl mutation, so manual unlock-on-exception
+     keeps Eio-fiber waiters cooperative without requiring Cancel.protect. *)
+  Eio.Mutex.lock health.mutex;
+  match f () with
+  | v ->
+    Eio.Mutex.unlock health.mutex;
+    v
+  | exception exn ->
+    Eio.Mutex.unlock health.mutex;
+    raise exn
 ;;
 
 let record_success health key =

--- a/lib/llm_provider/complete_cascade.mli
+++ b/lib/llm_provider/complete_cascade.mli
@@ -24,8 +24,9 @@ val default_cascade_config : cascade_config
 
 (** {1 Health Tracking} *)
 
-(** Thread-safe per-provider health state for circuit breaking.
-    Create once and share across cascade calls to maintain circuit state. *)
+(** Fiber-safe per-provider health state for circuit breaking.
+    Create once and share across cascade calls in the same Eio runtime to
+    maintain circuit state. *)
 type provider_health
 
 (** Create an empty health tracker.

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -152,6 +152,28 @@ let test_provider_health_scores_list () =
   check (float 0.001) "moonshot optimistic" 1.0 (List.assoc moonshot_key scores)
 ;;
 
+let test_provider_health_eio_mutex_concurrent_recording () =
+  Eio_main.run
+  @@ fun _env ->
+  let health = Complete_cascade.create_health () in
+  let key = "concurrent-model@https://example.invalid" in
+  let workers =
+    List.init 10 (fun _ ->
+      fun () ->
+      for _ = 1 to 10 do
+        Complete_cascade.record_failure health key
+      done)
+  in
+  Eio.Fiber.all workers;
+  let info =
+    Complete_cascade.provider_health_info
+      health
+      ~cascade_config:Complete_cascade.default_cascade_config
+      ~provider_key:key
+  in
+  check int "all fiber writes recorded" 100 info.consecutive_failures
+;;
+
 (* ── cascade_config defaults ──────────────────────────── *)
 
 let test_default_config () =
@@ -463,6 +485,9 @@ let suite =
   ; "health_success_reset", `Quick, test_health_success_resets
   ; "provider_health_info_scores", `Quick, test_provider_health_info_scores_failures
   ; "provider_health_scores_list", `Quick, test_provider_health_scores_list
+  ; ( "provider_health_eio_mutex_concurrent_recording"
+    , `Quick
+    , test_provider_health_eio_mutex_concurrent_recording )
   ; "default_config", `Quick, test_default_config
   ; "result_success", `Quick, test_result_success_variant
   ; "result_all_failed", `Quick, test_result_all_failed_variant


### PR DESCRIPTION
Summary:
- replace the OAS cascade provider-health Stdlib.Mutex/Fun.protect lock with Eio.Mutex lock/unlock
- keep pure health helper compatibility by avoiding Cancel.protect for the synchronous Hashtbl critical section
- add a concurrent Eio fiber regression that records provider failures through the shared health tracker

Why:
This is a narrow cancellation-risk reduction from the broader MASC/OAS incident queue. The cascade path runs in Eio, so provider-health waiters should not block the whole domain on Stdlib.Mutex. This does not close the whole cancellation-guard epic; it removes one concrete Mutex/Fun.protect hotspot.

Refs jeong-sik/masc-mcp#10395
Refs jeong-sik/masc-mcp#11929

Validation:
- git diff --check
- ocamlc -stop-after parsing lib/llm_provider/complete_cascade.ml lib/llm_provider/complete_cascade.mli test/test_complete_cascade.ml
- scripts/dune-local.sh build test/test_complete_cascade.exe
- ./_build/default/test/test_complete_cascade.exe