### PR TITLE
fix: harden exhaustive matches on closed variants (capabilities/streaming/agent)

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -628,10 +628,15 @@ let execute_tools
   =
   let tool_use_blocks =
     List.filter_map
-      (fun block ->
+      (fun (block : Types.content_block) ->
          match block with
          | ToolUse { id; name; input } -> Some (id, name, input)
-         | _ -> None)
+         | Text _ | Thinking _ | RedactedThinking _ | ToolResult _
+         | Image _ | Document _ | Audio _ ->
+           (* Only [ToolUse] blocks dispatch tools. Enumerated explicitly
+              so a new [content_block] variant cannot inherit "no tool"
+              behavior without review. *)
+           None)
       tool_uses
   in
   let scheduled = List.mapi (schedule_tool_use ~tools) tool_use_blocks in

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -18,10 +18,16 @@ type tool_call_fingerprint =
 
 let compute_fingerprints tool_uses =
   List.filter_map
-    (function
+    (fun (block : content_block) ->
+      match block with
       | ToolUse { name; input; _ } ->
         Some { fp_name = name; fp_input = Yojson.Safe.to_string input }
-      | _ -> None)
+      | Text _ | Thinking _ | RedactedThinking _ | ToolResult _
+      | Image _ | Document _ | Audio _ ->
+        (* Non-tool blocks do not participate in tool-call fingerprinting.
+           Enumerated so a new [content_block] variant forces review of
+           whether it should influence idle detection. *)
+        None)
     tool_uses
 ;;
 
@@ -78,9 +84,15 @@ let extract_last_user_text (messages : message list) : string =
       then (
         let texts =
           List.filter_map
-            (function
+            (fun (block : content_block) ->
+              match block with
               | Text s -> Some s
-              | _ -> None)
+              | Thinking _ | RedactedThinking _ | ToolUse _ | ToolResult _
+              | Image _ | Document _ | Audio _ ->
+                (* Tool_selector context only consumes user-authored prose;
+                   non-text user blocks (e.g. inline images) are excluded
+                   by design. Enumerated to surface new variants for review. *)
+                None)
             msg.content
         in
         match texts with

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1145,14 +1145,24 @@ let detect_drift (caps : capabilities) (resp : Types.api_response)
   (* Usage drift *)
   if caps.emits_usage_tokens && resp.usage = None
   then obs := Usage_missing_but_declared :: !obs;
-  (* Content block analysis *)
+  (* Content block analysis.
+     Enumerate every [Types.content_block] variant explicitly so that adding
+     a new constructor (e.g. [Video], [Reasoning_summary]) triggers an
+     exhaustiveness warning here, forcing a deliberate decision on whether
+     the new block carries tool-use or reasoning semantics. The previous
+     [_ -> ()] catch-all silently grouped 5 unrelated variants and would
+     have absorbed any future block without review. *)
   let has_tool_use = ref false
   and has_thinking = ref false in
   List.iter
-    (function
-      | Types.ToolUse _ -> has_tool_use := true
-      | Types.Thinking _ | Types.RedactedThinking _ -> has_thinking := true
-      | _ -> ())
+    (fun (block : Types.content_block) ->
+      match block with
+      | ToolUse _ -> has_tool_use := true
+      | Thinking _ | RedactedThinking _ -> has_thinking := true
+      | Text _ | ToolResult _ | Image _ | Document _ | Audio _ ->
+        (* No capability-drift signal: these blocks are valid against any
+           capability set the response declares. *)
+        ())
     resp.content;
   if !has_tool_use && not caps.supports_tools
   then obs := Tools_used_but_declared_unsupported :: !obs;

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -296,8 +296,13 @@ let openai_chunk_to_events (state : openai_stream_state) (chunk : openai_chunk)
    | Some text when text <> "" ->
      (match state.thinking_state with
       | Not_thinking ->
-        state.thinking_state <- Thinking_started (Unix.gettimeofday ());
-      | _ -> ());
+        state.thinking_state <- Thinking_started (Unix.gettimeofday ())
+      | Thinking_started _ | Thinking_done ->
+        (* Already started, or model is re-emitting reasoning after a
+           closure — keep current state. Enumerated explicitly so adding
+           a new [thinking_state] variant forces review of how it should
+           react to a fresh reasoning chunk. *)
+        ());
      if not state.thinking_block_started
      then (
        state.thinking_block_index <- state.next_block_index;
@@ -325,7 +330,11 @@ let openai_chunk_to_events (state : openai_stream_state) (chunk : openai_chunk)
                   ; model = state.model
                   ; thinking_duration_ms
                   })
-      | _ -> ())
+      | Not_thinking | Thinking_done ->
+        (* Empty reasoning chunk while never started, or after a prior
+           close — no telemetry to emit. Enumerated explicitly so a new
+           [thinking_state] variant cannot silently inherit the no-op. *)
+        ())
    | _ -> ());
   (* Text content delta *)
   (match chunk.delta_content with


### PR DESCRIPTION
## Why

Five `_ -> ()` / `_ -> None` catch-alls over closed-sum types in `lib/llm_provider/` and `lib/agent/`. Each one drops the exhaustiveness guarantee the type system would otherwise provide — when a new constructor is added to the underlying variant, the new value silently inherits the catch-all branch without any review point.

This is the AI-codegen anti-pattern documented in `~/me/instructions/software-development.md` §"FSM Sparse Match / `_ -> false` Catch-all": *the way to keep type-driven safety is to never write a catch-all over a closed sum.*

## What

Five sites, all converted from catch-all to explicit enumeration of every variant. Behavior is unchanged for the current shape of each type; the value of the patch is the *forward-compat* guarantee.

| Site | Type | Today's behavior preserved by |
|------|------|------------------------------|
| `capabilities.ml` `detect_drift` | `Types.content_block` (8 ctors) | `Text | ToolResult | Image | Document | Audio -> ()` |
| `streaming.ml` reasoning-start branch | `thinking_state` (3 ctors) | `Thinking_started _ | Thinking_done -> ()` |
| `streaming.ml` reasoning-end branch | `thinking_state` (3 ctors) | `Not_thinking | Thinking_done -> ()` |
| `agent_turn.ml` `compute_fingerprints` | `Types.content_block` (8 ctors) | all non-`ToolUse` -> `None` |
| `agent_turn.ml` `extract_last_user_text` | `Types.content_block` (8 ctors) | all non-`Text` -> `None` |
| `agent_tools.ml` `extract_tool_use_blocks` | `Types.content_block` (8 ctors) | all non-`ToolUse` -> `None` |

Adding a new constructor (e.g. `Video`, `Reasoning_summary`, `Thinking_paused`) will now produce `Warning 8: this pattern-matching is not exhaustive` at every call site that needs to classify it. A two-line code comment at each site explains the design intent so a future contributor doesn't reintroduce the catch-all.

## Verification

```
dune build @lib/llm_provider/check --root .  # exit 0
dune build @lib/agent/check --root .         # exit 0
dune runtest lib/llm_provider --root .       # exit 0
dune runtest lib/agent --root .              # exit 0
```

## Scope

Surgical. Six match expressions, three files, no behavior change for current variants. No `.mli` change.

## Anti-pattern context

This PR closes six known instances of the pattern across `lib/`. A pre-merge sweep flagged similar shapes that were *not* fixed here because the catch-all is structurally justified (e.g. `lib/llm_provider/cache.ml:68-91` matches a JSON `type` string, which is not a closed sum; `lib/llm_provider/transport_codex_cli.ml:590` matches a string command-execution kind). Those need a different intervention — parse-into-variant first, then exhaustively match — and are tracked as follow-ups.

## Commits

1. `fix(capabilities): make detect_drift content-block match exhaustive`
2. `fix(streaming): make thinking_state FSM matches exhaustive`
3. `fix(agent): make content_block filter-map matches exhaustive`

🤖 Generated with [Claude Code](https://claude.com/claude-code)