### PR TITLE
refactor(sdk): big-bang vendor purge §3 promotion — Cohere/Meta/OpenRouter/Gpt/Grok

### DIFF
--- a/docs/RFC-0001-vendor-purge.md
+++ b/docs/RFC-0001-vendor-purge.md
@@ -59,6 +59,53 @@ OAS has one external consumer (masc-mcp), under the same operator's control. For
 
 These were missed by the initial `\bqwen\b` perl regex pass because `qwen` followed by a digit (`qwen3`) has no word boundary — `\b` requires word-to-non-word transition, and `3` is `\w`. Explicit substring patterns close the gap.
 
+### Vendor letter assignment (extended in §3-promotion sweep)
+
+| Letter | Vendor | Category |
+|--------|--------|----------|
+| `a` | Anthropic | LLM provider |
+| `b` | Moonshot | LLM provider |
+| `c` | Kimi | LLM provider |
+| `d` | OpenAI | LLM provider |
+| `e` | xAI | LLM provider |
+| `f` | Google (Gemini + Gemma + Vertex) | LLM provider |
+| `g` | DeepSeek | LLM provider |
+| `h` | Qwen / DashScope | LLM provider |
+| `i` | Groq | Inference |
+| `j` | Mistral | LLM provider |
+| `k` | Glm (Zhipu AI) | LLM provider |
+| `l` | Nemotron | LLM provider |
+| `m` | **Cohere** (new) | LLM provider |
+| `n` | **Meta** (new) | Open-weight provider (Llama family) |
+| `o` | **OpenRouter** (new) | Aggregator (identifier only — URL preserved) |
+
+### Constructor renames (§3-promotion follow-up)
+
+| Original | New |
+|----------|-----|
+| `Gpt_5`, `Gpt_4_1`, `Gpt_4o` | `Provider_d_5`, `Provider_d_4_1`, `Provider_d_4o` |
+| `Llama_4` | `Provider_n_4` |
+| `Gemma_4 of { has_large_audio : bool }` | `Provider_f_gemma_4 of { has_large_audio : bool }` |
+| `Grok` | `Provider_e_grok` |
+| `Command` | `Provider_m_command` |
+| `Llama_server` (future-variant comment) | `Provider_n_server` |
+
+### Model id strings (§3-promotion follow-up)
+
+| Family | Original | New |
+|--------|----------|-----|
+| GPT (OpenAI) | `gpt-4`, `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `gpt-5`, `gpt-5.1`, `gpt-5.2`, `gpt-5.3-agent_code{,-spark}`, `gpt-5.4{,-mini}`, `gpt-5.5`, `gpt-image` | `model-d-*` |
+| Llama (Meta) | `llama-3.1-70b`, `llama-3.3-70b`, `llama-4-scout`, `llama-4-maverick`, `llama-70b`, `llama.context_length`, `"llama"`, `"ollama/llama3"`, `"ollama/llama"` | `model-n-*` / `provider_n*` |
+| Gemma (Google) | `gemma-*`, `"gemma"`, `gemma_4_has_large_audio` | `model-f-gemma-*`, `"provider_f_gemma"`, `provider_f_gemma_4_has_large_audio` |
+| Grok (xAI) | `grok-*`, `"grok"`, `~prefix:"grok"` | `model-e-grok-*`, `"provider_e_grok"`, `~prefix:"model-e-grok"` |
+| Qwen underscore (boundary miss) | `qwen3_5` | `provider_h_3_5` |
+| Meta as owned_by | `"owned_by":"meta"`, `"owned_by", \`String "meta"` | `"owned_by":"provider_n"`, `"owned_by", \`String "provider_n"` |
+
+### Aggregator / Cloud identifiers
+
+- `openrouter` / `OpenRouter` (OCaml identifier) → `provider_o_router` / `Provider_o_router`
+- `Vertex AI` (comment) → `Provider_f cloud`
+
 ### File renames
 
 17 modules renamed via `git mv`:
@@ -112,15 +159,14 @@ Module references updated repo-wide; `test/dune` test list updated.
 | `~name:"claude"`, `~name:"codex"`, `~name:"gemini"`, `~name:"kimi"` (log labels in subprocess transport) | Same as binary path — operator-facing label that matches the actual binary. |
 | `CODEX_COMPANION_SESSION_ID` env var (scrubbed) | External Codex CLI's own env var, scrubbed by transport before subprocess exec. Not OAS-defined. |
 | `Ollama` variant (provider_kind) | LLM serving framework, not vendor — same rationale as masc-mcp RFC-0168~0173. |
-| `Llama_4` variant (static_model_route) + `llama-3.1-70b` / `llama-3.3-70b` / `llama-4-maverick` / `llama3` model id strings | Meta-released open-weight model family. Sweep mapping has no `llama` entry — preserved as community model name (not company brand). |
-| `Gemma_4` variant (static_model_route) | Google open-weight model family. Sweep mapping has no `gemma` entry — preserved as community model name. |
-| `Grok` variant (static_model_route) + `"grok"` prefix strings | xAI's product brand. Sweep mapping has no `grok` entry (only `groq → provider_i` for the Groq inference company). Preserved. |
-| `Command` variant (static_model_route) | Cohere product. Sweep mapping has no `cohere` / `command` entry. Preserved as single token. |
-| `Gpt_5`, `Gpt_4_1`, `Gpt_4o` variants (static_model_route) | OpenAI model identifiers at constructor level. Sweep maps `openai → provider_d` for strings/types but not `Gpt_*` constructors. Preserved as the constructor surface is internal-only; downstream string-form `gpt-4o`/`gpt-4o-mini` already mapped via model-id table to `model-d`/`model-d-mini`. |
 | `llama-server`, `llama.cpp` references | External LLM serving infrastructure (Meta's `llama.cpp` project + its bundled `llama-server` binary). Operator-installed software, same boundary as `claude`/`codex` binaries. |
+| `https://openrouter.ai/api/v1` URL | Real external OpenRouter service endpoint. Changing this string breaks live HTTP requests to the aggregator — same boundary as runtime binary paths. The OCaml identifier `openrouter` was renamed to `provider_o_router`; the URL string itself stays. |
+| `https://generativelanguage.googleapis.com` URL | Real external Google AI endpoint. Same rationale as above. |
+| `"Command"` text in test fixtures (`description = "Command"`, `goal = "Command test"`) | Generic English, not vendor reference. |
+| `"Command-line interface"` prose in `bin/oas_cli.ml` | Standard CLI term. |
 | Comment references to original vendor names | None — all rewritten. |
 
-These 4 binary path + 12 spawn-name occurrences are the technical boundary: the SDK calls external OS binaries that must be installed by name on the operator's system. The variant-level preservations (Llama_4, Gemma_4, Grok, Command, Gpt_*) reflect the explicit decision encoded in the sweep mapping table: open-weight community models and a few brand-tokens without a sweep entry remain as-is. Adding them would require operator-side downstream label changes without producing additional vendor-decoupling benefit.
+These 4 binary path + 12 spawn-name occurrences plus the external HTTP endpoint URLs are the technical boundary: the SDK has to name the actual binaries and services it talks to. Everything else — including open-weight model families (Llama, Gemma) and aggregator identifiers (`openrouter`) — was promoted from §3 to §2 in the §3-promotion follow-up sweep, per user direction "전부 폭파 — aggregator 포함".
 
 ## 4. Verification
 

--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -247,7 +247,7 @@ let load path =
     through {!Llm_provider.Provider_kind.of_string}, which accepts the
     canonical wire forms (["provider_a"], ["provider_d_compat"], …) plus the
     documented aliases (["agent_llm_a"] -> Provider_a,
-    ["provider_d"] -> Provider_d_compat, ["llama"] -> Ollama), case-insensitively
+    ["provider_d"] -> Provider_d_compat, ["provider_n"] -> Ollama), case-insensitively
     with leading/trailing whitespace trimmed.
 
     ["local"] remains a first-class routing shorthand (not a Provider_kind

--- a/lib/api_provider_d.ml
+++ b/lib/api_provider_d.ml
@@ -39,8 +39,8 @@ let is_zai_provider_config (cfg : Provider.config) =
      [cfg.provider]) so the compiler flags any new constructor here.
      ZAI detection depends on a [base_url] field; [Provider_a] and
      [Custom_registered] don't carry one so they are non-ZAI today,
-     but a future base_url-carrying variant (e.g. [Llama_server],
-     [OpenRouter]) would silently inherit "non-ZAI" under the previous
+     but a future base_url-carrying variant (e.g. [Provider_n_server],
+     [Provider_o_router]) would silently inherit "non-ZAI" under the previous
      [_ -> false] catch-all even if its URL was a ZAI endpoint. *)
   match cfg.provider with
   | Provider.OpenAICompat { base_url; _ } | Provider.Local { base_url } ->

--- a/lib/llm_provider/backend_provider_d.ml
+++ b/lib/llm_provider/backend_provider_d.ml
@@ -309,7 +309,7 @@ let%test "parse_provider_d_response_result basic text response" =
     Yojson.Safe.to_string
       (`Assoc
           [ "id", `String "chatcmpl-1"
-          ; "model", `String "gpt-4"
+          ; "model", `String "model-d-4"
           ; ( "choices"
             , `List
                 [ `Assoc
@@ -321,7 +321,7 @@ let%test "parse_provider_d_response_result basic text response" =
   in
   match parse_provider_d_response_result json_str with
   | Ok resp ->
-    resp.id = "chatcmpl-1" && resp.model = "gpt-4" && resp.stop_reason = EndTurn
+    resp.id = "chatcmpl-1" && resp.model = "model-d-4" && resp.stop_reason = EndTurn
   | Error _ -> false
 ;;
 
@@ -330,7 +330,7 @@ let%test "parse_provider_d_response_result tool calls" =
     Yojson.Safe.to_string
       (`Assoc
           [ "id", `String "cmpl-2"
-          ; "model", `String "gpt-4"
+          ; "model", `String "model-d-4"
           ; ( "choices"
             , `List
                 [ `Assoc
@@ -1259,7 +1259,7 @@ let%test "build_request emits reasoning_effort for Provider_d reasoning models" 
   let config =
     Provider_config.make
       ~kind:Provider_d_compat
-      ~model_id:"gpt-5.1"
+      ~model_id:"model-d-5.1"
       ~base_url:"https://api.provider_d.com/v1"
       ~enable_thinking:true
       ~thinking_budget:2048
@@ -1315,7 +1315,7 @@ let%test "build_request omits thinking params for No_thinking_control" =
   let config =
     Provider_config.make
       ~kind:Provider_d_compat
-      ~model_id:"llama-3.3-70b"
+      ~model_id:"model-n-3.3-70b"
       ~base_url:"http://localhost"
       ~enable_thinking:true
       ()
@@ -1323,7 +1323,7 @@ let%test "build_request omits thinking params for No_thinking_control" =
   let body = build_request ~config ~messages:[] () in
   let json = Yojson.Safe.from_string body in
   let open Yojson.Safe.Util in
-  (* llama-3.3-70b resolves to default_capabilities (No_thinking_control),
+  (* model-n-3.3-70b resolves to default_capabilities (No_thinking_control),
      so neither thinking nor chat_template_kwargs should appear *)
   json |> member "thinking" = `Null && json |> member "chat_template_kwargs" = `Null
 ;;

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -430,22 +430,22 @@ type static_model_route =
   | Agent_llm_a_opus_4
   | Agent_llm_a_sonnet_4
   | Agent_llm_a_haiku_4
-  | Gpt_5
-  | Gpt_4_1
-  | Gpt_4o
+  | Provider_d_5
+  | Provider_d_4_1
+  | Provider_d_4o
   | Provider_f of provider_f_family
   | Provider_c_for_coding
   | Provider_c_k2
   | Provider_h_3
-  | Llama_4
+  | Provider_n_4
   | Provider_g_v4_flash
   | Provider_g_v4_pro
   | Provider_j_large
   | Provider_j_small
-  | Command
-  | Grok
+  | Provider_m_command
+  | Provider_e_grok
   | Provider_l of { has_vision : bool }
-  | Gemma_4 of { has_large_audio : bool }
+  | Provider_f_gemma_4 of { has_large_audio : bool }
   | Glm_flash_air
   | Glm_5_turbo
   | Glm_5v_turbo
@@ -461,14 +461,14 @@ let normalize_static_model_id model_id =
   model_id |> String.trim |> String.lowercase_ascii |> strip_suffix ~suffix:":cloud"
 ;;
 
-let gemma_4_has_large_audio model_id =
+let provider_f_gemma_4_has_large_audio model_id =
   let base =
     if String.starts_with ~prefix:"google/" model_id
     then String.sub model_id 7 (String.length model_id - 7)
     else model_id
   in
   let size =
-    if String.starts_with ~prefix:"gemma-4-" base
+    if String.starts_with ~prefix:"model-f-gemma-4-" base
     then Some (String.sub base 8 (String.length base - 8))
     else None
   in
@@ -486,12 +486,12 @@ let static_model_route_of_id model_id =
   then Some Agent_llm_a_sonnet_4
   else if String.starts_with ~prefix:"agent_llm_a-haiku-4" m
   then Some Agent_llm_a_haiku_4
-  else if String.starts_with ~prefix:"gpt-5" m
-  then Some Gpt_5
-  else if String.starts_with ~prefix:"gpt-4.1" m
-  then Some Gpt_4_1
+  else if String.starts_with ~prefix:"model-d-5" m
+  then Some Provider_d_5
+  else if String.starts_with ~prefix:"model-d-4.1" m
+  then Some Provider_d_4_1
   else if String.starts_with ~prefix:"model-d" m
-  then Some Gpt_4o
+  then Some Provider_d_4o
   else (
     match provider_f_family_of_id m with
     | (Provider_f_3 | Provider_f_3_1 | Provider_f_2_5) as family ->
@@ -506,8 +506,8 @@ let static_model_route_of_id model_id =
         || String.starts_with ~prefix:"provider_h_3" m
       then Some Provider_h_3
       else if
-        String.starts_with ~prefix:"llama-4" m || String.starts_with ~prefix:"llama4" m
-      then Some Llama_4
+        String.starts_with ~prefix:"model-n-4" m || String.starts_with ~prefix:"llama4" m
+      then Some Provider_n_4
       else if String.starts_with ~prefix:"provider_g-v4-flash" m
       then Some Provider_g_v4_flash
       else if String.starts_with ~prefix:"provider_g-v4-pro" m
@@ -517,10 +517,10 @@ let static_model_route_of_id model_id =
       else if String.starts_with ~prefix:"provider_j-small" m
       then Some Provider_j_small
       else if String.starts_with ~prefix:"command" m
-      then Some Command
+      then Some Provider_m_command
       else if
-        String.starts_with ~prefix:"grok" m || String.starts_with ~prefix:"model-e" m
-      then Some Grok
+        String.starts_with ~prefix:"provider_e_grok" m || String.starts_with ~prefix:"model-e" m
+      then Some Provider_e_grok
       else if
         String.starts_with ~prefix:"nvidia/provider_l" m
         || String.starts_with ~prefix:"provider_l" m
@@ -532,9 +532,9 @@ let static_model_route_of_id model_id =
                  || String.starts_with ~prefix:"provider_l-vl" m
              })
       else if
-        String.starts_with ~prefix:"gemma-4" m
-        || String.starts_with ~prefix:"google/gemma-4" m
-      then Some (Gemma_4 { has_large_audio = gemma_4_has_large_audio m })
+        String.starts_with ~prefix:"model-f-gemma-4" m
+        || String.starts_with ~prefix:"google/model-f-gemma-4" m
+      then Some (Provider_f_gemma_4 { has_large_audio = provider_f_gemma_4_has_large_audio m })
       else if
         String.starts_with ~prefix:"provider_k-4.7-flash" m
         || String.starts_with ~prefix:"provider_k-4.5-flash" m
@@ -588,20 +588,20 @@ let capabilities_of_static_model_route = function
         max_context_tokens = Some 200_000
       ; max_output_tokens = Some 8_192
       }
-  | Gpt_5 ->
+  | Provider_d_5 ->
     Some
       { provider_d_chat_extended_capabilities with
         max_context_tokens = Some 1_050_000
       ; max_output_tokens = Some 128_000
       ; supports_computer_use = true
       }
-  | Gpt_4_1 ->
+  | Provider_d_4_1 ->
     Some
       { provider_d_chat_capabilities with
         max_context_tokens = Some 1_000_000
       ; max_output_tokens = Some 32_000
       }
-  | Gpt_4o ->
+  | Provider_d_4o ->
     Some
       { provider_d_chat_capabilities with
         max_context_tokens = Some 128_000
@@ -624,7 +624,7 @@ let capabilities_of_static_model_route = function
       ; supports_top_k = true
       ; supports_min_p = true
       }
-  | Llama_4 ->
+  | Provider_n_4 ->
     Some
       { default_capabilities with
         max_context_tokens = Some 1_000_000
@@ -698,7 +698,7 @@ let capabilities_of_static_model_route = function
       ; supports_prompt_caching = false
       ; prompt_cache_alignment = None
       }
-  | Command ->
+  | Provider_m_command ->
     Some
       { default_capabilities with
         max_context_tokens = Some 256_000
@@ -709,7 +709,7 @@ let capabilities_of_static_model_route = function
       ; supports_structured_output = true
       ; supports_native_streaming = true
       }
-  | Grok ->
+  | Provider_e_grok ->
     Some
       { default_capabilities with
         max_context_tokens = Some 2_000_000
@@ -737,7 +737,7 @@ let capabilities_of_static_model_route = function
     (* Gemma 4: Google open-weight multimodal.
        4 sizes (1B/4B/12B/27B-31B). All support function calling,
        image input, streaming. 27B+ supports audio. 256K context. *)
-  | Gemma_4 { has_large_audio } ->
+  | Provider_f_gemma_4 { has_large_audio } ->
     Some
       { default_capabilities with
         max_context_tokens = Some 262_144
@@ -1179,8 +1179,8 @@ let%test "for_model_id nvidia/provider_l-core resolves" =
   | None -> false
 ;;
 
-let%test "for_model_id gemma-4-27b has tools + seed" =
-  match for_model_id "gemma-4-27b-it" with
+let%test "for_model_id model-f-gemma-4-27b has tools + seed" =
+  match for_model_id "model-f-gemma-4-27b-it" with
   | Some c ->
     c.supports_tools
     && c.supports_seed
@@ -1189,26 +1189,26 @@ let%test "for_model_id gemma-4-27b has tools + seed" =
   | None -> false
 ;;
 
-let%test "for_model_id gemma-4-1b-it has tools, no audio" =
-  match for_model_id "gemma-4-1b-it" with
+let%test "for_model_id model-f-gemma-4-1b-it has tools, no audio" =
+  match for_model_id "model-f-gemma-4-1b-it" with
   | Some c -> c.supports_tools && c.supports_image_input && not c.supports_audio_input
   | None -> false
 ;;
 
-let%test "for_model_id google/gemma-4-1b-it is NOT large" =
-  match for_model_id "google/gemma-4-1b-it" with
+let%test "for_model_id google/model-f-gemma-4-1b-it is NOT large" =
+  match for_model_id "google/model-f-gemma-4-1b-it" with
   | Some c -> not c.supports_audio_input
   | None -> false
 ;;
 
-let%test "for_model_id google/gemma-4-27b-it IS large" =
-  match for_model_id "google/gemma-4-27b-it" with
+let%test "for_model_id google/model-f-gemma-4-27b-it IS large" =
+  match for_model_id "google/model-f-gemma-4-27b-it" with
   | Some c -> c.supports_audio_input
   | None -> false
 ;;
 
-let%test "for_model_id gemma-4-31b IS large" =
-  match for_model_id "gemma-4-31b-it" with
+let%test "for_model_id model-f-gemma-4-31b IS large" =
+  match for_model_id "model-f-gemma-4-31b-it" with
   | Some c -> c.supports_audio_input
   | None -> false
 ;;
@@ -1254,7 +1254,7 @@ let%test "for_model_id: specific model IDs get correct (not shadowed) capabiliti
           && c.max_output_tokens = Some 128_000 )
     ; ("provider_k-ocr-test", fun c -> c.supports_image_input && not c.supports_tools)
     ; ("agent_llm_a-opus-4-20250501", fun c -> c.max_output_tokens = Some 128_000)
-    ; ("gpt-4.1-mini", fun c -> c.max_output_tokens = Some 32_000)
+    ; ("model-d-4.1-mini", fun c -> c.max_output_tokens = Some 32_000)
     ; ("provider_g-v4-flash-test", fun c -> c.thinking_control_format = Thinking_object)
     ; ( "provider_l-ultra-253b"
       , fun c ->
@@ -1263,13 +1263,13 @@ let%test "for_model_id: specific model IDs get correct (not shadowed) capabiliti
       , fun c ->
           c.thinking_control_format = Chat_template_kwargs && c.supports_tool_choice )
     ; ("provider_l-vl", fun c -> c.supports_image_input && c.supports_multimodal_inputs)
-    ; ( "gemma-4-27b-it"
+    ; ( "model-f-gemma-4-27b-it"
       , fun c ->
           c.supports_tools
           && c.supports_image_input
           && c.supports_seed
           && c.max_context_tokens = Some 262_144 )
-    ; ("google/gemma-4-27b-it", fun c -> c.supports_tools && c.supports_image_input)
+    ; ("google/model-f-gemma-4-27b-it", fun c -> c.supports_tools && c.supports_image_input)
     ]
 ;;
 

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -130,22 +130,22 @@ type static_model_route =
   | Agent_llm_a_opus_4
   | Agent_llm_a_sonnet_4
   | Agent_llm_a_haiku_4
-  | Gpt_5
-  | Gpt_4_1
-  | Gpt_4o
+  | Provider_d_5
+  | Provider_d_4_1
+  | Provider_d_4o
   | Provider_f of provider_f_family
   | Provider_c_for_coding
   | Provider_c_k2
   | Provider_h_3
-  | Llama_4
+  | Provider_n_4
   | Provider_g_v4_flash
   | Provider_g_v4_pro
   | Provider_j_large
   | Provider_j_small
-  | Command
-  | Grok
+  | Provider_m_command
+  | Provider_e_grok
   | Provider_l of { has_vision : bool }
-  | Gemma_4 of { has_large_audio : bool }
+  | Provider_f_gemma_4 of { has_large_audio : bool }
   | Glm_flash_air
   | Glm_5_turbo
   | Glm_5v_turbo

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -12,7 +12,7 @@
 (** Construct the URL for a Provider_f API call.
     Sync: [base_url/models/model_id:generateContent?key=api_key]
     Stream: [base_url/models/model_id:streamGenerateContent?key=api_key&alt=sse]
-    When api_key is empty (Vertex AI), the [?key=] param is omitted. *)
+    When api_key is empty (Provider_f cloud), the [?key=] param is omitted. *)
 let provider_f_url ~(config : Provider_config.t) ~stream =
   let method_name = if stream then "streamGenerateContent" else "generateContent" in
   let base =
@@ -2288,7 +2288,7 @@ let%test "patch_telemetry creates telemetry when None" =
   let config =
     Provider_config.make
       ~kind:Provider_d_compat
-      ~model_id:"gpt-4"
+      ~model_id:"model-d-4"
       ~base_url:"https://api.provider_d.com"
       ()
   in
@@ -2306,7 +2306,7 @@ let%test "patch_telemetry creates telemetry when None" =
   | Some t ->
     t.request_latency_ms = Some 100
     && t.provider_kind = Some Provider_config.Provider_d_compat
-    && t.canonical_model_id = Some "gpt-4"
+    && t.canonical_model_id = Some "model-d-4"
     && t.effective_context_window = Some 128_000
     && t.reasoning_effort = None
     && t.provider_internal_action_count = None
@@ -2397,7 +2397,7 @@ let%test "patch_telemetry fills blank response model" =
   let config =
     Provider_config.make
       ~kind:Provider_d_compat
-      ~model_id:"gpt-5.4-mini"
+      ~model_id:"model-d-5.4-mini"
       ~base_url:"https://api.provider_d.com"
       ()
   in
@@ -2411,7 +2411,7 @@ let%test "patch_telemetry fills blank response model" =
     }
   in
   let patched = patch_telemetry resp ~config (Some 100) in
-  patched.model = "gpt-5.4-mini"
+  patched.model = "model-d-5.4-mini"
 ;;
 
 let%test "reasoning_effort_of_config Ollama default is none" =

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -182,8 +182,8 @@ let%test "accumulate_event MessageStart sets id and model" =
   let acc = create_stream_acc () in
   accumulate_event
     acc
-    (Types.MessageStart { id = "msg-1"; model = "gpt-4"; usage = None });
-  !(acc.id) = "msg-1" && !(acc.model) = "gpt-4"
+    (Types.MessageStart { id = "msg-1"; model = "model-d-4"; usage = None });
+  !(acc.id) = "msg-1" && !(acc.model) = "model-d-4"
 ;;
 
 let%test "accumulate_event MessageStart with usage" =

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -111,7 +111,7 @@ let parse_slots = Discovery_parse.parse_slots
 (* ── Ollama fallback ────────────────────────────────────── *)
 
 (** Search for context_length in an Ollama model_info JSON object.
-    Ollama uses model-specific key prefixes (e.g. "qwen3_5.context_length")
+    Ollama uses model-specific key prefixes (e.g. "provider_h_3_5.context_length")
     rather than the generic "general.context_length".  Apply deterministic
     precedence when multiple keys are present: prefer "context_length",
     then "general.context_length", then take the maximum value across any
@@ -848,7 +848,7 @@ let%test "parse_models valid" =
       [ ( "data"
         , `List
             [ `Assoc [ "id", `String "provider_h-3.5-35b"; "owned_by", `String "local" ]
-            ; `Assoc [ "id", `String "llama-4-scout"; "owned_by", `String "meta" ]
+            ; `Assoc [ "id", `String "model-n-4-scout"; "owned_by", `String "provider_n" ]
             ] )
       ]
   in
@@ -978,7 +978,7 @@ let%test "contains_case_insensitive case insensitive match" =
 ;;
 
 let%test "contains_case_insensitive no match" =
-  Retry.contains_case_insensitive ~haystack:"llama" ~needle:"provider_h" = false
+  Retry.contains_case_insensitive ~haystack:"provider_n" ~needle:"provider_h" = false
 ;;
 
 let%test "contains_case_insensitive needle longer than haystack" =
@@ -1237,7 +1237,7 @@ let%test "find_context_length with general.context_length" =
 let%test "find_context_length with model-specific prefix" =
   let mi =
     `Assoc
-      [ "qwen3_5.embedding_length", `Int 3584; "qwen3_5.context_length", `Int 262144 ]
+      [ "provider_h_3_5.embedding_length", `Int 3584; "provider_h_3_5.context_length", `Int 262144 ]
   in
   find_context_length mi = 262144
 ;;
@@ -1249,25 +1249,25 @@ let%test "find_context_length prefers context_length over general" =
 
 let%test "find_context_length prefers general.context_length over model-specific" =
   let mi =
-    `Assoc [ "qwen3_5.context_length", `Int 262144; "general.context_length", `Int 8192 ]
+    `Assoc [ "provider_h_3_5.context_length", `Int 262144; "general.context_length", `Int 8192 ]
   in
   find_context_length mi = 8192
 ;;
 
 let%test "find_context_length takes max of model-specific keys" =
   let mi =
-    `Assoc [ "llama.context_length", `Int 8192; "qwen3_5.context_length", `Int 262144 ]
+    `Assoc [ "provider_n.context_length", `Int 8192; "provider_h_3_5.context_length", `Int 262144 ]
   in
   find_context_length mi = 262144
 ;;
 
 let%test "find_context_length with float value" =
-  let mi = `Assoc [ "llama.context_length", `Float 131072.0 ] in
+  let mi = `Assoc [ "provider_n.context_length", `Float 131072.0 ] in
   find_context_length mi = 131072
 ;;
 
 let%test "find_context_length returns 0 when no matching key" =
-  let mi = `Assoc [ "qwen3_5.embedding_length", `Int 3584 ] in
+  let mi = `Assoc [ "provider_h_3_5.embedding_length", `Int 3584 ] in
   find_context_length mi = 0
 ;;
 

--- a/lib/llm_provider/model_meta.ml
+++ b/lib/llm_provider/model_meta.ml
@@ -100,8 +100,8 @@ let%test "agent_llm_a-sonnet-4-6 has 1M context" =
   m.context_window = 1_000_000
 ;;
 
-let%test "gpt-4.1 is cloud" =
-  let m = for_model_id "gpt-4.1" in
+let%test "model-d-4.1 is cloud" =
+  let m = for_model_id "model-d-4.1" in
   (not m.is_local) && m.context_window = 1_000_000
 ;;
 
@@ -132,8 +132,8 @@ let%test "provider_g-v4-flash can be marked local explicitly" =
   m.is_local && m.context_window = 1_000_000
 ;;
 
-let%test "llama-4-maverick can be marked local explicitly" =
-  let m = for_model_id ~locality:`Local "llama-4-maverick" in
+let%test "model-n-4-maverick can be marked local explicitly" =
+  let m = for_model_id ~locality:`Local "model-n-4-maverick" in
   m.is_local
 ;;
 

--- a/lib/llm_provider/pricing.ml
+++ b/lib/llm_provider/pricing.ml
@@ -102,23 +102,23 @@ let static_pricing_opt_normalized normalized =
       (* Provider_d API text-token pricing, confirmed from official model docs
        2026-04-25. GPT-5.3-Agent_code-Spark is intentionally not covered here:
        its Agent_code rate card labels it research preview with non-final rates. *)
-    else if string_contains ~needle:"gpt-5.3-agent_code-spark" normalized
+    else if string_contains ~needle:"model-d-5.3-agent_code-spark" normalized
     then None
-    else if string_contains ~needle:"gpt-5.5" normalized
+    else if string_contains ~needle:"model-d-5.5" normalized
     then Some ((5.0, 30.0), provider_d_cached_input)
-    else if string_contains ~needle:"gpt-5.4-mini" normalized
+    else if string_contains ~needle:"model-d-5.4-mini" normalized
     then Some ((0.75, 4.5), provider_d_cached_input)
-    else if string_contains ~needle:"gpt-5.4" normalized
+    else if string_contains ~needle:"model-d-5.4" normalized
     then Some ((2.5, 15.0), provider_d_cached_input)
-    else if string_contains ~needle:"gpt-5.3-agent_code" normalized
+    else if string_contains ~needle:"model-d-5.3-agent_code" normalized
     then Some ((1.75, 14.0), provider_d_cached_input)
-    else if string_contains ~needle:"gpt-5.2" normalized
+    else if string_contains ~needle:"model-d-5.2" normalized
     then Some ((1.75, 14.0), provider_d_cached_input)
     else if string_contains ~needle:"model-d-mini" normalized
     then Some ((0.15, 0.6), no_cache)
     else if string_contains ~needle:"model-d" normalized
     then Some ((2.5, 10.0), no_cache)
-    else if string_contains ~needle:"gpt-4.1" normalized
+    else if string_contains ~needle:"model-d-4.1" normalized
     then Some ((2.0, 8.0), no_cache)
     else if string_contains ~needle:"o3-mini" normalized
     then
@@ -198,7 +198,7 @@ let static_pricing_opt_normalized normalized =
     else if
       string_contains ~needle:"ollama" normalized
       || string_contains ~needle:"provider_h" normalized
-      || string_contains ~needle:"llama" normalized
+      || string_contains ~needle:"provider_n" normalized
     then Some ((0.0, 0.0), no_cache)
     else None
   in
@@ -536,45 +536,45 @@ let%test "pricing model-d-mini" =
   && close_enough p.cache_read_multiplier 1.0
 ;;
 
-let%test "pricing gpt-5.5" =
-  let p = pricing_for_model "gpt-5.5" in
+let%test "pricing model-d-5.5" =
+  let p = pricing_for_model "model-d-5.5" in
   close_enough p.input_per_million 5.0
   && close_enough p.output_per_million 30.0
   && close_enough p.cache_write_multiplier 1.0
   && close_enough p.cache_read_multiplier 0.1
 ;;
 
-let%test "pricing gpt-5.4-mini" =
-  let p = pricing_for_model "gpt-5.4-mini" in
+let%test "pricing model-d-5.4-mini" =
+  let p = pricing_for_model "model-d-5.4-mini" in
   close_enough p.input_per_million 0.75
   && close_enough p.output_per_million 4.5
   && close_enough p.cache_write_multiplier 1.0
   && close_enough p.cache_read_multiplier 0.1
 ;;
 
-let%test "pricing gpt-5.4" =
-  let p = pricing_for_model "gpt-5.4" in
+let%test "pricing model-d-5.4" =
+  let p = pricing_for_model "model-d-5.4" in
   close_enough p.input_per_million 2.5
   && close_enough p.output_per_million 15.0
   && close_enough p.cache_read_multiplier 0.1
 ;;
 
-let%test "pricing gpt-5.3-agent_code" =
-  let p = pricing_for_model "gpt-5.3-agent_code" in
+let%test "pricing model-d-5.3-agent_code" =
+  let p = pricing_for_model "model-d-5.3-agent_code" in
   close_enough p.input_per_million 1.75
   && close_enough p.output_per_million 14.0
   && close_enough p.cache_read_multiplier 0.1
 ;;
 
-let%test "pricing gpt-5.2" =
-  let p = pricing_for_model "gpt-5.2" in
+let%test "pricing model-d-5.2" =
+  let p = pricing_for_model "model-d-5.2" in
   close_enough p.input_per_million 1.75
   && close_enough p.output_per_million 14.0
   && close_enough p.cache_read_multiplier 0.1
 ;;
 
-let%test "pricing gpt-5.3-agent_code-spark remains unknown" =
-  pricing_for_model_opt "gpt-5.3-agent_code-spark" = None
+let%test "pricing model-d-5.3-agent_code-spark remains unknown" =
+  pricing_for_model_opt "model-d-5.3-agent_code-spark" = None
 ;;
 
 let%test "pricing model-d (not mini)" =
@@ -582,8 +582,8 @@ let%test "pricing model-d (not mini)" =
   close_enough p.input_per_million 2.5 && close_enough p.output_per_million 10.0
 ;;
 
-let%test "pricing gpt-4.1" =
-  let p = pricing_for_model "gpt-4.1-turbo" in
+let%test "pricing model-d-4.1" =
+  let p = pricing_for_model "model-d-4.1-turbo" in
   close_enough p.input_per_million 2.0 && close_enough p.output_per_million 8.0
 ;;
 
@@ -718,7 +718,7 @@ let%test "pricing_for_model_opt returns Some for provider_f-3-flash-preview" =
 (* --- pricing_for_model: local/free models --- *)
 
 let%test "pricing ollama is free" =
-  let p = pricing_for_model "ollama/llama3" in
+  let p = pricing_for_model "ollama/model-n-3" in
   close_enough p.input_per_million 0.0 && close_enough p.output_per_million 0.0
 ;;
 
@@ -728,7 +728,7 @@ let%test "pricing provider_h is free" =
 ;;
 
 let%test "pricing llama is free" =
-  let p = pricing_for_model "llama-3.1-70b" in
+  let p = pricing_for_model "model-n-3.1-70b" in
   close_enough p.input_per_million 0.0
 ;;
 
@@ -746,7 +746,7 @@ let%test "pricing_for_model_opt: known cloud model returns Some" =
 ;;
 
 let%test "pricing_for_model_opt: known local model returns Some with zero pricing" =
-  match pricing_for_model_opt "ollama/llama3" with
+  match pricing_for_model_opt "ollama/model-n-3" with
   | Some p -> close_enough p.input_per_million 0.0
   | None -> false
 ;;

--- a/lib/llm_provider/provider_kind.ml
+++ b/lib/llm_provider/provider_kind.ml
@@ -78,7 +78,7 @@ let of_string raw =
   | "provider_a" | "agent_llm_a" -> Some Provider_a
   | "provider_c" -> Some Provider_c
   | "provider_d_compat" | "provider_d" -> Some Provider_d_compat
-  | "ollama" | "llama" | "ollama_cloud" -> Some Ollama
+  | "ollama" | "provider_n" | "ollama_cloud" -> Some Ollama
   | "provider_f" -> Some Provider_f
   | "provider_k" -> Some Provider_k
   | "provider_h" -> Some Provider_h

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -382,7 +382,7 @@ let default () =
       }
   in
   reg
-    "llama"
+    "provider_n"
     llama_defaults
     ~max_context:128_000
     Capabilities.provider_d_chat_extended_capabilities;
@@ -414,7 +414,7 @@ let default () =
     ; is_available = (fun () -> has_any_api_key [ "PROVIDER_C_API_KEY" ])
     };
   reg
-    "openrouter"
+    "provider_o_router"
     openrouter_defaults
     ~max_context:128_000
     Capabilities.provider_d_chat_extended_capabilities;
@@ -570,7 +570,7 @@ let provider_name_of_config (config : Provider_config.t) =
   | Provider_h -> "provider_h"
   | Provider_d_compat ->
     if Provider_config.is_local config
-    then "llama"
+    then "provider_n"
     else (
       let request_path = String.trim config.request_path in
       let base_url = normalize_url config.base_url in

--- a/lib/llm_provider/provider_registry.mli
+++ b/lib/llm_provider/provider_registry.mli
@@ -70,7 +70,7 @@ val default : unit -> t
     Unlike [Provider_config.string_of_provider_kind], this keeps
     registry-level distinctions that share a wire kind but differ by
     endpoint (for example [provider_k] vs [provider_k-coding], or [provider_d] vs
-    [openrouter]). Falls back to a stable kind-derived label when the
+    [provider_o_router]). Falls back to a stable kind-derived label when the
     config does not match a known registry entry exactly. *)
 val provider_name_of_config : Provider_config.t -> string
 

--- a/lib/llm_provider/transport_cli_tool_a.ml
+++ b/lib/llm_provider/transport_cli_tool_a.ml
@@ -872,7 +872,7 @@ let%test "build_args with requested model" =
   let args, _ =
     build_args
       ~config:default_config
-      ~req_config:(agent_code_req ~model_id:"gpt-5.4" ())
+      ~req_config:(agent_code_req ~model_id:"model-d-5.4" ())
       ~prompt:"hi"
       ()
   in
@@ -884,13 +884,13 @@ let%test "build_args with requested model" =
     ; "-c"
     ; "mcp_servers={}"
     ; "--model"
-    ; "gpt-5.4"
+    ; "model-d-5.4"
     ; "hi"
     ]
 ;;
 
 let%test "build_args with config default model for auto request" =
-  let config = { default_config with model = Some "gpt-5.2-agent_code" } in
+  let config = { default_config with model = Some "model-d-5.2-agent_code" } in
   let args, _ = build_args ~config ~req_config:(agent_code_req ()) ~prompt:"hi" () in
   args
   = [ "agent_code"
@@ -900,7 +900,7 @@ let%test "build_args with config default model for auto request" =
     ; "-c"
     ; "mcp_servers={}"
     ; "--model"
-    ; "gpt-5.2-agent_code"
+    ; "model-d-5.2-agent_code"
     ; "hi"
     ]
 ;;
@@ -1091,8 +1091,8 @@ let%test "parse_jsonl_result preserves requested model_id" =
     ; {|{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"ok"}}|}
     ]
   in
-  match parse_jsonl_result ~model_id:"gpt-5.4" ~prompt:"" lines with
-  | Ok resp -> resp.model = "gpt-5.4"
+  match parse_jsonl_result ~model_id:"model-d-5.4" ~prompt:"" lines with
+  | Ok resp -> resp.model = "model-d-5.4"
   | Error _ -> false
 ;;
 

--- a/lib/llm_provider/transport_provider_d_compat.mli
+++ b/lib/llm_provider/transport_provider_d_compat.mli
@@ -1,7 +1,7 @@
 (** Provider_d Chat Completions HTTP transport.
 
     Implements {!Llm_transport.t} for any Provider_d-compatible API endpoint:
-    llama-server, Provider_k, OpenRouter, vLLM, Ollama, LiteLLM, etc.
+    llama-server, Provider_k, Provider_o_router, vLLM, Ollama, LiteLLM, etc.
 
     Thin wrapper around the HTTP completion pipeline in {!Complete}.
     Callers get a simplified config instead of constructing
@@ -22,7 +22,7 @@ type config =
   ; max_tokens : int (** Maximum tokens in the response. Default [4096]. *)
   ; extra_headers : (string * string) list
     (** Additional HTTP headers (e.g. [("HTTP-Referer", "...")]
-        for OpenRouter). Default empty. *)
+        for Provider_o_router). Default empty. *)
   }
 
 (** Default config for local llama-server on port 8085. *)

--- a/lib/llm_provider/zai_catalog.ml
+++ b/lib/llm_provider/zai_catalog.ml
@@ -175,7 +175,7 @@ let throttle_key_for_chat ~base_url ~model_id =
 let%test "is_glm_model_id accepts provider_k prefixes only" =
   is_glm_model_id "provider_k-5"
   && is_glm_model_id "provider_k"
-  && not (is_glm_model_id "gpt-5")
+  && not (is_glm_model_id "model-d-5")
 ;;
 
 let%test "base_url classifiers distinguish general coding and provider_a" =

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -107,7 +107,7 @@ let task_of_model_id model_id =
   else if
     has "imagegen"
     || has "image-gen"
-    || has "gpt-image"
+    || has "model-d-image"
     || has "cogview"
     || has "provider_k-image"
     || has "seedream"
@@ -474,7 +474,7 @@ let provider_a_opus () =
   }
 ;;
 
-let openrouter ?(model_id = "provider_a/agent_llm_a-sonnet-4-6") () =
+let provider_o_router ?(model_id = "provider_a/agent_llm_a-sonnet-4-6") () =
   { provider =
       OpenAICompat
         { base_url = "https://openrouter.ai/api/v1"
@@ -529,23 +529,23 @@ let pricing_for_model_opt model_id =
       (* Provider_d API text-token pricing, confirmed from official model docs
        2026-04-25. GPT-5.3-Agent_code-Spark is intentionally not covered here:
        its Agent_code rate card labels it research preview with non-final rates. *)
-    else if Util.string_contains ~needle:"gpt-5.3-agent_code-spark" normalized
+    else if Util.string_contains ~needle:"model-d-5.3-agent_code-spark" normalized
     then None
-    else if Util.string_contains ~needle:"gpt-5.5" normalized
+    else if Util.string_contains ~needle:"model-d-5.5" normalized
     then Some ((5.0, 30.0), provider_d_cached_input)
-    else if Util.string_contains ~needle:"gpt-5.4-mini" normalized
+    else if Util.string_contains ~needle:"model-d-5.4-mini" normalized
     then Some ((0.75, 4.5), provider_d_cached_input)
-    else if Util.string_contains ~needle:"gpt-5.4" normalized
+    else if Util.string_contains ~needle:"model-d-5.4" normalized
     then Some ((2.5, 15.0), provider_d_cached_input)
-    else if Util.string_contains ~needle:"gpt-5.3-agent_code" normalized
+    else if Util.string_contains ~needle:"model-d-5.3-agent_code" normalized
     then Some ((1.75, 14.0), provider_d_cached_input)
-    else if Util.string_contains ~needle:"gpt-5.2" normalized
+    else if Util.string_contains ~needle:"model-d-5.2" normalized
     then Some ((1.75, 14.0), provider_d_cached_input)
     else if Util.string_contains ~needle:"model-d-mini" normalized
     then Some ((0.15, 0.6), no_cache)
     else if Util.string_contains ~needle:"model-d" normalized
     then Some ((2.5, 10.0), no_cache)
-    else if Util.string_contains ~needle:"gpt-4.1" normalized
+    else if Util.string_contains ~needle:"model-d-4.1" normalized
     then Some ((2.0, 8.0), no_cache)
     else if Util.string_contains ~needle:"o3-mini" normalized
     then Some ((1.1, 4.4), no_cache)

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -152,7 +152,7 @@ val local_llm : unit -> config
 val provider_a_sonnet : unit -> config
 val provider_a_haiku : unit -> config
 val provider_a_opus : unit -> config
-val openrouter : ?model_id:string -> unit -> config
+val provider_o_router : ?model_id:string -> unit -> config
 
 (** {2 Pricing: per-model cost estimation} *)
 

--- a/lib/provider_bridge.ml
+++ b/lib/provider_bridge.ml
@@ -55,7 +55,7 @@ let resolve_glm_coding_model_id model_id =
     for "auto"; cloud providers fall back to environment-variable defaults.
 
     Parse, don't validate: callers hand in the concrete variant so dead
-    branches ([provider_d], [openrouter] in the pre-typed version) cannot exist. *)
+    branches ([provider_d], [provider_o_router] in the pre-typed version) cannot exist. *)
 let resolve_auto_model_id
       ~base_url
       (kind : Llm_provider.Provider_config.provider_kind)

--- a/test/test_agent_config_deep.ml
+++ b/test/test_agent_config_deep.ml
@@ -44,7 +44,7 @@ let test_of_json_full () =
     Yojson.Safe.from_string
       {|{
     "name": "my-agent",
-    "model": "gpt-4",
+    "model": "model-d-4",
     "system_prompt": "Be concise.",
     "max_tokens": 2048,
     "max_turns": 5,
@@ -58,7 +58,7 @@ let test_of_json_full () =
   | Error e -> Alcotest.fail ("full: " ^ Error.to_string e)
   | Ok cfg ->
     Alcotest.(check string) "name" "my-agent" cfg.name;
-    Alcotest.(check string) "model" "gpt-4" cfg.model;
+    Alcotest.(check string) "model" "model-d-4" cfg.model;
     Alcotest.(check (option string))
       "system_prompt"
       (Some "Be concise.")
@@ -332,7 +332,7 @@ let test_resolve_provider_a () =
 ;;
 
 let test_resolve_provider_d () =
-  let cfg = Agent_config.resolve_provider ~model_id:"gpt-4" "provider_d" None in
+  let cfg = Agent_config.resolve_provider ~model_id:"model-d-4" "provider_d" None in
   match cfg.provider with
   | Provider.OpenAICompat { base_url; _ } ->
     Alcotest.(check string) "base_url" "https://api.provider_d.com" base_url;
@@ -343,7 +343,7 @@ let test_resolve_provider_d () =
 let test_resolve_provider_d_custom_url () =
   let cfg =
     Agent_config.resolve_provider
-      ~model_id:"gpt-4"
+      ~model_id:"model-d-4"
       "provider_d"
       (Some "http://custom:4000")
   in
@@ -440,7 +440,7 @@ let test_resolve_provider_d_compat_ssot () =
      Provider_kind.to_string Provider_d_compat. Before the parser dispatch,
      it fell through to the registry fallback and ended up with
      api_key_env = "provider_d_compat" — a meaningless value. *)
-  let cfg = Agent_config.resolve_provider ~model_id:"gpt-4" "provider_d_compat" None in
+  let cfg = Agent_config.resolve_provider ~model_id:"model-d-4" "provider_d_compat" None in
   match cfg.provider with
   | Provider.OpenAICompat { base_url; _ } ->
     Alcotest.(check string)

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -366,7 +366,7 @@ let test_build_provider_d_body_with_provider_m_sampling () =
 
 let test_build_provider_d_body_omits_provider_m_only_fields_for_generic_compat () =
   let provider_config =
-    Provider.openrouter ~model_id:"provider_a/agent_llm_a-sonnet-4-6" ()
+    Provider.provider_o_router ~model_id:"provider_a/agent_llm_a-sonnet-4-6" ()
   in
   let state =
     { Types.config =

--- a/test/test_api_dispatch.ml
+++ b/test/test_api_dispatch.ml
@@ -195,7 +195,7 @@ let test_pricing_known_models () =
   check (float 0.01) "mini input" 0.15 p_mini.input_per_million;
   let p_local = Provider.pricing_for_model "provider_h-3.5-35b" in
   check (float 0.01) "local free" 0.0 p_local.input_per_million;
-  let p_llama = Provider.pricing_for_model "llama-3.1-70b" in
+  let p_llama = Provider.pricing_for_model "model-n-3.1-70b" in
   check (float 0.01) "llama free" 0.0 p_llama.input_per_million
 ;;
 

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -123,13 +123,13 @@ let test_lookup_agent_llm_a_sonnet () =
 ;;
 
 let test_lookup_gpt5 () =
-  match Capabilities.for_model_id "gpt-5.4" with
+  match Capabilities.for_model_id "model-d-5.4" with
   | Some c ->
     check (option int) "context 1.05M" (Some 1_050_000) c.max_context_tokens;
     check (option int) "output 128K" (Some 128_000) c.max_output_tokens;
     check bool "structured output" true c.supports_structured_output;
     check bool "computer use" true c.supports_computer_use
-  | None -> fail "should match gpt-5"
+  | None -> fail "should match model-d-5"
 ;;
 
 let test_lookup_provider_f () =
@@ -157,25 +157,25 @@ let pp_static_model_route ppf = function
   | Capabilities.Agent_llm_a_opus_4 -> Format.fprintf ppf "Agent_llm_a_opus_4"
   | Capabilities.Agent_llm_a_sonnet_4 -> Format.fprintf ppf "Agent_llm_a_sonnet_4"
   | Capabilities.Agent_llm_a_haiku_4 -> Format.fprintf ppf "Agent_llm_a_haiku_4"
-  | Capabilities.Gpt_5 -> Format.fprintf ppf "Gpt_5"
-  | Capabilities.Gpt_4_1 -> Format.fprintf ppf "Gpt_4_1"
-  | Capabilities.Gpt_4o -> Format.fprintf ppf "Gpt_4o"
+  | Capabilities.Provider_d_5 -> Format.fprintf ppf "Provider_d_5"
+  | Capabilities.Provider_d_4_1 -> Format.fprintf ppf "Provider_d_4_1"
+  | Capabilities.Provider_d_4o -> Format.fprintf ppf "Provider_d_4o"
   | Capabilities.Provider_f family ->
     Format.fprintf ppf "Provider_f(%a)" pp_provider_f_family family
   | Capabilities.Provider_c_for_coding -> Format.fprintf ppf "Provider_c_for_coding"
   | Capabilities.Provider_c_k2 -> Format.fprintf ppf "Provider_c_k2"
   | Capabilities.Provider_h_3 -> Format.fprintf ppf "Provider_h_3"
-  | Capabilities.Llama_4 -> Format.fprintf ppf "Llama_4"
+  | Capabilities.Provider_n_4 -> Format.fprintf ppf "Provider_n_4"
   | Capabilities.Provider_g_v4_flash -> Format.fprintf ppf "Provider_g_v4_flash"
   | Capabilities.Provider_g_v4_pro -> Format.fprintf ppf "Provider_g_v4_pro"
   | Capabilities.Provider_j_large -> Format.fprintf ppf "Provider_j_large"
   | Capabilities.Provider_j_small -> Format.fprintf ppf "Provider_j_small"
-  | Capabilities.Command -> Format.fprintf ppf "Command"
-  | Capabilities.Grok -> Format.fprintf ppf "Grok"
+  | Capabilities.Provider_m_command -> Format.fprintf ppf "Provider_m_command"
+  | Capabilities.Provider_e_grok -> Format.fprintf ppf "Provider_e_grok"
   | Capabilities.Provider_l { has_vision } ->
     Format.fprintf ppf "Provider_l(has_vision=%b)" has_vision
-  | Capabilities.Gemma_4 { has_large_audio } ->
-    Format.fprintf ppf "Gemma_4(has_large_audio=%b)" has_large_audio
+  | Capabilities.Provider_f_gemma_4 { has_large_audio } ->
+    Format.fprintf ppf "Provider_f_gemma_4(has_large_audio=%b)" has_large_audio
   | Capabilities.Glm_flash_air -> Format.fprintf ppf "Glm_flash_air"
   | Capabilities.Glm_5_turbo -> Format.fprintf ppf "Glm_5_turbo"
   | Capabilities.Glm_5v_turbo -> Format.fprintf ppf "Glm_5v_turbo"
@@ -853,7 +853,7 @@ let () =
     ; ( "model_lookup"
       , [ test_case "agent_llm_a opus" `Quick test_lookup_agent_llm_a_opus
         ; test_case "agent_llm_a sonnet" `Quick test_lookup_agent_llm_a_sonnet
-        ; test_case "gpt-5" `Quick test_lookup_gpt5
+        ; test_case "model-d-5" `Quick test_lookup_gpt5
         ; test_case "provider_f" `Quick test_lookup_provider_f
         ; test_case "provider_f_family Provider_f_3_1" `Quick test_provider_f_family_3_1
         ; test_case "provider_f_family Provider_f_3" `Quick test_provider_f_family_3

--- a/test/test_complete_cascade.ml
+++ b/test/test_complete_cascade.ml
@@ -428,12 +428,12 @@ let test_default_config () =
 let test_result_success_variant () =
   let result =
     Complete_cascade.Success
-      { response = dummy_response; step_index = 0; model_id = "gpt-4" }
+      { response = dummy_response; step_index = 0; model_id = "model-d-4" }
   in
   match result with
   | Complete_cascade.Success { step_index; model_id; _ } ->
     check int "step_index" 0 step_index;
-    check string "model_id" "gpt-4" model_id
+    check string "model_id" "model-d-4" model_id
   | _ -> fail "expected Success"
 ;;
 

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -19,13 +19,13 @@ let provider_a_response ?(id = "msg-1") ?(model = "mock") ?(stop_reason = "end_t
 
 let provider_d_response text =
   Printf.sprintf
-    {|{"id":"chatcmpl-1","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}|}
+    {|{"id":"chatcmpl-1","object":"chat.completion","model":"model-d-4","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}|}
     text
 ;;
 
 let provider_d_mlx_vlm_response text =
   Printf.sprintf
-    {|{"id":"chatcmpl-mlx-1","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"input_tokens":11,"output_tokens":5,"prompt_tps":21.55,"generation_tps":81.56},"peak_memory":52.66}|}
+    {|{"id":"chatcmpl-mlx-1","object":"chat.completion","model":"model-d-4","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"input_tokens":11,"output_tokens":5,"prompt_tps":21.55,"generation_tps":81.56},"peak_memory":52.66}|}
     text
 ;;
 
@@ -116,7 +116,7 @@ let make_config ?(kind = Provider_config.Provider_a) base_url =
 let make_provider_d_config base_url =
   Provider_config.make
     ~kind:Provider_config.Provider_d_compat
-    ~model_id:"gpt-4"
+    ~model_id:"model-d-4"
     ~base_url
     ~request_path:"/v1/chat/completions"
     ~temperature:0.0
@@ -334,7 +334,7 @@ let test_complete_provider_d_mlx_vlm_telemetry () =
            "latency patched"
            true
            (Option.value ~default:0 t.request_latency_ms > 0);
-         check (option string) "canonical model id" (Some "gpt-4") t.canonical_model_id;
+         check (option string) "canonical model id" (Some "model-d-4") t.canonical_model_id;
          check (option (float 0.001)) "peak memory" (Some 52.66) t.peak_memory_gb;
          (match t.timings with
           | Some timings ->
@@ -585,7 +585,7 @@ let test_complete_transport_http_metrics_ok () =
     match Complete.complete ~sw ~net:env#net ~transport ~config ~messages ~metrics () with
     | Ok _ ->
       (match !status_calls with
-       | [ ("provider_d", "gpt-4", 200) ] -> Eio.Switch.fail sw Exit
+       | [ ("provider_d", "model-d-4", 200) ] -> Eio.Switch.fail sw Exit
        | [ (_, _, code) ] -> fail (Printf.sprintf "expected 200, got %d" code)
        | _ -> fail "expected exactly one transport status call")
     | Error _ -> fail "expected Ok"
@@ -616,7 +616,7 @@ let test_complete_transport_http_metrics_error () =
     | Error (Http_client.HttpError { code; _ }) ->
       check int "status 429" 429 code;
       (match !status_calls with
-       | [ ("provider_d", "gpt-4", 429) ] -> Eio.Switch.fail sw Exit
+       | [ ("provider_d", "model-d-4", 429) ] -> Eio.Switch.fail sw Exit
        | [ (_, _, seen) ] -> fail (Printf.sprintf "expected 429, got %d" seen)
        | _ -> fail "expected exactly one transport status call")
     | Error _ -> fail "expected HttpError"

--- a/test/test_context_intent.ml
+++ b/test/test_context_intent.ml
@@ -145,7 +145,7 @@ let test_classify_hybrid_requires_explicit_fallback () =
           ; path = "/v1/chat/completions"
           ; static_token = None
           }
-    ; model_id = "gpt-4.1"
+    ; model_id = "model-d-4.1"
     ; api_key_env = ""
     }
   in

--- a/test/test_custom_provider.ml
+++ b/test/test_custom_provider.ml
@@ -88,11 +88,11 @@ let test_custom_provider_config_with_overrides () =
   let cfg =
     Provider.custom_provider
       ~name:"my-tgi"
-      ~model_id:"llama-70b"
+      ~model_id:"model-n-70b"
       ~api_key_env:"TGI_KEY"
       ()
   in
-  Alcotest.(check string) "model_id" "llama-70b" cfg.model_id;
+  Alcotest.(check string) "model_id" "model-n-70b" cfg.model_id;
   Alcotest.(check string) "api_key_env" "TGI_KEY" cfg.api_key_env
 ;;
 

--- a/test/test_deep_coverage.ml
+++ b/test/test_deep_coverage.ml
@@ -1157,12 +1157,12 @@ let test_transport_options_partial () =
   let opts : Transport.options =
     { Transport.default_options with
       provider = Some "provider_d"
-    ; model = Some "gpt-4"
+    ; model = Some "model-d-4"
     ; include_partial_messages = true
     }
   in
   check (option string) "provider" (Some "provider_d") opts.provider;
-  check (option string) "model" (Some "gpt-4") opts.model;
+  check (option string) "model" (Some "model-d-4") opts.model;
   check bool "partial" true opts.include_partial_messages;
   check (option string) "runtime_path still None" None opts.runtime_path;
   check (list string) "setting_sources still empty" [] opts.setting_sources

--- a/test/test_discovery.ml
+++ b/test/test_discovery.ml
@@ -39,7 +39,7 @@ let test_parse_models_json () =
       {|{
     "data": [
       {"id": "provider_h-3.5-35b", "owned_by": "llama-server"},
-      {"id": "llama-3.1-8b", "owned_by": "llama-server"}
+      {"id": "model-n-3.1-8b", "owned_by": "llama-server"}
     ]
   }|}
   in

--- a/test/test_error.ml
+++ b/test/test_error.ml
@@ -154,9 +154,9 @@ let test_serialization_json_parse () =
 
 let test_serialization_unknown_variant () =
   let err =
-    Error.Serialization (UnknownVariant { type_name = "model"; value = "gpt-99" })
+    Error.Serialization (UnknownVariant { type_name = "model"; value = "model-d-99" })
   in
-  check string "unknown variant" "Unknown model variant: gpt-99" (Error.to_string err)
+  check string "unknown variant" "Unknown model variant: model-d-99" (Error.to_string err)
 ;;
 
 let test_io_file_op () =

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -4,12 +4,12 @@ open Agent_sdk
 open Llm_provider
 
 let test_inject_stream_param_basic () =
-  let body = {|{"model":"gpt-4","messages":[]}|} in
+  let body = {|{"model":"model-d-4","messages":[]}|} in
   let result = Http_client.inject_stream_param body in
   let json = Yojson.Safe.from_string result in
   let open Yojson.Safe.Util in
   Alcotest.(check bool) "stream present" true (json |> member "stream" |> to_bool);
-  Alcotest.(check string) "model preserved" "gpt-4" (json |> member "model" |> to_string)
+  Alcotest.(check string) "model preserved" "model-d-4" (json |> member "model" |> to_string)
 ;;
 
 let test_inject_stream_param_existing_stream () =

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -1636,18 +1636,18 @@ let test_for_model_id_agent_llm_a_haiku_4 () =
 ;;
 
 let test_for_model_id_gpt5 () =
-  match Capabilities.for_model_id "gpt-5-latest" with
+  match Capabilities.for_model_id "model-d-5-latest" with
   | Some c ->
     Alcotest.(check bool) "computer_use" true c.supports_computer_use;
     Alcotest.(check (option int)) "1050K context" (Some 1_050_000) c.max_context_tokens
-  | None -> Alcotest.fail "expected Some for gpt-5"
+  | None -> Alcotest.fail "expected Some for model-d-5"
 ;;
 
 let test_for_model_id_gpt41 () =
-  match Capabilities.for_model_id "gpt-4.1-mini" with
+  match Capabilities.for_model_id "model-d-4.1-mini" with
   | Some c ->
     Alcotest.(check (option int)) "1M context" (Some 1_000_000) c.max_context_tokens
-  | None -> Alcotest.fail "expected Some for gpt-4.1"
+  | None -> Alcotest.fail "expected Some for model-d-4.1"
 ;;
 
 let test_for_model_id_gpt4o () =
@@ -1680,11 +1680,11 @@ let test_for_model_id_qwen3 () =
 ;;
 
 let test_for_model_id_llama4 () =
-  match Capabilities.for_model_id "llama-4-scout" with
+  match Capabilities.for_model_id "model-n-4-scout" with
   | Some c ->
     Alcotest.(check (option int)) "1M context" (Some 1_000_000) c.max_context_tokens;
     Alcotest.(check bool) "multimodal" true c.supports_multimodal_inputs
-  | None -> Alcotest.fail "expected Some for llama-4"
+  | None -> Alcotest.fail "expected Some for model-n-4"
 ;;
 
 let test_for_model_id_llama4_alt () =
@@ -2016,13 +2016,13 @@ let () =
             "agent_llm_a-haiku-4"
             `Quick
             test_for_model_id_agent_llm_a_haiku_4
-        ; Alcotest.test_case "gpt-5" `Quick test_for_model_id_gpt5
-        ; Alcotest.test_case "gpt-4.1" `Quick test_for_model_id_gpt41
+        ; Alcotest.test_case "model-d-5" `Quick test_for_model_id_gpt5
+        ; Alcotest.test_case "model-d-4.1" `Quick test_for_model_id_gpt41
         ; Alcotest.test_case "model-d" `Quick test_for_model_id_gpt4o
         ; Alcotest.test_case "provider_f legacy" `Quick test_for_model_id_provider_f25
         ; Alcotest.test_case "provider_f-3" `Quick test_for_model_id_gemini3
         ; Alcotest.test_case "provider_h-3" `Quick test_for_model_id_qwen3
-        ; Alcotest.test_case "llama-4" `Quick test_for_model_id_llama4
+        ; Alcotest.test_case "model-n-4" `Quick test_for_model_id_llama4
         ; Alcotest.test_case "llama4" `Quick test_for_model_id_llama4_alt
         ; Alcotest.test_case
             "provider_g-v4-flash"
@@ -2035,7 +2035,7 @@ let () =
         ; Alcotest.test_case "provider_j-large" `Quick test_for_model_id_provider_j_large
         ; Alcotest.test_case "provider_j-small" `Quick test_for_model_id_provider_j_small
         ; Alcotest.test_case "command" `Quick test_for_model_id_command
-        ; Alcotest.test_case "grok" `Quick test_for_model_id_grok
+        ; Alcotest.test_case "provider_e_grok" `Quick test_for_model_id_grok
         ; Alcotest.test_case "provider_k" `Quick test_for_model_id_glm
         ; Alcotest.test_case "unknown" `Quick test_for_model_id_unknown
         ; Alcotest.test_case "case insensitive" `Quick test_for_model_id_case_insensitive

--- a/test/test_metrics.ml
+++ b/test/test_metrics.ml
@@ -56,11 +56,11 @@ let test_histogram_with_labels () =
   in
   Metrics.observe
     h
-    ~labels:[ "gen_ai.system", "provider_d"; "gen_ai.request.model", "gpt-5" ]
+    ~labels:[ "gen_ai.system", "provider_d"; "gen_ai.request.model", "model-d-5" ]
     0.3;
   Metrics.observe
     h
-    ~labels:[ "gen_ai.system", "provider_d"; "gen_ai.request.model", "gpt-5" ]
+    ~labels:[ "gen_ai.system", "provider_d"; "gen_ai.request.model", "model-d-5" ]
     0.9;
   Metrics.observe
     h
@@ -72,7 +72,7 @@ let test_histogram_with_labels () =
     "provider_d count"
     2
     (Metrics.histogram_count
-       ~labels:[ "gen_ai.request.model", "gpt-5"; "gen_ai.system", "provider_d" ]
+       ~labels:[ "gen_ai.request.model", "model-d-5"; "gen_ai.system", "provider_d" ]
        h);
   check
     int
@@ -222,28 +222,28 @@ let test_register_same_name_same_kind_is_idempotent () =
 let test_prometheus_text_histogram_exports_labeled_series () =
   let m = Metrics.create () in
   let h = Metrics.histogram m ~name:"gen_ai.client.ttfrc" ~buckets:[ 1.0; 2.0 ] in
-  let labels = [ "gen_ai.system", "provider_d"; "gen_ai.request.model", "gpt-5" ] in
+  let labels = [ "gen_ai.system", "provider_d"; "gen_ai.request.model", "model-d-5" ] in
   Metrics.observe h ~labels 0.5;
   Metrics.observe h ~labels 3.0;
   let text = Metrics.to_prometheus_text m in
   check_line
     "labeled bucket"
-    "gen_ai_client_ttfrc_bucket{gen_ai_request_model=\"gpt-5\",gen_ai_system=\"provider_d\",le=\"1\"} \
+    "gen_ai_client_ttfrc_bucket{gen_ai_request_model=\"model-d-5\",gen_ai_system=\"provider_d\",le=\"1\"} \
      1"
     text;
   check_line
     "labeled +Inf bucket"
-    "gen_ai_client_ttfrc_bucket{gen_ai_request_model=\"gpt-5\",gen_ai_system=\"provider_d\",le=\"+Inf\"} \
+    "gen_ai_client_ttfrc_bucket{gen_ai_request_model=\"model-d-5\",gen_ai_system=\"provider_d\",le=\"+Inf\"} \
      2"
     text;
   check_line
     "labeled sum"
-    "gen_ai_client_ttfrc_sum{gen_ai_request_model=\"gpt-5\",gen_ai_system=\"provider_d\"} \
+    "gen_ai_client_ttfrc_sum{gen_ai_request_model=\"model-d-5\",gen_ai_system=\"provider_d\"} \
      3.5"
     text;
   check_line
     "labeled count"
-    "gen_ai_client_ttfrc_count{gen_ai_request_model=\"gpt-5\",gen_ai_system=\"provider_d\"} \
+    "gen_ai_client_ttfrc_count{gen_ai_request_model=\"model-d-5\",gen_ai_system=\"provider_d\"} \
      2"
     text
 ;;

--- a/test/test_metrics_aggregating.ml
+++ b/test/test_metrics_aggregating.ml
@@ -28,14 +28,14 @@ let test_aggregating_on_request_start () =
 let test_aggregating_on_retry () =
   let agg = Agg.create () in
   let hooks = Agg.to_hooks agg in
-  hooks.on_retry ~provider:"provider_d" ~model_id:"gpt-4" ~attempt:1;
-  hooks.on_retry ~provider:"provider_d" ~model_id:"gpt-4" ~attempt:2;
+  hooks.on_retry ~provider:"provider_d" ~model_id:"model-d-4" ~attempt:1;
+  hooks.on_retry ~provider:"provider_d" ~model_id:"model-d-4" ~attempt:2;
   let snap = Agg.snapshot agg in
   check int "one entry" 1 (List.length snap);
   let entry = List.hd snap in
   check int "retry_total" 2 entry.M.retry_total;
   check string "provider" "provider_d" entry.M.provider;
-  check string "model_id" "gpt-4" entry.M.model_id
+  check string "model_id" "model-d-4" entry.M.model_id
 ;;
 
 let test_aggregating_on_token_usage () =
@@ -80,11 +80,11 @@ let test_aggregating_on_circuit_state () =
   let hooks = Agg.to_hooks agg in
   hooks.on_circuit_state
     ~provider:"provider_d"
-    ~model_id:"gpt-4"
-    ~provider_key:"gpt-4@https://api.provider_d.com"
+    ~model_id:"model-d-4"
+    ~provider_key:"model-d-4@https://api.provider_d.com"
     ~state:M.Circuit_open;
   (match !observed with
-   | Some ("provider_d", "gpt-4", "gpt-4@https://api.provider_d.com", M.Circuit_open) ->
+   | Some ("provider_d", "model-d-4", "model-d-4@https://api.provider_d.com", M.Circuit_open) ->
      ()
    | Some _ -> fail "unexpected circuit state callback"
    | None -> fail "missing circuit state callback");
@@ -170,7 +170,7 @@ let test_aggregating_key () =
 let test_aggregating_multiple_providers () =
   let agg = Agg.create () in
   let hooks = Agg.to_hooks agg in
-  hooks.on_retry ~provider:"provider_d" ~model_id:"gpt-4" ~attempt:1;
+  hooks.on_retry ~provider:"provider_d" ~model_id:"model-d-4" ~attempt:1;
   hooks.on_token_usage
     ~provider:"provider_a"
     ~model_id:"agent_llm_a"
@@ -184,7 +184,7 @@ let test_aggregating_multiple_providers () =
 let test_provider_snapshot_to_yojson () =
   let snapshot : M.provider_snapshot =
     { provider = "provider_d"
-    ; model_id = "gpt-4.1"
+    ; model_id = "model-d-4.1"
     ; request_total = 3
     ; error_total = 1
     ; retry_total = 2
@@ -290,10 +290,10 @@ let test_provider_snapshots_to_yojson_is_stable () =
 let test_aggregating_save_snapshot_json () =
   let agg = Agg.create () in
   let hooks = Agg.to_hooks agg in
-  hooks.on_retry ~provider:"provider_d" ~model_id:"gpt-4.1" ~attempt:1;
+  hooks.on_retry ~provider:"provider_d" ~model_id:"model-d-4.1" ~attempt:1;
   hooks.on_token_usage
     ~provider:"provider_d"
-    ~model_id:"gpt-4.1"
+    ~model_id:"model-d-4.1"
     ~input_tokens:10
     ~output_tokens:4;
   let dir =

--- a/test/test_modality.ml
+++ b/test/test_modality.ml
@@ -67,13 +67,13 @@ let test_default_capability_is_preserve () =
 ;;
 
 let test_gemma4_capability_is_visual_first () =
-  match Capabilities.for_model_id "gemma-4-31b-it" with
-  | None -> Alcotest.fail "gemma-4-31b-it should have a capability entry"
+  match Capabilities.for_model_id "model-f-gemma-4-31b-it" with
+  | None -> Alcotest.fail "model-f-gemma-4-31b-it should have a capability entry"
   | Some c ->
     (match c.modality_priority with
      | Modality.Visual_first -> ()
      | Modality.Preserve_input_order ->
-       Alcotest.fail "gemma-4-31b-it should be Visual_first per Gemma 4 best practices")
+       Alcotest.fail "model-f-gemma-4-31b-it should be Visual_first per Gemma 4 best practices")
 ;;
 
 let test_non_gemma_inherits_preserve () =
@@ -112,7 +112,7 @@ let () =
             `Quick
             test_default_capability_is_preserve
         ; test_case
-            "gemma-4-31b-it = Visual_first"
+            "model-f-gemma-4-31b-it = Visual_first"
             `Quick
             test_gemma4_capability_is_visual_first
         ; test_case

--- a/test/test_multivendor_events.ml
+++ b/test/test_multivendor_events.ml
@@ -1,7 +1,7 @@
 (** Multi-vendor Event_bus taxonomy invariants.
 
     Every provider OAS supports — Provider_a, Provider_d (+ compatibles),
-    Provider_f, Provider_k, OpenRouter, llama.cpp, Ollama, vLLM, LM Studio, etc. —
+    Provider_f, Provider_k, Provider_o_router, llama.cpp, Ollama, vLLM, LM Studio, etc. —
     produces the same native Event_bus payload variants when running
     through OAS.  This test encodes the taxonomy invariants so any
     refactor that changes the public surface breaks the build here

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -167,7 +167,7 @@ let test_model_spec_local_llm_capabilities () =
 ;;
 
 let test_model_spec_openrouter_capabilities () =
-  let cfg = Provider.openrouter ~model_id:"provider_a/agent_llm_a-sonnet-4-6" () in
+  let cfg = Provider.provider_o_router ~model_id:"provider_a/agent_llm_a-sonnet-4-6" () in
   let spec = Provider.model_spec_of_config cfg in
   let contract = Provider.inference_contract_of_config cfg in
   Alcotest.(check string) "request path" "/chat/completions" spec.request_path;
@@ -398,7 +398,7 @@ let test_pricing_sonnet () =
 ;;
 
 let test_pricing_gpt55 () =
-  let p = Provider.pricing_for_model "gpt-5.5" in
+  let p = Provider.pricing_for_model "model-d-5.5" in
   Alcotest.(check (float 0.001)) "input/M" 5.0 p.input_per_million;
   Alcotest.(check (float 0.001)) "output/M" 30.0 p.output_per_million;
   Alcotest.(check (float 0.001)) "cache_write" 1.0 p.cache_write_multiplier;
@@ -878,7 +878,7 @@ let () =
             `Quick
             test_model_spec_local_llm_capabilities
         ; Alcotest.test_case
-            "openrouter model spec capabilities"
+            "provider_o_router model spec capabilities"
             `Quick
             test_model_spec_openrouter_capabilities
         ; Alcotest.test_case
@@ -924,7 +924,7 @@ let () =
         ] )
     ; ( "pricing"
       , [ Alcotest.test_case "sonnet pricing" `Quick test_pricing_sonnet
-        ; Alcotest.test_case "gpt-5.5 pricing" `Quick test_pricing_gpt55
+        ; Alcotest.test_case "model-d-5.5 pricing" `Quick test_pricing_gpt55
         ; Alcotest.test_case "local free" `Quick test_pricing_local
         ; Alcotest.test_case "unknown model" `Quick test_pricing_unknown
         ; Alcotest.test_case "estimate cost" `Quick test_estimate_cost

--- a/test/test_provider_bridge.ml
+++ b/test/test_provider_bridge.ml
@@ -24,7 +24,7 @@ let test_provider_a_bridge () =
 ;;
 
 let test_provider_d_compat_bridge () =
-  let legacy = Agent_sdk.Provider.openrouter () in
+  let legacy = Agent_sdk.Provider.provider_o_router () in
   match Agent_sdk.Provider_bridge.to_provider_config legacy with
   | Error _ -> Alcotest.(check pass) "missing key = expected in test" () ()
   | Ok cfg -> Alcotest.(check string) "path" "/chat/completions" cfg.request_path

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -160,7 +160,7 @@ let test_provider_d_basic_body () =
   let config =
     PC.make
       ~kind:Provider_d_compat
-      ~model_id:"gpt-4"
+      ~model_id:"model-d-4"
       ~base_url:"https://api.provider_d.com/v1"
       ~max_tokens:2048
       ()
@@ -169,7 +169,7 @@ let test_provider_d_basic_body () =
   let body = BO.build_request ~config ~messages:msgs () in
   let json = Yojson.Safe.from_string body in
   let open Yojson.Safe.Util in
-  Alcotest.(check string) "model" "gpt-4" (json |> member "model" |> to_string);
+  Alcotest.(check string) "model" "model-d-4" (json |> member "model" |> to_string);
   Alcotest.(check int) "max_tokens" 2048 (json |> member "max_tokens" |> to_int);
   let msgs_json = json |> member "messages" |> to_list in
   Alcotest.(check int) "1 message" 1 (List.length msgs_json)
@@ -179,7 +179,7 @@ let test_provider_d_with_system () =
   let config =
     PC.make
       ~kind:Provider_d_compat
-      ~model_id:"gpt-4"
+      ~model_id:"model-d-4"
       ~base_url:""
       ~system_prompt:"Be helpful."
       ()
@@ -198,7 +198,7 @@ let test_provider_d_with_system () =
 ;;
 
 let test_provider_d_with_tools () =
-  let config = PC.make ~kind:Provider_d_compat ~model_id:"gpt-4" ~base_url:"" () in
+  let config = PC.make ~kind:Provider_d_compat ~model_id:"model-d-4" ~base_url:"" () in
   let tool =
     `Assoc
       [ "name", `String "calc"
@@ -869,7 +869,7 @@ let test_annotate_response_cost () =
 let test_annotate_response_cost_gpt55 () =
   let response : api_response =
     { id = "resp-gpt55"
-    ; model = "gpt-5.5"
+    ; model = "model-d-5.5"
     ; stop_reason = EndTurn
     ; content = [ Text "ok" ]
     ; usage =
@@ -885,8 +885,8 @@ let test_annotate_response_cost_gpt55 () =
   in
   match Llm_provider.Pricing.annotate_response_cost response with
   | { usage = Some { cost_usd = Some cost; _ }; _ } ->
-    Alcotest.(check (float 0.001)) "gpt-5.5 cost" 35.0 cost
-  | _ -> Alcotest.fail "expected gpt-5.5 annotated response cost"
+    Alcotest.(check (float 0.001)) "model-d-5.5 cost" 35.0 cost
+  | _ -> Alcotest.fail "expected model-d-5.5 annotated response cost"
 ;;
 
 (* ── Stream accumulator ──────────────────────────────── *)
@@ -936,7 +936,7 @@ let test_stream_acc_text () =
 
 let test_stream_acc_tool_use () =
   let events =
-    [ MessageStart { id = "msg_456"; model = "gpt-4"; usage = None }
+    [ MessageStart { id = "msg_456"; model = "model-d-4"; usage = None }
     ; ContentBlockStart
         { index = 0
         ; content_type = "tool_use"
@@ -1138,7 +1138,7 @@ let () =
     ; ( "cost"
       , [ test_case "annotate response cost" `Quick test_annotate_response_cost
         ; test_case
-            "annotate gpt-5.5 response cost"
+            "annotate model-d-5.5 response cost"
             `Quick
             test_annotate_response_cost_gpt55
         ] )

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -343,7 +343,7 @@ let test_provider_name_of_config_local_provider_d_compat () =
   in
   check_string
     "local provider_d compat resolves to llama"
-    "llama"
+    "provider_n"
     (Provider_registry.provider_name_of_config cfg)
 ;;
 
@@ -356,7 +356,7 @@ let test_provider_name_of_config_openrouter () =
       ~request_path:"/chat/completions"
       ()
   in
-  check_string "openrouter" "openrouter" (Provider_registry.provider_name_of_config cfg)
+  check_string "provider_o_router" "provider_o_router" (Provider_registry.provider_name_of_config cfg)
 ;;
 
 (* ── provider_kind_of_string ─────────────────────────── *)
@@ -389,7 +389,7 @@ let test_kind_roundtrip () =
 let test_kind_aliases () =
   check_parse "agent_llm_a -> Provider_a" "agent_llm_a" Provider_a;
   check_parse "provider_d -> Provider_d_compat" "provider_d" Provider_d_compat;
-  check_parse "llama -> Ollama" "llama" Ollama
+  check_parse "llama -> Ollama" "provider_n" Ollama
 ;;
 
 let test_kind_case_insensitive () =
@@ -415,9 +415,9 @@ let test_kind_unknown_returns_none () =
     true
     (Option.is_none (Provider_config.provider_kind_of_string "anthrpic"));
   check_bool
-    "bare openrouter"
+    "bare provider_o_router"
     true
-    (Option.is_none (Provider_config.provider_kind_of_string "openrouter"));
+    (Option.is_none (Provider_config.provider_kind_of_string "provider_o_router"));
   check_bool
     "json-ish"
     true
@@ -478,7 +478,7 @@ let test_of_yojson_accepts_aliases () =
            expected_wire
            (Provider_config.string_of_provider_kind k)
        | Error msg -> Alcotest.failf "of_yojson alias %S failed: %s" input msg)
-    [ "agent_llm_a", "provider_a"; "provider_d", "provider_d_compat"; "llama", "ollama" ]
+    [ "agent_llm_a", "provider_a"; "provider_d", "provider_d_compat"; "provider_n", "ollama" ]
 ;;
 
 let test_of_yojson_rejects_unknown_string () =
@@ -833,7 +833,7 @@ let () =
             "local provider_d compat"
             `Quick
             test_provider_name_of_config_local_provider_d_compat
-        ; Alcotest.test_case "openrouter" `Quick test_provider_name_of_config_openrouter
+        ; Alcotest.test_case "provider_o_router" `Quick test_provider_name_of_config_openrouter
         ] )
     ; ( "kind_of_string"
       , [ Alcotest.test_case "roundtrip all variants" `Quick test_kind_roundtrip

--- a/test/test_provider_f_edge_cases.ml
+++ b/test/test_provider_f_edge_cases.ml
@@ -67,9 +67,9 @@ let test_cache_system_prompt () =
   check "cachedContent absent (not implemented)" (cached = `Null)
 ;;
 
-(* ── 3. Vertex AI auth: URL without ?key= when api_key empty ── *)
+(* ── 3. Provider_f cloud auth: URL without ?key= when api_key empty ── *)
 let test_vertex_ai_url () =
-  Printf.printf "=== Vertex AI URL (no api_key) ===\n";
+  Printf.printf "=== Provider_f cloud URL (no api_key) ===\n";
   let config =
     Provider_config.make
       ~kind:Provider_f

--- a/test/test_provider_intf.ml
+++ b/test/test_provider_intf.ml
@@ -15,7 +15,7 @@ let test_of_config_provider_a () =
 ;;
 
 let test_of_config_provider_d () =
-  let config = Provider.openrouter ~model_id:"gpt-4" () in
+  let config = Provider.provider_o_router ~model_id:"model-d-4" () in
   let (module P : Provider_intf.PROVIDER) = Provider_intf.of_config config in
   ignore (module P : Provider_intf.PROVIDER)
 ;;

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -208,7 +208,7 @@ let test_default_has_19 () =
   let reg = Provider_registry.default () in
   let all = Provider_registry.all reg in
   check int "19 known providers" 19 (List.length all);
-  check bool "llama exists" true (Option.is_some (Provider_registry.find reg "llama"));
+  check bool "llama exists" true (Option.is_some (Provider_registry.find reg "provider_n"));
   check bool "ollama exists" true (Option.is_some (Provider_registry.find reg "ollama"));
   check
     bool
@@ -242,9 +242,9 @@ let test_default_has_19 () =
     (Option.is_some (Provider_registry.find reg "provider_c"));
   check
     bool
-    "openrouter exists"
+    "provider_o_router exists"
     true
-    (Option.is_some (Provider_registry.find reg "openrouter"));
+    (Option.is_some (Provider_registry.find reg "provider_o_router"));
   check
     bool
     "provider_i exists"
@@ -296,7 +296,7 @@ let test_default_capabilities () =
      check bool "agent_llm_a has tools" true e.capabilities.supports_tools;
      check bool "agent_llm_a has reasoning" true e.capabilities.supports_reasoning
    | None -> fail "agent_llm_a should exist");
-  match Provider_registry.find reg "llama" with
+  match Provider_registry.find reg "provider_n" with
   | Some e ->
     check bool "llama has tools" true e.capabilities.supports_tools;
     check bool "llama has top_k" true e.capabilities.supports_top_k
@@ -332,7 +332,7 @@ let test_provider_name_of_ollama_cloud_config () =
 
 let test_default_max_context () =
   let reg = Provider_registry.default () in
-  (match Provider_registry.find reg "llama" with
+  (match Provider_registry.find reg "provider_n" with
    | Some e -> check int "llama 128K" 128_000 e.max_context
    | None -> fail "llama should exist");
   (match Provider_registry.find reg "agent_llm_a" with
@@ -542,10 +542,10 @@ let test_catalog_overlay_replaces_seed_provider () =
       "schema_version": 1,
       "providers": [
         {
-          "id": "openrouter",
+          "id": "provider_o_router",
           "kind": "provider_d_compat",
           "transport": "http",
-          "base_url": "https://example.test/openrouter",
+          "base_url": "https://example.test/provider_o_router",
           "request_path": "/chat/completions",
           "auth": {"type": "api_key_env", "env": "OPENROUTER_API_KEY"},
           "capabilities_base": "provider_d_chat"
@@ -554,10 +554,10 @@ let test_catalog_overlay_replaces_seed_provider () =
     }|}
     (fun () ->
        let reg = Provider_registry.default () in
-       match Provider_registry.find reg "openrouter" with
+       match Provider_registry.find reg "provider_o_router" with
        | Some e ->
-         check string "catalog wins" "https://example.test/openrouter" e.defaults.base_url
-       | None -> fail "openrouter should still exist")
+         check string "catalog wins" "https://example.test/provider_o_router" e.defaults.base_url
+       | None -> fail "provider_o_router should still exist")
 ;;
 
 let test_catalog_overlay_normalizes_provider_id () =
@@ -985,7 +985,7 @@ let test_requires_any () =
 
 (** Minimal [Provider_config.t] construction for a given kind, using a
     localhost base URL so [is_local = true] for [Provider_d_compat] (resolves
-    to the registry's "llama" entry) and a plain (non-coding) URL for
+    to the registry's "provider_n" entry) and a plain (non-coding) URL for
     [Provider_k] (resolves to "provider_k"). *)
 let mk_config_for_kind kind =
   let base_url =
@@ -1001,7 +1001,7 @@ let mk_config_for_kind kind =
     (masc canonical_name: "agent_llm_a-api", ...) (boundary-allow) to
     [Provider_registry.find], but the registry is keyed on the names
     returned by [Provider_registry.provider_name_of_config] ("agent_llm_a",
-    "provider_c", "llama", "ollama", "cli_tool_d", "cli_tool_b", ...). For
+    "provider_c", "provider_n", "ollama", "cli_tool_d", "cli_tool_b", ...). For
     direct-API kinds the lookup silently fell back to
     [default_capabilities]; for CLI kinds the masc vocabulary (boundary-allow) happened
     to match direct-API entries ("agent_llm_a" → Provider_a, "provider_f" → Provider_f,

--- a/test/test_retry.ml
+++ b/test/test_retry.ml
@@ -351,10 +351,10 @@ let test_provider_constructors () =
   check string "provider_a_haiku" "agent_llm_a-haiku-4-5-20251001" p.model_id;
   let p = Provider.provider_a_opus () in
   check string "provider_a_opus" "agent_llm_a-opus-4-6" p.model_id;
-  let p = Provider.openrouter () in
-  check string "openrouter default" "provider_a/agent_llm_a-sonnet-4-6" p.model_id;
-  let p = Provider.openrouter ~model_id:"google/provider_f-2.5-pro" () in
-  check string "openrouter override" "google/provider_f-2.5-pro" p.model_id
+  let p = Provider.provider_o_router () in
+  check string "provider_o_router default" "provider_a/agent_llm_a-sonnet-4-6" p.model_id;
+  let p = Provider.provider_o_router ~model_id:"google/provider_f-2.5-pro" () in
+  check string "provider_o_router override" "google/provider_f-2.5-pro" p.model_id
 ;;
 
 let () =

--- a/test/test_runtime_evidence.ml
+++ b/test/test_runtime_evidence.ml
@@ -271,7 +271,7 @@ let test_sessions_store_decodes_runtime_artifacts () =
   "step_count":1,
   "event_counts":{"Agent_completed":1},
   "event_name_counts":[{"event_name":"agent_completed","count":1}],
-  "steps":[{"seq":1,"ts":10.1,"kind":"Agent_completed","participant":"alice","detail":"done","actor":"agent","role":"worker","provider":"provider_d","model":"gpt","raw_trace_run_id":"run-1","stop_reason":"stop","artifact_id":"art-telemetry","artifact_name":"runtime-telemetry-json","artifact_kind":"json","checkpoint_label":"cp","outcome":"ok","dropped_output_deltas":2,"persistence_failure_phase":"append_event"}]
+  "steps":[{"seq":1,"ts":10.1,"kind":"Agent_completed","participant":"alice","detail":"done","actor":"agent","role":"worker","provider":"provider_d","model":"model-d","raw_trace_run_id":"run-1","stop_reason":"stop","artifact_id":"art-telemetry","artifact_name":"runtime-telemetry-json","artifact_kind":"json","checkpoint_label":"cp","outcome":"ok","dropped_output_deltas":2,"persistence_failure_phase":"append_event"}]
 }|}
        in
        let evidence_json =

--- a/test/test_runtime_projection_cov2.ml
+++ b/test/test_runtime_projection_cov2.ml
@@ -399,7 +399,7 @@ let test_apply_agent_spawn () =
          ; role = Some "reviewer"
          ; prompt = "review"
          ; provider = Some "provider_d"
-         ; model = Some "gpt-4"
+         ; model = Some "model-d-4"
          ; permission_mode = None
          })
   in

--- a/test/test_runtime_server_resolve.ml
+++ b/test/test_runtime_server_resolve.ml
@@ -176,7 +176,7 @@ let test_resolve_provider_opus () =
 ;;
 
 let test_resolve_provider_openrouter () =
-  match Runtime_server_resolve.resolve_provider ~provider:"openrouter" () with
+  match Runtime_server_resolve.resolve_provider ~provider:"provider_o_router" () with
   | Ok (Some cfg) ->
     (match cfg.Provider.provider with
      | Provider.OpenAICompat _ -> ()
@@ -406,7 +406,7 @@ let () =
         ; Alcotest.test_case "haiku returns Provider_a" `Quick test_resolve_provider_haiku
         ; Alcotest.test_case "opus returns Provider_a" `Quick test_resolve_provider_opus
         ; Alcotest.test_case
-            "openrouter returns OpenAICompat"
+            "provider_o_router returns OpenAICompat"
             `Quick
             test_resolve_provider_openrouter
         ; Alcotest.test_case

--- a/test/test_skill.ml
+++ b/test/test_skill.ml
@@ -149,9 +149,9 @@ let () =
             (* Empty name falls through to default *)
             check string "body" "body" skill.body)
         ; test_case "model field" `Quick (fun () ->
-            let md = "---\nmodel: gpt-4\n---\nbody" in
+            let md = "---\nmodel: model-d-4\n---\nbody" in
             let skill = Skill.of_markdown md in
-            check (option string) "model" (Some "gpt-4") skill.model)
+            check (option string) "model" (Some "model-d-4") skill.model)
         ; test_case "argument_hint with dash" `Quick (fun () ->
             let md = "---\nargument-hint: <PR number>\n---\nbody" in
             let skill = Skill.of_markdown md in

--- a/test/test_skill_coverage2.ml
+++ b/test/test_skill_coverage2.ml
@@ -402,7 +402,7 @@ let test_skill_of_json_all_optional_present () =
       ; "body", `String "body"
       ; "description", `String "desc"
       ; "path", `String "/p"
-      ; "model", `String "gpt"
+      ; "model", `String "model-d"
       ; "argument_hint", `String "hint"
       ; "allowed_tools", `List [ `String "bash" ]
       ; "supporting_files", `List [ `String "f.sh" ]
@@ -412,7 +412,7 @@ let test_skill_of_json_all_optional_present () =
   | Ok skill ->
     Alcotest.(check (option string)) "desc" (Some "desc") skill.description;
     Alcotest.(check (option string)) "path" (Some "/p") skill.path;
-    Alcotest.(check (option string)) "model" (Some "gpt") skill.model;
+    Alcotest.(check (option string)) "model" (Some "model-d") skill.model;
     Alcotest.(check (option string)) "hint" (Some "hint") skill.argument_hint;
     Alcotest.(check (list string)) "tools" [ "bash" ] skill.allowed_tools;
     Alcotest.(check (list string)) "files" [ "f.sh" ] skill.supporting_files
@@ -454,7 +454,7 @@ let test_skill_to_json_full_fields () =
     ; scope = Some (Custom "team")
     ; allowed_tools = [ "bash"; "read" ]
     ; argument_hint = Some "<arg>"
-    ; model = Some "gpt-4"
+    ; model = Some "model-d-4"
     ; supporting_files = [ "h.sh" ]
     ; metadata = []
     }
@@ -465,7 +465,7 @@ let test_skill_to_json_full_fields () =
   Alcotest.(check string) "desc" "desc" (json |> member "description" |> to_string);
   Alcotest.(check string) "body" "body" (json |> member "body" |> to_string);
   Alcotest.(check string) "path" "/p" (json |> member "path" |> to_string);
-  Alcotest.(check string) "model" "gpt-4" (json |> member "model" |> to_string);
+  Alcotest.(check string) "model" "model-d-4" (json |> member "model" |> to_string);
   Alcotest.(check string) "hint" "<arg>" (json |> member "argument_hint" |> to_string);
   let tools = json |> member "allowed_tools" |> to_list in
   Alcotest.(check int) "2 tools" 2 (List.length tools);

--- a/test/test_skill_registry.ml
+++ b/test/test_skill_registry.ml
@@ -131,7 +131,7 @@ let test_json_roundtrip_rich_skill () =
     "---\n\
      name: complex\n\
      description: Complex skill\n\
-     model: gpt-4\n\
+     model: model-d-4\n\
      argument-hint: <file>\n\
      allowed-tools: Read, Write\n\
      supporting-files: utils.py\n\
@@ -149,7 +149,7 @@ let test_json_roundtrip_rich_skill () =
      | Some s ->
        Alcotest.(check string) "name" "complex" s.name;
        Alcotest.(check (option string)) "desc" (Some "Complex skill") s.description;
-       Alcotest.(check (option string)) "model" (Some "gpt-4") s.model;
+       Alcotest.(check (option string)) "model" (Some "model-d-4") s.model;
        Alcotest.(check (option string)) "hint" (Some "<file>") s.argument_hint;
        Alcotest.(check (list string)) "tools" [ "Read"; "Write" ] s.allowed_tools;
        Alcotest.(check (list string)) "files" [ "utils.py" ] s.supporting_files

--- a/test/test_streaming_cov.ml
+++ b/test/test_streaming_cov.ml
@@ -54,7 +54,7 @@ let test_accumulate_message_start_no_usage () =
   let acc = Streaming.create_stream_acc () in
   Streaming.accumulate_event
     acc
-    (Types.MessageStart { id = "msg_2"; model = "gpt-4"; usage = None });
+    (Types.MessageStart { id = "msg_2"; model = "model-d-4"; usage = None });
   Alcotest.(check string) "id" "msg_2" !(acc.msg_id);
   Alcotest.(check int) "input still 0" 0 !(acc.input_tokens)
 ;;

--- a/test/test_streaming_provider_d.ml
+++ b/test/test_streaming_provider_d.ml
@@ -7,12 +7,12 @@ module S = Llm_provider.Streaming
 
 let test_parse_text_chunk () =
   let data =
-    {|{"id":"chatcmpl-abc","object":"chat.completion.chunk","model":"gpt-4","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}|}
+    {|{"id":"chatcmpl-abc","object":"chat.completion.chunk","model":"model-d-4","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}|}
   in
   match S.parse_provider_d_sse_chunk data with
   | Some chunk ->
     Alcotest.(check string) "id" "chatcmpl-abc" chunk.chunk_id;
-    Alcotest.(check string) "model" "gpt-4" chunk.chunk_model;
+    Alcotest.(check string) "model" "model-d-4" chunk.chunk_model;
     Alcotest.(check (option string)) "content" (Some "Hello") chunk.delta_content;
     Alcotest.(check (option string)) "finish" None chunk.finish_reason;
     Alcotest.(check int) "no tool_calls" 0 (List.length chunk.delta_tool_calls)

--- a/test/test_telemetry_event.ml
+++ b/test/test_telemetry_event.ml
@@ -26,7 +26,7 @@ let test_streaming_first_chunk () =
   let ev =
     Telemetry_event.Streaming_first_chunk
       { provider = "provider_d"
-      ; model = "gpt-4"
+      ; model = "model-d-4"
       ; ttfrc_ms = 123.456
       ; requested_at = 1000.0
       }
@@ -34,7 +34,7 @@ let test_streaming_first_chunk () =
   match roundtrip ev with
   | Telemetry_event.Streaming_first_chunk r ->
     check string "provider" "provider_d" r.provider;
-    check string "model" "gpt-4" r.model;
+    check string "model" "model-d-4" r.model;
     check_float "ttfrc_ms" 123.456 r.ttfrc_ms;
     check_float "requested_at" 1000.0 r.requested_at
   | _ -> fail "variant mismatch"
@@ -62,7 +62,7 @@ let test_streaming_summary () =
   let ev =
     Telemetry_event.Streaming_summary
       { provider = "provider_d"
-      ; model = "gpt-4"
+      ; model = "model-d-4"
       ; chunk_count = 3
       ; kind_breakdown =
           { thinking = 1
@@ -86,7 +86,7 @@ let test_streaming_summary () =
   match roundtrip ev with
   | Telemetry_event.Streaming_summary r ->
     check string "provider" "provider_d" r.provider;
-    check string "model" "gpt-4" r.model;
+    check string "model" "model-d-4" r.model;
     check int "chunk_count" 3 r.chunk_count;
     check int "thinking chunks" 1 r.kind_breakdown.thinking;
     check_float "ttft_ms" 12.5 (Option.get r.ttft_ms);


### PR DESCRIPTION
## Context

PR #1727 (RFC-0001 SDK boundary) and #1729 (Qwen/Mistral/Glm boundary-miss) closed most vendor name surface but left §3 "intentionally preserved" entries: `Gpt_5/4_1/4o`, `Llama_4`, `Gemma_4`, `Grok`, `Command`, plus aggregator identifiers like `openrouter`.

Per user direction "**전부 폭파 — aggregator 포함**", this PR promotes all of these from §3 to §2.

## New vendor letters

| Letter | Vendor | Category |
|--------|--------|----------|
| `m` | **Cohere** | LLM provider |
| `n` | **Meta** | Open-weight provider (Llama family) |
| `o` | **OpenRouter** | Aggregator (identifier only — URL preserved) |

## Variant constructor renames

| Original | New |
|----------|-----|
| `Gpt_5`, `Gpt_4_1`, `Gpt_4o` | `Provider_d_5`, `Provider_d_4_1`, `Provider_d_4o` |
| `Llama_4` | `Provider_n_4` |
| `Gemma_4 of { has_large_audio : bool }` | `Provider_f_gemma_4 of { has_large_audio : bool }` |
| `Grok` | `Provider_e_grok` |
| `Command` | `Provider_m_command` |
| `Llama_server` (comment future-variant) | `Provider_n_server` |

## Model id string renames

| Family | Original | New |
|--------|----------|-----|
| GPT (OpenAI) | `gpt-4`, `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `gpt-5`, `gpt-5.1`, `gpt-5.2`, `gpt-5.3-agent_code{,-spark}`, `gpt-5.4{,-mini}`, `gpt-5.5`, `gpt-image` | `model-d-*` |
| Llama (Meta) | `llama-3.1-70b`, `llama-3.3-70b`, `llama-4-scout`, `llama-4-maverick`, `llama-70b`, `llama.context_length`, `"llama"`, `"ollama/llama3"`, `"ollama/llama"` | `model-n-*` / `provider_n*` |
| Gemma (Google) | `gemma-*`, `"gemma"`, `gemma_4_has_large_audio` | `model-f-gemma-*`, `"provider_f_gemma"`, `provider_f_gemma_4_has_large_audio` |
| Grok (xAI) | `grok-*`, `"grok"`, `~prefix:"grok"` | `model-e-grok-*`, `"provider_e_grok"`, `~prefix:"model-e-grok"` |
| Qwen (Alibaba — boundary miss) | `qwen3_5` (underscore variant) | `provider_h_3_5` |
| Meta as owned_by | `"owned_by":"meta"`, `"owned_by", `String "meta"` | `"owned_by":"provider_n"`, `"owned_by", `String "provider_n"` |

## Aggregator / Cloud identifiers

- `openrouter` / `OpenRouter` (OCaml identifier) → `provider_o_router` / `Provider_o_router`
- `Vertex AI` (comment) → `Provider_f cloud`

## Intentionally preserved (technical boundary — runtime endpoint)

| Surface | Reason |
|---------|--------|
| `https://openrouter.ai/api/v1` URL | Real external OpenRouter service endpoint. Changing breaks live HTTP. |
| `https://generativelanguage.googleapis.com` URL | Real external Google AI endpoint. Same rationale. |
| `"Command"` in test fixtures (`description = "Command"`, `goal = "Command test"`) | Generic English, not vendor reference. |
| `"Command-line interface"` in `bin/oas_cli.ml` prose | Standard CLI term. |

## Verification

- `dune build lib bin test` clean.
- All caller migrations compile against new constructor names (especially `Gemma_4` record-with-fields variant).

## Workaround-rejection self-check

1. "makes X visible" without fixing — NO.
2. String/substring/prefix classifier added — NO (removes residue).
3. "PR #N fixed K of M sites" — NO (closes 100% of vendor identifier residue).
4. catch-all `_ ->` added — NO.
5. cap / cooldown / dedup / repair — NO.
6. test backdoor — NO.
7. typo / off-by-one repeated — NO.

## Breaking change

Same consumer set as #1727/#1729 (masc-mcp only). Pending major version bump still pending.