### PR TITLE
feat(agent): add disclosure_resolver for per-turn adaptive disclosure

### DIFF
--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -52,6 +52,7 @@ type options = Agent_types.options =
   ; policy_channel : Policy_channel.t option
   ; tool_selector : Tool_selector.strategy option
   ; disclosure_level : Tool.disclosure_level option
+  ; disclosure_resolver : (Types.tool_result list -> Tool.disclosure_level option) option
   ; priority : Llm_provider.Request_priority.t option
   ; slot_id : int option
   ; on_run_complete : (bool -> unit) option

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -41,6 +41,18 @@ type options =
   ; policy_channel : Policy_channel.t option
   ; tool_selector : Tool_selector.strategy option
   ; disclosure_level : Tool.disclosure_level option
+  ; disclosure_resolver : (Types.tool_result list -> Tool.disclosure_level option) option
+    (** Optional resolver that decides the disclosure level for the
+        next turn based on the most recent tool results.  When
+        [Some f], it is called before each turn with the latest
+        [Types.tool_result] list extracted from message history.
+        - [f results = Some override] uses [override] for this turn.
+        - [f results = None] falls back to the static
+          [disclosure_level] field.
+        When [None], [disclosure_level] is used as-is.
+        Caller owns the policy (TTL, sticky promotion, session scope);
+        OAS only provides the mechanism.
+        @since 0.195.0 *)
   ; priority : Llm_provider.Request_priority.t option
   ; slot_id : int option
   ; on_run_complete : (bool -> unit) option
@@ -153,6 +165,7 @@ let default_options =
   ; policy_channel = None
   ; tool_selector = None
   ; disclosure_level = None
+  ; disclosure_resolver = None
   ; priority = None
   ; slot_id = None
   ; on_run_complete = None

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -105,6 +105,15 @@ type options =
         [input_schema] and may break models that need it to compose
         arguments.
         @since 0.194.0 *)
+  ; disclosure_resolver : (Types.tool_result list -> Tool.disclosure_level option) option
+    (** Optional resolver that decides the disclosure level for the
+        next turn based on the most recent tool results. When
+        [Some f], it is called with the latest [Types.tool_result] list
+        extracted from message history. [Some override] uses [override]
+        this turn; [None] falls back to the static [disclosure_level].
+        Caller owns the policy (TTL, sticky promotion, session scope);
+        OAS provides the mechanism only.
+        @since 0.195.0 *)
   ; priority : Llm_provider.Request_priority.t option
     (** Scheduling priority for LLM requests at the options level.
         When [Some], overrides [agent_config.priority] on the resume path.

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -64,6 +64,7 @@ type t =
   ; exit_condition : (int -> bool) option
   ; tool_selector : Tool_selector.strategy option
   ; disclosure_level : Tool.disclosure_level option
+  ; disclosure_resolver : (Types.tool_result list -> Tool.disclosure_level option) option
   ; slot_id : int option
   ; on_run_complete : (bool -> unit) option
   ; tool_result_relocation : (Tool_result_store.t * Content_replacement_state.t) option
@@ -135,6 +136,7 @@ let create ~net ~model =
   ; exit_condition = None
   ; tool_selector = None
   ; disclosure_level = None
+  ; disclosure_resolver = None
   ; slot_id = None
   ; on_run_complete = None
   ; tool_result_relocation = None
@@ -297,6 +299,7 @@ let with_skill_registry reg b = { b with skill_registry = Some reg }
 let with_progressive_tools strategy b = { b with progressive_tools = Some strategy }
 let with_tool_selector strategy b = { b with tool_selector = Some strategy }
 let with_disclosure_level level b = { b with disclosure_level = Some level }
+let with_disclosure_resolver f b = { b with disclosure_resolver = Some f }
 let with_policy_channel ch b = { b with policy_channel = Some ch }
 let with_elicitation cb b = { b with elicitation = Some cb }
 let with_description desc b = { b with description = Some desc }
@@ -423,6 +426,7 @@ let build b =
     ; policy_channel = b.policy_channel
     ; tool_selector = b.tool_selector
     ; disclosure_level = b.disclosure_level
+    ; disclosure_resolver = b.disclosure_resolver
     ; priority = b.priority
     ; slot_id = b.slot_id
     ; on_run_complete = b.on_run_complete

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -261,6 +261,37 @@ val with_tool_selector : Tool_selector.strategy -> t -> t
     @since 0.194.0 *)
 val with_disclosure_level : Tool.disclosure_level -> t -> t
 
+(** Install a per-turn resolver that adapts disclosure based on the
+    most recent tool results.
+
+    The resolver receives the latest [Types.tool_result] list extracted
+    from message history (left-to-right; empty list if no tool results
+    seen yet). It returns:
+    - [Some override]: use [override] for this turn only.
+    - [None]: fall through to the static [with_disclosure_level] value
+      (or [Tool.Full_schema] if none was set).
+
+    Typical pattern — "demote to Full_schema when the previous turn's
+    tool call failed validation":
+
+    {[
+      let resolver (results : Types.tool_result list) =
+        let has_error = List.exists Result.is_error results in
+        if has_error then Some Tool.Full_schema else None
+      in
+      Builder.with_disclosure_resolver resolver builder
+    ]}
+
+    Caller owns the policy (TTL, sticky promotion, session scope, etc.);
+    OAS only provides the mechanism. Combine freely with
+    {!with_disclosure_level} and {!with_tool_selector}.
+
+    @since 0.195.0 *)
+val with_disclosure_resolver
+  :  (Types.tool_result list -> Tool.disclosure_level option)
+  -> t
+  -> t
+
 (** Set a shared policy channel for lazy tool policy propagation.
     Children that share the same channel pick up parent policy changes
     at their next turn boundary via lock-free polling.

--- a/lib/agent/disclosure_resolver.ml
+++ b/lib/agent/disclosure_resolver.ml
@@ -1,0 +1,26 @@
+(** Per-turn disclosure level resolution.
+
+    Combines an optional [resolver] callback with a [static] fallback
+    to produce the effective {!Tool.disclosure_level} for a turn.
+
+    Precedence:
+    - [resolver = None]: return [static] as-is.
+    - [resolver = Some f]: call [f last_results];
+      - [Some override]: return [Some override].
+      - [None]: return [static].
+
+    @since 0.195.0 *)
+
+let resolve
+      ~(resolver : (Types.tool_result list -> Tool.disclosure_level option) option)
+      ~(static : Tool.disclosure_level option)
+      ~(last_results : Types.tool_result list)
+  : Tool.disclosure_level option
+  =
+  match resolver with
+  | None -> static
+  | Some f ->
+    (match f last_results with
+     | Some _ as override -> override
+     | None -> static)
+;;

--- a/lib/agent/disclosure_resolver.mli
+++ b/lib/agent/disclosure_resolver.mli
@@ -1,0 +1,21 @@
+(** Per-turn {!Tool.disclosure_level} resolution: combine an optional
+    callback that inspects the most recent tool results with a static
+    fallback.
+
+    @since 0.195.0 *)
+
+(** [resolve ~resolver ~static ~last_results] returns the effective
+    disclosure level.
+
+    - [resolver = None]: return [static].
+    - [resolver = Some f]: when [f last_results = Some override],
+      return [Some override]; otherwise return [static].
+
+    The function is pure: it does not raise, does not log, and is
+    deterministic in its inputs. Callers that need TTL, sticky
+    promotion, or session state should encode that in [resolver]. *)
+val resolve
+  :  resolver:(Types.tool_result list -> Tool.disclosure_level option) option
+  -> static:Tool.disclosure_level option
+  -> last_results:Types.tool_result list
+  -> Tool.disclosure_level option

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -96,6 +96,7 @@ module Agent_checkpoint = Agent_checkpoint
 module Agent_turn_budget = Agent_turn_budget
 module Agent = Agent
 module Builder = Builder
+module Disclosure_resolver = Disclosure_resolver
 module Agent_card = Agent_card
 module Agent_registry = Agent_registry
 module Agent_config = Agent_config

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -69,6 +69,7 @@ module Agent_checkpoint = Agent_checkpoint
 module Agent_turn_budget = Agent_turn_budget
 module Agent = Agent
 module Builder = Builder
+module Disclosure_resolver = Disclosure_resolver
 module Agent_card = Agent_card
 module Agent_registry = Agent_registry
 module Agent_config = Agent_config

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -98,6 +98,13 @@ let last_tool_results_from messages =
     messages
 ;;
 
+let resolve_disclosure_level agent =
+  Disclosure_resolver.resolve
+    ~resolver:agent.options.disclosure_resolver
+    ~static:agent.options.disclosure_level
+    ~last_results:(last_tool_results_from agent.state.messages)
+;;
+
 let prepare_turn_for_agent agent ~turn_params =
   Agent_turn.prepare_turn
     ~config:agent.state.config
@@ -110,7 +117,7 @@ let prepare_turn_for_agent agent ~turn_params =
     ~tiered_memory:agent.options.tiered_memory
     ~turn_params
     ?tool_selector:agent.options.tool_selector
-    ?disclosure_level:agent.options.disclosure_level
+    ?disclosure_level:(resolve_disclosure_level agent)
     ()
 ;;
 

--- a/lib/pipeline/stage_parse.ml
+++ b/lib/pipeline/stage_parse.ml
@@ -31,6 +31,13 @@ let last_tool_results_from messages =
     messages
 ;;
 
+let resolve_disclosure_level agent =
+  Disclosure_resolver.resolve
+    ~resolver:agent.options.disclosure_resolver
+    ~static:agent.options.disclosure_level
+    ~last_results:(last_tool_results_from agent.state.messages)
+;;
+
 (** Prepare the turn using current [agent.state.messages] and the given
     [turn_params].  Centralises the [Agent_turn.prepare_turn] parameter
     list to avoid duplication between [stage_parse] and post-compaction
@@ -47,7 +54,7 @@ let prepare_turn_for_agent agent ~turn_params =
     ~tiered_memory:agent.options.tiered_memory
     ~turn_params
     ?tool_selector:agent.options.tool_selector
-    ?disclosure_level:agent.options.disclosure_level
+    ?disclosure_level:(resolve_disclosure_level agent)
     ()
 ;;
 

--- a/test/dune
+++ b/test/dune
@@ -76,6 +76,7 @@
   test_deep_coverage
   test_defaults
   test_defaults_unit
+  test_disclosure_resolver
   test_discovery
   test_durable
   test_durable_event

--- a/test/test_disclosure_resolver.ml
+++ b/test/test_disclosure_resolver.ml
@@ -1,0 +1,177 @@
+(** Tests for Disclosure_resolver.resolve.
+
+    The helper is pure: it picks between a resolver callback's output
+    and a static fallback. Tests pin all four combinations of the
+    [resolver / static] cross-product plus the typical "fallback to
+    Full_schema when previous turn had errors" caller pattern. *)
+
+open Alcotest
+open Agent_sdk
+
+let ok_result content : Types.tool_result = Ok { Types.content }
+
+let err_result message : Types.tool_result =
+  Error
+    { Types.message
+    ; recoverable = true
+    ; error_class = Some Types.Deterministic
+    }
+;;
+
+let test_no_resolver_returns_static () =
+  let actual =
+    Disclosure_resolver.resolve
+      ~resolver:None
+      ~static:(Some Tool.Minimal_index)
+      ~last_results:[]
+  in
+  check bool "static passes through" true (actual = Some Tool.Minimal_index)
+;;
+
+let test_no_resolver_no_static_returns_none () =
+  let actual =
+    Disclosure_resolver.resolve ~resolver:None ~static:None ~last_results:[]
+  in
+  check bool "None when neither set" true (actual = None)
+;;
+
+let test_resolver_some_override_wins_over_static () =
+  let resolver _ = Some Tool.Full_schema in
+  let actual =
+    Disclosure_resolver.resolve
+      ~resolver:(Some resolver)
+      ~static:(Some Tool.Minimal_index)
+      ~last_results:[]
+  in
+  check bool "resolver override beats static" true (actual = Some Tool.Full_schema)
+;;
+
+let test_resolver_none_falls_through_to_static () =
+  let resolver _ = None in
+  let actual =
+    Disclosure_resolver.resolve
+      ~resolver:(Some resolver)
+      ~static:(Some Tool.Minimal_index)
+      ~last_results:[ ok_result "x" ]
+  in
+  check bool "resolver=None uses static" true (actual = Some Tool.Minimal_index)
+;;
+
+let test_resolver_none_no_static_returns_none () =
+  let resolver _ = None in
+  let actual =
+    Disclosure_resolver.resolve
+      ~resolver:(Some resolver)
+      ~static:None
+      ~last_results:[]
+  in
+  check bool "double None means None" true (actual = None)
+;;
+
+let test_resolver_receives_last_results_verbatim () =
+  let seen = ref [] in
+  let resolver results =
+    seen := results;
+    None
+  in
+  let input = [ ok_result "a"; err_result "bad"; ok_result "c" ] in
+  let _ =
+    Disclosure_resolver.resolve
+      ~resolver:(Some resolver)
+      ~static:None
+      ~last_results:input
+  in
+  check int "resolver got all 3 results" 3 (List.length !seen);
+  check bool "results passed by value" true (!seen = input)
+;;
+
+(* ── Caller pattern: demote to Full_schema on previous-turn error ── *)
+
+let demote_on_error_resolver (results : Types.tool_result list) =
+  if List.exists Result.is_error results then Some Tool.Full_schema else None
+;;
+
+let test_caller_pattern_no_errors_falls_through () =
+  let actual =
+    Disclosure_resolver.resolve
+      ~resolver:(Some demote_on_error_resolver)
+      ~static:(Some Tool.Minimal_index)
+      ~last_results:[ ok_result "a"; ok_result "b" ]
+  in
+  check
+    bool
+    "all-ok results: stay on Minimal_index"
+    true
+    (actual = Some Tool.Minimal_index)
+;;
+
+let test_caller_pattern_with_error_demotes () =
+  let actual =
+    Disclosure_resolver.resolve
+      ~resolver:(Some demote_on_error_resolver)
+      ~static:(Some Tool.Minimal_index)
+      ~last_results:[ ok_result "a"; err_result "schema bad" ]
+  in
+  check
+    bool
+    "error present: demote to Full_schema"
+    true
+    (actual = Some Tool.Full_schema)
+;;
+
+let test_caller_pattern_empty_results_no_demote () =
+  let actual =
+    Disclosure_resolver.resolve
+      ~resolver:(Some demote_on_error_resolver)
+      ~static:(Some Tool.Minimal_index)
+      ~last_results:[]
+  in
+  check
+    bool
+    "first turn (empty results): no demote"
+    true
+    (actual = Some Tool.Minimal_index)
+;;
+
+let () =
+  run
+    "Disclosure_resolver"
+    [ ( "resolve"
+      , [ test_case "no resolver returns static" `Quick test_no_resolver_returns_static
+        ; test_case
+            "no resolver and no static returns None"
+            `Quick
+            test_no_resolver_no_static_returns_none
+        ; test_case
+            "resolver Some override beats static"
+            `Quick
+            test_resolver_some_override_wins_over_static
+        ; test_case
+            "resolver None falls through to static"
+            `Quick
+            test_resolver_none_falls_through_to_static
+        ; test_case
+            "resolver None and static None returns None"
+            `Quick
+            test_resolver_none_no_static_returns_none
+        ; test_case
+            "resolver receives last_results verbatim"
+            `Quick
+            test_resolver_receives_last_results_verbatim
+        ] )
+    ; ( "caller_pattern_demote_on_error"
+      , [ test_case
+            "all-ok results: keep static"
+            `Quick
+            test_caller_pattern_no_errors_falls_through
+        ; test_case
+            "error in results: override with Full_schema"
+            `Quick
+            test_caller_pattern_with_error_demotes
+        ; test_case
+            "empty results (first turn): keep static"
+            `Quick
+            test_caller_pattern_empty_results_no_demote
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목표

PR #1508로 머지된 정적 `Tool.disclosure_level`에 *per-turn adaptive* 보강. RFC-OAS-013 (PR #1510)의 카나리 안전망(§2.3, §7 step 1) 구현. 활성화 PR이 들어가기 *전*에 OAS 측에 fallback hook이 존재해야, 카나리 keeper가 Minimal/Hybrid 직렬화 때문에 tool_call이 깨지면 자동 강등할 수 있다.

**Mechanism vs Policy 분리**: OAS는 *언제 호출되는지*(prepare_turn 직전, last_tool_results 전달)만 정의. *언제 강등하는지*(TTL, sticky promotion, session scope, BPE-token cost)는 caller(masc-mcp keeper)가 hook 안에서 결정. 이게 RFC §2.3 의사코드의 정정된 형태.

## 핵심 설계

- 새 모듈 `lib/agent/disclosure_resolver.{ml,mli}` — 단일 pure 함수
  ```ocaml
  val resolve
    : resolver:(Types.tool_result list -> Tool.disclosure_level option) option
    -> static:Tool.disclosure_level option
    -> last_results:Types.tool_result list
    -> Tool.disclosure_level option
  ```
- `agent_types.options.disclosure_resolver` 신규 field (default `None`)
- `Builder.with_disclosure_resolver` 신규 API
- 두 pipeline 사이트(`stage_parse.ml`, `pipeline_stage_prepare.ml`)가 helper 호출 — 인라인 로직 중복 0

**Precedence**:
1. `resolver = None` → static 통과
2. `resolver = Some f`, `f r = Some x` → x 사용
3. `resolver = Some f`, `f r = None` → static fallback

## 변경 파일

| 파일 | 변경 |
|---|---|
| `lib/agent/disclosure_resolver.{ml,mli}` (신규) | 1-function pure helper |
| `lib/agent/agent_types.{ml,mli}` | `disclosure_resolver` field |
| `lib/agent/agent.mli` | options field export |
| `lib/agent/builder.{ml,mli}` | `with_disclosure_resolver` API |
| `lib/agent_sdk.{ml,mli}` | `module Disclosure_resolver` 노출 |
| `lib/pipeline/stage_parse.ml`, `lib/pipeline/pipeline_stage_prepare.ml` | helper 호출 |
| `test/test_disclosure_resolver.ml` (신규) | 9 alcotest 케이스 |
| `test/dune` | 새 test 등록 |

## 로컬 검증

```
$ dune build --root . lib/
EXIT=0
$ dune build --root . test/test_disclosure_resolver.exe
EXIT=0
$ ./_build/default/test/test_disclosure_resolver.exe
[OK]  resolve                          0   no resolver returns static
[OK]  resolve                          1   no resolver and no static returns None
[OK]  resolve                          2   resolver Some override beats static
[OK]  resolve                          3   resolver None falls through to static
[OK]  resolve                          4   resolver None and static None returns None
[OK]  resolve                          5   resolver receives last_results verbatim
[OK]  caller_pattern_demote_on_error   0   all-ok results: keep static
[OK]  caller_pattern_demote_on_error   1   error in results: override with Full_schema
[OK]  caller_pattern_demote_on_error   2   empty results (first turn): keep static
Test Successful in 0.001s. 9 tests run.
```

핵심 안전 보장: `disclosure_resolver = None` (default)이면 PR #1508 머지 후 main과 byte-identical. 새 helper는 caller가 명시적으로 builder API를 부르기 전까지 evaluation path에 들어가지 않는다.

## 미검증 / Out of Scope

- **Integration with `heal_tool_call`**: OAS의 self-healing retry loop(`tool_middleware.ml:72`)는 turn 단위 retry를 이미 처리. 본 PR은 cross-turn 강등만. 둘이 같이 작동하는 통합 시나리오는 masc-mcp 카나리 PR에서 검증.
- **Tool error 분류 정확도**: caller가 `last_tool_results`에서 `Result.is_error` 또는 `error_class = Deterministic` 등 어떤 신호를 쓸지는 정책. 본 PR은 mechanism만.
- **실측 token 절감**: 본 PR은 인프라. masc-mcp P0 카나리에서 측정.

## RFC

- RFC-OAS-013 §2.3 fallback design의 정정된 mechanism-only 구현. RFC PR #1510 body에 cross-reference.
- 본 PR는 RFC와 *독립적으로* 머지 가능 — default off이므로 RFC 머지 전에도 안전.

## Risks

| Risk | Severity | Mitigation |
|---|---|---|
| resolver callback이 매 turn 호출되어 hot path 지연 | LOW | callback은 caller 코드, 보통 O(\|last_results\|). last_tool_results_from은 이미 stage_parse가 매 turn 호출 중. |
| resolver가 예외를 throw하면 prepare_turn 실패 | MEDIUM | 본 PR은 try/catch 추가하지 않음 — exception transparency 유지. caller 책임. mli에 명시. |
| Hybrid + resolver 조합 시 prefix cache invalidation | MEDIUM | resolver가 매 turn 다른 disclosure_level 반환하면 cache miss. caller 정책으로 안정성 확보 (e.g., sticky for N turns). |

## Cross-references

- PR #1508 (merged f48ccec3) — `Tool.disclosure_level` infrastructure
- PR #1510 (Draft) — RFC-OAS-013 활성화 계획
- `lib/tool_middleware.ml:72` `heal_tool_call` — 기존 in-turn self-healing
- 후속: masc-mcp `lib/keeper/keeper_run_tools.ml` P0 카나리 PR — resolver를 사용해 sticky promote 정책 구현