### PR TITLE
feat(bench): TTFT distribution bench + SLO doc (RFC-OAS-020 PR-1b)

### DIFF
--- a/docs/PERFORMANCE-SLO.md
+++ b/docs/PERFORMANCE-SLO.md
@@ -1,0 +1,81 @@
+# OAS Performance SLO
+
+Service Level Objectives for the OAS streaming-completion path.  RFC
+sources are cited at each row; calibration history is at the bottom.
+
+## TTFT — Time To First Token
+
+**Definition.**  Milliseconds from provider HTTP request submission
+to the first parsed chunk that carries a non-empty user-visible
+delta (text / reasoning / tool-call argument).  Captured in-process
+in `Complete.publish_summary` and emitted as
+`Streaming_summary.ttft_ms : float option` (RFC-OAS-020 §3.2).
+
+Distinct from `Streaming_first_chunk.ttfrc_ms` which fires on the
+first chunk regardless of payload — TTFT skips role-only preludes
+and finish-only finalizer chunks.
+
+| Provider | P50 target | P95 target | Source |
+|---|---|---|---|
+| Anthropic (cloud) | ≤ 400 ms | ≤ 1500 ms | RFC-OAS-020 §3.3 baseline (calibration pending — see below) |
+| Local llama-server (LAN) | ≤ 150 ms | ≤ 500 ms | RFC-OAS-020 §3.3 baseline (calibration pending) |
+| ZAI GLM (cloud) | ≤ 500 ms | ≤ 1500 ms | RFC-OAS-020 §3.3 baseline (calibration pending) |
+
+Targets are **uncalibrated baseline values** at PR-1b.  The
+calibration run described in RFC-OAS-020 §3.5 has not been executed
+because real provider keys / a live local llama-server are not
+available to the agent that authored this file.  When operator runs
+`scripts/bench/ttft_distribution.sh` for the first time, this table
+SHOULD be updated to the measured P50/P95 + a +30 % headroom on
+P95 (so transient spikes don't page).
+
+## prefill_ms — first SSE event lead time (when separable)
+
+**Definition.**  Milliseconds from provider HTTP request submission
+to the first SSE event of any kind.  `Some` iff the provider
+exposes a separable prelude (e.g. Anthropic emits `MessageStart`
+before the first `ContentBlockDelta`); `None` otherwise.
+
+| Provider | P95 target | Note |
+|---|---|---|
+| Anthropic | ≤ 300 ms | gap between MessageStart and first content_block_delta |
+| Local llama-server | ≤ 100 ms | prefill_ms is `None` in current backend (no separable prelude) — listed for future telemetry that may expose it |
+| GLM / OpenAI-compat / Gemini / Ollama | n/a | first event IS first token → `prefill_ms = None` |
+
+## Measurement protocol
+
+The bench script `scripts/bench/ttft_distribution.sh` measures
+**TTFB** (Time To First Byte of body) as a transport-level proxy.
+For OpenAI-compat / GLM / Ollama the gap between TTFB and TTFT is
+typically < 5 ms, so the script is a useful operational smoke
+check.  For Anthropic the gap can be tens to hundreds of
+milliseconds, so the SLO targets in this document **must** be
+calibrated against the in-process `Streaming_summary.ttft_ms`
+field, not against the bench script output alone.
+
+## Calibration log
+
+| Date | Provider | Model | P50 | P95 | max | std | n |
+|---|---|---|---|---|---|---|---|
+| (not yet run) | | | | | | | |
+
+When you run the bench, append a row here and update the targets
+table above if the new baseline is materially different.
+
+## Boundary with masc-mcp
+
+`masc-mcp` adds an *operator-visible* SLO on top of these provider
+SLOs: `ttft_to_client_ms ≈ ttft_ms + transport_overhead_ms` where
+`transport_overhead_ms` is the masc-mcp-side time from first SSE
+chunk arrival to flush-to-client (typically < 5 ms).  That
+composition lives in masc-mcp `docs/PERFORMANCE-SLO.md` (TBD) and
+is intentionally *not* coupled to this oas-side document.
+
+## References
+
+- RFC-OAS-020 — TTFT instrumentation in `Streaming_summary` (Active)
+- RFC-OAS-019 — Stream-lifetime telemetry aggregation (Active)
+- `lib/llm_provider/complete.ml` — capture site (`first_token_at_ref`,
+  `first_event_at_ref`)
+- `lib/llm_provider/streaming.ml` — typed predicates
+  (`chunk_has_non_empty_delta`, `sse_event_is_first_token_signal`)

--- a/scripts/bench/ttft_distribution.sh
+++ b/scripts/bench/ttft_distribution.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# scripts/bench/ttft_distribution.sh
+# RFC-OAS-020 PR-1b — TTFT (Time To First Token) distribution bench.
+#
+# What this measures
+# ------------------
+# This script measures **TTFB** (Time To First *Byte* of body) as a
+# transport-level proxy for TTFT.  TTFB is the closest curl can
+# observe without parsing the SSE stream; for the strict RFC-OAS-020
+# TTFT definition (time to first chunk with a non-empty user-visible
+# delta — text / reasoning / tool-call), use the in-process
+# capture point added in PR-1a (Streaming_summary.ttft_ms via
+# on_telemetry).
+#
+# Differences between TTFB (this script) and TTFT (PR-1a in-process):
+#
+# - **Anthropic**: TTFB ≈ time to MessageStart (prelude). TTFT ≈
+#   time to first ContentBlockDelta. Anthropic typically has a
+#   measurable gap between the two — TTFB will UNDER-report TTFT.
+# - **OpenAI-compat / Gemini / GLM / Ollama**: TTFB ≈ TTFT (first
+#   chunk is usually the first content delta). The two metrics
+#   typically agree within ~5 ms.
+#
+# Therefore the SLO targets in §3.3 of the RFC are calibrated using
+# the in-process TTFT capture, not this script.  This script is for
+# operational sanity checks and external smoke tests.
+#
+# Usage
+# -----
+#   $ scripts/bench/ttft_distribution.sh anthropic 100 claude-opus-4-7
+#   $ scripts/bench/ttft_distribution.sh llama-local 100 qwen3.5-9b
+#   $ scripts/bench/ttft_distribution.sh glm 100 glm-4-plus
+#
+# Output (last line is JSON, prior lines are per-iter samples on stderr):
+#   {"provider":"anthropic","model":"...","iter":100,"p50_ms":...,"p95_ms":...,"max_ms":...,"mean_ms":...,"std_ms":...}
+#
+# Environment
+# -----------
+#   ANTHROPIC_API_KEY  — required when provider=anthropic
+#   GLM_API_KEY        — required when provider=glm
+#   LLAMA_URL          — override default http://localhost:8085/v1/chat/completions
+#   GLM_URL            — override default https://open.bigmodel.cn/...
+#
+# Exit codes
+# ----------
+#   0  bench completed; JSON summary on stdout
+#   1  unknown provider / missing env var / curl failure rate > 10 %
+
+set -euo pipefail
+
+PROVIDER="${1:-anthropic}"
+ITER="${2:-100}"
+MODEL="${3:-}"
+
+# Provider-specific request config. Each block sets:
+#   URL, MODEL (if not overridden), AUTH_HEADER, BODY, EXTRA_HEADERS
+case "$PROVIDER" in
+  anthropic)
+    URL="https://api.anthropic.com/v1/messages"
+    MODEL="${MODEL:-claude-opus-4-7}"
+    : "${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY not set}"
+    AUTH_HEADER="x-api-key: ${ANTHROPIC_API_KEY}"
+    BODY="{\"model\":\"${MODEL}\",\"max_tokens\":50,\"messages\":[{\"role\":\"user\",\"content\":\"Say hi.\"}],\"stream\":true}"
+    EXTRA_HEADERS=(-H "anthropic-version: 2023-06-01" -H "Content-Type: application/json")
+    ;;
+  llama-local)
+    URL="${LLAMA_URL:-http://localhost:8085/v1/chat/completions}"
+    MODEL="${MODEL:-qwen3.5-9b}"
+    AUTH_HEADER="Authorization: Bearer dummy"
+    BODY="{\"model\":\"${MODEL}\",\"max_tokens\":50,\"messages\":[{\"role\":\"user\",\"content\":\"Say hi.\"}],\"stream\":true}"
+    EXTRA_HEADERS=(-H "Content-Type: application/json")
+    ;;
+  glm)
+    URL="${GLM_URL:-https://open.bigmodel.cn/api/paas/v4/chat/completions}"
+    MODEL="${MODEL:-glm-4-plus}"
+    : "${GLM_API_KEY:?GLM_API_KEY not set}"
+    AUTH_HEADER="Authorization: Bearer ${GLM_API_KEY}"
+    BODY="{\"model\":\"${MODEL}\",\"max_tokens\":50,\"messages\":[{\"role\":\"user\",\"content\":\"Say hi.\"}],\"stream\":true}"
+    EXTRA_HEADERS=(-H "Content-Type: application/json")
+    ;;
+  *)
+    echo "ERROR: unknown provider '$PROVIDER' (expected: anthropic | llama-local | glm)" >&2
+    exit 1
+    ;;
+esac
+
+echo "# TTFT bench (TTFB proxy): provider=${PROVIDER} model=${MODEL} iter=${ITER}" >&2
+echo "# Note: this measures TTFB, not strict TTFT. See header for details." >&2
+
+samples=()
+failures=0
+for i in $(seq 1 "$ITER") ; do
+  # -N            no buffering (start emitting as soon as body bytes arrive)
+  # -o /dev/null  discard body
+  # -w time_starttransfer  time from start of request to first body byte
+  # --max-time 30 hard cap per request
+  ttfb_s=$(curl -sS -N -o /dev/null \
+    -w "%{time_starttransfer}" \
+    --max-time 30 \
+    -X POST "$URL" \
+    -H "$AUTH_HEADER" \
+    "${EXTRA_HEADERS[@]}" \
+    -d "$BODY" 2>/dev/null) || ttfb_s=""
+
+  if [[ -z "$ttfb_s" || "$ttfb_s" == "0.000000" ]] ; then
+    failures=$((failures + 1))
+    echo "# iter=${i} FAILED" >&2
+    continue
+  fi
+
+  ttfb_ms=$(awk -v t="$ttfb_s" 'BEGIN { printf "%.3f", t * 1000 }')
+  samples+=("$ttfb_ms")
+  echo "${i} ${ttfb_ms}" >&2
+done
+
+n=${#samples[@]}
+if [ "$n" -eq 0 ] ; then
+  echo "ERROR: zero successful samples" >&2
+  exit 1
+fi
+
+# Allow up to 10 % failures before refusing to report; above that the
+# distribution is too biased toward the survivors to be meaningful.
+failure_rate=$(awk -v f="$failures" -v t="$ITER" 'BEGIN { printf "%.2f", (f / t) * 100 }')
+if awk -v fr="$failure_rate" 'BEGIN { exit (fr > 10.0 ? 0 : 1) }' ; then
+  echo "ERROR: failure rate ${failure_rate} % > 10 %" >&2
+  exit 1
+fi
+
+# Aggregate. Sort ascending, then compute p50/p95/max/mean/std via awk.
+printf '%s\n' "${samples[@]}" \
+  | sort -n \
+  | awk -v provider="$PROVIDER" -v model="$MODEL" -v iter="$ITER" '
+      BEGIN { sum = 0 }
+      { a[NR] = $1 ; sum += $1 }
+      END {
+        n = NR
+        p50_idx = int(n * 0.50) ; if (p50_idx < 1) p50_idx = 1
+        p95_idx = int(n * 0.95) ; if (p95_idx < 1) p95_idx = 1
+        p50 = a[p50_idx]
+        p95 = a[p95_idx]
+        pmax = a[n]
+        mean = sum / n
+        var = 0
+        for (i = 1 ; i <= n ; i++) var += (a[i] - mean) ^ 2
+        std = sqrt(var / n)
+        printf "{\"provider\":\"%s\",\"model\":\"%s\",\"iter\":%d,\"samples\":%d,\"p50_ms\":%.2f,\"p95_ms\":%.2f,\"max_ms\":%.2f,\"mean_ms\":%.2f,\"std_ms\":%.2f,\"metric\":\"ttfb_proxy\"}\n", provider, model, iter, n, p50, p95, pmax, mean, std
+      }
+    '


### PR DESCRIPTION
## Summary

PR-1a (#1620) added the typed in-process TTFT capture (`Streaming_summary.ttft_ms`, `prefill_ms`) and the pure classification helpers. PR-1b lands the operational pieces RFC-OAS-020 §4.2 / §5 explicitly deferred from PR-1a: a runnable distribution bench and the SLO target document.

## What lands

| File | Purpose |
|---|---|
| `scripts/bench/ttft_distribution.sh` | 3-provider TTFT distribution bench (executable, `set -euo pipefail`) |
| `docs/PERFORMANCE-SLO.md` | TTFT + prefill_ms target tables + calibration log (new file) |

## Bench design

| Aspect | Choice |
|---|---|
| Providers | `anthropic` / `llama-local` / `glm` (3-row CLI switch) |
| Measurement | `curl -w \"%{time_starttransfer}\"` → TTFB ms |
| Sample size | `$ITER` (default 100) sequential requests |
| Aggregation | sort + awk → JSON line `{p50_ms, p95_ms, max_ms, mean_ms, std_ms, samples, metric:\"ttfb_proxy\"}` |
| Robustness | > 10% per-request failure rate → exit 1 (refuses biased report) |

## Why TTFB (script) ≠ TTFT (in-process)

Documented in script header + SLO doc:

- **Anthropic**: `MessageStart` prelude arrives before the first `ContentBlockDelta`, so TTFB under-reports TTFT by tens of ms.
- **OpenAI-compat / Gemini / GLM / Ollama**: first chunk IS first token (no separable prelude), so TTFB ≈ TTFT within ~5 ms.

The script is therefore for **operational smoke checks**. SLO numbers in `docs/PERFORMANCE-SLO.md` should be calibrated against the in-process `Streaming_summary.ttft_ms` field from PR-1a, not the script output alone. The SLO doc explicitly marks targets as *uncalibrated baseline values at PR-1b* and includes an operator calibration log table.

## Why no OCaml binary

RFC-OAS-020 §4.2 says \"PR-1 ships a benchmark script\". A bash + curl harness:
- avoids spinning up a new `bin/` target
- remains operable without rebuilding `agent_sdk`
- gives operators a portable smoke check

A richer in-process driver that reads `on_telemetry` and reports strict TTFT is a worthy future PR (PR-1c or PR-2) but out of scope here.

## Test plan
- [x] `bash -n scripts/bench/ttft_distribution.sh` — syntax OK
- [x] `./scripts/bench/ttft_distribution.sh nonexistent_provider 1` — exits 1 with clear error
- [ ] Live runs require credentials (ANTHROPIC_API_KEY / GLM_API_KEY) and a local llama-server — out of scope; first operator run populates `docs/PERFORMANCE-SLO.md` calibration log

## Related
- RFC-OAS-020 (Active) — Body PR #1613 (merged)
- PR-1a #1620 (merged) — typed TTFT capture + `Streaming_summary.prefill_ms`

RFC-WAIVED: docs + executable script only. No source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)