### PR TITLE
fix(backend_openai): make Thinking-detection content_block matches exhaustive (2 sites)

### DIFF
--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -921,10 +921,15 @@ let%test "parse_openai_response_result with reasoning_content" =
   in
   match parse_openai_response_result json_str with
   | Ok resp ->
+    (* N-of-M followup to PR #1525 (backend_gemini.has_tool_use). Same
+       content_block catch-all family — enumerate every variant so a
+       future block type can't silently inherit "no thinking". *)
     List.exists
-      (function
+      (fun (block : Types.content_block) ->
+        match block with
         | Thinking _ -> true
-        | _ -> false)
+        | Text _ | RedactedThinking _ | ToolUse _ | ToolResult _
+        | Image _ | Document _ | Audio _ -> false)
       resp.content
   | Error _ -> false
 ;;
@@ -1343,9 +1348,11 @@ let%test "strip_thinking_blocks removes Thinking from all messages" =
     (fun (msg : message) ->
        not
          (List.exists
-            (function
+            (fun (block : Types.content_block) ->
+              match block with
               | Thinking _ -> true
-              | _ -> false)
+              | Text _ | RedactedThinking _ | ToolUse _ | ToolResult _
+              | Image _ | Document _ | Audio _ -> false)
             msg.content))
     stripped
 ;;


### PR DESCRIPTION
## Why

Two `List.exists (Thinking _ -> true | _ -> false)` patterns in `backend_openai.ml`. Same anti-pattern closed in PRs #1517, #1519, #1521, and #1525 — and missed by *all four* prior sweeps.

| Line | Function | Purpose |
|------|----------|---------|
| 924 | `response_contains_thinking` (after JSON parse) | Detect Thinking blocks in OpenAI response |
| 1345 | post-strip-thinking verification | Confirm no Thinking blocks remain after stripping |

Both check "does any content_block carry Thinking?" with `_ -> false` absorbing the other 7 variants. Forward-fragile — if a future variant carries reasoning info under a different constructor (e.g. `Reasoning_summary`), it would silently inherit "no thinking" with no review point.

## What

Enumerate every variant explicitly at both sites:

\`\`\`ocaml
List.exists
  (fun (block : Types.content_block) ->
    match block with
    | Thinking _ -> true
    | Text _ | RedactedThinking _ | ToolUse _ | ToolResult _
    | Image _ | Document _ | Audio _ -> false)
  ...
\`\`\`

Behavior unchanged for the current 8 `content_block` variants. Adding a 9th will now trigger `Warning 8` at both sites.

## Verification

\`\`\`
dune build @lib/llm_provider/check --root .   # exit 0
\`\`\`

## Process methodology

This PR was found by `rg -B 3 '^\s*\| Thinking' lib/ -t ocaml | rg -B 2 '_ -> false'` — the type+arm grep documented in `memory/feedback_exhaustive_match_sweep_type_plus_arm.md`. Four prior sweeps focused on `ToolUse` and `ToolResult` patterns and missed the `Thinking` shape entirely. **Lesson for future sweeps**: enumerate every *closed-sum variant* present in the codebase as a separate grep target — same anti-pattern lives under different constructor names.

## Scope

Surgical. Two match expressions, one file, no behavior change. No `.mli` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)