### PR TITLE
fix(metrics): aggregate streaming latency samples

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -1065,6 +1065,14 @@ let complete_with_retry
 (* Re-export stream accumulator for backward compatibility *)
 include Complete_stream_acc
 
+let record_streaming_metrics (metrics : Metrics.t) = function
+  | Telemetry_event.Streaming_first_chunk { provider; model; ttfrc_ms; _ } ->
+    metrics.on_streaming_first_chunk ~provider ~model_id:model ~ttfrc_ms
+  | Telemetry_event.Streaming_chunk_n { provider; model; chunk_index; inter_chunk_ms } ->
+    metrics.on_streaming_chunk ~provider ~model_id:model ~chunk_index ~inter_chunk_ms
+  | _ -> ()
+;;
+
 (* Internal: HTTP-specific streaming implementation. *)
 let complete_stream_http
       ~sw:_
@@ -1073,6 +1081,7 @@ let complete_stream_http
       ?stream_idle_timeout_s
       ?body_timeout_s
       ?(on_telemetry : (Telemetry_event.t -> unit) option)
+      ?(metrics = Metrics.get_global ())
       ~(config : Provider_config.t)
       ~(messages : Types.message list)
       ~tools
@@ -1138,6 +1147,7 @@ let complete_stream_http
       let provider = Provider_config.string_of_provider_kind config.kind in
       let model = config.model_id in
       let emit_telemetry evt =
+        record_streaming_metrics metrics evt;
         match on_telemetry with
         | Some f -> f evt
         | None -> ()
@@ -1167,19 +1177,17 @@ let complete_stream_http
       let classify_chunk_kind (evt : Types.sse_event) =
         match evt with
         | Types.MessageStart _ -> `Skip
-        | Types.ContentBlockStart { content_type = "tool_use"; _ } ->
-          `Tool_call_start
+        | Types.ContentBlockStart { content_type = "tool_use"; _ } -> `Tool_call_start
         | Types.ContentBlockStart _ -> `Substrate
         | Types.ContentBlockDelta { delta = TextDelta _; _ } -> `Answer
         | Types.ContentBlockDelta { delta = ThinkingDelta _; _ } -> `Thinking
-        | Types.ContentBlockDelta { delta = InputJsonDelta _; _ } ->
-          `Tool_call_arg_delta
+        | Types.ContentBlockDelta { delta = InputJsonDelta _; _ } -> `Tool_call_arg_delta
         | Types.ContentBlockStop _ -> `Tool_call_complete
         | Types.MessageDelta _ -> `Skip
         | Types.MessageStop -> `Done
         | Types.Ping -> `Heartbeat
-        | Types.SSEError _ | Types.SSEParseFailed _ | Types.SSEUnknownEventType _
-          -> `Wire_error
+        | Types.SSEError _ | Types.SSEParseFailed _ | Types.SSEUnknownEventType _ ->
+          `Wire_error
       in
       let percentiles () =
         match !inter_chunk_samples with
@@ -1262,8 +1270,7 @@ let complete_stream_http
                      | `Heartbeat -> incr n_heartbeat
                      | `Done -> incr n_done
                      | `Wire_error ->
-                       terminal_state :=
-                         Telemetry_event.Terminal_error "sse_wire_error")
+                       terminal_state := Telemetry_event.Terminal_error "sse_wire_error")
                   events;
                 if events <> []
                 then
@@ -1282,9 +1289,16 @@ let complete_stream_http
                     let inter_chunk_ms = (now -. !last_chunk_t) *. 1000.0 in
                     (* RFC-OAS-019: per-chunk [Streaming_chunk_n] publish
                        removed. Inter-chunk gaps are accumulated for the
-                       percentile reservoir in [Streaming_summary]. *)
-                    inter_chunk_samples :=
-                      inter_chunk_ms :: !inter_chunk_samples;
+                       percentile reservoir in [Streaming_summary]. Metrics
+                       sinks still receive the raw sample so aggregate backends
+                       can preserve latency counters without re-expanding the
+                       public telemetry stream. *)
+                    metrics.on_streaming_chunk
+                      ~provider
+                      ~model_id:model
+                      ~chunk_index:!chunk_counter
+                      ~inter_chunk_ms;
+                    inter_chunk_samples := inter_chunk_ms :: !inter_chunk_samples;
                     last_chunk_t := now;
                     incr chunk_counter);
                 match tel_opt with
@@ -1374,8 +1388,7 @@ let complete_stream_http
                  (* RFC-OAS-019: timeout path also publishes the summary
                     so operators see the partial stream's distribution. *)
                  publish_summary
-                   ~terminal:
-                     (Telemetry_event.Terminal_error "body_timeout_s_exceeded")
+                   ~terminal:(Telemetry_event.Terminal_error "body_timeout_s_exceeded")
                    ();
                  Error
                    (Printf.sprintf
@@ -1393,9 +1406,7 @@ let complete_stream_http
       | Error _ as e ->
         (* RFC-OAS-019: transport-level error before body_logic ran (or
            before its publish). Idempotent via summary_published. *)
-        publish_summary
-          ~terminal:(Telemetry_event.Terminal_error "transport_error")
-          ();
+        publish_summary ~terminal:(Telemetry_event.Terminal_error "transport_error") ();
         e
       | Ok (Ok resp) ->
         let latency_ms = int_of_float ((Unix.gettimeofday () -. t0) *. 1000.0) in
@@ -1473,8 +1484,7 @@ let complete_stream_http
       | Ok (Error msg) ->
         publish_summary
           ~terminal:
-            (Telemetry_event.Terminal_error
-               (Printf.sprintf "sse_stream_error: %s" msg))
+            (Telemetry_event.Terminal_error (Printf.sprintf "sse_stream_error: %s" msg))
           ();
         Error
           (Http_client.NetworkError
@@ -1494,6 +1504,7 @@ let complete_stream
       ?runtime_mcp_policy
       ?(trace_context = [])
       ~(on_event : Types.sse_event -> unit)
+      ?metrics
       ?(priority : Request_priority.t option)
       ?(on_telemetry : (Telemetry_event.t -> unit) option)
       ()
@@ -1504,11 +1515,24 @@ let complete_stream
     let _priority = priority in
     let request_config = config_with_trace_context config trace_context in
     let t0 = Unix.gettimeofday () in
+    let metrics_opt = metrics in
+    let metrics = Option.value metrics ~default:(Metrics.get_global ()) in
+    let on_telemetry_with_metrics evt =
+      record_streaming_metrics metrics evt;
+      match on_telemetry with
+      | Some f -> f evt
+      | None -> ()
+    in
+    let transport_on_telemetry =
+      match metrics_opt, on_telemetry with
+      | None, None -> None
+      | Some _, _ | None, Some _ -> Some on_telemetry_with_metrics
+    in
     let result =
       match transport with
       | Some t ->
         t.complete_stream
-          ?on_telemetry
+          ?on_telemetry:transport_on_telemetry
           ~on_event
           { Llm_transport.config = request_config; messages; tools; runtime_mcp_policy }
       | None when requires_non_http_transport request_config.kind ->
@@ -1525,6 +1549,7 @@ let complete_stream
           ?stream_idle_timeout_s
           ?body_timeout_s
           ?on_telemetry
+          ~metrics
           ~config:request_config
           ~messages
           ~tools

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -153,6 +153,7 @@ val complete_stream
   -> ?runtime_mcp_policy:Llm_transport.runtime_mcp_policy
   -> ?trace_context:(string * string) list
   -> on_event:(Types.sse_event -> unit)
+  -> ?metrics:Metrics.t
   -> ?priority:Request_priority.t
   -> ?on_telemetry:(Telemetry_event.t -> unit)
   -> unit

--- a/lib/llm_provider/metrics.ml
+++ b/lib/llm_provider/metrics.ml
@@ -44,6 +44,14 @@ type t =
       provider:string -> model_id:string -> input_tokens:int -> output_tokens:int -> unit
     (** Fired when a response carries usage tokens.
       @since 0.185.0 *)
+  ; on_streaming_first_chunk :
+      provider:string -> model_id:string -> ttfrc_ms:float -> unit
+  ; on_streaming_chunk :
+      provider:string
+      -> model_id:string
+      -> chunk_index:int
+      -> inter_chunk_ms:float
+      -> unit
   }
 
 let noop =
@@ -57,6 +65,9 @@ let noop =
   ; on_capability_drop = (fun ~model_id:_ ~field:_ -> ())
   ; on_retry = (fun ~provider:_ ~model_id:_ ~attempt:_ -> ())
   ; on_token_usage = (fun ~provider:_ ~model_id:_ ~input_tokens:_ ~output_tokens:_ -> ())
+  ; on_streaming_first_chunk = (fun ~provider:_ ~model_id:_ ~ttfrc_ms:_ -> ())
+  ; on_streaming_chunk =
+      (fun ~provider:_ ~model_id:_ ~chunk_index:_ ~inter_chunk_ms:_ -> ())
   }
 ;;
 
@@ -90,6 +101,10 @@ type provider_snapshot =
   ; output_tokens_total : int
   ; latency_ms_sum : int
   ; latency_ms_count : int
+  ; ttfrc_ms_sum : float
+  ; ttfrc_ms_count : int
+  ; inter_chunk_ms_sum : float
+  ; inter_chunk_ms_count : int
   }
 
 let provider_snapshot_to_yojson (snapshot : provider_snapshot) : Yojson.Safe.t =
@@ -103,6 +118,10 @@ let provider_snapshot_to_yojson (snapshot : provider_snapshot) : Yojson.Safe.t =
     ; "output_tokens_total", `Int snapshot.output_tokens_total
     ; "latency_ms_sum", `Int snapshot.latency_ms_sum
     ; "latency_ms_count", `Int snapshot.latency_ms_count
+    ; "ttfrc_ms_sum", `Float snapshot.ttfrc_ms_sum
+    ; "ttfrc_ms_count", `Int snapshot.ttfrc_ms_count
+    ; "inter_chunk_ms_sum", `Float snapshot.inter_chunk_ms_sum
+    ; "inter_chunk_ms_count", `Int snapshot.inter_chunk_ms_count
     ]
 ;;
 
@@ -198,6 +217,10 @@ type aggregate_state =
   ; mutable output_tokens_total : int
   ; mutable latency_ms_sum : int
   ; mutable latency_ms_count : int
+  ; mutable ttfrc_ms_sum : float
+  ; mutable ttfrc_ms_count : int
+  ; mutable inter_chunk_ms_sum : float
+  ; mutable inter_chunk_ms_count : int
   }
 
 let empty_state () : aggregate_state =
@@ -208,6 +231,10 @@ let empty_state () : aggregate_state =
   ; output_tokens_total = 0
   ; latency_ms_sum = 0
   ; latency_ms_count = 0
+  ; ttfrc_ms_sum = 0.0
+  ; ttfrc_ms_count = 0
+  ; inter_chunk_ms_sum = 0.0
+  ; inter_chunk_ms_count = 0
   }
 ;;
 
@@ -288,6 +315,18 @@ module Aggregating = struct
           with_state agg (key ~provider ~model_id) (fun s ->
             s.input_tokens_total <- s.input_tokens_total + input_tokens;
             s.output_tokens_total <- s.output_tokens_total + output_tokens))
+    ; on_streaming_first_chunk =
+        (fun ~provider ~model_id ~ttfrc_ms ->
+          agg.hooks.on_streaming_first_chunk ~provider ~model_id ~ttfrc_ms;
+          with_state agg (key ~provider ~model_id) (fun s ->
+            s.ttfrc_ms_sum <- s.ttfrc_ms_sum +. ttfrc_ms;
+            s.ttfrc_ms_count <- s.ttfrc_ms_count + 1))
+    ; on_streaming_chunk =
+        (fun ~provider ~model_id ~chunk_index ~inter_chunk_ms ->
+          agg.hooks.on_streaming_chunk ~provider ~model_id ~chunk_index ~inter_chunk_ms;
+          with_state agg (key ~provider ~model_id) (fun s ->
+            s.inter_chunk_ms_sum <- s.inter_chunk_ms_sum +. inter_chunk_ms;
+            s.inter_chunk_ms_count <- s.inter_chunk_ms_count + 1))
     }
   ;;
 
@@ -313,6 +352,10 @@ module Aggregating = struct
               ; output_tokens_total = s.output_tokens_total
               ; latency_ms_sum = s.latency_ms_sum
               ; latency_ms_count = s.latency_ms_count
+              ; ttfrc_ms_sum = s.ttfrc_ms_sum
+              ; ttfrc_ms_count = s.ttfrc_ms_count
+              ; inter_chunk_ms_sum = s.inter_chunk_ms_sum
+              ; inter_chunk_ms_count = s.inter_chunk_ms_count
               }
               :: acc)
            agg.states

--- a/lib/llm_provider/metrics.mli
+++ b/lib/llm_provider/metrics.mli
@@ -55,6 +55,21 @@ type t =
       provider:string -> model_id:string -> input_tokens:int -> output_tokens:int -> unit
     (** Fired when a response carries usage tokens.
       @since 0.185.0 *)
+  ; on_streaming_first_chunk :
+      provider:string -> model_id:string -> ttfrc_ms:float -> unit
+    (** Fired when a streaming response emits its first parsed response
+        event.  [ttfrc_ms] is wall-clock time-to-first-response-chunk.
+        @since 0.193.12 *)
+  ; on_streaming_chunk :
+      provider:string
+      -> model_id:string
+      -> chunk_index:int
+      -> inter_chunk_ms:float
+      -> unit
+    (** Fired for each subsequent parsed streaming response event.
+        [inter_chunk_ms] is elapsed wall-clock time since the previous
+        parsed event.  [chunk_index] is the zero-based index reported by
+        the streaming telemetry event.  @since 0.193.12 *)
   }
 
 (** No-op metrics — all callbacks do nothing. *)
@@ -102,6 +117,10 @@ type provider_snapshot =
   ; output_tokens_total : int
   ; latency_ms_sum : int
   ; latency_ms_count : int
+  ; ttfrc_ms_sum : float
+  ; ttfrc_ms_count : int
+  ; inter_chunk_ms_sum : float
+  ; inter_chunk_ms_count : int
   }
 
 (** Convert one provider snapshot to structured JSON.

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -706,6 +706,55 @@ let test_complete_stream_ok () =
   | Exit -> ()
 ;;
 
+let test_complete_stream_metrics () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url =
+      start_sse_server ~sw ~net:env#net (anthropic_sse_response "streamed text")
+    in
+    let config = make_config url in
+    let first_chunks = ref [] in
+    let inter_chunks = ref [] in
+    let metrics : Metrics.t =
+      { Metrics.noop with
+        on_streaming_first_chunk =
+          (fun ~provider ~model_id ~ttfrc_ms ->
+            first_chunks := (provider, model_id, ttfrc_ms) :: !first_chunks)
+      ; on_streaming_chunk =
+          (fun ~provider ~model_id ~chunk_index ~inter_chunk_ms ->
+            inter_chunks
+            := (provider, model_id, chunk_index, inter_chunk_ms) :: !inter_chunks)
+      }
+    in
+    let on_event _evt = () in
+    match
+      Complete.complete_stream ~sw ~net:env#net ~config ~messages ~on_event ~metrics ()
+    with
+    | Ok _ ->
+      check int "first chunk count" 1 (List.length !first_chunks);
+      (match !first_chunks with
+       | [ (provider, model_id, ttfrc_ms) ] ->
+         check string "provider" "anthropic" provider;
+         check string "model_id" "test-model" model_id;
+         check bool "ttfrc non-negative" true (ttfrc_ms >= 0.0)
+       | _ -> fail "expected one first chunk");
+      check bool "inter chunk metrics" true (List.length !inter_chunks > 0);
+      List.iter
+        (fun (provider, model_id, chunk_index, inter_chunk_ms) ->
+           check string "inter provider" "anthropic" provider;
+           check string "inter model_id" "test-model" model_id;
+           check bool "chunk_index non-negative" true (chunk_index >= 0);
+           check bool "inter chunk non-negative" true (inter_chunk_ms >= 0.0))
+        !inter_chunks;
+      Eio.Switch.fail sw Exit
+    | Error _ -> fail "expected Ok"
+  with
+  | Exit -> ()
+;;
+
 (* ── Runner ──────────────────────────────────────────── *)
 
 let () =
@@ -743,6 +792,9 @@ let () =
             test_metrics_global_used_when_no_per_call_metrics
         ] )
     ; "retry", [ test_case "first try ok" `Quick test_retry_first_try ]
-    ; "stream", [ test_case "sse ok" `Quick test_complete_stream_ok ]
+    ; ( "stream"
+      , [ test_case "sse ok" `Quick test_complete_stream_ok
+        ; test_case "streaming metrics" `Quick test_complete_stream_metrics
+        ] )
     ]
 ;;

--- a/test/test_metrics_aggregating.ml
+++ b/test/test_metrics_aggregating.ml
@@ -114,6 +114,31 @@ let test_aggregating_unknown_latency_does_not_add_sample () =
   check int "latency_ms_count" 0 entry.M.latency_ms_count
 ;;
 
+let test_aggregating_on_streaming_latency () =
+  let agg = Agg.create () in
+  let hooks = Agg.to_hooks agg in
+  hooks.on_streaming_first_chunk ~provider:"anthropic" ~model_id:"claude" ~ttfrc_ms:12.5;
+  hooks.on_streaming_chunk
+    ~provider:"anthropic"
+    ~model_id:"claude"
+    ~chunk_index:1
+    ~inter_chunk_ms:4.25;
+  hooks.on_streaming_chunk
+    ~provider:"anthropic"
+    ~model_id:"claude"
+    ~chunk_index:2
+    ~inter_chunk_ms:5.75;
+  let snap = Agg.snapshot agg in
+  check int "one entry" 1 (List.length snap);
+  let entry = List.hd snap in
+  check string "provider" "anthropic" entry.M.provider;
+  check string "model_id" "claude" entry.M.model_id;
+  check (float 0.001) "ttfrc_ms_sum" 12.5 entry.M.ttfrc_ms_sum;
+  check int "ttfrc_ms_count" 1 entry.M.ttfrc_ms_count;
+  check (float 0.001) "inter_chunk_ms_sum" 10.0 entry.M.inter_chunk_ms_sum;
+  check int "inter_chunk_ms_count" 2 entry.M.inter_chunk_ms_count
+;;
+
 let test_aggregating_reset () =
   let agg = Agg.create () in
   let hooks = Agg.to_hooks agg in
@@ -153,6 +178,10 @@ let test_provider_snapshot_to_yojson () =
     ; output_tokens_total = 45
     ; latency_ms_sum = 900
     ; latency_ms_count = 3
+    ; ttfrc_ms_sum = 15.5
+    ; ttfrc_ms_count = 1
+    ; inter_chunk_ms_sum = 8.25
+    ; inter_chunk_ms_count = 2
     }
   in
   let json = M.provider_snapshot_to_yojson snapshot in
@@ -172,7 +201,17 @@ let test_provider_snapshot_to_yojson () =
       (option int)
       "latency_ms_count"
       (Some 3)
-      (List.assoc_opt "latency_ms_count" fields |> Option.map Yojson.Safe.Util.to_int)
+      (List.assoc_opt "latency_ms_count" fields |> Option.map Yojson.Safe.Util.to_int);
+    check
+      (option (float 0.001))
+      "ttfrc_ms_sum"
+      (Some 15.5)
+      (List.assoc_opt "ttfrc_ms_sum" fields |> Option.map Yojson.Safe.Util.to_float);
+    check
+      (option int)
+      "inter_chunk_ms_count"
+      (Some 2)
+      (List.assoc_opt "inter_chunk_ms_count" fields |> Option.map Yojson.Safe.Util.to_int)
   | _ -> fail "expected object"
 ;;
 
@@ -187,6 +226,10 @@ let test_provider_snapshots_to_yojson_is_stable () =
       ; output_tokens_total = 0
       ; latency_ms_sum = 0
       ; latency_ms_count = 0
+      ; ttfrc_ms_sum = 0.0
+      ; ttfrc_ms_count = 0
+      ; inter_chunk_ms_sum = 0.0
+      ; inter_chunk_ms_count = 0
       }
     ; { provider = "a-provider"
       ; model_id = "a-model"
@@ -197,6 +240,10 @@ let test_provider_snapshots_to_yojson_is_stable () =
       ; output_tokens_total = 0
       ; latency_ms_sum = 0
       ; latency_ms_count = 0
+      ; ttfrc_ms_sum = 0.0
+      ; ttfrc_ms_count = 0
+      ; inter_chunk_ms_sum = 0.0
+      ; inter_chunk_ms_count = 0
       }
     ]
   in
@@ -300,6 +347,10 @@ let () =
             "unknown request latency is not sampled"
             `Quick
             test_aggregating_unknown_latency_does_not_add_sample
+        ; test_case
+            "streaming latency callbacks"
+            `Quick
+            test_aggregating_on_streaming_latency
         ] )
     ; ( "lifecycle"
       , [ test_case "reset clears all" `Quick test_aggregating_reset


### PR DESCRIPTION
## Summary
- add streaming first-chunk and inter-chunk latency callbacks to Llm_provider.Metrics
- persist those samples in Aggregating snapshots/JSON by provider and model
- wire HTTP streaming telemetry into metrics while preserving the no-event-bus transport callback contract

## Validation
- git diff --check
- opam exec -- ocamlformat --check lib/llm_provider/metrics.mli lib/llm_provider/metrics.ml lib/llm_provider/complete.mli lib/llm_provider/complete.ml test/test_metrics_aggregating.ml test/test_complete_http.ml
- scripts/dune-local.sh build test/test_metrics_aggregating.exe test/test_complete_http.exe test/test_complete_cascade.exe test/test_telemetry_pipeline.exe test/test_pipeline_metrics.exe
- ./_build/default/test/test_metrics_aggregating.exe
- ./_build/default/test/test_complete_http.exe
- ./_build/default/test/test_telemetry_pipeline.exe
- ./_build/default/test/test_pipeline_metrics.exe
- ./_build/default/test/test_complete_cascade.exe