### PR TITLE
fix(zai_catalog): remove unsupported glm-5-code from coding auto-models

### DIFF
--- a/lib/llm_provider/zai_catalog.ml
+++ b/lib/llm_provider/zai_catalog.ml
@@ -89,7 +89,7 @@ let glm_auto_models () =
 let glm_coding_auto_models () =
   match Cli_common_env.list ~sep:',' "ZAI_CODING_AUTO_MODELS" with
   | Some models -> models
-  | None -> [ "glm-5-code"; "glm-5.1"; "glm-5"; "glm-5-turbo"; "glm-4.7"; "glm-4.5-air" ]
+  | None -> [ "glm-5.1"; "glm-5"; "glm-5-turbo"; "glm-4.7"; "glm-4.5-air" ]
 ;;
 
 let resolve_glm_alias ~default_model model_id =
@@ -107,7 +107,6 @@ let resolve_glm_alias ~default_model model_id =
 let resolve_glm_coding_alias ~default_model model_id =
   match String.lowercase_ascii model_id with
   | "auto" -> default_model
-  | "code" -> "glm-5-code"
   | "flash" -> "glm-4.7-flashx"
   | "turbo" -> "glm-5-turbo"
   | "vision" | "v" -> "glm-4.6v"


### PR DESCRIPTION
## Summary

`glm-5-code` was added to the coding-plan auto-model rotation in PR #1334, but Z.AI returns **permission denied** for this model ID on this account. This causes all `glm-coding:auto` workers to fail immediately, blocking keeper auto-resume and cascading into fleet-wide idle states.

## Changes

- **`lib/llm_provider/zai_catalog.ml`**
  - Remove `\"glm-5-code\"` from the default return of `glm_coding_auto_models`.
  - Remove the `\"code\"` alias from `resolve_glm_coding_alias` (it mapped to `glm-5-code`).

## Test plan

- [x] `dune runtest lib/llm_provider/` passes (existing inline tests).
- [x] `opam install .` from this worktree updates switch `5.4.1` successfully.
- [x] Downstream `masc-mcp` tests rebuilt against the updated pin and pass (see companion PR).

## Risk

Low — only removes an entry from a default list and an alias mapping. No new code paths introduced.