### PR TITLE
fix(metrics): support labeled histograms

### DIFF
--- a/lib/metrics.ml
+++ b/lib/metrics.ml
@@ -25,13 +25,20 @@ type counter_data =
 
 (* -- Histogram -------------------------------------------------------- *)
 
+type histogram_series =
+  { hs_observations : float list
+  ; hs_sum : float
+  ; hs_count : int
+  }
+
 type histogram_data =
   { h_name : string
   ; h_buckets : float list
-  ; h_observations : float list
-  ; h_sum : float
-  ; h_count : int
+  ; h_values : histogram_series LabelMap.t
   }
+
+let empty_histogram_series = { hs_observations = []; hs_sum = 0.0; hs_count = 0 }
+let empty_histogram_values () = LabelMap.singleton [] empty_histogram_series
 
 (* -- Metrics instance ------------------------------------------------- *)
 
@@ -103,7 +110,8 @@ let check_no_normalized_collision_unlocked t ~kind ~name =
          existing_kind
          raw)
   in
-  List.iter (fun c -> if collides_with "counter" c.c_name then fail "counter" c.c_name)
+  List.iter
+    (fun c -> if collides_with "counter" c.c_name then fail "counter" c.c_name)
     t.counters;
   List.iter
     (fun h -> if collides_with "histogram" h.h_name then fail "histogram" h.h_name)
@@ -128,12 +136,7 @@ let histogram t ~name ~buckets =
     | None ->
       check_no_normalized_collision_unlocked t ~kind:"histogram" ~name;
       let h =
-        { h_name = name
-        ; h_buckets = buckets
-        ; h_observations = []
-        ; h_sum = 0.0
-        ; h_count = 0
-        }
+        { h_name = name; h_buckets = buckets; h_values = empty_histogram_values () }
       in
       t.histograms <- h :: t.histograms;
       t, name)
@@ -168,26 +171,41 @@ let counter_value (t, name) ?(labels = []) () =
     | None -> 0)
 ;;
 
-let observe (t, name) value =
+let observe (t, name) ?(labels = []) value =
+  let key = label_key_of labels in
   with_lock t (fun () ->
     t.histograms
     <- List.map
          (fun h ->
             if h.h_name = name
-            then
-              { h with
-                h_observations = value :: h.h_observations
-              ; h_sum = h.h_sum +. value
-              ; h_count = h.h_count + 1
-              }
+            then (
+              let series =
+                match LabelMap.find_opt key h.h_values with
+                | Some series -> series
+                | None -> empty_histogram_series
+              in
+              let updated =
+                { hs_observations = value :: series.hs_observations
+                ; hs_sum = series.hs_sum +. value
+                ; hs_count = series.hs_count + 1
+                }
+              in
+              { h with h_values = LabelMap.add key updated h.h_values })
             else h)
          t.histograms)
 ;;
 
-let histogram_count (t, name) =
+let histogram_count ?labels (t, name) =
   with_lock t (fun () ->
     match List.find_opt (fun h -> h.h_name = name) t.histograms with
-    | Some h -> h.h_count
+    | Some h ->
+      (match labels with
+       | Some labels ->
+         let key = label_key_of labels in
+         (match LabelMap.find_opt key h.h_values with
+          | Some series -> series.hs_count
+          | None -> 0)
+       | None -> LabelMap.fold (fun _ series acc -> acc + series.hs_count) h.h_values 0)
     | None -> 0)
 ;;
 
@@ -195,9 +213,7 @@ let reset t =
   with_lock t (fun () ->
     t.counters <- List.map (fun c -> { c with c_values = LabelMap.empty }) t.counters;
     t.histograms
-    <- List.map
-         (fun h -> { h with h_observations = []; h_sum = 0.0; h_count = 0 })
-         t.histograms)
+    <- List.map (fun h -> { h with h_values = empty_histogram_values () }) t.histograms)
 ;;
 
 (* -- OTLP JSON export ------------------------------------------------ *)
@@ -238,24 +254,33 @@ let bucket_counts buckets observations =
   counts @ [ overflow ]
 ;;
 
-let histogram_to_json (h : histogram_data) : Yojson.Safe.t =
-  let bc = bucket_counts h.h_buckets h.h_observations in
-  `Assoc
-    [ "name", `String h.h_name
-    ; ( "histogram"
-      , `Assoc
-          [ ( "dataPoints"
-            , `List
-                [ `Assoc
-                    [ "count", `String (string_of_int h.h_count)
-                    ; "sum", `Float h.h_sum
-                    ; ( "bucketCounts"
-                      , `List (List.map (fun n -> `String (string_of_int n)) bc) )
-                    ; "explicitBounds", `List (List.map (fun b -> `Float b) h.h_buckets)
-                    ]
-                ] )
-          ] )
+let histogram_datapoint_to_json buckets labels series : Yojson.Safe.t =
+  let bc = bucket_counts buckets series.hs_observations in
+  let base =
+    [ "count", `String (string_of_int series.hs_count)
+    ; "sum", `Float series.hs_sum
+    ; "bucketCounts", `List (List.map (fun n -> `String (string_of_int n)) bc)
+    ; "explicitBounds", `List (List.map (fun b -> `Float b) buckets)
     ]
+  in
+  let fields =
+    match labels with
+    | [] -> base
+    | _ -> ("attributes", labels_to_json labels) :: base
+  in
+  `Assoc fields
+;;
+
+let histogram_to_json (h : histogram_data) : Yojson.Safe.t =
+  let data_points =
+    LabelMap.fold
+      (fun labels series acc ->
+         histogram_datapoint_to_json h.h_buckets labels series :: acc)
+      h.h_values
+      []
+  in
+  `Assoc
+    [ "name", `String h.h_name; "histogram", `Assoc [ "dataPoints", `List data_points ] ]
 ;;
 
 let to_otlp_json t =
@@ -346,30 +371,44 @@ let counter_to_prometheus buf (c : counter_data) =
 let histogram_to_prometheus buf (h : histogram_data) =
   let prom_name = add_prometheus_header buf ~name:h.h_name ~kind:"histogram" in
   let sorted_buckets = List.sort_uniq Float.compare h.h_buckets in
-  List.iter
-    (fun bound ->
-       let count =
-         List.length (List.filter (fun value -> value <= bound) h.h_observations)
-       in
+  LabelMap.iter
+    (fun labels series ->
+       List.iter
+         (fun bound ->
+            let count =
+              List.length
+                (List.filter (fun value -> value <= bound) series.hs_observations)
+            in
+            Buffer.add_string
+              buf
+              (Printf.sprintf
+                 "%s_bucket%s %d\n"
+                 prom_name
+                 (labels_to_prometheus (labels @ [ "le", float_to_prometheus bound ]))
+                 count))
+         sorted_buckets;
        Buffer.add_string
          buf
          (Printf.sprintf
             "%s_bucket%s %d\n"
             prom_name
-            (labels_to_prometheus [ "le", float_to_prometheus bound ])
-            count))
-    sorted_buckets;
-  Buffer.add_string
-    buf
-    (Printf.sprintf
-       "%s_bucket%s %d\n"
-       prom_name
-       (labels_to_prometheus [ "le", "+Inf" ])
-       h.h_count);
-  Buffer.add_string
-    buf
-    (Printf.sprintf "%s_sum %s\n" prom_name (float_to_prometheus h.h_sum));
-  Buffer.add_string buf (Printf.sprintf "%s_count %d\n" prom_name h.h_count)
+            (labels_to_prometheus (labels @ [ "le", "+Inf" ]))
+            series.hs_count);
+       Buffer.add_string
+         buf
+         (Printf.sprintf
+            "%s_sum%s %s\n"
+            prom_name
+            (labels_to_prometheus labels)
+            (float_to_prometheus series.hs_sum));
+       Buffer.add_string
+         buf
+         (Printf.sprintf
+            "%s_count%s %d\n"
+            prom_name
+            (labels_to_prometheus labels)
+            series.hs_count))
+    h.h_values
 ;;
 
 let to_prometheus_text t =

--- a/lib/metrics.mli
+++ b/lib/metrics.mli
@@ -41,7 +41,7 @@ val histogram : t -> name:string -> buckets:float list -> histogram
 val incr : counter -> ?labels:(string * string) list -> int -> unit
 
 (** Record an observation in a histogram. *)
-val observe : histogram -> float -> unit
+val observe : histogram -> ?labels:(string * string) list -> float -> unit
 
 (** {1 Export} *)
 
@@ -60,8 +60,10 @@ val to_prometheus_text : t -> string
 (** Read current counter value for given labels. *)
 val counter_value : counter -> ?labels:(string * string) list -> unit -> int
 
-(** Number of observations recorded. *)
-val histogram_count : histogram -> int
+(** Number of observations recorded.
+
+    When [labels] is omitted, returns the total across all label series. *)
+val histogram_count : ?labels:(string * string) list -> histogram -> int
 
 (** Clear all recorded data. *)
 val reset : t -> unit

--- a/test/test_metrics.ml
+++ b/test/test_metrics.ml
@@ -46,6 +46,41 @@ let test_histogram_basic () =
   check int "count" 3 (Metrics.histogram_count h)
 ;;
 
+let test_histogram_with_labels () =
+  let m = Metrics.create () in
+  let h =
+    Metrics.histogram
+      m
+      ~name:"gen_ai.client.operation.duration"
+      ~buckets:[ 0.1; 0.5; 1.0; 5.0 ]
+  in
+  Metrics.observe
+    h
+    ~labels:[ "gen_ai.system", "openai"; "gen_ai.request.model", "gpt-5" ]
+    0.3;
+  Metrics.observe
+    h
+    ~labels:[ "gen_ai.system", "openai"; "gen_ai.request.model", "gpt-5" ]
+    0.9;
+  Metrics.observe
+    h
+    ~labels:[ "gen_ai.system", "anthropic"; "gen_ai.request.model", "claude" ]
+    2.5;
+  check int "total count" 3 (Metrics.histogram_count h);
+  check
+    int
+    "openai count"
+    2
+    (Metrics.histogram_count
+       ~labels:[ "gen_ai.request.model", "gpt-5"; "gen_ai.system", "openai" ]
+       h);
+  check
+    int
+    "missing label count"
+    0
+    (Metrics.histogram_count ~labels:[ "gen_ai.system", "missing" ] h)
+;;
+
 let test_counter_same_name_returns_same () =
   let m = Metrics.create () in
   let c1 = Metrics.counter m ~name:"x" ~unit_:"1" in
@@ -156,6 +191,22 @@ let test_prometheus_text_histogram_deduplicates_bucket_bounds () =
     (count_substring text "dup_bounds_bucket{le=\"1\"}")
 ;;
 
+let test_prometheus_text_histogram_exports_zero_series_on_create_and_reset () =
+  let m = Metrics.create () in
+  let h = Metrics.histogram m ~name:"empty.histogram" ~buckets:[ 1.0; 2.0 ] in
+  let check_zero_series prefix text =
+    check_line (prefix ^ " bucket le 1") "empty_histogram_bucket{le=\"1\"} 0" text;
+    check_line (prefix ^ " bucket le 2") "empty_histogram_bucket{le=\"2\"} 0" text;
+    check_line (prefix ^ " bucket le +Inf") "empty_histogram_bucket{le=\"+Inf\"} 0" text;
+    check_line (prefix ^ " sum") "empty_histogram_sum 0" text;
+    check_line (prefix ^ " count") "empty_histogram_count 0" text
+  in
+  check_zero_series "fresh" (Metrics.to_prometheus_text m);
+  Metrics.observe h 3.0;
+  Metrics.reset m;
+  check_zero_series "reset" (Metrics.to_prometheus_text m)
+;;
+
 let test_register_rejects_normalized_collision_counter_counter () =
   let m = Metrics.create () in
   let _ = Metrics.counter m ~name:"foo.bar" ~unit_:"1" in
@@ -180,6 +231,116 @@ let test_register_same_name_same_kind_is_idempotent () =
   ()
 ;;
 
+let test_prometheus_text_histogram_exports_labeled_series () =
+  let m = Metrics.create () in
+  let h = Metrics.histogram m ~name:"gen_ai.client.ttfrc" ~buckets:[ 1.0; 2.0 ] in
+  let labels = [ "gen_ai.system", "openai"; "gen_ai.request.model", "gpt-5" ] in
+  Metrics.observe h ~labels 0.5;
+  Metrics.observe h ~labels 3.0;
+  let text = Metrics.to_prometheus_text m in
+  check_line
+    "labeled bucket"
+    "gen_ai_client_ttfrc_bucket{gen_ai_request_model=\"gpt-5\",gen_ai_system=\"openai\",le=\"1\"} \
+     1"
+    text;
+  check_line
+    "labeled +Inf bucket"
+    "gen_ai_client_ttfrc_bucket{gen_ai_request_model=\"gpt-5\",gen_ai_system=\"openai\",le=\"+Inf\"} \
+     2"
+    text;
+  check_line
+    "labeled sum"
+    "gen_ai_client_ttfrc_sum{gen_ai_request_model=\"gpt-5\",gen_ai_system=\"openai\"} 3.5"
+    text;
+  check_line
+    "labeled count"
+    "gen_ai_client_ttfrc_count{gen_ai_request_model=\"gpt-5\",gen_ai_system=\"openai\"} 2"
+    text
+;;
+
+let test_otlp_json_histogram_exports_labeled_datapoints () =
+  let m = Metrics.create () in
+  let h = Metrics.histogram m ~name:"gen_ai.client.ttfrc" ~buckets:[ 1.0; 2.0 ] in
+  Metrics.observe h ~labels:[ "gen_ai.system", "openai" ] 0.5;
+  let json = Metrics.to_otlp_json m in
+  let open Yojson.Safe.Util in
+  let metrics =
+    json
+    |> member "resourceMetrics"
+    |> to_list
+    |> List.hd
+    |> member "scopeMetrics"
+    |> to_list
+    |> List.hd
+    |> member "metrics"
+    |> to_list
+  in
+  let metric =
+    List.find
+      (fun metric -> metric |> member "name" |> to_string = "gen_ai.client.ttfrc")
+      metrics
+  in
+  let data_point_attributes data_point =
+    match member "attributes" data_point with
+    | `List attrs -> attrs
+    | _ -> []
+  in
+  let data_point =
+    metric
+    |> member "histogram"
+    |> member "dataPoints"
+    |> to_list
+    |> List.find (fun data_point -> data_point_attributes data_point <> [])
+  in
+  let attrs = data_point_attributes data_point in
+  check int "one attribute" 1 (List.length attrs);
+  check string "attribute key" "gen_ai.system" (List.hd attrs |> member "key" |> to_string);
+  check
+    string
+    "attribute value"
+    "openai"
+    (List.hd attrs |> member "value" |> member "stringValue" |> to_string)
+;;
+
+let test_otlp_json_histogram_exports_zero_datapoint_before_observe () =
+  let m = Metrics.create () in
+  let _ = Metrics.histogram m ~name:"gen_ai.client.zero" ~buckets:[ 1.0; 2.0 ] in
+  let json = Metrics.to_otlp_json m in
+  let open Yojson.Safe.Util in
+  let metrics =
+    json
+    |> member "resourceMetrics"
+    |> to_list
+    |> List.hd
+    |> member "scopeMetrics"
+    |> to_list
+    |> List.hd
+    |> member "metrics"
+    |> to_list
+  in
+  let metric =
+    List.find
+      (fun metric -> metric |> member "name" |> to_string = "gen_ai.client.zero")
+      metrics
+  in
+  let data_points = metric |> member "histogram" |> member "dataPoints" |> to_list in
+  check int "one zero datapoint" 1 (List.length data_points);
+  let data_point = List.hd data_points in
+  check string "count" "0" (data_point |> member "count" |> to_string);
+  check (float 0.000001) "sum" 0.0 (data_point |> member "sum" |> to_float);
+  check
+    int
+    "bucket count length"
+    3
+    (data_point |> member "bucketCounts" |> to_list |> List.length);
+  let attrs =
+    match member "attributes" data_point with
+    | `List attrs -> attrs
+    | _ -> []
+  in
+  check int "no attributes" 0 (List.length attrs)
+;;
+
 let () =
   run
     "Metrics"
@@ -191,7 +352,10 @@ let () =
             `Quick
             (with_eio test_counter_same_name_returns_same)
         ] )
-    ; "histogram", [ test_case "basic observe" `Quick (with_eio test_histogram_basic) ]
+    ; ( "histogram"
+      , [ test_case "basic observe" `Quick (with_eio test_histogram_basic)
+        ; test_case "labeled observe" `Quick (with_eio test_histogram_with_labels)
+        ] )
     ; ( "lifecycle"
       , [ test_case "reset clears all" `Quick (with_eio test_reset)
         ; test_case "otlp json structure" `Quick (with_eio test_otlp_json_structure)
@@ -209,6 +373,23 @@ let () =
             "histogram text export deduplicates bucket bounds"
             `Quick
             (with_eio test_prometheus_text_histogram_deduplicates_bucket_bounds)
+        ; test_case
+            "histogram text export preserves zero series"
+            `Quick
+            (with_eio
+               test_prometheus_text_histogram_exports_zero_series_on_create_and_reset)
+        ; test_case
+            "histogram text export emits labeled series"
+            `Quick
+            (with_eio test_prometheus_text_histogram_exports_labeled_series)
+        ; test_case
+            "histogram OTLP export emits labeled datapoints"
+            `Quick
+            (with_eio test_otlp_json_histogram_exports_labeled_datapoints)
+        ; test_case
+            "histogram OTLP export preserves zero datapoint"
+            `Quick
+            (with_eio test_otlp_json_histogram_exports_zero_datapoint_before_observe)
         ] )
     ; ( "registration"
       , [ test_case


### PR DESCRIPTION
## Summary
- Add optional labels to `Metrics.observe` so OAS histograms can emit provider/model-specific latency series.
- Preserve existing unlabeled histogram calls and make `histogram_count` return total count by default, or a specific label series with `~labels`.
- Export labeled histogram datapoints in both OTLP JSON and Prometheus text format.
- Preserve pre-existing zero-valued default histogram series on registration and after `Metrics.reset`, so existing unlabeled dashboards/alerts keep seeing the series before the first observation.

## Review Response
- Rebased onto current `origin/main` and resolved the metric conflict by keeping main's normalized Prometheus-name collision guard.
- Addressed Codex review on fresh/reset histograms by seeding the default unlabeled zero series and adding Prometheus + OTLP regressions.

## Verification
- `git diff --check`
- `opam exec -- ocamlformat --check lib/metrics.ml lib/metrics.mli test/test_metrics.ml`
- `scripts/dune-local.sh build test/test_metrics.exe`
- `./_build/default/test/test_metrics.exe` (17 tests)

## Review Notes
- Draft PR only. This is the enabling layer for the old telemetry plan item requiring provider/model-specific latency histograms; no provider behavior is changed in this PR.
