### PR TITLE
fix(agent_turn): make reserve_strategy_budget strategy match exhaustive

### DIFF
--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -201,18 +201,28 @@ let tiered_memory_tokens tiered_memory =
   | Some recall -> Context_reducer.estimate_message_tokens recall
 ;;
 
-let rec reserve_strategy_budget ~reserved_tokens strategy =
+let rec reserve_strategy_budget ~reserved_tokens (strategy : Context_reducer.strategy) =
   match strategy with
-  | Context_reducer.Token_budget budget ->
+  | Token_budget budget ->
     Context_reducer.Token_budget (Int.max 0 (budget - reserved_tokens))
-  | Context_reducer.Compose strategies ->
+  | Compose strategies ->
     Context_reducer.Compose
       (List.map (reserve_strategy_budget ~reserved_tokens) strategies)
-  | Context_reducer.Dynamic selector ->
+  | Dynamic selector ->
     Context_reducer.Dynamic
       (fun ~turn ~messages ->
         reserve_strategy_budget ~reserved_tokens (selector ~turn ~messages))
-  | other -> other
+  (* Enumerate every other [strategy] variant so the compiler flags any
+     new constructor here. A new strategy that *does* carry a token budget
+     (e.g. a future [Hard_token_cap]) would silently inherit identity
+     passthrough under the previous [other -> other] catch-all, defeating
+     the per-call budget-reservation contract. *)
+  | ( Keep_last_n _ | Prune_tool_outputs _ | Prune_tool_args _
+    | Repair_dangling_tool_calls | Repair_orphaned_tool_results
+    | Merge_contiguous | Drop_thinking | Keep_first_and_last _
+    | Prune_by_role _ | Summarize_old _ | Clear_tool_results _
+    | Stub_tool_results _ | Cap_message_tokens _ | Cache_alignment _
+    | Relocate_tool_results _ | Custom _ ) as s -> s
 ;;
 
 let reserve_context_reducer ~tiered_memory = function


### PR DESCRIPTION
## Why

`reserve_strategy_budget` recurses into a `Context_reducer.strategy` and adjusts the budget on three variants:

\`\`\`ocaml
| Token_budget budget -> Token_budget (max 0 (budget - reserved))
| Compose strategies -> Compose (List.map (reserve ~reserved) strategies)
| Dynamic selector -> Dynamic (fun ~turn ~messages -> reserve (selector ~turn ~messages))
| other -> other
\`\`\`

`Context_reducer.strategy` currently has **19 constructors**. The named-binding catch-all `| other -> other` is identity-passthrough for the 16 remaining variants, which is *probably* the right behavior for new variants too — but the compiler stays silent if a future variant should also be reserved against (e.g. a hypothetical `Hard_token_cap`, `Adaptive_budget`, etc.). Same FSM Sparse Match anti-pattern as the catch-alls closed in PRs #1517, #1519, #1521, and now extended to the *identity-passthrough* shape.

## What

Replace `| other -> other` with an explicit `(C1 _ | C2 _ | ... ) as s -> s` enumerating the 16 passthrough constructors:

\`\`\`ocaml
| ( Keep_last_n _ | Prune_tool_outputs _ | Prune_tool_args _
  | Repair_dangling_tool_calls | Repair_orphaned_tool_results
  | Merge_contiguous | Drop_thinking | Keep_first_and_last _
  | Prune_by_role _ | Summarize_old _ | Clear_tool_results _
  | Stub_tool_results _ | Cap_message_tokens _ | Cache_alignment _
  | Relocate_tool_results _ | Custom _ ) as s -> s
\`\`\`

Behavior unchanged for current variants. Adding a 20th constructor to `Context_reducer.strategy` will now trigger `Warning 8: this pattern-matching is not exhaustive` at this call site, forcing a deliberate decision on whether the new strategy participates in budget reservation.

Also tightens `match strategy with` to bind the scrutinee at type `Context_reducer.strategy` (parameter annotation), letting the inner arms use unqualified constructor names — readability win consistent with how the code reads `Token_budget`/`Compose`/`Dynamic` after the qualifier is established.

## Why this matters (identity-passthrough nuance)

Most of the FSM Sparse Match work in prior PRs closed `_ -> false` / `_ -> None` shapes where the default *value* was load-bearing. Identity-passthrough (`| other -> other`) looks safer because it doesn't fabricate a value — but it has the same forward-fragility: a new variant inherits the default behavior without review. The only difference is the *direction* of forward fragility (silent identity vs silent false). Same compiler-guarantee gap.

## Verification

\`\`\`
dune build @lib/agent/check --root .   # exit 0
\`\`\`

## Scope

Surgical. One function, one file, no behavior change. No `.mli` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)