### PR TITLE
feat(mode_enforcer): wire Tool_id into classify_tool + builtin_descriptor (RFC-OAS-008 PR-3/5)

### DIFF
--- a/lib/mode_enforcer.ml
+++ b/lib/mode_enforcer.ml
@@ -188,15 +188,71 @@ let effect_evidence st = List.rev st.effect_evidence
 
 (* ── Tool classification ─────────────────────────────────────────── *)
 
+(** Total mapping from typed tool identifier to effect class. The match
+    is exhaustive on [Tool_id.t]; adding a new builtin constructor in
+    [lib/base/tool_id.ml] forces the compiler to update this branch.
+    See RFC-OAS-008. *)
+let effect_class_of_tool_id : Tool_id.t -> tool_effect_class = function
+  (* Read-only *)
+  | Read
+  | Glob
+  | Grep
+  | Search
+  | List_dir
+  | Find_file
+  | Read_file
+  | Find_symbol
+  | Get_symbols_overview
+  | Find_referencing_symbols
+  | Search_for_pattern
+  | Notebook_read
+  | Read_console_messages
+  | Read_network_requests
+  | Get_page_text
+  | Read_page
+  | Tabs_context_mcp
+  | Task_list
+  | Task_get
+  | Task_output -> Read_only
+  (* Local-mutation *)
+  | Write
+  | Edit
+  | Create_text_file
+  | Replace_content
+  | Rename_symbol
+  | Insert_after_symbol
+  | Insert_before_symbol
+  | Replace_symbol_body
+  | Notebook_edit
+  | Task_create
+  | Task_update
+  | Task_stop
+  | Team_create
+  | Team_delete -> Local_mutation
+  (* External-effect *)
+  | Ask_user_question
+  | Web_fetch
+  | Web_search
+  | Navigate
+  | Computer
+  | Find
+  | Form_input
+  | Javascript_tool
+  | Tabs_create_mcp
+  | Upload_image -> External_effect
+  (* Shell-dynamic *)
+  | Bash
+  | Execute_shell_command -> Shell_dynamic
+  (* Escape hatches: fail closed for MCP and user-supplied unknowns. *)
+  | Mcp _ -> External_effect
+  | User _ -> External_effect
+;;
+
 let classify_tool name =
   let key = String.lowercase_ascii name in
   match Hashtbl.find_opt tool_registry key with
   | Some cls -> cls
-  | None ->
-    (* Fail closed: MCP tools and anything unknown -> External_effect *)
-    if String.length key > 5 && String.sub key 0 5 = "mcp__"
-    then External_effect
-    else External_effect
+  | None -> effect_class_of_tool_id (Tool_id.of_string name)
 ;;
 
 (** Structured shell-command pattern entries.
@@ -328,7 +384,15 @@ let effect_class_to_permission = function
 
 let builtin_descriptor name : Tool.descriptor option =
   let key = String.lowercase_ascii name in
-  match Hashtbl.find_opt tool_registry key with
+  let cls_opt =
+    match Hashtbl.find_opt tool_registry key with
+    | Some cls -> Some cls
+    | None ->
+      (match Tool_id.of_string name with
+       | Tool_id.Mcp _ | Tool_id.User _ -> None
+       | id -> Some (effect_class_of_tool_id id))
+  in
+  match cls_opt with
   | None -> None
   | Some cls ->
     Some
@@ -595,4 +659,31 @@ let%test "register_tool_class extends registry" =
   match builtin_descriptor "my_custom_tool" with
   | Some d -> d.mutation_class = Some "read_only"
   | None -> false
+;;
+
+(* ── RFC-OAS-008 parity: Tool_id ↔ default_tool_entries ────────────── *)
+(* Every entry in [default_tool_entries] must round-trip through the
+   typed identifier with the same effect class. If this fails, either a
+   new builtin was added to [default_tool_entries] without a matching
+   constructor in [Tool_id.t], or the [effect_class_of_tool_id] match
+   disagrees with the seeded list. *)
+
+let%test "tool_id_parity_with_default_entries" =
+  List.for_all
+    (fun (name, expected) ->
+      let derived = effect_class_of_tool_id (Tool_id.of_string name) in
+      derived = expected)
+    default_tool_entries
+;;
+
+let%test "tool_id_classify_unknown_falls_back_to_external_effect" =
+  classify_tool "definitely_not_a_real_tool_xyz_42" = External_effect
+;;
+
+let%test "tool_id_classify_mcp_prefix_is_external_effect" =
+  classify_tool "mcp__some_server__some_tool" = External_effect
+;;
+
+let%test "tool_id_classify_uppercase_normalizes" =
+  classify_tool "READ" = Read_only && classify_tool "BASH" = Shell_dynamic
 ;;


### PR DESCRIPTION
## Summary

RFC-OAS-008 stacked PR 3/5. **내부 구현만 변경**, public API 동일.

## Changes

`lib/mode_enforcer.ml` 단일 파일, +97/-6.

### 1. 신규 `effect_class_of_tool_id : Tool_id.t -> tool_effect_class`
Closed Variant 위에 total match. `lib/base/tool_id.ml`에 새 builtin 추가 시 compiler가 이 arm 보강을 강제. catch-all `_ ->` 사용 안 함.

### 2. `classify_tool` 단순화
이전:
```ocaml
| None ->
  if String.length key > 5 && String.sub key 0 5 = "mcp__"
  then External_effect
  else External_effect  (* both branches identical, dead code *)
```
이후:
```ocaml
| None -> effect_class_of_tool_id (Tool_id.of_string name)
```

`Tool_id.of_string`이 `mcp__server__tool` prefix를 typed `Mcp { server; tool }`로 파싱. `effect_class_of_tool_id` total match가 `Mcp _ | User _ -> External_effect`로 fail-closed 유지. 외부 행동 동일, 결정 경로만 typed.

### 3. `builtin_descriptor` Tool_id fallback
Hashtbl miss 시 Tool_id로 분류하되 `Mcp _` / `User _`는 `None` 반환 (기존 unknown→None 의미 보존).

## Public API 동일성 증명

`lib/mode_enforcer.mli` 변경 0줄. `classify_tool : string -> tool_effect_class`, `register_tool_class`, `tool_effect_class` 모두 동일 시그니처.

## Tests

`dune runtest --root . lib/` exit 0. 신규 4개 inline test:

- `tool_id_parity_with_default_entries`: 46개 entry 전체에 대해 `effect_class_of_tool_id (Tool_id.of_string name) = expected_class` 일치 보장. 향후 drift는 빌드 시점 또는 테스트 시점에 즉시 감지.
- `tool_id_classify_unknown_falls_back_to_external_effect`
- `tool_id_classify_mcp_prefix_is_external_effect`
- `tool_id_classify_uppercase_normalizes`

기존 inline test (builtin_descriptor 4건, register_tool_class 1건) 변경 없이 통과.

## Defense-in-depth 유지 사항

- `default_tool_entries` 리스트 보존: parity test 참조 + Hashtbl 시드 유지 (기존 동작 우회 위험 0)
- `tool_registry` Hashtbl 시드 보존: `register_tool_class` 런타임 override 의미 보존
- PR-5 (cleanup)에서 시드 제거 검토 — 본 PR에서는 *추가만* 함

## Out of scope (다음 PR)

- `agent_tools.find_tool_by_name`을 Tool_id 기반 index로 (PR-4)
- `default_tool_entries` 시드 제거 (PR-5)

## Test plan

- [ ] reviewer 1+ approval
- [ ] `human-approved-ready` 라벨 부착
- [ ] PR-4 (agent_tools index) 분기

## Sign-off

Stays Draft. Agent ready 전환 금지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>