### PR TITLE
feat(transport_claude_code): expose stdout_idle_timeout_s on config

### DIFF
--- a/lib/llm_provider/transport_claude_code.ml
+++ b/lib/llm_provider/transport_claude_code.ml
@@ -26,6 +26,14 @@ type config =
     (* When [Some p] and [p] is resolved mid-run, the [claude]
        subprocess receives [SIGINT].  Applied to every call served
        by the transport instance.  Default [None]. *)
+  ; clock : float Eio.Time.clock_ty Eio.Resource.t option
+    (* Optional Eio clock used together with [stdout_idle_timeout_s]
+       to bound stdout silence.  Default [None]. *)
+  ; stdout_idle_timeout_s : float option
+    (* When [Some s] and [clock] is [Some _], the claude subprocess
+       is aborted via [SIGINT] if no stdout line arrives within [s]
+       seconds.  Wired into both [Cli_common_subprocess.run_collect]
+       and [Cli_common_subprocess.run_stream_lines].  Default [None]. *)
   }
 
 let default_config =
@@ -39,6 +47,8 @@ let default_config =
   ; tool_use_via_stream_json = true
   ; forward_tool_results = false
   ; cancel = None
+  ; clock = None
+  ; stdout_idle_timeout_s = None
   }
 ;;
 
@@ -635,6 +645,8 @@ let run ~sw ~mgr ~(config : config) ?stdin_content args =
   Cli_common_subprocess.run_collect
     ~sw
     ~mgr
+    ?clock:config.clock
+    ?stdout_idle_timeout_s:config.stdout_idle_timeout_s
     ~name:"claude"
     ~cwd:config.cwd
     ~extra_env:(subprocess_session_isolation_env ())
@@ -680,6 +692,8 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
             Cli_common_subprocess.run_stream_lines
               ~sw
               ~mgr
+              ?clock:config.clock
+              ?stdout_idle_timeout_s:config.stdout_idle_timeout_s
               ~name:"claude"
               ~cwd:config.cwd
               ~extra_env:(subprocess_session_isolation_env ())
@@ -742,6 +756,8 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
           Cli_common_subprocess.run_stream_lines
             ~sw
             ~mgr
+            ?clock:config.clock
+            ?stdout_idle_timeout_s:config.stdout_idle_timeout_s
             ~name:"claude"
             ~cwd:config.cwd
             ~extra_env:(subprocess_session_isolation_env ())

--- a/lib/llm_provider/transport_claude_code.mli
+++ b/lib/llm_provider/transport_claude_code.mli
@@ -44,6 +44,27 @@ type config =
         Default [None].
 
         @since 0.148.0 *)
+  ; clock : float Eio.Time.clock_ty Eio.Resource.t option
+    (** Optional Eio clock used together with
+        [stdout_idle_timeout_s] to bound subprocess silence.
+        Both must be [Some _] for the idle bound to engage —
+        see {!Cli_common_subprocess.run_collect} and
+        {!Cli_common_subprocess.run_stream_lines}.
+
+        Default [None].
+
+        @since 0.191.0 *)
+  ; stdout_idle_timeout_s : float option
+    (** When [Some s] and [clock] is [Some _], the [claude]
+        subprocess is aborted via [SIGINT] if no stdout line
+        arrives within [s] seconds.  Mirrors the kimi-cli idle
+        bound introduced for masc-mcp keeper turns in
+        masc-mcp PR #13894 (RFC-0022 attempt liveness); the
+        same field is wired here so OAS callers can opt-in.
+
+        Default [None].
+
+        @since 0.191.0 *)
   }
 
 (** Sensible defaults: [claude] in PATH, no overrides. *)


### PR DESCRIPTION
## Summary

Adds two opt-in fields to `Transport_claude_code.config`, mirroring [#1458](https://github.com/jeong-sik/oas/pull/1458) for `transport_codex_cli`:
- `clock : float Eio.Time.clock_ty Eio.Resource.t option`
- `stdout_idle_timeout_s : float option`

Threaded into all three `Cli_common_subprocess` call sites:
- `run` helper → `run_collect` (sync, `--output-format json`)
- `complete_sync` stream branch → `run_stream_lines`
- `complete_stream` → `run_stream_lines`

When both are `Some _`, the claude CLI subprocess is aborted via SIGINT if no stdout line arrives within the configured duration. Defaults `None` — no behavior change for existing callers.

## Why

Same gap closure as #1458 but for claude. masc-mcp PR [#13894](https://github.com/jeong-sik/masc-mcp/pull/13894) (RFC-0022 attempt liveness) introduced the idle bound for `Kimi_cli_transport_local` and explicitly noted:

> Transport_codex_cli, Transport_gemini_cli, Transport_claude_code (agent_sdk) do not yet expose stdout_idle_timeout_s in their config records — they need an OAS upstream PR before masc-mcp can plumb the same field through.

This PR closes the claude leg. After this and #1458 land, masc-mcp can plumb the kimi-style idle bound through both transports.

## Diff shape

```
lib/llm_provider/transport_claude_code.ml  | 16 ++++++++++++++++
lib/llm_provider/transport_claude_code.mli | 21 +++++++++++++++++++++
2 files changed, 37 insertions(+)
```

Pure additive. Pattern mirrors the existing `cancel : unit Eio.Promise.t option`.

## Test plan

- [x] Local build: `dune build lib` exit=0, no errors involving `transport_claude_code`. Full test run blocked behind dune-local.sh global lock; CI clean-env verification used as fallback per memory `feedback_masc_mcp_dune_local_lock_contention.md`.
- [ ] CI green
- [ ] Downstream wiring in masc-mcp (separate PR after both #1458 and this land)

## RFC

RFC-0022 (cascade attempt liveness) — incremental. No new RFC needed; `lib/llm_provider/*` is not in CLAUDE.md `agent_delegation` RFC-gated list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)