### PR TITLE
ci(code-smell): 4-metric monotone-decrease ratchet + RFC-OAS-022

### DIFF
--- a/.ci/code-smell-baseline.json
+++ b/.ci/code-smell-baseline.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Code-smell monotone-decrease ratchet baseline. Source: docs/rfc/RFC-OAS-022-code-smell-monotone-decrease-ratchet.md §3 (Reproducibility commands). PRs may decrease or hold counts; increases fail unless PR body carries RATCHET-WAIVED: <reason>. Updated only on main via scripts/ci-code-smell-ratchet.sh --rebaseline.",
+  "godfile": 10,
+  "catch_all": 768,
+  "duplicate_helpers": 9,
+  "ignore_calls": 15,
+  "lastUpdated": "2026-05-20T00:00:00Z",
+  "lastUpdatedCommit": "d845cad7b3410a2fafa2ce1743f122a21bef9be1"
+}

--- a/.github/workflows/code-smell-ratchet.yml
+++ b/.github/workflows/code-smell-ratchet.yml
@@ -1,0 +1,76 @@
+name: Code Smell Ratchet
+
+# Monotone-decrease ratchet for the four metrics defined in
+# docs/rfc/RFC-OAS-022-code-smell-monotone-decrease-ratchet.md §3:
+#   godfile, catch_all, duplicate_helpers, ignore_calls
+#
+# PRs may decrease or hold counts; increases fail unless the PR body
+# carries the line `RATCHET-WAIVED: <reason>`.
+#
+# Baseline:    .ci/code-smell-baseline.json
+# Gate script: scripts/ci-code-smell-ratchet.sh
+# RFC:         docs/rfc/RFC-OAS-022-code-smell-monotone-decrease-ratchet.md
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ratchet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Detect RATCHET-WAIVED label in PR body
+        id: waiver
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if printf '%s' "$PR_BODY" | grep -qE '^RATCHET-WAIVED:'; then
+            echo "waived=1" >> "$GITHUB_OUTPUT"
+            echo "PR body carries RATCHET-WAIVED — gate will report but not fail."
+          else
+            echo "waived=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run ratchet --check
+        id: check
+        run: |
+          set +e
+          bash scripts/ci-code-smell-ratchet.sh --check
+          echo "rc=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Enforce ratchet (fail unless waived)
+        if: github.event_name == 'pull_request'
+        run: |
+          rc="${{ steps.check.outputs.rc }}"
+          waived="${{ steps.waiver.outputs.waived }}"
+          if [ "$rc" != "0" ] && [ "$waived" != "1" ]; then
+            echo "Ratchet failed and PR body has no RATCHET-WAIVED: line. Failing."
+            exit 1
+          fi
+          if [ "$rc" != "0" ] && [ "$waived" = "1" ]; then
+            echo "Ratchet would fail, but RATCHET-WAIVED label present. Passing (must link a sunset RFC in body)."
+          fi
+          exit 0
+
+      - name: Fail push to main on regression (no waiver path on main)
+        if: github.event_name == 'push'
+        run: |
+          rc="${{ steps.check.outputs.rc }}"
+          if [ "$rc" != "0" ]; then
+            echo "main push regressed a code-smell metric — investigate or rebaseline via PR."
+            exit 1
+          fi
+          exit 0

--- a/docs/rfc/RFC-OAS-022-code-smell-monotone-decrease-ratchet.md
+++ b/docs/rfc/RFC-OAS-022-code-smell-monotone-decrease-ratchet.md
@@ -1,0 +1,221 @@
+# RFC-OAS-022: Code-Smell Monotone-Decrease Ratchet
+
+**Status**: Draft
+**Date**: 2026-05-20
+**Scope**: `.ci/code-smell-baseline.json`, `scripts/ci-code-smell-ratchet.sh`, `.github/workflows/code-smell-ratchet.yml`
+**One sentence**: Lock four OAS code-smell metrics (godfile / catch_all / duplicate_helpers / ignore_calls) against a stored baseline so that PRs can only decrease or hold the counts.
+
+## Related Documents
+
+- `memory/2026-05-20-masc-mcp-oas-workaround-audit.md` — Cluster C (exhaustive-match cleanup) prescription: `dune -w +8` strict + monotone-decrease ratchet for `_ ->` regressions.
+- masc-mcp PR #16833 (`29c2befa9f` — `ci(code-smell): 4-metric monotone-decrease ratchet + RFC-0146`) — sibling implementation in masc-mcp. OAS mirrors the script/workflow shape but defines a different metric set, since OAS has no HTML code-smell report and `contains_substring` is not the dominant duplicate-helper signature.
+- `~/me/instructions/software-development.md` §Workaround Rejection Bar — ratchets are the prescribed prevention for "every audit becomes a Sisyphus task" pattern.
+- OAS exhaustive-match cleanup history (9 merged PRs touching 27 sites) — without a gate, the next refactor wave will re-introduce `_ ->` arms in closed-variant contexts.
+
+## 0. Summary
+
+OAS has no automated guard against the four code-smell shapes that
+the 2026-05-20 audit (Cluster C) identified as regression-prone:
+
+1. **godfile** — `.ml` / `.mli` files ≥ 1000 LoC.
+2. **catch_all** — `| _ ->` arms (most are legitimate list filters,
+   but a non-trivial fraction silently absorbs new variants when a
+   closed sum type gains a constructor).
+3. **duplicate_helpers** — top-level redefinitions of small utility
+   functions that should live in a shared module
+   (`contains_substring`, `starts_with`, `first_token_basename`,
+   `last_pipeline_segment`).
+4. **ignore_calls** — bare `ignore (...)` call sites without an
+   adjacent comment justifying the discarded result.
+
+This RFC introduces a baseline + monotone-decrease ratchet. PRs may
+*decrease* or *hold* any metric; a PR that *increases* any metric
+fails CI unless the PR body carries `RATCHET-WAIVED: <reason>` and
+links a sunset RFC.
+
+## 1. Problem
+
+Audit cycles in OAS have repeatedly converged on the same pattern:
+
+1. A sweep identifies N regression-prone sites.
+2. K PRs land that reduce N → N - K.
+3. New PRs over the next weeks re-introduce roughly K sites.
+4. The next audit re-discovers the same shapes with the same N.
+
+The audit memory (`2026-05-20-masc-mcp-oas-workaround-audit.md`)
+records this for masc-mcp as the "Sisyphus task" pattern; the OAS
+exhaustive-match cleanup (9 PRs, 27 sites) is the local instance.
+
+`dune -w +8` strict warnings catch *fully-exhaustive missing arms*,
+but they cannot catch:
+
+- a new `| _ ->` arm added to a previously-exhaustive match
+  (downgrade is silent);
+- a third file defining `let contains_substring = ...` instead of
+  reusing an existing one;
+- a new file landing at 1500 LoC;
+- a new `ignore (expensive_call ())` without context.
+
+A ratchet does not replace `dune -w +8` — it complements it by
+locking the *aggregate* counts so any silent regression triggers CI
+attention.
+
+## 2. Decision
+
+Adopt a 4-metric monotone-decrease ratchet wired into CI.
+
+- Baseline file: `.ci/code-smell-baseline.json`.
+- Gate script: `scripts/ci-code-smell-ratchet.sh` with three modes
+  (`--measure | --check | --rebaseline`).
+- Workflow: `.github/workflows/code-smell-ratchet.yml` runs on
+  `pull_request` and `push:main`.
+- Escape hatch: `RATCHET-WAIVED: <reason>` line in PR body (PR path
+  only — `push:main` always fails on regression).
+
+## 3. Measurement Commands (Reproducibility)
+
+These commands are normative. Changing any of them requires a
+superseding RFC. The script wraps them verbatim.
+
+```bash
+# 1. godfile
+find lib -name "*.ml" -o -name "*.mli" \
+  | xargs wc -l \
+  | awk '$1>=1000 && $2!="total"{c++}END{print c+0}'
+
+# 2. catch_all
+rg -c "^\s*\| _ ->" lib/ --type ml \
+  | awk -F: '{s+=$NF}END{print s+0}'
+
+# 3. duplicate_helpers
+rg -c "^let (contains_substring|starts_with|first_token_basename|last_pipeline_segment)" lib/ --type ml \
+  | awk -F: '{s+=$NF}END{print s+0}'
+
+# 4. ignore_calls
+rg -c "^\s*ignore \(" lib/ --type ml \
+  | awk -F: '{s+=$NF}END{print s+0}'
+```
+
+Note on `find(1)`: some shells alias `find` to ripgrep. The script
+resolves `/usr/bin/find` first to preserve POSIX semantics. The
+in-script command is byte-identical to the form above when the alias
+is bypassed.
+
+## 4. Baseline (2026-05-20)
+
+Measured at `d845cad7b3410a2fafa2ce1743f122a21bef9be1` (`origin/main`):
+
+| metric             | count |
+|--------------------|-------|
+| godfile            | 10    |
+| catch_all          | 768   |
+| duplicate_helpers  | 9     |
+| ignore_calls       | 15    |
+
+The 10 godfiles span `lib/pipeline/pipeline.ml`,
+`lib/llm_provider/{complete,pricing,capabilities,transport_claude_code,streaming,discovery,backend_openai,transport_codex_cli}.ml`,
+and `lib/runtime_server.ml`. Reduction lives outside this RFC — the
+ratchet only prevents *growth*.
+
+## 5. Workflow Semantics
+
+| Event           | Behavior                                                        |
+|-----------------|-----------------------------------------------------------------|
+| `pull_request`  | Run `--check`. Fail unless ratchet PASSED or PR body waived.    |
+| `push:main`     | Run `--check`. Fail on any regression. No waiver path.          |
+
+`--rebaseline` is invoked manually on a PR (with reviewer approval)
+when a metric must legitimately grow — e.g. importing a vendored
+file. The RFC body of that PR must explain the increase.
+
+## 6. Why These Four Metrics
+
+OAS-specific reasoning, divergent from masc-mcp's identical-name
+slot:
+
+- **godfile** — OAS `lib/` has 10 files ≥ 1000 LoC, mostly in
+  `lib/llm_provider/`. Each new provider tends to push existing
+  files past the threshold. Holding the line is the first step
+  toward the existing `agent.ml → agent/` decomposition convention.
+- **catch_all** — most of OAS's 768 hits are list-pattern filters
+  (`| _ -> false` / `| [] -> ... | _ -> ...`). The ratchet does
+  not require *removing* them; it forbids *adding* new ones in
+  closed-variant matches without a manual review acknowledging the
+  trade-off.
+- **duplicate_helpers** — the OAS-specific four names
+  (`contains_substring`, `starts_with`, `first_token_basename`,
+  `last_pipeline_segment`) are textual signatures of helpers that
+  appear in 2+ files. `starts_with` is the most common drift
+  vector (string-prefix dispatch).
+- **ignore_calls** — `ignore (e)` discards a result without context.
+  The ratchet prefers `let _ : T = e (* reason *)` so the
+  intent is reviewable. This metric is small (15) and likely the
+  easiest to drive to zero over time.
+
+## 7. Escape Hatch & Sunset Criteria
+
+Escape hatch: PR body line
+
+```
+RATCHET-WAIVED: <reason, e.g. "vendored upstream patch, new provider import">
+```
+
+The waiver is only honored on `pull_request`. It must link the
+sunset RFC that removes the workaround. CI logs both the waiver and
+the regression delta.
+
+Sunset criteria: when *all four* metrics fall to ≤ 30 % of the
+2026-05-20 baseline (godfile ≤ 3, catch_all ≤ 230,
+duplicate_helpers ≤ 2, ignore_calls ≤ 4), this RFC supersedes
+itself with a stricter variant (no waiver path, or threshold
+counts rather than monotone-decrease).
+
+## 8. Non-Goals
+
+- This RFC does not measure or gate test code under `test/`.
+- It does not classify catch-all arms by RHS — that is a separate
+  audit step (see masc-mcp `audit-catchall.sh`; OAS may adopt a
+  similar tool in a follow-up).
+- It does not replace `dune -w +8` strict warnings or
+  bisect coverage floors.
+- It does not back-fill the existing godfiles toward 300-line
+  decomposition — that is RFC-OAS-017 / future work.
+
+## 9. Risks
+
+- **Baseline drift on legitimate refactors.** If a PR legitimately
+  needs to add a `| _ ->` arm (e.g. defending against a JSON shape
+  from an external API), the waiver path applies. The reviewer
+  must confirm the arm is not absorbing a closed sum.
+- **False sense of safety.** The ratchet does not catch *semantic*
+  regressions — only count regressions. A PR that *replaces* a
+  catch-all with another shape that is functionally identical but
+  textually different (e.g. `| (_ : t) ->`) would slip past
+  `catch_all` measurement. This is acceptable — the goal is
+  pressure, not perfection.
+- **find(1) alias on dev machines.** Mitigated by resolving
+  `/usr/bin/find` explicitly in the script.
+
+## 10. Compatibility with masc-mcp RFC-0146
+
+The two RFCs share script structure but not metric definitions:
+
+| metric (slot)      | masc-mcp (RFC-0146)                       | OAS (RFC-OAS-022)                                                                                  |
+|--------------------|-------------------------------------------|----------------------------------------------------------------------------------------------------|
+| godfile            | `find lib -name "*.ml"` (≥ 1000 LoC)      | `find lib -name "*.ml" -o -name "*.mli"` (≥ 1000 LoC) — `.mli` included                            |
+| catch_all          | same                                      | same                                                                                                |
+| 3rd metric         | `contains_substring` only                 | `contains_substring \| starts_with \| first_token_basename \| last_pipeline_segment` (4 names)     |
+| ignore_calls       | same                                      | same                                                                                                |
+
+The divergence is intentional: OAS does not have an HTML
+code-smell report to constrain it, and the helper-duplication
+signatures observed in `lib/llm_provider/` and `lib/pipeline/`
+differ from the masc-mcp keeper sub-system.
+
+## 11. Acceptance
+
+- [x] `.ci/code-smell-baseline.json` committed with current counts.
+- [x] `scripts/ci-code-smell-ratchet.sh` with `--measure | --check | --rebaseline`.
+- [x] `.github/workflows/code-smell-ratchet.yml` wired to `pull_request` + `push:main`.
+- [x] `--check` against baseline returns PASS at 0-diff (this PR).
+- [ ] Next PR that increases any metric exercises the waiver path.

--- a/scripts/ci-code-smell-ratchet.sh
+++ b/scripts/ci-code-smell-ratchet.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Code-smell monotone-decrease ratchet for OAS.
+#
+# Locks four metrics — defined verbatim in
+# docs/rfc/RFC-OAS-022-code-smell-monotone-decrease-ratchet.md §3 —
+# against a stored baseline (.ci/code-smell-baseline.json). PRs may
+# decrease or hold counts; increases fail this check.
+#
+# Metrics (DO NOT change these commands without a superseding RFC):
+#   1. godfile           — .ml/.mli files >= 1000 LoC under lib/
+#   2. catch_all         — "| _ ->" arms in lib/**/*.ml
+#   3. duplicate_helpers — top-level redefinitions of helpers that
+#                          should live in a shared module
+#                          (contains_substring | starts_with |
+#                           first_token_basename | last_pipeline_segment)
+#   4. ignore_calls      — bare "ignore (" call sites
+#
+# Usage:
+#   scripts/ci-code-smell-ratchet.sh --measure     # print current JSON, no compare
+#   scripts/ci-code-smell-ratchet.sh --check       # compare current vs baseline; fail if any metric exceeds baseline
+#   scripts/ci-code-smell-ratchet.sh --rebaseline  # main-only: write current counts to baseline JSON
+#
+# Escape hatch: `RATCHET-WAIVED: <reason>` line in the PR body. The CI
+# workflow (.github/workflows/code-smell-ratchet.yml) skips --check
+# failure when the waiver line is present on pull_request events.
+# Push to main does not honor the waiver — regressions must be
+# rebaselined via a follow-up PR.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+BASELINE_FILE=".ci/code-smell-baseline.json"
+
+# Resolve the real find(1). Some shells alias `find` to ripgrep.
+FIND_BIN="$(command -v /usr/bin/find || command -v find)"
+
+measure_godfile() {
+  # RFC-OAS-022 §3 command (verbatim):
+  #   find lib -name "*.ml" -o -name "*.mli" \
+  #     | xargs wc -l \
+  #     | awk '$1>=1000 && $2!="total"{c++}END{print c+0}'
+  "$FIND_BIN" lib -name "*.ml" -o -name "*.mli" 2>/dev/null \
+    | xargs wc -l 2>/dev/null \
+    | awk '$1>=1000 && $2!="total"{c++}END{print c+0}'
+}
+
+measure_catch_all() {
+  rg -c "^\s*\| _ ->" lib/ --type ml 2>/dev/null \
+    | awk -F: '{s+=$NF}END{print s+0}'
+}
+
+measure_duplicate_helpers() {
+  rg -c "^let (contains_substring|starts_with|first_token_basename|last_pipeline_segment)" lib/ --type ml 2>/dev/null \
+    | awk -F: '{s+=$NF}END{print s+0}'
+}
+
+measure_ignore_calls() {
+  rg -c "^\s*ignore \(" lib/ --type ml 2>/dev/null \
+    | awk -F: '{s+=$NF}END{print s+0}'
+}
+
+emit_json() {
+  local godfile catch_all duplicate_helpers ignore_calls
+  godfile="$(measure_godfile)"
+  catch_all="$(measure_catch_all)"
+  duplicate_helpers="$(measure_duplicate_helpers)"
+  ignore_calls="$(measure_ignore_calls)"
+  printf '{\n'
+  printf '  "godfile": %s,\n' "$godfile"
+  printf '  "catch_all": %s,\n' "$catch_all"
+  printf '  "duplicate_helpers": %s,\n' "$duplicate_helpers"
+  printf '  "ignore_calls": %s\n' "$ignore_calls"
+  printf '}\n'
+}
+
+read_baseline_key() {
+  # Tiny JSON read without jq dependency — values are simple integers.
+  local key="$1"
+  python3 -c "import json,sys; print(json.load(open('$BASELINE_FILE'))['$key'])"
+}
+
+do_check() {
+  local godfile_cur catch_all_cur dup_cur ignore_cur
+  local godfile_base catch_all_base dup_base ignore_base
+  local failed=0
+
+  godfile_cur="$(measure_godfile)"
+  catch_all_cur="$(measure_catch_all)"
+  dup_cur="$(measure_duplicate_helpers)"
+  ignore_cur="$(measure_ignore_calls)"
+
+  godfile_base="$(read_baseline_key godfile)"
+  catch_all_base="$(read_baseline_key catch_all)"
+  dup_base="$(read_baseline_key duplicate_helpers)"
+  ignore_base="$(read_baseline_key ignore_calls)"
+
+  printf "Code-smell ratchet (monotone-decrease)\n"
+  printf "Source: docs/rfc/RFC-OAS-022-code-smell-monotone-decrease-ratchet.md §3\n"
+  printf "%-22s %10s %10s %s\n" "metric" "baseline" "current" "verdict"
+  printf "%-22s %10s %10s %s\n" "----------------------" "--------" "-------" "-------"
+
+  check_one() {
+    local name="$1" base="$2" cur="$3"
+    local verdict
+    if [ "$cur" -gt "$base" ]; then
+      verdict="FAIL (+$((cur - base)))"
+      failed=1
+    elif [ "$cur" -lt "$base" ]; then
+      verdict="OK (decreased -$((base - cur)))"
+    else
+      verdict="OK (held)"
+    fi
+    printf "%-22s %10s %10s %s\n" "$name" "$base" "$cur" "$verdict"
+  }
+
+  check_one "godfile"           "$godfile_base"  "$godfile_cur"
+  check_one "catch_all"         "$catch_all_base" "$catch_all_cur"
+  check_one "duplicate_helpers" "$dup_base"      "$dup_cur"
+  check_one "ignore_calls"      "$ignore_base"   "$ignore_cur"
+
+  if [ "$failed" -ne 0 ]; then
+    printf "\nratchet FAILED — at least one metric increased above baseline.\n"
+    printf "Options:\n"
+    printf "  (a) reduce the metric in this PR (root fix > workaround)\n"
+    printf "  (b) add 'RATCHET-WAIVED: <reason>' to PR body and link a sunset RFC\n"
+    return 1
+  fi
+  printf "\nratchet PASSED.\n"
+  return 0
+}
+
+do_rebaseline() {
+  # main-only: write current measurements to baseline JSON. CI workflow
+  # job guards branch to refs/heads/main; this is a sanity check.
+  local current_branch
+  current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+  if [ "$current_branch" != "main" ] && [ "${ALLOW_REBASELINE_OFF_MAIN:-0}" != "1" ]; then
+    printf "refusing to rebaseline off main (branch=%s). Set ALLOW_REBASELINE_OFF_MAIN=1 to override.\n" "$current_branch" >&2
+    return 2
+  fi
+  local godfile catch_all duplicate_helpers ignore_calls commit ts
+  godfile="$(measure_godfile)"
+  catch_all="$(measure_catch_all)"
+  duplicate_helpers="$(measure_duplicate_helpers)"
+  ignore_calls="$(measure_ignore_calls)"
+  commit="$(git rev-parse HEAD)"
+  ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  mkdir -p "$(dirname "$BASELINE_FILE")"
+  cat > "$BASELINE_FILE" <<EOF
+{
+  "_comment": "Code-smell monotone-decrease ratchet baseline. Source: docs/rfc/RFC-OAS-022-code-smell-monotone-decrease-ratchet.md §3 (Reproducibility commands). PRs may decrease or hold counts; increases fail unless PR body carries RATCHET-WAIVED: <reason>. Updated only on main via scripts/ci-code-smell-ratchet.sh --rebaseline.",
+  "godfile": $godfile,
+  "catch_all": $catch_all,
+  "duplicate_helpers": $duplicate_helpers,
+  "ignore_calls": $ignore_calls,
+  "lastUpdated": "$ts",
+  "lastUpdatedCommit": "$commit"
+}
+EOF
+  printf "rebaselined: godfile=%s catch_all=%s duplicate_helpers=%s ignore_calls=%s\n" \
+    "$godfile" "$catch_all" "$duplicate_helpers" "$ignore_calls"
+}
+
+case "${1:---check}" in
+  --measure)    emit_json ;;
+  --check)      do_check ;;
+  --rebaseline) do_rebaseline ;;
+  -h|--help)
+    sed -n '2,30p' "$0"
+    ;;
+  *)
+    printf "unknown option: %s (use --measure | --check | --rebaseline)\n" "$1" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## 요약

OAS에 4-metric monotone-decrease ratchet 도입. PR이 `godfile / catch_all / duplicate_helpers / ignore_calls` 중 하나라도 증가시키면 CI fail. `RATCHET-WAIVED: <이유>` PR body line이 escape hatch (push to main에는 없음).

masc-mcp PR [#16833](https://github.com/jeong-sik/masc-mcp/commit/29c2befa9f) (`ci(code-smell): 4-metric monotone-decrease ratchet + RFC-0146`)의 OAS 버전. 동일한 script/workflow 형태이지만 metric set은 OAS 특이성에 맞춰 분기:

- `godfile`: `.ml` + `.mli` 모두 포함 (masc-mcp는 `.ml`만).
- `duplicate_helpers`: `contains_substring | starts_with | first_token_basename | last_pipeline_segment` 4개 (masc-mcp는 `contains_substring` 1개).

## 배경

2026-05-20 audit Cluster C (OAS/masc-mcp exhaustive-match cleanup) 처방:
- OAS exhaustive-match cleanup 9 PR 머지 (27 사이트 정리됨)
- 그러나 `lib/`에 잔여 `| _ ->` 767건 발견 — 대부분 정당한 list filter, 일부는 closed-variant silent absorption
- `dune -w +8` strict 만으로는 *catch-all 추가*가 silent (downgrade가 안 보임)
- ratchet이 *aggregate count*를 잠가서 어떤 silent regression도 CI signal로 끌어올림

masc-mcp는 #16833으로 동일 처방 처리됨. OAS는 미커버 — 본 PR이 그 gap을 닫는다.

## Baseline (2026-05-20, origin/main `d845cad7b3`)

| metric             | count |
|--------------------|-------|
| godfile            | 10    |
| catch_all          | 768   |
| duplicate_helpers  | 9     |
| ignore_calls       | 15    |

`bash scripts/ci-code-smell-ratchet.sh --check` PASS at 0-diff (self-test 통과).

## Files

- `.ci/code-smell-baseline.json` — baseline (10/768/9/15)
- `scripts/ci-code-smell-ratchet.sh` — `--measure | --check | --rebaseline`
- `.github/workflows/code-smell-ratchet.yml` — `pull_request` + `push:main` trigger
- `docs/rfc/RFC-OAS-022-code-smell-monotone-decrease-ratchet.md` — Draft

## Prevention root-fix self-check (7-point)

본 PR은 워크어라운드 거부 기준 7항목 어디에도 해당하지 않는다:

1. ❌ "makes X visible" 만 (fix 없음) — ratchet은 *prevention* 이지 visibility 만이 아님. 증가 시 CI fail.
2. ❌ string/substring 분류기 추가 — `rg`는 *count* 만 함, 분류 안 함.
3. ❌ "PR #N only fixed K of M sites" 자인 — N-of-M 패치 아님 (universe-wide count).
4. ❌ catch-all `_ ->` 추가 — 반대로, 추가를 *금지*.
5. ❌ cap/cooldown/dedup/repair으로 symptom 억제 — symptom이 아니라 prevention.
6. ❌ test backdoor 없음.
7. ❌ N개 사이트에서 N번 fix — 단일 ratchet으로 모든 lib/ 사이트 cover.

## RFC 인용 의무

본 PR은 `.github/workflows/`, `scripts/`, `docs/rfc/`, `.ci/` 만 건드림. RFC discovery 대상 subsystem(credential/identity/operator/sandbox/dashboard credential/hooks) *외부*. `pr-rfc-check.sh` exit=0.

## Test plan

- [x] `bash scripts/ci-code-smell-ratchet.sh --measure` → JSON 출력 검증
- [x] `bash scripts/ci-code-smell-ratchet.sh --check` → 0-diff PASS
- [ ] CI workflow `Code Smell Ratchet` job green (push 후 확인)
- [ ] follow-up PR이 metric을 증가시키면 fail 하는지 확인 (별도 verification)

## Sunset

모든 4 metric이 2026-05-20 baseline의 30% 이하로 떨어지면 (`godfile ≤ 3`, `catch_all ≤ 230`, `duplicate_helpers ≤ 2`, `ignore_calls ≤ 4`) 본 RFC가 더 strict 한 변형으로 supersede 한다 (waiver path 제거 또는 threshold count).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>