### PR TITLE
test: cover harness cases and artifacts

### DIFF
--- a/test/test_artifact_service.ml
+++ b/test/test_artifact_service.ml
@@ -1,10 +1,52 @@
-(** Unit tests for Artifact_service — pure helpers exposed for kind/mime
-    coercion. The file-IO surface (`save_text_internal`, `list`, `get_text`)
-    requires Eio and a Runtime_store; those are exercised by integration
-    tests, not here. *)
+(** Unit tests for Artifact_service — kind/mime coercion and persisted
+    artifact descriptor behavior. *)
 
 open Agent_sdk
 open Alcotest
+
+let with_temp_dir f =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "oas-artifact-service-%d-%06x"
+         (Unix.getpid ())
+         (Random.int 0xFFFFFF))
+  in
+  Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () -> ignore (Sys.command (Printf.sprintf "rm -rf %s" dir)))
+    (fun () -> f dir)
+;;
+
+let mk_session ?(artifacts = []) session_id : Runtime.session =
+  { session_id
+  ; goal = "artifact coverage"
+  ; title = Some "Artifact coverage"
+  ; tag = Some "test"
+  ; permission_mode = Some "default"
+  ; phase = Runtime.Running
+  ; created_at = 1.0
+  ; updated_at = 2.0
+  ; provider = None
+  ; model = None
+  ; system_prompt = None
+  ; max_turns = 3
+  ; workdir = None
+  ; planned_participants = []
+  ; participants = []
+  ; artifacts
+  ; pending_input = None
+  ; turn_count = 0
+  ; last_seq = 0
+  ; outcome = None
+  }
+;;
+
+let unwrap_result = function
+  | Ok value -> value
+  | Error e -> fail (Error.to_string e)
+;;
 
 (* ── extension_of_kind ────────────────────────────────── *)
 
@@ -126,6 +168,157 @@ let test_consistency_table () =
     ]
 ;;
 
+(* ── persisted artifacts ───────────────────────────────── *)
+
+let test_save_text_internal_persists_descriptor () =
+  with_temp_dir (fun root ->
+    let store = unwrap_result (Runtime_store.create ~root ()) in
+    let artifact =
+      unwrap_result
+        (Artifact_service.save_text_internal
+           store
+           ~session_id:"sess-art"
+           ~name:" Report / One "
+           ~kind:"markdown"
+           ~content:"# report\n")
+    in
+    check string "name preserved" " Report / One " artifact.name;
+    check string "kind preserved" "markdown" artifact.kind;
+    check string "mime" "text/markdown" artifact.mime_type;
+    check int "size" 9 artifact.size_bytes;
+    (match artifact.path with
+     | Some path ->
+       check bool "sanitized filename" true (String.ends_with ~suffix:".md" path);
+       check string "content" "# report\n" (unwrap_result (Runtime_store.load_text path))
+     | None -> fail "expected persisted path");
+    check bool "inline is absent" true (Option.is_none artifact.inline_content))
+;;
+
+let test_persisted_path_rejects_inline_only_artifact () =
+  let artifact : Runtime.artifact =
+    { artifact_id = "inline-1"
+    ; name = "inline"
+    ; kind = "text"
+    ; mime_type = "text/plain"
+    ; path = None
+    ; inline_content = Some "body"
+    ; size_bytes = 4
+    ; created_at = 1.0
+    }
+  in
+  match Artifact_service.persisted_path artifact with
+  | Ok _ -> fail "expected inline-only artifact to fail persisted_path"
+  | Error _ -> ()
+;;
+
+let test_overwrite_text_internal_updates_persisted_file () =
+  with_temp_dir (fun root ->
+    let store = unwrap_result (Runtime_store.create ~root ()) in
+    let artifact =
+      unwrap_result
+        (Artifact_service.save_text_internal
+           store
+           ~session_id:"sess-overwrite"
+           ~name:"notes"
+           ~kind:"txt"
+           ~content:"old")
+    in
+    unwrap_result (Artifact_service.overwrite_text_internal artifact ~content:"new");
+    let path = unwrap_result (Artifact_service.persisted_path artifact) in
+    check string "updated" "new" (unwrap_result (Runtime_store.load_text path)))
+;;
+
+let test_list_and_get_text_read_session_artifacts () =
+  with_temp_dir (fun root ->
+    let store = unwrap_result (Runtime_store.create ~root ()) in
+    let persisted =
+      unwrap_result
+        (Artifact_service.save_text_internal
+           store
+           ~session_id:"sess-list"
+           ~name:"persisted"
+           ~kind:"json"
+           ~content:{|{"ok":true}|})
+    in
+    let inline : Runtime.artifact =
+      { artifact_id = "inline-art"
+      ; name = "inline"
+      ; kind = "text"
+      ; mime_type = "text/plain"
+      ; path = None
+      ; inline_content = Some "inline body"
+      ; size_bytes = 11
+      ; created_at = 3.0
+      }
+    in
+    unwrap_result
+      (Runtime_store.save_session
+         store
+         (mk_session ~artifacts:[ persisted; inline ] "sess-list"));
+    let listed =
+      unwrap_result (Artifact_service.list ~session_root:root ~session_id:"sess-list" ())
+    in
+    check int "two artifacts" 2 (List.length listed);
+    check
+      string
+      "persisted content"
+      {|{"ok":true}|}
+      (unwrap_result
+         (Artifact_service.get_text
+            ~session_root:root
+            ~session_id:"sess-list"
+            ~artifact_id:persisted.artifact_id
+            ()));
+    check
+      string
+      "inline content"
+      "inline body"
+      (unwrap_result
+         (Artifact_service.get_text
+            ~session_root:root
+            ~session_id:"sess-list"
+            ~artifact_id:inline.artifact_id
+            ())))
+;;
+
+let test_get_text_reports_missing_or_unreadable_artifact () =
+  with_temp_dir (fun root ->
+    let store = unwrap_result (Runtime_store.create ~root ()) in
+    let missing_path_artifact : Runtime.artifact =
+      { artifact_id = "missing-path"
+      ; name = "missing"
+      ; kind = "text"
+      ; mime_type = "text/plain"
+      ; path = None
+      ; inline_content = None
+      ; size_bytes = 0
+      ; created_at = 1.0
+      }
+    in
+    unwrap_result
+      (Runtime_store.save_session
+         store
+         (mk_session ~artifacts:[ missing_path_artifact ] "sess-errors"));
+    (match
+       Artifact_service.get_text
+         ~session_root:root
+         ~session_id:"sess-errors"
+         ~artifact_id:"absent"
+         ()
+     with
+     | Ok _ -> fail "expected missing artifact error"
+     | Error _ -> ());
+    match
+      Artifact_service.get_text
+        ~session_root:root
+        ~session_id:"sess-errors"
+        ~artifact_id:"missing-path"
+        ()
+    with
+    | Ok _ -> fail "expected no content/path error"
+    | Error _ -> ())
+;;
+
 let () =
   run
     "Artifact_service"
@@ -156,5 +349,27 @@ let () =
         ; test_case "whitespace trimmed" `Quick test_mime_whitespace
         ] )
     ; "consistency", [ test_case "kind table" `Quick test_consistency_table ]
+    ; ( "persisted"
+      , [ test_case
+            "save_text_internal persists descriptor"
+            `Quick
+            test_save_text_internal_persists_descriptor
+        ; test_case
+            "persisted_path rejects inline only"
+            `Quick
+            test_persisted_path_rejects_inline_only_artifact
+        ; test_case
+            "overwrite_text_internal updates file"
+            `Quick
+            test_overwrite_text_internal_updates_persisted_file
+        ; test_case
+            "list and get_text"
+            `Quick
+            test_list_and_get_text_read_session_artifacts
+        ; test_case
+            "get_text error paths"
+            `Quick
+            test_get_text_reports_missing_or_unreadable_artifact
+        ] )
     ]
 ;;

--- a/test/test_harness_case.ml
+++ b/test/test_harness_case.ml
@@ -2,8 +2,23 @@
 
 open Agent_sdk
 open Alcotest
+open Harness_case
 
-let mk_record ~seq ~ts ~record_type ?prompt ?final_text ?error () : Raw_trace.record =
+let mk_record
+      ~seq
+      ~ts
+      ~record_type
+      ?prompt
+      ?tool_use_id
+      ?tool_name
+      ?tool_input
+      ?tool_result
+      ?tool_error
+      ?final_text
+      ?error
+      ()
+  : Raw_trace.record
+  =
   { trace_version = 1
   ; worker_run_id = "wr-hcase"
   ; seq
@@ -19,16 +34,16 @@ let mk_record ~seq ~ts ~record_type ?prompt ?final_text ?error () : Raw_trace.re
   ; block_index = None
   ; block_kind = None
   ; assistant_block = None
-  ; tool_use_id = None
-  ; tool_name = None
-  ; tool_input = None
+  ; tool_use_id
+  ; tool_name
+  ; tool_input
   ; tool_planned_index = None
   ; tool_batch_index = None
   ; tool_batch_size = None
   ; tool_concurrency_class = None
   ; evidence_role = None
-  ; tool_result = None
-  ; tool_error = None
+  ; tool_result
+  ; tool_error
   ; hook_name = None
   ; hook_decision = None
   ; hook_detail = None
@@ -82,10 +97,247 @@ let test_trace_replay_of_records () =
     check bool "has assertions" true (List.length case_.assertions >= 2)
 ;;
 
+let expect_case_ok json =
+  match Harness_case.of_json json with
+  | Ok case_ -> case_
+  | Error e -> fail (Error.to_string e)
+;;
+
+let expect_case_error json =
+  match Harness_case.of_json json with
+  | Ok _ -> fail "expected Harness_case.of_json to fail"
+  | Error _ -> ()
+;;
+
+let test_json_roundtrip_all_assertions () =
+  let case_ =
+    Harness_case.make_fixture
+      ~tags:[ "smoke"; "json" ]
+      ~artifacts:[ "/tmp/a.json" ]
+      ~assertions:
+        [ Response (Exact_text "done")
+        ; Response (Contains_text "on")
+        ; Response (Structural_json (`Assoc [ "ok", `Bool true ]))
+        ; Response (Fuzzy_text { expected = "roughly done"; threshold = 0.8 })
+        ; Trace Succeeds
+        ; Trace (Tool_called "lookup")
+        ; Trace (Tool_sequence [ "lookup"; "summarize" ])
+        ; Trace (Tool_call_count 2)
+        ; Trace (Max_turns 3)
+        ; Metric
+            { name = "accuracy"
+            ; goal = Eval.Higher
+            ; target = Eval.Float_val 0.9
+            ; tolerance_pct = Some 2.5
+            }
+        ]
+      ~id:"fixture-json"
+      ~prompt:"Run assertions"
+      ()
+  in
+  let parsed = expect_case_ok (Harness_case.to_json case_) in
+  check string "id" case_.id parsed.id;
+  check string "prompt" case_.prompt parsed.prompt;
+  check (list string) "tags" case_.tags parsed.tags;
+  check (list string) "artifacts" case_.artifacts parsed.artifacts;
+  check int "assertions" (List.length case_.assertions) (List.length parsed.assertions)
+;;
+
+let test_of_json_accepts_null_optional_lists () =
+  let json =
+    `Assoc
+      [ "id", `String "fixture-null"
+      ; "kind", `String "fixture"
+      ; "prompt", `String "No optional lists"
+      ; "tags", `Null
+      ; "assertions", `Null
+      ; "artifacts", `Null
+      ; "source_trace_path", `Null
+      ]
+  in
+  let parsed = expect_case_ok json in
+  check (list string) "tags default" [] parsed.tags;
+  check int "assertions default" 0 (List.length parsed.assertions);
+  check (list string) "artifacts default" [] parsed.artifacts;
+  check (option string) "source trace" None parsed.source_trace_path
+;;
+
+let test_of_json_rejects_unknown_kind () =
+  expect_case_error
+    (`Assoc
+        [ "id", `String "bad-kind"
+        ; "kind", `String "future"
+        ; "prompt", `String "x"
+        ; "tags", `List []
+        ; "assertions", `List []
+        ; "artifacts", `List []
+        ; "source_trace_path", `Null
+        ])
+;;
+
+let test_of_json_rejects_bad_tags () =
+  expect_case_error
+    (`Assoc
+        [ "id", `String "bad-tags"
+        ; "kind", `String "fixture"
+        ; "prompt", `String "x"
+        ; "tags", `List [ `String "ok"; `Int 1 ]
+        ; "assertions", `List []
+        ; "artifacts", `List []
+        ; "source_trace_path", `Null
+        ])
+;;
+
+let test_of_json_rejects_unknown_assertions () =
+  List.iter
+    expect_case_error
+    [ `Assoc
+        [ "id", `String "bad-response"
+        ; "kind", `String "fixture"
+        ; "prompt", `String "x"
+        ; "tags", `List []
+        ; ( "assertions"
+          , `List [ `Assoc [ "type", `String "response_future"; "value", `String "x" ] ] )
+        ; "artifacts", `List []
+        ; "source_trace_path", `Null
+        ]
+    ; `Assoc
+        [ "id", `String "bad-trace"
+        ; "kind", `String "fixture"
+        ; "prompt", `String "x"
+        ; "tags", `List []
+        ; ( "assertions"
+          , `List [ `Assoc [ "type", `String "trace_tool_sequence"; "value", `Int 1 ] ] )
+        ; "artifacts", `List []
+        ; "source_trace_path", `Null
+        ]
+    ; `Assoc
+        [ "id", `String "bad-metric-goal"
+        ; "kind", `String "fixture"
+        ; "prompt", `String "x"
+        ; "tags", `List []
+        ; ( "assertions"
+          , `List
+              [ `Assoc
+                  [ "type", `String "metric"
+                  ; "name", `String "latency"
+                  ; "goal", `String "sideways"
+                  ; "target", `Int 1
+                  ; "tolerance_pct", `Null
+                  ]
+              ] )
+        ; "artifacts", `List []
+        ; "source_trace_path", `Null
+        ]
+    ; `Assoc
+        [ "id", `String "bad-assertion"
+        ; "kind", `String "fixture"
+        ; "prompt", `String "x"
+        ; "tags", `List []
+        ; "assertions", `List [ `Assoc [ "type", `String "future_assertion" ] ]
+        ; "artifacts", `List []
+        ; "source_trace_path", `Null
+        ]
+    ]
+;;
+
+let test_make_trace_replay_adds_source_metadata () =
+  let case_ =
+    Harness_case.make_trace_replay
+      ~tags:[ "nightly" ]
+      ~artifacts:[ "/tmp/extra.json" ]
+      ~id:"trace-case"
+      ~prompt:"Replay"
+      ~source_trace_path:"/tmp/raw.jsonl"
+      ()
+  in
+  check bool "trace replay" true (case_.kind = Harness_case.Trace_replay);
+  check (list string) "tags" [ "trace-replay"; "nightly" ] case_.tags;
+  check (list string) "artifacts" [ "/tmp/raw.jsonl"; "/tmp/extra.json" ] case_.artifacts;
+  check (option string) "source" (Some "/tmp/raw.jsonl") case_.source_trace_path
+;;
+
+let test_trace_replay_requires_prompt () =
+  match
+    Harness_case.trace_replay_of_records
+      ~id:"trace-missing-prompt"
+      ~source_trace_path:"/tmp/trace.ndjson"
+      [ mk_record ~seq:1 ~ts:1.0 ~record_type:Run_finished ~final_text:"done" () ]
+  with
+  | Ok _ -> fail "expected missing prompt to fail"
+  | Error _ -> ()
+;;
+
+let test_trace_replay_extracts_tool_assertions () =
+  let records =
+    [ mk_record ~seq:1 ~ts:1.0 ~record_type:Run_started ~prompt:"Use a tool" ()
+    ; mk_record
+        ~seq:2
+        ~ts:2.0
+        ~record_type:Tool_execution_started
+        ~tool_use_id:"tu-1"
+        ~tool_name:"lookup"
+        ~tool_input:(`Assoc [ "q", `String "oas" ])
+        ()
+    ; mk_record
+        ~seq:3
+        ~ts:3.0
+        ~record_type:Tool_execution_finished
+        ~tool_use_id:"tu-1"
+        ~tool_result:"result"
+        ~tool_error:false
+        ()
+    ; mk_record ~seq:4 ~ts:4.0 ~record_type:Run_finished ~final_text:"done" ()
+    ]
+  in
+  match
+    Harness_case.trace_replay_of_records
+      ~id:"trace-tools"
+      ~source_trace_path:"/tmp/trace-tools.ndjson"
+      records
+  with
+  | Error e -> fail (Error.to_string e)
+  | Ok case_ ->
+    let has_sequence =
+      List.exists
+        (function
+          | Harness_case.Trace (Tool_sequence [ "lookup" ]) -> true
+          | _ -> false)
+        case_.assertions
+    in
+    let has_count =
+      List.exists
+        (function
+          | Harness_case.Trace (Tool_call_count 1) -> true
+          | _ -> false)
+        case_.assertions
+    in
+    check bool "tool sequence assertion" true has_sequence;
+    check bool "tool count assertion" true has_count
+;;
+
 let () =
   run
     "harness_case"
     [ "dataset", [ test_case "roundtrip" `Quick test_dataset_roundtrip ]
-    ; "trace_replay", [ test_case "of_records" `Quick test_trace_replay_of_records ]
+    ; ( "json"
+      , [ test_case "roundtrip all assertions" `Quick test_json_roundtrip_all_assertions
+        ; test_case "null optional lists" `Quick test_of_json_accepts_null_optional_lists
+        ; test_case "unknown kind rejected" `Quick test_of_json_rejects_unknown_kind
+        ; test_case "bad tags rejected" `Quick test_of_json_rejects_bad_tags
+        ; test_case
+            "unknown assertions rejected"
+            `Quick
+            test_of_json_rejects_unknown_assertions
+        ] )
+    ; ( "trace_replay"
+      , [ test_case "of_records" `Quick test_trace_replay_of_records
+        ; test_case
+            "make_trace_replay source metadata"
+            `Quick
+            test_make_trace_replay_adds_source_metadata
+        ; test_case "requires prompt" `Quick test_trace_replay_requires_prompt
+        ; test_case "tool assertions" `Quick test_trace_replay_extracts_tool_assertions
+        ] )
     ]
 ;;


### PR DESCRIPTION
Refs #1175

## Summary
- add behavior coverage for `Harness_case` JSON round-trips, parser rejection paths, trace replay metadata, missing-prompt failure, and tool-derived assertions
- add persisted artifact coverage for `Artifact_service.save_text_internal`, `persisted_path`, `overwrite_text_internal`, `list`, and `get_text` success/error paths

## Coverage Context
- post-#1757 main CI run `26366712071` / job `77611678388`: `22295/29724 = 75.01%`, threshold `73`
- remaining target from #1175: raise measured coverage to at least `76%`, then ratchet CI floor to `75`
- current hotspot baselines from that run:
  - `lib/artifact_service.ml`: `34/73 = 46.58%`
  - `lib/harness_case.ml`: `86/182 = 47.25%`

## Validation
- `scripts/dune-local.sh build test/test_harness_case.exe test/test_artifact_service.exe`
- `./_build/default/test/test_harness_case.exe`
- `./_build/default/test/test_artifact_service.exe`
- `opam exec -- ocamlformat --check test/test_harness_case.ml test/test_artifact_service.ml`
- `git diff --check`
- `scripts/lint-core-cdal-boundary.sh`