### PR TITLE
test: cover runtime evidence hotspots

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -167,6 +167,7 @@ module Eval_report = Eval_report
 module Eval_stats = Eval_stats
 module Defaults = Defaults
 module Runtime_store = Runtime_store
+module Runtime_evidence = Runtime_evidence
 module Runtime_server_types = Runtime_server_types
 module Runtime_server_resolve = Runtime_server_resolve
 module Runtime_health = Runtime_health

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -136,6 +136,7 @@ module Eval_report = Eval_report
 module Eval_stats = Eval_stats
 module Defaults = Defaults
 module Runtime_store = Runtime_store
+module Runtime_evidence = Runtime_evidence
 module Runtime_server_types = Runtime_server_types
 module Runtime_server_resolve = Runtime_server_resolve
 module Runtime_health = Runtime_health

--- a/test/dune
+++ b/test/dune
@@ -172,6 +172,7 @@
   test_request_priority
   test_retry
   test_runtime
+  test_runtime_evidence
   test_runtime_projection_cov2
   test_runtime_server_resolve
   test_runtime_server_types
@@ -388,6 +389,7 @@
   test_request_priority
   test_retry
   test_runtime
+  test_runtime_evidence
   test_runtime_projection_cov2
   test_runtime_server_resolve
   test_runtime_server_types

--- a/test/test_backend_tool_call_harness.ml
+++ b/test/test_backend_tool_call_harness.ml
@@ -1,5 +1,6 @@
 open Alcotest
 module H = Llm_provider.Backend_tool_call_harness
+module T = Llm_provider.Types
 
 let malformed_openai_response = `Assoc [ "choices", `String "not-a-list" ]
 
@@ -42,6 +43,105 @@ let test_openai_text_response_is_ok_empty_validation () =
     check int "no tool calls found" 0 (List.length result.tool_calls_found)
 ;;
 
+let mk_response ?(stop_reason = T.StopToolUse) content : T.api_response =
+  { id = "resp"; model = "model"; stop_reason; content; usage = None; telemetry = None }
+;;
+
+let test_schema_validation_reports_nested_violations () =
+  let schema =
+    `Assoc
+      [ "type", `String "object"
+      ; "required", `List [ `String "path"; `String "limit"; `String "tags" ]
+      ; ( "properties"
+        , `Assoc
+            [ "path", `Assoc [ "type", `String "string" ]
+            ; "limit", `Assoc [ "type", `String "integer" ]
+            ; ( "tags"
+              , `Assoc
+                  [ "type", `String "array"
+                  ; "items", `Assoc [ "type", `String "string" ]
+                  ] )
+            ; "mode", `Assoc [ "enum", `List [ `String "fast"; `String "safe" ] ]
+            ] )
+      ]
+  in
+  let response =
+    mk_response
+      [ T.ToolUse
+          { id = "call-1"
+          ; name = "read_file"
+          ; input =
+              `Assoc
+                [ "limit", `Float 1.5
+                ; "tags", `List [ `String "src"; `Int 1 ]
+                ; "mode", `String "slow"
+                ]
+          }
+      ; T.Text ""
+      ]
+  in
+  let result =
+    H.validate_response_with_schemas
+      ~declared_tools:[ "read_file" ]
+      ~tool_schemas:[ "read_file", schema ]
+      response
+  in
+  check bool "stop reason ok" true result.stop_reason_correct;
+  check bool "declared" true result.all_tools_declared;
+  check int "dropped empty text" 1 result.dropped_content_blocks;
+  match result.tool_calls_found with
+  | [ call ] ->
+    check bool "invalid arguments" false call.arguments_valid;
+    check int "violations" 4 (List.length call.violations);
+    check
+      (list string)
+      "paths"
+      [ "$.limit"; "$.mode"; "$.path"; "$.tags[1]" ]
+      (List.map (fun (v : H.schema_violation) -> v.path) call.violations
+       |> List.sort String.compare)
+  | _ -> fail "expected one tool call"
+;;
+
+let test_build_schema_map_accepts_provider_shapes () =
+  let anthropic_tool =
+    `Assoc
+      [ "name", `String "search"; "input_schema", `Assoc [ "type", `String "object" ] ]
+  in
+  let openai_tool =
+    `Assoc
+      [ ( "function"
+        , `Assoc
+            [ "name", `String "write_file"
+            ; "parameters", `Assoc [ "type", `String "object" ]
+            ] )
+      ]
+  in
+  let ignored = `Assoc [ "name", `String "noop"; "input_schema", `Null ] in
+  let schemas = H.build_schema_map [ anthropic_tool; openai_tool; ignored ] in
+  check (list string) "names" [ "search"; "write_file" ] (List.map fst schemas)
+;;
+
+let test_validate_response_flags_unknown_tool_and_stop_reason () =
+  let response =
+    mk_response
+      ~stop_reason:T.EndTurn
+      [ T.ToolUse { id = "call-2"; name = "undeclared"; input = `Assoc [] }
+      ; T.Thinking { thinking_type = "visible"; content = "reason" }
+      ; T.RedactedThinking "redacted"
+      ; T.ToolResult
+          { tool_use_id = "call-2"; content = "ok"; is_error = false; json = None }
+      ; T.Image { media_type = "image/png"; data = "abc"; source_type = "base64" }
+      ; T.Document { media_type = "text/plain"; data = "doc"; source_type = "base64" }
+      ; T.Audio { media_type = "audio/wav"; data = "audio"; source_type = "base64" }
+      ]
+  in
+  let result = H.validate_response ~declared_tools:[ "read_file" ] response in
+  check bool "wrong stop reason" false result.stop_reason_correct;
+  check bool "unknown tool" false result.all_tools_declared;
+  check int "tool calls" 1 (List.length result.tool_calls_found);
+  check int "no dropped blocks" 0 result.dropped_content_blocks
+;;
+
 let () =
   run
     "backend_tool_call_harness"
@@ -54,6 +154,17 @@ let () =
             "valid text response stays Ok with no tool calls"
             `Quick
             test_openai_text_response_is_ok_empty_validation
+        ] )
+    ; ( "schema_validation"
+      , [ test_case
+            "nested violations"
+            `Quick
+            test_schema_validation_reports_nested_violations
+        ; test_case "tool schema map" `Quick test_build_schema_map_accepts_provider_shapes
+        ; test_case
+            "unknown tool and stop reason"
+            `Quick
+            test_validate_response_flags_unknown_tool_and_stop_reason
         ] )
     ]
 ;;

--- a/test/test_runtime_evidence.ml
+++ b/test/test_runtime_evidence.ml
@@ -1,0 +1,411 @@
+open Agent_sdk
+open Alcotest
+
+let mk_session ?(artifacts = []) () : Runtime.session =
+  { session_id = "sess-evidence"
+  ; goal = "collect telemetry"
+  ; title = Some "Evidence"
+  ; tag = Some "test"
+  ; permission_mode = Some "default"
+  ; phase = Runtime.Running
+  ; created_at = 1.0
+  ; updated_at = 2.0
+  ; provider = Some "anthropic"
+  ; model = Some "claude"
+  ; system_prompt = None
+  ; max_turns = 10
+  ; workdir = Some "/tmp/work"
+  ; planned_participants = [ "alice" ]
+  ; participants = []
+  ; artifacts
+  ; pending_input = None
+  ; turn_count = 0
+  ; last_seq = 0
+  ; outcome = None
+  }
+;;
+
+let event seq kind : Runtime.event = { seq; ts = float_of_int seq; kind }
+
+let participant_event
+      ?summary
+      ?provider
+      ?model
+      ?error
+      ?raw_trace_run_id
+      ?stop_reason
+      ?completion_anomaly
+      ?failure_cause
+      participant_name
+  : Runtime.participant_event
+  =
+  { participant_name
+  ; summary
+  ; provider
+  ; model
+  ; error
+  ; raw_trace_run_id
+  ; stop_reason
+  ; completion_anomaly
+  ; failure_cause
+  }
+;;
+
+let all_event_kinds () =
+  let open Runtime in
+  let input_request : Runtime.input_request =
+    { request_id = "input-1"
+    ; participant_name = Some "alice"
+    ; question = "Continue?"
+    ; schema = Some (`Assoc [ "type", `String "string" ])
+    ; timeout_s = Some 30.0
+    ; created_at = 3.0
+    }
+  in
+  [ Session_started { goal = "collect telemetry"; participants = [ "alice" ] }
+  ; Session_settings_updated { model = Some "claude-opus"; permission_mode = Some "safe" }
+  ; Turn_recorded { actor = Some "user"; message = "start" }
+  ; Input_required input_request
+  ; Input_provided
+      { request_id = "input-1"
+      ; participant_name = Some "alice"
+      ; response = Input_answer (`String "yes")
+      }
+  ; Agent_spawn_requested
+      { participant_name = "alice"
+      ; role = Some "worker"
+      ; prompt = "do work"
+      ; provider = Some "anthropic"
+      ; model = Some "claude"
+      ; permission_mode = Some "safe"
+      }
+  ; Agent_became_live
+      (participant_event
+         ~summary:"ready"
+         ~provider:"anthropic"
+         ~model:"claude"
+         ~raw_trace_run_id:"raw-1"
+         ~stop_reason:"end_turn"
+         "alice")
+  ; Agent_output_delta { participant_name = "alice"; delta = "partial" }
+  ; Agent_completed
+      (participant_event
+         ~summary:
+           (Runtime_evidence.append_dropped_output_deltas_summary
+              ~summary:"done"
+              ~dropped_output_deltas:2)
+         ~provider:"anthropic"
+         ~model:"claude"
+         ~raw_trace_run_id:"raw-2"
+         ~stop_reason:"stop"
+         "alice")
+  ; Agent_completed
+      (participant_event
+         ~summary:"done with typed anomaly"
+         ~completion_anomaly:(Dropped_output_deltas { count = 3 })
+         "bob")
+  ; Agent_failed
+      (participant_event
+         ~error:
+           (Runtime_evidence.encode_persist_failure_detail
+              ~phase:"append_event"
+              "disk full")
+         "alice")
+  ; Agent_failed
+      (participant_event
+         ~failure_cause:
+           (Persistence_failure { phase = "save_session"; detail = "denied" })
+         "bob")
+  ; Artifact_attached
+      { artifact_id = "art-1"
+      ; name = "report.json"
+      ; kind = "json"
+      ; mime_type = "application/json"
+      ; path = "/tmp/report.json"
+      ; size_bytes = 42
+      }
+  ; Checkpoint_saved { label = Some "cp1"; path = "/tmp/cp.json" }
+  ; Finalize_requested { reason = Some "done" }
+  ; Session_completed { outcome = Some "ok" }
+  ; Session_failed { outcome = Some "failed" }
+  ; Agent_failed
+      (participant_event ~failure_cause:(Execution_error "tool failed") "charlie")
+  ]
+;;
+
+let test_telemetry_report_covers_event_shapes () =
+  let events =
+    all_event_kinds () |> List.mapi (fun index kind -> event (index + 1) kind)
+  in
+  let report = Runtime_evidence.build_telemetry_report (mk_session ()) events in
+  check int "step count" (List.length events) report.step_count;
+  check int "dropped deltas" 5 report.dropped_output_deltas;
+  check int "persistence failures" 2 report.persistence_failure_count;
+  check
+    (Alcotest.list Alcotest.string)
+    "dropped participants"
+    [ "alice"; "bob" ]
+    report.participants_with_dropped_output_deltas;
+  check
+    (Alcotest.list Alcotest.string)
+    "persistence participants"
+    [ "alice"; "bob" ]
+    report.participants_with_persistence_failures;
+  check int "agent_failed count" 3 (List.assoc "agent_failed" report.event_name_counts);
+  check
+    int
+    "agent_completed count"
+    2
+    (List.assoc "agent_completed" report.event_name_counts);
+  let json = Runtime_evidence.telemetry_report_to_json report in
+  let markdown = Runtime_evidence.telemetry_report_to_markdown report in
+  check bool "json has steps" true Yojson.Safe.Util.(json |> member "steps" <> `Null);
+  check bool "markdown mentions anomalies" true (String.contains markdown 'A')
+;;
+
+let test_evidence_bundle_collects_files_and_missing () =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "oas-runtime-evidence-%d" (Unix.getpid ()))
+  in
+  if not (Sys.file_exists dir) then Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () -> ignore (Sys.command (Printf.sprintf "rm -rf %s" dir)))
+    (fun () ->
+       let present = Filename.concat dir "present.txt" in
+       Runtime_store.save_text present "payload" |> Result.get_ok;
+       let missing = Filename.concat dir "missing.txt" in
+       let bundle =
+         Runtime_evidence.build_evidence_bundle
+           ~session_id:"sess-evidence"
+           [ "present", present; "missing", missing ]
+       in
+       check int "files" 1 (List.length bundle.files);
+       check int "missing" 1 (List.length bundle.missing_files);
+       let file = List.hd bundle.files in
+       check string "label" "present" file.label;
+       check int "size" 7 file.size_bytes;
+       check bool "md5" true (String.length file.md5 = 32);
+       let json = Runtime_evidence.evidence_bundle_to_json bundle in
+       check
+         string
+         "session"
+         "sess-evidence"
+         Yojson.Safe.Util.(json |> member "session_id" |> to_string))
+;;
+
+let test_file_specs_and_artifact_event () =
+  let store = { Runtime_store.root = "/tmp/oas-store" } in
+  let specs = Runtime_evidence.base_evidence_file_specs store "sess-1" in
+  check int "base spec count" 6 (List.length specs);
+  let artifact : Runtime.artifact =
+    { artifact_id = "art-2"
+    ; name = "out.txt"
+    ; kind = "text"
+    ; mime_type = "text/plain"
+    ; path = None
+    ; inline_content = Some "inline"
+    ; size_bytes = 6
+    ; created_at = 5.0
+    }
+  in
+  match Runtime_evidence.artifact_attached_event artifact with
+  | Runtime.Artifact_attached detail ->
+    check string "artifact path default" "" detail.path;
+    check string "artifact name" "out.txt" detail.name
+  | _ -> Alcotest.fail "expected artifact event"
+;;
+
+let test_raw_trace_manifest_json () =
+  let manifest =
+    Runtime_evidence.build_raw_trace_manifest
+      ~session_id:"sess-evidence"
+      ~latest_raw_trace_run:None
+      ~raw_trace_runs:[]
+      ~raw_trace_summaries:[]
+      ~raw_trace_validations:[]
+  in
+  let json = Runtime_evidence.raw_trace_manifest_to_json manifest in
+  check
+    string
+    "manifest session"
+    "sess-evidence"
+    Yojson.Safe.Util.(json |> member "session_id" |> to_string)
+;;
+
+let write_artifact store session_id ~artifact_id ~name ~kind ~created_at content =
+  let path =
+    Runtime_store.save_artifact_text store session_id ~name ~kind ~content
+    |> Result.get_ok
+  in
+  ({ Runtime.artifact_id
+   ; name
+   ; kind
+   ; mime_type = Artifact_service.mime_type_of_kind kind
+   ; path = Some path
+   ; inline_content = None
+   ; size_bytes = String.length content
+   ; created_at
+   }
+   : Runtime.artifact)
+;;
+
+let test_sessions_store_decodes_runtime_artifacts () =
+  let root =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "oas-sessions-parsers-%d" (Unix.getpid ()))
+  in
+  if not (Sys.file_exists root) then Unix.mkdir root 0o755;
+  Fun.protect
+    ~finally:(fun () -> ignore (Sys.command (Printf.sprintf "rm -rf %s" root)))
+    (fun () ->
+       let store = Runtime_store.create ~root () |> Result.get_ok in
+       let session_id = "sess-evidence" in
+       let telemetry_json =
+         {|{
+  "session_id":"sess-evidence",
+  "generated_at":10.0,
+  "step_count":1,
+  "event_counts":{"Agent_completed":1},
+  "event_name_counts":[{"event_name":"agent_completed","count":1}],
+  "steps":[{"seq":1,"ts":10.1,"kind":"Agent_completed","participant":"alice","detail":"done","actor":"agent","role":"worker","provider":"openai","model":"gpt","raw_trace_run_id":"run-1","stop_reason":"stop","artifact_id":"art-telemetry","artifact_name":"runtime-telemetry-json","artifact_kind":"json","checkpoint_label":"cp","outcome":"ok","dropped_output_deltas":2,"persistence_failure_phase":"append_event"}]
+}|}
+       in
+       let evidence_json =
+         {|{"session_id":"sess-evidence","generated_at":11.0,"files":[{"label":"report","path":"/tmp/report.json","size_bytes":12,"md5":"0123456789abcdef0123456789abcdef"}],"missing_files":[{"label":"proof","path":"/tmp/proof.json"}]}|}
+       in
+       let manifest =
+         Runtime_evidence.build_raw_trace_manifest
+           ~session_id
+           ~latest_raw_trace_run:None
+           ~raw_trace_runs:[]
+           ~raw_trace_summaries:[]
+           ~raw_trace_validations:[]
+       in
+       let raw_trace_json =
+         Runtime_evidence.raw_trace_manifest_to_json manifest
+         |> Yojson.Safe.pretty_to_string
+       in
+       let tool_catalog_json =
+         {|[
+  {
+    "name":"shell",
+    "description":"Run a command",
+    "origin":"runtime",
+    "kind":"local",
+    "shell":{"single_command_only":true,"shell_metacharacters_allowed":false,"chaining_allowed":false,"redirection_allowed":false,"pipes_allowed":true,"workdir_policy":"required"},
+    "notes":["audit"],
+    "examples":["ls"]
+  },
+  {
+    "name":"plain",
+    "description":"No shell constraints",
+    "notes":[],
+    "examples":[]
+  }
+]|}
+       in
+       let artifacts =
+         [ write_artifact
+             store
+             session_id
+             ~artifact_id:"art-telemetry"
+             ~name:"runtime-telemetry-json"
+             ~kind:"json"
+             ~created_at:1.0
+             telemetry_json
+         ; write_artifact
+             store
+             session_id
+             ~artifact_id:"art-evidence"
+             ~name:"runtime-evidence"
+             ~kind:"json"
+             ~created_at:2.0
+             evidence_json
+         ; write_artifact
+             store
+             session_id
+             ~artifact_id:"art-raw-trace"
+             ~name:"runtime-raw-trace-json"
+             ~kind:"json"
+             ~created_at:3.0
+             raw_trace_json
+         ; write_artifact
+             store
+             session_id
+             ~artifact_id:"art-tool-catalog"
+             ~name:"tool-catalog"
+             ~kind:"json"
+             ~created_at:4.0
+             tool_catalog_json
+         ]
+       in
+       Runtime_store.save_session store (mk_session ~artifacts ()) |> Result.get_ok;
+       let telemetry =
+         Sessions_store.get_telemetry ~session_root:root ~session_id () |> Result.get_ok
+       in
+       check int "legacy event counts" 1 (List.length telemetry.event_counts);
+       let structured =
+         Sessions_store.get_telemetry_structured ~session_root:root ~session_id ()
+         |> Result.get_ok
+       in
+       check
+         string
+         "structured event name"
+         "agent_completed"
+         (List.hd structured.event_counts).event_name;
+       let step = List.hd structured.steps in
+       check (option string) "step provider" (Some "openai") step.provider;
+       check (option int) "dropped deltas" (Some 2) step.dropped_output_deltas;
+       let evidence =
+         Sessions_store.get_evidence ~session_root:root ~session_id () |> Result.get_ok
+       in
+       check int "evidence files" 1 (List.length evidence.files);
+       check int "missing files" 1 (List.length evidence.missing_files);
+       let raw_trace =
+         Sessions_store.get_raw_trace_manifest ~session_root:root ~session_id ()
+         |> Result.get_ok
+       in
+       check string "raw trace manifest" session_id raw_trace.session_id;
+       let tools =
+         Sessions_store.get_tool_catalog ~session_root:root ~session_id ()
+         |> Result.get_ok
+       in
+       check int "tool catalog" 2 (List.length tools);
+       let shell_tool = List.hd tools in
+       check string "tool name" "shell" shell_tool.name;
+       match shell_tool.shell with
+       | Some shell ->
+         check bool "single command" true shell.Tool.single_command_only;
+         check bool "workdir policy" true (shell.Tool.workdir_policy = Some Tool.Required)
+       | None -> fail "expected shell constraints")
+;;
+
+let () =
+  Alcotest.run
+    "runtime_evidence"
+    [ ( "telemetry"
+      , [ Alcotest.test_case
+            "event shapes and anomalies"
+            `Quick
+            test_telemetry_report_covers_event_shapes
+        ] )
+    ; ( "bundle"
+      , [ Alcotest.test_case
+            "files and missing files"
+            `Quick
+            test_evidence_bundle_collects_files_and_missing
+        ; Alcotest.test_case
+            "file specs and artifact event"
+            `Quick
+            test_file_specs_and_artifact_event
+        ; Alcotest.test_case "raw trace manifest json" `Quick test_raw_trace_manifest_json
+        ; Alcotest.test_case
+            "sessions store artifact decoders"
+            `Quick
+            test_sessions_store_decodes_runtime_artifacts
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- Add focused runtime evidence coverage for telemetry/event anomaly paths, evidence bundles, artifact events, and raw-trace manifest JSON
- Exercise sessions-store artifact decoder paths for telemetry, structured telemetry, evidence, raw-trace manifests, and tool catalogs
- Add backend tool-call harness schema validation coverage for nested schema violations, provider schema-map parsing, unknown tools, stop reasons, and non-text blocks

## Validation
- `opam exec -- ocamlformat -i test/test_runtime_evidence.ml`
- `opam exec -- dune build --root . -j 2 test/test_runtime_evidence.exe test/test_backend_tool_call_harness.exe`
- `./_build/default/test/test_runtime_evidence.exe`
- `./_build/default/test/test_backend_tool_call_harness.exe`
- `git diff --check`
- `git diff --cached --check`

## Coverage note
Local full bisect coverage could not be measured because the current opam switch lacks `bisect_ppx`; CI will provide the authoritative coverage value for the next #1175 ratchet step.