### PR TITLE
fix(types): preserve missing response usage

### DIFF
--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -490,8 +490,5 @@ let zero_api_usage =
   }
 ;;
 
-let usage_of_response (resp : api_response) =
-  match resp.usage with
-  | Some u -> u
-  | None -> zero_api_usage
+let usage_of_response (resp : api_response) = resp.usage
 ;;

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -316,5 +316,6 @@ val text_of_response : api_response -> string
 (** Zero-valued usage sentinel for accumulation. *)
 val zero_api_usage : api_usage
 
-(** Extract usage from a response, defaulting to {!zero_api_usage}. *)
-val usage_of_response : api_response -> api_usage
+(** Extract usage from a response, preserving [None] when the provider did not
+    report usage. *)
+val usage_of_response : api_response -> api_usage option

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -413,9 +413,11 @@ let test_usage_of_response_some () =
     ; telemetry = None
     }
   in
-  let u = Types.usage_of_response resp in
-  check int "input" 100 u.input_tokens;
-  check int "output" 50 u.output_tokens
+  match Types.usage_of_response resp with
+  | Some u ->
+    check int "input" 100 u.input_tokens;
+    check int "output" 50 u.output_tokens
+  | None -> fail "expected reported usage"
 ;;
 
 let test_usage_of_response_none () =
@@ -428,9 +430,7 @@ let test_usage_of_response_none () =
     ; telemetry = None
     }
   in
-  let u = Types.usage_of_response resp in
-  check int "input fallback" 0 u.input_tokens;
-  check int "output fallback" 0 u.output_tokens
+  check (option reject) "missing usage preserved" None (Types.usage_of_response resp)
 ;;
 
 (* ── Capability_filter combinators ──────────────────── *)


### PR DESCRIPTION
## Summary
- change `Types.usage_of_response` to preserve `None` when a provider did not report usage
- keep `zero_api_usage` as the explicit accumulator sentinel instead of using it as an implicit response fallback
- update provider-registry tests to assert `Some` vs `None` response usage directly

## Why it matters
This addresses the Kimi cleanup P0 `usage_or_zero` item. Missing usage means measurement unavailable; it should not be collapsed into real zero-token usage telemetry.

## Validation
- `git diff --check`
- `ocamlformat --check lib/llm_provider/types.ml lib/llm_provider/types.mli test/test_provider_registry.ml`
- `scripts/dune-local.sh build test/test_provider_registry.exe`
- `./_build/default/test/test_provider_registry.exe` (22 tests passed)