### PR TITLE
feat(agent): add disclosure_level for tool schema serialization

### DIFF
--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -51,6 +51,7 @@ type options = Agent_types.options =
   ; operator_policy : Guardrails.tool_filter option
   ; policy_channel : Policy_channel.t option
   ; tool_selector : Tool_selector.strategy option
+  ; disclosure_level : Tool.disclosure_level option
   ; priority : Llm_provider.Request_priority.t option
   ; slot_id : int option
   ; on_run_complete : (bool -> unit) option

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -99,6 +99,7 @@ let prepare_tools
       ~turn_params
       ?tool_selector
       ?messages
+      ?(disclosure_level = Tool.Full_schema)
       ()
   =
   (* Precedence: policy_channel > operator > hook > agent.
@@ -156,7 +157,9 @@ let prepare_tools
       in
       Tool_selector.select ~strategy ~context ~tools:(Tool_set.to_list visible)
   in
-  let tool_schemas = List.map Tool.schema_to_json selected in
+  let tool_schemas =
+    List.map (Tool.schema_to_json_with_disclosure disclosure_level) selected
+  in
   let tools_json = if tool_schemas = [] then None else Some tool_schemas in
   let visible_tool_names = List.map (fun (t : Tool.t) -> t.schema.name) selected in
   tools_json, visible_tool_names, effective_guardrails
@@ -306,6 +309,7 @@ let prepare_turn
       ~tiered_memory
       ~turn_params
       ?tool_selector
+      ?disclosure_level
       ()
   =
   let tools_json, visible_tool_names, effective_guardrails =
@@ -316,6 +320,7 @@ let prepare_turn
       ~tools
       ~turn_params
       ?tool_selector
+      ?disclosure_level
       ~messages
       ()
   in

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -88,8 +88,13 @@ type turn_preparation =
     Priority: [turn_params.tool_filter_override] > [operator_policy] > [guardrails]
     Then: [tool_selector] narrows the guardrails-filtered set.
 
+    [disclosure_level] controls how each surviving tool's schema is
+    serialized. Default [Tool.Full_schema] preserves legacy behavior
+    byte-for-byte. See {!Tool.disclosure_level}.
+
     @since 0.94.0 added [operator_policy] parameter
-    @since 0.100.0 added [tool_selector] and [messages] parameters *)
+    @since 0.100.0 added [tool_selector] and [messages] parameters
+    @since 0.194.0 added [disclosure_level] parameter *)
 val prepare_tools
   :  guardrails:Guardrails.t
   -> operator_policy:Guardrails.tool_filter option
@@ -98,6 +103,7 @@ val prepare_tools
   -> turn_params:Hooks.turn_params
   -> ?tool_selector:Tool_selector.strategy
   -> ?messages:Types.message list
+  -> ?disclosure_level:Tool.disclosure_level
   -> unit
   -> Yojson.Safe.t list option * string list * Guardrails.t
 (** Returns [(tools_json, visible_tool_names, effective_guardrails)].
@@ -143,6 +149,7 @@ val prepare_turn
   -> tiered_memory:tiered_memory option
   -> turn_params:Hooks.turn_params
   -> ?tool_selector:Tool_selector.strategy
+  -> ?disclosure_level:Tool.disclosure_level
   -> unit
   -> turn_preparation
 

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -40,6 +40,7 @@ type options =
   ; operator_policy : Guardrails.tool_filter option
   ; policy_channel : Policy_channel.t option
   ; tool_selector : Tool_selector.strategy option
+  ; disclosure_level : Tool.disclosure_level option
   ; priority : Llm_provider.Request_priority.t option
   ; slot_id : int option
   ; on_run_complete : (bool -> unit) option
@@ -151,6 +152,7 @@ let default_options =
   ; operator_policy = None
   ; policy_channel = None
   ; tool_selector = None
+  ; disclosure_level = None
   ; priority = None
   ; slot_id = None
   ; on_run_complete = None

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -98,6 +98,13 @@ type options =
         user's query, improving selection accuracy from ~42% to 83-100%.
         Applied after guardrails and operator policy filtering.
         @since 0.100.0 *)
+  ; disclosure_level : Tool.disclosure_level option
+    (** Controls how each surviving tool's schema is serialized.
+        [None] preserves legacy behavior ([Full_schema]). See
+        {!Tool.disclosure_level} for risk notes — [Minimal_index] omits
+        [input_schema] and may break models that need it to compose
+        arguments.
+        @since 0.194.0 *)
   ; priority : Llm_provider.Request_priority.t option
     (** Scheduling priority for LLM requests at the options level.
         When [Some], overrides [agent_config.priority] on the resume path.

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -63,6 +63,7 @@ type t =
   ; yield_on_tool : bool
   ; exit_condition : (int -> bool) option
   ; tool_selector : Tool_selector.strategy option
+  ; disclosure_level : Tool.disclosure_level option
   ; slot_id : int option
   ; on_run_complete : (bool -> unit) option
   ; tool_result_relocation : (Tool_result_store.t * Content_replacement_state.t) option
@@ -133,6 +134,7 @@ let create ~net ~model =
   ; yield_on_tool = false
   ; exit_condition = None
   ; tool_selector = None
+  ; disclosure_level = None
   ; slot_id = None
   ; on_run_complete = None
   ; tool_result_relocation = None
@@ -294,6 +296,7 @@ let with_context_injector injector b = { b with context_injector = Some injector
 let with_skill_registry reg b = { b with skill_registry = Some reg }
 let with_progressive_tools strategy b = { b with progressive_tools = Some strategy }
 let with_tool_selector strategy b = { b with tool_selector = Some strategy }
+let with_disclosure_level level b = { b with disclosure_level = Some level }
 let with_policy_channel ch b = { b with policy_channel = Some ch }
 let with_elicitation cb b = { b with elicitation = Some cb }
 let with_description desc b = { b with description = Some desc }
@@ -419,6 +422,7 @@ let build b =
     ; operator_policy = b.operator_policy
     ; policy_channel = b.policy_channel
     ; tool_selector = b.tool_selector
+    ; disclosure_level = b.disclosure_level
     ; priority = b.priority
     ; slot_id = b.slot_id
     ; on_run_complete = b.on_run_complete

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -242,6 +242,25 @@ val with_progressive_tools : Progressive_tools.disclosure_strategy -> t -> t
     @since 0.100.0 *)
 val with_tool_selector : Tool_selector.strategy -> t -> t
 
+(** Set tool schema disclosure level for this agent.
+
+    Default behavior (no call) is [Tool.Full_schema], preserving the
+    legacy contract that every surviving tool's [input_schema] is sent
+    to the LLM on every turn.
+
+    [Tool.Minimal_index] omits [input_schema] from every tool — tokens
+    are minimized but the model must compose [function_call] arguments
+    without seeing the parameter schema. Verify model compatibility
+    before using.
+
+    [Tool.Hybrid { full_names }] sends [Full_schema] for the named tools
+    and [Minimal_index] for the rest. Pairs naturally with
+    {!with_tool_selector}: pre-selected top-K can be promoted to full
+    while the remainder stays as an index.
+
+    @since 0.194.0 *)
+val with_disclosure_level : Tool.disclosure_level -> t -> t
+
 (** Set a shared policy channel for lazy tool policy propagation.
     Children that share the same channel pick up parent policy changes
     at their next turn boundary via lock-free polling.

--- a/lib/base/tool.ml
+++ b/lib/base/tool.ml
@@ -192,6 +192,29 @@ let schema_to_json tool =
     ]
 ;;
 
+type disclosure_level =
+  | Full_schema
+  | Minimal_index
+  | Hybrid of { full_names : string list }
+[@@deriving show]
+
+let schema_to_json_minimal tool =
+  `Assoc
+    [ "name", `String tool.schema.name
+    ; "description", `String tool.schema.description
+    ]
+;;
+
+let schema_to_json_with_disclosure level tool =
+  match level with
+  | Full_schema -> schema_to_json tool
+  | Minimal_index -> schema_to_json_minimal tool
+  | Hybrid { full_names } ->
+    if List.mem tool.schema.name full_names
+    then schema_to_json tool
+    else schema_to_json_minimal tool
+;;
+
 (** Wrap a tool to inject default arguments when not provided by the LLM.
     Defaults are merged into JSON object args before the handler runs. *)
 let with_defaults (defaults : (string * Yojson.Safe.t) list) (tool : t) : t =

--- a/lib/base/tool.mli
+++ b/lib/base/tool.mli
@@ -109,6 +109,44 @@ val validate_descriptor : descriptor -> (unit, string) result
 val descriptor_to_yojson : descriptor option -> Yojson.Safe.t
 val schema_to_json : t -> Yojson.Safe.t
 
+(** Disclosure depth for tool schema serialization to LLM providers.
+
+    Background: when an agent exposes many tools, sending the full
+    [input_schema] for every tool on every turn inflates prompt tokens.
+    [Tool_selector] narrows the candidate set, but [schema_to_json] still
+    emits the full schema for whatever survives selection. This type
+    lets callers choose how much of each surviving tool's schema is sent.
+
+    Risk: [Minimal_index] omits [input_schema]. Models that rely on the
+    schema to compose [function_call] arguments may fail to populate
+    parameters correctly. Use [Full_schema] (the default) unless model
+    compatibility has been verified.
+
+    @since 0.194.0 *)
+type disclosure_level =
+  | Full_schema
+    (** Emit [name], [description], and [input_schema]. Identical to
+        legacy [schema_to_json] output. *)
+  | Minimal_index
+    (** Emit [name] and [description] only. [input_schema] is omitted.
+        Used to give the model an "index" of available tools without
+        paying for full parameter schemas. *)
+  | Hybrid of { full_names : string list }
+    (** Tools whose [schema.name] is in [full_names] are rendered with
+        [Full_schema]; all others with [Minimal_index]. Useful for the
+        2-stage pattern: pre-selected top-K tools get full schemas,
+        the remainder are visible by name only. *)
+[@@deriving show]
+
+(** Serialize a tool's schema at the requested disclosure level.
+
+    [schema_to_json_with_disclosure Full_schema t] is byte-identical to
+    [schema_to_json t]. Callers that don't care about disclosure should
+    continue using [schema_to_json].
+
+    @since 0.194.0 *)
+val schema_to_json_with_disclosure : disclosure_level -> t -> Yojson.Safe.t
+
 (** Wrap a tool to inject default arguments when not provided.
     Defaults are merged into the input JSON before the handler runs. *)
 val with_defaults : (string * Yojson.Safe.t) list -> t -> t

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -110,6 +110,7 @@ let prepare_turn_for_agent agent ~turn_params =
     ~tiered_memory:agent.options.tiered_memory
     ~turn_params
     ?tool_selector:agent.options.tool_selector
+    ?disclosure_level:agent.options.disclosure_level
     ()
 ;;
 

--- a/lib/pipeline/stage_parse.ml
+++ b/lib/pipeline/stage_parse.ml
@@ -47,6 +47,7 @@ let prepare_turn_for_agent agent ~turn_params =
     ~tiered_memory:agent.options.tiered_memory
     ~turn_params
     ?tool_selector:agent.options.tool_selector
+    ?disclosure_level:agent.options.disclosure_level
     ()
 ;;
 

--- a/test/dune
+++ b/test/dune
@@ -198,6 +198,7 @@
   test_succession
   test_swiss_verdict_json
   test_tool
+  test_tool_disclosure
   test_tool_index
   test_tool_input_validation
   test_tool_middleware

--- a/test/test_tool_disclosure.ml
+++ b/test/test_tool_disclosure.ml
@@ -1,0 +1,180 @@
+(** Tests for Tool.disclosure_level and schema_to_json_with_disclosure. *)
+
+open Alcotest
+open Agent_sdk
+
+let make_tool name =
+  Tool.create
+    ~name
+    ~description:("Description of " ^ name)
+    ~parameters:
+      [ { Types.name = "query"
+        ; description = "A query string"
+        ; param_type = Types.String
+        ; required = true
+        }
+      ; { Types.name = "limit"
+        ; description = "Max results"
+        ; param_type = Types.Integer
+        ; required = false
+        }
+      ]
+    (fun _ -> Ok { Types.content = "ok" })
+;;
+
+let json_keys = function
+  | `Assoc fields -> List.map fst fields
+  | _ -> []
+;;
+
+let has_key key json = List.mem key (json_keys json)
+
+let test_full_schema_byte_identical_to_legacy () =
+  let tool = make_tool "search" in
+  let legacy = Tool.schema_to_json tool |> Yojson.Safe.to_string in
+  let via_disclosure =
+    Tool.schema_to_json_with_disclosure Tool.Full_schema tool |> Yojson.Safe.to_string
+  in
+  check string "Full_schema = legacy schema_to_json" legacy via_disclosure
+;;
+
+let test_minimal_index_omits_input_schema () =
+  let tool = make_tool "search" in
+  let json = Tool.schema_to_json_with_disclosure Tool.Minimal_index tool in
+  check bool "no input_schema key" false (has_key "input_schema" json);
+  check bool "has name key" true (has_key "name" json);
+  check bool "has description key" true (has_key "description" json)
+;;
+
+let test_minimal_index_preserves_name_and_description () =
+  let tool = make_tool "search" in
+  match Tool.schema_to_json_with_disclosure Tool.Minimal_index tool with
+  | `Assoc fields ->
+    let name = List.assoc "name" fields in
+    let desc = List.assoc "description" fields in
+    check string "name field" "\"search\"" (Yojson.Safe.to_string name);
+    check string "description field"
+      "\"Description of search\"" (Yojson.Safe.to_string desc)
+  | _ -> fail "expected JSON object"
+;;
+
+let test_hybrid_full_names_selects_full () =
+  let tool_a = make_tool "a" in
+  let tool_b = make_tool "b" in
+  let level = Tool.Hybrid { full_names = [ "a" ] } in
+  let json_a = Tool.schema_to_json_with_disclosure level tool_a in
+  let json_b = Tool.schema_to_json_with_disclosure level tool_b in
+  check bool "a has input_schema (full)" true (has_key "input_schema" json_a);
+  check bool "b lacks input_schema (minimal)" false (has_key "input_schema" json_b)
+;;
+
+let test_hybrid_empty_full_names_acts_as_minimal () =
+  let tool = make_tool "search" in
+  let hybrid_json =
+    Tool.schema_to_json_with_disclosure (Tool.Hybrid { full_names = [] }) tool
+    |> Yojson.Safe.to_string
+  in
+  let minimal_json =
+    Tool.schema_to_json_with_disclosure Tool.Minimal_index tool
+    |> Yojson.Safe.to_string
+  in
+  check string "Hybrid [] = Minimal_index" minimal_json hybrid_json
+;;
+
+let test_hybrid_all_full_names_acts_as_full () =
+  let tool = make_tool "search" in
+  let hybrid_json =
+    Tool.schema_to_json_with_disclosure
+      (Tool.Hybrid { full_names = [ "search" ] })
+      tool
+    |> Yojson.Safe.to_string
+  in
+  let full_json =
+    Tool.schema_to_json_with_disclosure Tool.Full_schema tool |> Yojson.Safe.to_string
+  in
+  check string "Hybrid [tool_name] = Full_schema" full_json hybrid_json
+;;
+
+let test_byte_size_monotonic_full_geq_minimal () =
+  let tool = make_tool "search" in
+  let full_len =
+    String.length
+      (Yojson.Safe.to_string (Tool.schema_to_json_with_disclosure Tool.Full_schema tool))
+  in
+  let min_len =
+    String.length
+      (Yojson.Safe.to_string
+         (Tool.schema_to_json_with_disclosure Tool.Minimal_index tool))
+  in
+  check bool "Full size >= Minimal size" true (full_len >= min_len);
+  check bool "Minimal is strictly smaller (params exist)" true (min_len < full_len)
+;;
+
+let test_hybrid_size_bounded_by_full_and_minimal () =
+  let tool = make_tool "search" in
+  let full_len =
+    String.length
+      (Yojson.Safe.to_string (Tool.schema_to_json_with_disclosure Tool.Full_schema tool))
+  in
+  let min_len =
+    String.length
+      (Yojson.Safe.to_string
+         (Tool.schema_to_json_with_disclosure Tool.Minimal_index tool))
+  in
+  let hybrid_in_len =
+    String.length
+      (Yojson.Safe.to_string
+         (Tool.schema_to_json_with_disclosure
+            (Tool.Hybrid { full_names = [ "search" ] })
+            tool))
+  in
+  let hybrid_out_len =
+    String.length
+      (Yojson.Safe.to_string
+         (Tool.schema_to_json_with_disclosure
+            (Tool.Hybrid { full_names = [ "other" ] })
+            tool))
+  in
+  check int "Hybrid included = Full size" full_len hybrid_in_len;
+  check int "Hybrid excluded = Minimal size" min_len hybrid_out_len
+;;
+
+let () =
+  run
+    "Tool.disclosure"
+    [ ( "schema_to_json_with_disclosure"
+      , [ test_case
+            "Full_schema byte-identical to legacy schema_to_json"
+            `Quick
+            test_full_schema_byte_identical_to_legacy
+        ; test_case
+            "Minimal_index omits input_schema"
+            `Quick
+            test_minimal_index_omits_input_schema
+        ; test_case
+            "Minimal_index preserves name and description"
+            `Quick
+            test_minimal_index_preserves_name_and_description
+        ; test_case
+            "Hybrid full_names selects which tools get full"
+            `Quick
+            test_hybrid_full_names_selects_full
+        ; test_case
+            "Hybrid full_names=[] degenerates to Minimal_index"
+            `Quick
+            test_hybrid_empty_full_names_acts_as_minimal
+        ; test_case
+            "Hybrid full_names covering all tools degenerates to Full_schema"
+            `Quick
+            test_hybrid_all_full_names_acts_as_full
+        ; test_case
+            "Byte size: Full > Minimal when params exist"
+            `Quick
+            test_byte_size_monotonic_full_geq_minimal
+        ; test_case
+            "Hybrid byte size bounded by Full and Minimal per tool"
+            `Quick
+            test_hybrid_size_bounded_by_full_and_minimal
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목표

39+ tool을 노출하는 keeper-style 에이전트의 매 turn tool-schema 토큰 부담(약 25–30k tok)을 줄이기 위해, OAS에 `Tool.disclosure_level`을 도입하여 caller가 schema 직렬화 깊이를 선택할 수 있게 한다. **기본값 `Full_schema`는 wire byte-identical 보존** (no-op safe merge). 본 PR은 OAS 인프라만 추가하고, masc-mcp keeper 활성화는 별도 후속 PR (RFC 필요).

배경: OAS의 `Tool_selector`(0.100.0~)는 이미 후보 narrowing 단계(이름 기반)를 구현 중. 그러나 selected 된 top-K가 LLM에 갈 때 schema는 *full*로 직렬화된다 (`agent_turn.ml:159`). 2-stage routing이 **schema 단계에서 절반만 닫혀 있는** 상태. Hermes 류 lazy-disclosure 패턴을 schema-render 단계에 동등하게 적용한다.

## 변경 파일

| 파일 | 변경 |
|---|---|
| `lib/base/tool.ml` / `.mli` | `disclosure_level` 타입(closed sum) + `schema_to_json_with_disclosure` 추가 |
| `lib/agent/agent_turn.ml` / `.mli` | `prepare_tools` / `prepare_turn`에 `?disclosure_level` 추가, line 159 분기 |
| `lib/agent/agent_types.ml` / `.mli` | `options.disclosure_level : Tool.disclosure_level option` |
| `lib/agent/agent.mli` | options 필드 export |
| `lib/agent/builder.ml` / `.mli` | `with_disclosure_level` 빌더 API |
| `lib/pipeline/pipeline_stage_prepare.ml`, `lib/pipeline/stage_parse.ml` | options → prepare_turn 전파 |
| `test/test_tool_disclosure.ml` (신규) | 8 alcotest 케이스 |
| `test/dune` | 새 테스트 등록 |

closed sum type + exhaustive match (RFC-0042 / CLAUDE.md §AI 코드 생성 안티패턴 #4 정렬).

## 로컬 검증

```
$ dune build --root . lib/
EXIT=0
$ dune build --root . test/test_tool_disclosure.exe
EXIT=0
$ ./_build/default/test/test_tool_disclosure.exe
[OK]  schema_to_json_with_disclosure  0   Full_schema byte-identical to legacy schema_to_json
[OK]  schema_to_json_with_disclosure  1   Minimal_index omits input_schema
[OK]  schema_to_json_with_disclosure  2   Minimal_index preserves name and description
[OK]  schema_to_json_with_disclosure  3   Hybrid full_names selects which tools get full
[OK]  schema_to_json_with_disclosure  4   Hybrid full_names=[] degenerates to Minimal_index
[OK]  schema_to_json_with_disclosure  5   Hybrid full_names covering all tools degenerates to Full_schema
[OK]  schema_to_json_with_disclosure  6   Byte size: Full > Minimal when params exist
[OK]  schema_to_json_with_disclosure  7   Hybrid byte size bounded by Full and Minimal per tool
Test Successful in 0.001s. 8 tests run.
```

핵심 안전 보장: 케이스 #0이 `Full_schema` 출력이 기존 `schema_to_json`과 **byte-identical**임을 증명. 따라서 새 함수를 호출하지 않는 모든 caller는 wire body 변화 0bit.

## 미검증 / Out of Scope

- **Full test suite**: 로컬 `test/dune` 전체 빌드는 다수 `.mli` race 에러를 보임 (병렬 컴파일 race). main에도 동일하게 존재할 가능성이 높고 본 PR 변경과 무관 — CI 클린 환경 결과 대기.
- **실측 토큰 절감**: 본 PR은 인프라만. 후속 masc-mcp 활성화 PR에서 `Keeper_agent_prompt_metrics`의 `display_total_tokens` Before/After 측정 예정.
- **모델 호환성**: `Minimal_index`로 보냈을 때 모델이 `input_schema` 없이 `tool_use` 인자를 채우는지는 caller 책임. `.mli` docstring에 명시. 본 PR 머지로는 default `Full_schema`라 영향 없음.

## Risks

| Risk | Severity | Mitigation |
|---|---|---|
| 모델이 minimal schema로 args 생성 실패 | HIGH | default=Full_schema 유지로 본 PR 무영향. 활성화 PR에서 카나리 1명 + tool_call error 시 fallback 로직 (별도 RFC). |
| downstream consumer 빌드 깨짐 | LOW | 모든 새 파라미터 `optional` + default `Full_schema`. 시그니처 변경 없는 추가만. |
| `Hybrid.full_names`에 selected에 없는 이름 | LOW | 단순 `List.mem` 매치, mismatch 시 silent ignore (Minimal로 강등). 의도된 동작. |

## RFC

본 PR은 OAS-only, `lib/keeper/`·credential·operator 등 RFC 트리거 subsystem 무변경. `~/me/scripts/pr-rfc-check.sh` 적용 대상 아님.

후속 masc-mcp 활성화 PR(`lib/keeper/keeper_run_tools.ml` 수정)은 RFC 필수 — 본 PR 머지 직후 `docs/rfc/RFC-OAS-XXX-keeper-tool-disclosure.md` 작성 예정.

## 후속 작업

1. RFC 작성 → masc-mcp keeper 1명 카나리 활성화 PR (`disclosure_level = Hybrid { full_names = top_k_selected }`)
2. `Keeper_agent_prompt_metrics`로 토큰 절감 실측 (목표: schema bucket -30%+)
3. tool_call success rate regression 모니터 (1주 telemetry)
4. A6000×64k×4 keeper 부하 테스트