### PR TITLE
[codex] route provider interface through hardened HTTP client

### DIFF
--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -6,7 +6,24 @@
     {b Compile-time guarantee}: attempting to pass a non-streaming
     provider as STREAMING_PROVIDER produces a type error. *)
 
+module Http_client = Llm_provider.Http_client
 module Retry = Llm_provider.Retry
+
+let retry_error_of_http_error = function
+  | Http_client.HttpError { code; body } -> Retry.classify_error ~status:code ~body
+  | Http_client.NetworkError { message; kind = Http_client.Timeout } ->
+    Retry.Timeout { message }
+  | Http_client.NetworkError { message; kind } -> Retry.NetworkError { message; kind }
+  | Http_client.AcceptRejected { reason } ->
+    Retry.InvalidRequest { message = "Response rejected: " ^ reason }
+  | Http_client.CliTransportRequired { kind } ->
+    Retry.InvalidRequest
+      { message = Printf.sprintf "Provider kind requires CLI transport: %s" kind }
+  | Http_client.ProviderTerminal { message; _ } -> Retry.InvalidRequest { message }
+  | Http_client.ProviderFailure { kind; message } ->
+    Retry.InvalidRequest
+      { message = Http_client.provider_failure_to_string ~kind ~message }
+;;
 
 (** Synchronous provider: can send a message and get a response. *)
 module type PROVIDER = sig
@@ -76,60 +93,30 @@ let of_config (provider_cfg : Provider.config) : provider_module =
            | Some impl -> impl.build_body ~config ~messages ?tools ()
            | None -> Yojson.Safe.to_string (`Assoc []))
       in
-      let uri = Uri.of_string (base_url ^ path) in
-      let https = Api_common.make_https () in
-      let client = Cohttp_eio.Client.make ~https net in
-      let hdr_list = headers in
-      let hdr = Http.Header.of_list hdr_list in
-      try
-        let resp, body =
-          Cohttp_eio.Client.post
-            ~sw
-            client
-            ~headers:hdr
-            ~body:(Cohttp_eio.Body.of_string body_str)
-            uri
-        in
-        match Cohttp.Response.status resp with
-        | `OK ->
-          let body_str =
-            Eio.Buf_read.(of_flow ~max_size:Api_common.max_response_body body |> take_all)
-          in
-          (match kind with
-           | Provider.Anthropic_messages ->
-             Ok (Api_anthropic.parse_response (Yojson.Safe.from_string body_str))
-           | Provider.Openai_chat_completions ->
-             (match
-                Llm_provider.Backend_openai_parse.parse_openai_response_result body_str
-              with
-              | Ok resp -> Ok resp
-              | Error msg -> Error (Error.Api (Retry.InvalidRequest { message = msg })))
-           | Provider.Custom name ->
-             (match Provider.find_provider name with
-              | Some impl -> Ok (impl.parse_response body_str)
-              | None ->
-                (match
-                   Llm_provider.Backend_openai_parse.parse_openai_response_result body_str
-                 with
-                 | Ok resp -> Ok resp
-                 | Error msg -> Error (Error.Api (Retry.InvalidRequest { message = msg })))))
-        | status ->
-          let code = Cohttp.Code.code_of_status status in
-          let body_str =
-            Eio.Buf_read.(of_flow ~max_size:Api_common.max_response_body body |> take_all)
-          in
-          Error (Error.Api (Retry.classify_error ~status:code ~body:body_str))
-      with
-      | Eio.Io _ as exn ->
-        Error
-          (Error.Api
-             (Retry.NetworkError { message = Printexc.to_string exn; kind = Unknown }))
-      | Unix.Unix_error _ as exn ->
-        Error
-          (Error.Api
-             (Retry.NetworkError { message = Printexc.to_string exn; kind = Unknown }))
-      | Failure msg ->
-        Error (Error.Api (Retry.NetworkError { message = msg; kind = Unknown }))
+      let url = base_url ^ path in
+      match Http_client.post_sync ~sw ~net ~url ~headers ~body:body_str () with
+      | Ok (200, body_str) ->
+        (match kind with
+         | Provider.Anthropic_messages ->
+           Ok (Api_anthropic.parse_response (Yojson.Safe.from_string body_str))
+         | Provider.Openai_chat_completions ->
+           (match
+              Llm_provider.Backend_openai_parse.parse_openai_response_result body_str
+            with
+            | Ok resp -> Ok resp
+            | Error msg -> Error (Error.Api (Retry.InvalidRequest { message = msg })))
+         | Provider.Custom name ->
+           (match Provider.find_provider name with
+            | Some impl -> Ok (impl.parse_response body_str)
+            | None ->
+              (match
+                 Llm_provider.Backend_openai_parse.parse_openai_response_result body_str
+               with
+               | Ok resp -> Ok resp
+               | Error msg -> Error (Error.Api (Retry.InvalidRequest { message = msg })))))
+      | Ok (code, body_str) ->
+        Error (Error.Api (Retry.classify_error ~status:code ~body:body_str))
+      | Error err -> Error (Error.Api (retry_error_of_http_error err))
     ;;
   end
   in

--- a/test/test_provider_intf.ml
+++ b/test/test_provider_intf.ml
@@ -1,6 +1,7 @@
 (** Provider_intf tests — module type satisfaction and dispatch. *)
 
 open Agent_sdk
+open Agent_sdk.Types
 
 (* ── Module type satisfaction ────────────────────────────── *)
 
@@ -36,6 +37,88 @@ let test_streaming_provider_some () =
   | None -> Alcotest.fail "expected Some for anthropic"
 ;;
 
+(* ── HTTP dispatch ───────────────────────────────────────── *)
+
+let openai_response =
+  {|{"id":"chatcmpl-provider-intf","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2}}|}
+;;
+
+let with_mock_server ~port handler f =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let socket =
+      Eio.Net.listen
+        env#net
+        ~sw
+        ~backlog:128
+        ~reuse_addr:true
+        (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+    in
+    let server = Cohttp_eio.Server.make ~callback:handler () in
+    Eio.Fiber.fork ~sw (fun () ->
+      Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+    let base_url = Printf.sprintf "http://127.0.0.1:%d" port in
+    f ~sw ~net:env#net ~base_url;
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
+let test_provider_dispatch_uses_http_client () =
+  let seen_connection = ref None in
+  let seen_content_length = ref None in
+  let seen_path = ref None in
+  let handler _conn req body =
+    let headers = Cohttp.Request.headers req in
+    seen_connection := Cohttp.Header.get headers "connection";
+    seen_content_length := Cohttp.Header.get headers "content-length";
+    seen_path := Some (Uri.path (Cohttp.Request.uri req));
+    ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
+    Cohttp_eio.Server.respond_string ~status:`OK ~body:openai_response ()
+  in
+  with_mock_server ~port:18342 handler (fun ~sw ~net ~base_url ->
+    let provider : Provider.config =
+      { provider = Local { base_url }; model_id = "mock"; api_key_env = "DUMMY_KEY" }
+    in
+    let (module P : Provider_intf.PROVIDER) = Provider_intf.of_config provider in
+    let config =
+      { default_config with
+        model = provider.model_id
+      ; system_prompt = Some "reply briefly"
+      ; max_turns = 1
+      ; max_tokens = Some 16
+      }
+    in
+    let state = { config; messages = []; turn_count = 0; usage = empty_usage } in
+    let messages =
+      [ { role = User
+        ; content = [ Text "hello" ]
+        ; name = None
+        ; tool_call_id = None
+        ; metadata = []
+        }
+      ]
+    in
+    match P.create_message ~sw ~net ~config:state ~messages () with
+    | Error err -> Alcotest.failf "expected Ok, got %s" (Error.to_string err)
+    | Ok response ->
+      Alcotest.(check (option string))
+        "request path"
+        (Some "/v1/chat/completions")
+        !seen_path;
+      Alcotest.(check (option string)) "connection close" (Some "close") !seen_connection;
+      Alcotest.(check bool)
+        "content-length set"
+        true
+        (match !seen_content_length with
+         | Some raw -> int_of_string_opt raw |> Option.value ~default:0 > 0
+         | None -> false);
+      Alcotest.(check string) "model" "mock" response.model)
+;;
+
 (* ── Runner ──────────────────────────────────────────────── *)
 
 let () =
@@ -54,6 +137,12 @@ let () =
             `Quick
             test_anthropic_supports_streaming
         ; Alcotest.test_case "of_config_streaming" `Quick test_streaming_provider_some
+        ] )
+    ; ( "http_dispatch"
+      , [ Alcotest.test_case
+            "uses hardened post_sync headers"
+            `Quick
+            test_provider_dispatch_uses_http_client
         ] )
     ]
 ;;


### PR DESCRIPTION
Summary
- route `Provider_intf.of_config` synchronous dispatch through `Llm_provider.Http_client.post_sync`
- preserve provider-specific response parsing and HTTP error classification
- add a mock HTTP regression that verifies provider interface requests carry `Connection: close`, `Content-Length`, and the expected OpenAI-compatible path

Why
- the old provider interface path still constructed `Cohttp_eio.Client` directly and read bodies itself, bypassing the hardened client wrapper that closes transports promptly and normalizes network errors
- this closes another HTTP-client bypass called out by the old OCaml server performance analysis, adjacent to the legacy `Api.create_message` path

Validation
- `scripts/dune-local.sh build @test/runtest-test_provider_intf`
- `scripts/dune-local.sh build @test/runtest-test_http_client`
- `ocamlformat --check lib/provider_intf.ml test/test_provider_intf.ml`
- `git diff --check`
- `rg -n "Cohttp_eio\.Client|Eio\.Buf_read\.\(of_flow ~max_size:Api_common\.max_response_body|Http\.Header" lib/provider_intf.ml` returned no matches

Notes
- Draft PR intentionally; human review/ready labels remain separate policy gates.