### PR TITLE
refactor(json): spell out decoder fallbacks

### DIFF
--- a/lib/event_envelope.ml
+++ b/lib/event_envelope.ml
@@ -147,5 +147,6 @@ let of_json = function
       ; caused_by
       ; source_clock
       }
-  | _ -> Error "event envelope must be a JSON object"
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
+    Error "event envelope must be a JSON object"
 ;;

--- a/lib/runtime_sync.ml
+++ b/lib/runtime_sync.ml
@@ -188,7 +188,8 @@ let string_list_field name fields =
             let* rev = acc in
             match item with
             | `String value -> Ok (value :: rev)
-            | _ -> Error (Printf.sprintf "field %s must contain only strings" name))
+            | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null ->
+              Error (Printf.sprintf "field %s must contain only strings" name))
          (Ok [])
     |> Result.map List.rev
   | Ok _ -> Error (Printf.sprintf "field %s must be a list" name)
@@ -225,7 +226,8 @@ let event_record_of_yojson = function
     (match Runtime.event_of_yojson event_json with
      | Ok event -> Ok { envelope; event }
      | Error detail -> Error detail)
-  | _ -> Error "runtime sync event record must be a JSON object"
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
+    Error "runtime sync event record must be a JSON object"
 ;;
 
 let event_record_list_field name fields =
@@ -348,7 +350,8 @@ let window_of_yojson = function
       in
       let* () = validate_window window in
       Ok window
-  | _ -> Error "runtime sync window must be a JSON object"
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
+    Error "runtime sync window must be a JSON object"
 ;;
 
 let to_json = window_to_yojson


### PR DESCRIPTION
## Summary
- replace JSON decoder catch-all fallbacks in runtime_sync and event_envelope with explicit Yojson constructors
- keep the existing error messages and decode behavior
- reduce catch_all from 766 to 762 on this branch

## Validation
- ocamlformat --check lib/runtime_sync.ml lib/event_envelope.ml
- git diff --check
- bash scripts/ci-code-smell-ratchet.sh --check
- env MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_runtime_sync.exe test/test_event_envelope.exe
- _build/default/test/test_runtime_sync.exe (11 tests)
- _build/default/test/test_event_envelope.exe (8 tests)