### PR TITLE
[codex] support MiMo token plan endpoint

### DIFF
--- a/agent_sdk.opam
+++ b/agent_sdk.opam
@@ -16,6 +16,7 @@ depends: [
   "cohttp-eio" {>= "6.2.0"}
   "tls" {>= "2.0.0"}
   "tls-eio" {>= "2.0.0"}
+  "mirage-crypto-rng" {>= "1.0.0"}
   "ca-certs" {>= "1.0.0"}
   "yojson" {>= "3.0.0" & < "4.0.0"}
   "ppx_deriving_yojson" {>= "3.10.0"}

--- a/bin/dune
+++ b/bin/dune
@@ -2,7 +2,7 @@
  (name oas_cli_support)
  (wrapped false)
  (modules oas_cli_support)
- (libraries eio eio_main unix))
+ (libraries eio eio_main mirage-crypto-rng.unix unix))
 
 (executable
  (name oas_runtime)

--- a/bin/oas_cli_support.ml
+++ b/bin/oas_cli_support.ml
@@ -1,6 +1,7 @@
 let with_runtime f =
   Eio_main.run
   @@ fun env ->
+  Mirage_crypto_rng_unix.use_default ();
   Eio.Switch.run
   @@ fun sw ->
   let net = Eio.Stdenv.net env in

--- a/dune-project
+++ b/dune-project
@@ -20,6 +20,7 @@
   (cohttp-eio (>= 6.2.0))
   (tls (>= 2.0.0))
   (tls-eio (>= 2.0.0))
+  (mirage-crypto-rng (>= 1.0.0))
   (ca-certs (>= 1.0.0))
   (yojson (and (>= 3.0.0) (< 4.0.0)))
   (ppx_deriving_yojson (>= 3.10.0))

--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -32,6 +32,60 @@
 
 open Result_syntax
 
+let bearer_auth_header_for_env api_key_env =
+  if String.trim api_key_env = "" then None else Some "Authorization"
+;;
+
+let string_has_suffix s suffix =
+  let len = String.length s in
+  let suffix_len = String.length suffix in
+  len >= suffix_len && String.sub s (len - suffix_len) suffix_len = suffix
+;;
+
+let string_has_prefix s prefix =
+  let len = String.length s in
+  let prefix_len = String.length prefix in
+  len >= prefix_len && String.sub s 0 prefix_len = prefix
+;;
+
+let trim_trailing_slashes s =
+  let rec loop i =
+    if
+      i > 0
+      && s.[i - 1] = '/'
+      && not (i >= 3 && s.[i - 3] = ':' && s.[i - 2] = '/' && s.[i - 1] = '/')
+    then loop (i - 1)
+    else String.sub s 0 i
+  in
+  loop (String.length s)
+;;
+
+let normalize_request_path path =
+  let path = String.trim path in
+  if path = "" || path.[0] = '/' then path else "/" ^ path
+;;
+
+let normalize_openai_compat_endpoint ~base_url ~path =
+  let base_url = base_url |> String.trim |> trim_trailing_slashes in
+  let path = normalize_request_path path in
+  let path =
+    if string_has_suffix base_url "/v1" && string_has_prefix path "/v1/"
+    then String.sub path 3 (String.length path - 3)
+    else path
+  in
+  base_url, path
+;;
+
+let openai_compat_config ~base_url ~api_key_env ?(path = "/v1/chat/completions") () =
+  let base_url, path = normalize_openai_compat_endpoint ~base_url ~path in
+  Provider.OpenAICompat
+    { base_url
+    ; auth_header = bearer_auth_header_for_env api_key_env
+    ; path
+    ; static_token = None
+    }
+;;
+
 (* ── Tool config ─────────────────────────────────────────── *)
 
 type tool_file_config =
@@ -273,20 +327,15 @@ let resolve_provider ~model_id provider_str base_url =
     | Some Provider_a ->
       { Provider.provider = Provider_a; model_id; api_key_env = "PROVIDER_A_API_KEY" }
     | Some Provider_d_compat ->
+      let api_key_env = "PROVIDER_D_API_KEY" in
       let url =
         match base_url with
         | Some u -> u
         | None -> "https://api.provider_d.com"
       in
-      { Provider.provider =
-          OpenAICompat
-            { base_url = url
-            ; auth_header = None
-            ; path = "/v1/chat/completions"
-            ; static_token = None
-            }
+      { Provider.provider = openai_compat_config ~base_url:url ~api_key_env ()
       ; model_id
-      ; api_key_env = "PROVIDER_D_API_KEY"
+      ; api_key_env
       }
     | Some
         ( Provider_c
@@ -318,31 +367,26 @@ let resolve_provider ~model_id provider_str base_url =
                     flattens to Provider_d_compat. For kind-preserving override,
                     construct Llm_provider.Provider_config.t directly via
                     Provider_config.make. *)
+            let api_key_env = entry.defaults.api_key_env in
             { Provider.provider =
-                OpenAICompat
-                  { base_url = url
-                  ; auth_header = None
-                  ; path = entry.defaults.request_path
-                  ; static_token = None
-                  }
+                openai_compat_config
+                  ~base_url:url
+                  ~api_key_env
+                  ~path:entry.defaults.request_path
+                  ()
             ; model_id
-            ; api_key_env = entry.defaults.api_key_env
+            ; api_key_env
             })
        | None ->
+         let api_key_env = provider_str in
          let url =
            match base_url with
            | Some u -> u
            | None -> Defaults.local_llm_url
          in
-         { Provider.provider =
-             OpenAICompat
-               { base_url = url
-               ; auth_header = None
-               ; path = "/v1/chat/completions"
-               ; static_token = None
-               }
+         { Provider.provider = openai_compat_config ~base_url:url ~api_key_env ()
          ; model_id
-         ; api_key_env = provider_str
+         ; api_key_env
          }))
 ;;
 

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -433,6 +433,7 @@ type static_model_route =
   | Provider_d_5
   | Provider_d_4_1
   | Provider_d_4o
+  | Mimo_v2_5_chat
   | Provider_f of provider_f_family
   | Provider_c_for_coding
   | Provider_c_k2
@@ -506,6 +507,8 @@ let static_model_route_of_id model_id =
   then Some Provider_d_4_1
   else if String.starts_with ~prefix:"model-d" m
   then Some Provider_d_4o
+  else if m = "mimo-v2.5" || String.starts_with ~prefix:"mimo-v2.5-pro" m
+  then Some Mimo_v2_5_chat
   else (
     match provider_f_family_of_id m with
     | (Provider_f_3 | Provider_f_3_1 | Provider_f_2_5) as family ->
@@ -634,6 +637,12 @@ let capabilities_of_static_model_route = function
       { provider_d_chat_capabilities with
         max_context_tokens = Some 128_000
       ; max_output_tokens = Some 16_384
+      }
+  | Mimo_v2_5_chat ->
+    Some
+      { provider_d_chat_capabilities with
+        supports_reasoning = true
+      ; thinking_control_format = Thinking_object_only
       }
   | Provider_f _ -> Some provider_f_capabilities
   | Provider_c_for_coding | Provider_c_k2 -> Some provider_c_capabilities

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -133,6 +133,7 @@ type static_model_route =
   | Provider_d_5
   | Provider_d_4_1
   | Provider_d_4o
+  | Mimo_v2_5_chat
   | Provider_f of provider_f_family
   | Provider_c_for_coding
   | Provider_c_k2

--- a/test/test_agent_config_deep.ml
+++ b/test/test_agent_config_deep.ml
@@ -334,8 +334,9 @@ let test_resolve_provider_a () =
 let test_resolve_provider_d () =
   let cfg = Agent_config.resolve_provider ~model_id:"model-d-4" "provider_d" None in
   match cfg.provider with
-  | Provider.OpenAICompat { base_url; _ } ->
+  | Provider.OpenAICompat { base_url; auth_header; _ } ->
     Alcotest.(check string) "base_url" "https://api.provider_d.com" base_url;
+    Alcotest.(check (option string)) "auth header" (Some "Authorization") auth_header;
     Alcotest.(check string) "api_key_env" "PROVIDER_D_API_KEY" cfg.api_key_env
   | _ -> Alcotest.fail "expected OpenAICompat"
 ;;
@@ -348,16 +349,18 @@ let test_resolve_provider_d_custom_url () =
       (Some "http://custom:4000")
   in
   match cfg.provider with
-  | Provider.OpenAICompat { base_url; _ } ->
-    Alcotest.(check string) "custom url" "http://custom:4000" base_url
+  | Provider.OpenAICompat { base_url; auth_header; _ } ->
+    Alcotest.(check string) "custom url" "http://custom:4000" base_url;
+    Alcotest.(check (option string)) "auth header" (Some "Authorization") auth_header
   | _ -> Alcotest.fail "expected OpenAICompat"
 ;;
 
 let test_resolve_other () =
   let cfg = Agent_config.resolve_provider ~model_id:"m1" "MY_CUSTOM_KEY" None in
   match cfg.provider with
-  | Provider.OpenAICompat _ ->
-    Alcotest.(check string) "api_key_env" "MY_CUSTOM_KEY" cfg.api_key_env
+  | Provider.OpenAICompat { auth_header; _ } ->
+    Alcotest.(check string) "api_key_env" "MY_CUSTOM_KEY" cfg.api_key_env;
+    Alcotest.(check (option string)) "auth header" (Some "Authorization") auth_header
   | _ -> Alcotest.fail "expected OpenAICompat"
 ;;
 
@@ -366,8 +369,25 @@ let test_resolve_other_custom_url () =
     Agent_config.resolve_provider ~model_id:"m1" "MY_KEY" (Some "http://custom:5000")
   in
   match cfg.provider with
-  | Provider.OpenAICompat { base_url; _ } ->
-    Alcotest.(check string) "custom url" "http://custom:5000" base_url
+  | Provider.OpenAICompat { base_url; auth_header; _ } ->
+    Alcotest.(check string) "custom url" "http://custom:5000" base_url;
+    Alcotest.(check (option string)) "auth header" (Some "Authorization") auth_header
+  | _ -> Alcotest.fail "expected OpenAICompat"
+;;
+
+let test_resolve_other_openai_v1_base_url () =
+  let cfg =
+    Agent_config.resolve_provider
+      ~model_id:"mimo-v2.5-pro"
+      "MIMO_API_KEY"
+      (Some "https://token-plan-sgp.xiaomimimo.com/v1")
+  in
+  match cfg.provider with
+  | Provider.OpenAICompat { base_url; auth_header; path; _ } ->
+    Alcotest.(check string) "base_url" "https://token-plan-sgp.xiaomimimo.com/v1" base_url;
+    Alcotest.(check string) "path" "/chat/completions" path;
+    Alcotest.(check (option string)) "auth header" (Some "Authorization") auth_header;
+    Alcotest.(check string) "api_key_env" "MIMO_API_KEY" cfg.api_key_env
   | _ -> Alcotest.fail "expected OpenAICompat"
 ;;
 
@@ -401,8 +421,9 @@ let test_resolve_provider_i_custom_url () =
       (Some "http://proxy:8080")
   in
   match cfg.provider with
-  | Provider.OpenAICompat { base_url; _ } ->
-    Alcotest.(check string) "overridden url" "http://proxy:8080" base_url
+  | Provider.OpenAICompat { base_url; auth_header; _ } ->
+    Alcotest.(check string) "overridden url" "http://proxy:8080" base_url;
+    Alcotest.(check (option string)) "auth header" (Some "Authorization") auth_header
   | _ -> Alcotest.fail "expected OpenAICompat for provider_i custom url"
 ;;
 
@@ -505,6 +526,21 @@ let test_resolve_unknown_still_goes_to_registry_fallback () =
   | _ -> Alcotest.fail "expected registry fallback OpenAICompat"
 ;;
 
+let test_resolve_ollama_custom_url_stays_no_auth () =
+  let cfg =
+    Agent_config.resolve_provider
+      ~model_id:"llama3.2"
+      "ollama"
+      (Some "http://127.0.0.1:11434")
+  in
+  match cfg.provider with
+  | Provider.OpenAICompat { base_url; auth_header; path; _ } ->
+    Alcotest.(check string) "base_url" "http://127.0.0.1:11434" base_url;
+    Alcotest.(check string) "path" "/api/chat" path;
+    Alcotest.(check (option string)) "auth header" None auth_header
+  | _ -> Alcotest.fail "expected OpenAICompat for ollama custom url"
+;;
+
 (* ── of_json error cases ─────────────────────────────────────── *)
 
 let test_of_json_bad_param () =
@@ -598,6 +634,7 @@ let () =
         ; tc "provider_d custom url" test_resolve_provider_d_custom_url
         ; tc "other" test_resolve_other
         ; tc "other custom url" test_resolve_other_custom_url
+        ; tc "other OpenAI /v1 base url" test_resolve_other_openai_v1_base_url
         ; tc "provider_i" test_resolve_provider_i
         ; tc "provider_i custom url" test_resolve_provider_i_custom_url
         ; tc "provider_g" test_resolve_provider_g
@@ -610,6 +647,9 @@ let () =
         ; tc
             "unknown still goes to registry fallback"
             test_resolve_unknown_still_goes_to_registry_fallback
+        ; tc
+            "ollama custom url stays no-auth"
+            test_resolve_ollama_custom_url_stays_no_auth
         ] )
     ]
 ;;

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -103,6 +103,18 @@ let test_provider_d_extended () =
   check bool "has min_p" true c.supports_min_p
 ;;
 
+let test_lookup_mimo_v25_pro () =
+  match Capabilities.for_model_id "mimo-v2.5-pro" with
+  | Some c ->
+    check bool "has reasoning" true c.supports_reasoning;
+    check_thinking_control
+      "uses thinking object only"
+      Capabilities.Thinking_object_only
+      c.thinking_control_format;
+    check bool "has tools" true c.supports_tools
+  | None -> fail "should match mimo-v2.5-pro"
+;;
+
 (* ── Model lookup ────────────────────────────────────── *)
 
 let test_lookup_agent_llm_a_opus () =
@@ -160,6 +172,7 @@ let pp_static_model_route ppf = function
   | Capabilities.Provider_d_5 -> Format.fprintf ppf "Provider_d_5"
   | Capabilities.Provider_d_4_1 -> Format.fprintf ppf "Provider_d_4_1"
   | Capabilities.Provider_d_4o -> Format.fprintf ppf "Provider_d_4o"
+  | Capabilities.Mimo_v2_5_chat -> Format.fprintf ppf "Mimo_v2_5_chat"
   | Capabilities.Provider_f family ->
     Format.fprintf ppf "Provider_f(%a)" pp_provider_f_family family
   | Capabilities.Provider_c_for_coding -> Format.fprintf ppf "Provider_c_for_coding"
@@ -189,6 +202,7 @@ let pp_static_model_route ppf = function
   | Capabilities.Glm_4_flash -> Format.fprintf ppf "Glm_4_flash"
   | Capabilities.Glm_4v -> Format.fprintf ppf "Glm_4v"
   | Capabilities.Glm_4 -> Format.fprintf ppf "Glm_4"
+  | Capabilities.Qwen_3 -> Format.fprintf ppf "Qwen_3"
 ;;
 
 let static_model_route_testable = Alcotest.testable pp_static_model_route ( = )
@@ -718,6 +732,7 @@ let test_provider_d_compat_reasoning_records_have_explicit_control () =
     [ "provider_d_chat_extended", Some Capabilities.provider_d_chat_extended_capabilities
     ; "provider_c", Some Capabilities.provider_c_capabilities
     ; "provider_h", Some Capabilities.provider_h_capabilities
+    ; "mimo-v2.5-pro", Capabilities.for_model_id "mimo-v2.5-pro"
     ; "provider_h-3.5", Capabilities.for_model_id "provider_h-3.5-35b-a3b"
     ; "provider_g-v4-flash", Capabilities.for_model_id "provider_g-v4-flash"
     ; "provider_l-ultra", Capabilities.for_model_id "provider_l-ultra-253b"
@@ -867,6 +882,7 @@ let () =
         ; test_case "provider_k-5v vision" `Quick test_lookup_glm5v_vision
         ; test_case "provider_k-4.6v vision" `Quick test_lookup_glm46v_vision
         ; test_case "provider_k-ocr vision" `Quick test_lookup_glm_ocr
+        ; test_case "mimo-v2.5-pro" `Quick test_lookup_mimo_v25_pro
         ; test_case "unknown" `Quick test_lookup_unknown
         ; test_case "case insensitive" `Quick test_lookup_case_insensitive
         ] )


### PR DESCRIPTION
## Summary

- Initialize Mirage crypto RNG in the OAS CLI runtime before HTTPS provider calls.
- Send Bearer auth for OpenAI-compatible custom endpoints when an API key env var is configured.
- Normalize OpenAI-compatible `/v1` base URLs so token-plan endpoints do not become `/v1/v1/chat/completions`.
- Add MiMo V2.5 capability metadata so `enable_thinking=false` emits the provider's thinking-disable shape.

## Why

The Xiaomi MiMo Token Plan endpoint uses an OpenAI-compatible base URL at `https://token-plan-sgp.xiaomimimo.com/v1`. The OAS JSON config path reached the provider but failed across three surfaces: missing RNG initialization for TLS, missing auth for custom OpenAI-compatible configs, and duplicated `/v1` path construction. After those were fixed, MiMo still returned thinking output unless OAS knew the model's thinking-control shape.

## Validation

- `ocamlformat --check bin/oas_cli_support.ml lib/agent/agent_config.ml lib/llm_provider/capabilities.ml lib/llm_provider/capabilities.mli test/test_agent_config_deep.ml test/test_capabilities.ml`
- `DUNE_BUILD_DIR=.../_build dune build --root ... -j 1 test/test_agent_config_deep.exe test/test_capabilities.exe`
- `./_build/default/test/test_agent_config_deep.exe` (37 tests)
- `./_build/default/test/test_capabilities.exe` (47 tests)
- Live smoke against MiMo Token Plan endpoint with `MIMO_API_KEY`: returned `ok` with no `[thinking]` output
- `git diff --check`