### PR TITLE
feat(runtime): correlate output deltas with raw trace runs

### DIFF
--- a/docs/EVENT-CATALOG.md
+++ b/docs/EVENT-CATALOG.md
@@ -259,6 +259,9 @@ different payload shapes. Disambiguate by Custom name prefix:
 **Structured completion/failure metadata**:
 - `Runtime.participant_event` now carries optional `raw_trace_run_id`,
   `stop_reason`, `completion_anomaly`, and `failure_cause`.
+- `Runtime.output_delta_event` carries optional `raw_trace_run_id` so streamed
+  child-agent text can be joined to the same EventBus `run_id` and telemetry
+  row as its final completion event.
 - `Runtime.session.pending_input` carries the resumable `input_request`
   while phase is `Input_required`; `Provide_input` emits
   `Input_provided`, clears the payload, and returns the session to

--- a/lib/runtime.ml
+++ b/lib/runtime.ml
@@ -354,6 +354,7 @@ type participant_event =
 type output_delta_event =
   { participant_name : string
   ; delta : string
+  ; raw_trace_run_id : string option [@default None]
   }
 [@@deriving yojson, show]
 

--- a/lib/runtime.mli
+++ b/lib/runtime.mli
@@ -370,6 +370,7 @@ type participant_event =
 type output_delta_event =
   { participant_name : string
   ; delta : string
+  ; raw_trace_run_id : string option [@default None]
   }
 [@@deriving yojson, show]
 

--- a/lib/runtime_evidence.ml
+++ b/lib/runtime_evidence.ml
@@ -232,8 +232,8 @@ let structured_fields_of_event = function
     , None
     , None
     , None )
-  | Agent_output_delta _ ->
-    None, None, None, None, None, None, None, None, None, None, None
+  | Agent_output_delta detail ->
+    None, None, None, None, detail.raw_trace_run_id, None, None, None, None, None, None
   | Agent_completed detail ->
     ( None
     , None

--- a/lib/runtime_server.ml
+++ b/lib/runtime_server.ml
@@ -445,7 +445,7 @@ let generate_report_and_proof store state session_id =
     Ok (final_session, final_report, final_proof))
 ;;
 
-let emit_output_delta store state session_id participant_name delta =
+let emit_output_delta store state session_id participant_name ?raw_trace_run_id delta =
   if String.trim delta = ""
   then Ok ()
   else
@@ -454,7 +454,7 @@ let emit_output_delta store state session_id participant_name delta =
         store
         state
         session_id
-        (Agent_output_delta { participant_name; delta })
+        (Agent_output_delta { participant_name; delta; raw_trace_run_id })
     in
     Ok ()
 ;;
@@ -466,9 +466,12 @@ let emit_delta_text_with_refs
       participant_name
       ~delta_warn_logged
       ~delta_error_count
+      ?raw_trace_run_id
       text
   =
-  match emit_output_delta store state session_id participant_name text with
+  match
+    emit_output_delta store state session_id participant_name ?raw_trace_run_id text
+  with
   | Ok () -> ()
   | Error e ->
     incr delta_error_count;
@@ -513,7 +516,7 @@ let mock_prompt_requires_input prompt =
 ;;
 
 let run_participant
-      store
+      (store : Runtime_store.t)
       state
       session_id
       (resolution : execution_resolution)
@@ -521,16 +524,6 @@ let run_participant
   =
   let delta_warn_logged = ref false in
   let delta_error_count = ref 0 in
-  let emit_delta_text text =
-    emit_delta_text_with_refs
-      store
-      state
-      session_id
-      detail.participant_name
-      ~delta_warn_logged
-      ~delta_error_count
-      text
-  in
   let trace_sink =
     match
       Raw_trace.create_for_session
@@ -550,6 +543,18 @@ let run_participant
         ; Log.S ("error", Error.to_string e)
         ];
       None
+  in
+  let emit_delta_text text =
+    let raw_trace_run_id = latest_raw_trace_run_id trace_sink in
+    emit_delta_text_with_refs
+      store
+      state
+      session_id
+      detail.participant_name
+      ~delta_warn_logged
+      ~delta_error_count
+      ?raw_trace_run_id
+      text
   in
   let completion_anomaly () = completion_anomaly_of_delta_errors delta_error_count in
   match resolution.selected_provider with
@@ -886,6 +891,7 @@ let run_paused_participant_to_completion store state session_id paused runtime_r
   | "mock" | "echo" ->
     let full = mock_runtime_input_response paused.detail runtime_response in
     let emit_delta_text text =
+      let raw_trace_run_id = latest_raw_trace_run_id paused.trace_sink in
       emit_delta_text_with_refs
         store
         state
@@ -893,6 +899,7 @@ let run_paused_participant_to_completion store state session_id paused runtime_r
         participant_name
         ~delta_warn_logged:paused.delta_warn_logged
         ~delta_error_count:paused.delta_error_count
+        ?raw_trace_run_id
         text
     in
     let half = String.length full / 2 in
@@ -910,6 +917,7 @@ let run_paused_participant_to_completion store state session_id paused runtime_r
     Eio.Switch.run
     @@ fun sw ->
     let emit_delta_text text =
+      let raw_trace_run_id = latest_raw_trace_run_id paused.trace_sink in
       emit_delta_text_with_refs
         store
         state
@@ -917,6 +925,7 @@ let run_paused_participant_to_completion store state session_id paused runtime_r
         participant_name
         ~delta_warn_logged:paused.delta_warn_logged
         ~delta_error_count:paused.delta_error_count
+        ?raw_trace_run_id
         text
     in
     let on_event = function

--- a/lib/runtime_server_types.ml
+++ b/lib/runtime_server_types.ml
@@ -58,21 +58,23 @@ let custom_name_of_kind = function
 ;;
 
 let event_bus_run_id_of_event (event : event) =
-  let participant_run_id (participant : participant_event) =
-    match participant.raw_trace_run_id with
+  let clean_run_id = function
     | Some run_id when String.trim run_id <> "" -> Some run_id
     | _ -> None
+  in
+  let participant_run_id (participant : participant_event) =
+    clean_run_id participant.raw_trace_run_id
   in
   match event.kind with
   | Agent_became_live participant | Agent_completed participant | Agent_failed participant
     -> participant_run_id participant
+  | Agent_output_delta detail -> clean_run_id detail.raw_trace_run_id
   | Session_started _
   | Session_settings_updated _
   | Turn_recorded _
   | Input_required _
   | Input_provided _
   | Agent_spawn_requested _
-  | Agent_output_delta _
   | Artifact_attached _
   | Checkpoint_saved _
   | Finalize_requested _

--- a/test/test_runtime.ml
+++ b/test/test_runtime.ml
@@ -200,7 +200,37 @@ let test_runtime_client_roundtrip () =
          wait_until_session ~timeout_s:1.0 (fun () ->
            unwrap (Runtime_client.status client ~session_id:session.session_id))
        in
-       Alcotest.(check bool) "last seq progressed" true (status.last_seq >= 3))
+       Alcotest.(check bool) "last seq progressed" true (status.last_seq >= 3);
+       let events =
+         unwrap (Runtime_client.events client ~session_id:session.session_id ())
+       in
+       let output_delta_run_ids =
+         List.filter_map
+           (fun (event : Runtime.event) ->
+              match event.kind with
+              | Runtime.Agent_output_delta detail -> detail.raw_trace_run_id
+              | _ -> None)
+           events
+       in
+       let completion_run_id =
+         List.find_map
+           (fun (event : Runtime.event) ->
+              match event.kind with
+              | Runtime.Agent_completed detail -> detail.raw_trace_run_id
+              | _ -> None)
+           events
+       in
+       Alcotest.(check bool)
+         "output deltas carry raw trace run id"
+         true
+         (output_delta_run_ids <> []);
+       match completion_run_id with
+       | Some run_id ->
+         Alcotest.(check bool)
+           "delta and completion run ids match"
+           true
+           (List.for_all (String.equal run_id) output_delta_run_ids)
+       | None -> Alcotest.fail "missing completion raw trace run id")
 ;;
 
 let test_runtime_input_required_resume () =

--- a/test/test_runtime_evidence.ml
+++ b/test/test_runtime_evidence.ml
@@ -88,7 +88,8 @@ let all_event_kinds () =
          ~raw_trace_run_id:"raw-1"
          ~stop_reason:"end_turn"
          "alice")
-  ; Agent_output_delta { participant_name = "alice"; delta = "partial" }
+  ; Agent_output_delta
+      { participant_name = "alice"; delta = "partial"; raw_trace_run_id = Some "raw-1" }
   ; Agent_completed
       (participant_event
          ~summary:
@@ -161,6 +162,15 @@ let test_telemetry_report_covers_event_shapes () =
   let json = Runtime_evidence.telemetry_report_to_json report in
   let markdown = Runtime_evidence.telemetry_report_to_markdown report in
   check bool "json has steps" true Yojson.Safe.Util.(json |> member "steps" <> `Null);
+  let output_delta_step =
+    report.steps
+    |> List.find_opt (fun step ->
+      String.equal step.Runtime_evidence.event_name "agent_output_delta")
+  in
+  (match output_delta_step with
+   | Some step ->
+     check (option string) "delta raw trace run id" (Some "raw-1") step.raw_trace_run_id
+   | None -> fail "missing output delta step");
   check bool "markdown mentions anomalies" true (String.contains markdown 'A')
 ;;
 

--- a/test/test_runtime_projection_cov2.ml
+++ b/test/test_runtime_projection_cov2.ml
@@ -450,7 +450,9 @@ let test_apply_agent_output_delta () =
   let p = mk_participant ~name:"alice" ~state:Live () in
   let session = mk_session ~participants:[ p ] () in
   let event =
-    mk_event (Agent_output_delta { participant_name = "alice"; delta = "some output" })
+    mk_event
+      (Agent_output_delta
+         { participant_name = "alice"; delta = "some output"; raw_trace_run_id = None })
   in
   match Runtime_projection.apply_event session event with
   | Ok s ->

--- a/test/test_runtime_server_types.ml
+++ b/test/test_runtime_server_types.ml
@@ -71,6 +71,33 @@ let test_event_bus_run_id_ignores_blank_raw_trace_run_id () =
     (Runtime_server_types.event_bus_run_id_of_event event)
 ;;
 
+let test_event_bus_run_id_uses_output_delta_raw_trace_run_id () =
+  let event =
+    runtime_event
+      (Runtime.Agent_output_delta
+         { participant_name = "worker-1"
+         ; delta = "delta"
+         ; raw_trace_run_id = Some "raw-run-delta"
+         })
+  in
+  Alcotest.(check (option string))
+    "run_id"
+    (Some "raw-run-delta")
+    (Runtime_server_types.event_bus_run_id_of_event event)
+;;
+
+let test_event_bus_run_id_ignores_blank_output_delta_raw_trace_run_id () =
+  let event =
+    runtime_event
+      (Runtime.Agent_output_delta
+         { participant_name = "worker-1"; delta = "delta"; raw_trace_run_id = Some "  " })
+  in
+  Alcotest.(check (option string))
+    "run_id"
+    None
+    (Runtime_server_types.event_bus_run_id_of_event event)
+;;
+
 let test_event_bus_run_id_omits_session_events () =
   let event =
     runtime_event (Runtime.Session_started { goal = "test"; participants = [] })
@@ -117,7 +144,8 @@ let test_custom_name_of_kind_all_variants () =
           }
       , "runtime.agent_spawn_requested" )
     ; Runtime.Agent_became_live participant, "runtime.agent_became_live"
-    ; ( Runtime.Agent_output_delta { participant_name = "worker-1"; delta = "delta" }
+    ; ( Runtime.Agent_output_delta
+          { participant_name = "worker-1"; delta = "delta"; raw_trace_run_id = None }
       , "runtime.agent_output_delta" )
     ; Runtime.Agent_completed participant, "runtime.agent_completed"
     ; Runtime.Agent_failed participant, "runtime.agent_failed"
@@ -180,6 +208,14 @@ let () =
             "ignores blank raw trace run id"
             `Quick
             test_event_bus_run_id_ignores_blank_raw_trace_run_id
+        ; Alcotest.test_case
+            "uses output delta raw trace run id"
+            `Quick
+            test_event_bus_run_id_uses_output_delta_raw_trace_run_id
+        ; Alcotest.test_case
+            "ignores blank output delta raw trace run id"
+            `Quick
+            test_event_bus_run_id_ignores_blank_output_delta_raw_trace_run_id
         ; Alcotest.test_case
             "omits session events"
             `Quick

--- a/test/test_runtime_types.ml
+++ b/test/test_runtime_types.ml
@@ -461,7 +461,8 @@ let test_event_kind () =
         ; completion_anomaly = None
         ; failure_cause = None
         }
-    ; Runtime.Agent_output_delta { participant_name = "sub"; delta = "..." }
+    ; Runtime.Agent_output_delta
+        { participant_name = "sub"; delta = "..."; raw_trace_run_id = Some "wr-1" }
     ; Runtime.Artifact_attached
         { artifact_id = "a1"
         ; name = "r.json"
@@ -484,6 +485,14 @@ let test_event_kind () =
          ~name:"event_kind"
          ek)
     events
+;;
+
+let test_output_delta_legacy_json_defaults_raw_trace_run_id () =
+  let json = `Assoc [ "participant_name", `String "sub"; "delta", `String "legacy" ] in
+  match Runtime.output_delta_event_of_yojson json with
+  | Ok detail ->
+    Alcotest.(check (option string)) "raw trace default" None detail.raw_trace_run_id
+  | Error msg -> Alcotest.failf "output_delta_event parse failed: %s" msg
 ;;
 
 let test_event () =
@@ -552,6 +561,10 @@ let () =
     ; "command", [ Alcotest.test_case "variants" `Quick test_command ]
     ; ( "events"
       , [ Alcotest.test_case "event_kind all" `Quick test_event_kind
+        ; Alcotest.test_case
+            "output delta legacy json"
+            `Quick
+            test_output_delta_legacy_json_defaults_raw_trace_run_id
         ; Alcotest.test_case "event" `Quick test_event
         ] )
     ]


### PR DESCRIPTION
## Summary
- add optional raw_trace_run_id to Runtime.output_delta_event with legacy JSON default
- propagate latest raw trace run id into streamed runtime output deltas, including resumed participants
- map output deltas to EventBus run_id and telemetry raw_trace_run_id so deltas join with completion events
- document the runtime event catalog change

## Validation
- scripts/dune-local.sh build test/test_runtime_types.exe test/test_runtime_server_types.exe test/test_runtime_evidence.exe test/test_runtime_projection_cov2.exe test/test_runtime.exe bin/oas_runtime.exe
- ./_build/default/test/test_runtime_types.exe
- ./_build/default/test/test_runtime_server_types.exe
- ./_build/default/test/test_runtime_evidence.exe
- ./_build/default/test/test_runtime_projection_cov2.exe
- ./_build/default/test/test_runtime.exe -q
- ocamlformat --check lib/runtime.ml lib/runtime.mli lib/runtime_server.ml lib/runtime_server_types.ml lib/runtime_evidence.ml test/test_runtime.ml test/test_runtime_types.ml test/test_runtime_server_types.ml test/test_runtime_evidence.ml test/test_runtime_projection_cov2.ml
- git diff --check
- git diff --cached --check

Refs #522