### PR TITLE
fix(cascade): stop on TLS and local resource failures

### DIFF
--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -195,14 +195,23 @@ let kimi_message_to_json (msg : message) =
 ;;
 
 (** Create HTTPS upgrade function using tls-eio *)
-let make_https () : (Uri.t -> _ -> _) option =
+type https_init_error =
+  | Ca_certs_unavailable of string
+  | Tls_config_unavailable of string
+
+let https_init_error_to_string = function
+  | Ca_certs_unavailable msg -> "CA certificates unavailable: " ^ msg
+  | Tls_config_unavailable msg -> "TLS client configuration unavailable: " ^ msg
+;;
+
+let make_https_result () : (Uri.t -> _ -> _, https_init_error) result =
   match Ca_certs.authenticator () with
-  | Error _ -> None
+  | Error (`Msg msg) -> Error (Ca_certs_unavailable msg)
   | Ok authenticator ->
     (match Tls.Config.client ~authenticator () with
-     | Error _ -> None
+     | Error (`Msg msg) -> Error (Tls_config_unavailable msg)
      | Ok tls_config ->
-       Some
+       Ok
          (fun uri flow ->
            let host =
              match Uri.host uri with
@@ -213,4 +222,10 @@ let make_https () : (Uri.t -> _ -> _) option =
                 | Ok dn -> Some (Domain_name.host_exn dn))
            in
            Tls_eio.client_of_flow tls_config ?host flow))
+;;
+
+let make_https () =
+  match make_https_result () with
+  | Ok wrap -> Some wrap
+  | Error _ -> None
 ;;

--- a/lib/llm_provider/api_common.mli
+++ b/lib/llm_provider/api_common.mli
@@ -26,6 +26,18 @@ val kimi_message_to_json : Types.message -> Yojson.Safe.t
 
 (** {2 TLS} *)
 
+type https_init_error =
+  | Ca_certs_unavailable of string
+  | Tls_config_unavailable of string
+
+val https_init_error_to_string : https_init_error -> string
+
+val make_https_result
+  :  unit
+  -> ( Uri.t -> [> `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t -> Tls_eio.t
+       , https_init_error )
+       result
+
 val make_https
   :  unit
   -> (Uri.t -> [> `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t -> Tls_eio.t)

--- a/lib/llm_provider/complete_cascade.ml
+++ b/lib/llm_provider/complete_cascade.ml
@@ -526,6 +526,17 @@ let is_hard_quota_http_error = function
   | _ -> false
 ;;
 
+let network_error_stops_cascade = function
+  | Http_client.NetworkError
+      { kind = Http_client.Tls_error | Http_client.Local_resource_exhaustion; _ } -> true
+  | _ -> false
+;;
+
+let provider_failure_counts_for_health = function
+  | Http_client.NetworkError { kind = Http_client.Local_resource_exhaustion; _ } -> false
+  | _ -> true
+;;
+
 (* --- Main cascade execution --- *)
 
 let complete_cascade
@@ -633,10 +644,14 @@ let complete_cascade
         | Error (Http_client.ProviderTerminal { kind; message }) ->
           Provider_terminal { config; kind; message }
         | Error err ->
-          record_failure health key;
+          if provider_failure_counts_for_health err then record_failure health key;
           emit_circuit_state metrics_sink config ~cascade_config ~health ~provider_key:key;
           if is_hard_quota_http_error err
           then Hard_quota { config; error = err }
+          else if network_error_stops_cascade err
+          then
+            All_failed
+              { errors = List.rev ((config, err) :: errors); skipped = List.rev skipped }
           else loop rest (idx + 1) ((config, err) :: errors) skipped)
   in
   loop steps 0 [] []

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -249,7 +249,7 @@ let add_connection_close headers = ("connection", "close") :: headers
     availability can be checked up front and reported as typed errors. *)
 let make_closing_client ~sw ~net ~uri =
   let net = (net :> [ `Generic ] Eio.Net.ty Eio.Resource.t) in
-  let https = Api_common.make_https () in
+  let https = Api_common.make_https_result () in
   let* host =
     match Uri.host uri with
     | Some host when String.trim host <> "" -> Ok host
@@ -290,14 +290,15 @@ let make_closing_client ~sw ~net ~uri =
     match Uri.scheme uri with
     | Some "https" ->
       (match https with
-       | Some wrap -> Ok (Some wrap)
-       | None ->
+       | Ok wrap -> Ok (Some wrap)
+       | Error reason ->
          Error
            (NetworkError
               { message =
                   Printf.sprintf
-                    "HTTPS requested but TLS not available for %s"
+                    "HTTPS requested but TLS not available for %s: %s"
                     (Uri.to_string uri)
+                    (Api_common.https_init_error_to_string reason)
               ; kind = Tls_error
               }))
     | _ -> Ok None

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -61,7 +61,17 @@ let command_candidates ~name =
   if Filename.check_suffix name ".exe" then [ name ] else [ name; name ^ ".exe" ]
 ;;
 
-let is_runnable_path path = Sys.file_exists path && not (Sys.is_directory path)
+let safe_file_exists path =
+  try Sys.file_exists path with
+  | Sys_error _ | Unix.Unix_error _ -> false
+;;
+
+let safe_is_directory path =
+  try Sys.is_directory path with
+  | Sys_error _ | Unix.Unix_error _ -> false
+;;
+
+let is_runnable_path path = safe_file_exists path && not (safe_is_directory path)
 
 let command_in_path ?path name =
   path_entries ?path ()
@@ -86,7 +96,7 @@ let catalog_auth_available (entry : Provider_catalog.entry) =
     has_api_key env
   | Provider_catalog.No_auth -> true
   | Provider_catalog.Cli_cached_login | Provider_catalog.Oauth_cached_login -> true
-  | Provider_catalog.File path -> String.trim path <> "" && Sys.file_exists path
+  | Provider_catalog.File path -> String.trim path <> "" && safe_file_exists path
   | Provider_catalog.Exec command -> String.trim command <> ""
 ;;
 

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -198,17 +198,17 @@ let runtime_mcp_policy_for_prepared_turn
 let%test "runtime MCP policy is narrowed by AllowList guardrails" =
   let policy =
     { Llm_provider.Llm_transport.empty_runtime_mcp_policy with
-      allowed_tool_names = [ "status_tool"; "shell_tool"; "board_tool" ]
+      allowed_tool_names = [ "status_tool"; "shell_tool"; "ledger_tool" ]
     }
   in
   let narrowed =
     narrow_runtime_mcp_policy_for_turn
       { Guardrails.permissive with
-        tool_filter = Guardrails.AllowList [ "status_tool"; "board_tool" ]
+        tool_filter = Guardrails.AllowList [ "status_tool"; "ledger_tool" ]
       }
       policy
   in
-  narrowed.allowed_tool_names = [ "status_tool"; "board_tool" ]
+  narrowed.allowed_tool_names = [ "status_tool"; "ledger_tool" ]
 ;;
 
 let stage_parse ?raw_trace_run agent =

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -858,6 +858,156 @@ let test_provider_terminal_stops_without_calling_fallback () =
   | _ -> fail "expected Provider_terminal without fallback"
 ;;
 
+let test_tls_error_stops_without_calling_fallback () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let primary =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"ollama-cloud"
+      ~base_url:"https://ollama.com/v1"
+      ()
+  in
+  let fallback =
+    Provider_config.make
+      ~kind:Kimi
+      ~model_id:"moonshot-v1"
+      ~base_url:"https://api.moonshot.cn"
+      ()
+  in
+  let health = Complete_cascade.create_health ~clock () in
+  let called_models = ref [] in
+  let tls_error =
+    Http_client.NetworkError
+      { kind = Http_client.Tls_error; message = "invalid certificate chain" }
+  in
+  let transport : Llm_transport.t =
+    { complete_sync =
+        (fun (req : Llm_transport.completion_request) ->
+          called_models := req.config.model_id :: !called_models;
+          let response =
+            if String.equal req.config.model_id primary.model_id
+            then Error tls_error
+            else Ok dummy_response
+          in
+          { Llm_transport.response; latency_ms = Some 25 })
+    ; complete_stream =
+        (fun ?on_telemetry:_ ~on_event:_ (req : Llm_transport.completion_request) ->
+          called_models := req.config.model_id :: !called_models;
+          if String.equal req.config.model_id primary.model_id
+          then Error tls_error
+          else Ok dummy_response)
+    }
+  in
+  let result =
+    Complete_cascade.complete_cascade
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~clock
+      ~transport
+      ~health
+      ~steps:[ primary; fallback ]
+      ~messages:[]
+      ()
+  in
+  check (list string) "only primary provider called" [ primary.model_id ] !called_models;
+  let primary_health =
+    Complete_cascade.provider_health_info
+      health
+      ~cascade_config:Complete_cascade.default_cascade_config
+      ~provider_key:(Complete_cascade.provider_key primary)
+  in
+  check
+    int
+    "TLS failure counts against provider health"
+    1
+    primary_health.consecutive_failures;
+  match result with
+  | Complete_cascade.All_failed { errors = [ (config, error) ]; skipped = [] } ->
+    check string "failed provider" primary.model_id config.model_id;
+    check bool "preserves TLS error" true (error = tls_error)
+  | _ -> fail "expected TLS All_failed without fallback"
+;;
+
+let test_local_resource_error_stops_without_poisoning_provider_health () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let primary =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"ollama-cloud"
+      ~base_url:"https://ollama.com/v1"
+      ()
+  in
+  let fallback =
+    Provider_config.make
+      ~kind:Kimi
+      ~model_id:"moonshot-v1"
+      ~base_url:"https://api.moonshot.cn"
+      ()
+  in
+  let health = Complete_cascade.create_health ~clock () in
+  let called_models = ref [] in
+  let local_error =
+    Http_client.NetworkError
+      { kind = Http_client.Local_resource_exhaustion
+      ; message = "Too many open files in system"
+      }
+  in
+  let transport : Llm_transport.t =
+    { complete_sync =
+        (fun (req : Llm_transport.completion_request) ->
+          called_models := req.config.model_id :: !called_models;
+          let response =
+            if String.equal req.config.model_id primary.model_id
+            then Error local_error
+            else Ok dummy_response
+          in
+          { Llm_transport.response; latency_ms = Some 25 })
+    ; complete_stream =
+        (fun ?on_telemetry:_ ~on_event:_ (req : Llm_transport.completion_request) ->
+          called_models := req.config.model_id :: !called_models;
+          if String.equal req.config.model_id primary.model_id
+          then Error local_error
+          else Ok dummy_response)
+    }
+  in
+  let result =
+    Complete_cascade.complete_cascade
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~clock
+      ~transport
+      ~health
+      ~steps:[ primary; fallback ]
+      ~messages:[]
+      ()
+  in
+  check (list string) "only primary provider called" [ primary.model_id ] !called_models;
+  let primary_health =
+    Complete_cascade.provider_health_info
+      health
+      ~cascade_config:Complete_cascade.default_cascade_config
+      ~provider_key:(Complete_cascade.provider_key primary)
+  in
+  check
+    int
+    "local resource exhaustion does not poison provider health"
+    0
+    primary_health.consecutive_failures;
+  match result with
+  | Complete_cascade.All_failed { errors = [ (config, error) ]; skipped = [] } ->
+    check string "failed provider" primary.model_id config.model_id;
+    check bool "preserves local resource error" true (error = local_error)
+  | _ -> fail "expected local resource All_failed without fallback"
+;;
+
 let test_provider_throttle_serializes_concurrent_steps () =
   Eio_main.run
   @@ fun env ->
@@ -1155,6 +1305,12 @@ let suite =
   ; ( "provider_terminal_stops_without_fallback"
     , `Quick
     , test_provider_terminal_stops_without_calling_fallback )
+  ; ( "tls_error_stops_without_fallback"
+    , `Quick
+    , test_tls_error_stops_without_calling_fallback )
+  ; ( "local_resource_error_stops_without_fallback"
+    , `Quick
+    , test_local_resource_error_stops_without_poisoning_provider_health )
   ; ( "provider_throttle_serializes_concurrent_steps"
     , `Quick
     , test_provider_throttle_serializes_concurrent_steps )

--- a/test/test_completion_contract_tool_use_calls.ml
+++ b/test/test_completion_contract_tool_use_calls.ml
@@ -45,8 +45,7 @@ let test_single_tool_use_resolves () =
   let tools = [ make_tool "alpha"; make_tool "beta" ] in
   let response =
     make_response
-      ~content:
-        [ Lp.ToolUse { id = "id-1"; name = "beta"; input = `Assoc [] } ]
+      ~content:[ Lp.ToolUse { id = "id-1"; name = "beta"; input = `Assoc [] } ]
   in
   let calls = Completion_contract.tool_use_calls ~tools response in
   match calls with
@@ -63,8 +62,7 @@ let test_unknown_tool_use_yields_none () =
   let tools = [ make_tool "alpha" ] in
   let response =
     make_response
-      ~content:
-        [ Lp.ToolUse { id = "id-1"; name = "missing"; input = `Assoc [] } ]
+      ~content:[ Lp.ToolUse { id = "id-1"; name = "missing"; input = `Assoc [] } ]
   in
   match Completion_contract.tool_use_calls ~tools response with
   | [ call ] ->
@@ -94,8 +92,7 @@ let test_mixed_blocks_only_tool_uses_returned () =
 let test_tool_use_with_empty_tools_still_emits_call () =
   let response =
     make_response
-      ~content:
-        [ Lp.ToolUse { id = "id-1"; name = "anything"; input = `Assoc [] } ]
+      ~content:[ Lp.ToolUse { id = "id-1"; name = "anything"; input = `Assoc [] } ]
   in
   match Completion_contract.tool_use_calls ~tools:[] response with
   | [ call ] ->


### PR DESCRIPTION
## Summary
- preserve concrete TLS setup failures from HTTPS client initialization
- stop cascade fallback on TLS and local resource exhaustion errors
- avoid provider registry availability crashes when path probes raise under host FD pressure
- format one stale completion-contract test so full non-draft `@fmt` can pass

## Root cause
TLS setup failures and host resource exhaustion were treated like ordinary network failures, so cascade logic could fan out to additional providers while the host was already unhealthy. Provider discovery also used raw filesystem probes that could raise during FD pressure.

## Safety gate
This PR is intentionally draft. Repository policy keeps agent-authored PRs draft-only until a human adds the configured approval label, then full non-draft CI can run. Draft checks alone are not enough to call the incident fully resolved.

## Validation
- `scripts/dune-local.sh build @runtest-agent_sdk`
- `scripts/dune-local.sh exec test/test_complete_cascade.exe`
- `scripts/dune-local.sh exec test/test_provider_registry.exe`
- `scripts/dune-local.sh exec test/test_completion_contract_tool_use_calls.exe`
- `scripts/dune-local.sh build @fmt`
- `bash scripts/check-sdk-independence.sh`
- `git diff --check`
- Full manual CI workflow: https://github.com/jeong-sik/oas/actions/runs/25918619451
