### PR TITLE
[codex] route agent registry discovery through HTTP client

### DIFF
--- a/lib/protocol/agent_registry.ml
+++ b/lib/protocol/agent_registry.ml
@@ -84,36 +84,32 @@ let list_by_tool t tool_name =
 (** Fetch agent card from a remote URL via GET <url>/.well-known/agent.json. *)
 let fetch_remote_card ~sw ~net url =
   let card_url = url ^ "/.well-known/agent.json" in
-  let uri = Uri.of_string card_url in
-  let https = Api.make_https () in
-  let client = Cohttp_eio.Client.make ~https net in
-  try
-    let resp, body = Cohttp_eio.Client.get ~sw client uri in
-    match Cohttp.Response.status resp with
-    | `OK ->
-      let body_str =
-        Eio.Buf_read.(
-          of_flow ~max_size:Llm_provider.Api_common.max_response_body body |> take_all)
-      in
-      (try
-         let json = Yojson.Safe.from_string body_str in
-         Agent_card.of_json json
-       with
-       | Yojson.Json_error msg ->
-         Error
-           (Error.Orchestration
-              (DiscoveryFailed { url; detail = "JSON parse error: " ^ msg })))
-    | status ->
-      let code = Cohttp.Code.code_of_status status in
-      Error
-        (Error.Orchestration
-           (DiscoveryFailed { url; detail = Printf.sprintf "HTTP %d" code }))
-  with
-  | Eio.Io _ as exn ->
-    Error (Error.Orchestration (DiscoveryFailed { url; detail = Printexc.to_string exn }))
-  | Unix.Unix_error _ as exn ->
-    Error (Error.Orchestration (DiscoveryFailed { url; detail = Printexc.to_string exn }))
-  | Failure msg -> Error (Error.Orchestration (DiscoveryFailed { url; detail = msg }))
+  let error_detail = function
+    | Llm_provider.Http_client.HttpError { code; body } ->
+      Printf.sprintf "HTTP %d: %s" code body
+    | NetworkError { message; _ } -> message
+    | AcceptRejected { reason } -> "Response rejected: " ^ reason
+    | CliTransportRequired { kind } -> "CLI transport required: " ^ kind
+    | ProviderTerminal { message; _ } -> message
+    | ProviderFailure { kind; message } ->
+      Llm_provider.Http_client.provider_failure_to_string ~kind ~message
+  in
+  match Llm_provider.Http_client.get_sync ~sw ~net ~url:card_url ~headers:[] () with
+  | Ok (200, body_str) ->
+    (try
+       let json = Yojson.Safe.from_string body_str in
+       Agent_card.of_json json
+     with
+     | Yojson.Json_error msg ->
+       Error
+         (Error.Orchestration
+            (DiscoveryFailed { url; detail = "JSON parse error: " ^ msg })))
+  | Ok (code, _) ->
+    Error
+      (Error.Orchestration
+         (DiscoveryFailed { url; detail = Printf.sprintf "HTTP %d" code }))
+  | Error err ->
+    Error (Error.Orchestration (DiscoveryFailed { url; detail = error_detail err }))
 ;;
 
 (** Discover a remote agent by fetching its card and registering it. *)

--- a/lib/protocol/agent_registry.mli
+++ b/lib/protocol/agent_registry.mli
@@ -29,13 +29,13 @@ val list_by_tool : t -> string -> (string * agent_entry) list
 
 val fetch_remote_card
   :  sw:Eio.Switch.t
-  -> net:_ Eio.Net.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> string
   -> (Agent_card.agent_card, Error.sdk_error) result
 
 val discover_and_register
   :  sw:Eio.Switch.t
-  -> net:_ Eio.Net.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> t
   -> name:string
   -> url:string

--- a/test/test_agent_registry.ml
+++ b/test/test_agent_registry.ml
@@ -10,6 +10,81 @@ let make_agent () =
   Agent.create ~net ()
 ;;
 
+let fresh_port () =
+  let s = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Unix.setsockopt s Unix.SO_REUSEADDR true;
+  Unix.bind s (Unix.ADDR_INET (Unix.inet_addr_loopback, 0));
+  let port =
+    match Unix.getsockname s with
+    | Unix.ADDR_INET (_, p) -> p
+    | _ -> fail "expected TCP socket"
+  in
+  Unix.close s;
+  port
+;;
+
+let request_path request_line =
+  match String.split_on_char ' ' request_line with
+  | _method_ :: path :: _ -> path
+  | _ -> request_line
+;;
+
+let header_value line =
+  match String.index_opt line ':' with
+  | None -> None
+  | Some idx ->
+    let value_start = idx + 1 in
+    let value_len = String.length line - value_start in
+    Some (String.trim (String.sub line value_start value_len))
+;;
+
+let start_card_server ~sw ~net card =
+  let port = fresh_port () in
+  let seen_path = ref None in
+  let seen_connection = ref None in
+  let socket =
+    Eio.Net.listen
+      net
+      ~sw
+      ~backlog:128
+      ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  Eio.Fiber.fork ~sw (fun () ->
+    Eio.Net.accept_fork
+      ~sw
+      socket
+      ~on_error:(fun _ -> ())
+      (fun flow _addr ->
+         let reader = Eio.Buf_read.of_flow flow ~max_size:8192 in
+         let request_line = Eio.Buf_read.line reader in
+         seen_path := Some (request_path request_line);
+         let rec read_headers () =
+           match Eio.Buf_read.line reader with
+           | "" -> ()
+           | line ->
+             if String.starts_with ~prefix:"connection:" (String.lowercase_ascii line)
+             then seen_connection := Option.map String.lowercase_ascii (header_value line);
+             read_headers ()
+           | exception End_of_file -> ()
+         in
+         read_headers ();
+         let body = Agent_card.to_json card |> Yojson.Safe.to_string in
+         let response =
+           Printf.sprintf
+             "HTTP/1.1 200 OK\r\n\
+              Content-Length: %d\r\n\
+              Content-Type: application/json\r\n\
+              Connection: close\r\n\
+              \r\n\
+              %s"
+             (String.length body)
+             body
+         in
+         Eio.Flow.copy_string response flow));
+  Printf.sprintf "http://127.0.0.1:%d" port, seen_path, seen_connection
+;;
+
 (* ── Registration and lookup ────────────────────────────── *)
 
 let test_register_local () =
@@ -212,6 +287,36 @@ let test_fetch_card_unreachable () =
   | Ok _ -> fail "should fail for unreachable"
 ;;
 
+let test_fetch_card_http_client () =
+  Eio_main.run
+  @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  Eio.Switch.run
+  @@ fun sw ->
+  let card : Agent_card.agent_card =
+    { name = "remote-agent"
+    ; description = Some "A remote agent"
+    ; protocol_version = "1.0"
+    ; version = "1.0.0"
+    ; url = Some "http://example.com"
+    ; authentication = None
+    ; supported_interfaces = []
+    ; capabilities = [ Tools ]
+    ; tools = []
+    ; skills = []
+    ; supported_providers = []
+    ; metadata = []
+    }
+  in
+  let base_url, seen_path, seen_connection = start_card_server ~sw ~net card in
+  match Agent_registry.fetch_remote_card ~sw ~net base_url with
+  | Error err -> failf "fetch failed: %s" (Error.to_string err)
+  | Ok fetched ->
+    check string "card name" "remote-agent" fetched.name;
+    check (option string) "path" (Some "/.well-known/agent.json") !seen_path;
+    check (option string) "connection close" (Some "close") !seen_connection
+;;
+
 (* ── Overwrite registration ─────────────────────────────── *)
 
 let test_overwrite () =
@@ -264,6 +369,7 @@ let () =
     ; ( "discovery"
       , [ test_case "unreachable" `Quick test_discover_unreachable
         ; test_case "fetch card unreachable" `Quick test_fetch_card_unreachable
+        ; test_case "fetch card via http client" `Quick test_fetch_card_http_client
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- Route `Agent_registry.fetch_remote_card` through `Llm_provider.Http_client.get_sync` instead of constructing a direct `Cohttp_eio.Client`.
- Keep discovery error reporting mapped to `DiscoveryFailed`, while inheriting the central client's bounded body read, timeout classification, and explicit connection close behavior.
- Add a one-shot local HTTP regression for agent-card discovery that verifies the `/.well-known/agent.json` path and `Connection: close` request header.

## Why

The OCaml server performance audit called out direct per-call HTTP client construction and manual response reads as a boundary that can leak connection lifecycle behavior outside the hardened HTTP client. The provider paths are being moved to the central client; this closes the same gap for remote agent-card discovery.

## Validation

- `scripts/dune-local.sh build @test/runtest-test_agent_registry`
- `ocamlformat --check lib/protocol/agent_registry.ml lib/protocol/agent_registry.mli test/test_agent_registry.ml`
- `git diff --check`
- `rg -n "Cohttp_eio\\.Client|Eio\\.Buf_read\\.\\(.*max_response_body|Http\\.Header|Cohttp\\.Response|Uri\\.of_string" lib/protocol/agent_registry.ml` returned no matches.

## Note

I attempted to also run `@test/runtest-test_http_client`, but the process was waiting on the shared `/tmp/me-dune-local.lock` behind an unrelated MASC build. I stopped that extra wait; the targeted registry suite passed.
