### PR TITLE
refactor(memory_procedural): drop duplicated string_contains helper

### DIFF
--- a/lib/memory_procedural.ml
+++ b/lib/memory_procedural.ml
@@ -70,23 +70,14 @@ let procedure_of_json (json : Yojson.Safe.t) : procedure option =
   | Yojson.Safe.Util.Type_error _ | Not_found -> None
 ;;
 
-(* ── String matching helper ─────────────────────────────── *)
-
-let string_contains ~needle haystack =
-  let nlen = String.length needle in
-  let hlen = String.length haystack in
-  if nlen = 0
-  then true
-  else (
-    let rec loop i =
-      if i + nlen > hlen
-      then false
-      else if String.sub haystack i nlen = needle
-      then true
-      else loop (i + 1)
-    in
-    loop 0)
-;;
+(* String matching helper: reuse the canonical [Util.string_contains]
+   instead of carrying a byte-identical local copy.  [provider.ml]
+   already uses the same `let string_contains = Util.string_contains`
+   pattern, so this aligns with the in-library convention.  Removing
+   the local copy avoids the "Scattered Hardcoded Defaults" antipattern
+   (masc-mcp Doc #4 §AI 코드 생성 안티패턴 #1; same pattern caught in
+   PR #16364 for masc-mcp's keeper_unified_metrics.ml). *)
+let string_contains = Util.string_contains
 
 (* ── Operations ─────────────────────────────────────────── *)
 


### PR DESCRIPTION
## Summary

`memory_procedural.ml:75-89` defined a private `string_contains` that is byte-identical to `Util.string_contains` (in agent_sdk_base, visible via `(re_export agent_sdk_base)` from `lib/dune`). Same "Scattered Hardcoded Defaults" antipattern caught in masc-mcp's `keeper_unified_metrics.ml` (PR #16364).

A centralised helper exists and is already reused elsewhere — `provider.ml:50` has the very same `let string_contains = Util.string_contains` rebinding. This PR aligns `memory_procedural.ml` with that in-library convention.

Net -9 LoC. Third OAS contribution from this /loop (after #1635 and #1636).

## Product impact

- Eliminates one instance of the "copy this code from elsewhere" antipattern.
- Aligns `memory_procedural.ml` with `provider.ml`'s already-deduplicated pattern — future readers see one consistent convention.
- Behavior unchanged at the call site (`string_contains ~needle:pattern proc.pattern` at line 110); the central impl uses the same named-arg signature.

## Backwards compatibility

- Local `string_contains` was private (not in `.mli`); no external surface change.
- Two other duplicates audited and intentionally left in place:
  - `provider.ml:50` — already rebinds (`let string_contains = Util.string_contains`), not a real duplicate.
  - `pricing.ml:54` — lives in `lib/llm_provider/`, a sub-library that *cannot* depend on `agent_sdk_base` (which depends on `llm_provider` and would create a cycle). Justified by layering; stays untouched.

## Evidence

```
$ git diff --stat
 lib/memory_procedural.ml | 25 ++++++++-----------------
 1 file changed, 8 insertions(+), 17 deletions(-)
```

## Review evidence

- `bash scripts/dune-local.sh build --cache=disabled lib/.agent_sdk.objs/native/agent_sdk__Memory_procedural.cmx` — passed (exit 0).
- `opam exec -- ocamlformat --check lib/memory_procedural.ml` — pass.

## Linked issue

- Companion to masc-mcp PR #16364 (same antipattern, same dedup approach).
- Doc #4 §AI 코드 생성 안티패턴 #1 (Scattered Hardcoded Defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)