### PR TITLE
refactor: spell out memory tool parser fallbacks

### DIFF
--- a/lib/memory_tools_parse.ml
+++ b/lib/memory_tools_parse.ml
@@ -11,21 +11,24 @@ let parse_string_field json name =
   match Yojson.Safe.Util.member name json with
   | `String value -> Ok value
   | `Null -> tool_error (Printf.sprintf "missing '%s' parameter" name)
-  | _ -> tool_error (Printf.sprintf "expected '%s' to be a string" name)
+  | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ ->
+    tool_error (Printf.sprintf "expected '%s' to be a string" name)
 ;;
 
 let parse_optional_string_field json name =
   match Yojson.Safe.Util.member name json with
   | `String value -> Ok (Some value)
   | `Null -> Ok None
-  | _ -> tool_error (Printf.sprintf "expected '%s' to be a string" name)
+  | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ ->
+    tool_error (Printf.sprintf "expected '%s' to be a string" name)
 ;;
 
 let parse_bool_field json name ~default =
   match Yojson.Safe.Util.member name json with
   | `Bool value -> Ok value
   | `Null -> Ok default
-  | _ -> tool_error (Printf.sprintf "expected '%s' to be a boolean" name)
+  | `Assoc _ | `Float _ | `Int _ | `Intlit _ | `List _ | `String _ ->
+    tool_error (Printf.sprintf "expected '%s' to be a boolean" name)
 ;;
 
 let parse_float_field json name ~default =
@@ -33,7 +36,8 @@ let parse_float_field json name ~default =
   | `Float value -> Ok value
   | `Int value -> Ok (float_of_int value)
   | `Null -> Ok default
-  | _ -> tool_error (Printf.sprintf "expected '%s' to be a number" name)
+  | `Assoc _ | `Bool _ | `Intlit _ | `List _ | `String _ ->
+    tool_error (Printf.sprintf "expected '%s' to be a number" name)
 ;;
 
 let parse_generic_tier json ~default =
@@ -44,12 +48,15 @@ let parse_generic_tier json ~default =
     | "long_term" | "long-term" -> Ok Memory.Long_term
     | "episodic" | "procedural" ->
       tool_error "generic memory tools only support scratchpad, working, and long_term"
-    | _ -> tool_error "invalid 'tier'; expected one of scratchpad, working, or long_term"
+    | invalid ->
+      let _invalid_tier = invalid in
+      tool_error "invalid 'tier'; expected one of scratchpad, working, or long_term"
   in
   match Yojson.Safe.Util.member "tier" json with
   | `String value -> parse value
   | `Null -> Ok default
-  | _ -> tool_error "expected 'tier' to be a string"
+  | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ ->
+    tool_error "expected 'tier' to be a string"
 ;;
 
 let parse_string_list_field json name =
@@ -59,17 +66,20 @@ let parse_string_list_field json name =
     let rec loop acc = function
       | [] -> Ok (List.rev acc)
       | `String value :: rest -> loop (value :: acc) rest
-      | _ -> tool_error (Printf.sprintf "expected '%s' to be an array of strings" name)
+      | (`Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null) :: _ ->
+        tool_error (Printf.sprintf "expected '%s' to be an array of strings" name)
     in
     loop [] values
-  | _ -> tool_error (Printf.sprintf "expected '%s' to be an array of strings" name)
+  | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `String _ ->
+    tool_error (Printf.sprintf "expected '%s' to be an array of strings" name)
 ;;
 
 let parse_metadata_field json =
   match Yojson.Safe.Util.member "metadata" json with
   | `Null -> Ok []
   | `Assoc pairs -> Ok pairs
-  | _ -> tool_error "expected 'metadata' to be an object"
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `String _ ->
+    tool_error "expected 'metadata' to be an object"
 ;;
 
 open Result_syntax
@@ -88,5 +98,6 @@ let parse_outcome json =
   | `String "failure" -> Ok (Memory.Failure (Option.value detail ~default:""))
   | `String "neutral" -> Ok Memory.Neutral
   | `String _ -> tool_error "expected 'outcome' to be success, failure, or neutral"
-  | _ -> tool_error "expected 'outcome' to be a string"
+  | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ ->
+    tool_error "expected 'outcome' to be a string"
 ;;


### PR DESCRIPTION
## Summary
- replace bare JSON parser catch-all branches in Memory_tools_parse with explicit Yojson variants
- keep invalid string-value handling as named fallback cases where the domain is open-ended
- reduce the code-smell ratchet catch_all count by ten for this slice

## Validation
- ocamlformat --check lib/memory_tools_parse.ml
- git diff --check
- bash scripts/ci-code-smell-ratchet.sh --check
- env MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_memory_tools_parse.exe
- _build/default/test/test_memory_tools_parse.exe