### PR TITLE
fix(provider): persist cascade health snapshots

### DIFF
--- a/lib/llm_provider/complete_cascade.ml
+++ b/lib/llm_provider/complete_cascade.ml
@@ -273,6 +273,99 @@ let provider_health_snapshot_of_yojson json =
          (Yojson.Safe.to_string other))
 ;;
 
+let snapshot_file_error ~op ~path = function
+  | Sys_error detail -> Error (Printf.sprintf "%s %s: %s" op path detail)
+  | Unix.Unix_error (error, syscall, arg) ->
+    Error
+      (Printf.sprintf "%s %s: %s(%s): %s" op path syscall arg (Unix.error_message error))
+  | Yojson.Json_error detail ->
+    Error (Printf.sprintf "%s %s: JSON error: %s" op path detail)
+  | exn -> Error (Printf.sprintf "%s %s: %s" op path (Printexc.to_string exn))
+;;
+
+let rec ensure_snapshot_dir path =
+  if path = "" || path = "." || Sys.file_exists path
+  then Ok ()
+  else (
+    match ensure_snapshot_dir (Filename.dirname path) with
+    | Error _ as err -> err
+    | Ok () ->
+      (try
+         Sys.mkdir path 0o755;
+         Ok ()
+       with
+       | Sys_error _ when Sys.file_exists path -> Ok ()
+       | exn -> snapshot_file_error ~op:"mkdir" ~path exn))
+;;
+
+let fsync_snapshot_best_effort fd =
+  try Unix.fsync fd with
+  | Unix.Unix_error ((EINVAL | EOPNOTSUPP), _, _) -> ()
+;;
+
+let fsync_snapshot_dir_best_effort dir =
+  try
+    let fd = Unix.openfile dir [ Unix.O_RDONLY ] 0 in
+    Fun.protect
+      ~finally:(fun () ->
+        try Unix.close fd with
+        | Unix.Unix_error _ -> ())
+      (fun () -> fsync_snapshot_best_effort fd)
+  with
+  | Unix.Unix_error _ -> ()
+;;
+
+let write_snapshot_file_atomic path content =
+  let dir = Filename.dirname path in
+  match ensure_snapshot_dir dir with
+  | Error _ as err -> err
+  | Ok () ->
+    (try
+       let base = Filename.basename path in
+       let tmp_path = Filename.temp_file ~temp_dir:dir (base ^ ".") ".tmp" in
+       let clean_tmp () =
+         try Sys.remove tmp_path with
+         | Sys_error _ | Unix.Unix_error _ -> ()
+       in
+       try
+         Out_channel.with_open_bin tmp_path (fun oc ->
+           Out_channel.output_string oc content;
+           Out_channel.flush oc;
+           fsync_snapshot_best_effort (Unix.descr_of_out_channel oc));
+         Sys.rename tmp_path path;
+         fsync_snapshot_dir_best_effort dir;
+         Ok ()
+       with
+       | exn ->
+         clean_tmp ();
+         raise exn
+     with
+     | exn -> snapshot_file_error ~op:"write" ~path exn)
+;;
+
+let save_health_snapshot_json health ~path =
+  snapshot_health health
+  |> provider_health_snapshot_to_yojson
+  |> Yojson.Safe.pretty_to_string
+  |> write_snapshot_file_atomic path
+;;
+
+let load_health_snapshot_json ?clock ~path () =
+  let parse raw =
+    match Yojson.Safe.from_string raw |> provider_health_snapshot_of_yojson with
+    | Ok snapshot -> Ok (restore_health ?clock snapshot)
+    | Error err -> Error (Printf.sprintf "parse %s: %s" path err)
+  in
+  try In_channel.with_open_bin path (fun ic -> In_channel.input_all ic |> parse) with
+  | exn -> snapshot_file_error ~op:"read" ~path exn
+;;
+
+let load_or_create_health_snapshot_json ?clock ~path () =
+  if Sys.file_exists path
+  then load_health_snapshot_json ?clock ~path ()
+  else Ok (create_health ?clock ())
+;;
+
 let circuit_open_and_remaining health ~ccfg entry =
   if entry.consecutive_failures < ccfg.circuit_threshold
   then false, None

--- a/lib/llm_provider/complete_cascade.mli
+++ b/lib/llm_provider/complete_cascade.mli
@@ -81,6 +81,29 @@ val provider_health_snapshot_of_yojson
   :  Yojson.Safe.t
   -> (provider_health_snapshot, string) result
 
+(** Atomically persist the current provider health snapshot as pretty JSON.
+    Parent directories are created before writing with a writer-unique
+    temporary file and rename. *)
+val save_health_snapshot_json : provider_health -> path:string -> (unit, string) result
+
+(** Load a provider health tracker from a JSON snapshot file.
+    The file is parsed through {!provider_health_snapshot_of_yojson}; malformed
+    snapshots are returned as [Error] instead of silently resetting health. *)
+val load_health_snapshot_json
+  :  ?clock:_ Eio.Time.clock
+  -> path:string
+  -> unit
+  -> (provider_health, string) result
+
+(** Load a provider health tracker when [path] exists; otherwise create an
+    empty tracker.  Malformed existing snapshots are still [Error] so startup
+    does not silently erase a corrupt circuit-breaker state. *)
+val load_or_create_health_snapshot_json
+  :  ?clock:_ Eio.Time.clock
+  -> path:string
+  -> unit
+  -> (provider_health, string) result
+
 (** Provider health snapshot derived from the circuit-breaker state. *)
 type provider_health_info =
   { provider_key : string

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -20,6 +20,15 @@ let contains text needle =
     loop 0)
 ;;
 
+let with_temp_file f =
+  let path = Filename.temp_file "oas-provider-health-" ".json" in
+  Fun.protect
+    ~finally:(fun () ->
+      try Sys.remove path with
+      | Sys_error _ | Unix.Unix_error _ -> ())
+    (fun () -> f path)
+;;
+
 let dummy_response =
   Types.
     { id = "test-id"
@@ -240,6 +249,65 @@ let test_provider_health_snapshot_json_roundtrip () =
       "a@https://example.invalid"
       (List.hd parsed).snapshot_provider_key;
     check int "first failures" 2 (List.hd parsed).snapshot_consecutive_failures
+;;
+
+let test_provider_health_snapshot_file_roundtrip_preserves_open_circuit () =
+  with_temp_file (fun path ->
+    let health = Complete_cascade.create_health () in
+    let key = "file-snapshot-model@https://example.invalid" in
+    Complete_cascade.record_failure health key;
+    Complete_cascade.record_failure health key;
+    Complete_cascade.record_failure health key;
+    (match Complete_cascade.save_health_snapshot_json health ~path with
+     | Ok () -> ()
+     | Error err -> fail ("unexpected save error: " ^ err));
+    match Complete_cascade.load_health_snapshot_json ~path () with
+    | Error err -> fail ("unexpected load error: " ^ err)
+    | Ok restored ->
+      let info =
+        Complete_cascade.provider_health_info
+          restored
+          ~cascade_config:Complete_cascade.default_cascade_config
+          ~provider_key:key
+      in
+      check int "loaded failures" 3 info.consecutive_failures;
+      check bool "loaded circuit open" true info.circuit_open;
+      (match info.cooldown_remaining_s with
+       | Some remaining -> check bool "loaded cooldown positive" true (remaining > 0.0)
+       | None -> fail "expected loaded cooldown"))
+;;
+
+let test_provider_health_snapshot_file_rejects_malformed_json () =
+  with_temp_file (fun path ->
+    Out_channel.with_open_bin path (fun oc -> Out_channel.output_string oc "{broken");
+    match Complete_cascade.load_health_snapshot_json ~path () with
+    | Ok _ -> fail "expected malformed JSON rejection"
+    | Error err -> check bool "error mentions JSON" true (contains err "JSON error"))
+;;
+
+let test_provider_health_load_or_create_missing_file_starts_empty () =
+  with_temp_file (fun path ->
+    Sys.remove path;
+    match Complete_cascade.load_or_create_health_snapshot_json ~path () with
+    | Error err -> fail ("unexpected load-or-create error: " ^ err)
+    | Ok health ->
+      let key = "missing-file-model@https://example.invalid" in
+      let info =
+        Complete_cascade.provider_health_info
+          health
+          ~cascade_config:Complete_cascade.default_cascade_config
+          ~provider_key:key
+      in
+      check int "missing file starts without failures" 0 info.consecutive_failures;
+      check bool "missing file starts closed" false info.circuit_open)
+;;
+
+let test_provider_health_load_or_create_rejects_malformed_existing_file () =
+  with_temp_file (fun path ->
+    Out_channel.with_open_bin path (fun oc -> Out_channel.output_string oc "{broken");
+    match Complete_cascade.load_or_create_health_snapshot_json ~path () with
+    | Ok _ -> fail "expected malformed existing snapshot rejection"
+    | Error err -> check bool "error mentions JSON" true (contains err "JSON error"))
 ;;
 
 let test_provider_health_snapshot_json_rejects_negative_failures () =
@@ -977,6 +1045,18 @@ let suite =
   ; ( "provider_health_snapshot_json_roundtrip"
     , `Quick
     , test_provider_health_snapshot_json_roundtrip )
+  ; ( "provider_health_snapshot_file_roundtrip"
+    , `Quick
+    , test_provider_health_snapshot_file_roundtrip_preserves_open_circuit )
+  ; ( "provider_health_snapshot_file_rejects_malformed_json"
+    , `Quick
+    , test_provider_health_snapshot_file_rejects_malformed_json )
+  ; ( "provider_health_load_or_create_missing_file"
+    , `Quick
+    , test_provider_health_load_or_create_missing_file_starts_empty )
+  ; ( "provider_health_load_or_create_rejects_malformed"
+    , `Quick
+    , test_provider_health_load_or_create_rejects_malformed_existing_file )
   ; ( "provider_health_snapshot_json_rejects_negative"
     , `Quick
     , test_provider_health_snapshot_json_rejects_negative_failures )


### PR DESCRIPTION
## Summary
- add file-backed save/load helpers for cascade provider health snapshots
- add a load-or-create bootstrap helper so new snapshot paths start empty while malformed existing snapshots still fail closed
- cover file roundtrip persistence, missing-file bootstrap, and malformed JSON rejection in complete_cascade tests

## Deep Dive
- DD-017: provider health state should survive process restart via a durable snapshot path, not only in-memory snapshot/restore helpers.
- The new load-or-create path prevents first boot from needing caller-side special casing without silently erasing corrupt persisted circuit-breaker state.

## Validation
- ocamlformat --check lib/llm_provider/complete_cascade.mli lib/llm_provider/complete_cascade.ml test/test_complete_cascade.ml
- git diff --check
- env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_complete_cascade.exe
- _build/default/test/test_complete_cascade.exe
