### PR TITLE
feat(agent_tools): remove CDAL builtin_descriptor fallback (RFC-OAS-009 v2 PR-B)

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -60,14 +60,15 @@ let concurrency_class_from_descriptor (descriptor : Tool.descriptor) =
      | None -> Tool.Sequential_workspace)
 ;;
 
+(* RFC-OAS-009 v2 PR-B: removed CDAL builtin_descriptor fallback.
+   Tools without descriptor fall through to Sequential_workspace
+   (fail-closed). Consumers should supply Tool.descriptor at
+   construction time so the agent runtime never reaches into the
+   CDAL builtin registry to classify concurrency. *)
 let concurrency_class_of_tool tool =
   match Tool.descriptor tool with
   | Some descriptor -> concurrency_class_from_descriptor descriptor
-  | None ->
-    (* Fallback: check builtin descriptor registry before defaulting *)
-    (match Mode_enforcer.builtin_descriptor tool.schema.name with
-     | Some descriptor -> concurrency_class_from_descriptor descriptor
-     | None -> Tool.Sequential_workspace)
+  | None -> Tool.Sequential_workspace
 ;;
 
 let find_tool_by_name tools name =


### PR DESCRIPTION
## 요약

RFC-OAS-009 v2의 첫 구현 PR. OAS core → CDAL 역방향 의존 *2건 중 1건* 제거.

`lib/agent/agent_tools.ml:63-71`의 `concurrency_class_of_tool`이 `Mode_enforcer.builtin_descriptor` (CDAL) fallback에 들어가던 것을 끊고, *Tool.descriptor 없는 경우* 가장 보수적 분류 (`Sequential_workspace`, fail-closed)로 직접 떨어지게 합니다.

다른 1건 (`lib/protocol/mcp_schema.ml:63` `descriptor_for_builtin_tool` alias)은 PR-C 범위.

## 변경

```diff
+(* RFC-OAS-009 v2 PR-B: removed CDAL builtin_descriptor fallback.
+   Tools without descriptor fall through to Sequential_workspace
+   (fail-closed). Consumers should supply Tool.descriptor at
+   construction time so the agent runtime never reaches into the
+   CDAL builtin registry to classify concurrency. *)
 let concurrency_class_of_tool tool =
   match Tool.descriptor tool with
   | Some descriptor -> concurrency_class_from_descriptor descriptor
-  | None ->
-    (* Fallback: check builtin descriptor registry before defaulting *)
-    (match Mode_enforcer.builtin_descriptor tool.schema.name with
-     | Some descriptor -> concurrency_class_from_descriptor descriptor
-     | None -> Tool.Sequential_workspace)
+  | None -> Tool.Sequential_workspace
 ;;
```

단일 파일 변경: +6 -5.

## 동작 변화 (RFC §2.1)

| 입력 | Before | After |
|---|---|---|
| Tool with `descriptor` | `concurrency_class_from_descriptor` | 동일 (변경 없음) |
| Tool without descriptor, name in CDAL `default_tool_entries` | descriptor lookup → 분류 | `Sequential_workspace` (fail-closed) |
| Tool without descriptor, name unknown | `Sequential_workspace` | 동일 (변경 없음) |

`Tool.descriptor`를 채우지 않은 *legacy consumer*가 있다면 그 동시성 분류가 가장 보수적 `Sequential_workspace`로 떨어집니다. **안전 측면에서 더 엄격해지는 변경** (over-serialize 위험만 있음, race condition 위험 없음).

## 호출처 영향

`concurrency_class_of_tool`의 호출처는 단 1곳: `agent_tools.schedule_tool_use` (line 88). descriptor-supplied Tool에 대해서는 동작 0 변경.

## 검증

- `scripts/dune-local.sh build lib/agent/` exit 0 (clean compile)
- `rg -n "Mode_enforcer" lib/agent/agent_tools.ml` returns 0 matches (`agent_tools.ml`이 더 이상 CDAL을 참조하지 않음)
- `Mode_enforcer.builtin_descriptor` 자체는 PR-C/E까지 살아있음 (test/test_tool.ml의 5개 테스트 + mcp_schema.ml alias가 의존)

## RFC 시리즈 진행 상황

| PR | 상태 |
|---|---|
| RFC-OAS-009 v2 + 011 + 012 docs (#1480) | MERGED `86a15fbc` |
| **OAS-B (this)** | OPEN, Draft |
| OAS-C (`mcp_schema.ml` `descriptor_for_builtin_tool` 제거) | TBD |
| OAS-D (core → CDAL 0 의존 CI lint) | TBD |
| OAS-E (CDAL 30+ 모듈 제거, agent_sdk 0.193.0) | masc-mcp M3 머지 후 |

## Test plan

- [ ] CI green 확인 (`gh pr checks <PR>` watch)
- [ ] CodeRabbit/사람 리뷰 코멘트 대응
- [ ] `human-approved-ready` 라벨 부착 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)