### PR TITLE
test(telemetry): add SCA alias and producer coverage test

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -299,6 +299,11 @@
  (libraries agent_sdk llm_provider alcotest eio_main))
 
 (test
+ (name test_telemetry_sca)
+ (modules test_telemetry_sca)
+ (libraries agent_sdk alcotest))
+
+(test
  (name test_lenient_json)
  (modules test_lenient_json)
  (libraries agent_sdk alcotest))
@@ -343,3 +348,8 @@
  (name test_agent_cancellation_tla_parity)
  (modules test_agent_cancellation_tla_parity)
  (libraries agent_sdk alcotest))
+
+(rule
+ (alias telemetry_sca_check)
+ (deps test_telemetry_sca.exe)
+ (action (run ./test_telemetry_sca.exe)))

--- a/test/test_telemetry_sca.ml
+++ b/test/test_telemetry_sca.ml
@@ -1,0 +1,58 @@
+(** Telemetry Signal-Consumer Audit (SCA) verification.
+
+    Reads {!Telemetry_sca_registry} and asserts that every registered
+    signal appears in its declared producer_files.  This catches
+    registry drift when emit sites are refactored or renamed. *)
+
+open Agent_sdk
+
+let string_contains haystack needle =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  let rec aux i =
+    if i + nlen > hlen then false
+    else if String.sub haystack i nlen = needle then true
+    else aux (i + 1)
+  in
+  aux 0
+;;
+
+let read_file path =
+  try
+    let ic = open_in path in
+    let n = in_channel_length ic in
+    let s = really_input_string ic n in
+    close_in ic;
+    s
+  with exn ->
+    Printf.sprintf "(* could not read %s: %s *)" path (Printexc.to_string exn)
+;;
+
+let check_entry entry () =
+  let signal = entry.Telemetry_sca_registry.signal in
+  let producer_files = entry.Telemetry_sca_registry.producer_files in
+  List.iter
+    (fun file ->
+       let path = Filename.concat ".." file in
+       let content = read_file path in
+       Alcotest.check
+         Alcotest.bool
+         (Printf.sprintf "signal %s present in %s" signal file)
+         true
+         (string_contains content signal))
+    producer_files
+;;
+
+let () =
+  let registry = Telemetry_sca_registry.registry in
+  let tests =
+    List.map
+      (fun entry ->
+         Alcotest.test_case
+           entry.Telemetry_sca_registry.signal
+           `Quick
+           (check_entry entry))
+      registry
+  in
+  Alcotest.run "Telemetry SCA" [ "producer_coverage", tests ]
+;;


### PR DESCRIPTION
## Summary
Adds `@telemetry_sca_check` dune alias and a registry-based producer-coverage test that verifies every `Telemetry_event.t` signal has at least one producer site in the declared source files.

## Changes
- `test/test_telemetry_sca.ml` — reads `Telemetry_sca_registry.registry` and asserts each signal string is present in its `producer_files`
- `test/dune` — wires `(test)` stanza for `test_telemetry_sca` + `(rule (alias telemetry_sca_check))`

## Verification
```
$ dune build --root . @telemetry_sca_check
Testing `Telemetry SCA'.
  [OK] producer_coverage 0 Streaming_first_chunk.
  [OK] producer_coverage 1 Streaming_chunk_n.
  [OK] producer_coverage 2 Thinking_complete.
  [OK] producer_coverage 3 Timeout.
  [OK] producer_coverage 4 Prefill_complete.
  [OK] producer_coverage 5 Budget_exceeded.
Test Successful in 0.007s. 6 tests run.
```

## Scope
- Does NOT modify lib/ or bin/ — test-only addition.
- No breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)