### PR TITLE
chore(boundary): neutralize coordinator vocabulary in OAS test fixtures

### DIFF
--- a/scripts/check-sdk-independence.sh
+++ b/scripts/check-sdk-independence.sh
@@ -1,18 +1,45 @@
 #!/usr/bin/env bash
 # Guard OAS against coordinator-specific vocabulary in public/runtime surfaces.
+#
+# Tiers:
+#   strict  (default): lib/, bin/, README.md — any match fails the build.
+#   warn    (--include-tests): also scan test/. Matches are reported but exit 0.
+#                              Use --strict-tests to promote warn-tier matches to failures.
+#
+# Permanently excluded: docs/archive/, CHANGELOG.md, docs/rfc/, examples/
+# (history records and design RFCs may legitimately mention prior coordinator names).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-TARGETS=(lib bin README.md)
+include_tests=0
+strict_tests=0
+for arg in "$@"; do
+  case "$arg" in
+    --include-tests) include_tests=1 ;;
+    --strict-tests)  include_tests=1; strict_tests=1 ;;
+    -h|--help)
+      sed -n '1,12p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown flag: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
 
 if ! command -v rg >/dev/null 2>&1; then
   echo "SDK independence check failed: ripgrep (rg) is required" >&2
   exit 1
 fi
 
-patterns=(
+STRICT_TARGETS=(lib bin README.md)
+WARN_TARGETS=(test)
+
+# Strict tier: full coordinator vocabulary (lib/, bin/, README.md).
+strict_patterns=(
   '\bmasc\b'
   'masc_'
   '\bkeeper\b'
@@ -23,17 +50,82 @@ patterns=(
   'room_'
 )
 
-fail=0
-for pattern in "${patterns[@]}"; do
-  matches="$(rg -n -i -e "$pattern" "${TARGETS[@]}" || true)"
-  if [[ -n "$matches" ]]; then
-    echo "FAIL: coordinator-specific term matched pattern: $pattern" >&2
-    echo "$matches" >&2
-    fail=1
-  fi
-done
+# Warn tier: narrowed to high-signal terms only.
+# `room` and `board` collide with common test vocabulary (schema parameter
+# names, JSON keys, "no room", "scoreboard", etc.) and produce too many
+# false positives in test/. Keep them strict-only.
+warn_patterns=(
+  '\bmasc\b'
+  'masc_'
+  '\bkeeper\b'
+  'keeper_'
+)
 
-if [[ "$fail" -ne 0 ]]; then
+# Filter out:
+#   - lines explicitly tagged with `boundary-allow` (intentional historical references)
+#   - OCaml comment lines that start with "(*", "*", or "(**"  (left-trimmed)
+# Caveat: this is a line-level heuristic, not a full OCaml lexer. A code line
+# containing an inline `(* ... *)` whose pattern sits inside the comment may
+# slip through. Use `boundary-allow` for those edge cases.
+filter_noise() {
+  awk -F':' '
+    {
+      idx = index($0, ":")
+      rest = substr($0, idx + 1)
+      idx2 = index(rest, ":")
+      content = substr(rest, idx2 + 1)
+      # left-trim
+      sub(/^[[:space:]]+/, "", content)
+      # OCaml comment heuristics
+      if (content ~ /^\*/) next
+      if (content ~ /^\(\*/) next
+      # explicit allow marker
+      if ($0 ~ /boundary-allow/) next
+      print $0
+    }
+  '
+}
+
+scan_tier() {
+  local tier="$1"; shift
+  local fail_on_match="$1"; shift
+  # bash 3.2 (macOS default) lacks `local -n` nameref. Use indirect array
+  # expansion via eval to read the patterns array by name.
+  local patterns_var="$1"; shift
+  local targets=("$@")
+  local patterns_arr=()
+  eval "patterns_arr=( \"\${${patterns_var}[@]}\" )"
+  local tier_fail=0
+  for pattern in "${patterns_arr[@]}"; do
+    local matches
+    matches="$(rg -n -i -e "$pattern" "${targets[@]}" 2>/dev/null | filter_noise || true)"
+    if [[ -n "$matches" ]]; then
+      if [[ "$fail_on_match" -eq 1 ]]; then
+        echo "FAIL [$tier]: coordinator-specific term matched pattern: $pattern" >&2
+      else
+        echo "WARN [$tier]: coordinator-specific term matched pattern: $pattern" >&2
+      fi
+      echo "$matches" >&2
+      tier_fail=1
+    fi
+  done
+  return "$tier_fail"
+}
+
+overall_fail=0
+if ! scan_tier "strict" 1 strict_patterns "${STRICT_TARGETS[@]}"; then
+  overall_fail=1
+fi
+
+if [[ "$include_tests" -eq 1 ]]; then
+  if ! scan_tier "test" "$strict_tests" warn_patterns "${WARN_TARGETS[@]}"; then
+    if [[ "$strict_tests" -eq 1 ]]; then
+      overall_fail=1
+    fi
+  fi
+fi
+
+if [[ "$overall_fail" -ne 0 ]]; then
   echo "SDK independence check failed" >&2
   exit 1
 fi

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -555,13 +555,13 @@ let test_is_idle_exact_distinguishes_inputs () =
 ;;
 
 let test_is_idle_name_only_collapses_inputs () =
-  let a = [ fp "masc_status" {|{"token":"x"}|} ] in
-  let b = [ fp "masc_status" {|{"token":"y"}|} ] in
+  let a = [ fp "mock_tool_alpha" {|{"token":"x"}|} ] in
+  let b = [ fp "mock_tool_alpha" {|{"token":"y"}|} ] in
   Alcotest.(check bool)
     "Name_only: same name, different input -> idle"
     true
     (Agent_turn.is_idle ~granularity:Agent_turn.Name_only (Some a) b);
-  let c = [ fp "masc_heartbeat" {|{"token":"x"}|} ] in
+  let c = [ fp "mock_tool_beta" {|{"token":"x"}|} ] in
   Alcotest.(check bool)
     "Name_only: different name -> not idle"
     false
@@ -569,8 +569,8 @@ let test_is_idle_name_only_collapses_inputs () =
 ;;
 
 let test_is_idle_name_and_subset_placeholder_matches_name_only () =
-  let a = [ fp "masc_status" {|{"token":"x","verbose":true}|} ] in
-  let b = [ fp "masc_status" {|{"token":"y","verbose":false}|} ] in
+  let a = [ fp "mock_tool_alpha" {|{"token":"x","verbose":true}|} ] in
+  let b = [ fp "mock_tool_alpha" {|{"token":"y","verbose":false}|} ] in
   (* Placeholder semantics: keys list is currently ignored; behaves
      as Name_only. Locking this in a test so future leaves that wire
      up real subset matching will break loudly here. *)

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -950,7 +950,7 @@ let test_message_to_json_ignores_metadata () =
     ; name = Some "assistant"
     ; tool_call_id = Some "call_1"
     ; metadata =
-        [ ( "masc.replay"
+        [ ( "replay.namespace"
           , `Assoc
               [ "kind", `String "state_snapshot"
               ; "version", `Int 1

--- a/test/test_atomic_write_race.ml
+++ b/test/test_atomic_write_race.ml
@@ -5,7 +5,7 @@
     tmp path. Afterwards the target contains exactly one writer's
     bytes and no stray tmp sibling is left behind.
 
-    Reference: masc-mcp#9780 — two fibers wrote to "<id>.json.tmp"
+    Reference: masc-mcp#9780 (boundary-allow) — two fibers wrote to "<id>.json.tmp"
     and the second fiber's [rename] blew up when the first already
     consumed the shared tmp.
 

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -524,7 +524,7 @@ let test_gemini_stream_finish () =
 ;;
 
 (* NOTE: test_cascade_gemini_kind was removed — Cascade_config.parse_model_string
-   was deleted from OAS in 0.144.0 as part of the MASC migration. *)
+   was deleted from OAS in 0.144.0 as part of the MASC migration (boundary-allow). *)
 
 let test_gemini_capabilities_named () =
   let caps = Capabilities.gemini_capabilities in

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -299,7 +299,7 @@ let () =
             check int "2 blocks in first" 2 (List.length first.content))
         ; test_case "message metadata roundtrip" `Quick (fun () ->
             let replay_metadata =
-              [ ( "masc.replay"
+              [ ( "replay.namespace"
                 , `Assoc
                     [ "kind", `String "state_snapshot"
                     ; "version", `Int 1
@@ -310,7 +310,7 @@ let () =
             let msgs =
               [ { Types.role = Types.Assistant
                 ; content = [ Types.Text "Visible reply" ]
-                ; name = Some "keeper"
+                ; name = Some "agent_role_a"
                 ; tool_call_id = Some "call_1"
                 ; metadata = replay_metadata
                 }
@@ -320,7 +320,7 @@ let () =
             let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
             match cp2.messages with
             | [ msg ] ->
-              check (option string) "name" (Some "keeper") msg.name;
+              check (option string) "name" (Some "agent_role_a") msg.name;
               check (option string) "tool_call_id" (Some "call_1") msg.tool_call_id;
               check
                 string

--- a/test/test_checkpoint_delta.ml
+++ b/test/test_checkpoint_delta.ml
@@ -400,7 +400,7 @@ let test_empty_delta_roundtrip () =
 
 let test_delta_roundtrip_preserves_message_metadata () =
   let replay_metadata =
-    [ ( "masc.replay"
+    [ ( "replay.namespace"
       , `Assoc
           [ "kind", `String "state_snapshot"
           ; "version", `Int 1
@@ -431,7 +431,7 @@ let test_delta_roundtrip_preserves_message_metadata () =
           }
         ; { role = Assistant
           ; content = [ Text "done" ]
-          ; name = Some "keeper"
+          ; name = Some "agent_role_a"
           ; tool_call_id = Some "call_1"
           ; metadata = replay_metadata
           }
@@ -445,7 +445,7 @@ let test_delta_roundtrip_preserves_message_metadata () =
   | Ok rebuilt ->
     (match rebuilt.messages with
      | _ :: [ assistant ] ->
-       Alcotest.(check (option string)) "name" (Some "keeper") assistant.name;
+       Alcotest.(check (option string)) "name" (Some "agent_role_a") assistant.name;
        Alcotest.(check (option string))
          "tool_call_id"
          (Some "call_1")

--- a/test/test_eio_cancellability.ml
+++ b/test/test_eio_cancellability.ml
@@ -12,11 +12,11 @@
     intact across four scenarios.  This test ports those reproducers
     so a future Eio/cohttp-eio dependency bump that breaks cancellation
     fails CI immediately, instead of silently regressing into 3585s
-    keeper hangs in masc-mcp.
+    keeper hangs in masc-mcp. boundary-allow: cross-repo regression context.
 
     Cross-ref: planning/claude-plans/oas-execution-cancellability.md
                 (in jeong-sik/me) — falsified self-confession comment in
-                masc-mcp [keeper_llm_bridge.ml:35-39].
+                masc-mcp [keeper_llm_bridge.ml:35-39]. boundary-allow.
 
     All four cases use a 2.0s timeout budget; overshoot must stay under
     [overshoot_tolerance_s].  CI jitter is bounded by [tolerance];

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -217,8 +217,8 @@ let test_default_retry_config () =
 ;;
 
 (* NOTE: Cascade_config (parse_model_string, load_profile, etc.) was removed
-   from OAS in 0.144.0 as part of the MASC migration. Multi-provider cascade
-   configuration and group orchestration are now MASC-owned. Tests for that
+   from OAS in 0.144.0 as part of the MASC migration (boundary-allow). Multi-provider cascade
+   configuration and group orchestration are now MASC-owned (boundary-allow). Tests for that
    module have been archived. *)
 
 (* ═══════════════════════════════════════════════════
@@ -1378,7 +1378,7 @@ let test_glm_capabilities () =
      tool_choice contract to [Allow_text_or_tool] and a text response is
      accepted instead of raising [CompletionContractViolation].
      Regression guard added after 2026-04-18 incident (8+ violations in
-     a single MASC session against glm-5-turbo / glm-4.7 / glm-5.1). *)
+     a single MASC session against glm-5-turbo / glm-4.7 / glm-5.1) (boundary-allow). *)
   Alcotest.(check bool) "supports_tool_choice relaxed" false c.supports_tool_choice;
   Alcotest.(check bool) "structured output disabled" false c.supports_structured_output;
   Alcotest.(check (option int)) "200K context" (Some 200_000) c.max_context_tokens;

--- a/test/test_mcp_session.ml
+++ b/test/test_mcp_session.ml
@@ -130,12 +130,12 @@ let () =
             check int "beta tools" 1 (List.length (List.nth infos2 1).tool_schemas))
         ; test_case "http info roundtrip" `Quick (fun () ->
             let info : Mcp_session.info =
-              { server_name = "masc"
+              { server_name = "upstream"
               ; command = "http"
               ; args = []
               ; env = []
               ; http_base_url = Some "http://127.0.0.1:8935/mcp"
-              ; http_headers = [ "Authorization", "Bearer tok"; "X-MASC-Agent", "codex" ]
+              ; http_headers = [ "Authorization", "Bearer tok"; "X-Coordinator-Client", "codex" ]
               ; tool_schemas = [ sample_tool_schema ]
               ; transport_kind = Http
               }

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -468,14 +468,14 @@ let mk_config_for_kind kind =
   Provider_config.make ~kind ~model_id:"test" ~base_url ()
 ;;
 
-(** Regression guard for the masc-mcp capability-lookup bug fixed in
-    masc-mcp#9306. That bug passed [Provider_adapter.string_of_provider_kind]
-    (masc canonical_name: "claude-api", "kimi-api", "codex-api", ...) to
+(** Regression guard for the masc-mcp capability-lookup bug (boundary-allow) fixed in
+    masc-mcp#9306 (boundary-allow). That bug passed [Provider_adapter.string_of_provider_kind]
+    (masc canonical_name: "claude-api", ...) (boundary-allow) to
     [Provider_registry.find], but the registry is keyed on the names
     returned by [Provider_registry.provider_name_of_config] ("claude",
     "kimi", "llama", "ollama", "claude_code", "gemini_cli", ...). For
     direct-API kinds the lookup silently fell back to
-    [default_capabilities]; for CLI kinds the masc vocabulary happened
+    [default_capabilities]; for CLI kinds the masc vocabulary (boundary-allow) happened
     to match direct-API entries ("claude" → Anthropic, "gemini" → Gemini,
     "kimi" → Kimi) and returned the wrong capability matrix.
 
@@ -513,7 +513,7 @@ let test_every_kind_resolves_in_registry () =
 ;;
 
 (** Sharper assertion for the two CLI kinds that were the primary
-    wrong-hit victims in masc-mcp#9306: assert their registry entries
+    wrong-hit victims in masc-mcp#9306 (boundary-allow): assert their registry entries
     are CLI-shaped, not direct-API-shaped. If a regression reverts
     [provider_name_of_config Claude_code] back to ["claude"], this
     test fails because the resolved entry's [defaults.kind] will be

--- a/test/test_tool_use_recovery.ml
+++ b/test/test_tool_use_recovery.ml
@@ -53,11 +53,11 @@ let test_find_object_none () =
 let test_extract_anthropic_style () =
   let json =
     `Assoc
-      [ "name", `String "keeper_board_post"; "input", `Assoc [ "title", `String "hi" ] ]
+      [ "name", `String "mock_tool_post"; "input", `Assoc [ "title", `String "hi" ] ]
   in
   match TUR.extract_name_and_input json with
   | Some (name, input) ->
-    check string "name" "keeper_board_post" name;
+    check string "name" "mock_tool_post" name;
     check
       (option string)
       "title"


### PR DESCRIPTION
## Context

Part of the OAS ↔ masc-mcp boundary cleanup planned in
`~/me/planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-oas-crispy-oasis.md`
(PR-1 of 3).

OAS documents itself as coordinator-agnostic (`README.md`, `CLAUDE.md`,
`scripts/check-sdk-independence.sh`), but `test/` still embedded
masc-mcp specific identifiers in mock fixtures and message metadata.
Those identifiers were never enforced as cross-repo contracts (verified
by direct grep against masc-mcp `lib/`), so neutralizing them does not
require coordination with the consumer side.

A separate finding — that masc-mcp's production HTTP headers
(`X-MASC-Agent`, `x-masc-agent-name`) and stored checkpoint metadata key
(`masc.replay`) are real external contracts referenced from 16+ sites in
masc-mcp `lib/` (auth, transport, dashboard, runtime bootstrap) — is
intentionally **out of scope** here. Those need a phased migration plan
(alias period → client migration → cleanup), tracked in a follow-up RFC.

## Changes

**Test fixture neutralization** (5 files, real code):
- `test_agent_turn.ml`: `masc_status`/`masc_heartbeat` → `mock_tool_alpha`/`mock_tool_beta`
- `test_checkpoint.ml`, `test_checkpoint_delta.ml`: `Some \"keeper\"` → `Some \"agent_role_a\"`; `\"masc.replay\"` → `\"replay.namespace\"`
- `test_api.ml`: `\"masc.replay\"` → `\"replay.namespace\"`
- `test_mcp_session.ml`: `server_name = \"masc\"` → `\"upstream\"`; `X-MASC-Agent` → `X-Coordinator-Client`
- `test_tool_use_recovery.ml`: `\"keeper_board_post\"` → `\"mock_tool_post\"`

**Historical-comment preservation** (5 files): inline `(boundary-allow)`
markers added to long-standing migration/incident comments so the new
guard can pass `--strict-tests` while keeping the historical context.

**Guard script extension** (`scripts/check-sdk-independence.sh`):
- 2-tier design: strict (lib/, bin/, README.md) + warn (test/)
- Flags: `--include-tests` (informational) and `--strict-tests` (fail on test/ matches)
- bash 3.2 compatible (eval-based array indirection instead of `local -n`)
- Filter heuristics: skip OCaml comment-leading lines (`*`, `(*`) and any line tagged with `boundary-allow`
- Warn tier patterns narrowed to `masc*`/`keeper*` only — `room`/`board` are common words in test schemas (parameter names, JSON keys) and produced too many false positives

## Test plan

- [x] `bash scripts/check-sdk-independence.sh` passes (strict)
- [x] `bash scripts/check-sdk-independence.sh --include-tests` exits 0 (informational)
- [x] `bash scripts/check-sdk-independence.sh --strict-tests` passes
- [x] `dune build test/` succeeds
- [x] All 6 affected test executables pass (204 tests total):
  - test_agent_turn (46), test_checkpoint (53), test_checkpoint_delta (11)
  - test_api (65), test_mcp_session (15), test_tool_use_recovery (14)
- [ ] CI green