### PR TITLE
refactor: spell out procedural metadata fallback

### DIFF
--- a/lib/memory_procedural.ml
+++ b/lib/memory_procedural.ml
@@ -54,7 +54,7 @@ let procedure_of_json (json : Yojson.Safe.t) : procedure option =
     let metadata =
       match json |> member "metadata" with
       | `Assoc pairs -> pairs
-      | _ -> []
+      | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> []
     in
     Some
       { id


### PR DESCRIPTION
## Summary
- replace procedural memory metadata JSON catch-all with explicit non-object variants
- keep malformed/non-object metadata recovery behavior unchanged
- reduce the code-smell ratchet catch_all count by one for this slice

## Validation
- ocamlformat --check lib/memory_procedural.ml
- git diff --check
- bash scripts/ci-code-smell-ratchet.sh --check
- env MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_memory_procedural.exe
- _build/default/test/test_memory_procedural.exe