### PR TITLE
fix(provider): include context for empty HTTP errors

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -413,7 +413,7 @@ let http_error_diagnostic_body
       provider_name
       config.model_id
       (sanitize_url_for_log config.base_url)
-      config.request_path
+      (sanitize_url_for_log config.request_path)
       (sanitize_url_for_log url)
 ;;
 
@@ -425,7 +425,7 @@ let%test "http_error_diagnostic_body preserves non-empty provider body" =
       ~base_url:"https://generativelanguage.googleapis.com/v1beta/openai"
       ~api_key:"secret"
       ~headers:[]
-      ~request_path:"/v1/chat/completions"
+      ~request_path:"/v1/chat/completions?api_key=secret"
       ()
   in
   http_error_diagnostic_body
@@ -446,7 +446,7 @@ let%test "http_error_diagnostic_body enriches empty provider body" =
       ~base_url:"https://generativelanguage.googleapis.com/v1beta/openai"
       ~api_key:"secret"
       ~headers:[]
-      ~request_path:"/v1/chat/completions"
+      ~request_path:"/v1/chat/completions?api_key=secret"
       ()
   in
   http_error_diagnostic_body
@@ -752,7 +752,7 @@ let complete_http
                   provider_name
                   config.model_id
                   (sanitize_url_for_log config.base_url)
-                  config.request_path
+                  (sanitize_url_for_log config.request_path)
                   api_key_tag
                   body_len
                   body_balanced

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -395,6 +395,73 @@ let%test "sanitize_url_for_log handles missing path" =
   sanitize_url_for_log "https://api.example.com" = "https://api.example.com"
 ;;
 
+let http_error_diagnostic_body
+      ~provider_name
+      ~(config : Provider_config.t)
+      ~url
+      ~code
+      ~(body : string)
+  =
+  let trimmed = String.trim body in
+  if trimmed <> ""
+  then body
+  else
+    Printf.sprintf
+      "empty HTTP %d response from provider=%s model=%s base_url=%s request_path=%s \
+       url=%s"
+      code
+      provider_name
+      config.model_id
+      (sanitize_url_for_log config.base_url)
+      config.request_path
+      (sanitize_url_for_log url)
+;;
+
+let%test "http_error_diagnostic_body preserves non-empty provider body" =
+  let config =
+    Provider_config.make
+      ~kind:Provider_config.Gemini
+      ~model_id:"gemini-3-flash-preview"
+      ~base_url:"https://generativelanguage.googleapis.com/v1beta/openai"
+      ~api_key:"secret"
+      ~headers:[]
+      ~request_path:"/v1/chat/completions"
+      ()
+  in
+  http_error_diagnostic_body
+    ~provider_name:"gemini"
+    ~config
+    ~url:
+      "https://gen.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=secret"
+    ~code:404
+    ~body:"model not found"
+  = "model not found"
+;;
+
+let%test "http_error_diagnostic_body enriches empty provider body" =
+  let config =
+    Provider_config.make
+      ~kind:Provider_config.Gemini
+      ~model_id:"gemini-3-flash-preview"
+      ~base_url:"https://generativelanguage.googleapis.com/v1beta/openai"
+      ~api_key:"secret"
+      ~headers:[]
+      ~request_path:"/v1/chat/completions"
+      ()
+  in
+  http_error_diagnostic_body
+    ~provider_name:"gemini"
+    ~config
+    ~url:
+      "https://gen.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=secret"
+    ~code:404
+    ~body:""
+  = "empty HTTP 404 response from provider=gemini model=gemini-3-flash-preview \
+     base_url=https://generativelanguage.googleapis.com/v1beta/openai \
+     request_path=/v1/chat/completions \
+     url=https://gen.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent"
+;;
+
 let header_name_eq left right =
   String.equal (String.lowercase_ascii left) (String.lowercase_ascii right)
 ;;
@@ -796,6 +863,9 @@ let complete_http
                     with
                     | Unix.Unix_error (Unix.EEXIST, _, _) -> ()
                     | _ -> ())));
+              let body =
+                http_error_diagnostic_body ~provider_name ~config ~url ~code ~body
+              in
               Error (Http_client.HttpError { code; body }))
         in
         let latency_ms = int_of_float ((Unix.gettimeofday () -. t0) *. 1000.0) in

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -189,7 +189,16 @@ let test_complete_http_empty_error_body_has_context () =
     Eio.Switch.run
     @@ fun sw ->
     let url = start_mock_server ~sw ~net:env#net ~status:`Not_found "" in
-    let config = make_config url in
+    let config =
+      Provider_config.make
+        ~kind:Provider_config.Anthropic
+        ~model_id:"test-model"
+        ~base_url:url
+        ~request_path:"/v1/messages?api_key=secret"
+        ~temperature:0.0
+        ~max_tokens:100
+        ()
+    in
     match Complete.complete ~sw ~net:env#net ~config ~messages () with
     | Ok _ -> fail "expected Error"
     | Error (Http_client.HttpError { code; body }) ->

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -182,6 +182,33 @@ let test_complete_http_error () =
   | Exit -> ()
 ;;
 
+let test_complete_http_empty_error_body_has_context () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url = start_mock_server ~sw ~net:env#net ~status:`Not_found "" in
+    let config = make_config url in
+    match Complete.complete ~sw ~net:env#net ~config ~messages () with
+    | Ok _ -> fail "expected Error"
+    | Error (Http_client.HttpError { code; body }) ->
+      check int "status 404" 404 code;
+      check
+        string
+        "diagnostic body"
+        (Printf.sprintf
+           "empty HTTP 404 response from provider=claude model=test-model base_url=%s \
+            request_path=/v1/messages url=%s/v1/messages"
+           url
+           url)
+        body;
+      Eio.Switch.fail sw Exit
+    | Error _ -> fail "expected HttpError"
+  with
+  | Exit -> ()
+;;
+
 (* ── complete: OpenAI compat ─────────────────────────── *)
 
 let test_complete_openai_ok () =
@@ -763,6 +790,10 @@ let () =
     [ ( "complete"
       , [ test_case "anthropic ok" `Quick test_complete_anthropic_ok
         ; test_case "http error" `Quick test_complete_http_error
+        ; test_case
+            "empty http error body has context"
+            `Quick
+            test_complete_http_empty_error_body_has_context
         ; test_case "openai ok" `Quick test_complete_openai_ok
         ; test_case
             "openai mlx-vlm telemetry"


### PR DESCRIPTION
## Summary
- preserve non-empty provider error bodies unchanged
- enrich empty HTTP error bodies with provider, model, base_url, request_path, and sanitized request URL
- add coverage for empty 404 provider responses so downstream MASC logs do not collapse to `Not found:`

## Validation
- `opam exec -- ocamlformat --check lib/llm_provider/complete.ml test/test_complete_http.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_complete_http.exe`
- `./_build/default/test/test_complete_http.exe`