### PR TITLE
chore(agent_tools): log corrected fields and stages from correction_pipeline

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -284,11 +284,27 @@ let find_and_execute_tool_with_index
           match Correction_pipeline.run ~schema:tool.schema input with
           | Correction_pipeline.Fixed { corrected; corrections } ->
             if corrections <> []
-            then
+            then (
+              let field_names =
+                corrections
+                |> List.map (fun (c : Correction_pipeline.correction) -> c.field)
+                |> List.sort_uniq String.compare
+                |> String.concat ","
+              in
+              let stage_names =
+                corrections
+                |> List.map (fun (c : Correction_pipeline.correction) -> c.stage)
+                |> List.sort_uniq String.compare
+                |> String.concat ","
+              in
               Log.info
                 _log
                 "correction_pipeline fixed tool input fields"
-                [ Log.S ("tool", name); Log.I ("fixes", List.length corrections) ];
+                [ Log.S ("tool", name)
+                ; Log.I ("fixes", List.length corrections)
+                ; Log.S ("fields", field_names)
+                ; Log.S ("stages", stage_names)
+                ]);
             Ok corrected
           | Correction_pipeline.Still_invalid { errors; attempted } ->
             (* Det correction insufficient — build structured feedback for the


### PR DESCRIPTION
## Why

While auditing masc-mcp runtime logs for a §2 Permissive Default investigation, the bridge rendered:

```
tool masc_code_shell: correction_pipeline fixed 1 field(s)
```

This co-occurred with a separate `workflow_rejection` (Shell injection syntax). The two layers are independent and the rejection layer is already well-typed (`failure_class=workflow_rejection`, `retry_skipped=true`). However the **correction layer** emits only `fixes=N` — there is no way to tell from logs *which* field was corrected or by *which* stage.

That gap matters because `default_injection_stage` (`lib/correction_pipeline.ml`) silently injects zero-values (`String → ""`, `Integer → 0`, `Boolean → false`) for missing **optional** fields. That is intentional behavior (and arguably correct), but a silent transform of an optional field to its zero value can carry a semantic shift in tool implementations that interpret the zero as a meaningful value (e.g. `cwd: ""` as "current dir"). Without field-level visibility, we cannot tell that case apart from a harmless `String.trim`.

## What changes

Pure additive log enrichment in `lib/agent/agent_tools.ml`. The `Log.info` call inside `find_and_execute_tool_with_index`'s `Fixed` arm now also emits:

| key | value |
|-----|-------|
| `fields` | comma-separated sorted-unique names of corrected fields |
| `stages` | comma-separated sorted-unique stage names (`coercion` / `default_injection` / `format_normalization`) |

Behavior of `Correction_pipeline.run` and downstream dispatch is unchanged.

```diff
-              [ Log.S ("tool", name); Log.I ("fixes", List.length corrections) ];
+              [ Log.S ("tool", name)
+              ; Log.I ("fixes", List.length corrections)
+              ; Log.S ("fields", field_names)
+              ; Log.S ("stages", stage_names)
+              ]);
```

## Why this is not a §1 telemetry-as-fix

Per CLAUDE.md §1, "make X visible" without a fix is the anti-pattern. This PR explicitly **does not** claim to fix the optional-zero injection — it makes the inputs to that decision auditable. Downstream we can decide whether to:

1. Restrict `default_injection_stage` to a typed allowlist of fields where zero is unambiguous; or
2. Add per-tool opt-outs via `Tool.descriptor`; or
3. Leave behavior unchanged once audit confirms no silent semantic shifts.

That follow-up requires the data this PR exposes.

## Test plan

- [x] `dune build --root . lib` — clean
- [x] `dune build --root . test/test_correction_pipeline.exe` — clean
- [x] `dune exec --root . test/test_correction_pipeline.exe` — 12/12 PASS
- [x] `dune exec --root . test/test_agent_tool.exe` — 7/7 PASS
- [x] `dune exec --root . test/test_agent_tools_index.exe` — 5/5 PASS
- [ ] CI — pending

## masc-mcp bridge compat

`agent_sdk_log_bridge.ml` in masc-mcp renders the `correction_pipeline fixed tool input fields` message via `first_detail_label` with whitelisted keys (`tool_name|tool`, `fixes|count`). New keys `fields` and `stages` are ignored by the bridge → no rendering regression. They appear as structured log fields downstream and become queryable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)