### PR TITLE
fix: recognize bare GLM model ids in capabilities

### DIFF
--- a/lib/llm_provider/backend_provider_d.ml
+++ b/lib/llm_provider/backend_provider_d.ml
@@ -1255,6 +1255,24 @@ let%test "build_request serializes disabled thinking for provider_g-v4-pro" =
   json |> member "thinking" |> member "type" |> to_string = "disabled"
 ;;
 
+let%test "build_request serializes ZAI thinking object for bare GLM compat model" =
+  let config =
+    Provider_config.make
+      ~kind:Provider_d_compat
+      ~model_id:"glm-5"
+      ~base_url:Zai_catalog.coding_base_url
+      ~enable_thinking:true
+      ~clear_thinking:false
+      ()
+  in
+  let body = build_request ~config ~messages:[] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  json |> member "thinking" |> member "type" |> to_string = "enabled"
+  && json |> member "thinking" |> member "clear_thinking" |> to_bool = false
+  && json |> member "reasoning_effort" = `Null
+;;
+
 let%test "build_request emits reasoning_effort for Provider_d reasoning models" =
   let config =
     Provider_config.make

--- a/lib/llm_provider/backend_provider_d_request.ml
+++ b/lib/llm_provider/backend_provider_d_request.ml
@@ -106,6 +106,11 @@ let capabilities_of_config (config : Provider_config.t) =
      | Provider_config.Provider_d_compat -> Capabilities.default_capabilities)
 ;;
 
+let is_zai_glm_request (config : Provider_config.t) =
+  Zai_catalog.is_zai_base_url config.base_url
+  && Zai_catalog.is_glm_model_id config.model_id
+;;
+
 (** Build Provider_d Chat Completions request body from {!Provider_config.t}.
     Returns a JSON string ready for HTTP POST. *)
 let build_request
@@ -244,6 +249,18 @@ let build_request
          (match enabled, config.thinking_budget with
           | true, Some budget -> ("thinking_budget", `Int budget) :: body
           | _ -> body)
+       | No_thinking_control when is_zai_glm_request config ->
+         let thinking =
+           if enabled
+           then
+             `Assoc
+               [ "type", `String "enabled"
+               ; ( "clear_thinking"
+                 , `Bool (Option.value ~default:true config.clear_thinking) )
+               ]
+           else `Assoc [ "type", `String "disabled" ]
+         in
+         ("thinking", thinking) :: body
        | No_thinking_control -> body)
     | None ->
       (match caps.thinking_control_format with

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -446,12 +446,15 @@ type static_model_route =
   | Provider_e_grok
   | Provider_l of { has_vision : bool }
   | Provider_f_gemma_4 of { has_large_audio : bool }
-  | Glm_flash_air
+  | Glm_4_7_flash
+  | Glm_4_5_flash_air
   | Glm_5_turbo
   | Glm_5v_turbo
   | Glm_ocr
-  | Glm_4_vision_reasoning
+  | Glm_4_6_vision_reasoning
+  | Glm_4_5_vision_reasoning
   | Glm_5_code
+  | Glm_4_5_text
   | Glm_full_text
   | Glm_4_flash
   | Glm_4v
@@ -482,6 +485,10 @@ let provider_f_gemma_4_has_large_audio model_id =
   | Some size_token ->
     List.exists (fun prefix -> String.starts_with ~prefix size_token) [ "27b"; "31b" ]
   | None -> false
+;;
+
+let starts_with_any model_id prefixes =
+  List.exists (fun prefix -> String.starts_with ~prefix model_id) prefixes
 ;;
 
 let static_model_route_of_id model_id =
@@ -544,34 +551,43 @@ let static_model_route_of_id model_id =
       then
         Some
           (Provider_f_gemma_4 { has_large_audio = provider_f_gemma_4_has_large_audio m })
+      else if starts_with_any m [ "provider_k-4.7-flash"; "glm-4.7-flash" ]
+      then Some Glm_4_7_flash
       else if
-        String.starts_with ~prefix:"provider_k-4.7-flash" m
-        || String.starts_with ~prefix:"provider_k-4.5-flash" m
-        || String.starts_with ~prefix:"provider_k-4.5-air" m
-      then Some Glm_flash_air
-      else if String.starts_with ~prefix:"provider_k-5-turbo" m
+        starts_with_any
+          m
+          [ "provider_k-4.5-flash"; "provider_k-4.5-air"; "glm-4.5-flash"; "glm-4.5-air" ]
+      then Some Glm_4_5_flash_air
+      else if starts_with_any m [ "provider_k-5-turbo"; "glm-5-turbo" ]
       then Some Glm_5_turbo
-      else if String.starts_with ~prefix:"provider_k-5v-turbo" m
+      else if starts_with_any m [ "provider_k-5v-turbo"; "glm-5v-turbo" ]
       then Some Glm_5v_turbo
-      else if String.starts_with ~prefix:"provider_k-ocr" m
+      else if starts_with_any m [ "provider_k-ocr"; "glm-ocr" ]
       then Some Glm_ocr
-      else if
-        String.starts_with ~prefix:"provider_k-4.6v" m
-        || String.starts_with ~prefix:"provider_k-4.5v" m
-      then Some Glm_4_vision_reasoning
-      else if String.starts_with ~prefix:"provider_k-5-code" m
+      else if starts_with_any m [ "provider_k-4.6v"; "glm-4.6v" ]
+      then Some Glm_4_6_vision_reasoning
+      else if starts_with_any m [ "provider_k-4.5v"; "glm-4.5v" ]
+      then Some Glm_4_5_vision_reasoning
+      else if starts_with_any m [ "provider_k-5-code"; "glm-5-code" ]
       then Some Glm_5_code
+      else if starts_with_any m [ "provider_k-4.5"; "glm-4.5" ]
+      then Some Glm_4_5_text
       else if
-        String.starts_with ~prefix:"provider_k-4.5" m
-        || String.starts_with ~prefix:"provider_k-4.6" m
-        || String.starts_with ~prefix:"provider_k-4.7" m
-        || String.starts_with ~prefix:"provider_k-5" m
+        starts_with_any
+          m
+          [ "provider_k-4.6"
+          ; "provider_k-4.7"
+          ; "provider_k-5"
+          ; "glm-4.6"
+          ; "glm-4.7"
+          ; "glm-5"
+          ]
       then Some Glm_full_text
-      else if String.starts_with ~prefix:"provider_k-4-flash" m
+      else if starts_with_any m [ "provider_k-4-flash"; "glm-4-flash" ]
       then Some Glm_4_flash
-      else if String.starts_with ~prefix:"provider_k-4v" m
+      else if starts_with_any m [ "provider_k-4v"; "glm-4v" ]
       then Some Glm_4v
-      else if String.starts_with ~prefix:"provider_k-4" m
+      else if starts_with_any m [ "provider_k-4"; "glm-4" ]
       then Some Glm_4
       else None)
 ;;
@@ -764,27 +780,44 @@ let capabilities_of_static_model_route = function
           (* Gemma 4 best practices: place image/audio before text for
            optimal multimodal performance. *)
       }
-    (* Provider_k flash/air variants: faster, no reasoning, smaller output.
-     Must precede the broad provider_k-4.5/4.6/4.7/5 match below. *)
-  | Glm_flash_air ->
+    (* GLM-4.7 Flash/FlashX: official Z.AI GLM-4.7 series docs describe
+       thinking mode with 200K context and 128K max output. Must precede the
+       broad GLM-4.7 match below. *)
+  | Glm_4_7_flash ->
     Some
       { default_capabilities with
-        max_context_tokens = Some 128_000
-      ; max_output_tokens = Some 16_384
-      ; supports_tools = true
-      ; supports_tool_choice = false
-      ; supports_response_format_json = true
-      ; supports_native_streaming = true
-      }
-    (* Provider_k 5-turbo: tool-calling optimized, fast, reasoning but no extended thinking *)
-  | Glm_5_turbo ->
-    Some
-      { default_capabilities with
-        max_context_tokens = Some 128_000
-      ; max_output_tokens = Some 16_384
+        max_context_tokens = Some 200_000
+      ; max_output_tokens = Some 128_000
       ; supports_tools = true
       ; supports_tool_choice = false
       ; supports_reasoning = true
+      ; supports_extended_thinking = true
+      ; supports_response_format_json = true
+      ; supports_native_streaming = true
+      }
+  | Glm_4_5_flash_air ->
+    Some
+      { default_capabilities with
+        max_context_tokens = Some 128_000
+      ; max_output_tokens = Some 96_000
+      ; supports_tools = true
+      ; supports_tool_choice = false
+      ; supports_reasoning = true
+      ; supports_extended_thinking = true
+      ; supports_response_format_json = true
+      ; supports_native_streaming = true
+      }
+    (* GLM-5-Turbo: official docs list Thinking Mode, 200K context, and
+       128K max output. *)
+  | Glm_5_turbo ->
+    Some
+      { default_capabilities with
+        max_context_tokens = Some 200_000
+      ; max_output_tokens = Some 128_000
+      ; supports_tools = true
+      ; supports_tool_choice = false
+      ; supports_reasoning = true
+      ; supports_extended_thinking = true
       ; supports_response_format_json = true
       ; supports_native_streaming = true
       }
@@ -811,11 +844,24 @@ let capabilities_of_static_model_route = function
       ; supports_image_input = true
       ; supports_native_streaming = true
       }
-  | Glm_4_vision_reasoning ->
+  | Glm_4_6_vision_reasoning ->
     Some
       { default_capabilities with
         max_context_tokens = Some 128_000
       ; max_output_tokens = Some 32_768
+      ; supports_tools = true
+      ; supports_tool_choice = false
+      ; supports_reasoning = true
+      ; supports_extended_thinking = true
+      ; supports_multimodal_inputs = true
+      ; supports_image_input = true
+      ; supports_native_streaming = true
+      }
+  | Glm_4_5_vision_reasoning ->
+    Some
+      { default_capabilities with
+        max_context_tokens = Some 128_000
+      ; max_output_tokens = Some 16_384
       ; supports_tools = true
       ; supports_tool_choice = false
       ; supports_reasoning = true
@@ -838,7 +884,20 @@ let capabilities_of_static_model_route = function
       ; supports_response_format_json = true
       ; supports_native_streaming = true
       }
-    (* Provider_k full text models: reasoning, large context/output, but no vision. *)
+  | Glm_4_5_text ->
+    Some
+      { default_capabilities with
+        max_context_tokens = Some 128_000
+      ; max_output_tokens = Some 96_000
+      ; supports_tools = true
+      ; supports_tool_choice = false
+      ; supports_reasoning = true
+      ; supports_extended_thinking = true
+      ; supports_response_format_json = true
+      ; supports_native_streaming = true
+      }
+    (* GLM-4.6/4.7/5/5.1 full text models: reasoning, large context/output,
+       but no vision. *)
   | Glm_full_text ->
     Some
       { default_capabilities with
@@ -1005,7 +1064,11 @@ let for_model_id model_id =
 
 let%test "for_model_id provider_k-4.5 has reasoning" =
   match for_model_id "provider_k-4.5" with
-  | Some c -> c.supports_reasoning && c.max_context_tokens = Some 200_000
+  | Some c ->
+    c.supports_reasoning
+    && c.supports_extended_thinking
+    && c.max_context_tokens = Some 128_000
+    && c.max_output_tokens = Some 96_000
   | None -> false
 ;;
 
@@ -1049,36 +1112,45 @@ let%test "for_model_id provider_k-4.6v stays vision-capable" =
 let%test "for_model_id provider_k-4.5v stays vision-capable" =
   match for_model_id "provider_k-4.5v" with
   | Some c ->
-    c.supports_reasoning && c.supports_image_input && c.max_output_tokens = Some 32_768
+    c.supports_reasoning && c.supports_image_input && c.max_output_tokens = Some 16_384
   | None -> false
 ;;
 
-let%test "for_model_id provider_k-4.7-flashx is flash (no reasoning, 16K output)" =
+let%test "for_model_id provider_k-4.7-flashx has GLM-4.7 thinking limits" =
   match for_model_id "provider_k-4.7-flashx" with
   | Some c ->
-    (not c.supports_reasoning) && c.max_output_tokens = Some 16_384 && c.supports_tools
+    c.supports_reasoning
+    && c.supports_extended_thinking
+    && c.max_context_tokens = Some 200_000
+    && c.max_output_tokens = Some 128_000
+    && c.supports_tools
   | None -> false
 ;;
 
-let%test "for_model_id provider_k-4.7-flash is flash (not broad provider_k-4.7)" =
+let%test "for_model_id provider_k-4.7-flash has thinking" =
   match for_model_id "provider_k-4.7-flash" with
-  | Some c -> (not c.supports_reasoning) && c.max_output_tokens = Some 16_384
+  | Some c -> c.supports_reasoning && c.max_output_tokens = Some 128_000
   | None -> false
 ;;
 
-let%test "for_model_id provider_k-4.5-flash is flash (not broad provider_k-4.5)" =
+let%test "for_model_id provider_k-4.5-flash has GLM-4.5 thinking limits" =
   match for_model_id "provider_k-4.5-flash" with
   | Some c ->
-    (not c.supports_reasoning) && c.max_output_tokens = Some 16_384 && c.supports_tools
+    c.supports_reasoning
+    && c.supports_extended_thinking
+    && c.max_context_tokens = Some 128_000
+    && c.max_output_tokens = Some 96_000
+    && c.supports_tools
   | None -> false
 ;;
 
-let%test "for_model_id provider_k-5-turbo has reasoning but not extended thinking" =
+let%test "for_model_id provider_k-5-turbo has GLM-5 thinking limits" =
   match for_model_id "provider_k-5-turbo" with
   | Some c ->
     c.supports_reasoning
-    && (not c.supports_extended_thinking)
-    && c.max_output_tokens = Some 16_384
+    && c.supports_extended_thinking
+    && c.max_context_tokens = Some 200_000
+    && c.max_output_tokens = Some 128_000
   | None -> false
 ;;
 
@@ -1087,6 +1159,34 @@ let%test "for_model_id provider_k-5.1 full model (reasoning + extended thinking)
   | Some c ->
     c.supports_reasoning
     && c.supports_extended_thinking
+    && c.max_output_tokens = Some 128_000
+  | None -> false
+;;
+
+let%test "for_model_id bare glm-5 full model (reasoning + extended thinking)" =
+  match for_model_id "glm-5" with
+  | Some c ->
+    c.supports_reasoning
+    && c.supports_extended_thinking
+    && c.max_output_tokens = Some 128_000
+  | None -> false
+;;
+
+let%test "for_model_id bare glm-5.1 full model (reasoning + extended thinking)" =
+  match for_model_id "glm-5.1" with
+  | Some c ->
+    c.supports_reasoning
+    && c.supports_extended_thinking
+    && c.max_output_tokens = Some 128_000
+  | None -> false
+;;
+
+let%test "for_model_id bare glm-5-turbo has GLM-5 thinking limits" =
+  match for_model_id "glm-5-turbo" with
+  | Some c ->
+    c.supports_reasoning
+    && c.supports_extended_thinking
+    && c.max_context_tokens = Some 200_000
     && c.max_output_tokens = Some 128_000
   | None -> false
 ;;
@@ -1243,25 +1343,37 @@ let%test "for_model_id: specific model IDs get correct (not shadowed) capabiliti
   List.for_all
     (fun (m, e) -> check m e)
     [ ( "provider_k-4.7-flash-turbo"
-      , fun c -> c.max_output_tokens = Some 16_384 && not c.supports_reasoning )
+      , fun c -> c.max_output_tokens = Some 128_000 && c.supports_extended_thinking )
     ; ( "provider_k-4.5-flash-test"
-      , fun c -> c.max_output_tokens = Some 16_384 && not c.supports_reasoning )
+      , fun c -> c.max_output_tokens = Some 96_000 && c.supports_extended_thinking )
     ; ( "provider_k-5-turbo-latest"
-      , fun c -> c.max_output_tokens = Some 16_384 && not c.supports_extended_thinking )
+      , fun c -> c.max_output_tokens = Some 128_000 && c.supports_extended_thinking )
+    ; ( "glm-5-turbo-latest"
+      , fun c -> c.max_output_tokens = Some 128_000 && c.supports_extended_thinking )
     ; ("provider_k-4.6v-plus", fun c -> c.supports_image_input && c.supports_reasoning)
     ; ( "provider_k-4.7-flash-test"
-      , fun c -> c.max_output_tokens = Some 16_384 && not c.supports_reasoning )
+      , fun c -> c.max_output_tokens = Some 128_000 && c.supports_reasoning )
+    ; ( "glm-4.7-flashx"
+      , fun c -> c.max_output_tokens = Some 128_000 && c.supports_reasoning )
     ; ( "provider_k-4-flash-mini"
       , fun c -> c.max_output_tokens = Some 4_096 && not c.supports_reasoning )
     ; ("provider_k-4v-plus", fun c -> c.supports_image_input)
     ; ( "provider_k-4.5-air-test"
-      , fun c -> c.max_output_tokens = Some 16_384 && not c.supports_reasoning )
+      , fun c -> c.max_output_tokens = Some 96_000 && c.supports_reasoning )
+    ; ( "glm-4.5-air-test"
+      , fun c -> c.max_output_tokens = Some 96_000 && c.supports_reasoning )
     ; ( "provider_k-5v-turbo-latest"
       , fun c ->
           c.supports_image_input
           && c.supports_reasoning
           && c.max_output_tokens = Some 128_000 )
+    ; ( "glm-5v-turbo-latest"
+      , fun c ->
+          c.supports_image_input
+          && c.supports_reasoning
+          && c.max_output_tokens = Some 128_000 )
     ; ("provider_k-ocr-test", fun c -> c.supports_image_input && not c.supports_tools)
+    ; ("glm-ocr-test", fun c -> c.supports_image_input && not c.supports_tools)
     ; ("agent_llm_a-opus-4-20250501", fun c -> c.max_output_tokens = Some 128_000)
     ; ("model-d-4.1-mini", fun c -> c.max_output_tokens = Some 32_000)
     ; ("provider_g-v4-flash-test", fun c -> c.thinking_control_format = Thinking_object)

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -146,12 +146,15 @@ type static_model_route =
   | Provider_e_grok
   | Provider_l of { has_vision : bool }
   | Provider_f_gemma_4 of { has_large_audio : bool }
-  | Glm_flash_air
+  | Glm_4_7_flash
+  | Glm_4_5_flash_air
   | Glm_5_turbo
   | Glm_5v_turbo
   | Glm_ocr
-  | Glm_4_vision_reasoning
+  | Glm_4_6_vision_reasoning
+  | Glm_4_5_vision_reasoning
   | Glm_5_code
+  | Glm_4_5_text
   | Glm_full_text
   | Glm_4_flash
   | Glm_4v

--- a/lib/llm_provider/zai_catalog.ml
+++ b/lib/llm_provider/zai_catalog.ml
@@ -10,7 +10,9 @@ let provider_a_base_url = "https://api.z.ai/api/provider_a"
 
 let is_glm_model_id model_id =
   let m = String.lowercase_ascii (String.trim model_id) in
-  m = "provider_k" || String.starts_with ~prefix:"provider_k-" m
+  m = "provider_k"
+  || String.starts_with ~prefix:"provider_k-" m
+  || String.starts_with ~prefix:"glm-" m
 ;;
 
 let has_prefix value prefix =
@@ -172,9 +174,11 @@ let throttle_key_for_chat ~base_url ~model_id =
 
 [@@@coverage off]
 
-let%test "is_glm_model_id accepts provider_k prefixes only" =
+let%test "is_glm_model_id accepts provider_k and bare glm prefixes" =
   is_glm_model_id "provider_k-5"
   && is_glm_model_id "provider_k"
+  && is_glm_model_id "glm-5"
+  && is_glm_model_id "GLM-4.7-Flash"
   && not (is_glm_model_id "model-d-5")
 ;;
 

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -479,6 +479,62 @@ let test_build_provider_d_body_uses_glm_thinking_and_auto_tool_choice () =
     (json |> member "tool_choice" |> to_string)
 ;;
 
+let test_build_provider_d_body_uses_bare_glm_thinking_and_auto_tool_choice () =
+  let provider_config =
+    { Provider.provider =
+        Provider.OpenAICompat
+          { base_url = Llm_provider.Zai_catalog.general_base_url
+          ; auth_header = None
+          ; path = "/chat/completions"
+          ; static_token = None
+          }
+    ; model_id = "glm-5"
+    ; api_key_env = ""
+    }
+  in
+  let state =
+    { Types.config =
+        { Types.default_config with
+          model = provider_config.model_id
+        ; enable_thinking = Some true
+        ; tool_choice = Some (Types.Tool "calculator")
+        }
+    ; messages = []
+    ; turn_count = 0
+    ; usage = Types.empty_usage
+    }
+  in
+  let tool_json =
+    `Assoc
+      [ "name", `String "calculator"
+      ; "description", `String "math"
+      ; "input_schema", `Assoc [ "type", `String "object" ]
+      ]
+  in
+  let json =
+    Api.build_provider_d_body
+      ~provider_config
+      ~config:state
+      ~messages:[]
+      ~tools:[ tool_json ]
+      ()
+    |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  let thinking = json |> member "thinking" in
+  check string "thinking enabled" "enabled" (thinking |> member "type" |> to_string);
+  check
+    bool
+    "clear_thinking default true"
+    true
+    (thinking |> member "clear_thinking" |> to_bool);
+  check
+    string
+    "bare glm tool choice coerced"
+    "auto"
+    (json |> member "tool_choice" |> to_string)
+;;
+
 let test_build_provider_d_body_glm_preserves_reasoning_content () =
   let provider_config =
     { Provider.provider =
@@ -1426,6 +1482,10 @@ let () =
             "provider_k thinking + auto tool choice"
             `Quick
             test_build_provider_d_body_uses_glm_thinking_and_auto_tool_choice
+        ; test_case
+            "bare glm thinking + auto tool choice"
+            `Quick
+            test_build_provider_d_body_uses_bare_glm_thinking_and_auto_tool_choice
         ; test_case
             "provider_k preserved reasoning replay"
             `Quick

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -176,12 +176,15 @@ let pp_static_model_route ppf = function
     Format.fprintf ppf "Provider_l(has_vision=%b)" has_vision
   | Capabilities.Provider_f_gemma_4 { has_large_audio } ->
     Format.fprintf ppf "Provider_f_gemma_4(has_large_audio=%b)" has_large_audio
-  | Capabilities.Glm_flash_air -> Format.fprintf ppf "Glm_flash_air"
+  | Capabilities.Glm_4_7_flash -> Format.fprintf ppf "Glm_4_7_flash"
+  | Capabilities.Glm_4_5_flash_air -> Format.fprintf ppf "Glm_4_5_flash_air"
   | Capabilities.Glm_5_turbo -> Format.fprintf ppf "Glm_5_turbo"
   | Capabilities.Glm_5v_turbo -> Format.fprintf ppf "Glm_5v_turbo"
   | Capabilities.Glm_ocr -> Format.fprintf ppf "Glm_ocr"
-  | Capabilities.Glm_4_vision_reasoning -> Format.fprintf ppf "Glm_4_vision_reasoning"
+  | Capabilities.Glm_4_6_vision_reasoning -> Format.fprintf ppf "Glm_4_6_vision_reasoning"
+  | Capabilities.Glm_4_5_vision_reasoning -> Format.fprintf ppf "Glm_4_5_vision_reasoning"
   | Capabilities.Glm_5_code -> Format.fprintf ppf "Glm_5_code"
+  | Capabilities.Glm_4_5_text -> Format.fprintf ppf "Glm_4_5_text"
   | Capabilities.Glm_full_text -> Format.fprintf ppf "Glm_full_text"
   | Capabilities.Glm_4_flash -> Format.fprintf ppf "Glm_4_flash"
   | Capabilities.Glm_4v -> Format.fprintf ppf "Glm_4v"
@@ -758,27 +761,7 @@ let test_prefix_ordering_invariant () =
      The predicate is true only when the more-specific (longer-prefix)
      branch wins. *)
   let cases =
-    [ (* provider_k-4.7-flash must precede provider_k-4.7 (inside broad provider_k-4.5|4.6|4.7|5 branch) *)
-      ( "provider_k-4.7-flash-x"
-      , "provider_k-4.7-flash must precede broad provider_k-4.7"
-      , fun (c : Capabilities.capabilities) ->
-          (not c.supports_reasoning) && c.max_output_tokens = Some 16_384 )
-    ; (* provider_k-4.5-flash must precede provider_k-4.5 (inside broad branch) *)
-      ( "provider_k-4.5-flash-x"
-      , "provider_k-4.5-flash must precede broad provider_k-4.5"
-      , fun (c : Capabilities.capabilities) ->
-          (not c.supports_reasoning) && c.max_output_tokens = Some 16_384 )
-    ; (* provider_k-4.5-air must precede provider_k-4.5 (inside broad branch) *)
-      ( "provider_k-4.5-air-x"
-      , "provider_k-4.5-air must precede broad provider_k-4.5"
-      , fun (c : Capabilities.capabilities) ->
-          (not c.supports_reasoning) && c.max_output_tokens = Some 16_384 )
-    ; (* provider_k-5-turbo must precede provider_k-5 (inside broad branch) *)
-      ( "provider_k-5-turbo-x"
-      , "provider_k-5-turbo must precede broad provider_k-5"
-      , fun (c : Capabilities.capabilities) ->
-          (not c.supports_extended_thinking) && c.max_output_tokens = Some 16_384 )
-    ; (* provider_k-5v-turbo must precede provider_k-5 (inside broad branch).
+    [ (* provider_k-5v-turbo must precede provider_k-5 (inside broad branch).
          Discriminator: supports_image_input (5v-turbo) vs not (broad provider_k-5). *)
       ( "provider_k-5v-turbo-x"
       , "provider_k-5v-turbo must precede broad provider_k-5"
@@ -803,13 +786,13 @@ let test_prefix_ordering_invariant () =
       , fun (c : Capabilities.capabilities) ->
           c.supports_image_input
           && c.supports_reasoning
-          && c.max_output_tokens = Some 32_768 )
+          && c.max_output_tokens = Some 16_384 )
     ; (* broad provider_k-4.5 branch must precede provider_k-4.
-         Discriminator: supports_reasoning + 128K output (broad) vs neither (provider_k-4). *)
+         Discriminator: supports_reasoning + 96K output (broad) vs neither (provider_k-4). *)
       ( "provider_k-4.5-latest"
       , "broad provider_k-4.5 branch must precede provider_k-4"
       , fun (c : Capabilities.capabilities) ->
-          c.supports_reasoning && c.max_output_tokens = Some 128_000 )
+          c.supports_reasoning && c.max_output_tokens = Some 96_000 )
     ; (* provider_k-4v must precede provider_k-4.
          Discriminator: supports_image_input (provider_k-4v) vs not (provider_k-4). *)
       ( "provider_k-4v-x"

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -1748,13 +1748,14 @@ let test_for_model_id_grok () =
 ;;
 
 let test_for_model_id_glm () =
-  (* provider_k-4.5-flash now matches the flash-specific entry (128K ctx, 16K out) *)
+  (* provider_k-4.5-flash matches current Z.AI GLM-4.5 thinking limits. *)
   (match Capabilities.for_model_id "provider_k-4.5-flash" with
    | Some c ->
      Alcotest.(check (option int)) "128K context" (Some 128_000) c.max_context_tokens;
-     Alcotest.(check (option int)) "16K output" (Some 16_384) c.max_output_tokens;
+     Alcotest.(check (option int)) "96K output" (Some 96_000) c.max_output_tokens;
      Alcotest.(check bool) "tools" true c.supports_tools;
-     Alcotest.(check bool) "no reasoning" false c.supports_reasoning
+     Alcotest.(check bool) "reasoning" true c.supports_reasoning;
+     Alcotest.(check bool) "thinking" true c.supports_extended_thinking
    | None -> Alcotest.fail "expected Some for provider_k-4.5-flash");
   (* provider_k-5.1 should still get full capabilities *)
   match Capabilities.for_model_id "provider_k-5.1" with

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -840,6 +840,26 @@ let test_model_capability_thinking_drift_remains_warn () =
        entries)
 ;;
 
+let test_bare_glm_model_thinking_uses_model_capability () =
+  let config =
+    PC.make
+      ~kind:Provider_d_compat
+      ~model_id:"glm-5"
+      ~base_url:"https://api.z.ai/api/coding/paas/v4"
+      ()
+  in
+  let entries = complete_with_captured_diag ~config ~response:response_with_thinking in
+  Alcotest.(check bool)
+    "bare glm-5 thinking does not emit capability drift"
+    false
+    (List.exists
+       (fun (_level, ctx, message) ->
+          ctx = "complete"
+          && (contains_substring ~sub:"capability_observation" message
+              || contains_substring ~sub:"capability_drift" message))
+       entries)
+;;
+
 let test_complete_rejects_output_schema_for_glm () =
   Eio_main.run
   @@ fun env ->
@@ -1161,6 +1181,10 @@ let () =
             "model-specific thinking drift remains warn"
             `Quick
             test_model_capability_thinking_drift_remains_warn
+        ; test_case
+            "bare glm thinking uses model capability"
+            `Quick
+            test_bare_glm_model_thinking_uses_model_capability
         ] )
     ; ( "cost"
       , [ test_case "annotate response cost" `Quick test_annotate_response_cost


### PR DESCRIPTION
Summary
- Recognize bare Z.AI GLM model ids (for example glm-5 and glm-5-turbo) anywhere OAS detects GLM/provider_k behavior.
- Refresh GLM-4.5/4.7/5 capability routing for thinking support and current context/output limits from Z.AI docs.
- Ensure ZAI provider_d_compat requests with bare glm-* emit the ZAI thinking object and keep GLM tool_choice/reasoning replay behavior.

Evidence
- Z.AI Thinking Mode docs: https://docs.z.ai/guides/capabilities/thinking-mode
- Z.AI Chat Completion model list: https://docs.z.ai/api-reference/llm/chat-completion
- Z.AI GLM-4.7 docs: https://docs.z.ai/guides/llm/glm-4.7
- Z.AI GLM-4.5 docs: https://docs.z.ai/guides/llm/glm-4.5

Tests
- ocamlformat --check lib/llm_provider/capabilities.ml lib/llm_provider/capabilities.mli lib/llm_provider/zai_catalog.ml lib/llm_provider/backend_provider_d_request.ml lib/llm_provider/backend_provider_d.ml test/test_capabilities.ml test/test_llm_provider_cov.ml test/test_api.ml test/test_provider_complete.ml
- git diff --check
- env OAS_DUNE_ALLOW_BARE_DUNE=1 MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_provider_complete.exe test/test_api.exe test/test_capabilities.exe test/test_llm_provider_cov.exe @lib/llm_provider/runtest
- ./_build/default/test/test_provider_complete.exe
- ./_build/default/test/test_api.exe
- ./_build/default/test/test_capabilities.exe
- ./_build/default/test/test_llm_provider_cov.exe