### PR TITLE
feat(runtime): project checkpoint deltas from replay windows

### DIFF
--- a/docs/runtime-run-windows.md
+++ b/docs/runtime-run-windows.md
@@ -28,6 +28,21 @@ and events continue to load.
 deduplicated by stable event id `<session_id>#<event.seq>` before returning
 events.
 
+## Checkpoint Delta Projection
+
+`Runtime_replay.checkpoint_delta_projection_from_store` reads `Checkpoint_saved`
+events from the selected windows and loads each referenced path as a canonical
+`Checkpoint.t`. The first valid checkpoint is emitted as a full checkpoint; each
+following valid checkpoint is emitted as a `Checkpoint.compute_delta` result
+against the previous valid checkpoint. This gives replay consumers a concrete
+JSON contract for cross-run checkpoint deltas without changing the existing
+`Runtime_sync.window` event format.
+
+Checkpoint paths are deduplicated before projection, so overlapping selectors
+do not repeat the same checkpoint. Corrupt, missing, or non-checkpoint paths are
+reported as partial failures and do not prevent valid checkpoint deltas from
+being returned.
+
 ## Retention And Compatibility
 
 The read side only scans files currently present under the runtime session

--- a/lib/runtime_replay.ml
+++ b/lib/runtime_replay.ml
@@ -6,6 +6,34 @@ type sync_window_set =
   ; failures : Runtime_store.run_load_failure list
   }
 
+type checkpoint_ref =
+  { session_id : string
+  ; event_seq : int
+  ; label : string option
+  ; path : string
+  }
+
+type checkpoint_record =
+  { checkpoint_ref : checkpoint_ref
+  ; checkpoint : Checkpoint.t
+  }
+
+type checkpoint_delta_entry =
+  | Full_checkpoint of
+      { checkpoint_ref : checkpoint_ref
+      ; checkpoint : Checkpoint.t
+      }
+  | Delta_checkpoint of
+      { base : checkpoint_ref
+      ; target : checkpoint_ref
+      ; delta : Checkpoint.delta
+      }
+
+type checkpoint_delta_projection =
+  { entries : checkpoint_delta_entry list
+  ; failures : Runtime_store.run_load_failure list
+  }
+
 let artifact_refs (session : Runtime.session) =
   session.artifacts
   |> List.map (fun (artifact : Runtime.artifact) -> artifact.artifact_id)
@@ -71,4 +99,137 @@ let sync_windows_json_from_store ?after_seq ?persistence ?merge_policy store sel
     sync_windows_from_store ?after_seq ?persistence ?merge_policy store selectors
   in
   Ok (sync_window_set_to_yojson set)
+;;
+
+let checkpoint_ref_to_yojson (ref_ : checkpoint_ref) =
+  `Assoc
+    [ "session_id", `String ref_.session_id
+    ; "event_seq", `Int ref_.event_seq
+    ; ( "label"
+      , match ref_.label with
+        | None -> `Null
+        | Some label -> `String label )
+    ; "path", `String ref_.path
+    ]
+;;
+
+let checkpoint_delta_entry_to_yojson = function
+  | Full_checkpoint { checkpoint_ref; checkpoint } ->
+    `Assoc
+      [ "kind", `String "full_checkpoint"
+      ; "checkpoint_ref", checkpoint_ref_to_yojson checkpoint_ref
+      ; "checkpoint", Checkpoint.to_json checkpoint
+      ]
+  | Delta_checkpoint { base; target; delta } ->
+    `Assoc
+      [ "kind", `String "delta_checkpoint"
+      ; "base", checkpoint_ref_to_yojson base
+      ; "target", checkpoint_ref_to_yojson target
+      ; "delta", Checkpoint.delta_to_json delta
+      ]
+;;
+
+let checkpoint_delta_projection_to_yojson projection =
+  `Assoc
+    [ "schema_version", `Int Runtime_sync.schema_version_current
+    ; "projection", `String "checkpoint_delta_v1"
+    ; "entries", `List (List.map checkpoint_delta_entry_to_yojson projection.entries)
+    ; "failures", `List (List.map failure_to_yojson projection.failures)
+    ]
+;;
+
+let checkpoint_failure (ref_ : checkpoint_ref) detail : Runtime_store.run_load_failure =
+  { session_id = ref_.session_id; path = ref_.path; detail }
+;;
+
+let checkpoint_refs_from_events events =
+  events
+  |> List.filter_map (fun (record : Runtime_store.run_event_record) ->
+    match record.event.kind with
+    | Runtime.Checkpoint_saved { label; path } ->
+      Some { session_id = record.session_id; event_seq = record.event.seq; label; path }
+    | _ -> None)
+;;
+
+let dedupe_checkpoint_refs refs =
+  let seen = Hashtbl.create (List.length refs) in
+  refs
+  |> List.filter (fun (ref_ : checkpoint_ref) ->
+    if Hashtbl.mem seen ref_.path
+    then false
+    else (
+      Hashtbl.replace seen ref_.path ();
+      true))
+;;
+
+let dedupe_failures failures =
+  let seen = Hashtbl.create (List.length failures) in
+  failures
+  |> List.filter (fun (failure : Runtime_store.run_load_failure) ->
+    let key = failure.session_id ^ "\x00" ^ failure.path ^ "\x00" ^ failure.detail in
+    if Hashtbl.mem seen key
+    then false
+    else (
+      Hashtbl.replace seen key ();
+      true))
+  |> List.sort (fun (left : Runtime_store.run_load_failure) right ->
+    match String.compare left.session_id right.session_id with
+    | 0 ->
+      (match String.compare left.path right.path with
+       | 0 -> String.compare left.detail right.detail
+       | order -> order)
+    | order -> order)
+;;
+
+let load_checkpoint_ref ref_ =
+  match Runtime_store.load_text ref_.path with
+  | Error err -> Error (checkpoint_failure ref_ (Error.to_string err))
+  | Ok raw ->
+    (match Checkpoint.of_string raw with
+     | Ok checkpoint -> Ok { checkpoint_ref = ref_; checkpoint }
+     | Error err -> Error (checkpoint_failure ref_ (Error.to_string err)))
+;;
+
+let checkpoint_delta_entries records =
+  match records with
+  | [] -> []
+  | first :: rest ->
+    let _, rev_entries =
+      List.fold_left
+        (fun (base, entries) target ->
+           let delta = Checkpoint.compute_delta base.checkpoint target.checkpoint in
+           ( target
+           , Delta_checkpoint
+               { base = base.checkpoint_ref; target = target.checkpoint_ref; delta }
+             :: entries ))
+        ( first
+        , [ Full_checkpoint
+              { checkpoint_ref = first.checkpoint_ref; checkpoint = first.checkpoint }
+          ] )
+        rest
+    in
+    List.rev rev_entries
+;;
+
+let checkpoint_delta_projection_from_store store selectors =
+  let* selected = Runtime_store.read_window_events store selectors in
+  let refs = selected.events |> checkpoint_refs_from_events |> dedupe_checkpoint_refs in
+  let records, checkpoint_failures =
+    List.fold_left
+      (fun (records, failures) ref_ ->
+         match load_checkpoint_ref ref_ with
+         | Ok record -> record :: records, failures
+         | Error failure -> records, failure :: failures)
+      ([], [])
+      refs
+  in
+  Ok
+    { entries = checkpoint_delta_entries (List.rev records)
+    ; failures = dedupe_failures (selected.failures @ checkpoint_failures)
+    }
+;;
+
+let checkpoint_delta_projection_json_from_store store selectors =
+  let* projection = checkpoint_delta_projection_from_store store selectors in
+  Ok (checkpoint_delta_projection_to_yojson projection)
 ;;

--- a/lib/runtime_replay.mli
+++ b/lib/runtime_replay.mli
@@ -9,6 +9,41 @@ type sync_window_set =
   ; failures : Runtime_store.run_load_failure list
   }
 
+(** Checkpoint reference found in a replay window. [path] is expected to point
+    at a canonical {!Checkpoint.t} JSON document. *)
+type checkpoint_ref =
+  { session_id : string
+  ; event_seq : int
+  ; label : string option
+  ; path : string
+  }
+
+(** Loaded checkpoint plus its runtime event reference. *)
+type checkpoint_record =
+  { checkpoint_ref : checkpoint_ref
+  ; checkpoint : Checkpoint.t
+  }
+
+(** Projection entries are ordered for replay: one full checkpoint seed followed
+    by deltas computed from the previous valid checkpoint. *)
+type checkpoint_delta_entry =
+  | Full_checkpoint of
+      { checkpoint_ref : checkpoint_ref
+      ; checkpoint : Checkpoint.t
+      }
+  | Delta_checkpoint of
+      { base : checkpoint_ref
+      ; target : checkpoint_ref
+      ; delta : Checkpoint.delta
+      }
+
+(** Cross-run checkpoint delta projection. Invalid checkpoint paths are reported
+    in [failures] and do not prevent valid entries from being returned. *)
+type checkpoint_delta_projection =
+  { entries : checkpoint_delta_entry list
+  ; failures : Runtime_store.run_load_failure list
+  }
+
 val sync_windows_from_store
   :  ?after_seq:int
   -> ?persistence:Runtime_sync.persistence_contract
@@ -24,5 +59,21 @@ val sync_windows_json_from_store
   -> ?persistence:Runtime_sync.persistence_contract
   -> ?merge_policy:Runtime_sync.merge_policy
   -> Runtime_store.t
+  -> Runtime_store.run_window list
+  -> (Yojson.Safe.t, Error.sdk_error) result
+
+(** Build a checkpoint delta projection from [Checkpoint_saved] events in the
+    selected runtime windows. Overlapping selectors are deduplicated by
+    checkpoint path before deltas are computed. *)
+val checkpoint_delta_projection_from_store
+  :  Runtime_store.t
+  -> Runtime_store.run_window list
+  -> (checkpoint_delta_projection, Error.sdk_error) result
+
+val checkpoint_delta_projection_to_yojson : checkpoint_delta_projection -> Yojson.Safe.t
+
+(** JSON form of {!checkpoint_delta_projection_from_store}. *)
+val checkpoint_delta_projection_json_from_store
+  :  Runtime_store.t
   -> Runtime_store.run_window list
   -> (Yojson.Safe.t, Error.sdk_error) result

--- a/test/test_runtime_replay.ml
+++ b/test/test_runtime_replay.ml
@@ -49,6 +49,59 @@ let mk_event seq message : Runtime.event =
   }
 ;;
 
+let mk_checkpoint_event seq ?label path : Runtime.event =
+  { seq; ts = float_of_int seq; kind = Runtime.Checkpoint_saved { label; path } }
+;;
+
+let mk_message text : Types.message =
+  { role = Types.User
+  ; content = [ Types.Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+let mk_checkpoint ?(messages = []) ?(created_at = 1.0) ?(turn_count = 0) session_id
+  : Checkpoint.t
+  =
+  { version = Checkpoint.checkpoint_version
+  ; session_id
+  ; agent_name = "runtime-replay-agent"
+  ; model = "agent_llm_a-sonnet-4-6"
+  ; system_prompt = Some "replay"
+  ; messages
+  ; usage = Types.empty_usage
+  ; turn_count
+  ; created_at
+  ; tools = []
+  ; tool_choice = None
+  ; disable_parallel_tool_use = false
+  ; temperature = None
+  ; top_p = None
+  ; top_k = None
+  ; min_p = None
+  ; enable_thinking = None
+  ; response_format = Types.Off
+  ; thinking_budget = None
+  ; cache_system_prompt = false
+  ; max_input_tokens = None
+  ; max_total_tokens = None
+  ; context = Context.create ()
+  ; mcp_sessions = []
+  ; working_context = None
+  }
+;;
+
+let save_checkpoint_file root name checkpoint =
+  let path = Filename.concat root name in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc (Checkpoint.to_string checkpoint));
+  path
+;;
+
 let save_artifact store session_id ~artifact_id ~name content =
   let path =
     Runtime_store.save_artifact_text store session_id ~name ~kind:"json" ~content
@@ -144,6 +197,117 @@ let test_sync_windows_json_reports_selector_failures_and_dedupes_runs () =
       (json |> member "failures" |> to_list |> List.hd |> member "session_id" |> to_string))
 ;;
 
+let test_checkpoint_delta_projection_from_selected_runs () =
+  with_temp_dir (fun root ->
+    let store = Runtime_store.create ~root () |> expect_ok "create store" in
+    let base =
+      mk_checkpoint
+        ~created_at:10.0
+        ~turn_count:1
+        ~messages:[ mk_message "base" ]
+        "checkpoint-run"
+    in
+    let target =
+      mk_checkpoint
+        ~created_at:20.0
+        ~turn_count:2
+        ~messages:[ mk_message "base"; mk_message "target" ]
+        "checkpoint-run"
+    in
+    let base_path = save_checkpoint_file root "base-checkpoint.json" base in
+    let target_path = save_checkpoint_file root "target-checkpoint.json" target in
+    save_run
+      store
+      "run-a"
+      ~updated_at:10.0
+      [ mk_checkpoint_event 1 ~label:"base" base_path ];
+    save_run
+      store
+      "run-b"
+      ~updated_at:20.0
+      [ mk_checkpoint_event 1 ~label:"target" target_path ];
+    let projection =
+      Runtime_replay.checkpoint_delta_projection_from_store
+        store
+        [ Runtime_store.Last_n_runs 2 ]
+      |> expect_ok "checkpoint projection"
+    in
+    check int "entries" 2 (List.length projection.entries);
+    check int "failures" 0 (List.length projection.failures);
+    match projection.entries with
+    | [ Runtime_replay.Full_checkpoint { checkpoint; checkpoint_ref = base_ref }
+      ; Runtime_replay.Delta_checkpoint
+          { base = delta_base; target = delta_target; delta }
+      ] ->
+      check string "base path" base_path base_ref.path;
+      check string "delta base path" base_path delta_base.path;
+      check string "delta target path" target_path delta_target.path;
+      let rebuilt = Checkpoint.apply_delta checkpoint delta |> expect_ok "apply delta" in
+      check
+        string
+        "rebuilt target"
+        (Yojson.Safe.to_string (Checkpoint.to_json target))
+        (Yojson.Safe.to_string (Checkpoint.to_json rebuilt))
+    | _ -> fail "expected full checkpoint followed by delta checkpoint")
+;;
+
+let test_checkpoint_delta_projection_reports_corrupt_checkpoint () =
+  with_temp_dir (fun root ->
+    let store = Runtime_store.create ~root () |> expect_ok "create store" in
+    let checkpoint = mk_checkpoint ~messages:[ mk_message "valid" ] "checkpoint-run" in
+    let valid_path = save_checkpoint_file root "valid-checkpoint.json" checkpoint in
+    let corrupt_path = Filename.concat root "corrupt-checkpoint.json" in
+    let oc = open_out corrupt_path in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () -> output_string oc "not checkpoint json");
+    save_run
+      store
+      "run-a"
+      ~updated_at:10.0
+      [ mk_checkpoint_event 1 valid_path; mk_checkpoint_event 2 corrupt_path ];
+    let projection =
+      Runtime_replay.checkpoint_delta_projection_from_store
+        store
+        [ Runtime_store.Session "run-a" ]
+      |> expect_ok "checkpoint projection"
+    in
+    check int "valid entry" 1 (List.length projection.entries);
+    check int "one failure" 1 (List.length projection.failures);
+    match projection.failures with
+    | [ failure ] -> check string "corrupt path" corrupt_path failure.path
+    | _ -> fail "expected one corrupt checkpoint failure")
+;;
+
+let test_checkpoint_delta_projection_dedupes_overlapping_checkpoint_paths () =
+  with_temp_dir (fun root ->
+    let store = Runtime_store.create ~root () |> expect_ok "create store" in
+    let checkpoint = mk_checkpoint ~messages:[ mk_message "same" ] "checkpoint-run" in
+    let path = save_checkpoint_file root "same-checkpoint.json" checkpoint in
+    save_run
+      store
+      "run-a"
+      ~updated_at:10.0
+      [ mk_checkpoint_event 1 path; mk_checkpoint_event 2 path ];
+    let json =
+      Runtime_replay.checkpoint_delta_projection_json_from_store
+        store
+        [ Runtime_store.Last_n_runs 1; Runtime_store.Session "run-a" ]
+      |> expect_ok "checkpoint projection json"
+    in
+    let open Yojson.Safe.Util in
+    check
+      int
+      "one projected checkpoint"
+      1
+      (json |> member "entries" |> to_list |> List.length);
+    check
+      string
+      "projection kind"
+      "checkpoint_delta_v1"
+      (json |> member "projection" |> to_string))
+;;
+
 let () =
   Alcotest.run
     "runtime_replay"
@@ -156,6 +320,20 @@ let () =
             "json reports failures and dedupes runs"
             `Quick
             test_sync_windows_json_reports_selector_failures_and_dedupes_runs
+        ] )
+    ; ( "checkpoint_delta_projection"
+      , [ test_case
+            "selected checkpoints project full plus delta"
+            `Quick
+            test_checkpoint_delta_projection_from_selected_runs
+        ; test_case
+            "corrupt checkpoint is a partial failure"
+            `Quick
+            test_checkpoint_delta_projection_reports_corrupt_checkpoint
+        ; test_case
+            "overlapping checkpoint paths are deduped"
+            `Quick
+            test_checkpoint_delta_projection_dedupes_overlapping_checkpoint_paths
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- Add `Runtime_replay.checkpoint_delta_projection_from_store` for `Checkpoint_saved` events selected by runtime replay windows.
- Emit one full checkpoint seed followed by `Checkpoint.compute_delta` entries for later valid checkpoints.
- Deduplicate overlapping checkpoint paths and report corrupt/missing/non-checkpoint paths as partial failures.
- Document the checkpoint delta projection JSON contract in `docs/runtime-run-windows.md`.

## Verification

- `opam exec -- ocamlformat -i lib/runtime_replay.ml lib/runtime_replay.mli test/test_runtime_replay.ml`
- `scripts/dune-local.sh runtest test/test_runtime_replay.exe`
- `scripts/dune-local.sh runtest test/test_runtime_sync.exe test/test_runtime_store_unit.exe test/test_checkpoint_delta.exe`
- `scripts/dune-local.sh build @fmt`
- `git diff --check`
- `git diff --cached --check`

Follow-up for #484: this implements the explicit checkpoint-delta projection slice after #1716/#1720 added run windows and runtime sync window projection.
