### PR TITLE
[codex] route legacy create_message through hardened HTTP client

### DIFF
--- a/lib/api.ml
+++ b/lib/api.ml
@@ -5,6 +5,25 @@ open Types
 
 type response_accept = Types.api_response -> (unit, string) result
 
+let retry_error_of_http_error = function
+  | Llm_provider.Http_client.HttpError { code; body } ->
+    Retry.classify_error ~status:code ~body
+  | Llm_provider.Http_client.NetworkError
+      { message; kind = Llm_provider.Http_client.Timeout } -> Retry.Timeout { message }
+  | Llm_provider.Http_client.NetworkError { message; kind } ->
+    Retry.NetworkError { message; kind }
+  | Llm_provider.Http_client.AcceptRejected { reason } ->
+    Retry.InvalidRequest { message = "Response rejected: " ^ reason }
+  | Llm_provider.Http_client.CliTransportRequired { kind } ->
+    Retry.InvalidRequest
+      { message = Printf.sprintf "Provider kind requires CLI transport: %s" kind }
+  | Llm_provider.Http_client.ProviderTerminal { message; _ } ->
+    Retry.InvalidRequest { message }
+  | Llm_provider.Http_client.ProviderFailure { kind; message } ->
+    Retry.InvalidRequest
+      { message = Llm_provider.Http_client.provider_failure_to_string ~kind ~message }
+;;
+
 (* Re-export Api_common *)
 let default_base_url = Api_common.default_base_url
 let api_version = Api_common.api_version
@@ -114,7 +133,6 @@ let create_message
   match resolve_result with
   | Error e -> Error e
   | Ok (provider_cfg, base_url, header_list) ->
-    let headers = Http.Header.of_list header_list in
     let model_spec = Provider.model_spec_of_config provider_cfg in
     let kind = model_spec.request_kind in
     let path = model_spec.request_path in
@@ -136,30 +154,22 @@ let create_message
          | Some impl -> impl.build_body ~config ~messages ?tools ()
          | None -> Yojson.Safe.to_string (`Assoc []))
     in
-    let uri = Uri.of_string (base_url ^ path) in
-    let https = make_https () in
-    let client = Cohttp_eio.Client.make ~https net in
+    let url = base_url ^ path in
     let do_http_call () =
-      let resp, body =
-        Cohttp_eio.Client.post
+      match
+        Llm_provider.Http_client.post_sync
+          ?clock
+          ~timeout_s:request_timeout_s
           ~sw
-          client
-          ~headers
-          ~body:(Cohttp_eio.Body.of_string body_str)
-          uri
-      in
-      match Cohttp.Response.status resp with
-      | `OK ->
-        let body_str =
-          Eio.Buf_read.(of_flow ~max_size:max_response_body body |> take_all)
-        in
-        `Ok body_str
-      | status ->
-        let code = Cohttp.Code.code_of_status status in
-        let body_str =
-          Eio.Buf_read.(of_flow ~max_size:max_response_body body |> take_all)
-        in
-        `HttpError (code, body_str)
+          ~net
+          ~url
+          ~headers:header_list
+          ~body:body_str
+          ()
+      with
+      | Ok (200, body_str) -> `Ok body_str
+      | Ok (code, body_str) -> `HttpError (code, body_str)
+      | Error err -> `TransportError (retry_error_of_http_error err)
     in
     let do_request () =
       let t0 = Unix.gettimeofday () in
@@ -204,6 +214,7 @@ let create_message
                  | Error msg -> Error (Retry.InvalidRequest { message = msg }))))
         | `HttpError (code, body_str) ->
           Error (Retry.classify_error ~status:code ~body:body_str)
+        | `TransportError err -> Error err
       with
       | Eio.Time.Timeout ->
         Error

--- a/test/dune
+++ b/test/dune
@@ -38,6 +38,7 @@
   test_agent_turn
   test_agent_turn_budget_unit
   test_agent_typed
+  test_api_http_client
   test_api_dispatch
   test_append_instruction
   test_approval
@@ -245,6 +246,7 @@
   test_agent_turn
   test_agent_turn_budget_unit
   test_agent_typed
+  test_api_http_client
   test_api_dispatch
   test_append_instruction
   test_approval

--- a/test/test_api_http_client.ml
+++ b/test/test_api_http_client.ml
@@ -1,0 +1,102 @@
+open Agent_sdk
+open Types
+
+let openai_response =
+  {|{"id":"chatcmpl-legacy-api","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2}}|}
+;;
+
+let with_mock_server ~port handler f =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let socket =
+      Eio.Net.listen
+        env#net
+        ~sw
+        ~backlog:128
+        ~reuse_addr:true
+        (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+    in
+    let server = Cohttp_eio.Server.make ~callback:handler () in
+    Eio.Fiber.fork ~sw (fun () ->
+      Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+    let base_url = Printf.sprintf "http://127.0.0.1:%d" port in
+    f ~sw ~net:env#net ~clock:env#clock ~base_url;
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
+let test_create_message_uses_hardened_http_client () =
+  let seen_connection = ref None in
+  let seen_content_length = ref None in
+  let seen_path = ref None in
+  let handler _conn req body =
+    let headers = Cohttp.Request.headers req in
+    seen_connection := Cohttp.Header.get headers "connection";
+    seen_content_length := Cohttp.Header.get headers "content-length";
+    seen_path := Some (Uri.path (Cohttp.Request.uri req));
+    ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
+    Cohttp_eio.Server.respond_string ~status:`OK ~body:openai_response ()
+  in
+  with_mock_server ~port:18341 handler (fun ~sw ~net ~clock ~base_url ->
+    let provider : Provider.config =
+      { provider = Local { base_url }; model_id = "mock"; api_key_env = "DUMMY_KEY" }
+    in
+    let config =
+      { default_config with
+        model = provider.model_id
+      ; system_prompt = Some "reply briefly"
+      ; max_turns = 1
+      ; max_tokens = Some 16
+      }
+    in
+    let state = { config; messages = []; turn_count = 0; usage = empty_usage } in
+    let messages =
+      [ { role = User
+        ; content = [ Text "hello" ]
+        ; name = None
+        ; tool_call_id = None
+        ; metadata = []
+        }
+      ]
+    in
+    match Api.create_message ~sw ~net ~clock ~provider ~config:state ~messages () with
+    | Error err -> Alcotest.failf "expected Ok, got %s" (Error.to_string err)
+    | Ok response ->
+      Alcotest.(check (option string))
+        "request path"
+        (Some "/v1/chat/completions")
+        !seen_path;
+      Alcotest.(check (option string)) "connection close" (Some "close") !seen_connection;
+      Alcotest.(check bool)
+        "content-length set"
+        true
+        (match !seen_content_length with
+         | Some raw -> int_of_string_opt raw |> Option.value ~default:0 > 0
+         | None -> false);
+      Alcotest.(check string) "model" "mock" response.model;
+      Alcotest.(check int)
+        "text blocks"
+        1
+        (List.length
+           (List.filter_map
+              (function
+                | Text text -> Some text
+                | _ -> None)
+              response.content)))
+;;
+
+let () =
+  Alcotest.run
+    "Api_http_client"
+    [ ( "legacy_create_message"
+      , [ Alcotest.test_case
+            "uses hardened post_sync headers"
+            `Quick
+            test_create_message_uses_hardened_http_client
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- route legacy `Api.create_message` through `Llm_provider.Http_client.post_sync` instead of constructing a raw `Cohttp_eio.Client`
- preserve existing provider parsing/retry classification while using the shared timeout, connection-close, content-length, and switch-scoped FD cleanup behavior
- add a regression test proving the legacy path sends `Connection: close`, sets `Content-Length`, and still parses OpenAI-compatible responses

## Why
The old performance notes flagged `api.ml` as a remaining low-level stall/FD-risk boundary. Newer provider paths already use the shared HTTP client; this closes the legacy bypass without changing the public API.

## Verification
- scripts/dune-local.sh build @test/runtest-test_api_http_client
- scripts/dune-local.sh build @test/runtest-test_api_http_client @test/runtest-test_api
- scripts/dune-local.sh build @test/runtest-test_api_http_client @test/runtest-test_api @test/runtest-test_eio_cancellability
- ocamlformat --check lib/api.ml test/test_api_http_client.ml
- git diff --check

Intentionally draft.