### PR TITLE
feat(telemetry): RFC-OAS-019 Phase 1 — Streaming_summary at stream finalize

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -1111,6 +1111,81 @@ let complete_stream_http
       in
       let ollama_usage = ref None in
       let ollama_timings = ref None in
+      (* RFC-OAS-019 — stream-lifetime accumulators for the
+         [Streaming_summary] variant that fires once at finalize.
+         Hoisted out of [body_logic] so exception paths (timeout,
+         transport error, SSE wire error) can publish too.
+         [summary_published] makes publish_summary idempotent across
+         all four paths. *)
+      let first_chunk_seen = ref false in
+      let chunk_counter = ref 0 in
+      let last_chunk_t = ref 0.0 in
+      let n_thinking = ref 0 in
+      let n_answer = ref 0 in
+      let n_tool_call_start = ref 0 in
+      let n_tool_call_arg_delta = ref 0 in
+      let n_tool_call_complete = ref 0 in
+      let n_substrate = ref 0 in
+      let n_heartbeat = ref 0 in
+      let n_done = ref 0 in
+      let inter_chunk_samples = ref [] in
+      let terminal_state = ref Telemetry_event.Terminal_done in
+      let summary_published = ref false in
+      let classify_chunk_kind (evt : Types.sse_event) =
+        match evt with
+        | Types.MessageStart _ -> `Skip
+        | Types.ContentBlockStart { content_type = "tool_use"; _ } ->
+          `Tool_call_start
+        | Types.ContentBlockStart _ -> `Substrate
+        | Types.ContentBlockDelta { delta = TextDelta _; _ } -> `Answer
+        | Types.ContentBlockDelta { delta = ThinkingDelta _; _ } -> `Thinking
+        | Types.ContentBlockDelta { delta = InputJsonDelta _; _ } ->
+          `Tool_call_arg_delta
+        | Types.ContentBlockStop _ -> `Tool_call_complete
+        | Types.MessageDelta _ -> `Skip
+        | Types.MessageStop -> `Done
+        | Types.Ping -> `Heartbeat
+        | Types.SSEError _ | Types.SSEParseFailed _ | Types.SSEUnknownEventType _
+          -> `Wire_error
+      in
+      let percentiles () =
+        match !inter_chunk_samples with
+        | [] -> 0.0, 0.0, 0.0
+        | samples ->
+          let sorted = List.sort Float.compare samples in
+          let n = List.length sorted in
+          let nth k = List.nth sorted (max 0 (min (n - 1) k)) in
+          let idx q = int_of_float (Float.of_int n *. q) in
+          nth (idx 0.5), nth (idx 0.95), nth (n - 1)
+      in
+      let publish_summary ~terminal () =
+        if not !summary_published
+        then (
+          summary_published := true;
+          let p50, p95, pmax = percentiles () in
+          emit_telemetry
+            (Telemetry_event.Streaming_summary
+               { provider
+               ; model
+               ; chunk_count = !chunk_counter
+               ; kind_breakdown =
+                   { thinking = !n_thinking
+                   ; answer = !n_answer
+                   ; tool_call_start = !n_tool_call_start
+                   ; tool_call_arg_delta = !n_tool_call_arg_delta
+                   ; tool_call_complete = !n_tool_call_complete
+                   ; substrate = !n_substrate
+                   ; heartbeat = !n_heartbeat
+                   ; done_ = !n_done
+                   }
+               ; ttft_ms = !ttfrc_ref
+               ; total_ms = (Unix.gettimeofday () -. t0) *. 1000.0
+               ; inter_chunk_ms_p50 = p50
+               ; inter_chunk_ms_p95 = p95
+               ; inter_chunk_ms_max = pmax
+               ; terminal
+               }))
+      in
       match
         Http_client.with_post_stream
           ?clock
@@ -1122,9 +1197,9 @@ let complete_stream_http
             let body_logic () =
               let acc = create_stream_acc () in
               let openai_state = ref None in
-              let first_chunk_seen = ref false in
-              let chunk_counter = ref 0 in
-              let last_chunk_t = ref 0.0 in
+              (* RFC-OAS-019: first_chunk_seen / chunk_counter / last_chunk_t
+                 hoisted out of body_logic so publish_summary on
+                 exception paths sees consistent state. *)
               let get_state () =
                 match !openai_state with
                 | Some s -> s
@@ -1137,7 +1212,25 @@ let complete_stream_http
                 List.iter
                   (fun evt ->
                      on_event evt;
-                     accumulate_event acc evt)
+                     accumulate_event acc evt;
+                     (* RFC-OAS-019: classify each delta for the
+                        [Streaming_summary] kind_breakdown that fires at
+                        finalize. Wire errors set terminal_state; per-chunk
+                        emission of [Streaming_chunk_n] is no longer
+                        published — only the lifecycle summary is. *)
+                     match classify_chunk_kind evt with
+                     | `Skip -> ()
+                     | `Thinking -> incr n_thinking
+                     | `Answer -> incr n_answer
+                     | `Tool_call_start -> incr n_tool_call_start
+                     | `Tool_call_arg_delta -> incr n_tool_call_arg_delta
+                     | `Tool_call_complete -> incr n_tool_call_complete
+                     | `Substrate -> incr n_substrate
+                     | `Heartbeat -> incr n_heartbeat
+                     | `Done -> incr n_done
+                     | `Wire_error ->
+                       terminal_state :=
+                         Telemetry_event.Terminal_error "sse_wire_error")
                   events;
                 if events <> []
                 then
@@ -1154,9 +1247,11 @@ let complete_stream_http
                   else (
                     let now = Unix.gettimeofday () in
                     let inter_chunk_ms = (now -. !last_chunk_t) *. 1000.0 in
-                    emit_telemetry
-                      (Telemetry_event.Streaming_chunk_n
-                         { provider; model; chunk_index = !chunk_counter; inter_chunk_ms });
+                    (* RFC-OAS-019: per-chunk [Streaming_chunk_n] publish
+                       removed. Inter-chunk gaps are accumulated for the
+                       percentile reservoir in [Streaming_summary]. *)
+                    inter_chunk_samples :=
+                      inter_chunk_ms :: !inter_chunk_samples;
                     last_chunk_t := now;
                     incr chunk_counter);
                 match tel_opt with
@@ -1217,7 +1312,13 @@ let complete_stream_http
                      in
                      dispatch events)
                    ());
-              finalize_stream_acc acc
+              let result = finalize_stream_acc acc in
+              (* RFC-OAS-019: emit one [Streaming_summary] at stream
+                 finalize on the normal path. terminal_state defaults to
+                 [Terminal_done]; wire errors during dispatch upgrade it
+                 in place. *)
+              publish_summary ~terminal:!terminal_state ();
+              result
             in
             (* Body-level deadline (since 0.181.0). Wraps the entire
                body callback in [Eio.Time.with_timeout_exn] so a single
@@ -1237,6 +1338,12 @@ let complete_stream_http
                  emit_telemetry
                    (Telemetry_event.Timeout
                       { provider; model; timeout_type = No_response });
+                 (* RFC-OAS-019: timeout path also publishes the summary
+                    so operators see the partial stream's distribution. *)
+                 publish_summary
+                   ~terminal:
+                     (Telemetry_event.Terminal_error "body_timeout_s_exceeded")
+                   ();
                  Error
                    (Printf.sprintf
                       "body_timeout_s deadline exceeded after %.1fs (configured via \
@@ -1250,7 +1357,13 @@ let complete_stream_http
               body_logic ())
           ()
       with
-      | Error _ as e -> e
+      | Error _ as e ->
+        (* RFC-OAS-019: transport-level error before body_logic ran (or
+           before its publish). Idempotent via summary_published. *)
+        publish_summary
+          ~terminal:(Telemetry_event.Terminal_error "transport_error")
+          ();
+        e
       | Ok (Ok resp) ->
         let latency_ms = int_of_float ((Unix.gettimeofday () -. t0) *. 1000.0) in
         (* Ollama injection: usage from the done chunk wins over the
@@ -1320,8 +1433,16 @@ let complete_stream_http
          stream_idle_timeout_s docstring contract. The full message
          (including the configured deadline value) is preserved so
          operators can distinguish body vs inter-line timeout. *)
+        publish_summary
+          ~terminal:(Telemetry_event.Terminal_error "body_timeout_s_exceeded")
+          ();
         Error (Http_client.NetworkError { message = msg; kind = Timeout })
       | Ok (Error msg) ->
+        publish_summary
+          ~terminal:
+            (Telemetry_event.Terminal_error
+               (Printf.sprintf "sse_stream_error: %s" msg))
+          ();
         Error
           (Http_client.NetworkError
              { message = Printf.sprintf "SSE stream error: %s" msg; kind = Unknown }))

--- a/lib/llm_provider/telemetry_event.ml
+++ b/lib/llm_provider/telemetry_event.ml
@@ -10,6 +10,32 @@ type timeout_type =
   | Ttft_exceeded
 [@@deriving yojson, show]
 
+(* RFC-OAS-019 §4.1 — typed kind breakdown for [Streaming_summary].
+   Counts of SSE-level deltas observed during a stream lifecycle, used
+   by downstream operators to triage what a stream actually did without
+   having to re-aggregate raw chunks. [done_] uses a trailing underscore
+   because [done] is reserved (for loop syntax). *)
+type streaming_kind_breakdown =
+  { thinking : int
+  ; answer : int
+  ; tool_call_start : int
+  ; tool_call_arg_delta : int
+  ; tool_call_complete : int
+  ; substrate : int
+  ; heartbeat : int
+  ; done_ : int
+  }
+[@@deriving yojson, show]
+
+(* RFC-OAS-019 §4.4 — terminal classification for [Streaming_summary].
+   Nominal variant rather than polymorphic — yojson serialisation is
+   stable across compiler versions and ppx changes. *)
+type streaming_terminal =
+  | Terminal_done
+  | Terminal_cancelled
+  | Terminal_error of string
+[@@deriving yojson, show]
+
 type t =
   | Streaming_first_chunk of
       { provider : string
@@ -22,6 +48,18 @@ type t =
       ; model : string
       ; chunk_index : int
       ; inter_chunk_ms : float
+      }
+  | Streaming_summary of
+      { provider : string
+      ; model : string
+      ; chunk_count : int
+      ; kind_breakdown : streaming_kind_breakdown
+      ; ttft_ms : float option
+      ; total_ms : float
+      ; inter_chunk_ms_p50 : float
+      ; inter_chunk_ms_p95 : float
+      ; inter_chunk_ms_max : float
+      ; terminal : streaming_terminal
       }
   | Thinking_complete of
       { provider : string
@@ -51,6 +89,7 @@ type t =
 let event_type_name = function
   | Streaming_first_chunk _ -> "streaming_first_chunk"
   | Streaming_chunk_n _ -> "streaming_chunk_n"
+  | Streaming_summary _ -> "streaming_summary"
   | Thinking_complete _ -> "thinking_complete"
   | Timeout _ -> "timeout"
   | Prefill_complete _ -> "prefill_complete"

--- a/lib/llm_provider/telemetry_event.mli
+++ b/lib/llm_provider/telemetry_event.mli
@@ -5,6 +5,24 @@ type timeout_type =
   | Ttft_exceeded
 [@@deriving yojson, show]
 
+type streaming_kind_breakdown =
+  { thinking : int
+  ; answer : int
+  ; tool_call_start : int
+  ; tool_call_arg_delta : int
+  ; tool_call_complete : int
+  ; substrate : int
+  ; heartbeat : int
+  ; done_ : int
+  }
+[@@deriving yojson, show]
+
+type streaming_terminal =
+  | Terminal_done
+  | Terminal_cancelled
+  | Terminal_error of string
+[@@deriving yojson, show]
+
 type t =
   | Streaming_first_chunk of
       { provider : string
@@ -17,6 +35,18 @@ type t =
       ; model : string
       ; chunk_index : int
       ; inter_chunk_ms : float
+      }
+  | Streaming_summary of
+      { provider : string
+      ; model : string
+      ; chunk_count : int
+      ; kind_breakdown : streaming_kind_breakdown
+      ; ttft_ms : float option
+      ; total_ms : float
+      ; inter_chunk_ms_p50 : float
+      ; inter_chunk_ms_p95 : float
+      ; inter_chunk_ms_max : float
+      ; terminal : streaming_terminal
       }
   | Thinking_complete of
       { provider : string

--- a/lib/telemetry_sca_registry.ml
+++ b/lib/telemetry_sca_registry.ml
@@ -23,7 +23,17 @@ let registry : entry list =
     }
   ; { signal = "Streaming_chunk_n"
     ; producer_files = [ "lib/llm_provider/complete.ml" ]
-    ; description = "Inter-chunk latency for streaming deltas"
+    ; description =
+        "Inter-chunk latency for streaming deltas (deprecated by RFC-OAS-019 \
+         Phase 1; variant retained one release window for downstream consumer \
+         migration, then removed)"
+    }
+  ; { signal = "Streaming_summary"
+    ; producer_files = [ "lib/llm_provider/complete.ml" ]
+    ; description =
+        "Stream lifecycle summary published once per completion (RFC-OAS-019): \
+         chunk_count, kind_breakdown, TTFT, total_ms, inter_chunk p50/p95/max, \
+         terminal classification"
     }
   ; { signal = "Thinking_complete"
     ; producer_files = [ "lib/llm_provider/streaming.ml" ]

--- a/test/dune
+++ b/test/dune
@@ -193,6 +193,7 @@
   test_streaming_e2e
   test_streaming_keepalive_idle
   test_streaming_openai
+  test_streaming_summary
   test_structured
   test_structured_coverage
   test_structured_deep
@@ -403,6 +404,7 @@
   test_streaming_e2e
   test_streaming_keepalive_idle
   test_streaming_openai
+  test_streaming_summary
   test_structured
   test_structured_coverage
   test_structured_deep

--- a/test/test_streaming_summary.ml
+++ b/test/test_streaming_summary.ml
@@ -1,0 +1,117 @@
+(** RFC-OAS-019 Phase 1 unit tests.
+
+    Minimal Phase 1 coverage: the new [Streaming_summary] variant
+    serialises round-trip, exposes the right [event_type_name], and the
+    [streaming_terminal] / [streaming_kind_breakdown] auxiliary types
+    round-trip too.
+
+    Full integration coverage (100-chunk synthetic completion, cancel
+    mid-stream, provider error) is deferred to a follow-up PR — those
+    paths require an SSE mock that does not exist yet in this test
+    suite and would scope-creep the Phase 1 change. *)
+
+module T = Llm_provider.Telemetry_event
+
+let sample_breakdown : T.streaming_kind_breakdown =
+  { thinking = 5
+  ; answer = 300
+  ; tool_call_start = 1
+  ; tool_call_arg_delta = 4
+  ; tool_call_complete = 1
+  ; substrate = 0
+  ; heartbeat = 8
+  ; done_ = 1
+  }
+;;
+
+let sample_summary : T.t =
+  T.Streaming_summary
+    { provider = "openai_compat"
+    ; model = "glm-5.1"
+    ; chunk_count = 314
+    ; kind_breakdown = sample_breakdown
+    ; ttft_ms = Some 250.0
+    ; total_ms = 12_000.0
+    ; inter_chunk_ms_p50 = 40.0
+    ; inter_chunk_ms_p95 = 80.0
+    ; inter_chunk_ms_max = 150.0
+    ; terminal = T.Terminal_done
+    }
+;;
+
+let test_event_type_name () =
+  Alcotest.(check string)
+    "Streaming_summary event_type_name"
+    "streaming_summary"
+    (T.event_type_name sample_summary)
+;;
+
+let test_yojson_roundtrip_summary () =
+  let json = T.to_yojson sample_summary in
+  match T.of_yojson json with
+  | Ok roundtripped ->
+    Alcotest.(check bool) "structural equality" true (roundtripped = sample_summary)
+  | Error msg -> Alcotest.fail (Printf.sprintf "of_yojson failed: %s" msg)
+;;
+
+let test_terminal_error_roundtrip () =
+  let summary_with_error : T.t =
+    T.Streaming_summary
+      { provider = "openai_compat"
+      ; model = "glm-5.1"
+      ; chunk_count = 12
+      ; kind_breakdown =
+          { thinking = 0
+          ; answer = 10
+          ; tool_call_start = 0
+          ; tool_call_arg_delta = 0
+          ; tool_call_complete = 0
+          ; substrate = 0
+          ; heartbeat = 2
+          ; done_ = 0
+          }
+      ; ttft_ms = Some 110.0
+      ; total_ms = 2_400.0
+      ; inter_chunk_ms_p50 = 25.0
+      ; inter_chunk_ms_p95 = 60.0
+      ; inter_chunk_ms_max = 120.0
+      ; terminal = T.Terminal_error "body_timeout_s_exceeded"
+      }
+  in
+  let json = T.to_yojson summary_with_error in
+  match T.of_yojson json with
+  | Ok roundtripped ->
+    Alcotest.(check bool) "terminal-error round-trip" true (roundtripped = summary_with_error)
+  | Error msg -> Alcotest.fail (Printf.sprintf "of_yojson failed: %s" msg)
+;;
+
+let test_kind_breakdown_roundtrip () =
+  let json = T.streaming_kind_breakdown_to_yojson sample_breakdown in
+  match T.streaming_kind_breakdown_of_yojson json with
+  | Ok roundtripped ->
+    Alcotest.(check bool) "kind_breakdown structural equality" true (roundtripped = sample_breakdown)
+  | Error msg -> Alcotest.fail (Printf.sprintf "kind_breakdown of_yojson failed: %s" msg)
+;;
+
+let test_terminal_cancelled_roundtrip () =
+  let json = T.streaming_terminal_to_yojson T.Terminal_cancelled in
+  match T.streaming_terminal_of_yojson json with
+  | Ok T.Terminal_cancelled -> ()
+  | Ok _ -> Alcotest.fail "expected Terminal_cancelled after roundtrip"
+  | Error msg -> Alcotest.fail (Printf.sprintf "terminal of_yojson failed: %s" msg)
+;;
+
+let () =
+  Alcotest.run
+    "RFC-OAS-019 Streaming_summary"
+    [ ( "event_type_name"
+      , [ Alcotest.test_case "Streaming_summary maps to streaming_summary" `Quick test_event_type_name
+        ] )
+    ; ( "yojson"
+      , [ Alcotest.test_case "Streaming_summary round-trip (Terminal_done)" `Quick test_yojson_roundtrip_summary
+        ; Alcotest.test_case "Streaming_summary round-trip (Terminal_error)" `Quick test_terminal_error_roundtrip
+        ; Alcotest.test_case "streaming_kind_breakdown round-trip" `Quick test_kind_breakdown_roundtrip
+        ; Alcotest.test_case "streaming_terminal Cancelled round-trip" `Quick test_terminal_cancelled_roundtrip
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목표

RFC-OAS-019 §4 구현. `Telemetry_event.Streaming_chunk_n` per-chunk publish 를 단일 `Streaming_summary` 로 교체. 1 completion = O(chunks) telemetry records 를 1 records 로.

본 PR 은 RFC-OAS-019 Phase 1 (variant 추가 + accumulator + publish 제거 + minimal test). Phase 2 (variant 자체 제거) 는 follow-up — consumer migration window 후.

## 변경 파일

| 파일 | 변경 |
|---|---|
| `lib/llm_provider/telemetry_event.{ml,mli}` | `Streaming_summary` variant + `streaming_kind_breakdown` + `streaming_terminal` 신설. `event_type_name` 갱신. |
| `lib/telemetry_sca_registry.ml` | `Streaming_summary` entry 추가, `Streaming_chunk_n` description 에 deprecated 표기. |
| `lib/llm_provider/complete.ml` | refs / classify_chunk_kind / percentiles / publish_summary hoisted out of body_logic. dispatch 안 per-chunk emit 삭제 + kind classification 추가. publish_summary 호출 4 sites (정상 / timeout / transport error / sse error). |
| `test/dune` | `test_streaming_summary` 등록 (2 곳, 기존 names list duplication 유지). |
| `test/test_streaming_summary.ml` | yojson round-trip + event_type_name 5 cases. |

## 설계 결정

- **kind_breakdown 매핑** (sse_event → 8 카테고리):
  - `ContentBlockDelta TextDelta` → `answer`
  - `ContentBlockDelta ThinkingDelta` → `thinking`
  - `ContentBlockDelta InputJsonDelta` → `tool_call_arg_delta`
  - `ContentBlockStart content_type=tool_use` → `tool_call_start`
  - `ContentBlockStart other` → `substrate`
  - `ContentBlockStop` → `tool_call_complete`
  - `Ping` → `heartbeat`
  - `MessageStop` → `done_`
  - `MessageStart` / `MessageDelta` → `Skip` (protocol scaffolding)
  - `SSEError` / `SSEParseFailed` / `SSEUnknownEventType` → `terminal_state := Terminal_error \"sse_wire_error\"`
- **terminal**: nominal variant (`Terminal_done | Terminal_cancelled | Terminal_error of string`) — RFC §4.4 의 polymorphic spec 은 readability 용 표현, implementation 은 yojson serialisation 안정성 위해 nominal.
- **idempotent publish**: `summary_published` ref + 4 호출 site (정상 / timeout / transport error / sse error). RFC §8.1 risk mitigation.
- **percentile reservoir**: 본 PR 은 단순 List + `List.sort` (RFC §4.3 의 256-sample reservoir 는 large-stream 최적화, 본 phase 에선 chunk_count 가 보통 수백 이하라 List 가 비용 동일). 큰 stream 에서 메모리 문제 발생 시 reservoir 로 교체 — follow-up.

## 로컬 검증

- `dune build @lib/all --root .` → green (lib 컴파일 통과).
- `dune build test/test_streaming_summary.exe --root .` → green.
- `dune exec test/test_streaming_summary.exe --root .` → 5/5 PASS (event_type_name, summary round-trip Terminal_done/Terminal_error, kind_breakdown round-trip, terminal Cancelled round-trip).
- SDK Independence: PR diff 에 `masc-mcp` / downstream consumer 식별자 미언급. 발신 변경만.

## 남은 미검증 (follow-up)

- RFC-OAS-019 §6.2 #1 (100-chunk synthetic integration test) — SSE mock fixture 가 본 test suite 에 없음. body_logic 의 dispatch 안 분류 + publish 가 실제 stream 환경에서 정상 동작하는지는 별도 follow-up PR (SSE mock harness 도입).
- RFC §6.2 #4 (Cancellation mid-stream → Terminal_cancelled): `Eio.Cancel.Cancelled` catch 미추가. publish_summary 호출 5번째 site 가 cancel handler — follow-up.
- `Streaming_chunk_n` variant 자체 제거 (RFC §7 Phase 2): consumer migration window (1 release) 후 별도 PR.

## Cross-repo

Receive-side RFC + 후속 작업: **jeong-sik/masc-mcp#15137** (RFC-0074 envelope context + pivot timeline). 본 변경이 main 에 들어가면 그 측 pivot UI 가 typed `Streaming_summary` 를 그룹화해 표시 — operator 가 turn 당 1 record 만 보게 됨.

## CI 주의

`OCaml Format` job 이 advisory 또는 fail 일 수 있음 — 본 PR 의 새 코드 블록이 ocamlformat 위반 가능. fail 발견 시 `style(): apply ocamlformat` follow-up commit 으로 처리.

Refs: RFC-OAS-019 (#1574).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>