### PR TITLE
fix(llm_provider): restore main green — finish service-name migration (#1811)

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -480,6 +480,7 @@ let static_model_route_of_id model_id =
       else if
         String.starts_with ~prefix:"provider_h-3" m
         || String.starts_with ~prefix:"provider_h_3" m
+        || String.starts_with ~prefix:"dashscope_3" m
       then Some DashScope_3
       else if
         String.starts_with ~prefix:"model-n-4" m || String.starts_with ~prefix:"llama4" m

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -502,7 +502,7 @@ let test_config_of_provider_config_provider_c_uses_custom_provider () =
   match Provider.config_of_provider_config cfg with
   | { provider = Provider.Custom_registered { name }; api_key_env; _ } ->
     Alcotest.(check string) "provider name" "provider_c" name;
-    Alcotest.(check string) "api_key_env" "PROVIDER_C_API_KEY" api_key_env
+    Alcotest.(check string) "api_key_env" "KIMI_API_KEY" api_key_env
   | _ ->
     Alcotest.fail "expected provider_c config to round-trip through Custom_registered"
 ;;
@@ -585,7 +585,7 @@ let test_provider_config_of_agent_provider_a () =
   | Ok pc ->
     Alcotest.(check string)
       "kind"
-      "provider_a"
+      "anthropic"
       (Llm_provider.Provider_config.string_of_provider_kind pc.kind);
     Alcotest.(check string) "model_id" "agent_llm_a-sonnet-4-20250514" pc.model_id;
     Alcotest.(check string) "api_key" "sk-ant-adapter-test" pc.api_key;
@@ -632,8 +632,8 @@ let test_provider_config_of_agent_provider_d_compat_collapses () =
   with
   | Ok pc ->
     Alcotest.(check string)
-      "kind collapses to provider_d_compat"
-      "provider_d_compat"
+      "kind collapses to openai_compat"
+      "openai_compat"
       (Llm_provider.Provider_config.string_of_provider_kind pc.kind);
     Alcotest.(check string)
       "base_url from resolve"
@@ -680,8 +680,8 @@ let test_provider_config_of_agent_none_fallback () =
   with
   | Ok pc ->
     Alcotest.(check string)
-      "defaults to provider_a"
-      "provider_a"
+      "defaults to anthropic"
+      "anthropic"
       (Llm_provider.Provider_config.string_of_provider_kind pc.kind);
     Alcotest.(check string) "uses fallback key" "sk-ant-default-fallback" pc.api_key;
     Alcotest.(check string)
@@ -710,7 +710,7 @@ let test_provider_config_of_agent_local_strips_dummy_key () =
   | Ok pc ->
     Alcotest.(check string)
       "kind"
-      "provider_d_compat"
+      "openai_compat"
       (Llm_provider.Provider_config.string_of_provider_kind pc.kind);
     Alcotest.(check string) "request_path" "/v1/chat/completions" pc.request_path;
     Alcotest.(check string) "local strips dummy api_key" "" pc.api_key;


### PR DESCRIPTION
## 목표

`#1811`로 추적한 pre-existing main breakage 6건 해소. 사용자 결정("익명
라벨 유지하지 않음")에 따라, `#1809` 이후 `Provider_kind.to_string`이 이미
반환하는 **service 이름**을 SSOT로 삼고 테스트·라우팅을 정렬한다.

## 변경 내용

**test_provider (5건)** — 코드는 이미 service 이름을 반환, 테스트 기대값만 lag
- `provider_config_of_agent` kind: `"provider_a"` → `"anthropic"`,
  `"provider_d_compat"` → `"openai_compat"`
- `api_key_env`: `"PROVIDER_C_API_KEY"` → `"KIMI_API_KEY"`

**test_capabilities (1건)** — 라우팅 키 실명화 누락 (코드 수정)
- `static_model_route_of_id`에 `"dashscope_3"` prefix 추가 (기존
  `"provider_h-3"`/`"provider_h_3"` 옆에). `#1809`가 capability 레코드는
  DashScope로 rename했지만 라우팅은 익명 prefix만 인식해, 실제 DashScope
  모델 id(`DashScope_3.6-...gguf`)가 `None`으로 떨어졌다.

## 로컬 검증

- `dune exec --root . test/test_provider.exe` → 41/41 통과
- `dune exec --root . test/test_capabilities.exe` → 47/47 통과
- `dune build --root . lib` → clean
- baseline: `599a5522`(#1809)에서 6건 모두 실패하던 것을 확인 후 수정

## 범위 / 후속

- 이 PR은 **테스트 기대값 정렬 + 라우팅 prefix 1건**으로 main을 green으로
  되돌린다.
- 코드의 잔존 익명 표기(HTTP 헤더 `provider_a-version` → `anthropic-version`,
  `config_of_provider_config`의 `name="provider_c"`, model_id 문자열
  `agent_llm_a-*`/`provider_c-*` 등)는 외부 API 호환 영향이 있어 별도
  작업으로 분리한다. 이는 익명화 시스템 전면 제거의 큰 그림에 속한다.

Closes #1811

🤖 Generated with [Claude Code](https://claude.com/claude-code)