### PR TITLE
feat(raw-trace): expose validation evidence roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ original tag dates. `0.100.4` was never tagged or released.
 
 ## Unreleased
 
+### Features
+
+* **raw-trace:** include typed evidence role summaries in validation results
+
 ## [0.196.7](https://github.com/jeong-sik/oas/compare/v0.196.6...v0.196.7) (2026-05-21)
 
 

--- a/lib/raw_trace.ml
+++ b/lib/raw_trace.ml
@@ -74,6 +74,7 @@ type run_validation =
   ; checks : validation_check list
   ; evidence : string list
   ; paired_tool_result_count : int
+  ; evidence_roles : evidence_role_summary list [@default []]
   ; has_file_write : bool
   ; verification_pass_after_file_write : bool
   ; final_text : string option

--- a/lib/raw_trace.mli
+++ b/lib/raw_trace.mli
@@ -76,6 +76,7 @@ type run_validation =
   ; checks : validation_check list
   ; evidence : string list
   ; paired_tool_result_count : int
+  ; evidence_roles : evidence_role_summary list [@default []]
   ; has_file_write : bool
   ; verification_pass_after_file_write : bool
   ; final_text : string option

--- a/lib/raw_trace_query.ml
+++ b/lib/raw_trace_query.ml
@@ -390,6 +390,7 @@ let validate_run run_ref =
     ; checks
     ; evidence
     ; paired_tool_result_count
+    ; evidence_roles
     ; has_file_write
     ; verification_pass_after_file_write
     ; final_text = summary.final_text

--- a/lib/raw_trace_query.mli
+++ b/lib/raw_trace_query.mli
@@ -36,5 +36,6 @@ val summarize_run : Raw_trace.run_ref -> (Raw_trace.run_summary, Error.sdk_error
 
 (** Run structural validation checks on a single run.
     Checks sequence monotonicity, run start/finish presence,
-    tool execution pairing, and optional verification pass. *)
+    tool execution pairing, typed evidence-role summaries, and optional
+    verification pass. *)
 val validate_run : Raw_trace.run_ref -> (Raw_trace.run_validation, Error.sdk_error) result

--- a/test/test_raw_trace.ml
+++ b/test/test_raw_trace.ml
@@ -863,6 +863,13 @@ let test_run_validation_yojson () =
     ; checks = [ { name = "tool_pairs"; passed = true } ]
     ; evidence = [ "evidence1" ]
     ; paired_tool_result_count = 2
+    ; evidence_roles =
+        [ { evidence_role = Raw_trace.File_write
+          ; record_count = 2
+          ; successful_finished_count = 1
+          ; last_success_seq = Some 2
+          }
+        ]
     ; has_file_write = false
     ; verification_pass_after_file_write = false
     ; final_text = Some "ok"
@@ -872,13 +879,27 @@ let test_run_validation_yojson () =
     }
   in
   let json = Raw_trace.run_validation_to_yojson validation in
-  match Raw_trace.run_validation_of_yojson json with
+  (match Raw_trace.run_validation_of_yojson json with
+   | Ok decoded ->
+     Alcotest.(check string)
+       "roundtrip"
+       (Raw_trace.show_run_validation validation)
+       (Raw_trace.show_run_validation decoded)
+   | Error msg -> Alcotest.fail ("run_validation_of_yojson: " ^ msg));
+  let legacy_json =
+    match json with
+    | `Assoc fields ->
+      `Assoc
+        (List.filter (fun (name, _) -> not (String.equal name "evidence_roles")) fields)
+    | other -> other
+  in
+  match Raw_trace.run_validation_of_yojson legacy_json with
   | Ok decoded ->
-    Alcotest.(check string)
-      "roundtrip"
-      (Raw_trace.show_run_validation validation)
-      (Raw_trace.show_run_validation decoded)
-  | Error msg -> Alcotest.fail ("run_validation_of_yojson: " ^ msg)
+    Alcotest.(check int)
+      "legacy evidence roles default"
+      0
+      (List.length decoded.evidence_roles)
+  | Error msg -> Alcotest.fail ("legacy run_validation_of_yojson: " ^ msg)
 ;;
 
 let test_tool_result_assistant_block_summary () =

--- a/test/test_raw_trace_deep.ml
+++ b/test/test_raw_trace_deep.ml
@@ -689,7 +689,7 @@ let test_validate_run_uses_explicit_evidence_roles () =
     Alcotest.(check bool) "ok" true validation.ok;
     Alcotest.(check bool) "has file write role" true validation.has_file_write;
     let role_success_counts =
-      Raw_trace_query.evidence_role_summaries records
+      validation.evidence_roles
       |> List.map (fun (summary : Raw_trace.evidence_role_summary) ->
         ( Raw_trace.evidence_role_to_string summary.evidence_role
         , summary.successful_finished_count ))

--- a/test/test_sessions_types_deep.ml
+++ b/test/test_sessions_types_deep.ml
@@ -187,6 +187,13 @@ let mk_run_validation ?(ok = true) ?(failure_reason = None) () : Raw_trace.run_v
       ]
   ; evidence = [ "record_count=25"; "tool_exec_started=5" ]
   ; paired_tool_result_count = 5
+  ; evidence_roles =
+      [ { evidence_role = Raw_trace.File_write
+        ; record_count = 2
+        ; successful_finished_count = 1
+        ; last_success_seq = Some 14
+        }
+      ]
   ; has_file_write = true
   ; verification_pass_after_file_write = true
   ; final_text = Some "All done."
@@ -223,6 +230,7 @@ let test_raw_trace_validation_empty_checks () =
     ; checks = []
     ; evidence = []
     ; paired_tool_result_count = 0
+    ; evidence_roles = []
     ; has_file_write = false
     ; verification_pass_after_file_write = false
     ; final_text = None


### PR DESCRIPTION
## Summary
- add typed evidence_role summaries directly to Raw_trace.run_validation
- keep legacy has_file_write / verification_pass_after_file_write fields for compatibility
- default missing evidence_roles to [] for older validation JSON payloads

## Validation
- env MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_raw_trace.exe test/test_raw_trace_deep.exe test/test_sessions_types_deep.exe
- _build/default/test/test_raw_trace.exe (sandbox bind EPERM once; rerun with local TCP bind allowed passed)
- _build/default/test/test_raw_trace_deep.exe
- _build/default/test/test_sessions_types_deep.exe
- ocamlformat --check lib/raw_trace.ml lib/raw_trace.mli lib/raw_trace_query.ml lib/raw_trace_query.mli test/test_raw_trace.ml test/test_raw_trace_deep.ml test/test_sessions_types_deep.ml
- git diff --check