### PR TITLE
fix(metrics): reject duplicate histogram buckets at register time (root-fix for #1564)

### DIFF
--- a/lib/metrics.ml
+++ b/lib/metrics.ml
@@ -118,6 +118,33 @@ let check_no_normalized_collision_unlocked t ~kind ~name =
     t.histograms
 ;;
 
+(* [check_no_duplicate_buckets_unlocked ~name ~buckets] raises
+   [Invalid_argument] if [buckets] contains the same bound twice. A
+   duplicate bound would cause the Prometheus text exposition path to
+   emit the same [..._bucket{le="..."}] line twice for the same series,
+   triggering duplicate-sample errors at scrape time.
+
+   Detecting at register time mirrors [check_no_normalized_collision_unlocked]:
+   the bug is in the caller's metric definition, not in any runtime
+   observation, so we surface it as a programmer error at startup
+   instead of silently deduping on every emit (PR #1564 workaround). *)
+let check_no_duplicate_buckets_unlocked ~name ~buckets =
+  let sorted = List.sort Float.compare buckets in
+  let rec find_dup = function
+    | a :: (b :: _ as rest) ->
+      if Float.equal a b
+      then
+        invalid_arg
+          (Printf.sprintf
+             "Metrics.histogram: name %S has duplicate bucket bound %g"
+             name
+             a)
+      else find_dup rest
+    | _ -> ()
+  in
+  find_dup sorted
+;;
+
 let counter t ~name ~unit_ =
   with_lock t (fun () ->
     match List.find_opt (fun c -> c.c_name = name) t.counters with
@@ -135,6 +162,7 @@ let histogram t ~name ~buckets =
     | Some _ -> t, name
     | None ->
       check_no_normalized_collision_unlocked t ~kind:"histogram" ~name;
+      check_no_duplicate_buckets_unlocked ~name ~buckets;
       let h =
         { h_name = name; h_buckets = buckets; h_values = empty_histogram_values () }
       in
@@ -370,7 +398,11 @@ let counter_to_prometheus buf (c : counter_data) =
 
 let histogram_to_prometheus buf (h : histogram_data) =
   let prom_name = add_prometheus_header buf ~name:h.h_name ~kind:"histogram" in
-  let sorted_buckets = List.sort_uniq Float.compare h.h_buckets in
+  (* Bucket-bound uniqueness is enforced at registration via
+     [check_no_duplicate_buckets_unlocked] (root fix for the emit-time
+     [List.sort_uniq] workaround in PR #1564). Plain sort is enough
+     here; duplicates would have failed registration. *)
+  let sorted_buckets = List.sort Float.compare h.h_buckets in
   LabelMap.iter
     (fun labels series ->
        List.iter

--- a/test/test_metrics.ml
+++ b/test/test_metrics.ml
@@ -168,27 +168,15 @@ let test_prometheus_text_histogram_exports_buckets_sum_and_count () =
   check_line "histogram count" "gen_ai_client_operation_duration_count 2" text
 ;;
 
-let test_prometheus_text_histogram_deduplicates_bucket_bounds () =
+let test_register_rejects_duplicate_bucket_bounds () =
+  (* Root fix for PR #1564: duplicate bucket bounds are now rejected at
+     register time (mirroring PR #1570's normalized-name collision
+     check). The emit path used to silently dedupe via
+     [List.sort_uniq]; that was a telemetry-as-fix workaround. *)
   let m = Metrics.create () in
-  let h = Metrics.histogram m ~name:"dup.bounds" ~buckets:[ 1.0; 1.0; 2.0 ] in
-  Metrics.observe h 0.5;
-  let text = Metrics.to_prometheus_text m in
-  let count_substring text needle =
-    let len = String.length needle in
-    let rec loop start acc =
-      match String.index_from_opt text start needle.[0] with
-      | None -> acc
-      | Some i when i + len <= String.length text && String.sub text i len = needle ->
-        loop (i + len) (acc + 1)
-      | Some i -> loop (i + 1) acc
-    in
-    loop 0 0
-  in
-  check
-    int
-    "duplicate bound emitted exactly once"
-    1
-    (count_substring text "dup_bounds_bucket{le=\"1\"}")
+  match Metrics.histogram m ~name:"dup.bounds" ~buckets:[ 1.0; 1.0; 2.0 ] with
+  | exception Invalid_argument _ -> ()
+  | _ -> fail "expected Invalid_argument on duplicate bucket bounds"
 ;;
 
 let test_prometheus_text_histogram_exports_zero_series_on_create_and_reset () =
@@ -370,10 +358,6 @@ let () =
             `Quick
             (with_eio test_prometheus_text_histogram_exports_buckets_sum_and_count)
         ; test_case
-            "histogram text export deduplicates bucket bounds"
-            `Quick
-            (with_eio test_prometheus_text_histogram_deduplicates_bucket_bounds)
-        ; test_case
             "histogram text export preserves zero series"
             `Quick
             (with_eio
@@ -404,6 +388,10 @@ let () =
             "same name + same kind stays idempotent"
             `Quick
             (with_eio test_register_same_name_same_kind_is_idempotent)
+        ; test_case
+            "rejects duplicate histogram bucket bounds"
+            `Quick
+            (with_eio test_register_rejects_duplicate_bucket_bounds)
         ] )
     ]
 ;;


### PR DESCRIPTION
## 배경

PR #1564 는 `histogram_to_prometheus` (emit path) 에서 `List.sort_uniq Float.compare h.h_buckets` 로 중복 bucket bound 를 silent 하게 dedup 했습니다. 같은 sprint 의 sibling PR #1570 은 정규화 이름 collision 에 대해 *register-time `Invalid_argument`* 라는 올바른 패턴을 적용했고, PR #1564 본문도 이미 P1 finding 에 대해 "emit-time silent dedup 은 workaround 위 workaround — telemetry-as-fix" 라고 명시했습니다.

이 PR 은 #1564 의 emit-time workaround 를 root fix 로 옮겨 #1570 과 동일한 invariant style 로 정렬합니다.

## 변경

`lib/metrics.ml`:
- `check_no_duplicate_buckets_unlocked ~name ~buckets` 추가. `check_no_normalized_collision_unlocked` 와 같은 layout, 같은 raise pattern (`Invalid_argument`), 같은 호출 위치 (caller 가 instance lock 보유).
- `histogram` register 분기에서 idempotent lookup → normalized-collision check → **duplicate-bucket check** → entry 추가 순서로 호출.
- `histogram_to_prometheus` 의 `List.sort_uniq Float.compare` 를 `List.sort Float.compare` 로 교체. 등록이 authoritative 라는 점을 명시하는 주석 추가.

`test/test_metrics.ml`:
- 기존 `test_prometheus_text_histogram_deduplicates_bucket_bounds` (emit-time workaround 를 lock 하던 회귀 테스트) 를 `test_register_rejects_duplicate_bucket_bounds` 로 교체. `[1.0; 1.0; 2.0]` 등록 시 `Invalid_argument` 를 raise 하는지 검증.
- `prometheus` group → `registration` group 으로 이동. #1570 의 collision 테스트 3 개와 같은 그룹.

## 검증

```
./_build/default/test/test_metrics.exe
17 tests run, all OK
```

기존 16 tests (PR #1556/#1570 회귀 포함) + 신규 register-time 테스트 1 개. PR #1564 의 emit-time 테스트는 invariant 가 register 로 이동했으므로 register-time 테스트로 대체.

`./_build/default/test/test_checkpoint_delta.exe` 11 tests run, all OK. `Metrics.histogram` 의 유일한 production caller (`lib/checkpoint_delta.ml`) 는 중복 bound 를 등록하지 않으므로 영향 없음.

`dune build --root . lib` 통과.

## Workaround Rejection Bar

`software-development.md` §워크어라운드 거부 기준 §1 (telemetry-as-fix). #1564 PR body 자체가 "P1 collision 은 root fix (register-time) 가 별도 PR — workaround rejection bar §1" 이라고 명시했지만, 본인의 P2 fix 도 같은 카테고리였습니다. 이 PR 로 #1564 의 자기 모순을 해소합니다.

## Audit reference

`~/me/.tmp/pr-audit-2026-05-20/AUDIT-REPORT.md` Cluster E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)