### PR TITLE
refactor: spell out checkpoint prefix fallback

### DIFF
--- a/lib/checkpoint_delta.ml
+++ b/lib/checkpoint_delta.ml
@@ -33,7 +33,8 @@ let list_sub lst start len =
 let common_prefix_len left right =
   let rec loop n = function
     | x :: xs, y :: ys when x = y -> loop (n + 1) (xs, ys)
-    | _ -> n
+    | [], _ | _, [] -> n
+    | _ :: _, _ :: _ -> n
   in
   loop 0 (left, right)
 ;;


### PR DESCRIPTION
## Summary
- replace the checkpoint prefix-length catch-all match arm with explicit empty-list and mismatch cases
- reduce the code-smell ratchet catch_all count by one without changing splice behavior

## Validation
- ocamlformat --check lib/checkpoint_delta.ml
- git diff --check
- bash scripts/ci-code-smell-ratchet.sh --check
- env MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_checkpoint_delta.exe
- _build/default/test/test_checkpoint_delta.exe