### PR TITLE
fix(pipeline): reuse accumulated usage in collect stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,9 @@ jobs:
       - name: Forbid legacy pipeline stage modules
         run: bash scripts/lint-legacy-pipeline-stages.sh
 
+      - name: Enforce pipeline usage accumulator SSOT
+        run: bash scripts/lint-pipeline-usage-ssot.sh
+
   lint:
     name: Lint
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -414,11 +414,7 @@ let stage_collect ?raw_trace_run agent ~original_config response =
     { state with
       messages = Util.snoc state.messages assistant_message
     ; turn_count = state.turn_count + 1
-    ; usage =
-        Agent_turn.accumulate_usage
-          ~current_usage:state.usage
-          ~provider:agent.options.provider
-          ~response_usage:response.usage
+    ; usage
     });
   (match agent.options.event_bus with
    | Some bus ->

--- a/scripts/lint-pipeline-usage-ssot.sh
+++ b/scripts/lint-pipeline-usage-ssot.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="${1:-lib/pipeline/pipeline.ml}"
+
+if [[ ! -f "$file" ]]; then
+  echo "lint-pipeline-usage-ssot: missing file: $file" >&2
+  exit 1
+fi
+
+count="$(
+  awk '
+    /^let stage_collect/ { in_stage = 1 }
+    in_stage && /Agent_turn\.accumulate_usage/ { count++ }
+    in_stage && /^let handle_missing_required_tool_use/ { in_stage = 0 }
+    END { print count + 0 }
+  ' "$file"
+)"
+
+if [[ "$count" != "1" ]]; then
+  cat >&2 <<EOF
+lint-pipeline-usage-ssot: expected exactly one Agent_turn.accumulate_usage call in stage_collect, found $count.
+
+stage_collect must compute usage once and reuse that value for both the crash-recovery
+checkpoint and the live state update. Calling the accumulator twice can split the
+usage SSOT when pricing/accounting logic changes.
+EOF
+  exit 1
+fi
+
+echo "lint-pipeline-usage-ssot: clean"


### PR DESCRIPTION
## Summary

- Reuse the single `usage` value computed in `stage_collect` for both checkpoint persistence and the live state update.
- Add `scripts/lint-pipeline-usage-ssot.sh` and wire it into the fast boundary lint job so `stage_collect` cannot regain a second `Agent_turn.accumulate_usage` call.

## Report linkage

- Addresses the integrated masc/oas report finding under `GOAL-FIX-01`: duplicate `accumulate_usage` call in `pipeline.ml`.

## Evidence

- `bash scripts/lint-pipeline-usage-ssot.sh`
- `bash -n scripts/lint-pipeline-usage-ssot.sh`
- `opam exec -- ocamlformat --check lib/pipeline/pipeline.ml`
- `git diff --cached --check`

## Local validation note

Focused Dune build was attempted with `scripts/dune-local.sh build test/test_agent_pipeline.exe`, but it waited behind the shared `/tmp/me-dune-local.lock` and multiple unrelated long-running Dune jobs. I stopped the queued local build to avoid adding more contention; PR CI should perform the heavy build/test pass.
