### PR TITLE
refactor(cli): remove local starts_with helper

### DIFF
--- a/lib/llm_provider/cli_common_subprocess.ml
+++ b/lib/llm_provider/cli_common_subprocess.ml
@@ -5,14 +5,9 @@ type collect_result =
   ; recovered_exit_code : int option
   }
 
-let starts_with s prefix =
-  let lp = String.length prefix in
-  String.length s >= lp && String.sub s 0 lp = prefix
-;;
-
 let build_env ~cwd ~extra_env ?(scrub_env = []) () =
   let drop_scrubbed kv =
-    not (List.exists (fun k -> starts_with kv (k ^ "=")) scrub_env)
+    not (List.exists (fun k -> String.starts_with ~prefix:(k ^ "=") kv) scrub_env)
   in
   let base = Unix.environment () |> Array.to_list |> List.filter drop_scrubbed in
   let extras = List.map (fun (k, v) -> Printf.sprintf "%s=%s" k v) extra_env in


### PR DESCRIPTION
## Summary
- Remove the local starts_with helper in cli_common_subprocess.
- Use Stdlib String.starts_with directly for scrubbed environment filtering.
- Reduce the code-smell ratchet duplicate_helpers metric from 9 to 8.

## Verification
- ocamlformat --check lib/llm_provider/cli_common_subprocess.ml
- git diff --check
- bash scripts/ci-code-smell-ratchet.sh --check
- scripts/dune-local.sh build test/test_cli_common_subprocess.exe (not run: /tmp/me-dune-local.lock is currently held by other workspace builds)