### PR TITLE
[codex] Add approval-required fail-closed policy

### DIFF
--- a/docs/rfc/RFC-OAS-021-approval-required-missing-callback-policy.md
+++ b/docs/rfc/RFC-OAS-021-approval-required-missing-callback-policy.md
@@ -1,0 +1,161 @@
+# RFC-OAS-021: ApprovalRequired Missing Callback Policy
+
+| | |
+|---|---|
+| Status | Draft |
+| Author | vincent |
+| Created | 2026-05-17 |
+| Target | `agent_sdk` (oas) |
+| Related | RFC-OAS-013 (keeper tool disclosure), RFC-OAS-008 (typed tool identification), masc-mcp RFC-0109 (keeper admission denial boundary) |
+
+## 0. Summary
+
+`ApprovalRequired` used to execute the tool when no approval callback was
+registered. The behavior preserved compatibility, but it made a safety boundary
+depend on a missing runtime hook:
+
+```ocaml
+ApprovalRequired, approval = None -> execute_without_callback
+```
+
+This RFC adds an explicit policy to `Agent_options`:
+
+```ocaml
+type missing_approval_callback_policy =
+  | Execute_without_callback
+  | Reject_without_callback
+```
+
+The default remains `Execute_without_callback` for compatibility. Runtime
+profiles that need fail-closed safety can select `Reject_without_callback`.
+
+## 1. Problem
+
+`Hooks.ApprovalRequired` communicates a policy decision: a tool must not execute
+until a caller approves it. If the caller forgot to register an approval
+callback, the old SDK behavior logged a debug line and executed anyway.
+
+That shape is worse than a stopped agent:
+
+- the tool side effect still happens;
+- the missing callback is low-visibility;
+- downstream runtimes cannot distinguish "approved" from "approval hook absent";
+- adding only logs or counters would be telemetry-as-fix, not a boundary fix.
+
+## 2. Decision
+
+Missing approval callbacks are a first-class policy choice.
+
+- `Execute_without_callback` keeps legacy behavior and is the default.
+- `Reject_without_callback` returns a deterministic non-retryable tool error:
+  `Tool rejected: approval required but no approval callback is registered`.
+
+The policy is carried in `Agent_options`, configurable through `Builder`, and
+passed into `Agent_tools.execute_tools`.
+
+## 3. API
+
+### 3.1 Hooks
+
+```ocaml
+type missing_approval_callback_policy =
+  | Execute_without_callback
+  | Reject_without_callback
+```
+
+### 3.2 Agent Options
+
+```ocaml
+type options =
+  { ...
+  ; missing_approval_callback_policy : Hooks.missing_approval_callback_policy
+  }
+```
+
+Default:
+
+```ocaml
+missing_approval_callback_policy = Hooks.Execute_without_callback
+```
+
+### 3.3 Builder
+
+```ocaml
+val with_missing_approval_callback_policy :
+  Hooks.missing_approval_callback_policy -> t -> t
+```
+
+### 3.4 Tool Execution
+
+`Agent_tools.execute_tools` receives the policy explicitly:
+
+```ocaml
+~missing_approval_callback_policy:Hooks.missing_approval_callback_policy
+```
+
+On `ApprovalRequired` with no callback:
+
+| Policy | Result |
+|---|---|
+| `Execute_without_callback` | execute tool, preserving legacy behavior |
+| `Reject_without_callback` | return deterministic non-retryable tool error |
+
+## 4. Compatibility
+
+This is a non-breaking runtime default. Existing agents continue executing when
+the callback is absent unless they opt into `Reject_without_callback`.
+
+The only signature change is internal SDK plumbing where `execute_tools` is
+called from `Agent_trace` and tests. Public builder users get an additive setter.
+
+## 5. Verification
+
+Focused gates for the implementation PR:
+
+```bash
+scripts/dune-local.sh build \
+  test/test_approval.exe \
+  test/test_builder.exe \
+  test/test_builder_coverage.exe
+
+./_build/default/test/test_approval.exe
+./_build/default/test/test_builder.exe
+./_build/default/test/test_builder_coverage.exe
+git diff --check
+```
+
+Expected coverage:
+
+- legacy no-callback behavior still executes by default;
+- fail-closed policy rejects without executing;
+- rejection is deterministic and non-retryable;
+- builder setter stores the selected policy;
+- default options expose `Execute_without_callback`.
+
+## 6. Migration
+
+1. Add the policy type in `Hooks`.
+2. Add the option field to `Agent_options`.
+3. Add the builder setter and default.
+4. Pass the policy through `Agent_trace` to `Agent_tools`.
+5. Keep compatibility default until downstream runtime profiles can opt in.
+6. After downstream adoption, consider whether new safety-focused constructors
+   should default to `Reject_without_callback`.
+
+## 7. Acceptance
+
+- [x] Missing approval callback behavior is explicit policy, not an implicit
+  debug fallback.
+- [x] Compatibility default remains unchanged.
+- [x] Fail-closed mode rejects with deterministic non-retryable error.
+- [x] Builder and options expose the policy.
+- [x] Focused tests cover default and fail-closed behavior.
+- [ ] Downstream runtime profile adoption has landed and this RFC records the
+  PR number.
+
+## 8. References
+
+- `lib/agent/agent_tools.ml`: approval gate handling.
+- `lib/base/hooks.ml`: approval hook action and missing-callback policy.
+- `test/test_approval.ml`: default and fail-closed behavior.
+- `reports/keeper-stop-analysis-20260517.html`: OAS #18 / S13 finding.

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -50,6 +50,7 @@ type options = Agent_types.options =
   ; tracer : Tracing.t
   ; raw_trace : Raw_trace.t option
   ; approval : Hooks.approval_callback option
+  ; missing_approval_callback_policy : Hooks.missing_approval_callback_policy
   ; tool_retry_policy : Tool_retry_policy.t option
   ; context_reducer : Context_reducer.t option
   ; tiered_memory : tiered_memory option

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -123,6 +123,17 @@ let tool_exception_result ~id ~name exn =
   }
 ;;
 
+let approval_required_without_callback_result ~id ~name =
+  let reason = "approval required but no approval callback is registered" in
+  { tool_use_id = id
+  ; tool_name = name
+  ; content = "Tool rejected: " ^ reason
+  ; is_error = true
+  ; failure_kind = Some Non_retryable_tool_error
+  ; error_class = Some Types.Deterministic
+  }
+;;
+
 let schedule_tool_use ~tool_index index (id, name, input) =
   let concurrency_class =
     match find_in_index tool_index name with
@@ -493,6 +504,7 @@ let execute_scheduled_tool
       ~turn_count
       ~(usage : Types.usage_stats)
       ~approval
+      ~missing_approval_callback_policy
       ?correlation_id
       ?run_id
       ?on_tool_execution_started
@@ -562,25 +574,33 @@ let execute_scheduled_tool
            | Hooks.ApprovalRequired ->
              (match approval with
               | None ->
-                Log.debug
-                  _log
-                  "ApprovalRequired but no approval callback — executing"
-                  [ Log.S ("tool", name); Log.S ("agent", agent_name) ];
-                find_and_execute_tool_with_index
-                  ~context
-                  ~tool_index
-                  ~hooks
-                  ~event_bus
-                  ~tracer
-                  ~agent_name
-                  ~turn_count
-                  ?correlation_id
-                  ?run_id
-                  ?on_hook_invoked
-                  ~schedule
-                  name
-                  input
-                  id
+                (match missing_approval_callback_policy with
+                 | Hooks.Execute_without_callback ->
+                   Log.debug
+                     _log
+                     "ApprovalRequired but no approval callback — executing"
+                     [ Log.S ("tool", name); Log.S ("agent", agent_name) ];
+                   find_and_execute_tool_with_index
+                     ~context
+                     ~tool_index
+                     ~hooks
+                     ~event_bus
+                     ~tracer
+                     ~agent_name
+                     ~turn_count
+                     ?correlation_id
+                     ?run_id
+                     ?on_hook_invoked
+                     ~schedule
+                     name
+                     input
+                     id
+                 | Hooks.Reject_without_callback ->
+                   Log.warn
+                     _log
+                     "ApprovalRequired but no approval callback — rejecting"
+                     [ Log.S ("tool", name); Log.S ("agent", agent_name) ];
+                   approval_required_without_callback_result ~id ~name)
               | Some approve_fn ->
                 (match approve_fn ~tool_name:name ~input with
                  | Hooks.Approve ->
@@ -725,6 +745,7 @@ let execute_tools
       ~turn_count
       ~(usage : Types.usage_stats)
       ~approval
+      ~missing_approval_callback_policy
       ?correlation_id
       ?run_id
       ?on_tool_execution_started
@@ -765,6 +786,7 @@ let execute_tools
       ~turn_count
       ~usage
       ~approval
+      ~missing_approval_callback_policy
       ?correlation_id
       ?run_id
       ?on_tool_execution_started

--- a/lib/agent/agent_tools.mli
+++ b/lib/agent/agent_tools.mli
@@ -97,7 +97,9 @@ val find_and_execute_tool
 
     For each [ToolUse] block, applies the [PreToolUse] hook before execution.
     Supports approval flow: if the hook returns [ApprovalRequired], the
-    [approval] callback is invoked.
+    [approval] callback is invoked. If no callback is registered,
+    [missing_approval_callback_policy] chooses fail-open compatibility or
+    fail-closed rejection.
 
     Parallel batches catch exceptions per fiber to prevent one tool failure
     from canceling siblings (except [Out_of_memory], [Stack_overflow],
@@ -116,6 +118,7 @@ val execute_tools
   -> turn_count:int
   -> usage:Types.usage_stats
   -> approval:Hooks.approval_callback option
+  -> missing_approval_callback_policy:Hooks.missing_approval_callback_policy
   -> ?correlation_id:string
   -> ?run_id:string
   -> ?on_tool_execution_started:

--- a/lib/agent/agent_trace.ml
+++ b/lib/agent/agent_trace.ml
@@ -92,6 +92,7 @@ let execute_tools_with_trace agent active_run tool_uses =
     ~turn_count:agent.state.turn_count
     ~usage:agent.state.usage
     ~approval:agent.options.approval
+    ~missing_approval_callback_policy:agent.options.missing_approval_callback_policy
     ?correlation_id
     ?run_id
     ?on_tool_execution_started

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -45,6 +45,7 @@ type options =
   ; tracer : Tracing.t
   ; raw_trace : Raw_trace.t option
   ; approval : Hooks.approval_callback option
+  ; missing_approval_callback_policy : Hooks.missing_approval_callback_policy
   ; tool_retry_policy : Tool_retry_policy.t option
   ; context_reducer : Context_reducer.t option
   ; tiered_memory : tiered_memory option
@@ -169,6 +170,7 @@ let default_options =
   ; tracer = Tracing.null
   ; raw_trace = None
   ; approval = None
+  ; missing_approval_callback_policy = Hooks.Execute_without_callback
   ; tool_retry_policy = None
   ; context_reducer = Some Defaults.default_context_reducer
   ; tiered_memory = None

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -80,6 +80,7 @@ type options =
   ; tracer : Tracing.t
   ; raw_trace : Raw_trace.t option
   ; approval : Hooks.approval_callback option
+  ; missing_approval_callback_policy : Hooks.missing_approval_callback_policy
   ; tool_retry_policy : Tool_retry_policy.t option
   ; context_reducer : Context_reducer.t option
   ; tiered_memory : tiered_memory option

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -40,6 +40,7 @@ type t =
   ; tracer : Tracing.t
   ; raw_trace : Raw_trace.t option
   ; approval : Hooks.approval_callback option
+  ; missing_approval_callback_policy : Hooks.missing_approval_callback_policy
   ; tool_retry_policy : Tool_retry_policy.t option
   ; required_tool_satisfaction : Completion_contract.required_tool_satisfaction
   ; context_reducer : Context_reducer.t option
@@ -114,6 +115,7 @@ let create ~net ~model =
   ; tracer = Tracing.null
   ; raw_trace = None
   ; approval = None
+  ; missing_approval_callback_policy = Hooks.Execute_without_callback
   ; tool_retry_policy = None
   ; required_tool_satisfaction = Completion_contract.any_tool_call_satisfies
   ; context_reducer = None
@@ -202,6 +204,10 @@ let with_hooks hooks b = { b with hooks }
 let with_tracer tracer b = { b with tracer }
 let with_raw_trace raw_trace b = { b with raw_trace = Some raw_trace }
 let with_approval approval b = { b with approval = Some approval }
+
+let with_missing_approval_callback_policy missing_approval_callback_policy b =
+  { b with missing_approval_callback_policy }
+;;
 
 let with_tool_retry_policy tool_retry_policy b =
   { b with tool_retry_policy = Some tool_retry_policy }
@@ -422,6 +428,7 @@ let build b =
     ; tracer = b.tracer
     ; raw_trace = b.raw_trace
     ; approval = b.approval
+    ; missing_approval_callback_policy = b.missing_approval_callback_policy
     ; tool_retry_policy = b.tool_retry_policy
     ; context_reducer = b.context_reducer
     ; tiered_memory = b.tiered_memory

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -90,6 +90,9 @@ val with_slot_id : int -> t -> t
 val with_tracer : Tracing.t -> t -> t
 val with_raw_trace : Raw_trace.t -> t -> t
 val with_approval : Hooks.approval_callback -> t -> t
+val with_missing_approval_callback_policy :
+  Hooks.missing_approval_callback_policy -> t -> t
+
 val with_tool_retry_policy : Tool_retry_policy.t -> t -> t
 
 val with_required_tool_satisfaction

--- a/lib/base/hooks.ml
+++ b/lib/base/hooks.ml
@@ -230,6 +230,10 @@ type approval_decision =
   | Reject of string (** Block execution with reason *)
   | Edit of Yojson.Safe.t (** Proceed with modified input *)
 
+type missing_approval_callback_policy =
+  | Execute_without_callback
+  | Reject_without_callback
+
 (** Approval callback: called when a hook returns ApprovalRequired.
     Receives tool name and input, returns approval decision. *)
 type approval_callback = tool_name:string -> input:Yojson.Safe.t -> approval_decision

--- a/lib/base/hooks.mli
+++ b/lib/base/hooks.mli
@@ -155,7 +155,8 @@ type hook_decision =
   | ApprovalRequired
   (** Signals that the tool needs external approval.  If an
           {!approval_callback} is registered the callback is invoked;
-          otherwise the tool is executed and a debug log is emitted. *)
+          otherwise {!missing_approval_callback_policy} decides whether
+          the tool is executed or rejected. *)
   | AdjustParams of turn_params
   | ElicitInput of elicitation_request
   | Nudge of string
@@ -166,6 +167,12 @@ type approval_decision =
   | Approve
   | Reject of string
   | Edit of Yojson.Safe.t
+
+(** Behavior when a [PreToolUse] hook returns [ApprovalRequired] but no
+    {!approval_callback} is registered. *)
+type missing_approval_callback_policy =
+  | Execute_without_callback
+  | Reject_without_callback
 
 (** Approval callback: called when a hook returns ApprovalRequired *)
 type approval_callback = tool_name:string -> input:Yojson.Safe.t -> approval_decision

--- a/test/test_approval.ml
+++ b/test/test_approval.ml
@@ -55,9 +55,19 @@ let make_echo_tool ?descriptor name =
     Ok { Types.content = Yojson.Safe.to_string input })
 ;;
 
-let execute_with_tools_in_env env ~tools ~hooks ?event_bus ?approval tool_uses =
+let execute_with_tools_in_env
+      env
+      ~tools
+      ~hooks
+      ?event_bus
+      ?approval
+      ?(missing_approval_callback_policy = Hooks.Execute_without_callback)
+      tool_uses
+  =
   let net = Eio.Stdenv.net env in
-  let options = { Agent.default_options with hooks; approval } in
+  let options =
+    { Agent.default_options with hooks; approval; missing_approval_callback_policy }
+  in
   let agent = Agent.create ~net ~tools ~options () in
   let opts = Agent.options agent in
   let event_bus =
@@ -75,21 +85,36 @@ let execute_with_tools_in_env env ~tools ~hooks ?event_bus ?approval tool_uses =
     ~turn_count:(Agent.state agent).turn_count
     ~usage:(Agent.state agent).usage
     ~approval:opts.approval
+    ~missing_approval_callback_policy:opts.missing_approval_callback_policy
     tool_uses
 ;;
 
 (** Helper: create a minimal agent inside Eio with given hooks and approval.
     Returns execute_tools results for the given tool_uses. *)
-let run_execute_with_tools ~tools ~hooks ?approval tool_uses =
+let run_execute_with_tools
+      ~tools
+      ~hooks
+      ?approval
+      ?missing_approval_callback_policy
+      tool_uses
+  =
   Eio_main.run
-  @@ fun env -> execute_with_tools_in_env env ~tools ~hooks ?approval tool_uses
+  @@ fun env ->
+  execute_with_tools_in_env
+    env
+    ~tools
+    ~hooks
+    ?approval
+    ?missing_approval_callback_policy
+    tool_uses
 ;;
 
-let run_execute ~hooks ?approval tool_uses =
+let run_execute ~hooks ?approval ?missing_approval_callback_policy tool_uses =
   run_execute_with_tools
     ~tools:[ make_echo_tool "safe"; make_echo_tool "dangerous" ]
     ~hooks
     ?approval
+    ?missing_approval_callback_policy
     tool_uses
 ;;
 
@@ -108,6 +133,33 @@ let test_approval_required_no_callback () =
     check string "id" "t1" result.tool_use_id;
     check string "content" {|"hello"|} result.content;
     check bool "no error" false result.is_error
+  | _ -> fail "expected exactly one result"
+;;
+
+let test_approval_required_no_callback_fail_closed () =
+  let hooks =
+    { Hooks.empty with pre_tool_use = Some (fun _event -> Hooks.ApprovalRequired) }
+  in
+  let results =
+    run_execute
+      ~hooks
+      ~missing_approval_callback_policy:Hooks.Reject_without_callback
+      [ ToolUse { id = "t1"; name = "safe"; input = `String "hello" } ]
+  in
+  match results with
+  | [ result ] ->
+    check string "id" "t1" result.tool_use_id;
+    check string
+      "content"
+      "Tool rejected: approval required but no approval callback is registered"
+      result.content;
+    check bool "is error" true result.is_error;
+    (match result.failure_kind with
+     | Some Agent_tools.Non_retryable_tool_error -> ()
+     | _ -> fail "expected non-retryable tool error");
+    (match result.error_class with
+     | Some Types.Deterministic -> ()
+     | _ -> fail "expected deterministic error class")
   | _ -> fail "expected exactly one result"
 ;;
 
@@ -704,6 +756,10 @@ let () =
     "Approval"
     [ ( "approval_required"
       , [ test_case "no callback = fallthrough" `Quick test_approval_required_no_callback
+        ; test_case
+            "no callback + fail closed = rejected"
+            `Quick
+            test_approval_required_no_callback_fail_closed
         ; test_case "Approve = normal execution" `Quick test_approval_approve
         ; test_case "Reject with reason" `Quick test_approval_reject
         ; test_case "Edit modifies input" `Quick test_approval_edit

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -246,6 +246,21 @@ let test_with_approval () =
     (Option.is_some (Agent.options agent).approval)
 ;;
 
+let test_with_missing_approval_callback_policy () =
+  with_net
+  @@ fun net ->
+  let agent =
+    Builder.create ~net ~model:"claude-sonnet-4-6"
+    |> Builder.with_missing_approval_callback_policy Hooks.Reject_without_callback
+    |> Builder.build_safe
+    |> Result.get_ok
+  in
+  Alcotest.(check bool)
+    "missing approval callback policy set"
+    true
+    ((Agent.options agent).missing_approval_callback_policy = Hooks.Reject_without_callback)
+;;
+
 (* --- 12. with_tool_retry_policy --- *)
 
 let test_with_tool_retry_policy () =
@@ -1036,6 +1051,10 @@ let () =
         ; Alcotest.test_case "hooks" `Quick test_with_hooks
         ; Alcotest.test_case "tracer" `Quick test_with_tracer
         ; Alcotest.test_case "approval" `Quick test_with_approval
+        ; Alcotest.test_case
+            "missing approval callback policy"
+            `Quick
+            test_with_missing_approval_callback_policy
         ; Alcotest.test_case "tool retry policy" `Quick test_with_tool_retry_policy
         ; Alcotest.test_case "context_reducer" `Quick test_with_context_reducer
         ; Alcotest.test_case "tiered_memory" `Quick test_with_tiered_memory

--- a/test/test_builder_coverage.ml
+++ b/test/test_builder_coverage.ml
@@ -217,6 +217,10 @@ let test_agent_default_options () =
   let opts = Agent.default_options in
   Alcotest.(check bool) "no provider" true (opts.provider = None);
   Alcotest.(check bool) "no approval" true (opts.approval = None);
+  Alcotest.(check bool)
+    "missing approval callback executes by default"
+    true
+    (opts.missing_approval_callback_policy = Hooks.Execute_without_callback);
   Alcotest.(check bool) "no event_bus" true (opts.event_bus = None);
   Alcotest.(check bool) "no skill_registry" true (opts.skill_registry = None);
   Alcotest.(check bool) "no memory" true (opts.memory = None);


### PR DESCRIPTION
## Summary

- Add `Hooks.missing_approval_callback_policy`.
- Keep legacy `Execute_without_callback` as the default.
- Add opt-in `Reject_without_callback` fail-closed behavior for `ApprovalRequired` when no approval callback is registered.
- Thread the policy through agent options, builder, trace, and tool execution.
- Add RFC-OAS-021.

## Why

`ApprovalRequired` previously executed the tool when the approval callback was missing. That preserves compatibility, but it is a silent safety bypass for runtimes that expect approval to be mandatory.

This change turns the missing-callback behavior into explicit policy. Safety-focused profiles can now fail closed with a deterministic non-retryable tool error.

## Validation

- `scripts/dune-local.sh build test/test_approval.exe test/test_builder.exe test/test_builder_coverage.exe`
- `./_build/default/test/test_approval.exe` (17 tests)
- `./_build/default/test/test_builder.exe` (44 tests)
- `./_build/default/test/test_builder_coverage.exe` (17 tests)
- `git diff --check`
