### PR TITLE
fix: expose CLI stdout recovery metadata

### DIFF
--- a/lib/llm_provider/cli_common_subprocess.ml
+++ b/lib/llm_provider/cli_common_subprocess.ml
@@ -2,6 +2,7 @@ type collect_result =
   { stdout : string
   ; stderr : string
   ; latency_ms : int
+  ; recovered_exit_code : int option
   }
 
 let starts_with s prefix =
@@ -218,7 +219,13 @@ let run_core
            }))
     else (
       match status with
-      | `Exited 0 -> Ok { stdout = stdout_str; stderr = stderr_str; latency_ms }
+      | `Exited 0 ->
+        Ok
+          { stdout = stdout_str
+          ; stderr = stderr_str
+          ; latency_ms
+          ; recovered_exit_code = None
+          }
       | `Exited code ->
         (* Some CLI transports complete the LLM response on stdout but exit
          nonzero on post-response bookkeeping (e.g. codex-cli 0.125.0+
@@ -244,7 +251,23 @@ let run_core
           | None -> false
         in
         if recovered
-        then Ok { stdout = stdout_str; stderr = stderr_str; latency_ms }
+        then (
+          let stderr_detail =
+            match last_nonempty_line stderr_str with
+            | Some line -> line
+            | None -> "<empty stderr>"
+          in
+          Eio.traceln
+            "cli_common_subprocess: stdout_recovery accepted nonzero exit code %d; \
+             stderr_last=%s"
+            code
+            stderr_detail;
+          Ok
+            { stdout = stdout_str
+            ; stderr = stderr_str
+            ; latency_ms
+            ; recovered_exit_code = Some code
+            })
         else (
           let detail =
             if stderr_str <> ""
@@ -392,10 +415,10 @@ let%test "run_collect: stdout_recovery rescues nonzero exit when predicate match
       ~on_stderr_line:(fun _ -> ())
       [ "sh"; "-c"; "printf 'turn.completed marker\\n'; exit 1" ]
   with
-  | Ok { stdout; _ } ->
+  | Ok { stdout; recovered_exit_code; _ } ->
     (* The 'turn.completed marker\n' payload should be captured even
        though the subprocess exited 1. *)
-    String.length stdout > 0
+    String.length stdout > 0 && recovered_exit_code = Some 1
   | _ -> false
 ;;
 
@@ -437,6 +460,7 @@ let%test "run_collect: zero exit ignores stdout_recovery (still Ok)" =
       ~on_stderr_line:(fun _ -> ())
       [ "sh"; "-c"; "printf 'fine\\n'; exit 0" ]
   with
-  | Ok _ -> true
+  | Ok { recovered_exit_code = None; _ } -> true
+  | Ok _ -> false
   | _ -> false
 ;;

--- a/lib/llm_provider/cli_common_subprocess.mli
+++ b/lib/llm_provider/cli_common_subprocess.mli
@@ -9,6 +9,9 @@ type collect_result =
   { stdout : string
   ; stderr : string
   ; latency_ms : int
+  ; recovered_exit_code : int option
+    (** [Some code] when [stdout_recovery] converted a nonzero exit into
+            [Ok]. [None] means the subprocess exited 0. *)
   }
 
 (** Default stderr-line handler used when [~on_stderr_line] is
@@ -55,9 +58,12 @@ val default_on_stderr_line : name:string -> string -> unit
       retrying the cascade.  The hook is invoked only on nonzero exits
       and predicate exceptions are caught and logged.
 
-    Returns [Ok { stdout; stderr; latency_ms }] on a zero exit code (or
-    on a nonzero exit when [stdout_recovery] accepts the captured
-    stdout), or a [NetworkError] describing the failure. *)
+    Returns [Ok { stdout; stderr; latency_ms; recovered_exit_code }]
+    on a zero exit code or on a nonzero exit when [stdout_recovery]
+    accepts the captured stdout.  Recovered results preserve the
+    original nonzero code in [recovered_exit_code] and keep stderr in
+    [stderr].  Otherwise returns a [NetworkError] describing the
+    failure. *)
 val run_collect
   :  sw:Eio.Switch.t
   -> mgr:_ Eio.Process.mgr

--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -704,7 +704,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
               argv
           with
           | Error _ as e -> { Llm_transport.response = e; latency_ms = None }
-          | Ok { stdout = _; stderr = _; latency_ms } ->
+          | Ok { stdout = _; stderr = _; latency_ms; recovered_exit_code = _ } ->
             let response = parse_stream_result (List.rev !seen_lines) in
             { Llm_transport.response; latency_ms = Some latency_ms })
         else (
@@ -720,7 +720,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
           in
           match run ~sw ~mgr ~config ?stdin_content:(stdin_for_prompt prompt) args with
           | Error _ as e -> { Llm_transport.response = e; latency_ms = None }
-          | Ok { stdout; stderr = _; latency_ms } ->
+          | Ok { stdout; stderr = _; latency_ms; recovered_exit_code = _ } ->
             let response = parse_json_result ~prompt (String.trim stdout) in
             { Llm_transport.response; latency_ms = Some latency_ms }))
   ; complete_stream =

--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -729,7 +729,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
                argv
            with
            | Error _ as e -> { Llm_transport.response = e; latency_ms = None }
-           | Ok { stdout = _; stderr = _; latency_ms } ->
+           | Ok { stdout = _; stderr = _; latency_ms; recovered_exit_code = _ } ->
              let response = parse_jsonl_result ~model_id ~prompt (List.rev !seen_lines) in
              { Llm_transport.response; latency_ms = Some latency_ms }))
   ; complete_stream =

--- a/lib/llm_provider/transport_gemini_cli.ml
+++ b/lib/llm_provider/transport_gemini_cli.ml
@@ -511,7 +511,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
           let model = selected_model ~config ~req_config:req.config in
           (match run ~sw ~mgr ~config ?model argv with
            | Error _ as e -> { Llm_transport.response = e; latency_ms = None }
-           | Ok { stdout; stderr = _; latency_ms } ->
+           | Ok { stdout; stderr = _; latency_ms; recovered_exit_code = _ } ->
              let prompt_for_estimation =
                Cli_common_prompt.prompt_with_system_prompt ~prompt ~system_prompt
              in
@@ -548,7 +548,7 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
          after the sync call completes. *)
           (match run ~sw ~mgr ~config ?model argv with
            | Error _ as e -> e
-           | Ok { stdout; stderr = _; latency_ms = _ } ->
+           | Ok { stdout; stderr = _; latency_ms = _; recovered_exit_code = _ } ->
              let prompt_for_estimation =
                Cli_common_prompt.prompt_with_system_prompt ~prompt ~system_prompt
              in

--- a/test/test_cli_common_subprocess.ml
+++ b/test/test_cli_common_subprocess.ml
@@ -18,9 +18,10 @@ let test_run_collect_ok () =
       ~extra_env:[]
       [ sh; "-c"; "printf a; printf b >&2" ]
   with
-  | Ok { stdout; stderr; latency_ms } ->
+  | Ok { stdout; stderr; latency_ms; recovered_exit_code } ->
     Alcotest.(check string) "stdout" "a\n" stdout;
     Alcotest.(check string) "stderr" "b\n" stderr;
+    Alcotest.(check (option int)) "not recovered" None recovered_exit_code;
     Alcotest.(check bool) "latency non-negative" true (latency_ms >= 0)
   | Error _ -> Alcotest.fail "expected Ok"
 ;;


### PR DESCRIPTION
## Summary

- Add `recovered_exit_code` to `Cli_common_subprocess.collect_result`.
- Preserve `None` for normal exit-zero runs and `Some code` when `stdout_recovery` converts a nonzero exit into `Ok`.
- Emit a trace line when recovery is accepted, including the original exit code and last stderr line.

## Why

The Kimi OAS provider audit flagged `stdout_recovery` as hiding the original nonzero CLI exit. This keeps the existing opt-in recovery behavior for structurally complete stdout, but makes the recovery path observable and machine-readable for callers that need to distinguish clean success from recovered success.

## Validation

- `scripts/dune-local.sh build test/test_cli_common_subprocess.exe`
- `./_build/default/test/test_cli_common_subprocess.exe` (9 tests)
- `scripts/dune-local.sh build @lib/llm_provider/runtest`
- `ocamlformat --check lib/llm_provider/cli_common_subprocess.ml lib/llm_provider/cli_common_subprocess.mli lib/llm_provider/transport_gemini_cli.ml lib/llm_provider/transport_claude_code.ml lib/llm_provider/transport_codex_cli.ml test/test_cli_common_subprocess.ml`
- `git diff --check`

Note: an extra `test/test_llm_provider_cov.exe` build was queued, but I cancelled it because the shared Dune lock was held by an unrelated long `test/test_operator_control.exe` run. The touched library and transport call sites compiled through the focused subprocess build and inline provider tests above.