### PR TITLE
fix(api_openai): make is_zai_provider_config Provider.config match exhaustive

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -35,13 +35,13 @@ let capabilities_for_request ?provider_config (config : agent_state) =
 ;;
 
 let is_zai_provider_config (cfg : Provider.config) =
-  (* Enumerate every [Provider.provider_config] variant so the compiler
-     flags any new constructor here. ZAI detection depends on a [base_url]
-     field; [Anthropic] and [Custom_registered] don't carry one so they
-     are non-ZAI today, but a future base_url-carrying variant (e.g.
-     [Llama_server], [OpenRouter]) would silently inherit "non-ZAI"
-     under the previous [_ -> false] catch-all even if its URL was a
-     ZAI endpoint. *)
+  (* Enumerate every [Provider.provider] variant (the type of
+     [cfg.provider]) so the compiler flags any new constructor here.
+     ZAI detection depends on a [base_url] field; [Anthropic] and
+     [Custom_registered] don't carry one so they are non-ZAI today,
+     but a future base_url-carrying variant (e.g. [Llama_server],
+     [OpenRouter]) would silently inherit "non-ZAI" under the previous
+     [_ -> false] catch-all even if its URL was a ZAI endpoint. *)
   match cfg.provider with
   | Provider.OpenAICompat { base_url; _ } | Provider.Local { base_url } ->
     Llm_provider.Zai_catalog.is_zai_base_url base_url

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -35,10 +35,17 @@ let capabilities_for_request ?provider_config (config : agent_state) =
 ;;
 
 let is_zai_provider_config (cfg : Provider.config) =
+  (* Enumerate every [Provider.provider_config] variant so the compiler
+     flags any new constructor here. ZAI detection depends on a [base_url]
+     field; [Anthropic] and [Custom_registered] don't carry one so they
+     are non-ZAI today, but a future base_url-carrying variant (e.g.
+     [Llama_server], [OpenRouter]) would silently inherit "non-ZAI"
+     under the previous [_ -> false] catch-all even if its URL was a
+     ZAI endpoint. *)
   match cfg.provider with
   | Provider.OpenAICompat { base_url; _ } | Provider.Local { base_url } ->
     Llm_provider.Zai_catalog.is_zai_base_url base_url
-  | _ -> false
+  | Provider.Anthropic | Provider.Custom_registered _ -> false
 ;;
 
 let is_glm_request ?provider_config (config : agent_state) =


### PR DESCRIPTION
## Why

`is_zai_provider_config` checks whether a `Provider.config` points at a ZAI endpoint:

\`\`\`ocaml
match cfg.provider with
| Provider.OpenAICompat { base_url; _ } | Provider.Local { base_url } ->
  Llm_provider.Zai_catalog.is_zai_base_url base_url
| _ -> false
\`\`\`

`Provider.provider_config` has 4 constructors: `Local | Anthropic | OpenAICompat | Custom_registered { name }`. The catch-all silently absorbs `Anthropic` and `Custom_registered` — correct today since neither carries a `base_url`. But a future base_url-carrying variant (e.g. `Llama_server { base_url }`, `OpenRouter { base_url }`) would inherit "non-ZAI" silently *even if its URL was a ZAI endpoint*.

Same FSM Sparse Match anti-pattern (`~/me/instructions/software-development.md`) as previously closed in PRs #1517, #1519, #1521, #1522 (OAS) and #14716, #14762 (masc-mcp).

## What

\`\`\`ocaml
| Provider.OpenAICompat { base_url; _ } | Provider.Local { base_url } ->
  Llm_provider.Zai_catalog.is_zai_base_url base_url
| Provider.Anthropic | Provider.Custom_registered _ -> false
\`\`\`

Behavior unchanged for the current 4 variants. Adding a 5th constructor to `Provider.provider_config` will now trigger `Warning 8: this pattern-matching is not exhaustive` at this call site, forcing the maintainer to deliberately decide whether the new variant should be ZAI-checked. A short comment explains the design intent so a future contributor doesn't reintroduce the catch-all.

## Verification

\`\`\`
dune build @lib/check --root .   # exit 0
\`\`\`

## Scope

Surgical. One function, one file, no behavior change. No `.mli` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)