### PR TITLE
docs(rfc): redefine CDAL boundary — RFC-OAS-009 v2 + 011 + 012

### DIFF
--- a/docs/rfc/RFC-OAS-009-tool-name-ignorance.md
+++ b/docs/rfc/RFC-OAS-009-tool-name-ignorance.md
@@ -1,168 +1,292 @@
-# RFC-OAS-009: Tool Name Ignorance (OAS는 consumer의 tool 이름을 모른다)
+# RFC-OAS-009 (v2): Sever Core→CDAL Dependencies
 
 | | |
 |---|---|
-| Status | Draft |
+| Status | Draft (v2 — supersedes merged v1 in-place) |
 | Author | jeong-sik (with Claude analysis) |
-| Created | 2026-05-08 |
+| Created | 2026-05-08 (v1) / 2026-05-08 (v2 redefinition) |
 | Target | `agent_sdk` (oas) v0.193+ |
-| Supersedes | None |
-| Related | RFC-OAS-008 (typed tool identification) — 본 RFC가 그 한계를 보강 |
+| Supersedes | RFC-OAS-009 v1 (머지 후 의도 재정의) |
+| Related | RFC-OAS-011 (CDAL Migration to masc-mcp), RFC-OAS-012 (Tool Name Ignorance within CDAL) |
 
-## 0. Summary
+## 0. Revision History
 
-OAS는 일반 Agent SDK다. 어떤 consumer (masc-mcp / Claude Code agent harness / Serena MCP / claude-in-chrome MCP / computer-use)의 *tool 이름*도 OAS lib 코드에 박혀있어선 안 된다. Tool effect class는 *consumer가 자기 `Tool.descriptor.mutation_class`에 박고* OAS는 *런타임에 읽기만* 한다 (Inversion of Control).
+| Version | Merged | Title | Status |
+|---|---|---|---|
+| v1 | PR #1478 (`7149c5a7`, 2026-05-08 12:41Z) | "Tool Name Ignorance (OAS는 consumer tool 이름을 모름)" — `default_tool_entries` 등 *내부 정리* 의도 | **Superseded** by v2. v1 본문은 git history에 보존 |
+| v2 (this) | TBD | "Sever Core→CDAL Dependencies" — *경계 재정의*의 전제 작업 | Draft |
 
-본 RFC는 RFC-OAS-008(typed tool identification)이 *식별의 정확성*은 풀었으나 *layering 위반*은 풀지 않은 점을 보강한다. 적용 범위는 **OAS 내부의 4건 위반 제거**: `mode_enforcer.default_tool_entries`(46개 외부 builtin string 하드코딩), `mode_enforcer.classify_tool` 글로벌 함수(호출처 0건의 죽은 API), RFC-OAS-008 PR-2의 `Tool_id` builtin variants, `mcp_schema.ml`의 builtin 이름 inline test.
+### 0.1 Why v2 redefinition
 
-cross-repo 영향 0 — masc-mcp는 자체 `classify_tool` 보유 + OAS의 violation 타입/serialization만 import (검증: `lib/violation_record.ml`, `autonomous/autonomous_executor.ml:19`).
+v1은 *OAS 내부의 `default_tool_entries` 표면 정리*에 머물렀다. PR #1478 Draft 검토 중 사용자가 다음 두 질문을 제기:
+
+1. *"경계 제대로 나뉘는거 맞냐?"*
+2. *"CDAL 이거는 어차피 masc 에서만 있음 되는거 아니냐"*
+
+이 두 질문이 v1 의도의 한계를 노출했다. grep 검증 결과 (§1.1):
+
+- OAS lib에 **두 패키지가 섞여있음**: `agent_sdk core` (README 약속) + `CDAL` ("PoC-1" 자기 표기, README/CLAUDE.md 미언급).
+- CDAL 외부 consumer: **masc-mcp 단일** (검증).
+- OAS core → CDAL 역방향 의존: **단 2 호출** (둘 다 동일 함수 `Mode_enforcer.builtin_descriptor`).
+
+→ 사용자 의도: CDAL은 masc-mcp로 이주해야 옳다. v1의 `default_tool_entries` 정리는 *이주 후* 진행하는 것이 깨끗 (RFC-OAS-012). 본 v2 RFC는 *이주의 전제*: OAS core → CDAL 의존을 0건으로 만드는 작업.
 
 ## 1. Problem Statement
 
-### 1.0 Retroactive moment
+### 1.0 Boundary 그림 (verified)
 
-RFC-OAS-008 PR-2 (#1475) 머지 직후, 사용자가 `Tool_id` Variant에 `Team_create | Team_delete`가 들어있는 것을 보고 다음 질문을 제기:
-
-> "야 Team 기능은 없는데 왜 한거야?"
-
-이 질문이 RFC-OAS-008의 한계를 노출한다. PR-2는 string→Variant 매핑의 *충실한 미러링*을 했을 뿐, *애초에 OAS가 이 46개 이름을 알아야 하는가*에는 답하지 않았다. Team_create/Team_delete는 Claude Code agent harness의 tool 이름이고, OAS lib는 Claude Code의 존재를 몰라야 한다.
-
-### 1.1 검증된 사실 (line-pinned, origin/main 3c67d1e5 기준)
-
-`lib/mode_enforcer.ml`:
-- L85+ `default_tool_entries : (string * tool_effect_class) list` — 46개 외부 builtin 이름 하드코딩.
-  - Serena MCP (11): `find_symbol`, `find_file`, `get_symbols_overview`, `find_referencing_symbols`, `search_for_pattern`, `create_text_file`, `replace_content`, `rename_symbol`, `insert_after_symbol`, `insert_before_symbol`, `replace_symbol_body`
-  - Claude Code core (13): `read`, `glob`, `grep`, `search`, `list_dir`, `read_file`, `write`, `edit`, `bash`, `ask_user_question`, `web_fetch`, `web_search`, `notebook_read`
-  - Claude Code Task/Team (8): `task_list`, `task_get`, `task_output`, `task_create`, `task_update`, `task_stop`, **`team_create`**, **`team_delete`**
-  - claude-in-chrome MCP (12): `read_console_messages`, `read_network_requests`, `get_page_text`, `read_page`, `tabs_context_mcp`, `navigate`, `computer`, `find`, `form_input`, `javascript_tool`, `tabs_create_mcp`, `upload_image`
-  - 기타 (2): `notebook_edit`, `execute_shell_command`
-- `default_tool_entries` 외부 의존: **0건** (검증: `rg -n "default_tool_entries" .` returned 0 matches outside `lib/mode_enforcer.ml`).
-
-`lib/mode_enforcer.mli`:
-- L84 `val classify_tool : string -> tool_effect_class` — 글로벌 함수. 호출처 검증:
-  - OAS 내부 호출: 0건
-  - masc-mcp 호출: 0건 (masc-mcp는 자체 `Autonomous_executor.classify_tool` 보유)
-  - 즉 **dead public API**.
-
-`lib/base/tool_id.ml` (RFC-OAS-008 PR-2, `8f413f8a`):
-- 46개 builtin Variant 케이스가 `default_tool_entries`를 그대로 미러. 외부 의존 0건이므로 비파괴적 제거 가능.
-
-`lib/protocol/mcp_schema.ml`:
-- L192-193 `let%test "descriptor_for_builtin_tool task_create is mutation"` — inline test가 builtin 이름을 lib 내부에 박는다. layering 위반의 *마지막 흔적*.
-
-### 1.2 OAS가 *이미* 갖고 있는 깨끗한 경로 (positive evidence)
-
-`lib/contract_runner.ml:96-110`:
-```ocaml
-let tool_classifications =
-  Agent.tools agent
-  |> Tool_set.to_list
-  |> List.filter_map (fun (t : Tool.t) ->
-    match t.descriptor with
-    | Some d ->
-      Option.bind d.Tool.mutation_class Mode_enforcer.mutation_class_of_string
-      |> Option.map (fun cls -> t.schema.name, cls)
-    | None -> None)
-in
-let enforcer_state =
-  Mode_enforcer.create
-    ~contract
-    ~effective_mode:mode_decision.effective_mode
-    ~tool_classifications
-    ()
+```
+OAS lib/ (157 top-level modules, 단일 dune library `agent_sdk`)
+├─ agent_sdk core (README/CLAUDE.md 약속한 표면)
+│   ├─ agent_sdk(.ml/.mli — façade), agent_tool, async_agent, subagent, agent_typed
+│   ├─ api, api_anthropic, api_openai, api_zai, client, internal_client, provider_*
+│   ├─ tool, tool_set, tool_index, tool_middleware, typed_tool, hooks
+│   ├─ runtime, runtime_*, streaming, transport
+│   ├─ harness, harness_*, eval, eval_*
+│   ├─ pipeline/ (6-stage 턴 파이프라인 — CLAUDE.md)
+│   ├─ protocol/ (A2A, Agent Card, MCP — CLAUDE.md)
+│   ├─ agent/ (Agent 라이프사이클, 턴 실행, 도구 호출 — CLAUDE.md)
+│   └─ base/ (Completion_contract_id, Tool, Hooks, Error, Util, Types)
+│
+└─ CDAL (Contract-Driven Agent Loop, "PoC-1" 자기 표기)
+    ├─ Self-tagged (mli에 "CDAL PoC-1" 명시): cdal_proof, execution_mode,
+    │     mode_resolver, proof_capture, proof_store, risk_class, risk_contract
+    ├─ Implied (CDAL 모듈에 의존, 동일 layer): mode_enforcer, contract_runner,
+    │     audit, autonomy_*, cognitive_event, completion_contract,
+    │     guardrail_*, guardrails_async, verified_output, conformance,
+    │     direct_evidence, effect_evidence, runtime_evidence, sessions_proof
+    └─ ~ 30 modules total
 ```
 
-이 경로가 *옳은 패턴*이다. 각 Tool이 자기 `descriptor.mutation_class`를 가지고 다니고, runtime이 그것만 읽어 분류 리스트를 빌드한다. consumer가 자기 도구를 등록할 때 effect class를 함께 박는다 — OAS는 string도 Variant도 *모른다*.
+### 1.0.1 OAS의 *공식 문서*는 CDAL을 모른다
 
-`Mode_enforcer.create`의 `?tool_classifications` 옵셔널 파라미터는 이미 *Inversion-of-Control 진입점*. RFC-OAS-009는 사실상 "기본값(default_tool_entries)을 비우고 깨끗한 경로만 살린다"는 작은 작업이다.
+- **README.md**: *"OCaml agent SDK on OCaml 5.x + Eio. Talks to Anthropic Messages API and OpenAI-compatible chat endpoints"*. CDAL/Contract/Proof/Audit/Mode 언급 0건.
+- **dune-project synopsis**: *"Anthropic Agent SDK for OCaml (Eio Edition). A native OCaml implementation of the Anthropic Agent SDK using OCaml 5.x Eio"*. CDAL 언급 0건.
+- **CLAUDE.md**: *"Layer 1: Agent Runtime — 단일 에이전트 실행 엔진"*. CDAL/Contract/Proof/Audit/Mode 언급 0건. `lib/` 디렉토리 표에 CDAL 카테고리 *없음*.
 
-### 1.3 무엇이 망가지나
+즉 *3개 공식 문서*가 OAS = "agent SDK + LLM client + agent loop"로 일관되게 정의. CDAL은 어디에도 OAS의 정식 책임으로 표기되지 않음. 그러나 *코드는* CDAL 30+ 모듈을 lib/에 거주시킴 — **문서·코드 incongruence**.
 
-1. **Layering 위반**: OAS는 Claude Code/Serena/claude-in-chrome/Team 개념을 *몰라야* 하는 라이브러리인데 lib 코드에 그 이름들이 박혀 있음. CLAUDE.md의 *AI 코드 생성 안티패턴 #3 (Boundary Violation)* 정확한 위반.
-2. **Dead public API**: `classify_tool : string -> tool_effect_class`는 호출처가 없는데도 `.mli`에 노출되어 *외부 약속처럼 보임*. 향후 consumer가 잘못된 IoC 진입점으로 삼을 수 있음.
-3. **Workaround 토양**: 46개 builtin이 lib 내부에 있으면, 새 도구 추가 시 *자연스럽게* 47번째를 박는 PR이 등장한다. 이는 `workaround_rejection_bar` 시그니처 #2 (String 분류기 보강)의 정확한 양분.
-4. **이중 분류 경로**: `default_tool_entries`(글로벌 하드코딩)와 `Tool.descriptor.mutation_class`(consumer-supplied) 두 경로가 공존. 같은 도구 이름이 두 경로에서 다르게 분류될 위험.
+### 1.1 Verified facts (line-pinned, origin/main `fd28104b` 기준)
 
-### 1.4 무엇이 *문제 아닌가* (out of scope)
+#### 1.1.1 OAS core → CDAL 역방향 의존 = **단 2 호출**
 
-- **`?tool_classifications` 옵셔널 → required 전환**: 외부 consumer 깰 수 있어 별도 RFC. RFC-OAS-009는 *기본값을 비우는 것*까지만.
-- **`Tool.descriptor.mutation_class` 자체의 Variant화**: 현재 `string option` 타입. 별도 RFC.
-- **PPX 자동 생성**: RFC-OAS-008 §1.3의 out-of-scope 그대로 유지.
-- **masc-mcp의 자체 `classify_tool` 통합**: cross-repo 의사결정. 별도 RFC.
+```
+$ rg -n "Cdal_proof|Mode_enforcer|Risk_contract|Execution_mode|Proof_capture|Proof_store" \
+       lib/agent/ lib/llm_provider/ lib/protocol/ lib/base/
+```
+
+결과:
+- `lib/agent/agent_tools.ml:68` — `Mode_enforcer.builtin_descriptor tool.schema.name`
+- `lib/protocol/mcp_schema.ml:63` — `let descriptor_for_builtin_tool = Mode_enforcer.builtin_descriptor`
+
+이게 전부. 이 두 호출은 *동일 함수* (`Mode_enforcer.builtin_descriptor`)이고, 둘 다 *fallback 경로*에 있다 (Tool.descriptor가 없을 때만 builtin registry 조회).
+
+#### 1.1.2 base는 CDAL 의존 0
+
+```
+$ rg -n "Cdal_proof|Mode_enforcer|Risk_contract|Execution_mode|Proof_capture|Audit\b|Autonomy_" lib/base/
+```
+
+결과: `lib/base/error.ml:40`, `lib/base/error.mli:39`에서 `Completion_contract_id.t` 사용. 이건 `Agent_sdk_base.Completion_contract_id` (base 자체의 type), CDAL 아님. CDAL 모듈 import: 0건.
+
+#### 1.1.3 `Completion_contract` 모듈은 *core* (CDAL 아님)
+
+검증:
+- `lib/completion_contract.mli` 미존재 — *gold-standard CDAL 7개* (cdal_proof, execution_mode, mode_resolver, proof_capture, proof_store, risk_class, risk_contract)에 안 들어감.
+- `lib/completion_contract.ml`: `type t = Completion_contract_id.t = ...` — base의 variant를 re-export + satisfaction predicate (`required_tool_satisfaction`, `any_tool_call_satisfies`, `effectful_tool_satisfies`).
+- CDAL import: 0건 (검증: `rg -n "Cdal_proof|Mode_enforcer|Risk_contract|Execution_mode|Proof_capture|Proof_store|Audit\b|Autonomy_" lib/completion_contract.ml`).
+- 의존: `Types`, `Log`, `Tool`, `Yojson`, `Completion_contract_id` — 모두 base/core.
+
+따라서 `agent/agent_types.ml`/`agent.mli`/`builder.ml`이 사용하는 `Completion_contract.required_tool_satisfaction`은 *core 내부 의존*. CDAL 의존 아님.
+
+#### 1.1.4 pipeline은 core (Completion_contract만 사용)
+
+`lib/pipeline/pipeline_common.ml`/`pipeline.ml`의 의존:
+- `Completion_contract.of_tool_choice` / `validate_response` / `Require_tool_use` / `Allow_text_or_tool` / `Require_specific_tool` / `Require_no_tool_use` / `tool_use_names` / `resolve_tool_choice_contract`.
+- 모두 `Completion_contract` 모듈 (§1.1.3에서 core로 분류됨).
+- CDAL 모듈 호출: 0건.
+
+#### 1.1.5 `lib/agent_sdk.ml`/`mli`는 *façade* (re-export only)
+
+```
+$ rg -n "module\s+(Cdal_proof|Mode_enforcer|...)" lib/agent_sdk.ml lib/agent_sdk.mli
+```
+
+결과: 16개 CDAL 모듈을 façade로 re-export (예: `module Mode_enforcer = Mode_enforcer`, `module Cdal_proof = Cdal_proof`, `module Risk_contract = Risk_contract`, `module Audit = Audit`, …). 이건 *코드 의존*이 아니라 *공개 표면 노출*. β3 진행 시 이 16 라인을 *삭제 또는 sublibrary 경유 re-export로 변경*하면 끝.
+
+#### 1.1.6 CDAL 외부 consumer: masc-mcp 단일
+
+masc-mcp의 OAS CDAL 표면 사용 (검증: `rg -n "Mode_enforcer\.|Cdal_proof\.|Risk_contract\.|Risk_class\.|Execution_mode\." ~/me/workspace/yousleepwhen/masc-mcp/lib/`):
+
+masc-mcp가 *사용하는* CDAL 표면:
+- `Mode_enforcer.violation_kind` / `violation` / serialization 함수 (type re-export at `violation_record.ml`/`mli`)
+- `Cdal_proof.t` / `schema_version_current` / `of_json` / `to_json` / `run_id` / `result_status` / `artifact_ref`
+- `Risk_contract.t` / `of_yojson` / `contract_id` (`cdal_loader.ml`)
+- `Execution_mode.t` / `Execute` / `Draft` / `Diagnose` / `of_yojson`
+
+masc-mcp가 *호출하지 않는* CDAL API: `Mode_enforcer.classify_tool` / `all_read_only` / `all_workspace_only` / `builtin_descriptor` / `create` / `hooks` / `Contract_runner.*` / `Mode_resolver.*` / `Proof_capture.*` / `Audit.*` / `Autonomy_*.*` / `Effect_evidence.*` / `Direct_evidence.*` / `Verified_output.*` / `Conformance.*` / `Cognitive_event.*` / `Guardrail_*`.
+
+즉 masc-mcp는 *CDAL의 type/serialization*만 사용. 실행 함수(create/hooks/runner)는 미호출 — masc-mcp 자체에 자기 governance가 있음 (`autonomous/autonomous_executor.ml:19` `let classify_tool = ...`).
+
+#### 1.1.7 CDAL 안 leaf 순서 (RFC-OAS-011 batch 순서 결정용)
+
+```
+for m in cdal_proof execution_mode risk_class risk_contract mode_resolver proof_capture proof_store mode_enforcer contract_runner audit autonomy_exec autonomy_diff_guard cognitive_event verified_output guardrail_llm conformance direct_evidence effect_evidence; do
+  count=$(rg -l "Cdal_proof|Mode_enforcer|...|Effect_evidence" lib/$m.ml lib/$m.mli | wc -l)
+  echo "$m: imports $count CDAL files"
+done
+```
+
+결과:
+- **Pure leaves (0 CDAL imports)**: `execution_mode`, `effect_evidence`, `guardrail_llm`
+- **Low-deps (1)**: `verified_output`, `conformance`
+- **Mid+High-deps (2+)**: 나머지 (cdal_proof, risk_class, risk_contract, mode_resolver, proof_capture, proof_store, mode_enforcer, contract_runner, audit, autonomy_exec, autonomy_diff_guard, cognitive_event, direct_evidence)
+
+→ RFC-OAS-011은 leaf-first 5-batch migration.
+
+### 1.2 무엇이 망가져 있나
+
+1. **Layering 위반**: `agent_tools` (core, agent loop의 일부) → `Mode_enforcer.builtin_descriptor` (CDAL) — 의존 그래프가 하층 → 상층으로 흐름.
+2. **공식 문서 약속 위반**: README/dune-project/CLAUDE.md는 OAS = "Anthropic Agent SDK + LLM client + agent loop"로 일관 정의. CDAL은 약속 표면에 *없음*에도 lib/에 거주.
+3. **이주 차단**: RFC-OAS-011 (CDAL → masc-mcp 이주)이 진행되려면 core → CDAL 의존이 0이어야 함. 본 RFC는 그 전제.
+4. **호출이 fallback에 위치**: 두 호출 모두 *Tool.descriptor가 없을 때*의 fallback 경로. 즉 *primary path*는 이미 깨끗 (`contract_runner.ml:96-110`이 `Tool.descriptor.mutation_class` 직접 사용). fallback만 끊으면 됨.
+
+### 1.3 무엇이 *문제 아닌가* (Out of scope)
+
+- **CDAL 모듈 자체의 이주**: RFC-OAS-011 (별도).
+- **`default_tool_entries` 정리 / `classify_tool` 글로벌 제거 / `builtin_descriptor` 자체 제거**: RFC-OAS-012 (CDAL 이주 *후*).
+- **`agent_sdk.ml` façade의 16개 re-export 라인 정리**: RFC-OAS-011 §3.
+- **base/Completion_contract/pipeline의 의존**: §1.1.2~4에서 core로 확정 — 변경 불필요.
 
 ## 2. Proposal
 
-### 2.1 Tool effect class는 *Tool과 함께 다닌다*
+### 2.1 변경 1: `lib/agent/agent_tools.ml:68`의 builtin_descriptor fallback 제거
 
-**원칙**: OAS lib 코드는 어떤 consumer의 tool 이름도 알지 못한다. 분류는 다음 경로로만 흐른다:
+#### Before
 
+```ocaml
+let concurrency_class_of_tool tool =
+  match Tool.descriptor tool with
+  | Some descriptor -> concurrency_class_from_descriptor descriptor
+  | None ->
+    (* Fallback: check builtin descriptor registry before defaulting *)
+    (match Mode_enforcer.builtin_descriptor tool.schema.name with
+     | Some descriptor -> concurrency_class_from_descriptor descriptor
+     | None -> Tool.Sequential_workspace)
+;;
 ```
-consumer (masc-mcp / Claude Code / Serena / ...)
-   |
-   | (1) Tool.create ~name ~descriptor:{ mutation_class = "Read_only"; ... }
-   v
-Agent.tools (consumer-supplied tool set)
-   |
-   | (2) Mode_enforcer.create ~tool_classifications:[<from Tool.descriptor>]
-   v
-Mode_enforcer.state (no global, no hardcoded names)
+
+#### After
+
+```ocaml
+let concurrency_class_of_tool tool =
+  match Tool.descriptor tool with
+  | Some descriptor -> concurrency_class_from_descriptor descriptor
+  | None -> Tool.Sequential_workspace  (* fail-closed, no CDAL fallback *)
+;;
 ```
 
-OAS lib는 (2)에서 `tool_classifications`로 들어온 분류만 사용한다. (1)에서 미지정한 도구는 fallback `External_effect` (fail-closed) — 이미 구현됨, 변경 없음.
+#### 동작 변화
 
-### 2.2 4건 위반 제거 매트릭스
+| 입력 | Before | After |
+|---|---|---|
+| Tool with `descriptor` | `concurrency_class_from_descriptor` | 동일 (변경 없음) |
+| Tool without descriptor, name in CDAL `default_tool_entries` | descriptor에서 추출 | `Sequential_workspace` (fail-closed) |
+| Tool without descriptor, name unknown | `Sequential_workspace` | 동일 (변경 없음) |
 
-| 위치 | 변경 |
-|---|---|
-| `mode_enforcer.ml` `default_tool_entries` | `[]` 빈 리스트로. 46개 외부 이름 제거 |
-| `mode_enforcer.ml` `tool_registry` 초기 시드 | `default_tool_entries` 의존 제거. 빈 Hashtbl로 시작 |
-| `mode_enforcer.mli` `val classify_tool` | `[@@deprecated]` 마크 → 다음 minor에서 완전 제거 |
-| `mode_enforcer.ml` `classify_tool` 구현 | `tool_registry` lookup 유지하되 Hashtbl이 비어있으므로 항상 fallback |
-| `tool_id.ml` (RFC-OAS-008 PR-2 main 잔존) | `type t = Mcp of {server; tool} \| User of string`만 남김. 46 builtin 제거 |
-| `mcp_schema.ml:192-193` builtin inline test | 제거. consumer-side로 이동 (해당 inline test 의존자 grep 후) |
+Tool.descriptor를 채우지 않은 *legacy consumer*가 있다면 그 동시성 분류가 가장 보수적인 `Sequential_workspace`로 떨어짐. 안전 측면에서 더 엄격해지는 변경 (over-serialize 위험만 있음, race condition 위험은 없음).
 
-### 2.3 Backward compatibility
+### 2.2 변경 2: `lib/protocol/mcp_schema.ml:63`의 `descriptor_for_builtin_tool` 제거
 
-- `Mode_enforcer.create` 시그니처 **변경 없음** (`?tool_classifications` 옵셔널 그대로).
-- `Mode_enforcer.classify_tool` 시그니처 변경 없음 (deprecated mark만, 구현은 살아있음). 다음 minor에서 제거.
-- `Tool_id.t` 타입 시그니처 변경 (PR-2 머지 직후라 외부 호출처 0건. 검증: `rg -n "Tool_id\." lib/ test/` returned 0).
-- masc-mcp 영향 0 (자체 `classify_tool` + OAS violation type/serialization만 import).
+#### Before
 
-## 3. PR 시리즈 (5단계)
+```ocaml
+let descriptor_for_builtin_tool = Mode_enforcer.builtin_descriptor
 
-| PR | 내용 | 단일 파일? | 위험 |
+let mcp_tool_to_sdk_tool ~call_fn mcp_tool =
+  let params = json_schema_to_params mcp_tool.input_schema in
+  Tool.create
+    ?descriptor:(descriptor_for_builtin_tool mcp_tool.name)
+    ~name:mcp_tool.name
+    ~description:mcp_tool.description
+    ~parameters:params
+    call_fn
+;;
+```
+
+#### After
+
+```ocaml
+(* descriptor_for_builtin_tool removed: MCP→SDK Tool conversion no longer
+   consults the CDAL builtin registry. Consumer is responsible for supplying
+   descriptor through MCP tool annotation or a post-conversion enrichment hook. *)
+
+let mcp_tool_to_sdk_tool ~call_fn mcp_tool =
+  let params = json_schema_to_params mcp_tool.input_schema in
+  Tool.create
+    ~name:mcp_tool.name
+    ~description:mcp_tool.description
+    ~parameters:params
+    call_fn
+;;
+```
+
+#### 동작 변화
+
+MCP server가 노출한 tool을 SDK Tool.t로 변환할 때, descriptor가 *None*으로 시작. consumer가 변환 직후 `Tool.with_descriptor` 또는 별도 enrichment 단계에서 채워야 함. RFC-OAS-012가 이 자리를 *consumer-side annotation* (MCP `_meta` field 또는 명시적 register)으로 채움.
+
+### 2.3 inline test 정리
+
+`lib/protocol/mcp_schema.ml:192-193`의 `let%test "descriptor_for_builtin_tool task_create is mutation"` test는 함수 제거와 함께 사라짐. 다른 builtin 이름이 박힌 inline test는 일괄 grep 후 PR-C 안에서 정리.
+
+## 3. Backward Compatibility
+
+### 3.1 OAS 내부 호출자 영향
+
+- `concurrency_class_of_tool`의 호출자 (`agent_tools.ml:88` `schedule_tool_use`): *Tool.descriptor 채워진 경우 영향 0*.
+- `mcp_tool_to_sdk_tool`의 호출자: PR-C 작성 시 `rg -n "mcp_tool_to_sdk_tool" lib/ test/`로 검증.
+
+### 3.2 외부 consumer (masc-mcp) 영향
+
+- masc-mcp는 `Mode_enforcer.builtin_descriptor`를 직접 호출하지 않음 (§1.1.6 verified).
+- masc-mcp가 사용하는 표면 (violation type, Cdal_proof, Risk_contract, Execution_mode)은 본 RFC에서 변경 없음.
+- 영향: **0건**.
+
+### 3.3 Wire/JSON schema 호환
+
+- 본 RFC는 *함수 시그니처/구현*만 변경. type/JSON schema는 불변.
+- masc-mcp manifest 파일과의 호환성: 변경 없음.
+
+## 4. Migration Plan
+
+| PR | Branch | 내용 | 의존 |
 |---|---|---|---|
-| **A** (본 PR) | `docs/rfc/RFC-OAS-009-tool-name-ignorance.md` 추가 (구현 0줄) | yes | 0 |
-| **B** | `mode_enforcer.ml` `default_tool_entries → []`. parity test 제거. `classify_tool` 글로벌 함수에 `[@@deprecated "RFC-OAS-009: use Mode_enforcer.create ~tool_classifications"]` | yes | 낮음 (callers 0) |
-| **C** | `tool_id.ml` `type t = Mcp of {server;tool} \| User of string`만. PR-B 이후 builtin variants가 unused identifier로 잔존하던 것을 제거 | yes | 중간 (PR-2 후속) |
-| **D** | `mcp_schema.ml` builtin inline test 정리. 다른 builtin 이름 inline test 전수 grep 후 제거 | 1-2 파일 | 낮음 |
-| **E** | `Mode_enforcer.classify_tool` 글로벌 함수 *완전 제거* (`.mli`에서 삭제). PR-3 (#1476) close. RFC-OAS-009 마무리 | 단일 파일 | 낮음 |
+| **A** (this) | `feature/rfc-oas-009-v2-sever-cdal-deps` | RFC-OAS-009 v2 본문 + RFC-OAS-011 + RFC-OAS-012 docs | 독립 |
+| **B** | `feature/rfc-oas-009-pr-b-agent-tools` | `agent_tools.ml:68`의 builtin_descriptor fallback 제거. inline test 추가 (Tool descriptor 없음 → Sequential_workspace) | A 머지 후 |
+| **C** | `feature/rfc-oas-009-pr-c-mcp-schema` | `mcp_schema.ml:63`의 `descriptor_for_builtin_tool` 제거. mcp_tool_to_sdk_tool descriptor=None로. inline test 정리 | B 머지 후 |
+| **D** | `feature/rfc-oas-009-pr-d-verify-zero-deps` | 검증 PR: `rg -n "Cdal_proof|Mode_enforcer|Risk_contract|Risk_class|Execution_mode|Proof_capture|Proof_store" lib/agent/ lib/llm_provider/ lib/protocol/ lib/base/`가 0건 반환을 *CI lint*로 강제 | C 머지 후 |
 
-각 PR은 Draft + `human-approved-ready` 라벨 게이트. cron+자동 PR 패턴 거부 (메모리 `feedback_user_rejects_cron_pr_loop.md` 준수).
+각 PR은 Draft + `human-approved-ready` 라벨 게이트 (메모리 `feedback_user_rejects_cron_pr_loop`, `feedback_masc_mcp_draft_guard_blocks_agent_ready` 준수). cron+자동 PR 패턴 거부.
 
-## 4. Migration
-
-### 4.1 PR-3 (#1476) 처리
-
-PR-3 (`feature/rfc-oas-008-mode-enforcer-typed`)은 `default_tool_entries → Tool_id` 매핑이다. 본 RFC가 `default_tool_entries`를 비우므로 매핑 대상이 사라짐. PR-A 머지 후 close. close 코멘트에서 본 RFC를 reference로 인용.
-
-### 4.2 RFC-OAS-008과의 관계
-
-RFC-OAS-008은 *closed*되지 않는다. PR-2 (Tool_id 모듈 자체)는 `Mcp/User` 형태로 살아남는다 — 외부 tool 식별을 *typed Mcp* 형태로 잡는 가치는 유지. 다만 **builtin variants는 RFC-OAS-008의 잘못된 mirror**였음을 본 RFC §1.0에 명시.
-
-## 5. Risks (3건)
+## 5. Risks (4건)
 
 | # | 위험 | 완화 |
 |---|---|---|
-| 1 | PR-2 main 잔존 → builtin variants가 unused identifier로 PR-C 머지까지 잠시 남음 | OCaml `unused-constructor` warning만 발생, 동작 영향 0. PR-B 본문에 명시 |
-| 2 | `mcp_schema.ml` inline test가 다른 OAS lint/CI에 묶여있을 수 있음 | PR-D 작성 시 `rg -n "descriptor_for_builtin_tool" lib/ test/` 1회 grep 의무 |
-| 3 | `?tool_classifications`을 미공급한 외부 consumer가 빈 분류로 fail-closed에 걸림 | 의도된 동작. consumer가 자기 도구 분류를 register하지 않으면 `External_effect` fallback (fail-closed가 OAS의 기본 안전 정책) |
+| 1 | Tool.descriptor를 채우지 않은 *외부 consumer*가 빈 descriptor 반환에 의존 | §2.1 동작 변화 표 참조: 가장 보수적 분류 (`Sequential_workspace`)로 fail-closed. 안전 측면에서 더 엄격 |
+| 2 | `mcp_tool_to_sdk_tool`의 호출자가 descriptor=None Tool을 그대로 hook chain에 보내면 `mode_enforcer.classify_tool` 글로벌이 `External_effect` fallback 처리 (현재 동작 그대로 유지) | RFC-OAS-012가 `classify_tool` 글로벌 자체를 정리. 본 RFC 범위 외 |
+| 3 | inline test 제거가 다른 dune build/CI에 묶여있을 수 있음 | PR-C 작성 시 `rg -n "descriptor_for_builtin_tool" lib/ test/`로 grep 의무. 0건 확인 후 제거 |
+| 4 | RFC-OAS-009 v1이 main에 머지된 상태에서 v2로 본문 대체 — git history에 의도 변경이 모호하게 보일 수 있음 | §0 Revision History를 본 RFC 본문 첫 섹션에 명시. v1 PR (#1478)에 v2 redefinition 코멘트 추가 |
 
 ## 6. References
 
-- RFC-OAS-008: Typed Tool Identification (Phase 1)
-- CLAUDE.md `AI 코드 생성 안티패턴` §3 Boundary Violation
-- CLAUDE.md `워크어라운드 거부 기준` 시그니처 #2 String 분류기 보강
-- 메모리 `feedback_user_rejects_cron_pr_loop` (2026-05-07): 본 RFC도 stacked Draft PR + 라벨 게이트 준수
-- 메모리 `feedback_rfc_section_1_4_caller_context_unverified` (2026-05-05): 본 RFC §1.1의 line-pinned 검증은 본 메모리 룰 적용
-- `lib/contract_runner.ml:96-110` (positive evidence — 깨끗한 경로)
+- RFC-OAS-008: Typed Tool Identification
+- RFC-OAS-009 v1 (`docs/rfc/RFC-OAS-009-tool-name-ignorance.md`, merged `7149c5a7`): superseded by this v2
+- RFC-OAS-011 (this PR): CDAL Migration to masc-mcp — *follow-up* to this RFC
+- RFC-OAS-012 (this PR): Tool Name Ignorance within CDAL — RFC-OAS-009 v1의 *원의도*가 이주 후 흡수되는 곳
+- README.md (OAS): "Anthropic Agent SDK for OCaml (Eio Edition)" — CDAL은 약속에 없음
+- CLAUDE.md (OAS): "Layer 1: Agent Runtime — 단일 에이전트 실행 엔진" — CDAL 카테고리 없음
+- `lib/cdal_proof.mli` line 4: "Part of the Contract-Driven Agent Loop (CDAL) PoC-1"
+- `lib/contract_runner.ml:96-110` (positive evidence — 깨끗한 `Tool.descriptor` 경로)
+- 메모리 `feedback_rfc_section_1_4_caller_context_unverified` (2026-05-05): line-pinned 검증 룰
+- 메모리 `feedback_user_rejects_cron_pr_loop` (2026-05-07): Draft + `human-approved-ready` 라벨 게이트
+- 메모리 `feedback_masc_mcp_draft_guard_blocks_agent_ready` (2026-05-05): agent ready_for_review 자동 거부 — Draft 유지

--- a/docs/rfc/RFC-OAS-011-cdal-migration-to-masc-mcp.md
+++ b/docs/rfc/RFC-OAS-011-cdal-migration-to-masc-mcp.md
@@ -1,0 +1,301 @@
+# RFC-OAS-011: CDAL Migration to masc-mcp
+
+| | |
+|---|---|
+| Status | Draft |
+| Author | jeong-sik (with Claude analysis) |
+| Created | 2026-05-08 |
+| Target | `agent_sdk` (oas) v0.193+ → CDAL 30+ 모듈 제거 / `masc_mcp` v0.20+ → `masc_mcp.cdal` sublibrary 신설 |
+| Supersedes | None |
+| Depends-on | RFC-OAS-009 v2 (Sever Core→CDAL Dependencies) — *완료 후* 본 RFC 진행 |
+| Related | RFC-OAS-012 (Tool Name Ignorance within CDAL) |
+
+## 0. Summary
+
+CDAL (Contract-Driven Agent Loop) 30+ 모듈을 OAS lib에서 *제거*하고 masc-mcp의 새 sublibrary `masc_mcp.cdal`로 이주한다.
+
+**근거**:
+- OAS의 README/dune-project synopsis/CLAUDE.md 어디에도 CDAL이 OAS의 정식 책임으로 명시되지 않음 (RFC-OAS-009 §1.0.1 verified).
+- CDAL 외부 consumer는 masc-mcp 단일 (RFC-OAS-009 §1.1.6 verified).
+- CDAL 자체 mli 7개가 *"PoC-1"*로 자기 표기 — *experimental*임을 인정.
+- RFC-OAS-009 v2 완료 후 OAS core → CDAL 역방향 의존 0건이 됨 — 이주 가능 조건 충족.
+
+**결과**:
+- OAS lib는 README가 약속한 "Anthropic Agent SDK + LLM client + agent loop" 표면만 보유.
+- CDAL은 자기 *유일한 consumer* 안에 거주 — multi-agent governance가 multi-agent coordinator의 일부라는 *자연스러운 위치*.
+- 새 generic agent SDK consumer (CDAL 불필요)는 OAS만 의존.
+
+## 1. Problem Statement
+
+### 1.0 OAS lib는 *약속한 것보다 많은 것*을 갖고 있다
+
+#### 약속 (3개 공식 문서)
+- README.md: *"OCaml agent SDK on OCaml 5.x + Eio. Talks to Anthropic Messages API and OpenAI-compatible chat endpoints"*
+- dune-project synopsis: *"Anthropic Agent SDK for OCaml (Eio Edition)"*
+- CLAUDE.md: *"Layer 1: Agent Runtime — 단일 에이전트 실행 엔진"*
+
+#### 실제
+- 157 top-level modules
+- 그중 ~30 모듈이 *Contract-Driven Agent Loop (CDAL) PoC-1* — governance/proof/audit framework
+- 7 mli가 *"Part of the Contract-Driven Agent Loop (CDAL) PoC-1"*으로 자기 표기
+
+### 1.1 CDAL 모듈 인벤토리 (verified, line-pinned)
+
+#### 1.1.1 Self-tagged CDAL (mli "PoC-1" 표기, 7개)
+
+```
+$ rg -l "Part of the Contract-Driven Agent Loop|CDAL PoC" lib/
+```
+
+결과:
+- `lib/cdal_proof.mli`
+- `lib/execution_mode.mli`
+- `lib/mode_resolver.mli`
+- `lib/proof_capture.mli`
+- `lib/proof_store.mli`
+- `lib/risk_class.mli`
+- `lib/risk_contract.mli`
+
+이 7개는 *gold-standard CDAL*. 자기 선언.
+
+#### 1.1.2 Implied CDAL (gold-standard에 의존, 동일 layer로 간주)
+
+| 모듈 | gold-standard 의존 | 비고 |
+|---|---|---|
+| `mode_enforcer` | `Execution_mode`, `Risk_contract` | core가 호출 (RFC-OAS-009 §1.1.1) — RFC-OAS-009 v2 PR-B/C에서 끊음 |
+| `contract_runner` | `Risk_contract`, `Execution_mode`, `Cdal_proof` | masc-mcp 호출 0 |
+| `audit` | `Cdal_proof` | masc-mcp 호출 0 |
+| `autonomy_exec` | `Audit`, `Cdal_proof` | masc-mcp 호출 0 |
+| `autonomy_diff_guard` | `Audit` | masc-mcp 호출 0 |
+| `autonomy_trace_analyzer` | (검증 필요) | masc-mcp 호출 0 |
+| `cognitive_event` | `Cdal_proof` | masc-mcp 호출 0 |
+| `completion_contract` | base only — *core* (RFC-OAS-009 §1.1.3) | **이주 대상 아님** |
+| `guardrail_llm` | (CDAL imports 0) | mli에 PoC 표기 없음, 의존 그래프상 CDAL — 분류 검토 |
+| `guardrail_tripwire` | (검증 필요) | 분류 검토 |
+| `guardrails_async` | (검증 필요) | 분류 검토 |
+| `verified_output` | `Cdal_proof` | masc-mcp 호출 0 |
+| `conformance` | `Cdal_proof` | masc-mcp 호출 0 |
+| `direct_evidence` | `Cdal_proof` | masc-mcp 호출 0 |
+| `effect_evidence` | (CDAL imports 0) | 분류 검토 |
+| `runtime_evidence` | (검증 필요) | 분류 검토 |
+| `sessions_proof` | `Cdal_proof` | masc-mcp 호출 0 |
+
+→ **PR-A 머지 전 검증 필요**: 분류 검토 표시된 모듈은 PR-A 작성 직전 mli/ml 1차 grep으로 *정확한 layer*를 확정한다. core이면 이주 제외, CDAL이면 이주 포함.
+
+#### 1.1.3 Migration batch 순서 (leaf-first, 5 batches)
+
+CDAL 모듈끼리의 의존 그래프 (RFC-OAS-009 §1.1.7 verified):
+
+| Batch | 모듈 | leaf-status |
+|---|---|---|
+| **B1 (pure leaves)** | `execution_mode`, `effect_evidence`, `guardrail_llm` | 0 CDAL imports |
+| **B2 (low-deps)** | `risk_class`, `verified_output`, `conformance` | 1 CDAL import |
+| **B3 (mid-deps)** | `risk_contract`, `cdal_proof`, `mode_resolver`, `cognitive_event` | 2+ CDAL imports |
+| **B4 (high-deps)** | `proof_capture`, `proof_store`, `mode_enforcer`, `contract_runner`, `direct_evidence` | gold-standard 다수 의존 |
+| **B5 (top-deps)** | `audit`, `autonomy_exec`, `autonomy_diff_guard`, `sessions_proof` + 분류 검토 통과 모듈 | 모두 합체 |
+
+각 batch는 *별도 PR*. 빌드 clean + dune runtest 회귀 0이 batch 통과 조건.
+
+### 1.2 masc-mcp 측 사용 표면 (이주 후 inline 가능 여부 평가)
+
+masc-mcp가 *사용하는* CDAL 표면 (RFC-OAS-009 §1.1.6):
+- `Mode_enforcer.violation_kind` / `violation` / serialization (`violation_record.ml`/`mli`)
+- `Cdal_proof.t` / `schema_version_current` / `of_json` / `to_json` / `run_id` / `result_status` / `artifact_ref`
+- `Risk_contract.t` / `of_yojson` / `contract_id`
+- `Execution_mode.t` / variants / `of_yojson`
+
+이주 후 masc-mcp가 *직접 정의*: `Masc_mcp.Cdal.Mode_enforcer.violation`, `Masc_mcp.Cdal.Cdal_proof.t`, … 동일 type, 동일 serialization. 호출 코드만 prefix 변경.
+
+이주 후 masc-mcp가 *호출하지 않는* CDAL API: `classify_tool` / `all_read_only` / `all_workspace_only` / `builtin_descriptor` / `create` / `hooks` / `Contract_runner.*` / `Mode_resolver.*` / `Proof_capture.*` / `Audit.*` / `Autonomy_*.*` / `Effect_evidence.*` / `Direct_evidence.*` / `Verified_output.*` / `Conformance.*` / `Cognitive_event.*` — 즉 *대부분의 CDAL*은 masc-mcp 자체 호출자도 없음. *self-contained governance framework*가 *외부 호출 0*인 상태로 lib에 거주.
+
+→ 이주 후 *masc-mcp가 자기 호출 시작*할지, *deprecate*할지는 RFC-OAS-013+에서 결정 (본 RFC 범위 외).
+
+## 2. Proposal
+
+### 2.1 Target home: `masc-mcp/lib/cdal/` + dune sublibrary
+
+#### 새 dune library
+
+`~/me/workspace/yousleepwhen/masc-mcp/lib/cdal/dune`:
+
+```dune
+(library
+ (name masc_mcp_cdal)
+ (public_name masc_mcp.cdal)
+ (libraries
+   masc_types fs_compat time_compat masc_log
+   ; Note: NO dependency on agent_sdk's CDAL re-exports.
+   ;       Only depends on OAS's *core* (Tool, Hooks, base/types).
+   agent_sdk.base
+   yojson
+   ppx_deriving_yojson.runtime)
+ (preprocess
+  (pps ppx_deriving_yojson ppx_deriving.show ppx_inline_test ppx_let)))
+```
+
+masc-mcp의 main library가 `masc_mcp.cdal`을 의존하도록 `lib/dune`에 추가:
+
+```dune
+(library
+ (name masc_mcp)
+ (libraries
+   ...
+   masc_mcp.cdal     ; NEW
+   agent_sdk
+   agent_sdk.base
+   ...))
+```
+
+### 2.2 Module path 변환
+
+| Before (OAS) | After (masc-mcp) |
+|---|---|
+| `Agent_sdk.Cdal_proof` | `Masc_mcp_cdal.Cdal_proof` (또는 `Masc_mcp.Cdal.Cdal_proof`) |
+| `Agent_sdk.Mode_enforcer` | `Masc_mcp_cdal.Mode_enforcer` |
+| `Agent_sdk.Risk_contract` | `Masc_mcp_cdal.Risk_contract` |
+| `Agent_sdk.Execution_mode` | `Masc_mcp_cdal.Execution_mode` |
+| ... (30+ 모듈) | ... |
+
+### 2.3 Backward-compatibility shim (한시 유지)
+
+OAS 0.193 (이주 PR 머지 시점) 부터 0.194 (shim 제거 시점)까지 OAS lib에 *deprecated re-export* 유지:
+
+`lib/agent_sdk.ml`에 추가:
+```ocaml
+[@@@deprecated "RFC-OAS-011: CDAL moved to masc_mcp.cdal. Re-export will be removed in v0.194"]
+module Cdal_proof = Cdal_proof
+module Mode_enforcer = Mode_enforcer
+(* ...30+ 모듈 동일 패턴... *)
+```
+
+이 shim의 OAS lib 안 *원본 모듈*은 새 빈 stub (compile-only):
+
+`lib/cdal_proof.ml`:
+```ocaml
+(* DEPRECATED: This module has migrated to masc_mcp.cdal (RFC-OAS-011).
+   The implementation here is a compile-only re-export from masc_mcp.cdal.
+   Will be removed in agent_sdk v0.194. *)
+include Masc_mcp_cdal.Cdal_proof
+```
+
+→ **단, 이 패턴은 *역방향 의존*을 만들어 cycle 위험**: OAS lib가 masc_mcp.cdal에 의존하면 masc-mcp ↔ OAS 양방향 cycle. **Forbidden**. 따라서 shim은 *원본 코드를 OAS lib에 한시 유지*하고 masc-mcp에 *원본을 복사*하는 dual-source 방식으로 갈 수밖에 없음.
+
+#### Shim 설계 옵션
+
+| 옵션 | 면적 | 위험 |
+|---|---|---|
+| **A. Dual-source (원본을 OAS와 masc-mcp 양쪽에 한시 유지)** | OAS lib 변경 0 (이주 PR이 OAS 측에서는 *제거*만 수행). masc-mcp가 자기 카피 도입 | dual-source drift 위험 (한쪽만 수정되는 사고) → 이주 기간을 *짧게* (≤ 7일) 잡고 빠르게 OAS 측 제거 |
+| **B. No shim, hard switch** | OAS 0.193: CDAL 30+ 모듈 일괄 제거. masc-mcp 0.20: `masc_mcp.cdal` 신설 + agent_sdk pin 동시 bump | masc-mcp가 build break를 피하려면 *동시 머지* 필요. 머지 순서 race 위험 |
+| **C. opam package 분리 (`agent_sdk.cdal_legacy`)** | 별도 opam package로 한시 유지. masc-mcp 0.20+가 `agent_sdk.cdal_legacy`를 명시 의존 | opam package 추가 발급 + 추후 yank — 무거움 |
+
+**권장: B (Hard switch)**. 이유:
+- shim은 *drift 위험*을 키움 (메모리 `feedback_telemetry_as_fix_workaround` 정신).
+- 원본은 *masc-mcp가 자기 단독 consumer*임이 verified — 머지 순서만 잘 잡으면 hard switch가 깨끗.
+- 머지 순서: masc-mcp PR (cdal sublibrary 신설 + agent_sdk pin **현재 0.192 그대로**) → OAS PR (CDAL 제거, agent_sdk 0.193) → masc-mcp PR (agent_sdk pin → 0.193). 즉 *masc-mcp self-contained 시작*을 먼저 만들고, OAS 측 제거를 그 후에 하는 *zero-downtime* 시퀀스.
+
+### 2.4 OAS 측 제거 PR (B5 머지 후)
+
+`lib/agent_sdk.ml`/`mli`의 16 CDAL 모듈 re-export 라인 *전부 삭제*. 대응 모듈 파일 30+개 *전부 삭제*. dune `(libraries ...)`에서 CDAL이 의존하던 항목들 (예: `ppx_deriving_yojson.runtime`은 base에서도 사용하므로 유지) 정리.
+
+OAS 0.193.0 release notes에 *breaking change*: `Agent_sdk.{Cdal_proof, Mode_enforcer, Risk_contract, ...}` 모듈 제거. 이주 가이드: `masc_mcp.cdal`로 이전 또는 자체 governance 구현.
+
+## 3. Cross-Repo Wiring
+
+### 3.1 OAS 측 작업
+
+| PR | 내용 |
+|---|---|
+| **P-pre** | RFC-OAS-009 v2 PR-A/B/C/D 완료 (전제: core → CDAL 의존 0) |
+| **P1** | RFC-OAS-011 docs (this) — `docs/rfc/RFC-OAS-011-cdal-migration-to-masc-mcp.md` |
+| **P-final** | OAS lib에서 CDAL 30+ 모듈 + façade re-export 제거. agent_sdk 0.193.0 release |
+
+### 3.2 masc-mcp 측 작업
+
+| PR | 내용 |
+|---|---|
+| **M1** | `lib/cdal/` 디렉토리 + `lib/cdal/dune` 신설 (sublibrary `masc_mcp.cdal`). 빈 placeholder만 |
+| **M2** | OAS의 CDAL 모듈 30+개를 `lib/cdal/` 안에 복사. 각 파일의 `Agent_sdk.{X}` 참조를 `Agent_sdk_base.{X}` 또는 sublibrary 내부 참조로 갱신 |
+| **M3** | masc-mcp 본체의 `Agent_sdk.{Cdal_proof, Mode_enforcer, ...}` 호출을 `Masc_mcp_cdal.{X}`로 변환. dune `(libraries)`에 `masc_mcp.cdal` 추가 |
+| **M4** | (OAS P-final 머지 후) opam pin bump → `agent_sdk 0.193.0`. dune build clean 검증 |
+
+### 3.3 머지 시퀀스 (zero-downtime)
+
+```
+1. OAS P-pre (RFC-OAS-009 v2 PR-A/B/C/D) — 전제
+2. masc-mcp M1 + M2 + M3 — masc-mcp가 self-contained CDAL 보유 (agent_sdk pin = 0.192 그대로)
+   ↳ 이 시점에 masc-mcp는 OAS의 CDAL과 *자기 카피* 둘 다 컴파일에 보유 (자기 카피만 실제 호출)
+3. OAS P-final — OAS lib에서 CDAL 제거. agent_sdk 0.193.0
+4. masc-mcp M4 — opam pin → 0.193.0. 자동으로 OAS의 CDAL 부재 확인
+```
+
+이 시퀀스는 어느 단계에서도 *production-blocking* 상태가 없음:
+- 단계 2 직후: masc-mcp는 자기 카피 + OAS 카피 둘 다 가짐, 자기 카피만 호출 → 동작 영향 0
+- 단계 3 직후: OAS의 CDAL 사라짐. masc-mcp는 자기 카피만 사용 → 동작 영향 0
+- 단계 4: opam pin bump만 — OAS의 *core 변경*이 자동 반영
+
+## 4. Schema/JSON 호환성
+
+### 4.1 Cdal_proof JSON wire format
+
+본 RFC는 *모듈 path*만 변경. JSON wire format은 불변 (RFC-OAS-012가 capability_snapshot 시그니처를 변경할 때 schema version bump).
+
+masc-mcp의 디스크 manifest (`*.cdal-proof.json` 등): wire 호환 유지.
+
+### 4.2 OPAM package boundary
+
+- `agent_sdk` (OAS) v0.193.0: CDAL 30+ 모듈 *제거* — breaking change.
+- `masc_mcp` v0.20.0: `masc_mcp.cdal` sublibrary *추가*.
+- 외부 consumer (jeong-sik 본인의 다른 repo, 미래 generic agent SDK consumer): `Agent_sdk.{Cdal_proof, ...}` 호출 → 컴파일 에러. 이주 가이드 release notes에 명시.
+
+검증 (현재 외부 consumer):
+- jeong-sik의 다른 repo (kirin, wkbl, ocaml-webrtc, grpc-direct, anthropic-proxy-rs, masc-mcp, oas) 중 OAS의 CDAL 호출하는 곳: **masc-mcp만** (RFC-OAS-009 §1.1.6 verified).
+- 외부 사용자: README의 *"개인 프로젝트입니다. 프로덕션 SLA, 외부 지원, 호환성 보증 없음. 사용 시 자기 책임."* 명시 — breaking change 정당화.
+
+## 5. PR Sequence (12 PRs across both repos)
+
+### OAS
+
+| PR | Branch | 내용 | 의존 |
+|---|---|---|---|
+| **OAS-A** | `feature/rfc-oas-009-v2-sever-cdal-deps` | RFC-OAS-009 v2 + RFC-OAS-011 + RFC-OAS-012 docs (현재 PR) | 독립 |
+| **OAS-B** | `feature/rfc-oas-009-pr-b-agent-tools` | agent_tools.ml builtin_descriptor fallback 제거 | OAS-A 머지 후 |
+| **OAS-C** | `feature/rfc-oas-009-pr-c-mcp-schema` | mcp_schema.ml descriptor_for_builtin_tool 제거 | OAS-B 머지 후 |
+| **OAS-D** | `feature/rfc-oas-009-pr-d-verify-zero-deps` | core → CDAL 0 의존 CI lint | OAS-C 머지 후 |
+| **OAS-E** | `feature/rfc-oas-011-pr-e-remove-cdal` | OAS lib에서 CDAL 30+ 모듈 + façade re-export 제거. agent_sdk 0.193.0 | masc-mcp M3 머지 후 |
+
+### masc-mcp
+
+| PR | Branch | 내용 | 의존 |
+|---|---|---|---|
+| **MM-1** | `feature/rfc-oas-011-cdal-sublibrary-skel` | `lib/cdal/` 디렉토리 + `lib/cdal/dune` skel | OAS-D 머지 후 |
+| **MM-2-leaves** | `feature/rfc-oas-011-cdal-batch-1-leaves` | B1 batch 이주 (execution_mode, effect_evidence, guardrail_llm) | MM-1 머지 후 |
+| **MM-2-low** | `feature/rfc-oas-011-cdal-batch-2-low` | B2 batch (risk_class, verified_output, conformance) | MM-2-leaves 머지 후 |
+| **MM-2-mid** | `feature/rfc-oas-011-cdal-batch-3-mid` | B3 batch (risk_contract, cdal_proof, mode_resolver, cognitive_event) | MM-2-low 머지 후 |
+| **MM-2-high** | `feature/rfc-oas-011-cdal-batch-4-high` | B4 batch (proof_capture, proof_store, mode_enforcer, contract_runner, direct_evidence) | MM-2-mid 머지 후 |
+| **MM-2-top** | `feature/rfc-oas-011-cdal-batch-5-top` | B5 batch (audit, autonomy_*, sessions_proof + 분류 검토 모듈) | MM-2-high 머지 후 |
+| **MM-3-rewire** | `feature/rfc-oas-011-rewire-callers` | masc-mcp 본체의 `Agent_sdk.{Cdal_proof,...}` → `Masc_mcp_cdal.{X}` | MM-2-top 머지 후 |
+| **MM-4-pin-bump** | `feature/rfc-oas-011-pin-bump` | opam pin → agent_sdk 0.193.0 | OAS-E 머지 후 |
+
+각 PR Draft + `human-approved-ready` 라벨 게이트.
+
+## 6. Risks (5건)
+
+| # | 위험 | 완화 |
+|---|---|---|
+| 1 | 분류 검토 미정 모듈 (autonomy_trace_analyzer, guardrail_*, runtime_evidence, effect_evidence)이 core/CDAL 경계 모호 | OAS-D 머지 직후 1차 grep으로 확정. core면 이주 제외, CDAL이면 batch 안 추가 |
+| 2 | 30+ 모듈 동시 이주의 회귀 위험 | leaf-first 5-batch 분할. 각 batch마다 dune build clean + dune runtest 통과 강제 |
+| 3 | masc-mcp의 자기 governance(`Autonomous_executor.classify_tool`)와 이주된 CDAL 사이 *중복/모순* | RFC-OAS-013+에서 통합 검토. 본 RFC는 *위치 이동*만, 통합/제거는 별도 |
+| 4 | opam pin race (OAS-E 머지 직후 masc-mcp 빌드 실패 짧은 윈도우) | MM-4-pin-bump를 OAS-E 머지 *직후* 자동화 또는 즉시 수동 머지 |
+| 5 | OAS façade re-export 의존자 (검증되지 않은 외부 사용자) | README의 "사용 시 자기 책임" 약관. 0.193.0 release notes에 이주 가이드 명시 |
+
+## 7. References
+
+- RFC-OAS-009 v2 (this PR): Sever Core→CDAL Dependencies — *전제*
+- RFC-OAS-012 (this PR): Tool Name Ignorance within CDAL — *후속*
+- README.md (OAS): "OCaml agent SDK on OCaml 5.x + Eio. Talks to Anthropic Messages API and OpenAI-compatible chat endpoints"
+- dune-project (OAS): "Anthropic Agent SDK for OCaml (Eio Edition)"
+- CLAUDE.md (OAS): "Layer 1: Agent Runtime — 단일 에이전트 실행 엔진"
+- `lib/cdal_proof.mli` line 4: "Part of the Contract-Driven Agent Loop (CDAL) PoC-1"
+- `lib/contract_runner.ml:96-110` (positive evidence — `Tool.descriptor.mutation_class` 경로)
+- 메모리 `feedback_user_rejects_cron_pr_loop` (2026-05-07): Draft + `human-approved-ready` 라벨 게이트
+- 메모리 `feedback_split_brain_rfc_0022_pr_2_pr3_overlap` (2026-05-05): same-author parallel agents 동일 axis 동시 PR 회피 — 본 RFC는 *명시적 시퀀스 게이트*로 차단

--- a/docs/rfc/RFC-OAS-012-tool-name-ignorance-within-cdal.md
+++ b/docs/rfc/RFC-OAS-012-tool-name-ignorance-within-cdal.md
@@ -1,0 +1,209 @@
+# RFC-OAS-012: Tool Name Ignorance within CDAL (post-migration)
+
+| | |
+|---|---|
+| Status | Draft (deferred — depends on RFC-OAS-011 completion) |
+| Author | jeong-sik (with Claude analysis) |
+| Created | 2026-05-08 |
+| Target | `masc_mcp.cdal` v0.20+ (이주 후) |
+| Supersedes | RFC-OAS-009 v1 의도 (default_tool_entries 정리) — 이주 후 흡수 |
+| Depends-on | RFC-OAS-011 (CDAL Migration to masc-mcp) — *완료 후* 본 RFC 진행 |
+
+## 0. Summary
+
+CDAL이 `masc_mcp.cdal` sublibrary로 이주한 후, *CDAL 내부의 layering 위반*을 정리한다.
+
+- `Mode_enforcer.default_tool_entries`(46개 외부 builtin 이름 하드코딩) → 빈 리스트
+- `Mode_enforcer.classify_tool`(글로벌, 호출처 0건의 dead API) → 제거
+- `Mode_enforcer.builtin_descriptor`(글로벌, RFC-OAS-009 v2 PR-B/C 후 호출처 0건) → 제거
+- `Cdal_proof.capability_snapshot.tools : string list` → `(string * tool_effect_class) list` 시그니처 변경 + JSON schema version bump
+
+이 작업은 RFC-OAS-009 v1이 *원래* 다루려 했던 내용. 그러나 CDAL이 OAS lib에 거주할 때는 *cross-repo 영향*과 *layering boundary 미정리* 때문에 깨끗하게 끝낼 수 없었다. RFC-OAS-011 완료 후, CDAL은 *자기 유일한 consumer 안*에 거주하므로 본 RFC가 *masc-mcp 내부 작업*으로 줄어든다.
+
+## 1. Problem Statement (post-migration)
+
+### 1.0 RFC-OAS-009 v1의 잔여 의도
+
+v1은 다음 4건의 layering 위반을 식별했다 (현재는 RFC-OAS-011 완료 후 모두 `masc_mcp.cdal/` 안):
+
+1. `Mode_enforcer.default_tool_entries` — 46개 외부 builtin 이름 하드코딩 (Claude Code/Serena/claude-in-chrome/Team)
+2. `Mode_enforcer.classify_tool : string -> _` — 글로벌 함수, 호출처 0건
+3. (이전 위반) `Tool_id`의 builtin variants — RFC-OAS-008 PR-2의 mirror. RFC-OAS-009 v1 제안에서 trim 대상이었으나 *이주 후*에도 잔존
+4. `mcp_schema.ml`의 builtin 이름 inline test — RFC-OAS-009 v2 PR-C에서 이미 제거
+
+### 1.1 추가 위반 (RFC-OAS-009 v2 §1에서 발견되지 않은 것)
+
+`Cdal_proof.capability_snapshot.tools : string list` — 이름만 갖고 있고 *분류 정보 없음*. 그래서 `mode_resolver.capability_cap`이 `Mode_enforcer.all_read_only`/`all_workspace_only` 글로벌 lookup에 의존. 즉 capability_snapshot 자체가 *분류 정보를 직접 들고 다니지 않는* 구조 — 이게 글로벌 분류기의 *진짜 root cause*.
+
+올바른 구조: `capability_snapshot.tools : (string * tool_effect_class) list`. 그러면 `mode_resolver`가 lookup 없이 직접 분류.
+
+### 1.2 OAS 측 영향 (이주 후)
+
+- 본 RFC가 *masc-mcp 내부 작업*이 된 이유: RFC-OAS-011 완료 후 CDAL이 OAS lib에 없음.
+- OAS 측 변경: 0건.
+- Cdal_proof JSON schema 변경 → masc-mcp manifest의 *디스크 호환성*만 영향.
+
+### 1.3 무엇이 *문제 아닌가*
+
+- masc-mcp의 자체 `classify_tool` (`autonomous/autonomous_executor.ml:19`)와의 통합: RFC-OAS-013+.
+- `Tool.descriptor.mutation_class` 자체의 Variant화 (현재 `string option`): 별도 RFC.
+- PPX 자동 생성: RFC-OAS-008 §1.3과 일관 — out of scope.
+
+## 2. Proposal
+
+### 2.1 `Mode_enforcer.default_tool_entries` → `[]`
+
+`masc_mcp/lib/cdal/mode_enforcer.ml:85+` (이주 후 위치):
+
+```ocaml
+let default_tool_entries : (string * tool_effect_class) list = []
+```
+
+### 2.2 `Mode_enforcer.classify_tool` 제거
+
+`masc_mcp/lib/cdal/mode_enforcer.mli`에서 `val classify_tool` 라인 제거.
+`mode_enforcer.ml`의 구현 제거. `all_read_only`/`all_workspace_only`도 같이 제거 (호출처 = `mode_resolver.capability_cap`만, §2.3에서 시그니처 변경).
+
+### 2.3 `Cdal_proof.capability_snapshot.tools` 시그니처 변경
+
+#### Before
+
+```ocaml
+type capability_snapshot =
+  { tools : string list
+  ; mcp_servers : string list
+  ; max_turns : int
+  ; max_tokens : int option
+  ; thinking_enabled : bool option
+  }
+[@@deriving yojson, show]
+```
+
+#### After
+
+```ocaml
+type capability_snapshot =
+  { tools : (string * Mode_enforcer.tool_effect_class) list
+  ; mcp_servers : string list
+  ; max_turns : int
+  ; max_tokens : int option
+  ; thinking_enabled : bool option
+  }
+[@@deriving yojson, show]
+
+(* Backward-compat helper for legacy manifests *)
+val capability_snapshot_v1_to_v2 :
+  string list -> (string * Mode_enforcer.tool_effect_class) list
+```
+
+#### JSON schema 변화
+
+Before:
+```json
+{ "tools": ["read", "write", "bash"] }
+```
+
+After:
+```json
+{ "tools": [
+    ["read", "Read_only"],
+    ["write", "Local_mutation"],
+    ["bash", "Shell_dynamic"]
+  ]
+}
+```
+
+`Cdal_proof.schema_version_current` bump (예: 1 → 2).
+
+### 2.4 `mode_resolver.capability_cap` 직접 분류
+
+#### Before
+
+```ocaml
+let capability_cap (capabilities : Cdal_proof.capability_snapshot) =
+  if Mode_enforcer.all_read_only capabilities.tools
+  then Execution_mode.Diagnose
+  else if Mode_enforcer.all_workspace_only capabilities.tools
+  then Execution_mode.Draft
+  else Execution_mode.Execute
+;;
+```
+
+#### After
+
+```ocaml
+let capability_cap (capabilities : Cdal_proof.capability_snapshot) =
+  let all_in cls =
+    List.for_all (fun (_, c) -> Mode_enforcer.tool_effect_class_le c cls) capabilities.tools
+  in
+  if all_in Read_only
+  then Execution_mode.Diagnose
+  else if all_in Local_mutation
+  then Execution_mode.Draft
+  else Execution_mode.Execute
+;;
+```
+
+### 2.5 `Mode_enforcer.builtin_descriptor` 제거
+
+RFC-OAS-009 v2 PR-C 머지 후 호출처 0건. `mode_enforcer.mli`에서 `val builtin_descriptor` 제거. ml에서 구현 제거. `default_tool_entries` Hashtbl seed 로직도 함께 제거 (이미 빈 리스트).
+
+### 2.6 `Tool_id` (RFC-OAS-008 PR-2 main 잔존) trim
+
+`masc_mcp/lib/cdal/tool_id.ml` (이주 후 위치):
+
+```ocaml
+type t =
+  | Mcp of { server : string; tool : string }
+  | User of string
+[@@deriving show, eq]
+
+val to_string : t -> string
+val of_string : string -> t
+```
+
+46개 builtin variant 제거. `of_string`은 `mcp__` prefix 시 `Mcp _`, 그 외 `User _`로 단순화.
+
+## 3. Manifest Migration
+
+### 3.1 디스크 manifest
+
+- masc-mcp의 production manifest (`*.cdal-proof.json`)는 *schema_version=1*이 자동 detect되어 `capability_snapshot_v1_to_v2`로 자동 변환 후 read.
+- write-time은 항상 v2 schema. 즉 *이주 후 첫 write*부터 새 schema 사용.
+- 30일 후 (또는 다음 minor): v1 read 지원 제거.
+
+### 3.2 검증
+
+PR-D에서 mock manifest fixtures (v1 + v2)로 alcotest. `capability_snapshot_v1_to_v2`의 default classification은 *fail-closed* (`External_effect`).
+
+## 4. PR Sequence
+
+| PR | Branch (masc-mcp) | 내용 |
+|---|---|---|
+| **A** (this) | OAS의 `feature/rfc-oas-009-v2-sever-cdal-deps` | RFC-OAS-012 docs only (RFC-OAS-009 v2 + RFC-OAS-011와 같은 PR) |
+| **B** | `feature/rfc-oas-012-empty-default-tool-entries` | `Mode_enforcer.default_tool_entries → []`. `classify_tool`/`all_read_only`/`all_workspace_only` deprecated mark |
+| **C** | `feature/rfc-oas-012-builtin-descriptor-removal` | `builtin_descriptor` + `default_tool_entries` Hashtbl seed 제거 |
+| **D** | `feature/rfc-oas-012-capability-snapshot-typed` | `capability_snapshot.tools` 시그니처 변경 + schema_version bump + v1→v2 helper |
+| **E** | `feature/rfc-oas-012-mode-resolver-direct` | `mode_resolver.capability_cap` 직접 분류 |
+| **F** | `feature/rfc-oas-012-tool-id-trim` | `Tool_id` `Mcp \| User`만 |
+| **G** | `feature/rfc-oas-012-final-cleanup` | `classify_tool`/`all_read_only`/`all_workspace_only` 완전 제거 |
+
+각 PR Draft + `human-approved-ready` 라벨 게이트.
+
+## 5. Risks (3건)
+
+| # | 위험 | 완화 |
+|---|---|---|
+| 1 | masc-mcp의 *production* manifest (디스크에 있는 `*.cdal-proof.json`) 호환성 | `capability_snapshot_v1_to_v2` helper로 자동 변환. 30일 grace |
+| 2 | `Mode_enforcer.tool_effect_class_le` partial order가 모든 케이스 cover하는지 | Read_only < Local_mutation < {External_effect, Shell_dynamic}. inline test로 exhaustive |
+| 3 | `mode_resolver.capability_cap`의 시멘틱이 *기본 비어있는 capability*를 어떻게 처리 | 빈 capability tools → `all_in Read_only`가 trivially true → `Diagnose`. 가장 보수적. 안전 |
+
+## 6. References
+
+- RFC-OAS-009 v1 (merged `7149c5a7`): 본 RFC가 *원의도*를 흡수
+- RFC-OAS-009 v2 (this PR): Sever Core→CDAL Dependencies — *전제*
+- RFC-OAS-011 (this PR): CDAL Migration to masc-mcp — *전제*
+- `lib/cdal_proof.mli` line 30: `capability_snapshot.tools : string list` (현재)
+- `lib/mode_resolver.ml:7-15` `capability_cap` (현재)
+- 메모리 `feedback_user_rejects_cron_pr_loop` (2026-05-07): Draft + `human-approved-ready` 라벨 게이트
+- 메모리 `feedback_telemetry_as_fix_workaround` (2026-05-08): 본 RFC는 *symptom 정리*가 아니라 *root cause* (구조적 의존 정리)


### PR DESCRIPTION
## 요약

**OAS lib에 두 패키지가 섞여있다**는 사실을 grep으로 증명하고, CDAL을 OAS에서 *제거하고 masc-mcp로 이주*하는 정공 경로를 3개 RFC로 분할 정의합니다.

이 PR은 **docs only — 코드 0줄**. 본 PR이 청사진을 확정하고, 후속 구현 PR (OAS 4개 + masc-mcp 8개 = 총 12개)이 실제 변경을 수행합니다.

## Trigger

PR #1478 (RFC-OAS-009 v1, `7149c5a7` 머지)이 *default_tool_entries 정리*에 머물렀습니다. Draft 검토 중 사용자 두 질문이 한계를 노출:

> 1. *"경계 제대로 나뉘는거 맞냐?"*
> 2. *"CDAL 이거는 어차피 masc 에서만 있음 되는거 아니냐"*

## 검증된 사실 (RFC §1.1 line-pinned)

| 명제 | 검증 |
|---|---|
| OAS lib에 *agent_sdk core* + *CDAL ("PoC-1")* 두 패키지 섞임 | 7 mli 자기 표기 + README/CLAUDE.md/dune-project 모두 CDAL 미언급 |
| OAS core → CDAL 역방향 의존 = **단 2 호출** | `agent_tools.ml:68`, `mcp_schema.ml:63` (둘 다 `Mode_enforcer.builtin_descriptor`) |
| CDAL 외부 consumer = **masc-mcp 단일** | `rg`로 jeong-sik 모든 repo + 외부 검증 |
| masc-mcp는 CDAL *type/serialization만 사용* | violation kind/Cdal_proof.t/Risk_contract/Execution_mode. 실행 함수(create/hooks/runner) 호출 0건 |
| `contract_runner.ml:96-110`이 *깨끗한 경로* 제공 | `Tool.descriptor.mutation_class` 직접 사용 (positive evidence) |
| CDAL leaf 순서 | `execution_mode`/`effect_evidence`/`guardrail_llm` (0 imports) → `verified_output`/`conformance` (1) → … |

## 3 RFC 의도 분리

### RFC-OAS-009 v2: Sever Core→CDAL Dependencies (*전제*)

v1 (`7149c5a7`)은 main에 머지되었으나 의도가 *default_tool_entries 정리*. v2는 **본문을 in-place 재작성** + §0 Revision History 명시. *경계 재정의*의 전제 작업으로 의도 변경.

작업: `agent_tools.ml:68`과 `mcp_schema.ml:63`의 `Mode_enforcer.builtin_descriptor` 호출 2건 제거 + CI lint로 영구 차단.

### RFC-OAS-011: CDAL Migration to masc-mcp (*마이그레이션*)

CDAL 30+ 모듈을 OAS lib에서 제거 → 새 dune sublibrary `masc_mcp.cdal`로 이주.

- **leaf-first 5 batches** (B1: pure leaves → B5: top deps)
- **backward-compat shim 거부** (drift 위험, 메모리 `feedback_telemetry_as_fix_workaround` 정신)
- **zero-downtime 머지 시퀀스**: masc-mcp가 self-contained CDAL 보유 *후* OAS 측 제거 *후* opam pin bump

### RFC-OAS-012: Tool Name Ignorance within CDAL (*이주 후 정리*)

RFC-OAS-009 v1의 *원의도*가 이주 후 masc-mcp 내부 작업으로 줄어듦.

- `default_tool_entries → []`
- `classify_tool` / `builtin_descriptor` / `all_read_only` / `all_workspace_only` 제거
- `capability_snapshot.tools : string list` → `(string * tool_effect_class) list` 시그니처 변경
- `Cdal_proof` JSON schema version bump (1→2) + v1→v2 helper

## 머지 시퀀스 (12 PRs across both repos)

### OAS

| # | PR | 의존 |
|---|---|---|
| OAS-A | RFC docs (this) | 독립 |
| OAS-B | `agent_tools.ml` builtin_descriptor fallback 제거 | OAS-A 머지 후 |
| OAS-C | `mcp_schema.ml` `descriptor_for_builtin_tool` 제거 | OAS-B 머지 후 |
| OAS-D | core → CDAL 0 의존 CI lint | OAS-C 머지 후 |
| OAS-E | OAS lib에서 CDAL 30+ 모듈 제거 (agent_sdk 0.193.0) | masc-mcp M3 머지 후 |

### masc-mcp

| # | PR | 의존 |
|---|---|---|
| MM-1 | `lib/cdal/` skel + dune sublibrary | OAS-D 머지 후 |
| MM-2-leaves | B1 batch (3 modules) | MM-1 머지 후 |
| MM-2-low | B2 batch (3 modules) | MM-2-leaves 머지 후 |
| MM-2-mid | B3 batch (4 modules) | MM-2-low 머지 후 |
| MM-2-high | B4 batch (5 modules) | MM-2-mid 머지 후 |
| MM-2-top | B5 batch (4+ modules + 분류 검토 통과) | MM-2-high 머지 후 |
| MM-3-rewire | masc-mcp 본체의 `Agent_sdk.{Cdal_proof,...}` → `Masc_mcp_cdal.{X}` | MM-2-top 머지 후 |
| MM-4-pin-bump | opam pin → agent_sdk 0.193.0 | OAS-E 머지 후 |

각 PR Draft + `human-approved-ready` 라벨 게이트 (메모리 `feedback_user_rejects_cron_pr_loop`, `feedback_masc_mcp_draft_guard_blocks_agent_ready` 준수). cron+자동 PR 거부.

## masc-mcp 영향

본 docs PR: **0건**. 후속 구현 PR들에서 masc-mcp 측에 sublibrary 신설/모듈 복사/호출 갱신/opam pin bump 필요. Wire JSON schema는 RFC-OAS-012 PR-D까지 불변.

## Test plan

- [ ] OAS-A 머지 후 PR #1478에 v2 redefinition 코멘트 추가 (git history에 의도 변경 명시)
- [ ] OAS-B 작성 시 `dune build --root .` clean 확인
- [ ] OAS-B 작성 시 `dune runtest --root . lib/agent/`로 회귀 0
- [ ] OAS-C 작성 전 `rg -n "descriptor_for_builtin_tool" lib/ test/` grep 의무
- [ ] OAS-D 작성 시 CI workflow에 `core → CDAL 0 의존 lint` 추가 → green
- [ ] MM-2-* 작성 시 각 batch별 `dune build` clean + `dune runtest` 회귀 0
- [ ] OAS-E 머지 *직후* MM-4 즉시 진행 (opam pin race window 최소화)
- [ ] RFC-OAS-012 PR-D 작성 시 v1/v2 manifest fixture로 alcotest

🤖 Generated with [Claude Code](https://claude.com/claude-code)