### PR TITLE
ci: repair cli demo and format drift

### DIFF
--- a/examples/cli_transports_demo.ml
+++ b/examples/cli_transports_demo.ml
@@ -1,23 +1,23 @@
 (** Subprocess CLI transport demo.
 
     Shows how to wire up the four non-interactive CLI transports
-    ([Transport_claude_code], [Transport_gemini_cli],
-    [Transport_kimi_cli], [Transport_codex_cli]), invoke a single
+    ([Transport_cli_tool_d], [Transport_cli_tool_b],
+    [Transport_cli_tool_c], [Transport_cli_tool_a]), invoke a single
     completion through both [complete_sync] and [complete_stream], and
     observe the new [cancel] / [on_stderr_line] knobs added in
     v0.148.0+.
 
     Prerequisites:
-    - At least one of [claude] / [gemini] / [kimi] / [codex] in [PATH]
+    - At least one configured CLI tool binary in [PATH]
     - For real runs the CLI must be already authenticated (this demo
       makes a tiny "say hi" call that consumes a few tokens)
 
     Usage:
       dune exec examples/cli_transports_demo.exe                # auto-pick
-      OAS_CLI_DEMO=claude dune exec examples/cli_transports_demo.exe
-      OAS_CLI_DEMO=gemini dune exec examples/cli_transports_demo.exe
-      OAS_CLI_DEMO=kimi   dune exec examples/cli_transports_demo.exe
-      OAS_CLI_DEMO=codex  dune exec examples/cli_transports_demo.exe
+      OAS_CLI_DEMO=cli_tool_d dune exec examples/cli_transports_demo.exe
+      OAS_CLI_DEMO=cli_tool_b dune exec examples/cli_transports_demo.exe
+      OAS_CLI_DEMO=cli_tool_c dune exec examples/cli_transports_demo.exe
+      OAS_CLI_DEMO=cli_tool_a dune exec examples/cli_transports_demo.exe
 *)
 
 open Llm_provider
@@ -56,53 +56,51 @@ let on_event = function
 (** Pick a transport based on [OAS_CLI_DEMO] or first binary in PATH. *)
 let pick_transport ~sw ~mgr =
   let env = Sys.getenv_opt "OAS_CLI_DEMO" in
-  let in_path bin =
-    let path =
-      try Sys.getenv "PATH" with
-      | Not_found -> ""
-    in
+  let in_path command =
+    let binary = Filename.basename command in
+    let path = Option.value (Sys.getenv_opt "PATH") ~default:"" in
     String.split_on_char ':' path
-    |> List.exists (fun dir -> Sys.file_exists (Filename.concat dir bin))
+    |> List.exists (fun dir -> Sys.file_exists (Filename.concat dir binary))
   in
-  let claude () =
-    let on_stderr_line line = Eio.traceln "[claude stderr] %s" line in
+  let cli_tool_d () =
+    let on_stderr_line line = Eio.traceln "[cli_tool_d stderr] %s" line in
     ignore on_stderr_line;
     (* default already routes to traceln *)
-    ( Transport_claude_code.create ~sw ~mgr ~config:Transport_claude_code.default_config
-    , "claude"
-    , Provider_config.Claude_code )
+    ( Transport_cli_tool_d.create ~sw ~mgr ~config:Transport_cli_tool_d.default_config
+    , "cli_tool_d"
+    , Provider_config.Cli_tool_d )
   in
-  let gemini () =
-    ( Transport_gemini_cli.create ~sw ~mgr ~config:Transport_gemini_cli.default_config
-    , "gemini"
-    , Provider_config.Gemini_cli )
+  let cli_tool_b () =
+    ( Transport_cli_tool_b.create ~sw ~mgr ~config:Transport_cli_tool_b.default_config
+    , "cli_tool_b"
+    , Provider_config.Cli_tool_b )
   in
-  let kimi () =
-    ( Transport_kimi_cli.create ~sw ~mgr ~config:Transport_kimi_cli.default_config
-    , "kimi"
-    , Provider_config.Kimi_cli )
+  let cli_tool_c () =
+    ( Transport_cli_tool_c.create ~sw ~mgr ~config:Transport_cli_tool_c.default_config
+    , "cli_tool_c"
+    , Provider_config.Cli_tool_c )
   in
-  let codex () =
-    ( Transport_codex_cli.create ~sw ~mgr ~config:Transport_codex_cli.default_config
-    , "codex"
-    , Provider_config.Codex_cli )
+  let cli_tool_a () =
+    ( Transport_cli_tool_a.create ~sw ~mgr ~config:Transport_cli_tool_a.default_config
+    , "cli_tool_a"
+    , Provider_config.Cli_tool_a )
   in
   match env with
-  | Some "claude" -> claude ()
-  | Some "gemini" -> gemini ()
-  | Some "kimi" -> kimi ()
-  | Some "codex" -> codex ()
+  | Some "cli_tool_d" -> cli_tool_d ()
+  | Some "cli_tool_b" -> cli_tool_b ()
+  | Some "cli_tool_c" -> cli_tool_c ()
+  | Some "cli_tool_a" -> cli_tool_a ()
   | _ ->
-    if in_path "claude"
-    then claude ()
-    else if in_path "gemini"
-    then gemini ()
-    else if in_path "kimi"
-    then kimi ()
-    else if in_path "codex"
-    then codex ()
+    if in_path Transport_cli_tool_d.default_config.agent_llm_a_path
+    then cli_tool_d ()
+    else if in_path Transport_cli_tool_b.default_config.provider_f_path
+    then cli_tool_b ()
+    else if in_path Transport_cli_tool_c.default_config.provider_c_path
+    then cli_tool_c ()
+    else if in_path Transport_cli_tool_a.default_config.agent_code_path
+    then cli_tool_a ()
     else (
-      prerr_endline "No claude/gemini/kimi/codex binary in PATH; nothing to demo.";
+      prerr_endline "No configured CLI tool binary found in PATH; nothing to demo.";
       exit 0)
 ;;
 

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -519,7 +519,8 @@ let static_model_route_of_id model_id =
       else if String.starts_with ~prefix:"command" m
       then Some Provider_m_command
       else if
-        String.starts_with ~prefix:"provider_e_grok" m || String.starts_with ~prefix:"model-e" m
+        String.starts_with ~prefix:"provider_e_grok" m
+        || String.starts_with ~prefix:"model-e" m
       then Some Provider_e_grok
       else if
         String.starts_with ~prefix:"nvidia/provider_l" m
@@ -534,7 +535,9 @@ let static_model_route_of_id model_id =
       else if
         String.starts_with ~prefix:"model-f-gemma-4" m
         || String.starts_with ~prefix:"google/model-f-gemma-4" m
-      then Some (Provider_f_gemma_4 { has_large_audio = provider_f_gemma_4_has_large_audio m })
+      then
+        Some
+          (Provider_f_gemma_4 { has_large_audio = provider_f_gemma_4_has_large_audio m })
       else if
         String.starts_with ~prefix:"provider_k-4.7-flash" m
         || String.starts_with ~prefix:"provider_k-4.5-flash" m
@@ -1269,7 +1272,8 @@ let%test "for_model_id: specific model IDs get correct (not shadowed) capabiliti
           && c.supports_image_input
           && c.supports_seed
           && c.max_context_tokens = Some 262_144 )
-    ; ("google/model-f-gemma-4-27b-it", fun c -> c.supports_tools && c.supports_image_input)
+    ; ( "google/model-f-gemma-4-27b-it"
+      , fun c -> c.supports_tools && c.supports_image_input )
     ]
 ;;
 

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -1237,7 +1237,9 @@ let%test "find_context_length with general.context_length" =
 let%test "find_context_length with model-specific prefix" =
   let mi =
     `Assoc
-      [ "provider_h_3_5.embedding_length", `Int 3584; "provider_h_3_5.context_length", `Int 262144 ]
+      [ "provider_h_3_5.embedding_length", `Int 3584
+      ; "provider_h_3_5.context_length", `Int 262144
+      ]
   in
   find_context_length mi = 262144
 ;;
@@ -1249,14 +1251,20 @@ let%test "find_context_length prefers context_length over general" =
 
 let%test "find_context_length prefers general.context_length over model-specific" =
   let mi =
-    `Assoc [ "provider_h_3_5.context_length", `Int 262144; "general.context_length", `Int 8192 ]
+    `Assoc
+      [ "provider_h_3_5.context_length", `Int 262144
+      ; "general.context_length", `Int 8192
+      ]
   in
   find_context_length mi = 8192
 ;;
 
 let%test "find_context_length takes max of model-specific keys" =
   let mi =
-    `Assoc [ "provider_n.context_length", `Int 8192; "provider_h_3_5.context_length", `Int 262144 ]
+    `Assoc
+      [ "provider_n.context_length", `Int 8192
+      ; "provider_h_3_5.context_length", `Int 262144
+      ]
   in
   find_context_length mi = 262144
 ;;

--- a/test/test_agent_config_deep.ml
+++ b/test/test_agent_config_deep.ml
@@ -440,7 +440,9 @@ let test_resolve_provider_d_compat_ssot () =
      Provider_kind.to_string Provider_d_compat. Before the parser dispatch,
      it fell through to the registry fallback and ended up with
      api_key_env = "provider_d_compat" — a meaningless value. *)
-  let cfg = Agent_config.resolve_provider ~model_id:"model-d-4" "provider_d_compat" None in
+  let cfg =
+    Agent_config.resolve_provider ~model_id:"model-d-4" "provider_d_compat" None
+  in
   match cfg.provider with
   | Provider.OpenAICompat { base_url; _ } ->
     Alcotest.(check string)

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -334,7 +334,11 @@ let test_complete_provider_d_mlx_vlm_telemetry () =
            "latency patched"
            true
            (Option.value ~default:0 t.request_latency_ms > 0);
-         check (option string) "canonical model id" (Some "model-d-4") t.canonical_model_id;
+         check
+           (option string)
+           "canonical model id"
+           (Some "model-d-4")
+           t.canonical_model_id;
          check (option (float 0.001)) "peak memory" (Some 52.66) t.peak_memory_gb;
          (match t.timings with
           | Some timings ->

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -9,7 +9,10 @@ let test_inject_stream_param_basic () =
   let json = Yojson.Safe.from_string result in
   let open Yojson.Safe.Util in
   Alcotest.(check bool) "stream present" true (json |> member "stream" |> to_bool);
-  Alcotest.(check string) "model preserved" "model-d-4" (json |> member "model" |> to_string)
+  Alcotest.(check string)
+    "model preserved"
+    "model-d-4"
+    (json |> member "model" |> to_string)
 ;;
 
 let test_inject_stream_param_existing_stream () =

--- a/test/test_metrics_aggregating.ml
+++ b/test/test_metrics_aggregating.ml
@@ -84,8 +84,9 @@ let test_aggregating_on_circuit_state () =
     ~provider_key:"model-d-4@https://api.provider_d.com"
     ~state:M.Circuit_open;
   (match !observed with
-   | Some ("provider_d", "model-d-4", "model-d-4@https://api.provider_d.com", M.Circuit_open) ->
-     ()
+   | Some
+       ("provider_d", "model-d-4", "model-d-4@https://api.provider_d.com", M.Circuit_open)
+     -> ()
    | Some _ -> fail "unexpected circuit state callback"
    | None -> fail "missing circuit state callback");
   check int "state value" 1 (M.circuit_state_to_int M.Circuit_open);

--- a/test/test_modality.ml
+++ b/test/test_modality.ml
@@ -73,7 +73,8 @@ let test_gemma4_capability_is_visual_first () =
     (match c.modality_priority with
      | Modality.Visual_first -> ()
      | Modality.Preserve_input_order ->
-       Alcotest.fail "model-f-gemma-4-31b-it should be Visual_first per Gemma 4 best practices")
+       Alcotest.fail
+         "model-f-gemma-4-31b-it should be Visual_first per Gemma 4 best practices")
 ;;
 
 let test_non_gemma_inherits_preserve () =

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -356,7 +356,10 @@ let test_provider_name_of_config_openrouter () =
       ~request_path:"/chat/completions"
       ()
   in
-  check_string "provider_o_router" "provider_o_router" (Provider_registry.provider_name_of_config cfg)
+  check_string
+    "provider_o_router"
+    "provider_o_router"
+    (Provider_registry.provider_name_of_config cfg)
 ;;
 
 (* ── provider_kind_of_string ─────────────────────────── *)
@@ -478,7 +481,10 @@ let test_of_yojson_accepts_aliases () =
            expected_wire
            (Provider_config.string_of_provider_kind k)
        | Error msg -> Alcotest.failf "of_yojson alias %S failed: %s" input msg)
-    [ "agent_llm_a", "provider_a"; "provider_d", "provider_d_compat"; "provider_n", "ollama" ]
+    [ "agent_llm_a", "provider_a"
+    ; "provider_d", "provider_d_compat"
+    ; "provider_n", "ollama"
+    ]
 ;;
 
 let test_of_yojson_rejects_unknown_string () =
@@ -833,7 +839,10 @@ let () =
             "local provider_d compat"
             `Quick
             test_provider_name_of_config_local_provider_d_compat
-        ; Alcotest.test_case "provider_o_router" `Quick test_provider_name_of_config_openrouter
+        ; Alcotest.test_case
+            "provider_o_router"
+            `Quick
+            test_provider_name_of_config_openrouter
         ] )
     ; ( "kind_of_string"
       , [ Alcotest.test_case "roundtrip all variants" `Quick test_kind_roundtrip

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -208,7 +208,11 @@ let test_default_has_19 () =
   let reg = Provider_registry.default () in
   let all = Provider_registry.all reg in
   check int "19 known providers" 19 (List.length all);
-  check bool "llama exists" true (Option.is_some (Provider_registry.find reg "provider_n"));
+  check
+    bool
+    "llama exists"
+    true
+    (Option.is_some (Provider_registry.find reg "provider_n"));
   check bool "ollama exists" true (Option.is_some (Provider_registry.find reg "ollama"));
   check
     bool
@@ -556,7 +560,11 @@ let test_catalog_overlay_replaces_seed_provider () =
        let reg = Provider_registry.default () in
        match Provider_registry.find reg "provider_o_router" with
        | Some e ->
-         check string "catalog wins" "https://example.test/provider_o_router" e.defaults.base_url
+         check
+           string
+           "catalog wins"
+           "https://example.test/provider_o_router"
+           e.defaults.base_url
        | None -> fail "provider_o_router should still exist")
 ;;
 


### PR DESCRIPTION
## Summary

- Update examples/cli_transports_demo.ml from removed vendor transport modules to the current transport_cli_tool_{a,b,c,d} modules and Cli_tool_* provider variants.
- Repair current main OCamlFormat drift introduced after the vendor purge so @fmt is green again.

## Validation

- scripts/dune-local.sh build examples/cli_transports_demo.exe
- scripts/dune-local.sh build @fmt
- git diff --check
- git diff --cached --check
