### PR TITLE
refactor(checkpoint): stop re-exporting string helper

### DIFF
--- a/lib/checkpoint_validation.ml
+++ b/lib/checkpoint_validation.ml
@@ -6,8 +6,6 @@
 
 (* ── Text utilities ────────────────────────────────────────────── *)
 
-let contains_substring_ci = Util.contains_substring_ci
-
 let normalize_for_overlap s =
   let b = Buffer.create (String.length s) in
   String.iter
@@ -77,7 +75,7 @@ let validate_dna dna =
   else (
     let has_marker =
       List.exists
-        (fun needle -> contains_substring_ci ~haystack:dna ~needle)
+        (fun needle -> Util.contains_substring_ci ~haystack:dna ~needle)
         [ "goal"; "task"; "objective"; "context" ]
     in
     if not has_marker
@@ -100,9 +98,9 @@ let validate_dna dna =
       else (
         let has_structure =
           String.contains dna '\n'
-          || contains_substring_ci ~haystack:dna ~needle:"- "
-          || contains_substring_ci ~haystack:dna ~needle:": "
-          || contains_substring_ci ~haystack:dna ~needle:"* "
+          || Util.contains_substring_ci ~haystack:dna ~needle:"- "
+          || Util.contains_substring_ci ~haystack:dna ~needle:": "
+          || Util.contains_substring_ci ~haystack:dna ~needle:"* "
         in
         if not has_structure
         then Error "DNA lacks structure (expected: newlines, bullets, colons, or dashes)"
@@ -127,7 +125,7 @@ let continuity_check ~full_context ~compressed_context =
       (fun (acc, pass_n) (name, hint) ->
          let overlap = token_overlap_ratio ~source:hint ~target:compressed_context in
          let retained =
-           contains_substring_ci ~haystack:compressed_context ~needle:hint
+           Util.contains_substring_ci ~haystack:compressed_context ~needle:hint
            || overlap >= 0.6
          in
          let detail =

--- a/lib/checkpoint_validation.mli
+++ b/lib/checkpoint_validation.mli
@@ -33,9 +33,6 @@ val continuity_check : full_context:string -> compressed_context:string -> Yojso
 
 (** {1 Text utilities} *)
 
-(** Case-insensitive substring search. *)
-val contains_substring_ci : haystack:string -> needle:string -> bool
-
 (** Token overlap ratio between two text strings (0.0-1.0).
     Normalizes both strings, tokenizes (min 3 chars), and counts matches. *)
 val token_overlap_ratio : source:string -> target:string -> float

--- a/test/test_checkpoint_validation.ml
+++ b/test/test_checkpoint_validation.ml
@@ -96,17 +96,6 @@ let test_overlap_ratio_disjoint () =
   Alcotest.(check bool) "disjoint = 0.0" true (r < 0.01)
 ;;
 
-let test_contains_ci () =
-  Alcotest.(check bool)
-    "found"
-    true
-    (Checkpoint_validation.contains_substring_ci ~haystack:"Hello World" ~needle:"hello");
-  Alcotest.(check bool)
-    "not found"
-    false
-    (Checkpoint_validation.contains_substring_ci ~haystack:"Hello" ~needle:"xyz")
-;;
-
 let () =
   Alcotest.run
     "Checkpoint Validation"
@@ -125,7 +114,6 @@ let () =
     ; ( "text_utils"
       , [ Alcotest.test_case "overlap identical" `Quick test_overlap_ratio_identical
         ; Alcotest.test_case "overlap disjoint" `Quick test_overlap_ratio_disjoint
-        ; Alcotest.test_case "contains_ci" `Quick test_contains_ci
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- remove Checkpoint_validation.contains_substring_ci from the checkpoint public surface
- route checkpoint internals directly to Util.contains_substring_ci
- remove checkpoint-local tests for the generic substring helper; canonical coverage remains in test_util.ml
- rebased onto main after #1667 and #1668 so the branch reflects the final ratchet state

## Validation
- ocamlformat --check lib/checkpoint_validation.ml lib/checkpoint_validation.mli test/test_checkpoint_validation.ml
- git diff --check
- bash scripts/ci-code-smell-ratchet.sh --check
- bash scripts/ci-code-smell-ratchet.sh --measure => duplicate_helpers: 2

## Deferred
- scripts/dune-local.sh build test/test_checkpoint_validation.exe was attempted, but the local Dune lock was held by other long-running masc-mcp work; lockf -t 1 still reports /tmp/me-dune-local.lock locked, so no OAS compile started locally.