### PR TITLE
fix(agent): hydrate relocated tool results on resume

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -492,6 +492,15 @@ let resume
     | Some p -> { state with config = { state.config with priority = Some p } }
     | None -> state
   in
+  let options =
+    match options.tool_result_relocation with
+    | None -> options
+    | Some (store, _) ->
+      { options with
+        tool_result_relocation =
+          Some (store, Content_replacement_state.restore_from_context ctx)
+      }
+  in
   { mu = Eio.Mutex.create ()
   ; state
   ; lifecycle = None

--- a/test/test_session_resume.ml
+++ b/test/test_session_resume.ml
@@ -310,6 +310,77 @@ let test_resume_custom_options () =
     (Agent.options agent).base_url
 ;;
 
+let test_resume_restores_tool_result_relocation_state () =
+  with_net
+  @@ fun net ->
+  let checkpoint_context = Context.create () in
+  let checkpoint_crs = Content_replacement_state.create () in
+  Content_replacement_state.record_replacement
+    checkpoint_crs
+    { tool_use_id = "t1"; preview = "cached-preview"; original_chars = 4096 };
+  Content_replacement_state.record_kept checkpoint_crs "t2";
+  Content_replacement_state.persist_to_context checkpoint_context checkpoint_crs;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "oas_resume_reloc_%d" (Unix.getpid ()))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let store_ref = ref None in
+  Fun.protect
+    ~finally:(fun () ->
+      Option.iter (fun store -> ignore (Tool_result_store.cleanup store)) !store_ref;
+      try Unix.rmdir dir with
+      | _ -> ())
+    (fun () ->
+       let store =
+         Tool_result_store.create
+           { storage_dir = dir
+           ; session_id = "resume"
+           ; threshold_chars = 100
+           ; preview_chars = 50
+           ; aggregate_budget = 0
+           }
+         |> Result.get_ok
+       in
+       store_ref := Some store;
+       let supplied_crs = Content_replacement_state.create () in
+       let opts =
+         { Agent.default_options with
+           tool_result_relocation = Some (store, supplied_crs)
+         }
+       in
+       let cp = make_checkpoint ~context:checkpoint_context () in
+       let agent = Agent.resume ~net ~checkpoint:cp ~options:opts () in
+       match (Agent.options agent).tool_result_relocation with
+       | None -> Alcotest.fail "expected tool_result_relocation option"
+       | Some (_, restored_crs) ->
+         Alcotest.(check int)
+           "restored seen_count"
+           2
+           (Content_replacement_state.seen_count restored_crs);
+         Alcotest.(check bool)
+           "restored replacement frozen"
+           true
+           (Content_replacement_state.is_frozen restored_crs "t1");
+         Alcotest.(check bool)
+           "restored kept frozen"
+           true
+           (Content_replacement_state.is_frozen restored_crs "t2");
+         Alcotest.(check int)
+           "caller-supplied empty CRS unchanged"
+           0
+           (Content_replacement_state.seen_count supplied_crs);
+         (match Content_replacement_state.lookup_replacement restored_crs "t1" with
+          | Some replacement ->
+            Alcotest.(check string)
+              "restored preview"
+              "cached-preview"
+              replacement.preview
+          | None -> Alcotest.fail "expected restored replacement"))
+;;
+
 let test_resume_with_config_override () =
   with_net
   @@ fun net ->
@@ -462,6 +533,10 @@ let () =
         ; test_case "with tools" `Quick test_resume_with_tools
         ; test_case "default options" `Quick test_resume_default_options
         ; test_case "custom options" `Quick test_resume_custom_options
+        ; test_case
+            "restores tool_result_relocation state"
+            `Quick
+            test_resume_restores_tool_result_relocation_state
         ; test_case "config override" `Quick test_resume_with_config_override
         ; test_case "empty checkpoint" `Quick test_resume_empty_checkpoint
         ; test_case


### PR DESCRIPTION
## Summary

- Hydrate `tool_result_relocation` state from checkpoint context during `Agent.resume`.
- Preserve the caller-owned `Tool_result_store.t` while replacing the empty/stale `Content_replacement_state.t` with `Content_replacement_state.restore_from_context ctx`.
- Add a regression test proving restored replacement and kept decisions survive resume.

## Report linkage

- Addresses the integrated masc/oas report finding under `GOAL-FIX-01`: checkpoint restore missed `tool_result_relocation` state.

## Evidence

- `opam exec -- ocamlformat --check lib/agent/agent.ml test/test_session_resume.ml`
- `git diff --check`

## Local validation note

Focused Dune build was attempted with `scripts/dune-local.sh build test/test_session_resume.exe`, but it remained queued behind the shared `/tmp/me-dune-local.lock` and unrelated long-running Dune jobs. The queued local build was not completed; PR CI should perform the heavy build/test pass.
