### PR TITLE
fix(paths): replace assert false with invalid_arg, document MCP env var

### DIFF
--- a/lib/protocol/mcp_http.ml
+++ b/lib/protocol/mcp_http.ml
@@ -7,7 +7,10 @@ type config =
   }
 
 let default_config =
-  { base_url = Defaults.env_or "http://localhost:8080/mcp" "OAS_MCP_HTTP_URL"
+  { base_url =
+      Defaults.env_or "http://localhost:8080/mcp" "OAS_MCP_HTTP_URL"
+      (* Set OAS_MCP_HTTP_URL to override the MCP server endpoint.
+         Default assumes local dev server on port 8080. *)
   ; headers = []
   }
 ;;

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -820,13 +820,16 @@ let provider_config_of_agent
             match p.provider with
             | Anthropic -> Anthropic
             | Local _ | OpenAICompat _ -> OpenAI_compat
-            | Custom_registered _ -> assert false
+            | Custom_registered _ ->
+              invalid_arg "provider kind: Custom_registered excluded by outer match"
           in
           let sanitized_api_key =
             match p.provider with
             | Local _ -> ""
             | Anthropic | OpenAICompat _ -> api_key
-            | Custom_registered _ -> assert false
+            | Custom_registered _ ->
+              invalid_arg
+                "provider sanitized_api_key: Custom_registered excluded by outer match"
           in
           build
             ~kind


### PR DESCRIPTION
## Summary

- Replace `assert false` with `invalid_arg` + diagnostic message in `provider.ml` exhaustiveness guards (structurally unreachable but provides clear diagnostic if outer match is refactored)
- Add env var override comment to `mcp_http.ml` default_config (`OAS_MCP_HTTP_URL`)

## Audit findings addressed
A2 (`assert false` → `invalid_arg`), U5 (MCP HTTP env var comment)

## Pre-existing CI failures (NOT caused by this PR)
- **Build & Test / Lint**: `pipeline.ml:203` — `Pipeline_stage_prepare.turn_ready_tool_names` applied to too many arguments (type error in main)
- **SDK Independence Gate**: `board_tool` references in `pipeline_stage_prepare.ml` — pre-existing coordinator-specific terms
- **Draft Auto-Merge Guard**: Expected fail for Draft PR

## Test plan
- [x] `dune build @check` passes (lib/ type check clean)
- [x] OCaml Format passes
- [ ] Build & Test — blocked by pre-existing `pipeline.ml:203` type error
- [ ] Lint — same pre-existing type error

🤖 Generated with Claude Code