### PR TITLE
fix(metrics): reject normalized-name collisions at register time (follow-up #1556)

### DIFF
--- a/lib/metrics.ml
+++ b/lib/metrics.ml
@@ -47,11 +47,75 @@ type histogram = t * string
 let create () = { mu = Eio.Mutex.create (); counters = []; histograms = [] }
 let with_lock t f = Eio.Mutex.use_rw ~protect:true t.mu f
 
+(* Prometheus identifier normalization, hoisted above the registration
+   functions so they can detect post-normalization collisions at
+   register time. The text-export call sites below reuse the same
+   helper. *)
+let is_identifier_start = function
+  | 'A' .. 'Z' | 'a' .. 'z' | '_' | ':' -> true
+  | _ -> false
+;;
+
+let is_identifier_char = function
+  | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | ':' -> true
+  | _ -> false
+;;
+
+let prometheus_identifier raw =
+  let buf = Buffer.create (String.length raw + 1) in
+  String.iteri
+    (fun index ch ->
+       let valid = if index = 0 then is_identifier_start ch else is_identifier_char ch in
+       Buffer.add_char buf (if valid then ch else '_'))
+    raw;
+  let rendered = Buffer.contents buf in
+  if String.equal rendered "" then "_" else rendered
+;;
+
+(* [check_no_normalized_collision_unlocked t ~kind ~name] raises
+   [Invalid_argument] if registering [name] would emit a Prometheus
+   metric whose [prometheus_identifier]-normalized name clashes with
+   a *different* registered name in [t] (across counters and
+   histograms). Re-registering the exact same [name] under the same
+   kind is the idempotent path and skips this check; only true
+   collisions (e.g. [foo.bar] vs [foo_bar], or a counter and a
+   histogram that normalize to the same name) are rejected.
+
+   Detecting at register time stops the text-export emit path from
+   producing duplicate # HELP / # TYPE blocks for a single Prometheus
+   metric name — a violation of the text exposition format. Caller
+   must already hold the instance lock. *)
+let check_no_normalized_collision_unlocked t ~kind ~name =
+  let prom_name = prometheus_identifier name in
+  let collides_with existing_kind raw =
+    if String.equal raw name && String.equal existing_kind kind
+    then false (* same name + same kind = idempotent re-register *)
+    else String.equal (prometheus_identifier raw) prom_name
+  in
+  let fail existing_kind raw =
+    invalid_arg
+      (Printf.sprintf
+         "Metrics.%s: name %S normalizes to %S, which collides with the \
+          already-registered %s %S"
+         kind
+         name
+         prom_name
+         existing_kind
+         raw)
+  in
+  List.iter (fun c -> if collides_with "counter" c.c_name then fail "counter" c.c_name)
+    t.counters;
+  List.iter
+    (fun h -> if collides_with "histogram" h.h_name then fail "histogram" h.h_name)
+    t.histograms
+;;
+
 let counter t ~name ~unit_ =
   with_lock t (fun () ->
     match List.find_opt (fun c -> c.c_name = name) t.counters with
     | Some _ -> t, name
     | None ->
+      check_no_normalized_collision_unlocked t ~kind:"counter" ~name;
       let c = { c_name = name; c_unit = unit_; c_values = LabelMap.empty } in
       t.counters <- c :: t.counters;
       t, name)
@@ -62,6 +126,7 @@ let histogram t ~name ~buckets =
     match List.find_opt (fun h -> h.h_name = name) t.histograms with
     | Some _ -> t, name
     | None ->
+      check_no_normalized_collision_unlocked t ~kind:"histogram" ~name;
       let h =
         { h_name = name
         ; h_buckets = buckets
@@ -225,27 +290,8 @@ let to_otlp_json t =
 ;;
 
 (* -- Prometheus text export ------------------------------------------ *)
-
-let is_identifier_start = function
-  | 'A' .. 'Z' | 'a' .. 'z' | '_' | ':' -> true
-  | _ -> false
-;;
-
-let is_identifier_char = function
-  | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | ':' -> true
-  | _ -> false
-;;
-
-let prometheus_identifier raw =
-  let buf = Buffer.create (String.length raw + 1) in
-  String.iteri
-    (fun index ch ->
-       let valid = if index = 0 then is_identifier_start ch else is_identifier_char ch in
-       Buffer.add_char buf (if valid then ch else '_'))
-    raw;
-  let rendered = Buffer.contents buf in
-  if String.equal rendered "" then "_" else rendered
-;;
+(* [prometheus_identifier] / [is_identifier_*] are defined above so the
+   registration functions can detect post-normalization collisions. *)
 
 let escape_prometheus_value raw =
   let buf = Buffer.create (String.length raw) in

--- a/test/test_metrics.ml
+++ b/test/test_metrics.ml
@@ -156,6 +156,30 @@ let test_prometheus_text_histogram_deduplicates_bucket_bounds () =
     (count_substring text "dup_bounds_bucket{le=\"1\"}")
 ;;
 
+let test_register_rejects_normalized_collision_counter_counter () =
+  let m = Metrics.create () in
+  let _ = Metrics.counter m ~name:"foo.bar" ~unit_:"1" in
+  match Metrics.counter m ~name:"foo_bar" ~unit_:"1" with
+  | exception Invalid_argument _ -> ()
+  | _ -> fail "expected Invalid_argument on counter-counter normalized collision"
+;;
+
+let test_register_rejects_normalized_collision_counter_histogram () =
+  let m = Metrics.create () in
+  let _ = Metrics.counter m ~name:"shared.name" ~unit_:"1" in
+  match Metrics.histogram m ~name:"shared_name" ~buckets:[ 1.0 ] with
+  | exception Invalid_argument _ -> ()
+  | _ -> fail "expected Invalid_argument on counter-histogram normalized collision"
+;;
+
+let test_register_same_name_same_kind_is_idempotent () =
+  let m = Metrics.create () in
+  let _ = Metrics.counter m ~name:"foo.bar" ~unit_:"1" in
+  (* Same name + same kind is the documented "register or retrieve" path. *)
+  let _ = Metrics.counter m ~name:"foo.bar" ~unit_:"1" in
+  ()
+;;
+
 let () =
   run
     "Metrics"
@@ -185,6 +209,20 @@ let () =
             "histogram text export deduplicates bucket bounds"
             `Quick
             (with_eio test_prometheus_text_histogram_deduplicates_bucket_bounds)
+        ] )
+    ; ( "registration"
+      , [ test_case
+            "rejects counter-counter normalized collision"
+            `Quick
+            (with_eio test_register_rejects_normalized_collision_counter_counter)
+        ; test_case
+            "rejects counter-histogram normalized collision"
+            `Quick
+            (with_eio test_register_rejects_normalized_collision_counter_histogram)
+        ; test_case
+            "same name + same kind stays idempotent"
+            `Quick
+            (with_eio test_register_same_name_same_kind_is_idempotent)
         ] )
     ]
 ;;


### PR DESCRIPTION
## 배경

PR #1556 의 Codex review (P1, `lib/metrics.ml:287`) 가 unresolved 상태로 main 에 머지되었습니다.

`Metrics.to_prometheus_text` 의 `add_prometheus_header` 가 모든 metric 이름을 `prometheus_identifier` (invalid char → `_`) 로 정규화하지만, 정규화 후 collision 검사가 없습니다. 결과:

- 서로 다른 등록 이름이 같은 prom name 으로 정규화 (`foo.bar` vs `foo_bar`).
- counter 와 histogram 이 같은 정규화 이름.

→ Prometheus text exposition 규약 위반 (per metric 1 HELP/TYPE only). 스크랩 parse error / 일부 시리즈 drop 가능.

## 설계 결정

Iter 1 의 dedup PR (#1564) 에서 명시했듯, emit-time silent dedup 은 *워크어라운드 위 워크어라운드* — `workaround rejection bar §1` (telemetry-as-fix). Root fix 는 *register time* 에 검출하여 프로그래머 버그로 노출하는 것 (`Invalid_argument`). 등록은 일반적으로 startup-time 이라 runtime path 에 새 실패 모드를 도입하지 않습니다.

## 변경

`lib/metrics.ml`:
- `prometheus_identifier` / `is_identifier_*` 를 등록 함수 위로 이동. emit path 와 같은 normalizer 를 공유. 아래 위치의 중복 정의 삭제.
- `check_no_normalized_collision_unlocked t ~kind ~name` 추가. caller (= `counter` / `histogram`) 가 instance lock 을 잡은 채 호출. 자기 자신의 idempotent re-register 는 skip, 다른 이름 / 다른 kind 와의 정규화 충돌만 `invalid_arg` 로 거부.
- `counter` / `histogram` register 분기에서 idempotent lookup 직후 collision check 호출. 충돌이 없을 때만 새 entry 추가.

`test/test_metrics.ml` (`registration` 그룹 신규):
- counter `foo.bar` 등록 후 counter `foo_bar` 등록 → `Invalid_argument`.
- counter `shared.name` 등록 후 histogram `shared_name` 등록 → `Invalid_argument`.
- 같은 이름 + 같은 kind 두 번 등록 → idempotent (regression 방지).

## 검증

```
_build/default/test/test_metrics.exe
12 tests run, all OK (기존 9 + 회귀 3)
```

`dune build --root . lib` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)