### PR TITLE
test: cover coverage ratchet hotspots

### DIFF
--- a/test/test_artifact_service.ml
+++ b/test/test_artifact_service.ml
@@ -126,6 +126,172 @@ let test_consistency_table () =
     ]
 ;;
 
+(* ── persisted artifact I/O ───────────────────────────── *)
+
+let require_ok label = function
+  | Ok value -> value
+  | Error err -> failf "%s: %s" label (Error.to_string err)
+;;
+
+let temp_root label =
+  Filename.concat
+    (Filename.get_temp_dir_name ())
+    (Printf.sprintf
+       "oas-artifact-service-%s-%d-%d"
+       label
+       (Unix.getpid ())
+       (int_of_float (Unix.gettimeofday () *. 1_000_000.0)))
+;;
+
+let make_session ?(artifacts = []) session_id : Runtime.session =
+  { session_id
+  ; goal = "test"
+  ; title = Some "Artifact test"
+  ; tag = None
+  ; permission_mode = None
+  ; phase = Runtime.Completed
+  ; created_at = 1.0
+  ; updated_at = 2.0
+  ; provider = None
+  ; model = None
+  ; system_prompt = None
+  ; max_turns = 1
+  ; workdir = None
+  ; planned_participants = []
+  ; participants = []
+  ; artifacts
+  ; pending_input = None
+  ; turn_count = 0
+  ; last_seq = 0
+  ; outcome = Some "ok"
+  }
+;;
+
+let make_descriptor ?path ?inline_content artifact_id : Runtime.artifact =
+  { artifact_id
+  ; name = "inline"
+  ; kind = "text"
+  ; mime_type = "text/plain"
+  ; path
+  ; inline_content
+  ; size_bytes = Option.fold ~none:0 ~some:String.length inline_content
+  ; created_at = 1.0
+  }
+;;
+
+let test_save_list_get_and_overwrite_text () =
+  let root = temp_root "persisted" in
+  let session_id = "sess-artifact-persisted" in
+  let store = require_ok "create store" (Runtime_store.create ~root ()) in
+  let artifact =
+    require_ok
+      "save artifact"
+      (Artifact_service.save_text_internal
+         store
+         ~session_id
+         ~name:" Report / One "
+         ~kind:" Markdown "
+         ~content:"initial")
+  in
+  check string "mime" "text/markdown" artifact.mime_type;
+  check int "size" 7 artifact.size_bytes;
+  let path = require_ok "persisted path" (Artifact_service.persisted_path artifact) in
+  check string "extension" ".md" (Filename.extension path);
+  check
+    string
+    "file content"
+    "initial"
+    (require_ok "load text" (Runtime_store.load_text path));
+  require_ok
+    "save session"
+    (Runtime_store.save_session store (make_session ~artifacts:[ artifact ] session_id));
+  let artifacts =
+    require_ok "list artifacts" (Artifact_service.list ~session_root:root ~session_id ())
+  in
+  check int "one artifact" 1 (List.length artifacts);
+  check
+    string
+    "get persisted text"
+    "initial"
+    (require_ok
+       "get text"
+       (Artifact_service.get_text
+          ~session_root:root
+          ~session_id
+          ~artifact_id:artifact.artifact_id
+          ()));
+  require_ok
+    "overwrite text"
+    (Artifact_service.overwrite_text_internal artifact ~content:"updated");
+  check
+    string
+    "get overwritten text"
+    "updated"
+    (require_ok
+       "get overwritten"
+       (Artifact_service.get_text
+          ~session_root:root
+          ~session_id
+          ~artifact_id:artifact.artifact_id
+          ()))
+;;
+
+let test_get_text_prefers_inline_content () =
+  let root = temp_root "inline" in
+  let session_id = "sess-artifact-inline" in
+  let store = require_ok "create store" (Runtime_store.create ~root ()) in
+  let artifact =
+    make_descriptor
+      ~path:"/path/that/should/not/be/read"
+      ~inline_content:"inline body"
+      "inline-1"
+  in
+  require_ok
+    "save session"
+    (Runtime_store.save_session store (make_session ~artifacts:[ artifact ] session_id));
+  check
+    string
+    "inline body"
+    "inline body"
+    (require_ok
+       "get inline"
+       (Artifact_service.get_text
+          ~session_root:root
+          ~session_id
+          ~artifact_id:"inline-1"
+          ()))
+;;
+
+let test_artifact_error_paths () =
+  let root = temp_root "errors" in
+  let session_id = "sess-artifact-errors" in
+  let store = require_ok "create store" (Runtime_store.create ~root ()) in
+  let dangling = make_descriptor "dangling" in
+  (match Artifact_service.persisted_path dangling with
+   | Ok path -> fail ("expected missing path error, got " ^ path)
+   | Error err ->
+     check
+       bool
+       "mentions no persisted file path"
+       true
+       (String.contains (Error.to_string err) 'n'));
+  require_ok
+    "save session"
+    (Runtime_store.save_session store (make_session ~artifacts:[ dangling ] session_id));
+  (match
+     Artifact_service.get_text ~session_root:root ~session_id ~artifact_id:"missing" ()
+   with
+   | Ok body -> fail ("expected missing artifact, got " ^ body)
+   | Error err ->
+     check bool "missing artifact error" true (String.length (Error.to_string err) > 0));
+  match
+    Artifact_service.get_text ~session_root:root ~session_id ~artifact_id:"dangling" ()
+  with
+  | Ok body -> fail ("expected dangling artifact error, got " ^ body)
+  | Error err ->
+    check bool "dangling artifact error" true (String.length (Error.to_string err) > 0)
+;;
+
 let () =
   run
     "Artifact_service"
@@ -156,5 +322,10 @@ let () =
         ; test_case "whitespace trimmed" `Quick test_mime_whitespace
         ] )
     ; "consistency", [ test_case "kind table" `Quick test_consistency_table ]
+    ; ( "io"
+      , [ test_case "save/list/get/overwrite" `Quick test_save_list_get_and_overwrite_text
+        ; test_case "inline content" `Quick test_get_text_prefers_inline_content
+        ; test_case "error paths" `Quick test_artifact_error_paths
+        ] )
     ]
 ;;

--- a/test/test_llm_provider_error.ml
+++ b/test/test_llm_provider_error.ml
@@ -9,6 +9,21 @@
 open Alcotest
 open Llm_provider
 
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    if needle_len = 0
+    then true
+    else if idx + needle_len > haystack_len
+    then false
+    else if String.sub haystack idx needle_len = needle
+    then true
+    else loop (idx + 1)
+  in
+  loop 0
+;;
+
 let test_missing_api_key () =
   check
     string
@@ -181,6 +196,94 @@ let test_provider_terminal () =
           }))
 ;;
 
+let test_capacity_scope_strings () =
+  List.iter
+    (fun (scope, expected) ->
+       check string expected expected (Error.capacity_scope_to_string scope))
+    [ Error.CapacityModel, "model"
+    ; Error.CapacityAccount, "account"
+    ; Error.CapacityRegion, "region"
+    ; Error.CapacityProvider, "provider"
+    ; Error.CapacityUnknown, "unknown"
+    ]
+;;
+
+let test_network_error_kind_strings_and_retryability () =
+  List.iter
+    (fun (kind, expected, retryable) ->
+       let err =
+         Error.NetworkError
+           { provider = "net"
+           ; kind
+           ; timeout_phase = Some Http_client.Http_operation
+           ; detail = "failed"
+           }
+       in
+       check
+         bool
+         ("contains " ^ expected)
+         true
+         (contains_substring (Error.to_string err) expected);
+       check bool ("retryable " ^ expected) retryable (Error.is_retryable err))
+    [ Http_client.Connection_refused, "connection_refused", true
+    ; Http_client.Dns_failure, "dns_failure", true
+    ; Http_client.Tls_error, "tls_error", false
+    ; Http_client.Timeout, "timeout", true
+    ; Http_client.Local_resource_exhaustion, "local_resource_exhaustion", false
+    ; Http_client.End_of_file, "end_of_file", true
+    ; Http_client.Unknown, "unknown", true
+    ]
+;;
+
+let test_capacity_exhausted_without_suffixes () =
+  check
+    string
+    "CapacityExhausted without affected/retry suffix"
+    "Provider capacity exhausted (unknown): no capacity detail"
+    (Error.to_string
+       (Error.CapacityExhausted
+          { scope = Error.CapacityUnknown
+          ; affected = []
+          ; retry_after = None
+          ; detail = "no capacity detail"
+          }))
+;;
+
+let test_is_retryable_matrix () =
+  let retryable =
+    [ Error.RateLimit { provider = "p"; retry_after = None; detail = "soft" }
+    ; Error.CapacityExhausted
+        { scope = Error.CapacityProvider
+        ; affected = [ "p" ]
+        ; retry_after = None
+        ; detail = "busy"
+        }
+    ; Error.ServerError { provider = "p"; code = 503; transient = true; detail = "x" }
+    ; Error.Timeout { provider = "p"; timeout_phase = None; detail = "x" }
+    ]
+  in
+  let terminal =
+    [ Error.MissingApiKey { var_name = "KEY" }
+    ; Error.InvalidConfig { field = "f"; detail = "bad" }
+    ; Error.ParseError { detail = "bad json" }
+    ; Error.UnknownVariant { type_name = "kind"; value = "new" }
+    ; Error.ProviderUnavailable { provider = "p"; detail = "down" }
+    ; Error.HardQuota { provider = "p"; retry_after = None; detail = "quota" }
+    ; Error.AuthError { provider = "p"; detail = "denied" }
+    ; Error.ServerError { provider = "p"; code = 400; transient = false; detail = "x" }
+    ; Error.InvalidRequest { provider = "p"; reason = "bad" }
+    ; Error.NotFound { provider = "p"; detail = "missing" }
+    ; Error.ProviderTerminal { provider = "p"; reason = "done"; detail = "stop" }
+    ]
+  in
+  List.iter
+    (fun err -> check bool (Error.to_string err) true (Error.is_retryable err))
+    retryable;
+  List.iter
+    (fun err -> check bool (Error.to_string err) false (Error.is_retryable err))
+    terminal
+;;
+
 let test_retry_rate_limit_mapping () =
   let err =
     Error.of_retry_api_error
@@ -233,6 +336,39 @@ let test_retry_overloaded_unknown_provider_mapping () =
   check_unknown_provider (Some "")
 ;;
 
+let test_retry_api_error_variant_mappings () =
+  let cases =
+    [ ( Error.of_retry_api_error ~provider:"auth" (Retry.AuthError { message = "bad key" })
+      , "Provider 'auth' auth error: bad key" )
+    ; ( Error.of_retry_api_error
+          ~provider:"bad"
+          (Retry.InvalidRequest { message = "bad request" })
+      , "Provider 'bad' invalid request: bad request" )
+    ; ( Error.of_retry_api_error ~provider:"missing" (Retry.NotFound { message = "gone" })
+      , "Provider 'missing' not found: gone" )
+    ; ( Error.of_retry_api_error
+          ~provider:"ctx"
+          (Retry.ContextOverflow { message = "too long"; limit = Some 200_000 })
+      , "Provider 'ctx' invalid request: Context overflow (limit: 200000): too long" )
+    ; ( Error.of_retry_api_error
+          ~provider:"net"
+          (Retry.NetworkError { message = "eof"; kind = Http_client.End_of_file })
+      , "Provider 'net' network error (end_of_file): eof" )
+    ; ( Error.of_retry_api_error
+          ~provider:"slow"
+          (Retry.Timeout { message = "wall clock" })
+      , "Provider 'slow' timeout: wall clock" )
+    ; ( Error.of_retry_api_error
+          ~provider:"server"
+          (Retry.ServerError { status = 418; message = "teapot" })
+      , "Provider 'server' server error 418 (transient=true): teapot" )
+    ]
+  in
+  List.iter
+    (fun (err, expected) -> check string expected expected (Error.to_string err))
+    cases
+;;
+
 let test_http_capacity_failure_mapping () =
   let err =
     Error.of_http_error
@@ -254,6 +390,115 @@ let test_http_capacity_failure_mapping () =
     check (option (float 0.001)) "retry_after" (Some 7.0) retry_after;
     check string "detail" "model queue saturated" detail
   | _ -> fail "expected CapacityExhausted"
+;;
+
+let test_http_capacity_failure_scope_mappings () =
+  List.iter
+    (fun (http_scope, provider, expected_scope, expected_affected) ->
+       let err =
+         Error.of_http_error
+           ~provider
+           (Http_client.ProviderFailure
+              { kind =
+                  Http_client.Capacity_exhausted
+                    { scope = http_scope; retry_after = None; model = None }
+              ; message = "capacity"
+              })
+       in
+       match err with
+       | Error.CapacityExhausted { scope; affected; retry_after; detail } ->
+         check bool "scope" true (scope = expected_scope);
+         check (list string) "affected" expected_affected affected;
+         check (option (float 0.001)) "retry_after" None retry_after;
+         check string "detail" "capacity" detail
+       | _ -> fail "expected CapacityExhausted")
+    [ Http_client.Failure_scope_account, "account", Error.CapacityAccount, [ "account" ]
+    ; Http_client.Failure_scope_region, "region", Error.CapacityRegion, [ "region" ]
+    ; ( Http_client.Failure_scope_provider
+      , "provider"
+      , Error.CapacityProvider
+      , [ "provider" ] )
+    ; Http_client.Failure_scope_unknown, "", Error.CapacityUnknown, []
+    ]
+;;
+
+let test_http_provider_failure_variant_mappings () =
+  let cases =
+    [ ( Error.of_http_error
+          ~provider:"quota"
+          (Http_client.ProviderFailure
+             { kind = Http_client.Hard_quota { retry_after = Some 11.0 }
+             ; message = "paywall"
+             })
+      , "Provider 'quota' hard quota exhausted: paywall (retry_after: 11.000s)" )
+    ; ( Error.of_http_error
+          ~provider:"caps"
+          (Http_client.ProviderFailure
+             { kind = Http_client.Capability_mismatch { capability = Some "tools" }
+             ; message = "not supported"
+             })
+      , "Provider 'caps' invalid request: missing capability: tools: not supported" )
+    ; ( Error.of_http_error
+          ~provider:"caps"
+          (Http_client.ProviderFailure
+             { kind = Http_client.Capability_mismatch { capability = None }
+             ; message = "not supported"
+             })
+      , "Provider 'caps' invalid request: missing provider capability: not supported" )
+    ; ( Error.of_http_error
+          ~provider:"cli"
+          (Http_client.ProviderFailure
+             { kind =
+                 Http_client.Cli_policy_invalid
+                   { tool_name = Some "shell"; rule = Some 2 }
+             ; message = "blocked"
+             })
+      , "Provider 'cli' invalid request: CLI policy rejected shell at rule 2: blocked" )
+    ; ( Error.of_http_error
+          ~provider:"cli"
+          (Http_client.ProviderFailure
+             { kind = Http_client.Cli_policy_invalid { tool_name = None; rule = None }
+             ; message = "blocked"
+             })
+      , "Provider 'cli' invalid request: CLI policy rejected unknown_tool: blocked" )
+    ; ( Error.of_http_error
+          ~provider:"cli"
+          (Http_client.ProviderFailure
+             { kind = Http_client.Cli_startup_failed { reason = "missing binary" }
+             ; message = "codex"
+             })
+      , "Provider 'cli' unavailable: missing binary: codex" )
+    ; ( Error.of_http_error
+          (Http_client.ProviderFailure
+             { kind = Http_client.Provider_parse_error { parser = Some "openai" }
+             ; message = "bad choices"
+             })
+      , "Parse error: openai: bad choices" )
+    ; ( Error.of_http_error
+          (Http_client.ProviderFailure
+             { kind = Http_client.Provider_parse_error { parser = None }
+             ; message = "bad choices"
+             })
+      , "Parse error: unknown_parser: bad choices" )
+    ; ( Error.of_http_error
+          ~provider:"mystery"
+          (Http_client.ProviderFailure
+             { kind = Http_client.Unknown_provider_failure { reason = Some "throttle" }
+             ; message = "no slots"
+             })
+      , "Provider 'mystery' unavailable: throttle: no slots" )
+    ; ( Error.of_http_error
+          ~provider:"mystery"
+          (Http_client.ProviderFailure
+             { kind = Http_client.Unknown_provider_failure { reason = None }
+             ; message = "no slots"
+             })
+      , "Provider 'mystery' unavailable: unknown_provider_failure: no slots" )
+    ]
+  in
+  List.iter
+    (fun (err, expected) -> check string expected expected (Error.to_string err))
+    cases
 ;;
 
 let test_http_server_error_mapping () =
@@ -286,6 +531,30 @@ let test_http_terminal_mapping () =
     check string "reason" "max_turns:31/31" reason;
     check string "detail" "turn cap hit" detail
   | _ -> fail "expected ProviderTerminal"
+;;
+
+let test_http_accept_rejected_and_terminal_other_mapping () =
+  let accept =
+    Error.of_http_error
+      ~provider:"openai"
+      (Http_client.AcceptRejected { reason = "schema mismatch" })
+  in
+  check
+    string
+    "accept rejected"
+    "Provider 'openai' invalid request: accept rejected: schema mismatch"
+    (Error.to_string accept);
+  let terminal =
+    Error.of_http_error
+      ~provider:"claude_code"
+      (Http_client.ProviderTerminal
+         { kind = Http_client.Other "policy_stop"; message = "stopped" })
+  in
+  check
+    string
+    "terminal other"
+    "Provider 'claude_code' terminal policy_stop: stopped"
+    (Error.to_string terminal)
 ;;
 
 let test_http_network_error_mapping () =
@@ -359,6 +628,16 @@ let () =
         ; test_case "InvalidRequest" `Quick test_invalid_request
         ; test_case "NotFound" `Quick test_not_found
         ; test_case "ProviderTerminal" `Quick test_provider_terminal
+        ; test_case "capacity scope strings" `Quick test_capacity_scope_strings
+        ; test_case
+            "network kinds and retryability"
+            `Quick
+            test_network_error_kind_strings_and_retryability
+        ; test_case
+            "CapacityExhausted without suffixes"
+            `Quick
+            test_capacity_exhausted_without_suffixes
+        ; test_case "is_retryable matrix" `Quick test_is_retryable_matrix
         ] )
     ; ( "mapping"
       , [ test_case "Retry RateLimited" `Quick test_retry_rate_limit_mapping
@@ -367,9 +646,25 @@ let () =
             "Retry overloaded unknown provider"
             `Quick
             test_retry_overloaded_unknown_provider_mapping
+        ; test_case
+            "Retry api_error variants"
+            `Quick
+            test_retry_api_error_variant_mappings
         ; test_case "HTTP capacity failure" `Quick test_http_capacity_failure_mapping
+        ; test_case
+            "HTTP capacity scope variants"
+            `Quick
+            test_http_capacity_failure_scope_mappings
+        ; test_case
+            "HTTP provider failure variants"
+            `Quick
+            test_http_provider_failure_variant_mappings
         ; test_case "HTTP server error" `Quick test_http_server_error_mapping
         ; test_case "HTTP terminal" `Quick test_http_terminal_mapping
+        ; test_case
+            "HTTP accept rejected and terminal other"
+            `Quick
+            test_http_accept_rejected_and_terminal_other_mapping
         ; test_case "HTTP network error" `Quick test_http_network_error_mapping
         ; test_case "HTTP timeout error" `Quick test_http_timeout_error_mapping
         ; test_case "CLI transport required" `Quick test_cli_transport_required_mapping

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -289,6 +289,115 @@ let test_format_errors_inline_multiple () =
      Re.execp re1 msg && Re.execp re2 msg)
 ;;
 
+(* ── Low-level helper coverage ─────────────────────────── *)
+
+let test_describe_json_value_variants () =
+  let cases =
+    [ `Null, "null"
+    ; `Bool true, "boolean(true)"
+    ; `Int 7, "integer(7)"
+    ; `Float 3.5, "number(3.5)"
+    ; `String "abcdefghijklmnopqrstuv", "string(\"abcdefghijklmnopqrst...\")"
+    ; `List [], "array"
+    ; `Assoc [], "object"
+    ; `Intlit "9223372036854775808", "integer(9223372036854775808)"
+    ]
+  in
+  List.iter
+    (fun (json, expected) ->
+       check string expected expected (Tool_input_validation.describe_json_value json))
+    cases
+;;
+
+let check_coerce expected_type input expected =
+  match Tool_input_validation.try_coerce expected_type input, expected with
+  | Some actual, Some expected_json ->
+    check bool "coerced json" true (Yojson.Safe.equal actual expected_json)
+  | None, None -> ()
+  | Some actual, None -> fail ("expected no coercion, got " ^ Yojson.Safe.to_string actual)
+  | None, Some expected_json ->
+    fail ("expected coercion to " ^ Yojson.Safe.to_string expected_json)
+;;
+
+let test_try_coerce_additional_shapes () =
+  check_coerce Types.Integer (`Float 4.0) (Some (`Int 4));
+  check_coerce Types.Integer (`Float 4.5) None;
+  check_coerce Types.String (`Bool false) (Some (`String "false"));
+  check_coerce Types.String (`Int 9) (Some (`String "9"));
+  check_coerce Types.String (`Float 2.25) (Some (`String "2.25"));
+  check_coerce Types.Integer (`Intlit "123") (Some (`Int 123));
+  check_coerce Types.Integer (`Intlit "abc") None;
+  check_coerce Types.Number (`Intlit "123") (Some (`Float 123.0));
+  check_coerce Types.Number (`Intlit "abc") None
+;;
+
+let test_matches_type_additional_shapes () =
+  check bool "array" true (Tool_input_validation.matches_type Types.Array (`List []));
+  check bool "object" true (Tool_input_validation.matches_type Types.Object (`Assoc []));
+  check
+    bool
+    "intlit integer"
+    true
+    (Tool_input_validation.matches_type Types.Integer (`Intlit "42"));
+  check
+    bool
+    "intlit number"
+    true
+    (Tool_input_validation.matches_type Types.Number (`Intlit "42"));
+  check
+    bool
+    "bool is not object"
+    false
+    (Tool_input_validation.matches_type Types.Object (`Bool true))
+;;
+
+let test_validate_raw_non_object_input () =
+  let schema = make_schema [ make_param ~param_type:Types.Object "_raw" ] in
+  match Tool_input_validation.validate schema (`String "not-object") with
+  | Tool_input_validation.Invalid [ err ] ->
+    check string "path" "/_raw" err.path;
+    check string "expected" "object" err.expected;
+    check string "actual" "string(\"not-object\")" err.actual
+  | Tool_input_validation.Invalid errs ->
+    fail ("expected one error, got " ^ string_of_int (List.length errs))
+  | Tool_input_validation.Valid _ -> fail "expected raw object mismatch"
+;;
+
+let test_validate_null_input_with_required_field () =
+  let schema = make_schema [ make_param ~param_type:Types.String "name" ] in
+  match Tool_input_validation.validate schema `Null with
+  | Tool_input_validation.Invalid [ err ] ->
+    check string "path" "/name" err.path;
+    check string "actual" Tool_input_validation.missing_actual err.actual
+  | Tool_input_validation.Invalid errs ->
+    fail ("expected one error, got " ^ string_of_int (List.length errs))
+  | Tool_input_validation.Valid _ -> fail "expected required field error"
+;;
+
+let test_validate_intlit_and_exact_float_normalization () =
+  let schema =
+    make_schema
+      [ make_param ~param_type:Types.Integer "count"
+      ; make_param ~param_type:Types.Integer "exact"
+      ]
+  in
+  let input = `Assoc [ "count", `Intlit "42"; "exact", `Float 5.0 ] in
+  match Tool_input_validation.validate schema input with
+  | Tool_input_validation.Valid coerced ->
+    check
+      bool
+      "count normalized"
+      true
+      (Yojson.Safe.equal (Yojson.Safe.Util.member "count" coerced) (`Int 42));
+    check
+      bool
+      "exact float normalized"
+      true
+      (Yojson.Safe.equal (Yojson.Safe.Util.member "exact" coerced) (`Int 5))
+  | Tool_input_validation.Invalid errs ->
+    fail (Tool_input_validation.format_errors ~tool_name:"test_tool" errs)
+;;
+
 (* ── Test runner ──────────────────────────────────────── *)
 
 let () =
@@ -323,6 +432,29 @@ let () =
         ; test_case "inline: missing field" `Quick test_format_errors_inline_missing
         ; test_case "inline: type error" `Quick test_format_errors_inline_type_error
         ; test_case "inline: multiple errors" `Quick test_format_errors_inline_multiple
+        ] )
+    ; ( "helpers"
+      , [ test_case
+            "describe_json_value variants"
+            `Quick
+            test_describe_json_value_variants
+        ; test_case
+            "try_coerce additional shapes"
+            `Quick
+            test_try_coerce_additional_shapes
+        ; test_case
+            "matches_type additional shapes"
+            `Quick
+            test_matches_type_additional_shapes
+        ; test_case "raw non-object input" `Quick test_validate_raw_non_object_input
+        ; test_case
+            "null input with required field"
+            `Quick
+            test_validate_null_input_with_required_field
+        ; test_case
+            "intlit and exact float normalization"
+            `Quick
+            test_validate_intlit_and_exact_float_normalization
         ] )
     ]
 ;;

--- a/test/test_tool_schema_gen.ml
+++ b/test/test_tool_schema_gen.ml
@@ -100,6 +100,81 @@ let test_triple_params () =
   Alcotest.(check int) "3 params" 3 (List.length (Tool_schema_gen.to_params triple))
 ;;
 
+(* ── Four-field schema and coercion/error collection ─────────── *)
+
+let quad =
+  Tool_schema_gen.(
+    four
+      (string_field "name" ~required:true ~desc:"Name" ())
+      (int_field "count" ~required:true ~desc:"Count" ())
+      (float_field "ratio" ~required:false ~desc:"Ratio" ~default:1.5 ())
+      (bool_field "enabled" ~required:false ~desc:"Enabled" ~default:true ()))
+;;
+
+let test_quad_parse_with_coercions () =
+  let json =
+    `Assoc
+      [ "name", `Bool false
+      ; "count", `String " 8 "
+      ; "ratio", `Int 2
+      ; "enabled", `String "false"
+      ]
+  in
+  match Tool_schema_gen.parse quad json with
+  | Ok (name, count, ratio, enabled) ->
+    Alcotest.(check string) "name coerced" "false" name;
+    Alcotest.(check int) "count coerced" 8 count;
+    Alcotest.(check (float 0.001)) "ratio widened" 2.0 ratio;
+    Alcotest.(check bool) "enabled coerced" false enabled
+  | Error errs -> Alcotest.fail (format_errors errs)
+;;
+
+let test_quad_optional_defaults () =
+  let json = `Assoc [ "name", `String "Alice"; "count", `Int 1 ] in
+  match Tool_schema_gen.parse quad json with
+  | Ok (name, count, ratio, enabled) ->
+    Alcotest.(check string) "name" "Alice" name;
+    Alcotest.(check int) "count" 1 count;
+    Alcotest.(check (float 0.001)) "ratio default" 1.5 ratio;
+    Alcotest.(check bool) "enabled default" true enabled
+  | Error errs -> Alcotest.fail (format_errors errs)
+;;
+
+let test_quad_params_and_json_schema () =
+  Alcotest.(check int) "4 params" 4 (List.length (Tool_schema_gen.to_params quad));
+  let schema_json = Tool_schema_gen.to_json_schema quad in
+  let open Yojson.Safe.Util in
+  let props = schema_json |> member "properties" in
+  Alcotest.(check bool) "has ratio" true (props |> member "ratio" <> `Null);
+  Alcotest.(check bool) "has enabled" true (props |> member "enabled" <> `Null);
+  let req = schema_json |> member "required" |> to_list in
+  Alcotest.(check int) "2 required" 2 (List.length req)
+;;
+
+let test_quad_collects_multiple_errors () =
+  let json =
+    `Assoc [ "name", `List []; "ratio", `String "not-a-float"; "enabled", `String "true" ]
+  in
+  match Tool_schema_gen.parse quad json with
+  | Ok _ -> Alcotest.fail "expected errors"
+  | Error errs ->
+    Alcotest.(check int) "three errors" 3 (List.length errs);
+    Alcotest.(check (list string))
+      "paths"
+      [ "name"; "count"; "ratio" ]
+      (List.map (fun e -> e.Tool_input_validation.path) errs)
+;;
+
+let float_schema =
+  Tool_schema_gen.(one (float_field "score" ~required:true ~desc:"Score" ()))
+;;
+
+let test_float_accepts_int () =
+  match Tool_schema_gen.parse float_schema (`Assoc [ "score", `Int 9 ]) with
+  | Ok score -> Alcotest.(check (float 0.001)) "score" 9.0 score
+  | Error errs -> Alcotest.fail (format_errors errs)
+;;
+
 (* ── Integration: schema_gen + Typed_tool ───────────────── *)
 
 let test_typed_tool_integration () =
@@ -148,6 +223,16 @@ let () =
     ; ( "three_field"
       , [ Alcotest.test_case "parse" `Quick test_triple_parse
         ; Alcotest.test_case "params count" `Quick test_triple_params
+        ] )
+    ; ( "four_field"
+      , [ Alcotest.test_case "parse with coercions" `Quick test_quad_parse_with_coercions
+        ; Alcotest.test_case "optional defaults" `Quick test_quad_optional_defaults
+        ; Alcotest.test_case
+            "params and json schema"
+            `Quick
+            test_quad_params_and_json_schema
+        ; Alcotest.test_case "multiple errors" `Quick test_quad_collects_multiple_errors
+        ; Alcotest.test_case "float accepts int" `Quick test_float_accepts_int
         ] )
     ; ( "integration"
       , [ Alcotest.test_case "schema_gen + Typed_tool" `Quick test_typed_tool_integration

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -326,6 +326,64 @@ let test_tool_choice_roundtrip_all () =
     variants
 ;;
 
+let test_tool_choice_tool_requires_name () =
+  let json = `Assoc [ "type", `String "tool" ] in
+  match Types.tool_choice_of_json json with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected error for tool choice without name"
+;;
+
+let test_response_format_roundtrip_modes () =
+  let schema = `Assoc [ "type", `String "object" ] in
+  let variants = [ Types.Off; Types.JsonMode; Types.JsonSchema schema ] in
+  List.iter
+    (fun rf ->
+       let json = Types.response_format_to_json rf in
+       match Types.response_format_of_json json with
+       | Ok decoded ->
+         Alcotest.(check string)
+           "response_format roundtrip"
+           (Types.show_response_format rf)
+           (Types.show_response_format decoded)
+       | Error err ->
+         Alcotest.fail ("response_format roundtrip failed: " ^ Error.to_string err))
+    variants
+;;
+
+let test_response_format_bool_and_null () =
+  (match Types.response_format_of_json (`Bool true) with
+   | Ok Types.JsonMode -> ()
+   | Ok other ->
+     Alcotest.fail ("expected JsonMode, got " ^ Types.show_response_format other)
+   | Error err -> Alcotest.fail (Error.to_string err));
+  (match Types.response_format_of_json (`Bool false) with
+   | Ok Types.Off -> ()
+   | Ok other -> Alcotest.fail ("expected Off, got " ^ Types.show_response_format other)
+   | Error err -> Alcotest.fail (Error.to_string err));
+  match Types.response_format_of_json `Null with
+  | Ok Types.Off -> ()
+  | Ok other -> Alcotest.fail ("expected Off, got " ^ Types.show_response_format other)
+  | Error err -> Alcotest.fail (Error.to_string err)
+;;
+
+let test_response_format_errors () =
+  let cases =
+    [ `Assoc [ "type", `String "json_schema" ]
+    ; `Assoc [ "type", `String "future_mode" ]
+    ; `Assoc []
+    ; `String "json"
+    ]
+  in
+  List.iter
+    (fun json ->
+       match Types.response_format_of_json json with
+       | Error _ -> ()
+       | Ok decoded ->
+         Alcotest.fail
+           ("expected response_format error, got " ^ Types.show_response_format decoded))
+    cases
+;;
+
 (* ── role_of_string ──────────────────────────────────────── *)
 
 let test_role_of_string () =
@@ -497,6 +555,15 @@ let () =
     ; ( "tool_choice_errors"
       , [ Alcotest.test_case "bogus type" `Quick test_tool_choice_of_json_error_bogus
         ; Alcotest.test_case "non-object" `Quick test_tool_choice_of_json_error_non_object
+        ; Alcotest.test_case
+            "tool missing name"
+            `Quick
+            test_tool_choice_tool_requires_name
+        ] )
+    ; ( "response_format"
+      , [ Alcotest.test_case "roundtrip modes" `Quick test_response_format_roundtrip_modes
+        ; Alcotest.test_case "bool and null" `Quick test_response_format_bool_and_null
+        ; Alcotest.test_case "errors" `Quick test_response_format_errors
         ] )
     ; ( "show_functions"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary

Follow-up coverage ratchet slice for #1175 after #1726 measured 74.48% project coverage.

Adds focused branch coverage for:
- `Llm_provider.Error` retryability and HTTP/provider failure mapping variants
- `Tool_schema_gen` four-field schemas, coercion, defaults, and multi-error collection
- `Tool_input_validation` helper coercions, raw input handling, null required fields, and normalization
- `Artifact_service` persisted/inline artifact list/get/overwrite/error paths
- `Types.response_format` and tool-choice parser error branches

This PR intentionally leaves the CI threshold unchanged until GitHub Actions measures the updated bisect coverage. If CI lands above 75%, the next PR can ratchet `.github/workflows/ci.yml` from `THRESHOLD=72` to the safe integer floor below the measured value.

## Validation

- `opam exec -- ocamlformat --inplace test/test_llm_provider_error.ml test/test_tool_schema_gen.ml test/test_tool_input_validation.ml test/test_artifact_service.ml test/test_types.ml`
- `scripts/dune-local.sh build test/test_llm_provider_error.exe test/test_tool_schema_gen.exe test/test_tool_input_validation.exe test/test_artifact_service.exe test/test_types.exe`
- `./_build/default/test/test_llm_provider_error.exe` (33 tests)
- `./_build/default/test/test_tool_schema_gen.exe` (15 tests)
- `./_build/default/test/test_tool_input_validation.exe` (26 tests)
- `./_build/default/test/test_artifact_service.exe` (26 tests)
- `./_build/default/test/test_types.exe` (44 tests)
- `git diff --check`
- `git diff --cached --check`