### PR TITLE
feat(ci): boundary-lint for core→CDAL zero dependency (RFC-OAS-009 v2 PR-D)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,23 @@ jobs:
           opam install odoc --yes
           opam exec -- dune build @doc
 
+  boundary-lint:
+    # RFC-OAS-009 v2 PR-D — Core→CDAL boundary check.
+    # Runs on every push and PR (including drafts) to give fast feedback
+    # without waiting for the full opam-based build matrix.
+    name: Boundary Lint (Core→CDAL)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install ripgrep
+        run: sudo apt-get install -y ripgrep
+
+      - name: Forbid CDAL references in OAS core
+        run: bash scripts/lint-core-cdal-boundary.sh
+
   lint:
     name: Lint
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}

--- a/lib/base/tool_id.mli
+++ b/lib/base/tool_id.mli
@@ -1,9 +1,12 @@
 (** Typed tool identifier.
 
     Closed Variant for builtins, escape hatches for MCP and user-supplied tools.
-    See RFC-OAS-008 for the rationale. PR-2 ships only the identifier and
-    string conversion; PR-3 wires this into [Mode_enforcer] without changing
-    its external API. *)
+    See RFC-OAS-008 for the original rationale. PR-2 ships only the identifier
+    and string conversion. The wiring into the (CDAL-resident) classifier
+    that RFC-OAS-008 PR-3 originally proposed has been superseded by
+    RFC-OAS-009 v2: OAS core no longer references CDAL modules, and the
+    builtin variants here are scheduled for removal in RFC-OAS-012 once
+    CDAL migrates to masc-mcp (RFC-OAS-011). *)
 
 type t =
   (* Read-only — file & code navigation *)
@@ -83,5 +86,7 @@ val to_string : t -> string
 val of_string : string -> t
 
 (** Every builtin constructor in declaration order. Excludes [Mcp _] and
-    [User _]. Used by parity tests against [Mode_enforcer.default_tool_entries]. *)
+    [User _]. Originally introduced by RFC-OAS-008 PR-2 for parity with
+    the (CDAL-resident) builtin classifier; scheduled for removal in
+    RFC-OAS-012 alongside the CDAL migration in RFC-OAS-011. *)
 val all_builtins : t list

--- a/scripts/lint-core-cdal-boundary.sh
+++ b/scripts/lint-core-cdal-boundary.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# RFC-OAS-009 v2 PR-D — Core→CDAL boundary lint.
+#
+# Forbids OAS core (lib/agent/, lib/llm_provider/, lib/protocol/, lib/base/)
+# from referencing CDAL modules (gold-standard self-tagged "Part of CDAL PoC-1"
+# in their .mli plus the modules that depend on them).
+#
+# This script is the durable mechanism that prevents the layering violation
+# RFC-OAS-009 v2 closed (PR-B #1481, PR-C #1482) from reappearing. Future
+# PRs that introduce a Mode_enforcer/Cdal_proof/Risk_contract reference into
+# core will trip this lint at CI time.
+#
+# Usage:
+#   bash scripts/lint-core-cdal-boundary.sh
+#
+# Exit:
+#   0 = boundary clean.
+#   1 = at least one CDAL reference found in core.
+#
+# Tools: `rg` (ripgrep). Falls back to `grep -r` if rg is unavailable.
+
+set -euo pipefail
+
+# Resolve to repo root regardless of caller's cwd.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Core directories that must not reference CDAL.
+CORE_DIRS=(
+  lib/agent
+  lib/llm_provider
+  lib/protocol
+  lib/base
+)
+
+# CDAL module prefixes to forbid in core.
+# Gold-standard set: the seven mli files that self-tag "Part of CDAL PoC-1"
+# plus their direct dependents (mode_enforcer, contract_runner) which
+# constitute the CDAL boundary surface.
+CDAL_PATTERN='\b(Cdal_proof|Mode_enforcer|Mode_resolver|Risk_contract|Risk_class|Execution_mode|Proof_capture|Proof_store|Contract_runner)\b'
+
+# Pick the search tool.
+if command -v rg >/dev/null 2>&1; then
+  search() { rg --no-heading -n -- "$CDAL_PATTERN" "$@"; }
+else
+  # Fallback: grep -E with same pattern, recursive.
+  search() { grep -RnE -- "$CDAL_PATTERN" "$@" 2>/dev/null || true; }
+fi
+
+# Filter to only existing core dirs (defensive against future moves).
+existing_dirs=()
+for d in "${CORE_DIRS[@]}"; do
+  [ -d "$d" ] && existing_dirs+=("$d")
+done
+
+if [ "${#existing_dirs[@]}" -eq 0 ]; then
+  echo "lint-core-cdal-boundary: none of the configured core directories exist." >&2
+  echo "  Configured: ${CORE_DIRS[*]}" >&2
+  exit 1
+fi
+
+# Search and capture matches.
+matches="$(search "${existing_dirs[@]}" || true)"
+
+if [ -z "$matches" ]; then
+  echo "✓ lint-core-cdal-boundary: no CDAL references in OAS core."
+  echo "  Scanned: ${existing_dirs[*]}"
+  echo "  Forbidden: Cdal_proof | Mode_enforcer | Mode_resolver | Risk_contract"
+  echo "             | Risk_class | Execution_mode | Proof_capture | Proof_store"
+  echo "             | Contract_runner"
+  exit 0
+fi
+
+cat >&2 <<EOF
+✗ lint-core-cdal-boundary: OAS core references CDAL modules.
+
+RFC-OAS-009 v2 (Sever Core→CDAL Dependencies) forbids reverse dependencies
+from agent_sdk core (lib/agent, lib/llm_provider, lib/protocol, lib/base)
+into CDAL modules. The two original violations were:
+
+  - lib/agent/agent_tools.ml:68     (removed in PR-B #1481, 39082f60)
+  - lib/protocol/mcp_schema.ml:63   (removed in PR-C #1482, ffb8aff3)
+
+After OAS-D this lint blocks new violations at CI time.
+
+If your change needs CDAL-style classification on a Tool, supply
+Tool.descriptor.mutation_class at construction (see
+lib/contract_runner.ml:96-110 for the consumer-supplied pattern).
+
+Per RFC-OAS-011 the CDAL modules will migrate to masc-mcp.cdal —
+add new CDAL functionality there, not in OAS lib.
+
+Found references:
+
+EOF
+
+echo "$matches" >&2
+exit 1


### PR DESCRIPTION
## 요약

RFC-OAS-009 v2의 *마지막 PR* — PR-B (#1481) + PR-C (#1482)가 만든 `OAS core → CDAL 0 의존` 상태를 *영구히 잠금*. 미래 PR이 `Cdal_proof|Mode_enforcer|Mode_resolver|Risk_contract|Risk_class|Execution_mode|Proof_capture|Proof_store|Contract_runner`를 `lib/agent/`, `lib/llm_provider/`, `lib/protocol/`, `lib/base/` 어디에든 추가하면 CI red.

## 구성

| 항목 | 내용 |
|---|---|
| `scripts/lint-core-cdal-boundary.sh` (신규) | rg-based 검사, 로컬 + CI 양쪽 실행. 실패 시 actionable 메시지 (`contract_runner.ml:96-110` consumer-supplied 패턴 + RFC-OAS-011/012 reference) |
| `.github/workflows/ci.yml` (수정) | 새 job `Boundary Lint (Core→CDAL)` — opam 없음, draft PR에도 실행, ≤ 5분 timeout |
| `lib/base/tool_id.mli` (cleanup) | RFC-OAS-008 PR-2 시점의 doc 주석 2개가 `[Mode_enforcer]`를 언급 (RFC-OAS-008 PR-3가 wiring 예정이었음) — 그 의도가 RFC-OAS-009 v2로 superseded되었으므로 갱신 |

Stat: **+125 / -4** (스크립트 79 lines + workflow +17 + mli +9/-4)

## Why a separate fast job

기존 `lint` 와 `Build & Test` 는 opam setup 후 dune 컴파일까지 가야 신호. boundary 위반은 *15분 빌드 끝나야* 알 수 있게 두면 RFC가 약속한 *1차 게이트* 역할 못함. boundary-lint는 ripgrep 1회 호출이라 *push 후 30초 안에* 결과.

## 로컬 사용

```bash
bash scripts/lint-core-cdal-boundary.sh
```

clean이면:
```
✓ lint-core-cdal-boundary: no CDAL references in OAS core.
  Scanned: lib/agent lib/llm_provider lib/protocol lib/base
  Forbidden: Cdal_proof | Mode_enforcer | Mode_resolver | Risk_contract
             | Risk_class | Execution_mode | Proof_capture | Proof_store
             | Contract_runner
```

위반이면 violators + RFC reference + consumer-supplied 패턴 가이드 출력.

## 검증

- `bash scripts/lint-core-cdal-boundary.sh` exit 0 (locally)
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` OK
- 발견된 stale 참조 2건 (모두 *주석*) 정리:
  - `lib/base/tool_id.mli:5` `[Mode_enforcer]` doc reference
  - `lib/base/tool_id.mli:86` `[Mode_enforcer.default_tool_entries]` doc reference

## RFC 시리즈 진행 상황

| PR | 상태 |
|---|---|
| RFC-OAS-009 v2 + 011 + 012 docs (#1480) | MERGED `86a15fbc` |
| OAS-B agent_tools.ml (#1481) | MERGED `39082f60` |
| OAS-C mcp_schema.ml + test (#1482) | MERGED `ffb8aff3` |
| **OAS-D (this) boundary CI lint** | OPEN, Draft |
| OAS-E (CDAL 30+ 모듈 제거, agent_sdk 0.193.0) | RFC-OAS-011 masc-mcp M3 머지 후 |

OAS-D 머지 시 RFC-OAS-009 v2 종결. 다음 RFC (OAS-011 CDAL Migration to masc-mcp)로 진입.

## Test plan

- [ ] CI green 확인 — `Boundary Lint (Core→CDAL)` job pass
- [ ] CodeRabbit/사람 리뷰 코멘트 대응
- [ ] `human-approved-ready` 라벨 부착 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)