### PR TITLE
ci: raise coverage ratchet threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,12 @@ jobs:
           # added without corresponding test registration. Floor set to
           # floor(22.87) = 22 per ratchet policy until test registration
           # catches up.
-          THRESHOLD=22
+          #
+          # 2026-05-24: full CI on PR #1707 measured 70.90% coverage
+          # (run 26352648077, job 77573496681). Raise the floor to
+          # floor(70.90 - 1) = 69 per #1175 ratchet policy while leaving
+          # headroom for CI/runtime noise.
+          THRESHOLD=69
           if [ "$(echo "$COVERAGE < $THRESHOLD" | bc -l)" -eq 1 ]; then
             echo "::error::Coverage ${COVERAGE}% is below threshold ${THRESHOLD}%"
             exit 1

--- a/docs/_audit/2026-05-24-coverage-ratchet-evidence.md
+++ b/docs/_audit/2026-05-24-coverage-ratchet-evidence.md
@@ -1,0 +1,32 @@
+# Coverage ratchet evidence - 2026-05-24
+
+Scope: #1175 Stage A/B correction. Current CI coverage has recovered above the
+stale 22% floor, so the workflow threshold should ratchet upward instead of
+waiting for another coverage-specific test PR.
+
+## Measurement
+
+- Evidence: GitHub Actions full CI coverage report on PR #1707.
+- Run: `26352648077`
+- Job: `77573496681`
+- Command checked: `gh run view 26352648077 --job 77573496681 --log`
+- Measured coverage: `70.90%` (`21176/29866`)
+- Timestamp: 2026-05-24 KST
+- Confidence: High
+
+## Ratchet decision
+
+- Previous threshold: `22`
+- New threshold: `69`
+- Formula: `floor(70.90 - 1) = 69`
+- Reason: preserve one percentage point of CI/runtime headroom while making the
+  recovered coverage floor enforceable.
+
+## #1175 record
+
+- Stage A target (`22 -> 40`): satisfied by this measurement.
+- Stage B target (`40 -> 60`): satisfied by this measurement.
+- Next target: Stage C (`60 -> 75`), then Stage D (`75 -> 80`).
+- Top 0% files removed in this PR: none.
+- Tests added in this PR: none; this is a ratchet correction based on an
+  already-successful full CI measurement.


### PR DESCRIPTION
## Summary
- raise the CI coverage threshold from 22 to 69 based on the latest full CI measurement
- record the #1175 ratchet evidence in docs/_audit/2026-05-24-coverage-ratchet-evidence.md
- mark Stage A and Stage B targets as satisfied by the measured 70.90% coverage

## Evidence
- Full CI run: 26352648077
- Job: 77573496681
- Measured coverage: 70.90% (21176/29866)
- New threshold: floor(70.90 - 1) = 69

## Validation
- gh run view 26352648077 --job 77573496681 --log
- bash scripts/lint-core-cdal-boundary.sh
- git diff --cached --check

Refs #1175