### PR TITLE
fix(pipeline): make stage_output ToolUse filter content_block exhaustive (N-of-M followup #1517-#1526)

### DIFF
--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -598,9 +598,11 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
   | StopToolUse ->
     let tool_uses =
       List.filter
-        (function
+        (fun (block : Types.content_block) ->
+          match block with
           | ToolUse _ -> true
-          | _ -> false)
+          | Text _ | Thinking _ | RedactedThinking _ | ToolResult _
+          | Image _ | Document _ | Audio _ -> false)
         response.content
     in
     let result = stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses in

--- a/lib/pipeline/stage_output.ml
+++ b/lib/pipeline/stage_output.ml
@@ -10,9 +10,11 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
   | StopToolUse ->
     let tool_uses =
       List.filter
-        (function
+        (fun (block : Types.content_block) ->
+          match block with
           | ToolUse _ -> true
-          | _ -> false)
+          | Text _ | Thinking _ | RedactedThinking _ | ToolResult _
+          | Image _ | Document _ | Audio _ -> false)
         response.content
     in
     let result = stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses in


### PR DESCRIPTION
## Why

Sixth N-of-M sibling found for `Types.content_block` catch-all sweep. PRs #1517, #1519, #1521, #1525, #1526 all closed `function | <ctor> _ -> true | _ -> false` patterns across pipeline/context_reducer/tool_use_recovery/backend_gemini/backend_openai. Two hot-path sites in the pipeline's `stage_output` slipped past every prior sweep.

This PR closes the last two known sites in `lib/pipeline/`.

## Sites

| Location | Function | Catch-all shape |
|----------|----------|-----------------|
| `lib/pipeline/pipeline.ml:597-605` | `stage_output` (main pipeline) | `function \| ToolUse _ -> true \| _ -> false` |
| `lib/pipeline/stage_output.ml:9-17` | `stage_output` (extracted module) | same |

Both are evaluated on **every** `StopToolUse` turn — silent absorption of a future `content_block` variant would yield empty `tool_uses` and cascade to idle-skip without compiler warning.

## Fix

Explicit enumeration of the 7 non-`ToolUse` constructors:

```ocaml
List.filter
  (fun (block : Types.content_block) ->
    match block with
    | ToolUse _ -> true
    | Text _ | Thinking _ | RedactedThinking _ | ToolResult _
    | Image _ | Document _ | Audio _ -> false)
  response.content
```

Behavior preserving; OCaml warning 8 now catches future variants.

## Methodology lesson

Memory feedback `feedback_exhaustive_match_sweep_type_plus_arm.md` (iter #22) called out exactly this blind spot: five prior PRs swept the same `content_block` type but each fixated on one or two constructors (`ToolUse` / `ToolResult` / `Thinking`). The (type, constructor) pair matrix was the actual sweep unit; type-only sweep left these two hot-path files standing.

## Verification

- `dune build @lib/pipeline/check --root .` exit 0
- `git diff --stat`: 2 files, +8 −4
- No public API change