### PR TITLE
feat(llm_provider): RFC-0058 Phase B — CLI transport factory

### DIFF
--- a/lib/llm_provider/cli_transport_factory.ml
+++ b/lib/llm_provider/cli_transport_factory.ml
@@ -1,0 +1,143 @@
+(** Unified CLI transport factory — RFC-0058 Phase B.
+
+    Protocol-string dispatch over the 4 CLI transport modules:
+    - ["anthropic-cli"] → [Transport_claude_code]
+    - ["codex-cli"]     → [Transport_codex_cli]
+    - ["google-cli"]    → [Transport_gemini_cli]
+    - ["kimi-cli"]      → [Transport_kimi_cli]
+
+    Each protocol maps to an existing transport module's [create] function.
+    Fields in [cli_config] not used by a given protocol are silently ignored. *)
+
+type cli_config = {
+  command : string;
+  model : string option;
+  cwd : string option;
+  (* MCP config — shared by claude, codex, gemini (single file path) *)
+  mcp_config : string option;
+  (* MCP config — kimi-specific (lists of file paths / JSON strings) *)
+  mcp_config_files : string list;
+  mcp_config_json : string list;
+  (* Tool config *)
+  allowed_tools : string list;
+  max_turns : int option;
+  permission_mode : string option;
+  (* Protocol-specific flags *)
+  tool_use_via_stream_json : bool;   (** [anthropic-cli] only *)
+  forward_tool_results : bool;       (** [anthropic-cli], [kimi-cli] *)
+  yolo : bool;                       (** [google-cli] only *)
+  config_file : string option;       (** [kimi-cli] only *)
+  extra_env : (string * string) list; (** [kimi-cli] only *)
+  session_id : string option;        (** [kimi-cli] only *)
+  (* Infrastructure *)
+  cancel : unit Eio.Promise.t option;
+  clock : float Eio.Time.clock_ty Eio.Resource.t option;
+  stdout_idle_timeout_s : float option;
+}
+
+let default_config =
+  { command = ""
+  ; model = None
+  ; cwd = None
+  ; mcp_config = None
+  ; mcp_config_files = []
+  ; mcp_config_json = []
+  ; allowed_tools = []
+  ; max_turns = None
+  ; permission_mode = None
+  ; tool_use_via_stream_json = false
+  ; forward_tool_results = false
+  ; yolo = false
+  ; config_file = None
+  ; extra_env = []
+  ; session_id = None
+  ; cancel = None
+  ; clock = None
+  ; stdout_idle_timeout_s = None
+  }
+;;
+
+let registered_protocols () =
+  List.sort String.compare [ "anthropic-cli"; "codex-cli"; "google-cli"; "kimi-cli" ]
+;;
+
+let is_known_protocol protocol =
+  match protocol with
+  | "anthropic-cli" | "codex-cli" | "google-cli" | "kimi-cli" -> true
+  | _ -> false
+;;
+
+let create ~protocol ~config ~sw ~mgr =
+  match protocol with
+  | "anthropic-cli" ->
+    let tc =
+      { Transport_claude_code.claude_path = config.command
+      ; model = config.model
+      ; max_turns = config.max_turns
+      ; allowed_tools = config.allowed_tools
+      ; permission_mode = config.permission_mode
+      ; mcp_config = config.mcp_config
+      ; cwd = config.cwd
+      ; tool_use_via_stream_json = config.tool_use_via_stream_json
+      ; forward_tool_results = config.forward_tool_results
+      ; cancel = config.cancel
+      ; clock = config.clock
+      ; stdout_idle_timeout_s = config.stdout_idle_timeout_s
+      }
+    in
+    Transport_claude_code.create ~sw ~mgr ~config:tc
+  | "codex-cli" ->
+    let tc =
+      { Transport_codex_cli.codex_path = config.command
+      ; model = config.model
+      ; cwd = config.cwd
+      ; mcp_config = config.mcp_config
+      ; allowed_tools = config.allowed_tools
+      ; max_turns = config.max_turns
+      ; permission_mode = config.permission_mode
+      ; cancel = config.cancel
+      ; clock = config.clock
+      ; stdout_idle_timeout_s = config.stdout_idle_timeout_s
+      }
+    in
+    Transport_codex_cli.create ~sw ~mgr ~config:tc
+  | "google-cli" ->
+    let tc =
+      { Transport_gemini_cli.gemini_path = config.command
+      ; model = config.model
+      ; yolo = config.yolo
+      ; cwd = config.cwd
+      ; mcp_config = config.mcp_config
+      ; allowed_tools = config.allowed_tools
+      ; max_turns = config.max_turns
+      ; permission_mode = config.permission_mode
+      ; cancel = config.cancel
+      ; clock = config.clock
+      ; stdout_idle_timeout_s = config.stdout_idle_timeout_s
+      }
+    in
+    Transport_gemini_cli.create ~sw ~mgr ~config:tc
+  | "kimi-cli" ->
+    let tc =
+      { Transport_kimi_cli.kimi_path = config.command
+      ; model = config.model
+      ; cwd = config.cwd
+      ; config_file = config.config_file
+      ; mcp_config_files = config.mcp_config_files
+      ; mcp_config_json = config.mcp_config_json
+      ; forward_tool_results = config.forward_tool_results
+      ; extra_env = config.extra_env
+      ; cancel = config.cancel
+      ; session_id = config.session_id
+      ; clock = config.clock
+      ; stdout_idle_timeout_s = config.stdout_idle_timeout_s
+      }
+    in
+    Transport_kimi_cli.create ~sw ~mgr ~config:tc
+  | unknown ->
+    failwith
+      (Printf.sprintf
+         "Cli_transport_factory: unknown CLI protocol %S (expected one of: %s)"
+         unknown
+         (String.concat ", " (registered_protocols ())))
+;;

--- a/lib/llm_provider/cli_transport_factory.ml
+++ b/lib/llm_provider/cli_transport_factory.ml
@@ -64,6 +64,17 @@ let registered_protocols () = List.sort String.compare supported_protocols
 
 let is_known_protocol protocol = List.mem protocol supported_protocols
 
+(* Coalesce caller-supplied option with transport's native default.
+   [None] from the caller means "inherit the transport's default" —
+   used for fields like [model] where each transport ships a sensible
+   default (e.g. Kimi's "kimi-for-coding") that must not be silently
+   overwritten by [Cli_transport_factory.default_config]'s [None]. *)
+let inherit_or_override caller_value ~transport_default =
+  match caller_value with
+  | Some _ -> caller_value
+  | None -> transport_default
+;;
+
 let create ~protocol ~config ~sw ~mgr =
   if not (is_known_protocol protocol) then
     failwith
@@ -81,7 +92,9 @@ let create ~protocol ~config ~sw ~mgr =
     let tc =
       { Transport_claude_code.default_config with
         claude_path = config.command
-      ; model = config.model
+      ; model =
+          inherit_or_override config.model
+            ~transport_default:Transport_claude_code.default_config.model
       ; max_turns = config.max_turns
       ; allowed_tools = config.allowed_tools
       ; permission_mode = config.permission_mode
@@ -109,7 +122,9 @@ let create ~protocol ~config ~sw ~mgr =
        is the warning-23-clean alternative to a useless [with]. *)
     let tc : Transport_codex_cli.config =
       { codex_path = config.command
-      ; model = config.model
+      ; model =
+          inherit_or_override config.model
+            ~transport_default:Transport_codex_cli.default_config.model
       ; cwd = config.cwd
       ; mcp_config = config.mcp_config
       ; allowed_tools = config.allowed_tools
@@ -125,7 +140,9 @@ let create ~protocol ~config ~sw ~mgr =
     let tc =
       { Transport_gemini_cli.default_config with
         gemini_path = config.command
-      ; model = config.model
+      ; model =
+          inherit_or_override config.model
+            ~transport_default:Transport_gemini_cli.default_config.model
       ; cwd = config.cwd
       ; mcp_config = config.mcp_config
       ; allowed_tools = config.allowed_tools
@@ -146,7 +163,9 @@ let create ~protocol ~config ~sw ~mgr =
     let tc =
       { Transport_kimi_cli.default_config with
         kimi_path = config.command
-      ; model = config.model
+      ; model =
+          inherit_or_override config.model
+            ~transport_default:Transport_kimi_cli.default_config.model
       ; cwd = config.cwd
       ; config_file = config.config_file
       ; mcp_config_files = config.mcp_config_files

--- a/lib/llm_provider/cli_transport_factory.ml
+++ b/lib/llm_provider/cli_transport_factory.ml
@@ -7,29 +7,24 @@
     - ["kimi-cli"]      → [Transport_kimi_cli]
 
     Each protocol maps to an existing transport module's [create] function.
-    Fields in [cli_config] not used by a given protocol are silently ignored. *)
+    Fields in [cli_config] not consumed by a given protocol are ignored. *)
 
 type cli_config = {
   command : string;
   model : string option;
   cwd : string option;
-  (* MCP config — shared by claude, codex, gemini (single file path) *)
   mcp_config : string option;
-  (* MCP config — kimi-specific (lists of file paths / JSON strings) *)
   mcp_config_files : string list;
   mcp_config_json : string list;
-  (* Tool config *)
   allowed_tools : string list;
   max_turns : int option;
   permission_mode : string option;
-  (* Protocol-specific flags *)
-  tool_use_via_stream_json : bool;   (** [anthropic-cli] only *)
-  forward_tool_results : bool;       (** [anthropic-cli], [kimi-cli] *)
-  yolo : bool;                       (** [google-cli] only *)
-  config_file : string option;       (** [kimi-cli] only *)
-  extra_env : (string * string) list; (** [kimi-cli] only *)
-  session_id : string option;        (** [kimi-cli] only *)
-  (* Infrastructure *)
+  tool_use_via_stream_json : bool option;
+  forward_tool_results : bool option;
+  yolo : bool option;
+  config_file : string option;
+  extra_env : (string * string) list;
+  session_id : string option;
   cancel : unit Eio.Promise.t option;
   clock : float Eio.Time.clock_ty Eio.Resource.t option;
   stdout_idle_timeout_s : float option;
@@ -45,9 +40,9 @@ let default_config =
   ; allowed_tools = []
   ; max_turns = None
   ; permission_mode = None
-  ; tool_use_via_stream_json = false
-  ; forward_tool_results = false
-  ; yolo = false
+  ; tool_use_via_stream_json = None
+  ; forward_tool_results = None
+  ; yolo = None
   ; config_file = None
   ; extra_env = []
   ; session_id = None
@@ -57,38 +52,63 @@ let default_config =
   }
 ;;
 
-let registered_protocols () =
-  List.sort String.compare [ "anthropic-cli"; "codex-cli"; "google-cli"; "kimi-cli" ]
+(* Single source of truth — [registered_protocols], [is_known_protocol],
+   and [create]'s match all flow from this list. Adding a new CLI
+   protocol means adding here AND wiring a [create] arm; the build
+   surfaces the second because [unknown] catch-all is fatal. *)
+let supported_protocols =
+  [ "anthropic-cli"; "codex-cli"; "google-cli"; "kimi-cli" ]
 ;;
 
-let is_known_protocol protocol =
-  match protocol with
-  | "anthropic-cli" | "codex-cli" | "google-cli" | "kimi-cli" -> true
-  | _ -> false
-;;
+let registered_protocols () = List.sort String.compare supported_protocols
+
+let is_known_protocol protocol = List.mem protocol supported_protocols
 
 let create ~protocol ~config ~sw ~mgr =
+  if not (is_known_protocol protocol) then
+    failwith
+      (Printf.sprintf
+         "Cli_transport_factory.create: unknown CLI protocol %S (expected one of: %s)"
+         protocol
+         (String.concat ", " (registered_protocols ())));
+  if String.trim config.command = "" then
+    failwith
+      (Printf.sprintf
+         "Cli_transport_factory.create: protocol %S requires a non-empty command"
+         protocol);
   match protocol with
   | "anthropic-cli" ->
     let tc =
-      { Transport_claude_code.claude_path = config.command
+      { Transport_claude_code.default_config with
+        claude_path = config.command
       ; model = config.model
       ; max_turns = config.max_turns
       ; allowed_tools = config.allowed_tools
       ; permission_mode = config.permission_mode
       ; mcp_config = config.mcp_config
       ; cwd = config.cwd
-      ; tool_use_via_stream_json = config.tool_use_via_stream_json
-      ; forward_tool_results = config.forward_tool_results
       ; cancel = config.cancel
       ; clock = config.clock
       ; stdout_idle_timeout_s = config.stdout_idle_timeout_s
       }
     in
+    let tc =
+      match config.tool_use_via_stream_json with
+      | Some v -> { tc with Transport_claude_code.tool_use_via_stream_json = v }
+      | None -> tc
+    in
+    let tc =
+      match config.forward_tool_results with
+      | Some v -> { tc with Transport_claude_code.forward_tool_results = v }
+      | None -> tc
+    in
     Transport_claude_code.create ~sw ~mgr ~config:tc
   | "codex-cli" ->
-    let tc =
-      { Transport_codex_cli.codex_path = config.command
+    (* Codex CLI has no protocol-specific bool flags, so the cli_config
+       layer can fully specify the record. Listing all fields explicitly
+       is the warning-23-clean alternative to a useless [with]. *)
+    let tc : Transport_codex_cli.config =
+      { codex_path = config.command
       ; model = config.model
       ; cwd = config.cwd
       ; mcp_config = config.mcp_config
@@ -103,9 +123,9 @@ let create ~protocol ~config ~sw ~mgr =
     Transport_codex_cli.create ~sw ~mgr ~config:tc
   | "google-cli" ->
     let tc =
-      { Transport_gemini_cli.gemini_path = config.command
+      { Transport_gemini_cli.default_config with
+        gemini_path = config.command
       ; model = config.model
-      ; yolo = config.yolo
       ; cwd = config.cwd
       ; mcp_config = config.mcp_config
       ; allowed_tools = config.allowed_tools
@@ -116,16 +136,21 @@ let create ~protocol ~config ~sw ~mgr =
       ; stdout_idle_timeout_s = config.stdout_idle_timeout_s
       }
     in
+    let tc =
+      match config.yolo with
+      | Some v -> { tc with Transport_gemini_cli.yolo = v }
+      | None -> tc
+    in
     Transport_gemini_cli.create ~sw ~mgr ~config:tc
   | "kimi-cli" ->
     let tc =
-      { Transport_kimi_cli.kimi_path = config.command
+      { Transport_kimi_cli.default_config with
+        kimi_path = config.command
       ; model = config.model
       ; cwd = config.cwd
       ; config_file = config.config_file
       ; mcp_config_files = config.mcp_config_files
       ; mcp_config_json = config.mcp_config_json
-      ; forward_tool_results = config.forward_tool_results
       ; extra_env = config.extra_env
       ; cancel = config.cancel
       ; session_id = config.session_id
@@ -133,11 +158,19 @@ let create ~protocol ~config ~sw ~mgr =
       ; stdout_idle_timeout_s = config.stdout_idle_timeout_s
       }
     in
+    let tc =
+      match config.forward_tool_results with
+      | Some v -> { tc with Transport_kimi_cli.forward_tool_results = v }
+      | None -> tc
+    in
     Transport_kimi_cli.create ~sw ~mgr ~config:tc
   | unknown ->
+    (* Unreachable: [is_known_protocol] gate above rejects unknown values.
+       Kept as defensive arm so [supported_protocols] drift cannot reach
+       a partial match. *)
     failwith
       (Printf.sprintf
-         "Cli_transport_factory: unknown CLI protocol %S (expected one of: %s)"
-         unknown
-         (String.concat ", " (registered_protocols ())))
+         "Cli_transport_factory.create: unhandled CLI protocol %S \
+          (supported_protocols drift — add a dispatch arm)"
+         unknown)
 ;;

--- a/lib/llm_provider/cli_transport_factory.mli
+++ b/lib/llm_provider/cli_transport_factory.mli
@@ -1,5 +1,7 @@
 (** Unified CLI transport factory — RFC-0058 Phase B.
 
+    @stability Internal
+
     Protocol-string dispatch over the 4 CLI transport modules:
     - ["anthropic-cli"] → [Transport_claude_code]
     - ["codex-cli"]     → [Transport_codex_cli]
@@ -7,16 +9,21 @@
     - ["kimi-cli"]      → [Transport_kimi_cli]
 
     Each protocol maps to an existing transport module's [create] function.
-    Fields in [cli_config] not used by a given protocol are silently ignored.
+    Fields in [cli_config] not consumed by a given protocol are ignored;
+    some underlying transports (e.g. codex-cli, gemini-cli) emit one-shot
+    runtime warnings when they observe parity fields they cannot honor,
+    so "ignored" here means "no effect on the request" rather than silent.
 
     HTTP-only transports ([transport_openai_compat]) are NOT part of this
     factory — they are constructed directly from HTTP parameters. *)
 
 (** Superset config for all CLI transports.
 
-    Fields not used by a given protocol are ignored during construction.
-    This avoids per-protocol config types while keeping the mapping explicit
-    in the factory implementation. *)
+    Fields not consumed by a given protocol are ignored during construction.
+    Protocol-specific boolean flags are [bool option]: [None] means
+    "inherit the underlying transport's native default" (so the factory
+    cannot silently flip a default to [false]); [Some b] is an explicit
+    override. *)
 type cli_config = {
   command : string;
   model : string option;
@@ -30,13 +37,13 @@ type cli_config = {
   allowed_tools : string list;
   max_turns : int option;
   permission_mode : string option;
-  (* Protocol-specific flags *)
-  tool_use_via_stream_json : bool;   (** [anthropic-cli] only *)
-  forward_tool_results : bool;       (** [anthropic-cli], [kimi-cli] *)
-  yolo : bool;                       (** [google-cli] only *)
-  config_file : string option;       (** [kimi-cli] only *)
-  extra_env : (string * string) list; (** [kimi-cli] only *)
-  session_id : string option;        (** [kimi-cli] only *)
+  (* Protocol-specific flags. [None] = use the transport's native default. *)
+  tool_use_via_stream_json : bool option;   (** [anthropic-cli] only *)
+  forward_tool_results : bool option;       (** [anthropic-cli], [kimi-cli] *)
+  yolo : bool option;                       (** [google-cli] only *)
+  config_file : string option;              (** [kimi-cli] only *)
+  extra_env : (string * string) list;       (** [kimi-cli] only *)
+  session_id : string option;               (** [kimi-cli] only *)
   (* Infrastructure *)
   cancel : unit Eio.Promise.t option;
   clock : float Eio.Time.clock_ty Eio.Resource.t option;
@@ -44,8 +51,9 @@ type cli_config = {
 }
 
 val default_config : cli_config
-(** All fields at safe defaults: empty lists, [None] options, [false] bools.
-    [command] defaults to [""] — callers must override. *)
+(** All fields at safe defaults: empty lists, [None] options, [None] for
+    protocol-specific bool flags. [command] defaults to [""] — callers
+    must override; [create] rejects an empty [command] up-front. *)
 
 val create :
   protocol:string ->
@@ -55,7 +63,12 @@ val create :
   Llm_transport.t
 (** Construct a CLI [Llm_transport.t] by dispatching on [protocol].
 
-    @raise Failure if [protocol] has no registered CLI transport. *)
+    Internally starts from the target transport's [default_config] and
+    overrides only the fields the caller set, so a [cli_config] with
+    [tool_use_via_stream_json = None] preserves the underlying
+    transport's native default rather than forcing [false].
+
+    @raise Failure if [protocol] is unknown or [config.command] is empty. *)
 
 val is_known_protocol : string -> bool
 (** [true] when [protocol] maps to a registered CLI transport module. *)

--- a/lib/llm_provider/cli_transport_factory.mli
+++ b/lib/llm_provider/cli_transport_factory.mli
@@ -1,0 +1,64 @@
+(** Unified CLI transport factory — RFC-0058 Phase B.
+
+    Protocol-string dispatch over the 4 CLI transport modules:
+    - ["anthropic-cli"] → [Transport_claude_code]
+    - ["codex-cli"]     → [Transport_codex_cli]
+    - ["google-cli"]    → [Transport_gemini_cli]
+    - ["kimi-cli"]      → [Transport_kimi_cli]
+
+    Each protocol maps to an existing transport module's [create] function.
+    Fields in [cli_config] not used by a given protocol are silently ignored.
+
+    HTTP-only transports ([transport_openai_compat]) are NOT part of this
+    factory — they are constructed directly from HTTP parameters. *)
+
+(** Superset config for all CLI transports.
+
+    Fields not used by a given protocol are ignored during construction.
+    This avoids per-protocol config types while keeping the mapping explicit
+    in the factory implementation. *)
+type cli_config = {
+  command : string;
+  model : string option;
+  cwd : string option;
+  (* MCP config — shared by claude, codex, gemini (single file path) *)
+  mcp_config : string option;
+  (* MCP config — kimi-specific (lists of file paths / JSON strings) *)
+  mcp_config_files : string list;
+  mcp_config_json : string list;
+  (* Tool config *)
+  allowed_tools : string list;
+  max_turns : int option;
+  permission_mode : string option;
+  (* Protocol-specific flags *)
+  tool_use_via_stream_json : bool;   (** [anthropic-cli] only *)
+  forward_tool_results : bool;       (** [anthropic-cli], [kimi-cli] *)
+  yolo : bool;                       (** [google-cli] only *)
+  config_file : string option;       (** [kimi-cli] only *)
+  extra_env : (string * string) list; (** [kimi-cli] only *)
+  session_id : string option;        (** [kimi-cli] only *)
+  (* Infrastructure *)
+  cancel : unit Eio.Promise.t option;
+  clock : float Eio.Time.clock_ty Eio.Resource.t option;
+  stdout_idle_timeout_s : float option;
+}
+
+val default_config : cli_config
+(** All fields at safe defaults: empty lists, [None] options, [false] bools.
+    [command] defaults to [""] — callers must override. *)
+
+val create :
+  protocol:string ->
+  config:cli_config ->
+  sw:Eio.Switch.t ->
+  mgr:_ Eio.Process.mgr ->
+  Llm_transport.t
+(** Construct a CLI [Llm_transport.t] by dispatching on [protocol].
+
+    @raise Failure if [protocol] has no registered CLI transport. *)
+
+val is_known_protocol : string -> bool
+(** [true] when [protocol] maps to a registered CLI transport module. *)
+
+val registered_protocols : unit -> string list
+(** All registered protocol strings, sorted alphabetically. *)

--- a/test/dune
+++ b/test/dune
@@ -211,6 +211,7 @@
   test_tracing
   test_trajectory
   test_trajectory_unit
+  test_cli_transport_factory
   test_transport_deep
   test_transport_integration
   test_turn_budget

--- a/test/test_cli_transport_factory.ml
+++ b/test/test_cli_transport_factory.ml
@@ -1,12 +1,16 @@
 (** RFC-0058 Phase B — CLI transport factory unit tests.
 
-    Tests protocol-string dispatch, [is_known_protocol], and
-    [registered_protocols]. The [create] function requires live Eio
-    subprocess infrastructure and is tested via integration tests
-    in [test_transport_integration]. *)
+    Tests protocol-string dispatch, [is_known_protocol],
+    [registered_protocols], and the "[None] preserves transport native
+    default" invariant introduced for the silent-default-flip regression
+    flagged in PR #1520 review.
+
+    The [create] function requires live Eio subprocess infrastructure and
+    is exercised via integration tests in [test_transport_integration]. *)
 
 open Alcotest
-open Llm_provider.Cli_transport_factory
+open Llm_provider
+open Cli_transport_factory
 
 (* --- is_known_protocol --- *)
 
@@ -29,12 +33,29 @@ let test_unknown_protocol () =
 
 let test_registered_protocols_sorted () =
   let protocols = registered_protocols () in
-  check (list string) "sorted" [ "anthropic-cli"; "codex-cli"; "google-cli"; "kimi-cli" ] protocols
+  check (list string) "sorted"
+    [ "anthropic-cli"; "codex-cli"; "google-cli"; "kimi-cli" ]
+    protocols
 ;;
 
 let test_registered_protocols_count () =
   let protocols = registered_protocols () in
   check int "count" 4 (List.length protocols)
+;;
+
+let test_registry_consistency () =
+  (* Every protocol returned by [registered_protocols] must pass
+     [is_known_protocol], and vice versa for the documented set.
+     Catches drift between the two views of [supported_protocols]. *)
+  List.iter
+    (fun p ->
+      check bool ("registered ⇒ known: " ^ p) true (is_known_protocol p))
+    (registered_protocols ());
+  List.iter
+    (fun p ->
+      check bool ("documented ⇒ registered: " ^ p) true
+        (List.mem p (registered_protocols ())))
+    [ "anthropic-cli"; "codex-cli"; "google-cli"; "kimi-cli" ]
 ;;
 
 (* --- default_config --- *)
@@ -56,10 +77,15 @@ let test_default_config_int_fields () =
   check (option int) "max_turns None" None default_config.max_turns
 ;;
 
-let test_default_config_bool_fields () =
-  check bool "tool_use_via_stream_json" false default_config.tool_use_via_stream_json;
-  check bool "forward_tool_results" false default_config.forward_tool_results;
-  check bool "yolo" false default_config.yolo
+let test_default_config_bool_option_fields () =
+  (* Phase B regression guard: protocol-specific flags must default to
+     [None] so the factory inherits the transport's native default
+     rather than silently forcing [false].  See PR #1520 review. *)
+  check (option bool) "tool_use_via_stream_json None"
+    None default_config.tool_use_via_stream_json;
+  check (option bool) "forward_tool_results None"
+    None default_config.forward_tool_results;
+  check (option bool) "yolo None" None default_config.yolo
 ;;
 
 let test_default_config_list_fields () =
@@ -67,6 +93,23 @@ let test_default_config_list_fields () =
   check (list string) "mcp_config_json" [] default_config.mcp_config_json;
   check (list string) "allowed_tools" [] default_config.allowed_tools;
   check bool "extra_env empty" true (default_config.extra_env = [])
+;;
+
+(* --- Transport native defaults pinned to factory expectations.
+   These tests document the assumption that [None] in [cli_config]
+   inherits these specific values.  If a transport changes its native
+   default, the test pins the change so the factory's behavior is
+   re-reviewed.  --- *)
+
+let test_transport_native_defaults () =
+  check bool "claude tool_use_via_stream_json default true" true
+    Transport_claude_code.default_config.tool_use_via_stream_json;
+  check bool "claude forward_tool_results default false" false
+    Transport_claude_code.default_config.forward_tool_results;
+  check bool "kimi forward_tool_results default true" true
+    Transport_kimi_cli.default_config.forward_tool_results;
+  check bool "gemini yolo default true" true
+    Transport_gemini_cli.default_config.yolo
 ;;
 
 (* --- Test suite --- *)
@@ -80,12 +123,16 @@ let () =
       "registered_protocols", [
         test_case "sorted list" `Quick test_registered_protocols_sorted;
         test_case "count" `Quick test_registered_protocols_count;
+        test_case "registry consistency" `Quick test_registry_consistency;
       ];
       "default_config", [
         test_case "command empty" `Quick test_default_config_command;
         test_case "none fields" `Quick test_default_config_none_fields;
         test_case "int fields" `Quick test_default_config_int_fields;
-        test_case "bool fields" `Quick test_default_config_bool_fields;
+        test_case "bool option fields" `Quick test_default_config_bool_option_fields;
         test_case "list fields" `Quick test_default_config_list_fields;
+      ];
+      "transport_defaults", [
+        test_case "native default pins" `Quick test_transport_native_defaults;
       ];
     ]

--- a/test/test_cli_transport_factory.ml
+++ b/test/test_cli_transport_factory.ml
@@ -1,0 +1,91 @@
+(** RFC-0058 Phase B — CLI transport factory unit tests.
+
+    Tests protocol-string dispatch, [is_known_protocol], and
+    [registered_protocols]. The [create] function requires live Eio
+    subprocess infrastructure and is tested via integration tests
+    in [test_transport_integration]. *)
+
+open Alcotest
+open Llm_provider.Cli_transport_factory
+
+(* --- is_known_protocol --- *)
+
+let test_known_protocols () =
+  check bool "anthropic-cli" true (is_known_protocol "anthropic-cli");
+  check bool "codex-cli" true (is_known_protocol "codex-cli");
+  check bool "google-cli" true (is_known_protocol "google-cli");
+  check bool "kimi-cli" true (is_known_protocol "kimi-cli")
+;;
+
+let test_unknown_protocol () =
+  check bool "openai-http" false (is_known_protocol "openai-http");
+  check bool "ollama-http" false (is_known_protocol "ollama-http");
+  check bool "anthropic-http" false (is_known_protocol "anthropic-http");
+  check bool "bogus" false (is_known_protocol "bogus");
+  check bool "empty" false (is_known_protocol "")
+;;
+
+(* --- registered_protocols --- *)
+
+let test_registered_protocols_sorted () =
+  let protocols = registered_protocols () in
+  check (list string) "sorted" [ "anthropic-cli"; "codex-cli"; "google-cli"; "kimi-cli" ] protocols
+;;
+
+let test_registered_protocols_count () =
+  let protocols = registered_protocols () in
+  check int "count" 4 (List.length protocols)
+;;
+
+(* --- default_config --- *)
+
+let test_default_config_command () =
+  check string "command empty" "" default_config.command
+;;
+
+let test_default_config_none_fields () =
+  check (option string) "model None" None default_config.model;
+  check (option string) "cwd None" None default_config.cwd;
+  check (option string) "mcp_config None" None default_config.mcp_config;
+  check (option string) "permission_mode None" None default_config.permission_mode;
+  check (option string) "config_file None" None default_config.config_file;
+  check (option string) "session_id None" None default_config.session_id
+;;
+
+let test_default_config_int_fields () =
+  check (option int) "max_turns None" None default_config.max_turns
+;;
+
+let test_default_config_bool_fields () =
+  check bool "tool_use_via_stream_json" false default_config.tool_use_via_stream_json;
+  check bool "forward_tool_results" false default_config.forward_tool_results;
+  check bool "yolo" false default_config.yolo
+;;
+
+let test_default_config_list_fields () =
+  check (list string) "mcp_config_files" [] default_config.mcp_config_files;
+  check (list string) "mcp_config_json" [] default_config.mcp_config_json;
+  check (list string) "allowed_tools" [] default_config.allowed_tools;
+  check bool "extra_env empty" true (default_config.extra_env = [])
+;;
+
+(* --- Test suite --- *)
+
+let () =
+  run "cli-transport-factory"
+    [ "is_known_protocol", [
+        test_case "known protocols" `Quick test_known_protocols;
+        test_case "unknown protocols" `Quick test_unknown_protocol;
+      ];
+      "registered_protocols", [
+        test_case "sorted list" `Quick test_registered_protocols_sorted;
+        test_case "count" `Quick test_registered_protocols_count;
+      ];
+      "default_config", [
+        test_case "command empty" `Quick test_default_config_command;
+        test_case "none fields" `Quick test_default_config_none_fields;
+        test_case "int fields" `Quick test_default_config_int_fields;
+        test_case "bool fields" `Quick test_default_config_bool_fields;
+        test_case "list fields" `Quick test_default_config_list_fields;
+      ];
+    ]


### PR DESCRIPTION
## Summary

RFC-0058 Phase B: Add  module to OAS agent_sdk.

### Changes
- ****: New unified CLI transport factory
  -  superset type captures all per-protocol config fields
  -  dispatches by protocol string
  -  /  for validation
  - Protocol mapping:  → ,  → ,  → , ╭──────────────────────────────────────────────────────────────────────────────╮
│                                                                              │
│   ▐█▛█▛█▌  Welcome to Kimi Code CLI!                                         │
│   ▐█████▌  Send /help for help information.                                  │
│                                                                              │
│  Directory: ~/me/workspace/yousleepwhen/oas/.worktrees/rfc-0058-phase-b-cli  │
│  -transport-factory                                                          │
│  Session: a3bc6104-c7c1-4bab-a8ce-4fee7bc9ad90                               │
│  Model: echo                                                                 │
│  Tip: send /login to use Kimi for Coding                                     │
│                                                                              │
│  Tip: Spot a bug or have feedback? Type /feedback right in this session — e  │
│  very report makes Kimi better.                                              │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯

── input ───────────────────────────────────────────────────────────────────────
  → 
- ****: Unit tests for , , 

### Context
Part of the Provider-Free Cascade migration plan. This factory enables Phase C (masc-mcp): direct TOML → transport construction bypassing .

### Verification
- All 9 unit tests pass ✅