### PR TITLE
refactor(llm_provider): consolidate Ollama endpoint default into Constants

### DIFF
--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -332,7 +332,7 @@ let%test "build_request pins keep_alive=-1 as integer by default" =
       Provider_config.make
         ~kind:Ollama
         ~model_id:"qwen3.5:35b-a3b-nvfp4"
-        ~base_url:"http://127.0.0.1:11434"
+        ~base_url:Constants.Endpoints.ollama_default_url
         ()
     in
     let messages =
@@ -358,7 +358,7 @@ let%test "build_request integer override sent as `Int" =
       Provider_config.make
         ~kind:Ollama
         ~model_id:"qwen3.5:35b-a3b-nvfp4"
-        ~base_url:"http://127.0.0.1:11434"
+        ~base_url:Constants.Endpoints.ollama_default_url
         ()
     in
     let messages =
@@ -382,7 +382,7 @@ let%test "build_request duration string override sent as `String" =
       Provider_config.make
         ~kind:Ollama
         ~model_id:"qwen3.5:35b-a3b-nvfp4"
-        ~base_url:"http://127.0.0.1:11434"
+        ~base_url:Constants.Endpoints.ollama_default_url
         ()
     in
     let messages =
@@ -406,7 +406,7 @@ let%test "build_request trims whitespace around override" =
       Provider_config.make
         ~kind:Ollama
         ~model_id:"qwen3.5:35b-a3b-nvfp4"
-        ~base_url:"http://127.0.0.1:11434"
+        ~base_url:Constants.Endpoints.ollama_default_url
         ()
     in
     let messages =
@@ -430,7 +430,7 @@ let%test "build_request whitespace-only env falls back to default integer" =
       Provider_config.make
         ~kind:Ollama
         ~model_id:"qwen3.5:35b-a3b-nvfp4"
-        ~base_url:"http://127.0.0.1:11434"
+        ~base_url:Constants.Endpoints.ollama_default_url
         ()
     in
     let messages =
@@ -454,7 +454,7 @@ let%test "build_request config.keep_alive overrides env (string form)" =
       Provider_config.make
         ~kind:Ollama
         ~model_id:"qwen3.5:35b-a3b-nvfp4"
-        ~base_url:"http://127.0.0.1:11434"
+        ~base_url:Constants.Endpoints.ollama_default_url
         ~keep_alive:"5m"
         ()
     in
@@ -479,7 +479,7 @@ let%test "build_request config.keep_alive integer form sent as `Int" =
       Provider_config.make
         ~kind:Ollama
         ~model_id:"qwen3.5:35b-a3b-nvfp4"
-        ~base_url:"http://127.0.0.1:11434"
+        ~base_url:Constants.Endpoints.ollama_default_url
         ~keep_alive:"600"
         ()
     in
@@ -504,7 +504,7 @@ let%test "build_request config.num_ctx injected into options" =
       Provider_config.make
         ~kind:Ollama
         ~model_id:"qwen3:8b"
-        ~base_url:"http://127.0.0.1:11434"
+        ~base_url:Constants.Endpoints.ollama_default_url
         ~num_ctx:8192
         ()
     in
@@ -529,7 +529,7 @@ let%test "build_request omits num_ctx when None" =
       Provider_config.make
         ~kind:Ollama
         ~model_id:"qwen3:8b"
-        ~base_url:"http://127.0.0.1:11434"
+        ~base_url:Constants.Endpoints.ollama_default_url
         ()
     in
     let messages =
@@ -553,7 +553,7 @@ let%test "build_request num_ctx<=0 treated as unset" =
       Provider_config.make
         ~kind:Ollama
         ~model_id:"qwen3:8b"
-        ~base_url:"http://127.0.0.1:11434"
+        ~base_url:Constants.Endpoints.ollama_default_url
         ~num_ctx:0
         ()
     in
@@ -650,7 +650,7 @@ let%test "build_request sets think=true when enable_thinking=true" =
       Provider_config.make
         ~kind:Ollama
         ~model_id:"qwen3:8b"
-        ~base_url:"http://127.0.0.1:11434"
+        ~base_url:Constants.Endpoints.ollama_default_url
         ~enable_thinking:true
         ()
     in
@@ -666,7 +666,7 @@ let%test "build_request sets think=false when enable_thinking=false" =
       Provider_config.make
         ~kind:Ollama
         ~model_id:"qwen3:8b"
-        ~base_url:"http://127.0.0.1:11434"
+        ~base_url:Constants.Endpoints.ollama_default_url
         ~enable_thinking:false
         ()
     in
@@ -682,7 +682,7 @@ let%test "build_request maps max_tokens to num_predict in options" =
       Provider_config.make
         ~kind:Ollama
         ~model_id:"qwen3:8b"
-        ~base_url:"http://127.0.0.1:11434"
+        ~base_url:Constants.Endpoints.ollama_default_url
         ~max_tokens:2048
         ()
     in
@@ -706,7 +706,7 @@ let%test
       Provider_config.make
         ~kind:Ollama
         ~model_id:"qwen3:8b"
-        ~base_url:"http://127.0.0.1:11434"
+        ~base_url:Constants.Endpoints.ollama_default_url
         ~top_k:40
         ()
     in

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -172,7 +172,7 @@ let%test "ollama preserves min_p (llama.cpp supports it)" =
     Provider_config.make
       ~kind:Provider_config.Ollama
       ~model_id:"qwen3.5:35b-a3b-nvfp4"
-      ~base_url:"http://127.0.0.1:11434"
+      ~base_url:Constants.Endpoints.ollama_default_url
       ~min_p:0.05
       ()
   in

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -1677,7 +1677,7 @@ let%test "patch_telemetry fills latency and provider on existing telemetry" =
     Provider_config.make
       ~kind:Ollama
       ~model_id:"qwen3.5:9b"
-      ~base_url:"http://localhost:11434"
+      ~base_url:Constants.Endpoints.ollama_default_url
       ()
   in
   let resp =
@@ -1756,7 +1756,7 @@ let%test "patch_telemetry preserves ttfrc_ms/prefill_ms when optional args omitt
     Provider_config.make
       ~kind:Ollama
       ~model_id:"qwen3.5:9b"
-      ~base_url:"http://localhost:11434"
+      ~base_url:Constants.Endpoints.ollama_default_url
       ()
   in
   let resp =
@@ -1794,7 +1794,7 @@ let%test "patch_telemetry overrides ttfrc_ms/prefill_ms when passed as Some" =
     Provider_config.make
       ~kind:Ollama
       ~model_id:"qwen3.5:9b"
-      ~base_url:"http://localhost:11434"
+      ~base_url:Constants.Endpoints.ollama_default_url
       ()
   in
   let resp =
@@ -1852,7 +1852,11 @@ let%test "patch_telemetry fills blank response model" =
 
 let%test "reasoning_effort_of_config Ollama default is none" =
   let config =
-    Provider_config.make ~kind:Ollama ~model_id:"m" ~base_url:"http://localhost:11434" ()
+    Provider_config.make
+      ~kind:Ollama
+      ~model_id:"m"
+      ~base_url:Constants.Endpoints.ollama_default_url
+      ()
   in
   reasoning_effort_of_config config = Some "none"
 ;;
@@ -1862,7 +1866,7 @@ let%test "reasoning_effort_of_config Ollama thinking=true budget=4096 is medium"
     Provider_config.make
       ~kind:Ollama
       ~model_id:"m"
-      ~base_url:"http://localhost:11434"
+      ~base_url:Constants.Endpoints.ollama_default_url
       ~enable_thinking:true
       ~thinking_budget:4096
       ()
@@ -1875,7 +1879,7 @@ let%test "reasoning_effort_of_config Ollama thinking=true budget=16384 is high" 
     Provider_config.make
       ~kind:Ollama
       ~model_id:"m"
-      ~base_url:"http://localhost:11434"
+      ~base_url:Constants.Endpoints.ollama_default_url
       ~enable_thinking:true
       ~thinking_budget:16384
       ()

--- a/lib/llm_provider/constants.ml
+++ b/lib/llm_provider/constants.ml
@@ -162,14 +162,21 @@ end
     constants instead of hardcoding URL literals.
     @since 0.105.0 *)
 module Endpoints = struct
-  (** Default port for llama.cpp servers.
-      Ollama uses 11434 — configure via endpoint config or LLM_ENDPOINTS env. *)
+  (** Default port for llama.cpp servers.  Override per-instance via
+      endpoint config or [LLM_ENDPOINTS] env.  Ollama's port is
+      {!ollama_default_port}. *)
   let default_llama_port = 8085
 
   let default_url = "http://127.0.0.1:" ^ string_of_int default_llama_port
   let default_url_localhost = "http://localhost:" ^ string_of_int default_llama_port
   let local_prefix = "http://127.0.0.1"
   let localhost_prefix = "http://localhost"
+
+  (** Default port for Ollama's OpenAI-compatible / native API server.
+      Override per-instance via endpoint config or [OLLAMA_HOST] env. *)
+  let ollama_default_port = 11434
+
+  let ollama_default_url = "http://127.0.0.1:" ^ string_of_int ollama_default_port
 end
 
 (* ── Thinking ────────────────────────────────────── *)

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -70,7 +70,7 @@ let default_endpoint =
 let ollama_endpoint =
   match Cli_common_env.get "OLLAMA_HOST" with
   | Some url -> url
-  | None -> "http://127.0.0.1:11434"
+  | None -> Constants.Endpoints.ollama_default_url
 ;;
 
 let parse_llm_endpoints_env () =
@@ -460,7 +460,7 @@ let port_of_url (url : string) : int option =
     paths (/api/:11434), and query strings (?p=:11434). *)
 let url_is_ollama (url : string) : bool =
   match port_of_url url with
-  | Some 11434 -> true
+  | Some p when p = Constants.Endpoints.ollama_default_port -> true
   | _ -> String.equal (String.trim url) (String.trim ollama_endpoint)
 ;;
 
@@ -630,7 +630,16 @@ let refresh_and_sync ~sw ~net ~endpoints =
   statuses
 ;;
 
-let default_scan_ports = [ 8085; 8086; 8087; 8088; 8089; 8090; 11434 ]
+let default_scan_ports =
+  [ Constants.Endpoints.default_llama_port
+  ; 8086
+  ; 8087
+  ; 8088
+  ; 8089
+  ; 8090
+  ; Constants.Endpoints.ollama_default_port
+  ]
+;;
 
 let scan_local_endpoints ?(ports = default_scan_ports) ~sw ~net () =
   let candidates = List.map (fun p -> Printf.sprintf "http://127.0.0.1:%d" p) ports in

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -199,7 +199,7 @@ let kimi_defaults =
 
 let ollama_defaults =
   { kind = Ollama
-  ; base_url = env_or_default "OLLAMA_HOST" "http://127.0.0.1:11434"
+  ; base_url = env_or_default "OLLAMA_HOST" Constants.Endpoints.ollama_default_url
   ; api_key_env = ""
   ; request_path = "/api/chat"
   }


### PR DESCRIPTION
## Summary

Follow-up to the closed #557 ("consolidate local endpoint defaults and remove
8080/8085 drift"): #557 added `Constants.Endpoints.default_llama_port` /
`default_url` for the llama.cpp port, but the Ollama default endpoint
(`http://127.0.0.1:11434`) never got the same treatment — the literal was
copy-pasted across `lib/llm_provider/`.

Adds `Constants.Endpoints.ollama_default_port` (= 11434) and
`Constants.Endpoints.ollama_default_url`, and points the scattered sites at
them. No behaviour change: every replaced literal evaluated to the same string.

## What changed

| Site | Kind | Before → After |
|------|------|----------------|
| `constants.ml` `Endpoints` | new | `ollama_default_port = 11434`, `ollama_default_url` |
| `discovery.ml` `ollama_endpoint` (`None` branch) | prod default | literal → `Constants.Endpoints.ollama_default_url` |
| `discovery.ml` `url_is_ollama` | prod | `Some 11434 -> true` → `Some p when p = Constants.Endpoints.ollama_default_port -> true` |
| `discovery.ml` `default_scan_ports` | prod | `[ 8085; …; 11434 ]` → `[ default_llama_port; 8086; …; ollama_default_port ]` |
| `provider_registry.ml` `ollama_defaults.base_url` | prod default | `env_or_default "OLLAMA_HOST" "<literal>"` → `… ollama_default_url` |
| `backend_ollama.ml` ×14, `backend_openai.ml` ×1, `complete.ml` ×6 | test fixtures | `Provider_config.make ~base_url:"<literal>"` → `~base_url:Constants.Endpoints.ollama_default_url` |

**Left as literals (intentional):** `discovery.ml`'s `url_is_ollama` doc comment
(explains the strict-port-match rationale) and the `url_is_ollama` /
`first_discovered_model_id_for_url` inline tests, which exercise the
literal-port-recognition contract with concrete URL strings — a constant there
would weaken the test. `localhost`-variant fixtures in `complete.ml` are
unified onto `ollama_default_url` (`base_url` is incidental in those tests; an
Ollama-localhost constant had no other consumer, so YAGNI — the llama-side
`default_url_localhost` is kept since it may have real consumers).

## Validation

- `scripts/dune-local.sh build lib/`  (agent_sdk typechecks)
- `scripts/dune-local.sh build @check` (exit 0; the pre-existing `examples/*.mli` errors are unrelated — those `.mli` files don't exist on `main`)
- `scripts/dune-local.sh runtest lib/llm_provider/`  (ppx_inline_test `let%test` blocks — pass)
- `ocamlformat --check` clean on all 6 changed files

## Context

- Closes the Ollama-side gap left by #557.
- Found during a hardcoding / anti-pattern audit of `lib/llm_provider/`. The
  four 2026-04-04 sweep issues (#553 unknown provider→local, #555 unknown
  model→$0, #557 endpoint drift, #558 unknown limit→permissive) are otherwise
  genuinely fixed — typed `option`/`Error`, fail-closed, regression `let%test`s
  — this scattered literal was the one residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
