### PR TITLE
fix(sessions): drop stale parser helper signature

### DIFF
--- a/lib/sessions_store_parsers.mli
+++ b/lib/sessions_store_parsers.mli
@@ -29,8 +29,5 @@ val raw_trace_manifest_of_json
   :  Yojson.Safe.t
   -> (Sessions_types.raw_trace_manifest, string) result
 
-(** {1 Helpers} *)
-
-val contains_substring : sub:string -> string -> bool
 val workdir_policy_of_string : string -> Tool.workdir_policy option
 val infer_event_name_from_kind : string -> string


### PR DESCRIPTION
## Summary
- remove the stale contains_substring declaration from sessions_store_parsers.mli
- repair the interface mismatch introduced when the parser helper implementation was removed

## Validation
- ocamlformat --check lib/sessions_store_parsers.mli
- git diff --check
- bash scripts/ci-code-smell-ratchet.sh --check
- scripts/dune-local.sh build test/test_llm_provider_cov.exe
- _build/default/test/test_llm_provider_cov.exe (131 tests)