### PR TITLE
refactor(capabilities): type static model routes

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -306,19 +306,21 @@ type gemini_family =
   (** Unknown gemini id or non-gemini id. Retains the literal so the
           caller can log / fall through without losing data. *)
 
+let strip_suffix ~suffix value =
+  if String.ends_with ~suffix value
+  then String.sub value 0 (String.length value - String.length suffix)
+  else value
+;;
+
 (** Classify a model id into a [gemini_family]. Order matters: [gemini-3.1]
     is checked before [gemini-3] so the more specific prefix wins.
     Input is expected lowercased (callers pass the already-normalized id). *)
 let gemini_family_of_id (id : string) : gemini_family =
-  let starts_with prefix =
-    String.length id >= String.length prefix
-    && String.sub id 0 (String.length prefix) = prefix
-  in
-  if starts_with "gemini-3.1"
+  if String.starts_with ~prefix:"gemini-3.1" id
   then Gemini_3_1
-  else if starts_with "gemini-3"
+  else if String.starts_with ~prefix:"gemini-3" id
   then Gemini_3
-  else if starts_with "gemini-2.5"
+  else if String.starts_with ~prefix:"gemini-2.5" id
   then Gemini_2_5
   else Gemini_other id
 ;;
@@ -414,69 +416,185 @@ let codex_cli_capabilities =
 
 (* ── Model-specific overrides (lookup table) ─────────── *)
 
+type static_model_route =
+  | Claude_opus_4
+  | Claude_sonnet_4
+  | Claude_haiku_4
+  | Gpt_5
+  | Gpt_4_1
+  | Gpt_4o
+  | Gemini of gemini_family
+  | Kimi_for_coding
+  | Kimi_k2
+  | Qwen3
+  | Llama_4
+  | Deepseek_v4_flash
+  | Deepseek_v4_pro
+  | Mistral_large
+  | Mistral_small
+  | Command
+  | Grok
+  | Nemotron of { has_vision : bool }
+  | Gemma_4 of { has_large_audio : bool }
+  | Glm_flash_air
+  | Glm_5_turbo
+  | Glm_5v_turbo
+  | Glm_ocr
+  | Glm_4_vision_reasoning
+  | Glm_5_code
+  | Glm_full_text
+  | Glm_4_flash
+  | Glm_4v
+  | Glm_4
+
+let normalize_static_model_id model_id =
+  model_id |> String.trim |> String.lowercase_ascii |> strip_suffix ~suffix:":cloud"
+;;
+
+let gemma_4_has_large_audio model_id =
+  let base =
+    if String.starts_with ~prefix:"google/" model_id
+    then String.sub model_id 7 (String.length model_id - 7)
+    else model_id
+  in
+  let size =
+    if String.starts_with ~prefix:"gemma-4-" base
+    then Some (String.sub base 8 (String.length base - 8))
+    else None
+  in
+  match size with
+  | Some size_token ->
+    List.exists (fun prefix -> String.starts_with ~prefix size_token) [ "27b"; "31b" ]
+  | None -> false
+;;
+
+let static_model_route_of_id model_id =
+  let m = normalize_static_model_id model_id in
+  if String.starts_with ~prefix:"claude-opus-4" m
+  then Some Claude_opus_4
+  else if String.starts_with ~prefix:"claude-sonnet-4" m
+  then Some Claude_sonnet_4
+  else if String.starts_with ~prefix:"claude-haiku-4" m
+  then Some Claude_haiku_4
+  else if String.starts_with ~prefix:"gpt-5" m
+  then Some Gpt_5
+  else if String.starts_with ~prefix:"gpt-4.1" m
+  then Some Gpt_4_1
+  else if String.starts_with ~prefix:"gpt-4o" m
+  then Some Gpt_4o
+  else (
+    match gemini_family_of_id m with
+    | (Gemini_3 | Gemini_3_1 | Gemini_2_5) as family -> Some (Gemini family)
+    | Gemini_other _ ->
+      if String.starts_with ~prefix:"kimi-for-coding" m
+      then Some Kimi_for_coding
+      else if String.starts_with ~prefix:"kimi-k2" m
+      then Some Kimi_k2
+      else if String.starts_with ~prefix:"qwen3" m
+      then Some Qwen3
+      else if
+        String.starts_with ~prefix:"llama-4" m || String.starts_with ~prefix:"llama4" m
+      then Some Llama_4
+      else if String.starts_with ~prefix:"deepseek-v4-flash" m
+      then Some Deepseek_v4_flash
+      else if String.starts_with ~prefix:"deepseek-v4-pro" m
+      then Some Deepseek_v4_pro
+      else if String.starts_with ~prefix:"mistral-large" m
+      then Some Mistral_large
+      else if String.starts_with ~prefix:"mistral-small" m
+      then Some Mistral_small
+      else if String.starts_with ~prefix:"command" m
+      then Some Command
+      else if String.starts_with ~prefix:"grok" m
+      then Some Grok
+      else if
+        String.starts_with ~prefix:"nvidia/nemotron" m
+        || String.starts_with ~prefix:"nemotron" m
+      then
+        Some
+          (Nemotron
+             { has_vision =
+                 String.starts_with ~prefix:"nvidia/nemotron-vl" m
+                 || String.starts_with ~prefix:"nemotron-vl" m
+             })
+      else if
+        String.starts_with ~prefix:"gemma-4" m
+        || String.starts_with ~prefix:"google/gemma-4" m
+      then Some (Gemma_4 { has_large_audio = gemma_4_has_large_audio m })
+      else if
+        String.starts_with ~prefix:"glm-4.7-flash" m
+        || String.starts_with ~prefix:"glm-4.5-flash" m
+        || String.starts_with ~prefix:"glm-4.5-air" m
+      then Some Glm_flash_air
+      else if String.starts_with ~prefix:"glm-5-turbo" m
+      then Some Glm_5_turbo
+      else if String.starts_with ~prefix:"glm-5v-turbo" m
+      then Some Glm_5v_turbo
+      else if String.starts_with ~prefix:"glm-ocr" m
+      then Some Glm_ocr
+      else if
+        String.starts_with ~prefix:"glm-4.6v" m || String.starts_with ~prefix:"glm-4.5v" m
+      then Some Glm_4_vision_reasoning
+      else if String.starts_with ~prefix:"glm-5-code" m
+      then Some Glm_5_code
+      else if
+        String.starts_with ~prefix:"glm-4.5" m
+        || String.starts_with ~prefix:"glm-4.6" m
+        || String.starts_with ~prefix:"glm-4.7" m
+        || String.starts_with ~prefix:"glm-5" m
+      then Some Glm_full_text
+      else if String.starts_with ~prefix:"glm-4-flash" m
+      then Some Glm_4_flash
+      else if String.starts_with ~prefix:"glm-4v" m
+      then Some Glm_4v
+      else if String.starts_with ~prefix:"glm-4" m
+      then Some Glm_4
+      else None)
+;;
+
 (** Lookup capabilities by model_id prefix using the built-in static table.
     Returns None if no specific override is known. *)
-let for_model_id_static model_id =
-  (* Normalize: lowercase, strip quantization suffixes *)
-  let m = String.lowercase_ascii model_id in
-  let starts_with prefix =
-    String.length m >= String.length prefix
-    && String.sub m 0 (String.length prefix) = prefix
-  in
-  if starts_with "claude-opus-4"
-  then
+let capabilities_of_static_model_route = function
+  | Claude_opus_4 ->
     Some
       { anthropic_capabilities with
         max_context_tokens = Some 1_000_000
       ; max_output_tokens = Some 128_000
       }
-  else if starts_with "claude-sonnet-4"
-  then
+  | Claude_sonnet_4 ->
     Some
       { anthropic_capabilities with
         max_context_tokens = Some 1_000_000
       ; max_output_tokens = Some 64_000
       }
-  else if starts_with "claude-haiku-4"
-  then
+  | Claude_haiku_4 ->
     Some
       { anthropic_capabilities with
         max_context_tokens = Some 200_000
       ; max_output_tokens = Some 8_192
       }
-  else if starts_with "gpt-5"
-  then
+  | Gpt_5 ->
     Some
       { openai_chat_extended_capabilities with
         max_context_tokens = Some 1_050_000
       ; max_output_tokens = Some 128_000
       ; supports_computer_use = true
       }
-  else if starts_with "gpt-4.1"
-  then
+  | Gpt_4_1 ->
     Some
       { openai_chat_capabilities with
         max_context_tokens = Some 1_000_000
       ; max_output_tokens = Some 32_000
       }
-  else if starts_with "gpt-4o"
-  then
+  | Gpt_4o ->
     Some
       { openai_chat_capabilities with
         max_context_tokens = Some 128_000
       ; max_output_tokens = Some 16_384
       }
-  else if
-    (* Typed dispatch (root-fix for #968): the classifier owns the prefix
-       comparison so downstream code matches on the variant, not on strings. *)
-    match gemini_family_of_id m with
-    | Gemini_3 | Gemini_3_1 | Gemini_2_5 -> true
-    | Gemini_other _ -> false
-  then Some gemini_capabilities
-  else if starts_with "kimi-for-coding"
-  then Some kimi_capabilities
-  else if starts_with "qwen3"
-  then
+  | Gemini _ -> Some gemini_capabilities
+  | Kimi_for_coding | Kimi_k2 -> Some kimi_capabilities
+  | Qwen3 ->
     Some
       { default_capabilities with
         max_context_tokens = Some 262_144
@@ -491,8 +609,7 @@ let for_model_id_static model_id =
       ; supports_top_k = true
       ; supports_min_p = true
       }
-  else if starts_with "llama-4" || starts_with "llama4"
-  then
+  | Llama_4 ->
     Some
       { default_capabilities with
         max_context_tokens = Some 1_000_000
@@ -501,8 +618,7 @@ let for_model_id_static model_id =
       ; supports_image_input = true
       ; supports_native_streaming = true
       }
-  else if starts_with "deepseek-v4-flash"
-  then
+  | Deepseek_v4_flash ->
     Some
       { default_capabilities with
         max_context_tokens = Some 1_000_000
@@ -519,8 +635,7 @@ let for_model_id_static model_id =
       ; supports_prompt_caching = false
       ; prompt_cache_alignment = None
       }
-  else if starts_with "deepseek-v4-pro"
-  then
+  | Deepseek_v4_pro ->
     Some
       { default_capabilities with
         max_context_tokens = Some 1_000_000
@@ -537,8 +652,7 @@ let for_model_id_static model_id =
       ; supports_prompt_caching = false
       ; prompt_cache_alignment = None
       }
-  else if starts_with "mistral-large"
-  then
+  | Mistral_large ->
     Some
       { default_capabilities with
         max_context_tokens = Some 260_000
@@ -553,8 +667,7 @@ let for_model_id_static model_id =
       ; supports_prompt_caching = false
       ; prompt_cache_alignment = None
       }
-  else if starts_with "mistral-small"
-  then
+  | Mistral_small ->
     Some
       { default_capabilities with
         max_context_tokens = Some 256_000
@@ -570,8 +683,7 @@ let for_model_id_static model_id =
       ; supports_prompt_caching = false
       ; prompt_cache_alignment = None
       }
-  else if starts_with "command"
-  then
+  | Command ->
     Some
       { default_capabilities with
         max_context_tokens = Some 256_000
@@ -582,8 +694,7 @@ let for_model_id_static model_id =
       ; supports_structured_output = true
       ; supports_native_streaming = true
       }
-  else if starts_with "grok"
-  then
+  | Grok ->
     Some
       { default_capabilities with
         max_context_tokens = Some 2_000_000
@@ -600,9 +711,7 @@ let for_model_id_static model_id =
     (* NVIDIA Nemotron: Llama-based, NIM OpenAI-compat API.
        Base text models (nemotron-ultra, nemotron-core) get reasoning
        but no vision. VL suffix gets image input. *)
-  else if starts_with "nvidia/nemotron" || starts_with "nemotron"
-  then (
-    let has_vision = starts_with "nvidia/nemotron-vl" || starts_with "nemotron-vl" in
+  | Nemotron { has_vision } ->
     Some
       { nemotron_capabilities with
         max_context_tokens = Some 131_072
@@ -612,30 +721,8 @@ let for_model_id_static model_id =
       }
     (* Gemma 4: Google open-weight multimodal.
        4 sizes (1B/4B/12B/27B-31B). All support function calling,
-       image input, streaming. 27B+ supports audio. 256K context. *))
-  else if starts_with "gemma-4" || starts_with "google/gemma-4"
-  then (
-    let is_large =
-      let m = String.lowercase_ascii model_id in
-      (* Strip optional "google/" prefix, then "gemma-4-".  The next
-         token is the size: "27b", "31b", "1b", "4b", "12b", etc. *)
-      let base =
-        if String.length m > 7 && String.sub m 0 7 = "google/"
-        then String.sub m 7 (String.length m - 7)
-        else m
-      in
-      match
-        if String.length base >= 8 && String.sub base 0 8 = "gemma-4-"
-        then Some (String.sub base 8 (String.length base - 8))
-        else None
-      with
-      | Some size_token ->
-        List.exists
-          (fun prefix ->
-             String.length size_token >= 3 && String.sub size_token 0 3 = prefix)
-          [ "27b"; "31b" ]
-      | None -> false
-    in
+       image input, streaming. 27B+ supports audio. 256K context. *)
+  | Gemma_4 { has_large_audio } ->
     Some
       { default_capabilities with
         max_context_tokens = Some 262_144
@@ -645,7 +732,7 @@ let for_model_id_static model_id =
       ; supports_structured_output = true
       ; supports_multimodal_inputs = true
       ; supports_image_input = true
-      ; supports_audio_input = is_large
+      ; supports_audio_input = has_large_audio
       ; supports_native_streaming = true
       ; supports_seed = true
       ; modality_priority =
@@ -654,12 +741,8 @@ let for_model_id_static model_id =
            optimal multimodal performance. *)
       }
     (* GLM flash/air variants: faster, no reasoning, smaller output.
-     Must precede the broad glm-4.5/4.6/4.7/5 match below. *))
-  else if
-    starts_with "glm-4.7-flash"
-    || starts_with "glm-4.5-flash"
-    || starts_with "glm-4.5-air"
-  then
+     Must precede the broad glm-4.5/4.6/4.7/5 match below. *)
+  | Glm_flash_air ->
     Some
       { default_capabilities with
         max_context_tokens = Some 128_000
@@ -670,8 +753,7 @@ let for_model_id_static model_id =
       ; supports_native_streaming = true
       }
     (* GLM 5-turbo: tool-calling optimized, fast, reasoning but no extended thinking *)
-  else if starts_with "glm-5-turbo"
-  then
+  | Glm_5_turbo ->
     Some
       { default_capabilities with
         max_context_tokens = Some 128_000
@@ -682,8 +764,7 @@ let for_model_id_static model_id =
       ; supports_response_format_json = true
       ; supports_native_streaming = true
       }
-  else if starts_with "glm-5v-turbo"
-  then
+  | Glm_5v_turbo ->
     Some
       { default_capabilities with
         max_context_tokens = Some 200_000
@@ -697,8 +778,7 @@ let for_model_id_static model_id =
       ; supports_image_input = true
       ; supports_native_streaming = true
       }
-  else if starts_with "glm-ocr"
-  then
+  | Glm_ocr ->
     Some
       { default_capabilities with
         max_context_tokens = Some 128_000
@@ -707,8 +787,7 @@ let for_model_id_static model_id =
       ; supports_image_input = true
       ; supports_native_streaming = true
       }
-  else if starts_with "glm-4.6v" || starts_with "glm-4.5v"
-  then
+  | Glm_4_vision_reasoning ->
     Some
       { default_capabilities with
         max_context_tokens = Some 128_000
@@ -723,8 +802,7 @@ let for_model_id_static model_id =
       }
     (* GLM-5-Code: coding-specific variant with 128K context (not 200K).
        Z.AI docs: GLM-5-Code uses /api/coding/paas/ endpoint, 128K context. *)
-  else if starts_with "glm-5-code"
-  then
+  | Glm_5_code ->
     Some
       { default_capabilities with
         max_context_tokens = Some 128_000
@@ -737,12 +815,7 @@ let for_model_id_static model_id =
       ; supports_native_streaming = true
       }
     (* GLM full text models: reasoning, large context/output, but no vision. *)
-  else if
-    starts_with "glm-4.5"
-    || starts_with "glm-4.6"
-    || starts_with "glm-4.7"
-    || starts_with "glm-5"
-  then
+  | Glm_full_text ->
     Some
       { default_capabilities with
         max_context_tokens = Some 200_000
@@ -754,8 +827,7 @@ let for_model_id_static model_id =
       ; supports_response_format_json = true
       ; supports_native_streaming = true
       }
-  else if starts_with "glm-4-flash"
-  then
+  | Glm_4_flash ->
     Some
       { default_capabilities with
         max_context_tokens = Some 128_000
@@ -763,8 +835,7 @@ let for_model_id_static model_id =
       ; supports_tools = true
       ; supports_native_streaming = true
       }
-  else if starts_with "glm-4v"
-  then
+  | Glm_4v ->
     Some
       { default_capabilities with
         max_context_tokens = Some 128_000
@@ -774,8 +845,7 @@ let for_model_id_static model_id =
       ; supports_image_input = true
       ; supports_native_streaming = true
       }
-  else if starts_with "glm-4"
-  then
+  | Glm_4 ->
     Some
       { default_capabilities with
         max_context_tokens = Some 128_000
@@ -784,7 +854,12 @@ let for_model_id_static model_id =
       ; supports_tool_choice = false
       ; supports_native_streaming = true
       }
-  else None
+;;
+
+let for_model_id_static model_id =
+  match static_model_route_of_id model_id with
+  | Some route -> capabilities_of_static_model_route route
+  | None -> None
 ;;
 
 (** Lookup capabilities by provider label string.

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -113,6 +113,48 @@ type gemini_family =
     the boundary. *)
 val gemini_family_of_id : string -> gemini_family
 
+(** Typed route selected by the built-in static capability table.
+
+    This is the closed-sum replacement for the former monolithic
+    [for_model_id_static] string ladder. Prefix/string normalization stays
+    inside {!static_model_route_of_id}; capability construction switches on this
+    variant so adding or removing a model family is an exhaustive code change. *)
+type static_model_route =
+  | Claude_opus_4
+  | Claude_sonnet_4
+  | Claude_haiku_4
+  | Gpt_5
+  | Gpt_4_1
+  | Gpt_4o
+  | Gemini of gemini_family
+  | Kimi_for_coding
+  | Kimi_k2
+  | Qwen3
+  | Llama_4
+  | Deepseek_v4_flash
+  | Deepseek_v4_pro
+  | Mistral_large
+  | Mistral_small
+  | Command
+  | Grok
+  | Nemotron of { has_vision : bool }
+  | Gemma_4 of { has_large_audio : bool }
+  | Glm_flash_air
+  | Glm_5_turbo
+  | Glm_5v_turbo
+  | Glm_ocr
+  | Glm_4_vision_reasoning
+  | Glm_5_code
+  | Glm_full_text
+  | Glm_4_flash
+  | Glm_4v
+  | Glm_4
+
+(** Resolve a raw model id to the static capability-table route.
+    Input is case-insensitive and trims the Ollama Cloud [":cloud"] suffix
+    before family classification. *)
+val static_model_route_of_id : string -> static_model_route option
+
 (** Lookup capabilities for a known model_id.
     Returns [None] if the model is not in the built-in table. *)
 val for_model_id : string -> capabilities option

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -145,6 +145,42 @@ let pp_gemini_family ppf = function
 
 let gemini_family_testable = Alcotest.testable pp_gemini_family ( = )
 
+let pp_static_model_route ppf = function
+  | Capabilities.Claude_opus_4 -> Format.fprintf ppf "Claude_opus_4"
+  | Capabilities.Claude_sonnet_4 -> Format.fprintf ppf "Claude_sonnet_4"
+  | Capabilities.Claude_haiku_4 -> Format.fprintf ppf "Claude_haiku_4"
+  | Capabilities.Gpt_5 -> Format.fprintf ppf "Gpt_5"
+  | Capabilities.Gpt_4_1 -> Format.fprintf ppf "Gpt_4_1"
+  | Capabilities.Gpt_4o -> Format.fprintf ppf "Gpt_4o"
+  | Capabilities.Gemini family -> Format.fprintf ppf "Gemini(%a)" pp_gemini_family family
+  | Capabilities.Kimi_for_coding -> Format.fprintf ppf "Kimi_for_coding"
+  | Capabilities.Kimi_k2 -> Format.fprintf ppf "Kimi_k2"
+  | Capabilities.Qwen3 -> Format.fprintf ppf "Qwen3"
+  | Capabilities.Llama_4 -> Format.fprintf ppf "Llama_4"
+  | Capabilities.Deepseek_v4_flash -> Format.fprintf ppf "Deepseek_v4_flash"
+  | Capabilities.Deepseek_v4_pro -> Format.fprintf ppf "Deepseek_v4_pro"
+  | Capabilities.Mistral_large -> Format.fprintf ppf "Mistral_large"
+  | Capabilities.Mistral_small -> Format.fprintf ppf "Mistral_small"
+  | Capabilities.Command -> Format.fprintf ppf "Command"
+  | Capabilities.Grok -> Format.fprintf ppf "Grok"
+  | Capabilities.Nemotron { has_vision } ->
+    Format.fprintf ppf "Nemotron(has_vision=%b)" has_vision
+  | Capabilities.Gemma_4 { has_large_audio } ->
+    Format.fprintf ppf "Gemma_4(has_large_audio=%b)" has_large_audio
+  | Capabilities.Glm_flash_air -> Format.fprintf ppf "Glm_flash_air"
+  | Capabilities.Glm_5_turbo -> Format.fprintf ppf "Glm_5_turbo"
+  | Capabilities.Glm_5v_turbo -> Format.fprintf ppf "Glm_5v_turbo"
+  | Capabilities.Glm_ocr -> Format.fprintf ppf "Glm_ocr"
+  | Capabilities.Glm_4_vision_reasoning -> Format.fprintf ppf "Glm_4_vision_reasoning"
+  | Capabilities.Glm_5_code -> Format.fprintf ppf "Glm_5_code"
+  | Capabilities.Glm_full_text -> Format.fprintf ppf "Glm_full_text"
+  | Capabilities.Glm_4_flash -> Format.fprintf ppf "Glm_4_flash"
+  | Capabilities.Glm_4v -> Format.fprintf ppf "Glm_4v"
+  | Capabilities.Glm_4 -> Format.fprintf ppf "Glm_4"
+;;
+
+let static_model_route_testable = Alcotest.testable pp_static_model_route ( = )
+
 let test_gemini_family_3_1 () =
   check
     gemini_family_testable
@@ -208,6 +244,35 @@ let test_gemini_family_drives_capabilities () =
     (Some 1_000_000)
     (ctx "gemini-3.1-pro-preview");
   check (option int) "gemini-2.5-flash ctx" (Some 1_000_000) (ctx "gemini-2.5-flash")
+;;
+
+let test_static_model_route_normalizes_cloud_suffix () =
+  check
+    (option static_model_route_testable)
+    "kimi-k2 cloud route"
+    (Some Capabilities.Kimi_k2)
+    (Capabilities.static_model_route_of_id " kimi-k2.6:cloud ");
+  check
+    (option static_model_route_testable)
+    "deepseek cloud route"
+    (Some Capabilities.Deepseek_v4_pro)
+    (Capabilities.static_model_route_of_id "deepseek-v4-pro:cloud");
+  check
+    (option static_model_route_testable)
+    "glm cloud route"
+    (Some Capabilities.Glm_full_text)
+    (Capabilities.static_model_route_of_id "glm-5.1:cloud")
+;;
+
+let test_lookup_kimi_k2_cloud () =
+  match Capabilities.for_model_id "kimi-k2.6:cloud" with
+  | Some c ->
+    check (option int) "context 262K" (Some 262_144) c.max_context_tokens;
+    check (option int) "output 32K" (Some 32_768) c.max_output_tokens;
+    check bool "tools" true c.supports_tools;
+    check bool "reasoning" true c.supports_reasoning;
+    check bool "code execution" true c.supports_code_execution
+  | None -> fail "should match kimi-k2 cloud route"
 ;;
 
 let test_lookup_qwen () =
@@ -751,6 +816,11 @@ let () =
             "gemini_family drives 1M ctx capabilities"
             `Quick
             test_gemini_family_drives_capabilities
+        ; test_case
+            "static route normalizes cloud suffix"
+            `Quick
+            test_static_model_route_normalizes_cloud_suffix
+        ; test_case "kimi-k2 cloud" `Quick test_lookup_kimi_k2_cloud
         ; test_case "qwen" `Quick test_lookup_qwen
         ; test_case "qwen runpod name" `Quick test_lookup_qwen_runpod_name
         ; test_case "deepseek v4 flash" `Quick test_lookup_deepseek_v4_flash


### PR DESCRIPTION
## Summary
- Replace the monolithic static model-id prefix ladder with a typed static_model_route classifier.
- Normalize raw model IDs before classification (trim, lowercase, strip :cloud) and route kimi-k2* through the existing Kimi capabilities.
- Add regression coverage for cloud suffix normalization and kimi-k2.6:cloud lookup.

## Verification
- ocamlformat --check lib/llm_provider/capabilities.ml lib/llm_provider/capabilities.mli test/test_capabilities.ml
- git diff --check
- bash scripts/ci-code-smell-ratchet.sh --check
- bash scripts/lint-core-cdal-boundary.sh
- scripts/dune-local.sh build test/test_capabilities.exe (attempted; blocked behind shared /tmp/me-dune-local.lock queue and local wait was stopped)