### PR TITLE
fix(provider): resolve runtime binding by catalog config

### DIFF
--- a/lib/provider_runtime_binding.ml
+++ b/lib/provider_runtime_binding.ml
@@ -220,6 +220,114 @@ let find label =
     | None -> Option.map binding_of_registry_entry (PR.find registry normalized))
 ;;
 
+let normalize_endpoint_url value =
+  let trimmed = String.trim value in
+  if trimmed = ""
+  then trimmed
+  else (
+    let rec strip_trailing_slash s =
+      let len = String.length s in
+      if len > 1 && s.[len - 1] = '/'
+      then strip_trailing_slash (String.sub s 0 (len - 1))
+      else s
+    in
+    strip_trailing_slash trimmed)
+;;
+
+let config_endpoint_matches ~kind ~base_url ~request_path (cfg : PConfig.t) =
+  kind = cfg.kind
+  && String.equal (normalize_endpoint_url base_url) (normalize_endpoint_url cfg.base_url)
+  && String.equal (String.trim request_path) (String.trim cfg.request_path)
+;;
+
+let catalog_entry_matches_config cfg (entry : PC.entry) =
+  config_endpoint_matches
+    ~kind:entry.kind
+    ~base_url:entry.base_url
+    ~request_path:entry.request_path
+    cfg
+;;
+
+let registry_entry_matches_config cfg (entry : PR.entry) =
+  config_endpoint_matches
+    ~kind:entry.defaults.kind
+    ~base_url:entry.defaults.base_url
+    ~request_path:entry.defaults.request_path
+    cfg
+;;
+
+let catalog_binding_for_provider_config registry cfg =
+  match PC.global () with
+  | None -> None
+  | Some catalog ->
+    catalog
+    |> List.find_opt (catalog_entry_matches_config cfg)
+    |> Option.map (binding_of_catalog_entry registry)
+;;
+
+let registry_binding_for_provider_config registry cfg =
+  registry
+  |> PR.all
+  |> List.find_opt (registry_entry_matches_config cfg)
+  |> Option.map binding_of_registry_entry
+;;
+
+let binding_for_provider_config (cfg : PConfig.t) =
+  let registry = PR.default () in
+  match catalog_binding_for_provider_config registry cfg with
+  | Some binding -> Some binding
+  | None ->
+    (match registry_binding_for_provider_config registry cfg with
+     | Some binding -> Some binding
+     | None -> PR.provider_name_of_config cfg |> find)
+;;
+
+let base_capabilities_of_kind = function
+  | PConfig.Ollama -> Llm_provider.Capabilities.ollama_capabilities
+  | PConfig.Anthropic -> Llm_provider.Capabilities.anthropic_capabilities
+  | PConfig.Kimi -> Llm_provider.Capabilities.kimi_capabilities
+  | PConfig.OpenAI_compat -> Llm_provider.Capabilities.openai_chat_capabilities
+  | PConfig.Gemini -> Llm_provider.Capabilities.gemini_capabilities
+  | PConfig.Glm -> Llm_provider.Capabilities.glm_capabilities
+  | PConfig.DashScope -> Llm_provider.Capabilities.dashscope_capabilities
+  | PConfig.Claude_code -> Llm_provider.Capabilities.claude_code_capabilities
+  | PConfig.Gemini_cli -> Llm_provider.Capabilities.gemini_cli_capabilities
+  | PConfig.Kimi_cli -> Llm_provider.Capabilities.kimi_cli_capabilities
+  | PConfig.Codex_cli -> Llm_provider.Capabilities.codex_cli_capabilities
+;;
+
+let registry_capabilities_for_provider_config (cfg : PConfig.t) =
+  let registry = PR.default () in
+  let catalog_entry =
+    Option.bind (PC.global ()) (List.find_opt (catalog_entry_matches_config cfg))
+  in
+  match catalog_entry with
+  | Some entry -> entry.PC.capabilities
+  | None ->
+    (match PR.all registry |> List.find_opt (registry_entry_matches_config cfg) with
+     | Some entry -> entry.PR.capabilities
+     | None ->
+       let provider_name = PR.provider_name_of_config cfg in
+       (match PR.find registry provider_name with
+        | Some entry -> entry.PR.capabilities
+        | None -> base_capabilities_of_kind cfg.kind))
+;;
+
+let capabilities_for_provider_config (cfg : PConfig.t) =
+  let caps = registry_capabilities_for_provider_config cfg in
+  let caps =
+    if PConfig.is_subprocess_cli cfg.kind
+    then caps
+    else (
+      match Llm_provider.Capabilities.for_model_id cfg.model_id with
+      | Some model_caps -> model_caps
+      | None -> caps)
+  in
+  match cfg.supports_tool_choice_override with
+  | Some supports_tool_choice -> { caps with supports_tool_choice }
+  | None -> caps
+;;
+
 let resolve_model binding ~requested_model =
   match Option.bind requested_model trim_non_empty with
   | Some model -> model

--- a/lib/provider_runtime_binding.mli
+++ b/lib/provider_runtime_binding.mli
@@ -53,6 +53,23 @@ val all : unit -> t list
     case-insensitive and whitespace-trimmed. *)
 val find : string -> t option
 
+(** Resolve the runtime binding that owns a concrete provider config.
+
+    Catalog endpoint matches are resolved before registry provider-name
+    fallbacks, so catalog-provided OpenAI-compatible providers remain
+    OAS-owned even when the endpoint is local. *)
+val binding_for_provider_config : Llm_provider.Provider_config.t -> t option
+
+(** Resolve OAS-owned provider capabilities for a concrete provider config.
+
+    Catalog/registry provider capabilities are preferred. Non-CLI providers
+    then honor model-specific capability overrides when available. CLI
+    providers keep the transport-level capability record because their
+    [model_id] is a runtime selection hint rather than an API model id. *)
+val capabilities_for_provider_config
+  :  Llm_provider.Provider_config.t
+  -> Llm_provider.Capabilities.capabilities
+
 (** Resolve the model that should be used for a binding. [requested_model]
     wins when non-empty, followed by the binding catalog default, then OAS
     provider defaults. *)

--- a/test/test_provider_runtime_binding.ml
+++ b/test/test_provider_runtime_binding.ml
@@ -81,6 +81,55 @@ let test_catalog_to_provider_config () =
       (cfg.kind = Llm_provider.Provider_config.OpenAI_compat))
 ;;
 
+let test_binding_for_provider_config_uses_catalog_endpoint () =
+  with_provider_catalog catalog_json (fun () ->
+    let cfg =
+      Llm_provider.Provider_config.make
+        ~kind:Llm_provider.Provider_config.OpenAI_compat
+        ~model_id:"local-model"
+        ~base_url:"http://127.0.0.1:8123"
+        ~request_path:"/v1/chat/completions"
+        ()
+    in
+    match Provider_runtime_binding.binding_for_provider_config cfg with
+    | Some binding ->
+      Alcotest.(check string) "catalog binding id" "subscriber-local" binding.id
+    | None -> Alcotest.fail "expected catalog binding for provider config")
+;;
+
+let test_capabilities_for_provider_config_uses_catalog_capabilities () =
+  with_provider_catalog catalog_json (fun () ->
+    let cfg =
+      Llm_provider.Provider_config.make
+        ~kind:Llm_provider.Provider_config.OpenAI_compat
+        ~model_id:"unlisted-local-model"
+        ~base_url:"http://127.0.0.1:8123"
+        ~request_path:"/v1/chat/completions"
+        ()
+    in
+    let caps = Provider_runtime_binding.capabilities_for_provider_config cfg in
+    Alcotest.(check bool) "catalog supports tools" true caps.supports_tools;
+    Alcotest.(check bool)
+      "catalog support tool_choice default"
+      true
+      caps.supports_tool_choice)
+;;
+
+let test_capabilities_for_provider_config_honors_override () =
+  with_provider_catalog catalog_json (fun () ->
+    let cfg =
+      Llm_provider.Provider_config.make
+        ~kind:Llm_provider.Provider_config.OpenAI_compat
+        ~model_id:"unlisted-local-model"
+        ~base_url:"http://127.0.0.1:8123"
+        ~request_path:"/v1/chat/completions"
+        ~supports_tool_choice_override:false
+        ()
+    in
+    let caps = Provider_runtime_binding.capabilities_for_provider_config cfg in
+    Alcotest.(check bool) "override disables tool choice" false caps.supports_tool_choice)
+;;
+
 let test_all_includes_catalog_entry_once () =
   with_provider_catalog catalog_json (fun () ->
     let matches =
@@ -113,6 +162,18 @@ let () =
             `Quick
             test_catalog_alias_default_and_capabilities
         ; Alcotest.test_case "to provider config" `Quick test_catalog_to_provider_config
+        ; Alcotest.test_case
+            "binding for provider config"
+            `Quick
+            test_binding_for_provider_config_uses_catalog_endpoint
+        ; Alcotest.test_case
+            "capabilities for provider config"
+            `Quick
+            test_capabilities_for_provider_config_uses_catalog_capabilities
+        ; Alcotest.test_case
+            "capabilities honor tool_choice override"
+            `Quick
+            test_capabilities_for_provider_config_honors_override
         ; Alcotest.test_case
             "all includes catalog once"
             `Quick


### PR DESCRIPTION
## Summary
- add OAS runtime binding lookup for concrete provider configs
- prefer catalog endpoint matches before provider-name fallback, including local OpenAI-compatible endpoints
- expose catalog/registry capability resolution for downstream callers so MASC can consume OAS-owned provider truth

## Tests
- scripts/dune-local.sh build lib/agent_sdk.a test/test_provider_runtime_binding.exe
- _build/default/test/test_provider_runtime_binding.exe
- ocamlformat --check lib/provider_runtime_binding.ml lib/provider_runtime_binding.mli test/test_provider_runtime_binding.ml