### PR TITLE
refactor: remove bare ignore calls

### DIFF
--- a/lib/base/util.ml
+++ b/lib/base/util.ml
@@ -75,7 +75,7 @@ let contains_substring_ci ~haystack ~needle =
 
 let regex_match re str =
   try
-    ignore (Str.search_forward re str 0);
+    let (_ : int) = Str.search_forward re str 0 in
     true
   with
   | Not_found -> false

--- a/lib/completion_contract.ml
+++ b/lib/completion_contract.ml
@@ -477,7 +477,7 @@ let%test "validate_response preserves first-match tool descriptor semantics" =
   with
   | Error msg ->
     (try
-       ignore (Str.search_forward (Str.regexp_string "read-only") msg 0);
+       let (_ : int) = Str.search_forward (Str.regexp_string "read-only") msg 0 in
        true
      with
      | Not_found -> false)

--- a/lib/event_forward.ml
+++ b/lib/event_forward.ml
@@ -268,9 +268,11 @@ let deliver_to_file t path payloads =
       (List.map (fun p -> Yojson.Safe.to_string (payload_to_json p) ^ "\n") payloads)
   in
   match Fs_result.append_file path content with
-  | Ok () -> ignore (Atomic.fetch_and_add t.delivered_count n)
+  | Ok () ->
+    let (_ : int) = Atomic.fetch_and_add t.delivered_count n in
+    ()
   | Error err ->
-    ignore (Atomic.fetch_and_add t.failed_count n);
+    let (_ : int) = Atomic.fetch_and_add t.failed_count n in
     Log.warn
       t.log
       "file delivery failed"

--- a/lib/lesson_memory.ml
+++ b/lib/lesson_memory.ml
@@ -212,7 +212,9 @@ let%test "record_failure stores a procedure and an episode" =
 let%test "record_failure increments existing procedure failure count" =
   let mem = Memory.create () in
   let proc_id = record_failure mem base_failure_record in
-  ignore (record_failure mem { base_failure_record with summary = "Try smaller diff" });
+  let (_ : string) =
+    record_failure mem { base_failure_record with summary = "Try smaller diff" }
+  in
   match Memory.find_procedure mem ~pattern:"improve metric" () with
   | Some proc -> proc.id = proc_id && proc.failure_count = 2
   | None -> false
@@ -220,7 +222,7 @@ let%test "record_failure increments existing procedure failure count" =
 
 let%test "retrieve_lessons returns recent failures" =
   let mem = Memory.create () in
-  ignore (record_failure mem base_failure_record);
+  let (_ : string) = record_failure mem base_failure_record in
   match retrieve_lessons mem ~pattern:"metric" () with
   | [ { procedure; recent_failures } ] ->
     procedure.pattern = "improve metric" && List.length recent_failures = 1
@@ -231,7 +233,7 @@ let%test "render_prompt_context empty" = render_prompt_context [] = None
 
 let%test "render_prompt_context contains pattern and action" =
   let mem = Memory.create () in
-  ignore (record_failure mem base_failure_record);
+  let (_ : string) = record_failure mem base_failure_record in
   match render_prompt_context (retrieve_lessons mem ~pattern:"metric" ()) with
   | Some text ->
     Util.contains_substring_ci ~haystack:text ~needle:"improve metric"

--- a/lib/llm_provider/backend_openai_parse.ml
+++ b/lib/llm_provider/backend_openai_parse.ml
@@ -245,7 +245,7 @@ let parse_openai_response_result json_str =
       then text_content
       else (
         try
-          ignore (Yojson.Safe.from_string stripped);
+          let (_ : Yojson.Safe.t) = Yojson.Safe.from_string stripped in
           stripped
         with
         | Yojson.Json_error _ -> text_content)

--- a/lib/llm_provider/provider_throttle.ml
+++ b/lib/llm_provider/provider_throttle.ml
@@ -144,7 +144,7 @@ let%test "create with valid max_concurrent" =
 
 let%test "create rejects zero" =
   try
-    ignore (create ~max_concurrent:0 ~provider_name:"test");
+    let (_ : t) = create ~max_concurrent:0 ~provider_name:"test" in
     false
   with
   | Invalid_argument _ -> true
@@ -152,7 +152,7 @@ let%test "create rejects zero" =
 
 let%test "create rejects negative" =
   try
-    ignore (create ~max_concurrent:(-1) ~provider_name:"test");
+    let (_ : t) = create ~max_concurrent:(-1) ~provider_name:"test" in
     false
   with
   | Invalid_argument _ -> true

--- a/lib/llm_provider/slot_scheduler.ml
+++ b/lib/llm_provider/slot_scheduler.ml
@@ -192,7 +192,7 @@ let%test "create with valid max_slots" =
 
 let%test "create rejects zero" =
   try
-    ignore (create ~max_slots:0);
+    let (_ : t) = create ~max_slots:0 in
     false
   with
   | Invalid_argument _ -> true
@@ -200,7 +200,7 @@ let%test "create rejects zero" =
 
 let%test "create rejects negative" =
   try
-    ignore (create ~max_slots:(-1));
+    let (_ : t) = create ~max_slots:(-1) in
     false
   with
   | Invalid_argument _ -> true

--- a/lib/llm_provider/transport_codex_cli.ml
+++ b/lib/llm_provider/transport_codex_cli.ml
@@ -979,7 +979,9 @@ let%test "runtime_mcp_overrides redirects Bearer to env var indirection" =
          (List.exists
             (fun s ->
                try
-                 ignore (Str.search_forward (Str.regexp_string "secret-token") s 0);
+                 let (_ : int) =
+                   Str.search_forward (Str.regexp_string "secret-token") s 0
+                 in
                  true
                with
                | Not_found -> false)
@@ -996,8 +998,9 @@ let%test "runtime_mcp_overrides keeps non-Bearer auth header verbatim" =
           (List.exists
              (fun s ->
                 try
-                  ignore
-                    (Str.search_forward (Str.regexp_string "bearer_token_env_var") s 0);
+                  let (_ : int) =
+                    Str.search_forward (Str.regexp_string "bearer_token_env_var") s 0
+                  in
                   true
                 with
                 | Not_found -> false)
@@ -1005,7 +1008,9 @@ let%test "runtime_mcp_overrides keeps non-Bearer auth header verbatim" =
     && List.exists
          (fun s ->
             try
-              ignore (Str.search_forward (Str.regexp_string "Authorization=\"Basic") s 0);
+              let (_ : int) =
+                Str.search_forward (Str.regexp_string "Authorization=\"Basic") s 0
+              in
               true
             with
             | Not_found -> false)
@@ -1135,7 +1140,7 @@ let%test "events_of_line mcp_tool_call completion emits tool_result block" =
   let completed =
     {|{"type":"item.completed","item":{"id":"call_1","type":"mcp_tool_call","server":"example","tool":"example_status","result":{"content":[{"type":"text","text":"ok"}],"isError":false}}}|}
   in
-  ignore (events_of_line_with_state state started);
+  let (_ : Types.sse_event list) = events_of_line_with_state state started in
   match events_of_line_with_state state completed with
   | [ Types.ContentBlockStop _
     ; Types.ContentBlockStart { content_type = "tool_result"; _ }

--- a/lib/response_harness.ml
+++ b/lib/response_harness.ml
@@ -276,7 +276,7 @@ let%test "extract_score_from_text: clamps to range" =
 
 let%test "extract_score_from_text: tracks telemetry" =
   reset_telemetry ();
-  ignore (extract_score_from_text "0.5");
+  let (_ : float option) = extract_score_from_text "0.5" in
   let t = snapshot () in
   t.parse_success = 1 && t.text_extraction = 1
 ;;

--- a/scripts/ci-code-smell-ratchet.sh
+++ b/scripts/ci-code-smell-ratchet.sh
@@ -47,17 +47,17 @@ measure_godfile() {
 }
 
 measure_catch_all() {
-  rg -c "^\s*\| _ ->" lib/ --type ml 2>/dev/null \
+  (rg -c "^\s*\| _ ->" lib/ --type ml 2>/dev/null || true) \
     | awk -F: '{s+=$NF}END{print s+0}'
 }
 
 measure_duplicate_helpers() {
-  rg -c "^let (contains_substring|starts_with|first_token_basename|last_pipeline_segment)" lib/ --type ml 2>/dev/null \
+  (rg -c "^let (contains_substring|starts_with|first_token_basename|last_pipeline_segment)" lib/ --type ml 2>/dev/null || true) \
     | awk -F: '{s+=$NF}END{print s+0}'
 }
 
 measure_ignore_calls() {
-  rg -c "^\s*ignore \(" lib/ --type ml 2>/dev/null \
+  (rg -c "^\s*ignore \(" lib/ --type ml 2>/dev/null || true) \
     | awk -F: '{s+=$NF}END{print s+0}'
 }
 


### PR DESCRIPTION
## Summary
- replace bare ignore calls in lib/ with typed discard bindings
- make the code-smell ratchet tolerate zero-match rg results so a metric can actually reach 0
- reduce ignore_calls from 15 to 0 while keeping duplicate_helpers at the canonical Util helper only

## Validation
- ocamlformat --check touched OCaml files
- git diff --check
- bash -n scripts/ci-code-smell-ratchet.sh
- bash scripts/ci-code-smell-ratchet.sh --check
- bash scripts/ci-code-smell-ratchet.sh --measure => ignore_calls: 0
- env MASC_DUNE_THROTTLE=0 scripts/dune-local.sh runtest lib/llm_provider
- env MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build lib/agent_sdk.cma

## Note
- Used MASC_DUNE_THROTTLE=0 for the two focused OAS Dune checks because the shared /tmp/me-dune-local.lock was held by unrelated masc-mcp builds; the OAS build dir remained repo-local.