### PR TITLE
chore: bump version to 0.197.0 — vendor purge breaking change

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,6 @@
 (lang dune 3.22)
 (name agent_sdk)
-(version 0.196.16) ; x-release-please-version
+(version 0.197.0) ; x-release-please-version
 
 (generate_opam_files true)
 

--- a/lib/sdk_version.ml
+++ b/lib/sdk_version.ml
@@ -1,5 +1,5 @@
 (** Single source of truth for the SDK version string.
     All other modules reference this instead of hardcoding. *)
 
-let version = "0.196.16" (* x-release-please-version *)
+let version = "0.197.0" (* x-release-please-version *)
 let sdk_name = "agent_sdk"


### PR DESCRIPTION
## Why

PR #1727 / #1729 / #1731 (RFC-0001 family) renamed every public SDK identifier (variant constructors, env vars, file modules) for vendor decoupling. This is a breaking change for any downstream consumer of `agent_sdk` — major-style in spirit, but kept under 1.0.0 per the project's pre-1.0 versioning convention (`bump-minor-pre-major: true` in release-please-config).

masc-mcp is the only known consumer and is in flight (RFC-0174) to migrate. The version bump makes opam version constraints resolvable to the new SDK and forces fresh installs — the cached 0.196.16 source contains the pre-purge API and is corrupting downstream builds.

## What

- `lib/sdk_version.ml` — `0.196.16` → `0.197.0`
- `dune-project` (version field) — `0.196.16` → `0.197.0`

x-release-please-version markers preserved on both lines.

## Downstream impact

- masc-mcp dune-project will update its constraint `(agent_sdk (>= 0.197.0))` as part of RFC-0174 PR — gated on this PR's merge.
- No code change in this PR; SDK API is the post-#1731 main HEAD state.

## Workaround-rejection self-check

This PR is a pure version bump; no API change, no logic change, no telemetry. All 7 rejection signatures: NO.