### PR TITLE
fix: remove mutable anti-patterns

### DIFF
--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -206,10 +206,10 @@ let create_collector ~agent_name ~run_id =
   { agent_name; run_id; metrics = []; harness_verdicts = []; trace_summary = None }
 ;;
 
-let record collector metric = collector.metrics <- collector.metrics @ [ metric ]
+let record collector metric = collector.metrics <- metric :: collector.metrics
 
 let add_verdict collector verdict =
-  collector.harness_verdicts <- collector.harness_verdicts @ [ verdict ]
+  collector.harness_verdicts <- verdict :: collector.harness_verdicts
 ;;
 
 let set_trace_summary collector summary = collector.trace_summary <- Some summary
@@ -218,8 +218,8 @@ let finalize collector =
   { run_id = collector.run_id
   ; agent_name = collector.agent_name
   ; timestamp = Unix.gettimeofday ()
-  ; metrics = collector.metrics
-  ; harness_verdicts = collector.harness_verdicts
+  ; metrics = List.rev collector.metrics
+  ; harness_verdicts = List.rev collector.harness_verdicts
   ; trace_summary = collector.trace_summary
   }
 ;;

--- a/lib/llm_provider/metrics.ml
+++ b/lib/llm_provider/metrics.ml
@@ -253,7 +253,7 @@ type hooks = t
 
 module Aggregating = struct
   type t =
-    { mutable hooks : hooks
+    { hooks : hooks
     ; states : (aggregate_key, aggregate_state) Hashtbl.t
     ; mutex : Mutex.t
     }

--- a/lib/otel_tracer.ml
+++ b/lib/otel_tracer.ml
@@ -195,10 +195,6 @@ let inst_end_span inst (s : span) ~ok =
   inst_with_lock inst
   @@ fun () ->
   let target = ref None in
-  Printf.printf
-    "DEBUG: end_span for %s, current_spans size=%d\n%!"
-    s.span_id
-    (List.length inst.current_spans);
   inst.current_spans
   <- List.filter_map
        (fun sp ->
@@ -218,10 +214,6 @@ let inst_add_event inst (s : span) (msg : string) =
   inst_with_lock inst
   @@ fun () ->
   let evt = { event_name = msg; timestamp_ns = now_ns (); attributes = [] } in
-  Printf.printf
-    "DEBUG: add_event for %s, current_spans size=%d\n%!"
-    s.span_id
-    (List.length inst.current_spans);
   inst.current_spans
   <- List.map
        (fun sp ->
@@ -298,12 +290,13 @@ let inst_record_metric inst ~name ~value ~metric_type =
   inst_with_lock inst
   @@ fun () ->
   inst.metrics
-  <- Util.snoc inst.metrics { m_name = name; m_value = value; m_type = metric_type }
+  <- { m_name = name; m_value = value; m_type = metric_type } :: inst.metrics
 ;;
 
 let inst_get_metrics inst =
   inst_with_lock inst
-  @@ fun () -> List.map (fun m -> m.m_name, m.m_value, m.m_type) inst.metrics
+  @@ fun () ->
+  List.map (fun m -> m.m_name, m.m_value, m.m_type) (List.rev inst.metrics)
 ;;
 
 let inst_clear_metrics inst = inst_with_lock inst @@ fun () -> inst.metrics <- []
@@ -421,7 +414,8 @@ let metric_entry_to_json (m : metric_entry) : Yojson.Safe.t =
 
 let to_otlp_json (cfg : config) : Yojson.Safe.t =
   let spans, metrics =
-    inst_with_lock _global (fun () -> List.rev _global.completed_spans, _global.metrics)
+    inst_with_lock _global
+      (fun () -> List.rev _global.completed_spans, List.rev _global.metrics)
   in
   let resource =
     `Assoc [ "attributes", attrs_to_json [ "service.name", cfg.service_name ] ]


### PR DESCRIPTION
## Summary

- `lib/eval.ml`: O(n) list append (`@ [item]`) → O(1) cons + `List.rev` in `finalize`
- `lib/otel_tracer.ml`: Remove debug `Printf.printf` in mutex-protected critical sections; replace `Util.snoc` with cons + `List.rev`
- `lib/llm_provider/metrics.ml`: Remove dead `mutable` from `Aggregating.t` hooks field (never mutated after `create`)
- `lib/internal_query_engine.ml`: Replace O(n) `Util.snoc` with O(1) cons + `List.rev` at drain points

## Audit scope

All `.ml` files in `lib/`, `test/`, `bin/`, `examples/` searched. Classification:
- 5 anti-patterns fixed (this PR)
- 1 intentional O(n) FIFO append kept (`relay_delivery.ml` — `max_queue_depth=256`, drop-oldest semantics)
- `Util.snoc` on immutable records (pipeline stages) — legitimate functional updates, not mutable field mutations
- Remaining mutable usage: legitimate (Mutex/Eio.Mutex protected, single-threaded, append-only journal)

## Test plan

- [x] `dune build --root . lib/agent_sdk.a` compiles clean
- [x] Eval: 15 tests pass
- [x] OTel Tracer: 36 + 41 tests pass
- [x] Relay delivery: 4 tests pass (unchanged)
- [ ] `internal_query_engine`: no dedicated tests (SDK client integration module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)