### PR TITLE
feat: bridge runtime windows to sync replay

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -114,6 +114,7 @@ module Trace_eval = Trace_eval
 module Runtime = Runtime
 module Runtime_projection = Runtime_projection
 module Runtime_sync = Runtime_sync
+module Runtime_replay = Runtime_replay
 module Transport = Transport
 module Runtime_client = Runtime_client
 module Client = Client

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -87,6 +87,7 @@ module Trace_eval = Trace_eval
 module Runtime = Runtime
 module Runtime_projection = Runtime_projection
 module Runtime_sync = Runtime_sync
+module Runtime_replay = Runtime_replay
 module Transport = Transport
 module Runtime_client = Runtime_client
 module Client = Client

--- a/lib/runtime_replay.ml
+++ b/lib/runtime_replay.ml
@@ -1,0 +1,74 @@
+open Result_syntax
+
+type sync_window_set =
+  { windows : Runtime_sync.window list
+  ; runs : Runtime_store.run_record list
+  ; failures : Runtime_store.run_load_failure list
+  }
+
+let artifact_refs (session : Runtime.session) =
+  session.artifacts
+  |> List.map (fun (artifact : Runtime.artifact) -> artifact.artifact_id)
+;;
+
+let events_for_session session_id records =
+  records
+  |> List.filter_map (fun (record : Runtime_store.run_event_record) ->
+    if String.equal record.session_id session_id then Some record.event else None)
+;;
+
+let sync_windows_from_store
+      ?(after_seq = 0)
+      ?persistence
+      ?(merge_policy = Runtime_sync.Append_only)
+      store
+      selectors
+  =
+  let* selected = Runtime_store.read_window_events store selectors in
+  let windows =
+    selected.runs
+    |> List.map (fun (run : Runtime_store.run_record) ->
+      let session_id = run.session.session_id in
+      Runtime_sync.make_window
+        ?persistence
+        ~merge_policy
+        ~artifact_refs:(artifact_refs run.session)
+        ~stream_id:session_id
+        ~after_seq
+        (events_for_session session_id selected.events))
+  in
+  Ok { windows; runs = selected.runs; failures = selected.failures }
+;;
+
+let run_to_yojson (run : Runtime_store.run_record) =
+  `Assoc
+    [ "session_id", `String run.session.session_id
+    ; "path", `String run.path
+    ; "updated_at", `Float run.session.updated_at
+    ; "phase", Runtime.phase_to_yojson run.session.phase
+    ]
+;;
+
+let failure_to_yojson (failure : Runtime_store.run_load_failure) =
+  `Assoc
+    [ "session_id", `String failure.session_id
+    ; "path", `String failure.path
+    ; "detail", `String failure.detail
+    ]
+;;
+
+let sync_window_set_to_yojson set =
+  `Assoc
+    [ "schema_version", `Int Runtime_sync.schema_version_current
+    ; "windows", `List (List.map Runtime_sync.to_json set.windows)
+    ; "runs", `List (List.map run_to_yojson set.runs)
+    ; "failures", `List (List.map failure_to_yojson set.failures)
+    ]
+;;
+
+let sync_windows_json_from_store ?after_seq ?persistence ?merge_policy store selectors =
+  let* set =
+    sync_windows_from_store ?after_seq ?persistence ?merge_policy store selectors
+  in
+  Ok (sync_window_set_to_yojson set)
+;;

--- a/lib/runtime_replay.mli
+++ b/lib/runtime_replay.mli
@@ -1,0 +1,28 @@
+(** Runtime replay bridge from stored runs to versioned sync windows.
+
+    This module keeps {!Runtime_sync} pure while providing the read-side bridge
+    that turns {!Runtime_store} window selectors into replayable JSON windows. *)
+
+type sync_window_set =
+  { windows : Runtime_sync.window list
+  ; runs : Runtime_store.run_record list
+  ; failures : Runtime_store.run_load_failure list
+  }
+
+val sync_windows_from_store
+  :  ?after_seq:int
+  -> ?persistence:Runtime_sync.persistence_contract
+  -> ?merge_policy:Runtime_sync.merge_policy
+  -> Runtime_store.t
+  -> Runtime_store.run_window list
+  -> (sync_window_set, Error.sdk_error) result
+
+val sync_window_set_to_yojson : sync_window_set -> Yojson.Safe.t
+
+val sync_windows_json_from_store
+  :  ?after_seq:int
+  -> ?persistence:Runtime_sync.persistence_contract
+  -> ?merge_policy:Runtime_sync.merge_policy
+  -> Runtime_store.t
+  -> Runtime_store.run_window list
+  -> (Yojson.Safe.t, Error.sdk_error) result

--- a/test/dune
+++ b/test/dune
@@ -173,6 +173,7 @@
   test_retry
   test_runtime
   test_runtime_evidence
+  test_runtime_replay
   test_runtime_projection_cov2
   test_runtime_server_resolve
   test_runtime_server_types
@@ -390,6 +391,7 @@
   test_retry
   test_runtime
   test_runtime_evidence
+  test_runtime_replay
   test_runtime_projection_cov2
   test_runtime_server_resolve
   test_runtime_server_types

--- a/test/test_runtime_replay.ml
+++ b/test/test_runtime_replay.ml
@@ -1,0 +1,161 @@
+open Agent_sdk
+open Alcotest
+
+let expect_ok label = function
+  | Ok value -> value
+  | Error err -> fail (Printf.sprintf "%s: %s" label (Error.to_string err))
+;;
+
+let with_temp_dir f =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "oas-runtime-replay-%d-%06x" (Unix.getpid ()) (Random.int 0xFFFFFF))
+  in
+  Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () -> ignore (Sys.command (Printf.sprintf "rm -rf %s" dir)))
+    (fun () -> f dir)
+;;
+
+let mk_session ?(artifacts = []) ?(updated_at = 1.0) session_id : Runtime.session =
+  { session_id
+  ; goal = "runtime replay"
+  ; title = None
+  ; tag = None
+  ; permission_mode = None
+  ; phase = Runtime.Running
+  ; created_at = updated_at -. 0.5
+  ; updated_at
+  ; provider = Some "mock"
+  ; model = Some "model"
+  ; system_prompt = None
+  ; max_turns = 10
+  ; workdir = None
+  ; planned_participants = []
+  ; participants = []
+  ; artifacts
+  ; pending_input = None
+  ; turn_count = 0
+  ; last_seq = 0
+  ; outcome = None
+  }
+;;
+
+let mk_event seq message : Runtime.event =
+  { seq
+  ; ts = float_of_int seq
+  ; kind = Runtime.Turn_recorded { actor = Some "user"; message }
+  }
+;;
+
+let save_artifact store session_id ~artifact_id ~name content =
+  let path =
+    Runtime_store.save_artifact_text store session_id ~name ~kind:"json" ~content
+    |> expect_ok "save artifact"
+  in
+  ({ Runtime.artifact_id
+   ; name
+   ; kind = "json"
+   ; mime_type = "application/json"
+   ; path = Some path
+   ; inline_content = None
+   ; size_bytes = String.length content
+   ; created_at = 1.0
+   }
+   : Runtime.artifact)
+;;
+
+let save_run ?(artifacts = []) store session_id ~updated_at events =
+  Runtime_store.save_session store (mk_session ~artifacts ~updated_at session_id)
+  |> expect_ok "save session";
+  List.iter
+    (fun event ->
+       Runtime_store.append_event store session_id event |> expect_ok "append event")
+    events
+;;
+
+let test_sync_windows_from_selected_runs () =
+  with_temp_dir (fun root ->
+    let store = Runtime_store.create ~root () |> expect_ok "create store" in
+    let artifact =
+      save_artifact store "run-a" ~artifact_id:"art-run-a" ~name:"report" {|{"ok":true}|}
+    in
+    save_run
+      ~artifacts:[ artifact ]
+      store
+      "run-a"
+      ~updated_at:10.0
+      [ mk_event 1 "old-a"; mk_event 2 "new-a" ];
+    save_run store "run-b" ~updated_at:20.0 [ mk_event 1 "old-b"; mk_event 3 "new-b" ];
+    let set =
+      Runtime_replay.sync_windows_from_store
+        ~after_seq:1
+        store
+        [ Runtime_store.Last_n_runs 2 ]
+      |> expect_ok "sync windows"
+    in
+    check int "windows" 2 (List.length set.windows);
+    check
+      (list string)
+      "stream order"
+      [ "run-a"; "run-b" ]
+      (List.map (fun (window : Runtime_sync.window) -> window.stream_id) set.windows);
+    check
+      (list int)
+      "event counts"
+      [ 1; 1 ]
+      (List.map
+         (fun (window : Runtime_sync.window) -> List.length window.events)
+         set.windows);
+    let first = List.hd set.windows in
+    check int "cursor" 1 first.cursor.after_seq;
+    check int "next cursor" 2 first.next_cursor.after_seq;
+    check (list string) "artifact refs" [ "art-run-a" ] first.artifact_refs;
+    List.iter
+      (fun window ->
+         match Runtime_sync.validate_window window with
+         | Ok () -> ()
+         | Error detail -> fail detail)
+      set.windows)
+;;
+
+let test_sync_windows_json_reports_selector_failures_and_dedupes_runs () =
+  with_temp_dir (fun root ->
+    let store = Runtime_store.create ~root () |> expect_ok "create store" in
+    save_run store "run-a" ~updated_at:10.0 [ mk_event 1 "old-a"; mk_event 2 "new-a" ];
+    save_run store "run-b" ~updated_at:20.0 [ mk_event 1 "old-b"; mk_event 2 "new-b" ];
+    let json =
+      Runtime_replay.sync_windows_json_from_store
+        store
+        [ Runtime_store.Last_n_runs 1
+        ; Runtime_store.Session "run-b"
+        ; Runtime_store.Session "missing"
+        ]
+      |> expect_ok "sync window json"
+    in
+    let open Yojson.Safe.Util in
+    check int "one deduped window" 1 (json |> member "windows" |> to_list |> List.length);
+    check int "one failure" 1 (json |> member "failures" |> to_list |> List.length);
+    check
+      string
+      "missing failure"
+      "missing"
+      (json |> member "failures" |> to_list |> List.hd |> member "session_id" |> to_string))
+;;
+
+let () =
+  Alcotest.run
+    "runtime_replay"
+    [ ( "sync_windows"
+      , [ test_case
+            "selected runs to sync windows"
+            `Quick
+            test_sync_windows_from_selected_runs
+        ; test_case
+            "json reports failures and dedupes runs"
+            `Quick
+            test_sync_windows_json_reports_selector_failures_and_dedupes_runs
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- Add `Runtime_replay`, a bridge from `Runtime_store` window selectors to per-session `Runtime_sync.window` replay windows
- Preserve selected run ordering, dedupe behavior, artifact refs, and partial selector failures in a JSON envelope
- Export the bridge from `Agent_sdk` and add focused tests for selected windows, JSON failure propagation, and duplicate selector dedupe

## Validation
- `opam exec -- ocamlformat -i lib/runtime_replay.ml lib/runtime_replay.mli test/test_runtime_replay.ml`
- `opam exec -- dune build --root . -j 2 test/test_runtime_replay.exe test/test_runtime_sync.exe test/test_runtime_store_unit.exe`
- `./_build/default/test/test_runtime_replay.exe`
- `./_build/default/test/test_runtime_sync.exe`
- `./_build/default/test/test_runtime_store_unit.exe`
- `git diff --check`
- `git diff --cached --check`

## Issue
Progresses #484 by wiring the runtime run/window primitives into the higher-level sync/replay surface. The remaining #484 scope after this is explicit checkpoint-delta projection once the consumer contract chooses how to request deltas.