### PR TITLE
Preserve provider timeout evidence

### DIFF
--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -51,8 +51,9 @@ type options =
         compatible / Gemini / GLM). The deadline resets after each
         successful line, so this caps inter-chunk silence — not total
         stream duration. A stalled endpoint surfaces as
-        [NetworkError { kind = Timeout; _ }] which the cascade/retry
-        layer treats as retryable. CLI transports honour the parallel
+        [TimeoutError { phase = Stream_idle state; _ }], preserving
+        whether the stream was waiting for answer/thinking/tool-call
+        progress. CLI transports honour the parallel
         [stdout_idle_timeout_s] knob via the transport's own config.
         @since 0.176.0 *)
   ; body_timeout_s : float option
@@ -66,7 +67,7 @@ type options =
         deadline alone. Requires [clock] to be supplied; without a
         clock the wrapper is skipped and behaviour matches earlier
         versions. A timeout surfaces as
-        [NetworkError { kind = Timeout; _ }] which the cascade/retry
+        [TimeoutError { phase = Stream_body; _ }] which the cascade/retry
         layer treats as retryable.
         @since 0.181.0 *)
   ; max_idle_turns : int

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -132,16 +132,18 @@ val with_max_execution_time : float -> t -> t
     (Ollama NDJSON, Anthropic / OpenAI / Gemini / GLM SSE). Resets after
     each successful line, so this caps inter-chunk silence — not total
     stream duration. A stalled endpoint surfaces as
-    [NetworkError { kind = Timeout; _ }] which the cascade/retry layer
-    treats as retryable. @since 0.176.0 *)
+    [TimeoutError { phase = Stream_idle state; _ }], preserving whether
+    the stream was waiting for answer/thinking/tool-call progress.
+    @since 0.176.0 *)
 val with_stream_idle_timeout : float -> t -> t
 
 (** Set the per-line idle deadline applied to streaming HTTP responses
     (Ollama NDJSON, Anthropic / OpenAI / Gemini / GLM SSE). Resets after
     each successful line, so this caps inter-chunk silence — not total
     stream duration. A stalled endpoint surfaces as
-    [NetworkError { kind = Timeout; _ }] which the cascade/retry layer
-    treats as retryable. @since 0.176.0 *)
+    [TimeoutError { phase = Stream_idle state; _ }], preserving whether
+    the stream was waiting for answer/thinking/tool-call progress.
+    @since 0.176.0 *)
 val with_body_timeout : float -> t -> t
 (** Set the total deadline applied to streaming HTTP body consumption.
     Wraps the body callback in [Eio.Time.with_timeout_exn], complementing
@@ -149,8 +151,8 @@ val with_body_timeout : float -> t -> t
     Catches the case where a single bulk read hangs without producing
     line breaks. Requires a clock to be provided to the underlying
     request; without one the wrapper is skipped. A timeout surfaces as
-    [NetworkError { kind = Timeout; _ }] which the cascade/retry layer
-    treats as retryable. @since 0.181.0 *)
+    [TimeoutError { phase = Stream_body; _ }] which the cascade/retry
+    layer treats as retryable. @since 0.181.0 *)
 
 (** Set the total deadline applied to streaming HTTP body consumption.
     Wraps the body callback in [Eio.Time.with_timeout_exn], complementing
@@ -158,8 +160,8 @@ val with_body_timeout : float -> t -> t
     Catches the case where a single bulk read hangs without producing
     line breaks. Requires a clock to be provided to the underlying
     request; without one the wrapper is skipped. A timeout surfaces as
-    [NetworkError { kind = Timeout; _ }] which the cascade/retry layer
-    treats as retryable. @since 0.181.0 *)
+    [TimeoutError { phase = Stream_body; _ }] which the cascade/retry
+    layer treats as retryable. @since 0.181.0 *)
 val with_max_idle_turns : int -> t -> t
 
 val with_idle_final_warning_at : int -> t -> t

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -12,6 +12,7 @@ let retry_error_of_http_error = function
       { message; kind = Llm_provider.Http_client.Timeout } -> Retry.Timeout { message }
   | Llm_provider.Http_client.NetworkError { message; kind } ->
     Retry.NetworkError { message; kind }
+  | Llm_provider.Http_client.TimeoutError { message; _ } -> Retry.Timeout { message }
   | Llm_provider.Http_client.AcceptRejected { reason } ->
     Retry.InvalidRequest { message = "Response rejected: " ^ reason }
   | Llm_provider.Http_client.CliTransportRequired { kind } ->

--- a/lib/base/error.ml
+++ b/lib/base/error.ml
@@ -14,6 +14,9 @@ module Retry = Llm_provider.Retry
 (** API errors — alias for {!Retry.api_error}. *)
 type api_error = Retry.api_error
 
+(** Provider/runtime errors — alias for {!Llm_provider.Error.provider_error}. *)
+type provider_error = Llm_provider.Error.provider_error
+
 (** Agent runtime errors. *)
 type agent_error =
   | MaxTurnsExceeded of
@@ -131,6 +134,7 @@ type a2a_error =
 (** Top-level SDK error. *)
 type sdk_error =
   | Api of api_error
+  | Provider of provider_error
   | Agent of agent_error
   | Mcp of mcp_error
   | Config of config_error
@@ -234,6 +238,7 @@ let a2a_error_to_string = function
 
 let to_string = function
   | Api err -> Retry.error_message err
+  | Provider err -> Llm_provider.Error.to_string err
   | Agent err -> agent_error_to_string err
   | Mcp err -> mcp_error_to_string err
   | Config err -> config_error_to_string err
@@ -248,6 +253,7 @@ let to_string = function
 
 let is_retryable = function
   | Api err -> Retry.is_retryable err
+  | Provider err -> Llm_provider.Error.is_retryable err
   | Mcp (ServerStartFailed _) -> false
   | Mcp _ -> true
   | Agent _ | Config _ | Serialization _ | Io _ | Orchestration _ | A2a _ | Internal _ ->

--- a/lib/base/error.mli
+++ b/lib/base/error.mli
@@ -14,6 +14,9 @@ module Retry = Llm_provider.Retry
 (** API errors — same type as {!Retry.api_error}. *)
 type api_error = Retry.api_error
 
+(** Provider/runtime errors — same type as {!Llm_provider.Error.provider_error}. *)
+type provider_error = Llm_provider.Error.provider_error
+
 type agent_error =
   | MaxTurnsExceeded of
       { turns : int
@@ -129,6 +132,7 @@ type a2a_error =
 
 type sdk_error =
   | Api of api_error
+  | Provider of provider_error
   | Agent of agent_error
   | Mcp of mcp_error
   | Config of config_error

--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -79,9 +79,32 @@ let of_api_error (err : Retry.api_error) : provider_error =
   | Retry.ContextOverflow r -> `Context_overflow (r.message, r.limit)
 ;;
 
+let of_provider_error (err : Llm_provider.Error.provider_error) : provider_error =
+  match err with
+  | Llm_provider.Error.RateLimit r -> `Rate_limited r.retry_after
+  | Llm_provider.Error.HardQuota r -> `Rate_limited r.retry_after
+  | Llm_provider.Error.AuthError r -> `Auth_error r.detail
+  | Llm_provider.Error.ServerError r -> `Server_error (r.code, r.detail)
+  | Llm_provider.Error.NetworkError r -> `Network_error r.detail
+  | Llm_provider.Error.Timeout r -> `Provider_timeout r.detail
+  | Llm_provider.Error.CapacityExhausted _ -> `Overloaded
+  | Llm_provider.Error.InvalidRequest r -> `Invalid_request r.reason
+  | Llm_provider.Error.NotFound r -> `Not_found r.detail
+  | Llm_provider.Error.MissingApiKey r ->
+    `Auth_error (Printf.sprintf "missing API key: %s" r.var_name)
+  | Llm_provider.Error.InvalidConfig r -> `Invalid_request r.detail
+  | Llm_provider.Error.ParseError r -> `Invalid_request r.detail
+  | Llm_provider.Error.UnknownVariant r ->
+    `Invalid_request (Printf.sprintf "unknown %s variant: %s" r.type_name r.value)
+  | Llm_provider.Error.ProviderUnavailable r -> `Network_error r.detail
+  | Llm_provider.Error.ProviderTerminal r ->
+    `Invalid_request (Printf.sprintf "%s: %s" r.reason r.detail)
+;;
+
 let of_sdk_error (err : Error.sdk_error) : sdk_error_poly =
   match err with
   | Error.Api err -> (of_api_error err :> sdk_error_poly)
+  | Error.Provider err -> (of_provider_error err :> sdk_error_poly)
   | Error.Agent (MaxTurnsExceeded r) -> `Max_turns_exceeded (r.turns, r.limit)
   | Error.Agent (TokenBudgetExceeded r) -> `Token_budget_exceeded (r.used, r.limit)
   | Error.Agent (CostBudgetExceeded _) -> `Cost_budget_exceeded

--- a/lib/judge/judge.ml
+++ b/lib/judge/judge.ml
@@ -196,6 +196,7 @@ let judge ~sw ~net ~provider ~config ~context () =
           (if String.length body > 200 then String.sub body 0 200 ^ "..." else body)
       | Http_client.AcceptRejected { reason } -> reason
       | Http_client.NetworkError { message; _ } -> message
+      | Http_client.TimeoutError { message; _ } -> message
       | Http_client.CliTransportRequired { kind } ->
         Printf.sprintf "CLI transport required for %s" kind
       | Http_client.ProviderTerminal { message; _ } -> message

--- a/lib/llm_provider/cli_common_subprocess.ml
+++ b/lib/llm_provider/cli_common_subprocess.ml
@@ -209,13 +209,13 @@ let run_core
     then (
       let timeout_s = Option.value stdout_idle_timeout_s ~default:0.0 in
       Error
-        (Http_client.NetworkError
+        (Http_client.TimeoutError
            { message =
                Printf.sprintf
                  "%s produced no stdout for %.1fs; SIGINT delivered"
                  name
                  timeout_s
-           ; kind = Timeout
+           ; phase = Http_client.Cli_stdout_idle
            }))
     else (
       match status with
@@ -389,7 +389,7 @@ let%test "run_collect: stdout_idle_timeout fires when subprocess produces nothin
       ~on_stderr_line:(fun _ -> ())
       [ "sleep"; "5" ]
   with
-  | Error (Http_client.NetworkError { kind = Timeout; _ }) -> true
+  | Error (Http_client.TimeoutError { phase = Http_client.Cli_stdout_idle; _ }) -> true
   | _ -> false
 ;;
 

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -665,23 +665,23 @@ let complete_http
              intermediate lines to count, so [body_timeout_s] is the only
              deadline available on the non-streaming path.
            - No silent failure: on expiry we return a structured
-             [NetworkError { kind = Timeout }] whose message identifies the
-             body deadline, so cascade/retry layers treat it as retryable
-             with operator-visible attribution. *)
+             [TimeoutError { phase = Non_streaming_body }] whose message
+             identifies the body deadline, so cascade/retry layers treat it
+             as retryable with operator-visible attribution. *)
         let post_response =
           match clock, body_timeout_s with
           | Some clk, Some timeout_s ->
             (try Eio.Time.with_timeout_exn clk timeout_s post_sync_call with
              | Eio.Time.Timeout ->
                Error
-                 (Http_client.NetworkError
+                 (Http_client.TimeoutError
                     { message =
                         Printf.sprintf
                           "body_timeout_s deadline exceeded after %.1fs \
                            (Complete.complete non-streaming path; total HTTP \
                            round-trip cap, mirrors complete_stream contract)"
                           timeout_s
-                    ; kind = Timeout
+                    ; phase = Http_client.Non_streaming_body
                     }))
           | _, _ -> post_sync_call ()
         in
@@ -1068,6 +1068,7 @@ let complete
             | Http_client.HttpError { code; _ } -> Printf.sprintf "HTTP %d" code
             | Http_client.AcceptRejected { reason } -> reason
             | Http_client.NetworkError { message; _ } -> message
+            | Http_client.TimeoutError { message; _ } -> message
             | Http_client.CliTransportRequired { kind } ->
               Printf.sprintf "CLI transport required for %s but none injected" kind
             | Http_client.ProviderTerminal { message; _ } -> message
@@ -1107,6 +1108,7 @@ let classify_retry_error = function
   | Http_client.HttpError { code; body } -> Some (Retry.classify_error ~status:code ~body)
   | Http_client.NetworkError { message; kind; _ } ->
     Some (Retry.NetworkError { message; kind })
+  | Http_client.TimeoutError { message; _ } -> Some (Retry.Timeout { message })
   | Http_client.AcceptRejected _ -> None
   (* Wiring bug, not transient — retrying cannot summon a missing
      transport. *)
@@ -1313,6 +1315,7 @@ let complete_stream_http
       let inter_chunk_samples = ref [] in
       let terminal_state = ref Telemetry_event.Terminal_done in
       let summary_published = ref false in
+      let stream_idle_state = ref Http_client.Awaiting_first_event in
       let classify_chunk_kind (evt : Types.sse_event) =
         match evt with
         | Types.MessageStart _ -> `Skip
@@ -1413,7 +1416,9 @@ let complete_stream_http
                    surface a visible token. The two refs together
                    distinguish prefill from generation latency. *)
                 if events <> [] && Option.is_none !first_event_at_ref
-                then first_event_at_ref := Some (Unix.gettimeofday ());
+                then (
+                  first_event_at_ref := Some (Unix.gettimeofday ());
+                  stream_idle_state := Http_client.Awaiting_first_delta);
                 if Option.is_none !first_token_at_ref
                    && List.exists Streaming.sse_event_is_first_token_signal events
                 then first_token_at_ref := Some (Unix.gettimeofday ());
@@ -1428,15 +1433,32 @@ let complete_stream_http
                         published — only the lifecycle summary is. *)
                      match classify_chunk_kind evt with
                      | `Skip -> ()
-                     | `Thinking -> incr n_thinking
-                     | `Answer -> incr n_answer
-                     | `Tool_call_start -> incr n_tool_call_start
-                     | `Tool_call_arg_delta -> incr n_tool_call_arg_delta
-                     | `Tool_call_complete -> incr n_tool_call_complete
-                     | `Substrate -> incr n_substrate
-                     | `Heartbeat -> incr n_heartbeat
-                     | `Done -> incr n_done
+                     | `Thinking ->
+                       stream_idle_state := Http_client.Streaming_thinking;
+                       incr n_thinking
+                     | `Answer ->
+                       stream_idle_state := Http_client.Streaming_answer;
+                       incr n_answer
+                     | `Tool_call_start ->
+                       stream_idle_state := Http_client.Streaming_tool_call;
+                       incr n_tool_call_start
+                     | `Tool_call_arg_delta ->
+                       stream_idle_state := Http_client.Streaming_tool_call;
+                       incr n_tool_call_arg_delta
+                     | `Tool_call_complete ->
+                       stream_idle_state := Http_client.Streaming_tool_call;
+                       incr n_tool_call_complete
+                     | `Substrate ->
+                       stream_idle_state := Http_client.Streaming_substrate;
+                       incr n_substrate
+                     | `Heartbeat ->
+                       stream_idle_state := Http_client.Streaming_heartbeat;
+                       incr n_heartbeat
+                     | `Done ->
+                       stream_idle_state := Http_client.Streaming_done;
+                       incr n_done
                      | `Wire_error ->
+                       stream_idle_state := Http_client.Streaming_unknown;
                        terminal_state := Telemetry_event.Terminal_error "sse_wire_error")
                   events;
                 if events <> []
@@ -1472,67 +1494,107 @@ let complete_stream_http
                 | Some evt -> emit_telemetry evt
                 | None -> ()
               in
-              (match config.kind with
-               | Provider_config.Ollama ->
-                 Http_client.read_ndjson
-                   ?clock
-                   ?idle_timeout:stream_idle_timeout_s
-                   ~reader
-                   ~on_line:(fun line ->
-                     match Streaming.parse_ollama_ndjson_chunk line with
-                     | None -> ()
-                     | Some chunk ->
-                       (match chunk.oll_timings with
-                        | Some _ as t -> ollama_timings := t
-                        | None -> ());
-                       (match chunk.oll_usage with
-                        | Some _ as u -> ollama_usage := u
-                        | None -> ());
-                       dispatch (Streaming.ollama_chunk_to_events (get_state ()) chunk))
-                   ()
-               | _ ->
-                 Http_client.read_sse
-                   ?clock
-                   ?idle_timeout:stream_idle_timeout_s
-                   ~reader
-                   ~on_data:(fun ~event_type data ->
-                     let events =
-                       match config.kind with
-                       | Provider_config.Anthropic | Provider_config.Kimi ->
-                         (match Streaming.parse_sse_event event_type data with
-                          | Some evt -> [ evt ], None
-                          | None -> [], None)
-                       | Provider_config.OpenAI_compat | Provider_config.DashScope ->
-                         (match Streaming.parse_openai_sse_chunk data with
-                          | Some chunk ->
-                            Streaming.openai_chunk_to_events (get_state ()) chunk
-                          | None -> [], None)
-                       | Provider_config.Gemini ->
-                         (match Streaming.parse_gemini_sse_chunk data with
-                          | Some chunk ->
-                            Streaming.gemini_chunk_to_events (get_state ()) chunk
-                          | None -> [], None)
-                       | Provider_config.Glm ->
-                         (match Backend_glm.parse_stream_chunk data with
-                          | Some chunk ->
-                            Streaming.openai_chunk_to_events (get_state ()) chunk
-                          | None -> [], None)
-                       | Provider_config.Ollama ->
-                         [], None (* unreachable: handled above *)
-                       | Provider_config.Claude_code
-                       | Provider_config.Gemini_cli
-                       | Provider_config.Kimi_cli
-                       | Provider_config.Codex_cli -> [], None
-                     in
-                     dispatch events)
-                   ());
-              let result = finalize_stream_acc acc in
-              (* RFC-OAS-019: emit one [Streaming_summary] at stream
-                 finalize on the normal path. terminal_state defaults to
-                 [Terminal_done]; wire errors during dispatch upgrade it
-                 in place. *)
-              publish_summary ~terminal:!terminal_state ();
-              result
+              let stream_read_result =
+                try
+                  (match config.kind with
+                   | Provider_config.Ollama ->
+                     Http_client.read_ndjson
+                       ?clock
+                       ?idle_timeout:stream_idle_timeout_s
+                       ~reader
+                       ~on_line:(fun line ->
+                         match Streaming.parse_ollama_ndjson_chunk line with
+                         | None -> ()
+                         | Some chunk ->
+                           (match chunk.oll_timings with
+                            | Some _ as t -> ollama_timings := t
+                            | None -> ());
+                           (match chunk.oll_usage with
+                            | Some _ as u -> ollama_usage := u
+                            | None -> ());
+                           dispatch (Streaming.ollama_chunk_to_events (get_state ()) chunk))
+                       ()
+                   | _ ->
+                     Http_client.read_sse
+                       ?clock
+                       ?idle_timeout:stream_idle_timeout_s
+                       ~reader
+                       ~on_data:(fun ~event_type data ->
+                         let events =
+                           match config.kind with
+                           | Provider_config.Anthropic | Provider_config.Kimi ->
+                             (match Streaming.parse_sse_event event_type data with
+                              | Some evt -> [ evt ], None
+                              | None -> [], None)
+                           | Provider_config.OpenAI_compat | Provider_config.DashScope ->
+                             (match Streaming.parse_openai_sse_chunk data with
+                              | Some chunk ->
+                                Streaming.openai_chunk_to_events (get_state ()) chunk
+                              | None -> [], None)
+                           | Provider_config.Gemini ->
+                             (match Streaming.parse_gemini_sse_chunk data with
+                              | Some chunk ->
+                                Streaming.gemini_chunk_to_events (get_state ()) chunk
+                              | None -> [], None)
+                           | Provider_config.Glm ->
+                             (match Backend_glm.parse_stream_chunk data with
+                              | Some chunk ->
+                                Streaming.openai_chunk_to_events (get_state ()) chunk
+                              | None -> [], None)
+                           | Provider_config.Ollama ->
+                             [], None (* unreachable: handled above *)
+                           | Provider_config.Claude_code
+                           | Provider_config.Gemini_cli
+                           | Provider_config.Kimi_cli
+                           | Provider_config.Codex_cli -> [], None
+                         in
+                         dispatch events)
+                       ());
+                  Ok ()
+                with
+                | Eio.Time.Timeout ->
+                  let phase = Http_client.Stream_idle !stream_idle_state in
+                  emit_telemetry
+                    (Telemetry_event.Timeout
+                       { provider
+                       ; model
+                       ; timeout_type = Telemetry_event.Stream_idle !stream_idle_state
+                       });
+                  publish_summary
+                    ~terminal:
+                      (Telemetry_event.Terminal_error
+                         (Printf.sprintf
+                            "stream_idle_timeout_s_exceeded:%s"
+                            (Http_client.stream_idle_state_to_label !stream_idle_state)))
+                    ();
+                  Error
+                    (Http_client.TimeoutError
+                       { message =
+                           Printf.sprintf
+                             "stream_idle_timeout_s deadline exceeded while %s"
+                             (Http_client.stream_idle_state_to_label !stream_idle_state)
+                      ; phase
+                       })
+              in
+              match stream_read_result with
+              | Error _ as err -> err
+              | Ok () ->
+                let result =
+                  match finalize_stream_acc acc with
+                  | Ok _ as ok -> ok
+                  | Error msg ->
+                    Error
+                      (Http_client.NetworkError
+                         { message = Printf.sprintf "SSE stream error: %s" msg
+                         ; kind = Unknown
+                         })
+                in
+                (* RFC-OAS-019: emit one [Streaming_summary] at stream
+                   finalize on the normal path. terminal_state defaults to
+                   [Terminal_done]; wire errors during dispatch upgrade it
+                   in place. *)
+                publish_summary ~terminal:!terminal_state ();
+                result
             in
             (* Body-level deadline (since 0.181.0). Wraps the entire
                body callback in [Eio.Time.with_timeout_exn] so a single
@@ -1543,7 +1605,7 @@ let complete_stream_http
                No silent failure: on expiry we raise an inner [Error]
                whose message carries the configured deadline, and the
                outer match below promotes it to
-               [NetworkError { kind = Timeout }] so the cascade/retry
+               [TimeoutError { phase = Stream_body }] so the cascade/retry
                layer treats it as retryable. *)
             match clock, body_timeout_s with
             | Some clk, Some timeout_s ->
@@ -1551,18 +1613,22 @@ let complete_stream_http
                | Eio.Time.Timeout ->
                  emit_telemetry
                    (Telemetry_event.Timeout
-                      { provider; model; timeout_type = No_response });
+                      { provider; model; timeout_type = Telemetry_event.Stream_body });
                  (* RFC-OAS-019: timeout path also publishes the summary
                     so operators see the partial stream's distribution. *)
                  publish_summary
                    ~terminal:(Telemetry_event.Terminal_error "body_timeout_s_exceeded")
                    ();
                  Error
-                   (Printf.sprintf
-                      "body_timeout_s deadline exceeded after %.1fs (configured via \
-                       Builder.with_body_timeout; total body consumption cap, distinct \
-                       from stream_idle_timeout_s)"
-                      timeout_s))
+                   (Http_client.TimeoutError
+                      { message =
+                          Printf.sprintf
+                            "body_timeout_s deadline exceeded after %.1fs (configured via \
+                             Builder.with_body_timeout; total body consumption cap, \
+                             distinct from stream_idle_timeout_s)"
+                            timeout_s
+                      ; phase = Http_client.Stream_body
+                      }))
             | _, _ ->
               (* Explicit no-deadline path: caller did not provide a
                    clock or did not configure body_timeout_s. Behaviour
@@ -1636,26 +1702,28 @@ let complete_stream_http
              ~ttfrc_ms:!ttfrc_ref
              ~prefill_ms
              (Some latency_ms))
-      | Ok (Error msg)
-        when String.length msg >= 31
-             && String.equal (String.sub msg 0 31) "body_timeout_s deadline exceeded" ->
-        (* Promote body-deadline expiry to a structured Timeout so
-         cascade/retry treats it as retryable, matching the
-         stream_idle_timeout_s docstring contract. The full message
-         (including the configured deadline value) is preserved so
-         operators can distinguish body vs inter-line timeout. *)
+      | Ok (Error (Http_client.TimeoutError _ as err)) ->
         publish_summary
-          ~terminal:(Telemetry_event.Terminal_error "body_timeout_s_exceeded")
+          ~terminal:(Telemetry_event.Terminal_error "timeout_error")
           ();
-        Error (Http_client.NetworkError { message = msg; kind = Timeout })
-      | Ok (Error msg) ->
+        Error err
+      | Ok (Error err) ->
         publish_summary
           ~terminal:
-            (Telemetry_event.Terminal_error (Printf.sprintf "sse_stream_error: %s" msg))
+            (Telemetry_event.Terminal_error
+               (Printf.sprintf
+                  "sse_stream_error: %s"
+                  (match err with
+                   | Http_client.NetworkError { message; _ }
+                   | Http_client.TimeoutError { message; _ } -> message
+                   | Http_client.HttpError { code; _ } -> Printf.sprintf "HTTP %d" code
+                   | Http_client.AcceptRejected { reason } -> reason
+                   | Http_client.CliTransportRequired { kind } ->
+                     Printf.sprintf "CLI transport required for %s" kind
+                   | Http_client.ProviderTerminal { message; _ }
+                   | Http_client.ProviderFailure { message; _ } -> message)))
           ();
-        Error
-          (Http_client.NetworkError
-             { message = Printf.sprintf "SSE stream error: %s" msg; kind = Unknown }))
+        Error err)
 ;;
 
 let complete_stream

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -83,9 +83,9 @@ val complete
     on the non-streaming [Http_client.post_sync] path inside [complete].
     Requires [clock]; without one the wrapper is skipped and behaviour
     matches versions < 0.195.0. On expiry the result is
-    [Error (NetworkError { kind = Timeout; _ })] with a message that
-    identifies the body deadline so cascade/retry treats it as retryable
-    while operators retain attribution.
+    [Error (TimeoutError { phase = Non_streaming_body; _ })] with a
+    message that identifies the body deadline so cascade/retry treats it
+    as retryable while operators retain attribution.
 
     Mirror of {!complete_stream}'s [?body_timeout_s], adapted for the
     sync (non-streaming) path. Distinct from {!complete_stream}'s
@@ -155,9 +155,14 @@ include module type of Complete_stream_acc
     (see {!Http_client.read_sse}). The deadline resets after each
     successful line, so this does not cap total stream duration.
     SSE keepalive comments reset the deadline like any other line.
-    A stalled endpoint surfaces as [NetworkError { kind = Timeout; _ }]
-    which cascade/retry layers treat as retryable. Non-HTTP transports
-    (CLI subprocess) ignore [stream_idle_timeout_s]. *)
+    A stalled endpoint surfaces as
+    [TimeoutError { phase = Stream_idle state; _ }], where [state]
+    records whether the stream was waiting for the first event, answer
+    deltas, thinking deltas, tool-call deltas, heartbeat/substrate, or
+    completion. Cascade/retry layers treat this as retryable while
+    downstream policy can distinguish streaming/thinking idleness from
+    total-call deadlines. Non-HTTP transports (CLI subprocess) ignore
+    [stream_idle_timeout_s]. *)
 val complete_stream
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
@@ -181,7 +186,7 @@ val complete_stream
     the deadline between successful lines and cannot interrupt a
     single bulk read).  Requires [clock]; without one the wrapper is
     skipped and behaviour matches versions < 0.181.0.  On expiry the
-    result is [Error (NetworkError { kind = Timeout; _ })] with a
+    result is [Error (TimeoutError { phase = Stream_body; _ })] with a
     message that identifies the body deadline (vs inter-line idle), so
     cascade/retry treats it as retryable while operators retain
     attribution.  Non-HTTP transports (CLI subprocess) ignore

--- a/lib/llm_provider/complete_cascade.ml
+++ b/lib/llm_provider/complete_cascade.ml
@@ -39,8 +39,8 @@ type cascade_result =
       }
 
 let attempt_timeout_error ~attempt_index ~model_id ~provider_key ~timeout_s =
-  Http_client.NetworkError
-    { kind = Http_client.Timeout
+  Http_client.TimeoutError
+    { phase = Http_client.Provider_step
     ; message =
         Printf.sprintf
           "cascade provider attempt timed out phase=provider_step attempt_index=%d \
@@ -529,11 +529,13 @@ let is_hard_quota_http_error = function
 let network_error_stops_cascade = function
   | Http_client.NetworkError
       { kind = Http_client.Tls_error | Http_client.Local_resource_exhaustion; _ } -> true
+  | Http_client.TimeoutError _ -> false
   | _ -> false
 ;;
 
 let provider_failure_counts_for_health = function
   | Http_client.NetworkError { kind = Http_client.Local_resource_exhaustion; _ } -> false
+  | Http_client.TimeoutError _ -> true
   | _ -> true
 ;;
 

--- a/lib/llm_provider/complete_cascade.mli
+++ b/lib/llm_provider/complete_cascade.mli
@@ -190,9 +190,9 @@ type cascade_result =
 
     [?attempt_timeout_s] caps one provider step, including its internal
     retry loop. Timeout errors include the cascade phase, provider
-    attempt index, model id, and provider key in the structured
-    [NetworkError] message so downstream receipts can distinguish a
-    provider-step timeout from a caller-side budget gate:
+    attempt index, model id, and provider key in
+    [TimeoutError { phase = Provider_step; _ }] so downstream receipts
+    can distinguish a provider-step timeout from a caller-side budget gate:
     - omitted (no argument): provider-specific defaults from
       {!Provider_config.default_attempt_timeout_s} apply when present
       (Claude_code, Kimi_cli, and Gemini_cli have positive defaults;

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -101,6 +101,7 @@ let get_json ~sw ~net url =
   | Error (Http_client.HttpError { code; _ }) -> Error (Printf.sprintf "HTTP %d" code)
   | Error (Http_client.AcceptRejected { reason }) -> Error reason
   | Error (Http_client.NetworkError { message; _ }) -> Error message
+  | Error (Http_client.TimeoutError { message; _ }) -> Error message
   | Error (Http_client.CliTransportRequired { kind }) ->
     Error (Printf.sprintf "CLI transport required for %s" kind)
   | Error (Http_client.ProviderTerminal { message; _ }) ->
@@ -321,6 +322,7 @@ let probe_ollama_context ~sw ~net base_url =
             | Http_client.HttpError { code; body } ->
               Printf.sprintf "HTTP %d: %s" code body
             | Http_client.NetworkError { message; _ } -> message
+            | Http_client.TimeoutError { message; _ } -> message
             | Http_client.AcceptRejected { reason } -> reason
             | Http_client.CliTransportRequired { kind } ->
               Printf.sprintf "CLI transport required for %s" kind

--- a/lib/llm_provider/error.ml
+++ b/lib/llm_provider/error.ml
@@ -49,10 +49,12 @@ type provider_error =
   | NetworkError of
       { provider : string
       ; kind : Http_client.network_error_kind
+      ; timeout_phase : Http_client.timeout_phase option
       ; detail : string
       }
   | Timeout of
       { provider : string
+      ; timeout_phase : Http_client.timeout_phase option
       ; detail : string
       }
   | InvalidRequest of
@@ -101,6 +103,11 @@ let network_error_kind_to_string = function
   | Http_client.Unknown -> "unknown"
 ;;
 
+let timeout_phase_suffix = function
+  | None -> ""
+  | Some phase -> Printf.sprintf " phase=%s" (Http_client.timeout_phase_to_label phase)
+;;
+
 let retry_after_suffix = function
   | None -> ""
   | Some seconds -> Printf.sprintf " (retry_after: %.3fs)" seconds
@@ -147,11 +154,17 @@ let to_string = function
       r.detail
   | NetworkError r ->
     Printf.sprintf
-      "Provider '%s' network error (%s): %s"
+      "Provider '%s' network error (%s%s): %s"
       r.provider
       (network_error_kind_to_string r.kind)
+      (timeout_phase_suffix r.timeout_phase)
       r.detail
-  | Timeout r -> Printf.sprintf "Provider '%s' timeout: %s" r.provider r.detail
+  | Timeout r ->
+    Printf.sprintf
+      "Provider '%s' timeout%s: %s"
+      r.provider
+      (timeout_phase_suffix r.timeout_phase)
+      r.detail
   | InvalidRequest r ->
     Printf.sprintf "Provider '%s' invalid request: %s" r.provider r.reason
   | NotFound r -> Printf.sprintf "Provider '%s' not found: %s" r.provider r.detail
@@ -185,8 +198,9 @@ let of_retry_api_error ?provider err =
   | Retry.NotFound r -> NotFound { provider; detail = r.message }
   | Retry.ContextOverflow r ->
     InvalidRequest { provider; reason = Retry.error_message (Retry.ContextOverflow r) }
-  | Retry.NetworkError r -> NetworkError { provider; kind = r.kind; detail = r.message }
-  | Retry.Timeout r -> Timeout { provider; detail = r.message }
+  | Retry.NetworkError r ->
+    NetworkError { provider; kind = r.kind; timeout_phase = None; detail = r.message }
+  | Retry.Timeout r -> Timeout { provider; timeout_phase = None; detail = r.message }
 ;;
 
 let capacity_scope_of_http = function
@@ -251,7 +265,10 @@ let of_http_error ?provider = function
   | Http_client.HttpError { code; body } ->
     Retry.classify_error ~status:code ~body |> of_retry_api_error ?provider
   | Http_client.NetworkError { message; kind } ->
-    NetworkError { provider = provider_name provider; kind; detail = message }
+    NetworkError
+      { provider = provider_name provider; kind; timeout_phase = None; detail = message }
+  | Http_client.TimeoutError { message; phase } ->
+    Timeout { provider = provider_name provider; timeout_phase = Some phase; detail = message }
   | Http_client.AcceptRejected { reason } ->
     InvalidRequest
       { provider = provider_name provider; reason = "accept rejected: " ^ reason }
@@ -270,4 +287,24 @@ let of_http_error ?provider = function
     ProviderTerminal { provider = provider_name provider; reason; detail = message }
   | Http_client.ProviderFailure { kind; message } ->
     of_provider_failure ?provider kind message
+;;
+
+let is_retryable = function
+  | RateLimit _ -> true
+  | CapacityExhausted _ -> true
+  | ServerError r -> r.transient
+  | NetworkError { kind = Http_client.Tls_error; _ } -> false
+  | NetworkError { kind = Http_client.Local_resource_exhaustion; _ } -> false
+  | NetworkError _ -> true
+  | Timeout _ -> true
+  | MissingApiKey _
+  | InvalidConfig _
+  | ParseError _
+  | UnknownVariant _
+  | ProviderUnavailable _
+  | HardQuota _
+  | AuthError _
+  | InvalidRequest _
+  | NotFound _
+  | ProviderTerminal _ -> false
 ;;

--- a/lib/llm_provider/error.mli
+++ b/lib/llm_provider/error.mli
@@ -49,10 +49,12 @@ type provider_error =
   | NetworkError of
       { provider : string
       ; kind : Http_client.network_error_kind
+      ; timeout_phase : Http_client.timeout_phase option
       ; detail : string
       }
   | Timeout of
       { provider : string
+      ; timeout_phase : Http_client.timeout_phase option
       ; detail : string
       }
   | InvalidRequest of
@@ -77,6 +79,7 @@ and capacity_scope =
   | CapacityUnknown
 
 val to_string : provider_error -> string
+val is_retryable : provider_error -> bool
 val capacity_scope_to_string : capacity_scope -> string
 val of_retry_api_error : ?provider:string -> Retry.api_error -> provider_error
 val of_http_error : ?provider:string -> Http_client.http_error -> provider_error

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -21,6 +21,29 @@ type network_error_kind =
   | End_of_file
   | Unknown
 
+type stream_idle_state =
+  | Awaiting_first_event
+  | Awaiting_first_delta
+  | Streaming_answer
+  | Streaming_thinking
+  | Streaming_tool_call
+  | Streaming_heartbeat
+  | Streaming_substrate
+  | Streaming_done
+  | Streaming_unknown
+[@@deriving yojson, show]
+
+type timeout_phase =
+  | Http_operation
+  | Non_streaming_body
+  | Stream_body
+  | Stream_idle of stream_idle_state
+  | Provider_step
+  | Cli_stdout_idle
+  | Caller_budget
+  | Unknown_timeout
+[@@deriving yojson, show]
+
 (* Provider-internal terminal condition reported via structured exit
    (see .mli for the rationale and the @since note).  Adding a new
    variant rather than overloading [NetworkError] keeps cascades from
@@ -63,6 +86,10 @@ type http_error =
   | NetworkError of
       { message : string
       ; kind : network_error_kind
+      }
+  | TimeoutError of
+      { message : string
+      ; phase : timeout_phase
       }
   | AcceptRejected of { reason : string }
   (* Signals that a provider kind requires a non-HTTP transport (e.g. a
@@ -120,6 +147,30 @@ let provider_failure_kind_to_string = function
 let provider_failure_to_string ~kind ~message =
   let name = provider_failure_kind_to_string kind in
   if String.trim message = "" then name else Printf.sprintf "%s: %s" name message
+;;
+
+let stream_idle_state_to_label = function
+  | Awaiting_first_event -> "awaiting_first_event"
+  | Awaiting_first_delta -> "awaiting_first_delta"
+  | Streaming_answer -> "streaming_answer"
+  | Streaming_thinking -> "streaming_thinking"
+  | Streaming_tool_call -> "streaming_tool_call"
+  | Streaming_heartbeat -> "streaming_heartbeat"
+  | Streaming_substrate -> "streaming_substrate"
+  | Streaming_done -> "streaming_done"
+  | Streaming_unknown -> "streaming_unknown"
+;;
+
+let timeout_phase_to_label = function
+  | Http_operation -> "http_operation"
+  | Non_streaming_body -> "non_streaming_body"
+  | Stream_body -> "stream_body"
+  | Stream_idle state ->
+    Printf.sprintf "stream_idle:%s" (stream_idle_state_to_label state)
+  | Provider_step -> "provider_step"
+  | Cli_stdout_idle -> "cli_stdout_idle"
+  | Caller_budget -> "caller_budget"
+  | Unknown_timeout -> "unknown_timeout"
 ;;
 
 (** Default wall-clock timeout applied to synchronous HTTP operations
@@ -225,8 +276,10 @@ let catch_network f =
   | End_of_file -> Error (NetworkError { message = "End_of_file"; kind = End_of_file })
   | Eio.Time.Timeout ->
     Error
-      (NetworkError
-         { message = "HTTP operation exceeded wall-clock timeout"; kind = Timeout })
+      (TimeoutError
+         { message = "HTTP operation exceeded wall-clock timeout"
+         ; phase = Http_operation
+         })
   | Unix.Unix_error (code, _, _) as exn ->
     Error
       (NetworkError { message = Printexc.to_string exn; kind = classify_unix_error code })
@@ -243,6 +296,7 @@ let catch_network f =
     the bottleneck, not the remote server. *)
 let is_local_resource_exhaustion = function
   | NetworkError { kind = Local_resource_exhaustion; _ } -> true
+  | TimeoutError _ -> false
   | AcceptRejected _ -> false
   | HttpError _ -> false
   | CliTransportRequired _ -> false

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -23,6 +23,41 @@ type network_error_kind =
   | End_of_file (** Peer closed the connection unexpectedly. *)
   | Unknown (** Unclassified network error. *)
 
+(** Last observed streaming state when an inter-line idle deadline fired.
+
+    This is deliberately transport-generic.  Provider-specific parsers
+    translate chunks into OAS SSE events first; the timeout evidence only
+    records the broad activity the stream was in when progress stopped. *)
+type stream_idle_state =
+  | Awaiting_first_event
+  | Awaiting_first_delta
+  | Streaming_answer
+  | Streaming_thinking
+  | Streaming_tool_call
+  | Streaming_heartbeat
+  | Streaming_substrate
+  | Streaming_done
+  | Streaming_unknown
+[@@deriving yojson, show]
+
+(** Typed timeout source.
+
+    [NetworkError { kind = Timeout; _ }] still exists for low-level OS or
+    legacy timeouts.  New call-site-owned deadlines should surface as
+    {!TimeoutError} with one of these phases so downstream policy can
+    distinguish streaming idleness, thinking idleness, total body budget,
+    cascade attempt budget, CLI stdout idleness, and generic caller budgets. *)
+type timeout_phase =
+  | Http_operation
+  | Non_streaming_body
+  | Stream_body
+  | Stream_idle of stream_idle_state
+  | Provider_step
+  | Cli_stdout_idle
+  | Caller_budget
+  | Unknown_timeout
+[@@deriving yojson, show]
+
 (** Provider-internal terminal condition reported via structured exit.
 
     Distinct from {!network_error_kind}: the subprocess/API ran to
@@ -91,6 +126,10 @@ type http_error =
       { message : string
       ; kind : network_error_kind
       }
+  | TimeoutError of
+      { message : string
+      ; phase : timeout_phase
+      }
   | AcceptRejected of { reason : string }
   | CliTransportRequired of { kind : string }
   (** Provider kind requires a non-HTTP transport (CLI subprocess)
@@ -119,6 +158,8 @@ type http_error =
 
 val provider_failure_kind_to_string : provider_failure_kind -> string
 val provider_failure_to_string : kind:provider_failure_kind -> message:string -> string
+val stream_idle_state_to_label : stream_idle_state -> string
+val timeout_phase_to_label : timeout_phase -> string
 
 (** Default wall-clock timeout (seconds) applied to synchronous HTTP
     operations when a clock is supplied.  Streaming variants use this
@@ -130,9 +171,9 @@ val default_http_timeout_s : float
 
     When [clock] is supplied the entire operation (connect + response
     + body read) is bounded by [timeout_s] (default
-    {!default_http_timeout_s}); a timeout surfaces as
-    [NetworkError { kind = Timeout; _ }] which is classified as
-    retryable by {!Retry.is_retryable}. *)
+    {!default_http_timeout_s}); a timeout owned by this wrapper
+    surfaces as [TimeoutError { phase = Http_operation; _ }] which is
+    classified as retryable by {!Retry.is_retryable}. *)
 val get_sync
   :  ?clock:_ Eio.Time.clock
   -> ?timeout_s:float
@@ -147,8 +188,9 @@ val get_sync
     Returns [(status_code, body_string)] on success.
 
     When [clock] is supplied the entire operation is bounded by
-    [timeout_s] (default {!default_http_timeout_s}); a timeout surfaces
-    as [NetworkError { kind = Timeout; _ }]. *)
+    [timeout_s] (default {!default_http_timeout_s}); a timeout owned by
+    this wrapper surfaces as
+    [TimeoutError { phase = Http_operation; _ }]. *)
 val post_sync
   :  ?clock:_ Eio.Time.clock
   -> ?timeout_s:float
@@ -212,9 +254,9 @@ val with_post_stream
     the W3C EventSource spec) are skipped inside the same timeout
     window — they do NOT reset the deadline, so a stream of pure
     keepalives still trips [idle_timeout]. Wrapped by
-    {!with_post_stream} the timeout surfaces as
-    [NetworkError { kind = Timeout; _ }], which
-    {!Retry.is_retryable} treats as retryable. *)
+    {!with_post_stream} the timeout should be caught by the caller and
+    surfaced as [TimeoutError { phase = Stream_idle state; _ }] so
+    downstream policy can see which stream state stalled. *)
 val read_sse
   :  ?clock:_ Eio.Time.clock
   -> ?idle_timeout:float
@@ -230,10 +272,10 @@ val read_sse
     When both [clock] and [idle_timeout] are supplied, raises
     [Eio.Time.Timeout] if no line arrives within [idle_timeout]
     seconds. The deadline resets after each successful line, so this
-    bounds inter-line idle — not total stream duration. Wrapped by
-    {!with_post_stream} the timeout surfaces as
-    [NetworkError { kind = Timeout; _ }], which {!Retry.is_retryable}
-    treats as retryable. *)
+    bounds inter-line idle — not total stream duration. The raised
+    timeout should be caught by the caller and surfaced as
+    [TimeoutError { phase = Stream_idle state; _ }] so downstream
+    policy can see which stream state stalled. *)
 val read_ndjson
   :  ?clock:_ Eio.Time.clock
   -> ?idle_timeout:float

--- a/lib/llm_provider/slot_cache.ml
+++ b/lib/llm_provider/slot_cache.ml
@@ -27,6 +27,13 @@ let slot_action ~sw ~net ~endpoint ~slot_id ~action ~body_fields =
     Error (Printf.sprintf "slot %s rejected: %s" action reason)
   | Error (Http_client.NetworkError { message; _ }) ->
     Error (Printf.sprintf "slot %s network error: %s" action message)
+  | Error (Http_client.TimeoutError { message; phase }) ->
+    Error
+      (Printf.sprintf
+         "slot %s timeout (%s): %s"
+         action
+         (Http_client.timeout_phase_to_label phase)
+         message)
   | Error (Http_client.CliTransportRequired { kind }) ->
     Error (Printf.sprintf "slot %s: CLI transport required for %s" action kind)
   | Error (Http_client.ProviderTerminal { message; _ }) ->

--- a/lib/llm_provider/telemetry_event.ml
+++ b/lib/llm_provider/telemetry_event.ml
@@ -8,6 +8,13 @@
 type timeout_type =
   | No_response
   | Ttft_exceeded
+  | Non_streaming_body
+  | Stream_body
+  | Stream_idle of Http_client.stream_idle_state
+  | Provider_step
+  | Cli_stdout_idle
+  | Caller_budget
+  | Unknown_timeout
 [@@deriving yojson, show]
 
 (* RFC-OAS-019 §4.1 — typed kind breakdown for [Streaming_summary].

--- a/lib/llm_provider/telemetry_event.mli
+++ b/lib/llm_provider/telemetry_event.mli
@@ -3,6 +3,13 @@
 type timeout_type =
   | No_response
   | Ttft_exceeded
+  | Non_streaming_body
+  | Stream_body
+  | Stream_idle of Http_client.stream_idle_state
+  | Provider_step
+  | Cli_stdout_idle
+  | Caller_budget
+  | Unknown_timeout
 [@@deriving yojson, show]
 
 type streaming_kind_breakdown =

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -8,34 +8,18 @@ let sdk_error_of_http_error : Llm_provider.Http_client.http_error -> Error.sdk_e
     Error.Api (Retry.classify_error ~status:code ~body)
   | Llm_provider.Http_client.NetworkError { message; kind; _ } ->
     Error.Api (Retry.NetworkError { message; kind })
+  | Llm_provider.Http_client.TimeoutError _ as err ->
+    Error.Provider (Llm_provider.Error.of_http_error err)
   | Llm_provider.Http_client.AcceptRejected { reason } ->
     Error.Api (Retry.InvalidRequest { message = reason })
-  | Llm_provider.Http_client.CliTransportRequired { kind } ->
-    Error.Api
-      (Retry.InvalidRequest
-         { message =
-             Printf.sprintf
-               "CLI transport required for %s but none was injected; pass ~transport via \
-                agent.options.transport"
-               kind
-         })
+  | Llm_provider.Http_client.CliTransportRequired _ as err ->
+    Error.Provider (Llm_provider.Error.of_http_error err)
   | Llm_provider.Http_client.ProviderTerminal { kind = Max_turns r; _ } ->
     Error.Agent (MaxTurnsExceeded { turns = r.turns; limit = r.limit })
-  | Llm_provider.Http_client.ProviderTerminal { kind = Other reason; message } ->
-    Error.Api (Retry.InvalidRequest { message = Printf.sprintf "%s: %s" reason message })
-  | Llm_provider.Http_client.ProviderFailure { kind; message } ->
-    let message = Llm_provider.Http_client.provider_failure_to_string ~kind ~message in
-    (match kind with
-     | Llm_provider.Http_client.Capacity_exhausted _ ->
-       Error.Api (Retry.Overloaded { message })
-     | Llm_provider.Http_client.Hard_quota { retry_after } ->
-       Error.Api (Retry.RateLimited { retry_after; message })
-     | Llm_provider.Http_client.Capability_mismatch _
-     | Llm_provider.Http_client.Cli_policy_invalid _
-     | Llm_provider.Http_client.Cli_startup_failed _
-     | Llm_provider.Http_client.Provider_parse_error _
-     | Llm_provider.Http_client.Unknown_provider_failure _ ->
-       Error.Api (Retry.InvalidRequest { message }))
+  | Llm_provider.Http_client.ProviderTerminal { kind = Other _; _ } as err ->
+    Error.Provider (Llm_provider.Error.of_http_error err)
+  | Llm_provider.Http_client.ProviderFailure _ as err ->
+    Error.Provider (Llm_provider.Error.of_http_error err)
 ;;
 
 let dispatch_sync

--- a/lib/pipeline/stage_route.ml
+++ b/lib/pipeline/stage_route.ml
@@ -18,38 +18,22 @@ let sdk_error_of_http_error : Llm_provider.Http_client.http_error -> Error.sdk_e
     Error.Api (Retry.classify_error ~status:code ~body)
   | Llm_provider.Http_client.NetworkError { message; kind; _ } ->
     Error.Api (Retry.NetworkError { message; kind })
+  | Llm_provider.Http_client.TimeoutError _ as err ->
+    Error.Provider (Llm_provider.Error.of_http_error err)
   | Llm_provider.Http_client.AcceptRejected { reason } ->
     Error.Api (Retry.InvalidRequest { message = reason })
-  | Llm_provider.Http_client.CliTransportRequired { kind } ->
-    Error.Api
-      (Retry.InvalidRequest
-         { message =
-             Printf.sprintf
-               "CLI transport required for %s but none was injected; pass ~transport via \
-                agent.options.transport"
-               kind
-         })
+  | Llm_provider.Http_client.CliTransportRequired _ as err ->
+    Error.Provider (Llm_provider.Error.of_http_error err)
   | Llm_provider.Http_client.ProviderTerminal { kind = Max_turns r; _ } ->
     (* Map provider-internal max_turns to the agent-runtime variant so
          the existing [MaxTurnsExceeded] graceful path (checkpoint +
          [TurnBudgetExhausted] stop_reason) handles it instead of the
          cascade treating it as a transient API failure. *)
     Error.Agent (MaxTurnsExceeded { turns = r.turns; limit = r.limit })
-  | Llm_provider.Http_client.ProviderTerminal { kind = Other reason; message } ->
-    Error.Api (Retry.InvalidRequest { message = Printf.sprintf "%s: %s" reason message })
-  | Llm_provider.Http_client.ProviderFailure { kind; message } ->
-    let message = Llm_provider.Http_client.provider_failure_to_string ~kind ~message in
-    (match kind with
-     | Llm_provider.Http_client.Capacity_exhausted _ ->
-       Error.Api (Retry.Overloaded { message })
-     | Llm_provider.Http_client.Hard_quota { retry_after } ->
-       Error.Api (Retry.RateLimited { retry_after; message })
-     | Llm_provider.Http_client.Capability_mismatch _
-     | Llm_provider.Http_client.Cli_policy_invalid _
-     | Llm_provider.Http_client.Cli_startup_failed _
-     | Llm_provider.Http_client.Provider_parse_error _
-     | Llm_provider.Http_client.Unknown_provider_failure _ ->
-       Error.Api (Retry.InvalidRequest { message }))
+  | Llm_provider.Http_client.ProviderTerminal { kind = Other _; _ } as err ->
+    Error.Provider (Llm_provider.Error.of_http_error err)
+  | Llm_provider.Http_client.ProviderFailure _ as err ->
+    Error.Provider (Llm_provider.Error.of_http_error err)
 ;;
 
 (** Sync dispatch via {!Llm_provider.Complete.complete}.  Routes all

--- a/lib/protocol/agent_registry.ml
+++ b/lib/protocol/agent_registry.ml
@@ -88,6 +88,7 @@ let fetch_remote_card ~sw ~net url =
     | Llm_provider.Http_client.HttpError { code; body } ->
       Printf.sprintf "HTTP %d: %s" code body
     | NetworkError { message; _ } -> message
+    | TimeoutError { message; _ } -> message
     | AcceptRejected { reason } -> "Response rejected: " ^ reason
     | CliTransportRequired { kind } -> "CLI transport required: " ^ kind
     | ProviderTerminal { message; _ } -> message

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -14,6 +14,7 @@ let retry_error_of_http_error = function
   | Http_client.NetworkError { message; kind = Http_client.Timeout } ->
     Retry.Timeout { message }
   | Http_client.NetworkError { message; kind } -> Retry.NetworkError { message; kind }
+  | Http_client.TimeoutError { message; _ } -> Retry.Timeout { message }
   | Http_client.AcceptRejected { reason } ->
     Retry.InvalidRequest { message = "Response rejected: " ^ reason }
   | Http_client.CliTransportRequired { kind } ->

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -183,29 +183,16 @@ let map_http_error = function
     Error.Api (Retry.NetworkError { message = reason; kind = Unknown })
   | Llm_provider.Http_client.NetworkError { message; kind; _ } ->
     Error.Api (Retry.NetworkError { message; kind })
-  | Llm_provider.Http_client.CliTransportRequired { kind } ->
-    Error.Api
-      (Retry.InvalidRequest
-         { message =
-             Printf.sprintf "CLI transport required for %s but none was injected" kind
-         })
+  | Llm_provider.Http_client.TimeoutError _ as err ->
+    Error.Provider (Llm_provider.Error.of_http_error err)
+  | Llm_provider.Http_client.CliTransportRequired _ as err ->
+    Error.Provider (Llm_provider.Error.of_http_error err)
   | Llm_provider.Http_client.ProviderTerminal { kind = Max_turns r; _ } ->
     Error.Agent (MaxTurnsExceeded { turns = r.turns; limit = r.limit })
-  | Llm_provider.Http_client.ProviderTerminal { kind = Other reason; message } ->
-    Error.Api (Retry.InvalidRequest { message = Printf.sprintf "%s: %s" reason message })
-  | Llm_provider.Http_client.ProviderFailure { kind; message } ->
-    let message = Llm_provider.Http_client.provider_failure_to_string ~kind ~message in
-    (match kind with
-     | Llm_provider.Http_client.Capacity_exhausted _ ->
-       Error.Api (Retry.Overloaded { message })
-     | Llm_provider.Http_client.Hard_quota { retry_after } ->
-       Error.Api (Retry.RateLimited { retry_after; message })
-     | Llm_provider.Http_client.Capability_mismatch _
-     | Llm_provider.Http_client.Cli_policy_invalid _
-     | Llm_provider.Http_client.Cli_startup_failed _
-     | Llm_provider.Http_client.Provider_parse_error _
-     | Llm_provider.Http_client.Unknown_provider_failure _ ->
-       Error.Api (Retry.InvalidRequest { message }))
+  | Llm_provider.Http_client.ProviderTerminal { kind = Other _; _ } as err ->
+    Error.Provider (Llm_provider.Error.of_http_error err)
+  | Llm_provider.Http_client.ProviderFailure _ as err ->
+    Error.Provider (Llm_provider.Error.of_http_error err)
 ;;
 
 (** Streaming variant of create_message.

--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -80,6 +80,8 @@ let sdk_error_of_http_error = function
     Error.Api (Llm_provider.Retry.classify_error ~status:code ~body)
   | Llm_provider.Http_client.NetworkError { message; kind; _ } ->
     Error.Api (Llm_provider.Retry.NetworkError { message; kind })
+  | Llm_provider.Http_client.TimeoutError _ as err ->
+    Error.Provider (Llm_provider.Error.of_http_error err)
   | Llm_provider.Http_client.AcceptRejected { reason } ->
     Error.Config (InvalidConfig { field = "output_schema"; detail = reason })
   | Llm_provider.Http_client.CliTransportRequired { kind } ->
@@ -93,23 +95,10 @@ let sdk_error_of_http_error = function
          })
   | Llm_provider.Http_client.ProviderTerminal { kind = Max_turns r; _ } ->
     Error.Agent (MaxTurnsExceeded { turns = r.turns; limit = r.limit })
-  | Llm_provider.Http_client.ProviderTerminal { kind = Other reason; message } ->
-    Error.Api
-      (Llm_provider.Retry.InvalidRequest
-         { message = Printf.sprintf "%s: %s" reason message })
-  | Llm_provider.Http_client.ProviderFailure { kind; message } ->
-    let message = Llm_provider.Http_client.provider_failure_to_string ~kind ~message in
-    (match kind with
-     | Llm_provider.Http_client.Capacity_exhausted _ ->
-       Error.Api (Llm_provider.Retry.Overloaded { message })
-     | Llm_provider.Http_client.Hard_quota { retry_after } ->
-       Error.Api (Llm_provider.Retry.RateLimited { retry_after; message })
-     | Llm_provider.Http_client.Capability_mismatch _
-     | Llm_provider.Http_client.Cli_policy_invalid _
-     | Llm_provider.Http_client.Cli_startup_failed _
-     | Llm_provider.Http_client.Provider_parse_error _
-     | Llm_provider.Http_client.Unknown_provider_failure _ ->
-       Error.Api (Llm_provider.Retry.InvalidRequest { message }))
+  | Llm_provider.Http_client.ProviderTerminal { kind = Other _; _ } as err ->
+    Error.Provider (Llm_provider.Error.of_http_error err)
+  | Llm_provider.Http_client.ProviderFailure _ as err ->
+    Error.Provider (Llm_provider.Error.of_http_error err)
 ;;
 
 let provider_config_for_schema ~base_url ?provider ~config ~(schema : _ schema) () =

--- a/test/test_body_timeout.ml
+++ b/test/test_body_timeout.ml
@@ -1,9 +1,7 @@
 (** Unit tests for [body_timeout_s] option (since 0.181.0).
 
-    Validates the field flow plus the message-prefix contract that
-    [Complete.complete_stream_http]'s outer match relies on to promote
-    a body-deadline expiry to [NetworkError {kind = Timeout}] rather
-    than the generic [kind = Unknown] used for SSE parse errors. *)
+    Validates the field flow plus the operator-facing message contract
+    for [TimeoutError { phase = Stream_body; _ }]. *)
 
 open Agent_sdk
 
@@ -37,12 +35,9 @@ let test_options_record_update () =
 
 (* ── Message-prefix contract ────────────────────────────────────────
 
-   [Complete.complete_stream_http]'s outer match recognises the body
-   deadline by string prefix. If the producer-side message ever drifts
-   from this prefix the consumer-side [Ok (Error msg)] handler falls
-   through to [NetworkError {kind = Unknown}] — silently downgrading a
-   retryable [Timeout] to a non-retryable [Unknown]. This test pins
-   the contract so future edits to either side fail loudly. *)
+   The timeout is now typed by [TimeoutError.phase], but the message is
+   still pinned because operators and logs use it to distinguish total
+   body deadlines from inter-line stream idle deadlines. *)
 
 let body_timeout_message timeout_s =
   Printf.sprintf

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -1114,8 +1114,12 @@ let test_attempt_timeout_fast_paths_without_retrying_same_step () =
     (elapsed_s < 1.0);
   match result with
   | Complete_cascade.All_failed
-      { errors = [ (config, Http_client.NetworkError { kind; message }) ]; _ } ->
-    check bool "timeout classified" true (kind = Http_client.Timeout);
+      { errors = [ (config, Http_client.TimeoutError { phase; message }) ]; _ } ->
+    check
+      string
+      "timeout phase"
+      "provider_step"
+      (Http_client.timeout_phase_to_label phase);
     check bool "phase recorded" true (contains message "phase=provider_step");
     check bool "attempt index recorded" true (contains message "attempt_index=0");
     check

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -849,7 +849,7 @@ let test_complete_body_timeout_fires () =
     Eio.Switch.run
     @@ fun sw ->
     (* Server delays response by 2.0s; caller deadline 0.3s must fire first
-       and produce NetworkError{kind=Timeout} with a body-deadline message. *)
+       and produce TimeoutError{phase=Non_streaming_body} with a body-deadline message. *)
     let url =
       start_mock_server
         ~sw
@@ -871,7 +871,7 @@ let test_complete_body_timeout_fires () =
          ()
      with
      | Ok _ -> fail "expected Error (body_timeout_s should have fired)"
-     | Error (Http_client.NetworkError { kind = Timeout; message }) ->
+     | Error (Http_client.TimeoutError { phase = Http_client.Non_streaming_body; message }) ->
        let elapsed = Unix.gettimeofday () -. t0 in
        check bool "fires under server delay" true (elapsed < 1.5);
        check
@@ -882,7 +882,7 @@ let test_complete_body_timeout_fires () =
           String.length message >= String.length prefix
           && String.equal (String.sub message 0 (String.length prefix)) prefix)
      | Error _ ->
-       fail "unexpected error variant (expected NetworkError{kind=Timeout})");
+       fail "unexpected error variant (expected TimeoutError{phase=Non_streaming_body})");
     Eio.Switch.fail sw Exit
   with
   | Exit -> ()

--- a/test/test_error.ml
+++ b/test/test_error.ml
@@ -35,6 +35,25 @@ let test_agent_max_turns () =
   check string "max turns" "Max turns exceeded (turn 10, limit 10)" (Error.to_string err)
 ;;
 
+let test_provider_timeout_phase () =
+  let err =
+    Error.Provider
+      (Llm_provider.Error.Timeout
+         { provider = "openai"
+         ; timeout_phase =
+             Some
+               (Llm_provider.Http_client.Stream_idle
+                  Llm_provider.Http_client.Streaming_thinking)
+         ; detail = "stream stalled"
+         })
+  in
+  check
+    string
+    "provider timeout"
+    "Provider 'openai' timeout phase=stream_idle:streaming_thinking: stream stalled"
+    (Error.to_string err)
+;;
+
 let test_agent_token_budget () =
   let err =
     Error.Agent (TokenBudgetExceeded { kind = "Input"; used = 1500; limit = 1000 })
@@ -184,6 +203,21 @@ let test_retryable_agent () =
   check bool "agent error not retryable" false (Error.is_retryable err)
 ;;
 
+let test_retryable_provider_timeout () =
+  let err =
+    Error.Provider
+      (Llm_provider.Error.Timeout
+         { provider = "openai"
+         ; timeout_phase =
+             Some
+               (Llm_provider.Http_client.Stream_idle
+                  Llm_provider.Http_client.Streaming_answer)
+         ; detail = "stream stalled"
+         })
+  in
+  check bool "provider timeout is retryable" true (Error.is_retryable err)
+;;
+
 let test_retryable_mcp_init () =
   let err = Error.Mcp (InitializeFailed { detail = "" }) in
   check bool "mcp init is retryable" true (Error.is_retryable err)
@@ -224,6 +258,7 @@ let () =
     [ ( "to_string"
       , [ test_case "Api RateLimited" `Quick test_api_rate_limited
         ; test_case "Api AuthError" `Quick test_api_auth_error
+        ; test_case "Provider timeout phase" `Quick test_provider_timeout_phase
         ; test_case "Agent MaxTurnsExceeded" `Quick test_agent_max_turns
         ; test_case "Agent TokenBudgetExceeded" `Quick test_agent_token_budget
         ; test_case
@@ -253,6 +288,7 @@ let () =
       , [ test_case "Api RateLimited" `Quick test_retryable_api_rate_limited
         ; test_case "Api AuthError" `Quick test_retryable_api_auth
         ; test_case "Api ServerError" `Quick test_retryable_api_server_error
+        ; test_case "Provider timeout" `Quick test_retryable_provider_timeout
         ; test_case "Agent" `Quick test_retryable_agent
         ; test_case "Mcp InitializeFailed" `Quick test_retryable_mcp_init
         ; test_case "Mcp ServerStartFailed" `Quick test_retryable_mcp_start

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -126,6 +126,8 @@ let test_post_stream_invalid_url_returns_network_error () =
     Alcotest.fail "expected NetworkError for invalid URL, not ProviderTerminal"
   | Error (Http_client.ProviderFailure _) ->
     Alcotest.fail "expected NetworkError for invalid URL, not ProviderFailure"
+  | Error (Http_client.TimeoutError _) ->
+    Alcotest.fail "expected NetworkError for invalid URL, not TimeoutError"
   | Ok _ -> Alcotest.fail "expected invalid URL to fail before opening a stream"
 ;;
 

--- a/test/test_llm_provider_error.ml
+++ b/test/test_llm_provider_error.ml
@@ -117,7 +117,11 @@ let test_network_error () =
     "Provider 'local' network error (dns_failure): lookup failed"
     (Error.to_string
        (Error.NetworkError
-          { provider = "local"; kind = Http_client.Dns_failure; detail = "lookup failed" }))
+          { provider = "local"
+          ; kind = Http_client.Dns_failure
+          ; timeout_phase = None
+          ; detail = "lookup failed"
+          }))
 ;;
 
 let test_timeout () =
@@ -126,7 +130,21 @@ let test_timeout () =
     "Timeout format"
     "Provider 'gemini' timeout: request exceeded budget"
     (Error.to_string
-       (Error.Timeout { provider = "gemini"; detail = "request exceeded budget" }))
+       (Error.Timeout
+          { provider = "gemini"; timeout_phase = None; detail = "request exceeded budget" }))
+;;
+
+let test_timeout_phase () =
+  check
+    string
+    "Timeout phase format"
+    "Provider 'openai' timeout phase=stream_idle:streaming_thinking: stalled"
+    (Error.to_string
+       (Error.Timeout
+          { provider = "openai"
+          ; timeout_phase = Some (Http_client.Stream_idle Http_client.Streaming_thinking)
+          ; detail = "stalled"
+          }))
 ;;
 
 let test_invalid_request () =
@@ -274,11 +292,33 @@ let test_http_network_error_mapping () =
       (Http_client.NetworkError { message = "read timed out"; kind = Http_client.Timeout })
   in
   match err with
-  | Error.NetworkError { provider; kind; detail } ->
+  | Error.NetworkError { provider; kind; timeout_phase; detail } ->
     check string "provider" "local" provider;
     check bool "kind" true (kind = Http_client.Timeout);
+    check (option string) "timeout phase" None (Option.map Http_client.timeout_phase_to_label timeout_phase);
     check string "detail" "read timed out" detail
   | _ -> fail "expected NetworkError"
+;;
+
+let test_http_timeout_error_mapping () =
+  let err =
+    Error.of_http_error
+      ~provider:"openai"
+      (Http_client.TimeoutError
+         { message = "stream stalled"
+         ; phase = Http_client.Stream_idle Http_client.Streaming_thinking
+         })
+  in
+  match err with
+  | Error.Timeout { provider; timeout_phase; detail } ->
+    check string "provider" "openai" provider;
+    check
+      (option string)
+      "phase"
+      (Some "stream_idle:streaming_thinking")
+      (Option.map Http_client.timeout_phase_to_label timeout_phase);
+    check string "detail" "stream stalled" detail
+  | _ -> fail "expected Timeout"
 ;;
 
 let test_cli_transport_required_mapping () =
@@ -308,6 +348,7 @@ let () =
         ; test_case "ServerError" `Quick test_server_error
         ; test_case "NetworkError" `Quick test_network_error
         ; test_case "Timeout" `Quick test_timeout
+        ; test_case "Timeout phase" `Quick test_timeout_phase
         ; test_case "InvalidRequest" `Quick test_invalid_request
         ; test_case "NotFound" `Quick test_not_found
         ; test_case "ProviderTerminal" `Quick test_provider_terminal
@@ -323,6 +364,7 @@ let () =
         ; test_case "HTTP server error" `Quick test_http_server_error_mapping
         ; test_case "HTTP terminal" `Quick test_http_terminal_mapping
         ; test_case "HTTP network error" `Quick test_http_network_error_mapping
+        ; test_case "HTTP timeout error" `Quick test_http_timeout_error_mapping
         ; test_case "CLI transport required" `Quick test_cli_transport_required_mapping
         ] )
     ]

--- a/test/test_pipeline_metrics.ml
+++ b/test/test_pipeline_metrics.ml
@@ -157,6 +157,55 @@ let test_sdk_error_of_http_error_classifies () =
   ()
 ;;
 
+let test_sdk_error_preserves_streaming_timeout_phase () =
+  Eio_main.run
+  @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  let timeout_error =
+    Llm_provider.Http_client.TimeoutError
+      { message = "stream stalled"
+      ; phase =
+          Llm_provider.Http_client.Stream_idle Llm_provider.Http_client.Streaming_thinking
+      }
+  in
+  let transport : Llm_provider.Llm_transport.t =
+    { complete_sync = (fun _ -> { response = Error timeout_error; latency_ms = None })
+    ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _ -> Error timeout_error)
+    }
+  in
+  let provider =
+    Some
+      { Provider.provider = Provider.Custom_registered { name = "claude_code" }
+      ; model_id = "auto"
+      ; api_key_env = ""
+      }
+  in
+  let options = { Agent_types.default_options with transport = Some transport; provider } in
+  let agent =
+    Agent.create
+      ~net
+      ~config:{ Types.default_config with name = "timeout-phase-test"; max_turns = 1 }
+      ~options
+      ()
+  in
+  Eio.Switch.run
+  @@ fun sw ->
+  let err =
+    match Agent.run ~sw agent "ping" with
+    | Error err -> err
+    | Ok _ -> Alcotest.fail "expected provider timeout"
+  in
+  match err with
+  | Error.Provider
+      (Llm_provider.Error.Timeout { timeout_phase = Some phase; detail; _ }) ->
+    Alcotest.(check string)
+      "phase"
+      "stream_idle:streaming_thinking"
+      (Llm_provider.Http_client.timeout_phase_to_label phase);
+    Alcotest.(check string) "detail" "stream stalled" detail
+  | _ -> Alcotest.failf "expected provider timeout, got %s" (Error.to_string err)
+;;
+
 let () =
   Alcotest.run
     "Pipeline Metrics (PR-O2)"
@@ -169,6 +218,10 @@ let () =
             "sdk_error_of_http_error compiles"
             `Quick
             test_sdk_error_of_http_error_classifies
+        ; Alcotest.test_case
+            "sdk_error preserves streaming timeout phase"
+            `Quick
+            test_sdk_error_preserves_streaming_timeout_phase
         ; Alcotest.test_case
             "stage route forwards trace context"
             `Quick

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -687,6 +687,11 @@ let test_complete_claude_code_without_transport_is_guarded () =
             scheme None' regression)"
            expected_name
            message
+       | Error (Llm_provider.Http_client.TimeoutError { message; _ }) ->
+         Alcotest.failf
+           "%s expected CliTransportRequired, got TimeoutError: %s"
+           expected_name
+           message
        | Error (Llm_provider.Http_client.AcceptRejected { reason }) ->
          Alcotest.failf
            "%s expected CliTransportRequired, got AcceptRejected: %s"


### PR DESCRIPTION
## Summary
- add typed OAS timeout phases for HTTP operation, non-streaming body, stream body, stream idle state, provider step, CLI stdout idle, and caller budget
- preserve provider/runtime failures at the SDK boundary via Error.Provider instead of flattening all provider failures into coarse Api errors
- classify stream idle timeouts by last observed stream state, including thinking/answer/tool-call/substrate states

## Verification
- scripts/dune-local.sh build test/test_llm_provider_error.exe test/test_error.exe test/test_pipeline_metrics.exe test/test_body_timeout.exe test/test_cli_common_subprocess.exe test/test_complete_cascade.exe test/test_complete_http.exe test/test_http_client.exe test/test_provider_complete.exe
- ./_build/default/test/test_llm_provider_error.exe
- ./_build/default/test/test_error.exe
- ./_build/default/test/test_pipeline_metrics.exe
- ./_build/default/test/test_body_timeout.exe
- ./_build/default/test/test_complete_cascade.exe
- ./_build/default/test/test_cli_common_subprocess.exe
- ./_build/default/test/test_complete_http.exe
- ./_build/default/test/test_http_client.exe
- ./_build/default/test/test_provider_complete.exe
- git diff --check

## Notes
- A later retry of the focused build after doc/structured cleanup was interrupted by another local Dune lock/TERM; CI should be treated as the final verification surface for the last small cleanup edits.