### PR TITLE
fix(release): automate agent_sdk.opam sync inside release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run release-please
+        id: release
         # Pinned to v4 (latest stable manifest-driven major).
         # NOTE: GITHUB_TOKEN cannot trigger downstream workflows on the
         # release PR. To enable CI on the PR, register a PAT or App token
@@ -27,3 +28,51 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # Fallback safety net for opam metadata drift.
+      #
+      # release-please-config.json registers agent_sdk.opam under extra-files,
+      # but the generic updater has historically failed to apply the version
+      # bump (anchor handling on dune-generated files). This step pulls the
+      # release PR branch, compares agent_sdk.opam version vs the manifest,
+      # and pushes a sync commit if they differ. Idempotent: no-op when the
+      # generic updater already did its job.
+      #
+      # See: 0.193.12 (#1588), 0.193.13 (#1598), 0.193.14 (#1603) — three
+      # consecutive manual sync PRs that this step replaces.
+      - name: Sync opam metadata in release PR
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRS_JSON: ${{ steps.release.outputs.prs }}
+        run: |
+          set -euo pipefail
+          pr_branch=$(echo "$PRS_JSON" | jq -r '.[0].headBranchName // empty')
+          if [ -z "$pr_branch" ]; then
+            echo "no release PR branch in outputs; skipping opam sync"
+            exit 0
+          fi
+          echo "release PR branch: $pr_branch"
+
+          git config --global user.name  'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+          git clone --branch "$pr_branch" --depth 2 \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" repo
+          cd repo
+
+          target_version=$(jq -r '."."' .release-please-manifest.json)
+          current_opam=$(awk -F'"' '/^version: ".+"$/{print $2; exit}' agent_sdk.opam)
+          echo "manifest version: $target_version"
+          echo "opam version:     $current_opam"
+
+          if [ "$current_opam" = "$target_version" ]; then
+            echo "opam already in sync; no action needed"
+            exit 0
+          fi
+
+          sed -i "s/^version: \".*\"\$/version: \"${target_version}\"/" agent_sdk.opam
+          git add agent_sdk.opam
+          git commit -m "chore(release): sync agent_sdk.opam to ${target_version}"
+          git push origin "$pr_branch"
+          echo "pushed opam sync commit to $pr_branch"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,7 +21,7 @@
         {
           "type": "generic",
           "path": "agent_sdk.opam",
-          "pattern": "^version: \"(?<version>\\d+\\.\\d+\\.\\d+)\""
+          "pattern": "\nversion: \"(?<version>\\d+\\.\\d+\\.\\d+)\""
         }
       ]
     }


### PR DESCRIPTION
## Summary

Closes the recurring `agent_sdk.opam` version drift that forced three manual
sync PRs in three consecutive releases (#1588 for 0.193.12, #1598 for 0.193.13,
#1603 for 0.193.14).

Two layered fixes:

1. **`release-please-config.json`** — change the `agent_sdk.opam` extra-files
   pattern from `^`-anchored to `\n`-anchored. release-please 17.x's generic
   updater historically treats `^` as a string-anchor (matching only the first
   character of the file), so opam — which starts with `# This file is
   generated by dune` — never matched. Anchoring on a preceding newline
   guarantees a line-start match while still ruling out the
   `opam-version:` line two lines above the target.

2. **`.github/workflows/release-please.yml`** — add a fallback step that runs
   after `release-please-action`. If a release PR was created
   (`steps.release.outputs.prs_created == 'true'`), it clones the PR branch,
   compares `agent_sdk.opam`'s version against `.release-please-manifest.json`,
   and pushes a sync commit when they diverge. Idempotent — no-op when the
   generic updater already worked.

The fallback is the real safety net; the pattern fix is a best-effort
that becomes free once release-please resumes honoring it.

## Why this is needed

`agent_sdk.opam` is generated by dune (`(generate_opam_files true)` in
`dune-project`). release-please *fetches* it but, due to the anchor handling
above, doesn't *update* it. The result: every release-please cut produces
a PR that bumps `dune-project` and `lib/sdk_version.ml` to the new version
but leaves `agent_sdk.opam` at the prior version. `scripts/release.sh` then
exits at `DUNE_VER != OPAM_VER`, blocking the release-tag step until a
manual sync PR lands.

This pattern repeated three releases in a row — see workflow-rejection
criteria in `CLAUDE.md` ("N-of-M patches → root-fix required, not another
manual patch").

## Verification path

Local syntax checks:

```
$ python3 -c "import json; json.load(open('release-please-config.json'))"   # OK
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-please.yml'))"  # OK
```

Behavioral verification has to happen on the next release-please cut
(no straightforward way to dry-run release-please-action locally). Two
acceptable outcomes:

- **Best case**: the generic updater now respects the new pattern → the
  release PR includes `agent_sdk.opam` in its diff, no fallback commit.
- **Acceptable case**: the generic updater still skips opam → the fallback
  step pushes `chore(release): sync agent_sdk.opam to <version>` to the
  release PR head, visible in the PR's commit list.

Either way the release PR ships with `agent_sdk.opam` already in sync.

## Diff shape

```
.github/workflows/release-please.yml | 49 +++++++++++++++++++++++++++++++++++
release-please-config.json           |  2 +-
2 files changed, 50 insertions(+), 1 deletion(-)
```

## Notes

- The fallback step uses `GITHUB_TOKEN` to push to the release PR branch.
  This works for content writes (already permitted in `permissions: contents: write`)
  but, as the existing comment in the workflow notes, will not trigger
  downstream workflows on the release PR. That trade-off is unchanged.
- `git config --global user.name 'github-actions[bot]'` ensures the sync
  commit is attributed to the bot identity.

## Linked

- Follows up #1588, #1598, #1603 (manual sync PR chain)
- After this lands, the next release-please cut is the verification point.
