### PR TITLE
fix(telemetry): Eio.traceln → structured Log/Diag (8 sites)

### DIFF
--- a/lib/llm_provider/cli_common_subprocess.ml
+++ b/lib/llm_provider/cli_common_subprocess.ml
@@ -30,10 +30,10 @@ let cwd_wrapper = function
   | Some dir -> [ "/usr/bin/env"; "-C"; dir ]
 ;;
 
-(** Default stderr-line handler: route to [Eio.traceln] with a
+(** Default stderr-line handler: route to [Diag.warn] with a
     transport-name prefix.  Transports that want silence pass
     [~on_stderr_line:ignore]. *)
-let default_on_stderr_line ~name line = Eio.traceln "[%s stderr] %s" name line
+let default_on_stderr_line ~name line = Diag.warn name "[%s stderr] %s" name line
 
 let last_nonempty_line text =
   text
@@ -113,8 +113,9 @@ let run_core
        Eio.Flow.close r_stdin;
        (try Eio.Flow.copy_string s (w_stdin :> Eio.Flow.sink_ty Eio.Resource.t) with
         | exn ->
-          Eio.traceln
-            "cli_common_subprocess: stdin write raised: %s"
+          Diag.warn
+            "cli_common_subprocess"
+            "stdin write raised: %s"
             (Printexc.to_string exn));
        Eio.Flow.close w_stdin
      | _ -> ());
@@ -141,8 +142,9 @@ let run_core
           Buffer.add_char stdout_buf '\n';
           try on_line line with
           | exn ->
-            Eio.traceln
-              "cli_common_subprocess: on_line raised: %s"
+            Diag.warn
+              "cli_common_subprocess"
+              "on_line raised: %s"
               (Printexc.to_string exn)
         done
       with
@@ -170,8 +172,9 @@ let run_core
           Buffer.add_char stderr_buf '\n';
           try on_stderr_line line with
           | exn ->
-            Eio.traceln
-              "cli_common_subprocess: on_stderr_line raised: %s"
+            Diag.warn
+              "cli_common_subprocess"
+              "on_stderr_line raised: %s"
               (Printexc.to_string exn)
         done
       with
@@ -239,8 +242,9 @@ let run_core
           | Some predicate ->
             (try predicate stdout_str with
              | exn ->
-               Eio.traceln
-                 "cli_common_subprocess: stdout_recovery raised: %s"
+               Diag.warn
+                 "cli_common_subprocess"
+                 "stdout_recovery raised: %s"
                  (Printexc.to_string exn);
                false)
           | None -> false
@@ -252,9 +256,9 @@ let run_core
             | Some line -> line
             | None -> "<empty stderr>"
           in
-          Eio.traceln
-            "cli_common_subprocess: stdout_recovery accepted nonzero exit code %d; \
-             stderr_last=%s"
+          Diag.warn
+            "cli_common_subprocess"
+            "stdout_recovery accepted nonzero exit code %d; stderr_last=%s"
             code
             stderr_detail;
           Ok

--- a/lib/llm_provider/transport_cli_tool_c.ml
+++ b/lib/llm_provider/transport_cli_tool_c.ml
@@ -89,9 +89,9 @@ let cli_model_override ~(config : config) ~(req_config : Provider_config.t) =
    | Some m, Some supported ->
      if not (List.mem (String.lowercase_ascii m) supported)
      then
-       Eio.traceln
-         "[warn] [cli_tool_c] Unsupported model %s requested. Provider_c CLI officially \
-          supports %s"
+       Diag.warn
+         "cli_tool_c"
+         "Unsupported model %s requested. Provider_c CLI officially supports %s"
          m
          (String.concat ", " supported)
    | Some _, None | None, Some _ | None, None -> ());

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -16,11 +16,9 @@ open Agent_trace
 let _log = Log.create ~module_name:"pipeline" ()
 
 let safe_publish bus event =
-  try Event_bus.publish bus event
-  with exn ->
-    Log.warn _log
-      "Event_bus.publish failed"
-      [ Log.S ("error", Printexc.to_string exn) ]
+  try Event_bus.publish bus event with
+  | exn ->
+    Log.warn _log "Event_bus.publish failed" [ Log.S ("error", Printexc.to_string exn) ]
 ;;
 
 (* ── Context compaction watermark ───────────────────── *)
@@ -37,10 +35,10 @@ let compact_watermark_default =
     (match float_of_string_opt s with
      | Some w when w > 0.0 && w < 1.0 -> w
      | _ ->
-       Eio.traceln
-         "[warn] [pipeline] OAS_COMPACT_WATERMARK=%S invalid (expected 0.0 < v < 1.0), \
-          using 0.9"
-         s;
+       Log.warn
+         _log
+         "OAS_COMPACT_WATERMARK=%S invalid (expected 0.0 < v < 1.0), using 0.9"
+         [ Log.S ("value", s) ];
        0.9)
 ;;
 
@@ -408,7 +406,8 @@ let stage_collect ?raw_trace_run agent ~original_config response =
     });
   (match agent.options.event_bus with
    | Some bus ->
-     safe_publish bus
+     safe_publish
+       bus
        { meta = Pipeline_common.event_envelope agent
        ; payload =
            TurnCompleted { agent_name = agent.state.config.name; turn = completed_turn }
@@ -862,7 +861,8 @@ let proactive_compact ?raw_trace_run agent ~watermark () =
                 }));
         (match agent.options.event_bus with
          | Some bus ->
-           safe_publish bus
+           safe_publish
+             bus
              { meta = Pipeline_common.event_envelope agent
              ; payload =
                  ContextCompacted
@@ -956,7 +956,8 @@ let emergency_compact ?raw_trace_run agent ?limit () =
               }));
       (match agent.options.event_bus with
        | Some bus ->
-         safe_publish bus
+         safe_publish
+           bus
            { meta = Pipeline_common.event_envelope agent
            ; payload =
                ContextCompacted
@@ -1038,7 +1039,8 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
       (* Emit ContextOverflowImminent before compaction *)
       (match agent.options.event_bus with
        | Some bus ->
-         safe_publish bus
+         safe_publish
+           bus
            { meta = Pipeline_common.event_envelope agent
            ; payload =
                ContextOverflowImminent
@@ -1052,7 +1054,8 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
       (* Emit ContextCompactStarted *)
       (match agent.options.event_bus with
        | Some bus ->
-         safe_publish bus
+         safe_publish
+           bus
            { meta = Pipeline_common.event_envelope agent
            ; payload =
                ContextCompactStarted
@@ -1152,7 +1155,8 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
         when agent.auto_context_overflow_retry && compact_attempts < 2 ->
         (match agent.options.event_bus with
          | Some bus ->
-           safe_publish bus
+           safe_publish
+             bus
              { meta = Pipeline_common.event_envelope agent
              ; payload =
                  ContextCompactStarted


### PR DESCRIPTION
## Summary
- Replace 8 bare `Eio.traceln` calls with structured logging across 3 files
- `pipeline.ml`: compact_watermark_default validation → `Log.warn` with field
- `cli_common_subprocess.ml` (6 sites): → `Diag.warn` (llm_provider library boundary)
- `transport_cli_tool_c.ml`: unsupported model warning → `Diag.warn`

## Notes
- `lib/base/hooks.ml` intentionally kept as `Eio.traceln` — `agent_sdk_base` cannot reference `agent_sdk`'s `Log` module (circular dependency direction: `agent_sdk` → `agent_sdk_base`)
- All remaining `Eio.traceln` references in `lib/` are now in doc comments only

## Test plan
- [x] `dune build` passes (0 errors, pre-existing warning only)
- [ ] CI full build + tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>