### PR TITLE
fix(telemetry): emit context window usage

### DIFF
--- a/lib/llm_provider/telemetry_event.ml
+++ b/lib/llm_provider/telemetry_event.ml
@@ -84,6 +84,13 @@ type t =
       ; spent_usd : float
       ; limit_usd : float
       }
+  | Context_window_usage of
+      { agent_name : string
+      ; turn : int
+      ; estimated_tokens : int
+      ; limit_tokens : int
+      ; usage_ratio : float
+      }
 [@@deriving yojson, show]
 
 let event_type_name = function
@@ -94,4 +101,5 @@ let event_type_name = function
   | Timeout _ -> "timeout"
   | Prefill_complete _ -> "prefill_complete"
   | Budget_exceeded _ -> "budget_exceeded"
+  | Context_window_usage _ -> "context_window_usage"
 ;;

--- a/lib/llm_provider/telemetry_event.mli
+++ b/lib/llm_provider/telemetry_event.mli
@@ -71,6 +71,13 @@ type t =
       ; spent_usd : float
       ; limit_usd : float
       }
+  | Context_window_usage of
+      { agent_name : string
+      ; turn : int
+      ; estimated_tokens : int
+      ; limit_tokens : int
+      ; usage_ratio : float
+      }
 [@@deriving yojson, show]
 
 (** Human-readable event type label for metrics and logging. *)

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -756,6 +756,26 @@ let proactive_context_window_tokens agent =
   Provider.resolve_max_context_tokens ~fallback:128_000 agent.options.provider
 ;;
 
+let publish_context_window_usage agent ~estimated_tokens ~limit_tokens =
+  match agent.options.event_bus with
+  | None -> ()
+  | Some bus ->
+    let usage_ratio =
+      if limit_tokens <= 0
+      then 0.0
+      else float_of_int estimated_tokens /. float_of_int limit_tokens
+    in
+    Telemetry_bus.publish
+      (Telemetry_bus.of_event_bus bus)
+      (Llm_provider.Telemetry_event.Context_window_usage
+         { agent_name = agent.state.config.name
+         ; turn = agent.state.turn_count
+         ; estimated_tokens
+         ; limit_tokens
+         ; usage_ratio
+         })
+;;
+
 (** Apply proactive compaction when context usage exceeds the configured
     watermark ratio, BEFORE hitting the provider limit.  Uses
     [Budget_strategy.phase_of_usage_ratio] to pick the lightest phase
@@ -985,6 +1005,12 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
   stage_input ?raw_trace_run agent;
   (* Stage 2: Parse *)
   let prep, original_config, turn_params = stage_parse ?raw_trace_run agent in
+  let context_window = proactive_context_window_tokens agent in
+  let est_tokens = total_prompt_tokens_for_agent agent agent.state.messages in
+  publish_context_window_usage
+    agent
+    ~estimated_tokens:est_tokens
+    ~limit_tokens:context_window;
   (* Stage 2.3: Proactive watermark compaction — compact before overflow.
      Runs before async input validation so that validators operate on the
      already-compacted message set.  Re-prepares the turn via

--- a/lib/telemetry_sca_registry.ml
+++ b/lib/telemetry_sca_registry.ml
@@ -51,6 +51,11 @@ let registry : entry list =
     ; producer_files = [ "lib/agent/agent.ml" ]
     ; description = "Cost budget exceeded during agent run loop"
     }
+  ; { signal = "Context_window_usage"
+    ; producer_files = [ "lib/pipeline/pipeline.ml" ]
+    ; description =
+        "Per-turn context-window usage before proactive compaction or provider dispatch"
+    }
   ]
 ;;
 

--- a/test/telemetry_sca/test_telemetry_sca.ml
+++ b/test/telemetry_sca/test_telemetry_sca.ml
@@ -59,10 +59,12 @@ let test_registry_covers_all_variants () =
   let variants =
     [ "Streaming_first_chunk"
     ; "Streaming_chunk_n"
+    ; "Streaming_summary"
     ; "Thinking_complete"
     ; "Timeout"
     ; "Prefill_complete"
     ; "Budget_exceeded"
+    ; "Context_window_usage"
     ]
   in
   List.iter
@@ -87,11 +89,20 @@ let test_every_signal_has_producer () =
 
 let test_no_orphan_producer_variants () =
   (* Grep for Telemetry_event.(VariantName and ensure each is in the registry. *)
+  let nested_constructors =
+    [ "No_response"
+    ; "Ttft_exceeded"
+    ; "Terminal_done"
+    ; "Terminal_cancelled"
+    ; "Terminal_error"
+    ]
+  in
   let cmd =
     Printf.sprintf
       "grep -ho 'Telemetry_event\\.[A-Z][A-Za-z_]*' %s/lib/llm_provider/complete.ml \
-       %s/lib/llm_provider/streaming.ml %s/lib/agent/agent.ml 2>/dev/null | sed \
-       's/Telemetry_event\\.//' | sort -u"
+       %s/lib/llm_provider/streaming.ml %s/lib/agent/agent.ml \
+       %s/lib/pipeline/pipeline.ml 2>/dev/null | sed 's/Telemetry_event\\.//' | sort -u"
+      repo_root
       repo_root
       repo_root
       repo_root
@@ -108,11 +119,13 @@ let test_no_orphan_producer_variants () =
   let registry_names = all_signals () in
   List.iter
     (fun name ->
-       check
-         bool
-         (Printf.sprintf "producer variant %s is registered" name)
-         true
-         (List.mem name registry_names))
+       if not (List.mem name nested_constructors)
+       then
+         check
+           bool
+           (Printf.sprintf "producer variant %s is registered" name)
+           true
+           (List.mem name registry_names))
     !found
 ;;
 

--- a/test/test_telemetry_event.ml
+++ b/test/test_telemetry_event.ml
@@ -54,6 +54,45 @@ let test_streaming_chunk_n () =
   | _ -> fail "variant mismatch"
 ;;
 
+let test_streaming_summary () =
+  let ev =
+    Telemetry_event.Streaming_summary
+      { provider = "openai"
+      ; model = "gpt-4"
+      ; chunk_count = 3
+      ; kind_breakdown =
+          { thinking = 1
+          ; answer = 1
+          ; tool_call_start = 0
+          ; tool_call_arg_delta = 0
+          ; tool_call_complete = 0
+          ; substrate = 0
+          ; heartbeat = 0
+          ; done_ = 1
+          }
+      ; ttft_ms = Some 12.5
+      ; total_ms = 120.0
+      ; inter_chunk_ms_p50 = 20.0
+      ; inter_chunk_ms_p95 = 40.0
+      ; inter_chunk_ms_max = 60.0
+      ; terminal = Telemetry_event.Terminal_done
+      }
+  in
+  match roundtrip ev with
+  | Telemetry_event.Streaming_summary r ->
+    check string "provider" "openai" r.provider;
+    check string "model" "gpt-4" r.model;
+    check int "chunk_count" 3 r.chunk_count;
+    check int "thinking chunks" 1 r.kind_breakdown.thinking;
+    check_float "ttft_ms" 12.5 (Option.get r.ttft_ms);
+    check_float "total_ms" 120.0 r.total_ms;
+    check_float "p95" 40.0 r.inter_chunk_ms_p95;
+    (match r.terminal with
+     | Telemetry_event.Terminal_done -> ()
+     | _ -> fail "terminal mismatch")
+  | _ -> fail "variant mismatch"
+;;
+
 let test_thinking_complete () =
   let ev =
     Telemetry_event.Thinking_complete
@@ -127,6 +166,26 @@ let test_budget_exceeded () =
   | _ -> fail "variant mismatch"
 ;;
 
+let test_context_window_usage () =
+  let ev =
+    Telemetry_event.Context_window_usage
+      { agent_name = "alpha"
+      ; turn = 2
+      ; estimated_tokens = 64000
+      ; limit_tokens = 128000
+      ; usage_ratio = 0.5
+      }
+  in
+  match roundtrip ev with
+  | Telemetry_event.Context_window_usage r ->
+    check string "agent_name" "alpha" r.agent_name;
+    check int "turn" 2 r.turn;
+    check int "estimated_tokens" 64000 r.estimated_tokens;
+    check int "limit_tokens" 128000 r.limit_tokens;
+    check_float "usage_ratio" 0.5 r.usage_ratio
+  | _ -> fail "variant mismatch"
+;;
+
 (* ── event_type_name ──────────────────────────────────────────────── *)
 
 let test_event_type_name () =
@@ -137,6 +196,28 @@ let test_event_type_name () =
     ; ( Streaming_chunk_n
           { provider = ""; model = ""; chunk_index = 0; inter_chunk_ms = 0.0 }
       , "streaming_chunk_n" )
+    ; ( Streaming_summary
+          { provider = ""
+          ; model = ""
+          ; chunk_count = 0
+          ; kind_breakdown =
+              { thinking = 0
+              ; answer = 0
+              ; tool_call_start = 0
+              ; tool_call_arg_delta = 0
+              ; tool_call_complete = 0
+              ; substrate = 0
+              ; heartbeat = 0
+              ; done_ = 0
+              }
+          ; ttft_ms = None
+          ; total_ms = 0.0
+          ; inter_chunk_ms_p50 = 0.0
+          ; inter_chunk_ms_p95 = 0.0
+          ; inter_chunk_ms_max = 0.0
+          ; terminal = Terminal_done
+          }
+      , "streaming_summary" )
     ; ( Thinking_complete { provider = ""; model = ""; thinking_duration_ms = 0.0 }
       , "thinking_complete" )
     ; Timeout { provider = ""; model = ""; timeout_type = No_response }, "timeout"
@@ -150,6 +231,14 @@ let test_event_type_name () =
       , "prefill_complete" )
     ; ( Budget_exceeded { agent_name = ""; run_id = ""; spent_usd = 0.0; limit_usd = 0.0 }
       , "budget_exceeded" )
+    ; ( Context_window_usage
+          { agent_name = ""
+          ; turn = 0
+          ; estimated_tokens = 0
+          ; limit_tokens = 0
+          ; usage_ratio = 0.0
+          }
+      , "context_window_usage" )
     ]
   in
   List.iter
@@ -200,11 +289,13 @@ let () =
     [ ( "serialization"
       , [ test_case "Streaming_first_chunk roundtrip" `Quick test_streaming_first_chunk
         ; test_case "Streaming_chunk_n roundtrip" `Quick test_streaming_chunk_n
+        ; test_case "Streaming_summary roundtrip" `Quick test_streaming_summary
         ; test_case "Thinking_complete roundtrip" `Quick test_thinking_complete
         ; test_case "Timeout No_response roundtrip" `Quick test_timeout_no_response
         ; test_case "Timeout Ttft_exceeded roundtrip" `Quick test_timeout_ttft_exceeded
         ; test_case "Prefill_complete roundtrip" `Quick test_prefill_complete
         ; test_case "Budget_exceeded roundtrip" `Quick test_budget_exceeded
+        ; test_case "Context_window_usage roundtrip" `Quick test_context_window_usage
         ] )
     ; "event_type_name", [ test_case "all variants" `Quick test_event_type_name ]
     ; ( "telemetry_bus"

--- a/test/test_telemetry_pipeline.ml
+++ b/test/test_telemetry_pipeline.ml
@@ -21,6 +21,15 @@ let contains_substring ~sub text =
   loop 0
 ;;
 
+let find_context_window_usage events =
+  List.find_map
+    (function
+      | Llm_provider.Telemetry_event.Context_window_usage r ->
+        Some (r.agent_name, r.turn, r.estimated_tokens, r.limit_tokens, r.usage_ratio)
+      | _ -> None)
+    events
+;;
+
 let make_mock_transport () : Llm_provider.Llm_transport.t =
   let response : Types.api_response =
     { id = "telemetry-pipeline-mock"
@@ -172,12 +181,53 @@ let test_run_stream_emits_telemetry_via_pipeline () =
    | Ok _ -> ()
    | Error err -> Alcotest.fail ("expected stream success: " ^ Error.to_string err));
   let events = Telemetry_bus.drain sub in
-  Alcotest.(check int) "telemetry events received" 1 (List.length events);
-  (match events with
-   | [ Llm_provider.Telemetry_event.Streaming_first_chunk { provider; model; _ } ] ->
+  Alcotest.(check int) "telemetry events received" 2 (List.length events);
+  (match
+     List.find_opt
+       (function
+         | Llm_provider.Telemetry_event.Streaming_first_chunk _ -> true
+         | _ -> false)
+       events
+   with
+   | Some (Llm_provider.Telemetry_event.Streaming_first_chunk { provider; model; _ }) ->
      Alcotest.(check string) "provider" "mock-provider" provider;
      Alcotest.(check string) "model" "mock-model" model
    | _ -> Alcotest.fail "expected Streaming_first_chunk event");
+  (match find_context_window_usage events with
+   | Some (agent_name, turn, _estimated_tokens, limit_tokens, usage_ratio) ->
+     Alcotest.(check string) "usage agent" "telemetry-pipeline-test" agent_name;
+     Alcotest.(check int) "usage turn" 0 turn;
+     Alcotest.(check bool) "usage limit positive" true (limit_tokens > 0);
+     Alcotest.(check bool) "usage ratio non-negative" true (usage_ratio >= 0.0)
+   | None -> Alcotest.fail "expected Context_window_usage event");
+  Telemetry_bus.unsubscribe telemetry_bus sub
+;;
+
+let test_run_emits_context_window_usage () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let transport = make_sequence_transport [ text_response "ok" ] in
+  let agent, event_bus = make_agent ~net ~transport () in
+  let telemetry_bus = Telemetry_bus.of_event_bus event_bus in
+  let sub = Telemetry_bus.subscribe telemetry_bus in
+  (match Agent.run ~sw agent "capture context usage" with
+   | Ok _ -> ()
+   | Error err -> Alcotest.fail ("expected run success: " ^ Error.to_string err));
+  let events = Telemetry_bus.drain sub in
+  (match find_context_window_usage events with
+   | Some (agent_name, turn, estimated_tokens, limit_tokens, usage_ratio) ->
+     Alcotest.(check string) "usage agent" "telemetry-pipeline-test" agent_name;
+     Alcotest.(check int) "usage turn" 0 turn;
+     Alcotest.(check bool) "usage estimated positive" true (estimated_tokens > 0);
+     Alcotest.(check bool) "usage limit positive" true (limit_tokens > 0);
+     Alcotest.(check (float 0.001))
+       "usage ratio"
+       (float_of_int estimated_tokens /. float_of_int limit_tokens)
+       usage_ratio
+   | None -> Alcotest.fail "expected Context_window_usage event");
   Telemetry_bus.unsubscribe telemetry_bus sub
 ;;
 
@@ -469,6 +519,10 @@ let () =
             "run_stream skips telemetry without event_bus"
             `Quick
             test_run_stream_without_event_bus_skips_telemetry
+        ; Alcotest.test_case
+            "run emits context-window usage"
+            `Quick
+            test_run_emits_context_window_usage
         ; Alcotest.test_case
             "checkpoint after assistant collect"
             `Quick


### PR DESCRIPTION
## Summary

- add `Context_window_usage` typed telemetry for per-turn context-window usage before compaction/provider dispatch
- register the new signal in telemetry SCA and close the existing `Streaming_summary` coverage gap
- cover serialization, SCA producer audit, and sync/stream pipeline emission paths

## Verification

- `git diff --check`
- `scripts/dune-local.sh build @runtest-test_telemetry_event @runtest-test_telemetry_pipeline @runtest-test_telemetry_sca`
