### PR TITLE
[codex] log tool result relocation persist failures

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -245,16 +245,20 @@ let start_periodic_callbacks ~sw ?clock (cbs : periodic_callback list) =
                    | (Eio.Cancel.Cancelled _ | Out_of_memory | Stack_overflow | Sys.Break)
                      as ex -> raise ex
                    | exn ->
-                     Printf.eprintf
-                       "periodic callback raised: %s\n%!"
-                       (Printexc.to_string exn));
+                     Log.warn
+                       _log
+                       "periodic callback raised"
+                       [ Log.S ("error", Printexc.to_string exn) ]);
                  tick ())
              in
              try tick () with
              | (Eio.Cancel.Cancelled _ | Out_of_memory | Stack_overflow | Sys.Break) as ex
                -> raise ex
              | exn ->
-               Printf.eprintf "periodic tick crashed: %s\n%!" (Printexc.to_string exn));
+               Log.warn
+                 _log
+                 "periodic tick crashed"
+                 [ Log.S ("error", Printexc.to_string exn) ]);
            fun () -> active := false)
         cbs
     in

--- a/lib/agent/agent_trace.ml
+++ b/lib/agent/agent_trace.ml
@@ -2,6 +2,8 @@ open Types
 open Agent_types
 open Result_syntax
 
+let _log = Log.create ~module_name:"agent_trace" ()
+
 let record_hook_invocation active_run ~hook_name ~decision ?detail () =
   match active_run with
   | None -> ()
@@ -126,7 +128,10 @@ let invoke_on_run_complete agent ~ok =
   | Some cb ->
     (try cb ok with
      | exn ->
-       Printf.eprintf "[WARN] on_run_complete raised: %s\n%!" (Printexc.to_string exn))
+       Log.warn
+         _log
+         "on_run_complete callback raised"
+         [ Log.S ("error", Printexc.to_string exn) ])
 ;;
 
 let with_raw_trace_run agent user_prompt f =

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -9,6 +9,8 @@
 
 open Types
 
+let _log = Log.create ~module_name:"agent_turn" ()
+
 (* ── Fingerprint-based idle detection ─────────────────────────── *)
 
 type tool_call_fingerprint =
@@ -598,6 +600,27 @@ let update_idle_detection ~idle_state ~tool_uses =
     Pass [~max_result_chars:0] to disable. *)
 let default_max_tool_result_chars = 50_000
 
+let record_replacement_or_ignore crs replacement =
+  try Content_replacement_state.record_replacement crs replacement with
+  | Invalid_argument _ -> ()
+;;
+
+let record_kept_or_ignore crs tool_use_id =
+  try Content_replacement_state.record_kept crs tool_use_id with
+  | Invalid_argument _ -> ()
+;;
+
+let warn_tool_result_persist_failed ~phase ~tool_use_id ~content_chars err =
+  Log.warn
+    _log
+    "tool_result_relocation_persist_failed"
+    [ S ("phase", phase)
+    ; S ("tool_use_id", tool_use_id)
+    ; I ("content_chars", content_chars)
+    ; S ("error", Error.to_string err)
+    ]
+;;
+
 (** Process tool results into ToolResult content blocks.
     All entries are valid ToolUse results — non-ToolUse blocks are filtered
     upstream in {!Agent_tools.execute_tools}.
@@ -680,17 +703,21 @@ let make_tool_results
                    ~content:sanitized
                with
                | Ok preview ->
-                 (try
-                    Content_replacement_state.record_replacement
-                      crs
-                      { tool_use_id = result.tool_use_id
-                      ; preview
-                      ; original_chars = String.length sanitized
-                      }
-                  with
-                  | Invalid_argument _ -> ());
+                 record_replacement_or_ignore
+                   crs
+                   { tool_use_id = result.tool_use_id
+                   ; preview
+                   ; original_chars = String.length sanitized
+                   };
                  preview
-               | Error _ -> sanitized
+               | Error err ->
+                 warn_tool_result_persist_failed
+                   ~phase:"threshold"
+                   ~tool_use_id:result.tool_use_id
+                   ~content_chars:(String.length sanitized)
+                   err;
+                 record_kept_or_ignore crs result.tool_use_id;
+                 sanitized
              in
              result.tool_use_id, content, result.is_error, false)
            else
@@ -752,24 +779,21 @@ let make_tool_results
                  Tool_result_store.persist store ~tool_use_id:tid ~content:original
                with
                | Ok preview ->
-                 (try
-                    Content_replacement_state.record_replacement
-                      crs
-                      { tool_use_id = tid
-                      ; preview
-                      ; original_chars = String.length original
-                      }
-                  with
-                  | Invalid_argument _ -> ());
+                 record_replacement_or_ignore
+                   crs
+                   { tool_use_id = tid; preview; original_chars = String.length original };
                  preview
-               | Error _ ->
-                 (try Content_replacement_state.record_kept crs tid with
-                  | Invalid_argument _ -> ());
+               | Error err ->
+                 warn_tool_result_persist_failed
+                   ~phase:"aggregate"
+                   ~tool_use_id:tid
+                   ~content_chars:(String.length original)
+                   err;
+                 record_kept_or_ignore crs tid;
                  content)
              else (
                (* Under budget — record as kept *)
-               (try Content_replacement_state.record_kept crs tid with
-                | Invalid_argument _ -> ());
+               record_kept_or_ignore crs tid;
                content)
            else content
          in

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -1,5 +1,7 @@
 open Types
 
+let _log = Log.create ~module_name:"agent_types" ()
+
 type periodic_callback =
   { interval_sec : float
   ; callback : unit -> unit
@@ -268,8 +270,8 @@ let card t =
     write could interleave, losing an update.
 
     Validates the transition against {!Agent_lifecycle.valid_transitions}.
-    Invalid transitions are rejected: the state is not updated and an
-    error is logged to stderr. *)
+    Invalid transitions are rejected: the state is not updated and a
+    structured error record is logged. *)
 let set_lifecycle
       agent
       ?current_run_id
@@ -290,10 +292,12 @@ let set_lifecycle
       | Some prev ->
         (match Agent_lifecycle.transition ~from:prev.status ~to_:status with
          | Error e ->
-           Printf.eprintf
-             "[ERROR] %s (agent=%s)\n%!"
-             (Agent_lifecycle.transition_error_to_string e)
-             agent.state.config.name;
+           Log.error
+             _log
+             "invalid lifecycle transition"
+             [ Log.S ("agent", agent.state.config.name)
+             ; Log.S ("error", Agent_lifecycle.transition_error_to_string e)
+             ];
            false
          | Ok _ -> true)
       | None -> true

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -190,6 +190,7 @@ let with_optional_timeout ~clock ~timeout_s f =
 let classify_unix_error = function
   | Unix.ECONNREFUSED -> Connection_refused
   | Unix.ECONNRESET -> Connection_refused
+  | Unix.EPIPE -> End_of_file
   | Unix.ETIMEDOUT -> Timeout
   | Unix.ENETUNREACH -> Dns_failure
   | Unix.EHOSTUNREACH -> Dns_failure
@@ -238,6 +239,8 @@ let classify_by_message msg =
   let m = String.lowercase_ascii msg in
   if has_substr m "connection refused" || has_substr m "connection reset"
   then Connection_refused
+  else if has_substr m "connection closed by peer" || has_substr m "broken pipe"
+  then End_of_file
   else if has_substr m "timed out" || has_substr m "timeout"
   then Timeout
   else if
@@ -712,7 +715,7 @@ let%test "catch_network maps End_of_file to NetworkError with kind" =
 
 let%test "catch_network maps Sys_error to NetworkError" =
   match catch_network (fun () -> raise (Sys_error "broken pipe")) with
-  | Error (NetworkError { message; kind = Unknown }) ->
+  | Error (NetworkError { message; kind = End_of_file }) ->
     has_substr (String.lowercase_ascii message) "broken pipe"
   | _ -> false
 ;;
@@ -751,8 +754,8 @@ let%test "classify_unix_error: EADDRNOTAVAIL" =
   classify_unix_error Unix.EADDRNOTAVAIL = Local_resource_exhaustion
 ;;
 
-let%test "classify_unix_error: catchall returns Unknown" =
-  classify_unix_error Unix.EPIPE = Unknown
+let%test "classify_unix_error: EPIPE is End_of_file" =
+  classify_unix_error Unix.EPIPE = End_of_file
 ;;
 
 let%test "classify_unix_error: ECONNRESET is Connection_refused" =
@@ -855,7 +858,13 @@ let%test "classify_by_message: resource exhaustion" =
   classify_by_message "Too many open files" = Local_resource_exhaustion
 ;;
 
-let%test "classify_by_message: unknown" = classify_by_message "broken pipe" = Unknown
+let%test "classify_by_message: broken pipe" =
+  classify_by_message "broken pipe" = End_of_file
+;;
+
+let%test "classify_by_message: connection closed by peer" =
+  classify_by_message "connection closed by peer" = End_of_file
+;;
 
 let%test "classify_by_message: connection reset by peer" =
   classify_by_message "Connection reset by peer" = Connection_refused

--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -38,6 +38,16 @@ let default_config =
   }
 ;;
 
+let network_error_kind_label = function
+  | Http_client.Connection_refused -> "connection_refused"
+  | Http_client.Dns_failure -> "dns_failure"
+  | Http_client.Tls_error -> "tls_error"
+  | Http_client.Timeout -> "timeout"
+  | Http_client.Local_resource_exhaustion -> "local_resource_exhaustion"
+  | Http_client.End_of_file -> "end_of_file"
+  | Http_client.Unknown -> "unknown"
+;;
+
 let error_message = function
   | RateLimited r -> Printf.sprintf "Rate limited: %s" r.message
   | Overloaded r -> Printf.sprintf "Overloaded: %s" r.message
@@ -52,7 +62,9 @@ let error_message = function
       | None -> ""
     in
     Printf.sprintf "Context overflow%s: %s" limit_str r.message
-  | NetworkError r -> Printf.sprintf "Network error: %s" r.message
+  | NetworkError { message; kind = Unknown } -> Printf.sprintf "Network error: %s" message
+  | NetworkError { message; kind } ->
+    Printf.sprintf "Network error (%s): %s" (network_error_kind_label kind) message
   | Timeout r -> Printf.sprintf "Timeout: %s" r.message
 ;;
 

--- a/test/test_agent_periodic_cleanup.ml
+++ b/test/test_agent_periodic_cleanup.ml
@@ -35,12 +35,13 @@ let make_transport ~clock ~sleep_s () : Llm_provider.Llm_transport.t =
   }
 ;;
 
-let make_agent ~net ~transport ~callback () =
+let make_agent ?on_run_complete ~net ~transport ?(periodic_callbacks = []) () =
   let options =
     { Agent.default_options with
       provider = Some provider
     ; transport = Some transport
-    ; periodic_callbacks = [ callback ]
+    ; periodic_callbacks
+    ; on_run_complete
     }
   in
   let config =
@@ -51,6 +52,22 @@ let make_agent ~net ~transport ~callback () =
     }
   in
   Agent.create ~net ~config ~options ()
+;;
+
+let with_log_capture f =
+  let sink, get_records = Log.collector_sink () in
+  Log.clear_sinks ();
+  Log.set_global_level Log.Info;
+  Log.add_sink sink;
+  Fun.protect
+    ~finally:(fun () ->
+      Log.clear_sinks ();
+      Log.set_global_level Log.Info)
+    (fun () -> f get_records)
+;;
+
+let has_log_message message records =
+  List.exists (fun (record : Log.record) -> String.equal record.message message) records
 ;;
 
 let check_callback_loop_stopped ~clock calls =
@@ -73,7 +90,9 @@ let test_run_stops_periodic_callbacks_after_success () =
     { interval_sec = 0.005; callback = (fun () -> Atomic.incr calls) }
   in
   let transport = make_transport ~clock ~sleep_s:0.03 () in
-  let agent = make_agent ~net:(Eio.Stdenv.net env) ~transport ~callback () in
+  let agent =
+    make_agent ~net:(Eio.Stdenv.net env) ~transport ~periodic_callbacks:[ callback ] ()
+  in
   (match Agent.run ~sw ~clock agent "finish" with
    | Ok _ -> ()
    | Error err -> Alcotest.fail ("expected success: " ^ Error.to_string err));
@@ -91,7 +110,9 @@ let test_run_stops_periodic_callbacks_after_cancellation () =
     { interval_sec = 0.005; callback = (fun () -> Atomic.incr calls) }
   in
   let transport = make_transport ~clock ~sleep_s:1.0 () in
-  let agent = make_agent ~net:(Eio.Stdenv.net env) ~transport ~callback () in
+  let agent =
+    make_agent ~net:(Eio.Stdenv.net env) ~transport ~periodic_callbacks:[ callback ] ()
+  in
   (try
      ignore
        (Eio.Time.with_timeout_exn clock 0.05 (fun () ->
@@ -113,11 +134,69 @@ let test_run_stream_uses_same_cleanup_scope () =
     { interval_sec = 0.005; callback = (fun () -> Atomic.incr calls) }
   in
   let transport = make_transport ~clock ~sleep_s:0.03 () in
-  let agent = make_agent ~net:(Eio.Stdenv.net env) ~transport ~callback () in
+  let agent =
+    make_agent ~net:(Eio.Stdenv.net env) ~transport ~periodic_callbacks:[ callback ] ()
+  in
   (match Agent.run_stream ~sw ~clock ~on_event:(fun _ -> ()) agent "finish" with
    | Ok _ -> ()
    | Error err -> Alcotest.fail ("expected stream success: " ^ Error.to_string err));
   check_callback_loop_stopped ~clock calls
+;;
+
+let test_on_run_complete_failure_is_structured_log () =
+  with_log_capture
+  @@ fun get_records ->
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let transport = make_transport ~clock ~sleep_s:0.0 () in
+  let agent =
+    make_agent
+      ~net:(Eio.Stdenv.net env)
+      ~transport
+      ~on_run_complete:(fun _ -> failwith "completion sink failed")
+      ()
+  in
+  (match Agent.run ~sw ~clock agent "finish" with
+   | Ok _ -> ()
+   | Error err -> Alcotest.fail ("expected success: " ^ Error.to_string err));
+  Alcotest.(check bool)
+    "on_run_complete failure logged"
+    true
+    (has_log_message "on_run_complete callback raised" (get_records ()))
+;;
+
+let test_periodic_callback_failure_is_structured_log () =
+  with_log_capture
+  @@ fun get_records ->
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let calls = Atomic.make 0 in
+  let callback : Agent.periodic_callback =
+    { interval_sec = 0.005
+    ; callback =
+        (fun () ->
+          Atomic.incr calls;
+          failwith "periodic sink failed")
+    }
+  in
+  let transport = make_transport ~clock ~sleep_s:0.03 () in
+  let agent =
+    make_agent ~net:(Eio.Stdenv.net env) ~transport ~periodic_callbacks:[ callback ] ()
+  in
+  (match Agent.run ~sw ~clock agent "finish" with
+   | Ok _ -> ()
+   | Error err -> Alcotest.fail ("expected success: " ^ Error.to_string err));
+  Alcotest.(check bool) "callback loop had started" true (Atomic.get calls > 0);
+  Alcotest.(check bool)
+    "periodic callback failure logged"
+    true
+    (has_log_message "periodic callback raised" (get_records ()))
 ;;
 
 let () =
@@ -136,6 +215,14 @@ let () =
             "run_stream uses same cleanup"
             `Quick
             test_run_stream_uses_same_cleanup_scope
+        ; Alcotest.test_case
+            "on_run_complete failure uses structured log"
+            `Quick
+            test_on_run_complete_failure_is_structured_log
+        ; Alcotest.test_case
+            "periodic callback failure uses structured log"
+            `Quick
+            test_periodic_callback_failure_is_structured_log
         ] )
     ]
 ;;

--- a/test/test_agent_race.ml
+++ b/test/test_agent_race.ml
@@ -17,6 +17,22 @@ let make_agent env =
   Agent.create ~net:(Eio.Stdenv.net env) ~tools ()
 ;;
 
+let with_log_capture f =
+  let sink, get_records = Log.collector_sink () in
+  Log.clear_sinks ();
+  Log.set_global_level Log.Info;
+  Log.add_sink sink;
+  Fun.protect
+    ~finally:(fun () ->
+      Log.clear_sinks ();
+      Log.set_global_level Log.Info)
+    (fun () -> f get_records)
+;;
+
+let has_log_message message records =
+  List.exists (fun (record : Log.record) -> String.equal record.message message) records
+;;
+
 (* ── Test: concurrent set_lifecycle from parallel fibers ── *)
 
 let test_concurrent_set_lifecycle () =
@@ -167,6 +183,22 @@ let test_clone_independent_state () =
   Alcotest.(check int) "clone updated" 99 (Agent.state cloned).turn_count
 ;;
 
+let test_invalid_lifecycle_transition_is_structured_log () =
+  with_log_capture
+  @@ fun get_records ->
+  Eio_main.run
+  @@ fun env ->
+  let agent = make_agent env in
+  Agent.set_lifecycle agent Completed;
+  Agent.set_lifecycle agent Running;
+  let snap = Option.get (Agent.lifecycle agent) in
+  Alcotest.(check bool) "terminal lifecycle preserved" true (snap.status = Completed);
+  Alcotest.(check bool)
+    "invalid lifecycle transition logged"
+    true
+    (has_log_message "invalid lifecycle transition" (get_records ()))
+;;
+
 (* ── Runner ───────────────────────────────────────────────── *)
 
 let () =
@@ -192,6 +224,10 @@ let () =
             `Quick
             test_lifecycle_transition_order
         ; Alcotest.test_case "clone independent state" `Quick test_clone_independent_state
+        ; Alcotest.test_case
+            "invalid lifecycle transition uses structured log"
+            `Quick
+            test_invalid_lifecycle_transition_is_structured_log
         ] )
     ]
 ;;

--- a/test/test_retry.ml
+++ b/test/test_retry.ml
@@ -119,6 +119,11 @@ let test_error_message_all_variants () =
     ; Retry.InvalidRequest { message = "wrong" }, "Invalid request: wrong"
     ; Retry.NotFound { message = "no model" }, "Not found: no model"
     ; Retry.NetworkError { message = "dns"; kind = Unknown }, "Network error: dns"
+    ; ( Retry.NetworkError
+          { message = "failed to resolve hostname: api.z.ai"; kind = Dns_failure }
+      , "Network error (dns_failure): failed to resolve hostname: api.z.ai" )
+    ; ( Retry.NetworkError { message = "reset"; kind = Connection_refused }
+      , "Network error (connection_refused): reset" )
     ; Retry.Timeout { message = "10s" }, "Timeout: 10s"
     ]
   in

--- a/test/test_tool_result_relocation.ml
+++ b/test/test_tool_result_relocation.ml
@@ -255,6 +255,48 @@ let test_make_tool_results_with_relocation () =
   rm_rf dir
 ;;
 
+let test_make_tool_results_persist_failure_freezes_kept () =
+  let dir = tmp_dir () in
+  let config : Tool_result_store.config =
+    { storage_dir = dir
+    ; session_id = "s1"
+    ; threshold_chars = 100
+    ; preview_chars = 50
+    ; aggregate_budget = 0
+    }
+  in
+  let store = Tool_result_store.create config |> Result.get_ok in
+  let crs = Content_replacement_state.create () in
+  let original = String.make 200 'x' in
+  let mock_results : Agent_tools.tool_execution_result list =
+    [ { tool_use_id = "..."
+      ; tool_name = "read"
+      ; content = original
+      ; is_error = false
+      ; failure_kind = None
+      ; error_class = None
+      }
+    ]
+  in
+  let blocks = Agent_turn.make_tool_results ~relocation:(store, crs) mock_results in
+  (match blocks with
+   | [ Types.ToolResult { tool_use_id; content; _ } ] ->
+     Alcotest.(check string) "id preserved" "..." tool_use_id;
+     Alcotest.(check string) "content kept" original content
+   | _ -> Alcotest.fail "expected one ToolResult");
+  Alcotest.(check bool)
+    "persist failed"
+    false
+    (Tool_result_store.has store ~tool_use_id:"...");
+  Alcotest.(check bool)
+    "failure frozen as kept"
+    true
+    (Content_replacement_state.is_frozen crs "..."
+     && Content_replacement_state.lookup_replacement crs "..." = None);
+  let _ = Tool_result_store.cleanup store in
+  rm_rf dir
+;;
+
 (* ── 4. Compaction + relocation compose ───────────────── *)
 
 let test_compaction_preserves_relocated_previews () =
@@ -585,6 +627,10 @@ let () =
             "relocation integration"
             `Quick
             test_make_tool_results_with_relocation
+        ; Alcotest.test_case
+            "persist failure freezes kept"
+            `Quick
+            test_make_tool_results_persist_failure_freezes_kept
         ] )
     ; ( "compaction_compose"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary

- log tool-result relocation persist failures through structured `Log.warn`
- freeze failed relocation decisions as kept so the same failed persist path is not retried on replay
- add a regression test for invalid `tool_use_id` persist failure behavior

## Root Cause

`Agent_turn.make_tool_results` failed open when `Tool_result_store.persist` returned `Error _`, but the per-result threshold branch returned the sanitized full content without logging or recording a frozen kept decision. That preserved the turn but left no structured evidence and allowed repeated attempts for the same failing tool result.

## Validation

- `git diff --check`
- `ocamlformat --check lib/agent/agent_turn.ml test/test_tool_result_relocation.ml`
- `scripts/dune-local.sh build test/test_tool_result_relocation.exe`
- `./_build/default/test/test_tool_result_relocation.exe` (14 tests)
