### PR TITLE
test(stream): rescue structured stream suite

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -7,7 +7,6 @@
 ; ---- (1) compile failures — not wired until bodies are fixed ----
 ; The following files are NOT wired here because they fail to compile
 ; against current main.  Bodies untouched per fix scope.  Tracked separately:
-;   - test/test_structured_stream.ml   (build error — see CI log)
 ;
 ; ---- (2) pre-existing runtime failures — compile OK, runtest fails ----
 ; The following suites compile but have pre-existing test failures.
@@ -210,6 +209,7 @@
   test_structured_coverage
   test_structured_deep
   test_structured_ext
+  test_structured_stream
   test_subagent
   test_succession
   test_swiss_verdict_json

--- a/test/test_structured_stream.ml
+++ b/test/test_structured_stream.ml
@@ -163,6 +163,8 @@ let test_on_event_callback_fires () =
       | MessageStop -> "message_stop"
       | Ping -> "ping"
       | SSEError _ -> "error"
+      | SSEParseFailed _ -> "parse_failed"
+      | SSEUnknownEventType _ -> "unknown_event_type"
     in
     event_types := t :: !event_types);
   let types = List.rev !event_types in


### PR DESCRIPTION
## Summary
- wire test_structured_stream back into the Dune test list
- handle SSEParseFailed and SSEUnknownEventType in the event-label callback
- clear the final compile-failure orphan entry from test/dune

## Validation
- git diff --check origin/main...HEAD
- ocamlformat --check test/test_structured_stream.ml
- dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/test-structured-stream-orphan-rescue-0506 -j 1 @fmt
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build test/test_structured_stream.exe
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh exec test/test_structured_stream.exe