### PR TITLE
Add Ollama Cloud direct auth

### DIFF
--- a/lib/llm_provider/provider_kind.ml
+++ b/lib/llm_provider/provider_kind.ml
@@ -57,8 +57,8 @@ let default_api_key_env = function
   | Glm -> Some "ZAI_API_KEY"
   | DashScope -> Some "DASHSCOPE_API_KEY"
   | OpenAI_compat | Ollama | Claude_code | Gemini_cli | Kimi_cli | Codex_cli ->
-    (* Ollama Cloud uses the same kind; set OLLAMA_API_KEY when using
-       a remote endpoint that requires authentication. *)
+    (* Ollama Cloud uses the same wire kind. The named provider entry
+       prefers OLLAMA_CLOUD_API_KEY and falls back to OLLAMA_API_KEY. *)
     None
 ;;
 

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -29,7 +29,23 @@ let find_capable t pred = all t |> List.filter (fun e -> pred e.capabilities)
 
 (* ── Default registry ─────────────────────────────────── *)
 
-let has_api_key env_name = env_name = "" || Cli_common_env.get env_name <> None
+let api_key_env_candidates = function
+  | "OLLAMA_CLOUD_API_KEY" -> [ "OLLAMA_CLOUD_API_KEY"; "OLLAMA_API_KEY" ]
+  | env_name -> [ env_name ]
+;;
+
+let has_direct_api_key env_name =
+  env_name = ""
+  ||
+  match Cli_common_env.get env_name with
+  | Some value -> String.trim value <> ""
+  | None -> false
+;;
+
+let has_api_key env_name =
+  api_key_env_candidates env_name |> List.exists has_direct_api_key
+;;
+
 let has_any_api_key env_names = List.exists has_api_key env_names
 
 let path_entries ?path () =
@@ -272,6 +288,14 @@ let ollama_defaults =
   }
 ;;
 
+let ollama_cloud_defaults =
+  { kind = Ollama
+  ; base_url = env_or_default "OLLAMA_CLOUD_BASE_URL" "https://ollama.com"
+  ; api_key_env = "OLLAMA_CLOUD_API_KEY"
+  ; request_path = "/api/chat"
+  }
+;;
+
 let openrouter_defaults =
   { kind = OpenAI_compat
   ; base_url = "https://openrouter.ai/api/v1"
@@ -400,6 +424,11 @@ let default () =
     ; capabilities = Capabilities.ollama_capabilities
     ; is_available = (fun () -> true)
     };
+  reg
+    "ollama_cloud"
+    ollama_cloud_defaults
+    ~max_context:262_144
+    Capabilities.ollama_capabilities;
   (* CLI subprocess providers. Exposed under explicit provider labels so
      caller-managed provider/model specs can opt into the non-interactive transports
      without reusing the direct API names. *)
@@ -496,7 +525,13 @@ let provider_name_of_config (config : Provider_config.t) =
   | Gemini_cli -> "gemini_cli"
   | Kimi_cli -> "kimi_cli"
   | Codex_cli -> "codex_cli"
-  | Ollama -> "ollama"
+  | Ollama ->
+    if
+      String.equal
+        (normalize_url config.base_url)
+        (normalize_url ollama_cloud_defaults.base_url)
+    then "ollama_cloud"
+    else "ollama"
   | DashScope -> "dashscope"
   | OpenAI_compat ->
     if Provider_config.is_local config

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -621,6 +621,40 @@ let default_api_key_env_of_kind (kind : Llm_provider.Provider_config.provider_ki
   | None -> ""
 ;;
 
+let api_key_env_candidates = function
+  | "OLLAMA_CLOUD_API_KEY" -> [ "OLLAMA_CLOUD_API_KEY"; "OLLAMA_API_KEY" ]
+  | env_name -> [ env_name ]
+;;
+
+let api_key_from_env env_name =
+  api_key_env_candidates env_name
+  |> List.find_map (fun name ->
+    match Sys.getenv_opt name with
+    | Some value when String.trim value <> "" -> Some value
+    | _ -> None)
+  |> Option.value ~default:""
+;;
+
+let headers_with_auth_for_kind
+      ~(kind : Llm_provider.Provider_config.provider_kind)
+      ~api_key
+  =
+  let base = [ "Content-Type", "application/json" ] in
+  match String.trim api_key with
+  | "" -> base
+  | key ->
+    (match kind with
+     | Anthropic | Kimi ->
+       [ "x-api-key", key
+       ; "anthropic-version", "2023-06-01"
+       ; "Content-Type", "application/json"
+       ]
+     | Gemini -> base
+     | OpenAI_compat | Ollama | Glm | DashScope ->
+       ("Authorization", "Bearer " ^ key) :: base
+     | Claude_code | Gemini_cli | Kimi_cli | Codex_cli -> [])
+;;
+
 (** Convert a [Llm_provider.Provider_config.t] into a
     [Provider.config] (for Agent Builder).  Keeps the conversion
     internal to OAS so consumers don't need their own adapters.
@@ -766,16 +800,16 @@ let provider_config_of_agent
              let api_key =
                if entry.defaults.api_key_env = ""
                then ""
-               else (
-                 match Sys.getenv_opt entry.defaults.api_key_env with
-                 | Some k -> k
-                 | None -> "")
+               else api_key_from_env entry.defaults.api_key_env
+             in
+             let headers =
+               headers_with_auth_for_kind ~kind:entry.defaults.kind ~api_key
              in
              build
                ~kind:entry.defaults.kind
                ~resolved_base_url:entry.defaults.base_url
                ~api_key
-               ~headers:[]
+               ~headers
                ~request_path:entry.defaults.request_path
                ~model_id:p.model_id))
      | Anthropic | Local _ | OpenAICompat _ ->

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -3,6 +3,19 @@
 
 open Agent_sdk
 
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+;;
+
 let test_missing_env_var () =
   (* Anthropic provider checks env var; nonexistent key -> Error *)
   let cfg : Provider.config =
@@ -757,6 +770,64 @@ let test_provider_config_of_agent_custom_registered_kimi_preserves_headers () =
   | Error e -> Alcotest.fail (Printf.sprintf "unexpected error: %s" (Error.to_string e))
 ;;
 
+let test_provider_config_of_agent_custom_registered_ollama_cloud_headers () =
+  with_env "OLLAMA_CLOUD_API_KEY" (Some "ollama-cloud-provider-test-key") (fun () ->
+    with_env "OLLAMA_API_KEY" (Some "fallback-ollama-api-key") (fun () ->
+      let cfg : Provider.config =
+        { provider = Custom_registered { name = "ollama_cloud" }
+        ; model_id = "glm-5.1:cloud"
+        ; api_key_env = "OLLAMA_CLOUD_API_KEY"
+        }
+      in
+      let state = agent_state_with_params () in
+      match
+        Provider.provider_config_of_agent ~state ~base_url:"unused-fallback" (Some cfg)
+      with
+      | Ok pc ->
+        Alcotest.(check bool)
+          "kind preserves Ollama"
+          true
+          (pc.kind = Llm_provider.Provider_config.Ollama);
+        Alcotest.(check string) "base_url" "https://ollama.com" pc.base_url;
+        Alcotest.(check string) "request_path" "/api/chat" pc.request_path;
+        Alcotest.(check string)
+          "uses cloud-specific key first"
+          "ollama-cloud-provider-test-key"
+          pc.api_key;
+        Alcotest.(check bool)
+          "Authorization header present"
+          true
+          (List.mem ("Authorization", "Bearer ollama-cloud-provider-test-key") pc.headers)
+      | Error e ->
+        Alcotest.fail (Printf.sprintf "unexpected error: %s" (Error.to_string e))))
+;;
+
+let test_provider_config_of_agent_custom_registered_ollama_cloud_api_key_fallback () =
+  with_env "OLLAMA_CLOUD_API_KEY" None (fun () ->
+    with_env "OLLAMA_API_KEY" (Some "ollama-api-fallback-key") (fun () ->
+      let cfg : Provider.config =
+        { provider = Custom_registered { name = "ollama_cloud" }
+        ; model_id = "deepseek-v4-pro:cloud"
+        ; api_key_env = "OLLAMA_CLOUD_API_KEY"
+        }
+      in
+      let state = agent_state_with_params () in
+      match
+        Provider.provider_config_of_agent ~state ~base_url:"unused-fallback" (Some cfg)
+      with
+      | Ok pc ->
+        Alcotest.(check string)
+          "uses OLLAMA_API_KEY fallback"
+          "ollama-api-fallback-key"
+          pc.api_key;
+        Alcotest.(check bool)
+          "Authorization header present"
+          true
+          (List.mem ("Authorization", "Bearer ollama-api-fallback-key") pc.headers)
+      | Error e ->
+        Alcotest.fail (Printf.sprintf "unexpected error: %s" (Error.to_string e))))
+;;
+
 let test_provider_config_of_agent_custom_registered_unknown_name () =
   let cfg : Provider.config =
     { provider = Custom_registered { name = "nonexistent-provider-xyz" }
@@ -904,6 +975,14 @@ let () =
             "custom registered kimi preserves headers"
             `Quick
             test_provider_config_of_agent_custom_registered_kimi_preserves_headers
+        ; Alcotest.test_case
+            "custom registered ollama_cloud adds auth header"
+            `Quick
+            test_provider_config_of_agent_custom_registered_ollama_cloud_headers
+        ; Alcotest.test_case
+            "custom registered ollama_cloud falls back to OLLAMA_API_KEY"
+            `Quick
+            test_provider_config_of_agent_custom_registered_ollama_cloud_api_key_fallback
         ; Alcotest.test_case
             "custom registered unknown name errors"
             `Quick

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -204,12 +204,17 @@ let test_find_capable_composite () =
 
 (* ── Default registry ───────────────────────────────── *)
 
-let test_default_has_18 () =
+let test_default_has_19 () =
   let reg = Provider_registry.default () in
   let all = Provider_registry.all reg in
-  check int "18 known providers" 18 (List.length all);
+  check int "19 known providers" 19 (List.length all);
   check bool "llama exists" true (Option.is_some (Provider_registry.find reg "llama"));
   check bool "ollama exists" true (Option.is_some (Provider_registry.find reg "ollama"));
+  check
+    bool
+    "ollama_cloud exists"
+    true
+    (Option.is_some (Provider_registry.find reg "ollama_cloud"));
   check bool "claude exists" true (Option.is_some (Provider_registry.find reg "claude"));
   check bool "gemini exists" true (Option.is_some (Provider_registry.find reg "gemini"));
   check bool "glm exists" true (Option.is_some (Provider_registry.find reg "glm"));
@@ -276,6 +281,33 @@ let test_default_capabilities () =
     check bool "llama has tools" true e.capabilities.supports_tools;
     check bool "llama has top_k" true e.capabilities.supports_top_k
   | None -> fail "llama should exist"
+;;
+
+let test_default_ollama_cloud_entry () =
+  let reg = Provider_registry.default () in
+  match Provider_registry.find reg "ollama_cloud" with
+  | Some e ->
+    check bool "kind is Ollama" true (e.defaults.kind = Provider_config.Ollama);
+    check string "base_url" "https://ollama.com" e.defaults.base_url;
+    check string "api_key_env" "OLLAMA_CLOUD_API_KEY" e.defaults.api_key_env;
+    check string "request_path" "/api/chat" e.defaults.request_path
+  | None -> fail "ollama_cloud should exist"
+;;
+
+let test_provider_name_of_ollama_cloud_config () =
+  let cfg =
+    Provider_config.make
+      ~kind:Provider_config.Ollama
+      ~model_id:"glm-5.1:cloud"
+      ~base_url:"https://ollama.com"
+      ~request_path:"/api/chat"
+      ()
+  in
+  check
+    string
+    "provider name"
+    "ollama_cloud"
+    (Provider_registry.provider_name_of_config cfg)
 ;;
 
 let test_default_max_context () =
@@ -990,8 +1022,13 @@ let () =
         ; test_case "requires_any" `Quick test_requires_any
         ] )
     ; ( "default"
-      , [ test_case "has 18 providers" `Quick test_default_has_18
+      , [ test_case "has 19 providers" `Quick test_default_has_19
         ; test_case "correct capabilities" `Quick test_default_capabilities
+        ; test_case "ollama_cloud entry" `Quick test_default_ollama_cloud_entry
+        ; test_case
+            "provider_name_of_config returns ollama_cloud"
+            `Quick
+            test_provider_name_of_ollama_cloud_config
         ; test_case "max_context values" `Quick test_default_max_context
         ; test_case
             "max_context matches capabilities"


### PR DESCRIPTION
## Summary
- Register `ollama_cloud` as a named OAS provider at `https://ollama.com` using the Ollama wire format.
- Prefer `OLLAMA_CLOUD_API_KEY` and fall back to `OLLAMA_API_KEY` for availability and provider config resolution.
- Materialize Bearer auth headers for custom registered HTTP providers instead of leaving headers empty.

## Why
Ollama Cloud direct API calls require `Authorization: Bearer ...`. The previous custom registered fallback resolved provider kind and URL but dropped auth headers, which made direct Cloud use fail outside the local Ollama server path.

## Validation
- `scripts/dune-local.sh build ./test/test_provider.exe ./test/test_provider_registry.exe`
- `./_build/default/test/test_provider.exe` passed: 41 tests
- `./_build/default/test/test_provider_registry.exe` passed: 38 tests
- Live smoke: `POST https://ollama.com/api/chat` with `glm-5.1:cloud` returned HTTP 200, `done=true`, content `OK`