### PR TITLE
feat(mcp_schema): remove descriptor_for_builtin_tool alias (RFC-OAS-009 v2 PR-C)

### DIFF
--- a/lib/protocol/mcp_schema.ml
+++ b/lib/protocol/mcp_schema.ml
@@ -60,13 +60,16 @@ let mcp_tool_of_sdk_tool (t : Sdk_types.tool) : mcp_tool =
   }
 ;;
 
-let descriptor_for_builtin_tool = Mode_enforcer.builtin_descriptor
+(* RFC-OAS-009 v2 PR-C: removed descriptor_for_builtin_tool alias.
+   MCP→SDK Tool conversion no longer consults the CDAL builtin
+   descriptor registry. Consumers are responsible for supplying
+   Tool.descriptor through MCP tool annotation or a post-conversion
+   enrichment hook. *)
 
 (** Convert {!mcp_tool} to SDK {!Tool.t} with the given call handler. *)
 let mcp_tool_to_sdk_tool ~call_fn mcp_tool =
   let params = json_schema_to_params mcp_tool.input_schema in
   Tool.create
-    ?descriptor:(descriptor_for_builtin_tool mcp_tool.name)
     ~name:mcp_tool.name
     ~description:mcp_tool.description
     ~parameters:params
@@ -171,39 +174,10 @@ let%test "mcp_tool_of_sdk_tool None description becomes empty" =
   result.description = ""
 ;;
 
-let%test "descriptor_for_builtin_tool read is read_only" =
-  match descriptor_for_builtin_tool "read" with
-  | Some d ->
-    d.mutation_class = Some "read_only"
-    && d.concurrency_class = Some Tool.Parallel_read
-    && d.permission = Some Tool.ReadOnly
-  | None -> false
-;;
-
-let%test "descriptor_for_builtin_tool web_fetch is external" =
-  match descriptor_for_builtin_tool "web_fetch" with
-  | Some d ->
-    d.mutation_class = Some "external_effect"
-    && d.concurrency_class = Some Tool.Exclusive_external
-    && d.permission = Some Tool.Destructive
-  | None -> false
-;;
-
-let%test "descriptor_for_builtin_tool task_create is mutation" =
-  match descriptor_for_builtin_tool "task_create" with
-  | Some d ->
-    d.mutation_class = Some "local_mutation"
-    && d.concurrency_class = Some Tool.Sequential_workspace
-    && d.permission = Some Tool.Write
-  | None -> false
-;;
-
-let%test "descriptor_for_builtin_tool ask_user_question is external" =
-  match descriptor_for_builtin_tool "ask_user_question" with
-  | Some d -> d.concurrency_class = Some Tool.Exclusive_external
-  | None -> false
-;;
-
-let%test "descriptor_for_builtin_tool unknown returns None" =
-  descriptor_for_builtin_tool "nonexistent_xyz" = None
-;;
+(* RFC-OAS-009 v2 PR-C: removed 5 inline tests for descriptor_for_builtin_tool.
+   These tests pinned Claude Code/Serena/Team builtin names ("read", "web_fetch",
+   "task_create", "ask_user_question", "nonexistent_xyz") into mcp_schema's
+   inline tests, which is the precise layering violation RFC-OAS-009 v2 closes.
+   The descriptor_for_builtin_tool alias itself is also removed (line 63).
+   Behavior of mcp_tool_to_sdk_tool is now: descriptor=None for every MCP tool —
+   consumers supply via Tool.with_descriptor or a post-conversion enrichment. *)

--- a/test/test_mcp.ml
+++ b/test/test_mcp.ml
@@ -175,67 +175,14 @@ let test_mcp_tool_to_sdk_tool () =
   | Error _ -> Alcotest.fail "expected Ok"
 ;;
 
-let test_mcp_builtin_tool_descriptor_permission () =
-  let call_fn _input : Types.tool_result = Ok { content = "ok" } in
-  let read_tool =
-    Mcp.mcp_tool_to_sdk_tool
-      ~call_fn
-      { name = "read_file"; description = "Read"; input_schema = `Assoc [] }
-  in
-  let write_tool =
-    Mcp.mcp_tool_to_sdk_tool
-      ~call_fn
-      { name = "write"; description = "Write"; input_schema = `Assoc [] }
-  in
-  let external_tool =
-    Mcp.mcp_tool_to_sdk_tool
-      ~call_fn
-      { name = "web_fetch"; description = "Fetch"; input_schema = `Assoc [] }
-  in
-  (match Tool.descriptor read_tool with
-   | Some d ->
-     Alcotest.(check (option string))
-       "read mutation"
-       (Some "read_only")
-       d.Tool.mutation_class;
-     Alcotest.(check bool) "read permission" true (d.Tool.permission = Some Tool.ReadOnly)
-   | None -> Alcotest.fail "read_file descriptor missing");
-  (match Tool.descriptor write_tool with
-   | Some d ->
-     Alcotest.(check (option string))
-       "write mutation"
-       (Some "local_mutation")
-       d.Tool.mutation_class;
-     Alcotest.(check bool) "write permission" true (d.Tool.permission = Some Tool.Write)
-   | None -> Alcotest.fail "write descriptor missing");
-  (match
-     Completion_contract.effectful_tool_satisfies
-       { name = "write"; input = `Assoc []; tool = Some write_tool }
-   with
-   | Ok () -> ()
-   | Error msg -> Alcotest.fail ("write should satisfy effectful contract: " ^ msg));
-  (match
-     Completion_contract.effectful_tool_satisfies
-       { name = "read_file"; input = `Assoc []; tool = Some read_tool }
-   with
-   | Error msg ->
-     Alcotest.(check bool)
-       "read-only rejected"
-       true
-       (contains_substring ~sub:"read-only" msg)
-   | Ok () -> Alcotest.fail "read-only tool should not satisfy effectful contract");
-  match Tool.descriptor external_tool with
-  | Some d ->
-    Alcotest.(check (option string))
-      "external mutation"
-      (Some "external_effect")
-      d.Tool.mutation_class;
-    Alcotest.(check bool)
-      "external permission"
-      true
-      (d.Tool.permission = Some Tool.Destructive)
-  | None -> Alcotest.fail "web_fetch descriptor missing"
-;;
+(* RFC-OAS-009 v2 PR-C: removed test_mcp_builtin_tool_descriptor_permission.
+   This test pinned the layering violation: it expected mcp_tool_to_sdk_tool
+   to auto-fill descriptors based on builtin tool names ("read_file", "write",
+   "web_fetch") via the CDAL Mode_enforcer.builtin_descriptor registry —
+   precisely the boundary RFC-OAS-009 v2 closes. Per RFC §2.2, descriptor is
+   now consumer-supplied. The Completion_contract.effectful_tool_satisfies
+   coverage that lived inside this function is independent of the bridge and
+   remains validated by Tool.permission paths in other test suites. *)
 
 let test_mcp_tool_bridge_error () =
   let mcp_tool : Mcp.mcp_tool =
@@ -460,10 +407,6 @@ let () =
         ] )
     ; ( "tool_bridge"
       , [ test_case "mcp_tool_to_sdk_tool" `Quick test_mcp_tool_to_sdk_tool
-        ; test_case
-            "builtin descriptor permissions"
-            `Quick
-            test_mcp_builtin_tool_descriptor_permission
         ; test_case "bridge error propagation" `Quick test_mcp_tool_bridge_error
         ] )
     ; ( "sdk_bridge"


### PR DESCRIPTION
## 요약

RFC-OAS-009 v2의 두 번째 (그리고 마지막) 구현 PR. OAS core → CDAL 역방향 의존 *2건 중 2건째* 제거.

`mcp_tool_to_sdk_tool`이 *MCP server가 노출한 tool 이름*을 가지고 CDAL `Mode_enforcer.builtin_descriptor` registry를 조회해 descriptor를 자동 부여하던 layering 위반을 닫습니다. 이제 consumer가 descriptor를 *직접 supply*해야 합니다 (RFC §2.2).

이 PR 머지 후 **OAS core (lib/agent/, lib/llm_provider/, lib/protocol/, lib/base/)에 CDAL 직접 참조 0건**. RFC-OAS-011 (CDAL Migration to masc-mcp)의 *전제 조건 충족*.

## 변경

| 위치 | 변경 |
|---|---|
| `lib/protocol/mcp_schema.ml:63` | `let descriptor_for_builtin_tool = Mode_enforcer.builtin_descriptor` alias 제거 |
| `lib/protocol/mcp_schema.ml:69` | `mcp_tool_to_sdk_tool`에서 `?descriptor:(...)` 인자 제거 |
| `lib/protocol/mcp_schema.ml:174-209` | 5개 inline test 제거 (builtin 이름 박힘: `read` / `web_fetch` / `task_create` / `ask_user_question` / `nonexistent_xyz`) |
| `test/test_mcp.ml:178-238` | `test_mcp_builtin_tool_descriptor_permission` 함수 제거 (layering 위반을 *positive-evidence test*로 검증하던 negative case) |
| `test/test_mcp.ml:463-466` | 위 함수의 `test_case` register entry 제거 |

**Stat**: `+20 / -103` (대량 정리, RFC §2.2 + §2.5 + §3 약속과 1:1)

## 동작 변화 (RFC §2.2)

| 입력 | Before | After |
|---|---|---|
| `mcp_tool_to_sdk_tool ~call_fn { name = "read"; ... }` | `descriptor = Some {mutation_class=read_only; permission=ReadOnly; ...}` | `descriptor = None` |
| `mcp_tool_to_sdk_tool ~call_fn { name = "write"; ... }` | `descriptor = Some {mutation_class=local_mutation; ...}` | `descriptor = None` |
| `mcp_tool_to_sdk_tool ~call_fn { name = "unknown"; ... }` | `descriptor = None` (변경 없음) | 동일 |

이후 동작:
- 변환된 tool이 `agent_tools.concurrency_class_of_tool`에 들어가면 PR-B(`#1481`)의 fail-closed 경로로 `Sequential_workspace` 분류 (가장 보수적, RFC §2.1).
- `Tool.permission`이 `None`이라 `Completion_contract.effectful_tool_satisfies`는 기존 "no permission metadata" 에러를 반환 (현재 동작 유지).
- consumer는 변환 직후 `Tool.with_descriptor`로 채워 넣거나 별도 enrichment 단계를 거쳐야 함.

## 핵심 검증: OAS core → CDAL 0건 달성

```
$ rg -n "Cdal_proof|Mode_enforcer|Mode_resolver|Risk_contract|Risk_class|Execution_mode|Proof_capture|Proof_store|Contract_runner" \
       lib/agent/ lib/llm_provider/ lib/protocol/ lib/base/
```

PR-C 머지 후 결과: **0 matches**.

이 *invariant*를 영구 차단하는 것이 다음 PR (OAS-D, CI lint).

## RFC 시리즈 진행 상황

| PR | 상태 |
|---|---|
| RFC-OAS-009 v2 + 011 + 012 docs (#1480) | MERGED `86a15fbc` |
| OAS-B agent_tools fallback 제거 (#1481) | MERGED `39082f60` |
| **OAS-C (this)** | OPEN, Draft |
| OAS-D (core → CDAL 0 의존 CI lint) | TBD |
| OAS-E (CDAL 30+ 모듈 제거, agent_sdk 0.193.0) | masc-mcp M3 머지 후 |

## 검증

- `dune build --root . lib/protocol/` exit 0
- `dune build --root . test/test_mcp.exe` exit 0 (test 컴파일 통과)
- `rg -n "Mode_enforcer|builtin_descriptor" lib/protocol/mcp_schema.ml` returns 0 matches
- `rg -n "test_mcp_builtin_tool_descriptor_permission" test/ lib/` returns 0 matches

## Test plan

- [ ] CI green 확인 (`gh pr checks <PR>` watch)
- [ ] `dune runtest` 회귀 0 (CI에서 검증, 로컬에서는 `dune-local.sh` lock contention으로 14분+ 대기 발생해 직접 빌드만 검증)
- [ ] `human-approved-ready` 라벨 부착 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)