### PR TITLE
fix(mcp): preserve builtin tool permissions

### DIFF
--- a/lib/protocol/mcp_schema.ml
+++ b/lib/protocol/mcp_schema.ml
@@ -60,89 +60,7 @@ let mcp_tool_of_sdk_tool (t : Sdk_types.tool) : mcp_tool =
   }
 ;;
 
-let descriptor_for_builtin_tool name =
-  let empty =
-    { Tool.kind = None
-    ; mutation_class = None
-    ; concurrency_class = None
-    ; permission = None
-    ; shell = None
-    ; notes = []
-    ; examples = []
-    }
-  in
-  match String.lowercase_ascii name with
-  (* Read-only: file/code, notebook, browser observation, task queries *)
-  | "read"
-  | "glob"
-  | "grep"
-  | "search"
-  | "list_dir"
-  | "find_file"
-  | "read_file"
-  | "find_symbol"
-  | "get_symbols_overview"
-  | "find_referencing_symbols"
-  | "search_for_pattern"
-  | "notebook_read"
-  | "read_console_messages"
-  | "read_network_requests"
-  | "get_page_text"
-  | "read_page"
-  | "tabs_context_mcp"
-  | "task_list"
-  | "task_get"
-  | "task_output" ->
-    Some
-      { empty with
-        mutation_class = Some "read_only"
-      ; concurrency_class = Some Tool.Parallel_read
-      }
-  (* Local-mutation: file editing, task/team management *)
-  | "write"
-  | "edit"
-  | "create_text_file"
-  | "replace_content"
-  | "rename_symbol"
-  | "insert_after_symbol"
-  | "insert_before_symbol"
-  | "replace_symbol_body"
-  | "notebook_edit"
-  | "task_create"
-  | "task_update"
-  | "task_stop"
-  | "team_create"
-  | "team_delete" ->
-    Some
-      { empty with
-        mutation_class = Some "workspace_mutating"
-      ; concurrency_class = Some Tool.Sequential_workspace
-      }
-  (* External-effect: HITL, web, browser interaction *)
-  | "ask_user_question"
-  | "web_fetch"
-  | "web_search"
-  | "navigate"
-  | "computer"
-  | "find"
-  | "form_input"
-  | "javascript_tool"
-  | "tabs_create_mcp"
-  | "upload_image" ->
-    Some
-      { empty with
-        mutation_class = Some "external_effect"
-      ; concurrency_class = Some Tool.Exclusive_external
-      }
-  (* Shell-dynamic *)
-  | "bash" | "execute_shell_command" ->
-    Some
-      { empty with
-        mutation_class = Some "external_effect"
-      ; concurrency_class = Some Tool.Exclusive_external
-      }
-  | _ -> None
-;;
+let descriptor_for_builtin_tool = Mode_enforcer.builtin_descriptor
 
 (** Convert {!mcp_tool} to SDK {!Tool.t} with the given call handler. *)
 let mcp_tool_to_sdk_tool ~call_fn mcp_tool =
@@ -257,6 +175,7 @@ let%test "descriptor_for_builtin_tool read is read_only" =
   match descriptor_for_builtin_tool "read" with
   | Some d ->
     d.mutation_class = Some "read_only" && d.concurrency_class = Some Tool.Parallel_read
+    && d.permission = Some Tool.ReadOnly
   | None -> false
 ;;
 
@@ -265,14 +184,16 @@ let%test "descriptor_for_builtin_tool web_fetch is external" =
   | Some d ->
     d.mutation_class = Some "external_effect"
     && d.concurrency_class = Some Tool.Exclusive_external
+    && d.permission = Some Tool.Destructive
   | None -> false
 ;;
 
 let%test "descriptor_for_builtin_tool task_create is mutation" =
   match descriptor_for_builtin_tool "task_create" with
   | Some d ->
-    d.mutation_class = Some "workspace_mutating"
+    d.mutation_class = Some "local_mutation"
     && d.concurrency_class = Some Tool.Sequential_workspace
+    && d.permission = Some Tool.Write
   | None -> false
 ;;
 

--- a/lib/protocol/mcp_schema.ml
+++ b/lib/protocol/mcp_schema.ml
@@ -174,7 +174,8 @@ let%test "mcp_tool_of_sdk_tool None description becomes empty" =
 let%test "descriptor_for_builtin_tool read is read_only" =
   match descriptor_for_builtin_tool "read" with
   | Some d ->
-    d.mutation_class = Some "read_only" && d.concurrency_class = Some Tool.Parallel_read
+    d.mutation_class = Some "read_only"
+    && d.concurrency_class = Some Tool.Parallel_read
     && d.permission = Some Tool.ReadOnly
   | None -> false
 ;;

--- a/test/test_mcp.ml
+++ b/test/test_mcp.ml
@@ -194,17 +194,19 @@ let test_mcp_builtin_tool_descriptor_permission () =
   in
   (match Tool.descriptor read_tool with
    | Some d ->
-     Alcotest.(check (option string)) "read mutation" (Some "read_only")
+     Alcotest.(check (option string))
+       "read mutation"
+       (Some "read_only")
        d.Tool.mutation_class;
-     Alcotest.(check bool) "read permission" true
-       (d.Tool.permission = Some Tool.ReadOnly)
+     Alcotest.(check bool) "read permission" true (d.Tool.permission = Some Tool.ReadOnly)
    | None -> Alcotest.fail "read_file descriptor missing");
   (match Tool.descriptor write_tool with
    | Some d ->
-     Alcotest.(check (option string)) "write mutation" (Some "local_mutation")
+     Alcotest.(check (option string))
+       "write mutation"
+       (Some "local_mutation")
        d.Tool.mutation_class;
-     Alcotest.(check bool) "write permission" true
-       (d.Tool.permission = Some Tool.Write)
+     Alcotest.(check bool) "write permission" true (d.Tool.permission = Some Tool.Write)
    | None -> Alcotest.fail "write descriptor missing");
   (match
      Completion_contract.effectful_tool_satisfies
@@ -217,14 +219,20 @@ let test_mcp_builtin_tool_descriptor_permission () =
        { name = "read_file"; input = `Assoc []; tool = Some read_tool }
    with
    | Error msg ->
-     Alcotest.(check bool) "read-only rejected" true
+     Alcotest.(check bool)
+       "read-only rejected"
+       true
        (contains_substring ~sub:"read-only" msg)
    | Ok () -> Alcotest.fail "read-only tool should not satisfy effectful contract");
   match Tool.descriptor external_tool with
   | Some d ->
-    Alcotest.(check (option string)) "external mutation" (Some "external_effect")
+    Alcotest.(check (option string))
+      "external mutation"
+      (Some "external_effect")
       d.Tool.mutation_class;
-    Alcotest.(check bool) "external permission" true
+    Alcotest.(check bool)
+      "external permission"
+      true
       (d.Tool.permission = Some Tool.Destructive)
   | None -> Alcotest.fail "web_fetch descriptor missing"
 ;;

--- a/test/test_mcp.ml
+++ b/test/test_mcp.ml
@@ -175,6 +175,60 @@ let test_mcp_tool_to_sdk_tool () =
   | Error _ -> Alcotest.fail "expected Ok"
 ;;
 
+let test_mcp_builtin_tool_descriptor_permission () =
+  let call_fn _input : Types.tool_result = Ok { content = "ok" } in
+  let read_tool =
+    Mcp.mcp_tool_to_sdk_tool
+      ~call_fn
+      { name = "read_file"; description = "Read"; input_schema = `Assoc [] }
+  in
+  let write_tool =
+    Mcp.mcp_tool_to_sdk_tool
+      ~call_fn
+      { name = "write"; description = "Write"; input_schema = `Assoc [] }
+  in
+  let external_tool =
+    Mcp.mcp_tool_to_sdk_tool
+      ~call_fn
+      { name = "web_fetch"; description = "Fetch"; input_schema = `Assoc [] }
+  in
+  (match Tool.descriptor read_tool with
+   | Some d ->
+     Alcotest.(check (option string)) "read mutation" (Some "read_only")
+       d.Tool.mutation_class;
+     Alcotest.(check bool) "read permission" true
+       (d.Tool.permission = Some Tool.ReadOnly)
+   | None -> Alcotest.fail "read_file descriptor missing");
+  (match Tool.descriptor write_tool with
+   | Some d ->
+     Alcotest.(check (option string)) "write mutation" (Some "local_mutation")
+       d.Tool.mutation_class;
+     Alcotest.(check bool) "write permission" true
+       (d.Tool.permission = Some Tool.Write)
+   | None -> Alcotest.fail "write descriptor missing");
+  (match
+     Completion_contract.effectful_tool_satisfies
+       { name = "write"; input = `Assoc []; tool = Some write_tool }
+   with
+   | Ok () -> ()
+   | Error msg -> Alcotest.fail ("write should satisfy effectful contract: " ^ msg));
+  (match
+     Completion_contract.effectful_tool_satisfies
+       { name = "read_file"; input = `Assoc []; tool = Some read_tool }
+   with
+   | Error msg ->
+     Alcotest.(check bool) "read-only rejected" true
+       (contains_substring ~sub:"read-only" msg)
+   | Ok () -> Alcotest.fail "read-only tool should not satisfy effectful contract");
+  match Tool.descriptor external_tool with
+  | Some d ->
+    Alcotest.(check (option string)) "external mutation" (Some "external_effect")
+      d.Tool.mutation_class;
+    Alcotest.(check bool) "external permission" true
+      (d.Tool.permission = Some Tool.Destructive)
+  | None -> Alcotest.fail "web_fetch descriptor missing"
+;;
+
 let test_mcp_tool_bridge_error () =
   let mcp_tool : Mcp.mcp_tool =
     { name = "fail"
@@ -398,6 +452,10 @@ let () =
         ] )
     ; ( "tool_bridge"
       , [ test_case "mcp_tool_to_sdk_tool" `Quick test_mcp_tool_to_sdk_tool
+        ; test_case
+            "builtin descriptor permissions"
+            `Quick
+            test_mcp_builtin_tool_descriptor_permission
         ; test_case "bridge error propagation" `Quick test_mcp_tool_bridge_error
         ] )
     ; ( "sdk_bridge"


### PR DESCRIPTION
## Summary
- route MCP builtin tool descriptors through the centralized Mode_enforcer registry
- preserve permission metadata for read/write/external MCP-wrapped tools
- add regression coverage that strict effectful-tool contracts accept MCP write tools and reject MCP read-only tools

## Why it matters
Downstream coordinators need generic OAS permission metadata to decide whether tool use is read-only, workspace-mutating, or externally effectful. MCP-wrapped builtins previously had mutation/concurrency metadata but no Tool.permission, which made strict required-tool and approval policies treat them as unclassified.

## Validation
- scripts/dune-local.sh build test/test_mcp.exe
- ./_build/default/test/test_mcp.exe
- scripts/dune-local.sh runtest lib/protocol
- git diff --check