### PR TITLE
ci: ratchet coverage floor to 73

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,11 @@ jobs:
           # 2026-05-24: main CI after #1718 measured 73.73% coverage
           # (run 26354719636, job 77579231445). Raise the floor to
           # floor(73.73 - 1) = 72 per #1175 ratchet policy.
-          THRESHOLD=72
+          #
+          # 2026-05-24: PR #1738 CI measured 74.47% coverage
+          # (run 26360879180, job 77595953724). Raise the floor to
+          # floor(74.47 - 1) = 73 per #1175 ratchet policy.
+          THRESHOLD=73
           if [ "$(echo "$COVERAGE < $THRESHOLD" | bc -l)" -eq 1 ]; then
             echo "::error::Coverage ${COVERAGE}% is below threshold ${THRESHOLD}%"
             exit 1

--- a/docs/_audit/2026-05-24-coverage-ratchet-73-evidence.md
+++ b/docs/_audit/2026-05-24-coverage-ratchet-73-evidence.md
@@ -1,0 +1,32 @@
+# Coverage ratchet evidence - 2026-05-24 - threshold 73
+
+Scope: #1175 Stage C incremental ratchet after the runtime replay checkpoint
+delta slice improved measured coverage above the current 72% floor.
+
+## Measurement
+
+- Evidence: GitHub Actions full CI coverage report on PR #1738.
+- Run: `26360879180`
+- Job: `77595953724`
+- Command checked: `gh run view 26360879180 --job 77595953724 --log`
+- Measured coverage: `74.47%` (`22353/30018`)
+- Timestamp: 2026-05-24 KST
+- Confidence: High
+
+## Ratchet decision
+
+- Previous threshold: `72`
+- New threshold: `73`
+- Formula: `floor(74.47 - 1) = 73`
+- Reason: preserve one percentage point of CI/runtime headroom while making the
+  post-#1738 recovered coverage floor enforceable.
+
+## #1175 record
+
+- Stage C target (`60 -> 75`): still in progress; measured coverage is now
+  `74.47%`, just below the 75% stage line.
+- Top 0% files removed in this PR: none.
+- Tests added in this PR: none; this is a ratchet correction based on an
+  already-successful full CI measurement from #1738.
+- Next target: one focused coverage slice to reach measured coverage >= 76%,
+  then ratchet to at least `75`.


### PR DESCRIPTION
## Why

#1175 tracks ratcheting the coverage floor back toward 80%. PR #1738's full CI measured `74.47%` coverage, so the current `72%` floor can be raised without adding risk.

## What

- Raise CI coverage `THRESHOLD` from `72` to `73`.
- Add audit evidence for the #1738 measurement and the `floor(74.47 - 1) = 73` decision.

## Validation

- Evidence source: `gh run view 26360879180 --job 77595953724 --log`
- `git diff --check`
- `git diff --cached --check`

No code or test behavior changes in this PR.
