### PR TITLE
fix(agent): order checkpoint completion effects

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -470,6 +470,7 @@ let resume
       ?(tools = [])
       ?context
       ?(options = default_options)
+      ?checkpoint_sink
       ?config
       ?(auto_context_overflow_retry = true)
       ()
@@ -493,6 +494,7 @@ let resume
   ; net
   ; context = ctx
   ; options
+  ; checkpoint_sink
   }
 ;;
 

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -74,7 +74,6 @@ type options = Agent_types.options =
   ; on_run_complete : (bool -> unit) option
   ; tool_result_relocation : (Tool_result_store.t * Content_replacement_state.t) option
   ; journal : Durable_event.journal option
-  ; checkpoint_sink : checkpoint_sink option
   ; transport : Llm_provider.Llm_transport.t option
   ; runtime_mcp_policy : Llm_provider.Llm_transport.runtime_mcp_policy option
   ; summarizer : (Types.message list -> string) option
@@ -124,6 +123,7 @@ val create
   -> ?context:Context.t
   -> ?options:options
   -> ?auto_context_overflow_retry:bool
+  -> ?checkpoint_sink:checkpoint_sink
   -> unit
   -> t
 
@@ -192,6 +192,7 @@ val resume
   -> ?tools:Tool.t list
   -> ?context:Context.t
   -> ?options:options
+  -> ?checkpoint_sink:checkpoint_sink
   -> ?config:Types.agent_config
   -> ?auto_context_overflow_retry:bool
   -> unit

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -118,10 +118,11 @@ val sdk_version : string
     that own turn-level retry can pass [false].
 
     [checkpoint_sink] attaches an optional caller-owned turn-boundary
-    checkpoint sink.  The pipeline invokes it after durable in-memory
-    turn mutations that matter for crash recovery, such as assistant
-    collection and tool-result feedback appends.  The sink is passed
-    here rather than through {!options} so callers that construct
+    checkpoint sink.  The pipeline builds a post-mutation checkpoint
+    snapshot for crash recovery, invokes the sink before advancing the
+    live agent state and emitting completion/journal transitions, then
+    commits the same turn delta after the sink succeeds.  The sink is
+    passed here rather than through {!options} so callers that construct
     options records remain source-compatible. *)
 val create
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -115,7 +115,14 @@ val sdk_version : string
 (** [auto_context_overflow_retry] controls whether the turn pipeline performs
     its built-in compact-and-retry path after a provider [ContextOverflow].
     It defaults to [true] for standalone agents. Higher-level coordinators
-    that own turn-level retry can pass [false]. *)
+    that own turn-level retry can pass [false].
+
+    [checkpoint_sink] attaches an optional caller-owned turn-boundary
+    checkpoint sink.  The pipeline invokes it after durable in-memory
+    turn mutations that matter for crash recovery, such as assistant
+    collection and tool-result feedback appends.  The sink is passed
+    here rather than through {!options} so callers that construct
+    options records remain source-compatible. *)
 val create
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?config:Types.agent_config
@@ -186,6 +193,10 @@ val run_with_handoffs
 
 (** {1 Checkpoint / Resume} *)
 
+(** [resume ... ?checkpoint_sink ()] restores an agent from a checkpoint and
+    optionally attaches the same caller-owned turn-boundary checkpoint sink used
+    by {!create}.  The sink is not stored in {!options}; pass it explicitly when
+    resumed turns should continue emitting crash-recovery checkpoints. *)
 val resume
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> checkpoint:Checkpoint.t

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -93,7 +93,6 @@ type options =
         [Event_bus] publishes, enabling offline replay via
         {!Durable_event.replay_summary}.
         @since 0.133.0 *)
-  ; checkpoint_sink : checkpoint_sink option
   ; transport : Llm_provider.Llm_transport.t option
     (** Optional non-HTTP transport override.  Required for CLI provider
         kinds ([Claude_code], [Codex_cli], [Gemini_cli], [Kimi_cli]) which cannot be
@@ -192,7 +191,6 @@ let default_options =
   ; on_run_complete = None
   ; tool_result_relocation = None
   ; journal = None
-  ; checkpoint_sink = None
   ; transport = None
   ; runtime_mcp_policy = None
   ; summarizer = None
@@ -213,6 +211,7 @@ type t =
   ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   ; context : Context.t
   ; options : options
+  ; checkpoint_sink : checkpoint_sink option
   }
 
 (* Public accessors — .mli exposes Agent.t as abstract *)
@@ -326,6 +325,7 @@ let create
       ?context
       ?(options = default_options)
       ?(auto_context_overflow_retry = true)
+      ?checkpoint_sink
       ()
   =
   let mcp_tools =
@@ -350,6 +350,7 @@ let create
   ; net
   ; context = ctx
   ; options
+  ; checkpoint_sink
   }
 ;;
 
@@ -372,6 +373,7 @@ let clone ?(copy_context = false) agent =
   ; net = agent.net
   ; context = ctx
   ; options = agent.options
+  ; checkpoint_sink = agent.checkpoint_sink
   }
 ;;
 

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -157,13 +157,6 @@ type options =
         [Event_bus] publishes, enabling offline replay via
         {!Durable_event.replay_summary}.
         @since 0.133.0 *)
-  ; checkpoint_sink : checkpoint_sink option
-    (** Optional turn-boundary checkpoint sink.  When provided, the
-        pipeline emits a full checkpoint after durable in-memory turn
-        mutations that matter for crash recovery: assistant collection,
-        tool-result feedback append, and required-tool retry feedback
-        append.  The sink is generic and owned by the caller.
-        @since 0.193.9 *)
   ; transport : Llm_provider.Llm_transport.t option
     (** Optional non-HTTP transport override.  Required for CLI provider
         kinds ([Claude_code], [Codex_cli], [Gemini_cli], [Kimi_cli])
@@ -239,6 +232,7 @@ type t =
   ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   ; context : Context.t
   ; options : options
+  ; checkpoint_sink : checkpoint_sink option
   }
 
 (** {1 Defaults} *)
@@ -273,6 +267,7 @@ val create
   -> ?context:Context.t
   -> ?options:options
   -> ?auto_context_overflow_retry:bool
+  -> ?checkpoint_sink:checkpoint_sink
   -> unit
   -> t
 

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -444,7 +444,6 @@ let build b =
     ; on_run_complete = b.on_run_complete
     ; tool_result_relocation = b.tool_result_relocation
     ; journal = b.journal
-    ; checkpoint_sink = b.checkpoint_sink
     ; transport = b.transport
     ; runtime_mcp_policy = b.runtime_mcp_policy
     ; summarizer = b.summarizer
@@ -458,6 +457,7 @@ let build b =
     ?context
     ~options
     ~auto_context_overflow_retry:b.auto_context_overflow_retry
+    ?checkpoint_sink:b.checkpoint_sink
     ()
 ;;
 

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -325,7 +325,9 @@ val with_tool_result_relocation
     @since 0.133.0 *)
 val with_journal : Durable_event.journal -> t -> t
 
-(** Attach a caller-owned turn-boundary checkpoint sink.
+(** Attach a caller-owned turn-boundary checkpoint sink. The sink is stored
+    on the built {!Agent.t}, not in {!Agent.options}, so existing callers that
+    construct options records remain source-compatible.
     @since 0.193.9 *)
 val with_checkpoint_sink : Agent.checkpoint_sink -> t -> t
 

--- a/lib/agent_typed.ml
+++ b/lib/agent_typed.ml
@@ -12,8 +12,8 @@ type completed
    OCaml's type system enforces state transitions at compile time. *)
 type _ t = T : Agent.t -> _ t
 
-let create ~net ?config ?tools ?context ?options () =
-  T (Agent.create ~net ?config ?tools ?context ?options ())
+let create ~net ?config ?tools ?context ?options ?checkpoint_sink () =
+  T (Agent.create ~net ?config ?tools ?context ?options ?checkpoint_sink ())
 ;;
 
 let run ~sw ?clock (T agent) prompt =

--- a/lib/agent_typed.mli
+++ b/lib/agent_typed.mli
@@ -28,13 +28,17 @@ type _ t
 
 (** {1 Construction} *)
 
-(** Create a new agent in the [created] state. *)
+(** Create a new agent in the [created] state.
+
+    [?checkpoint_sink] is forwarded to {!Agent.create}; it attaches the
+    caller-owned turn-boundary checkpoint sink used for crash recovery. *)
 val create
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?config:Types.agent_config
   -> ?tools:Tool.t list
   -> ?context:Context.t
   -> ?options:Agent.options
+  -> ?checkpoint_sink:Agent.checkpoint_sink
   -> unit
   -> created t
 

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -109,20 +109,20 @@ let validate_completion_contract agent (response : Types.api_response) =
   | Error reason -> Error (Error.Agent (CompletionContractViolation { contract; reason }))
 ;;
 
-let persist_turn_checkpoint agent stage =
-  match agent.options.checkpoint_sink with
+let persist_turn_checkpoint_for_state agent stage state =
+  match agent.checkpoint_sink with
   | None -> Ok ()
   | Some sink ->
     let checkpoint =
       Agent_checkpoint.build_checkpoint
-        ~state:agent.state
+        ~state
         ~tools:agent.tools
         ~context:agent.context
         ~mcp_clients:agent.options.mcp_clients
         ()
     in
     let timestamp = checkpoint.created_at in
-    let turn = agent.state.turn_count in
+    let turn = state.turn_count in
     let stage_label = checkpoint_stage_to_string stage in
     let snapshot = { stage; turn; checkpoint; timestamp } in
     (match sink snapshot with
@@ -150,6 +150,10 @@ let persist_turn_checkpoint agent stage =
        Error
          (Error.Internal
             (Printf.sprintf "checkpoint sink failed at %s: %s" stage_label detail)))
+;;
+
+let persist_turn_checkpoint agent stage =
+  persist_turn_checkpoint_for_state agent stage agent.state
 ;;
 
 let requested_completion_contract agent =
@@ -351,14 +355,26 @@ let stage_collect ?raw_trace_run agent ~original_config response =
       agent.options.hooks.after_turn
       (Hooks.AfterTurn { turn = agent.state.turn_count; response })
   in
+  let completed_turn = agent.state.turn_count in
+  let next_state =
+    { agent.state with
+      messages =
+        Util.snoc agent.state.messages (make_message ~role:Assistant response.content)
+    ; turn_count = agent.state.turn_count + 1
+    ; usage
+    }
+  in
+  let* () =
+    persist_turn_checkpoint_for_state agent After_assistant_collected next_state
+  in
+  set_state agent next_state;
   (match agent.options.event_bus with
    | Some bus ->
      Event_bus.publish
        bus
        { meta = event_envelope agent
        ; payload =
-           TurnCompleted
-             { agent_name = agent.state.config.name; turn = agent.state.turn_count }
+           TurnCompleted { agent_name = agent.state.config.name; turn = completed_turn }
        }
    | None -> ());
   (match agent.options.journal with
@@ -372,13 +388,7 @@ let stage_collect ?raw_trace_run agent ~original_config response =
           ; timestamp = Unix.gettimeofday ()
           })
    | None -> ());
-  update_state agent (fun s ->
-    { s with
-      messages = Util.snoc s.messages (make_message ~role:Assistant response.content)
-    ; turn_count = s.turn_count + 1
-    ; usage
-    });
-  persist_turn_checkpoint agent After_assistant_collected
+  Ok ()
 ;;
 
 let handle_missing_required_tool_use

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -356,18 +356,27 @@ let stage_collect ?raw_trace_run agent ~original_config response =
       (Hooks.AfterTurn { turn = agent.state.turn_count; response })
   in
   let completed_turn = agent.state.turn_count in
-  let next_state =
+  let assistant_message = make_message ~role:Assistant response.content in
+  let checkpoint_state =
     { agent.state with
-      messages =
-        Util.snoc agent.state.messages (make_message ~role:Assistant response.content)
+      messages = Util.snoc agent.state.messages assistant_message
     ; turn_count = agent.state.turn_count + 1
     ; usage
     }
   in
   let* () =
-    persist_turn_checkpoint_for_state agent After_assistant_collected next_state
+    persist_turn_checkpoint_for_state agent After_assistant_collected checkpoint_state
   in
-  set_state agent next_state;
+  update_state agent (fun state ->
+    { state with
+      messages = Util.snoc state.messages assistant_message
+    ; turn_count = state.turn_count + 1
+    ; usage =
+        Agent_turn.accumulate_usage
+          ~current_usage:state.usage
+          ~provider:agent.options.provider
+          ~response_usage:response.usage
+    });
   (match agent.options.event_bus with
    | Some bus ->
      Event_bus.publish

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -1072,21 +1072,13 @@ let test_agent_run_context_overflow_auto_retry_can_be_disabled () =
       }
     in
     let config =
-      { Types.default_config with
-        name = "context-overflow-owner"
-      ; max_turns = 3
-      }
+      { Types.default_config with name = "context-overflow-owner"; max_turns = 3 }
     in
     let options =
       { Agent.default_options with base_url = url; provider = Some provider; hooks }
     in
     let agent =
-      Agent.create
-        ~net:env#net
-        ~config
-        ~options
-        ~auto_context_overflow_retry:false
-        ()
+      Agent.create ~net:env#net ~config ~options ~auto_context_overflow_retry:false ()
     in
     let history =
       [ { Types.role = User

--- a/test/test_agent_typed.ml
+++ b/test/test_agent_typed.ml
@@ -6,6 +6,24 @@
 open Agent_sdk
 open Alcotest
 
+let text_response text : Types.api_response =
+  { id = "typed-checkpoint-mock"
+  ; model = "mock-model"
+  ; stop_reason = Types.EndTurn
+  ; content = [ Types.Text text ]
+  ; usage = None
+  ; telemetry = None
+  }
+;;
+
+let make_transport response : Llm_provider.Llm_transport.t =
+  { complete_sync =
+      (fun _req ->
+        { Llm_provider.Llm_transport.response = Ok response; latency_ms = Some 0 })
+  ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _req -> Ok response)
+  }
+;;
+
 let test_create () =
   Eio_main.run
   @@ fun env ->
@@ -33,6 +51,39 @@ let test_last_trace_none () =
   @@ fun env ->
   let agent = Agent_typed.create ~net:env#net () in
   check bool "no trace" true (Option.is_none (Agent_typed.last_trace agent))
+;;
+
+let test_checkpoint_sink_forwarded () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let sink_calls = ref [] in
+  let checkpoint_sink (snapshot : Agent.checkpoint_snapshot) =
+    sink_calls := Agent.checkpoint_stage_to_string snapshot.stage :: !sink_calls;
+    Ok ()
+  in
+  let options =
+    { Agent.default_options with
+      transport = Some (make_transport (text_response "ok"))
+    ; provider =
+        Some
+          { provider = Provider.Local { base_url = "http://mock.local" }
+          ; model_id = "mock-model"
+          ; api_key_env = ""
+          }
+    }
+  in
+  let config = { Types.default_config with model = "mock-model"; max_turns = 1 } in
+  let agent = Agent_typed.create ~net:env#net ~config ~options ~checkpoint_sink () in
+  (match Agent_typed.run ~sw agent "hi" with
+   | Ok (_response, _completed) -> ()
+   | Error err -> Alcotest.fail ("expected run success: " ^ Error.to_string err));
+  check
+    (list string)
+    "checkpoint stages"
+    [ "after_assistant_collected" ]
+    (List.rev !sink_calls)
 ;;
 
 (** Compile-time type safety test:
@@ -64,6 +115,7 @@ let () =
       , [ test_case "create" `Quick test_create
         ; test_case "inner" `Quick test_inner
         ; test_case "last_trace_none" `Quick test_last_trace_none
+        ; test_case "checkpoint_sink_forwarded" `Quick test_checkpoint_sink_forwarded
         ; test_case "phantom_documented" `Quick test_phantom_type_documented
         ] )
     ]

--- a/test/test_builder_coverage.ml
+++ b/test/test_builder_coverage.ml
@@ -221,7 +221,6 @@ let test_agent_default_options () =
   Alcotest.(check bool) "no skill_registry" true (opts.skill_registry = None);
   Alcotest.(check bool) "no memory" true (opts.memory = None);
   Alcotest.(check bool) "no tiered_memory" true (opts.tiered_memory = None);
-  Alcotest.(check bool) "no checkpoint_sink" true (opts.checkpoint_sink = None);
   Alcotest.(check int) "max_idle_turns" 3 opts.max_idle_turns;
   Alcotest.(check int) "empty mcp" 0 (List.length opts.mcp_clients)
 ;;

--- a/test/test_telemetry_pipeline.ml
+++ b/test/test_telemetry_pipeline.ml
@@ -125,11 +125,21 @@ let make_agent ~net ~transport () =
   agent, event_bus
 ;;
 
-let make_checkpoint_agent ~net ~transport ~checkpoint_sink ~max_turns ~tools () =
+let make_checkpoint_agent
+      ?event_bus
+      ?journal
+      ~net
+      ~transport
+      ~checkpoint_sink
+      ~max_turns
+      ~tools
+      ()
+  =
   let options =
     { Agent.default_options with
       transport = Some transport
-    ; checkpoint_sink = Some checkpoint_sink
+    ; event_bus
+    ; journal
     ; provider =
         Some
           { provider = Provider.Local { base_url = "http://mock.local" }
@@ -145,7 +155,7 @@ let make_checkpoint_agent ~net ~transport ~checkpoint_sink ~max_turns ~tools () 
     ; max_turns
     }
   in
-  Agent.create ~net ~config ~tools ~options ()
+  Agent.create ~net ~config ~tools ~options ~checkpoint_sink ()
 ;;
 
 let test_run_stream_emits_telemetry_via_pipeline () =
@@ -339,10 +349,15 @@ let test_checkpoint_sink_failure_fails_turn () =
   @@ fun env ->
   Eio.Switch.run
   @@ fun sw ->
+  let event_bus = Event_bus.create ~buffer_size:32 () in
+  let event_sub = Event_bus.subscribe event_bus in
+  let journal = Durable_event.create () in
   let checkpoint_sink _snapshot = Error "disk full" in
   let transport = make_sequence_transport [ text_response "ok" ] in
   let agent =
     make_checkpoint_agent
+      ~event_bus
+      ~journal
       ~net:env#net
       ~transport
       ~checkpoint_sink
@@ -356,7 +371,27 @@ let test_checkpoint_sink_failure_fails_turn () =
     Alcotest.(check bool)
       "error mentions checkpoint sink"
       true
-      (contains_substring ~sub:"checkpoint sink failed" (Error.to_string err))
+      (contains_substring ~sub:"checkpoint sink failed" (Error.to_string err));
+    let event_payloads =
+      Event_bus.drain event_sub |> List.map (fun event -> event.Event_bus.payload)
+    in
+    Alcotest.(check bool)
+      "no TurnCompleted event after checkpoint failure"
+      false
+      (List.exists
+         (function
+           | Event_bus.TurnCompleted _ -> true
+           | _ -> false)
+         event_payloads);
+    let journal_events = Durable_event.events journal in
+    Alcotest.(check bool)
+      "no turn_complete journal transition after checkpoint failure"
+      false
+      (List.exists
+         (function
+           | Durable_event.State_transition { to_state = "turn_complete"; _ } -> true
+           | _ -> false)
+         journal_events)
 ;;
 
 let () =

--- a/test/test_telemetry_pipeline.ml
+++ b/test/test_telemetry_pipeline.ml
@@ -394,6 +394,69 @@ let test_checkpoint_sink_failure_fails_turn () =
          journal_events)
 ;;
 
+let test_checkpoint_sink_does_not_clobber_intervening_state () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let agent_ref = ref None in
+  let marker_message =
+    { Types.role = Types.System
+    ; content = [ Types.Text "sink-side-effect" ]
+    ; name = None
+    ; tool_call_id = None
+    ; metadata = []
+    }
+  in
+  let checkpoint_sink _snapshot =
+    (match !agent_ref with
+     | Some agent ->
+       Agent.update_state agent (fun state ->
+         { state with messages = state.messages @ [ marker_message ] })
+     | None -> ());
+    Ok ()
+  in
+  let transport = make_sequence_transport [ text_response "ok" ] in
+  let agent =
+    make_checkpoint_agent
+      ~net:env#net
+      ~transport
+      ~checkpoint_sink
+      ~max_turns:1
+      ~tools:[]
+      ()
+  in
+  agent_ref := Some agent;
+  (match Agent.run ~sw agent "capture this turn" with
+   | Ok _ -> ()
+   | Error err -> Alcotest.fail ("expected run success: " ^ Error.to_string err));
+  let messages = (Agent.state agent).messages in
+  Alcotest.(check bool)
+    "sink state mutation preserved"
+    true
+    (List.exists
+       (fun (msg : Types.message) ->
+          msg.role = Types.System
+          && List.exists
+               (function
+                 | Types.Text "sink-side-effect" -> true
+                 | _ -> false)
+               msg.content)
+       messages);
+  Alcotest.(check bool)
+    "assistant state mutation preserved"
+    true
+    (List.exists
+       (fun (msg : Types.message) ->
+          msg.role = Types.Assistant
+          && List.exists
+               (function
+                 | Types.Text "ok" -> true
+                 | _ -> false)
+               msg.content)
+       messages)
+;;
+
 let () =
   Alcotest.run
     "Telemetry pipeline integration"
@@ -418,6 +481,10 @@ let () =
             "checkpoint sink failure fails turn"
             `Quick
             test_checkpoint_sink_failure_fails_turn
+        ; Alcotest.test_case
+            "checkpoint sink preserves intervening state"
+            `Quick
+            test_checkpoint_sink_does_not_clobber_intervening_state
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- keep checkpoint sink out of the public Agent.options record
- persist the after-assistant checkpoint before mutating completion side effects
- cover checkpoint sink failures so TurnCompleted and turn_complete are not emitted after a failed checkpoint

## Verification
- scripts/dune-local.sh build test/test_telemetry_pipeline.exe test/test_builder_coverage.exe
- scripts/dune-local.sh build @fmt
- scripts/dune-local.sh exec test/test_telemetry_pipeline.exe
- scripts/dune-local.sh exec test/test_builder_coverage.exe
- git diff --check