### PR TITLE
fix(http_client): replace pre-send header-size guard with 4xx response profiler

### DIFF
--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -234,67 +234,101 @@ let log_close_failure ~url ~message =
   Diag.warn "http_client" "%s" (Yojson.Safe.to_string json)
 ;;
 
-(* CDN/reverse-proxy total-header-size budget. Cloudflare and similar edges
-   (e.g. RunPod's *.proxy.runpod.net) reject requests whose combined header
-   bytes exceed roughly this size with an opaque "400 Bad Request" HTML page
-   returned at the edge — before the request reaches the origin server. The SDK
-   then surfaces only that HTML, which is undiagnosable. 8 KB is conservative:
-   normal completion requests carry well under 1 KB of headers, so this only
-   fires on genuinely oversized request-scoped headers. *)
-let cdn_safe_header_budget_bytes = 8192
+(* Empirically measured (2026-05-31) against RunPod's *.proxy.runpod.net edge:
+   a single request header LINE >= 8192 bytes is rejected by the cloudflare edge
+   with an opaque "400 Bad Request" (server: cloudflare, empty body, cf-ray)
+   BEFORE the request reaches the origin. The binding limit is per-header-line,
+   NOT the header total — 20 x 500B headers (10 KB total) passed, while one
+   8192B header did not. Body size (up to 2 MB) and malformed header values did
+   not reproduce it. *)
+let cdn_per_header_limit_bytes = 8192
 
 (* key + ": " + value + CRLF — the on-wire size of one header line. *)
-let header_line_bytes (key, value) =
-  String.length key + String.length value + 4
+let header_line_bytes (key, value) = String.length key + String.length value + 4
 
-let warn_if_headers_exceed_cdn_budget ~url headers =
-  let total = List.fold_left (fun acc h -> acc + header_line_bytes h) 0 headers in
-  if total > cdn_safe_header_budget_bytes then begin
-    let largest =
-      headers
-      |> List.map (fun ((k, _) as h) -> (k, header_line_bytes h))
-      |> List.sort (fun (_, a) (_, b) -> compare b a)
-      |> (function a :: b :: c :: _ -> [ a; b; c ] | l -> l)
-      |> List.map (fun (k, n) -> `Assoc [ "key", `String k; "bytes", `Int n ])
+(* Request header size profile (name + on-wire bytes, largest first). VALUES ARE
+   OMITTED: header values may carry credentials (Authorization, tokens), so only
+   sizes are logged. *)
+let header_size_profile headers =
+  headers
+  |> List.map (fun ((k, _) as h) -> k, header_line_bytes h)
+  |> List.sort (fun (_, a) (_, b) -> compare b a)
+  |> List.map (fun (k, n) -> `Assoc [ "name", `String k; "bytes", `Int n ])
+;;
+
+let max_single_header_bytes headers =
+  List.fold_left (fun acc h -> max acc (header_line_bytes h)) 0 headers
+;;
+
+(* On a 4xx response, log the request's header size profile and the response's
+   edge signature (server, cf-ray). A 4xx with an empty/opaque body and a
+   "cloudflare" server indicates an edge rejection — commonly a single header
+   line over [cdn_per_header_limit_bytes] — rather than an origin-level error.
+   This names the offending header WHEN a real failure recurs: header contents
+   are runtime-dependent and not knowable statically, so a pre-send size guess
+   either never fires (small headers) or false-fires on benign many-small-header
+   requests the edge accepts. *)
+let profile_headers_on_client_error ~url ~code ~resp_headers request_headers =
+  if code >= 400 && code < 500
+  then (
+    let server = Http.Header.get resp_headers "server" in
+    let cf_ray = Http.Header.get resp_headers "cf-ray" in
+    let opt = function
+      | Some s -> `String s
+      | None -> `Null
+    in
+    let total =
+      List.fold_left (fun acc h -> acc + header_line_bytes h) 0 request_headers
     in
     let json =
       `Assoc
-        [ "event", `String "http_client_headers_exceed_cdn_budget"
+        [ "event", `String "http_client_4xx_request_header_profile"
         ; "url", `String url
-        ; "total_header_bytes", `Int total
-        ; "cdn_safe_budget_bytes", `Int cdn_safe_header_budget_bytes
-        ; "largest_headers", `List largest
+        ; "status", `Int code
+        ; "response_server", opt server
+        ; "cf_ray", opt cf_ray
+        ; "request_header_count", `Int (List.length request_headers)
+        ; "total_request_header_bytes", `Int total
+        ; "max_single_header_bytes", `Int (max_single_header_bytes request_headers)
+        ; "cdn_per_header_limit_bytes", `Int cdn_per_header_limit_bytes
+        ; "header_sizes", `List (header_size_profile request_headers)
         ; ( "note"
           , `String
-              "CDN/proxy (e.g. cloudflare) may reject this request with an \
-               opaque 400 before it reaches the origin; reduce request-scoped \
-               header size." )
+              "4xx from an LLM endpoint. Header VALUES omitted (may carry credentials); \
+               sizes only. A cloudflare/RunPod edge rejects a single header line over \
+               cdn_per_header_limit_bytes with an opaque 400 before the origin — compare \
+               max_single_header_bytes." )
         ]
     in
-    Diag.warn "http_client" "%s" (Yojson.Safe.to_string json)
-  end
+    Diag.warn "http_client" "%s" (Yojson.Safe.to_string json))
 ;;
 
 let%test "header_line_bytes = key + value + 4 (\": \" + CRLF)" =
   (* "x-runtime-mcp" = 13, "abc" = 3, + 4 = 20 *)
   header_line_bytes ("x-runtime-mcp", "abc") = 20
+;;
 
-let%test "an oversized single header exceeds the CDN header budget" =
-  let total =
-    List.fold_left (fun a h -> a + header_line_bytes h) 0
-      [ ("x-big", String.make 9000 'x') ]
-  in
-  total > cdn_safe_header_budget_bytes
+let%test "header_size_profile orders the largest header first" =
+  match
+    header_size_profile
+      [ "small", "v"; "big", String.make 100 'x'; "mid", String.make 20 'y' ]
+  with
+  | `Assoc (("name", `String "big") :: _) :: _ -> true
+  | _ -> false
+;;
 
-let%test "a normal completion request header set is under the CDN budget" =
-  let normal =
-    [ ("Authorization", "Bearer " ^ String.make 64 'k')
-    ; ("Content-Type", "application/json")
-    ; ("x-masc-keeper-name", "masc-improver")
-    ]
+(* The edge checks per-header-line size, not the total. Many small headers whose
+   total far exceeds the limit are accepted; only the per-header max matters. *)
+let%test "max_single_header_bytes ignores the total, tracks the largest line" =
+  let many_small =
+    List.init 20 (fun i -> Printf.sprintf "x-h%d" i, String.make 500 'y')
   in
-  let total = List.fold_left (fun a h -> a + header_line_bytes h) 0 normal in
-  not (total > cdn_safe_header_budget_bytes)
+  max_single_header_bytes many_small < cdn_per_header_limit_bytes
+;;
+
+let%test "max_single_header_bytes flags a single oversized header line" =
+  max_single_header_bytes [ "x-big", String.make 9000 'x' ] > cdn_per_header_limit_bytes
+;;
 
 (* Substring check on already-lowered strings. *)
 let has_substr haystack needle =
@@ -583,7 +617,6 @@ let post_sync
       ("content-length", string_of_int (String.length body))
       :: add_connection_close headers
     in
-    warn_if_headers_exceed_cdn_budget ~url headers_with_length;
     let hdr = Http.Header.of_list headers_with_length in
     with_optional_timeout ~clock ~timeout_s (fun () ->
       let resp, resp_body =
@@ -595,6 +628,11 @@ let post_sync
           uri
       in
       let code = Cohttp.Response.status resp |> Cohttp.Code.code_of_status in
+      profile_headers_on_client_error
+        ~url
+        ~code
+        ~resp_headers:(Cohttp.Response.headers resp)
+        headers_with_length;
       let body_str =
         try
           Eio.Buf_read.(
@@ -624,7 +662,6 @@ let post_stream
       ("content-length", string_of_int (String.length body))
       :: add_connection_close headers
     in
-    warn_if_headers_exceed_cdn_budget ~url headers_with_length;
     let hdr = Http.Header.of_list headers_with_length in
     (* Only the connect + initial response headers are bounded; body
        consumption happens in the returned reader and is the caller's
@@ -642,6 +679,11 @@ let post_stream
     | `OK -> Ok (Eio.Buf_read.of_flow ~max_size:Api_common.max_response_body resp_body)
     | status ->
       let code = Cohttp.Code.code_of_status status in
+      profile_headers_on_client_error
+        ~url
+        ~code
+        ~resp_headers:(Cohttp.Response.headers resp)
+        headers_with_length;
       let body_str =
         try
           Eio.Buf_read.(
@@ -673,7 +715,6 @@ let with_post_stream
       ("content-length", string_of_int (String.length body))
       :: add_connection_close headers
     in
-    warn_if_headers_exceed_cdn_budget ~url headers_with_length;
     let hdr = Http.Header.of_list headers_with_length in
     (* Only bound connect + initial response headers.  Body consumption
        in [f] is the caller's responsibility to timebox. *)
@@ -694,6 +735,11 @@ let with_post_stream
       Ok (f reader)
     | status ->
       let code = Cohttp.Code.code_of_status status in
+      profile_headers_on_client_error
+        ~url
+        ~code
+        ~resp_headers:(Cohttp.Response.headers resp)
+        headers_with_length;
       let body_str =
         try
           Eio.Buf_read.(


### PR DESCRIPTION
## 배경 — #1819의 가설이 반박됨

#1819은 masc가 RunPod-hosted qwen 엔드포인트로 **거대 헤더**를 보낸다는 가설로 *pre-send* TOTAL 헤더 크기 가드(8KB 초과 시 WARN)를 추가했습니다. 정밀 조사 결과 가설의 양쪽이 모두 틀렸습니다.

### 실증 (endpoint 직접 측정, 2026-05-31)
| 실험 | 결과 |
|------|------|
| `/health`, `/v1/models`, 최소 completion | 200 OK |
| body 4KB→2MB | **전부 origin 도달** (JSON `exceeds context size`, 2-5s) — cloudflare 400 아님 |
| 단일 헤더 ≥ 8192B | **400** `server: cloudflare`, `cf-ray`, empty body (사용자 증상과 일치) |
| 20×500B = **총 10KB** 헤더 | **200 OK** → 한도는 **per-header-line**, total 아님 |
| malformed 값(non-ASCII/tab/빈값/긴 이름) | 200 OK |
| masc 실제 헤더셋(`Authorization: Bearer <RUNPOD_API_TOKEN>`) + tools body | 200 OK |

### 정적 추적
qwen completion 요청의 실제 wire 헤더 = `runtime_adapter`의 `custom_headers @ auth`. qwen provider 블록(`keeper_runtime.toml`)은 custom 헤더 미선언 → `Authorization: Bearer <token>` (+ Content-Type)뿐. runtime MCP policy(유일한 대형 구조)는 HTTP 경로에서 cache-key로만 쓰이고 drop되며, `x-masc-*` identity 헤더는 **MCP-server 연결**에 실립니다(completion 요청 아님).

**결론**: masc의 completion 헤더는 작습니다 → #1819의 pre-send 가드는 실제 트래픽에서 **영영 안 뜸**(dead code). 게다가 TOTAL 기준은 per-header 한도를 잘못 표현해 많은 작은 헤더에 false-positive.

## 변경

`warn_if_headers_exceed_cdn_budget`(pre-send TOTAL) → `profile_headers_on_client_error`(post-response):
- **4xx 응답 시** 요청 헤더 크기 프로파일(이름 + on-wire 바이트, 큰 순, **값은 생략** — credential 가능성)과 응답 edge 시그니처(`server`, `cf-ray`)를 로깅.
- `post_sync` / `post_stream` / `with_post_stream` 3경로 모두 배선.
- 재발 시 어떤 헤더가 범인인지 이름이 드러남 — 헤더 내용은 runtime 의존이라 정적으로 알 수 없고, pre-send 임계값은 (작은 헤더면 침묵 / edge가 허용하는 헤더셋에 false-fire) 둘 다 실패하기 때문.

## 테스트

inline `let%test` 4건: per-line byte 계산 / largest-first 정렬 / **per-header(total 아님) 한도**(20×500B는 한도 미만) / 단일 oversized 헤더 감지. `dune build lib` exit 0, http_client 테스트 전부 통과.

(주의: `capabilities.ml`·`discovery.ml:973`·`zai_catalog.ml:220` 테스트 실패는 본 변경과 무관한 pre-existing — 건드리지 않은 모듈.)

## 남은 것

근본 원인은 **재현 불가**(masc의 모든 재구성 요청이 200, 헤더 작음). 사용자가 본 400은 transient/runtime-특정으로 추정. 본 프로파일러는 재발 시 실제 전송 내용을 포착하는 계측이며, 그 로그를 본 뒤 근본 수정으로 진행합니다. 헤더→축소 같은 transport 동작 변경은 별도 RFC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)