### PR TITLE
feat(llm_provider): Visual_first modality ordering for Gemma 4

### DIFF
--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -29,7 +29,9 @@ let build_request
            [ "role", `String "system"; "content", `String (Utf8_sanitize.sanitize s) ]
        ]
      | _ -> [])
-    @ List.concat_map Backend_openai_serialize.ollama_messages_of_message messages
+    @ List.concat_map
+        (Backend_openai_serialize.ollama_messages_of_message ~model_id:config.model_id)
+        messages
   in
   let body = [ "model", `String config.model_id; "messages", `List provider_messages ] in
   (* think: false by default for Ollama to prevent thinking models from

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -105,12 +105,19 @@ let assistant_reasoning_content_of_blocks blocks =
 let messages_of_message_with
       ?(tool_calls_fn = tool_calls_to_openai_json)
       ?(include_reasoning_content = false)
+      ?(modality_priority = Modality.Preserve_input_order)
       (msg : message)
   : Yojson.Safe.t list
   =
   match msg.role with
   | User ->
-    let content_parts = openai_content_parts_of_blocks msg.content in
+    (* Apply modality reordering policy before flattening into JSON parts.
+       For [Preserve_input_order] (default) this is a no-op; for
+       [Visual_first] image/audio/document blocks move ahead of text.
+       has_multimodal inspects the input list (pre-reorder) — the boolean
+       is invariant under reordering, so either input is correct. *)
+    let ordered_content = Modality.reorder modality_priority msg.content in
+    let content_parts = openai_content_parts_of_blocks ordered_content in
     let has_multimodal =
       List.exists
         (function
@@ -198,8 +205,17 @@ let glm_messages_of_message msg =
     msg
 ;;
 
-let ollama_messages_of_message msg =
-  messages_of_message_with ~tool_calls_fn:tool_calls_to_ollama_json msg
+let modality_priority_for_model_id model_id =
+  match Capabilities.for_model_id model_id with
+  | Some c -> c.modality_priority
+  | None -> Modality.Preserve_input_order
+;;
+
+let ollama_messages_of_message ?(model_id = "") msg =
+  messages_of_message_with
+    ~tool_calls_fn:tool_calls_to_ollama_json
+    ~modality_priority:(modality_priority_for_model_id model_id)
+    msg
 ;;
 
 (** Strip ToolResult blocks whose tool_use_id has no matching ToolUse

--- a/lib/llm_provider/backend_openai_serialize.mli
+++ b/lib/llm_provider/backend_openai_serialize.mli
@@ -9,7 +9,7 @@ val tool_calls_to_openai_json : Types.content_block list -> Yojson.Safe.t list
 val openai_content_parts_of_blocks : Types.content_block list -> Yojson.Safe.t list
 val openai_messages_of_message : Types.message -> Yojson.Safe.t list
 val glm_messages_of_message : Types.message -> Yojson.Safe.t list
-val ollama_messages_of_message : Types.message -> Yojson.Safe.t list
+val ollama_messages_of_message : ?model_id:string -> Types.message -> Yojson.Safe.t list
 val tool_choice_to_openai_json : Types.tool_choice -> Yojson.Safe.t
 val build_openai_tool_json : Yojson.Safe.t -> Yojson.Safe.t
 

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -46,6 +46,10 @@ type capabilities =
   ; supports_image_input : bool
   ; supports_audio_input : bool
   ; supports_video_input : bool
+  ; modality_priority : Modality.priority
+    (** Block ordering applied to multimodal user messages just before
+        serialization. [Visual_first] for Gemma 4 family.
+        @since 0.193.0 *)
   ; (* ── Protocol ──────────────────────────────────────── *)
     supports_native_streaming : bool
   ; supports_system_prompt : bool
@@ -100,6 +104,7 @@ let default_capabilities =
   ; supports_image_input = false
   ; supports_audio_input = false
   ; supports_video_input = false
+  ; modality_priority = Modality.Preserve_input_order
   ; supports_native_streaming = false
   ; supports_system_prompt = true
   ; (* most models support it *)
@@ -597,6 +602,9 @@ let for_model_id_static model_id =
       ; supports_audio_input = is_large
       ; supports_native_streaming = true
       ; supports_seed = true
+      ; modality_priority = Modality.Visual_first
+        (* Gemma 4 best practices: place image/audio before text for
+           optimal multimodal performance. *)
       }
     (* GLM flash/air variants: faster, no reasoning, smaller output.
      Must precede the broad glm-4.5/4.6/4.7/5 match below. *))

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -35,6 +35,7 @@ type capabilities =
   ; supports_image_input : bool
   ; supports_audio_input : bool
   ; supports_video_input : bool
+  ; modality_priority : Modality.priority
   ; (* Protocol *)
     supports_native_streaming : bool
   ; supports_system_prompt : bool

--- a/lib/llm_provider/modality.ml
+++ b/lib/llm_provider/modality.ml
@@ -1,0 +1,17 @@
+open Types
+
+type priority =
+  | Preserve_input_order
+  | Visual_first
+
+let reorder priority (blocks : content_block list) : content_block list =
+  match priority with
+  | Preserve_input_order -> blocks
+  | Visual_first ->
+    let is_visual = function
+      | Image _ | Audio _ | Document _ -> true
+      | Text _ | Thinking _ | RedactedThinking _ | ToolUse _ | ToolResult _ -> false
+    in
+    let visuals, others = List.partition is_visual blocks in
+    visuals @ others
+;;

--- a/lib/llm_provider/modality.mli
+++ b/lib/llm_provider/modality.mli
@@ -1,0 +1,38 @@
+(** Modality ordering policy for multimodal user messages.
+
+    Some models perform better when image / audio / document blocks
+    precede text in the serialized request. Gemma 4 best practices state:
+
+    {v
+      Modality order: For optimal performance with multimodal inputs,
+      place image and/or audio content before the text in your prompt.
+    v}
+
+    Other models (Anthropic, OpenAI, GLM) are not sensitive to this
+    ordering, so the default is to preserve caller-supplied block order.
+
+    @since 0.193.0 *)
+
+(** Block ordering policy applied to a {!Types.message}'s content list
+    just before serialization. Modeled as a sum type rather than a
+    boolean so future policies (e.g. interleaved, audio-only-first) can
+    be added without breaking existing call sites. *)
+type priority =
+  | Preserve_input_order
+    (** Default. Caller's block order is kept verbatim. *)
+  | Visual_first
+    (** [Image], [Audio], and [Document] blocks are moved ahead of
+        [Text] blocks. Other block kinds (tool calls, thinking) keep
+        their relative position. Stable: within each group input order
+        is preserved. Recommended for Gemma 4 family models. *)
+
+(** [reorder priority blocks] applies [priority] to [blocks].
+
+    Pure function — no I/O, no mutation, no allocation when [priority]
+    is [Preserve_input_order]. Stable: relative order within each group
+    is preserved.
+
+    Block kinds classified as visual: [Image], [Audio], [Document].
+    All others (Text, Thinking, RedactedThinking, ToolUse, ToolResult)
+    are treated as non-visual. *)
+val reorder : priority -> Types.content_block list -> Types.content_block list

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -55,6 +55,7 @@ type capabilities =
   ; supports_image_input : bool
   ; supports_audio_input : bool
   ; supports_video_input : bool
+  ; modality_priority : Llm_provider.Modality.priority
   ; supports_native_streaming : bool
   ; supports_system_prompt : bool
   ; supports_caching : bool

--- a/test/dune
+++ b/test/dune
@@ -19,6 +19,7 @@
 (tests
  (names
   test_metrics_aggregating
+  test_modality
   test_capabilities
   test_call_time_pruner_config
   test_agent

--- a/test/test_modality.ml
+++ b/test/test_modality.ml
@@ -1,0 +1,128 @@
+(** Tests for [Llm_provider.Modality] reorder policy and capability
+    integration with Gemma 4 [Visual_first]. *)
+
+open Alcotest
+open Llm_provider
+
+let block_kind = function
+  | Types.Text _ -> "Text"
+  | Types.Image _ -> "Image"
+  | Types.Audio _ -> "Audio"
+  | Types.Document _ -> "Document"
+  | Types.Thinking _ -> "Thinking"
+  | Types.RedactedThinking _ -> "RedactedThinking"
+  | Types.ToolUse _ -> "ToolUse"
+  | Types.ToolResult _ -> "ToolResult"
+;;
+
+let kinds bs = List.map block_kind bs
+
+let mk_text s = Types.Text s
+
+let mk_image () =
+  Types.Image { media_type = "image/png"; data = "AAAA"; source_type = "base64" }
+;;
+
+let mk_audio () =
+  Types.Audio { media_type = "audio/mp3"; data = "BBBB"; source_type = "base64" }
+;;
+
+let mk_document () =
+  Types.Document
+    { media_type = "application/pdf"; data = "CCCC"; source_type = "base64" }
+;;
+
+let test_preserve_input_order () =
+  let blocks = [ mk_text "before"; mk_image (); mk_text "after" ] in
+  let result = Modality.reorder Modality.Preserve_input_order blocks in
+  check (list string) "order unchanged" [ "Text"; "Image"; "Text" ] (kinds result)
+;;
+
+let test_visual_first_moves_image_ahead () =
+  let blocks = [ mk_text "describe"; mk_image () ] in
+  let result = Modality.reorder Modality.Visual_first blocks in
+  check (list string) "image leads" [ "Image"; "Text" ] (kinds result)
+;;
+
+let test_visual_first_stable_within_groups () =
+  (* Image, Text, Audio, Text → Visual_first → Image, Audio, Text, Text *)
+  let blocks =
+    [ mk_image (); mk_text "t1"; mk_audio (); mk_text "t2"; mk_document () ]
+  in
+  let result = Modality.reorder Modality.Visual_first blocks in
+  check
+    (list string)
+    "stable partition by group"
+    [ "Image"; "Audio"; "Document"; "Text"; "Text" ]
+    (kinds result)
+;;
+
+let test_visual_first_no_visuals_is_identity () =
+  let blocks = [ mk_text "a"; mk_text "b" ] in
+  let result = Modality.reorder Modality.Visual_first blocks in
+  check (list string) "no visuals, no change" [ "Text"; "Text" ] (kinds result)
+;;
+
+let test_default_capability_is_preserve () =
+  let p = Capabilities.default_capabilities.modality_priority in
+  match p with
+  | Modality.Preserve_input_order -> ()
+  | Modality.Visual_first -> Alcotest.fail "default should be Preserve_input_order"
+;;
+
+let test_gemma4_capability_is_visual_first () =
+  match Capabilities.for_model_id "gemma-4-31b-it" with
+  | None -> Alcotest.fail "gemma-4-31b-it should have a capability entry"
+  | Some c ->
+    (match c.modality_priority with
+     | Modality.Visual_first -> ()
+     | Modality.Preserve_input_order ->
+       Alcotest.fail "gemma-4-31b-it should be Visual_first per Gemma 4 best practices")
+;;
+
+let test_non_gemma_inherits_preserve () =
+  (* Anthropic models stay Preserve_input_order — the default — since
+     Anthropic does not call out a modality-order preference. *)
+  match Capabilities.for_model_id "claude-sonnet-4-6" with
+  | None -> () (* not in static table — fine, default applies *)
+  | Some c ->
+    (match c.modality_priority with
+     | Modality.Preserve_input_order -> ()
+     | Modality.Visual_first ->
+       Alcotest.fail "claude should not opt into Visual_first")
+;;
+
+let () =
+  Alcotest.run
+    "modality"
+    [ ( "reorder"
+      , [ test_case "Preserve_input_order is identity" `Quick test_preserve_input_order
+        ; test_case
+            "Visual_first moves image ahead"
+            `Quick
+            test_visual_first_moves_image_ahead
+        ; test_case
+            "Visual_first stable within groups"
+            `Quick
+            test_visual_first_stable_within_groups
+        ; test_case
+            "Visual_first no-visuals identity"
+            `Quick
+            test_visual_first_no_visuals_is_identity
+        ] )
+    ; ( "capability_wiring"
+      , [ test_case
+            "default_capabilities = Preserve_input_order"
+            `Quick
+            test_default_capability_is_preserve
+        ; test_case
+            "gemma-4-31b-it = Visual_first"
+            `Quick
+            test_gemma4_capability_is_visual_first
+        ; test_case
+            "non-gemma stays Preserve_input_order"
+            `Quick
+            test_non_gemma_inherits_preserve
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

Gemma 4 best practices state: *"place image and/or audio content before the text in your prompt"* for optimal multimodal performance. OAS의 OpenAI-compat 직렬화 (`backend_openai_serialize`) 는 caller block 순서를 그대로 보존하므로, 일반적인 `<text>describe</text> + <image>` 입력이 Gemma 4 에 권장과 반대 순서로 전달됨.

이 PR 은 `Modality.priority` Variant 를 도입해 capability record 를 통해 model-aware 정렬을 활성화. Gemma 4 family 만 `Visual_first` 옵트인, 다른 모델은 `Preserve_input_order` 유지 — backwards-compatible, Anthropic/OpenAI/GLM 경로 회귀 0.

## 설계 — Variant 우선

\`\`\`ocaml
type priority =
  | Preserve_input_order  (* default — caller order kept *)
  | Visual_first          (* Gemma 4 — Image/Audio/Document moved ahead *)
\`\`\`

**왜 string match (e.g. \`if starts_with \"gemma-4\"\`) 가 아닌 Variant 인가?**

- 새 모델이 정책에 합류 = capability record 에 1줄. Serializer 는 model_id 를 절대 직접 inspect 하지 않음.
- 새 정책 (e.g. \`Audio_first\`, \`Interleaved\`) 추가 시 컴파일러가 모든 분기 점검 강제.
- \"Adaptive\" 동작이 spec 변경에 흡수 가능 — 어거지 하드코딩이 아닌 진퉁 capability-driven dispatch.

## Audit verification (caller-context 30–50줄 직접 read)

검증된 사실:
- \`backend_openai_serialize.ml:43-128\` — \`openai_content_parts_of_blocks\` 는 input list를 \`List.filter_map\` 만 함, **reorder 없음**. \`messages_of_message_with\` 의 User branch 가 그대로 직렬화. *"text-first 고정\"* audit 결론 확정.
- \`capabilities.ml:565-600\` — Gemma 4 capability 분기가 이미 존재. \`{ default_capabilities with ... }\` \`with\` 패턴이라 inline 1줄 (\`modality_priority = Modality.Visual_first\`) 추가로 충분.
- 8 개 OpenAI-compat caller (\`openai_messages_of_message\`, \`glm_messages_of_message\`, \`ollama_messages_of_message\`, plus 5 internal) 는 default \`Preserve_input_order\` 상속. **\`ollama_messages_of_message\` 만 \`~model_id\`를 받아 priority 추출** — 회귀 표면적 최소화.

## 변경 파일 (6 modified, 2 new, +217 / -5)

| 파일 | 역할 |
|---|---|
| \`lib/llm_provider/modality.ml/.mli\` (새) | \`type priority\` Variant + \`reorder\` pure function |
| \`lib/llm_provider/capabilities.ml/.mli\` | record field \`modality_priority\` 추가, default + Gemma 4 분기 |
| \`lib/llm_provider/backend_openai_serialize.ml/.mli\` | \`?modality_priority\` opt-arg 통합, \`modality_priority_for_model_id\` helper |
| \`lib/llm_provider/backend_ollama.ml\` | \`config.model_id\` 를 \`ollama_messages_of_message\` 로 전달 |
| \`lib/provider.mli\` | \`capabilities\` type re-export sync |
| \`test/test_modality.ml\` (새), \`test/dune\` | 7 alcotest case |

## 건드리지 않은 것

- Anthropic backend (\`backend_anthropic.ml\`) — Anthropic Messages API 가 multimodal modality order 에 sensitive 하지 않음 + 별도 직렬화 경로
- 사용자 입력 \`message.content\` block 자체 순서 — reorder 는 serialization 시점에만, in-memory 표현 보존
- Other capability fields (sampling, thinking, vision support) — 이 PR scope 밖
- OpenAI / GLM caller — default \`Preserve_input_order\` 유지로 동작 byte-identical

## Test plan

- [x] \`scripts/dune-local.sh build lib\` (exit 0)
- [x] \`_build/default/test/test_modality.exe\` — 7/7 alcotest pass
  - reorder: \`Preserve_input_order\` identity / \`Visual_first\` 이미지 앞 / 안정 정렬 / no-visuals identity
  - capability_wiring: default = \`Preserve_input_order\` / gemma-4-31b-it = \`Visual_first\` / non-gemma 비변경
- [ ] CI green check (push 후 모니터링)

## Follow-up (이 PR scope 밖)

- **PR-A (thinking parser)**: audit 의 \"Gemma 4 채널 형식 미파싱\" 결론은 추가 검증 필요. Ollama native API 가 \`<|channel>thought<channel|>\` 토큰을 \`message.thinking\` 으로 자동 분리하는지 spec test (5분) 후 결정. 자동 분리 시 PR 캔슬, 미분리 시 별도 parser PR.
- **PR-C (sampling default)**: Gemma 4 권장 \`temp=1.0/top_p=0.95/top_k=64\` model-aware default. 현재 per-call override 만 가능, model 매핑 없음.
- **PR-D (visual token budget)**: 70/140/280/560/1120 enum. 멀티모달 path 본격 사용 시.
- **PR-E (telemetry 통합)**: OAS \`metrics.ml\` ↔ masc-mcp \`model_inference_metrics.ml\` 의 \`thinking_enabled\` 라벨 통합.

🤖 Generated with [Claude Code](https://claude.com/claude-code)