### PR TITLE
feat(transport_gemini_cli): expose stdout_idle_timeout_s on config

### DIFF
--- a/lib/llm_provider/transport_gemini_cli.ml
+++ b/lib/llm_provider/transport_gemini_cli.ml
@@ -23,6 +23,14 @@ type config =
   ; cancel : unit Eio.Promise.t option
     (* When [Some p] and [p] resolves mid-run, the [gemini]
        subprocess receives [SIGINT].  Default [None]. *)
+  ; clock : float Eio.Time.clock_ty Eio.Resource.t option
+    (* Optional Eio clock used together with [stdout_idle_timeout_s]
+       to bound stdout silence.  Default [None]. *)
+  ; stdout_idle_timeout_s : float option
+    (* When [Some s] and [clock] is [Some _], the gemini subprocess
+       is aborted via [SIGINT] if no stdout line arrives within [s]
+       seconds.  Wired into [Cli_common_subprocess.run_collect].
+       Default [None]. *)
   }
 
 let default_config =
@@ -35,6 +43,8 @@ let default_config =
   ; max_turns = None
   ; permission_mode = None
   ; cancel = None
+  ; clock = None
+  ; stdout_idle_timeout_s = None
   }
 ;;
 
@@ -434,6 +444,8 @@ let run ~sw ~mgr ~(config : config) ?model argv =
     Cli_common_subprocess.run_collect
       ~sw
       ~mgr
+      ?clock:config.clock
+      ?stdout_idle_timeout_s:config.stdout_idle_timeout_s
       ~name:"gemini"
       ~cwd:config.cwd
       ~extra_env:[]

--- a/lib/llm_provider/transport_gemini_cli.mli
+++ b/lib/llm_provider/transport_gemini_cli.mli
@@ -37,6 +37,26 @@ type config =
         Default [None].
 
         @since 0.148.0 *)
+  ; clock : float Eio.Time.clock_ty Eio.Resource.t option
+    (** Optional Eio clock used together with
+        [stdout_idle_timeout_s] to bound subprocess silence.
+        Both must be [Some _] for the idle bound to engage —
+        see {!Cli_common_subprocess.run_collect}.
+
+        Default [None].
+
+        @since 0.191.0 *)
+  ; stdout_idle_timeout_s : float option
+    (** When [Some s] and [clock] is [Some _], the [gemini]
+        subprocess is aborted via [SIGINT] if no stdout line
+        arrives within [s] seconds.  Mirrors masc-mcp PR #13894
+        ([Kimi_cli_transport_local], RFC-0022 attempt liveness)
+        and oas PRs #1458 (codex_cli) / #1459 (claude_code) /
+        #1460 (kimi_cli).
+
+        Default [None].
+
+        @since 0.191.0 *)
   }
 
 (** Sensible defaults: [gemini] in PATH, yolo enabled, no overrides. *)


### PR DESCRIPTION
## Summary

Adds two opt-in fields to `Transport_gemini_cli.config`, completing the agent_sdk CLI transport idle-bound surface:
- `clock : float Eio.Time.clock_ty Eio.Resource.t option`
- `stdout_idle_timeout_s : float option`

Threaded into the single `Cli_common_subprocess.run_collect` call site that backs Gemini's sync (`--output-format json`) flow.

## Surface complete

After this PR all four agent_sdk CLI transports carry the same opt-in idle bound:

| Transport | PR | Plumb sites |
|-----------|-----|------------|
| codex_cli | [#1458](https://github.com/jeong-sik/oas/pull/1458) | 2 × run_stream_lines |
| claude_code | [#1459](https://github.com/jeong-sik/oas/pull/1459) | 1 × run_collect + 2 × run_stream_lines |
| kimi_cli | [#1460](https://github.com/jeong-sik/oas/pull/1460) | 2 × run_stream_lines |
| **gemini_cli** | **this** | 1 × run_collect |

## Correction

Prior PR bodies on #1458/#1459/#1460 incorrectly described `transport_gemini_cli` as "HTTP-shaped" and out of scope. Re-reading `lib/llm_provider/transport_gemini_cli.ml` shows it is also subprocess-based — `run_collect` at L434. This PR corrects that.

## Diff shape

```
lib/llm_provider/transport_gemini_cli.ml  | 12 ++++++++++++
lib/llm_provider/transport_gemini_cli.mli | 20 ++++++++++++++++++++
2 files changed, 32 insertions(+)
```

## Test plan

- [x] Local build: `dune build lib` exit=0, no errors involving `transport_gemini_cli`. dune-local.sh global lock contention noted; CI clean-env verification used as fallback.
- [ ] CI green (Draft → ready_for_review when human approves)
- [ ] Downstream wiring (masc-mcp, after all 4 land — separate PR)

## RFC

RFC-0022 (cascade attempt liveness) — incremental. No new RFC needed; `lib/llm_provider/*` is not in CLAUDE.md `agent_delegation` RFC-gated list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)