### PR TITLE
[codex] Require explicit raw-trace evidence roles

### DIFF
--- a/lib/agent/agent_trace.ml
+++ b/lib/agent/agent_trace.ml
@@ -17,6 +17,21 @@ let record_hook_invocation active_run ~hook_name ~decision ?detail () =
          ())
 ;;
 
+let raw_trace_evidence_role_of_tool_role = function
+  | Tool.File_write -> Raw_trace.File_write
+  | Tool.Verification -> Raw_trace.Verification
+;;
+
+let tool_evidence_role tools tool_name =
+  tools
+  |> List.find_map (fun (tool : Tool.t) ->
+    if String.equal tool.schema.name tool_name
+    then
+      Option.bind (Tool.descriptor tool) (fun descriptor -> descriptor.Tool.evidence_role)
+      |> Option.map raw_trace_evidence_role_of_tool_role
+    else None)
+;;
+
 let invoke_hook_with_trace agent ?raw_trace_run ~hook_name hook_opt event =
   Tracing.with_span
     agent.options.tracer
@@ -35,6 +50,7 @@ let invoke_hook_with_trace agent ?raw_trace_run ~hook_name hook_opt event =
 let execute_tools_with_trace agent active_run tool_uses =
   let correlation_id = Option.bind agent.options.raw_trace Raw_trace.session_id in
   let run_id = Option.map Raw_trace.active_run_id active_run in
+  let tools = Tool_set.to_list agent.tools in
   let on_tool_execution_started =
     match active_run with
     | None -> None
@@ -78,14 +94,16 @@ let execute_tools_with_trace agent active_run tool_uses =
                ~tool_use_id
                ~tool_name
                ~tool_result:content
-               ~tool_error:is_error))
+               ?evidence_role:(tool_evidence_role tools tool_name)
+               ~tool_error:is_error
+               ()))
   in
   let on_hook_invoked ~hook_name ~decision ~detail =
     record_hook_invocation active_run ~hook_name ~decision ?detail ()
   in
   Agent_tools.execute_tools
     ~context:agent.context
-    ~tools:(Tool_set.to_list agent.tools)
+    ~tools
     ~hooks:agent.options.hooks
     ~event_bus:agent.options.event_bus
     ?journal:agent.options.journal

--- a/lib/base/tool.ml
+++ b/lib/base/tool.ml
@@ -26,6 +26,11 @@ type permission =
   | Destructive
 [@@deriving yojson, show]
 
+type evidence_role =
+  | File_write
+  | Verification
+[@@deriving yojson, show]
+
 type shell_constraints =
   { single_command_only : bool
   ; shell_metacharacters_allowed : bool
@@ -41,6 +46,7 @@ type descriptor =
   ; mutation_class : string option
   ; concurrency_class : concurrency_class option
   ; permission : permission option
+  ; evidence_role : evidence_role option
   ; shell : shell_constraints option
   ; notes : string list
   ; examples : string list
@@ -135,6 +141,11 @@ let permission_to_string = function
   | Destructive -> "destructive"
 ;;
 
+let evidence_role_to_string = function
+  | File_write -> "file_write"
+  | Verification -> "verification"
+;;
+
 let workdir_policy_to_json = function
   | Required -> `String "required"
   | Recommended -> `String "recommended"
@@ -177,6 +188,12 @@ let descriptor_to_yojson = function
         , Option.value
             ~default:`Null
             (Option.map permission_to_yojson descriptor.permission) )
+      ; ( "evidence_role"
+        , Option.value
+            ~default:`Null
+            (Option.map
+               (fun role -> `String (evidence_role_to_string role))
+               descriptor.evidence_role) )
       ; "shell", shell_json
       ; "notes", `List (List.map (fun s -> `String s) descriptor.notes)
       ; "examples", `List (List.map (fun s -> `String s) descriptor.examples)

--- a/lib/base/tool.mli
+++ b/lib/base/tool.mli
@@ -27,6 +27,11 @@ type permission =
   | Destructive (** External effects or irreversible operations. *)
 [@@deriving yojson, show]
 
+type evidence_role =
+  | File_write
+  | Verification
+[@@deriving yojson, show]
+
 type shell_constraints =
   { single_command_only : bool
   ; shell_metacharacters_allowed : bool
@@ -46,6 +51,10 @@ type descriptor =
           Approval hooks can use this to skip confirmation for [ReadOnly]
           tools or require explicit approval for [Destructive] ones.
           [None] means unclassified (legacy tools). *)
+  ; evidence_role : evidence_role option
+    (** Optional proof role emitted into raw traces when this tool completes.
+          This is declarative tool metadata, not inferred from the tool name
+          or textual result. *)
   ; shell : shell_constraints option
   ; notes : string list
   ; examples : string list
@@ -104,8 +113,10 @@ val permission_to_string : permission -> string
       [\[@@deriving show\]] produces module-qualified CamelCase and is intended
       for diagnostics only.
       @since 0.120.0 *)
-val validate_descriptor : descriptor -> (unit, string) result
+val evidence_role_to_string : evidence_role -> string
+(** Stable snake_case string for raw-trace proof roles. *)
 
+val validate_descriptor : descriptor -> (unit, string) result
 val descriptor_to_yojson : descriptor option -> Yojson.Safe.t
 val schema_to_json : t -> Yojson.Safe.t
 

--- a/lib/completion_contract.ml
+++ b/lib/completion_contract.ml
@@ -416,6 +416,7 @@ let%test "validate_response preserves first-match tool descriptor semantics" =
       ; mutation_class = None
       ; concurrency_class = None
       ; permission = Some perm
+      ; evidence_role = None
       ; shell = None
       ; notes = []
       ; examples = []

--- a/lib/raw_trace.ml
+++ b/lib/raw_trace.ml
@@ -218,31 +218,7 @@ let evidence_role_of_json_opt json =
             { type_name = "raw_trace.evidence_role"; value = Yojson.Safe.to_string value }))
 ;;
 
-let successful_tool_finish (record : record) =
-  match record.record_type, record.tool_error with
-  | Tool_execution_finished, Some false -> true
-  | _ -> false
-;;
-
-let result_contains_pass (record : record) =
-  match record.tool_result with
-  | Some result -> Util.string_contains ~needle:"PASS" (String.uppercase_ascii result)
-  | None -> false
-;;
-
-let legacy_evidence_role (record : record) =
-  match record.tool_name with
-  | Some "file_write" -> Some File_write
-  | Some "shell_exec" when successful_tool_finish record && result_contains_pass record ->
-    Some Verification
-  | _ -> None
-;;
-
-let record_evidence_role (record : record) =
-  match record.evidence_role with
-  | Some _ as role -> role
-  | None -> legacy_evidence_role record
-;;
+let record_evidence_role (record : record) = record.evidence_role
 
 let record_to_json (record : record) =
   `Assoc
@@ -429,6 +405,7 @@ let append_record
       ?tool_batch_index
       ?tool_batch_size
       ?tool_concurrency_class
+      ?evidence_role
       ?tool_result
       ?tool_error
       ?hook_name
@@ -464,7 +441,7 @@ let append_record
       ; tool_batch_index
       ; tool_batch_size
       ; tool_concurrency_class
-      ; evidence_role = None
+      ; evidence_role
       ; tool_result
       ; tool_error
       ; hook_name
@@ -475,7 +452,6 @@ let append_record
       ; error
       }
     in
-    let record = { record with evidence_role = record_evidence_role record } in
     let result = append_locked active.sink record in
     (match result with
      | Ok () ->
@@ -571,7 +547,14 @@ let record_tool_execution_started
   |> Result.map (fun _ -> ())
 ;;
 
-let record_tool_execution_finished active ~tool_use_id ~tool_name ~tool_result ~tool_error
+let record_tool_execution_finished
+      active
+      ~tool_use_id
+      ~tool_name
+      ~tool_result
+      ?evidence_role
+      ~tool_error
+      ()
   =
   append_record
     active
@@ -579,6 +562,7 @@ let record_tool_execution_finished active ~tool_use_id ~tool_name ~tool_result ~
     ~tool_use_id
     ~tool_name
     ~tool_result
+    ?evidence_role
     ~tool_error
     ()
   |> Result.map (fun _ -> ())

--- a/lib/raw_trace.mli
+++ b/lib/raw_trace.mli
@@ -174,7 +174,9 @@ val record_tool_execution_finished
   -> tool_use_id:string
   -> tool_name:string
   -> tool_result:string
+  -> ?evidence_role:evidence_role
   -> tool_error:bool
+  -> unit
   -> (unit, Error.sdk_error) result
 
 val record_hook_invoked

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -131,6 +131,7 @@ let descriptor permission : Tool.descriptor =
   ; mutation_class = None
   ; concurrency_class = None
   ; permission = Some permission
+  ; evidence_role = None
   ; shell = None
   ; notes = []
   ; examples = []

--- a/test/test_approval.ml
+++ b/test/test_approval.ml
@@ -9,6 +9,7 @@ let descriptor_with ?mutation_class concurrency_class =
   ; mutation_class
   ; concurrency_class = Some concurrency_class
   ; permission = None
+  ; evidence_role = None
   ; shell = None
   ; notes = []
   ; examples = []
@@ -20,6 +21,7 @@ let shell_descriptor () =
   ; mutation_class = Some "workspace_mutating"
   ; concurrency_class = Some Tool.Sequential_workspace
   ; permission = Some Tool.Write
+  ; evidence_role = None
   ; shell =
       Some
         { Tool.single_command_only = true

--- a/test/test_completion_contract_violation.ml
+++ b/test/test_completion_contract_violation.ml
@@ -30,6 +30,7 @@ let read_only_tool name =
       ; mutation_class = None
       ; concurrency_class = None
       ; permission = Some ReadOnly
+      ; evidence_role = None
       ; shell = None
       ; notes = []
       ; examples = []

--- a/test/test_raw_trace.ml
+++ b/test/test_raw_trace.ml
@@ -154,6 +154,16 @@ let test_agent_run_stream_append_only_raw_trace () =
   in
   let file_write_tool =
     Tool.create
+      ~descriptor:
+        { Tool.kind = Some "file"
+        ; mutation_class = Some "workspace"
+        ; concurrency_class = Some Tool.Sequential_workspace
+        ; permission = Some Tool.Write
+        ; evidence_role = Some Tool.File_write
+        ; shell = None
+        ; notes = []
+        ; examples = []
+        }
       ~name:"file_write"
       ~description:"Write a file"
       ~parameters:
@@ -176,6 +186,16 @@ let test_agent_run_stream_append_only_raw_trace () =
   in
   let shell_exec_tool =
     Tool.create
+      ~descriptor:
+        { Tool.kind = Some "shell"
+        ; mutation_class = Some "read_only"
+        ; concurrency_class = Some Tool.Parallel_read
+        ; permission = Some Tool.ReadOnly
+        ; evidence_role = Some Tool.Verification
+        ; shell = None
+        ; notes = []
+        ; examples = []
+        }
       ~name:"shell_exec"
       ~description:"Run a verification command"
       ~parameters:
@@ -397,9 +417,9 @@ let test_agent_run_stream_append_only_raw_trace () =
     Alcotest.(check (list (option string)))
       "concurrency classes"
       [ Some "sequential_workspace"
+      ; Some "parallel_read"
       ; Some "sequential_workspace"
-      ; Some "sequential_workspace"
-      ; Some "sequential_workspace"
+      ; Some "parallel_read"
       ]
       (List.map
          (fun (record : Raw_trace.record) -> record.tool_concurrency_class)
@@ -568,6 +588,54 @@ let test_evidence_role_of_string () =
   match Raw_trace.evidence_role_of_string "shell_exec" with
   | Error _ -> ()
   | Ok _ -> Alcotest.fail "expected error for legacy tool name"
+;;
+
+let test_record_evidence_role_does_not_infer_legacy_tool_names () =
+  let record : Raw_trace.record =
+    { trace_version = 1
+    ; worker_run_id = "wr-legacy"
+    ; seq = 1
+    ; ts = 1700000000.0
+    ; agent_name = "test-agent"
+    ; session_id = None
+    ; record_type = Raw_trace.Tool_execution_finished
+    ; prompt = None
+    ; model = None
+    ; tool_choice = None
+    ; enable_thinking = None
+    ; thinking_budget = None
+    ; block_index = None
+    ; block_kind = None
+    ; assistant_block = None
+    ; tool_use_id = Some "tu-legacy"
+    ; tool_name = Some "file_write"
+    ; tool_input = None
+    ; tool_planned_index = None
+    ; tool_batch_index = None
+    ; tool_batch_size = None
+    ; tool_concurrency_class = None
+    ; evidence_role = None
+    ; tool_result = Some "PASS"
+    ; tool_error = Some false
+    ; hook_name = None
+    ; hook_decision = None
+    ; hook_detail = None
+    ; final_text = None
+    ; stop_reason = None
+    ; error = None
+    }
+  in
+  Alcotest.(check (option string))
+    "legacy tool name alone has no evidence role"
+    None
+    (Option.map Raw_trace.evidence_role_to_string (Raw_trace.record_evidence_role record));
+  Alcotest.(check (option string))
+    "explicit role is preserved"
+    (Some "file_write")
+    (Option.map
+       Raw_trace.evidence_role_to_string
+       (Raw_trace.record_evidence_role
+          { record with evidence_role = Some Raw_trace.File_write }))
 ;;
 
 let test_record_to_json_roundtrip () =
@@ -852,6 +920,10 @@ let () =
         ; Alcotest.test_case "record_type_of_string" `Quick test_record_type_of_string
         ; Alcotest.test_case "evidence_role_to_string" `Quick test_evidence_role_to_string
         ; Alcotest.test_case "evidence_role_of_string" `Quick test_evidence_role_of_string
+        ; Alcotest.test_case
+            "no legacy evidence role inference"
+            `Quick
+            test_record_evidence_role_does_not_infer_legacy_tool_names
         ] )
     ; ( "record_json"
       , [ Alcotest.test_case "minimal roundtrip" `Quick test_record_to_json_roundtrip

--- a/test/test_raw_trace_deep.ml
+++ b/test/test_raw_trace_deep.ml
@@ -696,6 +696,76 @@ let test_validate_run_uses_explicit_evidence_roles () =
     Alcotest.fail (Printf.sprintf "validate_run failed: %s" (Error.to_string err))
 ;;
 
+let test_validate_run_ignores_legacy_tool_names_without_roles () =
+  let dir = tmpdir () in
+  let path = Filename.concat dir "validate_no_legacy_roles.jsonl" in
+  let records =
+    [ mk_record ~seq:1 ~record_type:Raw_trace.Run_started ~prompt:(Some "go") ()
+    ; mk_record
+        ~seq:2
+        ~record_type:Raw_trace.Tool_execution_started
+        ~prompt:None
+        ~tool_use_id:(Some "tu-write")
+        ~tool_name:(Some "file_write")
+        ~tool_input:(Some `Null)
+        ()
+    ; mk_record
+        ~seq:3
+        ~record_type:Raw_trace.Tool_execution_finished
+        ~prompt:None
+        ~tool_use_id:(Some "tu-write")
+        ~tool_name:(Some "file_write")
+        ~tool_result:(Some "wrote")
+        ~tool_error:(Some false)
+        ()
+    ; mk_record
+        ~seq:4
+        ~record_type:Raw_trace.Tool_execution_started
+        ~prompt:None
+        ~tool_use_id:(Some "tu-verify")
+        ~tool_name:(Some "shell_exec")
+        ~tool_input:(Some `Null)
+        ()
+    ; mk_record
+        ~seq:5
+        ~record_type:Raw_trace.Tool_execution_finished
+        ~prompt:None
+        ~tool_use_id:(Some "tu-verify")
+        ~tool_name:(Some "shell_exec")
+        ~tool_result:(Some "PASS")
+        ~tool_error:(Some false)
+        ()
+    ; mk_record
+        ~seq:6
+        ~record_type:Raw_trace.Run_finished
+        ~prompt:None
+        ~final_text:(Some "OK")
+        ~stop_reason:(Some "end_turn")
+        ()
+    ]
+  in
+  write_jsonl path records;
+  let run_ref : Raw_trace.run_ref =
+    { worker_run_id = "wr-test-0001"
+    ; path
+    ; start_seq = 1
+    ; end_seq = 6
+    ; agent_name = "test_agent"
+    ; session_id = Some "s-test-001"
+    }
+  in
+  match Raw_trace_query.validate_run run_ref with
+  | Ok validation ->
+    Alcotest.(check bool) "ok" true validation.ok;
+    Alcotest.(check bool) "legacy file_write ignored" false validation.has_file_write;
+    Alcotest.(check bool)
+      "legacy shell PASS ignored"
+      false
+      validation.verification_pass_after_file_write
+  | Error err ->
+    Alcotest.fail (Printf.sprintf "validate_run failed: %s" (Error.to_string err))
+;;
+
 let test_validate_run_no_finished () =
   let dir = tmpdir () in
   let path = Filename.concat dir "validate_nofin.jsonl" in
@@ -879,6 +949,10 @@ let () =
             "explicit evidence roles"
             `Quick
             test_validate_run_uses_explicit_evidence_roles
+        ; Alcotest.test_case
+            "legacy tool names are ignored"
+            `Quick
+            test_validate_run_ignores_legacy_tool_names_without_roles
         ; Alcotest.test_case "no run_finished" `Quick test_validate_run_no_finished
         ; Alcotest.test_case
             "unmatched tool pairs"

--- a/test/test_tool.ml
+++ b/test/test_tool.ml
@@ -154,6 +154,7 @@ let test_descriptor_preserved_and_not_in_schema () =
         ; mutation_class = None
         ; concurrency_class = Some Tool.Exclusive_external
         ; permission = Some Tool.Destructive
+        ; evidence_role = None
         ; shell =
             Some
               { Tool.single_command_only = true
@@ -278,6 +279,7 @@ let test_create_rejects_inconsistent_descriptor () =
               ; mutation_class = Some "read_only"
               ; concurrency_class = Some Tool.Sequential_workspace
               ; permission = None
+              ; evidence_role = None
               ; shell = None
               ; notes = []
               ; examples = []

--- a/test/test_tool_middleware.ml
+++ b/test/test_tool_middleware.ml
@@ -47,6 +47,7 @@ let shell_descriptor
   ; mutation_class = None
   ; concurrency_class = None
   ; permission = None
+  ; evidence_role = None
   ; shell =
       Some
         { single_command_only

--- a/test/test_typed_tool.ml
+++ b/test/test_typed_tool.ml
@@ -184,6 +184,7 @@ let test_descriptor_some () =
         ; mutation_class = Some "read_only"
         ; concurrency_class = Some Tool.Parallel_read
         ; permission = Some Tool.ReadOnly
+        ; evidence_role = None
         ; shell = None
         ; notes = []
         ; examples = []


### PR DESCRIPTION
## Summary
- add explicit Tool.descriptor evidence_role metadata for raw-trace proof roles
- pass descriptor roles into raw trace tool-finished records instead of inferring from legacy tool names/results
- remove legacy file_write/shell_exec PASS inference and add regression tests that prove it stays gone

## Validation
- ocamlformat --check on touched OCaml files
- git diff --check
- rg "successful_tool_finish|result_contains_pass|legacy_evidence_role" lib test (no matches)
- env MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_raw_trace.exe test/test_raw_trace_deep.exe
- env MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_agent_pipeline.exe test/test_approval.exe test/test_completion_contract_violation.exe test/test_tool.exe test/test_tool_middleware.exe test/test_typed_tool.exe
- ./_build/default/test/test_raw_trace.exe
- ./_build/default/test/test_raw_trace_deep.exe
- ./_build/default/test/test_tool.exe
- ./_build/default/test/test_agent_pipeline.exe
- ./_build/default/test/test_completion_contract_violation.exe
- ./_build/default/test/test_tool_middleware.exe
- ./_build/default/test/test_approval.exe
- ./_build/default/test/test_typed_tool.exe