### PR TITLE
feat(transport_kimi_cli): expose stdout_idle_timeout_s on config

### DIFF
--- a/lib/llm_provider/transport_kimi_cli.ml
+++ b/lib/llm_provider/transport_kimi_cli.ml
@@ -13,6 +13,14 @@ type config =
   ; extra_env : (string * string) list
   ; cancel : unit Eio.Promise.t option
   ; session_id : string option
+  ; clock : float Eio.Time.clock_ty Eio.Resource.t option
+    (* Optional Eio clock used together with [stdout_idle_timeout_s]
+       to bound stdout silence.  Default [None]. *)
+  ; stdout_idle_timeout_s : float option
+    (* When [Some s] and [clock] is [Some _], the kimi subprocess
+       is aborted via [SIGINT] if no stdout line arrives within [s]
+       seconds.  Wired into [Cli_common_subprocess.run_stream_lines].
+       Default [None]. *)
   }
 
 let default_config =
@@ -26,6 +34,8 @@ let default_config =
   ; extra_env = []
   ; cancel = None
   ; session_id = None
+  ; clock = None
+  ; stdout_idle_timeout_s = None
   }
 ;;
 
@@ -438,6 +448,8 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
           Cli_common_subprocess.run_stream_lines
             ~sw
             ~mgr
+            ?clock:config.clock
+            ?stdout_idle_timeout_s:config.stdout_idle_timeout_s
             ~name:"kimi"
             ~cwd:config.cwd
             ~extra_env:config.extra_env
@@ -487,6 +499,8 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
             (Cli_common_subprocess.run_stream_lines
                ~sw
                ~mgr
+               ?clock:config.clock
+               ?stdout_idle_timeout_s:config.stdout_idle_timeout_s
                ~name:"kimi"
                ~cwd:config.cwd
                ~extra_env:config.extra_env

--- a/lib/llm_provider/transport_kimi_cli.mli
+++ b/lib/llm_provider/transport_kimi_cli.mli
@@ -43,6 +43,24 @@ type config =
         The transport then reuses the CLI's on-disk session state and sends
         only the message delta on later turns, which avoids re-transmitting
         the entire conversation history in session-reuse mode. Default [None]. *)
+  ; clock : float Eio.Time.clock_ty Eio.Resource.t option
+    (** Optional Eio clock used together with
+        [stdout_idle_timeout_s] to bound subprocess silence.
+        Both must be [Some _] for the idle bound to engage —
+        see {!Cli_common_subprocess.run_stream_lines}.
+
+        Default [None].
+
+        @since 0.191.0 *)
+  ; stdout_idle_timeout_s : float option
+    (** When [Some s] and [clock] is [Some _], the [kimi]
+        subprocess is aborted via [SIGINT] if no stdout line
+        arrives within [s] seconds.  Mirrors masc-mcp PR #13894
+        ([Kimi_cli_transport_local], RFC-0022 attempt liveness)
+        and oas PRs #1458 (codex_cli) / #1459 (claude_code).
+        Default [None].
+
+        @since 0.191.0 *)
   }
 
 (** Sensible defaults: [kimi] in PATH, [kimi-for-coding], no explicit


### PR DESCRIPTION
## Summary

Adds two opt-in fields to `Transport_kimi_cli.config`, mirroring [#1458](https://github.com/jeong-sik/oas/pull/1458) (codex_cli) and [#1459](https://github.com/jeong-sik/oas/pull/1459) (claude_code):
- `clock : float Eio.Time.clock_ty Eio.Resource.t option`
- `stdout_idle_timeout_s : float option`

Threaded into both `Cli_common_subprocess.run_stream_lines` call sites in `complete_sync` and `complete_stream`. When both are `Some _`, the kimi CLI subprocess is aborted via SIGINT if no stdout line arrives within the configured duration. Defaults `None` — no behavior change for existing callers.

## Why

masc-mcp PR [#13894](https://github.com/jeong-sik/masc-mcp/pull/13894) already wired this idle bound into masc-mcp's *local* `Kimi_cli_transport_local` (which calls `Cli_common_subprocess.run_*` directly, bypassing this transport). However `agent_sdk`'s `Transport_kimi_cli`, which other consumers may use, never exposed the field. With this PR all three CLI transports in `agent_sdk` (codex_cli, claude_code, kimi_cli) carry the same opt-in idle bound surface.

## Diff shape

```
lib/llm_provider/transport_kimi_cli.ml  | 14 ++++++++++++++
lib/llm_provider/transport_kimi_cli.mli | 18 ++++++++++++++++++
2 files changed, 32 insertions(+)
```

Pure additive. Pattern mirrors the existing `cancel : unit Eio.Promise.t option`.

## Test plan

- [x] Local build: `dune build lib` exit=0, no errors involving `transport_kimi_cli`. dune-local.sh global lock contention noted; CI clean-env verification used as fallback per memory `feedback_masc_mcp_dune_local_lock_contention.md`.
- [ ] CI green
- [ ] Downstream wiring (masc-mcp, after #1458/#1459 land — separate PR)

## RFC

RFC-0022 (cascade attempt liveness) — incremental. No new RFC needed; `lib/llm_provider/*` is not in CLAUDE.md `agent_delegation` RFC-gated list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)