### PR TITLE
refactor(kimi): remove local starts_with helper

### DIFF
--- a/lib/llm_provider/transport_kimi_cli.ml
+++ b/lib/llm_provider/transport_kimi_cli.ml
@@ -328,14 +328,9 @@ let emit_blocks ~on_event ~start_index blocks =
 
 (* ── Error classification ────────────────────────────── *)
 
-let starts_with s prefix =
-  let lp = String.length prefix in
-  String.length s >= lp && String.sub s 0 lp = prefix
-;;
-
 let exit_code_of_message message =
   let prefix = "kimi exited with code " in
-  if not (starts_with message prefix)
+  if not (String.starts_with ~prefix message)
   then None
   else (
     match String.index_from_opt message (String.length prefix) ':' with


### PR DESCRIPTION
## Summary
- Remove the local starts_with helper in transport_kimi_cli.
- Use Stdlib String.starts_with directly for Kimi CLI exit-code classification.
- Reduce the code-smell ratchet duplicate_helpers metric from 9 to 8.

## Verification
- ocamlformat --check lib/llm_provider/transport_kimi_cli.ml
- git diff --check
- bash scripts/ci-code-smell-ratchet.sh --check
- scripts/dune-local.sh build lib/llm_provider/transport_kimi_cli.cmx (not run: /tmp/me-dune-local.lock is currently held by other workspace builds)