### PR TITLE
feat: persist runtime input-required state

### DIFF
--- a/docs/EVENT-CATALOG.md
+++ b/docs/EVENT-CATALOG.md
@@ -237,6 +237,8 @@ on **two channels simultaneously**:
 | `Session_started` | `runtime.session_started` |
 | `Session_settings_updated` | `runtime.session_settings_updated` |
 | `Turn_recorded` | `runtime.turn_recorded` |
+| `Input_required` | `runtime.input_required` |
+| `Input_provided` | `runtime.input_provided` |
 | `Agent_spawn_requested` | `runtime.agent_spawn_requested` |
 | `Agent_became_live` | `runtime.agent_became_live` |
 | `Agent_output_delta` | `runtime.agent_output_delta` |
@@ -257,6 +259,10 @@ different payload shapes. Disambiguate by Custom name prefix:
 **Structured completion/failure metadata**:
 - `Runtime.participant_event` now carries optional `raw_trace_run_id`,
   `stop_reason`, `completion_anomaly`, and `failure_cause`.
+- `Runtime.session.pending_input` carries the resumable `input_request`
+  while phase is `Input_required`; `Provide_input` emits
+  `Input_provided`, clears the payload, and returns the session to
+  `Running`.
 - Runtime finalization persists the operator-facing evidence set:
   `report.json`, `proof.json`, `runtime-telemetry-json`,
   `runtime-telemetry`, `runtime-raw-trace-json`, and `runtime-evidence`.

--- a/lib/internal_query_engine.ml
+++ b/lib/internal_query_engine.ml
@@ -270,6 +270,7 @@ let ensure_session state ~prompt =
        start_new ()
      | Runtime.Bootstrapping
      | Runtime.Running
+     | Runtime.Input_required
      | Runtime.Waiting_on_workers
      | Runtime.Finalizing -> Ok session)
 ;;

--- a/lib/runtime.ml
+++ b/lib/runtime.ml
@@ -1,6 +1,7 @@
 type phase =
   | Bootstrapping
   | Running
+  | Input_required
   | Waiting_on_workers
   | Finalizing
   | Completed
@@ -146,6 +147,22 @@ type artifact =
   }
 [@@deriving yojson, show]
 
+type input_request =
+  { request_id : string
+  ; participant_name : string option
+  ; question : string
+  ; schema : Yojson.Safe.t option
+  ; timeout_s : float option
+  ; created_at : float
+  }
+[@@deriving yojson, show]
+
+type input_response =
+  | Input_answer of Yojson.Safe.t
+  | Input_declined
+  | Input_timeout
+[@@deriving yojson, show]
+
 (** Runtime session — wire protocol record. *)
 type session =
   { session_id : string
@@ -164,6 +181,7 @@ type session =
   ; planned_participants : string list
   ; participants : participant list
   ; artifacts : artifact list
+  ; pending_input : input_request option [@default None]
   ; turn_count : int
   ; last_seq : int
   ; outcome : string option
@@ -242,6 +260,12 @@ type record_turn_request =
   }
 [@@deriving yojson, show]
 
+type provide_input_request =
+  { request_id : string
+  ; response : input_response
+  }
+[@@deriving yojson, show]
+
 type spawn_agent_request =
   { participant_name : string
   ; role : string option
@@ -265,6 +289,8 @@ type finalize_request = { reason : string option } [@@deriving yojson, show]
 
 type command =
   | Record_turn of record_turn_request
+  | Request_input of input_request
+  | Provide_input of provide_input_request
   | Spawn_agent of spawn_agent_request
   | Update_session_settings of update_settings_request
   | Attach_artifact of attach_artifact_request
@@ -281,6 +307,13 @@ type start_event =
 type turn_event =
   { actor : string option
   ; message : string
+  }
+[@@deriving yojson, show]
+
+type input_provided_event =
+  { request_id : string
+  ; participant_name : string option
+  ; response : input_response
   }
 [@@deriving yojson, show]
 
@@ -346,6 +379,8 @@ type event_kind =
   | Session_started of start_event
   | Session_settings_updated of update_settings_request
   | Turn_recorded of turn_event
+  | Input_required of input_request
+  | Input_provided of input_provided_event
   | Agent_spawn_requested of spawn_event
   | Agent_became_live of participant_event
   | Agent_output_delta of output_delta_event

--- a/lib/runtime.mli
+++ b/lib/runtime.mli
@@ -13,6 +13,7 @@
 type phase =
   | Bootstrapping
   | Running
+  | Input_required
   | Waiting_on_workers
   | Finalizing
   | Completed
@@ -158,6 +159,22 @@ type artifact =
   }
 [@@deriving yojson, show]
 
+type input_request =
+  { request_id : string
+  ; participant_name : string option
+  ; question : string
+  ; schema : Yojson.Safe.t option
+  ; timeout_s : float option
+  ; created_at : float
+  }
+[@@deriving yojson, show]
+
+type input_response =
+  | Input_answer of Yojson.Safe.t
+  | Input_declined
+  | Input_timeout
+[@@deriving yojson, show]
+
 (** Runtime session — wire protocol record. *)
 type session =
   { session_id : string
@@ -176,6 +193,7 @@ type session =
   ; planned_participants : string list
   ; participants : participant list
   ; artifacts : artifact list
+  ; pending_input : input_request option [@default None]
   ; turn_count : int
   ; last_seq : int
   ; outcome : string option
@@ -256,6 +274,12 @@ type record_turn_request =
   }
 [@@deriving yojson, show]
 
+type provide_input_request =
+  { request_id : string
+  ; response : input_response
+  }
+[@@deriving yojson, show]
+
 type spawn_agent_request =
   { participant_name : string
   ; role : string option
@@ -279,6 +303,8 @@ type finalize_request = { reason : string option } [@@deriving yojson, show]
 
 type command =
   | Record_turn of record_turn_request
+  | Request_input of input_request
+  | Provide_input of provide_input_request
   | Spawn_agent of spawn_agent_request
   | Update_session_settings of update_settings_request
   | Attach_artifact of attach_artifact_request
@@ -297,6 +323,13 @@ type start_event =
 type turn_event =
   { actor : string option
   ; message : string
+  }
+[@@deriving yojson, show]
+
+type input_provided_event =
+  { request_id : string
+  ; participant_name : string option
+  ; response : input_response
   }
 [@@deriving yojson, show]
 
@@ -362,6 +395,8 @@ type event_kind =
   | Session_started of start_event
   | Session_settings_updated of update_settings_request
   | Turn_recorded of turn_event
+  | Input_required of input_request
+  | Input_provided of input_provided_event
   | Agent_spawn_requested of spawn_event
   | Agent_became_live of participant_event
   | Agent_output_delta of output_delta_event

--- a/lib/runtime_client.ml
+++ b/lib/runtime_client.ml
@@ -81,6 +81,15 @@ let apply_command ?control_handler ?event_handler client ~session_id command =
             (Runtime.show_response other)))
 ;;
 
+let provide_input ?control_handler ?event_handler client ~session_id ~request_id response =
+  apply_command
+    ?control_handler
+    ?event_handler
+    client
+    ~session_id
+    (Runtime.Provide_input { request_id; response })
+;;
+
 let status client ~session_id =
   let* response = request client (Runtime.Status { session_id }) in
   match response with

--- a/lib/runtime_client.mli
+++ b/lib/runtime_client.mli
@@ -59,6 +59,15 @@ val apply_command
   -> Runtime.command
   -> (Runtime.session, Error.sdk_error) result
 
+val provide_input
+  :  ?control_handler:Transport.control_handler
+  -> ?event_handler:Transport.event_handler
+  -> t
+  -> session_id:string
+  -> request_id:string
+  -> Runtime.input_response
+  -> (Runtime.session, Error.sdk_error) result
+
 val status : t -> session_id:string -> (Runtime.session, Error.sdk_error) result
 
 val events

--- a/lib/runtime_evidence.ml
+++ b/lib/runtime_evidence.ml
@@ -147,6 +147,8 @@ let participant_and_detail_of_event = function
   | Session_started _ -> None, Some "session_started"
   | Session_settings_updated _ -> None, Some "session_settings_updated"
   | Turn_recorded detail -> detail.actor, Some detail.message
+  | Input_required detail -> detail.participant_name, Some detail.question
+  | Input_provided detail -> detail.participant_name, Some detail.request_id
   | Agent_spawn_requested detail -> Some detail.participant_name, Some detail.prompt
   | Agent_became_live detail -> Some detail.participant_name, detail.summary
   | Agent_output_delta detail -> Some detail.participant_name, Some detail.delta
@@ -182,6 +184,8 @@ let event_name_of_kind = function
   | Session_started _ -> "session_started"
   | Session_settings_updated _ -> "session_settings_updated"
   | Turn_recorded _ -> "turn_recorded"
+  | Input_required _ -> "input_required"
+  | Input_provided _ -> "input_provided"
   | Agent_spawn_requested _ -> "agent_spawn_requested"
   | Agent_became_live _ -> "agent_became_live"
   | Agent_output_delta _ -> "agent_output_delta"
@@ -200,6 +204,10 @@ let structured_fields_of_event = function
     None, None, None, detail.model, None, None, None, None, None, None, None
   | Turn_recorded detail ->
     detail.actor, None, None, None, None, None, None, None, None, None, None
+  | Input_required detail ->
+    detail.participant_name, None, None, None, None, None, None, None, None, None, None
+  | Input_provided detail ->
+    detail.participant_name, None, None, None, None, None, None, None, None, None, None
   | Agent_spawn_requested detail ->
     ( None
     , detail.role

--- a/lib/runtime_projection.ml
+++ b/lib/runtime_projection.ml
@@ -54,6 +54,7 @@ let initial_session (request : start_request) =
   ; planned_participants = request.participants
   ; participants = List.map make_planned_participant request.participants
   ; artifacts = []
+  ; pending_input = None
   ; turn_count = 0
   ; last_seq = 0
   ; outcome = None
@@ -107,7 +108,8 @@ let ensure_active_phase session =
   match session.phase with
   | Completed | Failed | Cancelled ->
     Error (Error.Internal (Printf.sprintf "Session %s is terminal" session.session_id))
-  | Bootstrapping | Running | Waiting_on_workers | Finalizing -> Ok session
+  | Bootstrapping | Running | Input_required | Waiting_on_workers | Finalizing ->
+    Ok session
 ;;
 
 let participant_presence_status_of_state = function
@@ -175,6 +177,35 @@ let collaboration_events_of_event (event : event) =
         ~severity:Severity_low
         ~title:"turn recorded"
         ~summary:detail.message
+        ()
+    ]
+  | Input_required detail ->
+    [ system_event
+        ~severity:Severity_normal
+        ~status:"input_required"
+        ~summary:detail.question
+        "runtime_session"
+    ; activity_event
+        ?actor:detail.participant_name
+        ~category:Activity_coordination
+        ~severity:Severity_normal
+        ~title:"input required"
+        ~summary:detail.question
+        ~subject:detail.request_id
+        ()
+    ]
+  | Input_provided detail ->
+    [ system_event
+        ~severity:Severity_normal
+        ~status:"running"
+        ~summary:detail.request_id
+        "runtime_session"
+    ; activity_event
+        ?actor:detail.participant_name
+        ~category:Activity_coordination
+        ~severity:Severity_low
+        ~title:"input provided"
+        ~subject:detail.request_id
         ()
     ]
   | Agent_spawn_requested detail ->
@@ -294,12 +325,36 @@ let failure_cause_message = function
 let apply_event (session : session) (event : event) =
   let session = update_session_meta session event in
   match event.kind with
-  | Session_started _ -> Ok { session with phase = Running }
+  | Session_started _ -> Ok { session with phase = Running; pending_input = None }
   | Session_settings_updated detail ->
     Ok { session with model = detail.model; permission_mode = detail.permission_mode }
   | Turn_recorded _ ->
     let* session = ensure_active_phase session in
     Ok { session with turn_count = session.turn_count + 1 }
+  | Input_required detail ->
+    let* session = ensure_active_phase session in
+    Ok { session with phase = Input_required; pending_input = Some detail }
+  | Input_provided detail ->
+    let* session = ensure_active_phase session in
+    (match session.pending_input with
+     | Some pending when String.equal pending.request_id detail.request_id ->
+       Ok
+         { session with
+           phase = Running
+         ; pending_input = None
+         ; turn_count = session.turn_count + 1
+         }
+     | Some pending ->
+       Error
+         (Error.Internal
+            (Printf.sprintf
+               "Input response %s does not match pending request %s"
+               detail.request_id
+               pending.request_id))
+     | None ->
+       Error
+         (Error.Internal
+            (Printf.sprintf "Input response %s has no pending request" detail.request_id)))
   | Agent_spawn_requested detail ->
     let* session = ensure_active_phase session in
     Ok
@@ -448,11 +503,23 @@ let apply_event (session : session) (event : event) =
     Ok session
   | Finalize_requested detail ->
     let* session = ensure_active_phase session in
-    Ok { session with phase = Finalizing; outcome = detail.reason }
+    Ok { session with phase = Finalizing; pending_input = None; outcome = detail.reason }
   | Session_completed detail ->
-    Ok { session with phase = Completed; outcome = detail.outcome; updated_at = event.ts }
+    Ok
+      { session with
+        phase = Completed
+      ; pending_input = None
+      ; outcome = detail.outcome
+      ; updated_at = event.ts
+      }
   | Session_failed detail ->
-    Ok { session with phase = Failed; outcome = detail.outcome; updated_at = event.ts }
+    Ok
+      { session with
+        phase = Failed
+      ; pending_input = None
+      ; outcome = detail.outcome
+      ; updated_at = event.ts
+      }
 ;;
 
 let count_by_state target (session : session) =
@@ -531,7 +598,7 @@ let build_proof (session : session) (events : event list) =
   let has_turn =
     List.exists
       (function
-        | { kind = Turn_recorded _; _ } -> true
+        | { kind = Turn_recorded _ | Input_provided _; _ } -> true
         | _ -> false)
       events
   in
@@ -545,7 +612,7 @@ let build_proof (session : session) (events : event list) =
   let finalized =
     match session.phase with
     | Completed | Failed | Cancelled -> true
-    | Bootstrapping | Running | Waiting_on_workers | Finalizing -> false
+    | Bootstrapping | Running | Input_required | Waiting_on_workers | Finalizing -> false
   in
   let has_session_started =
     List.exists

--- a/lib/runtime_projection.mli
+++ b/lib/runtime_projection.mli
@@ -11,7 +11,7 @@
 
 (** Create an initial session from a start request.
     Sets phase to [Bootstrapping], turn count to 0, and
-    initialises participants as [Planned]. *)
+    initialises participants as [Planned] with no pending input. *)
 val initial_session : Runtime.start_request -> Runtime.session
 
 (** Apply a single event to a session, evolving its state.

--- a/lib/runtime_server.ml
+++ b/lib/runtime_server.ml
@@ -485,7 +485,7 @@ let finalize_session state store (session : session) reason =
   let* session, _ =
     match session.phase with
     | Finalizing -> Ok (session, make_event session (Finalize_requested { reason }))
-    | Bootstrapping | Running | Waiting_on_workers ->
+    | Bootstrapping | Running | Input_required | Waiting_on_workers ->
       persist_event store state session_id (Finalize_requested { reason })
     | Completed | Failed | Cancelled ->
       Ok (session, make_event session (Session_completed { outcome = session.outcome }))
@@ -494,7 +494,7 @@ let finalize_session state store (session : session) reason =
     match session.phase with
     | Failed -> Session_failed { outcome = reason }
     | Completed | Cancelled -> Session_completed { outcome = session.outcome }
-    | Bootstrapping | Running | Waiting_on_workers | Finalizing ->
+    | Bootstrapping | Running | Input_required | Waiting_on_workers | Finalizing ->
       Session_completed { outcome = first_some reason session.outcome }
   in
   let* _final_session, _ = persist_event store state session_id completion_kind in
@@ -516,6 +516,42 @@ let apply_command ~sw state store (session : session) command =
         (Turn_recorded { actor = detail.actor; message = detail.message })
     in
     Ok (Command_applied session)
+  | Request_input detail ->
+    if String.trim detail.request_id = ""
+    then Error (Error.Internal "input request_id must be non-empty")
+    else
+      let* session, _ = persist_event store state session_id (Input_required detail) in
+      Ok (Command_applied session)
+  | Provide_input detail ->
+    with_store_lock state (fun () ->
+      let* session = Runtime_store.load_session store session_id in
+      match session.pending_input with
+      | None ->
+        Error
+          (Error.Internal
+             (Printf.sprintf
+                "cannot provide input %s: no pending input request"
+                detail.request_id))
+      | Some pending when not (String.equal pending.request_id detail.request_id) ->
+        Error
+          (Error.Internal
+             (Printf.sprintf
+                "cannot provide input %s: pending request is %s"
+                detail.request_id
+                pending.request_id))
+      | Some pending ->
+        let* session, _ =
+          persist_event_locked
+            store
+            state
+            session
+            (Input_provided
+               { request_id = detail.request_id
+               ; participant_name = pending.participant_name
+               ; response = detail.response
+               })
+        in
+        Ok (Command_applied session))
   | Update_session_settings detail ->
     let* session, _ =
       persist_event store state session_id (Session_settings_updated detail)
@@ -789,6 +825,7 @@ let handle_request ~sw state request =
              [ "initialize"
              ; "start_session"
              ; "apply_command"
+             ; "input_required"
              ; "status"
              ; "events"
              ; "finalize"

--- a/lib/runtime_server_types.ml
+++ b/lib/runtime_server_types.ml
@@ -43,6 +43,8 @@ let custom_name_of_kind = function
   | Session_started _ -> "runtime.session_started"
   | Session_settings_updated _ -> "runtime.session_settings_updated"
   | Turn_recorded _ -> "runtime.turn_recorded"
+  | Input_required _ -> "runtime.input_required"
+  | Input_provided _ -> "runtime.input_provided"
   | Agent_spawn_requested _ -> "runtime.agent_spawn_requested"
   | Agent_became_live _ -> "runtime.agent_became_live"
   | Agent_output_delta _ -> "runtime.agent_output_delta"
@@ -67,6 +69,8 @@ let event_bus_run_id_of_event (event : event) =
   | Session_started _
   | Session_settings_updated _
   | Turn_recorded _
+  | Input_required _
+  | Input_provided _
   | Agent_spawn_requested _
   | Agent_output_delta _
   | Artifact_attached _

--- a/test/test_agent_cancellation_tla_parity.ml
+++ b/test/test_agent_cancellation_tla_parity.ml
@@ -2,7 +2,7 @@
 
    OCaml mirror predicate for the AgentCancellation.tla spec.
    Validates that Runtime.phase values align with the TLA+ model:
-   - 7-state alphabet
+   - 8-state alphabet
    - 3 terminal phases (Completed, Failed, Cancelled)
    - TerminalIsStable: terminal -> non-terminal is disallowed
    - CancelledRequiresSignal: implied by construction (Cancelled is terminal)
@@ -15,6 +15,7 @@ open Agent_sdk
 let all_phases =
   [ Runtime.Bootstrapping
   ; Runtime.Running
+  ; Runtime.Input_required
   ; Runtime.Waiting_on_workers
   ; Runtime.Finalizing
   ; Runtime.Completed
@@ -28,6 +29,7 @@ let terminal_phases = [ Runtime.Completed; Runtime.Failed; Runtime.Cancelled ]
 let non_terminal_phases =
   [ Runtime.Bootstrapping
   ; Runtime.Running
+  ; Runtime.Input_required
   ; Runtime.Waiting_on_workers
   ; Runtime.Finalizing
   ]
@@ -42,15 +44,15 @@ let terminal_is_stable ~prev_phase ~phase =
 
 (* Mirror of TLA+ CancelledIsTerminal *)
 let cancelled_is_terminal () = List.mem Runtime.Cancelled terminal_phases
-let phase_count_matches () = List.length all_phases = 7
+let phase_count_matches () = List.length all_phases = 8
 let terminal_count_matches () = List.length terminal_phases = 3
 
 let () =
   Alcotest.run
     "agent_cancellation_tla_parity"
     [ ( "invariants"
-      , [ Alcotest.test_case "phase count is 7" `Quick (fun () ->
-            Alcotest.(check bool) "7 phases" true (phase_count_matches ()))
+      , [ Alcotest.test_case "phase count is 8" `Quick (fun () ->
+            Alcotest.(check bool) "8 phases" true (phase_count_matches ()))
         ; Alcotest.test_case "terminal count is 3" `Quick (fun () ->
             Alcotest.(check bool) "3 terminal" true (terminal_count_matches ()))
         ; Alcotest.test_case "Cancelled is terminal" `Quick (fun () ->

--- a/test/test_deep_coverage.ml
+++ b/test/test_deep_coverage.ml
@@ -137,6 +137,7 @@ let test_session_info_all_phases () =
   let phases =
     [ Runtime.Bootstrapping
     ; Running
+    ; Input_required
     ; Waiting_on_workers
     ; Finalizing
     ; Completed

--- a/test/test_runtime.ml
+++ b/test/test_runtime.ml
@@ -201,6 +201,146 @@ let test_runtime_client_roundtrip () =
        Alcotest.(check bool) "last seq progressed" true (status.last_seq >= 3))
 ;;
 
+let test_runtime_input_required_resume () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let mgr = Eio.Stdenv.process_mgr env in
+  with_temp_dir
+  @@ fun session_root ->
+  let runtime = runtime_path () in
+  let start_request =
+    Runtime.
+      { session_id = Some "sess-input-required"
+      ; goal = "Pause for human input"
+      ; participants = [ "planner" ]
+      ; provider = Some "mock"
+      ; model = None
+      ; permission_mode = Some "default"
+      ; system_prompt = None
+      ; max_turns = Some 3
+      ; workdir = None
+      }
+  in
+  let session =
+    match
+      unwrap_response
+        (runtime_query
+           ~sw
+           ~mgr
+           ~runtime_path:runtime
+           ~session_root
+           (Runtime.Start_session start_request))
+    with
+    | Runtime.Session_started_response session -> session
+    | other -> Alcotest.fail (Runtime.show_response other)
+  in
+  let input_request : Runtime.input_request =
+    { request_id = "input-1"
+    ; participant_name = Some "planner"
+    ; question = "Which deployment environment?"
+    ; schema = Some (`Assoc [ "type", `String "string" ])
+    ; timeout_s = Some 30.0
+    ; created_at = 123.0
+    }
+  in
+  let waiting =
+    match
+      unwrap_response
+        (runtime_query
+           ~sw
+           ~mgr
+           ~runtime_path:runtime
+           ~session_root
+           (Runtime.Apply_command
+              { session_id = session.session_id
+              ; command = Runtime.Request_input input_request
+              }))
+    with
+    | Runtime.Command_applied session -> session
+    | other -> Alcotest.fail (Runtime.show_response other)
+  in
+  Alcotest.(check bool)
+    "phase input_required"
+    true
+    (waiting.phase = Runtime.Input_required);
+  (match waiting.pending_input with
+   | Some pending ->
+     Alcotest.(check string) "pending request id" "input-1" pending.request_id;
+     Alcotest.(check string) "pending question" input_request.question pending.question
+   | None -> Alcotest.fail "missing pending input");
+  let status =
+    match
+      unwrap_response
+        (runtime_query
+           ~sw
+           ~mgr
+           ~runtime_path:runtime
+           ~session_root
+           (Runtime.Status { session_id = session.session_id }))
+    with
+    | Runtime.Status_response session -> session
+    | other -> Alcotest.fail (Runtime.show_response other)
+  in
+  Alcotest.(check bool) "status keeps pending" true (Option.is_some status.pending_input);
+  let resumed =
+    match
+      unwrap_response
+        (runtime_query
+           ~sw
+           ~mgr
+           ~runtime_path:runtime
+           ~session_root
+           (Runtime.Apply_command
+              { session_id = session.session_id
+              ; command =
+                  Runtime.Provide_input
+                    { request_id = "input-1"
+                    ; response = Runtime.Input_answer (`String "production")
+                    }
+              }))
+    with
+    | Runtime.Command_applied session -> session
+    | other -> Alcotest.fail (Runtime.show_response other)
+  in
+  Alcotest.(check bool) "phase running" true (resumed.phase = Runtime.Running);
+  Alcotest.(check bool) "pending cleared" true (Option.is_none resumed.pending_input);
+  Alcotest.(check int) "input counted as turn" 1 resumed.turn_count;
+  let events =
+    match
+      unwrap_response
+        (runtime_query
+           ~sw
+           ~mgr
+           ~runtime_path:runtime
+           ~session_root
+           (Runtime.Events { session_id = session.session_id; after_seq = None }))
+    with
+    | Runtime.Events_response events -> events
+    | other -> Alcotest.fail (Runtime.show_response other)
+  in
+  Alcotest.(check bool)
+    "input required event persisted"
+    true
+    (List.exists
+       (fun (event : Runtime.event) ->
+          match event.kind with
+          | Runtime.Input_required request ->
+            String.equal request.request_id input_request.request_id
+          | _ -> false)
+       events);
+  Alcotest.(check bool)
+    "input provided event persisted"
+    true
+    (List.exists
+       (fun (event : Runtime.event) ->
+          match event.kind with
+          | Runtime.Input_provided detail -> String.equal detail.request_id "input-1"
+          | _ -> false)
+       events)
+;;
+
 let test_runtime_attach_artifact_and_read_back () =
   Eio_main.run
   @@ fun env ->
@@ -1079,6 +1219,12 @@ let () =
       , [ Alcotest.test_case "local first options" `Quick test_default_local_first_options
         ] )
     ; "query", [ Alcotest.test_case "lifecycle" `Quick test_query_lifecycle ]
+    ; ( "input_required"
+      , [ Alcotest.test_case
+            "request input then resume"
+            `Quick
+            test_runtime_input_required_resume
+        ] )
     ; ( "artifacts"
       , [ Alcotest.test_case
             "attach artifact and read back"

--- a/test/test_runtime_projection_cov2.ml
+++ b/test/test_runtime_projection_cov2.ml
@@ -36,6 +36,7 @@ let mk_session
       ?(phase = Runtime.Running)
       ?(participants = [])
       ?(artifacts = [])
+      ?(pending_input = None)
       ?(outcome = None)
       ?(turn_count = 0)
       ?(last_seq = 0)
@@ -58,6 +59,7 @@ let mk_session
   ; planned_participants = List.map (fun (p : Runtime.participant) -> p.name) participants
   ; participants
   ; artifacts
+  ; pending_input
   ; turn_count
   ; last_seq
   ; outcome
@@ -137,6 +139,14 @@ let test_turn_on_running_ok () =
   match Runtime_projection.apply_event session event with
   | Ok _ -> ()
   | Error _ -> Alcotest.fail "Running should accept turns"
+;;
+
+let test_turn_on_input_required_ok () =
+  let session = mk_session ~phase:Input_required () in
+  let event = mk_event (Turn_recorded { actor = None; message = "x" }) in
+  match Runtime_projection.apply_event session event with
+  | Ok _ -> ()
+  | Error _ -> Alcotest.fail "Input_required should accept resume turns"
 ;;
 
 let test_turn_on_bootstrapping_ok () =
@@ -307,6 +317,67 @@ let test_apply_turn_recorded () =
   match Runtime_projection.apply_event session event with
   | Ok s -> Alcotest.(check int) "turn_count" 3 s.turn_count
   | Error e -> Alcotest.fail (Error.to_string e)
+;;
+
+let input_request ?(request_id = "input-1") () : Runtime.input_request =
+  { request_id
+  ; participant_name = Some "alice"
+  ; question = "Which environment?"
+  ; schema = Some (`Assoc [ "type", `String "string" ])
+  ; timeout_s = Some 30.0
+  ; created_at = 123.0
+  }
+;;
+
+let test_apply_input_required_sets_pending_payload () =
+  let session = mk_session ~phase:Running () in
+  let request = input_request () in
+  let event = mk_event (Input_required request) in
+  match Runtime_projection.apply_event session event with
+  | Ok s ->
+    Alcotest.(check bool) "phase Input_required" true (s.phase = Input_required);
+    (match s.pending_input with
+     | Some pending ->
+       Alcotest.(check string) "request_id" request.request_id pending.request_id;
+       Alcotest.(check string) "question" request.question pending.question
+     | None -> Alcotest.fail "missing pending input")
+  | Error e -> Alcotest.fail (Error.to_string e)
+;;
+
+let test_apply_input_provided_resumes_running () =
+  let request = input_request () in
+  let session = mk_session ~phase:Input_required ~pending_input:(Some request) () in
+  let event =
+    mk_event
+      (Input_provided
+         { request_id = request.request_id
+         ; participant_name = request.participant_name
+         ; response = Input_answer (`String "prod")
+         })
+  in
+  match Runtime_projection.apply_event session event with
+  | Ok s ->
+    Alcotest.(check bool) "phase Running" true (s.phase = Running);
+    Alcotest.(check bool) "pending cleared" true (Option.is_none s.pending_input);
+    Alcotest.(check int) "input counts as turn" 1 s.turn_count
+  | Error e -> Alcotest.fail (Error.to_string e)
+;;
+
+let test_apply_input_provided_rejects_mismatch () =
+  let session =
+    mk_session
+      ~phase:Input_required
+      ~pending_input:(Some (input_request ~request_id:"input-1" ()))
+      ()
+  in
+  let event =
+    mk_event
+      (Input_provided
+         { request_id = "input-2"; participant_name = None; response = Input_declined })
+  in
+  match Runtime_projection.apply_event session event with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "mismatched input response should fail"
 ;;
 
 let test_apply_turn_recorded_terminal_fails () =
@@ -777,6 +848,7 @@ let () =
         ] )
     ; ( "ensure_active_phase"
       , [ Alcotest.test_case "Running ok" `Quick test_turn_on_running_ok
+        ; Alcotest.test_case "Input_required ok" `Quick test_turn_on_input_required_ok
         ; Alcotest.test_case "Bootstrapping ok" `Quick test_turn_on_bootstrapping_ok
         ; Alcotest.test_case "Waiting ok" `Quick test_turn_on_waiting_ok
         ; Alcotest.test_case "Finalizing ok" `Quick test_turn_on_finalizing_ok
@@ -788,6 +860,18 @@ let () =
       , [ Alcotest.test_case "Session_started" `Quick test_apply_session_started
         ; Alcotest.test_case "Settings_updated" `Quick test_apply_settings_updated
         ; Alcotest.test_case "Turn_recorded" `Quick test_apply_turn_recorded
+        ; Alcotest.test_case
+            "Input_required"
+            `Quick
+            test_apply_input_required_sets_pending_payload
+        ; Alcotest.test_case
+            "Input_provided resumes"
+            `Quick
+            test_apply_input_provided_resumes_running
+        ; Alcotest.test_case
+            "Input_provided mismatch"
+            `Quick
+            test_apply_input_provided_rejects_mismatch
         ; Alcotest.test_case
             "Turn terminal fails"
             `Quick

--- a/test/test_runtime_server_resolve.ml
+++ b/test/test_runtime_server_resolve.ml
@@ -36,6 +36,7 @@ let dummy_session : Runtime.session =
   ; planned_participants = []
   ; participants = []
   ; artifacts = []
+  ; pending_input = None
   ; turn_count = 0
   ; last_seq = 0
   ; outcome = None

--- a/test/test_runtime_store_unit.ml
+++ b/test/test_runtime_store_unit.ml
@@ -132,6 +132,7 @@ let mk_session ?(session_id = "test-sess") () : Runtime.session =
   ; planned_participants = [ "agent-1" ]
   ; participants = []
   ; artifacts = []
+  ; pending_input = None
   ; turn_count = 0
   ; last_seq = 0
   ; outcome = None

--- a/test/test_runtime_types.ml
+++ b/test/test_runtime_types.ml
@@ -30,6 +30,7 @@ let test_phase () =
     Runtime.
       [ Bootstrapping
       ; Running
+      ; Input_required
       ; Waiting_on_workers
       ; Finalizing
       ; Completed
@@ -207,6 +208,7 @@ let test_session () =
           }
         ]
     ; artifacts = []
+    ; pending_input = None
     ; turn_count = 0
     ; last_seq = 0
     ; outcome = None
@@ -381,8 +383,20 @@ let test_attach_artifact_request () =
 ;;
 
 let test_command () =
+  let input_request : Runtime.input_request =
+    { request_id = "input-1"
+    ; participant_name = Some "sub"
+    ; question = "Confirm?"
+    ; schema = None
+    ; timeout_s = Some 10.0
+    ; created_at = 1.7e9
+    }
+  in
   let variants =
     [ Runtime.Record_turn { actor = Some "user"; message = "hello" }
+    ; Runtime.Request_input input_request
+    ; Runtime.Provide_input
+        { request_id = "input-1"; response = Runtime.Input_answer (`String "yes") }
     ; Runtime.Spawn_agent
         { participant_name = "sub"
         ; role = None
@@ -410,9 +424,24 @@ let test_command () =
 ;;
 
 let test_event_kind () =
+  let input_request : Runtime.input_request =
+    { request_id = "input-1"
+    ; participant_name = Some "sub"
+    ; question = "Confirm?"
+    ; schema = None
+    ; timeout_s = Some 10.0
+    ; created_at = 1.7e9
+    }
+  in
   let events =
     [ Runtime.Session_started { goal = "test"; participants = [ "a1" ] }
     ; Runtime.Turn_recorded { actor = Some "user"; message = "hi" }
+    ; Runtime.Input_required input_request
+    ; Runtime.Input_provided
+        { request_id = "input-1"
+        ; participant_name = Some "sub"
+        ; response = Runtime.Input_answer (`String "yes")
+        }
     ; Runtime.Agent_spawn_requested
         { participant_name = "sub"
         ; role = None

--- a/test/test_sessions_cov2.ml
+++ b/test/test_sessions_cov2.ml
@@ -109,6 +109,7 @@ let test_session_info_all_phases () =
     Runtime.
       [ Bootstrapping
       ; Running
+      ; Input_required
       ; Waiting_on_workers
       ; Finalizing
       ; Completed


### PR DESCRIPTION
## Summary
- add Runtime.Input_required phase, pending_input payload, and Input_required/Input_provided events
- add Request_input/Provide_input runtime commands plus Runtime_client.provide_input helper
- document runtime event names and add projection/runtime fixtures for request/resume persistence

## Validation
- scripts/dune-local.sh build bin/oas_runtime.exe test/test_runtime.exe
- scripts/dune-local.sh build test/test_runtime_types.exe test/test_runtime_projection_cov2.exe test/test_runtime_store_unit.exe test/test_runtime_server_types.exe test/test_runtime_server_resolve.exe test/test_agent_cancellation_tla_parity.exe test/test_sessions_cov2.exe
- ./_build/default/test/test_runtime.exe -q
- ./_build/default/test/test_runtime_projection_cov2.exe
- ./_build/default/test/test_runtime_types.exe
- ./_build/default/test/test_runtime_store_unit.exe
- ./_build/default/test/test_runtime_server_types.exe
- ./_build/default/test/test_runtime_server_resolve.exe
- ./_build/default/test/test_agent_cancellation_tla_parity.exe
- ./_build/default/test/test_sessions_cov2.exe
- git diff --check
- git diff --cached --check

Refs #522