### PR TITLE
refactor(harness) + docs(rfc): RFC-OAS-015 PR-B — fold harness fuzzy-match ref + recipe fix

### DIFF
--- a/docs/rfc/RFC-OAS-015-mutable-cleanup-roadmap.md
+++ b/docs/rfc/RFC-OAS-015-mutable-cleanup-roadmap.md
@@ -101,13 +101,36 @@ total
 패턴 예:
 ```ocaml
 let x = ref initial in
-(* no := anywhere *)
+(* no `:=`, no `incr x`, no `decr x` *)
 ... !x ...
 ```
 
 이런 ref는 *완전히 불필요*. let binding 직접 교체.
 
 **처리**: *우선순위 cleanup*. 위험 0, 면적 작음.
+
+#### 2.3.1 Identification grep recipe
+
+```bash
+# Look for ref vars with NO mutation of any kind:
+#   `:=` assignment, `incr v`, `decr v`.
+# Pattern (rg with -e to avoid shell quoting traps):
+for f in $(rg -l 'let \w+ = ref ' lib/); do
+  for v in $(grep -oE 'let [a-z_][a-z_0-9]* = ref ' "$f" | awk '{print $2}'); do
+    mut=$(rg -c -e "\b$v\s*:=" -e "\bincr\s+$v\b" -e "\bdecr\s+$v\b" "$f" 2>/dev/null \
+          | awk -F: '{s+=$NF} END{print s+0}')
+    rd=$(rg -c "!$v\b" "$f" 2>/dev/null || echo 0)
+    if [ "$mut" = "0" ] && [ "$rd" -ge "1" ]; then
+      echo "$f: '$v' is Category C (no mutation, $rd reads)"
+    fi
+  done
+done
+```
+
+PR-A의 *first attempt* (단일 regex 안 alternation `\|`)는 *shell-escape false negative*로
+`incr` / `decr`를 놓쳐 *Category B*를 *Category C*로 오분류했다 — 후속 PR-B에서
+`harness.ml:366` `common` ref가 실은 `incr common` (Category B)임을 발견. 위 recipe는
+`-e` 분리 alternation으로 그 false negative를 차단한다.
 
 ## 3. Quick-win Demo (이 PR)
 

--- a/lib/harness.ml
+++ b/lib/harness.ml
@@ -355,7 +355,10 @@ module Regression = struct
          | Ok golden_json -> cmp obs.output_json golden_json, None
          | Error msg -> false, Some (Printf.sprintf "Invalid golden JSON: %s" msg))
       | FuzzyMatch { threshold } ->
-        (* Simple character-level similarity *)
+        (* Simple character-level similarity.
+           RFC-OAS-015 PR-B: replaced the imperative `for` loop with an
+           external `ref common` counter by a tail-recursive accumulator.
+           Same arithmetic, identical traversal order. *)
         let len1 = String.length obs.output_text in
         let len2 = String.length golden in
         let max_len = max len1 len2 in
@@ -363,12 +366,16 @@ module Regression = struct
           if max_len = 0
           then true
           else (
-            let common = ref 0 in
             let min_len = min len1 len2 in
-            for i = 0 to min_len - 1 do
-              if obs.output_text.[i] = golden.[i] then incr common
-            done;
-            Float.of_int !common /. Float.of_int max_len >= threshold)
+            let rec count_matches i acc =
+              if i >= min_len
+              then acc
+              else if obs.output_text.[i] = golden.[i]
+              then count_matches (i + 1) (acc + 1)
+              else count_matches (i + 1) acc
+            in
+            let common = count_matches 0 0 in
+            Float.of_int common /. Float.of_int max_len >= threshold)
         in
         passed, None
     in


### PR DESCRIPTION
## 요약

RFC-OAS-015 PR-B. 두 가지 결합 수정:

1. **lib/harness.ml**: FuzzyMatch char-similarity counter (`let common = ref 0` + `incr common` inside `for` loop) → tail-recursive accumulator
2. **RFC §2.3.1**: Category-C grep recipe 정확화 — PR-A의 single-regex alternation이 *shell-escape false negative*로 `incr`/`decr` 매치 놓쳤음

## 발견된 *grep false negative*

PR-A의 grep:
```bash
rg -c "\bincr\s+$v\b\|\bdecr\s+$v\b" "$f"
```

shell이 `\|`를 *literal pipe*로 해석 → `incr`/`decr` 매치 0건 반환. `harness.ml:366`의 `common` ref가 *실제론 `incr common`을 가짐* — Category B인데 Category C로 오분류.

## 수정된 grep recipe (RFC §2.3.1)

```bash
mut=$(rg -c -e "\b$v\s*:=" -e "\bincr\s+$v\b" -e "\bdecr\s+$v\b" "$f")
```

`-e` separate alternation — shell 경로 우회.

## 변경

### Before
```ocaml
let common = ref 0 in
let min_len = min len1 len2 in
for i = 0 to min_len - 1 do
  if obs.output_text.[i] = golden.[i] then incr common
done;
Float.of_int !common /. Float.of_int max_len >= threshold
```

### After
```ocaml
let min_len = min len1 len2 in
let rec count_matches i acc =
  if i >= min_len
  then acc
  else if obs.output_text.[i] = golden.[i]
  then count_matches (i + 1) (acc + 1)
  else count_matches (i + 1) acc
in
let common = count_matches 0 0 in
Float.of_int common /. Float.of_int max_len >= threshold
```

**Behavior**: 동일 traversal order, 동일 arithmetic.

## 검증

```bash
$ rg -n 'ref common\|incr common\|!common\b' lib/harness.ml
# (empty — clean)
```

Stat: 2 files, +35/-7.

## RFC-OAS-015 진행

| Phase | 상태 |
|---|---|
| PR-A (#1491) docs + eval_stats demo | MERGED |
| **PR-B (this) harness + recipe fix** | OPEN Draft |
| PR-C+ Category B 나머지 | TBD |
| 별 RFC-MASC | masc-mcp 592 ref surface | TBD |

## Test plan

- [ ] CI green
- [ ] FuzzyMatch alcotest (있다면) 통과
- [ ] `human-approved-ready` 라벨 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)