### PR TITLE
docs(rfc) + refactor(eval_stats): RFC-OAS-015 mutable cleanup roadmap + 1 demo

### DIFF
--- a/docs/rfc/RFC-OAS-015-mutable-cleanup-roadmap.md
+++ b/docs/rfc/RFC-OAS-015-mutable-cleanup-roadmap.md
@@ -1,0 +1,179 @@
+# RFC-OAS-015: Mutable Cleanup Roadmap
+
+| | |
+|---|---|
+| Status | Draft |
+| Author | jeong-sik (with Claude analysis) |
+| Created | 2026-05-09 |
+| Target | `agent_sdk` (oas) — and as cross-repo template for `masc_mcp` |
+| Supersedes | None |
+
+## 0. Summary
+
+OCaml `ref` / `mutable record` / `Hashtbl` 사용지점을 *3 카테고리*로 분류하고 *category별 점진 cleanup roadmap*을 제시. 무차별 immutable 변환은 *concurrency 의미*와 *성능 가정*을 silent로 깨뜨릴 수 있어 *분류 우선* 전략 채택.
+
+본 RFC는 *roadmap docs + 1 demo cleanup*. 실제 변환은 *카테고리별 후속 PR*로 분리.
+
+## 1. Inventory (line-pinned, 2026-05-09 main)
+
+### 1.1 OAS (`agent_sdk`)
+
+| 패턴 | 카운트 | 비고 |
+|---|---|---|
+| `let X = ref Y` | 149 init | 가장 큰 surface |
+| `mutable record field` | 50+ files | metrics + state buffers |
+| `Hashtbl` | 100+ files | tool_index, content_replacement_state, complete_stream_acc |
+
+Top files:
+- `lib/streaming.ml`: 17 ref (streaming buffer — *legitimate*)
+- `lib/llm_provider/complete_stream_acc.ml`: 16 ref (stream accumulator — *legitimate*)
+- `lib/llm_provider/transport_codex_cli.ml`: 12 ref (transport state — 검토 필요)
+- `lib/context_reducer_apply.ml`: 12 ref (검토 필요)
+- `lib/proof_store.ml`: 11 ref (RFC-OAS-011에서 cdal_runtime 이주, OAS lib에서 제거됨)
+
+### 1.2 masc-mcp
+
+| 패턴 | 카운트 | 비고 |
+|---|---|---|
+| `let X = ref Y` | **592 init** | 340 files |
+| `mutable record field` | 132 files | dashboard + governance state |
+| `Hashtbl` | 230 files | coordination state, registry |
+
+Top files:
+- `lib/keeper/keeper_run_tools.ml`: 28 ref
+- `lib/keeper/keeper_turn_slot.ml`: 24 ref
+- `lib/keeper/keeper_heartbeat_loop.ml`: 19 ref
+- `lib/dashboard/dashboard_http_keeper.ml`: 18 ref
+
+### 1.3 합계
+
+**OAS + masc-mcp = ~700+ ref** + **180+ mutable record** + **300+ Hashtbl**.
+
+## 2. 카테고리 분류
+
+### 2.1 Category A — Legitimate (변경 금지)
+
+*concurrency, performance, streaming buffer, atomic counter for thread-safety* 정당한 사용.
+
+특징:
+- `Atomic.t` 기반 lock-free
+- streaming buffer (byte-level append)
+- *Eio-domain shared state* (mutex-protected)
+- Hashtbl with O(1) lookup performance assumption
+
+예: `streaming.ml`의 17 ref, `complete_stream_acc.ml`의 51 Hashtbl.
+
+**처리**: *그대로 유지*. cleanup 대상 아님.
+
+### 2.2 Category B — Idiomatic but replaceable (cleanup 가능)
+
+*counter, accumulator in pure-ish function* — `fold` 또는 `mapi`로 대체 가능.
+
+패턴 예:
+```ocaml
+let idx = ref 0 in
+List.fold_left (fun acc x ->
+  let v = f x !idx in
+  incr idx;
+  acc + v
+) 0 xs
+```
+
+→
+```ocaml
+let _, total =
+  List.fold_left (fun (idx, acc) x ->
+    let v = f x idx in
+    (idx + 1, acc + v)
+  ) (0, 0) xs
+in
+total
+```
+
+또는 `List.mapi` + `List.fold_left`로.
+
+**처리**: *카테고리별 PR로 점진 변환*. behavior 변화 0이지만 idiomatic 깨끗함 +.
+
+### 2.3 Category C — Workaround (cleanup 우선)
+
+*single-write 후 read*만 — `let binding`으로 충분한데 `ref` 사용. *lazy code* 또는 *literal copy from imperative source*.
+
+패턴 예:
+```ocaml
+let x = ref initial in
+(* no := anywhere *)
+... !x ...
+```
+
+이런 ref는 *완전히 불필요*. let binding 직접 교체.
+
+**처리**: *우선순위 cleanup*. 위험 0, 면적 작음.
+
+## 3. Quick-win Demo (이 PR)
+
+`lib/eval_stats.ml:137`의 *Category B* 패턴을 *fold accumulator*로 변환:
+
+### Before
+```ocaml
+let idx = ref 0 in
+let num, den =
+  List.fold_left
+    (fun (num, den) y ->
+       let dx = float_of_int !idx -. x_mean in
+       incr idx;
+       num +. (dx *. (y -. m)), den +. (dx *. dx))
+    (0.0, 0.0)
+    xs
+in
+```
+
+### After
+```ocaml
+let _, num, den =
+  List.fold_left
+    (fun (idx, num, den) y ->
+       let dx = float_of_int idx -. x_mean in
+       (idx + 1, num +. (dx *. (y -. m)), den +. (dx *. dx)))
+    (0, 0.0, 0.0)
+    xs
+in
+```
+
+- `idx`가 *fold accumulator의 첫 번째 필드*로 들어감
+- `incr idx` → `idx + 1` (immutable update)
+- `!idx` → `idx` (직접 binding)
+- 결과 tuple destructure: `let _, num, den = ...`
+
+**Behavior 변화**: 0 (수학적 동일).
+
+## 4. Roadmap
+
+| Phase | 작업 | 면적 |
+|---|---|---|
+| **PR-A (this)** | RFC docs + Category B demo (eval_stats.ml) | 2 files / small |
+| **PR-B+ (future)** | Category C cleanup — *single-read zero-mutation ref* per file | per-file |
+| **PR-X (future, lab/)** | Category B — counter/accumulator → fold (eval_stats 외) | per pattern |
+| **deferred** | Category A — 그대로 유지 (정당화 문서만) | 0 |
+
+masc-mcp 측은 *별 RFC* (RFC-MASC-XXX) 또는 본 RFC 본문 확장.
+
+## 5. 정량 측정 (Phase별)
+
+각 cleanup PR이:
+- *line-by-line* 변환 (immutable 1:1)
+- behavior 동일 (테스트 통과 + dune build clean)
+- 가능하면 *property test* 추가 (qcheck로 input 무작위 후 동일 결과)
+
+## 6. 위험과 완화
+
+| # | 위험 | 완화 |
+|---|---|---|
+| 1 | Category A를 잘못 분류해서 변경 → concurrency 깨짐 | RFC §2의 카테고리 정의를 *grep + caller-context*로 검증 후 PR 생성 |
+| 2 | Category B의 *fold accumulator* 변환이 *closure capture* 가정 깨뜨림 | inline test + property test로 동일성 검증 |
+| 3 | RFC-OAS-011 정신 (workaround rejection bar)와의 정합 | 카테고리 C는 *workaround*에 해당, 정리가 *워크어라운드 거부 bar* 정신 일치 |
+
+## 7. References
+
+- `software-development.md` §OCaml — Result Type 우선, Obj.magic 금지
+- `feedback_pre_migration_grep_for_classification.md` — pre-migration grep 룰
+- 메모리 `feedback_workaround_rejection_bar` — workaround signature

--- a/lib/eval_stats.ml
+++ b/lib/eval_stats.ml
@@ -134,14 +134,16 @@ let detect_trend ~window data =
       let m = mean xs in
       let fn = float_of_int n in
       let x_mean = (fn -. 1.0) /. 2.0 in
-      let idx = ref 0 in
-      let num, den =
+      (* RFC-OAS-015: idx counter folded into the accumulator tuple instead
+         of an external [ref] mutated via [incr]. Same arithmetic, no
+         observable behaviour change — Category B (idiomatic but replaceable
+         mutable). *)
+      let _, num, den =
         List.fold_left
-          (fun (num, den) y ->
-             let dx = float_of_int !idx -. x_mean in
-             incr idx;
-             num +. (dx *. (y -. m)), den +. (dx *. dx))
-          (0.0, 0.0)
+          (fun (idx, num, den) y ->
+             let dx = float_of_int idx -. x_mean in
+             idx + 1, num +. (dx *. (y -. m)), den +. (dx *. dx))
+          (0, 0.0, 0.0)
           xs
       in
       if den < 1e-12


### PR DESCRIPTION
## 요약

OCaml *mutable surface*의 점진 cleanup roadmap. 무차별 변환 시 *concurrency 의미*와 *성능 가정*을 silent로 깨뜨릴 수 있어 *3 카테고리 분류 우선* 전략.

본 PR은 **RFC docs + 1 demo cleanup**. 실제 cleanup은 *카테고리별 후속 PR*로 분리.

## Inventory

| 항목 | OAS | masc-mcp |
|---|---|---|
| `let X = ref Y` initializations | 149 | **592** (340 files) |
| `mutable record` files | 50+ | 132 |
| `Hashtbl` files | 100+ | 230 |

총 **~700+ ref**, **180+ mutable record**, **300+ Hashtbl** — *수개월급* 작업.

## 3 카테고리

| Category | 정의 | 처리 |
|---|---|---|
| **A. Legitimate** | concurrency / streaming buffer / Atomic / Eio shared state | *그대로 유지* |
| **B. Idiomatic but replaceable** | fold/iter 안 counter/accumulator. fold accumulator tuple로 immutable 변환 가능 | 카테고리별 PR로 점진 |
| **C. Workaround** | `let X = ref Y` + zero `:=` — let binding으로 충분 | 우선순위 cleanup, 위험 0 |

## Demo (이 PR)

`lib/eval_stats.ml:137`의 *Category B* 패턴:

### Before
```ocaml
let idx = ref 0 in
let num, den =
  List.fold_left
    (fun (num, den) y ->
       let dx = float_of_int !idx -. x_mean in
       incr idx;
       num +. (dx *. (y -. m)), den +. (dx *. dx))
    (0.0, 0.0)
    xs
in
```

### After
```ocaml
let _, num, den =
  List.fold_left
    (fun (idx, num, den) y ->
       let dx = float_of_int idx -. x_mean in
       idx + 1, num +. (dx *. (y -. m)), den +. (dx *. dx))
    (0, 0.0, 0.0)
    xs
in
```

**Behavior 변화**: 0 (수학적 동일).

## Roadmap

| Phase | 범위 |
|---|---|
| **PR-A (this)** | RFC docs + Category B demo |
| **PR-B+** | Category C cleanup (single-read zero-mutation ref) |
| **PR-X (lab/)** | Category B 나머지 (eval_stats 외) |
| **deferred** | Category A — 정당화 문서만 |
| **별 RFC** | masc-mcp 592 ref surface (RFC-MASC-XXX) |
| **별 RFC** | mutable record → functional update (API visibility) |
| **별 RFC** | Hashtbl → Map (perf bench 필요) |

## 검증

```bash
$ rg -n '\bref\b' lib/eval_stats.ml
138:         of an external [ref] mutated via [incr]    # comment only
# 코드 의존 0
```

## 위험과 완화

| # | 위험 | 완화 |
|---|---|---|
| 1 | Category A 잘못 분류 → concurrency 깨짐 | grep + caller-context 검증 후 PR 생성 |
| 2 | Category B fold 변환이 closure capture 깨뜨림 | inline test + property test (qcheck) 검증 |
| 3 | RFC-OAS-011의 workaround rejection bar 정합 | Category C는 *workaround*에 정확히 해당 |

## Test plan

- [ ] CI green — `Build & Test` (eval_stats 사용 모듈) + `Boundary Lint`
- [ ] CodeRabbit/사람 리뷰
- [ ] `human-approved-ready` 라벨 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)