### PR TITLE
docs: remove stale CDAL stability surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,10 @@ For the full 186-file classification, see `docs/api-stability.md`.
 
 **Evolving** -- API may change between minor versions:
 
-`Streaming`, `Structured`, `Orchestrator`, `Runtime`, `Memory`, `Policy`, `Proof_store`, `Cdal_proof`
+`Streaming`, `Structured`, `Orchestrator`, `Runtime`, `Memory`, `Policy`
+
+CDAL proof artifacts are no longer exposed as public OCaml modules from OAS.
+Use the versioned JSON schema catalog for downstream proof-bundle artifacts.
 
 **Internal** -- implementation details with no compatibility promise:
 

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -86,10 +86,13 @@ Representative modules:
 | Runtime | `lib/runtime.mli` | Runtime protocol types are still evolving |
 | Memory | `lib/memory.mli` | Memory system is under active development |
 | Policy | `lib/policy.mli` | Rule engine surface is still settling |
-| Proof_store | `lib/proof_store.mli` | CDAL storage API is newly added |
 
 Collaboration substrate guidance is intentionally docs/schema-only; there is
 no public `Collaboration` module in `agent_sdk`.
+
+CDAL proof-bundle artifacts are intentionally schema-only in OAS. They are
+tracked in `docs/schema-surfaces/runtime-output-surfaces.v1.json`, not as
+public OCaml modules in this stability table.
 
 ### Internal modules
 


### PR DESCRIPTION
## Summary
- remove missing CDAL module names from README Evolving API examples
- remove stale Proof_store entry from docs/api-stability.md
- clarify that CDAL proof-bundle artifacts remain schema-only surfaces in the runtime-output schema catalog

## Validation
- rg -n "Proof_store|Cdal_proof|lib/proof_store|lib/cdal_proof" README.md docs/api-stability.md returned no matches
- git diff --check