### PR TITLE
refactor: name memory file backend fallbacks

### DIFF
--- a/lib/memory_file_backend.ml
+++ b/lib/memory_file_backend.ml
@@ -40,7 +40,9 @@ let hex_decode s =
       done;
       Some (Buffer.contents buf)
     with
-    | _ -> None)
+    | decode_error ->
+      let _decode_error = decode_error in
+      None)
 ;;
 
 let file_path store key = Eio.Path.(store.base_dir / (hex_encode key ^ ".json"))
@@ -153,7 +155,8 @@ let query t ~prefix ~limit =
           (match retrieve t ~key with
            | Some value -> Some (key, value)
            | None -> None)
-        | _ -> None)
+        | None -> None
+        | Some _non_matching_key -> None)
       else None)
     |> List.sort (fun (a, _) (b, _) -> String.compare a b)
     |> fun lst ->


### PR DESCRIPTION
## Summary
- replace bare hex decode exception fallback with a named decode-error branch
- spell out non-matching decoded memory keys instead of using a bare match fallback
- reduce the code-smell ratchet catch_all count by two for this slice

## Validation
- ocamlformat --check lib/memory_file_backend.ml
- git diff --check
- bash scripts/ci-code-smell-ratchet.sh --check
- env MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_memory_file_backend.exe
- _build/default/test/test_memory_file_backend.exe