### PR TITLE
[codex] Align judge structured output contract

### DIFF
--- a/lib/judge/judge.ml
+++ b/lib/judge/judge.ml
@@ -161,6 +161,25 @@ let parse_judgment text =
 
 (* ── LLM call (single provider) ─────────────────────────── *)
 
+let provider_config_for_judge ~(provider : Provider_config.t) ~(config : judge_config) =
+  let response_format =
+    match config.output_schema with
+    | Some schema -> Types.JsonSchema schema
+    | None -> provider.response_format
+  in
+  let output_schema =
+    Provider_config.output_schema_of_response_format
+      ?override:config.output_schema
+      response_format
+  in
+  { provider with
+    Provider_config.temperature = Some config.temperature
+  ; max_tokens = Some config.max_tokens
+  ; response_format
+  ; output_schema
+  }
+;;
+
 let judge ~sw ~net ~provider ~config ~context () =
   let messages : Types.message list =
     [ { role = System
@@ -177,14 +196,7 @@ let judge ~sw ~net ~provider ~config ~context () =
       }
     ]
   in
-  (* Override provider sampling with judge_config (deterministic evaluation). *)
-  let provider_cfg =
-    { provider with
-      Provider_config.temperature = Some config.temperature
-    ; max_tokens = Some config.max_tokens
-    ; output_schema = config.output_schema
-    }
-  in
+  let provider_cfg = provider_config_for_judge ~provider ~config in
   match Complete.complete ~sw ~net ~config:provider_cfg ~messages ~tools:[] () with
   | Error err ->
     let msg =

--- a/lib/judge/judge.mli
+++ b/lib/judge/judge.mli
@@ -49,6 +49,17 @@ type judge_config =
 (** Default configuration: temperature 0.2, max_tokens 2048. *)
 val default_config : unit -> judge_config
 
+(** Apply judge-specific overrides to a provider config.
+
+    When [config.output_schema] is set, the returned provider config carries
+    both [response_format = JsonSchema schema] and [output_schema = Some schema]
+    so downstream provider adapters see one consistent structured-output
+    contract. *)
+val provider_config_for_judge
+  :  provider:Llm_provider.Provider_config.t
+  -> config:judge_config
+  -> Llm_provider.Provider_config.t
+
 (** Derive risk level from a 0.0-1.0 score.
     - [< 0.3] = Low
     - [< 0.6] = Medium

--- a/lib/llm_provider/backend_provider_a.ml
+++ b/lib/llm_provider/backend_provider_a.ml
@@ -137,7 +137,13 @@ let build_request
     | _ -> body
   in
   let body =
-    match config.output_schema with
+    let output_schema =
+      match config.output_schema, config.response_format with
+      | Some schema, _ -> Some schema
+      | None, JsonSchema schema -> Some schema
+      | None, JsonMode | None, Off -> None
+    in
+    match output_schema with
     | Some schema ->
       ( "output_config"
       , `Assoc [ "format", `Assoc [ "type", `String "json_schema"; "schema", schema ] ] )

--- a/test/test_judge.ml
+++ b/test/test_judge.ml
@@ -1,6 +1,8 @@
 (** Tests for Judge module -- LLM-based evaluation and scoring. *)
 
 open Agent_sdk
+module PC = Llm_provider.Provider_config
+module LT = Llm_provider.Types
 
 (* ── Alcotest testable for risk_level ────────────────────── *)
 
@@ -114,6 +116,66 @@ let test_default_config () =
   Alcotest.(check (float 0.001)) "temperature" 0.2 cfg.temperature;
   Alcotest.(check int) "max_tokens" 2048 cfg.max_tokens;
   Alcotest.(check bool) "output_schema is None" true (Option.is_none cfg.output_schema)
+;;
+
+(* ── provider_config_for_judge ───────────────────────────── *)
+
+let judge_output_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; "properties", `Assoc [ "score", `Assoc [ "type", `String "number" ] ]
+    ; "required", `List [ `String "score" ]
+    ]
+;;
+
+let test_provider_config_for_judge_sets_schema_contract () =
+  let provider =
+    PC.make
+      ~kind:PC.Provider_d_compat
+      ~model_id:"model-d-mini"
+      ~base_url:"https://api.provider_d.com/v1"
+      ~response_format:LT.JsonMode
+      ()
+  in
+  let config =
+    { (Judge.default_config ()) with
+      temperature = 0.0
+    ; max_tokens = 512
+    ; output_schema = Some judge_output_schema
+    }
+  in
+  let actual = Judge.provider_config_for_judge ~provider ~config in
+  Alcotest.(check bool)
+    "response_format is JsonSchema"
+    true
+    (actual.response_format = LT.JsonSchema judge_output_schema);
+  Alcotest.(check bool)
+    "output_schema is set"
+    true
+    (actual.output_schema = Some judge_output_schema);
+  Alcotest.(check bool) "temperature override" true (actual.temperature = Some 0.0);
+  Alcotest.(check bool) "max_tokens override" true (actual.max_tokens = Some 512)
+;;
+
+let test_provider_config_for_judge_preserves_provider_response_format () =
+  let provider =
+    PC.make
+      ~kind:PC.Provider_a
+      ~model_id:"agent_llm_a-sonnet-4-6"
+      ~base_url:"https://api.provider_a.com"
+      ~response_format:(LT.JsonSchema judge_output_schema)
+      ()
+  in
+  let config = Judge.default_config () in
+  let actual = Judge.provider_config_for_judge ~provider ~config in
+  Alcotest.(check bool)
+    "provider response_format preserved"
+    true
+    (actual.response_format = LT.JsonSchema judge_output_schema);
+  Alcotest.(check bool)
+    "output_schema derived from preserved response_format"
+    true
+    (actual.output_schema = Some judge_output_schema)
 ;;
 
 (* ── risk_of_score derivation ────────────────────────────── *)
@@ -269,6 +331,16 @@ let () =
         ; Alcotest.test_case "score boundaries" `Quick test_parse_score_boundaries
         ] )
     ; "default_config", [ Alcotest.test_case "values" `Quick test_default_config ]
+    ; ( "provider_config_for_judge"
+      , [ Alcotest.test_case
+            "sets schema contract"
+            `Quick
+            test_provider_config_for_judge_sets_schema_contract
+        ; Alcotest.test_case
+            "preserves provider response format"
+            `Quick
+            test_provider_config_for_judge_preserves_provider_response_format
+        ] )
     ; ( "risk_of_score"
       , [ Alcotest.test_case "low" `Quick test_risk_of_score_low
         ; Alcotest.test_case "medium" `Quick test_risk_of_score_medium

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -122,6 +122,29 @@ let test_provider_a_output_schema () =
     (json |> member "output_config" |> member "format" |> member "schema" = schema)
 ;;
 
+let test_provider_a_json_schema_response_format_without_output_schema () =
+  let schema =
+    `Assoc
+      [ "type", `String "object"
+      ; "properties", `Assoc [ "answer", `Assoc [ "type", `String "string" ] ]
+      ; "required", `List [ `String "answer" ]
+      ]
+  in
+  let config =
+    { (PC.make ~kind:Provider_a ~model_id:"agent_llm_a-sonnet-4-6" ~base_url:"" ()) with
+      response_format = JsonSchema schema
+    ; output_schema = None
+    }
+  in
+  let body = BA.build_request ~config ~messages:[ user_msg "hi" ] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  Alcotest.(check bool)
+    "schema copied from response_format"
+    true
+    (json |> member "output_config" |> member "format" |> member "schema" = schema)
+;;
+
 let test_provider_a_parse_response_initializes_telemetry () =
   let json =
     Yojson.Safe.from_string
@@ -1067,6 +1090,10 @@ let () =
         ; test_case "with system" `Quick test_provider_a_with_system
         ; test_case "with thinking" `Quick test_provider_a_with_thinking
         ; test_case "with output schema" `Quick test_provider_a_output_schema
+        ; test_case
+            "with json schema response_format"
+            `Quick
+            test_provider_a_json_schema_response_format_without_output_schema
         ; test_case "stream flag" `Quick test_provider_a_stream_flag
         ; test_case
             "parse response initializes telemetry"


### PR DESCRIPTION
## Summary
- Ensure `Judge.output_schema` produces a consistent provider config with both `response_format = JsonSchema` and `output_schema = Some schema`.
- Let the Provider A backend honor `response_format = JsonSchema` even when direct record-literal configs leave `output_schema = None`.
- Add focused regression coverage for judge provider config wiring and Provider A request JSON generation.

## Validation
- `ocamlformat --check lib/judge/judge.ml lib/judge/judge.mli lib/llm_provider/backend_provider_a.ml test/test_judge.ml test/test_provider_complete.ml`
- `scripts/dune-local.sh build test/test_judge.exe test/test_provider_complete.exe`
- `./_build/default/test/test_judge.exe`
- `./_build/default/test/test_provider_complete.exe`
- `git diff --check`