### PR TITLE
fix(agent_tools): preserve optional absence in correction

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -112,6 +112,12 @@ let recoverable_of_failure_kind = function
   | Some Non_retryable_tool_error | None -> false
 ;;
 
+let json_object_keys_for_log = function
+  | `Assoc fields ->
+    fields |> List.map fst |> List.sort_uniq String.compare |> String.concat ","
+  | _ -> "-"
+;;
+
 let tool_exception_result ~id ~name exn =
   let msg = Printf.sprintf "Tool '%s' raised: %s" name (Printexc.to_string exn) in
   { tool_use_id = id
@@ -275,10 +281,12 @@ let find_and_execute_tool_with_index
              : Hooks.hook_decision)
         in
         (* Multi-stage deterministic correction before execution.
-       Correction_pipeline runs 3 stages (type coercion, default injection,
-       format normalization) then validates. If det correction fixes the
-       input, skip the LLM retry path entirely. If still invalid, fall back
-       to Tool_middleware.validate_and_coerce for structured error feedback.
+       Correction_pipeline runs safe default stages (type coercion and format
+       normalization) then validates. Optional zero-default injection is
+       opt-in because adding absent optional fields can change a tool-call
+       union branch. If det correction fixes the input, skip the LLM retry
+       path entirely. If still invalid, fall back to
+       Tool_middleware.validate_and_coerce for structured error feedback.
        Ref: Samchon function calling harness (6.75% → 100%). *)
         let validated_input =
           match Correction_pipeline.run ~schema:tool.schema input with
@@ -297,6 +305,24 @@ let find_and_execute_tool_with_index
                 |> List.sort_uniq String.compare
                 |> String.concat ","
               in
+              let added_fields =
+                corrections
+                |> List.filter_map (fun (c : Correction_pipeline.correction) ->
+                  match c.from_value with
+                  | None -> Some c.field
+                  | Some _ -> None)
+                |> List.sort_uniq String.compare
+                |> String.concat ","
+              in
+              let changed_fields =
+                corrections
+                |> List.filter_map (fun (c : Correction_pipeline.correction) ->
+                  match c.from_value with
+                  | Some _ -> Some c.field
+                  | None -> None)
+                |> List.sort_uniq String.compare
+                |> String.concat ","
+              in
               Log.info
                 _log
                 "correction_pipeline fixed tool input fields"
@@ -304,6 +330,10 @@ let find_and_execute_tool_with_index
                 ; Log.I ("fixes", List.length corrections)
                 ; Log.S ("fields", field_names)
                 ; Log.S ("stages", stage_names)
+                ; Log.S ("input_keys", json_object_keys_for_log input)
+                ; Log.S ("corrected_keys", json_object_keys_for_log corrected)
+                ; Log.S ("added_fields", added_fields)
+                ; Log.S ("changed_fields", changed_fields)
                 ]);
             Ok corrected
           | Correction_pipeline.Still_invalid { errors; attempted } ->

--- a/lib/correction_pipeline.ml
+++ b/lib/correction_pipeline.ml
@@ -128,7 +128,9 @@ let format_normalization_stage = make_format_normalization_stage ()
 
 (* ── Default pipeline ───────────────────────────────────── *)
 
-let default_stages =
+let default_stages = [ coercion_stage; format_normalization_stage ]
+
+let zero_default_stages =
   [ coercion_stage; default_injection_stage; format_normalization_stage ]
 ;;
 

--- a/lib/correction_pipeline.mli
+++ b/lib/correction_pipeline.mli
@@ -4,10 +4,14 @@
     LLM retry. Enforces the Det/NonDet boundary at the function signature level:
     {!build_nondet_feedback} requires errors from a failed deterministic run.
 
-    Stage ordering (most specific first):
+    Default stage ordering (most specific first):
     1. Type coercion — delegates to {!Tool_input_validation.try_coerce}
-    2. Default injection — fills missing optional fields from schema
-    3. Format normalization — trims whitespace from string values
+    2. Format normalization — trims whitespace from string values
+
+    Zero-default injection remains available as an explicit stage for callers
+    that own a closed input shape. It is not part of the default pipeline
+    because optional fields can participate in discriminated tool-call unions,
+    where adding a missing optional field changes the caller-selected branch.
 
     Inspired by Typia's 3-layer harness (lenient parse → coercion → feedback).
 
@@ -69,8 +73,18 @@ val make_format_normalization_stage
   -> unit
   -> stage
 
-(** The default pipeline: [coercion; default_injection; format_normalization]. *)
+(** The default pipeline: [coercion; format_normalization].
+
+    Missing optional fields remain absent unless the caller opts into
+    {!zero_default_stages} or passes {!default_injection_stage} explicitly. *)
 val default_stages : stage list
+
+(** Legacy zero-value pipeline:
+    [coercion; default_injection; format_normalization].
+
+    Use only when absent optional fields are semantically equivalent to zero
+    values for the target tool. *)
+val zero_default_stages : stage list
 
 (** {1 Pipeline execution} *)
 

--- a/test/test_correction_pipeline.ml
+++ b/test/test_correction_pipeline.ml
@@ -18,6 +18,23 @@ let bool_param name required : Types.tool_param =
   { name; description = ""; param_type = Boolean; required }
 ;;
 
+let array_param name required : Types.tool_param =
+  { name; description = ""; param_type = Array; required }
+;;
+
+let object_param name required : Types.tool_param =
+  { name; description = ""; param_type = Object; required }
+;;
+
+let number_param name required : Types.tool_param =
+  { name; description = ""; param_type = Number; required }
+;;
+
+let has_object_key key = function
+  | `Assoc fields -> List.mem_assoc key fields
+  | _ -> false
+;;
+
 (* ── Stage 1: Coercion ──────────────────────────────────── *)
 
 let test_coercion_string_to_int () =
@@ -55,7 +72,9 @@ let test_coercion_impossible () =
 let test_default_missing_optional () =
   let schema = make_schema [ str_param "name" true; str_param "format" false ] in
   let input = `Assoc [ "name", `String "test" ] in
-  match Correction_pipeline.run ~schema input with
+  match
+    Correction_pipeline.run ~schema ~stages:Correction_pipeline.zero_default_stages input
+  with
   | Fixed { corrected; corrections } ->
     let format = Yojson.Safe.Util.(corrected |> member "format" |> to_string) in
     Alcotest.(check string) "default injected" "" format;
@@ -65,6 +84,19 @@ let test_default_missing_optional () =
       (List.exists
          (fun c -> c.Correction_pipeline.stage = "default_injection")
          corrections)
+  | Still_invalid _ -> Alcotest.fail "expected Fixed"
+;;
+
+let test_default_pipeline_preserves_missing_optional () =
+  let schema = make_schema [ str_param "name" true; str_param "format" false ] in
+  let input = `Assoc [ "name", `String "test" ] in
+  match Correction_pipeline.run ~schema input with
+  | Fixed { corrected; corrections } ->
+    Alcotest.(check bool)
+      "format remains absent"
+      false
+      (has_object_key "format" corrected);
+    Alcotest.(check int) "no correction" 0 (List.length corrections)
   | Still_invalid _ -> Alcotest.fail "expected Fixed"
 ;;
 
@@ -84,7 +116,9 @@ let test_default_no_inject_if_present () =
 
 let test_default_null_input () =
   let schema = make_schema [ str_param "opt" false ] in
-  match Correction_pipeline.run ~schema `Null with
+  match
+    Correction_pipeline.run ~schema ~stages:Correction_pipeline.zero_default_stages `Null
+  with
   | Fixed { corrected; _ } ->
     (match corrected with
      | `Assoc _ -> () (* null treated as empty object with defaults *)
@@ -108,14 +142,42 @@ let test_format_trim_whitespace () =
 
 let test_multi_stage_correction () =
   let schema = make_schema [ int_param "count" true; str_param "label" false ] in
-  (* count is string (needs coercion), label is missing (needs default) *)
+  (* count is string (needs coercion), label is optional and remains absent. *)
   let input = `Assoc [ "count", `String "7" ] in
   match Correction_pipeline.run ~schema input with
   | Fixed { corrected; corrections } ->
     let count = Yojson.Safe.Util.(corrected |> member "count" |> to_int) in
     Alcotest.(check int) "coerced count" 7 count;
-    Alcotest.(check bool) "multi corrections" true (List.length corrections >= 2)
+    Alcotest.(check bool) "label remains absent" false (has_object_key "label" corrected);
+    Alcotest.(check int) "coercion only" 1 (List.length corrections)
   | Still_invalid _ -> Alcotest.fail "expected Fixed after multi-stage"
+;;
+
+let test_default_pipeline_preserves_execute_union_branch () =
+  let schema =
+    make_schema
+      [ str_param "executable" false
+      ; array_param "argv" false
+      ; array_param "pipeline" false
+      ; object_param "env" false
+      ; str_param "cwd" false
+      ; number_param "timeout_sec" false
+      ]
+  in
+  let input = `Assoc [ "executable", `String "ls"; "argv", `List [ `String "repos" ] ] in
+  match Correction_pipeline.run ~schema input with
+  | Fixed { corrected; _ } ->
+    Alcotest.(check bool)
+      "pipeline remains absent"
+      false
+      (has_object_key "pipeline" corrected);
+    Alcotest.(check bool) "env remains absent" false (has_object_key "env" corrected);
+    Alcotest.(check bool) "cwd remains absent" false (has_object_key "cwd" corrected);
+    Alcotest.(check bool)
+      "timeout_sec remains absent"
+      false
+      (has_object_key "timeout_sec" corrected)
+  | Still_invalid _ -> Alcotest.fail "expected Fixed"
 ;;
 
 let test_valid_input_no_corrections () =
@@ -201,6 +263,10 @@ let () =
     ; ( "default_injection"
       , [ Alcotest.test_case "missing optional" `Quick test_default_missing_optional
         ; Alcotest.test_case
+            "default pipeline preserves missing optional"
+            `Quick
+            test_default_pipeline_preserves_missing_optional
+        ; Alcotest.test_case
             "no inject if present"
             `Quick
             test_default_no_inject_if_present
@@ -210,6 +276,10 @@ let () =
       , [ Alcotest.test_case "trim whitespace" `Quick test_format_trim_whitespace ] )
     ; ( "combined"
       , [ Alcotest.test_case "multi-stage" `Quick test_multi_stage_correction
+        ; Alcotest.test_case
+            "Execute branch-preserving default pipeline"
+            `Quick
+            test_default_pipeline_preserves_execute_union_branch
         ; Alcotest.test_case
             "valid = no corrections"
             `Quick


### PR DESCRIPTION
## Summary
- remove zero-default injection from the default correction pipeline so missing optional fields stay absent at tool boundaries
- keep zero-default injection as explicit opt-in stages for callers that own closed shapes
- add correction logging keys/added/changed fields for tool-input forensics
- add regression coverage for Execute-style executable vs pipeline union inputs

## Validation
- ocamlformat --check lib/correction_pipeline.ml lib/correction_pipeline.mli lib/agent/agent_tools.ml test/test_correction_pipeline.ml
- scripts/dune-local.sh build test/test_correction_pipeline.exe
- ./_build/default/test/test_correction_pipeline.exe

## Downstream
- This is the upstream prerequisite for the masc-mcp agent_sdk pin bump. The downstream source pin should move only after this commit is reachable from OAS main/release.