### PR TITLE
fix(capabilities): emit chat_template_kwargs for qwen3

### DIFF
--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -1314,6 +1314,22 @@ let%test "build_request emits chat_template_kwargs for nemotron (Chat_template_k
   ctk |> member "enable_thinking" |> to_bool = true && json |> member "thinking" = `Null
 ;;
 
+let%test "build_request emits chat_template_kwargs for qwen3" =
+  let config =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"qwen3.5-35b-a3b"
+      ~base_url:"http://localhost"
+      ~enable_thinking:true
+      ()
+  in
+  let body = build_request ~config ~messages:[] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  let ctk = json |> member "chat_template_kwargs" in
+  ctk |> member "enable_thinking" |> to_bool = true && json |> member "thinking" = `Null
+;;
+
 let%test "build_request omits seed when model does not support it" =
   (* glm-5.1 inherits default_capabilities.supports_seed = false.
      The capability gate must exclude the "seed" field from the

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -443,6 +443,8 @@ let for_model_id_static model_id =
       ; supports_parallel_tool_calls = true
       ; supports_reasoning = true
       ; supports_extended_thinking = true
+      ; supports_reasoning_budget = true
+      ; thinking_control_format = Chat_template_kwargs
       ; supports_native_streaming = true
       ; supports_top_k = true
       ; supports_min_p = true
@@ -1025,6 +1027,18 @@ let%test "for_model_id nemotron-ultra has reasoning" =
 let%test "for_model_id nemotron-vl has image input" =
   match for_model_id "nemotron-vl" with
   | Some c -> c.supports_image_input && c.supports_multimodal_inputs
+  | None -> false
+;;
+
+let%test "for_model_id qwen3 has chat_template_kwargs thinking control" =
+  (* Qwen3.x OpenAI-compatible llama.cpp/llama-server deployments return
+     [reasoning_content] when thinking is enabled through
+     {"chat_template_kwargs": {"enable_thinking": bool}}.  Without this
+     format, [supports_extended_thinking = true] never reaches the wire. *)
+  match for_model_id "qwen3.5" with
+  | Some c ->
+    c.supports_reasoning_budget
+    && c.thinking_control_format = Chat_template_kwargs
   | None -> false
 ;;
 

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -140,6 +140,12 @@ let test_lookup_qwen () =
     check (option int) "context 262K" (Some 262_144) c.max_context_tokens;
     check bool "tools" true c.supports_tools;
     check bool "thinking" true c.supports_extended_thinking;
+    check bool "reasoning budget" true c.supports_reasoning_budget;
+    check
+      bool
+      "chat_template_kwargs thinking control"
+      true
+      (c.thinking_control_format = Capabilities.Chat_template_kwargs);
     check bool "top_k" true c.supports_top_k
   | None -> fail "should match qwen3"
 ;;


### PR DESCRIPTION
## Summary

Qwen3 capability record set `supports_reasoning = true` and `supports_extended_thinking = true` but inherited `thinking_control_format = No_thinking_control` from `default_capabilities`. As a result `backend_openai_request.ml` never emitted `{"chat_template_kwargs": {"enable_thinking": bool}}` on the wire for Qwen3 deployments — the wire signal was silently dropped.

Observed downstream on a RunPod-hosted Qwen3.6 35B-A3B (llama.cpp `b1-6049906`): HTTP 200, `content = ""`, `reasoning_content = "Here's a thinking process: 1. **Analyze User Input**: ..."`, `finish_reason = length`. The model never exited the thinking channel because the disable signal was not in the request body.

In `masc-mcp` consumers this surfaced as:
- empty content metric (`empty_response_content_metric`) firing repeatedly
- keeper turn driver classifying the result as `Agent_sdk.Error.Internal`
- `keeper_execution_receipt.ml` collapsing the unrecognized message to literal `"internal_error"`
- `disposition = pause_human reason = internal_error` for analyst / nick0cave / sangsu / executor / qa-king on a 1-hour backoff cycle

## Change

- `lib/llm_provider/capabilities.ml` — Qwen3 branch now sets `thinking_control_format = Chat_template_kwargs` (the same pattern Nemotron already uses) and `supports_reasoning_budget = true`.
- `lib/llm_provider/backend_openai.ml` — added `let%test "build_request emits chat_template_kwargs for qwen3"` asserting the JSON body shape.
- `lib/llm_provider/capabilities.ml` — added `let%test "for_model_id qwen3 has chat_template_kwargs thinking control"` asserting the capability lookup.
- `test/test_capabilities.ml` — extended `test_lookup_qwen` to assert the wire format.

## Out of scope

A wider audit found `anthropic_capabilities`, `kimi_capabilities`, `openai_chat_capabilities`, `openai_chat_extended_capabilities`, `gemini_capabilities`, and `dashscope_capabilities` all inherit `No_thinking_control` from `default_capabilities`. Those records do **not** route through `backend_openai_request.ml`'s `chat_template_kwargs` emission path — Anthropic uses `backend_anthropic.ml`, Gemini uses `backend_gemini.ml`, GLM strips the field in `backend_glm.ml`, etc. A separate audit can decide whether the type-level invariant should force every reasoning-supporting record to make `thinking_control_format` explicit, but that is not on the critical path of this fix.

## Test plan

- [x] `dune build --root . lib/` — clean
- [x] `dune runtest --root . lib/llm_provider` — inline tests including new build_request and for_model_id tests
- [x] `_build/default/test/test_capabilities.exe` — 36/36 tests pass
- [ ] Confirm `masc-mcp` daemon picks up new OAS version → keeper pause cycle stops on next restart

## Why not a workaround

Per the masc-mcp `Workaround Rejection Bar` checklist:
- Not telemetry-as-fix: the existing `empty_response_content_metric` was the workaround; this PR removes the *cause* of empty content.
- Not a string classifier: the capability is a typed variant (`thinking_control_format`), not a string match.
- Not N-of-M: the only branch that asserts thinking support on the openai-compat path is Qwen3; the named records above route elsewhere.
- Not catch-all: no `_ ->` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
