### PR TITLE
docs(rfc): renumber release-please adoption to RFC-OAS-010

### DIFF
--- a/docs/rfc/RFC-OAS-010-release-please-adoption.md
+++ b/docs/rfc/RFC-OAS-010-release-please-adoption.md
@@ -1,4 +1,4 @@
-# RFC-OAS-009: release-please Adoption
+# RFC-OAS-010: release-please Adoption
 
 | | |
 |---|---|


### PR DESCRIPTION
## Summary

PR #1477 (release-please adoption) 과 #1478 (tool name ignorance) 가 동일한 RFC-OAS-009 번호로 동시 머지되어 충돌 발생. release-please RFC 를 RFC-OAS-010 으로 renumber.

## Resolution

| 번호 | RFC | Origin |
|---|---|---|
| RFC-OAS-008 | typed tool identification | #1474 |
| RFC-OAS-009 | tool name ignorance | #1478 (유지) |
| **RFC-OAS-010** | release-please adoption | 이전 #1477 (renumber) |

## Why this direction

- 도메인 시퀀스: tool (008→009) → 인프라 (010) 가 자연스러움
- #1478 본문의 자기 인용 (line 77, 88, 135-136, 139) 다수 → 그쪽을 그대로 두는 비용이 낮음
- release-please RFC 자체는 자기 인용 1곳 (헤더) 외 없음 → renumber 비용 1줄

## Verification

- `git mv` rename 99% 보존
- `rg "RFC-OAS-009"` 검증: 잔여 인용 모두 tool-name-ignorance 의도 (RFC-OAS-008 의 forward reference 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)