### PR TITLE
feat(lib): add Cognitive_event typed schema (RFC-0036 PR-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ original tag dates. `0.100.4` was never tagged or released.
 ### Changed
 - `Llm_provider.Llm_transport.sync_result.latency_ms`, `Types.inference_telemetry.request_latency_ms`, and `Metrics.on_request_end` now carry `int option` latency. Transports report `Some ms` only when they measured elapsed time and `None` when latency is unavailable, so telemetry JSON emits `null` instead of conflating unknown latency with a measured `0`. Downstream repos such as `masc-mcp` must handle the optional field when updating their OAS pin. (#1450)
 
+### Added
+- `lib/cognitive_event.{ml,mli}`: typed JSON-codecable cognitive event schema for SDK consumers. Four variants — `Gravity_ranked`, `Intent_predicted`, `Mode_transitioned`, `Disclosure_level` — backed by `[@@deriving yojson, show]` plus a `name` label getter and an `is_well_formed` invariant checker. The host (masc-mcp) emits these; the SDK does not produce them itself in this PR. The type lives here so future SDK-side consumers (Hooks, Tracing) share a single schema. RFC-0036 PR-B.
+- `test/test_cognitive_event.ml`: 5 alcotest cases (label stability, well-formed accepts, well-formed rejects 12 invalid inputs, yojson roundtrip, yojson rejects garbage).
+
+
 ## [0.190.26] - 2026-05-06
 
 ### Fixed

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -57,6 +57,7 @@ module Hooks = Agent_sdk_base.Hooks
 module Tracing = Tracing
 module Context_reducer = Context_reducer
 module Context_intent = Context_intent
+module Cognitive_event = Cognitive_event
 module Budget_strategy = Budget_strategy
 module Tool = Agent_sdk_base.Tool
 module Typed_tool = Typed_tool

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -30,6 +30,7 @@ module Hooks = Agent_sdk_base.Hooks
 module Tracing = Tracing
 module Context_reducer = Context_reducer
 module Context_intent = Context_intent
+module Cognitive_event = Cognitive_event
 module Budget_strategy = Budget_strategy
 module Tool = Agent_sdk_base.Tool
 module Typed_tool = Typed_tool

--- a/lib/cognitive_event.ml
+++ b/lib/cognitive_event.ml
@@ -1,0 +1,56 @@
+(* Cognitive_event — implementation.
+
+   See cognitive_event.mli for the interface contract. *)
+
+type t =
+  | Gravity_ranked of {
+      ranked_count : int;
+      query_terms : int;
+    }
+  | Intent_predicted of {
+      intent_label : string;
+      confidence : float;
+    }
+  | Mode_transitioned of {
+      from_mode : string;
+      to_mode : string;
+    }
+  | Disclosure_level of { level : int }
+[@@deriving yojson, show]
+
+let name = function
+  | Gravity_ranked _ -> "gravity_ranked"
+  | Intent_predicted _ -> "intent_predicted"
+  | Mode_transitioned _ -> "mode_transitioned"
+  | Disclosure_level _ -> "disclosure_level"
+
+let is_well_formed = function
+  | Gravity_ranked { ranked_count; query_terms } ->
+    if ranked_count < 0 then
+      Error "Gravity_ranked.ranked_count must be non-negative"
+    else if query_terms < 0 then
+      Error "Gravity_ranked.query_terms must be non-negative"
+    else Ok ()
+  | Intent_predicted { intent_label; confidence } ->
+    if String.length intent_label = 0 then
+      Error "Intent_predicted.intent_label must be non-empty"
+    else if
+      (not (Float.is_finite confidence))
+      || confidence < 0.0
+      || confidence > 1.0
+    then
+      Error
+        "Intent_predicted.confidence must be a finite float in [0.0, 1.0]"
+    else Ok ()
+  | Mode_transitioned { from_mode; to_mode } ->
+    if String.length from_mode = 0 then
+      Error "Mode_transitioned.from_mode must be non-empty"
+    else if String.length to_mode = 0 then
+      Error "Mode_transitioned.to_mode must be non-empty"
+    else if String.equal from_mode to_mode then
+      Error "Mode_transitioned.from_mode and to_mode must differ"
+    else Ok ()
+  | Disclosure_level { level } ->
+    if level < 0 || level > 3 then
+      Error "Disclosure_level.level must be in [0, 3]"
+    else Ok ()

--- a/lib/cognitive_event.mli
+++ b/lib/cognitive_event.mli
@@ -1,0 +1,64 @@
+(** Cognitive event types for SDK consumers (RFC-0036 PR-B,
+    Master Report transport schema).
+
+    A typed, JSON-codecable enumeration of the cognitive events that
+    the host (masc-mcp) emits when its cognitive layer fires
+    (gravity ranking, intent prediction, mode transition, disclosure
+    level change). The SDK does not produce these events itself in
+    this PR; the type lives here so both the host emitter and any
+    future SDK-side consumer (Hooks, Tracing) share a single schema.
+
+    Design choices:
+
+    - Variants carry only structural data, not closures or
+      file-handle references — the type must remain JSON-stable
+      across pin bumps.
+    - {!Intent_predicted} carries [intent_label : string] rather
+      than referring to {!Context_intent.intent}. This keeps
+      {!Cognitive_event} independent of {!Context_intent}'s
+      enum lifecycle: hosts that classify with a richer
+      taxonomy (e.g. RFC-0036 Extension A's [Cognitive_op]
+      variant) can still serialise events without depending on
+      a particular SDK pin.
+    - No timestamps in the variants. Callers add timing via the
+      surrounding {!Tracing} or {!Hooks} envelope.
+
+    @stability Evolving
+    @since 0.190.27 *)
+
+(** A cognitive event emitted by the host. *)
+type t =
+  | Gravity_ranked of {
+      ranked_count : int;
+      query_terms : int;
+    }
+  | Intent_predicted of {
+      intent_label : string;
+      confidence : float;
+    }
+  | Mode_transitioned of {
+      from_mode : string;
+      to_mode : string;
+    }
+  | Disclosure_level of { level : int }
+[@@deriving yojson, show]
+
+(** [name t] returns the variant tag as a stable lowercase string,
+    suitable for log labels and Prometheus counters. *)
+val name : t -> string
+
+(** [is_well_formed t] checks the lightweight invariants this module
+    enforces:
+
+    - [Gravity_ranked]: [ranked_count] and [query_terms] non-negative.
+    - [Intent_predicted]: [intent_label] non-empty,
+      [confidence] in the closed interval [0.0, 1.0].
+    - [Mode_transitioned]: [from_mode] and [to_mode] non-empty and
+      not equal.
+    - [Disclosure_level]: [level] in the closed interval [0, 3]
+      (Master Report defines L0 / L1 / L2 / L3 disclosure tiers).
+
+    The function returns [Ok ()] on a well-formed event and [Error
+    msg] otherwise. Decoders that want to reject malformed inputs
+    should call this after {!of_yojson}. *)
+val is_well_formed : t -> (unit, string) result

--- a/test/dune
+++ b/test/dune
@@ -362,3 +362,8 @@
  (name test_runtime_worker_integration)
  (modules test_runtime_worker_integration)
  (libraries agent_sdk alcotest eio eio_main unix))
+
+(test
+ (name test_cognitive_event)
+ (modules test_cognitive_event)
+ (libraries agent_sdk alcotest))

--- a/test/test_cognitive_event.ml
+++ b/test/test_cognitive_event.ml
@@ -1,0 +1,124 @@
+(** Unit tests for Cognitive_event (RFC-0036 PR-B,
+    Master Report transport schema). *)
+
+open Agent_sdk.Cognitive_event
+
+let test_name_is_stable () =
+  Alcotest.(check string)
+    "gravity_ranked label" "gravity_ranked"
+    (name (Gravity_ranked { ranked_count = 0; query_terms = 0 }));
+  Alcotest.(check string)
+    "intent_predicted label" "intent_predicted"
+    (name (Intent_predicted { intent_label = "x"; confidence = 0.5 }));
+  Alcotest.(check string)
+    "mode_transitioned label" "mode_transitioned"
+    (name (Mode_transitioned { from_mode = "a"; to_mode = "b" }));
+  Alcotest.(check string)
+    "disclosure_level label" "disclosure_level"
+    (name (Disclosure_level { level = 0 }))
+
+let test_well_formed_accepts_valid () =
+  let cases =
+    [ Gravity_ranked { ranked_count = 0; query_terms = 0 }
+    ; Gravity_ranked { ranked_count = 5; query_terms = 3 }
+    ; Intent_predicted { intent_label = "task_command"; confidence = 0.95 }
+    ; Intent_predicted { intent_label = "x"; confidence = 0.0 }
+    ; Intent_predicted { intent_label = "x"; confidence = 1.0 }
+    ; Mode_transitioned { from_mode = "focus"; to_mode = "scan" }
+    ; Disclosure_level { level = 0 }
+    ; Disclosure_level { level = 3 }
+    ]
+  in
+  List.iter
+    (fun ev ->
+      match is_well_formed ev with
+      | Ok () -> ()
+      | Error msg ->
+        Alcotest.failf "expected %s to be well-formed but got: %s"
+          (name ev) msg)
+    cases
+
+let check_rejects label result =
+  match result with
+  | Ok () -> Alcotest.failf "%s should have been rejected" label
+  | Error _ -> ()
+
+let test_well_formed_rejects_invalid () =
+  check_rejects "negative ranked_count"
+    (is_well_formed (Gravity_ranked { ranked_count = -1; query_terms = 0 }));
+  check_rejects "negative query_terms"
+    (is_well_formed (Gravity_ranked { ranked_count = 0; query_terms = -1 }));
+  check_rejects "empty intent_label"
+    (is_well_formed (Intent_predicted { intent_label = ""; confidence = 0.5 }));
+  check_rejects "confidence below 0"
+    (is_well_formed
+       (Intent_predicted { intent_label = "x"; confidence = -0.1 }));
+  check_rejects "confidence above 1"
+    (is_well_formed
+       (Intent_predicted { intent_label = "x"; confidence = 1.01 }));
+  check_rejects "confidence NaN"
+    (is_well_formed
+       (Intent_predicted { intent_label = "x"; confidence = Float.nan }));
+  check_rejects "confidence +inf"
+    (is_well_formed
+       (Intent_predicted { intent_label = "x"; confidence = Float.infinity }));
+  check_rejects "empty from_mode"
+    (is_well_formed (Mode_transitioned { from_mode = ""; to_mode = "b" }));
+  check_rejects "empty to_mode"
+    (is_well_formed (Mode_transitioned { from_mode = "a"; to_mode = "" }));
+  check_rejects "from_mode = to_mode"
+    (is_well_formed (Mode_transitioned { from_mode = "a"; to_mode = "a" }));
+  check_rejects "level below 0"
+    (is_well_formed (Disclosure_level { level = -1 }));
+  check_rejects "level above 3"
+    (is_well_formed (Disclosure_level { level = 4 }))
+
+let test_yojson_roundtrip () =
+  let cases =
+    [ Gravity_ranked { ranked_count = 7; query_terms = 2 }
+    ; Intent_predicted
+        { intent_label = "knowledge_query"; confidence = 0.84 }
+    ; Mode_transitioned { from_mode = "focus"; to_mode = "scan" }
+    ; Disclosure_level { level = 2 }
+    ]
+  in
+  List.iter
+    (fun ev ->
+      let json = to_yojson ev in
+      match of_yojson json with
+      | Ok ev' ->
+        Alcotest.(check string)
+          (Printf.sprintf "roundtrip preserves name (%s)" (name ev))
+          (name ev) (name ev');
+        Alcotest.(check string)
+          (Printf.sprintf "roundtrip preserves show (%s)" (name ev))
+          (show ev) (show ev')
+      | Error msg ->
+        Alcotest.failf "yojson roundtrip failed for %s: %s" (name ev) msg)
+    cases
+
+let test_yojson_rejects_garbage () =
+  let bad = Yojson.Safe.from_string {|{"unexpected":42}|} in
+  match of_yojson bad with
+  | Ok _ -> Alcotest.fail "of_yojson should have rejected unexpected JSON"
+  | Error _ -> ()
+
+let () =
+  Alcotest.run "cognitive_event"
+    [
+      ( "labels",
+        [ Alcotest.test_case "name is stable" `Quick test_name_is_stable ] );
+      ( "well_formed",
+        [
+          Alcotest.test_case "accepts valid" `Quick
+            test_well_formed_accepts_valid;
+          Alcotest.test_case "rejects invalid" `Quick
+            test_well_formed_rejects_invalid;
+        ] );
+      ( "yojson",
+        [
+          Alcotest.test_case "roundtrip" `Quick test_yojson_roundtrip;
+          Alcotest.test_case "rejects garbage" `Quick
+            test_yojson_rejects_garbage;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- 새 모듈 `lib/cognitive_event.{ml,mli}` 추가: 호스트(masc-mcp)가 emit하는 4종 cognitive event의 typed JSON-codecable 스키마.
- 3-surface 버전 sync 범프 `0.190.26 → 0.190.27`.
- 기존 public-API 변경 0건. 동작 변경 0건.

## Why this PR

masc-mcp의 `RFC-0036-oas-cognitive-mapping.md` (PR #13915) Extension B 구현. 호스트가 cognitive 이벤트(gravity rank, intent prediction, mode transition, disclosure level)를 emit할 때 SDK 측에 단일 스키마가 필요했고, 이게 그 자리.

호스트는 lib/cognitive_gravity / lib/intentional_projection (RFC-0035 PR-1/PR-2 #13797/#13821)을 통해 이벤트를 만듭니다. 그 transport 형식을 oas에 두면 향후 SDK-side consumer (Hooks, Tracing)가 같은 스키마를 공유합니다.

## Design choices

- **Variants carry only structural data** — JSON-stable across pin bumps.
- **Intent_predicted는 `intent_label : string`을 carry** (referring to `Context_intent.intent` 안 함). Extension A로 `Cognitive_op` variant를 추가해도 이미 직렬화된 이벤트는 깨지지 않음.
- **No timestamps in variants** — 시간은 surrounding `Tracing` / `Hooks` envelope의 책임.

```ocaml
type t =
  | Gravity_ranked    of { ranked_count : int; query_terms : int }
  | Intent_predicted  of { intent_label : string; confidence : float }
  | Mode_transitioned of { from_mode : string; to_mode : string }
  | Disclosure_level  of { level : int }
[@@deriving yojson, show]
```

`is_well_formed` 헬퍼가 가벼운 invariant 검증:
- 음수 count 거부
- empty intent_label 거부
- confidence ∈ [0.0, 1.0] (NaN/+∞ 거부)
- mode_transitioned에서 from_mode = to_mode 거부
- level ∈ [0, 3] (Master Report L0~L3)

## Changes

| File | Δ |
|---|---|
| `lib/cognitive_event.{ml,mli}` | new — 56 + 64 LOC, type + 2 helpers |
| `lib/agent_sdk.{ml,mli}` | +1 line each — `module Cognitive_event = Cognitive_event` re-export |
| `test/test_cognitive_event.ml` | new — 5 alcotest (label stability, well-formed accepts, well-formed rejects 12 invalid inputs, yojson roundtrip, yojson rejects garbage) |
| `test/dune` | new `(test ...)` 블록, libraries `agent_sdk + alcotest` |
| `dune-project` | version `0.190.26 → 0.190.27` |
| `lib/sdk_version.ml` | version sync 0.190.27 |
| `agent_sdk.opam` | dune 자동 sync 0.190.27 |
| `CHANGELOG.md` | `[0.190.27]` 섹션 |

총 **+260 / -3**, 10 파일.

## Verification

```
cd .worktrees/feat-rfc-0036-pr-b-cognitive-event
dune build --root . lib/.agent_sdk.objs/byte/agent_sdk__Cognitive_event.cmi    # PASS clean
dune build --root . lib/.agent_sdk.objs/native/agent_sdk__Cognitive_event.cmx  # PASS clean
dune build --root . test/test_cognitive_event.exe                              # PASS clean
./_build/default/test/test_cognitive_event.exe                                 # 5/5 OK in 0.001s
dune build --root . agent_sdk.opam                                             # version: "0.190.27"
```

3-surface version sync 검증:
- `dune-project (version 0.190.27)`
- `lib/sdk_version.ml let version = "0.190.27"`
- `agent_sdk.opam version: "0.190.27"`

`scripts/sync-version-truth.sh` / `scripts/check-tag-drift.sh`가 이미 이 sync를 강제하므로 추가 가드 불필요.

## Best Programmer self-review

- **목표**: 호스트와 SDK 사이에 cognitive event transport schema를 두되, 동작 변경 0으로.
- **변경 파일**: 10개. lib 신규 2 + test 신규 1 + re-export 2 + 메타 5.
- **로컬 검증**: 5/5 alcotest PASS.
- **남은 미검증**: 전체 `dune runtest` (오랜 시간 비용으로 보류, CI에 위임).
- **회귀 가능성**: 새 모듈 dead-add. 어떤 기존 호출 사이트도 사용 안 함.

## Out of scope

- 실제 emit 로직 — 호스트 측 별도 PR이 만들 것. 이 PR은 schema only.
- `Hooks` / `Tracing`에 `Cognitive_event`를 받는 endpoint 추가 — 별도 RFC.
- Extension A (`Context_intent.intent`에 `Cognitive_op` variant) — 별개 PR-A2.

## Test plan

- [x] `dune build` (lib + test 격리)
- [x] `./_build/.../test_cognitive_event.exe` 5/5 PASS
- [x] 3-surface version sync 검증 (0.190.27 일치)
- [ ] CI 전체 — 코드 surface는 신규 모듈 + re-export 2줄이라 회귀 위험 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>