### PR TITLE
feat(capability_manifest): add set_global / clear_global runtime override (RFC-0058 Phase 2)

### DIFF
--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -201,16 +201,28 @@ let lookup (t : t) model_id =
     t
 ;;
 
-(* ── Global lazy manifest ───────────────────────────────── *)
+(* ── Global manifest ───────────────────────────────────────
+   Two-tier source: runtime override (set by host application via
+   [set_global]) takes precedence over the env-var-loaded lazy
+   manifest. The env path stays as the file-based default for
+   standalone OAS deployments without an embedding host. *)
 
-let global_manifest : t option Lazy.t =
+let env_loaded_manifest : t option Lazy.t =
   lazy
     (match Cli_common_env.get "OAS_CAPABILITY_MANIFEST" with
      | None -> None
      | Some path -> load_runtime_file path)
 ;;
 
-let global () = Lazy.force global_manifest
+let runtime_override : t option ref = ref None
+let set_global m = runtime_override := Some m
+let clear_global () = runtime_override := None
+
+let global () =
+  match !runtime_override with
+  | Some _ as o -> o
+  | None -> Lazy.force env_loaded_manifest
+;;
 
 (* ── Inline tests ───────────────────────────────────────── *)
 
@@ -309,4 +321,43 @@ let%test "of_json: unknown fields are ignored (forward-compat)" =
   match of_json json with
   | Ok [ entry ] -> entry.id_prefix = "m"
   | _ -> false
+;;
+
+let%test "set_global / clear_global: runtime override roundtrips" =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"runtime-override-token-9fX","base":"openai_chat"}]}|}
+  in
+  let manifest = of_json json |> Result.get_ok in
+  set_global manifest;
+  let observed_after_set =
+    match global () with
+    | Some entries ->
+      List.exists (fun e -> e.id_prefix = "runtime-override-token-9fX") entries
+    | None -> false
+  in
+  clear_global ();
+  (* After [clear_global], the override is gone. Whether [global ()] returns
+     [None] or some env-loaded value depends on the test runner's environment;
+     we only assert the override entry no longer surfaces. *)
+  let observed_after_clear =
+    match global () with
+    | Some entries ->
+      not
+        (List.exists (fun e -> e.id_prefix = "runtime-override-token-9fX") entries)
+    | None -> true
+  in
+  observed_after_set && observed_after_clear
+;;
+
+let%test "set_global takes precedence regardless of env var presence" =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"override-precedence-test"}]}|}
+  in
+  let manifest = of_json json |> Result.get_ok in
+  set_global manifest;
+  let entry = lookup (Option.get (global ())) "override-precedence-test-v2" in
+  clear_global ();
+  Option.is_some entry
 ;;

--- a/lib/llm_provider/capability_manifest.mli
+++ b/lib/llm_provider/capability_manifest.mli
@@ -96,9 +96,32 @@ val load_runtime_file : string -> t option
     entry matches. *)
 val lookup : t -> string -> entry option
 
-(** The globally loaded manifest (lazy, loaded once on first use).
+(** The currently active manifest.
 
-    Reads [OAS_CAPABILITY_MANIFEST] env var on first call.  Returns
-    [None] when the variable is unset or when the file cannot be
-    loaded (a warning is emitted via {!Diag} in that case). *)
+    Resolution order (highest priority first):
+    + 1. Runtime override set by {!set_global} — embedding hosts
+        (e.g. masc-mcp loading its declarative cascade.toml) install
+        a programmatic manifest at boot.
+    + 2. [OAS_CAPABILITY_MANIFEST] env var pointing at a JSON file
+        (loaded lazily on first call, once per process).
+
+    Returns [None] when neither source supplies a manifest. *)
 val global : unit -> t option
+
+(** [set_global m] installs [m] as the runtime-override manifest,
+    shadowing any [OAS_CAPABILITY_MANIFEST]-loaded entries until
+    {!clear_global} is called.
+
+    Idempotent — calling twice replaces the override with the latest
+    value. Intended for hosts that own the model catalog (e.g.
+    masc-mcp's [cascade.toml]) and want OAS to consume the same
+    capability data without round-tripping through a JSON file.
+
+    @since 0.194.0 *)
+val set_global : t -> unit
+
+(** [clear_global ()] removes the runtime override and lets
+    {!global} fall back to the env-var-loaded manifest (or [None]).
+
+    @since 0.194.0 *)
+val clear_global : unit -> unit


### PR DESCRIPTION
## RFC-0058 Phase 2 — OAS-side change

Adds a runtime-override layer to \`Capability_manifest.global ()\` so embedding hosts (masc-mcp etc.) can install a programmatic manifest at boot without round-tripping through a JSON file.

\`★ Insight ─────────────────────────────────────\`

**Additive only.** Callers that don't touch \`set_global\` see zero behavior change — the env path (\`OAS_CAPABILITY_MANIFEST\`) remains the sole source until something calls \`set_global\`. Lazy semantics of the env source are preserved.

## API delta (\`lib/llm_provider/capability_manifest.mli\`)

\`\`\`ocaml
val set_global : t -> unit
val clear_global : unit -> unit
\`\`\`

## Resolution order (highest priority first)

1. **Runtime override** set by \`set_global\` — host application controls the manifest contents
2. **\`OAS_CAPABILITY_MANIFEST\` env var** — file-based default for standalone OAS deployments
3. **\`None\`** — no model-specific overrides; \`for_model_id\` falls through to the built-in 27-branch static table

## Motivation

OAS's existing capability manifest accepts a JSON file via env var. masc-mcp's Plan v1 proposed adding a parallel \`set_external_resolver\` callback to \`Capabilities\`, but that would duplicate the data path. v2 pivot: reuse the existing \`Capability_manifest.entry\` type (24 fields, mature parser, lookup, lazy-load) and just add a programmatic install point.

Downstream PR (masc-mcp): \`Cascade_capabilities_bridge\` will translate \`cascade_model_capabilities\` records → \`Capability_manifest.entry\` records and call \`set_global manifest\` once at keeper boot, after \`cascade.toml\` load and before the first LLM call.

## Tests

Two new \`let%test\` cases inline in \`capability_manifest.ml\`:

1. \`set_global / clear_global: runtime override roundtrips\` — install, observe, clear, verify gone
2. \`set_global takes precedence regardless of env var presence\` — \`lookup\` on the runtime override succeeds even when env file is loaded

## Out of scope

- masc-mcp bridge module + boot wiring (Phase 4 follow-up in masc-mcp repo)
- Removing the 27-branch static fallback in \`capabilities.ml:for_model_id_static\` (defer until masc-mcp side provides 100% coverage via \`set_global\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)