### PR TITLE
feat(base): Tool_id closed Variant identifier (RFC-OAS-008 PR-2/5)

### DIFF
--- a/lib/base/tool_id.ml
+++ b/lib/base/tool_id.ml
@@ -1,0 +1,278 @@
+type t =
+  | Read
+  | Glob
+  | Grep
+  | Search
+  | List_dir
+  | Find_file
+  | Read_file
+  | Find_symbol
+  | Get_symbols_overview
+  | Find_referencing_symbols
+  | Search_for_pattern
+  | Notebook_read
+  | Read_console_messages
+  | Read_network_requests
+  | Get_page_text
+  | Read_page
+  | Tabs_context_mcp
+  | Task_list
+  | Task_get
+  | Task_output
+  | Write
+  | Edit
+  | Create_text_file
+  | Replace_content
+  | Rename_symbol
+  | Insert_after_symbol
+  | Insert_before_symbol
+  | Replace_symbol_body
+  | Notebook_edit
+  | Task_create
+  | Task_update
+  | Task_stop
+  | Team_create
+  | Team_delete
+  | Ask_user_question
+  | Web_fetch
+  | Web_search
+  | Navigate
+  | Computer
+  | Find
+  | Form_input
+  | Javascript_tool
+  | Tabs_create_mcp
+  | Upload_image
+  | Bash
+  | Execute_shell_command
+  | Mcp of
+      { server : string
+      ; tool : string
+      }
+  | User of string
+[@@deriving show]
+
+(* Variant constructors carry only strings and immutable record fields, so
+   structural equality via polymorphic [=] is well-defined and equivalent to
+   a hand-rolled match. *)
+let equal = ( = )
+
+let to_string = function
+  | Read -> "read"
+  | Glob -> "glob"
+  | Grep -> "grep"
+  | Search -> "search"
+  | List_dir -> "list_dir"
+  | Find_file -> "find_file"
+  | Read_file -> "read_file"
+  | Find_symbol -> "find_symbol"
+  | Get_symbols_overview -> "get_symbols_overview"
+  | Find_referencing_symbols -> "find_referencing_symbols"
+  | Search_for_pattern -> "search_for_pattern"
+  | Notebook_read -> "notebook_read"
+  | Read_console_messages -> "read_console_messages"
+  | Read_network_requests -> "read_network_requests"
+  | Get_page_text -> "get_page_text"
+  | Read_page -> "read_page"
+  | Tabs_context_mcp -> "tabs_context_mcp"
+  | Task_list -> "task_list"
+  | Task_get -> "task_get"
+  | Task_output -> "task_output"
+  | Write -> "write"
+  | Edit -> "edit"
+  | Create_text_file -> "create_text_file"
+  | Replace_content -> "replace_content"
+  | Rename_symbol -> "rename_symbol"
+  | Insert_after_symbol -> "insert_after_symbol"
+  | Insert_before_symbol -> "insert_before_symbol"
+  | Replace_symbol_body -> "replace_symbol_body"
+  | Notebook_edit -> "notebook_edit"
+  | Task_create -> "task_create"
+  | Task_update -> "task_update"
+  | Task_stop -> "task_stop"
+  | Team_create -> "team_create"
+  | Team_delete -> "team_delete"
+  | Ask_user_question -> "ask_user_question"
+  | Web_fetch -> "web_fetch"
+  | Web_search -> "web_search"
+  | Navigate -> "navigate"
+  | Computer -> "computer"
+  | Find -> "find"
+  | Form_input -> "form_input"
+  | Javascript_tool -> "javascript_tool"
+  | Tabs_create_mcp -> "tabs_create_mcp"
+  | Upload_image -> "upload_image"
+  | Bash -> "bash"
+  | Execute_shell_command -> "execute_shell_command"
+  | Mcp { server; tool } -> "mcp__" ^ server ^ "__" ^ tool
+  | User name -> name
+;;
+
+let all_builtins =
+  [ Read
+  ; Glob
+  ; Grep
+  ; Search
+  ; List_dir
+  ; Find_file
+  ; Read_file
+  ; Find_symbol
+  ; Get_symbols_overview
+  ; Find_referencing_symbols
+  ; Search_for_pattern
+  ; Notebook_read
+  ; Read_console_messages
+  ; Read_network_requests
+  ; Get_page_text
+  ; Read_page
+  ; Tabs_context_mcp
+  ; Task_list
+  ; Task_get
+  ; Task_output
+  ; Write
+  ; Edit
+  ; Create_text_file
+  ; Replace_content
+  ; Rename_symbol
+  ; Insert_after_symbol
+  ; Insert_before_symbol
+  ; Replace_symbol_body
+  ; Notebook_edit
+  ; Task_create
+  ; Task_update
+  ; Task_stop
+  ; Team_create
+  ; Team_delete
+  ; Ask_user_question
+  ; Web_fetch
+  ; Web_search
+  ; Navigate
+  ; Computer
+  ; Find
+  ; Form_input
+  ; Javascript_tool
+  ; Tabs_create_mcp
+  ; Upload_image
+  ; Bash
+  ; Execute_shell_command
+  ]
+;;
+
+let mcp_prefix = "mcp__"
+let mcp_separator = "__"
+
+(* Parse "mcp__<server>__<tool>". Returns [None] when prefix missing,
+   server or tool empty, or no separator between server and tool. *)
+let parse_mcp s =
+  let plen = String.length mcp_prefix in
+  let n = String.length s in
+  if n <= plen || not (String.equal (String.sub s 0 plen) mcp_prefix)
+  then None
+  else (
+    let rest = String.sub s plen (n - plen) in
+    let rlen = String.length rest in
+    let rec find_sep i =
+      if i + 1 >= rlen
+      then None
+      else if Char.equal rest.[i] '_' && Char.equal rest.[i + 1] '_'
+      then Some i
+      else find_sep (i + 1)
+    in
+    match find_sep 0 with
+    | None -> None
+    | Some i ->
+      let server = String.sub rest 0 i in
+      let tool = String.sub rest (i + String.length mcp_separator) (rlen - i - String.length mcp_separator) in
+      if String.equal server "" || String.equal tool ""
+      then None
+      else Some (Mcp { server; tool }))
+;;
+
+let of_string raw =
+  let s = String.lowercase_ascii raw in
+  match s with
+  | "read" -> Read
+  | "glob" -> Glob
+  | "grep" -> Grep
+  | "search" -> Search
+  | "list_dir" -> List_dir
+  | "find_file" -> Find_file
+  | "read_file" -> Read_file
+  | "find_symbol" -> Find_symbol
+  | "get_symbols_overview" -> Get_symbols_overview
+  | "find_referencing_symbols" -> Find_referencing_symbols
+  | "search_for_pattern" -> Search_for_pattern
+  | "notebook_read" -> Notebook_read
+  | "read_console_messages" -> Read_console_messages
+  | "read_network_requests" -> Read_network_requests
+  | "get_page_text" -> Get_page_text
+  | "read_page" -> Read_page
+  | "tabs_context_mcp" -> Tabs_context_mcp
+  | "task_list" -> Task_list
+  | "task_get" -> Task_get
+  | "task_output" -> Task_output
+  | "write" -> Write
+  | "edit" -> Edit
+  | "create_text_file" -> Create_text_file
+  | "replace_content" -> Replace_content
+  | "rename_symbol" -> Rename_symbol
+  | "insert_after_symbol" -> Insert_after_symbol
+  | "insert_before_symbol" -> Insert_before_symbol
+  | "replace_symbol_body" -> Replace_symbol_body
+  | "notebook_edit" -> Notebook_edit
+  | "task_create" -> Task_create
+  | "task_update" -> Task_update
+  | "task_stop" -> Task_stop
+  | "team_create" -> Team_create
+  | "team_delete" -> Team_delete
+  | "ask_user_question" -> Ask_user_question
+  | "web_fetch" -> Web_fetch
+  | "web_search" -> Web_search
+  | "navigate" -> Navigate
+  | "computer" -> Computer
+  | "find" -> Find
+  | "form_input" -> Form_input
+  | "javascript_tool" -> Javascript_tool
+  | "tabs_create_mcp" -> Tabs_create_mcp
+  | "upload_image" -> Upload_image
+  | "bash" -> Bash
+  | "execute_shell_command" -> Execute_shell_command
+  | other ->
+    (match parse_mcp other with
+     | Some m -> m
+     | None -> User other)
+;;
+
+let%test "all_builtins_round_trip" =
+  List.for_all (fun b -> equal (of_string (to_string b)) b) all_builtins
+;;
+
+let%test "of_string_lowercases_builtin" = equal (of_string "READ") Read
+let%test "of_string_user_lowercases" = equal (of_string "MyTool") (User "mytool")
+
+let%test "of_string_mcp_parses" =
+  equal (of_string "mcp__claude__read_file") (Mcp { server = "claude"; tool = "read_file" })
+;;
+
+let%test "of_string_mcp_lowercases" =
+  equal (of_string "MCP__Server__Tool") (Mcp { server = "server"; tool = "tool" })
+;;
+
+let%test "of_string_malformed_mcp_falls_back_to_user" =
+  equal (of_string "mcp__only_server") (User "mcp__only_server")
+;;
+
+let%test "of_string_empty_mcp_server_falls_back" =
+  equal (of_string "mcp____tool") (User "mcp____tool")
+;;
+
+let%test "to_string_mcp_round_trips" =
+  let m = Mcp { server = "abc"; tool = "xyz" } in
+  equal (of_string (to_string m)) m
+;;
+
+let%test "no_duplicate_in_all_builtins" =
+  let strs = List.map to_string all_builtins in
+  let unique = List.sort_uniq String.compare strs in
+  List.length strs = List.length unique
+;;

--- a/lib/base/tool_id.mli
+++ b/lib/base/tool_id.mli
@@ -1,0 +1,87 @@
+(** Typed tool identifier.
+
+    Closed Variant for builtins, escape hatches for MCP and user-supplied tools.
+    See RFC-OAS-008 for the rationale. PR-2 ships only the identifier and
+    string conversion; PR-3 wires this into [Mode_enforcer] without changing
+    its external API. *)
+
+type t =
+  (* Read-only — file & code navigation *)
+  | Read
+  | Glob
+  | Grep
+  | Search
+  | List_dir
+  | Find_file
+  | Read_file
+  | Find_symbol
+  | Get_symbols_overview
+  | Find_referencing_symbols
+  | Search_for_pattern
+  (* Read-only — notebook *)
+  | Notebook_read
+  (* Read-only — browser observation *)
+  | Read_console_messages
+  | Read_network_requests
+  | Get_page_text
+  | Read_page
+  | Tabs_context_mcp
+  (* Read-only — task queries *)
+  | Task_list
+  | Task_get
+  | Task_output
+  (* Local-mutation — file editing *)
+  | Write
+  | Edit
+  | Create_text_file
+  | Replace_content
+  | Rename_symbol
+  | Insert_after_symbol
+  | Insert_before_symbol
+  | Replace_symbol_body
+  | Notebook_edit
+  (* Local-mutation — task & team management *)
+  | Task_create
+  | Task_update
+  | Task_stop
+  | Team_create
+  | Team_delete
+  (* External-effect — HITL *)
+  | Ask_user_question
+  (* External-effect — web & research *)
+  | Web_fetch
+  | Web_search
+  (* External-effect — browser interaction *)
+  | Navigate
+  | Computer
+  | Find
+  | Form_input
+  | Javascript_tool
+  | Tabs_create_mcp
+  | Upload_image
+  (* Shell-dynamic *)
+  | Bash
+  | Execute_shell_command
+  (* Escape hatches *)
+  | Mcp of
+      { server : string
+      ; tool : string
+      }
+  | User of string
+[@@deriving show]
+
+val equal : t -> t -> bool
+(** Structural equality. [Mcp] compares by [server] and [tool] fields;
+    [User name] compares by exact (lowercased) name. *)
+
+val to_string : t -> string
+(** Stable string form. Builtins and [Mcp] round-trip with [of_string].
+    [User name] returns the (already lowercased) name. *)
+
+val of_string : string -> t
+(** Total. Lowercases input, matches builtins, parses [mcp__server__tool] into
+    [Mcp], otherwise returns [User <lowercased>]. Never raises. *)
+
+val all_builtins : t list
+(** Every builtin constructor in declaration order. Excludes [Mcp _] and
+    [User _]. Used by parity tests against [Mode_enforcer.default_tool_entries]. *)


### PR DESCRIPTION
## Summary

RFC-OAS-008 stacked PR 2/5. 닫힌 Variant tool 식별자 모듈을 `lib/base/`에 추가. **사용처 0** — 순수 additive.

## Surface

```ocaml
type t = (* 46 builtins *) | Mcp of { server; tool } | User of string [@@deriving show]
val equal : t -> t -> bool
val to_string : t -> string
val of_string : string -> t  (* total, never raises *)
val all_builtins : t list
```

## Variant 매핑 검증

`lib/base/tool_id.ml`의 46개 builtin은 `lib/mode_enforcer.ml:85` `default_tool_entries`의 모든 항목과 1:1 대응 (Read_only 20 + Local_mutation 14 + External_effect 10 + Shell_dynamic 2 = 46).

## Tests

9개 inline test (`let%test` via `ppx_inline_test`) 모두 통과:

- `all_builtins_round_trip`: `to_string |> of_string` 항등
- `of_string_lowercases_builtin`: "READ" → `Read`
- `of_string_user_lowercases`: "MyTool" → `User "mytool"`
- `of_string_mcp_parses`: "mcp__claude__read_file" → `Mcp { server = "claude"; tool = "read_file" }`
- `of_string_mcp_lowercases`: 대문자 정규화
- `of_string_malformed_mcp_falls_back_to_user`: 분리자 없는 mcp__ → `User`
- `of_string_empty_mcp_server_falls_back`: 빈 server → `User`
- `to_string_mcp_round_trips`: Mcp 구성요소 보존
- `no_duplicate_in_all_builtins`: builtin 이름 유일성

## 빌드 검증

- `dune build --root . lib/base/` ✅
- `dune runtest --root . lib/base/` ✅ (9/9)
- `dune build --root . lib/` ✅ (이름 충돌 없음, lib/dune의 `-open Agent_sdk_base` 호환)

## Why this PR has zero call sites

`Mode_enforcer.default_tool_entries`는 `.mli`에 비노출. PR-3에서 `Mode_enforcer` 내부 구현을 `Tool_id` 기반으로 재작성할 때 parity assertion을 동시에 추가. PR-2를 순수 additive로 유지해 회귀 면적을 0으로 만드는 stacked-PR 의도.

## Out of scope (deferred)

- `effect_class : t -> Mode_enforcer.tool_effect_class` (PR-3)
- `Mode_enforcer.tool_registry` 내부 변환 (PR-3)
- `Agent_tools.find_tool_by_name` index 도입 (PR-4)
- PPX `[@@deriving tool]` (별도 RFC)

## Test plan

- [ ] `human-approved-ready` 라벨 부착
- [ ] reviewer 1+ approval
- [ ] PR-3 (mode_enforcer wiring)이 이 PR base에서 분기

## Sign-off

Stays Draft. Agent ready 전환 금지 (memory `feedback_masc_mcp_draft_guard_blocks_agent_ready`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>