### PR TITLE
[P1] Add risk-class cascade defaults to execution manifest

### DIFF
--- a/lib/execution_manifest.ml
+++ b/lib/execution_manifest.ml
@@ -1,6 +1,11 @@
 type provider_health_score = string * float
 
 type cascade_config =
+  { circuit_threshold : int
+  ; circuit_cooldown_s : float
+  }
+
+type cascade_strategy =
   { max_steps : int
   ; step_timeout_s : float
   ; global_timeout_s : float
@@ -24,7 +29,26 @@ let make ?(provider_health = []) ?cascade_config ~contract ~mode ~risk_class () 
   { contract; mode; risk_class; provider_health; cascade_config }
 ;;
 
-let cascade_config_for_risk_class = function
+let cascade_config_of_strategy (strategy : cascade_strategy) : cascade_config =
+  { circuit_threshold = strategy.circuit_threshold
+  ; circuit_cooldown_s = strategy.circuit_cooldown_s
+  }
+;;
+
+let neutral_cascade_strategy =
+  { max_steps = 3
+  ; step_timeout_s = 20.0
+  ; global_timeout_s = 60.0
+  ; backoff_base_s = 0.5
+  ; backoff_max_s = 5.0
+  ; jitter = 0.1
+  ; circuit_threshold = 10
+  ; circuit_cooldown_s = 120.0
+  ; health_check_interval_s = 30.0
+  }
+;;
+
+let cascade_strategy_for_risk_class = function
   | Risk_class.Critical ->
     { max_steps = 5
     ; step_timeout_s = 5.0
@@ -48,16 +72,7 @@ let cascade_config_for_risk_class = function
     ; health_check_interval_s = 10.0
     }
   | Risk_class.Medium ->
-    { max_steps = 3
-    ; step_timeout_s = 20.0
-    ; global_timeout_s = 60.0
-    ; backoff_base_s = 0.5
-    ; backoff_max_s = 5.0
-    ; jitter = 0.1
-    ; circuit_threshold = 10
-    ; circuit_cooldown_s = 120.0
-    ; health_check_interval_s = 30.0
-    }
+    neutral_cascade_strategy
   | Risk_class.Low ->
     { max_steps = 2
     ; step_timeout_s = 30.0
@@ -71,10 +86,22 @@ let cascade_config_for_risk_class = function
     }
 ;;
 
+let cascade_config_for_risk_class risk_class =
+  cascade_config_of_strategy (cascade_strategy_for_risk_class risk_class)
+;;
+
 let cascade_config_of_complete_cascade
       (config : Llm_provider.Complete_cascade.cascade_config)
   =
-  { (cascade_config_for_risk_class Risk_class.Medium) with
+  { circuit_threshold = config.circuit_threshold
+  ; circuit_cooldown_s = config.circuit_cooldown_s
+  }
+;;
+
+let cascade_strategy_of_complete_cascade
+      (config : Llm_provider.Complete_cascade.cascade_config)
+  =
+  { neutral_cascade_strategy with
     circuit_threshold = config.circuit_threshold
   ; circuit_cooldown_s = config.circuit_cooldown_s
   }

--- a/lib/execution_manifest.ml
+++ b/lib/execution_manifest.ml
@@ -1,8 +1,15 @@
 type provider_health_score = string * float
 
 type cascade_config =
-  { circuit_threshold : int
+  { max_steps : int
+  ; step_timeout_s : float
+  ; global_timeout_s : float
+  ; backoff_base_s : float
+  ; backoff_max_s : float
+  ; jitter : float
+  ; circuit_threshold : int
   ; circuit_cooldown_s : float
+  ; health_check_interval_s : float
   }
 
 type t =
@@ -17,10 +24,58 @@ let make ?(provider_health = []) ?cascade_config ~contract ~mode ~risk_class () 
   { contract; mode; risk_class; provider_health; cascade_config }
 ;;
 
+let cascade_config_for_risk_class = function
+  | Risk_class.Critical ->
+    { max_steps = 5
+    ; step_timeout_s = 5.0
+    ; global_timeout_s = 15.0
+    ; backoff_base_s = 0.1
+    ; backoff_max_s = 1.0
+    ; jitter = 0.3
+    ; circuit_threshold = 3
+    ; circuit_cooldown_s = 30.0
+    ; health_check_interval_s = 5.0
+    }
+  | Risk_class.High ->
+    { max_steps = 4
+    ; step_timeout_s = 10.0
+    ; global_timeout_s = 30.0
+    ; backoff_base_s = 0.2
+    ; backoff_max_s = 2.0
+    ; jitter = 0.2
+    ; circuit_threshold = 5
+    ; circuit_cooldown_s = 60.0
+    ; health_check_interval_s = 10.0
+    }
+  | Risk_class.Medium ->
+    { max_steps = 3
+    ; step_timeout_s = 20.0
+    ; global_timeout_s = 60.0
+    ; backoff_base_s = 0.5
+    ; backoff_max_s = 5.0
+    ; jitter = 0.1
+    ; circuit_threshold = 10
+    ; circuit_cooldown_s = 120.0
+    ; health_check_interval_s = 30.0
+    }
+  | Risk_class.Low ->
+    { max_steps = 2
+    ; step_timeout_s = 30.0
+    ; global_timeout_s = 120.0
+    ; backoff_base_s = 1.0
+    ; backoff_max_s = 10.0
+    ; jitter = 0.1
+    ; circuit_threshold = 20
+    ; circuit_cooldown_s = 300.0
+    ; health_check_interval_s = 60.0
+    }
+;;
+
 let cascade_config_of_complete_cascade
       (config : Llm_provider.Complete_cascade.cascade_config)
   =
-  { circuit_threshold = config.circuit_threshold
+  { (cascade_config_for_risk_class Risk_class.Medium) with
+    circuit_threshold = config.circuit_threshold
   ; circuit_cooldown_s = config.circuit_cooldown_s
   }
 ;;

--- a/lib/execution_manifest.mli
+++ b/lib/execution_manifest.mli
@@ -4,6 +4,11 @@
 type provider_health_score = string * float
 
 type cascade_config =
+  { circuit_threshold : int
+  ; circuit_cooldown_s : float
+  }
+
+type cascade_strategy =
   { max_steps : int
   ; step_timeout_s : float
   ; global_timeout_s : float
@@ -32,12 +37,25 @@ val make
   -> unit
   -> t
 
+(** Compatibility projection of the advisory strategy for consumers that only
+    understand the existing complete-cascade circuit breaker settings. *)
+val cascade_config_for_risk_class : Risk_class.t -> cascade_config
+
+(** Neutral advisory values used when lifting legacy complete-cascade configs.
+    Kept separate from any risk-class policy so compatibility behavior does not
+    drift when a risk class is retuned. *)
+val neutral_cascade_strategy : cascade_strategy
+
 (** Product-neutral advisory cascade defaults for a risk class.
 
     OAS only carries the contract policy here; it does not own the distributed
     cascade runtime, provider quota manager, or health tracker. *)
-val cascade_config_for_risk_class : Risk_class.t -> cascade_config
+val cascade_strategy_for_risk_class : Risk_class.t -> cascade_strategy
 
 val cascade_config_of_complete_cascade
   :  Llm_provider.Complete_cascade.cascade_config
   -> cascade_config
+
+val cascade_strategy_of_complete_cascade
+  :  Llm_provider.Complete_cascade.cascade_config
+  -> cascade_strategy

--- a/lib/execution_manifest.mli
+++ b/lib/execution_manifest.mli
@@ -4,8 +4,15 @@
 type provider_health_score = string * float
 
 type cascade_config =
-  { circuit_threshold : int
+  { max_steps : int
+  ; step_timeout_s : float
+  ; global_timeout_s : float
+  ; backoff_base_s : float
+  ; backoff_max_s : float
+  ; jitter : float
+  ; circuit_threshold : int
   ; circuit_cooldown_s : float
+  ; health_check_interval_s : float
   }
 
 type t =
@@ -24,6 +31,12 @@ val make
   -> risk_class:Risk_class.t
   -> unit
   -> t
+
+(** Product-neutral advisory cascade defaults for a risk class.
+
+    OAS only carries the contract policy here; it does not own the distributed
+    cascade runtime, provider quota manager, or health tracker. *)
+val cascade_config_for_risk_class : Risk_class.t -> cascade_config
 
 val cascade_config_of_complete_cascade
   :  Llm_provider.Complete_cascade.cascade_config

--- a/test/test_execution_manifest.ml
+++ b/test/test_execution_manifest.ml
@@ -45,13 +45,11 @@ let test_make_carries_provider_health_and_cascade_config () =
   | None -> fail "expected cascade_config"
   | Some cfg ->
     check int "circuit_threshold" 3 cfg.circuit_threshold;
-    check (float 0.001) "circuit_cooldown_s" 30.0 cfg.circuit_cooldown_s;
-    check int "max_steps defaulted" 3 cfg.max_steps;
-    check (float 0.001) "step_timeout_s defaulted" 20.0 cfg.step_timeout_s
+    check (float 0.001) "circuit_cooldown_s" 30.0 cfg.circuit_cooldown_s
 ;;
 
-let test_cascade_config_for_risk_class_critical () =
-  let cfg = EM.cascade_config_for_risk_class Agent_sdk.Risk_class.Critical in
+let test_cascade_strategy_for_risk_class_critical () =
+  let cfg = EM.cascade_strategy_for_risk_class Agent_sdk.Risk_class.Critical in
   check int "critical max_steps" 5 cfg.max_steps;
   check (float 0.001) "critical step timeout" 5.0 cfg.step_timeout_s;
   check (float 0.001) "critical global timeout" 15.0 cfg.global_timeout_s;
@@ -63,8 +61,8 @@ let test_cascade_config_for_risk_class_critical () =
   check (float 0.001) "critical health check" 5.0 cfg.health_check_interval_s
 ;;
 
-let test_cascade_config_for_risk_class_low () =
-  let cfg = EM.cascade_config_for_risk_class Agent_sdk.Risk_class.Low in
+let test_cascade_strategy_for_risk_class_low () =
+  let cfg = EM.cascade_strategy_for_risk_class Agent_sdk.Risk_class.Low in
   check int "low max_steps" 2 cfg.max_steps;
   check (float 0.001) "low step timeout" 30.0 cfg.step_timeout_s;
   check (float 0.001) "low global timeout" 120.0 cfg.global_timeout_s;
@@ -77,11 +75,33 @@ let test_cascade_config_for_risk_class_low () =
 ;;
 
 let test_high_risk_is_stricter_than_low_for_timeout_and_circuit () =
-  let high = EM.cascade_config_for_risk_class Agent_sdk.Risk_class.High in
-  let low = EM.cascade_config_for_risk_class Agent_sdk.Risk_class.Low in
+  let high = EM.cascade_strategy_for_risk_class Agent_sdk.Risk_class.High in
+  let low = EM.cascade_strategy_for_risk_class Agent_sdk.Risk_class.Low in
   check bool "high has lower step timeout" true (high.step_timeout_s < low.step_timeout_s);
   check bool "high has lower cooldown" true (high.circuit_cooldown_s < low.circuit_cooldown_s);
   check bool "high opens circuit sooner" true (high.circuit_threshold < low.circuit_threshold)
+;;
+
+let test_cascade_config_for_risk_class_projects_legacy_shape () =
+  let cfg = EM.cascade_config_for_risk_class Agent_sdk.Risk_class.Critical in
+  check int "critical circuit threshold" 3 cfg.circuit_threshold;
+  check (float 0.001) "critical cooldown" 30.0 cfg.circuit_cooldown_s
+;;
+
+let test_complete_cascade_lifts_with_neutral_strategy_defaults () =
+  let complete_cfg =
+    Llm_provider.Complete_cascade.
+      { circuit_threshold = 7; circuit_cooldown_s = 42.0 }
+  in
+  let strategy = EM.cascade_strategy_of_complete_cascade complete_cfg in
+  check int "lifted circuit threshold" 7 strategy.circuit_threshold;
+  check (float 0.001) "lifted cooldown" 42.0 strategy.circuit_cooldown_s;
+  check int "neutral max steps" EM.neutral_cascade_strategy.max_steps strategy.max_steps;
+  check
+    (float 0.001)
+    "neutral step timeout"
+    EM.neutral_cascade_strategy.step_timeout_s
+    strategy.step_timeout_s
 ;;
 
 let () =
@@ -96,15 +116,23 @@ let () =
         ; test_case
             "critical risk cascade defaults"
             `Quick
-            test_cascade_config_for_risk_class_critical
+            test_cascade_strategy_for_risk_class_critical
         ; test_case
             "low risk cascade defaults"
             `Quick
-            test_cascade_config_for_risk_class_low
+            test_cascade_strategy_for_risk_class_low
         ; test_case
             "high risk cascade defaults are stricter than low"
             `Quick
             test_high_risk_is_stricter_than_low_for_timeout_and_circuit
+        ; test_case
+            "risk cascade config projects legacy shape"
+            `Quick
+            test_cascade_config_for_risk_class_projects_legacy_shape
+        ; test_case
+            "complete cascade lifts with neutral strategy defaults"
+            `Quick
+            test_complete_cascade_lifts_with_neutral_strategy_defaults
         ] )
     ]
 ;;

--- a/test/test_execution_manifest.ml
+++ b/test/test_execution_manifest.ml
@@ -45,7 +45,43 @@ let test_make_carries_provider_health_and_cascade_config () =
   | None -> fail "expected cascade_config"
   | Some cfg ->
     check int "circuit_threshold" 3 cfg.circuit_threshold;
-    check (float 0.001) "circuit_cooldown_s" 30.0 cfg.circuit_cooldown_s
+    check (float 0.001) "circuit_cooldown_s" 30.0 cfg.circuit_cooldown_s;
+    check int "max_steps defaulted" 3 cfg.max_steps;
+    check (float 0.001) "step_timeout_s defaulted" 20.0 cfg.step_timeout_s
+;;
+
+let test_cascade_config_for_risk_class_critical () =
+  let cfg = EM.cascade_config_for_risk_class Agent_sdk.Risk_class.Critical in
+  check int "critical max_steps" 5 cfg.max_steps;
+  check (float 0.001) "critical step timeout" 5.0 cfg.step_timeout_s;
+  check (float 0.001) "critical global timeout" 15.0 cfg.global_timeout_s;
+  check (float 0.001) "critical backoff base" 0.1 cfg.backoff_base_s;
+  check (float 0.001) "critical backoff max" 1.0 cfg.backoff_max_s;
+  check (float 0.001) "critical jitter" 0.3 cfg.jitter;
+  check int "critical circuit threshold" 3 cfg.circuit_threshold;
+  check (float 0.001) "critical cooldown" 30.0 cfg.circuit_cooldown_s;
+  check (float 0.001) "critical health check" 5.0 cfg.health_check_interval_s
+;;
+
+let test_cascade_config_for_risk_class_low () =
+  let cfg = EM.cascade_config_for_risk_class Agent_sdk.Risk_class.Low in
+  check int "low max_steps" 2 cfg.max_steps;
+  check (float 0.001) "low step timeout" 30.0 cfg.step_timeout_s;
+  check (float 0.001) "low global timeout" 120.0 cfg.global_timeout_s;
+  check (float 0.001) "low backoff base" 1.0 cfg.backoff_base_s;
+  check (float 0.001) "low backoff max" 10.0 cfg.backoff_max_s;
+  check (float 0.001) "low jitter" 0.1 cfg.jitter;
+  check int "low circuit threshold" 20 cfg.circuit_threshold;
+  check (float 0.001) "low cooldown" 300.0 cfg.circuit_cooldown_s;
+  check (float 0.001) "low health check" 60.0 cfg.health_check_interval_s
+;;
+
+let test_high_risk_is_stricter_than_low_for_timeout_and_circuit () =
+  let high = EM.cascade_config_for_risk_class Agent_sdk.Risk_class.High in
+  let low = EM.cascade_config_for_risk_class Agent_sdk.Risk_class.Low in
+  check bool "high has lower step timeout" true (high.step_timeout_s < low.step_timeout_s);
+  check bool "high has lower cooldown" true (high.circuit_cooldown_s < low.circuit_cooldown_s);
+  check bool "high opens circuit sooner" true (high.circuit_threshold < low.circuit_threshold)
 ;;
 
 let () =
@@ -57,6 +93,18 @@ let () =
             "make carries provider health and cascade config"
             `Quick
             test_make_carries_provider_health_and_cascade_config
+        ; test_case
+            "critical risk cascade defaults"
+            `Quick
+            test_cascade_config_for_risk_class_critical
+        ; test_case
+            "low risk cascade defaults"
+            `Quick
+            test_cascade_config_for_risk_class_low
+        ; test_case
+            "high risk cascade defaults are stricter than low"
+            `Quick
+            test_high_risk_is_stricter_than_low_for_timeout_and_circuit
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- expand `Execution_manifest.cascade_config` into an advisory cascade strategy shape
- add `cascade_config_for_risk_class` for Critical/High/Medium/Low defaults
- keep `cascade_config_of_complete_cascade` compatible by preserving circuit breaker values while filling neutral defaults
- cover manifest defaults and risk-class strategy boundaries in focused tests

## Why
OAS already carries provider health and cascade config at the manifest boundary, but it did not expose a canonical risk-class mapping. This keeps the policy contract product-neutral while leaving distributed provider orchestration and health tracking in downstream runtimes such as MASC.

The important boundary is compatibility: existing consumers that read `cascade_config` for circuit threshold/cooldown should still work, while newer consumers can opt into the richer `cascade_strategy` defaults.

Closes #1440

## Validation
- `scripts/dune-local.sh exec ./test/test_execution_manifest.exe` (7 tests)
- `git diff --check`
- GitHub checks currently pass or skip on this draft PR.

## Review focus
- Confirm legacy `cascade_config` readers keep the same threshold/cooldown behavior.
- Confirm risk-class defaults are declarative OAS contract metadata, not MASC-specific provider routing logic.
- Confirm neutral defaults in `cascade_config_of_complete_cascade` avoid surprising retry/timeout changes for existing complete-cascade conversions.
