### PR TITLE
fix(content_block): close 7 catch-all sites across pipeline + context_reducer + tool_use_recovery

### DIFF
--- a/lib/context_reducer_turns.ml
+++ b/lib/context_reducer_turns.ml
@@ -9,9 +9,11 @@ let group_into_turns (messages : message list) : message list list =
       then (
         let has_tool_result =
           List.exists
-            (function
+            (fun (block : content_block) ->
+              match block with
               | ToolResult _ -> true
-              | _ -> false)
+              | Text _ | Thinking _ | RedactedThinking _ | ToolUse _
+              | Image _ | Document _ | Audio _ -> false)
             msg.content
         in
         if has_tool_result

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -444,9 +444,11 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
   then (
     let tool_names =
       List.filter_map
-        (function
+        (fun (block : content_block) ->
+          match block with
           | ToolUse { name; _ } -> Some name
-          | _ -> None)
+          | Text _ | Thinking _ | RedactedThinking _ | ToolResult _
+          | Image _ | Document _ | Audio _ -> None)
         tool_uses
     in
     let consecutive_idle_turns = agent.consecutive_idle_turns in
@@ -598,9 +600,11 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
   | StopToolUse ->
     let tool_uses =
       List.filter
-        (function
+        (fun (block : content_block) ->
+          match block with
           | ToolUse _ -> true
-          | _ -> false)
+          | Text _ | Thinking _ | RedactedThinking _ | ToolResult _
+          | Image _ | Document _ | Audio _ -> false)
         response.content
     in
     let result = stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses in

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -78,7 +78,8 @@ let last_tool_results_from messages =
     then []
     else
       List.filter_map
-        (function
+        (fun (block : content_block) ->
+          match block with
           | ToolResult { content; is_error; _ } ->
             if is_error
             then
@@ -86,7 +87,8 @@ let last_tool_results_from messages =
                 (Error { Types.message = content; recoverable = true; error_class = None }
                  : Types.tool_result)
             else Some (Ok { Types.content } : Types.tool_result)
-          | _ -> None)
+          | Text _ | Thinking _ | RedactedThinking _ | ToolUse _
+          | Image _ | Document _ | Audio _ -> None)
         msg.content
   in
   List.fold_left

--- a/lib/pipeline/stage_output.ml
+++ b/lib/pipeline/stage_output.ml
@@ -10,9 +10,11 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
   | StopToolUse ->
     let tool_uses =
       List.filter
-        (function
+        (fun (block : content_block) ->
+          match block with
           | ToolUse _ -> true
-          | _ -> false)
+          | Text _ | Thinking _ | RedactedThinking _ | ToolResult _
+          | Image _ | Document _ | Audio _ -> false)
         response.content
     in
     let result = stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses in

--- a/lib/pipeline/stage_parse.ml
+++ b/lib/pipeline/stage_parse.ml
@@ -11,7 +11,8 @@ let last_tool_results_from messages =
     then []
     else
       List.filter_map
-        (function
+        (fun (block : content_block) ->
+          match block with
           | ToolResult { content; is_error; _ } ->
             if is_error
             then
@@ -19,7 +20,8 @@ let last_tool_results_from messages =
                 (Error { Types.message = content; recoverable = true; error_class = None }
                  : Types.tool_result)
             else Some (Ok { Types.content } : Types.tool_result)
-          | _ -> None)
+          | Text _ | Thinking _ | RedactedThinking _ | ToolUse _
+          | Image _ | Document _ | Audio _ -> None)
         msg.content
   in
   List.fold_left

--- a/lib/tool_use_recovery.ml
+++ b/lib/tool_use_recovery.ml
@@ -202,9 +202,11 @@ let recover_response ~(valid_tool_names : string list) (response : api_response)
   else (
     let has_tool_use =
       List.exists
-        (function
+        (fun (block : Types.content_block) ->
+          match block with
           | ToolUse _ -> true
-          | _ -> false)
+          | Text _ | Thinking _ | RedactedThinking _ | ToolResult _
+          | Image _ | Document _ | Audio _ -> false)
         response.content
     in
     if has_tool_use


### PR DESCRIPTION
## Why

Seven `List.filter` / `List.filter_map` / `List.exists` sites on `Types.content_block` extracted one variant and dumped every other variant — including any future constructor — into `_ -> false` or `_ -> None`.

This is the same FSM Sparse Match anti-pattern (`~/me/instructions/software-development.md`) previously closed for `lib/llm_provider/` and `lib/agent/` in PR #1517. The remaining sites in `lib/pipeline/` and the two reducer/recovery helpers had been overlooked.

## Sites (7)

| File | Function | Filter target |
|------|----------|--------------|
| `pipeline/stage_output.ml:11-16` | StopToolUse handler | `ToolUse _` |
| `pipeline/stage_parse.ml:13-22` | `last_tool_results_from` | `ToolResult _` |
| `pipeline/pipeline.ml:446-450` | idle tool-name extraction | `ToolUse { name }` |
| `pipeline/pipeline.ml:600-604` | StopToolUse handler (duplicate of stage_output) | `ToolUse _` |
| `pipeline/pipeline_stage_prepare.ml:80-89` | `last_tool_results_from` (duplicate of stage_parse) | `ToolResult _` |
| `context_reducer_turns.ml:11` | `group_into_turns` user-msg detection | `ToolResult _` |
| `tool_use_recovery.ml:204` | tool-use presence check before recovery | `ToolUse _` |

## What

Each site converted from `function | ... | _ -> X` to an explicit match enumerating all 8 `content_block` variants. Behavior is unchanged for the current shape; the value is the forward-compat guarantee that any new constructor (e.g. `Video`, `Reasoning_summary`) triggers `Warning 8: this pattern-matching is not exhaustive` at every call site, forcing a deliberate decision.

## Verification

\`\`\`
dune build @lib/check --root .          # exit 0
dune runtest lib/pipeline --root .      # exit 0
\`\`\`

After this PR, `rg -B 3 '^\s*\| _ -> (false|None|true)' lib/ -t ocaml | rg -B 2 'ToolUse|ToolResult|Thinking|RedactedThinking'` returns only test fixtures (`api.ml` inline tests). Production `content_block` catch-all sites in `lib/` should be at zero.

## Scope

Surgical. Six files, seven match expressions, no behavior change. No `.mli` change.

## Companion to PR #1517

#1517 closed six sites in `lib/llm_provider/` and `lib/agent/`. This PR closes the remaining seven sites elsewhere in `lib/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)