### PR TITLE
fix(telemetry): propagate participant_name, add structured logging (v0.200.2)

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -337,6 +337,13 @@ let find_and_execute_tool_with_index
                 ]);
             Ok corrected
           | Correction_pipeline.Still_invalid { errors; attempted } ->
+            Log.warn
+              _log
+              "correction_pipeline still invalid after deterministic fixes"
+              [ Log.S ("tool", name)
+              ; Log.I ("error_count", List.length errors)
+              ; Log.I ("attempted_corrections", List.length attempted)
+              ];
             (* Det correction insufficient — build structured feedback for the
            turn-level retry policy (pipeline Stage 5) to relay to the LLM. *)
             let message =

--- a/lib/content_replacement_event_bridge.ml
+++ b/lib/content_replacement_event_bridge.ml
@@ -7,9 +7,17 @@
 
 module S = Content_replacement_state
 
+let log = Log.create ~module_name:"content_replacement_event_bridge" ()
+
 let publish_event ~bus ~correlation_id ~run_id payload =
   let event = Event_bus.mk_event ~correlation_id ~run_id payload in
-  Event_bus.publish bus event
+  try Event_bus.publish bus event
+  with exn ->
+    Log.warn log
+      "publish_event failed after state change committed"
+      [ S ("correlation_id", correlation_id)
+      ; S ("error", Printexc.to_string exn)
+      ]
 ;;
 
 let record_replacement_with_events

--- a/lib/runtime_evidence.ml
+++ b/lib/runtime_evidence.ml
@@ -233,7 +233,17 @@ let structured_fields_of_event = function
     , None
     , None )
   | Agent_output_delta detail ->
-    None, None, None, None, detail.raw_trace_run_id, None, None, None, None, None, None
+    ( Some detail.participant_name
+    , None
+    , None
+    , None
+    , detail.raw_trace_run_id
+    , None
+    , None
+    , None
+    , None
+    , None
+    , None )
   | Agent_completed detail ->
     ( None
     , None


### PR DESCRIPTION
## Summary
- **P0**: `Agent_output_delta` in `runtime_evidence.ml` now propagates `participant_name` to telemetry reports (was always `None`)
- **P1**: `content_replacement_event_bridge.ml` logs a structured warning when `Event_bus.publish` fails after state change is committed
- **P1**: `agent_tools.ml` logs a structured warning when `Correction_pipeline` returns `Still_invalid`
- Version bump to 0.200.2

## Test plan
- [x] `dune build --root . lib/agent_sdk.cma` passes
- [ ] Verify telemetry report `participant` field is populated for `agent_output_delta` events
- [ ] Verify structured warn appears on correction pipeline still-invalid path

🤖 Generated with [Claude Code](https://claude.com/claude-code)