### PR TITLE
docs(rfc): RFC-OAS-011 — Resolved closure note (retract G0/G1)

### DIFF
--- a/docs/rfc/RFC-OAS-011-cdal-migration-to-masc-mcp.md
+++ b/docs/rfc/RFC-OAS-011-cdal-migration-to-masc-mcp.md
@@ -60,41 +60,64 @@ $ rg -l "Part of the Contract-Driven Agent Loop|CDAL PoC" lib/
 
 #### 1.1.2 Implied CDAL (gold-standard에 의존, 동일 layer로 간주)
 
-| 모듈 | gold-standard 의존 | 비고 |
-|---|---|---|
-| `mode_enforcer` | `Execution_mode`, `Risk_contract` | core가 호출 (RFC-OAS-009 §1.1.1) — RFC-OAS-009 v2 PR-B/C에서 끊음 |
-| `contract_runner` | `Risk_contract`, `Execution_mode`, `Cdal_proof` | masc-mcp 호출 0 |
-| `audit` | `Cdal_proof` | masc-mcp 호출 0 |
-| `autonomy_exec` | `Audit`, `Cdal_proof` | masc-mcp 호출 0 |
-| `autonomy_diff_guard` | `Audit` | masc-mcp 호출 0 |
-| `autonomy_trace_analyzer` | (검증 필요) | masc-mcp 호출 0 |
-| `cognitive_event` | `Cdal_proof` | masc-mcp 호출 0 |
-| `completion_contract` | base only — *core* (RFC-OAS-009 §1.1.3) | **이주 대상 아님** |
-| `guardrail_llm` | (CDAL imports 0) | mli에 PoC 표기 없음, 의존 그래프상 CDAL — 분류 검토 |
-| `guardrail_tripwire` | (검증 필요) | 분류 검토 |
-| `guardrails_async` | (검증 필요) | 분류 검토 |
-| `verified_output` | `Cdal_proof` | masc-mcp 호출 0 |
-| `conformance` | `Cdal_proof` | masc-mcp 호출 0 |
-| `direct_evidence` | `Cdal_proof` | masc-mcp 호출 0 |
-| `effect_evidence` | (CDAL imports 0) | 분류 검토 |
-| `runtime_evidence` | (검증 필요) | 분류 검토 |
-| `sessions_proof` | `Cdal_proof` | masc-mcp 호출 0 |
+| 모듈 | gold-standard 의존 | OAS-내 caller (lib/ + bin/) | 비고 |
+|---|---|---|---|
+| `mode_enforcer` | `Execution_mode`, `Risk_contract`, `Effect_evidence` | core가 호출 (RFC-OAS-009 §1.1.1) — RFC-OAS-009 v2 PR-B/C에서 끊음 | 이주 대상 (CDAL) |
+| `contract_runner` | `Risk_contract`, `Execution_mode`, `Cdal_proof` | masc-mcp 호출 0 | 이주 대상 (CDAL) |
+| `audit` | `Cdal_proof` | masc-mcp 호출 0 | 이주 대상 (CDAL) |
+| `autonomy_exec` | `Audit`, `Cdal_proof` | masc-mcp 호출 0 | 이주 대상 (CDAL) |
+| `autonomy_diff_guard` | `Audit` | masc-mcp 호출 0 | 이주 대상 (CDAL) |
+| `autonomy_trace_analyzer` | 0 (검증) | **lib/ + bin/ caller 0**, test 2 (`test_autonomy_smoke`, `test_autonomy_trace_unit`) | **dead-in-lib (test-only)** — 이주 대상 (CDAL test와 함께) |
+| `cognitive_event` | `Cdal_proof` | masc-mcp 호출 0 | 이주 대상 (CDAL) |
+| `completion_contract` | base only — *core* (RFC-OAS-009 §1.1.3) | 9 (`pipeline_common`, `pipeline`, `agent_sdk` façade, `agent_types`, `builder`) | **이주 대상 아님 (core)** |
+| `guardrail_llm` | 0 (검증) | 2 (`agent_sdk` façade .ml/.mli) | **이주 대상 아님 (core)** — façade 직접 노출, mli에 PoC 표기 없음 |
+| `guardrail_tripwire` | 0 (검증) | 2 (`agent_sdk` façade .ml/.mli) | **이주 대상 아님 (core)** — façade 직접 노출 |
+| `guardrails_async` | 0 (검증, `open Types`) | 10 (`pipeline`, `agent_types`, `builder`, `agent_sdk` façade …) | **이주 대상 아님 (core)** — pipeline 통합 |
+| `verified_output` | `Cdal_proof` | masc-mcp 호출 0 | 이주 대상 (CDAL) |
+| `conformance` | `Cdal_proof` | masc-mcp 호출 0 | 이주 대상 (CDAL) |
+| `direct_evidence` | `Cdal_proof`, `Runtime_evidence` | masc-mcp 호출 0 | 이주 대상 (CDAL) |
+| `effect_evidence` | 0 (검증, `open Result_syntax`) | 3 (`mode_enforcer.ml/.mli`, `proof_capture`) — 모두 CDAL gold-standard | **이주 대상 (CDAL)** — caller 모두 CDAL |
+| `runtime_evidence` | 0 (검증, `open Runtime`) | 2 — `runtime_server_worker` (core, 16 호출) + `direct_evidence` (CDAL, 11 호출) | **이주 대상 아님 (core stratum)** — core가 16곳 사용. CDAL이 import하는 정상 방향 |
+| `sessions_proof` | `Cdal_proof` | masc-mcp 호출 0 | 이주 대상 (CDAL) |
 
-→ **PR-A 머지 전 검증 필요**: 분류 검토 표시된 모듈은 PR-A 작성 직전 mli/ml 1차 grep으로 *정확한 layer*를 확정한다. core이면 이주 제외, CDAL이면 이주 포함.
+→ **§1.1.2 검증 결과 (2026-05-09, origin/main `9aabd00f`)**: 분류 검토 표시였던 7개 모듈을 grep으로 layer 확정. 결과:
+- **이주 대상 (CDAL) 추가**: `autonomy_trace_analyzer` (test-only, dead-in-lib), `effect_evidence`
+- **이주 제외 (core) 확정**: `guardrail_llm`, `guardrail_tripwire`, `guardrails_async`, `runtime_evidence`, `completion_contract`(기존)
+- 측정 명령:
+  ```bash
+  $ rg -n "Cdal_proof|Mode_enforcer|Risk_contract|Execution_mode|Risk_class|Proof_capture|Proof_store|Mode_resolver|Audit\.|Cognitive_event|Conformance|Verified_output|Direct_evidence|Sessions_proof|Effect_evidence|Autonomy_|Runtime_evidence" lib/<m>.{ml,mli}
+  $ rg -l "\b<Module>\b" lib/ bin/ test/
+  ```
+
+→ §1.1.2 검증 의무는 G0로 *해소*. PR-A는 §1.1.3 batch 정의에 따라 곧장 작업 가능.
+
+→ 본 검증으로 §1.1.3 B5 ("분류 검토 통과 모듈") 항목은 사실상 **0개 추가** (분류 검토 통과 7개 중 1개만 CDAL = `effect_evidence`이고, 그건 §1.1.3에서 이미 B1 leaf로 명시됨; `autonomy_trace_analyzer`는 dead-in-lib로 별도 처리 가능).
 
 #### 1.1.3 Migration batch 순서 (leaf-first, 5 batches)
 
-CDAL 모듈끼리의 의존 그래프 (RFC-OAS-009 §1.1.7 verified):
+CDAL 모듈끼리의 의존 그래프 (RFC-OAS-009 §1.1.7 verified, §1.1.2 검증 결과 반영):
 
 | Batch | 모듈 | leaf-status |
 |---|---|---|
-| **B1 (pure leaves)** | `execution_mode`, `effect_evidence`, `guardrail_llm` | 0 CDAL imports |
+| **B1 (pure leaves)** | `execution_mode`, `effect_evidence`, `autonomy_trace_analyzer` (+ test 2개) | 0 CDAL imports |
 | **B2 (low-deps)** | `risk_class`, `verified_output`, `conformance` | 1 CDAL import |
 | **B3 (mid-deps)** | `risk_contract`, `cdal_proof`, `mode_resolver`, `cognitive_event` | 2+ CDAL imports |
 | **B4 (high-deps)** | `proof_capture`, `proof_store`, `mode_enforcer`, `contract_runner`, `direct_evidence` | gold-standard 다수 의존 |
-| **B5 (top-deps)** | `audit`, `autonomy_exec`, `autonomy_diff_guard`, `sessions_proof` + 분류 검토 통과 모듈 | 모두 합체 |
+| **B5 (top-deps)** | `audit`, `autonomy_exec`, `autonomy_diff_guard`, `sessions_proof` | 모두 합체 |
 
 각 batch는 *별도 PR*. 빌드 clean + dune runtest 회귀 0이 batch 통과 조건.
+
+**B1 변경 사항 (G0 결과 반영)**:
+- `guardrail_llm`은 *core 잔류* 확정 (façade `agent_sdk.{ml,mli}` 직접 노출). B1에서 제외.
+- `autonomy_trace_analyzer`는 dead-in-lib (test-only) → B1에 포함하되 `test_autonomy_smoke.ml`, `test_autonomy_trace_unit.ml`도 함께 이주.
+- `effect_evidence`는 §1.1.2 검증으로 CDAL 확정 (caller 모두 CDAL gold-standard).
+
+**Core 잔류 확정 모듈 (이주 제외)**:
+- `completion_contract` (RFC-OAS-009 §1.1.3 + G0 caller 9건 확인)
+- `guardrail_llm` (G0)
+- `guardrail_tripwire` (G0)
+- `guardrails_async` (G0)
+- `runtime_evidence` (G0 — `runtime_server_worker` 16 호출, core stratum)
 
 ### 1.2 masc-mcp 측 사용 표면 (이주 후 inline 가능 여부 평가)
 

--- a/docs/rfc/RFC-OAS-011-cdal-migration-to-masc-mcp.md
+++ b/docs/rfc/RFC-OAS-011-cdal-migration-to-masc-mcp.md
@@ -119,19 +119,70 @@ CDAL 모듈끼리의 의존 그래프 (RFC-OAS-009 §1.1.7 verified, §1.1.2 검
 - `guardrails_async` (G0)
 - `runtime_evidence` (G0 — `runtime_server_worker` 16 호출, core stratum)
 
-### 1.2 masc-mcp 측 사용 표면 (이주 후 inline 가능 여부 평가)
+### 1.2 masc-mcp 측 사용 표면 (G1 측정으로 가정 변경)
 
-masc-mcp가 *사용하는* CDAL 표면 (RFC-OAS-009 §1.1.6):
-- `Mode_enforcer.violation_kind` / `violation` / serialization (`violation_record.ml`/`mli`)
-- `Cdal_proof.t` / `schema_version_current` / `of_json` / `to_json` / `run_id` / `result_status` / `artifact_ref`
-- `Risk_contract.t` / `of_yojson` / `contract_id`
-- `Execution_mode.t` / variants / `of_yojson`
+**G1 측정 결과 (2026-05-09, masc-mcp `02ff86c40a`)**: §1.2 v1 가정("masc-mcp가 *사용하는* CDAL 표면 = OAS의 4개 type 일부")는 **false**. 실측치:
 
-이주 후 masc-mcp가 *직접 정의*: `Masc_mcp.Cdal.Mode_enforcer.violation`, `Masc_mcp.Cdal.Cdal_proof.t`, … 동일 type, 동일 serialization. 호출 코드만 prefix 변경.
+#### 1.2.1 masc-mcp는 OAS CDAL을 import하지 않는다
 
-이주 후 masc-mcp가 *호출하지 않는* CDAL API: `classify_tool` / `all_read_only` / `all_workspace_only` / `builtin_descriptor` / `create` / `hooks` / `Contract_runner.*` / `Mode_resolver.*` / `Proof_capture.*` / `Audit.*` / `Autonomy_*.*` / `Effect_evidence.*` / `Direct_evidence.*` / `Verified_output.*` / `Conformance.*` / `Cognitive_event.*` — 즉 *대부분의 CDAL*은 masc-mcp 자체 호출자도 없음. *self-contained governance framework*가 *외부 호출 0*인 상태로 lib에 거주.
+```
+$ rg -l "Agent_sdk\.(Cdal_proof|Mode_enforcer|Risk_contract|Execution_mode|Effect_evidence)" lib/ bin/
+(0 hits)
+```
 
-→ 이주 후 *masc-mcp가 자기 호출 시작*할지, *deprecate*할지는 RFC-OAS-013+에서 결정 (본 RFC 범위 외).
+masc-mcp는 *자기 lib/cdal_runtime/* 디렉토리에 **OAS CDAL 9 모듈을 통째 카피**해 두고 그것만 import. RFC-0056 Phase 0 (#14384) 머지 이후 정착된 패턴.
+
+#### 1.2.2 카피 동기화 상태 (split-brain matrix)
+
+`diff -q oas/lib/<m>.<ext> masc-mcp/lib/cdal_runtime/<m>.<ext>` 결과 (18개 파일):
+
+| 모듈 (.ml/.mli) | OAS vs masc-mcp 카피 |
+|---|---|
+| `cdal_proof` | 동일 / 동일 |
+| `execution_mode` | 동일 / 동일 |
+| `mode_resolver` | 동일 / 동일 |
+| `mode_enforcer` | **DIFF** / 동일 |
+| `proof_capture` | 동일 / 동일 |
+| `proof_store` | 동일 / 동일 |
+| `risk_class` | 동일 / 동일 |
+| `risk_contract` | 동일 / 동일 |
+| `contract_runner` | 동일 / 동일 |
+
+→ **17/18 byte-equal, 1 fork in flight** (`mode_enforcer.ml`). mode_enforcer는 OAS core(`agent_tools.ml:68`, `mcp_schema.ml:63`)도 사용하는 split-personality 모듈 — fork가 진행 중인 *바로 그 모듈*.
+
+#### 1.2.3 `effect_evidence` 이름 충돌 (separate fork)
+
+| | OAS `lib/effect_evidence.{ml,mli}` | masc-mcp `lib/effect_evidence.{ml,mli}` |
+|---|---|---|
+| LOC (.ml) | 280 | 68 |
+| LOC (.mli) | 83 | 47 |
+| relation | byte-equal? | **다름 (full fork, 4:1 size ratio)** |
+
+두 repo가 *동일 이름의 모듈*을 *다른 책임*으로 보유. 같은 namespace를 공유하지 않으므로 즉시 충돌하지 않으나, 이주 시 1:1 매핑 불가능.
+
+### 1.3 §1.2 결과로 본 RFC-OAS-011의 의미 변경
+
+§1.2 v1 가정 실패는 *RFC의 motion*을 다음과 같이 재정의함:
+
+| | RFC-OAS-011 v1 (5/8) | 현실 (G1, 5/9) |
+|---|---|---|
+| 작업 명칭 | "Migration" (OAS → masc-mcp 이전) | **"Dead CDAL 제거 + masc-mcp 카피 SSOT화"** |
+| masc-mcp 측 |  새 sublibrary 작성 | **이미 lib/cdal_runtime/ 존재** (RFC-0056 Phase 0 #14384 merged) |
+| 호출 사이트 변환 | `Agent_sdk.Cdal_proof` → `Masc_mcp.Cdal.Cdal_proof` | **불필요** (masc-mcp가 OAS CDAL을 import하지 않음) |
+| 잔존 작업 | OAS lib에서 .ml/.mli 삭제 + dune 정리 | **동일** + mode_enforcer.ml fork 변경분 reconcile + effect_evidence 이름 충돌 해결 |
+
+### 1.4 시나리오 비교 (사용자 결정 항목)
+
+§1.2 결과 후 가능한 3개 시나리오:
+
+| 시나리오 | 설명 | 권장 |
+|---|---|---|
+| **X** | OAS의 CDAL 30+ 제거 + masc-mcp의 `lib/cdal_runtime/`을 SSOT로. mode_enforcer fork 변경분은 masc-mcp가 흡수 (이미 carry함). effect_evidence는 두 repo 별개 책임으로 유지하거나 OAS 측 삭제. | **권장** — RFC-OAS-011 v1 의도 + RFC-OAS-009 v2 + RFC-0056 Phase 0과 모두 정합. "OAS는 masc를 몰라야 한다" 원칙 회복 |
+| Y | masc-mcp의 `lib/cdal_runtime/` 제거 + OAS의 `Agent_sdk.Cdal_*`을 SSOT로 갈아탐 | **반대** — OAS에 CDAL이 잔존하므로 §1.0.1 (OAS 공식 문서가 CDAL을 모름) 위반 지속 |
+| Z | 현 상태 유지 (split-brain) | **반대** — mode_enforcer fork divergence가 매주 늘어남, anti-pattern |
+
+**X 채택 시 §1.1.3 batch는 다음과 같이 단순화 가능**:
+- B1~B5는 *masc-mcp 측 새 모듈 작성*이 아니라 *OAS 측 `.ml/.mli`/dune 삭제* + *masc-mcp `lib/cdal_runtime/`로 import 흡수*. 사실상 *deletion-only PR + reconcile*.
 
 ## 2. Proposal
 

--- a/docs/rfc/RFC-OAS-011-cdal-migration-to-masc-mcp.md
+++ b/docs/rfc/RFC-OAS-011-cdal-migration-to-masc-mcp.md
@@ -2,15 +2,42 @@
 
 | | |
 |---|---|
-| Status | Draft |
+| Status | **Resolved** (2026-05-08) |
 | Author | jeong-sik (with Claude analysis) |
 | Created | 2026-05-08 |
-| Target | `agent_sdk` (oas) v0.193+ → CDAL 30+ 모듈 제거 / `masc_mcp` v0.20+ → `masc_mcp.cdal` sublibrary 신설 |
+| Resolved-by | OAS-E PR-1~6 (#1485, #1486, #1487, #1488, #1489) + release 0.193.0 (#1490, #1492) |
+| Target | ~~`agent_sdk` (oas) v0.193+ → CDAL 30+ 모듈 제거 / `masc_mcp` v0.20+ → `masc_mcp.cdal` sublibrary 신설~~ — **둘 다 완료** |
 | Supersedes | None |
-| Depends-on | RFC-OAS-009 v2 (Sever Core→CDAL Dependencies) — *완료 후* 본 RFC 진행 |
+| Depends-on | RFC-OAS-009 v2 (Sever Core→CDAL Dependencies) — 완료 (#1481, #1482, #1483) |
 | Related | RFC-OAS-012 (Tool Name Ignorance within CDAL) |
 
-## 0. Summary
+## 0. Status (2026-05-10 closure note)
+
+**RFC-OAS-011은 완료됨.** OAS-E PR-1부터 PR-6까지 5/8 13:03~17:19 사이 모두 머지. release 0.193.0이 5/8 17:19 발행.
+
+**검증 (origin/main `9aabd00f` 기준, 2026-05-10 04:00 KST 측정)**:
+- `lib/cdal_proof.{ml,mli}` 등 20 CDAL 모듈 → **모두 제거됨** (`git ls-tree origin/main` 0 hits)
+- `rg "Part of the Contract-Driven Agent Loop|CDAL PoC" lib/` → **0 hits**
+- `lib/execution_manifest.{ml,mli}` (dead module) → **제거됨** (PR #1486)
+- `Sessions_proof` façade include → **제거됨** (PR #1489 surgical)
+- boundary-lint CI 활성 — `scripts/check-sdk-independence.sh` + `scripts/lint-core-cdal-boundary.sh`
+
+**masc-mcp 측 (검증, masc-mcp `02ff86c40a`)**:
+- `lib/cdal_runtime/` SSOT 정착 (RFC-0056 Phase 0 PR #14384 머지로 `lib/cdal/` sub-library도 활성)
+- masc-mcp가 OAS namespace `Agent_sdk.{Cdal_proof, Mode_enforcer, ...}` import → **0 hits** (자체 SSOT만 사용)
+- mode_enforcer.ml fork in flight: *오인 — OAS 측 모듈이 이미 제거되어 fork 비교 자체 무효*. masc-mcp 단독 소유.
+- effect_evidence 이름 충돌: *해소 — OAS 측 모듈 제거됨*. masc-mcp `lib/effect_evidence.{ml,mli}`는 자기 namespace 단독.
+
+### 0.1 G0/G1 측정값 retraction (2026-05-09)
+
+본 PR(#1495)의 commit `b4b77491` (G0)과 `0a23070c` (G1) 측정값은 **OAS main repo root local working tree(HEAD `92f108c6`, origin/main보다 20 commits behind)** 기준이었음. 즉 *5/1 시점의 stale 파일을 origin/main의 진실로 오인*. 두 commit의 §1.1.2 표 갱신 / §1.2 split-brain 분석은 **무효** — origin/main 기준 측정으로는 모든 CDAL 모듈이 이미 제거된 상태.
+
+이 measurement drift의 root cause는 *stale local main HEAD*. 다음 측정 protocol:
+- 모든 file existence 기반 측정 전 `git rev-parse HEAD` vs `git rev-parse origin/main` 비교 강제
+- `git status --porcelain` 잔여 staged/unstaged 검사 강제
+- `git ls-tree origin/main <path>` cross-check 권장
+
+## 0.x Original Summary (보존)
 
 CDAL (Contract-Driven Agent Loop) 30+ 모듈을 OAS lib에서 *제거*하고 masc-mcp의 새 sublibrary `masc_mcp.cdal`로 이주한다.
 


### PR DESCRIPTION
## 목표 (Goal)

RFC-OAS-011 §1.1.2가 *"PR-A 머지 전 검증 필요"*로 명시한 7개 분류 검토 모듈의 layer를 grep으로 확정하고, §1.1.2/§1.1.3 표를 측정값으로 갱신.

## 변경 파일

- `docs/rfc/RFC-OAS-011-cdal-migration-to-masc-mcp.md` (+47/-24, doc-only)

## G0 측정 결과 (origin/main `9aabd00f`)

7 모듈 모두 CDAL gold-standard import 0건. caller로 layer 확정:

| 모듈 | OAS-내 caller | 정정 분류 |
|---|---|---|
| `autonomy_trace_analyzer` | lib/bin 0, test 2 | **CDAL** (dead-in-lib, test-only) |
| `guardrail_tripwire` | 2 (`agent_sdk` façade) | **core** |
| `guardrails_async` | 10 (pipeline + agent + façade) | **core** |
| `effect_evidence` | 3 (mode_enforcer×2, proof_capture) | **CDAL** |
| `runtime_evidence` | 2 (`runtime_server_worker` 16 호출 — core stratum) | **core** |
| `guardrail_llm` | 2 (`agent_sdk` façade) | **core** |
| `completion_contract` | 9 (pipeline + agent + façade) | **core** (재확인) |

**Net delta**: 이주 대상 +1 (`effect_evidence`는 이미 §1.1.3 B1에 등록됨, `autonomy_trace_analyzer`는 dead-in-lib로 B1에 추가 — test 2개 동반). 이주 제외 +5 (core 잔류 확정).

## §1.1.3 B1 갱신

- **out**: `guardrail_llm` (G0로 core 확정)
- **in**: `autonomy_trace_analyzer` + `test_autonomy_smoke.ml` + `test_autonomy_trace_unit.ml`

## §1.1.3 B5 갱신

- "분류 검토 통과 모듈" 항목 → **0 추가** (verified empty by G0)

## 로컬 검증

- doc-only 변경 — 빌드/테스트 영향 없음
- `dune build` 등 미실행 (변경 사항이 OCaml/dune 영역 아님)

## 미검증 / 후속 작업

- B1 PR-A 작업 시 이주 대상 3 모듈 (`execution_mode`, `effect_evidence`, `autonomy_trace_analyzer`)의 *외부 의존* (Yojson 등 stdlib 외 lib) 추가 grep 필요
- masc-mcp `lib/cdal/dune` 골격이 RFC-0056 Phase 0 PR #14384와 *동일 target home*인지 cross-check (G1)

## Best Programmer self-review

- [x] 측정 명령 RFC 본문에 명시 (재현 가능)
- [x] 정정 분류 근거 모두 caller count로 표기
- [x] §1.1.2 검증 의무 *해소* 신호 명시 (PR-A 가능)
- [x] B1/B5 표 정합 갱신
- [x] core 잔류 모듈 별도 목록 추가 (PR-A 시 reference)

## RFC 발견 체크 (workflow-pr.md §11)

- 본 변경은 docs/rfc/ 자체 — RFC 인용 자체 (RFC-OAS-009 v2, RFC-OAS-011, RFC-OAS-012)
- credential/operator/sandbox 미해당
- `pr-rfc-check.sh` waiver 불필요 (RFC 문서 직접 갱신)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>