### PR TITLE
fix(agent_tools): restrict User _ fallback to prevent case-variant dispatch (follow-up #1557)

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -57,7 +57,17 @@ let build_index tools =
 let find_in_index index name =
   match Hashtbl.find_opt index.by_name name with
   | Some _ as found -> found
-  | None -> Hashtbl.find_opt index.by_id (Tool_id.of_string name)
+  | None ->
+    (* Fallback applies the case-insensitive [Tool_id.of_string] mapping so
+       canonical built-ins and MCP IDs still resolve when the caller emits a
+       case-variant. For user-defined tools, [Tool_id.of_string] lowercases the
+       raw name into [User _], which would let a case-variant call dispatch a
+       *different* user tool (e.g. caller "MyTool" → user "mytool" when only
+       the latter is registered). To preserve approval/audit behavior, gate
+       the fallback so user IDs require an exact [by_name] match. *)
+    (match Tool_id.of_string name with
+     | Tool_id.User _ -> None
+     | id -> Hashtbl.find_opt index.by_id id)
 ;;
 
 let concurrency_class_to_string = function

--- a/lib/agent/agent_tools.mli
+++ b/lib/agent/agent_tools.mli
@@ -34,6 +34,14 @@ type tool_index
     the same dispatch path without each caller scanning the full list. *)
 val build_index : Tool.t list -> tool_index
 
+(** [find_in_index index name] resolves a tool by its registered name. Falls
+    back to [Tool_id.of_string] for canonical built-ins and MCP IDs only;
+    user-defined tools (which [Tool_id.of_string] would map to [User _]) must
+    match by [by_name] exactly to avoid case-variant cross-dispatch.
+
+    Example: with only ["mytool"] registered, [find_in_index idx "MYTOOL"]
+    returns [None] — not the lowercased neighbor — so approval and audit
+    context cannot be applied to a tool the caller didn't actually name. *)
 val find_in_index : tool_index -> string -> Tool.t option
 
 type tool_failure_kind =

--- a/test/test_agent_tools_index.ml
+++ b/test/test_agent_tools_index.ml
@@ -49,6 +49,42 @@ let test_tool_id_normalized_lookup_for_builtin () =
   | Some tool -> check string "normalized lookup" "READ_FILE" tool.schema.name
 ;;
 
+let test_user_tool_case_variant_does_not_fallback () =
+  (* Regression: Tool_id.of_string lowercases unknown names into User _.
+     If find_in_index applied that fallback to user tools, a case-variant
+     call would silently dispatch a different user-defined tool than the
+     model named, breaking approval/audit context. The fallback must only
+     fire for canonical built-ins/MCP IDs. *)
+  let tools = [ make_tool "mytool" ] in
+  let index = Agent_tools.build_index tools in
+  (match Agent_tools.find_in_index index "mytool" with
+   | None -> fail "exact match should still work"
+   | Some _ -> ());
+  check
+    (option string)
+    "case-variant returns None for user tool"
+    None
+    (tool_description (Agent_tools.find_in_index index "MYTOOL"));
+  check
+    (option string)
+    "title-cased variant returns None for user tool"
+    None
+    (tool_description (Agent_tools.find_in_index index "MyTool"))
+;;
+
+let test_user_tool_case_variant_does_not_dispatch_neighbor () =
+  (* Stronger regression: a user tool is registered under its lowercase
+     name. A title-case variant must return None, not silently dispatch
+     the lowercase neighbor (which would alter approval/audit context). *)
+  let tools = [ make_tool ~content:"lowercased" "fetcha" ] in
+  let index = Agent_tools.build_index tools in
+  check
+    (option string)
+    "uppercase variant of unregistered user tool returns None"
+    None
+    (tool_description (Agent_tools.find_in_index index "FetchA"))
+;;
+
 let () =
   run
     "Agent_tools_index"
@@ -65,6 +101,14 @@ let () =
             "tool_id normalized lookup for builtin"
             `Quick
             test_tool_id_normalized_lookup_for_builtin
+        ; test_case
+            "user tool case variant does not fallback"
+            `Quick
+            test_user_tool_case_variant_does_not_fallback
+        ; test_case
+            "user tool case variant does not dispatch lowercase neighbor"
+            `Quick
+            test_user_tool_case_variant_does_not_dispatch_neighbor
         ] )
     ]
 ;;


### PR DESCRIPTION
## 배경

PR #1557 의 Codex review (P1) 가 unresolved 상태로 main 에 머지되었습니다.

`Agent_tools.find_in_index` (lib/agent/agent_tools.ml:57) 가 by_name miss 시 `Tool_id.of_string` 으로 fallback 합니다. 그런데 `Tool_id.of_string` (lib/base/tool_id.ml:196) 은 built-in 도 MCP 도 아닌 raw 이름을 `lowercase_ascii` 한 뒤 `User other` 로 매핑합니다.

결과: case-variant 호출이 *다른* user-defined tool 을 silent dispatch 가능.

예: `"mytool"` user tool 만 등록되어 있을 때 caller 가 `"MYTOOL"` 호출 →
1. by_name miss (`"MYTOOL"` ≠ `"mytool"`).
2. fallback: `Tool_id.of_string "MYTOOL"` = `User "mytool"`.
3. by_id 에 `User "mytool"` 키 존재 → 매핑된 tool dispatch.
4. 결과: caller 가 명명한 이름과 다른 tool 이 실행되고, 그 tool 의 approval / audit context 가 잘못 적용됨.

## 변경

- `lib/agent/agent_tools.ml`: `find_in_index` fallback 을 `Tool_id.User _` 만 거부하도록 gate. canonical built-ins / MCP 에는 case-insensitive resolution 유지 (기존 contract).
- `lib/agent/agent_tools.mli`: `find_in_index` doc-comment 에 새 contract 명시 + 예시.
- `test/test_agent_tools_index.ml`: 2 회귀 케이스 추가.
  - `user tool case variant does not fallback`: `"mytool"` 등록 → `"MYTOOL"`, `"MyTool"` 호출 모두 `None`.
  - `user tool case variant does not dispatch lowercase neighbor`: `"fetcha"` 등록 → `"FetchA"` 호출 `None` (lowercase neighbor cross-dispatch 차단).

## 검증

```
_build/default/test/test_agent_tools_index.exe
5 tests run, all OK (기존 3 + 회귀 2)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)