### PR TITLE
fix(collaboration): make is_claimable claim_phase match exhaustive

### DIFF
--- a/lib/collaboration.ml
+++ b/lib/collaboration.ml
@@ -213,7 +213,12 @@ let open_claim item_id = { item_id; phase = Open; claimant = None; logical_clock
 
 let is_claimable = function
   | { phase = Open; claimant = None; _ } -> true
-  | _ -> false
+  (* Enumerate every [claim_phase] outcome so the compiler flags any new
+     phase added to [claim_phase]. [verify_claim] below already follows
+     this pattern; [is_claimable] was inconsistent with [_ -> false]. *)
+  | { phase = Open; claimant = Some _; _ }
+  | { phase = Claimed; _ }
+  | { phase = Closed; _ } -> false
 ;;
 
 let claim ~actor_id ~logical_clock snapshot =


### PR DESCRIPTION
## Why

`is_claimable` tested whether a `claim_snapshot` is open and unclaimed:

\`\`\`ocaml
let is_claimable = function
  | { phase = Open; claimant = None; _ } -> true
  | _ -> false
\`\`\`

`claim_phase` has 3 variants today: `Open | Claimed | Closed`. The `_` catch-all silently absorbed three independent rejection paths:

| Rejection path | Reason |
|----------------|--------|
| `Open` with `Some _` | Race — someone just took the claim |
| `Claimed` | Already taken |
| `Closed` | Terminal phase |

All three correctly return `false` today, but a future variant (e.g. a hypothetical `Reopened` that mirrors `Open`) would silently inherit "not claimable" with no review point. Same FSM Sparse Match anti-pattern as the closed-sum tuple matches addressed in PRs #1517, #1519, #1521, etc.

## What

\`\`\`ocaml
| { phase = Open; claimant = None; _ } -> true
| { phase = Open; claimant = Some _; _ }
| { phase = Claimed; _ }
| { phase = Closed; _ } -> false
\`\`\`

Behavior unchanged for current 3 phases. Adding a 4th constructor to `claim_phase` will now trigger `Warning 8: this pattern-matching is not exhaustive` at this site.

This also aligns `is_claimable` with `verify_claim` directly below — that function already enumerates every `claim_phase` explicitly (`| { phase = Closed; _ } -> ... | { phase = Claimed; ... } -> ... | { phase = Open; _ } | { phase = Claimed; claimant = None; _ } -> ...`). The two functions now consistently surface Warning 8 at the same call sites when `claim_phase` gains a new constructor.

## Verification

\`\`\`
dune build @lib/check --root .   # exit 0
\`\`\`

## Scope

Surgical. One function, one file, no behavior change. No `.mli` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)