### PR TITLE
fix(metrics): persist provider snapshots as json

### DIFF
--- a/lib/llm_provider/metrics.ml
+++ b/lib/llm_provider/metrics.ml
@@ -92,6 +92,102 @@ type provider_snapshot =
   ; latency_ms_count : int
   }
 
+let provider_snapshot_to_yojson (snapshot : provider_snapshot) : Yojson.Safe.t =
+  `Assoc
+    [ "provider", `String snapshot.provider
+    ; "model_id", `String snapshot.model_id
+    ; "request_total", `Int snapshot.request_total
+    ; "error_total", `Int snapshot.error_total
+    ; "retry_total", `Int snapshot.retry_total
+    ; "input_tokens_total", `Int snapshot.input_tokens_total
+    ; "output_tokens_total", `Int snapshot.output_tokens_total
+    ; "latency_ms_sum", `Int snapshot.latency_ms_sum
+    ; "latency_ms_count", `Int snapshot.latency_ms_count
+    ]
+;;
+
+let compare_provider_snapshot left right =
+  match String.compare left.provider right.provider with
+  | 0 -> String.compare left.model_id right.model_id
+  | cmp -> cmp
+;;
+
+let provider_snapshots_to_yojson (snapshots : provider_snapshot list) : Yojson.Safe.t =
+  let snapshots = List.sort compare_provider_snapshot snapshots in
+  `Assoc
+    [ "schema_version", `Int 1
+    ; "providers", `List (List.map provider_snapshot_to_yojson snapshots)
+    ]
+;;
+
+let file_error ~op ~path = function
+  | Sys_error detail -> Error (Printf.sprintf "%s %s: %s" op path detail)
+  | Unix.Unix_error (error, syscall, arg) ->
+    Error
+      (Printf.sprintf "%s %s: %s(%s): %s" op path syscall arg (Unix.error_message error))
+  | exn -> Error (Printf.sprintf "%s %s: %s" op path (Printexc.to_string exn))
+;;
+
+let rec ensure_dir path =
+  if path = "" || path = "." || Sys.file_exists path
+  then Ok ()
+  else (
+    match ensure_dir (Filename.dirname path) with
+    | Error _ as err -> err
+    | Ok () ->
+      (try
+         Sys.mkdir path 0o755;
+         Ok ()
+       with
+       | Sys_error _ when Sys.file_exists path -> Ok ()
+       | exn -> file_error ~op:"mkdir" ~path exn))
+;;
+
+let fsync_best_effort fd =
+  try Unix.fsync fd with
+  | Unix.Unix_error ((EINVAL | EOPNOTSUPP), _, _) -> ()
+;;
+
+let fsync_dir_best_effort dir =
+  try
+    let fd = Unix.openfile dir [ Unix.O_RDONLY ] 0 in
+    Fun.protect
+      ~finally:(fun () ->
+        try Unix.close fd with
+        | Unix.Unix_error _ -> ())
+      (fun () -> fsync_best_effort fd)
+  with
+  | Unix.Unix_error _ -> ()
+;;
+
+let write_file_atomic path content =
+  let dir = Filename.dirname path in
+  match ensure_dir dir with
+  | Error _ as err -> err
+  | Ok () ->
+    (try
+       let base = Filename.basename path in
+       let tmp_path = Filename.temp_file ~temp_dir:dir (base ^ ".") ".tmp" in
+       let clean_tmp () =
+         try Sys.remove tmp_path with
+         | Sys_error _ | Unix.Unix_error _ -> ()
+       in
+       try
+         Out_channel.with_open_bin tmp_path (fun oc ->
+           Out_channel.output_string oc content;
+           Out_channel.flush oc;
+           fsync_best_effort (Unix.descr_of_out_channel oc));
+         Sys.rename tmp_path path;
+         fsync_dir_best_effort dir;
+         Ok ()
+       with
+       | exn ->
+         clean_tmp ();
+         raise exn
+     with
+     | exn -> file_error ~op:"write" ~path exn)
+;;
+
 type aggregate_key = string
 
 type aggregate_state =
@@ -221,6 +317,13 @@ module Aggregating = struct
               :: acc)
            agg.states
            [])
+  ;;
+
+  let snapshot_to_yojson agg = provider_snapshots_to_yojson (snapshot agg)
+
+  let save_snapshot_json agg ~path =
+    let payload = snapshot_to_yojson agg |> Yojson.Safe.pretty_to_string in
+    write_file_atomic path payload
   ;;
 
   let reset (agg : t) =

--- a/lib/llm_provider/metrics.mli
+++ b/lib/llm_provider/metrics.mli
@@ -104,6 +104,18 @@ type provider_snapshot =
   ; latency_ms_count : int
   }
 
+(** Convert one provider snapshot to structured JSON.
+
+    @since 0.193.11 *)
+val provider_snapshot_to_yojson : provider_snapshot -> Yojson.Safe.t
+
+(** Convert provider snapshots to a stable JSON payload suitable for
+    durable periodic flushes. The payload includes a [schema_version] field
+    so downstream readers can evolve without guessing the shape.
+
+    @since 0.193.11 *)
+val provider_snapshots_to_yojson : provider_snapshot list -> Yojson.Safe.t
+
 (** Mutable counters for a single aggregation key. *)
 type aggregate_state
 
@@ -136,6 +148,14 @@ module Aggregating : sig
 
   (** Read all accumulated counters as an immutable snapshot list. *)
   val snapshot : t -> provider_snapshot list
+
+  (** Read all accumulated counters and encode them as stable JSON. *)
+  val snapshot_to_yojson : t -> Yojson.Safe.t
+
+  (** Atomically persist the current snapshot as pretty JSON. Creates parent
+      directories before writing with a writer-unique temporary file and
+      rename. *)
+  val save_snapshot_json : t -> path:string -> (unit, string) result
 
   (** Reset all counters to zero. *)
   val reset : t -> unit

--- a/test/test_metrics_aggregating.ml
+++ b/test/test_metrics_aggregating.ml
@@ -142,6 +142,131 @@ let test_aggregating_multiple_providers () =
   check int "three entries" 3 (List.length snap)
 ;;
 
+let test_provider_snapshot_to_yojson () =
+  let snapshot : M.provider_snapshot =
+    { provider = "openai"
+    ; model_id = "gpt-4.1"
+    ; request_total = 3
+    ; error_total = 1
+    ; retry_total = 2
+    ; input_tokens_total = 123
+    ; output_tokens_total = 45
+    ; latency_ms_sum = 900
+    ; latency_ms_count = 3
+    }
+  in
+  let json = M.provider_snapshot_to_yojson snapshot in
+  match json with
+  | `Assoc fields ->
+    check
+      (option string)
+      "provider"
+      (Some "openai")
+      (List.assoc_opt "provider" fields |> Option.map Yojson.Safe.Util.to_string);
+    check
+      (option int)
+      "request_total"
+      (Some 3)
+      (List.assoc_opt "request_total" fields |> Option.map Yojson.Safe.Util.to_int);
+    check
+      (option int)
+      "latency_ms_count"
+      (Some 3)
+      (List.assoc_opt "latency_ms_count" fields |> Option.map Yojson.Safe.Util.to_int)
+  | _ -> fail "expected object"
+;;
+
+let test_provider_snapshots_to_yojson_is_stable () =
+  let snapshots : M.provider_snapshot list =
+    [ { provider = "z-provider"
+      ; model_id = "z-model"
+      ; request_total = 1
+      ; error_total = 0
+      ; retry_total = 0
+      ; input_tokens_total = 0
+      ; output_tokens_total = 0
+      ; latency_ms_sum = 0
+      ; latency_ms_count = 0
+      }
+    ; { provider = "a-provider"
+      ; model_id = "a-model"
+      ; request_total = 2
+      ; error_total = 0
+      ; retry_total = 0
+      ; input_tokens_total = 0
+      ; output_tokens_total = 0
+      ; latency_ms_sum = 0
+      ; latency_ms_count = 0
+      }
+    ]
+  in
+  match M.provider_snapshots_to_yojson snapshots with
+  | `Assoc fields ->
+    check
+      (option int)
+      "schema_version"
+      (Some 1)
+      (List.assoc_opt "schema_version" fields |> Option.map Yojson.Safe.Util.to_int);
+    (match List.assoc_opt "providers" fields with
+     | Some (`List (`Assoc first :: _)) ->
+       check
+         string
+         "first provider"
+         "a-provider"
+         (List.assoc "provider" first |> Yojson.Safe.Util.to_string)
+     | _ -> fail "expected providers list")
+  | _ -> fail "expected object"
+;;
+
+let test_aggregating_save_snapshot_json () =
+  let agg = Agg.create () in
+  let hooks = Agg.to_hooks agg in
+  hooks.on_retry ~provider:"openai" ~model_id:"gpt-4.1" ~attempt:1;
+  hooks.on_token_usage
+    ~provider:"openai"
+    ~model_id:"gpt-4.1"
+    ~input_tokens:10
+    ~output_tokens:4;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "oas-metrics-snapshot-%d" (Unix.getpid ()))
+  in
+  let path = Filename.concat dir "provider-snapshot.json" in
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.remove path with
+       | Sys_error _ -> ());
+      try Unix.rmdir dir with
+      | Unix.Unix_error _ -> ())
+    (fun () ->
+       match Agg.save_snapshot_json agg ~path with
+       | Error err -> failf "save_snapshot_json failed: %s" err
+       | Ok () ->
+         let json = Yojson.Safe.from_file path in
+         (match json with
+          | `Assoc fields ->
+            (match List.assoc_opt "providers" fields with
+             | Some (`List [ `Assoc provider ]) ->
+               check
+                 string
+                 "provider"
+                 "openai"
+                 (List.assoc "provider" provider |> Yojson.Safe.Util.to_string);
+               check
+                 int
+                 "retry_total"
+                 1
+                 (List.assoc "retry_total" provider |> Yojson.Safe.Util.to_int);
+               check
+                 int
+                 "input_tokens_total"
+                 10
+                 (List.assoc "input_tokens_total" provider |> Yojson.Safe.Util.to_int)
+             | _ -> fail "expected one provider")
+          | _ -> fail "expected object"))
+;;
+
 let test_aggregating_inner_delegation () =
   let inner_request_start_called = ref false in
   let inner : M.t =
@@ -180,6 +305,12 @@ let () =
       , [ test_case "reset clears all" `Quick test_aggregating_reset
         ; test_case "key format" `Quick test_aggregating_key
         ; test_case "multiple providers" `Quick test_aggregating_multiple_providers
+        ; test_case "snapshot to JSON" `Quick test_provider_snapshot_to_yojson
+        ; test_case
+            "snapshot list JSON is stable"
+            `Quick
+            test_provider_snapshots_to_yojson_is_stable
+        ; test_case "save snapshot JSON" `Quick test_aggregating_save_snapshot_json
         ; test_case "inner delegation" `Quick test_aggregating_inner_delegation
         ] )
     ]


### PR DESCRIPTION
## What changed
- Added stable JSON encoders for `Llm_provider.Metrics.provider_snapshot` payloads.
- Added `Metrics.Aggregating.snapshot_to_yojson` and `save_snapshot_json` for periodic provider metrics flushes.
- Persisted snapshots use a schema version, deterministic provider/model ordering, parent directory creation, writer-unique temp files, fsync best effort, and rename.
- Extended `test_metrics_aggregating` coverage for JSON shape, stable ordering, and writing/reading a snapshot file.

## Why
Old telemetry follow-up notes called out that in-process provider metrics could be sampled but not durably flushed. This gives host/runtime code a small API to persist provider counters without adding a new metrics backend dependency.

## Impact
Operators can wire a periodic flush loop and retain provider request/error/retry/token/latency counters across process restarts or external scrape gaps.

## Validation
- `git diff --check`
- `opam exec -- ocamlformat --check lib/llm_provider/metrics.mli lib/llm_provider/metrics.ml test/test_metrics_aggregating.ml`
- `scripts/dune-local.sh build test/test_metrics_aggregating.exe`
- `./_build/default/test/test_metrics_aggregating.exe`