### PR TITLE
docs: remove stale OAS CDAL stability surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,7 @@ Anything outside this repository — multi-process coordination, repo-wide task 
 | `Contract` | Runtime contracts: instruction layers, triggers, tool grants |
 | `Memory` | 5-tier memory: Scratchpad, Working, Episodic, Procedural, Long_term |
 | `Memory_access` | Deny-by-default agent-scoped memory permissions |
-| `Verified_output` | Phantom-typed compile-time output verification |
 | `Policy` | Priority-ordered rule evaluation at decision points |
-| `Audit` | Immutable log of policy decisions and agent actions |
 | `Durable` | Typed step chains with execution journal for crash recovery |
 | `Plan` | Goal decomposition with dependency DAG and re-planning |
 
@@ -198,7 +196,7 @@ Anything outside this repository — multi-process coordination, repo-wide task 
 
 Not all modules are equally stable. Use this to gauge risk when depending on a module.
 Every `.mli` now carries an explicit `@stability` tag and `@since` marker.
-For the full 186-file classification, see `docs/api-stability.md`.
+For the current classification policy, see `docs/api-stability.md`.
 
 **Stable** -- safe to depend on, breaking changes only on minor version bumps:
 

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -22,7 +22,7 @@ Each `.mli` file carries a `@stability` annotation in its top-level doc comment.
 ### Evolving
 
 - Modules under active development with external consumers.
-- New features (autonomy, CDAL, harness) that have not yet settled.
+- New features (runtime evidence, structured output, harness) that have not yet settled.
 - Runtime orchestration helpers whose API is still being refined.
 
 ### Internal

--- a/docs/sdk-independence-principle.md
+++ b/docs/sdk-independence-principle.md
@@ -9,10 +9,11 @@ downstream coordinator. The dependency direction is strictly:
 MCP Protocol SDK  <--  OAS (Agent SDK)  <--  External coordinator
 ```
 
-OAS provides generic agent primitives (execution modes, risk contracts, proof
-bundles, intent classification). Coordinators consume these primitives and add
-their own orchestration semantics. OAS is not allowed to name, depend on, or
-adapt to any specific coordinator.
+OAS provides generic single-agent primitives: context, hooks, tool/runtime
+abstractions, provider-neutral runtime events, and intent classification.
+Coordinators consume these primitives and add their own orchestration
+semantics. OAS is not allowed to name, depend on, or adapt to any specific
+coordinator.
 
 ## What this means in practice
 
@@ -49,13 +50,20 @@ coordinator wraps these in is intentionally outside this document.
 | Module | Owner |
 |--------|-------|
 | `Context_intent` | OAS |
-| `Risk_contract`, `Cdal_proof` | OAS |
-| `Execution_mode`, `Risk_class` | OAS |
-| `Mode_enforcer`, `Proof_capture` | OAS |
+| `Contract`, `Completion_contract` | OAS |
+| `Policy`, `Guardrails`, `Guardrail_*` | OAS |
+| `Runtime`, `Runtime_evidence` | OAS |
+| `Raw_trace`, `Sessions` | OAS |
 
 If a coordinator builds its own contract module (for example a CDAL contract
 or a CDAL judge), that module belongs to the coordinator's repository, not
 to OAS, and is not tracked here.
+
+CDAL/proof OCaml modules such as `Risk_contract`, `Cdal_proof`,
+`Execution_mode`, `Risk_class`, `Mode_enforcer`, and `Proof_capture` are not
+OAS-owned surfaces after the 0.193.0 migration. Versioned JSON schemas under
+`docs/schemas/` may remain as cross-repo interoperability contracts, but they
+do not imply an `Agent_sdk` OCaml module.
 
 ## Enforcement
 
@@ -72,3 +80,6 @@ to OAS, and is not tracked here.
   "route", "transfer", "actor".
 - 2026-04-17: Tightened. Owner/consumers table no longer names downstream
   coordinators; OAS docs do not depend on any specific consumer.
+- 2026-05-21: Removed stale CDAL module ownership after the 0.193.0 migration;
+  proof artifacts are schema-level interoperability contracts, not OAS OCaml
+  modules.

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -182,8 +182,6 @@ module Checkpoint_validation = Checkpoint_validation
 module Judge = Judge
 module Vcs_graph_snapshot = Vcs_graph_snapshot
 
-(* CDAL — Contract-Driven Agent Loop PoC-1 *)
-
 (** Quick start: create an agent with default config *)
 let create_agent
       ~net

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -155,8 +155,6 @@ module Checkpoint_validation = Checkpoint_validation
 module Judge = Judge
 module Vcs_graph_snapshot = Vcs_graph_snapshot
 
-(** {1 CDAL -- Contract-Driven Agent Loop PoC-1} *)
-
 (** {1 Quick Start} *)
 
 (** Create an agent with default config.


### PR DESCRIPTION
## Summary
- Remove stale `Verified_output` and `Audit` rows from the README module surface now that those CDAL-era modules are no longer exposed by OAS.
- Replace the outdated SDK-independence ownership table for `Risk_contract`, `Cdal_proof`, `Execution_mode`, `Mode_enforcer`, and related CDAL modules with current OAS-owned single-agent/runtime surfaces.
- Drop empty CDAL section headers from `Agent_sdk` top-level docs and implementation comments.
- Keep proof-bundle guidance as schema-level interoperability, not an `Agent_sdk` OCaml module surface.

## Validation
- `rg -n 'Cdal_proof|Proof_store|Verified_output|\bAudit\b|Mode_enforcer|Risk_contract|Execution_mode|Proof_capture|Conformance|Cognitive_event|Direct_evidence|Autonomy_|Sessions_proof' README.md docs/sdk-independence-principle.md docs/api-stability.md lib/agent_sdk.ml lib/agent_sdk.mli`
  - Remaining matches are only explicit negative statements that those CDAL/proof modules are not OAS-owned surfaces.
- `ocamlformat --check lib/agent_sdk.ml lib/agent_sdk.mli`
- `ocamlc -stop-after parsing lib/agent_sdk.ml`
- `ocamlc -stop-after parsing lib/agent_sdk.mli`
- `git diff --check`
- `scripts/lint-core-cdal-boundary.sh`
- `scripts/dune-local.sh build lib/agent_sdk.cmxa` was attempted but stopped after prolonged machine-wide Dune lock contention; no focused Dune result was produced.