### PR TITLE
fix(otel): propagate trace context to provider calls

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -395,6 +395,30 @@ let%test "sanitize_url_for_log handles missing path" =
   sanitize_url_for_log "https://api.example.com" = "https://api.example.com"
 ;;
 
+let header_name_eq left right =
+  String.equal (String.lowercase_ascii left) (String.lowercase_ascii right)
+;;
+
+let merge_trace_context_headers headers trace_context =
+  match trace_context with
+  | [] -> headers
+  | _ ->
+    let is_trace_header name =
+      List.exists (fun (trace_name, _) -> header_name_eq name trace_name) trace_context
+    in
+    List.filter (fun (name, _) -> not (is_trace_header name)) headers @ trace_context
+;;
+
+let config_with_trace_context config trace_context =
+  match trace_context with
+  | [] -> config
+  | _ ->
+    { config with
+      Provider_config.headers =
+        merge_trace_context_headers config.Provider_config.headers trace_context
+    }
+;;
+
 let complete_http
       ~sw
       ~net
@@ -791,6 +815,7 @@ let complete
       ~(messages : Types.message list)
       ?(tools = [])
       ?runtime_mcp_policy
+      ?(trace_context = [])
       ?(cache : Cache.t option)
       ?(metrics : Metrics.t option)
       ?(priority : Request_priority.t option)
@@ -806,6 +831,7 @@ let complete
       | None -> Metrics.get_global ()
     in
     let model_id = config.model_id in
+    let request_config = config_with_trace_context config trace_context in
     (* Cache lookup *)
     (* Compute fingerprint once; reuse for both lookup and store *)
     let cache_key =
@@ -838,7 +864,12 @@ let complete
        let { Llm_transport.response = result; latency_ms } =
          match transport with
          | Some t ->
-           t.complete_sync { Llm_transport.config; messages; tools; runtime_mcp_policy }
+           t.complete_sync
+             { Llm_transport.config = request_config
+             ; messages
+             ; tools
+             ; runtime_mcp_policy
+             }
          | None when requires_non_http_transport config.kind ->
            (* CLI subprocess providers (claude_code/codex_cli/gemini_cli/kimi_cli)
              register with [base_url = ""] on purpose.  Without a CLI
@@ -859,7 +890,7 @@ let complete
                ~net
                ?clock
                ~on_http_status:m.on_http_status
-               ~config
+               ~config:request_config
                ~messages
                ~tools
                ()
@@ -980,6 +1011,7 @@ let complete_with_retry
       ~(messages : Types.message list)
       ?(tools = [])
       ?runtime_mcp_policy
+      ?trace_context
       ?(retry_config = default_retry_config)
       ?cache
       ?metrics
@@ -1000,6 +1032,7 @@ let complete_with_retry
       ~messages
       ~tools
       ?runtime_mcp_policy
+      ?trace_context
       ?cache
       ~metrics:m
       ?priority
@@ -1338,6 +1371,7 @@ let complete_stream
       ~(messages : Types.message list)
       ?(tools = [])
       ?runtime_mcp_policy
+      ?(trace_context = [])
       ~(on_event : Types.sse_event -> unit)
       ?(priority : Request_priority.t option)
       ?(on_telemetry : (Telemetry_event.t -> unit) option)
@@ -1347,6 +1381,7 @@ let complete_stream
   | Error err -> Error err
   | Ok () ->
     let _priority = priority in
+    let request_config = config_with_trace_context config trace_context in
     let t0 = Unix.gettimeofday () in
     let result =
       match transport with
@@ -1354,8 +1389,8 @@ let complete_stream
         t.complete_stream
           ?on_telemetry
           ~on_event
-          { Llm_transport.config; messages; tools; runtime_mcp_policy }
-      | None when requires_non_http_transport config.kind ->
+          { Llm_transport.config = request_config; messages; tools; runtime_mcp_policy }
+      | None when requires_non_http_transport request_config.kind ->
         (* Same rationale as the sync [complete] guard: CLI kinds have
        [base_url = ""] and must not reach cohttp-eio. *)
         Error
@@ -1369,7 +1404,7 @@ let complete_stream
           ?stream_idle_timeout_s
           ?body_timeout_s
           ?on_telemetry
-          ~config
+          ~config:request_config
           ~messages
           ~tools
           ~on_event

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -72,6 +72,7 @@ val complete
   -> messages:Types.message list
   -> ?tools:Yojson.Safe.t list
   -> ?runtime_mcp_policy:Llm_transport.runtime_mcp_policy
+  -> ?trace_context:(string * string) list
   -> ?cache:Cache.t
   -> ?metrics:Metrics.t
   -> ?priority:Request_priority.t
@@ -106,6 +107,7 @@ val complete_with_retry
   -> messages:Types.message list
   -> ?tools:Yojson.Safe.t list
   -> ?runtime_mcp_policy:Llm_transport.runtime_mcp_policy
+  -> ?trace_context:(string * string) list
   -> ?retry_config:retry_config
   -> ?cache:Cache.t
   -> ?metrics:Metrics.t
@@ -149,6 +151,7 @@ val complete_stream
   -> messages:Types.message list
   -> ?tools:Yojson.Safe.t list
   -> ?runtime_mcp_policy:Llm_transport.runtime_mcp_policy
+  -> ?trace_context:(string * string) list
   -> on_event:(Types.sse_event -> unit)
   -> ?priority:Request_priority.t
   -> ?on_telemetry:(Telemetry_event.t -> unit)

--- a/lib/otel_tracer.ml
+++ b/lib/otel_tracer.ml
@@ -266,6 +266,32 @@ let inst_active_count inst =
   inst_with_lock inst @@ fun () -> List.length inst.current_spans
 ;;
 
+let inst_current_span inst =
+  inst_with_lock inst
+  @@ fun () ->
+  match inst.current_spans with
+  | current :: _ -> Some current
+  | [] -> None
+;;
+
+let traceparent_of_span ?(sampled = true) (span : span) =
+  let flags = if sampled then "01" else "00" in
+  Printf.sprintf "00-%s-%s-%s" span.trace_id span.span_id flags
+;;
+
+let trace_context_headers_of_span ?(sampled = true) ?tracestate span =
+  let headers = [ "traceparent", traceparent_of_span ~sampled span ] in
+  match tracestate with
+  | Some state when String.trim state <> "" -> headers @ [ "tracestate", state ]
+  | Some _ | None -> headers
+;;
+
+let inst_trace_context_headers ?sampled ?tracestate inst =
+  match inst_current_span inst with
+  | Some span -> trace_context_headers_of_span ?sampled ?tracestate span
+  | None -> []
+;;
+
 (* -- Instance metric operations --------------------------------------- *)
 
 let inst_record_metric inst ~name ~value ~metric_type =
@@ -467,6 +493,7 @@ let tracer_of_instance inst : Tracing.t =
     let add_attrs = inst_add_attrs inst
     let trace_id s = Some s.trace_id
     let span_id s = Some s.span_id
+    let trace_context_headers () = inst_trace_context_headers inst
   end)
 ;;
 

--- a/lib/otel_tracer.mli
+++ b/lib/otel_tracer.mli
@@ -90,6 +90,20 @@ val inst_flush : instance -> span list
 val inst_reset : instance -> unit
 val inst_completed_count : instance -> int
 val inst_active_count : instance -> int
+val inst_current_span : instance -> span option
+val traceparent_of_span : ?sampled:bool -> span -> string
+
+val trace_context_headers_of_span
+  :  ?sampled:bool
+  -> ?tracestate:string
+  -> span
+  -> (string * string) list
+
+val inst_trace_context_headers
+  :  ?sampled:bool
+  -> ?tracestate:string
+  -> instance
+  -> (string * string) list
 
 (** {1 Instance metric operations} *)
 

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -319,7 +319,9 @@ let stage_route ~sw ?clock ~api_strategy agent prep =
       ; turn = agent.state.turn_count
       ; extra = []
       }
-      (fun _tracer -> dispatch_sync ~sw ?clock agent prep)
+      (fun tracer ->
+         let trace_context = Tracing.trace_context_headers tracer in
+         dispatch_sync ~sw ?clock ~trace_context agent prep)
   | Stream { on_event; on_telemetry } ->
     Tracing.with_span
       agent.options.tracer
@@ -329,7 +331,9 @@ let stage_route ~sw ?clock ~api_strategy agent prep =
       ; turn = agent.state.turn_count
       ; extra = []
       }
-      (fun _tracer -> dispatch_stream ~sw ?clock agent prep ~on_event ?on_telemetry ())
+      (fun tracer ->
+         let trace_context = Tracing.trace_context_headers tracer in
+         dispatch_stream ~sw ?clock ~trace_context agent prep ~on_event ?on_telemetry ())
 ;;
 
 (* ── Stage 4: Collect ────────────────────────────────────── *)

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -38,7 +38,13 @@ let sdk_error_of_http_error : Llm_provider.Http_client.http_error -> Error.sdk_e
        Error.Api (Retry.InvalidRequest { message }))
 ;;
 
-let dispatch_sync ~sw ?clock agent (prep : Agent_turn.turn_preparation) =
+let dispatch_sync
+      ~sw
+      ?clock
+      ?(trace_context = [])
+      agent
+      (prep : Agent_turn.turn_preparation)
+  =
   let tools = Option.value prep.Agent_turn.tools_json ~default:[] in
   let* pc =
     Provider.provider_config_of_agent
@@ -58,6 +64,7 @@ let dispatch_sync ~sw ?clock agent (prep : Agent_turn.turn_preparation) =
         ~messages:prep.Agent_turn.effective_messages
         ~tools
         ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+        ~trace_context
         ?priority:agent.options.priority
         ()
     | None ->
@@ -69,6 +76,7 @@ let dispatch_sync ~sw ?clock agent (prep : Agent_turn.turn_preparation) =
         ~messages:prep.Agent_turn.effective_messages
         ~tools
         ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+        ~trace_context
         ?priority:agent.options.priority
         ()
   in
@@ -83,6 +91,7 @@ let dispatch_stream
       agent
       (prep : Agent_turn.turn_preparation)
       ~on_event
+      ?(trace_context = [])
       ?on_telemetry
       ()
   =
@@ -105,6 +114,7 @@ let dispatch_stream
       ~messages:prep.Agent_turn.effective_messages
       ~tools
       ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+      ~trace_context
       ~on_event
       ?on_telemetry
       ?priority:agent.options.priority

--- a/lib/pipeline/stage_route.ml
+++ b/lib/pipeline/stage_route.ml
@@ -57,7 +57,7 @@ let sdk_error_of_http_error : Llm_provider.Http_client.http_error -> Error.sdk_e
     metrics fire and [Llm_transport.t] (set via [agent.options.transport])
     handles CLI providers.  Legacy {!Api.create_message} remains for
     Stream fallback pending PR-O2b. *)
-let dispatch_sync ~sw ?clock agent prep =
+let dispatch_sync ~sw ?clock ?(trace_context = []) agent prep =
   let tools = Option.value prep.Agent_turn.tools_json ~default:[] in
   let open Result in
   let* pc =
@@ -78,6 +78,7 @@ let dispatch_sync ~sw ?clock agent prep =
         ~messages:prep.effective_messages
         ~tools
         ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+        ~trace_context
         ?priority:agent.options.priority
         ()
     | None ->
@@ -89,6 +90,7 @@ let dispatch_sync ~sw ?clock agent prep =
         ~messages:prep.effective_messages
         ~tools
         ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+        ~trace_context
         ?priority:agent.options.priority
         ()
   in
@@ -97,7 +99,8 @@ let dispatch_sync ~sw ?clock agent prep =
   | Error err -> Error (sdk_error_of_http_error err)
 ;;
 
-let dispatch_stream ~sw ?clock agent prep ~on_event ?on_telemetry () =
+let dispatch_stream ~sw ?clock ?(trace_context = []) agent prep ~on_event ?on_telemetry ()
+  =
   let tools = Option.value prep.Agent_turn.tools_json ~default:[] in
   let open Result in
   let* pc =
@@ -116,6 +119,7 @@ let dispatch_stream ~sw ?clock agent prep ~on_event ?on_telemetry () =
       ~messages:prep.effective_messages
       ~tools
       ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+      ~trace_context
       ~on_event
       ?on_telemetry
       ?priority:agent.options.priority
@@ -137,7 +141,9 @@ let stage_route ~sw ?clock ~api_strategy agent prep =
       ; turn = agent.state.turn_count
       ; extra = []
       }
-      (fun _tracer -> dispatch_sync ~sw ?clock agent prep)
+      (fun tracer ->
+         let trace_context = Tracing.trace_context_headers tracer in
+         dispatch_sync ~sw ?clock ~trace_context agent prep)
   | Stream { on_event; on_telemetry } ->
     Tracing.with_span
       agent.options.tracer
@@ -147,5 +153,7 @@ let stage_route ~sw ?clock ~api_strategy agent prep =
       ; turn = agent.state.turn_count
       ; extra = []
       }
-      (fun _tracer -> dispatch_stream ~sw ?clock agent prep ~on_event ?on_telemetry ())
+      (fun tracer ->
+         let trace_context = Tracing.trace_context_headers tracer in
+         dispatch_stream ~sw ?clock ~trace_context agent prep ~on_event ?on_telemetry ())
 ;;

--- a/lib/tracing.ml
+++ b/lib/tracing.ml
@@ -28,6 +28,7 @@ module type TRACER = sig
   val add_attrs : span -> (string * string) list -> unit
   val trace_id : span -> string option
   val span_id : span -> string option
+  val trace_context_headers : unit -> (string * string) list
 end
 
 module Null_tracer : TRACER with type span = unit = struct
@@ -39,6 +40,7 @@ module Null_tracer : TRACER with type span = unit = struct
   let add_attrs () _attrs = ()
   let trace_id () = None
   let span_id () = None
+  let trace_context_headers () = []
 end
 
 module Fmt_tracer : TRACER = struct
@@ -97,12 +99,18 @@ module Fmt_tracer : TRACER = struct
 
   let trace_id _span = None
   let span_id _span = None
+  let trace_context_headers () = []
 end
 
 type t = (module TRACER)
 
 let null : t = (module Null_tracer)
 let fmt : t = (module Fmt_tracer)
+
+let trace_context_headers (type a) (tracer : t) =
+  let module T = (val tracer : TRACER) in
+  T.trace_context_headers ()
+;;
 
 (** Run [f] within a traced span. [end_span] is called on both normal return
     and exception, with [ok] set accordingly. The exception is re-raised. *)

--- a/lib/tracing.mli
+++ b/lib/tracing.mli
@@ -36,6 +36,7 @@ module type TRACER = sig
   val add_attrs : span -> (string * string) list -> unit
   val trace_id : span -> string option
   val span_id : span -> string option
+  val trace_context_headers : unit -> (string * string) list
 end
 
 (** {1 Built-in Tracers} *)
@@ -53,6 +54,10 @@ val null : t
 
 (** Stderr-printing tracer for development. *)
 val fmt : t
+
+(** Return outbound W3C trace context headers for the current active span,
+    or [[]] when the tracer has no active context. *)
+val trace_context_headers : t -> (string * string) list
 
 (** Run [f] within a traced span.  [end_span] is called on both normal
     return and exception, with [ok] set accordingly.  The exception is

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -64,6 +64,32 @@ let start_mock_server ~sw ~net ?(status = `OK) ?(delay_sec = 0.0) ?clock respons
   Printf.sprintf "http://127.0.0.1:%d" port
 ;;
 
+let start_header_capture_server ~sw ~net ~seen response_body =
+  let port = fresh_port () in
+  let handler _conn req body =
+    let _ = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    let headers = Cohttp.Request.headers req in
+    seen
+    := Some
+         ( Cohttp.Header.get headers "traceparent"
+         , Cohttp.Header.get headers "tracestate"
+         , Cohttp.Header.get headers "x-custom" );
+    Cohttp_eio.Server.respond_string ~status:`OK ~body:response_body ()
+  in
+  let socket =
+    Eio.Net.listen
+      net
+      ~sw
+      ~backlog:8
+      ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  let server = Cohttp_eio.Server.make ~callback:handler () in
+  Eio.Fiber.fork ~sw (fun () ->
+    Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+  Printf.sprintf "http://127.0.0.1:%d" port
+;;
+
 (* ── Helper: make Provider_config ────────────────────── *)
 
 let make_config ?(kind = Provider_config.Anthropic) base_url =
@@ -179,6 +205,44 @@ let test_complete_openai_ok () =
       check string "text" "openai reply" text;
       Eio.Switch.fail sw Exit
     | Error _ -> fail "expected Ok for openai"
+  with
+  | Exit -> ()
+;;
+
+let test_complete_trace_context_headers () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let seen = ref None in
+    let url =
+      start_header_capture_server ~sw ~net:env#net ~seen (anthropic_response "ok")
+    in
+    let config =
+      { (make_config url) with
+        Provider_config.headers = [ "traceparent", "stale"; "x-custom", "yes" ]
+      }
+    in
+    let trace_context =
+      [ "traceparent", "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01"
+      ; "tracestate", "vendor=value"
+      ]
+    in
+    (match Complete.complete ~sw ~net:env#net ~config ~messages ~trace_context () with
+     | Ok _ -> ()
+     | Error _ -> fail "expected Ok");
+    match !seen with
+    | Some (traceparent, tracestate, custom) ->
+      check
+        (option string)
+        "traceparent"
+        (Some "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01")
+        traceparent;
+      check (option string) "tracestate" (Some "vendor=value") tracestate;
+      check (option string) "custom header preserved" (Some "yes") custom;
+      Eio.Switch.fail sw Exit
+    | None -> fail "server did not capture headers"
   with
   | Exit -> ()
 ;;
@@ -655,6 +719,7 @@ let () =
             "openai mlx-vlm telemetry"
             `Quick
             test_complete_openai_mlx_vlm_telemetry
+        ; test_case "trace context headers" `Quick test_complete_trace_context_headers
         ; test_case "non-retryable" `Quick test_complete_non_retryable
         ] )
     ; "cache", [ test_case "store and hit" `Quick test_complete_cache_store_and_hit ]

--- a/test/test_otel_tracer.ml
+++ b/test/test_otel_tracer.ml
@@ -555,6 +555,65 @@ let test_otlp_json_without_metrics () =
     (json_assoc_field "resourceMetrics" json = None)
 ;;
 
+(* ── Trace Context Propagation ─────────────────────────────────────── *)
+
+let test_traceparent_of_span () =
+  Otel_tracer.reset ();
+  let span = Otel_tracer.start_span (default_attrs ~name:"propagate" ()) in
+  let expected = Printf.sprintf "00-%s-%s-01" span.trace_id span.span_id in
+  check string "traceparent sampled" expected (Otel_tracer.traceparent_of_span span);
+  let unsampled = Printf.sprintf "00-%s-%s-00" span.trace_id span.span_id in
+  check
+    string
+    "traceparent unsampled"
+    unsampled
+    (Otel_tracer.traceparent_of_span ~sampled:false span);
+  Otel_tracer.end_span span ~ok:true
+;;
+
+let test_trace_context_headers_of_span () =
+  Otel_tracer.reset ();
+  let span = Otel_tracer.start_span (default_attrs ~name:"headers" ()) in
+  let headers =
+    Otel_tracer.trace_context_headers_of_span ~tracestate:"vendor=value" span
+  in
+  check
+    (list (pair string string))
+    "headers"
+    [ "traceparent", Otel_tracer.traceparent_of_span span; "tracestate", "vendor=value" ]
+    headers;
+  Otel_tracer.end_span span ~ok:true
+;;
+
+let test_instance_trace_context_headers () =
+  let inst = Otel_tracer.create_instance () in
+  check
+    (list (pair string string))
+    "empty when no active span"
+    []
+    (Otel_tracer.inst_trace_context_headers inst);
+  let span = Otel_tracer.inst_start_span inst (default_attrs ~name:"active" ()) in
+  check
+    (list (pair string string))
+    "active span header"
+    [ "traceparent", Otel_tracer.traceparent_of_span span ]
+    (Otel_tracer.inst_trace_context_headers inst);
+  Otel_tracer.inst_end_span inst span ~ok:true
+;;
+
+let test_first_class_trace_context_headers () =
+  let tracer = Otel_tracer.create () in
+  Tracing.with_span
+    tracer
+    (default_attrs ~name:"first_class_context" ())
+    (fun active_tracer ->
+       match Tracing.trace_context_headers active_tracer with
+       | [ ("traceparent", value) ] ->
+         check int "traceparent length" 55 (String.length value)
+       | headers ->
+         failf "unexpected headers: %s" (String.concat "," (List.map fst headers)))
+;;
+
 (* ── Entry point ─────────────────────────────────────────────────── *)
 
 let () =
@@ -611,6 +670,21 @@ let () =
             "otlp json omits metrics when empty"
             `Quick
             test_otlp_json_without_metrics
+        ] )
+    ; ( "trace_context"
+      , [ test_case "traceparent of span" `Quick test_traceparent_of_span
+        ; test_case
+            "trace context headers of span"
+            `Quick
+            test_trace_context_headers_of_span
+        ; test_case
+            "instance trace context headers"
+            `Quick
+            (with_eio test_instance_trace_context_headers)
+        ; test_case
+            "first-class trace context headers"
+            `Quick
+            (with_eio test_first_class_trace_context_headers)
         ] )
     ]
 ;;

--- a/test/test_pipeline_metrics.ml
+++ b/test/test_pipeline_metrics.ml
@@ -41,6 +41,18 @@ let mk_mock_transport (counter : int ref) : Llm_provider.Llm_transport.t =
   }
 ;;
 
+let mk_header_capture_transport headers_ref : Llm_provider.Llm_transport.t =
+  { complete_sync =
+      (fun req ->
+        headers_ref := req.Llm_provider.Llm_transport.config.headers;
+        { response = Ok (mk_mock_response ()); latency_ms = Some 5 })
+  ; complete_stream =
+      (fun ?on_telemetry:_ ~on_event:_ req ->
+        headers_ref := req.Llm_provider.Llm_transport.config.headers;
+        Ok (mk_mock_response ()))
+  }
+;;
+
 let test_sync_dispatches_via_complete_triggers_metrics () =
   Eio_main.run
   @@ fun env ->
@@ -101,6 +113,41 @@ let test_sync_dispatches_via_complete_triggers_metrics () =
   | Error _ -> Alcotest.fail "expected Ok from mock transport"
 ;;
 
+let test_stage_route_passes_trace_context_headers () =
+  Eio_main.run
+  @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  let observed_headers = ref [] in
+  let tracer = Otel_tracer.create () in
+  let transport = mk_header_capture_transport observed_headers in
+  let provider =
+    Some
+      { Provider.provider = Provider.Custom_registered { name = "claude_code" }
+      ; model_id = "auto"
+      ; api_key_env = ""
+      }
+  in
+  let options =
+    { Agent_types.default_options with transport = Some transport; tracer; provider }
+  in
+  let agent =
+    Agent.create
+      ~net
+      ~config:{ Types.default_config with name = "trace-context-test"; max_turns = 1 }
+      ~options
+      ()
+  in
+  Eio.Switch.run
+  @@ fun sw ->
+  let result = Agent.run ~sw agent "ping" in
+  match result with
+  | Error err -> Alcotest.failf "expected Ok: %s" (Error.to_string err)
+  | Ok _ ->
+    (match List.assoc_opt "traceparent" !observed_headers with
+     | Some value -> Alcotest.(check int) "traceparent length" 55 (String.length value)
+     | None -> Alcotest.fail "missing traceparent header")
+;;
+
 let test_sdk_error_of_http_error_classifies () =
   (* Pure smoke test for the conversion helper introduced in pipeline.ml *)
   let _ : Error.sdk_error =
@@ -122,6 +169,10 @@ let () =
             "sdk_error_of_http_error compiles"
             `Quick
             test_sdk_error_of_http_error_classifies
+        ; Alcotest.test_case
+            "stage route forwards trace context"
+            `Quick
+            test_stage_route_passes_trace_context_headers
         ] )
     ]
 ;;

--- a/test/test_tracing.ml
+++ b/test/test_tracing.ml
@@ -112,6 +112,7 @@ end = struct
 
   let trace_id _span = None
   let span_id _span = None
+  let trace_context_headers () = [ "traceparent", "00-test-test-01" ]
   let events () = List.rev !log
   let reset () = log := []
 end
@@ -131,6 +132,19 @@ let test_custom_tracer () =
   check string "second is event" "event:custom:hi" (List.nth evts 1);
   check string "third is attr" "attr:custom:a=1" (List.nth evts 2);
   check string "fourth is end" "end:custom:ok=true" (List.nth evts 3)
+;;
+
+let test_trace_context_headers () =
+  check
+    (list (pair string string))
+    "null has no trace headers"
+    []
+    (Tracing.trace_context_headers Tracing.null);
+  check
+    (list (pair string string))
+    "custom headers"
+    [ "traceparent", "00-test-test-01" ]
+    (Tracing.trace_context_headers (module Recording_tracer))
 ;;
 
 let test_span_kind_coverage () =
@@ -184,7 +198,10 @@ let () =
         ; test_case "exception path" `Quick test_with_span_exception
         ; test_case "exception ends span" `Quick test_with_span_exception_ends_span
         ] )
-    ; "custom", [ test_case "recording tracer" `Quick test_custom_tracer ]
+    ; ( "custom"
+      , [ test_case "recording tracer" `Quick test_custom_tracer
+        ; test_case "trace context headers" `Quick test_trace_context_headers
+        ] )
     ; "coverage", [ test_case "all span_kind variants" `Quick test_span_kind_coverage ]
     ]
 ;;


### PR DESCRIPTION
## What changed
- Added `Tracing.trace_context_headers` to expose outbound W3C trace context for the current active span.
- Added OTel helpers for rendering `traceparent` and optional `tracestate` from active spans.
- Threaded trace context from `Pipeline.stage_route` into `Llm_provider.Complete` for sync, retry, streaming, and injected transports.
- Merged trace context into provider HTTP headers while replacing stale `traceparent`/`tracestate` values and preserving unrelated headers.
- Added regression tests for tracer header rendering, direct HTTP header capture, transport request propagation, and full `Agent.run` pipeline forwarding.

## Why
The old telemetry audit called out that OAS could export spans but did not propagate W3C trace context to downstream provider HTTP calls. That left provider-side logs and distributed traces disconnected from the agent API span.

## Impact
Provider requests now carry `traceparent` from the active OTel API span when an OTel tracer is installed. Existing callers without a tracer keep sending no trace headers, and cache fingerprints still use the original provider config rather than the per-call trace header.

## Validation
- `git diff --check`
- `opam exec -- ocamlformat --check lib/tracing.mli lib/tracing.ml lib/otel_tracer.mli lib/otel_tracer.ml lib/llm_provider/complete.mli lib/llm_provider/complete.ml lib/pipeline/pipeline_stage_route.ml lib/pipeline/stage_route.ml lib/pipeline/pipeline.ml test/test_tracing.ml test/test_otel_tracer.ml test/test_complete_http.ml test/test_pipeline_metrics.ml`
- `scripts/dune-local.sh build test/test_tracing.exe test/test_otel_tracer.exe test/test_complete_http.exe test/test_pipeline_metrics.exe`
- `./_build/default/test/test_tracing.exe` (9 tests)
- `./_build/default/test/test_otel_tracer.exe` (36 tests)
- `./_build/default/test/test_complete_http.exe` (17 tests)
- `./_build/default/test/test_pipeline_metrics.exe` (3 tests)