### PR TITLE
[codex] purge legacy fallback surfaces

### DIFF
--- a/docs/provider-catalog.md
+++ b/docs/provider-catalog.md
@@ -97,7 +97,7 @@ Important provider fields:
 | Field | Type | Description |
 |---|---|---|
 | `kind` | string | Existing wire/runtime kind, for example `openai_compat`, `anthropic`, `gemini`, `codex_cli`. Defaults to `openai_compat`. |
-| `transport` | string | `http`, `managed`, or legacy alias `custom-openai-compat`. |
+| `transport` | string | `http` or `managed`. |
 | `base_url` | string | HTTP endpoint base URL. |
 | `request_path` | string | Completion request path. Defaults from `kind`. |
 | `auth` | object | Credential mode. See below. |

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -130,9 +130,7 @@ let build_request
   in
   let options = ref [] in
   (let mt =
-     Option.value
-       ~default:Constants.Inference.unknown_model_max_tokens_fallback
-       config.max_tokens
+     Option.value ~default:Constants.unknown_model_max_tokens_fallback config.max_tokens
    in
    options := ("num_predict", `Int mt) :: !options);
   (match config.temperature with

--- a/lib/llm_provider/backend_provider_a.ml
+++ b/lib/llm_provider/backend_provider_a.ml
@@ -76,7 +76,7 @@ let build_request
     ; ( "max_tokens"
       , `Int
           (Option.value
-             ~default:Constants.Inference.unknown_model_max_tokens_fallback
+             ~default:Constants.unknown_model_max_tokens_fallback
              config.max_tokens) )
     ; "messages", `List msgs_json
     ; "stream", `Bool stream

--- a/lib/llm_provider/backend_provider_d_request.ml
+++ b/lib/llm_provider/backend_provider_d_request.ml
@@ -150,7 +150,7 @@ let build_request
   (* Resolve [max_tokens] from three layers:
      1. Caller override ([config.max_tokens = Some n]) - explicit request
      2. Model capability ([caps.max_output_tokens]) - provider's ceiling
-     3. Fallback [Constants.Inference.unknown_model_max_tokens_fallback] - last resort when both are unknown
+     3. Fallback [Constants.unknown_model_max_tokens_fallback] - last resort when both are unknown
 
      When the caller sends [None], they want the model's own maximum.
      When the caller sends [Some n], we clamp to the capability ceiling
@@ -161,7 +161,7 @@ let build_request
   let effective_max_tokens =
     match config.max_tokens, caps.max_output_tokens with
     | None, Some cap -> cap
-    | None, None -> Constants.Inference.unknown_model_max_tokens_fallback
+    | None, None -> Constants.unknown_model_max_tokens_fallback
     | Some n, Some cap when n > cap ->
       warn_capability_drop ~model_id:config.model_id ~field:"max_tokens:clamp";
       cap

--- a/lib/llm_provider/backend_provider_f.ml
+++ b/lib/llm_provider/backend_provider_f.ml
@@ -182,9 +182,7 @@ let build_request
   (* generationConfig *)
   let gen_config = ref [] in
   (let mt =
-     Option.value
-       ~default:Constants.Inference.unknown_model_max_tokens_fallback
-       config.max_tokens
+     Option.value ~default:Constants.unknown_model_max_tokens_fallback config.max_tokens
    in
    gen_config := ("maxOutputTokens", `Int mt) :: !gen_config);
   (match config.temperature with

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -71,8 +71,8 @@ let apply_sampling_defaults (config : Provider_config.t) : Provider_config.t =
   let defaults = provider_sampling_defaults config.kind in
   let default_min_p =
     match config.kind with
-    | Provider_config.OpenAI_compat
-      when not (openai_compat_should_default_min_p config) -> None
+    | Provider_config.OpenAI_compat when not (openai_compat_should_default_min_p config)
+      -> None
     | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope ->
       defaults.default_min_p
   in
@@ -535,8 +535,8 @@ let complete_http
           Backend_provider_a.build_request ~config ~messages ~tools ()
         | Provider_config.Ollama ->
           Backend_ollama.build_request ~config ~messages ~tools ()
-        | Provider_config.OpenAI_compat | Provider_config.DashScope | Provider_config.Kimi ->
-          Backend_provider_d.build_request ~config ~messages ~tools ()
+        | Provider_config.OpenAI_compat | Provider_config.DashScope | Provider_config.Kimi
+          -> Backend_provider_d.build_request ~config ~messages ~tools ()
         | Provider_config.Gemini ->
           Backend_provider_f.build_request ~config ~messages ~tools ()
         | Provider_config.Glm ->
@@ -694,7 +694,9 @@ let complete_http
                   (match Backend_ollama.parse_ollama_response body with
                    | Ok resp -> Ok resp
                    | Error msg -> Error (Http_client.HttpError { code = 400; body = msg }))
-                | Provider_config.OpenAI_compat | Provider_config.DashScope | Provider_config.Kimi ->
+                | Provider_config.OpenAI_compat
+                | Provider_config.DashScope
+                | Provider_config.Kimi ->
                   (match
                      Backend_provider_d_parse.parse_provider_d_response_result body
                    with
@@ -1141,9 +1143,6 @@ let complete_with_retry
 
 (* ── Streaming ───────────────────────────────────────── *)
 
-(* Re-export stream accumulator for backward compatibility *)
-include Complete_stream_acc
-
 let record_streaming_metrics (metrics : Metrics.t) = function
   | Telemetry_event.Streaming_first_chunk { provider; model; ttfrc_ms; _ } ->
     metrics.on_streaming_first_chunk ~provider ~model_id:model ~ttfrc_ms
@@ -1199,8 +1198,8 @@ let complete_stream_http
            for every streaming caller. NDJSON parser is now in
            Streaming.parse_ollama_ndjson_chunk. *)
           Backend_ollama.build_request ~stream:true ~config ~messages ~tools ()
-        | Provider_config.OpenAI_compat | Provider_config.DashScope | Provider_config.Kimi ->
-          Backend_provider_d.build_request ~stream:true ~config ~messages ~tools ()
+        | Provider_config.OpenAI_compat | Provider_config.DashScope | Provider_config.Kimi
+          -> Backend_provider_d.build_request ~stream:true ~config ~messages ~tools ()
         | Provider_config.Gemini ->
           Backend_provider_f.build_request ~stream:true ~config ~messages ~tools ()
         | Provider_config.Glm ->
@@ -1343,7 +1342,7 @@ let complete_stream_http
           ~body:body_with_stream
           ~f:(fun reader ->
             let body_logic () =
-              let acc = create_stream_acc () in
+              let acc = Complete_stream_acc.create_stream_acc () in
               let provider_d_state = ref None in
               (* RFC-OAS-019: first_chunk_seen / chunk_counter / last_chunk_t
                  hoisted out of body_logic so publish_summary on
@@ -1374,7 +1373,7 @@ let complete_stream_http
                 List.iter
                   (fun evt ->
                      on_event evt;
-                     accumulate_event acc evt;
+                     Complete_stream_acc.accumulate_event acc evt;
                      (* RFC-OAS-019: classify each delta for the
                         [Streaming_summary] kind_breakdown that fires at
                         finalize. Wire errors set terminal_state; per-chunk
@@ -1476,7 +1475,8 @@ let complete_stream_http
                              (match Streaming.parse_sse_event event_type data with
                               | Some evt -> [ evt ], None
                               | None -> [], None)
-                           | Provider_config.OpenAI_compat | Provider_config.DashScope
+                           | Provider_config.OpenAI_compat
+                           | Provider_config.DashScope
                            | Provider_config.Kimi ->
                              (match Streaming.parse_provider_d_sse_chunk data with
                               | Some chunk ->
@@ -1529,7 +1529,7 @@ let complete_stream_http
               | Error _ as err -> err
               | Ok () ->
                 let result =
-                  match finalize_stream_acc acc with
+                  match Complete_stream_acc.finalize_stream_acc acc with
                   | Ok _ as ok -> ok
                   | Error msg ->
                     Error

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -133,12 +133,6 @@ val complete_with_retry
     Each retry attempt gets a fresh deadline; the parameter does not
     cap the total time across all attempts. @since 0.195.0 *)
 
-(** {1 Stream Accumulator} *)
-
-(** Re-exported from {!Complete_stream_acc} for backward compatibility.
-    @since 0.79.0 *)
-include module type of Complete_stream_acc
-
 (** {1 Streaming Completion} *)
 
 (** Execute a streaming LLM completion.

--- a/lib/llm_provider/constants.ml
+++ b/lib/llm_provider/constants.ml
@@ -73,10 +73,9 @@ end
     are absent. Emitted as a required field by Provider_d-compat and Anthropic
     backends.
 
-    16384 covers most modern models (GPT-4o, Agent_llm_a Sonnet 4, Gemini 2.5,
-    DashScope_3, Provider_g-V3) without overrunning smaller model limits. Models
-    with lower caps should be declared in [Capabilities.for_model_id] so
-    the capability-gated path (not this fallback) applies.
+    16384 is a last-resort ceiling for modern high-context models. Models with
+    lower caps should be declared in [Capabilities.for_model_id] so the
+    capability-gated path (not this fallback) applies.
     @since 0.188.0
     @since 0.185.0 — raised from 4096 to 16384 *)
 let unknown_model_max_tokens_fallback =

--- a/lib/llm_provider/constants.ml
+++ b/lib/llm_provider/constants.ml
@@ -69,37 +69,29 @@ module Inference_profile = struct
   let deterministic = { no_sampling_overrides with temperature = 0.0; max_tokens = 4096 }
 end
 
-(** Backward-compatible aliases — existing callers of
-    [Constants.Inference.default_temperature] continue to compile.
-    New code should prefer {!Inference_profile}. *)
-module Inference = struct
-  let default_temperature = Inference_profile.cascade_default.temperature
-  let default_max_tokens = Inference_profile.cascade_default.max_tokens
+(** Fallback [max_tokens] when both caller override and model capability
+    are absent. Emitted as a required field by Provider_d-compat and Anthropic
+    backends.
 
-  (** Fallback [max_tokens] when both caller override and model capability
-      are absent. Emitted as a required field by Provider_d-compat and Anthropic
-      backends.
-
-      16384 covers most modern models (GPT-4o, Agent_llm_a Sonnet 4, Gemini 2.5,
-      DashScope_3, Provider_g-V3) without overrunning smaller model limits. Models
-      with lower caps should be declared in [Capabilities.for_model_id] so
-      the capability-gated path (not this fallback) applies.
-      @since 0.188.0
-      @since 0.185.0 — raised from 4096 to 16384 *)
-  let unknown_model_max_tokens_fallback =
-    match Sys.getenv "OAS_MAX_TOKENS_DEFAULT" with
-    | exception Not_found -> 16384
-    | s ->
-      (match int_of_string_opt s with
-       | Some n when n > 0 -> n
-       | _ ->
-         Diag.warn
-           "constants"
-           "OAS_MAX_TOKENS_DEFAULT=%S is not a valid positive int, using 16384"
-           s;
-         16384)
-  ;;
-end
+    16384 covers most modern models (GPT-4o, Agent_llm_a Sonnet 4, Gemini 2.5,
+    DashScope_3, Provider_g-V3) without overrunning smaller model limits. Models
+    with lower caps should be declared in [Capabilities.for_model_id] so
+    the capability-gated path (not this fallback) applies.
+    @since 0.188.0
+    @since 0.185.0 — raised from 4096 to 16384 *)
+let unknown_model_max_tokens_fallback =
+  match Sys.getenv "OAS_MAX_TOKENS_DEFAULT" with
+  | exception Not_found -> 16384
+  | s ->
+    (match int_of_string_opt s with
+     | Some n when n > 0 -> n
+     | _ ->
+       Diag.warn
+         "constants"
+         "OAS_MAX_TOKENS_DEFAULT=%S is not a valid positive int, using 16384"
+         s;
+       16384)
+;;
 
 (* ── Cache ───────────────────────────────────────── *)
 

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -132,12 +132,8 @@ let parse_transport = function
      | "" -> Ok None
      | "http" -> Ok (Some Http)
      | "managed" -> Ok (Some Managed)
-     | "custom-openai-compat" -> Ok (Some Http)
      | other ->
-       Error
-         (Printf.sprintf
-            "unknown transport %S (canonical: http, managed, custom-openai-compat)"
-            other))
+       Error (Printf.sprintf "unknown transport %S (canonical: http, managed)" other))
 ;;
 
 let default_transport_for_kind _kind = Http
@@ -155,29 +151,21 @@ let parse_auth json =
       |> String.trim
       |> String.lowercase_ascii
     in
-    let env =
-      match member_string "env" auth_json with
-      | Some v -> v
-      | None -> member_string_default "key" ~default:"" auth_json
-    in
+    let env = member_string_default "env" ~default:"" auth_json in
     (match auth_type with
      | "none" -> Ok No_auth
-     | "api_key_env" | "api-key-env" | "env" -> Ok (Api_key_env env)
-     | "setup_token_env" | "setup-token-env" -> Ok (Setup_token_env env)
-     | "oauth_cached_login" | "oauth-cached-login" -> Ok Oauth_cached_login
+     | "api_key_env" -> Ok (Api_key_env env)
+     | "setup_token_env" -> Ok (Setup_token_env env)
+     | "oauth_cached_login" -> Ok Oauth_cached_login
      | "file" -> Ok (File (member_string_default "path" ~default:"" auth_json))
      | "exec" -> Ok (Exec (member_string_default "command" ~default:"" auth_json))
      | other ->
        Error
          (Printf.sprintf
             "unknown auth type %S (canonical: none, api_key_env, setup_token_env, \
-             oauth_cached_login, file, exec; dashed and short aliases also accepted, \
-             e.g. api-key-env, env)"
+             oauth_cached_login, file, exec)"
             other))
-  | _ ->
-    (match member_string "api_key_env" json with
-     | Some env when String.trim env <> "" -> Ok (Api_key_env env)
-     | _ -> Ok No_auth)
+  | _ -> Ok No_auth
 ;;
 
 let parse_thinking_control_format = function
@@ -186,35 +174,25 @@ let parse_thinking_control_format = function
     let trimmed = String.lowercase_ascii (String.trim raw) in
     (match trimmed with
      | "" -> Ok None
-     | "none" | "no_thinking_control" | "no-thinking-control" ->
-       Ok (Some Capabilities.No_thinking_control)
-     | "thinking_object" | "thinking-object" -> Ok (Some Capabilities.Thinking_object)
-     | "thinking_object_only"
-     | "thinking-object-only"
-     | "thinking_object_plain"
-     | "thinking-object-plain" -> Ok (Some Capabilities.Thinking_object_only)
-     | "chat_template_kwargs" | "chat-template-kwargs" ->
-       Ok (Some Capabilities.Chat_template_kwargs)
-     | "reasoning_effort" | "reasoning-effort" -> Ok (Some Capabilities.Reasoning_effort)
-     | "enable_thinking" | "enable-thinking" -> Ok (Some Capabilities.Enable_thinking)
+     | "none" -> Ok (Some Capabilities.No_thinking_control)
+     | "thinking_object" -> Ok (Some Capabilities.Thinking_object)
+     | "thinking_object_only" -> Ok (Some Capabilities.Thinking_object_only)
+     | "chat_template_kwargs" -> Ok (Some Capabilities.Chat_template_kwargs)
+     | "reasoning_effort" -> Ok (Some Capabilities.Reasoning_effort)
+     | "enable_thinking" -> Ok (Some Capabilities.Enable_thinking)
      | other ->
        Error
          (Printf.sprintf
             "unknown thinking_control_format %S (canonical: none, thinking_object, \
              thinking_object_only, chat_template_kwargs, reasoning_effort, \
-             enable_thinking; dashed and full-word aliases also accepted, e.g. \
-             no_thinking_control, thinking-object)"
+             enable_thinking)"
             other))
 ;;
 
 let member_supported_models json = member_string_list "supported_models" json
 
 let capability_base json =
-  let label =
-    match member_string "capabilities_base" json with
-    | Some v -> Some v
-    | None -> member_string "base" json
-  in
+  let label = member_string "capabilities_base" json in
   match label with
   | None -> Ok Capabilities.default_capabilities
   | Some raw ->
@@ -450,12 +428,17 @@ let parse_entry json =
       | None -> Error (Printf.sprintf "provider %S has unknown kind %S" id kind_raw)
       | Some kind ->
         let prefix_id msg = Printf.sprintf "provider %S: %s" id msg in
-        let* auth = Result.map_error prefix_id (parse_auth json) in
-        let api_key_env =
-          match member_string "api_key_env" json with
-          | Some env -> env
-          | None -> auth_env auth
+        let* () =
+          match member "api_key_env" json with
+          | `Null -> Ok ()
+          | _ ->
+            Error
+              (prefix_id
+                 "removed provider catalog field \"api_key_env\"; use \
+                  auth.type=api_key_env with auth.env")
         in
+        let* auth = Result.map_error prefix_id (parse_auth json) in
+        let api_key_env = auth_env auth in
         let* transport_opt =
           Result.map_error prefix_id (parse_transport (member_string "transport" json))
         in

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -61,6 +61,11 @@ let warn_type_mismatch key ~expected actual =
 
 let member key json = Yojson.Safe.Util.member key json
 
+let member_present key = function
+  | `Assoc fields -> List.exists (fun (name, _) -> String.equal name key) fields
+  | _ -> false
+;;
+
 let member_string key json =
   match member key json with
   | `String s -> Some s
@@ -429,13 +434,13 @@ let parse_entry json =
       | Some kind ->
         let prefix_id msg = Printf.sprintf "provider %S: %s" id msg in
         let* () =
-          match member "api_key_env" json with
-          | `Null -> Ok ()
-          | _ ->
+          if member_present "api_key_env" json
+          then
             Error
               (prefix_id
                  "removed provider catalog field \"api_key_env\"; use \
                   auth.type=api_key_env with auth.env")
+          else Ok ()
         in
         let* auth = Result.map_error prefix_id (parse_auth json) in
         let api_key_env = auth_env auth in

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -192,18 +192,14 @@ val default_api_key_env : provider_kind -> string option
 
 (** Canonical inverse of {!string_of_provider_kind}.
 
-    Accepts every lowercase form produced by {!string_of_provider_kind} plus
-    the documented legacy aliases used by cascade configs and callers:
-    - [agent_llm_a]  -> [Anthropic]
-    - [provider_d]  -> [OpenAI_compat]
-    - [llama]   -> [Ollama]
+    Accepts every lowercase form produced by {!string_of_provider_kind}.
 
     The match is case-insensitive; leading and trailing whitespace is
     trimmed. Returns [None] for any other input so callers fail fast
     rather than silently falling back to a default provider.
 
-    Use this instead of scattered ad-hoc [match s with "agent_llm_a" -> ...]
-    ladders to keep all string-to-kind drift in one place.
+    Use this instead of scattered ad-hoc string-to-kind matches to keep all
+    string drift in one place.
     @since 0.165.0 *)
 val provider_kind_of_string : string -> provider_kind option
 

--- a/lib/llm_provider/provider_kind.ml
+++ b/lib/llm_provider/provider_kind.ml
@@ -43,12 +43,12 @@ let default_api_key_env = function
 
 let of_string raw =
   match String.lowercase_ascii (String.trim raw) with
-  | "anthropic" | "claude" -> Some Anthropic
+  | "anthropic" -> Some Anthropic
   | "kimi" -> Some Kimi
-  | "openai_compat" | "openai" | "provider_d" -> Some OpenAI_compat
-  | "ollama" | "llama" | "ollama_cloud" -> Some Ollama
+  | "openai_compat" -> Some OpenAI_compat
+  | "ollama" -> Some Ollama
   | "gemini" -> Some Gemini
-  | "glm" | "zhipu" -> Some Glm
+  | "glm" -> Some Glm
   | "dashscope" -> Some DashScope
   | _ -> None
 ;;

--- a/lib/llm_provider/provider_kind.mli
+++ b/lib/llm_provider/provider_kind.mli
@@ -35,11 +35,10 @@ val default_api_key_env : t -> string option
     Exhaustive — adding a new variant forces a compile error. *)
 val to_string : t -> string
 
-(** Canonical inverse of {!to_string}. Accepts the 7 canonical forms plus
-    the documented legacy aliases [claude -> Anthropic],
-    [openai -> OpenAI_compat], [llama -> Ollama]. Match is case-insensitive
-    with leading/trailing whitespace trimmed. Returns [None] for anything
-    else so callers fail fast instead of silently defaulting. *)
+(** Canonical inverse of {!to_string}. Accepts only the 7 canonical forms.
+    Match is case-insensitive with leading/trailing whitespace trimmed. Returns
+    [None] for anything else so callers fail fast instead of silently
+    defaulting. *)
 val of_string : string -> t option
 
 val pp : Format.formatter -> t -> unit

--- a/lib/llm_provider/transport_provider_d_compat.ml
+++ b/lib/llm_provider/transport_provider_d_compat.ml
@@ -16,7 +16,7 @@ let default_config =
   ; api_key = ""
   ; model_id = ""
   ; request_path = "/v1/chat/completions"
-  ; max_tokens = Constants.Inference.unknown_model_max_tokens_fallback
+  ; max_tokens = Constants.unknown_model_max_tokens_fallback
   ; extra_headers = []
   }
 ;;
@@ -93,7 +93,7 @@ let%test "default_config request_path" =
 ;;
 
 let%test "default_config max_tokens" =
-  default_config.max_tokens = Constants.Inference.unknown_model_max_tokens_fallback
+  default_config.max_tokens = Constants.unknown_model_max_tokens_fallback
 ;;
 
 let%test "default_config api_key empty" = default_config.api_key = ""

--- a/lib/memory.ml
+++ b/lib/memory.ml
@@ -45,24 +45,6 @@ let default_retrieve_result backend ~key =
   | None -> Error Missing_key
 ;;
 
-let legacy_backend ~persist ~retrieve ~remove =
-  { persist =
-      (fun ~key value ->
-        persist ~key value;
-        Ok ())
-  ; retrieve
-  ; remove =
-      (fun ~key ->
-        remove ~key;
-        Ok ())
-  ; batch_persist =
-      (fun pairs ->
-        List.iter (fun (k, v) -> persist ~key:k v) pairs;
-        Ok ())
-  ; query = (fun ~prefix:_ ~limit:_ -> [])
-  }
-;;
-
 type outcome = Memory_episodic.outcome =
   | Success of string
   | Failure of string

--- a/lib/memory.mli
+++ b/lib/memory.mli
@@ -96,15 +96,6 @@ type procedural_backend =
   ; all_procedures : unit -> procedure list
   }
 
-(** Wrap legacy callbacks that return [unit] into a {!long_term_backend}
-    where [persist]/[remove] always return [Ok ()],
-    [batch_persist] iterates, and [query] returns [[]]. *)
-val legacy_backend
-  :  persist:(key:string -> Yojson.Safe.t -> unit)
-  -> retrieve:(key:string -> Yojson.Safe.t option)
-  -> remove:(key:string -> unit)
-  -> long_term_backend
-
 (** {1 Abstract type} *)
 
 type t

--- a/lib/protocol/mcp_session.ml
+++ b/lib/protocol/mcp_session.ml
@@ -84,9 +84,7 @@ let to_http_spec (info : info) : Mcp_http.http_spec option =
 
 (** Reconnect to MCP servers from saved session info.
     Returns a pair: (successfully connected, failed infos with error messages).
-    Failed connections do not abort the others.
-    Legacy HTTP checkpoints without stored endpoint metadata still cannot be
-    reconnected and are reported as failed with an informational error. *)
+    Failed connections do not abort the others. *)
 let reconnect_all ~sw ~mgr ~net (infos : info list)
   : Mcp.managed list * (info * Error.sdk_error) list
   =
@@ -105,8 +103,8 @@ let reconnect_all ~sw ~mgr ~net (infos : info list)
                 (InitializeFailed
                    { detail =
                        Printf.sprintf
-                         "HTTP MCP server '%s' cannot be reconnected from legacy session \
-                          data"
+                         "HTTP MCP server '%s' cannot be reconnected without \
+                          http_base_url"
                          info.server_name
                    })
             in
@@ -164,8 +162,12 @@ let transport_kind_to_string = function
 ;;
 
 let transport_kind_of_string = function
-  | "http" -> Http
-  | _ -> Stdio (* default to stdio for backward compat *)
+  | "stdio" -> Ok Stdio
+  | "http" -> Ok Http
+  | value ->
+    Error
+      (Error.Serialization
+         (UnknownVariant { type_name = "mcp_session.transport_kind"; value }))
 ;;
 
 let info_to_json (info : info) : Yojson.Safe.t =
@@ -207,32 +209,38 @@ let info_of_json json : (info, Error.sdk_error) result =
     in
     match env_result, http_headers_result, tools_result with
     | Ok env, Ok http_headers, Ok tool_schemas ->
-      let transport_kind =
-        json
-        |> member "transport_kind"
-        |> to_string_option
-        |> Option.value ~default:"stdio"
-        |> transport_kind_of_string
-      in
-      let http_base_url =
-        match json |> member "http_base_url" |> to_string_option with
-        | Some base_url -> Some base_url
+      let transport_kind_result =
+        match json |> member "transport_kind" |> to_string_option with
+        | Some raw -> transport_kind_of_string raw
         | None ->
-          (match transport_kind with
-           | Http when json |> member "command" |> to_string <> "http" ->
-             Some (json |> member "command" |> to_string)
-           | _ -> None)
+          Error
+            (Error.Serialization
+               (JsonParseError
+                  { detail = "Mcp_session.info_of_json: missing transport_kind" }))
       in
-      Ok
-        { server_name = json |> member "server_name" |> to_string
-        ; command = json |> member "command" |> to_string
-        ; args = json |> member "args" |> to_list |> List.map to_string
-        ; env
-        ; http_base_url
-        ; http_headers
-        ; tool_schemas
-        ; transport_kind
-        }
+      (match transport_kind_result with
+       | Error e -> Error e
+       | Ok transport_kind ->
+         let http_base_url = json |> member "http_base_url" |> to_string_option in
+         (match transport_kind, http_base_url with
+          | Http, None ->
+            Error
+              (Error.Serialization
+                 (JsonParseError
+                    { detail =
+                        "Mcp_session.info_of_json: HTTP transport requires http_base_url"
+                    }))
+          | _ ->
+            Ok
+              { server_name = json |> member "server_name" |> to_string
+              ; command = json |> member "command" |> to_string
+              ; args = json |> member "args" |> to_list |> List.map to_string
+              ; env
+              ; http_base_url
+              ; http_headers
+              ; tool_schemas
+              ; transport_kind
+              }))
     | Error e, _, _ -> Error e
     | _, Error e, _ -> Error e
     | _, _, Error e -> Error e

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -769,15 +769,7 @@ let test_constants_inference_profiles () =
   check_profile "agent" 0.7 16_384 Constants.Inference_profile.agent_default;
   check_profile "low_variance" 0.1 2048 Constants.Inference_profile.low_variance;
   check_profile "worker" 0.2 16_384 Constants.Inference_profile.worker_default;
-  check_profile "deterministic" 0.0 4096 Constants.Inference_profile.deterministic;
-  Alcotest.(check (float 0.001))
-    "legacy temperature"
-    Constants.Inference_profile.cascade_default.temperature
-    Constants.Inference.default_temperature;
-  Alcotest.(check int)
-    "legacy max tokens"
-    Constants.Inference_profile.cascade_default.max_tokens
-    Constants.Inference.default_max_tokens
+  check_profile "deterministic" 0.0 4096 Constants.Inference_profile.deterministic
 ;;
 
 let test_constants_retry_cache_sampling_and_endpoints () =
@@ -1784,9 +1776,7 @@ let test_with_context_size () =
 
 let test_with_context_size_overrides () =
   let c =
-    Capabilities.with_context_size
-      Capabilities.anthropic_capabilities
-      ~ctx_size:1_000_000
+    Capabilities.with_context_size Capabilities.anthropic_capabilities ~ctx_size:1_000_000
   in
   Alcotest.(check (option int)) "overrides" (Some 1_000_000) c.max_context_tokens
 ;;

--- a/test/test_mcp_http.ml
+++ b/test/test_mcp_http.ml
@@ -172,8 +172,7 @@ let test_session_transport_kind () =
   check (option string) "http url" (Some "http://127.0.0.1:8935/mcp") info2.http_base_url
 ;;
 
-let test_session_transport_kind_stdio_default () =
-  (* Old JSON without transport_kind should default to Stdio *)
+let test_session_transport_kind_required () =
   let json =
     `Assoc
       [ "server_name", `String "old-srv"
@@ -183,8 +182,11 @@ let test_session_transport_kind_stdio_default () =
       ; "tool_schemas", `List [] (* no transport_kind field *)
       ]
   in
-  let info = Result.get_ok (Mcp_session.info_of_json json) in
-  check bool "defaults to Stdio" true (info.transport_kind = Mcp_session.Stdio)
+  check
+    bool
+    "missing transport_kind rejected"
+    true
+    (Result.is_error (Mcp_session.info_of_json json))
 ;;
 
 (* ── Suite ──────────────────────────────────────────────── *)
@@ -211,10 +213,7 @@ let () =
     ; "errors", [ test_case "http transport error" `Quick test_http_transport_error ]
     ; ( "session"
       , [ test_case "transport_kind roundtrip" `Quick test_session_transport_kind
-        ; test_case
-            "transport_kind default stdio"
-            `Quick
-            test_session_transport_kind_stdio_default
+        ; test_case "transport_kind required" `Quick test_session_transport_kind_required
         ] )
     ]
 ;;

--- a/test/test_mcp_session.ml
+++ b/test/test_mcp_session.ml
@@ -241,10 +241,10 @@ let () =
                 ]
             in
             check bool "error" true (Result.is_error (Mcp_session.info_of_json bad)))
-        ; test_case "legacy http info without endpoint still parses" `Quick (fun () ->
-            let legacy =
+        ; test_case "http info without endpoint rejected" `Quick (fun () ->
+            let missing_endpoint =
               `Assoc
-                [ "server_name", `String "legacy-http"
+                [ "server_name", `String "http-no-endpoint"
                 ; "command", `String "http"
                 ; "args", `List []
                 ; "env", `List []
@@ -252,9 +252,11 @@ let () =
                 ; "transport_kind", `String "http"
                 ]
             in
-            let info = Result.get_ok (Mcp_session.info_of_json legacy) in
-            check (option string) "no http endpoint" None info.http_base_url;
-            check int "no http headers" 0 (List.length info.http_headers))
+            check
+              bool
+              "error"
+              true
+              (Result.is_error (Mcp_session.info_of_json missing_endpoint)))
         ] )
     ; ( "spec_roundtrip"
       , [ test_case "to_server_spec preserves all fields" `Quick (fun () ->

--- a/test/test_memory.ml
+++ b/test/test_memory.ml
@@ -274,27 +274,6 @@ let test_long_term_backend_set_after_create () =
   | _ -> fail "late backend should work"
 ;;
 
-let test_legacy_backend_batch_and_remove () =
-  let store = Hashtbl.create 4 in
-  let removed = ref [] in
-  let backend =
-    Memory.legacy_backend
-      ~persist:(fun ~key value -> Hashtbl.replace store key value)
-      ~retrieve:(fun ~key -> Hashtbl.find_opt store key)
-      ~remove:(fun ~key ->
-        removed := key :: !removed;
-        Hashtbl.remove store key)
-  in
-  check_ok "legacy persist" (backend.persist ~key:"one" (json_i 1));
-  check_ok "legacy batch" (backend.batch_persist [ "two", json_i 2; "three", json_i 3 ]);
-  (match backend.retrieve ~key:"two" with
-   | Some (`Int 2) -> ()
-   | _ -> fail "batch should persist values");
-  check int "legacy query empty" 0 (List.length (backend.query ~prefix:"" ~limit:10));
-  check_ok "legacy remove" (backend.remove ~key:"one");
-  check (list string) "remove callback called" [ "one" ] !removed
-;;
-
 let test_long_term_backend_errors_and_result_fallback () =
   let backend : Memory.long_term_backend =
     { persist = (fun ~key:_ _ -> Error "disk full")
@@ -610,7 +589,6 @@ let () =
             "set backend after create"
             `Quick
             test_long_term_backend_set_after_create
-        ; test_case "legacy backend" `Quick test_legacy_backend_batch_and_remove
         ; test_case
             "backend errors and result fallback"
             `Quick

--- a/test/test_memory_lt_backend.ml
+++ b/test/test_memory_lt_backend.ml
@@ -232,65 +232,6 @@ let test_remove_error_propagates () =
   | Ok () -> fail "expected Error from forget"
 ;;
 
-(* ── legacy_backend ──────────────────────────────────── *)
-
-let test_legacy_backend () =
-  let store = Hashtbl.create 4 in
-  let backend =
-    Memory.legacy_backend
-      ~persist:(fun ~key value -> Hashtbl.replace store key value)
-      ~retrieve:(fun ~key -> Hashtbl.find_opt store key)
-      ~remove:(fun ~key -> Hashtbl.remove store key)
-  in
-  let mem = Memory.create ~long_term:backend () in
-  ignore (Memory.store mem ~tier:Long_term "lk" (json_s "lv"));
-  check
-    (option string)
-    "persisted"
-    (Some "\"lv\"")
-    (Option.map Yojson.Safe.to_string (Hashtbl.find_opt store "lk"));
-  ignore (Memory.forget mem ~tier:Long_term "lk");
-  check bool "removed" true (not (Hashtbl.mem store "lk"))
-;;
-
-let test_legacy_backend_batch () =
-  let store = Hashtbl.create 4 in
-  let backend =
-    Memory.legacy_backend
-      ~persist:(fun ~key value -> Hashtbl.replace store key value)
-      ~retrieve:(fun ~key -> Hashtbl.find_opt store key)
-      ~remove:(fun ~key -> Hashtbl.remove store key)
-  in
-  (match backend.batch_persist [ "a", json_i 1; "b", json_i 2 ] with
-   | Ok () -> ()
-   | Error e -> fail e);
-  check
-    int
-    "a"
-    1
-    (match Hashtbl.find_opt store "a" with
-     | Some (`Int n) -> n
-     | _ -> -1);
-  check
-    int
-    "b"
-    2
-    (match Hashtbl.find_opt store "b" with
-     | Some (`Int n) -> n
-     | _ -> -1)
-;;
-
-let test_legacy_backend_query_empty () =
-  let backend =
-    Memory.legacy_backend
-      ~persist:(fun ~key:_ _v -> ())
-      ~retrieve:(fun ~key:_ -> None)
-      ~remove:(fun ~key:_ -> ())
-  in
-  let results = backend.query ~prefix:"any" ~limit:10 in
-  check int "always empty" 0 (List.length results)
-;;
-
 (* ── Suite ───────────────────────────────────────────── *)
 
 let () =
@@ -318,11 +259,6 @@ let () =
     ; ( "error_propagation"
       , [ test_case "persist error" `Quick test_persist_error_propagates
         ; test_case "remove error" `Quick test_remove_error_propagates
-        ] )
-    ; ( "legacy_backend"
-      , [ test_case "persist/remove" `Quick test_legacy_backend
-        ; test_case "batch via legacy" `Quick test_legacy_backend_batch
-        ; test_case "query returns empty" `Quick test_legacy_backend_query_empty
         ] )
     ]
 ;;

--- a/test/test_provider_catalog_coverage.ml
+++ b/test/test_provider_catalog_coverage.ml
@@ -36,12 +36,12 @@ let test_full_entry_parses_auth_transport_and_capabilities () =
             "id": "rich-http",
             "aliases": [" Alias ", "", 7, "second"],
             "kind": "openai_compat",
-            "transport": "custom-openai-compat",
+            "transport": "http",
             "base_url": "https://rich.example/v1",
             "request_path": "/chat/completions",
             "default_model": "rich-model",
             "credential_scope": "workspace",
-            "auth": {"type": "setup-token-env", "key": "SETUP_TOKEN"},
+            "auth": {"type": "setup_token_env", "env": "SETUP_TOKEN"},
             "max_context": 32000,
             "capabilities_base": "provider_d_chat",
             "capabilities": {
@@ -73,7 +73,7 @@ let test_full_entry_parses_auth_transport_and_capabilities () =
               "supports_computer_use": true,
               "supports_code_execution": true,
               "emits_usage_tokens": true,
-              "thinking_control_format": "chat-template-kwargs",
+              "thinking_control_format": "chat_template_kwargs",
               "supported_models": [" rich-model ", "", 3, "rich-fast"]
             }
           },
@@ -99,11 +99,6 @@ let test_full_entry_parses_auth_transport_and_capabilities () =
             "id": "exec-auth",
             "kind": "openai_compat",
             "auth": {"type": "exec", "command": "op read token"}
-          },
-          {
-            "id": "legacy-env",
-            "kind": "openai_compat",
-            "api_key_env": "LEGACY_KEY"
           }
         ]
       }|}
@@ -111,11 +106,7 @@ let test_full_entry_parses_auth_transport_and_capabilities () =
   let rich = require_lookup catalog "alias" in
   check string "id" "rich-http" rich.id;
   check (list string) "aliases" [ "Alias"; "second" ] rich.aliases;
-  check
-    bool
-    "legacy custom transport alias"
-    true
-    (rich.transport = Provider_catalog.Http);
+  check bool "http transport" true (rich.transport = Provider_catalog.Http);
   check bool "setup auth" true (rich.auth = Provider_catalog.Setup_token_env "SETUP_TOKEN");
   check string "api key from setup auth" "SETUP_TOKEN" rich.api_key_env;
   check (option string) "default model" (Some "rich-model") rich.default_model;
@@ -178,13 +169,7 @@ let test_full_entry_parses_auth_transport_and_capabilities () =
     true
     (file_auth.auth = Provider_catalog.File "/tmp/provider-token");
   let exec_auth = require_lookup catalog "exec-auth" in
-  check bool "exec auth" true (exec_auth.auth = Provider_catalog.Exec "op read token");
-  let legacy = require_lookup catalog "legacy-env" in
-  check
-    bool
-    "legacy api_key_env auth"
-    true
-    (legacy.auth = Provider_catalog.Api_key_env "LEGACY_KEY")
+  check bool "exec auth" true (exec_auth.auth = Provider_catalog.Exec "op read token")
 ;;
 
 let test_type_mismatches_fall_back_without_rejecting_entry () =
@@ -198,7 +183,7 @@ let test_type_mismatches_fall_back_without_rejecting_entry () =
             "kind": 42,
             "aliases": "not-array",
             "transport": false,
-            "auth": {"type": "env", "env": 17},
+            "auth": 17,
             "capabilities": {
               "supports_tools": "yes",
               "max_output_tokens": "many",
@@ -212,7 +197,11 @@ let test_type_mismatches_fall_back_without_rejecting_entry () =
   check bool "default kind" true (typed.kind = Provider_config.OpenAI_compat);
   check bool "default transport" true (typed.transport = Provider_catalog.Http);
   check (list string) "aliases default empty" [] typed.aliases;
-  check bool "env auth with empty env" true (typed.auth = Provider_catalog.Api_key_env "");
+  check
+    bool
+    "invalid auth defaults to no_auth"
+    true
+    (typed.auth = Provider_catalog.No_auth);
   check bool "supports tools remains default" false typed.capabilities.supports_tools;
   check
     (option int)
@@ -226,7 +215,7 @@ let test_type_mismatches_fall_back_without_rejecting_entry () =
     typed.capabilities.supported_models
 ;;
 
-let test_transport_auth_and_thinking_alias_matrix () =
+let test_transport_auth_and_thinking_canonical_matrix () =
   let catalog =
     catalog_of_string
       {|{
@@ -243,32 +232,32 @@ let test_transport_auth_and_thinking_alias_matrix () =
             "id": "cli-env",
             "kind": "openai_compat",
             "transport": "http",
-            "auth": {"type": "api-key-env", "env": "ENV_KEY"},
-            "capabilities": {"thinking_control_format": "thinking-object"}
+            "auth": {"type": "api_key_env", "env": "ENV_KEY"},
+            "capabilities": {"thinking_control_format": "thinking_object"}
           },
       {
-            "id": "compat-alias",
+            "id": "http-direct",
             "kind": "openai_compat",
-            "transport": "custom-openai-compat",
-            "auth": {"type": "env", "env": "SHORT_ENV"},
-            "capabilities": {"thinking_control_format": "thinking-object-plain"}
+            "transport": "http",
+            "auth": {"type": "api_key_env", "env": "SHORT_ENV"},
+            "capabilities": {"thinking_control_format": "thinking_object_only"}
           },
           {
             "id": "reasoning",
             "kind": "openai_compat",
             "auth": {"type": "api_key_env", "env": "REASON_KEY"},
-            "capabilities": {"thinking_control_format": "reasoning-effort"}
+            "capabilities": {"thinking_control_format": "reasoning_effort"}
           },
           {
             "id": "enable",
             "kind": "openai_compat",
-            "auth": {"type": "api-key-env", "env": "ENABLE_KEY"},
-            "capabilities": {"thinking_control_format": "enable-thinking"}
+            "auth": {"type": "api_key_env", "env": "ENABLE_KEY"},
+            "capabilities": {"thinking_control_format": "enable_thinking"}
           },
           {
-            "id": "base-fallback",
+            "id": "base-entry",
             "kind": "openai_compat",
-            "base": "provider_d_chat",
+            "capabilities_base": "provider_d_chat",
             "max_context": 9223372036854775807999,
             "capabilities": {
               "prompt_cache_alignment": 9223372036854775807999
@@ -287,49 +276,65 @@ let test_transport_auth_and_thinking_alias_matrix () =
     (http_none.capabilities.thinking_control_format = Capabilities.No_thinking_control);
   let cli_env = require_lookup catalog "cli-env" in
   check bool "cli transport" true (cli_env.transport = Provider_catalog.Http);
+  check bool "api key auth" true (cli_env.auth = Provider_catalog.Api_key_env "ENV_KEY");
   check
     bool
-    "api key auth alias"
-    true
-    (cli_env.auth = Provider_catalog.Api_key_env "ENV_KEY");
-  check
-    bool
-    "thinking object alias"
+    "thinking object"
     true
     (cli_env.capabilities.thinking_control_format = Capabilities.Thinking_object);
-  let compat = require_lookup catalog "compat-alias" in
+  let compat = require_lookup catalog "http-direct" in
+  check bool "http transport" true (compat.transport = Provider_catalog.Http);
+  check bool "env auth" true (compat.auth = Provider_catalog.Api_key_env "SHORT_ENV");
   check
     bool
-    "custom-openai-compat transport alias"
-    true
-    (compat.transport = Provider_catalog.Http);
-  check bool "env auth alias" true (compat.auth = Provider_catalog.Api_key_env "SHORT_ENV");
-  check
-    bool
-    "thinking object plain alias"
+    "thinking object only"
     true
     (compat.capabilities.thinking_control_format = Capabilities.Thinking_object_only);
   let reasoning = require_lookup catalog "reasoning" in
   check
     bool
-    "reasoning effort alias"
+    "reasoning effort"
     true
     (reasoning.capabilities.thinking_control_format = Capabilities.Reasoning_effort);
   let enable = require_lookup catalog "enable" in
   check bool "enable env" true (enable.auth = Provider_catalog.Api_key_env "ENABLE_KEY");
   check
     bool
-    "enable thinking alias"
+    "enable thinking"
     true
     (enable.capabilities.thinking_control_format = Capabilities.Enable_thinking);
-  let base = require_lookup catalog "base-fallback" in
-  check bool "base fallback supports tools" true base.capabilities.supports_tools;
+  let base = require_lookup catalog "base-entry" in
+  check bool "capabilities_base supports tools" true base.capabilities.supports_tools;
   check
     (option int)
     "oversized prompt alignment ignored"
     None
     base.capabilities.prompt_cache_alignment;
   check int "catalog size" 6 (List.length catalog)
+;;
+
+let test_removed_catalog_aliases_are_rejected () =
+  let assert_reject label json_text needle =
+    match Provider_catalog.of_json (Yojson.Safe.from_string json_text) with
+    | Error msg -> check bool label true (contains ~needle msg)
+    | Ok _ -> failf "%s should be rejected" label
+  in
+  assert_reject
+    "transport alias rejected"
+    {|{"schema_version":1,"providers":[{"id":"p","transport":"custom-openai-compat"}]}|}
+    "unknown transport";
+  assert_reject
+    "top-level api_key_env rejected"
+    {|{"schema_version":1,"providers":[{"id":"p","api_key_env":"LEGACY_KEY"}]}|}
+    "removed provider catalog field";
+  assert_reject
+    "auth alias rejected"
+    {|{"schema_version":1,"providers":[{"id":"p","auth":{"type":"api-key-env","env":"K"}}]}|}
+    "unknown auth type";
+  assert_reject
+    "thinking alias rejected"
+    {|{"schema_version":1,"providers":[{"id":"p","capabilities":{"thinking_control_format":"thinking-object"}}]}|}
+    "unknown thinking_control_format"
 ;;
 
 let test_non_list_providers_is_empty_catalog () =
@@ -444,9 +449,13 @@ let () =
             `Quick
             test_type_mismatches_fall_back_without_rejecting_entry
         ; test_case
-            "transport auth thinking aliases"
+            "transport auth thinking canonical"
             `Quick
-            test_transport_auth_and_thinking_alias_matrix
+            test_transport_auth_and_thinking_canonical_matrix
+        ; test_case
+            "removed catalog aliases rejected"
+            `Quick
+            test_removed_catalog_aliases_are_rejected
         ; test_case
             "non-list providers is empty"
             `Quick

--- a/test/test_provider_catalog_coverage.ml
+++ b/test/test_provider_catalog_coverage.ml
@@ -328,6 +328,10 @@ let test_removed_catalog_aliases_are_rejected () =
     {|{"schema_version":1,"providers":[{"id":"p","api_key_env":"LEGACY_KEY"}]}|}
     "removed provider catalog field";
   assert_reject
+    "top-level api_key_env null rejected"
+    {|{"schema_version":1,"providers":[{"id":"p","api_key_env":null}]}|}
+    "removed provider catalog field";
+  assert_reject
     "auth alias rejected"
     {|{"schema_version":1,"providers":[{"id":"p","auth":{"type":"api-key-env","env":"K"}}]}|}
     "unknown auth type";

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -45,7 +45,7 @@ let test_request_path_provider_a () =
 
 let test_request_path_provider_c () =
   let cfg = Provider_config.make ~kind:Kimi ~model_id:"m" ~base_url:"" () in
-  check_string "provider_c path" "/v1/messages" cfg.request_path
+  check_string "kimi path" "/v1/chat/completions" cfg.request_path
 ;;
 
 let test_request_path_provider_d () =
@@ -560,20 +560,24 @@ let test_kind_roundtrip () =
     all_kinds
 ;;
 
-let test_kind_aliases () =
-  check_parse "agent_llm_a -> Anthropic" "agent_llm_a" Anthropic;
-  check_parse "provider_d -> OpenAI_compat" "provider_d" OpenAI_compat;
-  check_parse "llama -> Ollama" "provider_n" Ollama
+let test_kind_aliases_rejected () =
+  List.iter
+    (fun input ->
+       check_bool
+         ("alias rejected " ^ input)
+         true
+         (Option.is_none (Provider_config.provider_kind_of_string input)))
+    [ "agent_llm_a"; "provider_d"; "provider_n"; "claude"; "openai"; "llama"; "zhipu" ]
 ;;
 
 let test_kind_case_insensitive () =
-  check_parse "PROVIDER_A" "PROVIDER_A" Anthropic;
-  check_parse "Agent_llm_a" "Agent_llm_a" Anthropic;
+  check_parse "ANTHROPIC" "ANTHROPIC" Anthropic;
+  check_parse "OpenAI_Compat" "OpenAI_Compat" OpenAI_compat;
   check_parse "Glm" "Glm" Glm
 ;;
 
 let test_kind_whitespace () =
-  check_parse "leading ws" "  agent_llm_a" Anthropic;
+  check_parse "leading ws" "  anthropic" Anthropic;
   check_parse "trailing ws" "ollama  " Ollama;
   check_parse "both ws" "\topenai_compat\n" OpenAI_compat
 ;;
@@ -614,7 +618,7 @@ let test_pp_uses_lowercase () =
   let fmt = Format.formatter_of_buffer buf in
   Provider_config.pp_provider_kind fmt Anthropic;
   Format.pp_print_flush fmt ();
-  check_string "pp Anthropic" "provider_a" (Buffer.contents buf)
+  check_string "pp Anthropic" "anthropic" (Buffer.contents buf)
 ;;
 
 let test_to_yojson_roundtrip () =
@@ -640,21 +644,14 @@ let test_of_yojson_accepts_canonical () =
     all_kinds
 ;;
 
-let test_of_yojson_accepts_aliases () =
+let test_of_yojson_rejects_aliases () =
   List.iter
-    (fun (input, expected_wire) ->
+    (fun input ->
        let json : Yojson.Safe.t = `String input in
        match Provider_config.provider_kind_of_yojson json with
-       | Ok k ->
-         check_string
-           ("of_yojson alias " ^ input)
-           expected_wire
-           (Provider_config.string_of_provider_kind k)
-       | Error msg -> Alcotest.failf "of_yojson alias %S failed: %s" input msg)
-    [ "agent_llm_a", "provider_a"
-    ; "provider_d", "openai_compat"
-    ; "provider_n", "ollama"
-    ]
+       | Ok _ -> Alcotest.failf "of_yojson alias %S should fail" input
+       | Error _ -> ())
+    [ "agent_llm_a"; "provider_d"; "provider_n" ]
 ;;
 
 let test_of_yojson_rejects_unknown_string () =
@@ -715,11 +712,11 @@ let contains_substring ~sub text =
 
 let test_wire_kind_lowercase () =
   let cases =
-    [ Provider_config.Anthropic, "\"provider_kind\":\"provider_a\""
+    [ Provider_config.Anthropic, "\"provider_kind\":\"anthropic\""
     ; Provider_config.OpenAI_compat, "\"provider_kind\":\"openai_compat\""
     ; Provider_config.Ollama, "\"provider_kind\":\"ollama\""
-    ; Provider_config.Gemini, "\"provider_kind\":\"provider_f\""
-    ; Provider_config.Glm, "\"provider_kind\":\"provider_k\""
+    ; Provider_config.Gemini, "\"provider_kind\":\"gemini\""
+    ; Provider_config.Glm, "\"provider_kind\":\"glm\""
     ]
   in
   List.iter
@@ -793,7 +790,7 @@ let test_wire_measured_zero_latency_is_distinct () =
     silently skip the new kind otherwise. *)
 let test_all_is_exhaustive () =
   let xs = Provider_config.all_provider_kinds in
-  Alcotest.(check int) "eleven canonical variants" 11 (List.length xs);
+  Alcotest.(check int) "seven canonical variants" 7 (List.length xs);
   Alcotest.(check bool)
     "no duplicate canonical strings"
     true
@@ -828,20 +825,20 @@ let test_all_drives_parse_roundtrip () =
 
 let test_default_api_key_env_known () =
   Alcotest.(check (option string))
-    "provider_a"
-    (Some "PROVIDER_A_API_KEY")
+    "anthropic"
+    (Some "ANTHROPIC_API_KEY")
     (Provider_config.default_api_key_env Anthropic);
   Alcotest.(check (option string))
-    "provider_f"
-    (Some "PROVIDER_F_API_KEY")
+    "gemini"
+    (Some "GEMINI_API_KEY")
     (Provider_config.default_api_key_env Gemini);
   Alcotest.(check (option string))
     "provider_k"
     (Some "ZAI_API_KEY")
     (Provider_config.default_api_key_env Glm);
   Alcotest.(check (option string))
-    "provider_c"
-    (Some "PROVIDER_C_API_KEY")
+    "kimi"
+    (Some "KIMI_API_KEY")
     (Provider_config.default_api_key_env Kimi)
 ;;
 
@@ -851,9 +848,7 @@ let test_default_api_key_env_none_for_others () =
   List.iter
     (fun (label, k) ->
        Alcotest.(check (option string)) label None (Provider_config.default_api_key_env k))
-    [ "openai_compat", Provider_config.OpenAI_compat
-    ; "ollama", Provider_config.Ollama
-    ]
+    [ "openai_compat", Provider_config.OpenAI_compat; "ollama", Provider_config.Ollama ]
 ;;
 
 let test_wire_kind_roundtrip_via_yojson () =
@@ -997,7 +992,7 @@ let () =
         ] )
     ; ( "kind_of_string"
       , [ Alcotest.test_case "roundtrip all variants" `Quick test_kind_roundtrip
-        ; Alcotest.test_case "documented aliases" `Quick test_kind_aliases
+        ; Alcotest.test_case "aliases rejected" `Quick test_kind_aliases_rejected
         ; Alcotest.test_case "case insensitive" `Quick test_kind_case_insensitive
         ; Alcotest.test_case "whitespace trimmed" `Quick test_kind_whitespace
         ; Alcotest.test_case "unknown returns None" `Quick test_kind_unknown_returns_none
@@ -1007,7 +1002,10 @@ let () =
         ; Alcotest.test_case "pp uses lowercase" `Quick test_pp_uses_lowercase
         ; Alcotest.test_case "to_yojson roundtrip" `Quick test_to_yojson_roundtrip
         ; Alcotest.test_case "of_yojson canonical" `Quick test_of_yojson_accepts_canonical
-        ; Alcotest.test_case "of_yojson aliases" `Quick test_of_yojson_accepts_aliases
+        ; Alcotest.test_case
+            "of_yojson aliases rejected"
+            `Quick
+            test_of_yojson_rejects_aliases
         ; Alcotest.test_case
             "of_yojson unknown rejected"
             `Quick

--- a/test/test_provider_runtime_binding.ml
+++ b/test/test_provider_runtime_binding.ml
@@ -40,10 +40,10 @@ let catalog_variants_json =
       "id": "custom-rich",
       "aliases": ["Rich-Alias"],
       "kind": "openai_compat",
-      "transport": "custom-openai-compat",
+      "transport": "http",
       "base_url": "https://rich.example/v1/",
       "request_path": "/chat/completions",
-      "auth": {"type": "setup-token-env", "key": "RICH_SETUP_TOKEN"},
+      "auth": {"type": "setup_token_env", "env": "RICH_SETUP_TOKEN"},
       "default_model": "rich-default",
       "capabilities_base": "provider_d_chat"
     },
@@ -69,7 +69,7 @@ let catalog_variants_json =
     {
       "id": "api-key-auth",
       "kind": "openai_compat",
-      "api_key_env": "API_KEY_AUTH",
+      "auth": {"type": "api_key_env", "env": "API_KEY_AUTH"},
       "capabilities_base": "provider_d_chat"
     }
   ]


### PR DESCRIPTION
## Summary
- Remove legacy provider-kind/provider-catalog aliases and compatibility auth/transport fallback keys.
- Require canonical MCP session transport metadata and explicit HTTP endpoint configuration.
- Drop legacy memory/constants/complete re-export surfaces and update docs/tests for the hard cut.

## Breaking changes
- Removed provider aliases: `claude`, `openai`, `provider_d`, `llama`, `ollama_cloud`, `zhipu`.
- Removed catalog auth/transport aliases including dashed auth aliases, `key`, top-level `api_key_env`, and `base` capability alias.
- Removed MCP session fallback inference for missing `transport_kind` and HTTP endpoint.
- Removed `Memory.legacy_backend`, `Constants.Inference`, and the `Complete_stream_acc` include re-export.

## Validation
- `./scripts/dune-local.sh build test/test_provider_config.exe test/test_provider_catalog_coverage.exe test/test_provider_runtime_binding.exe test/test_mcp_session.exe test/test_mcp_http.exe test/test_memory.exe test/test_memory_lt_backend.exe test/test_llm_provider_cov.exe`
- `./_build/default/test/test_provider_config.exe`
- `./_build/default/test/test_provider_catalog_coverage.exe`
- `./_build/default/test/test_provider_runtime_binding.exe`
- `./_build/default/test/test_mcp_session.exe`
- `./_build/default/test/test_mcp_http.exe`
- `./_build/default/test/test_memory.exe`
- `./_build/default/test/test_memory_lt_backend.exe`
- `./_build/default/test/test_llm_provider_cov.exe`
- `git diff --check`
