### PR TITLE
Map transport errors to typed provider errors

### DIFF
--- a/lib/llm_provider/error.ml
+++ b/lib/llm_provider/error.ml
@@ -20,6 +20,96 @@ type provider_error =
       { provider : string
       ; detail : string
       }
+  | RateLimit of
+      { provider : string
+      ; retry_after : float option
+      ; detail : string
+      }
+  | HardQuota of
+      { provider : string
+      ; retry_after : float option
+      ; detail : string
+      }
+  | CapacityExhausted of
+      { scope : capacity_scope
+      ; affected : string list
+      ; retry_after : float option
+      ; detail : string
+      }
+  | AuthError of
+      { provider : string
+      ; detail : string
+      }
+  | ServerError of
+      { provider : string
+      ; code : int
+      ; transient : bool
+      ; detail : string
+      }
+  | NetworkError of
+      { provider : string
+      ; kind : Http_client.network_error_kind
+      ; detail : string
+      }
+  | Timeout of
+      { provider : string
+      ; detail : string
+      }
+  | InvalidRequest of
+      { provider : string
+      ; reason : string
+      }
+  | NotFound of
+      { provider : string
+      ; detail : string
+      }
+  | ProviderTerminal of
+      { provider : string
+      ; reason : string
+      ; detail : string
+      }
+
+and capacity_scope =
+  | CapacityModel
+  | CapacityAccount
+  | CapacityRegion
+  | CapacityProvider
+  | CapacityUnknown
+
+let provider_name = function
+  | Some provider when String.trim provider <> "" -> provider
+  | _ -> "unknown"
+;;
+
+let affected_provider provider = if provider = "unknown" then [] else [ provider ]
+
+let capacity_scope_to_string = function
+  | CapacityModel -> "model"
+  | CapacityAccount -> "account"
+  | CapacityRegion -> "region"
+  | CapacityProvider -> "provider"
+  | CapacityUnknown -> "unknown"
+;;
+
+let network_error_kind_to_string = function
+  | Http_client.Connection_refused -> "connection_refused"
+  | Http_client.Dns_failure -> "dns_failure"
+  | Http_client.Tls_error -> "tls_error"
+  | Http_client.Timeout -> "timeout"
+  | Http_client.Local_resource_exhaustion -> "local_resource_exhaustion"
+  | Http_client.End_of_file -> "end_of_file"
+  | Http_client.Unknown -> "unknown"
+;;
+
+let retry_after_suffix = function
+  | None -> ""
+  | Some seconds -> Printf.sprintf " (retry_after: %.3fs)" seconds
+;;
+
+let affected_suffix = function
+  | [] -> ""
+  | affected -> Printf.sprintf " affected=[%s]" (String.concat "," affected)
+;;
 
 let to_string = function
   | MissingApiKey r -> Printf.sprintf "Missing API key env var: %s" r.var_name
@@ -28,4 +118,156 @@ let to_string = function
   | UnknownVariant r -> Printf.sprintf "Unknown %s variant: %s" r.type_name r.value
   | ProviderUnavailable r ->
     Printf.sprintf "Provider '%s' unavailable: %s" r.provider r.detail
+  | RateLimit r ->
+    Printf.sprintf
+      "Provider '%s' rate limited: %s%s"
+      r.provider
+      r.detail
+      (retry_after_suffix r.retry_after)
+  | HardQuota r ->
+    Printf.sprintf
+      "Provider '%s' hard quota exhausted: %s%s"
+      r.provider
+      r.detail
+      (retry_after_suffix r.retry_after)
+  | CapacityExhausted r ->
+    Printf.sprintf
+      "Provider capacity exhausted (%s): %s%s%s"
+      (capacity_scope_to_string r.scope)
+      r.detail
+      (affected_suffix r.affected)
+      (retry_after_suffix r.retry_after)
+  | AuthError r -> Printf.sprintf "Provider '%s' auth error: %s" r.provider r.detail
+  | ServerError r ->
+    Printf.sprintf
+      "Provider '%s' server error %d (transient=%b): %s"
+      r.provider
+      r.code
+      r.transient
+      r.detail
+  | NetworkError r ->
+    Printf.sprintf
+      "Provider '%s' network error (%s): %s"
+      r.provider
+      (network_error_kind_to_string r.kind)
+      r.detail
+  | Timeout r -> Printf.sprintf "Provider '%s' timeout: %s" r.provider r.detail
+  | InvalidRequest r ->
+    Printf.sprintf "Provider '%s' invalid request: %s" r.provider r.reason
+  | NotFound r -> Printf.sprintf "Provider '%s' not found: %s" r.provider r.detail
+  | ProviderTerminal r ->
+    Printf.sprintf "Provider '%s' terminal %s: %s" r.provider r.reason r.detail
+;;
+
+let of_retry_api_error ?provider err =
+  let provider = provider_name provider in
+  match err with
+  | Retry.RateLimited r when Retry.is_hard_quota err ->
+    HardQuota { provider; retry_after = r.retry_after; detail = r.message }
+  | Retry.RateLimited r ->
+    RateLimit { provider; retry_after = r.retry_after; detail = r.message }
+  | Retry.Overloaded r ->
+    CapacityExhausted
+      { scope = CapacityProvider
+      ; affected = affected_provider provider
+      ; retry_after = None
+      ; detail = r.message
+      }
+  | Retry.ServerError r ->
+    ServerError
+      { provider
+      ; code = r.status
+      ; transient = Retry.is_retryable err
+      ; detail = r.message
+      }
+  | Retry.AuthError r -> AuthError { provider; detail = r.message }
+  | Retry.InvalidRequest r -> InvalidRequest { provider; reason = r.message }
+  | Retry.NotFound r -> NotFound { provider; detail = r.message }
+  | Retry.ContextOverflow r ->
+    InvalidRequest { provider; reason = Retry.error_message (Retry.ContextOverflow r) }
+  | Retry.NetworkError r -> NetworkError { provider; kind = r.kind; detail = r.message }
+  | Retry.Timeout r -> Timeout { provider; detail = r.message }
+;;
+
+let capacity_scope_of_http = function
+  | Http_client.Failure_scope_model -> CapacityModel
+  | Http_client.Failure_scope_account -> CapacityAccount
+  | Http_client.Failure_scope_region -> CapacityRegion
+  | Http_client.Failure_scope_provider -> CapacityProvider
+  | Http_client.Failure_scope_unknown -> CapacityUnknown
+;;
+
+let of_provider_failure ?provider kind message =
+  let provider = provider_name provider in
+  match kind with
+  | Http_client.Capacity_exhausted { scope; retry_after; model } ->
+    let affected =
+      match model with
+      | Some model -> [ model ]
+      | None -> affected_provider provider
+    in
+    CapacityExhausted
+      { scope = capacity_scope_of_http scope; affected; retry_after; detail = message }
+  | Http_client.Hard_quota { retry_after } ->
+    HardQuota { provider; retry_after; detail = message }
+  | Http_client.Capability_mismatch { capability } ->
+    let reason =
+      match capability with
+      | Some capability -> Printf.sprintf "missing capability: %s" capability
+      | None -> "missing provider capability"
+    in
+    InvalidRequest { provider; reason = reason ^ ": " ^ message }
+  | Http_client.Cli_policy_invalid { tool_name; rule } ->
+    let tool =
+      match tool_name with
+      | Some name -> name
+      | None -> "unknown_tool"
+    in
+    let reason =
+      match rule with
+      | Some n -> Printf.sprintf "CLI policy rejected %s at rule %d" tool n
+      | None -> Printf.sprintf "CLI policy rejected %s" tool
+    in
+    InvalidRequest { provider; reason = reason ^ ": " ^ message }
+  | Http_client.Cli_startup_failed { reason } ->
+    ProviderUnavailable { provider; detail = Printf.sprintf "%s: %s" reason message }
+  | Http_client.Provider_parse_error { parser } ->
+    let parser =
+      match parser with
+      | Some parser -> parser
+      | None -> "unknown_parser"
+    in
+    ParseError { detail = Printf.sprintf "%s: %s" parser message }
+  | Http_client.Unknown_provider_failure { reason } ->
+    let reason =
+      match reason with
+      | Some reason -> reason
+      | None -> "unknown_provider_failure"
+    in
+    ProviderUnavailable { provider; detail = Printf.sprintf "%s: %s" reason message }
+;;
+
+let of_http_error ?provider = function
+  | Http_client.HttpError { code; body } ->
+    Retry.classify_error ~status:code ~body |> of_retry_api_error ?provider
+  | Http_client.NetworkError { message; kind } ->
+    NetworkError { provider = provider_name provider; kind; detail = message }
+  | Http_client.AcceptRejected { reason } ->
+    InvalidRequest
+      { provider = provider_name provider; reason = "accept rejected: " ^ reason }
+  | Http_client.CliTransportRequired { kind } ->
+    InvalidConfig
+      { field = "transport"
+      ; detail = Printf.sprintf "CLI transport required for %s" kind
+      }
+  | Http_client.ProviderTerminal { kind = Http_client.Max_turns r; message } ->
+    ProviderTerminal
+      { provider = provider_name provider
+      ; reason = Printf.sprintf "max_turns:%d/%d" r.turns r.limit
+      ; detail = message
+      }
+  | Http_client.ProviderTerminal { kind = Http_client.Other reason; message } ->
+    ProviderTerminal { provider = provider_name provider; reason; detail = message }
+  | Http_client.ProviderFailure { kind; message } ->
+    of_provider_failure ?provider kind message
 ;;

--- a/lib/llm_provider/error.mli
+++ b/lib/llm_provider/error.mli
@@ -20,5 +20,63 @@ type provider_error =
       { provider : string
       ; detail : string
       }
+  | RateLimit of
+      { provider : string
+      ; retry_after : float option
+      ; detail : string
+      }
+  | HardQuota of
+      { provider : string
+      ; retry_after : float option
+      ; detail : string
+      }
+  | CapacityExhausted of
+      { scope : capacity_scope
+      ; affected : string list
+      ; retry_after : float option
+      ; detail : string
+      }
+  | AuthError of
+      { provider : string
+      ; detail : string
+      }
+  | ServerError of
+      { provider : string
+      ; code : int
+      ; transient : bool
+      ; detail : string
+      }
+  | NetworkError of
+      { provider : string
+      ; kind : Http_client.network_error_kind
+      ; detail : string
+      }
+  | Timeout of
+      { provider : string
+      ; detail : string
+      }
+  | InvalidRequest of
+      { provider : string
+      ; reason : string
+      }
+  | NotFound of
+      { provider : string
+      ; detail : string
+      }
+  | ProviderTerminal of
+      { provider : string
+      ; reason : string
+      ; detail : string
+      }
+
+and capacity_scope =
+  | CapacityModel
+  | CapacityAccount
+  | CapacityRegion
+  | CapacityProvider
+  | CapacityUnknown
 
 val to_string : provider_error -> string
+val capacity_scope_to_string : capacity_scope -> string
+val of_retry_api_error : ?provider:string -> Retry.api_error -> provider_error
+val of_http_error : ?provider:string -> Http_client.http_error -> provider_error

--- a/test/test_llm_provider_error.ml
+++ b/test/test_llm_provider_error.ml
@@ -1,10 +1,10 @@
-(** Coverage for [Llm_provider.Error.provider_error] and its
-    [to_string] formatter (oas#1175 — file at 0% coverage in the
+(** Coverage for [Llm_provider.Error.provider_error], its [to_string]
+    formatter, and typed transport/retry mapping (oas#1175 - file at 0% coverage in the
     initial coverage measurement (`66.42%`, run `24887636744`)).
 
-    The module is 5 line-counted regions and the formatter has one
-    case per variant; one test per variant brings the file from 0%
-    to 100% with no behavior change. *)
+    The formatter has one case per variant; the [to_string] group keeps
+    one assertion per [provider_error] variant while the mapping group
+    covers the conversion boundaries. *)
 
 open Alcotest
 open Llm_provider
@@ -53,6 +53,245 @@ let test_provider_unavailable () =
           { provider = "anthropic"; detail = "HTTP 503 retry-after exhausted" }))
 ;;
 
+let test_rate_limit () =
+  check
+    string
+    "RateLimit format"
+    "Provider 'anthropic' rate limited: quota window exhausted (retry_after: 1.250s)"
+    (Error.to_string
+       (Error.RateLimit
+          { provider = "anthropic"
+          ; retry_after = Some 1.25
+          ; detail = "quota window exhausted"
+          }))
+;;
+
+let test_hard_quota () =
+  check
+    string
+    "HardQuota format"
+    "Provider 'zai' hard quota exhausted: no remaining balance"
+    (Error.to_string
+       (Error.HardQuota
+          { provider = "zai"; retry_after = None; detail = "no remaining balance" }))
+;;
+
+let test_capacity_exhausted () =
+  check
+    string
+    "CapacityExhausted format"
+    "Provider capacity exhausted (model): model queue saturated affected=[gemini-3-pro] \
+     (retry_after: 7.000s)"
+    (Error.to_string
+       (Error.CapacityExhausted
+          { scope = Error.CapacityModel
+          ; affected = [ "gemini-3-pro" ]
+          ; retry_after = Some 7.0
+          ; detail = "model queue saturated"
+          }))
+;;
+
+let test_auth_error () =
+  check
+    string
+    "AuthError format"
+    "Provider 'openai' auth error: invalid API key"
+    (Error.to_string
+       (Error.AuthError { provider = "openai"; detail = "invalid API key" }))
+;;
+
+let test_server_error () =
+  check
+    string
+    "ServerError format"
+    "Provider 'openai' server error 503 (transient=true): down"
+    (Error.to_string
+       (Error.ServerError
+          { provider = "openai"; code = 503; transient = true; detail = "down" }))
+;;
+
+let test_network_error () =
+  check
+    string
+    "NetworkError format"
+    "Provider 'local' network error (dns_failure): lookup failed"
+    (Error.to_string
+       (Error.NetworkError
+          { provider = "local"; kind = Http_client.Dns_failure; detail = "lookup failed" }))
+;;
+
+let test_timeout () =
+  check
+    string
+    "Timeout format"
+    "Provider 'gemini' timeout: request exceeded budget"
+    (Error.to_string
+       (Error.Timeout { provider = "gemini"; detail = "request exceeded budget" }))
+;;
+
+let test_invalid_request () =
+  check
+    string
+    "InvalidRequest format"
+    "Provider 'anthropic' invalid request: context too long"
+    (Error.to_string
+       (Error.InvalidRequest { provider = "anthropic"; reason = "context too long" }))
+;;
+
+let test_not_found () =
+  check
+    string
+    "NotFound format"
+    "Provider 'gemini' not found: model not available"
+    (Error.to_string
+       (Error.NotFound { provider = "gemini"; detail = "model not available" }))
+;;
+
+let test_provider_terminal () =
+  check
+    string
+    "ProviderTerminal format"
+    "Provider 'claude_code' terminal max_turns:31/31: turn cap hit"
+    (Error.to_string
+       (Error.ProviderTerminal
+          { provider = "claude_code"
+          ; reason = "max_turns:31/31"
+          ; detail = "turn cap hit"
+          }))
+;;
+
+let test_retry_rate_limit_mapping () =
+  let err =
+    Error.of_retry_api_error
+      ~provider:"anthropic"
+      (Retry.RateLimited { retry_after = Some 2.5; message = "try later" })
+  in
+  match err with
+  | Error.RateLimit { provider; retry_after; detail } ->
+    check string "provider" "anthropic" provider;
+    check (option (float 0.001)) "retry_after" (Some 2.5) retry_after;
+    check string "detail" "try later" detail
+  | _ -> fail "expected RateLimit"
+;;
+
+let test_retry_hard_quota_mapping () =
+  let err =
+    Error.of_retry_api_error
+      ~provider:"zai"
+      (Retry.RateLimited
+         { retry_after = Some 10.0
+         ; message = "Insufficient balance or no resource package. Please recharge."
+         })
+  in
+  match err with
+  | Error.HardQuota { provider; retry_after; detail } ->
+    check string "provider" "zai" provider;
+    check (option (float 0.001)) "retry_after" (Some 10.0) retry_after;
+    check
+      string
+      "detail"
+      "Insufficient balance or no resource package. Please recharge."
+      detail
+  | _ -> fail "expected HardQuota"
+;;
+
+let test_retry_overloaded_unknown_provider_mapping () =
+  let check_unknown_provider provider =
+    let err =
+      Error.of_retry_api_error ?provider (Retry.Overloaded { message = "busy" })
+    in
+    match err with
+    | Error.CapacityExhausted { scope; affected; retry_after; detail } ->
+      check bool "scope" true (scope = Error.CapacityProvider);
+      check (list string) "affected" [] affected;
+      check (option (float 0.001)) "retry_after" None retry_after;
+      check string "detail" "busy" detail
+    | _ -> fail "expected CapacityExhausted"
+  in
+  check_unknown_provider None;
+  check_unknown_provider (Some "")
+;;
+
+let test_http_capacity_failure_mapping () =
+  let err =
+    Error.of_http_error
+      ~provider:"gemini"
+      (Http_client.ProviderFailure
+         { kind =
+             Http_client.Capacity_exhausted
+               { scope = Http_client.Failure_scope_model
+               ; retry_after = Some 7.0
+               ; model = Some "gemini-3-pro"
+               }
+         ; message = "model queue saturated"
+         })
+  in
+  match err with
+  | Error.CapacityExhausted { scope; affected; retry_after; detail } ->
+    check bool "scope" true (scope = Error.CapacityModel);
+    check (list string) "affected" [ "gemini-3-pro" ] affected;
+    check (option (float 0.001)) "retry_after" (Some 7.0) retry_after;
+    check string "detail" "model queue saturated" detail
+  | _ -> fail "expected CapacityExhausted"
+;;
+
+let test_http_server_error_mapping () =
+  let err =
+    Error.of_http_error
+      ~provider:"openai"
+      (Http_client.HttpError { code = 503; body = "down" })
+  in
+  match err with
+  | Error.ServerError { provider; code; transient; detail } ->
+    check string "provider" "openai" provider;
+    check int "code" 503 code;
+    check bool "transient" true transient;
+    check string "detail" "down" detail
+  | _ -> fail "expected ServerError"
+;;
+
+let test_http_terminal_mapping () =
+  let err =
+    Error.of_http_error
+      ~provider:"claude_code"
+      (Http_client.ProviderTerminal
+         { kind = Http_client.Max_turns { turns = 31; limit = 31 }
+         ; message = "turn cap hit"
+         })
+  in
+  match err with
+  | Error.ProviderTerminal { provider; reason; detail } ->
+    check string "provider" "claude_code" provider;
+    check string "reason" "max_turns:31/31" reason;
+    check string "detail" "turn cap hit" detail
+  | _ -> fail "expected ProviderTerminal"
+;;
+
+let test_http_network_error_mapping () =
+  let err =
+    Error.of_http_error
+      ~provider:"local"
+      (Http_client.NetworkError { message = "read timed out"; kind = Http_client.Timeout })
+  in
+  match err with
+  | Error.NetworkError { provider; kind; detail } ->
+    check string "provider" "local" provider;
+    check bool "kind" true (kind = Http_client.Timeout);
+    check string "detail" "read timed out" detail
+  | _ -> fail "expected NetworkError"
+;;
+
+let test_cli_transport_required_mapping () =
+  let err =
+    Error.of_http_error (Http_client.CliTransportRequired { kind = "codex_cli" })
+  in
+  match err with
+  | Error.InvalidConfig { field; detail } ->
+    check string "field" "transport" field;
+    check string "detail" "CLI transport required for codex_cli" detail
+  | _ -> fail "expected InvalidConfig"
+;;
+
 let () =
   run
     "llm_provider_error"
@@ -62,6 +301,29 @@ let () =
         ; test_case "ParseError" `Quick test_parse_error
         ; test_case "UnknownVariant" `Quick test_unknown_variant
         ; test_case "ProviderUnavailable" `Quick test_provider_unavailable
+        ; test_case "RateLimit" `Quick test_rate_limit
+        ; test_case "HardQuota" `Quick test_hard_quota
+        ; test_case "CapacityExhausted" `Quick test_capacity_exhausted
+        ; test_case "AuthError" `Quick test_auth_error
+        ; test_case "ServerError" `Quick test_server_error
+        ; test_case "NetworkError" `Quick test_network_error
+        ; test_case "Timeout" `Quick test_timeout
+        ; test_case "InvalidRequest" `Quick test_invalid_request
+        ; test_case "NotFound" `Quick test_not_found
+        ; test_case "ProviderTerminal" `Quick test_provider_terminal
+        ] )
+    ; ( "mapping"
+      , [ test_case "Retry RateLimited" `Quick test_retry_rate_limit_mapping
+        ; test_case "Retry hard quota" `Quick test_retry_hard_quota_mapping
+        ; test_case
+            "Retry overloaded unknown provider"
+            `Quick
+            test_retry_overloaded_unknown_provider_mapping
+        ; test_case "HTTP capacity failure" `Quick test_http_capacity_failure_mapping
+        ; test_case "HTTP server error" `Quick test_http_server_error_mapping
+        ; test_case "HTTP terminal" `Quick test_http_terminal_mapping
+        ; test_case "HTTP network error" `Quick test_http_network_error_mapping
+        ; test_case "CLI transport required" `Quick test_cli_transport_required_mapping
         ] )
     ]
 ;;


### PR DESCRIPTION
## What
- Extend `Llm_provider.Error.provider_error` with typed runtime/provider error variants for rate limits, hard quota, capacity exhaustion, auth, server, network, timeout, invalid request, not found, and terminal provider exits.
- Add conversion helpers from `Retry.api_error` and `Http_client.http_error` into the provider-error surface.
- Expand `test_llm_provider_error` with table-sized coverage for retry, hard-quota, capacity, server, terminal, network, and missing CLI transport mappings.

## Why
This is an additive OAS slice for `jeong-sik/masc-mcp#11925`. OAS already has structured `Retry.api_error` and `Http_client.http_error` types, but the provider-level error module could only express a few generic formatting variants. That left a gap for consumers that want to preserve typed provider/runtime failure semantics without parsing strings or reaching into transport-specific error types.

## Compatibility
Existing provider-error variants and strings remain intact. This PR adds new variants and helpers; it does not change retry classification, cascade behavior, or transport error emission.

## Validation
Fresh validation on current head `f2b8f1a88c514abd816ed77e2681345be83b6900` at 2026-05-07 10:20 KST:

- `scripts/dune-local.sh build test/test_llm_provider_error.exe` attempted first; stopped while queued behind `/tmp/me-dune-local.lock` host contention.
- `env DUNE_JOBS=1 dune build --root . test/test_llm_provider_error.exe`
- `./_build/default/test/test_llm_provider_error.exe` - 23 tests passed
- `env DUNE_JOBS=1 dune build --root . test/test_retry.exe test/test_complete_cascade.exe`
- `./_build/default/test/test_retry.exe` - 16 tests passed
- `./_build/default/test/test_complete_cascade.exe` - 18 tests passed
- `ocamlformat --check lib/llm_provider/error.ml lib/llm_provider/error.mli test/test_llm_provider_error.ml`
- `git diff --check`
- `git diff --check origin/main...HEAD`

## Review Focus
- Whether the new provider-error variants are the right stable provider-facing shape.
- Whether `of_http_error` should live here long term or move closer to the transport boundary once downstream telemetry consumes it.

Refs jeong-sik/masc-mcp#11925.
