### PR TITLE
[codex] add Prometheus text export for metrics

### DIFF
--- a/lib/metrics.ml
+++ b/lib/metrics.ml
@@ -223,3 +223,117 @@ let to_otlp_json t =
             ] )
       ])
 ;;
+
+(* -- Prometheus text export ------------------------------------------ *)
+
+let is_identifier_start = function
+  | 'A' .. 'Z' | 'a' .. 'z' | '_' | ':' -> true
+  | _ -> false
+;;
+
+let is_identifier_char = function
+  | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | ':' -> true
+  | _ -> false
+;;
+
+let prometheus_identifier raw =
+  let buf = Buffer.create (String.length raw + 1) in
+  String.iteri
+    (fun index ch ->
+       let valid = if index = 0 then is_identifier_start ch else is_identifier_char ch in
+       Buffer.add_char buf (if valid then ch else '_'))
+    raw;
+  let rendered = Buffer.contents buf in
+  if String.equal rendered "" then "_" else rendered
+;;
+
+let escape_prometheus_value raw =
+  let buf = Buffer.create (String.length raw) in
+  String.iter
+    (function
+      | '\\' -> Buffer.add_string buf "\\\\"
+      | '"' -> Buffer.add_string buf "\\\""
+      | '\n' -> Buffer.add_string buf "\\n"
+      | ch -> Buffer.add_char buf ch)
+    raw;
+  Buffer.contents buf
+;;
+
+let float_to_prometheus value =
+  match classify_float value with
+  | FP_nan -> "NaN"
+  | FP_infinite -> if value > 0.0 then "+Inf" else "-Inf"
+  | FP_normal | FP_subnormal | FP_zero -> Printf.sprintf "%.17g" value
+;;
+
+let labels_to_prometheus labels =
+  match labels with
+  | [] -> ""
+  | _ ->
+    labels
+    |> List.map (fun (key, value) ->
+      Printf.sprintf
+        "%s=\"%s\""
+        (prometheus_identifier key)
+        (escape_prometheus_value value))
+    |> String.concat ","
+    |> Printf.sprintf "{%s}"
+;;
+
+let add_prometheus_header buf ~name ~kind =
+  let prom_name = prometheus_identifier name in
+  Buffer.add_string buf (Printf.sprintf "# HELP %s %s\n" prom_name name);
+  Buffer.add_string buf (Printf.sprintf "# TYPE %s %s\n" prom_name kind);
+  prom_name
+;;
+
+let counter_to_prometheus buf (c : counter_data) =
+  let prom_name = add_prometheus_header buf ~name:c.c_name ~kind:"counter" in
+  LabelMap.iter
+    (fun labels value ->
+       Buffer.add_string
+         buf
+         (Printf.sprintf "%s%s %d\n" prom_name (labels_to_prometheus labels) value))
+    c.c_values
+;;
+
+let histogram_to_prometheus buf (h : histogram_data) =
+  let prom_name = add_prometheus_header buf ~name:h.h_name ~kind:"histogram" in
+  let sorted_buckets = List.sort Float.compare h.h_buckets in
+  List.iter
+    (fun bound ->
+       let count =
+         List.length (List.filter (fun value -> value <= bound) h.h_observations)
+       in
+       Buffer.add_string
+         buf
+         (Printf.sprintf
+            "%s_bucket%s %d\n"
+            prom_name
+            (labels_to_prometheus [ "le", float_to_prometheus bound ])
+            count))
+    sorted_buckets;
+  Buffer.add_string
+    buf
+    (Printf.sprintf
+       "%s_bucket%s %d\n"
+       prom_name
+       (labels_to_prometheus [ "le", "+Inf" ])
+       h.h_count);
+  Buffer.add_string
+    buf
+    (Printf.sprintf "%s_sum %s\n" prom_name (float_to_prometheus h.h_sum));
+  Buffer.add_string buf (Printf.sprintf "%s_count %d\n" prom_name h.h_count)
+;;
+
+let to_prometheus_text t =
+  with_lock t (fun () ->
+    let buf = Buffer.create 256 in
+    let counters = List.sort (fun a b -> String.compare a.c_name b.c_name) t.counters in
+    let histograms =
+      List.sort (fun a b -> String.compare a.h_name b.h_name) t.histograms
+    in
+    List.iter (counter_to_prometheus buf) counters;
+    List.iter (histogram_to_prometheus buf) histograms;
+    Buffer.contents buf)
+;;

--- a/lib/metrics.mli
+++ b/lib/metrics.mli
@@ -48,6 +48,13 @@ val observe : histogram -> float -> unit
 (** Export all metrics in OTLP JSON format. *)
 val to_otlp_json : t -> Yojson.Safe.t
 
+(** Export all metrics in Prometheus text exposition format.
+
+    OTel-style metric and label names such as [gen_ai.client.token.usage]
+    are normalized to Prometheus identifiers such as
+    [gen_ai_client_token_usage]. *)
+val to_prometheus_text : t -> string
+
 (** {1 Inspection} *)
 
 (** Read current counter value for given labels. *)

--- a/test/test_metrics.ml
+++ b/test/test_metrics.ml
@@ -81,6 +81,58 @@ let test_otlp_json_structure () =
   check int "2 metrics" 2 (List.length metrics)
 ;;
 
+let prometheus_lines text =
+  text |> String.split_on_char '\n' |> List.filter (fun line -> line <> "")
+;;
+
+let check_line label expected text =
+  check bool label true (List.mem expected (prometheus_lines text))
+;;
+
+let test_prometheus_text_counter_normalizes_names_and_labels () =
+  let m = Metrics.create () in
+  let c = Metrics.counter m ~name:"gen_ai.client.token.usage" ~unit_:"token" in
+  Metrics.incr c ~labels:[ "gen_ai.token.type", "input" ] 150;
+  Metrics.incr c ~labels:[ "gen_ai.token.type", "output" ] 42;
+  let text = Metrics.to_prometheus_text m in
+  check_line
+    "counter HELP"
+    "# HELP gen_ai_client_token_usage gen_ai.client.token.usage"
+    text;
+  check_line "counter TYPE" "# TYPE gen_ai_client_token_usage counter" text;
+  check_line
+    "input counter sample"
+    "gen_ai_client_token_usage{gen_ai_token_type=\"input\"} 150"
+    text;
+  check_line
+    "output counter sample"
+    "gen_ai_client_token_usage{gen_ai_token_type=\"output\"} 42"
+    text
+;;
+
+let test_prometheus_text_histogram_exports_buckets_sum_and_count () =
+  let m = Metrics.create () in
+  let h =
+    Metrics.histogram m ~name:"gen_ai.client.operation.duration" ~buckets:[ 1.0; 2.0 ]
+  in
+  Metrics.observe h 1.0;
+  Metrics.observe h 3.0;
+  let text = Metrics.to_prometheus_text m in
+  check_line
+    "histogram HELP"
+    "# HELP gen_ai_client_operation_duration gen_ai.client.operation.duration"
+    text;
+  check_line "histogram TYPE" "# TYPE gen_ai_client_operation_duration histogram" text;
+  check_line "bucket le 1" "gen_ai_client_operation_duration_bucket{le=\"1\"} 1" text;
+  check_line "bucket le 2" "gen_ai_client_operation_duration_bucket{le=\"2\"} 1" text;
+  check_line
+    "bucket le +Inf"
+    "gen_ai_client_operation_duration_bucket{le=\"+Inf\"} 2"
+    text;
+  check_line "histogram sum" "gen_ai_client_operation_duration_sum 4" text;
+  check_line "histogram count" "gen_ai_client_operation_duration_count 2" text
+;;
+
 let () =
   run
     "Metrics"
@@ -96,6 +148,16 @@ let () =
     ; ( "lifecycle"
       , [ test_case "reset clears all" `Quick (with_eio test_reset)
         ; test_case "otlp json structure" `Quick (with_eio test_otlp_json_structure)
+        ] )
+    ; ( "prometheus"
+      , [ test_case
+            "counter text export normalizes names and labels"
+            `Quick
+            (with_eio test_prometheus_text_counter_normalizes_names_and_labels)
+        ; test_case
+            "histogram text export emits buckets sum and count"
+            `Quick
+            (with_eio test_prometheus_text_histogram_exports_buckets_sum_and_count)
         ] )
     ]
 ;;


### PR DESCRIPTION
Summary
- Add Metrics.to_prometheus_text for counters and histograms.
- Normalize OTel dotted metric and label names into Prometheus identifiers.
- Cover counter and histogram text export with focused regression tests.

Why
- The old telemetry gap doc called out that OAS metrics only had OTLP JSON export. This adds a direct Prometheus text surface without changing existing OTLP behavior.

Validation
- scripts/dune-local.sh build @test/runtest-test_metrics
- ocamlformat --check lib/metrics.ml lib/metrics.mli test/test_metrics.ml
- git diff --check HEAD~1..HEAD