### PR TITLE
feat(http_client): diagnose oversized request headers that CDN proxies reject

### DIFF
--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -234,6 +234,68 @@ let log_close_failure ~url ~message =
   Diag.warn "http_client" "%s" (Yojson.Safe.to_string json)
 ;;
 
+(* CDN/reverse-proxy total-header-size budget. Cloudflare and similar edges
+   (e.g. RunPod's *.proxy.runpod.net) reject requests whose combined header
+   bytes exceed roughly this size with an opaque "400 Bad Request" HTML page
+   returned at the edge — before the request reaches the origin server. The SDK
+   then surfaces only that HTML, which is undiagnosable. 8 KB is conservative:
+   normal completion requests carry well under 1 KB of headers, so this only
+   fires on genuinely oversized request-scoped headers. *)
+let cdn_safe_header_budget_bytes = 8192
+
+(* key + ": " + value + CRLF — the on-wire size of one header line. *)
+let header_line_bytes (key, value) =
+  String.length key + String.length value + 4
+
+let warn_if_headers_exceed_cdn_budget ~url headers =
+  let total = List.fold_left (fun acc h -> acc + header_line_bytes h) 0 headers in
+  if total > cdn_safe_header_budget_bytes then begin
+    let largest =
+      headers
+      |> List.map (fun ((k, _) as h) -> (k, header_line_bytes h))
+      |> List.sort (fun (_, a) (_, b) -> compare b a)
+      |> (function a :: b :: c :: _ -> [ a; b; c ] | l -> l)
+      |> List.map (fun (k, n) -> `Assoc [ "key", `String k; "bytes", `Int n ])
+    in
+    let json =
+      `Assoc
+        [ "event", `String "http_client_headers_exceed_cdn_budget"
+        ; "url", `String url
+        ; "total_header_bytes", `Int total
+        ; "cdn_safe_budget_bytes", `Int cdn_safe_header_budget_bytes
+        ; "largest_headers", `List largest
+        ; ( "note"
+          , `String
+              "CDN/proxy (e.g. cloudflare) may reject this request with an \
+               opaque 400 before it reaches the origin; reduce request-scoped \
+               header size." )
+        ]
+    in
+    Diag.warn "http_client" "%s" (Yojson.Safe.to_string json)
+  end
+;;
+
+let%test "header_line_bytes = key + value + 4 (\": \" + CRLF)" =
+  (* "x-runtime-mcp" = 13, "abc" = 3, + 4 = 20 *)
+  header_line_bytes ("x-runtime-mcp", "abc") = 20
+
+let%test "an oversized single header exceeds the CDN header budget" =
+  let total =
+    List.fold_left (fun a h -> a + header_line_bytes h) 0
+      [ ("x-big", String.make 9000 'x') ]
+  in
+  total > cdn_safe_header_budget_bytes
+
+let%test "a normal completion request header set is under the CDN budget" =
+  let normal =
+    [ ("Authorization", "Bearer " ^ String.make 64 'k')
+    ; ("Content-Type", "application/json")
+    ; ("x-masc-keeper-name", "masc-improver")
+    ]
+  in
+  let total = List.fold_left (fun a h -> a + header_line_bytes h) 0 normal in
+  not (total > cdn_safe_header_budget_bytes)
+
 (* Substring check on already-lowered strings. *)
 let has_substr haystack needle =
   let hlen = String.length haystack
@@ -521,6 +583,7 @@ let post_sync
       ("content-length", string_of_int (String.length body))
       :: add_connection_close headers
     in
+    warn_if_headers_exceed_cdn_budget ~url headers_with_length;
     let hdr = Http.Header.of_list headers_with_length in
     with_optional_timeout ~clock ~timeout_s (fun () ->
       let resp, resp_body =
@@ -561,6 +624,7 @@ let post_stream
       ("content-length", string_of_int (String.length body))
       :: add_connection_close headers
     in
+    warn_if_headers_exceed_cdn_budget ~url headers_with_length;
     let hdr = Http.Header.of_list headers_with_length in
     (* Only the connect + initial response headers are bounded; body
        consumption happens in the returned reader and is the caller's
@@ -609,6 +673,7 @@ let with_post_stream
       ("content-length", string_of_int (String.length body))
       :: add_connection_close headers
     in
+    warn_if_headers_exceed_cdn_budget ~url headers_with_length;
     let hdr = Http.Header.of_list headers_with_length in
     (* Only bound connect + initial response headers.  Body consumption
        in [f] is the caller's responsibility to timebox. *)


### PR DESCRIPTION
## 배경 / 증상

masc-mcp의 keeper governance 턴(`compute_judgments`)이 RunPod-hosted qwen 엔드포인트(`https://ma8xbr1kgbclkl-19123.proxy.runpod.net/v1`)로 요청할 때 다음 에러로 실패했습니다:

```
[Governance] compute_judgments failed: Invalid request: 400 Bad Request cloudflare ... model=qwen
```

특징:
- 실패가 `~0.06s` 만에 발생 — origin(llama-server)에 도달하기 전 **edge(cloudflare/RunPod proxy)에서 거부**.
- 응답 본문이 cloudflare의 불투명한 `400 Bad Request` HTML — SDK는 이 HTML만 surface해서 **진단 불가**.
- 동일 엔드포인트가 일반 요청은 정상 처리 → 엔드포인트 자체는 healthy. 거부는 **request 단위(헤더 크기)**.

`*.proxy.runpod.net` 같은 reverse proxy는 결합 헤더 바이트가 임계값(~4-8KB)을 넘으면 origin 도달 전에 400을 반환합니다. 어떤 request-scoped 헤더가 비대해졌는지 정적으로 특정할 수 없어, **정확한 경계(HTTP request 직전)에서 진단을 남기는** 방식으로 접근했습니다.

## 변경

`lib/llm_provider/http_client.ml`:
- `warn_if_headers_exceed_cdn_budget`: POST 직전 결합 헤더 바이트를 합산해 `cdn_safe_header_budget_bytes`(8KB, 보수적 — 정상 completion 요청은 1KB 미만)를 넘으면 총 바이트 + 가장 큰 헤더 키 3개를 WARN으로 로깅.
- `post_sync` / `post_stream`의 각 POST 직전에 호출. 임계값 이하면 no-op, request 동작은 변경 없음.

다음 거부 발생 시 어떤 헤더가 budget을 넘겼는지 로그에서 즉시 식별됩니다.

## 테스트

inline `let%test` 3건:
- per-line byte 계산 (`("x-runtime-mcp","abc")` → 20 bytes)
- oversized 헤더가 budget 초과 감지
- 정상 헤더가 budget 이하

`dune build lib --root .` exit 0. (examples/ 빌드 에러 및 discovery.ml/zai_catalog.ml 테스트 실패는 본 변경과 무관한 pre-existing 이슈.)

## 미검증

정확한 oversized 헤더를 정적으로 특정하지 못했습니다. 본 diagnostic은 다음 governance 턴에서 culprit 헤더를 로그로 드러내는 것이 목적입니다 — 그 후 근본 수정(헤더 축소)을 후속 PR로 진행합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)