### PR TITLE
[codex] reject removed provider catalog aliases

### DIFF
--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -151,25 +151,28 @@ let auth_env = function
 let parse_auth json =
   match member "auth" json with
   | `Assoc _ as auth_json ->
-    let auth_type =
-      member_string_default "type" ~default:"none" auth_json
-      |> String.trim
-      |> String.lowercase_ascii
-    in
-    let env = member_string_default "env" ~default:"" auth_json in
-    (match auth_type with
-     | "none" -> Ok No_auth
-     | "api_key_env" -> Ok (Api_key_env env)
-     | "setup_token_env" -> Ok (Setup_token_env env)
-     | "oauth_cached_login" -> Ok Oauth_cached_login
-     | "file" -> Ok (File (member_string_default "path" ~default:"" auth_json))
-     | "exec" -> Ok (Exec (member_string_default "command" ~default:"" auth_json))
-     | other ->
-       Error
-         (Printf.sprintf
-            "unknown auth type %S (canonical: none, api_key_env, setup_token_env, \
-             oauth_cached_login, file, exec)"
-            other))
+    if member_present "key" auth_json
+    then Error "removed provider catalog auth field \"key\"; use auth.env"
+    else (
+      let auth_type =
+        member_string_default "type" ~default:"none" auth_json
+        |> String.trim
+        |> String.lowercase_ascii
+      in
+      let env = member_string_default "env" ~default:"" auth_json in
+      match auth_type with
+      | "none" -> Ok No_auth
+      | "api_key_env" -> Ok (Api_key_env env)
+      | "setup_token_env" -> Ok (Setup_token_env env)
+      | "oauth_cached_login" -> Ok Oauth_cached_login
+      | "file" -> Ok (File (member_string_default "path" ~default:"" auth_json))
+      | "exec" -> Ok (Exec (member_string_default "command" ~default:"" auth_json))
+      | other ->
+        Error
+          (Printf.sprintf
+             "unknown auth type %S (canonical: none, api_key_env, setup_token_env, \
+              oauth_cached_login, file, exec)"
+             other))
   | _ -> Ok No_auth
 ;;
 
@@ -197,22 +200,25 @@ let parse_thinking_control_format = function
 let member_supported_models json = member_string_list "supported_models" json
 
 let capability_base json =
-  let label = member_string "capabilities_base" json in
-  match label with
-  | None -> Ok Capabilities.default_capabilities
-  | Some raw ->
-    let trimmed = String.trim raw in
-    if trimmed = ""
-    then Ok Capabilities.default_capabilities
-    else (
-      match Capabilities.capabilities_for_provider_label trimmed with
-      | Some caps -> Ok caps
-      | None ->
-        Error
-          (Printf.sprintf
-             "unknown capabilities_base %S (see \
-              Capabilities.capabilities_for_provider_label for valid presets)"
-             trimmed))
+  if member_present "base" json
+  then Error "removed provider catalog field \"base\"; use \"capabilities_base\""
+  else (
+    let label = member_string "capabilities_base" json in
+    match label with
+    | None -> Ok Capabilities.default_capabilities
+    | Some raw ->
+      let trimmed = String.trim raw in
+      if trimmed = ""
+      then Ok Capabilities.default_capabilities
+      else (
+        match Capabilities.capabilities_for_provider_label trimmed with
+        | Some caps -> Ok caps
+        | None ->
+          Error
+            (Printf.sprintf
+               "unknown capabilities_base %S (see \
+                Capabilities.capabilities_for_provider_label for valid presets)"
+               trimmed)))
 ;;
 
 let override_bool key caps f json =

--- a/test/test_provider_catalog_coverage.ml
+++ b/test/test_provider_catalog_coverage.ml
@@ -332,6 +332,14 @@ let test_removed_catalog_aliases_are_rejected () =
     {|{"schema_version":1,"providers":[{"id":"p","api_key_env":null}]}|}
     "removed provider catalog field";
   assert_reject
+    "auth key rejected"
+    {|{"schema_version":1,"providers":[{"id":"p","auth":{"type":"api_key_env","key":"LEGACY_KEY"}}]}|}
+    "removed provider catalog auth field";
+  assert_reject
+    "capability base alias rejected"
+    {|{"schema_version":1,"providers":[{"id":"p","base":"provider_d_chat"}]}|}
+    "removed provider catalog field \"base\"";
+  assert_reject
     "auth alias rejected"
     {|{"schema_version":1,"providers":[{"id":"p","auth":{"type":"api-key-env","env":"K"}}]}|}
     "unknown auth type";


### PR DESCRIPTION
Follow-up to #1821 post-merge review comments.

Changes:
- Reject removed nested auth.key in provider catalog entries.
- Reject removed top-level base alias; require capabilities_base.
- Add coverage to removed catalog alias tests.

Validation:
- ocamlformat --check lib/llm_provider/provider_catalog.ml test/test_provider_catalog_coverage.ml
- git diff --check
- ./scripts/dune-local.sh build test/test_provider_catalog_coverage.exe
- ./_build/default/test/test_provider_catalog_coverage.exe