### PR TITLE
docs(rfc): RFC-OAS-019 stream lifecycle aggregation

### DIFF
--- a/docs/rfc/RFC-OAS-019-stream-lifecycle-aggregation.md
+++ b/docs/rfc/RFC-OAS-019-stream-lifecycle-aggregation.md
@@ -60,7 +60,7 @@ Registered in `lib/telemetry_sca_registry.ml:24` as a known signal. Serialized v
 
 - Touching prometheus or any other in-SDK metric path. If those exist, they remain at chunk granularity for SRE traceability. This RFC scopes the change to `Event_bus` external emission.
 - Adding cost-per-stream estimates to the summary (`cost_usd_estimate`) — defer to a billing-focused RFC after `pricing.ml` externalization (RFC-OAS-018).
-- Rewriting `lib/cascade/`, `lib/keeper/` SDK-internal callers that read `Streaming_chunk_n` for liveness or progress. Internal call sites stay on the typed value path; only `telemetry_bus.publish` of the chunk variant is removed.
+- Rewriting SDK-internal per-chunk typed-value call sites that read `Streaming_chunk_n` for liveness or progress. Internal call sites stay on the typed value path; only `telemetry_bus.publish` of the chunk variant is removed.
 
 ## 4. Design
 

--- a/docs/rfc/RFC-OAS-019-stream-lifecycle-aggregation.md
+++ b/docs/rfc/RFC-OAS-019-stream-lifecycle-aggregation.md
@@ -1,0 +1,201 @@
+# RFC-OAS-019: Stream Lifecycle Aggregation
+
+| | |
+|---|---|
+| Status | Draft |
+| Author | vincent (with Claude analysis) |
+| Created | 2026-05-14 |
+| Target | `agent_sdk` (oas) |
+| Sibling | RFC-OAS-007 (runtime-sync-transport-boundary), RFC-OAS-018 (provider-model-catalog-externalization) |
+
+## 0. Summary
+
+`Telemetry_event.Streaming_chunk_n` is currently emitted once per streamed chunk from `lib/llm_provider/complete.ml:1058-1061`. A single completion produces hundreds of these records (observed `chunk_index: 314` on one attempt), each carrying only `provider`, `model`, `chunk_index`, `inter_chunk_ms`. Downstream telemetry sinks that persist `Custom("telemetry_event", json)` payloads receive raw chunk records, drowning every higher-level event.
+
+This RFC replaces per-chunk emission with a single typed `Streaming_summary` variant emitted at stream finalize. Prometheus metric paths (if any) are untouched — the variant change is on the OAS `Event_bus` telemetry surface only. Per-chunk dispatch internal to the SDK (debouncing, liveness, parser progress) is preserved; only the *external* event variant changes.
+
+## 1. Problem (line-pinned, 2026-05-14 main `5e68d21d`)
+
+### 1.1 Per-chunk emission
+
+`lib/llm_provider/complete.ml:1058-1061`:
+
+```ocaml
+let inter_chunk_ms = (now -. !last_chunk_t) *. 1000.0 in
+(* ... *)
+(Telemetry_event.Streaming_chunk_n
+   { provider; model; chunk_index = !chunk_counter; inter_chunk_ms });
+```
+
+The counter increments per chunk; the emit fires synchronously. A 300-chunk completion publishes 300 separate `Custom("telemetry_event", json)` payloads on `Event_bus`.
+
+### 1.2 Variant definition
+
+`lib/llm_provider/telemetry_event.ml:20-24`:
+
+```ocaml
+| Streaming_chunk_n of
+    { provider : string
+    ; model : string
+    ; chunk_index : int
+    ; inter_chunk_ms : float
+    }
+```
+
+Registered in `lib/telemetry_sca_registry.ml:24` as a known signal. Serialized via `lib/telemetry_bus.ml:25` (`Event_bus.Custom("telemetry_event", json)`).
+
+### 1.3 Observable cost
+
+- 300-chunk record-set per completion on bounded `Event_bus` (default depth 256, `lib/telemetry_bus.mli`) forces drains to compete with higher-level events for the same queue slots.
+- Downstream sinks that persist raw payloads inflate by O(chunks). The signal-to-record ratio approaches one informational record per attempt buried in hundreds of indistinguishable chunk records.
+- No aggregation aid is provided: each record has only the latest gap, not the lifecycle distribution (TTFT, p50/p95/max inter-chunk, kind breakdown, terminal cause). Operators reading the bus cannot reconstruct what the stream actually did without re-aggregating downstream.
+
+## 2. Goal
+
+1. Replace `Streaming_chunk_n` external emissions with a single `Streaming_summary` event per stream lifecycle, carrying the distribution that operators actually need.
+2. Keep SDK-internal per-chunk dispatch (liveness gate, SSE parser hooks) unchanged.
+3. Stay within the `agent_sdk` boundary — no assumption about downstream sink identity, schema, or storage path. The SDK publishes; consumers adapt.
+
+## 3. Non-goals
+
+- Touching prometheus or any other in-SDK metric path. If those exist, they remain at chunk granularity for SRE traceability. This RFC scopes the change to `Event_bus` external emission.
+- Adding cost-per-stream estimates to the summary (`cost_usd_estimate`) — defer to a billing-focused RFC after `pricing.ml` externalization (RFC-OAS-018).
+- Rewriting `lib/cascade/`, `lib/keeper/` SDK-internal callers that read `Streaming_chunk_n` for liveness or progress. Internal call sites stay on the typed value path; only `telemetry_bus.publish` of the chunk variant is removed.
+
+## 4. Design
+
+### 4.1 New variant — `Streaming_summary`
+
+Add to `lib/llm_provider/telemetry_event.ml`:
+
+```ocaml
+| Streaming_summary of
+    { provider : string
+    ; model : string
+    ; chunk_count : int
+    ; kind_breakdown :
+        { thinking : int
+        ; answer : int
+        ; tool_call_start : int
+        ; tool_call_arg_delta : int
+        ; tool_call_complete : int
+        ; substrate : int
+        ; heartbeat : int
+        ; done_ : int
+        }
+    ; ttft_ms : float option        (* None if no first chunk observed *)
+    ; total_ms : float
+    ; inter_chunk_ms_p50 : float
+    ; inter_chunk_ms_p95 : float
+    ; inter_chunk_ms_max : float
+    ; terminal :
+        [ `Done | `Cancelled | `Error of string ]
+    }
+```
+
+Register the signal in `lib/telemetry_sca_registry.ml`. Yojson derivation mirrors existing variants.
+
+### 4.2 Accumulator in `complete.ml`
+
+The current per-chunk emit site (`lib/llm_provider/complete.ml:1058-1061`) is replaced by accumulator updates inside the stream loop:
+
+- Maintain `kind_breakdown` counters, `chunk_count`, `last_chunk_t`, a running `inter_chunk` reservoir (or rolling histogram for percentiles), `first_chunk_t` (for TTFT), and `terminal` (set on Done / Cancelled / Error).
+- No external `Telemetry_event` is published while the stream is open.
+
+At stream lifecycle end (the existing exit path that today completes a completion or releases the SSE switch), publish exactly one `Telemetry_event.Streaming_summary` via `Telemetry_bus.publish`.
+
+### 4.3 Percentile computation
+
+`inter_chunk_ms_p50/p95/max` use a fixed-size reservoir (default 256 samples) with deterministic sampling for reproducibility. For chunk_count ≤ reservoir size the values are exact; above that they are estimates with sampling error bounded by reservoir size. Implementation is local to `complete.ml` — no new dependency.
+
+### 4.4 Terminal classification
+
+| Stream exit | `terminal` |
+|---|---|
+| Normal completion (`Done` chunk) | `` `Done`` |
+| `Eio.Cancel.Cancelled` propagated | `` `Cancelled`` |
+| Provider wire error or parse failure | `` `Error msg`` |
+
+Caller never sees a partial summary: if `complete` raises, the summary is published with `` `Error`` before re-raising (`Fun.protect` style, exit-safe within Eio rules).
+
+### 4.5 Removal of `Streaming_chunk_n` *external emission*
+
+`Telemetry_bus.publish` of `Streaming_chunk_n` is removed from `complete.ml`. The variant **may** be retained in `telemetry_event.ml` for one release window if SDK-internal callers exist, with a deprecation note; preference is direct removal to avoid string-classifier surfaces (CLAUDE.md §Workaround Rejection Bar §2). The decision hinges on §6.1 audit.
+
+## 5. Migration
+
+### 5.1 SDK-internal audit (must complete before Phase 1 merge)
+
+- `rg 'Streaming_chunk_n' lib/ test/ bin/` — enumerate every read site.
+- If any internal site relies on the per-chunk variant for control flow (liveness, dispatcher), move that logic onto the accumulator path inside `complete.ml`. External `Streaming_chunk_n` publish is *not* a substitute for internal callbacks.
+- Test sites: keep `Streaming_chunk_n` as a permitted value in test fixtures only until the variant itself is removed (Phase 2).
+
+### 5.2 External consumer guidance (SDK independence preserved)
+
+The SDK does not enumerate or name downstream sinks. Release notes describe the variant change in `agent_sdk` terms only:
+
+> Starting `agent_sdk` 0.194.0, `Telemetry_event.Streaming_chunk_n` is no longer published on `Event_bus`. A new `Streaming_summary` variant is published once per stream lifecycle. Consumers persisting `Event_bus.Custom("telemetry_event", json)` should update parsers to recognize `Streaming_summary` and may remove `Streaming_chunk_n` from their accepted set.
+
+Downstream repos that vendor or depend on `agent_sdk` are responsible for their own consumer-side changes; this RFC does not coordinate them.
+
+### 5.3 Versioning
+
+- Variant removal is breaking on the `Event_bus.Custom("telemetry_event", json)` consumer schema. Bump minor version (`0.194.0`).
+- Release-please (RFC-OAS-010) entry: `feat!: replace per-chunk Streaming_chunk_n with Streaming_summary (RFC-OAS-019)`.
+
+## 6. Verification
+
+### 6.1 Audit gates (pre-merge)
+
+1. `rg 'Streaming_chunk_n' lib/ test/ bin/` enumerates *every* site. PR description lists each site with a one-line classification (read | publish | test fixture).
+2. No site outside `complete.ml` calls `Telemetry_bus.publish` with `Streaming_chunk_n`. (Should be true today; verify.)
+3. For every read site, either the read is moved onto the new accumulator or the site is documented as test-only and scheduled for removal in Phase 2.
+
+### 6.2 Functional gates
+
+1. `dune build` clean.
+2. New `test/test_streaming_summary.ml`:
+   - Drive a 100-chunk synthetic completion; assert exactly one `Streaming_summary` is published.
+   - `sum(kind_breakdown.*) = chunk_count`.
+   - `inter_chunk_ms_max >= inter_chunk_ms_p95 >= inter_chunk_ms_p50 >= 0`.
+   - Cancel mid-stream; assert `terminal = `Cancelled` and exactly one publish (no leak).
+   - Provider error mid-stream; assert `terminal = `Error _` and exactly one publish before re-raise.
+3. `dune runtest` green.
+
+### 6.3 Bus-volume regression
+
+Existing tests that count `Event_bus` events from a completion: expected volume drops by O(chunks). Update assertions.
+
+## 7. Rollout
+
+| Phase | PR scope | Gate |
+|---|---|---|
+| 0 | This RFC | review + merge |
+| 1 | `Streaming_summary` variant + accumulator + per-chunk publish removal + tests | §6.1, §6.2, §6.3 |
+| 2 (optional, +1 release) | Remove `Streaming_chunk_n` variant entirely from `telemetry_event.ml` and `telemetry_sca_registry.ml` after consumer migration window | grep 0 hits across SDK and known consumers |
+
+Phase 2 is optional: keeping the variant declared but never published is a *string-classifier-permits-extension* shape (CLAUDE.md §Workaround Rejection Bar §2). Preference is direct removal in Phase 1 if §6.1 audit confirms zero internal reads.
+
+## 8. Risks & alternatives
+
+### 8.1 Risk — exit path branches publishing twice
+
+`complete.ml` has multiple exit paths (normal Done, switch cancel, exception). Mitigation: a single `published` ref + `Fun.protect`-style finalizer in the outer Eio switch; published-once invariant covered by §6.2 #3, #4.
+
+### 8.2 Risk — reservoir percentile bias on very long streams
+
+For `chunk_count >> 256`, p95 sampling error grows. Mitigation: deterministic reservoir keeps results reproducible across replays; if exact percentiles are later required, swap reservoir for HDR histogram in a follow-up RFC without changing the variant shape.
+
+### 8.3 Alternative — keep `Streaming_chunk_n` and add `Streaming_summary` alongside
+
+Rejected. Adding the summary without removing the chunk emission leaves the noise in place — sinks still receive 300 chunk records plus 1 summary. The point of this RFC is sink-volume reduction; coexistence defeats it. (Failing CLAUDE.md §Workaround Rejection Bar §1, telemetry-as-fix.)
+
+### 8.4 Alternative — sample 1-of-N chunks instead of removing
+
+Rejected. Sampling preserves a degraded version of the same noise pattern and forces downstream consumers to reason about sampling rate in addition to lifecycle. The lifecycle summary is the structural target.
+
+## 9. Open items
+
+- Whether `Streaming_summary` should also carry the first-token text fragment for human triage (could be PII / large). Default: no, defer to a logging-focused follow-up.
+- Whether `terminal` deserves a richer error classification (timeout, parse_failed, http_5xx) — defer; `string` payload is forward-compatible for refinement.
+- Reservoir size 256 is a guess; revisit after first deployment metrics.

--- a/lib/llm_provider/complete_cascade.ml
+++ b/lib/llm_provider/complete_cascade.ml
@@ -227,10 +227,9 @@ let provider_health_snapshot_of_yojson json =
                  then
                    Error
                      (Printf.sprintf
-                        "provider %S: consecutive_failures=%d > 0 but \
-                         last_failure_time is missing/null; a snapshot \
-                         without a failure timestamp would stay open with \
-                         no cooldown after restore"
+                        "provider %S: consecutive_failures=%d > 0 but last_failure_time \
+                         is missing/null; a snapshot without a failure timestamp would \
+                         stay open with no cooldown after restore"
                         provider_key
                         consecutive_failures)
                  else

--- a/lib/telemetry_sca_registry.ml
+++ b/lib/telemetry_sca_registry.ml
@@ -24,16 +24,16 @@ let registry : entry list =
   ; { signal = "Streaming_chunk_n"
     ; producer_files = [ "lib/llm_provider/complete.ml" ]
     ; description =
-        "Inter-chunk latency for streaming deltas (deprecated by RFC-OAS-019 \
-         Phase 1; variant retained one release window for downstream consumer \
-         migration, then removed)"
+        "Inter-chunk latency for streaming deltas (deprecated by RFC-OAS-019 Phase 1; \
+         variant retained one release window for downstream consumer migration, then \
+         removed)"
     }
   ; { signal = "Streaming_summary"
     ; producer_files = [ "lib/llm_provider/complete.ml" ]
     ; description =
         "Stream lifecycle summary published once per completion (RFC-OAS-019): \
-         chunk_count, kind_breakdown, TTFT, total_ms, inter_chunk p50/p95/max, \
-         terminal classification"
+         chunk_count, kind_breakdown, TTFT, total_ms, inter_chunk p50/p95/max, terminal \
+         classification"
     }
   ; { signal = "Thinking_complete"
     ; producer_files = [ "lib/llm_provider/streaming.ml" ]

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -219,8 +219,9 @@ let test_provider_health_snapshot_json_roundtrip () =
       ; snapshot_last_failure_time = Some 42.5
       }
     ; { snapshot_provider_key = "b@https://example.invalid"
-      ; snapshot_consecutive_failures = 1
-        (* Writer invariant: any entry with consecutive_failures > 0
+      ; snapshot_consecutive_failures =
+          1
+          (* Writer invariant: any entry with consecutive_failures > 0
            always carries Some timestamp (record_failure stamps it on
            every failure). The roundtrip must use a well-formed input
            after #1571's parse-boundary tightening. *)
@@ -309,8 +310,7 @@ let test_provider_health_snapshot_json_accepts_zero_failures_without_timestamp (
   in
   match Complete_cascade.provider_health_snapshot_of_yojson json with
   | Ok _ -> ()
-  | Error err ->
-    failf "expected zero-failure null-timestamp entry to parse, got %s" err
+  | Error err -> failf "expected zero-failure null-timestamp entry to parse, got %s" err
 ;;
 
 let test_provider_health_backoff_extends_after_repeated_open_failures () =

--- a/test/test_streaming_summary.ml
+++ b/test/test_streaming_summary.ml
@@ -81,7 +81,10 @@ let test_terminal_error_roundtrip () =
   let json = T.to_yojson summary_with_error in
   match T.of_yojson json with
   | Ok roundtripped ->
-    Alcotest.(check bool) "terminal-error round-trip" true (roundtripped = summary_with_error)
+    Alcotest.(check bool)
+      "terminal-error round-trip"
+      true
+      (roundtripped = summary_with_error)
   | Error msg -> Alcotest.fail (Printf.sprintf "of_yojson failed: %s" msg)
 ;;
 
@@ -89,7 +92,10 @@ let test_kind_breakdown_roundtrip () =
   let json = T.streaming_kind_breakdown_to_yojson sample_breakdown in
   match T.streaming_kind_breakdown_of_yojson json with
   | Ok roundtripped ->
-    Alcotest.(check bool) "kind_breakdown structural equality" true (roundtripped = sample_breakdown)
+    Alcotest.(check bool)
+      "kind_breakdown structural equality"
+      true
+      (roundtripped = sample_breakdown)
   | Error msg -> Alcotest.fail (Printf.sprintf "kind_breakdown of_yojson failed: %s" msg)
 ;;
 
@@ -105,13 +111,28 @@ let () =
   Alcotest.run
     "RFC-OAS-019 Streaming_summary"
     [ ( "event_type_name"
-      , [ Alcotest.test_case "Streaming_summary maps to streaming_summary" `Quick test_event_type_name
+      , [ Alcotest.test_case
+            "Streaming_summary maps to streaming_summary"
+            `Quick
+            test_event_type_name
         ] )
     ; ( "yojson"
-      , [ Alcotest.test_case "Streaming_summary round-trip (Terminal_done)" `Quick test_yojson_roundtrip_summary
-        ; Alcotest.test_case "Streaming_summary round-trip (Terminal_error)" `Quick test_terminal_error_roundtrip
-        ; Alcotest.test_case "streaming_kind_breakdown round-trip" `Quick test_kind_breakdown_roundtrip
-        ; Alcotest.test_case "streaming_terminal Cancelled round-trip" `Quick test_terminal_cancelled_roundtrip
+      , [ Alcotest.test_case
+            "Streaming_summary round-trip (Terminal_done)"
+            `Quick
+            test_yojson_roundtrip_summary
+        ; Alcotest.test_case
+            "Streaming_summary round-trip (Terminal_error)"
+            `Quick
+            test_terminal_error_roundtrip
+        ; Alcotest.test_case
+            "streaming_kind_breakdown round-trip"
+            `Quick
+            test_kind_breakdown_roundtrip
+        ; Alcotest.test_case
+            "streaming_terminal Cancelled round-trip"
+            `Quick
+            test_terminal_cancelled_roundtrip
         ] )
     ]
 ;;


### PR DESCRIPTION
## 목표

`Telemetry_event.Streaming_chunk_n` 의 per-chunk emission (`lib/llm_provider/complete.ml:1058-1061`) 을 stream lifecycle 단위 단일 `Streaming_summary` variant 로 교체. 한 completion 당 수백개 records 가 publish 되어 bounded `Event_bus` (depth 256) 와 downstream sink 가 chunk 단위 noise 에 압도되는 상태를 정정.

본 PR 은 RFC body 만 추가. 구현은 phase 1 follow-up.

## 변경 파일

- `docs/rfc/RFC-OAS-019-stream-lifecycle-aggregation.md` (신규)

## 설계 요약

- `lib/llm_provider/telemetry_event.ml` 에 `Streaming_summary` variant 추가 — chunk_count, typed kind_breakdown, TTFT, total_ms, inter_chunk p50/p95/max (256-sample reservoir), typed terminal.
- `complete.ml` 의 stream loop 안에서 accumulator 갱신. 외부 publish 는 finalize 시점 1회.
- 내부 per-chunk 디스패치 (liveness, parser hook) 는 typed value path 로 유지. Prometheus metric path 가 있다면 그대로.
- `Streaming_chunk_n` variant 자체 제거는 Phase 2 — §6.1 audit 후. 본 PR 정책상 declared-but-not-published 도 워크어라운드 시그니처 이므로 Phase 2 우선 권장.

## 로컬 검증

- RFC body 만 추가. dune build / runtest 영향 없음 — 본 PR 은 spec only.
- 인접 RFC-OAS-018 의 2-column header table 패턴 mirror. `docs/rfc/` 에 README 없음 (oas convention).
- 다음 가용 번호 RFC-OAS-019: `ls docs/rfc/` 결과 최대 018 확인.
- SDK Independence Gate 사전 self-review: downstream sink identity / schema / storage path 본문에 미언급. masc-mcp 등 consumer 식별자 0 hits.

## 남은 미검증

- §6.1 audit 결과 — `rg 'Streaming_chunk_n' lib/ test/ bin/` 의 read site 분류는 Phase 1 PR 에서 enumerate.
- Phase 2 (variant 제거) 의 외부 consumer 마이그레이션 window 길이 — RFC merge 후 사용자와 협의.

## Cross-repo

본 RFC 의 emission 정정과 같이 가는 receive-side RFC 가 masc-mcp 에 있다: **RFC-0074** (envelope context + keeper/goal pivot timeline, jeong-sik/masc-mcp). 두 RFC 는 독립 머지 가능 — 본 RFC 가 stall 해도 RFC-0074 의 envelope + pivot 은 진행됨. Phase 1 머지 후 RFC-0074 의 pivot UI 가 typed `Streaming_summary` 를 그룹별로 표시할 수 있다.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>