### PR TITLE
ci: repair main test drift after vendor purge

### DIFF
--- a/test/test_llm_call.ml
+++ b/test/test_llm_call.ml
@@ -1,8 +1,8 @@
 (** Minimal LLM call test — no tools, just one API round-trip *)
 open Agent_sdk
 
-let () =
-  Printf.printf "Testing LLM call via provider_a-proxy...\n%!";
+let run_live_test () =
+  Printf.printf "Testing LLM call via local LLM endpoint...\n%!";
   Eio_main.run
   @@ fun env ->
   let net = Eio.Stdenv.net env in
@@ -68,4 +68,12 @@ let () =
        Printf.printf "Usage: in=%d out=%d\n%!" u.Types.input_tokens u.output_tokens
      | None -> Printf.printf "No usage data\n%!")
   | Error e -> Printf.printf "Error: %s\n%!" (Error.to_string e)
+;;
+
+let () =
+  match Sys.getenv_opt "LLAMA_LIVE_TEST" with
+  | Some "1" -> run_live_test ()
+  | _ ->
+    Printf.printf
+      "Skipped: set LLAMA_LIVE_TEST=1 to run test_llm_call against local LLM\n%!"
 ;;

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -399,13 +399,13 @@ let test_kind_case_insensitive () =
   check_parse "PROVIDER_A" "PROVIDER_A" Provider_a;
   check_parse "Agent_llm_a" "Agent_llm_a" Provider_a;
   check_parse "Provider_k" "Provider_k" Provider_k;
-  check_parse "Gemini_CLI" "Gemini_CLI" Cli_tool_b
+  check_parse "CLI_TOOL_B" "CLI_TOOL_B" Cli_tool_b
 ;;
 
 let test_kind_whitespace () =
   check_parse "leading ws" "  agent_llm_a" Provider_a;
   check_parse "trailing ws" "ollama  " Ollama;
-  check_parse "both ws" "\topenai\n" Provider_d_compat
+  check_parse "both ws" "\tprovider_d_compat\n" Provider_d_compat
 ;;
 
 let test_kind_unknown_returns_none () =


### PR DESCRIPTION
Summary
- Update provider kind parser tests to use canonical vendor-neutral names after the vendor purge.
- Gate test_llm_call behind LLAMA_LIVE_TEST=1 so normal CI does not attempt a local LLM request.

Validation
- scripts/dune-local.sh runtest test/test_provider_config.exe
- scripts/dune-local.sh exec test/test_llm_call.exe
- scripts/dune-local.sh build @fmt
- git diff --check
- git diff --cached --check