### PR TITLE
fix(backend_gemini): make has_tool_use content_block match exhaustive (N-of-M followup to #1519/#1521)

### DIFF
--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -319,10 +319,16 @@ let parse_response json =
       |> Option.value ~default:"STOP"
     in
     let has_tool_use =
+      (* N-of-M followup to PR #1519 / #1521 — same content_block
+         catch-all that was closed in tool_use_recovery.ml and
+         context_reducer_apply.ml. The Gemini backend's stop-reason
+         inference uses the same shape and was missed in those sweeps. *)
       List.exists
-        (function
+        (fun (block : Types.content_block) ->
+          match block with
           | ToolUse _ -> true
-          | _ -> false)
+          | Text _ | Thinking _ | RedactedThinking _ | ToolResult _
+          | Image _ | Document _ | Audio _ -> false)
         content
     in
     let stop_reason =


### PR DESCRIPTION
## Why

The Gemini backend's stop-reason inference walks `content` with the same shape closed in PRs **#1519** (`tool_use_recovery.ml`, `pipeline/`) and **#1521** (`context_reducer_apply.ml`):

\`\`\`ocaml
List.exists
  (function
    | ToolUse _ -> true
    | _ -> false)
  content
\`\`\`

`Types.content_block` has 8 constructors today. The `_ -> false` catch-all silently absorbs the 7 non-`ToolUse` variants and would inherit "no tool" for any future variant (e.g. `Video`, `Reasoning_summary`) — exactly wrong for stop-reason inference, which uses this signal to choose between `StopToolUse` and provider-reported finish reasons.

This site was missed in the two prior sweeps. Function-name greps don't catch sibling files — the N-of-M lesson learned across iter #18 and #19.

## What

\`\`\`ocaml
List.exists
  (fun (block : Types.content_block) ->
    match block with
    | ToolUse _ -> true
    | Text _ | Thinking _ | RedactedThinking _ | ToolResult _
    | Image _ | Document _ | Audio _ -> false)
  content
\`\`\`

Behavior unchanged for current 8 variants. Adding a 9th constructor to `Types.content_block` will now trigger `Warning 8` at this site simultaneously with the other sites already closed by #1519 and #1521 (once those merge).

## Verification

\`\`\`
dune build @lib/llm_provider/check --root .   # exit 0
\`\`\`

## Scope

Surgical. One match expression, one file, no behavior change. No `.mli` change.

## Process methodology

This PR was found via `rg -B 3 '^\s*\| ToolUse' lib/ -t ocaml | rg -B 2 '_ -> false'` — the *type + arm shape* grep that should have been part of the original sweep. Documented in `~/me/.claude/projects/-Users-dancer-me/memory/feedback_exhaustive_match_sweep_type_plus_arm.md` for future reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)