### PR TITLE
feat(provider): add external provider catalog overlay

### DIFF
--- a/docs/capability-manifest.md
+++ b/docs/capability-manifest.md
@@ -4,6 +4,11 @@ OAS supports an **external JSON capability manifest** that lets operators and
 model deployers describe the capabilities of custom, quantized, or future
 model variants without requiring an OAS code change.
 
+Provider connection metadata is handled separately by
+[`docs/provider-catalog.md`](provider-catalog.md). Use the provider catalog for
+endpoint/auth/transport/default-model facts, and use this capability manifest
+for model-specific feature and limit facts.
+
 ## Why
 
 `Capabilities.for_model_id` uses a built-in prefix table (H12 anti-pattern).

--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -3,6 +3,11 @@
 OAS supports runtime provider registration for third-party LLM endpoints
 (vLLM, TGI, custom inference servers) without modifying the SDK source.
 
+For OpenAI-compatible HTTP providers that only need endpoint/auth/capability
+metadata, prefer the provider catalog first:
+[`docs/provider-catalog.md`](provider-catalog.md). Use `Provider.register_provider`
+when the provider needs custom request construction or response parsing code.
+
 ## Quick Start (v0.27.0+)
 
 ```ocaml

--- a/docs/provider-catalog.md
+++ b/docs/provider-catalog.md
@@ -1,0 +1,196 @@
+# Provider Catalog
+
+OAS supports an external provider catalog for adding or overriding provider
+connection metadata without changing SDK code. This is the provider-side
+companion to `OAS_CAPABILITY_MANIFEST`: capabilities describe what a model can
+do, while the provider catalog describes how a runtime connects to that model.
+
+The catalog is intentionally coordinator-neutral. It must not contain
+downstream orchestration concepts such as domain roles, workflow queues,
+operator-facing UI, or product-specific routing policies. Coordinators may
+project their own configuration into this catalog shape, but OAS only consumes
+generic provider/runtime facts.
+
+## Loading
+
+Set `OAS_PROVIDER_CATALOG` to a JSON file:
+
+```sh
+export OAS_PROVIDER_CATALOG="$HOME/.config/oas/providers.json"
+```
+
+Embedding applications can also install a process-local catalog with
+`Llm_provider.Provider_catalog.set_global`.
+
+Resolution order:
+
+1. Runtime override installed with `Provider_catalog.set_global`
+2. `OAS_PROVIDER_CATALOG`
+3. Built-in provider seed data
+
+Catalog entries overwrite built-in provider ids when ids collide. Aliases are
+registered as additional lookup keys for the same entry.
+
+## Schema
+
+```json
+{
+  "schema_version": 1,
+  "providers": [
+    {
+      "id": "vllm-local",
+      "aliases": ["subscriber-local"],
+      "kind": "openai_compat",
+      "transport": "http",
+      "base_url": "http://127.0.0.1:8000",
+      "request_path": "/v1/chat/completions",
+      "auth": {"type": "none"},
+      "default_model": "local-model",
+      "capabilities_base": "openai_chat",
+      "capabilities": {
+        "max_context_tokens": 131072,
+        "supports_tools": true,
+        "supports_tool_choice": true
+      },
+      "non_interactive": true,
+      "interactive_required": false,
+      "daemon_safe": true
+    }
+  ]
+}
+```
+
+Required fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `schema_version` | integer | Must be `1`. |
+| `providers[].id` | string | Opaque provider id. This is config identity, not a vendor branch in code. |
+
+Important provider fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `kind` | string | Existing wire/runtime kind, for example `openai_compat`, `anthropic`, `gemini`, `codex_cli`. Defaults to `openai_compat`. |
+| `transport` | string | `http`, `cli`, `managed`, or `custom_openai_compat`. |
+| `command` | string | CLI binary name for `transport = "cli"`. Used for availability. |
+| `base_url` | string | HTTP endpoint base URL. |
+| `request_path` | string | Completion request path. Defaults from `kind`. |
+| `auth` | object | Credential mode. See below. |
+| `default_model` | string | Used when a caller selects the provider without a model. |
+| `aliases` | string array | Additional provider ids registered to the same entry. |
+| `capabilities_base` | string | Provider preset from `Capabilities.capabilities_for_provider_label`. |
+| `capabilities` | object | Optional capability overrides. |
+| `non_interactive` | bool | Runtime can run without prompts once credentials exist. |
+| `interactive_required` | bool | Runtime may require browser/login/user interaction at call time. |
+| `daemon_safe` | bool | Runtime is suitable for long-running background processes. |
+| `credential_scope` | string | Human-readable credential scope label. |
+
+Auth modes:
+
+| `auth.type` | Extra field | Use case |
+|---|---|---|
+| `none` | | Local unauthenticated endpoints. |
+| `api_key_env` | `env` | Cloud APIs using an API key environment variable. |
+| `setup_token_env` | `env` | Setup/bootstrap token environment variable. |
+| `cli_cached_login` | | Subscription CLI already logged in locally. |
+| `oauth_cached_login` | | OAuth-backed cached login. |
+| `file` | `path` | Credential file owned by the embedding app. |
+| `exec` | `command` | External credential helper. OAS records availability only; it does not shell out from the catalog loader. |
+
+## Cloud API Example
+
+```json
+{
+  "schema_version": 1,
+  "providers": [
+    {
+      "id": "acme-cloud",
+      "kind": "openai_compat",
+      "transport": "http",
+      "base_url": "https://api.acme.example/v1",
+      "request_path": "/chat/completions",
+      "auth": {"type": "api_key_env", "env": "ACME_API_KEY"},
+      "default_model": "acme-large",
+      "capabilities_base": "openai_chat",
+      "capabilities": {
+        "supports_tools": true,
+        "supports_response_format_json": true
+      },
+      "daemon_safe": true
+    }
+  ]
+}
+```
+
+Use this for OpenAI-compatible cloud providers, hosted vLLM gateways,
+OpenRouter-style aggregators, and private model APIs that already follow the
+chat-completions contract.
+
+## CLI / Subscriber Runtime Example
+
+```json
+{
+  "schema_version": 1,
+  "providers": [
+    {
+      "id": "subscriber-codex",
+      "kind": "codex_cli",
+      "transport": "cli",
+      "command": "codex",
+      "auth": {"type": "cli_cached_login"},
+      "default_model": "auto",
+      "capabilities_base": "codex_cli",
+      "non_interactive": true,
+      "interactive_required": false,
+      "daemon_safe": false,
+      "credential_scope": "local subscription login"
+    }
+  ]
+}
+```
+
+Use this for users who want to consume a local subscription or cached CLI
+login in non-interactive mode. `daemon_safe = false` is a useful default for
+CLI runtimes whose cached login or binary behavior is not guaranteed to be
+stable in a long-running service.
+
+## Capability Overrides
+
+The `capabilities` object accepts the same capability field names used by
+`Capabilities.capabilities`, including:
+
+- `max_context_tokens`, `max_output_tokens`
+- `supports_tools`, `supports_tool_choice`, `supports_parallel_tool_calls`
+- `supports_runtime_mcp_tools`, `supports_runtime_tool_events`
+- `supports_reasoning`, `supports_extended_thinking`, `supports_reasoning_budget`
+- `thinking_control_format`
+- `supports_response_format_json`, `supports_structured_output`
+- `supports_image_input`, `supports_audio_input`, `supports_video_input`
+- `supports_native_streaming`, `supports_system_prompt`
+- `supports_top_k`, `supports_min_p`, `supports_seed`
+- `emits_usage_tokens`, `supported_models`
+
+Model-specific facts should still live in `OAS_CAPABILITY_MANIFEST`. Provider
+catalog capabilities should describe runtime/provider defaults and transport
+constraints.
+
+## External Design References
+
+The catalog shape follows a common pattern in current agent tools:
+
+- Hermes Agent separates primary/fallback providers and provider credentials.
+- OpenClaw exposes model/provider status, auth modes, and fallback chains.
+- OpenAI Agents SDK separates `Model` from `ModelProvider`.
+- Claude Agent SDK supports SDK and CLI-driven agent loops.
+- Google ADK uses provider connectors such as LiteLLM for broad model coverage.
+
+References were checked on 2026-05-12:
+
+- https://hermes-agent.nousresearch.com/docs/user-guide/features/fallback-providers/
+- https://docs.openclaw.ai/concepts/model-failover
+- https://docs.openclaw.ai/cli/models
+- https://docs.openclaw.ai/gateway/authentication
+- https://openai.github.io/openai-agents-js/guides/models/
+- https://code.claude.com/docs/en/agent-sdk
+- https://adk.dev/agents/models/litellm/

--- a/docs/rfc/RFC-OAS-018-provider-model-catalog-externalization.md
+++ b/docs/rfc/RFC-OAS-018-provider-model-catalog-externalization.md
@@ -1,0 +1,199 @@
+# RFC-OAS-018: Provider/Model Catalog Externalization
+
+| | |
+|---|---|
+| Status | Draft |
+| Author | jeong-sik (with Claude analysis) |
+| Created | 2026-05-12 |
+| Target | `agent_sdk` (oas) |
+| Supersedes | PR #1536 (`refactor/ollama-endpoint-constant`, closed as antipattern reinforcement) |
+| Sibling | RFC-OAS-009 (tool name ignorance), RFC-OAS-015 (mutable cleanup), RFC-OAS-016 (mcp optional), RFC-OAS-017 (coordinator-shape leak) |
+
+## 0. Summary
+
+OAS 의 `lib/` 안에 *vendor*, *model name*, *endpoint port*, *capability dispatcher*, *pricing table* 이 source-level 로 박혀 있다. 같은 SDK 가 "MASC 를 모른다" 와 자매 약속인 "Ollama / Qwen / Gemma / Kimi 를 모른다" 가 깨져 있고, *추가 vendor* 마다 core 변이가 강제되는 *closed-sum dispatch* 가 누적 중이다.
+
+본 RFC 는 이 leak 을 *4-phase* 로 외부 catalog 화한다. 한 PR 로 240 사이트 rewrite 는 *명시적 비목표* (CLAUDE.md §Workaround Rejection Bar #3 N-of-M).
+
+## 1. Inventory (line-pinned, 2026-05-12 main `8d8402f6`)
+
+| Surface | Site count | 진단 |
+|---|---|---|
+| Model-name literals in `lib/` | **240** in 25 files | catalog data leak |
+| Hardcoded local-LLM ports (`:11434`, `:8085-8090`) | **85** | endpoint assumption leak |
+| `starts_with` model-string dispatchers in `capabilities.ml` | **35** | CLAUDE.md §Workaround Sig #2 (string classifier) |
+| `Provider_kind.t` closed-sum variants | **11** | extension-by-core-mutation |
+
+Model literal regex: `"(qwen[^"]*|llama-?[0-9][^"]*|gemma-?[0-9][^"]*|claude-[a-z]+-[0-9][^"]*|gpt-[0-9][^"]*|deepseek[^"]*|kimi-[^"]*)"`.
+
+Top-leak files (count per file):
+- `lib/llm_provider/pricing.ml` — 46 literals
+- `lib/llm_provider/discovery.ml` — 28 literals + `:11434` hot path
+- `lib/llm_provider/capabilities.ml` — 23 literals + 35 `starts_with` (1238 LOC, candidate for split)
+- `lib/llm_provider/backend_ollama.ml` — 20 literals
+- `lib/llm_provider/model_meta.ml` — 19 literals (incl. `"qwen3.5-35b"` × 6, `"llama-4-maverick"` × 2)
+- `lib/llm_provider/transport_kimi_cli.ml` — 15 literals
+- `lib/provider.ml` — 13 literals
+- `lib/agent/agent_config.ml` — 2 literals
+- `lib/completion_contract.ml` — 2 literals (`"claude-haiku-4-5-20251001"` × 2)
+
+11 `Provider_kind.t` variants (`lib/llm_provider/provider_kind.ml:9-23`):
+`Anthropic | OpenAI_compat | Ollama | Kimi | Gemini | Glm | DashScope | Claude_code | Gemini_cli | Kimi_cli | Codex_cli`.
+
+### 1.1 Concrete leak examples
+
+```ocaml
+(* lib/llm_provider/model_meta.ml:82  — test embeds vendor+size *)
+let%test "qwen3.5-35b inferred as cloud" =
+  let m = for_model_id "qwen3.5-35b" in
+  ...
+
+(* lib/llm_provider/capabilities.ml:434+  — 35 starts_with branches *)
+else if starts_with "qwen3"   ...
+else if starts_with "llama-4" || starts_with "llama4" ...
+else if starts_with "gemma-4" ...
+
+(* lib/llm_provider/capabilities.ml:590  — size token list *)
+[ "27b"; "31b" ] |> List.exists (fun sz -> String.equal token sz)
+
+(* lib/llm_provider/discovery.ml:73, :633  — port assumption *)
+| None -> "http://127.0.0.1:11434"
+let default_scan_ports = [ 8085; 8086; 8087; 8088; 8089; 8090; 11434 ]
+
+(* lib/llm_provider/discovery.ml:455-463  — Ollama recognition by port *)
+let url_is_ollama url = match port url with Some 11434 -> true | _ -> ...
+```
+
+## 2. Non-goals (명시적 거부)
+
+- 한 PR 로 240 사이트 fix — N-of-M 함정.
+- `starts_with` 분류기를 더 정교하게 만드는 보강 — string 분류기 #2.
+- Provider_kind 에 새 variant 추가 (`XAI`, `Mistral` 등) — 동일 패턴 누적. 본 RFC 합의 전 PR 거부.
+- compile-time embedded JSON (`[%blob "models.json"]`) — 결과적으로 lib 안에 다시 박힘. 거부.
+- prefix dispatcher 에 hex/glob lint 추가하는 "guard" PR — RFC-OAS-precedent (RFC-OAS-009 등) 가 advisory 였음에도 본 RFC 는 *데이터 자체* 를 옮기는 것이지 *문자열 검사 를 강화* 하는 것이 아님.
+
+## 3. Goal — typed catalog interface
+
+```ocaml
+(* lib/llm_provider/catalog_intf.mli — Phase 0 *)
+module type CATALOG = sig
+  type t
+
+  type entry =
+    { provider_tag : string  (* opaque — e.g. "anthropic", "ollama-local-1" *)
+    ; capabilities : Capabilities.capabilities
+    ; pricing : Pricing.pricing
+    ; locality : [ `Local | `Remote ]
+    ; max_context_tokens : int
+    ; max_output_tokens : int
+    ; params_millions : int option  (* "27b" -> 27_000 *)
+    }
+
+  val lookup : t -> model_id:string -> entry option
+  val provider_endpoints : t -> tag:string -> string list
+end
+```
+
+SDK 핵심 가정:
+- Catalog 채우는 책임은 *SDK 밖*: user config TOML (production), in-memory fixture (test), example asset (demo).
+- `lookup` 결과 `None` → typed `Unknown_model of string` 에러 fail-closed. PR #1539 의 `unpriced_model : string option` 은 본 RFC 의 *partial path* — Phase 2 에서 typed error 로 승급.
+- `Provider.t` 는 abstract; *closed sum 제거*. 호출자는 capability flags 와 transport 종류로 판단, vendor name 으로 분기하지 않음.
+
+## 4. Phases (each = own PR, own gate)
+
+### Phase 0 — Foundations
+- 본 RFC 머지.
+- `lib/llm_provider/catalog_intf.mli` (interface only, 구현 0). 본 RFC 머지 직후 stub PR.
+- `docs/rfc/oas-018/inventory.md` 에 240 사이트 file:line 고정 (drift 감지 baseline).
+- **G0**: `catalog_intf.mli` 추가, lib 동작 0 변경.
+
+### Phase 1 — Catalog provider parallel, prefix dispatch survives
+- `lib/llm_provider/catalog_toml.ml` (TOML 로더), `lib/llm_provider/catalog_default.ml` (in-memory minimal default).
+- `Capabilities.for_model_id` / `Pricing.pricing_for_model` 는 *Catalog lookup 우선, miss 시 기존 prefix dispatch fallback*.
+- **G1**: 기존 240 사이트 *그대로*. 새 catalog path 가 read-side 에 옵션적으로 합류. 모든 기존 test green.
+
+### Phase 2 — Catalog primary, prefix dispatch deprecated
+- `Capabilities.for_model_id` 의 prefix 갈래를 `[@@deprecated "RFC-OAS-018 Phase 2"]`.
+- 새 `Catalog_only.for_model_id` 가 production primary.
+- 기존 `pricing_for_model` zero-default 제거 (PR #1539 의 `unpriced_model` 길과 통합 → `result` 반환).
+- **G2**: Phase 1 fallback path 가 *read-only*. 새 코드는 catalog 만 사용 (lint).
+
+### Phase 3 — Prefix dispatch removal + Provider_kind narrowing
+- `capabilities.ml:434-590` (35 starts_with) 삭제. `model_meta.ml:82-200` test 도 catalog fixture 로 교체.
+- `Provider_kind.t` narrow:
+  ```ocaml
+  type t =
+    | Anthropic                       (* native protocol *)
+    | OpenAI_compat of { vendor : string }   (* opaque tag — replaces Ollama/Kimi/Gemini/Glm/DashScope/OpenAI_compat *)
+    | Gemini_native                   (* protocol family, not vendor *)
+    | Cli_subprocess of { kind : string }    (* replaces Claude_code/Gemini_cli/Kimi_cli/Codex_cli *)
+  ```
+  11 → 4 variants. capability 차이는 catalog 에 위임.
+- **G3 lint**: lib/ 에서 `qwen|llama-|gemma-|gpt-|claude-[a-z]+-[0-9]|deepseek|kimi-` 검색 0건 (RFC artifacts 와 catalog loader 제외).
+
+### Phase 4 — Endpoint discovery decoupling
+- `discovery.ml:633 default_scan_ports` → user config (`OAS_DISCOVERY_PORTS=8085,8090,...`) + fixture default.
+- `discovery.ml:73, :455-463` 의 `:11434` 인식 함수 제거. provider 식별은 *capability handshake* (e.g. `/api/tags` GET 결과의 schema) 로 대체.
+- **G4 lint**: lib/ 에서 `:11434|:8085|:8086|:8087|:8088|:8089|:8090` literal 0건.
+
+## 5. Drift guards (CI lint)
+
+`scripts/check-sdk-vocabulary.sh` 신설 (RFC-OAS-009 SDK independence gate 자매):
+
+```bash
+# Phase 별 staged enforcement
+PHASE_GATE="${OAS_VOCAB_PHASE:-0}"
+case "$PHASE_GATE" in
+  0) MODE=warn ;;
+  1) MODE=warn ;;
+  2) MODE=warn ;;
+  3) MODE=error  # G3
+     PATTERN_MODEL='qwen|llama-|gemma-|gpt-[0-9]|claude-[a-z]+-[0-9]|deepseek|kimi-'
+     ;;
+  4) MODE=error  # G4 includes G3
+     PATTERN_PORT=':11434|:808[5-9]|:8090'
+     ;;
+esac
+# Allow-list: lib/llm_provider/catalog_*, docs/, assets/
+```
+
+이 가드는 *데이터 가 옮겨갔는지* 검사하는 것이지 *문자열 검사로 fix 한다* 가 아니다 (CLAUDE.md feedback: lint with hardcoded phrase list ≠ structural — 본 가드의 structural 부분은 *데이터 분리 가 끝났는가* 의 *증거* 로만 동작).
+
+## 6. Backward compatibility
+
+- Phase 1 동안 catalog 미설정 사용자 → fallback (기존 동작 유지).
+- Phase 3 cutover 직전 minor release 에 README + CHANGELOG 명시.
+- `assets/catalog_defaults.toml` 을 example 로 추가 (compiled-in 아닌 *문서 자산*).
+- `Provider_kind_legacy.t` alias 를 한 minor (`0.200.x`) 동안 유지 후 제거.
+
+## 7. Open questions
+
+- Catalog 파일 위치: `$XDG_CONFIG_HOME/oas/catalog.toml` 우선, fallback `./oas-catalog.toml`. RFC-OAS-016 (MCP optional config) 와 같은 convention 채택.
+- Size token (`27b`, `31b`) → `params_millions : int option` 으로 일반화. 모델별 사이즈 variant 는 catalog entry id 로 표현.
+- Multi-generation drift (같은 `claude-haiku-4-5` 가 시점에 따라 capability 변경) → 본 RFC scope 밖, RFC-OAS-019 후보.
+- Catalog hot-reload (server 재기동 없이 reload) → Phase 4 후 별도 RFC.
+
+## 8. Non-blocking dependencies
+
+- PR #1539 (`max_cost_usd` unpriced model fail-closed) — Phase 2 에서 typed `Unknown_model` 로 흡수, 그 전까지는 호환.
+- RFC-OAS-016 (mcp optional) — 외부화 패턴 동일, coherent.
+- RFC-OAS-017 (coordinator-shape) — 직접 의존성 없음.
+- RFC-OAS-015 (mutable cleanup) — 직접 의존성 없음.
+
+## 9. Verification / Exit criteria
+
+| Phase | Exit gate |
+|---|---|
+| 0 | `catalog_intf.mli` 머지, inventory.md 머지, lib 동작 byte-for-byte 동일 |
+| 1 | catalog loader + fallback, 기존 test 100% green, 새 catalog 테스트 alcotest suite 1개 |
+| 2 | prefix dispatch `[@@deprecated]`, 모든 lib 호출 catalog 경유 (call-site lint) |
+| 3 | lib/ 에 모델 family literal 0건, Provider_kind 4 variants |
+| 4 | lib/ 에 hardcoded `:11434` 등 0건, endpoint discovery user-config-driven |
+
+## 10. References
+
+- CLAUDE.md §Workaround Rejection Bar — signatures #2 (string classifier) + #3 (N-of-M)
+- RFC-OAS-009 — tool name ignorance (자매 가드: vocabulary independence)
+- RFC-OAS-015 — mutable cleanup phased precedent
+- RFC-OAS-016 — mcp optional dependency (외부화 패턴 자매)
+- 측정 명령: `rg '"(qwen[^"]*|llama-?[0-9][^"]*|gemma-?[0-9][^"]*|claude-[a-z]+-[0-9][^"]*|gpt-[0-9][^"]*|deepseek[^"]*|kimi-[^"]*)"' lib/ | wc -l` → 240 (2026-05-12 main `8d8402f6`)

--- a/docs/sdk-independence-principle.md
+++ b/docs/sdk-independence-principle.md
@@ -36,6 +36,11 @@ adapt to any specific coordinator.
    responsibilities. OAS may expose neutral runtime events and protocol fields
    that such systems observe, but it must not own their coordination model.
 
+6. **Provider catalogs stay generic.** `OAS_PROVIDER_CATALOG` entries may
+   describe provider ids, transport, auth mode, endpoint, default model, and
+   capabilities. They must not encode coordinator-owned routing concepts such
+   as keeper, room, tier-group, board, governance queue, or dashboard policy.
+
 ## Module ownership (this repository only)
 
 This table is restricted to OAS-owned modules. Whatever a downstream

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -1,0 +1,594 @@
+(** External provider catalog overlay. *)
+
+type transport =
+  | Http
+  | Cli
+  | Managed
+  | Custom_openai_compat
+[@@deriving show]
+
+type auth_mode =
+  | No_auth
+  | Api_key_env of string
+  | Cli_cached_login
+  | Oauth_cached_login
+  | Setup_token_env of string
+  | File of string
+  | Exec of string
+[@@deriving show]
+
+type entry =
+  { id : string
+  ; aliases : string list
+  ; kind : Provider_config.provider_kind
+  ; transport : transport
+  ; command : string option
+  ; base_url : string
+  ; request_path : string
+  ; api_key_env : string
+  ; auth : auth_mode
+  ; default_model : string option
+  ; max_context : int option
+  ; capabilities : Capabilities.capabilities
+  ; non_interactive : bool
+  ; interactive_required : bool
+  ; daemon_safe : bool
+  ; credential_scope : string option
+  }
+
+type t = entry list
+
+let json_kind = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+;;
+
+let warn_type_mismatch key ~expected actual =
+  match actual with
+  | `Null -> ()
+  | _ ->
+    Diag.warn
+      "provider_catalog"
+      "ignoring field %S: expected %s, got %s"
+      key
+      expected
+      (json_kind actual)
+;;
+
+let member key json = Yojson.Safe.Util.member key json
+
+let member_string key json =
+  match member key json with
+  | `String s -> Some s
+  | actual ->
+    warn_type_mismatch key ~expected:"string" actual;
+    None
+;;
+
+let member_string_default key ~default json =
+  match member_string key json with
+  | Some s -> s
+  | None -> default
+;;
+
+let member_bool key json =
+  match member key json with
+  | `Bool b -> Some b
+  | actual ->
+    warn_type_mismatch key ~expected:"bool" actual;
+    None
+;;
+
+let member_bool_default key ~default json =
+  match member_bool key json with
+  | Some b -> b
+  | None -> default
+;;
+
+let member_int key json =
+  match member key json with
+  | `Int n -> Some n
+  | `Intlit s ->
+    (match int_of_string_opt s with
+     | Some n -> Some n
+     | None ->
+       Diag.warn
+         "provider_catalog"
+         "ignoring field %S: integer literal %S out of native int range"
+         key
+         s;
+       None)
+  | actual ->
+    warn_type_mismatch key ~expected:"int" actual;
+    None
+;;
+
+let member_string_list key json =
+  match member key json with
+  | `List items ->
+    Some
+      (List.filter_map
+         (function
+           | `String s when String.trim s <> "" -> Some (String.trim s)
+           | actual ->
+             warn_type_mismatch key ~expected:"string list" actual;
+             None)
+         items)
+  | `Null -> None
+  | actual ->
+    warn_type_mismatch key ~expected:"array" actual;
+    None
+;;
+
+let parse_transport = function
+  | None -> None
+  | Some raw ->
+    (match String.lowercase_ascii (String.trim raw) with
+     | "http" -> Some Http
+     | "cli" -> Some Cli
+     | "managed" -> Some Managed
+     | "custom_openai_compat" | "custom-openai-compat" | "openai_compat" ->
+       Some Custom_openai_compat
+     | other ->
+       Diag.warn "provider_catalog" "unknown transport %S; treating as http" other;
+       Some Http)
+;;
+
+let default_transport_for_kind kind =
+  if Provider_kind.is_subprocess_cli kind then Cli else Http
+;;
+
+let auth_env = function
+  | Api_key_env env | Setup_token_env env -> env
+  | No_auth | Cli_cached_login | Oauth_cached_login | File _ | Exec _ -> ""
+;;
+
+let parse_auth json =
+  match member "auth" json with
+  | `Assoc _ as auth_json ->
+    let auth_type =
+      member_string_default "type" ~default:"none" auth_json
+      |> String.trim
+      |> String.lowercase_ascii
+    in
+    let env =
+      match member_string "env" auth_json with
+      | Some v -> v
+      | None -> member_string_default "key" ~default:"" auth_json
+    in
+    (match auth_type with
+     | "none" -> No_auth
+     | "api_key_env" | "api-key-env" | "env" -> Api_key_env env
+     | "setup_token_env" | "setup-token-env" -> Setup_token_env env
+     | "cli_cached_login" | "cli-cached-login" -> Cli_cached_login
+     | "oauth_cached_login" | "oauth-cached-login" -> Oauth_cached_login
+     | "file" -> File (member_string_default "path" ~default:"" auth_json)
+     | "exec" -> Exec (member_string_default "command" ~default:"" auth_json)
+     | other ->
+       Diag.warn "provider_catalog" "unknown auth type %S; treating as none" other;
+       No_auth)
+  | _ ->
+    (match member_string "api_key_env" json with
+     | Some env when String.trim env <> "" -> Api_key_env env
+     | _ -> No_auth)
+;;
+
+let parse_thinking_control_format = function
+  | None -> None
+  | Some raw ->
+    (match String.lowercase_ascii (String.trim raw) with
+     | "none" | "no_thinking_control" | "no-thinking-control" ->
+       Some Capabilities.No_thinking_control
+     | "thinking_object" | "thinking-object" -> Some Capabilities.Thinking_object
+     | "chat_template_kwargs" | "chat-template-kwargs" ->
+       Some Capabilities.Chat_template_kwargs
+     | other ->
+       Diag.warn
+         "provider_catalog"
+         "unknown thinking_control_format %S; inheriting base"
+         other;
+       None)
+;;
+
+let member_supported_models json = member_string_list "supported_models" json
+
+let capability_base json =
+  let label =
+    match member_string "capabilities_base" json with
+    | Some v -> Some v
+    | None -> member_string "base" json
+  in
+  match label with
+  | Some raw ->
+    (match Capabilities.capabilities_for_provider_label raw with
+     | Some caps -> caps
+     | None ->
+       Diag.warn
+         "provider_catalog"
+         "unknown capabilities_base %S; using default capabilities"
+         raw;
+       Capabilities.default_capabilities)
+  | None -> Capabilities.default_capabilities
+;;
+
+let override_bool key caps f json =
+  match member_bool key json with
+  | Some v -> f caps v
+  | None -> caps
+;;
+
+let override_int_opt key caps f json =
+  match member_int key json with
+  | Some v -> f caps (Some v)
+  | None -> caps
+;;
+
+let parse_capabilities provider_json =
+  let cap_json =
+    match member "capabilities" provider_json with
+    | `Assoc _ as v -> v
+    | _ -> provider_json
+  in
+  let base = capability_base provider_json in
+  let caps =
+    base
+    |> fun caps ->
+    override_int_opt
+      "max_context_tokens"
+      caps
+      (fun caps v -> { caps with Capabilities.max_context_tokens = v })
+      cap_json
+    |> fun caps ->
+    override_int_opt
+      "max_output_tokens"
+      caps
+      (fun caps v -> { caps with Capabilities.max_output_tokens = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_tools"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_tools = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_tool_choice"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_tool_choice = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_parallel_tool_calls"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_parallel_tool_calls = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_runtime_mcp_tools"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_runtime_mcp_tools = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_runtime_tool_events"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_runtime_tool_events = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_reasoning"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_reasoning = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_extended_thinking"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_extended_thinking = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_reasoning_budget"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_reasoning_budget = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_response_format_json"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_response_format_json = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_structured_output"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_structured_output = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_multimodal_inputs"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_multimodal_inputs = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_image_input"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_image_input = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_audio_input"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_audio_input = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_video_input"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_video_input = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_native_streaming"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_native_streaming = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_system_prompt"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_system_prompt = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_caching"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_caching = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_prompt_caching"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_prompt_caching = v })
+      cap_json
+    |> fun caps ->
+    override_int_opt
+      "prompt_cache_alignment"
+      caps
+      (fun caps v -> { caps with Capabilities.prompt_cache_alignment = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_top_k"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_top_k = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_min_p"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_min_p = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_seed"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_seed = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_seed_with_images"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_seed_with_images = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_computer_use"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_computer_use = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "supports_code_execution"
+      caps
+      (fun caps v -> { caps with Capabilities.supports_code_execution = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "is_ollama"
+      caps
+      (fun caps v -> { caps with Capabilities.is_ollama = v })
+      cap_json
+    |> fun caps ->
+    override_bool
+      "emits_usage_tokens"
+      caps
+      (fun caps v -> { caps with Capabilities.emits_usage_tokens = v })
+      cap_json
+  in
+  let caps =
+    match parse_thinking_control_format (member_string "thinking_control_format" cap_json) with
+    | Some thinking_control_format -> { caps with Capabilities.thinking_control_format }
+    | None -> caps
+  in
+  match member_supported_models cap_json with
+  | Some models -> { caps with Capabilities.supported_models = Some models }
+  | None -> caps
+;;
+
+let parse_entry json =
+  match member_string "id" json with
+  | None -> Error "provider entry missing required \"id\" field"
+  | Some id ->
+    let id = String.trim id in
+    if id = ""
+    then Error "provider entry has empty \"id\" field"
+    else
+      let kind_raw = member_string_default "kind" ~default:"openai_compat" json in
+      (match Provider_kind.of_string kind_raw with
+       | None -> Error (Printf.sprintf "provider %S has unknown kind %S" id kind_raw)
+       | Some kind ->
+         let auth = parse_auth json in
+         let api_key_env =
+           match member_string "api_key_env" json with
+           | Some env -> env
+           | None -> auth_env auth
+         in
+         let transport =
+           match parse_transport (member_string "transport" json) with
+           | Some transport -> transport
+           | None -> default_transport_for_kind kind
+         in
+         let interactive_required =
+           member_bool_default "interactive_required" ~default:false json
+         in
+         let non_interactive =
+           member_bool_default
+             "non_interactive"
+             ~default:(not interactive_required)
+             json
+         in
+         let daemon_safe =
+           member_bool_default
+             "daemon_safe"
+             ~default:(non_interactive && not interactive_required)
+             json
+         in
+         let capabilities = parse_capabilities json in
+         let max_context =
+           match member_int "max_context" json with
+           | Some _ as v -> v
+           | None -> capabilities.Capabilities.max_context_tokens
+         in
+         Ok
+           { id
+           ; aliases = Option.value (member_string_list "aliases" json) ~default:[]
+           ; kind
+           ; transport
+           ; command = member_string "command" json
+           ; base_url = member_string_default "base_url" ~default:"" json
+           ; request_path =
+               member_string_default
+                 "request_path"
+                 ~default:(Provider_config.request_path_default_for_kind kind)
+                 json
+           ; api_key_env
+           ; auth
+           ; default_model = member_string "default_model" json
+           ; max_context
+           ; capabilities
+           ; non_interactive
+           ; interactive_required
+           ; daemon_safe
+           ; credential_scope = member_string "credential_scope" json
+           })
+;;
+
+let of_json json =
+  let schema_version =
+    match member "schema_version" json with
+    | `Int n -> n
+    | _ -> 0
+  in
+  if schema_version <> 1
+  then
+    Error
+      (Printf.sprintf
+         "unsupported provider catalog schema_version: %d (expected 1)"
+         schema_version)
+  else (
+    let items =
+      match member "providers" json with
+      | `List xs -> xs
+      | _ -> []
+    in
+    let results = List.map parse_entry items in
+    let errors =
+      List.filter_map
+        (function
+          | Error e -> Some e
+          | Ok _ -> None)
+        results
+    in
+    if errors <> []
+    then Error (String.concat "; " errors)
+    else
+      Ok
+        (List.filter_map
+           (function
+             | Ok e -> Some e
+             | Error _ -> None)
+           results))
+;;
+
+let load_file path =
+  let read_result =
+    try Ok (Yojson.Safe.from_file path) with
+    | Sys_error msg ->
+      Error (Printf.sprintf "cannot read provider catalog %s: %s" path msg)
+    | Yojson.Json_error msg ->
+      Error (Printf.sprintf "provider catalog JSON parse error in %s: %s" path msg)
+  in
+  Result.bind read_result of_json
+;;
+
+let load_runtime_file path =
+  match load_file path with
+  | Ok catalog ->
+    Diag.info
+      "provider_catalog"
+      "loaded %d provider entries from %s"
+      (List.length catalog)
+      path;
+    Some catalog
+  | Error msg ->
+    Diag.warn "provider_catalog" "failed to load %s: %s" path msg;
+    None
+;;
+
+let normalize_id s = String.lowercase_ascii (String.trim s)
+
+let lookup t provider_id =
+  let needle = normalize_id provider_id in
+  List.find_opt
+    (fun entry ->
+       normalize_id entry.id = needle
+       || List.exists (fun alias -> normalize_id alias = needle) entry.aliases)
+    t
+;;
+
+let default_model_for_provider t provider_id =
+  match lookup t provider_id with
+  | Some entry -> entry.default_model
+  | None -> None
+;;
+
+let env_loaded_catalog : t option Lazy.t =
+  lazy
+    (match Cli_common_env.get "OAS_PROVIDER_CATALOG" with
+     | None -> None
+     | Some path -> load_runtime_file path)
+;;
+
+let runtime_override : t option Atomic.t = Atomic.make None
+let set_global t = Atomic.set runtime_override (Some t)
+let clear_global () = Atomic.set runtime_override None
+
+let global () =
+  match Atomic.get runtime_override with
+  | Some _ as v -> v
+  | None ->
+    let env_value = Lazy.force env_loaded_catalog in
+    (match Atomic.get runtime_override with
+     | Some _ as v -> v
+     | None -> env_value)
+;;

--- a/lib/llm_provider/provider_catalog.mli
+++ b/lib/llm_provider/provider_catalog.mli
@@ -1,0 +1,90 @@
+(** External provider catalog overlay.
+
+    Provider entries describe connection and runtime metadata without teaching
+    OAS about any downstream coordinator. The catalog augments
+    {!Provider_registry.default}: built-in entries remain as seed data, while
+    file/runtime catalog entries overwrite or add provider ids at process
+    startup.
+
+    @since 0.194.0 *)
+
+type transport =
+  | Http
+  | Cli
+  | Managed
+  | Custom_openai_compat
+[@@deriving show]
+
+type auth_mode =
+  | No_auth
+  | Api_key_env of string
+  | Cli_cached_login
+  | Oauth_cached_login
+  | Setup_token_env of string
+  | File of string
+  | Exec of string
+[@@deriving show]
+
+type entry =
+  { id : string
+  ; aliases : string list
+  ; kind : Provider_config.provider_kind
+  ; transport : transport
+  ; command : string option
+  ; base_url : string
+  ; request_path : string
+  ; api_key_env : string
+  ; auth : auth_mode
+  ; default_model : string option
+  ; max_context : int option
+  ; capabilities : Capabilities.capabilities
+  ; non_interactive : bool
+  ; interactive_required : bool
+  ; daemon_safe : bool
+  ; credential_scope : string option
+  }
+
+type t = entry list
+
+(** Parse a provider catalog JSON document.
+
+    Expected top-level shape:
+
+    {[
+      {
+        "schema_version": 1,
+        "providers": [
+          {
+            "id": "vllm-local",
+            "kind": "openai_compat",
+            "transport": "http",
+            "base_url": "http://127.0.0.1:8000",
+            "request_path": "/v1/chat/completions",
+            "auth": {"type": "none"},
+            "capabilities_base": "openai_chat",
+            "capabilities": {"supports_tools": true}
+          }
+        ]
+      }
+    ]} *)
+val of_json : Yojson.Safe.t -> (t, string) result
+
+val load_file : string -> (t, string) result
+val load_runtime_file : string -> t option
+
+(** Find an entry by id or alias. *)
+val lookup : t -> string -> entry option
+
+(** Return an entry's explicit default model by id or alias. *)
+val default_model_for_provider : t -> string -> string option
+
+(** Process-wide catalog overlay.
+
+    Resolution order:
+    + 1. runtime override installed with {!set_global}
+    + 2. [OAS_PROVIDER_CATALOG] JSON file, loaded lazily once
+    + 3. no overlay *)
+val global : unit -> t option
+
+val set_global : t -> unit
+val clear_global : unit -> unit

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -54,6 +54,67 @@ let command_in_path ?path name =
     |> List.exists (fun candidate -> is_runnable_path (Filename.concat dir candidate)))
 ;;
 
+let catalog_command_available (entry : Provider_catalog.entry) =
+  match entry.transport, entry.command with
+  | Provider_catalog.Cli, Some command when String.trim command <> "" ->
+    command_in_path command
+  | Provider_catalog.Cli, _ -> false
+  | Provider_catalog.Http, _
+  | Provider_catalog.Managed, _
+  | Provider_catalog.Custom_openai_compat, _ -> true
+;;
+
+let catalog_auth_available (entry : Provider_catalog.entry) =
+  match entry.auth with
+  | Provider_catalog.Api_key_env env | Provider_catalog.Setup_token_env env ->
+    has_api_key env
+  | Provider_catalog.No_auth -> true
+  | Provider_catalog.Cli_cached_login | Provider_catalog.Oauth_cached_login -> true
+  | Provider_catalog.File path -> String.trim path <> "" && Sys.file_exists path
+  | Provider_catalog.Exec command -> String.trim command <> ""
+;;
+
+let catalog_entry_available entry =
+  catalog_command_available entry && catalog_auth_available entry
+;;
+
+let register_catalog_entry t (entry : Provider_catalog.entry) =
+  let max_context =
+    match entry.max_context, entry.capabilities.Capabilities.max_context_tokens with
+    | Some n, _ when n > 0 -> n
+    | _, Some n when n > 0 -> n
+    | _ -> 128_000
+  in
+  let defaults : provider_defaults =
+    { kind = entry.kind
+    ; base_url = entry.base_url
+    ; api_key_env = entry.api_key_env
+    ; request_path = entry.request_path
+    }
+  in
+  let register_name name =
+    let name = String.lowercase_ascii (String.trim name) in
+    if name <> ""
+    then
+      register
+        t
+        { name
+        ; defaults
+        ; max_context
+        ; capabilities = entry.capabilities
+        ; is_available = (fun () -> catalog_entry_available entry)
+        }
+  in
+  register_name entry.id;
+  List.iter register_name entry.aliases
+;;
+
+let overlay_provider_catalog t =
+  match Provider_catalog.global () with
+  | None -> ()
+  | Some entries -> List.iter (register_catalog_entry t) entries
+;;
+
 (** Initial endpoints from LLM_ENDPOINTS env var.
     Falls back to [[Discovery.default_endpoint]] when the variable is
     unset or has no non-empty entries (SSOT: see
@@ -415,6 +476,7 @@ let default () =
     ; capabilities = Capabilities.codex_cli_capabilities
     ; is_available = codex_cli_available
     };
+  overlay_provider_catalog t;
   t
 ;;
 

--- a/lib/llm_provider/provider_registry.mli
+++ b/lib/llm_provider/provider_registry.mli
@@ -59,7 +59,11 @@ val command_in_path : ?path:string -> string -> bool
     non-interactive CLI transports ([claude_code], [gemini_cli],
     [kimi], [kimi_cli], [codex_cli], and compat alias [cc]).
     Availability is determined by API-key env vars for direct providers
-    and PATH discovery for CLI transports. *)
+    and PATH discovery for CLI transports.
+
+    If [OAS_PROVIDER_CATALOG] or {!Provider_catalog.set_global} supplies
+    entries, those entries are overlaid last and may add or replace provider
+    ids without changing SDK code. *)
 val default : unit -> t
 
 (** Best-effort canonical provider name for a concrete provider config.

--- a/lib/runtime_server_resolve.ml
+++ b/lib/runtime_server_resolve.ml
@@ -35,6 +35,98 @@ let provider_runtime_name selected (cfg : Provider.config option) =
      | Provider.Custom_registered { name } -> "custom:" ^ name)
 ;;
 
+let registry_valid_provider_detail registry =
+  let names =
+    Llm_provider.Provider_registry.all registry
+    |> List.map (fun (entry : Llm_provider.Provider_registry.entry) -> entry.name)
+    |> List.sort_uniq String.compare
+  in
+  let names = "local" :: names in
+  let names =
+    if Defaults.allow_test_providers () then "mock" :: "echo" :: names else names
+  in
+  String.concat ", " (List.sort_uniq String.compare names)
+;;
+
+let provider_config_of_registry_entry
+      ~provider_name
+      ~model_id
+      (entry : Llm_provider.Provider_registry.entry)
+  =
+  match entry.defaults.kind with
+  | Llm_provider.Provider_config.Anthropic ->
+    { Provider.provider = Provider.Anthropic
+    ; model_id
+    ; api_key_env = entry.defaults.api_key_env
+    }
+  | Llm_provider.Provider_config.OpenAI_compat ->
+    { Provider.provider =
+        Provider.OpenAICompat
+          { base_url = entry.defaults.base_url
+          ; auth_header =
+              (if String.trim entry.defaults.api_key_env = ""
+               then None
+               else Some "Authorization")
+          ; path = entry.defaults.request_path
+          ; static_token = None
+          }
+    ; model_id
+    ; api_key_env = entry.defaults.api_key_env
+    }
+  | _ ->
+    { Provider.provider = Provider.Custom_registered { name = provider_name }
+    ; model_id
+    ; api_key_env = entry.defaults.api_key_env
+    }
+;;
+
+let catalog_default_model provider_name =
+  match Llm_provider.Provider_catalog.global () with
+  | None -> None
+  | Some catalog -> Llm_provider.Provider_catalog.default_model_for_provider catalog provider_name
+;;
+
+let effective_model_id ~provider_name ~entry ?model () =
+  match model with
+  | Some value when String.trim value <> "" -> value
+  | _ ->
+    (match catalog_default_model provider_name with
+     | Some model_id when String.trim model_id <> "" -> model_id
+     | _ ->
+       (match entry.Llm_provider.Provider_registry.defaults.kind with
+        | Llm_provider.Provider_config.Ollama -> "default"
+        | _ -> Model_registry.default_model_id))
+;;
+
+let resolve_from_registry registry ~provider_name ?model () =
+  match Llm_provider.Provider_registry.find registry provider_name with
+  | Some entry ->
+    let model_id = effective_model_id ~provider_name ~entry ?model () in
+    Ok (Some (provider_config_of_registry_entry ~provider_name ~model_id entry))
+  | None ->
+    let resolved_model = Model_registry.resolve_model_id provider_name in
+    if not (String.equal resolved_model provider_name)
+    then (
+      match Llm_provider.Provider_registry.find registry "claude" with
+      | Some entry ->
+        Ok
+          (Some
+             (provider_config_of_registry_entry
+                ~provider_name:"claude"
+                ~model_id:resolved_model
+                entry))
+      | None ->
+        unsupported_provider
+          "provider alias resolved to an Anthropic model but provider catalog has no \
+           \"claude\" entry")
+    else
+      unsupported_provider
+        (Printf.sprintf
+           "unknown provider %S; valid: %s"
+           provider_name
+           (registry_valid_provider_detail registry))
+;;
+
 let resolve_provider ?provider ?model () =
   let selected =
     match provider with
@@ -42,22 +134,14 @@ let resolve_provider ?provider ?model () =
       String.lowercase_ascii (String.trim value)
     | _ -> Defaults.fallback_provider
   in
+  let registry = Llm_provider.Provider_registry.default () in
   let base =
     match selected with
     | "mock" | "echo" ->
       let* () = ensure_test_provider_enabled selected in
       Ok None
     | "local" -> Ok (Some (Provider.local_llm ()))
-    | "sonnet" -> Ok (Some (Provider.anthropic_sonnet ()))
-    | "haiku" -> Ok (Some (Provider.anthropic_haiku ()))
-    | "opus" -> Ok (Some (Provider.anthropic_opus ()))
-    | "openrouter" -> Ok (Some (Provider.openrouter ()))
-    | other ->
-      unsupported_provider
-        (Printf.sprintf
-           "unknown provider %S; valid: local, sonnet, haiku, opus, openrouter%s"
-           other
-           (if Defaults.allow_test_providers () then ", mock, echo" else ""))
+    | other -> resolve_from_registry registry ~provider_name:other ?model ()
   in
   match base with
   | Error _ as e -> e

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -385,6 +385,217 @@ let test_blank_zai_base_urls_fall_back () =
        | None -> fail "glm-coding should exist")
 ;;
 
+(* ── Provider catalog overlay ────────────────────────── *)
+
+let with_provider_catalog json f =
+  match Provider_catalog.of_json (Yojson.Safe.from_string json) with
+  | Error msg -> fail msg
+  | Ok catalog ->
+    Provider_catalog.set_global catalog;
+    Fun.protect ~finally:Provider_catalog.clear_global f
+;;
+
+let with_env key value f =
+  let previous = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some previous -> Unix.putenv key previous
+      | None -> Unix.putenv key "")
+    f
+;;
+
+let test_catalog_overlay_adds_provider_and_alias () =
+  with_provider_catalog
+    {|{
+      "schema_version": 1,
+      "providers": [
+        {
+          "id": "vllm-local",
+          "aliases": ["Subscriber-Local"],
+          "kind": "openai_compat",
+          "transport": "http",
+          "base_url": "http://127.0.0.1:8000",
+          "request_path": "/v1/chat/completions",
+          "auth": {"type": "none"},
+          "default_model": "local-model",
+          "capabilities_base": "openai_chat",
+          "capabilities": {
+            "max_context_tokens": 131072,
+            "supports_tools": true,
+            "supports_tool_choice": true
+          }
+        }
+      ]
+    }|}
+    (fun () ->
+       let reg = Provider_registry.default () in
+       (match Provider_registry.find reg "vllm-local" with
+        | Some e ->
+          check string "base url" "http://127.0.0.1:8000" e.defaults.base_url;
+          check int "max context" 131_072 e.max_context;
+          check bool "tools" true e.capabilities.supports_tools;
+          check bool "tool choice" true e.capabilities.supports_tool_choice
+        | None -> fail "catalog provider should be registered");
+       match Provider_registry.find reg "subscriber-local" with
+       | Some e -> check string "alias base url" "http://127.0.0.1:8000" e.defaults.base_url
+       | None -> fail "catalog alias should be registered")
+;;
+
+let test_catalog_overlay_replaces_seed_provider () =
+  with_provider_catalog
+    {|{
+      "schema_version": 1,
+      "providers": [
+        {
+          "id": "openrouter",
+          "kind": "openai_compat",
+          "transport": "http",
+          "base_url": "https://example.test/openrouter",
+          "request_path": "/chat/completions",
+          "auth": {"type": "api_key_env", "env": "OPENROUTER_API_KEY"},
+          "capabilities_base": "openai_chat"
+        }
+      ]
+    }|}
+    (fun () ->
+       let reg = Provider_registry.default () in
+       match Provider_registry.find reg "openrouter" with
+       | Some e ->
+         check string "catalog wins" "https://example.test/openrouter" e.defaults.base_url
+       | None -> fail "openrouter should still exist")
+;;
+
+let test_catalog_overlay_normalizes_provider_id () =
+  with_provider_catalog
+    {|{
+      "schema_version": 1,
+      "providers": [
+        {
+          "id": "Acme-Cloud",
+          "kind": "openai_compat",
+          "transport": "http",
+          "base_url": "https://acme.example/v1",
+          "auth": {"type": "none"},
+          "capabilities_base": "openai_chat"
+        }
+      ]
+    }|}
+    (fun () ->
+       let reg = Provider_registry.default () in
+       match Provider_registry.find reg "acme-cloud" with
+       | Some e -> check string "base url" "https://acme.example/v1" e.defaults.base_url
+       | None -> fail "catalog provider id should be normalized")
+;;
+
+let test_catalog_cli_noninteractive_availability_uses_command () =
+  with_provider_catalog
+    {|{
+      "schema_version": 1,
+      "providers": [
+        {
+          "id": "ghost-cli",
+          "kind": "codex_cli",
+          "transport": "cli",
+          "command": "provider-registry-missing-binary",
+          "auth": {"type": "cli_cached_login"},
+          "capabilities_base": "codex_cli",
+          "non_interactive": true,
+          "daemon_safe": false
+        }
+      ]
+    }|}
+    (fun () ->
+       let reg = Provider_registry.default () in
+       match Provider_registry.find reg "ghost-cli" with
+       | Some e -> check bool "missing command unavailable" false (e.is_available ())
+       | None -> fail "ghost-cli should be registered")
+;;
+
+let test_catalog_rejects_empty_provider_id () =
+  match
+    Provider_catalog.of_json
+      (Yojson.Safe.from_string
+         {|{
+           "schema_version": 1,
+           "providers": [
+             {"id": "  ", "kind": "openai_compat"}
+           ]
+         }|})
+  with
+  | Error _ -> ()
+  | Ok _ -> fail "empty provider id should be rejected"
+;;
+
+let test_catalog_load_file_and_lookup_alias () =
+  let path = Filename.temp_file "provider-catalog" ".json" in
+  Fun.protect
+    ~finally:(fun () ->
+      try Sys.remove path with
+      | Sys_error _ -> ())
+    (fun () ->
+       let oc = open_out path in
+       Fun.protect
+         ~finally:(fun () -> close_out_noerr oc)
+         (fun () ->
+            output_string
+              oc
+              {|{
+                "schema_version": 1,
+                "providers": [
+                  {
+                    "id": "file-cloud",
+                    "aliases": ["file-cloud-alias"],
+                    "kind": "openai_compat",
+                    "transport": "http",
+                    "base_url": "https://file-cloud.example/v1",
+                    "default_model": "file-model",
+                    "auth": {"type": "none"}
+                  }
+                ]
+              }|});
+       match Provider_catalog.load_file path with
+       | Error msg -> fail msg
+       | Ok catalog ->
+         (match Provider_catalog.lookup catalog "file-cloud-alias" with
+          | Some entry ->
+            check string "id" "file-cloud" entry.id;
+            check (option string) "default model" (Some "file-model") entry.default_model
+          | None -> fail "catalog alias should resolve"))
+;;
+
+let test_catalog_api_key_env_availability () =
+  let env_name = "OAS_TEST_PROVIDER_CATALOG_API_KEY" in
+  let json =
+    Printf.sprintf
+      {|{
+        "schema_version": 1,
+        "providers": [
+          {
+            "id": "cloud-api",
+            "kind": "openai_compat",
+            "transport": "http",
+            "base_url": "https://cloud-api.example/v1",
+            "auth": {"type": "api_key_env", "env": "%s"},
+            "capabilities_base": "openai_chat"
+          }
+        ]
+      }|}
+      env_name
+  in
+  let available_with value =
+    with_env env_name value (fun () ->
+      with_provider_catalog json (fun () ->
+        let reg = Provider_registry.default () in
+        match Provider_registry.find reg "cloud-api" with
+        | Some entry -> entry.is_available ()
+        | None -> fail "cloud-api should be registered"))
+  in
+  check bool "missing api key unavailable" false (available_with "");
+  check bool "present api key available" true (available_with "secret")
+;;
+
 (* ── Types usage helpers ───────────────────────────── *)
 
 let test_zero_api_usage () =
@@ -599,6 +810,36 @@ let () =
             "blank zai base urls fall back"
             `Quick
             test_blank_zai_base_urls_fall_back
+        ] )
+    ; ( "provider_catalog"
+      , [ test_case
+            "overlay adds provider and alias"
+            `Quick
+            test_catalog_overlay_adds_provider_and_alias
+        ; test_case
+            "overlay replaces seed provider"
+            `Quick
+            test_catalog_overlay_replaces_seed_provider
+        ; test_case
+            "overlay normalizes provider id"
+            `Quick
+            test_catalog_overlay_normalizes_provider_id
+        ; test_case
+            "cli non-interactive availability uses command"
+            `Quick
+            test_catalog_cli_noninteractive_availability_uses_command
+        ; test_case
+            "rejects empty provider id"
+            `Quick
+            test_catalog_rejects_empty_provider_id
+        ; test_case
+            "load_file and lookup alias"
+            `Quick
+            test_catalog_load_file_and_lookup_alias
+        ; test_case
+            "api key env gates availability"
+            `Quick
+            test_catalog_api_key_env_availability
         ] )
     ; ( "kind_registry_integrity"
       , [ test_case "every kind resolves" `Quick test_every_kind_resolves_in_registry

--- a/test/test_runtime_server_resolve.ml
+++ b/test/test_runtime_server_resolve.ml
@@ -11,6 +11,14 @@ let with_test_providers_enabled f =
     f
 ;;
 
+let with_provider_catalog json f =
+  match Llm_provider.Provider_catalog.of_json (Yojson.Safe.from_string json) with
+  | Error msg -> Alcotest.fail msg
+  | Ok catalog ->
+    Llm_provider.Provider_catalog.set_global catalog;
+    Fun.protect ~finally:Llm_provider.Provider_catalog.clear_global f
+;;
+
 let dummy_session : Runtime.session =
   { session_id = "test-sess"
   ; goal = "test"
@@ -216,6 +224,36 @@ let test_resolve_provider_trimmed_lowercased () =
     | _ -> Alcotest.fail "expected mock alias to resolve to None")
 ;;
 
+let test_resolve_provider_catalog_entry () =
+  with_provider_catalog
+    {|{
+      "schema_version": 1,
+      "providers": [
+        {
+          "id": "vllm-local",
+          "aliases": ["Subscriber-Local"],
+          "kind": "openai_compat",
+          "transport": "http",
+          "base_url": "http://127.0.0.1:8000",
+          "request_path": "/v1/chat/completions",
+          "auth": {"type": "none"},
+          "default_model": "local-model",
+          "capabilities_base": "openai_chat"
+        }
+      ]
+    }|}
+    (fun () ->
+       match Runtime_server_resolve.resolve_provider ~provider:"subscriber-local" () with
+       | Ok (Some cfg) ->
+         Alcotest.(check string) "default model" "local-model" cfg.Provider.model_id;
+         (match cfg.Provider.provider with
+          | Provider.OpenAICompat { base_url; path; _ } ->
+            Alcotest.(check string) "base_url" "http://127.0.0.1:8000" base_url;
+            Alcotest.(check string) "path" "/v1/chat/completions" path
+          | _ -> Alcotest.fail "expected OpenAICompat")
+       | _ -> Alcotest.fail "expected catalog provider")
+;;
+
 let test_resolve_execution_mock_provider () =
   with_test_providers_enabled (fun () ->
     let detail = { dummy_spawn with provider = Some "mock" } in
@@ -394,6 +432,10 @@ let () =
             "trimmed and lowercased"
             `Quick
             test_resolve_provider_trimmed_lowercased
+        ; Alcotest.test_case
+            "catalog entry and alias"
+            `Quick
+            test_resolve_provider_catalog_entry
         ] )
     ; ( "resolve_execution"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary

Implements RFC-OAS-018's first runtime slice: OAS can now load an external provider catalog and overlay it on top of the built-in provider registry.

- adds `Llm_provider.Provider_catalog` with JSON parsing, file loading, runtime override, aliases, auth/transport metadata, capability overrides, and default models
- wires `Provider_registry.default()` and runtime server provider resolution through the catalog/registry path instead of hardcoded provider branching
- documents `OAS_PROVIDER_CATALOG` for cloud APIs, OpenAI-compatible gateways, local endpoints, and non-interactive subscription CLI runtimes
- updates SDK independence/custom-provider docs to keep coordinator policy outside OAS

## Boundary

OAS still does not know MASC. Catalog entries describe only generic provider/runtime facts: transport, auth, endpoint, request path, capability defaults, and model defaults. Downstream coordinators can project their own config into this shape, but OAS does not consume downstream routing or product semantics.

## Validation

- `scripts/dune-local.sh build test/test_provider_registry.exe test/test_runtime_server_resolve.exe`
- `./_build/default/test/test_provider_registry.exe` — 29 tests
- `./_build/default/test/test_runtime_server_resolve.exe` — 31 tests
- `scripts/check-sdk-independence.sh`
- `git diff --check origin/main...HEAD`

## Notes

This PR intentionally updates the existing RFC-OAS-018 draft PR instead of opening a duplicate PR for the implementation branch.
