### PR TITLE
ci: repair post vendor purge gates

### DIFF
--- a/lib/api_provider_d.ml
+++ b/lib/api_provider_d.ml
@@ -111,7 +111,9 @@ let build_provider_d_body ?provider_config ~config ~messages ?tools ?slot_id () 
     | Some top_k when capabilities.supports_top_k -> ("top_k", `Int top_k) :: body_assoc
     | None -> body_assoc
     | Some _ ->
-      Llm_provider.Backend_provider_d.warn_capability_drop ~model_id:model_str ~field:"top_k";
+      Llm_provider.Backend_provider_d.warn_capability_drop
+        ~model_id:model_str
+        ~field:"top_k";
       body_assoc
   in
   let body_assoc =
@@ -119,7 +121,9 @@ let build_provider_d_body ?provider_config ~config ~messages ?tools ?slot_id () 
     | Some min_p when capabilities.supports_min_p -> ("min_p", `Float min_p) :: body_assoc
     | None -> body_assoc
     | Some _ ->
-      Llm_provider.Backend_provider_d.warn_capability_drop ~model_id:model_str ~field:"min_p";
+      Llm_provider.Backend_provider_d.warn_capability_drop
+        ~model_id:model_str
+        ~field:"min_p";
       body_assoc
   in
   let body_assoc =

--- a/lib/api_zai.ml
+++ b/lib/api_zai.ml
@@ -410,7 +410,8 @@ let%test "parse_image_generation rejects malformed json" =
 
 let%test "parse_async_submit handles basic body" =
   match
-    parse_async_submit {|{"model":"provider_k-image","id":"job-1","task_status":"PROCESSING"}|}
+    parse_async_submit
+      {|{"model":"provider_k-image","id":"job-1","task_status":"PROCESSING"}|}
   with
   | Ok result -> result.id = "job-1" && result.task_status = Processing
   | Error _ -> false
@@ -471,7 +472,10 @@ let%test "parse_transcription handles sync response" =
 
 let%test "multipart_body reports missing file path" =
   match
-    multipart_body ~model:"provider_k-asr-2512" ~source:(File_path "/nonexistent/file.wav") ()
+    multipart_body
+      ~model:"provider_k-asr-2512"
+      ~source:(File_path "/nonexistent/file.wav")
+      ()
   with
   | Error _ -> true
   | Ok _ -> false

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -30,7 +30,8 @@ let build_request
        ]
      | _ -> [])
     @ List.concat_map
-        (Backend_provider_d_serialize.ollama_messages_of_message ~model_id:config.model_id)
+        (Backend_provider_d_serialize.ollama_messages_of_message
+           ~model_id:config.model_id)
         messages
   in
   let body = [ "model", `String config.model_id; "messages", `List provider_messages ] in
@@ -103,7 +104,8 @@ let build_request
     match tools with
     | [] -> body
     | ts ->
-      ("tools", `List (List.map Backend_provider_d_serialize.build_provider_d_tool_json ts))
+      ( "tools"
+      , `List (List.map Backend_provider_d_serialize.build_provider_d_tool_json ts) )
       :: body
   in
   (* Sampling parameters go inside Ollama's "options" object.

--- a/lib/llm_provider/backend_provider_d.ml
+++ b/lib/llm_provider/backend_provider_d.ml
@@ -11,15 +11,26 @@ open Types
 
 (* ── Re-exports from serialization ─────────────────────── *)
 
-let tool_calls_to_provider_d_json = Backend_provider_d_serialize.tool_calls_to_provider_d_json
+let tool_calls_to_provider_d_json =
+  Backend_provider_d_serialize.tool_calls_to_provider_d_json
+;;
 
 let provider_d_content_parts_of_blocks =
   Backend_provider_d_serialize.provider_d_content_parts_of_blocks
 ;;
 
-let provider_d_messages_of_message = Backend_provider_d_serialize.provider_d_messages_of_message
-let provider_k_messages_of_message = Backend_provider_d_serialize.provider_k_messages_of_message
-let tool_choice_to_provider_d_json = Backend_provider_d_serialize.tool_choice_to_provider_d_json
+let provider_d_messages_of_message =
+  Backend_provider_d_serialize.provider_d_messages_of_message
+;;
+
+let provider_k_messages_of_message =
+  Backend_provider_d_serialize.provider_k_messages_of_message
+;;
+
+let tool_choice_to_provider_d_json =
+  Backend_provider_d_serialize.tool_choice_to_provider_d_json
+;;
+
 let build_provider_d_tool_json = Backend_provider_d_serialize.build_provider_d_tool_json
 let strip_orphaned_tool_results = Backend_provider_d_serialize.strip_orphaned_tool_results
 let strip_thinking_blocks = Backend_provider_d_serialize.strip_thinking_blocks
@@ -28,7 +39,10 @@ let strip_thinking_blocks = Backend_provider_d_serialize.strip_thinking_blocks
 
 let strip_json_markdown_fences = Backend_provider_d_parse.strip_json_markdown_fences
 let usage_of_provider_d_json = Backend_provider_d_parse.usage_of_provider_d_json
-let parse_provider_d_response_result = Backend_provider_d_parse.parse_provider_d_response_result
+
+let parse_provider_d_response_result =
+  Backend_provider_d_parse.parse_provider_d_response_result
+;;
 
 (* ── Re-exports from request building ─────────────────── *)
 
@@ -36,8 +50,15 @@ let warn_capability_drop = Backend_provider_d_request.warn_capability_drop
 let effective_tool_choice = Backend_provider_d_request.effective_tool_choice
 let effective_tools = Backend_provider_d_request.effective_tools
 let structured_schema_of_config = Backend_provider_d_request.structured_schema_of_config
-let provider_d_json_schema_payload = Backend_provider_d_request.provider_d_json_schema_payload
-let response_format_to_provider_d_json = Backend_provider_d_request.response_format_to_provider_d_json
+
+let provider_d_json_schema_payload =
+  Backend_provider_d_request.provider_d_json_schema_payload
+;;
+
+let response_format_to_provider_d_json =
+  Backend_provider_d_request.response_format_to_provider_d_json
+;;
+
 let response_format_of_config = Backend_provider_d_request.response_format_of_config
 let build_request = Backend_provider_d_request.build_request
 
@@ -1081,7 +1102,9 @@ let%test "provider_k build_request drops tool_choice when unsupported" =
   | _ -> false
 ;;
 
-let%test "provider_k build_request replays reasoning_content without leaking it into content" =
+let%test
+    "provider_k build_request replays reasoning_content without leaking it into content"
+  =
   let config =
     Provider_config.make
       ~kind:Provider_config.Provider_k

--- a/lib/llm_provider/backend_provider_d_request.ml
+++ b/lib/llm_provider/backend_provider_d_request.ml
@@ -37,7 +37,8 @@ let warn_capability_drop ~model_id ~field =
 let effective_tool_choice (config : Provider_config.t) =
   match config.tool_choice with
   | Some None_ -> None
-  | Some choice -> Some (Backend_provider_d_serialize.tool_choice_to_provider_d_json choice)
+  | Some choice ->
+    Some (Backend_provider_d_serialize.tool_choice_to_provider_d_json choice)
   | None -> None
 ;;
 
@@ -121,7 +122,8 @@ let build_request
   let provider_messages =
     let message_serializer =
       match config.kind with
-      | Provider_config.Provider_k -> Backend_provider_d_serialize.provider_k_messages_of_message
+      | Provider_config.Provider_k ->
+        Backend_provider_d_serialize.provider_k_messages_of_message
       | Provider_config.Provider_a
       | Provider_config.Provider_c
       | Provider_config.Provider_d_compat
@@ -131,7 +133,8 @@ let build_request
       | Provider_config.Cli_tool_d
       | Provider_config.Cli_tool_b
       | Provider_config.Cli_tool_c
-      | Provider_config.Cli_tool_a -> Backend_provider_d_serialize.provider_d_messages_of_message
+      | Provider_config.Cli_tool_a ->
+        Backend_provider_d_serialize.provider_d_messages_of_message
     in
     (match config.system_prompt with
      | Some s when not (Api_common.string_is_blank s) ->
@@ -280,7 +283,8 @@ let build_request
     match tools with
     | [] -> body
     | ts ->
-      ("tools", `List (List.map Backend_provider_d_serialize.build_provider_d_tool_json ts))
+      ( "tools"
+      , `List (List.map Backend_provider_d_serialize.build_provider_d_tool_json ts) )
       :: body
   in
   let body =

--- a/lib/llm_provider/backend_provider_f.ml
+++ b/lib/llm_provider/backend_provider_f.ml
@@ -64,9 +64,9 @@ let part_of_content_block id_to_name = function
         Diag.warn
           "backend_provider_f"
           "ToolResult tool_use_id '%s' has no matching ToolUse in %d-entry lookup table; \
-           using UUID as functionResponse name (Provider_f API requires name). This usually \
-           means the ToolUse block was in a conversation turn that was compacted or \
-           trimmed."
+           using UUID as functionResponse name (Provider_f API requires name). This \
+           usually means the ToolUse block was in a conversation turn that was compacted \
+           or trimmed."
           tool_use_id
           (Hashtbl.length id_to_name);
         tool_use_id
@@ -101,7 +101,9 @@ let contents_of_messages (messages : message list) =
          then
            contents
            := `Assoc
-                [ "role", `String (provider_f_role_of_oas msg.role); "parts", `List parts ]
+                [ "role", `String (provider_f_role_of_oas msg.role)
+                ; "parts", `List parts
+                ]
               :: !contents)
     messages;
   let system_instruction =

--- a/lib/llm_provider/backend_provider_k.ml
+++ b/lib/llm_provider/backend_provider_k.ml
@@ -327,34 +327,42 @@ let%test "classify quota exceeded from message" =
 ;;
 
 let%test "classify quota from code 1113 (arrears)" =
-  classify_provider_k_error ~code:"1113" ~message:"whatever" = (Provider_k_quota_exceeded, false)
+  classify_provider_k_error ~code:"1113" ~message:"whatever"
+  = (Provider_k_quota_exceeded, false)
 ;;
 
 let%test "classify auth from code 1001" =
-  classify_provider_k_error ~code:"1001" ~message:"whatever" = (Provider_k_auth_error, false)
+  classify_provider_k_error ~code:"1001" ~message:"whatever"
+  = (Provider_k_auth_error, false)
 ;;
 
 let%test "classify quota from code 1304 (daily limit)" =
-  classify_provider_k_error ~code:"1304" ~message:"whatever" = (Provider_k_quota_exceeded, false)
+  classify_provider_k_error ~code:"1304" ~message:"whatever"
+  = (Provider_k_quota_exceeded, false)
 ;;
 
 let%test "classify quota from code 1308 (usage limit)" =
-  classify_provider_k_error ~code:"1308" ~message:"whatever" = (Provider_k_quota_exceeded, false)
+  classify_provider_k_error ~code:"1308" ~message:"whatever"
+  = (Provider_k_quota_exceeded, false)
 ;;
 
 let%test "classify rate limited from code 1305" =
-  classify_provider_k_error ~code:"1305" ~message:"whatever" = (Provider_k_rate_limited, true)
+  classify_provider_k_error ~code:"1305" ~message:"whatever"
+  = (Provider_k_rate_limited, true)
 ;;
 
 let%test "classify invalid request from code 1301 (unsafe content)" =
-  classify_provider_k_error ~code:"1301" ~message:"whatever" = (Provider_k_invalid_request, false)
+  classify_provider_k_error ~code:"1301" ~message:"whatever"
+  = (Provider_k_invalid_request, false)
 ;;
 
 let%test "http_code quota maps to 429" =
   http_code_of_provider_k_error_class Provider_k_quota_exceeded = 429
 ;;
 
-let%test "http_code auth maps to 401" = http_code_of_provider_k_error_class Provider_k_auth_error = 401
+let%test "http_code auth maps to 401" =
+  http_code_of_provider_k_error_class Provider_k_auth_error = 401
+;;
 
 let%test "extract_reasoning_content prepends thinking block" =
   let resp =

--- a/lib/llm_provider/backend_provider_k.mli
+++ b/lib/llm_provider/backend_provider_k.mli
@@ -37,7 +37,10 @@ exception Provider_k_api_error of provider_k_error
 
 (** Classify a Provider_k error code + message into a semantic class.
     Code-based classification takes priority; message keywords are fallback. *)
-val classify_provider_k_error : code:string -> message:string -> provider_k_error_class * bool
+val classify_provider_k_error
+  :  code:string
+  -> message:string
+  -> provider_k_error_class * bool
 
 (** Map a Provider_k error class to the equivalent HTTP status code.
     Used by complete.ml to normalize provider-specific codes

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -308,7 +308,8 @@ let provider_k_capabilities =
 
     @since 0.196.3 *)
 type provider_f_family =
-  | Provider_f_3_1 (** [provider_f-3.1.*] — 3.1 line (pro-preview, flash-lite-preview, …) *)
+  | Provider_f_3_1
+  (** [provider_f-3.1.*] — 3.1 line (pro-preview, flash-lite-preview, …) *)
   | Provider_f_3 (** [provider_f-3.*] but not 3.1 — flash-preview and siblings *)
   | Provider_f_2_5 (** [provider_f-2.5.*] — legacy line, kept until removal PR *)
   | Provider_f_other of string
@@ -493,13 +494,16 @@ let static_model_route_of_id model_id =
   then Some Gpt_4o
   else (
     match provider_f_family_of_id m with
-    | (Provider_f_3 | Provider_f_3_1 | Provider_f_2_5) as family -> Some (Provider_f family)
+    | (Provider_f_3 | Provider_f_3_1 | Provider_f_2_5) as family ->
+      Some (Provider_f family)
     | Provider_f_other _ ->
       if String.starts_with ~prefix:"provider_c-for-coding" m
       then Some Provider_c_for_coding
       else if String.starts_with ~prefix:"provider_c-k2" m
       then Some Provider_c_k2
-      else if String.starts_with ~prefix:"provider_h-3" m
+      else if
+        String.starts_with ~prefix:"provider_h-3" m
+        || String.starts_with ~prefix:"provider_h_3" m
       then Some Provider_h_3
       else if
         String.starts_with ~prefix:"llama-4" m || String.starts_with ~prefix:"llama4" m
@@ -514,7 +518,8 @@ let static_model_route_of_id model_id =
       then Some Provider_j_small
       else if String.starts_with ~prefix:"command" m
       then Some Command
-      else if String.starts_with ~prefix:"grok" m
+      else if
+        String.starts_with ~prefix:"grok" m || String.starts_with ~prefix:"model-e" m
       then Some Grok
       else if
         String.starts_with ~prefix:"nvidia/provider_l" m
@@ -542,7 +547,8 @@ let static_model_route_of_id model_id =
       else if String.starts_with ~prefix:"provider_k-ocr" m
       then Some Glm_ocr
       else if
-        String.starts_with ~prefix:"provider_k-4.6v" m || String.starts_with ~prefix:"provider_k-4.5v" m
+        String.starts_with ~prefix:"provider_k-4.6v" m
+        || String.starts_with ~prefix:"provider_k-4.5v" m
       then Some Glm_4_vision_reasoning
       else if String.starts_with ~prefix:"provider_k-5-code" m
       then Some Glm_5_code
@@ -1335,7 +1341,9 @@ let%test "capabilities_for_provider_label: aliases resolve to identical capabili
       && ca.thinking_control_format = cb.thinking_control_format
     | _ -> false
   in
-  let alias_pairs = [ "provider_d", "provider_d_chat"; "provider_k", "provider_k-coding" ] in
+  let alias_pairs =
+    [ "provider_d", "provider_d_chat"; "provider_k", "provider_k-coding" ]
+  in
   List.for_all (fun (a, b) -> same_base a b) alias_pairs
   && Option.is_some (resolve "provider_a")
   && Option.is_some (resolve "provider_f")

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -111,7 +111,8 @@ type provider_f_family =
   | Provider_f_3_1 (** [provider_f-3.1.*] *)
   | Provider_f_3 (** [provider_f-3.*] but not 3.1 *)
   | Provider_f_2_5 (** [provider_f-2.5.*] (legacy line) *)
-  | Provider_f_other of string (** Unknown provider_f id, or non-provider_f id (literal retained). *)
+  | Provider_f_other of string
+  (** Unknown provider_f id, or non-provider_f id (literal retained). *)
 
 (** Classify a model id into a [provider_f_family]. Order: [3.1] before [3] so the
     more specific prefix wins. Input is expected lowercased; callers that

--- a/lib/llm_provider/cli_transport_factory.ml
+++ b/lib/llm_provider/cli_transport_factory.ml
@@ -56,7 +56,10 @@ let default_config =
    and [create]'s match all flow from this list. Adding a new CLI
    protocol means adding here AND wiring a [create] arm; the build
    surfaces the second because [unknown] catch-all is fatal. *)
-let supported_protocols = [ "provider_a-cli"; "agent_code-cli"; "google-cli"; "provider_c-cli" ]
+let supported_protocols =
+  [ "provider_a-cli"; "agent_code-cli"; "google-cli"; "provider_c-cli" ]
+;;
+
 let registered_protocols () = List.sort String.compare supported_protocols
 let is_known_protocol protocol = List.mem protocol supported_protocols
 

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -76,8 +76,8 @@ let apply_sampling_defaults (config : Provider_config.t) : Provider_config.t =
   let defaults = provider_sampling_defaults config.kind in
   let default_min_p =
     match config.kind with
-    | Provider_config.Provider_d_compat when not (provider_d_compat_should_default_min_p config)
-      -> None
+    | Provider_config.Provider_d_compat
+      when not (provider_d_compat_should_default_min_p config) -> None
     | Provider_a
     | Provider_c
     | Provider_d_compat
@@ -564,7 +564,8 @@ let complete_http
           Backend_provider_d.build_request ~config ~messages ~tools ()
         | Provider_config.Provider_f ->
           Backend_provider_f.build_request ~config ~messages ~tools ()
-        | Provider_config.Provider_k -> Backend_provider_k.build_request ~config ~messages ~tools ()
+        | Provider_config.Provider_k ->
+          Backend_provider_k.build_request ~config ~messages ~tools ()
         | Provider_config.Cli_tool_d
         | Provider_config.Cli_tool_b
         | Provider_config.Cli_tool_c
@@ -733,12 +734,15 @@ let complete_http
                    | Ok resp -> Ok resp
                    | Error msg -> Error (Http_client.HttpError { code = 400; body = msg }))
                 | Provider_config.Provider_d_compat | Provider_config.Provider_h ->
-                  (match Backend_provider_d_parse.parse_provider_d_response_result body with
+                  (match
+                     Backend_provider_d_parse.parse_provider_d_response_result body
+                   with
                    | Ok resp -> Ok resp
                    | Error msg -> Error (Http_client.HttpError { code = 400; body = msg }))
                 | Provider_config.Provider_f ->
                   Ok (Backend_provider_f.parse_response (Yojson.Safe.from_string body))
-                | Provider_config.Provider_k -> Ok (Backend_provider_k.parse_response body)
+                | Provider_config.Provider_k ->
+                  Ok (Backend_provider_k.parse_response body)
                 | Provider_config.Cli_tool_d
                 | Provider_config.Cli_tool_b
                 | Provider_config.Cli_tool_c
@@ -763,12 +767,15 @@ let complete_http
               | Backend_provider_f.Gemini_api_error msg ->
                 Diag.error "complete" "Provider_f API error: %s" msg;
                 Error
-                  (Http_client.HttpError { code = 400; body = "Provider_f API error: " ^ msg })
+                  (Http_client.HttpError
+                     { code = 400; body = "Provider_f API error: " ^ msg })
               | Backend_provider_k.Provider_k_api_error err ->
                 let semantic_code =
                   Backend_provider_k.http_code_of_provider_k_error_class err.error_class
                 in
-                let body = Printf.sprintf "Provider_k error %s: %s" err.code err.message in
+                let body =
+                  Printf.sprintf "Provider_k error %s: %s" err.code err.message
+                in
                 Diag.error
                   "complete"
                   "Provider_k API error (code=%s class=%d): %s"
@@ -1551,7 +1558,8 @@ let complete_stream_http
                              (match Streaming.parse_sse_event event_type data with
                               | Some evt -> [ evt ], None
                               | None -> [], None)
-                           | Provider_config.Provider_d_compat | Provider_config.Provider_h ->
+                           | Provider_config.Provider_d_compat
+                           | Provider_config.Provider_h ->
                              (match Streaming.parse_provider_d_sse_chunk data with
                               | Some chunk ->
                                 Streaming.provider_d_chunk_to_events (get_state ()) chunk

--- a/lib/llm_provider/constants.ml
+++ b/lib/llm_provider/constants.ml
@@ -203,7 +203,7 @@ module Thinking = struct
   (** Per-provider thinking budget overrides. Resolution order:
       1. Explicit [~thinking_budget] in request config
       2. Provider-specific env var ([OAS_PROVIDER_A_THINKING_BUDGET],
-         [OAS_CLI_TOOL_B_THINKING_BUDGET])
+         [OAS_PROVIDER_F_THINKING_BUDGET])
       3. [OAS_THINKING_BUDGET_DEFAULT] env var
       4. Hardcoded default (16000)
       @since 0.185.0 *)
@@ -214,7 +214,7 @@ module Thinking = struct
   ;;
 
   let provider_f_budget () =
-    match env_budget "OAS_CLI_TOOL_B_THINKING_BUDGET" with
+    match env_budget "OAS_PROVIDER_F_THINKING_BUDGET" with
     | Some n -> n
     | None -> default_budget
   ;;

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -973,7 +973,8 @@ let%test "parse_slots neither is_processing nor state defaults to idle" =
 (* --- contains_case_insensitive (via Retry SSOT) --- *)
 
 let%test "contains_case_insensitive case insensitive match" =
-  Retry.contains_case_insensitive ~haystack:"Provider_h_3.5-35B" ~needle:"provider_h" = true
+  Retry.contains_case_insensitive ~haystack:"Provider_h_3.5-35B" ~needle:"provider_h"
+  = true
 ;;
 
 let%test "contains_case_insensitive no match" =
@@ -1582,7 +1583,8 @@ let%test "first_discovered_model_id_for_url prevents cross-provider" =
          ; per_slot_ctx = None
          };
        (* ollama endpoint must NOT return the llama-server model *)
-       first_discovered_model_id_for_url "http://127.0.0.1:8085" = Some "provider_h-3.5-9b-local"
+       first_discovered_model_id_for_url "http://127.0.0.1:8085"
+       = Some "provider_h-3.5-9b-local"
        && first_discovered_model_id_for_url "http://127.0.0.1:11434"
           = Some "provider_h-3.5:9b-nvfp4")
 ;;

--- a/lib/llm_provider/model_meta.ml
+++ b/lib/llm_provider/model_meta.ml
@@ -167,7 +167,8 @@ let%test "for_model_id_with_ctx overrides context_window" =
 ;;
 
 let%test "is_free for local models" =
-  is_free (for_model_id "provider_h-3.5-35b") && not (is_free (for_model_id "agent_llm_a-opus-4-6"))
+  is_free (for_model_id "provider_h-3.5-35b")
+  && not (is_free (for_model_id "agent_llm_a-opus-4-6"))
 ;;
 
 let%test "provider_k-5 is cloud" =

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -144,8 +144,8 @@ let parse_transport = function
      | other ->
        Error
          (Printf.sprintf
-            "unknown transport %S (canonical: http, cli, managed, custom_provider_d_compat; \
-             dashed aliases also accepted)"
+            "unknown transport %S (canonical: http, cli, managed, \
+             custom_provider_d_compat; dashed aliases also accepted)"
             other))
 ;;
 

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -191,8 +191,14 @@ let default_attempt_timeout_s = function
   | Cli_tool_d -> Some 120.0
   | Cli_tool_c -> Some 60.0
   | Cli_tool_b -> Some 180.0
-  | Provider_a | Provider_c | Provider_d_compat | Ollama | Provider_f | Provider_k | Provider_h | Cli_tool_a ->
-    None
+  | Provider_a
+  | Provider_c
+  | Provider_d_compat
+  | Ollama
+  | Provider_f
+  | Provider_k
+  | Provider_h
+  | Cli_tool_a -> None
 ;;
 
 (** Default reasoning effort level when thinking is enabled but no budget
@@ -323,8 +329,8 @@ let validate_output_schema_request (config : t) =
      | Provider_f | Provider_a | Ollama | Provider_h -> Ok ()
      | Provider_k ->
        Error
-         "Provider_k supports JSON mode (json_object) only; native json_schema output is not \
-          documented in the current Z.AI API"
+         "Provider_k supports JSON mode (json_object) only; native json_schema output is \
+          not documented in the current Z.AI API"
      | Provider_c ->
        Error "Provider_c direct API native json_schema output is not verified yet in OAS"
      | Provider_d_compat ->
@@ -344,7 +350,8 @@ let validate_output_schema_request (config : t) =
        else
          Error
            (Printf.sprintf
-              "native structured output is only wired for official Provider_d hosts, got %s"
+              "native structured output is only wired for official Provider_d hosts, got \
+               %s"
               config.base_url)
      | Cli_tool_d | Cli_tool_b | Cli_tool_c | Cli_tool_a ->
        Error
@@ -377,7 +384,13 @@ let validate_cli_sampling_params (config : t) =
              CLI subprocess transport"
             (string_of_provider_kind config.kind)
             (String.concat ", " fields)))
-  | Provider_a | Provider_c | Provider_d_compat | Ollama | Provider_f | Provider_k | Provider_h -> Ok ()
+  | Provider_a
+  | Provider_c
+  | Provider_d_compat
+  | Ollama
+  | Provider_f
+  | Provider_k
+  | Provider_h -> Ok ()
 ;;
 
 let has_host_prefix ~url ~prefix =

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -14,7 +14,8 @@
     it can be shared with {!Types} without creating a dependency cycle. *)
 type provider_kind = Provider_kind.t =
   | Provider_a
-  | Provider_c (** Provider_c Code direct API: Provider_a-compatible [/v1/messages]. @since 0.169.0 *)
+  | Provider_c
+  (** Provider_c Code direct API: Provider_a-compatible [/v1/messages]. @since 0.169.0 *)
   | Provider_d_compat
   | Ollama
   (** Ollama: Provider_d compat wire format + reasoning_effort + no tool_choice. @since 0.112.0 *)

--- a/lib/llm_provider/provider_kind.ml
+++ b/lib/llm_provider/provider_kind.ml
@@ -64,7 +64,13 @@ let default_api_key_env = function
 
 let is_subprocess_cli = function
   | Cli_tool_d | Cli_tool_b | Cli_tool_c | Cli_tool_a -> true
-  | Provider_a | Provider_c | Provider_d_compat | Ollama | Provider_f | Provider_k | Provider_h -> false
+  | Provider_a
+  | Provider_c
+  | Provider_d_compat
+  | Ollama
+  | Provider_f
+  | Provider_k
+  | Provider_h -> false
 ;;
 
 let of_string raw =

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -386,16 +386,30 @@ let default () =
     llama_defaults
     ~max_context:128_000
     Capabilities.provider_d_chat_extended_capabilities;
-  reg "agent_llm_a" agent_llm_a_defaults ~max_context:200_000 Capabilities.provider_a_capabilities;
-  reg "provider_f" provider_f_defaults ~max_context:1_000_000 Capabilities.provider_f_capabilities;
+  reg
+    "agent_llm_a"
+    agent_llm_a_defaults
+    ~max_context:200_000
+    Capabilities.provider_a_capabilities;
+  reg
+    "provider_f"
+    provider_f_defaults
+    ~max_context:1_000_000
+    Capabilities.provider_f_capabilities;
   reg "provider_k" glm_defaults ~max_context:200_000 Capabilities.provider_k_capabilities;
-  reg "provider_k-coding" glm_coding_defaults ~max_context:128_000 Capabilities.provider_k_capabilities;
+  reg
+    "provider_k-coding"
+    glm_coding_defaults
+    ~max_context:128_000
+    Capabilities.provider_k_capabilities;
   register
     t
     { name = "provider_c"
     ; defaults = provider_c_defaults
     ; max_context =
-        max_context_from_capabilities ~default:262_144 Capabilities.provider_c_capabilities
+        max_context_from_capabilities
+          ~default:262_144
+          Capabilities.provider_c_capabilities
     ; capabilities = Capabilities.provider_c_capabilities
     ; is_available = (fun () -> has_any_api_key [ "PROVIDER_C_API_KEY" ])
     };
@@ -404,7 +418,11 @@ let default () =
     openrouter_defaults
     ~max_context:128_000
     Capabilities.provider_d_chat_extended_capabilities;
-  reg "provider_i" provider_i_defaults ~max_context:131_072 Capabilities.provider_d_chat_capabilities;
+  reg
+    "provider_i"
+    provider_i_defaults
+    ~max_context:131_072
+    Capabilities.provider_d_chat_capabilities;
   (* Provider_g v4 series (flash / pro). 1M context, reasoning, tools. *)
   reg
     "provider_g"
@@ -508,7 +526,9 @@ let default () =
     { name = "cli_tool_c"
     ; defaults = provider_c_cli_defaults
     ; max_context =
-        max_context_from_capabilities ~default:262_144 Capabilities.provider_c_cli_capabilities
+        max_context_from_capabilities
+          ~default:262_144
+          Capabilities.provider_c_cli_capabilities
     ; capabilities = Capabilities.provider_c_cli_capabilities
     ; is_available = provider_c_cli_available
     };
@@ -517,7 +537,9 @@ let default () =
     { name = "cli_tool_a"
     ; defaults = agent_code_cli_defaults
     ; max_context =
-        max_context_from_capabilities ~default:128_000 Capabilities.agent_code_cli_capabilities
+        max_context_from_capabilities
+          ~default:128_000
+          Capabilities.agent_code_cli_capabilities
     ; capabilities = Capabilities.agent_code_cli_capabilities
     ; is_available = agent_code_cli_available
     };
@@ -530,7 +552,10 @@ let provider_name_of_config (config : Provider_config.t) =
   | Provider_a -> "agent_llm_a"
   | Provider_c -> "provider_c"
   | Provider_f -> "provider_f"
-  | Provider_k -> if Zai_catalog.is_coding_base_url config.base_url then "provider_k-coding" else "provider_k"
+  | Provider_k ->
+    if Zai_catalog.is_coding_base_url config.base_url
+    then "provider_k-coding"
+    else "provider_k"
   | Cli_tool_d -> "cli_tool_d"
   | Cli_tool_b -> "cli_tool_b"
   | Cli_tool_c -> "cli_tool_c"

--- a/lib/llm_provider/provider_throttle.ml
+++ b/lib/llm_provider/provider_throttle.ml
@@ -107,15 +107,16 @@ let of_discovery_status (status : Discovery.endpoint_status) =
     All created with [source = Fallback]. *)
 let default_for_kind (kind : Provider_config.provider_kind) =
   match kind with
-  | Provider_config.Provider_d_compat | Provider_config.Ollama | Provider_config.Provider_h ->
-    create ~max_concurrent:4 ~provider_name:"local"
+  | Provider_config.Provider_d_compat
+  | Provider_config.Ollama
+  | Provider_config.Provider_h -> create ~max_concurrent:4 ~provider_name:"local"
   | Provider_config.Provider_a -> create ~max_concurrent:5 ~provider_name:"provider_a"
   | Provider_config.Provider_c -> create ~max_concurrent:5 ~provider_name:"provider_c"
   | Provider_config.Provider_f -> create ~max_concurrent:10 ~provider_name:"provider_f"
   | Provider_config.Provider_k -> create ~max_concurrent:10 ~provider_name:"provider_k"
   | Provider_config.Cli_tool_d -> create ~max_concurrent:2 ~provider_name:"cli_tool_d"
-  | Provider_config.Cli_tool_b | Provider_config.Cli_tool_c | Provider_config.Cli_tool_a ->
-    create ~max_concurrent:2 ~provider_name:"cli_subprocess"
+  | Provider_config.Cli_tool_b | Provider_config.Cli_tool_c | Provider_config.Cli_tool_a
+    -> create ~max_concurrent:2 ~provider_name:"cli_subprocess"
 ;;
 
 (* ── Capacity Query ────────────────────────────────────── *)

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -323,7 +323,9 @@ let create_provider_d_stream_state ?(provider = "") ?(model = "") () =
 (** Convert a parsed {!provider_d_chunk} into {!sse_event} list.
     Synthesizes [ContentBlockStart] events on first occurrence of
     text content or each new tool_call index. *)
-let provider_d_chunk_to_events (state : provider_d_stream_state) (chunk : provider_d_chunk)
+let provider_d_chunk_to_events
+      (state : provider_d_stream_state)
+      (chunk : provider_d_chunk)
   : sse_event list * Telemetry_event.t option
   =
   let events = ref [] in
@@ -488,7 +490,9 @@ let parse_provider_f_sse_chunk data_str : provider_f_chunk option =
   | Invalid_argument _ -> None
 ;;
 
-let provider_f_chunk_to_events (state : provider_d_stream_state) (chunk : provider_f_chunk)
+let provider_f_chunk_to_events
+      (state : provider_d_stream_state)
+      (chunk : provider_f_chunk)
   : sse_event list * Telemetry_event.t option
   =
   let open Yojson.Safe.Util in

--- a/lib/llm_provider/transport_cli_tool_a.ml
+++ b/lib/llm_provider/transport_cli_tool_a.ml
@@ -660,7 +660,10 @@ let warn_unsupported_once (config : config) (req_config : Provider_config.t) war
   else (
     warned := true;
     let warn field =
-      Diag.warn "transport_agent_code_cli" "%s is not supported by cli_tool_a, ignoring" field
+      Diag.warn
+        "transport_agent_code_cli"
+        "%s is not supported by cli_tool_a, ignoring"
+        field
     in
     if Option.is_some config.mcp_config then warn "mcp_config";
     if config.allowed_tools <> [] then warn "allowed_tools";
@@ -828,7 +831,8 @@ let%test "build_args includes --json flag" =
   let args, env =
     build_args ~config:default_config ~req_config:(agent_code_req ()) ~prompt:"hello" ()
   in
-  args = [ "agent_code"; "exec"; "--json"; "--ephemeral"; "-c"; "mcp_servers={}"; "hello" ]
+  args
+  = [ "agent_code"; "exec"; "--json"; "--ephemeral"; "-c"; "mcp_servers={}"; "hello" ]
   && env = []
 ;;
 
@@ -1204,10 +1208,21 @@ let%test "default: argv disables MCP even with no env" =
       with_unset "OAS_CLI_TOOL_A_PROFILE" (fun () ->
         with_unset "OAS_CLI_TOOL_A_SKIP_GIT" (fun () ->
           let args, _ =
-            build_args ~config:default_config ~req_config:(agent_code_req ()) ~prompt:"hi" ()
+            build_args
+              ~config:default_config
+              ~req_config:(agent_code_req ())
+              ~prompt:"hi"
+              ()
           in
           args
-          = [ "agent_code"; "exec"; "--json"; "--ephemeral"; "-c"; "mcp_servers={}"; "hi" ]))))
+          = [ "agent_code"
+            ; "exec"
+            ; "--json"
+            ; "--ephemeral"
+            ; "-c"
+            ; "mcp_servers={}"
+            ; "hi"
+            ]))))
 ;;
 
 let%test "env: OAS_CLI_TOOL_A_CONFIG emits -c pairs before prompt" =

--- a/lib/llm_provider/transport_cli_tool_a.mli
+++ b/lib/llm_provider/transport_cli_tool_a.mli
@@ -12,7 +12,8 @@
 
 (** Configuration for the Agent_code CLI subprocess. *)
 type config =
-  { agent_code_path : string (** Path to the [agent_code] executable. Default ["agent_code"]. *)
+  { agent_code_path : string
+    (** Path to the [agent_code] executable. Default ["agent_code"]. *)
   ; model : string option
     (** [--model] override. [None] uses the user's Agent_code CLI default.
 

--- a/lib/llm_provider/transport_cli_tool_b.ml
+++ b/lib/llm_provider/transport_cli_tool_b.ml
@@ -475,7 +475,10 @@ let warn_unsupported_once (config : config) warned =
   else (
     warned := true;
     let warn field =
-      Diag.warn "transport_provider_f_cli" "%s is not supported by cli_tool_b, ignoring" field
+      Diag.warn
+        "transport_provider_f_cli"
+        "%s is not supported by cli_tool_b, ignoring"
+        field
     in
     if Option.is_some config.mcp_config then warn "mcp_config";
     if config.allowed_tools <> [] then warn "allowed_tools";
@@ -650,8 +653,7 @@ let%test "build_args omits auto model override" =
   let args =
     build_args
       ~config:default_config
-      ~req_config:
-        (Provider_config.make ~kind:Cli_tool_d ~model_id:"auto" ~base_url:"" ())
+      ~req_config:(Provider_config.make ~kind:Cli_tool_d ~model_id:"auto" ~base_url:"" ())
       ~prompt:"hello"
       ~system_prompt:None
   in
@@ -786,8 +788,8 @@ let%test "provider_failure_of_stderr_line detects model capacity" =
   with
   | Some
       (Http_client.Capacity_exhausted
-         { scope = Http_client.Failure_scope_model; model = Some "provider_f-2.5-pro"; _ }) ->
-    true
+         { scope = Http_client.Failure_scope_model; model = Some "provider_f-2.5-pro"; _ })
+    -> true
   | _unexpected_failure -> false
 ;;
 
@@ -806,8 +808,9 @@ let%test "provider_failure_of_stderr_line extracts invalid policy tool" =
     provider_failure_of_stderr_line
       {|Rule #248: Unrecognized tool name "provider_k". Did you mean one of: "glob"?|}
   with
-  | Some (Http_client.Cli_policy_invalid { tool_name = Some "provider_k"; rule = Some 248 }) ->
-    true
+  | Some
+      (Http_client.Cli_policy_invalid { tool_name = Some "provider_k"; rule = Some 248 })
+    -> true
   | _unexpected_failure -> false
 ;;
 

--- a/lib/llm_provider/transport_cli_tool_b.mli
+++ b/lib/llm_provider/transport_cli_tool_b.mli
@@ -9,7 +9,8 @@
 
 (** Configuration for the Provider_f CLI subprocess. *)
 type config =
-  { provider_f_path : string (** Path to the [provider_f] executable. Default ["provider_f"]. *)
+  { provider_f_path : string
+    (** Path to the [provider_f] executable. Default ["provider_f"]. *)
   ; model : string option (** [--model] override. [None] uses the user's default. *)
   ; yolo : bool (** [--yolo] flag disables confirmation prompts. Default [true]. *)
   ; cwd : string option (** Working directory for the subprocess. *)

--- a/lib/llm_provider/transport_cli_tool_c.ml
+++ b/lib/llm_provider/transport_cli_tool_c.ml
@@ -90,8 +90,8 @@ let cli_model_override ~(config : config) ~(req_config : Provider_config.t) =
      if not (List.mem (String.lowercase_ascii m) supported)
      then
        Eio.traceln
-         "[warn] [cli_tool_c] Unsupported model %s requested. Provider_c CLI officially supports \
-          %s"
+         "[warn] [cli_tool_c] Unsupported model %s requested. Provider_c CLI officially \
+          supports %s"
          m
          (String.concat ", " supported)
    | Some _, None | None, Some _ | None, None -> ());
@@ -101,7 +101,9 @@ let cli_model_override ~(config : config) ~(req_config : Provider_config.t) =
 let build_args ~(config : config) ~(req_config : Provider_config.t) ~prompt =
   let prompt = sanitize_for_provider_c prompt in
   let prompt_via_stdin = prompt_needs_stdin prompt in
-  let args = ref [ config.provider_c_path; "--print"; "--output-format"; "stream-json" ] in
+  let args =
+    ref [ config.provider_c_path; "--print"; "--output-format"; "stream-json" ]
+  in
   let add a = args := !args @ a in
   if not prompt_via_stdin then add [ "-p"; prompt ];
   (match cli_model_override ~config ~req_config with
@@ -485,7 +487,8 @@ let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) : Llm_transport.t =
           then (
             started := true;
             on_event
-              (Types.MessageStart { id = "provider_c-print"; model = model_id; usage = None }))
+              (Types.MessageStart
+                 { id = "provider_c-print"; model = model_id; usage = None }))
         in
         let on_line line =
           if String.trim line <> ""
@@ -546,7 +549,9 @@ let%test "default_config uses provider_c-for-coding" =
 ;;
 
 let%test "build_args basic" =
-  let args = build_args ~config:default_config ~req_config:(provider_c_req ()) ~prompt:"hi" in
+  let args =
+    build_args ~config:default_config ~req_config:(provider_c_req ()) ~prompt:"hi"
+  in
   args
   = [ "provider_c"
     ; "--print"
@@ -597,19 +602,25 @@ let%test "build_args uses request model over default" =
 
 let%test "build_args routes threshold prompt via stdin" =
   let big = String.make (1 * 1024 * 1024) 'x' in
-  let args = build_args ~config:default_config ~req_config:(provider_c_req ()) ~prompt:big in
+  let args =
+    build_args ~config:default_config ~req_config:(provider_c_req ()) ~prompt:big
+  in
   (not (List.mem big args)) && not (List.mem "-p" args)
 ;;
 
 let%test "build_args routes large prompt via stdin" =
   let big = String.make (70 * 1024) 'x' in
-  let args = build_args ~config:default_config ~req_config:(provider_c_req ()) ~prompt:big in
+  let args =
+    build_args ~config:default_config ~req_config:(provider_c_req ()) ~prompt:big
+  in
   (not (List.mem big args)) && not (List.mem "-p" args)
 ;;
 
 let%test "build_args sanitizes broken utf8 prompt before argv" =
   let bad = "prefix\x80suffix" in
-  let args = build_args ~config:default_config ~req_config:(provider_c_req ()) ~prompt:bad in
+  let args =
+    build_args ~config:default_config ~req_config:(provider_c_req ()) ~prompt:bad
+  in
   (not (List.mem bad args)) && not (List.mem "-p" args)
 ;;
 

--- a/lib/llm_provider/transport_cli_tool_c.mli
+++ b/lib/llm_provider/transport_cli_tool_c.mli
@@ -10,7 +10,8 @@
 
 (** Configuration for the Provider_c CLI subprocess. *)
 type config =
-  { provider_c_path : string (** Path to the [provider_c] executable. Default ["provider_c"]. *)
+  { provider_c_path : string
+    (** Path to the [provider_c] executable. Default ["provider_c"]. *)
   ; model : string option
     (** [--model] override. [None] uses the CLI-configured default.
         Default is [Some "provider_c-for-coding"] so the coding plan model is

--- a/lib/llm_provider/transport_cli_tool_d.ml
+++ b/lib/llm_provider/transport_cli_tool_d.ml
@@ -53,9 +53,7 @@ let default_config =
 ;;
 
 let effective_max_turns config =
-  Option.map
-    (Provider_config.clamp_max_turns Provider_config.Cli_tool_d)
-    config.max_turns
+  Option.map (Provider_config.clamp_max_turns Provider_config.Cli_tool_d) config.max_turns
 ;;
 
 (* Prompt shaping, JSON helpers, and subprocess orchestration live in the
@@ -336,7 +334,10 @@ let parse_json_result ~prompt json_str =
         Error
           (Http_client.NetworkError
              { message =
-                 Printf.sprintf "Agent_llm_a Code error (%s): %s" unknown_error_subtype msg
+                 Printf.sprintf
+                   "Agent_llm_a Code error (%s): %s"
+                   unknown_error_subtype
+                   msg
              ; kind = Unknown
              }))
     else (
@@ -550,7 +551,10 @@ let parse_stream_result lines =
            Error
              (Http_client.NetworkError
                 { message =
-                    Printf.sprintf "Agent_llm_a Code error (%s): %s" unknown_error_subtype msg
+                    Printf.sprintf
+                      "Agent_llm_a Code error (%s): %s"
+                      unknown_error_subtype
+                      msg
                 ; kind = Unknown
                 }))
        else (
@@ -653,7 +657,8 @@ let subprocess_session_isolation_counter = Atomic.make 0
 let subprocess_session_isolation_env () =
   let n = Atomic.fetch_and_add subprocess_session_isolation_counter 1 in
   [ ( "CODEX_COMPANION_SESSION_ID"
-    , Printf.sprintf "oas-agent_llm_a-%d-%d-%f" (Unix.getpid ()) n (Unix.gettimeofday ()) )
+    , Printf.sprintf "oas-agent_llm_a-%d-%d-%f" (Unix.getpid ()) n (Unix.gettimeofday ())
+    )
   ]
 ;;
 
@@ -923,7 +928,11 @@ let%test "build_args with model" =
     build_args
       ~config:default_config
       ~req_config:
-        (Provider_config.make ~kind:Provider_a ~model_id:"agent_llm_a-sonnet-4" ~base_url:"" ())
+        (Provider_config.make
+           ~kind:Provider_a
+           ~model_id:"agent_llm_a-sonnet-4"
+           ~base_url:""
+           ())
       ~prompt:"hello"
       ~stream:true
       ~system_prompt:(Some "be helpful")
@@ -940,8 +949,7 @@ let%test "build_args omits auto model override" =
   let args =
     build_args
       ~config:default_config
-      ~req_config:
-        (Provider_config.make ~kind:Cli_tool_d ~model_id:"auto" ~base_url:"" ())
+      ~req_config:(Provider_config.make ~kind:Cli_tool_d ~model_id:"auto" ~base_url:"" ())
       ~prompt:"hello"
       ~stream:false
       ~system_prompt:None
@@ -955,8 +963,7 @@ let%test "build_args clamps agent_llm_a max_turns to provider hard cap" =
   let args =
     build_args
       ~config
-      ~req_config:
-        (Provider_config.make ~kind:Cli_tool_d ~model_id:"auto" ~base_url:"" ())
+      ~req_config:(Provider_config.make ~kind:Cli_tool_d ~model_id:"auto" ~base_url:"" ())
       ~prompt:"hello"
       ~stream:false
       ~system_prompt:None

--- a/lib/llm_provider/transport_cli_tool_d.mli
+++ b/lib/llm_provider/transport_cli_tool_d.mli
@@ -12,7 +12,8 @@
 
 (** Configuration for the Agent_llm_a Code subprocess. *)
 type config =
-  { agent_llm_a_path : string (** Path to the [agent_llm_a] executable. Default ["agent_llm_a"]. *)
+  { agent_llm_a_path : string
+    (** Path to the [agent_llm_a] executable. Default ["agent_llm_a"]. *)
   ; model : string option (** [--model] override. [None] uses the user's default. *)
   ; max_turns : int option
     (** [--max-turns] limit. [None] uses the default (single turn). *)

--- a/lib/llm_provider/transport_provider_d_compat.ml
+++ b/lib/llm_provider/transport_provider_d_compat.ml
@@ -100,7 +100,9 @@ let%test "default_config api_key empty" = default_config.api_key = ""
 
 let%test "merge_config uses transport base_url when req empty" =
   let transport_cfg = { default_config with base_url = "http://myserver:9000" } in
-  let req_cfg = Provider_config.make ~kind:Provider_d_compat ~model_id:"" ~base_url:"" () in
+  let req_cfg =
+    Provider_config.make ~kind:Provider_d_compat ~model_id:"" ~base_url:"" ()
+  in
   let merged = merge_config ~transport_cfg req_cfg in
   merged.base_url = "http://myserver:9000"
 ;;
@@ -120,7 +122,9 @@ let%test "merge_config preserves req base_url when present" =
 
 let%test "merge_config uses transport model_id when req empty" =
   let transport_cfg = { default_config with model_id = "provider_h-3.5-35b" } in
-  let req_cfg = Provider_config.make ~kind:Provider_d_compat ~model_id:"" ~base_url:"" () in
+  let req_cfg =
+    Provider_config.make ~kind:Provider_d_compat ~model_id:"" ~base_url:"" ()
+  in
   let merged = merge_config ~transport_cfg req_cfg in
   merged.model_id = "provider_h-3.5-35b"
 ;;
@@ -136,14 +140,18 @@ let%test "merge_config preserves req model_id when present" =
 
 let%test "merge_config uses transport api_key when req empty" =
   let transport_cfg = { default_config with api_key = "sk-test123" } in
-  let req_cfg = Provider_config.make ~kind:Provider_d_compat ~model_id:"m" ~base_url:"" () in
+  let req_cfg =
+    Provider_config.make ~kind:Provider_d_compat ~model_id:"m" ~base_url:"" ()
+  in
   let merged = merge_config ~transport_cfg req_cfg in
   merged.api_key = "sk-test123"
 ;;
 
 let%test "merge_config preserves req request_path (make fills default)" =
   let transport_cfg = { default_config with request_path = "/api/v2/chat" } in
-  let req_cfg = Provider_config.make ~kind:Provider_d_compat ~model_id:"m" ~base_url:"" () in
+  let req_cfg =
+    Provider_config.make ~kind:Provider_d_compat ~model_id:"m" ~base_url:"" ()
+  in
   let merged = merge_config ~transport_cfg req_cfg in
   (* Provider_config.make fills request_path = "/v1/chat/completions" for Provider_d_compat *)
   merged.request_path = "/v1/chat/completions"
@@ -188,7 +196,9 @@ let%test "merge_config appends extra_headers to explicit req headers" =
 
 let%test "merge_config appends extra_headers to default req headers" =
   let transport_cfg = { default_config with extra_headers = [ "X-Custom", "value" ] } in
-  let req_cfg = Provider_config.make ~kind:Provider_d_compat ~model_id:"m" ~base_url:"" () in
+  let req_cfg =
+    Provider_config.make ~kind:Provider_d_compat ~model_id:"m" ~base_url:"" ()
+  in
   let merged = merge_config ~transport_cfg req_cfg in
   (* Provider_config.make defaults headers to [("Content-Type", "application/json")] *)
   List.length merged.headers = 2
@@ -198,7 +208,9 @@ let%test "merge_config appends extra_headers to default req headers" =
 
 let%test "merge_config no extra_headers preserves req headers" =
   let transport_cfg = { default_config with extra_headers = [] } in
-  let req_cfg = Provider_config.make ~kind:Provider_d_compat ~model_id:"m" ~base_url:"" () in
+  let req_cfg =
+    Provider_config.make ~kind:Provider_d_compat ~model_id:"m" ~base_url:"" ()
+  in
   let merged = merge_config ~transport_cfg req_cfg in
   merged.headers = [ "Content-Type", "application/json" ]
 ;;
@@ -206,7 +218,12 @@ let%test "merge_config no extra_headers preserves req headers" =
 let%test "merge_config uses transport max_tokens when req zero" =
   let transport_cfg = { default_config with max_tokens = 8192 } in
   let req_cfg =
-    Provider_config.make ~kind:Provider_d_compat ~model_id:"m" ~base_url:"" ~max_tokens:0 ()
+    Provider_config.make
+      ~kind:Provider_d_compat
+      ~model_id:"m"
+      ~base_url:""
+      ~max_tokens:0
+      ()
   in
   let merged = merge_config ~transport_cfg req_cfg in
   merged.max_tokens = Some 8192

--- a/lib/llm_provider/zai_catalog.ml
+++ b/lib/llm_provider/zai_catalog.ml
@@ -10,7 +10,7 @@ let provider_a_base_url = "https://api.z.ai/api/provider_a"
 
 let is_glm_model_id model_id =
   let m = String.lowercase_ascii (String.trim model_id) in
-  m = "provider_k" || (String.length m > 4 && String.sub m 0 4 = "provider_k-")
+  m = "provider_k" || String.starts_with ~prefix:"provider_k-" m
 ;;
 
 let has_prefix value prefix =
@@ -83,13 +83,20 @@ let split_csv = Cli_common_env.split_on_char_trim ','
 let provider_k_auto_models () =
   match Cli_common_env.list ~sep:',' "ZAI_AUTO_MODELS" with
   | Some models -> models
-  | None -> [ "provider_k-5.1"; "provider_k-5-turbo"; "provider_k-4.7"; "provider_k-4.7-flashx" ]
+  | None ->
+    [ "provider_k-5.1"; "provider_k-5-turbo"; "provider_k-4.7"; "provider_k-4.7-flashx" ]
 ;;
 
 let provider_k_coding_auto_models () =
   match Cli_common_env.list ~sep:',' "ZAI_CODING_AUTO_MODELS" with
   | Some models -> models
-  | None -> [ "provider_k-5.1"; "provider_k-5"; "provider_k-5-turbo"; "provider_k-4.7"; "provider_k-4.5-air" ]
+  | None ->
+    [ "provider_k-5.1"
+    ; "provider_k-5"
+    ; "provider_k-5-turbo"
+    ; "provider_k-4.7"
+    ; "provider_k-4.5-air"
+    ]
 ;;
 
 let resolve_glm_alias ~default_model model_id =
@@ -166,7 +173,9 @@ let throttle_key_for_chat ~base_url ~model_id =
 [@@@coverage off]
 
 let%test "is_glm_model_id accepts provider_k prefixes only" =
-  is_glm_model_id "provider_k-5" && is_glm_model_id "provider_k" && not (is_glm_model_id "gpt-5")
+  is_glm_model_id "provider_k-5"
+  && is_glm_model_id "provider_k"
+  && not (is_glm_model_id "gpt-5")
 ;;
 
 let%test "base_url classifiers distinguish general coding and provider_a" =
@@ -190,7 +199,8 @@ let%test "resolve_glm_alias covers common aliases" =
   && resolve_glm_alias ~default_model:"provider_k-5.1" "flash" = "provider_k-4.7-flashx"
   && resolve_glm_alias ~default_model:"provider_k-5.1" "vf" = "provider_k-4.6v-flashx"
   && resolve_glm_alias ~default_model:"provider_k-5.1" "air" = "provider_k-4.5-air"
-  && resolve_glm_alias ~default_model:"provider_k-5.1" "provider_k-5-turbo" = "provider_k-5-turbo"
+  && resolve_glm_alias ~default_model:"provider_k-5.1" "provider_k-5-turbo"
+     = "provider_k-5-turbo"
 ;;
 
 let%test "general_concurrency_for_model hits key provider_k families" =
@@ -206,7 +216,8 @@ let%test "general_concurrency_for_model hits key provider_k families" =
 let%test "throttle_key_for_chat separates coding and general plans" =
   throttle_key_for_chat ~base_url:general_base_url ~model_id:" Provider_k-5 "
   = "zai/general/chat/provider_k-5"
-  && throttle_key_for_chat ~base_url:coding_base_url ~model_id:"provider_k-5" = "zai/coding/chat"
+  && throttle_key_for_chat ~base_url:coding_base_url ~model_id:"provider_k-5"
+     = "zai/coding/chat"
 ;;
 
 let%test "is_zai_base_url rejects untrusted host lookalikes" =

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -81,7 +81,12 @@ let of_config (provider_cfg : Provider.config) : provider_module =
         | Provider.Provider_a_messages ->
           Yojson.Safe.to_string
             (`Assoc
-                (Api_provider_a.build_body_assoc ~config ~messages ?tools ~stream:false ()))
+                (Api_provider_a.build_body_assoc
+                   ~config
+                   ~messages
+                   ?tools
+                   ~stream:false
+                   ()))
         | Provider.Openai_chat_completions ->
           Api_provider_d.build_provider_d_body
             ~provider_config:provider_cfg
@@ -102,7 +107,8 @@ let of_config (provider_cfg : Provider.config) : provider_module =
            Ok (Api_provider_a.parse_response (Yojson.Safe.from_string body_str))
          | Provider.Openai_chat_completions ->
            (match
-              Llm_provider.Backend_provider_d_parse.parse_provider_d_response_result body_str
+              Llm_provider.Backend_provider_d_parse.parse_provider_d_response_result
+                body_str
             with
             | Ok resp -> Ok resp
             | Error msg -> Error (Error.Api (Retry.InvalidRequest { message = msg })))
@@ -111,7 +117,8 @@ let of_config (provider_cfg : Provider.config) : provider_module =
             | Some impl -> Ok (impl.parse_response body_str)
             | None ->
               (match
-                 Llm_provider.Backend_provider_d_parse.parse_provider_d_response_result body_str
+                 Llm_provider.Backend_provider_d_parse.parse_provider_d_response_result
+                   body_str
                with
                | Ok resp -> Ok resp
                | Error msg -> Error (Error.Api (Retry.InvalidRequest { message = msg })))))

--- a/scripts/check-transport-truth.sh
+++ b/scripts/check-transport-truth.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # check-transport-truth.sh
 # Drift gate for OAS CLI transports
-# (transport_{claude_code,gemini_cli,kimi_cli,codex_cli}).
+# (transport_cli_tool_{a,b,c,d}).
 #
 # Background
 # ----------
@@ -11,7 +11,7 @@
 #   - mark it as a parity-only field and warn via warn_unsupported_once.
 #
 # Prior audits (see planning/task-118/origin-report.md, 2026-04-16) found
-# that transport_gemini_cli.mli and transport_codex_cli.mli declared
+# that the Gemini/Codex CLI transport mli files declared
 # fields (max_turns / allowed_tools / mcp_config / permission_mode) whose
 # behavior only existed as a warn-and-drop. The .mli comments claimed
 # "Gemini has no equivalent flag" — a claim that was false by 2026-04
@@ -44,10 +44,10 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 # transport name : path prefix (relative to ROOT, without .ml/.mli suffix)
 TRANSPORTS=(
-  "claude_code:lib/llm_provider/transport_claude_code"
-  "gemini_cli:lib/llm_provider/transport_gemini_cli"
-  "kimi_cli:lib/llm_provider/transport_kimi_cli"
-  "codex_cli:lib/llm_provider/transport_codex_cli"
+  "cli_tool_a:lib/llm_provider/transport_cli_tool_a"
+  "cli_tool_b:lib/llm_provider/transport_cli_tool_b"
+  "cli_tool_c:lib/llm_provider/transport_cli_tool_c"
+  "cli_tool_d:lib/llm_provider/transport_cli_tool_d"
 )
 
 # Extract field names from the `type config = { ... }` record block.

--- a/test/test_agent_config_deep.ml
+++ b/test/test_agent_config_deep.ml
@@ -321,7 +321,9 @@ let test_resolve_local_custom_url () =
 ;;
 
 let test_resolve_provider_a () =
-  let cfg = Agent_config.resolve_provider ~model_id:"agent_llm_a-sonnet" "provider_a" None in
+  let cfg =
+    Agent_config.resolve_provider ~model_id:"agent_llm_a-sonnet" "provider_a" None
+  in
   match cfg.provider with
   | Provider.Provider_a ->
     Alcotest.(check string) "model_id" "agent_llm_a-sonnet" cfg.model_id;
@@ -340,7 +342,10 @@ let test_resolve_provider_d () =
 
 let test_resolve_provider_d_custom_url () =
   let cfg =
-    Agent_config.resolve_provider ~model_id:"gpt-4" "provider_d" (Some "http://custom:4000")
+    Agent_config.resolve_provider
+      ~model_id:"gpt-4"
+      "provider_d"
+      (Some "http://custom:4000")
   in
   match cfg.provider with
   | Provider.OpenAICompat { base_url; _ } ->
@@ -371,12 +376,20 @@ let test_resolve_provider_i () =
      so that downstream can look up the registry-declared kind.
      entry.defaults (url, path, api_key_env) are carried via the
      registry, not embedded in the Provider.config variant. *)
-  let cfg = Agent_config.resolve_provider ~model_id:"provider_h/provider_h_3-32b" "provider_i" None in
+  let cfg =
+    Agent_config.resolve_provider
+      ~model_id:"provider_h/provider_h_3-32b"
+      "provider_i"
+      None
+  in
   match cfg.provider with
   | Provider.Custom_registered { name } ->
     Alcotest.(check string) "provider_i name" "provider_i" name;
     Alcotest.(check string) "provider_i api_key_env" "GROQ_API_KEY" cfg.api_key_env;
-    Alcotest.(check string) "provider_i model_id" "provider_h/provider_h_3-32b" cfg.model_id
+    Alcotest.(check string)
+      "provider_i model_id"
+      "provider_h/provider_h_3-32b"
+      cfg.model_id
   | _ -> Alcotest.fail "expected Custom_registered for provider_i (registered)"
 ;;
 
@@ -409,7 +422,9 @@ let test_resolve_provider_f_preserves_kind () =
      preserves entry.defaults.kind. Previously resolve_provider
      returned OpenAICompat, flattening kind to Provider_d_compat and
      producing 404 against the Provider_f endpoint. *)
-  let cfg = Agent_config.resolve_provider ~model_id:"provider_f-2.5-flash" "provider_f" None in
+  let cfg =
+    Agent_config.resolve_provider ~model_id:"provider_f-2.5-flash" "provider_f" None
+  in
   match cfg.provider with
   | Provider.Custom_registered { name } ->
     Alcotest.(check string) "provider_f name" "provider_f" name;
@@ -444,7 +459,9 @@ let test_resolve_provider_a_case_insensitive () =
      both land on the Provider_a branch, not the registry fallback. *)
   List.iter
     (fun input ->
-       let cfg = Agent_config.resolve_provider ~model_id:"agent_llm_a-sonnet" input None in
+       let cfg =
+         Agent_config.resolve_provider ~model_id:"agent_llm_a-sonnet" input None
+       in
        match cfg.provider with
        | Provider.Provider_a ->
          Alcotest.(check string)
@@ -460,7 +477,9 @@ let test_resolve_agent_llm_a_alias_routes_to_provider_a () =
      to this fix it fell to the registry fallback (Provider_registry
      has no "agent_llm_a" entry) and ended up as OpenAICompat with
      api_key_env = "agent_llm_a" — broken. *)
-  let cfg = Agent_config.resolve_provider ~model_id:"agent_llm_a-sonnet" "agent_llm_a" None in
+  let cfg =
+    Agent_config.resolve_provider ~model_id:"agent_llm_a-sonnet" "agent_llm_a" None
+  in
   match cfg.provider with
   | Provider.Provider_a ->
     Alcotest.(check string)

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -1296,7 +1296,11 @@ let test_agent_run_tiered_memory_triggers_proactive_compaction () =
     Eio.Switch.run
     @@ fun sw ->
     let url =
-      start_multi_mock ~sw ~net:env#net ~port:20011 [ provider_d_text_response "compacted" ]
+      start_multi_mock
+        ~sw
+        ~net:env#net
+        ~port:20011
+        [ provider_d_text_response "compacted" ]
     in
     let provider : Provider.config =
       { provider = Provider.Local { base_url = url }

--- a/test/test_agent_stream.ml
+++ b/test/test_agent_stream.ml
@@ -337,7 +337,9 @@ let test_roundtrip_mixed_block_count () =
 ;;
 
 let test_roundtrip_message_start_fields () =
-  let response = make_response ~id:"msg-xyz" ~model:"agent_llm_a-test" [ Types.Text "x" ] in
+  let response =
+    make_response ~id:"msg-xyz" ~model:"agent_llm_a-test" [ Types.Text "x" ]
+  in
   let events = collect_events response in
   match List.nth events 0 with
   | Types.MessageStart { id; model; _ } ->

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -365,7 +365,9 @@ let test_build_provider_d_body_with_provider_m_sampling () =
 ;;
 
 let test_build_provider_d_body_omits_provider_m_only_fields_for_generic_compat () =
-  let provider_config = Provider.openrouter ~model_id:"provider_a/agent_llm_a-sonnet-4-6" () in
+  let provider_config =
+    Provider.openrouter ~model_id:"provider_a/agent_llm_a-sonnet-4-6" ()
+  in
   let state =
     { Types.config =
         { Types.default_config with
@@ -470,7 +472,11 @@ let test_build_provider_d_body_uses_glm_thinking_and_auto_tool_choice () =
     "clear_thinking default true"
     true
     (thinking |> member "clear_thinking" |> to_bool);
-  check string "provider_k tool choice coerced" "auto" (json |> member "tool_choice" |> to_string)
+  check
+    string
+    "provider_k tool choice coerced"
+    "auto"
+    (json |> member "tool_choice" |> to_string)
 ;;
 
 let test_build_provider_d_body_glm_preserves_reasoning_content () =
@@ -572,7 +578,11 @@ let test_build_provider_d_body_does_not_treat_non_zai_glm_as_glm () =
   in
   let open Yojson.Safe.Util in
   let assoc = to_assoc json in
-  check bool "thinking omitted for non-zai provider_k" false (List.mem_assoc "thinking" assoc);
+  check
+    bool
+    "thinking omitted for non-zai provider_k"
+    false
+    (List.mem_assoc "thinking" assoc);
   check
     bool
     "chat_template_kwargs omitted for non-zai provider_k"
@@ -625,7 +635,11 @@ let test_build_provider_d_body_glm_tool_choice_none_omits_tools () =
   in
   let open Yojson.Safe.Util in
   let assoc = to_assoc json in
-  check bool "tool_choice omitted for provider_k none" false (List.mem_assoc "tool_choice" assoc);
+  check
+    bool
+    "tool_choice omitted for provider_k none"
+    false
+    (List.mem_assoc "tool_choice" assoc);
   check bool "tools omitted for provider_k none" false (List.mem_assoc "tools" assoc)
 ;;
 
@@ -1388,7 +1402,10 @@ let () =
         ; test_case "without thinking" `Quick test_build_body_without_thinking
         ; test_case "with tool_choice" `Quick test_build_body_with_tool_choice
         ; test_case "with tools" `Quick test_build_body_with_tools
-        ; test_case "provider_d json schema" `Quick test_build_provider_d_body_with_json_schema
+        ; test_case
+            "provider_d json schema"
+            `Quick
+            test_build_provider_d_body_with_json_schema
         ; test_case
             "provider_a sampling params serialized"
             `Quick
@@ -1397,7 +1414,10 @@ let () =
             "provider_a sampling params omitted when None"
             `Quick
             test_build_body_sampling_params_omitted_when_none
-        ; test_case "with provider_h sampling" `Quick test_build_provider_d_body_with_provider_m_sampling
+        ; test_case
+            "with provider_h sampling"
+            `Quick
+            test_build_provider_d_body_with_provider_m_sampling
         ; test_case
             "generic compat omits provider_h-only fields"
             `Quick
@@ -1450,7 +1470,10 @@ let () =
             "blank reasoning_content"
             `Quick
             test_parse_provider_d_response_blank_reasoning
-        ; test_case "no reasoning_content" `Quick test_parse_provider_d_response_no_reasoning
+        ; test_case
+            "no reasoning_content"
+            `Quick
+            test_parse_provider_d_response_no_reasoning
         ; test_case
             "ollama reasoning field"
             `Quick
@@ -1469,7 +1492,10 @@ let () =
             "provider_d api error unknown message"
             `Quick
             test_provider_d_api_error_unknown_message
-        ; test_case "provider_d error returns result" `Quick test_provider_d_error_returns_result
+        ; test_case
+            "provider_d error returns result"
+            `Quick
+            test_provider_d_error_returns_result
         ] )
     ; ( "parse_sse_event"
       , [ test_case "message_start" `Quick test_parse_sse_message_start

--- a/test/test_backend_provider_f.ml
+++ b/test/test_backend_provider_f.ml
@@ -778,6 +778,7 @@ let () =
             test_provider_f_stream_tool_first_then_text
         ] )
     ; ( "capabilities"
-      , [ test_case "provider_f capabilities" `Quick test_provider_f_capabilities_named ] )
+      , [ test_case "provider_f capabilities" `Quick test_provider_f_capabilities_named ]
+      )
     ]
 ;;

--- a/test/test_backend_tool_call_harness.ml
+++ b/test/test_backend_tool_call_harness.ml
@@ -6,7 +6,9 @@ let malformed_provider_d_response = `Assoc [ "choices", `String "not-a-list" ]
 
 let test_provider_d_parse_error_is_typed () =
   match
-    H.validate_provider_d_response ~declared_tools:[ "read_file" ] malformed_provider_d_response
+    H.validate_provider_d_response
+      ~declared_tools:[ "read_file" ]
+      malformed_provider_d_response
   with
   | Ok _ -> fail "expected typed parse error"
   | Error err ->

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -40,7 +40,9 @@ let test_create_sets_model () =
   with_net
   @@ fun net ->
   let agent =
-    Builder.create ~net ~model:"agent_llm_a-haiku-4-5" |> Builder.build_safe |> Result.get_ok
+    Builder.create ~net ~model:"agent_llm_a-haiku-4-5"
+    |> Builder.build_safe
+    |> Result.get_ok
   in
   check_model "model" "agent_llm_a-haiku-4-5-20251001" (Agent.state agent).config.model
 ;;
@@ -962,7 +964,9 @@ let test_defaults_match_agent_create () =
   with_net
   @@ fun net ->
   let builder_agent =
-    Builder.create ~net ~model:"agent_llm_a-sonnet-4-6" |> Builder.build_safe |> Result.get_ok
+    Builder.create ~net ~model:"agent_llm_a-sonnet-4-6"
+    |> Builder.build_safe
+    |> Result.get_ok
   in
   let direct_agent = Agent.create ~net () in
   let bc = (Agent.state builder_agent).config in
@@ -1021,7 +1025,9 @@ let test_build_minimal_required_only () =
   with_net
   @@ fun net ->
   let agent =
-    Builder.create ~net ~model:"agent_llm_a-3-7-sonnet" |> Builder.build_safe |> Result.get_ok
+    Builder.create ~net ~model:"agent_llm_a-3-7-sonnet"
+    |> Builder.build_safe
+    |> Result.get_ok
   in
   check_model "model" "agent_llm_a-3-7-sonnet-20250219" (Agent.state agent).config.model;
   Alcotest.(check string) "name" "agent" (Agent.state agent).config.name;

--- a/test/test_cache.ml
+++ b/test/test_cache.ml
@@ -273,7 +273,10 @@ let () =
       , [ test_case "cache token accumulation" `Quick test_add_usage_cache_accumulation ]
       )
     ; ( "provider_d_cache"
-      , [ test_case "usage with cached_tokens" `Quick test_provider_d_usage_with_cached_tokens
+      , [ test_case
+            "usage with cached_tokens"
+            `Quick
+            test_provider_d_usage_with_cached_tokens
         ; test_case
             "usage without cached_tokens"
             `Quick

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -160,7 +160,8 @@ let pp_static_model_route ppf = function
   | Capabilities.Gpt_5 -> Format.fprintf ppf "Gpt_5"
   | Capabilities.Gpt_4_1 -> Format.fprintf ppf "Gpt_4_1"
   | Capabilities.Gpt_4o -> Format.fprintf ppf "Gpt_4o"
-  | Capabilities.Provider_f family -> Format.fprintf ppf "Provider_f(%a)" pp_provider_f_family family
+  | Capabilities.Provider_f family ->
+    Format.fprintf ppf "Provider_f(%a)" pp_provider_f_family family
   | Capabilities.Provider_c_for_coding -> Format.fprintf ppf "Provider_c_for_coding"
   | Capabilities.Provider_c_k2 -> Format.fprintf ppf "Provider_c_k2"
   | Capabilities.Provider_h_3 -> Format.fprintf ppf "Provider_h_3"
@@ -251,7 +252,11 @@ let test_provider_f_family_drives_capabilities () =
     "provider_f-3.1-pro-preview ctx"
     (Some 1_000_000)
     (ctx "provider_f-3.1-pro-preview");
-  check (option int) "provider_f-2.5-flash ctx" (Some 1_000_000) (ctx "provider_f-2.5-flash")
+  check
+    (option int)
+    "provider_f-2.5-flash ctx"
+    (Some 1_000_000)
+    (ctx "provider_f-2.5-flash")
 ;;
 
 let test_static_model_route_normalizes_cloud_suffix () =
@@ -353,7 +358,11 @@ let test_lookup_unknown () =
 ;;
 
 let test_lookup_case_insensitive () =
-  check bool "uppercase matches" true (Capabilities.for_model_id "Agent_llm_a-Opus-4-6" <> None)
+  check
+    bool
+    "uppercase matches"
+    true
+    (Capabilities.for_model_id "Agent_llm_a-Opus-4-6" <> None)
 ;;
 
 let test_lookup_glm5_text_only () =

--- a/test/test_capabilities_wiring.ml
+++ b/test/test_capabilities_wiring.ml
@@ -12,7 +12,11 @@ let test_discovery_infers_from_model_name () =
   in
   let props : Discovery.server_props option =
     Some
-      { total_slots = 4; ctx_size = 262144; model = "provider_h-3.5-35b"; supports_tools = None }
+      { total_slots = 4
+      ; ctx_size = 262144
+      ; model = "provider_h-3.5-35b"
+      ; supports_tools = None
+      }
   in
   (* Discovery.infer_capabilities is internal, but we can test via
      the endpoint_status.capabilities after Discovery.discover.
@@ -39,15 +43,27 @@ let test_filter_parallel_tools () =
   let no =
     { Capabilities.default_capabilities with supports_parallel_tool_calls = false }
   in
-  check bool "provider_a has parallel" true (Capability_filter.requires_parallel_tools yes);
+  check
+    bool
+    "provider_a has parallel"
+    true
+    (Capability_filter.requires_parallel_tools yes);
   check bool "default lacks parallel" false (Capability_filter.requires_parallel_tools no)
 ;;
 
 let test_filter_thinking () =
   let agent_llm_a = Capabilities.provider_a_capabilities in
   let basic = Capabilities.provider_d_chat_capabilities in
-  check bool "agent_llm_a has thinking" true (Capability_filter.requires_thinking agent_llm_a);
-  check bool "basic provider_d no thinking" false (Capability_filter.requires_thinking basic)
+  check
+    bool
+    "agent_llm_a has thinking"
+    true
+    (Capability_filter.requires_thinking agent_llm_a);
+  check
+    bool
+    "basic provider_d no thinking"
+    false
+    (Capability_filter.requires_thinking basic)
 ;;
 
 let test_filter_fits_context () =

--- a/test/test_checkpoint_delta.ml
+++ b/test/test_checkpoint_delta.ml
@@ -126,7 +126,8 @@ let checkpoint_gen =
   let* session_id = small_string_gen in
   let* agent_name = small_string_gen in
   let* model =
-    oneof [ return "agent_llm_a-sonnet-4-6"; return "agent_llm_a-opus-4-6"; small_string_gen ]
+    oneof
+      [ return "agent_llm_a-sonnet-4-6"; return "agent_llm_a-opus-4-6"; small_string_gen ]
   in
   let* system_prompt = option small_string_gen in
   let* messages = list_size (int_range 0 5) message_gen in

--- a/test/test_cli_transport_factory.ml
+++ b/test/test_cli_transport_factory.ml
@@ -36,7 +36,7 @@ let test_registered_protocols_sorted () =
   check
     (list string)
     "sorted"
-    [ "provider_a-cli"; "agent_code-cli"; "google-cli"; "provider_c-cli" ]
+    [ "agent_code-cli"; "google-cli"; "provider_a-cli"; "provider_c-cli" ]
     protocols
 ;;
 
@@ -184,7 +184,11 @@ let test_create_rejects_empty_command () =
   with_eio
   @@ fun ~sw ~mgr ->
   expect_failure_contains "empty command" "requires a non-empty command" (fun () ->
-    create ~protocol:"agent_code-cli" ~config:{ dispatch_config with command = "   " } ~sw ~mgr)
+    create
+      ~protocol:"agent_code-cli"
+      ~config:{ dispatch_config with command = "   " }
+      ~sw
+      ~mgr)
 ;;
 
 let test_create_dispatches_all_protocols () =

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -185,7 +185,11 @@ let test_provider_health_scores_list () =
       ~provider_keys:[ provider_a_key; provider_b_key ]
   in
   check int "score count" 2 (List.length scores);
-  check (float 0.001) "provider_a degraded" (2.0 /. 3.0) (List.assoc provider_a_key scores);
+  check
+    (float 0.001)
+    "provider_a degraded"
+    (2.0 /. 3.0)
+    (List.assoc provider_a_key scores);
   check (float 0.001) "provider_b optimistic" 1.0 (List.assoc provider_b_key scores)
 ;;
 

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -7,7 +7,8 @@ open Llm_provider
 
 (* ── Mock server ─────────────────────────────────────── *)
 
-let provider_a_response ?(id = "msg-1") ?(model = "mock") ?(stop_reason = "end_turn") text =
+let provider_a_response ?(id = "msg-1") ?(model = "mock") ?(stop_reason = "end_turn") text
+  =
   Printf.sprintf
     {|{"id":"%s","type":"message","role":"assistant","model":"%s","content":[{"type":"text","text":"%s"}],"stop_reason":"%s","usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}|}
     id
@@ -216,8 +217,8 @@ let test_complete_http_empty_error_body_has_context () =
         string
         "diagnostic body"
         (Printf.sprintf
-           "empty HTTP 404 response from provider=agent_llm_a model=test-model base_url=%s \
-            request_path=/v1/messages url=%s/v1/messages"
+           "empty HTTP 404 response from provider=agent_llm_a model=test-model \
+            base_url=%s request_path=/v1/messages url=%s/v1/messages"
            url
            url)
         body;
@@ -235,7 +236,9 @@ let test_complete_provider_d_ok () =
   try
     Eio.Switch.run
     @@ fun sw ->
-    let url = start_mock_server ~sw ~net:env#net (provider_d_response "provider_d reply") in
+    let url =
+      start_mock_server ~sw ~net:env#net (provider_d_response "provider_d reply")
+    in
     let config = make_provider_d_config url in
     match Complete.complete ~sw ~net:env#net ~config ~messages () with
     | Ok resp ->

--- a/test/test_e2e_v024.ml
+++ b/test/test_e2e_v024.ml
@@ -23,7 +23,12 @@ let provider : Provider.config =
 let base_url = "http://127.0.0.1:8085"
 let local_model = provider.model_id
 
-let provider_m_config ?(system_prompt = None) ?(max_tokens = Some 200) ?(max_turns = 5) name =
+let provider_m_config
+      ?(system_prompt = None)
+      ?(max_tokens = Some 200)
+      ?(max_turns = 5)
+      name
+  =
   { default_config with
     name
   ; model = local_model

--- a/test/test_full_pipeline_cov.ml
+++ b/test/test_full_pipeline_cov.ml
@@ -214,7 +214,11 @@ let test_basic_text () =
     Eio.Switch.run
     @@ fun sw ->
     let url =
-      start_multi ~sw ~net:env#net ~port:21001 [ provider_d_text_response "hello coverage" ]
+      start_multi
+        ~sw
+        ~net:env#net
+        ~port:21001
+        [ provider_d_text_response "hello coverage" ]
     in
     let agent = make_agent ~net:env#net url in
     match Agent.run ~sw agent "hi" with
@@ -698,7 +702,9 @@ let test_context_tool () =
     Eio.Switch.run
     @@ fun sw ->
     let responses =
-      [ provider_d_tool_use "ctx_tool" {|{"key":"val"}|}; provider_d_text_response "ctx done" ]
+      [ provider_d_tool_use "ctx_tool" {|{"key":"val"}|}
+      ; provider_d_text_response "ctx done"
+      ]
     in
     let url = start_multi ~sw ~net:env#net ~port:21020 responses in
     let tool =

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -656,7 +656,9 @@ let test_build_request_basic () =
       ~temperature:0.5
       ()
   in
-  let body_str = Backend_provider_f.build_request ~config ~messages:[ user_msg "hello" ] () in
+  let body_str =
+    Backend_provider_f.build_request ~config ~messages:[ user_msg "hello" ] ()
+  in
   let json = Yojson.Safe.from_string body_str in
   let open Yojson.Safe.Util in
   (* Check contents exist *)
@@ -671,9 +673,15 @@ let test_build_request_basic () =
 
 let test_build_request_with_system_prompt () =
   let config =
-    make_config ~kind:Provider_f ~model_id:provider_f25_flash_model ~system_prompt:"be helpful" ()
+    make_config
+      ~kind:Provider_f
+      ~model_id:provider_f25_flash_model
+      ~system_prompt:"be helpful"
+      ()
   in
-  let body_str = Backend_provider_f.build_request ~config ~messages:[ user_msg "hello" ] () in
+  let body_str =
+    Backend_provider_f.build_request ~config ~messages:[ user_msg "hello" ] ()
+  in
   let json = Yojson.Safe.from_string body_str in
   let open Yojson.Safe.Util in
   match json |> member "systemInstruction" with
@@ -707,7 +715,11 @@ let test_build_request_with_thinking () =
 
 let test_build_request_with_thinking_default_budget () =
   let config =
-    make_config ~kind:Provider_f ~model_id:provider_f25_flash_model ~enable_thinking:true ()
+    make_config
+      ~kind:Provider_f
+      ~model_id:provider_f25_flash_model
+      ~enable_thinking:true
+      ()
   in
   let body_str =
     Backend_provider_f.build_request ~config ~messages:[ user_msg "reason" ] ()
@@ -911,7 +923,11 @@ let test_llm_transport_runtime_mcp_policy_json () =
 
 let test_build_request_json_mode () =
   let config =
-    make_config ~kind:Provider_f ~model_id:provider_f25_flash_model ~response_format_json:true ()
+    make_config
+      ~kind:Provider_f
+      ~model_id:provider_f25_flash_model
+      ~response_format_json:true
+      ()
   in
   let body_str =
     Backend_provider_f.build_request ~config ~messages:[ user_msg "json pls" ] ()
@@ -994,7 +1010,9 @@ let test_build_request_tool_choice_none () =
   let config =
     make_config ~kind:Provider_f ~model_id:provider_f25_flash_model ~tool_choice:None_ ()
   in
-  let body_str = Backend_provider_f.build_request ~config ~messages:[ user_msg "hi" ] () in
+  let body_str =
+    Backend_provider_f.build_request ~config ~messages:[ user_msg "hi" ] ()
+  in
   let json = Yojson.Safe.from_string body_str in
   let open Yojson.Safe.Util in
   let tc = json |> member "toolConfig" |> member "functionCallingConfig" in
@@ -1009,7 +1027,9 @@ let test_build_request_tool_choice_specific () =
       ~tool_choice:(Tool "get_weather")
       ()
   in
-  let body_str = Backend_provider_f.build_request ~config ~messages:[ user_msg "hi" ] () in
+  let body_str =
+    Backend_provider_f.build_request ~config ~messages:[ user_msg "hi" ] ()
+  in
   let json = Yojson.Safe.from_string body_str in
   let open Yojson.Safe.Util in
   let tc = json |> member "toolConfig" |> member "functionCallingConfig" in
@@ -1029,7 +1049,9 @@ let test_build_request_top_p_top_k () =
       ~top_k:40
       ()
   in
-  let body_str = Backend_provider_f.build_request ~config ~messages:[ user_msg "hi" ] () in
+  let body_str =
+    Backend_provider_f.build_request ~config ~messages:[ user_msg "hi" ] ()
+  in
   let json = Yojson.Safe.from_string body_str in
   let open Yojson.Safe.Util in
   let gc = json |> member "generationConfig" in
@@ -1285,7 +1307,10 @@ let test_parse_response_usage_with_cache () =
 
 let test_requires_tools () =
   let caps = Capabilities.provider_a_capabilities in
-  Alcotest.(check bool) "provider_a has tools" true (Capability_filter.requires_tools caps);
+  Alcotest.(check bool)
+    "provider_a has tools"
+    true
+    (Capability_filter.requires_tools caps);
   Alcotest.(check bool)
     "default no tools"
     false
@@ -1354,7 +1379,8 @@ let test_requires_structured_output () =
   Alcotest.(check bool)
     "provider_d structured"
     true
-    (Capability_filter.requires_structured_output Capabilities.provider_d_chat_capabilities);
+    (Capability_filter.requires_structured_output
+       Capabilities.provider_d_chat_capabilities);
   Alcotest.(check bool)
     "default no structured"
     false
@@ -1761,7 +1787,9 @@ let test_with_context_size () =
 
 let test_with_context_size_overrides () =
   let c =
-    Capabilities.with_context_size Capabilities.provider_a_capabilities ~ctx_size:1_000_000
+    Capabilities.with_context_size
+      Capabilities.provider_a_capabilities
+      ~ctx_size:1_000_000
   in
   Alcotest.(check (option int)) "overrides" (Some 1_000_000) c.max_context_tokens
 ;;
@@ -1976,9 +2004,18 @@ let () =
         ; Alcotest.test_case "provider_k" `Quick test_provider_k_capabilities
         ] )
     ; ( "capabilities.for_model_id"
-      , [ Alcotest.test_case "agent_llm_a-opus-4" `Quick test_for_model_id_agent_llm_a_opus_4
-        ; Alcotest.test_case "agent_llm_a-sonnet-4" `Quick test_for_model_id_agent_llm_a_sonnet_4
-        ; Alcotest.test_case "agent_llm_a-haiku-4" `Quick test_for_model_id_agent_llm_a_haiku_4
+      , [ Alcotest.test_case
+            "agent_llm_a-opus-4"
+            `Quick
+            test_for_model_id_agent_llm_a_opus_4
+        ; Alcotest.test_case
+            "agent_llm_a-sonnet-4"
+            `Quick
+            test_for_model_id_agent_llm_a_sonnet_4
+        ; Alcotest.test_case
+            "agent_llm_a-haiku-4"
+            `Quick
+            test_for_model_id_agent_llm_a_haiku_4
         ; Alcotest.test_case "gpt-5" `Quick test_for_model_id_gpt5
         ; Alcotest.test_case "gpt-4.1" `Quick test_for_model_id_gpt41
         ; Alcotest.test_case "model-d" `Quick test_for_model_id_gpt4o
@@ -1991,7 +2028,10 @@ let () =
             "provider_g-v4-flash"
             `Quick
             test_for_model_id_provider_g_v4_flash
-        ; Alcotest.test_case "provider_g-v4-pro" `Quick test_for_model_id_provider_g_v4_pro
+        ; Alcotest.test_case
+            "provider_g-v4-pro"
+            `Quick
+            test_for_model_id_provider_g_v4_pro
         ; Alcotest.test_case "provider_j-large" `Quick test_for_model_id_provider_j_large
         ; Alcotest.test_case "provider_j-small" `Quick test_for_model_id_provider_j_small
         ; Alcotest.test_case "command" `Quick test_for_model_id_command

--- a/test/test_llm_provider_error.ml
+++ b/test/test_llm_provider_error.ml
@@ -80,8 +80,8 @@ let test_capacity_exhausted () =
   check
     string
     "CapacityExhausted format"
-    "Provider capacity exhausted (model): model queue saturated affected=[provider_f-3-pro] \
-     (retry_after: 7.000s)"
+    "Provider capacity exhausted (model): model queue saturated \
+     affected=[provider_f-3-pro] (retry_after: 7.000s)"
     (Error.to_string
        (Error.CapacityExhausted
           { scope = Error.CapacityModel
@@ -175,10 +175,7 @@ let test_provider_terminal () =
     "Provider 'cli_tool_d' terminal max_turns:31/31: turn cap hit"
     (Error.to_string
        (Error.ProviderTerminal
-          { provider = "cli_tool_d"
-          ; reason = "max_turns:31/31"
-          ; detail = "turn cap hit"
-          }))
+          { provider = "cli_tool_d"; reason = "max_turns:31/31"; detail = "turn cap hit" }))
 ;;
 
 let test_retry_rate_limit_mapping () =

--- a/test/test_metrics.ml
+++ b/test/test_metrics.ml
@@ -238,11 +238,13 @@ let test_prometheus_text_histogram_exports_labeled_series () =
     text;
   check_line
     "labeled sum"
-    "gen_ai_client_ttfrc_sum{gen_ai_request_model=\"gpt-5\",gen_ai_system=\"provider_d\"} 3.5"
+    "gen_ai_client_ttfrc_sum{gen_ai_request_model=\"gpt-5\",gen_ai_system=\"provider_d\"} \
+     3.5"
     text;
   check_line
     "labeled count"
-    "gen_ai_client_ttfrc_count{gen_ai_request_model=\"gpt-5\",gen_ai_system=\"provider_d\"} 2"
+    "gen_ai_client_ttfrc_count{gen_ai_request_model=\"gpt-5\",gen_ai_system=\"provider_d\"} \
+     2"
     text
 ;;
 

--- a/test/test_metrics_aggregating.ml
+++ b/test/test_metrics_aggregating.ml
@@ -84,7 +84,8 @@ let test_aggregating_on_circuit_state () =
     ~provider_key:"gpt-4@https://api.provider_d.com"
     ~state:M.Circuit_open;
   (match !observed with
-   | Some ("provider_d", "gpt-4", "gpt-4@https://api.provider_d.com", M.Circuit_open) -> ()
+   | Some ("provider_d", "gpt-4", "gpt-4@https://api.provider_d.com", M.Circuit_open) ->
+     ()
    | Some _ -> fail "unexpected circuit state callback"
    | None -> fail "missing circuit state callback");
   check int "state value" 1 (M.circuit_state_to_int M.Circuit_open);
@@ -127,7 +128,10 @@ let test_aggregating_unknown_latency_does_not_add_sample () =
 let test_aggregating_on_streaming_latency () =
   let agg = Agg.create () in
   let hooks = Agg.to_hooks agg in
-  hooks.on_streaming_first_chunk ~provider:"provider_a" ~model_id:"agent_llm_a" ~ttfrc_ms:12.5;
+  hooks.on_streaming_first_chunk
+    ~provider:"provider_a"
+    ~model_id:"agent_llm_a"
+    ~ttfrc_ms:12.5;
   hooks.on_streaming_chunk
     ~provider:"provider_a"
     ~model_id:"agent_llm_a"

--- a/test/test_modality.ml
+++ b/test/test_modality.ml
@@ -84,7 +84,8 @@ let test_non_gemma_inherits_preserve () =
   | Some c ->
     (match c.modality_priority with
      | Modality.Preserve_input_order -> ()
-     | Modality.Visual_first -> Alcotest.fail "agent_llm_a should not opt into Visual_first")
+     | Modality.Visual_first ->
+       Alcotest.fail "agent_llm_a should not opt into Visual_first")
 ;;
 
 let () =

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -69,7 +69,10 @@ let test_provider_a_provider () =
   let env_var = "AGENT_SDK_TEST_PROVIDER_A_KEY_x9y8z7" in
   Unix.putenv env_var "sk-ant-test-key";
   let cfg : Provider.config =
-    { provider = Provider_a; model_id = "agent_llm_a-sonnet-4-20250514"; api_key_env = env_var }
+    { provider = Provider_a
+    ; model_id = "agent_llm_a-sonnet-4-20250514"
+    ; api_key_env = env_var
+    }
   in
   match Provider.resolve cfg with
   | Ok (base_url, api_key, _headers) ->
@@ -306,8 +309,8 @@ let test_validate_inference_contract_rejects_unsupported_modality () =
     Alcotest.(check string) "field" "modality" field;
     Alcotest.(check string)
       "detail"
-      "Model 'provider_h-3.5-35b-a3b-ud-q8-xl' for provider 'local' does not support modality \
-       'image'"
+      "Model 'provider_h-3.5-35b-a3b-ud-q8-xl' for provider 'local' does not support \
+       modality 'image'"
       detail
   | Error e ->
     Alcotest.fail (Printf.sprintf "unexpected error variant: %s" (Error.to_string e))
@@ -500,7 +503,8 @@ let test_config_of_provider_config_provider_c_uses_custom_provider () =
   | { provider = Provider.Custom_registered { name }; api_key_env; _ } ->
     Alcotest.(check string) "provider name" "provider_c" name;
     Alcotest.(check string) "api_key_env" "PROVIDER_C_API_KEY" api_key_env
-  | _ -> Alcotest.fail "expected provider_c config to round-trip through Custom_registered"
+  | _ ->
+    Alcotest.fail "expected provider_c config to round-trip through Custom_registered"
 ;;
 
 let test_provider_d_compat_static_token () =
@@ -566,7 +570,10 @@ let test_provider_config_of_agent_provider_a () =
   let env_var = "AGENT_SDK_TEST_ADAPTER_KEY_anth" in
   Unix.putenv env_var "sk-ant-adapter-test";
   let cfg : Provider.config =
-    { provider = Provider_a; model_id = "agent_llm_a-sonnet-4-20250514"; api_key_env = env_var }
+    { provider = Provider_a
+    ; model_id = "agent_llm_a-sonnet-4-20250514"
+    ; api_key_env = env_var
+    }
   in
   let state = agent_state_with_params () in
   match

--- a/test/test_provider_bridge.ml
+++ b/test/test_provider_bridge.ml
@@ -122,7 +122,8 @@ let test_zai_coding_auto_uses_coding_default_model () =
       in
       match Agent_sdk.Provider_bridge.to_provider_config legacy with
       | Error _ -> Alcotest.fail "z.ai coding provider should resolve without env var"
-      | Ok cfg -> Alcotest.(check string) "coding auto model" "provider_k-4.5-air" cfg.model_id))
+      | Ok cfg ->
+        Alcotest.(check string) "coding auto model" "provider_k-4.5-air" cfg.model_id))
 ;;
 
 let test_provider_c_custom_registered_becomes_provider_c_provider_config () =
@@ -153,7 +154,12 @@ let test_zai_coding_auto_models_default_order () =
   with_env "ZAI_CODING_AUTO_MODELS" "" (fun () ->
     Alcotest.(check (list string))
       "coding auto order"
-      [ "provider_k-5.1"; "provider_k-5"; "provider_k-5-turbo"; "provider_k-4.7"; "provider_k-4.5-air" ]
+      [ "provider_k-5.1"
+      ; "provider_k-5"
+      ; "provider_k-5-turbo"
+      ; "provider_k-4.7"
+      ; "provider_k-4.5-air"
+      ]
       (Llm_provider.Zai_catalog.provider_k_coding_auto_models ()))
 ;;
 
@@ -169,7 +175,10 @@ let () =
             "non-zai provider_k stays provider_d compat"
             `Quick
             test_non_zai_glm_stays_provider_d_compat
-        ; test_case "zai provider_k becomes provider_k" `Quick test_zai_glm_becomes_glm_provider_config
+        ; test_case
+            "zai provider_k becomes provider_k"
+            `Quick
+            test_zai_glm_becomes_glm_provider_config
         ; test_case
             "zai coding auto uses coding default model"
             `Quick

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -36,7 +36,10 @@ let test_provider_a_basic_body () =
   let body = BA.build_request ~config ~messages:msgs () in
   let json = Yojson.Safe.from_string body in
   let open Yojson.Safe.Util in
-  Alcotest.(check string) "model" "agent_llm_a-sonnet-4-6" (json |> member "model" |> to_string);
+  Alcotest.(check string)
+    "model"
+    "agent_llm_a-sonnet-4-6"
+    (json |> member "model" |> to_string);
   Alcotest.(check int) "max_tokens" 1024 (json |> member "max_tokens" |> to_int);
   Alcotest.(check bool) "stream false" false (json |> member "stream" |> to_bool);
   let msgs_json = json |> member "messages" |> to_list in
@@ -426,7 +429,10 @@ let test_provider_c_direct_with_tools_and_thinking () =
   let open Yojson.Safe.Util in
   let tools = json |> member "tools" |> to_list in
   let thinking = json |> member "thinking" in
-  Alcotest.(check string) "model" "provider_c-for-coding" (json |> member "model" |> to_string);
+  Alcotest.(check string)
+    "model"
+    "provider_c-for-coding"
+    (json |> member "model" |> to_string);
   Alcotest.(check int) "tool count" 1 (List.length tools);
   Alcotest.(check string)
     "thinking type"
@@ -765,7 +771,11 @@ let response_with_thinking =
 
 let test_provider_default_thinking_drift_is_info () =
   let config =
-    PC.make ~kind:Provider_d_compat ~model_id:"auto" ~base_url:"https://example.invalid/v1" ()
+    PC.make
+      ~kind:Provider_d_compat
+      ~model_id:"auto"
+      ~base_url:"https://example.invalid/v1"
+      ()
   in
   let entries = complete_with_captured_diag ~config ~response:response_with_thinking in
   Alcotest.(check bool)

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -297,7 +297,10 @@ let test_default_attempt_timeout_s () =
   check_timeout "cli_tool_d keeps CLI default" (Some 120.0) Cli_tool_d;
   check_timeout "cli_tool_c keeps CLI default" (Some 60.0) Cli_tool_c;
   check_timeout "cli_tool_b keeps CLI default" (Some 180.0) Cli_tool_b;
-  check_timeout "provider_d_compat has no default hard attempt timeout" None Provider_d_compat
+  check_timeout
+    "provider_d_compat has no default hard attempt timeout"
+    None
+    Provider_d_compat
 ;;
 
 (* ── provider_name_of_config ─────────────────────────── *)
@@ -310,7 +313,10 @@ let test_provider_name_of_config_glm_general () =
       ~base_url:Zai_catalog.general_base_url
       ()
   in
-  check_string "provider_k general" "provider_k" (Provider_registry.provider_name_of_config cfg)
+  check_string
+    "provider_k general"
+    "provider_k"
+    (Provider_registry.provider_name_of_config cfg)
 ;;
 
 let test_provider_name_of_config_glm_coding () =
@@ -321,7 +327,10 @@ let test_provider_name_of_config_glm_coding () =
       ~base_url:Zai_catalog.coding_base_url
       ()
   in
-  check_string "provider_k coding" "provider_k-coding" (Provider_registry.provider_name_of_config cfg)
+  check_string
+    "provider_k coding"
+    "provider_k-coding"
+    (Provider_registry.provider_name_of_config cfg)
 ;;
 
 let test_provider_name_of_config_local_provider_d_compat () =
@@ -812,8 +821,14 @@ let () =
             test_default_attempt_timeout_s
         ] )
     ; ( "provider_name"
-      , [ Alcotest.test_case "provider_k general" `Quick test_provider_name_of_config_glm_general
-        ; Alcotest.test_case "provider_k coding" `Quick test_provider_name_of_config_glm_coding
+      , [ Alcotest.test_case
+            "provider_k general"
+            `Quick
+            test_provider_name_of_config_glm_general
+        ; Alcotest.test_case
+            "provider_k coding"
+            `Quick
+            test_provider_name_of_config_glm_coding
         ; Alcotest.test_case
             "local provider_d compat"
             `Quick

--- a/test/test_provider_f_edge_cases.ml
+++ b/test/test_provider_f_edge_cases.ml
@@ -56,7 +56,9 @@ let test_cache_system_prompt () =
       ~system_prompt:"Be helpful."
       ()
   in
-  let body = Backend_provider_f.build_request ~config ~messages:[ Types.user_msg "hi" ] () in
+  let body =
+    Backend_provider_f.build_request ~config ~messages:[ Types.user_msg "hi" ] ()
+  in
   let json = Yojson.Safe.from_string body in
   let open Yojson.Safe.Util in
   let si = json |> member "systemInstruction" in

--- a/test/test_provider_intf.ml
+++ b/test/test_provider_intf.ml
@@ -24,7 +24,10 @@ let test_of_config_provider_d () =
 
 let test_provider_a_supports_streaming () =
   let config = Provider.provider_a_sonnet () in
-  Alcotest.(check bool) "provider_a streams" true (Provider_intf.supports_streaming config)
+  Alcotest.(check bool)
+    "provider_a streams"
+    true
+    (Provider_intf.supports_streaming config)
 ;;
 
 (* ── of_config_streaming ─────────────────────────────────── *)
@@ -129,7 +132,10 @@ let () =
             "provider_a satisfies PROVIDER"
             `Quick
             test_of_config_provider_a
-        ; Alcotest.test_case "provider_d satisfies PROVIDER" `Quick test_of_config_provider_d
+        ; Alcotest.test_case
+            "provider_d satisfies PROVIDER"
+            `Quick
+            test_of_config_provider_d
         ] )
     ; ( "streaming"
       , [ Alcotest.test_case

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -215,21 +215,41 @@ let test_default_has_19 () =
     "ollama_cloud exists"
     true
     (Option.is_some (Provider_registry.find reg "ollama_cloud"));
-  check bool "agent_llm_a exists" true (Option.is_some (Provider_registry.find reg "agent_llm_a"));
-  check bool "provider_f exists" true (Option.is_some (Provider_registry.find reg "provider_f"));
-  check bool "provider_k exists" true (Option.is_some (Provider_registry.find reg "provider_k"));
+  check
+    bool
+    "agent_llm_a exists"
+    true
+    (Option.is_some (Provider_registry.find reg "agent_llm_a"));
+  check
+    bool
+    "provider_f exists"
+    true
+    (Option.is_some (Provider_registry.find reg "provider_f"));
+  check
+    bool
+    "provider_k exists"
+    true
+    (Option.is_some (Provider_registry.find reg "provider_k"));
   check
     bool
     "provider_k-coding exists"
     true
     (Option.is_some (Provider_registry.find reg "provider_k-coding"));
-  check bool "provider_c exists" true (Option.is_some (Provider_registry.find reg "provider_c"));
+  check
+    bool
+    "provider_c exists"
+    true
+    (Option.is_some (Provider_registry.find reg "provider_c"));
   check
     bool
     "openrouter exists"
     true
     (Option.is_some (Provider_registry.find reg "openrouter"));
-  check bool "provider_i exists" true (Option.is_some (Provider_registry.find reg "provider_i"));
+  check
+    bool
+    "provider_i exists"
+    true
+    (Option.is_some (Provider_registry.find reg "provider_i"));
   check
     bool
     "provider_g exists"
@@ -376,12 +396,24 @@ let test_default_zai_base_urls () =
    | None -> fail "provider_k should exist");
   (match Provider_registry.find reg "provider_k-coding" with
    | Some e ->
-     check string "provider_k-coding base_url" Zai_catalog.coding_base_url e.defaults.base_url;
-     check string "provider_k-coding api_key_env" "ZAI_CODING_API_KEY" e.defaults.api_key_env
+     check
+       string
+       "provider_k-coding base_url"
+       Zai_catalog.coding_base_url
+       e.defaults.base_url;
+     check
+       string
+       "provider_k-coding api_key_env"
+       "ZAI_CODING_API_KEY"
+       e.defaults.api_key_env
    | None -> fail "provider_k-coding should exist");
   match Provider_registry.find reg "provider_c" with
   | Some e ->
-    check string "provider_c base_url" "https://api.provider_c.com/coding" e.defaults.base_url;
+    check
+      string
+      "provider_c base_url"
+      "https://api.provider_c.com/coding"
+      e.defaults.base_url;
     check string "provider_c request_path" "/v1/messages" e.defaults.request_path
   | None -> fail "provider_c should exist"
 ;;

--- a/test/test_runtime.ml
+++ b/test/test_runtime.ml
@@ -1134,7 +1134,10 @@ let test_session_settings_persist_across_resume () =
     "protocol unchanged"
     Runtime.protocol_version
     info.protocol_version;
-  Alcotest.(check (option string)) "model persisted" (Some "provider_h-3.5-coder") session.model;
+  Alcotest.(check (option string))
+    "model persisted"
+    (Some "provider_h-3.5-coder")
+    session.model;
   Alcotest.(check (option string))
     "permission mode persisted"
     (Some "bypass_permissions")

--- a/test/test_runtime_evidence.ml
+++ b/test/test_runtime_evidence.ml
@@ -63,7 +63,8 @@ let all_event_kinds () =
     }
   in
   [ Session_started { goal = "collect telemetry"; participants = [ "alice" ] }
-  ; Session_settings_updated { model = Some "agent_llm_a-opus"; permission_mode = Some "safe" }
+  ; Session_settings_updated
+      { model = Some "agent_llm_a-opus"; permission_mode = Some "safe" }
   ; Turn_recorded { actor = Some "user"; message = "start" }
   ; Input_required input_request
   ; Input_provided

--- a/test/test_runtime_projection_cov2.ml
+++ b/test/test_runtime_projection_cov2.ml
@@ -410,7 +410,10 @@ let test_apply_agent_spawn () =
     in
     Alcotest.(check bool) "state Starting" true (bob.state = Starting);
     Alcotest.(check (option string)) "role" (Some "reviewer") bob.role;
-    Alcotest.(check (option string)) "req_provider" (Some "provider_d") bob.requested_provider
+    Alcotest.(check (option string))
+      "req_provider"
+      (Some "provider_d")
+      bob.requested_provider
   | Error e -> Alcotest.fail (Error.to_string e)
 ;;
 

--- a/test/test_subagent.ml
+++ b/test/test_subagent.ml
@@ -464,7 +464,11 @@ let () =
             in
             check string "name" "helper" target.name;
             check string "desc" "Helps out" target.description;
-            check bool "model" true (target.config.model = "agent_llm_a-haiku-4-5-20251001");
+            check
+              bool
+              "model"
+              true
+              (target.config.model = "agent_llm_a-haiku-4-5-20251001");
             check int "max_turns" 3 target.config.max_turns;
             check
               (option string)

--- a/test/test_telemetry_event.ml
+++ b/test/test_telemetry_event.ml
@@ -25,7 +25,11 @@ let check_float msg expected actual = check (float 0.001) msg expected actual
 let test_streaming_first_chunk () =
   let ev =
     Telemetry_event.Streaming_first_chunk
-      { provider = "provider_d"; model = "gpt-4"; ttfrc_ms = 123.456; requested_at = 1000.0 }
+      { provider = "provider_d"
+      ; model = "gpt-4"
+      ; ttfrc_ms = 123.456
+      ; requested_at = 1000.0
+      }
   in
   match roundtrip ev with
   | Telemetry_event.Streaming_first_chunk r ->
@@ -108,7 +112,10 @@ let test_thinking_complete () =
 let test_timeout_no_response () =
   let ev =
     Telemetry_event.Timeout
-      { provider = "provider_f"; model = "flash"; timeout_type = Telemetry_event.No_response }
+      { provider = "provider_f"
+      ; model = "flash"
+      ; timeout_type = Telemetry_event.No_response
+      }
   in
   match roundtrip ev with
   | Telemetry_event.Timeout r ->

--- a/test/test_tool_use_recovery.ml
+++ b/test/test_tool_use_recovery.ml
@@ -175,7 +175,10 @@ let () =
         ] )
     ; ( "extract_name_and_input"
       , [ test_case "provider_a style" `Quick test_extract_provider_a_style
-        ; test_case "provider_d arguments object" `Quick test_extract_provider_d_arguments_object
+        ; test_case
+            "provider_d arguments object"
+            `Quick
+            test_extract_provider_d_arguments_object
         ; test_case "double stringified" `Quick test_extract_double_stringified
         ; test_case "tool_calls wrapper" `Quick test_extract_tool_calls_wrapper
         ; test_case "no shape" `Quick test_extract_none


### PR DESCRIPTION
## Summary

- Update the transport drift gate to check the renamed `transport_cli_tool_{a,b,c,d}` files instead of deleted legacy transport modules.
- Apply the repository's current `ocamlformat` 0.29.0 output after the vendor purge so `@fmt` is green again.
- Repair remaining provider drift: `model-e` now resolves through the Grok capability route, `provider_f_budget` reads `OAS_PROVIDER_F_THINKING_BUDGET`, and the CLI transport registry test expects the sorted contract.

## Validation

- `scripts/check-transport-truth.sh`
- `scripts/dune-local.sh build @fmt`
- `scripts/dune-local.sh build test/test_cli_transport_factory.exe test/test_llm_provider_cov.exe test/test_capabilities.exe test/test_provider_intf.exe test/test_provider_registry.exe`
- `./_build/default/test/test_cli_transport_factory.exe`
- `./_build/default/test/test_llm_provider_cov.exe`
- `./_build/default/test/test_capabilities.exe`
- `./_build/default/test/test_provider_registry.exe`
- `./_build/default/test/test_llm_provider_error.exe`
- `./_build/default/test/test_tool_schema_gen.exe`
- `./_build/default/test/test_tool_input_validation.exe`
- `./_build/default/test/test_artifact_service.exe`
- `./_build/default/test/test_types.exe`
- `git diff --check`
- `git diff --cached --check`

Note: `./_build/default/test/test_provider_intf.exe` still fails locally in this sandbox at the loopback mock server bind step with `Unix.EPERM`; this is the same environment-limited local failure path observed before this fix branch.