### PR TITLE
fix(tools): enforce shell descriptor constraints

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -229,6 +229,28 @@ let find_and_execute_tool_with_index
   let result =
     match tool_opt with
     | Some tool ->
+      let validation_error_result message =
+        { tool_use_id = id
+        ; tool_name = name
+        ; content = message
+        ; is_error = true
+        ; failure_kind = Some Validation_error
+        ; error_class = Some Types.Deterministic
+        }
+      in
+      let emit_post_tool_use_failure ~input message =
+        ignore
+          (invoke_hook
+             ?on_hook_invoked
+             ~tracer
+             ~agent_name
+             ~turn_count
+             ~hook_name:"post_tool_use_failure"
+             hooks.post_tool_use_failure
+             (Hooks.PostToolUseFailure
+                { tool_use_id = id; tool_name = name; input; error = message; schedule })
+           : Hooks.hook_decision)
+      in
       (* Multi-stage deterministic correction before execution.
        Correction_pipeline runs 3 stages (type coercion, default injection,
        format normalization) then validates. If det correction fixes the
@@ -255,105 +277,104 @@ let find_and_execute_tool_with_index
               ~still_invalid:errors
               ~attempted
           in
-          ignore
-            (invoke_hook
-               ?on_hook_invoked
-               ~tracer
-               ~agent_name
-               ~turn_count
-               ~hook_name:"post_tool_use_failure"
-               hooks.post_tool_use_failure
-               (Hooks.PostToolUseFailure
-                  { tool_use_id = id; tool_name = name; input; error = message; schedule })
-             : Hooks.hook_decision);
+          emit_post_tool_use_failure ~input message;
           Error message
       in
       (match validated_input with
-       | Error msg ->
-         { tool_use_id = id
-         ; tool_name = name
-         ; content = msg
-         ; is_error = true
-         ; failure_kind = Some Validation_error
-         ; error_class = Some Types.Deterministic
-         }
+       | Error msg -> validation_error_result msg
        | Ok coerced_input ->
-         let t0 = Unix.gettimeofday () in
-         let result = Tool.execute ~context tool coerced_input in
-         let duration_ms = (Unix.gettimeofday () -. t0) *. 1000.0 in
-         let result_bytes =
-           match result with
-           | Ok { content } -> String.length content
-           | Error { message; _ } -> String.length message
+         let shell_constraint_result =
+           match Tool.descriptor tool with
+           | None -> Tool_middleware.Pass
+           | Some descriptor ->
+             Tool_middleware.validate_shell_constraints
+               ~tool_name:name
+               ~descriptor
+               coerced_input
          in
-         let _post =
-           invoke_hook
-             ?on_hook_invoked
-             ~tracer
-             ~agent_name
-             ~turn_count
-             ~hook_name:"post_tool_use"
-             hooks.post_tool_use
-             (Hooks.PostToolUse
-                { tool_use_id = id
-                ; tool_name = name
-                ; input = coerced_input
-                ; output = result
-                ; result_bytes
-                ; duration_ms
-                ; schedule
-                })
-         in
-         (match result with
-          | Error { message; _ } ->
-            ignore
-              (invoke_hook
-                 ?on_hook_invoked
-                 ~tracer
-                 ~agent_name
-                 ~turn_count
-                 ~hook_name:"post_tool_use_failure"
-                 hooks.post_tool_use_failure
-                 (Hooks.PostToolUseFailure
-                    { tool_use_id = id
-                    ; tool_name = name
-                    ; input = coerced_input
-                    ; error = message
-                    ; schedule
-                    })
-               : Hooks.hook_decision);
-            (* OnToolError: minimal tool-name/error event for consumers that
+         (match shell_constraint_result with
+          | Tool_middleware.Reject { message; _ } ->
+            emit_post_tool_use_failure ~input:coerced_input message;
+            validation_error_result message
+          | Tool_middleware.Pass | Tool_middleware.Proceed _ ->
+            let t0 = Unix.gettimeofday () in
+            let result = Tool.execute ~context tool coerced_input in
+            let duration_ms = (Unix.gettimeofday () -. t0) *. 1000.0 in
+            let result_bytes =
+              match result with
+              | Ok { content } -> String.length content
+              | Error { message; _ } -> String.length message
+            in
+            let _post =
+              invoke_hook
+                ?on_hook_invoked
+                ~tracer
+                ~agent_name
+                ~turn_count
+                ~hook_name:"post_tool_use"
+                hooks.post_tool_use
+                (Hooks.PostToolUse
+                   { tool_use_id = id
+                   ; tool_name = name
+                   ; input = coerced_input
+                   ; output = result
+                   ; result_bytes
+                   ; duration_ms
+                   ; schedule
+                   })
+            in
+            (match result with
+             | Error { message; _ } ->
+               ignore
+                 (invoke_hook
+                    ?on_hook_invoked
+                    ~tracer
+                    ~agent_name
+                    ~turn_count
+                    ~hook_name:"post_tool_use_failure"
+                    hooks.post_tool_use_failure
+                    (Hooks.PostToolUseFailure
+                       { tool_use_id = id
+                       ; tool_name = name
+                       ; input = coerced_input
+                       ; error = message
+                       ; schedule
+                       })
+                  : Hooks.hook_decision);
+               (* OnToolError: minimal tool-name/error event for consumers that
             don't need the PostToolUseFailure context (tool_use_id,
             schedule). Previously the hook type existed but had no emit
             site — registering [on_tool_error] was a silent no-op (#1029). *)
-            ignore
-              (invoke_hook
-                 ?on_hook_invoked
-                 ~tracer
-                 ~agent_name
-                 ~turn_count
-                 ~hook_name:"on_tool_error"
-                 hooks.on_tool_error
-                 (Hooks.OnToolError { tool_name = name; error = message })
-               : Hooks.hook_decision)
-          | Ok _ -> ());
-         let content, is_error, failure_kind, error_class =
-           match result with
-           | Ok { content } -> content, false, None, None
-           | Error { message; recoverable; error_class } ->
-             let failure_kind =
-               Some
-                 (if recoverable then Recoverable_tool_error else Non_retryable_tool_error)
-             in
-             message, true, failure_kind, error_class
-         in
-         { tool_use_id = id
-         ; tool_name = name
-         ; content
-         ; is_error
-         ; failure_kind
-         ; error_class
-         })
+               ignore
+                 (invoke_hook
+                    ?on_hook_invoked
+                    ~tracer
+                    ~agent_name
+                    ~turn_count
+                    ~hook_name:"on_tool_error"
+                    hooks.on_tool_error
+                    (Hooks.OnToolError { tool_name = name; error = message })
+                  : Hooks.hook_decision)
+             | Ok _ -> ());
+            let content, is_error, failure_kind, error_class =
+              match result with
+              | Ok { content } -> content, false, None, None
+              | Error { message; recoverable; error_class } ->
+                let failure_kind =
+                  Some
+                    (if recoverable
+                     then Recoverable_tool_error
+                     else Non_retryable_tool_error)
+                in
+                message, true, failure_kind, error_class
+            in
+            { tool_use_id = id
+            ; tool_name = name
+            ; content
+            ; is_error
+            ; failure_kind
+            ; error_class
+            }))
       (* Tool_middleware validation match *)
     | None ->
       (* Tool dispatch failure (the LLM asked for a tool that isn't

--- a/lib/tool_middleware.ml
+++ b/lib/tool_middleware.ml
@@ -26,6 +26,97 @@ let validate_and_coerce ~tool_name ~(schema : Types.tool_schema) args =
       Reject { is_error = true; message })
 ;;
 
+(* -- Descriptor shell constraints --------------------------------------- *)
+
+let contains_substring s needle =
+  let s_len = String.length s in
+  let needle_len = String.length needle in
+  let rec loop i =
+    if needle_len = 0
+    then true
+    else if i + needle_len > s_len
+    then false
+    else if String.sub s i needle_len = needle
+    then true
+    else loop (i + 1)
+  in
+  loop 0
+;;
+
+let extract_shell_command_arg = function
+  | `Assoc fields ->
+    List.find_map
+      (fun name ->
+         match List.assoc_opt name fields with
+         | Some (`String value) -> Some value
+         | _ -> None)
+      [ "command"; "cmd" ]
+  | _ -> None
+;;
+
+let has_dangerous_ampersand cmd =
+  let len = String.length cmd in
+  let rec loop i =
+    if i >= len
+    then false
+    else if cmd.[i] <> '&'
+    then loop (i + 1)
+    else if i > 0 && cmd.[i - 1] = '>'
+    then loop (i + 1)
+    else true
+  in
+  loop 0
+;;
+
+let has_chaining cmd =
+  contains_substring cmd "&&"
+  || contains_substring cmd "||"
+  || String.exists
+       (function
+         | ';' | '\n' | '\r' -> true
+         | _ -> false)
+       cmd
+  || has_dangerous_ampersand cmd
+;;
+
+let has_redirection cmd =
+  String.exists
+    (function
+      | '<' | '>' -> true
+      | _ -> false)
+    cmd
+;;
+
+let has_command_substitution cmd =
+  contains_substring cmd "$("
+  || contains_substring cmd "`"
+  || contains_substring cmd "<("
+  || contains_substring cmd ">("
+;;
+
+let validate_shell_constraints ~tool_name ~(descriptor : Tool.descriptor) args =
+  match descriptor.shell, extract_shell_command_arg args with
+  | None, _ | Some _, None -> Pass
+  | Some shell, Some command ->
+    let command = String.trim command in
+    let reject reason =
+      Reject
+        { is_error = true
+        ; message =
+            Printf.sprintf "Tool '%s' shell constraint violation: %s" tool_name reason
+        }
+    in
+    if (shell.single_command_only || not shell.chaining_allowed) && has_chaining command
+    then reject "command chaining is not allowed"
+    else if (not shell.pipes_allowed) && String.contains command '|'
+    then reject "pipes are not allowed"
+    else if (not shell.redirection_allowed) && has_redirection command
+    then reject "redirection is not allowed"
+    else if (not shell.shell_metacharacters_allowed) && has_command_substitution command
+    then reject "command substitution is not allowed"
+    else Pass
+;;
+
 (* ── Schema conversion ────────────────────────────────────── *)
 
 let tool_schema_of_json ~name ?(description = "") json_schema : Types.tool_schema =

--- a/lib/tool_middleware.mli
+++ b/lib/tool_middleware.mli
@@ -35,6 +35,18 @@ val validate_and_coerce
   -> Yojson.Safe.t
   -> pre_hook_action
 
+(** Validate a tool input against {!Tool.descriptor.shell} when present.
+
+    The command text is read from a string ["command"] field, falling back to
+    ["cmd"]. Tools without shell constraints, or shell-constrained tools with no
+    command-like field, return {!Pass}; schema validation remains responsible
+    for required-field errors. *)
+val validate_shell_constraints
+  :  tool_name:string
+  -> descriptor:Tool.descriptor
+  -> Yojson.Safe.t
+  -> pre_hook_action
+
 (** {1 Schema conversion}
 
     Convert JSON Schema objects to OAS typed parameter lists.

--- a/test/test_approval.ml
+++ b/test/test_approval.ml
@@ -15,6 +15,40 @@ let descriptor_with ?mutation_class concurrency_class =
   }
 ;;
 
+let shell_descriptor () =
+  { Tool.kind = Some "bash"
+  ; mutation_class = Some "workspace_mutating"
+  ; concurrency_class = Some Tool.Sequential_workspace
+  ; permission = Some Tool.Write
+  ; shell =
+      Some
+        { Tool.single_command_only = true
+        ; shell_metacharacters_allowed = false
+        ; chaining_allowed = false
+        ; redirection_allowed = false
+        ; pipes_allowed = false
+        ; workdir_policy = Some Tool.Recommended
+        }
+  ; notes = []
+  ; examples = []
+  }
+;;
+
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    if needle_len = 0
+    then true
+    else if idx + needle_len > haystack_len
+    then false
+    else if String.sub haystack idx needle_len = needle
+    then true
+    else loop (idx + 1)
+  in
+  loop 0
+;;
+
 (** Helper: create a simple tool that echoes its input as JSON string *)
 let make_echo_tool ?descriptor name =
   Tool.create ?descriptor ~name ~description:"echo" ~parameters:[] (fun input ->
@@ -573,6 +607,47 @@ let test_exclusive_batch_kind_metadata () =
     kinds
 ;;
 
+let test_shell_descriptor_constraint_blocks_execution () =
+  let handler_called = ref false in
+  let shell_tool =
+    Tool.create
+      ~descriptor:(shell_descriptor ())
+      ~name:"shell_exec"
+      ~description:"shell"
+      ~parameters:
+        [ { Types.name = "command"
+          ; param_type = Types.String
+          ; description = "command"
+          ; required = true
+          }
+        ]
+      (fun _ ->
+         handler_called := true;
+         Ok { Types.content = "ran" })
+  in
+  let results =
+    run_execute_with_tools
+      ~tools:[ shell_tool ]
+      ~hooks:Hooks.empty
+      [ ToolUse
+          { id = "t1"
+          ; name = "shell_exec"
+          ; input = `Assoc [ "command", `String "echo $(date)" ]
+          }
+      ]
+  in
+  match results with
+  | [ result ] ->
+    check bool "blocked" true result.is_error;
+    check bool "handler not called" false !handler_called;
+    check
+      bool
+      "constraint message"
+      true
+      (contains_substring ~needle:"shell constraint violation" result.content)
+  | _ -> fail "expected exactly one result"
+;;
+
 let () =
   run
     "Approval"
@@ -613,6 +688,12 @@ let () =
             "exclusive batch_kind metadata (#589)"
             `Quick
             test_exclusive_batch_kind_metadata
+        ] )
+    ; ( "shell_constraints"
+      , [ test_case
+            "descriptor shell constraints block execution"
+            `Quick
+            test_shell_descriptor_constraint_blocks_execution
         ] )
     ]
 ;;

--- a/test/test_tool_middleware.ml
+++ b/test/test_tool_middleware.ml
@@ -19,6 +19,48 @@ let tool_schema name json_schema : Types.tool_schema =
   Tool_middleware.tool_schema_of_json ~name json_schema
 ;;
 
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    if needle_len = 0
+    then true
+    else if idx + needle_len > haystack_len
+    then false
+    else if String.sub haystack idx needle_len = needle
+    then true
+    else loop (idx + 1)
+  in
+  loop 0
+;;
+
+let shell_descriptor
+      ?(single_command_only = true)
+      ?(shell_metacharacters_allowed = false)
+      ?(chaining_allowed = false)
+      ?(redirection_allowed = false)
+      ?(pipes_allowed = false)
+      ()
+  : Tool.descriptor
+  =
+  { kind = Some "bash"
+  ; mutation_class = None
+  ; concurrency_class = None
+  ; permission = None
+  ; shell =
+      Some
+        { single_command_only
+        ; shell_metacharacters_allowed
+        ; chaining_allowed
+        ; redirection_allowed
+        ; pipes_allowed
+        ; workdir_policy = Some Tool.Recommended
+        }
+  ; notes = []
+  ; examples = []
+  }
+;;
+
 (* ── validate_and_coerce ─────────────────────────────────── *)
 
 let test_pass_no_params () =
@@ -163,6 +205,81 @@ let test_hook_rejection () =
   match hook ~name:"strict" ~args with
   | Tool_middleware.Reject _ -> ()
   | _ -> Alcotest.fail "expected Reject"
+;;
+
+(* ── validate_shell_constraints ──────────────────────────── *)
+
+let test_shell_constraints_pass_plain_command () =
+  let descriptor = shell_descriptor () in
+  match
+    Tool_middleware.validate_shell_constraints
+      ~tool_name:"shell_exec"
+      ~descriptor
+      (`Assoc [ "command", `String "git status --short" ])
+  with
+  | Tool_middleware.Pass -> ()
+  | Tool_middleware.Proceed _ -> Alcotest.fail "shell constraints should not coerce"
+  | Tool_middleware.Reject r -> Alcotest.fail r.message
+;;
+
+let test_shell_constraints_reject_command_substitution () =
+  let descriptor = shell_descriptor () in
+  match
+    Tool_middleware.validate_shell_constraints
+      ~tool_name:"shell_exec"
+      ~descriptor
+      (`Assoc [ "cmd", `String "echo $(date)" ])
+  with
+  | Tool_middleware.Reject r ->
+    Alcotest.(check bool)
+      "mentions command substitution"
+      true
+      (contains_substring ~needle:"command substitution" r.message)
+  | Tool_middleware.Pass | Tool_middleware.Proceed _ ->
+    Alcotest.fail "command substitution must be rejected"
+;;
+
+let test_shell_constraints_reject_pipe_when_disabled () =
+  let descriptor = shell_descriptor ~pipes_allowed:false () in
+  match
+    Tool_middleware.validate_shell_constraints
+      ~tool_name:"shell_exec"
+      ~descriptor
+      (`Assoc [ "command", `String "rg foo | wc -l" ])
+  with
+  | Tool_middleware.Reject r ->
+    Alcotest.(check bool)
+      "mentions pipes"
+      true
+      (contains_substring ~needle:"pipes" r.message)
+  | Tool_middleware.Pass | Tool_middleware.Proceed _ ->
+    Alcotest.fail "pipe must be rejected"
+;;
+
+let test_shell_constraints_allow_fd_redirect_when_enabled () =
+  let descriptor = shell_descriptor ~redirection_allowed:true () in
+  match
+    Tool_middleware.validate_shell_constraints
+      ~tool_name:"shell_exec"
+      ~descriptor
+      (`Assoc [ "command", `String "dune build 2>&1" ])
+  with
+  | Tool_middleware.Pass -> ()
+  | Tool_middleware.Proceed _ -> Alcotest.fail "shell constraints should not coerce"
+  | Tool_middleware.Reject r -> Alcotest.fail r.message
+;;
+
+let test_shell_constraints_no_command_field_passes () =
+  let descriptor = shell_descriptor () in
+  match
+    Tool_middleware.validate_shell_constraints
+      ~tool_name:"shell_exec"
+      ~descriptor
+      (`Assoc [ "path", `String "README.md" ])
+  with
+  | Tool_middleware.Pass -> ()
+  | Tool_middleware.Proceed _ -> Alcotest.fail "shell constraints should not coerce"
+  | Tool_middleware.Reject r -> Alcotest.fail r.message
 ;;
 
 (* ── heal_tool_call ─────────────────────────────────────── *)
@@ -455,6 +572,28 @@ let () =
         ; Alcotest.test_case "valid tool -> Pass" `Quick test_hook_valid_tool
         ; Alcotest.test_case "coercion -> Proceed" `Quick test_hook_coercion
         ; Alcotest.test_case "invalid -> Reject" `Quick test_hook_rejection
+        ] )
+    ; ( "validate_shell_constraints"
+      , [ Alcotest.test_case
+            "plain command passes"
+            `Quick
+            test_shell_constraints_pass_plain_command
+        ; Alcotest.test_case
+            "command substitution rejects"
+            `Quick
+            test_shell_constraints_reject_command_substitution
+        ; Alcotest.test_case
+            "pipe rejects when disabled"
+            `Quick
+            test_shell_constraints_reject_pipe_when_disabled
+        ; Alcotest.test_case
+            "fd redirect allowed when enabled"
+            `Quick
+            test_shell_constraints_allow_fd_redirect_when_enabled
+        ; Alcotest.test_case
+            "missing command-like field passes"
+            `Quick
+            test_shell_constraints_no_command_field_passes
         ] )
     ; ( "heal_tool_call"
       , [ Alcotest.test_case "valid first try" `Quick test_heal_valid_first_try


### PR DESCRIPTION
## Summary

- enforce `Tool.descriptor.shell` constraints centrally in the OAS agent tool execution path
- block command substitution, command chaining, disabled pipes, and disabled redirects before handler execution
- report shell constraint violations as deterministic validation errors through existing failure hooks
- add direct middleware coverage and an execution-level regression test proving the handler is not called
- update stale `Pipeline_stage_prepare.turn_ready_tool_names` callers to match the current signature

## Why

OAS already had shell constraint metadata on tool descriptors, but the runtime only serialized and exposed it. This makes the descriptor operational: tools that declare shell policy now get enforcement before side effects can occur.

## Validation

- `git diff --check origin/main...HEAD`
- `ocamlformat --check lib/pipeline/pipeline.ml lib/agent/agent_tools.ml lib/tool_middleware.ml lib/tool_middleware.mli test/test_approval.ml test/test_tool_middleware.ml`
- `scripts/dune-local.sh build test/test_tool_middleware.exe test/test_approval.exe`
- `./_build/default/test/test_tool_middleware.exe`
- `./_build/default/test/test_approval.exe`
