### PR TITLE
fix(completion): lower tool-choice fallback log noise

### DIFF
--- a/lib/completion_contract.ml
+++ b/lib/completion_contract.ml
@@ -62,7 +62,7 @@ let of_tool_choice ?(supports_tool_choice = true) choice =
   | Allow_text_or_tool -> Allow_text_or_tool
   | contract when supports_tool_choice -> contract
   | contract ->
-    Log.info
+    Log.debug
       _log
       "tool_choice contract relaxed (provider does not support tool_choice)"
       [ Log.S ("requested", to_string contract)

--- a/test/test_completion_contract_tool_use_calls.ml
+++ b/test/test_completion_contract_tool_use_calls.ml
@@ -101,6 +101,26 @@ let test_tool_use_with_empty_tools_still_emits_call () =
   | _ -> Alcotest.fail "expected exactly one call"
 ;;
 
+let test_tool_choice_relaxation_does_not_emit_info_log () =
+  let sink, get_records = Log.collector_sink () in
+  let cleanup () =
+    Log.clear_sinks ();
+    Log.set_global_level Log.Info
+  in
+  Log.clear_sinks ();
+  Log.set_global_level Log.Info;
+  Log.add_sink sink;
+  Fun.protect ~finally:cleanup (fun () ->
+    let contract =
+      Completion_contract.of_tool_choice ~supports_tool_choice:false (Some Lp.Any)
+    in
+    Alcotest.(check bool)
+      "contract still relaxes"
+      true
+      (contract = Completion_contract.Allow_text_or_tool);
+    Alcotest.(check int) "no info-level noise" 0 (List.length (get_records ())))
+;;
+
 let () =
   Alcotest.run
     "completion_contract_tool_use_calls"
@@ -129,6 +149,12 @@ let () =
             "ToolUse with empty catalog still emits unresolved call"
             `Quick
             test_tool_use_with_empty_tools_still_emits_call
+        ] )
+    ; ( "log_noise"
+      , [ Alcotest.test_case
+            "tool_choice relaxation is below info level"
+            `Quick
+            test_tool_choice_relaxation_does_not_emit_info_log
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- demote the provider tool_choice fallback notice from INFO to DEBUG
- keep completion-contract relaxation behavior unchanged
- add coverage that relaxation no longer emits at INFO level

## Root cause
Providers without native tool_choice support relax requested tool contracts on each turn. That path is expected behavior, but logging it at INFO level repeats during keeper loops and adds noise to local runtime logs.

## Validation
- ocamlformat --check lib/completion_contract.ml test/test_completion_contract_tool_use_calls.ml
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build test/test_completion_contract_tool_use_calls.exe
- ./_build/default/test/test_completion_contract_tool_use_calls.exe