### PR TITLE
fix(ci): repair post-merge OAS main checks

### DIFF
--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -90,8 +90,11 @@ val with_slot_id : int -> t -> t
 val with_tracer : Tracing.t -> t -> t
 val with_raw_trace : Raw_trace.t -> t -> t
 val with_approval : Hooks.approval_callback -> t -> t
-val with_missing_approval_callback_policy :
-  Hooks.missing_approval_callback_policy -> t -> t
+
+val with_missing_approval_callback_policy
+  :  Hooks.missing_approval_callback_policy
+  -> t
+  -> t
 
 val with_tool_retry_policy : Tool_retry_policy.t -> t -> t
 

--- a/lib/completion_contract.ml
+++ b/lib/completion_contract.ml
@@ -27,7 +27,7 @@ type required_tool_satisfaction = tool_call -> (unit, string) result
 type violation_detail =
   { called_tools : string list
   ; satisfying_tools : string list
-  ; rejection_reasons : (string * string) list  (** [(tool_name, reason)] *)
+  ; rejection_reasons : (string * string) list (** [(tool_name, reason)] *)
   }
 [@@deriving show]
 
@@ -45,19 +45,19 @@ let violation_detail_to_string (detail : violation_detail) : string =
         " (%s)"
         (String.concat
            "; "
-           (List.map
-              (fun (name, reason) -> Printf.sprintf "%s: %s" name reason)
-              reasons))
+           (List.map (fun (name, reason) -> Printf.sprintf "%s: %s" name reason) reasons))
   in
   let suggestion =
     match detail.satisfying_tools with
-    | [] -> "\nNo currently visible tool can satisfy this contract -- emit a blocker instead."
+    | [] ->
+      "\nNo currently visible tool can satisfy this contract -- emit a blocker instead."
     | tools ->
       Printf.sprintf
         "\nSatisfying tools for this contract: [%s]"
         (String.concat ", " tools)
   in
   called ^ rejections ^ suggestion
+;;
 
 let any_tool_call_satisfies (_call : tool_call) = Ok ()
 
@@ -161,9 +161,7 @@ let format_suggestion ?(satisfying_tools = []) () =
   match satisfying_tools with
   | [] -> ""
   | tools ->
-    Printf.sprintf
-      "\nSatisfying tools for this contract: [%s]"
-      (String.concat ", " tools)
+    Printf.sprintf "\nSatisfying tools for this contract: [%s]" (String.concat ", " tools)
 ;;
 
 let unsatisfied_calls_message calls errors =
@@ -217,14 +215,14 @@ let validate_response
         (unsatisfied_calls_message
            calls
            (satisfaction_errors ~required_tool_satisfaction calls)
-        ^ suggestion)
+         ^ suggestion)
     else if stop_reason_is_resumable response.stop_reason
     then Ok ()
     else
       Error
         ("required tool contract unsatisfied: tool_choice requested tool use, but the \
           model returned no ToolUse block"
-        ^ suggestion)
+         ^ suggestion)
   | Require_specific_tool name ->
     let calls = tool_use_calls ~tools response in
     (match calls with
@@ -235,7 +233,7 @@ let validate_response
             "required tool contract unsatisfied: tool_choice requested tool '%s', but \
              the model returned no ToolUse block"
             name
-         ^ suggestion)
+          ^ suggestion)
      | calls ->
        let matching = List.filter (fun call -> String.equal call.name name) calls in
        if matching <> [] && any_satisfying_call ~required_tool_satisfaction matching
@@ -250,7 +248,7 @@ let validate_response
               (String.concat
                  "; "
                  (satisfaction_errors ~required_tool_satisfaction matching))
-           ^ suggestion)
+            ^ suggestion)
        else (
          let tool_names = List.map (fun call -> call.name) calls in
          Error
@@ -259,7 +257,7 @@ let validate_response
                the model called [%s]"
               name
               (String.concat ", " tool_names)
-           ^ suggestion)))
+            ^ suggestion)))
   | Require_no_tool_use ->
     (match tool_use_names response with
      | [] -> Ok ()
@@ -297,7 +295,7 @@ let violation_detail_of_response
     if calls <> [] && any_satisfying_call ~required_tool_satisfaction calls
     then Ok ()
     else if calls <> []
-    then
+    then (
       let reasons =
         List.filter_map
           (fun call ->
@@ -306,7 +304,7 @@ let violation_detail_of_response
              | Error reason -> Some (call.name, reason))
           calls
       in
-      make_detail ~rejection_reasons:reasons (List.map (fun c -> c.name) calls)
+      make_detail ~rejection_reasons:reasons (List.map (fun c -> c.name) calls))
     else if stop_reason_is_resumable response.stop_reason
     then Ok ()
     else make_detail []
@@ -320,7 +318,7 @@ let violation_detail_of_response
        if matching <> [] && any_satisfying_call ~required_tool_satisfaction matching
        then Ok ()
        else if matching <> []
-       then
+       then (
          let reasons =
            List.filter_map
              (fun call ->
@@ -329,13 +327,12 @@ let violation_detail_of_response
                 | Error reason -> Some (call.name, reason))
              matching
          in
-         make_detail ~rejection_reasons:reasons [ name ]
+         make_detail ~rejection_reasons:reasons [ name ])
        else make_detail (List.map (fun c -> c.name) calls))
   | Require_no_tool_use ->
     (match tool_use_names response with
      | [] -> Ok ()
-     | tool_names ->
-       make_detail tool_names)
+     | tool_names -> make_detail tool_names)
 ;;
 
 let accept_on_exhaustion ~(contract : t) =
@@ -647,5 +644,3 @@ let%test "stop_reason_is_resumable classification" =
   && (not (stop_reason_is_resumable (Unknown "refusal")))
   && not (stop_reason_is_resumable (Unknown "anything-else"))
 ;;
-
-

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -303,7 +303,7 @@ type gemini_family =
   | Gemini_3 (** [gemini-3.*] but not 3.1 — flash-preview and siblings *)
   | Gemini_2_5 (** [gemini-2.5.*] — legacy line, kept until removal PR *)
   | Gemini_other of string
-      (** Unknown gemini id or non-gemini id. Retains the literal so the
+  (** Unknown gemini id or non-gemini id. Retains the literal so the
           caller can log / fall through without losing data. *)
 
 (** Classify a model id into a [gemini_family]. Order matters: [gemini-3.1]
@@ -1079,8 +1079,7 @@ let%test "for_model_id qwen3 has chat_template_kwargs thinking control" =
      format, [supports_extended_thinking = true] never reaches the wire. *)
   match for_model_id "qwen3.5" with
   | Some c ->
-    c.supports_reasoning_budget
-    && c.thinking_control_format = Chat_template_kwargs
+    c.supports_reasoning_budget && c.thinking_control_format = Chat_template_kwargs
   | None -> false
 ;;
 

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -678,8 +678,8 @@ let complete_http
                     { message =
                         Printf.sprintf
                           "body_timeout_s deadline exceeded after %.1fs \
-                           (Complete.complete non-streaming path; total HTTP \
-                           round-trip cap, mirrors complete_stream contract)"
+                           (Complete.complete non-streaming path; total HTTP round-trip \
+                           cap, mirrors complete_stream contract)"
                           timeout_s
                     ; phase = Http_client.Non_streaming_body
                     }))
@@ -1326,8 +1326,7 @@ let complete_stream_http
           in
           let prefill_ms =
             match !first_event_at_ref, !first_token_at_ref with
-            | Some fe, Some ft when ft > fe ->
-              Some ((fe -. t0) *. 1000.0)
+            | Some fe, Some ft when ft > fe -> Some ((fe -. t0) *. 1000.0)
             | _ -> None
           in
           emit_telemetry
@@ -1387,8 +1386,9 @@ let complete_stream_http
                 then (
                   first_event_at_ref := Some (Unix.gettimeofday ());
                   stream_idle_state := Http_client.Awaiting_first_delta);
-                if Option.is_none !first_token_at_ref
-                   && List.exists Streaming.sse_event_is_first_token_signal events
+                if
+                  Option.is_none !first_token_at_ref
+                  && List.exists Streaming.sse_event_is_first_token_signal events
                 then first_token_at_ref := Some (Unix.gettimeofday ());
                 List.iter
                   (fun evt ->
@@ -1480,7 +1480,8 @@ let complete_stream_http
                            (match chunk.oll_usage with
                             | Some _ as u -> ollama_usage := u
                             | None -> ());
-                           dispatch (Streaming.ollama_chunk_to_events (get_state ()) chunk))
+                           dispatch
+                             (Streaming.ollama_chunk_to_events (get_state ()) chunk))
                        ()
                    | _ ->
                      Http_client.read_sse
@@ -1541,7 +1542,7 @@ let complete_stream_http
                            Printf.sprintf
                              "stream_idle_timeout_s deadline exceeded while %s"
                              (Http_client.stream_idle_state_to_label !stream_idle_state)
-                      ; phase
+                       ; phase
                        })
               in
               match stream_read_result with
@@ -1591,8 +1592,8 @@ let complete_stream_http
                    (Http_client.TimeoutError
                       { message =
                           Printf.sprintf
-                            "body_timeout_s deadline exceeded after %.1fs (configured via \
-                             Builder.with_body_timeout; total body consumption cap, \
+                            "body_timeout_s deadline exceeded after %.1fs (configured \
+                             via Builder.with_body_timeout; total body consumption cap, \
                              distinct from stream_idle_timeout_s)"
                             timeout_s
                       ; phase = Http_client.Stream_body
@@ -1671,9 +1672,7 @@ let complete_stream_http
              ~prefill_ms
              (Some latency_ms))
       | Ok (Error (Http_client.TimeoutError _ as err)) ->
-        publish_summary
-          ~terminal:(Telemetry_event.Terminal_error "timeout_error")
-          ();
+        publish_summary ~terminal:(Telemetry_event.Terminal_error "timeout_error") ();
         Error err
       | Ok (Error err) ->
         publish_summary

--- a/lib/llm_provider/discovery_http.mli
+++ b/lib/llm_provider/discovery_http.mli
@@ -12,11 +12,6 @@
     (lines 254, 481, 488, 510, +1).  Neither helper was previously
     exposed in [discovery.mli], so external surface is unaffected. *)
 
-val get_json
-  :  sw:Eio.Switch.t
-  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
-  -> string
-  -> (Yojson.Safe.t, string) result
 (** GET [url] and decode the body as JSON.  Returns [Error msg] for
     non-2xx responses, transport errors, parser errors, and the
     closed-sum [Http_client.http_error] variants ([AcceptRejected],
@@ -24,12 +19,17 @@ val get_json
     [ProviderTerminal], [ProviderFailure]).  [ProviderTerminal] is
     surfaced defensively — discovery hits HTTP endpoints only, so
     CLI-subprocess terminals cannot reach this match. *)
+val get_json
+  :  sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> string
+  -> (Yojson.Safe.t, string) result
 
+(** GET [url] and return [true] iff the response status is 2xx.
+    Discards body and error context — used for liveness probes only
+    (e.g. [/health], [/]). *)
 val get_ok
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> string
   -> bool
-(** GET [url] and return [true] iff the response status is 2xx.
-    Discards body and error context — used for liveness probes only
-    (e.g. [/health], [/]). *)

--- a/lib/llm_provider/discovery_parse.mli
+++ b/lib/llm_provider/discovery_parse.mli
@@ -34,19 +34,19 @@ type slot_status =
   ; idle : int
   }
 
-val parse_models : Yojson.Safe.t -> model_info list
 (** OpenAI-compatible [/v1/models] response → list of [{ id; owned_by }].
     Returns the empty list on missing/non-list [data], or when no item
     has a string [id].  [owned_by] defaults to ["unknown"] when absent. *)
+val parse_models : Yojson.Safe.t -> model_info list
 
-val parse_props : Yojson.Safe.t -> server_props option
 (** llama-server [/props] response → typed {!server_props}.  Requires a
     numeric [total_slots]; falls back to [0] for missing [n_ctx] and
     to [""] for missing [model].  Returns [None] when [total_slots] is
     missing or non-numeric. *)
+val parse_props : Yojson.Safe.t -> server_props option
 
-val parse_slots : Yojson.Safe.t -> slot_status option
 (** llama-server [/slots] response → typed {!slot_status}.  Counts a
     slot as busy when [is_processing] is [true] OR when [state] is a
     non-zero integer.  Returns [None] when the input is not a non-empty
     list. *)
+val parse_slots : Yojson.Safe.t -> slot_status option

--- a/lib/llm_provider/error.ml
+++ b/lib/llm_provider/error.ml
@@ -268,7 +268,8 @@ let of_http_error ?provider = function
     NetworkError
       { provider = provider_name provider; kind; timeout_phase = None; detail = message }
   | Http_client.TimeoutError { message; phase } ->
-    Timeout { provider = provider_name provider; timeout_phase = Some phase; detail = message }
+    Timeout
+      { provider = provider_name provider; timeout_phase = Some phase; detail = message }
   | Http_client.AcceptRejected { reason } ->
     InvalidRequest
       { provider = provider_name provider; reason = "accept rejected: " ^ reason }

--- a/lib/llm_provider/fd_throttle_hook.ml
+++ b/lib/llm_provider/fd_throttle_hook.ml
@@ -5,10 +5,7 @@
    call — no branch on Some/None per invocation. *)
 
 let identity_wrapper : (unit -> unit) -> unit = fun thunk -> thunk ()
-
-let _handler : ((unit -> unit) -> unit) Atomic.t =
-  Atomic.make identity_wrapper
-
+let _handler : ((unit -> unit) -> unit) Atomic.t = Atomic.make identity_wrapper
 let _installed : bool Atomic.t = Atomic.make false
 
 let with_slot (type a) (f : unit -> a) : a =
@@ -19,23 +16,26 @@ let with_slot (type a) (f : unit -> a) : a =
      propagate through the wrapper (wrappers are expected to be
      transparent on exception, like [Fun.protect] or [Eio.Switch]). *)
   let result : a option ref = ref None in
-  wrapper (fun () -> result := Some (f ())) ;
+  wrapper (fun () -> result := Some (f ()));
   match !result with
   | Some v -> v
   | None ->
-      (* A non-conformant wrapper that swallowed its thunk. Treat as
+    (* A non-conformant wrapper that swallowed its thunk. Treat as
          programmer error — the contract is "must call thunk exactly
          once". *)
-      failwith
-        "Fd_throttle_hook: installed handler did not invoke its \
-         thunk; wrapper contract violated"
+    failwith
+      "Fd_throttle_hook: installed handler did not invoke its thunk; wrapper contract \
+       violated"
+;;
 
 let set_handler h =
-  Atomic.set _handler h ;
+  Atomic.set _handler h;
   Atomic.set _installed true
+;;
 
 let reset_handler () =
-  Atomic.set _handler identity_wrapper ;
+  Atomic.set _handler identity_wrapper;
   Atomic.set _installed false
+;;
 
 let is_installed () = Atomic.get _installed

--- a/lib/llm_provider/retry_classify.mli
+++ b/lib/llm_provider/retry_classify.mli
@@ -18,15 +18,14 @@ type retry_config =
   ; backoff_multiplier : float
   }
 
-val default_retry_config : retry_config
 (** Pulled from [Constants.Retry] so tuning lives in one place. *)
+val default_retry_config : retry_config
 
-val shared_retry_config_of_complete : retry_config -> Retry.retry_config
 (** Adapter into the shared [Retry] module's config shape.  Used by
     the orchestrator (still in [Complete.complete_with_retry]) and by
     any caller that wants to feed [Retry.is_retryable] through. *)
+val shared_retry_config_of_complete : retry_config -> Retry.retry_config
 
-val classify_retry_error : Http_client.http_error -> Retry.api_error option
 (** Translates an [Http_client.http_error] into a [Retry.api_error]
     where retryability is meaningful.
 
@@ -40,8 +39,9 @@ val classify_retry_error : Http_client.http_error -> Retry.api_error option
     - [ProviderFailure] — provider/runtime failures are semantic
       cascade inputs, not local retry inputs; retrying the same
       lane would hide the typed reason from downstream policy. *)
+val classify_retry_error : Http_client.http_error -> Retry.api_error option
 
-val is_retryable : Http_client.http_error -> bool
 (** Convenience wrapper: [true] iff [classify_retry_error] yields a
     retryable [Retry.api_error].  Used by [Complete_cascade] and
     direct callers that just need a yes/no signal. *)
+val is_retryable : Http_client.http_error -> bool

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -19,7 +19,6 @@ val emit_synthetic_events : api_response -> (sse_event -> unit) -> unit
     *first-token* events (which set [ttft_ms]). The capture site
     is [Complete] §publish_summary. *)
 
-val sse_event_is_first_token_signal : sse_event -> bool
 (** [true] when the SSE event represents the first user-visible
     token delta. That means a [ContentBlockDelta] carrying a
     non-empty [TextDelta] / [ThinkingDelta] / [InputJsonDelta]
@@ -28,6 +27,7 @@ val sse_event_is_first_token_signal : sse_event -> bool
     no usage), and error events return [false].
 
     @stability Internal *)
+val sse_event_is_first_token_signal : sse_event -> bool
 
 (** {1 OpenAI SSE} *)
 
@@ -67,7 +67,6 @@ type openai_stream_state =
 
 val parse_openai_sse_chunk : string -> openai_chunk option
 
-val chunk_has_non_empty_delta : openai_chunk -> bool
 (** RFC-OAS-020: [true] when the chunk carries either a non-empty
     [delta_content] or a non-empty [delta_reasoning] or any
     [delta_tool_calls] — that is, the consumer would surface a
@@ -77,6 +76,7 @@ val chunk_has_non_empty_delta : openai_chunk -> bool
     first real token.
 
     @stability Internal *)
+val chunk_has_non_empty_delta : openai_chunk -> bool
 
 val create_openai_stream_state
   :  ?provider:string

--- a/lib/memory_procedural.ml
+++ b/lib/memory_procedural.ml
@@ -75,8 +75,7 @@ let procedure_of_json (json : Yojson.Safe.t) : procedure option =
    already uses the same `let string_contains = Util.string_contains`
    pattern, so this aligns with the in-library convention.  Removing
    the local copy avoids the "Scattered Hardcoded Defaults" antipattern
-   (masc-mcp Doc #4 §AI 코드 생성 안티패턴 #1; same pattern caught in
-   PR #16364 for masc-mcp's keeper_unified_metrics.ml). *)
+   recorded in the downstream coordinator docs for the same helper shape. *)
 let string_contains = Util.string_contains
 
 (* ── Operations ─────────────────────────────────────────── *)

--- a/lib/otel_tracer.ml
+++ b/lib/otel_tracer.ml
@@ -289,14 +289,12 @@ let inst_trace_context_headers ?sampled ?tracestate inst =
 let inst_record_metric inst ~name ~value ~metric_type =
   inst_with_lock inst
   @@ fun () ->
-  inst.metrics
-  <- { m_name = name; m_value = value; m_type = metric_type } :: inst.metrics
+  inst.metrics <- { m_name = name; m_value = value; m_type = metric_type } :: inst.metrics
 ;;
 
 let inst_get_metrics inst =
   inst_with_lock inst
-  @@ fun () ->
-  List.map (fun m -> m.m_name, m.m_value, m.m_type) (List.rev inst.metrics)
+  @@ fun () -> List.map (fun m -> m.m_name, m.m_value, m.m_type) (List.rev inst.metrics)
 ;;
 
 let inst_clear_metrics inst = inst_with_lock inst @@ fun () -> inst.metrics <- []
@@ -414,8 +412,8 @@ let metric_entry_to_json (m : metric_entry) : Yojson.Safe.t =
 
 let to_otlp_json (cfg : config) : Yojson.Safe.t =
   let spans, metrics =
-    inst_with_lock _global
-      (fun () -> List.rev _global.completed_spans, List.rev _global.metrics)
+    inst_with_lock _global (fun () ->
+      List.rev _global.completed_spans, List.rev _global.metrics)
   in
   let resource =
     `Assoc [ "attributes", attrs_to_json [ "service.name", cfg.service_name ] ]

--- a/test/telemetry_sca/test_telemetry_sca.ml
+++ b/test/telemetry_sca/test_telemetry_sca.ml
@@ -92,6 +92,13 @@ let test_no_orphan_producer_variants () =
   let nested_constructors =
     [ "No_response"
     ; "Ttft_exceeded"
+    ; "Non_streaming_body"
+    ; "Stream_body"
+    ; "Stream_idle"
+    ; "Provider_step"
+    ; "Cli_stdout_idle"
+    ; "Caller_budget"
+    ; "Unknown_timeout"
     ; "Terminal_done"
     ; "Terminal_cancelled"
     ; "Terminal_error"

--- a/test/test_approval.ml
+++ b/test/test_approval.ml
@@ -149,7 +149,8 @@ let test_approval_required_no_callback_fail_closed () =
   match results with
   | [ result ] ->
     check string "id" "t1" result.tool_use_id;
-    check string
+    check
+      string
       "content"
       "Tool rejected: approval required but no approval callback is registered"
       result.content;

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -258,7 +258,8 @@ let test_with_missing_approval_callback_policy () =
   Alcotest.(check bool)
     "missing approval callback policy set"
     true
-    ((Agent.options agent).missing_approval_callback_policy = Hooks.Reject_without_callback)
+    ((Agent.options agent).missing_approval_callback_policy
+     = Hooks.Reject_without_callback)
 ;;
 
 (* --- 12. with_tool_retry_policy --- *)

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -871,7 +871,8 @@ let test_complete_body_timeout_fires () =
          ()
      with
      | Ok _ -> fail "expected Error (body_timeout_s should have fired)"
-     | Error (Http_client.TimeoutError { phase = Http_client.Non_streaming_body; message }) ->
+     | Error
+         (Http_client.TimeoutError { phase = Http_client.Non_streaming_body; message }) ->
        let elapsed = Unix.gettimeofday () -. t0 in
        check bool "fires under server delay" true (elapsed < 1.5);
        check
@@ -895,9 +896,7 @@ let test_complete_body_timeout_does_not_fire_on_fast_response () =
     Eio.Switch.run
     @@ fun sw ->
     (* No server delay; generous body_timeout_s must not interfere. *)
-    let url =
-      start_mock_server ~sw ~net:env#net (anthropic_response "fast response")
-    in
+    let url = start_mock_server ~sw ~net:env#net (anthropic_response "fast response") in
     let config = make_config url in
     (match
        Complete.complete

--- a/test/test_completion_contract_violation.ml
+++ b/test/test_completion_contract_violation.ml
@@ -35,12 +35,7 @@ let read_only_tool name =
       ; examples = []
       }
   in
-  Tool.create
-    ~descriptor
-    ~name
-    ~description:("desc:" ^ name)
-    ~parameters:[]
-    noop_handler
+  Tool.create ~descriptor ~name ~description:("desc:" ^ name) ~parameters:[] noop_handler
 ;;
 
 (* --- violation_detail_to_string --- *)
@@ -50,7 +45,7 @@ let test_to_string_with_satisfying_tools () =
     Completion_contract.
       { called_tools = [ "search" ]
       ; satisfying_tools = [ "keeper_bash"; "keeper_write" ]
-      ; rejection_reasons = [ ("search", "read-only and cannot satisfy") ]
+      ; rejection_reasons = [ "search", "read-only and cannot satisfy" ]
       }
   in
   let s = Completion_contract.violation_detail_to_string detail in
@@ -75,16 +70,16 @@ let test_to_string_with_satisfying_tools () =
 let test_to_string_without_satisfying_tools () =
   let detail =
     Completion_contract.
-      { called_tools = [ "search" ]
-      ; satisfying_tools = []
-      ; rejection_reasons = []
-      }
+      { called_tools = [ "search" ]; satisfying_tools = []; rejection_reasons = [] }
   in
   let s = Completion_contract.violation_detail_to_string detail in
   let has_blocker =
     try
       ignore
-        (Str.search_forward (Str.regexp_string "No currently visible tool can satisfy") s 0);
+        (Str.search_forward
+           (Str.regexp_string "No currently visible tool can satisfy")
+           s
+           0);
       true
     with
     | Not_found -> false
@@ -126,7 +121,10 @@ let test_satisfying_tools_appended_to_error () =
     let has_suggestion =
       try
         ignore
-          (Str.search_forward (Str.regexp_string "Satisfying tools for this contract:") msg 0);
+          (Str.search_forward
+             (Str.regexp_string "Satisfying tools for this contract:")
+             msg
+             0);
         true
       with
       | Not_found -> false
@@ -158,7 +156,10 @@ let test_satisfying_tools_appended_for_specific_tool () =
     let has_suggestion =
       try
         ignore
-          (Str.search_forward (Str.regexp_string "Satisfying tools for this contract:") msg 0);
+          (Str.search_forward
+             (Str.regexp_string "Satisfying tools for this contract:")
+             msg
+             0);
         true
       with
       | Not_found -> false
@@ -180,7 +181,10 @@ let test_detail_on_failure_no_calls () =
   | Error detail ->
     Alcotest.(check int) "called_tools empty" 0 (List.length detail.called_tools);
     Alcotest.(check int) "satisfying_tools has 1" 1 (List.length detail.satisfying_tools);
-    Alcotest.(check int) "rejection_reasons empty" 0 (List.length detail.rejection_reasons)
+    Alcotest.(check int)
+      "rejection_reasons empty"
+      0
+      (List.length detail.rejection_reasons)
   | Ok () -> Alcotest.fail "expected Error"
 ;;
 
@@ -240,7 +244,10 @@ let test_detail_specific_tool_no_calls () =
   with
   | Error detail ->
     Alcotest.(check int) "called_tools empty" 0 (List.length detail.called_tools);
-    Alcotest.(check int) "satisfying has calculator" 1 (List.length detail.satisfying_tools)
+    Alcotest.(check int)
+      "satisfying has calculator"
+      1
+      (List.length detail.satisfying_tools)
   | Ok () -> Alcotest.fail "expected Error"
 ;;
 

--- a/test/test_fd_throttle_hook.ml
+++ b/test/test_fd_throttle_hook.ml
@@ -6,87 +6,93 @@ module P = Llm_provider.Provider_throttle
 module Pri = Llm_provider.Request_priority
 
 let test_default_is_identity () =
-  H.reset_handler () ;
-  check bool "default not installed" false (H.is_installed ()) ;
+  H.reset_handler ();
+  check bool "default not installed" false (H.is_installed ());
   let r = H.with_slot (fun () -> 42) in
   check int "identity returns value" 42 r
+;;
 
 let test_set_handler_marks_installed () =
-  H.reset_handler () ;
-  H.set_handler (fun thunk -> thunk ()) ;
-  check bool "installed after set" true (H.is_installed ()) ;
+  H.reset_handler ();
+  H.set_handler (fun thunk -> thunk ());
+  check bool "installed after set" true (H.is_installed ());
   H.reset_handler ()
+;;
 
 let test_handler_is_invoked () =
-  H.reset_handler () ;
+  H.reset_handler ();
   let call_count = ref 0 in
   H.set_handler (fun thunk ->
-    incr call_count ;
-    thunk ()) ;
+    incr call_count;
+    thunk ());
   let r1 = H.with_slot (fun () -> "a") in
   let r2 = H.with_slot (fun () -> "b") in
-  check string "first call result" "a" r1 ;
-  check string "second call result" "b" r2 ;
-  check int "handler invoked once per with_slot" 2 !call_count ;
+  check string "first call result" "a" r1;
+  check string "second call result" "b" r2;
+  check int "handler invoked once per with_slot" 2 !call_count;
   H.reset_handler ()
+;;
 
 let test_handler_propagates_exception () =
-  H.reset_handler () ;
+  H.reset_handler ();
   let entered = ref false in
   H.set_handler (fun thunk ->
-    entered := true ;
-    thunk ()) ;
+    entered := true;
+    thunk ());
   let exn = Failure "boom" in
   (try H.with_slot (fun () -> raise exn) |> ignore with
-   | Failure msg -> check string "exception preserved" "boom" msg) ;
-  check bool "handler still entered before exception" true !entered ;
+   | Failure msg -> check string "exception preserved" "boom" msg);
+  check bool "handler still entered before exception" true !entered;
   H.reset_handler ()
+;;
 
 let test_non_conformant_handler_fails_loudly () =
-  H.reset_handler () ;
+  H.reset_handler ();
   (* Wrapper that swallows the thunk — violates contract. *)
-  H.set_handler (fun _thunk -> ()) ;
+  H.set_handler (fun _thunk -> ());
   (try
-     H.with_slot (fun () -> 1) |> ignore ;
+     H.with_slot (fun () -> 1) |> ignore;
      Alcotest.fail "should have raised on contract violation"
    with
    | Failure msg ->
-     check bool
-       "error mentions wrapper contract"
-       true
-       (String.length msg > 0)) ;
+     check bool "error mentions wrapper contract" true (String.length msg > 0));
   H.reset_handler ()
+;;
 
 let test_handler_swap_is_atomic () =
-  H.reset_handler () ;
-  H.set_handler (fun thunk -> thunk ()) ;
-  H.set_handler (fun thunk -> thunk ()) ;
-  check bool "still installed after swap" true (H.is_installed ()) ;
+  H.reset_handler ();
+  H.set_handler (fun thunk -> thunk ());
+  H.set_handler (fun thunk -> thunk ());
+  check bool "still installed after swap" true (H.is_installed ());
   H.reset_handler ()
+;;
 
 let test_provider_throttle_composition () =
   (* The whole point of PR-3: every Provider_throttle.with_permit_priority
      goes through the hook. Install a counter and verify. *)
-  H.reset_handler () ;
+  H.reset_handler ();
   let hook_calls = ref 0 in
   H.set_handler (fun thunk ->
-    incr hook_calls ;
-    thunk ()) ;
-  Eio_main.run @@ fun _env ->
+    incr hook_calls;
+    thunk ());
+  Eio_main.run
+  @@ fun _env ->
   let t = P.create ~max_concurrent:4 ~provider_name:"test" in
   let r = P.with_permit_priority ~priority:Pri.Background t (fun () -> "ok") in
-  check string "throttled call result" "ok" r ;
-  check int "hook engaged through provider_throttle" 1 !hook_calls ;
+  check string "throttled call result" "ok" r;
+  check int "hook engaged through provider_throttle" 1 !hook_calls;
   H.reset_handler ()
+;;
 
 let test_reset_handler_restores_identity () =
-  H.reset_handler () ;
-  H.set_handler (fun thunk -> thunk ()) ;
-  check bool "installed before reset" true (H.is_installed ()) ;
-  H.reset_handler () ;
-  check bool "not installed after reset" false (H.is_installed ()) ;
+  H.reset_handler ();
+  H.set_handler (fun thunk -> thunk ());
+  check bool "installed before reset" true (H.is_installed ());
+  H.reset_handler ();
+  check bool "not installed after reset" false (H.is_installed ());
   let r = H.with_slot (fun () -> 7) in
   check int "identity restored" 7 r
+;;
 
 let () =
   Alcotest.run
@@ -108,9 +114,7 @@ let () =
             test_non_conformant_handler_fails_loudly
         ] )
     ; ( "provider_throttle composition"
-      , [ test_case
-            "permit goes through hook"
-            `Quick
-            test_provider_throttle_composition
-        ] )
+      , [ test_case "permit goes through hook" `Quick test_provider_throttle_composition ]
+      )
     ]
+;;

--- a/test/test_llm_provider_error.ml
+++ b/test/test_llm_provider_error.ml
@@ -131,7 +131,10 @@ let test_timeout () =
     "Provider 'gemini' timeout: request exceeded budget"
     (Error.to_string
        (Error.Timeout
-          { provider = "gemini"; timeout_phase = None; detail = "request exceeded budget" }))
+          { provider = "gemini"
+          ; timeout_phase = None
+          ; detail = "request exceeded budget"
+          }))
 ;;
 
 let test_timeout_phase () =
@@ -295,7 +298,11 @@ let test_http_network_error_mapping () =
   | Error.NetworkError { provider; kind; timeout_phase; detail } ->
     check string "provider" "local" provider;
     check bool "kind" true (kind = Http_client.Timeout);
-    check (option string) "timeout phase" None (Option.map Http_client.timeout_phase_to_label timeout_phase);
+    check
+      (option string)
+      "timeout phase"
+      None
+      (Option.map Http_client.timeout_phase_to_label timeout_phase);
     check string "detail" "read timed out" detail
   | _ -> fail "expected NetworkError"
 ;;

--- a/test/test_pipeline_metrics.ml
+++ b/test/test_pipeline_metrics.ml
@@ -180,7 +180,9 @@ let test_sdk_error_preserves_streaming_timeout_phase () =
       ; api_key_env = ""
       }
   in
-  let options = { Agent_types.default_options with transport = Some transport; provider } in
+  let options =
+    { Agent_types.default_options with transport = Some transport; provider }
+  in
   let agent =
     Agent.create
       ~net
@@ -196,8 +198,8 @@ let test_sdk_error_preserves_streaming_timeout_phase () =
     | Ok _ -> Alcotest.fail "expected provider timeout"
   in
   match err with
-  | Error.Provider
-      (Llm_provider.Error.Timeout { timeout_phase = Some phase; detail; _ }) ->
+  | Error.Provider (Llm_provider.Error.Timeout { timeout_phase = Some phase; detail; _ })
+    ->
     Alcotest.(check string)
       "phase"
       "stream_idle:streaming_thinking"

--- a/test/test_streaming_summary.ml
+++ b/test/test_streaming_summary.ml
@@ -114,8 +114,9 @@ let test_terminal_cancelled_roundtrip () =
 module Streaming = Llm_provider.Streaming
 module Types = Llm_provider.Types
 
-let make_openai_chunk ?delta_content ?delta_reasoning ?(delta_tool_calls = []) () :
-    Streaming.openai_chunk =
+let make_openai_chunk ?delta_content ?delta_reasoning ?(delta_tool_calls = []) ()
+  : Streaming.openai_chunk
+  =
   { chunk_id = "c1"
   ; chunk_model = "m"
   ; delta_content
@@ -128,19 +129,25 @@ let make_openai_chunk ?delta_content ?delta_reasoning ?(delta_tool_calls = []) (
 
 let test_chunk_has_non_empty_delta_content () =
   let c = make_openai_chunk ~delta_content:"hello" () in
-  Alcotest.(check bool) "non-empty content is a token signal" true
+  Alcotest.(check bool)
+    "non-empty content is a token signal"
+    true
     (Streaming.chunk_has_non_empty_delta c)
 ;;
 
 let test_chunk_empty_delta_is_not_token () =
   let c = make_openai_chunk ~delta_content:"" () in
-  Alcotest.(check bool) "empty string content is not a token" false
+  Alcotest.(check bool)
+    "empty string content is not a token"
+    false
     (Streaming.chunk_has_non_empty_delta c)
 ;;
 
 let test_chunk_only_reasoning_is_token () =
   let c = make_openai_chunk ~delta_reasoning:"thinking..." () in
-  Alcotest.(check bool) "reasoning-only chunk is a token" true
+  Alcotest.(check bool)
+    "reasoning-only chunk is a token"
+    true
     (Streaming.chunk_has_non_empty_delta c)
 ;;
 
@@ -153,41 +160,48 @@ let test_chunk_tool_call_is_token () =
     }
   in
   let c = make_openai_chunk ~delta_tool_calls:[ tc ] () in
-  Alcotest.(check bool) "tool_call delta is a token" true
+  Alcotest.(check bool)
+    "tool_call delta is a token"
+    true
     (Streaming.chunk_has_non_empty_delta c)
 ;;
 
 let test_chunk_finish_only_is_not_token () =
   let c = make_openai_chunk () in
-  Alcotest.(check bool) "finish-only / empty chunk is not a token" false
+  Alcotest.(check bool)
+    "finish-only / empty chunk is not a token"
+    false
     (Streaming.chunk_has_non_empty_delta c)
 ;;
 
 let test_sse_event_message_start_is_not_token () =
-  let e = Types.MessageStart { id = "x" ; model = "m" ; usage = None } in
-  Alcotest.(check bool) "MessageStart is prelude, not token" false
+  let e = Types.MessageStart { id = "x"; model = "m"; usage = None } in
+  Alcotest.(check bool)
+    "MessageStart is prelude, not token"
+    false
     (Streaming.sse_event_is_first_token_signal e)
 ;;
 
 let test_sse_event_text_delta_is_token () =
-  let e =
-    Types.ContentBlockDelta
-      { index = 0 ; delta = Types.TextDelta "hello" }
-  in
-  Alcotest.(check bool) "TextDelta with content is a token" true
+  let e = Types.ContentBlockDelta { index = 0; delta = Types.TextDelta "hello" } in
+  Alcotest.(check bool)
+    "TextDelta with content is a token"
+    true
     (Streaming.sse_event_is_first_token_signal e)
 ;;
 
 let test_sse_event_empty_text_delta_is_not_token () =
-  let e =
-    Types.ContentBlockDelta { index = 0 ; delta = Types.TextDelta "" }
-  in
-  Alcotest.(check bool) "empty TextDelta is not a token" false
+  let e = Types.ContentBlockDelta { index = 0; delta = Types.TextDelta "" } in
+  Alcotest.(check bool)
+    "empty TextDelta is not a token"
+    false
     (Streaming.sse_event_is_first_token_signal e)
 ;;
 
 let test_sse_event_ping_is_not_token () =
-  Alcotest.(check bool) "Ping is not a token" false
+  Alcotest.(check bool)
+    "Ping is not a token"
+    false
     (Streaming.sse_event_is_first_token_signal Types.Ping)
 ;;
 

--- a/test/test_telemetry_event.ml
+++ b/test/test_telemetry_event.ml
@@ -71,6 +71,7 @@ let test_streaming_summary () =
           ; done_ = 1
           }
       ; ttft_ms = Some 12.5
+      ; prefill_ms = None
       ; total_ms = 120.0
       ; inter_chunk_ms_p50 = 20.0
       ; inter_chunk_ms_p95 = 40.0
@@ -211,6 +212,7 @@ let test_event_type_name () =
               ; done_ = 0
               }
           ; ttft_ms = None
+          ; prefill_ms = None
           ; total_ms = 0.0
           ; inter_chunk_ms_p50 = 0.0
           ; inter_chunk_ms_p95 = 0.0


### PR DESCRIPTION
## Summary

Repairs post-merge CI failures observed after #1647/#1645 landed on main.

- Adds missing `prefill_ms = None` in `test/test_telemetry_event.ml` records.
- Removes coordinator-specific terms from the strict SDK independence scan path.
- Promotes repo-wide ocamlformat drift from recent merged changes.

## Verification

- `bash scripts/check-sdk-independence.sh`
- `scripts/dune-local.sh build test/test_telemetry_event.exe`
- `scripts/dune-local.sh build @fmt`
- `scripts/dune-local.sh build @all`
