### PR TITLE
ci: repair post-1732 inline tests

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -462,14 +462,20 @@ let normalize_static_model_id model_id =
 ;;
 
 let provider_f_gemma_4_has_large_audio model_id =
+  let prefix = "model-f-gemma-4-" in
   let base =
     if String.starts_with ~prefix:"google/" model_id
     then String.sub model_id 7 (String.length model_id - 7)
     else model_id
   in
   let size =
-    if String.starts_with ~prefix:"model-f-gemma-4-" base
-    then Some (String.sub base 8 (String.length base - 8))
+    if String.starts_with ~prefix base
+    then
+      Some
+        (String.sub
+           base
+           (String.length prefix)
+           (String.length base - String.length prefix))
     else None
   in
   match size with
@@ -1119,8 +1125,8 @@ let%test "capabilities_for_provider_label: cli_tool_c" =
   | None -> false
 ;;
 
-let%test "capabilities_for_provider_label: KIMI_CLI (case insensitive)" =
-  Option.is_some (capabilities_for_provider_label "KIMI_CLI")
+let%test "capabilities_for_provider_label: CLI_TOOL_C (case insensitive)" =
+  Option.is_some (capabilities_for_provider_label "CLI_TOOL_C")
 ;;
 
 let%test "capabilities_for_provider_label: trims whitespace" =

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -990,7 +990,7 @@ let%test "contains_case_insensitive empty needle" =
 ;;
 
 let%test "contains_case_insensitive exact match" =
-  Retry.contains_case_insensitive ~haystack:"QWEN" ~needle:"provider_h" = true
+  Retry.contains_case_insensitive ~haystack:"PROVIDER_H" ~needle:"provider_h" = true
 ;;
 
 (* --- infer_capabilities --- *)

--- a/lib/llm_provider/pricing.ml
+++ b/lib/llm_provider/pricing.ml
@@ -114,12 +114,12 @@ let static_pricing_opt_normalized normalized =
     then Some ((1.75, 14.0), provider_d_cached_input)
     else if string_contains ~needle:"model-d-5.2" normalized
     then Some ((1.75, 14.0), provider_d_cached_input)
+    else if string_contains ~needle:"model-d-4.1" normalized
+    then Some ((2.0, 8.0), no_cache)
     else if string_contains ~needle:"model-d-mini" normalized
     then Some ((0.15, 0.6), no_cache)
     else if string_contains ~needle:"model-d" normalized
     then Some ((2.5, 10.0), no_cache)
-    else if string_contains ~needle:"model-d-4.1" normalized
-    then Some ((2.0, 8.0), no_cache)
     else if string_contains ~needle:"o3-mini" normalized
     then
       Some ((1.1, 4.4), no_cache)

--- a/lib/llm_provider/transport_cli_tool_a.ml
+++ b/lib/llm_provider/transport_cli_tool_a.ml
@@ -831,8 +831,7 @@ let%test "build_args includes --json flag" =
   let args, env =
     build_args ~config:default_config ~req_config:(agent_code_req ()) ~prompt:"hello" ()
   in
-  args
-  = [ "agent_code"; "exec"; "--json"; "--ephemeral"; "-c"; "mcp_servers={}"; "hello" ]
+  args = [ "codex"; "exec"; "--json"; "--ephemeral"; "-c"; "mcp_servers={}"; "hello" ]
   && env = []
 ;;
 
@@ -865,7 +864,7 @@ let%test "build_args ignores extra parity fields" =
     }
   in
   let args, _ = build_args ~config ~req_config:(agent_code_req ()) ~prompt:"hi" () in
-  args = [ "agent_code"; "exec"; "--json"; "--ephemeral"; "-c"; "mcp_servers={}"; "hi" ]
+  args = [ "codex"; "exec"; "--json"; "--ephemeral"; "-c"; "mcp_servers={}"; "hi" ]
 ;;
 
 let%test "build_args with requested model" =
@@ -877,7 +876,7 @@ let%test "build_args with requested model" =
       ()
   in
   args
-  = [ "agent_code"
+  = [ "codex"
     ; "exec"
     ; "--json"
     ; "--ephemeral"
@@ -893,7 +892,7 @@ let%test "build_args with config default model for auto request" =
   let config = { default_config with model = Some "model-d-5.2-agent_code" } in
   let args, _ = build_args ~config ~req_config:(agent_code_req ()) ~prompt:"hi" () in
   args
-  = [ "agent_code"
+  = [ "codex"
     ; "exec"
     ; "--json"
     ; "--ephemeral"
@@ -1215,14 +1214,7 @@ let%test "default: argv disables MCP even with no env" =
               ()
           in
           args
-          = [ "agent_code"
-            ; "exec"
-            ; "--json"
-            ; "--ephemeral"
-            ; "-c"
-            ; "mcp_servers={}"
-            ; "hi"
-            ]))))
+          = [ "codex"; "exec"; "--json"; "--ephemeral"; "-c"; "mcp_servers={}"; "hi" ]))))
 ;;
 
 let%test "env: OAS_CLI_TOOL_A_CONFIG emits -c pairs before prompt" =

--- a/lib/llm_provider/transport_cli_tool_c.ml
+++ b/lib/llm_provider/transport_cli_tool_c.ml
@@ -553,7 +553,7 @@ let%test "build_args basic" =
     build_args ~config:default_config ~req_config:(provider_c_req ()) ~prompt:"hi"
   in
   args
-  = [ "provider_c"
+  = [ "kimi"
     ; "--print"
     ; "--output-format"
     ; "stream-json"


### PR DESCRIPTION
## Summary

- Fix the remaining inline test drift after PR 1732: vendor-neutral CLI labels, current CLI default binaries, Provider_f Gemma 4 size parsing, and model-d-4.1 pricing route order.
- Keep the branch limited to the 5 files that failed in the workflow_dispatch Build & Test job.

## Validation

- scripts/dune-local.sh runtest lib/llm_provider
- scripts/dune-local.sh build @fmt
- git diff --check
- git diff --cached --check