### PR TITLE
feat(llm_provider): Fd_throttle_hook injection point (RFC-0101 PR-3)

### DIFF
--- a/lib/llm_provider/fd_throttle_hook.ml
+++ b/lib/llm_provider/fd_throttle_hook.ml
@@ -1,0 +1,41 @@
+(* Atomic stores a wrapper of type [(unit -> unit) -> unit]. The
+   wrapper takes a thunk and is responsible for invoking it; identity
+   default is [fun thunk -> thunk ()]. We store the wrapper rather
+   than an option so the hot path is one Atomic.get + one indirect
+   call — no branch on Some/None per invocation. *)
+
+let identity_wrapper : (unit -> unit) -> unit = fun thunk -> thunk ()
+
+let _handler : ((unit -> unit) -> unit) Atomic.t =
+  Atomic.make identity_wrapper
+
+let _installed : bool Atomic.t = Atomic.make false
+
+let with_slot (type a) (f : unit -> a) : a =
+  let wrapper = Atomic.get _handler in
+  (* Cross the unit-returning wrapper boundary using a ref. The wrapper
+     never sees the typed result; OCaml's value restriction is fine
+     because [result] is a fresh ref per call. Exceptions from [f]
+     propagate through the wrapper (wrappers are expected to be
+     transparent on exception, like [Fun.protect] or [Eio.Switch]). *)
+  let result : a option ref = ref None in
+  wrapper (fun () -> result := Some (f ())) ;
+  match !result with
+  | Some v -> v
+  | None ->
+      (* A non-conformant wrapper that swallowed its thunk. Treat as
+         programmer error — the contract is "must call thunk exactly
+         once". *)
+      failwith
+        "Fd_throttle_hook: installed handler did not invoke its \
+         thunk; wrapper contract violated"
+
+let set_handler h =
+  Atomic.set _handler h ;
+  Atomic.set _installed true
+
+let reset_handler () =
+  Atomic.set _handler identity_wrapper ;
+  Atomic.set _installed false
+
+let is_installed () = Atomic.get _installed

--- a/lib/llm_provider/fd_throttle_hook.mli
+++ b/lib/llm_provider/fd_throttle_hook.mli
@@ -1,0 +1,40 @@
+(** Process-wide FD throttle injection point (RFC-0101 PR-3).
+
+    OAS does not own the host FD ceiling — that is a concern of the
+    embedding process (e.g. masc-mcp, which has [Fd_accountant] +
+    [Keeper_fd_pressure]). But every outbound LLM HTTP call here goes
+    through {!Provider_throttle.with_permit_priority}, so a single
+    injection point at that chokepoint lets the embedder bound
+    Process-wide FD cost across all providers without OAS taking a
+    cross-repo dependency.
+
+    Default handler is identity ({!set_handler} not called) — OAS works
+    standalone with no behavioural change. When the embedder registers
+    a handler, every permit acquisition is additionally wrapped by it
+    before the user function runs.
+
+    Composition note: this is orthogonal to {!Provider_throttle}.
+    Provider_throttle bounds *per-provider* concurrency (e.g. 16 slots
+    on Anthropic). This hook bounds *process-wide* concurrency across
+    all providers — both apply to a single call. *)
+
+val with_slot : (unit -> 'a) -> 'a
+(** [with_slot f] runs [f ()] under the currently-installed handler.
+    If no handler is installed, equivalent to [f ()]. Handler swap is
+    atomic; concurrent calls observe a consistent handler reference for
+    their duration. *)
+
+val set_handler : ((unit -> unit) -> unit) -> unit
+(** [set_handler h] installs [h] as the wrapping function. Subsequent
+    [with_slot] calls invoke [h] which is responsible for calling its
+    own argument. Idempotent / overwriting — the most recently set
+    handler wins. Intended to be called once at embedder startup. *)
+
+val reset_handler : unit -> unit
+(** [reset_handler ()] restores the identity default. Test-only;
+    production embedders should set once and leave installed. *)
+
+val is_installed : unit -> bool
+(** [is_installed ()] returns true iff a non-identity handler is
+    currently installed. Observability only — not a synchronization
+    primitive. *)

--- a/lib/llm_provider/provider_throttle.ml
+++ b/lib/llm_provider/provider_throttle.ml
@@ -37,7 +37,11 @@ let create ~max_concurrent ~provider_name =
 ;;
 
 let with_permit_priority ~priority t f =
-  Slot_scheduler.with_permit ~priority t.scheduler f
+  (* RFC-0101 PR-3: compose per-provider permit with process-wide FD
+     throttle hook. Identity default when no embedder registered, so
+     standalone OAS behaviour is unchanged. *)
+  Slot_scheduler.with_permit ~priority t.scheduler (fun () ->
+    Fd_throttle_hook.with_slot f)
 ;;
 
 let with_permit t f = with_permit_priority ~priority:Request_priority.Background t f

--- a/test/dune
+++ b/test/dune
@@ -163,6 +163,7 @@
   test_provider_intf
   test_provider_runtime_binding
   test_provider_registry
+  test_fd_throttle_hook
   test_raw_trace
   test_raw_trace_deep
   test_reflexion
@@ -377,6 +378,7 @@
   test_provider_intf
   test_provider_runtime_binding
   test_provider_registry
+  test_fd_throttle_hook
   test_raw_trace
   test_raw_trace_deep
   test_reflexion

--- a/test/test_fd_throttle_hook.ml
+++ b/test/test_fd_throttle_hook.ml
@@ -1,0 +1,116 @@
+(** Unit tests for [Fd_throttle_hook] (RFC-0101 PR-3). *)
+
+open Alcotest
+module H = Llm_provider.Fd_throttle_hook
+module P = Llm_provider.Provider_throttle
+module Pri = Llm_provider.Request_priority
+
+let test_default_is_identity () =
+  H.reset_handler () ;
+  check bool "default not installed" false (H.is_installed ()) ;
+  let r = H.with_slot (fun () -> 42) in
+  check int "identity returns value" 42 r
+
+let test_set_handler_marks_installed () =
+  H.reset_handler () ;
+  H.set_handler (fun thunk -> thunk ()) ;
+  check bool "installed after set" true (H.is_installed ()) ;
+  H.reset_handler ()
+
+let test_handler_is_invoked () =
+  H.reset_handler () ;
+  let call_count = ref 0 in
+  H.set_handler (fun thunk ->
+    incr call_count ;
+    thunk ()) ;
+  let r1 = H.with_slot (fun () -> "a") in
+  let r2 = H.with_slot (fun () -> "b") in
+  check string "first call result" "a" r1 ;
+  check string "second call result" "b" r2 ;
+  check int "handler invoked once per with_slot" 2 !call_count ;
+  H.reset_handler ()
+
+let test_handler_propagates_exception () =
+  H.reset_handler () ;
+  let entered = ref false in
+  H.set_handler (fun thunk ->
+    entered := true ;
+    thunk ()) ;
+  let exn = Failure "boom" in
+  (try H.with_slot (fun () -> raise exn) |> ignore with
+   | Failure msg -> check string "exception preserved" "boom" msg) ;
+  check bool "handler still entered before exception" true !entered ;
+  H.reset_handler ()
+
+let test_non_conformant_handler_fails_loudly () =
+  H.reset_handler () ;
+  (* Wrapper that swallows the thunk — violates contract. *)
+  H.set_handler (fun _thunk -> ()) ;
+  (try
+     H.with_slot (fun () -> 1) |> ignore ;
+     Alcotest.fail "should have raised on contract violation"
+   with
+   | Failure msg ->
+     check bool
+       "error mentions wrapper contract"
+       true
+       (String.length msg > 0)) ;
+  H.reset_handler ()
+
+let test_handler_swap_is_atomic () =
+  H.reset_handler () ;
+  H.set_handler (fun thunk -> thunk ()) ;
+  H.set_handler (fun thunk -> thunk ()) ;
+  check bool "still installed after swap" true (H.is_installed ()) ;
+  H.reset_handler ()
+
+let test_provider_throttle_composition () =
+  (* The whole point of PR-3: every Provider_throttle.with_permit_priority
+     goes through the hook. Install a counter and verify. *)
+  H.reset_handler () ;
+  let hook_calls = ref 0 in
+  H.set_handler (fun thunk ->
+    incr hook_calls ;
+    thunk ()) ;
+  Eio_main.run @@ fun _env ->
+  let t = P.create ~max_concurrent:4 ~provider_name:"test" in
+  let r = P.with_permit_priority ~priority:Pri.Background t (fun () -> "ok") in
+  check string "throttled call result" "ok" r ;
+  check int "hook engaged through provider_throttle" 1 !hook_calls ;
+  H.reset_handler ()
+
+let test_reset_handler_restores_identity () =
+  H.reset_handler () ;
+  H.set_handler (fun thunk -> thunk ()) ;
+  check bool "installed before reset" true (H.is_installed ()) ;
+  H.reset_handler () ;
+  check bool "not installed after reset" false (H.is_installed ()) ;
+  let r = H.with_slot (fun () -> 7) in
+  check int "identity restored" 7 r
+
+let () =
+  Alcotest.run
+    "Fd_throttle_hook"
+    [ ( "identity default"
+      , [ test_case "default is identity" `Quick test_default_is_identity
+        ; test_case "reset restores identity" `Quick test_reset_handler_restores_identity
+        ] )
+    ; ( "handler lifecycle"
+      , [ test_case "set marks installed" `Quick test_set_handler_marks_installed
+        ; test_case "handler invoked" `Quick test_handler_is_invoked
+        ; test_case "swap is atomic" `Quick test_handler_swap_is_atomic
+        ] )
+    ; ( "contract"
+      , [ test_case "exception propagates" `Quick test_handler_propagates_exception
+        ; test_case
+            "non-conformant wrapper fails loudly"
+            `Quick
+            test_non_conformant_handler_fails_loudly
+        ] )
+    ; ( "provider_throttle composition"
+      , [ test_case
+            "permit goes through hook"
+            `Quick
+            test_provider_throttle_composition
+        ] )
+    ]


### PR DESCRIPTION
## Summary

RFC-0101 PR-3 — Provider HTTP wrap via **dependency injection** instead of direct cross-repo call. OAS cannot depend on masc-mcp, but every outbound LLM HTTP call goes through `Provider_throttle.with_permit_priority`, so a single injection point at that chokepoint lets the embedder (masc-mcp) bound process-wide FD cost without OAS taking a cross-repo dependency.

## What changes

| File | Change |
|---|---|
| `lib/llm_provider/fd_throttle_hook.ml(i)` | new — Atomic handler ref, identity default; `with_slot` / `set_handler` / `reset_handler` / `is_installed` |
| `lib/llm_provider/provider_throttle.ml` | `with_permit_priority` composes `Slot_scheduler.with_permit` with `Fd_throttle_hook.with_slot` |
| `test/dune` | wire `test_fd_throttle_hook` into both `(tests (names …))` blocks |
| `test/test_fd_throttle_hook.ml` | new — 8 tests (identity, lifecycle, contract, composition) |

## RFC body reframe

RFC-0101 §3.3 originally specified that `oas/lib/llm_provider/backend_*.ml` would call `masc-mcp Fd_accountant` directly. Since the dep graph is the other way around (masc-mcp → oas), DI is the only safe path. The hook is identity-default so **standalone OAS behaviour is unchanged**; masc-mcp registers a handler at bootstrap:

```ocaml
Fd_throttle_hook.set_handler
  (fun thunk -> Fd_accountant.with_slot ~kind:Provider_http thunk)
```

I will follow up with a `chore(rfc)` commit on the masc-mcp side to erratum §3.3 with this DI pattern.

## Composition (orthogonal layers)

| Layer | Bound | Implementation |
|---|---|---|
| `Provider_throttle` | per-provider concurrency | `Slot_scheduler` (e.g. 16 Anthropic slots) |
| `Fd_throttle_hook` | process-wide concurrency | embedder-injected (`Fd_accountant` Provider_http kind) |

Both apply to every call. The hook runs *after* the per-provider permit is acquired, so a thread that's queueing on a full provider doesn't also hold the global FD slot.

## Contract

- Wrapper must invoke its thunk exactly once. A wrapper that swallows the thunk is detected and **fails loudly** (programmer error, not silent data loss).
- Exceptions from `f` propagate through the wrapper.
- Handler swap is atomic via `Atomic.set`; concurrent calls observe a consistent reference for their duration.

## Test plan
- [x] `dune build --root . lib/llm_provider` silent OK
- [x] `dune exec --root . test/test_fd_throttle_hook.exe` → 8/8 OK
- [x] Regression: `test_provider.exe` 41/41 OK, `test_provider_runtime_binding.exe` 7/7 OK
- [ ] CI

## Related
- masc-mcp RFC-0101 PR-2 (#15816 merged) — `Fd_accountant` 4-kind pool with `Provider_http` kind.
- masc-mcp side will need a small wire-up commit (Fd_throttle_hook.set_handler at server bootstrap) in a follow-up.

RFC-WAIVED: oas does not gate on masc-mcp RFC-0101 subsystems; hook is identity default and standalone OAS unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)