### PR TITLE
[codex] tolerate release version markers

### DIFF
--- a/scripts/release-version-lib.sh
+++ b/scripts/release-version-lib.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Shared release-version extraction helpers.
+
+release_extract_dune_project_version() {
+  local file="${1:-dune-project}"
+  sed -nE 's/^[[:space:]]*\(version[[:space:]]+([^[:space:])]+).*/\1/p' "$file" | head -n 1
+}
+
+release_extract_sdk_version() {
+  local file="${1:-lib/sdk_version.ml}"
+  sed -nE 's/^[[:space:]]*let[[:space:]]+version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' "$file" | head -n 1
+}
+
+release_extract_opam_version() {
+  local file="${1:-agent_sdk.opam}"
+  sed -nE 's/^[[:space:]]*version:[[:space:]]*"([^"]+)".*/\1/p' "$file" | head -n 1
+}
+
+release_is_supported_version() {
+  local version="${1:-}"
+  [[ "$version" =~ ^[0-9]+[.][0-9]+([.][0-9]+)?([-+][0-9A-Za-z][0-9A-Za-z._+-]*)?$ ]]
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -19,6 +19,9 @@ if [[ "${1:-}" == "--tag" ]]; then
   TAG_MODE=true
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/release-version-lib.sh"
+
 # Check -1: running on `main` synced with origin/main.
 # Rationale: tag lands on HEAD, so a non-main HEAD (or a stale main)
 # produces an orphaned tag after PR merge rebases the SHA.
@@ -47,9 +50,9 @@ if [[ "$LOCAL_MAIN" != "$ORIGIN_MAIN" ]]; then
 fi
 
 # Extract versions from canonical sources
-DUNE_VER=$(grep '(version' dune-project | head -1 | sed 's/.*version \(.*\))/\1/')
-SDK_VER=$(sed -n 's/^let version = "\(.*\)"$/\1/p' lib/sdk_version.ml | head -1)
-OPAM_VER=$(sed -n 's/^version: "\(.*\)"$/\1/p' agent_sdk.opam | head -1)
+DUNE_VER=$(release_extract_dune_project_version dune-project)
+SDK_VER=$(release_extract_sdk_version lib/sdk_version.ml)
+OPAM_VER=$(release_extract_opam_version agent_sdk.opam)
 LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1)
 
 echo "dune-project version: $DUNE_VER"
@@ -63,6 +66,13 @@ if [[ -z "$DUNE_VER" || -z "$SDK_VER" || -z "$OPAM_VER" ]]; then
   echo "ERROR: Failed to extract one or more version strings."
   exit 1
 fi
+
+for parsed_version in "$DUNE_VER" "$SDK_VER" "$OPAM_VER"; do
+  if ! release_is_supported_version "$parsed_version"; then
+    echo "ERROR: Extracted invalid release version string: $parsed_version"
+    exit 1
+  fi
+done
 
 # Check 1: dune-project == sdk_version.ml == agent_sdk.opam
 if [[ "$DUNE_VER" != "$SDK_VER" ]]; then

--- a/scripts/test-release-version-extraction.sh
+++ b/scripts/test-release-version-extraction.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${repo_root}/scripts/release-version-lib.sh"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+
+  if [[ "$actual" != "$expected" ]]; then
+    echo "FAIL ${label}: expected ${expected}, got ${actual}" >&2
+    exit 1
+  fi
+}
+
+assert_valid() {
+  local label="$1"
+  local actual="$2"
+
+  if ! release_is_supported_version "$actual"; then
+    echo "FAIL ${label}: invalid version ${actual}" >&2
+    exit 1
+  fi
+}
+
+write_fixture() {
+  local path="$1"
+  local content="$2"
+  printf '%s\n' "$content" > "$path"
+}
+
+write_fixture "$tmpdir/dune-marker" '(version 0.196.10) ; x-release-please-version'
+write_fixture "$tmpdir/dune-plain" '(version 0.196.10)'
+write_fixture "$tmpdir/sdk-marker" 'let version = "0.196.10" (* x-release-please-version *)'
+write_fixture "$tmpdir/sdk-plain" 'let version = "0.196.10"'
+write_fixture "$tmpdir/opam-marker" 'version: "0.196.10" # x-release-please-version'
+write_fixture "$tmpdir/opam-plain" 'version: "0.196.10"'
+
+assert_eq "dune marker" "0.196.10" "$(release_extract_dune_project_version "$tmpdir/dune-marker")"
+assert_eq "dune plain" "0.196.10" "$(release_extract_dune_project_version "$tmpdir/dune-plain")"
+assert_eq "sdk marker" "0.196.10" "$(release_extract_sdk_version "$tmpdir/sdk-marker")"
+assert_eq "sdk plain" "0.196.10" "$(release_extract_sdk_version "$tmpdir/sdk-plain")"
+assert_eq "opam marker" "0.196.10" "$(release_extract_opam_version "$tmpdir/opam-marker")"
+assert_eq "opam plain" "0.196.10" "$(release_extract_opam_version "$tmpdir/opam-plain")"
+
+current_dune="$(release_extract_dune_project_version "${repo_root}/dune-project")"
+current_sdk="$(release_extract_sdk_version "${repo_root}/lib/sdk_version.ml")"
+current_opam="$(release_extract_opam_version "${repo_root}/agent_sdk.opam")"
+
+assert_eq "current dune/sdk" "$current_dune" "$current_sdk"
+assert_eq "current dune/opam" "$current_dune" "$current_opam"
+assert_valid "current dune" "$current_dune"
+assert_valid "current sdk" "$current_sdk"
+assert_valid "current opam" "$current_opam"
+
+case "$current_dune $current_sdk $current_opam" in
+  *x-release-please-version*)
+    echo "FAIL current extraction leaked release-please marker" >&2
+    exit 1
+    ;;
+esac
+
+echo "release version extraction fixtures passed for ${current_dune}"


### PR DESCRIPTION
## Summary

- Fix #1704.
- Move release version extraction into `scripts/release-version-lib.sh` with marker-tolerant readers for `dune-project`, `lib/sdk_version.ml`, and `agent_sdk.opam`.
- Update `scripts/release.sh` to use those readers and reject invalid extracted version strings before comparing surfaces.
- Add `scripts/test-release-version-extraction.sh` with marker/no-marker fixtures for all three version surfaces plus current-file checks.

## Root cause

`release.sh` still used older sed expressions that treated release-please markers as part of the `dune-project` version and failed to extract `lib/sdk_version.ml` when the line had a trailing comment.

## Validation

- `bash -n scripts/release.sh`
- `bash -n scripts/release-version-lib.sh`
- `bash -n scripts/test-release-version-extraction.sh`
- `scripts/test-release-version-extraction.sh`
- `git diff --check`
- `git diff --cached --check`

Note: running `scripts/release.sh` directly on this branch still fails at the existing main-branch guard, as expected. The parser regression is covered by the new fixture script.