### PR TITLE
fix(metrics): emit Circuit_open directly from open-skip (follow-up #1563)

### DIFF
--- a/lib/llm_provider/complete_cascade.ml
+++ b/lib/llm_provider/complete_cascade.ml
@@ -185,14 +185,24 @@ let circuit_state_of_info ~cascade_config info =
   else Metrics.Circuit_closed
 ;;
 
-let emit_circuit_state metrics config ~cascade_config ~health ~provider_key =
-  let info = provider_health_info health ~cascade_config ~provider_key in
-  let state = circuit_state_of_info ~cascade_config info in
+(* Direct-state emit: lets callers reuse a circuit state they already
+   determined from an earlier [is_circuit_open] / [provider_health_info]
+   read, instead of re-reading [health]. This avoids a TOCTOU window
+   where the cooldown boundary (or another fiber's update) can flip the
+   computed state between the skip decision and the metric emit, which
+   would contradict the operator-visible reason this request skipped. *)
+let emit_circuit_state_with_state metrics config ~provider_key ~state =
   metrics.Metrics.on_circuit_state
     ~provider:(Provider_registry.provider_name_of_config config)
     ~model_id:config.Provider_config.model_id
     ~provider_key
     ~state
+;;
+
+let emit_circuit_state metrics config ~cascade_config ~health ~provider_key =
+  let info = provider_health_info health ~cascade_config ~provider_key in
+  let state = circuit_state_of_info ~cascade_config info in
+  emit_circuit_state_with_state metrics config ~provider_key ~state
 ;;
 
 let emit_half_open_if_needed metrics config ~cascade_config ~health ~provider_key =
@@ -246,7 +256,15 @@ let complete_cascade
       let key = provider_key config in
       if is_circuit_open health ~ccfg:cascade_config key
       then (
-        emit_circuit_state metrics_sink config ~cascade_config ~health ~provider_key:key;
+        (* Already decided the skip is due to an open circuit on this
+           [health] read; emit [Circuit_open] directly so the metric
+           cannot contradict the skip reason if the cooldown boundary
+           flips before a second read. *)
+        emit_circuit_state_with_state
+          metrics_sink
+          config
+          ~provider_key:key
+          ~state:Metrics.Circuit_open;
         loop
           rest
           (idx + 1)

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -746,6 +746,76 @@ let test_attempt_timeout_disable_via_nonpositive_sentinel () =
   | _ -> fail "expected Success when timeout disabled by sentinel"
 ;;
 
+let test_circuit_open_skip_emits_only_circuit_open_for_skipped_provider () =
+  (* Regression for the TOCTOU window in the open-skip emit: the skip
+     branch must record exactly one [Circuit_open] for the open provider,
+     never [Circuit_half_open] or [Circuit_closed] for that same key. *)
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let health = Complete_cascade.create_health ~clock () in
+  let primary =
+    Provider_config.make
+      ~kind:Anthropic
+      ~model_id:"claude-sonnet-4-20250514"
+      ~base_url:"https://api.anthropic.com"
+      ()
+  in
+  let fallback =
+    Provider_config.make
+      ~kind:Kimi
+      ~model_id:"moonshot-v1"
+      ~base_url:"https://api.moonshot.cn"
+      ()
+  in
+  let primary_key = Complete_cascade.provider_key primary in
+  Complete_cascade.record_failure health primary_key;
+  Complete_cascade.record_failure health primary_key;
+  Complete_cascade.record_failure health primary_key;
+  let circuit_states = ref [] in
+  let metrics : Metrics.t =
+    { Metrics.noop with
+      on_circuit_state =
+        (fun ~provider:_ ~model_id:_ ~provider_key ~state ->
+          circuit_states := (provider_key, state) :: !circuit_states)
+    }
+  in
+  let transport : Llm_transport.t =
+    { complete_sync =
+        (fun (_ : Llm_transport.completion_request) ->
+          { Llm_transport.response = Ok dummy_response; latency_ms = Some 25 })
+    ; complete_stream =
+        (fun ?on_telemetry:_ ~on_event:_ (_ : Llm_transport.completion_request) ->
+          Ok dummy_response)
+    }
+  in
+  let _ =
+    Complete_cascade.complete_cascade
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~clock
+      ~transport
+      ~health
+      ~metrics
+      ~steps:[ primary; fallback ]
+      ~messages:[]
+      ()
+  in
+  let states_for_primary =
+    List.filter
+      (fun (provider_key, _) -> String.equal provider_key primary_key)
+      !circuit_states
+    |> List.map snd
+  in
+  check
+    (list (testable Fmt.nop ( = )))
+    "primary key emits exactly one Circuit_open and nothing else"
+    [ Metrics.Circuit_open ]
+    states_for_primary
+;;
+
 (* ── Test suite ───────────────────────────────────────── *)
 
 let suite =
@@ -771,6 +841,9 @@ let suite =
   ; ( "circuit_state_half_open_closed"
     , `Quick
     , test_circuit_state_metric_half_open_then_closed )
+  ; ( "circuit_open_skip_emits_only_circuit_open"
+    , `Quick
+    , test_circuit_open_skip_emits_only_circuit_open_for_skipped_provider )
   ; ( "hard_quota_stops_without_fallback"
     , `Quick
     , test_hard_quota_stops_without_calling_fallback )


### PR DESCRIPTION
## 배경

PR #1563 의 Codex review (P2) 가 unresolved 상태로 main 에 머지되었습니다.

`lib/llm_provider/complete_cascade.ml` 의 cascade loop 가 open-skip branch 에서 `health` 를 **두 번** 읽습니다:

1. `is_circuit_open health ~ccfg key` — skip 결정.
2. `emit_circuit_state ... ~health ~provider_key` — 내부에서 `provider_health_info` 로 재읽어 metric 상태 계산.

두 read 사이에 cooldown 경계가 지나거나 (clock-driven) 다른 fiber 의 `record_success` 가 entry 를 mutate 하면, metric 은 `Circuit_half_open` 또는 `Circuit_closed` 로 emit 될 수 있습니다 — request 가 실제로는 *open* 이유로 skip 됐는데 telemetry 는 다른 state 를 보고 → operator alert / debugging 에 contradictory 신호.

## 변경

- `lib/llm_provider/complete_cascade.ml`:
  - 새 private helper `emit_circuit_state_with_state` 추가. 이미 결정된 state 를 인자로 받아 health 재read 없이 sink 에 emit.
  - 기존 `emit_circuit_state` 는 이 helper 를 reuse 하도록 리팩터.
  - cascade loop 의 open-skip branch 는 `emit_circuit_state_with_state ... ~state:Metrics.Circuit_open` 직접 호출. skip 이유와 metric 이 *by construction* 일치.
- `test/test_complete_cascade.ml`: 회귀 테스트 `circuit_open_skip_emits_only_circuit_open` 추가. open 인 primary key 에 대해 emit 된 state list 가 정확히 `[Circuit_open]` 인지 검증 (race 가 끼어들면 다른 state 가 섞일 수 있음 — 이 테스트는 구조적 invariant 를 핀).

## 검증

```
_build/default/test/test_complete_cascade.exe
23 tests run, all OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)