### PR TITLE
fix(metrics): dedup histogram bucket bounds (follow-up #1556)

### DIFF
--- a/lib/metrics.ml
+++ b/lib/metrics.ml
@@ -299,7 +299,7 @@ let counter_to_prometheus buf (c : counter_data) =
 
 let histogram_to_prometheus buf (h : histogram_data) =
   let prom_name = add_prometheus_header buf ~name:h.h_name ~kind:"histogram" in
-  let sorted_buckets = List.sort Float.compare h.h_buckets in
+  let sorted_buckets = List.sort_uniq Float.compare h.h_buckets in
   List.iter
     (fun bound ->
        let count =

--- a/test/test_metrics.ml
+++ b/test/test_metrics.ml
@@ -133,6 +133,29 @@ let test_prometheus_text_histogram_exports_buckets_sum_and_count () =
   check_line "histogram count" "gen_ai_client_operation_duration_count 2" text
 ;;
 
+let test_prometheus_text_histogram_deduplicates_bucket_bounds () =
+  let m = Metrics.create () in
+  let h = Metrics.histogram m ~name:"dup.bounds" ~buckets:[ 1.0; 1.0; 2.0 ] in
+  Metrics.observe h 0.5;
+  let text = Metrics.to_prometheus_text m in
+  let count_substring text needle =
+    let len = String.length needle in
+    let rec loop start acc =
+      match String.index_from_opt text start needle.[0] with
+      | None -> acc
+      | Some i when i + len <= String.length text && String.sub text i len = needle ->
+        loop (i + len) (acc + 1)
+      | Some i -> loop (i + 1) acc
+    in
+    loop 0 0
+  in
+  check
+    int
+    "duplicate bound emitted exactly once"
+    1
+    (count_substring text "dup_bounds_bucket{le=\"1\"}")
+;;
+
 let () =
   run
     "Metrics"
@@ -158,6 +181,10 @@ let () =
             "histogram text export emits buckets sum and count"
             `Quick
             (with_eio test_prometheus_text_histogram_exports_buckets_sum_and_count)
+        ; test_case
+            "histogram text export deduplicates bucket bounds"
+            `Quick
+            (with_eio test_prometheus_text_histogram_deduplicates_bucket_bounds)
         ] )
     ]
 ;;


### PR DESCRIPTION
## 배경

PR #1556 의 Codex review 에서 두 건의 unresolved finding 이 남은 채 main 에 머지되었습니다.

- **P1**: `to_prometheus_text` 가 normalized name collision 을 감지하지 않음 (`foo.bar` 와 `foo_bar` 가 동시 등록되면 같은 `# HELP/# TYPE` 블록을 두 번 emit).
- **P2** (이 PR): `histogram_to_prometheus` 가 bucket bound 를 정렬만 하고 deduplicate 하지 않음. duplicate bound 가 등록되면 같은 `..._bucket{le="…"}` 라인이 중복 emit 되어 Prometheus 스크랩 시 duplicate-sample 오류 가능.

## 변경

- `lib/metrics.ml`: `List.sort Float.compare h.h_buckets` → `List.sort_uniq Float.compare h.h_buckets`.
- `test/test_metrics.ml`: histogram 에 `[1.0; 1.0; 2.0]` 같은 중복 bound 를 등록한 뒤, `dup_bounds_bucket{le="1"}` 라인이 정확히 1회 emit 되는지 검증하는 회귀 테스트 추가.

## 검증

```
_build/default/test/test_metrics.exe
9 tests run, all OK
```

## P1 (collision) 는 분리

P1 finding 은 emit-time 보강(workaround)보다는 register-time guard 가 root fix 라 판단해 본 PR 범위에서 제외했습니다 (`workaround rejection bar` §1 텔레메트리-as-fix 회피). 별도 RFC/PR 로 후속 처리 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)