### PR TITLE
fix(context_reducer): close 9 content_block catch-all sites in apply

### DIFF
--- a/lib/context_reducer_apply.ml
+++ b/lib/context_reducer_apply.ml
@@ -98,10 +98,12 @@ let apply_repair_dangling_tool_calls messages =
     | (msg : message) :: rest ->
       let orphan_ids =
         List.filter_map
-          (fun block ->
+          (fun (block : content_block) ->
              match block with
              | ToolUse { id; _ } when not (List.mem id result_ids) -> Some id
-             | _ -> None)
+             | ToolUse _
+             | Text _ | Thinking _ | RedactedThinking _ | ToolResult _
+             | Image _ | Document _ | Audio _ -> None)
           msg.content
       in
       if orphan_ids = []
@@ -135,10 +137,11 @@ let apply_repair_orphaned_tool_results messages =
     List.fold_left
       (fun acc (msg : message) ->
          List.fold_left
-           (fun acc block ->
+           (fun acc (block : content_block) ->
               match block with
               | ToolUse { id; _ } -> id :: acc
-              | _ -> acc)
+              | Text _ | Thinking _ | RedactedThinking _ | ToolResult _
+              | Image _ | Document _ | Audio _ -> acc)
            acc
            msg.content)
       []
@@ -148,10 +151,11 @@ let apply_repair_orphaned_tool_results messages =
     (fun (msg : message) ->
        let content =
          List.filter
-           (fun block ->
+           (fun (block : content_block) ->
               match block with
               | ToolResult { tool_use_id; _ } -> List.mem tool_use_id use_ids
-              | _ -> true)
+              | Text _ | Thinking _ | RedactedThinking _ | ToolUse _
+              | Image _ | Document _ | Audio _ -> true)
            msg.content
        in
        if content = [] then None else Some { msg with content })
@@ -167,15 +171,19 @@ let apply_merge_contiguous messages =
          when prev.role = msg.role
               && (not
                     (List.exists
-                       (function
+                       (fun (block : content_block) ->
+                         match block with
                          | ToolResult _ -> true
-                         | _ -> false)
+                         | Text _ | Thinking _ | RedactedThinking _ | ToolUse _
+                         | Image _ | Document _ | Audio _ -> false)
                        msg.content))
               && not
                    (List.exists
-                      (function
+                      (fun (block : content_block) ->
+                        match block with
                         | ToolResult _ -> true
-                        | _ -> false)
+                        | Text _ | Thinking _ | RedactedThinking _ | ToolUse _
+                        | Image _ | Document _ | Audio _ -> false)
                       prev.content) ->
          let merged = { prev with content = prev.content @ msg.content } in
          aux (merged :: acc_rest) rest
@@ -193,10 +201,11 @@ let apply_drop_thinking messages =
        else (
          let content =
            List.filter
-             (fun block ->
+             (fun (block : content_block) ->
                 match block with
                 | Thinking _ | RedactedThinking _ -> false
-                | _ -> true)
+                | Text _ | ToolUse _ | ToolResult _
+                | Image _ | Document _ | Audio _ -> true)
              msg.content
          in
          if content = [] then None else Some { msg with content }))
@@ -208,15 +217,19 @@ let apply_prune_by_role ~drop_roles messages =
     List.exists (fun r -> r = msg.role) drop_roles
     && (not
           (List.exists
-             (function
+             (fun (block : content_block) ->
+               match block with
                | ToolResult _ -> true
-               | _ -> false)
+               | Text _ | Thinking _ | RedactedThinking _ | ToolUse _
+               | Image _ | Document _ | Audio _ -> false)
              msg.content))
     && not
          (List.exists
-            (function
+            (fun (block : content_block) ->
+              match block with
               | ToolUse _ -> true
-              | _ -> false)
+              | Text _ | Thinking _ | RedactedThinking _ | ToolResult _
+              | Image _ | Document _ | Audio _ -> false)
             msg.content)
   in
   List.filter (fun msg -> not (should_drop msg)) messages
@@ -328,9 +341,11 @@ let apply_cap_message_tokens ~max_tokens ~keep_recent messages =
     else (
       let front_budget = max_tokens * 6 / 10 in
       let back_budget = max_tokens * 3 / 10 in
-      let is_pair_block = function
+      let is_pair_block (block : content_block) =
+        match block with
         | ToolUse _ | ToolResult _ -> true
-        | _ -> false
+        | Text _ | Thinking _ | RedactedThinking _
+        | Image _ | Document _ | Audio _ -> false
       in
       let cap_message (msg : message) =
         let msg_tokens = estimate_message_tokens msg in


### PR DESCRIPTION
## Why

`lib/context_reducer_apply.ml` had **nine** sites that pattern-matched on `Types.content_block` with a `_ -> false` / `_ -> None` / `_ -> true` catch-all absorbing every non-target variant. These were missed by the sweep in PR #1519 because the file sits at `lib/` top-level (not under `lib/pipeline/` or `lib/agent/`, which were the focus of that sweep).

Same FSM Sparse Match anti-pattern (`~/me/instructions/software-development.md`) and same fix approach as PRs #1517 and #1519.

## Sites (9)

| Line range | Function | Filter target |
|------------|----------|--------------|
| 100-105 | `find_orphan_tool_uses` | `ToolUse { id; _ }` (with guard) |
| 138-143 | `apply_repair_orphaned_tool_results` (use_ids fold) | `ToolUse { id; _ }` |
| 150-155 | `apply_repair_orphaned_tool_results` (filter) | `ToolResult { tool_use_id; _ }` |
| 168-173 | `apply_merge_contiguous` (msg side) | `ToolResult _` exists |
| 174-179 | `apply_merge_contiguous` (prev side) | `ToolResult _` exists (duplicate of above) |
| 195-200 | `apply_drop_thinking` | `Thinking _ \| RedactedThinking _` (reverse: drop these) |
| 209-214 | `apply_prune_by_role` | `ToolResult _` exists |
| 215-220 | `apply_prune_by_role` | `ToolUse _` exists |
| 330-333 | `apply_summarize` `is_pair_block` | `ToolUse _ \| ToolResult _` |

## What

Each site converted from `function | ... | _ -> X` (or equivalent) to an explicit match enumerating all 8 `content_block` variants. Behavior unchanged for current variants; the value is the forward-compat guarantee — a new constructor (e.g. `Video`, `Reasoning_summary`) triggers `Warning 8: this pattern-matching is not exhaustive` at every call site.

## Verification

\`\`\`
dune build @lib/check --root .   # exit 0
\`\`\`

## Scope

Surgical. One file, nine match expressions, no behavior change. No `.mli` change. Net +33/-18 LOC.

## After this PR

Together with #1517 (6 sites in `llm_provider`/`agent`) and #1519 (7 sites in `pipeline`/`context_reducer_turns`/`tool_use_recovery`), the content_block forward-compat invariant should hold across `lib/` production code. Test fixtures in `lib/api.ml` retain `_ -> false` for hardcoded test predicates — those don't impact the invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)