### PR TITLE
test(cascade): cover capacity admission fast-fail

### DIFF
--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -1130,6 +1130,78 @@ let test_admission_queue_timeout_fails_before_provider_attempt () =
   | _ -> fail "expected admission queue timeout before provider attempt"
 ;;
 
+let test_admission_capacity_backpressure_fails_before_provider_attempt () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let config =
+    Provider_config.make
+      ~kind:Ollama
+      ~model_id:"saturated"
+      ~base_url:"http://localhost:11434"
+      ()
+  in
+  let throttle = Provider_throttle.create ~max_concurrent:1 ~provider_name:"local" in
+  let holder_ready, resolve_holder_ready = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    Provider_throttle.with_permit_priority
+      ~priority:Request_priority.Background
+      throttle
+      (fun () ->
+         Eio.Promise.resolve resolve_holder_ready ();
+         Eio.Time.sleep clock 0.1));
+  Eio.Promise.await holder_ready;
+  let health = Complete_cascade.create_health ~clock () in
+  let calls = Atomic.make 0 in
+  let transport : Llm_transport.t =
+    { complete_sync =
+        (fun _ ->
+          Atomic.incr calls;
+          { Llm_transport.response = Ok dummy_response; latency_ms = Some 0 })
+    ; complete_stream =
+        (fun ?on_telemetry:_ ~on_event:_ _ ->
+          Atomic.incr calls;
+          Ok dummy_response)
+    }
+  in
+  let result =
+    Complete_cascade.complete_cascade
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~clock
+      ~transport
+      ~health
+      ~attempt_timeout_s:1.0
+      ~admission_queue_timeout_s:0.0
+      ~throttle_resolver:(fun _ -> Some throttle)
+      ~steps:[ config ]
+      ~messages:[]
+      ()
+  in
+  check int "transport not called before capacity admission" 0 (Atomic.get calls);
+  let info =
+    Complete_cascade.provider_health_info
+      health
+      ~cascade_config:Complete_cascade.default_cascade_config
+      ~provider_key:(Complete_cascade.provider_key config)
+  in
+  check int "capacity backpressure does not poison health" 0 info.consecutive_failures;
+  match result with
+  | Complete_cascade.All_failed
+      { errors = [ (_, Http_client.TimeoutError { phase; message }) ]; skipped = [] } ->
+    check
+      string
+      "phase"
+      "capacity_backpressure"
+      (Http_client.timeout_phase_to_label phase);
+    check bool "phase recorded" true (contains message "phase=capacity_backpressure");
+    check bool "attempt index recorded" true (contains message "attempt_index=0");
+    check bool "active slot recorded" true (contains message "throttle_active=1")
+  | _ -> fail "expected capacity backpressure before provider attempt"
+;;
+
 let test_attempt_timeout_fast_paths_without_retrying_same_step () =
   Eio_main.run
   @@ fun env ->
@@ -1387,6 +1459,9 @@ let suite =
   ; ( "admission_queue_timeout_before_provider_attempt"
     , `Quick
     , test_admission_queue_timeout_fails_before_provider_attempt )
+  ; ( "admission_capacity_backpressure_before_provider_attempt"
+    , `Quick
+    , test_admission_capacity_backpressure_fails_before_provider_attempt )
   ; ( "attempt_timeout_fast_path"
     , `Quick
     , test_attempt_timeout_fast_paths_without_retrying_same_step )


### PR DESCRIPTION
## Summary
- Add coverage for `admission_queue_timeout_s <= 0.0` capacity admission fast-fail.
- Assert saturated provider throttle returns `TimeoutError { phase = Capacity_backpressure }` before transport/body execution.
- Assert the admission fast-fail does not poison provider health.

## Report item
- `Provider admission phase` from `masc-oas-uncovered-after-cycle-2026-05-20.html`. OAS main already had queue/capacity implementation from the timeout phase work; this PR closes the missing non-blocking capacity admission proof.

## Validation
- `ocamlformat --check test/test_complete_cascade.ml`
- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build test/test_complete_cascade.exe`
- `./_build/default/test/test_complete_cascade.exe`