### PR TITLE
fix: type provider reasoning controls

### DIFF
--- a/docs/_audit/2026-05-24-provider-reasoning-evidence-record.md
+++ b/docs/_audit/2026-05-24-provider-reasoning-evidence-record.md
@@ -1,0 +1,47 @@
+# Provider reasoning-control evidence record - 2026-05-24
+
+Scope: #1706 first implementation slice. This records the provider-facing
+wire-format facts used to set OAS `thinking_control_format` values and GLM
+coding credential separation.
+
+## OpenAI
+
+- Evidence: OpenAI Chat Completions documents `reasoning_effort` as the request
+  parameter for reasoning models, with currently documented values including
+  `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`.
+- Source: https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
+- Timestamp: 2026-05-24 KST
+- Confidence: High
+- Delta: OAS maps OpenAI-style reasoning records to `Reasoning_effort`.
+
+## Z.AI
+
+- Evidence: Z.AI documents the general API endpoint
+  `https://api.z.ai/api/paas/v4` and a distinct GLM Coding Plan endpoint
+  `https://api.z.ai/api/coding/paas/v4`.
+- Source: https://docs.z.ai/api-reference/introduction
+- Timestamp: 2026-05-24 KST
+- Confidence: High
+- Delta: OAS keeps general GLM on `ZAI_API_KEY` and defaults the coding lane to
+  `ZAI_CODING_API_KEY`.
+
+## Kimi / Moonshot
+
+- Evidence: Kimi K2.5 request-body differences document a top-level `thinking`
+  object. Thinking can be disabled with `{"type": "disabled"}`, and thinking
+  output is surfaced as `reasoning_content`.
+- Source: https://platform.kimi.ai/docs/guide/kimi-k2-5-quickstart
+- Timestamp: 2026-05-24 KST
+- Confidence: High
+- Delta: OAS maps Kimi K2.5-style reasoning control to `Thinking_object_only`
+  rather than mixing it with `reasoning_effort`.
+
+## DashScope
+
+- Evidence: DashScope OpenAI-compatible deep-thinking examples show top-level
+  `enable_thinking` and `thinking_budget` fields and stream
+  `reasoning_content`.
+- Source: https://help.aliyun.com/zh/model-studio/deep-thinking
+- Timestamp: 2026-05-24 KST
+- Confidence: High
+- Delta: OAS maps DashScope reasoning control to `Enable_thinking`.

--- a/docs/provider-catalog.md
+++ b/docs/provider-catalog.md
@@ -203,6 +203,15 @@ Model-specific facts should still live in `OAS_CAPABILITY_MANIFEST`. Provider
 catalog capabilities should describe runtime/provider defaults and transport
 constraints.
 
+Accepted `thinking_control_format` values are:
+
+- `none`
+- `thinking_object` (top-level `thinking` object plus `reasoning_effort`)
+- `thinking_object_only` (top-level `thinking` object only)
+- `chat_template_kwargs`
+- `reasoning_effort`
+- `enable_thinking` (top-level `enable_thinking` plus optional `thinking_budget`)
+
 ## External Design References
 
 The catalog shape follows a common pattern in current agent tools:

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -133,16 +133,39 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
              ~thinking_budget:config.config.thinking_budget
          in
          ("reasoning_effort", `String effort) :: body_assoc
-       | _ when is_glm_request ?provider_config config ->
+       | Llm_provider.Capabilities.Thinking_object ->
+         let effort =
+           Llm_provider.Provider_config.effort_of_thinking_config
+             ~enable_thinking:(Some enabled)
+             ~thinking_budget:config.config.thinking_budget
+         in
+         if enabled
+         then
+           ("reasoning_effort", `String effort)
+           :: ("thinking", `Assoc [ "type", `String "enabled" ])
+           :: body_assoc
+         else ("thinking", `Assoc [ "type", `String "disabled" ]) :: body_assoc
+       | Llm_provider.Capabilities.Thinking_object_only ->
+         ( "thinking"
+         , `Assoc [ "type", `String (if enabled then "enabled" else "disabled") ] )
+         :: body_assoc
+       | Llm_provider.Capabilities.Enable_thinking ->
+         let body_assoc = ("enable_thinking", `Bool enabled) :: body_assoc in
+         (match enabled, config.config.thinking_budget with
+          | true, Some budget -> ("thinking_budget", `Int budget) :: body_assoc
+          | _ -> body_assoc)
+       | Llm_provider.Capabilities.No_thinking_control
+         when is_glm_request ?provider_config config ->
          let thinking =
            if enabled
            then `Assoc [ "type", `String "enabled"; "clear_thinking", `Bool true ]
            else `Assoc [ "type", `String "disabled" ]
          in
          ("thinking", thinking) :: body_assoc
-       | _ ->
+       | Llm_provider.Capabilities.Chat_template_kwargs ->
          ("chat_template_kwargs", `Assoc [ "enable_thinking", `Bool enabled ])
-         :: body_assoc)
+         :: body_assoc
+       | Llm_provider.Capabilities.No_thinking_control -> body_assoc)
     | None
       when capabilities.thinking_control_format
            = Llm_provider.Capabilities.Reasoning_effort ->

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -1232,17 +1232,63 @@ let%test "build_request serializes disabled thinking for deepseek-v4-pro" =
   json |> member "thinking" |> member "type" |> to_string = "disabled"
 ;;
 
-let%test "build_request emits chat_template_kwargs for Chat_template_kwargs capability" =
-  (* ollama_capabilities inherits Chat_template_kwargs from the new field.
-     Using a model_id that is NOT in for_model_id → defaults to
-     default_capabilities where thinking_control_format = No_thinking_control,
-     so the test must use a model that resolves to ollama_capabilities.
-     We override via supports_tool_choice_override path is not available
-     for thinking, so instead we test with a model_id that exercises
-     the Chat_template_kwargs branch through Ollama routing.
-     However, build_request resolves caps via Capabilities.for_model_id,
-     which does not match generic "llama-*" names. The correct test
-     verifies that No_thinking_control models do NOT emit thinking params. *)
+let%test "build_request emits reasoning_effort for OpenAI reasoning models" =
+  let config =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"gpt-5.1"
+      ~base_url:"https://api.openai.com/v1"
+      ~enable_thinking:true
+      ~thinking_budget:2048
+      ()
+  in
+  let body = build_request ~config ~messages:[] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  json |> member "reasoning_effort" |> to_string = "low"
+  && json |> member "thinking" = `Null
+  && json |> member "enable_thinking" = `Null
+;;
+
+let%test "build_request emits thinking object only for Kimi K2.5" =
+  let config =
+    Provider_config.make
+      ~kind:Kimi
+      ~model_id:"kimi-k2.5"
+      ~base_url:"https://api.moonshot.ai/v1"
+      ~enable_thinking:false
+      ()
+  in
+  let body = build_request ~config ~messages:[] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  json |> member "thinking" |> member "type" |> to_string = "disabled"
+  && json |> member "reasoning_effort" = `Null
+  && json |> member "chat_template_kwargs" = `Null
+;;
+
+let%test "build_request emits enable_thinking for DashScope provider kind" =
+  let config =
+    Provider_config.make
+      ~kind:DashScope
+      ~model_id:"qwen-plus"
+      ~base_url:"https://dashscope.aliyuncs.com/compatible-mode/v1"
+      ~enable_thinking:true
+      ~thinking_budget:50
+      ()
+  in
+  let body = build_request ~config ~messages:[] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  json |> member "enable_thinking" |> to_bool = true
+  && json |> member "thinking_budget" |> to_int = 50
+  && json |> member "chat_template_kwargs" = `Null
+;;
+
+let%test "build_request omits thinking params for No_thinking_control" =
+  (* Generic unknown OpenAI-compatible model ids fall back to
+     No_thinking_control and must not emit any provider-specific thinking
+     parameter. *)
   let config =
     Provider_config.make
       ~kind:OpenAI_compat

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -87,6 +87,24 @@ let response_format_of_config (config : Provider_config.t) =
   | None -> None
 ;;
 
+let capabilities_of_config (config : Provider_config.t) =
+  match Capabilities.for_model_id config.model_id with
+  | Some caps -> caps
+  | None ->
+    (match config.kind with
+     | Provider_config.Ollama -> Capabilities.ollama_capabilities
+     | Provider_config.Kimi -> Capabilities.kimi_capabilities
+     | Provider_config.DashScope -> Capabilities.dashscope_capabilities
+     | Provider_config.Glm -> Capabilities.glm_capabilities
+     | Provider_config.Anthropic -> Capabilities.anthropic_capabilities
+     | Provider_config.Gemini -> Capabilities.gemini_capabilities
+     | Provider_config.Claude_code -> Capabilities.claude_code_capabilities
+     | Provider_config.Gemini_cli -> Capabilities.gemini_cli_capabilities
+     | Provider_config.Kimi_cli -> Capabilities.kimi_cli_capabilities
+     | Provider_config.Codex_cli -> Capabilities.codex_cli_capabilities
+     | Provider_config.OpenAI_compat -> Capabilities.default_capabilities)
+;;
+
 (** Build OpenAI Chat Completions request body from {!Provider_config.t}.
     Returns a JSON string ready for HTTP POST. *)
 let build_request
@@ -126,14 +144,10 @@ let build_request
   (* Look up per-model capabilities once - drives:
      (1) the [max_tokens] clamp below (avoid server 400 on over-cap),
      (2) the [top_k] / [min_p] sampling-field gates further down.
-     If no capability record exists for the model, fall back to
-     [default_capabilities] (conservative: drop non-standard params,
-     pass through standard ones). *)
-  let caps =
-    match Capabilities.for_model_id config.model_id with
-    | Some c -> c
-    | None -> Capabilities.default_capabilities
-  in
+     If no model-specific record exists, fall back to the provider-kind
+     preset, then to conservative defaults for unknown OpenAI-compatible
+     configs. *)
+  let caps = capabilities_of_config config in
   (* Resolve [max_tokens] from three layers:
      1. Caller override ([config.max_tokens = Some n]) - explicit request
      2. Model capability ([caps.max_output_tokens]) - provider's ceiling
@@ -209,6 +223,10 @@ let build_request
            :: ("thinking", `Assoc [ "type", `String "enabled" ])
            :: body)
          else ("thinking", `Assoc [ "type", `String "disabled" ]) :: body
+       | Thinking_object_only ->
+         ( "thinking"
+         , `Assoc [ "type", `String (if enabled then "enabled" else "disabled") ] )
+         :: body
        | Chat_template_kwargs ->
          ("chat_template_kwargs", `Assoc [ "enable_thinking", `Bool enabled ]) :: body
        | Reasoning_effort ->
@@ -218,6 +236,11 @@ let build_request
              ~thinking_budget:config.thinking_budget
          in
          ("reasoning_effort", `String effort) :: body
+       | Enable_thinking ->
+         let body = ("enable_thinking", `Bool enabled) :: body in
+         (match enabled, config.thinking_budget with
+          | true, Some budget -> ("thinking_budget", `Int budget) :: body
+          | _ -> body)
        | No_thinking_control -> body)
     | None ->
       (match caps.thinking_control_format with

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -14,7 +14,10 @@
     @since 0.184.0 *)
 type thinking_control_format =
   | No_thinking_control (** No thinking control supported *)
-  | Thinking_object (** DeepSeek-style: {"thinking":{"type":"enabled"}} *)
+  | Thinking_object
+  (** DeepSeek-style: top-level [thinking] object plus [reasoning_effort]. *)
+  | Thinking_object_only
+  (** Kimi K2.5-style: top-level [thinking] object without [reasoning_effort]. *)
   | Chat_template_kwargs
   (** llama-server style: {"chat_template_kwargs":{"enable_thinking":b}} *)
   | Reasoning_effort
@@ -23,6 +26,9 @@ type thinking_control_format =
       see {!Provider_config.effort_of_thinking_config}. (OpenAI's spec
       also accepts ["minimal"], but no current OAS request builder emits
       it.) Ollama's OpenAI-compatible mode uses this shape. *)
+  | Enable_thinking
+  (** DashScope-style top-level [enable_thinking] bool plus optional
+      [thinking_budget]. *)
 
 type capabilities =
   { (* ── Numeric limits ────────────────────────────────── *)
@@ -167,6 +173,7 @@ let kimi_capabilities =
   ; supports_tools = true
   ; supports_tool_choice = true
   ; supports_reasoning = true
+  ; thinking_control_format = Thinking_object_only
   ; supports_system_prompt = true
   ; supports_code_execution = true
   }
@@ -195,6 +202,7 @@ let openai_chat_extended_capabilities =
     supports_reasoning = true
   ; supports_extended_thinking = true
   ; supports_reasoning_budget = true
+  ; thinking_control_format = Reasoning_effort
   ; supports_top_k = true
   ; supports_min_p = true
   }
@@ -247,6 +255,7 @@ let dashscope_capabilities =
   { openai_chat_extended_capabilities with
     supports_tool_choice = true
   ; supports_min_p = true
+  ; thinking_control_format = Enable_thinking
   }
 ;;
 

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -8,7 +8,10 @@
 
 type thinking_control_format =
   | No_thinking_control (** No thinking control supported *)
-  | Thinking_object (** DeepSeek-style: {"thinking":{"type":"enabled"}} *)
+  | Thinking_object
+  (** DeepSeek-style: top-level [thinking] object plus [reasoning_effort]. *)
+  | Thinking_object_only
+  (** Kimi K2.5-style: top-level [thinking] object without [reasoning_effort]. *)
   | Chat_template_kwargs
   (** llama-server style: {"chat_template_kwargs":{"enable_thinking":b}} *)
   | Reasoning_effort
@@ -17,6 +20,9 @@ type thinking_control_format =
       see {!Provider_config.effort_of_thinking_config}. (OpenAI's spec
       also accepts ["minimal"], but no current OAS request builder emits
       it.) Ollama's OpenAI-compatible mode uses this shape. *)
+  | Enable_thinking
+  (** DashScope-style top-level [enable_thinking] bool plus optional
+      [thinking_budget]. *)
 
 type capabilities =
   { (* Numeric limits *)

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -201,15 +201,21 @@ let parse_thinking_control_format = function
      | "none" | "no_thinking_control" | "no-thinking-control" ->
        Ok (Some Capabilities.No_thinking_control)
      | "thinking_object" | "thinking-object" -> Ok (Some Capabilities.Thinking_object)
+     | "thinking_object_only"
+     | "thinking-object-only"
+     | "thinking_object_plain"
+     | "thinking-object-plain" -> Ok (Some Capabilities.Thinking_object_only)
      | "chat_template_kwargs" | "chat-template-kwargs" ->
        Ok (Some Capabilities.Chat_template_kwargs)
      | "reasoning_effort" | "reasoning-effort" -> Ok (Some Capabilities.Reasoning_effort)
+     | "enable_thinking" | "enable-thinking" -> Ok (Some Capabilities.Enable_thinking)
      | other ->
        Error
          (Printf.sprintf
             "unknown thinking_control_format %S (canonical: none, thinking_object, \
-             chat_template_kwargs, reasoning_effort; dashed and full-word aliases also \
-             accepted, e.g. no_thinking_control, thinking-object)"
+             thinking_object_only, chat_template_kwargs, reasoning_effort, \
+             enable_thinking; dashed and full-word aliases also accepted, e.g. \
+             no_thinking_control, thinking-object)"
             other))
 ;;
 

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -277,7 +277,7 @@ let glm_defaults =
 let glm_coding_defaults =
   { kind = Glm
   ; base_url = env_or_default "ZAI_CODING_BASE_URL" Zai_catalog.coding_base_url
-  ; api_key_env = "ZAI_API_KEY"
+  ; api_key_env = "ZAI_CODING_API_KEY"
   ; request_path = "/chat/completions"
   }
 ;;

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -56,8 +56,10 @@ type modality =
 type thinking_control_format = Llm_provider.Capabilities.thinking_control_format =
   | No_thinking_control
   | Thinking_object
+  | Thinking_object_only (** @since 0.196.11 *)
   | Chat_template_kwargs
   | Reasoning_effort (** @since 0.195.0 *)
+  | Enable_thinking (** @since 0.196.11 *)
 
 type capabilities =
   { max_context_tokens : int option

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -23,6 +23,10 @@ let check_contains label s sub =
   then Alcotest.failf "%s: expected %S to contain %S" label s sub
 ;;
 
+let check_thinking_control label expected actual =
+  check bool label true (actual = expected)
+;;
+
 let with_temp_manifest contents f =
   let path = Filename.temp_file "oas-capability-manifest" ".json" in
   let oc = open_out path in
@@ -91,6 +95,10 @@ let test_openai_capabilities () =
 let test_openai_extended () =
   let c = Capabilities.openai_chat_extended_capabilities in
   check bool "has reasoning" true c.supports_reasoning;
+  check_thinking_control
+    "uses reasoning_effort"
+    Capabilities.Reasoning_effort
+    c.thinking_control_format;
   check bool "has top_k" true c.supports_top_k;
   check bool "has min_p" true c.supports_min_p
 ;;
@@ -271,6 +279,10 @@ let test_lookup_kimi_k2_cloud () =
     check (option int) "output 32K" (Some 32_768) c.max_output_tokens;
     check bool "tools" true c.supports_tools;
     check bool "reasoning" true c.supports_reasoning;
+    check_thinking_control
+      "thinking object only"
+      Capabilities.Thinking_object_only
+      c.thinking_control_format;
     check bool "code execution" true c.supports_code_execution
   | None -> fail "should match kimi-k2 cloud route"
 ;;
@@ -681,7 +693,36 @@ let test_dashscope_capabilities () =
   check bool "has json mode" true c.supports_response_format_json;
   check bool "has tools" true c.supports_tools;
   check bool "has tool_choice" true c.supports_tool_choice;
+  check bool "has reasoning" true c.supports_reasoning;
+  check_thinking_control
+    "enable_thinking control"
+    Capabilities.Enable_thinking
+    c.thinking_control_format;
   check bool "has min_p" true c.supports_min_p
+;;
+
+let test_openai_compat_reasoning_records_have_explicit_control () =
+  let cases =
+    [ "openai_chat_extended", Some Capabilities.openai_chat_extended_capabilities
+    ; "kimi", Some Capabilities.kimi_capabilities
+    ; "dashscope", Some Capabilities.dashscope_capabilities
+    ; "qwen3.5", Capabilities.for_model_id "qwen3.5-35b-a3b"
+    ; "deepseek-v4-flash", Capabilities.for_model_id "deepseek-v4-flash"
+    ; "nemotron-ultra", Capabilities.for_model_id "nemotron-ultra-253b"
+    ]
+  in
+  List.iter
+    (fun (label, caps) ->
+       match caps with
+       | None -> fail (Printf.sprintf "%s should resolve capabilities" label)
+       | Some (c : Capabilities.capabilities) ->
+         check bool (label ^ " supports reasoning") true c.supports_reasoning;
+         check
+           bool
+           (label ^ " has explicit thinking control")
+           true
+           (c.thinking_control_format <> Capabilities.No_thinking_control))
+    cases
 ;;
 
 (* ── Prefix ordering invariant (M01) ────────────────────── *)
@@ -795,6 +836,10 @@ let () =
         ; test_case "openai" `Quick test_openai_capabilities
         ; test_case "openai extended" `Quick test_openai_extended
         ; test_case "dashscope" `Quick test_dashscope_capabilities
+        ; test_case
+            "openai compat reasoning records have explicit control"
+            `Quick
+            test_openai_compat_reasoning_records_have_explicit_control
         ] )
     ; ( "model_lookup"
       , [ test_case "claude opus" `Quick test_lookup_claude_opus

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -371,17 +371,45 @@ let test_default_zai_base_urls () =
   let reg = Provider_registry.default () in
   (match Provider_registry.find reg "glm" with
    | Some e ->
-     check string "glm base_url" Zai_catalog.general_base_url e.defaults.base_url
+     check string "glm base_url" Zai_catalog.general_base_url e.defaults.base_url;
+     check string "glm api_key_env" "ZAI_API_KEY" e.defaults.api_key_env
    | None -> fail "glm should exist");
   (match Provider_registry.find reg "glm-coding" with
    | Some e ->
-     check string "glm-coding base_url" Zai_catalog.coding_base_url e.defaults.base_url
+     check string "glm-coding base_url" Zai_catalog.coding_base_url e.defaults.base_url;
+     check string "glm-coding api_key_env" "ZAI_CODING_API_KEY" e.defaults.api_key_env
    | None -> fail "glm-coding should exist");
   match Provider_registry.find reg "kimi" with
   | Some e ->
     check string "kimi base_url" "https://api.kimi.com/coding" e.defaults.base_url;
     check string "kimi request_path" "/v1/messages" e.defaults.request_path
   | None -> fail "kimi should exist"
+;;
+
+let test_glm_coding_api_key_env_isolated () =
+  let prev_general = Sys.getenv_opt "ZAI_API_KEY" in
+  let prev_coding = Sys.getenv_opt "ZAI_CODING_API_KEY" in
+  let restore key = function
+    | Some v -> Unix.putenv key v
+    | None -> Unix.putenv key ""
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      restore "ZAI_API_KEY" prev_general;
+      restore "ZAI_CODING_API_KEY" prev_coding)
+    (fun () ->
+       Unix.putenv "ZAI_API_KEY" "general-key";
+       Unix.putenv "ZAI_CODING_API_KEY" "";
+       let general_only = Provider_registry.default () in
+       (match Provider_registry.find general_only "glm-coding" with
+        | Some e ->
+          check bool "general key does not enable coding lane" false (e.is_available ())
+        | None -> fail "glm-coding should exist");
+       Unix.putenv "ZAI_CODING_API_KEY" "coding-key";
+       let coding = Provider_registry.default () in
+       match Provider_registry.find coding "glm-coding" with
+       | Some e -> check bool "coding key enables coding lane" true (e.is_available ())
+       | None -> fail "glm-coding should exist")
 ;;
 
 let test_blank_zai_base_urls_fall_back () =
@@ -624,6 +652,39 @@ let test_catalog_rejects_unknown_thinking_control_format () =
   | Error _ -> ()
   | Ok _ ->
     fail "unknown thinking_control_format should be rejected, not silently coerced"
+;;
+
+let test_catalog_accepts_explicit_thinking_control_formats () =
+  match
+    Provider_catalog.of_json
+      (Yojson.Safe.from_string
+         {|{
+           "schema_version": 1,
+           "providers": [
+             {"id": "kimi-k2", "kind": "openai_compat",
+              "capabilities": {"thinking_control_format": "thinking_object_only"}},
+             {"id": "dashscope", "kind": "openai_compat",
+              "capabilities": {"thinking_control_format": "enable_thinking"}},
+             {"id": "openai-reasoning", "kind": "openai_compat",
+              "capabilities": {"thinking_control_format": "reasoning_effort"}}
+           ]
+         }|})
+  with
+  | Error msg -> fail msg
+  | Ok catalog ->
+    let check_format id expected =
+      match Provider_catalog.lookup catalog id with
+      | Some entry ->
+        check
+          bool
+          (id ^ " thinking_control_format")
+          true
+          (entry.capabilities.thinking_control_format = expected)
+      | None -> fail (id ^ " should exist")
+    in
+    check_format "kimi-k2" Capabilities.Thinking_object_only;
+    check_format "dashscope" Capabilities.Enable_thinking;
+    check_format "openai-reasoning" Capabilities.Reasoning_effort
 ;;
 
 let test_catalog_lookup_first_match_wins () =
@@ -1036,6 +1097,10 @@ let () =
             test_default_max_context_matches_capabilities
         ; test_case "zai base urls" `Quick test_default_zai_base_urls
         ; test_case
+            "glm coding api key env isolated"
+            `Quick
+            test_glm_coding_api_key_env_isolated
+        ; test_case
             "blank zai base urls fall back"
             `Quick
             test_blank_zai_base_urls_fall_back
@@ -1077,6 +1142,10 @@ let () =
             "rejects unknown thinking_control_format"
             `Quick
             test_catalog_rejects_unknown_thinking_control_format
+        ; test_case
+            "accepts explicit thinking_control_format values"
+            `Quick
+            test_catalog_accepts_explicit_thinking_control_formats
         ; test_case
             "lookup first-match-wins on duplicate id"
             `Quick


### PR DESCRIPTION
## Summary
- add explicit thinking_control_format variants for Kimi-style thinking objects and DashScope enable_thinking bodies
- map OpenAI reasoning records to reasoning_effort, Kimi to thinking object only, and DashScope to enable_thinking
- separate GLM coding credential default to ZAI_CODING_API_KEY and add availability isolation tests
- add #1706 provider evidence record and provider-catalog docs for the new values

## Validation
- scripts/dune-local.sh build test/test_capabilities.exe test/test_provider_registry.exe test/test_api.exe
- ./_build/default/test/test_capabilities.exe
- ./_build/default/test/test_provider_registry.exe
- ./_build/default/test/test_api.exe
- scripts/dune-local.sh runtest lib/llm_provider
- scripts/dune-local.sh runtest lib
- git diff --cached --check

Refs #1706