### PR TITLE
chore(release): 0.193.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,118 @@ original tag dates. `0.100.4` was never tagged or released.
 
 ## Unreleased
 
+## [0.193.0] - 2026-05-09
+
+### BREAKING CHANGES
+
+- **CDAL framework relocated to `masc_mcp.cdal_runtime`** (RFC-OAS-011). The
+  Contract-Driven Agent Loop modules previously hosted in `agent_sdk` were
+  consumer-side governance only ever used by `masc-mcp`; their presence in
+  the SDK was a layering violation surfaced by RFC-OAS-009 v2. All 23
+  modules now live in `masc_mcp.cdal_runtime` (jeong-sik/masc-mcp); `agent_sdk`
+  no longer exposes them.
+
+  Modules removed from `Agent_sdk`:
+  `Cdal_proof`, `Mode_enforcer`, `Mode_resolver`, `Risk_contract`,
+  `Risk_class`, `Execution_mode`, `Proof_capture`, `Proof_store`,
+  `Contract_runner`, `Effect_evidence`, `Direct_evidence`, `Verified_output`,
+  `Conformance`, `Cognitive_event`, `Audit`, `Autonomy_exec`,
+  `Autonomy_diff_guard`, `Autonomy_trace_analyzer`, `Sessions_proof`,
+  `Runtime_evidence`. Façade re-exports from `lib/agent_sdk.{ml,mli}`
+  also dropped (#1489).
+
+  Migration: external consumers should depend on `masc_mcp.cdal_runtime`
+  for these symbols, or define their own equivalents.
+
+- **`lib/sessions.{ml,mli}` no longer `include module type of Sessions_proof`**
+  (#1489). The proof-bundle assembly migrated with the rest of CDAL.
+  `Sessions_types` and `Sessions_store` includes are unchanged. Code using
+  `Agent_sdk.Sessions.proof_bundle` etc. needs to switch to
+  `Masc_mcp_cdal_runtime.Sessions_proof.proof_bundle`.
+
+### Removed
+
+- `lib/execution_manifest.{ml,mli}` (#1486): dead module, zero callers
+  across OAS+masc-mcp ecosystem. Surfaced by the expanded CDAL boundary
+  lint because its mli carried `Execution_mode.t`/`Risk_class.t` fields.
+- `lib/runtime_server_worker.{ml,mli}` (#1487): dead module, zero
+  production callers. Removed alongside its `Runtime_evidence` 15-call
+  dependency chain and three associated test files (`test_runtime_evidence`,
+  `test_runtime_server_worker`, `test_runtime_worker_integration`).
+- 18 CDAL test files + 4 demo executables purged (#1488): coverage
+  follows the modules to `masc_mcp.cdal_runtime`. `test_tool.ml` also
+  drops its `builtin_descriptor` test group (5 cases) — RFC-OAS-009 v2
+  PR-B/C unwired the API and PR-6 deletes the function entirely.
+
 ### Added
-- `lib/base/tool_id.{ml,mli}`: closed Variant `Tool_id.t` module. Identifier moves from string SSOT to typed Variant; Phase 1 of RFC-OAS-008. (#1475)
+
+- `scripts/lint-core-cdal-boundary.sh` (#1483, #1485): rg-based CI guard
+  that forbids OAS core (`lib/agent`, `lib/llm_provider`, `lib/protocol`,
+  `lib/base`) from referencing CDAL modules. Originally 9 prefixes
+  (RFC-OAS-009 v2 PR-D), expanded to 20 (RFC-OAS-011 OAS-E PR-1) after
+  inventory revealed 14 implied-CDAL prefixes (`Audit`, `Autonomy_*`,
+  `Sessions_proof`, `Runtime_evidence`, etc.) had been silently leaking.
+- `lib/base/tool_id.{ml,mli}`: closed Variant `Tool_id.t` module.
+  Identifier moves from string SSOT to typed Variant; Phase 1 of
+  RFC-OAS-008. (#1475)
+- New `Boundary Lint (Core→CDAL)` GitHub Actions job (#1483): fast
+  `ripgrep`-only check, runs on Drafts, ≤5 min timeout. Provides
+  same-minute feedback ahead of the heavier `Build & Test` matrix.
+
+### Changed
+
+- `lib/agent/agent_tools.ml:68` (#1481): `concurrency_class_of_tool` no
+  longer falls back to `Mode_enforcer.builtin_descriptor` when the
+  Tool's descriptor is missing. Instead returns
+  `Tool.Sequential_workspace` (fail-closed). Severs the first of two
+  core→CDAL reverse dependencies identified by RFC-OAS-009 v2 §1.1.1.
+- `lib/protocol/mcp_schema.ml:63` (#1482): drops the
+  `descriptor_for_builtin_tool` alias and its inline tests.
+  `mcp_tool_to_sdk_tool` now creates `Tool.t` with `descriptor = None`
+  by default; consumers supply via `Tool.with_descriptor` or MCP tool
+  annotation. Severs the second of the two reverse dependencies.
+- `lib/agent/agent_turn.ml:137` (#1485): doc comment reword
+  ("Audit log…" → "Diagnostic log…") so the expanded boundary lint
+  doesn't catch a coincidental keyword in a comment that was never an
+  actual `Audit` module reference.
+
+### Reclassified (no breaking change)
+
+- `Agent_sdk.Guardrails_async` / `Guardrail_llm` / `Guardrail_tripwire`
+  intentionally **stay** in OAS core. The OAS-E boundary-lint expansion
+  initially flagged them but they are SDK-native safety hooks (carried
+  as record fields in `agent_types.t` / `builder.t`) — Anthropic-style
+  surface, not CDAL. Documented in `scripts/lint-core-cdal-boundary.sh`.
+  Their cdal_runtime copies (introduced during MM-2 migration) are now
+  redundant artifacts to be retired in masc-mcp's RFC-OAS-013.
 
 ### Documentation
-- `docs/rfc/RFC-OAS-008-typed-tool-identification.md`: typed tool identification design (Phase 1 only). Scope intentionally narrow — registry / lookup migration deferred. (#1474)
+
+- `docs/rfc/RFC-OAS-008-typed-tool-identification.md`: typed tool
+  identification design (Phase 1 only). Scope intentionally narrow —
+  registry / lookup migration deferred. (#1474)
+- `docs/rfc/RFC-OAS-009-tool-name-ignorance.md`: redefined v2 (Sever
+  Core→CDAL Dependencies) supersedes the merged v1 (default_tool_entries
+  cleanup). v1's original intent migrates to RFC-OAS-012 once CDAL is
+  hosted by masc-mcp.
+- `docs/rfc/RFC-OAS-011-cdal-migration-to-masc-mcp.md`: cross-repo CDAL
+  migration plan (#1480). Records the leaf-first batch ordering, the
+  zero-downtime three-step merge sequence (masc-mcp self-contained →
+  OAS-side removal → opam pin bump), and Sessions facade trim handoff.
+- `docs/rfc/RFC-OAS-012-tool-name-ignorance-within-cdal.md`: post-migration
+  cleanup plan (#1480). RFC-OAS-009 v1's original intent
+  (`default_tool_entries` empty, `classify_tool` global removal,
+  `capability_snapshot.tools` schema bump) now lives inside
+  `masc_mcp.cdal_runtime` rather than OAS.
+
+### Stat
+
+OAS-E sweep total: **-18,237 LoC** removed across 6 PRs (#1485–#1489
+plus #1483). Counterpart: ~7,531 LoC migrated into
+`masc_mcp.cdal_runtime` across MM-2 batches (jeong-sik/masc-mcp PRs
+#14248, #14253, #14255, #14259, #14264). Net OAS lib reduction
+larger than the migrated payload — most of the delta was over-tested
+dead surface accumulated alongside the CDAL framework.
 
 ## [0.192.1] - 2026-05-08
 

--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,6 @@
 (lang dune 3.22)
 (name agent_sdk)
-(version 0.192.1) ; x-release-please-version
+(version 0.193.0) ; x-release-please-version
 
 (generate_opam_files true)
 

--- a/lib/sdk_version.ml
+++ b/lib/sdk_version.ml
@@ -1,5 +1,5 @@
 (** Single source of truth for the SDK version string.
     All other modules reference this instead of hardcoding. *)
 
-let version = "0.192.1" (* x-release-please-version *)
+let version = "0.193.0" (* x-release-please-version *)
 let sdk_name = "agent_sdk"


### PR DESCRIPTION
## 요약 — 수동 0.193.0 release cut

release-please workflow가 *3번 연속 fail* (2026-05-08T15:48–15:59)하며 0.193.0 PR을 자동 생성 못 했습니다. 이 PR이 *수동으로* version bump + CHANGELOG promote을 진행해 masc-mcp의 MM-4 follow-up (`BASE_VERSION` / `MIN_VERSION` bump)이 진행되도록 합니다.

## 변경 (3 files / +112 / -5)

| 파일 | 변경 |
|---|---|
| `lib/sdk_version.ml` | `let version = "0.192.1"` → `"0.193.0"` |
| `dune-project` | `(version 0.192.1)` → `(version 0.193.0)` |
| `CHANGELOG.md` | `## Unreleased` → `## [0.193.0] - 2026-05-09` + RFC-OAS-011 OAS-E entries |

## RFC-OAS-011 OAS-E 정리 종합

| PR | 의미 | LoC |
|---|---|---|
| #1485 | boundary lint pattern 9→20 prefix | +28/-6 |
| #1481 | agent_tools.ml builtin_descriptor fallback 제거 | +6/-5 |
| #1482 | mcp_schema.ml descriptor_for_builtin_tool 제거 | +20/-103 |
| #1483 | Boundary CI lint workflow | +125/-4 |
| #1486 | execution_manifest dead module 제거 | -326 |
| #1487 | runtime_server_worker + Runtime_evidence 제거 | -2039 |
| #1488 | test/+examples CDAL coverage purge | -8725/+6 |
| #1489 | 20 CDAL modules + 19 façade re-exports + sessions facade trim | -7004/+7 |
| **누적** | | **≈ -18,237 LoC** |

## BREAKING change matrix

OAS lib에서 **사라진** export:

```
Agent_sdk.Cdal_proof          Agent_sdk.Risk_class
Agent_sdk.Mode_enforcer       Agent_sdk.Execution_mode
Agent_sdk.Mode_resolver       Agent_sdk.Proof_capture
Agent_sdk.Risk_contract       Agent_sdk.Proof_store
Agent_sdk.Contract_runner     Agent_sdk.Effect_evidence
Agent_sdk.Direct_evidence     Agent_sdk.Verified_output
Agent_sdk.Conformance         Agent_sdk.Cognitive_event
Agent_sdk.Audit               Agent_sdk.Autonomy_exec
Agent_sdk.Autonomy_diff_guard Agent_sdk.Autonomy_trace_analyzer
Agent_sdk.Sessions_proof      Agent_sdk.Runtime_evidence

Sessions facade: drop `include module type of Sessions_proof`
```

→ Migration: `Masc_mcp_cdal_runtime.X` (jeong-sik/masc-mcp).

## **유지된** surface (SDK core 재분류)

- `Agent_sdk.Guardrails_async` / `Guardrail_llm` / `Guardrail_tripwire` — *Anthropic-style safety hooks*. agent_types.t / builder.t의 record field로 박혀있어 *제거 시 Agent.t public API 깨짐*. SDK 본체에 거주.
- `Agent_sdk.Sessions` (Sessions_types + Sessions_store만 include) — proof_bundle은 빠짐.

## release-please 자동화 fix는 별 트랙

본 PR은 *0.193.0 release를 막고 있던 blocker 해결*. release-please workflow 실패 진단은 RFC 외 별도 이슈로 추적 (workflow log 분석 필요).

## Test plan

- [ ] CI green — boundary lint + build & test 모두 통과
- [ ] 머지 후 `git tag v0.193.0` (수동 또는 release-please 워크플로 다시 시도)
- [ ] masc-mcp follow-up: `OAS_AGENT_SDK_BASE_VERSION` `v0.192.1` → `v0.193.0`, `OAS_AGENT_SDK_MIN_VERSION` `0.192.1` → `0.193.0`
- [ ] `human-approved-ready` 라벨 부착 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)