### PR TITLE
feat(transport_codex_cli): expose stdout_idle_timeout_s on config

### DIFF
--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -31,6 +31,14 @@ type config =
   ; cancel : unit Eio.Promise.t option
     (* When [Some p] and [p] resolves mid-run, the [codex]
        subprocess receives [SIGINT].  Default [None]. *)
+  ; clock : float Eio.Time.clock_ty Eio.Resource.t option
+    (* Optional Eio clock used together with [stdout_idle_timeout_s]
+       to bound stdout silence.  Default [None]. *)
+  ; stdout_idle_timeout_s : float option
+    (* When [Some s] and [clock] is [Some _], the codex subprocess
+       is aborted via [SIGINT] if no stdout line arrives within [s]
+       seconds.  Wired into [Cli_common_subprocess.run_stream_lines].
+       Default [None]. *)
   }
 
 let default_config =
@@ -42,6 +50,8 @@ let default_config =
   ; max_turns = None
   ; permission_mode = None
   ; cancel = None
+  ; clock = None
+  ; stdout_idle_timeout_s = None
   }
 ;;
 
@@ -714,6 +724,8 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
                ~stdout_recovery:stdout_contains_turn_completed
                ~on_line
                ?cancel:config.cancel
+               ?clock:config.clock
+               ?stdout_idle_timeout_s:config.stdout_idle_timeout_s
                argv
            with
            | Error _ as e -> { Llm_transport.response = e; latency_ms = 0 }
@@ -776,6 +788,8 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
                ~stdout_recovery:stdout_contains_turn_completed
                ~on_line
                ?cancel:config.cancel
+               ?clock:config.clock
+               ?stdout_idle_timeout_s:config.stdout_idle_timeout_s
                argv
            with
            | Error _ as e -> e

--- a/lib/llm_provider/transport_codex_cli.mli
+++ b/lib/llm_provider/transport_codex_cli.mli
@@ -42,6 +42,26 @@ type config =
         Default [None].
 
         @since 0.148.0 *)
+  ; clock : float Eio.Time.clock_ty Eio.Resource.t option
+    (** Optional Eio clock used together with
+        [stdout_idle_timeout_s] to bound subprocess silence.
+        Both must be [Some _] for the idle bound to engage —
+        see {!Cli_common_subprocess.run_stream_lines}.
+
+        Default [None].
+
+        @since 0.191.0 *)
+  ; stdout_idle_timeout_s : float option
+    (** When [Some s] and [clock] is [Some _], the [codex]
+        subprocess is aborted via [SIGINT] if no stdout line
+        arrives within [s] seconds.  Mirrors the kimi-cli idle
+        bound introduced for masc-mcp keeper turns in
+        masc-mcp PR #13894 (RFC-0022 attempt liveness); the
+        same field is wired here so OAS callers can opt-in.
+
+        Default [None].
+
+        @since 0.191.0 *)
   }
 
 (** Sensible defaults: [codex] in PATH, no overrides. *)


### PR DESCRIPTION
## Summary

Adds two opt-in fields to `Transport_codex_cli.config`:
- `clock : float Eio.Time.clock_ty Eio.Resource.t option`
- `stdout_idle_timeout_s : float option`

Both are threaded into the existing `Cli_common_subprocess.run_stream_lines` call sites in `complete_sync` and `complete_stream`. When both are `Some _`, the codex CLI subprocess is aborted via SIGINT if no stdout line arrives within the configured duration. Defaults `None` — no behavior change for existing callers.

## Why

masc-mcp PR [#13894](https://github.com/jeong-sik/masc-mcp/pull/13894) introduced the same idle bound for `Kimi_cli_transport_local` (RFC-0022 attempt liveness) and noted in its commit message:

> Transport_codex_cli, Transport_gemini_cli, Transport_claude_code (agent_sdk) do not yet expose stdout_idle_timeout_s in their config records — they need an OAS upstream PR before masc-mcp can plumb the same field through.

This PR is that upstream change for `codex_cli`. The `Cli_common_subprocess` API has accepted `?clock` and `?stdout_idle_timeout_s` since #1191; only the per-transport config records were missing.

## Scope (codex_cli only)

- `Transport_claude_code` and `Transport_kimi_cli` have the same gap; planned as follow-ups so this PR stays small.
- `Transport_gemini_cli` uses a different mechanism (HTTP-shaped streaming) and is out of scope.

## Diff shape

```
lib/llm_provider/transport_codex_cli.ml  | 14 ++++++++++++++
lib/llm_provider/transport_codex_cli.mli | 20 ++++++++++++++++++++
2 files changed, 34 insertions(+)
```

Pure additive. Pattern mirrors the existing `cancel : unit Eio.Promise.t option` field for an Eio resource passed via config.

## Test plan

- [x] Local build: `dune build lib` exit=0, no errors involving `transport_codex_cli` (full local build blocked behind dune-local.sh global lock for ~1h+; per memory `feedback_masc_mcp_dune_local_lock_contention.md`, CI clean-env verification is the recommended fallback).
- [ ] CI green
- [ ] Downstream wiring in masc-mcp to actually engage the bound (separate PR)

## RFC

RFC-0022 (cascade attempt liveness) — incremental. No new RFC needed; `lib/llm_provider/*` is not in CLAUDE.md `agent_delegation` RFC-gated list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)