### PR TITLE
refactor: name artifact mime fallback

### DIFF
--- a/lib/artifact_service.ml
+++ b/lib/artifact_service.ml
@@ -30,7 +30,9 @@ let mime_type_of_kind kind =
   | "html" -> "text/html"
   | "csv" -> "text/csv"
   | "text" | "txt" | "" -> "text/plain"
-  | _ -> "application/octet-stream"
+  | unknown_kind ->
+    let _unknown_kind = unknown_kind in
+    "application/octet-stream"
 ;;
 
 let artifact_counter = Atomic.make 0


### PR DESCRIPTION
## Summary
- replace the artifact MIME bare catch-all with a named unknown-kind fallback
- keep unknown MIME behavior as application/octet-stream
- reduce the code-smell ratchet catch_all count by one for this slice

## Validation
- ocamlformat --check lib/artifact_service.ml
- git diff --check
- bash scripts/ci-code-smell-ratchet.sh --check
- env MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_artifact_service.exe
- _build/default/test/test_artifact_service.exe