### PR TITLE
fix(main): unblock 3 CI categories after #1469-#1471 cascade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,8 +319,11 @@ jobs:
             java -cp specs/tla2tools.jar tlc2.TLC -config "$cfg" "$tla"
             exit_code=$?
             set -e
-            if [ $exit_code -eq 12 ]; then
-              echo "  Invariant violated as expected (exit 12)"
+            # TLC 1.8.0 exit codes for buggy specs:
+            #   12 = state-level invariant violation
+            #   13 = trace-level invariant violation (action/liveness)
+            if [ $exit_code -eq 12 ] || [ $exit_code -eq 13 ]; then
+              echo "  Invariant violated as expected (exit $exit_code)"
             elif [ $exit_code -eq 0 ]; then
               echo "ERROR: Buggy spec should have violated invariant but passed"
               exit 1

--- a/examples/cli_transports_demo.ml
+++ b/examples/cli_transports_demo.ml
@@ -120,7 +120,7 @@ let () =
    | Ok resp ->
      Printf.printf
        "  latency=%d ms id=%s model=%s blocks=%d\n"
-       latency_ms
+       (Option.value latency_ms ~default:(-1))
        resp.id
        resp.model
        (List.length resp.content);

--- a/lib/agent/agent_lifecycle.ml
+++ b/lib/agent/agent_lifecycle.ml
@@ -71,7 +71,8 @@ type lifecycle_snapshot =
   ; started_at : float option
   ; last_progress_at : float option
   ; finished_at : float option
-  } [@@deriving yojson]
+  }
+[@@deriving yojson]
 
 let provider_runtime_name (cfg : Provider.config option) =
   match cfg with

--- a/lib/agent/agent_lifecycle.mli
+++ b/lib/agent/agent_lifecycle.mli
@@ -77,7 +77,8 @@ type lifecycle_snapshot =
   ; started_at : float option
   ; last_progress_at : float option
   ; finished_at : float option
-  } [@@deriving yojson]
+  }
+[@@deriving yojson]
 
 (** {1 Construction} *)
 

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -602,8 +602,9 @@ let for_model_id_static model_id =
       ; supports_audio_input = is_large
       ; supports_native_streaming = true
       ; supports_seed = true
-      ; modality_priority = Modality.Visual_first
-        (* Gemma 4 best practices: place image/audio before text for
+      ; modality_priority =
+          Modality.Visual_first
+          (* Gemma 4 best practices: place image/audio before text for
            optimal multimodal performance. *)
       }
     (* GLM flash/air variants: faster, no reasoning, smaller output.

--- a/lib/llm_provider/modality.mli
+++ b/lib/llm_provider/modality.mli
@@ -18,10 +18,9 @@
     boolean so future policies (e.g. interleaved, audio-only-first) can
     be added without breaking existing call sites. *)
 type priority =
-  | Preserve_input_order
-    (** Default. Caller's block order is kept verbatim. *)
+  | Preserve_input_order (** Default. Caller's block order is kept verbatim. *)
   | Visual_first
-    (** [Image], [Audio], and [Document] blocks are moved ahead of
+  (** [Image], [Audio], and [Document] blocks are moved ahead of
         [Text] blocks. Other block kinds (tool calls, thinking) keep
         their relative position. Stable: within each group input order
         is preserved. Recommended for Gemma 4 family models. *)

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -491,4 +491,3 @@ let zero_api_usage =
 ;;
 
 let usage_of_response (resp : api_response) = resp.usage
-;;


### PR DESCRIPTION
## Summary

main이 broken 상태입니다. PR #1472 (bump) 포함 후속 PR이 모두 차단되어 unblock합니다.

## 차단된 카테고리 → fix

| Fail | Root cause | Fix |
|---|---|---|
| **OCaml Format** (5 파일) | #1469 머지 시 ocamlformat 미실행 | `ocamlformat --inplace` 6 파일 |
| **Build & Test** | `examples/cli_transports_demo.ml:123` `latency_ms : int option` unwrap 누락 | `Option.value ~default:(-1)` |
| **TLA+ Model Checking** | CI 가드가 exit 12만 인정, ContentReplacementState 는 trace-level 로 exit 13 | 가드 `12 \|\| 13` 둘 다 허용 |

## Why this is one PR

세 fail 모두 **main 차단 사슬의 단일 root**(post-#1469 검사 우회 머지)에서 파생된 카테고리. 분리 PR이면 각각이 다른 fail에 다시 막혀 deadlock 발생 — 이번 한 batch 로 unblock 후 #1472 가 정상 ready/merge 가능.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` PASS
- ocamlformat 0.29.0 (janestreet) 로 6 파일 promote
- example demo 의 latency 출력에 미측정 표시 (`-1`) 채택

## Note

CLAUDE.md memory `feedback_main_blocker_chain_4x_session.md` 가 정확히 이 패턴을 경고합니다. 이번이 5회차. hook-level 강제가 필요하다는 신호.

🤖 Generated with [Claude Code](https://claude.com/claude-code)