### PR TITLE
fix(agent-tools): purge retired native tool ids

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -118,6 +118,40 @@ let json_object_keys_for_log = function
   | _ -> "-"
 ;;
 
+let tool_names_of_index index =
+  Hashtbl.fold (fun name _ acc -> name :: acc) index.by_name []
+  |> List.sort_uniq String.compare
+;;
+
+let preview_tool_names ?(limit = 12) names =
+  match names with
+  | [] -> "(none)"
+  | _ ->
+    let rec take n rest =
+      if n = 0
+      then []
+      else (
+        match rest with
+        | [] -> []
+        | x :: xs -> x :: take (n - 1) xs)
+    in
+    let visible = take limit names in
+    let suffix =
+      let extra = List.length names - List.length visible in
+      if extra > 0 then [ Printf.sprintf "...(+%d more)" extra ] else []
+    in
+    String.concat "," (visible @ suffix)
+;;
+
+let unknown_tool_failure ~requested ~available =
+  let available_preview = preview_tool_names available in
+  let failure_kind =
+    if available = [] then Some Non_retryable_tool_error else Some Validation_error
+  in
+  ( Printf.sprintf "Tool not found: %s. Available tools: %s" requested available_preview
+  , failure_kind )
+;;
+
 let tool_exception_result ~id ~name exn =
   let msg = Printf.sprintf "Tool '%s' raised: %s" name (Printexc.to_string exn) in
   { tool_use_id = id
@@ -457,7 +491,17 @@ let find_and_execute_tool_with_index
          registered). Distinct from OnToolError — that fires when a
          tool actually ran and returned Error. This is a configuration
          / routing mistake, so it belongs on the general OnError
-         channel. First production emit site for Hooks.OnError (#1032). *)
+         channel. Unknown names are treated as validation errors when
+         the current turn has visible tools, so the retry path can use
+         the actual schema instead of preserving a stale name. *)
+        let available = tool_names_of_index tool_index in
+        let message, failure_kind = unknown_tool_failure ~requested:name ~available in
+        Log.warn
+          _log
+          "tool not found"
+          [ Log.S ("tool", name)
+          ; Log.S ("available_tools", preview_tool_names available)
+          ];
         ignore
           (invoke_hook
              ?on_hook_invoked
@@ -467,15 +511,13 @@ let find_and_execute_tool_with_index
              ~hook_name:"on_error"
              hooks.on_error
              (Hooks.OnError
-                { detail = Printf.sprintf "Tool not found: %s" name
-                ; context = "agent_tools.find_and_execute_tool"
-                })
+                { detail = message; context = "agent_tools.find_and_execute_tool" })
            : Hooks.hook_decision);
         { tool_use_id = id
         ; tool_name = name
-        ; content = "Tool not found"
+        ; content = message
         ; is_error = true
-        ; failure_kind = Some Non_retryable_tool_error
+        ; failure_kind
         ; error_class = Some Types.Deterministic
         }
     with

--- a/lib/base/tool_id.ml
+++ b/lib/base/tool_id.ml
@@ -1,7 +1,4 @@
 type t =
-  | Read
-  | Glob
-  | Grep
   | Search
   | List_dir
   | Find_file
@@ -19,8 +16,6 @@ type t =
   | Task_list
   | Task_get
   | Task_output
-  | Write
-  | Edit
   | Create_text_file
   | Replace_content
   | Rename_symbol
@@ -43,7 +38,6 @@ type t =
   | Javascript_tool
   | Tabs_create_mcp
   | Upload_image
-  | Bash
   | Execute_shell_command
   | Mcp of
       { server : string
@@ -58,9 +52,6 @@ type t =
 let equal = ( = )
 
 let to_string = function
-  | Read -> "read"
-  | Glob -> "glob"
-  | Grep -> "grep"
   | Search -> "search"
   | List_dir -> "list_dir"
   | Find_file -> "find_file"
@@ -78,8 +69,6 @@ let to_string = function
   | Task_list -> "task_list"
   | Task_get -> "task_get"
   | Task_output -> "task_output"
-  | Write -> "write"
-  | Edit -> "edit"
   | Create_text_file -> "create_text_file"
   | Replace_content -> "replace_content"
   | Rename_symbol -> "rename_symbol"
@@ -102,17 +91,13 @@ let to_string = function
   | Javascript_tool -> "javascript_tool"
   | Tabs_create_mcp -> "tabs_create_mcp"
   | Upload_image -> "upload_image"
-  | Bash -> "bash"
   | Execute_shell_command -> "execute_shell_command"
   | Mcp { server; tool } -> "mcp__" ^ server ^ "__" ^ tool
   | User name -> name
 ;;
 
 let all_builtins =
-  [ Read
-  ; Glob
-  ; Grep
-  ; Search
+  [ Search
   ; List_dir
   ; Find_file
   ; Read_file
@@ -129,8 +114,6 @@ let all_builtins =
   ; Task_list
   ; Task_get
   ; Task_output
-  ; Write
-  ; Edit
   ; Create_text_file
   ; Replace_content
   ; Rename_symbol
@@ -153,7 +136,6 @@ let all_builtins =
   ; Javascript_tool
   ; Tabs_create_mcp
   ; Upload_image
-  ; Bash
   ; Execute_shell_command
   ]
 ;;
@@ -196,9 +178,6 @@ let parse_mcp s =
 let of_string raw =
   let s = String.lowercase_ascii raw in
   match s with
-  | "read" -> Read
-  | "glob" -> Glob
-  | "grep" -> Grep
   | "search" -> Search
   | "list_dir" -> List_dir
   | "find_file" -> Find_file
@@ -216,8 +195,6 @@ let of_string raw =
   | "task_list" -> Task_list
   | "task_get" -> Task_get
   | "task_output" -> Task_output
-  | "write" -> Write
-  | "edit" -> Edit
   | "create_text_file" -> Create_text_file
   | "replace_content" -> Replace_content
   | "rename_symbol" -> Rename_symbol
@@ -240,7 +217,6 @@ let of_string raw =
   | "javascript_tool" -> Javascript_tool
   | "tabs_create_mcp" -> Tabs_create_mcp
   | "upload_image" -> Upload_image
-  | "bash" -> Bash
   | "execute_shell_command" -> Execute_shell_command
   | other ->
     (match parse_mcp other with
@@ -252,7 +228,14 @@ let%test "all_builtins_round_trip" =
   List.for_all (fun b -> equal (of_string (to_string b)) b) all_builtins
 ;;
 
-let%test "of_string_lowercases_builtin" = equal (of_string "READ") Read
+let%test "of_string_lowercases_builtin" = equal (of_string "READ_FILE") Read_file
+
+let%test "of_string_retired_native_tool_names_are_user_tools" =
+  List.for_all
+    (fun name -> equal (of_string name) (User (String.lowercase_ascii name)))
+    [ "Read"; "Glob"; "Grep"; "Write"; "Edit"; "Bash" ]
+;;
+
 let%test "of_string_user_lowercases" = equal (of_string "MyTool") (User "mytool")
 
 let%test "of_string_mcp_parses" =

--- a/lib/base/tool_id.mli
+++ b/lib/base/tool_id.mli
@@ -11,9 +11,6 @@
 
 type t =
   (* Read-only — file & code navigation *)
-  | Read
-  | Glob
-  | Grep
   | Search
   | List_dir
   | Find_file
@@ -35,8 +32,6 @@ type t =
   | Task_get
   | Task_output
   (* Local-mutation — file editing *)
-  | Write
-  | Edit
   | Create_text_file
   | Replace_content
   | Rename_symbol
@@ -64,7 +59,6 @@ type t =
   | Tabs_create_mcp
   | Upload_image
   (* Shell-dynamic *)
-  | Bash
   | Execute_shell_command
   (* Escape hatches *)
   | Mcp of

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -5,6 +5,14 @@ open Agent_sdk
 
 (* ── Helpers ──────────────────────────────────────────────────────── *)
 
+let string_contains ~needle haystack =
+  try
+    let _ = Str.search_forward (Str.regexp_string needle) haystack 0 in
+    true
+  with
+  | Not_found -> false
+;;
+
 let mock_response text =
   { Types.id = "r-1"
   ; model = "mock"
@@ -556,6 +564,87 @@ let test_on_error_fires_on_tool_not_found () =
   | _ -> fail "on_error fired more than once"
 ;;
 
+let test_unknown_tool_reports_available_tools_and_retries () =
+  Eio_main.run
+  @@ fun _env ->
+  let context = Context.create () in
+  let bus = Event_bus.create () in
+  let read_file =
+    Tool.create ~name:"ReadFile" ~description:"Read a file" ~parameters:[] (fun _ ->
+      Ok { Types.content = "unused" })
+  in
+  let schedule : Hooks.tool_schedule =
+    { planned_index = 0
+    ; batch_index = 0
+    ; batch_size = 1
+    ; concurrency_class = "sequential_workspace"
+    ; batch_kind = "sequential"
+    }
+  in
+  let fired = ref [] in
+  let on_error =
+    Some
+      (fun event ->
+        (match event with
+         | Hooks.OnError { detail; context } -> fired := (detail, context) :: !fired
+         | _ -> ());
+        Hooks.Continue)
+  in
+  let hooks = { Hooks.empty with on_error } in
+  let result =
+    Agent_tools.find_and_execute_tool
+      ~context
+      ~tools:[ read_file ]
+      ~hooks
+      ~event_bus:(Some bus)
+      ~tracer:Tracing.null
+      ~agent_name:"agent"
+      ~turn_count:0
+      ~correlation_id:"c"
+      ~run_id:"r"
+      ~schedule
+      "Read"
+      (`Assoc [])
+      "tool-unknown"
+  in
+  check bool "unknown call is an error" true result.is_error;
+  check
+    (option string)
+    "unknown call is retryable validation"
+    (Some "validation")
+    (Option.map
+       (function
+         | Agent_tools.Validation_error -> "validation"
+         | Agent_tools.Recoverable_tool_error -> "recoverable"
+         | Agent_tools.Non_retryable_tool_error -> "non_retryable")
+       result.failure_kind);
+  check
+    bool
+    "content names missing tool"
+    true
+    (string_contains ~needle:"Tool not found: Read" result.content);
+  check
+    bool
+    "content includes available tools"
+    true
+    (string_contains ~needle:"Available tools: ReadFile" result.content);
+  match List.rev !fired with
+  | [ (detail, ctx) ] ->
+    check
+      bool
+      "detail names missing tool"
+      true
+      (string_contains ~needle:"Tool not found: Read" detail);
+    check
+      bool
+      "detail includes available tools"
+      true
+      (string_contains ~needle:"Available tools: ReadFile" detail);
+    check string "context labels dispatch site" "agent_tools.find_and_execute_tool" ctx
+  | [] -> fail "on_error hook not fired"
+  | _ -> fail "on_error fired more than once"
+;;
+
 let test_on_error_silent_on_successful_dispatch () =
   Eio_main.run
   @@ fun _env ->
@@ -893,6 +982,10 @@ let () =
             "on_error fires on tool-not-found"
             `Quick
             test_on_error_fires_on_tool_not_found
+        ; test_case
+            "unknown tool reports available tools and retries"
+            `Quick
+            test_unknown_tool_reports_available_tools_and_retries
         ; test_case
             "on_error silent on successful dispatch"
             `Quick


### PR DESCRIPTION
## Summary
- Remove retired native tool IDs (Read, Glob, Grep, Write, Edit, Bash) from OAS Tool_id builtins so they no longer participate in builtin/case-insensitive dispatch fallback
- Replace the legacy-specific replacement table with generic unknown-tool feedback that reports the actual available tool names for the current turn
- Keep unknown tool calls retryable when visible tools exist, so the next turn can use the real schema instead of preserving a stale name

## Verification
- ocamlformat --check lib/base/tool_id.ml lib/base/tool_id.mli lib/agent/agent_tools.ml test/test_event_bus.ml
- git diff --check
- constructor sweep: no remaining Tool_id.Read/Glob/Grep/Write/Edit/Bash references outside the new retired-name regression
- scripts/dune-local.sh build ./test/test_event_bus.exe (blocked by existing /tmp/me-dune-local.lock holders from concurrent masc-mcp Dune jobs; stopped the waiting local run)