### PR TITLE
[codex] normalize provider tool names

### DIFF
--- a/lib/agent/agent_tool_name_alias.ml
+++ b/lib/agent/agent_tool_name_alias.ml
@@ -1,0 +1,119 @@
+let has_assoc_key key fields = List.exists (fun (k, _) -> String.equal k key) fields
+
+let assoc_first_string keys fields =
+  let rec loop = function
+    | [] -> None
+    | key :: rest ->
+      (match List.assoc_opt key fields with
+       | Some (`String value) -> Some value
+       | _ -> loop rest)
+  in
+  loop keys
+;;
+
+let select_assoc_keys keys fields =
+  List.filter_map
+    (fun key ->
+       match List.assoc_opt key fields with
+       | Some value -> Some (key, value)
+       | None -> None)
+    keys
+;;
+
+let normalize_read_input = function
+  | `Assoc fields as input ->
+    if has_assoc_key "file_path" fields
+    then input
+    else (
+      match List.assoc_opt "path" fields with
+      | Some path -> `Assoc (("file_path", path) :: fields)
+      | None -> input)
+  | input -> input
+;;
+
+let normalize_search_input = function
+  | `Assoc fields as input ->
+    if has_assoc_key "pattern" fields
+    then input
+    else (
+      match assoc_first_string [ "query"; "regex"; "name"; "needle" ] fields with
+      | Some pattern -> `Assoc (("pattern", `String pattern) :: fields)
+      | None -> input)
+  | input -> input
+;;
+
+let simple_argv_unsafe_char = function
+  | '\000'
+  | '\n'
+  | '\r'
+  | '\t'
+  | '\''
+  | '"'
+  | '`'
+  | '|'
+  | '&'
+  | ';'
+  | '<'
+  | '>'
+  | '('
+  | ')'
+  | '{'
+  | '}'
+  | '['
+  | ']'
+  | '$'
+  | '*'
+  | '?'
+  | '!'
+  | '~'
+  | '#' -> true
+  | _ -> false
+;;
+
+let simple_command_tokens command =
+  let command = String.trim command in
+  if String.length command = 0 || String.exists simple_argv_unsafe_char command
+  then None
+  else (
+    let tokens =
+      command
+      |> String.split_on_char ' '
+      |> List.filter (fun token -> not (String.equal token ""))
+    in
+    match tokens with
+    | [] -> None
+    | _ -> Some tokens)
+;;
+
+let normalize_execute_input = function
+  | `Assoc fields as input ->
+    if has_assoc_key "executable" fields || has_assoc_key "pipeline" fields
+    then input
+    else (
+      match
+        match assoc_first_string [ "command"; "cmd" ] fields with
+        | Some command -> simple_command_tokens command
+        | None -> None
+      with
+      | Some (executable :: argv) ->
+        let passthrough =
+          select_assoc_keys
+            [ "cwd"; "env"; "timeout_sec"; "stdin"; "stdout"; "stderr" ]
+            fields
+        in
+        `Assoc
+          (("executable", `String executable)
+           :: ("argv", `List (List.map (fun arg -> `String arg) argv))
+           :: passthrough)
+      | Some [] | None -> input)
+  | input -> input
+;;
+
+let resolve ~requested ~input =
+  match requested with
+  | "Read" -> Some ("ReadFile", normalize_read_input input)
+  | "Grep" | "Search" | "Find" -> Some ("SearchFiles", normalize_search_input input)
+  | "Bash" | "Shell" | "execute_command" | "masc_code_shell" ->
+    Some ("Execute", normalize_execute_input input)
+  | _ -> None
+;;

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -152,30 +152,11 @@ let unknown_tool_failure ~requested ~available =
   , failure_kind )
 ;;
 
-let has_assoc_key key fields = List.exists (fun (k, _) -> String.equal k key) fields
-
-let normalize_read_alias_input = function
-  | `Assoc fields as input ->
-    if has_assoc_key "file_path" fields
-    then input
-    else (
-      match List.assoc_opt "path" fields with
-      | Some path -> `Assoc (("file_path", path) :: fields)
-      | None -> input)
-  | input -> input
-;;
-
-let legacy_tool_alias requested input =
-  match requested with
-  | "Read" -> Some ("ReadFile", normalize_read_alias_input input)
-  | _ -> None
-;;
-
 let resolve_tool_call tool_index name input =
   match find_in_index tool_index name with
   | Some tool -> name, input, Some tool, None
   | None ->
-    (match legacy_tool_alias name input with
+    (match Agent_tool_name_alias.resolve ~requested:name ~input with
      | Some (alias, aliased_input) ->
        (match find_in_index tool_index alias with
         | Some tool -> alias, aliased_input, Some tool, Some alias
@@ -305,7 +286,7 @@ let find_and_execute_tool_with_index
    | Some alias ->
      Log.info
        _log
-       "legacy tool alias resolved"
+       "provider tool name alias resolved"
        [ Log.S ("requested_tool", requested_name); Log.S ("resolved_tool", alias) ]
    | None -> ());
   (* ToolCalled event — capture the published envelope's run_id so the

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -645,7 +645,7 @@ let test_unknown_tool_reports_available_tools_and_retries () =
   | _ -> fail "on_error fired more than once"
 ;;
 
-let test_legacy_read_dispatches_to_read_file_when_visible () =
+let test_provider_read_alias_dispatches_to_read_file_when_visible () =
   Eio_main.run
   @@ fun _env ->
   let context = Context.create () in
@@ -689,9 +689,9 @@ let test_legacy_read_dispatches_to_read_file_when_visible () =
       ~schedule
       "Read"
       (`Assoc [ "path", `String "README.md" ])
-      "tool-legacy-read"
+      "tool-name-alias-read"
   in
-  check bool "legacy Read succeeds" false result.is_error;
+  check bool "provider Read alias succeeds" false result.is_error;
   check string "result uses visible tool name" "ReadFile" result.tool_name;
   check string "read content" "read-ok" result.content;
   check bool "on_error not called" false !on_error_called;
@@ -717,6 +717,146 @@ let test_legacy_read_dispatches_to_read_file_when_visible () =
           | Event_bus.ToolCompleted { tool_name; _ } -> String.equal tool_name "ReadFile"
           | _ -> false)
        events)
+;;
+
+let test_provider_search_alias_dispatches_to_search_files_when_visible () =
+  Eio_main.run
+  @@ fun _env ->
+  let context = Context.create () in
+  let captured_input = ref `Null in
+  let search_files =
+    Tool.create
+      ~name:"SearchFiles"
+      ~description:"Search files"
+      ~parameters:[]
+      (fun input ->
+         captured_input := input;
+         Ok { Types.content = "search-ok" })
+  in
+  let schedule : Hooks.tool_schedule =
+    { planned_index = 0
+    ; batch_index = 0
+    ; batch_size = 1
+    ; concurrency_class = "sequential_workspace"
+    ; batch_kind = "sequential"
+    }
+  in
+  let on_error_called = ref false in
+  let hooks =
+    { Hooks.empty with
+      on_error =
+        Some
+          (fun _event ->
+            on_error_called := true;
+            Hooks.Continue)
+    }
+  in
+  let result =
+    Agent_tools.find_and_execute_tool
+      ~context
+      ~tools:[ search_files ]
+      ~hooks
+      ~event_bus:None
+      ~tracer:Tracing.null
+      ~agent_name:"agent"
+      ~turn_count:0
+      ~schedule
+      "Grep"
+      (`Assoc [ "query", `String "tool_returned_error_result"; "path", `String "logs" ])
+      "tool-name-alias-search"
+  in
+  check bool "provider Grep alias succeeds" false result.is_error;
+  check string "result uses visible tool name" "SearchFiles" result.tool_name;
+  check string "search content" "search-ok" result.content;
+  check bool "on_error not called" false !on_error_called;
+  match !captured_input with
+  | `Assoc fields ->
+    check
+      (option string)
+      "query normalized to pattern"
+      (Some "tool_returned_error_result")
+      (match List.assoc_opt "pattern" fields with
+       | Some (`String pattern) -> Some pattern
+       | _ -> None);
+    check
+      (option string)
+      "path preserved"
+      (Some "logs")
+      (match List.assoc_opt "path" fields with
+       | Some (`String path) -> Some path
+       | _ -> None)
+  | _ -> fail "expected object input"
+;;
+
+let test_provider_execute_alias_dispatches_simple_command_as_typed_argv () =
+  Eio_main.run
+  @@ fun _env ->
+  let context = Context.create () in
+  let captured_input = ref `Null in
+  let execute =
+    Tool.create
+      ~name:"Execute"
+      ~description:"Execute command"
+      ~parameters:[]
+      (fun input ->
+         captured_input := input;
+         Ok { Types.content = "execute-ok" })
+  in
+  let schedule : Hooks.tool_schedule =
+    { planned_index = 0
+    ; batch_index = 0
+    ; batch_size = 1
+    ; concurrency_class = "sequential_workspace"
+    ; batch_kind = "sequential"
+    }
+  in
+  let result =
+    Agent_tools.find_and_execute_tool
+      ~context
+      ~tools:[ execute ]
+      ~hooks:Hooks.empty
+      ~event_bus:None
+      ~tracer:Tracing.null
+      ~agent_name:"agent"
+      ~turn_count:0
+      ~schedule
+      "execute_command"
+      (`Assoc [ "command", `String "git status --short"; "cwd", `String "/tmp/workspace" ])
+      "tool-name-alias-execute"
+  in
+  check bool "provider execute_command alias succeeds" false result.is_error;
+  check string "result uses visible tool name" "Execute" result.tool_name;
+  check string "execute content" "execute-ok" result.content;
+  match !captured_input with
+  | `Assoc fields ->
+    check
+      (option string)
+      "command normalized to executable"
+      (Some "git")
+      (match List.assoc_opt "executable" fields with
+       | Some (`String executable) -> Some executable
+       | _ -> None);
+    check
+      (list string)
+      "command args normalized to argv"
+      [ "status"; "--short" ]
+      (match List.assoc_opt "argv" fields with
+       | Some (`List argv) ->
+         List.filter_map
+           (function
+             | `String arg -> Some arg
+             | _ -> None)
+           argv
+       | _ -> []);
+    check
+      (option string)
+      "cwd preserved"
+      (Some "/tmp/workspace")
+      (match List.assoc_opt "cwd" fields with
+       | Some (`String cwd) -> Some cwd
+       | _ -> None);
+    check bool "raw command omitted" false (List.mem_assoc "command" fields)
+  | _ -> fail "expected object input"
 ;;
 
 let test_on_error_silent_on_successful_dispatch () =
@@ -1061,9 +1201,17 @@ let () =
             `Quick
             test_unknown_tool_reports_available_tools_and_retries
         ; test_case
-            "legacy Read dispatches to ReadFile when visible"
+            "provider Read alias dispatches to ReadFile when visible"
             `Quick
-            test_legacy_read_dispatches_to_read_file_when_visible
+            test_provider_read_alias_dispatches_to_read_file_when_visible
+        ; test_case
+            "provider Grep alias dispatches to SearchFiles when visible"
+            `Quick
+            test_provider_search_alias_dispatches_to_search_files_when_visible
+        ; test_case
+            "provider execute_command alias dispatches to typed Execute when visible"
+            `Quick
+            test_provider_execute_alias_dispatches_simple_command_as_typed_argv
         ; test_case
             "on_error silent on successful dispatch"
             `Quick


### PR DESCRIPTION
## Summary

- Normalize provider-emitted tool names to visible public tool names when the target tool is already available.
- Map `Grep`/`Search`/`Find` to `SearchFiles`, including deterministic `query`/`regex`/`name`/`needle` to `pattern` normalization.
- Map `Bash`/`Shell`/`execute_command`/`masc_code_shell` to `Execute`, with conservative simple-command conversion to typed `executable`/`argv`.

## Why

MASC runtime logs showed repeated `Tool not found` errors for provider-emitted names after the public tool surface moved to names like `ReadFile`, `SearchFiles`, and typed `Execute`. The dispatch layer already recovered `Read -> ReadFile`; this extends that provider-name normalization path without exposing aliases unless the target public tool is already visible.

## Validation

- `scripts/dune-local.sh build test/test_event_bus.exe`
- `./_build/default/test/test_event_bus.exe`