### PR TITLE
test: expand coverage hotspots

### DIFF
--- a/lib/runtime_server_types.mli
+++ b/lib/runtime_server_types.mli
@@ -18,5 +18,6 @@ val store_of_state : state -> (Runtime_store.t, Error.sdk_error) result
 val session_root_request_path : string option -> string option
 val write_protocol_message : state -> Runtime.protocol_message -> unit
 val next_control_id : state -> string
+val custom_name_of_kind : Runtime.event_kind -> string
 val event_bus_run_id_of_event : Runtime.event -> string option
 val emit_event : state -> string -> Runtime.event -> unit

--- a/test/dune
+++ b/test/dune
@@ -83,6 +83,7 @@
   test_defaults_unit
   test_disclosure_resolver
   test_discovery
+  test_discovery_http
   test_durable
   test_durable_event
   test_e2e_v024
@@ -170,9 +171,11 @@
   test_reflexion
   test_relay_delivery
   test_request_priority
+  test_response_harness
   test_retry
   test_runtime
   test_runtime_evidence
+  test_runtime_health
   test_runtime_replay
   test_runtime_projection_cov2
   test_runtime_server_resolve
@@ -192,6 +195,7 @@
   test_skill_coverage2
   test_skill_discovery
   test_skill_registry
+  test_slot_cache_http
   test_slot_scheduler_event_bridge
   test_sse_parser
   test_stream_accumulator
@@ -301,6 +305,7 @@
   test_defaults_unit
   test_disclosure_resolver
   test_discovery
+  test_discovery_http
   test_durable
   test_durable_event
   test_e2e_v024
@@ -388,9 +393,11 @@
   test_reflexion
   test_relay_delivery
   test_request_priority
+  test_response_harness
   test_retry
   test_runtime
   test_runtime_evidence
+  test_runtime_health
   test_runtime_replay
   test_runtime_projection_cov2
   test_runtime_server_resolve
@@ -410,6 +417,7 @@
   test_skill_coverage2
   test_skill_discovery
   test_skill_registry
+  test_slot_cache_http
   test_slot_scheduler_event_bridge
   test_sse_parser
   test_stream_accumulator

--- a/test/test_cli_transport_factory.ml
+++ b/test/test_cli_transport_factory.ml
@@ -126,6 +126,75 @@ let test_transport_native_defaults () =
   check bool "gemini yolo default true" true Transport_gemini_cli.default_config.yolo
 ;;
 
+let contains_substring ~sub text =
+  let sub_len = String.length sub in
+  let text_len = String.length text in
+  let rec loop idx =
+    if idx + sub_len > text_len
+    then false
+    else if String.sub text idx sub_len = sub
+    then true
+    else loop (idx + 1)
+  in
+  sub_len = 0 || loop 0
+;;
+
+let expect_failure_contains label needle f =
+  match f () with
+  | exception Failure msg -> check bool label true (contains_substring ~sub:needle msg)
+  | exception exn ->
+    fail (Printf.sprintf "%s: unexpected %s" label (Printexc.to_string exn))
+  | _ -> fail (label ^ ": expected Failure")
+;;
+
+let with_eio f =
+  Eio_main.run
+  @@ fun env -> Eio.Switch.run @@ fun sw -> f ~sw ~mgr:(Eio.Stdenv.process_mgr env)
+;;
+
+let dispatch_config =
+  { default_config with
+    command = "/bin/echo"
+  ; model = Some "mock-model"
+  ; cwd = Some "/tmp"
+  ; mcp_config = Some "/tmp/mcp.json"
+  ; mcp_config_files = [ "/tmp/kimi-a.json"; "/tmp/kimi-b.json" ]
+  ; mcp_config_json = [ {|{"mcpServers":{}}|} ]
+  ; allowed_tools = [ "Read"; "Write" ]
+  ; max_turns = Some 2
+  ; permission_mode = Some "acceptEdits"
+  ; tool_use_via_stream_json = Some false
+  ; forward_tool_results = Some true
+  ; yolo = Some false
+  ; config_file = Some "/tmp/kimi.toml"
+  ; extra_env = [ "OAS_TEST", "1" ]
+  ; session_id = Some "session-1"
+  ; stdout_idle_timeout_s = Some 0.5
+  }
+;;
+
+let test_create_rejects_unknown_protocol () =
+  with_eio
+  @@ fun ~sw ~mgr ->
+  expect_failure_contains "unknown protocol" "unknown CLI protocol" (fun () ->
+    create ~protocol:"openai-http" ~config:dispatch_config ~sw ~mgr)
+;;
+
+let test_create_rejects_empty_command () =
+  with_eio
+  @@ fun ~sw ~mgr ->
+  expect_failure_contains "empty command" "requires a non-empty command" (fun () ->
+    create ~protocol:"codex-cli" ~config:{ dispatch_config with command = "   " } ~sw ~mgr)
+;;
+
+let test_create_dispatches_all_protocols () =
+  with_eio
+  @@ fun ~sw ~mgr ->
+  List.iter
+    (fun protocol -> ignore (create ~protocol ~config:dispatch_config ~sw ~mgr))
+    (registered_protocols ())
+;;
+
 (* --- Test suite --- *)
 
 let () =
@@ -149,5 +218,10 @@ let () =
         ] )
     ; ( "transport_defaults"
       , [ test_case "native default pins" `Quick test_transport_native_defaults ] )
+    ; ( "create"
+      , [ test_case "rejects unknown protocol" `Quick test_create_rejects_unknown_protocol
+        ; test_case "rejects empty command" `Quick test_create_rejects_empty_command
+        ; test_case "dispatches all protocols" `Quick test_create_dispatches_all_protocols
+        ] )
     ]
 ;;

--- a/test/test_discovery_http.ml
+++ b/test/test_discovery_http.ml
@@ -1,0 +1,79 @@
+open Alcotest
+open Llm_provider
+
+let with_mock_server ~port handler f =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let socket =
+      Eio.Net.listen
+        env#net
+        ~sw
+        ~backlog:128
+        ~reuse_addr:true
+        (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+    in
+    let server = Cohttp_eio.Server.make ~callback:handler () in
+    Eio.Fiber.fork ~sw (fun () ->
+      Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+    let endpoint = Printf.sprintf "http://127.0.0.1:%d" port in
+    f ~sw ~net:env#net ~endpoint;
+    Eio.Switch.fail sw Exit
+  with
+  | Unix.Unix_error (Unix.EPERM, "bind", _) -> Alcotest.skip ()
+  | Exit -> ()
+;;
+
+let test_get_json_success_and_parse_error () =
+  let handler _conn req body =
+    ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
+    match Uri.path (Cohttp.Request.uri req) with
+    | "/json" -> Cohttp_eio.Server.respond_string ~status:`OK ~body:{|{"ok":true}|} ()
+    | "/bad-json" -> Cohttp_eio.Server.respond_string ~status:`OK ~body:"not-json" ()
+    | _ -> Cohttp_eio.Server.respond_string ~status:`Not_found ~body:"missing" ()
+  in
+  with_mock_server ~port:18345 handler (fun ~sw ~net ~endpoint ->
+    (match Discovery_http.get_json ~sw ~net (endpoint ^ "/json") with
+     | Ok json ->
+       let open Yojson.Safe.Util in
+       check bool "ok" true (json |> member "ok" |> to_bool)
+     | Error err -> fail err);
+    match Discovery_http.get_json ~sw ~net (endpoint ^ "/bad-json") with
+    | Error err -> check bool "parse error" true (String.length err > 0)
+    | Ok _ -> fail "expected parse error")
+;;
+
+let test_get_json_http_error_and_get_ok () =
+  let handler _conn req body =
+    ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
+    match Uri.path (Cohttp.Request.uri req) with
+    | "/healthy" -> Cohttp_eio.Server.respond_string ~status:`No_content ~body:"" ()
+    | _ -> Cohttp_eio.Server.respond_string ~status:`Internal_server_error ~body:"boom" ()
+  in
+  with_mock_server ~port:18346 handler (fun ~sw ~net ~endpoint ->
+    (match Discovery_http.get_json ~sw ~net (endpoint ^ "/broken") with
+     | Error "HTTP 500" -> ()
+     | Error err -> fail ("unexpected error: " ^ err)
+     | Ok _ -> fail "expected HTTP 500");
+    check bool "get_ok true" true (Discovery_http.get_ok ~sw ~net (endpoint ^ "/healthy"));
+    check
+      bool
+      "get_ok false"
+      false
+      (Discovery_http.get_ok ~sw ~net (endpoint ^ "/broken")))
+;;
+
+let () =
+  run
+    "discovery-http"
+    [ ( "http helpers"
+      , [ test_case
+            "json success and parse error"
+            `Quick
+            test_get_json_success_and_parse_error
+        ; test_case "http error and ok probe" `Quick test_get_json_http_error_and_get_ok
+        ] )
+    ]
+;;

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -722,6 +722,193 @@ let test_build_request_with_thinking_default_budget () =
     (tc |> member "thinkingBudget" |> to_int)
 ;;
 
+let with_env name value f =
+  let saved = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match saved with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+;;
+
+let test_constants_http_code_sets () =
+  Alcotest.(check (list int))
+    "retryable"
+    [ 429; 500; 502; 503; 529 ]
+    Constants.Http.retryable_codes;
+  Alcotest.(check (list int))
+    "cascadable"
+    [ 401; 403; 429; 498; 500; 502; 503; 529 ]
+    Constants.Http.cascadable_codes
+;;
+
+let test_constants_inference_profiles () =
+  let check_profile label expected_temp expected_max profile =
+    Alcotest.(check (float 0.001))
+      (label ^ " temp")
+      expected_temp
+      profile.Constants.Inference_profile.temperature;
+    Alcotest.(check int) (label ^ " max") expected_max profile.max_tokens;
+    Alcotest.(check (option (float 0.001))) (label ^ " top_p") None profile.top_p;
+    Alcotest.(check (option int)) (label ^ " top_k") None profile.top_k;
+    Alcotest.(check (option (float 0.001))) (label ^ " min_p") None profile.min_p
+  in
+  check_profile "cascade" 0.3 500 Constants.Inference_profile.cascade_default;
+  check_profile "agent" 0.7 16_384 Constants.Inference_profile.agent_default;
+  check_profile "low_variance" 0.1 2048 Constants.Inference_profile.low_variance;
+  check_profile "worker" 0.2 16_384 Constants.Inference_profile.worker_default;
+  check_profile "deterministic" 0.0 4096 Constants.Inference_profile.deterministic;
+  Alcotest.(check (float 0.001))
+    "legacy temperature"
+    Constants.Inference_profile.cascade_default.temperature
+    Constants.Inference.default_temperature;
+  Alcotest.(check int)
+    "legacy max tokens"
+    Constants.Inference_profile.cascade_default.max_tokens
+    Constants.Inference.default_max_tokens
+;;
+
+let test_constants_retry_cache_sampling_and_endpoints () =
+  Alcotest.(check int) "cache ttl" 300 Constants.Cache.default_ttl_sec;
+  Alcotest.(check int) "retry max" 3 Constants.Retry.max_retries;
+  Alcotest.(check (float 0.001)) "retry initial" 1.0 Constants.Retry.initial_delay_sec;
+  Alcotest.(check (float 0.001)) "retry max delay" 30.0 Constants.Retry.max_delay_sec;
+  Alcotest.(check int) "structured max" 3 Constants.Structured_retry.max_retries;
+  Alcotest.(check (float 0.001))
+    "structured max delay"
+    60.0
+    Constants.Structured_retry.max_delay;
+  Alcotest.(check (float 0.001)) "min_p" 0.05 Constants.Sampling.openai_compat_min_p;
+  Alcotest.(check int) "truncate" 200 Constants.Truncation.max_error_body_length;
+  Alcotest.(check int) "llama port" 8085 Constants.Endpoints.default_llama_port;
+  Alcotest.(check string)
+    "default url"
+    "http://127.0.0.1:8085"
+    Constants.Endpoints.default_url;
+  Alcotest.(check string)
+    "localhost url"
+    "http://localhost:8085"
+    Constants.Endpoints.default_url_localhost;
+  Alcotest.(check int) "chars per token" 4 Constants.Token_estimation.chars_per_token
+;;
+
+let test_constants_env_helpers () =
+  with_env "OAS_DEFAULT_SEED" (Some "123") (fun () ->
+    Alcotest.(check (option int))
+      "seed valid"
+      (Some 123)
+      (Constants.Deterministic.seed_of_env ()));
+  with_env "OAS_DEFAULT_SEED" (Some "not-an-int") (fun () ->
+    Alcotest.(check (option int))
+      "seed invalid"
+      None
+      (Constants.Deterministic.seed_of_env ()));
+  with_env "OAS_THINKING_BUDGET_DEFAULT" (Some "4096") (fun () ->
+    Alcotest.(check (option int))
+      "env budget valid"
+      (Some 4096)
+      (Constants.Thinking.env_budget "OAS_THINKING_BUDGET_DEFAULT"));
+  with_env "OAS_THINKING_BUDGET_DEFAULT" (Some "0") (fun () ->
+    Alcotest.(check (option int))
+      "env budget zero invalid"
+      None
+      (Constants.Thinking.env_budget "OAS_THINKING_BUDGET_DEFAULT"));
+  with_env "OAS_ANTHROPIC_THINKING_BUDGET" (Some "2048") (fun () ->
+    Alcotest.(check int)
+      "anthropic override"
+      2048
+      (Constants.Thinking.anthropic_budget ()));
+  with_env "OAS_GEMINI_THINKING_BUDGET" (Some "3072") (fun () ->
+    Alcotest.(check int) "gemini override" 3072 (Constants.Thinking.gemini_budget ()));
+  Alcotest.(check int)
+    "anthropic cache min chars"
+    3500
+    Constants.Anthropic.default_prompt_cache_min_chars;
+  Alcotest.(check int)
+    "anthropic cache min tools"
+    3
+    Constants.Anthropic.prompt_cache_min_tools
+;;
+
+let test_slot_cache_helpers () =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "oas-slot-cache-%d" (Unix.getpid ()))
+  in
+  if Sys.file_exists dir then Unix.rmdir dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () -> if Sys.file_exists dir then Unix.rmdir dir)
+    (fun () ->
+       let filename = Slot_cache.cache_filename ~session_id:"session-1" ~slot_id:7 in
+       Alcotest.(check string) "filename" "slot-session-1-7.bin" filename;
+       let path = Filename.concat dir filename in
+       let oc = open_out path in
+       output_string oc "cache";
+       close_out oc;
+       Alcotest.(check bool) "file exists" true (Sys.file_exists path);
+       Slot_cache.cleanup_file ~filename ~save_dir:dir;
+       Alcotest.(check bool) "file removed" false (Sys.file_exists path);
+       Slot_cache.cleanup_file ~filename:"missing.bin" ~save_dir:dir)
+;;
+
+let test_llm_transport_runtime_mcp_policy_json () =
+  let stdio =
+    Llm_transport.Stdio_server
+      { name = "local"
+      ; command = "python"
+      ; args = [ "-m"; "server" ]
+      ; env = [ "TOKEN", "redacted" ]
+      }
+  in
+  let http =
+    Llm_transport.Http_server
+      { name = "remote"
+      ; url = "http://127.0.0.1:8931/mcp"
+      ; headers = [ "Authorization", "Bearer token" ]
+      }
+  in
+  Alcotest.(check string)
+    "stdio name"
+    "local"
+    (Llm_transport.runtime_mcp_server_name stdio);
+  Alcotest.(check string)
+    "http name"
+    "remote"
+    (Llm_transport.runtime_mcp_server_name http);
+  let policy =
+    { Llm_transport.servers = [ stdio; http ]
+    ; allowed_server_names = [ "local"; "remote" ]
+    ; allowed_tool_names = [ "read"; "write" ]
+    ; permission_mode = Some "ask"
+    ; approval_mode = Some "manual"
+    ; strict = false
+    ; disable_builtin_tools = true
+    }
+  in
+  let json = Llm_transport.runtime_mcp_policy_to_yojson policy in
+  let open Yojson.Safe.Util in
+  Alcotest.(check int)
+    "server count"
+    2
+    (json |> member "servers" |> to_list |> List.length);
+  Alcotest.(check string)
+    "permission"
+    "ask"
+    (json |> member "permission_mode" |> to_string);
+  Alcotest.(check string) "approval" "manual" (json |> member "approval_mode" |> to_string);
+  Alcotest.(check bool) "strict" false (json |> member "strict" |> to_bool);
+  Alcotest.(check bool)
+    "disable builtins"
+    true
+    (json |> member "disable_builtin_tools" |> to_bool)
+;;
+
 let test_build_request_json_mode () =
   let config =
     make_config ~kind:Gemini ~model_id:gemini25_flash_model ~response_format_json:true ()
@@ -1703,6 +1890,22 @@ let () =
             `Quick
             test_build_request_tool_choice_specific
         ; Alcotest.test_case "top_p top_k" `Quick test_build_request_top_p_top_k
+        ] )
+    ; ( "constants"
+      , [ Alcotest.test_case "http code sets" `Quick test_constants_http_code_sets
+        ; Alcotest.test_case "inference profiles" `Quick test_constants_inference_profiles
+        ; Alcotest.test_case
+            "retry cache sampling endpoints"
+            `Quick
+            test_constants_retry_cache_sampling_and_endpoints
+        ; Alcotest.test_case "env helpers" `Quick test_constants_env_helpers
+        ] )
+    ; "slot_cache", [ Alcotest.test_case "file helpers" `Quick test_slot_cache_helpers ]
+    ; ( "llm_transport"
+      , [ Alcotest.test_case
+            "runtime mcp policy json"
+            `Quick
+            test_llm_transport_runtime_mcp_policy_json
         ] )
     ; ( "backend_gemini.parse_response"
       , [ Alcotest.test_case "basic" `Quick test_parse_response_basic

--- a/test/test_progressive_tools.ml
+++ b/test/test_progressive_tools.ml
@@ -97,6 +97,133 @@ let test_gav_boundary_turns () =
   check_int "turn 6: all" 3 (List.length t6)
 ;;
 
+(* ── Retrieval_based ─────────────────────────────────── *)
+
+let retrieval_index () =
+  Tool_index.build
+    [ { name = "read_file"
+      ; description = "Read project files from disk"
+      ; group = Some "fs"
+      ; aliases = [ "open"; "inspect" ]
+      }
+    ; { name = "write_file"
+      ; description = "Write project files to disk"
+      ; group = Some "fs"
+      ; aliases = [ "save" ]
+      }
+    ; { name = "search_code"
+      ; description = "Search source code by text"
+      ; group = None
+      ; aliases = [ "grep"; "ripgrep" ]
+      }
+    ]
+;;
+
+let test_retrieval_without_context_uses_fallback () =
+  let strategy =
+    Progressive_tools.Retrieval_based
+      { index = retrieval_index ()
+      ; confidence_threshold = 0.01
+      ; fallback_tools = [ "read_file"; "search_code" ]
+      ; always_include = [ "help" ]
+      }
+  in
+  Alcotest.(check (list string))
+    "always + fallback"
+    [ "help"; "read_file"; "search_code" ]
+    (Progressive_tools.tools_for_turn strategy 1 ())
+;;
+
+let test_retrieval_confident_dedupes_always_and_group_tools () =
+  let strategy =
+    Progressive_tools.Retrieval_based
+      { index = retrieval_index ()
+      ; confidence_threshold = 0.01
+      ; fallback_tools = [ "fallback" ]
+      ; always_include = [ "read_file"; "help" ]
+      }
+  in
+  let tools =
+    Progressive_tools.tools_for_turn strategy 1 ~context:"inspect file contents" ()
+  in
+  check_bool "read present" true (List.mem "read_file" tools);
+  check_bool "group peer included" true (List.mem "write_file" tools);
+  check_bool "always included" true (List.mem "help" tools);
+  check_int
+    "deduped read_file"
+    1
+    (List.length (List.filter (String.equal "read_file") tools))
+;;
+
+let test_retrieval_below_threshold_uses_fallback () =
+  let strategy =
+    Progressive_tools.Retrieval_based
+      { index = retrieval_index ()
+      ; confidence_threshold = 10_000.0
+      ; fallback_tools = [ "safe_tool" ]
+      ; always_include = [ "help" ]
+      }
+  in
+  Alcotest.(check (list string))
+    "fallback"
+    [ "help"; "safe_tool" ]
+    (Progressive_tools.tools_for_turn strategy 3 ~context:"read project file" ())
+;;
+
+let test_retrieval_hook_extracts_last_user_message () =
+  let strategy =
+    Progressive_tools.Retrieval_based
+      { index = retrieval_index ()
+      ; confidence_threshold = 0.01
+      ; fallback_tools = [ "fallback" ]
+      ; always_include = [ "help" ]
+      }
+  in
+  let messages : Types.message list =
+    [ { role = Types.User
+      ; content =
+          [ Types.Text "first"
+          ; Types.Image { media_type = "image/png"; data = ""; source_type = "base64" }
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ; { role = Types.Assistant
+      ; content = [ Types.Text "assistant" ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ; { role = Types.User
+      ; content = [ Types.Text "search"; Types.Text "source code" ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let hook = Progressive_tools.as_hook strategy in
+  let event =
+    Hooks.BeforeTurnParams
+      { turn = 1
+      ; max_turns = 5
+      ; messages
+      ; last_tool_results = []
+      ; current_params = Hooks.default_turn_params
+      ; reasoning = Hooks.empty_reasoning_summary
+      }
+  in
+  match hook event with
+  | Hooks.AdjustParams params ->
+    (match params.tool_filter_override with
+     | Some (Guardrails.AllowList tools) ->
+       check_bool "retrieved search_code" true (List.mem "search_code" tools);
+       check_bool "always included" true (List.mem "help" tools)
+     | _ -> Alcotest.fail "expected AllowList")
+  | _ -> Alcotest.fail "expected AdjustParams"
+;;
+
 (* ── as_hook ──────────────────────────────────────────── *)
 
 let test_as_hook_returns_adjust_params () =
@@ -258,6 +385,24 @@ let () =
         ; Alcotest.test_case "act phase" `Quick test_gav_act_phase
         ; Alcotest.test_case "verify phase" `Quick test_gav_verify_phase
         ; Alcotest.test_case "boundary turns" `Quick test_gav_boundary_turns
+        ] )
+    ; ( "retrieval_based"
+      , [ Alcotest.test_case
+            "without context uses fallback"
+            `Quick
+            test_retrieval_without_context_uses_fallback
+        ; Alcotest.test_case
+            "confident retrieval dedupes"
+            `Quick
+            test_retrieval_confident_dedupes_always_and_group_tools
+        ; Alcotest.test_case
+            "below threshold uses fallback"
+            `Quick
+            test_retrieval_below_threshold_uses_fallback
+        ; Alcotest.test_case
+            "hook extracts last user context"
+            `Quick
+            test_retrieval_hook_extracts_last_user_message
         ] )
     ; ( "as_hook"
       , [ Alcotest.test_case

--- a/test/test_response_harness.ml
+++ b/test/test_response_harness.ml
@@ -1,0 +1,117 @@
+open Agent_sdk
+open Alcotest
+module R = Response_harness
+
+let check_metric label expected_name expected_value actual =
+  check string (label ^ " name") expected_name actual.Metric_contract.name;
+  check (float 0.001) (label ^ " value") expected_value actual.value
+;;
+
+let test_extract_first_float_patterns () =
+  check (option (float 0.001)) "plain" (Some 0.75) (R.extract_first_float "0.75");
+  check (option (float 0.001)) "prefix" (Some 0.85) (R.extract_first_float "Score: 0.85");
+  check (option (float 0.001)) "leading dot" (Some 0.5) (R.extract_first_float ".5 ok");
+  check
+    (option (float 0.001))
+    "negative"
+    (Some (-0.25))
+    (R.extract_first_float "loss=-0.25");
+  check (option (float 0.001)) "percent" (Some 0.75) (R.extract_first_float "75%");
+  check (option (float 0.001)) "none" None (R.extract_first_float "no number")
+;;
+
+let test_extract_score_tracks_telemetry () =
+  R.reset_telemetry ();
+  check (option (float 0.001)) "clamped high" (Some 1.0) (R.extract_score_from_text "2.5");
+  check (option (float 0.001)) "clamped low" (Some 0.0) (R.extract_score_from_text "-0.5");
+  check (option (float 0.001)) "missing" None (R.extract_score_from_text "none");
+  let snap = R.snapshot () in
+  check int "successes" 2 snap.parse_success;
+  check int "failures" 1 snap.parse_failure;
+  check int "text extractions" 2 snap.text_extraction;
+  check (float 0.001) "success rate" (2.0 /. 3.0) snap.success_rate
+;;
+
+let test_metric_schema_parse_paths () =
+  let schema = R.metric_schema ~metric_name:"quality" () in
+  check string "schema name" "report_metric" schema.name;
+  check int "params" 2 (List.length schema.params);
+  (match schema.parse (`Assoc [ "name", `String "quality"; "value", `Float 0.91 ]) with
+   | Ok parsed -> check_metric "parsed" "quality" 0.91 parsed
+   | Error err -> fail err);
+  (match
+     schema.parse (`Assoc [ "name", `String "quality"; "value", `Float Float.nan ])
+   with
+   | Error err -> check bool "finite error" true (String.length err > 0)
+   | Ok _ -> fail "expected nan rejection");
+  match schema.parse (`Assoc [ "name", `Int 1; "value", `String "bad" ]) with
+  | Error err -> check bool "type error" true (String.length err > 0)
+  | Ok _ -> fail "expected type error"
+;;
+
+let test_parse_metric_from_text_direct_recovered_and_failure () =
+  R.reset_telemetry ();
+  (match
+     R.parse_metric_from_text ~expected_name:"score" "<metric name=\"score\">0.7</metric>"
+   with
+   | Ok parsed -> check_metric "direct" "score" 0.7 parsed
+   | Error err -> fail err);
+  (match
+     R.parse_metric_from_text
+       ~expected_name:"score"
+       "```xml\n<metric name=\"score\">0.8</metric>\n```"
+   with
+   | Ok parsed -> check_metric "recovered" "score" 0.8 parsed
+   | Error err -> fail err);
+  (match
+     R.parse_metric_from_text ~expected_name:"score" "<metric name=\"loss\">0.2</metric>"
+   with
+   | Error err -> check bool "mismatch" true (String.length err > 0)
+   | Ok _ -> fail "expected mismatch");
+  let snap = R.snapshot () in
+  check int "parse success" 2 snap.parse_success;
+  check int "parse failure" 1 snap.parse_failure;
+  check int "recovery" 0 snap.recovery_applied;
+  check int "text extraction" 2 snap.text_extraction
+;;
+
+let test_extract_metric_from_response_tool_use () =
+  R.reset_telemetry ();
+  let content =
+    [ Types.Text "using tool"
+    ; Types.ToolUse
+        { id = "toolu-1"
+        ; name = "report_metric"
+        ; input = `Assoc [ "name", `String "score"; "value", `Float 0.66 ]
+        }
+    ]
+  in
+  (match R.extract_metric_from_response ~metric_name:"score" content with
+   | Ok parsed -> check_metric "tool metric" "score" 0.66 parsed
+   | Error err -> fail err);
+  (match R.extract_metric_from_response ~metric_name:"score" [ Types.Text "none" ] with
+   | Error err -> check bool "missing tool error" true (String.length err > 0)
+   | Ok _ -> fail "expected missing tool error");
+  let snap = R.snapshot () in
+  check int "success" 1 snap.parse_success;
+  check int "failure" 1 snap.parse_failure;
+  check int "tool extraction" 1 snap.tool_use_extraction
+;;
+
+let () =
+  run
+    "response-harness"
+    [ ( "float extraction"
+      , [ test_case "patterns" `Quick test_extract_first_float_patterns
+        ; test_case "score telemetry" `Quick test_extract_score_tracks_telemetry
+        ] )
+    ; ( "metric extraction"
+      , [ test_case "schema parse paths" `Quick test_metric_schema_parse_paths
+        ; test_case
+            "text direct recovered failure"
+            `Quick
+            test_parse_metric_from_text_direct_recovered_and_failure
+        ; test_case "tool use response" `Quick test_extract_metric_from_response_tool_use
+        ] )
+    ]
+;;

--- a/test/test_runtime_health.ml
+++ b/test/test_runtime_health.ml
@@ -1,0 +1,153 @@
+open Agent_sdk
+open Alcotest
+module H = Runtime_health
+
+let status =
+  testable (fun fmt s -> Format.pp_print_string fmt (H.status_to_string s)) ( = )
+;;
+
+let probe_name =
+  testable (fun fmt n -> Format.pp_print_string fmt (H.probe_name_to_string n)) ( = )
+;;
+
+let test_status_roundtrip () =
+  List.iter
+    (fun expected ->
+       let encoded = H.status_to_string expected in
+       match H.status_of_string encoded with
+       | Ok actual -> check status encoded expected actual
+       | Error err -> fail err)
+    [ H.Status_ok; Degraded; Failed; Unknown ];
+  match H.status_of_string "paused" with
+  | Error err -> check string "invalid status error" "unknown health status: paused" err
+  | Ok _ -> fail "expected invalid status to fail"
+;;
+
+let test_probe_name_roundtrip () =
+  let cases =
+    [ H.Provider, "provider"
+    ; Transport, "transport"
+    ; Checkpoint, "checkpoint"
+    ; Context, "context"
+    ; Event_bus, "event_bus"
+    ; Custom "scheduler", "scheduler"
+    ]
+  in
+  List.iter
+    (fun (expected, encoded) ->
+       check string "encode" encoded (H.probe_name_to_string expected);
+       check probe_name "decode" expected (H.probe_name_of_string encoded))
+    cases
+;;
+
+let test_make_probe_and_overall_status () =
+  let ok =
+    H.make_probe
+      ~name:H.Provider
+      ~status:H.Status_ok
+      ~detail:"ready"
+      ~checked_at:10.0
+      ~latency_ms:2.5
+      ()
+  in
+  check probe_name "probe name" H.Provider ok.name;
+  check status "probe status" H.Status_ok ok.status;
+  check (option string) "detail" (Some "ready") ok.detail;
+  check (float 0.001) "checked_at" 10.0 ok.checked_at;
+  check (option (float 0.001)) "latency_ms" (Some 2.5) ok.latency_ms;
+  check status "empty overall" H.Unknown (H.overall_status []);
+  check status "ok overall" H.Status_ok (H.overall_status [ ok ]);
+  check
+    status
+    "failed wins"
+    H.Failed
+    (H.overall_status
+       [ ok
+       ; H.make_probe ~name:H.Transport ~status:H.Degraded ~checked_at:11.0 ()
+       ; H.make_probe ~name:H.Context ~status:H.Failed ~checked_at:12.0 ()
+       ]);
+  check
+    status
+    "unknown beats ok"
+    H.Unknown
+    (H.overall_status [ ok; H.make_probe ~name:H.Event_bus ~status:H.Unknown () ])
+;;
+
+let test_report_json_roundtrip () =
+  let probes =
+    [ H.make_probe
+        ~name:H.Provider
+        ~status:H.Status_ok
+        ~detail:"provider reachable"
+        ~checked_at:1.0
+        ~latency_ms:3.0
+        ()
+    ; H.make_probe ~name:(H.Custom "queue") ~status:H.Degraded ~checked_at:2.0 ()
+    ]
+  in
+  let report = H.make ~generated_at:42.0 probes in
+  check status "overall" H.Degraded report.overall;
+  let json = H.to_json report in
+  match H.of_json json with
+  | Error err -> fail err
+  | Ok decoded ->
+    check (float 0.001) "generated_at" 42.0 decoded.generated_at;
+    check status "decoded overall" H.Degraded decoded.overall;
+    check int "probe count" 2 (List.length decoded.probes);
+    let first = List.hd decoded.probes in
+    check probe_name "first name" H.Provider first.name;
+    check (option string) "first detail" (Some "provider reachable") first.detail;
+    check (option (float 0.001)) "first latency" (Some 3.0) first.latency_ms
+;;
+
+let expect_error label expected = function
+  | Ok _ -> fail (label ^ ": expected error")
+  | Error actual -> check string label expected actual
+;;
+
+let test_json_error_paths () =
+  expect_error
+    "probe non-object"
+    "health probe must be a JSON object"
+    (H.probe_of_json `Null);
+  expect_error
+    "probe missing field"
+    "missing field: status"
+    (H.probe_of_json (`Assoc [ "name", `String "provider" ]));
+  expect_error
+    "probe bad status"
+    "unknown health status: weird"
+    (H.probe_of_json
+       (`Assoc
+           [ "name", `String "provider"
+           ; "status", `String "weird"
+           ; "detail", `Null
+           ; "checked_at", `Float 1.0
+           ; "latency_ms", `Null
+           ]));
+  expect_error
+    "report non-object"
+    "runtime health report must be a JSON object"
+    (H.of_json `Null);
+  expect_error
+    "report probes not list"
+    "field probes must be a list"
+    (H.of_json
+       (`Assoc
+           [ "generated_at", `Float 1.0; "overall", `String "ok"; "probes", `Assoc [] ]))
+;;
+
+let () =
+  run
+    "runtime-health"
+    [ ( "status"
+      , [ test_case "status roundtrip" `Quick test_status_roundtrip
+        ; test_case "probe name roundtrip" `Quick test_probe_name_roundtrip
+        ; test_case "overall severity" `Quick test_make_probe_and_overall_status
+        ] )
+    ; ( "json"
+      , [ test_case "report roundtrip" `Quick test_report_json_roundtrip
+        ; test_case "error paths" `Quick test_json_error_paths
+        ] )
+    ]
+;;

--- a/test/test_runtime_server_types.ml
+++ b/test/test_runtime_server_types.ml
@@ -81,6 +81,86 @@ let test_event_bus_run_id_omits_session_events () =
     (Runtime_server_types.event_bus_run_id_of_event event)
 ;;
 
+let input_request : Runtime.input_request =
+  { request_id = "input-1"
+  ; participant_name = Some "worker-1"
+  ; question = "Continue?"
+  ; schema = None
+  ; timeout_s = None
+  ; created_at = 1.0
+  }
+;;
+
+let test_custom_name_of_kind_all_variants () =
+  let participant = participant_event () in
+  let cases =
+    [ ( Runtime.Session_started { goal = "g"; participants = [ "p" ] }
+      , "runtime.session_started" )
+    ; ( Runtime.Session_settings_updated { model = Some "m"; permission_mode = None }
+      , "runtime.session_settings_updated" )
+    ; ( Runtime.Turn_recorded { actor = Some "user"; message = "hello" }
+      , "runtime.turn_recorded" )
+    ; Runtime.Input_required input_request, "runtime.input_required"
+    ; ( Runtime.Input_provided
+          { request_id = "input-1"
+          ; participant_name = Some "worker-1"
+          ; response = Runtime.Input_answer (`String "yes")
+          }
+      , "runtime.input_provided" )
+    ; ( Runtime.Agent_spawn_requested
+          { participant_name = "worker-1"
+          ; role = Some "reviewer"
+          ; prompt = "review"
+          ; provider = Some "mock"
+          ; model = Some "mock-model"
+          ; permission_mode = Some "ask"
+          }
+      , "runtime.agent_spawn_requested" )
+    ; Runtime.Agent_became_live participant, "runtime.agent_became_live"
+    ; ( Runtime.Agent_output_delta { participant_name = "worker-1"; delta = "delta" }
+      , "runtime.agent_output_delta" )
+    ; Runtime.Agent_completed participant, "runtime.agent_completed"
+    ; Runtime.Agent_failed participant, "runtime.agent_failed"
+    ; ( Runtime.Artifact_attached
+          { artifact_id = "artifact-1"
+          ; name = "report"
+          ; kind = "text"
+          ; mime_type = "text/plain"
+          ; path = "/tmp/report.txt"
+          ; size_bytes = 12
+          }
+      , "runtime.artifact_attached" )
+    ; ( Runtime.Checkpoint_saved { label = Some "cp"; path = "/tmp/cp" }
+      , "runtime.checkpoint_saved" )
+    ; Runtime.Finalize_requested { reason = Some "done" }, "runtime.finalize_requested"
+    ; Runtime.Session_completed { outcome = Some "ok" }, "runtime.session_completed"
+    ; Runtime.Session_failed { outcome = Some "failed" }, "runtime.session_failed"
+    ]
+  in
+  List.iter
+    (fun (kind, expected) ->
+       Alcotest.(check string)
+         expected
+         expected
+         (Runtime_server_types.custom_name_of_kind kind))
+    cases
+;;
+
+let test_session_root_request_path_trims_blank_values () =
+  Alcotest.(check (option string))
+    "blank"
+    None
+    (Runtime_server_types.session_root_request_path (Some "   "));
+  Alcotest.(check (option string))
+    "trimmed"
+    (Some "/tmp/oas")
+    (Runtime_server_types.session_root_request_path (Some "  /tmp/oas  "));
+  Alcotest.(check (option string))
+    "none"
+    None
+    (Runtime_server_types.session_root_request_path None)
+;;
+
 let () =
   Alcotest.run
     "Runtime_server_types"
@@ -104,6 +184,18 @@ let () =
             "omits session events"
             `Quick
             test_event_bus_run_id_omits_session_events
+        ] )
+    ; ( "event names"
+      , [ Alcotest.test_case
+            "custom names cover all event kinds"
+            `Quick
+            test_custom_name_of_kind_all_variants
+        ] )
+    ; ( "session root"
+      , [ Alcotest.test_case
+            "trims request path"
+            `Quick
+            test_session_root_request_path_trims_blank_values
         ] )
     ]
 ;;

--- a/test/test_slot_cache_http.ml
+++ b/test/test_slot_cache_http.ml
@@ -1,0 +1,111 @@
+open Alcotest
+open Llm_provider
+
+let contains_substring ~sub text =
+  let sub_len = String.length sub in
+  let text_len = String.length text in
+  let rec loop idx =
+    if idx + sub_len > text_len
+    then false
+    else if String.sub text idx sub_len = sub
+    then true
+    else loop (idx + 1)
+  in
+  sub_len = 0 || loop 0
+;;
+
+let with_mock_server ~port handler f =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let socket =
+      Eio.Net.listen
+        env#net
+        ~sw
+        ~backlog:128
+        ~reuse_addr:true
+        (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+    in
+    let server = Cohttp_eio.Server.make ~callback:handler () in
+    Eio.Fiber.fork ~sw (fun () ->
+      Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+    let endpoint = Printf.sprintf "http://127.0.0.1:%d" port in
+    f ~sw ~net:env#net ~endpoint;
+    Eio.Switch.fail sw Exit
+  with
+  | Unix.Unix_error (Unix.EPERM, "bind", _) -> Alcotest.skip ()
+  | Exit -> ()
+;;
+
+let test_save_restore_and_erase_send_expected_requests () =
+  let seen = ref [] in
+  let handler _conn req body =
+    let uri = Cohttp.Request.uri req in
+    let path = Uri.path uri in
+    let action = Uri.get_query_param uri "action" |> Option.value ~default:"" in
+    let body_text = Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) in
+    seen := (path, action, body_text) :: !seen;
+    Cohttp_eio.Server.respond_string ~status:`OK ~body:"{}" ()
+  in
+  with_mock_server ~port:18343 handler (fun ~sw ~net ~endpoint ->
+    check
+      (result unit string)
+      "save"
+      (Ok ())
+      (Slot_cache.save ~sw ~net ~endpoint ~slot_id:7 ~filename:"slot.bin");
+    check
+      (result unit string)
+      "restore"
+      (Ok ())
+      (Slot_cache.restore ~sw ~net ~endpoint ~slot_id:7 ~filename:"slot.bin");
+    check
+      (result unit string)
+      "erase"
+      (Ok ())
+      (Slot_cache.erase ~sw ~net ~endpoint ~slot_id:7));
+  let entries = List.rev !seen in
+  check int "request count" 3 (List.length entries);
+  check
+    (list (triple string string string))
+    "requests"
+    [ "/slots/7", "save", {|{"filename":"slot.bin"}|}
+    ; "/slots/7", "restore", {|{"filename":"slot.bin"}|}
+    ; "/slots/7", "erase", "{}"
+    ]
+    entries
+;;
+
+let test_non_2xx_response_surfaces_action_and_body () =
+  let handler _conn _req body =
+    ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
+    Cohttp_eio.Server.respond_string ~status:`Internal_server_error ~body:"slot failed" ()
+  in
+  with_mock_server ~port:18344 handler (fun ~sw ~net ~endpoint ->
+    match Slot_cache.restore ~sw ~net ~endpoint ~slot_id:3 ~filename:"missing.bin" with
+    | Ok () -> fail "expected restore error"
+    | Error msg ->
+      check
+        bool
+        "mentions action"
+        true
+        (contains_substring ~sub:"slot restore HTTP 500" msg);
+      check bool "mentions body" true (contains_substring ~sub:"slot failed" msg))
+;;
+
+let () =
+  run
+    "slot-cache-http"
+    [ ( "slot api"
+      , [ test_case
+            "save restore erase requests"
+            `Quick
+            test_save_restore_and_erase_send_expected_requests
+        ; test_case
+            "non-2xx response"
+            `Quick
+            test_non_2xx_response_surfaces_action_and_body
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

Coverage ratchet Stage C hotspot slice for #1175.

Adds focused behavior coverage for:
- `Runtime_health` status/probe severity and JSON error paths
- runtime server event-name and session-root helpers
- CLI transport factory create dispatch/rejection paths
- `Response_harness` metric extraction and telemetry paths
- `Progressive_tools` retrieval-based disclosure branch
- `Llm_transport` runtime MCP policy JSON helpers
- slot-cache and discovery HTTP helpers via loopback mock servers

## Validation

- `opam exec -- dune build --root . -j 2 test/test_runtime_health.exe test/test_runtime_server_types.exe test/test_cli_transport_factory.exe test/test_llm_provider_cov.exe test/test_response_harness.exe test/test_progressive_tools.exe test/test_slot_cache_http.exe test/test_discovery_http.exe`
- focused executables passed locally:
  - `test_runtime_health` 5 tests
  - `test_runtime_server_types` 7 tests
  - `test_cli_transport_factory` 14 tests
  - `test_llm_provider_cov` 137 tests
  - `test_response_harness` 5 tests
  - `test_progressive_tools` 17 tests
  - `test_slot_cache_http` / `test_discovery_http` skip locally when loopback bind is unavailable in this sandbox; they execute in normal CI/network environments
- `git diff --check`
- `git diff --cached --check`

Local full bisect coverage was not available because this opam switch does not have `bisect_ppx`; this PR intentionally leaves `THRESHOLD=72` unchanged so CI can measure the new coverage before the ratchet follow-up.