### PR TITLE
feat(completion-contract): typed violation_detail with satisfying_tools

### DIFF
--- a/lib/completion_contract.ml
+++ b/lib/completion_contract.ml
@@ -24,6 +24,41 @@ type tool_call =
 
 type required_tool_satisfaction = tool_call -> (unit, string) result
 
+type violation_detail =
+  { called_tools : string list
+  ; satisfying_tools : string list
+  ; rejection_reasons : (string * string) list  (** [(tool_name, reason)] *)
+  }
+[@@deriving show]
+
+let violation_detail_to_string (detail : violation_detail) : string =
+  let called =
+    match detail.called_tools with
+    | [] -> ""
+    | tools -> Printf.sprintf "model called [%s]" (String.concat ", " tools)
+  in
+  let rejections =
+    match detail.rejection_reasons with
+    | [] -> ""
+    | reasons ->
+      Printf.sprintf
+        " (%s)"
+        (String.concat
+           "; "
+           (List.map
+              (fun (name, reason) -> Printf.sprintf "%s: %s" name reason)
+              reasons))
+  in
+  let suggestion =
+    match detail.satisfying_tools with
+    | [] -> "\nNo currently visible tool can satisfy this contract -- emit a blocker instead."
+    | tools ->
+      Printf.sprintf
+        "\nSatisfying tools for this contract: [%s]"
+        (String.concat ", " tools)
+  in
+  called ^ rejections ^ suggestion
+
 let any_tool_call_satisfies (_call : tool_call) = Ok ()
 
 let effectful_tool_satisfies (call : tool_call) =
@@ -122,6 +157,15 @@ let any_satisfying_call ~required_tool_satisfaction calls =
   List.exists (fun call -> Result.is_ok (required_tool_satisfaction call)) calls
 ;;
 
+let format_suggestion ?(satisfying_tools = []) () =
+  match satisfying_tools with
+  | [] -> ""
+  | tools ->
+    Printf.sprintf
+      "\nSatisfying tools for this contract: [%s]"
+      (String.concat ", " tools)
+;;
+
 let unsatisfied_calls_message calls errors =
   match errors with
   | [] ->
@@ -155,10 +199,12 @@ let stop_reason_is_resumable (sr : stop_reason) : bool =
 let validate_response
       ?(tools = [])
       ?(required_tool_satisfaction = any_tool_call_satisfies)
+      ?(satisfying_tools = [])
       ~(contract : t)
       (response : api_response)
   : (unit, string) result
   =
+  let suggestion = format_suggestion ~satisfying_tools () in
   match contract with
   | Allow_text_or_tool -> Ok ()
   | Require_tool_use ->
@@ -170,13 +216,15 @@ let validate_response
       Error
         (unsatisfied_calls_message
            calls
-           (satisfaction_errors ~required_tool_satisfaction calls))
+           (satisfaction_errors ~required_tool_satisfaction calls)
+        ^ suggestion)
     else if stop_reason_is_resumable response.stop_reason
     then Ok ()
     else
       Error
-        "required tool contract unsatisfied: tool_choice requested tool use, but the \
-         model returned no ToolUse block"
+        ("required tool contract unsatisfied: tool_choice requested tool use, but the \
+          model returned no ToolUse block"
+        ^ suggestion)
   | Require_specific_tool name ->
     let calls = tool_use_calls ~tools response in
     (match calls with
@@ -186,7 +234,8 @@ let validate_response
          (Printf.sprintf
             "required tool contract unsatisfied: tool_choice requested tool '%s', but \
              the model returned no ToolUse block"
-            name)
+            name
+         ^ suggestion)
      | calls ->
        let matching = List.filter (fun call -> String.equal call.name name) calls in
        if matching <> [] && any_satisfying_call ~required_tool_satisfaction matching
@@ -200,7 +249,8 @@ let validate_response
               name
               (String.concat
                  "; "
-                 (satisfaction_errors ~required_tool_satisfaction matching)))
+                 (satisfaction_errors ~required_tool_satisfaction matching))
+           ^ suggestion)
        else (
          let tool_names = List.map (fun call -> call.name) calls in
          Error
@@ -208,7 +258,8 @@ let validate_response
               "required tool contract unsatisfied: tool_choice requested tool '%s', but \
                the model called [%s]"
               name
-              (String.concat ", " tool_names))))
+              (String.concat ", " tool_names)
+           ^ suggestion)))
   | Require_no_tool_use ->
     (match tool_use_names response with
      | [] -> Ok ()
@@ -222,6 +273,69 @@ let validate_response
 
 let validator ~(contract : t) (response : api_response) =
   validate_response ~contract response
+;;
+
+(** Extract structured violation details from a failed validation.
+
+    Returns [Ok ()] when the contract is satisfied, or [Error violation_detail]
+    with the called tools, rejection reasons, and suggested satisfying tools. *)
+let violation_detail_of_response
+      ?(tools = [])
+      ?(required_tool_satisfaction = any_tool_call_satisfies)
+      ?(satisfying_tools = [])
+      ~(contract : t)
+      (response : api_response)
+  : (unit, violation_detail) result
+  =
+  let make_detail ?(rejection_reasons = []) called_tool_names =
+    Error { called_tools = called_tool_names; satisfying_tools; rejection_reasons }
+  in
+  match contract with
+  | Allow_text_or_tool -> Ok ()
+  | Require_tool_use ->
+    let calls = tool_use_calls ~tools response in
+    if calls <> [] && any_satisfying_call ~required_tool_satisfaction calls
+    then Ok ()
+    else if calls <> []
+    then
+      let reasons =
+        List.filter_map
+          (fun call ->
+             match required_tool_satisfaction call with
+             | Ok () -> None
+             | Error reason -> Some (call.name, reason))
+          calls
+      in
+      make_detail ~rejection_reasons:reasons (List.map (fun c -> c.name) calls)
+    else if stop_reason_is_resumable response.stop_reason
+    then Ok ()
+    else make_detail []
+  | Require_specific_tool name ->
+    let calls = tool_use_calls ~tools response in
+    (match calls with
+     | [] when stop_reason_is_resumable response.stop_reason -> Ok ()
+     | [] -> make_detail []
+     | calls ->
+       let matching = List.filter (fun call -> String.equal call.name name) calls in
+       if matching <> [] && any_satisfying_call ~required_tool_satisfaction matching
+       then Ok ()
+       else if matching <> []
+       then
+         let reasons =
+           List.filter_map
+             (fun call ->
+                match required_tool_satisfaction call with
+                | Ok () -> None
+                | Error reason -> Some (call.name, reason))
+             matching
+         in
+         make_detail ~rejection_reasons:reasons [ name ]
+       else make_detail (List.map (fun c -> c.name) calls))
+  | Require_no_tool_use ->
+    (match tool_use_names response with
+     | [] -> Ok ()
+     | tool_names ->
+       make_detail tool_names)
 ;;
 
 let accept_on_exhaustion ~(contract : t) =
@@ -533,3 +647,5 @@ let%test "stop_reason_is_resumable classification" =
   && (not (stop_reason_is_resumable (Unknown "refusal")))
   && not (stop_reason_is_resumable (Unknown "anything-else"))
 ;;
+
+

--- a/test/dune
+++ b/test/dune
@@ -63,6 +63,7 @@
   test_clone
   test_complete_ext
   test_completion_contract_tool_use_calls
+  test_completion_contract_violation
   test_conditional_orch
   test_consumer
   test_content_replacement_event_bridge
@@ -278,6 +279,7 @@
   test_clone
   test_complete_ext
   test_completion_contract_tool_use_calls
+  test_completion_contract_violation
   test_conditional_orch
   test_consumer
   test_content_replacement_event_bridge

--- a/test/test_completion_contract_violation.ml
+++ b/test/test_completion_contract_violation.ml
@@ -1,0 +1,329 @@
+(** Tests for Completion_contract.violation_detail and satisfying_tools.
+
+    Structured violation details with tool suggestions — callers can extract
+    which tools were called, why each was rejected, and which tools would
+    satisfy the contract. *)
+
+open Agent_sdk
+module Lp = Llm_provider.Types
+
+let noop_handler _ = Ok { Types.content = "ok" }
+
+let make_response ~content : Lp.api_response =
+  { id = "test"
+  ; model = "test-model"
+  ; stop_reason = Lp.EndTurn
+  ; content
+  ; usage = None
+  ; telemetry = None
+  }
+;;
+
+let make_tool name =
+  Tool.create ~name ~description:("desc:" ^ name) ~parameters:[] noop_handler
+;;
+
+let read_only_tool name =
+  let descriptor =
+    Tool.
+      { kind = None
+      ; mutation_class = None
+      ; concurrency_class = None
+      ; permission = Some ReadOnly
+      ; shell = None
+      ; notes = []
+      ; examples = []
+      }
+  in
+  Tool.create
+    ~descriptor
+    ~name
+    ~description:("desc:" ^ name)
+    ~parameters:[]
+    noop_handler
+;;
+
+(* --- violation_detail_to_string --- *)
+
+let test_to_string_with_satisfying_tools () =
+  let detail =
+    Completion_contract.
+      { called_tools = [ "search" ]
+      ; satisfying_tools = [ "keeper_bash"; "keeper_write" ]
+      ; rejection_reasons = [ ("search", "read-only and cannot satisfy") ]
+      }
+  in
+  let s = Completion_contract.violation_detail_to_string detail in
+  let has_satisfying =
+    try
+      ignore (Str.search_forward (Str.regexp_string "Satisfying tools") s 0);
+      true
+    with
+    | Not_found -> false
+  in
+  let has_keeper =
+    try
+      ignore (Str.search_forward (Str.regexp_string "keeper_bash") s 0);
+      true
+    with
+    | Not_found -> false
+  in
+  Alcotest.(check bool) "contains Satisfying tools" true has_satisfying;
+  Alcotest.(check bool) "contains keeper_bash" true has_keeper
+;;
+
+let test_to_string_without_satisfying_tools () =
+  let detail =
+    Completion_contract.
+      { called_tools = [ "search" ]
+      ; satisfying_tools = []
+      ; rejection_reasons = []
+      }
+  in
+  let s = Completion_contract.violation_detail_to_string detail in
+  let has_blocker =
+    try
+      ignore
+        (Str.search_forward (Str.regexp_string "No currently visible tool can satisfy") s 0);
+      true
+    with
+    | Not_found -> false
+  in
+  Alcotest.(check bool) "contains blocker suggestion" true has_blocker
+;;
+
+(* --- validate_response satisfying_tools parameter --- *)
+
+let test_backward_compat_no_satisfying_tools () =
+  let response = make_response ~content:[ Lp.Text "hello" ] in
+  match
+    Completion_contract.validate_response
+      ~contract:Completion_contract.Require_tool_use
+      response
+  with
+  | Error msg ->
+    let has_suggestion =
+      try
+        ignore (Str.search_forward (Str.regexp_string "Satisfying tools") msg 0);
+        true
+      with
+      | Not_found -> false
+    in
+    Alcotest.(check bool) "no suggestion when param omitted" false has_suggestion;
+    Alcotest.(check bool) "error message non-trivial" true (String.length msg > 10)
+  | Ok () -> Alcotest.fail "expected Error"
+;;
+
+let test_satisfying_tools_appended_to_error () =
+  let response = make_response ~content:[ Lp.Text "hello" ] in
+  match
+    Completion_contract.validate_response
+      ~satisfying_tools:[ "keeper_bash"; "keeper_write" ]
+      ~contract:Completion_contract.Require_tool_use
+      response
+  with
+  | Error msg ->
+    let has_suggestion =
+      try
+        ignore
+          (Str.search_forward (Str.regexp_string "Satisfying tools for this contract:") msg 0);
+        true
+      with
+      | Not_found -> false
+    in
+    let has_keeper =
+      try
+        ignore (Str.search_forward (Str.regexp_string "keeper_bash") msg 0);
+        true
+      with
+      | Not_found -> false
+    in
+    Alcotest.(check bool) "has suggestion line" true has_suggestion;
+    Alcotest.(check bool) "has keeper_bash" true has_keeper
+  | Ok () -> Alcotest.fail "expected Error"
+;;
+
+let test_satisfying_tools_appended_for_specific_tool () =
+  let response =
+    make_response
+      ~content:[ Lp.ToolUse { id = "c1"; name = "search"; input = `Assoc [] } ]
+  in
+  match
+    Completion_contract.validate_response
+      ~satisfying_tools:[ "calculator" ]
+      ~contract:(Completion_contract.Require_specific_tool "calculator")
+      response
+  with
+  | Error msg ->
+    let has_suggestion =
+      try
+        ignore
+          (Str.search_forward (Str.regexp_string "Satisfying tools for this contract:") msg 0);
+        true
+      with
+      | Not_found -> false
+    in
+    Alcotest.(check bool) "has suggestion" true has_suggestion
+  | Ok () -> Alcotest.fail "expected Error for wrong tool"
+;;
+
+(* --- violation_detail_of_response --- *)
+
+let test_detail_on_failure_no_calls () =
+  let response = make_response ~content:[ Lp.Text "hello" ] in
+  match
+    Completion_contract.violation_detail_of_response
+      ~satisfying_tools:[ "keeper_bash" ]
+      ~contract:Completion_contract.Require_tool_use
+      response
+  with
+  | Error detail ->
+    Alcotest.(check int) "called_tools empty" 0 (List.length detail.called_tools);
+    Alcotest.(check int) "satisfying_tools has 1" 1 (List.length detail.satisfying_tools);
+    Alcotest.(check int) "rejection_reasons empty" 0 (List.length detail.rejection_reasons)
+  | Ok () -> Alcotest.fail "expected Error"
+;;
+
+let test_detail_with_rejected_calls () =
+  let tool = read_only_tool "search" in
+  let response =
+    make_response
+      ~content:[ Lp.ToolUse { id = "c1"; name = "search"; input = `Assoc [] } ]
+  in
+  match
+    Completion_contract.violation_detail_of_response
+      ~tools:[ tool ]
+      ~required_tool_satisfaction:Completion_contract.effectful_tool_satisfies
+      ~satisfying_tools:[ "keeper_bash" ]
+      ~contract:Completion_contract.Require_tool_use
+      response
+  with
+  | Error detail ->
+    Alcotest.(check int) "called_tools has 1" 1 (List.length detail.called_tools);
+    Alcotest.(check int) "satisfying_tools has 1" 1 (List.length detail.satisfying_tools);
+    (match detail.rejection_reasons with
+     | [ ("search", reason) ] ->
+       let has_readonly =
+         try
+           ignore (Str.search_forward (Str.regexp_string "read-only") reason 0);
+           true
+         with
+         | Not_found -> false
+       in
+       Alcotest.(check bool) "reason mentions read-only" true has_readonly
+     | _ -> Alcotest.fail "expected single rejection reason for 'search'")
+  | Ok () -> Alcotest.fail "expected Error"
+;;
+
+let test_detail_ok_when_satisfied () =
+  let response =
+    make_response
+      ~content:[ Lp.ToolUse { id = "c1"; name = "calculator"; input = `Assoc [] } ]
+  in
+  match
+    Completion_contract.violation_detail_of_response
+      ~satisfying_tools:[ "keeper_bash" ]
+      ~contract:Completion_contract.Require_tool_use
+      response
+  with
+  | Ok () -> () (* pass *)
+  | Error _ -> Alcotest.fail "expected Ok for satisfied contract"
+;;
+
+let test_detail_specific_tool_no_calls () =
+  let response = make_response ~content:[ Lp.Text "hello" ] in
+  match
+    Completion_contract.violation_detail_of_response
+      ~satisfying_tools:[ "calculator" ]
+      ~contract:(Completion_contract.Require_specific_tool "calculator")
+      response
+  with
+  | Error detail ->
+    Alcotest.(check int) "called_tools empty" 0 (List.length detail.called_tools);
+    Alcotest.(check int) "satisfying has calculator" 1 (List.length detail.satisfying_tools)
+  | Ok () -> Alcotest.fail "expected Error"
+;;
+
+let test_detail_allow_text_always_ok () =
+  let response = make_response ~content:[ Lp.Text "hello" ] in
+  match
+    Completion_contract.violation_detail_of_response
+      ~satisfying_tools:[ "keeper_bash" ]
+      ~contract:Completion_contract.Allow_text_or_tool
+      response
+  with
+  | Ok () -> () (* pass *)
+  | Error _ -> Alcotest.fail "Allow_text_or_tool should always pass"
+;;
+
+let test_detail_no_tool_use_violation () =
+  let response =
+    make_response
+      ~content:[ Lp.ToolUse { id = "c1"; name = "search"; input = `Assoc [] } ]
+  in
+  match
+    Completion_contract.violation_detail_of_response
+      ~contract:Completion_contract.Require_no_tool_use
+      response
+  with
+  | Error detail ->
+    Alcotest.(check int) "called has search" 1 (List.length detail.called_tools);
+    Alcotest.(check int) "no satisfying tools" 0 (List.length detail.satisfying_tools)
+  | Ok () -> Alcotest.fail "expected Error for tool use when no-tool required"
+;;
+
+let () =
+  Alcotest.run
+    "completion_contract.violation_detail"
+    [ ( "to_string"
+      , [ Alcotest.test_case
+            "with satisfying tools"
+            `Quick
+            test_to_string_with_satisfying_tools
+        ; Alcotest.test_case
+            "without satisfying tools (blocker suggestion)"
+            `Quick
+            test_to_string_without_satisfying_tools
+        ] )
+    ; ( "validate_response satisfying_tools param"
+      , [ Alcotest.test_case
+            "backward compat: no satisfying_tools still works"
+            `Quick
+            test_backward_compat_no_satisfying_tools
+        ; Alcotest.test_case
+            "satisfying_tools appended to Require_tool_use error"
+            `Quick
+            test_satisfying_tools_appended_to_error
+        ; Alcotest.test_case
+            "satisfying_tools appended to Require_specific_tool error"
+            `Quick
+            test_satisfying_tools_appended_for_specific_tool
+        ] )
+    ; ( "violation_detail_of_response"
+      , [ Alcotest.test_case
+            "returns structured detail on failure (no calls)"
+            `Quick
+            test_detail_on_failure_no_calls
+        ; Alcotest.test_case
+            "with rejected calls returns reasons"
+            `Quick
+            test_detail_with_rejected_calls
+        ; Alcotest.test_case
+            "returns Ok when contract satisfied"
+            `Quick
+            test_detail_ok_when_satisfied
+        ; Alcotest.test_case
+            "Require_specific_tool with no calls"
+            `Quick
+            test_detail_specific_tool_no_calls
+        ; Alcotest.test_case
+            "Allow_text_or_tool always Ok"
+            `Quick
+            test_detail_allow_text_always_ok
+        ; Alcotest.test_case
+            "Require_no_tool_use violation"
+            `Quick
+            test_detail_no_tool_use_violation
+        ] )
+    ]
+;;


### PR DESCRIPTION
Add violation_detail record with called_tools, satisfying_tools, rejection_reasons. Backward compat via optional param. 11 Alcotest tests.

Depends on: masc-mcp PRs #16640 #16641 #16642