### PR TITLE
refactor(llm_provider): extract Discovery_parse pure JSON parsers

### DIFF
--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -14,19 +14,24 @@ let warn_probe_failure ~url ~phase detail =
   Diag.debug "discovery" "%s" (Yojson.Safe.to_string json)
 ;;
 
-type model_info =
+(* Discovery types + JSON parsers moved to {!Discovery_parse}.  The
+   transparent record-alias re-exports below preserve every existing
+   [Discovery.model_info] / [Discovery.server_props] /
+   [Discovery.slot_status] caller without forcing them to switch
+   imports. *)
+type model_info = Discovery_parse.model_info =
   { id : string
   ; owned_by : string
   }
 
-type server_props =
+type server_props = Discovery_parse.server_props =
   { total_slots : int
   ; ctx_size : int
   ; model : string
   ; supports_tools : bool option
   }
 
-type slot_status =
+type slot_status = Discovery_parse.slot_status =
   { total : int
   ; busy : int
   ; idle : int
@@ -119,79 +124,11 @@ let get_ok ~sw ~net url =
   | _ -> false
 ;;
 
-(* ── Parsers ─────────────────────────────────────────────── *)
-
-let parse_models json =
-  let open Yojson.Safe.Util in
-  match member "data" json with
-  | `List items ->
-    items
-    |> List.filter_map (fun item ->
-      match item |> member "id" |> to_string_option with
-      | Some id ->
-        let owned_by =
-          item |> member "owned_by" |> to_string_option |> Option.value ~default:"unknown"
-        in
-        Some { id; owned_by }
-      | None -> None)
-  | _ -> []
-;;
-
-let parse_props json =
-  let open Yojson.Safe.Util in
-  match member "total_slots" json with
-  | `Int total_slots ->
-    let dgs = member "default_generation_settings" json in
-    let ctx_size =
-      match dgs with
-      | `Assoc _ ->
-        (match member "n_ctx" dgs with
-         | `Int n -> n
-         | _ -> 0)
-      | _ -> 0
-    in
-    let model =
-      match dgs with
-      | `Assoc _ ->
-        (match member "model" dgs with
-         | `String s -> s
-         | _ -> "")
-      | _ -> ""
-    in
-    Some { total_slots; ctx_size; model; supports_tools = None }
-  | _ -> None
-;;
-
-let parse_slots json =
-  let open Yojson.Safe.Util in
-  let items =
-    match json with
-    | `List items -> items
-    | _ -> []
-  in
-  if items = []
-  then None
-  else (
-    let total = List.length items in
-    let busy =
-      items
-      |> List.fold_left
-           (fun acc slot ->
-              let is_busy =
-                slot
-                |> member "is_processing"
-                |> to_bool_option
-                |> Option.value ~default:false
-                ||
-                match slot |> member "state" with
-                | `Int n -> n <> 0
-                | _ -> false
-              in
-              if is_busy then acc + 1 else acc)
-           0
-    in
-    Some { total; busy; idle = total - busy })
-;;
+(* Parsers moved to {!Discovery_parse}; re-export so the in-file
+   [probe_endpoint] call sites still type-check unchanged. *)
+let parse_models = Discovery_parse.parse_models
+let parse_props = Discovery_parse.parse_props
+let parse_slots = Discovery_parse.parse_slots
 
 (* ── Ollama fallback ────────────────────────────────────── *)
 

--- a/lib/llm_provider/discovery.mli
+++ b/lib/llm_provider/discovery.mli
@@ -9,22 +9,26 @@
     @stability Internal
     @since 0.93.1 *)
 
-(** Model info from /v1/models *)
-type model_info =
+(** Model info from /v1/models — re-exported from {!Discovery_parse}
+    so existing [Discovery.model_info] consumers do not need to switch
+    imports. *)
+type model_info = Discovery_parse.model_info =
   { id : string
   ; owned_by : string
   }
 
-(** Server properties from /props *)
-type server_props =
+(** Server properties from /props — re-exported from
+    {!Discovery_parse}. *)
+type server_props = Discovery_parse.server_props =
   { total_slots : int
   ; ctx_size : int
   ; model : string
   ; supports_tools : bool option
   }
 
-(** Slot utilization from /slots *)
-type slot_status =
+(** Slot utilization from /slots — re-exported from
+    {!Discovery_parse}. *)
+type slot_status = Discovery_parse.slot_status =
   { total : int
   ; busy : int
   ; idle : int

--- a/lib/llm_provider/discovery_parse.ml
+++ b/lib/llm_provider/discovery_parse.ml
@@ -1,0 +1,91 @@
+(* See discovery_parse.mli for module rationale. *)
+
+type model_info =
+  { id : string
+  ; owned_by : string
+  }
+
+type server_props =
+  { total_slots : int
+  ; ctx_size : int
+  ; model : string
+  ; supports_tools : bool option
+  }
+
+type slot_status =
+  { total : int
+  ; busy : int
+  ; idle : int
+  }
+
+let parse_models json =
+  let open Yojson.Safe.Util in
+  match member "data" json with
+  | `List items ->
+    items
+    |> List.filter_map (fun item ->
+      match item |> member "id" |> to_string_option with
+      | Some id ->
+        let owned_by =
+          item |> member "owned_by" |> to_string_option |> Option.value ~default:"unknown"
+        in
+        Some { id; owned_by }
+      | None -> None)
+  | _ -> []
+;;
+
+let parse_props json =
+  let open Yojson.Safe.Util in
+  match member "total_slots" json with
+  | `Int total_slots ->
+    let dgs = member "default_generation_settings" json in
+    let ctx_size =
+      match dgs with
+      | `Assoc _ ->
+        (match member "n_ctx" dgs with
+         | `Int n -> n
+         | _ -> 0)
+      | _ -> 0
+    in
+    let model =
+      match dgs with
+      | `Assoc _ ->
+        (match member "model" dgs with
+         | `String s -> s
+         | _ -> "")
+      | _ -> ""
+    in
+    Some { total_slots; ctx_size; model; supports_tools = None }
+  | _ -> None
+;;
+
+let parse_slots json =
+  let open Yojson.Safe.Util in
+  let items =
+    match json with
+    | `List items -> items
+    | _ -> []
+  in
+  if items = []
+  then None
+  else (
+    let total = List.length items in
+    let busy =
+      items
+      |> List.fold_left
+           (fun acc slot ->
+              let is_busy =
+                slot
+                |> member "is_processing"
+                |> to_bool_option
+                |> Option.value ~default:false
+                ||
+                match slot |> member "state" with
+                | `Int n -> n <> 0
+                | _ -> false
+              in
+              if is_busy then acc + 1 else acc)
+           0
+    in
+    Some { total; busy; idle = total - busy })
+;;

--- a/lib/llm_provider/discovery_parse.mli
+++ b/lib/llm_provider/discovery_parse.mli
@@ -1,0 +1,52 @@
+(** Discovery_parse — pure JSON parsers for the llama-server discovery
+    surface.
+
+    Extracted from {!Discovery} (lines 122-195 in the pre-split
+    [discovery.ml]) so the parse layer can be reused by callers that
+    just need to interpret one of the discovery JSON shapes without
+    pulling in the I/O + Atomic-state half of [Discovery].
+
+    {!Discovery} re-exports {!model_info}, {!server_props}, and
+    {!slot_status} as transparent record aliases so existing imports
+    of [Discovery.model_info] etc. continue to type-check and continue
+    to pattern-match against record literals.
+
+    Pure module: no I/O, no env reads, no async. *)
+
+(** Model info from [/v1/models]. *)
+type model_info =
+  { id : string
+  ; owned_by : string
+  }
+
+(** Server properties from [/props]. *)
+type server_props =
+  { total_slots : int
+  ; ctx_size : int
+  ; model : string
+  ; supports_tools : bool option
+  }
+
+(** Slot utilization from [/slots]. *)
+type slot_status =
+  { total : int
+  ; busy : int
+  ; idle : int
+  }
+
+val parse_models : Yojson.Safe.t -> model_info list
+(** OpenAI-compatible [/v1/models] response → list of [{ id; owned_by }].
+    Returns the empty list on missing/non-list [data], or when no item
+    has a string [id].  [owned_by] defaults to ["unknown"] when absent. *)
+
+val parse_props : Yojson.Safe.t -> server_props option
+(** llama-server [/props] response → typed {!server_props}.  Requires a
+    numeric [total_slots]; falls back to [0] for missing [n_ctx] and
+    to [""] for missing [model].  Returns [None] when [total_slots] is
+    missing or non-numeric. *)
+
+val parse_slots : Yojson.Safe.t -> slot_status option
+(** llama-server [/slots] response → typed {!slot_status}.  Counts a
+    slot as busy when [is_processing] is [true] OR when [state] is a
+    non-zero integer.  Returns [None] when the input is not a non-empty
+    list. *)


### PR DESCRIPTION
## Summary

`discovery.ml` at 1715 LoC carries three pure JSON parsers (`parse_models`, `parse_props`, `parse_slots`) plus the three record types they produce. None of the parser code uses I/O, env, or the `Atomic`-state half of `Discovery` — it just maps the OpenAI-compat / llama-server discovery responses to typed records.

Moves the types + parsers to a new `Discovery_parse` module so the parse layer becomes independently testable and reusable. `discovery.ml` shrinks 1715 → 1652 LoC (-63 LoC).

Second OAS-side leaf extraction after PR #1635 (Retry_classify). Same transparent record alias pattern.

## Product impact

- Callers that just need to interpret one of the discovery JSON shapes do not have to pull in the full `Discovery` (which carries HTTP probes, Atomic state, and Ollama fallback logic).
- The parse layer becomes independently testable without spinning up the discover loop.
- Behavior unchanged at every existing call site.

## Evidence

```
$ git diff --stat
 lib/llm_provider/discovery.ml             | 89 ++++-------------------
 lib/llm_provider/discovery.mli            | 16 ++++---
 (new) lib/llm_provider/discovery_parse.ml  | 91
 (new) lib/llm_provider/discovery_parse.mli | 52
 4 files changed, 166 insertions(+), 82 deletions(-)
```

File sizes:

```
discovery.ml:  1715 → 1652 (-63 LoC)
discovery_parse.{ml,mli}: 91 + 52 = 143 LoC (new)
```

## Review evidence

- `bash scripts/dune-local.sh build --cache=disabled lib/llm_provider/.llm_provider.objs/native/llm_provider__Discovery.cmx lib/llm_provider/.llm_provider.objs/native/llm_provider__Discovery_parse.cmx` — both built (exit 0).
- `opam exec -- ocamlformat --check` — pass on all 4 files.

## Backwards compatibility

Transparent record alias re-export in both `discovery.ml` and `discovery.mli`:

```ocaml
type model_info = Discovery_parse.model_info =
  { id : string
  ; owned_by : string
  }
```

Record literals built against `Discovery.model_info` continue to match — see e.g. the implicit constructor in `endpoint_status` (still in `discovery.ml`).

`Discovery.parse_models` etc. are `let X = Discovery_parse.X` rebinds. The parsers are not in `discovery.mli` so there is no public surface delta on the function side; only the type re-exports change the `.mli`, and they keep the same record shape (just with `= Discovery_parse.X` qualifier).

## Linked issue

Per OAS CLAUDE.md "파일 300줄 이상 → 분할 검토". Followup splits in `discovery.ml`:
- "Ollama fallback" (140 LoC, touches env + HTTP)
- "Capability inference" (75 LoC, touches `Capabilities`)
- "Probe" (130 LoC, owns the actual HTTP probe loop)

Each deserves its own RFC because they touch external endpoints / Atomic state, not just pure data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)