### PR TITLE
fix(agent): narrow runtime MCP per turn

### DIFF
--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -77,6 +77,7 @@ type turn_preparation =
   ; effective_messages : message list
   ; effective_guardrails : Guardrails.t
   ; visible_tool_names : string list
+  ; runtime_mcp_policy : Llm_provider.Llm_transport.runtime_mcp_policy option
   }
 
 (* ── Extract last user text from messages (for Tool_selector context) ── *)
@@ -369,7 +370,12 @@ let prepare_turn
   let effective_messages =
     prepare_messages ?config ~messages ~context_reducer ~tiered_memory ~turn_params ()
   in
-  { tools_json; effective_messages; effective_guardrails; visible_tool_names }
+  { tools_json
+  ; effective_messages
+  ; effective_guardrails
+  ; visible_tool_names
+  ; runtime_mcp_policy = None
+  }
 ;;
 
 (* ── Usage accumulation ───────────────────────────────────────── *)

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -76,6 +76,16 @@ type turn_preparation =
         order from [Tool_set.to_list].
 
         @since 0.162.0 *)
+  ; runtime_mcp_policy : Llm_provider.Llm_transport.runtime_mcp_policy option
+    (** Request-scoped runtime MCP policy for this prepared turn.
+
+        This is narrowed by the same effective guardrails that produced
+        [visible_tool_names] before dispatch. A raw agent-level policy must not
+        be used directly after per-turn [tool_filter_override], or CLI runtime
+        MCP tools can remain broader than [TurnReady] and inline tool
+        visibility claim.
+
+        @since 0.194.1 *)
   }
 
 (** Prepare tool schemas, applying operator policy and optional

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -153,9 +153,9 @@ let turn_ready_tool_names_from_policy ?runtime_mcp_policy visible_tool_names =
   dedupe_preserve_order (visible_tool_names @ runtime_tool_names)
 ;;
 
-let turn_ready_tool_names agent (prep : Agent_turn.turn_preparation) =
+let turn_ready_tool_names (prep : Agent_turn.turn_preparation) =
   turn_ready_tool_names_from_policy
-    ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+    ?runtime_mcp_policy:prep.runtime_mcp_policy
     prep.visible_tool_names
 ;;
 
@@ -167,6 +167,48 @@ let%test "turn_ready_tool_names includes runtime MCP policy names" =
   in
   turn_ready_tool_names_from_policy ~runtime_mcp_policy [ "inline_tool" ]
   = [ "inline_tool"; "status_tool"; "shell_tool" ]
+;;
+
+let filter_runtime_tool_names tool_filter names =
+  match tool_filter with
+  | Guardrails.AllowAll -> names
+  | AllowList allowed -> List.filter (fun name -> List.mem name allowed) names
+  | DenyList denied -> List.filter (fun name -> not (List.mem name denied)) names
+  | Custom _ -> []
+;;
+
+let narrow_runtime_mcp_policy_for_turn
+      (guardrails : Guardrails.t)
+      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
+  =
+  { policy with
+    allowed_tool_names =
+      filter_runtime_tool_names guardrails.tool_filter policy.allowed_tool_names
+  }
+;;
+
+let runtime_mcp_policy_for_prepared_turn
+      runtime_mcp_policy
+      (prep : Agent_turn.turn_preparation)
+  =
+  runtime_mcp_policy
+  |> Option.map (narrow_runtime_mcp_policy_for_turn prep.effective_guardrails)
+;;
+
+let%test "runtime MCP policy is narrowed by AllowList guardrails" =
+  let policy =
+    { Llm_provider.Llm_transport.empty_runtime_mcp_policy with
+      allowed_tool_names = [ "status_tool"; "shell_tool"; "board_tool" ]
+    }
+  in
+  let narrowed =
+    narrow_runtime_mcp_policy_for_turn
+      { Guardrails.permissive with
+        tool_filter = Guardrails.AllowList [ "status_tool"; "board_tool" ]
+      }
+      policy
+  in
+  narrowed.allowed_tool_names = [ "status_tool"; "board_tool" ]
 ;;
 
 let stage_parse ?raw_trace_run agent =
@@ -252,7 +294,11 @@ let stage_parse ?raw_trace_run agent =
        (Turn_started { turn = agent.state.turn_count; timestamp = Unix.gettimeofday () })
    | None -> ());
   let prep = prepare_turn_for_agent agent ~turn_params in
-  let ready_tool_names = turn_ready_tool_names agent prep in
+  let runtime_mcp_policy =
+    runtime_mcp_policy_for_prepared_turn agent.options.runtime_mcp_policy prep
+  in
+  let prep = { prep with runtime_mcp_policy } in
+  let ready_tool_names = turn_ready_tool_names prep in
   (* TurnReady event — emitted after guardrails + operator policy +
      tool_filter_override + tool_selector have produced the final tool
      list the LLM will see this turn. CLI runtime-MCP tools are included

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -63,7 +63,7 @@ let dispatch_sync
         ~config:pc
         ~messages:prep.Agent_turn.effective_messages
         ~tools
-        ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+        ?runtime_mcp_policy:prep.Agent_turn.runtime_mcp_policy
         ~trace_context
         ?priority:agent.options.priority
         ()
@@ -75,7 +75,7 @@ let dispatch_sync
         ~config:pc
         ~messages:prep.Agent_turn.effective_messages
         ~tools
-        ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+        ?runtime_mcp_policy:prep.Agent_turn.runtime_mcp_policy
         ~trace_context
         ?priority:agent.options.priority
         ()
@@ -113,7 +113,7 @@ let dispatch_stream
       ~config:pc
       ~messages:prep.Agent_turn.effective_messages
       ~tools
-      ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+      ?runtime_mcp_policy:prep.Agent_turn.runtime_mcp_policy
       ~trace_context
       ~on_event
       ?on_telemetry

--- a/lib/pipeline/stage_route.ml
+++ b/lib/pipeline/stage_route.ml
@@ -77,7 +77,7 @@ let dispatch_sync ~sw ?clock ?(trace_context = []) agent prep =
         ~config:pc
         ~messages:prep.effective_messages
         ~tools
-        ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+        ?runtime_mcp_policy:prep.runtime_mcp_policy
         ~trace_context
         ?priority:agent.options.priority
         ()
@@ -89,7 +89,7 @@ let dispatch_sync ~sw ?clock ?(trace_context = []) agent prep =
         ~config:pc
         ~messages:prep.effective_messages
         ~tools
-        ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+        ?runtime_mcp_policy:prep.runtime_mcp_policy
         ~trace_context
         ?priority:agent.options.priority
         ()
@@ -118,7 +118,7 @@ let dispatch_stream ~sw ?clock ?(trace_context = []) agent prep ~on_event ?on_te
       ~config:pc
       ~messages:prep.effective_messages
       ~tools
-      ?runtime_mcp_policy:agent.options.runtime_mcp_policy
+      ?runtime_mcp_policy:prep.runtime_mcp_policy
       ~trace_context
       ~on_event
       ?on_telemetry

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -806,6 +806,70 @@ let test_prepare_turn_tool_filter_override () =
   | None -> Alcotest.fail "expected some tools"
 ;;
 
+let test_stage_parse_narrows_runtime_mcp_policy () =
+  Eio_main.run
+  @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  Eio.Switch.run
+  @@ fun sw ->
+  let captured_runtime_mcp_policy = ref None in
+  let transport =
+    { Llm_provider.Llm_transport.complete_sync =
+        (fun req ->
+          captured_runtime_mcp_policy := req.runtime_mcp_policy;
+          { Llm_provider.Llm_transport.response = Ok (Provider_mock.text_response "ok" [])
+          ; latency_ms = Some 0
+          })
+    ; complete_stream =
+        (fun ?on_telemetry:_ ~on_event:_ req ->
+          captured_runtime_mcp_policy := req.runtime_mcp_policy;
+          Ok (Provider_mock.text_response "ok" []))
+    }
+  in
+  let runtime_mcp_policy =
+    { Llm_provider.Llm_transport.empty_runtime_mcp_policy with
+      allowed_tool_names = [ "allowed"; "blocked" ]
+    }
+  in
+  let hooks =
+    { Hooks.empty with
+      before_turn_params =
+        Some
+          (fun _ ->
+            Hooks.AdjustParams
+              { Hooks.default_turn_params with
+                tool_filter_override = Some (AllowList [ "allowed" ])
+              })
+    }
+  in
+  let options =
+    { Agent.default_options with
+      hooks
+    ; guardrails = Guardrails.permissive
+    ; runtime_mcp_policy = Some runtime_mcp_policy
+    ; transport = Some transport
+    ; provider = Some (Provider_mock.to_provider_config ())
+    }
+  in
+  let agent =
+    Agent.create
+      ~net
+      ~config:{ Types.default_config with name = "runtime-mcp-filter-test" }
+      ~options
+      ()
+  in
+  (match Agent.run ~sw agent "hello" with
+   | Ok _ -> ()
+   | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err));
+  match !captured_runtime_mcp_policy with
+  | Some policy ->
+    Alcotest.(check (list string))
+      "runtime MCP tools narrowed"
+      [ "allowed" ]
+      policy.allowed_tool_names
+  | None -> Alcotest.fail "expected runtime MCP policy"
+;;
+
 (* ── Error_domain: tag_error ─────────────────────────────── *)
 
 let test_error_domain_of_sdk_error () =
@@ -1013,6 +1077,10 @@ let () =
             "tool filter override"
             `Quick
             test_prepare_turn_tool_filter_override
+        ; Alcotest.test_case
+            "runtime MCP filter override"
+            `Quick
+            test_stage_parse_narrows_runtime_mcp_policy
         ] )
     ; ( "guardrails"
       , [ Alcotest.test_case "allow all" `Quick test_guardrails_allow_all


### PR DESCRIPTION
## Summary
- carry request-scoped runtime MCP policy on turn preparation
- narrow runtime MCP allowed tool names with the effective per-turn guardrails before TurnReady and provider dispatch
- add a regression that captures the runtime MCP policy sent to a mock transport after tool_filter_override

## Verification
- opam exec -- ocamlformat --check lib/agent/agent_turn.ml lib/agent/agent_turn.mli lib/pipeline/pipeline_stage_prepare.ml lib/pipeline/pipeline_stage_route.ml lib/pipeline/stage_route.ml test/test_pipeline.ml
- git diff --check
- scripts/dune-local.sh build test/test_pipeline.exe
- ./_build/default/test/test_pipeline.exe