### PR TITLE
Add cascade timeout attempt diagnostics

### DIFF
--- a/lib/llm_provider/complete_cascade.ml
+++ b/lib/llm_provider/complete_cascade.ml
@@ -33,13 +33,16 @@ type cascade_result =
       ; error : Http_client.http_error
       }
 
-let attempt_timeout_error ~model_id ~timeout_s =
+let attempt_timeout_error ~attempt_index ~model_id ~provider_key ~timeout_s =
   Http_client.NetworkError
     { kind = Http_client.Timeout
     ; message =
         Printf.sprintf
-          "cascade provider attempt for %s exceeded attempt_timeout_s %gs"
+          "cascade provider attempt timed out phase=provider_step attempt_index=%d \
+           model=%s provider_key=%s attempt_timeout_s=%gs"
+          attempt_index
           model_id
+          provider_key
           timeout_s
     }
 ;;
@@ -240,7 +243,12 @@ let complete_cascade
           | Some timeout_s ->
             (try Eio.Time.with_timeout_exn clock timeout_s attempt with
              | Eio.Time.Timeout ->
-               Error (attempt_timeout_error ~model_id:config.model_id ~timeout_s))
+               Error
+                 (attempt_timeout_error
+                    ~attempt_index:idx
+                    ~model_id:config.model_id
+                    ~provider_key:key
+                    ~timeout_s))
         in
         match result with
         | Ok response ->

--- a/lib/llm_provider/complete_cascade.mli
+++ b/lib/llm_provider/complete_cascade.mli
@@ -120,7 +120,10 @@ type cascade_result =
     5. On other error, record failure and try next step
 
     [?attempt_timeout_s] caps one provider step, including its internal
-    retry loop:
+    retry loop. Timeout errors include the cascade phase, provider
+    attempt index, model id, and provider key in the structured
+    [NetworkError] message so downstream receipts can distinguish a
+    provider-step timeout from a caller-side budget gate:
     - omitted (no argument): provider-specific defaults from
       {!Provider_config.default_attempt_timeout_s} apply when present
       (Ollama, Claude_code, Kimi_cli, Gemini_cli have positive defaults;

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -4,6 +4,22 @@
 open Alcotest
 open Llm_provider
 
+let contains text needle =
+  let text_len = String.length text in
+  let needle_len = String.length needle in
+  if needle_len = 0
+  then true
+  else (
+    let rec loop idx =
+      if idx + needle_len > text_len
+      then false
+      else if String.sub text idx needle_len = needle
+      then true
+      else loop (idx + 1)
+    in
+    loop 0)
+;;
+
 let dummy_response =
   Types.
     { id = "test-id"
@@ -424,8 +440,15 @@ let test_attempt_timeout_fast_paths_without_retrying_same_step () =
     (elapsed_s < 1.0);
   match result with
   | Complete_cascade.All_failed
-      { errors = [ (_, Http_client.NetworkError { kind; _ }) ]; _ } ->
-    check bool "timeout classified" true (kind = Http_client.Timeout)
+      { errors = [ (config, Http_client.NetworkError { kind; message }) ]; _ } ->
+    check bool "timeout classified" true (kind = Http_client.Timeout);
+    check bool "phase recorded" true (contains message "phase=provider_step");
+    check bool "attempt index recorded" true (contains message "attempt_index=0");
+    check
+      bool
+      "provider key recorded"
+      true
+      (contains message (Complete_cascade.provider_key config))
   | _ -> fail "expected timeout All_failed"
 ;;
 


### PR DESCRIPTION
## Summary
- Include `phase=provider_step`, cascade attempt index, model id, and provider key in cascade attempt timeout errors.
- Document that timeout diagnostic payload in `complete_cascade.mli`.
- Pin the timeout message fields in `test_complete_cascade`.

## Why
MASC receipts can now distinguish caller-side budget gates from provider-step timeouts. OAS should preserve enough attempt context in its own timeout error so downstream ledgers and dashboards do not collapse every timeout into an unhelpful generic provider failure.

## Tests
- `env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_complete_cascade.exe`
- `./_build/default/test/test_complete_cascade.exe`