### PR TITLE
fix(agent): index tool lookup paths

### DIFF
--- a/lib/completion_contract.ml
+++ b/lib/completion_contract.ml
@@ -85,14 +85,24 @@ let tool_use_names (response : api_response) =
     response.content
 ;;
 
-let tool_lookup tools name =
-  List.find_opt (fun (tool : Tool.t) -> String.equal tool.schema.name name) tools
+type tool_lookup_index = (string, Tool.t) Hashtbl.t
+
+let add_first tbl key value = if not (Hashtbl.mem tbl key) then Hashtbl.add tbl key value
+
+let build_tool_lookup_index tools =
+  let index = Hashtbl.create (max 16 (List.length tools * 2)) in
+  List.iter (fun (tool : Tool.t) -> add_first index tool.schema.name tool) tools;
+  index
 ;;
 
+let tool_lookup index name = Hashtbl.find_opt index name
+
 let tool_use_calls ~(tools : Tool.t list) (response : api_response) =
+  let tool_index = build_tool_lookup_index tools in
   List.filter_map
     (function
-      | ToolUse { name; input; _ } -> Some { name; input; tool = tool_lookup tools name }
+      | ToolUse { name; input; _ } ->
+        Some { name; input; tool = tool_lookup tool_index name }
       | _ -> None)
     response.content
 ;;
@@ -284,6 +294,48 @@ let%test "validate_response accepts matching ToolUse for Require_specific_tool" 
     ; telemetry = None
     }
   = Ok ()
+;;
+
+let%test "validate_response preserves first-match tool descriptor semantics" =
+  let descriptor perm =
+    Tool.
+      { kind = None
+      ; mutation_class = None
+      ; concurrency_class = None
+      ; permission = Some perm
+      ; shell = None
+      ; notes = []
+      ; examples = []
+      }
+  in
+  let tool permission content =
+    Tool.create
+      ~descriptor:(descriptor permission)
+      ~name:"status"
+      ~description:content
+      ~parameters:[]
+      (fun _ -> Ok { content })
+  in
+  match
+    validate_response
+      ~tools:[ tool Tool.ReadOnly "read-only first"; tool Tool.Write "write second" ]
+      ~required_tool_satisfaction:effectful_tool_satisfies
+      ~contract:Require_tool_use
+      { id = "r"
+      ; model = "m"
+      ; stop_reason = StopToolUse
+      ; content = [ ToolUse { id = "call-1"; name = "status"; input = `Assoc [] } ]
+      ; usage = None
+      ; telemetry = None
+      }
+  with
+  | Error msg ->
+    (try
+       ignore (Str.search_forward (Str.regexp_string "read-only") msg 0);
+       true
+     with
+     | Not_found -> false)
+  | Ok () -> false
 ;;
 
 let%test "validate_response rejects different ToolUse for Require_specific_tool" =

--- a/lib/tool_selector.ml
+++ b/lib/tool_selector.ml
@@ -45,11 +45,31 @@ let merge_names ~always_include ~top_names =
 ;;
 
 (** Filter [tools] to only those whose [schema.name] is in [names].
-    Preserves original order of [tools]. *)
+    Preserves original order of [tools] and keeps the first descriptor for
+    duplicate names, matching the agent execution index. *)
 let filter_by_names names tools =
   let set = Hashtbl.create (List.length names) in
   List.iter (fun n -> Hashtbl.replace set n true) names;
-  List.filter (fun (t : Tool.t) -> Hashtbl.mem set t.schema.name) tools
+  let emitted = Hashtbl.create (List.length names) in
+  List.filter
+    (fun (t : Tool.t) ->
+       let name = t.schema.name in
+       if Hashtbl.mem set name && not (Hashtbl.mem emitted name)
+       then (
+         Hashtbl.replace emitted name true;
+         true)
+       else false)
+    tools
+;;
+
+let build_tool_name_index tools =
+  let index = Hashtbl.create (max 16 (List.length tools * 2)) in
+  List.iter
+    (fun (tool : Tool.t) ->
+       if not (Hashtbl.mem index tool.schema.name)
+       then Hashtbl.add index tool.schema.name tool)
+    tools;
+  index
 ;;
 
 (* ── Strategy implementations ────────────────────────────── *)
@@ -81,11 +101,12 @@ let select_llm_core
   else (
     (* Stage 1: BM25 pre-filter *)
     let bm25_top = List.filteri (fun i _ -> i < bm25_prefilter_n) retrieved in
+    let tool_by_name = build_tool_name_index tools in
     (* Build (name, description) candidates for reranker *)
     let candidates =
       List.filter_map
         (fun (name, _score) ->
-           match List.find_opt (fun (t : Tool.t) -> t.schema.name = name) tools with
+           match Hashtbl.find_opt tool_by_name name with
            | Some t -> Some (name, t.schema.description)
            | None -> None)
         bm25_top

--- a/lib/tool_selector.ml
+++ b/lib/tool_selector.ml
@@ -304,6 +304,8 @@ let auto ~tools =
 
 let default_rerank_fn ~sw ~net ~provider ~k () =
   fun ~context ~candidates ->
+  let candidate_names = Hashtbl.create (List.length candidates) in
+  List.iter (fun (name, _) -> Hashtbl.replace candidate_names name true) candidates;
   let tool_list =
     List.mapi
       (fun i (name, desc) -> Printf.sprintf "%d. %s: %s" (i + 1) name desc)
@@ -365,7 +367,7 @@ let default_rerank_fn ~sw ~net ~provider ~k () =
             | _ -> trimmed)
           else trimmed
         in
-        if List.exists (fun (n, _) -> n = name) candidates then Some name else None))
+        if Hashtbl.mem candidate_names name then Some name else None))
   | Error _ ->
     (* Graceful degradation: return candidates in BM25 order *)
     bm25_fallback ()

--- a/test/test_tool_selector.ml
+++ b/test/test_tool_selector.ml
@@ -288,6 +288,39 @@ let test_topk_llm_invalid_names_dropped () =
   check int "no tools from invalid rerank" 0 (List.length result)
 ;;
 
+let test_topk_llm_candidates_preserve_first_duplicate_descriptor () =
+  let saw_first_description = ref false in
+  let rerank ~context:_ ~candidates =
+    saw_first_description
+    := List.exists
+         (fun (name, description) ->
+            name = "status" && description = "First status descriptor")
+         candidates;
+    [ "status" ]
+  in
+  let tools =
+    [ make_tool "status" "First status descriptor"
+    ; make_tool "status" "Second status descriptor"
+    ; make_tool "search" "Search status entries"
+    ]
+  in
+  let result =
+    Tool_selector.select
+      ~strategy:
+        (TopK_llm
+           { k = 1
+           ; bm25_prefilter_n = 3
+           ; always_include = []
+           ; confidence_threshold = 0.0
+           ; rerank_fn = rerank
+           })
+      ~context:"status"
+      ~tools
+  in
+  check bool "reranker saw first descriptor" true !saw_first_description;
+  check (list string) "selected status once" [ "status" ] (tool_names result)
+;;
+
 (* ── Categorical stubs ──────────────────────────── *)
 
 let test_categorical_llm_unimplemented_returns_empty () =
@@ -425,6 +458,10 @@ let () =
             test_topk_llm_low_confidence_skips_llm
         ; test_case "empty tools" `Quick test_topk_llm_empty_tools
         ; test_case "invalid names dropped" `Quick test_topk_llm_invalid_names_dropped
+        ; test_case
+            "duplicate candidate descriptor keeps first"
+            `Quick
+            test_topk_llm_candidates_preserve_first_duplicate_descriptor
         ] )
     ; ( "stubs"
       , [ test_case


### PR DESCRIPTION
## Summary
- replace per-ToolUse linear scans in completion-contract validation with a per-response tool-name index
- index TopK LLM selector candidate lookup and dedupe duplicate selected tool names to first descriptor semantics
- preserve first-match descriptor behavior for duplicate tool names across validation, selection, and execution lookup paths
- add regression coverage for duplicate descriptors in strict completion contracts and tool selector reranking

## Validation
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build lib/agent_sdk.cmxa test/test_tool_selector.exe test/test_agent_tools_index.exe test/test_agent_pipeline.exe
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh runtest lib
- ./_build/default/test/test_tool_selector.exe
- ./_build/default/test/test_agent_tools_index.exe
- ./_build/default/test/test_agent_pipeline.exe
- ocamlformat --check lib/tool_selector.ml test/test_tool_selector.ml lib/completion_contract.ml
- git diff --check