### PR TITLE
chore(fmt): restore main green — apply ocamlformat to contract

### DIFF
--- a/lib/contract.ml
+++ b/lib/contract.ml
@@ -125,8 +125,7 @@ let with_quota_allocations allocations contract =
 
 let with_default_quota_allocations ~total_requests_per_minute contract =
   match
-    Llm_provider.Request_priority.default_quota_allocations
-      ~total_requests_per_minute
+    Llm_provider.Request_priority.default_quota_allocations ~total_requests_per_minute
   with
   | Ok allocations -> Ok (with_quota_allocations allocations contract)
   | Error _ as error -> error
@@ -202,13 +201,10 @@ let string_list_option_to_json = function
   | Some values -> Util.json_of_string_list values
 ;;
 
-let quota_allocation_to_json
-      (allocation : Llm_provider.Request_priority.quota_allocation)
+let quota_allocation_to_json (allocation : Llm_provider.Request_priority.quota_allocation)
   =
   `Assoc
-    [ ( "tier"
-      , `String
-          (Llm_provider.Request_priority.quota_tier_label allocation.tier) )
+    [ "tier", `String (Llm_provider.Request_priority.quota_tier_label allocation.tier)
     ; "share_percent", `Int allocation.share_percent
     ; "requests_per_minute", `Int allocation.requests_per_minute
     ]

--- a/lib/contract.mli
+++ b/lib/contract.mli
@@ -70,10 +70,7 @@ val with_mcp_tool_allowlist : string list -> t -> t
 
     Passing [[]] records an explicit empty quota specification. This allows a
     right-hand contract to clear inherited quota metadata during {!merge}. *)
-val with_quota_allocations
-  :  Llm_provider.Request_priority.quota_allocation list
-  -> t
-  -> t
+val with_quota_allocations : Llm_provider.Request_priority.quota_allocation list -> t -> t
 
 val with_default_quota_allocations
   :  total_requests_per_minute:int

--- a/test/test_contract.ml
+++ b/test/test_contract.ml
@@ -161,10 +161,7 @@ let test_with_quota_allocations () =
   let c = Contract.with_quota_allocations [ allocation ] Contract.empty in
   match c.quota_allocations with
   | Some [ stored ] ->
-    check_string
-      "tier"
-      "p1_standard"
-      (RP.quota_tier_label stored.tier);
+    check_string "tier" "p1_standard" (RP.quota_tier_label stored.tier);
     check_int "share" 40 stored.share_percent;
     check_int "rpm" 400 stored.requests_per_minute
   | _ -> Alcotest.fail "expected one quota allocation"
@@ -183,7 +180,9 @@ let test_with_empty_quota_allocations_clears_spec () =
 ;;
 
 let test_with_default_quota_allocations () =
-  match Contract.with_default_quota_allocations ~total_requests_per_minute:1000 Contract.empty with
+  match
+    Contract.with_default_quota_allocations ~total_requests_per_minute:1000 Contract.empty
+  with
   | Error e -> Alcotest.fail (RP.show_quota_allocation_error e)
   | Ok c ->
     (match c.quota_allocations with
@@ -195,7 +194,9 @@ let test_with_default_quota_allocations () =
 ;;
 
 let test_with_default_quota_allocations_rejects_invalid_total () =
-  match Contract.with_default_quota_allocations ~total_requests_per_minute:0 Contract.empty with
+  match
+    Contract.with_default_quota_allocations ~total_requests_per_minute:0 Contract.empty
+  with
   | Error (RP.Invalid_total_requests_per_minute 0) -> ()
   | Ok _ -> Alcotest.fail "expected invalid total error"
   | Error e -> Alcotest.fail (RP.show_quota_allocation_error e)
@@ -245,10 +246,7 @@ let test_merge_quota_allocations_right_wins () =
   let merged = Contract.merge left right in
   match merged.quota_allocations with
   | Some [ stored ] ->
-    check_string
-      "right tier"
-      "p0_critical"
-      (RP.quota_tier_label stored.tier);
+    check_string "right tier" "p0_critical" (RP.quota_tier_label stored.tier);
     check_int "right rpm" 10 stored.requests_per_minute
   | _ -> Alcotest.fail "right quota allocations should win"
 ;;
@@ -451,10 +449,7 @@ let () =
     ; ( "tool_grants"
       , [ Alcotest.test_case "with_tool_grants" `Quick test_with_tool_grants
         ; Alcotest.test_case "with_mcp_allowlist" `Quick test_with_mcp_allowlist
-        ; Alcotest.test_case
-            "with_quota_allocations"
-            `Quick
-            test_with_quota_allocations
+        ; Alcotest.test_case "with_quota_allocations" `Quick test_with_quota_allocations
         ; Alcotest.test_case
             "with empty quota allocations"
             `Quick


### PR DESCRIPTION
## Summary
- main CI red 원인: PR #1443 (P1 quota allocations, 6611f7e4) 머지 시 `dune build @fmt` 미적용으로 OCaml Format job 실패.
- 본 PR은 `dune build @fmt --auto-promote`의 결정론적 출력만 포함 (formatting only, 0 semantic change).

## Verification
- `dune build @fmt` ✅ idempotent (재실행 시 변경 없음)
- `dune build` ✅
- `dune runtest` ✅ 14 tests pass

## Files
- `lib/contract.ml` (10 lines, fmt only)
- `lib/contract.mli` (5 lines, fmt only)
- `test/test_contract.ml` (23 lines, fmt only)

## Why Draft
AI agent 작성 PR이므로 사용자가 검토 후 `human-approved-ready` 라벨 붙이고 ready 전환 권장.