### PR TITLE
feat(error): carry completion contract violation detail

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -53,6 +53,10 @@ module Retry = Llm_provider.Retry
 module Error = Agent_sdk_base.Error
 module Error_domain = Error_domain
 module Completion_contract_id = Agent_sdk_base.Completion_contract_id
+
+module Completion_contract_violation_detail =
+  Agent_sdk_base.Completion_contract_violation_detail
+
 module Completion_contract = Completion_contract
 module Hooks = Agent_sdk_base.Hooks
 module Tracing = Tracing

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -26,6 +26,10 @@ module Retry = Llm_provider.Retry
 module Error = Agent_sdk_base.Error
 module Error_domain = Error_domain
 module Completion_contract_id = Agent_sdk_base.Completion_contract_id
+
+module Completion_contract_violation_detail =
+  Agent_sdk_base.Completion_contract_violation_detail
+
 module Completion_contract = Completion_contract
 module Hooks = Agent_sdk_base.Hooks
 module Tracing = Tracing

--- a/lib/base/completion_contract_violation_detail.ml
+++ b/lib/base/completion_contract_violation_detail.ml
@@ -1,0 +1,5 @@
+type t =
+  { called_tools : string list
+  ; satisfying_tools : string list
+  ; rejection_reasons : (string * string) list
+  }

--- a/lib/base/completion_contract_violation_detail.mli
+++ b/lib/base/completion_contract_violation_detail.mli
@@ -1,0 +1,5 @@
+type t =
+  { called_tools : string list
+  ; satisfying_tools : string list
+  ; rejection_reasons : (string * string) list
+  }

--- a/lib/base/error.ml
+++ b/lib/base/error.ml
@@ -46,6 +46,7 @@ type agent_error =
   | CompletionContractViolation of
       { contract : Completion_contract_id.t
       ; reason : string
+      ; violation_detail : Completion_contract_violation_detail.t option
       }
   | GuardrailViolation of
       { validator : string

--- a/lib/base/error.mli
+++ b/lib/base/error.mli
@@ -48,6 +48,7 @@ type agent_error =
   | CompletionContractViolation of
       { contract : Completion_contract_id.t
       ; reason : string
+      ; violation_detail : Completion_contract_violation_detail.t option
       }
   | GuardrailViolation of
       { validator : string

--- a/lib/completion_contract.ml
+++ b/lib/completion_contract.ml
@@ -24,7 +24,7 @@ type tool_call =
 
 type required_tool_satisfaction = tool_call -> (unit, string) result
 
-type violation_detail =
+type violation_detail = Completion_contract_violation_detail.t =
   { called_tools : string list
   ; satisfying_tools : string list
   ; rejection_reasons : (string * string) list (** [(tool_name, reason)] *)
@@ -333,6 +333,38 @@ let violation_detail_of_response
     (match tool_use_names response with
      | [] -> Ok ()
      | tool_names -> make_detail tool_names)
+;;
+
+let validate_response_with_detail
+      ?(tools = [])
+      ?(required_tool_satisfaction = any_tool_call_satisfies)
+      ?(satisfying_tools = [])
+      ~(contract : t)
+      (response : api_response)
+  =
+  match
+    validate_response
+      ~tools
+      ~required_tool_satisfaction
+      ~satisfying_tools
+      ~contract
+      response
+  with
+  | Ok () -> Ok ()
+  | Error reason ->
+    let violation_detail =
+      match
+        violation_detail_of_response
+          ~tools
+          ~required_tool_satisfaction
+          ~satisfying_tools
+          ~contract
+          response
+      with
+      | Ok () -> None
+      | Error detail -> Some detail
+    in
+    Error (reason, violation_detail)
 ;;
 
 let accept_on_exhaustion ~(contract : t) =

--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -26,7 +26,8 @@ type agent_error =
   | `Cost_budget_unenforceable of string * float
   | `Idle_detected of int
   | `Tool_retry_exhausted of int * int * string
-  | `Completion_contract_violation of Completion_contract_id.t * string
+  | `Completion_contract_violation of
+      Completion_contract_id.t * string * Completion_contract_violation_detail.t option
   | `Guardrail_violation of string * string
   | `Tripwire_violation of string * string
   | `Unrecognized_stop_reason of string
@@ -114,7 +115,7 @@ let of_sdk_error (err : Error.sdk_error) : sdk_error_poly =
   | Error.Agent (ToolRetryExhausted r) ->
     `Tool_retry_exhausted (r.attempts, r.limit, r.detail)
   | Error.Agent (CompletionContractViolation r) ->
-    `Completion_contract_violation (r.contract, r.reason)
+    `Completion_contract_violation (r.contract, r.reason, r.violation_detail)
   | Error.Agent (GuardrailViolation r) -> `Guardrail_violation (r.validator, r.reason)
   | Error.Agent (TripwireViolation r) -> `Tripwire_violation (r.tripwire, r.reason)
   | Error.Agent (UnrecognizedStopReason r) -> `Unrecognized_stop_reason r.reason
@@ -168,8 +169,8 @@ let to_sdk_error (err : sdk_error_poly) : Error.sdk_error =
   | `Idle_detected n -> Error.Agent (IdleDetected { consecutive_idle_turns = n })
   | `Tool_retry_exhausted (attempts, limit, detail) ->
     Error.Agent (ToolRetryExhausted { attempts; limit; detail })
-  | `Completion_contract_violation (contract, reason) ->
-    Error.Agent (CompletionContractViolation { contract; reason })
+  | `Completion_contract_violation (contract, reason, violation_detail) ->
+    Error.Agent (CompletionContractViolation { contract; reason; violation_detail })
   | `Guardrail_violation (validator, reason) ->
     Error.Agent (GuardrailViolation { validator; reason })
   | `Tripwire_violation (tripwire, reason) ->

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -51,8 +51,9 @@ type agent_error =
         with no pricing entry, so the cap cannot be enforced. *)
   | `Idle_detected of int (** consecutive_idle_turns *)
   | `Tool_retry_exhausted of int * int * string (** attempts, limit, detail *)
-  | `Completion_contract_violation of Completion_contract_id.t * string
-    (** contract, reason *)
+  | `Completion_contract_violation of
+      Completion_contract_id.t * string * Completion_contract_violation_detail.t option
+    (** contract, reason, violation detail *)
   | `Guardrail_violation of string * string (** validator, reason *)
   | `Tripwire_violation of string * string (** tripwire, reason *)
   | `Unrecognized_stop_reason of string

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -99,14 +99,16 @@ let validate_completion_contract agent (response : Types.api_response) =
     else resolved.effective
   in
   match
-    Completion_contract.validate_response
+    Completion_contract.validate_response_with_detail
       ~tools:(Tool_set.to_list agent.tools)
       ~required_tool_satisfaction:agent.options.required_tool_satisfaction
       ~contract
       response
   with
   | Ok () -> Ok ()
-  | Error reason -> Error (Error.Agent (CompletionContractViolation { contract; reason }))
+  | Error (reason, violation_detail) ->
+    Error
+      (Error.Agent (CompletionContractViolation { contract; reason; violation_detail }))
 ;;
 
 let persist_turn_checkpoint_for_state agent stage state =
@@ -209,6 +211,7 @@ let validate_requested_tool_choice_visibility agent (prep : Agent_turn.turn_prep
             { contract = resolved.effective
             ; reason =
                 "tool_choice requires tool use, but no tools are visible in this turn"
+            ; violation_detail = None
             }))
   | Completion_contract.Require_specific_tool name
     when not (tool_name_visible visible_tool_names name) ->
@@ -222,6 +225,7 @@ let validate_requested_tool_choice_visibility agent (prep : Agent_turn.turn_prep
                    advertised tool set: [%s]"
                   name
                   (preview_tool_names visible_tool_names)
+            ; violation_detail = None
             }))
   | Completion_contract.Allow_text_or_tool
   | Completion_contract.Require_no_tool_use
@@ -502,6 +506,18 @@ let handle_missing_required_tool_use
                         reason
                         attempts
                         limit
+                  ; violation_detail =
+                      (match
+                         Completion_contract.violation_detail_of_response
+                           ~tools:(Tool_set.to_list agent.tools)
+                           ~required_tool_satisfaction:
+                             agent.options.required_tool_satisfaction
+                           ~satisfying_tools:valid_tool_names
+                           ~contract:retry_contract
+                           response
+                       with
+                       | Ok () -> None
+                       | Error detail -> Some detail)
                   }))))
 ;;
 

--- a/lib/pipeline/pipeline_common.ml
+++ b/lib/pipeline/pipeline_common.ml
@@ -41,14 +41,16 @@ let validate_completion_contract agent (response : Types.api_response) =
       agent.state.config.tool_choice
   in
   match
-    Completion_contract.validate_response
+    Completion_contract.validate_response_with_detail
       ~tools:(Tool_set.to_list agent.tools)
       ~required_tool_satisfaction:agent.options.required_tool_satisfaction
       ~contract
       response
   with
   | Ok () -> Ok ()
-  | Error reason -> Error (Error.Agent (CompletionContractViolation { contract; reason }))
+  | Error (reason, violation_detail) ->
+    Error
+      (Error.Agent (CompletionContractViolation { contract; reason; violation_detail }))
 ;;
 
 let event_envelope agent : Event_bus.envelope =

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -241,13 +241,20 @@ let test_agent_run_requires_tool_use_when_tool_choice_is_any () =
     let agent = make_agent ~net:env#net ~tools:[ time_tool ] ~tool_choice:Types.Any url in
     match Agent.run ~sw agent "what time is it?" with
     | Ok _ -> fail "expected required tool contract failure"
-    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason })) ->
+    | Error
+        (Error.Agent
+           (Error.CompletionContractViolation { contract; reason; violation_detail })) ->
       check bool "contract" true (contract = Completion_contract.Require_tool_use);
       check
         bool
         "reason mentions tool contract"
         true
         (contains_substring ~needle:"required tool contract unsatisfied" reason);
+      (match violation_detail with
+       | Some detail ->
+         check (list string) "called tools" [] detail.called_tools;
+         check (list string) "satisfying tools" [] detail.satisfying_tools
+       | None -> fail "expected typed violation detail");
       Eio.Switch.fail sw Exit
     | Error e -> fail (Error.to_string e)
   with
@@ -368,7 +375,7 @@ let test_agent_run_missing_required_tool_use_retry_exhausted () =
     in
     match Agent.run ~sw agent "what time is it?" with
     | Ok _ -> fail "expected missing required tool retry exhaustion"
-    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason })) ->
+    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason; _ })) ->
       check bool "contract" true (contract = Completion_contract.Require_tool_use);
       check
         bool
@@ -467,7 +474,7 @@ let test_agent_run_requires_specific_tool_when_tool_choice_is_tool () =
     in
     match Agent.run ~sw agent "what time is it?" with
     | Ok _ -> fail "expected specific-tool contract failure"
-    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason })) ->
+    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason; _ })) ->
       check
         bool
         "contract"
@@ -505,7 +512,7 @@ let test_agent_run_rejects_any_tool_choice_when_no_tools_visible () =
     let agent = make_agent ~net:env#net ~tools:[] ~tool_choice:Types.Any url in
     match Agent.run ~sw agent "use any available tool" with
     | Ok _ -> fail "expected no-visible-tools contract failure"
-    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason })) ->
+    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason; _ })) ->
       check bool "contract" true (contract = Completion_contract.Require_tool_use);
       check
         bool
@@ -545,7 +552,7 @@ let test_agent_run_accepts_any_tool_choice_when_only_runtime_mcp_tools_visible (
     in
     match Agent.run ~sw agent "use any available tool" with
     | Ok _ -> fail "expected required tool contract failure"
-    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason })) ->
+    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason; _ })) ->
       check bool "contract" true (contract = Completion_contract.Require_tool_use);
       check
         bool
@@ -597,7 +604,7 @@ let test_agent_run_rejects_specific_tool_choice_when_tool_hidden () =
     in
     match Agent.run ~sw agent "what time is it?" with
     | Ok _ -> fail "expected hidden specific-tool contract failure"
-    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason })) ->
+    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason; _ })) ->
       check
         bool
         "contract"
@@ -639,7 +646,7 @@ let test_agent_run_rejects_tool_use_when_tool_choice_is_none () =
     in
     match Agent.run ~sw agent "do not use tools" with
     | Ok _ -> fail "expected no-tool contract failure"
-    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason })) ->
+    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason; _ })) ->
       check bool "contract" true (contract = Completion_contract.Require_no_tool_use);
       check
         bool
@@ -683,7 +690,7 @@ let test_agent_run_strict_required_tool_rejects_read_only_tool () =
     in
     match Agent.run ~sw agent "must use a productive tool" with
     | Ok _ -> fail "expected read-only tool contract failure"
-    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason })) ->
+    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason; _ })) ->
       check bool "contract" true (contract = Completion_contract.Require_tool_use);
       check
         bool
@@ -757,7 +764,7 @@ let test_agent_run_strict_specific_tool_rejects_read_only_match () =
     in
     match Agent.run ~sw agent "must use status" with
     | Ok _ -> fail "expected read-only specific-tool contract failure"
-    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason })) ->
+    | Error (Error.Agent (Error.CompletionContractViolation { contract; reason; _ })) ->
       check
         bool
         "contract"

--- a/test/test_error.ml
+++ b/test/test_error.ml
@@ -78,7 +78,10 @@ let test_agent_completion_contract_violation () =
   let err =
     Error.Agent
       (CompletionContractViolation
-         { contract = Completion_contract.Require_tool_use; reason = "no ToolUse block" })
+         { contract = Completion_contract.Require_tool_use
+         ; reason = "no ToolUse block"
+         ; violation_detail = None
+         })
   in
   check
     string

--- a/test/test_error_domain.ml
+++ b/test/test_error_domain.ml
@@ -139,7 +139,7 @@ let test_to_string_each_variant () =
     ; `Token_budget_exceeded (5000, 4000)
     ; `Idle_detected 5
     ; `Completion_contract_violation
-        (Completion_contract.Require_tool_use, "no ToolUse block")
+        (Completion_contract.Require_tool_use, "no ToolUse block", None)
     ; `Unrecognized_stop_reason "weird"
     ; `Missing_env_var "SECRET"
     ; `Unsupported_provider "unknown_llm"
@@ -184,7 +184,7 @@ let test_all_variants_convert () =
     ; `Token_budget_exceeded (100, 50)
     ; `Idle_detected 3
     ; `Completion_contract_violation
-        (Completion_contract.Require_tool_use, "no ToolUse block")
+        (Completion_contract.Require_tool_use, "no ToolUse block", None)
     ; `Unrecognized_stop_reason "x"
     ; `Missing_env_var "X"
     ; `Unsupported_provider "x"
@@ -352,19 +352,39 @@ let test_roundtrip_agent_completion_contract_violation () =
   let orig =
     Error.Agent
       (CompletionContractViolation
-         { contract = Completion_contract.Require_tool_use; reason = "no ToolUse block" })
+         { contract = Completion_contract.Require_tool_use
+         ; reason = "no ToolUse block"
+         ; violation_detail =
+             Some
+               { Agent_sdk.Completion_contract_violation_detail.called_tools =
+                   [ "read_status" ]
+               ; satisfying_tools = [ "write_note" ]
+               ; rejection_reasons = [ "read_status", "read-only" ]
+               }
+         })
   in
   let poly = Error_domain.of_sdk_error orig in
   (match poly with
    | `Completion_contract_violation
-       (Completion_contract.Require_tool_use, "no ToolUse block") -> ()
+       ( Completion_contract.Require_tool_use
+       , "no ToolUse block"
+       , Some { called_tools = [ "read_status" ]; satisfying_tools = [ "write_note" ]; _ }
+       ) -> ()
    | _ -> Alcotest.fail "expected Completion_contract_violation");
   let back = Error_domain.to_sdk_error poly in
   match back with
   | Error.Agent
       (CompletionContractViolation
-         { contract = Completion_contract.Require_tool_use; reason = "no ToolUse block" })
-    -> ()
+         { contract = Completion_contract.Require_tool_use
+         ; reason = "no ToolUse block"
+         ; violation_detail =
+             Some
+               { Agent_sdk.Completion_contract_violation_detail.called_tools =
+                   [ "read_status" ]
+               ; satisfying_tools = [ "write_note" ]
+               ; rejection_reasons = [ ("read_status", "read-only") ]
+               }
+         }) -> ()
   | _ -> Alcotest.fail "roundtrip mismatch for CompletionContractViolation"
 ;;
 


### PR DESCRIPTION
## Summary
- add a public completion contract violation detail record and re-export it from Agent_sdk
- preserve typed violation detail on CompletionContractViolation and Error_domain roundtrips
- populate violation_detail from completion contract validation while keeping the existing reason string stable

## Verification
- ocamlformat --check touched OCaml files
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/agent_sdk.cmxa test/test_error.exe test/test_error_domain.exe test/test_completion_contract_violation.exe test/test_agent_pipeline.exe
- _build/default/test/test_error.exe
- _build/default/test/test_error_domain.exe
- _build/default/test/test_completion_contract_violation.exe
- _build/default/test/test_agent_pipeline.exe (rerun outside sandbox because local mock server bind needs network permission)