### PR TITLE
fix(memory): persist episodic procedural backends

### DIFF
--- a/lib/memory.ml
+++ b/lib/memory.ml
@@ -46,9 +46,51 @@ let legacy_backend ~persist ~retrieve ~remove =
   }
 ;;
 
+type outcome = Memory_episodic.outcome =
+  | Success of string
+  | Failure of string
+  | Neutral
+
+type episode = Memory_episodic.episode =
+  { id : string
+  ; timestamp : float
+  ; participants : string list
+  ; action : string
+  ; outcome : outcome
+  ; salience : float
+  ; metadata : (string * Yojson.Safe.t) list
+  }
+
+type procedure = Memory_procedural.procedure =
+  { id : string
+  ; pattern : string
+  ; action : string
+  ; success_count : int
+  ; failure_count : int
+  ; confidence : float
+  ; last_used : float
+  ; metadata : (string * Yojson.Safe.t) list
+  }
+
+type episodic_backend =
+  { persist_episode : episode -> unit
+  ; retrieve_episode : id:string -> episode option
+  ; remove_episode : id:string -> unit
+  ; all_episodes : unit -> episode list
+  }
+
+type procedural_backend =
+  { persist_procedure : procedure -> unit
+  ; retrieve_procedure : id:string -> procedure option
+  ; remove_procedure : id:string -> unit
+  ; all_procedures : unit -> procedure list
+  }
+
 type t =
   { ctx : Context.t
   ; mutable long_term : long_term_backend option
+  ; mutable episodic : episodic_backend option
+  ; mutable procedural : procedural_backend option
   }
 
 let scope_of_tier = function
@@ -59,8 +101,13 @@ let scope_of_tier = function
   | Long_term -> Context.Custom "lt"
 ;;
 
-let create ?(ctx = Context.create ()) ?long_term () = { ctx; long_term }
+let create ?(ctx = Context.create ()) ?long_term ?episodic ?procedural () =
+  { ctx; long_term; episodic; procedural }
+;;
+
 let set_long_term_backend t backend = t.long_term <- Some backend
+let set_episodic_backend t backend = t.episodic <- Some backend
+let set_procedural_backend t backend = t.procedural <- Some backend
 
 let store t ~tier key value =
   match tier with
@@ -97,7 +144,30 @@ let recall t ~tier key =
        (match t.long_term with
         | Some backend -> backend.retrieve ~key
         | None -> None)
-     | Episodic | Procedural -> None)
+     | Episodic ->
+       (match t.episodic with
+        | Some backend ->
+          Option.map Memory_episodic.episode_to_json (backend.retrieve_episode ~id:key)
+        | None -> None)
+     | Procedural ->
+       (match t.procedural with
+        | Some backend ->
+          Option.map
+            Memory_procedural.procedure_to_json
+            (backend.retrieve_procedure ~id:key)
+        | None -> None))
+;;
+
+let context_episode_json t key =
+  match Memory_episodic.recall_one t.ctx key with
+  | Some ep -> Some (Memory_episodic.episode_to_json ep)
+  | None -> Context.get_scoped t.ctx (scope_of_tier Episodic) key
+;;
+
+let context_procedure_json t key =
+  match Context.get_scoped t.ctx (scope_of_tier Procedural) key with
+  | Some _ as found -> found
+  | None -> None
 ;;
 
 let recall_exact t ~tier key =
@@ -106,6 +176,20 @@ let recall_exact t ~tier key =
     (match t.long_term with
      | Some backend -> backend.retrieve ~key
      | None -> Context.get_scoped t.ctx (scope_of_tier Long_term) key)
+  | Episodic ->
+    (match t.episodic with
+     | Some backend ->
+       (match backend.retrieve_episode ~id:key with
+        | Some ep -> Some (Memory_episodic.episode_to_json ep)
+        | None -> context_episode_json t key)
+     | None -> context_episode_json t key)
+  | Procedural ->
+    (match t.procedural with
+     | Some backend ->
+       (match backend.retrieve_procedure ~id:key with
+        | Some proc -> Some (Memory_procedural.procedure_to_json proc)
+        | None -> context_procedure_json t key)
+     | None -> context_procedure_json t key)
   | _ -> Context.get_scoped t.ctx (scope_of_tier tier) key
 ;;
 
@@ -119,6 +203,14 @@ let forget t ~tier key =
         | Ok () -> Ok ()
         | Error reason -> Error reason)
      | None -> Ok ())
+  | Episodic ->
+    Context.delete_scoped t.ctx (scope_of_tier Episodic) key;
+    Option.iter (fun backend -> backend.remove_episode ~id:key) t.episodic;
+    Ok ()
+  | Procedural ->
+    Context.delete_scoped t.ctx (scope_of_tier Procedural) key;
+    Option.iter (fun backend -> backend.remove_procedure ~id:key) t.procedural;
+    Ok ()
   | _ ->
     Context.delete_scoped t.ctx (scope_of_tier tier) key;
     Ok ()
@@ -151,6 +243,25 @@ let query_context t ~tier ~prefix =
     | None -> None)
 ;;
 
+let query_episodic_backend t ~prefix =
+  match t.episodic with
+  | None -> []
+  | Some (backend : episodic_backend) ->
+    backend.all_episodes ()
+    |> List.filter (fun (ep : episode) -> String.starts_with ~prefix ep.id)
+    |> List.map (fun (ep : episode) -> ep.id, Memory_episodic.episode_to_json ep)
+;;
+
+let query_procedural_backend t ~prefix =
+  match t.procedural with
+  | None -> []
+  | Some (backend : procedural_backend) ->
+    backend.all_procedures ()
+    |> List.filter (fun (proc : procedure) -> String.starts_with ~prefix proc.id)
+    |> List.map (fun (proc : procedure) ->
+      proc.id, Memory_procedural.procedure_to_json proc)
+;;
+
 let query t ~tier ~prefix ~limit =
   if limit <= 0
   then []
@@ -163,6 +274,12 @@ let query t ~tier ~prefix ~limit =
         | None -> []
       in
       take_unique limit (backend_entries @ query_context t ~tier:Long_term ~prefix)
+    | Episodic ->
+      take_unique limit (query_episodic_backend t ~prefix @ query_context t ~tier ~prefix)
+    | Procedural ->
+      take_unique
+        limit
+        (query_procedural_backend t ~prefix @ query_context t ~tier ~prefix)
     | _ -> take_unique limit (query_context t ~tier ~prefix))
 ;;
 
@@ -197,67 +314,193 @@ let clear_scratchpad t =
 ;;
 
 let keys_in_tier t tier = Context.keys_in_scope t.ctx (scope_of_tier tier)
-
-let stats t =
-  let count tier = List.length (keys_in_tier t tier) in
-  count Scratchpad, count Working, count Episodic, count Procedural, count Long_term
-;;
-
 let context t = t.ctx
 
 (* ── Episodic memory (delegated to Memory_episodic) ───── *)
 
-type outcome = Memory_episodic.outcome =
-  | Success of string
-  | Failure of string
-  | Neutral
-
-type episode = Memory_episodic.episode =
-  { id : string
-  ; timestamp : float
-  ; participants : string list
-  ; action : string
-  ; outcome : outcome
-  ; salience : float
-  ; metadata : (string * Yojson.Safe.t) list
-  }
-
-let store_episode t ep = Memory_episodic.store t.ctx ep
-let recall_episode t id = Memory_episodic.recall_one t.ctx id
-
-let recall_episodes t ?now ?decay_rate ?min_salience ?limit ?filter () =
-  Memory_episodic.recall t.ctx ?now ?decay_rate ?min_salience ?limit ?filter ()
+let unique_episodes episodes =
+  let seen = Hashtbl.create (List.length episodes + 1) in
+  List.filter
+    (fun (ep : episode) ->
+       if Hashtbl.mem seen ep.id
+       then false
+       else (
+         Hashtbl.replace seen ep.id ();
+         true))
+    episodes
 ;;
 
-let boost_salience t id amount = Memory_episodic.boost_salience t.ctx id amount
-let forget_episode t id = Memory_episodic.forget t.ctx id
-let episode_count t = Memory_episodic.count t.ctx
+let unique_procedures procedures =
+  let seen = Hashtbl.create (List.length procedures + 1) in
+  List.filter
+    (fun (proc : procedure) ->
+       if Hashtbl.mem seen proc.id
+       then false
+       else (
+         Hashtbl.replace seen proc.id ();
+         true))
+    procedures
+;;
+
+let context_episodes t = Memory_episodic.all t.ctx
+
+let backend_episodes t =
+  match t.episodic with
+  | Some backend -> backend.all_episodes ()
+  | None -> []
+;;
+
+let all_episodes t = unique_episodes (backend_episodes t @ context_episodes t)
+
+let store_episode t ep =
+  Memory_episodic.store t.ctx ep;
+  Option.iter (fun backend -> backend.persist_episode ep) t.episodic
+;;
+
+let recall_episode t id =
+  match t.episodic with
+  | Some backend ->
+    (match backend.retrieve_episode ~id with
+     | Some _ as found -> found
+     | None -> Memory_episodic.recall_one t.ctx id)
+  | None -> Memory_episodic.recall_one t.ctx id
+;;
+
+let recall_episodes t ?now ?decay_rate ?min_salience ?limit ?filter () =
+  let now = Option.value now ~default:(Unix.gettimeofday ()) in
+  let decay_rate = Option.value decay_rate ~default:0.01 in
+  let min_salience = Option.value min_salience ~default:0.1 in
+  let limit = Option.value limit ~default:50 in
+  all_episodes t
+  |> List.map (fun ep ->
+    let effective = Memory_episodic.decayed_salience ~now ~decay_rate ep in
+    { ep with salience = effective }, effective)
+  |> List.filter (fun (_, salience) -> salience >= min_salience)
+  |> List.filter (fun (ep, _) ->
+    match filter with
+    | Some predicate -> predicate ep
+    | None -> true)
+  |> List.sort (fun (_, left) (_, right) -> Float.compare right left)
+  |> fun episodes ->
+  let rec take n acc = function
+    | [] -> List.rev acc
+    | _ when n <= 0 -> List.rev acc
+    | (ep, _) :: rest -> take (n - 1) (ep :: acc) rest
+  in
+  take limit [] episodes
+;;
+
+let boost_salience t id amount =
+  match recall_episode t id with
+  | Some ep ->
+    let boosted = Float.min 1.0 (ep.salience +. amount) in
+    store_episode t { ep with salience = boosted }
+  | None -> ()
+;;
+
+let forget_episode t id =
+  Memory_episodic.forget t.ctx id;
+  Option.iter (fun backend -> backend.remove_episode ~id) t.episodic
+;;
+
+let episode_count t = List.length (all_episodes t)
 
 (* ── Procedural memory (delegated to Memory_procedural) ── *)
 
-type procedure = Memory_procedural.procedure =
-  { id : string
-  ; pattern : string
-  ; action : string
-  ; success_count : int
-  ; failure_count : int
-  ; confidence : float
-  ; last_used : float
-  ; metadata : (string * Yojson.Safe.t) list
-  }
+let context_procedures t = Memory_procedural.all t.ctx
 
-let store_procedure t proc = Memory_procedural.store t.ctx proc
+let backend_procedures t =
+  match t.procedural with
+  | Some backend -> backend.all_procedures ()
+  | None -> []
+;;
+
+let all_procedures t = unique_procedures (backend_procedures t @ context_procedures t)
+
+let recall_procedure t id =
+  match t.procedural with
+  | Some backend ->
+    (match backend.retrieve_procedure ~id with
+     | Some _ as found -> found
+     | None ->
+       (match Context.get_scoped t.ctx (scope_of_tier Procedural) id with
+        | Some json -> Memory_procedural.procedure_of_json json
+        | None -> None))
+  | None ->
+    (match Context.get_scoped t.ctx (scope_of_tier Procedural) id with
+     | Some json -> Memory_procedural.procedure_of_json json
+     | None -> None)
+;;
+
+let store_procedure t proc =
+  Memory_procedural.store t.ctx proc;
+  Option.iter (fun backend -> backend.persist_procedure proc) t.procedural
+;;
 
 let matching_procedures t ~pattern ?min_confidence ?filter () =
-  Memory_procedural.matching t.ctx ~pattern ?min_confidence ?filter ()
+  let min_confidence = Option.value min_confidence ~default:0.0 in
+  all_procedures t
+  |> List.filter (fun proc ->
+    Memory_procedural.string_contains ~needle:pattern proc.pattern
+    && proc.confidence >= min_confidence
+    &&
+    match filter with
+    | Some predicate -> predicate proc
+    | None -> true)
+  |> List.sort (fun left right -> Float.compare right.confidence left.confidence)
 ;;
 
 let find_procedure t ~pattern ?min_confidence ?filter ?touch () =
-  Memory_procedural.find t.ctx ~pattern ?min_confidence ?filter ?touch ()
+  let touch = Option.value touch ~default:false in
+  match matching_procedures t ~pattern ?min_confidence ?filter () with
+  | best :: _ ->
+    if touch
+    then (
+      let touched = { best with last_used = Unix.gettimeofday () } in
+      store_procedure t touched;
+      Some touched)
+    else Some best
+  | [] -> None
 ;;
 
-let best_procedure t ~pattern = Memory_procedural.best t.ctx ~pattern
-let record_success t id = Memory_procedural.record_success t.ctx id
-let record_failure t id = Memory_procedural.record_failure t.ctx id
-let forget_procedure t id = Memory_procedural.forget t.ctx id
-let procedure_count t = Memory_procedural.count t.ctx
+let best_procedure t ~pattern = find_procedure t ~pattern ()
+
+let update_procedure t id f =
+  match recall_procedure t id with
+  | Some proc -> store_procedure t (f proc)
+  | None -> ()
+;;
+
+let record_success t id =
+  update_procedure t id (fun proc ->
+    let success_count = proc.success_count + 1 in
+    let confidence =
+      Memory_procedural.compute_confidence
+        ~success_count
+        ~failure_count:proc.failure_count
+    in
+    { proc with success_count; confidence; last_used = Unix.gettimeofday () })
+;;
+
+let record_failure t id =
+  update_procedure t id (fun proc ->
+    let failure_count = proc.failure_count + 1 in
+    let confidence =
+      Memory_procedural.compute_confidence
+        ~success_count:proc.success_count
+        ~failure_count
+    in
+    { proc with failure_count; confidence; last_used = Unix.gettimeofday () })
+;;
+
+let forget_procedure t id =
+  Memory_procedural.forget t.ctx id;
+  Option.iter (fun backend -> backend.remove_procedure ~id) t.procedural
+;;
+
+let procedure_count t = List.length (all_procedures t)
+
+let stats t =
+  let count tier = List.length (keys_in_tier t tier) in
+  count Scratchpad, count Working, episode_count t, procedure_count t, count Long_term
+;;

--- a/lib/memory.mli
+++ b/lib/memory.mli
@@ -24,7 +24,7 @@ type tier =
   | Procedural
   | Long_term
 
-(** {1 Long-term backend} *)
+(** {1 Memory backends} *)
 
 (** Callback for long-term memory persistence.
 
@@ -37,6 +37,55 @@ type long_term_backend =
   ; remove : key:string -> (unit, string) result
   ; batch_persist : (string * Yojson.Safe.t) list -> (unit, string) result
   ; query : prefix:string -> limit:int -> (string * Yojson.Safe.t) list
+  }
+
+(** Outcome of an interaction. *)
+type outcome = Memory_episodic.outcome =
+  | Success of string
+  | Failure of string
+  | Neutral
+
+(** A single episodic memory record. *)
+type episode = Memory_episodic.episode =
+  { id : string
+  ; timestamp : float
+  ; participants : string list
+  ; action : string
+  ; outcome : outcome
+  ; salience : float (** 0.0-1.0, decays over time *)
+  ; metadata : (string * Yojson.Safe.t) list
+  }
+
+(** A learned procedure. *)
+type procedure = Memory_procedural.procedure =
+  { id : string
+  ; pattern : string (** What triggers this procedure *)
+  ; action : string (** What to do *)
+  ; success_count : int
+  ; failure_count : int
+  ; confidence : float (** success / (success + failure), 0.0-1.0 *)
+  ; last_used : float
+  ; metadata : (string * Yojson.Safe.t) list
+  }
+
+(** Optional persistence backend for episodic memory. The in-memory context
+    remains a hot cache; this backend lets a fresh [Memory.t] recall episodes
+    written by an earlier instance. *)
+type episodic_backend =
+  { persist_episode : episode -> unit
+  ; retrieve_episode : id:string -> episode option
+  ; remove_episode : id:string -> unit
+  ; all_episodes : unit -> episode list
+  }
+
+(** Optional persistence backend for procedural memory. The in-memory context
+    remains a hot cache; this backend lets learned procedures survive fresh
+    [Memory.t] instances. *)
+type procedural_backend =
+  { persist_procedure : procedure -> unit
+  ; retrieve_procedure : id:string -> procedure option
+  ; remove_procedure : id:string -> unit
+  ; all_procedures : unit -> procedure list
   }
 
 (** Wrap legacy callbacks that return [unit] into a {!long_term_backend}
@@ -52,10 +101,22 @@ val legacy_backend
 
 type t
 
-val create : ?ctx:Context.t -> ?long_term:long_term_backend -> unit -> t
+val create
+  :  ?ctx:Context.t
+  -> ?long_term:long_term_backend
+  -> ?episodic:episodic_backend
+  -> ?procedural:procedural_backend
+  -> unit
+  -> t
 
 (** Set or replace the long-term backend. *)
 val set_long_term_backend : t -> long_term_backend -> unit
+
+(** Set or replace the episodic backend. *)
+val set_episodic_backend : t -> episodic_backend -> unit
+
+(** Set or replace the procedural backend. *)
+val set_procedural_backend : t -> procedural_backend -> unit
 
 (** {1 Generic key-value operations (Scratchpad, Working, Long_term)} *)
 
@@ -107,23 +168,6 @@ val context : t -> Context.t
     Use for "what happened" recall — past interactions,
     outcomes, participant involvement. *)
 
-(** Outcome of an interaction. *)
-type outcome =
-  | Success of string
-  | Failure of string
-  | Neutral
-
-(** A single episodic memory record. *)
-type episode =
-  { id : string
-  ; timestamp : float
-  ; participants : string list
-  ; action : string
-  ; outcome : outcome
-  ; salience : float (** 0.0–1.0, decays over time *)
-  ; metadata : (string * Yojson.Safe.t) list
-  }
-
 (** Store an episode.  The episode's [id] is used as the storage key. *)
 val store_episode : t -> episode -> unit
 
@@ -159,18 +203,6 @@ val episode_count : t -> int
     Stores learned action patterns with success/failure tracking.
     Use for "how to do X" recall — reusable strategies,
     tool usage patterns, decision heuristics. *)
-
-(** A learned procedure. *)
-type procedure =
-  { id : string
-  ; pattern : string (** What triggers this procedure *)
-  ; action : string (** What to do *)
-  ; success_count : int
-  ; failure_count : int
-  ; confidence : float (** success / (success + failure), 0.0–1.0 *)
-  ; last_used : float
-  ; metadata : (string * Yojson.Safe.t) list
-  }
 
 (** Store or update a procedure. Uses [id] as storage key. *)
 val store_procedure : t -> procedure -> unit

--- a/lib/memory_file_backend.ml
+++ b/lib/memory_file_backend.ml
@@ -164,6 +164,65 @@ let to_backend t : Memory.long_term_backend =
   }
 ;;
 
+let episodic_prefix = "ep:"
+let procedural_prefix = "pr:"
+let episodic_key id = episodic_prefix ^ id
+let procedural_key id = procedural_prefix ^ id
+
+let warn_callback_error ~op ~key reason =
+  warn_backend_issue ~op ~path:key (Failure reason)
+;;
+
+let to_episodic_backend t : Memory.episodic_backend =
+  { persist_episode =
+      (fun ep ->
+        let key = episodic_key ep.id in
+        match persist t ~key (Memory_episodic.episode_to_json ep) with
+        | Ok () -> ()
+        | Error reason -> warn_callback_error ~op:"persist_episode" ~key reason)
+  ; retrieve_episode =
+      (fun ~id ->
+        match retrieve t ~key:(episodic_key id) with
+        | Some json -> Memory_episodic.episode_of_json json
+        | None -> None)
+  ; remove_episode =
+      (fun ~id ->
+        let key = episodic_key id in
+        match remove t ~key with
+        | Ok () -> ()
+        | Error reason -> warn_callback_error ~op:"remove_episode" ~key reason)
+  ; all_episodes =
+      (fun () ->
+        query t ~prefix:episodic_prefix ~limit:0
+        |> List.filter_map (fun (_, json) -> Memory_episodic.episode_of_json json))
+  }
+;;
+
+let to_procedural_backend t : Memory.procedural_backend =
+  { persist_procedure =
+      (fun proc ->
+        let key = procedural_key proc.id in
+        match persist t ~key (Memory_procedural.procedure_to_json proc) with
+        | Ok () -> ()
+        | Error reason -> warn_callback_error ~op:"persist_procedure" ~key reason)
+  ; retrieve_procedure =
+      (fun ~id ->
+        match retrieve t ~key:(procedural_key id) with
+        | Some json -> Memory_procedural.procedure_of_json json
+        | None -> None)
+  ; remove_procedure =
+      (fun ~id ->
+        let key = procedural_key id in
+        match remove t ~key with
+        | Ok () -> ()
+        | Error reason -> warn_callback_error ~op:"remove_procedure" ~key reason)
+  ; all_procedures =
+      (fun () ->
+        query t ~prefix:procedural_prefix ~limit:0
+        |> List.filter_map (fun (_, json) -> Memory_procedural.procedure_of_json json))
+  }
+;;
+
 (* ── Utility ─────────────────────────────────────────────────── *)
 
 let keys t =

--- a/lib/memory_file_backend.mli
+++ b/lib/memory_file_backend.mli
@@ -24,6 +24,12 @@ val create : Eio.Fs.dir_ty Eio.Path.t -> (t, Error.sdk_error) result
 (** Get the {!Memory.long_term_backend} for use with {!Memory.create}. *)
 val to_backend : t -> Memory.long_term_backend
 
+(** Get the {!Memory.episodic_backend} for use with {!Memory.create}. *)
+val to_episodic_backend : t -> Memory.episodic_backend
+
+(** Get the {!Memory.procedural_backend} for use with {!Memory.create}. *)
+val to_procedural_backend : t -> Memory.procedural_backend
+
 (** Count stored entries. *)
 val entry_count : t -> int
 

--- a/test/test_memory_episodic.ml
+++ b/test/test_memory_episodic.ml
@@ -1,5 +1,17 @@
 open Agent_sdk
 
+let make_backend () =
+  let store = Hashtbl.create 4 in
+  let backend : Memory.episodic_backend =
+    { persist_episode = (fun ep -> Hashtbl.replace store ep.id ep)
+    ; retrieve_episode = (fun ~id -> Hashtbl.find_opt store id)
+    ; remove_episode = (fun ~id -> Hashtbl.remove store id)
+    ; all_episodes = (fun () -> Hashtbl.to_seq_values store |> List.of_seq)
+    }
+  in
+  backend
+;;
+
 let () =
   Alcotest.run
     "Memory_Episodic"
@@ -26,6 +38,30 @@ let () =
         ; Alcotest.test_case "recall nonexistent episode" `Quick (fun () ->
             let mem = Memory.create () in
             Alcotest.(check bool) "none" true (Memory.recall_episode mem "nope" = None))
+        ; Alcotest.test_case "backend survives fresh memory instance" `Quick (fun () ->
+            let backend = make_backend () in
+            let ep : Memory.episode =
+              { id = "ep-backend"
+              ; timestamp = 1000.0
+              ; participants = [ "keeper" ]
+              ; action = "fixed CI"
+              ; outcome = Success "checks green"
+              ; salience = 0.7
+              ; metadata = []
+              }
+            in
+            let writer = Memory.create ~episodic:backend () in
+            Memory.store_episode writer ep;
+            let reader = Memory.create ~episodic:backend () in
+            (match Memory.recall_episode reader "ep-backend" with
+             | Some found ->
+               Alcotest.(check string) "backend id" "ep-backend" found.id;
+               Alcotest.(check string) "backend action" "fixed CI" found.action
+             | None -> Alcotest.fail "episode missing from backend");
+            let episodes = Memory.recall_episodes reader ~min_salience:0.0 () in
+            Alcotest.(check int) "backend recall list" 1 (List.length episodes);
+            let _, _, ep_count, _, _ = Memory.stats reader in
+            Alcotest.(check int) "backend stats" 1 ep_count)
         ] )
     ; ( "salience_decay"
       , [ Alcotest.test_case
@@ -209,6 +245,25 @@ let () =
             match Memory.recall_episode mem "ep1" with
             | Some ep -> Alcotest.(check (float 0.01)) "capped" 1.0 ep.salience
             | None -> Alcotest.fail "not found")
+        ; Alcotest.test_case "boost persists through backend" `Quick (fun () ->
+            let backend = make_backend () in
+            let writer = Memory.create ~episodic:backend () in
+            Memory.store_episode
+              writer
+              { id = "ep1"
+              ; timestamp = 100.0
+              ; participants = []
+              ; action = "task"
+              ; outcome = Neutral
+              ; salience = 0.5
+              ; metadata = []
+              };
+            let updater = Memory.create ~episodic:backend () in
+            Memory.boost_salience updater "ep1" 0.25;
+            let reader = Memory.create ~episodic:backend () in
+            match Memory.recall_episode reader "ep1" with
+            | Some ep -> Alcotest.(check (float 0.01)) "persisted boost" 0.75 ep.salience
+            | None -> Alcotest.fail "not found")
         ] )
     ; ( "forget_count"
       , [ Alcotest.test_case "forget removes episode" `Quick (fun () ->
@@ -226,6 +281,25 @@ let () =
             Alcotest.(check int) "count 1" 1 (Memory.episode_count mem);
             Memory.forget_episode mem "ep1";
             Alcotest.(check int) "count 0" 0 (Memory.episode_count mem))
+        ; Alcotest.test_case "forget removes backend episode" `Quick (fun () ->
+            let backend = make_backend () in
+            let mem = Memory.create ~episodic:backend () in
+            Memory.store_episode
+              mem
+              { id = "ep1"
+              ; timestamp = 100.0
+              ; participants = []
+              ; action = "task"
+              ; outcome = Neutral
+              ; salience = 0.5
+              ; metadata = []
+              };
+            Memory.forget_episode mem "ep1";
+            let fresh = Memory.create ~episodic:backend () in
+            Alcotest.(check bool)
+              "backend removed"
+              true
+              (Memory.recall_episode fresh "ep1" = None))
         ] )
     ; ( "stats"
       , [ Alcotest.test_case "episodic count in stats" `Quick (fun () ->

--- a/test/test_memory_file_backend.ml
+++ b/test/test_memory_file_backend.ml
@@ -270,6 +270,65 @@ let test_memory_integration () =
      | _ -> Alcotest.fail "not persisted to disk")
 ;;
 
+let test_memory_episodic_integration () =
+  Eio_main.run
+  @@ fun env ->
+  with_tmp_dir env
+  @@ fun dir ->
+  match Memory_file_backend.create dir with
+  | Error e -> Alcotest.failf "create: %s" (Error.to_string e)
+  | Ok file_store ->
+    let backend = Memory_file_backend.to_episodic_backend file_store in
+    let writer = Memory.create ~episodic:backend () in
+    Memory.store_episode
+      writer
+      { id = "ep1"
+      ; timestamp = 100.0
+      ; participants = [ "keeper" ]
+      ; action = "fixed issue"
+      ; outcome = Success "merged"
+      ; salience = 0.8
+      ; metadata = []
+      };
+    let reader = Memory.create ~episodic:backend () in
+    (match Memory.recall_episode reader "ep1" with
+     | Some ep -> Alcotest.(check string) "action" "fixed issue" ep.action
+     | None -> Alcotest.fail "episode not persisted");
+    Alcotest.(check int) "stored file" 1 (Memory_file_backend.entry_count file_store)
+;;
+
+let test_memory_procedural_integration () =
+  Eio_main.run
+  @@ fun env ->
+  with_tmp_dir env
+  @@ fun dir ->
+  match Memory_file_backend.create dir with
+  | Error e -> Alcotest.failf "create: %s" (Error.to_string e)
+  | Ok file_store ->
+    let backend = Memory_file_backend.to_procedural_backend file_store in
+    let writer = Memory.create ~procedural:backend () in
+    Memory.store_procedure
+      writer
+      { id = "pr1"
+      ; pattern = "deploy"
+      ; action = "rollback"
+      ; success_count = 1
+      ; failure_count = 1
+      ; confidence = 0.5
+      ; last_used = 100.0
+      ; metadata = []
+      };
+    let updater = Memory.create ~procedural:backend () in
+    Memory.record_success updater "pr1";
+    let reader = Memory.create ~procedural:backend () in
+    (match Memory.best_procedure reader ~pattern:"deploy" with
+     | Some proc ->
+       Alcotest.(check int) "success persisted" 2 proc.success_count;
+       Alcotest.(check (float 0.01)) "confidence" 0.667 proc.confidence
+     | None -> Alcotest.fail "procedure not persisted");
+    Alcotest.(check int) "stored file" 1 (Memory_file_backend.entry_count file_store)
+;;
+
 (* ── Suite ───────────────────────────────────────────────────── *)
 
 let () =
@@ -293,6 +352,13 @@ let () =
     ; "clear", [ Alcotest.test_case "clear" `Quick test_clear ]
     ; "keys", [ Alcotest.test_case "sorted" `Quick test_keys_sorted ]
     ; "special", [ Alcotest.test_case "special_chars" `Quick test_special_chars_key ]
-    ; "integration", [ Alcotest.test_case "memory_t" `Quick test_memory_integration ]
+    ; ( "integration"
+      , [ Alcotest.test_case "memory_t" `Quick test_memory_integration
+        ; Alcotest.test_case "episodic_memory_t" `Quick test_memory_episodic_integration
+        ; Alcotest.test_case
+            "procedural_memory_t"
+            `Quick
+            test_memory_procedural_integration
+        ] )
     ]
 ;;

--- a/test/test_memory_procedural.ml
+++ b/test/test_memory_procedural.ml
@@ -1,5 +1,17 @@
 open Agent_sdk
 
+let make_backend () =
+  let store = Hashtbl.create 4 in
+  let backend : Memory.procedural_backend =
+    { persist_procedure = (fun proc -> Hashtbl.replace store proc.id proc)
+    ; retrieve_procedure = (fun ~id -> Hashtbl.find_opt store id)
+    ; remove_procedure = (fun ~id -> Hashtbl.remove store id)
+    ; all_procedures = (fun () -> Hashtbl.to_seq_values store |> List.of_seq)
+    }
+  in
+  backend
+;;
+
 let () =
   Alcotest.run
     "Memory_Procedural"
@@ -24,6 +36,29 @@ let () =
               Alcotest.(check string) "id" "pr1" found.id;
               Alcotest.(check string) "action" "rollback then retry" found.action;
               Alcotest.(check int) "success" 5 found.success_count)
+        ; Alcotest.test_case "backend survives fresh memory instance" `Quick (fun () ->
+            let backend = make_backend () in
+            let proc : Memory.procedure =
+              { id = "pr-backend"
+              ; pattern = "deploy error"
+              ; action = "rollback then retry"
+              ; success_count = 5
+              ; failure_count = 1
+              ; confidence = 5.0 /. 6.0
+              ; last_used = 1000.0
+              ; metadata = []
+              }
+            in
+            let writer = Memory.create ~procedural:backend () in
+            Memory.store_procedure writer proc;
+            let reader = Memory.create ~procedural:backend () in
+            (match Memory.find_procedure reader ~pattern:"deploy" () with
+             | Some found ->
+               Alcotest.(check string) "backend id" "pr-backend" found.id;
+               Alcotest.(check string) "backend action" "rollback then retry" found.action
+             | None -> Alcotest.fail "procedure missing from backend");
+            let _, _, _, pr_count, _ = Memory.stats reader in
+            Alcotest.(check int) "backend stats" 1 pr_count)
         ] )
     ; ( "matching"
       , [ Alcotest.test_case "pattern substring match" `Quick (fun () ->
@@ -180,6 +215,28 @@ let () =
               Alcotest.(check int) "success_count" 2 proc.success_count;
               Alcotest.(check (float 0.01)) "confidence" 0.667 proc.confidence
             | None -> Alcotest.fail "not found")
+        ; Alcotest.test_case "record_success persists through backend" `Quick (fun () ->
+            let backend = make_backend () in
+            let writer = Memory.create ~procedural:backend () in
+            Memory.store_procedure
+              writer
+              { id = "pr1"
+              ; pattern = "task"
+              ; action = "do it"
+              ; success_count = 1
+              ; failure_count = 1
+              ; confidence = 0.5
+              ; last_used = 100.0
+              ; metadata = []
+              };
+            let updater = Memory.create ~procedural:backend () in
+            Memory.record_success updater "pr1";
+            let reader = Memory.create ~procedural:backend () in
+            match Memory.best_procedure reader ~pattern:"task" with
+            | Some proc ->
+              Alcotest.(check int) "success_count" 2 proc.success_count;
+              Alcotest.(check (float 0.01)) "confidence" 0.667 proc.confidence
+            | None -> Alcotest.fail "not found")
         ; Alcotest.test_case "record_failure updates confidence" `Quick (fun () ->
             let mem = Memory.create () in
             Memory.store_procedure
@@ -242,6 +299,26 @@ let () =
             Alcotest.(check int) "count 1" 1 (Memory.procedure_count mem);
             Memory.forget_procedure mem "pr1";
             Alcotest.(check int) "count 0" 0 (Memory.procedure_count mem))
+        ; Alcotest.test_case "forget removes backend procedure" `Quick (fun () ->
+            let backend = make_backend () in
+            let mem = Memory.create ~procedural:backend () in
+            Memory.store_procedure
+              mem
+              { id = "pr1"
+              ; pattern = "x"
+              ; action = "y"
+              ; success_count = 0
+              ; failure_count = 0
+              ; confidence = 0.0
+              ; last_used = 0.0
+              ; metadata = []
+              };
+            Memory.forget_procedure mem "pr1";
+            let fresh = Memory.create ~procedural:backend () in
+            Alcotest.(check bool)
+              "backend removed"
+              true
+              (Memory.best_procedure fresh ~pattern:"x" = None))
         ] )
     ; ( "stats"
       , [ Alcotest.test_case "procedural count in stats" `Quick (fun () ->


### PR DESCRIPTION
## Summary
- add optional episodic/procedural Memory backends and route store/recall/query/forget/stats through backend plus hot context cache
- expose file-backed episodic/procedural adapters so fresh Memory.t instances can recover episodes and learned procedures
- add regression coverage for fresh-instance recall, persisted boost/record updates, forget, and file-backed persistence

## Tests
- opam exec -- ocamlformat --check lib/memory.ml lib/memory.mli lib/memory_file_backend.ml lib/memory_file_backend.mli test/test_memory_episodic.ml test/test_memory_procedural.ml test/test_memory_file_backend.ml
- env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_memory_episodic.exe test/test_memory_procedural.exe test/test_memory_file_backend.exe test/test_memory.exe test/test_memory_access.exe test/test_memory_tools.exe test/test_memory_advanced.exe test/test_memory_coverage.exe test/test_memory_lt_backend.exe test/test_memory_tools_parse.exe
- ./_build/default/test/test_memory_episodic.exe
- ./_build/default/test/test_memory_procedural.exe
- ./_build/default/test/test_memory_file_backend.exe
- ./_build/default/test/test_memory.exe
- ./_build/default/test/test_memory_access.exe
- ./_build/default/test/test_memory_tools.exe
- ./_build/default/test/test_memory_advanced.exe
- ./_build/default/test/test_memory_coverage.exe
- ./_build/default/test/test_memory_lt_backend.exe
- ./_build/default/test/test_memory_tools_parse.exe

Notes: reinforces DD-006/DD-027 persistence gaps for episodic/procedural memory.