### PR TITLE
fix(tools): normalize Read to visible ReadFile

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -152,6 +152,37 @@ let unknown_tool_failure ~requested ~available =
   , failure_kind )
 ;;
 
+let has_assoc_key key fields = List.exists (fun (k, _) -> String.equal k key) fields
+
+let normalize_read_alias_input = function
+  | `Assoc fields as input ->
+    if has_assoc_key "file_path" fields
+    then input
+    else (
+      match List.assoc_opt "path" fields with
+      | Some path -> `Assoc (("file_path", path) :: fields)
+      | None -> input)
+  | input -> input
+;;
+
+let legacy_tool_alias requested input =
+  match requested with
+  | "Read" -> Some ("ReadFile", normalize_read_alias_input input)
+  | _ -> None
+;;
+
+let resolve_tool_call tool_index name input =
+  match find_in_index tool_index name with
+  | Some tool -> name, input, Some tool, None
+  | None ->
+    (match legacy_tool_alias name input with
+     | Some (alias, aliased_input) ->
+       (match find_in_index tool_index alias with
+        | Some tool -> alias, aliased_input, Some tool, Some alias
+        | None -> name, input, None, None)
+     | None -> name, input, None, None)
+;;
+
 let tool_exception_result ~id ~name exn =
   let msg = Printf.sprintf "Tool '%s' raised: %s" name (Printexc.to_string exn) in
   { tool_use_id = id
@@ -268,6 +299,15 @@ let find_and_execute_tool_with_index
       input
       id
   =
+  let requested_name = name in
+  let name, input, tool_opt, alias_opt = resolve_tool_call tool_index name input in
+  (match alias_opt with
+   | Some alias ->
+     Log.info
+       _log
+       "legacy tool alias resolved"
+       [ Log.S ("requested_tool", requested_name); Log.S ("resolved_tool", alias) ]
+   | None -> ());
   (* ToolCalled event — capture the published envelope's run_id so the
      matching ToolCompleted records it as caused_by, preserving the
      call -> completion causation chain per tool invocation (#877).
@@ -283,15 +323,15 @@ let find_and_execute_tool_with_index
           ?run_id
           (ToolCalled { agent_name; tool_name = name; input })
       in
-      (try Event_bus.publish bus ev
-       with exn ->
-         Log.warn _log
+      (try Event_bus.publish bus ev with
+       | exn ->
+         Log.warn
+           _log
            "Event_bus.publish failed (ToolCalled)"
            [ Log.S ("error", Printexc.to_string exn) ]);
       Some ev.meta.run_id
     | None -> None
   in
-  let tool_opt = find_in_index tool_index name in
   let result =
     try
       match tool_opt with
@@ -499,11 +539,13 @@ let find_and_execute_tool_with_index
          the current turn has visible tools, so the retry path can use
          the actual schema instead of preserving a stale name. *)
         let available = tool_names_of_index tool_index in
-        let message, failure_kind = unknown_tool_failure ~requested:name ~available in
+        let message, failure_kind =
+          unknown_tool_failure ~requested:requested_name ~available
+        in
         Log.warn
           _log
           "tool not found"
-          [ Log.S ("tool", name)
+          [ Log.S ("tool", requested_name)
           ; Log.S ("available_tools", preview_tool_names available)
           ];
         ignore
@@ -518,7 +560,7 @@ let find_and_execute_tool_with_index
                 { detail = message; context = "agent_tools.find_and_execute_tool" })
            : Hooks.hook_decision);
         { tool_use_id = id
-        ; tool_name = name
+        ; tool_name = requested_name
         ; content = message
         ; is_error = true
         ; failure_kind
@@ -546,15 +588,18 @@ let find_and_execute_tool_with_index
            }
        else Ok { content = output_content }
      in
-     (try Event_bus.publish
-        bus
-        (Event_bus.mk_event
-           ?correlation_id
-           ?run_id
-           ?caused_by:tool_called_run_id
-           (ToolCompleted { agent_name; tool_name = name; output }))
-      with exn ->
-        Log.warn _log
+     (try
+        Event_bus.publish
+          bus
+          (Event_bus.mk_event
+             ?correlation_id
+             ?run_id
+             ?caused_by:tool_called_run_id
+             (ToolCompleted { agent_name; tool_name = name; output }))
+      with
+      | exn ->
+        Log.warn
+          _log
           "Event_bus.publish failed (ToolCompleted)"
           [ Log.S ("error", Printexc.to_string exn) ])
    | None -> ());

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -603,7 +603,7 @@ let test_unknown_tool_reports_available_tools_and_retries () =
       ~correlation_id:"c"
       ~run_id:"r"
       ~schedule
-      "Read"
+      "MissingRead"
       (`Assoc [])
       "tool-unknown"
   in
@@ -622,7 +622,7 @@ let test_unknown_tool_reports_available_tools_and_retries () =
     bool
     "content names missing tool"
     true
-    (string_contains ~needle:"Tool not found: Read" result.content);
+    (string_contains ~needle:"Tool not found: MissingRead" result.content);
   check
     bool
     "content includes available tools"
@@ -634,7 +634,7 @@ let test_unknown_tool_reports_available_tools_and_retries () =
       bool
       "detail names missing tool"
       true
-      (string_contains ~needle:"Tool not found: Read" detail);
+      (string_contains ~needle:"Tool not found: MissingRead" detail);
     check
       bool
       "detail includes available tools"
@@ -643,6 +643,80 @@ let test_unknown_tool_reports_available_tools_and_retries () =
     check string "context labels dispatch site" "agent_tools.find_and_execute_tool" ctx
   | [] -> fail "on_error hook not fired"
   | _ -> fail "on_error fired more than once"
+;;
+
+let test_legacy_read_dispatches_to_read_file_when_visible () =
+  Eio_main.run
+  @@ fun _env ->
+  let context = Context.create () in
+  let bus = Event_bus.create () in
+  let captured_input = ref `Null in
+  let read_file =
+    Tool.create ~name:"ReadFile" ~description:"Read a file" ~parameters:[] (fun input ->
+      captured_input := input;
+      Ok { Types.content = "read-ok" })
+  in
+  let schedule : Hooks.tool_schedule =
+    { planned_index = 0
+    ; batch_index = 0
+    ; batch_size = 1
+    ; concurrency_class = "sequential_workspace"
+    ; batch_kind = "sequential"
+    }
+  in
+  let on_error_called = ref false in
+  let hooks =
+    { Hooks.empty with
+      on_error =
+        Some
+          (fun _event ->
+            on_error_called := true;
+            Hooks.Continue)
+    }
+  in
+  let sub = Event_bus.subscribe bus in
+  let result =
+    Agent_tools.find_and_execute_tool
+      ~context
+      ~tools:[ read_file ]
+      ~hooks
+      ~event_bus:(Some bus)
+      ~tracer:Tracing.null
+      ~agent_name:"agent"
+      ~turn_count:0
+      ~correlation_id:"c"
+      ~run_id:"r"
+      ~schedule
+      "Read"
+      (`Assoc [ "path", `String "README.md" ])
+      "tool-legacy-read"
+  in
+  check bool "legacy Read succeeds" false result.is_error;
+  check string "result uses visible tool name" "ReadFile" result.tool_name;
+  check string "read content" "read-ok" result.content;
+  check bool "on_error not called" false !on_error_called;
+  (match !captured_input with
+   | `Assoc fields ->
+     check
+       (option string)
+       "path normalized to file_path"
+       (Some "README.md")
+       (match List.assoc_opt "file_path" fields with
+        | Some (`String path) -> Some path
+        | _ -> None)
+   | _ -> fail "expected object input");
+  let events = Event_bus.drain sub in
+  check
+    bool
+    "event bus records resolved tool name"
+    true
+    (List.exists
+       (fun (event : Event_bus.event) ->
+          match event.payload with
+          | Event_bus.ToolCalled { tool_name; _ }
+          | Event_bus.ToolCompleted { tool_name; _ } -> String.equal tool_name "ReadFile"
+          | _ -> false)
+       events)
 ;;
 
 let test_on_error_silent_on_successful_dispatch () =
@@ -986,6 +1060,10 @@ let () =
             "unknown tool reports available tools and retries"
             `Quick
             test_unknown_tool_reports_available_tools_and_retries
+        ; test_case
+            "legacy Read dispatches to ReadFile when visible"
+            `Quick
+            test_legacy_read_dispatches_to_read_file_when_visible
         ; test_case
             "on_error silent on successful dispatch"
             `Quick


### PR DESCRIPTION
Summary
- Normalize provider-emitted Read tool calls to ReadFile when ReadFile is visible in the current tool surface.
- Normalize path to file_path for the resolved call and keep true unknown tools on the validation-feedback path.
- Add event-bus coverage proving Read dispatches to ReadFile without firing on_error.

Validation
- ocamlformat --check lib/agent/agent_tools.ml test/test_event_bus.ml
- git diff --check
- scripts/dune-local.sh build test/test_event_bus.exe
- ./_build/default/test/test_event_bus.exe