### PR TITLE
test: scope provider_h reasoning property

### DIFF
--- a/test/test_property_advanced.ml
+++ b/test/test_property_advanced.ml
@@ -254,12 +254,13 @@ let test_local_provider_resolve_always_succeeds =
 let test_capabilities_provider_m_reasoning =
   QCheck.Test.make
     ~count:50
-    ~name:"Provider_h models get reasoning capability"
+    ~name:"Provider_h_3 models get reasoning capability"
     (QCheck.make
+       ~print:(fun s -> s)
        (QCheck.Gen.oneof
           [ QCheck.Gen.return "provider_h-3.5-35b"
-          ; QCheck.Gen.return "Qwen2.5-72B"
-          ; QCheck.Gen.return "provider_h-turbo"
+          ; QCheck.Gen.return "provider_h_3.6:27b-coding-nvfp4"
+          ; QCheck.Gen.return "Provider_h_3.6-35B-A3B-UD-Q4_K_XL.gguf"
           ]))
     (fun model_id ->
        let caps =


### PR DESCRIPTION
## Summary
- scope the Provider_h reasoning property to Provider_h_3 model IDs that the static capability router recognizes
- add QCheck printing so future coverage failures show the sampled model id

## Verification
- scripts/dune-local.sh runtest test/test_property_advanced.exe
- scripts/dune-local.sh build @fmt
- git diff --check
- git diff --cached --check

Follow-up to #1735: the manual CI coverage rerun exposed this property drift after #1735 had already merged.