### PR TITLE
fix(pipeline): reject invisible tool choice contracts

### DIFF
--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -174,21 +174,6 @@ let requested_tool_label = function
     "tool_choice_contract"
 ;;
 
-let missing_required_tool_use_reason ~contract response =
-  match contract with
-  | Completion_contract.Require_tool_use | Completion_contract.Require_specific_tool _ ->
-    if
-      has_tool_use response
-      || Completion_contract.stop_reason_is_resumable response.stop_reason
-    then None
-    else (
-      match Completion_contract.validate_response ~contract response with
-      | Ok () -> None
-      | Error reason -> Some reason)
-  | Completion_contract.Allow_text_or_tool | Completion_contract.Require_no_tool_use ->
-    None
-;;
-
 let preview_tool_names names =
   let rec take n xs =
     if n <= 0
@@ -207,6 +192,56 @@ let preview_tool_names names =
       if extra > 0 then Printf.sprintf ", ... (+%d more)" extra else ""
     in
     String.concat ", " shown ^ suffix
+;;
+
+let tool_name_visible visible_tool_names name =
+  List.exists (fun visible -> String.equal visible name) visible_tool_names
+;;
+
+let validate_requested_tool_choice_visibility agent (prep : Agent_turn.turn_preparation) =
+  let resolved = requested_completion_contract agent in
+  let visible_tool_names = prep.visible_tool_names in
+  match resolved.effective with
+  | Completion_contract.Require_tool_use when visible_tool_names = [] ->
+    Error
+      (Error.Agent
+         (CompletionContractViolation
+            { contract = resolved.effective
+            ; reason =
+                "tool_choice requires tool use, but no tools are visible in this turn"
+            }))
+  | Completion_contract.Require_specific_tool name
+    when not (tool_name_visible visible_tool_names name) ->
+    Error
+      (Error.Agent
+         (CompletionContractViolation
+            { contract = resolved.effective
+            ; reason =
+                Printf.sprintf
+                  "tool_choice requested tool '%s', but it is not visible in this turn's \
+                   advertised tool set: [%s]"
+                  name
+                  (preview_tool_names visible_tool_names)
+            }))
+  | Completion_contract.Allow_text_or_tool
+  | Completion_contract.Require_no_tool_use
+  | Completion_contract.Require_tool_use
+  | Completion_contract.Require_specific_tool _ -> Ok ()
+;;
+
+let missing_required_tool_use_reason ~contract response =
+  match contract with
+  | Completion_contract.Require_tool_use | Completion_contract.Require_specific_tool _ ->
+    if
+      has_tool_use response
+      || Completion_contract.stop_reason_is_resumable response.stop_reason
+    then None
+    else (
+      match Completion_contract.validate_response ~contract response with
+      | Ok () -> None
+      | Error reason -> Some reason)
+  | Completion_contract.Allow_text_or_tool | Completion_contract.Require_no_tool_use ->
+    None
 ;;
 
 let missing_tool_feedback_text
@@ -1103,7 +1138,11 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
           attempt_route ~prep:prep' ~compact_attempts:(compact_attempts + 1))
       | other -> other
     in
-    let api_result = attempt_route ~prep ~compact_attempts:0 in
+    let api_result =
+      match validate_requested_tool_choice_visibility agent prep with
+      | Ok () -> attempt_route ~prep ~compact_attempts:0
+      | Error _ as err -> err
+    in
     (* Stage 4+5+6: Collect, Execute/Output *)
     (match api_result with
      | Error e ->
@@ -1116,7 +1155,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
        Promote recoverable Text blocks to ToolUse before contract
        validation so the pipeline proceeds normally.
        Ref: Samchon harness Layer 1 (dev.to/samchon, Qwen 2025). *)
-       let valid_tool_names = Tool_set.names agent.tools in
+       let valid_tool_names = prep.Agent_turn.visible_tool_names in
        let response = Tool_use_recovery.recover_response ~valid_tool_names raw_response in
        let* missing_tool_action =
          handle_missing_required_tool_use

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -486,6 +486,86 @@ let test_agent_run_requires_specific_tool_when_tool_choice_is_tool () =
   | Exit -> ()
 ;;
 
+let test_agent_run_rejects_any_tool_choice_when_no_tools_visible () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url =
+      start_multi_mock
+        ~sw
+        ~net:env#net
+        ~port:20121
+        [ openai_text_response "should not be requested" ]
+    in
+    let agent = make_agent ~net:env#net ~tools:[] ~tool_choice:Types.Any url in
+    match Agent.run ~sw agent "use any available tool" with
+    | Ok _ -> fail "expected no-visible-tools contract failure"
+    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason })) ->
+      check bool "contract" true (contract = Completion_contract.Require_tool_use);
+      check
+        bool
+        "reason mentions no visible tools"
+        true
+        (contains_substring ~needle:"no tools are visible" reason);
+      Eio.Switch.fail sw Exit
+    | Error e -> fail (Error.to_string e)
+  with
+  | Exit -> ()
+;;
+
+let test_agent_run_rejects_specific_tool_choice_when_tool_hidden () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url =
+      start_multi_mock
+        ~sw
+        ~net:env#net
+        ~port:20122
+        [ openai_tool_use_response "get_time" {|{}|} ]
+    in
+    let time_tool =
+      Tool.create
+        ~name:"get_time"
+        ~description:"Get current time"
+        ~parameters:[]
+        (fun _input -> Ok { Types.content = "12:00 UTC" })
+    in
+    let guardrails =
+      Guardrails.
+        { tool_filter = DenyList [ "get_time" ]; max_tool_calls_per_turn = Some 5 }
+    in
+    let agent =
+      make_agent
+        ~net:env#net
+        ~tools:[ time_tool ]
+        ~guardrails
+        ~tool_choice:(Types.Tool "get_time")
+        url
+    in
+    match Agent.run ~sw agent "what time is it?" with
+    | Ok _ -> fail "expected hidden specific-tool contract failure"
+    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason })) ->
+      check
+        bool
+        "contract"
+        true
+        (contract = Completion_contract.Require_specific_tool "get_time");
+      check
+        bool
+        "reason mentions visibility"
+        true
+        (contains_substring ~needle:"not visible" reason);
+      Eio.Switch.fail sw Exit
+    | Error e -> fail (Error.to_string e)
+  with
+  | Exit -> ()
+;;
+
 let test_agent_run_rejects_tool_use_when_tool_choice_is_none () =
   Eio_main.run
   @@ fun env ->
@@ -1332,6 +1412,14 @@ let () =
             "tool_choice tool requires specific tool"
             `Quick
             test_agent_run_requires_specific_tool_when_tool_choice_is_tool
+        ; test_case
+            "tool_choice any rejects no visible tools"
+            `Quick
+            test_agent_run_rejects_any_tool_choice_when_no_tools_visible
+        ; test_case
+            "tool_choice tool rejects hidden tool"
+            `Quick
+            test_agent_run_rejects_specific_tool_choice_when_tool_hidden
         ; test_case
             "tool_choice none rejects tool use"
             `Quick


### PR DESCRIPTION
## Summary
- Reject tool_choice contracts before provider dispatch when no tools are visible for Any.
- Reject specific tool_choice values when the requested tool is hidden from the current advertised tool set.
- Constrain lenient tool-use recovery to the current turn visible tool names instead of all registered tools.

## Verification
- git diff --check
- opam exec -- ocamlformat --check lib/pipeline/pipeline.ml test/test_agent_pipeline.ml
- env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_agent_pipeline.exe
- ./_build/default/test/test_agent_pipeline.exe