### PR TITLE
chore(release-please): add named-capture pattern for agent_sdk.opam bumps

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,7 +20,8 @@
         },
         {
           "type": "generic",
-          "path": "agent_sdk.opam"
+          "path": "agent_sdk.opam",
+          "pattern": "^version: \"(?<version>\\d+\\.\\d+\\.\\d+)\""
         }
       ]
     }


### PR DESCRIPTION
Closes #1506.

## Summary

release-please-config.json 의 \`agent_sdk.opam\` extra-file 엔트리에 \`pattern\` 옵션을 추가.

\`\`\`diff
 {
   "type": "generic",
-  "path": "agent_sdk.opam"
+  "path": "agent_sdk.opam",
+  "pattern": "^version: \\"(?<version>\\\\d+\\\\.\\\\d+\\\\.\\\\d+)\\""
 }
\`\`\`

## Hypothesis

\`agent_sdk.opam\` 은 dune 이 \`generate_opam_files true\` 로 생성하는 파일이라 in-line \`# x-release-please-version\` 주석이 들어가지 않음. release-please generic updater 기본 동작은 그 주석 위치를 찾아 version 자리를 교체하므로, 주석이 없으면 silent skip.

\`pattern\` 옵션은 named-capture group (\`(?<version>...)\`) 을 지정해 in-line marker 없이도 version 자리를 직접 매칭 가능.

## Verification limit (Important)

- 이번 PR 의 commit type 은 \`chore:\` 라 release-please 가 새 release PR 을 trigger 하지 않음
- pattern 효과 검증은 *다음* \`feat:\`/\`fix:\` commit 이 main 에 들어가는 시점까지 deferred
- pattern 문법이 release-please v4 generic updater 규약과 정확히 호환되는지 공식 문서 cross-check 가 미흡 — Draft 로 두고 stakeholder 의 다음 release cycle 관찰 의존

## Fallback (if pattern doesn't work)

다음 release 에서 또 stale 이면 두 가지 follow-up 후보:

| Option | Action |
|--------|--------|
| post-release workflow | release-please-action 후 \`dune build && git diff --quiet || (git add agent_sdk.opam && git commit -m 'chore: regen opam' && git push)\` 단계 추가. GITHUB_TOKEN 한계로 PAT 또는 App token 필요 |
| dune-project 의 (generate_opam_files true) 제거 | agent_sdk.opam 을 hand-maintain, in-line marker 추가. OCaml ecosystem 표준 패턴 위반이라 trade-off 큼 |

## References

- Issue #1506 (recurring drift report)
- release-please generic updater: <https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files>
- 이번 세션의 hand-regen 사례 2회: PR #1502 last commit, PR #1505 last commit