### PR TITLE
fix(telemetry): Event_bus.publish error handling round 2 (8 sites)

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -389,7 +389,7 @@ let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
                  match agent_with_handoffs.options.event_bus with
                  | Some bus ->
                    let run_id = Event_bus.fresh_id () in
-                   Event_bus.publish
+                   (try Event_bus.publish
                      bus
                      (Event_bus.mk_event
                         ~run_id
@@ -397,7 +397,11 @@ let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
                            { from_agent = from_name
                            ; to_agent = target.name
                            ; reason = prompt
-                           }));
+                           }))
+                   with exn ->
+                     Log.warn _log
+                       "Event_bus.publish failed (HandoffRequested)"
+                       [ Log.S ("error", Printexc.to_string exn) ]);
                    Some run_id
                  | None -> None
                in
@@ -419,15 +423,19 @@ let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
                let handoff_elapsed = Unix.gettimeofday () -. handoff_t0 in
                (match agent_with_handoffs.options.event_bus with
                 | Some bus ->
-                  Event_bus.publish
-                    bus
-                    (Event_bus.mk_event
-                       ?caused_by:handoff_requested_run_id
-                       (HandoffCompleted
-                          { from_agent = from_name
-                          ; to_agent = target.name
-                          ; elapsed = handoff_elapsed
-                          }))
+                  (try Event_bus.publish
+                     bus
+                     (Event_bus.mk_event
+                        ?caused_by:handoff_requested_run_id
+                        (HandoffCompleted
+                           { from_agent = from_name
+                           ; to_agent = target.name
+                           ; elapsed = handoff_elapsed
+                           }))
+                   with exn ->
+                     Log.warn _log
+                       "Event_bus.publish failed (HandoffCompleted)"
+                       [ Log.S ("error", Printexc.to_string exn) ])
                 | None -> ());
                (match sub_result with
                 | Error e ->

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -283,7 +283,11 @@ let find_and_execute_tool_with_index
           ?run_id
           (ToolCalled { agent_name; tool_name = name; input })
       in
-      Event_bus.publish bus ev;
+      (try Event_bus.publish bus ev
+       with exn ->
+         Log.warn _log
+           "Event_bus.publish failed (ToolCalled)"
+           [ Log.S ("error", Printexc.to_string exn) ]);
       Some ev.meta.run_id
     | None -> None
   in
@@ -542,13 +546,17 @@ let find_and_execute_tool_with_index
            }
        else Ok { content = output_content }
      in
-     Event_bus.publish
-       bus
-       (Event_bus.mk_event
-          ?correlation_id
-          ?run_id
-          ?caused_by:tool_called_run_id
-          (ToolCompleted { agent_name; tool_name = name; output }))
+     (try Event_bus.publish
+        bus
+        (Event_bus.mk_event
+           ?correlation_id
+           ?run_id
+           ?caused_by:tool_called_run_id
+           (ToolCompleted { agent_name; tool_name = name; output }))
+      with exn ->
+        Log.warn _log
+          "Event_bus.publish failed (ToolCompleted)"
+          [ Log.S ("error", Printexc.to_string exn) ])
    | None -> ());
   result
 ;;

--- a/lib/journal_bridge.ml
+++ b/lib/journal_bridge.ml
@@ -80,10 +80,15 @@ let projection_of_event (evt : Durable_event.event) : string * Yojson.Safe.t =
         ] )
 ;;
 
+let _log = Log.create ~module_name:"journal_bridge" ()
+
 let make ~bus ?correlation_id ?run_id () : Durable_event.event -> unit =
   fun evt ->
   let name, payload = projection_of_event evt in
-  Event_bus.publish
-    bus
-    (Event_bus.mk_event ?correlation_id ?run_id (Custom (name, payload)))
+  (try Event_bus.publish bus
+       (Event_bus.mk_event ?correlation_id ?run_id (Custom (name, payload)))
+   with exn ->
+     Log.warn _log
+       "Event_bus.publish failed in journal bridge"
+       [ Log.S ("error", Printexc.to_string exn) ])
 ;;

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -7,7 +7,6 @@
     @since 0.53.0  Streaming, retry
     @since 0.54.0  Optional cache + metrics hooks *)
 
-let _log = Log.create ~module_name:"complete" ()
 
 (* ── Internal: timed HTTP completion ──────────────────── *)
 
@@ -1094,9 +1093,8 @@ let complete
              let json = Cache.response_to_json resp in
              (try c.set ~key ~ttl_sec:Constants.Cache.default_ttl_sec json with
               | Eio.Io _ | Sys_error _ as exn ->
-                Log.warn _log
-                  "cache set failed"
-                  [ Log.S ("key", key); Log.S ("error", Printexc.to_string exn) ])
+                Diag.warn "complete"
+                  "cache set failed for key %s: %s" key (Printexc.to_string exn) )
            | _, _ -> ());
           Ok resp
         | Error err ->

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -408,8 +408,7 @@ let stage_collect ?raw_trace_run agent ~original_config response =
     });
   (match agent.options.event_bus with
    | Some bus ->
-     Event_bus.publish
-       bus
+     safe_publish bus
        { meta = Pipeline_common.event_envelope agent
        ; payload =
            TurnCompleted { agent_name = agent.state.config.name; turn = completed_turn }
@@ -863,8 +862,7 @@ let proactive_compact ?raw_trace_run agent ~watermark () =
                 }));
         (match agent.options.event_bus with
          | Some bus ->
-           Event_bus.publish
-             bus
+           safe_publish bus
              { meta = Pipeline_common.event_envelope agent
              ; payload =
                  ContextCompacted
@@ -958,8 +956,7 @@ let emergency_compact ?raw_trace_run agent ?limit () =
               }));
       (match agent.options.event_bus with
        | Some bus ->
-         Event_bus.publish
-           bus
+         safe_publish bus
            { meta = Pipeline_common.event_envelope agent
            ; payload =
                ContextCompacted
@@ -1041,8 +1038,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
       (* Emit ContextOverflowImminent before compaction *)
       (match agent.options.event_bus with
        | Some bus ->
-         Event_bus.publish
-           bus
+         safe_publish bus
            { meta = Pipeline_common.event_envelope agent
            ; payload =
                ContextOverflowImminent
@@ -1056,8 +1052,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
       (* Emit ContextCompactStarted *)
       (match agent.options.event_bus with
        | Some bus ->
-         Event_bus.publish
-           bus
+         safe_publish bus
            { meta = Pipeline_common.event_envelope agent
            ; payload =
                ContextCompactStarted
@@ -1157,8 +1152,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
         when agent.auto_context_overflow_retry && compact_attempts < 2 ->
         (match agent.options.event_bus with
          | Some bus ->
-           Event_bus.publish
-             bus
+           safe_publish bus
              { meta = Pipeline_common.event_envelope agent
              ; payload =
                  ContextCompactStarted

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -8,6 +8,16 @@ open Agent_trace
     via local aliases so existing tests and call sites remain unchanged while
     the file is split by stage responsibility. *)
 
+let _stage_log = Log.create ~module_name:"pipeline_stage_prepare" ()
+
+let safe_publish bus event =
+  try Event_bus.publish bus event
+  with exn ->
+    Log.warn _stage_log
+      "Event_bus.publish failed"
+      [ Log.S ("error", Printexc.to_string exn) ]
+;;
+
 let stage_input ?raw_trace_run agent =
   let ts = Unix.gettimeofday () in
   set_lifecycle agent ~ready_at:ts Ready;
@@ -26,8 +36,7 @@ let stage_input ?raw_trace_run agent =
        let response = cb req in
        (match agent.options.event_bus with
         | Some bus ->
-          Event_bus.publish
-            bus
+          safe_publish bus
             (Event_bus.mk_event
                (ElicitationCompleted
                   { agent_name = agent.state.config.name
@@ -263,8 +272,7 @@ let stage_parse ?raw_trace_run agent =
   let original_config = original_config in
   (match agent.options.event_bus with
    | Some bus ->
-     Event_bus.publish
-       bus
+     safe_publish bus
        { meta =
            Event_bus.mk_envelope
              ~correlation_id:
@@ -306,8 +314,7 @@ let stage_parse ?raw_trace_run agent =
      Sibling of TurnStarted (announce) and TurnCompleted (post-LLM). *)
   (match agent.options.event_bus with
    | Some bus ->
-     Event_bus.publish
-       bus
+     safe_publish bus
        { meta =
            Event_bus.mk_envelope
              ~correlation_id:

--- a/lib/runtime_server_types.ml
+++ b/lib/runtime_server_types.ml
@@ -90,6 +90,10 @@ let emit_event state session_id (event : event) =
     | Some run_id -> Event_bus.mk_event ~correlation_id:session_id ~run_id payload
     | None -> Event_bus.mk_event ~correlation_id:session_id payload
   in
-  Event_bus.publish state.event_bus event_bus_event;
+  (try Event_bus.publish state.event_bus event_bus_event
+   with exn ->
+     Log.warn (Log.create ~module_name:"runtime_server_types" ())
+       "Event_bus.publish failed"
+       [ Log.S ("error", Printexc.to_string exn) ]);
   write_protocol_message state (Event_message { session_id = Some session_id; event })
 ;;


### PR DESCRIPTION
## Summary
- Wrap all remaining `Event_bus.publish` calls in try/with to prevent silent event bus failures from disrupting business logic
- 8 call sites across 5 files: `pipeline_stage_prepare.ml` (3), `agent_tools.ml` (2), `agent.ml` (2), `runtime_server_types.ml` (1), `journal_bridge.ml` (1)
- Fix `complete.ml`: replaced `Log` (unavailable in `llm_provider`) with `Diag` for cache set failure logging
- `pipeline.ml`: `safe_publish` helper centralizes error handling for 6 publish calls
- Version bump 0.200.4 → 0.200.5

## Changes
| File | Change |
|------|--------|
| `pipeline_stage_prepare.ml` | 3 publishes → `safe_publish` + local logger |
| `agent_tools.ml` | ToolCalled + ToolCompleted wrapped in try/with |
| `agent.ml` | HandoffRequested + HandoffCompleted wrapped in try/with |
| `runtime_server_types.ml` | runtime event emit wrapped in try/with |
| `journal_bridge.ml` | durable event bridge wrapped + module logger |
| `pipeline.ml` | `safe_publish` helper + 6 bare calls replaced |
| `complete.ml` | `Log` → `Diag` (llm_provider has no agent_sdk dep) |

## Test plan
- [x] `dune build` passes (lib compiles cleanly)
- [ ] CI checks pass
- [ ] Existing Event_bus inline tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>