### PR TITLE
fix(context): surface reducer repair diagnostics

### DIFF
--- a/lib/context_reducer.ml
+++ b/lib/context_reducer.ml
@@ -77,6 +77,13 @@ let apply_keep_first_and_last = Context_reducer_turns.apply_keep_first_and_last
 let apply_prune_tool_outputs = Context_reducer_apply.apply_prune_tool_outputs
 let apply_prune_tool_args = Context_reducer_apply.apply_prune_tool_args
 
+type dangling_repair_report = Context_reducer_apply.dangling_repair_report =
+  { synthesized_tool_results : int }
+
+let repair_dangling_tool_calls_with_report =
+  Context_reducer_apply.apply_repair_dangling_tool_calls_with_report
+;;
+
 let apply_repair_dangling_tool_calls =
   Context_reducer_apply.apply_repair_dangling_tool_calls
 ;;

--- a/lib/context_reducer.mli
+++ b/lib/context_reducer.mli
@@ -111,6 +111,20 @@ val group_into_turns : message list -> message list list
 (** Reduce messages according to the configured strategy. *)
 val reduce : t -> message list -> message list
 
+type dangling_repair_report =
+  { synthesized_tool_results : int
+    (** Number of explicit synthetic ToolResult messages inserted for
+        assistant ToolUse blocks that had no adjacent result span. *)
+  }
+
+(** Apply the same repair as {!repair_dangling_tool_calls}, returning
+    counters so callers can log or meter synthetic ToolResult insertion.
+    The inserted ToolResult messages carry [metadata] marking them as
+    synthetic. *)
+val repair_dangling_tool_calls_with_report
+  :  message list
+  -> message list * dangling_repair_report
+
 (** {1 Convenience constructors} *)
 
 val keep_last : int -> t

--- a/lib/context_reducer_apply.ml
+++ b/lib/context_reducer_apply.ml
@@ -109,19 +109,27 @@ let tool_result_ids (msg : message) =
 
 let has_tool_result msg = tool_result_ids msg <> []
 
+type dangling_repair_report = { synthesized_tool_results : int }
+
 let synthetic_tool_result_message id =
   { role = User
   ; content =
       [ ToolResult
           { tool_use_id = id
-          ; content = "Tool call cancelled before completion."
+          ; content =
+              "OAS context reducer synthesized this error result because the original \
+               tool call had no matching ToolResult."
           ; is_error = true
           ; json = None
           }
       ]
   ; name = None
   ; tool_call_id = None
-  ; metadata = []
+  ; metadata =
+      [ "oas.synthetic_tool_result", `Bool true
+      ; "oas.synthetic_reason", `String "dangling_tool_use"
+      ; "oas.tool_use_id", `String id
+      ]
   }
 ;;
 
@@ -133,9 +141,10 @@ let split_tool_result_span messages =
   loop [] messages
 ;;
 
-let apply_repair_dangling_tool_calls messages =
+let apply_repair_dangling_tool_calls_with_report messages =
+  let synthesized_tool_results = ref 0 in
   let rec aux acc = function
-    | [] -> List.rev acc
+    | [] -> List.rev acc, { synthesized_tool_results = !synthesized_tool_results }
     | (msg : message) :: rest ->
       let use_ids = if msg.role = Assistant then tool_use_ids msg else [] in
       if use_ids = []
@@ -144,11 +153,16 @@ let apply_repair_dangling_tool_calls messages =
         let result_span, tail = split_tool_result_span rest in
         let result_ids = List.concat_map tool_result_ids result_span in
         let orphan_ids = List.filter (fun id -> not (List.mem id result_ids)) use_ids in
+        synthesized_tool_results := !synthesized_tool_results + List.length orphan_ids;
         let repairs = List.map synthetic_tool_result_message orphan_ids in
         let segment = (msg :: result_span) @ repairs in
         aux (List.rev_append segment acc) tail)
   in
   aux [] messages
+;;
+
+let apply_repair_dangling_tool_calls messages =
+  fst (apply_repair_dangling_tool_calls_with_report messages)
 ;;
 
 let apply_repair_orphaned_tool_results messages =
@@ -346,11 +360,17 @@ let apply_stub_tool_results ~keep_recent messages =
   then messages
   else (
     let tool_names = Hashtbl.create 32 in
+    let record_tool_name id name =
+      match Hashtbl.find_opt tool_names id with
+      | None -> Hashtbl.add tool_names id name
+      | Some existing when String.equal existing name -> ()
+      | Some _ -> Hashtbl.replace tool_names id "ambiguous_tool_use_id"
+    in
     List.iter
       (fun (msg : message) ->
          List.iter
            (function
-             | ToolUse { id; name; _ } -> Hashtbl.replace tool_names id name
+             | ToolUse { id; name; _ } -> record_tool_name id name
              | _ -> ())
            msg.content)
       messages;
@@ -512,7 +532,18 @@ let apply_summarize_old ~keep_recent ~summarizer messages =
     let old_turns = List.filteri (fun i _ -> i < total - keep_recent) turns in
     let recent_turns = List.filteri (fun i _ -> i >= total - keep_recent) turns in
     let old_messages = List.concat old_turns in
-    let summary_text = summarizer old_messages in
+    let fallback_summary exn =
+      let reason = Printexc.to_string exn in
+      Printf.sprintf
+        "[Summary unavailable: summarizer failed: %s]\n[Preserved %d recent turns]"
+        reason
+        keep_recent
+    in
+    let summary_text =
+      try summarizer old_messages with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn -> fallback_summary exn
+    in
     let summary_msg =
       { role = User
       ; content = [ Text summary_text ]

--- a/lib/memory_file_backend.ml
+++ b/lib/memory_file_backend.ml
@@ -46,6 +46,17 @@ let hex_decode s =
 let file_path store key = Eio.Path.(store.base_dir / (hex_encode key ^ ".json"))
 let io_error_of_exn = Fs_result.io_error_of_exn
 
+type retrieve_error =
+  | Missing_key
+  | Corrupt_json of string
+  | Backend_error of string
+
+let retrieve_error_to_string = function
+  | Missing_key -> "missing_key"
+  | Corrupt_json reason -> "corrupt_json: " ^ reason
+  | Backend_error reason -> "backend_error: " ^ reason
+;;
+
 (* ── Lifecycle ───────────────────────────────────────────────── *)
 
 let create base_dir =
@@ -67,22 +78,31 @@ let persist t ~key value =
   | Error e -> Error (Printf.sprintf "persist '%s' failed: %s" key (Error.to_string e))
 ;;
 
-let retrieve t ~key =
+let retrieve_result t ~key =
   let path = file_path t key in
   try
     let data = Eio.Path.load path in
-    Some (Yojson.Safe.from_string data)
+    Ok (Yojson.Safe.from_string data)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | Eio.Io (Eio.Fs.E (Not_found _), _) -> None
-  | Yojson.Json_error _ as exn ->
-    warn_backend_issue ~op:"retrieve_parse" ~path:key exn;
+  | Eio.Io (Eio.Fs.E (Not_found _), _) -> Error Missing_key
+  | Yojson.Json_error reason -> Error (Corrupt_json reason)
+  | Eio.Io _ as exn -> Error (Backend_error (Printexc.to_string exn))
+  | Unix.Unix_error _ as exn -> Error (Backend_error (Printexc.to_string exn))
+;;
+
+let retrieve t ~key =
+  match retrieve_result t ~key with
+  | Ok json -> Some json
+  | Error Missing_key -> None
+  | Error (Corrupt_json _ as err) ->
+    warn_backend_issue
+      ~op:"retrieve_parse"
+      ~path:key
+      (Failure (retrieve_error_to_string err));
     None
-  | Eio.Io _ as exn ->
-    warn_backend_issue ~op:"retrieve" ~path:key exn;
-    None
-  | Unix.Unix_error _ as exn ->
-    warn_backend_issue ~op:"retrieve" ~path:key exn;
+  | Error (Backend_error _ as err) ->
+    warn_backend_issue ~op:"retrieve" ~path:key (Failure (retrieve_error_to_string err));
     None
 ;;
 

--- a/lib/memory_file_backend.mli
+++ b/lib/memory_file_backend.mli
@@ -17,9 +17,21 @@
 
 type t
 
+type retrieve_error =
+  | Missing_key
+  | Corrupt_json of string
+  | Backend_error of string
+
+val retrieve_error_to_string : retrieve_error -> string
+
 (** Create a file-backed memory store.
     Creates [base_dir] if it does not exist. *)
 val create : Eio.Fs.dir_ty Eio.Path.t -> (t, Error.sdk_error) result
+
+(** Retrieve a stored key with typed failure information. This avoids the
+    legacy [Memory.long_term_backend.retrieve] ambiguity where a missing key,
+    corrupt JSON, and I/O failure all collapse to [None]. *)
+val retrieve_result : t -> key:string -> (Yojson.Safe.t, retrieve_error) result
 
 (** Get the {!Memory.long_term_backend} for use with {!Memory.create}. *)
 val to_backend : t -> Memory.long_term_backend

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -876,6 +876,30 @@ let test_summarize_old_all_recent () =
   Alcotest.(check int) "no change" 2 (List.length result)
 ;;
 
+let test_summarize_old_catches_callback_failure () =
+  let msgs =
+    [ user_msg "turn1"
+    ; asst_msg "r1"
+    ; user_msg "turn2"
+    ; asst_msg "r2"
+    ; user_msg "turn3"
+    ; asst_msg "r3"
+    ]
+  in
+  let summarizer _ = failwith "summarizer backend unavailable" in
+  let result =
+    Context_reducer.reduce (Context_reducer.summarize_old ~keep_recent:1 ~summarizer) msgs
+  in
+  Alcotest.(check int) "fallback summary + recent turn" 3 (List.length result);
+  match result with
+  | { Types.content = [ Types.Text t ]; _ } :: _ ->
+    Alcotest.(check bool)
+      "fallback states summarizer failed"
+      true
+      (String.starts_with ~prefix:"[Summary unavailable:" t)
+  | _ -> Alcotest.fail "expected fallback summary first"
+;;
+
 (* --- clear_tool_results --- *)
 
 let test_clear_tool_results_clears_old () =
@@ -1181,6 +1205,26 @@ let test_repair_single_orphan () =
   | _ -> Alcotest.fail "expected synthetic tool result"
 ;;
 
+let test_repair_report_counts_synthetic_results () =
+  let msgs = [ user_msg "q"; tool_use_msg "t1" "calc"; asst_msg "continuing" ] in
+  let result, report = Context_reducer.repair_dangling_tool_calls_with_report msgs in
+  Alcotest.(check int) "repaired (+1 msg)" 4 (List.length result);
+  Alcotest.(check int) "one synthetic result" 1 report.synthesized_tool_results;
+  match List.nth result 2 with
+  | { Types.metadata; content = [ Types.ToolResult { content; _ } ]; _ } ->
+    Alcotest.(check (option bool))
+      "synthetic metadata"
+      (Some true)
+      (match List.assoc_opt "oas.synthetic_tool_result" metadata with
+       | Some (`Bool value) -> Some value
+       | _ -> None);
+    Alcotest.(check bool)
+      "content does not claim execution"
+      true
+      (String.starts_with ~prefix:"OAS context reducer synthesized" content)
+  | _ -> Alcotest.fail "expected synthetic tool result"
+;;
+
 let test_repair_multiple_orphans () =
   let msgs =
     [ user_msg "q"
@@ -1241,6 +1285,36 @@ let test_repair_late_result_is_not_pairing () =
     Alcotest.(check string) "synthetic id" "t1" tool_use_id;
     Alcotest.(check bool) "synthetic error" true is_error
   | _ -> Alcotest.fail "expected synthetic adjacent tool result"
+;;
+
+let test_stub_tool_results_marks_conflicting_tool_names_ambiguous () =
+  let long_output = String.make 80 'x' in
+  let msgs =
+    [ user_msg "turn1"
+    ; tool_use_msg "same-id" "read"
+    ; tool_result_msg "same-id" long_output
+    ; tool_use_msg "same-id" "write"
+    ; user_msg "turn2"
+    ; asst_msg "recent"
+    ]
+  in
+  let result =
+    Context_reducer.reduce (Context_reducer.stub_tool_results ~keep_recent:1) msgs
+  in
+  let stub =
+    List.find_map
+      (fun (msg : Types.message) ->
+         List.find_map
+           (function
+             | Types.ToolResult { tool_use_id = "same-id"; content; _ } -> Some content
+             | _ -> None)
+           msg.content)
+      result
+  in
+  Alcotest.(check (option string))
+    "ambiguous duplicate id"
+    (Some "[tool: ambiguous_tool_use_id, 1 lines, ok]")
+    stub
 ;;
 
 (* --- repair_orphaned_tool_results --- *)
@@ -1433,6 +1507,10 @@ let () =
     ; ( "summarize_old"
       , [ Alcotest.test_case "basic summarization" `Quick test_summarize_old_basic
         ; Alcotest.test_case "all recent no-op" `Quick test_summarize_old_all_recent
+        ; Alcotest.test_case
+            "callback failure fallback"
+            `Quick
+            test_summarize_old_catches_callback_failure
         ] )
     ; ( "clear_tool_results"
       , [ Alcotest.test_case
@@ -1475,6 +1553,10 @@ let () =
       , [ Alcotest.test_case "no orphans unchanged" `Quick test_repair_no_orphans
         ; Alcotest.test_case "single orphan repaired" `Quick test_repair_single_orphan
         ; Alcotest.test_case
+            "report counts synthetic results"
+            `Quick
+            test_repair_report_counts_synthetic_results
+        ; Alcotest.test_case
             "multiple orphans repaired"
             `Quick
             test_repair_multiple_orphans
@@ -1483,6 +1565,12 @@ let () =
             "late result does not satisfy adjacency"
             `Quick
             test_repair_late_result_is_not_pairing
+        ] )
+    ; ( "stub_tool_results"
+      , [ Alcotest.test_case
+            "duplicate tool_use id becomes ambiguous"
+            `Quick
+            test_stub_tool_results_marks_conflicting_tool_names_ambiguous
         ] )
     ; ( "repair_orphaned_tool_results"
       , [ Alcotest.test_case

--- a/test/test_memory_file_backend.ml
+++ b/test/test_memory_file_backend.ml
@@ -58,6 +58,36 @@ let test_persist_retrieve () =
     Alcotest.(check int) "1 entry" 1 (Memory_file_backend.entry_count t)
 ;;
 
+let test_retrieve_result_distinguishes_missing_and_corrupt () =
+  Eio_main.run
+  @@ fun env ->
+  with_tmp_dir env
+  @@ fun dir ->
+  match Memory_file_backend.create dir with
+  | Error e -> Alcotest.failf "create: %s" (Error.to_string e)
+  | Ok t ->
+    (match Memory_file_backend.retrieve_result t ~key:"missing" with
+     | Error Memory_file_backend.Missing_key -> ()
+     | Ok json -> Alcotest.failf "expected missing, got %s" (Yojson.Safe.to_string json)
+     | Error err ->
+       Alcotest.failf
+         "expected Missing_key, got %s"
+         (Memory_file_backend.retrieve_error_to_string err));
+    Eio.Path.save ~create:(`Or_truncate 0o644) Eio.Path.(dir / "626164.json") "{bad";
+    (match Memory_file_backend.retrieve_result t ~key:"bad" with
+     | Error (Memory_file_backend.Corrupt_json _) -> ()
+     | Ok json -> Alcotest.failf "expected corrupt, got %s" (Yojson.Safe.to_string json)
+     | Error err ->
+       Alcotest.failf
+         "expected Corrupt_json, got %s"
+         (Memory_file_backend.retrieve_error_to_string err));
+    let backend = Memory_file_backend.to_backend t in
+    Alcotest.(check bool)
+      "legacy backend still maps corrupt to None"
+      true
+      (backend.retrieve ~key:"bad" = None)
+;;
+
 let test_persist_overwrite () =
   Eio_main.run
   @@ fun env ->
@@ -337,6 +367,10 @@ let () =
     [ "create", [ Alcotest.test_case "create" `Quick test_create ]
     ; ( "persist_retrieve"
       , [ Alcotest.test_case "round_trip" `Quick test_persist_retrieve
+        ; Alcotest.test_case
+            "typed retrieve errors"
+            `Quick
+            test_retrieve_result_distinguishes_missing_and_corrupt
         ; Alcotest.test_case "overwrite" `Quick test_persist_overwrite
         ] )
     ; ( "remove"


### PR DESCRIPTION
## Summary
- add typed reporting for context reducer synthetic ToolResult repairs and mark synthetic results in metadata
- add typed `Memory_file_backend.retrieve_result` while preserving the legacy option-based backend contract
- guard `Summarize_old` against non-cancel summarizer exceptions and prevent duplicate tool_use id name drift from last-write-wins stubs

## Verification
- `scripts/dune-local.sh build test/test_context_reducer.exe test/test_memory_file_backend.exe`
- `./_build/default/test/test_context_reducer.exe` (61 tests)
- `./_build/default/test/test_memory_file_backend.exe` (16 tests)