### PR TITLE
fix: remove masc reference from comment for SDK independence (#1791)

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1183,8 +1183,8 @@ let%test "for_model_id provider_k-4.5-flash has GLM-4.5 thinking limits" =
 
 (* qwen3 family tests use [for_model_id_static] rather than [for_model_id]
    so they remain stable when an ambient [OAS_CAPABILITY_MANIFEST] or
-   the default [~/.masc/config/capability-manifest.json] overrides the
-   static table — the contract under test here is the static fallback
+   an external manifest file overrides the static table — the contract
+   under test here is the static fallback
    for environments without a manifest. *)
 let%test "for_model_id_static qwen3 has extended thinking" =
   match for_model_id_static "qwen3-32b" with


### PR DESCRIPTION
## Summary

- `lib/llm_provider/capabilities.ml:1186` コメント内に `~/.masc/config/capability-manifest.json` への参照があり、`check-sdk-independence.sh` の `\bmasc\b` パターンマッチに引っかかっていた
- コメントを汎用的な「external manifest file」表現に変更

## Test plan

- [ ] `bash scripts/check-sdk-independence.sh` が PASSすることを確認
- [ ] コメントのみの変更なので既存テストへの影響なし

Closes #1791

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>