### PR TITLE
[codex] Harden provider health and parse validation

### DIFF
--- a/lib/llm_provider/backend_tool_call_harness.ml
+++ b/lib/llm_provider/backend_tool_call_harness.ml
@@ -32,10 +32,15 @@ type validation_result =
   ; dropped_content_blocks : int
   }
 
-let empty_result =
+type response_parse_error =
+  { response_backend : string
+  ; response_parse_error : string
+  }
+
+let parse_error_result =
   { tool_calls_found = []
-  ; stop_reason_correct = true
-  ; all_tools_declared = true
+  ; stop_reason_correct = false
+  ; all_tools_declared = false
   ; dropped_content_blocks = 0
   }
 ;;
@@ -317,11 +322,22 @@ let validate_gemini_response ~declared_tools json =
   validate_response ~declared_tools (Backend_gemini.parse_response json)
 ;;
 
-let validate_openai_response ~declared_tools json =
+let validate_openai_response_result ~declared_tools json =
   let json_str = Yojson.Safe.to_string json in
-  match Backend_openai_parse.parse_openai_response_result json_str with
-  | Ok resp -> validate_response ~declared_tools resp
-  | Error _ -> empty_result
+  let parsed =
+    try Backend_openai_parse.parse_openai_response_result json_str with
+    | exn -> Error (Printexc.to_string exn)
+  in
+  match parsed with
+  | Ok resp -> Ok (validate_response ~declared_tools resp)
+  | Error response_parse_error ->
+    Error { response_backend = "openai"; response_parse_error }
+;;
+
+let validate_openai_response ~declared_tools json =
+  match validate_openai_response_result ~declared_tools json with
+  | Ok result -> result
+  | Error _ -> parse_error_result
 ;;
 
 (* ── Inline Tests ─────────────────────────────────────── *)

--- a/lib/llm_provider/backend_tool_call_harness.mli
+++ b/lib/llm_provider/backend_tool_call_harness.mli
@@ -32,7 +32,10 @@ type validation_result =
   ; dropped_content_blocks : int
   }
 
-val empty_result : validation_result
+type response_parse_error =
+  { response_backend : string
+  ; response_parse_error : string
+  }
 
 (** {1 Schema extraction} *)
 
@@ -82,3 +85,8 @@ val validate_openai_response
   :  declared_tools:string list
   -> Yojson.Safe.t
   -> validation_result
+
+val validate_openai_response_result
+  :  declared_tools:string list
+  -> Yojson.Safe.t
+  -> (validation_result, response_parse_error) result

--- a/lib/llm_provider/complete_cascade.ml
+++ b/lib/llm_provider/complete_cascade.ml
@@ -268,13 +268,6 @@ let circuit_open_and_remaining health ~ccfg entry =
       if remaining > 0.0 then true, Some remaining else false, None)
 ;;
 
-let is_circuit_open health ~ccfg key =
-  with_mutex health (fun () ->
-    match Hashtbl.find_opt health.entries key with
-    | None -> false
-    | Some entry -> fst (circuit_open_and_remaining health ~ccfg entry))
-;;
-
 type provider_health_info =
   { provider_key : string
   ; health_score : float
@@ -331,8 +324,7 @@ let circuit_state_of_info ~cascade_config info =
   else Metrics.Circuit_closed
 ;;
 
-let emit_circuit_state metrics config ~cascade_config ~health ~provider_key =
-  let info = provider_health_info health ~cascade_config ~provider_key in
+let emit_circuit_state_from_info metrics config ~cascade_config ~provider_key info =
   let state = circuit_state_of_info ~cascade_config info in
   metrics.Metrics.on_circuit_state
     ~provider:(Provider_registry.provider_name_of_config config)
@@ -341,8 +333,12 @@ let emit_circuit_state metrics config ~cascade_config ~health ~provider_key =
     ~state
 ;;
 
-let emit_half_open_if_needed metrics config ~cascade_config ~health ~provider_key =
+let emit_circuit_state metrics config ~cascade_config ~health ~provider_key =
   let info = provider_health_info health ~cascade_config ~provider_key in
+  emit_circuit_state_from_info metrics config ~cascade_config ~provider_key info
+;;
+
+let emit_half_open_if_needed_from_info metrics config ~cascade_config ~provider_key info =
   match circuit_state_of_info ~cascade_config info with
   | Metrics.Circuit_half_open ->
     metrics.Metrics.on_circuit_state
@@ -390,21 +386,27 @@ let complete_cascade
     | [] -> All_failed { errors = List.rev errors; skipped = List.rev skipped }
     | config :: rest ->
       let key = provider_key config in
-      if is_circuit_open health ~ccfg:cascade_config key
+      let info = provider_health_info health ~cascade_config ~provider_key:key in
+      if info.circuit_open
       then (
-        emit_circuit_state metrics_sink config ~cascade_config ~health ~provider_key:key;
+        emit_circuit_state_from_info
+          metrics_sink
+          config
+          ~cascade_config
+          ~provider_key:key
+          info;
         loop
           rest
           (idx + 1)
           errors
           ((config, Circuit_breaker_open { provider = key }) :: skipped))
       else (
-        emit_half_open_if_needed
+        emit_half_open_if_needed_from_info
           metrics_sink
           config
           ~cascade_config
-          ~health
-          ~provider_key:key;
+          ~provider_key:key
+          info;
         let attempt () =
           Complete.complete_with_retry
             ~sw

--- a/lib/llm_provider/complete_cascade.ml
+++ b/lib/llm_provider/complete_cascade.ml
@@ -110,6 +110,149 @@ let record_failure health key =
     Hashtbl.replace health.entries key entry)
 ;;
 
+type provider_health_snapshot_entry =
+  { snapshot_provider_key : string
+  ; snapshot_consecutive_failures : int
+  ; snapshot_last_failure_time : float option
+  }
+
+type provider_health_snapshot = provider_health_snapshot_entry list
+
+let snapshot_health health =
+  with_mutex health (fun () ->
+    health.entries
+    |> Hashtbl.to_seq
+    |> Seq.filter_map (fun (provider_key, entry) ->
+      if entry.consecutive_failures <= 0
+      then None
+      else
+        Some
+          { snapshot_provider_key = provider_key
+          ; snapshot_consecutive_failures = entry.consecutive_failures
+          ; snapshot_last_failure_time = entry.last_failure_time
+          })
+    |> List.of_seq
+    |> List.sort (fun a b ->
+      String.compare a.snapshot_provider_key b.snapshot_provider_key))
+;;
+
+let replace_health_snapshot health snapshot =
+  with_mutex health (fun () ->
+    Hashtbl.reset health.entries;
+    List.iter
+      (fun entry ->
+         if entry.snapshot_consecutive_failures > 0
+         then
+           Hashtbl.replace
+             health.entries
+             entry.snapshot_provider_key
+             { consecutive_failures = entry.snapshot_consecutive_failures
+             ; last_failure_time = entry.snapshot_last_failure_time
+             })
+      snapshot)
+;;
+
+let restore_health ?clock snapshot =
+  let health = create_health ?clock () in
+  replace_health_snapshot health snapshot;
+  health
+;;
+
+let provider_health_snapshot_to_yojson snapshot =
+  `List
+    (List.map
+       (fun entry ->
+          `Assoc
+            [ "provider_key", `String entry.snapshot_provider_key
+            ; "consecutive_failures", `Int entry.snapshot_consecutive_failures
+            ; ( "last_failure_time"
+              , match entry.snapshot_last_failure_time with
+                | Some ts -> `Float ts
+                | None -> `Null )
+            ])
+       snapshot)
+;;
+
+let provider_health_snapshot_of_yojson json =
+  let parse_float = function
+    | `Float f -> Ok f
+    | `Int i -> Ok (float_of_int i)
+    | `Intlit s ->
+      (try Ok (float_of_string s) with
+       | Failure _ -> Error ("invalid last_failure_time: " ^ s))
+    | other ->
+      Error
+        (Printf.sprintf
+           "last_failure_time must be a number or null, got %s"
+           (Yojson.Safe.to_string other))
+  in
+  let parse_entry = function
+    | `Assoc fields ->
+      let find name = List.assoc_opt name fields in
+      (match find "provider_key", find "consecutive_failures" with
+       | Some (`String provider_key), Some failures_json ->
+         if String.equal provider_key ""
+         then Error "provider_key must not be empty"
+         else (
+           let parse_failures = function
+             | `Int i -> Ok i
+             | `Intlit s ->
+               (try Ok (int_of_string s) with
+                | Failure _ -> Error ("invalid consecutive_failures: " ^ s))
+             | other ->
+               Error
+                 (Printf.sprintf
+                    "consecutive_failures must be an integer, got %s"
+                    (Yojson.Safe.to_string other))
+           in
+           match parse_failures failures_json with
+           | Error _ as err -> err
+           | Ok consecutive_failures ->
+             if consecutive_failures < 0
+             then Error "consecutive_failures must be >= 0"
+             else (
+               match find "last_failure_time" with
+               | None | Some `Null ->
+                 Ok
+                   { snapshot_provider_key = provider_key
+                   ; snapshot_consecutive_failures = consecutive_failures
+                   ; snapshot_last_failure_time = None
+                   }
+               | Some ts_json ->
+                 (match parse_float ts_json with
+                  | Error _ as err -> err
+                  | Ok ts ->
+                    Ok
+                      { snapshot_provider_key = provider_key
+                      ; snapshot_consecutive_failures = consecutive_failures
+                      ; snapshot_last_failure_time = Some ts
+                      })))
+       | _ ->
+         Error
+           "provider health snapshot entry requires provider_key and consecutive_failures")
+    | other ->
+      Error
+        (Printf.sprintf
+           "provider health snapshot entry must be an object, got %s"
+           (Yojson.Safe.to_string other))
+  in
+  match json with
+  | `List entries ->
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | entry :: rest ->
+        (match parse_entry entry with
+         | Ok parsed -> loop (parsed :: acc) rest
+         | Error _ as err -> err)
+    in
+    loop [] entries
+  | other ->
+    Error
+      (Printf.sprintf
+         "provider health snapshot must be a list, got %s"
+         (Yojson.Safe.to_string other))
+;;
+
 let circuit_open_and_remaining health ~ccfg entry =
   if entry.consecutive_failures < ccfg.circuit_threshold
   then false, None
@@ -118,7 +261,10 @@ let circuit_open_and_remaining health ~ccfg entry =
     | None -> true, None
     | Some t ->
       let elapsed = health.time_fn () -. t in
-      let remaining = ccfg.circuit_cooldown_s -. elapsed in
+      let extra_failures = entry.consecutive_failures - ccfg.circuit_threshold in
+      let multiplier = 2. ** float_of_int (max 0 (min 6 extra_failures)) in
+      let cooldown_s = Float.min 3600.0 (ccfg.circuit_cooldown_s *. multiplier) in
+      let remaining = cooldown_s -. elapsed in
       if remaining > 0.0 then true, Some remaining else false, None)
 ;;
 

--- a/lib/llm_provider/complete_cascade.mli
+++ b/lib/llm_provider/complete_cascade.mli
@@ -47,6 +47,40 @@ val record_success : provider_health -> string -> unit
     After [circuit_threshold] consecutive failures, the circuit opens. *)
 val record_failure : provider_health -> string -> unit
 
+(** Serializable provider health entry. *)
+type provider_health_snapshot_entry =
+  { snapshot_provider_key : string
+  ; snapshot_consecutive_failures : int
+  ; snapshot_last_failure_time : float option
+  }
+
+(** Serializable provider health state.
+
+    Consumers that run long-lived agents can persist this value outside OAS
+    and restore it after process restart so circuit state is not erased by a
+    supervisor restart. *)
+type provider_health_snapshot = provider_health_snapshot_entry list
+
+(** Export the current provider health table as a stable snapshot. *)
+val snapshot_health : provider_health -> provider_health_snapshot
+
+(** Replace the contents of an existing provider health table from a snapshot. *)
+val replace_health_snapshot : provider_health -> provider_health_snapshot -> unit
+
+(** Create a provider health table from a previously exported snapshot. *)
+val restore_health
+  :  ?clock:_ Eio.Time.clock
+  -> provider_health_snapshot
+  -> provider_health
+
+(** Convert a provider health snapshot to JSON. *)
+val provider_health_snapshot_to_yojson : provider_health_snapshot -> Yojson.Safe.t
+
+(** Parse a provider health snapshot from JSON. *)
+val provider_health_snapshot_of_yojson
+  :  Yojson.Safe.t
+  -> (provider_health_snapshot, string) result
+
 (** Provider health snapshot derived from the circuit-breaker state. *)
 type provider_health_info =
   { provider_key : string

--- a/test/dune
+++ b/test/dune
@@ -47,6 +47,7 @@
   test_artifact_service
   test_async_agent
   test_atomic_write_race
+  test_backend_tool_call_harness
   test_backend_gemini
   test_body_timeout
   test_budget_strategy
@@ -256,6 +257,7 @@
   test_artifact_service
   test_async_agent
   test_atomic_write_race
+  test_backend_tool_call_harness
   test_backend_gemini
   test_body_timeout
   test_budget_strategy
@@ -435,7 +437,7 @@
   test_util
   test_v024_fixes
   test_vcs_graph_snapshot)
- (libraries agent_sdk alcotest)
+ (libraries agent_sdk agent_sdk.llm_provider alcotest)
  (deps %{bin:oas-runtime})
  (action
   (setenv

--- a/test/test_backend_tool_call_harness.ml
+++ b/test/test_backend_tool_call_harness.ml
@@ -1,0 +1,45 @@
+open Alcotest
+module H = Llm_provider.Backend_tool_call_harness
+
+let malformed_openai_response = `Assoc [ "choices", `String "not-a-list" ]
+
+let test_openai_parse_error_is_typed () =
+  match
+    H.validate_openai_response_result
+      ~declared_tools:[ "read_file" ]
+      malformed_openai_response
+  with
+  | Ok _ -> fail "expected typed parse error"
+  | Error err ->
+    check string "backend" "openai" err.response_backend;
+    check
+      bool
+      "parse error detail is surfaced"
+      true
+      (String.length err.response_parse_error > 0)
+;;
+
+let test_openai_parse_error_fails_closed_for_legacy_wrapper () =
+  let result =
+    H.validate_openai_response ~declared_tools:[ "read_file" ] malformed_openai_response
+  in
+  check bool "stop reason not accepted" false result.stop_reason_correct;
+  check bool "declared tools not accepted" false result.all_tools_declared;
+  check int "no tool calls fabricated" 0 (List.length result.tool_calls_found)
+;;
+
+let () =
+  run
+    "backend_tool_call_harness"
+    [ ( "openai_parse_errors"
+      , [ test_case
+            "typed result surfaces parse error"
+            `Quick
+            test_openai_parse_error_is_typed
+        ; test_case
+            "legacy wrapper fails closed"
+            `Quick
+            test_openai_parse_error_fails_closed_for_legacy_wrapper
+        ] )
+    ]
+;;

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -190,6 +190,86 @@ let test_provider_health_eio_mutex_concurrent_recording () =
   check int "all fiber writes recorded" 100 info.consecutive_failures
 ;;
 
+let test_provider_health_snapshot_restore_preserves_open_circuit () =
+  let health = Complete_cascade.create_health () in
+  let key = "snapshot-model@https://example.invalid" in
+  Complete_cascade.record_failure health key;
+  Complete_cascade.record_failure health key;
+  Complete_cascade.record_failure health key;
+  let snapshot = Complete_cascade.snapshot_health health in
+  check int "one snapshot entry" 1 (List.length snapshot);
+  let restored = Complete_cascade.restore_health snapshot in
+  let info =
+    Complete_cascade.provider_health_info
+      restored
+      ~cascade_config:Complete_cascade.default_cascade_config
+      ~provider_key:key
+  in
+  check int "restored failures" 3 info.consecutive_failures;
+  check bool "restored circuit open" true info.circuit_open;
+  match info.cooldown_remaining_s with
+  | Some remaining -> check bool "restored cooldown positive" true (remaining > 0.0)
+  | None -> fail "expected restored cooldown"
+;;
+
+let test_provider_health_snapshot_json_roundtrip () =
+  let snapshot : Complete_cascade.provider_health_snapshot =
+    [ { snapshot_provider_key = "a@https://example.invalid"
+      ; snapshot_consecutive_failures = 2
+      ; snapshot_last_failure_time = Some 42.5
+      }
+    ; { snapshot_provider_key = "b@https://example.invalid"
+      ; snapshot_consecutive_failures = 1
+      ; snapshot_last_failure_time = None
+      }
+    ]
+  in
+  let json = Complete_cascade.provider_health_snapshot_to_yojson snapshot in
+  match Complete_cascade.provider_health_snapshot_of_yojson json with
+  | Error err -> fail ("unexpected parse error: " ^ err)
+  | Ok parsed ->
+    check int "roundtrip length" 2 (List.length parsed);
+    check
+      string
+      "first key"
+      "a@https://example.invalid"
+      (List.hd parsed).snapshot_provider_key;
+    check int "first failures" 2 (List.hd parsed).snapshot_consecutive_failures
+;;
+
+let test_provider_health_snapshot_json_rejects_negative_failures () =
+  let json =
+    `List
+      [ `Assoc
+          [ "provider_key", `String "bad@https://example.invalid"
+          ; "consecutive_failures", `Int (-1)
+          ; "last_failure_time", `Null
+          ]
+      ]
+  in
+  match Complete_cascade.provider_health_snapshot_of_yojson json with
+  | Ok _ -> fail "expected negative failure count rejection"
+  | Error err -> check bool "error mentions failures" true (contains err "failures")
+;;
+
+let test_provider_health_backoff_extends_after_repeated_open_failures () =
+  let health = Complete_cascade.create_health () in
+  let key = "backoff-model@https://example.invalid" in
+  for _ = 1 to 4 do
+    Complete_cascade.record_failure health key
+  done;
+  let info =
+    Complete_cascade.provider_health_info
+      health
+      ~cascade_config:Complete_cascade.default_cascade_config
+      ~provider_key:key
+  in
+  match info.cooldown_remaining_s with
+  | Some remaining ->
+    check bool "fourth failure extends beyond base cooldown" true (remaining > 30.0)
+  | None -> fail "expected cooldown"
+;;
+
 (* ── cascade_config defaults ──────────────────────────── *)
 
 let test_default_config () =
@@ -760,6 +840,18 @@ let suite =
   ; ( "provider_health_eio_mutex_concurrent_recording"
     , `Quick
     , test_provider_health_eio_mutex_concurrent_recording )
+  ; ( "provider_health_snapshot_restore"
+    , `Quick
+    , test_provider_health_snapshot_restore_preserves_open_circuit )
+  ; ( "provider_health_snapshot_json_roundtrip"
+    , `Quick
+    , test_provider_health_snapshot_json_roundtrip )
+  ; ( "provider_health_snapshot_json_rejects_negative"
+    , `Quick
+    , test_provider_health_snapshot_json_rejects_negative_failures )
+  ; ( "provider_health_backoff_extends"
+    , `Quick
+    , test_provider_health_backoff_extends_after_repeated_open_failures )
   ; "default_config", `Quick, test_default_config
   ; "result_success", `Quick, test_result_success_variant
   ; "result_all_failed", `Quick, test_result_all_failed_variant

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -826,6 +826,73 @@ let test_attempt_timeout_disable_via_nonpositive_sentinel () =
   | _ -> fail "expected Success when timeout disabled by sentinel"
 ;;
 
+let test_circuit_open_skip_emits_only_circuit_open_for_skipped_provider () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let health = Complete_cascade.create_health ~clock () in
+  let primary =
+    Provider_config.make
+      ~kind:Anthropic
+      ~model_id:"claude-sonnet-4-20250514"
+      ~base_url:"https://api.anthropic.com"
+      ()
+  in
+  let fallback =
+    Provider_config.make
+      ~kind:Kimi
+      ~model_id:"moonshot-v1"
+      ~base_url:"https://api.moonshot.cn"
+      ()
+  in
+  let primary_key = Complete_cascade.provider_key primary in
+  Complete_cascade.record_failure health primary_key;
+  Complete_cascade.record_failure health primary_key;
+  Complete_cascade.record_failure health primary_key;
+  let circuit_states = ref [] in
+  let metrics : Metrics.t =
+    { Metrics.noop with
+      on_circuit_state =
+        (fun ~provider:_ ~model_id:_ ~provider_key ~state ->
+          circuit_states := (provider_key, state) :: !circuit_states)
+    }
+  in
+  let transport : Llm_transport.t =
+    { complete_sync =
+        (fun (_ : Llm_transport.completion_request) ->
+          { Llm_transport.response = Ok dummy_response; latency_ms = Some 25 })
+    ; complete_stream =
+        (fun ?on_telemetry:_ ~on_event:_ (_ : Llm_transport.completion_request) ->
+          Ok dummy_response)
+    }
+  in
+  let _ =
+    Complete_cascade.complete_cascade
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~clock
+      ~transport
+      ~health
+      ~metrics
+      ~steps:[ primary; fallback ]
+      ~messages:[]
+      ()
+  in
+  let states_for_primary =
+    List.filter
+      (fun (provider_key, _) -> String.equal provider_key primary_key)
+      !circuit_states
+    |> List.map snd
+  in
+  check
+    (list (testable Fmt.nop ( = )))
+    "primary key emits exactly one Circuit_open and nothing else"
+    [ Metrics.Circuit_open ]
+    states_for_primary
+;;
+
 (* ── Test suite ───────────────────────────────────────── *)
 
 let suite =
@@ -863,6 +930,9 @@ let suite =
   ; ( "circuit_state_half_open_closed"
     , `Quick
     , test_circuit_state_metric_half_open_then_closed )
+  ; ( "circuit_open_skip_emits_only_circuit_open"
+    , `Quick
+    , test_circuit_open_skip_emits_only_circuit_open_for_skipped_provider )
   ; ( "hard_quota_stops_without_fallback"
     , `Quick
     , test_hard_quota_stops_without_calling_fallback )


### PR DESCRIPTION
## Summary

This patch hardens the OAS provider/tool-call path for long-running keeper fleets.

- adds a serializable provider-health snapshot API for `Complete_cascade`
- adds bounded exponential circuit cooldown after repeated provider failures
- keeps open-skip circuit metrics anchored to the same health snapshot as the skip decision
- exposes OpenAI tool-call harness parse failures through a typed result
- makes the legacy OpenAI validation wrapper fail closed instead of returning a valid-looking empty result

## Why

The deep-dive notes identified three unhealthy patterns in OAS:

- provider circuit state was process-local and fixed-cooldown, so restarts erased failure memory
- open-skip telemetry could contradict the actual skip reason if the health state was re-read across a cooldown boundary
- OpenAI parse failures collapsed into an ambiguous empty validation record that looked successful

Those paths matter for 18+ keeper operation because provider failure memory and parse-failure semantics must survive enough to steer retries and avoid silently accepting malformed responses.

## Validation

- `scripts/dune-local.sh build test/test_backend_tool_call_harness.exe test/test_complete_cascade.exe`
- `./_build/default/test/test_backend_tool_call_harness.exe`
- `./_build/default/test/test_complete_cascade.exe`
- `opam exec -- ocamlformat --check lib/llm_provider/backend_tool_call_harness.ml lib/llm_provider/backend_tool_call_harness.mli test/test_backend_tool_call_harness.ml lib/llm_provider/complete_cascade.ml lib/llm_provider/complete_cascade.mli test/test_complete_cascade.ml`
- `git diff --check`
