### PR TITLE
fix(agent): surface Agent.run execution timeouts

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -272,15 +272,17 @@ let start_periodic_callbacks ~sw ?clock (cbs : periodic_callback list) =
 let with_optional_timeout ?clock agent f =
   match agent.options.max_execution_time_s, clock with
   | Some timeout_s, Some clock ->
+    let started_at = Unix.gettimeofday () in
     (try Eio.Time.with_timeout_exn clock timeout_s f with
      | Eio.Time.Timeout ->
+       let elapsed_sec = Float.max 0.0 (Unix.gettimeofday () -. started_at) in
        Error
-         (Error.Api
-            (Llm_provider.Retry.Timeout
-               { message =
-                   Printf.sprintf
-                     "Agent execution exceeded max_execution_time_s (%f)"
-                     timeout_s
+         (Error.Agent
+            (Error.AgentExecutionTimeout
+               { elapsed_sec
+               ; timeout_sec = timeout_s
+               ; turn_count = agent.state.turn_count
+               ; max_turns = agent.state.config.max_turns
                })))
   | _ -> f ()
 ;;

--- a/lib/base/error.ml
+++ b/lib/base/error.ml
@@ -52,6 +52,12 @@ type agent_error =
       ; limit : int
       ; detail : string
       }
+  | AgentExecutionTimeout of
+      { elapsed_sec : float
+      ; timeout_sec : float
+      ; turn_count : int
+      ; max_turns : int
+      }
   | CompletionContractViolation of
       { contract : Completion_contract_id.t
       ; reason : string
@@ -185,6 +191,13 @@ let agent_error_to_string = function
       r.attempts
       r.limit
       r.detail
+  | AgentExecutionTimeout r ->
+    Printf.sprintf
+      "Agent execution timed out after %.1fs (max_execution_time_s=%.1fs, turns=%d/%d)"
+      r.elapsed_sec
+      r.timeout_sec
+      r.turn_count
+      r.max_turns
   | CompletionContractViolation r ->
     Printf.sprintf
       "Completion contract [%s] violated: %s"

--- a/lib/base/error.mli
+++ b/lib/base/error.mli
@@ -54,6 +54,12 @@ type agent_error =
       ; limit : int
       ; detail : string
       }
+  | AgentExecutionTimeout of
+      { elapsed_sec : float
+      ; timeout_sec : float
+      ; turn_count : int
+      ; max_turns : int
+      }
   | CompletionContractViolation of
       { contract : Completion_contract_id.t
       ; reason : string

--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -26,6 +26,7 @@ type agent_error =
   | `Cost_budget_unenforceable of string * float
   | `Idle_detected of int
   | `Tool_retry_exhausted of int * int * string
+  | `Agent_execution_timeout of float * float * int * int
   | `Completion_contract_violation of
       Completion_contract_id.t * string * Completion_contract_violation_detail.t option
   | `Guardrail_violation of string * string
@@ -115,6 +116,8 @@ let of_sdk_error (err : Error.sdk_error) : sdk_error_poly =
   | Error.Agent (IdleDetected r) -> `Idle_detected r.consecutive_idle_turns
   | Error.Agent (ToolRetryExhausted r) ->
     `Tool_retry_exhausted (r.attempts, r.limit, r.detail)
+  | Error.Agent (AgentExecutionTimeout r) ->
+    `Agent_execution_timeout (r.elapsed_sec, r.timeout_sec, r.turn_count, r.max_turns)
   | Error.Agent (CompletionContractViolation r) ->
     `Completion_contract_violation (r.contract, r.reason, r.violation_detail)
   | Error.Agent (GuardrailViolation r) -> `Guardrail_violation (r.validator, r.reason)
@@ -171,6 +174,9 @@ let to_sdk_error (err : sdk_error_poly) : Error.sdk_error =
   | `Idle_detected n -> Error.Agent (IdleDetected { consecutive_idle_turns = n })
   | `Tool_retry_exhausted (attempts, limit, detail) ->
     Error.Agent (ToolRetryExhausted { attempts; limit; detail })
+  | `Agent_execution_timeout (elapsed_sec, timeout_sec, turn_count, max_turns) ->
+    Error.Agent
+      (AgentExecutionTimeout { elapsed_sec; timeout_sec; turn_count; max_turns })
   | `Completion_contract_violation (contract, reason, violation_detail) ->
     Error.Agent (CompletionContractViolation { contract; reason; violation_detail })
   | `Guardrail_violation (validator, reason) ->

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -51,6 +51,8 @@ type agent_error =
         with no pricing entry, so the cap cannot be enforced. *)
   | `Idle_detected of int (** consecutive_idle_turns *)
   | `Tool_retry_exhausted of int * int * string (** attempts, limit, detail *)
+  | `Agent_execution_timeout of float * float * int * int
+    (** elapsed_sec, timeout_sec, turn_count, max_turns *)
   | `Completion_contract_violation of
       Completion_contract_id.t * string * Completion_contract_violation_detail.t option
     (** contract, reason, violation detail *)

--- a/test/test_async_agent.ml
+++ b/test/test_async_agent.ml
@@ -330,7 +330,11 @@ let test_all_timeout_is_per_agent () =
      | Ok resp -> check string "first sibling completed" "fast-1" (extract_text resp)
      | Error e -> fail (Printf.sprintf "first sibling failed: %s" (Error.to_string e)));
     (match lookup "all-slow" with
-     | Error (Error.Api (Retry.Timeout _)) -> ()
+     | Error
+         (Error.Agent
+            (Error.AgentExecutionTimeout { timeout_sec; turn_count; max_turns; _ })) ->
+       Alcotest.(check bool) "timeout budget preserved" true (timeout_sec <= 0.21);
+       Alcotest.(check bool) "turn count captured" true (turn_count <= max_turns)
      | Ok _ -> fail "slow branch should time out"
      | Error e -> fail (Printf.sprintf "wrong slow error: %s" (Error.to_string e)));
     (match lookup "all-fast-2" with

--- a/test/test_error.ml
+++ b/test/test_error.ml
@@ -65,6 +65,19 @@ let test_agent_token_budget () =
     (Error.to_string err)
 ;;
 
+let test_agent_execution_timeout () =
+  let err =
+    Error.Agent
+      (AgentExecutionTimeout
+         { elapsed_sec = 12.3; timeout_sec = 10.0; turn_count = 4; max_turns = 8 })
+  in
+  check
+    string
+    "agent execution timeout"
+    "Agent execution timed out after 12.3s (max_execution_time_s=10.0s, turns=4/8)"
+    (Error.to_string err)
+;;
+
 let test_agent_stop_reason () =
   let err = Error.Agent (UnrecognizedStopReason { reason = "unknown_42" }) in
   check
@@ -264,6 +277,7 @@ let () =
         ; test_case "Provider timeout phase" `Quick test_provider_timeout_phase
         ; test_case "Agent MaxTurnsExceeded" `Quick test_agent_max_turns
         ; test_case "Agent TokenBudgetExceeded" `Quick test_agent_token_budget
+        ; test_case "Agent AgentExecutionTimeout" `Quick test_agent_execution_timeout
         ; test_case
             "Agent CompletionContractViolation"
             `Quick

--- a/test/test_error_domain.ml
+++ b/test/test_error_domain.ml
@@ -35,6 +35,24 @@ let test_roundtrip_agent_max_turns () =
   | _ -> Alcotest.fail "roundtrip mismatch for MaxTurnsExceeded"
 ;;
 
+let test_roundtrip_agent_execution_timeout () =
+  let orig =
+    Error.Agent
+      (AgentExecutionTimeout
+         { elapsed_sec = 12.0; timeout_sec = 10.0; turn_count = 4; max_turns = 8 })
+  in
+  let poly = Error_domain.of_sdk_error orig in
+  (match poly with
+   | `Agent_execution_timeout (12.0, 10.0, 4, 8) -> ()
+   | _ -> Alcotest.fail "expected Agent_execution_timeout");
+  let back = Error_domain.to_sdk_error poly in
+  match back with
+  | Error.Agent
+      (AgentExecutionTimeout
+         { elapsed_sec = 12.0; timeout_sec = 10.0; turn_count = 4; max_turns = 8 }) -> ()
+  | _ -> Alcotest.fail "roundtrip mismatch for AgentExecutionTimeout"
+;;
+
 let test_roundtrip_config_missing_env () =
   let orig = Error.Config (MissingEnvVar { var_name = "API_KEY" }) in
   let poly = Error_domain.of_sdk_error orig in
@@ -138,6 +156,7 @@ let test_to_string_each_variant () =
     ; `Max_turns_exceeded (20, 10)
     ; `Token_budget_exceeded (5000, 4000)
     ; `Idle_detected 5
+    ; `Agent_execution_timeout (12.0, 10.0, 4, 8)
     ; `Completion_contract_violation
         (Completion_contract.Require_tool_use, "no ToolUse block", None)
     ; `Unrecognized_stop_reason "weird"
@@ -183,6 +202,7 @@ let test_all_variants_convert () =
     ; `Max_turns_exceeded (1, 2)
     ; `Token_budget_exceeded (100, 50)
     ; `Idle_detected 3
+    ; `Agent_execution_timeout (12.0, 10.0, 4, 8)
     ; `Completion_contract_violation
         (Completion_contract.Require_tool_use, "no ToolUse block", None)
     ; `Unrecognized_stop_reason "x"
@@ -765,6 +785,10 @@ let () =
             `Quick
             test_roundtrip_api_context_overflow_no_limit
         ; Alcotest.test_case "agent max_turns" `Quick test_roundtrip_agent_max_turns
+        ; Alcotest.test_case
+            "agent execution_timeout"
+            `Quick
+            test_roundtrip_agent_execution_timeout
         ; Alcotest.test_case "agent token_budget" `Quick test_roundtrip_agent_token_budget
         ; Alcotest.test_case
             "agent idle_detected"


### PR DESCRIPTION
## Summary

- add a typed `AgentExecutionTimeout` error for `Agent.run` wall-clock exhaustion
- preserve elapsed time, configured timeout, turn count, and max turn count in the error payload
- round-trip the new error through `Error_domain` instead of reporting it as a provider/API timeout

## Why

`Eio.Time.Timeout` from the enclosing `Agent.run` execution budget is not proof that the provider was silent. It can happen after successful turns and tool calls. This makes that structural timeout explicit so downstream callers can report the actual cause.

## Validation

- `scripts/dune-local.sh build test/test_async_agent.exe test/test_error.exe test/test_error_domain.exe`
- `_build/default/test/test_error.exe`
- `_build/default/test/test_error_domain.exe`
- `_build/default/test/test_async_agent.exe`
