### PR TITLE
fix(cascade): gate provider attempts with throttle

### DIFF
--- a/lib/llm_provider/complete_cascade.ml
+++ b/lib/llm_provider/complete_cascade.ml
@@ -78,6 +78,47 @@ let provider_key (config : Provider_config.t) =
   Printf.sprintf "%s@%s" config.Provider_config.model_id config.Provider_config.base_url
 ;;
 
+let throttle_key (config : Provider_config.t) =
+  let account_key =
+    if String.equal config.Provider_config.api_key ""
+    then "no-key"
+    else Digest.(config.Provider_config.api_key |> string |> to_hex)
+  in
+  Printf.sprintf
+    "%s@%s#%s"
+    (Provider_config.string_of_provider_kind config.kind)
+    config.Provider_config.base_url
+    account_key
+;;
+
+let default_throttles : (string, Provider_throttle.t) Hashtbl.t = Hashtbl.create 16
+
+(* The fallback throttle table is a global pure Hashtbl that tests may touch
+   outside [Eio_main.run]; Stdlib [Mutex] is sufficient here. *)
+let default_throttles_mu = Mutex.create ()
+
+let with_default_throttles_lock f =
+  Mutex.lock default_throttles_mu;
+  match f () with
+  | value ->
+    Mutex.unlock default_throttles_mu;
+    value
+  | exception exn ->
+    Mutex.unlock default_throttles_mu;
+    raise exn
+;;
+
+let default_throttle_resolver config =
+  let key = throttle_key config in
+  with_default_throttles_lock (fun () ->
+    match Hashtbl.find_opt default_throttles key with
+    | Some throttle -> Some throttle
+    | None ->
+      let throttle = Provider_throttle.default_for_kind config.Provider_config.kind in
+      Hashtbl.add default_throttles key throttle;
+      Some throttle)
+;;
+
 let with_mutex health f =
   (* Avoid [use_rw ~protect:true] here: health snapshots are also used by
      pure tests/callers outside an Eio cancellation context.  The protected
@@ -498,6 +539,8 @@ let complete_cascade
       ?attempt_timeout_s
       ?(cascade_config = default_cascade_config)
       ?(health = create_health ~clock ())
+      ?(priority = Request_priority.default)
+      ?(throttle_resolver = default_throttle_resolver)
       ~steps
       ~messages
       ?tools
@@ -545,10 +588,17 @@ let complete_cascade
             ?cache
             ?metrics
             ?retry_config
+            ~priority
             ~config
             ~messages
             ?tools
             ()
+        in
+        let throttled_attempt () =
+          match throttle_resolver config with
+          | None -> attempt ()
+          | Some throttle ->
+            Provider_throttle.with_permit_priority ~priority throttle attempt
         in
         let result =
           (* Sentinel: [Some t] with [t <= 0.0] disables the cascade-level
@@ -563,9 +613,9 @@ let complete_cascade
             | None -> Provider_config.default_attempt_timeout_s config.kind
           in
           match timeout_s with
-          | None -> attempt ()
+          | None -> throttled_attempt ()
           | Some timeout_s ->
-            (try Eio.Time.with_timeout_exn clock timeout_s attempt with
+            (try Eio.Time.with_timeout_exn clock timeout_s throttled_attempt with
              | Eio.Time.Timeout ->
                Error
                  (attempt_timeout_error

--- a/lib/llm_provider/complete_cascade.mli
+++ b/lib/llm_provider/complete_cascade.mli
@@ -205,7 +205,14 @@ type cascade_result =
       default is too aggressive.
 
     When [health] is [None], a fresh tracker is created per call.
-    Pass a shared tracker to maintain circuit state across calls. *)
+    Pass a shared tracker to maintain circuit state across calls.
+
+    [?throttle_resolver] maps each provider config to the shared
+    provider-level throttle that gates the attempt. The default resolver
+    creates one fallback throttle per provider kind/base URL/account key, so
+    concurrent cascade calls in this process queue before reaching the backend
+    instead of stampeding a limited-capacity provider. Return [None] from a
+    custom resolver to opt a config out of throttling. *)
 val complete_cascade
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
@@ -217,6 +224,8 @@ val complete_cascade
   -> ?attempt_timeout_s:float
   -> ?cascade_config:cascade_config
   -> ?health:provider_health
+  -> ?priority:Request_priority.t
+  -> ?throttle_resolver:(Provider_config.t -> Provider_throttle.t option)
   -> steps:Provider_config.t list
   -> messages:Types.message list
   -> ?tools:Yojson.Safe.t list

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -40,6 +40,18 @@ let dummy_response =
     }
 ;;
 
+let update_atomic_max cell candidate =
+  let rec loop () =
+    let current = Atomic.get cell in
+    if candidate <= current
+    then ()
+    else if Atomic.compare_and_set cell current candidate
+    then ()
+    else loop ()
+  in
+  loop ()
+;;
+
 (* ── provider_key ────────────────────────────────────── *)
 
 let test_provider_key () =
@@ -846,6 +858,60 @@ let test_provider_terminal_stops_without_calling_fallback () =
   | _ -> fail "expected Provider_terminal without fallback"
 ;;
 
+let test_provider_throttle_serializes_concurrent_steps () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let config =
+    Provider_config.make
+      ~kind:Ollama
+      ~model_id:"llama3"
+      ~base_url:"http://localhost:11434"
+      ()
+  in
+  let throttle = Provider_throttle.create ~max_concurrent:1 ~provider_name:"local" in
+  let active_calls = Atomic.make 0 in
+  let max_active_calls = Atomic.make 0 in
+  let total_calls = Atomic.make 0 in
+  let transport : Llm_transport.t =
+    { complete_sync =
+        (fun _ ->
+          Atomic.incr total_calls;
+          let active_now = Atomic.fetch_and_add active_calls 1 + 1 in
+          update_atomic_max max_active_calls active_now;
+          Eio.Time.sleep clock 0.05;
+          Atomic.decr active_calls;
+          { Llm_transport.response = Ok dummy_response; latency_ms = Some 50 })
+    ; complete_stream =
+        (fun ?on_telemetry:_ ~on_event:_ _ -> fail "test uses sync completion only")
+    }
+  in
+  let run_one () =
+    match
+      Complete_cascade.complete_cascade
+        ~sw
+        ~net:(Eio.Stdenv.net env)
+        ~clock
+        ~transport
+        ~throttle_resolver:(fun _ -> Some throttle)
+        ~steps:[ config ]
+        ~messages:[]
+        ()
+    with
+    | Complete_cascade.Success _ -> ()
+    | _ -> fail "expected throttled cascade success"
+  in
+  Eio.Fiber.both run_one run_one;
+  check int "both attempts ran" 2 (Atomic.get total_calls);
+  check
+    int
+    "transport concurrency capped by provider throttle"
+    1
+    (Atomic.get max_active_calls)
+;;
+
 let test_attempt_timeout_fast_paths_without_retrying_same_step () =
   Eio_main.run
   @@ fun env ->
@@ -1089,6 +1155,9 @@ let suite =
   ; ( "provider_terminal_stops_without_fallback"
     , `Quick
     , test_provider_terminal_stops_without_calling_fallback )
+  ; ( "provider_throttle_serializes_concurrent_steps"
+    , `Quick
+    , test_provider_throttle_serializes_concurrent_steps )
   ; ( "attempt_timeout_fast_path"
     , `Quick
     , test_attempt_timeout_fast_paths_without_retrying_same_step )


### PR DESCRIPTION
## Summary
- gate Complete_cascade provider attempts with shared Provider_throttle permits
- add a default fallback throttle table keyed by provider kind/base URL/account key
- add a concurrent cascade regression test proving transport calls are serialized by an injected max_concurrent=1 throttle

## Tests
- opam exec -- ocamlformat --check lib/llm_provider/complete_cascade.ml lib/llm_provider/complete_cascade.mli test/test_complete_cascade.ml
- env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_complete_cascade.exe
- ./_build/default/test/test_complete_cascade.exe