### PR TITLE
fix(provider): surface OpenAI harness parse errors

### DIFF
--- a/lib/llm_provider/backend_tool_call_harness.ml
+++ b/lib/llm_provider/backend_tool_call_harness.ml
@@ -37,14 +37,6 @@ type response_parse_error =
   ; response_parse_error : string
   }
 
-let parse_error_result =
-  { tool_calls_found = []
-  ; stop_reason_correct = false
-  ; all_tools_declared = false
-  ; dropped_content_blocks = 0
-  }
-;;
-
 (* ── Minimal JSON Schema validator ──────────────────── *)
 
 (** Validate a JSON value against a minimal JSON Schema subset.
@@ -322,7 +314,7 @@ let validate_gemini_response ~declared_tools json =
   validate_response ~declared_tools (Backend_gemini.parse_response json)
 ;;
 
-let validate_openai_response_result ~declared_tools json =
+let validate_openai_response ~declared_tools json =
   let json_str = Yojson.Safe.to_string json in
   let parsed =
     try Backend_openai_parse.parse_openai_response_result json_str with
@@ -332,12 +324,6 @@ let validate_openai_response_result ~declared_tools json =
   | Ok resp -> Ok (validate_response ~declared_tools resp)
   | Error response_parse_error ->
     Error { response_backend = "openai"; response_parse_error }
-;;
-
-let validate_openai_response ~declared_tools json =
-  match validate_openai_response_result ~declared_tools json with
-  | Ok result -> result
-  | Error _ -> parse_error_result
 ;;
 
 (* ── Inline Tests ─────────────────────────────────────── *)
@@ -467,11 +453,13 @@ let%test "openai tool_calls response validates correctly" =
             ] )
       ]
   in
-  let result = validate_openai_response ~declared_tools:[ "read_file" ] json in
-  result.stop_reason_correct
-  && result.all_tools_declared
-  && List.length result.tool_calls_found = 1
-  && (List.hd result.tool_calls_found).name = "read_file"
+  match validate_openai_response ~declared_tools:[ "read_file" ] json with
+  | Error _ -> false
+  | Ok result ->
+    result.stop_reason_correct
+    && result.all_tools_declared
+    && List.length result.tool_calls_found = 1
+    && (List.hd result.tool_calls_found).name = "read_file"
 ;;
 
 let%test "wrong stop_reason for tool calls fails validation" =

--- a/lib/llm_provider/backend_tool_call_harness.mli
+++ b/lib/llm_provider/backend_tool_call_harness.mli
@@ -84,9 +84,4 @@ val validate_gemini_response
 val validate_openai_response
   :  declared_tools:string list
   -> Yojson.Safe.t
-  -> validation_result
-
-val validate_openai_response_result
-  :  declared_tools:string list
-  -> Yojson.Safe.t
   -> (validation_result, response_parse_error) result

--- a/test/test_backend_tool_call_harness.ml
+++ b/test/test_backend_tool_call_harness.ml
@@ -5,9 +5,7 @@ let malformed_openai_response = `Assoc [ "choices", `String "not-a-list" ]
 
 let test_openai_parse_error_is_typed () =
   match
-    H.validate_openai_response_result
-      ~declared_tools:[ "read_file" ]
-      malformed_openai_response
+    H.validate_openai_response ~declared_tools:[ "read_file" ] malformed_openai_response
   with
   | Ok _ -> fail "expected typed parse error"
   | Error err ->
@@ -19,13 +17,29 @@ let test_openai_parse_error_is_typed () =
       (String.length err.response_parse_error > 0)
 ;;
 
-let test_openai_parse_error_fails_closed_for_legacy_wrapper () =
-  let result =
-    H.validate_openai_response ~declared_tools:[ "read_file" ] malformed_openai_response
+let test_openai_text_response_is_ok_empty_validation () =
+  let json =
+    `Assoc
+      [ "id", `String "chatcmpl-text"
+      ; "model", `String "gpt-4o"
+      ; ( "choices"
+        , `List
+            [ `Assoc
+                [ ( "message"
+                  , `Assoc
+                      [ "role", `String "assistant"; "content", `String "plain response" ]
+                  )
+                ; "finish_reason", `String "stop"
+                ]
+            ] )
+      ]
   in
-  check bool "stop reason not accepted" false result.stop_reason_correct;
-  check bool "declared tools not accepted" false result.all_tools_declared;
-  check int "no tool calls fabricated" 0 (List.length result.tool_calls_found)
+  match H.validate_openai_response ~declared_tools:[ "read_file" ] json with
+  | Error err -> fail ("unexpected parse error: " ^ err.response_parse_error)
+  | Ok result ->
+    check bool "stop reason accepted" true result.stop_reason_correct;
+    check bool "declared tools accepted" true result.all_tools_declared;
+    check int "no tool calls found" 0 (List.length result.tool_calls_found)
 ;;
 
 let () =
@@ -37,9 +51,9 @@ let () =
             `Quick
             test_openai_parse_error_is_typed
         ; test_case
-            "legacy wrapper fails closed"
+            "valid text response stays Ok with no tool calls"
             `Quick
-            test_openai_parse_error_fails_closed_for_legacy_wrapper
+            test_openai_text_response_is_ok_empty_validation
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

Closes DD-012 by making the OpenAI backend tool-call harness surface parse failures as a typed `Error` instead of folding them into a valid-looking empty validation record.

- removes the legacy `validate_openai_response_result` / wrapper split
- makes `validate_openai_response` return `(validation_result, response_parse_error) result`
- keeps valid text-only OpenAI responses as `Ok` with zero tool calls, so "no tool call" is distinct from "could not parse/validate provider response"

## Why

The deep-dive identified `empty_result` as fail-open: malformed OpenAI-compatible responses could be reported as if stop reason and declared-tool checks had passed. That hides provider/parser failures from keeper-facing validation and makes tool-call history look healthier than it is.

## Validation

- `scripts/dune-local.sh build test/test_backend_tool_call_harness.exe`
- `./_build/default/test/test_backend_tool_call_harness.exe`
- `ocamlformat --check lib/llm_provider/backend_tool_call_harness.ml lib/llm_provider/backend_tool_call_harness.mli test/test_backend_tool_call_harness.ml`
- `git diff --check`
