### PR TITLE
fix(spec): include input-required runtime phase

### DIFF
--- a/specs/AgentCancellation.tla
+++ b/specs/AgentCancellation.tla
@@ -2,8 +2,8 @@
 (* Models Runtime.phase's Cancelled state and Eio.Cancel.Cancelled reraise
    behaviour across the OAS codebase.
 
-   Runtime.phase alphabet (7 states):
-     Bootstrapping, Running, Waiting_on_workers, Finalizing,
+   Runtime.phase alphabet (8 states):
+     Bootstrapping, Running, Input_required, Waiting_on_workers, Finalizing,
      Completed, Failed, Cancelled
 
    Cancellation propagation contract (lib/eval_baseline.ml:80,
@@ -32,10 +32,11 @@ VARIABLES
 
 vars == <<phase, prev_phase, cancel_count, absorbed>>
 
-Phases == {"Bootstrapping", "Running", "Waiting_on_workers",
+Phases == {"Bootstrapping", "Running", "Input_required", "Waiting_on_workers",
            "Finalizing", "Completed", "Failed", "Cancelled"}
 
-NonTerminal == {"Bootstrapping", "Running", "Waiting_on_workers", "Finalizing"}
+NonTerminal == {"Bootstrapping", "Running", "Input_required",
+                "Waiting_on_workers", "Finalizing"}
 Terminal == {"Completed", "Failed", "Cancelled"}
 
 (* ── Type invariant ─────────────────────────────────────── *)
@@ -65,7 +66,15 @@ NormalBootstrapping ==
     /\ phase = "Bootstrapping"
     /\ TransitionTo("Running")
 
-NormalRunning ==
+NormalRunningToInput ==
+    /\ phase = "Running"
+    /\ TransitionTo("Input_required")
+
+NormalInputRequired ==
+    /\ phase = "Input_required"
+    /\ TransitionTo("Running")
+
+NormalRunningToWorkers ==
     /\ phase = "Running"
     /\ TransitionTo("Waiting_on_workers")
 
@@ -80,7 +89,9 @@ NormalFinalizing ==
 NormalTransition ==
     /\ ~absorbed
     /\ (NormalBootstrapping
-        \/ NormalRunning
+        \/ NormalRunningToInput
+        \/ NormalInputRequired
+        \/ NormalRunningToWorkers
         \/ NormalWaiting
         \/ NormalFinalizing)
 

--- a/test/test_agent_cancellation_tla_parity.ml
+++ b/test/test_agent_cancellation_tla_parity.ml
@@ -45,6 +45,7 @@ let terminal_is_stable ~prev_phase ~phase =
 (* Mirror of TLA+ CancelledIsTerminal *)
 let cancelled_is_terminal () = List.mem Runtime.Cancelled terminal_phases
 let phase_count_matches () = List.length all_phases = 8
+let non_terminal_count_matches () = List.length non_terminal_phases = 5
 let terminal_count_matches () = List.length terminal_phases = 3
 
 let () =
@@ -55,6 +56,8 @@ let () =
             Alcotest.(check bool) "8 phases" true (phase_count_matches ()))
         ; Alcotest.test_case "terminal count is 3" `Quick (fun () ->
             Alcotest.(check bool) "3 terminal" true (terminal_count_matches ()))
+        ; Alcotest.test_case "non-terminal count is 5" `Quick (fun () ->
+            Alcotest.(check bool) "5 non-terminal" true (non_terminal_count_matches ()))
         ; Alcotest.test_case "Cancelled is terminal" `Quick (fun () ->
             Alcotest.(check bool) "cancelled terminal" true (cancelled_is_terminal ()))
         ; Alcotest.test_case


### PR DESCRIPTION
## Summary

- align `specs/AgentCancellation.tla` with the current `Runtime.phase` alphabet by adding `Input_required`
- model the normal `Running -> Input_required -> Running` pause/resume path
- extend the OCaml parity test to assert the 5 non-terminal runtime phases

## Evidence

- `opam exec -- ocamlformat --check test/test_agent_cancellation_tla_parity.ml`: passed.
- `java -cp /private/tmp/tla2tools-1.8.0.jar tlc2.TLC -config specs/AgentCancellation.cfg specs/AgentCancellation.tla`: passed.
- `java -cp /private/tmp/tla2tools-1.8.0.jar tlc2.TLC -config specs/AgentCancellation-buggy.cfg specs/AgentCancellation.tla`: failed with invariant violation as expected, exit 12.
- `lockf -t 5 /tmp/me-dune-local.lock env MASC_DUNE_THROTTLE=0 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_agent_cancellation_tla_parity.exe`: passed.
- `lockf -t 5 /tmp/me-dune-local.lock env MASC_DUNE_THROTTLE=0 DUNE_CACHE=disabled scripts/dune-local.sh exec ./test/test_agent_cancellation_tla_parity.exe`: passed.
- `git diff --check`: passed.

## Notes

This does not introduce a direct `Runtime.phase` to `Agent_lifecycle.lifecycle_status` mapping. Those remain separate session-level and agent-level state machines; this PR fixes the TLA parity drift in the session-level runtime phase model.
