### PR TITLE
test: anchor A2A resume on runtime replay

### DIFF
--- a/docs/EVENT-CATALOG.md
+++ b/docs/EVENT-CATALOG.md
@@ -23,12 +23,14 @@ of external relevance.
 | 3 | **Durable journal** | `Durable_event` | In-memory append-only + JSONL | Crash recovery + event-sourced replay |
 | 4 | **Runtime protocol** | `Runtime` + `Runtime_server_*` | stdout JSON-RPC-ish protocol | `oas_runtime` subprocess consumers |
 | 5 | **LLM wire stream** | `Types.sse_event` | Provider-specific SSE → normalized | Internal (streaming accumulation) |
-| 6 | **A2A task stream** | `A2a_server.task_event` | HTTP SSE | External A2A clients |
+| 6 | **Runtime resume replay** | `Runtime_sync.window` | JSON replay window | External resume/A2A adapters |
 
 Surfaces 3 and 4 **bridge into** Surface 1 via `Journal_bridge` and
-`Runtime_server_types.emit_event` respectively (see §7).
+`Runtime_server_types.emit_event` respectively (see §4.2 and §5.1).
 
-Surfaces 5 and 6 are independent and do not flow to Event_bus.
+Surface 5 is independent and does not flow to Event_bus. Surface 6 replays
+Surface 4 events for cursor-based resume; it does not publish additional
+Event_bus payloads.
 
 ---
 
@@ -349,17 +351,28 @@ around that) become observable.
 
 ---
 
-## 7. Surface 6: A2A task stream
+## 7. Surface 6: Runtime resume replay
 
-**Header**: `lib/protocol/a2a_server.ml`. Stability: Evolving.
+**Header**: `lib/runtime_sync.mli`; event truth:
+`lib/runtime.mli`. Stability: Evolving.
 
-HTTP SSE stream emitted by the A2A protocol server for external A2A
-clients. **Independent of Event_bus.**
+Current OAS core does not expose a `lib/protocol/a2a_server.ml` HTTP task
+stream. External A2A or resume-capable adapters should bridge protocol
+messages onto Runtime commands and consume `Runtime_sync.window` for replay.
 
-| Variant | Purpose |
-|---------|---------|
-| `TaskStateChanged` | Task transitioned to an intermediate state |
-| `TaskCompleted` | Task reached a terminal state |
+| Runtime surface | Adapter purpose |
+|-----------------|-----------------|
+| `Runtime.Request_input` / `Runtime.Input_required` | Pause a runtime session with a durable `pending_input` payload |
+| `Runtime.Provide_input` / `Runtime.Input_provided` | Resume the matching input request and clear `pending_input` |
+| `Runtime_sync.window` | Return cursor-based replay rows for events after `after_seq` |
+
+**Contract**:
+- The replay stream is keyed by `stream_id`; adapters may use their own
+  external task/message identifier as long as cursors remain stream-local.
+- Resume fixtures must assert both pause and resume events:
+  `Input_required` followed by matching `Input_provided`.
+- This surface derives from Runtime events. It does not reintroduce the legacy
+  `TaskStateChanged` / `TaskCompleted` task stream.
 
 ---
 

--- a/docs/RUNTIME-OUTPUT-SCHEMA-INDEX.md
+++ b/docs/RUNTIME-OUTPUT-SCHEMA-INDEX.md
@@ -12,7 +12,7 @@ Machine-readable catalog: `docs/schema-surfaces/runtime-output-surfaces.v1.json`
 | --- | --- | --- | --- |
 | `oas.event_bus.v1` | In-process agent lifecycle events | `lib/event_bus.mli`, `docs/EVENT-CATALOG.md` | Event bus and envelope tests |
 | `oas.runtime_protocol.v1` | `oas_runtime` NDJSON protocol messages | `lib/runtime.mli` | Runtime protocol roundtrip tests |
-| `oas.runtime_sync_window.v1` | Runtime replay window JSON | `lib/runtime_sync.mli`, `docs/schemas/runtime-sync-window-v1.json` | `Runtime_sync.of_json` and schema version tests |
+| `oas.runtime_sync_window.v1` | Runtime replay window JSON for offline and external resume adapters | `lib/runtime_sync.mli`, `docs/schemas/runtime-sync-window-v1.json` | `Runtime_sync.of_json`, schema version, and input pause/resume fixture tests |
 | `oas.runtime_report.v1` | Runtime session report artifact / protocol response | `lib/runtime.mli`, `lib/runtime_projection.mli` | Runtime type and projection tests |
 | `oas.runtime_proof.v1` | Runtime proof artifact / protocol response | `lib/runtime.mli`, `lib/runtime_projection.mli` | Runtime type and proof projection tests |
 | `oas.runtime_telemetry_report.v1` | Runtime telemetry JSON/Markdown artifacts | `lib/runtime_evidence.mli`, `lib/sessions_types.mli` | Runtime session artifact and session type tests |

--- a/docs/schema-surfaces/runtime-output-surfaces.v1.json
+++ b/docs/schema-surfaces/runtime-output-surfaces.v1.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-05-14",
+  "updated_at": "2026-05-25",
   "description": "Operator-facing index of OAS runtime output and schema surfaces.",
   "surfaces": [
     {
@@ -36,14 +36,14 @@
       "kind": "json_schema",
       "owner": "OAS",
       "producer": "Runtime_sync",
-      "consumer": ["offline/runtime sync clients", "downstream replay tooling"],
+      "consumer": ["offline/runtime sync clients", "downstream replay tooling", "external resume/A2A adapters"],
       "wire_or_artifact": "Runtime sync window JSON",
       "schema_source": ["lib/runtime_sync.mli", "docs/schemas/runtime-sync-window-v1.json"],
       "validator": "Runtime_sync.of_json plus schema_version gate",
       "tests": ["test/test_runtime_sync.ml"],
       "stability": "evolving",
       "version_field": "schema_version",
-      "notes": "Replay window over Runtime.event rows and Event_envelope metadata."
+      "notes": "Replay window over Runtime.event rows and Event_envelope metadata, including the Runtime input pause/resume fixture used by external resume/A2A adapters."
     },
     {
       "id": "oas.runtime_report.v1",

--- a/test/test_runtime_sync.ml
+++ b/test/test_runtime_sync.ml
@@ -8,9 +8,35 @@ let mk_event seq =
   }
 ;;
 
+let mk_runtime_event seq kind = { Runtime.seq; ts = float_of_int seq; kind }
+
 let expect_ok label = function
   | Ok value -> value
   | Error _ -> failf "%s failed" label
+;;
+
+let decode_window label window =
+  Runtime_sync.to_json window |> Runtime_sync.of_json |> expect_ok label
+;;
+
+let apply_event label session event =
+  match Runtime_projection.apply_event session event with
+  | Ok session -> session
+  | Error err -> failf "%s failed: %s" label (Error.to_string err)
+;;
+
+let apply_records label session (records : Runtime_sync.event_record list) =
+  List.fold_left
+    (fun session (record : Runtime_sync.event_record) ->
+       apply_event label session record.event)
+    session
+    records
+;;
+
+let single_window_event label (window : Runtime_sync.window) =
+  match window.events with
+  | [ record ] -> record.event
+  | records -> failf "%s expected one event, got %d" label (List.length records)
 ;;
 
 let test_make_window_sets_cursors () =
@@ -193,6 +219,97 @@ let test_merge_offline_events_reports_conflict () =
     check int "conflict seq" 2 (List.hd conflicts).Runtime_sync.seq
 ;;
 
+let test_a2a_resume_fixture_uses_runtime_input_events () =
+  let stream_id = "a2a-task/task-42" in
+  let start_request : Runtime.start_request =
+    { session_id = Some "session-a2a-resume"
+    ; goal = "Resume external task"
+    ; participants = [ "planner" ]
+    ; provider = Some "mock"
+    ; model = None
+    ; permission_mode = Some "default"
+    ; system_prompt = None
+    ; max_turns = Some 3
+    ; workdir = None
+    }
+  in
+  let input_request : Runtime.input_request =
+    { request_id = "input-task-42"
+    ; participant_name = Some "planner"
+    ; question = "Provide task resume payload"
+    ; schema =
+        Some
+          (`Assoc
+              [ "type", `String "object"
+              ; "required", `List [ `String "decision" ]
+              ; "properties", `Assoc [ "decision", `Assoc [ "type", `String "string" ] ]
+              ])
+    ; timeout_s = Some 60.0
+    ; created_at = 2.0
+    }
+  in
+  let session_started =
+    mk_runtime_event
+      1
+      (Runtime.Session_started
+         { goal = start_request.goal; participants = start_request.participants })
+  in
+  let input_required = mk_runtime_event 2 (Runtime.Input_required input_request) in
+  let input_provided =
+    mk_runtime_event
+      3
+      (Runtime.Input_provided
+         { request_id = input_request.request_id
+         ; participant_name = input_request.participant_name
+         ; response = Runtime.Input_answer (`Assoc [ "decision", `String "approve" ])
+         })
+  in
+  let pause_events = [ session_started; input_required ] in
+  let events = pause_events @ [ input_provided ] in
+  let running =
+    Runtime_projection.initial_session start_request
+    |> fun session -> apply_event "session start" session session_started
+  in
+  let pause_window =
+    Runtime_sync.make_window
+      ~artifact_refs:[ "a2a://task/task-42" ]
+      ~stream_id
+      ~after_seq:1
+      pause_events
+    |> decode_window "pause window decode"
+  in
+  check int "pause cursor" 1 pause_window.cursor.after_seq;
+  check int "pause next cursor" 2 pause_window.next_cursor.after_seq;
+  (match single_window_event "pause" pause_window with
+   | { kind = Runtime.Input_required request; _ } ->
+     check string "pause request id" input_request.request_id request.request_id
+   | event -> failf "expected Input_required, got %s" (Runtime.show_event event));
+  let paused = apply_records "pause replay" running pause_window.events in
+  check bool "paused phase" true (paused.phase = Runtime.Input_required);
+  (match paused.pending_input with
+   | Some pending ->
+     check string "pending input request" input_request.request_id pending.request_id
+   | None -> fail "missing pending input after pause replay");
+  let resume_window =
+    Runtime_sync.make_window
+      ~artifact_refs:[ "a2a://task/task-42" ]
+      ~stream_id
+      ~after_seq:2
+      events
+    |> decode_window "resume window decode"
+  in
+  check int "resume cursor" 2 resume_window.cursor.after_seq;
+  check int "resume next cursor" 3 resume_window.next_cursor.after_seq;
+  (match single_window_event "resume" resume_window with
+   | { kind = Runtime.Input_provided detail; _ } ->
+     check string "resume request id" input_request.request_id detail.request_id
+   | event -> failf "expected Input_provided, got %s" (Runtime.show_event event));
+  let resumed = apply_records "resume replay" paused resume_window.events in
+  check bool "resumed phase" true (resumed.phase = Runtime.Running);
+  check bool "pending cleared" true (Option.is_none resumed.pending_input);
+  check int "resume counts as turn" 1 resumed.turn_count
+;;
+
 let () =
   run
     "Runtime_sync"
@@ -231,6 +348,12 @@ let () =
             "reports committed sequence conflicts"
             `Quick
             test_merge_offline_events_reports_conflict
+        ] )
+    ; ( "resume_fixture"
+      , [ test_case
+            "A2A adapter pause/resume uses Runtime input replay"
+            `Quick
+            test_a2a_resume_fixture_uses_runtime_input_events
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- replace the stale Event Catalog A2A task stream entry with the current Runtime_sync resume replay surface
- document external resume/A2A adapters as Runtime input pause/resume consumers instead of reviving A2a_server
- add a Runtime_sync fixture that replays Input_required and matching Input_provided through Runtime_projection

Closes #1752

## Verification
- scripts/dune-local.sh build test/test_runtime_sync.exe test/test_schema_surface_index.exe
- ./_build/default/test/test_runtime_sync.exe
- ./_build/default/test/test_schema_surface_index.exe
- opam exec -- ocamlformat --check test/test_runtime_sync.ml
- git diff --check
- scripts/lint-core-cdal-boundary.sh