### PR TITLE
chore(boundary): restore SDK independence after transport+cognitive_event merges

### DIFF
--- a/lib/cognitive_event.mli
+++ b/lib/cognitive_event.mli
@@ -2,11 +2,12 @@
     Master Report transport schema).
 
     A typed, JSON-codecable enumeration of the cognitive events that
-    the host (masc-mcp) emits when its cognitive layer fires
-    (gravity ranking, intent prediction, mode transition, disclosure
-    level change). The SDK does not produce these events itself in
-    this PR; the type lives here so both the host emitter and any
-    future SDK-side consumer (Hooks, Tracing) share a single schema.
+    a downstream coordinator host (boundary-allow: e.g. masc-mcp)
+    emits when its cognitive layer fires (gravity ranking, intent
+    prediction, mode transition, disclosure level change). The SDK
+    does not produce these events itself in this PR; the type lives
+    here so both the host emitter and any future SDK-side consumer
+    (Hooks, Tracing) share a single schema.
 
     Design choices:
 

--- a/lib/llm_provider/transport_claude_code.mli
+++ b/lib/llm_provider/transport_claude_code.mli
@@ -58,9 +58,10 @@ type config =
     (** When [Some s] and [clock] is [Some _], the [claude]
         subprocess is aborted via [SIGINT] if no stdout line
         arrives within [s] seconds.  Mirrors the kimi-cli idle
-        bound introduced for masc-mcp keeper turns in
-        masc-mcp PR #13894 (RFC-0022 attempt liveness); the
-        same field is wired here so OAS callers can opt-in.
+        bound introduced for long-running coordinator turns
+        (boundary-allow: see masc-mcp #13894 for original RFC-0022
+        attempt-liveness context); the same field is wired here so
+        OAS callers can opt-in.
 
         Default [None].
 

--- a/lib/llm_provider/transport_codex_cli.mli
+++ b/lib/llm_provider/transport_codex_cli.mli
@@ -55,9 +55,10 @@ type config =
     (** When [Some s] and [clock] is [Some _], the [codex]
         subprocess is aborted via [SIGINT] if no stdout line
         arrives within [s] seconds.  Mirrors the kimi-cli idle
-        bound introduced for masc-mcp keeper turns in
-        masc-mcp PR #13894 (RFC-0022 attempt liveness); the
-        same field is wired here so OAS callers can opt-in.
+        bound introduced for long-running coordinator turns
+        (boundary-allow: see masc-mcp #13894 for original RFC-0022
+        attempt-liveness context); the same field is wired here so
+        OAS callers can opt-in.
 
         Default [None].
 

--- a/lib/llm_provider/transport_gemini_cli.mli
+++ b/lib/llm_provider/transport_gemini_cli.mli
@@ -49,10 +49,10 @@ type config =
   ; stdout_idle_timeout_s : float option
     (** When [Some s] and [clock] is [Some _], the [gemini]
         subprocess is aborted via [SIGINT] if no stdout line
-        arrives within [s] seconds.  Mirrors masc-mcp PR #13894
-        ([Kimi_cli_transport_local], RFC-0022 attempt liveness)
-        and oas PRs #1458 (codex_cli) / #1459 (claude_code) /
-        #1460 (kimi_cli).
+        arrives within [s] seconds.  Mirrors the kimi-cli idle
+        bound (boundary-allow: external-coordinator origin masc-mcp #13894,
+        RFC-0022 attempt liveness) and oas PRs #1458
+        (codex_cli) / #1459 (claude_code) / #1460 (kimi_cli).
 
         Default [None].
 

--- a/lib/llm_provider/transport_kimi_cli.mli
+++ b/lib/llm_provider/transport_kimi_cli.mli
@@ -55,9 +55,10 @@ type config =
   ; stdout_idle_timeout_s : float option
     (** When [Some s] and [clock] is [Some _], the [kimi]
         subprocess is aborted via [SIGINT] if no stdout line
-        arrives within [s] seconds.  Mirrors masc-mcp PR #13894
-        ([Kimi_cli_transport_local], RFC-0022 attempt liveness)
-        and oas PRs #1458 (codex_cli) / #1459 (claude_code).
+        arrives within [s] seconds.  External-coordinator origin
+        (boundary-allow: masc-mcp #13894, [Kimi_cli_transport_local],
+        RFC-0022 attempt liveness) and oas PRs #1458 (codex_cli) /
+        #1459 (claude_code).
         Default [None].
 
         @since 0.191.0 *)


### PR DESCRIPTION
## Context

Recent merges (transport CLI timeout group: #1458/1459/1460/1461; cognitive event: #1451) left coordinator-specific terminology in `lib/` doc comments — `masc-mcp keeper turns`, `masc-mcp PR #13894`, `the host (masc-mcp) emits` — which trips the strict tier of `scripts/check-sdk-independence.sh` (the SSOT introduced by #1462).

Asked main directly:

```
$ bash scripts/check-sdk-independence.sh
FAIL [strict]: \bmasc\b
  lib/llm_provider/transport_codex_cli.mli:58-59
  lib/llm_provider/transport_claude_code.mli:61-62
  lib/llm_provider/transport_gemini_cli.mli:52
  lib/llm_provider/transport_kimi_cli.mli:58
  lib/cognitive_event.mli:5
FAIL [strict]: \bkeeper\b
  lib/llm_provider/transport_codex_cli.mli:58
  lib/llm_provider/transport_claude_code.mli:61
SDK independence check failed
```

## Root cause

The SDK Independence Gate runs in CI (`.github/workflows/ci.yml:245-258`) but was **not in the required-status-checks list** on `main`. Branch protection currently requires only `Lint` and `Build & Test (OCaml 5.4.1)`, so a failing gate informational-fails without blocking merge — the recent PRs slipped through.

A follow-up should promote `SDK Independence Gate` to a required check. This PR addresses the leak itself.

## Approach

Doc comments are kept readable and the masc-mcp issue/PR references are preserved for traceability, but the coordinator vocabulary is generalized:
- `masc-mcp keeper turns` → `long-running coordinator turns`
- `the host (masc-mcp) emits` → `a downstream coordinator host (boundary-allow: e.g. masc-mcp) emits`
- `Mirrors masc-mcp PR #13894` → `... (boundary-allow: external-coordinator origin masc-mcp #13894, RFC-0022 attempt liveness)`

Lines that still name `masc-mcp` for traceability carry an inline `(boundary-allow: …)` marker which the guard's `filter_noise` heuristic recognizes as intentional — same pattern as #1462.

## Files

- `lib/llm_provider/transport_codex_cli.mli`
- `lib/llm_provider/transport_claude_code.mli`
- `lib/llm_provider/transport_gemini_cli.mli`
- `lib/llm_provider/transport_kimi_cli.mli`
- `lib/cognitive_event.mli`

`+22 / -18` (doc-only changes; no type signature change, no semantic change).

## Test plan

- [x] `bash scripts/check-sdk-independence.sh` passes (strict)
- [x] `bash scripts/check-sdk-independence.sh --strict-tests` passes
- [ ] CI green
- [ ] (Follow-up PR) Promote `SDK Independence Gate` to a required status check on `main`