### PR TITLE
test: fix provider_intf mock server bind robustness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,12 @@ jobs:
           # 76.02% (22598/29728) after provider dispatch, provider_d codec,
           # and streaming edge coverage. Raise the floor to
           # floor(76.02 - 1) = 75 per #1175 ratchet policy.
-          THRESHOLD=75
+          #
+          # 2026-05-25: local clean full coverage on PR #1759 measured
+          # 77.72% (23104/29728) after Stage D client/pipeline/pure module,
+          # harness, and CLI transport coverage. Raise the floor to
+          # floor(77.72 - 1) = 76 per #1175 ratchet policy.
+          THRESHOLD=76
           if [ "$(echo "$COVERAGE < $THRESHOLD" | bc -l)" -eq 1 ]; then
             echo "::error::Coverage ${COVERAGE}% is below threshold ${THRESHOLD}%"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,12 @@ jobs:
           # 2026-05-24: PR #1738 CI measured 74.47% coverage
           # (run 26360879180, job 77595953724). Raise the floor to
           # floor(74.47 - 1) = 73 per #1175 ratchet policy.
-          THRESHOLD=73
+          #
+          # 2026-05-25: local clean full coverage on PR #1759 measured
+          # 76.02% (22598/29728) after provider dispatch, provider_d codec,
+          # and streaming edge coverage. Raise the floor to
+          # floor(76.02 - 1) = 75 per #1175 ratchet policy.
+          THRESHOLD=75
           if [ "$(echo "$COVERAGE < $THRESHOLD" | bc -l)" -eq 1 ]; then
             echo "::error::Coverage ${COVERAGE}% is below threshold ${THRESHOLD}%"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,12 @@ jobs:
           # 77.72% (23104/29728) after Stage D client/pipeline/pure module,
           # harness, and CLI transport coverage. Raise the floor to
           # floor(77.72 - 1) = 76 per #1175 ratchet policy.
-          THRESHOLD=76
+          #
+          # 2026-05-25: local clean full coverage on PR #1759 measured
+          # 78.13% (23241/29748) after Stage D provider_k, tool-call
+          # harness, and provider catalog coverage. Raise the floor to
+          # floor(78.13 - 1) = 77 per #1175 ratchet policy.
+          THRESHOLD=77
           if [ "$(echo "$COVERAGE < $THRESHOLD" | bc -l)" -eq 1 ]; then
             echo "::error::Coverage ${COVERAGE}% is below threshold ${THRESHOLD}%"
             exit 1

--- a/docs/_audit/2026-05-25-coverage-ratchet-75-evidence.md
+++ b/docs/_audit/2026-05-25-coverage-ratchet-75-evidence.md
@@ -64,3 +64,23 @@ streaming edge-case tests, so the CI coverage floor can move from 73% to 75%.
 - Timestamp: 2026-05-25 KST
   Confidence: High for focused slice coverage; project-wide CI coverage remains
   governed by the `75` floor above.
+
+## Stage D pure-module follow-up
+
+- Evidence: local focused coverage run on PR #1759 after extending
+  `test/test_tool_schema_gen.ml` and `test/test_memory_procedural.ml`.
+- Command:
+  `env MASC_DUNE_THROTTLE=0 BISECT_ENABLE=yes BISECT_FILE=/tmp/oas_stage_d_pure_coverage/bisect scripts/dune-local.sh build --instrument-with bisect_ppx test/test_tool_schema_gen.exe test/test_memory_procedural.exe`
+- Test binaries:
+  `./_build/default/test/test_tool_schema_gen.exe`,
+  `./_build/default/test/test_memory_procedural.exe`
+- Summary command:
+  `opam exec -- bisect-ppx-report summary --per-file --coverage-path=/tmp/oas_stage_d_pure_coverage`
+- Focused per-file results:
+  - `lib/tool_schema_gen.ml`: `82.22%` (`74/90`)
+  - `lib/memory_procedural.ml`: `83.78%` (`62/74`)
+  - `lib/memory.ml`: `23.48%` (`85/362`)
+  - `lib/tool_input_validation.ml`: `20.37%` (`22/108`)
+- Timestamp: 2026-05-25 KST
+  Confidence: High for focused pure-module coverage; project-wide CI coverage
+  remains governed by the `75` floor above until the next clean full run.

--- a/docs/_audit/2026-05-25-coverage-ratchet-75-evidence.md
+++ b/docs/_audit/2026-05-25-coverage-ratchet-75-evidence.md
@@ -84,3 +84,35 @@ streaming edge-case tests, so the CI coverage floor can move from 73% to 75%.
 - Timestamp: 2026-05-25 KST
   Confidence: High for focused pure-module coverage; project-wide CI coverage
   remains governed by the `75` floor above until the next clean full run.
+
+## Stage D harness and CLI transport follow-up
+
+- Evidence: local focused coverage run on PR #1759 after extending
+  `test/test_harness_runner.ml` and adding subprocess-backed
+  `test/test_transport_cli_tool_b_coverage.ml` /
+  `test/test_transport_cli_tool_c_coverage.ml`.
+- Command:
+  `env MASC_DUNE_THROTTLE=0 BISECT_ENABLE=yes BISECT_FILE=/tmp/oas_stage_d_cli_harness_coverage/bisect scripts/dune-local.sh build --instrument-with bisect_ppx test/test_harness_runner.exe test/test_transport_cli_tool_b_coverage.exe test/test_transport_cli_tool_c_coverage.exe`
+- Test binaries:
+  `./_build/default/test/test_harness_runner.exe`,
+  `./_build/default/test/test_transport_cli_tool_b_coverage.exe`,
+  `./_build/default/test/test_transport_cli_tool_c_coverage.exe`
+- Summary command:
+  `opam exec -- bisect-ppx-report summary --per-file --coverage-path=/tmp/oas_stage_d_cli_harness_coverage`
+- Focused per-file results:
+  - `lib/harness_runner.ml`: `77.13%` (`172/223`)
+  - `lib/llm_provider/transport_cli_tool_b.ml`: `52.16%` (`133/255`)
+  - `lib/llm_provider/transport_cli_tool_c.ml`: `63.10%` (`183/290`)
+  - `lib/llm_provider/cli_common_subprocess.ml`: `47.43%` (`83/175`)
+  - `lib/llm_provider/cli_common_synthetic_events.ml`: `55.00%` (`11/20`)
+- Behaviors added:
+  - harness response/trace/metric pass and fail grading, skipped cases, trace
+    path validation, and execute-case failure shaping.
+  - `cli_tool_b` Provider_f JSON parsing, synthetic stream replay,
+    request-scoped MCP rejection, and terminal quota stderr classification.
+  - `cli_tool_c` JSONL text/tool/tool-result restoration, stream event
+    emission, subprocess-error surfacing, no-output parse failure, stdin prompt
+    routing, and session delta reuse.
+- Timestamp: 2026-05-25 KST
+  Confidence: High for focused behavior coverage; project-wide CI coverage
+  remains governed by the `75` floor above until the next clean full run.

--- a/docs/_audit/2026-05-25-coverage-ratchet-75-evidence.md
+++ b/docs/_audit/2026-05-25-coverage-ratchet-75-evidence.md
@@ -27,7 +27,8 @@ streaming edge-case tests, so the CI coverage floor can move from 73% to 75%.
 ## #1175 record
 
 - Stage C target (`60 -> 75`): floor now reaches 75.
-- Stage D target (`75 -> 80`): still open.
+- Stage D target (`75 -> 80`): still open, with the first low-coverage
+  follow-up slice landed in this PR.
 - Top 0% files removed in this PR: none; this slice targets low/mid coverage
   provider and streaming surfaces rather than zero-coverage files.
 - Tests added in this PR:
@@ -38,3 +39,28 @@ streaming edge-case tests, so the CI coverage floor can move from 73% to 75%.
     edge branches.
   - `test/test_streaming_edge_cases.ml`: provider_a SSE, provider_d,
     provider_f, Ollama NDJSON, and synthetic-event edge branches.
+  - `test/test_client_wrapper_coverage.ml`: public client wrapper show/default
+    aliases.
+  - `test/test_pipeline_common_coverage.ml`: pipeline strategy/outcome,
+    completion-contract validation, event envelopes, and tiered-memory token
+    counting.
+
+## Stage D focused follow-up
+
+- Evidence: local focused coverage run on PR #1759 after adding the client and
+  pipeline-common tests.
+- Command:
+  `env MASC_DUNE_THROTTLE=0 BISECT_ENABLE=yes BISECT_FILE=/tmp/oas_stage_d_focus_coverage/bisect scripts/dune-local.sh build --instrument-with bisect_ppx test/test_client_wrapper_coverage.exe test/test_pipeline_common_coverage.exe test/test_provider_intf.exe`
+- Test binaries:
+  `./_build/default/test/test_client_wrapper_coverage.exe`,
+  `./_build/default/test/test_pipeline_common_coverage.exe`,
+  `./_build/default/test/test_provider_intf.exe`
+- Summary command:
+  `opam exec -- bisect-ppx-report summary --per-file --coverage-path=/tmp/oas_stage_d_focus_coverage`
+- Focused per-file results:
+  - `lib/client.ml`: `74.47%` (`35/47`)
+  - `lib/pipeline/pipeline_common.ml`: `100.00%` (`24/24`)
+  - `lib/provider_intf.ml`: `53.70%` (`29/54`)
+- Timestamp: 2026-05-25 KST
+  Confidence: High for focused slice coverage; project-wide CI coverage remains
+  governed by the `75` floor above.

--- a/docs/_audit/2026-05-25-coverage-ratchet-75-evidence.md
+++ b/docs/_audit/2026-05-25-coverage-ratchet-75-evidence.md
@@ -1,21 +1,21 @@
 # Coverage ratchet evidence - 2026-05-25
 
 Scope: #1175 Stage C/D continuation. PR #1759 raises measured project coverage
-above 77% with behavior-backed provider dispatch, provider_d codec, streaming,
-pure-module, harness, and CLI transport tests, so the CI coverage floor can
-move from 73% to 76%.
+above 78% with behavior-backed provider dispatch, provider_d codec, streaming,
+pure-module, harness, CLI transport, provider_k, and provider catalog tests, so
+the CI coverage floor can move from 73% to 77%.
 
 ## Measurement
 
 - Evidence: local clean full coverage run on PR #1759 after the Stage D
-  client/pipeline/pure-module/harness/CLI transport follow-ups.
+  provider contract and catalog follow-ups.
 - Command:
-  `env MASC_DUNE_THROTTLE=0 BISECT_ENABLE=yes EIO_BACKEND=posix BISECT_FILE=/tmp/oas_stage_d_full_after_ad_error_validation_coverage/bisect scripts/dune-local.sh runtest --force --instrument-with bisect_ppx`
+  `env MASC_DUNE_THROTTLE=0 BISECT_ENABLE=yes EIO_BACKEND=posix BISECT_FILE=/tmp/oas_stage_d_full_after_provider_k_harness_catalog_coverage/bisect scripts/dune-local.sh runtest --force --instrument-with bisect_ppx`
 - Summary command:
-  `opam exec -- bisect-ppx-report summary --coverage-path=/tmp/oas_stage_d_full_after_ad_error_validation_coverage`
-- Measured coverage: `77.72%` (`23104/29728`)
-- Earlier Stage C clean measurement before the Stage D follow-ups:
-  `76.02%` (`22598/29728`)
+  `opam exec -- bisect-ppx-report summary --coverage-path=/tmp/oas_stage_d_full_after_provider_k_harness_catalog_coverage`
+- Measured coverage: `78.13%` (`23241/29748`)
+- Earlier clean measurements before the provider contract/catalog follow-up:
+  `77.72%` (`23104/29728`) and `76.02%` (`22598/29728`)
 - Timestamp: 2026-05-25 KST
 - Confidence: High for local measurement; GitHub full CI remains the final
   merge gate after the draft PR is marked ready.
@@ -24,15 +24,16 @@ move from 73% to 76%.
 
 - Base threshold before this PR: `73`
 - Intermediate threshold after the Stage C slice: `75`
-- New threshold after the Stage D follow-ups: `76`
-- Formula: `floor(77.72 - 1) = 76`
+- Intermediate threshold after earlier Stage D follow-ups: `76`
+- New threshold after the provider contract/catalog follow-up: `77`
+- Formula: `floor(78.13 - 1) = 77`
 - Reason: preserve one percentage point of CI/runtime headroom while enforcing
   the measured recovery toward the 80% terminal goal.
 
 ## #1175 record
 
 - Stage C target (`60 -> 75`): floor reaches 75.
-- Stage D target (`75 -> 80`): in progress; floor now reaches 76 and still
+- Stage D target (`75 -> 80`): in progress; floor now reaches 77 and still
   needs further measured slices before 80.
 - Top 0% files removed in this PR: none; this slice targets low/mid coverage
   provider and streaming surfaces rather than zero-coverage files.
@@ -59,6 +60,15 @@ move from 73% to 76%.
     mapping variants and retryability matrix.
   - `test/test_tool_input_validation.ml`: scalar coercion edges, optional null,
     non-object input, JSON actual descriptions, and inline formatting fallback.
+  - `test/test_backend_provider_k_coverage.ml`: provider_k error
+    classification, status mapping, request modes, response parsing, duplicate
+    reasoning guard, parse-error normalization, and stream reasoning deltas.
+  - `test/test_backend_tool_call_harness.ml`: scalar actual-type schema
+    validation, invalid schema map entry filtering, and provider convenience
+    validators.
+  - `test/test_provider_catalog_coverage.ml`: catalog entry parsing,
+    auth/transport/thinking aliases, capability overrides, malformed entry
+    errors, load-file behavior, and global override lifecycle.
 
 ## Stage D focused follow-up
 
@@ -78,7 +88,7 @@ move from 73% to 76%.
   - `lib/provider_intf.ml`: `53.70%` (`29/54`)
 - Timestamp: 2026-05-25 KST
   Confidence: High for focused slice coverage; project-wide CI coverage is now
-  governed by the latest `76` floor above.
+  governed by the latest `77` floor above.
 
 ## Stage D pure-module follow-up
 
@@ -98,7 +108,7 @@ move from 73% to 76%.
   - `lib/tool_input_validation.ml`: `20.37%` (`22/108`)
 - Timestamp: 2026-05-25 KST
   Confidence: High for focused pure-module coverage; project-wide CI coverage
-  is now governed by the latest `76` floor above.
+  is now governed by the latest `77` floor above.
 
 ## Stage D harness and CLI transport follow-up
 
@@ -130,7 +140,7 @@ move from 73% to 76%.
     routing, and session delta reuse.
 - Timestamp: 2026-05-25 KST
   Confidence: High for focused behavior coverage; project-wide CI coverage is
-  now governed by the latest `76` floor above.
+  now governed by the latest `77` floor above.
 
 ## Stage D CLI A/D and validation follow-up
 
@@ -169,4 +179,39 @@ move from 73% to 76%.
     descriptions, optional null, non-object input, and inline path fallback.
 - Timestamp: 2026-05-25 KST
   Confidence: High for focused behavior coverage; project-wide CI coverage is
-  now governed by the latest `76` floor above.
+  now governed by the latest `77` floor above.
+
+## Stage D provider contract and catalog follow-up
+
+- Evidence: local focused coverage run on PR #1759 after adding
+  `test/test_backend_provider_k_coverage.ml`,
+  `test/test_provider_catalog_coverage.ml`, and extending
+  `test/test_backend_tool_call_harness.ml`.
+- Command:
+  `env MASC_DUNE_THROTTLE=0 BISECT_ENABLE=yes BISECT_FILE=/tmp/oas_stage_d_provider_contract_catalog_coverage/bisect scripts/dune-local.sh build --instrument-with bisect_ppx test/test_backend_provider_k_coverage.exe test/test_backend_tool_call_harness.exe test/test_provider_catalog_coverage.exe`
+- Test binaries:
+  `BISECT_FILE=/tmp/oas_stage_d_provider_contract_catalog_coverage/bisect ./_build/default/test/test_backend_provider_k_coverage.exe`,
+  `BISECT_FILE=/tmp/oas_stage_d_provider_contract_catalog_coverage/bisect ./_build/default/test/test_backend_tool_call_harness.exe`,
+  `BISECT_FILE=/tmp/oas_stage_d_provider_contract_catalog_coverage/bisect ./_build/default/test/test_provider_catalog_coverage.exe`
+- Summary command:
+  `opam exec -- bisect-ppx-report summary --per-file --coverage-path=/tmp/oas_stage_d_provider_contract_catalog_coverage`
+- Focused per-file results:
+  - `lib/llm_provider/backend_provider_k.ml`: `51.97%` (`66/127`)
+  - `lib/llm_provider/backend_tool_call_harness.ml`: `59.09%`
+    (`182/308`)
+  - `lib/llm_provider/provider_catalog.ml`: `86.09%` (`291/338`)
+- Full clean coverage after this follow-up:
+  `78.13%` (`23241/29748`) from
+  `/tmp/oas_stage_d_full_after_provider_k_harness_catalog_coverage`.
+- Behaviors added:
+  - provider_k retry/error classification, HTTP status mapping, thinking and
+    tool-stream request modes, usage/reasoning parsing, duplicate reasoning
+    suppression, parse-error wrapping, and stream reasoning chunks.
+  - tool-call harness scalar actual-type reporting, missing/invalid schema-map
+    filtering, feedback formatting, and provider convenience validators.
+  - provider catalog auth/transport/thinking aliases, capability override
+    matrix, malformed entry handling, file load failures, and global override
+    lifecycle.
+- Timestamp: 2026-05-25 KST
+  Confidence: High for focused behavior coverage; project-wide CI coverage is
+  now governed by the latest `77` floor above.

--- a/docs/_audit/2026-05-25-coverage-ratchet-75-evidence.md
+++ b/docs/_audit/2026-05-25-coverage-ratchet-75-evidence.md
@@ -1,34 +1,39 @@
 # Coverage ratchet evidence - 2026-05-25
 
-Scope: #1175 Stage C continuation. PR #1759 raises measured project coverage
-above 76% with behavior-backed provider dispatch, provider_d codec, and
-streaming edge-case tests, so the CI coverage floor can move from 73% to 75%.
+Scope: #1175 Stage C/D continuation. PR #1759 raises measured project coverage
+above 77% with behavior-backed provider dispatch, provider_d codec, streaming,
+pure-module, harness, and CLI transport tests, so the CI coverage floor can
+move from 73% to 76%.
 
 ## Measurement
 
-- Evidence: local clean full coverage run on PR #1759.
+- Evidence: local clean full coverage run on PR #1759 after the Stage D
+  client/pipeline/pure-module/harness/CLI transport follow-ups.
 - Command:
-  `env MASC_DUNE_THROTTLE=0 BISECT_ENABLE=yes EIO_BACKEND=posix OAS_RUNTIME_PATH=... BISECT_FILE=/tmp/oas_provider_intf_coverage_final/bisect scripts/dune-local.sh runtest --force --instrument-with bisect_ppx`
+  `env MASC_DUNE_THROTTLE=0 BISECT_ENABLE=yes EIO_BACKEND=posix BISECT_FILE=/tmp/oas_stage_d_full_after_ad_error_validation_coverage/bisect scripts/dune-local.sh runtest --force --instrument-with bisect_ppx`
 - Summary command:
-  `opam exec -- bisect-ppx-report summary --coverage-path=/tmp/oas_provider_intf_coverage_final`
-- Measured coverage: `76.02%` (`22598/29728`)
+  `opam exec -- bisect-ppx-report summary --coverage-path=/tmp/oas_stage_d_full_after_ad_error_validation_coverage`
+- Measured coverage: `77.72%` (`23104/29728`)
+- Earlier Stage C clean measurement before the Stage D follow-ups:
+  `76.02%` (`22598/29728`)
 - Timestamp: 2026-05-25 KST
 - Confidence: High for local measurement; GitHub full CI remains the final
   merge gate after the draft PR is marked ready.
 
 ## Ratchet decision
 
-- Previous threshold: `73`
-- New threshold: `75`
-- Formula: `floor(76.02 - 1) = 75`
+- Base threshold before this PR: `73`
+- Intermediate threshold after the Stage C slice: `75`
+- New threshold after the Stage D follow-ups: `76`
+- Formula: `floor(77.72 - 1) = 76`
 - Reason: preserve one percentage point of CI/runtime headroom while enforcing
   the measured recovery toward the 80% terminal goal.
 
 ## #1175 record
 
-- Stage C target (`60 -> 75`): floor now reaches 75.
-- Stage D target (`75 -> 80`): still open, with the first low-coverage
-  follow-up slice landed in this PR.
+- Stage C target (`60 -> 75`): floor reaches 75.
+- Stage D target (`75 -> 80`): in progress; floor now reaches 76 and still
+  needs further measured slices before 80.
 - Top 0% files removed in this PR: none; this slice targets low/mid coverage
   provider and streaming surfaces rather than zero-coverage files.
 - Tests added in this PR:
@@ -44,6 +49,16 @@ streaming edge-case tests, so the CI coverage floor can move from 73% to 75%.
   - `test/test_pipeline_common_coverage.ml`: pipeline strategy/outcome,
     completion-contract validation, event envelopes, and tiered-memory token
     counting.
+  - `test/test_transport_cli_tool_a_coverage.ml`: Agent_code JSONL,
+    runtime MCP env-token override, stdout recovery, stdin prompt routing, and
+    parse-error paths.
+  - `test/test_transport_cli_tool_d_coverage.ml`: Agent_llm_a stream-json,
+    JSON output, runtime MCP args, max-turns terminal mapping, stdin prompt
+    routing, and parse-error paths.
+  - `test/test_llm_provider_error.ml`: remaining retry/http/provider-failure
+    mapping variants and retryability matrix.
+  - `test/test_tool_input_validation.ml`: scalar coercion edges, optional null,
+    non-object input, JSON actual descriptions, and inline formatting fallback.
 
 ## Stage D focused follow-up
 
@@ -62,8 +77,8 @@ streaming edge-case tests, so the CI coverage floor can move from 73% to 75%.
   - `lib/pipeline/pipeline_common.ml`: `100.00%` (`24/24`)
   - `lib/provider_intf.ml`: `53.70%` (`29/54`)
 - Timestamp: 2026-05-25 KST
-  Confidence: High for focused slice coverage; project-wide CI coverage remains
-  governed by the `75` floor above.
+  Confidence: High for focused slice coverage; project-wide CI coverage is now
+  governed by the latest `76` floor above.
 
 ## Stage D pure-module follow-up
 
@@ -83,7 +98,7 @@ streaming edge-case tests, so the CI coverage floor can move from 73% to 75%.
   - `lib/tool_input_validation.ml`: `20.37%` (`22/108`)
 - Timestamp: 2026-05-25 KST
   Confidence: High for focused pure-module coverage; project-wide CI coverage
-  remains governed by the `75` floor above until the next clean full run.
+  is now governed by the latest `76` floor above.
 
 ## Stage D harness and CLI transport follow-up
 
@@ -114,5 +129,44 @@ streaming edge-case tests, so the CI coverage floor can move from 73% to 75%.
     emission, subprocess-error surfacing, no-output parse failure, stdin prompt
     routing, and session delta reuse.
 - Timestamp: 2026-05-25 KST
-  Confidence: High for focused behavior coverage; project-wide CI coverage
-  remains governed by the `75` floor above until the next clean full run.
+  Confidence: High for focused behavior coverage; project-wide CI coverage is
+  now governed by the latest `76` floor above.
+
+## Stage D CLI A/D and validation follow-up
+
+- Evidence: local focused coverage run on PR #1759 after adding
+  subprocess-backed `test/test_transport_cli_tool_a_coverage.ml` and
+  `test/test_transport_cli_tool_d_coverage.ml`, then extending
+  `test/test_llm_provider_error.ml` and `test/test_tool_input_validation.ml`.
+- Command:
+  `env MASC_DUNE_THROTTLE=0 BISECT_ENABLE=yes BISECT_FILE=/tmp/oas_stage_d_cli_ad_error_validation_coverage/bisect scripts/dune-local.sh build --instrument-with bisect_ppx test/test_transport_cli_tool_a_coverage.exe test/test_transport_cli_tool_d_coverage.exe test/test_llm_provider_error.exe test/test_tool_input_validation.exe`
+- Test binaries:
+  `./_build/default/test/test_transport_cli_tool_a_coverage.exe`,
+  `./_build/default/test/test_transport_cli_tool_d_coverage.exe`,
+  `./_build/default/test/test_llm_provider_error.exe`,
+  `./_build/default/test/test_tool_input_validation.exe`
+- Summary command:
+  `opam exec -- bisect-ppx-report summary --per-file --coverage-path=/tmp/oas_stage_d_cli_ad_error_validation_coverage`
+- Focused per-file results:
+  - `lib/llm_provider/error.ml`: `81.95%` (`109/133`)
+  - `lib/tool_input_validation.ml`: `87.04%` (`94/108`)
+  - `lib/llm_provider/transport_cli_tool_a.ml`: `73.09%` (`277/379`)
+  - `lib/llm_provider/transport_cli_tool_d.ml`: `69.40%` (`220/317`)
+  - `lib/llm_provider/cli_common_subprocess.ml`: `48.57%` (`85/175`)
+- Behaviors added:
+  - `cli_tool_a` JSONL text/tool/tool-result restoration, telemetry for
+    provider-internal command execution, stream events, nonzero-exit stdout
+    recovery, runtime MCP bearer-token env indirection, stdin prompt routing,
+    and empty-output parse failure.
+  - `cli_tool_d` stream-json structured text/thinking/tool-use restoration,
+    stream events, JSON-output fallback, internal max-turns terminal mapping,
+    runtime MCP argv construction, stdin prompt routing, and empty-output parse
+    failure.
+  - provider error mapping for retry/auth/invalid/not-found/context/network/
+    timeout variants, provider-failure subtypes, accept rejection, terminal
+    `Other`, and retryability classification.
+  - tool input validation for scalar coercion edge cases, JSON actual
+    descriptions, optional null, non-object input, and inline path fallback.
+- Timestamp: 2026-05-25 KST
+  Confidence: High for focused behavior coverage; project-wide CI coverage is
+  now governed by the latest `76` floor above.

--- a/docs/_audit/2026-05-25-coverage-ratchet-75-evidence.md
+++ b/docs/_audit/2026-05-25-coverage-ratchet-75-evidence.md
@@ -1,0 +1,40 @@
+# Coverage ratchet evidence - 2026-05-25
+
+Scope: #1175 Stage C continuation. PR #1759 raises measured project coverage
+above 76% with behavior-backed provider dispatch, provider_d codec, and
+streaming edge-case tests, so the CI coverage floor can move from 73% to 75%.
+
+## Measurement
+
+- Evidence: local clean full coverage run on PR #1759.
+- Command:
+  `env MASC_DUNE_THROTTLE=0 BISECT_ENABLE=yes EIO_BACKEND=posix OAS_RUNTIME_PATH=... BISECT_FILE=/tmp/oas_provider_intf_coverage_final/bisect scripts/dune-local.sh runtest --force --instrument-with bisect_ppx`
+- Summary command:
+  `opam exec -- bisect-ppx-report summary --coverage-path=/tmp/oas_provider_intf_coverage_final`
+- Measured coverage: `76.02%` (`22598/29728`)
+- Timestamp: 2026-05-25 KST
+- Confidence: High for local measurement; GitHub full CI remains the final
+  merge gate after the draft PR is marked ready.
+
+## Ratchet decision
+
+- Previous threshold: `73`
+- New threshold: `75`
+- Formula: `floor(76.02 - 1) = 75`
+- Reason: preserve one percentage point of CI/runtime headroom while enforcing
+  the measured recovery toward the 80% terminal goal.
+
+## #1175 record
+
+- Stage C target (`60 -> 75`): floor now reaches 75.
+- Stage D target (`75 -> 80`): still open.
+- Top 0% files removed in this PR: none; this slice targets low/mid coverage
+  provider and streaming surfaces rather than zero-coverage files.
+- Tests added in this PR:
+  - `test/test_provider_intf.ml`: provider dispatch error/custom-provider paths.
+  - `test/test_backend_provider_d_codec.ml`: provider_d serialization, schema,
+    parse, telemetry, reasoning, fenced JSON, and malformed tool-call branches.
+  - `test/test_streaming_coverage.ml`: stream accumulator/finalize/http-error
+    edge branches.
+  - `test/test_streaming_edge_cases.ml`: provider_a SSE, provider_d,
+    provider_f, Ollama NDJSON, and synthetic-event edge branches.

--- a/lib/llm_provider/backend_provider_k.ml
+++ b/lib/llm_provider/backend_provider_k.ml
@@ -164,8 +164,11 @@ let extract_reasoning_content (resp : api_response) body : api_response =
       let reasoning = msg |> member "reasoning_content" |> to_string_option in
       (match reasoning with
        | Some r when String.trim r <> "" ->
-         let thinking_block = Thinking { thinking_type = "thinking"; content = r } in
-         { resp with content = thinking_block :: resp.content }
+         (match resp.content with
+          | Thinking { content; _ } :: _ when String.equal content r -> resp
+          | _ ->
+            let thinking_block = Thinking { thinking_type = "thinking"; content = r } in
+            { resp with content = thinking_block :: resp.content })
        | Some _ | None -> resp)
     | `List [] | `Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null ->
       resp
@@ -173,20 +176,27 @@ let extract_reasoning_content (resp : api_response) body : api_response =
   | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> resp
 ;;
 
+let provider_k_parse_error message =
+  Provider_k_api_error
+    { code = "parse"
+    ; message
+    ; error_class = Provider_k_invalid_request
+    ; is_retryable = false
+    }
+;;
+
 let parse_response body =
   match check_glm_error body with
   | Some err -> raise (Provider_k_api_error err)
   | None ->
-    (match Backend_provider_d_parse.parse_provider_d_response_result body with
-     | Error msg ->
-       raise
-         (Provider_k_api_error
-            { code = "parse"
-            ; message = msg
-            ; error_class = Provider_k_invalid_request
-            ; is_retryable = false
-            })
-     | Ok resp -> extract_reasoning_content resp body)
+    (try
+       match Backend_provider_d_parse.parse_provider_d_response_result body with
+       | Error msg -> raise (provider_k_parse_error msg)
+       | Ok resp -> extract_reasoning_content resp body
+     with
+     | Yojson.Json_error msg -> raise (provider_k_parse_error msg)
+     | Yojson.Safe.Util.Type_error (msg, _) -> raise (provider_k_parse_error msg)
+     | Yojson.Safe.Util.Undefined (msg, _) -> raise (provider_k_parse_error msg))
 ;;
 
 (* ── Streaming ───────────────────────────────────── *)

--- a/lib/llm_provider/backend_tool_call_harness.ml
+++ b/lib/llm_provider/backend_tool_call_harness.ml
@@ -228,9 +228,10 @@ let build_schema_map (tools : Yojson.Safe.t list) : (string * Yojson.Safe.t) lis
          match json_string (tool |> member "name") with
          | Some s -> s
          | None ->
-           Option.value
-             ~default:""
-             (json_string (tool |> member "function" |> member "name"))
+           (match tool |> member "function" with
+            | `Assoc func ->
+              Option.value ~default:"" (json_string (`Assoc func |> member "name"))
+            | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> "")
        in
        if name = ""
        then None

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -26,6 +26,11 @@ let retry_error_of_http_error = function
       { message = Http_client.provider_failure_to_string ~kind ~message }
 ;;
 
+let parse_provider_d_response_result body_str =
+  try Llm_provider.Backend_provider_d_parse.parse_provider_d_response_result body_str with
+  | Yojson.Json_error msg | Yojson.Safe.Util.Type_error (msg, _) -> Error msg
+;;
+
 (** Synchronous provider: can send a message and get a response. *)
 module type PROVIDER = sig
   type t
@@ -106,20 +111,14 @@ let of_config (provider_cfg : Provider.config) : provider_module =
          | Provider.Provider_a_messages ->
            Ok (Api_provider_a.parse_response (Yojson.Safe.from_string body_str))
          | Provider.Openai_chat_completions ->
-           (match
-              Llm_provider.Backend_provider_d_parse.parse_provider_d_response_result
-                body_str
-            with
+           (match parse_provider_d_response_result body_str with
             | Ok resp -> Ok resp
             | Error msg -> Error (Error.Api (Retry.InvalidRequest { message = msg })))
          | Provider.Custom name ->
            (match Provider.find_provider name with
             | Some impl -> Ok (impl.parse_response body_str)
             | None ->
-              (match
-                 Llm_provider.Backend_provider_d_parse.parse_provider_d_response_result
-                   body_str
-               with
+              (match parse_provider_d_response_result body_str with
                | Ok resp -> Ok resp
                | Error msg -> Error (Error.Api (Retry.InvalidRequest { message = msg })))))
       | Ok (code, body_str) ->

--- a/test/dune
+++ b/test/dune
@@ -198,6 +198,7 @@
   test_sse_parser
   test_stream_accumulator
   test_streaming_cov
+  test_streaming_edge_cases
   test_streaming_coverage
   test_streaming_e2e
   test_streaming_keepalive_idle
@@ -418,6 +419,7 @@
   test_sse_parser
   test_stream_accumulator
   test_streaming_cov
+  test_streaming_edge_cases
   test_streaming_coverage
   test_streaming_e2e
   test_streaming_keepalive_idle

--- a/test/dune
+++ b/test/dune
@@ -228,6 +228,8 @@
   test_trajectory
   test_trajectory_unit
   test_cli_transport_factory
+  test_transport_cli_tool_b_coverage
+  test_transport_cli_tool_c_coverage
   test_transport_deep
   test_transport_integration
   test_turn_budget
@@ -451,6 +453,8 @@
   test_trajectory
   test_trajectory_unit
   test_cli_transport_factory
+  test_transport_cli_tool_b_coverage
+  test_transport_cli_tool_c_coverage
   test_transport_deep
   test_transport_integration
   test_turn_budget

--- a/test/dune
+++ b/test/dune
@@ -228,8 +228,10 @@
   test_trajectory
   test_trajectory_unit
   test_cli_transport_factory
+  test_transport_cli_tool_a_coverage
   test_transport_cli_tool_b_coverage
   test_transport_cli_tool_c_coverage
+  test_transport_cli_tool_d_coverage
   test_transport_deep
   test_transport_integration
   test_turn_budget
@@ -453,8 +455,10 @@
   test_trajectory
   test_trajectory_unit
   test_cli_transport_factory
+  test_transport_cli_tool_a_coverage
   test_transport_cli_tool_b_coverage
   test_transport_cli_tool_c_coverage
+  test_transport_cli_tool_d_coverage
   test_transport_deep
   test_transport_integration
   test_turn_budget

--- a/test/dune
+++ b/test/dune
@@ -48,6 +48,7 @@
   test_async_agent
   test_atomic_write_race
   test_backend_provider_d_codec
+  test_backend_provider_k_coverage
   test_backend_tool_call_harness
   test_backend_provider_f
   test_body_timeout
@@ -161,6 +162,7 @@
   test_policy_channel
   test_progressive_tools
   test_provider
+  test_provider_catalog_coverage
   test_provider_config
   test_provider_intf
   test_provider_runtime_binding
@@ -275,6 +277,7 @@
   test_async_agent
   test_atomic_write_race
   test_backend_provider_d_codec
+  test_backend_provider_k_coverage
   test_backend_tool_call_harness
   test_backend_provider_f
   test_body_timeout
@@ -388,6 +391,7 @@
   test_policy_channel
   test_progressive_tools
   test_provider
+  test_provider_catalog_coverage
   test_provider_config
   test_provider_intf
   test_provider_runtime_binding

--- a/test/dune
+++ b/test/dune
@@ -61,6 +61,7 @@
   test_checkpoint_store
   test_checkpoint_validation
   test_cli_common_subprocess
+  test_client_wrapper_coverage
   test_code_snippet_eval
   test_clone
   test_complete_ext
@@ -152,6 +153,7 @@
   test_otel_export
   test_otel_tracer
   test_pipeline
+  test_pipeline_common_coverage
   test_pipeline_deep
   test_pipeline_metrics
   test_plan
@@ -282,6 +284,7 @@
   test_checkpoint_store
   test_checkpoint_validation
   test_cli_common_subprocess
+  test_client_wrapper_coverage
   test_code_snippet_eval
   test_clone
   test_complete_ext
@@ -373,6 +376,7 @@
   test_otel_export
   test_otel_tracer
   test_pipeline
+  test_pipeline_common_coverage
   test_pipeline_deep
   test_pipeline_metrics
   test_plan

--- a/test/dune
+++ b/test/dune
@@ -47,6 +47,7 @@
   test_artifact_service
   test_async_agent
   test_atomic_write_race
+  test_backend_provider_d_codec
   test_backend_tool_call_harness
   test_backend_provider_f
   test_body_timeout
@@ -266,6 +267,7 @@
   test_artifact_service
   test_async_agent
   test_atomic_write_race
+  test_backend_provider_d_codec
   test_backend_tool_call_harness
   test_backend_provider_f
   test_body_timeout

--- a/test/test_backend_provider_d_codec.ml
+++ b/test/test_backend_provider_d_codec.ml
@@ -324,6 +324,146 @@ let test_tool_choice_and_tool_schema_conversion () =
     (Serialize.build_provider_d_tool_json passthrough = passthrough)
 ;;
 
+let ignored_blocks : content_block list =
+  [ Thinking { thinking_type = "reasoning"; content = "   " }
+  ; RedactedThinking "hidden"
+  ; ToolResult
+      { tool_use_id = "call-x"; content = "ignored"; is_error = false; json = None }
+  ; Image { media_type = "image/png"; data = "img"; source_type = "base64" }
+  ; Document { media_type = "application/pdf"; data = "doc"; source_type = "base64" }
+  ; Audio { media_type = "wav"; data = "aud"; source_type = "base64" }
+  ]
+;;
+
+let test_serializer_ignored_block_variants () =
+  check_int
+    "provider_d tool_calls ignores non-tool blocks"
+    0
+    (Serialize.tool_calls_to_provider_d_json ignored_blocks |> List.length);
+  let ollama =
+    Serialize.ollama_messages_of_message (msg Assistant ignored_blocks) |> only "ollama"
+  in
+  Alcotest.(check bool)
+    "ollama has no tool_calls"
+    true
+    (member "tool_calls" ollama = `Null);
+  let assistant =
+    Serialize.provider_d_messages_of_message (msg Assistant ignored_blocks)
+    |> only "assistant"
+  in
+  check_string "assistant content is empty" "" (member "content" assistant |> to_string);
+  Alcotest.(check bool)
+    "assistant has no tool_calls"
+    true
+    (member "tool_calls" assistant = `Null);
+  let provider_k =
+    Serialize.provider_k_messages_of_message (msg Assistant ignored_blocks)
+    |> only "provider_k"
+  in
+  Alcotest.(check bool)
+    "blank reasoning omitted"
+    true
+    (member "reasoning_content" provider_k = `Null);
+  let tool_fallback_blocks =
+    [ Thinking { thinking_type = "reasoning"; content = "   " }
+    ; RedactedThinking "hidden"
+    ; ToolUse { id = "local-call"; name = "local"; input = `Null }
+    ; Image { media_type = "image/png"; data = "img"; source_type = "base64" }
+    ; Document { media_type = "application/pdf"; data = "doc"; source_type = "base64" }
+    ; Audio { media_type = "wav"; data = "aud"; source_type = "base64" }
+    ]
+  in
+  let tool_fallback =
+    Serialize.provider_d_messages_of_message (msg Tool tool_fallback_blocks)
+    |> only "tool fallback"
+  in
+  check_string "tool fallback role" "user" (member "role" tool_fallback |> to_string)
+;;
+
+let test_strip_helpers_cover_non_tool_variants () =
+  let messages =
+    [ msg Assistant ignored_blocks
+    ; msg
+        User
+        (Text "kept"
+         :: ToolUse { id = "local-call"; name = "local"; input = `Null }
+         :: ignored_blocks)
+    ]
+  in
+  let stripped = Serialize.strip_orphaned_tool_results messages in
+  check_int "both messages remain" 2 (List.length stripped);
+  let user = List.nth stripped 1 in
+  Alcotest.(check bool)
+    "orphan tool result dropped"
+    false
+    (List.exists
+       (function
+         | ToolResult _ -> true
+         | _ -> false)
+       user.content);
+  let no_thinking =
+    Serialize.strip_thinking_blocks
+      [ msg
+          Assistant
+          [ RedactedThinking "hidden"
+          ; ToolUse { id = "call"; name = "lookup"; input = `Null }
+          ; ToolResult
+              { tool_use_id = "call"; content = "ok"; is_error = false; json = None }
+          ; Image { media_type = "image/png"; data = "img"; source_type = "base64" }
+          ; Document
+              { media_type = "application/pdf"; data = "doc"; source_type = "base64" }
+          ; Audio { media_type = "wav"; data = "aud"; source_type = "base64" }
+          ]
+      ]
+  in
+  check_int "non-thinking blocks preserved" 6 (List.length (List.hd no_thinking).content)
+;;
+
+let test_tool_schema_defaults_and_legacy_edge_params () =
+  let defaulted =
+    Serialize.build_provider_d_tool_json
+      (`Assoc [ "name", `Int 1; "description", `Bool true ])
+  in
+  check_string
+    "default name"
+    "tool"
+    (member "function" defaulted |> member "name" |> to_string);
+  check_string
+    "default description"
+    ""
+    (member "function" defaulted |> member "description" |> to_string);
+  let legacy =
+    Serialize.build_provider_d_tool_json
+      (`Assoc
+          [ "name", `String "legacy-edge"
+          ; ( "parameters"
+            , `List
+                [ `Assoc [ "name", `Int 1; "description", `String "bad name" ]
+                ; `Assoc
+                    [ "name", `String "flag"
+                    ; "description", `Bool true
+                    ; "type", `Bool true
+                    ; "required", `String "yes"
+                    ]
+                ; `String "ignored"
+                ] )
+          ])
+  in
+  let params = member "function" legacy |> member "parameters" in
+  check_string
+    "default legacy param type"
+    "string"
+    (member "properties" params |> member "flag" |> member "type" |> to_string);
+  check_string
+    "default legacy param description"
+    ""
+    (member "properties" params |> member "flag" |> member "description" |> to_string);
+  check_int
+    "non-bool required omitted"
+    0
+    (member "required" params |> as_list "required" |> List.length)
+;;
+
 let test_strip_json_markdown_fences_variants () =
   check_string "plain" "plain" (Parse.strip_json_markdown_fences " plain ");
   check_string
@@ -487,6 +627,55 @@ let test_parse_error_default_message () =
   | Ok _ -> Alcotest.fail "expected API error"
 ;;
 
+let test_parse_edge_shapes_for_text_and_telemetry () =
+  let invalid_fence =
+    parse_ok (response_json ~content:(`String "```json\nnot-json\n```") ())
+  in
+  (match invalid_fence.content with
+   | [ Text "```json\nnot-json\n```" ] -> ()
+   | _ -> Alcotest.fail "invalid JSON fence should keep original text");
+  let no_text =
+    parse_ok
+      (response_json
+         ~content:
+           (`List
+               [ `Assoc [ "text", `Int 1 ]; `Assoc [ "type", `String "ignored" ]; `Int 7 ])
+         ~message_fields:[ "reasoning_content", `String "  " ]
+         ())
+  in
+  check_int "invalid content blocks produce no content" 0 (List.length no_text.content);
+  let telemetry =
+    parse_ok
+      (`Assoc
+          [ "id", `String "chatcmpl-telemetry"
+          ; "model", `String "provider-d-test"
+          ; ( "choices"
+            , `List
+                [ `Assoc
+                    [ "finish_reason", `String "length"
+                    ; "message", `Assoc [ "content", `Assoc [ "unexpected", `Bool true ] ]
+                    ]
+                ] )
+          ; ( "usage"
+            , `Assoc
+                [ "input_tokens", `Int 11
+                ; "output_tokens", `Int 5
+                ; "prompt_tps", `Int 22
+                ; "generation_tps", `Int 50
+                ; "peak_memory", `Int 3
+                ] )
+          ])
+  in
+  (match telemetry.stop_reason with
+   | MaxTokens -> ()
+   | _ -> Alcotest.fail "length should map to MaxTokens");
+  match telemetry.telemetry with
+  | Some { timings = Some t; peak_memory_gb = Some peak; _ } ->
+    check_float "int prompt tps" 22.0 (Option.get t.prompt_per_second);
+    check_float "int peak memory" 3.0 peak
+  | _ -> Alcotest.fail "expected telemetry from integer rates"
+;;
+
 let () =
   Alcotest.run
     "backend_provider_d_codec"
@@ -520,6 +709,18 @@ let () =
             "tool choice and schema conversion"
             `Quick
             test_tool_choice_and_tool_schema_conversion
+        ; Alcotest.test_case
+            "ignored block variants"
+            `Quick
+            test_serializer_ignored_block_variants
+        ; Alcotest.test_case
+            "strip helpers non-tool variants"
+            `Quick
+            test_strip_helpers_cover_non_tool_variants
+        ; Alcotest.test_case
+            "tool schema defaults and legacy edge params"
+            `Quick
+            test_tool_schema_defaults_and_legacy_edge_params
         ] )
     ; ( "parse"
       , [ Alcotest.test_case
@@ -543,6 +744,10 @@ let () =
             "error default message"
             `Quick
             test_parse_error_default_message
+        ; Alcotest.test_case
+            "edge text shapes and telemetry"
+            `Quick
+            test_parse_edge_shapes_for_text_and_telemetry
         ] )
     ]
 ;;

--- a/test/test_backend_provider_d_codec.ml
+++ b/test/test_backend_provider_d_codec.ml
@@ -1,0 +1,548 @@
+open Llm_provider
+open Types
+module Parse = Backend_provider_d_parse
+module Serialize = Backend_provider_d_serialize
+
+let check_string = Alcotest.(check string)
+let check_int = Alcotest.(check int)
+let check_bool = Alcotest.(check bool)
+let check_float = Alcotest.(check (float 0.0001))
+
+let msg role content : message =
+  { role; content; name = None; tool_call_id = None; metadata = [] }
+;;
+
+let only label = function
+  | [ x ] -> x
+  | xs ->
+    Alcotest.fail (Printf.sprintf "expected one %s item, got %d" label (List.length xs))
+;;
+
+let as_list label = function
+  | `List xs -> xs
+  | json ->
+    Alcotest.fail
+      (Printf.sprintf "expected %s list, got %s" label (Yojson.Safe.to_string json))
+;;
+
+let member key json = Yojson.Safe.Util.member key json
+let to_string json = Yojson.Safe.Util.to_string json
+let to_int json = Yojson.Safe.Util.to_int json
+
+let response_json ?(content = `String "ok") ?(finish_reason = "stop") ?message_fields () =
+  let message_fields =
+    match message_fields with
+    | Some fields -> ("content", content) :: fields
+    | None -> [ "content", content ]
+  in
+  `Assoc
+    [ "id", `String "chatcmpl-test"
+    ; "model", `String "provider-d-test"
+    ; ( "choices"
+      , `List
+          [ `Assoc
+              [ "finish_reason", `String finish_reason; "message", `Assoc message_fields ]
+          ] )
+    ]
+;;
+
+let parse_ok json =
+  match Parse.parse_provider_d_response_result (Yojson.Safe.to_string json) with
+  | Ok response -> response
+  | Error msg -> Alcotest.fail ("unexpected parse error: " ^ msg)
+;;
+
+let test_content_parts_cover_modalities () =
+  let parts =
+    Serialize.provider_d_content_parts_of_blocks
+      [ Text "hello"
+      ; Image { media_type = "image/png"; data = "img"; source_type = "base64" }
+      ; Document { media_type = "application/pdf"; data = "doc"; source_type = "base64" }
+      ; Audio { media_type = "wav"; data = "aud"; source_type = "base64" }
+      ; Thinking { thinking_type = "reasoning"; content = "hidden" }
+      ; RedactedThinking "redacted"
+      ; ToolUse { id = "tc"; name = "tool"; input = `Assoc [] }
+      ]
+  in
+  check_int "parts" 4 (List.length parts);
+  let text = List.nth parts 0 in
+  check_string "text type" "text" (member "type" text |> to_string);
+  check_string "text value" "hello" (member "text" text |> to_string);
+  let image = List.nth parts 1 in
+  check_string "image type" "image_url" (member "type" image |> to_string);
+  check_string
+    "image url"
+    "data:image/png;base64,img"
+    (member "image_url" image |> member "url" |> to_string);
+  let document = List.nth parts 2 in
+  check_string
+    "document url"
+    "data:application/pdf;base64,doc"
+    (member "image_url" document |> member "url" |> to_string);
+  let audio = List.nth parts 3 in
+  check_string "audio type" "input_audio" (member "type" audio |> to_string);
+  check_string
+    "audio format"
+    "wav"
+    (member "input_audio" audio |> member "format" |> to_string)
+;;
+
+let test_provider_d_user_messages_text_tool_and_empty () =
+  let user =
+    msg
+      User
+      [ Text "first"
+      ; Text "second"
+      ; ToolResult
+          { tool_use_id = "call-1"; content = "42"; is_error = false; json = None }
+      ]
+  in
+  let messages = Serialize.provider_d_messages_of_message user in
+  check_int "user + tool messages" 2 (List.length messages);
+  let user_json = List.nth messages 0 in
+  check_string "user role" "user" (member "role" user_json |> to_string);
+  check_string "user content" "first\nsecond" (member "content" user_json |> to_string);
+  let tool_json = List.nth messages 1 in
+  check_string "tool role" "tool" (member "role" tool_json |> to_string);
+  check_string "tool id" "call-1" (member "tool_call_id" tool_json |> to_string);
+  check_string "tool content" "42" (member "content" tool_json |> to_string);
+  let empty_user =
+    Serialize.provider_d_messages_of_message
+      (msg User [ Thinking { thinking_type = ""; content = "x" } ])
+  in
+  check_int "empty user drops message" 0 (List.length empty_user)
+;;
+
+let test_user_multimodal_preserve_and_visual_first () =
+  let content =
+    [ Text "caption"
+    ; Image { media_type = "image/jpeg"; data = "jpeg"; source_type = "base64" }
+    ]
+  in
+  let provider_d =
+    Serialize.provider_d_messages_of_message (msg User content) |> only "provider_d"
+  in
+  let provider_d_parts = member "content" provider_d |> as_list "provider_d content" in
+  check_string
+    "provider_d preserves text first"
+    "text"
+    (List.nth provider_d_parts 0 |> member "type" |> to_string);
+  let visual_first =
+    Serialize.ollama_messages_of_message
+      ~model_id:"model-f-gemma-4-27b-it"
+      (msg User content)
+    |> only "ollama"
+  in
+  let visual_parts = member "content" visual_first |> as_list "ollama content" in
+  check_string
+    "visual model moves image first"
+    "image_url"
+    (List.nth visual_parts 0 |> member "type" |> to_string)
+;;
+
+let test_assistant_tool_calls_provider_d_ollama_and_provider_k () =
+  let assistant =
+    msg
+      Assistant
+      [ ToolUse { id = "call-1"; name = "lookup"; input = `Assoc [ "q", `String "x" ] } ]
+  in
+  let provider_d =
+    Serialize.provider_d_messages_of_message assistant |> only "provider_d"
+  in
+  check_string "assistant role" "assistant" (member "role" provider_d |> to_string);
+  Alcotest.(check bool)
+    "provider_d content null"
+    true
+    (member "content" provider_d = `Null);
+  let call = member "tool_calls" provider_d |> as_list "tool_calls" |> only "tool_call" in
+  check_string
+    "provider_d arguments string"
+    {|{"q":"x"}|}
+    (member "function" call |> member "arguments" |> to_string);
+  let ollama = Serialize.ollama_messages_of_message assistant |> only "ollama" in
+  let ollama_call =
+    member "tool_calls" ollama |> as_list "ollama tool_calls" |> only "tool_call"
+  in
+  check_string
+    "ollama arguments raw json"
+    "x"
+    (member "function" ollama_call |> member "arguments" |> member "q" |> to_string);
+  let provider_k =
+    Serialize.provider_k_messages_of_message
+      (msg
+         Assistant
+         [ Text "answer"; Thinking { thinking_type = "reasoning"; content = "because" } ])
+    |> only "provider_k"
+  in
+  check_string "provider_k content" "answer" (member "content" provider_k |> to_string);
+  check_string
+    "provider_k reasoning"
+    "because"
+    (member "reasoning_content" provider_k |> to_string)
+;;
+
+let test_system_and_tool_role_messages () =
+  let system =
+    Serialize.provider_d_messages_of_message (msg System [ Text "sys" ]) |> only "system"
+  in
+  check_string "system role" "system" (member "role" system |> to_string);
+  check_string "system content" "sys" (member "content" system |> to_string);
+  let tool =
+    Serialize.provider_d_messages_of_message
+      (msg
+         Tool
+         [ ToolResult
+             { tool_use_id = "call-2"; content = "ok"; is_error = false; json = None }
+         ])
+    |> only "tool"
+  in
+  check_string "tool role" "tool" (member "role" tool |> to_string);
+  check_string "tool call id" "call-2" (member "tool_call_id" tool |> to_string);
+  let fallback =
+    Serialize.provider_d_messages_of_message (msg Tool [ Text "plain fallback" ])
+    |> only "fallback"
+  in
+  check_string "fallback role" "user" (member "role" fallback |> to_string);
+  check_string "fallback content" "plain fallback" (member "content" fallback |> to_string)
+;;
+
+let test_strip_orphaned_tool_results_dedupes_and_drops_empty () =
+  let messages =
+    [ msg
+        Assistant
+        [ ToolUse { id = "call-1"; name = "a"; input = `Null }
+        ; ToolUse { id = "call-2"; name = "b"; input = `Null }
+        ]
+    ; msg
+        User
+        [ ToolResult
+            { tool_use_id = "call-1"; content = "first"; is_error = false; json = None }
+        ; ToolResult
+            { tool_use_id = "call-1"; content = "dupe"; is_error = false; json = None }
+        ; ToolResult
+            { tool_use_id = "orphan"; content = "bad"; is_error = true; json = None }
+        ; Text "kept"
+        ]
+    ; msg
+        User
+        [ ToolResult
+            { tool_use_id = "orphan-2"; content = "drop"; is_error = false; json = None }
+        ]
+    ; msg Assistant [ Text "done" ]
+    ]
+  in
+  let stripped = Serialize.strip_orphaned_tool_results messages in
+  check_int "drops empty orphan-only message" 3 (List.length stripped);
+  let user = List.nth stripped 1 in
+  check_int "keeps one matching result and text" 2 (List.length user.content);
+  match user.content with
+  | ToolResult { tool_use_id; content; _ } :: Text text :: _ ->
+    check_string "tool id" "call-1" tool_use_id;
+    check_string "tool content" "first" content;
+    check_string "text" "kept" text
+  | _ -> Alcotest.fail "unexpected stripped user content"
+;;
+
+let test_strip_thinking_blocks () =
+  let messages =
+    [ msg
+        Assistant
+        [ Thinking { thinking_type = "reasoning"; content = "x" }; Text "visible" ]
+    ; msg User [ Text "same" ]
+    ]
+  in
+  let stripped = Serialize.strip_thinking_blocks messages in
+  (match (List.hd stripped).content with
+   | [ Text "visible" ] -> ()
+   | _ -> Alcotest.fail "thinking block should be stripped");
+  match (List.nth stripped 1).content with
+  | [ Text "same" ] -> ()
+  | _ -> Alcotest.fail "unchanged text block should remain"
+;;
+
+let test_tool_choice_and_tool_schema_conversion () =
+  check_string
+    "auto"
+    "\"auto\""
+    (Serialize.tool_choice_to_provider_d_json Auto |> Yojson.Safe.to_string);
+  check_string
+    "required"
+    "\"required\""
+    (Serialize.tool_choice_to_provider_d_json Any |> Yojson.Safe.to_string);
+  check_string
+    "none"
+    "\"none\""
+    (Serialize.tool_choice_to_provider_d_json None_ |> Yojson.Safe.to_string);
+  let tool_choice = Serialize.tool_choice_to_provider_d_json (Tool "lookup") in
+  check_string
+    "tool choice name"
+    "lookup"
+    (member "function" tool_choice |> member "name" |> to_string);
+  let schema = `Assoc [ "type", `String "object" ] in
+  let with_input_schema =
+    Serialize.build_provider_d_tool_json
+      (`Assoc
+          [ "name", `String "direct"; "description", `String "d"; "input_schema", schema ])
+  in
+  check_string
+    "input_schema passes through"
+    "object"
+    (member "function" with_input_schema
+     |> member "parameters"
+     |> member "type"
+     |> to_string);
+  let legacy =
+    Serialize.build_provider_d_tool_json
+      (`Assoc
+          [ "name", `String "legacy"
+          ; ( "parameters"
+            , `List
+                [ `Assoc
+                    [ "name", `String "city"
+                    ; "description", `String "City name"
+                    ; "param_type", `String "string"
+                    ; "required", `Bool true
+                    ]
+                ; `Assoc [ "description", `String "missing name" ]
+                ] )
+          ])
+  in
+  let params = member "function" legacy |> member "parameters" in
+  check_string "legacy type" "object" (member "type" params |> to_string);
+  check_string
+    "legacy property type"
+    "string"
+    (member "properties" params |> member "city" |> member "type" |> to_string);
+  check_string
+    "legacy required"
+    "city"
+    (member "required" params |> as_list "required" |> only "required" |> to_string);
+  let passthrough = `String "raw" in
+  Alcotest.(check bool)
+    "non-object passthrough"
+    true
+    (Serialize.build_provider_d_tool_json passthrough = passthrough)
+;;
+
+let test_strip_json_markdown_fences_variants () =
+  check_string "plain" "plain" (Parse.strip_json_markdown_fences " plain ");
+  check_string
+    "json fence"
+    {|{"a":1}|}
+    (Parse.strip_json_markdown_fences "```json\n{\"a\":1}\n```");
+  check_string
+    "unterminated fence"
+    "```\n{\"a\":1}"
+    (Parse.strip_json_markdown_fences "```\n{\"a\":1}")
+;;
+
+let test_usage_provider_d_fallbacks () =
+  let usage =
+    Parse.usage_of_provider_d_json
+      (`Assoc
+          [ ( "usage"
+            , `Assoc
+                [ "input_tokens", `Int 11
+                ; "output_tokens", `Int 5
+                ; "prompt_cache_hit_tokens", `Int 4
+                ] )
+          ])
+  in
+  (match usage with
+   | Some u ->
+     check_int "input" 11 u.input_tokens;
+     check_int "output" 5 u.output_tokens;
+     check_int "cache read" 4 u.cache_read_input_tokens
+   | None -> Alcotest.fail "expected usage");
+  let usage =
+    Parse.usage_of_provider_d_json
+      (`Assoc
+          [ ( "usage"
+            , `Assoc
+                [ "prompt_tokens", `Int 7
+                ; "completion_tokens", `Int 3
+                ; "prompt_tokens_details", `Assoc [ "cached_tokens", `Int 2 ]
+                ] )
+          ])
+  in
+  match usage with
+  | Some u ->
+    check_int "prompt" 7 u.input_tokens;
+    check_int "completion" 3 u.output_tokens;
+    check_int "details cache" 2 u.cache_read_input_tokens
+  | None -> Alcotest.fail "expected usage with details"
+;;
+
+let test_parse_text_list_reasoning_and_reported_telemetry () =
+  let json =
+    response_json
+      ~content:
+        (`List
+            [ `Assoc [ "type", `String "text"; "text", `String "hello" ]
+            ; `Assoc [ "type", `String "ignored" ]
+            ; `String " raw"
+            ])
+      ~message_fields:[ "reasoning_content", `String "reported reasoning" ]
+      ()
+  in
+  let json =
+    match json with
+    | `Assoc fields ->
+      `Assoc
+        (fields
+         @ [ ( "usage"
+             , `Assoc
+                 [ "prompt_tokens", `Int 12
+                 ; "completion_tokens", `Int 7
+                 ; "completion_tokens_details", `Assoc [ "reasoning_tokens", `Int 5 ]
+                 ] )
+           ; ( "timings"
+             , `Assoc
+                 [ "prompt_n", `Int 12
+                 ; "prompt_ms", `Float 20.5
+                 ; "predicted_n", `Int 7
+                 ; "predicted_per_second", `Float 14.0
+                 ; "cache_n", `Int 2
+                 ] )
+           ; "system_fingerprint", `String "fp-test"
+           ; "peak_memory_gb", `Float 1.25
+           ])
+    | _ -> json
+  in
+  let response = parse_ok json in
+  (match response.content with
+   | [ Thinking { content = "reported reasoning"; _ }; Text "hello raw" ] -> ()
+   | _ -> Alcotest.fail "expected thinking + concatenated text");
+  match response.telemetry with
+  | Some
+      { system_fingerprint = Some fp
+      ; timings = Some timings
+      ; reasoning_tokens = Some rt
+      ; reasoning_tokens_estimated
+      ; peak_memory_gb = Some peak
+      ; _
+      } ->
+    check_string "fingerprint" "fp-test" fp;
+    check_int "reasoning tokens" 5 rt;
+    check_bool "reported not estimated" false reasoning_tokens_estimated;
+    check_float "prompt ms" 20.5 (Option.get timings.prompt_ms);
+    check_float "predicted per second" 14.0 (Option.get timings.predicted_per_second);
+    check_int "cache_n" 2 (Option.get timings.cache_n);
+    check_float "peak" 1.25 peak
+  | _ -> Alcotest.fail "expected telemetry"
+;;
+
+let test_parse_reasoning_estimate_and_fenced_json () =
+  let json =
+    response_json
+      ~content:(`String "```json\n{\"ok\":true}\n```")
+      ~message_fields:[ "reasoning", `String "abcdefghij" ]
+      ()
+  in
+  let response = parse_ok json in
+  (match response.content with
+   | [ Thinking { content = "abcdefghij"; _ }; Text {|{"ok":true}|} ] -> ()
+   | _ -> Alcotest.fail "expected estimated reasoning and stripped JSON text");
+  match response.telemetry with
+  | Some
+      { timings = None; reasoning_tokens = Some n; reasoning_tokens_estimated = true; _ }
+    -> check_bool "estimated at least one token" true (n >= 1)
+  | _ -> Alcotest.fail "expected estimated reasoning telemetry"
+;;
+
+let test_parse_tool_calls_filters_malformed_and_sets_stop_reason () =
+  let json =
+    response_json
+      ~content:`Null
+      ~finish_reason:"unexpected-finish"
+      ~message_fields:
+        [ ( "tool_calls"
+          , `List
+              [ `Assoc
+                  [ "id", `String "call-ok"
+                  ; ( "function"
+                    , `Assoc
+                        [ "name", `String "lookup"
+                        ; "arguments", `String {|{"city":"Seoul"}|}
+                        ] )
+                  ]
+              ; `Assoc [ "id", `String "broken"; "function", `Assoc [] ]
+              ] )
+        ]
+      ()
+  in
+  let response = parse_ok json in
+  match response.stop_reason, response.content with
+  | StopToolUse, [ ToolUse { id; name; input } ] ->
+    check_string "tool id" "call-ok" id;
+    check_string "tool name" "lookup" name;
+    check_string "tool arg" "Seoul" (member "city" input |> to_string)
+  | _ -> Alcotest.fail "expected valid tool call and StopToolUse"
+;;
+
+let test_parse_error_default_message () =
+  let json = `Assoc [ "error", `Assoc [] ] |> Yojson.Safe.to_string in
+  match Parse.parse_provider_d_response_result json with
+  | Error msg -> check_string "default error" "Unknown API error" msg
+  | Ok _ -> Alcotest.fail "expected API error"
+;;
+
+let () =
+  Alcotest.run
+    "backend_provider_d_codec"
+    [ ( "serialize"
+      , [ Alcotest.test_case
+            "content parts cover modalities"
+            `Quick
+            test_content_parts_cover_modalities
+        ; Alcotest.test_case
+            "provider_d user text/tool/empty"
+            `Quick
+            test_provider_d_user_messages_text_tool_and_empty
+        ; Alcotest.test_case
+            "multimodal ordering policies"
+            `Quick
+            test_user_multimodal_preserve_and_visual_first
+        ; Alcotest.test_case
+            "assistant tool calls provider variants"
+            `Quick
+            test_assistant_tool_calls_provider_d_ollama_and_provider_k
+        ; Alcotest.test_case
+            "system and tool roles"
+            `Quick
+            test_system_and_tool_role_messages
+        ; Alcotest.test_case
+            "strip orphaned tool results"
+            `Quick
+            test_strip_orphaned_tool_results_dedupes_and_drops_empty
+        ; Alcotest.test_case "strip thinking blocks" `Quick test_strip_thinking_blocks
+        ; Alcotest.test_case
+            "tool choice and schema conversion"
+            `Quick
+            test_tool_choice_and_tool_schema_conversion
+        ] )
+    ; ( "parse"
+      , [ Alcotest.test_case
+            "strip markdown fences variants"
+            `Quick
+            test_strip_json_markdown_fences_variants
+        ; Alcotest.test_case "usage fallbacks" `Quick test_usage_provider_d_fallbacks
+        ; Alcotest.test_case
+            "text list reasoning and reported telemetry"
+            `Quick
+            test_parse_text_list_reasoning_and_reported_telemetry
+        ; Alcotest.test_case
+            "reasoning estimate and fenced JSON"
+            `Quick
+            test_parse_reasoning_estimate_and_fenced_json
+        ; Alcotest.test_case
+            "tool calls filter malformed"
+            `Quick
+            test_parse_tool_calls_filters_malformed_and_sets_stop_reason
+        ; Alcotest.test_case
+            "error default message"
+            `Quick
+            test_parse_error_default_message
+        ] )
+    ]
+;;

--- a/test/test_backend_provider_k_coverage.ml
+++ b/test/test_backend_provider_k_coverage.ml
@@ -1,0 +1,266 @@
+open Alcotest
+module K = Llm_provider.Backend_provider_k
+module PC = Llm_provider.Provider_config
+module T = Llm_provider.Types
+
+let member key json = Yojson.Safe.Util.member key json
+let to_bool json = Yojson.Safe.Util.to_bool json
+let to_string json = Yojson.Safe.Util.to_string json
+
+let provider_k_config ?enable_thinking ?clear_thinking ?(tool_stream = false) () =
+  PC.make
+    ~kind:PC.Provider_k
+    ~model_id:"provider_k-5.1"
+    ~base_url:"https://api.z.ai/api/paas/v4"
+    ?enable_thinking
+    ?clear_thinking
+    ~tool_stream
+    ()
+;;
+
+let check_class label expected actual = check bool label true (actual = expected)
+
+let check_classification label code message expected retryable =
+  let actual, retry = K.classify_provider_k_error ~code ~message in
+  check_class (label ^ " class") expected actual;
+  check bool (label ^ " retryable") retryable retry
+;;
+
+let response_json ?(reasoning = Some "step by step") ?(content = "answer") () =
+  let message_fields =
+    [ "role", `String "assistant"; "content", `String content ]
+    @
+    match reasoning with
+    | Some r -> [ "reasoning_content", `String r ]
+    | None -> []
+  in
+  Yojson.Safe.to_string
+    (`Assoc
+        [ "id", `String "chatcmpl-provider-k"
+        ; "model", `String "provider_k-5.1"
+        ; ( "choices"
+          , `List
+              [ `Assoc
+                  [ "finish_reason", `String "stop"; "message", `Assoc message_fields ]
+              ] )
+        ; ( "usage"
+          , `Assoc
+              [ "prompt_tokens", `Int 7
+              ; "completion_tokens", `Int 3
+              ; "total_tokens", `Int 10
+              ] )
+        ])
+;;
+
+let test_classification_matrix () =
+  check_classification "auth" "1001" "bad api key" K.Provider_k_auth_error false;
+  check_classification "rate" "1305" "service overloaded" K.Provider_k_rate_limited true;
+  check_classification "quota" "1308" "quota exhausted" K.Provider_k_quota_exceeded false;
+  check_classification "server" "1234" "backend timeout" K.Provider_k_server_error true;
+  check_classification "invalid" "1210" "bad parameter" K.Provider_k_invalid_request false;
+  check_classification
+    "message quota fallback"
+    "unknown"
+    "usage limit exceeded"
+    K.Provider_k_quota_exceeded
+    false;
+  check_classification
+    "message rate fallback"
+    "unknown"
+    "rate limit hit"
+    K.Provider_k_rate_limited
+    true;
+  check_classification
+    "unknown fallback"
+    "9999"
+    "unclassified"
+    K.Provider_k_invalid_request
+    false
+;;
+
+let test_http_status_mapping () =
+  check
+    int
+    "quota"
+    429
+    (K.http_code_of_provider_k_error_class K.Provider_k_quota_exceeded);
+  check int "rate" 429 (K.http_code_of_provider_k_error_class K.Provider_k_rate_limited);
+  check int "auth" 401 (K.http_code_of_provider_k_error_class K.Provider_k_auth_error);
+  check int "server" 500 (K.http_code_of_provider_k_error_class K.Provider_k_server_error);
+  check
+    int
+    "invalid"
+    400
+    (K.http_code_of_provider_k_error_class K.Provider_k_invalid_request)
+;;
+
+let test_build_request_thinking_modes_and_tool_stream () =
+  let messages = [ T.user_msg "calculate" ] in
+  let enabled =
+    K.build_request
+      ~stream:true
+      ~config:
+        (provider_k_config
+           ~enable_thinking:true
+           ~clear_thinking:false
+           ~tool_stream:true
+           ())
+      ~messages
+      ~tools:[ `Assoc [ "name", `String "calc" ] ]
+      ()
+    |> Yojson.Safe.from_string
+  in
+  check
+    string
+    "thinking enabled"
+    "enabled"
+    (enabled |> member "thinking" |> member "type" |> to_string);
+  check
+    bool
+    "clear thinking false"
+    false
+    (enabled |> member "thinking" |> member "clear_thinking" |> to_bool);
+  check bool "tool stream true" true (enabled |> member "tool_stream" |> to_bool);
+  let disabled =
+    K.build_request
+      ~config:(provider_k_config ~enable_thinking:false ~tool_stream:true ())
+      ~messages
+      ()
+    |> Yojson.Safe.from_string
+  in
+  check
+    string
+    "thinking disabled"
+    "disabled"
+    (disabled |> member "thinking" |> member "type" |> to_string);
+  check
+    bool
+    "tool stream gated by stream flag"
+    true
+    (disabled |> member "tool_stream" = `Null);
+  let passthrough =
+    K.build_request ~config:(provider_k_config ()) ~messages () |> Yojson.Safe.from_string
+  in
+  check bool "thinking omitted" true (passthrough |> member "thinking" = `Null)
+;;
+
+let test_parse_response_extracts_reasoning_and_usage () =
+  let resp = K.parse_response (response_json ()) in
+  check string "id" "chatcmpl-provider-k" resp.id;
+  check string "model" "provider_k-5.1" resp.model;
+  (match resp.content with
+   | [ T.Thinking { content = "step by step"; _ }; T.Text "answer" ] -> ()
+   | _ -> fail "expected reasoning block followed by answer text");
+  match resp.usage with
+  | Some usage ->
+    check int "input tokens" 7 usage.input_tokens;
+    check int "output tokens" 3 usage.output_tokens
+  | None -> fail "expected usage"
+;;
+
+let test_parse_response_classifies_provider_k_errors () =
+  let cases =
+    [ ( {|{"error":{"code":"1305","message":"service overloaded"}}|}
+      , "1305"
+      , K.Provider_k_rate_limited
+      , true )
+    ; ( {|{"error":{"code":1234,"message":"server unavailable"}}|}
+      , "1234"
+      , K.Provider_k_server_error
+      , true )
+    ; ( {|{"error":{"code":{"nested":true},"message":"quota exceeded"}}|}
+      , "unknown"
+      , K.Provider_k_quota_exceeded
+      , false )
+    ; {|{"error":{"code":1200}}|}, "1200", K.Provider_k_invalid_request, false
+    ]
+  in
+  List.iter
+    (fun (body, code, expected_class, expected_retryable) ->
+       match K.parse_response body with
+       | exception K.Provider_k_api_error err ->
+         check string "error code" code err.code;
+         check_class "error class" expected_class err.error_class;
+         check bool "retryable" expected_retryable err.is_retryable
+       | _ -> fail "expected Provider_k_api_error")
+    cases
+;;
+
+let test_parse_response_wraps_provider_d_parse_errors () =
+  match K.parse_response {|{"choices":"not-a-list"}|} with
+  | exception K.Provider_k_api_error err ->
+    check string "parse code" "parse" err.code;
+    check_class "parse class" K.Provider_k_invalid_request err.error_class;
+    check bool "parse is not retryable" false err.is_retryable;
+    check bool "parse message surfaced" true (String.length err.message > 0)
+  | _ -> fail "expected Provider_k_api_error"
+;;
+
+let test_extract_reasoning_handles_empty_and_malformed_bodies () =
+  let resp =
+    { T.id = "resp"
+    ; model = "provider_k-5.1"
+    ; stop_reason = T.EndTurn
+    ; content = [ T.Text "answer" ]
+    ; usage = None
+    ; telemetry = None
+    }
+  in
+  let unchanged label body =
+    match (K.extract_reasoning_content resp body).content with
+    | [ T.Text "answer" ] -> ()
+    | _ -> fail (label ^ ": expected unchanged response")
+  in
+  unchanged "blank reasoning" (response_json ~reasoning:(Some "   ") ());
+  unchanged "no choices" {|{"choices":[]}|};
+  unchanged "malformed json" {|not json|}
+;;
+
+let test_parse_stream_chunk_delegates_reasoning_delta () =
+  let data =
+    {|{"id":"chunk-1","model":"provider_k-5.1","choices":[{"delta":{"reasoning_content":"thinking","content":"token"},"index":0}]}|}
+  in
+  match K.parse_stream_chunk data with
+  | Some chunk ->
+    check (option string) "content" (Some "token") chunk.delta_content;
+    check (option string) "reasoning" (Some "thinking") chunk.delta_reasoning
+  | None -> fail "expected stream chunk"
+;;
+
+let () =
+  run
+    "backend_provider_k_coverage"
+    [ ( "classification"
+      , [ test_case "error classification matrix" `Quick test_classification_matrix
+        ; test_case "http status mapping" `Quick test_http_status_mapping
+        ] )
+    ; ( "request"
+      , [ test_case
+            "thinking modes and tool_stream"
+            `Quick
+            test_build_request_thinking_modes_and_tool_stream
+        ] )
+    ; ( "response"
+      , [ test_case
+            "reasoning content and usage"
+            `Quick
+            test_parse_response_extracts_reasoning_and_usage
+        ; test_case
+            "provider_k error classes"
+            `Quick
+            test_parse_response_classifies_provider_k_errors
+        ; test_case
+            "provider_d parse errors"
+            `Quick
+            test_parse_response_wraps_provider_d_parse_errors
+        ; test_case
+            "empty and malformed reasoning bodies"
+            `Quick
+            test_extract_reasoning_handles_empty_and_malformed_bodies
+        ; test_case
+            "stream reasoning delta"
+            `Quick
+            test_parse_stream_chunk_delegates_reasoning_delta
+        ] )
+    ]
+;;

--- a/test/test_backend_tool_call_harness.ml
+++ b/test/test_backend_tool_call_harness.ml
@@ -144,6 +144,154 @@ let test_validate_response_flags_unknown_tool_and_stop_reason () =
   check int "no dropped blocks" 0 result.dropped_content_blocks
 ;;
 
+let contains ~needle text =
+  let needle_len = String.length needle in
+  let text_len = String.length text in
+  let rec loop idx =
+    if idx + needle_len > text_len
+    then false
+    else if String.sub text idx needle_len = needle
+    then true
+    else loop (idx + 1)
+  in
+  needle_len = 0 || loop 0
+;;
+
+let test_schema_validation_covers_scalar_actual_types_and_feedback () =
+  let schema =
+    `Assoc
+      [ "type", `String "object"
+      ; ( "properties"
+        , `Assoc
+            [ "as_array", `Assoc [ "type", `String "object" ]
+            ; "as_object", `Assoc [ "type", `String "array" ]
+            ; "as_null", `Assoc [ "type", `String "string" ]
+            ; "as_bool", `Assoc [ "type", `String "number" ]
+            ; "as_string", `Assoc [ "type", `String "boolean" ]
+            ; "as_float", `Assoc [ "type", `String "integer" ]
+            ] )
+      ]
+  in
+  let response =
+    mk_response
+      [ T.ToolUse
+          { id = "call-3"
+          ; name = "shape_check"
+          ; input =
+              `Assoc
+                [ "as_array", `List []
+                ; "as_object", `Assoc []
+                ; "as_null", `Null
+                ; "as_bool", `Bool true
+                ; "as_string", `String "yes"
+                ; "as_float", `Float 1.5
+                ]
+          }
+      ]
+  in
+  let result =
+    H.validate_response_with_schemas
+      ~declared_tools:[ "shape_check" ]
+      ~tool_schemas:[ "shape_check", schema ]
+      response
+  in
+  match result.tool_calls_found with
+  | [ call ] ->
+    check bool "invalid arguments" false call.arguments_valid;
+    check
+      (list string)
+      "paths"
+      [ "$.as_array"
+      ; "$.as_bool"
+      ; "$.as_float"
+      ; "$.as_null"
+      ; "$.as_object"
+      ; "$.as_string"
+      ]
+      (List.map (fun (v : H.schema_violation) -> v.path) call.violations
+       |> List.sort String.compare);
+    let feedback = H.format_violations_feedback call in
+    check bool "feedback names tool" true (contains ~needle:"shape_check" feedback);
+    check bool "feedback includes path" true (contains ~needle:"$.as_null" feedback);
+    check bool "feedback asks retry" true (contains ~needle:"Please retry" feedback)
+  | _ -> fail "expected one tool call"
+;;
+
+let test_build_schema_map_rejects_missing_name_and_schema () =
+  let direct_parameters =
+    `Assoc [ "name", `String "direct"; "parameters", `Assoc [ "type", `String "object" ] ]
+  in
+  let no_name = `Assoc [ "parameters", `Assoc [ "type", `String "object" ] ] in
+  let no_schema = `Assoc [ "name", `String "no_schema" ] in
+  let function_without_parameters =
+    `Assoc [ "function", `Assoc [ "name", `String "wrapped_no_schema" ] ]
+  in
+  let function_not_object =
+    `Assoc
+      [ "function", `String "bad"; "parameters", `Assoc [ "type", `String "object" ] ]
+  in
+  check
+    bool
+    "null schema ignored"
+    true
+    (H.extract_tool_schema (`Assoc [ "input_schema", `Null ]) = None);
+  let schemas =
+    H.build_schema_map
+      [ direct_parameters
+      ; no_name
+      ; no_schema
+      ; function_without_parameters
+      ; function_not_object
+      ]
+  in
+  check (list string) "only valid named schema" [ "direct" ] (List.map fst schemas)
+;;
+
+let test_provider_convenience_validators_cover_tool_responses () =
+  let provider_a_json =
+    `Assoc
+      [ "id", `String "msg_123"
+      ; "model", `String "agent_llm_a-sonnet"
+      ; "stop_reason", `String "tool_use"
+      ; ( "content"
+        , `List
+            [ `Assoc
+                [ "type", `String "tool_use"
+                ; "id", `String "toolu_1"
+                ; "name", `String "lookup"
+                ; "input", `Assoc [ "q", `String "test" ]
+                ]
+            ] )
+      ]
+  in
+  let provider_a =
+    H.validate_provider_a_response ~declared_tools:[ "lookup" ] provider_a_json
+  in
+  check bool "provider_a stop reason" true provider_a.stop_reason_correct;
+  check bool "provider_a declared tool" true provider_a.all_tools_declared;
+  check int "provider_a tool calls" 1 (List.length provider_a.tool_calls_found);
+  let provider_f_json =
+    Yojson.Safe.from_string
+      {|{
+        "candidates": [{
+          "content": {
+            "parts": [{
+              "functionCall": {"name": "lookup", "args": {"q": "test"}}
+            }],
+            "role": "model"
+          },
+          "finishReason": "STOP"
+        }]
+      }|}
+  in
+  let provider_f =
+    H.validate_provider_f_response ~declared_tools:[ "lookup" ] provider_f_json
+  in
+  check bool "provider_f stop reason" true provider_f.stop_reason_correct;
+  check bool "provider_f declared tool" true provider_f.all_tools_declared;
+  check int "provider_f tool calls" 1 (List.length provider_f.tool_calls_found)
+;;
+
 let () =
   run
     "backend_tool_call_harness"
@@ -167,6 +315,18 @@ let () =
             "unknown tool and stop reason"
             `Quick
             test_validate_response_flags_unknown_tool_and_stop_reason
+        ; test_case
+            "scalar actual types and feedback"
+            `Quick
+            test_schema_validation_covers_scalar_actual_types_and_feedback
+        ; test_case
+            "invalid schema map entries"
+            `Quick
+            test_build_schema_map_rejects_missing_name_and_schema
+        ; test_case
+            "provider convenience validators"
+            `Quick
+            test_provider_convenience_validators_cover_tool_responses
         ] )
     ]
 ;;

--- a/test/test_client_wrapper_coverage.ml
+++ b/test/test_client_wrapper_coverage.ml
@@ -1,0 +1,98 @@
+open Agent_sdk
+module C = Client
+
+let check_bool = Alcotest.(check bool)
+let check_opt_string = Alcotest.(check (option string))
+let check_show label rendered = check_bool label true (String.length rendered > 0)
+
+let minimal_session : Runtime.session =
+  { session_id = "session-client-wrapper"
+  ; goal = "cover client wrapper"
+  ; title = Some "Client wrapper"
+  ; tag = Some "coverage"
+  ; permission_mode = Some "default"
+  ; phase = Runtime.Running
+  ; created_at = 1.0
+  ; updated_at = 2.0
+  ; provider = Some "mock"
+  ; model = Some "mock-model"
+  ; system_prompt = None
+  ; max_turns = 2
+  ; workdir = None
+  ; planned_participants = [ "planner" ]
+  ; participants = []
+  ; artifacts = []
+  ; pending_input = None
+  ; turn_count = 0
+  ; last_seq = 0
+  ; outcome = None
+  }
+;;
+
+let test_client_show_reexported_types () =
+  check_show "default" (C.show_permission_mode C.Default);
+  check_show "accept" (C.show_permission_mode C.Accept_edits);
+  check_show "plan" (C.show_permission_mode C.Plan);
+  check_show "bypass" (C.show_permission_mode C.Bypass_permissions);
+  check_show "user" (C.show_setting_source C.User);
+  check_show "project" (C.show_setting_source C.Project);
+  check_show "local" (C.show_setting_source C.Local);
+  let agent : C.agent_definition =
+    { description = "planner"; prompt = "plan"; tools = Some [ "read" ]; model = None }
+  in
+  check_bool
+    "agent definition show"
+    true
+    (String.length (C.show_agent_definition agent) > 0);
+  check_bool "options show" true (String.length (C.show_options C.default_options) > 0)
+;;
+
+let test_client_show_message_variants () =
+  let messages : C.message list =
+    [ C.System_message "system"
+    ; C.Partial_message { participant_name = "planner"; delta = "partial" }
+    ; C.Session_status minimal_session
+    ; C.Session_events []
+    ; C.Session_report
+        { session_id = minimal_session.session_id
+        ; summary = [ "done" ]
+        ; markdown = "# done"
+        ; generated_at = 3.0
+        }
+    ; C.Session_proof
+        { session_id = minimal_session.session_id
+        ; ok = true
+        ; checks = [ { name = "covered"; passed = true } ]
+        ; evidence = [ "test" ]
+        ; generated_at = 4.0
+        }
+    ]
+  in
+  List.iter
+    (fun msg ->
+       check_bool "message show non-empty" true (String.length (C.show_message msg) > 0))
+    messages
+;;
+
+let test_client_default_options_alias () =
+  check_opt_string "default provider" (Some "local") C.default_options.provider;
+  check_bool "default max turns" true (C.default_options.max_turns = Some 8);
+  check_bool "default setting sources" true (C.default_options.setting_sources = []);
+  check_bool "default no resume" true (Option.is_none C.default_options.resume_session)
+;;
+
+let () =
+  Alcotest.run
+    "Client_wrapper_coverage"
+    [ ( "show"
+      , [ Alcotest.test_case "reexported types" `Quick test_client_show_reexported_types
+        ; Alcotest.test_case "message variants" `Quick test_client_show_message_variants
+        ] )
+    ; ( "defaults"
+      , [ Alcotest.test_case
+            "default options alias"
+            `Quick
+            test_client_default_options_alias
+        ] )
+    ]
+;;

--- a/test/test_harness_runner.ml
+++ b/test/test_harness_runner.ml
@@ -261,6 +261,236 @@ let test_grade_case_negative_metric_tolerance () =
   check bool "failed" true (result.status = Harness_report.Fail)
 ;;
 
+let test_grade_case_skips_empty_assertions () =
+  let case_ = Harness_case.make_fixture ~id:"empty" ~prompt:"noop" () in
+  let result =
+    Harness_runner.grade_case
+      ~agent_name:"runner-agent"
+      ~elapsed:0.1
+      ~response:(Ok (ok_response "done"))
+      ~observation:(mk_observation ())
+      case_
+  in
+  check bool "skipped" true (result.status = Harness_report.Skip);
+  check (option string) "detail" (Some "case had no assertions") result.detail
+;;
+
+let test_grade_case_response_assertion_failures () =
+  let case_ =
+    Harness_case.make_fixture
+      ~assertions:
+        [ Harness_case.Response (Harness_case.Exact_text "expected")
+        ; Harness_case.Response (Harness_case.Contains_text "needle")
+        ; Harness_case.Response
+            (Harness_case.Structural_json (`Assoc [ "ok", `Bool true ]))
+        ]
+      ~id:"response-failures"
+      ~prompt:"noop"
+      ()
+  in
+  let result =
+    Harness_runner.grade_case
+      ~agent_name:"runner-agent"
+      ~elapsed:0.1
+      ~response:(Ok (ok_response "not-json"))
+      ~observation:(mk_observation ~final_response:"not-json" ())
+      case_
+  in
+  check bool "failed" true (result.status = Harness_report.Fail);
+  check int "all verdicts evaluated" 3 (List.length result.verdicts)
+;;
+
+let test_grade_case_structural_json_passes () =
+  let case_ =
+    Harness_case.make_fixture
+      ~assertions:
+        [ Harness_case.Response
+            (Harness_case.Structural_json (`Assoc [ "ok", `Bool true ]))
+        ]
+      ~id:"json-pass"
+      ~prompt:"noop"
+      ()
+  in
+  let result =
+    Harness_runner.grade_case
+      ~agent_name:"runner-agent"
+      ~elapsed:0.1
+      ~response:(Ok (ok_response {|{"ok":true}|}))
+      ~observation:(mk_observation ~final_response:{|{"ok":true}|} ())
+      case_
+  in
+  check bool "passed" true (result.status = Harness_report.Pass)
+;;
+
+let test_grade_case_trace_assertion_matrix () =
+  let case_ =
+    Harness_case.make_fixture
+      ~assertions:
+        [ Harness_case.Trace (Harness_case.Tool_called "read")
+        ; Harness_case.Trace (Harness_case.Tool_sequence [ "read"; "write" ])
+        ; Harness_case.Trace (Harness_case.Tool_call_count 2)
+        ; Harness_case.Trace (Harness_case.Max_turns 3)
+        ]
+      ~id:"trace-pass"
+      ~prompt:"noop"
+      ()
+  in
+  let result =
+    Harness_runner.grade_case
+      ~agent_name:"runner-agent"
+      ~elapsed:0.1
+      ~response:(Ok (ok_response "done"))
+      ~observation:(mk_observation ~tools_called:[ "read"; "write" ] ~turn_count:2 ())
+      ~trajectory:(mk_trajectory ~tool_names:[ "read"; "write" ] ())
+      case_
+  in
+  check bool "passed" true (result.status = Harness_report.Pass);
+  check int "trace verdicts" 4 (List.length result.verdicts)
+;;
+
+let test_grade_case_trace_assertion_failures () =
+  let case_ =
+    Harness_case.make_fixture
+      ~assertions:
+        [ Harness_case.Trace (Harness_case.Tool_called "write")
+        ; Harness_case.Trace (Harness_case.Tool_sequence [ "write" ])
+        ; Harness_case.Trace (Harness_case.Tool_call_count 2)
+        ; Harness_case.Trace (Harness_case.Max_turns 2)
+        ]
+      ~id:"trace-fail"
+      ~prompt:"noop"
+      ()
+  in
+  let result =
+    Harness_runner.grade_case
+      ~agent_name:"runner-agent"
+      ~elapsed:0.1
+      ~response:(Ok (ok_response "done"))
+      ~observation:(mk_observation ~tools_called:[ "read" ] ~turn_count:5 ())
+      ~trajectory:(mk_trajectory ~tool_names:[ "read" ] ())
+      case_
+  in
+  check bool "failed" true (result.status = Harness_report.Fail);
+  check int "trace verdicts" 4 (List.length result.verdicts)
+;;
+
+let test_grade_case_metric_variants () =
+  let pass_case =
+    Harness_case.make_fixture
+      ~assertions:
+        [ Harness_case.Metric
+            { name = "input_tokens"
+            ; goal = Eval.Higher
+            ; target = Eval.Int_val 5
+            ; tolerance_pct = Some 0.0
+            }
+        ; Harness_case.Metric
+            { name = "output_tokens"
+            ; goal = Eval.Exact
+            ; target = Eval.Int_val 5
+            ; tolerance_pct = Some 0.0
+            }
+        ; Harness_case.Metric
+            { name = "success"
+            ; goal = Eval.Exact
+            ; target = Eval.Bool_val true
+            ; tolerance_pct = None
+            }
+        ]
+      ~id:"metric-pass"
+      ~prompt:"noop"
+      ()
+  in
+  let pass_result =
+    Harness_runner.grade_case
+      ~agent_name:"runner-agent"
+      ~elapsed:0.1
+      ~response:(Ok (ok_response "done"))
+      ~observation:(mk_observation ())
+      pass_case
+  in
+  check bool "metrics pass" true (pass_result.status = Harness_report.Pass);
+  let fail_case =
+    Harness_case.make_fixture
+      ~assertions:
+        [ Harness_case.Metric
+            { name = "missing_metric"
+            ; goal = Eval.Exact
+            ; target = Eval.Int_val 1
+            ; tolerance_pct = None
+            }
+        ; Harness_case.Metric
+            { name = "success"
+            ; goal = Eval.Higher
+            ; target = Eval.Bool_val false
+            ; tolerance_pct = None
+            }
+        ]
+      ~id:"metric-fail"
+      ~prompt:"noop"
+      ()
+  in
+  let fail_result =
+    Harness_runner.grade_case
+      ~agent_name:"runner-agent"
+      ~elapsed:0.1
+      ~response:(Ok (ok_response "done"))
+      ~observation:(mk_observation ())
+      fail_case
+  in
+  check bool "metrics fail" true (fail_result.status = Harness_report.Fail);
+  check int "all metric verdicts" 2 (List.length fail_result.verdicts)
+;;
+
+let test_grade_case_error_response_fails_success_assertion () =
+  let case_ =
+    Harness_case.make_fixture
+      ~assertions:[ Harness_case.Trace Harness_case.Succeeds ]
+      ~id:"error-response"
+      ~prompt:"noop"
+      ()
+  in
+  let result =
+    Harness_runner.grade_case
+      ~agent_name:"runner-agent"
+      ~elapsed:0.1
+      ~response:(Error (Error.Internal "boom"))
+      ~observation:(mk_observation ())
+      case_
+  in
+  check bool "failed" true (result.status = Harness_report.Fail);
+  check (option string) "empty response text" (Some "") result.response_text
+;;
+
+let trace_case_without_path =
+  { Harness_case.id = "trace-no-path"
+  ; kind = Harness_case.Trace_replay
+  ; prompt = "Replay"
+  ; tags = []
+  ; assertions = [ Harness_case.Trace Harness_case.Succeeds ]
+  ; artifacts = []
+  ; source_trace_path = None
+  }
+;;
+
+let test_grade_case_from_trace_rejects_missing_path () =
+  match Harness_runner.grade_case_from_trace trace_case_without_path with
+  | Ok _ -> fail "expected missing trace path to fail"
+  | Error _ -> ()
+;;
+
+let test_execute_case_trace_missing_path_returns_failure () =
+  let result = Harness_runner.execute_case trace_case_without_path in
+  check bool "failed" true (result.status = Harness_report.Fail);
+  check
+    bool
+    "detail mentions source_trace_path"
+    true
+    (match result.detail with
+     | Some detail -> Util.string_contains ~needle:"source_trace_path" detail
+     | None -> false)
+;;
+
 let test_run_dataset_mixed_dispatches_by_kind () =
   with_trace_file "mixed" (fun trace_path ->
     let fixture_case =
@@ -339,6 +569,30 @@ let () =
             "rejects negative tolerance"
             `Quick
             test_grade_case_negative_metric_tolerance
+        ; test_case "skips empty assertions" `Quick test_grade_case_skips_empty_assertions
+        ; test_case
+            "response assertion failures"
+            `Quick
+            test_grade_case_response_assertion_failures
+        ; test_case "structural json passes" `Quick test_grade_case_structural_json_passes
+        ; test_case "trace assertion matrix" `Quick test_grade_case_trace_assertion_matrix
+        ; test_case
+            "trace assertion failures"
+            `Quick
+            test_grade_case_trace_assertion_failures
+        ; test_case "metric variants" `Quick test_grade_case_metric_variants
+        ; test_case
+            "error response fails success assertion"
+            `Quick
+            test_grade_case_error_response_fails_success_assertion
+        ; test_case
+            "trace missing path rejected"
+            `Quick
+            test_grade_case_from_trace_rejects_missing_path
+        ; test_case
+            "execute trace missing path"
+            `Quick
+            test_execute_case_trace_missing_path_returns_failure
         ; test_case
             "mixed dataset dispatches by kind"
             `Quick

--- a/test/test_llm_provider_error.ml
+++ b/test/test_llm_provider_error.ml
@@ -336,6 +336,208 @@ let test_cli_transport_required_mapping () =
   | _ -> fail "expected InvalidConfig"
 ;;
 
+let test_retry_remaining_variants_mapping () =
+  let cases =
+    [ ( Error.of_retry_api_error
+          ~provider:"provider_d"
+          (Retry.AuthError { message = "bad key" })
+      , "auth" )
+    ; ( Error.of_retry_api_error
+          ~provider:"provider_d"
+          (Retry.InvalidRequest { message = "bad payload" })
+      , "invalid" )
+    ; ( Error.of_retry_api_error
+          ~provider:"provider_d"
+          (Retry.NotFound { message = "missing model" })
+      , "not_found" )
+    ; ( Error.of_retry_api_error
+          ~provider:"provider_d"
+          (Retry.ContextOverflow { message = "too long"; limit = Some 123 })
+      , "context" )
+    ; ( Error.of_retry_api_error
+          ~provider:"provider_d"
+          (Retry.NetworkError { message = "tls"; kind = Http_client.Tls_error })
+      , "network" )
+    ; ( Error.of_retry_api_error
+          ~provider:"provider_d"
+          (Retry.Timeout { message = "slow" })
+      , "timeout" )
+    ]
+  in
+  List.iter
+    (fun (err, expected) ->
+       match expected, err with
+       | "auth", Error.AuthError { detail; _ } ->
+         check string "auth detail" "bad key" detail
+       | "invalid", Error.InvalidRequest { reason; _ } ->
+         check string "invalid reason" "bad payload" reason
+       | "not_found", Error.NotFound { detail; _ } ->
+         check string "not found detail" "missing model" detail
+       | "context", Error.InvalidRequest { reason; _ } ->
+         check bool "context reason" true (String.length reason > 0)
+       | "network", Error.NetworkError { kind = Http_client.Tls_error; detail; _ } ->
+         check string "network detail" "tls" detail
+       | "timeout", Error.Timeout { detail; _ } ->
+         check string "timeout detail" "slow" detail
+       | _ -> fail ("unexpected mapping for " ^ expected))
+    cases
+;;
+
+let test_provider_failure_remaining_variants_mapping () =
+  let provider_failure ?provider kind message =
+    Error.of_http_error ?provider (Http_client.ProviderFailure { kind; message })
+  in
+  let hard_quota =
+    provider_failure
+      ~provider:"provider_f"
+      (Http_client.Hard_quota { retry_after = Some 4.0 })
+      "billing"
+  in
+  (match hard_quota with
+   | Error.HardQuota { provider; retry_after; detail } ->
+     check string "hard quota provider" "provider_f" provider;
+     check (option (float 0.001)) "hard quota retry after" (Some 4.0) retry_after;
+     check string "hard quota detail" "billing" detail
+   | _ -> fail "expected HardQuota");
+  let capacity_unknown_provider =
+    provider_failure
+      ~provider:""
+      (Http_client.Capacity_exhausted
+         { scope = Http_client.Failure_scope_account; retry_after = None; model = None })
+      "account queue"
+  in
+  (match capacity_unknown_provider with
+   | Error.CapacityExhausted { scope; affected; detail; _ } ->
+     check bool "account scope" true (scope = Error.CapacityAccount);
+     check (list string) "unknown provider has no affected list" [] affected;
+     check string "capacity detail" "account queue" detail
+   | _ -> fail "expected account CapacityExhausted");
+  let mismatch =
+    provider_failure
+      ~provider:"provider_c"
+      (Http_client.Capability_mismatch { capability = None })
+      "tool stream disabled"
+  in
+  (match mismatch with
+   | Error.InvalidRequest { reason; _ } ->
+     check
+       bool
+       "default capability reason"
+       true
+       (Agent_sdk.Util.string_contains ~needle:"missing provider capability" reason)
+   | _ -> fail "expected InvalidRequest capability mismatch");
+  let policy =
+    provider_failure
+      ~provider:"cli_tool_d"
+      (Http_client.Cli_policy_invalid { tool_name = Some "Read"; rule = Some 3 })
+      "blocked"
+  in
+  (match policy with
+   | Error.InvalidRequest { reason; _ } ->
+     check
+       bool
+       "policy reason"
+       true
+       (Agent_sdk.Util.string_contains ~needle:"rule 3" reason)
+   | _ -> fail "expected InvalidRequest policy rejection");
+  let startup =
+    provider_failure
+      ~provider:"cli_tool_a"
+      (Http_client.Cli_startup_failed { reason = "not executable" })
+      "permission denied"
+  in
+  (match startup with
+   | Error.ProviderUnavailable { detail; _ } ->
+     check string "startup detail" "not executable: permission denied" detail
+   | _ -> fail "expected ProviderUnavailable startup failure");
+  let parse =
+    provider_failure (Http_client.Provider_parse_error { parser = None }) "bad JSON"
+  in
+  (match parse with
+   | Error.ParseError { detail } ->
+     check string "parser default" "unknown_parser: bad JSON" detail
+   | _ -> fail "expected ParseError");
+  let unknown =
+    provider_failure
+      ~provider:"provider_x"
+      (Http_client.Unknown_provider_failure { reason = Some "exit_status" })
+      "exited 2"
+  in
+  match unknown with
+  | Error.ProviderUnavailable { detail; _ } ->
+    check string "unknown detail" "exit_status: exited 2" detail
+  | _ -> fail "expected ProviderUnavailable unknown failure"
+;;
+
+let test_http_boundary_remaining_variants_mapping () =
+  let accept =
+    Error.of_http_error
+      ~provider:"provider_a"
+      (Http_client.AcceptRejected { reason = "unsupported media type" })
+  in
+  (match accept with
+   | Error.InvalidRequest { reason; _ } ->
+     check string "accept rejection" "accept rejected: unsupported media type" reason
+   | _ -> fail "expected accept InvalidRequest");
+  let terminal_other =
+    Error.of_http_error
+      ~provider:"cli_tool_a"
+      (Http_client.ProviderTerminal
+         { kind = Http_client.Other "cancelled"; message = "operator cancelled" })
+  in
+  match terminal_other with
+  | Error.ProviderTerminal { reason; detail; _ } ->
+    check string "terminal reason" "cancelled" reason;
+    check string "terminal detail" "operator cancelled" detail
+  | _ -> fail "expected ProviderTerminal Other"
+;;
+
+let test_is_retryable_matrix () =
+  let retryable err = check bool (Error.to_string err) true (Error.is_retryable err) in
+  let not_retryable err =
+    check bool (Error.to_string err) false (Error.is_retryable err)
+  in
+  retryable (Error.RateLimit { provider = "p"; retry_after = None; detail = "burst" });
+  retryable
+    (Error.CapacityExhausted
+       { scope = Error.CapacityProvider
+       ; affected = [ "p" ]
+       ; retry_after = None
+       ; detail = "busy"
+       });
+  retryable
+    (Error.ServerError { provider = "p"; code = 503; transient = true; detail = "down" });
+  not_retryable
+    (Error.ServerError { provider = "p"; code = 500; transient = false; detail = "fatal" });
+  retryable
+    (Error.NetworkError
+       { provider = "p"
+       ; kind = Http_client.Connection_refused
+       ; timeout_phase = None
+       ; detail = "refused"
+       });
+  not_retryable
+    (Error.NetworkError
+       { provider = "p"
+       ; kind = Http_client.Tls_error
+       ; timeout_phase = None
+       ; detail = "tls"
+       });
+  not_retryable
+    (Error.NetworkError
+       { provider = "p"
+       ; kind = Http_client.Local_resource_exhaustion
+       ; timeout_phase = None
+       ; detail = "fd"
+       });
+  retryable (Error.Timeout { provider = "p"; timeout_phase = None; detail = "slow" });
+  not_retryable
+    (Error.HardQuota { provider = "p"; retry_after = None; detail = "billing" });
+  not_retryable (Error.ProviderUnavailable { provider = "p"; detail = "missing" });
+  not_retryable (Error.AuthError { provider = "p"; detail = "bad key" });
+  not_retryable (Error.NotFound { provider = "p"; detail = "model" })
+;;
+
 let () =
   run
     "llm_provider_error"
@@ -370,6 +572,19 @@ let () =
         ; test_case "HTTP network error" `Quick test_http_network_error_mapping
         ; test_case "HTTP timeout error" `Quick test_http_timeout_error_mapping
         ; test_case "CLI transport required" `Quick test_cli_transport_required_mapping
+        ; test_case
+            "Retry remaining variants"
+            `Quick
+            test_retry_remaining_variants_mapping
+        ; test_case
+            "Provider failure remaining variants"
+            `Quick
+            test_provider_failure_remaining_variants_mapping
+        ; test_case
+            "HTTP boundary remaining variants"
+            `Quick
+            test_http_boundary_remaining_variants_mapping
+        ; test_case "is_retryable matrix" `Quick test_is_retryable_matrix
         ] )
     ]
 ;;

--- a/test/test_memory_procedural.ml
+++ b/test/test_memory_procedural.ml
@@ -1,4 +1,5 @@
 open Agent_sdk
+module Procedural = Agent_sdk__Memory_procedural
 
 let make_backend () =
   let store = Hashtbl.create 4 in
@@ -10,6 +11,19 @@ let make_backend () =
     }
   in
   backend
+;;
+
+let procedure ?(metadata = []) ?(success_count = 2) ?(failure_count = 1) id =
+  let confidence = Procedural.compute_confidence ~success_count ~failure_count in
+  { Procedural.id
+  ; pattern = "deploy " ^ id
+  ; action = "run " ^ id
+  ; success_count
+  ; failure_count
+  ; confidence
+  ; last_used = 100.0
+  ; metadata
+  }
 ;;
 
 let () =
@@ -336,6 +350,95 @@ let () =
               };
             let _, _, _, pr, _ = Memory.stats mem in
             Alcotest.(check int) "procedural count" 1 pr)
+        ] )
+    ; ( "low_level"
+      , [ Alcotest.test_case "confidence zero and ratio" `Quick (fun () ->
+            Alcotest.(check (float 0.0001))
+              "empty confidence"
+              0.0
+              (Procedural.compute_confidence ~success_count:0 ~failure_count:0);
+            Alcotest.(check (float 0.0001))
+              "ratio confidence"
+              0.75
+              (Procedural.compute_confidence ~success_count:3 ~failure_count:1))
+        ; Alcotest.test_case "json round trip preserves metadata" `Quick (fun () ->
+            let proc =
+              procedure
+                "pr-json"
+                ~metadata:[ "team", `String "release"; "attempts", `Int 2 ]
+            in
+            match Procedural.procedure_of_json (Procedural.procedure_to_json proc) with
+            | Some parsed ->
+              Alcotest.(check string) "id" proc.id parsed.id;
+              Alcotest.(check int) "metadata count" 2 (List.length parsed.metadata)
+            | None -> Alcotest.fail "expected procedure json to parse")
+        ; Alcotest.test_case
+            "json rejects missing required fields and ignores bad metadata"
+            `Quick
+            (fun () ->
+               let invalid = `Assoc [ "id", `String "missing-fields" ] in
+               Alcotest.(check bool)
+                 "missing fields rejected"
+                 true
+                 (Option.is_none (Procedural.procedure_of_json invalid));
+               let with_bad_metadata =
+                 `Assoc
+                   [ "id", `String "pr-bad-meta"
+                   ; "pattern", `String "deploy"
+                   ; "action", `String "retry"
+                   ; "success_count", `Int 1
+                   ; "failure_count", `Int 0
+                   ; "confidence", `Float 1.0
+                   ; "last_used", `Float 10.0
+                   ; "metadata", `String "not-object"
+                   ]
+               in
+               match Procedural.procedure_of_json with_bad_metadata with
+               | Some parsed ->
+                 Alcotest.(check int)
+                   "bad metadata normalized"
+                   0
+                   (List.length parsed.metadata)
+               | None -> Alcotest.fail "expected bad metadata to normalize")
+        ; Alcotest.test_case
+            "context operations sort, update, and forget"
+            `Quick
+            (fun () ->
+               let ctx = Context.create () in
+               Procedural.store ctx (procedure "low" ~success_count:1 ~failure_count:3);
+               Procedural.store ctx (procedure "high" ~success_count:4 ~failure_count:0);
+               let matches = Procedural.matching ctx ~pattern:"deploy" () in
+               (match matches with
+                | high :: low :: _ ->
+                  Alcotest.(check string) "highest confidence first" "high" high.id;
+                  Alcotest.(check string) "lower confidence second" "low" low.id
+                | _ -> Alcotest.fail "expected two sorted procedures");
+               Procedural.record_failure ctx "high";
+               (match Procedural.find ctx ~pattern:"high" () with
+                | Some high ->
+                  Alcotest.(check int) "failure incremented" 1 high.failure_count;
+                  Alcotest.(check (float 0.0001)) "confidence updated" 0.8 high.confidence
+                | None -> Alcotest.fail "updated procedure missing");
+               Procedural.record_success ctx "missing";
+               Context.set_scoped ctx (Context.Custom "pr") "corrupt" (`String "bad");
+               Procedural.record_success ctx "corrupt";
+               Procedural.forget ctx "low";
+               Procedural.forget ctx "corrupt";
+               Alcotest.(check int) "one valid remains" 1 (Procedural.count ctx))
+        ; Alcotest.test_case "find touch persists last_used" `Quick (fun () ->
+            let ctx = Context.create () in
+            Procedural.store ctx (procedure "touch" ~success_count:1 ~failure_count:0);
+            match Procedural.find ctx ~pattern:"touch" ~touch:true () with
+            | Some touched ->
+              Alcotest.(check bool) "touched" true (touched.last_used > 100.0);
+              (match Procedural.best ctx ~pattern:"touch" with
+               | Some persisted ->
+                 Alcotest.(check (float 0.001))
+                   "persisted touch"
+                   touched.last_used
+                   persisted.last_used
+               | None -> Alcotest.fail "persisted touch missing")
+            | None -> Alcotest.fail "touch procedure missing")
         ] )
     ]
 ;;

--- a/test/test_pipeline_common_coverage.ml
+++ b/test/test_pipeline_common_coverage.ml
@@ -1,0 +1,200 @@
+open Agent_sdk
+module Internal_agent = Agent_sdk__Agent_types
+module Pipeline_common = Agent_sdk__Pipeline_common
+
+let check_bool = Alcotest.(check bool)
+let check_int = Alcotest.(check int)
+let check_string = Alcotest.(check string)
+
+let provider_d_config : Provider.config =
+  { provider = Local { base_url = "http://127.0.0.1:65535" }
+  ; model_id = "provider_d_chat"
+  ; api_key_env = "DUMMY_KEY"
+  }
+;;
+
+let text_response ?(content = [ Types.Text "ok" ]) () : Types.api_response =
+  { id = "resp-1"
+  ; model = "provider_d_chat"
+  ; stop_reason = EndTurn
+  ; content
+  ; usage = None
+  ; telemetry = None
+  }
+;;
+
+let with_agent
+      ?(config = Types.default_config)
+      ?(options = Internal_agent.default_options)
+      f
+  =
+  Eio_main.run
+  @@ fun env ->
+  let agent = Internal_agent.create ~net:env#net ~config ~options () in
+  f agent
+;;
+
+let test_strategy_and_outcome_constructors () =
+  let events = ref 0 in
+  let strategy =
+    Pipeline_common.Stream
+      { on_event = (fun _ -> incr events); on_telemetry = Some (fun _ -> incr events) }
+  in
+  (match strategy with
+   | Pipeline_common.Stream { on_event; on_telemetry = Some _ } ->
+     on_event MessageStop;
+     check_int "event callback" 1 !events
+   | _ -> Alcotest.fail "expected stream strategy");
+  (match Pipeline_common.Sync with
+   | Pipeline_common.Sync -> ()
+   | _ -> Alcotest.fail "expected sync strategy");
+  let complete = Pipeline_common.Complete (text_response ()) in
+  (match complete with
+   | Pipeline_common.Complete response -> check_string "response id" "resp-1" response.id
+   | _ -> Alcotest.fail "expected complete outcome");
+  (match Pipeline_common.ToolsExecuted with
+   | Pipeline_common.ToolsExecuted -> ()
+   | _ -> Alcotest.fail "expected tools outcome");
+  match Pipeline_common.IdleSkipped with
+  | Pipeline_common.IdleSkipped -> ()
+  | _ -> Alcotest.fail "expected idle outcome"
+;;
+
+let test_validate_completion_contract_accepts_default_text () =
+  with_agent (fun agent ->
+    match Pipeline_common.validate_completion_contract agent (text_response ()) with
+    | Ok () -> ()
+    | Error err -> Alcotest.failf "unexpected contract error: %s" (Error.to_string err))
+;;
+
+let test_validate_completion_contract_rejects_missing_tool () =
+  let config = { Types.default_config with tool_choice = Some Types.Any } in
+  let options =
+    { Internal_agent.default_options with provider = Some provider_d_config }
+  in
+  with_agent ~config ~options (fun agent ->
+    match Pipeline_common.validate_completion_contract agent (text_response ()) with
+    | Error (Error.Agent (CompletionContractViolation _)) -> ()
+    | Error err -> Alcotest.failf "unexpected error: %s" (Error.to_string err)
+    | Ok () -> Alcotest.fail "expected missing tool-use violation")
+;;
+
+let test_validate_completion_contract_accepts_tool_use () =
+  let config = { Types.default_config with tool_choice = Some Types.Any } in
+  let options =
+    { Internal_agent.default_options with provider = Some provider_d_config }
+  in
+  let response =
+    text_response
+      ~content:[ Types.ToolUse { id = "call-1"; name = "lookup"; input = `Assoc [] } ]
+      ()
+  in
+  with_agent ~config ~options (fun agent ->
+    match Pipeline_common.validate_completion_contract agent response with
+    | Ok () -> ()
+    | Error err -> Alcotest.failf "unexpected contract error: %s" (Error.to_string err))
+;;
+
+let test_event_envelope_falls_back_without_trace () =
+  with_agent (fun agent ->
+    let envelope = Pipeline_common.event_envelope agent in
+    check_bool "correlation id" true (String.length envelope.correlation_id > 0);
+    check_bool "run id" true (String.length envelope.run_id > 0))
+;;
+
+let test_event_envelope_uses_trace_and_lifecycle () =
+  let root =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "oas-pipeline-common-%d" (Unix.getpid ()))
+  in
+  Unix.mkdir root 0o755;
+  let trace_path = Filename.concat root "trace.jsonl" in
+  let trace =
+    match Raw_trace.create ~session_id:"session-123" ~path:trace_path () with
+    | Ok trace -> trace
+    | Error err -> Alcotest.fail (Error.to_string err)
+  in
+  let options = { Internal_agent.default_options with raw_trace = Some trace } in
+  with_agent ~options (fun agent ->
+    Internal_agent.set_lifecycle agent ~current_run_id:"run-123" Agent.Running;
+    let envelope = Pipeline_common.event_envelope agent in
+    check_string "trace session" "session-123" envelope.correlation_id;
+    check_string "lifecycle run" "run-123" envelope.run_id);
+  (try Sys.remove trace_path with
+   | Sys_error _ -> ());
+  try Unix.rmdir root with
+  | Unix.Unix_error _ -> ()
+;;
+
+let test_total_prompt_tokens_for_agent_includes_tiered_memory () =
+  let messages : Types.message list =
+    [ { role = User
+      ; content = [ Text "short request" ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let base_tokens =
+    with_agent (fun agent -> Pipeline_common.total_prompt_tokens_for_agent agent messages)
+  in
+  let tiered_memory : Types.tiered_memory =
+    { long_term = Some "long term memory"
+    ; mid_term = Some "mid term memory"
+    ; short_term = Some "short term memory"
+    }
+  in
+  let options =
+    { Internal_agent.default_options with tiered_memory = Some tiered_memory }
+  in
+  let tiered_tokens =
+    with_agent ~options (fun agent ->
+      Pipeline_common.total_prompt_tokens_for_agent agent messages)
+  in
+  check_bool "base tokens positive" true (base_tokens > 0);
+  check_bool "tiered memory adds tokens" true (tiered_tokens > base_tokens)
+;;
+
+let () =
+  Alcotest.run
+    "Pipeline_common_coverage"
+    [ ( "types"
+      , [ Alcotest.test_case
+            "strategy and outcome constructors"
+            `Quick
+            test_strategy_and_outcome_constructors
+        ] )
+    ; ( "contract"
+      , [ Alcotest.test_case
+            "default text accepted"
+            `Quick
+            test_validate_completion_contract_accepts_default_text
+        ; Alcotest.test_case
+            "missing required tool rejected"
+            `Quick
+            test_validate_completion_contract_rejects_missing_tool
+        ; Alcotest.test_case
+            "tool use accepted"
+            `Quick
+            test_validate_completion_contract_accepts_tool_use
+        ] )
+    ; ( "envelope"
+      , [ Alcotest.test_case
+            "fallback ids"
+            `Quick
+            test_event_envelope_falls_back_without_trace
+        ; Alcotest.test_case
+            "trace and lifecycle ids"
+            `Quick
+            test_event_envelope_uses_trace_and_lifecycle
+        ] )
+    ; ( "tokens"
+      , [ Alcotest.test_case
+            "tiered memory counted"
+            `Quick
+            test_total_prompt_tokens_for_agent_includes_tiered_memory
+        ] )
+    ]
+;;

--- a/test/test_provider_catalog_coverage.ml
+++ b/test/test_provider_catalog_coverage.ml
@@ -1,0 +1,475 @@
+open Alcotest
+open Llm_provider
+
+let contains ~needle text =
+  let needle_len = String.length needle in
+  let text_len = String.length text in
+  let rec loop idx =
+    if idx + needle_len > text_len
+    then false
+    else if String.sub text idx needle_len = needle
+    then true
+    else loop (idx + 1)
+  in
+  needle_len = 0 || loop 0
+;;
+
+let catalog_of_string text =
+  match Provider_catalog.of_json (Yojson.Safe.from_string text) with
+  | Ok catalog -> catalog
+  | Error msg -> fail msg
+;;
+
+let require_lookup catalog id =
+  match Provider_catalog.lookup catalog id with
+  | Some entry -> entry
+  | None -> failf "expected catalog entry %S" id
+;;
+
+let test_full_entry_parses_auth_transport_and_capabilities () =
+  let catalog =
+    catalog_of_string
+      {|{
+        "schema_version": 1,
+        "providers": [
+          {
+            "id": "rich-http",
+            "aliases": [" Alias ", "", 7, "second"],
+            "kind": "provider_d_compat",
+            "transport": "custom-openai-compat",
+            "base_url": "https://rich.example/v1",
+            "request_path": "/chat/completions",
+            "default_model": "rich-model",
+            "credential_scope": "workspace",
+            "auth": {"type": "setup-token-env", "key": "SETUP_TOKEN"},
+            "interactive_required": true,
+            "non_interactive": false,
+            "daemon_safe": false,
+            "max_context": 32000,
+            "capabilities_base": "provider_d_chat",
+            "capabilities": {
+              "max_context_tokens": 64000,
+              "max_output_tokens": 4096,
+              "supports_tools": true,
+              "supports_tool_choice": true,
+              "supports_parallel_tool_calls": true,
+              "supports_runtime_mcp_tools": true,
+              "supports_runtime_tool_events": true,
+              "supports_reasoning": true,
+              "supports_extended_thinking": true,
+              "supports_reasoning_budget": true,
+              "supports_response_format_json": true,
+              "supports_structured_output": true,
+              "supports_multimodal_inputs": true,
+              "supports_image_input": true,
+              "supports_audio_input": true,
+              "supports_video_input": true,
+              "supports_native_streaming": true,
+              "supports_system_prompt": false,
+              "supports_caching": true,
+              "supports_prompt_caching": true,
+              "prompt_cache_alignment": 128,
+              "supports_top_k": true,
+              "supports_min_p": true,
+              "supports_seed": true,
+              "supports_seed_with_images": true,
+              "supports_computer_use": true,
+              "supports_code_execution": true,
+              "emits_usage_tokens": true,
+              "thinking_control_format": "chat-template-kwargs",
+              "supported_models": [" rich-model ", "", 3, "rich-fast"]
+            }
+          },
+          {
+            "id": "cli-cached",
+            "kind": "cli_tool_a",
+            "transport": "",
+            "command": "tool-a",
+            "auth": {"type": "cli-cached-login"}
+          },
+          {
+            "id": "oauth",
+            "kind": "provider_d_compat",
+            "transport": "managed",
+            "auth": {"type": "oauth_cached_login"}
+          },
+          {
+            "id": "file-auth",
+            "kind": "provider_d_compat",
+            "auth": {"type": "file", "path": "/tmp/provider-token"}
+          },
+          {
+            "id": "exec-auth",
+            "kind": "provider_d_compat",
+            "auth": {"type": "exec", "command": "op read token"}
+          },
+          {
+            "id": "legacy-env",
+            "kind": "provider_d_compat",
+            "api_key_env": "LEGACY_KEY"
+          }
+        ]
+      }|}
+  in
+  let rich = require_lookup catalog "alias" in
+  check string "id" "rich-http" rich.id;
+  check (list string) "aliases" [ "Alias"; "second" ] rich.aliases;
+  check
+    bool
+    "custom transport"
+    true
+    (rich.transport = Provider_catalog.Custom_provider_d_compat);
+  check bool "setup auth" true (rich.auth = Provider_catalog.Setup_token_env "SETUP_TOKEN");
+  check string "api key from setup auth" "SETUP_TOKEN" rich.api_key_env;
+  check (option string) "default model" (Some "rich-model") rich.default_model;
+  check (option int) "explicit max context" (Some 32000) rich.max_context;
+  check (option string) "credential scope" (Some "workspace") rich.credential_scope;
+  check bool "interactive required" true rich.interactive_required;
+  check bool "non interactive" false rich.non_interactive;
+  check bool "daemon safe" false rich.daemon_safe;
+  let caps = rich.capabilities in
+  check (option int) "cap max context" (Some 64000) caps.max_context_tokens;
+  check (option int) "cap max output" (Some 4096) caps.max_output_tokens;
+  check bool "supports tools" true caps.supports_tools;
+  check bool "supports tool choice" true caps.supports_tool_choice;
+  check bool "supports parallel calls" true caps.supports_parallel_tool_calls;
+  check bool "runtime mcp tools" true caps.supports_runtime_mcp_tools;
+  check bool "runtime tool events" true caps.supports_runtime_tool_events;
+  check bool "reasoning" true caps.supports_reasoning;
+  check bool "extended thinking" true caps.supports_extended_thinking;
+  check bool "reasoning budget" true caps.supports_reasoning_budget;
+  check bool "json response" true caps.supports_response_format_json;
+  check bool "structured output" true caps.supports_structured_output;
+  check bool "multimodal" true caps.supports_multimodal_inputs;
+  check bool "image" true caps.supports_image_input;
+  check bool "audio" true caps.supports_audio_input;
+  check bool "video" true caps.supports_video_input;
+  check bool "native streaming" true caps.supports_native_streaming;
+  check bool "system prompt override" false caps.supports_system_prompt;
+  check bool "caching" true caps.supports_caching;
+  check bool "prompt caching" true caps.supports_prompt_caching;
+  check (option int) "cache alignment" (Some 128) caps.prompt_cache_alignment;
+  check bool "top k" true caps.supports_top_k;
+  check bool "min p" true caps.supports_min_p;
+  check bool "seed" true caps.supports_seed;
+  check bool "seed images" true caps.supports_seed_with_images;
+  check bool "computer use" true caps.supports_computer_use;
+  check bool "code execution" true caps.supports_code_execution;
+  check bool "usage tokens" true caps.emits_usage_tokens;
+  check
+    bool
+    "thinking format"
+    true
+    (caps.thinking_control_format = Capabilities.Chat_template_kwargs);
+  check
+    (option (list string))
+    "supported models"
+    (Some [ "rich-model"; "rich-fast" ])
+    caps.supported_models;
+  check
+    (option string)
+    "default model helper"
+    (Some "rich-model")
+    (Provider_catalog.default_model_for_provider catalog "rich-http");
+  let cli = require_lookup catalog "cli-cached" in
+  check bool "cli default transport" true (cli.transport = Provider_catalog.Cli);
+  check bool "cli cached auth" true (cli.auth = Provider_catalog.Cli_cached_login);
+  check bool "cli non interactive default" true cli.non_interactive;
+  check bool "cli daemon safe default" true cli.daemon_safe;
+  let oauth = require_lookup catalog "oauth" in
+  check bool "managed transport" true (oauth.transport = Provider_catalog.Managed);
+  check bool "oauth auth" true (oauth.auth = Provider_catalog.Oauth_cached_login);
+  let file_auth = require_lookup catalog "file-auth" in
+  check
+    bool
+    "file auth"
+    true
+    (file_auth.auth = Provider_catalog.File "/tmp/provider-token");
+  let exec_auth = require_lookup catalog "exec-auth" in
+  check bool "exec auth" true (exec_auth.auth = Provider_catalog.Exec "op read token");
+  let legacy = require_lookup catalog "legacy-env" in
+  check
+    bool
+    "legacy api_key_env auth"
+    true
+    (legacy.auth = Provider_catalog.Api_key_env "LEGACY_KEY")
+;;
+
+let test_type_mismatches_fall_back_without_rejecting_entry () =
+  let catalog =
+    catalog_of_string
+      {|{
+        "schema_version": 1,
+        "providers": [
+          {
+            "id": "typed",
+            "kind": 42,
+            "aliases": "not-array",
+            "transport": false,
+            "auth": {"type": "env", "env": 17},
+            "capabilities": {
+              "supports_tools": "yes",
+              "max_output_tokens": "many",
+              "supported_models": "single"
+            }
+          }
+        ]
+      }|}
+  in
+  let typed = require_lookup catalog "typed" in
+  check bool "default kind" true (typed.kind = Provider_config.Provider_d_compat);
+  check bool "default transport" true (typed.transport = Provider_catalog.Http);
+  check (list string) "aliases default empty" [] typed.aliases;
+  check bool "env auth with empty env" true (typed.auth = Provider_catalog.Api_key_env "");
+  check bool "supports tools remains default" false typed.capabilities.supports_tools;
+  check
+    (option int)
+    "max output remains default"
+    None
+    typed.capabilities.max_output_tokens;
+  check
+    (option (list string))
+    "models remain default"
+    None
+    typed.capabilities.supported_models
+;;
+
+let test_transport_auth_and_thinking_alias_matrix () =
+  let catalog =
+    catalog_of_string
+      {|{
+        "schema_version": 1,
+        "providers": [
+          {
+            "id": "http-none",
+            "kind": "provider_d_compat",
+            "transport": "http",
+            "auth": {"type": "none"},
+            "capabilities": {"thinking_control_format": "none"}
+          },
+          {
+            "id": "cli-env",
+            "kind": "cli_tool_b",
+            "transport": "cli",
+            "auth": {"type": "api-key-env", "env": "ENV_KEY"},
+            "capabilities": {"thinking_control_format": "thinking-object"}
+          },
+          {
+            "id": "compat-alias",
+            "kind": "provider_d_compat",
+            "transport": "provider_d_compat",
+            "auth": {"type": "env", "env": "SHORT_ENV"},
+            "capabilities": {"thinking_control_format": "thinking-object-plain"}
+          },
+          {
+            "id": "reasoning",
+            "kind": "provider_d_compat",
+            "auth": {"type": "api_key_env", "env": "REASON_KEY"},
+            "capabilities": {"thinking_control_format": "reasoning-effort"}
+          },
+          {
+            "id": "enable",
+            "kind": "provider_d_compat",
+            "auth": {"type": "api-key-env", "env": "ENABLE_KEY"},
+            "capabilities": {"thinking_control_format": "enable-thinking"}
+          },
+          {
+            "id": "base-fallback",
+            "kind": "provider_d_compat",
+            "base": "provider_d_chat",
+            "max_context": 9223372036854775807999,
+            "capabilities": {
+              "prompt_cache_alignment": 9223372036854775807999
+            }
+          }
+        ]
+      }|}
+  in
+  let http_none = require_lookup catalog "http-none" in
+  check bool "http transport" true (http_none.transport = Provider_catalog.Http);
+  check bool "none auth" true (http_none.auth = Provider_catalog.No_auth);
+  check
+    bool
+    "none thinking format"
+    true
+    (http_none.capabilities.thinking_control_format = Capabilities.No_thinking_control);
+  let cli_env = require_lookup catalog "cli-env" in
+  check bool "cli transport" true (cli_env.transport = Provider_catalog.Cli);
+  check
+    bool
+    "api key auth alias"
+    true
+    (cli_env.auth = Provider_catalog.Api_key_env "ENV_KEY");
+  check
+    bool
+    "thinking object alias"
+    true
+    (cli_env.capabilities.thinking_control_format = Capabilities.Thinking_object);
+  let compat = require_lookup catalog "compat-alias" in
+  check
+    bool
+    "provider_d_compat transport alias"
+    true
+    (compat.transport = Provider_catalog.Custom_provider_d_compat);
+  check bool "env auth alias" true (compat.auth = Provider_catalog.Api_key_env "SHORT_ENV");
+  check
+    bool
+    "thinking object plain alias"
+    true
+    (compat.capabilities.thinking_control_format = Capabilities.Thinking_object_only);
+  let reasoning = require_lookup catalog "reasoning" in
+  check
+    bool
+    "reasoning effort alias"
+    true
+    (reasoning.capabilities.thinking_control_format = Capabilities.Reasoning_effort);
+  let enable = require_lookup catalog "enable" in
+  check bool "enable env" true (enable.auth = Provider_catalog.Api_key_env "ENABLE_KEY");
+  check
+    bool
+    "enable thinking alias"
+    true
+    (enable.capabilities.thinking_control_format = Capabilities.Enable_thinking);
+  let base = require_lookup catalog "base-fallback" in
+  check bool "base fallback supports tools" true base.capabilities.supports_tools;
+  check
+    (option int)
+    "oversized prompt alignment ignored"
+    None
+    base.capabilities.prompt_cache_alignment;
+  check int "catalog size" 6 (List.length catalog)
+;;
+
+let test_non_list_providers_is_empty_catalog () =
+  let catalog = catalog_of_string {|{"schema_version": 1, "providers": {}}|} in
+  check int "empty catalog" 0 (List.length catalog);
+  check (option reject) "lookup none" None (Provider_catalog.lookup catalog "missing")
+;;
+
+let test_rejects_schema_version_and_accumulates_entry_errors () =
+  (match Provider_catalog.of_json (Yojson.Safe.from_string {|{"schema_version": 2}|}) with
+   | Error msg ->
+     check bool "schema version message" true (contains ~needle:"schema_version" msg)
+   | Ok _ -> fail "unsupported schema_version should be rejected");
+  match
+    Provider_catalog.of_json
+      (Yojson.Safe.from_string
+         {|{
+           "schema_version": 1,
+           "providers": [
+             {"kind": "provider_d_compat"},
+             {"id": "bad-kind", "kind": "missing_kind"},
+             {"id": "bad-auth", "auth": {"type": "unknown"}}
+           ]
+         }|})
+  with
+  | Error msg ->
+    check bool "missing id surfaced" true (contains ~needle:"missing required" msg);
+    check bool "unknown kind surfaced" true (contains ~needle:"unknown kind" msg);
+    check bool "unknown auth surfaced" true (contains ~needle:"unknown auth type" msg)
+  | Ok _ -> fail "entry errors should be accumulated"
+;;
+
+let test_load_file_and_runtime_file_edges () =
+  let valid_path = Filename.temp_file "provider-catalog-coverage" ".json" in
+  let invalid_path = Filename.temp_file "provider-catalog-invalid" ".json" in
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.remove valid_path with
+       | Sys_error _ -> ());
+      try Sys.remove invalid_path with
+      | Sys_error _ -> ())
+    (fun () ->
+       let write_file path contents =
+         let oc = open_out path in
+         Fun.protect
+           ~finally:(fun () -> close_out_noerr oc)
+           (fun () -> output_string oc contents)
+       in
+       write_file
+         valid_path
+         {|{"schema_version":1,"providers":[{"id":"runtime","kind":"provider_d_compat"}]}|};
+       write_file invalid_path {|{"schema_version":|};
+       (match Provider_catalog.load_file valid_path with
+        | Ok catalog ->
+          check
+            bool
+            "load_file lookup"
+            true
+            (Option.is_some (Provider_catalog.lookup catalog "runtime"))
+        | Error msg -> fail msg);
+       (match Provider_catalog.load_file invalid_path with
+        | Error msg ->
+          check bool "parse error mentions path" true (contains ~needle:invalid_path msg)
+        | Ok _ -> fail "invalid JSON should fail");
+       (match Provider_catalog.load_file (valid_path ^ ".missing") with
+        | Error msg ->
+          check bool "missing file mentions path" true (contains ~needle:valid_path msg)
+        | Ok _ -> fail "missing file should fail");
+       (match Provider_catalog.load_runtime_file valid_path with
+        | Some catalog ->
+          check
+            bool
+            "runtime load"
+            true
+            (Option.is_some (Provider_catalog.lookup catalog "runtime"))
+        | None -> fail "valid runtime catalog should load");
+       check
+         (option reject)
+         "runtime invalid file returns none"
+         None
+         (Provider_catalog.load_runtime_file invalid_path))
+;;
+
+let test_global_override_lifecycle () =
+  Provider_catalog.clear_global ();
+  let catalog =
+    catalog_of_string
+      {|{"schema_version":1,"providers":[{"id":"override","kind":"provider_d_compat"}]}|}
+  in
+  Provider_catalog.set_global catalog;
+  (match Provider_catalog.global () with
+   | Some loaded ->
+     check
+       bool
+       "override visible"
+       true
+       (Option.is_some (Provider_catalog.lookup loaded "override"))
+   | None -> fail "expected global override");
+  Provider_catalog.clear_global ()
+;;
+
+let () =
+  run
+    "provider_catalog_coverage"
+    [ ( "parse"
+      , [ test_case
+            "full entry auth transport capabilities"
+            `Quick
+            test_full_entry_parses_auth_transport_and_capabilities
+        ; test_case
+            "type mismatches fall back"
+            `Quick
+            test_type_mismatches_fall_back_without_rejecting_entry
+        ; test_case
+            "transport auth thinking aliases"
+            `Quick
+            test_transport_auth_and_thinking_alias_matrix
+        ; test_case
+            "non-list providers is empty"
+            `Quick
+            test_non_list_providers_is_empty_catalog
+        ; test_case
+            "schema and entry errors"
+            `Quick
+            test_rejects_schema_version_and_accumulates_entry_errors
+        ] )
+    ; ( "load"
+      , [ test_case
+            "load_file and load_runtime_file edges"
+            `Quick
+            test_load_file_and_runtime_file_edges
+        ; test_case "global override lifecycle" `Quick test_global_override_lifecycle
+        ] )
+    ]
+;;

--- a/test/test_provider_intf.ml
+++ b/test/test_provider_intf.ml
@@ -69,12 +69,26 @@ let state_for_provider (provider : Provider.config) =
   { config; messages = []; turn_count = 0; usage = empty_usage }
 ;;
 
-let with_mock_server ~port handler f =
+let fresh_port () =
+  let s = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Unix.setsockopt s Unix.SO_REUSEADDR true;
+  Unix.bind s (Unix.ADDR_INET (Unix.inet_addr_loopback, 0));
+  let port =
+    match Unix.getsockname s with
+    | Unix.ADDR_INET (_, p) -> p
+    | _ -> Alcotest.fail "expected inet socket"
+  in
+  Unix.close s;
+  port
+;;
+
+let with_mock_server ?port handler f =
   Eio_main.run
   @@ fun env ->
   try
     Eio.Switch.run
     @@ fun sw ->
+    let port = Option.value ~default:(fresh_port ()) port in
     let socket =
       Eio.Net.listen
         env#net
@@ -105,7 +119,7 @@ let test_provider_dispatch_uses_http_client () =
     ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
     Cohttp_eio.Server.respond_string ~status:`OK ~body:provider_d_response ()
   in
-  with_mock_server ~port:18342 handler (fun ~sw ~net ~base_url ->
+  with_mock_server handler (fun ~sw ~net ~base_url ->
     let provider : Provider.config =
       { provider = Local { base_url }; model_id = "mock"; api_key_env = "DUMMY_KEY" }
     in
@@ -142,7 +156,7 @@ let test_provider_dispatch_maps_server_error () =
       ~body:"temporarily down"
       ()
   in
-  with_mock_server ~port:18356 handler (fun ~sw ~net ~base_url ->
+  with_mock_server handler (fun ~sw ~net ~base_url ->
     let provider : Provider.config =
       { provider = Local { base_url }; model_id = "mock"; api_key_env = "DUMMY_KEY" }
     in
@@ -167,7 +181,7 @@ let test_provider_dispatch_rejects_malformed_provider_d_response () =
     ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
     Cohttp_eio.Server.respond_string ~status:`OK ~body:{|{"choices":"not-a-list"}|} ()
   in
-  with_mock_server ~port:18357 handler (fun ~sw ~net ~base_url ->
+  with_mock_server handler (fun ~sw ~net ~base_url ->
     let provider : Provider.config =
       { provider = Local { base_url }; model_id = "mock"; api_key_env = "DUMMY_KEY" }
     in
@@ -195,7 +209,7 @@ let test_custom_provider_dispatch_uses_registered_impl () =
     seen_body := Some Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all);
     Cohttp_eio.Server.respond_string ~status:`OK ~body:"custom response body" ()
   in
-  with_mock_server ~port:18358 handler (fun ~sw ~net ~base_url ->
+  with_mock_server handler (fun ~sw ~net ~base_url ->
     let impl : Provider.provider_impl =
       { name = custom_name
       ; request_kind = Provider.Custom custom_name

--- a/test/test_provider_intf.ml
+++ b/test/test_provider_intf.ml
@@ -69,34 +69,35 @@ let state_for_provider (provider : Provider.config) =
   { config; messages = []; turn_count = 0; usage = empty_usage }
 ;;
 
-let fresh_port () =
-  let s = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
-  Unix.setsockopt s Unix.SO_REUSEADDR true;
-  Unix.bind s (Unix.ADDR_INET (Unix.inet_addr_loopback, 0));
-  let port =
-    match Unix.getsockname s with
-    | Unix.ADDR_INET (_, p) -> p
-    | _ -> Alcotest.fail "expected inet socket"
-  in
-  Unix.close s;
-  port
-;;
-
 let with_mock_server ?port handler f =
   Eio_main.run
   @@ fun env ->
   try
     Eio.Switch.run
     @@ fun sw ->
-    let port = Option.value ~default:(fresh_port ()) port in
-    let socket =
-      Eio.Net.listen
-        env#net
-        ~sw
-        ~backlog:128
-        ~reuse_addr:true
-        (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+    let candidate_ports =
+      match port with
+      | Some p -> [ p; p + 1; p + 2; p + 3; p + 4; p + 5 ]
+      | None ->
+        [ 18342; 18356; 18357; 18358; 18359; 18360; 18361; 18362; 18363; 18364 ]
     in
+    let rec bind_with_retry = function
+      | [] -> failwith "no free port found for mock server"
+      | port :: remaining ->
+        try
+          let socket =
+            Eio.Net.listen
+              env#net
+              ~sw
+              ~backlog:128
+              ~reuse_addr:true
+              (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+          in
+          (socket, port)
+        with
+        | Unix.Unix_error (Unix.EADDRINUSE, _, _) -> bind_with_retry remaining
+    in
+    let socket, port = bind_with_retry candidate_ports in
     let server = Cohttp_eio.Server.make ~callback:handler () in
     Eio.Fiber.fork ~sw (fun () ->
       Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
@@ -104,6 +105,7 @@ let with_mock_server ?port handler f =
     f ~sw ~net:env#net ~base_url;
     Eio.Switch.fail sw Exit
   with
+  | Unix.Unix_error (Unix.EPERM, "bind", _) -> Alcotest.skip ()
   | Exit -> ()
 ;;
 

--- a/test/test_provider_intf.ml
+++ b/test/test_provider_intf.ml
@@ -2,6 +2,7 @@
 
 open Agent_sdk
 open Agent_sdk.Types
+module Retry = Llm_provider.Retry
 
 (* ── Module type satisfaction ────────────────────────────── *)
 
@@ -46,6 +47,28 @@ let provider_d_response =
   {|{"id":"chatcmpl-provider-intf","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2}}|}
 ;;
 
+let user_messages =
+  [ { role = User
+    ; content = [ Text "hello" ]
+    ; name = None
+    ; tool_call_id = None
+    ; metadata = []
+    }
+  ]
+;;
+
+let state_for_provider (provider : Provider.config) =
+  let config =
+    { default_config with
+      model = provider.model_id
+    ; system_prompt = Some "reply briefly"
+    ; max_turns = 1
+    ; max_tokens = Some 16
+    }
+  in
+  { config; messages = []; turn_count = 0; usage = empty_usage }
+;;
+
 let with_mock_server ~port handler f =
   Eio_main.run
   @@ fun env ->
@@ -87,25 +110,14 @@ let test_provider_dispatch_uses_http_client () =
       { provider = Local { base_url }; model_id = "mock"; api_key_env = "DUMMY_KEY" }
     in
     let (module P : Provider_intf.PROVIDER) = Provider_intf.of_config provider in
-    let config =
-      { default_config with
-        model = provider.model_id
-      ; system_prompt = Some "reply briefly"
-      ; max_turns = 1
-      ; max_tokens = Some 16
-      }
-    in
-    let state = { config; messages = []; turn_count = 0; usage = empty_usage } in
-    let messages =
-      [ { role = User
-        ; content = [ Text "hello" ]
-        ; name = None
-        ; tool_call_id = None
-        ; metadata = []
-        }
-      ]
-    in
-    match P.create_message ~sw ~net ~config:state ~messages () with
+    match
+      P.create_message
+        ~sw
+        ~net
+        ~config:(state_for_provider provider)
+        ~messages:user_messages
+        ()
+    with
     | Error err -> Alcotest.failf "expected Ok, got %s" (Error.to_string err)
     | Ok response ->
       Alcotest.(check (option string))
@@ -120,6 +132,116 @@ let test_provider_dispatch_uses_http_client () =
          | Some raw -> int_of_string_opt raw |> Option.value ~default:0 > 0
          | None -> false);
       Alcotest.(check string) "model" "mock" response.model)
+;;
+
+let test_provider_dispatch_maps_server_error () =
+  let handler _conn _req body =
+    ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
+    Cohttp_eio.Server.respond_string
+      ~status:`Service_unavailable
+      ~body:"temporarily down"
+      ()
+  in
+  with_mock_server ~port:18356 handler (fun ~sw ~net ~base_url ->
+    let provider : Provider.config =
+      { provider = Local { base_url }; model_id = "mock"; api_key_env = "DUMMY_KEY" }
+    in
+    let (module P : Provider_intf.PROVIDER) = Provider_intf.of_config provider in
+    match
+      P.create_message
+        ~sw
+        ~net
+        ~config:(state_for_provider provider)
+        ~messages:user_messages
+        ()
+    with
+    | Error (Error.Api (Retry.ServerError { status; message })) ->
+      Alcotest.(check int) "status" 503 status;
+      Alcotest.(check string) "message" "temporarily down" message
+    | Error err -> Alcotest.failf "unexpected error: %s" (Error.to_string err)
+    | Ok _ -> Alcotest.fail "expected server error")
+;;
+
+let test_provider_dispatch_rejects_malformed_provider_d_response () =
+  let handler _conn _req body =
+    ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
+    Cohttp_eio.Server.respond_string ~status:`OK ~body:{|{"choices":"not-a-list"}|} ()
+  in
+  with_mock_server ~port:18357 handler (fun ~sw ~net ~base_url ->
+    let provider : Provider.config =
+      { provider = Local { base_url }; model_id = "mock"; api_key_env = "DUMMY_KEY" }
+    in
+    let (module P : Provider_intf.PROVIDER) = Provider_intf.of_config provider in
+    match
+      P.create_message
+        ~sw
+        ~net
+        ~config:(state_for_provider provider)
+        ~messages:user_messages
+        ()
+    with
+    | Error (Error.Api (Retry.InvalidRequest { message })) ->
+      Alcotest.(check bool) "parse message present" true (String.length message > 0)
+    | Error err -> Alcotest.failf "unexpected error: %s" (Error.to_string err)
+    | Ok _ -> Alcotest.fail "expected malformed response rejection")
+;;
+
+let test_custom_provider_dispatch_uses_registered_impl () =
+  let custom_name = "provider-intf-custom-dispatch" in
+  let seen_path = ref None in
+  let seen_body = ref None in
+  let handler _conn req body =
+    seen_path := Some (Uri.path (Cohttp.Request.uri req));
+    seen_body := Some Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all);
+    Cohttp_eio.Server.respond_string ~status:`OK ~body:"custom response body" ()
+  in
+  with_mock_server ~port:18358 handler (fun ~sw ~net ~base_url ->
+    let impl : Provider.provider_impl =
+      { name = custom_name
+      ; request_kind = Provider.Custom custom_name
+      ; request_path = "/v1/custom"
+      ; capabilities =
+          { Provider.default_capabilities with supports_native_streaming = false }
+      ; build_body = (fun ~config:_ ~messages:_ ?tools:_ () -> {|{"custom":true}|})
+      ; parse_response =
+          (fun body ->
+            { id = "custom-id"
+            ; model = "custom-model"
+            ; stop_reason = EndTurn
+            ; content = [ Text body ]
+            ; usage = None
+            ; telemetry = None
+            })
+      ; resolve = (fun _cfg -> Ok (base_url, "", [ "Content-Type", "application/json" ]))
+      }
+    in
+    Provider.register_provider impl;
+    let provider =
+      Provider.custom_provider ~name:custom_name ~model_id:"custom-model" ()
+    in
+    (match Provider_intf.of_config_streaming provider with
+     | None -> ()
+     | Some _ -> Alcotest.fail "custom provider should not expose streaming");
+    let (module P : Provider_intf.PROVIDER) = Provider_intf.of_config provider in
+    match
+      P.create_message
+        ~sw
+        ~net
+        ~config:(state_for_provider provider)
+        ~messages:user_messages
+        ()
+    with
+    | Error err -> Alcotest.failf "expected Ok, got %s" (Error.to_string err)
+    | Ok response ->
+      Alcotest.(check (option string)) "custom path" (Some "/v1/custom") !seen_path;
+      Alcotest.(check (option string)) "custom body" (Some {|{"custom":true}|}) !seen_body;
+      Alcotest.(check string) "custom response id" "custom-id" response.id;
+      Alcotest.(check string)
+        "custom response text"
+        "custom response body"
+        (match response.content with
+         | [ Text text ] -> text
+         | _ -> Alcotest.fail "expected text response"))
 ;;
 
 (* ── Runner ──────────────────────────────────────────────── *)
@@ -149,6 +271,18 @@ let () =
             "uses hardened post_sync headers"
             `Quick
             test_provider_dispatch_uses_http_client
+        ; Alcotest.test_case
+            "maps server error"
+            `Quick
+            test_provider_dispatch_maps_server_error
+        ; Alcotest.test_case
+            "rejects malformed response"
+            `Quick
+            test_provider_dispatch_rejects_malformed_provider_d_response
+        ; Alcotest.test_case
+            "custom provider dispatch"
+            `Quick
+            test_custom_provider_dispatch_uses_registered_impl
         ] )
     ]
 ;;

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -250,6 +250,33 @@ let test_acc_sse_error_propagated () =
   | Ok _ -> Alcotest.fail "expected Error from SSEError"
 ;;
 
+let test_acc_parse_failed_truncates_raw_chunk () =
+  let acc = Streaming.create_stream_acc () in
+  let raw = String.make 240 'x' in
+  Streaming.accumulate_event acc (SSEParseFailed { raw; reason = "bad-json" });
+  match Streaming.finalize_stream_acc acc with
+  | Error msg ->
+    check_bool "has prefix" true (String.starts_with ~prefix:"sse_parse_failed:" msg);
+    check_bool "truncated" true (String.contains msg '.')
+  | Ok _ -> Alcotest.fail "expected parse failure"
+;;
+
+let test_acc_unknown_event_truncates_raw_chunk () =
+  let acc = Streaming.create_stream_acc () in
+  let raw = String.make 240 'y' in
+  Streaming.accumulate_event
+    acc
+    (SSEUnknownEventType { event_type = "future.event"; raw });
+  match Streaming.finalize_stream_acc acc with
+  | Error msg ->
+    check_bool
+      "has prefix"
+      true
+      (String.starts_with ~prefix:"sse_unknown_event_type: future.event" msg);
+    check_bool "truncated" true (String.contains msg '.')
+  | Ok _ -> Alcotest.fail "expected unknown event failure"
+;;
+
 let test_acc_ignores_content_block_stop () =
   let acc = Streaming.create_stream_acc () in
   Streaming.accumulate_event acc (ContentBlockStop { index = 0 });
@@ -365,6 +392,15 @@ let test_finalize_unknown_content_type () =
     (ContentBlockDelta { index = 0; delta = TextDelta "ignored" });
   let resp = finalize_ok acc in
   check_int "unknown type skipped" 0 (List.length resp.content)
+;;
+
+let test_finalize_registered_type_without_buffer () =
+  let acc = Streaming.create_stream_acc () in
+  Hashtbl.replace acc.block_types 7 "text";
+  let resp = finalize_ok acc in
+  match resp.content with
+  | [ Text "" ] -> ()
+  | _ -> Alcotest.fail "expected empty text from missing buffer"
 ;;
 
 (* ── finalize: usage thresholds ─────────────────────────────────── *)
@@ -576,6 +612,40 @@ let test_map_http_error_auth_error () =
   | _ -> Alcotest.fail "expected Error.Api AuthError"
 ;;
 
+let test_map_http_error_extra_variants () =
+  let open Llm_provider.Http_client in
+  (match Streaming.map_http_error (AcceptRejected { reason = "policy" }) with
+   | Error.Api (Retry.NetworkError { message = "policy"; _ }) -> ()
+   | _ -> Alcotest.fail "expected AcceptRejected as Api NetworkError");
+  (match
+     Streaming.map_http_error
+       (TimeoutError { message = "deadline"; phase = Caller_budget })
+   with
+   | Error.Provider _ -> ()
+   | _ -> Alcotest.fail "expected TimeoutError as Provider error");
+  (match Streaming.map_http_error (CliTransportRequired { kind = "cli_tool_d" }) with
+   | Error.Provider _ -> ()
+   | _ -> Alcotest.fail "expected CliTransportRequired as Provider error");
+  (match
+     Streaming.map_http_error
+       (ProviderTerminal { kind = Max_turns { turns = 31; limit = 31 }; message = "max" })
+   with
+   | Error.Agent (MaxTurnsExceeded { turns = 31; limit = 31 }) -> ()
+   | _ -> Alcotest.fail "expected max-turns terminal as Agent error");
+  (match
+     Streaming.map_http_error (ProviderTerminal { kind = Other "halt"; message = "halt" })
+   with
+   | Error.Provider _ -> ()
+   | _ -> Alcotest.fail "expected other terminal as Provider error");
+  match
+    Streaming.map_http_error
+      (ProviderFailure
+         { kind = Provider_parse_error { parser = Some "provider" }; message = "bad" })
+  with
+  | Error.Provider _ -> ()
+  | _ -> Alcotest.fail "expected ProviderFailure as Provider error"
+;;
+
 (* ── MessageDelta cache update with prior values ────────────────── *)
 
 let test_acc_message_delta_cache_update_nonzero () =
@@ -738,6 +808,14 @@ let () =
         ; Alcotest.test_case "ignores MessageStop" `Quick test_acc_ignores_message_stop
         ; Alcotest.test_case "SSEError propagated" `Quick test_acc_sse_error_propagated
         ; Alcotest.test_case
+            "SSEParseFailed truncates"
+            `Quick
+            test_acc_parse_failed_truncates_raw_chunk
+        ; Alcotest.test_case
+            "SSEUnknownEventType truncates"
+            `Quick
+            test_acc_unknown_event_truncates_raw_chunk
+        ; Alcotest.test_case
             "ignores ContentBlockStop"
             `Quick
             test_acc_ignores_content_block_stop
@@ -763,6 +841,10 @@ let () =
             "unknown content_type"
             `Quick
             test_finalize_unknown_content_type
+        ; Alcotest.test_case
+            "registered type without buffer"
+            `Quick
+            test_finalize_registered_type_without_buffer
         ; Alcotest.test_case "usage all zero" `Quick test_finalize_usage_all_zero
         ; Alcotest.test_case
             "usage only cache_creation"
@@ -786,6 +868,7 @@ let () =
         ; Alcotest.test_case "network error" `Quick test_map_http_error_network_error
         ; Alcotest.test_case "server 500" `Quick test_map_http_error_server_error
         ; Alcotest.test_case "auth 401" `Quick test_map_http_error_auth_error
+        ; Alcotest.test_case "extra variants" `Quick test_map_http_error_extra_variants
         ] )
     ]
 ;;

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -1,0 +1,470 @@
+open Alcotest
+open Llm_provider.Types
+module S = Llm_provider.Streaming
+
+let usage ?(input_tokens = 1) ?(output_tokens = 2) () =
+  { input_tokens
+  ; output_tokens
+  ; cache_creation_input_tokens = 0
+  ; cache_read_input_tokens = 0
+  ; cost_usd = None
+  }
+;;
+
+let provider_d_chunk
+      ?delta_content
+      ?delta_reasoning
+      ?(delta_tool_calls = [])
+      ?finish_reason
+      ?chunk_usage
+      ()
+  : S.provider_d_chunk
+  =
+  { chunk_id = "chunk-1"
+  ; chunk_model = "model-1"
+  ; delta_content
+  ; delta_reasoning
+  ; delta_tool_calls
+  ; finish_reason
+  ; chunk_usage
+  }
+;;
+
+let ollama_chunk
+      ?delta_content
+      ?delta_thinking
+      ?(tool_calls = [])
+      ?done_reason
+      ?usage
+      ?timings
+      ?(is_done = false)
+      ()
+  : S.ollama_chunk
+  =
+  { oll_model = "provider_h-3:8b"
+  ; oll_delta_content = delta_content
+  ; oll_delta_thinking = delta_thinking
+  ; oll_tool_calls = tool_calls
+  ; oll_done_reason = done_reason
+  ; oll_is_done = is_done
+  ; oll_usage = usage
+  ; oll_timings = timings
+  }
+;;
+
+let check_event_count label expected events =
+  check int label expected (List.length events)
+;;
+
+let require_some label = function
+  | Some x -> x
+  | None -> fail (label ^ ": expected Some")
+;;
+
+let test_provider_a_sse_parser_edges () =
+  (match
+     S.parse_sse_event
+       (Some "message_start")
+       {|{"message":{"id":"msg-1","model":"m","usage":null}}|}
+   with
+   | Some (MessageStart { usage = None; _ }) -> ()
+   | _ -> fail "message_start without usage should parse");
+  (match
+     S.parse_sse_event
+       (Some "content_block_delta")
+       {|{"index":0,"delta":{"type":"future_delta","value":"ignored"}}|}
+   with
+   | Some (ContentBlockDelta { delta = TextDelta ""; _ }) -> ()
+   | _ -> fail "unknown delta type should surface empty TextDelta");
+  (match
+     S.parse_sse_event
+       (Some "message_delta")
+       {|{"delta":{"stop_reason":null},"usage":null}|}
+   with
+   | Some (MessageDelta { stop_reason = None; usage = None }) -> ()
+   | _ -> fail "message_delta without usage should parse");
+  match S.parse_sse_event (Some "message_start") {|{"message":{"id":1}}|} with
+  | Some (SSEParseFailed { reason; _ }) ->
+    check bool "type error reason" true (String.starts_with ~prefix:"type_error:" reason)
+  | _ -> fail "bad message_start shape should become SSEParseFailed"
+;;
+
+let test_first_token_classifier_edges () =
+  check
+    bool
+    "thinking token"
+    true
+    (S.sse_event_is_first_token_signal
+       (ContentBlockDelta { index = 0; delta = ThinkingDelta "plan" }));
+  check
+    bool
+    "json token"
+    true
+    (S.sse_event_is_first_token_signal
+       (ContentBlockDelta { index = 0; delta = InputJsonDelta "{}" }));
+  check
+    bool
+    "empty thinking"
+    false
+    (S.sse_event_is_first_token_signal
+       (ContentBlockDelta { index = 0; delta = ThinkingDelta "" }));
+  List.iter
+    (fun event ->
+       check bool "non-token event" false (S.sse_event_is_first_token_signal event))
+    [ ContentBlockStop { index = 0 }
+    ; MessageDelta { stop_reason = None; usage = None }
+    ; MessageStop
+    ; SSEError "boom"
+    ; SSEParseFailed { raw = "x"; reason = "bad" }
+    ; SSEUnknownEventType { event_type = "future"; raw = "{}" }
+    ]
+;;
+
+let test_synthetic_events_media_blocks () =
+  let response : api_response =
+    { id = "r1"
+    ; model = "m1"
+    ; stop_reason = EndTurn
+    ; usage = Some (usage ())
+    ; telemetry = None
+    ; content =
+        [ Image { media_type = "image/png"; data = "aW1n"; source_type = "base64" }
+        ; Document
+            { media_type = "application/pdf"; data = "ZG9j"; source_type = "base64" }
+        ; Audio { media_type = "wav"; data = "YXVkaW8="; source_type = "base64" }
+        ; RedactedThinking "hidden"
+        ; ToolResult
+            { tool_use_id = "call-1"; content = "ok"; is_error = false; json = None }
+        ]
+    }
+  in
+  let events = ref [] in
+  S.emit_synthetic_events response (fun event -> events := event :: !events);
+  let events = List.rev !events in
+  check_event_count "start + 5 block starts/stops + stop" 13 events;
+  let starts =
+    List.filter_map
+      (function
+        | ContentBlockStart { content_type; tool_id; _ } -> Some (content_type, tool_id)
+        | _ -> None)
+      events
+  in
+  check
+    (list (pair string (option string)))
+    "media-like synthetic starts"
+    [ "text", None; "text", None; "text", None; "text", None; "text", None ]
+    starts
+;;
+
+let test_provider_d_parse_edge_shapes () =
+  let mixed_tool_calls =
+    {|{"id":"c","model":"m","choices":[{"delta":{"tool_calls":[{"index":"bad"},{"index":0,"function":{"arguments":"{}"}}]},"finish_reason":null}],"usage":{"prompt_tokens":4,"completion_tokens":5,"prompt_tokens_details":{"cached_tokens":3}}}|}
+  in
+  let chunk =
+    require_some
+      "provider_d mixed tool calls"
+      (S.parse_provider_d_sse_chunk mixed_tool_calls)
+  in
+  check int "only valid tool call retained" 1 (List.length chunk.delta_tool_calls);
+  (match chunk.chunk_usage with
+   | Some u ->
+     check int "cached tokens" 3 u.cache_read_input_tokens;
+     check int "input tokens" 4 u.input_tokens
+   | None -> fail "expected usage");
+  let non_list_tool_calls =
+    {|{"id":"c","model":"m","choices":[{"delta":{"tool_calls":{"unexpected":true}},"finish_reason":null}]}|}
+  in
+  let chunk =
+    require_some
+      "provider_d non-list tool calls"
+      (S.parse_provider_d_sse_chunk non_list_tool_calls)
+  in
+  check int "non-list tool calls ignored" 0 (List.length chunk.delta_tool_calls)
+;;
+
+let test_provider_d_event_edge_branches () =
+  let state = S.create_provider_d_stream_state ~provider:"p" ~model:"m" () in
+  ignore
+    (S.provider_d_chunk_to_events state (provider_d_chunk ~delta_reasoning:"thinking" ()));
+  let empty_reasoning_events, telemetry =
+    S.provider_d_chunk_to_events state (provider_d_chunk ~delta_reasoning:"" ())
+  in
+  check_event_count "empty reasoning emits no content event" 0 empty_reasoning_events;
+  (match telemetry with
+   | Some (Llm_provider.Telemetry_event.Thinking_complete r) ->
+     check string "provider" "p" r.provider;
+     check string "model" "m" r.model
+   | _ -> fail "expected thinking completion telemetry");
+  state.thinking_state <- S.Thinking_done;
+  let repeat_reasoning_events, _ =
+    S.provider_d_chunk_to_events state (provider_d_chunk ~delta_reasoning:"again" ())
+  in
+  check_event_count
+    "repeat reasoning after done emits delta only"
+    1
+    repeat_reasoning_events;
+  let tool_state = S.create_provider_d_stream_state () in
+  let tc_empty =
+    { S.tc_index = 0
+    ; tc_id = Some "call-1"
+    ; tc_name = Some "search"
+    ; tc_arguments = Some ""
+    }
+  in
+  let tc_none = { S.tc_index = 0; tc_id = None; tc_name = None; tc_arguments = None } in
+  let first_tool_events, _ =
+    S.provider_d_chunk_to_events
+      tool_state
+      (provider_d_chunk ~delta_tool_calls:[ tc_empty ] ())
+  in
+  check_event_count "empty-args tool starts block only" 1 first_tool_events;
+  let reused_tool_events, _ =
+    S.provider_d_chunk_to_events
+      tool_state
+      (provider_d_chunk ~delta_tool_calls:[ tc_none ] ())
+  in
+  check_event_count "same tool index without args emits nothing" 0 reused_tool_events;
+  let unknown_finish_events, _ =
+    S.provider_d_chunk_to_events
+      tool_state
+      (provider_d_chunk ~finish_reason:"safety_filter" ~chunk_usage:(usage ()) ())
+  in
+  match unknown_finish_events with
+  | [ MessageDelta { stop_reason = Some (Unknown "safety_filter"); usage = Some _ } ] ->
+    ()
+  | _ -> fail "expected unknown finish reason"
+;;
+
+let test_provider_f_parse_edge_shapes () =
+  (match
+     S.parse_provider_f_sse_chunk
+       {|{"modelVersion":"gem","candidates":[],"usageMetadata":null}|}
+   with
+   | None -> ()
+   | Some _ -> fail "empty candidates should be rejected by missing content");
+  (match
+     S.parse_provider_f_sse_chunk
+       {|{"modelVersion":"gem","candidates":{"unexpected":true},"usageMetadata":null}|}
+   with
+   | None -> ()
+   | Some _ -> fail "non-list candidates should be rejected by missing content");
+  let non_list_parts =
+    require_some
+      "non-list parts"
+      (S.parse_provider_f_sse_chunk
+         {|{"modelVersion":"gem","candidates":[{"content":{"parts":{"bad":true}}}],"usageMetadata":null}|})
+  in
+  check int "non-list parts ignored" 0 (List.length non_list_parts.gem_parts);
+  match S.parse_provider_f_sse_chunk "{not-json" with
+  | None -> ()
+  | Some _ -> fail "invalid provider_f json should return None"
+;;
+
+let provider_f_chunk ?(parts = []) ?finish_reason ?usage () : S.provider_f_chunk =
+  { gem_model = "provider_f-test"
+  ; gem_parts = parts
+  ; gem_finish_reason = finish_reason
+  ; gem_usage = usage
+  }
+;;
+
+let test_provider_f_event_edge_branches () =
+  let state = S.create_provider_d_stream_state ~provider:"provider_f" ~model:"gem" () in
+  let thought_part = `Assoc [ "thought", `Bool true; "text", `String "plan" ] in
+  ignore
+    (S.provider_f_chunk_to_events state (provider_f_chunk ~parts:[ thought_part ] ()));
+  let no_thought_events, telemetry =
+    S.provider_f_chunk_to_events state (provider_f_chunk ~parts:[ `Assoc [] ] ())
+  in
+  check_event_count "no-thought chunk emits no events" 0 no_thought_events;
+  (match telemetry with
+   | Some (Llm_provider.Telemetry_event.Thinking_complete r) ->
+     check string "provider" "provider_f" r.provider
+   | _ -> fail "expected provider_f thinking completion telemetry");
+  state.thinking_state <- S.Thinking_done;
+  let restarted_events, _ =
+    S.provider_f_chunk_to_events state (provider_f_chunk ~parts:[ thought_part ] ())
+  in
+  check_event_count "thinking after done restarts and emits delta" 1 restarted_events;
+  let empty_text_with_call =
+    `Assoc
+      [ "text", `String ""
+      ; ( "functionCall"
+        , `Assoc [ "name", `String "lookup"; "args", `Assoc [ "q", `String "seoul" ] ] )
+      ]
+  in
+  let tool_events, _ =
+    S.provider_f_chunk_to_events
+      (S.create_provider_d_stream_state ())
+      (provider_f_chunk ~parts:[ empty_text_with_call ] ())
+  in
+  check_event_count "empty text can still carry function call" 2 tool_events;
+  let empty_text_without_call =
+    `Assoc [ "text", `String ""; "functionCall", `String "not-an-object" ]
+  in
+  let ignored_events, _ =
+    S.provider_f_chunk_to_events
+      (S.create_provider_d_stream_state ())
+      (provider_f_chunk ~parts:[ empty_text_without_call ] ())
+  in
+  check_event_count "non-object functionCall ignored" 0 ignored_events;
+  let max_tokens_events, _ =
+    S.provider_f_chunk_to_events
+      (S.create_provider_d_stream_state ())
+      (provider_f_chunk ~finish_reason:"MAX_TOKENS" ~usage:(usage ()) ())
+  in
+  (match max_tokens_events with
+   | [ MessageDelta { stop_reason = Some MaxTokens; usage = Some _ } ] -> ()
+   | _ -> fail "expected provider_f max-tokens finish");
+  let unknown_events, _ =
+    S.provider_f_chunk_to_events
+      (S.create_provider_d_stream_state ())
+      (provider_f_chunk ~finish_reason:"SAFETY" ())
+  in
+  match unknown_events with
+  | [ MessageDelta { stop_reason = Some (Unknown "SAFETY"); _ } ] -> ()
+  | _ -> fail "expected provider_f unknown finish"
+;;
+
+let test_ollama_parse_edge_shapes () =
+  let non_object_message =
+    require_some
+      "non-object message"
+      (S.parse_ollama_ndjson_chunk {|{"model":"m","message":"text","done":false}|})
+  in
+  check (option string) "no content" None non_object_message.oll_delta_content;
+  check int "no tool calls" 0 (List.length non_object_message.oll_tool_calls);
+  let args_variants =
+    require_some
+      "tool argument variants"
+      (S.parse_ollama_ndjson_chunk
+         {|{"model":"m","message":{"content":"","thinking":"","tool_calls":[{"id":"a","function":{"name":"null_args","arguments":null}},{"function":{"name":"string_args","arguments":"{\"x\":1}"}},{"function":{"name":"bool_args","arguments":true}}]},"done":true,"prompt_eval_duration":1000000,"eval_duration":0}|})
+  in
+  check (option string) "empty content becomes None" None args_variants.oll_delta_content;
+  check
+    (option string)
+    "empty thinking becomes None"
+    None
+    args_variants.oll_delta_thinking;
+  check int "three tool calls" 3 (List.length args_variants.oll_tool_calls);
+  (match args_variants.oll_tool_calls with
+   | [ first; second; third ] ->
+     check (option string) "null args" None first.oll_tc_arguments;
+     check (option string) "string args" (Some {|{"x":1}|}) second.oll_tc_arguments;
+     check (option string) "bool args" (Some "true") third.oll_tc_arguments
+   | _ -> fail "unexpected tool calls");
+  (match args_variants.oll_timings with
+   | Some t ->
+     check (option (float 0.001)) "prompt ms" (Some 1.0) t.prompt_ms;
+     check (option (float 0.001)) "zero eval rate" None t.predicted_per_second
+   | None -> fail "expected timings");
+  match S.parse_ollama_ndjson_chunk {|{"model":1,"done":false}|} with
+  | None -> ()
+  | Some _ -> fail "type error should return None"
+;;
+
+let test_ollama_event_edge_branches () =
+  let state = S.create_provider_d_stream_state ~provider:"ollama" ~model:"m" () in
+  ignore (S.ollama_chunk_to_events state (ollama_chunk ~delta_thinking:"first" ()));
+  let repeated_thinking_events, _ =
+    S.ollama_chunk_to_events state (ollama_chunk ~delta_thinking:"second" ())
+  in
+  check_event_count "repeated thinking emits delta only" 1 repeated_thinking_events;
+  let empty_thinking_events, empty_tel =
+    S.ollama_chunk_to_events state (ollama_chunk ~delta_thinking:"" ())
+  in
+  check_event_count "empty thinking emits no event" 0 empty_thinking_events;
+  (match empty_tel with
+   | Some (Llm_provider.Telemetry_event.Thinking_complete r) ->
+     check string "provider" "ollama" r.provider
+   | _ -> fail "expected empty-thinking telemetry");
+  state.thinking_state <- S.Thinking_started 0.0;
+  let none_thinking_events, none_tel = S.ollama_chunk_to_events state (ollama_chunk ()) in
+  check_event_count "missing thinking closes telemetry only" 0 none_thinking_events;
+  (match none_tel with
+   | Some (Llm_provider.Telemetry_event.Thinking_complete _) -> ()
+   | _ -> fail "expected none-thinking telemetry");
+  let text_empty_events, _ =
+    S.ollama_chunk_to_events
+      (S.create_provider_d_stream_state ())
+      (ollama_chunk ~delta_content:"" ())
+  in
+  check_event_count "empty text ignored" 0 text_empty_events;
+  let tool_state = S.create_provider_d_stream_state () in
+  let tc_empty =
+    { S.oll_tc_index = 0
+    ; oll_tc_id = Some "call"
+    ; oll_tc_name = Some "lookup"
+    ; oll_tc_arguments = Some ""
+    }
+  in
+  let tc_none =
+    { S.oll_tc_index = 0; oll_tc_id = None; oll_tc_name = None; oll_tc_arguments = None }
+  in
+  let tool_start_events, _ =
+    S.ollama_chunk_to_events tool_state (ollama_chunk ~tool_calls:[ tc_empty ] ())
+  in
+  check_event_count "empty-args ollama tool starts only" 1 tool_start_events;
+  let tool_reuse_events, _ =
+    S.ollama_chunk_to_events tool_state (ollama_chunk ~tool_calls:[ tc_none ] ())
+  in
+  check_event_count "reused ollama tool without args emits nothing" 0 tool_reuse_events;
+  let done_none_events, _ =
+    S.ollama_chunk_to_events
+      (S.create_provider_d_stream_state ())
+      (ollama_chunk ~is_done:true ())
+  in
+  (match done_none_events with
+   | [ MessageDelta { stop_reason = Some EndTurn; _ } ] -> ()
+   | _ -> fail "done without reason should be EndTurn");
+  let done_length_events, _ =
+    S.ollama_chunk_to_events
+      (S.create_provider_d_stream_state ())
+      (ollama_chunk ~is_done:true ~done_reason:"length" ())
+  in
+  (match done_length_events with
+   | [ MessageDelta { stop_reason = Some MaxTokens; _ } ] -> ()
+   | _ -> fail "done length should be MaxTokens");
+  let done_unknown_tool_events, _ =
+    S.ollama_chunk_to_events
+      (S.create_provider_d_stream_state ())
+      (ollama_chunk ~is_done:true ~done_reason:"future" ~tool_calls:[ tc_none ] ())
+  in
+  (match done_unknown_tool_events with
+   | [ ContentBlockStart _; MessageDelta { stop_reason = Some StopToolUse; _ } ] -> ()
+   | _ -> fail "unknown done reason with tools should stop for tool use");
+  let done_unknown_events, _ =
+    S.ollama_chunk_to_events
+      (S.create_provider_d_stream_state ())
+      (ollama_chunk ~is_done:true ~done_reason:"content_filter" ())
+  in
+  match done_unknown_events with
+  | [ MessageDelta { stop_reason = Some (Unknown "content_filter"); _ } ] -> ()
+  | _ -> fail "unknown done reason should be preserved"
+;;
+
+let () =
+  run
+    "streaming_edge_cases"
+    [ ( "provider_a_sse"
+      , [ test_case "parser edge cases" `Quick test_provider_a_sse_parser_edges
+        ; test_case
+            "first-token classifier edges"
+            `Quick
+            test_first_token_classifier_edges
+        ; test_case "synthetic media events" `Quick test_synthetic_events_media_blocks
+        ] )
+    ; ( "provider_d_sse"
+      , [ test_case "parse edge shapes" `Quick test_provider_d_parse_edge_shapes
+        ; test_case "event edge branches" `Quick test_provider_d_event_edge_branches
+        ] )
+    ; ( "provider_f_sse"
+      , [ test_case "parse edge shapes" `Quick test_provider_f_parse_edge_shapes
+        ; test_case "event edge branches" `Quick test_provider_f_event_edge_branches
+        ] )
+    ; ( "ollama_ndjson"
+      , [ test_case "parse edge shapes" `Quick test_ollama_parse_edge_shapes
+        ; test_case "event edge branches" `Quick test_ollama_event_edge_branches
+        ] )
+    ]
+;;

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -140,6 +140,79 @@ let test_no_coerce_non_numeric_string () =
   | Tool_input_validation.Valid _ -> fail "\"sixty\" should not coerce to integer"
 ;;
 
+let test_coerce_scalar_edges_and_intlit_normalization () =
+  let schema =
+    make_schema
+      [ make_param ~param_type:Types.Integer "whole_float"
+      ; make_param ~param_type:Types.String "bool_as_string"
+      ; make_param ~param_type:Types.String "int_as_string"
+      ; make_param ~param_type:Types.String "float_as_string"
+      ; make_param ~param_type:Types.Integer "intlit_as_int"
+      ; make_param ~param_type:Types.Number "intlit_as_number"
+      ; make_param ~param_type:Types.Boolean "trimmed_bool"
+      ]
+  in
+  let input =
+    `Assoc
+      [ "whole_float", `Float 7.0
+      ; "bool_as_string", `Bool false
+      ; "int_as_string", `Int 12
+      ; "float_as_string", `Float 1.5
+      ; "intlit_as_int", `Intlit "42"
+      ; "intlit_as_number", `Intlit "42"
+      ; "trimmed_bool", `String " TRUE "
+      ]
+  in
+  match Tool_input_validation.validate schema input with
+  | Tool_input_validation.Valid coerced ->
+    check
+      string
+      "whole float"
+      "`Int (7)"
+      (Yojson.Safe.show (Yojson.Safe.Util.member "whole_float" coerced));
+    check
+      string
+      "bool string"
+      {|`String ("false")|}
+      (Yojson.Safe.show (Yojson.Safe.Util.member "bool_as_string" coerced));
+    check
+      string
+      "int string"
+      {|`String ("12")|}
+      (Yojson.Safe.show (Yojson.Safe.Util.member "int_as_string" coerced));
+    check
+      string
+      "float string"
+      {|`String ("1.5")|}
+      (Yojson.Safe.show (Yojson.Safe.Util.member "float_as_string" coerced));
+    check
+      string
+      "intlit int"
+      "`Int (42)"
+      (Yojson.Safe.show (Yojson.Safe.Util.member "intlit_as_int" coerced));
+    check
+      string
+      "intlit number"
+      "`Float (42.)"
+      (Yojson.Safe.show (Yojson.Safe.Util.member "intlit_as_number" coerced));
+    check
+      string
+      "trimmed bool"
+      "`Bool (true)"
+      (Yojson.Safe.show (Yojson.Safe.Util.member "trimmed_bool" coerced))
+  | Tool_input_validation.Invalid _ -> fail "expected scalar coercions to succeed"
+;;
+
+let test_non_integral_float_to_integer_fails () =
+  let schema = make_schema [ make_param ~param_type:Types.Integer "count" ] in
+  let input = `Assoc [ "count", `Float 7.25 ] in
+  match Tool_input_validation.validate schema input with
+  | Tool_input_validation.Invalid errors ->
+    check int "one error" 1 (List.length errors);
+    check string "actual" "number(7.25)" (List.hd errors).actual
+  | Tool_input_validation.Valid _ -> fail "expected non-integral float to fail"
+;;
+
 (* ── Edge cases ───────────────────────────────────────── *)
 
 let test_empty_params () =
@@ -170,6 +243,73 @@ let test_multiple_errors () =
   | Tool_input_validation.Invalid errors -> check int "two errors" 2 (List.length errors)
   | Tool_input_validation.Valid _ ->
     fail "expected two errors for two missing required fields"
+;;
+
+let test_optional_null_is_valid () =
+  let schema =
+    make_schema [ make_param ~required:false ~param_type:Types.Object "payload" ]
+  in
+  let input = `Assoc [ "payload", `Null ] in
+  match Tool_input_validation.validate schema input with
+  | Tool_input_validation.Valid _ -> ()
+  | Tool_input_validation.Invalid _ -> fail "optional null should be accepted"
+;;
+
+let test_non_object_input_treats_declared_field_as_missing () =
+  let schema = make_schema [ make_param ~param_type:Types.String "room" ] in
+  let input = `List [ `String "not"; `String "an object" ] in
+  match Tool_input_validation.validate schema input with
+  | Tool_input_validation.Invalid errors ->
+    check int "one error" 1 (List.length errors);
+    check string "path" "/room" (List.hd errors).path;
+    check string "actual" "missing" (List.hd errors).actual
+  | Tool_input_validation.Valid _ -> fail "expected declared field to be missing"
+;;
+
+let test_actual_descriptions_cover_json_shapes () =
+  let schema =
+    make_schema
+      [ make_param ~param_type:Types.Integer "bool_value"
+      ; make_param ~param_type:Types.Boolean "float_value"
+      ; make_param ~param_type:Types.Integer "long_string"
+      ; make_param ~param_type:Types.Object "array_value"
+      ; make_param ~param_type:Types.Array "object_value"
+      ; make_param ~param_type:Types.Boolean "bad_intlit"
+      ]
+  in
+  let input =
+    `Assoc
+      [ "bool_value", `Bool true
+      ; "float_value", `Float 1.25
+      ; "long_string", `String "abcdefghijklmnopqrstuvwxyz"
+      ; "array_value", `List [ `Int 1 ]
+      ; "object_value", `Assoc [ "k", `String "v" ]
+      ; "bad_intlit", `Intlit "999999999999999999999999999999"
+      ]
+  in
+  let actual_for path errors =
+    errors
+    |> List.find (fun (e : Tool_input_validation.field_error) -> e.path = path)
+    |> fun e -> e.actual
+  in
+  match Tool_input_validation.validate schema input with
+  | Tool_input_validation.Invalid errors ->
+    check string "bool" "boolean(true)" (actual_for "/bool_value" errors);
+    check string "float" "number(1.25)" (actual_for "/float_value" errors);
+    check
+      string
+      "long string preview"
+      {|string("abcdefghijklmnopqrst...")|}
+      (actual_for "/long_string" errors);
+    check string "array" "array" (actual_for "/array_value" errors);
+    check string "object" "object" (actual_for "/object_value" errors);
+    check
+      string
+      "intlit"
+      "integer(999999999999999999999999999999)"
+      (actual_for "/bad_intlit" errors);
+    check int "six errors" 6 (List.length errors)
+  | Tool_input_validation.Valid _ -> fail "expected shape description errors"
 ;;
 
 (* ── format_errors tests ──────────────────────────────── *)
@@ -289,6 +429,24 @@ let test_format_errors_inline_multiple () =
      Re.execp re1 msg && Re.execp re2 msg)
 ;;
 
+let test_format_errors_inline_path_without_slash () =
+  let errors : Tool_input_validation.field_error list =
+    [ { path = "raw"; expected = "object"; actual = "array" } ]
+  in
+  let msg =
+    Tool_input_validation.format_errors_inline
+      ~tool_name:"test_tool"
+      ~args:(`List [])
+      errors
+  in
+  check
+    bool
+    "uses raw path as field name"
+    true
+    (let re = Re.(compile (str "\"raw\": wrong type")) in
+     Re.execp re msg)
+;;
+
 (* ── Test runner ──────────────────────────────────────── *)
 
 let () =
@@ -312,17 +470,38 @@ let () =
         ; test_case "string→float" `Quick test_coerce_string_to_float
         ; test_case "int→number" `Quick test_coerce_int_to_number
         ; test_case "non-numeric string fails" `Quick test_no_coerce_non_numeric_string
+        ; test_case
+            "scalar edges and intlit normalization"
+            `Quick
+            test_coerce_scalar_edges_and_intlit_normalization
+        ; test_case
+            "non-integral float to integer fails"
+            `Quick
+            test_non_integral_float_to_integer_fails
         ] )
     ; ( "edge_cases"
       , [ test_case "empty params" `Quick test_empty_params
         ; test_case "null input" `Quick test_null_input
         ; test_case "multiple errors" `Quick test_multiple_errors
+        ; test_case "optional null" `Quick test_optional_null_is_valid
+        ; test_case
+            "non-object input"
+            `Quick
+            test_non_object_input_treats_declared_field_as_missing
+        ; test_case
+            "actual descriptions"
+            `Quick
+            test_actual_descriptions_cover_json_shapes
         ] )
     ; ( "format"
       , [ test_case "format_errors output" `Quick test_format_errors
         ; test_case "inline: missing field" `Quick test_format_errors_inline_missing
         ; test_case "inline: type error" `Quick test_format_errors_inline_type_error
         ; test_case "inline: multiple errors" `Quick test_format_errors_inline_multiple
+        ; test_case
+            "inline: path without slash"
+            `Quick
+            test_format_errors_inline_path_without_slash
         ] )
     ]
 ;;

--- a/test/test_tool_schema_gen.ml
+++ b/test/test_tool_schema_gen.ml
@@ -100,6 +100,63 @@ let test_triple_params () =
   Alcotest.(check int) "3 params" 3 (List.length (Tool_schema_gen.to_params triple))
 ;;
 
+(* ── Four-field schema and coercion/error accumulation ──── *)
+
+let four_fields =
+  Tool_schema_gen.(
+    four
+      (string_field "label" ~required:true ~desc:"Label" ())
+      (int_field "count" ~required:true ~desc:"Count" ())
+      (float_field "ratio" ~required:true ~desc:"Ratio" ())
+      (bool_field "enabled" ~required:true ~desc:"Enabled" ()))
+;;
+
+let test_four_field_coercion () =
+  let json =
+    `Assoc
+      [ "label", `Bool true
+      ; "count", `Intlit "9"
+      ; "ratio", `String "2.5"
+      ; "enabled", `String "false"
+      ]
+  in
+  match Tool_schema_gen.parse four_fields json with
+  | Ok (label, count, ratio, enabled) ->
+    Alcotest.(check string) "label coerced" "true" label;
+    Alcotest.(check int) "count coerced" 9 count;
+    Alcotest.(check (float 0.0001)) "ratio coerced" 2.5 ratio;
+    Alcotest.(check bool) "enabled coerced" false enabled
+  | Error errs -> Alcotest.fail (format_errors errs)
+;;
+
+let test_four_field_error_accumulation () =
+  let json = `Assoc [ "label", `List []; "count", `Float 1.5; "ratio", `Bool false ] in
+  match Tool_schema_gen.parse four_fields json with
+  | Ok _ -> Alcotest.fail "expected field errors"
+  | Error errs ->
+    let paths = List.map (fun e -> e.Tool_input_validation.path) errs in
+    Alcotest.(check int) "all four errors" 4 (List.length errs);
+    Alcotest.(check bool) "label error" true (List.mem "label" paths);
+    Alcotest.(check bool) "count error" true (List.mem "count" paths);
+    Alcotest.(check bool) "ratio error" true (List.mem "ratio" paths);
+    Alcotest.(check bool) "enabled missing" true (List.mem "enabled" paths)
+;;
+
+let optional_defaults =
+  Tool_schema_gen.(
+    two
+      (float_field "ratio" ~required:false ~desc:"Ratio" ~default:0.25 ())
+      (bool_field "enabled" ~required:false ~desc:"Enabled" ~default:true ()))
+;;
+
+let test_optional_custom_defaults () =
+  match Tool_schema_gen.parse optional_defaults (`Assoc []) with
+  | Ok (ratio, enabled) ->
+    Alcotest.(check (float 0.0001)) "ratio default" 0.25 ratio;
+    Alcotest.(check bool) "enabled default" true enabled
+  | Error errs -> Alcotest.fail (format_errors errs)
+;;
+
 (* ── Integration: schema_gen + Typed_tool ───────────────── *)
 
 let test_typed_tool_integration () =
@@ -148,6 +205,14 @@ let () =
     ; ( "three_field"
       , [ Alcotest.test_case "parse" `Quick test_triple_parse
         ; Alcotest.test_case "params count" `Quick test_triple_params
+        ] )
+    ; ( "four_field"
+      , [ Alcotest.test_case "coercion" `Quick test_four_field_coercion
+        ; Alcotest.test_case
+            "error accumulation"
+            `Quick
+            test_four_field_error_accumulation
+        ; Alcotest.test_case "optional defaults" `Quick test_optional_custom_defaults
         ] )
     ; ( "integration"
       , [ Alcotest.test_case "schema_gen + Typed_tool" `Quick test_typed_tool_integration

--- a/test/test_transport_cli_tool_a_coverage.ml
+++ b/test/test_transport_cli_tool_a_coverage.ml
@@ -1,0 +1,364 @@
+open Alcotest
+open Llm_provider
+
+let write_script name body =
+  let path = Filename.temp_file name ".sh" in
+  Out_channel.with_open_text path (fun oc -> output_string oc body);
+  Unix.chmod path 0o755;
+  path
+;;
+
+let remove_quietly path =
+  try Sys.remove path with
+  | Sys_error _ -> ()
+;;
+
+let with_script name body f =
+  let path = write_script name body in
+  match f path with
+  | result ->
+    remove_quietly path;
+    result
+  | exception exn ->
+    remove_quietly path;
+    raise exn
+;;
+
+let req_config ?(model_id = "auto") ?min_p ?top_k () =
+  Provider_config.make
+    ~kind:Provider_config.Cli_tool_a
+    ~model_id
+    ~base_url:""
+    ?min_p
+    ?top_k
+    ()
+;;
+
+let user_message text : Types.message =
+  { role = Types.User
+  ; content = [ Types.Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+let request
+      ?(config = req_config ())
+      ?runtime_mcp_policy
+      ?(messages = [ user_message "hello" ])
+      ()
+  =
+  { Llm_transport.config; messages; tools = []; runtime_mcp_policy }
+;;
+
+let agent_code_success_script =
+  {|#!/bin/sh
+cat <<'JSONL'
+{"type":"thread.started","thread_id":"thread-a"}
+{"type":"item.started","item":{"id":"call-1","type":"mcp_tool_call","server":"runtime","tool":"inspect","arguments":{"path":"README.md"}}}
+{"type":"item.completed","item":{"id":"msg-1","type":"agent_message","text":"Hello from agent_code"}}
+{"type":"item.completed","item":{"id":"call-1","type":"mcp_tool_call","server":"runtime","tool":"inspect","arguments":{"path":"README.md"},"result":{"content":[{"type":"text","text":"ok"}],"isError":true}}}
+{"type":"item.completed","item":{"id":"cmd-1","type":"command_execution","command":"pwd","aggregated_output":"/tmp","exit_code":0}}
+{"type":"turn.completed","usage":{"input_tokens":3,"cached_input_tokens":1,"output_tokens":4}}
+JSONL
+|}
+;;
+
+let agent_code_recovered_exit_script =
+  {|#!/bin/sh
+cat <<'JSONL'
+{"type":"thread.started","thread_id":"thread-recovered"}
+{"type":"item.completed","item":{"id":"msg-1","type":"agent_message","text":"Recovered"}}
+{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}
+JSONL
+echo 'late session persistence failure' >&2
+exit 1
+|}
+;;
+
+let agent_code_empty_script =
+  {|#!/bin/sh
+exit 0
+|}
+;;
+
+let agent_code_capture_script =
+  {|#!/bin/sh
+printf '%s\n' "$*" > "$ARGS_CAPTURE"
+printf '%s\n' "$OAS_CLI_TOOL_A_MCP_WORKER_BEARER" > "$ENV_CAPTURE"
+cat <<'JSONL'
+{"type":"thread.started","thread_id":"thread-mcp"}
+{"type":"item.completed","item":{"id":"msg-1","type":"agent_message","text":"MCP configured"}}
+{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}
+JSONL
+|}
+;;
+
+let agent_code_stdin_capture_script =
+  {|#!/bin/sh
+cat > "$CAPTURE_PATH"
+cat <<'JSONL'
+{"type":"thread.started","thread_id":"thread-stdin"}
+{"type":"item.completed","item":{"id":"msg-1","type":"agent_message","text":"Captured"}}
+{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}
+JSONL
+|}
+;;
+
+let with_transport_config ?(configure = fun config -> config) script f =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let config =
+    { Transport_cli_tool_a.default_config with
+      agent_code_path = script
+    ; model = Some "agent-code-default"
+    ; mcp_config = Some "/tmp/ignored-mcp.json"
+    ; allowed_tools = [ "Read" ]
+    ; max_turns = Some 2
+    ; permission_mode = Some "acceptEdits"
+    }
+    |> configure
+  in
+  let transport =
+    Transport_cli_tool_a.create ~sw ~mgr:(Eio.Stdenv.process_mgr env) ~config
+  in
+  f transport
+;;
+
+let with_transport script f = with_transport_config script f
+
+let text_of_first_block = function
+  | Types.Text text :: _ -> text
+  | _ -> ""
+;;
+
+let test_complete_sync_restores_jsonl_blocks_and_telemetry () =
+  with_script "oas-agent-code-success" agent_code_success_script
+  @@ fun script ->
+  with_transport script
+  @@ fun transport ->
+  let config = req_config ~model_id:"agent-code-requested" ~min_p:0.1 ~top_k:40 () in
+  match (transport.Llm_transport.complete_sync (request ~config ())).response with
+  | Ok response ->
+    check string "id" "thread-a" response.id;
+    check string "model" "agent-code-requested" response.model;
+    (match response.content with
+     | [ Types.Text "Hello from agent_code"
+       ; Types.ToolUse { id = "call-1"; name = "mcp__runtime__inspect"; input }
+       ; Types.ToolResult
+           { tool_use_id = "call-1"; content = "ok"; is_error = true; json }
+       ] ->
+       check string "tool input" {|{"path":"README.md"}|} (Yojson.Safe.to_string input);
+       check bool "tool result json preserved" true (Option.is_some json)
+     | _ -> fail "unexpected content blocks");
+    (match response.telemetry with
+     | Some telemetry ->
+       check
+         (option int)
+         "provider internal action count"
+         (Some 1)
+         telemetry.provider_internal_action_count
+     | None -> fail "expected telemetry")
+  | Error _ -> fail "expected agent_code JSONL success"
+;;
+
+let test_complete_stream_emits_tool_result_and_stop () =
+  with_script "oas-agent-code-stream" agent_code_success_script
+  @@ fun script ->
+  with_transport script
+  @@ fun transport ->
+  let events = ref [] in
+  match
+    transport.Llm_transport.complete_stream
+      ~on_event:(fun event -> events := event :: !events)
+      (request ())
+  with
+  | Ok response ->
+    check string "id" "thread-a" response.id;
+    let events = List.rev !events in
+    check
+      bool
+      "message start"
+      true
+      (List.exists
+         (function
+           | Types.MessageStart _ -> true
+           | _ -> false)
+         events);
+    check
+      bool
+      "tool result error block"
+      true
+      (List.exists
+         (function
+           | Types.ContentBlockStart { content_type = "tool_result_error"; _ } -> true
+           | _ -> false)
+         events);
+    check
+      bool
+      "message stop"
+      true
+      (List.exists
+         (function
+           | Types.MessageStop -> true
+           | _ -> false)
+         events)
+  | Error _ -> fail "expected streaming success"
+;;
+
+let test_nonzero_exit_recovers_when_turn_completed_seen () =
+  with_script "oas-agent-code-recovered" agent_code_recovered_exit_script
+  @@ fun script ->
+  with_transport script
+  @@ fun transport ->
+  match (transport.Llm_transport.complete_sync (request ())).response with
+  | Ok response ->
+    check string "id" "thread-recovered" response.id;
+    check string "text" "Recovered" (text_of_first_block response.content)
+  | Error _ -> fail "expected stdout recovery success"
+;;
+
+let test_runtime_mcp_bearer_header_uses_env_var_override () =
+  let args_path = Filename.temp_file "oas-agent-code-args" ".txt" in
+  let env_path = Filename.temp_file "oas-agent-code-env" ".txt" in
+  match
+    with_script "oas-agent-code-capture" agent_code_capture_script
+    @@ fun script ->
+    with_transport_config
+      ~configure:(fun config ->
+        { config with
+          mcp_config = None
+        ; allowed_tools = []
+        ; max_turns = None
+        ; permission_mode = None
+        })
+      script
+    @@ fun transport ->
+    Unix.putenv "ARGS_CAPTURE" args_path;
+    Unix.putenv "ENV_CAPTURE" env_path;
+    let policy =
+      { Llm_transport.empty_runtime_mcp_policy with
+        servers =
+          [ Llm_transport.Http_server
+              { name = "worker"
+              ; url = "http://127.0.0.1:9182/mcp"
+              ; headers = [ "Authorization", "Bearer secret-token"; "X-Trace", "enabled" ]
+              }
+          ]
+      ; allowed_tool_names = [ "inspect" ]
+      }
+    in
+    match
+      (transport.Llm_transport.complete_sync (request ~runtime_mcp_policy:policy ()))
+        .response
+    with
+    | Ok response ->
+      check string "text" "MCP configured" (text_of_first_block response.content);
+      let args = In_channel.with_open_text args_path In_channel.input_all in
+      let env = In_channel.with_open_text env_path In_channel.input_all |> String.trim in
+      check bool "bearer token passed through env" true (String.equal "secret-token" env);
+      check
+        bool
+        "argv names bearer env var"
+        true
+        (Agent_sdk.Util.string_contains ~needle:"bearer_token_env_var" args);
+      check
+        bool
+        "argv omits raw secret"
+        false
+        (Agent_sdk.Util.string_contains ~needle:"secret-token" args)
+    | Error _ -> fail "expected runtime MCP success"
+  with
+  | result ->
+    remove_quietly args_path;
+    remove_quietly env_path;
+    result
+  | exception exn ->
+    remove_quietly args_path;
+    remove_quietly env_path;
+    raise exn
+;;
+
+let test_large_prompt_is_sent_over_stdin () =
+  let capture_path = Filename.temp_file "oas-agent-code-stdin" ".txt" in
+  match
+    with_script "oas-agent-code-stdin" agent_code_stdin_capture_script
+    @@ fun script ->
+    with_transport_config
+      ~configure:(fun config ->
+        { config with
+          mcp_config = None
+        ; allowed_tools = []
+        ; max_turns = None
+        ; permission_mode = None
+        })
+      script
+    @@ fun transport ->
+    Unix.putenv "CAPTURE_PATH" capture_path;
+    let large = String.make (600 * 1024) 'a' in
+    match
+      (transport.Llm_transport.complete_sync
+         (request ~messages:[ user_message large ] ()))
+        .response
+    with
+    | Ok response ->
+      check string "id" "thread-stdin" response.id;
+      let captured = In_channel.with_open_text capture_path In_channel.input_all in
+      check bool "captured via stdin" true (String.length captured >= 600 * 1024)
+    | Error _ -> fail "expected stdin prompt success"
+  with
+  | result ->
+    remove_quietly capture_path;
+    result
+  | exception exn ->
+    remove_quietly capture_path;
+    raise exn
+;;
+
+let test_empty_output_returns_parse_error () =
+  with_script "oas-agent-code-empty" agent_code_empty_script
+  @@ fun script ->
+  with_transport script
+  @@ fun transport ->
+  match (transport.Llm_transport.complete_sync (request ())).response with
+  | Error (Http_client.NetworkError { message; _ }) ->
+    check
+      bool
+      "mentions no events"
+      true
+      (Agent_sdk.Util.string_contains ~needle:"no events parsed" message)
+  | Error _ -> fail "expected parse NetworkError"
+  | Ok _ -> fail "expected parse error"
+;;
+
+let () =
+  run
+    "transport_cli_tool_a_coverage"
+    [ ( "transport"
+      , [ test_case
+            "complete_sync restores JSONL blocks and telemetry"
+            `Quick
+            test_complete_sync_restores_jsonl_blocks_and_telemetry
+        ; test_case
+            "complete_stream emits tool result and stop"
+            `Quick
+            test_complete_stream_emits_tool_result_and_stop
+        ; test_case
+            "nonzero exit recovers after turn.completed"
+            `Quick
+            test_nonzero_exit_recovers_when_turn_completed_seen
+        ; test_case
+            "runtime MCP bearer header uses env var"
+            `Quick
+            test_runtime_mcp_bearer_header_uses_env_var_override
+        ; test_case "large prompt uses stdin" `Quick test_large_prompt_is_sent_over_stdin
+        ; test_case
+            "empty output returns parse error"
+            `Quick
+            test_empty_output_returns_parse_error
+        ] )
+    ]
+;;

--- a/test/test_transport_cli_tool_b_coverage.ml
+++ b/test/test_transport_cli_tool_b_coverage.ml
@@ -1,0 +1,207 @@
+open Alcotest
+open Llm_provider
+
+let write_script name body =
+  let path = Filename.temp_file name ".sh" in
+  Out_channel.with_open_text path (fun oc -> output_string oc body);
+  Unix.chmod path 0o755;
+  path
+;;
+
+let remove_quietly path =
+  try Sys.remove path with
+  | Sys_error _ -> ()
+;;
+
+let with_script name body f =
+  let path = write_script name body in
+  match f path with
+  | result ->
+    remove_quietly path;
+    result
+  | exception exn ->
+    remove_quietly path;
+    raise exn
+;;
+
+let req_config =
+  Provider_config.make
+    ~kind:Provider_config.Cli_tool_b
+    ~model_id:"provider_f-2.5-pro"
+    ~base_url:""
+    ()
+;;
+
+let user_message text : Types.message =
+  { role = Types.User
+  ; content = [ Types.Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+let request ?runtime_mcp_policy () =
+  { Llm_transport.config = req_config
+  ; messages = [ user_message "hello" ]
+  ; tools = []
+  ; runtime_mcp_policy
+  }
+;;
+
+let provider_f_success_script =
+  {|#!/bin/sh
+echo '{"session_id":"gemini-cli","response":"Hello from provider_f","stats":{"models":{"provider_f-2.5-pro":{"tokens":{"input":3,"candidates":4,"cached":1}}}}}'
+|}
+;;
+
+let provider_f_quota_script =
+  {|#!/bin/sh
+echo 'TerminalQuotaError retryDelayMs: 2000' >&2
+exit 1
+|}
+;;
+
+let with_transport script f =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let config =
+    { Transport_cli_tool_b.default_config with
+      provider_f_path = script
+    ; model = Some "provider_f-2.5-pro"
+    ; mcp_config = Some "/tmp/ignored-mcp.json"
+    ; allowed_tools = [ "Read" ]
+    ; max_turns = Some 2
+    ; permission_mode = Some "acceptEdits"
+    }
+  in
+  let transport =
+    Transport_cli_tool_b.create ~sw ~mgr:(Eio.Stdenv.process_mgr env) ~config
+  in
+  f transport
+;;
+
+let test_complete_sync_parses_provider_f_json () =
+  with_script "oas-provider-f-success" provider_f_success_script
+  @@ fun script ->
+  with_transport script
+  @@ fun transport ->
+  match (transport.Llm_transport.complete_sync (request ())).response with
+  | Ok response ->
+    check string "id" "gemini-cli" response.id;
+    check string "model" "provider_f" response.model;
+    check
+      string
+      "text"
+      "Hello from provider_f"
+      (match response.content with
+       | Types.Text text :: _ -> text
+       | _ -> "");
+    (match response.usage with
+     | Some usage ->
+       check int "input tokens" 3 usage.input_tokens;
+       check int "output tokens" 4 usage.output_tokens;
+       check int "cached tokens" 1 usage.cache_read_input_tokens
+     | None -> fail "expected usage")
+  | Error _ -> fail "expected provider_f JSON success"
+;;
+
+let test_complete_stream_replays_synthetic_events () =
+  with_script "oas-provider-f-stream" provider_f_success_script
+  @@ fun script ->
+  with_transport script
+  @@ fun transport ->
+  let events = ref [] in
+  match
+    transport.Llm_transport.complete_stream
+      ~on_event:(fun event -> events := event :: !events)
+      (request ())
+  with
+  | Ok response ->
+    check string "id" "gemini-cli" response.id;
+    let events = List.rev !events in
+    check
+      bool
+      "message start"
+      true
+      (List.exists
+         (function
+           | Types.MessageStart _ -> true
+           | _ -> false)
+         events);
+    check
+      bool
+      "message stop"
+      true
+      (List.exists
+         (function
+           | Types.MessageStop -> true
+           | _ -> false)
+         events)
+  | Error _ -> fail "expected synthetic stream success"
+;;
+
+let test_runtime_mcp_policy_is_rejected_before_subprocess () =
+  with_script "oas-provider-f-unused" provider_f_success_script
+  @@ fun script ->
+  with_transport script
+  @@ fun transport ->
+  let policy =
+    { Llm_transport.empty_runtime_mcp_policy with
+      servers =
+        [ Llm_transport.Http_server
+            { name = "mcp"; url = "http://127.0.0.1:1"; headers = [] }
+        ]
+    }
+  in
+  match
+    (transport.Llm_transport.complete_sync (request ~runtime_mcp_policy:policy ()))
+      .response
+  with
+  | Error
+      (Http_client.ProviderFailure
+         { kind = Capability_mismatch { capability = Some cap }; _ }) ->
+    check string "capability" "request_scoped_runtime_mcp" cap
+  | Error _ -> fail "expected capability mismatch"
+  | Ok _ -> fail "expected runtime MCP rejection"
+;;
+
+let test_quota_stderr_maps_to_provider_failure () =
+  with_script "oas-provider-f-quota" provider_f_quota_script
+  @@ fun script ->
+  with_transport script
+  @@ fun transport ->
+  match (transport.Llm_transport.complete_sync (request ())).response with
+  | Error
+      (Http_client.ProviderFailure
+         { kind = Hard_quota { retry_after = Some retry_after }; _ }) ->
+    check (float 0.001) "retry after seconds" 2.0 retry_after
+  | Error _ -> fail "expected hard quota provider failure"
+  | Ok _ -> fail "expected quota failure"
+;;
+
+let () =
+  run
+    "transport_cli_tool_b_coverage"
+    [ ( "transport"
+      , [ test_case
+            "complete_sync parses provider_f JSON"
+            `Quick
+            test_complete_sync_parses_provider_f_json
+        ; test_case
+            "complete_stream replays synthetic events"
+            `Quick
+            test_complete_stream_replays_synthetic_events
+        ; test_case
+            "runtime MCP policy rejected"
+            `Quick
+            test_runtime_mcp_policy_is_rejected_before_subprocess
+        ; test_case
+            "quota stderr maps to provider failure"
+            `Quick
+            test_quota_stderr_maps_to_provider_failure
+        ] )
+    ]
+;;

--- a/test/test_transport_cli_tool_c_coverage.ml
+++ b/test/test_transport_cli_tool_c_coverage.ml
@@ -1,0 +1,351 @@
+open Alcotest
+open Llm_provider
+
+let write_script name body =
+  let path = Filename.temp_file name ".sh" in
+  Out_channel.with_open_text path (fun oc -> output_string oc body);
+  Unix.chmod path 0o755;
+  path
+;;
+
+let remove_quietly path =
+  try Sys.remove path with
+  | Sys_error _ -> ()
+;;
+
+let with_script name body f =
+  let path = write_script name body in
+  match f path with
+  | result ->
+    remove_quietly path;
+    result
+  | exception exn ->
+    remove_quietly path;
+    raise exn
+;;
+
+let req_config =
+  Provider_config.make ~kind:Provider_config.Cli_tool_c ~model_id:"auto" ~base_url:"" ()
+;;
+
+let user_message text : Types.message =
+  { role = Types.User
+  ; content = [ Types.Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+let request ?(messages = [ user_message "hello" ]) ?(tools = []) () =
+  { Llm_transport.config = req_config; messages; tools; runtime_mcp_policy = None }
+;;
+
+let provider_c_success_script =
+  {|#!/bin/sh
+echo '{"id":"resp-cli","role":"assistant","model":"provider_c-test","content":"Hello"}'
+echo '{"role":"assistant","tool_calls":[{"type":"function","id":"call-1","function":{"name":"inspect","arguments":"{\"path\":\"README.md\"}"}}]}'
+echo '{"role":"tool","tool_call_id":"call-1","content":"{\"ok\":true}"}'
+echo '{"usage":{"input_tokens":3,"output_tokens":4}}'
+|}
+;;
+
+let provider_c_exit_1_script =
+  {|#!/bin/sh
+echo 'auth failed' >&2
+exit 1
+|}
+;;
+
+let provider_c_empty_script =
+  {|#!/bin/sh
+exit 0
+|}
+;;
+
+let provider_c_stdin_capture_script =
+  {|#!/bin/sh
+cat > "$CAPTURE_PATH"
+echo '{"id":"stdin-cli","role":"assistant","model":"provider_c-test","content":"Captured"}'
+|}
+;;
+
+let provider_c_argv_capture_script =
+  {|#!/bin/sh
+printf '%s\n' "$*" >> "$ARGS_CAPTURE"
+echo '{"id":"argv-cli","role":"assistant","model":"provider_c-test","content":"Argv"}'
+|}
+;;
+
+let with_transport_config ?(configure = fun config -> config) script f =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let config =
+    { Transport_cli_tool_c.default_config with
+      provider_c_path = script
+    ; model = Some "provider_c-test"
+    ; extra_env = [ "OAS_TEST_TRANSPORT_C", "1" ]
+    }
+    |> configure
+  in
+  let transport =
+    Transport_cli_tool_c.create ~sw ~mgr:(Eio.Stdenv.process_mgr env) ~config
+  in
+  f transport
+;;
+
+let with_transport script f = with_transport_config script f
+
+let test_complete_sync_restores_text_tool_and_usage () =
+  with_script "oas-provider-c-success" provider_c_success_script
+  @@ fun script ->
+  with_transport script
+  @@ fun transport ->
+  match (transport.Llm_transport.complete_sync (request ())).response with
+  | Ok response ->
+    check string "id" "resp-cli" response.id;
+    check string "model" "provider_c-test" response.model;
+    (match response.content with
+     | [ Types.Text "Hello"
+       ; Types.ToolUse { id = "call-1"; name = "inspect"; input }
+       ; Types.ToolResult { tool_use_id; content; json; _ }
+       ] ->
+       check string "tool input" {|{"path":"README.md"}|} (Yojson.Safe.to_string input);
+       check string "tool result id" "call-1" tool_use_id;
+       check string "tool result content" {|{"ok":true}|} content;
+       check bool "tool result json parsed" true (Option.is_some json)
+     | _ -> fail "unexpected content blocks");
+    (match response.usage with
+     | Some usage ->
+       check bool "estimated input positive" true (usage.input_tokens > 0);
+       check bool "estimated output positive" true (usage.output_tokens > 0)
+     | None -> fail "expected usage")
+  | Error err ->
+    let message =
+      match err with
+      | Http_client.HttpError { code; body } -> Printf.sprintf "http %d %s" code body
+      | Http_client.NetworkError { message; _ }
+      | Http_client.TimeoutError { message; _ }
+      | Http_client.ProviderTerminal { message; _ }
+      | Http_client.ProviderFailure { message; _ } -> message
+      | Http_client.AcceptRejected { reason } -> reason
+      | Http_client.CliTransportRequired { kind } -> kind
+    in
+    fail ("unexpected error: " ^ message)
+;;
+
+let test_complete_stream_emits_blocks_and_stop () =
+  with_script "oas-provider-c-stream" provider_c_success_script
+  @@ fun script ->
+  with_transport script
+  @@ fun transport ->
+  let events = ref [] in
+  match
+    transport.Llm_transport.complete_stream
+      ~on_event:(fun event -> events := event :: !events)
+      (request ())
+  with
+  | Ok response ->
+    check string "id" "resp-cli" response.id;
+    let events = List.rev !events in
+    check
+      bool
+      "message start"
+      true
+      (List.exists
+         (function
+           | Types.MessageStart _ -> true
+           | _ -> false)
+         events);
+    check
+      bool
+      "content start"
+      true
+      (List.exists
+         (function
+           | Types.ContentBlockStart _ -> true
+           | _ -> false)
+         events);
+    check
+      bool
+      "message stop"
+      true
+      (List.exists
+         (function
+           | Types.MessageStop -> true
+           | _ -> false)
+         events)
+  | Error _ -> fail "expected streaming success"
+;;
+
+let test_complete_sync_exit_1_surfaces_subprocess_error () =
+  with_script "oas-provider-c-exit1" provider_c_exit_1_script
+  @@ fun script ->
+  with_transport script
+  @@ fun transport ->
+  match (transport.Llm_transport.complete_sync (request ())).response with
+  | Error (Http_client.NetworkError { message; _ }) ->
+    check
+      bool
+      "mentions exit 1"
+      true
+      (Agent_sdk.Util.string_contains ~needle:"exit code 1" message
+       || Agent_sdk.Util.string_contains ~needle:"exited with code 1" message)
+  | Error _ -> fail "expected subprocess network error"
+  | Ok _ -> fail "expected error"
+;;
+
+let test_warns_once_for_external_tools () =
+  with_script "oas-provider-c-tools" provider_c_success_script
+  @@ fun script ->
+  with_transport script
+  @@ fun transport ->
+  let tool = `Assoc [ "name", `String "external_tool" ] in
+  match (transport.Llm_transport.complete_sync (request ~tools:[ tool ] ())).response with
+  | Ok response ->
+    check
+      string
+      "text restored"
+      "Hello"
+      (match response.content with
+       | Types.Text text :: _ -> text
+       | _ -> "")
+  | Error _ -> fail "expected success with ignored external tool callback"
+;;
+
+let test_complete_sync_empty_output_returns_parse_error () =
+  with_script "oas-provider-c-empty" provider_c_empty_script
+  @@ fun script ->
+  with_transport script
+  @@ fun transport ->
+  match (transport.Llm_transport.complete_sync (request ())).response with
+  | Error (Http_client.NetworkError { message; _ }) ->
+    check
+      bool
+      "mentions no messages"
+      true
+      (Agent_sdk.Util.string_contains ~needle:"no messages parsed" message)
+  | Error _ -> fail "expected parse NetworkError"
+  | Ok _ -> fail "expected parse error"
+;;
+
+let test_large_prompt_is_sent_over_stdin () =
+  let capture_path = Filename.temp_file "oas-provider-c-stdin" ".txt" in
+  match
+    with_script "oas-provider-c-stdin" provider_c_stdin_capture_script
+    @@ fun script ->
+    with_transport_config
+      ~configure:(fun config ->
+        { config with extra_env = ("CAPTURE_PATH", capture_path) :: config.extra_env })
+      script
+    @@ fun transport ->
+    let large = String.make (70 * 1024) 'x' in
+    match
+      (transport.Llm_transport.complete_sync
+         (request ~messages:[ user_message large ] ()))
+        .response
+    with
+    | Ok response ->
+      check string "id" "stdin-cli" response.id;
+      let captured = In_channel.with_open_text capture_path In_channel.input_all in
+      check bool "captured via stdin" true (String.length captured >= 70 * 1024)
+    | Error _ -> fail "expected stdin prompt success"
+  with
+  | result ->
+    remove_quietly capture_path;
+    result
+  | exception exn ->
+    remove_quietly capture_path;
+    raise exn
+;;
+
+let test_session_reuse_sends_only_message_delta () =
+  let args_path = Filename.temp_file "oas-provider-c-argv" ".txt" in
+  match
+    with_script "oas-provider-c-argv" provider_c_argv_capture_script
+    @@ fun script ->
+    with_transport_config
+      ~configure:(fun config ->
+        { config with
+          session_id = Some "session-xyz"
+        ; extra_env = ("ARGS_CAPTURE", args_path) :: config.extra_env
+        })
+      script
+    @@ fun transport ->
+    let first = request ~messages:[ user_message "first turn" ] () in
+    let second =
+      request ~messages:[ user_message "first turn"; user_message "second turn" ] ()
+    in
+    ignore (transport.Llm_transport.complete_sync first);
+    ignore (transport.Llm_transport.complete_sync second);
+    let lines =
+      In_channel.with_open_text args_path In_channel.input_all
+      |> String.split_on_char '\n'
+      |> List.filter (fun line -> String.trim line <> "")
+    in
+    match lines with
+    | first_args :: second_args :: _ ->
+      check
+        bool
+        "session flag emitted"
+        true
+        (Agent_sdk.Util.string_contains ~needle:"--session session-xyz" first_args);
+      check
+        bool
+        "first prompt includes first turn"
+        true
+        (Agent_sdk.Util.string_contains ~needle:"first turn" first_args);
+      check
+        bool
+        "second prompt includes second turn"
+        true
+        (Agent_sdk.Util.string_contains ~needle:"second turn" second_args);
+      check
+        bool
+        "second prompt omits prior turn"
+        false
+        (Agent_sdk.Util.string_contains ~needle:"first turn" second_args)
+    | _ -> fail "expected two argv capture lines"
+  with
+  | result ->
+    remove_quietly args_path;
+    result
+  | exception exn ->
+    remove_quietly args_path;
+    raise exn
+;;
+
+let () =
+  run
+    "transport_cli_tool_c_coverage"
+    [ ( "transport"
+      , [ test_case
+            "complete_sync restores text/tool/usage"
+            `Quick
+            test_complete_sync_restores_text_tool_and_usage
+        ; test_case
+            "complete_stream emits block events"
+            `Quick
+            test_complete_stream_emits_blocks_and_stop
+        ; test_case
+            "exit 1 surfaces subprocess error"
+            `Quick
+            test_complete_sync_exit_1_surfaces_subprocess_error
+        ; test_case
+            "external tools warning path still succeeds"
+            `Quick
+            test_warns_once_for_external_tools
+        ; test_case
+            "empty output returns parse error"
+            `Quick
+            test_complete_sync_empty_output_returns_parse_error
+        ; test_case "large prompt uses stdin" `Quick test_large_prompt_is_sent_over_stdin
+        ; test_case
+            "session reuse sends only delta"
+            `Quick
+            test_session_reuse_sends_only_message_delta
+        ] )
+    ]
+;;

--- a/test/test_transport_cli_tool_d_coverage.ml
+++ b/test/test_transport_cli_tool_d_coverage.ml
@@ -1,0 +1,378 @@
+open Alcotest
+open Llm_provider
+
+let write_script name body =
+  let path = Filename.temp_file name ".sh" in
+  Out_channel.with_open_text path (fun oc -> output_string oc body);
+  Unix.chmod path 0o755;
+  path
+;;
+
+let remove_quietly path =
+  try Sys.remove path with
+  | Sys_error _ -> ()
+;;
+
+let with_script name body f =
+  let path = write_script name body in
+  match f path with
+  | result ->
+    remove_quietly path;
+    result
+  | exception exn ->
+    remove_quietly path;
+    raise exn
+;;
+
+let req_config ?(model_id = "auto") () =
+  Provider_config.make ~kind:Provider_config.Cli_tool_d ~model_id ~base_url:"" ()
+;;
+
+let user_message text : Types.message =
+  { role = Types.User
+  ; content = [ Types.Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+let request
+      ?(config = req_config ())
+      ?runtime_mcp_policy
+      ?(messages = [ user_message "hello" ])
+      ()
+  =
+  { Llm_transport.config; messages; tools = []; runtime_mcp_policy }
+;;
+
+let cli_tool_d_stream_success_script =
+  {|#!/bin/sh
+cat <<'JSONL'
+{"type":"system","subtype":"init","model":"agent_llm_a-test","session_id":"session-d"}
+{"type":"assistant","message":{"id":"msg-1","model":"agent_llm_a-test","content":[{"type":"text","text":"Hello from agent_llm_a"},{"type":"thinking","thinking":"careful thought","text":"careful thought"},{"type":"tool_use","id":"tool-1","name":"inspect","input":{"path":"README.md"}}],"stop_reason":"tool_use","usage":{"input_tokens":3,"output_tokens":2}}}
+{"type":"result","subtype":"success","is_error":false,"result":"fallback text","model":"agent_llm_a-test","stop_reason":"end_turn","session_id":"session-d","usage":{"input_tokens":8,"output_tokens":5,"cache_creation_input_tokens":1,"cache_read_input_tokens":2}}
+JSONL
+|}
+;;
+
+let cli_tool_d_json_success_script =
+  {|#!/bin/sh
+echo '{"type":"result","subtype":"success","is_error":false,"result":"Plain JSON result","model":"agent_llm_a-json","stop_reason":"end_turn","session_id":"json-session","usage":{"input_tokens":7,"output_tokens":4}}'
+|}
+;;
+
+let cli_tool_d_error_max_turns_script =
+  {|#!/bin/sh
+cat <<'JSONL'
+{"type":"result","subtype":"error_max_turns","is_error":true,"result":"","model":"agent_llm_a-test","stop_reason":"tool_use","session_id":"session-d","num_turns":31}
+JSONL
+|}
+;;
+
+let cli_tool_d_capture_script =
+  {|#!/bin/sh
+printf '%s\n' "$*" > "$ARGS_CAPTURE"
+cat <<'JSONL'
+{"type":"system","subtype":"init","model":"agent_llm_a-test","session_id":"session-mcp"}
+{"type":"assistant","message":{"id":"msg-1","model":"agent_llm_a-test","content":[{"type":"text","text":"MCP configured"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}}
+{"type":"result","subtype":"success","is_error":false,"result":"MCP configured","model":"agent_llm_a-test","stop_reason":"end_turn","session_id":"session-mcp","usage":{"input_tokens":1,"output_tokens":1}}
+JSONL
+|}
+;;
+
+let cli_tool_d_stdin_capture_script =
+  {|#!/bin/sh
+cat > "$CAPTURE_PATH"
+cat <<'JSONL'
+{"type":"system","subtype":"init","model":"agent_llm_a-test","session_id":"session-stdin"}
+{"type":"assistant","message":{"id":"msg-1","model":"agent_llm_a-test","content":[{"type":"text","text":"Captured"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}}
+{"type":"result","subtype":"success","is_error":false,"result":"Captured","model":"agent_llm_a-test","stop_reason":"end_turn","session_id":"session-stdin","usage":{"input_tokens":1,"output_tokens":1}}
+JSONL
+|}
+;;
+
+let cli_tool_d_empty_script =
+  {|#!/bin/sh
+exit 0
+|}
+;;
+
+let with_transport_config ?(configure = fun config -> config) script f =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let config =
+    { Transport_cli_tool_d.default_config with
+      agent_llm_a_path = script
+    ; model = Some "agent_llm_a-default"
+    ; max_turns = Some 40
+    ; allowed_tools = [ "Read" ]
+    ; permission_mode = Some "acceptEdits"
+    ; mcp_config = Some "/tmp/ignored-mcp.json"
+    ; forward_tool_results = true
+    }
+    |> configure
+  in
+  let transport =
+    Transport_cli_tool_d.create ~sw ~mgr:(Eio.Stdenv.process_mgr env) ~config
+  in
+  f transport
+;;
+
+let with_transport script f = with_transport_config script f
+
+let text_of_first_block = function
+  | Types.Text text :: _ -> text
+  | _ -> ""
+;;
+
+let test_complete_sync_stream_json_preserves_structured_blocks () =
+  with_script "oas-cli-tool-d-stream-success" cli_tool_d_stream_success_script
+  @@ fun script ->
+  with_transport script
+  @@ fun transport ->
+  let config = req_config ~model_id:"agent_llm_a-requested" () in
+  match (transport.Llm_transport.complete_sync (request ~config ())).response with
+  | Ok response ->
+    check string "id" "session-d" response.id;
+    check string "model" "agent_llm_a-test" response.model;
+    (match response.content with
+     | [ Types.Text "Hello from agent_llm_a"
+       ; Types.Thinking { thinking_type = "thinking"; content = "careful thought" }
+       ; Types.ToolUse { id = "tool-1"; name = "inspect"; input }
+       ] ->
+       check string "tool input" {|{"path":"README.md"}|} (Yojson.Safe.to_string input)
+     | _ -> fail "unexpected content blocks");
+    (match response.usage with
+     | Some usage ->
+       check int "input" 8 usage.input_tokens;
+       check int "output" 5 usage.output_tokens;
+       check int "cache create" 1 usage.cache_creation_input_tokens;
+       check int "cache read" 2 usage.cache_read_input_tokens
+     | None -> fail "expected usage")
+  | Error _ -> fail "expected stream-json sync success"
+;;
+
+let test_complete_stream_emits_content_events_and_stop () =
+  with_script "oas-cli-tool-d-stream" cli_tool_d_stream_success_script
+  @@ fun script ->
+  with_transport script
+  @@ fun transport ->
+  let events = ref [] in
+  match
+    transport.Llm_transport.complete_stream
+      ~on_event:(fun event -> events := event :: !events)
+      (request ())
+  with
+  | Ok response ->
+    check string "id" "session-d" response.id;
+    let events = List.rev !events in
+    check
+      bool
+      "message start"
+      true
+      (List.exists
+         (function
+           | Types.MessageStart _ -> true
+           | _ -> false)
+         events);
+    check
+      bool
+      "tool use delta"
+      true
+      (List.exists
+         (function
+           | Types.ContentBlockDelta { delta = Types.InputJsonDelta _; _ } -> true
+           | _ -> false)
+         events);
+    check
+      bool
+      "message stop"
+      true
+      (List.exists
+         (function
+           | Types.MessageStop -> true
+           | _ -> false)
+         events)
+  | Error _ -> fail "expected streaming success"
+;;
+
+let test_complete_sync_json_output_path () =
+  with_script "oas-cli-tool-d-json" cli_tool_d_json_success_script
+  @@ fun script ->
+  with_transport_config
+    ~configure:(fun config -> { config with tool_use_via_stream_json = false })
+    script
+  @@ fun transport ->
+  match (transport.Llm_transport.complete_sync (request ())).response with
+  | Ok response ->
+    check string "id" "json-session" response.id;
+    check string "model" "agent_llm_a-json" response.model;
+    check string "text" "Plain JSON result" (text_of_first_block response.content)
+  | Error _ -> fail "expected JSON output success"
+;;
+
+let test_error_max_turns_maps_to_provider_terminal () =
+  with_script "oas-cli-tool-d-max-turns" cli_tool_d_error_max_turns_script
+  @@ fun script ->
+  with_transport script
+  @@ fun transport ->
+  match (transport.Llm_transport.complete_sync (request ())).response with
+  | Error (Http_client.ProviderTerminal { kind = Http_client.Max_turns r; message }) ->
+    check int "turns" 31 r.turns;
+    check int "limit" 31 r.limit;
+    check
+      bool
+      "message mentions max turns"
+      true
+      (Agent_sdk.Util.string_contains ~needle:"max_turns" message)
+  | Error _ -> fail "expected ProviderTerminal"
+  | Ok _ -> fail "expected max-turns error"
+;;
+
+let test_runtime_mcp_policy_builds_allowed_tools_and_config () =
+  let args_path = Filename.temp_file "oas-cli-tool-d-args" ".txt" in
+  match
+    with_script "oas-cli-tool-d-capture" cli_tool_d_capture_script
+    @@ fun script ->
+    with_transport_config
+      ~configure:(fun config ->
+        { config with
+          mcp_config = None
+        ; allowed_tools = []
+        ; max_turns = None
+        ; permission_mode = None
+        })
+      script
+    @@ fun transport ->
+    Unix.putenv "ARGS_CAPTURE" args_path;
+    let policy =
+      { Llm_transport.empty_runtime_mcp_policy with
+        servers =
+          [ Llm_transport.Stdio_server
+              { name = "worker"
+              ; command = "worker-mcp"
+              ; args = [ "--stdio" ]
+              ; env = [ "TOKEN", "abc" ]
+              }
+          ]
+      ; allowed_tool_names = [ "inspect" ]
+      ; permission_mode = Some "acceptEdits"
+      ; strict = true
+      }
+    in
+    match
+      (transport.Llm_transport.complete_sync (request ~runtime_mcp_policy:policy ()))
+        .response
+    with
+    | Ok response ->
+      check string "text" "MCP configured" (text_of_first_block response.content);
+      let args = In_channel.with_open_text args_path In_channel.input_all in
+      check
+        bool
+        "allowed MCP tool emitted"
+        true
+        (Agent_sdk.Util.string_contains ~needle:"mcp__worker__inspect" args);
+      check
+        bool
+        "inline MCP config emitted"
+        true
+        (Agent_sdk.Util.string_contains ~needle:"mcpServers" args);
+      check
+        bool
+        "strict config emitted"
+        true
+        (Agent_sdk.Util.string_contains ~needle:"--strict-mcp-config" args)
+    | Error _ -> fail "expected runtime MCP success"
+  with
+  | result ->
+    remove_quietly args_path;
+    result
+  | exception exn ->
+    remove_quietly args_path;
+    raise exn
+;;
+
+let test_large_prompt_is_sent_over_stdin () =
+  let capture_path = Filename.temp_file "oas-cli-tool-d-stdin" ".txt" in
+  match
+    with_script "oas-cli-tool-d-stdin" cli_tool_d_stdin_capture_script
+    @@ fun script ->
+    with_transport_config
+      ~configure:(fun config ->
+        { config with
+          mcp_config = None
+        ; allowed_tools = []
+        ; max_turns = None
+        ; permission_mode = None
+        })
+      script
+    @@ fun transport ->
+    Unix.putenv "CAPTURE_PATH" capture_path;
+    let large = String.make (600 * 1024) 'd' in
+    match
+      (transport.Llm_transport.complete_sync
+         (request ~messages:[ user_message large ] ()))
+        .response
+    with
+    | Ok response ->
+      check string "id" "session-stdin" response.id;
+      let captured = In_channel.with_open_text capture_path In_channel.input_all in
+      check bool "captured via stdin" true (String.length captured >= 600 * 1024)
+    | Error _ -> fail "expected stdin prompt success"
+  with
+  | result ->
+    remove_quietly capture_path;
+    result
+  | exception exn ->
+    remove_quietly capture_path;
+    raise exn
+;;
+
+let test_empty_output_returns_parse_error () =
+  with_script "oas-cli-tool-d-empty" cli_tool_d_empty_script
+  @@ fun script ->
+  with_transport script
+  @@ fun transport ->
+  match (transport.Llm_transport.complete_sync (request ())).response with
+  | Error (Http_client.NetworkError { message; _ }) ->
+    check
+      bool
+      "mentions missing stream result"
+      true
+      (Agent_sdk.Util.string_contains ~needle:"No result or assistant message" message)
+  | Error _ -> fail "expected parse NetworkError"
+  | Ok _ -> fail "expected parse error"
+;;
+
+let () =
+  run
+    "transport_cli_tool_d_coverage"
+    [ ( "transport"
+      , [ test_case
+            "complete_sync stream-json preserves structured blocks"
+            `Quick
+            test_complete_sync_stream_json_preserves_structured_blocks
+        ; test_case
+            "complete_stream emits content events"
+            `Quick
+            test_complete_stream_emits_content_events_and_stop
+        ; test_case "json output path" `Quick test_complete_sync_json_output_path
+        ; test_case
+            "error_max_turns maps to ProviderTerminal"
+            `Quick
+            test_error_max_turns_maps_to_provider_terminal
+        ; test_case
+            "runtime MCP policy builds args"
+            `Quick
+            test_runtime_mcp_policy_builds_allowed_tools_and_config
+        ; test_case "large prompt uses stdin" `Quick test_large_prompt_is_sent_over_stdin
+        ; test_case
+            "empty output returns parse error"
+            `Quick
+            test_empty_output_returns_parse_error
+        ] )
+    ]
+;;


### PR DESCRIPTION
Follow-up to PR #1759: harden provider_intf mock server binding against test environments where Eio bind may throw EPERM and avoid fixed-port collisions by retrying candidates.