### PR TITLE
chore(provider_catalog): document lookup/collision spec + warn on empty alias

### DIFF
--- a/docs/provider-catalog.md
+++ b/docs/provider-catalog.md
@@ -31,6 +31,30 @@ Resolution order:
 Catalog entries overwrite built-in provider ids when ids collide. Aliases are
 registered as additional lookup keys for the same entry.
 
+## Lookup and collisions
+
+| Surface | Collision rule |
+|---|---|
+| `Provider_catalog.lookup` (in-catalog match) | **First match in source order wins.** Later duplicate ids/aliases in the same catalog file are unreachable through `lookup`. |
+| `Provider_registry` overlay (catalog vs. built-in) | **Catalog overwrites built-in** by id when registered (`Hashtbl.replace`). The catalog overlay is applied last in `Provider_registry.default ()`. |
+| `Provider_registry` overlay (catalog vs. catalog) | **Last register wins.** If two catalog entries share an id (or one's alias collides with another's id), the entry registered later replaces the earlier one in the registry — even though `Provider_catalog.lookup` would still return the earlier one. This is intentionally asymmetric: write to the catalog, read in source order. |
+
+Lookup is **case-insensitive**: both ids and aliases are trimmed and
+lowercased before comparison. `"VLLM-LOCAL"`, `"vllm-local"`, and
+`"  vllm-local  "` resolve to the same entry.
+
+Invalid identifiers are rejected or skipped:
+
+- Empty/whitespace **id** at parse time → `of_json` returns `Error`.
+- Empty/whitespace **alias** at overlay time → skipped and logged via
+  `Diag.warn` (ctx `provider_registry`, format `ignoring empty %s for
+  provider %S in catalog overlay`, e.g. `ignoring empty alias for
+  provider "vllm-local" in catalog overlay`).
+
+If you have duplicate ids in a single catalog file, the recommended fix
+is to consolidate them — relying on first-match-wins or last-write-wins
+makes the behavior depend on which API the caller used.
+
 ## Schema
 
 ```json

--- a/lib/llm_provider/provider_catalog.mli
+++ b/lib/llm_provider/provider_catalog.mli
@@ -72,10 +72,20 @@ val of_json : Yojson.Safe.t -> (t, string) result
 val load_file : string -> (t, string) result
 val load_runtime_file : string -> t option
 
-(** Find an entry by id or alias. *)
+(** Find an entry by id or alias.
+
+    Lookup is case-insensitive (id and alias are trimmed + lowercased
+    before comparison). When more than one entry shares the same id or
+    alias, the {b first} matching entry in source order wins; later
+    duplicates are unreachable through this function.
+
+    Empty or whitespace-only ids are rejected at parse time by
+    {!of_json}, so they will not appear here. *)
 val lookup : t -> string -> entry option
 
-(** Return an entry's explicit default model by id or alias. *)
+(** Return an entry's explicit default model by id or alias.
+
+    Follows the same first-match-wins semantics as {!lookup}. *)
 val default_model_for_provider : t -> string -> string option
 
 (** Process-wide catalog overlay.

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -92,21 +92,27 @@ let register_catalog_entry t (entry : Provider_catalog.entry) =
     ; request_path = entry.request_path
     }
   in
-  let register_name name =
-    let name = String.lowercase_ascii (String.trim name) in
-    if name <> ""
+  let register_name ~origin name =
+    let normalized = String.lowercase_ascii (String.trim name) in
+    if normalized = ""
     then
+      Diag.warn
+        "provider_registry"
+        "ignoring empty %s for provider %S in catalog overlay"
+        origin
+        entry.id
+    else
       register
         t
-        { name
+        { name = normalized
         ; defaults
         ; max_context
         ; capabilities = entry.capabilities
         ; is_available = (fun () -> catalog_entry_available entry)
         }
   in
-  register_name entry.id;
-  List.iter register_name entry.aliases
+  register_name ~origin:"id" entry.id;
+  List.iter (register_name ~origin:"alias") entry.aliases
 ;;
 
 let overlay_provider_catalog t =

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -658,25 +658,38 @@ let test_catalog_lookup_case_insensitive () =
       (Option.is_some (Provider_catalog.lookup catalog "  alsomixed  "))
 ;;
 
+(* Constructs Provider_catalog.t directly (bypassing JSON parse) so that
+   empty/whitespace aliases survive to the registry overlay, where the
+   register_name warn is emitted. JSON parse-time filtering would otherwise
+   drop them before the overlay sees them. *)
 let test_catalog_empty_alias_not_registered () =
-  let json =
-    {|{
-       "schema_version": 1,
-       "providers": [
-         {"id": "host", "kind": "openai_compat",
-          "aliases": ["good-alias", "", "   "],
-          "base_url": "http://host.example",
-          "auth": {"type": "none"}}
-       ]
-     }|}
+  let entry : Provider_catalog.entry =
+    { id = "host"
+    ; aliases = [ "good-alias"; ""; "   " ]
+    ; kind = OpenAI_compat
+    ; transport = Http
+    ; command = None
+    ; base_url = "http://host.example"
+    ; request_path = "/v1/chat/completions"
+    ; api_key_env = ""
+    ; auth = No_auth
+    ; default_model = None
+    ; max_context = None
+    ; capabilities = Capabilities.default_capabilities
+    ; non_interactive = false
+    ; interactive_required = false
+    ; daemon_safe = false
+    ; credential_scope = None
+    }
   in
+  Provider_catalog.set_global [ entry ];
   let warns = ref [] in
   let sink level ~ctx msg =
     match level with
     | Diag.Warn -> warns := (ctx, msg) :: !warns
     | _ -> ()
   in
-  with_provider_catalog json (fun () ->
+  Fun.protect ~finally:Provider_catalog.clear_global (fun () ->
     Diag.with_sink sink (fun () ->
       let reg = Provider_registry.default () in
       check bool "id registered" true (Option.is_some (Provider_registry.find reg "host"));
@@ -690,17 +703,19 @@ let test_catalog_empty_alias_not_registered () =
         "empty alias not registered"
         false
         (Option.is_some (Provider_registry.find reg ""))));
+  let starts_with ~prefix s =
+    let plen = String.length prefix in
+    String.length s >= plen && String.sub s 0 plen = prefix
+  in
   let empty_alias_warns =
     List.filter
       (fun (ctx, msg) ->
-         ctx = "provider_registry"
-         && String.length msg >= 20
-         && String.sub msg 0 20 = "ignoring empty alias")
+         ctx = "provider_registry" && starts_with ~prefix:"ignoring empty alias" msg)
       !warns
   in
   check
     bool
-    "Diag.warn emitted for empty alias from provider_registry ctx"
+    "Diag.warn fired from provider_registry for at least one empty alias"
     true
     (List.length empty_alias_warns >= 1)
 ;;

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -594,6 +594,117 @@ let test_catalog_rejects_unknown_thinking_control_format () =
     fail "unknown thinking_control_format should be rejected, not silently coerced"
 ;;
 
+let test_catalog_lookup_first_match_wins () =
+  match
+    Provider_catalog.of_json
+      (Yojson.Safe.from_string
+         {|{
+           "schema_version": 1,
+           "providers": [
+             {"id": "dup", "kind": "openai_compat",
+              "base_url": "http://first.example"},
+             {"id": "dup", "kind": "openai_compat",
+              "base_url": "http://second.example"}
+           ]
+         }|})
+  with
+  | Error msg -> fail msg
+  | Ok catalog ->
+    (match Provider_catalog.lookup catalog "dup" with
+     | Some entry ->
+       check
+         string
+         "first-match-wins resolves to earlier entry"
+         "http://first.example"
+         entry.base_url
+     | None -> fail "duplicate id should still resolve to first entry")
+;;
+
+let test_catalog_lookup_case_insensitive () =
+  match
+    Provider_catalog.of_json
+      (Yojson.Safe.from_string
+         {|{
+           "schema_version": 1,
+           "providers": [
+             {"id": "mixed-Case",
+              "aliases": ["AlsoMixed"],
+              "kind": "openai_compat",
+              "base_url": "http://x.example"}
+           ]
+         }|})
+  with
+  | Error msg -> fail msg
+  | Ok catalog ->
+    check
+      bool
+      "id uppercase MIXED-CASE"
+      true
+      (Option.is_some (Provider_catalog.lookup catalog "MIXED-CASE"));
+    check
+      bool
+      "id lowercase mixed-case"
+      true
+      (Option.is_some (Provider_catalog.lookup catalog "mixed-case"));
+    check
+      bool
+      "alias uppercase ALSOMIXED"
+      true
+      (Option.is_some (Provider_catalog.lookup catalog "ALSOMIXED"));
+    check
+      bool
+      "alias trim/whitespace"
+      true
+      (Option.is_some (Provider_catalog.lookup catalog "  alsomixed  "))
+;;
+
+let test_catalog_empty_alias_not_registered () =
+  let json =
+    {|{
+       "schema_version": 1,
+       "providers": [
+         {"id": "host", "kind": "openai_compat",
+          "aliases": ["good-alias", "", "   "],
+          "base_url": "http://host.example",
+          "auth": {"type": "none"}}
+       ]
+     }|}
+  in
+  let warns = ref [] in
+  let sink level ~ctx msg =
+    match level with
+    | Diag.Warn -> warns := (ctx, msg) :: !warns
+    | _ -> ()
+  in
+  with_provider_catalog json (fun () ->
+    Diag.with_sink sink (fun () ->
+      let reg = Provider_registry.default () in
+      check bool "id registered" true (Option.is_some (Provider_registry.find reg "host"));
+      check
+        bool
+        "good alias registered"
+        true
+        (Option.is_some (Provider_registry.find reg "good-alias"));
+      check
+        bool
+        "empty alias not registered"
+        false
+        (Option.is_some (Provider_registry.find reg ""))));
+  let empty_alias_warns =
+    List.filter
+      (fun (ctx, msg) ->
+         ctx = "provider_registry"
+         && String.length msg >= 20
+         && String.sub msg 0 20 = "ignoring empty alias")
+      !warns
+  in
+  check
+    bool
+    "Diag.warn emitted for empty alias from provider_registry ctx"
+    true
+    (List.length empty_alias_warns >= 1)
+;;
+
 let test_catalog_load_file_and_lookup_alias () =
   let path = Filename.temp_file "provider-catalog" ".json" in
   Fun.protect
@@ -914,6 +1025,18 @@ let () =
             "rejects unknown thinking_control_format"
             `Quick
             test_catalog_rejects_unknown_thinking_control_format
+        ; test_case
+            "lookup first-match-wins on duplicate id"
+            `Quick
+            test_catalog_lookup_first_match_wins
+        ; test_case
+            "lookup is case-insensitive"
+            `Quick
+            test_catalog_lookup_case_insensitive
+        ; test_case
+            "empty alias not registered"
+            `Quick
+            test_catalog_empty_alias_not_registered
         ; test_case
             "load_file and lookup alias"
             `Quick


### PR DESCRIPTION
## Summary

`Provider_catalog` 와 `Provider_registry` overlay 가 ID/alias 충돌 시 두 axis 의 비대칭 동작을 *문서화 0* 인 채로 가지고 있었습니다. 이 PR 은 spec 을 명시하고, 빈 alias 의 silent skip 을 `Diag.warn` 으로 가시화합니다.

| Axis | 동작 | 정정 |
|---|---|---|
| `Provider_catalog.lookup` (in-catalog duplicate) | first-match-wins (`List.find_opt`) | `.mli` docstring + docs 명시 |
| `Provider_registry` overlay (catalog vs built-in) | catalog overwrites built-in by id (`Hashtbl.replace`) | docs 의 표로 명시 |
| `Provider_registry` overlay (catalog vs catalog dup) | **last-write-wins** — lookup 과 *반대* | docs 의 asymmetry 명시 (call site 의 trap 차단) |
| id/alias normalize | trim + lowercase | docstring 에 명시 |
| 빈 alias | silent skip | `Diag.warn "ignoring empty alias for provider %S"` |

## Why this matters

비대칭이 가장 큰 trap:

```json
{
  "providers": [
    {"id": "ollama", "base_url": "http://first.example"},
    {"id": "ollama", "base_url": "http://second.example"}
  ]
}
```

`Provider_catalog.lookup catalog "ollama"` → `first.example` 반환.
`Provider_registry.default () |> find "ollama"` → `second.example` 반환.

caller 가 *어느 API 를 사용했는지에 따라* 다른 URL 로 라우팅 — 가장 디버깅 어려운 종류의 silent failure. 본 PR 은 동작을 *바꾸지 않고* 문서화 + recommended fix ("consolidate them") 를 명시.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `dune exec --root . test/test_provider_registry.exe` — 32 tests run, all green (was 29, +3)
- [x] 3 새 test:
  - `lookup first-match-wins on duplicate id`
  - `lookup is case-insensitive`
  - `empty alias not registered`
- [x] ocamlformat 적용

## Scope

**P2** of the 7-axis catalog hardening sweep (RFC-OAS-018 follow-ups, /loop iteration 2).

| ID | 상태 |
|---|---|
| P1 fail-fast 4 함수 | #1544 Draft |
| **P2 lookup/collision spec** | **본 PR** |
| P3 `is_ollama` vendor flag → behavior-class | next iter |
| P4 222 model literal cutover | next iter (large) |
| P5 85 hardcoded port | next iter |
| P6 35 `starts_with` dispatchers | next iter |
| P7 `Provider_kind.t` 11 variants narrow | next iter (large) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
