### PR TITLE
fix(ci): restore main build after usage update

### DIFF
--- a/docs/provider-catalog.md
+++ b/docs/provider-catalog.md
@@ -45,8 +45,12 @@ lowercased before comparison. `"VLLM-LOCAL"`, `"vllm-local"`, and
 
 Invalid identifiers are rejected or skipped:
 
-- Empty/whitespace **id** at parse time → `of_json` returns `Error`.
-- Empty/whitespace **alias** at overlay time → skipped and logged via
+- Empty/whitespace **id** in a JSON catalog → `of_json` returns `Error`.
+- Empty/whitespace **alias** in a JSON catalog → skipped by `of_json`
+  before registry overlay, so JSON-file catalogs do not emit the
+  `provider_registry` empty-alias warning.
+- Empty/whitespace **alias** in a programmatically constructed catalog →
+  skipped at overlay time and logged via
   `Diag.warn` (ctx `provider_registry`, format `ignoring empty %s for
   provider %S in catalog overlay`, e.g. `ignoring empty alias for
   provider "vllm-local" in catalog overlay`).

--- a/lib/agent/agent_turn_budget.ml
+++ b/lib/agent/agent_turn_budget.ml
@@ -104,7 +104,8 @@ let make_tool ~agent_ref ~budget ?(max_idle_before_extend = 2) () =
           | None -> Ok ()
           | Some max_cost ->
             if Option.is_some state.usage.unpriced_model
-            then Error Cost_exceeded
+            then
+              Error Cost_exceeded
               (* Use strict greater-than to align with
                  [Cost_tracker.check_budget], which is the SSOT for cost
                  enforcement (see [lib/cost_tracker.ml]).  Previously this

--- a/lib/llm_provider/provider_catalog.mli
+++ b/lib/llm_provider/provider_catalog.mli
@@ -79,8 +79,11 @@ val load_runtime_file : string -> t option
     alias, the {b first} matching entry in source order wins; later
     duplicates are unreachable through this function.
 
-    Empty or whitespace-only ids are rejected at parse time by
-    {!of_json}, so they will not appear here. *)
+    For catalogs produced by {!of_json}, empty or whitespace-only ids
+    are rejected at parse time and empty aliases are dropped before
+    lookup. Programmatically constructed catalogs must preserve the same
+    non-empty id/alias invariant themselves; [lookup] only normalizes and
+    compares the data it is given. *)
 val lookup : t -> string -> entry option
 
 (** Return an entry's explicit default model by id or alias.

--- a/test/test_checkpoint_store.ml
+++ b/test/test_checkpoint_store.ml
@@ -278,6 +278,7 @@ let test_roundtrip_preserves_usage () =
           ; total_cache_read_input_tokens = 20
           ; api_calls = 3
           ; estimated_cost_usd = 0.0
+          ; unpriced_model = None
           }
       }
     in

--- a/test/test_session_resume.ml
+++ b/test/test_session_resume.ml
@@ -80,6 +80,7 @@ let sample_usage : Types.usage_stats =
   ; total_cache_read_input_tokens = 10
   ; api_calls = 3
   ; estimated_cost_usd = 0.0
+  ; unpriced_model = None
   }
 ;;
 
@@ -404,6 +405,7 @@ let test_resume_cache_tokens () =
     ; total_cache_read_input_tokens = 25
     ; api_calls = 2
     ; estimated_cost_usd = 0.0
+    ; unpriced_model = None
     }
   in
   let cp = make_checkpoint ~usage () in

--- a/test/test_structured_deep.ml
+++ b/test/test_structured_deep.ml
@@ -399,6 +399,7 @@ let test_retry_result_type () =
         ; total_cache_read_input_tokens = 5
         ; api_calls = 2
         ; estimated_cost_usd = 0.0
+        ; unpriced_model = None
         }
     ; attempts = 2
     }


### PR DESCRIPTION
Follow-up for the red CI and late review comments discovered after PR #1545 merged.

Changes:
- apply ocamlformat-required layout in lib/agent/agent_turn_budget.ml
- fill the new Types.usage_stats.unpriced_model field in remaining test fixtures
- scope provider catalog docs to distinguish JSON parsing from programmatic catalog invariants

Validation:
- git diff --check
- scripts/dune-local.sh build @fmt
- scripts/dune-local.sh build test/test_metrics_aggregating.exe