### PR TITLE
feat(agent): pause on async elicitation

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -55,6 +55,10 @@ let run_turn_with_trace ~sw ?clock ?raw_trace_run agent =
   run_turn_core ~sw ?clock ~api_strategy:Sync ?raw_trace_run agent
 ;;
 
+let provide_input agent request response =
+  Agent_elicitation.apply_response agent request response
+;;
+
 let check_token_budget = Agent_turn.check_token_budget
 
 (* ── Shared loop guard (max_turns + idle + budget) ─────────── *)

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -183,6 +183,12 @@ val run_turn_stream
   -> t
   -> ([ `Complete of Types.api_response | `ToolsExecuted ], Error.sdk_error) result
 
+(** Append an elicitation response to the agent conversation so callers that
+    received {!Error.InputRequired} can resume with {!run_turn_stream} or an
+    equivalent turn driver. [Declined] and [Timeout] preserve the legacy
+    callback behavior and do not append a synthetic user message. *)
+val provide_input : t -> Error.input_required -> Hooks.elicitation_response -> unit
+
 (** {1 Handoff} *)
 
 val run_with_handoffs

--- a/lib/agent/agent_elicitation.ml
+++ b/lib/agent/agent_elicitation.ml
@@ -1,0 +1,68 @@
+open Types
+open Agent_types
+
+let sanitize_request_id_component value =
+  let buf = Buffer.create (String.length value) in
+  String.iter
+    (fun ch ->
+       match ch with
+       | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' -> Buffer.add_char buf ch
+       | '-' | '_' -> Buffer.add_char buf ch
+       | _ -> Buffer.add_char buf '-')
+    value;
+  let raw = Buffer.contents buf |> String.lowercase_ascii in
+  let trimmed = String.trim raw in
+  if trimmed = "" then "agent" else trimmed
+;;
+
+let input_required_of_request ~agent_name ~turn ?created_at req =
+  let created_at = Option.value created_at ~default:(Unix.gettimeofday ()) in
+  let participant = sanitize_request_id_component agent_name in
+  let created_ms = int_of_float (created_at *. 1000.0) in
+  { Error.request_id = Printf.sprintf "%s-turn-%d-input-%d" participant turn created_ms
+  ; participant_name = Some agent_name
+  ; question = req.Hooks.question
+  ; schema = req.schema
+  ; timeout_s = req.timeout_s
+  ; created_at
+  }
+;;
+
+let runtime_input_request_of_input_required (req : Error.input_required) =
+  { Runtime.request_id = req.request_id
+  ; participant_name = req.participant_name
+  ; question = req.question
+  ; schema = req.schema
+  ; timeout_s = req.timeout_s
+  ; created_at = req.created_at
+  }
+;;
+
+let runtime_response_to_hooks = function
+  | Runtime.Input_answer json -> Hooks.Answer json
+  | Runtime.Input_declined -> Hooks.Declined
+  | Runtime.Input_timeout -> Hooks.Timeout
+;;
+
+let message_of_response ~question = function
+  | Hooks.Answer json ->
+    let text =
+      Printf.sprintf "[User input] %s: %s" question (Yojson.Safe.to_string json)
+    in
+    Some
+      { role = User
+      ; content = [ Text text ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+  | Hooks.Declined | Hooks.Timeout -> None
+;;
+
+let apply_response agent (req : Error.input_required) response =
+  match message_of_response ~question:req.question response with
+  | None -> ()
+  | Some message ->
+    update_state agent (fun state ->
+      { state with messages = Util.snoc state.messages message })
+;;

--- a/lib/agent/agent_elicitation.mli
+++ b/lib/agent/agent_elicitation.mli
@@ -1,0 +1,29 @@
+(** Agent elicitation bridge helpers.
+
+    These helpers keep the hook-level {!Hooks.ElicitInput} API aligned with
+    runtime input pause/resume payloads without making the base error library
+    depend on runtime protocol modules. *)
+
+val input_required_of_request
+  :  agent_name:string
+  -> turn:int
+  -> ?created_at:float
+  -> Hooks.elicitation_request
+  -> Error.input_required
+
+val runtime_input_request_of_input_required
+  :  Error.input_required
+  -> Runtime.input_request
+
+val runtime_response_to_hooks : Runtime.input_response -> Hooks.elicitation_response
+
+val message_of_response
+  :  question:string
+  -> Hooks.elicitation_response
+  -> Types.message option
+
+val apply_response
+  :  Agent_types.t
+  -> Error.input_required
+  -> Hooks.elicitation_response
+  -> unit

--- a/lib/base/error.ml
+++ b/lib/base/error.ml
@@ -17,6 +17,15 @@ type api_error = Retry.api_error
 (** Provider/runtime errors — alias for {!Llm_provider.Error.provider_error}. *)
 type provider_error = Llm_provider.Error.provider_error
 
+type input_required =
+  { request_id : string
+  ; participant_name : string option
+  ; question : string
+  ; schema : Yojson.Safe.t option
+  ; timeout_s : float option
+  ; created_at : float
+  }
+
 (** Agent runtime errors. *)
 type agent_error =
   | MaxTurnsExceeded of
@@ -56,6 +65,7 @@ type agent_error =
       { tripwire : string
       ; reason : string
       }
+  | InputRequired of input_required
   | ExitConditionMet of { turn : int }
 
 (** MCP client errors. *)
@@ -184,6 +194,14 @@ let agent_error_to_string = function
     Printf.sprintf "Guardrail violation [%s]: %s" r.validator r.reason
   | TripwireViolation r ->
     Printf.sprintf "Tripwire violation [%s]: %s" r.tripwire r.reason
+  | InputRequired r ->
+    Printf.sprintf
+      "Input required%s: %s (request %s)"
+      (match r.participant_name with
+       | Some participant -> Printf.sprintf " for %s" participant
+       | None -> "")
+      r.question
+      r.request_id
   | ExitConditionMet r -> Printf.sprintf "Exit condition met at turn %d" r.turn
 ;;
 

--- a/lib/base/error.mli
+++ b/lib/base/error.mli
@@ -17,6 +17,15 @@ type api_error = Retry.api_error
 (** Provider/runtime errors — same type as {!Llm_provider.Error.provider_error}. *)
 type provider_error = Llm_provider.Error.provider_error
 
+type input_required =
+  { request_id : string
+  ; participant_name : string option
+  ; question : string
+  ; schema : Yojson.Safe.t option
+  ; timeout_s : float option
+  ; created_at : float
+  }
+
 type agent_error =
   | MaxTurnsExceeded of
       { turns : int
@@ -58,6 +67,7 @@ type agent_error =
       { tripwire : string
       ; reason : string
       }
+  | InputRequired of input_required
   | ExitConditionMet of { turn : int }
 
 type mcp_error =

--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -30,6 +30,7 @@ type agent_error =
       Completion_contract_id.t * string * Completion_contract_violation_detail.t option
   | `Guardrail_violation of string * string
   | `Tripwire_violation of string * string
+  | `Input_required of string * string
   | `Unrecognized_stop_reason of string
   | `Exit_condition_met of int
   ]
@@ -118,6 +119,7 @@ let of_sdk_error (err : Error.sdk_error) : sdk_error_poly =
     `Completion_contract_violation (r.contract, r.reason, r.violation_detail)
   | Error.Agent (GuardrailViolation r) -> `Guardrail_violation (r.validator, r.reason)
   | Error.Agent (TripwireViolation r) -> `Tripwire_violation (r.tripwire, r.reason)
+  | Error.Agent (InputRequired r) -> `Input_required (r.request_id, r.question)
   | Error.Agent (UnrecognizedStopReason r) -> `Unrecognized_stop_reason r.reason
   | Error.Agent (ExitConditionMet r) -> `Exit_condition_met r.turn
   | Error.Config (MissingEnvVar r) -> `Missing_env_var r.var_name
@@ -175,6 +177,16 @@ let to_sdk_error (err : sdk_error_poly) : Error.sdk_error =
     Error.Agent (GuardrailViolation { validator; reason })
   | `Tripwire_violation (tripwire, reason) ->
     Error.Agent (TripwireViolation { tripwire; reason })
+  | `Input_required (request_id, question) ->
+    Error.Agent
+      (InputRequired
+         { request_id
+         ; participant_name = None
+         ; question
+         ; schema = None
+         ; timeout_s = None
+         ; created_at = Unix.gettimeofday ()
+         })
   | `Unrecognized_stop_reason reason -> Error.Agent (UnrecognizedStopReason { reason })
   | `Exit_condition_met turn -> Error.Agent (ExitConditionMet { turn })
   | `Missing_env_var var -> Error.Config (MissingEnvVar { var_name = var })

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -56,6 +56,7 @@ type agent_error =
     (** contract, reason, violation detail *)
   | `Guardrail_violation of string * string (** validator, reason *)
   | `Tripwire_violation of string * string (** tripwire, reason *)
+  | `Input_required of string * string (** request_id, question *)
   | `Unrecognized_stop_reason of string
   | `Exit_condition_met of int (** turn at which exit condition triggered *)
   ]

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -1018,7 +1018,7 @@ let tag_error stage result =
 
 let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
   (* Stage 1: Input *)
-  stage_input ?raw_trace_run agent;
+  let* () = stage_input ?raw_trace_run agent |> tag_error "input" in
   (* Stage 2: Parse *)
   let prep, original_config, turn_params = stage_parse ?raw_trace_run agent in
   let context_window = proactive_context_window_tokens agent in

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -35,25 +35,20 @@ let stage_input ?raw_trace_run agent =
                   ; response
                   }))
         | None -> ());
-       (match response with
-        | Hooks.Answer json ->
-          let text =
-            Printf.sprintf "[User input] %s: %s" req.question (Yojson.Safe.to_string json)
-          in
-          update_state agent (fun s ->
-            { s with
-              messages =
-                Util.snoc
-                  s.messages
-                  { role = User
-                  ; content = [ Text text ]
-                  ; name = None
-                  ; tool_call_id = None
-                  ; metadata = []
-                  }
-            })
-        | Hooks.Declined | Hooks.Timeout -> ())
-     | None -> ())
+       (match Agent_elicitation.message_of_response ~question:req.question response with
+        | Some message ->
+          update_state agent (fun s -> { s with messages = Util.snoc s.messages message })
+        | None -> ());
+       Ok ()
+     | None ->
+       let input_required =
+         Agent_elicitation.input_required_of_request
+           ~agent_name:agent.state.config.name
+           ~turn:agent.state.turn_count
+           ~created_at:ts
+           req
+       in
+       Error (Error.Agent (InputRequired input_required)))
   | Hooks.Nudge nudge_msg ->
     (* Keep BeforeTurn nudge behavior identical to the inlined pipeline path:
          append it as a User message so it is seen in this same turn. *)
@@ -68,8 +63,9 @@ let stage_input ?raw_trace_run agent =
             ; tool_call_id = None
             ; metadata = []
             }
-      })
-  | _ -> ()
+      });
+    Ok ()
+  | _ -> Ok ()
 ;;
 
 let last_tool_results_from messages =

--- a/lib/runtime_server.ml
+++ b/lib/runtime_server.ml
@@ -37,6 +37,10 @@ type participant_run_success =
   ; completion_anomaly : Runtime.completion_anomaly option
   }
 
+type participant_run_result =
+  | Participant_completed of participant_run_success
+  | Participant_input_required of Runtime.input_request
+
 type participant_run_failure =
   { error : Error.sdk_error
   ; raw_trace_run_id : string option
@@ -348,11 +352,12 @@ let run_participant
           ; Log.I ("dropped_output_deltas", !delta_error_count)
           ];
       Ok
-        { summary = full
-        ; raw_trace_run_id = latest_raw_trace_run_id trace_sink
-        ; stop_reason = Some "EndTurn"
-        ; completion_anomaly = completion_anomaly ()
-        })
+        (Participant_completed
+           { summary = full
+           ; raw_trace_run_id = latest_raw_trace_run_id trace_sink
+           ; stop_reason = Some "EndTurn"
+           ; completion_anomaly = completion_anomaly ()
+           }))
   | _selected_provider ->
     Eio.Switch.run
     @@ fun sw ->
@@ -399,11 +404,16 @@ let run_participant
               ; Log.I ("dropped_output_deltas", !delta_error_count)
               ];
           Ok
-            { summary = extract_text response
-            ; raw_trace_run_id = latest_raw_trace_run_id trace_sink
-            ; stop_reason = Some (Types.show_stop_reason response.stop_reason)
-            ; completion_anomaly = completion_anomaly ()
-            }
+            (Participant_completed
+               { summary = extract_text response
+               ; raw_trace_run_id = latest_raw_trace_run_id trace_sink
+               ; stop_reason = Some (Types.show_stop_reason response.stop_reason)
+               ; completion_anomaly = completion_anomaly ()
+               })
+        | Error (Error.Agent (Error.InputRequired request)) ->
+          Ok
+            (Participant_input_required
+               (Agent_elicitation.runtime_input_request_of_input_required request))
         | Error err ->
           Error { error = err; raw_trace_run_id = latest_raw_trace_run_id trace_sink }))
 ;;
@@ -690,7 +700,7 @@ let apply_command ~sw state store (session : session) command =
                  ()
              | Ok _ ->
                (match run_participant store state session_id resolution detail with
-                | Ok outcome ->
+                | Ok (Participant_completed outcome) ->
                   (match
                      persist_event
                        store
@@ -732,6 +742,34 @@ let apply_command ~sw state store (session : session) command =
                        ?raw_trace_run_id:outcome.raw_trace_run_id
                        ~failure_cause:
                          (Persistence_failure { phase = "agent_completed"; detail })
+                       ())
+                | Ok (Participant_input_required request) ->
+                  (match
+                     persist_event store state session_id (Input_required request)
+                   with
+                   | Ok _ -> ()
+                   | Error err ->
+                     let detail =
+                       Printf.sprintf
+                         "participant requested input but input_required event could not \
+                          be persisted: %s"
+                         (Error.to_string err)
+                     in
+                     log_participant_persist_failure
+                       ~session_id
+                       ~participant_name
+                       ~phase:"input_required"
+                       err;
+                     persist_participant_failure
+                       store
+                       state
+                       ~session_id
+                       ~participant_name
+                       ~provider:resolution.resolved_provider
+                       ~model:resolution.resolved_model
+                       ~detail
+                       ~failure_cause:
+                         (Persistence_failure { phase = "input_required"; detail })
                        ())
                 | Error failure ->
                   persist_participant_failure

--- a/test/test_elicitation.ml
+++ b/test/test_elicitation.ml
@@ -146,6 +146,58 @@ let test_agent_options_elicitation_default () =
   Alcotest.(check bool) "default none" true (Option.is_none opts.elicitation)
 ;;
 
+let test_agent_elicit_input_without_callback_pauses () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let schema =
+    `Assoc
+      [ "type", `String "object"
+      ; "properties", `Assoc [ "env", `Assoc [ "type", `String "string" ] ]
+      ]
+  in
+  let request : Hooks.elicitation_request =
+    { question = "Which environment?"; schema = Some schema; timeout_s = Some 20.0 }
+  in
+  let before_turn = function
+    | Hooks.BeforeTurn _ -> Hooks.ElicitInput request
+    | _ -> Hooks.Continue
+  in
+  let options =
+    { Agent.default_options with
+      base_url = "http://unused"
+    ; hooks = { Hooks.empty with before_turn = Some before_turn }
+    }
+  in
+  let config = { Types.default_config with name = "human-reviewer" } in
+  let agent = Agent.create ~net:env#net ~config ~options () in
+  match Agent.run ~sw agent "deploy" with
+  | Error (Error.Agent (Error.InputRequired input)) ->
+    (match input.participant_name with
+     | Some participant ->
+       Alcotest.(check string) "participant" "human-reviewer" participant
+     | None -> Alcotest.fail "expected participant");
+    Alcotest.(check string) "question" "Which environment?" input.question;
+    Alcotest.(check bool) "schema preserved" true (Option.is_some input.schema);
+    Alcotest.(check bool) "timeout preserved" true (input.timeout_s = Some 20.0);
+    Alcotest.(check bool) "request_id non-empty" true (String.length input.request_id > 0);
+    let state_after_pause = Agent.state agent in
+    Alcotest.(check int) "prompt retained" 1 (List.length state_after_pause.messages);
+    Agent.provide_input agent input (Hooks.Answer (`Assoc [ "env", `String "prod" ]));
+    let state_after_input = Agent.state agent in
+    Alcotest.(check int) "input appended" 2 (List.length state_after_input.messages);
+    (match List.rev state_after_input.messages with
+     | { Types.role = Types.User; content = [ Types.Text text ]; _ } :: _ ->
+       Alcotest.(check string)
+         "input message"
+         "[User input] Which environment?: {\"env\":\"prod\"}"
+         text
+     | _ -> Alcotest.fail "expected user input message")
+  | Error err -> Alcotest.failf "expected InputRequired, got %s" (Error.to_string err)
+  | Ok _ -> Alcotest.fail "expected InputRequired"
+;;
+
 let () =
   let open Alcotest in
   run
@@ -171,5 +223,11 @@ let () =
         ] )
     ; ( "agent_options"
       , [ test_case "default none" `Quick test_agent_options_elicitation_default ] )
+    ; ( "agent_pause"
+      , [ test_case
+            "ElicitInput without callback returns InputRequired"
+            `Quick
+            test_agent_elicit_input_without_callback_pauses
+        ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- add a typed `Error.InputRequired` payload for agent elicitation pauses
- make `before_turn` `Hooks.ElicitInput` without a synchronous callback stop before provider dispatch instead of being silently ignored
- add `Agent.provide_input` and shared elicitation bridge helpers for runtime input payloads
- persist agent `InputRequired` results as runtime `Input_required` events instead of `Agent_failed`

Refs #522.

## Validation
- `opam exec -- dune build --root . -j 2 test/test_elicitation.exe test/test_runtime.exe bin/oas_runtime.exe`
- `./_build/default/test/test_elicitation.exe`
- `./_build/default/test/test_runtime.exe -q`
- `git diff --check`