### PR TITLE
fix(agent): publish content replacement events by default

### DIFF
--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -617,21 +617,31 @@ let update_idle_detection ~idle_state ~tool_uses =
     Pass [~max_result_chars:0] to disable. *)
 let default_max_tool_result_chars = 50_000
 
-let record_replacement_or_ignore ?event_bus crs replacement =
+let record_replacement_or_ignore ?event_bus ?correlation_id ?run_id crs replacement =
   try
     match event_bus with
     | Some bus ->
-      Content_replacement_event_bridge.record_replacement_with_events bus crs replacement
+      Content_replacement_event_bridge.record_replacement_with_events
+        ?correlation_id
+        ?run_id
+        bus
+        crs
+        replacement
     | None -> Content_replacement_state.record_replacement crs replacement
   with
   | Invalid_argument _ -> ()
 ;;
 
-let record_kept_or_ignore ?event_bus crs tool_use_id =
+let record_kept_or_ignore ?event_bus ?correlation_id ?run_id crs tool_use_id =
   try
     match event_bus with
     | Some bus ->
-      Content_replacement_event_bridge.record_kept_with_events bus crs tool_use_id
+      Content_replacement_event_bridge.record_kept_with_events
+        ?correlation_id
+        ?run_id
+        bus
+        crs
+        tool_use_id
     | None -> Content_replacement_state.record_kept crs tool_use_id
   with
   | Invalid_argument _ -> ()
@@ -672,6 +682,8 @@ let warn_tool_result_persist_failed ~phase ~tool_use_id ~content_chars err =
 let make_tool_results
       ?(max_result_chars = default_max_tool_result_chars)
       ?event_bus
+      ?correlation_id
+      ?run_id
       ?relocation
       results
   =
@@ -733,6 +745,8 @@ let make_tool_results
                | Ok preview ->
                  record_replacement_or_ignore
                    ?event_bus
+                   ?correlation_id
+                   ?run_id
                    crs
                    { tool_use_id = result.tool_use_id
                    ; preview
@@ -745,7 +759,12 @@ let make_tool_results
                    ~tool_use_id:result.tool_use_id
                    ~content_chars:(String.length sanitized)
                    err;
-                 record_kept_or_ignore ?event_bus crs result.tool_use_id;
+                 record_kept_or_ignore
+                   ?event_bus
+                   ?correlation_id
+                   ?run_id
+                   crs
+                   result.tool_use_id;
                  sanitized
              in
              result.tool_use_id, content, result.is_error, false)
@@ -810,6 +829,8 @@ let make_tool_results
                | Ok preview ->
                  record_replacement_or_ignore
                    ?event_bus
+                   ?correlation_id
+                   ?run_id
                    crs
                    { tool_use_id = tid; preview; original_chars = String.length original };
                  preview
@@ -819,11 +840,11 @@ let make_tool_results
                    ~tool_use_id:tid
                    ~content_chars:(String.length original)
                    err;
-                 record_kept_or_ignore ?event_bus crs tid;
+                 record_kept_or_ignore ?event_bus ?correlation_id ?run_id crs tid;
                  content)
              else (
                (* Under budget — record as kept *)
-               record_kept_or_ignore ?event_bus crs tid;
+               record_kept_or_ignore ?event_bus ?correlation_id ?run_id crs tid;
                content)
            else content
          in

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -617,13 +617,23 @@ let update_idle_detection ~idle_state ~tool_uses =
     Pass [~max_result_chars:0] to disable. *)
 let default_max_tool_result_chars = 50_000
 
-let record_replacement_or_ignore crs replacement =
-  try Content_replacement_state.record_replacement crs replacement with
+let record_replacement_or_ignore ?event_bus crs replacement =
+  try
+    match event_bus with
+    | Some bus ->
+      Content_replacement_event_bridge.record_replacement_with_events bus crs replacement
+    | None -> Content_replacement_state.record_replacement crs replacement
+  with
   | Invalid_argument _ -> ()
 ;;
 
-let record_kept_or_ignore crs tool_use_id =
-  try Content_replacement_state.record_kept crs tool_use_id with
+let record_kept_or_ignore ?event_bus crs tool_use_id =
+  try
+    match event_bus with
+    | Some bus ->
+      Content_replacement_event_bridge.record_kept_with_events bus crs tool_use_id
+    | None -> Content_replacement_state.record_kept crs tool_use_id
+  with
   | Invalid_argument _ -> ()
 ;;
 
@@ -661,6 +671,7 @@ let warn_tool_result_persist_failed ~phase ~tool_use_id ~content_chars err =
     @since 0.128.0 (Phase 1), 0.129.0 (Phase 2 aggregate budget) *)
 let make_tool_results
       ?(max_result_chars = default_max_tool_result_chars)
+      ?event_bus
       ?relocation
       results
   =
@@ -721,6 +732,7 @@ let make_tool_results
                with
                | Ok preview ->
                  record_replacement_or_ignore
+                   ?event_bus
                    crs
                    { tool_use_id = result.tool_use_id
                    ; preview
@@ -733,7 +745,7 @@ let make_tool_results
                    ~tool_use_id:result.tool_use_id
                    ~content_chars:(String.length sanitized)
                    err;
-                 record_kept_or_ignore crs result.tool_use_id;
+                 record_kept_or_ignore ?event_bus crs result.tool_use_id;
                  sanitized
              in
              result.tool_use_id, content, result.is_error, false)
@@ -797,6 +809,7 @@ let make_tool_results
                with
                | Ok preview ->
                  record_replacement_or_ignore
+                   ?event_bus
                    crs
                    { tool_use_id = tid; preview; original_chars = String.length original };
                  preview
@@ -806,11 +819,11 @@ let make_tool_results
                    ~tool_use_id:tid
                    ~content_chars:(String.length original)
                    err;
-                 record_kept_or_ignore crs tid;
+                 record_kept_or_ignore ?event_bus crs tid;
                  content)
              else (
                (* Under budget — record as kept *)
-               record_kept_or_ignore crs tid;
+               record_kept_or_ignore ?event_bus crs tid;
                content)
            else content
          in

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -251,6 +251,7 @@ val default_max_tool_result_chars : int
     @since 0.128.0 added [relocation] parameter *)
 val make_tool_results
   :  ?max_result_chars:int
+  -> ?event_bus:Event_bus.t
   -> ?relocation:Tool_result_store.t * Content_replacement_state.t
   -> Agent_tools.tool_execution_result list
   -> Types.content_block list

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -252,6 +252,8 @@ val default_max_tool_result_chars : int
 val make_tool_results
   :  ?max_result_chars:int
   -> ?event_bus:Event_bus.t
+  -> ?correlation_id:string
+  -> ?run_id:string
   -> ?relocation:Tool_result_store.t * Content_replacement_state.t
   -> Agent_tools.tool_execution_result list
   -> Types.content_block list

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -613,6 +613,7 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
       let* results = results in
       let tool_results =
         Agent_turn.make_tool_results
+          ?event_bus:agent.options.event_bus
           ?relocation:agent.options.tool_result_relocation
           results
       in

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -611,9 +611,12 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
           Error err
       in
       let* results = results in
+      let tool_result_event_envelope = Pipeline_common.event_envelope agent in
       let tool_results =
         Agent_turn.make_tool_results
           ?event_bus:agent.options.event_bus
+          ~correlation_id:tool_result_event_envelope.correlation_id
+          ~run_id:tool_result_event_envelope.run_id
           ?relocation:agent.options.tool_result_relocation
           results
       in

--- a/test/test_tool_result_relocation.ml
+++ b/test/test_tool_result_relocation.ml
@@ -298,6 +298,8 @@ let test_make_tool_results_persist_failure_freezes_kept () =
 ;;
 
 let test_make_tool_results_publishes_content_replacement_events () =
+  Eio_main.run
+  @@ fun _env ->
   let dir = tmp_dir () in
   let config : Tool_result_store.config =
     { storage_dir = dir
@@ -329,16 +331,29 @@ let test_make_tool_results_publishes_content_replacement_events () =
     ]
   in
   let _blocks =
-    Agent_turn.make_tool_results ~event_bus:bus ~relocation:(store, crs) mock_results
+    Agent_turn.make_tool_results
+      ~event_bus:bus
+      ~correlation_id:"corr-events"
+      ~run_id:"run-events"
+      ~relocation:(store, crs)
+      mock_results
   in
   let events = Event_bus.drain sub in
   Alcotest.(check int) "events published" 2 (List.length events);
+  List.iter
+    (fun (event : Event_bus.event) ->
+       Alcotest.(check string)
+         "correlation propagated"
+         "corr-events"
+         event.Event_bus.meta.correlation_id;
+       Alcotest.(check string) "run propagated" "run-events" event.Event_bus.meta.run_id)
+    events;
   Alcotest.(check bool)
     "replacement event emitted"
     true
     (List.exists
-       (fun event ->
-          match event.payload with
+       (fun (event : Event_bus.event) ->
+          match event.Event_bus.payload with
           | Event_bus.ContentReplacementReplaced payload ->
             String.equal payload.tool_use_id "big"
             && payload.original_chars = 40
@@ -349,8 +364,8 @@ let test_make_tool_results_publishes_content_replacement_events () =
     "kept event emitted"
     true
     (List.exists
-       (fun event ->
-          match event.payload with
+       (fun (event : Event_bus.event) ->
+          match event.Event_bus.payload with
           | Event_bus.ContentReplacementKept payload ->
             String.equal payload.tool_use_id "small" && payload.seen_count_after >= 1
           | _ -> false)

--- a/test/test_tool_result_relocation.ml
+++ b/test/test_tool_result_relocation.ml
@@ -297,6 +297,68 @@ let test_make_tool_results_persist_failure_freezes_kept () =
   rm_rf dir
 ;;
 
+let test_make_tool_results_publishes_content_replacement_events () =
+  let dir = tmp_dir () in
+  let config : Tool_result_store.config =
+    { storage_dir = dir
+    ; session_id = "events"
+    ; threshold_chars = 10
+    ; preview_chars = 5
+    ; aggregate_budget = 0
+    }
+  in
+  let store = Tool_result_store.create config |> Result.get_ok in
+  let crs = Content_replacement_state.create () in
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  let mock_results : Agent_tools.tool_execution_result list =
+    [ { tool_use_id = "big"
+      ; tool_name = "read"
+      ; content = String.make 40 'x'
+      ; is_error = false
+      ; failure_kind = None
+      ; error_class = None
+      }
+    ; { tool_use_id = "small"
+      ; tool_name = "echo"
+      ; content = "ok"
+      ; is_error = false
+      ; failure_kind = None
+      ; error_class = None
+      }
+    ]
+  in
+  let _blocks =
+    Agent_turn.make_tool_results ~event_bus:bus ~relocation:(store, crs) mock_results
+  in
+  let events = Event_bus.drain sub in
+  Alcotest.(check int) "events published" 2 (List.length events);
+  Alcotest.(check bool)
+    "replacement event emitted"
+    true
+    (List.exists
+       (fun event ->
+          match event.payload with
+          | Event_bus.ContentReplacementReplaced payload ->
+            String.equal payload.tool_use_id "big"
+            && payload.original_chars = 40
+            && payload.seen_count_after >= 1
+          | _ -> false)
+       events);
+  Alcotest.(check bool)
+    "kept event emitted"
+    true
+    (List.exists
+       (fun event ->
+          match event.payload with
+          | Event_bus.ContentReplacementKept payload ->
+            String.equal payload.tool_use_id "small" && payload.seen_count_after >= 1
+          | _ -> false)
+       events);
+  let _ = Tool_result_store.cleanup store in
+  rm_rf dir
+;;
+
 (* ── 4. Compaction + relocation compose ───────────────── *)
 
 let test_compaction_preserves_relocated_previews () =
@@ -631,6 +693,10 @@ let () =
             "persist failure freezes kept"
             `Quick
             test_make_tool_results_persist_failure_freezes_kept
+        ; Alcotest.test_case
+            "publishes content replacement events"
+            `Quick
+            test_make_tool_results_publishes_content_replacement_events
         ] )
     ; ( "compaction_compose"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary

- Wire the existing `Content_replacement_event_bridge` into the default tool-result relocation path.
- Pass the agent event bus from `pipeline.ml` into `Agent_turn.make_tool_results`.
- Add a regression test proving relocation emits both `ContentReplacementReplaced` and `ContentReplacementKept` events.

## Report linkage

- Addresses the integrated masc/oas report finding under `GOAL-FIX-01`: `content_replacement_event_bridge.ml` existed as opt-in only and was not connected to the default pipeline path.

## Evidence

- `opam exec -- ocamlformat --check lib/agent/agent_turn.ml lib/agent/agent_turn.mli lib/pipeline/pipeline.ml test/test_tool_result_relocation.ml`
- `git diff --check`
- `opam exec -- ocamldep -modules lib/agent/agent_turn.ml lib/pipeline/pipeline.ml test/test_tool_result_relocation.ml`

## Local validation note

Focused Dune build was attempted with a short shared-lock timeout:
`lockf -t 5 /tmp/me-dune-local.lock /usr/bin/env MASC_DUNE_LOCK_HELD=1 scripts/dune-local.sh build test/test_tool_result_relocation.exe`.
The lock was already held, so the command exited cleanly without queuing. PR CI should perform the heavy build/test pass.
