### PR TITLE
refactor(llm_provider): extract Discovery_http HTTP-result helpers

### DIFF
--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -90,34 +90,12 @@ let endpoints_from_env () =
   if List.mem ollama_endpoint explicit then explicit else explicit @ [ ollama_endpoint ]
 ;;
 
-(* ── HTTP helpers ────────────────────────────────────────── *)
-
-let get_json ~sw ~net url =
-  match Http_client.get_sync ~sw ~net ~url ~headers:[] () with
-  | Ok (code, body) when code >= 200 && code < 300 ->
-    (try Ok (Yojson.Safe.from_string body) with
-     | Yojson.Json_error msg -> Error msg)
-  | Ok (code, _) -> Error (Printf.sprintf "HTTP %d" code)
-  | Error (Http_client.HttpError { code; _ }) -> Error (Printf.sprintf "HTTP %d" code)
-  | Error (Http_client.AcceptRejected { reason }) -> Error reason
-  | Error (Http_client.NetworkError { message; _ }) -> Error message
-  | Error (Http_client.TimeoutError { message; _ }) -> Error message
-  | Error (Http_client.CliTransportRequired { kind }) ->
-    Error (Printf.sprintf "CLI transport required for %s" kind)
-  | Error (Http_client.ProviderTerminal { message; _ }) ->
-    (* Discovery hits HTTP endpoints only; CLI subprocess terminals
-       cannot reach this match.  Surface the message defensively so the
-       exhaustive match stays sound. *)
-    Error message
-  | Error (Http_client.ProviderFailure { kind; message }) ->
-    Error (Http_client.provider_failure_to_string ~kind ~message)
-;;
-
-let get_ok ~sw ~net url =
-  match Http_client.get_sync ~sw ~net ~url ~headers:[] () with
-  | Ok (code, _) when code >= 200 && code < 300 -> true
-  | _ -> false
-;;
+(* HTTP helpers moved to {!Discovery_http} so the exhaustive
+   [Http_client.http_error] pattern match lives in one place.
+   Re-export keeps the in-file probe call sites
+   (lines ~250, 480, 487, 510) unchanged. *)
+let get_json = Discovery_http.get_json
+let get_ok = Discovery_http.get_ok
 
 (* ── Parsers ─────────────────────────────────────────────── *)
 

--- a/lib/llm_provider/discovery_http.ml
+++ b/lib/llm_provider/discovery_http.ml
@@ -1,0 +1,28 @@
+(* See discovery_http.mli for module rationale. *)
+
+let get_json ~sw ~net url =
+  match Http_client.get_sync ~sw ~net ~url ~headers:[] () with
+  | Ok (code, body) when code >= 200 && code < 300 ->
+    (try Ok (Yojson.Safe.from_string body) with
+     | Yojson.Json_error msg -> Error msg)
+  | Ok (code, _) -> Error (Printf.sprintf "HTTP %d" code)
+  | Error (Http_client.HttpError { code; _ }) -> Error (Printf.sprintf "HTTP %d" code)
+  | Error (Http_client.AcceptRejected { reason }) -> Error reason
+  | Error (Http_client.NetworkError { message; _ }) -> Error message
+  | Error (Http_client.TimeoutError { message; _ }) -> Error message
+  | Error (Http_client.CliTransportRequired { kind }) ->
+    Error (Printf.sprintf "CLI transport required for %s" kind)
+  | Error (Http_client.ProviderTerminal { message; _ }) ->
+    (* Discovery hits HTTP endpoints only; CLI subprocess terminals
+       cannot reach this match.  Surface the message defensively so the
+       exhaustive match stays sound. *)
+    Error message
+  | Error (Http_client.ProviderFailure { kind; message }) ->
+    Error (Http_client.provider_failure_to_string ~kind ~message)
+;;
+
+let get_ok ~sw ~net url =
+  match Http_client.get_sync ~sw ~net ~url ~headers:[] () with
+  | Ok (code, _) when code >= 200 && code < 300 -> true
+  | _ -> false
+;;

--- a/lib/llm_provider/discovery_http.mli
+++ b/lib/llm_provider/discovery_http.mli
@@ -1,0 +1,35 @@
+(** Discovery_http — HTTP-client → typed-result helpers for the
+    llama-server / OpenAI-compat discovery surface.
+
+    Extracted from {!Discovery} (lines 93-121 in the pre-split
+    [discovery.ml]) so the HTTP error-translation surface can be
+    reused outside the discover loop — and so {!Discovery} no longer
+    inlines [Http_client.http_error] pattern matching that has to be
+    kept exhaustive twice.
+
+    {!Discovery} keeps the [get_json] / [get_ok] names via simple
+    [let] rebinds for the 5 internal call sites in [discovery.ml]
+    (lines 254, 481, 488, 510, +1).  Neither helper was previously
+    exposed in [discovery.mli], so external surface is unaffected. *)
+
+val get_json
+  :  sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> string
+  -> (Yojson.Safe.t, string) result
+(** GET [url] and decode the body as JSON.  Returns [Error msg] for
+    non-2xx responses, transport errors, parser errors, and the
+    closed-sum [Http_client.http_error] variants ([AcceptRejected],
+    [NetworkError], [TimeoutError], [CliTransportRequired],
+    [ProviderTerminal], [ProviderFailure]).  [ProviderTerminal] is
+    surfaced defensively — discovery hits HTTP endpoints only, so
+    CLI-subprocess terminals cannot reach this match. *)
+
+val get_ok
+  :  sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> string
+  -> bool
+(** GET [url] and return [true] iff the response status is 2xx.
+    Discards body and error context — used for liveness probes only
+    (e.g. [/health], [/]). *)


### PR DESCRIPTION
## Summary

`discovery.ml` keeps two private helpers (`get_json`, `get_ok`) that wrap `Http_client.get_sync` and translate the closed-sum `Http_client.http_error` variants into `(Yojson.Safe.t, string) result` / `bool`. The pattern match is 8 arms long and has to be kept exhaustive — duplicating that match in other modules wanting similar GET-and-translate semantics would be costly.

Moves both into a new `Discovery_http` module. `discovery.ml` shrinks 1715 → 1693 LoC. Third discovery-side leaf extraction (after PR #1635 Retry_classify and PR #1636 Discovery_parse).

## Product impact

- Future callers can reuse the exhaustive `http_error → string` translation without copy-paste.
- When `Http_client.http_error` adds a new variant, only one place needs an update (previously two: this module + any future copy).
- Behavior unchanged: the 5 internal call sites in `discovery.ml` (lines ~250, 480, 487, 510 + one more) keep working through `Discovery.get_json` / `Discovery.get_ok` rebinds.

## Evidence

```
$ git diff --stat
 lib/llm_provider/discovery.ml             | 34 +++----------------------------
 (new) lib/llm_provider/discovery_http.ml   | 28
 (new) lib/llm_provider/discovery_http.mli  | 35
 3 files changed, 69 insertions(+), 28 deletions(-)
```

File sizes:

```
discovery.ml:  1715 → 1693 (-22 LoC)
discovery_http.{ml,mli}: 28 + 35 = 63 LoC (new)
```

## Review evidence

- `bash scripts/dune-local.sh build --cache=disabled lib/llm_provider/.llm_provider.objs/native/llm_provider__Discovery.cmx lib/llm_provider/.llm_provider.objs/native/llm_provider__Discovery_http.cmx` — both built (exit 0).
- `opam exec -- ocamlformat --check` — pass on all 3 files.

## Backwards compatibility

- Both helpers were private to `discovery.ml` (not in `discovery.mli`).
- `Discovery.get_json` / `Discovery.get_ok` are now `let get_json = Discovery_http.get_json` rebinds.
- `discovery.mli` is not modified by this commit; no external surface delta.

## Linked issue

- Orthogonal to PR #1636 (Discovery_parse) — different sections of `discovery.ml`, no merge conflict.
- Per OAS CLAUDE.md "파일 300줄 이상 → 분할 검토".

🤖 Generated with [Claude Code](https://claude.com/claude-code)