### PR TITLE
feat(eval): gate CodeSnippet adoption criteria

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -131,6 +131,7 @@ module Harness_runner = Harness_runner
 module Eval = Eval
 module Eval_collector = Eval_collector
 module Eval_otel_bridge = Eval_otel_bridge
+module Code_snippet_eval = Code_snippet_eval
 module Trajectory = Trajectory
 module Sandbox_runner = Sandbox_runner
 module Metric_contract = Metric_contract

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -104,6 +104,7 @@ module Harness_runner = Harness_runner
 module Eval = Eval
 module Eval_collector = Eval_collector
 module Eval_otel_bridge = Eval_otel_bridge
+module Code_snippet_eval = Code_snippet_eval
 module Trajectory = Trajectory
 module Sandbox_runner = Sandbox_runner
 module Metric_contract = Metric_contract

--- a/lib/code_snippet_eval.ml
+++ b/lib/code_snippet_eval.ml
@@ -1,0 +1,209 @@
+(** Code-snippet tool strategy evaluation gate. *)
+
+let experimental_env_var = "OAS_EXPERIMENTAL_CODE_SNIPPET"
+
+type mode_metrics =
+  { turns : int
+  ; llm_calls : int
+  ; tokens : int
+  ; passed : bool
+  }
+
+type comparison =
+  { task_name : string
+  ; json_mode : mode_metrics
+  ; snippet_mode : mode_metrics
+  ; call_reduction_pct : float
+  ; tokens_saved : int
+  }
+
+type gate =
+  { min_tasks : int
+  ; min_avg_call_reduction_pct : float
+  ; require_no_pass_regression : bool
+  }
+
+type gate_result =
+  { passed : bool
+  ; task_count : int
+  ; avg_call_reduction_pct : float
+  ; json_passes : int
+  ; snippet_passes : int
+  ; failures : string list
+  }
+
+type comparison_error =
+  | Empty_task_name
+  | Negative_metric of
+      { task_name : string
+      ; mode : string
+      ; field : string
+      ; value : int
+      }
+  | Nonpositive_json_llm_calls of string
+
+let default_gate =
+  { min_tasks = 10; min_avg_call_reduction_pct = 25.0; require_no_pass_regression = true }
+;;
+
+let show_comparison_error = function
+  | Empty_task_name -> "task_name must not be empty"
+  | Negative_metric { task_name; mode; field; value } ->
+    Printf.sprintf "%s %s.%s must be non-negative, got %d" task_name mode field value
+  | Nonpositive_json_llm_calls task_name ->
+    Printf.sprintf "%s json_mode.llm_calls must be positive" task_name
+;;
+
+let validate_mode ~task_name ~mode_name mode =
+  let fields =
+    [ "turns", mode.turns; "llm_calls", mode.llm_calls; "tokens", mode.tokens ]
+  in
+  List.find_map
+    (fun (field, value) ->
+       if value < 0
+       then Some (Negative_metric { task_name; mode = mode_name; field; value })
+       else None)
+    fields
+;;
+
+let compare_task ~task_name ~json_mode ~snippet_mode =
+  let task_name = String.trim task_name in
+  if String.equal task_name ""
+  then Error Empty_task_name
+  else (
+    match validate_mode ~task_name ~mode_name:"json_mode" json_mode with
+    | Some err -> Error err
+    | None ->
+      (match validate_mode ~task_name ~mode_name:"snippet_mode" snippet_mode with
+       | Some err -> Error err
+       | None ->
+         if json_mode.llm_calls <= 0
+         then Error (Nonpositive_json_llm_calls task_name)
+         else (
+           let call_reduction_pct =
+             float_of_int (json_mode.llm_calls - snippet_mode.llm_calls)
+             /. float_of_int json_mode.llm_calls
+             *. 100.0
+           in
+           Ok
+             { task_name
+             ; json_mode
+             ; snippet_mode
+             ; call_reduction_pct
+             ; tokens_saved = json_mode.tokens - snippet_mode.tokens
+             })))
+;;
+
+let count_passes comparisons ~(select : comparison -> mode_metrics) =
+  List.fold_left
+    (fun acc comparison ->
+       let mode = select comparison in
+       if mode.passed then acc + 1 else acc)
+    0
+    comparisons
+;;
+
+let average_call_reduction = function
+  | [] -> 0.0
+  | comparisons ->
+    let total =
+      List.fold_left
+        (fun acc comparison -> acc +. comparison.call_reduction_pct)
+        0.0
+        comparisons
+    in
+    total /. float_of_int (List.length comparisons)
+;;
+
+let evaluate ?(gate = default_gate) comparisons =
+  let task_count = List.length comparisons in
+  let avg_call_reduction_pct = average_call_reduction comparisons in
+  let json_passes = count_passes comparisons ~select:(fun c -> c.json_mode) in
+  let snippet_passes = count_passes comparisons ~select:(fun c -> c.snippet_mode) in
+  let failures =
+    []
+    |> (fun acc ->
+    if task_count < gate.min_tasks
+    then Printf.sprintf "task_count %d < required %d" task_count gate.min_tasks :: acc
+    else acc)
+    |> (fun acc ->
+    if avg_call_reduction_pct < gate.min_avg_call_reduction_pct
+    then
+      Printf.sprintf
+        "avg_call_reduction_pct %.2f < required %.2f"
+        avg_call_reduction_pct
+        gate.min_avg_call_reduction_pct
+      :: acc
+    else acc)
+    |> (fun acc ->
+    if gate.require_no_pass_regression && snippet_passes < json_passes
+    then
+      Printf.sprintf "snippet_passes %d < json_passes %d" snippet_passes json_passes
+      :: acc
+    else acc)
+    |> List.rev
+  in
+  { passed = failures = []
+  ; task_count
+  ; avg_call_reduction_pct
+  ; json_passes
+  ; snippet_passes
+  ; failures
+  }
+;;
+
+let metric name value =
+  { Eval.name; value; unit_ = None; tags = [ "strategy", "code_snippet" ] }
+;;
+
+let metrics_of_gate_result result =
+  [ metric "code_snippet_eval_task_count" (Eval.Int_val result.task_count)
+  ; metric
+      "code_snippet_eval_avg_call_reduction_pct"
+      (Eval.Float_val result.avg_call_reduction_pct)
+  ; metric "code_snippet_eval_json_passes" (Eval.Int_val result.json_passes)
+  ; metric "code_snippet_eval_snippet_passes" (Eval.Int_val result.snippet_passes)
+  ]
+;;
+
+let verdict_of_gate_result result =
+  let score = result.avg_call_reduction_pct /. 100.0 |> Float.max 0.0 |> Float.min 1.0 in
+  let evidence =
+    [ Printf.sprintf "task_count=%d" result.task_count
+    ; Printf.sprintf "avg_call_reduction_pct=%.2f" result.avg_call_reduction_pct
+    ; Printf.sprintf "json_passes=%d" result.json_passes
+    ; Printf.sprintf "snippet_passes=%d" result.snippet_passes
+    ]
+    @ List.map (Printf.sprintf "failure=%s") result.failures
+  in
+  { Harness.passed = result.passed
+  ; score = Some score
+  ; evidence
+  ; detail =
+      (if result.passed
+       then Some "CodeSnippet adoption gate passed"
+       else Some "CodeSnippet adoption gate failed")
+  }
+;;
+
+let truthy_env value =
+  match String.lowercase_ascii (String.trim value) with
+  | "1" | "true" | "yes" | "on" -> true
+  | _ -> false
+;;
+
+let is_experiment_enabled ?(getenv = Sys.getenv_opt) () =
+  match getenv experimental_env_var with
+  | Some value -> truthy_env value
+  | None -> false
+;;
+
+let require_experiment_enabled ?getenv () =
+  if is_experiment_enabled ?getenv ()
+  then Ok ()
+  else
+    Error
+      (Printf.sprintf
+         "%s must be truthy to run CodeSnippet experiments"
+         experimental_env_var)
+;;

--- a/lib/code_snippet_eval.mli
+++ b/lib/code_snippet_eval.mli
@@ -1,0 +1,69 @@
+(** Code-snippet tool strategy evaluation gate.
+
+    This module intentionally does not execute snippets.  It records the
+    quantitative adoption criteria from RFC-OAS-004 and issue #522 so the
+    experimental strategy cannot be promoted without a reproducible 10+ task
+    comparison against JSON tool-call mode.
+
+    @stability Experimental *)
+
+val experimental_env_var : string
+
+type mode_metrics =
+  { turns : int
+  ; llm_calls : int
+  ; tokens : int
+  ; passed : bool
+  }
+
+type comparison =
+  { task_name : string
+  ; json_mode : mode_metrics
+  ; snippet_mode : mode_metrics
+  ; call_reduction_pct : float
+  ; tokens_saved : int
+  }
+
+type gate =
+  { min_tasks : int
+  ; min_avg_call_reduction_pct : float
+  ; require_no_pass_regression : bool
+  }
+
+type gate_result =
+  { passed : bool
+  ; task_count : int
+  ; avg_call_reduction_pct : float
+  ; json_passes : int
+  ; snippet_passes : int
+  ; failures : string list
+  }
+
+type comparison_error =
+  | Empty_task_name
+  | Negative_metric of
+      { task_name : string
+      ; mode : string
+      ; field : string
+      ; value : int
+      }
+  | Nonpositive_json_llm_calls of string
+
+val default_gate : gate
+val show_comparison_error : comparison_error -> string
+
+val compare_task
+  :  task_name:string
+  -> json_mode:mode_metrics
+  -> snippet_mode:mode_metrics
+  -> (comparison, comparison_error) result
+
+val evaluate : ?gate:gate -> comparison list -> gate_result
+val metrics_of_gate_result : gate_result -> Eval.metric list
+val verdict_of_gate_result : gate_result -> Harness.verdict
+val is_experiment_enabled : ?getenv:(string -> string option) -> unit -> bool
+
+val require_experiment_enabled
+  :  ?getenv:(string -> string option)
+  -> unit
+  -> (unit, string) result

--- a/test/dune
+++ b/test/dune
@@ -60,6 +60,7 @@
   test_checkpoint_store
   test_checkpoint_validation
   test_cli_common_subprocess
+  test_code_snippet_eval
   test_clone
   test_complete_ext
   test_completion_contract_tool_use_calls
@@ -282,6 +283,7 @@
   test_checkpoint_store
   test_checkpoint_validation
   test_cli_common_subprocess
+  test_code_snippet_eval
   test_clone
   test_complete_ext
   test_completion_contract_tool_use_calls

--- a/test/test_code_snippet_eval.ml
+++ b/test/test_code_snippet_eval.ml
@@ -1,0 +1,180 @@
+open Agent_sdk
+open Code_snippet_eval
+
+let mode ?(turns = 1) ?(tokens = 100) ?(passed = true) llm_calls =
+  { Code_snippet_eval.turns; llm_calls; tokens; passed }
+;;
+
+let comparison
+      ?(json_passed = true)
+      ?(snippet_passed = true)
+      name
+      json_calls
+      snippet_calls
+  =
+  match
+    Code_snippet_eval.compare_task
+      ~task_name:name
+      ~json_mode:(mode ~passed:json_passed json_calls)
+      ~snippet_mode:(mode ~passed:snippet_passed snippet_calls)
+  with
+  | Ok comparison -> comparison
+  | Error err -> Alcotest.fail (Code_snippet_eval.show_comparison_error err)
+;;
+
+let ten_good_comparisons () =
+  List.init 10 (fun index -> comparison (Printf.sprintf "task-%02d" index) 4 3)
+;;
+
+let test_compare_task_computes_reduction () =
+  let c =
+    match
+      Code_snippet_eval.compare_task
+        ~task_name:" search-read-edit "
+        ~json_mode:(mode ~turns:3 ~tokens:900 4)
+        ~snippet_mode:(mode ~turns:1 ~tokens:650 2)
+    with
+    | Ok c -> c
+    | Error err -> Alcotest.fail (Code_snippet_eval.show_comparison_error err)
+  in
+  Alcotest.(check string) "trimmed name" "search-read-edit" c.task_name;
+  Alcotest.(check (float 0.001)) "call reduction" 50.0 c.call_reduction_pct;
+  Alcotest.(check int) "tokens saved" 250 c.tokens_saved
+;;
+
+let test_compare_task_rejects_invalid_metrics () =
+  match
+    Code_snippet_eval.compare_task
+      ~task_name:"bad"
+      ~json_mode:(mode (-1))
+      ~snippet_mode:(mode 1)
+  with
+  | Error (Negative_metric { mode; field; value; _ }) ->
+    Alcotest.(check string) "mode" "json_mode" mode;
+    Alcotest.(check string) "field" "llm_calls" field;
+    Alcotest.(check int) "value" (-1) value
+  | Error err -> Alcotest.fail (Code_snippet_eval.show_comparison_error err)
+  | Ok _ -> Alcotest.fail "expected invalid metric error"
+;;
+
+let test_gate_requires_ten_tasks () =
+  let result =
+    Code_snippet_eval.evaluate [ comparison "task-1" 4 2; comparison "task-2" 4 2 ]
+  in
+  Alcotest.(check bool) "failed" false result.passed;
+  Alcotest.(check int) "task count" 2 result.task_count;
+  Alcotest.(check bool)
+    "mentions task_count"
+    true
+    (List.exists
+       (fun failure -> String.starts_with ~prefix:"task_count" failure)
+       result.failures)
+;;
+
+let test_gate_accepts_quantitative_success () =
+  let result = Code_snippet_eval.evaluate (ten_good_comparisons ()) in
+  Alcotest.(check bool) "passed" true result.passed;
+  Alcotest.(check int) "task count" 10 result.task_count;
+  Alcotest.(check (float 0.001)) "avg reduction" 25.0 result.avg_call_reduction_pct;
+  Alcotest.(check int) "json passes" 10 result.json_passes;
+  Alcotest.(check int) "snippet passes" 10 result.snippet_passes
+;;
+
+let test_gate_rejects_low_reduction () =
+  let low =
+    List.init 10 (fun index -> comparison (Printf.sprintf "low-%02d" index) 4 4)
+  in
+  let result = Code_snippet_eval.evaluate low in
+  Alcotest.(check bool) "failed" false result.passed;
+  Alcotest.(check bool)
+    "mentions reduction"
+    true
+    (List.exists
+       (fun failure -> String.starts_with ~prefix:"avg_call_reduction_pct" failure)
+       result.failures)
+;;
+
+let test_gate_rejects_pass_regression () =
+  let comparisons =
+    List.init 10 (fun index ->
+      comparison ~snippet_passed:(index <> 0) (Printf.sprintf "pass-%02d" index) 4 2)
+  in
+  let result = Code_snippet_eval.evaluate comparisons in
+  Alcotest.(check bool) "failed" false result.passed;
+  Alcotest.(check int) "json passes" 10 result.json_passes;
+  Alcotest.(check int) "snippet passes" 9 result.snippet_passes
+;;
+
+let test_gate_exports_eval_metrics_and_verdict () =
+  let result = Code_snippet_eval.evaluate (ten_good_comparisons ()) in
+  let metrics = Code_snippet_eval.metrics_of_gate_result result in
+  let verdict = Code_snippet_eval.verdict_of_gate_result result in
+  Alcotest.(check int) "metrics" 4 (List.length metrics);
+  Alcotest.(check bool) "verdict passed" true verdict.passed;
+  Alcotest.(check (option (float 0.001))) "score" (Some 0.25) verdict.score;
+  Alcotest.(check bool)
+    "evidence includes task count"
+    true
+    (List.exists (String.equal "task_count=10") verdict.evidence)
+;;
+
+let getenv_true name =
+  if String.equal name Code_snippet_eval.experimental_env_var then Some "true" else None
+;;
+
+let getenv_false name =
+  if String.equal name Code_snippet_eval.experimental_env_var then Some "false" else None
+;;
+
+let test_experimental_guard () =
+  Alcotest.(check bool)
+    "enabled"
+    true
+    (Code_snippet_eval.is_experiment_enabled ~getenv:getenv_true ());
+  Alcotest.(check bool)
+    "disabled"
+    false
+    (Code_snippet_eval.is_experiment_enabled ~getenv:getenv_false ());
+  (match Code_snippet_eval.require_experiment_enabled ~getenv:getenv_true () with
+   | Ok () -> ()
+   | Error err -> Alcotest.fail err);
+  match Code_snippet_eval.require_experiment_enabled ~getenv:getenv_false () with
+  | Error _ -> ()
+  | Ok () -> Alcotest.fail "expected disabled experiment guard"
+;;
+
+let () =
+  Alcotest.run
+    "Code_snippet_eval"
+    [ ( "comparison"
+      , [ Alcotest.test_case
+            "computes reduction"
+            `Quick
+            test_compare_task_computes_reduction
+        ; Alcotest.test_case
+            "rejects invalid metrics"
+            `Quick
+            test_compare_task_rejects_invalid_metrics
+        ] )
+    ; ( "gate"
+      , [ Alcotest.test_case "requires ten tasks" `Quick test_gate_requires_ten_tasks
+        ; Alcotest.test_case
+            "accepts success"
+            `Quick
+            test_gate_accepts_quantitative_success
+        ; Alcotest.test_case
+            "rejects low reduction"
+            `Quick
+            test_gate_rejects_low_reduction
+        ; Alcotest.test_case
+            "rejects pass regression"
+            `Quick
+            test_gate_rejects_pass_regression
+        ; Alcotest.test_case
+            "exports metrics and verdict"
+            `Quick
+            test_gate_exports_eval_metrics_and_verdict
+        ] )
+    ; "guard", [ Alcotest.test_case "experimental env" `Quick test_experimental_guard ]
+    ]
+;;


### PR DESCRIPTION
## Summary
- add Code_snippet_eval as the RFC-OAS-004 adoption gate for #522
- require 10+ task comparisons, >=25% average LLM-call reduction, and no snippet pass-rate regression before promotion
- expose gate metrics/verdicts through existing Eval/Harness types and require OAS_EXPERIMENTAL_CODE_SNIPPET for experiments

## Validation
- scripts/dune-local.sh build test/test_code_snippet_eval.exe
- ./_build/default/test/test_code_snippet_eval.exe
- ocamlformat --check lib/code_snippet_eval.ml lib/code_snippet_eval.mli lib/agent_sdk.ml lib/agent_sdk.mli test/test_code_snippet_eval.ml
- git diff --check
- git diff --cached --check

Refs #522