### PR TITLE
feat(agent_tool): add typed child invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ original tag dates. `0.100.4` was never tagged or released.
 
 ### Features
 
+* **agent_tool:** add typed child-agent invocation wrapper for agent-as-tool parity
 * **raw-trace:** include typed evidence role summaries in validation results
 
 ## [0.198.0](https://github.com/jeong-sik/oas/compare/v0.197.0...v0.198.0) (2026-05-24)

--- a/lib/agent_tool.ml
+++ b/lib/agent_tool.ml
@@ -6,6 +6,16 @@ open Types
 
 type agent_runner = string -> (api_response, Error.sdk_error) result
 
+type child_invocation =
+  { prompt : string
+  ; raw_input : Yojson.Safe.t
+  }
+
+type child_output =
+  { text : string
+  ; response : api_response
+  }
+
 type config =
   { name : string
   ; description : string
@@ -25,7 +35,112 @@ let text_of_response (resp : api_response) =
   |> String.concat "\n"
 ;;
 
+let stop_reason_to_string = function
+  | EndTurn -> "end_turn"
+  | StopToolUse -> "tool_use"
+  | MaxTokens -> "max_tokens"
+  | StopSequence -> "stop_sequence"
+  | Unknown s -> s
+;;
+
+let api_usage_to_json = function
+  | None -> `Null
+  | Some usage ->
+    `Assoc
+      [ "input_tokens", `Int usage.input_tokens
+      ; "output_tokens", `Int usage.output_tokens
+      ; "cache_creation_input_tokens", `Int usage.cache_creation_input_tokens
+      ; "cache_read_input_tokens", `Int usage.cache_read_input_tokens
+      ; ( "cost_usd"
+        , match usage.cost_usd with
+          | Some cost -> `Float cost
+          | None -> `Null )
+      ]
+;;
+
+let content_block_to_json = function
+  | Text text -> `Assoc [ "type", `String "text"; "text", `String text ]
+  | Thinking { thinking_type; content } ->
+    `Assoc
+      [ "type", `String "thinking"
+      ; "thinking_type", `String thinking_type
+      ; "content", `String content
+      ]
+  | RedactedThinking value ->
+    `Assoc [ "type", `String "redacted_thinking"; "content", `String value ]
+  | ToolUse { id; name; input } ->
+    `Assoc
+      [ "type", `String "tool_use"
+      ; "id", `String id
+      ; "name", `String name
+      ; "input", input
+      ]
+  | ToolResult { tool_use_id; content; is_error; json } ->
+    `Assoc
+      [ "type", `String "tool_result"
+      ; "tool_use_id", `String tool_use_id
+      ; "content", `String content
+      ; "is_error", `Bool is_error
+      ; "json", Option.value ~default:`Null json
+      ]
+  | Image { media_type; data; source_type } ->
+    `Assoc
+      [ "type", `String "image"
+      ; "media_type", `String media_type
+      ; "data", `String data
+      ; "source_type", `String source_type
+      ]
+  | Document { media_type; data; source_type } ->
+    `Assoc
+      [ "type", `String "document"
+      ; "media_type", `String media_type
+      ; "data", `String data
+      ; "source_type", `String source_type
+      ]
+  | Audio { media_type; data; source_type } ->
+    `Assoc
+      [ "type", `String "audio"
+      ; "media_type", `String media_type
+      ; "data", `String data
+      ; "source_type", `String source_type
+      ]
+;;
+
+let child_output_to_json output =
+  let response = output.response in
+  `Assoc
+    [ "type", `String "agent_tool_child_output"
+    ; "response_id", `String response.id
+    ; "model", `String response.model
+    ; "stop_reason", `String (stop_reason_to_string response.stop_reason)
+    ; "text", `String output.text
+    ; "content", `List (List.map content_block_to_json response.content)
+    ; "usage", api_usage_to_json response.usage
+    ]
+;;
+
 (* ── Tool handler ────────────────────────────────────────────── *)
+
+let prompt_param =
+  { name = "prompt"
+  ; description = "The prompt to send to the agent"
+  ; param_type = String
+  ; required = true
+  }
+;;
+
+let parameters config = prompt_param :: config.input_parameters
+
+let prompt_of_input = function
+  | `Assoc fields ->
+    (match List.assoc_opt "prompt" fields with
+     | Some (`String s) -> Ok s
+     | Some _ -> Error "Agent_tool prompt must be a string"
+     | None -> Error "Agent_tool input requires a prompt field")
+  | `String s -> Ok s
+  | json ->
+    Error ("Agent_tool input must be an object or string: " ^ Yojson.Safe.to_string json)
+;;
 
 let make_handler config : Tool.tool_handler =
   fun (input : Yojson.Safe.t) ->
@@ -53,23 +168,47 @@ let make_handler config : Tool.tool_handler =
     Error { message = Error.to_string e; recoverable = false; error_class = None }
 ;;
 
+let parse_child_invocation input =
+  match prompt_of_input input with
+  | Ok prompt -> Ok { prompt; raw_input = input }
+  | Error message -> Error message
+;;
+
+let make_typed_handler config (input : child_invocation) =
+  match config.runner input.prompt with
+  | Ok response ->
+    let text = text_of_response response in
+    let text =
+      match config.output_summarizer with
+      | Some summarize -> summarize text
+      | None -> text
+    in
+    Ok { text; response }
+  | Error e -> Error (Error.to_string e)
+;;
+
 (* ── Construction ────────────────────────────────────────────── *)
 
 let create config =
-  let parameters =
-    { name = "prompt"
-    ; description = "The prompt to send to the agent"
-    ; param_type = String
-    ; required = true
-    }
-    :: config.input_parameters
-  in
   Tool.create
     ~name:config.name
     ~description:config.description
-    ~parameters
+    ~parameters:(parameters config)
     (make_handler config)
 ;;
+
+let create_typed config =
+  Typed_tool.create
+    ~name:config.name
+    ~description:config.description
+    ~params:(parameters config)
+    ~parse:parse_child_invocation
+    ~handler:(make_typed_handler config)
+    ~encode:child_output_to_json
+    ()
+;;
+
+let create_typed_untyped config = config |> create_typed |> Typed_tool.to_untyped
 
 let create_simple ~name ~description runner =
   create { name; description; runner; output_summarizer = None; input_parameters = [] }

--- a/lib/agent_tool.mli
+++ b/lib/agent_tool.mli
@@ -18,6 +18,18 @@
     Captured in a closure at tool creation time. *)
 type agent_runner = string -> (Types.api_response, Error.sdk_error) result
 
+type child_invocation =
+  { prompt : string
+  ; raw_input : Yojson.Safe.t
+    (** Original tool input JSON. Use this for correlation fields that are not
+        part of the prompt contract. *)
+  }
+
+type child_output =
+  { text : string
+  ; response : Types.api_response
+  }
+
 type config =
   { name : string (** Tool name (shown to the parent agent). *)
   ; description : string (** Tool description (shown to the parent agent). *)
@@ -35,5 +47,20 @@ type config =
     calls the runner, and returns the text output as a tool result. *)
 val create : config -> Tool.t
 
+(** Create a typed tool wrapper for agent-as-tool child invocation.
+
+    The typed wrapper parses tool input into {!child_invocation} and encodes
+    the child result as structured JSON via {!child_output_to_json}. Use
+    {!Typed_tool.to_untyped} or {!create_typed_untyped} to register it in
+    existing {!Tool.t}-based dispatch. *)
+val create_typed : config -> (child_invocation, child_output) Typed_tool.t
+
+(** Convenience bridge for existing {!Tool.t}-based dispatch while preserving
+    the structured child-output JSON contract. *)
+val create_typed_untyped : config -> Tool.t
+
 (** Convenience: create from a runner function with minimal config. *)
 val create_simple : name:string -> description:string -> agent_runner -> Tool.t
+
+(** Encode typed child output into stable JSON for tool_result content. *)
+val child_output_to_json : child_output -> Yojson.Safe.t

--- a/test/test_agent_tool.ml
+++ b/test/test_agent_tool.ml
@@ -30,6 +30,32 @@ let error_runner _prompt : (Types.api_response, Error.sdk_error) result =
   Error (Error.Internal "agent crashed")
 ;;
 
+let structured_runner prompt : (Types.api_response, Error.sdk_error) result =
+  Ok
+    { id = "child-run-1"
+    ; model = "child-model"
+    ; stop_reason = EndTurn
+    ; content =
+        [ Text (Printf.sprintf "child: %s" prompt)
+        ; ToolResult
+            { tool_use_id = "toolu-child"
+            ; content = {|{"ok":true}|}
+            ; is_error = false
+            ; json = Some (`Assoc [ "ok", `Bool true ])
+            }
+        ]
+    ; usage =
+        Some
+          { input_tokens = 3
+          ; output_tokens = 5
+          ; cache_creation_input_tokens = 0
+          ; cache_read_input_tokens = 0
+          ; cost_usd = Some 0.01
+          }
+    ; telemetry = None
+    }
+;;
+
 (* ── Basic creation ──────────────────────────────────────────── *)
 
 let test_create_simple () =
@@ -136,6 +162,89 @@ let test_multi_content () =
   | Error { message; _ } -> Alcotest.failf "error: %s" message
 ;;
 
+(* ── Typed child invocation ──────────────────────────────────── *)
+
+let typed_config runner =
+  { Agent_tool.name = "typed_child"
+  ; description = "Typed child agent"
+  ; runner
+  ; output_summarizer = None
+  ; input_parameters = []
+  }
+;;
+
+let test_create_typed_schema () =
+  let tool = Agent_tool.create_typed (typed_config structured_runner) in
+  let schema = Typed_tool.schema tool in
+  Alcotest.(check string) "name" "typed_child" schema.name;
+  Alcotest.(check bool)
+    "has prompt param"
+    true
+    (List.exists (fun (p : Types.tool_param) -> p.name = "prompt") schema.parameters)
+;;
+
+let test_typed_child_invocation_output_json () =
+  let open Yojson.Safe.Util in
+  let tool = Agent_tool.create_typed (typed_config structured_runner) in
+  match Typed_tool.execute tool (`Assoc [ "prompt", `String "hello" ]) with
+  | Error { message; _ } -> Alcotest.failf "error: %s" message
+  | Ok { content } ->
+    let json = Yojson.Safe.from_string content in
+    Alcotest.(check string)
+      "type"
+      "agent_tool_child_output"
+      (json |> member "type" |> to_string);
+    Alcotest.(check string)
+      "response_id"
+      "child-run-1"
+      (json |> member "response_id" |> to_string);
+    Alcotest.(check string) "model" "child-model" (json |> member "model" |> to_string);
+    Alcotest.(check string) "text" "child: hello" (json |> member "text" |> to_string);
+    Alcotest.(check int)
+      "content blocks"
+      2
+      (json |> member "content" |> to_list |> List.length);
+    Alcotest.(check int)
+      "input tokens"
+      3
+      (json |> member "usage" |> member "input_tokens" |> to_int)
+;;
+
+let test_typed_child_invocation_preserves_raw_input () =
+  let open Yojson.Safe.Util in
+  let raw_input = `Assoc [ "prompt", `String "hello"; "parent_run_id", `String "p1" ] in
+  let tool = Agent_tool.create_typed (typed_config structured_runner) in
+  match Typed_tool.execute_parsed tool raw_input with
+  | Error message -> Alcotest.failf "parse error: %s" message
+  | Ok ((input : Agent_tool.child_invocation), Ok output) ->
+    Alcotest.(check string) "prompt" "hello" input.prompt;
+    Alcotest.(check string)
+      "parent_run_id"
+      "p1"
+      (input.raw_input |> member "parent_run_id" |> to_string);
+    Alcotest.(check string) "text" "child: hello" output.text
+  | Ok (_, Error message) -> Alcotest.failf "handler error: %s" message
+;;
+
+let test_typed_untyped_bridge_returns_json () =
+  let open Yojson.Safe.Util in
+  let tool = Agent_tool.create_typed_untyped (typed_config structured_runner) in
+  match Tool.execute tool (`Assoc [ "prompt", `String "bridge" ]) with
+  | Error { message; _ } -> Alcotest.failf "error: %s" message
+  | Ok { content } ->
+    let json = Yojson.Safe.from_string content in
+    Alcotest.(check string) "text" "child: bridge" (json |> member "text" |> to_string)
+;;
+
+let test_typed_missing_prompt_recoverable () =
+  let tool = Agent_tool.create_typed (typed_config structured_runner) in
+  match Typed_tool.execute tool (`Assoc [ "other", `String "x" ]) with
+  | Ok _ -> Alcotest.fail "expected parse error"
+  | Error { recoverable; message; _ } ->
+    Alcotest.(check bool) "recoverable" true recoverable;
+    Alcotest.(check string) "message" "Agent_tool input requires a prompt field" message
+;;
+
 (* ── Suite ───────────────────────────────────────────────────── *)
 
 let () =
@@ -150,5 +259,18 @@ let () =
     ; "summarizer", [ Alcotest.test_case "truncate" `Quick test_output_summarizer ]
     ; "params", [ Alcotest.test_case "extra" `Quick test_extra_parameters ]
     ; "multi_content", [ Alcotest.test_case "joined" `Quick test_multi_content ]
+    ; ( "typed_child"
+      , [ Alcotest.test_case "schema" `Quick test_create_typed_schema
+        ; Alcotest.test_case "output_json" `Quick test_typed_child_invocation_output_json
+        ; Alcotest.test_case
+            "preserves_raw_input"
+            `Quick
+            test_typed_child_invocation_preserves_raw_input
+        ; Alcotest.test_case
+            "untyped_bridge"
+            `Quick
+            test_typed_untyped_bridge_returns_json
+        ; Alcotest.test_case "missing_prompt" `Quick test_typed_missing_prompt_recoverable
+        ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- Add `Agent_tool.child_invocation` / `child_output` plus `create_typed` and `create_typed_untyped` for agent-as-tool child invocation.
- Encode typed child output as structured JSON with response id, model, stop reason, text, content blocks, and usage.
- Keep the existing text-only `Agent_tool.create` behavior unchanged.

## Issue

Part of #522. This PR covers the agents-as-tools typed child invocation slice only. Durable restart restore, A2A resume fixture, nested streaming correlation, and CodeSnippet eval remain separate #522 slices.

## Validation

- `scripts/dune-local.sh build test/test_agent_tool.exe`
- `./_build/default/test/test_agent_tool.exe`
- `ocamlformat --check lib/agent_tool.mli lib/agent_tool.ml test/test_agent_tool.ml`
- `git diff --check`
- `git diff --cached --check`