### PR TITLE
test: cover runtime server and provider config paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,12 @@ jobs:
           # HTTP client, tool selector, checkpoint, and type coverage.
           # Raise the floor to floor(80.02 - 1) = 79 per #1175 ratchet
           # policy.
-          THRESHOLD=79
+          #
+          # 2026-05-25: local clean full coverage measured 81.01%
+          # (24098/29746) after Stage G maintained provider bridge,
+          # sessions, memory, and runtime evidence coverage. Raise the
+          # floor to floor(81.01 - 1) = 80 per #1175 ratchet policy.
+          THRESHOLD=80
           if [ "$(echo "$COVERAGE < $THRESHOLD" | bc -l)" -eq 1 ]; then
             echo "::error::Coverage ${COVERAGE}% is below threshold ${THRESHOLD}%"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,13 @@ jobs:
           # (23500/29748) after Stage E runtime server and provider config
           # coverage. Raise the floor to floor(79.00 - 1) = 78 per #1175
           # ratchet policy.
-          THRESHOLD=78
+          #
+          # 2026-05-25: local clean full coverage measured 80.02%
+          # (23803/29748) after Stage F maintained memory, discovery,
+          # HTTP client, tool selector, checkpoint, and type coverage.
+          # Raise the floor to floor(80.02 - 1) = 79 per #1175 ratchet
+          # policy.
+          THRESHOLD=79
           if [ "$(echo "$COVERAGE < $THRESHOLD" | bc -l)" -eq 1 ]; then
             echo "::error::Coverage ${COVERAGE}% is below threshold ${THRESHOLD}%"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,12 @@ jobs:
           # 78.13% (23241/29748) after Stage D provider_k, tool-call
           # harness, and provider catalog coverage. Raise the floor to
           # floor(78.13 - 1) = 77 per #1175 ratchet policy.
-          THRESHOLD=77
+          #
+          # 2026-05-25: local clean full coverage measured 79.00%
+          # (23500/29748) after Stage E runtime server and provider config
+          # coverage. Raise the floor to floor(79.00 - 1) = 78 per #1175
+          # ratchet policy.
+          THRESHOLD=78
           if [ "$(echo "$COVERAGE < $THRESHOLD" | bc -l)" -eq 1 ]; then
             echo "::error::Coverage ${COVERAGE}% is below threshold ${THRESHOLD}%"
             exit 1

--- a/docs/_audit/2026-05-25-coverage-ratchet-75-evidence.md
+++ b/docs/_audit/2026-05-25-coverage-ratchet-75-evidence.md
@@ -142,6 +142,50 @@ the CI coverage floor can move from 73% to 77%.
   Confidence: High for focused behavior coverage; project-wide CI coverage is
   now governed by the latest `77` floor above.
 
+## Stage E runtime server and provider config follow-up
+
+- Evidence: local focused and full coverage runs after PR #1759 merged, adding
+  maintained runtime server request/command coverage and extending pure
+  provider configuration coverage. Deprecated runtime paths were intentionally
+  left out of this slice.
+- Runtime server focused command:
+  `DUNE_BUILD_DIR=/tmp/oas_runtime_server_cov_build dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/runtime-server-coverage-20260525 --instrument-with bisect_ppx test/test_runtime_server_coverage.exe`
+- Runtime server focused test:
+  `env BISECT_FILE=/tmp/oas_stage_e_runtime_server_coverage_run2/bisect /tmp/oas_runtime_server_cov_build/default/test/test_runtime_server_coverage.exe`
+- Runtime server focused result:
+  `test/test_runtime_server_coverage.exe` passed 3 tests;
+  `lib/runtime_server.ml` reached `31.33%` (`193/616`) in the focused slice.
+- Provider config focused command:
+  `DUNE_BUILD_DIR=/tmp/oas_provider_config_cov_build2 dune build --root /Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/runtime-server-coverage-20260525 --instrument-with bisect_ppx test/test_provider_config.exe`
+- Provider config focused test:
+  `env BISECT_FILE=/tmp/oas_provider_config_cov_run2/bisect /tmp/oas_provider_config_cov_build2/default/test/test_provider_config.exe`
+- Provider config focused result:
+  `test/test_provider_config.exe` passed 65 tests;
+  `lib/llm_provider/provider_config.ml` reached `79.19%` (`156/197`) in
+  the focused slice.
+- Full clean coverage command:
+  `env MASC_DUNE_THROTTLE=0 BISECT_ENABLE=yes EIO_BACKEND=posix BISECT_FILE=/tmp/oas_stage_e_full_runtime_provider_coverage_final/bisect DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/runtime-server-coverage-20260525/_build_cov_runtime_provider scripts/dune-local.sh runtest --force --instrument-with bisect_ppx`
+- Full clean coverage result:
+  `79.00%` (`23500/29748`) from
+  `/tmp/oas_stage_e_full_runtime_provider_coverage_final`.
+- Full per-file results:
+  - `lib/runtime_server.ml`: `33.12%` (`204/616`)
+  - `lib/llm_provider/provider_config.ml`: `82.74%` (`163/197`)
+  - `lib/runtime_evidence.ml`: `94.21%` (`244/259`)
+  - `lib/runtime_projection.ml`: `81.75%` (`233/285`)
+  - `lib/runtime_store.ml`: `87.79%` (`266/303`)
+- Ratchet decision:
+  CI coverage threshold raised from `77` to `78`, leaving 1 point of headroom
+  below the measured `79.00%` while preventing regression.
+- Note:
+  A prior full coverage attempt with `DUNE_BUILD_DIR=/tmp/...` failed because
+  sandboxed repo-root-sensitive tests could not locate `dune-project`; rerunning
+  with the build dir inside the worktree passed. This was an execution
+  environment issue, not a product test failure.
+- Timestamp: 2026-05-25 KST
+  Confidence: High for focused behavior coverage and full project coverage;
+  project-wide CI coverage is now governed by the latest `78` floor above.
+
 ## Stage D CLI A/D and validation follow-up
 
 - Evidence: local focused coverage run on PR #1759 after adding

--- a/docs/_audit/2026-05-25-coverage-ratchet-75-evidence.md
+++ b/docs/_audit/2026-05-25-coverage-ratchet-75-evidence.md
@@ -1,9 +1,11 @@
 # Coverage ratchet evidence - 2026-05-25
 
-Scope: #1175 Stage C/D continuation. PR #1759 raises measured project coverage
-above 78% with behavior-backed provider dispatch, provider_d codec, streaming,
-pure-module, harness, CLI transport, provider_k, and provider catalog tests, so
-the CI coverage floor can move from 73% to 77%.
+Scope: #1175 Stage C/D/E/F continuation. PRs #1759 and #1761 raise measured
+project coverage above 80% with behavior-backed provider dispatch, provider_d
+codec, streaming, pure-module, harness, CLI transport, provider_k, provider
+catalog, runtime server, provider config, memory, discovery, HTTP client, tool
+selector, checkpoint, and type tests, so the CI coverage floor can move from
+73% to 79%.
 
 ## Measurement
 
@@ -141,6 +143,40 @@ the CI coverage floor can move from 73% to 77%.
 - Timestamp: 2026-05-25 KST
   Confidence: High for focused behavior coverage; project-wide CI coverage is
   now governed by the latest `77` floor above.
+
+## Stage F terminal-target follow-up
+
+- Evidence: local focused and full coverage runs on PR #1761 after extending
+  maintained memory, discovery, HTTP client, tool selector, checkpoint, and type
+  tests. Deprecated Orchestrator/Collaboration paths were intentionally not
+  expanded.
+- Focused validation:
+  `env MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_memory.exe test/test_tool_selector.exe test/test_discovery.exe test/test_http_client.exe test/test_types.exe`
+  and
+  `env MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_memory_episodic.exe test/test_memory_tools_parse.exe test/test_checkpoint_delta.exe test/test_checkpoint.exe`
+- Full clean coverage command:
+  `env MASC_DUNE_THROTTLE=0 BISECT_ENABLE=yes EIO_BACKEND=posix BISECT_FILE=/tmp/oas_stage_f_full_coverage_20260525_3/bisect DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/runtime-server-coverage-20260525/_build_cov_stage_f3 scripts/dune-local.sh runtest --force --instrument-with bisect_ppx`
+- Summary command:
+  `opam exec -- bisect-ppx-report summary --per-file --coverage-path=/tmp/oas_stage_f_full_coverage_20260525_3`
+- Full clean coverage result:
+  `80.02%` (`23803/29748`) from
+  `/tmp/oas_stage_f_full_coverage_20260525_3`.
+- Key full-run per-file results:
+  - `lib/checkpoint_codec.ml`: `93.10%` (`351/377`)
+  - `lib/memory_episodic.ml`: `93.42%` (`71/76`)
+  - `lib/memory_tools_parse.ml`: `100.00%` (`112/112`)
+  - `lib/memory.ml`: `82.60%` (`299/362`)
+  - `lib/llm_provider/discovery.ml`: `71.58%` (`199/278`)
+  - `lib/llm_provider/http_client.ml`: `65.53%` (`268/409`)
+  - `lib/llm_provider/types.ml`: `76.03%` (`241/317`)
+  - `lib/tool_selector.ml`: `69.74%` (`106/152`)
+- Ratchet decision:
+  CI coverage threshold raised from `78` to `79`, using
+  `floor(80.02 - 1) = 79` and keeping one percentage point of headroom below
+  the measured result.
+- Timestamp: 2026-05-25 KST
+  Confidence: High for focused behavior coverage and full project coverage;
+  project-wide CI coverage is now governed by the latest `79` floor above.
 
 ## Stage E runtime server and provider config follow-up
 

--- a/lib/provider_bridge.ml
+++ b/lib/provider_bridge.ml
@@ -99,9 +99,7 @@ let to_provider_config (legacy : Provider.config)
   | Error e -> Error e
   | Ok (base_url, api_key, headers) ->
     let m_lower = String.lowercase_ascii legacy.model_id in
-    let is_provider_f_model =
-      String.length m_lower >= 6 && String.sub m_lower 0 6 = "provider_f"
-    in
+    let is_provider_f_model = String.starts_with ~prefix:"provider_f" m_lower in
     let is_glm_model = is_glm_model_or_alias m_lower in
     let is_zai_provider = Llm_provider.Zai_catalog.is_zai_base_url base_url in
     let is_provider_c_provider = is_provider_c_coding_base_url base_url in

--- a/test/dune
+++ b/test/dune
@@ -180,6 +180,7 @@
   test_runtime_health
   test_runtime_replay
   test_runtime_projection_cov2
+  test_runtime_server_coverage
   test_runtime_server_resolve
   test_runtime_server_types
   test_runtime_store_unit
@@ -409,6 +410,7 @@
   test_runtime_health
   test_runtime_replay
   test_runtime_projection_cov2
+  test_runtime_server_coverage
   test_runtime_server_resolve
   test_runtime_server_types
   test_runtime_store_unit

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -353,6 +353,25 @@ let () =
             let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
             check int "input" 0 cp2.usage.total_input_tokens;
             check int "api_calls" 0 cp2.usage.api_calls)
+        ; test_case "usage legacy defaults and unpriced model" `Quick (fun () ->
+            let usage =
+              Checkpoint.usage_of_json
+                (`Assoc
+                    [ "total_input_tokens", `Int 10
+                    ; "total_output_tokens", `Int 5
+                    ; "api_calls", `Int 2
+                    ; "estimated_cost_usd", `Int 1
+                    ; "unpriced_model", `String "custom-model"
+                    ])
+            in
+            check int "cache create default" 0 usage.total_cache_creation_input_tokens;
+            check int "cache read default" 0 usage.total_cache_read_input_tokens;
+            check (float 0.001) "int cost widens" 1.0 usage.estimated_cost_usd;
+            check
+              (option string)
+              "unpriced model"
+              (Some "custom-model")
+              usage.unpriced_model)
         ] )
     ; ( "tools"
       , [ test_case "tool_schema roundtrip" `Quick (fun () ->
@@ -814,6 +833,69 @@ let () =
               | other -> other
             in
             check bool "error" true (Result.is_error (Checkpoint.of_json bad)))
+        ; test_case "message metadata must be object" `Quick (fun () ->
+            let cp =
+              make_checkpoint
+                ~messages:
+                  [ { Types.role = Types.Assistant
+                    ; content = [ Types.Text "hello" ]
+                    ; name = None
+                    ; tool_call_id = None
+                    ; metadata = []
+                    }
+                  ]
+                ()
+            in
+            let json = Checkpoint.to_json cp in
+            let bad =
+              match json with
+              | `Assoc pairs ->
+                `Assoc
+                  (List.map
+                     (fun (k, v) ->
+                        if k = "messages"
+                        then (
+                          match v with
+                          | `List (`Assoc msg_fields :: rest) ->
+                            ( k
+                            , `List
+                                (`Assoc (("metadata", `String "bad") :: msg_fields)
+                                 :: rest) )
+                          | other -> k, other)
+                        else k, v)
+                     pairs)
+              | other -> other
+            in
+            check bool "error" true (Result.is_error (Checkpoint.of_json bad)))
+        ; test_case "context null and working_context value decode" `Quick (fun () ->
+            let cp = make_checkpoint () in
+            let working_context =
+              `Assoc [ "kind", `String "ctx"; "generation", `Int 1 ]
+            in
+            let json =
+              match Checkpoint.to_json cp with
+              | `Assoc pairs ->
+                `Assoc
+                  (List.map
+                     (fun (k, v) ->
+                        match k with
+                        | "context" -> k, `Null
+                        | "working_context" -> k, working_context
+                        | _ -> k, v)
+                     pairs)
+              | other -> other
+            in
+            let decoded = Result.get_ok (Checkpoint.of_json json) in
+            check
+              int
+              "context starts empty"
+              0
+              (List.length (Context.keys decoded.context));
+            check
+              (option (testable Yojson.Safe.pp Yojson.Safe.equal))
+              "working context"
+              (Some working_context)
+              decoded.working_context)
         ] )
     ; ( "mcp_sessions"
       , [ test_case "empty mcp_sessions roundtrip" `Quick (fun () ->

--- a/test/test_checkpoint_delta.ml
+++ b/test/test_checkpoint_delta.ml
@@ -240,6 +240,26 @@ let make_unit_checkpoint
   }
 ;;
 
+let sample_tool_schema =
+  { name = "lookup"
+  ; description = "Lookup a value"
+  ; parameters =
+      [ { name = "key"; description = "Key"; param_type = String; required = true } ]
+  }
+;;
+
+let sample_mcp_session =
+  { Mcp_session.server_name = "memory"
+  ; command = "memory-server"
+  ; args = [ "--stdio" ]
+  ; env = [ "MODE", "test" ]
+  ; http_base_url = None
+  ; http_headers = []
+  ; tool_schemas = [ sample_tool_schema ]
+  ; transport_kind = Mcp_session.Stdio
+  }
+;;
+
 let test_delta_roundtrip_property =
   QCheck.Test.make
     ~count:100
@@ -300,6 +320,125 @@ let test_delta_json_roundtrip () =
     (match Checkpoint.apply_delta base decoded with
      | Ok rebuilt -> checkpoint_equal rebuilt target
      | Error _ -> false)
+;;
+
+let test_delta_json_all_replacement_ops () =
+  let base = make_unit_checkpoint ~tool_choice:(Some Auto) () in
+  let target =
+    { base with
+      system_prompt = None
+    ; usage =
+        { total_input_tokens = 11
+        ; total_output_tokens = 7
+        ; total_cache_creation_input_tokens = 3
+        ; total_cache_read_input_tokens = 2
+        ; api_calls = 4
+        ; estimated_cost_usd = 0.42
+        ; unpriced_model = Some "custom-unpriced"
+        }
+    ; turn_count = 9
+    ; tools = [ sample_tool_schema ]
+    ; tool_choice = Some (Tool "lookup")
+    ; temperature = Some 0.2
+    ; top_p = Some 0.9
+    ; top_k = Some 40
+    ; min_p = Some 0.05
+    ; enable_thinking = Some true
+    ; thinking_budget = Some 128
+    ; disable_parallel_tool_use = true
+    ; response_format = JsonSchema (`Assoc [ "type", `String "object" ])
+    ; cache_system_prompt = true
+    ; max_input_tokens = Some 2048
+    ; max_total_tokens = Some 4096
+    ; mcp_sessions = [ sample_mcp_session ]
+    ; working_context = Some (`Assoc [ "kind", `String "full_replace" ])
+    }
+  in
+  let delta = Checkpoint.compute_delta base target in
+  let delta_json = Checkpoint.delta_to_json delta in
+  let kinds =
+    match delta_json with
+    | `Assoc fields ->
+      (match List.assoc_opt "operations" fields with
+       | Some (`List operations) ->
+         List.filter_map
+           (function
+             | `Assoc op_fields ->
+               (match List.assoc_opt "kind" op_fields with
+                | Some (`String kind) -> Some kind
+                | _ -> None)
+             | _ -> None)
+           operations
+       | _ -> Alcotest.fail "operations missing")
+    | _ -> Alcotest.fail "delta json should be an object"
+  in
+  List.iter
+    (fun kind -> Alcotest.(check bool) kind true (List.mem kind kinds))
+    [ "replace_system_prompt"
+    ; "replace_usage"
+    ; "replace_turn_count"
+    ; "replace_tools"
+    ; "replace_tool_choice"
+    ; "replace_sampling"
+    ; "replace_limits"
+    ; "replace_mcp_sessions"
+    ; "replace_working_context"
+    ];
+  let decoded = delta_json |> Checkpoint.delta_of_json |> Result.get_ok in
+  match Checkpoint.apply_delta base decoded with
+  | Ok rebuilt ->
+    Alcotest.(check bool)
+      "decoded replacement delta applies"
+      true
+      (checkpoint_equal rebuilt target)
+  | Error err ->
+    Alcotest.failf "expected delta to apply: %s" (Agent_sdk.Error.to_string err)
+;;
+
+let test_delta_json_null_and_legacy_limit_paths () =
+  let base = make_unit_checkpoint ~tool_choice:(Some Any) () in
+  let target = { base with tool_choice = None; working_context = None } in
+  let delta = Checkpoint.compute_delta base target in
+  let decoded =
+    delta |> Checkpoint.delta_to_json |> Checkpoint.delta_of_json |> Result.get_ok
+  in
+  (match Checkpoint.apply_delta base decoded with
+   | Ok rebuilt ->
+     Alcotest.(check bool) "tool choice none" true (Option.is_none rebuilt.tool_choice)
+   | Error err ->
+     Alcotest.failf "expected null delta to apply: %s" (Agent_sdk.Error.to_string err));
+  let with_operations operations =
+    match Checkpoint.delta_to_json (Checkpoint.compute_delta base base) with
+    | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (key, value) ->
+              if key = "operations" then key, `List operations else key, value)
+           fields)
+    | _ -> Alcotest.fail "delta json should be an object"
+  in
+  let legacy_limits_json =
+    with_operations
+      [ `Assoc
+          [ "kind", `String "replace_limits"
+          ; "disable_parallel_tool_use", `Bool false
+          ; "response_format", `Null
+          ; "response_format_json", `Bool true
+          ; "cache_system_prompt", `Bool false
+          ; "max_input_tokens", `Null
+          ; "max_total_tokens", `Null
+          ]
+      ]
+  in
+  Alcotest.(check bool)
+    "legacy response_format_json accepted"
+    true
+    (Result.is_ok (Checkpoint.delta_of_json legacy_limits_json));
+  let unknown_op_json = with_operations [ `Assoc [ "kind", `String "bogus" ] ] in
+  Alcotest.(check bool)
+    "unknown op rejected"
+    true
+    (Result.is_error (Checkpoint.delta_of_json unknown_op_json))
 ;;
 
 let test_delta_json_rejects_malformed_context_removed () =
@@ -665,6 +804,14 @@ let () =
             "delta JSON rejects malformed context removed"
             `Quick
             test_delta_json_rejects_malformed_context_removed
+        ; Alcotest.test_case
+            "delta JSON all replacement ops"
+            `Quick
+            test_delta_json_all_replacement_ops
+        ; Alcotest.test_case
+            "delta JSON null and legacy limit paths"
+            `Quick
+            test_delta_json_null_and_legacy_limit_paths
         ; Alcotest.test_case "empty delta roundtrip" `Quick test_empty_delta_roundtrip
         ; Alcotest.test_case
             "metadata delta roundtrip"

--- a/test/test_complete_ext.ml
+++ b/test/test_complete_ext.ml
@@ -4,6 +4,129 @@
 open Alcotest
 open Llm_provider
 
+let make_config
+      ?(kind = Provider_config.Provider_d_compat)
+      ?(model_id = "coverage-model")
+      ?(base_url = "http://127.0.0.1:8080")
+      ?(headers = [])
+      ?(request_path = "/v1/chat/completions")
+      ?api_key
+      ?min_p
+      ?top_p
+      ?top_k
+      ()
+  =
+  Provider_config.make
+    ~kind
+    ~model_id
+    ~base_url
+    ~headers
+    ~request_path
+    ?api_key
+    ?min_p
+    ?top_p
+    ?top_k
+    ()
+;;
+
+let make_usage ?(input_tokens = 11) ?(output_tokens = 7) () : Types.api_usage =
+  { input_tokens
+  ; output_tokens
+  ; cache_creation_input_tokens = 0
+  ; cache_read_input_tokens = 0
+  ; cost_usd = None
+  }
+;;
+
+let make_response ?(model = "") ?(content = [ Types.Text "ok" ]) ?usage () =
+  { Types.id = "resp-complete-ext"
+  ; model
+  ; stop_reason = EndTurn
+  ; content
+  ; usage
+  ; telemetry = None
+  }
+;;
+
+type metric_probe =
+  { mutable cache_hits : int
+  ; mutable cache_misses : int
+  ; mutable starts : int
+  ; mutable ends : int
+  ; mutable errors : string list
+  ; mutable statuses : int list
+  ; mutable token_usage : (int * int) list
+  ; mutable tool_calls : int list
+  ; mutable retries : int list
+  ; mutable streaming_first_chunks : float list
+  }
+
+let metric_probe () =
+  { cache_hits = 0
+  ; cache_misses = 0
+  ; starts = 0
+  ; ends = 0
+  ; errors = []
+  ; statuses = []
+  ; token_usage = []
+  ; tool_calls = []
+  ; retries = []
+  ; streaming_first_chunks = []
+  }
+;;
+
+let metrics_of_probe probe =
+  { Metrics.noop with
+    on_cache_hit = (fun ~model_id:_ -> probe.cache_hits <- probe.cache_hits + 1)
+  ; on_cache_miss = (fun ~model_id:_ -> probe.cache_misses <- probe.cache_misses + 1)
+  ; on_request_start = (fun ~model_id:_ -> probe.starts <- probe.starts + 1)
+  ; on_request_end = (fun ~model_id:_ ~latency_ms:_ -> probe.ends <- probe.ends + 1)
+  ; on_error = (fun ~model_id:_ ~error -> probe.errors <- error :: probe.errors)
+  ; on_http_status =
+      (fun ~provider:_ ~model_id:_ ~status -> probe.statuses <- status :: probe.statuses)
+  ; on_token_usage =
+      (fun ~provider:_ ~model_id:_ ~input_tokens ~output_tokens ->
+        probe.token_usage <- (input_tokens, output_tokens) :: probe.token_usage)
+  ; on_tool_calls =
+      (fun ~provider:_ ~model_id:_ ~count ->
+        probe.tool_calls <- count :: probe.tool_calls)
+  ; on_retry =
+      (fun ~provider:_ ~model_id:_ ~attempt -> probe.retries <- attempt :: probe.retries)
+  ; on_streaming_first_chunk =
+      (fun ~provider:_ ~model_id:_ ~ttfrc_ms ->
+        probe.streaming_first_chunks <- ttfrc_ms :: probe.streaming_first_chunks)
+  }
+;;
+
+let in_memory_cache () =
+  let table = Hashtbl.create 4 in
+  ({ Cache.get = (fun ~key -> Hashtbl.find_opt table key)
+   ; set = (fun ~key ~ttl_sec:_ json -> Hashtbl.replace table key json)
+   }
+   : Cache.t)
+;;
+
+let transport_of_sync sync_response =
+  { Llm_transport.complete_sync = (fun _request -> sync_response ())
+  ; complete_stream =
+      (fun ?on_telemetry:_ ~on_event:_ _request ->
+        match sync_response () with
+        | { response = Ok resp; _ } -> Ok resp
+        | { response = Error err; _ } -> Error err)
+  }
+;;
+
+let string_of_http_error = function
+  | Http_client.HttpError { code; body } -> Printf.sprintf "HTTP %d: %s" code body
+  | NetworkError { message; _ } -> message
+  | TimeoutError { message; _ } -> message
+  | AcceptRejected { reason } -> reason
+  | CliTransportRequired { kind } -> Printf.sprintf "CLI transport required: %s" kind
+  | ProviderTerminal { message; _ } -> message
+  | ProviderFailure { kind; message } ->
+    Http_client.provider_failure_to_string ~kind ~message
+;;
+
 (* ── is_retryable ────────────────────────────────────── *)
 
 let test_retryable_429 () =
@@ -122,6 +245,376 @@ let test_retry_config_backoff () =
   check (float 0.01) "backoff" 2.0 Complete.default_retry_config.backoff_multiplier
 ;;
 
+(* ── Provider defaults / public helpers ───────────────── *)
+
+let test_provider_f_url_variants () =
+  let keyed =
+    make_config
+      ~kind:Provider_config.Provider_f
+      ~model_id:"provider_f-3-flash"
+      ~base_url:"https://generativelanguage.googleapis.com/v1beta"
+      ~api_key:"secret"
+      ()
+  in
+  check
+    string
+    "sync keyed"
+    "https://generativelanguage.googleapis.com/v1beta/models/provider_f-3-flash:generateContent?key=secret"
+    (Complete.provider_f_url ~config:keyed ~stream:false);
+  check
+    string
+    "stream keyed"
+    "https://generativelanguage.googleapis.com/v1beta/models/provider_f-3-flash:streamGenerateContent?key=secret&alt=sse"
+    (Complete.provider_f_url ~config:keyed ~stream:true);
+  let no_key =
+    make_config
+      ~kind:Provider_config.Provider_f
+      ~model_id:"provider_f-3-flash"
+      ~base_url:"https://generativelanguage.googleapis.com/v1beta"
+      ()
+  in
+  check
+    string
+    "stream no key"
+    "https://generativelanguage.googleapis.com/v1beta/models/provider_f-3-flash:streamGenerateContent?alt=sse"
+    (Complete.provider_f_url ~config:no_key ~stream:true)
+;;
+
+let test_sampling_defaults_and_overlay () =
+  let defaults = Complete.provider_sampling_defaults Provider_config.Provider_d_compat in
+  check
+    (option (float 0.001))
+    "provider_d min_p"
+    (Some Constants.Sampling.provider_d_compat_min_p)
+    defaults.default_min_p;
+  let no_defaults = Complete.provider_sampling_defaults Provider_config.Provider_a in
+  check (option (float 0.001)) "provider_a min_p" None no_defaults.default_min_p;
+  let local = make_config () in
+  let local_defaulted = Complete.apply_sampling_defaults local in
+  check
+    (option (float 0.001))
+    "local min_p defaulted"
+    (Some Constants.Sampling.provider_d_compat_min_p)
+    local_defaulted.min_p;
+  let explicit = make_config ~min_p:0.2 ~top_p:0.7 ~top_k:17 () in
+  let explicit_defaulted = Complete.apply_sampling_defaults explicit in
+  check
+    (option (float 0.001))
+    "explicit min_p preserved"
+    (Some 0.2)
+    explicit_defaulted.min_p;
+  check
+    (option (float 0.001))
+    "explicit top_p preserved"
+    (Some 0.7)
+    explicit_defaulted.top_p;
+  check (option int) "explicit top_k preserved" (Some 17) explicit_defaulted.top_k
+;;
+
+(* ── complete wrapper paths ───────────────────────────── *)
+
+let test_complete_transport_success_cache_metrics_and_trace_headers () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let probe = metric_probe () in
+  let metrics = metrics_of_probe probe in
+  let cache = in_memory_cache () in
+  let calls = ref 0 in
+  let config =
+    make_config
+      ~headers:[ "traceparent", "old"; "x-base", "base" ]
+      ~model_id:"provider_d-test"
+      ()
+  in
+  let content =
+    [ Types.Text "done"
+    ; Types.ToolUse { id = "tool-1"; name = "lookup"; input = `Assoc [] }
+    ]
+  in
+  let response = make_response ~content ~usage:(make_usage ()) () in
+  let transport =
+    { Llm_transport.complete_sync =
+        (fun request ->
+          incr calls;
+          check
+            bool
+            "traceparent replaced"
+            true
+            (List.mem ("traceparent", "new") request.config.headers);
+          check
+            bool
+            "tracestate appended"
+            true
+            (List.mem ("tracestate", "state") request.config.headers);
+          check
+            bool
+            "base header preserved"
+            true
+            (List.mem ("x-base", "base") request.config.headers);
+          { Llm_transport.response = Ok response; latency_ms = Some 42 })
+    ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _request -> Ok response)
+    }
+  in
+  let messages = [ Types.user_msg "hello" ] in
+  let first =
+    Complete.complete
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~transport
+      ~config
+      ~messages
+      ~trace_context:[ "traceparent", "new"; "tracestate", "state" ]
+      ~cache
+      ~metrics
+      ()
+  in
+  (match first with
+   | Ok resp ->
+     check string "model patched" "provider_d-test" resp.model;
+     (match resp.telemetry with
+      | Some t ->
+        check (option int) "latency patched" (Some 42) t.request_latency_ms;
+        check
+          (option string)
+          "canonical model"
+          (Some "provider_d-test")
+          t.canonical_model_id
+      | None -> fail "expected telemetry")
+   | Error err -> failf "unexpected complete error: %s" (string_of_http_error err));
+  let second =
+    Complete.complete
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~transport
+      ~config
+      ~messages
+      ~trace_context:[ "traceparent", "new"; "tracestate", "state" ]
+      ~cache
+      ~metrics
+      ()
+  in
+  (match second with
+   | Ok resp -> check string "cached text" "done" (Types.text_of_response resp)
+   | Error err -> failf "unexpected cached error: %s" (string_of_http_error err));
+  check int "transport called once" 1 !calls;
+  check int "cache miss once" 1 probe.cache_misses;
+  check int "cache hit once" 1 probe.cache_hits;
+  check int "request start once" 1 probe.starts;
+  check int "request end once" 1 probe.ends;
+  check (list int) "status 200" [ 200 ] (List.rev probe.statuses);
+  check (list (pair int int)) "usage" [ 11, 7 ] (List.rev probe.token_usage);
+  check (list int) "tool calls" [ 1 ] (List.rev probe.tool_calls)
+;;
+
+let test_complete_transport_error_and_cli_required_metrics () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let probe = metric_probe () in
+  let metrics = metrics_of_probe probe in
+  let config = make_config ~model_id:"provider_d-error" () in
+  let transport =
+    transport_of_sync (fun () ->
+      { Llm_transport.response =
+          Error (Http_client.HttpError { code = 503; body = "down" })
+      ; latency_ms = Some 5
+      })
+  in
+  (match
+     Complete.complete
+       ~sw
+       ~net:(Eio.Stdenv.net env)
+       ~transport
+       ~config
+       ~messages:[ Types.user_msg "hello" ]
+       ~metrics
+       ()
+   with
+   | Error (Http_client.HttpError { code = 503; _ }) -> ()
+   | Error err -> failf "wrong error: %s" (string_of_http_error err)
+   | Ok _ -> fail "expected HTTP error");
+  check (list int) "transport status" [ 503 ] (List.rev probe.statuses);
+  check (list string) "transport error metric" [ "HTTP 503" ] (List.rev probe.errors);
+  let cli_probe = metric_probe () in
+  let cli_config =
+    make_config ~kind:Provider_config.Cli_tool_a ~model_id:"cli-tool-a" ~base_url:"" ()
+  in
+  (match
+     Complete.complete
+       ~sw
+       ~net:(Eio.Stdenv.net env)
+       ~config:cli_config
+       ~messages:[ Types.user_msg "hello" ]
+       ~metrics:(metrics_of_probe cli_probe)
+       ()
+   with
+   | Error (Http_client.CliTransportRequired { kind }) ->
+     check string "cli kind" "cli_tool_a" kind
+   | Error err -> failf "wrong cli error: %s" (string_of_http_error err)
+   | Ok _ -> fail "expected CLI transport required");
+  check
+    (list string)
+    "cli error metric"
+    [ "CLI transport required for cli_tool_a but none injected" ]
+    (List.rev cli_probe.errors);
+  check (list int) "no cli HTTP status" [] (List.rev cli_probe.statuses)
+;;
+
+let test_complete_with_retry_retries_then_success () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let probe = metric_probe () in
+  let metrics = metrics_of_probe probe in
+  let attempts = ref 0 in
+  let config = make_config ~model_id:"provider_d-retry" () in
+  let response = make_response ~model:"provider_d-retry" ~usage:(make_usage ()) () in
+  let transport =
+    transport_of_sync (fun () ->
+      incr attempts;
+      if !attempts < 3
+      then
+        { Llm_transport.response =
+            Error (Http_client.HttpError { code = 500; body = "temporary" })
+        ; latency_ms = Some 3
+        }
+      else { Llm_transport.response = Ok response; latency_ms = Some 9 })
+  in
+  let retry_config =
+    { Complete.max_retries = 3
+    ; initial_delay_sec = 0.0
+    ; max_delay_sec = 0.0
+    ; backoff_multiplier = 1.0
+    }
+  in
+  (match
+     Complete.complete_with_retry
+       ~sw
+       ~net:(Eio.Stdenv.net env)
+       ~transport
+       ~clock:(Eio.Stdenv.clock env)
+       ~config
+       ~messages:[ Types.user_msg "hello" ]
+       ~retry_config
+       ~metrics
+       ()
+   with
+   | Ok resp -> check string "retry success" "provider_d-retry" resp.model
+   | Error err -> failf "unexpected retry error: %s" (string_of_http_error err));
+  check int "attempts" 3 !attempts;
+  check (list int) "retry callbacks" [ 1; 2 ] (List.rev probe.retries);
+  check (list int) "statuses" [ 500; 500; 200 ] (List.rev probe.statuses);
+  check (list string) "errors" [ "HTTP 500"; "HTTP 500" ] (List.rev probe.errors)
+;;
+
+let test_complete_stream_transport_success_metrics_and_telemetry () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let probe = metric_probe () in
+  let metrics = metrics_of_probe probe in
+  let seen_events = ref [] in
+  let seen_telemetry = ref [] in
+  let config =
+    make_config ~model_id:"provider_d-stream" ~headers:[ "traceparent", "old-stream" ] ()
+  in
+  let response =
+    make_response
+      ~content:
+        [ Types.Text "streamed"
+        ; Types.ToolUse { id = "tool-stream"; name = "search"; input = `Assoc [] }
+        ]
+      ()
+  in
+  let transport =
+    { Llm_transport.complete_sync =
+        (fun _request -> { Llm_transport.response = Ok response; latency_ms = Some 1 })
+    ; complete_stream =
+        (fun ?on_telemetry ~on_event request ->
+          check
+            bool
+            "stream trace replaced"
+            true
+            (List.mem ("traceparent", "new-stream") request.config.headers);
+          let event = Types.Ping in
+          on_event event;
+          seen_events := event :: !seen_events;
+          (match on_telemetry with
+           | Some emit ->
+             emit
+               (Telemetry_event.Streaming_first_chunk
+                  { provider = "provider_d"
+                  ; model = request.config.model_id
+                  ; ttfrc_ms = 1.5
+                  ; requested_at = 0.0
+                  })
+           | None -> ());
+          Ok response)
+    }
+  in
+  (match
+     Complete.complete_stream
+       ~sw
+       ~net:(Eio.Stdenv.net env)
+       ~transport
+       ~config
+       ~messages:[ Types.user_msg "hello stream" ]
+       ~trace_context:[ "traceparent", "new-stream" ]
+       ~on_event:(fun _event -> ())
+       ~on_telemetry:(fun event -> seen_telemetry := event :: !seen_telemetry)
+       ~metrics
+       ()
+   with
+   | Ok resp ->
+     check string "stream model patched" "provider_d-stream" resp.model;
+     (match resp.telemetry with
+      | Some t ->
+        check bool "stream latency patched" true (Option.is_some t.request_latency_ms);
+        check
+          (option string)
+          "stream canonical model"
+          (Some "provider_d-stream")
+          t.canonical_model_id
+      | None -> fail "expected stream telemetry")
+   | Error err -> failf "unexpected stream error: %s" (string_of_http_error err));
+  check int "event observed" 1 (List.length !seen_events);
+  check int "telemetry observed" 1 (List.length !seen_telemetry);
+  check (list int) "stream tool calls" [ 1 ] (List.rev probe.tool_calls);
+  check
+    (list (float 0.001))
+    "first chunk metric"
+    [ 1.5 ]
+    (List.rev probe.streaming_first_chunks)
+;;
+
+let test_complete_stream_cli_required () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let cli_config =
+    make_config ~kind:Provider_config.Cli_tool_b ~model_id:"cli-tool-b" ~base_url:"" ()
+  in
+  match
+    Complete.complete_stream
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~config:cli_config
+      ~messages:[ Types.user_msg "hello" ]
+      ~on_event:(fun _ -> ())
+      ()
+  with
+  | Error (Http_client.CliTransportRequired { kind }) ->
+    check string "stream cli kind" "cli_tool_b" kind
+  | Error err -> failf "wrong stream cli error: %s" (string_of_http_error err)
+  | Ok _ -> fail "expected stream CLI transport required"
+;;
+
 (* ── Runner ──────────────────────────────────────────── *)
 
 let () =
@@ -146,6 +639,32 @@ let () =
         ; test_case "initial delay" `Quick test_retry_config_initial
         ; test_case "max delay" `Quick test_retry_config_max_delay
         ; test_case "backoff" `Quick test_retry_config_backoff
+        ] )
+    ; ( "helpers"
+      , [ test_case "provider_f URL variants" `Quick test_provider_f_url_variants
+        ; test_case
+            "sampling defaults and overlay"
+            `Quick
+            test_sampling_defaults_and_overlay
+        ] )
+    ; ( "complete"
+      , [ test_case
+            "transport success cache metrics and trace headers"
+            `Quick
+            test_complete_transport_success_cache_metrics_and_trace_headers
+        ; test_case
+            "transport error and cli required metrics"
+            `Quick
+            test_complete_transport_error_and_cli_required_metrics
+        ; test_case
+            "retry retries then success"
+            `Quick
+            test_complete_with_retry_retries_then_success
+        ; test_case
+            "stream transport success metrics and telemetry"
+            `Quick
+            test_complete_stream_transport_success_metrics_and_telemetry
+        ; test_case "stream cli required" `Quick test_complete_stream_cli_required
         ] )
     ]
 ;;

--- a/test/test_context_intent.ml
+++ b/test/test_context_intent.ml
@@ -15,6 +15,70 @@ let test_intent_of_string_transfer_alias () =
   | Error detail -> fail detail
 ;;
 
+let test_intent_and_classification_json_roundtrips () =
+  List.iter
+    (fun intent ->
+       let json = Context_intent.intent_to_yojson intent in
+       (match Context_intent.intent_of_yojson json with
+        | Ok decoded -> check bool "intent roundtrip" true (decoded = intent)
+        | Error detail -> fail detail);
+       check
+         bool
+         "show intent"
+         true
+         (String.length (Context_intent.show_intent intent) > 0))
+    [ Context_intent.Conversational
+    ; Context_intent.Task_command
+    ; Context_intent.Status_check
+    ; Context_intent.Knowledge_query
+    ; Context_intent.Coordination
+    ];
+  List.iter
+    (fun depth ->
+       let json = Context_intent.retrieval_depth_to_yojson depth in
+       (match Context_intent.retrieval_depth_of_yojson json with
+        | Ok decoded -> check bool "depth roundtrip" true (decoded = depth)
+        | Error detail -> fail detail);
+       check
+         bool
+         "show depth"
+         true
+         (String.length (Context_intent.show_retrieval_depth depth) > 0))
+    [ Context_intent.Skip; Context_intent.Light; Context_intent.Full ];
+  let classification : Context_intent.classification =
+    { intent = Context_intent.Status_check
+    ; depth = Context_intent.Light
+    ; confidence = 0.91
+    ; rationale = Some "json"
+    }
+  in
+  let json = Context_intent.classification_to_yojson classification in
+  (match Context_intent.classification_of_yojson json with
+   | Ok decoded ->
+     check
+       string
+       "classification intent"
+       "status_check"
+       (Context_intent.intent_to_string decoded.intent);
+     check (float 0.0001) "classification confidence" 0.91 decoded.confidence
+   | Error detail -> fail detail);
+  match Context_intent.intent_of_string "conversation" with
+  | Ok Context_intent.Conversational -> ()
+  | Ok other -> failf "expected conversational, got %s" (Context_intent.show_intent other)
+  | Error detail -> fail detail
+;;
+
+let test_intent_of_string_rejects_unknown () =
+  match Context_intent.intent_of_string "ship-it" with
+  | Ok other -> failf "expected unknown intent, got %s" (Context_intent.show_intent other)
+  | Error detail ->
+    check
+      bool
+      "mentions unknown"
+      true
+      (Util.contains_substring_ci ~haystack:detail ~needle:"unknown intent")
+;;
+
 let test_parse_model_json_valid () =
   let json =
     `Assoc
@@ -33,6 +97,38 @@ let test_parse_model_json_valid () =
     check bool "depth" true (parsed.depth = Context_intent.Full);
     check (float 0.0001) "confidence" 0.82 parsed.confidence
   | Error detail -> fail detail
+;;
+
+let test_parse_model_json_alias_without_rationale () =
+  let json = `Assoc [ "intent", `String "progress"; "confidence", `Float 0.64 ] in
+  match Context_intent.parse_model_json json with
+  | Ok parsed ->
+    check string "intent" "status_check" (Context_intent.intent_to_string parsed.intent);
+    check bool "depth" true (parsed.depth = Context_intent.Light);
+    check (float 0.0001) "confidence" 0.64 parsed.confidence;
+    check (option string) "no rationale" None parsed.rationale
+  | Error detail -> fail detail
+;;
+
+let test_parse_model_json_requires_intent_and_confidence () =
+  let missing_intent = `Assoc [ "confidence", `Float 0.5 ] in
+  (match Context_intent.parse_model_json missing_intent with
+   | Ok _ -> fail "expected missing intent failure"
+   | Error detail ->
+     check
+       bool
+       "missing intent"
+       true
+       (Util.contains_substring_ci ~haystack:detail ~needle:"intent"));
+  let missing_confidence = `Assoc [ "intent", `String "task_command" ] in
+  match Context_intent.parse_model_json missing_confidence with
+  | Ok _ -> fail "expected missing confidence failure"
+  | Error detail ->
+    check
+      bool
+      "missing confidence"
+      true
+      (Util.contains_substring_ci ~haystack:detail ~needle:"confidence")
 ;;
 
 let test_parse_model_json_rejects_out_of_range_confidence () =
@@ -100,6 +196,45 @@ let test_heuristic_coordination_generic () =
       "notify the monitor group and reserve the next parallel task"
   in
   check string "intent" "coordination" (Context_intent.intent_to_string classified.intent)
+;;
+
+let test_heuristic_fallback_paths () =
+  let question = Context_intent.heuristic_classify "who" in
+  check
+    string
+    "question fallback intent"
+    "knowledge_query"
+    (Context_intent.intent_to_string question.intent);
+  check
+    (option string)
+    "question rationale"
+    (Some "knowledge_query: default fallback")
+    question.rationale;
+  let short = Context_intent.heuristic_classify "ok" in
+  check
+    string
+    "short fallback intent"
+    "conversational"
+    (Context_intent.intent_to_string short.intent);
+  check
+    (option string)
+    "short rationale"
+    (Some "conversational: default fallback")
+    short.rationale;
+  let imperative =
+    Context_intent.heuristic_classify
+      "proceed through the next slice until verification succeeds"
+  in
+  check
+    string
+    "imperative fallback intent"
+    "task_command"
+    (Context_intent.intent_to_string imperative.intent);
+  check
+    (option string)
+    "imperative rationale"
+    (Some "task_command: default fallback")
+    imperative.rationale
 ;;
 
 let test_no_reserved_keywords_in_heuristic () =
@@ -182,7 +317,20 @@ let () =
     [ ( "parsing"
       , [ test_case "intent aliases" `Quick test_intent_of_string_accepts_aliases
         ; test_case "transfer alias" `Quick test_intent_of_string_transfer_alias
+        ; test_case
+            "intent and classification json roundtrips"
+            `Quick
+            test_intent_and_classification_json_roundtrips
+        ; test_case "unknown intent rejected" `Quick test_intent_of_string_rejects_unknown
         ; test_case "valid model json" `Quick test_parse_model_json_valid
+        ; test_case
+            "alias without rationale"
+            `Quick
+            test_parse_model_json_alias_without_rationale
+        ; test_case
+            "required model json fields"
+            `Quick
+            test_parse_model_json_requires_intent_and_confidence
         ; test_case
             "confidence bounds"
             `Quick
@@ -195,6 +343,7 @@ let () =
         ; test_case "knowledge query" `Quick test_heuristic_knowledge_query
         ; test_case "coordination" `Quick test_heuristic_coordination
         ; test_case "coordination generic" `Quick test_heuristic_coordination_generic
+        ; test_case "fallback paths" `Quick test_heuristic_fallback_paths
         ; test_case "no reserved keywords" `Quick test_no_reserved_keywords_in_heuristic
         ] )
     ; ( "prompt"

--- a/test/test_discovery.ml
+++ b/test/test_discovery.ml
@@ -4,6 +4,45 @@
 
 open Llm_provider
 
+let fresh_port () =
+  let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Unix.setsockopt socket Unix.SO_REUSEADDR true;
+  Unix.bind socket (Unix.ADDR_INET (Unix.inet_addr_loopback, 0));
+  let port =
+    match Unix.getsockname socket with
+    | Unix.ADDR_INET (_, port) -> port
+    | _ -> Alcotest.fail "expected TCP socket"
+  in
+  Unix.close socket;
+  port
+;;
+
+let with_mock_server handler f =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let port = fresh_port () in
+    let socket =
+      Eio.Net.listen
+        env#net
+        ~sw
+        ~backlog:128
+        ~reuse_addr:true
+        (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+    in
+    let server = Cohttp_eio.Server.make ~callback:handler () in
+    Eio.Fiber.fork ~sw (fun () ->
+      Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+    let endpoint = Printf.sprintf "http://127.0.0.1:%d" port in
+    f ~sw ~net:env#net ~endpoint;
+    Eio.Switch.fail sw Exit
+  with
+  | Unix.Unix_error ((Unix.EPERM | Unix.EADDRINUSE), "bind", _) -> Alcotest.skip ()
+  | Exit -> ()
+;;
+
 let test_endpoints_from_env_default () =
   (* When LLM_ENDPOINTS is not set, should return default *)
   let saved = Sys.getenv_opt "LLM_ENDPOINTS" in
@@ -225,6 +264,117 @@ let test_refresh_and_sync_updates_context () =
   Alcotest.(check (option int)) "no props" None result
 ;;
 
+let test_refresh_and_sync_mock_server_updates_indexes () =
+  let handler _conn req body =
+    ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
+    match Uri.path (Cohttp.Request.uri req) with
+    | "/health" -> Cohttp_eio.Server.respond_string ~status:`OK ~body:"ok" ()
+    | "/v1/models" ->
+      Cohttp_eio.Server.respond_string
+        ~status:`OK
+        ~body:
+          {|
+          {
+            "data": [
+              {"id":"provider_h-3.5-35b","owned_by":"llama-server"},
+              {"id":"model-n-3.1-8b","owned_by":"llama-server"}
+            ]
+          }
+          |}
+        ()
+    | "/props" ->
+      Cohttp_eio.Server.respond_string
+        ~status:`OK
+        ~body:
+          {|
+          {
+            "total_slots": 4,
+            "default_generation_settings": {
+              "n_ctx": 65536,
+              "model": "provider_h-3.5-35b"
+            }
+          }
+          |}
+        ()
+    | "/slots" ->
+      Cohttp_eio.Server.respond_string
+        ~status:`OK
+        ~body:
+          {|
+          [
+            {"id":0,"is_processing":true},
+            {"id":1,"is_processing":false},
+            {"id":2,"state":1},
+            {"id":3,"state":0}
+          ]
+          |}
+        ()
+    | _ -> Cohttp_eio.Server.respond_string ~status:`Not_found ~body:"missing" ()
+  in
+  with_mock_server handler (fun ~sw ~net ~endpoint ->
+    let statuses = Discovery.refresh_and_sync ~sw ~net ~endpoints:[ endpoint ] in
+    match statuses with
+    | [ status ] ->
+      Alcotest.(check bool) "healthy" true status.healthy;
+      Alcotest.(check int) "models" 2 (List.length status.models);
+      Alcotest.(check (option int))
+        "max context uses props"
+        (Some 65536)
+        (Discovery.max_context_of_status status);
+      Alcotest.(check (option int))
+        "global context"
+        (Some 65536)
+        (Discovery.discovered_per_slot_context ());
+      Alcotest.(check (option int))
+        "endpoint context"
+        (Some 65536)
+        (Discovery.discovered_context_for_url ("  " ^ endpoint ^ "  "));
+      Alcotest.(check (option string))
+        "model endpoint"
+        (Some endpoint)
+        (Discovery.endpoint_for_model "provider_h-3.5-35b");
+      Alcotest.(check (option string))
+        "first model"
+        (Some "provider_h-3.5-35b")
+        (Discovery.first_discovered_model_id ());
+      Alcotest.(check (option string))
+        "first model for endpoint"
+        (Some "provider_h-3.5-35b")
+        (Discovery.first_discovered_model_id_for_url endpoint);
+      Alcotest.(check (option (pair string int)))
+        "context for model"
+        (Some (endpoint, 65536))
+        (Discovery.context_for_model "provider_h-3.5-35b");
+      (match status.slots with
+       | Some slots ->
+         Alcotest.(check int) "slot total" 4 slots.total;
+         Alcotest.(check int) "busy" 2 slots.busy;
+         Alcotest.(check int) "idle" 2 slots.idle
+       | None -> Alcotest.fail "expected slots");
+      Alcotest.(check bool)
+        "provider_h model infers extended reasoning"
+        true
+        status.capabilities.supports_extended_thinking
+    | _ -> Alcotest.fail "expected one endpoint status")
+;;
+
+let test_max_context_of_status_falls_back_to_capabilities () =
+  let status : Discovery.endpoint_status =
+    { url = "http://fallback"
+    ; healthy = true
+    ; models = []
+    ; props = None
+    ; slots = None
+    ; capabilities =
+        Capabilities.with_context_size Capabilities.default_capabilities ~ctx_size:4096
+    }
+  in
+  Alcotest.(check (option int))
+    "fallback context"
+    (Some 4096)
+    (Discovery.max_context_of_status status)
+;;
+
 let () =
   Alcotest.run
     "Discovery"
@@ -253,6 +403,14 @@ let () =
             "per-slot computation"
             `Quick
             test_refresh_and_sync_updates_context
+        ; Alcotest.test_case
+            "mock server updates indexes"
+            `Quick
+            test_refresh_and_sync_mock_server_updates_indexes
+        ; Alcotest.test_case
+            "max context fallback"
+            `Quick
+            test_max_context_of_status_falls_back_to_capabilities
         ] )
     ]
 ;;

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -139,10 +139,17 @@ let test_timeout_phase_policy_labels () =
     [ Http_client.Admission, "admission"
     ; Http_client.Queue, "queue"
     ; Http_client.First_token, "first_token"
-    ; ( Http_client.Stream_idle Http_client.Streaming_thinking
-      , "stream_idle:streaming_thinking" )
     ; Http_client.Wall_clock, "wall_clock"
     ; Http_client.Capacity_backpressure, "capacity_backpressure"
+    ; Http_client.Http_operation, "http_operation"
+    ; Http_client.Non_streaming_body, "non_streaming_body"
+    ; Http_client.Stream_body, "stream_body"
+    ; ( Http_client.Stream_idle Http_client.Streaming_thinking
+      , "stream_idle:streaming_thinking" )
+    ; Http_client.Provider_step, "provider_step"
+    ; Http_client.Cli_stdout_idle, "cli_stdout_idle"
+    ; Http_client.Caller_budget, "caller_budget"
+    ; Http_client.Unknown_timeout, "unknown_timeout"
     ]
   in
   List.iter
@@ -158,8 +165,13 @@ let test_timeout_phase_of_stream_idle_state () =
   let cases =
     [ Http_client.Awaiting_first_event, "first_token"
     ; Http_client.Awaiting_first_delta, "first_token"
-    ; Http_client.Streaming_thinking, "stream_idle:streaming_thinking"
     ; Http_client.Streaming_answer, "stream_idle:streaming_answer"
+    ; Http_client.Streaming_thinking, "stream_idle:streaming_thinking"
+    ; Http_client.Streaming_tool_call, "stream_idle:streaming_tool_call"
+    ; Http_client.Streaming_heartbeat, "stream_idle:streaming_heartbeat"
+    ; Http_client.Streaming_substrate, "stream_idle:streaming_substrate"
+    ; Http_client.Streaming_done, "stream_idle:streaming_done"
+    ; Http_client.Streaming_unknown, "stream_idle:streaming_unknown"
     ]
   in
   List.iter
@@ -170,6 +182,68 @@ let test_timeout_phase_of_stream_idle_state () =
          expected
          (Http_client.timeout_phase_to_label phase))
     cases
+;;
+
+let test_provider_failure_string_helpers () =
+  let cases =
+    [ ( Http_client.Capacity_exhausted
+          { scope = Http_client.Failure_scope_model
+          ; retry_after = Some 1.0
+          ; model = Some "m"
+          }
+      , "capacity_exhausted:model" )
+    ; ( Http_client.Capacity_exhausted
+          { scope = Http_client.Failure_scope_account; retry_after = None; model = None }
+      , "capacity_exhausted:account" )
+    ; ( Http_client.Capacity_exhausted
+          { scope = Http_client.Failure_scope_region; retry_after = None; model = None }
+      , "capacity_exhausted:region" )
+    ; ( Http_client.Capacity_exhausted
+          { scope = Http_client.Failure_scope_provider; retry_after = None; model = None }
+      , "capacity_exhausted:provider" )
+    ; ( Http_client.Capacity_exhausted
+          { scope = Http_client.Failure_scope_unknown; retry_after = None; model = None }
+      , "capacity_exhausted:unknown" )
+    ; Http_client.Hard_quota { retry_after = None }, "hard_quota"
+    ; ( Http_client.Capability_mismatch { capability = Some "json_schema" }
+      , "capability_mismatch:json_schema" )
+    ; Http_client.Capability_mismatch { capability = None }, "capability_mismatch"
+    ; ( Http_client.Cli_policy_invalid { tool_name = Some "Read"; rule = Some 2 }
+      , "cli_policy_invalid:rule_2:Read" )
+    ; ( Http_client.Cli_policy_invalid { tool_name = Some "Read"; rule = None }
+      , "cli_policy_invalid:Read" )
+    ; ( Http_client.Cli_policy_invalid { tool_name = None; rule = Some 7 }
+      , "cli_policy_invalid:rule_7" )
+    ; ( Http_client.Cli_policy_invalid { tool_name = None; rule = None }
+      , "cli_policy_invalid" )
+    ; Http_client.Cli_startup_failed { reason = "missing" }, "cli_startup_failed"
+    ; ( Http_client.Provider_parse_error { parser = Some "provider_k" }
+      , "provider_parse_error:provider_k" )
+    ; Http_client.Provider_parse_error { parser = None }, "provider_parse_error"
+    ; ( Http_client.Unknown_provider_failure { reason = Some "exit_status" }
+      , "unknown_provider_failure:exit_status" )
+    ; Http_client.Unknown_provider_failure { reason = None }, "unknown_provider_failure"
+    ]
+  in
+  List.iter
+    (fun (kind, expected) ->
+       Alcotest.(check string)
+         expected
+         expected
+         (Http_client.provider_failure_kind_to_string kind))
+    cases;
+  Alcotest.(check string)
+    "blank message"
+    "hard_quota"
+    (Http_client.provider_failure_to_string
+       ~kind:(Http_client.Hard_quota { retry_after = None })
+       ~message:"   ");
+  Alcotest.(check string)
+    "with message"
+    "hard_quota: quota exhausted"
+    (Http_client.provider_failure_to_string
+       ~kind:(Http_client.Hard_quota { retry_after = None })
+       ~message:"quota exhausted")
 ;;
 
 let test_api_common_string_is_blank () =
@@ -331,6 +405,9 @@ let () =
             "stream idle pre-token maps to first_token"
             `Quick
             test_timeout_phase_of_stream_idle_state
+        ] )
+    ; ( "provider_failure"
+      , [ Alcotest.test_case "string helpers" `Quick test_provider_failure_string_helpers
         ] )
     ; ( "api_common"
       , [ Alcotest.test_case "string_is_blank" `Quick test_api_common_string_is_blank

--- a/test/test_memory.ml
+++ b/test/test_memory.ml
@@ -8,6 +8,47 @@ open Agent_sdk
 let json_s s = `String s
 let json_i i = `Int i
 
+let check_ok label = function
+  | Ok () -> ()
+  | Error reason -> failf "%s: %s" label reason
+;;
+
+let check_missing_key label = function
+  | Error Memory.Missing_key -> ()
+  | Ok json -> failf "%s: expected missing key, got %s" label (Yojson.Safe.to_string json)
+  | Error err -> failf "%s: %s" label (Memory.retrieve_error_to_string err)
+;;
+
+let episode ?(id = "ep-1") ?(timestamp = 10.0) ?(salience = 0.8) action =
+  { Memory.id
+  ; timestamp
+  ; participants = [ "agent"; "user" ]
+  ; action
+  ; outcome = Memory.Success "done"
+  ; salience
+  ; metadata = [ "source", `String "test" ]
+  }
+;;
+
+let procedure
+      ?(id = "proc-1")
+      ?(pattern = "deploy service")
+      ?(confidence = 0.7)
+      ?(success_count = 7)
+      ?(failure_count = 3)
+      action
+  =
+  { Memory.id
+  ; pattern
+  ; action
+  ; success_count
+  ; failure_count
+  ; confidence
+  ; last_used = 1.0
+  ; metadata = [ "team", `String "runtime" ]
+  }
+;;
+
 (* ── Basic store/recall ───────────────────────────── *)
 
 let test_store_and_recall_scratchpad () =
@@ -33,6 +74,26 @@ let test_recall_missing () =
     "missing key"
     true
     (Option.is_none (Memory.recall mem ~tier:Scratchpad "nope"))
+;;
+
+let test_result_helpers () =
+  check
+    string
+    "missing string"
+    "missing_key"
+    (Memory.retrieve_error_to_string Memory.Missing_key);
+  check
+    string
+    "backend error string"
+    "backend_error: corrupt"
+    (Memory.retrieve_error_to_string (Memory.Backend_error "corrupt"));
+  let mem = Memory.create () in
+  check_missing_key
+    "missing exact working"
+    (Memory.recall_exact_result mem ~tier:Working "missing");
+  check_missing_key
+    "missing recall working"
+    (Memory.recall_result mem ~tier:Working "missing")
 ;;
 
 (* ── Tier fallback ────────────────────────────────── *)
@@ -213,6 +274,65 @@ let test_long_term_backend_set_after_create () =
   | _ -> fail "late backend should work"
 ;;
 
+let test_legacy_backend_batch_and_remove () =
+  let store = Hashtbl.create 4 in
+  let removed = ref [] in
+  let backend =
+    Memory.legacy_backend
+      ~persist:(fun ~key value -> Hashtbl.replace store key value)
+      ~retrieve:(fun ~key -> Hashtbl.find_opt store key)
+      ~remove:(fun ~key ->
+        removed := key :: !removed;
+        Hashtbl.remove store key)
+  in
+  check_ok "legacy persist" (backend.persist ~key:"one" (json_i 1));
+  check_ok "legacy batch" (backend.batch_persist [ "two", json_i 2; "three", json_i 3 ]);
+  (match backend.retrieve ~key:"two" with
+   | Some (`Int 2) -> ()
+   | _ -> fail "batch should persist values");
+  check int "legacy query empty" 0 (List.length (backend.query ~prefix:"" ~limit:10));
+  check_ok "legacy remove" (backend.remove ~key:"one");
+  check (list string) "remove callback called" [ "one" ] !removed
+;;
+
+let test_long_term_backend_errors_and_result_fallback () =
+  let backend : Memory.long_term_backend =
+    { persist = (fun ~key:_ _ -> Error "disk full")
+    ; retrieve = (fun ~key:_ -> None)
+    ; remove = (fun ~key:_ -> Error "permission denied")
+    ; batch_persist = (fun _ -> Error "batch failed")
+    ; query = (fun ~prefix:_ ~limit:_ -> [])
+    }
+  in
+  let retrieve_result ~key =
+    match key with
+    | "broken" -> Error (Memory.Backend_error "bad json")
+    | _ -> Error Memory.Missing_key
+  in
+  let mem =
+    Memory.create ~long_term:backend ~long_term_retrieve_result:retrieve_result ()
+  in
+  (match Memory.store mem ~tier:Long_term "broken" (json_s "cached") with
+   | Error "disk full" -> ()
+   | Ok () -> fail "store should surface backend persist error"
+   | Error reason -> failf "unexpected persist error: %s" reason);
+  (match Memory.recall_exact_result mem ~tier:Long_term "broken" with
+   | Error (Memory.Backend_error "bad json") -> ()
+   | Ok json -> failf "expected backend error, got %s" (Yojson.Safe.to_string json)
+   | Error err ->
+     failf "unexpected retrieve error: %s" (Memory.retrieve_error_to_string err));
+  (match Memory.recall_result mem ~tier:Scratchpad "broken" with
+   | Error (Memory.Backend_error "bad json") -> ()
+   | Ok json ->
+     failf "expected scratchpad fallback error, got %s" (Yojson.Safe.to_string json)
+   | Error err ->
+     failf "unexpected fallback error: %s" (Memory.retrieve_error_to_string err));
+  match Memory.forget mem ~tier:Long_term "broken" with
+  | Error "permission denied" -> ()
+  | Ok () -> fail "forget should surface backend remove error"
+  | Error reason -> failf "unexpected remove error: %s" reason
+;;
+
 let test_query_long_term_prefix () =
   let store = Hashtbl.create 4 in
   let backend : Memory.long_term_backend =
@@ -250,6 +370,200 @@ let test_query_long_term_prefix () =
   check bool "crew" true (List.mem "world:crew" keys)
 ;;
 
+let test_query_limits_and_deduplicates_backend_first () =
+  let backend : Memory.long_term_backend =
+    { persist = (fun ~key:_ _ -> Ok ())
+    ; retrieve = (fun ~key:_ -> None)
+    ; remove = (fun ~key:_ -> Ok ())
+    ; batch_persist = (fun _ -> Ok ())
+    ; query =
+        (fun ~prefix ~limit:_ ->
+          [ prefix ^ ":dup", json_s "backend"
+          ; prefix ^ ":backend-only", json_s "backend-only"
+          ; prefix ^ ":extra", json_s "extra"
+          ])
+    }
+  in
+  let mem = Memory.create () in
+  check_ok "context dup" (Memory.store mem ~tier:Long_term "world:dup" (json_s "ctx"));
+  check_ok
+    "context only"
+    (Memory.store mem ~tier:Long_term "world:context-only" (json_s "ctx-only"));
+  Memory.set_long_term_backend mem backend;
+  check
+    int
+    "zero limit"
+    0
+    (List.length (Memory.query mem ~tier:Long_term ~prefix:"world" ~limit:0));
+  let results = Memory.query mem ~tier:Long_term ~prefix:"world" ~limit:3 in
+  check
+    (list string)
+    "backend order and duplicate removed"
+    [ "world:dup"; "world:backend-only"; "world:extra" ]
+    (List.map fst results);
+  match List.assoc_opt "world:dup" results with
+  | Some (`String "backend") -> ()
+  | _ -> fail "backend duplicate should win"
+;;
+
+let test_scratchpad_entries () =
+  let mem = Memory.create () in
+  check_ok "scratch a" (Memory.store mem ~tier:Scratchpad "a" (json_i 1));
+  check_ok "scratch b" (Memory.store mem ~tier:Scratchpad "b" (json_i 2));
+  check_ok "working c" (Memory.store mem ~tier:Working "c" (json_i 3));
+  let keys = Memory.scratchpad_entries mem |> List.map fst |> List.sort String.compare in
+  check (list string) "scratchpad keys" [ "a"; "b" ] keys
+;;
+
+(* ── Episodic facade ───────────────────────────────── *)
+
+let make_episodic_backend () =
+  let store = Hashtbl.create 4 in
+  let backend : Memory.episodic_backend =
+    { persist_episode = (fun ep -> Hashtbl.replace store ep.Memory.id ep)
+    ; retrieve_episode = (fun ~id -> Hashtbl.find_opt store id)
+    ; remove_episode = (fun ~id -> Hashtbl.remove store id)
+    ; all_episodes = (fun () -> Hashtbl.to_seq_values store |> List.of_seq)
+    }
+  in
+  backend, store
+;;
+
+let test_episodic_backend_recall_query_and_forget () =
+  let backend, store = make_episodic_backend () in
+  let mem = Memory.create ~episodic:backend () in
+  let ep = episode ~id:"ep:alpha" "deploy alpha" in
+  Memory.store_episode mem ep;
+  check bool "backend persisted" true (Hashtbl.mem store "ep:alpha");
+  let fresh = Memory.create ~episodic:backend () in
+  (match Memory.recall_episode fresh "ep:alpha" with
+   | Some found -> check string "backend recall" "deploy alpha" found.Memory.action
+   | None -> fail "backend episode should be recalled");
+  (match Memory.recall fresh ~tier:Episodic "ep:alpha" with
+   | Some (`Assoc _) -> ()
+   | _ -> fail "generic episodic recall should return episode json");
+  (match Memory.recall_exact_result fresh ~tier:Episodic "ep:alpha" with
+   | Ok (`Assoc _) -> ()
+   | Ok json -> failf "expected episode object, got %s" (Yojson.Safe.to_string json)
+   | Error err ->
+     failf "unexpected episodic error: %s" (Memory.retrieve_error_to_string err));
+  let queried = Memory.query fresh ~tier:Episodic ~prefix:"ep:" ~limit:5 in
+  check (list string) "episode query" [ "ep:alpha" ] (List.map fst queried);
+  Memory.forget_episode fresh "ep:alpha";
+  check bool "backend removed" false (Hashtbl.mem store "ep:alpha")
+;;
+
+let test_episodic_recall_sort_filter_boost_and_count () =
+  let mem = Memory.create () in
+  Memory.store_episode mem (episode ~id:"ep:low" ~timestamp:1.0 ~salience:0.2 "old");
+  Memory.store_episode mem (episode ~id:"ep:high" ~timestamp:9.0 ~salience:0.7 "new");
+  Memory.boost_salience mem "ep:low" 0.9;
+  Memory.boost_salience mem "missing" 0.5;
+  check int "episode count" 2 (Memory.episode_count mem);
+  let recalled =
+    Memory.recall_episodes
+      mem
+      ~now:10.0
+      ~decay_rate:0.0
+      ~min_salience:0.5
+      ~limit:1
+      ~filter:(fun ep -> String.starts_with ~prefix:"ep:" ep.Memory.id)
+      ()
+  in
+  match recalled with
+  | [ ep ] ->
+    check string "boosted first" "ep:low" ep.Memory.id;
+    check (float 0.0001) "salience capped" 1.0 ep.Memory.salience
+  | _ -> fail "expected one boosted episode"
+;;
+
+(* ── Procedural facade ─────────────────────────────── *)
+
+let make_procedural_backend () =
+  let store = Hashtbl.create 4 in
+  let backend : Memory.procedural_backend =
+    { persist_procedure = (fun proc -> Hashtbl.replace store proc.Memory.id proc)
+    ; retrieve_procedure = (fun ~id -> Hashtbl.find_opt store id)
+    ; remove_procedure = (fun ~id -> Hashtbl.remove store id)
+    ; all_procedures = (fun () -> Hashtbl.to_seq_values store |> List.of_seq)
+    }
+  in
+  backend, store
+;;
+
+let test_procedural_backend_matching_touch_and_updates () =
+  let backend, store = make_procedural_backend () in
+  let mem = Memory.create ~procedural:backend () in
+  Memory.store_procedure
+    mem
+    (procedure
+       ~id:"deploy-safe"
+       ~pattern:"deploy service safely"
+       ~confidence:0.9
+       "run smoke tests");
+  Memory.store_procedure
+    mem
+    (procedure
+       ~id:"deploy-risky"
+       ~pattern:"deploy service quickly"
+       ~confidence:0.4
+       "skip checks");
+  check int "procedure count" 2 (Memory.procedure_count mem);
+  let matches =
+    Memory.matching_procedures
+      mem
+      ~pattern:"deploy"
+      ~min_confidence:0.5
+      ~filter:(fun proc -> proc.Memory.action <> "skip checks")
+      ()
+  in
+  check
+    (list string)
+    "filtered matches"
+    [ "deploy-safe" ]
+    (List.map (fun p -> p.Memory.id) matches);
+  let before = (Option.get (Hashtbl.find_opt store "deploy-safe")).Memory.last_used in
+  Unix.sleepf 0.001;
+  (match Memory.find_procedure mem ~pattern:"deploy" ~touch:true () with
+   | Some proc ->
+     check string "found best" "deploy-safe" proc.Memory.id;
+     check bool "touch updates last_used" true (proc.Memory.last_used > before)
+   | None -> fail "expected best procedure");
+  Memory.record_success mem "deploy-safe";
+  Memory.record_failure mem "deploy-safe";
+  Memory.record_success mem "missing";
+  (match Memory.find_procedure mem ~pattern:"deploy service safely" () with
+   | Some proc ->
+     check int "success incremented" 8 proc.Memory.success_count;
+     check int "failure incremented" 4 proc.Memory.failure_count;
+     check (float 0.0001) "confidence recomputed" (8.0 /. 12.0) proc.Memory.confidence
+   | None -> fail "procedure should still exist");
+  (match Memory.best_procedure mem ~pattern:"deploy" with
+   | Some proc -> check string "best procedure" "deploy-safe" proc.Memory.id
+   | None -> fail "expected best procedure");
+  Memory.forget_procedure mem "deploy-safe";
+  check bool "backend procedure removed" false (Hashtbl.mem store "deploy-safe")
+;;
+
+let test_procedural_generic_recall_and_query () =
+  let backend, _store = make_procedural_backend () in
+  let proc =
+    procedure ~id:"ops:restart" ~pattern:"restart service" "restart then tail logs"
+  in
+  backend.persist_procedure proc;
+  let mem = Memory.create ~procedural:backend () in
+  (match Memory.recall mem ~tier:Procedural "ops:restart" with
+   | Some (`Assoc _) -> ()
+   | _ -> fail "generic procedural recall should return procedure json");
+  (match Memory.recall_exact_result mem ~tier:Procedural "ops:restart" with
+   | Ok (`Assoc _) -> ()
+   | Ok json -> failf "expected procedure object, got %s" (Yojson.Safe.to_string json)
+   | Error err ->
+     failf "unexpected procedural error: %s" (Memory.retrieve_error_to_string err));
+  let queried = Memory.query mem ~tier:Procedural ~prefix:"ops:" ~limit:5 in
+  check (list string) "procedure query" [ "ops:restart" ] (List.map fst queried)
+;;
+
 (* ── Context access ───────────────────────────────── *)
 
 let test_context_access () =
@@ -272,6 +586,7 @@ let () =
       , [ test_case "store/recall scratchpad" `Quick test_store_and_recall_scratchpad
         ; test_case "store/recall working" `Quick test_store_and_recall_working
         ; test_case "recall missing" `Quick test_recall_missing
+        ; test_case "result helpers" `Quick test_result_helpers
         ] )
     ; ( "fallback"
       , [ test_case "scratchpad -> working" `Quick test_scratchpad_falls_back_to_working
@@ -286,6 +601,7 @@ let () =
     ; ( "lifecycle"
       , [ test_case "clear scratchpad" `Quick test_clear_scratchpad
         ; test_case "working entries" `Quick test_working_entries
+        ; test_case "scratchpad entries" `Quick test_scratchpad_entries
         ; test_case "stats" `Quick test_stats
         ] )
     ; ( "long_term"
@@ -294,7 +610,36 @@ let () =
             "set backend after create"
             `Quick
             test_long_term_backend_set_after_create
+        ; test_case "legacy backend" `Quick test_legacy_backend_batch_and_remove
+        ; test_case
+            "backend errors and result fallback"
+            `Quick
+            test_long_term_backend_errors_and_result_fallback
         ; test_case "query prefix" `Quick test_query_long_term_prefix
+        ; test_case
+            "query limit and dedupe"
+            `Quick
+            test_query_limits_and_deduplicates_backend_first
+        ] )
+    ; ( "episodic"
+      , [ test_case
+            "backend recall query and forget"
+            `Quick
+            test_episodic_backend_recall_query_and_forget
+        ; test_case
+            "recall sort filter boost and count"
+            `Quick
+            test_episodic_recall_sort_filter_boost_and_count
+        ] )
+    ; ( "procedural"
+      , [ test_case
+            "backend matching touch and updates"
+            `Quick
+            test_procedural_backend_matching_touch_and_updates
+        ; test_case
+            "generic recall and query"
+            `Quick
+            test_procedural_generic_recall_and_query
         ] )
     ; "context", [ test_case "context access" `Quick test_context_access ]
     ]

--- a/test/test_memory_advanced.ml
+++ b/test/test_memory_advanced.ml
@@ -163,6 +163,149 @@ let test_backend_remove_error () =
   | Ok () -> fail "expected Error from forget"
 ;;
 
+let test_tier_fallbacks_query_dedupe_and_typed_results () =
+  let backend : Memory.long_term_backend =
+    { persist = (fun ~key:_ _value -> Ok ())
+    ; retrieve =
+        (fun ~key ->
+          match key with
+          | "lt" -> Some (json_s "from-backend")
+          | _ -> None)
+    ; remove = (fun ~key:_ -> Ok ())
+    ; batch_persist = (fun _ -> Ok ())
+    ; query =
+        (fun ~prefix ~limit:_ ->
+          if prefix = "k"
+          then [ "k1", json_s "backend"; "k2", json_s "backend-only" ]
+          else [])
+    }
+  in
+  let retrieve_result ~key =
+    match key with
+    | "lt" -> Ok (json_s "typed")
+    | "bad" -> Error (Memory.Backend_error "corrupt")
+    | _ -> Error Memory.Missing_key
+  in
+  let mem =
+    Memory.create ~long_term:backend ~long_term_retrieve_result:retrieve_result ()
+  in
+  ignore (Memory.store mem ~tier:Working "scratch-fallback" (json_s "working"));
+  ignore (Memory.store mem ~tier:Long_term "k1" (json_s "context"));
+  check
+    (option string)
+    "scratch falls back to working"
+    (Some "working")
+    (Option.map
+       (function
+         | `String value -> value
+         | _ -> "wrong")
+       (Memory.recall mem ~tier:Scratchpad "scratch-fallback"));
+  (match Memory.recall_result mem ~tier:Scratchpad "lt" with
+   | Ok (`String "typed") -> ()
+   | Ok json -> failf "unexpected recall_result json: %s" (Yojson.Safe.to_string json)
+   | Error err ->
+     failf "unexpected recall_result error: %s" (Memory.retrieve_error_to_string err));
+  (match Memory.recall_exact_result mem ~tier:Long_term "bad" with
+   | Error (Memory.Backend_error "corrupt") -> ()
+   | Ok json -> failf "expected backend error, got %s" (Yojson.Safe.to_string json)
+   | Error err -> failf "unexpected error: %s" (Memory.retrieve_error_to_string err));
+  check
+    (list string)
+    "deduped query"
+    [ "k1"; "k2" ]
+    (Memory.query mem ~tier:Long_term ~prefix:"k" ~limit:10 |> List.map fst);
+  check
+    int
+    "zero limit"
+    0
+    (Memory.query mem ~tier:Long_term ~prefix:"k" ~limit:0 |> List.length)
+;;
+
+let test_episodic_and_procedural_backend_fallbacks () =
+  let backend_episode : Memory.episode =
+    { id = "ep-backend"
+    ; timestamp = 10.0
+    ; participants = [ "tester" ]
+    ; action = "backend episode"
+    ; outcome = Neutral
+    ; salience = 0.8
+    ; metadata = []
+    }
+  in
+  let backend_proc : Memory.procedure =
+    { id = "pr-backend"
+    ; pattern = "deploy"
+    ; action = "verify"
+    ; success_count = 2
+    ; failure_count = 0
+    ; confidence = 1.0
+    ; last_used = 10.0
+    ; metadata = []
+    }
+  in
+  let stored_episodes = ref [ backend_episode ] in
+  let stored_procedures = ref [ backend_proc ] in
+  let episodic : Memory.episodic_backend =
+    { persist_episode = (fun ep -> stored_episodes := ep :: !stored_episodes)
+    ; retrieve_episode =
+        (fun ~id ->
+          List.find_opt (fun (ep : Memory.episode) -> ep.id = id) !stored_episodes)
+    ; remove_episode =
+        (fun ~id ->
+          stored_episodes
+          := List.filter (fun (ep : Memory.episode) -> ep.id <> id) !stored_episodes)
+    ; all_episodes = (fun () -> !stored_episodes)
+    }
+  in
+  let procedural : Memory.procedural_backend =
+    { persist_procedure = (fun proc -> stored_procedures := proc :: !stored_procedures)
+    ; retrieve_procedure =
+        (fun ~id ->
+          List.find_opt (fun (proc : Memory.procedure) -> proc.id = id) !stored_procedures)
+    ; remove_procedure =
+        (fun ~id ->
+          stored_procedures
+          := List.filter
+               (fun (proc : Memory.procedure) -> proc.id <> id)
+               !stored_procedures)
+    ; all_procedures = (fun () -> !stored_procedures)
+    }
+  in
+  let mem = Memory.create ~episodic ~procedural () in
+  (match Memory.recall_exact_result mem ~tier:Episodic "ep-backend" with
+   | Ok (`Assoc _) -> ()
+   | Ok json -> failf "expected episode json, got %s" (Yojson.Safe.to_string json)
+   | Error err ->
+     failf "unexpected episode error: %s" (Memory.retrieve_error_to_string err));
+  (match Memory.recall_exact_result mem ~tier:Procedural "pr-backend" with
+   | Ok (`Assoc _) -> ()
+   | Ok json -> failf "expected procedure json, got %s" (Yojson.Safe.to_string json)
+   | Error err ->
+     failf "unexpected procedure error: %s" (Memory.retrieve_error_to_string err));
+  check
+    (list string)
+    "episodic query"
+    [ "ep-backend" ]
+    (Memory.query mem ~tier:Episodic ~prefix:"ep-" ~limit:10 |> List.map fst);
+  check
+    (list string)
+    "procedural query"
+    [ "pr-backend" ]
+    (Memory.query mem ~tier:Procedural ~prefix:"pr-" ~limit:10 |> List.map fst);
+  Memory.forget_episode mem "ep-backend";
+  Memory.forget_procedure mem "pr-backend";
+  check
+    bool
+    "episode removed"
+    true
+    (Option.is_none (Memory.recall_episode mem "ep-backend"));
+  check
+    bool
+    "procedure removed"
+    true
+    (Option.is_none (Memory.best_procedure mem ~pattern:"deploy"))
+;;
+
 (* ── Large-scale tests ───────────────────────────────── *)
 
 let test_1000_keys () =
@@ -211,6 +354,14 @@ let () =
       , [ test_case "persist error" `Quick test_backend_persist_error
         ; test_case "retrieve returns None" `Quick test_backend_retrieve_returns_none
         ; test_case "remove error" `Quick test_backend_remove_error
+        ; test_case
+            "fallbacks query dedupe and typed results"
+            `Quick
+            test_tier_fallbacks_query_dedupe_and_typed_results
+        ; test_case
+            "episodic and procedural backend fallbacks"
+            `Quick
+            test_episodic_and_procedural_backend_fallbacks
         ] )
     ; ( "large_scale"
       , [ test_case "1000 keys" `Quick test_1000_keys

--- a/test/test_memory_episodic.ml
+++ b/test/test_memory_episodic.ml
@@ -1,4 +1,5 @@
 open Agent_sdk
+module Episodic = Agent_sdk__Memory_episodic
 
 let make_backend () =
   let store = Hashtbl.create 4 in
@@ -10,6 +11,17 @@ let make_backend () =
     }
   in
   backend
+;;
+
+let make_direct_episode ?(id = "direct") ?(timestamp = 0.0) ?(salience = 0.5) () =
+  { Episodic.id
+  ; timestamp
+  ; participants = [ "alice" ]
+  ; action = "direct recall"
+  ; outcome = Episodic.Neutral
+  ; salience
+  ; metadata = []
+  }
 ;;
 
 let () =
@@ -316,6 +328,78 @@ let () =
               };
             let _, _, ep, _, _ = Memory.stats mem in
             Alcotest.(check int) "episodic count" 1 ep)
+        ] )
+    ; ( "direct_module"
+      , [ Alcotest.test_case "outcome JSON edge cases" `Quick (fun () ->
+            (match
+               Episodic.outcome_of_json
+                 (`Assoc [ "type", `String "success"; "detail", `Null ])
+             with
+             | Episodic.Success "" -> ()
+             | _ -> Alcotest.fail "expected success with empty detail");
+            (match Episodic.outcome_of_json (`Assoc [ "type", `String "failure" ]) with
+             | Episodic.Failure "" -> ()
+             | _ -> Alcotest.fail "expected failure with empty detail");
+            (match Episodic.outcome_of_json (`Assoc [ "type", `String "unknown" ]) with
+             | Episodic.Neutral -> ()
+             | _ -> Alcotest.fail "expected neutral for unknown type");
+            match Episodic.outcome_of_json (`String "bad") with
+            | Episodic.Neutral -> ()
+            | _ -> Alcotest.fail "expected neutral for non-object")
+        ; Alcotest.test_case "episode JSON parse edge cases" `Quick (fun () ->
+            let json =
+              `Assoc
+                [ "id", `String "json-ep"
+                ; "timestamp", `Float 1.0
+                ; "participants", `List [ `String "alice" ]
+                ; "action", `String "act"
+                ; "outcome", `Assoc [ "type", `String "neutral" ]
+                ; "salience", `Float 0.4
+                ; "metadata", `String "not-object"
+                ]
+            in
+            (match Episodic.episode_of_json json with
+             | Some ep ->
+               Alcotest.(check string) "id" "json-ep" ep.Episodic.id;
+               Alcotest.(check int)
+                 "metadata default"
+                 0
+                 (List.length ep.Episodic.metadata)
+             | None -> Alcotest.fail "expected valid episode");
+            Alcotest.(check bool)
+              "missing required field rejected"
+              true
+              (Option.is_none
+                 (Episodic.episode_of_json (`Assoc [ "id", `String "missing" ]))))
+        ; Alcotest.test_case "direct recall sort filter limit and boost" `Quick (fun () ->
+            let ctx = Context.create () in
+            Episodic.store ctx (make_direct_episode ~id:"old" ~timestamp:0.0 ());
+            Episodic.store
+              ctx
+              (make_direct_episode ~id:"new" ~timestamp:9.0 ~salience:0.9 ());
+            let recalled =
+              Episodic.recall
+                ctx
+                ~now:10.0
+                ~decay_rate:0.0
+                ~min_salience:0.1
+                ~limit:1
+                ~filter:(fun ep -> ep.Episodic.id = "new")
+                ()
+            in
+            (match recalled with
+             | [ ep ] -> Alcotest.(check string) "new only" "new" ep.Episodic.id
+             | _ -> Alcotest.fail "expected one filtered episode");
+            Alcotest.(check int)
+              "zero limit"
+              0
+              (List.length (Episodic.recall ctx ~now:10.0 ~limit:0 ()));
+            Episodic.boost_salience ctx "old" 0.4;
+            Episodic.boost_salience ctx "missing" 0.4;
+            (match Episodic.recall_one ctx "old" with
+             | Some ep -> Alcotest.(check (float 0.01)) "boosted" 0.9 ep.salience
+             | None -> Alcotest.fail "old episode missing");
+            Alcotest.(check int) "direct count" 2 (Episodic.count ctx))
         ] )
     ]
 ;;

--- a/test/test_memory_file_backend.ml
+++ b/test/test_memory_file_backend.ml
@@ -231,6 +231,48 @@ let test_query_empty_prefix () =
     Alcotest.(check int) "all 2" 2 (List.length results)
 ;;
 
+let test_query_skips_invalid_entries_and_limit_zero_returns_all () =
+  Eio_main.run
+  @@ fun env ->
+  with_tmp_dir env
+  @@ fun dir ->
+  match Memory_file_backend.create dir with
+  | Error e -> Alcotest.failf "create: %s" (Error.to_string e)
+  | Ok t ->
+    let backend = Memory_file_backend.to_backend t in
+    ignore (backend.persist ~key:"valid:a" (`Int 1));
+    Eio.Path.save ~create:(`Or_truncate 0o644) Eio.Path.(dir / "abc.json") "{}";
+    Eio.Path.save ~create:(`Or_truncate 0o644) Eio.Path.(dir / "zz.json") "{}";
+    Eio.Path.save
+      ~create:(`Or_truncate 0o644)
+      Eio.Path.(dir / "76616c69643a626164.json")
+      "{bad";
+    Eio.Path.save
+      ~create:(`Or_truncate 0o644)
+      Eio.Path.(dir / "76616c69643a746d70.json.tmp")
+      "{}";
+    Eio.Path.save ~create:(`Or_truncate 0o644) Eio.Path.(dir / "note.txt") "{}";
+    let results = backend.query ~prefix:"valid:" ~limit:0 in
+    Alcotest.(check (list string))
+      "valid entries only"
+      [ "valid:a" ]
+      (List.map fst results);
+    Alcotest.(check (list string))
+      "keys skip invalid"
+      [ "valid:a"; "valid:bad" ]
+      (Memory_file_backend.keys t);
+    Alcotest.(check string)
+      "backend error string"
+      "backend_error: disk"
+      (Memory_file_backend.retrieve_error_to_string
+         (Memory_file_backend.Backend_error "disk"));
+    (match Memory_file_backend.to_retrieve_result t ~key:"missing" with
+     | Error Memory.Missing_key -> ()
+     | Ok json -> Alcotest.failf "expected missing, got %s" (Yojson.Safe.to_string json)
+     | Error err ->
+       Alcotest.failf "expected Missing_key, got %s" (Memory.retrieve_error_to_string err))
+;;
+
 (* ── Clear ───────────────────────────────────────────────────── *)
 
 let test_clear () =
@@ -371,6 +413,53 @@ let test_memory_procedural_integration () =
     Alcotest.(check int) "stored file" 1 (Memory_file_backend.entry_count file_store)
 ;;
 
+let test_direct_episodic_and_procedural_backends () =
+  Eio_main.run
+  @@ fun env ->
+  with_tmp_dir env
+  @@ fun dir ->
+  match Memory_file_backend.create dir with
+  | Error e -> Alcotest.failf "create: %s" (Error.to_string e)
+  | Ok file_store ->
+    let episodic = Memory_file_backend.to_episodic_backend file_store in
+    let procedural = Memory_file_backend.to_procedural_backend file_store in
+    episodic.persist_episode
+      { id = "ep-direct"
+      ; timestamp = 200.0
+      ; participants = [ "user"; "assistant" ]
+      ; action = "direct episode"
+      ; outcome = Neutral
+      ; salience = 0.4
+      ; metadata = []
+      };
+    Eio.Path.save ~create:(`Or_truncate 0o644) Eio.Path.(dir / "65703a626164.json") "{bad";
+    let episodes = episodic.all_episodes () in
+    Alcotest.(check int) "one valid episode" 1 (List.length episodes);
+    episodic.remove_episode ~id:"ep-direct";
+    Alcotest.(check bool)
+      "episode removed"
+      true
+      (Option.is_none (episodic.retrieve_episode ~id:"ep-direct"));
+    procedural.persist_procedure
+      { id = "pr-direct"
+      ; pattern = "ship"
+      ; action = "verify"
+      ; success_count = 3
+      ; failure_count = 1
+      ; confidence = 0.75
+      ; last_used = 200.0
+      ; metadata = []
+      };
+    Eio.Path.save ~create:(`Or_truncate 0o644) Eio.Path.(dir / "70723a626164.json") "{bad";
+    let procedures = procedural.all_procedures () in
+    Alcotest.(check int) "one valid procedure" 1 (List.length procedures);
+    procedural.remove_procedure ~id:"pr-direct";
+    Alcotest.(check bool)
+      "procedure removed"
+      true
+      (Option.is_none (procedural.retrieve_procedure ~id:"pr-direct"))
+;;
+
 (* ── Suite ───────────────────────────────────────────────────── *)
 
 let () =
@@ -394,6 +483,10 @@ let () =
       , [ Alcotest.test_case "prefix" `Quick test_query_prefix
         ; Alcotest.test_case "limit" `Quick test_query_limit
         ; Alcotest.test_case "empty_prefix" `Quick test_query_empty_prefix
+        ; Alcotest.test_case
+            "skips invalid entries"
+            `Quick
+            test_query_skips_invalid_entries_and_limit_zero_returns_all
         ] )
     ; "clear", [ Alcotest.test_case "clear" `Quick test_clear ]
     ; "keys", [ Alcotest.test_case "sorted" `Quick test_keys_sorted ]
@@ -405,6 +498,10 @@ let () =
             "procedural_memory_t"
             `Quick
             test_memory_procedural_integration
+        ; Alcotest.test_case
+            "direct episodic and procedural backends"
+            `Quick
+            test_direct_episodic_and_procedural_backends
         ] )
     ]
 ;;

--- a/test/test_memory_tools_parse.ml
+++ b/test/test_memory_tools_parse.ml
@@ -40,6 +40,18 @@ let test_string_wrong_type () =
     (is_error (Memory_tools_parse.parse_string_field j "name"))
 ;;
 
+let test_string_wrong_type_variants () =
+  List.iter
+    (fun value ->
+       let j = `Assoc [ "name", value ] in
+       check
+         bool
+         "wrong string type variant"
+         true
+         (is_error (Memory_tools_parse.parse_string_field j "name")))
+    [ `Assoc []; `Bool true; `Float 1.2; `Intlit "123"; `List [] ]
+;;
+
 (* ── parse_optional_string_field ───────────────────────── *)
 
 let test_optional_string_present () =
@@ -63,6 +75,18 @@ let test_optional_string_wrong_type () =
     "non-string → Error"
     true
     (is_error (Memory_tools_parse.parse_optional_string_field j "k"))
+;;
+
+let test_optional_string_wrong_type_variants () =
+  List.iter
+    (fun value ->
+       let j = `Assoc [ "k", value ] in
+       check
+         bool
+         "wrong optional string type variant"
+         true
+         (is_error (Memory_tools_parse.parse_optional_string_field j "k")))
+    [ `Assoc []; `Float 1.2; `Int 1; `Intlit "1"; `List [] ]
 ;;
 
 (* ── parse_bool_field with default ─────────────────────── *)
@@ -90,6 +114,18 @@ let test_bool_wrong_type () =
     (is_error (Memory_tools_parse.parse_bool_field j "flag" ~default:false))
 ;;
 
+let test_bool_wrong_type_variants () =
+  List.iter
+    (fun value ->
+       let j = `Assoc [ "flag", value ] in
+       check
+         bool
+         "wrong bool type variant"
+         true
+         (is_error (Memory_tools_parse.parse_bool_field j "flag" ~default:false)))
+    [ `Assoc []; `Float 1.2; `Int 1; `Intlit "1"; `List [] ]
+;;
+
 (* ── parse_float_field with default ────────────────────── *)
 
 let test_float_present () =
@@ -114,6 +150,59 @@ let test_float_missing_uses_default () =
   | Error _ -> fail "expected Ok default"
 ;;
 
+let test_float_wrong_type_variants () =
+  List.iter
+    (fun value ->
+       let j = `Assoc [ "x", value ] in
+       check
+         bool
+         "wrong float type variant"
+         true
+         (is_error (Memory_tools_parse.parse_float_field j "x" ~default:0.0)))
+    [ `Assoc []; `Bool true; `Intlit "1"; `List []; `String "1.0" ]
+;;
+
+(* ── parse_generic_tier ───────────────────────────────── *)
+
+let test_generic_tier_variants () =
+  let cases =
+    [ "scratchpad", Memory.Scratchpad
+    ; "working", Memory.Working
+    ; "long-term", Memory.Long_term
+    ; "long_term", Memory.Long_term
+    ]
+  in
+  List.iter
+    (fun (tier, expected) ->
+       let j = `Assoc [ "tier", `String tier ] in
+       match Memory_tools_parse.parse_generic_tier j ~default:Memory.Working with
+       | Ok actual -> check bool "tier" true (actual = expected)
+       | Error err -> fail err.message)
+    cases;
+  (match Memory_tools_parse.parse_generic_tier (`Assoc []) ~default:Memory.Working with
+   | Ok Memory.Working -> ()
+   | Ok _ -> fail "expected default working"
+   | Error err -> fail err.message);
+  List.iter
+    (fun value ->
+       let j = `Assoc [ "tier", value ] in
+       check
+         bool
+         "tier error"
+         true
+         (is_error (Memory_tools_parse.parse_generic_tier j ~default:Memory.Working)))
+    [ `String "episodic"
+    ; `String "procedural"
+    ; `String "bad"
+    ; `Assoc []
+    ; `Bool true
+    ; `Float 1.0
+    ; `Int 1
+    ; `Intlit "1"
+    ; `List []
+    ]
+;;
+
 (* ── parse_string_list_field ───────────────────────────── *)
 
 let test_string_list_present () =
@@ -130,6 +219,32 @@ let test_string_list_missing () =
   | Ok [] -> ()
   | Ok _ -> fail "expected []"
   | Error _ -> () (* either Ok [] or Error is acceptable *)
+;;
+
+let test_string_list_errors () =
+  let bad_outer_values =
+    [ `Assoc []; `Bool true; `Float 1.0; `Int 1; `Intlit "1"; `String "x" ]
+  in
+  List.iter
+    (fun value ->
+       check
+         bool
+         "bad string list outer"
+         true
+         (is_error
+            (Memory_tools_parse.parse_string_list_field (`Assoc [ "tags", value ]) "tags")))
+    bad_outer_values;
+  List.iter
+    (fun value ->
+       check
+         bool
+         "bad string list item"
+         true
+         (is_error
+            (Memory_tools_parse.parse_string_list_field
+               (`Assoc [ "tags", `List [ value ] ])
+               "tags")))
+    [ `Assoc []; `Bool true; `Float 1.0; `Int 1; `Intlit "1"; `List []; `Null ]
 ;;
 
 (* ── parse_metadata_field ──────────────────────────────── *)
@@ -151,6 +266,18 @@ let test_metadata_missing () =
   | _ -> fail "expected Ok [] when absent"
 ;;
 
+let test_metadata_errors () =
+  List.iter
+    (fun value ->
+       check
+         bool
+         "metadata error"
+         true
+         (is_error
+            (Memory_tools_parse.parse_metadata_field (`Assoc [ "metadata", value ]))))
+    [ `Bool true; `Float 1.0; `Int 1; `Intlit "1"; `List []; `String "x" ]
+;;
+
 (* ── parse_outcome ─────────────────────────────────────── *)
 
 let test_outcome_success () =
@@ -170,6 +297,37 @@ let test_outcome_neutral_default () =
   | Error _ -> () (* or error if no default *)
 ;;
 
+let test_outcome_variants_and_errors () =
+  (match Memory_tools_parse.parse_outcome (json {|{"outcome":"success"}|}) with
+   | Ok (Memory.Success "") -> ()
+   | _ -> fail "expected success with empty detail");
+  (match
+     Memory_tools_parse.parse_outcome (json {|{"outcome":"failure","detail":"bad"}|})
+   with
+   | Ok (Memory.Failure "bad") -> ()
+   | _ -> fail "expected failure detail");
+  (match
+     Memory_tools_parse.parse_outcome (json {|{"outcome":"neutral","detail":"ignored"}|})
+   with
+   | Ok Memory.Neutral -> ()
+   | _ -> fail "expected neutral");
+  List.iter
+    (fun value ->
+       check
+         bool
+         "outcome error"
+         true
+         (is_error (Memory_tools_parse.parse_outcome (`Assoc [ "outcome", value ]))))
+    [ `String "weird"; `Assoc []; `Bool true; `Float 1.0; `Int 1; `Intlit "1"; `List [] ];
+  check
+    bool
+    "detail wrong type"
+    true
+    (is_error
+       (Memory_tools_parse.parse_outcome
+          (`Assoc [ "outcome", `String "success"; "detail", `Int 1 ])))
+;;
+
 (* ── parse_value_json ──────────────────────────────────── *)
 
 let test_value_json_present () =
@@ -180,6 +338,17 @@ let test_value_json_present () =
   | Error _ -> fail "expected Ok"
 ;;
 
+let test_value_json_fallback_and_error () =
+  (match Memory_tools_parse.parse_value_json (json {|{"value_json":"not json"}|}) with
+   | Ok (`String "not json") -> ()
+   | _ -> fail "expected raw string fallback");
+  check
+    bool
+    "missing value_json"
+    true
+    (is_error (Memory_tools_parse.parse_value_json (`Assoc [])))
+;;
+
 let () =
   run
     "Memory_tools_parse"
@@ -187,34 +356,46 @@ let () =
       , [ test_case "present" `Quick test_string_present
         ; test_case "missing → Error" `Quick test_string_missing
         ; test_case "wrong type → Error" `Quick test_string_wrong_type
+        ; test_case "wrong type variants" `Quick test_string_wrong_type_variants
         ] )
     ; ( "parse_optional_string_field"
       , [ test_case "present → Some" `Quick test_optional_string_present
         ; test_case "missing → None" `Quick test_optional_string_missing
         ; test_case "wrong type → Error" `Quick test_optional_string_wrong_type
+        ; test_case "wrong type variants" `Quick test_optional_string_wrong_type_variants
         ] )
     ; ( "parse_bool_field"
       , [ test_case "present" `Quick test_bool_present
         ; test_case "missing uses default" `Quick test_bool_missing_uses_default
         ; test_case "wrong type → Error" `Quick test_bool_wrong_type
+        ; test_case "wrong type variants" `Quick test_bool_wrong_type_variants
         ] )
     ; ( "parse_float_field"
       , [ test_case "present" `Quick test_float_present
         ; test_case "int widens to float" `Quick test_float_int_accepted
         ; test_case "missing uses default" `Quick test_float_missing_uses_default
+        ; test_case "wrong type variants" `Quick test_float_wrong_type_variants
         ] )
+    ; ( "parse_generic_tier"
+      , [ test_case "variants and errors" `Quick test_generic_tier_variants ] )
     ; ( "parse_string_list_field"
       , [ test_case "present" `Quick test_string_list_present
         ; test_case "missing tolerated" `Quick test_string_list_missing
+        ; test_case "errors" `Quick test_string_list_errors
         ] )
     ; ( "parse_metadata_field"
       , [ test_case "object" `Quick test_metadata_object
         ; test_case "missing tolerated" `Quick test_metadata_missing
+        ; test_case "errors" `Quick test_metadata_errors
         ] )
     ; ( "parse_outcome"
       , [ test_case "success+detail" `Quick test_outcome_success
         ; test_case "missing → tolerated" `Quick test_outcome_neutral_default
+        ; test_case "variants and errors" `Quick test_outcome_variants_and_errors
         ] )
-    ; "parse_value_json", [ test_case "present" `Quick test_value_json_present ]
+    ; ( "parse_value_json"
+      , [ test_case "present" `Quick test_value_json_present
+        ; test_case "fallback and error" `Quick test_value_json_fallback_and_error
+        ] )
     ]
 ;;

--- a/test/test_pipeline_common_coverage.ml
+++ b/test/test_pipeline_common_coverage.ml
@@ -5,12 +5,30 @@ module Pipeline_common = Agent_sdk__Pipeline_common
 let check_bool = Alcotest.(check bool)
 let check_int = Alcotest.(check int)
 let check_string = Alcotest.(check string)
+let check_opt_string = Alcotest.(check (option string))
+let check_string_list = Alcotest.(check (list string))
 
 let provider_d_config : Provider.config =
   { provider = Local { base_url = "http://127.0.0.1:65535" }
   ; model_id = "provider_d_chat"
   ; api_key_env = "DUMMY_KEY"
   }
+;;
+
+let echo_tool =
+  Tool.create
+    ~name:"echo"
+    ~description:"Echo input"
+    ~parameters:
+      [ { Types.name = "message"
+        ; description = "Message"
+        ; param_type = Types.String
+        ; required = true
+        }
+      ]
+    (fun input ->
+       let open Yojson.Safe.Util in
+       Ok { Types.content = input |> member "message" |> to_string })
 ;;
 
 let text_response ?(content = [ Types.Text "ok" ]) () : Types.api_response =
@@ -58,6 +76,154 @@ let test_strategy_and_outcome_constructors () =
   match Pipeline_common.IdleSkipped with
   | Pipeline_common.IdleSkipped -> ()
   | _ -> Alcotest.fail "expected idle outcome"
+;;
+
+let test_agent_type_checkpoint_stage_labels () =
+  check_string
+    "assistant collected"
+    "after_assistant_collected"
+    (Internal_agent.checkpoint_stage_to_string After_assistant_collected);
+  check_string
+    "tool results appended"
+    "after_tool_results_appended"
+    (Internal_agent.checkpoint_stage_to_string After_tool_results_appended);
+  check_string
+    "retry feedback appended"
+    "after_retry_feedback_appended"
+    (Internal_agent.checkpoint_stage_to_string After_retry_feedback_appended)
+;;
+
+let test_agent_type_accessors_card_and_state_mutators () =
+  let config =
+    { Types.default_config with name = "coverage-agent"; model = "provider_d_chat" }
+  in
+  let options =
+    { Internal_agent.default_options with
+      description = Some "Coverage agent"
+    ; provider = Some provider_d_config
+    ; allowed_paths = [ "/tmp/oas" ]
+    }
+  in
+  Eio_main.run
+  @@ fun env ->
+  let agent =
+    Internal_agent.create ~net:env#net ~config ~tools:[ echo_tool ] ~options ()
+  in
+  check_string "config name" "coverage-agent" (Internal_agent.state agent).config.name;
+  check_bool "same net accessor" true (Internal_agent.net agent == env#net);
+  check_bool "tool present" true (Tool_set.mem "echo" (Internal_agent.tools agent));
+  check_bool
+    "context initially empty"
+    true
+    (Context.keys (Internal_agent.context agent) = []);
+  check_opt_string
+    "description"
+    (Some "Coverage agent")
+    (Internal_agent.description agent);
+  check_string_list "allowed paths" [ "/tmp/oas" ] (Internal_agent.allowed_paths agent);
+  check_bool "memory absent" true (Option.is_none (Internal_agent.memory agent));
+  check_bool
+    "provider option"
+    true
+    (Option.is_some (Internal_agent.options agent).provider);
+  let card = Internal_agent.card agent in
+  check_string "card name" "coverage-agent" card.name;
+  check_opt_string "card description" (Some "Coverage agent") card.description;
+  check_int "card tools" 1 (List.length card.tools);
+  Internal_agent.set_state agent { (Internal_agent.state agent) with turn_count = 2 };
+  check_int "set_state" 2 (Internal_agent.state agent).turn_count;
+  Internal_agent.update_state agent (fun state ->
+    { state with turn_count = state.turn_count + 3 });
+  check_int "update_state" 5 (Internal_agent.state agent).turn_count;
+  Internal_agent.set_consecutive_idle_turns agent 4;
+  check_int "idle turns" 4 agent.consecutive_idle_turns
+;;
+
+let test_agent_type_lifecycle_status_show () =
+  List.iter
+    (fun status ->
+       check_bool
+         "show status"
+         true
+         (String.length (Internal_agent.show_lifecycle_status status) > 0))
+    [ Accepted; Ready; Running; Completed; Failed ]
+;;
+
+let test_agent_type_create_merges_mcp_tools () =
+  Eio_main.run
+  @@ fun env ->
+  let managed : Mcp.managed =
+    { tools = [ echo_tool ]
+    ; name = "coverage-mcp"
+    ; transport =
+        Mcp.Http
+          { close_fn = (fun () -> ()); base_url = "http://127.0.0.1"; headers = [] }
+    }
+  in
+  let options = { Internal_agent.default_options with mcp_clients = [ managed ] } in
+  let agent = Internal_agent.create ~net:env#net ~options () in
+  check_bool "mcp tool merged" true (Tool_set.mem "echo" (Internal_agent.tools agent))
+;;
+
+let test_agent_type_lifecycle_rejects_invalid_transition () =
+  Eio_main.run
+  @@ fun env ->
+  let agent = Internal_agent.create ~net:env#net () in
+  Internal_agent.set_lifecycle agent ~accepted_at:1.0 Accepted;
+  Internal_agent.set_lifecycle agent ~ready_at:2.0 Ready;
+  Internal_agent.set_lifecycle agent ~current_run_id:"run-1" ~started_at:3.0 Running;
+  Internal_agent.set_lifecycle agent ~finished_at:4.0 Completed;
+  (match Internal_agent.lifecycle agent with
+   | Some snapshot ->
+     check_bool "completed" true (snapshot.status = Completed);
+     check_opt_string "run id" (Some "run-1") snapshot.current_run_id
+   | None -> Alcotest.fail "expected lifecycle snapshot");
+  Internal_agent.set_lifecycle agent Running;
+  match Internal_agent.lifecycle agent with
+  | Some snapshot ->
+    check_bool "invalid transition rejected" true (snapshot.status = Completed)
+  | None -> Alcotest.fail "expected lifecycle snapshot"
+;;
+
+let test_agent_type_clone_variants () =
+  let config = { Types.default_config with name = "clone-source"; max_turns = 5 } in
+  Eio_main.run
+  @@ fun env ->
+  let context = Context.create () in
+  Context.set context "marker" (`String "copied");
+  let agent =
+    Internal_agent.create
+      ~net:env#net
+      ~config
+      ~context
+      ~tools:[ echo_tool ]
+      ~auto_context_overflow_retry:false
+      ()
+  in
+  Internal_agent.set_state
+    agent
+    { (Internal_agent.state agent) with
+      turn_count = 7
+    ; messages = [ Types.user_msg "hello" ]
+    };
+  Internal_agent.set_lifecycle agent Accepted;
+  Internal_agent.set_consecutive_idle_turns agent 9;
+  let fresh = Internal_agent.clone agent in
+  check_int "fresh state copied" 7 (Internal_agent.state fresh).turn_count;
+  check_int "fresh messages copied" 1 (List.length (Internal_agent.state fresh).messages);
+  check_bool "fresh context empty" true (Context.keys (Internal_agent.context fresh) = []);
+  check_int "fresh idle reset" 0 fresh.consecutive_idle_turns;
+  check_bool "tools shared" true (Tool_set.mem "echo" (Internal_agent.tools fresh));
+  let copied = Internal_agent.clone ~copy_context:true agent in
+  check_bool
+    "context copied"
+    true
+    (Context.get (Internal_agent.context copied) "marker" = Some (`String "copied"));
+  Context.set (Internal_agent.context copied) "marker" (`String "changed");
+  check_bool
+    "source context independent"
+    true
+    (Context.get (Internal_agent.context agent) "marker" = Some (`String "copied"))
 ;;
 
 let test_validate_completion_contract_accepts_default_text () =
@@ -165,6 +331,27 @@ let () =
             "strategy and outcome constructors"
             `Quick
             test_strategy_and_outcome_constructors
+        ; Alcotest.test_case
+            "agent checkpoint labels"
+            `Quick
+            test_agent_type_checkpoint_stage_labels
+        ; Alcotest.test_case
+            "agent accessors card and state mutators"
+            `Quick
+            test_agent_type_accessors_card_and_state_mutators
+        ; Alcotest.test_case
+            "agent lifecycle status show"
+            `Quick
+            test_agent_type_lifecycle_status_show
+        ; Alcotest.test_case
+            "agent create merges mcp tools"
+            `Quick
+            test_agent_type_create_merges_mcp_tools
+        ; Alcotest.test_case
+            "agent lifecycle rejects invalid transition"
+            `Quick
+            test_agent_type_lifecycle_rejects_invalid_transition
+        ; Alcotest.test_case "agent clone variants" `Quick test_agent_type_clone_variants
         ] )
     ; ( "contract"
       , [ Alcotest.test_case

--- a/test/test_provider_bridge.ml
+++ b/test/test_provider_bridge.ml
@@ -12,6 +12,13 @@ let with_env key value f =
     f ())
 ;;
 
+let check_kind label expected (cfg : Llm_provider.Provider_config.t) =
+  Alcotest.(check string)
+    label
+    expected
+    (Llm_provider.Provider_config.string_of_provider_kind cfg.kind)
+;;
+
 let test_provider_a_bridge () =
   let legacy = Agent_sdk.Provider.provider_a_sonnet () in
   match Agent_sdk.Provider_bridge.to_provider_config legacy with
@@ -150,6 +157,79 @@ let test_provider_c_custom_registered_becomes_provider_c_provider_config () =
       Alcotest.(check string) "path" "/v1/messages" cfg.request_path)
 ;;
 
+let test_provider_a_auto_and_explicit_models () =
+  let api_key_env = "PROVIDER_A_BRIDGE_TEST_KEY" in
+  with_env api_key_env "provider-a-test-key" (fun () ->
+    with_env "PROVIDER_A_DEFAULT_MODEL" "agent_llm_a-test-default" (fun () ->
+      let auto =
+        { Agent_sdk.Provider.provider = Provider_a; model_id = "auto"; api_key_env }
+      in
+      let explicit = { auto with model_id = "agent_llm_a-explicit" } in
+      (match Agent_sdk.Provider_bridge.to_provider_config auto with
+       | Ok cfg ->
+         check_kind "provider_a kind" "provider_a" cfg;
+         Alcotest.(check string) "auto model" "agent_llm_a-test-default" cfg.model_id
+       | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err));
+      match Agent_sdk.Provider_bridge.to_provider_config explicit with
+      | Ok cfg ->
+        check_kind "provider_a explicit kind" "provider_a" cfg;
+        Alcotest.(check string) "explicit model" "agent_llm_a-explicit" cfg.model_id
+      | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)))
+;;
+
+let test_openai_compat_auto_model_branches () =
+  with_env "OLLAMA_DEFAULT_MODEL" "provider-d-env-default" (fun () ->
+    with_env "PROVIDER_F_DEFAULT_MODEL" "provider_f-env-default" (fun () ->
+      let provider_d_auto =
+        { Agent_sdk.Provider.provider =
+            OpenAICompat
+              { base_url = "https://provider-d.example/v1"
+              ; auth_header = None
+              ; path = "/chat/completions"
+              ; static_token = None
+              }
+        ; model_id = "auto"
+        ; api_key_env = ""
+        }
+      in
+      let provider_f_prefixed = { provider_d_auto with model_id = "provider_f-auto" } in
+      let provider_f_explicit =
+        { provider_d_auto with model_id = "provider_f-2.5-pro" }
+      in
+      (match Agent_sdk.Provider_bridge.to_provider_config provider_d_auto with
+       | Ok cfg ->
+         check_kind "provider_d compat kind" "provider_d_compat" cfg;
+         Alcotest.(check string) "provider_d auto" "provider-d-env-default" cfg.model_id
+       | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err));
+      (match Agent_sdk.Provider_bridge.to_provider_config provider_f_prefixed with
+       | Ok cfg ->
+         check_kind "provider_f kind" "provider_f" cfg;
+         Alcotest.(check string) "provider_f prefixed" "provider_f-auto" cfg.model_id
+       | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err));
+      match Agent_sdk.Provider_bridge.to_provider_config provider_f_explicit with
+      | Ok cfg ->
+        check_kind "provider_f explicit kind" "provider_f" cfg;
+        Alcotest.(check string) "provider_f explicit" "provider_f-2.5-pro" cfg.model_id
+      | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)))
+;;
+
+let test_provider_c_explicit_model_and_non_coding_base_url () =
+  let api_key_env = "PROVIDER_C_BRIDGE_TEST_KEY" in
+  with_env api_key_env "provider-c-test-key" (fun () ->
+    with_env "PROVIDER_C_BASE_URL" "https://api.provider_c.com/messages" (fun () ->
+      let non_coding =
+        { Agent_sdk.Provider.provider = Custom_registered { name = "provider_c" }
+        ; model_id = "provider_c-k2"
+        ; api_key_env
+        }
+      in
+      match Agent_sdk.Provider_bridge.to_provider_config non_coding with
+      | Ok cfg ->
+        check_kind "non-coding base routes as provider_a" "provider_a" cfg;
+        Alcotest.(check string) "explicit provider_c model" "provider_c-k2" cfg.model_id
+      | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)))
+;;
+
 let test_zai_coding_auto_models_default_order () =
   with_env "ZAI_CODING_AUTO_MODELS" "" (fun () ->
     Alcotest.(check (list string))
@@ -187,6 +267,18 @@ let () =
             "provider_c custom provider becomes provider_c"
             `Quick
             test_provider_c_custom_registered_becomes_provider_c_provider_config
+        ; test_case
+            "provider_a auto and explicit models"
+            `Quick
+            test_provider_a_auto_and_explicit_models
+        ; test_case
+            "openai compat auto model branches"
+            `Quick
+            test_openai_compat_auto_model_branches
+        ; test_case
+            "provider_c explicit model and non-coding base url"
+            `Quick
+            test_provider_c_explicit_model_and_non_coding_base_url
         ; test_case
             "zai coding auto models default order"
             `Quick

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -63,6 +63,16 @@ let test_request_path_glm () =
   check_string "provider_k path" "/chat/completions" cfg.request_path
 ;;
 
+let test_request_path_ollama () =
+  let cfg = Provider_config.make ~kind:Ollama ~model_id:"m" ~base_url:"" () in
+  check_string "ollama path" "/api/chat" cfg.request_path
+;;
+
+let test_request_path_provider_h () =
+  let cfg = Provider_config.make ~kind:Provider_h ~model_id:"m" ~base_url:"" () in
+  check_string "provider_h path" "/chat/completions" cfg.request_path
+;;
+
 let test_request_path_agent_llm_a_code () =
   let cfg = Provider_config.make ~kind:Cli_tool_d ~model_id:"m" ~base_url:"" () in
   check_string "cli_tool_d path" "" cfg.request_path
@@ -71,6 +81,17 @@ let test_request_path_agent_llm_a_code () =
 let test_request_path_provider_c_cli () =
   let cfg = Provider_config.make ~kind:Cli_tool_c ~model_id:"m" ~base_url:"" () in
   check_string "cli_tool_c path" "" cfg.request_path
+;;
+
+let test_request_path_other_cli_kinds () =
+  List.iter
+    (fun kind ->
+       let cfg = Provider_config.make ~kind ~model_id:"m" ~base_url:"" () in
+       check_string
+         (Provider_config.string_of_provider_kind kind ^ " path")
+         ""
+         cfg.request_path)
+    [ Cli_tool_a; Cli_tool_b ]
 ;;
 
 let test_request_path_override () =
@@ -130,6 +151,45 @@ let test_make_with_all_options () =
     (cfg.response_format = Types.JsonSchema expected_schema);
   check_bool "has output schema" true (Option.is_some cfg.output_schema);
   check_bool "cache prompt" true cfg.cache_system_prompt
+;;
+
+let test_make_response_format_json_mode () =
+  let cfg =
+    Provider_config.make
+      ~kind:Provider_d_compat
+      ~model_id:"model-d"
+      ~base_url:"https://api.provider_d.com/v1"
+      ~response_format_json:true
+      ()
+  in
+  check_bool "json mode" true (cfg.response_format = Types.JsonMode);
+  check_bool "no json schema" true (Option.is_none cfg.output_schema)
+;;
+
+let test_output_schema_of_response_format () =
+  let schema = `Assoc [ "type", `String "object" ] in
+  check_bool
+    "schema derived"
+    true
+    (Option.equal
+       Yojson.Safe.equal
+       (Some schema)
+       (Provider_config.output_schema_of_response_format (Types.JsonSchema schema)));
+  check_bool
+    "json mode has no schema"
+    true
+    (Option.is_none (Provider_config.output_schema_of_response_format Types.JsonMode));
+  check_bool
+    "off has no schema"
+    true
+    (Option.is_none (Provider_config.output_schema_of_response_format Types.Off));
+  check_bool
+    "override wins"
+    true
+    (Option.equal
+       Yojson.Safe.equal
+       (Some schema)
+       (Provider_config.output_schema_of_response_format ~override:schema Types.JsonMode))
 ;;
 
 let test_validate_output_schema_provider_d_official () =
@@ -205,6 +265,86 @@ let test_validate_output_schema_provider_c_rejected () =
     "provider_c rejected"
     true
     (Result.is_error (Provider_config.validate_output_schema_request cfg))
+;;
+
+let test_validate_output_schema_unrequested_ok () =
+  let cfg =
+    Provider_config.make
+      ~kind:Provider_c
+      ~model_id:"provider_c-for-coding"
+      ~base_url:"https://api.provider_c.com/coding"
+      ()
+  in
+  check_bool
+    "no schema request bypasses provider restriction"
+    true
+    (Result.is_ok (Provider_config.validate_output_schema_request cfg))
+;;
+
+let test_validate_output_schema_direct_response_format_record () =
+  let schema = `Assoc [ "type", `String "object" ] in
+  let cfg =
+    { (Provider_config.make
+         ~kind:Provider_d_compat
+         ~model_id:"model-d"
+         ~base_url:"https://openrouter.ai/api/v1"
+         ())
+      with
+      response_format = Types.JsonSchema schema
+    ; output_schema = None
+    }
+  in
+  check_bool
+    "response_format JsonSchema is validated even without output_schema"
+    true
+    (Result.is_error (Provider_config.validate_output_schema_request cfg))
+;;
+
+let test_validate_output_schema_supported_non_provider_d () =
+  let schema = `Assoc [ "type", `String "object" ] in
+  List.iter
+    (fun kind ->
+       let cfg =
+         Provider_config.make
+           ~kind
+           ~model_id:"m"
+           ~base_url:"https://api.example.test"
+           ~output_schema:schema
+           ()
+       in
+       check_bool
+         (Provider_config.string_of_provider_kind kind ^ " accepts schema")
+         true
+         (Result.is_ok (Provider_config.validate_output_schema_request cfg)))
+    [ Provider_a; Provider_f; Ollama; Provider_h ]
+;;
+
+let test_validate_output_schema_cli_rejected () =
+  let schema = `Assoc [ "type", `String "object" ] in
+  List.iter
+    (fun kind ->
+       let cfg =
+         Provider_config.make ~kind ~model_id:"m" ~base_url:"" ~output_schema:schema ()
+       in
+       check_bool
+         (Provider_config.string_of_provider_kind kind ^ " rejects schema")
+         true
+         (Result.is_error (Provider_config.validate_output_schema_request cfg)))
+    [ Cli_tool_a; Cli_tool_b; Cli_tool_c; Cli_tool_d ]
+;;
+
+let test_validate_output_schema_capability_rejected () =
+  let cfg =
+    Provider_config.make
+      ~kind:Provider_d_compat
+      ~model_id:"unknown-model-without-schema-capability"
+      ~base_url:"https://api.provider_d.com/v1"
+      ~output_schema:(`Assoc [ "type", `String "object" ])
+      ()
+  in
+  match Provider_config.validate_output_schema_request cfg with
+  | Error msg -> check_bool "returns explanatory error" true (String.length msg > 0)
+  | Ok () -> Alcotest.fail "expected model capability rejection"
 ;;
 
 (* ── make: headers default ────────────────────────────── *)
@@ -301,6 +441,132 @@ let test_default_attempt_timeout_s () =
     "provider_d_compat has no default hard attempt timeout"
     None
     Provider_d_compat
+;;
+
+let test_max_turns_hard_cap_and_clamp () =
+  Alcotest.(check (option int))
+    "cli_tool_d hard cap"
+    (Some 30)
+    (Provider_config.max_turns_hard_cap Cli_tool_d);
+  Alcotest.(check (option int))
+    "provider_a no hard cap"
+    None
+    (Provider_config.max_turns_hard_cap Provider_a);
+  check_int
+    "cli_tool_d clamps high request"
+    30
+    (Provider_config.clamp_max_turns Cli_tool_d 99);
+  check_int
+    "cli_tool_d preserves low request"
+    12
+    (Provider_config.clamp_max_turns Cli_tool_d 12);
+  check_int
+    "provider_a preserves request"
+    99
+    (Provider_config.clamp_max_turns Provider_a 99)
+;;
+
+let test_reasoning_effort_of_thinking_config () =
+  let check_effort label expected enable_thinking thinking_budget =
+    check_string
+      label
+      expected
+      (Provider_config.effort_of_thinking_config ~enable_thinking ~thinking_budget)
+  in
+  check_effort "disabled" "none" (Some false) (Some 4096);
+  check_effort "missing flag" "none" None (Some 4096);
+  check_effort "zero budget" "none" (Some true) (Some 0);
+  check_effort "low budget" "low" (Some true) (Some 2048);
+  check_effort "medium budget" "medium" (Some true) (Some 8192);
+  check_effort "high budget" "high" (Some true) (Some 8193)
+;;
+
+let test_reasoning_effort_of_config () =
+  let ollama =
+    Provider_config.make
+      ~kind:Ollama
+      ~model_id:"llama"
+      ~base_url:"http://127.0.0.1:11434"
+      ~enable_thinking:true
+      ~thinking_budget:2048
+      ()
+  in
+  let provider_a =
+    Provider_config.make
+      ~kind:Provider_a
+      ~model_id:"agent_llm_a-sonnet"
+      ~base_url:"https://api.provider_a.com"
+      ~enable_thinking:true
+      ~thinking_budget:2048
+      ()
+  in
+  Alcotest.(check (option string))
+    "ollama exposes effort"
+    (Some "low")
+    (Provider_config.reasoning_effort_of_config ollama);
+  Alcotest.(check (option string))
+    "non-ollama has no effort"
+    None
+    (Provider_config.reasoning_effort_of_config provider_a)
+;;
+
+let test_structured_output_name_of_schema () =
+  let check_name label expected schema =
+    check_string label expected (Provider_config.structured_output_name_of_schema schema)
+  in
+  check_name "normalizes title" "invoice_v2" (`Assoc [ "title", `String " Invoice V2! " ]);
+  check_name
+    "keeps hyphen underscore"
+    "my-schema_v2"
+    (`Assoc [ "title", `String "My-Schema_v2" ]);
+  check_name
+    "blank title uses default"
+    "structured_output"
+    (`Assoc [ "title", `String "   " ]);
+  check_name "missing title uses default" "structured_output" (`Assoc []);
+  check_name "non-object uses default" "structured_output" (`List [])
+;;
+
+let test_validate_cli_sampling_params () =
+  let expect_error label cfg =
+    check_bool
+      label
+      true
+      (Result.is_error (Provider_config.validate_cli_sampling_params cfg))
+  in
+  let expect_ok label cfg =
+    check_bool
+      label
+      true
+      (Result.is_ok (Provider_config.validate_cli_sampling_params cfg))
+  in
+  expect_error
+    "cli min_p"
+    (Provider_config.make ~kind:Cli_tool_a ~model_id:"m" ~base_url:"" ~min_p:0.05 ());
+  expect_error
+    "cli top_k"
+    (Provider_config.make ~kind:Cli_tool_b ~model_id:"m" ~base_url:"" ~top_k:40 ());
+  expect_error
+    "cli both"
+    (Provider_config.make
+       ~kind:Cli_tool_c
+       ~model_id:"m"
+       ~base_url:""
+       ~min_p:0.05
+       ~top_k:40
+       ());
+  expect_ok
+    "cli clean"
+    (Provider_config.make ~kind:Cli_tool_d ~model_id:"m" ~base_url:"" ());
+  expect_ok
+    "http provider accepts sampling"
+    (Provider_config.make
+       ~kind:Provider_a
+       ~model_id:"m"
+       ~base_url:"https://api.provider_a.com"
+       ~min_p:0.05
+       ~top_k:40
+       ())
 ;;
 
 (* ── provider_name_of_config ─────────────────────────── *)
@@ -779,13 +1045,24 @@ let () =
         ; Alcotest.test_case "provider_d" `Quick test_request_path_provider_d
         ; Alcotest.test_case "provider_f" `Quick test_request_path_provider_f
         ; Alcotest.test_case "provider_k" `Quick test_request_path_glm
+        ; Alcotest.test_case "ollama" `Quick test_request_path_ollama
+        ; Alcotest.test_case "provider_h" `Quick test_request_path_provider_h
         ; Alcotest.test_case "cli_tool_d" `Quick test_request_path_agent_llm_a_code
         ; Alcotest.test_case "cli_tool_c" `Quick test_request_path_provider_c_cli
+        ; Alcotest.test_case "other cli kinds" `Quick test_request_path_other_cli_kinds
         ; Alcotest.test_case "override" `Quick test_request_path_override
         ] )
     ; ( "explicit_values"
       , [ Alcotest.test_case "all options" `Quick test_make_with_all_options
         ; Alcotest.test_case "custom headers" `Quick test_custom_headers
+        ; Alcotest.test_case
+            "response_format_json mode"
+            `Quick
+            test_make_response_format_json_mode
+        ; Alcotest.test_case
+            "output schema derivation"
+            `Quick
+            test_output_schema_of_response_format
         ] )
     ; ( "output_schema"
       , [ Alcotest.test_case
@@ -808,6 +1085,26 @@ let () =
             "provider_h accepted"
             `Quick
             test_validate_output_schema_provider_h_accepted
+        ; Alcotest.test_case
+            "unrequested schema bypasses restrictions"
+            `Quick
+            test_validate_output_schema_unrequested_ok
+        ; Alcotest.test_case
+            "direct JsonSchema record is validated"
+            `Quick
+            test_validate_output_schema_direct_response_format_record
+        ; Alcotest.test_case
+            "supported non-provider_d providers"
+            `Quick
+            test_validate_output_schema_supported_non_provider_d
+        ; Alcotest.test_case
+            "cli providers rejected"
+            `Quick
+            test_validate_output_schema_cli_rejected
+        ; Alcotest.test_case
+            "provider_d capability rejection"
+            `Quick
+            test_validate_output_schema_capability_rejected
         ] )
     ; ( "locality"
       , [ Alcotest.test_case "loopback ip" `Quick test_is_local_loopback_ip
@@ -825,6 +1122,26 @@ let () =
             "default attempt timeout hints"
             `Quick
             test_default_attempt_timeout_s
+        ; Alcotest.test_case
+            "turn hard caps and clamp"
+            `Quick
+            test_max_turns_hard_cap_and_clamp
+        ; Alcotest.test_case
+            "thinking effort thresholds"
+            `Quick
+            test_reasoning_effort_of_thinking_config
+        ; Alcotest.test_case
+            "reasoning effort by config"
+            `Quick
+            test_reasoning_effort_of_config
+        ; Alcotest.test_case
+            "structured output names"
+            `Quick
+            test_structured_output_name_of_schema
+        ; Alcotest.test_case
+            "cli sampling validation"
+            `Quick
+            test_validate_cli_sampling_params
         ] )
     ; ( "provider_name"
       , [ Alcotest.test_case

--- a/test/test_provider_runtime_binding.ml
+++ b/test/test_provider_runtime_binding.ml
@@ -34,6 +34,76 @@ let catalog_json =
 |}
 ;;
 
+let catalog_variants_json =
+  {|
+{
+  "schema_version": 1,
+  "providers": [
+    {
+      "id": "custom-rich",
+      "aliases": ["Rich-Alias"],
+      "kind": "provider_d_compat",
+      "transport": "custom-openai-compat",
+      "base_url": "https://rich.example/v1/",
+      "request_path": "/chat/completions",
+      "auth": {"type": "setup-token-env", "key": "RICH_SETUP_TOKEN"},
+      "default_model": "rich-default",
+      "capabilities_base": "provider_d_chat"
+    },
+    {
+      "id": "managed-oauth",
+      "kind": "provider_d_compat",
+      "transport": "managed",
+      "auth": {"type": "oauth_cached_login"},
+      "capabilities_base": "provider_d_chat"
+    },
+    {
+      "id": "cli-login",
+      "kind": "cli_tool_a",
+      "transport": "cli",
+      "command": "agent_code",
+      "auth": {"type": "cli-cached-login"}
+    },
+    {
+      "id": "file-auth",
+      "kind": "provider_d_compat",
+      "auth": {"type": "file", "path": "/tmp/provider-token"},
+      "capabilities_base": "provider_d_chat"
+    },
+    {
+      "id": "exec-auth",
+      "kind": "provider_d_compat",
+      "auth": {"type": "exec", "command": "op read token"},
+      "capabilities_base": "provider_d_chat"
+    },
+    {
+      "id": "api-key-auth",
+      "kind": "provider_d_compat",
+      "api_key_env": "API_KEY_AUTH",
+      "capabilities_base": "provider_d_chat"
+    }
+  ]
+}
+|}
+;;
+
+let transport_to_string = function
+  | Provider_runtime_binding.Http -> "http"
+  | Provider_runtime_binding.Cli -> "cli"
+  | Provider_runtime_binding.Managed -> "managed"
+  | Provider_runtime_binding.Custom_provider_d_compat -> "custom"
+;;
+
+let auth_to_string = function
+  | Provider_runtime_binding.No_auth -> "none"
+  | Provider_runtime_binding.Api_key_env env -> "api_key_env:" ^ env
+  | Provider_runtime_binding.Cli_cached_login -> "cli"
+  | Provider_runtime_binding.Oauth_cached_login -> "oauth"
+  | Provider_runtime_binding.Setup_token_env env -> "setup:" ^ env
+  | Provider_runtime_binding.File path -> "file:" ^ path
+  | Provider_runtime_binding.Exec command -> "exec:" ^ command
+;;
+
 let expect_binding label =
   match Provider_runtime_binding.find label with
   | Some binding -> binding
@@ -140,6 +210,57 @@ let test_all_includes_catalog_entry_once () =
     Alcotest.(check int) "catalog entry count" 1 (List.length matches))
 ;;
 
+let test_catalog_transport_and_auth_variants () =
+  with_provider_catalog catalog_variants_json (fun () ->
+    let cases =
+      [ "rich-alias", "custom", "setup:RICH_SETUP_TOKEN", Some "rich-default", None
+      ; "managed-oauth", "managed", "oauth", None, None
+      ; "cli-login", "cli", "cli", None, Some "agent_code"
+      ; "file-auth", "http", "file:/tmp/provider-token", None, None
+      ; "exec-auth", "http", "exec:op read token", None, None
+      ; "api-key-auth", "http", "api_key_env:API_KEY_AUTH", None, None
+      ]
+    in
+    List.iter
+      (fun (label, transport, auth, default_model, command) ->
+         let binding = expect_binding label in
+         Alcotest.(check string)
+           (label ^ " transport")
+           transport
+           (transport_to_string binding.transport);
+         Alcotest.(check string) (label ^ " auth") auth (auth_to_string binding.auth);
+         Alcotest.(check (option string))
+           (label ^ " default model")
+           default_model
+           binding.default_model;
+         Alcotest.(check (option string)) (label ^ " command") command binding.command)
+      cases)
+;;
+
+let test_find_empty_missing_and_provider_config_fallbacks () =
+  Alcotest.(check bool)
+    "empty missing"
+    true
+    (Option.is_none (Provider_runtime_binding.find " "));
+  Alcotest.(check bool)
+    "unknown missing"
+    true
+    (Option.is_none (Provider_runtime_binding.find "not-a-provider"));
+  with_provider_catalog catalog_variants_json (fun () ->
+    let cfg =
+      Llm_provider.Provider_config.make
+        ~kind:Llm_provider.Provider_config.Provider_d_compat
+        ~model_id:"rich-default"
+        ~base_url:" https://rich.example/v1/// "
+        ~request_path:" /chat/completions "
+        ()
+    in
+    match Provider_runtime_binding.binding_for_provider_config cfg with
+    | Some binding ->
+      Alcotest.(check string) "normalized endpoint match" "custom-rich" binding.id
+    | None -> Alcotest.fail "expected normalized endpoint binding")
+;;
+
 let test_builtin_binding_resolves () =
   let binding = expect_binding "agent_llm_a" in
   Alcotest.(check string) "builtin id" "agent_llm_a" binding.id;
@@ -178,6 +299,14 @@ let () =
             "all includes catalog once"
             `Quick
             test_all_includes_catalog_entry_once
+        ; Alcotest.test_case
+            "transport and auth variants"
+            `Quick
+            test_catalog_transport_and_auth_variants
+        ; Alcotest.test_case
+            "find and provider config fallbacks"
+            `Quick
+            test_find_empty_missing_and_provider_config_fallbacks
         ] )
     ; ( "builtins"
       , [ Alcotest.test_case "builtin resolves" `Quick test_builtin_binding_resolves ] )

--- a/test/test_runtime_evidence.ml
+++ b/test/test_runtime_evidence.ml
@@ -1,22 +1,32 @@
 open Agent_sdk
 open Alcotest
 
-let mk_session ?(artifacts = []) () : Runtime.session =
-  { session_id = "sess-evidence"
-  ; goal = "collect telemetry"
-  ; title = Some "Evidence"
-  ; tag = Some "test"
+let mk_session
+      ?(session_id = "sess-evidence")
+      ?(goal = "collect telemetry")
+      ?(title = Some "Evidence")
+      ?(tag = Some "test")
+      ?(updated_at = 2.0)
+      ?(participants = [])
+      ?(artifacts = [])
+      ()
+  : Runtime.session
+  =
+  { session_id
+  ; goal
+  ; title
+  ; tag
   ; permission_mode = Some "default"
   ; phase = Runtime.Running
   ; created_at = 1.0
-  ; updated_at = 2.0
+  ; updated_at
   ; provider = Some "provider_a"
   ; model = Some "agent_llm_a"
   ; system_prompt = None
   ; max_turns = 10
   ; workdir = Some "/tmp/work"
   ; planned_participants = [ "alice" ]
-  ; participants = []
+  ; participants
   ; artifacts
   ; pending_input = None
   ; turn_count = 0
@@ -262,6 +272,301 @@ let write_artifact store session_id ~artifact_id ~name ~kind ~created_at content
    : Runtime.artifact)
 ;;
 
+let with_temp_root prefix f =
+  let root =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "%s-%d-%06x" prefix (Unix.getpid ()) (Random.int 0xFFFFFF))
+  in
+  Unix.mkdir root 0o755;
+  Fun.protect
+    ~finally:(fun () -> ignore (Sys.command (Printf.sprintf "rm -rf %s" root)))
+    (fun () -> f root)
+;;
+
+let participant ?(aliases = []) name : Runtime.participant =
+  { name
+  ; role = Some "worker"
+  ; aliases
+  ; worker_id = None
+  ; runtime_actor = None
+  ; requested_provider = None
+  ; requested_model = None
+  ; requested_policy = None
+  ; provider = None
+  ; model = None
+  ; resolved_provider = None
+  ; resolved_model = None
+  ; state = Runtime.Planned
+  ; summary = None
+  ; accepted_at = None
+  ; ready_at = None
+  ; first_progress_at = None
+  ; started_at = None
+  ; finished_at = None
+  ; last_progress_at = None
+  ; last_error = None
+  }
+;;
+
+let check_error label result =
+  match result with
+  | Ok _ -> fail (label ^ ": expected error")
+  | Error _ -> ()
+;;
+
+let test_sessions_store_helpers_listing_and_mutation () =
+  with_temp_root "oas-sessions-store"
+  @@ fun root ->
+  let older : Runtime.artifact =
+    { artifact_id = "old"
+    ; name = "report"
+    ; kind = "json"
+    ; mime_type = "application/json"
+    ; path = None
+    ; inline_content = Some "{}"
+    ; size_bytes = 2
+    ; created_at = 1.0
+    }
+  in
+  let newer = { older with artifact_id = "new"; created_at = 3.0 } in
+  let other =
+    { older with artifact_id = "other"; name = "telemetry"; created_at = 5.0 }
+  in
+  check (option string) "primary alias empty" None (Sessions_store.primary_alias []);
+  check
+    (option string)
+    "primary alias blank"
+    None
+    (Sessions_store.primary_alias [ "  "; "later" ]);
+  check
+    (option string)
+    "primary alias first"
+    (Some " coder ")
+    (Sessions_store.primary_alias [ " coder "; "fallback" ]);
+  (match Sessions_store.latest_named_artifact [ older; other; newer ] "report" with
+   | Some artifact -> check string "latest artifact" "new" artifact.artifact_id
+   | None -> fail "missing latest artifact");
+  check
+    (option string)
+    "missing latest artifact"
+    None
+    (Option.map
+       (fun (artifact : Runtime.artifact) -> artifact.artifact_id)
+       (Sessions_store.latest_named_artifact [ older; newer ] "missing"));
+  let store = Runtime_store.create ~root () |> Result.get_ok in
+  let alice = participant ~aliases:[ "a"; "coder" ] "alice" in
+  Runtime_store.save_session
+    store
+    (mk_session
+       ~session_id:"sess-a"
+       ~goal:"first"
+       ~title:(Some "First")
+       ~tag:(Some "alpha")
+       ~updated_at:10.0
+       ~participants:[ alice ]
+       ())
+  |> Result.get_ok;
+  Runtime_store.save_session
+    store
+    (mk_session
+       ~session_id:"sess-b"
+       ~goal:"second"
+       ~title:None
+       ~tag:None
+       ~updated_at:11.0
+       ())
+  |> Result.get_ok;
+  let corrupt_dir = Runtime_store.session_dir store "sess-corrupt" in
+  Runtime_store.ensure_dir corrupt_dir |> Result.get_ok;
+  Runtime_store.save_text (Runtime_store.session_path store "sess-corrupt") "{broken"
+  |> Result.get_ok;
+  Runtime_store.save_text
+    (Filename.concat (Runtime_store.sessions_dir store) "not-a-dir")
+    ""
+  |> Result.get_ok;
+  let sessions = Sessions_store.list_sessions ~session_root:root () |> Result.get_ok in
+  check
+    (list string)
+    "valid sessions only"
+    [ "sess-a"; "sess-b" ]
+    (List.map (fun (info : Sessions.session_info) -> info.session_id) sessions);
+  let first = List.hd sessions in
+  check int "participant count" 1 first.participant_count;
+  check string "session path" (Runtime_store.session_path store "sess-a") first.path;
+  Sessions_store.rename_session ~session_root:root ~session_id:"sess-a" ~title:"   " ()
+  |> Result.get_ok;
+  Sessions_store.tag_session
+    ~session_root:root
+    ~session_id:"sess-a"
+    ~tag:(Some "  stable  ")
+    ()
+  |> Result.get_ok;
+  let renamed = Runtime_store.load_session store "sess-a" |> Result.get_ok in
+  check (option string) "blank title clears" None renamed.title;
+  check (option string) "trimmed tag" (Some "stable") renamed.tag;
+  Sessions_store.tag_session ~session_root:root ~session_id:"sess-a" ~tag:None ()
+  |> Result.get_ok;
+  let untagged = Runtime_store.load_session store "sess-a" |> Result.get_ok in
+  check (option string) "none tag clears" None untagged.tag;
+  check
+    int
+    "events missing"
+    0
+    (Sessions_store.get_session_events ~session_root:root "sess-a"
+     |> Result.get_ok
+     |> List.length);
+  check_error
+    "missing named artifact"
+    (Sessions_store.get_named_artifact
+       ~session_root:root
+       ~session_id:"sess-a"
+       ~name:"missing"
+       ());
+  check
+    int
+    "tool catalog absent"
+    0
+    (Sessions_store.get_tool_catalog ~session_root:root ~session_id:"sess-a" ()
+     |> Result.get_ok
+     |> List.length)
+;;
+
+let test_sessions_store_raw_trace_files_and_hooks () =
+  with_temp_root "oas-sessions-store-raw"
+  @@ fun root ->
+  check
+    (list string)
+    "missing raw trace dir"
+    []
+    (Sessions_store.get_raw_trace_files ~session_root:root ~session_id:"sess-hooks" ()
+     |> Result.get_ok);
+  let store = Runtime_store.create ~root () |> Result.get_ok in
+  Runtime_store.ensure_tree store "sess-hooks" |> Result.get_ok;
+  let raw_dir =
+    Sessions_store.get_raw_trace_dir ~session_root:root ~session_id:"sess-hooks" ()
+    |> Result.get_ok
+  in
+  let trace_path = Filename.concat raw_dir "hook_worker.jsonl" in
+  let record
+        ?prompt
+        ?model
+        ?hook_name
+        ?hook_decision
+        ?hook_detail
+        ?final_text
+        ?stop_reason
+        seq
+        record_type
+    : Raw_trace.record
+    =
+    { trace_version = Raw_trace.trace_version
+    ; worker_run_id = "wr-hooks"
+    ; seq
+    ; ts = float_of_int seq
+    ; agent_name = "hook worker"
+    ; session_id = Some "sess-hooks"
+    ; record_type
+    ; prompt
+    ; model
+    ; tool_choice = None
+    ; enable_thinking = None
+    ; thinking_budget = None
+    ; block_index = None
+    ; block_kind = None
+    ; assistant_block = None
+    ; tool_use_id = None
+    ; tool_name = None
+    ; tool_input = None
+    ; tool_planned_index = None
+    ; tool_batch_index = None
+    ; tool_batch_size = None
+    ; tool_concurrency_class = None
+    ; evidence_role = None
+    ; tool_result = None
+    ; tool_error = None
+    ; hook_name
+    ; hook_decision
+    ; hook_detail
+    ; final_text
+    ; stop_reason
+    ; error = None
+    }
+  in
+  [ record ~prompt:"collect hooks" ~model:"model-hook" 1 Raw_trace.Run_started
+  ; record
+      ~hook_name:"pre_tool"
+      ~hook_decision:"allow"
+      ~hook_detail:"initial"
+      2
+      Raw_trace.Hook_invoked
+  ; record
+      ~hook_name:"pre_tool"
+      ~hook_decision:"deny"
+      ~hook_detail:"latest"
+      3
+      Raw_trace.Hook_invoked
+  ; record ~hook_name:"post_tool" ~hook_decision:"allow" 4 Raw_trace.Hook_invoked
+  ; record ~final_text:"done" ~stop_reason:"stop" 5 Raw_trace.Run_finished
+  ]
+  |> List.map (fun record -> Raw_trace.record_to_json record |> Yojson.Safe.to_string)
+  |> String.concat "\n"
+  |> fun raw ->
+  Runtime_store.save_text trace_path (raw ^ "\n") |> Result.get_ok;
+  Runtime_store.save_text (Filename.concat raw_dir "ignore.txt") "ignored"
+  |> Result.get_ok;
+  let files =
+    Sessions_store.get_raw_trace_files ~session_root:root ~session_id:"sess-hooks" ()
+    |> Result.get_ok
+  in
+  check int "jsonl files only" 1 (List.length files);
+  check string "trace file path" trace_path (List.hd files);
+  let summaries =
+    Sessions_store.get_hook_summary ~session_root:root ~session_id:"sess-hooks" ()
+    |> Result.get_ok
+  in
+  check
+    (list string)
+    "hook summary sorted"
+    [ "post_tool"; "pre_tool" ]
+    (List.map (fun (summary : Sessions.hook_summary) -> summary.hook_name) summaries);
+  let pre_tool =
+    List.find
+      (fun (summary : Sessions.hook_summary) -> String.equal summary.hook_name "pre_tool")
+      summaries
+  in
+  check int "pre_tool count" 2 pre_tool.count;
+  check (option string) "latest decision" (Some "deny") pre_tool.latest_decision;
+  check (option string) "latest detail" (Some "latest") pre_tool.latest_detail;
+  check bool "latest timestamp" true (Option.is_some pre_tool.latest_ts);
+  let latest =
+    Sessions_store.get_latest_raw_trace_run ~session_root:root ~session_id:"sess-hooks" ()
+    |> Result.get_ok
+  in
+  check
+    (option string)
+    "latest run"
+    (Some "wr-hooks")
+    (Option.map (fun (run : Raw_trace.run_ref) -> run.worker_run_id) latest);
+  check_error
+    "missing raw trace run"
+    (Sessions_store.get_raw_trace_run
+       ~session_root:root
+       ~session_id:"sess-hooks"
+       ~worker_run_id:"missing"
+       ());
+  check
+    int
+    "summarize empty"
+    0
+    (Sessions_store.summarize_runs [] |> Result.get_ok |> List.length);
+  check
+    int
+    "validate empty"
+    0
+    (Sessions_store.validate_runs [] |> Result.get_ok |> List.length)
+;;
+
 let test_sessions_store_decodes_runtime_artifacts () =
   let root =
     Filename.concat
@@ -413,6 +718,14 @@ let () =
             `Quick
             test_file_specs_and_artifact_event
         ; Alcotest.test_case "raw trace manifest json" `Quick test_raw_trace_manifest_json
+        ; Alcotest.test_case
+            "sessions store helpers listing mutation"
+            `Quick
+            test_sessions_store_helpers_listing_and_mutation
+        ; Alcotest.test_case
+            "sessions store raw trace hooks"
+            `Quick
+            test_sessions_store_raw_trace_files_and_hooks
         ; Alcotest.test_case
             "sessions store artifact decoders"
             `Quick

--- a/test/test_runtime_server_coverage.ml
+++ b/test/test_runtime_server_coverage.ml
@@ -1,0 +1,365 @@
+open Agent_sdk
+module Runtime_server = Agent_sdk__Runtime_server
+
+let expect_ok label = function
+  | Ok value -> value
+  | Error err -> Alcotest.failf "%s: %s" label (Error.to_string err)
+;;
+
+let contains label ~needle text =
+  Alcotest.(check bool) label true (Util.string_contains ~needle text)
+;;
+
+let with_temp_store f =
+  let root =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "oas-runtime-server-cov-%d-%06x"
+         (Unix.getpid ())
+         (Random.int 0xFFFFFF))
+  in
+  let store = Runtime_store.create ~root () |> expect_ok "create store" in
+  f root store
+;;
+
+let make_state env root =
+  let state = Runtime_server_types.create ~net:(Eio.Stdenv.net env) () in
+  state.session_root <- Some root;
+  state
+;;
+
+let start_request ?(session_id = "rt-cov") () : Runtime.start_request =
+  { session_id = Some session_id
+  ; goal = "cover runtime server"
+  ; participants = [ "worker" ]
+  ; provider = Some "mock"
+  ; model = Some "mock-model"
+  ; permission_mode = Some "ask"
+  ; system_prompt = Some "session prompt"
+  ; max_turns = Some 4
+  ; workdir = Some "/tmp/oas"
+  }
+;;
+
+let mk_session ?session_id () =
+  Runtime_projection.initial_session (start_request ?session_id ())
+;;
+
+let save_session store session =
+  Runtime_store.save_session store session |> expect_ok "save session"
+;;
+
+let read_events store session_id =
+  Runtime_store.read_events store session_id () |> expect_ok "read events"
+;;
+
+let event_exists predicate events =
+  List.exists (fun (event : Runtime.event) -> predicate event.kind) events
+;;
+
+let test_handle_initialize_status_events_report_prove_shutdown () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_store
+  @@ fun root store ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let state = Runtime_server_types.create ~net:(Eio.Stdenv.net env) () in
+  let init : Runtime.init_request =
+    { session_root = Some ("  " ^ root ^ "  ")
+    ; provider = Some "mock"
+    ; model = Some "mock-model"
+    ; permission_mode = Some "ask"
+    ; include_partial_messages = false
+    ; setting_sources = [ "test" ]
+    ; resume_session = None
+    ; cwd = Some "/tmp/oas"
+    }
+  in
+  (match Runtime_server.handle_request ~sw state (Runtime.Initialize init) with
+   | Ok (Runtime.Initialized response) ->
+     Alcotest.(check string) "sdk" "agent_sdk" response.sdk_name;
+     Alcotest.(check string) "root" root (Option.value ~default:"" state.session_root);
+     Alcotest.(check bool)
+       "capability"
+       true
+       (List.mem "apply_command" response.capabilities)
+   | Ok _ -> Alcotest.fail "expected Initialized"
+   | Error err -> Alcotest.fail (Error.to_string err));
+  let session = mk_session () in
+  save_session store session;
+  let session =
+    match
+      Runtime_server.apply_command
+        ~sw
+        state
+        store
+        session
+        (Runtime.Record_turn { actor = Some "user"; message = "status please" })
+    with
+    | Ok (Runtime.Command_applied session) -> session
+    | Ok _ -> Alcotest.fail "expected Command_applied"
+    | Error err -> Alcotest.fail (Error.to_string err)
+  in
+  (match
+     Runtime_server.handle_request
+       ~sw
+       state
+       (Runtime.Status { session_id = session.session_id })
+   with
+   | Ok (Runtime.Status_response loaded) ->
+     Alcotest.(check string) "status id" session.session_id loaded.session_id
+   | Ok _ -> Alcotest.fail "expected status"
+   | Error err -> Alcotest.fail (Error.to_string err));
+  (match
+     Runtime_server.handle_request
+       ~sw
+       state
+       (Runtime.Events { session_id = session.session_id; after_seq = Some 0 })
+   with
+   | Ok (Runtime.Events_response events) ->
+     Alcotest.(check int) "events" 1 (List.length events)
+   | Ok _ -> Alcotest.fail "expected events"
+   | Error err -> Alcotest.fail (Error.to_string err));
+  (match
+     Runtime_server.handle_request
+       ~sw
+       state
+       (Runtime.Report { session_id = session.session_id })
+   with
+   | Ok (Runtime.Report_response report) ->
+     Alcotest.(check string) "report" session.session_id report.session_id
+   | Ok _ -> Alcotest.fail "expected report"
+   | Error err -> Alcotest.fail (Error.to_string err));
+  (match
+     Runtime_server.handle_request
+       ~sw
+       state
+       (Runtime.Prove { session_id = session.session_id })
+   with
+   | Ok (Runtime.Prove_response proof) ->
+     Alcotest.(check string) "proof" session.session_id proof.session_id
+   | Ok _ -> Alcotest.fail "expected proof"
+   | Error err -> Alcotest.fail (Error.to_string err));
+  match Runtime_server.handle_request ~sw state Runtime.Shutdown with
+  | Ok Runtime.Shutdown_ack -> ()
+  | Ok _ -> Alcotest.fail "expected shutdown"
+  | Error err -> Alcotest.fail (Error.to_string err)
+;;
+
+let test_apply_command_public_paths_and_errors () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_store
+  @@ fun root store ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let state = make_state env root in
+  let session = mk_session () in
+  save_session store session;
+  let session =
+    match
+      Runtime_server.apply_command
+        ~sw
+        state
+        store
+        session
+        (Runtime.Record_turn { actor = Some "user"; message = "hello" })
+    with
+    | Ok (Runtime.Command_applied session) ->
+      Alcotest.(check int) "record seq" 1 session.last_seq;
+      session
+    | Ok _ -> Alcotest.fail "expected record response"
+    | Error err -> Alcotest.fail (Error.to_string err)
+  in
+  let input : Runtime.input_request =
+    { request_id = "input-1"
+    ; participant_name = Some "worker"
+    ; question = "Continue?"
+    ; schema = Some (`Assoc [ "type", `String "string" ])
+    ; timeout_s = None
+    ; created_at = 2.0
+    }
+  in
+  let session =
+    match
+      Runtime_server.apply_command ~sw state store session (Runtime.Request_input input)
+    with
+    | Ok (Runtime.Command_applied session) ->
+      Alcotest.(check bool) "pending" true (Option.is_some session.pending_input);
+      session
+    | Ok _ -> Alcotest.fail "expected input response"
+    | Error err -> Alcotest.fail (Error.to_string err)
+  in
+  (match
+     Runtime_server.apply_command
+       ~sw
+       state
+       store
+       session
+       (Runtime.Request_input { input with request_id = "   " })
+   with
+   | Error (Error.Internal msg) -> contains "empty request id" ~needle:"non-empty" msg
+   | Error err -> Alcotest.fail (Error.to_string err)
+   | Ok _ -> Alcotest.fail "blank request id should fail");
+  let session =
+    match
+      Runtime_server.apply_command
+        ~sw
+        state
+        store
+        session
+        (Runtime.Update_session_settings
+           { model = Some "new-model"; permission_mode = Some "never" })
+    with
+    | Ok (Runtime.Command_applied session) ->
+      Alcotest.(check (option string)) "model updated" (Some "new-model") session.model;
+      session
+    | Ok _ -> Alcotest.fail "expected settings response"
+    | Error err -> Alcotest.fail (Error.to_string err)
+  in
+  let session =
+    match
+      Runtime_server.apply_command
+        ~sw
+        state
+        store
+        session
+        (Runtime.Attach_artifact
+           { name = "note"; kind = "text"; content = "artifact body" })
+    with
+    | Ok (Runtime.Command_applied session) ->
+      Alcotest.(check int) "artifact count" 1 (List.length session.artifacts);
+      session
+    | Ok _ -> Alcotest.fail "expected artifact response"
+    | Error err -> Alcotest.fail (Error.to_string err)
+  in
+  let session =
+    match
+      Runtime_server.apply_command
+        ~sw
+        state
+        store
+        session
+        (Runtime.Checkpoint { label = Some "before finalize" })
+    with
+    | Ok (Runtime.Command_applied session) ->
+      Alcotest.(check int) "checkpoint seq" 5 session.last_seq;
+      session
+    | Ok _ -> Alcotest.fail "expected checkpoint response"
+    | Error err -> Alcotest.fail (Error.to_string err)
+  in
+  let events = read_events store session.session_id in
+  Alcotest.(check bool)
+    "turn event"
+    true
+    (event_exists
+       (function
+         | Runtime.Turn_recorded _ -> true
+         | _ -> false)
+       events);
+  Alcotest.(check bool)
+    "checkpoint event"
+    true
+    (event_exists
+       (function
+         | Runtime.Checkpoint_saved _ -> true
+         | _ -> false)
+       events);
+  let no_pending = mk_session ~session_id:"rt-no-pending" () in
+  save_session store no_pending;
+  (match
+     Runtime_server.apply_command
+       ~sw
+       state
+       store
+       no_pending
+       (Runtime.Provide_input
+          { request_id = "missing"; response = Runtime.Input_declined })
+   with
+   | Error (Error.Internal msg) -> contains "no pending" ~needle:"no pending" msg
+   | Error err -> Alcotest.fail (Error.to_string err)
+   | Ok _ -> Alcotest.fail "provide without pending should fail");
+  let pending : Runtime.input_request =
+    { request_id = "expected"
+    ; participant_name = Some "worker"
+    ; question = "Continue?"
+    ; schema = None
+    ; timeout_s = None
+    ; created_at = 2.0
+    }
+  in
+  let pending_session =
+    { no_pending with
+      session_id = "rt-pending"
+    ; phase = Runtime.Input_required
+    ; pending_input = Some pending
+    ; last_seq = 1
+    }
+  in
+  save_session store pending_session;
+  match
+    Runtime_server.apply_command
+      ~sw
+      state
+      store
+      pending_session
+      (Runtime.Provide_input { request_id = "wrong"; response = Runtime.Input_timeout })
+  with
+  | Error (Error.Internal msg) ->
+    contains "mismatch" ~needle:"pending request is expected" msg
+  | Error err -> Alcotest.fail (Error.to_string err)
+  | Ok _ -> Alcotest.fail "mismatched input id should fail"
+;;
+
+let test_finalize_session_active_and_terminal () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_store
+  @@ fun root store ->
+  let state = make_state env root in
+  let running = mk_session ~session_id:"rt-finalize" () in
+  save_session store running;
+  let finalized =
+    match Runtime_server.finalize_session state store running (Some "done") with
+    | Ok (Runtime.Finalized session) ->
+      Alcotest.(check string) "outcome" "done" (Option.value ~default:"" session.outcome);
+      session
+    | Ok _ -> Alcotest.fail "expected finalized"
+    | Error err -> Alcotest.fail (Error.to_string err)
+  in
+  let completed =
+    { finalized with phase = Runtime.Completed; outcome = Some "already done" }
+  in
+  save_session store completed;
+  match Runtime_server.finalize_session state store completed (Some "ignored") with
+  | Ok (Runtime.Finalized session) ->
+    Alcotest.(check (option string)) "preserved" (Some "already done") session.outcome
+  | Ok _ -> Alcotest.fail "expected finalized terminal session"
+  | Error err -> Alcotest.fail (Error.to_string err)
+;;
+
+let () =
+  Alcotest.run
+    "Runtime_server_coverage"
+    [ ( "request"
+      , [ Alcotest.test_case
+            "initialize status events report prove shutdown"
+            `Quick
+            test_handle_initialize_status_events_report_prove_shutdown
+        ] )
+    ; ( "commands"
+      , [ Alcotest.test_case
+            "public paths and errors"
+            `Quick
+            test_apply_command_public_paths_and_errors
+        ] )
+    ; ( "finalize"
+      , [ Alcotest.test_case
+            "active and terminal sessions"
+            `Quick
+            test_finalize_session_active_and_terminal
+        ] )
+    ]
+;;

--- a/test/test_sessions_types_deep.ml
+++ b/test/test_sessions_types_deep.ml
@@ -247,6 +247,25 @@ let test_raw_trace_validation_empty_checks () =
     v
 ;;
 
+let test_raw_trace_manifest_roundtrip () =
+  let run_ref = mk_run_ref () in
+  let v : Sessions.raw_trace_manifest =
+    { session_id = "s-001"
+    ; generated_at = 123.0
+    ; latest_raw_trace_run = Some run_ref
+    ; raw_trace_runs = [ run_ref ]
+    ; raw_trace_summaries = [ mk_run_summary () ]
+    ; raw_trace_validations = [ mk_run_validation () ]
+    }
+  in
+  roundtrip
+    ~to_yojson:Sessions.raw_trace_manifest_to_yojson
+    ~of_yojson:Sessions.raw_trace_manifest_of_yojson
+    ~show:Sessions.show_raw_trace_manifest
+    ~name:"raw_trace_manifest"
+    v
+;;
+
 (* ── worker_run with each status variant ────────────────────────── *)
 
 let mk_worker_run status : Sessions.worker_run =
@@ -458,6 +477,153 @@ let test_record_minimal () =
     v
 ;;
 
+(* ── proof_bundle composite roundtrip ───────────────────────────── *)
+
+let mk_runtime_session () : Runtime.session =
+  { session_id = "s-001"
+  ; goal = "verify proof bundle"
+  ; title = Some "Proof"
+  ; tag = Some "coverage"
+  ; permission_mode = Some "default"
+  ; phase = Runtime.Completed
+  ; created_at = 1.0
+  ; updated_at = 2.0
+  ; provider = Some "provider_a"
+  ; model = Some "agent_llm_a-sonnet"
+  ; system_prompt = Some "system"
+  ; max_turns = 3
+  ; workdir = Some "/tmp"
+  ; planned_participants = [ "tester" ]
+  ; participants = []
+  ; artifacts = []
+  ; pending_input = None
+  ; turn_count = 1
+  ; last_seq = 3
+  ; outcome = Some "ok"
+  }
+;;
+
+let test_proof_bundle_roundtrip () =
+  let run_ref = mk_run_ref () in
+  let worker = mk_worker_run Sessions.Completed in
+  let telemetry_step : Sessions.telemetry_step =
+    { seq = 1
+    ; ts = 1.0
+    ; kind = "Agent_completed"
+    ; participant = Some "tester"
+    ; detail = Some "done"
+    }
+  in
+  let structured_step : Sessions.structured_telemetry_step =
+    { seq = 1
+    ; ts = 1.0
+    ; event_name = "agent_completed"
+    ; participant = Some "tester"
+    ; detail = Some "done"
+    ; actor = Some "agent"
+    ; role = Some "worker"
+    ; provider = Some "provider_a"
+    ; model = Some "agent_llm_a-sonnet"
+    ; raw_trace_run_id = Some run_ref.worker_run_id
+    ; stop_reason = Some "end_turn"
+    ; artifact_id = Some "artifact-1"
+    ; artifact_name = Some "report"
+    ; artifact_kind = Some "json"
+    ; checkpoint_label = Some "final"
+    ; outcome = Some "ok"
+    ; dropped_output_deltas = Some 0
+    ; persistence_failure_phase = None
+    }
+  in
+  let bundle : Sessions.proof_bundle =
+    { session = mk_runtime_session ()
+    ; report =
+        { Runtime.session_id = "s-001"
+        ; summary = [ "completed" ]
+        ; markdown = "# completed"
+        ; generated_at = 3.0
+        }
+    ; proof =
+        { Runtime.session_id = "s-001"
+        ; ok = true
+        ; checks = [ ({ name = "seq_contiguous"; passed = true } : Runtime.proof_check) ]
+        ; evidence = [ "events=3" ]
+        ; generated_at = 3.0
+        }
+    ; telemetry =
+        { session_id = "s-001"
+        ; generated_at = 3.0
+        ; step_count = 1
+        ; event_counts = [ { name = "Agent_completed"; count = 1 } ]
+        ; steps = [ telemetry_step ]
+        }
+    ; structured_telemetry =
+        { session_id = "s-001"
+        ; generated_at = 3.0
+        ; step_count = 1
+        ; event_counts = [ { event_name = "agent_completed"; count = 1 } ]
+        ; steps = [ structured_step ]
+        }
+    ; evidence =
+        { session_id = "s-001"
+        ; generated_at = 3.0
+        ; files =
+            [ { label = "report"
+              ; path = "/tmp/report.json"
+              ; size_bytes = 12
+              ; md5 = "0123456789abcdef0123456789abcdef"
+              }
+            ]
+        ; missing_files = [ { label = "proof"; path = "/tmp/proof.json" } ]
+        }
+    ; hook_summary =
+        [ { hook_name = "pre_tool"
+          ; count = 1
+          ; latest_decision = Some "allow"
+          ; latest_detail = Some "ok"
+          ; latest_ts = Some 2.0
+          }
+        ]
+    ; tool_catalog =
+        [ { name = "read_file"
+          ; description = "Read a file"
+          ; origin = Some "runtime"
+          ; kind = Some "local"
+          ; shell = None
+          ; notes = [ "readonly" ]
+          ; examples = [ "read_file path" ]
+          }
+        ]
+    ; latest_raw_trace_run = Some run_ref
+    ; raw_trace_runs = [ run_ref ]
+    ; raw_trace_summaries = [ mk_run_summary () ]
+    ; raw_trace_validations = [ mk_run_validation () ]
+    ; worker_runs = [ worker ]
+    ; latest_accepted_worker_run = None
+    ; latest_ready_worker_run = None
+    ; latest_running_worker_run = None
+    ; latest_worker_run = Some worker
+    ; latest_completed_worker_run = Some worker
+    ; latest_validated_worker_run = Some worker
+    ; latest_failed_worker_run = None
+    ; validated_worker_runs = [ worker ]
+    ; raw_trace_run_count = 1
+    ; validated_worker_run_count = 1
+    ; trace_capabilities = [ Sessions.Raw; Sessions.Summary_only; Sessions.No_trace ]
+    ; capabilities = { raw_trace = true; validated_summary = true; proof_bundle = true }
+    }
+  in
+  roundtrip_json_stable
+    ~to_yojson:Sessions.proof_bundle_to_yojson
+    ~of_yojson:Sessions.proof_bundle_of_yojson
+    ~name:"proof_bundle"
+    bundle;
+  Alcotest.(check bool)
+    "show proof bundle"
+    true
+    (String.length (Sessions.show_proof_bundle bundle) > 0)
+;;
+
 (* ── Test runner ───────────────────────────────────────────────── *)
 
 let () =
@@ -478,6 +644,8 @@ let () =
         ; Alcotest.test_case "fail" `Quick test_raw_trace_validation_fail
         ; Alcotest.test_case "empty checks" `Quick test_raw_trace_validation_empty_checks
         ] )
+    ; ( "raw_trace_manifest"
+      , [ Alcotest.test_case "roundtrip" `Quick test_raw_trace_manifest_roundtrip ] )
     ; ( "worker_run_statuses"
       , [ Alcotest.test_case "all 6 variants" `Quick test_worker_run_all_statuses
         ; Alcotest.test_case
@@ -493,5 +661,7 @@ let () =
       , [ Alcotest.test_case "tool execution" `Quick test_record_full
         ; Alcotest.test_case "minimal run_started" `Quick test_record_minimal
         ] )
+    ; ( "proof_bundle"
+      , [ Alcotest.test_case "roundtrip" `Quick test_proof_bundle_roundtrip ] )
     ]
 ;;

--- a/test/test_slot_cache_http.ml
+++ b/test/test_slot_cache_http.ml
@@ -94,6 +94,20 @@ let test_non_2xx_response_surfaces_action_and_body () =
       check bool "mentions body" true (contains_substring ~sub:"slot failed" msg))
 ;;
 
+let test_non_2xx_response_truncates_long_body () =
+  let long_body = String.make 240 'x' ^ "tail" in
+  let handler _conn _req body =
+    ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
+    Cohttp_eio.Server.respond_string ~status:`Bad_gateway ~body:long_body ()
+  in
+  with_mock_server ~port:18345 handler (fun ~sw ~net ~endpoint ->
+    match Slot_cache.save ~sw ~net ~endpoint ~slot_id:4 ~filename:"slot.bin" with
+    | Ok () -> fail "expected save error"
+    | Error msg ->
+      check bool "mentions status" true (contains_substring ~sub:"slot save HTTP 502" msg);
+      check bool "truncated body" true (String.length msg < String.length long_body))
+;;
+
 let () =
   run
     "slot-cache-http"
@@ -106,6 +120,10 @@ let () =
             "non-2xx response"
             `Quick
             test_non_2xx_response_surfaces_action_and_body
+        ; test_case
+            "non-2xx long body is truncated"
+            `Quick
+            test_non_2xx_response_truncates_long_body
         ] )
     ]
 ;;

--- a/test/test_tool_selector.ml
+++ b/test/test_tool_selector.ml
@@ -390,6 +390,31 @@ let test_topk_llm_candidates_preserve_first_duplicate_descriptor () =
   check (list string) "selected status once" [ "status" ] (tool_names result)
 ;;
 
+let test_default_rerank_fn_falls_back_to_candidates_on_provider_error () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let provider =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Provider_d_compat
+      ~model_id:"provider_d_chat"
+      ~base_url:"http://"
+      ()
+  in
+  let rerank = Tool_selector.default_rerank_fn ~sw ~net:env#net ~provider ~k:2 () in
+  let selected =
+    rerank
+      ~context:"read file"
+      ~candidates:
+        [ "read_file", "Read file contents"
+        ; "search", "Search code"
+        ; "write_file", "Write file contents"
+        ]
+  in
+  check (list string) "bm25 fallback order" [ "read_file"; "search" ] selected
+;;
+
 (* ── Categorical stubs ──────────────────────────── *)
 
 let test_categorical_llm_unimplemented_returns_empty () =
@@ -580,6 +605,10 @@ let () =
             "duplicate candidate descriptor keeps first"
             `Quick
             test_topk_llm_candidates_preserve_first_duplicate_descriptor
+        ; test_case
+            "default rerank falls back on provider error"
+            `Quick
+            test_default_rerank_fn_falls_back_to_candidates_on_provider_error
         ] )
     ; ( "stubs"
       , [ test_case

--- a/test/test_tool_selector.ml
+++ b/test/test_tool_selector.ml
@@ -170,6 +170,26 @@ let test_select_names () =
   check (list string) "all names" (tool_names tools_5) names
 ;;
 
+let test_select_names_with_index_bm25 () =
+  let index = Tool_index.of_tools tools_5 in
+  let names =
+    Tool_selector.select_names_with_index
+      ~strategy:
+        (TopK_bm25
+           { k = 2
+           ; always_include = [ "broadcast"; "missing_tool" ]
+           ; confidence_threshold = None
+           ; fallback_tools = []
+           })
+      ~index
+      ~context:"read file"
+      ~tools:tools_5
+  in
+  check bool "broadcast included" true (List.mem "broadcast" names);
+  check bool "missing ignored" false (List.mem "missing_tool" names);
+  check bool "bounded plus always include" true (List.length names <= 3)
+;;
+
 (* ── TopK_llm ───────────────────────────────────── *)
 
 let mock_rerank ~k =
@@ -195,7 +215,7 @@ let test_topk_llm_with_mock () =
 ;;
 
 let test_topk_llm_fallback_on_failure () =
-  let failing_rerank ~context:_ ~candidates:_ = failwith "LLM unavailable" in
+  let failing_rerank ~context:_ ~candidates:_ = raise (Failure "LLM unavailable") in
   let result =
     Tool_selector.select
       ~strategy:
@@ -286,6 +306,55 @@ let test_topk_llm_invalid_names_dropped () =
   in
   (* Invalid names dropped, only always_include survives (empty here) *)
   check int "no tools from invalid rerank" 0 (List.length result)
+;;
+
+let test_topk_llm_invalid_names_preserve_always_include () =
+  let bad_rerank ~context:_ ~candidates:_ = [ "nonexistent_tool" ] in
+  let result =
+    Tool_selector.select
+      ~strategy:
+        (TopK_llm
+           { k = 3
+           ; bm25_prefilter_n = 5
+           ; always_include = [ "broadcast"; "missing_tool" ]
+           ; confidence_threshold = 0.0
+           ; rerank_fn = bad_rerank
+           })
+      ~context:"read file"
+      ~tools:tools_5
+  in
+  check
+    (list string)
+    "only valid always_include remains"
+    [ "broadcast" ]
+    (tool_names result)
+;;
+
+let test_select_with_index_topk_llm_uses_index () =
+  let index = Tool_index.of_tools tools_5 in
+  let seen_candidates = ref [] in
+  let rerank ~context:_ ~candidates =
+    seen_candidates := candidates;
+    [ "search"; "read_file" ]
+  in
+  let result =
+    Tool_selector.select_with_index
+      ~strategy:
+        (TopK_llm
+           { k = 2
+           ; bm25_prefilter_n = 5
+           ; always_include = []
+           ; confidence_threshold = 0.0
+           ; rerank_fn = rerank
+           })
+      ~index
+      ~context:"search file"
+      ~tools:tools_5
+  in
+  let names = tool_names result in
+  check bool "reranker saw candidates" true (List.length !seen_candidates > 0);
+  check bool "search selected" true (List.mem "search" names);
+  check bool "read_file selected" true (List.mem "read_file" names)
 ;;
 
 let test_topk_llm_candidates_preserve_first_duplicate_descriptor () =
@@ -420,6 +489,41 @@ let test_categorical_bm25 () =
   check bool "at least 1 result" true (List.length result >= 1)
 ;;
 
+let test_categorical_bm25_always_include_and_missing_names () =
+  let groups = [ "file_ops", [ "read_file"; "missing_tool" ] ] in
+  let result =
+    Tool_selector.select
+      ~strategy:
+        (Categorical
+           { groups
+           ; classifier = `Bm25
+           ; always_include = [ "broadcast"; "also_missing" ]
+           })
+      ~context:"read file"
+      ~tools:tools_5
+  in
+  let names = tool_names result in
+  check bool "broadcast always included" true (List.mem "broadcast" names);
+  check bool "read_file included from group" true (List.mem "read_file" names);
+  check bool "missing group tool ignored" false (List.mem "missing_tool" names);
+  check bool "missing always include ignored" false (List.mem "also_missing" names)
+;;
+
+let test_categorical_bm25_empty_tools () =
+  let result =
+    Tool_selector.select
+      ~strategy:
+        (Categorical
+           { groups = [ "file_ops", [ "read_file" ] ]
+           ; classifier = `Bm25
+           ; always_include = [ "broadcast" ]
+           })
+      ~context:"read file"
+      ~tools:[]
+  in
+  check int "empty tools" 0 (List.length result)
+;;
+
 (* ── Runner ──────────────────────────────────────── *)
 
 let () =
@@ -442,7 +546,13 @@ let () =
         ; test_case "boundary 15 -> All" `Quick test_auto_boundary
         ; test_case "16 -> TopK_bm25" `Quick test_auto_16
         ] )
-    ; "select_names", [ test_case "returns names" `Quick test_select_names ]
+    ; ( "select_names"
+      , [ test_case "returns names" `Quick test_select_names
+        ; test_case
+            "with index filters missing names"
+            `Quick
+            test_select_names_with_index_bm25
+        ] )
     ; ( "confidence"
       , [ test_case "fallback on low confidence" `Quick test_bm25_confidence_fallback
         ; test_case "no fallback above threshold" `Quick test_bm25_confidence_above
@@ -459,6 +569,14 @@ let () =
         ; test_case "empty tools" `Quick test_topk_llm_empty_tools
         ; test_case "invalid names dropped" `Quick test_topk_llm_invalid_names_dropped
         ; test_case
+            "invalid names preserve always_include"
+            `Quick
+            test_topk_llm_invalid_names_preserve_always_include
+        ; test_case
+            "select_with_index uses supplied index"
+            `Quick
+            test_select_with_index_topk_llm_uses_index
+        ; test_case
             "duplicate candidate descriptor keeps first"
             `Quick
             test_topk_llm_candidates_preserve_first_duplicate_descriptor
@@ -474,6 +592,12 @@ let () =
             test_categorical_llm_unimplemented_returns_empty_with_index
         ] )
     ; ( "categorical_bm25"
-      , [ test_case "file query matches file_ops" `Quick test_categorical_bm25 ] )
+      , [ test_case "file query matches file_ops" `Quick test_categorical_bm25
+        ; test_case
+            "always_include and missing names"
+            `Quick
+            test_categorical_bm25_always_include_and_missing_names
+        ; test_case "empty tools" `Quick test_categorical_bm25_empty_tools
+        ] )
     ]
 ;;

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -400,6 +400,31 @@ let test_tool_param_manual_json_helpers () =
   | Error msg -> Alcotest.fail msg
 ;;
 
+let test_tool_schema_manual_json_rejects_bad_param () =
+  let bad_schema =
+    `Assoc
+      [ "name", `String "broken"
+      ; "description", `String "Broken schema"
+      ; ( "parameters"
+        , `List
+            [ `Assoc
+                [ "name", `String "x"
+                ; "description", `String "bad"
+                ; "param_type", `String "not-a-type"
+                ; "required", `Bool true
+                ]
+            ] )
+      ]
+  in
+  match Types.tool_schema_of_json bad_schema with
+  | Error msg ->
+    Alcotest.(check bool)
+      "propagates bad param"
+      true
+      (Agent_sdk.Util.contains_substring_ci ~haystack:msg ~needle:"not-a-type")
+  | Ok _ -> Alcotest.fail "expected tool_schema_of_json error"
+;;
+
 let test_result_all_helper () =
   Alcotest.(check (list int))
     "all ok"
@@ -409,6 +434,89 @@ let test_result_all_helper () =
   | Error "boom" -> ()
   | Error other -> Alcotest.fail ("unexpected error: " ^ other)
   | Ok _ -> Alcotest.fail "expected first error"
+;;
+
+let test_tool_error_class_yojson_roundtrip () =
+  List.iter
+    (fun error_class ->
+       let json = Types.tool_error_class_to_yojson error_class in
+       (match Types.tool_error_class_of_yojson json with
+        | Ok decoded ->
+          Alcotest.(check string)
+            "tool_error_class"
+            (Types.show_tool_error_class error_class)
+            (Types.show_tool_error_class decoded)
+        | Error msg -> Alcotest.fail msg);
+       Alcotest.(check bool)
+         "show non-empty"
+         true
+         (String.length (Types.show_tool_error_class error_class) > 0))
+    [ Types.Transient; Types.Deterministic; Types.Unknown ]
+;;
+
+let test_usage_and_inference_telemetry_yojson_roundtrip () =
+  let usage : Types.api_usage =
+    { input_tokens = 11
+    ; output_tokens = 22
+    ; cache_creation_input_tokens = 3
+    ; cache_read_input_tokens = 4
+    ; cost_usd = Some 0.25
+    }
+  in
+  (match Types.api_usage_of_yojson (Types.api_usage_to_yojson usage) with
+   | Ok decoded ->
+     Alcotest.(check int) "usage input" 11 decoded.input_tokens;
+     Alcotest.(check bool)
+       "usage show"
+       true
+       (String.length (Types.show_api_usage decoded) > 0)
+   | Error msg -> Alcotest.fail msg);
+  let timings : Types.inference_timings =
+    { prompt_n = Some 10
+    ; prompt_ms = Some 20.5
+    ; prompt_per_second = Some 30.5
+    ; predicted_n = Some 4
+    ; predicted_ms = Some 5.5
+    ; predicted_per_second = Some 6.5
+    ; cache_n = Some 7
+    }
+  in
+  (match
+     Types.inference_timings_of_yojson (Types.inference_timings_to_yojson timings)
+   with
+   | Ok decoded ->
+     Alcotest.(check (option int)) "cache_n" (Some 7) decoded.cache_n;
+     Alcotest.(check bool)
+       "timings show"
+       true
+       (String.length (Types.show_inference_timings decoded) > 0)
+   | Error msg -> Alcotest.fail msg);
+  let telemetry : Types.inference_telemetry =
+    { system_fingerprint = Some "fp"
+    ; timings = Some timings
+    ; reasoning_tokens = Some 12
+    ; reasoning_tokens_estimated = false
+    ; request_latency_ms = Some 123
+    ; peak_memory_gb = Some 4.5
+    ; provider_kind = Some Llm_provider.Provider_config.Provider_d_compat
+    ; reasoning_effort = Some "medium"
+    ; canonical_model_id = Some "model-d"
+    ; effective_context_window = Some 8192
+    ; provider_internal_action_count = Some 2
+    ; ttfrc_ms = Some 10.0
+    ; prefill_ms = Some 11.0
+    }
+  in
+  match
+    Types.inference_telemetry_of_yojson (Types.inference_telemetry_to_yojson telemetry)
+  with
+  | Ok decoded ->
+    Alcotest.(check (option string)) "fingerprint" (Some "fp") decoded.system_fingerprint;
+    Alcotest.(check bool)
+      "telemetry show"
+      true
+      (String.length (Types.show_inference_telemetry decoded) > 0)
+  | Error msg -> Alcotest.fail msg
 ;;
 
 (* ── role_of_string ──────────────────────────────────────── *)
@@ -716,6 +824,10 @@ let () =
     ; ( "usage"
       , [ Alcotest.test_case "add_usage" `Quick test_add_usage
         ; Alcotest.test_case "accumulates" `Quick test_add_usage_accumulates
+        ; Alcotest.test_case
+            "usage and telemetry yojson"
+            `Quick
+            test_usage_and_inference_telemetry_yojson_roundtrip
         ] )
     ; "config", [ Alcotest.test_case "default_config" `Quick test_default_config ]
     ; ( "yojson_roundtrip"
@@ -791,6 +903,14 @@ let () =
             `Quick
             test_tool_param_manual_json_helpers
         ; Alcotest.test_case "result_all" `Quick test_result_all_helper
+        ; Alcotest.test_case
+            "tool_schema_of_json bad param"
+            `Quick
+            test_tool_schema_manual_json_rejects_bad_param
+        ; Alcotest.test_case
+            "tool_error_class yojson"
+            `Quick
+            test_tool_error_class_yojson_roundtrip
         ] )
     ; ( "text_extraction"
       , [ Alcotest.test_case "text only" `Quick test_text_of_content_text_only

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -112,6 +112,31 @@ let test_tool_choice_none () =
   | Error _ -> Alcotest.fail "expected Ok"
 ;;
 
+let test_response_format_json_helpers () =
+  let schema = `Assoc [ "type", `String "object" ] in
+  let cases =
+    [ Types.Off, `Assoc [ "type", `String "off" ]
+    ; Types.JsonMode, `Assoc [ "type", `String "json_mode" ]
+    ; Types.JsonSchema schema, `Assoc [ "type", `String "json_schema"; "schema", schema ]
+    ]
+  in
+  List.iter
+    (fun (format, expected) ->
+       Alcotest.(check string)
+         "response_format json"
+         (Yojson.Safe.to_string expected)
+         (Types.response_format_to_json format |> Yojson.Safe.to_string))
+    cases;
+  Alcotest.(check string)
+    "enabled"
+    (Types.show_response_format Types.JsonMode)
+    (Types.response_format_of_json_mode true |> Types.show_response_format);
+  Alcotest.(check string)
+    "disabled"
+    (Types.show_response_format Types.Off)
+    (Types.response_format_of_json_mode false |> Types.show_response_format)
+;;
+
 let test_add_usage () =
   let stats = Types.empty_usage in
   let u : Types.api_usage =
@@ -326,6 +351,66 @@ let test_tool_choice_roundtrip_all () =
     variants
 ;;
 
+let test_tool_param_manual_json_helpers () =
+  let params =
+    [ { Types.name = "q"
+      ; description = "Query"
+      ; param_type = Types.String
+      ; required = true
+      }
+    ; { Types.name = "limit"
+      ; description = "Limit"
+      ; param_type = Types.Integer
+      ; required = false
+      }
+    ]
+  in
+  let schema = Types.params_to_input_schema params in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "schema type" "object" (schema |> member "type" |> to_string);
+  Alcotest.(check int)
+    "required count"
+    1
+    (schema |> member "required" |> to_list |> List.length);
+  let param_json = Types.tool_param_to_json (List.hd params) in
+  (match Types.tool_param_of_json param_json with
+   | Ok decoded -> Alcotest.(check string) "decoded" "q" decoded.name
+   | Error msg -> Alcotest.fail msg);
+  let bad_param =
+    `Assoc
+      [ "name", `String "x"
+      ; "description", `String "bad"
+      ; "param_type", `String "bad_type"
+      ; "required", `Bool true
+      ]
+  in
+  (match Types.tool_param_of_json bad_param with
+   | Error msg ->
+     Alcotest.(check bool)
+       "mentions param_type"
+       true
+       (Agent_sdk.Util.contains_substring_ci ~haystack:msg ~needle:"param_type")
+   | Ok _ -> Alcotest.fail "expected bad param type");
+  let tool_schema =
+    { Types.name = "search"; description = "Search"; parameters = params }
+  in
+  let manual_json = Types.tool_schema_to_json tool_schema in
+  match Types.tool_schema_of_json manual_json with
+  | Ok decoded -> Alcotest.(check int) "params" 2 (List.length decoded.parameters)
+  | Error msg -> Alcotest.fail msg
+;;
+
+let test_result_all_helper () =
+  Alcotest.(check (list int))
+    "all ok"
+    [ 1; 2 ]
+    (Result.get_ok (Types.result_all [ Ok 1; Ok 2 ]));
+  match Types.result_all [ Ok 1; Error "boom"; Ok 3 ] with
+  | Error "boom" -> ()
+  | Error other -> Alcotest.fail ("unexpected error: " ^ other)
+  | Ok _ -> Alcotest.fail "expected first error"
+;;
+
 (* ── role_of_string ──────────────────────────────────────── *)
 
 let test_role_of_string () =
@@ -398,6 +483,24 @@ let test_tool_result_msg_error () =
   | _ -> Alcotest.fail "expected error ToolResult"
 ;;
 
+let test_tool_result_msg_json_detection () =
+  let m = Types.tool_result_msg ~tool_use_id:"tu-json" ~content:{|{"ok":true}|} () in
+  (match m.content with
+   | [ Types.ToolResult { json = Some (`Assoc _); _ } ] -> ()
+   | _ -> Alcotest.fail "expected parsed JSON payload");
+  let explicit = `Assoc [ "explicit", `Bool true ] in
+  let m =
+    Types.tool_result_msg ~tool_use_id:"tu-explicit" ~content:"not-json" ~json:explicit ()
+  in
+  match m.content with
+  | [ Types.ToolResult { json = Some json; _ } ] ->
+    Alcotest.(check string)
+      "explicit json wins"
+      (Yojson.Safe.to_string explicit)
+      (Yojson.Safe.to_string json)
+  | _ -> Alcotest.fail "expected explicit JSON payload"
+;;
+
 (* ── text_of_content / text_of_message ─────────────────── *)
 
 let test_text_of_content_text_only () =
@@ -444,6 +547,131 @@ let test_text_of_message () =
   Alcotest.(check string) "text" "hi" (Types.text_of_message m)
 ;;
 
+let test_text_of_response_and_usage_helpers () =
+  let usage =
+    { Types.input_tokens = 1
+    ; output_tokens = 2
+    ; cache_creation_input_tokens = 3
+    ; cache_read_input_tokens = 4
+    ; cost_usd = Some 0.01
+    }
+  in
+  let response : Types.api_response =
+    { id = "resp"
+    ; model = "model"
+    ; stop_reason = Types.EndTurn
+    ; content =
+        [ Types.Text "hello"
+        ; Types.ToolResult
+            { tool_use_id = "tu"; content = "tool text"; is_error = false; json = None }
+        ; Types.Thinking { thinking_type = "sig"; content = "hidden" }
+        ]
+    ; usage = Some usage
+    ; telemetry = None
+    }
+  in
+  Alcotest.(check string)
+    "response text"
+    "hello\ntool text"
+    (Types.text_of_response response);
+  Alcotest.(check (option int))
+    "usage"
+    (Some 1)
+    (Option.map (fun u -> u.Types.input_tokens) (Types.usage_of_response response));
+  Alcotest.(check int) "zero input" 0 Types.zero_api_usage.input_tokens
+;;
+
+let test_validate_tool_result_shape () =
+  let object_result =
+    Types.ToolResult
+      { tool_use_id = "obj"
+      ; content = {|{"ok":true}|}
+      ; is_error = false
+      ; json = Some (`Assoc [ "ok", `Bool true ])
+      }
+  in
+  let array_result =
+    Types.ToolResult
+      { tool_use_id = "arr"
+      ; content = "[1,2]"
+      ; is_error = false
+      ; json = Some (`List [ `Int 1; `Int 2 ])
+      }
+  in
+  let invalid_json_result =
+    Types.ToolResult
+      { tool_use_id = "bad"; content = "not-json"; is_error = false; json = None }
+  in
+  let empty_result =
+    Types.ToolResult
+      { tool_use_id = "empty"; content = " "; is_error = false; json = None }
+  in
+  Alcotest.(check bool)
+    "object ok"
+    true
+    (Result.is_ok
+       (Types.validate_tool_result_shape
+          ~expect_object:true
+          ~expect_array:false
+          object_result));
+  Alcotest.(check bool)
+    "array ok"
+    true
+    (Result.is_ok
+       (Types.validate_tool_result_shape
+          ~expect_object:false
+          ~expect_array:true
+          array_result));
+  Alcotest.(check bool)
+    "both accepts any json"
+    true
+    (Result.is_ok
+       (Types.validate_tool_result_shape
+          ~expect_object:true
+          ~expect_array:true
+          array_result));
+  Alcotest.(check bool)
+    "object expected"
+    true
+    (Result.is_error
+       (Types.validate_tool_result_shape
+          ~expect_object:true
+          ~expect_array:false
+          array_result));
+  Alcotest.(check bool)
+    "array expected"
+    true
+    (Result.is_error
+       (Types.validate_tool_result_shape
+          ~expect_object:false
+          ~expect_array:true
+          object_result));
+  Alcotest.(check bool)
+    "parse error"
+    true
+    (Result.is_error
+       (Types.validate_tool_result_shape
+          ~expect_object:true
+          ~expect_array:false
+          invalid_json_result));
+  Alcotest.(check bool)
+    "empty content"
+    true
+    (Result.is_error
+       (Types.validate_tool_result_shape
+          ~expect_object:false
+          ~expect_array:false
+          empty_result));
+  Alcotest.(check bool)
+    "non tool result ignored"
+    true
+    (Result.is_ok
+       (Types.validate_tool_result_shape
+          ~expect_object:true
+          ~expect_array:false
+          (Types.Text "plain")))
+;;
+
 (* ── Audio content block show ──────────────────────────── *)
 
 let test_show_audio_block () =
@@ -483,6 +711,8 @@ let () =
         ; Alcotest.test_case "tool" `Quick test_tool_choice_tool
         ; Alcotest.test_case "none roundtrip" `Quick test_tool_choice_none
         ] )
+    ; ( "response_format"
+      , [ Alcotest.test_case "json helpers" `Quick test_response_format_json_helpers ] )
     ; ( "usage"
       , [ Alcotest.test_case "add_usage" `Quick test_add_usage
         ; Alcotest.test_case "accumulates" `Quick test_add_usage_accumulates
@@ -556,6 +786,11 @@ let () =
               Alcotest.(check string) "name" "x" decoded.name;
               Alcotest.(check bool) "required" true decoded.required
             | Error msg -> Alcotest.fail ("tool_param_of_yojson: " ^ msg))
+        ; Alcotest.test_case
+            "manual json helpers"
+            `Quick
+            test_tool_param_manual_json_helpers
+        ; Alcotest.test_case "result_all" `Quick test_result_all_helper
         ] )
     ; ( "text_extraction"
       , [ Alcotest.test_case "text only" `Quick test_text_of_content_text_only
@@ -563,6 +798,14 @@ let () =
         ; Alcotest.test_case "tool result" `Quick test_text_of_content_tool_result
         ; Alcotest.test_case "empty" `Quick test_text_of_content_empty
         ; Alcotest.test_case "text_of_message" `Quick test_text_of_message
+        ; Alcotest.test_case
+            "text_of_response and usage"
+            `Quick
+            test_text_of_response_and_usage_helpers
+        ] )
+    ; ( "tool_result_validation"
+      , [ Alcotest.test_case "shape checks" `Quick test_validate_tool_result_shape
+        ; Alcotest.test_case "json detection" `Quick test_tool_result_msg_json_detection
         ] )
     ]
 ;;


### PR DESCRIPTION
Refs #1175

## Summary
- Adds maintained-path coverage for provider bridge/complete transport, context intent, memory/session/runtime evidence, provider runtime binding, type serialization, tool selector, and slot-cache HTTP behavior.
- Fixes provider_f bridge routing by replacing the unreachable substring check with a direct `provider_f` prefix check.
- Raises the CI coverage threshold from 79% to 80% after local full coverage measured 81.01%.
- Avoids adding coverage for deprecated Orchestrator/Collaboration runtime surfaces.

## Validation
- `env MASC_DUNE_THROTTLE=0 BISECT_ENABLE=yes EIO_BACKEND=posix BISECT_FILE=/tmp/oas_stage_g_full_coverage_20260525_4/bisect DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/runtime-server-coverage-20260525/_build_cov_stage_g4 scripts/dune-local.sh runtest --force --instrument-with bisect_ppx`
- `opam exec -- bisect-ppx-report summary --coverage-path=/tmp/oas_stage_g_full_coverage_20260525_4` -> `24098/29746 = 81.01%`
- `git diff --check`
- GitHub checks on latest push: `ratchet` pass, `Boundary Lint (Core->CDAL)` pass, `Draft Auto-Merge Guard` pass.

## Notes
- PR remains draft per repo workflow.
- Draft-triggered CI jobs such as build/lint/format are skipped by workflow policy.
