### PR TITLE
feat(agent): idle/progress-aware execution timeout

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -392,12 +392,17 @@ let%test "race_idle_watchdog: returns f's result immediately on fast completion"
 
 (* Wrap [f] in the configured execution timeouts:
    - [max_execution_time_s] -> a hard total wall-clock backstop (the
-     historical behaviour), surfacing as [AgentExecutionTimeout].
+     historical behaviour), surfacing as [AgentExecutionTimeout]. Any
+     [Some _] engages it, including [Some 0.0] / negatives which fire
+     immediately via [with_timeout_exn] exactly as before this field
+     gained an idle companion — the ceiling's semantics are unchanged.
    - [execution_idle_timeout_s] -> an inactivity watchdog that resets on
-     progress, surfacing as [AgentExecutionIdleTimeout].
-   Both require a clock and are independently optional; with neither set
-   (or no clock) behaviour matches earlier versions. When both are set,
-   the ceiling wraps the idle watchdog so either guard can fire. *)
+     progress, surfacing as [AgentExecutionIdleTimeout]. A non-positive
+     value disables it (treated like [None]): a 0s idle deadline would
+     cancel on the first check, which is never useful.
+   Both require a clock; with neither set (or no clock) behaviour matches
+   earlier versions. When both are set, the ceiling wraps the idle
+   watchdog so either guard can fire. *)
 let with_optional_timeout ?clock ~last_activity agent f =
   match clock with
   | None -> f ()
@@ -409,7 +414,7 @@ let with_optional_timeout ?clock ~last_activity agent f =
       | _ -> f ()
     in
     (match agent.options.max_execution_time_s with
-     | Some timeout_s when timeout_s > 0.0 ->
+     | Some timeout_s ->
        let started_at = Unix.gettimeofday () in
        (try Eio.Time.with_timeout_exn clock timeout_s run_with_idle with
         | Eio.Time.Timeout ->

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -317,9 +317,12 @@ let race_idle_watchdog ~clock ~idle_timeout_s ~last_activity f =
          else (
            (* Sleep only the remaining window; activity during the sleep
               advances [last_activity], so the post-wake re-check resets
-              the deadline instead of firing. The small floor avoids a
-              busy-spin when [idle_for] races just under the threshold. *)
-           Eio.Time.sleep clock (Float.max 0.05 (idle_timeout_s -. idle_for));
+              the deadline instead of firing. Floor the sleep to avoid a
+              busy-spin when [idle_for] races just under the threshold, but
+              cap the floor at [idle_timeout_s] so a sub-floor idle window
+              is still respected (fires on time, not one floor late). *)
+           let floor = Float.min 0.05 idle_timeout_s in
+           Eio.Time.sleep clock (Float.max floor (idle_timeout_s -. idle_for));
            watch ())
        in
        watch ())
@@ -478,10 +481,13 @@ let run_stream ~sw ?clock ~on_event ?on_yield ?on_resume agent user_prompt =
      reach [on_event] as [ContentBlockDelta { delta = ThinkingDelta _ }]
      (see Llm_provider.Streaming.provider_d_chunk_to_events) — counts as
      progress, so a long reasoning burst keeps the idle watchdog from
-     firing. The caller's [on_event] runs after the bump. *)
+     firing. [caller_on_event] is the original callback (bound under a
+     distinct name so the wrapper is not misread as self-recursion); it
+     runs after the activity bump. *)
+  let caller_on_event = on_event in
   let on_event ev =
     on_activity ();
-    on_event ev
+    caller_on_event ev
   in
   with_periodic_callbacks ~sw ?clock ~last_activity agent (fun () ->
     run_loop
@@ -714,10 +720,13 @@ let checkpoint ?(session_id = "") ?working_context agent =
 let run_turn_stream ~sw ?clock ~on_event ?on_telemetry agent =
   let last_activity = ref (now_or_zero clock) in
   (* Single-turn streaming: only token-level [on_event] bumps activity
-     (no run_loop, so no turn-boundary signal). *)
+     (no run_loop, so no turn-boundary signal). [caller_on_event] is the
+     original callback, bound under a distinct name so the wrapper is not
+     misread as self-recursion. *)
+  let caller_on_event = on_event in
   let on_event ev =
     last_activity := now_or_zero clock;
-    on_event ev
+    caller_on_event ev
   in
   with_optional_timeout ?clock ~last_activity agent (fun () ->
     run_turn_core ~sw ?clock ~api_strategy:(Stream { on_event; on_telemetry }) agent)

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -132,7 +132,12 @@ let log_turn ~run_start ~turn_start ~turn_index ~max_turns ~model ~stop =
     ]
 ;;
 
-let run_loop ~sw ?clock ~api_strategy ?on_yield ?on_resume agent user_prompt =
+let run_loop ~sw ?clock ~api_strategy ?on_yield ?on_resume ?on_activity agent user_prompt =
+  let bump_activity () =
+    match on_activity with
+    | Some f -> f ()
+    | None -> ()
+  in
   let user_prompt = Llm_provider.Utf8_sanitize.sanitize user_prompt in
   let user_msg =
     { role = User
@@ -195,6 +200,12 @@ let run_loop ~sw ?clock ~api_strategy ?on_yield ?on_resume agent user_prompt =
       let max_turns = agent.state.config.max_turns in
       let turn_start = Unix.gettimeofday () in
       let result = run_turn_core ~sw ?clock ~api_strategy ?raw_trace_run agent in
+      (* A completed turn is execution progress: bump the idle watchdog
+         so a multi-turn run (especially non-streaming, where there are no
+         token-level [on_event] signals) is not flagged as stalled between
+         turns. Streaming turns also bump per token via the wrapped
+         [on_event] in [run_stream]. *)
+      bump_activity ();
       (match result with
        | Error e ->
          log_turn
@@ -269,22 +280,149 @@ let start_periodic_callbacks ~sw ?clock (cbs : periodic_callback list) =
     fun () -> List.iter (fun stop -> stop ()) stops
 ;;
 
-let with_optional_timeout ?clock agent f =
-  match agent.options.max_execution_time_s, clock with
-  | Some timeout_s, Some clock ->
-    let started_at = Unix.gettimeofday () in
-    (try Eio.Time.with_timeout_exn clock timeout_s f with
-     | Eio.Time.Timeout ->
-       let elapsed_sec = Float.max 0.0 (Unix.gettimeofday () -. started_at) in
-       Error
-         (Error.Agent
-            (Error.AgentExecutionTimeout
-               { elapsed_sec
-               ; timeout_sec = timeout_s
-               ; turn_count = agent.state.turn_count
-               ; max_turns = agent.state.config.max_turns
-               })))
-  | _ -> f ()
+(* Eio clock read; falls back to 0.0 when no clock is available (the
+   timers below are skipped in that case anyway, so the value is unused). *)
+let now_or_zero = function
+  | Some clock -> Eio.Time.now clock
+  | None -> 0.0
+;;
+
+(* Idle / no-progress watchdog. Races [f] against an inactivity timer
+   that resets whenever [!last_activity] advances — bumped per streamed
+   token via the wrapped [on_event] in {!run_stream} and per completed
+   turn via {!run_loop}'s [on_activity]. Returns [f]'s result, or an
+   [AgentExecutionIdleTimeout] when no activity is seen for
+   [idle_timeout_s].
+
+   Cancellation safety: [Eio.Fiber.first] cancels the loser through the
+   same Eio cancellation path the hard ceiling ([with_timeout_exn])
+   already relies on. When the watchdog fires it cancels [f]; the
+   streaming HTTP connection lives under an [Eio.Switch] inside
+   [Http_client], so the socket is released on cancel. When [f] finishes
+   first, the sleeping watchdog is cancelled and its [Cancelled] is
+   absorbed by [Eio.Fiber.first]. We never catch [Cancelled] here, so a
+   parent-scope cancellation propagates unchanged. *)
+(* Racing core, kept agent-free so it is unit-testable with only a clock
+   and an activity ref (no full agent / network). Returns
+   [`Completed (f ())] when [f] finishes first, or [`Idle_timeout idle_for]
+   when [idle_timeout_s] elapses with [!last_activity] never advancing. *)
+let race_idle_watchdog ~clock ~idle_timeout_s ~last_activity f =
+  Eio.Fiber.first
+    (fun () -> `Completed (f ()))
+    (fun () ->
+       let rec watch () =
+         let idle_for = Eio.Time.now clock -. !last_activity in
+         if idle_for >= idle_timeout_s
+         then `Idle_timeout idle_for
+         else (
+           (* Sleep only the remaining window; activity during the sleep
+              advances [last_activity], so the post-wake re-check resets
+              the deadline instead of firing. The small floor avoids a
+              busy-spin when [idle_for] races just under the threshold. *)
+           Eio.Time.sleep clock (Float.max 0.05 (idle_timeout_s -. idle_for));
+           watch ())
+       in
+       watch ())
+;;
+
+let with_idle_watchdog ~clock ~idle_timeout_s ~last_activity agent f =
+  match race_idle_watchdog ~clock ~idle_timeout_s ~last_activity f with
+  | `Completed result -> result
+  | `Idle_timeout idle_for ->
+    Error
+      (Error.Agent
+         (Error.AgentExecutionIdleTimeout
+            { idle_sec = idle_for
+            ; idle_timeout_sec = idle_timeout_s
+            ; turn_count = agent.state.turn_count
+            ; max_turns = agent.state.config.max_turns
+            }))
+;;
+
+let%test "race_idle_watchdog: fires when f makes no progress" =
+  Eio_main.run
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let last_activity = ref (Eio.Time.now clock) in
+  let outcome =
+    race_idle_watchdog ~clock ~idle_timeout_s:0.05 ~last_activity (fun () ->
+      (* Stuck run: sleeps far past the idle window, never bumps activity. *)
+      Eio.Time.sleep clock 1.0;
+      `Done)
+  in
+  match outcome with
+  | `Idle_timeout idle_for -> idle_for >= 0.05
+  | `Completed _ -> false
+;;
+
+let%test "race_idle_watchdog: does NOT fire while f keeps bumping activity" =
+  Eio_main.run
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let last_activity = ref (Eio.Time.now clock) in
+  let outcome =
+    race_idle_watchdog ~clock ~idle_timeout_s:0.1 ~last_activity (fun () ->
+      (* Progressing stream: 15 "tokens" at 0.02s each (total ~0.3s, 3x the
+         idle window) each bumping activity. Proves the watchdog tracks
+         progress, not total elapsed time — the exact regression a blunt
+         total wall-clock would cause on a long reasoning burst. *)
+      for _ = 1 to 15 do
+        Eio.Time.sleep clock 0.02;
+        last_activity := Eio.Time.now clock
+      done;
+      `Done)
+  in
+  match outcome with
+  | `Completed `Done -> true
+  | `Completed _ | `Idle_timeout _ -> false
+;;
+
+let%test "race_idle_watchdog: returns f's result immediately on fast completion" =
+  Eio_main.run
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let last_activity = ref (Eio.Time.now clock) in
+  let outcome =
+    race_idle_watchdog ~clock ~idle_timeout_s:10.0 ~last_activity (fun () -> `Done)
+  in
+  match outcome with
+  | `Completed `Done -> true
+  | `Completed _ | `Idle_timeout _ -> false
+;;
+
+(* Wrap [f] in the configured execution timeouts:
+   - [max_execution_time_s] -> a hard total wall-clock backstop (the
+     historical behaviour), surfacing as [AgentExecutionTimeout].
+   - [execution_idle_timeout_s] -> an inactivity watchdog that resets on
+     progress, surfacing as [AgentExecutionIdleTimeout].
+   Both require a clock and are independently optional; with neither set
+   (or no clock) behaviour matches earlier versions. When both are set,
+   the ceiling wraps the idle watchdog so either guard can fire. *)
+let with_optional_timeout ?clock ~last_activity agent f =
+  match clock with
+  | None -> f ()
+  | Some clock ->
+    let run_with_idle () =
+      match agent.options.execution_idle_timeout_s with
+      | Some idle_timeout_s when idle_timeout_s > 0.0 ->
+        with_idle_watchdog ~clock ~idle_timeout_s ~last_activity agent f
+      | _ -> f ()
+    in
+    (match agent.options.max_execution_time_s with
+     | Some timeout_s when timeout_s > 0.0 ->
+       let started_at = Unix.gettimeofday () in
+       (try Eio.Time.with_timeout_exn clock timeout_s run_with_idle with
+        | Eio.Time.Timeout ->
+          let elapsed_sec = Float.max 0.0 (Unix.gettimeofday () -. started_at) in
+          Error
+            (Error.Agent
+               (Error.AgentExecutionTimeout
+                  { elapsed_sec
+                  ; timeout_sec = timeout_s
+                  ; turn_count = agent.state.turn_count
+                  ; max_turns = agent.state.config.max_turns
+                  })))
+     | _ -> run_with_idle ())
 ;;
 
 let stop_once stop =
@@ -292,14 +430,14 @@ let stop_once stop =
   fun () -> if Atomic.compare_and_set stopped false true then stop ()
 ;;
 
-let with_periodic_callbacks ~sw:_ ?clock agent f =
+let with_periodic_callbacks ~sw:_ ?clock ~last_activity agent f =
   match agent.options.periodic_callbacks with
-  | [] -> with_optional_timeout ?clock agent f
+  | [] -> with_optional_timeout ?clock ~last_activity agent f
   | callbacks ->
     Eio.Switch.run
     @@ fun callback_sw ->
     let stop = start_periodic_callbacks ~sw:callback_sw ?clock callbacks |> stop_once in
-    (match with_optional_timeout ?clock agent f with
+    (match with_optional_timeout ?clock ~last_activity agent f with
      | result ->
        stop ();
        result
@@ -309,8 +447,18 @@ let with_periodic_callbacks ~sw:_ ?clock agent f =
 ;;
 
 let run ~sw ?clock ?on_yield ?on_resume agent user_prompt =
-  with_periodic_callbacks ~sw ?clock agent (fun () ->
-    run_loop ~sw ?clock ~api_strategy:Sync ?on_yield ?on_resume agent user_prompt)
+  let last_activity = ref (now_or_zero clock) in
+  let on_activity () = last_activity := now_or_zero clock in
+  with_periodic_callbacks ~sw ?clock ~last_activity agent (fun () ->
+    run_loop
+      ~sw
+      ?clock
+      ~api_strategy:Sync
+      ?on_yield
+      ?on_resume
+      ~on_activity
+      agent
+      user_prompt)
 ;;
 
 let run_stream ~sw ?clock ~on_event ?on_yield ?on_resume agent user_prompt =
@@ -319,13 +467,25 @@ let run_stream ~sw ?clock ~on_event ?on_yield ?on_resume agent user_prompt =
       (fun bus -> Telemetry_bus.publish (Telemetry_bus.of_event_bus bus))
       agent.options.event_bus
   in
-  with_periodic_callbacks ~sw ?clock agent (fun () ->
+  let last_activity = ref (now_or_zero clock) in
+  let on_activity () = last_activity := now_or_zero clock in
+  (* Every streamed event — including reasoning/thinking deltas, which
+     reach [on_event] as [ContentBlockDelta { delta = ThinkingDelta _ }]
+     (see Llm_provider.Streaming.provider_d_chunk_to_events) — counts as
+     progress, so a long reasoning burst keeps the idle watchdog from
+     firing. The caller's [on_event] runs after the bump. *)
+  let on_event ev =
+    on_activity ();
+    on_event ev
+  in
+  with_periodic_callbacks ~sw ?clock ~last_activity agent (fun () ->
     run_loop
       ~sw
       ?clock
       ~api_strategy:(Stream { on_event; on_telemetry })
       ?on_yield
       ?on_resume
+      ~on_activity
       agent
       user_prompt)
 ;;
@@ -547,7 +707,14 @@ let checkpoint ?(session_id = "") ?working_context agent =
 ;;
 
 let run_turn_stream ~sw ?clock ~on_event ?on_telemetry agent =
-  with_optional_timeout ?clock agent (fun () ->
+  let last_activity = ref (now_or_zero clock) in
+  (* Single-turn streaming: only token-level [on_event] bumps activity
+     (no run_loop, so no turn-boundary signal). *)
+  let on_event ev =
+    last_activity := now_or_zero clock;
+    on_event ev
+  in
+  with_optional_timeout ?clock ~last_activity agent (fun () ->
     run_turn_core ~sw ?clock ~api_strategy:(Stream { on_event; on_telemetry }) agent)
 ;;
 

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -42,6 +42,7 @@ type options = Agent_types.options =
   ; max_execution_time_s : float option
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
+  ; execution_idle_timeout_s : float option
   ; max_idle_turns : int
   ; idle_final_warning_at : int option
   ; hooks : Hooks.hooks

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -39,6 +39,7 @@ type options =
   ; max_execution_time_s : float option
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
+  ; execution_idle_timeout_s : float option
   ; max_idle_turns : int
   ; idle_final_warning_at : int option
   ; hooks : Hooks.hooks
@@ -164,6 +165,7 @@ let default_options =
   ; max_execution_time_s = None
   ; stream_idle_timeout_s = None
   ; body_timeout_s = None
+  ; execution_idle_timeout_s = None
   ; max_idle_turns = 3
   ; idle_final_warning_at = None
   ; hooks = Hooks.empty

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -88,8 +88,9 @@ type options =
 
         Requires [clock] to be supplied to [run]/[run_stream]; without a
         clock the watchdog is skipped and behaviour matches earlier
-        versions. For non-streaming [run], activity is observed only at
-        turn boundaries (no token signal), so set this above the longest
+        versions. A non-positive value disables the watchdog (treated like
+        [None]). For non-streaming [run], activity is observed only at turn
+        boundaries (no token signal), so set this above the longest
         expected single-turn latency or prefer [run_stream].
         @since 0.201.0 *)
   ; max_idle_turns : int

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -70,6 +70,28 @@ type options =
         [TimeoutError { phase = Stream_body; _ }] which the cascade/retry
         layer treats as retryable.
         @since 0.181.0 *)
+  ; execution_idle_timeout_s : float option
+    (** Agent-level inactivity deadline for the entire run. The timer
+        resets on execution activity — a streamed token (every
+        [on_event], including reasoning/thinking deltas) or a completed
+        turn — and fires only after [execution_idle_timeout_s] of genuine
+        silence, surfacing as [Error.AgentExecutionIdleTimeout]. Unlike
+        [max_execution_time_s] (a total wall-clock that also kills a
+        healthy-but-slow run) this never cancels a stream that is still
+        producing output, so it is the liveness guard while
+        [max_execution_time_s] becomes a generous backstop.
+
+        Complements [stream_idle_timeout_s], which caps per-line silence
+        at the HTTP layer for a single stream; this knob spans the whole
+        run, including the gaps between turns (tool execution, turn
+        transitions) where no stream is open.
+
+        Requires [clock] to be supplied to [run]/[run_stream]; without a
+        clock the watchdog is skipped and behaviour matches earlier
+        versions. For non-streaming [run], activity is observed only at
+        turn boundaries (no token signal), so set this above the longest
+        expected single-turn latency or prefer [run_stream].
+        @since 0.201.0 *)
   ; max_idle_turns : int
   ; idle_final_warning_at : int option
     (** Threshold for [Hooks.on_idle_escalated] to emit

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -32,6 +32,7 @@ type t =
   ; max_execution_time_s : float option
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
+  ; execution_idle_timeout_s : float option
   ; max_idle_turns : int
   ; idle_final_warning_at : int option
   ; hooks : Hooks.hooks
@@ -107,6 +108,7 @@ let create ~net ~model =
   ; max_execution_time_s = None
   ; stream_idle_timeout_s = None
   ; body_timeout_s = None
+  ; execution_idle_timeout_s = None
   ; max_idle_turns = 3
   ; idle_final_warning_at = None
   ; hooks = Hooks.empty
@@ -310,6 +312,7 @@ let with_event_bus bus b = { b with event_bus = Some bus }
 let with_max_execution_time s b = { b with max_execution_time_s = Some s }
 let with_stream_idle_timeout s b = { b with stream_idle_timeout_s = Some s }
 let with_body_timeout s b = { b with body_timeout_s = Some s }
+let with_execution_idle_timeout s b = { b with execution_idle_timeout_s = Some s }
 let with_max_idle_turns n b = { b with max_idle_turns = n }
 let with_idle_final_warning_at n b = { b with idle_final_warning_at = Some n }
 let with_context_injector injector b = { b with context_injector = Some injector }
@@ -388,6 +391,7 @@ let build b =
     ; max_execution_time_s = b.max_execution_time_s
     ; stream_idle_timeout_s = b.stream_idle_timeout_s
     ; body_timeout_s = b.body_timeout_s
+    ; execution_idle_timeout_s = b.execution_idle_timeout_s
     ; max_idle_turns = b.max_idle_turns
     ; idle_final_warning_at = b.idle_final_warning_at
     ; hooks =

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -157,7 +157,6 @@ val with_body_timeout : float -> t -> t
     [TimeoutError { phase = Stream_body; _ }] which the cascade/retry
     layer treats as retryable. @since 0.181.0 *)
 
-val with_execution_idle_timeout : float -> t -> t
 (** Set the agent-level inactivity deadline for the entire run. The timer
     resets on execution activity — a streamed token (every [on_event],
     including reasoning/thinking deltas) or a completed turn — and fires
@@ -170,6 +169,7 @@ val with_execution_idle_timeout : float -> t -> t
     spanning the gaps between turns. Requires a clock on [run]/[run_stream];
     without one the watchdog is skipped. For non-streaming [run], activity
     is observed only at turn boundaries. @since 0.201.0 *)
+val with_execution_idle_timeout : float -> t -> t
 
 (** Set the total deadline applied to streaming HTTP body consumption.
     Wraps the body callback in [Eio.Time.with_timeout_exn], complementing

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -157,6 +157,20 @@ val with_body_timeout : float -> t -> t
     [TimeoutError { phase = Stream_body; _ }] which the cascade/retry
     layer treats as retryable. @since 0.181.0 *)
 
+val with_execution_idle_timeout : float -> t -> t
+(** Set the agent-level inactivity deadline for the entire run. The timer
+    resets on execution activity — a streamed token (every [on_event],
+    including reasoning/thinking deltas) or a completed turn — and fires
+    only after this many seconds of genuine silence, surfacing as
+    [Error.AgentExecutionIdleTimeout]. Unlike [with_max_execution_time]
+    (a total wall-clock that also kills a healthy-but-slow run) this never
+    cancels a stream that is still producing output, so it is the liveness
+    guard while [with_max_execution_time] becomes a generous backstop.
+    Complements [with_stream_idle_timeout] (per-line, single stream) by
+    spanning the gaps between turns. Requires a clock on [run]/[run_stream];
+    without one the watchdog is skipped. For non-streaming [run], activity
+    is observed only at turn boundaries. @since 0.201.0 *)
+
 (** Set the total deadline applied to streaming HTTP body consumption.
     Wraps the body callback in [Eio.Time.with_timeout_exn], complementing
     [with_stream_idle_timeout] (which only caps inter-line silence).

--- a/lib/base/error.ml
+++ b/lib/base/error.ml
@@ -58,6 +58,18 @@ type agent_error =
       ; turn_count : int
       ; max_turns : int
       }
+  | AgentExecutionIdleTimeout of
+      { idle_sec : float
+      ; idle_timeout_sec : float
+      ; turn_count : int
+      ; max_turns : int
+      }
+      (** No execution activity (streamed token or completed turn) was
+          observed for [idle_timeout_sec]. Distinct from
+          [AgentExecutionTimeout], which caps total wall-clock regardless
+          of progress: an idle timeout means the run is genuinely stuck,
+          whereas an execution timeout can fire on a healthy-but-slow run.
+          @since 0.201.0 *)
   | CompletionContractViolation of
       { contract : Completion_contract_id.t
       ; reason : string
@@ -196,6 +208,13 @@ let agent_error_to_string = function
       "Agent execution timed out after %.1fs (max_execution_time_s=%.1fs, turns=%d/%d)"
       r.elapsed_sec
       r.timeout_sec
+      r.turn_count
+      r.max_turns
+  | AgentExecutionIdleTimeout r ->
+    Printf.sprintf
+      "Agent stalled: no progress for %.1fs (execution_idle_timeout_s=%.1fs, turns=%d/%d)"
+      r.idle_sec
+      r.idle_timeout_sec
       r.turn_count
       r.max_turns
   | CompletionContractViolation r ->

--- a/lib/base/error.ml
+++ b/lib/base/error.ml
@@ -64,7 +64,7 @@ type agent_error =
       ; turn_count : int
       ; max_turns : int
       }
-      (** No execution activity (streamed token or completed turn) was
+  (** No execution activity (streamed token or completed turn) was
           observed for [idle_timeout_sec]. Distinct from
           [AgentExecutionTimeout], which caps total wall-clock regardless
           of progress: the idle deadline resets on each unit of progress

--- a/lib/base/error.ml
+++ b/lib/base/error.ml
@@ -67,8 +67,11 @@ type agent_error =
       (** No execution activity (streamed token or completed turn) was
           observed for [idle_timeout_sec]. Distinct from
           [AgentExecutionTimeout], which caps total wall-clock regardless
-          of progress: an idle timeout means the run is genuinely stuck,
-          whereas an execution timeout can fire on a healthy-but-slow run.
+          of progress: the idle deadline resets on each unit of progress
+          and fires only on observed silence, so it does not cancel a run
+          that is still streaming output. For non-streaming [run] activity
+          is seen only at turn boundaries, so a long single turn can trip
+          this without the run being hung.
           @since 0.201.0 *)
   | CompletionContractViolation of
       { contract : Completion_contract_id.t

--- a/lib/base/error.mli
+++ b/lib/base/error.mli
@@ -69,8 +69,11 @@ type agent_error =
       (** No execution activity (streamed token or completed turn) was
           observed for [idle_timeout_sec]. Distinct from
           [AgentExecutionTimeout], which caps total wall-clock regardless
-          of progress: an idle timeout means the run is genuinely stuck,
-          whereas an execution timeout can fire on a healthy-but-slow run.
+          of progress: the idle deadline resets on each unit of progress
+          and fires only on observed silence, so it does not cancel a run
+          that is still streaming output. For non-streaming [run] activity
+          is seen only at turn boundaries, so a long single turn can trip
+          this without the run being hung.
           @since 0.201.0 *)
   | CompletionContractViolation of
       { contract : Completion_contract_id.t

--- a/lib/base/error.mli
+++ b/lib/base/error.mli
@@ -66,7 +66,7 @@ type agent_error =
       ; turn_count : int
       ; max_turns : int
       }
-      (** No execution activity (streamed token or completed turn) was
+  (** No execution activity (streamed token or completed turn) was
           observed for [idle_timeout_sec]. Distinct from
           [AgentExecutionTimeout], which caps total wall-clock regardless
           of progress: the idle deadline resets on each unit of progress

--- a/lib/base/error.mli
+++ b/lib/base/error.mli
@@ -60,6 +60,18 @@ type agent_error =
       ; turn_count : int
       ; max_turns : int
       }
+  | AgentExecutionIdleTimeout of
+      { idle_sec : float
+      ; idle_timeout_sec : float
+      ; turn_count : int
+      ; max_turns : int
+      }
+      (** No execution activity (streamed token or completed turn) was
+          observed for [idle_timeout_sec]. Distinct from
+          [AgentExecutionTimeout], which caps total wall-clock regardless
+          of progress: an idle timeout means the run is genuinely stuck,
+          whereas an execution timeout can fire on a healthy-but-slow run.
+          @since 0.201.0 *)
   | CompletionContractViolation of
       { contract : Completion_contract_id.t
       ; reason : string

--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -27,6 +27,7 @@ type agent_error =
   | `Idle_detected of int
   | `Tool_retry_exhausted of int * int * string
   | `Agent_execution_timeout of float * float * int * int
+  | `Agent_execution_idle_timeout of float * float * int * int
   | `Completion_contract_violation of
       Completion_contract_id.t * string * Completion_contract_violation_detail.t option
   | `Guardrail_violation of string * string
@@ -118,6 +119,9 @@ let of_sdk_error (err : Error.sdk_error) : sdk_error_poly =
     `Tool_retry_exhausted (r.attempts, r.limit, r.detail)
   | Error.Agent (AgentExecutionTimeout r) ->
     `Agent_execution_timeout (r.elapsed_sec, r.timeout_sec, r.turn_count, r.max_turns)
+  | Error.Agent (AgentExecutionIdleTimeout r) ->
+    `Agent_execution_idle_timeout
+      (r.idle_sec, r.idle_timeout_sec, r.turn_count, r.max_turns)
   | Error.Agent (CompletionContractViolation r) ->
     `Completion_contract_violation (r.contract, r.reason, r.violation_detail)
   | Error.Agent (GuardrailViolation r) -> `Guardrail_violation (r.validator, r.reason)
@@ -177,6 +181,9 @@ let to_sdk_error (err : sdk_error_poly) : Error.sdk_error =
   | `Agent_execution_timeout (elapsed_sec, timeout_sec, turn_count, max_turns) ->
     Error.Agent
       (AgentExecutionTimeout { elapsed_sec; timeout_sec; turn_count; max_turns })
+  | `Agent_execution_idle_timeout (idle_sec, idle_timeout_sec, turn_count, max_turns) ->
+    Error.Agent
+      (AgentExecutionIdleTimeout { idle_sec; idle_timeout_sec; turn_count; max_turns })
   | `Completion_contract_violation (contract, reason, violation_detail) ->
     Error.Agent (CompletionContractViolation { contract; reason; violation_detail })
   | `Guardrail_violation (validator, reason) ->

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -53,6 +53,8 @@ type agent_error =
   | `Tool_retry_exhausted of int * int * string (** attempts, limit, detail *)
   | `Agent_execution_timeout of float * float * int * int
     (** elapsed_sec, timeout_sec, turn_count, max_turns *)
+  | `Agent_execution_idle_timeout of float * float * int * int
+    (** idle_sec, idle_timeout_sec, turn_count, max_turns *)
   | `Completion_contract_violation of
       Completion_contract_id.t * string * Completion_contract_violation_detail.t option
     (** contract, reason, violation detail *)

--- a/test/dune
+++ b/test/dune
@@ -90,6 +90,7 @@
   test_elicitation
   test_error
   test_error_domain
+  test_execution_idle_timeout
   test_eval
   test_eval_baseline
   test_eval_coverage
@@ -298,6 +299,7 @@
   test_elicitation
   test_error
   test_error_domain
+  test_execution_idle_timeout
   test_eval
   test_eval_baseline
   test_eval_coverage

--- a/test/test_execution_idle_timeout.ml
+++ b/test/test_execution_idle_timeout.ml
@@ -135,7 +135,8 @@ let test_error_domain_roundtrip () =
   match back with
   | Error.Agent
       (Error.AgentExecutionIdleTimeout
-         { idle_sec = 45.0; idle_timeout_sec = 40.0; turn_count = 2; max_turns = 8 }) -> ()
+         { idle_sec = 45.0; idle_timeout_sec = 40.0; turn_count = 2; max_turns = 8 }) ->
+    ()
   | _ -> Alcotest.fail "roundtrip mismatch for AgentExecutionIdleTimeout"
 ;;
 
@@ -152,6 +153,7 @@ let () =
         ; tc "distinct from total timeout msg" test_message_differs_from_execution_timeout
         ; tc "distinct variant" test_idle_is_not_execution_timeout_variant
         ] )
-    ; ("error_domain round-trip", [ tc "idle timeout roundtrip" test_error_domain_roundtrip ])
+    ; ( "error_domain round-trip"
+      , [ tc "idle timeout roundtrip" test_error_domain_roundtrip ] )
     ]
 ;;

--- a/test/test_execution_idle_timeout.ml
+++ b/test/test_execution_idle_timeout.ml
@@ -1,0 +1,157 @@
+(** Unit tests for [execution_idle_timeout_s] option (since 0.201.0).
+
+    Validates the option field flow, the typed [AgentExecutionIdleTimeout]
+    error (distinct from [AgentExecutionTimeout]), its operator-facing
+    message, and the [Error_domain] round-trip.
+
+    The watchdog firing behaviour itself is proven by the inline
+    [race_idle_watchdog] tests in {!Agent} (lib/agent/agent.ml), which
+    drive a real Eio clock to show the timer fires on a genuine stall but
+    NOT on a stream that keeps producing output. *)
+
+open Agent_sdk
+
+let tc name f = Alcotest.test_case name `Quick f
+
+(* ── Field default + record update flow ─────────────────────────── *)
+
+let test_default_options_idle_none () =
+  Alcotest.(check (option (float 0.001)))
+    "default execution_idle_timeout_s is None"
+    None
+    Agent.default_options.execution_idle_timeout_s
+;;
+
+let test_options_record_update () =
+  let opts = Agent.default_options in
+  Alcotest.(check (option (float 0.001)))
+    "baseline execution_idle_timeout_s is None"
+    None
+    opts.execution_idle_timeout_s;
+  let opts' = { opts with execution_idle_timeout_s = Some 120.0 } in
+  Alcotest.(check (option (float 0.001)))
+    "record update sets execution_idle_timeout_s"
+    (Some 120.0)
+    opts'.execution_idle_timeout_s;
+  (* The idle knob is independent of the total wall-clock ceiling and of
+     the per-line stream idle deadline — setting one must not move the
+     others. *)
+  Alcotest.(check (option (float 0.001)))
+    "max_execution_time_s untouched by idle update"
+    None
+    opts'.max_execution_time_s;
+  Alcotest.(check (option (float 0.001)))
+    "stream_idle_timeout_s untouched by idle update"
+    None
+    opts'.stream_idle_timeout_s
+;;
+
+let test_builder_setter () =
+  Eio_main.run
+  @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  let agent =
+    Builder.create ~net ~model:"test-model"
+    |> Builder.with_execution_idle_timeout 90.0
+    |> Builder.build
+  in
+  Alcotest.(check (option (float 0.001)))
+    "builder threads execution_idle_timeout_s into options"
+    (Some 90.0)
+    (Agent.options agent).execution_idle_timeout_s
+;;
+
+(* ── Typed error: distinct variant + operator message ───────────── *)
+
+let idle_error idle_sec idle_timeout_sec =
+  Error.Agent
+    (Error.AgentExecutionIdleTimeout
+       { idle_sec; idle_timeout_sec; turn_count = 2; max_turns = 8 })
+;;
+
+let contains_substring ~needle s =
+  let ln = String.length needle in
+  let ls = String.length s in
+  if ln > ls
+  then false
+  else (
+    let found = ref false in
+    let i = ref 0 in
+    while (not !found) && !i <= ls - ln do
+      if String.equal (String.sub s !i ln) needle then found := true;
+      incr i
+    done;
+    !found)
+;;
+
+let test_message_names_idle_progress () =
+  (* Operators must tell a stall (no progress) apart from a total-budget
+     timeout by the message alone — they have different remediations
+     (the run is stuck vs the run was healthy-but-slow). *)
+  let msg = Error.to_string (idle_error 30.0 30.0) in
+  Alcotest.(check bool)
+    "message reports no-progress / stall"
+    true
+    (contains_substring ~needle:"no progress" msg);
+  Alcotest.(check bool)
+    "message names the execution_idle_timeout_s knob"
+    true
+    (contains_substring ~needle:"execution_idle_timeout_s" msg)
+;;
+
+let test_message_differs_from_execution_timeout () =
+  let idle_msg = Error.to_string (idle_error 30.0 30.0) in
+  let total_msg =
+    Error.to_string
+      (Error.Agent
+         (Error.AgentExecutionTimeout
+            { elapsed_sec = 30.0; timeout_sec = 30.0; turn_count = 2; max_turns = 8 }))
+  in
+  Alcotest.(check bool)
+    "idle and total-timeout messages are distinct"
+    true
+    (not (String.equal idle_msg total_msg))
+;;
+
+let test_idle_is_not_execution_timeout_variant () =
+  (* The whole point of a separate variant: code that classifies
+     [AgentExecutionTimeout] must NOT silently absorb an idle timeout. *)
+  match idle_error 1.0 1.0 with
+  | Error.Agent (Error.AgentExecutionTimeout _) ->
+    Alcotest.fail "idle timeout wrongly matched as AgentExecutionTimeout"
+  | Error.Agent (Error.AgentExecutionIdleTimeout _) -> ()
+  | _ -> Alcotest.fail "expected AgentExecutionIdleTimeout"
+;;
+
+(* ── Error_domain round-trip ────────────────────────────────────── *)
+
+let test_error_domain_roundtrip () =
+  let orig = idle_error 45.0 40.0 in
+  let poly = Error_domain.of_sdk_error orig in
+  (match poly with
+   | `Agent_execution_idle_timeout (45.0, 40.0, 2, 8) -> ()
+   | _ -> Alcotest.fail "expected Agent_execution_idle_timeout");
+  let back = Error_domain.to_sdk_error poly in
+  match back with
+  | Error.Agent
+      (Error.AgentExecutionIdleTimeout
+         { idle_sec = 45.0; idle_timeout_sec = 40.0; turn_count = 2; max_turns = 8 }) -> ()
+  | _ -> Alcotest.fail "roundtrip mismatch for AgentExecutionIdleTimeout"
+;;
+
+let () =
+  Alcotest.run
+    "execution_idle_timeout"
+    [ ( "options field flow"
+      , [ tc "default None" test_default_options_idle_none
+        ; tc "record update" test_options_record_update
+        ; tc "builder setter" test_builder_setter
+        ] )
+    ; ( "typed error + message"
+      , [ tc "message names no-progress" test_message_names_idle_progress
+        ; tc "distinct from total timeout msg" test_message_differs_from_execution_timeout
+        ; tc "distinct variant" test_idle_is_not_execution_timeout_variant
+        ] )
+    ; ("error_domain round-trip", [ tc "idle timeout roundtrip" test_error_domain_roundtrip ])
+    ]
+;;


### PR DESCRIPTION
## 목적

총량 wall-clock(`max_execution_time_s`)이 deadline을 지나는 순간, 토큰이 여전히 도착 중인 **건강한 streaming 턴**도 mid-stream에서 cancel한다. 느린 endpoint에서 reasoning이 길어지는 턴은 실제로 진행 중인데도 죽는다. 근본 문제는 총량 cap을 liveness 판정에 전용한 것이다.

## 변경

`execution_idle_timeout_s`(agent 옵션, 기본 `None`)를 추가한다. 실행 활동 — streaming 토큰(모든 `on_event`, reasoning/thinking delta 포함)과 완료된 턴 — 마다 reset되는 inactivity watchdog이며, 진짜로 침묵한 경우에만 발화해 새 typed 에러 `Error.AgentExecutionIdleTimeout`로 표면화된다.

- `max_execution_time_s`는 generous한 hard-ceiling backstop으로 유지된다(의미 불변).
- 두 timeout은 독립적으로 optional이고 `clock`을 요구한다. **둘 다 미설정이면 동작은 이전과 동일**(opt-in, back-compat).
- liveness는 idle watchdog이, budget은 총량 cap이 담당하도록 **경계를 분리**한다. 기존 `stream_idle_timeout_s`(HTTP per-line idle)를 보완하며, 턴 사이 gap(tool 실행, 턴 전환)까지 포함하는 run 전체 범위를 커버한다.

## 구현

watchdog은 `Eio.Fiber.first`로 run을 race한다 — hard ceiling이 이미 쓰는 `Eio.Time.with_timeout_exn`와 **동일한 Eio cancellation 경로**를 재사용한다. streaming HTTP 연결은 `Http_client`의 `Eio.Switch` 스코프 안에 있어 cancel 시 소켓이 정리된다. fiber leak/double-cancel 없음, `Eio.Cancel.Cancelled`를 삼키지 않으므로 부모 스코프 cancellation은 그대로 전파된다.

reasoning delta가 `on_event`에 도달함은 `Llm_provider.Streaming.provider_d_chunk_to_events`에서 확인했다(`ContentBlockDelta { delta = ThinkingDelta _ }`). 따라서 reasoning burst 동안 watchdog은 매 토큰마다 reset되어 발화하지 않는다.

## 검증

- `dune build lib`/`examples`/`bin`: exit 0.
- inline `race_idle_watchdog` 테스트(`lib/agent/agent.ml`): real Eio clock으로 (a) 진짜 stall 시 발화, (b) progressing stream(총 ~0.3s, idle window 0.1s의 3배)에서 미발화를 증명.
- `test/test_execution_idle_timeout.ml`: 옵션 flow, typed 에러 + operator 메시지, `Error_domain` round-trip — 7/7 통과.

## 미검증 / 남은 것

- 배포 후 라이브 검증(masc keeper가 qwen 호출 시 long reasoning 턴 생존)은 consumer 쪽 wiring 후 가능.
- consumer(masc-mcp)는 pin bump 시 `AgentExecutionIdleTimeout` 변형을 컴파일러가 강제하는 ~13곳에서 처리해야 한다(대부분 기존 `AgentExecutionTimeout` arm에 합류, `runtime_agent`의 partial_response 텍스트와 provider-attempt telemetry는 구분 가치 있음).
- non-streaming `run`은 턴 경계만 활동 신호로 본다(토큰 신호 없음). `.mli`에 명시: single-turn latency보다 크게 설정하거나 `run_stream` 사용.

WORKAROUND-WAIVED: 이 PR은 root fix다 — 증상 억제(cap/cooldown/dedup/repair)가 아니라, 총량 wall-clock을 liveness proxy로 오용하던 것을 typed idle/progress 감지로 교체한다. telemetry-as-fix 없음, string 분류기 없음, catch-all 추가 없음. 새 typed 변형 `AgentExecutionIdleTimeout`로 exhaustive match를 강제한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
