### PR TITLE
feat: add runtime run window reads

### DIFF
--- a/docs/runtime-run-windows.md
+++ b/docs/runtime-run-windows.md
@@ -1,0 +1,36 @@
+# Runtime Run Windows
+
+`Runtime_store` exposes deterministic read-side windows for runtime replay.
+
+## Ordering
+
+Runs are ordered by ascending `Runtime.session.updated_at`, then ascending
+`session_id`. `Last_n_runs(n)` selects the newest `n` runs by that order and
+returns them in chronological order.
+
+## Window Selectors
+
+- `Last_n_runs(n)`: newest `n` valid runs; `n <= 0` selects no runs.
+- `Session(session_id)`: one named session, reported as a partial failure if
+  missing or corrupted.
+- `Rolling_seconds(s)`: uses the newest valid run's `updated_at` as the anchor
+  and selects runs where `updated_at >= anchor - s`; `s <= 0` selects no runs.
+
+## Partial Failures
+
+Corrupted or incomplete run directories do not fail the whole query. They are
+reported in `run_listing.failures` or `run_window_events.failures`; valid runs
+and events continue to load.
+
+## Duplicate Events
+
+`read_window_events` accepts multiple selectors. Overlapping selectors are
+deduplicated by stable event id `<session_id>#<event.seq>` before returning
+events.
+
+## Retention And Compatibility
+
+The read side only scans files currently present under the runtime session
+root. Retention is therefore store-driven: deleted run directories simply do
+not appear. Existing `Runtime.event` JSON remains the schema authority; event
+decode failures are partial failures for the affected run.

--- a/lib/runtime_store.ml
+++ b/lib/runtime_store.ml
@@ -3,6 +3,39 @@ open Result_syntax
 
 type t = { root : string }
 
+type run_record =
+  { session : session
+  ; path : string
+  }
+
+type run_load_failure =
+  { session_id : string
+  ; path : string
+  ; detail : string
+  }
+
+type run_listing =
+  { runs : run_record list
+  ; failures : run_load_failure list
+  }
+
+type run_window =
+  | Last_n_runs of int
+  | Session of string
+  | Rolling_seconds of float
+
+type run_event_record =
+  { event_id : string
+  ; session_id : string
+  ; event : event
+  }
+
+type run_window_events =
+  { runs : run_record list
+  ; events : run_event_record list
+  ; failures : run_load_failure list
+  }
+
 let sessions_dir store = Filename.concat store.root "sessions"
 let session_dir store session_id = Filename.concat (sessions_dir store) session_id
 
@@ -124,6 +157,149 @@ let load_session store session_id =
   | Yojson.Json_error detail -> Error (Error.Serialization (JsonParseError { detail }))
 ;;
 
+let compare_run_record left right =
+  match Float.compare left.session.updated_at right.session.updated_at with
+  | 0 -> String.compare left.session.session_id right.session.session_id
+  | order -> order
+;;
+
+let sort_runs runs = List.sort compare_run_record runs
+
+let run_failure store session_id detail =
+  { session_id; path = session_path store session_id; detail }
+;;
+
+let list_runs store =
+  let root = sessions_dir store in
+  if not (Sys.file_exists root)
+  then Ok { runs = []; failures = [] }
+  else
+    root
+    |> Sys.readdir
+    |> Array.to_list
+    |> List.sort String.compare
+    |> List.fold_left
+         (fun acc session_id ->
+            let ({ runs; failures } : run_listing) = acc in
+            let dir = session_dir store session_id in
+            if not (Sys.is_directory dir)
+            then acc
+            else (
+              match load_session store session_id with
+              | Ok session ->
+                { runs = { session; path = session_path store session_id } :: runs
+                ; failures
+                }
+              | Error err ->
+                { runs
+                ; failures =
+                    run_failure store session_id (Error.to_string err) :: failures
+                }))
+         ({ runs = []; failures = [] } : run_listing)
+    |> fun (listing : run_listing) ->
+    Ok
+      ({ runs = sort_runs listing.runs
+       ; failures =
+           List.sort
+             (fun (left : run_load_failure) (right : run_load_failure) ->
+                String.compare left.session_id right.session_id)
+             listing.failures
+       }
+       : run_listing)
+;;
+
+let take n xs =
+  if n <= 0
+  then []
+  else (
+    let rec loop remaining acc = function
+      | [] -> List.rev acc
+      | _ when remaining <= 0 -> List.rev acc
+      | x :: rest -> loop (remaining - 1) (x :: acc) rest
+    in
+    loop n [] xs)
+;;
+
+let select_from_listing store (listing : run_listing) = function
+  | Last_n_runs n -> listing.runs |> List.rev |> take n |> sort_runs, []
+  | Session session_id ->
+    (match
+       List.find_opt
+         (fun run -> String.equal run.session.session_id session_id)
+         listing.runs
+     with
+     | Some run -> [ run ], []
+     | None ->
+       if
+         List.exists
+           (fun (failure : run_load_failure) ->
+              String.equal failure.session_id session_id)
+           listing.failures
+       then [], []
+       else
+         ( []
+         , [ run_failure
+               store
+               session_id
+               (Printf.sprintf "session %S not found in runtime store" session_id)
+           ] ))
+  | Rolling_seconds seconds ->
+    if seconds <= 0.0
+    then [], []
+    else (
+      match List.rev listing.runs with
+      | [] -> [], []
+      | newest :: _ ->
+        let lower_bound = newest.session.updated_at -. seconds in
+        List.filter (fun run -> run.session.updated_at >= lower_bound) listing.runs, [])
+;;
+
+let dedupe_runs runs =
+  let seen = Hashtbl.create (List.length runs) in
+  runs
+  |> List.filter (fun run ->
+    let session_id = run.session.session_id in
+    if Hashtbl.mem seen session_id
+    then false
+    else (
+      Hashtbl.replace seen session_id ();
+      true))
+  |> sort_runs
+;;
+
+let dedupe_failures failures =
+  let seen = Hashtbl.create (List.length failures) in
+  failures
+  |> List.filter (fun (failure : run_load_failure) ->
+    let key = failure.session_id ^ "\x00" ^ failure.path ^ "\x00" ^ failure.detail in
+    if Hashtbl.mem seen key
+    then false
+    else (
+      Hashtbl.replace seen key ();
+      true))
+  |> List.sort (fun (left : run_load_failure) (right : run_load_failure) ->
+    match String.compare left.session_id right.session_id with
+    | 0 -> String.compare left.detail right.detail
+    | order -> order)
+;;
+
+let select_run_windows store windows =
+  let* listing = list_runs store in
+  let selected, window_failures =
+    List.fold_left
+      (fun (runs, failures) window ->
+         let window_runs, new_failures = select_from_listing store listing window in
+         window_runs @ runs, new_failures @ failures)
+      ([], [])
+      windows
+  in
+  Ok
+    ({ runs = dedupe_runs selected
+     ; failures = dedupe_failures (listing.failures @ window_failures)
+     }
+     : run_listing)
+;;
+
 let append_event store session_id (event : event) =
   let* () = ensure_tree store session_id in
   let path = events_path store session_id in
@@ -159,6 +335,59 @@ let read_events store session_id ?after_seq () =
               Error (Error.Serialization (JsonParseError { detail })))
          (Ok [])
     |> Result.map List.rev
+;;
+
+let run_event_id session_id (event : event) = Printf.sprintf "%s#%d" session_id event.seq
+
+let read_window_events store windows =
+  let* listing = select_run_windows store windows in
+  let event_seen = Hashtbl.create 64 in
+  let run_order = Hashtbl.create (List.length listing.runs) in
+  List.iteri
+    (fun index run -> Hashtbl.replace run_order run.session.session_id index)
+    listing.runs;
+  let events, event_failures =
+    List.fold_left
+      (fun (events, failures) run ->
+         let session_id = run.session.session_id in
+         match read_events store session_id () with
+         | Error err ->
+           events, run_failure store session_id (Error.to_string err) :: failures
+         | Ok loaded ->
+           let new_events =
+             loaded
+             |> List.filter_map (fun event ->
+               let event_id = run_event_id session_id event in
+               if Hashtbl.mem event_seen event_id
+               then None
+               else (
+                 Hashtbl.replace event_seen event_id ();
+                 Some { event_id; session_id; event }))
+           in
+           new_events @ events, failures)
+      ([], [])
+      listing.runs
+  in
+  Ok
+    ({ runs = listing.runs
+     ; events =
+         List.sort
+           (fun left right ->
+              match
+                Int.compare
+                  (Option.value
+                     (Hashtbl.find_opt run_order left.session_id)
+                     ~default:max_int)
+                  (Option.value
+                     (Hashtbl.find_opt run_order right.session_id)
+                     ~default:max_int)
+              with
+              | 0 -> Int.compare left.event.seq right.event.seq
+              | order -> order)
+           events
+     ; failures = dedupe_failures (listing.failures @ event_failures)
+     }
+     : run_window_events)
 ;;
 
 let snapshot_path store session_id ~seq ~label =

--- a/lib/runtime_store.mli
+++ b/lib/runtime_store.mli
@@ -9,6 +9,51 @@
 (** Store handle wrapping a root directory. *)
 type t = { root : string }
 
+(** One loadable runtime run from the store. [path] points at the canonical
+    [session.json]. Run ordering is deterministic: ascending
+    [session.updated_at], then ascending [session.session_id]. *)
+type run_record =
+  { session : Runtime.session
+  ; path : string
+  }
+
+(** Non-fatal run/window read failure. Listing APIs keep loading other runs
+    and report corrupted or incomplete directories here. *)
+type run_load_failure =
+  { session_id : string
+  ; path : string
+  ; detail : string
+  }
+
+type run_listing =
+  { runs : run_record list
+  ; failures : run_load_failure list
+  }
+
+(** Runtime replay window selector.
+
+    [Last_n_runs n] selects the newest [n] valid runs by the stable ordering,
+    then returns them in chronological order. [Rolling_seconds s] uses the
+    newest valid run's [updated_at] as the anchor and selects runs with
+    [updated_at >= anchor - s]. This makes replay deterministic and avoids
+    wall-clock-dependent tests. *)
+type run_window =
+  | Last_n_runs of int
+  | Session of string
+  | Rolling_seconds of float
+
+type run_event_record =
+  { event_id : string
+  ; session_id : string
+  ; event : Runtime.event
+  }
+
+type run_window_events =
+  { runs : run_record list
+  ; events : run_event_record list
+  ; failures : run_load_failure list
+  }
+
 (** {1 Store creation} *)
 
 val default_root : unit -> string
@@ -39,6 +84,13 @@ val load_text : string -> (string, Error.sdk_error) result
 
 val save_session : t -> Runtime.session -> (unit, Error.sdk_error) result
 val load_session : t -> string -> (Runtime.session, Error.sdk_error) result
+val list_runs : t -> (run_listing, Error.sdk_error) result
+val select_run_windows : t -> run_window list -> (run_listing, Error.sdk_error) result
+
+val read_window_events
+  :  t
+  -> run_window list
+  -> (run_window_events, Error.sdk_error) result
 
 (** {1 Event I/O} *)
 

--- a/test/test_runtime_store_unit.ml
+++ b/test/test_runtime_store_unit.ml
@@ -115,7 +115,7 @@ let test_store_create () =
 
 (* ── save_session / load_session tests ───────────────────────── *)
 
-let mk_session ?(session_id = "test-sess") () : Runtime.session =
+let mk_session ?(session_id = "test-sess") ?(updated_at = 1001.0) () : Runtime.session =
   { session_id
   ; goal = "test goal"
   ; title = None
@@ -123,7 +123,7 @@ let mk_session ?(session_id = "test-sess") () : Runtime.session =
   ; permission_mode = None
   ; phase = Running
   ; created_at = 1000.0
-  ; updated_at = 1001.0
+  ; updated_at
   ; provider = Some "anthropic"
   ; model = Some "test-model"
   ; system_prompt = None
@@ -185,14 +185,172 @@ let test_load_session_corrupt () =
        | Error _ -> ()))
 ;;
 
-(* ── append_event / read_events tests ────────────────────────── *)
-
 let mk_event seq =
   { Runtime.seq
   ; ts = float_of_int seq
   ; kind = Turn_recorded { actor = Some "agent"; message = Printf.sprintf "turn %d" seq }
   }
 ;;
+
+let save_run store session_id updated_at =
+  let session = mk_session ~session_id ~updated_at () in
+  match Runtime_store.save_session store session with
+  | Ok () -> session
+  | Error e -> Alcotest.fail (Error.to_string e)
+;;
+
+let corrupt_run store session_id =
+  let sess_dir = Runtime_store.session_dir store session_id in
+  (match Runtime_store.ensure_dir sess_dir with
+   | Ok () -> ()
+   | Error e -> Alcotest.fail (Error.to_string e));
+  let oc = open_out (Runtime_store.session_path store session_id) in
+  output_string oc "{not-json";
+  close_out oc
+;;
+
+let test_list_runs_stable_updated_at_order () =
+  with_temp_dir (fun dir ->
+    let root = Filename.concat dir "store" in
+    match Runtime_store.create ~root () with
+    | Error e -> Alcotest.fail (Error.to_string e)
+    | Ok store ->
+      ignore (save_run store "run-c" 30.0);
+      ignore (save_run store "run-a" 10.0);
+      ignore (save_run store "run-b" 20.0);
+      (match Runtime_store.list_runs store with
+       | Error e -> Alcotest.fail (Error.to_string e)
+       | Ok listing ->
+         Alcotest.(check (list string))
+           "updated_at ordering"
+           [ "run-a"; "run-b"; "run-c" ]
+           (List.map
+              (fun (run : Runtime_store.run_record) -> run.session.session_id)
+              listing.runs);
+         Alcotest.(check int) "no failures" 0 (List.length listing.failures)))
+;;
+
+let test_list_runs_reports_corrupt_without_dropping_valid_runs () =
+  with_temp_dir (fun dir ->
+    let root = Filename.concat dir "store" in
+    match Runtime_store.create ~root () with
+    | Error e -> Alcotest.fail (Error.to_string e)
+    | Ok store ->
+      ignore (save_run store "run-ok" 10.0);
+      corrupt_run store "run-bad";
+      (match Runtime_store.list_runs store with
+       | Error e -> Alcotest.fail (Error.to_string e)
+       | Ok listing ->
+         Alcotest.(check (list string))
+           "valid runs"
+           [ "run-ok" ]
+           (List.map
+              (fun (run : Runtime_store.run_record) -> run.session.session_id)
+              listing.runs);
+         Alcotest.(check int) "one partial failure" 1 (List.length listing.failures);
+         (match listing.failures with
+          | [ failure ] ->
+            Alcotest.(check string) "failure session" "run-bad" failure.session_id
+          | _ -> Alcotest.fail "expected one failure")))
+;;
+
+let test_select_run_windows_variants () =
+  with_temp_dir (fun dir ->
+    let root = Filename.concat dir "store" in
+    match Runtime_store.create ~root () with
+    | Error e -> Alcotest.fail (Error.to_string e)
+    | Ok store ->
+      ignore (save_run store "run-a" 10.0);
+      ignore (save_run store "run-b" 20.0);
+      ignore (save_run store "run-c" 30.0);
+      let ids (listing : Runtime_store.run_listing) =
+        List.map
+          (fun (run : Runtime_store.run_record) -> run.session.session_id)
+          listing.Runtime_store.runs
+      in
+      (match Runtime_store.select_run_windows store [ Runtime_store.Last_n_runs 2 ] with
+       | Ok listing ->
+         Alcotest.(check (list string)) "last n" [ "run-b"; "run-c" ] (ids listing)
+       | Error e -> Alcotest.fail (Error.to_string e));
+      (match Runtime_store.select_run_windows store [ Runtime_store.Session "run-a" ] with
+       | Ok listing -> Alcotest.(check (list string)) "session" [ "run-a" ] (ids listing)
+       | Error e -> Alcotest.fail (Error.to_string e));
+      (match
+         Runtime_store.select_run_windows store [ Runtime_store.Rolling_seconds 15.0 ]
+       with
+       | Ok listing ->
+         Alcotest.(check (list string))
+           "rolling seconds"
+           [ "run-b"; "run-c" ]
+           (ids listing)
+       | Error e -> Alcotest.fail (Error.to_string e)))
+;;
+
+let test_select_run_windows_corrupt_session_is_single_partial_failure () =
+  with_temp_dir (fun dir ->
+    let root = Filename.concat dir "store" in
+    match Runtime_store.create ~root () with
+    | Error e -> Alcotest.fail (Error.to_string e)
+    | Ok store ->
+      ignore (save_run store "run-ok" 10.0);
+      corrupt_run store "run-bad";
+      (match
+         Runtime_store.select_run_windows store [ Runtime_store.Session "run-bad" ]
+       with
+       | Error e -> Alcotest.fail (Error.to_string e)
+       | Ok listing ->
+         Alcotest.(check int) "no selected corrupt run" 0 (List.length listing.runs);
+         Alcotest.(check int) "single failure" 1 (List.length listing.failures);
+         (match listing.failures with
+          | [ failure ] ->
+            Alcotest.(check string) "failure session" "run-bad" failure.session_id
+          | _ -> Alcotest.fail "expected one failure")))
+;;
+
+let test_read_window_events_dedupes_overlapping_windows () =
+  with_temp_dir (fun dir ->
+    let root = Filename.concat dir "store" in
+    match Runtime_store.create ~root () with
+    | Error e -> Alcotest.fail (Error.to_string e)
+    | Ok store ->
+      ignore (save_run store "run-a" 10.0);
+      ignore (save_run store "run-b" 20.0);
+      let append session_id seq =
+        match Runtime_store.append_event store session_id (mk_event seq) with
+        | Ok () -> ()
+        | Error e -> Alcotest.fail (Error.to_string e)
+      in
+      append "run-a" 1;
+      append "run-b" 1;
+      append "run-b" 2;
+      (match
+         Runtime_store.read_window_events
+           store
+           [ Runtime_store.Last_n_runs 2
+           ; Runtime_store.Session "run-b"
+           ; Runtime_store.Rolling_seconds 5.0
+           ]
+       with
+       | Error e -> Alcotest.fail (Error.to_string e)
+       | Ok window ->
+         let event_ids =
+           List.map
+             (fun (record : Runtime_store.run_event_record) -> record.event_id)
+             window.events
+         in
+         let unique_ids = List.sort_uniq String.compare event_ids in
+         Alcotest.(check (list string))
+           "event order"
+           [ "run-a#1"; "run-b#1"; "run-b#2" ]
+           event_ids;
+         Alcotest.(check int)
+           "0 duplicate event ids"
+           (List.length event_ids)
+           (List.length unique_ids);
+         Alcotest.(check int) "no failures" 0 (List.length window.failures)))
+;;
+
+(* ── append_event / read_events tests ────────────────────────── *)
 
 let test_append_and_read_events () =
   with_temp_dir (fun dir ->
@@ -363,6 +521,25 @@ let () =
       , [ Alcotest.test_case "save and load" `Quick test_save_load_session
         ; Alcotest.test_case "missing" `Quick test_load_session_missing
         ; Alcotest.test_case "corrupt" `Quick test_load_session_corrupt
+        ] )
+    ; ( "runs"
+      , [ Alcotest.test_case
+            "stable updated_at ordering"
+            `Quick
+            test_list_runs_stable_updated_at_order
+        ; Alcotest.test_case
+            "corrupt run is partial failure"
+            `Quick
+            test_list_runs_reports_corrupt_without_dropping_valid_runs
+        ; Alcotest.test_case "window selectors" `Quick test_select_run_windows_variants
+        ; Alcotest.test_case
+            "corrupt selected run is one partial failure"
+            `Quick
+            test_select_run_windows_corrupt_session_is_single_partial_failure
+        ; Alcotest.test_case
+            "overlapping windows dedupe events"
+            `Quick
+            test_read_window_events_dedupes_overlapping_windows
         ] )
     ; ( "events"
       , [ Alcotest.test_case "append and read" `Quick test_append_and_read_events


### PR DESCRIPTION
## Summary

- Add deterministic `Runtime_store.list_runs` with stable `updated_at`/`session_id` ordering and non-fatal load failures.
- Add `Last_n_runs`, `Session`, and `Rolling_seconds` selectors plus overlapping-window event reads with stable event ID dedupe.
- Document runtime run window semantics and cover ordering, corruption, selector, and duplicate-event cases in focused unit tests.

Refs #484

## Validation

- `opam exec -- ocamlformat -i lib/runtime_store.ml lib/runtime_store.mli test/test_runtime_store_unit.ml`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/feat-runtime-run-windows-20260524 -j 2 test/test_runtime_store_unit.exe`
- `./_build/default/test/test_runtime_store_unit.exe` (23 tests)
- `git diff --check`
- `git diff --cached --check`

Note: `scripts/dune-local.sh build test/test_runtime_store_unit.exe` was attempted but could not acquire `/tmp/me-dune-local.lock` because another local MASC build held the shared wrapper lock; the direct focused Dune build above passed in this worktree.