### PR TITLE
fix: restore json fallback catch-alls

### DIFF
--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -75,17 +75,17 @@ type agent_file_config =
 
 let list_or_empty = function
   | `List values -> values
-  | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `Null | `String _ -> []
+  | _ -> []
 ;;
 
 let assoc_or_empty = function
   | `Assoc pairs -> pairs
-  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> []
+  | _ -> []
 ;;
 
 let string_option = function
   | `String value -> Some value
-  | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null -> None
+  | _ -> None
 ;;
 
 let parse_param json =

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -29,7 +29,7 @@ let metric_value_of_yojson = function
   | `Float f -> Ok (Float_val f)
   | `Bool b -> Ok (Bool_val b)
   | `String s -> Ok (String_val s)
-  | `Assoc _ | `List _ | `Null | `Intlit _ -> Error "expected int, float, bool, or string"
+  | _ -> Error "expected int, float, bool, or string"
 ;;
 
 let show_metric_value = function
@@ -50,7 +50,7 @@ let metric_value_to_float = function
 
 let tags_of_json = function
   | `Assoc kvs -> List.map (fun (k, v) -> k, Yojson.Safe.Util.to_string v) kvs
-  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> []
+  | _ -> []
 ;;
 
 let numeric_threshold_violated ~compare value threshold =

--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -118,7 +118,7 @@ let build_request
       else fields
     in
     Yojson.Safe.to_string (`Assoc fields)
-  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> base_body
+  | _ -> base_body
 ;;
 
 (* ── Response parsing ────────────────────────────── *)
@@ -137,7 +137,7 @@ let check_glm_error body : glm_error option =
         match err |> member "code" with
         | `String s -> s
         | `Int n -> string_of_int n
-        | `Assoc _ | `List _ | `Intlit _ | `Float _ | `Bool _ | `Null -> "unknown"
+        | _ -> "unknown"
       in
       let message =
         err
@@ -167,8 +167,7 @@ let extract_reasoning_content (resp : api_response) body : api_response =
          let thinking_block = Thinking { thinking_type = "thinking"; content = r } in
          { resp with content = thinking_block :: resp.content }
        | Some _ | None -> resp)
-    | `List [] | `Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null ->
-      resp
+    | _ -> resp
   with
   | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> resp
 ;;

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -388,8 +388,7 @@ let legacy_parameters_to_json_schema params =
            let name =
              match List.assoc_opt "name" fields with
              | Some (`String s) -> s
-             | Some (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
-             | None -> ""
+             | Some _ | None -> ""
            in
            if name = ""
            then props_acc, req_acc
@@ -397,27 +396,15 @@ let legacy_parameters_to_json_schema params =
              let description =
                match List.assoc_opt "description" fields with
                | Some (`String s) -> s
-               | Some
-                   (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
-               | None -> ""
+               | Some _ | None -> ""
              in
              let type_name =
                match List.assoc_opt "param_type" fields with
                | Some (`String s) -> s
-               | Some
-                   (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
-               | None ->
+               | Some _ | None ->
                  (match List.assoc_opt "type" fields with
                   | Some (`String s) -> s
-                  | Some
-                      ( `Assoc _
-                      | `List _
-                      | `Int _
-                      | `Intlit _
-                      | `Float _
-                      | `Bool _
-                      | `Null )
-                  | None -> "string")
+                  | Some _ | None -> "string")
              in
              let prop =
                `Assoc [ "type", `String type_name; "description", `String description ]
@@ -425,15 +412,10 @@ let legacy_parameters_to_json_schema params =
              let req_acc =
                match List.assoc_opt "required" fields with
                | Some (`Bool true) -> `String name :: req_acc
-               | Some
-                   ( `Assoc _ | `List _ | `String _ | `Int _ | `Intlit _ | `Float _
-                   | `Bool false
-                   | `Null )
-               | None -> req_acc
+               | Some _ | None -> req_acc
              in
              (name, prop) :: props_acc, req_acc)
-         | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null ->
-           props_acc, req_acc)
+         | _ -> props_acc, req_acc)
       ([], [])
       params
   in
@@ -449,14 +431,12 @@ let build_openai_tool_json = function
     let name =
       match List.assoc_opt "name" fields with
       | Some (`String s) -> s
-      | Some (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) | None
-        -> "tool"
+      | Some _ | None -> "tool"
     in
     let description =
       match List.assoc_opt "description" fields with
       | Some (`String s) -> s
-      | Some (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) | None
-        -> ""
+      | Some _ | None -> ""
     in
     let parameters =
       match List.assoc_opt "input_schema" fields with

--- a/lib/protocol/mcp.ml
+++ b/lib/protocol/mcp.ml
@@ -146,14 +146,12 @@ let mcp_tool_of_json = function
          ; description =
              (match List.assoc_opt "description" fields with
               | Some (`String s) -> s
-              | Some (`Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null)
-              | None -> "")
+              | Some _ | None -> "")
          ; input_schema
          }
-     | Some (`Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null) | None
-       -> None)
+     | Some _ | None -> None)
     (* skip tools without a valid name *)
-  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
+  | _ -> None
 ;;
 
 let initialize t =


### PR DESCRIPTION
## Summary
- restore catch-all fallback branches for JSON helper/parser matches that replaced previous wildcards
- keep the public Yojson.Safe.t boundaries intact instead of adding unsupported Tuple/Variant constructors
- cover the unresolved post-merge review comments that still apply as fallback-resilience fixes

## Review threads checked
- jeong-sik/oas#1682 r3281227768
- jeong-sik/oas#1684 r3281407146
- jeong-sik/oas#1686 r3281417011 / r3281417018
- jeong-sik/oas#1691 r3281622262 / r3281622268
- jeong-sik/oas#1693 r3281621871

## Verification
- ocamlformat on touched files
- git diff --check
- scripts/dune-local.sh build test/test_eval_coverage.exe test/test_mcp.exe test/test_provider_complete.exe