### PR TITLE
fix(llm): lower confidence for fallback capability drift

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -100,6 +100,130 @@ let apply_sampling_defaults (config : Provider_config.t) : Provider_config.t =
     Delegates to {!Provider_config.reasoning_effort_of_config}. *)
 let reasoning_effort_of_config = Provider_config.reasoning_effort_of_config
 
+type capability_source =
+  | Model_capability
+  | Provider_default_capability
+
+let capability_source_to_string = function
+  | Model_capability -> "model"
+  | Provider_default_capability -> "provider_default"
+;;
+
+let base_capabilities_for_kind = function
+  | Provider_config.Ollama -> Capabilities.ollama_capabilities
+  | DashScope -> Capabilities.dashscope_capabilities
+  | Anthropic -> Capabilities.anthropic_capabilities
+  | Kimi -> Capabilities.kimi_capabilities
+  | Glm -> Capabilities.glm_capabilities
+  | Gemini -> Capabilities.gemini_capabilities
+  | OpenAI_compat -> Capabilities.openai_chat_capabilities
+  | Claude_code -> Capabilities.claude_code_capabilities
+  | Gemini_cli -> Capabilities.gemini_cli_capabilities
+  | Kimi_cli -> Capabilities.kimi_cli_capabilities
+  | Codex_cli -> Capabilities.codex_cli_capabilities
+;;
+
+let resolve_capabilities_for_config (config : Provider_config.t) =
+  match Capabilities.for_model_id config.model_id with
+  | Some caps -> caps, Model_capability
+  | None -> base_capabilities_for_kind config.kind, Provider_default_capability
+;;
+
+let warn_on_drift_observation source = function
+  | Capabilities.Thinking_returned_but_declared_unsupported ->
+    (match source with
+     | Model_capability -> true
+     | Provider_default_capability -> false)
+  | Capabilities.Usage_missing_but_declared
+  | Capabilities.Tools_used_but_declared_unsupported
+  | Capabilities.Stop_tool_use_but_declared_unsupported -> true
+;;
+
+let partition_drift_observations source observations =
+  List.fold_right
+    (fun observation (warn_observations, info_observations) ->
+       if warn_on_drift_observation source observation
+       then observation :: warn_observations, info_observations
+       else warn_observations, observation :: info_observations)
+    observations
+    ([], [])
+;;
+
+let capability_observation_payload
+      ~(event : string)
+      ~(confidence : string)
+      ~(source : capability_source)
+      ~(config : Provider_config.t)
+      observations
+  =
+  `Assoc
+    [ "event", `String event
+    ; "model", `String config.model_id
+    ; "provider", `String (Provider_config.show_provider_kind config.kind)
+    ; "capability_source", `String (capability_source_to_string source)
+    ; "confidence", `String confidence
+    ; ( "observations"
+      , `List
+          (List.map
+             (fun observation ->
+                `String (Capabilities.show_drift_observation observation))
+             observations) )
+    ]
+  |> Yojson.Safe.to_string
+;;
+
+let emit_capability_observations ~config ~source observations =
+  let warn_observations, info_observations =
+    partition_drift_observations source observations
+  in
+  (match warn_observations with
+   | [] -> ()
+   | observations ->
+     Diag.warn
+       "complete"
+       "%s"
+       (capability_observation_payload
+          ~event:"capability_drift"
+          ~confidence:"high"
+          ~source
+          ~config
+          observations));
+  match info_observations with
+  | [] -> ()
+  | observations ->
+    Diag.info
+      "complete"
+      "%s"
+      (capability_observation_payload
+         ~event:"capability_observation"
+         ~confidence:"low"
+         ~source
+         ~config
+         observations)
+;;
+
+let%test "provider-default thinking drift is low-confidence observation" =
+  let warn_observations, info_observations =
+    partition_drift_observations
+      Provider_default_capability
+      [ Capabilities.Thinking_returned_but_declared_unsupported
+      ; Capabilities.Tools_used_but_declared_unsupported
+      ]
+  in
+  warn_observations = [ Capabilities.Tools_used_but_declared_unsupported ]
+  && info_observations = [ Capabilities.Thinking_returned_but_declared_unsupported ]
+;;
+
+let%test "model capability thinking drift remains high-confidence warning" =
+  let warn_observations, info_observations =
+    partition_drift_observations
+      Model_capability
+      [ Capabilities.Thinking_returned_but_declared_unsupported ]
+  in
+  warn_observations = [ Capabilities.Thinking_returned_but_declared_unsupported ]
+  && info_observations = []
+;;
+
 (** Patch {!Types.api_response} telemetry with transport latency and provider
     metadata.
     The JSON parser sets [request_latency_ms = None] because it cannot see the
@@ -116,25 +240,7 @@ let patch_telemetry
   let pk = Some config.kind in
   let re = reasoning_effort_of_config config in
   let model = if String.trim resp.model = "" then config.model_id else resp.model in
-  let base_caps =
-    match config.kind with
-    | Ollama -> Capabilities.ollama_capabilities
-    | DashScope -> Capabilities.dashscope_capabilities
-    | Anthropic -> Capabilities.anthropic_capabilities
-    | Kimi -> Capabilities.kimi_capabilities
-    | Glm -> Capabilities.glm_capabilities
-    | Gemini -> Capabilities.gemini_capabilities
-    | OpenAI_compat -> Capabilities.openai_chat_capabilities
-    | Claude_code -> Capabilities.claude_code_capabilities
-    | Gemini_cli -> Capabilities.gemini_cli_capabilities
-    | Kimi_cli -> Capabilities.kimi_cli_capabilities
-    | Codex_cli -> Capabilities.codex_cli_capabilities
-  in
-  let caps =
-    match Capabilities.for_model_id config.model_id with
-    | Some c -> c
-    | None -> base_caps
-  in
+  let caps, capability_source = resolve_capabilities_for_config config in
   let ctx_window = caps.max_context_tokens in
   let canonical = Some config.model_id in
   let telemetry =
@@ -180,15 +286,7 @@ let patch_telemetry
   (match Capabilities.detect_drift caps patched with
    | [] -> ()
    | observations ->
-     let obs_strings =
-       List.map (fun o -> Capabilities.show_drift_observation o) observations
-     in
-     Diag.warn
-       "complete"
-       {|{"event":"capability_drift","model":"%s","provider":"%s","observations":[%s] }|}
-       config.model_id
-       (Provider_config.show_provider_kind config.kind)
-       (String.concat "," (List.map (fun s -> "\"" ^ s ^ "\"") obs_strings)));
+     emit_capability_observations ~config ~source:capability_source observations);
   patched
 ;;
 

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -1072,21 +1072,13 @@ let test_agent_run_context_overflow_auto_retry_can_be_disabled () =
       }
     in
     let config =
-      { Types.default_config with
-        name = "context-overflow-owner"
-      ; max_turns = 3
-      }
+      { Types.default_config with name = "context-overflow-owner"; max_turns = 3 }
     in
     let options =
       { Agent.default_options with base_url = url; provider = Some provider; hooks }
     in
     let agent =
-      Agent.create
-        ~net:env#net
-        ~config
-        ~options
-        ~auto_context_overflow_retry:false
-        ()
+      Agent.create ~net:env#net ~config ~options ~auto_context_overflow_retry:false ()
     in
     let history =
       [ { Types.role = User

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -621,6 +621,103 @@ let test_complete_claude_code_without_transport_is_guarded () =
     kinds
 ;;
 
+let usage =
+  Some
+    { input_tokens = 1
+    ; output_tokens = 1
+    ; cache_creation_input_tokens = 0
+    ; cache_read_input_tokens = 0
+    ; cost_usd = None
+    }
+;;
+
+let fake_transport response : Llm_provider.Llm_transport.t =
+  { complete_sync = (fun _request -> { response = Ok response; latency_ms = Some 1 })
+  ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _request -> Ok response)
+  }
+;;
+
+let complete_with_captured_diag ~config ~response =
+  let entries = ref [] in
+  let run () =
+    Eio_main.run
+    @@ fun env ->
+    Eio.Switch.run
+    @@ fun sw ->
+    let net = Eio.Stdenv.net env in
+    let transport = fake_transport response in
+    match
+      Llm_provider.Complete.complete
+        ~sw
+        ~net
+        ~config
+        ~messages:[ user_msg "hi" ]
+        ~transport
+        ()
+    with
+    | Ok _ -> ()
+    | Error _ -> Alcotest.fail "fake completion should succeed"
+  in
+  Llm_provider.Diag.with_sink
+    (fun level ~ctx message -> entries := (level, ctx, message) :: !entries)
+    run;
+  List.rev !entries
+;;
+
+let response_with_thinking =
+  { id = "resp-thinking"
+  ; model = "auto"
+  ; stop_reason = EndTurn
+  ; content = [ Thinking { thinking_type = "thinking"; content = "reasoning" } ]
+  ; usage
+  ; telemetry = None
+  }
+;;
+
+let test_provider_default_thinking_drift_is_info () =
+  let config =
+    PC.make ~kind:OpenAI_compat ~model_id:"auto" ~base_url:"https://example.invalid/v1" ()
+  in
+  let entries = complete_with_captured_diag ~config ~response:response_with_thinking in
+  Alcotest.(check bool)
+    "no warn for provider-default thinking observation"
+    false
+    (List.exists (fun (level, _, _) -> level = Llm_provider.Diag.Warn) entries);
+  Alcotest.(check bool)
+    "low-confidence info is recorded"
+    true
+    (List.exists
+       (fun (level, ctx, message) ->
+          level = Llm_provider.Diag.Info
+          && ctx = "complete"
+          && contains_substring ~sub:"capability_observation" message
+          && contains_substring ~sub:"provider_default" message
+          && contains_substring ~sub:"low" message)
+       entries)
+;;
+
+let test_model_capability_thinking_drift_remains_warn () =
+  let config =
+    PC.make
+      ~kind:OpenAI_compat
+      ~model_id:"glm-4-flash"
+      ~base_url:"https://example.invalid/v1"
+      ()
+  in
+  let entries = complete_with_captured_diag ~config ~response:response_with_thinking in
+  Alcotest.(check bool)
+    "model-specific mismatch remains warn"
+    true
+    (List.exists
+       (fun (level, ctx, message) ->
+          level = Llm_provider.Diag.Warn
+          && ctx = "complete"
+          && contains_substring ~sub:"capability_drift" message
+          && contains_substring ~sub:"model" message
+          && contains_substring ~sub:"high" message)
+       entries)
+;;
+
 let test_complete_rejects_output_schema_for_glm () =
   Eio_main.run
   @@ fun env ->
@@ -916,6 +1013,16 @@ let () =
             "glm output schema rejected before request"
             `Quick
             test_complete_rejects_output_schema_for_glm
+        ] )
+    ; ( "capability_drift"
+      , [ test_case
+            "provider-default thinking observation is info"
+            `Quick
+            test_provider_default_thinking_drift_is_info
+        ; test_case
+            "model-specific thinking drift remains warn"
+            `Quick
+            test_model_capability_thinking_drift_remains_warn
         ] )
     ; ( "cost"
       , [ test_case "annotate response cost" `Quick test_annotate_response_cost


### PR DESCRIPTION
## Summary
- split LLM capability diagnostics by capability source: model-specific drift remains high-confidence WARN, provider-default fallback observations become INFO
- keep structured JSON payloads with capability_source/confidence so dashboards can explain why an observation was downgraded
- include the current main ocamlformat fix for test_agent_pipeline.ml so this branch is independently green before PR #1552 lands

## Verification
- git diff --check
- scripts/dune-local.sh build @fmt
- scripts/dune-local.sh build test/test_provider_complete.exe test/test_llm_provider_cov.exe
- scripts/dune-local.sh build test/test_agent_pipeline.exe
- ./_build/default/test/test_provider_complete.exe
- ./_build/default/test/test_llm_provider_cov.exe