### PR TITLE
refactor(capabilities): typed gemini_family variant (root-fix #968 string-classifier drift gate)

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -286,6 +286,43 @@ let glm_capabilities =
   }
 ;;
 
+(** Typed Gemini model family (root-fix for #968 string-classifier drift gate).
+
+    Centralizes the [String.starts_with ~prefix:"gemini-..."] dispatch into a
+    single classifier with an exhaustive variant. Downstream code switches on
+    the variant instead of comparing strings, so a new family member is a
+    compile-time obligation rather than a runtime string-match miss.
+
+    The internal use of [starts_with] inside [gemini_family_of_id] is
+    intentional and bounded: prefix matching is the only signal Google's model
+    IDs offer. Concentrating it here keeps the rest of the codebase typed.
+
+    @since 0.196.3 *)
+type gemini_family =
+  | Gemini_3_1 (** [gemini-3.1.*] — 3.1 line (pro-preview, flash-lite-preview, …) *)
+  | Gemini_3 (** [gemini-3.*] but not 3.1 — flash-preview and siblings *)
+  | Gemini_2_5 (** [gemini-2.5.*] — legacy line, kept until removal PR *)
+  | Gemini_other of string
+      (** Unknown gemini id or non-gemini id. Retains the literal so the
+          caller can log / fall through without losing data. *)
+
+(** Classify a model id into a [gemini_family]. Order matters: [gemini-3.1]
+    is checked before [gemini-3] so the more specific prefix wins.
+    Input is expected lowercased (callers pass the already-normalized id). *)
+let gemini_family_of_id (id : string) : gemini_family =
+  let starts_with prefix =
+    String.length id >= String.length prefix
+    && String.sub id 0 (String.length prefix) = prefix
+  in
+  if starts_with "gemini-3.1"
+  then Gemini_3_1
+  else if starts_with "gemini-3"
+  then Gemini_3
+  else if starts_with "gemini-2.5"
+  then Gemini_2_5
+  else Gemini_other id
+;;
+
 let gemini_capabilities =
   { default_capabilities with
     max_context_tokens = Some 1_000_000
@@ -429,7 +466,12 @@ let for_model_id_static model_id =
         max_context_tokens = Some 128_000
       ; max_output_tokens = Some 16_384
       }
-  else if starts_with "gemini-3" || starts_with "gemini-2.5"
+  else if
+    (* Typed dispatch (root-fix for #968): the classifier owns the prefix
+       comparison so downstream code matches on the variant, not on strings. *)
+    match gemini_family_of_id m with
+    | Gemini_3 | Gemini_3_1 | Gemini_2_5 -> true
+    | Gemini_other _ -> false
   then Some gemini_capabilities
   else if starts_with "kimi-for-coding"
   then Some kimi_capabilities

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -96,6 +96,23 @@ val codex_cli_capabilities : capabilities
     @since 0.185.0 *)
 val nemotron_capabilities : capabilities
 
+(** Typed Gemini model family. SSOT for the [gemini-*] prefix dispatch that
+    used to live as scattered [String.starts_with] calls. Downstream code
+    should switch on this variant rather than re-compare strings.
+
+    @since 0.196.3 *)
+type gemini_family =
+  | Gemini_3_1 (** [gemini-3.1.*] *)
+  | Gemini_3 (** [gemini-3.*] but not 3.1 *)
+  | Gemini_2_5 (** [gemini-2.5.*] (legacy line) *)
+  | Gemini_other of string (** Unknown gemini id, or non-gemini id (literal retained). *)
+
+(** Classify a model id into a [gemini_family]. Order: [3.1] before [3] so the
+    more specific prefix wins. Input is expected lowercased; callers that
+    cannot lowercase first should normalize via [String.lowercase_ascii] at
+    the boundary. *)
+val gemini_family_of_id : string -> gemini_family
+
 (** Lookup capabilities for a known model_id.
     Returns [None] if the model is not in the built-in table. *)
 val for_model_id : string -> capabilities option

--- a/scripts/check-model-inventory-truth.sh
+++ b/scripts/check-model-inventory-truth.sh
@@ -1,14 +1,23 @@
 #!/usr/bin/env bash
 # check-model-inventory-truth.sh
-# Drift gate for the Gemini 3 model inventory (PR Cadd, 2026-04-16).
+# Drift gate for the Gemini model inventory.
 #
-# Guards three invariants that can silently drift:
-#   1. capabilities.ml retains the `gemini-3` prefix matcher
-#      (without it, gemini-3-* models fall back to default_capabilities).
-#   2. model_meta.ml retains the gemini-3 inline %test block
-#      (proof that gemini-3 IDs actually resolve to 1M context + tool support).
-#   3. Legacy gemini-2.x references in lib/ + test/ do not grow beyond the
-#      baseline captured when this gate was introduced.
+# Originally added in PR #968 (2026-04-16) with a `starts_with "gemini-3"`
+# literal grep — that itself locked in the string-classifier anti-pattern.
+# Replaced 2026-05-20 (Cluster D root-fix, see
+# ~/me/.tmp/pr-audit-2026-05-20/AUDIT-REPORT.md) with a typed-variant check.
+#
+# Invariants:
+#   1a. capabilities.ml exposes `gemini_family_of_id` (the typed classifier).
+#   1b. The dispatch site names all live variants (Gemini_3 | Gemini_3_1 |
+#       Gemini_2_5) so a missing case is a compile-time obligation, not a
+#       silent string miss.
+#   1c. capabilities.mli exports the `gemini_family` variant so downstream
+#       code can match on it instead of re-comparing strings.
+#   2.  model_meta.ml retains inline %test blocks for the 3 preview IDs
+#       (proof that gemini-3 IDs resolve to 1M context + tool support).
+#   3.  Legacy gemini-2.x references in lib/ + test/ do not grow beyond the
+#       baseline captured when this gate was introduced.
 #
 # The baseline is intentionally permissive (equal to the 2026-04-16 count).
 # Follow-up PRs Cdeprecate and Cremove will lower it.
@@ -20,14 +29,29 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CAPS="$ROOT/lib/llm_provider/capabilities.ml"
+CAPS_MLI="$ROOT/lib/llm_provider/capabilities.mli"
 META="$ROOT/lib/llm_provider/model_meta.ml"
 BASELINE_LEGACY=53
 
 fail=0
 
-# ── Invariant 1: gemini-3 prefix matcher present ────────────────
-if ! grep -Fq 'starts_with "gemini-3"' "$CAPS"; then
-  echo "FAIL: gemini-3 prefix matcher missing in $CAPS" >&2
+# ── Invariant 1a: typed gemini_family classifier present ────────
+if ! grep -Fq 'let gemini_family_of_id' "$CAPS"; then
+  echo "FAIL: typed gemini_family_of_id missing in $CAPS" >&2
+  fail=1
+fi
+
+# ── Invariant 1b: dispatch site names all live variants ─────────
+# An underscore-only arm here would re-introduce the silent-fallback hazard
+# the root-fix removed.
+if ! grep -Fq 'Gemini_3 | Gemini_3_1 | Gemini_2_5' "$CAPS"; then
+  echo "FAIL: typed gemini_family dispatch (Gemini_3 | Gemini_3_1 | Gemini_2_5) missing in $CAPS" >&2
+  fail=1
+fi
+
+# ── Invariant 1c: variant exported via .mli ─────────────────────
+if ! grep -Fq 'type gemini_family' "$CAPS_MLI"; then
+  echo "FAIL: gemini_family variant not exported in $CAPS_MLI" >&2
   fail=1
 fi
 
@@ -54,4 +78,4 @@ if [ "$fail" -ne 0 ]; then
   exit 1
 fi
 
-echo "OK: gemini-3 matcher present, inline tests present, legacy count $legacy ≤ baseline $BASELINE_LEGACY"
+echo "OK: gemini_family typed classifier + dispatch present, inline tests present, legacy count $legacy ≤ baseline $BASELINE_LEGACY"

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -134,6 +134,82 @@ let test_lookup_gemini () =
   | None -> fail "should match gemini"
 ;;
 
+(* ── Typed gemini_family classifier (root-fix for #968) ─────── *)
+
+let pp_gemini_family ppf = function
+  | Capabilities.Gemini_3_1 -> Format.fprintf ppf "Gemini_3_1"
+  | Capabilities.Gemini_3 -> Format.fprintf ppf "Gemini_3"
+  | Capabilities.Gemini_2_5 -> Format.fprintf ppf "Gemini_2_5"
+  | Capabilities.Gemini_other s -> Format.fprintf ppf "Gemini_other(%s)" s
+;;
+
+let gemini_family_testable = Alcotest.testable pp_gemini_family ( = )
+
+let test_gemini_family_3_1 () =
+  check
+    gemini_family_testable
+    "gemini-3.1-pro-preview classifies as Gemini_3_1"
+    Capabilities.Gemini_3_1
+    (Capabilities.gemini_family_of_id "gemini-3.1-pro-preview")
+;;
+
+let test_gemini_family_3 () =
+  check
+    gemini_family_testable
+    "gemini-3-flash-preview classifies as Gemini_3 (not 3.1)"
+    Capabilities.Gemini_3
+    (Capabilities.gemini_family_of_id "gemini-3-flash-preview")
+;;
+
+let test_gemini_family_2_5 () =
+  check
+    gemini_family_testable
+    "gemini-2.5-flash classifies as Gemini_2_5"
+    Capabilities.Gemini_2_5
+    (Capabilities.gemini_family_of_id "gemini-2.5-flash")
+;;
+
+let test_gemini_family_other_non_gemini () =
+  check
+    gemini_family_testable
+    "non-gemini id falls into Gemini_other with literal retained"
+    (Capabilities.Gemini_other "claude-opus-4")
+    (Capabilities.gemini_family_of_id "claude-opus-4")
+;;
+
+let test_gemini_family_other_unknown_gemini () =
+  (* A future gemini line not yet classified should land in Gemini_other —
+     not be silently absorbed into an existing arm. *)
+  check
+    gemini_family_testable
+    "gemini-4-foo lands in Gemini_other (no silent fallback)"
+    (Capabilities.Gemini_other "gemini-4-foo")
+    (Capabilities.gemini_family_of_id "gemini-4-foo")
+;;
+
+let test_gemini_family_drives_capabilities () =
+  (* Behavioural cross-check: all three live variants resolve to
+     gemini_capabilities (1M context). This is the property the #968 drift
+     gate was trying to assert via string-grep; now it is enforced by the
+     type system at the dispatch site and by this test. *)
+  let ctx id =
+    match Capabilities.for_model_id id with
+    | Some c -> c.max_context_tokens
+    | None -> None
+  in
+  check
+    (option int)
+    "gemini-3-flash-preview ctx"
+    (Some 1_000_000)
+    (ctx "gemini-3-flash-preview");
+  check
+    (option int)
+    "gemini-3.1-pro-preview ctx"
+    (Some 1_000_000)
+    (ctx "gemini-3.1-pro-preview");
+  check (option int) "gemini-2.5-flash ctx" (Some 1_000_000) (ctx "gemini-2.5-flash")
+;;
+
 let test_lookup_qwen () =
   match Capabilities.for_model_id "qwen3.5-35b-a3b" with
   | Some c ->
@@ -660,6 +736,21 @@ let () =
         ; test_case "claude sonnet" `Quick test_lookup_claude_sonnet
         ; test_case "gpt-5" `Quick test_lookup_gpt5
         ; test_case "gemini" `Quick test_lookup_gemini
+        ; test_case "gemini_family Gemini_3_1" `Quick test_gemini_family_3_1
+        ; test_case "gemini_family Gemini_3" `Quick test_gemini_family_3
+        ; test_case "gemini_family Gemini_2_5" `Quick test_gemini_family_2_5
+        ; test_case
+            "gemini_family Gemini_other (non-gemini)"
+            `Quick
+            test_gemini_family_other_non_gemini
+        ; test_case
+            "gemini_family Gemini_other (unknown gemini)"
+            `Quick
+            test_gemini_family_other_unknown_gemini
+        ; test_case
+            "gemini_family drives 1M ctx capabilities"
+            `Quick
+            test_gemini_family_drives_capabilities
         ; test_case "qwen" `Quick test_lookup_qwen
         ; test_case "qwen runpod name" `Quick test_lookup_qwen_runpod_name
         ; test_case "deepseek v4 flash" `Quick test_lookup_deepseek_v4_flash


### PR DESCRIPTION
## 배경

`~/me/.tmp/pr-audit-2026-05-20/AUDIT-REPORT.md` **Cluster D** 워크어라운드 root-fix.

PR #968 (`test(model_meta): commit to gemini-3-* inventory + drift gate`, 2026-04-16 머지됨)이 도입한 `scripts/check-model-inventory-truth.sh` line 29:

```sh
grep -Fq 'starts_with "gemini-3"' "$CAPS"
```

이 grep은 `lib/llm_provider/capabilities.ml:432`의 string-classifier 안티패턴이 **계속 존재할 것을 요구**한다. 즉 drift gate 자체가 `String.starts_with ~prefix:"gemini-3"` 분기를 lock-in 함. `software-development.md` §워크어라운드 시그니처 2 ("String/Substring 분류기 보강")에 해당.

## 변경

### 1. `lib/llm_provider/capabilities.ml` + `.mli`

```ocaml
type gemini_family =
  | Gemini_3_1
  | Gemini_3
  | Gemini_2_5
  | Gemini_other of string

val gemini_family_of_id : string -> gemini_family
```

- prefix 비교는 `gemini_family_of_id` **한 곳**에 집중 (Google의 모델 ID가 prefix 외 다른 분류 신호를 제공하지 않으므로 prefix 사용 자체는 유지하되 그 경계를 줄임).
- `for_model_id_static`의 dispatch 가 `match gemini_family_of_id m with | Gemini_3 | Gemini_3_1 | Gemini_2_5 -> true | Gemini_other _ -> false`로 교체됨.
- 새로운 Gemini 라인 추가 시 컴파일러가 누락된 case를 잡음 (string miss로 silent fallback 되지 않음).

### 2. `scripts/check-model-inventory-truth.sh`

invariant를 typed 변형으로 교체:

- **1a.** `let gemini_family_of_id` 존재.
- **1b.** dispatch 사이트가 `Gemini_3 | Gemini_3_1 | Gemini_2_5` 세 변형을 모두 명시.
- **1c.** `.mli`에서 `type gemini_family` export.

기존 invariant 2 (model_meta inline test) + 3 (legacy gemini-2.x baseline)는 유지.

### 3. `test/test_capabilities.ml`

6개 Alcotest 케이스 추가:
- 각 변형 (`Gemini_3_1` / `Gemini_3` / `Gemini_2_5`) 분류.
- `Gemini_other`로 non-gemini ID와 미분류 gemini ID (`gemini-4-foo`) 둘 다 떨어지는지 확인 — silent fallback이 없음을 증명.
- 세 변형 모두 `gemini_capabilities` (1M ctx)로 dispatch 됨을 cross-check (drift gate가 grep으로 주장하던 속성을 type system + 동작 테스트로 enforce).

## 동작 변경 없음

`for_model_id "gemini-3-flash-preview"` / `"gemini-3.1-pro-preview"` / `"gemini-2.5-flash"` 모두 종전과 동일한 capabilities 반환. `dune runtest lib/llm_provider`의 inline test 11건 + alcotest 43건 모두 PASS.

## Why this is the root-fix, not another workaround

- (a) prefix 비교가 *완전히 사라지는 것은 아님* — 내부적으로 `gemini_family_of_id` 안에 남아있다. 단, 그 경계가 1개 함수로 좁혀짐.
- (b) drift gate가 *typed 변형*과 *exhaustive dispatch* 를 검증 → silent fallback 회귀 시 컴파일러가 잡고, 그게 실패하면 gate가 잡음.
- (c) downstream 코드(`for_model_id_static`, future `model_meta` 분기)는 변형에 대해 `match`함 — 새 변형 추가 시 컴파일 obligation.

## Verification

- `dune build --root . lib/llm_provider` → exit 0
- `dune build --root . test/test_capabilities.exe` → exit 0
- `dune exec --root . test/test_capabilities.exe` → 43/43 PASS (6 new + 37 existing)
- `dune runtest --root . lib/llm_provider` → exit 0
- `bash scripts/check-model-inventory-truth.sh` → `OK: gemini_family typed classifier + dispatch present, inline tests present, legacy count 46 ≤ baseline 53`

## Scope

다른 `starts_with` 분류기 (claude / gpt / qwen / llama / mistral / command / grok / nemotron / deepseek) 는 별도 작업으로 남김 — 본 PR은 Cluster D #968 root-fix에 한정.

## 참조

- 감사 보고서: `~/me/.tmp/pr-audit-2026-05-20/AUDIT-REPORT.md` Cluster D
- 원 PR (locked-in workaround): #968
- 원칙: `~/me/instructions/software-development.md` §워크어라운드 거부 기준 시그니처 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)