### PR TITLE
[codex] emit cascade circuit state metrics

### DIFF
--- a/lib/llm_provider/complete_cascade.ml
+++ b/lib/llm_provider/complete_cascade.ml
@@ -177,6 +177,36 @@ let provider_health_scores health ~cascade_config ~provider_keys =
     provider_keys
 ;;
 
+let circuit_state_of_info ~cascade_config info =
+  if info.circuit_open
+  then Metrics.Circuit_open
+  else if info.consecutive_failures >= max 1 cascade_config.circuit_threshold
+  then Metrics.Circuit_half_open
+  else Metrics.Circuit_closed
+;;
+
+let emit_circuit_state metrics config ~cascade_config ~health ~provider_key =
+  let info = provider_health_info health ~cascade_config ~provider_key in
+  let state = circuit_state_of_info ~cascade_config info in
+  metrics.Metrics.on_circuit_state
+    ~provider:(Provider_registry.provider_name_of_config config)
+    ~model_id:config.Provider_config.model_id
+    ~provider_key
+    ~state
+;;
+
+let emit_half_open_if_needed metrics config ~cascade_config ~health ~provider_key =
+  let info = provider_health_info health ~cascade_config ~provider_key in
+  match circuit_state_of_info ~cascade_config info with
+  | Metrics.Circuit_half_open ->
+    metrics.Metrics.on_circuit_state
+      ~provider:(Provider_registry.provider_name_of_config config)
+      ~model_id:config.Provider_config.model_id
+      ~provider_key
+      ~state:Metrics.Circuit_half_open
+  | Metrics.Circuit_closed | Metrics.Circuit_open -> ()
+;;
+
 (* --- Error classification --- *)
 
 let is_hard_quota_http_error = function
@@ -204,19 +234,31 @@ let complete_cascade
       ?tools
       ()
   =
+  let metrics_sink =
+    match metrics with
+    | Some m -> m
+    | None -> Metrics.get_global ()
+  in
   let rec loop remaining idx errors skipped =
     match remaining with
     | [] -> All_failed { errors = List.rev errors; skipped = List.rev skipped }
     | config :: rest ->
       let key = provider_key config in
       if is_circuit_open health ~ccfg:cascade_config key
-      then
+      then (
+        emit_circuit_state metrics_sink config ~cascade_config ~health ~provider_key:key;
         loop
           rest
           (idx + 1)
           errors
-          ((config, Circuit_breaker_open { provider = key }) :: skipped)
+          ((config, Circuit_breaker_open { provider = key }) :: skipped))
       else (
+        emit_half_open_if_needed
+          metrics_sink
+          config
+          ~cascade_config
+          ~health
+          ~provider_key:key;
         let attempt () =
           Complete.complete_with_retry
             ~sw
@@ -258,12 +300,14 @@ let complete_cascade
         match result with
         | Ok response ->
           record_success health key;
+          emit_circuit_state metrics_sink config ~cascade_config ~health ~provider_key:key;
           Success
             { response; step_index = idx; model_id = config.Provider_config.model_id }
         | Error (Http_client.ProviderTerminal { kind; message }) ->
           Provider_terminal { config; kind; message }
         | Error err ->
           record_failure health key;
+          emit_circuit_state metrics_sink config ~cascade_config ~health ~provider_key:key;
           if is_hard_quota_http_error err
           then Hard_quota { config; error = err }
           else loop rest (idx + 1) ((config, err) :: errors) skipped)

--- a/lib/llm_provider/metrics.ml
+++ b/lib/llm_provider/metrics.ml
@@ -1,5 +1,22 @@
 (** Metrics hooks for LLM completion observability. *)
 
+type circuit_state =
+  | Circuit_closed
+  | Circuit_open
+  | Circuit_half_open
+
+let circuit_state_to_int = function
+  | Circuit_closed -> 0
+  | Circuit_open -> 1
+  | Circuit_half_open -> 2
+;;
+
+let circuit_state_to_string = function
+  | Circuit_closed -> "closed"
+  | Circuit_open -> "open"
+  | Circuit_half_open -> "half_open"
+;;
+
 type t =
   { on_cache_hit : model_id:string -> unit
   ; on_cache_miss : model_id:string -> unit
@@ -7,6 +24,12 @@ type t =
   ; on_request_end : model_id:string -> latency_ms:int option -> unit
   ; on_error : model_id:string -> error:string -> unit
   ; on_http_status : provider:string -> model_id:string -> status:int -> unit
+  ; on_circuit_state :
+      provider:string
+      -> model_id:string
+      -> provider_key:string
+      -> state:circuit_state
+      -> unit
   ; on_capability_drop : model_id:string -> field:string -> unit
     (** Fired when a request parameter is silently dropped because the
       model's capability record reports it as unsupported.
@@ -30,6 +53,7 @@ let noop =
   ; on_request_end = (fun ~model_id:_ ~latency_ms:_ -> ())
   ; on_error = (fun ~model_id:_ ~error:_ -> ())
   ; on_http_status = (fun ~provider:_ ~model_id:_ ~status:_ -> ())
+  ; on_circuit_state = (fun ~provider:_ ~model_id:_ ~provider_key:_ ~state:_ -> ())
   ; on_capability_drop = (fun ~model_id:_ ~field:_ -> ())
   ; on_retry = (fun ~provider:_ ~model_id:_ ~attempt:_ -> ())
   ; on_token_usage = (fun ~provider:_ ~model_id:_ ~input_tokens:_ ~output_tokens:_ -> ())
@@ -152,6 +176,9 @@ module Aggregating = struct
     ; on_http_status =
         (fun ~provider ~model_id ~status ->
           agg.hooks.on_http_status ~provider ~model_id ~status)
+    ; on_circuit_state =
+        (fun ~provider ~model_id ~provider_key ~state ->
+          agg.hooks.on_circuit_state ~provider ~model_id ~provider_key ~state)
     ; on_capability_drop =
         (fun ~model_id ~field -> agg.hooks.on_capability_drop ~model_id ~field)
     ; on_retry =

--- a/lib/llm_provider/metrics.mli
+++ b/lib/llm_provider/metrics.mli
@@ -8,6 +8,17 @@
     @stability Internal
     @since 0.93.1 *)
 
+(** Circuit-breaker state encoded for metrics backends. The integer
+    mapping follows the common gauge convention:
+    [0=closed], [1=open], [2=half-open]. *)
+type circuit_state =
+  | Circuit_closed
+  | Circuit_open
+  | Circuit_half_open
+
+val circuit_state_to_int : circuit_state -> int
+val circuit_state_to_string : circuit_state -> string
+
 (** Metrics callback interface. All callbacks are optional — provide [noop]
     as a default that does nothing.
 
@@ -24,6 +35,18 @@ type t =
   ; on_request_end : model_id:string -> latency_ms:int option -> unit
   ; on_error : model_id:string -> error:string -> unit
   ; on_http_status : provider:string -> model_id:string -> status:int -> unit
+  ; on_circuit_state :
+      provider:string
+      -> model_id:string
+      -> provider_key:string
+      -> state:circuit_state
+      -> unit
+    (** Fired when cascade circuit-breaker state is observed or updated.
+        Backends can export this as a gauge using
+        {!circuit_state_to_int}; [provider_key] keeps same-model,
+        different-endpoint circuits distinguishable.
+
+        @since 0.193.10 *)
   ; on_capability_drop : model_id:string -> field:string -> unit
   ; on_retry : provider:string -> model_id:string -> attempt:int -> unit
     (** Fired when a request is retried due to a retryable error.

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -310,6 +310,14 @@ let test_circuit_open_skips_provider_and_falls_back () =
   Complete_cascade.record_failure health anthropic_key;
   Complete_cascade.record_failure health anthropic_key;
   let seen_models = ref [] in
+  let circuit_states = ref [] in
+  let metrics : Metrics.t =
+    { Metrics.noop with
+      on_circuit_state =
+        (fun ~provider ~model_id ~provider_key ~state ->
+          circuit_states := (provider, model_id, provider_key, state) :: !circuit_states)
+    }
+  in
   let transport : Llm_transport.t =
     { complete_sync =
         (fun (req : Llm_transport.completion_request) ->
@@ -328,6 +336,7 @@ let test_circuit_open_skips_provider_and_falls_back () =
       ~clock
       ~transport
       ~health
+      ~metrics
       ~steps:[ anthropic; moonshot ]
       ~messages:[]
       ()
@@ -341,11 +350,147 @@ let test_circuit_open_skips_provider_and_falls_back () =
       ~provider_key:anthropic_key
   in
   check bool "anthropic circuit remains open" true anthropic_info.circuit_open;
+  check
+    bool
+    "open circuit state metric emitted"
+    true
+    (List.exists
+       (fun (_provider, model_id, provider_key, state) ->
+          String.equal model_id anthropic.model_id
+          && String.equal provider_key anthropic_key
+          && state = Metrics.Circuit_open)
+       !circuit_states);
   match result with
   | Complete_cascade.Success { step_index; model_id; _ } ->
     check int "fallback step index" 1 step_index;
     check string "fallback model" "moonshot-v1" model_id
   | _ -> fail "expected fallback Success"
+;;
+
+let test_circuit_state_metric_on_failure_open () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let config =
+    Provider_config.make
+      ~kind:Ollama
+      ~model_id:"llama3"
+      ~base_url:"http://localhost:11434"
+      ()
+  in
+  let key = Complete_cascade.provider_key config in
+  let circuit_states = ref [] in
+  let metrics : Metrics.t =
+    { Metrics.noop with
+      on_circuit_state =
+        (fun ~provider:_ ~model_id:_ ~provider_key ~state ->
+          circuit_states := (provider_key, state) :: !circuit_states)
+    }
+  in
+  let transport : Llm_transport.t =
+    { complete_sync =
+        (fun _ ->
+          { Llm_transport.response =
+              Error
+                (Http_client.NetworkError
+                   { kind = Http_client.Timeout; message = "timeout" })
+          ; latency_ms = None
+          })
+    ; complete_stream =
+        (fun ?on_telemetry:_ ~on_event:_ _ ->
+          Error
+            (Http_client.NetworkError { kind = Http_client.Timeout; message = "timeout" }))
+    }
+  in
+  let result =
+    Complete_cascade.complete_cascade
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~clock
+      ~transport
+      ~metrics
+      ~cascade_config:{ circuit_threshold = 1; circuit_cooldown_s = 30.0 }
+      ~steps:[ config ]
+      ~messages:[]
+      ()
+  in
+  (match result with
+   | Complete_cascade.All_failed _ -> ()
+   | _ -> fail "expected failed cascade");
+  check
+    bool
+    "failure opens circuit metric"
+    true
+    (List.exists
+       (fun (provider_key, state) ->
+          String.equal provider_key key && state = Metrics.Circuit_open)
+       !circuit_states)
+;;
+
+let test_circuit_state_metric_half_open_then_closed () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let health = Complete_cascade.create_health ~clock () in
+  let config =
+    Provider_config.make
+      ~kind:Ollama
+      ~model_id:"llama3"
+      ~base_url:"http://localhost:11434"
+      ()
+  in
+  let key = Complete_cascade.provider_key config in
+  Complete_cascade.record_failure health key;
+  let circuit_states = ref [] in
+  let metrics : Metrics.t =
+    { Metrics.noop with
+      on_circuit_state =
+        (fun ~provider:_ ~model_id:_ ~provider_key ~state ->
+          circuit_states := (provider_key, state) :: !circuit_states)
+    }
+  in
+  let transport : Llm_transport.t =
+    { complete_sync =
+        (fun _ -> { Llm_transport.response = Ok dummy_response; latency_ms = Some 10 })
+    ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _ -> Ok dummy_response)
+    }
+  in
+  let result =
+    Complete_cascade.complete_cascade
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~clock
+      ~transport
+      ~metrics
+      ~health
+      ~cascade_config:{ circuit_threshold = 1; circuit_cooldown_s = 0.0 }
+      ~steps:[ config ]
+      ~messages:[]
+      ()
+  in
+  (match result with
+   | Complete_cascade.Success _ -> ()
+   | _ -> fail "expected successful half-open probe");
+  check
+    bool
+    "half-open metric emitted before probe"
+    true
+    (List.exists
+       (fun (provider_key, state) ->
+          String.equal provider_key key && state = Metrics.Circuit_half_open)
+       !circuit_states);
+  check
+    bool
+    "closed metric emitted after success"
+    true
+    (List.exists
+       (fun (provider_key, state) ->
+          String.equal provider_key key && state = Metrics.Circuit_closed)
+       !circuit_states)
 ;;
 
 let test_hard_quota_stops_without_calling_fallback () =
@@ -622,6 +767,10 @@ let suite =
   ; "result_provider_terminal", `Quick, test_result_provider_terminal_variant
   ; "skip_reason", `Quick, test_skip_reason_variant
   ; "circuit_open_fallback", `Quick, test_circuit_open_skips_provider_and_falls_back
+  ; "circuit_state_failure_open", `Quick, test_circuit_state_metric_on_failure_open
+  ; ( "circuit_state_half_open_closed"
+    , `Quick
+    , test_circuit_state_metric_half_open_then_closed )
   ; ( "hard_quota_stops_without_fallback"
     , `Quick
     , test_hard_quota_stops_without_calling_fallback )

--- a/test/test_metrics_aggregating.ml
+++ b/test/test_metrics_aggregating.ml
@@ -57,6 +57,30 @@ let test_aggregating_on_token_usage () =
   check int "output_tokens_total" 125 entry.M.output_tokens_total
 ;;
 
+let test_aggregating_on_circuit_state () =
+  let observed = ref None in
+  let inner : M.t =
+    { M.noop with
+      on_circuit_state =
+        (fun ~provider ~model_id ~provider_key ~state ->
+          observed := Some (provider, model_id, provider_key, state))
+    }
+  in
+  let agg = Agg.create ~inner () in
+  let hooks = Agg.to_hooks agg in
+  hooks.on_circuit_state
+    ~provider:"openai"
+    ~model_id:"gpt-4"
+    ~provider_key:"gpt-4@https://api.openai.com"
+    ~state:M.Circuit_open;
+  (match !observed with
+   | Some ("openai", "gpt-4", "gpt-4@https://api.openai.com", M.Circuit_open) -> ()
+   | Some _ -> fail "unexpected circuit state callback"
+   | None -> fail "missing circuit state callback");
+  check int "state value" 1 (M.circuit_state_to_int M.Circuit_open);
+  check string "state label" "open" (M.circuit_state_to_string M.Circuit_open)
+;;
+
 let test_aggregating_on_error () =
   let agg = Agg.create () in
   let hooks = Agg.to_hooks agg in
@@ -141,6 +165,7 @@ let () =
       , [ test_case "on_request_start" `Quick test_aggregating_on_request_start
         ; test_case "on_retry" `Quick test_aggregating_on_retry
         ; test_case "on_token_usage" `Quick test_aggregating_on_token_usage
+        ; test_case "on_circuit_state" `Quick test_aggregating_on_circuit_state
         ; test_case "on_error" `Quick test_aggregating_on_error
         ; test_case
             "on_request_end latency"


### PR DESCRIPTION
## Summary

- Add a typed `Llm_provider.Metrics.circuit_state` hook with the gauge mapping `0=closed`, `1=open`, `2=half_open`.
- Emit cascade circuit-breaker state when a provider is skipped as open, when a failure opens or updates the circuit, when a cooled-down provider is probed half-open, and when a successful probe closes the circuit.
- Cover the new hook in `Metrics.Aggregating` delegation tests and `Complete_cascade` control-flow tests.

## Why

The old telemetry audit called out provider circuit-breaker state as an operator-visible metric. OAS had circuit health snapshots and fallback behavior, but no metrics hook for Prometheus/StatsD/OTel adapters to export the actual state transitions. This makes the state observable without coupling OAS to a specific metrics backend.

## Validation

- `scripts/dune-local.sh build @test/runtest-test_complete_cascade @test/runtest-test_metrics_aggregating`
- `ocamlformat --check lib/llm_provider/metrics.ml lib/llm_provider/metrics.mli lib/llm_provider/complete_cascade.ml test/test_complete_cascade.ml test/test_metrics_aggregating.ml`
- `git diff --check origin/main...HEAD`
