### PR TITLE
docs(rfc): RFC-OAS-015 §2.3.1 — multi-line + closure false negatives

### DIFF
--- a/docs/rfc/RFC-OAS-015-mutable-cleanup-roadmap.md
+++ b/docs/rfc/RFC-OAS-015-mutable-cleanup-roadmap.md
@@ -112,12 +112,18 @@ let x = ref initial in
 #### 2.3.1 Identification grep recipe
 
 ```bash
-# Look for ref vars with NO mutation of any kind:
-#   `:=` assignment, `incr v`, `decr v`.
-# Pattern (rg with -e to avoid shell quoting traps):
+# Look for ref vars with NO mutation of any kind across the whole file:
+#   `:=` assignment (any newline-formatting), `incr v`, `decr v`.
+# Multi-line (-U) is required: OCaml frequently formats long mutations as
+#   `varname\n        := <expression>` over two lines, and a line-based
+# rg call would treat the `:=` line as not containing the variable.
 for f in $(rg -l 'let \w+ = ref ' lib/); do
   for v in $(grep -oE 'let [a-z_][a-z_0-9]* = ref ' "$f" | awk '{print $2}'); do
-    mut=$(rg -c -e "\b$v\s*:=" -e "\bincr\s+$v\b" -e "\bdecr\s+$v\b" "$f" 2>/dev/null \
+    mut=$(rg -U -c \
+            -e "\b$v\s*:=" \
+            -e "\bincr\s+$v\b" \
+            -e "\bdecr\s+$v\b" \
+            "$f" 2>/dev/null \
           | awk -F: '{s+=$NF} END{print s+0}')
     rd=$(rg -c "!$v\b" "$f" 2>/dev/null || echo 0)
     if [ "$mut" = "0" ] && [ "$rd" -ge "1" ]; then
@@ -127,10 +133,47 @@ for f in $(rg -l 'let \w+ = ref ' lib/); do
 done
 ```
 
-PR-A의 *first attempt* (단일 regex 안 alternation `\|`)는 *shell-escape false negative*로
-`incr` / `decr`를 놓쳐 *Category B*를 *Category C*로 오분류했다 — 후속 PR-B에서
-`harness.ml:366` `common` ref가 실은 `incr common` (Category B)임을 발견. 위 recipe는
-`-e` 분리 alternation으로 그 false negative를 차단한다.
+##### Known false-negative classes (lessons learned)
+
+| Iteration | Pattern that fooled it | Fix |
+|---|---|---|
+| PR-A | single regex with shell-quoted `\|` alternation | use `rg -e` per pattern |
+| PR-B | `incr` / `decr` not covered | added per-pattern `-e` clauses |
+| PR-C (this) | multi-line formatting `var\n  := ...` (line-based rg miss) | added `rg -U` (multiline) |
+
+##### Closure-around-ref caveat (still a Category B, not C)
+
+The recipe above flags *zero file-wide mutation*. It does **not** distinguish
+between:
+
+- *truly unused mutation* (Category C) — let-binding suffices
+- *closure-mediated mutation* (Category B) — a helper inside the same function
+  body mutates the ref:
+
+```ocaml
+let violations = ref [] in
+let add ~axis ~code ~severity ~message =
+  violations := add_violation !violations ~axis ~code ~severity ~message
+in
+... add ~... ; add ~... ; ...
+List.rev !violations
+```
+
+Both `:=` and `!violations` exist; the recipe correctly counts them. But the
+mutation is *inside a let-binding closure*, and a single mass-conversion is
+risky because every caller of `add` becomes responsible for threading the
+accumulator. Treat closure-around-ref as **Category B with elevated review
+cost** — defer to lab/ branch demos, never bulk-cleanup.
+
+##### Verified scan as of RFC-OAS-015 PR-C
+
+| Repo | Category C strict (true zero mutation) |
+|---|---|
+| OAS `lib/` | **0** after PR-A + PR-B (eval_stats.idx and harness.common were Category B incr-loops, both converted) |
+| masc-mcp `lib/` | **2** false-positives traced to multi-line `:=` formatting (`cdal_runtime/proof_capture.ml: refs`, `coordination_product.ml: violations`) — both reclassified Category B (closure-around-ref) and deferred. |
+
+→ *true Category C is the rare case*. Most "looks like a bare ref" is actually
+Category B with a non-obvious mutator.
 
 ## 3. Quick-win Demo (이 PR)
 


### PR DESCRIPTION
## 요약

PR-B의 `incr`/`decr` 추가 후 *cross-repo wide scan*에서 두 추가 *false negative*가 노출. RFC §2.3.1을 *최종 형태*로 정확화.

**docs only. 코드 0줄.**

## 발견된 false negatives

| Iteration | 패턴 | Fix |
|---|---|---|
| PR-A (#1491) | single regex `\|` shell-escape | `-e` per pattern |
| PR-B (#1493) | `incr` / `decr` 누락 | per-pattern `-e` clauses |
| **PR-C (this)** | multi-line `var\n  := ...` (line-based rg miss) | `rg -U` multiline |

## Multi-line 사례 (masc-mcp scan)

```
lib/cdal_runtime/proof_capture.ml:215  let refs = ref [] in
                              :222    refs
                              :222         := Proof_store.make_ref ... :: !refs);
```

line-based `rg -c '\brefs\s*:='`가 line 222의 `:=`를 *line 222 내 'refs' 없음*으로 0 매치. 실제론 *직전 line의 'refs'와 multi-line 형태*. `-U` flag로 해결.

## Closure-around-ref caveat

```ocaml
let violations = ref [] in
let add ~axis ~code ~severity ~message =
  violations := add_violation !violations ~axis ~code ~severity ~message
in
... add ~... ; add ~... ; ...
List.rev !violations
```

mutation count *non-zero* (recipe 정상 작동) — *false negative 아님*. 그러나 *mass-conversion 위험*: 모든 closure caller가 accumulator threading 책임 떠안음. **Category B with elevated review cost**로 분리 — lab/ 브랜치 demo로 처리, bulk PR 금지.

## Verified scan (post-PR-A/B/C)

| Repo | strict Category C |
|---|---|
| OAS `lib/` | **0** (PR-A/B에서 Category B로 흡수) |
| masc-mcp `lib/` | **0** (multi-line false positives 재분류 후) |

→ *true Category C는 희귀*. *"bare ref처럼 보이는 것"* 대부분이 *non-obvious mutator를 가진 Category B*. 이 사실을 RFC §2.3.1에 *최종 분류* 결과로 박음.

## 다음 단계

| Phase | 위치 |
|---|---|
| Category B 표준 변환 (fold accumulator, tail-recursive loop) | lab/ branch demos, *file-by-file* |
| Closure-around-ref refactor | 별 RFC + multi-PR (caller threading) |
| masc-mcp 측 mirror RFC | RFC-MASC-XXX (별 트랙) |
| `mutable record` / `Hashtbl` | 각자 별 RFC, 성능 bench 동반 |

## Test plan

- [ ] CI green (docs only)
- [ ] `human-approved-ready` 라벨 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)