### PR TITLE
feat(timeout): add provider timeout policy phases

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -1522,7 +1522,9 @@ let complete_stream_http
                   Ok ()
                 with
                 | Eio.Time.Timeout ->
-                  let phase = Http_client.Stream_idle !stream_idle_state in
+                  let phase =
+                    Http_client.timeout_phase_of_stream_idle_state !stream_idle_state
+                  in
                   emit_telemetry
                     (Telemetry_event.Timeout
                        { provider

--- a/lib/llm_provider/complete_cascade.ml
+++ b/lib/llm_provider/complete_cascade.ml
@@ -52,6 +52,34 @@ let attempt_timeout_error ~attempt_index ~model_id ~provider_key ~timeout_s =
     }
 ;;
 
+let admission_timeout_error
+      ~phase
+      ~attempt_index
+      ~model_id
+      ~provider_key
+      ~timeout_s
+      ~(snapshot : Slot_scheduler.snapshot)
+  =
+  let phase_label = Http_client.timeout_phase_to_label phase in
+  Http_client.TimeoutError
+    { phase
+    ; message =
+        Printf.sprintf
+          "cascade provider admission timed out phase=%s attempt_index=%d model=%s \
+           provider_key=%s admission_timeout_s=%gs throttle_active=%d \
+           throttle_available=%d throttle_queue_length=%d throttle_max=%d"
+          phase_label
+          attempt_index
+          model_id
+          provider_key
+          timeout_s
+          snapshot.active
+          snapshot.available
+          snapshot.queue_length
+          snapshot.max_slots
+    }
+;;
+
 (* --- Per-provider health tracking (Eio.Mutex-guarded) --- *)
 
 type provider_entry =
@@ -535,6 +563,8 @@ let network_error_stops_cascade = function
 
 let provider_failure_counts_for_health = function
   | Http_client.NetworkError { kind = Http_client.Local_resource_exhaustion; _ } -> false
+  | Http_client.TimeoutError
+      { phase = Http_client.Queue | Http_client.Capacity_backpressure; _ } -> false
   | Http_client.TimeoutError _ -> true
   | _ -> true
 ;;
@@ -550,6 +580,7 @@ let complete_cascade
       ?metrics
       ?retry_config
       ?attempt_timeout_s
+      ?admission_queue_timeout_s
       ?(cascade_config = default_cascade_config)
       ?(health = create_health ~clock ())
       ?(priority = Request_priority.default)
@@ -592,7 +623,7 @@ let complete_cascade
           ~cascade_config
           ~health
           ~provider_key:key;
-        let attempt () =
+        let provider_attempt () =
           Complete.complete_with_retry
             ~sw
             ~net
@@ -607,18 +638,7 @@ let complete_cascade
             ?tools
             ()
         in
-        let throttled_attempt () =
-          match throttle_resolver config with
-          | None -> attempt ()
-          | Some throttle ->
-            Provider_throttle.with_permit_priority ~priority throttle attempt
-        in
-        let result =
-          (* Sentinel: [Some t] with [t <= 0.0] disables the cascade-level
-             timeout for this call, even when the provider default would
-             otherwise apply. Required so callers can opt out for
-             long-running local models without losing the per-kind default
-             for everyone else. *)
+        let run_provider_step () =
           let timeout_s =
             match attempt_timeout_s with
             | Some t when t <= 0.0 -> None
@@ -626,9 +646,9 @@ let complete_cascade
             | None -> Provider_config.default_attempt_timeout_s config.kind
           in
           match timeout_s with
-          | None -> throttled_attempt ()
+          | None -> provider_attempt ()
           | Some timeout_s ->
-            (try Eio.Time.with_timeout_exn clock timeout_s throttled_attempt with
+            (try Eio.Time.with_timeout_exn clock timeout_s provider_attempt with
              | Eio.Time.Timeout ->
                Error
                  (attempt_timeout_error
@@ -636,6 +656,75 @@ let complete_cascade
                     ~model_id:config.model_id
                     ~provider_key:key
                     ~timeout_s))
+        in
+        let run_with_admitted_permit throttle =
+          match admission_queue_timeout_s with
+          | None ->
+            let throttled_attempt () =
+              Provider_throttle.with_permit_priority ~priority throttle provider_attempt
+            in
+            (* Legacy mode: provider-step timeout still wraps throttle queueing. *)
+            let timeout_s =
+              match attempt_timeout_s with
+              | Some t when t <= 0.0 -> None
+              | Some t -> Some t
+              | None -> Provider_config.default_attempt_timeout_s config.kind
+            in
+            (match timeout_s with
+             | None -> throttled_attempt ()
+             | Some timeout_s ->
+               (try Eio.Time.with_timeout_exn clock timeout_s throttled_attempt with
+                | Eio.Time.Timeout ->
+                  Error
+                    (attempt_timeout_error
+                       ~attempt_index:idx
+                       ~model_id:config.model_id
+                       ~provider_key:key
+                       ~timeout_s)))
+          | Some timeout_s when timeout_s <= 0.0 ->
+            (match
+               Provider_throttle.try_permit ~priority throttle (fun () ->
+                 Fd_throttle_hook.with_slot run_provider_step)
+             with
+             | Some result -> result
+             | None ->
+               Error
+                 (admission_timeout_error
+                    ~phase:Http_client.Capacity_backpressure
+                    ~attempt_index:idx
+                    ~model_id:config.model_id
+                    ~provider_key:key
+                    ~timeout_s
+                    ~snapshot:(Provider_throttle.snapshot throttle)))
+          | Some timeout_s ->
+            let permit =
+              try
+                Ok
+                  (Eio.Time.with_timeout_exn clock timeout_s (fun () ->
+                     Provider_throttle.acquire_permit ~priority throttle))
+              with
+              | Eio.Time.Timeout ->
+                Error
+                  (admission_timeout_error
+                     ~phase:Http_client.Queue
+                     ~attempt_index:idx
+                     ~model_id:config.model_id
+                     ~provider_key:key
+                     ~timeout_s
+                     ~snapshot:(Provider_throttle.snapshot throttle))
+            in
+            (match permit with
+             | Error err -> Error err
+             | Ok permit ->
+               Eio.Switch.run (fun permit_sw ->
+                 Eio.Switch.on_release permit_sw (fun () ->
+                   Provider_throttle.release_permit throttle permit);
+                 Fd_throttle_hook.with_slot run_provider_step))
+        in
+        let result =
+          match throttle_resolver config with
+          | None -> run_provider_step ()
+          | Some throttle -> run_with_admitted_permit throttle
         in
         match result with
         | Ok response ->

--- a/lib/llm_provider/complete_cascade.mli
+++ b/lib/llm_provider/complete_cascade.mli
@@ -188,8 +188,9 @@ type cascade_result =
        without falling through or poisoning provider health
     6. On other error, record failure and try next step
 
-    [?attempt_timeout_s] caps one provider step, including its internal
-    retry loop. Timeout errors include the cascade phase, provider
+    [?attempt_timeout_s] caps one admitted provider step, including its internal
+    retry loop but not an explicitly separated admission queue wait. Timeout
+    errors include the cascade phase, provider
     attempt index, model id, and provider key in
     [TimeoutError { phase = Provider_step; _ }] so downstream receipts
     can distinguish a provider-step timeout from a caller-side budget gate:
@@ -202,6 +203,17 @@ type cascade_result =
     - [Some t] with [t <= 0.0]: disable the cascade-level timeout for
       this call. Use this to opt out for long-running local models
       when the caller supplied a tighter attempt budget.
+
+    [?admission_queue_timeout_s] separates provider-throttle admission from the
+    provider body/attempt budget:
+    - omitted (no argument): preserve legacy throttle behavior and queue inside
+      the provider step.
+    - [Some t] with [t > 0.0]: wait up to [t] seconds for the provider throttle
+      permit before starting the provider attempt; timeout surfaces as
+      [TimeoutError { phase = Queue; _ }].
+    - [Some t] with [t <= 0.0]: perform a non-blocking admission check; if no
+      permit is immediately available, surface
+      [TimeoutError { phase = Capacity_backpressure; _ }].
 
     When [health] is [None], a fresh tracker is created per call.
     Pass a shared tracker to maintain circuit state across calls.
@@ -221,6 +233,7 @@ val complete_cascade
   -> ?metrics:Metrics.t
   -> ?retry_config:Complete.retry_config
   -> ?attempt_timeout_s:float
+  -> ?admission_queue_timeout_s:float
   -> ?cascade_config:cascade_config
   -> ?health:provider_health
   -> ?priority:Request_priority.t

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -34,6 +34,11 @@ type stream_idle_state =
 [@@deriving yojson, show]
 
 type timeout_phase =
+  | Admission
+  | Queue
+  | First_token
+  | Wall_clock
+  | Capacity_backpressure
   | Http_operation
   | Non_streaming_body
   | Stream_body
@@ -161,7 +166,17 @@ let stream_idle_state_to_label = function
   | Streaming_unknown -> "streaming_unknown"
 ;;
 
+let timeout_phase_of_stream_idle_state = function
+  | Awaiting_first_event | Awaiting_first_delta -> First_token
+  | state -> Stream_idle state
+;;
+
 let timeout_phase_to_label = function
+  | Admission -> "admission"
+  | Queue -> "queue"
+  | First_token -> "first_token"
+  | Wall_clock -> "wall_clock"
+  | Capacity_backpressure -> "capacity_backpressure"
   | Http_operation -> "http_operation"
   | Non_streaming_body -> "non_streaming_body"
   | Stream_body -> "stream_body"

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -45,9 +45,25 @@ type stream_idle_state =
     [NetworkError { kind = Timeout; _ }] still exists for low-level OS or
     legacy timeouts.  New call-site-owned deadlines should surface as
     {!TimeoutError} with one of these phases so downstream policy can
-    distinguish streaming idleness, thinking idleness, total body budget,
-    cascade attempt budget, CLI stdout idleness, and generic caller budgets. *)
+    distinguish admission checks, scheduler queueing, first-token wait,
+    streaming idleness, whole-call wall clocks, capacity backpressure,
+    transport/body deadlines, cascade attempt budgets, CLI stdout idleness,
+    and generic caller budgets. *)
 type timeout_phase =
+  | Admission
+  (** Pre-flight provider/capability/admission checks before a request is
+      allowed to spend body budget. *)
+  | Queue
+  (** Waiting for an internal scheduler, slot, or provider queue before the
+      request starts producing provider output. *)
+  | First_token
+  (** Request was accepted and submitted, but no first user-visible token or
+      delta arrived before the deadline. *)
+  | Wall_clock
+  (** Whole operation wall-clock deadline, independent of streaming progress. *)
+  | Capacity_backpressure
+  (** Provider or local capacity pressure rejected or delayed the request
+      before normal request execution. *)
   | Http_operation
   | Non_streaming_body
   | Stream_body
@@ -159,6 +175,7 @@ type http_error =
 val provider_failure_kind_to_string : provider_failure_kind -> string
 val provider_failure_to_string : kind:provider_failure_kind -> message:string -> string
 val stream_idle_state_to_label : stream_idle_state -> string
+val timeout_phase_of_stream_idle_state : stream_idle_state -> timeout_phase
 val timeout_phase_to_label : timeout_phase -> string
 
 (** Default wall-clock timeout (seconds) applied to synchronous HTTP

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -1062,6 +1062,74 @@ let test_provider_throttle_serializes_concurrent_steps () =
     (Atomic.get max_active_calls)
 ;;
 
+let test_admission_queue_timeout_fails_before_provider_attempt () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let config =
+    Provider_config.make
+      ~kind:Ollama
+      ~model_id:"queued"
+      ~base_url:"http://localhost:11434"
+      ()
+  in
+  let throttle = Provider_throttle.create ~max_concurrent:1 ~provider_name:"local" in
+  let holder_ready, resolve_holder_ready = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    Provider_throttle.with_permit_priority
+      ~priority:Request_priority.Background
+      throttle
+      (fun () ->
+         Eio.Promise.resolve resolve_holder_ready ();
+         Eio.Time.sleep clock 0.1));
+  Eio.Promise.await holder_ready;
+  let health = Complete_cascade.create_health ~clock () in
+  let calls = Atomic.make 0 in
+  let transport : Llm_transport.t =
+    { complete_sync =
+        (fun _ ->
+          Atomic.incr calls;
+          { Llm_transport.response = Ok dummy_response; latency_ms = Some 0 })
+    ; complete_stream =
+        (fun ?on_telemetry:_ ~on_event:_ _ ->
+          Atomic.incr calls;
+          Ok dummy_response)
+    }
+  in
+  let result =
+    Complete_cascade.complete_cascade
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~clock
+      ~transport
+      ~health
+      ~attempt_timeout_s:1.0
+      ~admission_queue_timeout_s:0.01
+      ~throttle_resolver:(fun _ -> Some throttle)
+      ~steps:[ config ]
+      ~messages:[]
+      ()
+  in
+  check int "transport not called before admission" 0 (Atomic.get calls);
+  let info =
+    Complete_cascade.provider_health_info
+      health
+      ~cascade_config:Complete_cascade.default_cascade_config
+      ~provider_key:(Complete_cascade.provider_key config)
+  in
+  check int "admission queue does not poison health" 0 info.consecutive_failures;
+  match result with
+  | Complete_cascade.All_failed
+      { errors = [ (_, Http_client.TimeoutError { phase; message }) ]; skipped = [] } ->
+    check string "phase" "queue" (Http_client.timeout_phase_to_label phase);
+    check bool "phase recorded" true (contains message "phase=queue");
+    check bool "attempt index recorded" true (contains message "attempt_index=0");
+    check bool "queue length recorded" true (contains message "throttle_queue_length=")
+  | _ -> fail "expected admission queue timeout before provider attempt"
+;;
+
 let test_attempt_timeout_fast_paths_without_retrying_same_step () =
   Eio_main.run
   @@ fun env ->
@@ -1316,6 +1384,9 @@ let suite =
   ; ( "provider_throttle_serializes_concurrent_steps"
     , `Quick
     , test_provider_throttle_serializes_concurrent_steps )
+  ; ( "admission_queue_timeout_before_provider_attempt"
+    , `Quick
+    , test_admission_queue_timeout_fails_before_provider_attempt )
   ; ( "attempt_timeout_fast_path"
     , `Quick
     , test_attempt_timeout_fast_paths_without_retrying_same_step )

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -131,6 +131,44 @@ let test_post_stream_invalid_url_returns_network_error () =
   | Ok _ -> Alcotest.fail "expected invalid URL to fail before opening a stream"
 ;;
 
+let test_timeout_phase_policy_labels () =
+  let cases =
+    [ Http_client.Admission, "admission"
+    ; Http_client.Queue, "queue"
+    ; Http_client.First_token, "first_token"
+    ; ( Http_client.Stream_idle Http_client.Streaming_thinking
+      , "stream_idle:streaming_thinking" )
+    ; Http_client.Wall_clock, "wall_clock"
+    ; Http_client.Capacity_backpressure, "capacity_backpressure"
+    ]
+  in
+  List.iter
+    (fun (phase, expected) ->
+       Alcotest.(check string)
+         expected
+         expected
+         (Http_client.timeout_phase_to_label phase))
+    cases
+;;
+
+let test_timeout_phase_of_stream_idle_state () =
+  let cases =
+    [ Http_client.Awaiting_first_event, "first_token"
+    ; Http_client.Awaiting_first_delta, "first_token"
+    ; Http_client.Streaming_thinking, "stream_idle:streaming_thinking"
+    ; Http_client.Streaming_answer, "stream_idle:streaming_answer"
+    ]
+  in
+  List.iter
+    (fun (state, expected) ->
+       let phase = Http_client.timeout_phase_of_stream_idle_state state in
+       Alcotest.(check string)
+         expected
+         expected
+         (Http_client.timeout_phase_to_label phase))
+    cases
+;;
+
 let test_api_common_string_is_blank () =
   Alcotest.(check bool) "empty is blank" true (Api_common.string_is_blank "");
   Alcotest.(check bool) "spaces is blank" true (Api_common.string_is_blank "   ");
@@ -283,6 +321,13 @@ let () =
             "invalid url returns network error"
             `Quick
             test_post_stream_invalid_url_returns_network_error
+        ] )
+    ; ( "timeout_phase"
+      , [ Alcotest.test_case "policy labels" `Quick test_timeout_phase_policy_labels
+        ; Alcotest.test_case
+            "stream idle pre-token maps to first_token"
+            `Quick
+            test_timeout_phase_of_stream_idle_state
         ] )
     ; ( "api_common"
       , [ Alcotest.test_case "string_is_blank" `Quick test_api_common_string_is_blank


### PR DESCRIPTION
## Summary
- add explicit provider timeout policy phases for admission, queue, first_token, wall_clock, and capacity_backpressure
- keep existing timeout_phase constructors for compatibility
- map pre-token stream-idle states to the first_token phase while preserving stream-idle states after output begins
- add optional complete_cascade admission_queue_timeout_s so provider throttle queueing is separated from admitted provider attempt/body budget
- avoid poisoning provider health for local queue/capacity-backpressure admission timeouts
- cover report-required policy labels, stream-idle phase mapping, and queue-admission timeout before transport invocation

## Validation
- ocamlformat --check lib/llm_provider/http_client.ml lib/llm_provider/http_client.mli lib/llm_provider/complete.ml lib/llm_provider/complete_cascade.ml lib/llm_provider/complete_cascade.mli test/test_http_client.ml test/test_complete_cascade.ml
- ocamlc -stop-after parsing lib/llm_provider/http_client.mli
- ocamlc -stop-after parsing lib/llm_provider/http_client.ml
- ocamlc -stop-after parsing lib/llm_provider/complete.ml
- ocamlc -stop-after parsing lib/llm_provider/complete_cascade.mli
- ocamlc -stop-after parsing lib/llm_provider/complete_cascade.ml
- ocamlc -stop-after parsing test/test_http_client.ml
- ocamlc -stop-after parsing test/test_complete_cascade.ml
- git diff --check
- attempted earlier: scripts/dune-local.sh build test/test_http_client.exe, but local /tmp/me-dune-local.lock stayed held by another lockf process; lock remained held before the complete_cascade follow-up