### PR TITLE
refactor(sessions): remove parser substring alias

### DIFF
--- a/lib/sessions_store_parsers.ml
+++ b/lib/sessions_store_parsers.ml
@@ -65,8 +65,6 @@ let tool_contract_of_json json =
   }
 ;;
 
-let contains_substring ~sub text = Util.string_contains ~needle:sub text
-
 let telemetry_of_json json =
   let open Yojson.Safe.Util in
   let event_counts : telemetry_event_count list =
@@ -114,7 +112,7 @@ let infer_event_name_from_kind kind =
     ]
   in
   known
-  |> List.find_opt (fun (needle, _) -> contains_substring ~sub:needle kind)
+  |> List.find_opt (fun (needle, _) -> Util.string_contains ~needle kind)
   |> Option.map snd
   |> Option.value ~default:(String.lowercase_ascii kind)
 ;;


### PR DESCRIPTION
## Summary
- Remove the local contains_substring alias from Sessions_store_parsers.
- Call Util.string_contains directly when inferring structured telemetry event names.
- Reduce code-smell ratchet duplicate_helpers on this branch from 9 to 7.

## Verification
- ocamlformat --check lib/sessions_store_parsers.ml
- git diff --check
- bash scripts/ci-code-smell-ratchet.sh --check
- scripts/dune-local.sh build test/test_sessions_cov2.exe (attempted; stopped after >90s waiting on /tmp/me-dune-local.lock)