### PR TITLE
feat(raw-trace): expose evidence role summaries

### DIFF
--- a/lib/raw_trace.ml
+++ b/lib/raw_trace.ml
@@ -60,6 +60,14 @@ type validation_check =
   }
 [@@deriving yojson, show]
 
+type evidence_role_summary =
+  { evidence_role : evidence_role
+  ; record_count : int
+  ; successful_finished_count : int
+  ; last_success_seq : int option
+  }
+[@@deriving yojson, show]
+
 type run_validation =
   { run_ref : run_ref
   ; ok : bool

--- a/lib/raw_trace.mli
+++ b/lib/raw_trace.mli
@@ -62,6 +62,14 @@ type validation_check =
   }
 [@@deriving yojson, show]
 
+type evidence_role_summary =
+  { evidence_role : evidence_role
+  ; record_count : int
+  ; successful_finished_count : int
+  ; last_success_seq : int option
+  }
+[@@deriving yojson, show]
+
 type run_validation =
   { run_ref : run_ref
   ; ok : bool

--- a/lib/raw_trace_query.ml
+++ b/lib/raw_trace_query.ml
@@ -18,6 +18,56 @@ let successful_finished_evidence role (record : Raw_trace.record) =
   && record_has_evidence_role role record
 ;;
 
+let evidence_role_summaries records =
+  let table : (Raw_trace.evidence_role, Raw_trace.evidence_role_summary) Hashtbl.t =
+    Hashtbl.create 4
+  in
+  List.iter
+    (fun (record : Raw_trace.record) ->
+       match Raw_trace.record_evidence_role record with
+       | None -> ()
+       | Some evidence_role ->
+         let successful =
+           record.record_type = Raw_trace.Tool_execution_finished
+           && record.tool_error = Some false
+         in
+         let current =
+           match Hashtbl.find_opt table evidence_role with
+           | Some summary -> summary
+           | None ->
+             { Raw_trace.evidence_role
+             ; record_count = 0
+             ; successful_finished_count = 0
+             ; last_success_seq = None
+             }
+         in
+         let last_success_seq =
+           if successful
+           then
+             Some
+               (max
+                  (Option.value ~default:record.seq current.last_success_seq)
+                  record.seq)
+           else current.last_success_seq
+         in
+         Hashtbl.replace
+           table
+           evidence_role
+           { current with
+             record_count = current.record_count + 1
+           ; successful_finished_count =
+               (current.successful_finished_count + if successful then 1 else 0)
+           ; last_success_seq
+           })
+    records;
+  Hashtbl.to_seq_values table
+  |> List.of_seq
+  |> List.sort (fun (a : Raw_trace.evidence_role_summary) b ->
+    String.compare
+      (Raw_trace.evidence_role_to_string a.evidence_role)
+      (Raw_trace.evidence_role_to_string b.evidence_role))
+;;
+
 (* ── Run discovery ──────────────────────────────────────────── *)
 
 let run_refs_of_records ~path records : Raw_trace.run_ref list =
@@ -252,6 +302,7 @@ let validate_run run_ref =
   let has_file_write =
     List.exists (record_has_evidence_role Raw_trace.File_write) records
   in
+  let evidence_roles = evidence_role_summaries records in
   let last_file_write_seq =
     records
     |> List.fold_left
@@ -317,6 +368,16 @@ let validate_run run_ref =
     ; Printf.sprintf "stop_reason=%s" (Option.value summary.stop_reason ~default:"")
     ; Printf.sprintf "error=%s" (Option.value summary.error ~default:"")
     ; Printf.sprintf "paired_tool_result_count=%d" paired_tool_result_count
+    ; Printf.sprintf
+        "evidence_roles=%s"
+        (evidence_roles
+         |> List.map (fun (summary : Raw_trace.evidence_role_summary) ->
+           Printf.sprintf
+             "%s:%d:%d"
+             (Raw_trace.evidence_role_to_string summary.evidence_role)
+             summary.record_count
+             summary.successful_finished_count)
+         |> String.concat ",")
     ; Printf.sprintf "has_file_write=%b" has_file_write
     ; Printf.sprintf
         "verification_pass_after_file_write=%b"

--- a/lib/raw_trace_query.mli
+++ b/lib/raw_trace_query.mli
@@ -19,6 +19,13 @@ val read_runs : path:string -> unit -> (Raw_trace.run_ref list, Error.sdk_error)
 (** Read all records for a single run. *)
 val read_run : Raw_trace.run_ref -> (Raw_trace.record list, Error.sdk_error) result
 
+(** Summarize observed evidence roles in records without relying on tool names.
+    This is the typed extension point for future evidence roles: callers can
+    group by [Raw_trace.evidence_role] without changing raw-trace query code. *)
+val evidence_role_summaries
+  :  Raw_trace.record list
+  -> Raw_trace.evidence_role_summary list
+
 (** {1 Summarize} *)
 
 (** Produce a summary of a single run (event counts, tool/hook names,

--- a/test/test_raw_trace.ml
+++ b/test/test_raw_trace.ml
@@ -492,6 +492,19 @@ let test_agent_run_stream_append_only_raw_trace () =
       "verification pass after file_write"
       true
       run1_validation.verification_pass_after_file_write;
+    let role_counts =
+      Raw_trace_query.evidence_role_summaries run1_records
+      |> List.map (fun (summary : Raw_trace.evidence_role_summary) ->
+        Raw_trace.evidence_role_to_string summary.evidence_role, summary.record_count)
+    in
+    Alcotest.(check (option int))
+      "generic file_write role count"
+      (Some 1)
+      (List.assoc_opt "file_write" role_counts);
+    Alcotest.(check (option int))
+      "generic verification role count"
+      (Some 2)
+      (List.assoc_opt "verification" role_counts);
     let evidence_roles =
       run1_records
       |> List.filter_map Raw_trace.record_evidence_role

--- a/test/test_raw_trace_deep.ml
+++ b/test/test_raw_trace_deep.ml
@@ -688,6 +688,20 @@ let test_validate_run_uses_explicit_evidence_roles () =
   | Ok validation ->
     Alcotest.(check bool) "ok" true validation.ok;
     Alcotest.(check bool) "has file write role" true validation.has_file_write;
+    let role_success_counts =
+      Raw_trace_query.evidence_role_summaries records
+      |> List.map (fun (summary : Raw_trace.evidence_role_summary) ->
+        ( Raw_trace.evidence_role_to_string summary.evidence_role
+        , summary.successful_finished_count ))
+    in
+    Alcotest.(check (option int))
+      "generic file write success count"
+      (Some 1)
+      (List.assoc_opt "file_write" role_success_counts);
+    Alcotest.(check (option int))
+      "generic verification success count"
+      (Some 1)
+      (List.assoc_opt "verification" role_success_counts);
     Alcotest.(check bool)
       "verification role after write"
       true


### PR DESCRIPTION
## Summary
- add Raw_trace.evidence_role_summary as the structured summary shape for evidence-role counts
- expose Raw_trace_query.evidence_role_summaries so callers can group observed evidence roles without tool-name hardcoding
- keep Raw_trace.run_validation source-compatible while adding generic evidence_role counts to its evidence strings
- add raw_trace tests for generic file_write / verification role counts

## Validation
- ocamlformat --check lib/raw_trace.mli lib/raw_trace.ml lib/raw_trace_query.mli lib/raw_trace_query.ml test/test_raw_trace.ml test/test_raw_trace_deep.ml test/test_sessions_types_deep.ml
- ocamlc -stop-after parsing -intf lib/raw_trace_query.mli
- ocamlc -stop-after parsing -impl lib/raw_trace_query.ml
- ocamlc -stop-after parsing -impl test/test_raw_trace.ml
- ocamlc -stop-after parsing -impl test/test_raw_trace_deep.ml
- git diff --check
- scripts/dune-local.sh build test/test_raw_trace.exe test/test_raw_trace_deep.exe
- scripts/dune-local.sh exec test/test_raw_trace.exe
- scripts/dune-local.sh exec test/test_raw_trace_deep.exe
- scripts/dune-local.sh exec test/test_sessions_types_deep.exe