### PR TITLE
[Audit] TLA+ CI gate + AgentCancellation.tla + lifecycle_status yojson

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,55 @@ jobs:
 
           echo "Version consistency check passed: $DUNE_VER"
 
+  tla-model-check:
+    name: TLA+ Model Check
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Download TLC
+        run: |
+          wget -q https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
+          ls -la tla2tools.jar
+
+      - name: Run clean TLA+ specs
+        run: |
+          for spec in AgentLifecycle ContentReplacementState ContextWindowExhaustion EventBusCausality; do
+            echo "::group::TLC $spec (clean)"
+            java -cp tla2tools.jar tlc2.TLC -config "specs/${spec}.cfg" "specs/${spec}.tla"
+            echo "::endgroup::"
+          done
+
+      - name: Verify Bug Model (buggy variants should fail)
+        run: |
+          check_buggy() {
+            local cfg="$1"
+            local tla="$2"
+            echo "::group::TLC $(basename "$cfg") (buggy — expect violation)"
+            if java -cp tla2tools.jar tlc2.TLC -config "$cfg" "$tla" 2>&1 | tee /tmp/tlc-buggy.log | grep -q "is violated"; then
+              echo "✓ Buggy variant $(basename "$cfg") correctly violates invariant"
+            else
+              echo "✗ Buggy variant $(basename "$cfg") did not violate expected invariant"
+              cat /tmp/tlc-buggy.log
+              exit 1
+            fi
+            echo "::endgroup::"
+          }
+          check_buggy specs/AgentLifecycle-buggy.cfg specs/AgentLifecycle.tla
+          check_buggy specs/ContentReplacementState-buggy.cfg specs/ContentReplacementState.tla
+          check_buggy specs/ContextWindowExhaustion-buggy.cfg specs/ContextWindowExhaustion.tla
+          check_buggy specs/EventBusCausality-buggy.cfg specs/EventBusCausality.tla
+
   transport-drift:
     name: Transport Drift Gate
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}

--- a/lib/agent/agent_lifecycle.ml
+++ b/lib/agent/agent_lifecycle.ml
@@ -10,7 +10,7 @@ type lifecycle_status =
   | Running
   | Completed
   | Failed
-[@@deriving show]
+[@@deriving show, yojson]
 
 (* ── Transition guards ─────────────────────────── *)
 

--- a/lib/agent/agent_lifecycle.mli
+++ b/lib/agent/agent_lifecycle.mli
@@ -28,7 +28,7 @@ type lifecycle_status =
   | Running
   | Completed
   | Failed
-[@@deriving show]
+[@@deriving show, yojson]
 
 (** {1 Transition guards} *)
 

--- a/specs/AgentCancellation-buggy.cfg
+++ b/specs/AgentCancellation-buggy.cfg
@@ -1,0 +1,8 @@
+\* Bug model: BugCancelledResurrection forces Cancelled -> Running.
+\* TerminalIsStable SHOULD be violated.
+SPECIFICATION SpecBuggy
+CONSTANTS
+    MaxTurns = 3
+INVARIANT TypeOK
+INVARIANT TerminalIsStableMustHold
+CHECK_DEADLOCK FALSE

--- a/specs/AgentCancellation.cfg
+++ b/specs/AgentCancellation.cfg
@@ -1,0 +1,13 @@
+\* Clean model: MaxTurns=3, no illegal transitions.
+\* All safety invariants should hold.
+SPECIFICATION Spec
+CONSTANTS
+    MaxTurns = 3
+INVARIANT TypeOK
+INVARIANT PrevNotEqualPhase
+INVARIANT TerminalIsStable
+INVARIANT NoIllegalTransition
+INVARIANT CancelledIsTerminal
+INVARIANT CancelledRequiresNonTerminal
+INVARIANT NoTransitionIntoBootstrapping
+CHECK_DEADLOCK FALSE

--- a/specs/AgentCancellation.tla
+++ b/specs/AgentCancellation.tla
@@ -1,0 +1,154 @@
+---- MODULE AgentCancellation ----
+\* Models Runtime.phase cancellation semantics.
+\*
+\* Addresses the "Cancelled dilemma": Runtime.phase has 7 states including
+\* Cancelled, but AgentLifecycle.tla (5 states) explicitly declines to model
+\* cancellation.  This spec closes that gap.
+\*
+\* States:
+\*   Bootstrapping, Running, Waiting_on_workers, Finalizing,
+\*   Completed, Failed, Cancelled
+\*
+\* Allowed transitions (inferred from runtime_projection.ml apply_event
+\* and ensure_active_phase semantics):
+\*   Bootstrapping      -> Running | Failed | Cancelled
+\*   Running            -> Waiting_on_workers | Finalizing | Completed | Failed | Cancelled
+\*   Waiting_on_workers -> Running | Finalizing | Failed | Cancelled
+\*   Finalizing         -> Completed | Failed | Cancelled
+\*   Completed          -> (terminal)
+\*   Failed             -> (terminal)
+\*   Cancelled          -> (terminal)
+\*
+\* Cancellation is triggered by Eio.Cancel.Cancelled and is terminal.
+\* Recovery from Cancelled is NOT modeled — consistent with Eio.Switch
+\* semantics where cancellation is final (guardrail_tripwire.ml:45).
+\*
+\* @since (issue #1212 follow-up)
+
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+    MaxTurns        \* Bound on Bootstrapping->Running cycles
+
+VARIABLES
+    phase,          \* Current runtime phase
+    prev_phase,     \* Phase that immediately preceded `phase`
+    turn_count      \* Number of completed Bootstrapping->Running cycles
+
+vars == <<phase, prev_phase, turn_count>>
+
+States       == {"Bootstrapping", "Running", "Waiting_on_workers", "Finalizing", "Completed", "Failed", "Cancelled"}
+StatesOrNone == States \cup {"None"}
+
+NonTerminal == {"Bootstrapping", "Running", "Waiting_on_workers", "Finalizing"}
+Terminal    == {"Completed", "Failed", "Cancelled"}
+
+TypeOK ==
+    /\ phase \in States
+    /\ prev_phase \in StatesOrNone
+    /\ turn_count \in 0..MaxTurns
+
+\* ── Helpers ──────────────────────────────────
+IsTerminal(s) == s \in Terminal
+
+\* Allowed next-state set per runtime semantics.
+AllowedNext(s) ==
+    CASE s = "Bootstrapping"      -> {"Running", "Failed", "Cancelled"}
+      [] s = "Running"            -> {"Waiting_on_workers", "Finalizing", "Completed", "Failed", "Cancelled"}
+      [] s = "Waiting_on_workers" -> {"Running", "Finalizing", "Failed", "Cancelled"}
+      [] s = "Finalizing"         -> {"Completed", "Failed", "Cancelled"}
+      [] s = "Completed"          -> {}
+      [] s = "Failed"             -> {}
+      [] s = "Cancelled"          -> {}
+
+\* ── Initial state ────────────────────────────
+Init ==
+    /\ phase = "Bootstrapping"
+    /\ prev_phase = "None"
+    /\ turn_count = 0
+
+\* ── Transition actions ───────────────────────
+Transition(to_) ==
+    /\ ~IsTerminal(phase)
+    /\ to_ # phase                                  \* not a reaffirm
+    /\ to_ \in AllowedNext(phase)
+    \* Bound Bootstrapping->Running cycles.
+    /\ ~(phase = "Bootstrapping" /\ to_ = "Running" /\ turn_count >= MaxTurns)
+    /\ prev_phase' = phase
+    /\ phase' = to_
+    /\ turn_count' =
+        IF phase = "Bootstrapping" /\ to_ = "Running"
+        THEN turn_count + 1
+        ELSE turn_count
+
+\* Same-state reaffirm: allowed on non-terminal states.
+Reaffirm ==
+    /\ ~IsTerminal(phase)
+    /\ UNCHANGED vars
+
+\* Stutter on terminal states.
+StutterTerminal ==
+    /\ IsTerminal(phase)
+    /\ UNCHANGED vars
+
+Next ==
+    /\ \E to_ \in States : Transition(to_)
+    /\ Reaffirm
+    /\ StutterTerminal
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(\E to_ \in States : Transition(to_))
+
+\* ── Safety Invariants ────────────────────────
+
+\* 1. PrevNotEqualPhase: prev_phase differs from phase (when set).
+PrevNotEqualPhase ==
+    prev_phase # "None" => prev_phase # phase
+
+\* 2. TerminalIsStable: once terminal, phase never changes.
+TerminalIsStable ==
+    IsTerminal(prev_phase) => phase = prev_phase
+
+\* 3. NoIllegalTransition: every transition arrow is declared.
+NoIllegalTransition ==
+    prev_phase # "None" =>
+        phase \in AllowedNext(prev_phase)
+
+\* 4. CancelledIsTerminal: Cancelled has no outgoing transitions.
+CancelledIsTerminal ==
+    phase = "Cancelled" => IsTerminal(phase)
+
+\* 5. CancelledRequiresNonTerminal: Cancelled can only be reached from
+\*    a non-terminal state (or initial).
+CancelledRequiresNonTerminal ==
+    phase = "Cancelled" =>
+        (prev_phase = "None" \/ prev_phase \in NonTerminal)
+
+\* 6. NoTransitionIntoBootstrapping: Bootstrapping is initial-only.
+NoTransitionIntoBootstrapping ==
+    (phase = "Bootstrapping") => (prev_phase \in {"None", "Bootstrapping"})
+
+\* ── Bug Model: Cancelled Resurrection ────────
+\* Models a regression where Cancelled is incorrectly re-transitioned
+\* to Running — e.g. a buggy checkpoint restore or retry loop that
+\* ignores cancellation as a terminal state.
+\*
+\* SHOULD violate TerminalIsStable.
+
+BugCancelledResurrection ==
+    /\ phase = "Cancelled"
+    /\ prev_phase' = "Cancelled"
+    /\ phase' = "Running"
+    /\ UNCHANGED turn_count
+
+NextBuggy ==
+    /\ \E to_ \in States : Transition(to_)
+    /\ Reaffirm
+    /\ StutterTerminal
+    /\ BugCancelledResurrection
+
+SpecBuggy == Init /\ [][NextBuggy]_vars /\ WF_vars(\E to_ \in States : Transition(to_))
+
+\* Invariant SHOULD be violated under SpecBuggy.
+TerminalIsStableMustHold == TerminalIsStable
+
+====

--- a/test/test_agent_lifecycle.ml
+++ b/test/test_agent_lifecycle.ml
@@ -313,6 +313,48 @@ let test_transition_error_to_string () =
   Alcotest.(check bool) "contains 'terminal'" true (String.length s2 > 0)
 ;;
 
+(* ── yojson round-trip tests (PR-A3 mirror) ───────────────── *)
+(* Mirrors AgentLifecycle.tla state set {Accepted, Ready, Running,
+   Completed, Failed} via ppx_deriving_yojson.  Round-trip ensures that
+   adding a constructor without updating wire encoders is caught at
+   test time rather than at deserialization. *)
+
+let test_yojson_round_trip () =
+  let all_states =
+    [ Agent_lifecycle.Accepted
+    ; Agent_lifecycle.Ready
+    ; Agent_lifecycle.Running
+    ; Agent_lifecycle.Completed
+    ; Agent_lifecycle.Failed
+    ]
+  in
+  List.iter
+    (fun status ->
+      let json = Agent_lifecycle.lifecycle_status_to_yojson status in
+      match Agent_lifecycle.lifecycle_status_of_yojson json with
+      | Ok parsed ->
+        Alcotest.(check bool)
+          (Printf.sprintf
+             "round-trip %s"
+             (Agent_lifecycle.show_lifecycle_status status))
+          true
+          (status = parsed)
+      | Error msg ->
+        Alcotest.fail
+          (Printf.sprintf
+             "round-trip failed for %s: %s"
+             (Agent_lifecycle.show_lifecycle_status status)
+             msg))
+    all_states
+;;
+
+let test_yojson_rejects_unknown () =
+  let bogus = `String "NonexistentStatus" in
+  match Agent_lifecycle.lifecycle_status_of_yojson bogus with
+  | Error _ -> () (* expected — unknown value rejected *)
+  | Ok _ -> Alcotest.fail "unknown string should be rejected"
+;;
+
 (* ── Test runner ────────────────────────────────────────── *)
 
 let () =
@@ -384,6 +426,10 @@ let () =
             `Quick
             test_valid_transitions_exhaustive
         ; Alcotest.test_case "error_to_string" `Quick test_transition_error_to_string
+        ] )
+    ; ( "yojson"
+      , [ Alcotest.test_case "round-trip all states" `Quick test_yojson_round_trip
+        ; Alcotest.test_case "rejects unknown" `Quick test_yojson_rejects_unknown
         ] )
     ]
 ;;


### PR DESCRIPTION
## 요약

masc-mcp ↔ oas 정합성 감사의 oas 측 척추 보강.

## 변경 (4 commits)

| # | Type | 설명 |
|---|------|------|
| 1 | ci | `.github/workflows/ci.yml`에 `tla-model-check` job 추가 — 4 specs × (clean + buggy) 자동 검증 |
| 2 | spec | `AgentCancellation.tla` 신규 작성 — Runtime.phase의 7-state FSM, Cancelled terminal 모델링 |
| 3 | feat | `lifecycle_status`에 `[@@deriving show, yojson]` 추가 |
| 4 | test | `test_agent_lifecycle.ml`에 yojson round-trip + unknown-rejection test 추가 |

## 동기

Audit 결과:
- oas의 4 spec에 TLC가 한 번도 실행되지 않고 있었음 (CI gate 0건)
- AgentLifecycle.tla:26-28에 \"A separate spec (AgentCancellation.tla) should model that\" 명시되어 있으나 미작성
- Runtime.phase의 Cancelled는 5개 reraise site에서 사용되지만 spec 밖
- lifecycle_status는 spec 1:1인데 yojson 미derive (역설적 비대칭)

## Bug Model 패턴

Clean cfg는 \"No error\" 통과, Buggy cfg는 \"Invariant violated\" 통과.

## 검증

GitHub Actions CI:
- `tla-model-check` job이 TLC를 실행하고 결과를 보고
- `test_agent_lifecycle` alcotest suite가 yojson round-trip 검증

## 상태

**Draft** — human-approved-ready 라벨 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)