### PR TITLE
fix(pipeline): drop unused agent arg from turn_ready_tool_names callers (follow-up #1596)

### DIFF
--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -200,7 +200,7 @@ let tool_name_visible visible_tool_names name =
 
 let validate_requested_tool_choice_visibility agent (prep : Agent_turn.turn_preparation) =
   let resolved = requested_completion_contract agent in
-  let visible_tool_names = Pipeline_stage_prepare.turn_ready_tool_names agent prep in
+  let visible_tool_names = Pipeline_stage_prepare.turn_ready_tool_names prep in
   match resolved.effective with
   | Completion_contract.Require_tool_use when visible_tool_names = [] ->
     Error
@@ -1185,7 +1185,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
        Promote recoverable Text blocks to ToolUse before contract
        validation so the pipeline proceeds normally.
        Ref: Samchon harness Layer 1 (dev.to/samchon, Qwen 2025). *)
-       let valid_tool_names = Pipeline_stage_prepare.turn_ready_tool_names agent prep in
+       let valid_tool_names = Pipeline_stage_prepare.turn_ready_tool_names prep in
        let response = Tool_use_recovery.recover_response ~valid_tool_names raw_response in
        let* missing_tool_action =
          handle_missing_required_tool_use


### PR DESCRIPTION
## Summary

- Drop the unused `agent` argument from the two `Pipeline_stage_prepare.turn_ready_tool_names` callers in `lib/pipeline/pipeline.ml` (lines 203 and 1188).

## Why — main is currently un-buildable

#1596 (`fix(agent): narrow runtime mcp per turn`) narrowed the signature of
`turn_ready_tool_names` from `agent -> turn_preparation -> _` to just
`turn_preparation -> _`, sourcing `runtime_mcp_policy` from `prep` instead of
`agent.options.runtime_mcp_policy`. The internal caller in
`pipeline_stage_prepare.ml:301` was updated in the same PR, but the two
external callers in `pipeline.ml` were missed.

```
File "lib/pipeline/pipeline.ml", line 203, characters 27-82:
Error: The function Pipeline_stage_prepare.turn_ready_tool_names has type
       Agent_turn.turn_preparation -> string list
       It is applied to too many arguments
File "lib/pipeline/pipeline.ml", line 203, characters 78-82:
```

The same shape repeats at `pipeline.ml:1188`. With `agent` removed from the
function signature, both call sites now fail typeck and break every consumer
that pulls in `agent_sdk`.

## Behavior

The fix is purely the dropped argument — both call sites end up taking
`runtime_mcp_policy` from `prep` instead of `agent.options.runtime_mcp_policy`,
which is the intended semantics from #1596 ("narrow runtime mcp per turn").

`requested_completion_contract agent` in
`validate_requested_tool_choice_visibility` still uses `agent`, so no other
argument needs touching.

## Evidence

```
$ ./scripts/dune-local.sh build @check
... (will fill from monitor output) ...
```

## Diff shape

```
lib/pipeline/pipeline.ml | 4 ++--
1 file changed, 2 insertions(+), 2 deletions(-)
```

## Linked

- Follows up #1596 (caller-update gap)
- Unblocks #1598 (opam sync) and the lazy-tool-lookup-index PR currently in flight
