### PR TITLE
fix: warn on invalid CLI integer env

### DIFF
--- a/lib/llm_provider/cli_common_env.ml
+++ b/lib/llm_provider/cli_common_env.ml
@@ -51,11 +51,85 @@ let kv_pairs name =
   | Some v -> Some (split_on_char_trim ',' v |> List.filter_map parse_kv)
 ;;
 
-let int ~default var =
+let int ?(allow_negative = false) ~default var =
   match Sys.getenv_opt var with
   | Some raw ->
-    (match int_of_string_opt (String.trim raw) with
-     | Some v when v >= 0 -> v
-     | _ -> default)
+    let trimmed = String.trim raw in
+    if trimmed = ""
+    then default
+    else (
+      match int_of_string_opt trimmed with
+      | Some v when allow_negative || v >= 0 -> v
+      | Some v ->
+        Diag.warn
+          "cli_common_env"
+          "%s=%S is negative (%d); using default %d"
+          var
+          raw
+          v
+          default;
+        default
+      | None ->
+        Diag.warn
+          "cli_common_env"
+          "%s=%S is not an integer; using default %d"
+          var
+          raw
+          default;
+        default)
   | None -> default
+;;
+
+[@@@coverage off]
+
+let with_env name value f =
+  let original = Sys.getenv_opt name in
+  let restore () =
+    match original with
+    | None -> Unix.putenv name ""
+    | Some v -> Unix.putenv name v
+  in
+  Fun.protect ~finally:restore (fun () ->
+    Unix.putenv name value;
+    f ())
+;;
+
+let%test "int accepts positive env value" =
+  with_env "OAS_TEST_CLI_COMMON_ENV_INT_POSITIVE" "12" (fun () ->
+    int ~default:7 "OAS_TEST_CLI_COMMON_ENV_INT_POSITIVE" = 12)
+;;
+
+let%test "int rejects negative env value by default" =
+  with_env "OAS_TEST_CLI_COMMON_ENV_INT_NEGATIVE" "-1" (fun () ->
+    let warnings = ref [] in
+    let value =
+      Diag.with_sink
+        (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
+        (fun () -> int ~default:7 "OAS_TEST_CLI_COMMON_ENV_INT_NEGATIVE")
+    in
+    value = 7
+    && List.exists
+         (fun (level, ctx, msg) ->
+            level = Diag.Warn && ctx = "cli_common_env" && String.contains msg '-')
+         !warnings)
+;;
+
+let%test "int allows negative env value when requested" =
+  with_env "OAS_TEST_CLI_COMMON_ENV_INT_ALLOW_NEGATIVE" "-1" (fun () ->
+    int ~allow_negative:true ~default:7 "OAS_TEST_CLI_COMMON_ENV_INT_ALLOW_NEGATIVE" = -1)
+;;
+
+let%test "int rejects non-numeric env value" =
+  with_env "OAS_TEST_CLI_COMMON_ENV_INT_NON_NUMERIC" "not-a-number" (fun () ->
+    let warnings = ref [] in
+    let value =
+      Diag.with_sink
+        (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
+        (fun () -> int ~default:7 "OAS_TEST_CLI_COMMON_ENV_INT_NON_NUMERIC")
+    in
+    value = 7
+    && List.exists
+         (fun (level, ctx, msg) ->
+            level = Diag.Warn && ctx = "cli_common_env" && String.contains msg 'n')
+         !warnings)
 ;;

--- a/lib/llm_provider/cli_common_env.mli
+++ b/lib/llm_provider/cli_common_env.mli
@@ -52,6 +52,8 @@ val trim_non_empty : string -> string option
 (** [trim_non_empty_opt opt] maps [trim_non_empty] over an option. *)
 val trim_non_empty_opt : string option -> string option
 
-(** [int ~default var] parses env var [var] as a non-negative integer.
-    Returns [default] when unset, empty, negative, or non-numeric. *)
-val int : default:int -> string -> int
+(** [int ?allow_negative ~default var] parses env var [var] as an integer.
+    Returns [default] when unset or empty.  Negative values are rejected
+    unless [allow_negative] is [true].  Rejected negative and non-numeric
+    values emit a warning before falling back to [default]. *)
+val int : ?allow_negative:bool -> default:int -> string -> int

--- a/lib/llm_provider/diag.ml
+++ b/lib/llm_provider/diag.ml
@@ -11,9 +11,16 @@ let level_to_string = function
   | Error -> "ERROR"
 ;;
 
-let debug_enabled =
-  Cli_common_env.bool "OAS_LLM_PROVIDER_DEBUG" || Cli_common_env.bool "OAS_CASCADE_DIAG"
+let env_bool name =
+  match Sys.getenv_opt name with
+  | None -> false
+  | Some raw ->
+    (match String.lowercase_ascii (String.trim raw) with
+     | "1" | "true" | "yes" | "on" -> true
+     | _ -> false)
 ;;
+
+let debug_enabled = env_bool "OAS_LLM_PROVIDER_DEBUG" || env_bool "OAS_CASCADE_DIAG"
 
 let default_sink (lvl : level) ~ctx msg =
   match lvl with


### PR DESCRIPTION
## Summary

- Make `Cli_common_env.int` emit a warning when an integer env var is malformed or negative and has to fall back to its default.
- Add `?allow_negative` for callers that intentionally accept negative integer sentinels.
- Route these warnings through `Diag.warn` by removing the `Diag -> Cli_common_env` dependency, so operator log sinks can capture the signal.

## Why

The Kimi OAS provider audit flagged integer env parsing as silently replacing bad values with defaults. That hides operator misconfiguration on CLI transport knobs such as prompt argv thresholds. This keeps the existing conservative default behavior, but makes the fallback visible and test-covered.

## Validation

- `scripts/dune-local.sh build test/test_llm_provider_cov.exe`
- `scripts/dune-local.sh build @lib/llm_provider/runtest`
- `./_build/default/test/test_llm_provider_cov.exe` (131 tests)
- `ocamlformat --check lib/llm_provider/cli_common_env.ml lib/llm_provider/cli_common_env.mli lib/llm_provider/diag.ml`
- `git diff --check`