### PR TITLE
fix(hooks): catch user-hook exceptions in invoke / invoke_validated

### DIFF
--- a/lib/base/hooks.ml
+++ b/lib/base/hooks.ml
@@ -395,29 +395,65 @@ let validate_decision ~stage decision =
     Error msg)
 ;;
 
-(** Invoke a hook if present, returning Continue if absent *)
+(* Run a user-supplied hook and capture its decision.  Reserved exceptions
+   ([Out_of_memory], [Stack_overflow], [Eio.Cancel.Cancelled]) propagate;
+   anything else is captured so callers can degrade to [Continue].  This
+   mirrors the context_injector exception-wrap in
+   [Agent_turn.apply_context_injection] so a buggy lifecycle hook cannot
+   abort an agent run. *)
+let try_hook f event =
+  try Ok (f event) with
+  | (Out_of_memory | Stack_overflow | Eio.Cancel.Cancelled _) as e -> raise e
+  | exn -> Error exn
+;;
+
+let warn_hook_raised stage exn =
+  Eio.traceln
+    "[warn] [hooks] user hook for %s raised %s -- treating as Continue"
+    stage
+    (Printexc.to_string exn)
+;;
+
+(** Invoke a hook if present, returning Continue if absent.
+
+    If the hook raises a non-reserved exception, logs a warning via
+    [Eio.traceln] and returns [Continue] rather than propagating; this
+    matches the safety of the tool-path hooks (caught in [Agent_tools])
+    and the context-injector path. *)
 let invoke hook_opt event =
   match hook_opt with
   | None -> Continue
-  | Some f -> f event
+  | Some f ->
+    (match try_hook f event with
+     | Ok decision -> decision
+     | Error exn ->
+       warn_hook_raised (stage_of_event event) exn;
+       Continue)
 ;;
 
 (** Invoke a hook with decision validation.
     If the hook returns an illegal decision for the stage,
-    falls back to [Continue] and calls [on_illegal] (if provided). *)
+    falls back to [Continue] and calls [on_illegal] (if provided).
+    If the hook raises (non-reserved), the exception is logged and
+    [Continue] is returned without invoking [on_illegal] (which is
+    reserved for decision-shape errors, not exceptions). *)
 let invoke_validated ?on_illegal hook_opt event =
   match hook_opt with
   | None -> Continue
   | Some f ->
-    let decision = f event in
     let stage = stage_of_event event in
-    (match validate_decision ~stage decision with
-     | Ok d -> d
-     | Error msg ->
-       (match on_illegal with
-        | Some cb -> cb ~stage ~decision ~msg
-        | None -> ());
-       Continue)
+    (match try_hook f event with
+     | Error exn ->
+       warn_hook_raised stage exn;
+       Continue
+     | Ok decision ->
+       (match validate_decision ~stage decision with
+        | Ok d -> d
+        | Error msg ->
+          (match on_illegal with
+           | Some cb -> cb ~stage ~decision ~msg
+           | None -> ());
+          Continue))
 ;;
 
 (** Compose a single hook slot. [outer] fires first.
@@ -453,4 +489,45 @@ let compose ~outer ~inner =
   ; on_context_compacted =
       compose_hook outer.on_context_compacted inner.on_context_compacted
   }
+;;
+
+(* ── Hook exception safety regression tests ─────────────────── *)
+
+let%test "invoke: hook returning Continue propagates" =
+  let event = BeforeTurn { turn = 0; messages = [] } in
+  match invoke (Some (fun _ -> Continue)) event with
+  | Continue -> true
+  | _ -> false
+;;
+
+let%test "invoke: None hook returns Continue" =
+  let event = BeforeTurn { turn = 0; messages = [] } in
+  match invoke None event with
+  | Continue -> true
+  | _ -> false
+;;
+
+let%test "invoke: raising hook is caught and returns Continue" =
+  let event = BeforeTurn { turn = 0; messages = [] } in
+  let raising _ = failwith "boom" in
+  match invoke (Some raising) event with
+  | Continue -> true
+  | _ -> false
+;;
+
+let%test "invoke_validated: raising hook is caught and returns Continue" =
+  let event = BeforeTurn { turn = 0; messages = [] } in
+  let raising _ = failwith "kaboom" in
+  match invoke_validated (Some raising) event with
+  | Continue -> true
+  | _ -> false
+;;
+
+let%test "invoke_validated: on_illegal is NOT invoked when hook raises" =
+  let event = BeforeTurn { turn = 0; messages = [] } in
+  let raising _ = failwith "kaboom" in
+  let illegal_called = ref false in
+  let on_illegal ~stage:_ ~decision:_ ~msg:_ = illegal_called := true in
+  let _ = invoke_validated ~on_illegal (Some raising) event in
+  not !illegal_called
 ;;


### PR DESCRIPTION
## Summary

`Hooks.invoke` and `Hooks.invoke_validated` (`lib/base/hooks.ml`) previously called the user-supplied callback unguarded — `| Some f -> f event`. If the hook raised, the exception propagated out of the agent run.

This is asymmetric with the rest of OAS:

- **Tool-path hooks** (`pre_tool_use`, `post_tool_use*`, `approval_callback`, `on_tool_error`, `on_error`) are wrapped in `agent_tools.ml:568-583`: a raising hook becomes a `Tool 'X' raised: ...` error result.
- **Context injector** is wrapped in `agent_turn.ml:491-510`: raises a `Log.warn "context_injector raised"` and continues.
- **Turn-lifecycle hooks** (`before_turn`, `before_turn_params`, `after_turn`, `on_stop`, `on_idle*`, `pre_compact`, `post_compact`, `on_context_compacted`) — these all go through `invoke_hook_with_trace` → `Tracing.with_span`, which on exception calls `end_span ~ok:false` and **re-raises**. `pipeline.ml:509-512`'s outer `try` only catches `Raw_trace.Trace_error`, and `agent.ml run_loop` has no outer `with` — so a buggy lifecycle hook killed the agent run with an uncaught OCaml exception.

Now: `try_hook` wraps `f event`. Reserved exceptions (`Out_of_memory`, `Stack_overflow`, `Eio.Cancel.Cancelled`) re-raise unchanged. Anything else is captured, logged via `Eio.traceln "[warn] [hooks] user hook for <stage> raised <exn> -- treating as Continue"`, and the call returns `Continue`. Mirrors the `context_injector` exception-wrap.

## ⚠️ Behavior change — please confirm intent

Today, a raising lifecycle hook *aborts* the agent run. After this PR, it logs and the run continues as if the hook had returned `Continue`.

If "raise = hard-stop" was an intentional contract (i.e., users are expected to use `raise` as a fatal exit instead of returning a `Skip`/`Stop` decision), this PR is the wrong move and the right fix is documenting the contract in `hooks.mli` instead. **Nothing in `hooks.mli`, `examples/hooks_and_guardrails.ml`, the CHANGELOG, or any RFC says "exceptions propagate" or "hooks must not raise"** — so the asymmetry reads as oversight rather than design, but you're the source of truth here.

## What changed

- `lib/base/hooks.ml`: new private `try_hook` + `warn_hook_raised` helpers; `invoke` and `invoke_validated` route through them. Public signatures unchanged — `hooks.mli` not touched.
- `lib/base/hooks.ml`: 5 inline `let%test` regression tests covering propagation of `Continue`, `None` short-circuit, raising hook → `Continue` (the new contract), and that `on_illegal` is not fired when the hook raises (it's reserved for decision-shape errors, not exceptions).

## Reserved exceptions

`Out_of_memory`, `Stack_overflow`, `Eio.Cancel.Cancelled _` — re-raised. These must propagate for the runtime to do its job; the `context_injector` wrap reserves the same set (`agent_turn.ml:504`).

## Validation

- `ocamlformat --check lib/base/hooks.ml` — clean
- `scripts/dune-local.sh build lib/` — exit 0
- `scripts/dune-local.sh runtest lib/base/` — inline tests pass
- 5 new `let%test`: `invoke: Continue propagates`, `invoke: None returns Continue`, `invoke: raising hook → Continue`, `invoke_validated: raising hook → Continue`, `invoke_validated: on_illegal NOT invoked when hook raises`

## Not in scope

- The `lib/agent/agent_trace.ml` `invoke_hook_with_trace` path that wraps hooks in `Tracing.with_span` (which re-raises on exception). This PR fixes the inner `invoke`; the trace wrapper now operates on an already-safe callable so its re-raise is unreachable for hook exceptions. If you want belt-and-suspenders, that's a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
