### PR TITLE
refactor: rename provider_d wire modules

### DIFF
--- a/docs/RFC-0001-vendor-purge.md
+++ b/docs/RFC-0001-vendor-purge.md
@@ -43,8 +43,8 @@ OAS has one external consumer (masc-mcp), under the same operator's control. For
 | `Anthropic` | `Provider_a` |
 | `Moonshot` | `Provider_b` |
 | `Kimi` | `Provider_c` |
-| `OpenAI_compat` | `Provider_d_compat` |
-| `OpenAI` (if any) | `Provider_d` |
+| `OpenAI_compat` | `Chat_completions_v1` |
+| `OpenAI` (if any) | `Chat_completions_v1` |
 | `Gemini` | `Provider_f` |
 | `DeepSeek` | `Provider_g` |
 | `DashScope` | `Provider_h` |
@@ -99,7 +99,7 @@ These were missed by the initial `\bqwen\b` perl regex pass because `qwen` follo
 
 | Original | New |
 |----------|-----|
-| `Gpt_5`, `Gpt_4_1`, `Gpt_4o` | `Provider_d_5`, `Provider_d_4_1`, `Provider_d_4o` |
+| `Gpt_5`, `Gpt_4_1`, `Gpt_4o` | `Chat_completions_v1_5`, `Chat_completions_v1_4_1`, `Chat_completions_v1_4o` |
 | `Llama_4` | `Provider_n_4` |
 | `Gemma_4 of { has_large_audio : bool }` | `Provider_f_gemma_4 of { has_large_audio : bool }` |
 | `Grok` | `Provider_e_grok` |
@@ -127,19 +127,19 @@ These were missed by the initial `\bqwen\b` perl regex pass because `qwen` follo
 17 modules renamed via `git mv`:
 
 - `api_anthropic.{ml,mli}` → `api_provider_a.{ml,mli}`
-- `api_openai.{ml,mli}` → `api_provider_d.{ml,mli}`
+- `api_openai.{ml,mli}` → `api_chat_completions_v1.{ml,mli}`
 - `backend_anthropic.{ml,mli}` → `backend_provider_a.{ml,mli}`
-- `backend_openai{,_parse,_request,_serialize}.{ml,mli}` → `backend_provider_d{,_parse,_request,_serialize}.{ml,mli}`
+- `backend_openai{,_parse,_request,_serialize}.{ml,mli}` → `backend_chat_completions_v1{,_parse,_request,_serialize}.{ml,mli}`
 - `backend_gemini.{ml,mli}` → `backend_provider_f.{ml,mli}`
 - `backend_glm.{ml,mli}` → `backend_provider_k.{ml,mli}`
 - `transport_codex_cli.{ml,mli}` → `transport_cli_tool_a.{ml,mli}`
 - `transport_gemini_cli.{ml,mli}` → `transport_cli_tool_b.{ml,mli}`
 - `transport_kimi_cli.{ml,mli}` → `transport_cli_tool_c.{ml,mli}`
 - `transport_claude_code.{ml,mli}` → `transport_cli_tool_d.{ml,mli}`
-- `transport_openai_compat.{ml,mli}` → `transport_provider_d_compat.{ml,mli}`
+- `transport_openai_compat.{ml,mli}` → `transport_chat_completions_v1_http.{ml,mli}`
 - `test_gemini_edge_cases.ml` → `test_provider_f_edge_cases.ml`
 - `test_backend_gemini.ml` → `test_backend_provider_f.ml`
-- `test_streaming_openai.ml` → `test_streaming_provider_d.ml`
+- `test_streaming_openai.ml` → `test_streaming_chat_completions_v1.ml`
 
 Module references updated repo-wide; `test/dune` test list updated.
 

--- a/docs/_audit/2026-05-25-coverage-ratchet-75-evidence.md
+++ b/docs/_audit/2026-05-25-coverage-ratchet-75-evidence.md
@@ -1,7 +1,7 @@
 # Coverage ratchet evidence - 2026-05-25
 
 Scope: #1175 Stage C/D/E/F continuation. PRs #1759 and #1761 raise measured
-project coverage above 80% with behavior-backed provider dispatch, provider_d
+project coverage above 80% with behavior-backed provider dispatch, chat_completions_v1
 codec, streaming, pure-module, harness, CLI transport, provider_k, provider
 catalog, runtime server, provider config, memory, discovery, HTTP client, tool
 selector, checkpoint, and type tests, so the CI coverage floor can move from
@@ -41,11 +41,11 @@ selector, checkpoint, and type tests, so the CI coverage floor can move from
   provider and streaming surfaces rather than zero-coverage files.
 - Tests added in this PR:
   - `test/test_provider_intf.ml`: provider dispatch error/custom-provider paths.
-  - `test/test_backend_provider_d_codec.ml`: provider_d serialization, schema,
+  - `test/test_backend_chat_completions_v1_codec.ml`: chat_completions_v1 serialization, schema,
     parse, telemetry, reasoning, fenced JSON, and malformed tool-call branches.
   - `test/test_streaming_coverage.ml`: stream accumulator/finalize/http-error
     edge branches.
-  - `test/test_streaming_edge_cases.ml`: provider_a SSE, provider_d,
+  - `test/test_streaming_edge_cases.ml`: provider_a SSE, chat_completions_v1,
     provider_f, Ollama NDJSON, and synthetic-event edge branches.
   - `test/test_client_wrapper_coverage.ml`: public client wrapper show/default
     aliases.

--- a/docs/example-capability-manifest.json
+++ b/docs/example-capability-manifest.json
@@ -5,7 +5,7 @@
     {
       "_comment": "Kimi K2.6 — Moonshot AI. 1T MoE / 32B active. 256K ctx. Top-level thinking + budget. Released 2026-04-20. https://platform.kimi.ai/docs/guide/kimi-k2-6-quickstart",
       "id_prefix": "kimi-k2.6",
-      "base_label": "provider_d_chat",
+      "base_label": "chat_completions_v1",
       "max_context_tokens": 262144,
       "supports_tools": true,
       "supports_tool_choice": true,
@@ -17,7 +17,7 @@
       "supports_system_prompt": true
     },
     {
-      "_comment": "GPT-5.3-Codex-Spark — OpenAI. Codex/ChatGPT-Pro subscription required, NOT public chat completions API. Reachable via Codex CLI bridge (non-interactive batch invocation), so base_label is cli_tool_a (Cli_tool_a transport) not provider_d_chat. supports_native_streaming=false because non-interactive call surface streams whole response. https://openai.com/index/introducing-gpt-5-3-codex-spark/",
+      "_comment": "GPT-5.3-Codex-Spark — OpenAI. Codex/ChatGPT-Pro subscription required, NOT public chat completions API. Reachable via Codex CLI bridge (non-interactive batch invocation), so base_label is cli_tool_a (Cli_tool_a transport) not chat_completions_v1. supports_native_streaming=false because non-interactive call surface streams whole response. https://openai.com/index/introducing-gpt-5-3-codex-spark/",
       "id_prefix": "gpt-5.3-codex-spark",
       "base_label": "cli_tool_a",
       "max_context_tokens": 131072,
@@ -30,7 +30,7 @@
     {
       "_comment": "GPT-4.1 — OpenAI. 1M ctx, 32K output, image input, no extended thinking. https://openai.com/index/gpt-4-1/",
       "id_prefix": "gpt-4.1",
-      "base_label": "provider_d_chat",
+      "base_label": "chat_completions_v1",
       "max_context_tokens": 1047576,
       "max_output_tokens": 32768,
       "supports_tools": true,
@@ -42,7 +42,7 @@
     {
       "_comment": "GLM-5.1 — Zhipu/Z.AI. 744B MoE / 40B active. 200K ctx, 128K output. Thinking on/off. Released 2026-04-07. https://docs.z.ai/guides/llm/glm-5.1",
       "id_prefix": "glm-5.1",
-      "base_label": "provider_d_chat",
+      "base_label": "chat_completions_v1",
       "max_context_tokens": 200000,
       "max_output_tokens": 128000,
       "supports_tools": true,
@@ -54,7 +54,7 @@
     {
       "_comment": "GLM-5 Turbo — Z.AI faster tier of GLM-5. Same 202K ctx (CORRECTED — turbo is NOT smaller-context). 131K output. https://openrouter.ai/z-ai/glm-5-turbo",
       "id_prefix": "glm-5-turbo",
-      "base_label": "provider_d_chat",
+      "base_label": "chat_completions_v1",
       "max_context_tokens": 202752,
       "max_output_tokens": 131072,
       "supports_tools": true,
@@ -66,7 +66,7 @@
     {
       "_comment": "GLM-5 — Z.AI. 202K ctx (CORRECTED — was 128K), 98K output. Released 2026-02-11. https://docs.z.ai/guides/llm/glm-5",
       "id_prefix": "glm-5",
-      "base_label": "provider_d_chat",
+      "base_label": "chat_completions_v1",
       "max_context_tokens": 202752,
       "max_output_tokens": 98304,
       "supports_tools": true,
@@ -78,7 +78,7 @@
     {
       "_comment": "Gemma 4 E2B — Google. 131K ctx. Native function calling (CORRECTED — prior tools=false was WRONG). Multimodal (image input). https://ai.google.dev/gemma/docs/capabilities/text/function-calling-gemma4",
       "id_prefix": "gemma4",
-      "base_label": "provider_d_chat",
+      "base_label": "chat_completions_v1",
       "max_context_tokens": 131072,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -88,7 +88,7 @@
     {
       "_comment": "Qwen3.5-Plus — Alibaba DashScope. 1M ctx (CORRECTED — was 128K), 65K output. enable_thinking with 3 budget modes. https://openrouter.ai/qwen/qwen3.5-plus-20260420",
       "id_prefix": "qwen3.5",
-      "base_label": "provider_d_chat",
+      "base_label": "chat_completions_v1",
       "max_context_tokens": 1000000,
       "max_output_tokens": 65536,
       "supports_tools": true,
@@ -102,7 +102,7 @@
     {
       "_comment": "Qwen3.5-35B-A3B — Local llama-server / vLLM. 256K native ctx (CORRECTED — was 128K; extensible to 1M via YaRN). enable_thinking default on. https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
       "id_prefix": "qwen-local-35b-a3b",
-      "base_label": "provider_d_chat",
+      "base_label": "chat_completions_v1",
       "max_context_tokens": 262144,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -112,13 +112,13 @@
     {
       "_comment": "qwen — generic alias, capability 모델 따라 다름. base inherit. downstream qwen3.5 / qwen-local-35b-a3b entries 가 더 정확.",
       "id_prefix": "qwen",
-      "base_label": "provider_d_chat",
+      "base_label": "chat_completions_v1",
       "supports_native_streaming": true
     },
     {
       "_comment": "DeepSeek V4 Pro — 1.6T MoE / 49B active. 1M ctx, 65K output, reasoning_effort 3 modes (incl. Think Max), image input, prompt caching native. https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro",
       "id_prefix": "deepseek-v4-pro",
-      "base_label": "provider_d_chat",
+      "base_label": "chat_completions_v1",
       "max_context_tokens": 1000000,
       "max_output_tokens": 65536,
       "supports_tools": true,
@@ -133,7 +133,7 @@
     {
       "_comment": "DeepSeek V4 Flash — 284B MoE / 13B active. 1M ctx (CORRECTED — was 64K; Flash differentiation is parameters not context). Same 3 effort modes, image input. https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
       "id_prefix": "deepseek-v4-flash",
-      "base_label": "provider_d_chat",
+      "base_label": "chat_completions_v1",
       "max_context_tokens": 1000000,
       "max_output_tokens": 65536,
       "supports_tools": true,

--- a/docs/rfc/RFC-OAS-023-capability-axis-reshape.md
+++ b/docs/rfc/RFC-OAS-023-capability-axis-reshape.md
@@ -15,7 +15,7 @@
 
 OAS capability catalog가 두 가지 동시 결함을 가지고 있다.
 
-1. **표기 결함** — RFC-0001 후 brand가 알파벳 부호로 1:1 치환되었다 (`Anthropic → Provider_a`, `Kimi → Provider_c`, `OpenAI_compat → Provider_d_compat` 등 14×N). [feedback_vendor_brand_substitution_is_encryption_not_abstraction] 메모리(2026-05-24)의 자기 비판이 그대로 적용된다 — abstraction이 아니라 encryption.
+1. **표기 결함** — RFC-0001 후 brand가 알파벳 부호로 1:1 치환되었다 (`Anthropic → Provider_a`, `Kimi → Provider_c`, `OpenAI_compat → Chat_completions_v1` 등 14×N). [feedback_vendor_brand_substitution_is_encryption_not_abstraction] 메모리(2026-05-24)의 자기 비판이 그대로 적용된다 — abstraction이 아니라 encryption.
 2. **축 결함** — capability의 1차 축은 *model*인데 catalog는 *provider* 부호로 분류되어 있다. 같은 모델(`kimi-k2.6`)이 여러 provider(Moonshot direct / Ollama Turbo cloud / OpenRouter / local quantization)로 갈 수 있고, capability는 `model_caps ∩ transport_caps`의 cross-product에서 결정되는데, 지금 catalog는 두 record를 한 record로 압축하여 *둘 다*를 잃었다.
 
 본 RFC는 두 결함을 동시에 해결한다:
@@ -33,7 +33,7 @@ RFC-0001은 "OAS 가 그쪽이니까 같이 폭파에 동참하자", "전체 폭
 Anthropic       → Provider_a
 Moonshot        → Provider_b
 Kimi            → Provider_c
-OpenAI_compat   → Provider_d_compat
+OpenAI_compat   → Chat_completions_v1
 Gemini          → Provider_f
 DeepSeek        → Provider_g
 DashScope       → Provider_h
@@ -52,9 +52,9 @@ Codex_cli       → Cli_tool_a
 
 증상:
 
-- 새 maintainer가 `base = "provider_d_chat"` manifest entry를 적으려면 `capabilities_for_provider_label` 매핑을 *역추적*해야 한다 ("끝말풀이").
+- 새 maintainer가 `base = "chat_completions_v1"` manifest entry를 적으려면 `capabilities_for_provider_label` 매핑을 *역추적*해야 한다 ("끝말풀이").
 - cascade.toml의 model id는 brand 그대로(`kimi-k2.6:cloud`, `deepseek-v4-pro:cloud`)인데 OAS catalog만 부호 — 양쪽이 만나는 모든 경계에서 매핑 테이블이 필요해진다.
-- 부호의 *의미*는 코드 어디에도 명시되어 있지 않다 (`provider_d_chat`이 OpenAI chat completions wire를 가리킨다는 사실은 `backend_openai.ml` 파일명을 봐야 추정 가능).
+- 부호의 *의미*는 코드 어디에도 명시되어 있지 않다 (`chat_completions_v1`이 OpenAI chat completions wire를 가리킨다는 사실은 `backend_openai.ml` 파일명을 봐야 추정 가능).
 
 ### 1.2 Axis confusion — capability의 1차축이 model
 
@@ -67,10 +67,10 @@ Codex_cli       → Cli_tool_a
   ...
   (match Llm_provider.Capabilities.for_model_id model_id with
    | Some caps -> caps
-   | None -> default_provider_d_compat_capabilities model_id)  (* ← silent default *)
+   | None -> default_chat_completions_v1_capabilities model_id)  (* ← silent default *)
 ```
 
-증상: 카탈로그에 없는 모델이 `provider_d_chat_capabilities` (reasoning=false)로 fallback → 실제 응답에 thinking block이 있어 `Thinking_returned_but_declared_unsupported` drift WARN. 이는 *catalog miss*를 *capability 사실*로 silent하게 변환한 결과.
+증상: 카탈로그에 없는 모델이 `chat_completions_v1_capabilities` (reasoning=false)로 fallback → 실제 응답에 thinking block이 있어 `Thinking_returned_but_declared_unsupported` drift WARN. 이는 *catalog miss*를 *capability 사실*로 silent하게 변환한 결과.
 
 ### 1.3 Cross-product collapse — model × transport
 
@@ -90,7 +90,7 @@ kimi-k2.6  →  Moonshot direct           (chat_completions_v1)
 - Local quantization: max_context_tokens가 quantization config에 의해 잘림
 - Moonshot direct: 모든 모델 capability 운반 가능 (canonical)
 
-지금 catalog는 이 cross-product를 *한 record로 압축*하고 있다 — `provider_d_chat_capabilities`는 "OpenAI 호환 chat completions wire를 통과한 어떤 가상 모델의 보수적 caps"라는 chimera. model도 transport도 아닌 중간 존재.
+지금 catalog는 이 cross-product를 *한 record로 압축*하고 있다 — `chat_completions_v1_capabilities`는 "OpenAI 호환 chat completions wire를 통과한 어떤 가상 모델의 보수적 caps"라는 chimera. model도 transport도 아닌 중간 존재.
 
 증상:
 
@@ -178,7 +178,7 @@ val effective_caps : model_id:string -> provider:provider -> capabilities
 
 ### 3.2 Unknown model 정책 — fail closed
 
-`provider.ml:296`의 silent default fallback (`default_provider_d_compat_capabilities`)을 폐지한다. catalog miss는:
+`provider.ml:296`의 silent default fallback (`default_chat_completions_v1_capabilities`)을 폐지한다. catalog miss는:
 
 - (a) RFC-OAS-018에서 도입한 manifest layer로 *재시도* (operator escape hatch),
 - (b) 그래도 miss면 `Capability_unknown { model_id }` 에러를 *큰소리로* 호출자에 전달.
@@ -187,8 +187,8 @@ val effective_caps : model_id:string -> provider:provider -> capabilities
 
 **제거 비용 정량 (Decision #5, 2026-05-26)**:
 
-- `default_provider_d_compat_capabilities` callers in `test/`: **3 파일 (7 사이트)** (test_capabilities × 1, test_capabilities_wiring × 1, test_llm_provider_cov × 5)
-- Lock 패턴: `rg "expect.*provider_d_chat|Alcotest.check.*default" test/` → **0 matches**, `rg "let%expect_test" test/` → **0 matches**
+- `default_chat_completions_v1_capabilities` callers in `test/`: **3 파일 (7 사이트)** (test_capabilities × 1, test_capabilities_wiring × 1, test_llm_provider_cov × 5)
+- Lock 패턴: `rg "expect.*chat_completions_v1|Alcotest.check.*default" test/` → **0 matches**, `rg "let%expect_test" test/` → **0 matches**
 - [feedback_tests_locking_anti_pattern_behavior] 의 lock 패턴이 OAS test/ 에 *부재*
 
 → Decision #5 hard error 전환 비용 *예상보다 낮음*. 73 callsite migration 이 *값 expectation 깨짐 없이* 안전.
@@ -218,7 +218,7 @@ val model_family_default_caps : Model_family.t -> model_caps
 
 **실 외부 caller: 3 사이트**. 폐지 비용 *낮음*.
 
-silent default (`default_provider_d_compat_capabilities`) 의 의존도는 *별개 큰 비용*: lib/ 60 callsite + test/ 73 callsite = **133 사이트** (Decision #5 §3.2 측정). 두 Decision (#3 함수 폐지 + #5 silent default 제거) 가 *분리 가능*.
+silent default (`default_chat_completions_v1_capabilities`) 의 의존도는 *별개 큰 비용*: lib/ 60 callsite + test/ 73 callsite = **133 사이트** (Decision #5 §3.2 측정). 두 Decision (#3 함수 폐지 + #5 silent default 제거) 가 *분리 가능*.
 
 > **[DECISION NEEDED #3 — RESOLVED (권고)]** 옵션 (a) **`capabilities_for_provider_label` 완전 폐지** 권고 (외부 caller 3 사이트 migration).
 
@@ -235,7 +235,7 @@ silent default (`default_provider_d_compat_capabilities`) 의 의존도는 *별�
 핵심 관찰:
 
 1. **Cache control 은 Anthropic 만 운반** — 다른 모든 wire 에서 0 사이트.
-2. **`chat_completions_v1` 의 thinking_control_format 이 비대칭 복잡** (39 사이트) — 단일 wire 가 여러 thinking 변형 (Kimi K2.5, Qwen `enable_thinking`, OpenAI `reasoning_effort`) 동시 처리. `provider_d_chat_extended_capabilities` 가 별도 존재한 *이유* 이자 axis confusion 의 가장 선명한 증거.
+2. **`chat_completions_v1` 의 thinking_control_format 이 비대칭 복잡** (39 사이트) — 단일 wire 가 여러 thinking 변형 (Kimi K2.5, Qwen `enable_thinking`, OpenAI `reasoning_effort`) 동시 처리. `chat_completions_v1_extended_capabilities` 가 별도 존재한 *이유* 이자 axis confusion 의 가장 선명한 증거.
 
 `transport_caps` record schema 1차 안:
 
@@ -268,8 +268,8 @@ type transport_caps = {
 | `Provider_a` | `Anthropic` | model brand |
 | `Provider_b` | `Moonshot` | model brand |
 | `Provider_c` | `Kimi` | model brand |
-| `Provider_d` | `OpenAI` | model brand |
-| `Provider_d_compat` | `Chat_completions_v1` | **wire protocol** (OpenAI-호환 wire를 의미하므로) |
+| `Chat_completions_v1` | `OpenAI` | model brand |
+| `Chat_completions_v1` | `Chat_completions_v1` | **wire protocol** (OpenAI-호환 wire를 의미하므로) |
 | `Provider_f` | `Gemini` | model brand |
 | `Provider_g` | `DeepSeek` | model brand |
 | `Provider_h` | `DashScope` | model brand |
@@ -281,20 +281,20 @@ type transport_caps = {
 | `Cli_tool_c` | `Kimi_cli` | tool brand |
 | `Cli_tool_d` | `Claude_code_cli` | tool brand |
 
-핵심 관찰: `Provider_d_compat`만 wire-protocol로 가는 이유 — 이 variant는 brand가 아니라 *protocol*을 의미했다 (Ollama, OpenRouter, llama-server, vLLM 모두 같은 chat completions wire를 구현). 나머지는 brand 그대로 복원.
+핵심 관찰: `Chat_completions_v1`만 wire-protocol로 가는 이유 — 이 variant는 brand가 아니라 *protocol*을 의미했다 (Ollama, OpenRouter, llama-server, vLLM 모두 같은 chat completions wire를 구현). 나머지는 brand 그대로 복원.
 
 ### 4.2 함수/타입 명명 sweep
 
 ```
 provider_a_capabilities             → anthropic_model_caps
-provider_d_chat_capabilities        → chat_completions_v1_transport_caps + openai_model_default_caps (분리)
-provider_d_chat_extended_capabilities → 폐지 (Provider_h가 wire가 아니라 model이므로 model_caps에 흡수)
+chat_completions_v1_capabilities        → chat_completions_v1_transport_caps + openai_model_default_caps (분리)
+chat_completions_v1_extended_capabilities → 폐지 (Provider_h가 wire가 아니라 model이므로 model_caps에 흡수)
 provider_c_capabilities             → kimi_model_default_caps
 provider_k_capabilities             → glm_model_default_caps
 ...
 ```
 
-`provider_d_chat_extended_capabilities`의 사례가 axis confusion의 가장 선명한 증거 — "OpenAI 호환 wire의 *Qwen-3 확장*"이라는 명명 자체가 두 축을 한 record로 압축했다는 자기 진술.
+`chat_completions_v1_extended_capabilities`의 사례가 axis confusion의 가장 선명한 증거 — "OpenAI 호환 wire의 *Qwen-3 확장*"이라는 명명 자체가 두 축을 한 record로 압축했다는 자기 진술.
 
 ### 4.3 함수/타입 명명 sweep (full mapping table)
 
@@ -315,18 +315,18 @@ provider_k_capabilities             → glm_model_default_caps
 
 | RFC-0001 | RFC-OAS-023 |
 |---|---|
-| `provider_d_chat_capabilities` | `chat_completions_v1_transport_caps` + `openai_model_caps` (분리) |
-| `provider_d_chat_extended_capabilities` | **폐지** — Qwen-3 부분은 `qwen_3_model_caps` 흡수 |
+| `chat_completions_v1_capabilities` | `chat_completions_v1_transport_caps` + `openai_model_caps` (분리) |
+| `chat_completions_v1_extended_capabilities` | **폐지** — Qwen-3 부분은 `qwen_3_model_caps` 흡수 |
 
 **파일명 rename**:
 
 | RFC-0001 | RFC-OAS-023 |
 |---|---|
 | `backend_provider_a.ml/.mli` | `backend_messages_v1.ml/.mli` |
-| `backend_provider_d.ml + _parse/_request/_serialize` | `backend_chat_completions_v1.ml + ...` |
+| `backend_chat_completions_v1.ml + _parse/_request/_serialize` | `backend_chat_completions_v1.ml + ...` |
 | `backend_provider_f.ml` | `backend_gemini_generate_v1.ml` |
 | `backend_provider_k.ml` | `backend_glm_native_v1.ml` |
-| `transport_provider_d_compat.ml` | `transport_chat_completions_v1_http.ml` |
+| `transport_chat_completions_v1_http.ml` | `transport_chat_completions_v1_http.ml` |
 | `transport_cli_tool_[abcd].ml` | `transport_codex_cli.ml` / `_gemini_cli.ml` / `_kimi_cli.ml` / `_claude_code_cli.ml` |
 | `api_provider_a.ml/.mli` | `api_anthropic.ml/.mli` |
 
@@ -348,8 +348,8 @@ provider_k_capabilities             → glm_model_default_caps
 
 | api-name (wire에 흐르는 그대로) | Brand | RFC-0001 cipher | OAS prefix가 기대하는 형태 | Match |
 |---|---|---|---|---|
-| `gpt-5.3-codex-spark` | OpenAI | Provider_d | `model-d-5*` | **MISS** |
-| `gpt-4.1` | OpenAI | Provider_d | `model-d-4.1*` | **MISS** |
+| `gpt-5.3-codex-spark` | OpenAI | Chat_completions_v1 | `model-d-5*` | **MISS** |
+| `gpt-4.1` | OpenAI | Chat_completions_v1 | `model-d-4.1*` | **MISS** |
 | `glm-5.1` | GLM | Provider_k | (no `provider_k-*` prefix) | **MISS** |
 | `glm-5-turbo` | GLM | Provider_k | — | **MISS** |
 | `glm-5` | GLM | Provider_k | — | **MISS** |
@@ -367,7 +367,7 @@ provider_k_capabilities             → glm_model_default_caps
 해석:
 
 - RFC-0001 이 *source-level brand* 는 cipher 로 바꿨지만, *wire 에 들어오는 model_id 문자열* 은 brand 그대로다. cascade 가 `kimi-k2.6:cloud` 를 그대로 흘리는데 OAS catalog 의 prefix table 은 `provider_c-k2*` 를 기대 — 100% miss.
-- 결과적으로 cascade.toml 의 모든 모델이 `default_provider_d_compat_capabilities` (≡ `provider_d_chat_capabilities`, reasoning=false) 보수적 default 로 fallback 중. 즉 cascade.toml 의 `[models.X.capabilities]` 블록에 사용자가 *명시적으로 적은* capability 선언이 OAS 가 보는 effective_caps 와 *전혀 일치하지 않는다*.
+- 결과적으로 cascade.toml 의 모든 모델이 `default_chat_completions_v1_capabilities` (≡ `chat_completions_v1_capabilities`, reasoning=false) 보수적 default 로 fallback 중. 즉 cascade.toml 의 `[models.X.capabilities]` 블록에 사용자가 *명시적으로 적은* capability 선언이 OAS 가 보는 effective_caps 와 *전혀 일치하지 않는다*.
 - drift WARN (`Thinking_returned_but_declared_unsupported`, `Tools_used_but_declared_unsupported` 등) 이 *전체 cascade 모델* 에서 발생 가능 상태. kimi-k2.6 만 본 것이 아니라 *시스템 전체* 가 catalog miss 영역에 있다.
 
 평면 불일치 문제로서의 함의:
@@ -380,7 +380,7 @@ provider_k_capabilities             → glm_model_default_caps
 
 ```
 [2026-05-26 16:42:27] [llm_provider] [INFO] capability_observation
-    model=kimi-k2.6:cloud provider=provider_d_compat
+    model=kimi-k2.6:cloud provider=chat_completions_v1
     capability_source=provider_default confidence=low
     observations=[Thinking_returned_but_declared_unsupported]
 [2026-05-26 16:42:58] [llm_provider] [INFO] capability_observation
@@ -542,7 +542,7 @@ OAS 외부 codebase 에서 vendor sweep 진행 후 발생한 사고 (`gh pr list
 |---|---|---|
 | **Facade 반복 declare** | `provider_kind.ml/.mli` + `provider_config.ml/.mli` 모두 *type 을 재선언* | §6.2 audit #3 (`include Module` / re-export) 의 *실증*. dead-export 안전망 *반드시* 의무 |
 | **`Provider_a` reference 분포** | `lib/` 55+ 파일 (single variant 만) | §6.1 의 1159 callsite / 138 file 의 *실측 근거* (cipher 당 평균 ~83) |
-| **파일명 cipher 침투** | `backend_provider_a.ml/.mli`, `api_provider_a.ml/.mli`, `transport_provider_d_compat.ml` 등 ~12 파일 | Sweep 가 *파일 시스템 rename* 까지 own. 정적 grep 만으로는 *filename cipher* 못 잡음 |
+| **파일명 cipher 침투** | `backend_provider_a.ml/.mli`, `api_provider_a.ml/.mli`, `transport_chat_completions_v1_http.ml` 등 ~12 파일 | Sweep 가 *파일 시스템 rename* 까지 own. 정적 grep 만으로는 *filename cipher* 못 잡음 |
 | **dune first-error halt** | 1 변경 → 1 error 만 보고 | `--keep-going` 또는 fix-and-retry loop 필수 (§6.3) |
 
 **Sweep 패턴 권고** (Phase 1 본격 작업):
@@ -591,7 +591,7 @@ RFC-OAS-023 stack merge (this RFC)
 **RFC-OAS-018 schema 영향**:
 
 - `id_prefix` (capability_manifest schema) 를 *brand model_id* 기반으로 사용 (`"kimi-k2.6"`, `"claude-opus-4"`). cipher prefix 폐기.
-- `base` label 은 `Wire_protocol.t` 또는 `Model_family.t` — `provider_d_chat` 같은 chimera 부호 폐지.
+- `base` label 은 `Wire_protocol.t` 또는 `Model_family.t` — `chat_completions_v1` 같은 chimera 부호 폐지.
 - JSON manifest entry 의 *transport-bound 필드* 와 *model-bound 필드* 분리 (§3.4 정합).
 
 **가속 효과**: §5.2 의 +91% literal leak 가 RFC-OAS-018 진입 직전까지 자가 가속. Phase 1-5 sweep 이 catalog 데이터를 *brand 평면* 으로 정착시켜 RFC-OAS-018 시점 anchor 정확. 두 RFC 합쳐서 leak 곡선 *반전*.

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -479,7 +479,7 @@ let run_stream ~sw ?clock ~on_event ?on_yield ?on_resume agent user_prompt =
   let on_activity () = last_activity := now_or_zero clock in
   (* Every streamed event — including reasoning/thinking deltas, which
      reach [on_event] as [ContentBlockDelta { delta = ThinkingDelta _ }]
-     (see Llm_provider.Streaming.provider_d_chunk_to_events) — counts as
+     (see Llm_provider.Streaming.chat_completions_v1_chunk_to_events) — counts as
      progress, so a long reasoning burst keeps the idle watchdog from
      firing. [caller_on_event] is the original callback (bound under a
      distinct name so the wrapper is not misread as self-recursion); it

--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -26,8 +26,8 @@
       }
     ]}
 
-    Provider values: "local" (llama-server), "provider_a", "provider_d",
-    or any string (treated as Provider_d-compatible with api_key_env = that string).
+    Provider values: "local" (llama-server), "provider_a", "chat_completions_v1",
+    or any string (treated as Chat_completions_v1-compatible with api_key_env = that string).
 *)
 
 open Result_syntax
@@ -301,7 +301,7 @@ let load path =
     through {!Llm_provider.Provider_kind.of_string}, which accepts the
     canonical wire forms (["provider_a"], ["openai_compat"], …) plus the
     documented aliases (["agent_llm_a"] -> Anthropic,
-    ["provider_d"] -> OpenAI_compat, ["provider_n"] -> Ollama), case-insensitively
+    ["chat_completions_v1"] -> OpenAI_compat, ["provider_n"] -> Ollama), case-insensitively
     with leading/trailing whitespace trimmed.
 
     ["local"] remains a first-class routing shorthand (not a Provider_kind
@@ -331,7 +331,7 @@ let resolve_provider ~model_id provider_str base_url =
       let url =
         match base_url with
         | Some u -> u
-        | None -> "https://api.provider_d.com"
+        | None -> "https://api.chat-completions-v1.example"
       in
       { Provider.provider = openai_compat_config ~base_url:url ~api_key_env ()
       ; model_id

--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -86,6 +86,14 @@ let openai_compat_config ~base_url ~api_key_env ?(path = "/v1/chat/completions")
     }
 ;;
 
+let provider_kind_of_config_string raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "provider_a" | "agent_llm_a" -> Some Llm_provider.Provider_kind.Anthropic
+  | "chat_completions_v1" -> Some Llm_provider.Provider_kind.OpenAI_compat
+  | "provider_n" -> Some Llm_provider.Provider_kind.Ollama
+  | normalized -> Llm_provider.Provider_kind.of_string normalized
+;;
+
 (* ── Tool config ─────────────────────────────────────────── *)
 
 type tool_file_config =
@@ -298,11 +306,13 @@ let load path =
 (** Resolve provider string + optional base_url to a Provider.config.
 
     Canonical provider kinds ({!Llm_provider.Provider_kind.t}) are dispatched
-    through {!Llm_provider.Provider_kind.of_string}, which accepts the
-    canonical wire forms (["provider_a"], ["openai_compat"], …) plus the
-    documented aliases (["agent_llm_a"] -> Anthropic,
-    ["chat_completions_v1"] -> OpenAI_compat, ["provider_n"] -> Ollama), case-insensitively
-    with leading/trailing whitespace trimmed.
+    through [provider_kind_of_config_string]. It accepts canonical kind strings
+    (for example ["anthropic"], ["openai_compat"], and ["ollama"]) plus legacy
+    configuration aliases (["provider_a"] / ["agent_llm_a"] -> Anthropic,
+    ["chat_completions_v1"] -> OpenAI_compat, ["provider_n"] -> Ollama),
+    case-insensitively with leading/trailing whitespace trimmed.
+    Catalog-provided names are resolved by the registry lookup below after the
+    kind parser misses.
 
     ["local"] remains a first-class routing shorthand (not a Provider_kind
     variant) and is matched explicitly before the parser so that
@@ -323,7 +333,7 @@ let resolve_provider ~model_id provider_str base_url =
     in
     { Provider.provider = Local { base_url = url }; model_id; api_key_env = "" })
   else (
-    match Llm_provider.Provider_kind.of_string provider_str with
+    match provider_kind_of_config_string provider_str with
     | Some Anthropic ->
       { Provider.provider = Anthropic; model_id; api_key_env = "PROVIDER_A_API_KEY" }
     | Some OpenAI_compat ->

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -47,7 +47,7 @@ type options =
         Threaded through {!Pipeline.stage_route} into
         {!Llm_provider.Complete.complete_stream}, which forwards it to
         {!Llm_provider.Http_client.read_ndjson} (Ollama native NDJSON)
-        and {!Llm_provider.Http_client.read_sse} (Anthropic / Provider_d-
+        and {!Llm_provider.Http_client.read_sse} (Anthropic / Chat_completions_v1-
         compatible / Gemini / Glm). The deadline resets after each
         successful line, so this caps inter-chunk silence — not total
         stream duration. A stalled endpoint surfaces as
@@ -162,7 +162,7 @@ type options =
         @since 0.102.0 *)
   ; slot_id : int option
     (** Pin LLM requests to a specific llama-server slot for KV cache reuse.
-        When [Some n], adds ["id_slot": n] to Provider_d-compat request body.
+        When [Some n], adds ["id_slot": n] to Chat_completions_v1-compat request body.
         @since 0.109.0 *)
   ; on_run_complete : (bool -> unit) option
     (** Optional callback invoked when a run finishes.  Receives [true]

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -132,7 +132,7 @@ val with_event_bus : Event_bus.t -> t -> t
 val with_max_execution_time : float -> t -> t
 
 (** Set the per-line idle deadline applied to streaming HTTP responses
-    (Ollama NDJSON, Anthropic / Provider_d / Gemini / Glm SSE). Resets after
+    (Ollama NDJSON, Anthropic / Chat_completions_v1 / Gemini / Glm SSE). Resets after
     each successful line, so this caps inter-chunk silence — not total
     stream duration. A stalled endpoint surfaces as
     [TimeoutError { phase = Stream_idle state; _ }], preserving whether
@@ -141,7 +141,7 @@ val with_max_execution_time : float -> t -> t
 val with_stream_idle_timeout : float -> t -> t
 
 (** Set the per-line idle deadline applied to streaming HTTP responses
-    (Ollama NDJSON, Anthropic / Provider_d / Gemini / Glm SSE). Resets after
+    (Ollama NDJSON, Anthropic / Chat_completions_v1 / Gemini / Glm SSE). Resets after
     each successful line, so this caps inter-chunk silence — not total
     stream duration. A stalled endpoint surfaces as
     [TimeoutError { phase = Stream_idle state; _ }], preserving whether

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -41,13 +41,21 @@ let build_body_assoc ~config ~messages ?tools ~stream () =
   Api_provider_a.build_body_assoc ~config ~messages ?tools ~stream ()
 ;;
 
-(* Re-export Api_provider_d *)
-let provider_d_messages_of_message = Api_provider_d.provider_d_messages_of_message
-let provider_d_content_parts_of_blocks = Api_provider_d.provider_d_content_parts_of_blocks
-let build_provider_d_body = Api_provider_d.build_provider_d_body
+(* Re-export Api_chat_completions_v1 *)
+let chat_completions_v1_messages_of_message =
+  Api_chat_completions_v1.chat_completions_v1_messages_of_message
+;;
 
-let parse_provider_d_response_result =
-  Llm_provider.Backend_provider_d_parse.parse_provider_d_response_result
+let chat_completions_v1_content_parts_of_blocks =
+  Api_chat_completions_v1.chat_completions_v1_content_parts_of_blocks
+;;
+
+let build_chat_completions_v1_body =
+  Api_chat_completions_v1.build_chat_completions_v1_body
+;;
+
+let parse_chat_completions_v1_response_result =
+  Llm_provider.Backend_chat_completions_v1_parse.parse_chat_completions_v1_response_result
 ;;
 
 (* Wall-clock latency patch. Parser layers leave request_latency_ms unknown
@@ -140,7 +148,7 @@ let create_message
         Yojson.Safe.to_string
           (`Assoc (build_body_assoc ~config ~messages ?tools ~stream:false ()))
       | Provider.Openai_chat_completions ->
-        Api_provider_d.build_provider_d_body
+        Api_chat_completions_v1.build_chat_completions_v1_body
           ~provider_config:provider_cfg
           ~config
           ~messages
@@ -201,7 +209,7 @@ let create_message
                 |> Llm_provider.Pricing.annotate_response_cost
                 |> fun r -> patch_latency r lat)
            | Provider.Openai_chat_completions ->
-             (match parse_provider_d_response_result body_str with
+             (match parse_chat_completions_v1_response_result body_str with
               | Ok resp ->
                 Ok
                   (Llm_provider.Pricing.annotate_response_cost resp
@@ -215,7 +223,7 @@ let create_message
                    |> Llm_provider.Pricing.annotate_response_cost
                    |> fun r -> patch_latency r lat)
               | None ->
-                (match parse_provider_d_response_result body_str with
+                (match parse_chat_completions_v1_response_result body_str with
                  | Ok resp ->
                    Ok
                      (Llm_provider.Pricing.annotate_response_cost resp

--- a/lib/api.mli
+++ b/lib/api.mli
@@ -36,14 +36,17 @@ val build_body_assoc
   -> unit
   -> (string * Yojson.Safe.t) list
 
-(** {1 Re-exports from Api_provider_d} *)
+(** {1 Re-exports from Api_chat_completions_v1} *)
 
-val provider_d_messages_of_message : Types.message -> Yojson.Safe.t list
-val provider_d_content_parts_of_blocks : Types.content_block list -> Yojson.Safe.t list
+val chat_completions_v1_messages_of_message : Types.message -> Yojson.Safe.t list
 
-(** Parse an Provider_d-compatible JSON response.
+val chat_completions_v1_content_parts_of_blocks
+  :  Types.content_block list
+  -> Yojson.Safe.t list
+
+(** Parse an Chat_completions_v1-compatible JSON response.
     Returns [Ok api_response] on success, [Error msg] on API error. *)
-val build_provider_d_body
+val build_chat_completions_v1_body
   :  ?provider_config:Provider.config
   -> config:Types.agent_state
   -> messages:Types.message list
@@ -52,9 +55,11 @@ val build_provider_d_body
   -> unit
   -> string
 
-(** Parse an Provider_d-compatible JSON response.
+(** Parse an Chat_completions_v1-compatible JSON response.
     Returns [Ok api_response] on success, [Error msg] on API error. *)
-val parse_provider_d_response_result : string -> (Types.api_response, string) result
+val parse_chat_completions_v1_response_result
+  :  string
+  -> (Types.api_response, string) result
 
 (** {1 Non-streaming request} *)
 

--- a/lib/api_chat_completions_v1.ml
+++ b/lib/api_chat_completions_v1.ml
@@ -1,12 +1,12 @@
-(** Provider_d-compatible API request building and response parsing.
+(** Chat_completions_v1-compatible API request building and response parsing.
 
-    Pure serialization/parsing is delegated to {!Llm_provider.Backend_provider_d}.
+    Pure serialization/parsing is delegated to {!Llm_provider.Backend_chat_completions_v1}.
     Request building remains here due to agent_config/agent_state/Provider coupling. *)
 
 open Types
 
 (* Re-export pure functions from llm_provider *)
-include Llm_provider.Backend_provider_d
+include Llm_provider.Backend_chat_completions_v1
 
 let system_message_json (config : agent_state) : Yojson.Safe.t list =
   match config.config.system_prompt with
@@ -64,11 +64,11 @@ let effective_tool_choice_json
   match config.config.tool_choice with
   | Some Types.None_ when is_glm -> None
   | Some (Types.Auto | Types.Any | Types.Tool _) when is_glm ->
-    Some (tool_choice_to_provider_d_json Types.Auto)
+    Some (tool_choice_to_chat_completions_v1_json Types.Auto)
   | Some Types.Auto when capabilities.supports_tool_choice ->
-    Some (tool_choice_to_provider_d_json Types.Auto)
+    Some (tool_choice_to_chat_completions_v1_json Types.Auto)
   | Some choice when capabilities.supports_tool_choice ->
-    Some (tool_choice_to_provider_d_json choice)
+    Some (tool_choice_to_chat_completions_v1_json choice)
   | _ -> None
 ;;
 
@@ -78,15 +78,16 @@ let should_include_tools ?provider_config (config : agent_state) =
   | _ -> true
 ;;
 
-let build_provider_d_body ?provider_config ~config ~messages ?tools ?slot_id () =
+let build_chat_completions_v1_body ?provider_config ~config ~messages ?tools ?slot_id () =
   let model_str = model_to_string config.config.model in
   let capabilities = capabilities_for_request ?provider_config config in
   let sanitized_messages = strip_orphaned_tool_results messages in
   let provider_messages =
     let message_serializer =
       if is_glm_request ?provider_config config
-      then Llm_provider.Backend_provider_d_serialize.provider_k_messages_of_message
-      else provider_d_messages_of_message
+      then
+        Llm_provider.Backend_chat_completions_v1_serialize.provider_k_messages_of_message
+      else chat_completions_v1_messages_of_message
     in
     system_message_json config @ List.concat_map message_serializer sanitized_messages
   in
@@ -111,7 +112,7 @@ let build_provider_d_body ?provider_config ~config ~messages ?tools ?slot_id () 
     | Some top_k when capabilities.supports_top_k -> ("top_k", `Int top_k) :: body_assoc
     | None -> body_assoc
     | Some _ ->
-      Llm_provider.Backend_provider_d.warn_capability_drop
+      Llm_provider.Backend_chat_completions_v1.warn_capability_drop
         ~model_id:model_str
         ~field:"top_k";
       body_assoc
@@ -121,7 +122,7 @@ let build_provider_d_body ?provider_config ~config ~messages ?tools ?slot_id () 
     | Some min_p when capabilities.supports_min_p -> ("min_p", `Float min_p) :: body_assoc
     | None -> body_assoc
     | Some _ ->
-      Llm_provider.Backend_provider_d.warn_capability_drop
+      Llm_provider.Backend_chat_completions_v1.warn_capability_drop
         ~model_id:model_str
         ~field:"min_p";
       body_assoc
@@ -183,7 +184,8 @@ let build_provider_d_body ?provider_config ~config ~messages ?tools ?slot_id () 
       when entries <> []
            && capabilities.supports_tools
            && should_include_tools ?provider_config config ->
-      ("tools", `List (List.map build_provider_d_tool_json entries)) :: body_assoc
+      ("tools", `List (List.map build_chat_completions_v1_tool_json entries))
+      :: body_assoc
     | _ -> body_assoc
   in
   let body_assoc =
@@ -199,11 +201,13 @@ let build_provider_d_body ?provider_config ~config ~messages ?tools ?slot_id () 
   let body_assoc =
     match config.config.response_format with
     | JsonMode when capabilities.supports_response_format_json ->
-      (match response_format_to_provider_d_json JsonMode with
+      (match response_format_to_chat_completions_v1_json JsonMode with
        | Some response_format -> ("response_format", response_format) :: body_assoc
        | None -> body_assoc)
     | JsonSchema _ when capabilities.supports_structured_output ->
-      (match response_format_to_provider_d_json config.config.response_format with
+      (match
+         response_format_to_chat_completions_v1_json config.config.response_format
+       with
        | Some response_format -> ("response_format", response_format) :: body_assoc
        | None -> body_assoc)
     | JsonSchema _ | JsonMode | Off -> body_assoc

--- a/lib/api_chat_completions_v1.mli
+++ b/lib/api_chat_completions_v1.mli
@@ -1,16 +1,16 @@
 (** OpenAI-compatible API request building and response parsing.
 
-    Includes re-exports from {!Llm_provider.Backend_provider_d}.
+    Includes re-exports from {!Llm_provider.Backend_chat_completions_v1}.
 
     @stability Internal
     @since 0.93.1 *)
 
-include module type of Llm_provider.Backend_provider_d
+include module type of Llm_provider.Backend_chat_completions_v1
 
 (** Build OpenAI-compatible request body JSON string.
     Respects provider capabilities for tool_choice, top_k, min_p,
     reasoning, and response_format. *)
-val build_provider_d_body
+val build_chat_completions_v1_body
   :  ?provider_config:Provider.config
   -> config:Types.agent_state
   -> messages:Types.message list

--- a/lib/base/types.ml
+++ b/lib/base/types.ml
@@ -103,7 +103,7 @@ type agent_config =
   ; thinking_budget : int option (* For Agent_llm_a 3.7+ extended thinking *)
   ; tool_choice : tool_choice option
   ; disable_parallel_tool_use : bool
-    (* Anthropic: tool_choice.disable_parallel_tool_use, Provider_d: parallel_tool_calls=false *)
+    (* Anthropic: tool_choice.disable_parallel_tool_use, Chat_completions_v1: parallel_tool_calls=false *)
   ; cache_system_prompt : bool (* Wrap system prompt with cache_control ephemeral *)
   ; cache_extended_ttl : bool (* true=1h TTL (2x write cost), false=5min default *)
   ; max_input_tokens : int option (* Token budget: max cumulative input tokens *)

--- a/lib/content_replacement_state.mli
+++ b/lib/content_replacement_state.mli
@@ -13,7 +13,7 @@
     it will always return [true] regardless of subsequent operations.
 
     This preserves prompt cache prefixes across turns for all providers
-    (Anthropic, Provider_d, Ollama 0.5+).
+    (Anthropic, Chat_completions_v1, Ollama 0.5+).
 
     @stability Evolving
     @since 0.128.0 *)

--- a/lib/context_reducer.mli
+++ b/lib/context_reducer.mli
@@ -134,7 +134,7 @@ val prune_tool_args : max_arg_len:int -> ?keep_recent:int -> unit -> t
 val repair_dangling_tool_calls : t
 
 (** Remove ToolResult blocks whose tool_use_id has no matching ToolUse.
-    Provider_d-compatible APIs (Glm, Provider_i, etc.) reject orphaned ToolResults.
+    Chat_completions_v1-compatible APIs (Glm, Provider_i, etc.) reject orphaned ToolResults.
     Complement of [repair_dangling_tool_calls].
     @since 0.99.2 *)
 val repair_orphaned_tool_results : t

--- a/lib/event_bus.mli
+++ b/lib/event_bus.mli
@@ -106,14 +106,14 @@ type payload =
       }
   (** Agent-to-agent handoff has been requested. Emitted when an
           agent delegates control to another agent (e.g. via a handoff
-          tool). Mirrors Provider_d Agents SDK [handoff_requested].
+          tool). Mirrors Chat_completions_v1 Agents SDK [handoff_requested].
           @since 0.154.0 *)
   | HandoffCompleted of
       { from_agent : string
       ; to_agent : string
       ; elapsed : float
       }
-  (** Handoff target finished its run. Mirrors Provider_d Agents SDK
+  (** Handoff target finished its run. Mirrors Chat_completions_v1 Agents SDK
           [handoff_occurred].
           @since 0.154.0 *)
   | ElicitationCompleted of
@@ -198,7 +198,7 @@ type payload =
 
           Subscribers should treat absent fields as "backend did not
           report this metric" — never fabricate a value or substitute
-          a default. Ollama reports all five metrics; Provider_d-compatible
+          a default. Ollama reports all five metrics; Chat_completions_v1-compatible
           backends typically report only token counts. *)
   | Custom of string * Yojson.Safe.t
   (** Extension point.  [name] must be a dot-separated, lowercase,
@@ -209,7 +209,7 @@ type payload =
           - [durable.*] — bridged from [Durable_event] journal.
           - [provider.*] — provider-specific escape hatch
             (e.g. [provider.provider_a.cache_hit],
-            [provider.provider_d.reasoning_tokens]).
+            [provider.chat_completions_v1.reasoning_tokens]).
           - [oas.*] — reserved for future OAS use.
 
           External publishers should use their own [Event_bus.t] instance

--- a/lib/llm_provider/backend_chat_completions_v1.ml
+++ b/lib/llm_provider/backend_chat_completions_v1.ml
@@ -1,84 +1,101 @@
-(** Provider_d-compatible API response parsing, message serialization,
+(** Chat_completions_v1-compatible API response parsing, message serialization,
     and request building.
 
     Pure functions operating on {!Llm_provider.Types}.
     {!build_request} uses {!Provider_config.t} (no agent_sdk coupling).
 
-    @since 0.92.0 decomposed into Backend_provider_d_serialize,
-    Backend_provider_d_parse *)
+    @since 0.92.0 decomposed into Backend_chat_completions_v1_serialize,
+    Backend_chat_completions_v1_parse *)
 
 open Types
 
 (* ── Re-exports from serialization ─────────────────────── *)
 
-let tool_calls_to_provider_d_json =
-  Backend_provider_d_serialize.tool_calls_to_provider_d_json
+let tool_calls_to_chat_completions_v1_json =
+  Backend_chat_completions_v1_serialize.tool_calls_to_chat_completions_v1_json
 ;;
 
-let provider_d_content_parts_of_blocks =
-  Backend_provider_d_serialize.provider_d_content_parts_of_blocks
+let chat_completions_v1_content_parts_of_blocks =
+  Backend_chat_completions_v1_serialize.chat_completions_v1_content_parts_of_blocks
 ;;
 
-let provider_d_messages_of_message =
-  Backend_provider_d_serialize.provider_d_messages_of_message
+let chat_completions_v1_messages_of_message =
+  Backend_chat_completions_v1_serialize.chat_completions_v1_messages_of_message
 ;;
 
 let provider_k_messages_of_message =
-  Backend_provider_d_serialize.provider_k_messages_of_message
+  Backend_chat_completions_v1_serialize.provider_k_messages_of_message
 ;;
 
-let tool_choice_to_provider_d_json =
-  Backend_provider_d_serialize.tool_choice_to_provider_d_json
+let tool_choice_to_chat_completions_v1_json =
+  Backend_chat_completions_v1_serialize.tool_choice_to_chat_completions_v1_json
 ;;
 
-let build_provider_d_tool_json = Backend_provider_d_serialize.build_provider_d_tool_json
-let strip_orphaned_tool_results = Backend_provider_d_serialize.strip_orphaned_tool_results
-let strip_thinking_blocks = Backend_provider_d_serialize.strip_thinking_blocks
+let build_chat_completions_v1_tool_json =
+  Backend_chat_completions_v1_serialize.build_chat_completions_v1_tool_json
+;;
+
+let strip_orphaned_tool_results =
+  Backend_chat_completions_v1_serialize.strip_orphaned_tool_results
+;;
+
+let strip_thinking_blocks = Backend_chat_completions_v1_serialize.strip_thinking_blocks
 
 (* ── Re-exports from parsing ──────────────────────────── *)
 
-let strip_json_markdown_fences = Backend_provider_d_parse.strip_json_markdown_fences
-let usage_of_provider_d_json = Backend_provider_d_parse.usage_of_provider_d_json
+let strip_json_markdown_fences =
+  Backend_chat_completions_v1_parse.strip_json_markdown_fences
+;;
 
-let parse_provider_d_response_result =
-  Backend_provider_d_parse.parse_provider_d_response_result
+let usage_of_chat_completions_v1_json =
+  Backend_chat_completions_v1_parse.usage_of_chat_completions_v1_json
+;;
+
+let parse_chat_completions_v1_response_result =
+  Backend_chat_completions_v1_parse.parse_chat_completions_v1_response_result
 ;;
 
 (* ── Re-exports from request building ─────────────────── *)
 
-let warn_capability_drop = Backend_provider_d_request.warn_capability_drop
-let effective_tool_choice = Backend_provider_d_request.effective_tool_choice
-let effective_tools = Backend_provider_d_request.effective_tools
-let structured_schema_of_config = Backend_provider_d_request.structured_schema_of_config
+let warn_capability_drop = Backend_chat_completions_v1_request.warn_capability_drop
+let effective_tool_choice = Backend_chat_completions_v1_request.effective_tool_choice
+let effective_tools = Backend_chat_completions_v1_request.effective_tools
 
-let provider_d_json_schema_payload =
-  Backend_provider_d_request.provider_d_json_schema_payload
+let structured_schema_of_config =
+  Backend_chat_completions_v1_request.structured_schema_of_config
 ;;
 
-let response_format_to_provider_d_json =
-  Backend_provider_d_request.response_format_to_provider_d_json
+let chat_completions_v1_json_schema_payload =
+  Backend_chat_completions_v1_request.chat_completions_v1_json_schema_payload
 ;;
 
-let response_format_of_config = Backend_provider_d_request.response_format_of_config
-let build_request = Backend_provider_d_request.build_request
+let response_format_to_chat_completions_v1_json =
+  Backend_chat_completions_v1_request.response_format_to_chat_completions_v1_json
+;;
+
+let response_format_of_config =
+  Backend_chat_completions_v1_request.response_format_of_config
+;;
+
+let build_request = Backend_chat_completions_v1_request.build_request
 
 [@@@coverage off]
 (* === Inline tests === *)
 
-let%test "tool_choice_to_provider_d_json Auto" =
-  tool_choice_to_provider_d_json Auto = `String "auto"
+let%test "tool_choice_to_chat_completions_v1_json Auto" =
+  tool_choice_to_chat_completions_v1_json Auto = `String "auto"
 ;;
 
-let%test "tool_choice_to_provider_d_json Any" =
-  tool_choice_to_provider_d_json Any = `String "required"
+let%test "tool_choice_to_chat_completions_v1_json Any" =
+  tool_choice_to_chat_completions_v1_json Any = `String "required"
 ;;
 
-let%test "tool_choice_to_provider_d_json None_" =
-  tool_choice_to_provider_d_json None_ = `String "none"
+let%test "tool_choice_to_chat_completions_v1_json None_" =
+  tool_choice_to_chat_completions_v1_json None_ = `String "none"
 ;;
 
-let%test "tool_choice_to_provider_d_json Tool name" =
-  let result = tool_choice_to_provider_d_json (Tool "my_tool") in
+let%test "tool_choice_to_chat_completions_v1_json Tool name" =
+  let result = tool_choice_to_chat_completions_v1_json (Tool "my_tool") in
   let open Yojson.Safe.Util in
   result |> member "type" |> to_string = "function"
   && result |> member "function" |> member "name" |> to_string = "my_tool"
@@ -155,7 +172,7 @@ let%test "provider_k drops tools when tool_choice none" =
 let%test "provider_k drops min_p when model does not support it" =
   (* Glm's glm_capabilities inherits supports_min_p = false from
      default_capabilities.  Even when the caller sets min_p explicitly
-     (via higher-level config inheritance or agent default), backend_provider_d must
+     (via higher-level config inheritance or agent default), backend_chat_completions_v1 must
      omit it from the wire body — ZAI rejects the request with
      "property 'min_p' is unsupported". *)
   let cfg =
@@ -222,30 +239,30 @@ let%test "strip_json_markdown_fences short string unchanged" =
   strip_json_markdown_fences "hi" = "hi"
 ;;
 
-let%test "tool_calls_to_provider_d_json extracts ToolUse blocks" =
+let%test "tool_calls_to_chat_completions_v1_json extracts ToolUse blocks" =
   let blocks =
     [ Text "hello"; ToolUse { id = "tc1"; name = "fn1"; input = `Assoc [ "x", `Int 1 ] } ]
   in
-  let result = tool_calls_to_provider_d_json blocks in
+  let result = tool_calls_to_chat_completions_v1_json blocks in
   List.length result = 1
 ;;
 
-let%test "tool_calls_to_provider_d_json empty for no tool_use" =
-  tool_calls_to_provider_d_json [ Text "no tools" ] = []
+let%test "tool_calls_to_chat_completions_v1_json empty for no tool_use" =
+  tool_calls_to_chat_completions_v1_json [ Text "no tools" ] = []
 ;;
 
-let%test "provider_d_content_parts_of_blocks filters text and image" =
+let%test "chat_completions_v1_content_parts_of_blocks filters text and image" =
   let blocks =
     [ Text "hello"
     ; Thinking { thinking_type = "reasoning"; content = "..." }
     ; ToolUse { id = "tc1"; name = "fn"; input = `Null }
     ]
   in
-  let result = provider_d_content_parts_of_blocks blocks in
+  let result = chat_completions_v1_content_parts_of_blocks blocks in
   List.length result = 1
 ;;
 
-let%test "build_provider_d_tool_json converts input_schema to parameters" =
+let%test "build_chat_completions_v1_tool_json converts input_schema to parameters" =
   let tool_json =
     `Assoc
       [ "name", `String "my_fn"
@@ -253,7 +270,7 @@ let%test "build_provider_d_tool_json converts input_schema to parameters" =
       ; "input_schema", `Assoc [ "type", `String "object" ]
       ]
   in
-  let result = build_provider_d_tool_json tool_json in
+  let result = build_chat_completions_v1_tool_json tool_json in
   let open Yojson.Safe.Util in
   result |> member "type" |> to_string = "function"
   && result |> member "function" |> member "name" |> to_string = "my_fn"
@@ -265,30 +282,30 @@ let%test "build_provider_d_tool_json converts input_schema to parameters" =
      = "object"
 ;;
 
-let%test "build_provider_d_tool_json non-assoc passthrough" =
-  build_provider_d_tool_json (`String "bad") = `String "bad"
+let%test "build_chat_completions_v1_tool_json non-assoc passthrough" =
+  build_chat_completions_v1_tool_json (`String "bad") = `String "bad"
 ;;
 
-let%test "usage_of_provider_d_json parses usage" =
+let%test "usage_of_chat_completions_v1_json parses usage" =
   let json =
     `Assoc [ "usage", `Assoc [ "prompt_tokens", `Int 100; "completion_tokens", `Int 50 ] ]
   in
-  match usage_of_provider_d_json json with
+  match usage_of_chat_completions_v1_json json with
   | Some u -> u.input_tokens = 100 && u.output_tokens = 50
   | None -> false
 ;;
 
-let%test "usage_of_provider_d_json null usage returns None" =
+let%test "usage_of_chat_completions_v1_json null usage returns None" =
   let json = `Assoc [ "usage", `Null ] in
-  usage_of_provider_d_json json = None
+  usage_of_chat_completions_v1_json json = None
 ;;
 
-let%test "usage_of_provider_d_json missing usage returns None" =
+let%test "usage_of_chat_completions_v1_json missing usage returns None" =
   let json = `Assoc [] in
-  usage_of_provider_d_json json = None
+  usage_of_chat_completions_v1_json json = None
 ;;
 
-let%test "usage_of_provider_d_json with cached_tokens" =
+let%test "usage_of_chat_completions_v1_json with cached_tokens" =
   let json =
     `Assoc
       [ ( "usage"
@@ -299,12 +316,12 @@ let%test "usage_of_provider_d_json with cached_tokens" =
             ] )
       ]
   in
-  match usage_of_provider_d_json json with
+  match usage_of_chat_completions_v1_json json with
   | Some u -> u.cache_read_input_tokens = 30
   | None -> false
 ;;
 
-let%test "parse_provider_d_response_result basic text response" =
+let%test "parse_chat_completions_v1_response_result basic text response" =
   let json_str =
     Yojson.Safe.to_string
       (`Assoc
@@ -319,13 +336,13 @@ let%test "parse_provider_d_response_result basic text response" =
                 ] )
           ])
   in
-  match parse_provider_d_response_result json_str with
+  match parse_chat_completions_v1_response_result json_str with
   | Ok resp ->
     resp.id = "chatcmpl-1" && resp.model = "model-d-4" && resp.stop_reason = EndTurn
   | Error _ -> false
 ;;
 
-let%test "parse_provider_d_response_result tool calls" =
+let%test "parse_chat_completions_v1_response_result tool calls" =
   let json_str =
     Yojson.Safe.to_string
       (`Assoc
@@ -355,12 +372,12 @@ let%test "parse_provider_d_response_result tool calls" =
                 ] )
           ])
   in
-  match parse_provider_d_response_result json_str with
+  match parse_chat_completions_v1_response_result json_str with
   | Ok resp -> resp.stop_reason = StopToolUse
   | Error _ -> false
 ;;
 
-let%test "parse_provider_d_response_result max_tokens stop reason" =
+let%test "parse_chat_completions_v1_response_result max_tokens stop reason" =
   let json_str =
     Yojson.Safe.to_string
       (`Assoc
@@ -375,22 +392,22 @@ let%test "parse_provider_d_response_result max_tokens stop reason" =
                 ] )
           ])
   in
-  match parse_provider_d_response_result json_str with
+  match parse_chat_completions_v1_response_result json_str with
   | Ok resp -> resp.stop_reason = MaxTokens
   | Error _ -> false
 ;;
 
-let%test "parse_provider_d_response_result error returns Error" =
+let%test "parse_chat_completions_v1_response_result error returns Error" =
   let json_str =
     Yojson.Safe.to_string
       (`Assoc [ "error", `Assoc [ "message", `String "rate limited" ] ])
   in
-  match parse_provider_d_response_result json_str with
+  match parse_chat_completions_v1_response_result json_str with
   | Error msg -> msg = "rate limited"
   | Ok _ -> false
 ;;
 
-let%test "provider_d_messages_of_message user text" =
+let%test "chat_completions_v1_messages_of_message user text" =
   let msg =
     { role = User
     ; content = [ Text "hello" ]
@@ -399,11 +416,11 @@ let%test "provider_d_messages_of_message user text" =
     ; metadata = []
     }
   in
-  let result = provider_d_messages_of_message msg in
+  let result = chat_completions_v1_messages_of_message msg in
   List.length result = 1
 ;;
 
-let%test "provider_d_messages_of_message user with tool_result" =
+let%test "chat_completions_v1_messages_of_message user with tool_result" =
   let msg =
     { role = User
     ; content =
@@ -416,7 +433,7 @@ let%test "provider_d_messages_of_message user with tool_result" =
     ; metadata = []
     }
   in
-  let result = provider_d_messages_of_message msg in
+  let result = chat_completions_v1_messages_of_message msg in
   List.length result = 2
 ;;
 
@@ -462,7 +479,7 @@ let%test "build_request strips orphaned tool results from wire messages" =
   roles = [ "assistant"; "user" ]
 ;;
 
-let%test "provider_d_messages_of_message assistant with tool_calls" =
+let%test "chat_completions_v1_messages_of_message assistant with tool_calls" =
   let msg =
     { role = Assistant
     ; content = [ ToolUse { id = "tc1"; name = "fn"; input = `Assoc [] } ]
@@ -471,11 +488,11 @@ let%test "provider_d_messages_of_message assistant with tool_calls" =
     ; metadata = []
     }
   in
-  let result = provider_d_messages_of_message msg in
+  let result = chat_completions_v1_messages_of_message msg in
   List.length result = 1
 ;;
 
-let%test "provider_d_messages_of_message system" =
+let%test "chat_completions_v1_messages_of_message system" =
   let msg =
     { role = System
     ; content = [ Text "system prompt" ]
@@ -484,19 +501,19 @@ let%test "provider_d_messages_of_message system" =
     ; metadata = []
     }
   in
-  let result = provider_d_messages_of_message msg in
+  let result = chat_completions_v1_messages_of_message msg in
   List.length result = 1
 ;;
 
-let%test "provider_d_messages_of_message user empty content" =
+let%test "chat_completions_v1_messages_of_message user empty content" =
   let msg =
     { role = User; content = []; name = None; tool_call_id = None; metadata = [] }
   in
-  let result = provider_d_messages_of_message msg in
+  let result = chat_completions_v1_messages_of_message msg in
   result = []
 ;;
 
-let%test "provider_d_messages_of_message user with image" =
+let%test "chat_completions_v1_messages_of_message user with image" =
   let msg =
     { role = User
     ; content =
@@ -508,11 +525,11 @@ let%test "provider_d_messages_of_message user with image" =
     ; metadata = []
     }
   in
-  let result = provider_d_messages_of_message msg in
+  let result = chat_completions_v1_messages_of_message msg in
   List.length result = 1
 ;;
 
-let%test "provider_d_messages_of_message user with document" =
+let%test "chat_completions_v1_messages_of_message user with document" =
   let msg =
     { role = User
     ; content =
@@ -524,11 +541,11 @@ let%test "provider_d_messages_of_message user with document" =
     ; metadata = []
     }
   in
-  let result = provider_d_messages_of_message msg in
+  let result = chat_completions_v1_messages_of_message msg in
   List.length result = 1
 ;;
 
-let%test "provider_d_messages_of_message user with audio" =
+let%test "chat_completions_v1_messages_of_message user with audio" =
   let msg =
     { role = User
     ; content =
@@ -538,11 +555,11 @@ let%test "provider_d_messages_of_message user with audio" =
     ; metadata = []
     }
   in
-  let result = provider_d_messages_of_message msg in
+  let result = chat_completions_v1_messages_of_message msg in
   List.length result = 1
 ;;
 
-let%test "provider_d_messages_of_message assistant text only" =
+let%test "chat_completions_v1_messages_of_message assistant text only" =
   let msg =
     { role = Assistant
     ; content = [ Text "hello" ]
@@ -551,13 +568,15 @@ let%test "provider_d_messages_of_message assistant text only" =
     ; metadata = []
     }
   in
-  let result = provider_d_messages_of_message msg in
+  let result = chat_completions_v1_messages_of_message msg in
   let json = List.hd result in
   let open Yojson.Safe.Util in
   json |> member "content" |> to_string = "hello"
 ;;
 
-let%test "provider_d_messages_of_message assistant excludes reasoning from content" =
+let%test
+    "chat_completions_v1_messages_of_message assistant excludes reasoning from content"
+  =
   let msg =
     { role = Assistant
     ; content =
@@ -569,7 +588,7 @@ let%test "provider_d_messages_of_message assistant excludes reasoning from conte
     ; metadata = []
     }
   in
-  let result = provider_d_messages_of_message msg in
+  let result = chat_completions_v1_messages_of_message msg in
   let json = List.hd result in
   let open Yojson.Safe.Util in
   json |> member "content" |> to_string = "final answer"
@@ -596,7 +615,7 @@ let%test "provider_k_messages_of_message preserves reasoning_content separately"
   && json |> member "tool_calls" |> to_list |> List.length = 1
 ;;
 
-let%test "provider_d_messages_of_message assistant blank text with tool_calls" =
+let%test "chat_completions_v1_messages_of_message assistant blank text with tool_calls" =
   let msg =
     { role = Assistant
     ; content = [ Text ""; ToolUse { id = "tc1"; name = "fn"; input = `Assoc [] } ]
@@ -605,13 +624,13 @@ let%test "provider_d_messages_of_message assistant blank text with tool_calls" =
     ; metadata = []
     }
   in
-  let result = provider_d_messages_of_message msg in
+  let result = chat_completions_v1_messages_of_message msg in
   let json = List.hd result in
   let open Yojson.Safe.Util in
   json |> member "content" = `Null
 ;;
 
-let%test "provider_d_messages_of_message Tool role with ToolResult" =
+let%test "chat_completions_v1_messages_of_message Tool role with ToolResult" =
   let msg =
     { role = Tool
     ; content =
@@ -627,7 +646,7 @@ let%test "provider_d_messages_of_message Tool role with ToolResult" =
     ; metadata = []
     }
   in
-  let result = provider_d_messages_of_message msg in
+  let result = chat_completions_v1_messages_of_message msg in
   List.length result = 1
   &&
   let json = List.hd result in
@@ -635,7 +654,10 @@ let%test "provider_d_messages_of_message Tool role with ToolResult" =
   json |> member "role" |> to_string = "tool"
 ;;
 
-let%test "provider_d_messages_of_message Tool role without ToolResult fallback to user" =
+let%test
+    "chat_completions_v1_messages_of_message Tool role without ToolResult fallback to \
+     user"
+  =
   let msg =
     { role = Tool
     ; content = [ Text "fallback" ]
@@ -644,13 +666,13 @@ let%test "provider_d_messages_of_message Tool role without ToolResult fallback t
     ; metadata = []
     }
   in
-  let result = provider_d_messages_of_message msg in
+  let result = chat_completions_v1_messages_of_message msg in
   let json = List.hd result in
   let open Yojson.Safe.Util in
   json |> member "role" |> to_string = "user"
 ;;
 
-let%test "build_provider_d_tool_json with parameters field" =
+let%test "build_chat_completions_v1_tool_json with parameters field" =
   let tool_json =
     `Assoc
       [ "name", `String "my_fn"
@@ -658,7 +680,7 @@ let%test "build_provider_d_tool_json with parameters field" =
       ; "parameters", `Assoc [ "type", `String "object" ]
       ]
   in
-  let result = build_provider_d_tool_json tool_json in
+  let result = build_chat_completions_v1_tool_json tool_json in
   let open Yojson.Safe.Util in
   result
   |> member "function"
@@ -668,7 +690,9 @@ let%test "build_provider_d_tool_json with parameters field" =
   = "object"
 ;;
 
-let%test "build_provider_d_tool_json converts legacy parameter list to json schema" =
+let%test
+    "build_chat_completions_v1_tool_json converts legacy parameter list to json schema"
+  =
   let tool_json =
     `Assoc
       [ "name", `String "my_fn"
@@ -690,7 +714,7 @@ let%test "build_provider_d_tool_json converts legacy parameter list to json sche
             ] )
       ]
   in
-  let result = build_provider_d_tool_json tool_json in
+  let result = build_chat_completions_v1_tool_json tool_json in
   let open Yojson.Safe.Util in
   let parameters = result |> member "function" |> member "parameters" in
   parameters |> member "type" |> to_string = "object"
@@ -709,7 +733,7 @@ let%test "build_provider_d_tool_json converts legacy parameter list to json sche
   && List.mem "query" (parameters |> member "required" |> to_list |> List.map to_string)
 ;;
 
-let%test "build_provider_d_tool_json skips malformed legacy parameter entries" =
+let%test "build_chat_completions_v1_tool_json skips malformed legacy parameter entries" =
   let tool_json =
     `Assoc
       [ "name", `String "my_fn"
@@ -728,7 +752,7 @@ let%test "build_provider_d_tool_json skips malformed legacy parameter entries" =
             ] )
       ]
   in
-  let result = build_provider_d_tool_json tool_json in
+  let result = build_chat_completions_v1_tool_json tool_json in
   let open Yojson.Safe.Util in
   let parameters = result |> member "function" |> member "parameters" in
   parameters
@@ -741,26 +765,26 @@ let%test "build_provider_d_tool_json skips malformed legacy parameter entries" =
   && List.mem "query" (parameters |> member "required" |> to_list |> List.map to_string)
 ;;
 
-let%test "build_provider_d_tool_json missing all optional fields" =
+let%test "build_chat_completions_v1_tool_json missing all optional fields" =
   let tool_json = `Assoc [] in
-  let result = build_provider_d_tool_json tool_json in
+  let result = build_chat_completions_v1_tool_json tool_json in
   let open Yojson.Safe.Util in
   result |> member "function" |> member "name" |> to_string = "tool"
   && result |> member "function" |> member "description" |> to_string = ""
 ;;
 
-let%test "build_provider_d_tool_json list passthrough" =
-  build_provider_d_tool_json (`List [ `String "bad" ]) = `List [ `String "bad" ]
+let%test "build_chat_completions_v1_tool_json list passthrough" =
+  build_chat_completions_v1_tool_json (`List [ `String "bad" ]) = `List [ `String "bad" ]
 ;;
 
-let%test "response_format_to_provider_d_json wraps raw json schema" =
+let%test "response_format_to_chat_completions_v1_json wraps raw json schema" =
   let schema =
     `Assoc
       [ "type", `String "object"
       ; "properties", `Assoc [ "answer", `Assoc [ "type", `String "string" ] ]
       ]
   in
-  match response_format_to_provider_d_json (Types.JsonSchema schema) with
+  match response_format_to_chat_completions_v1_json (Types.JsonSchema schema) with
   | Some json ->
     let open Yojson.Safe.Util in
     json |> member "type" |> to_string = "json_schema"
@@ -774,7 +798,7 @@ let%test "response_format_to_provider_d_json wraps raw json schema" =
   | None -> false
 ;;
 
-let%test "response_format_to_provider_d_json preserves named schema envelope" =
+let%test "response_format_to_chat_completions_v1_json preserves named schema envelope" =
   let schema =
     `Assoc
       [ "name", `String "math_response"
@@ -786,7 +810,7 @@ let%test "response_format_to_provider_d_json preserves named schema envelope" =
             ] )
       ]
   in
-  match response_format_to_provider_d_json (Types.JsonSchema schema) with
+  match response_format_to_chat_completions_v1_json (Types.JsonSchema schema) with
   | Some json ->
     let open Yojson.Safe.Util in
     json |> member "json_schema" |> member "name" |> to_string = "math_response"
@@ -807,7 +831,7 @@ let%test "strip_json_markdown_fences no closing fence" =
 
 let%test "strip_json_markdown_fences empty content" = strip_json_markdown_fences "" = ""
 
-let%test "parse_provider_d_response_result unknown finish_reason" =
+let%test "parse_chat_completions_v1_response_result unknown finish_reason" =
   let json_str =
     Yojson.Safe.to_string
       (`Assoc
@@ -822,12 +846,12 @@ let%test "parse_provider_d_response_result unknown finish_reason" =
                 ] )
           ])
   in
-  match parse_provider_d_response_result json_str with
+  match parse_chat_completions_v1_response_result json_str with
   | Ok resp -> resp.stop_reason = Unknown "something_new"
   | Error _ -> false
 ;;
 
-let%test "parse_provider_d_response_result end_turn finish_reason" =
+let%test "parse_chat_completions_v1_response_result end_turn finish_reason" =
   let json_str =
     Yojson.Safe.to_string
       (`Assoc
@@ -842,12 +866,12 @@ let%test "parse_provider_d_response_result end_turn finish_reason" =
                 ] )
           ])
   in
-  match parse_provider_d_response_result json_str with
+  match parse_chat_completions_v1_response_result json_str with
   | Ok resp -> resp.stop_reason = EndTurn
   | Error _ -> false
 ;;
 
-let%test "parse_provider_d_response_result null content" =
+let%test "parse_chat_completions_v1_response_result null content" =
   let json_str =
     Yojson.Safe.to_string
       (`Assoc
@@ -862,12 +886,12 @@ let%test "parse_provider_d_response_result null content" =
                 ] )
           ])
   in
-  match parse_provider_d_response_result json_str with
+  match parse_chat_completions_v1_response_result json_str with
   | Ok resp -> resp.stop_reason = EndTurn
   | Error _ -> false
 ;;
 
-let%test "parse_provider_d_response_result list content" =
+let%test "parse_chat_completions_v1_response_result list content" =
   let json_str =
     Yojson.Safe.to_string
       (`Assoc
@@ -883,7 +907,7 @@ let%test "parse_provider_d_response_result list content" =
                 ] )
           ])
   in
-  match parse_provider_d_response_result json_str with
+  match parse_chat_completions_v1_response_result json_str with
   | Ok resp ->
     (match resp.content with
      | [ Text t ] -> String.length t > 0
@@ -891,7 +915,7 @@ let%test "parse_provider_d_response_result list content" =
   | Error _ -> false
 ;;
 
-let%test "parse_provider_d_response_result list content with assoc text blocks" =
+let%test "parse_chat_completions_v1_response_result list content with assoc text blocks" =
   let json_str =
     Yojson.Safe.to_string
       (`Assoc
@@ -913,7 +937,7 @@ let%test "parse_provider_d_response_result list content with assoc text blocks" 
                 ] )
           ])
   in
-  match parse_provider_d_response_result json_str with
+  match parse_chat_completions_v1_response_result json_str with
   | Ok resp ->
     (match resp.content with
      | [ Text t ] -> t = "block1block2"
@@ -921,7 +945,7 @@ let%test "parse_provider_d_response_result list content with assoc text blocks" 
   | Error _ -> false
 ;;
 
-let%test "parse_provider_d_response_result with reasoning_content" =
+let%test "parse_chat_completions_v1_response_result with reasoning_content" =
   let json_str =
     Yojson.Safe.to_string
       (`Assoc
@@ -940,7 +964,7 @@ let%test "parse_provider_d_response_result with reasoning_content" =
                 ] )
           ])
   in
-  match parse_provider_d_response_result json_str with
+  match parse_chat_completions_v1_response_result json_str with
   | Ok resp ->
     (* N-of-M followup to PR #1525 (backend_provider_f.has_tool_use). Same
        content_block catch-all family — enumerate every variant so a
@@ -960,7 +984,7 @@ let%test "parse_provider_d_response_result with reasoning_content" =
   | Error _ -> false
 ;;
 
-let%test "parse_provider_d_response_result JSON list wrapping" =
+let%test "parse_chat_completions_v1_response_result JSON list wrapping" =
   let inner =
     `Assoc
       [ "id", `String "c1"
@@ -975,19 +999,19 @@ let%test "parse_provider_d_response_result JSON list wrapping" =
       ]
   in
   let json_str = Yojson.Safe.to_string (`List [ inner ]) in
-  match parse_provider_d_response_result json_str with
+  match parse_chat_completions_v1_response_result json_str with
   | Ok resp -> resp.id = "c1"
   | Error _ -> false
 ;;
 
-let%test "parse_provider_d_response_result error without message" =
+let%test "parse_chat_completions_v1_response_result error without message" =
   let json_str = Yojson.Safe.to_string (`Assoc [ "error", `Assoc [] ]) in
-  match parse_provider_d_response_result json_str with
+  match parse_chat_completions_v1_response_result json_str with
   | Error msg -> msg = "Unknown API error"
   | Ok _ -> false
 ;;
 
-let%test "usage_of_provider_d_json prompt_tokens_details null" =
+let%test "usage_of_chat_completions_v1_json prompt_tokens_details null" =
   let json =
     `Assoc
       [ ( "usage"
@@ -998,47 +1022,47 @@ let%test "usage_of_provider_d_json prompt_tokens_details null" =
             ] )
       ]
   in
-  match usage_of_provider_d_json json with
+  match usage_of_chat_completions_v1_json json with
   | Some u -> u.cache_read_input_tokens = 0
   | None -> false
 ;;
 
-let%test "provider_d_content_parts_of_blocks image block" =
+let%test "chat_completions_v1_content_parts_of_blocks image block" =
   let blocks =
     [ Image { media_type = "image/png"; data = "abc"; source_type = "base64" } ]
   in
-  let result = provider_d_content_parts_of_blocks blocks in
+  let result = chat_completions_v1_content_parts_of_blocks blocks in
   List.length result = 1
 ;;
 
-let%test "provider_d_content_parts_of_blocks document block" =
+let%test "chat_completions_v1_content_parts_of_blocks document block" =
   let blocks =
     [ Document { media_type = "application/pdf"; data = "abc"; source_type = "base64" } ]
   in
-  let result = provider_d_content_parts_of_blocks blocks in
+  let result = chat_completions_v1_content_parts_of_blocks blocks in
   List.length result = 1
 ;;
 
-let%test "provider_d_content_parts_of_blocks audio block" =
+let%test "chat_completions_v1_content_parts_of_blocks audio block" =
   let blocks =
     [ Audio { media_type = "audio/wav"; data = "abc"; source_type = "base64" } ]
   in
-  let result = provider_d_content_parts_of_blocks blocks in
+  let result = chat_completions_v1_content_parts_of_blocks blocks in
   List.length result = 1
 ;;
 
-let%test "provider_d_content_parts_of_blocks redacted thinking filtered" =
+let%test "chat_completions_v1_content_parts_of_blocks redacted thinking filtered" =
   let blocks = [ RedactedThinking "secret"; Text "visible" ] in
-  let result = provider_d_content_parts_of_blocks blocks in
+  let result = chat_completions_v1_content_parts_of_blocks blocks in
   List.length result = 1
 ;;
 
-let%test "provider_d_content_parts_of_blocks tool_result filtered" =
+let%test "chat_completions_v1_content_parts_of_blocks tool_result filtered" =
   let blocks =
     [ ToolResult { tool_use_id = "t1"; content = "result"; is_error = false; json = None }
     ]
   in
-  provider_d_content_parts_of_blocks blocks = []
+  chat_completions_v1_content_parts_of_blocks blocks = []
 ;;
 
 let%test "build_request includes tool_choice for model with supports_tool_choice=true" =
@@ -1145,7 +1169,7 @@ let%test "build_request uses json_schema response_format when output_schema is s
     Provider_config.make
       ~kind:OpenAI_compat
       ~model_id:"model-d"
-      ~base_url:"https://api.provider_d.com/v1"
+      ~base_url:"https://api.chat-completions-v1.example/v1"
       ~output_schema:schema
       ()
   in
@@ -1172,7 +1196,7 @@ let%test "build_request prefers output_schema over json_object mode" =
     Provider_config.make
       ~kind:OpenAI_compat
       ~model_id:"model-d"
-      ~base_url:"https://api.provider_d.com/v1"
+      ~base_url:"https://api.chat-completions-v1.example/v1"
       ~response_format_json:true
       ~output_schema:schema
       ()
@@ -1273,12 +1297,12 @@ let%test "build_request serializes ZAI thinking object for bare GLM compat model
   && json |> member "reasoning_effort" = `Null
 ;;
 
-let%test "build_request emits reasoning_effort for Provider_d reasoning models" =
+let%test "build_request emits reasoning_effort for Chat_completions_v1 reasoning models" =
   let config =
     Provider_config.make
       ~kind:OpenAI_compat
       ~model_id:"model-d-5.1"
-      ~base_url:"https://api.provider_d.com/v1"
+      ~base_url:"https://api.chat-completions-v1.example/v1"
       ~enable_thinking:true
       ~thinking_budget:2048
       ()
@@ -1327,7 +1351,7 @@ let%test "build_request emits enable_thinking for DashScope provider kind" =
 ;;
 
 let%test "build_request omits thinking params for No_thinking_control" =
-  (* Generic unknown Provider_d-compatible model ids fall back to
+  (* Generic unknown Chat_completions_v1-compatible model ids fall back to
      No_thinking_control and must not emit any provider-specific thinking
      parameter. *)
   let config =

--- a/lib/llm_provider/backend_chat_completions_v1.mli
+++ b/lib/llm_provider/backend_chat_completions_v1.mli
@@ -1,24 +1,35 @@
-(** Provider_d-compatible API response parsing and request building.
+(** Chat_completions_v1-compatible API response parsing and request building.
 
     Pure functions operating on {!Llm_provider.Types}.
 
     @stability Internal
     @since 0.93.1 *)
 
-val tool_calls_to_provider_d_json : Types.content_block list -> Yojson.Safe.t list
-val provider_d_content_parts_of_blocks : Types.content_block list -> Yojson.Safe.t list
-val provider_d_messages_of_message : Types.message -> Yojson.Safe.t list
+val tool_calls_to_chat_completions_v1_json
+  :  Types.content_block list
+  -> Yojson.Safe.t list
+
+val chat_completions_v1_content_parts_of_blocks
+  :  Types.content_block list
+  -> Yojson.Safe.t list
+
+val chat_completions_v1_messages_of_message : Types.message -> Yojson.Safe.t list
 val strip_json_markdown_fences : string -> string
-val tool_choice_to_provider_d_json : Types.tool_choice -> Yojson.Safe.t
-val build_provider_d_tool_json : Yojson.Safe.t -> Yojson.Safe.t
+val tool_choice_to_chat_completions_v1_json : Types.tool_choice -> Yojson.Safe.t
+val build_chat_completions_v1_tool_json : Yojson.Safe.t -> Yojson.Safe.t
 val strip_orphaned_tool_results : Types.message list -> Types.message list
-val response_format_to_provider_d_json : Types.response_format -> Yojson.Safe.t option
 
-(** Parse an Provider_d-compatible JSON response.
+val response_format_to_chat_completions_v1_json
+  :  Types.response_format
+  -> Yojson.Safe.t option
+
+(** Parse an Chat_completions_v1-compatible JSON response.
     Returns [Ok api_response] on success, [Error msg] on API error. *)
-val parse_provider_d_response_result : string -> (Types.api_response, string) result
+val parse_chat_completions_v1_response_result
+  :  string
+  -> (Types.api_response, string) result
 
-val usage_of_provider_d_json : Yojson.Safe.t -> Types.api_usage option
+val usage_of_chat_completions_v1_json : Yojson.Safe.t -> Types.api_usage option
 
 val build_request
   :  ?stream:bool
@@ -32,7 +43,7 @@ val build_request
     sampling field is dropped for a given [(model_id, field)] pair.
 
     Called from the silent-drop branches of the capability gates in
-    {!build_request} and [Api_provider_d.build_provider_d_body] so operators
+    {!build_request} and [Api_chat_completions_v1.build_chat_completions_v1_body] so operators
     who set a non-supported field (e.g. [min_p] on a Glm config) see
     exactly which field was stripped without the per-request WARN
     spam that would otherwise fire on every automated turn.

--- a/lib/llm_provider/backend_chat_completions_v1_parse.ml
+++ b/lib/llm_provider/backend_chat_completions_v1_parse.ml
@@ -1,9 +1,9 @@
-(** Provider_d-compatible response parsing.
+(** Chat_completions_v1-compatible response parsing.
 
-    Parses JSON responses from Provider_d Chat Completions API into
+    Parses JSON responses from Chat_completions_v1 Chat Completions API into
     agent_sdk Types (api_response, api_usage).
 
-    @since 0.92.0 extracted from Backend_provider_d *)
+    @since 0.92.0 extracted from Backend_chat_completions_v1 *)
 
 open Types
 
@@ -25,7 +25,7 @@ let non_blank_json_string = function
     None
 ;;
 
-let text_of_provider_d_content_block = function
+let text_of_chat_completions_v1_content_block = function
   | `String s -> Some s
   | `Assoc fields ->
     (match List.assoc_opt "text" fields with
@@ -35,11 +35,13 @@ let text_of_provider_d_content_block = function
   | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
 ;;
 
-let text_content_of_provider_d_content = function
+let text_content_of_chat_completions_v1_content = function
   | `String s -> s
   | `Null -> ""
   | `List blocks ->
-    blocks |> List.filter_map text_of_provider_d_content_block |> String.concat ""
+    blocks
+    |> List.filter_map text_of_chat_completions_v1_content_block
+    |> String.concat ""
   | `Assoc _ | `Int _ | `Intlit _ | `Float _ | `Bool _ -> ""
 ;;
 
@@ -94,7 +96,7 @@ let strip_json_markdown_fences text =
           trimmed))
 ;;
 
-let usage_of_provider_d_json json =
+let usage_of_chat_completions_v1_json json =
   let open Yojson.Safe.Util in
   let usage = json |> member "usage" in
   if usage = `Null
@@ -125,7 +127,7 @@ let usage_of_provider_d_json json =
 (** Extract provider-reported inference telemetry from the raw JSON.
     llama-server populates [timings] and [system_fingerprint];
     cloud providers return [None] for those fields. *)
-let telemetry_of_provider_d_json json =
+let telemetry_of_chat_completions_v1_json json =
   let open Yojson.Safe.Util in
   let usage = json |> member "usage" in
   let usage_int keys = if usage = `Null then None else member_int_fallback usage keys in
@@ -236,9 +238,9 @@ let telemetry_of_provider_d_json json =
     }
 ;;
 
-(** Parse an Provider_d-compatible JSON response string into an [api_response].
+(** Parse an Chat_completions_v1-compatible JSON response string into an [api_response].
     Returns [Error msg] when the response body contains an API error. *)
-let parse_provider_d_response_result json_str =
+let parse_chat_completions_v1_response_result json_str =
   let open Yojson.Safe.Util in
   let raw_json = Yojson.Safe.from_string json_str in
   let json =
@@ -254,7 +256,9 @@ let parse_provider_d_response_result json_str =
     let finish_reason =
       choice |> member "finish_reason" |> to_string_option |> Option.value ~default:"stop"
     in
-    let text_content = text_content_of_provider_d_content (msg |> member "content") in
+    let text_content =
+      text_content_of_chat_completions_v1_content (msg |> member "content")
+    in
     let text_content =
       let stripped = strip_json_markdown_fences text_content in
       if stripped = text_content
@@ -293,7 +297,7 @@ let parse_provider_d_response_result json_str =
       | `Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> []
     in
     let thinking_blocks =
-      (* Ollama uses "reasoning" field; Provider_d/Provider_g use "reasoning_content".
+      (* Ollama uses "reasoning" field; Chat_completions_v1/Provider_g use "reasoning_content".
            Check both, preferring reasoning_content. *)
       let reasoning_text =
         match non_blank_json_string (msg |> member "reasoning_content") with
@@ -320,8 +324,8 @@ let parse_provider_d_response_result json_str =
           thinking_blocks
           @ (if Api_common.string_is_blank text_content then [] else [ Text text_content ])
           @ tool_blocks
-      ; usage = usage_of_provider_d_json json
-      ; telemetry = telemetry_of_provider_d_json json
+      ; usage = usage_of_chat_completions_v1_json json
+      ; telemetry = telemetry_of_chat_completions_v1_json json
       }
   | err ->
     let msg =
@@ -333,7 +337,7 @@ let parse_provider_d_response_result json_str =
     Error msg
 ;;
 
-let%test "usage_of_provider_d_json supports mlx_vlm input/output token fields" =
+let%test "usage_of_chat_completions_v1_json supports mlx_vlm input/output token fields" =
   let json =
     `Assoc
       [ ( "usage"
@@ -342,12 +346,12 @@ let%test "usage_of_provider_d_json supports mlx_vlm input/output token fields" =
         )
       ]
   in
-  match usage_of_provider_d_json json with
+  match usage_of_chat_completions_v1_json json with
   | Some u -> u.input_tokens = 11 && u.output_tokens = 5
   | None -> false
 ;;
 
-let%test "telemetry_of_provider_d_json synthesizes timings from mlx_vlm usage" =
+let%test "telemetry_of_chat_completions_v1_json synthesizes timings from mlx_vlm usage" =
   let json =
     `Assoc
       [ ( "usage"
@@ -360,7 +364,7 @@ let%test "telemetry_of_provider_d_json synthesizes timings from mlx_vlm usage" =
       ; "peak_memory", `Float 52.66
       ]
   in
-  match telemetry_of_provider_d_json json with
+  match telemetry_of_chat_completions_v1_json json with
   | Some { timings = Some t; peak_memory_gb = Some peak; _ } ->
     t.prompt_n = Some 11
     && t.predicted_n = Some 5
@@ -374,11 +378,12 @@ let%test "telemetry_of_provider_d_json synthesizes timings from mlx_vlm usage" =
   | None -> false
 ;;
 
-let%test "telemetry_of_provider_d_json keeps timings none without timing signals" =
+let%test "telemetry_of_chat_completions_v1_json keeps timings none without timing signals"
+  =
   let json =
     `Assoc [ "usage", `Assoc [ "prompt_tokens", `Int 11; "completion_tokens", `Int 5 ] ]
   in
-  match telemetry_of_provider_d_json json with
+  match telemetry_of_chat_completions_v1_json json with
   | Some { timings = None; peak_memory_gb = None; _ } -> true
   | Some { timings = Some _; _ }
   | Some { timings = None; peak_memory_gb = Some _; _ }

--- a/lib/llm_provider/backend_chat_completions_v1_parse.mli
+++ b/lib/llm_provider/backend_chat_completions_v1_parse.mli
@@ -1,13 +1,15 @@
 (** OpenAI-compatible response parsing.
 
-    @since 0.92.0 extracted from Backend_provider_d
+    @since 0.92.0 extracted from Backend_chat_completions_v1
 
     @stability Internal
     @since 0.93.1 *)
 
 val strip_json_markdown_fences : string -> string
-val usage_of_provider_d_json : Yojson.Safe.t -> Types.api_usage option
+val usage_of_chat_completions_v1_json : Yojson.Safe.t -> Types.api_usage option
 
 (** Parse an OpenAI-compatible JSON response.
     Returns [Ok api_response] on success, [Error msg] on API error. *)
-val parse_provider_d_response_result : string -> (Types.api_response, string) result
+val parse_chat_completions_v1_response_result
+  :  string
+  -> (Types.api_response, string) result

--- a/lib/llm_provider/backend_chat_completions_v1_request.ml
+++ b/lib/llm_provider/backend_chat_completions_v1_request.ml
@@ -1,6 +1,6 @@
-(** Provider_d-compatible request body building.
+(** Chat_completions_v1-compatible request body building.
 
-    Extracted from {!Backend_provider_d} so the top-level backend module can stay
+    Extracted from {!Backend_chat_completions_v1} so the top-level backend module can stay
     a compatibility facade over request construction, response parsing, and
     message serialization. *)
 
@@ -23,7 +23,7 @@ let warn_capability_drop ~model_id ~field =
     Hashtbl.replace capability_drop_warned key ();
     (Metrics.get_global ()).on_capability_drop ~model_id ~field;
     Diag.warn
-      "backend_provider_d"
+      "backend_chat_completions_v1"
       "dropping sampling field %s for model %s: capability record reports supports_%s = \
        false. Update Capabilities.for_model_id if this model actually supports it, \
        otherwise remove the field from your request config."
@@ -38,7 +38,9 @@ let effective_tool_choice (config : Provider_config.t) =
   match config.tool_choice with
   | Some None_ -> None
   | Some choice ->
-    Some (Backend_provider_d_serialize.tool_choice_to_provider_d_json choice)
+    Some
+      (Backend_chat_completions_v1_serialize.tool_choice_to_chat_completions_v1_json
+         choice)
   | None -> None
 ;;
 
@@ -55,7 +57,7 @@ let structured_schema_of_config (config : Provider_config.t) =
   | None, JsonMode | None, Off -> None
 ;;
 
-let provider_d_json_schema_payload (schema : Yojson.Safe.t) : Yojson.Safe.t =
+let chat_completions_v1_json_schema_payload (schema : Yojson.Safe.t) : Yojson.Safe.t =
   match schema with
   | `Assoc fields when List.mem_assoc "name" fields && List.mem_assoc "schema" fields ->
     schema
@@ -67,24 +69,24 @@ let provider_d_json_schema_payload (schema : Yojson.Safe.t) : Yojson.Safe.t =
       ]
 ;;
 
-let response_format_to_provider_d_json = function
+let response_format_to_chat_completions_v1_json = function
   | Types.Off -> None
   | Types.JsonMode -> Some (`Assoc [ "type", `String "json_object" ])
   | Types.JsonSchema schema ->
     Some
       (`Assoc
           [ "type", `String "json_schema"
-          ; "json_schema", provider_d_json_schema_payload schema
+          ; "json_schema", chat_completions_v1_json_schema_payload schema
           ])
 ;;
 
-(** Build Provider_d Chat Completions request body from {!Provider_config.t}.
+(** Build Chat_completions_v1 Chat Completions request body from {!Provider_config.t}.
     Returns a JSON string ready for HTTP POST. *)
 let response_format_of_config (config : Provider_config.t) =
   match structured_schema_of_config config with
-  | Some schema -> response_format_to_provider_d_json (Types.JsonSchema schema)
+  | Some schema -> response_format_to_chat_completions_v1_json (Types.JsonSchema schema)
   | None when config.response_format = JsonMode ->
-    response_format_to_provider_d_json Types.JsonMode
+    response_format_to_chat_completions_v1_json Types.JsonMode
   | None -> None
 ;;
 
@@ -107,7 +109,7 @@ let is_zai_glm_request (config : Provider_config.t) =
   && Zai_catalog.is_glm_model_id config.model_id
 ;;
 
-(** Build Provider_d Chat Completions request body from {!Provider_config.t}.
+(** Build Chat_completions_v1 Chat Completions request body from {!Provider_config.t}.
     Returns a JSON string ready for HTTP POST. *)
 let build_request
       ?(stream = false)
@@ -118,19 +120,20 @@ let build_request
   =
   let tools = effective_tools config tools in
   let sanitized_messages =
-    Backend_provider_d_serialize.strip_orphaned_tool_results messages
+    Backend_chat_completions_v1_serialize.strip_orphaned_tool_results messages
   in
   let provider_messages =
     let message_serializer =
       match config.kind with
-      | Provider_config.Glm -> Backend_provider_d_serialize.provider_k_messages_of_message
+      | Provider_config.Glm ->
+        Backend_chat_completions_v1_serialize.provider_k_messages_of_message
       | Provider_config.Anthropic
       | Provider_config.Kimi
       | Provider_config.OpenAI_compat
       | Provider_config.Ollama
       | Provider_config.DashScope
       | Provider_config.Gemini ->
-        Backend_provider_d_serialize.provider_d_messages_of_message
+        Backend_chat_completions_v1_serialize.chat_completions_v1_messages_of_message
     in
     (match config.system_prompt with
      | Some s when not (Api_common.string_is_blank s) ->
@@ -144,7 +147,7 @@ let build_request
      (1) the [max_tokens] clamp below (avoid server 400 on over-cap),
      (2) the [top_k] / [min_p] sampling-field gates further down.
      If no model-specific record exists, fall back to the provider-kind
-     preset, then to conservative defaults for unknown Provider_d-compatible
+     preset, then to conservative defaults for unknown Chat_completions_v1-compatible
      configs. *)
   let caps = capabilities_of_config config in
   (* Resolve [max_tokens] from three layers:
@@ -157,7 +160,7 @@ let build_request
      to avoid 400 errors that corrupt partial-commit state.
 
      The resolved value is always emitted - Anthropic and most
-     Provider_d-compat endpoints REQUIRE the field. *)
+     Chat_completions_v1-compat endpoints REQUIRE the field. *)
   let effective_max_tokens =
     match config.max_tokens, caps.max_output_tokens with
     | None, Some cap -> cap
@@ -260,8 +263,8 @@ let build_request
   in
   (* tool_choice uses a DIFFERENT unknown-model default than top_k /
      min_p above: unknown -> assume supported (true). Two reasons:
-       (1) [tool_choice] is a standard Provider_d Chat Completions body
-           param and virtually every Provider_d-compat server accepts it,
+       (1) [tool_choice] is a standard Chat_completions_v1 Chat Completions body
+           param and virtually every Chat_completions_v1-compat server accepts it,
            so conservatively dropping it on unknown models would
            regress every agent that uses a model Capabilities does
            not know about yet.
@@ -292,7 +295,10 @@ let build_request
     | [] -> body
     | ts ->
       ( "tools"
-      , `List (List.map Backend_provider_d_serialize.build_provider_d_tool_json ts) )
+      , `List
+          (List.map
+             Backend_chat_completions_v1_serialize.build_chat_completions_v1_tool_json
+             ts) )
       :: body
   in
   let body =

--- a/lib/llm_provider/backend_chat_completions_v1_request.mli
+++ b/lib/llm_provider/backend_chat_completions_v1_request.mli
@@ -1,7 +1,7 @@
 (** OpenAI-compatible request body building.
 
     This module owns provider-config -> Chat Completions JSON request
-    construction. {!Backend_provider_d} re-exports the public surface for
+    construction. {!Backend_chat_completions_v1} re-exports the public surface for
     backwards compatibility while response parsing and message serialization
     stay in their existing modules.
 
@@ -11,8 +11,12 @@ val warn_capability_drop : model_id:string -> field:string -> unit
 val effective_tool_choice : Provider_config.t -> Yojson.Safe.t option
 val effective_tools : Provider_config.t -> Yojson.Safe.t list -> Yojson.Safe.t list
 val structured_schema_of_config : Provider_config.t -> Yojson.Safe.t option
-val provider_d_json_schema_payload : Yojson.Safe.t -> Yojson.Safe.t
-val response_format_to_provider_d_json : Types.response_format -> Yojson.Safe.t option
+val chat_completions_v1_json_schema_payload : Yojson.Safe.t -> Yojson.Safe.t
+
+val response_format_to_chat_completions_v1_json
+  :  Types.response_format
+  -> Yojson.Safe.t option
+
 val response_format_of_config : Provider_config.t -> Yojson.Safe.t option
 
 val build_request

--- a/lib/llm_provider/backend_chat_completions_v1_serialize.ml
+++ b/lib/llm_provider/backend_chat_completions_v1_serialize.ml
@@ -1,13 +1,13 @@
-(** Provider_d-compatible request serialization.
+(** Chat_completions_v1-compatible request serialization.
 
     Converts agent_sdk Types (content blocks, messages, tools) into
-    Provider_d Chat Completions API JSON format.
+    Chat_completions_v1 Chat Completions API JSON format.
 
-    @since 0.92.0 extracted from Backend_provider_d *)
+    @since 0.92.0 extracted from Backend_chat_completions_v1 *)
 
 open Types
 
-let tool_calls_to_provider_d_json blocks =
+let tool_calls_to_chat_completions_v1_json blocks =
   blocks
   |> List.filter_map (function
     | ToolUse { id; name; input } ->
@@ -52,7 +52,7 @@ let tool_calls_to_ollama_json blocks =
     | Audio _ -> None)
 ;;
 
-let provider_d_content_parts_of_blocks blocks =
+let chat_completions_v1_content_parts_of_blocks blocks =
   blocks
   |> List.filter_map (function
     | Text s ->
@@ -115,7 +115,7 @@ let assistant_reasoning_content_of_blocks blocks =
 ;;
 
 let messages_of_message_with
-      ?(tool_calls_fn = tool_calls_to_provider_d_json)
+      ?(tool_calls_fn = tool_calls_to_chat_completions_v1_json)
       ?(include_reasoning_content = false)
       ?(modality_priority = Modality.Preserve_input_order)
       (msg : message)
@@ -129,7 +129,7 @@ let messages_of_message_with
        has_multimodal inspects the input list (pre-reorder) — the boolean
        is invariant under reordering, so either input is correct. *)
     let ordered_content = Modality.reorder modality_priority msg.content in
-    let content_parts = provider_d_content_parts_of_blocks ordered_content in
+    let content_parts = chat_completions_v1_content_parts_of_blocks ordered_content in
     let has_multimodal =
       List.exists
         (function
@@ -218,13 +218,13 @@ let messages_of_message_with
      | tool_msgs -> tool_msgs)
 ;;
 
-let provider_d_messages_of_message msg =
-  messages_of_message_with ~tool_calls_fn:tool_calls_to_provider_d_json msg
+let chat_completions_v1_messages_of_message msg =
+  messages_of_message_with ~tool_calls_fn:tool_calls_to_chat_completions_v1_json msg
 ;;
 
 let provider_k_messages_of_message msg =
   messages_of_message_with
-    ~tool_calls_fn:tool_calls_to_provider_d_json
+    ~tool_calls_fn:tool_calls_to_chat_completions_v1_json
     ~include_reasoning_content:true
     msg
 ;;
@@ -247,8 +247,8 @@ let ollama_messages_of_message ?(model_id = "") msg =
     compaction drops or reorders a ToolUse while the corresponding
     ToolResult survives.
 
-    Provider_d-compatible APIs reject orphaned tool_call_ids; the Anthropic
-    API has its own dangling-tool-call repair, so this is Provider_d-path only.
+    Chat_completions_v1-compatible APIs reject orphaned tool_call_ids; the Anthropic
+    API has its own dangling-tool-call repair, so this is Chat_completions_v1-path only.
 
     Pure function — no I/O, no mutation. *)
 let strip_orphaned_tool_results (messages : message list) : message list =
@@ -371,7 +371,7 @@ let strip_thinking_blocks (messages : message list) : message list =
     messages
 ;;
 
-let tool_choice_to_provider_d_json = function
+let tool_choice_to_chat_completions_v1_json = function
   | Auto -> `String "auto"
   | Any -> `String "required"
   | Tool name ->
@@ -444,7 +444,7 @@ let legacy_parameters_to_json_schema params =
     ]
 ;;
 
-let build_provider_d_tool_json = function
+let build_chat_completions_v1_tool_json = function
   | `Assoc fields ->
     let name =
       match List.assoc_opt "name" fields with

--- a/lib/llm_provider/backend_chat_completions_v1_serialize.mli
+++ b/lib/llm_provider/backend_chat_completions_v1_serialize.mli
@@ -1,26 +1,32 @@
-(** Provider_d-compatible request serialization.
+(** Chat_completions_v1-compatible request serialization.
 
-    @since 0.92.0 extracted from Backend_provider_d
+    @since 0.92.0 extracted from Backend_chat_completions_v1
 
     @stability Internal
     @since 0.93.1 *)
 
-val tool_calls_to_provider_d_json : Types.content_block list -> Yojson.Safe.t list
-val provider_d_content_parts_of_blocks : Types.content_block list -> Yojson.Safe.t list
-val provider_d_messages_of_message : Types.message -> Yojson.Safe.t list
+val tool_calls_to_chat_completions_v1_json
+  :  Types.content_block list
+  -> Yojson.Safe.t list
+
+val chat_completions_v1_content_parts_of_blocks
+  :  Types.content_block list
+  -> Yojson.Safe.t list
+
+val chat_completions_v1_messages_of_message : Types.message -> Yojson.Safe.t list
 val provider_k_messages_of_message : Types.message -> Yojson.Safe.t list
 val ollama_messages_of_message : ?model_id:string -> Types.message -> Yojson.Safe.t list
-val tool_choice_to_provider_d_json : Types.tool_choice -> Yojson.Safe.t
-val build_provider_d_tool_json : Yojson.Safe.t -> Yojson.Safe.t
+val tool_choice_to_chat_completions_v1_json : Types.tool_choice -> Yojson.Safe.t
+val build_chat_completions_v1_tool_json : Yojson.Safe.t -> Yojson.Safe.t
 
 (** Remove ToolResult blocks whose tool_use_id has no matching ToolUse
     in any Assistant message. Call before serializing messages for
-    Provider_d-compatible APIs to prevent orphaned tool_call_id errors
+    Chat_completions_v1-compatible APIs to prevent orphaned tool_call_id errors
     after context compaction.  @since 0.103.0 *)
 val strip_orphaned_tool_results : Types.message list -> Types.message list
 
 (** Remove Thinking blocks from all messages. Provider_g-compatible APIs
     reject [reasoning_content] in request messages — it is response-only.
-    Call before serializing messages for Provider_d-compatible APIs.
+    Call before serializing messages for Chat_completions_v1-compatible APIs.
     @since 0.184.0 *)
 val strip_thinking_blocks : Types.message list -> Types.message list

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -10,7 +10,7 @@ open Types
 (* ── Request building ────────────────────────────────── *)
 
 (** Build Ollama native [/api/chat] request body.
-    Key differences from Provider_d compat:
+    Key differences from Chat_completions_v1 compat:
     - [think] parameter (boolean) instead of [chat_template_kwargs]
     - Sampling params go inside [options] object
     - [num_predict] instead of [max_tokens]
@@ -30,7 +30,7 @@ let build_request
        ]
      | _ -> [])
     @ List.concat_map
-        (Backend_provider_d_serialize.ollama_messages_of_message
+        (Backend_chat_completions_v1_serialize.ollama_messages_of_message
            ~model_id:config.model_id)
         messages
   in
@@ -105,7 +105,10 @@ let build_request
     | [] -> body
     | ts ->
       ( "tools"
-      , `List (List.map Backend_provider_d_serialize.build_provider_d_tool_json ts) )
+      , `List
+          (List.map
+             Backend_chat_completions_v1_serialize.build_chat_completions_v1_tool_json
+             ts) )
       :: body
   in
   (* Sampling parameters go inside Ollama's "options" object.
@@ -122,7 +125,7 @@ let build_request
      behaviour is byte-identical for the common path. The gate only
      fires when an operator explicitly sets [supports_min_p = false]
      or [supports_top_k = false] for a specific Ollama variant — at
-     which point the one-shot WARN from Backend_provider_d also fires. *)
+     which point the one-shot WARN from Backend_chat_completions_v1 also fires. *)
   let caps =
     match Capabilities.for_model_id config.model_id with
     | Some c -> c
@@ -142,12 +145,16 @@ let build_request
   (match config.top_k with
    | Some k when caps.supports_top_k -> options := ("top_k", `Int k) :: !options
    | Some _ ->
-     Backend_provider_d.warn_capability_drop ~model_id:config.model_id ~field:"top_k"
+     Backend_chat_completions_v1.warn_capability_drop
+       ~model_id:config.model_id
+       ~field:"top_k"
    | None -> ());
   (match config.min_p with
    | Some p when caps.supports_min_p -> options := ("min_p", `Float p) :: !options
    | Some _ ->
-     Backend_provider_d.warn_capability_drop ~model_id:config.model_id ~field:"min_p"
+     Backend_chat_completions_v1.warn_capability_drop
+       ~model_id:config.model_id
+       ~field:"min_p"
    | None -> ());
   (* num_ctx: per-request KV cache allocation in tokens. Honored by Ollama
      only. [None] omits the field so Ollama uses its own default
@@ -728,8 +735,8 @@ let%test
   (* Pins the supported path: default Ollama capabilities have
      supports_top_k=true, so the serializer threads top_k into options.
      The capability-gated drop path (supports_top_k=false ->
-     warn_capability_drop) is covered by the Provider_d-compat tests in
-     backend_provider_d.ml; Ollama uses the same gate via shared helpers. *)
+     warn_capability_drop) is covered by the Chat_completions_v1-compat tests in
+     backend_chat_completions_v1.ml; Ollama uses the same gate via shared helpers. *)
   with_keep_alive_env "" (fun () ->
     let config =
       Provider_config.make

--- a/lib/llm_provider/backend_provider_f.mli
+++ b/lib/llm_provider/backend_provider_f.mli
@@ -1,7 +1,7 @@
 (** Gemini native API request building and response parsing.
 
     Uses the Gemini [contents/parts] wire format instead of the
-    Provider_d-compatible [/chat/completions] wrapper.  Enables native
+    Chat_completions_v1-compatible [/chat/completions] wrapper.  Enables native
     thinking (thinkingConfig), function calling, and multimodal input.
 
     Pure functions operating on {!Llm_provider.Types}.

--- a/lib/llm_provider/backend_provider_k.ml
+++ b/lib/llm_provider/backend_provider_k.ml
@@ -1,6 +1,6 @@
 (** ZhipuAI Glm native backend.
 
-    Provider_d wire format with Glm-specific extensions:
+    Chat_completions_v1 wire format with Glm-specific extensions:
     - [thinking] parameter: [{"type":"enabled","clear_thinking":true}]
     - [reasoning_content] in response message and streaming delta
     - String error codes (e.g., ["1305"])
@@ -96,7 +96,9 @@ let build_request
       ?(tools : Yojson.Safe.t list = [])
       ()
   =
-  let base_body = Backend_provider_d.build_request ~stream ~config ~messages ~tools () in
+  let base_body =
+    Backend_chat_completions_v1.build_request ~stream ~config ~messages ~tools ()
+  in
   match Yojson.Safe.from_string base_body with
   | `Assoc fields ->
     let fields =
@@ -125,7 +127,7 @@ let build_request
 
 (** Glm error responses use string error codes:
     [{"error":{"code":"1305","message":"..."}}]
-    Standard Provider_d uses numeric HTTP codes. *)
+    Standard Chat_completions_v1 uses numeric HTTP codes. *)
 let check_glm_error body : provider_k_error option =
   try
     let json = Yojson.Safe.from_string body in
@@ -186,7 +188,9 @@ let parse_response body =
   | Some err -> raise (Glm_api_error err)
   | None ->
     (try
-       match Backend_provider_d_parse.parse_provider_d_response_result body with
+       match
+         Backend_chat_completions_v1_parse.parse_chat_completions_v1_response_result body
+       with
        | Error msg -> raise (provider_k_parse_error msg)
        | Ok resp -> extract_reasoning_content resp body
      with
@@ -197,10 +201,10 @@ let parse_response body =
 
 (* ── Streaming ───────────────────────────────────── *)
 
-(** Parse Glm SSE chunk.  Glm uses Provider_d SSE format but adds
+(** Parse Glm SSE chunk.  Glm uses Chat_completions_v1 SSE format but adds
     [delta.reasoning_content] for thinking. We parse this as
-    [delta_reasoning] in the provider_d_chunk type. *)
-let parse_stream_chunk = Streaming.parse_provider_d_sse_chunk
+    [delta_reasoning] in the chat_completions_v1_chunk type. *)
+let parse_stream_chunk = Streaming.parse_chat_completions_v1_sse_chunk
 
 (* ── Inline tests ────────────────────────────────── *)
 
@@ -398,7 +402,7 @@ let%test "extract_reasoning_content skips empty reasoning" =
   List.length result.content = 1
 ;;
 
-let%test "parse_stream_chunk delegates to provider_d" =
+let%test "parse_stream_chunk delegates to chat_completions_v1" =
   let data = {|{"id":"x","choices":[{"delta":{"content":"hi"},"index":0}]}|} in
   match parse_stream_chunk data with
   | Some chunk -> chunk.delta_content = Some "hi"

--- a/lib/llm_provider/backend_provider_k.mli
+++ b/lib/llm_provider/backend_provider_k.mli
@@ -1,6 +1,6 @@
 (** ZhipuAI Glm native backend.
 
-    Uses Provider_d-compatible wire format with Glm-specific extensions:
+    Uses Chat_completions_v1-compatible wire format with Glm-specific extensions:
     - [thinking] parameter: [{"type":"enabled","clear_thinking":true}]
     - [reasoning_content] in response and streaming delta
     - String error codes (e.g., ["1305"])
@@ -48,7 +48,7 @@ val classify_provider_k_error
 val http_code_of_provider_k_error_class : provider_k_error_class -> int
 
 (** Build a Glm chat completion request body.
-    Delegates to {!Backend_provider_d.build_request} and injects
+    Delegates to {!Backend_chat_completions_v1.build_request} and injects
     Glm-specific [thinking] parameter when [enable_thinking] is set. *)
 val build_request
   :  ?stream:bool
@@ -68,5 +68,5 @@ val parse_response : string -> api_response
 val extract_reasoning_content : api_response -> string -> api_response
 
 (** Parse a Glm SSE streaming chunk.
-    Delegates to {!Streaming.parse_provider_d_sse_chunk}. *)
-val parse_stream_chunk : string -> Streaming.provider_d_chunk option
+    Delegates to {!Streaming.parse_chat_completions_v1_sse_chunk}. *)
+val parse_stream_chunk : string -> Streaming.chat_completions_v1_chunk option

--- a/lib/llm_provider/backend_tool_call_harness.ml
+++ b/lib/llm_provider/backend_tool_call_harness.ml
@@ -204,7 +204,7 @@ let is_dropped_content_block = function
 ;;
 
 (** Extract parameter schema from a tool definition JSON.
-    Handles both "input_schema" (Anthropic) and "parameters" (Provider_d). *)
+    Handles both "input_schema" (Anthropic) and "parameters" (Chat_completions_v1). *)
 let extract_tool_schema (tool_def : Yojson.Safe.t) : Yojson.Safe.t option =
   let open Yojson.Safe.Util in
   match schema_if_present (tool_def |> member "input_schema") with
@@ -213,7 +213,7 @@ let extract_tool_schema (tool_def : Yojson.Safe.t) : Yojson.Safe.t option =
     (match schema_if_present (tool_def |> member "parameters") with
      | Some schema -> Some schema
      | None ->
-       (* Provider_d wraps in "function" *)
+       (* Chat_completions_v1 wraps in "function" *)
        (match tool_def |> member "function" with
         | `Assoc func -> schema_if_present (`Assoc func |> member "parameters")
         | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None))
@@ -333,16 +333,18 @@ let validate_provider_f_response ~declared_tools json =
   validate_response ~declared_tools (Backend_provider_f.parse_response json)
 ;;
 
-let validate_provider_d_response ~declared_tools json =
+let validate_chat_completions_v1_response ~declared_tools json =
   let json_str = Yojson.Safe.to_string json in
   let parsed =
-    try Backend_provider_d_parse.parse_provider_d_response_result json_str with
+    try
+      Backend_chat_completions_v1_parse.parse_chat_completions_v1_response_result json_str
+    with
     | exn -> Error (Printexc.to_string exn)
   in
   match parsed with
   | Ok resp -> Ok (validate_response ~declared_tools resp)
   | Error response_parse_error ->
-    Error { response_backend = "provider_d"; response_parse_error }
+    Error { response_backend = "chat_completions_v1"; response_parse_error }
 ;;
 
 (* ── Inline Tests ─────────────────────────────────────── *)
@@ -436,7 +438,7 @@ let%test "provider_f functionCall response validates correctly" =
   && List.length result.tool_calls_found = 1
 ;;
 
-let%test "provider_d tool_calls response validates correctly" =
+let%test "chat_completions_v1 tool_calls response validates correctly" =
   let json =
     `Assoc
       [ "id", `String "chatcmpl-123"
@@ -472,7 +474,7 @@ let%test "provider_d tool_calls response validates correctly" =
             ] )
       ]
   in
-  match validate_provider_d_response ~declared_tools:[ "read_file" ] json with
+  match validate_chat_completions_v1_response ~declared_tools:[ "read_file" ] json with
   | Error _ -> false
   | Ok result ->
     result.stop_reason_correct

--- a/lib/llm_provider/backend_tool_call_harness.mli
+++ b/lib/llm_provider/backend_tool_call_harness.mli
@@ -40,8 +40,8 @@ type response_parse_error =
 (** {1 Schema extraction} *)
 
 (** Extract parameter schema from a tool definition JSON.
-    Handles "input_schema" (Anthropic), "parameters" (Provider_d),
-    and "function.parameters" (Provider_d nested). *)
+    Handles "input_schema" (Anthropic), "parameters" (Chat_completions_v1),
+    and "function.parameters" (Chat_completions_v1 nested). *)
 val extract_tool_schema : Yojson.Safe.t -> Yojson.Safe.t option
 
 (** Build a name→schema map from a list of tool definition JSONs. *)
@@ -81,7 +81,7 @@ val validate_provider_f_response
   -> Yojson.Safe.t
   -> validation_result
 
-val validate_provider_d_response
+val validate_chat_completions_v1_response
   :  declared_tools:string list
   -> Yojson.Safe.t
   -> (validation_result, response_parse_error) result

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -7,7 +7,7 @@
     @since 0.42.0
     @since 0.72.0 — added numeric limits, parallel tool calls, thinking split *)
 
-(** Wire-format for controlling thinking/reasoning on Provider_d-compat backends.
+(** Wire-format for controlling thinking/reasoning on Chat_completions_v1-compat backends.
     Different model families use different JSON shapes to enable/disable
     thinking, so the runtime must know which format to emit.
 
@@ -21,11 +21,11 @@ type thinking_control_format =
   | Chat_template_kwargs
   (** llama-server style: {"chat_template_kwargs":{"enable_thinking":b}} *)
   | Reasoning_effort
-  (** Provider_d-style top-level [reasoning_effort] string field. The set of
+  (** Chat_completions_v1-style top-level [reasoning_effort] string field. The set of
       values this codebase emits is [{"none","low","medium","high"}] —
-      see {!Provider_config.effort_of_thinking_config}. (Provider_d's spec
+      see {!Provider_config.effort_of_thinking_config}. (Chat_completions_v1's spec
       also accepts ["minimal"], but no current OAS request builder emits
-      it.) Ollama's Provider_d-compatible mode uses this shape. *)
+      it.) Ollama's Chat_completions_v1-compatible mode uses this shape. *)
   | Enable_thinking
   (** DashScope-style top-level [enable_thinking] bool plus optional
       [thinking_budget]. *)
@@ -45,10 +45,10 @@ type capabilities =
   ; supports_extended_thinking : bool (** budget_tokens / reasoning_effort *)
   ; supports_reasoning_budget : bool (** Controllable reasoning depth *)
   ; thinking_control_format : thinking_control_format
-    (** Wire-format for thinking control on Provider_d-compat backends.
+    (** Wire-format for thinking control on Chat_completions_v1-compat backends.
         Determines which JSON shape the backend emits for enable_thinking.
         Only meaningful when [supports_reasoning] or [supports_extended_thinking]
-        is true and the request goes through backend_provider_d.
+        is true and the request goes through backend_chat_completions_v1.
         @since 0.184.0 *)
   ; (* ── Output format ─────────────────────────────────── *)
     supports_response_format_json : bool (** JSON mode *)
@@ -76,7 +76,7 @@ type capabilities =
     (** Whether the provider respects [seed] deterministically when
       image inputs are present.  Local providers (Ollama, llama-server)
       achieve near-perfect determinism on identical hardware; cloud
-      providers (Provider_d, Gemini) do not guarantee deterministic output
+      providers (Chat_completions_v1, Gemini) do not guarantee deterministic output
       when images are in the prompt. *)
   ; (* ── Advanced modalities ───────────────────────────── *)
     supports_computer_use : bool
@@ -155,8 +155,8 @@ let anthropic_capabilities =
      subsequent token", docs.provider_a.com/en/api/messages body
      params). [backend_provider_a.build_request] already serializes
      [config.top_k] unconditionally when [Some]; the capability record
-     must match so cross-layer consumers (the #831 Api_provider_d gate,
-     the #830 Backend_provider_d gate, and the capability_filter passes)
+     must match so cross-layer consumers (the #831 Api_chat_completions_v1 gate,
+     the #830 Backend_chat_completions_v1 gate, and the capability_filter passes)
      do not silently drop top_k when the caller routes an Anthropic
      config through a capability-checking path. [supports_min_p]
      remains [false] — Anthropic does not accept min_p. *)
@@ -221,7 +221,7 @@ let openai_compat_chat_extended_capabilities =
   }
 ;;
 
-(* Ollama Provider_d-compat endpoint behavior on tool_choice is model-dependent
+(* Ollama Chat_completions_v1-compat endpoint behavior on tool_choice is model-dependent
    (docs.ollama.com/capabilities/tool-calling: the parameter is silently
    ignored for some models). Some DashScope_3.5 deployments w/ native Jinja
    chat template do honor tool_choice:required in practice.
@@ -243,7 +243,7 @@ let openai_compat_chat_extended_capabilities =
    static-table approach, which requires JSON edits + redeploy to
    flip capability, and avoids the fragile model_id pattern match that
    the Agent_llm_a Agent SDK sidesteps by being single-provider. *)
-(* NVIDIA NIM Provider_l: Llama-based Provider_d-compatible endpoint.
+(* NVIDIA NIM Provider_l: Llama-based Chat_completions_v1-compatible endpoint.
    Thinking uses chat_template_kwargs (same wire format as Ollama's
    llama-server backend). VL variants add image input.
    Ref: build.nvidia.com/nvidia docs, Provider_l model cards. *)
@@ -297,7 +297,7 @@ let glm_capabilities =
   ; (* Z.AI's current official docs describe JSON mode via
      response_format={"type":"json_object"} plus prompt/schema-in-text
      guidance, but do not document a native JSON-schema request field
-     equivalent to Provider_d's json_schema response_format. OAS therefore
+     equivalent to Chat_completions_v1's json_schema response_format. OAS therefore
      treats Glm as JSON-mode-only: supports_response_format_json=true
      but supports_structured_output=false. validate_output_schema_request
      rejects output_schema for Glm configs to prevent silent pass-through
@@ -373,7 +373,7 @@ let gemini_capabilities =
      [backend_provider_f.build_request] serializer already emits it at
      lib/llm_provider/backend_provider_f.ml:162-164, so the capability
      record must match. Same discrepancy story as anthropic_capabilities
-     (#832) — Provider_d-compat consumers that route a Gemini config
+     (#832) — Chat_completions_v1-compat consumers that route a Gemini config
      through a capability-checking path were silently dropping top_k.
      [supports_min_p] stays false; Gemini's generationConfig has no
      min_p field. *)
@@ -390,9 +390,9 @@ type static_model_route =
   | Agent_llm_a_opus_4
   | Agent_llm_a_sonnet_4
   | Agent_llm_a_haiku_4
-  | Provider_d_5
-  | Provider_d_4_1
-  | Provider_d_4o
+  | Chat_completions_v1_5
+  | Chat_completions_v1_4_1
+  | Chat_completions_v1_4o
   | Mimo_v2_5_chat
   | Gemini of provider_f_family
   | Kimi_for_coding
@@ -462,11 +462,11 @@ let static_model_route_of_id model_id =
   else if String.starts_with ~prefix:"agent_llm_a-haiku-4" m
   then Some Agent_llm_a_haiku_4
   else if String.starts_with ~prefix:"model-d-5" m
-  then Some Provider_d_5
+  then Some Chat_completions_v1_5
   else if String.starts_with ~prefix:"model-d-4.1" m
-  then Some Provider_d_4_1
+  then Some Chat_completions_v1_4_1
   else if String.starts_with ~prefix:"model-d" m
-  then Some Provider_d_4o
+  then Some Chat_completions_v1_4o
   else if m = "mimo-v2.5" || String.starts_with ~prefix:"mimo-v2.5-pro" m
   then Some Mimo_v2_5_chat
   else (
@@ -578,20 +578,20 @@ let capabilities_of_static_model_route = function
         max_context_tokens = Some 200_000
       ; max_output_tokens = Some 8_192
       }
-  | Provider_d_5 ->
+  | Chat_completions_v1_5 ->
     Some
       { openai_compat_chat_extended_capabilities with
         max_context_tokens = Some 1_050_000
       ; max_output_tokens = Some 128_000
       ; supports_computer_use = true
       }
-  | Provider_d_4_1 ->
+  | Chat_completions_v1_4_1 ->
     Some
       { openai_compat_chat_capabilities with
         max_context_tokens = Some 1_000_000
       ; max_output_tokens = Some 32_000
       }
-  | Provider_d_4o ->
+  | Chat_completions_v1_4o ->
     Some
       { openai_compat_chat_capabilities with
         max_context_tokens = Some 128_000
@@ -719,7 +719,7 @@ let capabilities_of_static_model_route = function
       ; supports_prompt_caching = false
       ; prompt_cache_alignment = None
       }
-    (* NVIDIA Provider_l: Llama-based, NIM Provider_d-compat API.
+    (* NVIDIA Provider_l: Llama-based, NIM Chat_completions_v1-compat API.
        Base text models (provider_l-ultra, provider_l-core) get reasoning
        but no vision. VL suffix gets image input. *)
   | Provider_l { has_vision } ->
@@ -949,9 +949,9 @@ let for_model_id_static model_id =
 let capabilities_for_provider_label label =
   match String.lowercase_ascii (String.trim label) with
   | "anthropic" | "claude" | "provider_a" -> Some anthropic_capabilities
-  | "openai_compat" | "openai" | "provider_d" | "provider_d_chat" ->
+  | "openai_compat" | "openai" | "chat_completions_v1" ->
     Some openai_compat_chat_capabilities
-  | "openai_compat_chat_extended" | "provider_d_chat_extended" ->
+  | "openai_compat_chat_extended" | "chat_completions_v1_extended" ->
     Some openai_compat_chat_extended_capabilities
   | "gemini" | "provider_f" -> Some gemini_capabilities
   | "ollama" | "ollama_cloud" -> Some ollama_capabilities
@@ -1230,9 +1230,9 @@ let%test "capabilities_for_provider_label: anthropic" =
   | None -> false
 ;;
 
-let%test "capabilities_for_provider_label: provider_d alias" =
-  Option.is_some (capabilities_for_provider_label "provider_d")
-  && Option.is_some (capabilities_for_provider_label "provider_d_chat")
+let%test "capabilities_for_provider_label: chat_completions_v1 alias" =
+  Option.is_some (capabilities_for_provider_label "chat_completions_v1")
+  && Option.is_some (capabilities_for_provider_label "openai_compat")
 ;;
 
 let%test "capabilities_for_provider_label: provider_k alias" =
@@ -1263,7 +1263,7 @@ let%test "for_model_id provider_l-vl has image input" =
 ;;
 
 let%test "for_model_id provider_h_3 has chat_template_kwargs thinking control" =
-  (* DashScope_3.x Provider_d-compatible llama.cpp/llama-server deployments return
+  (* DashScope_3.x Chat_completions_v1-compatible llama.cpp/llama-server deployments return
      [reasoning_content] when thinking is enabled through
      {"chat_template_kwargs": {"enable_thinking": bool}}.  Without this
      format, [supports_extended_thinking = true] never reaches the wire. *)
@@ -1455,7 +1455,7 @@ let%test "capabilities_for_provider_label: aliases resolve to identical capabili
     | _ -> false
   in
   let alias_pairs =
-    [ "provider_d", "provider_d_chat"; "provider_k", "provider_k-coding" ]
+    [ "chat_completions_v1", "openai_compat"; "provider_k", "provider_k-coding" ]
   in
   List.for_all (fun (a, b) -> same_base a b) alias_pairs
   && Option.is_some (resolve "provider_a")
@@ -1471,9 +1471,8 @@ let%test "capabilities_for_provider_label: aliases resolve to identical capabili
 let%test "capabilities_for_provider_label: all declared labels resolve" =
   let labels =
     [ "provider_a"
-    ; "provider_d"
-    ; "provider_d_chat"
-    ; "provider_d_chat_extended"
+    ; "chat_completions_v1"
+    ; "chat_completions_v1_extended"
     ; "provider_f"
     ; "ollama"
     ; "provider_k"

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -15,11 +15,11 @@ type thinking_control_format =
   | Chat_template_kwargs
   (** llama-server style: {"chat_template_kwargs":{"enable_thinking":b}} *)
   | Reasoning_effort
-  (** Provider_d-style top-level [reasoning_effort] string field. The set of
+  (** Chat_completions_v1-style top-level [reasoning_effort] string field. The set of
       values this codebase emits is [{"none","low","medium","high"}] —
-      see {!Provider_config.effort_of_thinking_config}. (Provider_d's spec
+      see {!Provider_config.effort_of_thinking_config}. (Chat_completions_v1's spec
       also accepts ["minimal"], but no current OAS request builder emits
-      it.) Ollama's Provider_d-compatible mode uses this shape. *)
+      it.) Ollama's Chat_completions_v1-compatible mode uses this shape. *)
   | Enable_thinking
   (** DashScope-style top-level [enable_thinking] bool plus optional
       [thinking_budget]. *)
@@ -63,7 +63,7 @@ type capabilities =
   ; supports_seed_with_images : bool
     (** Whether seed determinism is maintained when image inputs are present.
       Local providers (Ollama) achieve near-perfect reproducibility; cloud
-      providers (Provider_d, Gemini) do not guarantee it.
+      providers (Chat_completions_v1, Gemini) do not guarantee it.
       @since 0.185.0 *)
   ; (* Advanced modalities *)
     supports_computer_use : bool
@@ -123,9 +123,9 @@ type static_model_route =
   | Agent_llm_a_opus_4
   | Agent_llm_a_sonnet_4
   | Agent_llm_a_haiku_4
-  | Provider_d_5
-  | Provider_d_4_1
-  | Provider_d_4o
+  | Chat_completions_v1_5
+  | Chat_completions_v1_4_1
+  | Chat_completions_v1_4o
   | Mimo_v2_5_chat
   | Gemini of provider_f_family
   | Kimi_for_coding

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -242,13 +242,13 @@ let global () =
 let%test "of_json: valid manifest parses successfully" =
   let json =
     Yojson.Safe.from_string
-      {|{"schema_version":1,"models":[{"id_prefix":"my-llm","base":"provider_d_chat","max_context_tokens":131072,"supports_tools":true}]}|}
+      {|{"schema_version":1,"models":[{"id_prefix":"my-llm","base":"chat_completions_v1","max_context_tokens":131072,"supports_tools":true}]}|}
   in
   match of_json json with
   | Ok entries ->
     List.length entries = 1
     && (List.hd entries).id_prefix = "my-llm"
-    && (List.hd entries).base_label = Some "provider_d_chat"
+    && (List.hd entries).base_label = Some "chat_completions_v1"
     && (List.hd entries).max_context_tokens = Some 131072
     && (List.hd entries).supports_tools = Some true
   | Error _ -> false
@@ -270,7 +270,8 @@ let%test "of_json: missing schema_version returns error" =
 
 let%test "of_json: entry missing id_prefix returns error" =
   let json =
-    Yojson.Safe.from_string {|{"schema_version":1,"models":[{"base":"provider_d_chat"}]}|}
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"base":"chat_completions_v1"}]}|}
   in
   match of_json json with
   | Error _ -> true
@@ -337,7 +338,7 @@ let%test "of_json: unknown fields are ignored (forward-compat)" =
 let%test "set_global / clear_global: runtime override roundtrips" =
   let json =
     Yojson.Safe.from_string
-      {|{"schema_version":1,"models":[{"id_prefix":"runtime-override-token-9fX","base":"provider_d_chat"}]}|}
+      {|{"schema_version":1,"models":[{"id_prefix":"runtime-override-token-9fX","base":"chat_completions_v1"}]}|}
   in
   match of_json json with
   | Error _ -> false

--- a/lib/llm_provider/capability_manifest.mli
+++ b/lib/llm_provider/capability_manifest.mli
@@ -12,7 +12,7 @@
         "models": [
           {
             "id_prefix": "my-local-llama",
-            "base": "provider_d_chat",
+            "base": "chat_completions_v1",
             "max_context_tokens": 131072,
             "supports_tools": true,
             "supports_reasoning": false
@@ -38,7 +38,7 @@
     [id_prefix] is matched as a case-insensitive prefix against the
     model ID being looked up.  [base] names a provider preset from
     {!Capabilities.capabilities_for_provider_label} (e.g.
-    ["provider_d_chat"], ["provider_a"]); when absent or unrecognised the
+    ["chat_completions_v1"], ["provider_a"]); when absent or unrecognised the
     built-in [default_capabilities] is used.
 
     All other fields are optional overrides: a [None] value means
@@ -46,7 +46,7 @@
 type entry =
   { id_prefix : string
   ; base_label : string option
-    (** Provider preset label, e.g. ["provider_d_chat"] or ["provider_a"]. *)
+    (** Provider preset label, e.g. ["chat_completions_v1"] or ["provider_a"]. *)
   ; max_context_tokens : int option (** [None] = inherit from base. *)
   ; max_output_tokens : int option (** [None] = inherit from base. *)
   ; supports_tools : bool option

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -289,7 +289,7 @@ let provider_name_of_kind : Provider_config.provider_kind -> string = function
   | DashScope -> "provider_h"
   | Anthropic -> "provider_a"
   | Kimi -> "provider_c"
-  | OpenAI_compat -> "provider_d"
+  | OpenAI_compat -> "chat_completions_v1"
   | Gemini -> "provider_f"
   | Glm -> "provider_k"
 ;;
@@ -431,7 +431,7 @@ let%test "http_error_diagnostic_body preserves non-empty provider body" =
     Provider_config.make
       ~kind:Provider_config.Gemini
       ~model_id:"provider_f-3-flash-preview"
-      ~base_url:"https://generativelanguage.googleapis.com/v1beta/provider_d"
+      ~base_url:"https://generativelanguage.googleapis.com/v1beta/chat_completions_v1"
       ~api_key:"secret"
       ~headers:[]
       ~request_path:"/v1/chat/completions?api_key=secret"
@@ -452,7 +452,7 @@ let%test "http_error_diagnostic_body enriches empty provider body" =
     Provider_config.make
       ~kind:Provider_config.Gemini
       ~model_id:"provider_f-3-flash-preview"
-      ~base_url:"https://generativelanguage.googleapis.com/v1beta/provider_d"
+      ~base_url:"https://generativelanguage.googleapis.com/v1beta/chat_completions_v1"
       ~api_key:"secret"
       ~headers:[]
       ~request_path:"/v1/chat/completions?api_key=secret"
@@ -466,7 +466,7 @@ let%test "http_error_diagnostic_body enriches empty provider body" =
     ~code:404
     ~body:""
   = "empty HTTP 404 response from provider=provider_f model=provider_f-3-flash-preview \
-     base_url=https://generativelanguage.googleapis.com/v1beta/provider_d \
+     base_url=https://generativelanguage.googleapis.com/v1beta/chat_completions_v1 \
      request_path=/v1/chat/completions \
      url=https://gen.googleapis.com/v1beta/models/provider_f-3-flash-preview:generateContent"
 ;;
@@ -536,7 +536,7 @@ let complete_http
         | Provider_config.Ollama ->
           Backend_ollama.build_request ~config ~messages ~tools ()
         | Provider_config.OpenAI_compat | Provider_config.DashScope | Provider_config.Kimi
-          -> Backend_provider_d.build_request ~config ~messages ~tools ()
+          -> Backend_chat_completions_v1.build_request ~config ~messages ~tools ()
         | Provider_config.Gemini ->
           Backend_provider_f.build_request ~config ~messages ~tools ()
         | Provider_config.Glm ->
@@ -698,7 +698,9 @@ let complete_http
                 | Provider_config.DashScope
                 | Provider_config.Kimi ->
                   (match
-                     Backend_provider_d_parse.parse_provider_d_response_result body
+                     Backend_chat_completions_v1_parse
+                     .parse_chat_completions_v1_response_result
+                       body
                    with
                    | Ok resp -> Ok resp
                    | Error msg -> Error (Http_client.HttpError { code = 400; body = msg }))
@@ -1191,7 +1193,7 @@ let complete_stream_http
         | Provider_config.Anthropic ->
           Backend_provider_a.build_request ~stream:true ~config ~messages ~tools ()
         | Provider_config.Ollama ->
-          (* Native /api/chat + NDJSON. The Backend_provider_d detour was a
+          (* Native /api/chat + NDJSON. The Backend_chat_completions_v1 detour was a
            deferred work-around (#849) that dropped Ollama's
            prompt_eval_count / eval_count / *_duration fields and
            silently disabled prompt_tok_s / decode_tok_s telemetry
@@ -1199,7 +1201,13 @@ let complete_stream_http
            Streaming.parse_ollama_ndjson_chunk. *)
           Backend_ollama.build_request ~stream:true ~config ~messages ~tools ()
         | Provider_config.OpenAI_compat | Provider_config.DashScope | Provider_config.Kimi
-          -> Backend_provider_d.build_request ~stream:true ~config ~messages ~tools ()
+          ->
+          Backend_chat_completions_v1.build_request
+            ~stream:true
+            ~config
+            ~messages
+            ~tools
+            ()
         | Provider_config.Gemini ->
           Backend_provider_f.build_request ~stream:true ~config ~messages ~tools ()
         | Provider_config.Glm ->
@@ -1297,7 +1305,7 @@ let complete_stream_http
           (* RFC-OAS-020: compute TTFT from first-token capture
              (was first-chunk = ttfrc). [prefill_ms] is the gap
              between any first event and the first token; [None]
-             when they coincide (Provider_d-compat: no separable
+             when they coincide (Chat_completions_v1-compat: no separable
              prelude). *)
           let ttft_ms =
             match !first_token_at_ref with
@@ -1343,16 +1351,18 @@ let complete_stream_http
           ~f:(fun reader ->
             let body_logic () =
               let acc = Complete_stream_acc.create_stream_acc () in
-              let provider_d_state = ref None in
+              let chat_completions_v1_state = ref None in
               (* RFC-OAS-019: first_chunk_seen / chunk_counter / last_chunk_t
                  hoisted out of body_logic so publish_summary on
                  exception paths sees consistent state. *)
               let get_state () =
-                match !provider_d_state with
+                match !chat_completions_v1_state with
                 | Some s -> s
                 | None ->
-                  let s = Streaming.create_provider_d_stream_state ~provider ~model () in
-                  provider_d_state := Some s;
+                  let s =
+                    Streaming.create_chat_completions_v1_stream_state ~provider ~model ()
+                  in
+                  chat_completions_v1_state := Some s;
                   s
               in
               let dispatch (events, tel_opt) =
@@ -1478,9 +1488,13 @@ let complete_stream_http
                            | Provider_config.OpenAI_compat
                            | Provider_config.DashScope
                            | Provider_config.Kimi ->
-                             (match Streaming.parse_provider_d_sse_chunk data with
+                             (match
+                                Streaming.parse_chat_completions_v1_sse_chunk data
+                              with
                               | Some chunk ->
-                                Streaming.provider_d_chunk_to_events (get_state ()) chunk
+                                Streaming.chat_completions_v1_chunk_to_events
+                                  (get_state ())
+                                  chunk
                               | None -> [], None)
                            | Provider_config.Gemini ->
                              (match Streaming.parse_provider_f_sse_chunk data with
@@ -1490,7 +1504,9 @@ let complete_stream_http
                            | Provider_config.Glm ->
                              (match Backend_provider_k.parse_stream_chunk data with
                               | Some chunk ->
-                                Streaming.provider_d_chunk_to_events (get_state ()) chunk
+                                Streaming.chat_completions_v1_chunk_to_events
+                                  (get_state ())
+                                  chunk
                               | None -> [], None)
                            | Provider_config.Ollama ->
                              [], None (* unreachable: handled above *)
@@ -2056,7 +2072,7 @@ let%test "apply_sampling_defaults OpenAI_compat Gemini model does not set min_p"
     Provider_config.make
       ~kind:OpenAI_compat
       ~model_id:"provider_f-2.5-flash"
-      ~base_url:"https://generativelanguage.googleapis.com/v1beta/provider_d"
+      ~base_url:"https://generativelanguage.googleapis.com/v1beta/chat_completions_v1"
       ()
   in
   let applied = apply_sampling_defaults config in
@@ -2181,7 +2197,7 @@ let%test "patch_telemetry creates telemetry when None" =
     Provider_config.make
       ~kind:OpenAI_compat
       ~model_id:"model-d-4"
-      ~base_url:"https://api.provider_d.com"
+      ~base_url:"https://api.chat-completions-v1.example"
       ()
   in
   let resp =
@@ -2290,7 +2306,7 @@ let%test "patch_telemetry fills blank response model" =
     Provider_config.make
       ~kind:OpenAI_compat
       ~model_id:"model-d-5.4-mini"
-      ~base_url:"https://api.provider_d.com"
+      ~base_url:"https://api.chat-completions-v1.example"
       ()
   in
   let resp =

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -698,8 +698,7 @@ let complete_http
                 | Provider_config.DashScope
                 | Provider_config.Kimi ->
                   (match
-                     Backend_chat_completions_v1_parse
-                     .parse_chat_completions_v1_response_result
+                     Backend_chat_completions_v1_parse.parse_chat_completions_v1_response_result
                        body
                    with
                    | Ok resp -> Ok resp

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -139,13 +139,13 @@ val complete_with_retry
     Each SSE event is passed to [on_event] as it arrives.
     Returns the final assembled {!Types.api_response} after the stream ends.
 
-    Supports both Anthropic native SSE and Provider_d-compatible SSE formats,
+    Supports both Anthropic native SSE and Chat_completions_v1-compatible SSE formats,
     dispatched by {!Provider_config.t.kind}.
 
     [clock] and [stream_idle_timeout_s] together bound inter-line idle
     on every HTTP streaming path: Ollama native NDJSON
     (see {!Http_client.read_ndjson}) and the SSE format used by
-    Anthropic, Provider_d-compatible, Gemini, and Glm
+    Anthropic, Chat_completions_v1-compatible, Gemini, and Glm
     (see {!Http_client.read_sse}). The deadline resets after each
     successful line, so this does not cap total stream duration.
     SSE keepalive comments reset the deadline like any other line.

--- a/lib/llm_provider/constants.ml
+++ b/lib/llm_provider/constants.ml
@@ -70,7 +70,7 @@ module Inference_profile = struct
 end
 
 (** Fallback [max_tokens] when both caller override and model capability
-    are absent. Emitted as a required field by Provider_d-compat and Anthropic
+    are absent. Emitted as a required field by Chat_completions_v1-compat and Anthropic
     backends.
 
     16384 is a last-resort ceiling for modern high-context models. Models with
@@ -135,7 +135,7 @@ end
 (* ── Sampling ────────────────────────────────────── *)
 
 module Sampling = struct
-  (** Default min_p for Provider_d-compatible (llama.cpp) providers.
+  (** Default min_p for Chat_completions_v1-compatible (llama.cpp) providers.
       2026 llama.cpp standard: min_p = 0.05. *)
   let openai_compat_min_p = 0.05
 end

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -269,7 +269,7 @@ let apply_reasoning_effort_overlay (caps : Capabilities.capabilities)
 (** Infer capabilities from model info and server props.
     Priority: model-specific lookup > generic inference > default.
     When [uses_reasoning_effort] is [true] the endpoint speaks the
-    Provider_d-compatible reasoning_effort wire format (currently mapped from
+    Chat_completions_v1-compatible reasoning_effort wire format (currently mapped from
     Ollama-endpoint detection at the caller, but the function takes the
     behavior class — not the vendor — as input), so
     {!apply_reasoning_effort_overlay} is layered on top of the
@@ -1001,7 +1001,7 @@ let%test "infer_capabilities provider_h model gets extended" =
   && caps.supports_min_p = true
 ;;
 
-let%test "infer_capabilities unknown model gets basic provider_d" =
+let%test "infer_capabilities unknown model gets basic chat_completions_v1" =
   let models = [ { id = "my-custom-model"; owned_by = "local" } ] in
   let caps = infer_capabilities ~uses_reasoning_effort:false models None in
   caps.supports_tools = true && caps.supports_reasoning = false

--- a/lib/llm_provider/modality.mli
+++ b/lib/llm_provider/modality.mli
@@ -8,7 +8,7 @@
       place image and/or audio content before the text in your prompt.
     v}
 
-    Other models (Anthropic, Provider_d, Glm) are not sensitive to this
+    Other models (Anthropic, Chat_completions_v1, Glm) are not sensitive to this
     ordering, so the default is to preserve caller-supplied block order.
 
     @since 0.193.0 *)

--- a/lib/llm_provider/pricing.ml
+++ b/lib/llm_provider/pricing.ml
@@ -67,11 +67,11 @@ let string_contains ~needle haystack =
 (* Internal: static pricing table lookup on a pre-normalised model ID.
    Called by [pricing_for_model_opt] when no dynamic override matches.
    Anthropic cache pricing: write = 1.25x input, read = 0.1x input.
-   Newer Provider_d text models expose cached input at 0.1x input.
+   Newer Chat_completions_v1 text models expose cached input at 0.1x input.
    Local/free models keep no-op cache multipliers. *)
 let static_pricing_opt_normalized normalized =
   let provider_a_cache = 1.25, 0.1 in
-  let provider_d_cached_input = 1.0, 0.1 in
+  let chat_completions_v1_cached_input = 1.0, 0.1 in
   let no_cache = 1.0, 1.0 in
   let result =
     if string_contains ~needle:"opus-4-6" normalized
@@ -99,21 +99,21 @@ let static_pricing_opt_normalized normalized =
       || string_contains ~needle:"cc:" normalized
     then
       Some ((3.0, 15.0), provider_a_cache)
-      (* Provider_d API text-token pricing, confirmed from official model docs
+      (* Chat_completions_v1 API text-token pricing, confirmed from official model docs
        2026-04-25. GPT-5.3-Agent_code-Spark is intentionally not covered here:
        its Agent_code rate card labels it research preview with non-final rates. *)
     else if string_contains ~needle:"model-d-5.3-agent_code-spark" normalized
     then None
     else if string_contains ~needle:"model-d-5.5" normalized
-    then Some ((5.0, 30.0), provider_d_cached_input)
+    then Some ((5.0, 30.0), chat_completions_v1_cached_input)
     else if string_contains ~needle:"model-d-5.4-mini" normalized
-    then Some ((0.75, 4.5), provider_d_cached_input)
+    then Some ((0.75, 4.5), chat_completions_v1_cached_input)
     else if string_contains ~needle:"model-d-5.4" normalized
-    then Some ((2.5, 15.0), provider_d_cached_input)
+    then Some ((2.5, 15.0), chat_completions_v1_cached_input)
     else if string_contains ~needle:"model-d-5.3-agent_code" normalized
-    then Some ((1.75, 14.0), provider_d_cached_input)
+    then Some ((1.75, 14.0), chat_completions_v1_cached_input)
     else if string_contains ~needle:"model-d-5.2" normalized
-    then Some ((1.75, 14.0), provider_d_cached_input)
+    then Some ((1.75, 14.0), chat_completions_v1_cached_input)
     else if string_contains ~needle:"model-d-4.1" normalized
     then Some ((2.0, 8.0), no_cache)
     else if string_contains ~needle:"model-d-mini" normalized
@@ -526,7 +526,7 @@ let%test "pricing agent_llm_a-3-7-sonnet" =
   && close_enough p.cache_write_multiplier 1.25
 ;;
 
-(* --- pricing_for_model: Provider_d models --- *)
+(* --- pricing_for_model: Chat_completions_v1 models --- *)
 
 let%test "pricing model-d-mini" =
   let p = pricing_for_model "model-d-mini" in

--- a/lib/llm_provider/provider_catalog.mli
+++ b/lib/llm_provider/provider_catalog.mli
@@ -55,7 +55,7 @@ type t = entry list
             "base_url": "http://127.0.0.1:8000",
             "request_path": "/v1/chat/completions",
             "auth": {"type": "none"},
-            "capabilities_base": "provider_d_chat",
+            "capabilities_base": "chat_completions_v1",
             "capabilities": {"supports_tools": true}
           }
         ]

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -211,7 +211,7 @@ let default_reasoning_effort () =
     When [thinking_budget] is [None] and thinking is enabled, the default
     effort is resolved from [OAS_DEFAULT_REASONING_EFFORT] env var
     (fallback: "medium").
-    Shared by Ollama backends and api_provider_d request building.
+    Shared by Ollama backends and api_chat_completions_v1 request building.
     @since 0.114.0 *)
 let effort_of_thinking_config
       ~(enable_thinking : bool option)
@@ -291,9 +291,9 @@ let structured_output_name_of_schema (schema : Yojson.Safe.t) : string =
   if trimmed = "" then default_name else trimmed
 ;;
 
-let provider_d_host_supports_output_schema base_url =
+let chat_completions_v1_host_supports_output_schema base_url =
   match Uri.of_string base_url |> Uri.host with
-  | Some host -> String.lowercase_ascii host = "api.provider_d.com"
+  | Some host -> String.lowercase_ascii host = "api.chat-completions-v1.example"
   | None -> false
 ;;
 
@@ -301,7 +301,7 @@ let provider_d_host_supports_output_schema base_url =
     Callers can build a [Provider_config.t] directly with [response_format =
     JsonSchema _] and [output_schema = None]; gating only on [output_schema]
     would let that path skip provider/host validation and still emit
-    [response_format.type=json_schema] in [backend_provider_d]. *)
+    [response_format.type=json_schema] in [backend_chat_completions_v1]. *)
 let structured_schema_requested (config : t) : bool =
   match config.output_schema, config.response_format with
   | Some _, _ -> true
@@ -331,13 +331,13 @@ let validate_output_schema_request (config : t) =
            (Printf.sprintf
               "model %s does not advertise native structured output"
               config.model_id)
-       else if provider_d_host_supports_output_schema config.base_url
+       else if chat_completions_v1_host_supports_output_schema config.base_url
        then Ok ()
        else
          Error
            (Printf.sprintf
-              "native structured output is only wired for official Provider_d hosts, got \
-               %s"
+              "native structured output is only wired for official Chat_completions_v1 \
+               hosts, got %s"
               config.base_url))
 ;;
 

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -185,7 +185,7 @@ val all_provider_kinds : provider_kind list
 (** Conventional API key env var name per kind. Re-export of
     {!Provider_kind.default_api_key_env}. Returns [None] for kinds
     that do not have a universally-agreed env var (local / transport-
-    mediated / Provider_d-compatible spaces where the env name is
+    mediated / Chat_completions_v1-compatible spaces where the env name is
     consumer-specified).
     @since 0.166.0 *)
 val default_api_key_env : provider_kind -> string option
@@ -252,7 +252,7 @@ val effort_of_thinking_config
 val reasoning_effort_of_config : t -> string option
 
 (** Derive a provider-safe schema name for native structured-output APIs
-    that require one (for example Provider_d's [json_schema.name]). *)
+    that require one (for example Chat_completions_v1's [json_schema.name]). *)
 val structured_output_name_of_schema : Yojson.Safe.t -> string
 
 (** Validate whether [output_schema] can be sent natively for this config.
@@ -262,12 +262,12 @@ val structured_output_name_of_schema : Yojson.Safe.t -> string
     before making an HTTP request.
 
     Conservative policy:
-    - [OpenAI_compat] is accepted only for official Provider_d hosts with a
+    - [OpenAI_compat] is accepted only for official Chat_completions_v1 hosts with a
       model capability record that reports [supports_structured_output].
     - [Gemini], [Anthropic], [Ollama], and [DashScope] are accepted.
       DashScope (DashScope) exposes [response_format.json_schema] on its
-      Provider_d-compatible endpoint; the field is forwarded by
-      [backend_provider_d.ml] without additional host validation.
+      Chat_completions_v1-compatible endpoint; the field is forwarded by
+      [backend_chat_completions_v1.ml] without additional host validation.
     - [Kimi] is rejected until native json_schema support is verified.
     - [Glm] is rejected: Z.AI's current official docs document JSON mode
       ([json_object]) only; [response_format.json_schema] is not listed.

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -311,7 +311,8 @@ let openrouter_defaults =
 
 let provider_i_defaults =
   { kind = OpenAI_compat
-  ; base_url = env_or_default "GROQ_BASE_URL" "https://api.provider_i.com/provider_d/v1"
+  ; base_url =
+      env_or_default "GROQ_BASE_URL" "https://api.provider_i.com/chat_completions_v1/v1"
   ; api_key_env = "GROQ_API_KEY"
   ; request_path = "/chat/completions"
   }
@@ -486,5 +487,5 @@ let provider_name_of_config (config : Provider_config.t) =
           && String.equal (String.trim entry.defaults.request_path) request_path)
       with
       | Some entry -> entry.name
-      | None -> "provider_d")
+      | None -> "chat_completions_v1")
 ;;

--- a/lib/llm_provider/provider_registry.mli
+++ b/lib/llm_provider/provider_registry.mli
@@ -69,7 +69,7 @@ val default : unit -> t
 (** Best-effort canonical provider name for a concrete provider config.
     Unlike [Provider_config.string_of_provider_kind], this keeps
     registry-level distinctions that share a wire kind but differ by
-    endpoint (for example [provider_k] vs [provider_k-coding], or [provider_d] vs
+    endpoint (for example [provider_k] vs [provider_k-coding], or [chat_completions_v1] vs
     [provider_o_router]). Falls back to a stable kind-derived label when the
     config does not match a known registry entry exactly. *)
 val provider_name_of_config : Provider_config.t -> string

--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -124,7 +124,7 @@ let malformed_json_indicators =
     - z.ai / Glm: "Insufficient balance or no resource package. Please
       recharge."
     - Anthropic: "You have insufficient credits"; "billing_hard_limit"
-    - Provider_d: "You exceeded your current quota, please check your plan
+    - Chat_completions_v1: "You exceeded your current quota, please check your plan
       and billing details"
     - Provider account-limit variants: "Your account has exceeded the
       API usage limit"
@@ -204,7 +204,7 @@ let is_hard_quota = function
 (** Extract a human-readable error message from a provider error body.
 
     Supports three common shapes:
-    - Provider_d/Anthropic style: [{"error": {"message": "...", ...}}]
+    - Chat_completions_v1/Anthropic style: [{"error": {"message": "...", ...}}]
     - Ollama/llama.cpp style: [{"error": "..."}] (error is a flat string)
     - ZAI/Glm style with nested code: [{"error": {"code": "1113", "message": "..."}}]
 
@@ -470,7 +470,7 @@ let%test "parse_context_overflow_limit: budget exceeded format" =
   parse_context_overflow_limit "input token budget exceeded: 15000 / 8192" = Some 8192
 ;;
 
-let%test "extract_error_message: nested error.message (Provider_d shape)" =
+let%test "extract_error_message: nested error.message (Chat_completions_v1 shape)" =
   extract_error_message {|{"error":{"message":"invalid tool schema","code":400}}|}
   = "invalid tool schema"
 ;;
@@ -637,7 +637,7 @@ let%test "RateLimited provider_a billing_hard_limit is NOT retryable" =
           }))
 ;;
 
-let%test "RateLimited provider_d exceeded quota is NOT retryable" =
+let%test "RateLimited chat_completions_v1 exceeded quota is NOT retryable" =
   not
     (is_retryable
        (RateLimited

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -176,40 +176,40 @@ let emit_synthetic_events (response : api_response) on_event =
   on_event MessageStop
 ;;
 
-(** {1 Provider_d-compatible SSE Streaming}
+(** {1 Chat_completions_v1-compatible SSE Streaming}
 
-    Provider_d Chat Completions streaming uses SSE with flat deltas:
+    Chat_completions_v1 Chat Completions streaming uses SSE with flat deltas:
     - Text content arrives as [delta.content] strings
     - Tool calls arrive as [delta.tool_calls] with incremental arguments
     - [finish_reason] signals end of a choice
     - No explicit content_block_start/stop events (unlike Anthropic)
 
-    We parse each SSE chunk into {!provider_d_chunk}, then convert to
-    {!sse_event} list using a stateful adapter ({!provider_d_stream_state}). *)
+    We parse each SSE chunk into {!chat_completions_v1_chunk}, then convert to
+    {!sse_event} list using a stateful adapter ({!chat_completions_v1_stream_state}). *)
 
-type provider_d_tool_call_delta =
+type chat_completions_v1_tool_call_delta =
   { tc_index : int
   ; tc_id : string option
   ; tc_name : string option
   ; tc_arguments : string option
   }
 
-type provider_d_chunk =
+type chat_completions_v1_chunk =
   { chunk_id : string
   ; chunk_model : string
   ; delta_content : string option
   ; delta_reasoning : string option
-  ; delta_tool_calls : provider_d_tool_call_delta list
+  ; delta_tool_calls : chat_completions_v1_tool_call_delta list
   ; finish_reason : string option
   ; chunk_usage : api_usage option
   }
 
-(* RFC-OAS-020: TTFT classification for Provider_d-compat / Gemini /
+(* RFC-OAS-020: TTFT classification for Chat_completions_v1-compat / Gemini /
    Ollama chunk streams. [true] when this chunk would surface a
    visible token (or tool-call argument) to the application;
    [false] for role-prelude chunks, [DONE]-only finalisers, and
    empty deltas. *)
-let chunk_has_non_empty_delta (c : provider_d_chunk) : bool =
+let chunk_has_non_empty_delta (c : chat_completions_v1_chunk) : bool =
   let non_empty_opt = function
     | Some s -> String.length s > 0
     | None -> false
@@ -219,9 +219,9 @@ let chunk_has_non_empty_delta (c : provider_d_chunk) : bool =
   || c.delta_tool_calls <> []
 ;;
 
-(** Parse a single Provider_d SSE data payload into an {!provider_d_chunk}.
+(** Parse a single Chat_completions_v1 SSE data payload into an {!chat_completions_v1_chunk}.
     Returns [None] for the "[DONE]" sentinel or unparseable data. *)
-let parse_provider_d_sse_chunk data_str : provider_d_chunk option =
+let parse_chat_completions_v1_sse_chunk data_str : chat_completions_v1_chunk option =
   if data_str = "[DONE]"
   then None
   else
@@ -289,13 +289,13 @@ let parse_provider_d_sse_chunk data_str : provider_d_chunk option =
     | Invalid_argument _ -> None
 ;;
 
-(** Mutable state for converting Provider_d flat deltas to block-based events. *)
+(** Mutable state for converting Chat_completions_v1 flat deltas to block-based events. *)
 type thinking_state =
   | Not_thinking
   | Thinking_started of float
   | Thinking_done
 
-type provider_d_stream_state =
+type chat_completions_v1_stream_state =
   { mutable thinking_block_started : bool
   ; mutable thinking_block_index : int
   ; mutable text_block_started : bool
@@ -307,7 +307,7 @@ type provider_d_stream_state =
   ; model : string
   }
 
-let create_provider_d_stream_state ?(provider = "") ?(model = "") () =
+let create_chat_completions_v1_stream_state ?(provider = "") ?(model = "") () =
   { thinking_block_started = false
   ; thinking_block_index = -1
   ; text_block_started = false
@@ -320,12 +320,12 @@ let create_provider_d_stream_state ?(provider = "") ?(model = "") () =
   }
 ;;
 
-(** Convert a parsed {!provider_d_chunk} into {!sse_event} list.
+(** Convert a parsed {!chat_completions_v1_chunk} into {!sse_event} list.
     Synthesizes [ContentBlockStart] events on first occurrence of
     text content or each new tool_call index. *)
-let provider_d_chunk_to_events
-      (state : provider_d_stream_state)
-      (chunk : provider_d_chunk)
+let chat_completions_v1_chunk_to_events
+      (state : chat_completions_v1_stream_state)
+      (chunk : chat_completions_v1_chunk)
   : sse_event list * Telemetry_event.t option
   =
   let events = ref [] in
@@ -397,7 +397,7 @@ let provider_d_chunk_to_events
    | None -> ());
   (* Tool call deltas *)
   List.iter
-    (fun (tc : provider_d_tool_call_delta) ->
+    (fun (tc : chat_completions_v1_tool_call_delta) ->
        let block_idx =
          match Hashtbl.find_opt state.tool_block_indices tc.tc_index with
          | Some idx -> idx
@@ -491,7 +491,7 @@ let parse_provider_f_sse_chunk data_str : provider_f_chunk option =
 ;;
 
 let provider_f_chunk_to_events
-      (state : provider_d_stream_state)
+      (state : chat_completions_v1_stream_state)
       (chunk : provider_f_chunk)
   : sse_event list * Telemetry_event.t option
   =
@@ -605,7 +605,7 @@ let provider_f_chunk_to_events
     line. Non-final lines carry a [message.content] delta; the final
     line has [done:true] together with [done_reason] and the four
     timing fields ([prompt_eval_count] / [prompt_eval_duration] /
-    [eval_count] / [eval_duration]) that the Provider_d compat path on
+    [eval_count] / [eval_duration]) that the Chat_completions_v1 compat path on
     [/v1/chat/completions] strips out. *)
 
 type ollama_tool_call_delta =
@@ -741,8 +741,10 @@ let parse_ollama_ndjson_chunk data_str : ollama_chunk option =
 ;;
 
 (** Convert a parsed {!ollama_chunk} into {!sse_event} list.
-    Reuses {!provider_d_stream_state} for block index tracking. *)
-let ollama_chunk_to_events (state : provider_d_stream_state) (chunk : ollama_chunk)
+    Reuses {!chat_completions_v1_stream_state} for block index tracking. *)
+let ollama_chunk_to_events
+      (state : chat_completions_v1_stream_state)
+      (chunk : ollama_chunk)
   : sse_event list * Telemetry_event.t option
   =
   let events = ref [] in
@@ -950,7 +952,7 @@ let%test "parse_ollama_ndjson_chunk: malformed json → None" =
 (* ── ollama_chunk_to_events tests ─────────────────────────── *)
 
 let%test "ollama_chunk_to_events: content delta emits Start+Delta" =
-  let state = create_provider_d_stream_state () in
+  let state = create_chat_completions_v1_stream_state () in
   let chunk =
     { oll_model = "provider_h-3:8b"
     ; oll_delta_content = Some "hello"
@@ -973,7 +975,7 @@ let%test "ollama_chunk_to_events: content delta emits Start+Delta" =
 ;;
 
 let%test "ollama_chunk_to_events: subsequent content delta reuses block" =
-  let state = create_provider_d_stream_state () in
+  let state = create_chat_completions_v1_stream_state () in
   let mk text =
     { oll_model = "provider_h-3:8b"
     ; oll_delta_content = Some text
@@ -996,7 +998,7 @@ let%test "ollama_chunk_to_events: subsequent content delta reuses block" =
 ;;
 
 let%test "ollama_chunk_to_events: done with stop_reason emits MessageDelta" =
-  let state = create_provider_d_stream_state () in
+  let state = create_chat_completions_v1_stream_state () in
   let chunk =
     { oll_model = "provider_h-3:8b"
     ; oll_delta_content = None
@@ -1025,7 +1027,7 @@ let%test "ollama_chunk_to_events: done with stop_reason emits MessageDelta" =
 ;;
 
 let%test "ollama_chunk_to_events: tool_calls emit Start+InputJsonDelta" =
-  let state = create_provider_d_stream_state () in
+  let state = create_chat_completions_v1_stream_state () in
   let chunk =
     { oll_model = "provider_h-3:8b"
     ; oll_delta_content = None
@@ -1056,7 +1058,7 @@ let%test "ollama_chunk_to_events: tool_calls emit Start+InputJsonDelta" =
 ;;
 
 let%test "ollama_chunk_to_events: thinking delta emits thinking block first" =
-  let state = create_provider_d_stream_state () in
+  let state = create_chat_completions_v1_stream_state () in
   let chunk =
     { oll_model = "provider_h-3:8b"
     ; oll_delta_content = None

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -1,4 +1,4 @@
-(** SSE event parsing for Anthropic and Provider_d streaming APIs.
+(** SSE event parsing for Anthropic and Chat_completions_v1 streaming APIs.
 
     Pure functions — no I/O or agent_sdk coupling.
 
@@ -29,21 +29,21 @@ val emit_synthetic_events : api_response -> (sse_event -> unit) -> unit
     @stability Internal *)
 val sse_event_is_first_token_signal : sse_event -> bool
 
-(** {1 Provider_d SSE} *)
+(** {1 Chat_completions_v1 SSE} *)
 
-type provider_d_tool_call_delta =
+type chat_completions_v1_tool_call_delta =
   { tc_index : int
   ; tc_id : string option
   ; tc_name : string option
   ; tc_arguments : string option
   }
 
-type provider_d_chunk =
+type chat_completions_v1_chunk =
   { chunk_id : string
   ; chunk_model : string
   ; delta_content : string option
   ; delta_reasoning : string option
-  ; delta_tool_calls : provider_d_tool_call_delta list
+  ; delta_tool_calls : chat_completions_v1_tool_call_delta list
   ; finish_reason : string option
   ; chunk_usage : api_usage option
   }
@@ -53,7 +53,7 @@ type thinking_state =
   | Thinking_started of float
   | Thinking_done
 
-type provider_d_stream_state =
+type chat_completions_v1_stream_state =
   { mutable thinking_block_started : bool
   ; mutable thinking_block_index : int
   ; mutable text_block_started : bool
@@ -65,7 +65,7 @@ type provider_d_stream_state =
   ; model : string
   }
 
-val parse_provider_d_sse_chunk : string -> provider_d_chunk option
+val parse_chat_completions_v1_sse_chunk : string -> chat_completions_v1_chunk option
 
 (** RFC-OAS-020: [true] when the chunk carries either a non-empty
     [delta_content] or a non-empty [delta_reasoning] or any
@@ -76,24 +76,24 @@ val parse_provider_d_sse_chunk : string -> provider_d_chunk option
     first real token.
 
     @stability Internal *)
-val chunk_has_non_empty_delta : provider_d_chunk -> bool
+val chunk_has_non_empty_delta : chat_completions_v1_chunk -> bool
 
-val create_provider_d_stream_state
+val create_chat_completions_v1_stream_state
   :  ?provider:string
   -> ?model:string
   -> unit
-  -> provider_d_stream_state
+  -> chat_completions_v1_stream_state
 
-val provider_d_chunk_to_events
-  :  provider_d_stream_state
-  -> provider_d_chunk
+val chat_completions_v1_chunk_to_events
+  :  chat_completions_v1_stream_state
+  -> chat_completions_v1_chunk
   -> sse_event list * Telemetry_event.t option
 
 (** {1 Gemini SSE}
 
     Gemini [streamGenerateContent?alt=sse] emits SSE chunks with
     [{candidates: [{content: {parts: [...]}}]}] structure per chunk.
-    We reuse {!provider_d_stream_state} for block tracking since the
+    We reuse {!chat_completions_v1_stream_state} for block tracking since the
     state management pattern is identical. *)
 
 type provider_f_chunk =
@@ -106,7 +106,7 @@ type provider_f_chunk =
 val parse_provider_f_sse_chunk : string -> provider_f_chunk option
 
 val provider_f_chunk_to_events
-  :  provider_d_stream_state
+  :  chat_completions_v1_stream_state
   -> provider_f_chunk
   -> sse_event list * Telemetry_event.t option
 
@@ -116,10 +116,10 @@ val provider_f_chunk_to_events
     line (newline-delimited JSON, NDJSON). The final line carries
     [done:true] together with [done_reason] and the
     [prompt_eval_count] / [prompt_eval_duration] /
-    [eval_count] / [eval_duration] timing fields that the Provider_d
+    [eval_count] / [eval_duration] timing fields that the Chat_completions_v1
     compat path on [/v1/chat/completions] strips out.
 
-    State management reuses {!provider_d_stream_state} since the block
+    State management reuses {!chat_completions_v1_stream_state} since the block
     tracking pattern is identical. Tool calls in Ollama typically
     arrive fully-formed in the [done:true] line, so the streaming
     consumer treats them as a single delta rather than incremental.
@@ -155,6 +155,6 @@ val parse_ollama_ndjson_chunk : string -> ollama_chunk option
     [done:true] chunk also emits [MessageDelta] carrying the
     stop_reason and any token-count usage. *)
 val ollama_chunk_to_events
-  :  provider_d_stream_state
+  :  chat_completions_v1_stream_state
   -> ollama_chunk
   -> sse_event list * Telemetry_event.t option

--- a/lib/llm_provider/telemetry_event.mli
+++ b/lib/llm_provider/telemetry_event.mli
@@ -61,7 +61,7 @@ type t =
             exposes a separable prefill marker
             (e.g. Anthropic [MessageStart] arrives before the first
             [ContentBlockDelta]); [None] for providers that do not
-            (e.g. Provider_d-compat first chunk is a content delta). *)
+            (e.g. Chat_completions_v1-compat first chunk is a content delta). *)
       ; total_ms : float
       ; inter_chunk_ms_p50 : float
       ; inter_chunk_ms_p95 : float

--- a/lib/llm_provider/transport_chat_completions_v1_http.ml
+++ b/lib/llm_provider/transport_chat_completions_v1_http.ml
@@ -1,4 +1,4 @@
-(** Provider_d Chat Completions HTTP transport.
+(** Chat_completions_v1 Chat Completions HTTP transport.
 
     @since 0.86.0 *)
 

--- a/lib/llm_provider/transport_chat_completions_v1_http.mli
+++ b/lib/llm_provider/transport_chat_completions_v1_http.mli
@@ -1,6 +1,6 @@
-(** Provider_d Chat Completions HTTP transport.
+(** Chat_completions_v1 Chat Completions HTTP transport.
 
-    Implements {!Llm_transport.t} for any Provider_d-compatible API endpoint:
+    Implements {!Llm_transport.t} for any Chat_completions_v1-compatible API endpoint:
     llama-server, Glm, Provider_o_router, vLLM, Ollama, LiteLLM, etc.
 
     Thin wrapper around the HTTP completion pipeline in {!Complete}.
@@ -12,7 +12,7 @@
     @stability Internal
     @since 0.93.1 *)
 
-(** Configuration for an Provider_d-compatible endpoint. *)
+(** Configuration for an Chat_completions_v1-compatible endpoint. *)
 type config =
   { base_url : string (** Base URL (e.g. {!Constants.Endpoints.default_url}). *)
   ; api_key : string (** API key. Empty string when no auth is needed (local servers). *)
@@ -28,10 +28,10 @@ type config =
 (** Default config for local llama-server on port 8085. *)
 val default_config : config
 
-(** Create an Provider_d-compatible HTTP transport.
+(** Create an Chat_completions_v1-compatible HTTP transport.
 
     The returned {!Llm_transport.t} sends requests to the configured
-    endpoint using the Provider_d Chat Completions wire format.
+    endpoint using the Chat_completions_v1 Chat Completions wire format.
 
     Per-request overrides from {!Llm_transport.completion_request.config}
     (temperature, system_prompt, tools, etc.) are respected. The

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -179,7 +179,7 @@ type tool_choice =
   | Auto
   | Any
   | Tool of string
-  | None_ (** Disables tool use. Anthropic: {type:none}, Provider_d: "none" *)
+  | None_ (** Disables tool use. Anthropic: {type:none}, Chat_completions_v1: "none" *)
 [@@deriving show]
 
 let tool_choice_to_json = function

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -47,7 +47,7 @@ type model_spec =
   ; capabilities : capabilities
   }
 
-(** Check if a model needs extended Provider_d capabilities
+(** Check if a model needs extended Chat_completions_v1 capabilities
     (reasoning, top_k, min_p). Currently triggers on provider_h family models. *)
 let needs_extended_capabilities model_id =
   let normalized = String.lowercase_ascii (String.trim model_id) in
@@ -280,8 +280,8 @@ let capabilities_for_model ~(provider : provider) ~(model_id : string) =
      | Some caps -> caps
      | None -> anthropic_capabilities)
   | Local _ ->
-    (* Local (llama-server) uses Provider_d-compatible API.
-         Resolve capabilities by model_id, fall back to provider_d_chat. *)
+    (* Local (llama-server) uses Chat_completions_v1-compatible API.
+         Resolve capabilities by model_id, fall back to chat_completions_v1. *)
     (match Llm_provider.Capabilities.for_model_id model_id with
      | Some caps -> caps
      | None -> openai_compat_chat_capabilities)
@@ -499,10 +499,10 @@ let zero_pricing =
 let pricing_for_model_opt model_id =
   let normalized = String.lowercase_ascii (String.trim model_id) in
   (* Anthropic cache pricing: write = 1.25x input, read = 0.1x input.
-     Newer Provider_d text models expose cached input at 0.1x input.
+     Newer Chat_completions_v1 text models expose cached input at 0.1x input.
      Local/free models keep no-op cache multipliers. *)
   let provider_a_cache = 1.25, 0.1 in
-  let provider_d_cached_input = 1.0, 0.1 in
+  let chat_completions_v1_cached_input = 1.0, 0.1 in
   let no_cache = 1.0, 1.0 in
   let result =
     if Util.string_contains ~needle:"opus-4-6" normalized
@@ -518,21 +518,21 @@ let pricing_for_model_opt model_id =
     else if Util.string_contains ~needle:"agent_llm_a-3-7-sonnet" normalized
     then
       Some ((3.0, 15.0), provider_a_cache)
-      (* Provider_d API text-token pricing, confirmed from official model docs
+      (* Chat_completions_v1 API text-token pricing, confirmed from official model docs
        2026-04-25. GPT-5.3-Agent_code-Spark is intentionally not covered here:
        its Agent_code rate card labels it research preview with non-final rates. *)
     else if Util.string_contains ~needle:"model-d-5.3-agent_code-spark" normalized
     then None
     else if Util.string_contains ~needle:"model-d-5.5" normalized
-    then Some ((5.0, 30.0), provider_d_cached_input)
+    then Some ((5.0, 30.0), chat_completions_v1_cached_input)
     else if Util.string_contains ~needle:"model-d-5.4-mini" normalized
-    then Some ((0.75, 4.5), provider_d_cached_input)
+    then Some ((0.75, 4.5), chat_completions_v1_cached_input)
     else if Util.string_contains ~needle:"model-d-5.4" normalized
-    then Some ((2.5, 15.0), provider_d_cached_input)
+    then Some ((2.5, 15.0), chat_completions_v1_cached_input)
     else if Util.string_contains ~needle:"model-d-5.3-agent_code" normalized
-    then Some ((1.75, 14.0), provider_d_cached_input)
+    then Some ((1.75, 14.0), chat_completions_v1_cached_input)
     else if Util.string_contains ~needle:"model-d-5.2" normalized
-    then Some ((1.75, 14.0), provider_d_cached_input)
+    then Some ((1.75, 14.0), chat_completions_v1_cached_input)
     else if Util.string_contains ~needle:"model-d-mini" normalized
     then Some ((0.15, 0.6), no_cache)
     else if Util.string_contains ~needle:"model-d" normalized
@@ -711,7 +711,7 @@ let config_of_provider_config (pc : Llm_provider.Provider_config.t) : config =
 
     [OpenAICompat] provider collapses to [OpenAI_compat] kind — the
     legacy {!config} variant does not distinguish arbitrary
-    Provider_d-compatible endpoints from named providers carrying their
+    Chat_completions_v1-compatible endpoints from named providers carrying their
     own kind.  Callers that require kind + arbitrary URL should
     construct {!Llm_provider.Provider_config.t} directly via
     {!Llm_provider.Provider_config.make}.

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -32,7 +32,7 @@ type modality =
   | Video
   | Multimodal
 
-(** Wire-format for controlling thinking/reasoning on Provider_d-compat backends.
+(** Wire-format for controlling thinking/reasoning on Chat_completions_v1-compat backends.
 
     {b API stability note (pre-1.0).}  This type is part of the Stable
     surface but is intentionally a transparent equation of
@@ -236,7 +236,7 @@ val config_of_provider_config : Llm_provider.Provider_config.t -> config
 
     [OpenAICompat] provider collapses to [OpenAI_compat] kind: the
     legacy {!config} variant does not distinguish arbitrary
-    Provider_d-compatible endpoints from named providers carrying their own
+    Chat_completions_v1-compatible endpoints from named providers carrying their own
     kind.  Callers needing kind + arbitrary URL should construct
     {!Llm_provider.Provider_config.t} via
     {!Llm_provider.Provider_config.make} directly.

--- a/lib/provider_bridge.ml
+++ b/lib/provider_bridge.ml
@@ -55,7 +55,7 @@ let resolve_glm_coding_model_id model_id =
     for "auto"; cloud providers fall back to environment-variable defaults.
 
     Parse, don't validate: callers hand in the concrete variant so dead
-    branches ([provider_d], [provider_o_router] in the pre-typed version) cannot exist. *)
+    branches ([chat_completions_v1], [provider_o_router] in the pre-typed version) cannot exist. *)
 let resolve_auto_model_id
       ~base_url
       (kind : Llm_provider.Provider_config.provider_kind)
@@ -64,9 +64,9 @@ let resolve_auto_model_id
   let open Llm_provider.Provider_config in
   match kind with
   | Ollama | OpenAI_compat | DashScope ->
-    (* Local llama-server and Provider_d-compatible endpoints share the
+    (* Local llama-server and Chat_completions_v1-compatible endpoints share the
          "auto" -> discovery -> OLLAMA_DEFAULT_MODEL fallback. Cloud-only
-         Provider_d-compatible backends still traverse this branch. *)
+         Chat_completions_v1-compatible backends still traverse this branch. *)
     if model_id = "auto"
     then (
       match Llm_provider.Discovery.first_discovered_model_id () with

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -23,8 +23,12 @@ let retry_error_of_http_error = function
       { message = Http_client.provider_failure_to_string ~kind ~message }
 ;;
 
-let parse_provider_d_response_result body_str =
-  try Llm_provider.Backend_provider_d_parse.parse_provider_d_response_result body_str with
+let parse_chat_completions_v1_response_result body_str =
+  try
+    Llm_provider.Backend_chat_completions_v1_parse
+    .parse_chat_completions_v1_response_result
+      body_str
+  with
   | Yojson.Json_error msg | Yojson.Safe.Util.Type_error (msg, _) -> Error msg
 ;;
 
@@ -90,7 +94,7 @@ let of_config (provider_cfg : Provider.config) : provider_module =
                    ~stream:false
                    ()))
         | Provider.Openai_chat_completions ->
-          Api_provider_d.build_provider_d_body
+          Api_chat_completions_v1.build_chat_completions_v1_body
             ~provider_config:provider_cfg
             ~config
             ~messages
@@ -127,14 +131,14 @@ let of_config (provider_cfg : Provider.config) : provider_module =
          | Provider.Anthropic_messages ->
            Ok (Api_provider_a.parse_response (Yojson.Safe.from_string body_str))
          | Provider.Openai_chat_completions ->
-           (match parse_provider_d_response_result body_str with
+           (match parse_chat_completions_v1_response_result body_str with
             | Ok resp -> Ok resp
             | Error msg -> Error (Error.Api (Retry.InvalidRequest { message = msg })))
          | Provider.Custom name ->
            (match Provider.find_provider name with
             | Some impl -> Ok (impl.parse_response body_str)
             | None ->
-              (match parse_provider_d_response_result body_str with
+              (match parse_chat_completions_v1_response_result body_str with
                | Ok resp -> Ok resp
                | Error msg -> Error (Error.Api (Retry.InvalidRequest { message = msg })))))
       | Ok (code, body_str) ->
@@ -153,7 +157,7 @@ let supports_streaming (provider_cfg : Provider.config) : bool =
 ;;
 
 (** Resolve to a streaming provider if supported.
-    Returns [Some] for Anthropic and Provider_d-compatible providers. *)
+    Returns [Some] for Anthropic and Chat_completions_v1-compatible providers. *)
 let of_config_streaming (provider_cfg : Provider.config)
   : streaming_provider_module option
   =
@@ -213,7 +217,7 @@ let%test "supports_streaming OpenAICompat" =
     ; api_key_env = ""
     }
   in
-  (* Provider_d-compat providers support streaming *)
+  (* Chat_completions_v1-compat providers support streaming *)
   supports_streaming cfg
 ;;
 

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -25,8 +25,7 @@ let retry_error_of_http_error = function
 
 let parse_chat_completions_v1_response_result body_str =
   try
-    Llm_provider.Backend_chat_completions_v1_parse
-    .parse_chat_completions_v1_response_result
+    Llm_provider.Backend_chat_completions_v1_parse.parse_chat_completions_v1_response_result
       body_str
   with
   | Yojson.Json_error msg | Yojson.Safe.Util.Type_error (msg, _) -> Error msg

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -1,6 +1,6 @@
 (** SSE streaming client for multi-provider LLM APIs.
 
-    Supports Anthropic (native SSE) and Provider_d-compatible (SSE).
+    Supports Anthropic (native SSE) and Chat_completions_v1-compatible (SSE).
     Pure SSE event parsing and synthetic emission are delegated to
     {!Llm_provider.Streaming}. The HTTP streaming client remains here
     due to agent_state/Provider/Error coupling. *)
@@ -194,7 +194,7 @@ let map_http_error = function
 ;;
 
 (** Streaming variant of create_message.
-    Supports Anthropic (native SSE) and Provider_d-compatible (SSE).
+    Supports Anthropic (native SSE) and Chat_completions_v1-compatible (SSE).
     Custom providers fall back to sync + synthetic events.
 
     Does not accept retry_config: SSE streams deliver partial results
@@ -274,7 +274,7 @@ let create_message_stream
                (Retry.NetworkError
                   { message = Printf.sprintf "SSE stream error: %s" msg; kind = Unknown })))
      | Provider.Openai_chat_completions ->
-       (* Provider_d-compatible SSE streaming. *)
+       (* Chat_completions_v1-compatible SSE streaming. *)
        let headers =
          match Provider.resolve provider_cfg with
          | Ok (_, _, h) -> h
@@ -282,7 +282,7 @@ let create_message_stream
        in
        let stream_path = Provider.request_path provider_cfg.provider in
        let body =
-         Api_provider_d.build_provider_d_body
+         Api_chat_completions_v1.build_chat_completions_v1_body
            ~provider_config:provider_cfg
            ~config
            ~messages
@@ -299,7 +299,9 @@ let create_message_stream
             ~body
             ~f:(fun reader ->
               let acc = create_stream_acc () in
-              let oai_state = Llm_provider.Streaming.create_provider_d_stream_state () in
+              let oai_state =
+                Llm_provider.Streaming.create_chat_completions_v1_stream_state ()
+              in
               let msg_started = ref false in
               Llm_provider.Http_client.read_sse
                 ~reader
@@ -307,7 +309,9 @@ let create_message_stream
                   if data = "[DONE]"
                   then ()
                   else (
-                    match Llm_provider.Streaming.parse_provider_d_sse_chunk data with
+                    match
+                      Llm_provider.Streaming.parse_chat_completions_v1_sse_chunk data
+                    with
                     | None -> ()
                     | Some chunk ->
                       if not !msg_started
@@ -323,7 +327,9 @@ let create_message_stream
                         on_event evt;
                         accumulate_event acc evt);
                       let evs, _tel =
-                        Llm_provider.Streaming.provider_d_chunk_to_events oai_state chunk
+                        Llm_provider.Streaming.chat_completions_v1_chunk_to_events
+                          oai_state
+                          chunk
                       in
                       List.iter
                         (fun evt ->

--- a/lib/streaming.mli
+++ b/lib/streaming.mli
@@ -1,6 +1,6 @@
 (** SSE streaming client for multi-provider LLM APIs.
 
-    Supports Anthropic (native SSE) and Provider_d-compatible (SSE).
+    Supports Anthropic (native SSE) and Chat_completions_v1-compatible (SSE).
     Pure SSE event parsing and synthetic emission are delegated to
     {!Llm_provider.Streaming}.  The HTTP streaming client remains here
     due to agent_state/Provider/Error coupling.
@@ -53,7 +53,7 @@ val map_http_error : Llm_provider.Http_client.http_error -> Error.sdk_error
 (** {1 Streaming API Call} *)
 
 (** Create a streaming LLM message.
-    Supports Anthropic (native SSE), Provider_d-compatible (SSE),
+    Supports Anthropic (native SSE), Chat_completions_v1-compatible (SSE),
     and custom providers (sync fallback with synthetic events).
 
     Does not accept [retry_config]: SSE streams deliver partial results

--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -75,7 +75,7 @@ let extract_text_json ~(schema : _ schema) (response : api_response)
   let text =
     response
     |> Types.text_of_response
-    |> Llm_provider.Backend_provider_d.strip_json_markdown_fences
+    |> Llm_provider.Backend_chat_completions_v1.strip_json_markdown_fences
     |> String.trim
   in
   if text = ""

--- a/lib/tool_use_recovery.ml
+++ b/lib/tool_use_recovery.ml
@@ -93,9 +93,9 @@ let try_parse_json_object (s : string) : Yojson.Safe.t option =
     common tool-call shapes:
 
     - Anthropic-style: [{"name": "X", "input": {...}}]
-    - Provider_d function call: [{"name": "X", "arguments": {...}}]
+    - Chat_completions_v1 function call: [{"name": "X", "arguments": {...}}]
       where arguments may be a JSON-encoded string (double-stringified)
-    - Provider_d tool_calls wrapper: [{"tool_calls": [{"function": {...}}]}]
+    - Chat_completions_v1 tool_calls wrapper: [{"tool_calls": [{"function": {...}}]}]
     - Bare function wrapper: [{"function": {"name": ..., ...}}]
 
     Returns [None] if no recognizable shape is found. *)

--- a/lib/tool_use_recovery.mli
+++ b/lib/tool_use_recovery.mli
@@ -19,9 +19,9 @@ val find_json_object : string -> (int * int) option
 val try_parse_json_object : string -> Yojson.Safe.t option
 
 (** Match a JSON value against known tool-call shapes and extract
-    [(name, input)]. Handles Anthropic-style [{name, input}], Provider_d
+    [(name, input)]. Handles Anthropic-style [{name, input}], Chat_completions_v1
     [{name, arguments}] (including double-stringified [arguments]),
-    Provider_d [{tool_calls: [...]}] wrapper, and bare [{function: ...}]. *)
+    Chat_completions_v1 [{tool_calls: [...]}] wrapper, and bare [{function: ...}]. *)
 val extract_name_and_input : Yojson.Safe.t -> (string * Yojson.Safe.t) option
 
 (** Scan content blocks and replace recoverable Text blocks with

--- a/test/dune
+++ b/test/dune
@@ -47,7 +47,7 @@
   test_artifact_service
   test_async_agent
   test_atomic_write_race
-  test_backend_provider_d_codec
+  test_backend_chat_completions_v1_codec
   test_backend_provider_k_coverage
   test_backend_tool_call_harness
   test_backend_provider_f
@@ -193,7 +193,7 @@
   test_streaming_coverage
   test_streaming_e2e
   test_streaming_keepalive_idle
-  test_streaming_provider_d
+  test_streaming_chat_completions_v1
   test_streaming_summary
   test_structured
   test_structured_coverage
@@ -256,7 +256,7 @@
   test_artifact_service
   test_async_agent
   test_atomic_write_race
-  test_backend_provider_d_codec
+  test_backend_chat_completions_v1_codec
   test_backend_provider_k_coverage
   test_backend_tool_call_harness
   test_backend_provider_f
@@ -402,7 +402,7 @@
   test_streaming_coverage
   test_streaming_e2e
   test_streaming_keepalive_idle
-  test_streaming_provider_d
+  test_streaming_chat_completions_v1
   test_streaming_summary
   test_structured
   test_structured_coverage

--- a/test/test_agent_config_deep.ml
+++ b/test/test_agent_config_deep.ml
@@ -331,21 +331,23 @@ let test_resolve_provider_a () =
   | _ -> Alcotest.fail "expected Anthropic"
 ;;
 
-let test_resolve_provider_d () =
-  let cfg = Agent_config.resolve_provider ~model_id:"model-d-4" "provider_d" None in
+let test_resolve_chat_completions_v1 () =
+  let cfg =
+    Agent_config.resolve_provider ~model_id:"model-d-4" "chat_completions_v1" None
+  in
   match cfg.provider with
   | Provider.OpenAICompat { base_url; auth_header; _ } ->
-    Alcotest.(check string) "base_url" "https://api.provider_d.com" base_url;
+    Alcotest.(check string) "base_url" "https://api.chat-completions-v1.example" base_url;
     Alcotest.(check (option string)) "auth header" (Some "Authorization") auth_header;
     Alcotest.(check string) "api_key_env" "PROVIDER_D_API_KEY" cfg.api_key_env
   | _ -> Alcotest.fail "expected OpenAICompat"
 ;;
 
-let test_resolve_provider_d_custom_url () =
+let test_resolve_chat_completions_v1_custom_url () =
   let cfg =
     Agent_config.resolve_provider
       ~model_id:"model-d-4"
-      "provider_d"
+      "chat_completions_v1"
       (Some "http://custom:4000")
   in
   match cfg.provider with
@@ -438,7 +440,7 @@ let test_resolve_provider_g () =
 ;;
 
 let test_resolve_provider_f_preserves_kind () =
-  (* Regression for #1003: registered providers with non-Provider_d kind
+  (* Regression for #1003: registered providers with non-Chat_completions_v1 kind
      (e.g. Gemini) must route through Custom_registered so downstream
      preserves entry.defaults.kind. Previously resolve_provider
      returned OpenAICompat, flattening kind to OpenAI_compat and
@@ -465,8 +467,8 @@ let test_resolve_openai_compat_ssot () =
   match cfg.provider with
   | Provider.OpenAICompat { base_url; _ } ->
     Alcotest.(check string)
-      "canonical form reaches provider_d branch"
-      "https://api.provider_d.com"
+      "canonical form reaches chat_completions_v1 branch"
+      "https://api.chat-completions-v1.example"
       base_url;
     Alcotest.(check string)
       "api_key_env is PROVIDER_D_API_KEY"
@@ -628,8 +630,8 @@ let () =
       , [ tc "local" test_resolve_local
         ; tc "local custom url" test_resolve_local_custom_url
         ; tc "provider_a" test_resolve_provider_a
-        ; tc "provider_d" test_resolve_provider_d
-        ; tc "provider_d custom url" test_resolve_provider_d_custom_url
+        ; tc "chat_completions_v1" test_resolve_chat_completions_v1
+        ; tc "chat_completions_v1 custom url" test_resolve_chat_completions_v1_custom_url
         ; tc "other" test_resolve_other
         ; tc "other custom url" test_resolve_other_custom_url
         ; tc "other OpenAI /v1 base url" test_resolve_other_openai_v1_base_url

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -8,8 +8,8 @@ open Alcotest
 
 (* ── Mock server: stateful, multi-response ──────────── *)
 
-(* Provider_d Chat Completions format — Local provider routes through this since PR #308 *)
-let provider_d_text_response ?(id = "chatcmpl-1") text =
+(* Chat_completions_v1 Chat Completions format — Local provider routes through this since PR #308 *)
+let chat_completions_v1_text_response ?(id = "chatcmpl-1") text =
   Printf.sprintf
     {|{"id":"%s","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}|}
     id
@@ -43,7 +43,7 @@ let contains_substring ~needle haystack =
   loop 0
 ;;
 
-let provider_d_tool_use_response tool_name input_json =
+let chat_completions_v1_tool_use_response tool_name input_json =
   Printf.sprintf
     {|{"id":"chatcmpl-t","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"%s","arguments":"%s"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":15,"completion_tokens":10,"total_tokens":25}}|}
     tool_name
@@ -160,7 +160,7 @@ let test_agent_run_simple () =
         ~sw
         ~net:env#net
         ~port:20001
-        [ provider_d_text_response "hello pipeline" ]
+        [ chat_completions_v1_text_response "hello pipeline" ]
     in
     let agent = make_agent ~net:env#net url in
     match Agent.run ~sw agent "test prompt" with
@@ -182,9 +182,9 @@ let test_agent_run_tool_use () =
     @@ fun sw ->
     let responses =
       [ (* Turn 1: model calls a tool *)
-        provider_d_tool_use_response "get_time" {|{"timezone": "UTC"}|}
+        chat_completions_v1_tool_use_response "get_time" {|{"timezone": "UTC"}|}
       ; (* Turn 2: model responds with text after tool result *)
-        provider_d_text_response "The time is 12:00 UTC"
+        chat_completions_v1_text_response "The time is 12:00 UTC"
       ]
     in
     let url = start_multi_mock ~sw ~net:env#net ~port:20002 responses in
@@ -223,7 +223,7 @@ let test_agent_run_requires_tool_use_when_tool_choice_is_any () =
         ~sw
         ~net:env#net
         ~port:20013
-        [ provider_d_text_response "I ignored the tool requirement" ]
+        [ chat_completions_v1_text_response "I ignored the tool requirement" ]
     in
     let time_tool =
       Tool.create
@@ -268,9 +268,9 @@ let test_agent_run_missing_required_tool_use_retry_success () =
     Eio.Switch.run
     @@ fun sw ->
     let responses =
-      [ provider_d_text_response "I ignored the tool requirement"
-      ; provider_d_tool_use_response "get_time" {|{"timezone": "UTC"}|}
-      ; provider_d_text_response "The time is 12:00 UTC"
+      [ chat_completions_v1_text_response "I ignored the tool requirement"
+      ; chat_completions_v1_tool_use_response "get_time" {|{"timezone": "UTC"}|}
+      ; chat_completions_v1_text_response "The time is 12:00 UTC"
       ]
     in
     let url = start_multi_mock ~sw ~net:env#net ~port:20016 responses in
@@ -313,9 +313,9 @@ let test_agent_run_missing_specific_tool_retry_success () =
     Eio.Switch.run
     @@ fun sw ->
     let responses =
-      [ provider_d_text_response "I ignored the specific tool requirement"
-      ; provider_d_tool_use_response "get_time" {|{}|}
-      ; provider_d_text_response "The time is 12:00 UTC"
+      [ chat_completions_v1_text_response "I ignored the specific tool requirement"
+      ; chat_completions_v1_tool_use_response "get_time" {|{}|}
+      ; chat_completions_v1_text_response "The time is 12:00 UTC"
       ]
     in
     let url = start_multi_mock ~sw ~net:env#net ~port:20017 responses in
@@ -355,7 +355,7 @@ let test_agent_run_missing_required_tool_use_retry_exhausted () =
         ~sw
         ~net:env#net
         ~port:20018
-        [ provider_d_text_response "still no tool" ]
+        [ chat_completions_v1_text_response "still no tool" ]
     in
     let time_tool =
       Tool.create
@@ -395,9 +395,9 @@ let test_agent_run_missing_required_tool_use_does_not_retry_on_relaxed_provider 
     Eio.Switch.run
     @@ fun sw ->
     let responses =
-      [ provider_d_text_response "I ignored the relaxed tool_choice"
-      ; provider_d_tool_use_response "get_time" {|{"timezone": "UTC"}|}
-      ; provider_d_text_response "The time is 12:00 UTC"
+      [ chat_completions_v1_text_response "I ignored the relaxed tool_choice"
+      ; chat_completions_v1_tool_use_response "get_time" {|{"timezone": "UTC"}|}
+      ; chat_completions_v1_text_response "The time is 12:00 UTC"
       ]
     in
     let url = start_multi_mock ~sw ~net:env#net ~port:20019 responses in
@@ -449,7 +449,7 @@ let test_agent_run_requires_specific_tool_when_tool_choice_is_tool () =
         ~sw
         ~net:env#net
         ~port:20014
-        [ provider_d_tool_use_response "other_tool" {|{}|} ]
+        [ chat_completions_v1_tool_use_response "other_tool" {|{}|} ]
     in
     let requested_tool =
       Tool.create
@@ -507,7 +507,7 @@ let test_agent_run_rejects_any_tool_choice_when_no_tools_visible () =
         ~sw
         ~net:env#net
         ~port:20121
-        [ provider_d_text_response "should not be requested" ]
+        [ chat_completions_v1_text_response "should not be requested" ]
     in
     let agent = make_agent ~net:env#net ~tools:[] ~tool_choice:Types.Any url in
     match Agent.run ~sw agent "use any available tool" with
@@ -540,7 +540,7 @@ let test_agent_run_accepts_any_tool_choice_when_only_runtime_mcp_tools_visible (
         ~sw
         ~net:env#net
         ~port:20131
-        [ provider_d_text_response "should reach provider" ]
+        [ chat_completions_v1_text_response "should reach provider" ]
     in
     let agent =
       make_agent
@@ -581,7 +581,7 @@ let test_agent_run_rejects_specific_tool_choice_when_tool_hidden () =
         ~sw
         ~net:env#net
         ~port:20122
-        [ provider_d_tool_use_response "get_time" {|{}|} ]
+        [ chat_completions_v1_tool_use_response "get_time" {|{}|} ]
     in
     let time_tool =
       Tool.create
@@ -632,7 +632,7 @@ let test_agent_run_rejects_tool_use_when_tool_choice_is_none () =
         ~sw
         ~net:env#net
         ~port:20015
-        [ provider_d_tool_use_response "other_tool" {|{}|} ]
+        [ chat_completions_v1_tool_use_response "other_tool" {|{}|} ]
     in
     let other_tool =
       Tool.create
@@ -670,7 +670,7 @@ let test_agent_run_strict_required_tool_rejects_read_only_tool () =
         ~sw
         ~net:env#net
         ~port:20016
-        [ provider_d_tool_use_response "status" {|{}|} ]
+        [ chat_completions_v1_tool_use_response "status" {|{}|} ]
     in
     let status_tool =
       Tool.create
@@ -744,7 +744,7 @@ let test_agent_run_strict_specific_tool_rejects_read_only_match () =
         ~sw
         ~net:env#net
         ~port:20018
-        [ provider_d_tool_use_response "status" {|{}|} ]
+        [ chat_completions_v1_tool_use_response "status" {|{}|} ]
     in
     let status_tool =
       Tool.create
@@ -795,7 +795,7 @@ let test_agent_run_max_turns () =
         ~sw
         ~net:env#net
         ~port:20003
-        [ provider_d_tool_use_response "loop_tool" {|{}|} ]
+        [ chat_completions_v1_tool_use_response "loop_tool" {|{}|} ]
     in
     let loop_tool =
       Tool.create
@@ -826,7 +826,11 @@ let test_agent_run_with_hooks () =
     Eio.Switch.run
     @@ fun sw ->
     let url =
-      start_multi_mock ~sw ~net:env#net ~port:20004 [ provider_d_text_response "hooked" ]
+      start_multi_mock
+        ~sw
+        ~net:env#net
+        ~port:20004
+        [ chat_completions_v1_text_response "hooked" ]
     in
     let before_count = ref 0 in
     let after_count = ref 0 in
@@ -865,7 +869,11 @@ let test_agent_run_with_reducer () =
     Eio.Switch.run
     @@ fun sw ->
     let url =
-      start_multi_mock ~sw ~net:env#net ~port:20005 [ provider_d_text_response "reduced" ]
+      start_multi_mock
+        ~sw
+        ~net:env#net
+        ~port:20005
+        [ chat_completions_v1_text_response "reduced" ]
     in
     let reducer =
       Context_reducer.compose
@@ -883,7 +891,7 @@ let test_agent_run_with_reducer () =
 
 (* ── Test 6: Agent.run_stream ────────────────────────── *)
 
-let provider_d_sse text =
+let chat_completions_v1_sse text =
   Printf.sprintf
     "data: \
      {\"id\":\"chatcmpl-s1\",\"object\":\"chat.completion.chunk\",\"model\":\"mock\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"},\"finish_reason\":null}]}\n\n\
@@ -922,7 +930,11 @@ let test_agent_run_stream () =
     Eio.Switch.run
     @@ fun sw ->
     let url =
-      start_sse_mock ~sw ~net:env#net ~port:20006 (provider_d_sse "stream pipeline")
+      start_sse_mock
+        ~sw
+        ~net:env#net
+        ~port:20006
+        (chat_completions_v1_sse "stream pipeline")
     in
     let agent = make_agent ~net:env#net url in
     let events = ref [] in
@@ -947,8 +959,8 @@ let test_agent_run_tool_error () =
     Eio.Switch.run
     @@ fun sw ->
     let responses =
-      [ provider_d_tool_use_response "fail_tool" {|{}|}
-      ; provider_d_text_response "recovered from tool error"
+      [ chat_completions_v1_tool_use_response "fail_tool" {|{}|}
+      ; chat_completions_v1_text_response "recovered from tool error"
       ]
     in
     let url = start_multi_mock ~sw ~net:env#net ~port:20007 responses in
@@ -977,9 +989,9 @@ let test_agent_run_validation_retry_success () =
     Eio.Switch.run
     @@ fun sw ->
     let responses =
-      [ provider_d_tool_use_response "get_time" {|{}|}
-      ; provider_d_tool_use_response "get_time" {|{"timezone":"UTC"}|}
-      ; provider_d_text_response "The time is 12:00 UTC"
+      [ chat_completions_v1_tool_use_response "get_time" {|{}|}
+      ; chat_completions_v1_tool_use_response "get_time" {|{"timezone":"UTC"}|}
+      ; chat_completions_v1_text_response "The time is 12:00 UTC"
       ]
     in
     let url = start_multi_mock ~sw ~net:env#net ~port:20011 responses in
@@ -1027,9 +1039,9 @@ let test_agent_run_validation_retry_exhausted () =
     Eio.Switch.run
     @@ fun sw ->
     let responses =
-      [ provider_d_tool_use_response "get_time" {|{}|}
-      ; provider_d_tool_use_response "get_time" {|{}|}
-      ; provider_d_text_response "should not happen"
+      [ chat_completions_v1_tool_use_response "get_time" {|{}|}
+      ; chat_completions_v1_tool_use_response "get_time" {|{}|}
+      ; chat_completions_v1_text_response "should not happen"
       ]
     in
     let url = start_multi_mock ~sw ~net:env#net ~port:20012 responses in
@@ -1086,8 +1098,8 @@ let test_agent_run_pre_tool_hook () =
     Eio.Switch.run
     @@ fun sw ->
     let responses =
-      [ provider_d_tool_use_response "blocked_tool" {|{}|}
-      ; provider_d_text_response "after block"
+      [ chat_completions_v1_tool_use_response "blocked_tool" {|{}|}
+      ; chat_completions_v1_text_response "after block"
       ]
     in
     let url = start_multi_mock ~sw ~net:env#net ~port:20008 responses in
@@ -1186,7 +1198,9 @@ let test_agent_run_context_overflow_auto_retry_can_be_disabled () =
         ~sw
         ~net:env#net
         ~port:20020
-        [ `Bad_request, overflow_body; `OK, provider_d_text_response "should not retry" ]
+        [ `Bad_request, overflow_body
+        ; `OK, chat_completions_v1_text_response "should not retry"
+        ]
     in
     let provider : Provider.config =
       { provider = Provider.Local { base_url = url }
@@ -1267,7 +1281,11 @@ let test_agent_run_guardrails () =
     Eio.Switch.run
     @@ fun sw ->
     let url =
-      start_multi_mock ~sw ~net:env#net ~port:20010 [ provider_d_text_response "guarded" ]
+      start_multi_mock
+        ~sw
+        ~net:env#net
+        ~port:20010
+        [ chat_completions_v1_text_response "guarded" ]
     in
     let guardrails =
       { Guardrails.tool_filter = Guardrails.AllowAll; max_tool_calls_per_turn = Some 5 }
@@ -1300,7 +1318,7 @@ let test_agent_run_tiered_memory_triggers_proactive_compaction () =
         ~sw
         ~net:env#net
         ~port:20011
-        [ provider_d_text_response "compacted" ]
+        [ chat_completions_v1_text_response "compacted" ]
     in
     let provider : Provider.config =
       { provider = Provider.Local { base_url = url }

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -242,7 +242,7 @@ let test_build_body_with_tools () =
   check int "1 tool" 1 (List.length tools)
 ;;
 
-let test_build_provider_d_body_with_json_schema () =
+let test_build_chat_completions_v1_body_with_json_schema () =
   let schema =
     `Assoc
       [ "type", `String "object"
@@ -261,7 +261,8 @@ let test_build_provider_d_body_with_json_schema () =
     }
   in
   let json =
-    Api.build_provider_d_body ~config:state ~messages:[] () |> Yojson.Safe.from_string
+    Api.build_chat_completions_v1_body ~config:state ~messages:[] ()
+    |> Yojson.Safe.from_string
   in
   let open Yojson.Safe.Util in
   let response_format = json |> member "response_format" in
@@ -326,7 +327,7 @@ let test_build_body_sampling_params_omitted_when_none () =
   check bool "no min_p key" false (List.exists (fun (k, _) -> k = "min_p") assoc)
 ;;
 
-let test_build_provider_d_body_with_provider_m_sampling () =
+let test_build_chat_completions_v1_body_with_provider_m_sampling () =
   let state =
     { Types.config =
         { Types.default_config with
@@ -343,7 +344,8 @@ let test_build_provider_d_body_with_provider_m_sampling () =
     }
   in
   let json =
-    Api.build_provider_d_body ~config:state ~messages:[] () |> Yojson.Safe.from_string
+    Api.build_chat_completions_v1_body ~config:state ~messages:[] ()
+    |> Yojson.Safe.from_string
   in
   let open Yojson.Safe.Util in
   check
@@ -364,7 +366,8 @@ let test_build_provider_d_body_with_provider_m_sampling () =
     (json |> member "chat_template_kwargs" |> member "enable_thinking" |> to_bool)
 ;;
 
-let test_build_provider_d_body_omits_provider_m_only_fields_for_generic_compat () =
+let test_build_chat_completions_v1_body_omits_provider_m_only_fields_for_generic_compat ()
+  =
   let provider_config =
     Provider.provider_o_router ~model_id:"provider_a/agent_llm_a-sonnet-4-6" ()
   in
@@ -392,7 +395,7 @@ let test_build_provider_d_body_omits_provider_m_only_fields_for_generic_compat (
       ]
   in
   let json =
-    Api.build_provider_d_body
+    Api.build_chat_completions_v1_body
       ~provider_config
       ~config:state
       ~messages:[]
@@ -423,7 +426,7 @@ let test_build_provider_d_body_omits_provider_m_only_fields_for_generic_compat (
   check bool "tools preserved" true (List.mem_assoc "tools" assoc)
 ;;
 
-let test_build_provider_d_body_uses_glm_thinking_and_auto_tool_choice () =
+let test_build_chat_completions_v1_body_uses_glm_thinking_and_auto_tool_choice () =
   let provider_config =
     { Provider.provider =
         Provider.OpenAICompat
@@ -456,7 +459,7 @@ let test_build_provider_d_body_uses_glm_thinking_and_auto_tool_choice () =
       ]
   in
   let json =
-    Api.build_provider_d_body
+    Api.build_chat_completions_v1_body
       ~provider_config
       ~config:state
       ~messages:[]
@@ -479,7 +482,7 @@ let test_build_provider_d_body_uses_glm_thinking_and_auto_tool_choice () =
     (json |> member "tool_choice" |> to_string)
 ;;
 
-let test_build_provider_d_body_uses_bare_glm_thinking_and_auto_tool_choice () =
+let test_build_chat_completions_v1_body_uses_bare_glm_thinking_and_auto_tool_choice () =
   let provider_config =
     { Provider.provider =
         Provider.OpenAICompat
@@ -512,7 +515,7 @@ let test_build_provider_d_body_uses_bare_glm_thinking_and_auto_tool_choice () =
       ]
   in
   let json =
-    Api.build_provider_d_body
+    Api.build_chat_completions_v1_body
       ~provider_config
       ~config:state
       ~messages:[]
@@ -535,7 +538,7 @@ let test_build_provider_d_body_uses_bare_glm_thinking_and_auto_tool_choice () =
     (json |> member "tool_choice" |> to_string)
 ;;
 
-let test_build_provider_d_body_glm_preserves_reasoning_content () =
+let test_build_chat_completions_v1_body_glm_preserves_reasoning_content () =
   let provider_config =
     { Provider.provider =
         Provider.OpenAICompat
@@ -577,7 +580,7 @@ let test_build_provider_d_body_glm_preserves_reasoning_content () =
     }
   in
   let json =
-    Api.build_provider_d_body ~provider_config ~config:state ~messages ()
+    Api.build_chat_completions_v1_body ~provider_config ~config:state ~messages ()
     |> Yojson.Safe.from_string
   in
   let open Yojson.Safe.Util in
@@ -591,7 +594,7 @@ let test_build_provider_d_body_glm_preserves_reasoning_content () =
   check string "tool choice still auto" "auto" (json |> member "tool_choice" |> to_string)
 ;;
 
-let test_build_provider_d_body_does_not_treat_non_zai_glm_as_glm () =
+let test_build_chat_completions_v1_body_does_not_treat_non_zai_glm_as_glm () =
   let provider_config =
     { Provider.provider =
         Provider.OpenAICompat
@@ -624,7 +627,7 @@ let test_build_provider_d_body_does_not_treat_non_zai_glm_as_glm () =
       ]
   in
   let json =
-    Api.build_provider_d_body
+    Api.build_chat_completions_v1_body
       ~provider_config
       ~config:state
       ~messages:[]
@@ -649,7 +652,7 @@ let test_build_provider_d_body_does_not_treat_non_zai_glm_as_glm () =
   | _ -> fail "non-zai provider_k tool_choice should preserve named function form"
 ;;
 
-let test_build_provider_d_body_glm_tool_choice_none_omits_tools () =
+let test_build_chat_completions_v1_body_glm_tool_choice_none_omits_tools () =
   let provider_config =
     { Provider.provider =
         Provider.OpenAICompat
@@ -681,7 +684,7 @@ let test_build_provider_d_body_glm_tool_choice_none_omits_tools () =
       ]
   in
   let json =
-    Api.build_provider_d_body
+    Api.build_chat_completions_v1_body
       ~provider_config
       ~config:state
       ~messages:[]
@@ -770,7 +773,7 @@ let test_parse_response_unknown_stop () =
   | sr -> fail (Printf.sprintf "expected Unknown, got %s" (Types.show_stop_reason sr))
 ;;
 
-let test_parse_provider_d_response_strips_fenced_json () =
+let test_parse_chat_completions_v1_response_strips_fenced_json () =
   let json_str =
     {|{
     "id": "chatcmpl_test",
@@ -785,7 +788,7 @@ let test_parse_provider_d_response_strips_fenced_json () =
     }]
   }|}
   in
-  match Api.parse_provider_d_response_result json_str with
+  match Api.parse_chat_completions_v1_response_result json_str with
   | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
   | Ok resp ->
     (match resp.content with
@@ -797,7 +800,7 @@ let test_parse_provider_d_response_strips_fenced_json () =
      | _ -> Alcotest.fail "expected stripped text block")
 ;;
 
-let test_parse_provider_d_response_reasoning_content () =
+let test_parse_chat_completions_v1_response_reasoning_content () =
   let json_str =
     {|{
     "id": "chatcmpl_think",
@@ -814,7 +817,7 @@ let test_parse_provider_d_response_reasoning_content () =
     "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}
   }|}
   in
-  match Api.parse_provider_d_response_result json_str with
+  match Api.parse_chat_completions_v1_response_result json_str with
   | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
   | Ok resp ->
     check int "2 content blocks" 2 (List.length resp.content);
@@ -830,7 +833,7 @@ let test_parse_provider_d_response_reasoning_content () =
      | _ -> Alcotest.fail "expected [Thinking; Text]")
 ;;
 
-let test_parse_provider_d_response_reasoning_with_tools () =
+let test_parse_chat_completions_v1_response_reasoning_with_tools () =
   let json_str =
     {|{
     "id": "chatcmpl_think_tool",
@@ -851,7 +854,7 @@ let test_parse_provider_d_response_reasoning_with_tools () =
     }]
   }|}
   in
-  match Api.parse_provider_d_response_result json_str with
+  match Api.parse_chat_completions_v1_response_result json_str with
   | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
   | Ok resp ->
     check int "2 content blocks" 2 (List.length resp.content);
@@ -867,7 +870,7 @@ let test_parse_provider_d_response_reasoning_with_tools () =
          (Printf.sprintf "expected StopToolUse, got %s" (Types.show_stop_reason sr)))
 ;;
 
-let test_parse_provider_d_response_blank_reasoning () =
+let test_parse_chat_completions_v1_response_blank_reasoning () =
   let json_str =
     {|{
     "id": "chatcmpl_blank",
@@ -883,7 +886,7 @@ let test_parse_provider_d_response_blank_reasoning () =
     }]
   }|}
   in
-  match Api.parse_provider_d_response_result json_str with
+  match Api.parse_chat_completions_v1_response_result json_str with
   | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
   | Ok resp ->
     check int "1 content block (blank reasoning filtered)" 1 (List.length resp.content);
@@ -892,7 +895,7 @@ let test_parse_provider_d_response_blank_reasoning () =
      | _ -> Alcotest.fail "expected [Text] only, blank reasoning should be filtered")
 ;;
 
-let test_parse_provider_d_response_no_reasoning () =
+let test_parse_chat_completions_v1_response_no_reasoning () =
   let json_str =
     {|{
     "id": "chatcmpl_no_think",
@@ -907,7 +910,7 @@ let test_parse_provider_d_response_no_reasoning () =
     }]
   }|}
   in
-  match Api.parse_provider_d_response_result json_str with
+  match Api.parse_chat_completions_v1_response_result json_str with
   | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
   | Ok resp ->
     check int "1 content block" 1 (List.length resp.content);
@@ -916,7 +919,7 @@ let test_parse_provider_d_response_no_reasoning () =
      | _ -> Alcotest.fail "expected [Text]")
 ;;
 
-let test_parse_provider_d_response_ollama_reasoning () =
+let test_parse_chat_completions_v1_response_ollama_reasoning () =
   let json_str =
     {|{
     "id": "chatcmpl_ollama",
@@ -933,7 +936,7 @@ let test_parse_provider_d_response_ollama_reasoning () =
     "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}
   }|}
   in
-  match Api.parse_provider_d_response_result json_str with
+  match Api.parse_chat_completions_v1_response_result json_str with
   | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
   | Ok resp ->
     check int "2 content blocks (thinking + text)" 2 (List.length resp.content);
@@ -956,7 +959,7 @@ let test_parse_provider_d_response_ollama_reasoning () =
      | _ -> Alcotest.fail "expected [Thinking; Text]")
 ;;
 
-let test_parse_provider_d_response_reasoning_content_preferred () =
+let test_parse_chat_completions_v1_response_reasoning_content_preferred () =
   let json_str =
     {|{
     "id": "chatcmpl_both",
@@ -974,7 +977,7 @@ let test_parse_provider_d_response_reasoning_content_preferred () =
     "usage": {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10}
   }|}
   in
-  match Api.parse_provider_d_response_result json_str with
+  match Api.parse_chat_completions_v1_response_result json_str with
   | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
   | Ok resp ->
     (match resp.content with
@@ -1295,10 +1298,10 @@ let test_message_to_json_assistant () =
 ;;
 
 (* ------------------------------------------------------------------ *)
-(* provider_d_messages_of_message: multimodal user content                  *)
+(* chat_completions_v1_messages_of_message: multimodal user content                  *)
 (* ------------------------------------------------------------------ *)
 
-let test_provider_d_messages_text_only () =
+let test_chat_completions_v1_messages_text_only () =
   let msg =
     { Types.role = Types.User
     ; content = [ Types.Text "hello" ]
@@ -1307,7 +1310,7 @@ let test_provider_d_messages_text_only () =
     ; metadata = []
     }
   in
-  let msgs = Api.provider_d_messages_of_message msg in
+  let msgs = Api.chat_completions_v1_messages_of_message msg in
   check int "1 message" 1 (List.length msgs);
   let open Yojson.Safe.Util in
   let content = List.hd msgs |> member "content" in
@@ -1315,7 +1318,7 @@ let test_provider_d_messages_text_only () =
   check string "plain string" "hello" (to_string content)
 ;;
 
-let test_provider_d_messages_with_image () =
+let test_chat_completions_v1_messages_with_image () =
   let msg =
     { Types.role = Types.User
     ; content =
@@ -1328,7 +1331,7 @@ let test_provider_d_messages_with_image () =
     ; metadata = []
     }
   in
-  let msgs = Api.provider_d_messages_of_message msg in
+  let msgs = Api.chat_completions_v1_messages_of_message msg in
   check int "1 message" 1 (List.length msgs);
   let open Yojson.Safe.Util in
   let content = List.hd msgs |> member "content" |> to_list in
@@ -1340,32 +1343,32 @@ let test_provider_d_messages_with_image () =
 ;;
 
 (* ------------------------------------------------------------------ *)
-(* F1: Provider_d API error → Openai_api_error exception                    *)
+(* F1: Chat_completions_v1 API error → Openai_api_error exception                    *)
 (* ------------------------------------------------------------------ *)
 
-let test_provider_d_api_error_returns_error () =
+let test_chat_completions_v1_api_error_returns_error () =
   let error_json =
     {|{"error":{"message":"Invalid API key","type":"invalid_request_error"}}|}
   in
-  match Api.parse_provider_d_response_result error_json with
+  match Api.parse_chat_completions_v1_response_result error_json with
   | Error msg -> check string "error message" "Invalid API key" msg
   | Ok _ -> Alcotest.fail "expected Error on API error"
 ;;
 
-let test_provider_d_api_error_unknown_message () =
+let test_chat_completions_v1_api_error_unknown_message () =
   let error_json = {|{"error":{}}|} in
-  match Api.parse_provider_d_response_result error_json with
+  match Api.parse_chat_completions_v1_response_result error_json with
   | Error msg -> check string "unknown error" "Unknown API error" msg
   | Ok _ -> Alcotest.fail "expected Error on empty error"
 ;;
 
 (* ------------------------------------------------------------------ *)
-(* F2: Provider_d error returns structured Error, not exception              *)
+(* F2: Chat_completions_v1 error returns structured Error, not exception              *)
 (* ------------------------------------------------------------------ *)
 
-let test_provider_d_error_returns_result () =
+let test_chat_completions_v1_error_returns_result () =
   let error_json = {|{"error":{"message":"bad request"}}|} in
-  match Api.parse_provider_d_response_result error_json with
+  match Api.parse_chat_completions_v1_response_result error_json with
   | Error msg -> check string "error msg" "bad request" msg
   | Ok _ -> Alcotest.fail "expected Error result"
 ;;
@@ -1459,9 +1462,9 @@ let () =
         ; test_case "with tool_choice" `Quick test_build_body_with_tool_choice
         ; test_case "with tools" `Quick test_build_body_with_tools
         ; test_case
-            "provider_d json schema"
+            "chat_completions_v1 json schema"
             `Quick
-            test_build_provider_d_body_with_json_schema
+            test_build_chat_completions_v1_body_with_json_schema
         ; test_case
             "provider_a sampling params serialized"
             `Quick
@@ -1473,31 +1476,31 @@ let () =
         ; test_case
             "with provider_h sampling"
             `Quick
-            test_build_provider_d_body_with_provider_m_sampling
+            test_build_chat_completions_v1_body_with_provider_m_sampling
         ; test_case
             "generic compat omits provider_h-only fields"
             `Quick
-            test_build_provider_d_body_omits_provider_m_only_fields_for_generic_compat
+            test_build_chat_completions_v1_body_omits_provider_m_only_fields_for_generic_compat
         ; test_case
             "provider_k thinking + auto tool choice"
             `Quick
-            test_build_provider_d_body_uses_glm_thinking_and_auto_tool_choice
+            test_build_chat_completions_v1_body_uses_glm_thinking_and_auto_tool_choice
         ; test_case
             "bare glm thinking + auto tool choice"
             `Quick
-            test_build_provider_d_body_uses_bare_glm_thinking_and_auto_tool_choice
+            test_build_chat_completions_v1_body_uses_bare_glm_thinking_and_auto_tool_choice
         ; test_case
             "provider_k preserved reasoning replay"
             `Quick
-            test_build_provider_d_body_glm_preserves_reasoning_content
+            test_build_chat_completions_v1_body_glm_preserves_reasoning_content
         ; test_case
             "non-zai provider_k avoids provider_k path"
             `Quick
-            test_build_provider_d_body_does_not_treat_non_zai_glm_as_glm
+            test_build_chat_completions_v1_body_does_not_treat_non_zai_glm_as_glm
         ; test_case
             "provider_k none tool_choice omits tools"
             `Quick
-            test_build_provider_d_body_glm_tool_choice_none_omits_tools
+            test_build_chat_completions_v1_body_glm_tool_choice_none_omits_tools
         ; test_case "with cache_system_prompt" `Quick test_build_body_with_cache
         ; test_case
             "tools cache_control with flag"
@@ -1516,46 +1519,46 @@ let () =
         ; test_case
             "strip fenced json"
             `Quick
-            test_parse_provider_d_response_strips_fenced_json
+            test_parse_chat_completions_v1_response_strips_fenced_json
         ; test_case "cache tokens in usage" `Quick test_parse_response_with_cache_tokens
         ; test_case
             "reasoning_content"
             `Quick
-            test_parse_provider_d_response_reasoning_content
+            test_parse_chat_completions_v1_response_reasoning_content
         ; test_case
             "reasoning_content with tools"
             `Quick
-            test_parse_provider_d_response_reasoning_with_tools
+            test_parse_chat_completions_v1_response_reasoning_with_tools
         ; test_case
             "blank reasoning_content"
             `Quick
-            test_parse_provider_d_response_blank_reasoning
+            test_parse_chat_completions_v1_response_blank_reasoning
         ; test_case
             "no reasoning_content"
             `Quick
-            test_parse_provider_d_response_no_reasoning
+            test_parse_chat_completions_v1_response_no_reasoning
         ; test_case
             "ollama reasoning field"
             `Quick
-            test_parse_provider_d_response_ollama_reasoning
+            test_parse_chat_completions_v1_response_ollama_reasoning
         ; test_case
             "reasoning_content preferred over reasoning"
             `Quick
-            test_parse_provider_d_response_reasoning_content_preferred
+            test_parse_chat_completions_v1_response_reasoning_content_preferred
         ] )
     ; ( "error_handling"
       , [ test_case
-            "provider_d api error returns Error"
+            "chat_completions_v1 api error returns Error"
             `Quick
-            test_provider_d_api_error_returns_error
+            test_chat_completions_v1_api_error_returns_error
         ; test_case
-            "provider_d api error unknown message"
+            "chat_completions_v1 api error unknown message"
             `Quick
-            test_provider_d_api_error_unknown_message
+            test_chat_completions_v1_api_error_unknown_message
         ; test_case
-            "provider_d error returns result"
+            "chat_completions_v1 error returns result"
             `Quick
-            test_provider_d_error_returns_result
+            test_chat_completions_v1_error_returns_result
         ] )
     ; ( "parse_sse_event"
       , [ test_case "message_start" `Quick test_parse_sse_message_start
@@ -1584,9 +1587,9 @@ let () =
         ; test_case "ignores metadata" `Quick test_message_to_json_ignores_metadata
         ; test_case "assistant mixed content" `Quick test_message_to_json_assistant
         ] )
-    ; ( "provider_d_messages"
-      , [ test_case "text only user" `Quick test_provider_d_messages_text_only
-        ; test_case "user with image" `Quick test_provider_d_messages_with_image
+    ; ( "chat_completions_v1_messages"
+      , [ test_case "text only user" `Quick test_chat_completions_v1_messages_text_only
+        ; test_case "user with image" `Quick test_chat_completions_v1_messages_with_image
         ] )
     ; ( "api_common_helpers"
       , [ test_case "text_blocks_to_string" `Quick test_text_blocks_to_string

--- a/test/test_api_dispatch.ml
+++ b/test/test_api_dispatch.ml
@@ -95,9 +95,9 @@ let test_provider_a_parse_response () =
   | _ -> fail "expected single text block"
 ;;
 
-(* ── Provider_d body shape ───────────────────────────────────────── *)
+(* ── Chat_completions_v1 body shape ───────────────────────────────────────── *)
 
-let test_provider_d_body_shape () =
+let test_chat_completions_v1_body_shape () =
   let provider_config : Provider.config =
     { provider =
         OpenAICompat
@@ -111,7 +111,7 @@ let test_provider_d_body_shape () =
     }
   in
   let body_str =
-    Api.build_provider_d_body
+    Api.build_chat_completions_v1_body
       ~provider_config
       ~config:base_state
       ~messages:base_state.messages
@@ -120,13 +120,13 @@ let test_provider_d_body_shape () =
   let json = Yojson.Safe.from_string body_str in
   check bool "has model" true (json_has_key "model" json);
   check bool "has messages" true (json_has_key "messages" json);
-  (* build_provider_d_body uses config.model, not provider_config.model_id *)
+  (* build_chat_completions_v1_body uses config.model, not provider_config.model_id *)
   match json_get "model" json with
   | Some (`String "test-model") -> ()
   | _ -> fail "model should come from config"
 ;;
 
-let test_provider_d_parse_response () =
+let test_chat_completions_v1_parse_response () =
   let mock_body =
     {|{
     "id": "chatcmpl-test",
@@ -136,7 +136,7 @@ let test_provider_d_parse_response () =
       "index": 0,
       "message": {
         "role": "assistant",
-        "content": "Provider_d response"
+        "content": "Chat_completions_v1 response"
       },
       "finish_reason": "stop"
     }],
@@ -145,7 +145,7 @@ let test_provider_d_parse_response () =
   }|}
   in
   let resp =
-    match Api.parse_provider_d_response_result mock_body with
+    match Api.parse_chat_completions_v1_response_result mock_body with
     | Ok r -> r
     | Error msg -> failwith msg
   in
@@ -154,7 +154,7 @@ let test_provider_d_parse_response () =
    | Types.EndTurn -> ()
    | _ -> fail "expected EndTurn from stop");
   match resp.content with
-  | [ Types.Text "Provider_d response" ] -> ()
+  | [ Types.Text "Chat_completions_v1 response" ] -> ()
   | _ -> fail "expected single text block"
 ;;
 
@@ -168,14 +168,14 @@ let test_request_kind_routing () =
       expected
       (match Provider.request_kind provider with
        | Provider.Anthropic_messages -> "provider_a"
-       | Provider.Openai_chat_completions -> "provider_d"
+       | Provider.Openai_chat_completions -> "chat_completions_v1"
        | Provider.Custom name -> "custom:" ^ name)
   in
-  check_kind "local" "provider_d" (Provider.Local { base_url = "http://x" });
+  check_kind "local" "chat_completions_v1" (Provider.Local { base_url = "http://x" });
   check_kind "provider_a" "provider_a" Provider.Anthropic;
   check_kind
-    "provider_d"
-    "provider_d"
+    "chat_completions_v1"
+    "chat_completions_v1"
     (Provider.OpenAICompat
        { base_url = "http://x"
        ; auth_header = None
@@ -315,7 +315,7 @@ let test_cache_cost_no_cache_tokens () =
 
 let test_cache_multipliers_for_non_provider_a () =
   let pricing = Provider.pricing_for_model "model-d" in
-  (* Provider_d: no cache pricing, multipliers are 1.0 *)
+  (* Chat_completions_v1: no cache pricing, multipliers are 1.0 *)
   check (float 0.001) "no cache write discount" 1.0 pricing.cache_write_multiplier;
   check (float 0.001) "no cache read discount" 1.0 pricing.cache_read_multiplier
 ;;
@@ -330,9 +330,9 @@ let () =
         ; test_case "body stream" `Quick test_provider_a_body_stream
         ; test_case "parse response" `Quick test_provider_a_parse_response
         ] )
-    ; ( "provider_d"
-      , [ test_case "body shape" `Quick test_provider_d_body_shape
-        ; test_case "parse response" `Quick test_provider_d_parse_response
+    ; ( "chat_completions_v1"
+      , [ test_case "body shape" `Quick test_chat_completions_v1_body_shape
+        ; test_case "parse response" `Quick test_chat_completions_v1_parse_response
         ] )
     ; "routing", [ test_case "request_kind" `Quick test_request_kind_routing ]
     ; ( "pricing"

--- a/test/test_api_http_client.ml
+++ b/test/test_api_http_client.ml
@@ -1,7 +1,7 @@
 open Agent_sdk
 open Types
 
-let provider_d_response =
+let chat_completions_v1_response =
   {|{"id":"chatcmpl-legacy-api","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2}}|}
 ;;
 
@@ -39,7 +39,7 @@ let test_create_message_uses_hardened_http_client () =
     seen_content_length := Cohttp.Header.get headers "content-length";
     seen_path := Some (Uri.path (Cohttp.Request.uri req));
     ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
-    Cohttp_eio.Server.respond_string ~status:`OK ~body:provider_d_response ()
+    Cohttp_eio.Server.respond_string ~status:`OK ~body:chat_completions_v1_response ()
   in
   with_mock_server ~port:18341 handler (fun ~sw ~net ~clock ~base_url ->
     let provider : Provider.config =

--- a/test/test_backend_chat_completions_v1_codec.ml
+++ b/test/test_backend_chat_completions_v1_codec.ml
@@ -1,7 +1,7 @@
 open Llm_provider
 open Types
-module Parse = Backend_provider_d_parse
-module Serialize = Backend_provider_d_serialize
+module Parse = Backend_chat_completions_v1_parse
+module Serialize = Backend_chat_completions_v1_serialize
 
 let check_string = Alcotest.(check string)
 let check_int = Alcotest.(check int)
@@ -37,7 +37,7 @@ let response_json ?(content = `String "ok") ?(finish_reason = "stop") ?message_f
   in
   `Assoc
     [ "id", `String "chatcmpl-test"
-    ; "model", `String "provider-d-test"
+    ; "model", `String "chat-completions-v1-test"
     ; ( "choices"
       , `List
           [ `Assoc
@@ -47,14 +47,14 @@ let response_json ?(content = `String "ok") ?(finish_reason = "stop") ?message_f
 ;;
 
 let parse_ok json =
-  match Parse.parse_provider_d_response_result (Yojson.Safe.to_string json) with
+  match Parse.parse_chat_completions_v1_response_result (Yojson.Safe.to_string json) with
   | Ok response -> response
   | Error msg -> Alcotest.fail ("unexpected parse error: " ^ msg)
 ;;
 
 let test_content_parts_cover_modalities () =
   let parts =
-    Serialize.provider_d_content_parts_of_blocks
+    Serialize.chat_completions_v1_content_parts_of_blocks
       [ Text "hello"
       ; Image { media_type = "image/png"; data = "img"; source_type = "base64" }
       ; Document { media_type = "application/pdf"; data = "doc"; source_type = "base64" }
@@ -87,7 +87,7 @@ let test_content_parts_cover_modalities () =
     (member "input_audio" audio |> member "format" |> to_string)
 ;;
 
-let test_provider_d_user_messages_text_tool_and_empty () =
+let test_chat_completions_v1_user_messages_text_tool_and_empty () =
   let user =
     msg
       User
@@ -97,7 +97,7 @@ let test_provider_d_user_messages_text_tool_and_empty () =
           { tool_use_id = "call-1"; content = "42"; is_error = false; json = None }
       ]
   in
-  let messages = Serialize.provider_d_messages_of_message user in
+  let messages = Serialize.chat_completions_v1_messages_of_message user in
   check_int "user + tool messages" 2 (List.length messages);
   let user_json = List.nth messages 0 in
   check_string "user role" "user" (member "role" user_json |> to_string);
@@ -107,7 +107,7 @@ let test_provider_d_user_messages_text_tool_and_empty () =
   check_string "tool id" "call-1" (member "tool_call_id" tool_json |> to_string);
   check_string "tool content" "42" (member "content" tool_json |> to_string);
   let empty_user =
-    Serialize.provider_d_messages_of_message
+    Serialize.chat_completions_v1_messages_of_message
       (msg User [ Thinking { thinking_type = ""; content = "x" } ])
   in
   check_int "empty user drops message" 0 (List.length empty_user)
@@ -119,14 +119,17 @@ let test_user_multimodal_preserve_and_visual_first () =
     ; Image { media_type = "image/jpeg"; data = "jpeg"; source_type = "base64" }
     ]
   in
-  let provider_d =
-    Serialize.provider_d_messages_of_message (msg User content) |> only "provider_d"
+  let chat_completions_v1 =
+    Serialize.chat_completions_v1_messages_of_message (msg User content)
+    |> only "chat_completions_v1"
   in
-  let provider_d_parts = member "content" provider_d |> as_list "provider_d content" in
+  let chat_completions_v1_parts =
+    member "content" chat_completions_v1 |> as_list "chat_completions_v1 content"
+  in
   check_string
-    "provider_d preserves text first"
+    "chat_completions_v1 preserves text first"
     "text"
-    (List.nth provider_d_parts 0 |> member "type" |> to_string);
+    (List.nth chat_completions_v1_parts 0 |> member "type" |> to_string);
   let visual_first =
     Serialize.ollama_messages_of_message
       ~model_id:"model-f-gemma-4-27b-it"
@@ -140,23 +143,29 @@ let test_user_multimodal_preserve_and_visual_first () =
     (List.nth visual_parts 0 |> member "type" |> to_string)
 ;;
 
-let test_assistant_tool_calls_provider_d_ollama_and_provider_k () =
+let test_assistant_tool_calls_chat_completions_v1_ollama_and_provider_k () =
   let assistant =
     msg
       Assistant
       [ ToolUse { id = "call-1"; name = "lookup"; input = `Assoc [ "q", `String "x" ] } ]
   in
-  let provider_d =
-    Serialize.provider_d_messages_of_message assistant |> only "provider_d"
+  let chat_completions_v1 =
+    Serialize.chat_completions_v1_messages_of_message assistant
+    |> only "chat_completions_v1"
   in
-  check_string "assistant role" "assistant" (member "role" provider_d |> to_string);
-  Alcotest.(check bool)
-    "provider_d content null"
-    true
-    (member "content" provider_d = `Null);
-  let call = member "tool_calls" provider_d |> as_list "tool_calls" |> only "tool_call" in
   check_string
-    "provider_d arguments string"
+    "assistant role"
+    "assistant"
+    (member "role" chat_completions_v1 |> to_string);
+  Alcotest.(check bool)
+    "chat_completions_v1 content null"
+    true
+    (member "content" chat_completions_v1 = `Null);
+  let call =
+    member "tool_calls" chat_completions_v1 |> as_list "tool_calls" |> only "tool_call"
+  in
+  check_string
+    "chat_completions_v1 arguments string"
     {|{"q":"x"}|}
     (member "function" call |> member "arguments" |> to_string);
   let ollama = Serialize.ollama_messages_of_message assistant |> only "ollama" in
@@ -183,12 +192,13 @@ let test_assistant_tool_calls_provider_d_ollama_and_provider_k () =
 
 let test_system_and_tool_role_messages () =
   let system =
-    Serialize.provider_d_messages_of_message (msg System [ Text "sys" ]) |> only "system"
+    Serialize.chat_completions_v1_messages_of_message (msg System [ Text "sys" ])
+    |> only "system"
   in
   check_string "system role" "system" (member "role" system |> to_string);
   check_string "system content" "sys" (member "content" system |> to_string);
   let tool =
-    Serialize.provider_d_messages_of_message
+    Serialize.chat_completions_v1_messages_of_message
       (msg
          Tool
          [ ToolResult
@@ -199,7 +209,7 @@ let test_system_and_tool_role_messages () =
   check_string "tool role" "tool" (member "role" tool |> to_string);
   check_string "tool call id" "call-2" (member "tool_call_id" tool |> to_string);
   let fallback =
-    Serialize.provider_d_messages_of_message (msg Tool [ Text "plain fallback" ])
+    Serialize.chat_completions_v1_messages_of_message (msg Tool [ Text "plain fallback" ])
     |> only "fallback"
   in
   check_string "fallback role" "user" (member "role" fallback |> to_string);
@@ -264,23 +274,23 @@ let test_tool_choice_and_tool_schema_conversion () =
   check_string
     "auto"
     "\"auto\""
-    (Serialize.tool_choice_to_provider_d_json Auto |> Yojson.Safe.to_string);
+    (Serialize.tool_choice_to_chat_completions_v1_json Auto |> Yojson.Safe.to_string);
   check_string
     "required"
     "\"required\""
-    (Serialize.tool_choice_to_provider_d_json Any |> Yojson.Safe.to_string);
+    (Serialize.tool_choice_to_chat_completions_v1_json Any |> Yojson.Safe.to_string);
   check_string
     "none"
     "\"none\""
-    (Serialize.tool_choice_to_provider_d_json None_ |> Yojson.Safe.to_string);
-  let tool_choice = Serialize.tool_choice_to_provider_d_json (Tool "lookup") in
+    (Serialize.tool_choice_to_chat_completions_v1_json None_ |> Yojson.Safe.to_string);
+  let tool_choice = Serialize.tool_choice_to_chat_completions_v1_json (Tool "lookup") in
   check_string
     "tool choice name"
     "lookup"
     (member "function" tool_choice |> member "name" |> to_string);
   let schema = `Assoc [ "type", `String "object" ] in
   let with_input_schema =
-    Serialize.build_provider_d_tool_json
+    Serialize.build_chat_completions_v1_tool_json
       (`Assoc
           [ "name", `String "direct"; "description", `String "d"; "input_schema", schema ])
   in
@@ -292,7 +302,7 @@ let test_tool_choice_and_tool_schema_conversion () =
      |> member "type"
      |> to_string);
   let legacy =
-    Serialize.build_provider_d_tool_json
+    Serialize.build_chat_completions_v1_tool_json
       (`Assoc
           [ "name", `String "legacy"
           ; ( "parameters"
@@ -321,7 +331,7 @@ let test_tool_choice_and_tool_schema_conversion () =
   Alcotest.(check bool)
     "non-object passthrough"
     true
-    (Serialize.build_provider_d_tool_json passthrough = passthrough)
+    (Serialize.build_chat_completions_v1_tool_json passthrough = passthrough)
 ;;
 
 let ignored_blocks : content_block list =
@@ -337,9 +347,9 @@ let ignored_blocks : content_block list =
 
 let test_serializer_ignored_block_variants () =
   check_int
-    "provider_d tool_calls ignores non-tool blocks"
+    "chat_completions_v1 tool_calls ignores non-tool blocks"
     0
-    (Serialize.tool_calls_to_provider_d_json ignored_blocks |> List.length);
+    (Serialize.tool_calls_to_chat_completions_v1_json ignored_blocks |> List.length);
   let ollama =
     Serialize.ollama_messages_of_message (msg Assistant ignored_blocks) |> only "ollama"
   in
@@ -348,7 +358,7 @@ let test_serializer_ignored_block_variants () =
     true
     (member "tool_calls" ollama = `Null);
   let assistant =
-    Serialize.provider_d_messages_of_message (msg Assistant ignored_blocks)
+    Serialize.chat_completions_v1_messages_of_message (msg Assistant ignored_blocks)
     |> only "assistant"
   in
   check_string "assistant content is empty" "" (member "content" assistant |> to_string);
@@ -374,7 +384,7 @@ let test_serializer_ignored_block_variants () =
     ]
   in
   let tool_fallback =
-    Serialize.provider_d_messages_of_message (msg Tool tool_fallback_blocks)
+    Serialize.chat_completions_v1_messages_of_message (msg Tool tool_fallback_blocks)
     |> only "tool fallback"
   in
   check_string "tool fallback role" "user" (member "role" tool_fallback |> to_string)
@@ -421,7 +431,7 @@ let test_strip_helpers_cover_non_tool_variants () =
 
 let test_tool_schema_defaults_and_legacy_edge_params () =
   let defaulted =
-    Serialize.build_provider_d_tool_json
+    Serialize.build_chat_completions_v1_tool_json
       (`Assoc [ "name", `Int 1; "description", `Bool true ])
   in
   check_string
@@ -433,7 +443,7 @@ let test_tool_schema_defaults_and_legacy_edge_params () =
     ""
     (member "function" defaulted |> member "description" |> to_string);
   let legacy =
-    Serialize.build_provider_d_tool_json
+    Serialize.build_chat_completions_v1_tool_json
       (`Assoc
           [ "name", `String "legacy-edge"
           ; ( "parameters"
@@ -476,9 +486,9 @@ let test_strip_json_markdown_fences_variants () =
     (Parse.strip_json_markdown_fences "```\n{\"a\":1}")
 ;;
 
-let test_usage_provider_d_fallbacks () =
+let test_usage_chat_completions_v1_fallbacks () =
   let usage =
-    Parse.usage_of_provider_d_json
+    Parse.usage_of_chat_completions_v1_json
       (`Assoc
           [ ( "usage"
             , `Assoc
@@ -495,7 +505,7 @@ let test_usage_provider_d_fallbacks () =
      check_int "cache read" 4 u.cache_read_input_tokens
    | None -> Alcotest.fail "expected usage");
   let usage =
-    Parse.usage_of_provider_d_json
+    Parse.usage_of_chat_completions_v1_json
       (`Assoc
           [ ( "usage"
             , `Assoc
@@ -622,7 +632,7 @@ let test_parse_tool_calls_filters_malformed_and_sets_stop_reason () =
 
 let test_parse_error_default_message () =
   let json = `Assoc [ "error", `Assoc [] ] |> Yojson.Safe.to_string in
-  match Parse.parse_provider_d_response_result json with
+  match Parse.parse_chat_completions_v1_response_result json with
   | Error msg -> check_string "default error" "Unknown API error" msg
   | Ok _ -> Alcotest.fail "expected API error"
 ;;
@@ -648,7 +658,7 @@ let test_parse_edge_shapes_for_text_and_telemetry () =
     parse_ok
       (`Assoc
           [ "id", `String "chatcmpl-telemetry"
-          ; "model", `String "provider-d-test"
+          ; "model", `String "chat-completions-v1-test"
           ; ( "choices"
             , `List
                 [ `Assoc
@@ -678,16 +688,16 @@ let test_parse_edge_shapes_for_text_and_telemetry () =
 
 let () =
   Alcotest.run
-    "backend_provider_d_codec"
+    "backend_chat_completions_v1_codec"
     [ ( "serialize"
       , [ Alcotest.test_case
             "content parts cover modalities"
             `Quick
             test_content_parts_cover_modalities
         ; Alcotest.test_case
-            "provider_d user text/tool/empty"
+            "chat_completions_v1 user text/tool/empty"
             `Quick
-            test_provider_d_user_messages_text_tool_and_empty
+            test_chat_completions_v1_user_messages_text_tool_and_empty
         ; Alcotest.test_case
             "multimodal ordering policies"
             `Quick
@@ -695,7 +705,7 @@ let () =
         ; Alcotest.test_case
             "assistant tool calls provider variants"
             `Quick
-            test_assistant_tool_calls_provider_d_ollama_and_provider_k
+            test_assistant_tool_calls_chat_completions_v1_ollama_and_provider_k
         ; Alcotest.test_case
             "system and tool roles"
             `Quick
@@ -727,7 +737,10 @@ let () =
             "strip markdown fences variants"
             `Quick
             test_strip_json_markdown_fences_variants
-        ; Alcotest.test_case "usage fallbacks" `Quick test_usage_provider_d_fallbacks
+        ; Alcotest.test_case
+            "usage fallbacks"
+            `Quick
+            test_usage_chat_completions_v1_fallbacks
         ; Alcotest.test_case
             "text list reasoning and reported telemetry"
             `Quick

--- a/test/test_backend_provider_f.ml
+++ b/test/test_backend_provider_f.ml
@@ -438,7 +438,7 @@ let test_provider_f_stream_text () =
   match Streaming.parse_provider_f_sse_chunk data with
   | Some chunk ->
     check int "one part" 1 (List.length chunk.gem_parts);
-    let state = Streaming.create_provider_d_stream_state () in
+    let state = Streaming.create_chat_completions_v1_stream_state () in
     let events, _tel = Streaming.provider_f_chunk_to_events state chunk in
     check bool "has events" true (List.length events > 0)
   | None -> fail "expected Some chunk"
@@ -457,7 +457,7 @@ let test_provider_f_stream_thinking () =
   in
   match Streaming.parse_provider_f_sse_chunk data with
   | Some chunk ->
-    let state = Streaming.create_provider_d_stream_state () in
+    let state = Streaming.create_chat_completions_v1_stream_state () in
     let events, _tel = Streaming.provider_f_chunk_to_events state chunk in
     let has_thinking =
       List.exists
@@ -485,7 +485,7 @@ let test_provider_f_stream_function_call () =
   in
   match Streaming.parse_provider_f_sse_chunk data with
   | Some chunk ->
-    let state = Streaming.create_provider_d_stream_state () in
+    let state = Streaming.create_chat_completions_v1_stream_state () in
     let events, _tel = Streaming.provider_f_chunk_to_events state chunk in
     let has_tool =
       List.exists
@@ -510,7 +510,7 @@ let test_provider_f_stream_finish () =
   in
   match Streaming.parse_provider_f_sse_chunk data with
   | Some chunk ->
-    let state = Streaming.create_provider_d_stream_state () in
+    let state = Streaming.create_chat_completions_v1_stream_state () in
     let events, _tel = Streaming.provider_f_chunk_to_events state chunk in
     let has_delta =
       List.exists
@@ -607,7 +607,7 @@ let test_provider_f_stream_thinking_delta_index () =
     }]
   }|}
   in
-  let state = Streaming.create_provider_d_stream_state () in
+  let state = Streaming.create_chat_completions_v1_stream_state () in
   (match Streaming.parse_provider_f_sse_chunk data1 with
    | Some chunk ->
      let events, _tel = Streaming.provider_f_chunk_to_events state chunk in
@@ -666,7 +666,7 @@ let test_provider_f_stream_thinking_delta_index () =
 (** Regression test for issue #333: function call before text in Gemini
     must not collide block indices. *)
 let test_provider_f_stream_tool_first_then_text () =
-  let state = Streaming.create_provider_d_stream_state () in
+  let state = Streaming.create_chat_completions_v1_stream_state () in
   (* Chunk 1: functionCall — gets block index 0 *)
   let data1 =
     {|{

--- a/test/test_backend_provider_k_coverage.ml
+++ b/test/test_backend_provider_k_coverage.ml
@@ -178,7 +178,7 @@ let test_parse_response_classifies_provider_k_errors () =
     cases
 ;;
 
-let test_parse_response_wraps_provider_d_parse_errors () =
+let test_parse_response_wraps_chat_completions_v1_parse_errors () =
   match K.parse_response {|{"choices":"not-a-list"}|} with
   | exception K.Glm_api_error err ->
     check string "parse code" "parse" err.code;
@@ -242,9 +242,9 @@ let () =
             `Quick
             test_parse_response_classifies_provider_k_errors
         ; test_case
-            "provider_d parse errors"
+            "chat_completions_v1 parse errors"
             `Quick
-            test_parse_response_wraps_provider_d_parse_errors
+            test_parse_response_wraps_chat_completions_v1_parse_errors
         ; test_case
             "empty and malformed reasoning bodies"
             `Quick

--- a/test/test_backend_tool_call_harness.ml
+++ b/test/test_backend_tool_call_harness.ml
@@ -2,17 +2,17 @@ open Alcotest
 module H = Llm_provider.Backend_tool_call_harness
 module T = Llm_provider.Types
 
-let malformed_provider_d_response = `Assoc [ "choices", `String "not-a-list" ]
+let malformed_chat_completions_v1_response = `Assoc [ "choices", `String "not-a-list" ]
 
-let test_provider_d_parse_error_is_typed () =
+let test_chat_completions_v1_parse_error_is_typed () =
   match
-    H.validate_provider_d_response
+    H.validate_chat_completions_v1_response
       ~declared_tools:[ "read_file" ]
-      malformed_provider_d_response
+      malformed_chat_completions_v1_response
   with
   | Ok _ -> fail "expected typed parse error"
   | Error err ->
-    check string "backend" "provider_d" err.response_backend;
+    check string "backend" "chat_completions_v1" err.response_backend;
     check
       bool
       "parse error detail is surfaced"
@@ -20,7 +20,7 @@ let test_provider_d_parse_error_is_typed () =
       (String.length err.response_parse_error > 0)
 ;;
 
-let test_provider_d_text_response_is_ok_empty_validation () =
+let test_chat_completions_v1_text_response_is_ok_empty_validation () =
   let json =
     `Assoc
       [ "id", `String "chatcmpl-text"
@@ -37,7 +37,7 @@ let test_provider_d_text_response_is_ok_empty_validation () =
             ] )
       ]
   in
-  match H.validate_provider_d_response ~declared_tools:[ "read_file" ] json with
+  match H.validate_chat_completions_v1_response ~declared_tools:[ "read_file" ] json with
   | Error err -> fail ("unexpected parse error: " ^ err.response_parse_error)
   | Ok result ->
     check bool "stop reason accepted" true result.stop_reason_correct;
@@ -109,7 +109,7 @@ let test_build_schema_map_accepts_provider_shapes () =
     `Assoc
       [ "name", `String "search"; "input_schema", `Assoc [ "type", `String "object" ] ]
   in
-  let provider_d_tool =
+  let chat_completions_v1_tool =
     `Assoc
       [ ( "function"
         , `Assoc
@@ -119,7 +119,9 @@ let test_build_schema_map_accepts_provider_shapes () =
       ]
   in
   let ignored = `Assoc [ "name", `String "noop"; "input_schema", `Null ] in
-  let schemas = H.build_schema_map [ provider_a_tool; provider_d_tool; ignored ] in
+  let schemas =
+    H.build_schema_map [ provider_a_tool; chat_completions_v1_tool; ignored ]
+  in
   check (list string) "names" [ "search"; "write_file" ] (List.map fst schemas)
 ;;
 
@@ -295,15 +297,15 @@ let test_provider_convenience_validators_cover_tool_responses () =
 let () =
   run
     "backend_tool_call_harness"
-    [ ( "provider_d_parse_errors"
+    [ ( "chat_completions_v1_parse_errors"
       , [ test_case
             "typed result surfaces parse error"
             `Quick
-            test_provider_d_parse_error_is_typed
+            test_chat_completions_v1_parse_error_is_typed
         ; test_case
             "valid text response stays Ok with no tool calls"
             `Quick
-            test_provider_d_text_response_is_ok_empty_validation
+            test_chat_completions_v1_text_response_is_ok_empty_validation
         ] )
     ; ( "schema_validation"
       , [ test_case

--- a/test/test_cache.ml
+++ b/test/test_cache.ml
@@ -131,10 +131,10 @@ let test_add_usage_cache_accumulation () =
 ;;
 
 (* ------------------------------------------------------------------ *)
-(* Provider_d: cache token parsing from prompt_tokens_details               *)
+(* Chat_completions_v1: cache token parsing from prompt_tokens_details               *)
 (* ------------------------------------------------------------------ *)
 
-let test_provider_d_usage_with_cached_tokens () =
+let test_chat_completions_v1_usage_with_cached_tokens () =
   let json_str =
     {|{
     "id": "chatcmpl-abc",
@@ -154,7 +154,7 @@ let test_provider_d_usage_with_cached_tokens () =
   }|}
   in
   let resp =
-    match Agent_sdk.Api.parse_provider_d_response_result json_str with
+    match Agent_sdk.Api.parse_chat_completions_v1_response_result json_str with
     | Ok r -> r
     | Error msg -> failwith msg
   in
@@ -167,7 +167,7 @@ let test_provider_d_usage_with_cached_tokens () =
   | None -> Alcotest.fail "expected usage"
 ;;
 
-let test_provider_d_usage_without_cached_tokens () =
+let test_chat_completions_v1_usage_without_cached_tokens () =
   let json_str =
     {|{
     "id": "chatcmpl-def",
@@ -184,7 +184,7 @@ let test_provider_d_usage_without_cached_tokens () =
   }|}
   in
   let resp =
-    match Agent_sdk.Api.parse_provider_d_response_result json_str with
+    match Agent_sdk.Api.parse_chat_completions_v1_response_result json_str with
     | Ok r -> r
     | Error msg -> failwith msg
   in
@@ -272,15 +272,15 @@ let () =
     ; ( "add_usage"
       , [ test_case "cache token accumulation" `Quick test_add_usage_cache_accumulation ]
       )
-    ; ( "provider_d_cache"
+    ; ( "chat_completions_v1_cache"
       , [ test_case
             "usage with cached_tokens"
             `Quick
-            test_provider_d_usage_with_cached_tokens
+            test_chat_completions_v1_usage_with_cached_tokens
         ; test_case
             "usage without cached_tokens"
             `Quick
-            test_provider_d_usage_without_cached_tokens
+            test_chat_completions_v1_usage_without_cached_tokens
         ] )
     ; ( "streaming_delta_cache"
       , [ test_case

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -84,7 +84,7 @@ let test_anthropic_capabilities () =
   check bool "context 200K" true (c.max_context_tokens = Some 200_000)
 ;;
 
-let test_provider_d_capabilities () =
+let test_chat_completions_v1_capabilities () =
   let c = Capabilities.openai_compat_chat_capabilities in
   check bool "has structured output" true c.supports_structured_output;
   check bool "has parallel tools" true c.supports_parallel_tool_calls;
@@ -92,7 +92,7 @@ let test_provider_d_capabilities () =
   check bool "context 128K" true (c.max_context_tokens = Some 128_000)
 ;;
 
-let test_provider_d_extended () =
+let test_chat_completions_v1_extended () =
   let c = Capabilities.openai_compat_chat_extended_capabilities in
   check bool "has reasoning" true c.supports_reasoning;
   check_thinking_control
@@ -169,9 +169,9 @@ let pp_static_model_route ppf = function
   | Capabilities.Agent_llm_a_opus_4 -> Format.fprintf ppf "Agent_llm_a_opus_4"
   | Capabilities.Agent_llm_a_sonnet_4 -> Format.fprintf ppf "Agent_llm_a_sonnet_4"
   | Capabilities.Agent_llm_a_haiku_4 -> Format.fprintf ppf "Agent_llm_a_haiku_4"
-  | Capabilities.Provider_d_5 -> Format.fprintf ppf "Provider_d_5"
-  | Capabilities.Provider_d_4_1 -> Format.fprintf ppf "Provider_d_4_1"
-  | Capabilities.Provider_d_4o -> Format.fprintf ppf "Provider_d_4o"
+  | Capabilities.Chat_completions_v1_5 -> Format.fprintf ppf "Chat_completions_v1_5"
+  | Capabilities.Chat_completions_v1_4_1 -> Format.fprintf ppf "Chat_completions_v1_4_1"
+  | Capabilities.Chat_completions_v1_4o -> Format.fprintf ppf "Chat_completions_v1_4o"
   | Capabilities.Mimo_v2_5_chat -> Format.fprintf ppf "Mimo_v2_5_chat"
   | Capabilities.Gemini family ->
     Format.fprintf ppf "Gemini(%a)" pp_provider_f_family family
@@ -456,7 +456,7 @@ let test_manifest_overrides_static_table () =
      but different capabilities — manifest must win. *)
   let m =
     make_manifest
-      ~base:"provider_d_chat"
+      ~base:"chat_completions_v1"
       ~extra_fields:
         [ "max_context_tokens", "999999"
         ; "supports_computer_use", "false"
@@ -492,18 +492,18 @@ let test_manifest_unknown_model_still_none () =
     (Capabilities.for_model_id_with_manifest m "totally-unknown-xyz" = None)
 ;;
 
-let test_manifest_base_label_provider_d_chat () =
+let test_manifest_base_label_chat_completions_v1 () =
   let m =
     make_manifest
-      ~base:"provider_d_chat"
+      ~base:"chat_completions_v1"
       ~extra_fields:[ "max_context_tokens", "65536" ]
       "custom-gpt"
   in
   match Capabilities.for_model_id_with_manifest m "custom-gpt-v2" with
   | Some c ->
     check (option int) "custom ctx" (Some 65536) c.max_context_tokens;
-    check bool "provider_d_chat base: tools" true c.supports_tools;
-    check bool "provider_d_chat base: streaming" true c.supports_native_streaming
+    check bool "chat_completions_v1 base: tools" true c.supports_tools;
+    check bool "chat_completions_v1 base: streaming" true c.supports_native_streaming
   | None -> fail "expected Some"
 ;;
 
@@ -543,14 +543,14 @@ let test_manifest_prefix_wins_over_longer_static_prefix () =
      letting operator override even well-known models. *)
   let m =
     make_manifest
-      ~base:"provider_d_chat"
+      ~base:"chat_completions_v1"
       ~extra_fields:[ "supports_reasoning", "false" ]
       "provider_h-3"
   in
   match Capabilities.for_model_id_with_manifest m "provider_h-3.5-35b-a3b-q4" with
   | Some c ->
     check bool "manifest disables reasoning" false c.supports_reasoning;
-    check bool "base provider_d_chat: tools" true c.supports_tools
+    check bool "base chat_completions_v1: tools" true c.supports_tools
   | None -> fail "expected Some"
 ;;
 
@@ -714,7 +714,7 @@ let test_manifest_load_runtime_file_success_logs_info () =
 
 let test_dashscope_capabilities () =
   let c = Capabilities.dashscope_capabilities in
-  (* DashScope (DashScope) exposes response_format.json_schema on its Provider_d-compatible
+  (* DashScope (DashScope) exposes response_format.json_schema on its Chat_completions_v1-compatible
      endpoint; native schema output is supported. Ref: DashScope structured output
      guide — checked 2026-05-05. *)
   check bool "has structured output" true c.supports_structured_output;
@@ -731,7 +731,7 @@ let test_dashscope_capabilities () =
 
 let test_openai_compat_reasoning_records_have_explicit_control () =
   let cases =
-    [ ( "provider_d_chat_extended"
+    [ ( "chat_completions_v1_extended"
       , Some Capabilities.openai_compat_chat_extended_capabilities )
     ; "provider_c", Some Capabilities.kimi_capabilities
     ; "provider_h", Some Capabilities.dashscope_capabilities
@@ -843,11 +843,14 @@ let () =
         ] )
     ; ( "presets"
       , [ test_case "provider_a" `Quick test_anthropic_capabilities
-        ; test_case "provider_d" `Quick test_provider_d_capabilities
-        ; test_case "provider_d extended" `Quick test_provider_d_extended
+        ; test_case "chat_completions_v1" `Quick test_chat_completions_v1_capabilities
+        ; test_case
+            "chat_completions_v1 extended"
+            `Quick
+            test_chat_completions_v1_extended
         ; test_case "provider_h" `Quick test_dashscope_capabilities
         ; test_case
-            "provider_d compat reasoning records have explicit control"
+            "chat_completions_v1 compat reasoning records have explicit control"
             `Quick
             test_openai_compat_reasoning_records_have_explicit_control
         ] )
@@ -894,7 +897,10 @@ let () =
       , [ test_case "overrides static table" `Quick test_manifest_overrides_static_table
         ; test_case "fallback to static" `Quick test_manifest_fallback_to_static
         ; test_case "unknown model → None" `Quick test_manifest_unknown_model_still_none
-        ; test_case "base provider_d_chat" `Quick test_manifest_base_label_provider_d_chat
+        ; test_case
+            "base chat_completions_v1"
+            `Quick
+            test_manifest_base_label_chat_completions_v1
         ; test_case "base provider_a" `Quick test_manifest_base_label_provider_a
         ; test_case "base absent = default" `Quick test_manifest_base_absent_uses_default
         ; test_case

--- a/test/test_capabilities_wiring.ml
+++ b/test/test_capabilities_wiring.ml
@@ -61,7 +61,7 @@ let test_filter_thinking () =
     (Capability_filter.requires_thinking agent_llm_a);
   check
     bool
-    "basic provider_d no thinking"
+    "basic chat_completions_v1 no thinking"
     false
     (Capability_filter.requires_thinking basic)
 ;;

--- a/test/test_complete_ext.ml
+++ b/test/test_complete_ext.ml
@@ -283,7 +283,7 @@ let test_sampling_defaults_and_overlay () =
   let defaults = Complete.provider_sampling_defaults Provider_config.OpenAI_compat in
   check
     (option (float 0.001))
-    "provider_d min_p"
+    "chat_completions_v1 min_p"
     (Some Constants.Sampling.openai_compat_min_p)
     defaults.default_min_p;
   let no_defaults = Complete.provider_sampling_defaults Provider_config.Anthropic in
@@ -324,7 +324,7 @@ let test_complete_transport_success_cache_metrics_and_trace_headers () =
   let config =
     make_config
       ~headers:[ "traceparent", "old"; "x-base", "base" ]
-      ~model_id:"provider_d-test"
+      ~model_id:"chat_completions_v1-test"
       ()
   in
   let content =
@@ -371,14 +371,14 @@ let test_complete_transport_success_cache_metrics_and_trace_headers () =
   in
   (match first with
    | Ok resp ->
-     check string "model patched" "provider_d-test" resp.model;
+     check string "model patched" "chat_completions_v1-test" resp.model;
      (match resp.telemetry with
       | Some t ->
         check (option int) "latency patched" (Some 42) t.request_latency_ms;
         check
           (option string)
           "canonical model"
-          (Some "provider_d-test")
+          (Some "chat_completions_v1-test")
           t.canonical_model_id
       | None -> fail "expected telemetry")
    | Error err -> failf "unexpected complete error: %s" (string_of_http_error err));
@@ -415,8 +415,10 @@ let test_complete_with_retry_retries_then_success () =
   let probe = metric_probe () in
   let metrics = metrics_of_probe probe in
   let attempts = ref 0 in
-  let config = make_config ~model_id:"provider_d-retry" () in
-  let response = make_response ~model:"provider_d-retry" ~usage:(make_usage ()) () in
+  let config = make_config ~model_id:"chat_completions_v1-retry" () in
+  let response =
+    make_response ~model:"chat_completions_v1-retry" ~usage:(make_usage ()) ()
+  in
   let transport =
     transport_of_sync (fun () ->
       incr attempts;
@@ -447,7 +449,7 @@ let test_complete_with_retry_retries_then_success () =
        ~metrics
        ()
    with
-   | Ok resp -> check string "retry success" "provider_d-retry" resp.model
+   | Ok resp -> check string "retry success" "chat_completions_v1-retry" resp.model
    | Error err -> failf "unexpected retry error: %s" (string_of_http_error err));
   check int "attempts" 3 !attempts;
   check (list int) "retry callbacks" [ 1; 2 ] (List.rev probe.retries);
@@ -465,7 +467,10 @@ let test_complete_stream_transport_success_metrics_and_telemetry () =
   let seen_events = ref [] in
   let seen_telemetry = ref [] in
   let config =
-    make_config ~model_id:"provider_d-stream" ~headers:[ "traceparent", "old-stream" ] ()
+    make_config
+      ~model_id:"chat_completions_v1-stream"
+      ~headers:[ "traceparent", "old-stream" ]
+      ()
   in
   let response =
     make_response
@@ -492,7 +497,7 @@ let test_complete_stream_transport_success_metrics_and_telemetry () =
            | Some emit ->
              emit
                (Telemetry_event.Streaming_first_chunk
-                  { provider = "provider_d"
+                  { provider = "chat_completions_v1"
                   ; model = request.config.model_id
                   ; ttfrc_ms = 1.5
                   ; requested_at = 0.0
@@ -515,14 +520,14 @@ let test_complete_stream_transport_success_metrics_and_telemetry () =
        ()
    with
    | Ok resp ->
-     check string "stream model patched" "provider_d-stream" resp.model;
+     check string "stream model patched" "chat_completions_v1-stream" resp.model;
      (match resp.telemetry with
       | Some t ->
         check bool "stream latency patched" true (Option.is_some t.request_latency_ms);
         check
           (option string)
           "stream canonical model"
-          (Some "provider_d-stream")
+          (Some "chat_completions_v1-stream")
           t.canonical_model_id
       | None -> fail "expected stream telemetry")
    | Error err -> failf "unexpected stream error: %s" (string_of_http_error err));

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -17,13 +17,13 @@ let provider_a_response ?(id = "msg-1") ?(model = "mock") ?(stop_reason = "end_t
     stop_reason
 ;;
 
-let provider_d_response text =
+let chat_completions_v1_response text =
   Printf.sprintf
     {|{"id":"chatcmpl-1","object":"chat.completion","model":"model-d-4","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}|}
     text
 ;;
 
-let provider_d_mlx_vlm_response text =
+let chat_completions_v1_mlx_vlm_response text =
   Printf.sprintf
     {|{"id":"chatcmpl-mlx-1","object":"chat.completion","model":"model-d-4","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"input_tokens":11,"output_tokens":5,"prompt_tps":21.55,"generation_tps":81.56},"peak_memory":52.66}|}
     text
@@ -113,7 +113,7 @@ let make_config ?(kind = Provider_config.Anthropic) base_url =
     ()
 ;;
 
-let make_provider_d_config base_url =
+let make_chat_completions_v1_config base_url =
   Provider_config.make
     ~kind:Provider_config.OpenAI_compat
     ~model_id:"model-d-4"
@@ -228,18 +228,21 @@ let test_complete_http_empty_error_body_has_context () =
   | Exit -> ()
 ;;
 
-(* ── complete: Provider_d compat ─────────────────────────── *)
+(* ── complete: Chat_completions_v1 compat ─────────────────────────── *)
 
-let test_complete_provider_d_ok () =
+let test_complete_chat_completions_v1_ok () =
   Eio_main.run
   @@ fun env ->
   try
     Eio.Switch.run
     @@ fun sw ->
     let url =
-      start_mock_server ~sw ~net:env#net (provider_d_response "provider_d reply")
+      start_mock_server
+        ~sw
+        ~net:env#net
+        (chat_completions_v1_response "chat_completions_v1 reply")
     in
-    let config = make_provider_d_config url in
+    let config = make_chat_completions_v1_config url in
     match Complete.complete ~sw ~net:env#net ~config ~messages () with
     | Ok resp ->
       let text =
@@ -250,9 +253,9 @@ let test_complete_provider_d_ok () =
           resp.content
         |> String.concat ""
       in
-      check string "text" "provider_d reply" text;
+      check string "text" "chat_completions_v1 reply" text;
       Eio.Switch.fail sw Exit
-    | Error _ -> fail "expected Ok for provider_d"
+    | Error _ -> fail "expected Ok for chat_completions_v1"
   with
   | Exit -> ()
 ;;
@@ -295,7 +298,7 @@ let test_complete_trace_context_headers () =
   | Exit -> ()
 ;;
 
-let test_complete_provider_d_mlx_vlm_telemetry () =
+let test_complete_chat_completions_v1_mlx_vlm_telemetry () =
   Eio_main.run
   @@ fun env ->
   let clock = Eio.Stdenv.clock env in
@@ -308,9 +311,9 @@ let test_complete_provider_d_mlx_vlm_telemetry () =
         ~net:env#net
         ~delay_sec:0.02
         ~clock
-        (provider_d_mlx_vlm_response "mlx reply")
+        (chat_completions_v1_mlx_vlm_response "mlx reply")
     in
-    let config = make_provider_d_config url in
+    let config = make_chat_completions_v1_config url in
     match Complete.complete ~sw ~net:env#net ~config ~messages () with
     | Ok resp ->
       let text =
@@ -355,7 +358,7 @@ let test_complete_provider_d_mlx_vlm_telemetry () =
           | None -> fail "expected timings")
        | None -> fail "expected telemetry");
       Eio.Switch.fail sw Exit
-    | Error _ -> fail "expected Ok for mlx-vlm provider_d compat"
+    | Error _ -> fail "expected Ok for mlx-vlm chat_completions_v1 compat"
   with
   | Exit -> ()
 ;;
@@ -576,7 +579,7 @@ let test_complete_transport_http_metrics_ok () =
   try
     Eio.Switch.run
     @@ fun sw ->
-    let config = make_provider_d_config "http://unused.test" in
+    let config = make_chat_completions_v1_config "http://unused.test" in
     let status_calls = ref [] in
     let metrics : Metrics.t =
       { Metrics.noop with
@@ -589,7 +592,7 @@ let test_complete_transport_http_metrics_ok () =
     match Complete.complete ~sw ~net:env#net ~transport ~config ~messages ~metrics () with
     | Ok _ ->
       (match !status_calls with
-       | [ ("provider_d", "model-d-4", 200) ] -> Eio.Switch.fail sw Exit
+       | [ ("chat_completions_v1", "model-d-4", 200) ] -> Eio.Switch.fail sw Exit
        | [ (_, _, code) ] -> fail (Printf.sprintf "expected 200, got %d" code)
        | _ -> fail "expected exactly one transport status call")
     | Error _ -> fail "expected Ok"
@@ -603,7 +606,7 @@ let test_complete_transport_http_metrics_error () =
   try
     Eio.Switch.run
     @@ fun sw ->
-    let config = make_provider_d_config "http://unused.test" in
+    let config = make_chat_completions_v1_config "http://unused.test" in
     let status_calls = ref [] in
     let metrics : Metrics.t =
       { Metrics.noop with
@@ -620,7 +623,7 @@ let test_complete_transport_http_metrics_error () =
     | Error (Http_client.HttpError { code; _ }) ->
       check int "status 429" 429 code;
       (match !status_calls with
-       | [ ("provider_d", "model-d-4", 429) ] -> Eio.Switch.fail sw Exit
+       | [ ("chat_completions_v1", "model-d-4", 429) ] -> Eio.Switch.fail sw Exit
        | [ (_, _, seen) ] -> fail (Printf.sprintf "expected 429, got %d" seen)
        | _ -> fail "expected exactly one transport status call")
     | Error _ -> fail "expected HttpError"
@@ -943,11 +946,11 @@ let () =
             "empty http error body has context"
             `Quick
             test_complete_http_empty_error_body_has_context
-        ; test_case "provider_d ok" `Quick test_complete_provider_d_ok
+        ; test_case "chat_completions_v1 ok" `Quick test_complete_chat_completions_v1_ok
         ; test_case
-            "provider_d mlx-vlm telemetry"
+            "chat_completions_v1 mlx-vlm telemetry"
             `Quick
-            test_complete_provider_d_mlx_vlm_telemetry
+            test_complete_chat_completions_v1_mlx_vlm_telemetry
         ; test_case "trace context headers" `Quick test_complete_trace_context_headers
         ; test_case "non-retryable" `Quick test_complete_non_retryable
         ; test_case

--- a/test/test_error.ml
+++ b/test/test_error.ml
@@ -39,7 +39,7 @@ let test_provider_timeout_phase () =
   let err =
     Error.Provider
       (Llm_provider.Error.Timeout
-         { provider = "provider_d"
+         { provider = "chat_completions_v1"
          ; timeout_phase =
              Some
                (Llm_provider.Http_client.Stream_idle
@@ -50,7 +50,8 @@ let test_provider_timeout_phase () =
   check
     string
     "provider timeout"
-    "Provider 'provider_d' timeout phase=stream_idle:streaming_thinking: stream stalled"
+    "Provider 'chat_completions_v1' timeout phase=stream_idle:streaming_thinking: stream \
+     stalled"
     (Error.to_string err)
 ;;
 
@@ -223,7 +224,7 @@ let test_retryable_provider_timeout () =
   let err =
     Error.Provider
       (Llm_provider.Error.Timeout
-         { provider = "provider_d"
+         { provider = "chat_completions_v1"
          ; timeout_phase =
              Some
                (Llm_provider.Http_client.Stream_idle

--- a/test/test_event_forward.ml
+++ b/test/test_event_forward.ml
@@ -352,7 +352,7 @@ let test_inference_telemetry_payload () =
 ;;
 
 let test_inference_telemetry_partial_fields () =
-  (* Provider_d-compat backends typically only report token counts; absent
+  (* Chat_completions_v1-compat backends typically only report token counts; absent
      timing fields must serialize as JSON null, not be omitted or default
      to 0. Subscribers distinguish "absent" from "zero". *)
   let evt =

--- a/test/test_event_integration.ml
+++ b/test/test_event_integration.ml
@@ -11,7 +11,7 @@ open Agent_sdk
 
 (* ── A. run_with_handoffs emits Handoff{Requested,Completed} ──── *)
 
-(* Reuse the same mock wire format as test_handoff: Provider_d-compatible
+(* Reuse the same mock wire format as test_handoff: Chat_completions_v1-compatible
    chat.completions that responds with a transfer_to_* tool call on the
    first request and a plain text response on the second. *)
 

--- a/test/test_full_pipeline_cov.ml
+++ b/test/test_full_pipeline_cov.ml
@@ -1,6 +1,6 @@
 (** Full-pipeline coverage tests with mock HTTP server.
     Exercises Agent.run end-to-end: api.ml, provider_intf.ml, pipeline.ml,
-    backend_provider_d.ml, complete.ml, streaming.ml, structured.ml,
+    backend_chat_completions_v1.ml, complete.ml, streaming.ml, structured.ml,
     agent_tools.ml, context_reducer, mcp, error paths.
 
     All responses are canned JSON. No real LLM calls. *)
@@ -22,7 +22,7 @@ let escape_json_string s =
   Buffer.contents buf
 ;;
 
-let provider_d_text_response ?(id = "chatcmpl-1") text =
+let chat_completions_v1_text_response ?(id = "chatcmpl-1") text =
   Printf.sprintf
     {|{"id":"%s","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}|}
     id
@@ -43,7 +43,7 @@ let provider_a_text_response
     stop_reason
 ;;
 
-let provider_d_tool_use ?(id = "chatcmpl-t") tool_name input_json =
+let chat_completions_v1_tool_use ?(id = "chatcmpl-t") tool_name input_json =
   Printf.sprintf
     {|{"id":"%s","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"%s","arguments":"%s"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":15,"completion_tokens":10,"total_tokens":25}}|}
     id
@@ -51,7 +51,7 @@ let provider_d_tool_use ?(id = "chatcmpl-t") tool_name input_json =
     (escape_json_string input_json)
 ;;
 
-let provider_d_multi_content tool_name input_json text =
+let chat_completions_v1_multi_content tool_name input_json text =
   Printf.sprintf
     {|{"id":"chatcmpl-m","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s","tool_calls":[{"id":"call_2","type":"function","function":{"name":"%s","arguments":"%s"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":20,"completion_tokens":15,"total_tokens":35}}|}
     (escape_json_string text)
@@ -59,13 +59,13 @@ let provider_d_multi_content tool_name input_json text =
     (escape_json_string input_json)
 ;;
 
-let provider_d_response text =
+let chat_completions_v1_response text =
   Printf.sprintf
     {|{"id":"chatcmpl-1","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}|}
     (escape_json_string text)
 ;;
 
-let provider_d_sse text =
+let chat_completions_v1_sse text =
   Printf.sprintf
     "data: \
      {\"id\":\"chatcmpl-s1\",\"object\":\"chat.completion.chunk\",\"model\":\"mock\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"%s\"},\"finish_reason\":null}]}\n\n\
@@ -218,7 +218,7 @@ let test_basic_text () =
         ~sw
         ~net:env#net
         ~port:21001
-        [ provider_d_text_response "hello coverage" ]
+        [ chat_completions_v1_text_response "hello coverage" ]
     in
     let agent = make_agent ~net:env#net url in
     match Agent.run ~sw agent "hi" with
@@ -239,7 +239,9 @@ let test_tool_call_loop () =
     Eio.Switch.run
     @@ fun sw ->
     let responses =
-      [ provider_d_tool_use "calc" {|{"x":42}|}; provider_d_text_response "result is 42" ]
+      [ chat_completions_v1_tool_use "calc" {|{"x":42}|}
+      ; chat_completions_v1_text_response "result is 42"
+      ]
     in
     let url = start_multi ~sw ~net:env#net ~port:21002 responses in
     let tool =
@@ -276,8 +278,8 @@ let test_multi_content_tool () =
     Eio.Switch.run
     @@ fun sw ->
     let responses =
-      [ provider_d_multi_content "greet" {|{"name":"test"}|} "thinking..."
-      ; provider_d_text_response "done"
+      [ chat_completions_v1_multi_content "greet" {|{"name":"test"}|} "thinking..."
+      ; chat_completions_v1_text_response "done"
       ]
     in
     let url = start_multi ~sw ~net:env#net ~port:21003 responses in
@@ -312,7 +314,9 @@ let test_streaming_sse () =
   try
     Eio.Switch.run
     @@ fun sw ->
-    let url = start_sse ~sw ~net:env#net ~port:21004 (provider_d_sse "streamed text") in
+    let url =
+      start_sse ~sw ~net:env#net ~port:21004 (chat_completions_v1_sse "streamed text")
+    in
     let agent = make_agent ~net:env#net url in
     let events = ref [] in
     match
@@ -393,7 +397,9 @@ let test_tool_error_recovery () =
     Eio.Switch.run
     @@ fun sw ->
     let responses =
-      [ provider_d_tool_use "bad_tool" {|{}|}; provider_d_text_response "recovered" ]
+      [ chat_completions_v1_tool_use "bad_tool" {|{}|}
+      ; chat_completions_v1_text_response "recovered"
+      ]
     in
     let url = start_multi ~sw ~net:env#net ~port:21008 responses in
     let tool =
@@ -419,7 +425,11 @@ let test_max_turns () =
     Eio.Switch.run
     @@ fun sw ->
     let url =
-      start_multi ~sw ~net:env#net ~port:21009 [ provider_d_tool_use "loop" {|{}|} ]
+      start_multi
+        ~sw
+        ~net:env#net
+        ~port:21009
+        [ chat_completions_v1_tool_use "loop" {|{}|} ]
     in
     let tool =
       Tool.create ~name:"loop" ~description:"loops" ~parameters:[] (fun _input ->
@@ -442,7 +452,11 @@ let test_hooks_turn () =
     Eio.Switch.run
     @@ fun sw ->
     let url =
-      start_multi ~sw ~net:env#net ~port:21010 [ provider_d_text_response "hooked" ]
+      start_multi
+        ~sw
+        ~net:env#net
+        ~port:21010
+        [ chat_completions_v1_text_response "hooked" ]
     in
     let before_count = ref 0 in
     let after_count = ref 0 in
@@ -480,7 +494,11 @@ let test_context_reducer () =
     Eio.Switch.run
     @@ fun sw ->
     let url =
-      start_multi ~sw ~net:env#net ~port:21019 [ provider_d_text_response "reduced" ]
+      start_multi
+        ~sw
+        ~net:env#net
+        ~port:21019
+        [ chat_completions_v1_text_response "reduced" ]
     in
     let reducer =
       Context_reducer.compose
@@ -505,7 +523,11 @@ let test_guardrails_filter () =
     Eio.Switch.run
     @@ fun sw ->
     let url =
-      start_multi ~sw ~net:env#net ~port:21012 [ provider_d_text_response "guarded" ]
+      start_multi
+        ~sw
+        ~net:env#net
+        ~port:21012
+        [ chat_completions_v1_text_response "guarded" ]
     in
     let guardrails =
       { Guardrails.tool_filter = Guardrails.AllowAll; max_tool_calls_per_turn = Some 3 }
@@ -529,7 +551,9 @@ let test_pre_tool_skip () =
     Eio.Switch.run
     @@ fun sw ->
     let responses =
-      [ provider_d_tool_use "skipped" {|{}|}; provider_d_text_response "skipped result" ]
+      [ chat_completions_v1_tool_use "skipped" {|{}|}
+      ; chat_completions_v1_text_response "skipped result"
+      ]
     in
     let url = start_multi ~sw ~net:env#net ~port:21013 responses in
     let tool =
@@ -545,7 +569,7 @@ let test_pre_tool_skip () =
   | Exit -> ()
 ;;
 
-(* ── 14. Provider_d-compatible provider ───────────────────────────── *)
+(* ── 14. Chat_completions_v1-compatible provider ───────────────────────────── *)
 
 let test_openai_compat () =
   Eio_main.run
@@ -554,7 +578,11 @@ let test_openai_compat () =
     Eio.Switch.run
     @@ fun sw ->
     let url =
-      start_multi ~sw ~net:env#net ~port:21014 [ provider_d_response "provider_d hello" ]
+      start_multi
+        ~sw
+        ~net:env#net
+        ~port:21014
+        [ chat_completions_v1_response "chat_completions_v1 hello" ]
     in
     let provider : Provider.config =
       { provider =
@@ -564,18 +592,20 @@ let test_openai_compat () =
             ; path = "/v1/chat/completions"
             ; static_token = None
             }
-      ; model_id = "mock-provider_d"
+      ; model_id = "mock-chat_completions_v1"
       ; api_key_env = ""
       }
     in
-    let config = { Types.default_config with name = "provider_d-agent"; max_turns = 1 } in
+    let config =
+      { Types.default_config with name = "chat_completions_v1-agent"; max_turns = 1 }
+    in
     let options =
       { Agent.default_options with base_url = url; provider = Some provider }
     in
     let a = Agent.create ~net:env#net ~config ~options () in
     match Agent.run ~sw a "hello" with
     | Ok resp ->
-      check string "text" "provider_d hello" (extract_text resp);
+      check string "text" "chat_completions_v1 hello" (extract_text resp);
       Eio.Switch.fail sw Exit
     | Error e -> fail (Error.to_string e)
   with
@@ -591,7 +621,11 @@ let test_agent_clone_run () =
     Eio.Switch.run
     @@ fun sw ->
     let url =
-      start_multi ~sw ~net:env#net ~port:21015 [ provider_d_text_response "cloned" ]
+      start_multi
+        ~sw
+        ~net:env#net
+        ~port:21015
+        [ chat_completions_v1_text_response "cloned" ]
     in
     let agent = make_agent ~net:env#net url in
     let cloned = Agent.clone agent in
@@ -702,8 +736,8 @@ let test_context_tool () =
     Eio.Switch.run
     @@ fun sw ->
     let responses =
-      [ provider_d_tool_use "ctx_tool" {|{"key":"val"}|}
-      ; provider_d_text_response "ctx done"
+      [ chat_completions_v1_tool_use "ctx_tool" {|{"key":"val"}|}
+      ; chat_completions_v1_text_response "ctx done"
       ]
     in
     let url = start_multi ~sw ~net:env#net ~port:21020 responses in
@@ -739,7 +773,7 @@ let () =
     "full_pipeline_cov"
     [ ( "basic"
       , [ test_case "text completion" `Quick test_basic_text
-        ; test_case "provider_d compat" `Quick test_openai_compat
+        ; test_case "chat_completions_v1 compat" `Quick test_openai_compat
         ; test_case "agent clone" `Quick test_agent_clone_run
         ; test_case "agent card" `Quick test_agent_card
         ] )

--- a/test/test_integration.ml
+++ b/test/test_integration.ml
@@ -1,7 +1,7 @@
 open Agent_sdk
 open Types
 
-(** Mock Server Logic — Provider_d Chat Completions format *)
+(** Mock Server Logic — Chat_completions_v1 Chat Completions format *)
 let mock_handler _conn req body =
   let path = Uri.path (Cohttp.Request.uri req) in
   match path with

--- a/test/test_judge.ml
+++ b/test/test_judge.ml
@@ -133,7 +133,7 @@ let test_provider_config_for_judge_sets_schema_contract () =
     PC.make
       ~kind:PC.OpenAI_compat
       ~model_id:"model-d-mini"
-      ~base_url:"https://api.provider_d.com/v1"
+      ~base_url:"https://api.chat-completions-v1.example/v1"
       ~response_format:LT.JsonMode
       ()
   in

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -1336,7 +1336,7 @@ let test_requires_multimodal () =
 
 let test_requires_json_format () =
   Alcotest.(check bool)
-    "provider_d json"
+    "chat_completions_v1 json"
     true
     (Capability_filter.requires_json_format Capabilities.openai_compat_chat_capabilities);
   Alcotest.(check bool)
@@ -1365,7 +1365,7 @@ let test_requires_thinking () =
 
 let test_requires_structured_output () =
   Alcotest.(check bool)
-    "provider_d structured"
+    "chat_completions_v1 structured"
     true
     (Capability_filter.requires_structured_output
        Capabilities.openai_compat_chat_capabilities);
@@ -1982,9 +1982,12 @@ let () =
     ; ( "capabilities.presets"
       , [ Alcotest.test_case "default" `Quick test_default_capabilities
         ; Alcotest.test_case "provider_a" `Quick test_anthropic_capabilities
-        ; Alcotest.test_case "provider_d_chat" `Quick test_openai_compat_chat_capabilities
         ; Alcotest.test_case
-            "provider_d_chat_extended"
+            "chat_completions_v1"
+            `Quick
+            test_openai_compat_chat_capabilities
+        ; Alcotest.test_case
+            "chat_completions_v1_extended"
             `Quick
             test_openai_compat_chat_extended_capabilities
         ; Alcotest.test_case "provider_f" `Quick test_gemini_capabilities

--- a/test/test_llm_provider_error.ml
+++ b/test/test_llm_provider_error.ml
@@ -95,19 +95,23 @@ let test_auth_error () =
   check
     string
     "AuthError format"
-    "Provider 'provider_d' auth error: invalid API key"
+    "Provider 'chat_completions_v1' auth error: invalid API key"
     (Error.to_string
-       (Error.AuthError { provider = "provider_d"; detail = "invalid API key" }))
+       (Error.AuthError { provider = "chat_completions_v1"; detail = "invalid API key" }))
 ;;
 
 let test_server_error () =
   check
     string
     "ServerError format"
-    "Provider 'provider_d' server error 503 (transient=true): down"
+    "Provider 'chat_completions_v1' server error 503 (transient=true): down"
     (Error.to_string
        (Error.ServerError
-          { provider = "provider_d"; code = 503; transient = true; detail = "down" }))
+          { provider = "chat_completions_v1"
+          ; code = 503
+          ; transient = true
+          ; detail = "down"
+          }))
 ;;
 
 let test_network_error () =
@@ -141,10 +145,10 @@ let test_timeout_phase () =
   check
     string
     "Timeout phase format"
-    "Provider 'provider_d' timeout phase=stream_idle:streaming_thinking: stalled"
+    "Provider 'chat_completions_v1' timeout phase=stream_idle:streaming_thinking: stalled"
     (Error.to_string
        (Error.Timeout
-          { provider = "provider_d"
+          { provider = "chat_completions_v1"
           ; timeout_phase = Some (Http_client.Stream_idle Http_client.Streaming_thinking)
           ; detail = "stalled"
           }))
@@ -256,12 +260,12 @@ let test_http_capacity_failure_mapping () =
 let test_http_server_error_mapping () =
   let err =
     Error.of_http_error
-      ~provider:"provider_d"
+      ~provider:"chat_completions_v1"
       (Http_client.HttpError { code = 503; body = "down" })
   in
   match err with
   | Error.ServerError { provider; code; transient; detail } ->
-    check string "provider" "provider_d" provider;
+    check string "provider" "chat_completions_v1" provider;
     check int "code" 503 code;
     check bool "transient" true transient;
     check string "detail" "down" detail
@@ -307,7 +311,7 @@ let test_http_network_error_mapping () =
 let test_http_timeout_error_mapping () =
   let err =
     Error.of_http_error
-      ~provider:"provider_d"
+      ~provider:"chat_completions_v1"
       (Http_client.TimeoutError
          { message = "stream stalled"
          ; phase = Http_client.Stream_idle Http_client.Streaming_thinking
@@ -315,7 +319,7 @@ let test_http_timeout_error_mapping () =
   in
   match err with
   | Error.Timeout { provider; timeout_phase; detail } ->
-    check string "provider" "provider_d" provider;
+    check string "provider" "chat_completions_v1" provider;
     check
       (option string)
       "phase"
@@ -328,27 +332,27 @@ let test_http_timeout_error_mapping () =
 let test_retry_remaining_variants_mapping () =
   let cases =
     [ ( Error.of_retry_api_error
-          ~provider:"provider_d"
+          ~provider:"chat_completions_v1"
           (Retry.AuthError { message = "bad key" })
       , "auth" )
     ; ( Error.of_retry_api_error
-          ~provider:"provider_d"
+          ~provider:"chat_completions_v1"
           (Retry.InvalidRequest { message = "bad payload" })
       , "invalid" )
     ; ( Error.of_retry_api_error
-          ~provider:"provider_d"
+          ~provider:"chat_completions_v1"
           (Retry.NotFound { message = "missing model" })
       , "not_found" )
     ; ( Error.of_retry_api_error
-          ~provider:"provider_d"
+          ~provider:"chat_completions_v1"
           (Retry.ContextOverflow { message = "too long"; limit = Some 123 })
       , "context" )
     ; ( Error.of_retry_api_error
-          ~provider:"provider_d"
+          ~provider:"chat_completions_v1"
           (Retry.NetworkError { message = "tls"; kind = Http_client.Tls_error })
       , "network" )
     ; ( Error.of_retry_api_error
-          ~provider:"provider_d"
+          ~provider:"chat_completions_v1"
           (Retry.Timeout { message = "slow" })
       , "timeout" )
     ]

--- a/test/test_metrics.ml
+++ b/test/test_metrics.ml
@@ -56,11 +56,13 @@ let test_histogram_with_labels () =
   in
   Metrics.observe
     h
-    ~labels:[ "gen_ai.system", "provider_d"; "gen_ai.request.model", "model-d-5" ]
+    ~labels:
+      [ "gen_ai.system", "chat_completions_v1"; "gen_ai.request.model", "model-d-5" ]
     0.3;
   Metrics.observe
     h
-    ~labels:[ "gen_ai.system", "provider_d"; "gen_ai.request.model", "model-d-5" ]
+    ~labels:
+      [ "gen_ai.system", "chat_completions_v1"; "gen_ai.request.model", "model-d-5" ]
     0.9;
   Metrics.observe
     h
@@ -69,10 +71,11 @@ let test_histogram_with_labels () =
   check int "total count" 3 (Metrics.histogram_count h);
   check
     int
-    "provider_d count"
+    "chat_completions_v1 count"
     2
     (Metrics.histogram_count
-       ~labels:[ "gen_ai.request.model", "model-d-5"; "gen_ai.system", "provider_d" ]
+       ~labels:
+         [ "gen_ai.request.model", "model-d-5"; "gen_ai.system", "chat_completions_v1" ]
        h);
   check
     int
@@ -222,28 +225,30 @@ let test_register_same_name_same_kind_is_idempotent () =
 let test_prometheus_text_histogram_exports_labeled_series () =
   let m = Metrics.create () in
   let h = Metrics.histogram m ~name:"gen_ai.client.ttfrc" ~buckets:[ 1.0; 2.0 ] in
-  let labels = [ "gen_ai.system", "provider_d"; "gen_ai.request.model", "model-d-5" ] in
+  let labels =
+    [ "gen_ai.system", "chat_completions_v1"; "gen_ai.request.model", "model-d-5" ]
+  in
   Metrics.observe h ~labels 0.5;
   Metrics.observe h ~labels 3.0;
   let text = Metrics.to_prometheus_text m in
   check_line
     "labeled bucket"
-    "gen_ai_client_ttfrc_bucket{gen_ai_request_model=\"model-d-5\",gen_ai_system=\"provider_d\",le=\"1\"} \
+    "gen_ai_client_ttfrc_bucket{gen_ai_request_model=\"model-d-5\",gen_ai_system=\"chat_completions_v1\",le=\"1\"} \
      1"
     text;
   check_line
     "labeled +Inf bucket"
-    "gen_ai_client_ttfrc_bucket{gen_ai_request_model=\"model-d-5\",gen_ai_system=\"provider_d\",le=\"+Inf\"} \
+    "gen_ai_client_ttfrc_bucket{gen_ai_request_model=\"model-d-5\",gen_ai_system=\"chat_completions_v1\",le=\"+Inf\"} \
      2"
     text;
   check_line
     "labeled sum"
-    "gen_ai_client_ttfrc_sum{gen_ai_request_model=\"model-d-5\",gen_ai_system=\"provider_d\"} \
+    "gen_ai_client_ttfrc_sum{gen_ai_request_model=\"model-d-5\",gen_ai_system=\"chat_completions_v1\"} \
      3.5"
     text;
   check_line
     "labeled count"
-    "gen_ai_client_ttfrc_count{gen_ai_request_model=\"model-d-5\",gen_ai_system=\"provider_d\"} \
+    "gen_ai_client_ttfrc_count{gen_ai_request_model=\"model-d-5\",gen_ai_system=\"chat_completions_v1\"} \
      2"
     text
 ;;
@@ -251,7 +256,7 @@ let test_prometheus_text_histogram_exports_labeled_series () =
 let test_otlp_json_histogram_exports_labeled_datapoints () =
   let m = Metrics.create () in
   let h = Metrics.histogram m ~name:"gen_ai.client.ttfrc" ~buckets:[ 1.0; 2.0 ] in
-  Metrics.observe h ~labels:[ "gen_ai.system", "provider_d" ] 0.5;
+  Metrics.observe h ~labels:[ "gen_ai.system", "chat_completions_v1" ] 0.5;
   let json = Metrics.to_otlp_json m in
   let open Yojson.Safe.Util in
   let metrics =
@@ -288,7 +293,7 @@ let test_otlp_json_histogram_exports_labeled_datapoints () =
   check
     string
     "attribute value"
-    "provider_d"
+    "chat_completions_v1"
     (List.hd attrs |> member "value" |> member "stringValue" |> to_string)
 ;;
 

--- a/test/test_metrics_aggregating.ml
+++ b/test/test_metrics_aggregating.ml
@@ -28,13 +28,13 @@ let test_aggregating_on_request_start () =
 let test_aggregating_on_retry () =
   let agg = Agg.create () in
   let hooks = Agg.to_hooks agg in
-  hooks.on_retry ~provider:"provider_d" ~model_id:"model-d-4" ~attempt:1;
-  hooks.on_retry ~provider:"provider_d" ~model_id:"model-d-4" ~attempt:2;
+  hooks.on_retry ~provider:"chat_completions_v1" ~model_id:"model-d-4" ~attempt:1;
+  hooks.on_retry ~provider:"chat_completions_v1" ~model_id:"model-d-4" ~attempt:2;
   let snap = Agg.snapshot agg in
   check int "one entry" 1 (List.length snap);
   let entry = List.hd snap in
   check int "retry_total" 2 entry.M.retry_total;
-  check string "provider" "provider_d" entry.M.provider;
+  check string "provider" "chat_completions_v1" entry.M.provider;
   check string "model_id" "model-d-4" entry.M.model_id
 ;;
 
@@ -79,14 +79,16 @@ let test_aggregating_on_circuit_state () =
   let agg = Agg.create ~inner () in
   let hooks = Agg.to_hooks agg in
   hooks.on_circuit_state
-    ~provider:"provider_d"
+    ~provider:"chat_completions_v1"
     ~model_id:"model-d-4"
-    ~provider_key:"model-d-4@https://api.provider_d.com"
+    ~provider_key:"model-d-4@https://api.chat-completions-v1.example"
     ~state:M.Circuit_open;
   (match !observed with
    | Some
-       ("provider_d", "model-d-4", "model-d-4@https://api.provider_d.com", M.Circuit_open)
-     -> ()
+       ( "chat_completions_v1"
+       , "model-d-4"
+       , "model-d-4@https://api.chat-completions-v1.example"
+       , M.Circuit_open ) -> ()
    | Some _ -> fail "unexpected circuit state callback"
    | None -> fail "missing circuit state callback");
   check int "state value" 1 (M.circuit_state_to_int M.Circuit_open);
@@ -171,7 +173,7 @@ let test_aggregating_key () =
 let test_aggregating_multiple_providers () =
   let agg = Agg.create () in
   let hooks = Agg.to_hooks agg in
-  hooks.on_retry ~provider:"provider_d" ~model_id:"model-d-4" ~attempt:1;
+  hooks.on_retry ~provider:"chat_completions_v1" ~model_id:"model-d-4" ~attempt:1;
   hooks.on_token_usage
     ~provider:"provider_a"
     ~model_id:"agent_llm_a"
@@ -184,7 +186,7 @@ let test_aggregating_multiple_providers () =
 
 let test_provider_snapshot_to_yojson () =
   let snapshot : M.provider_snapshot =
-    { provider = "provider_d"
+    { provider = "chat_completions_v1"
     ; model_id = "model-d-4.1"
     ; request_total = 3
     ; error_total = 1
@@ -206,7 +208,7 @@ let test_provider_snapshot_to_yojson () =
     check
       (option string)
       "provider"
-      (Some "provider_d")
+      (Some "chat_completions_v1")
       (List.assoc_opt "provider" fields |> Option.map Yojson.Safe.Util.to_string);
     check
       (option int)
@@ -291,9 +293,9 @@ let test_provider_snapshots_to_yojson_is_stable () =
 let test_aggregating_save_snapshot_json () =
   let agg = Agg.create () in
   let hooks = Agg.to_hooks agg in
-  hooks.on_retry ~provider:"provider_d" ~model_id:"model-d-4.1" ~attempt:1;
+  hooks.on_retry ~provider:"chat_completions_v1" ~model_id:"model-d-4.1" ~attempt:1;
   hooks.on_token_usage
-    ~provider:"provider_d"
+    ~provider:"chat_completions_v1"
     ~model_id:"model-d-4.1"
     ~input_tokens:10
     ~output_tokens:4;
@@ -321,7 +323,7 @@ let test_aggregating_save_snapshot_json () =
                check
                  string
                  "provider"
-                 "provider_d"
+                 "chat_completions_v1"
                  (List.assoc "provider" provider |> Yojson.Safe.Util.to_string);
                check
                  int

--- a/test/test_multivendor_events.ml
+++ b/test/test_multivendor_events.ml
@@ -1,6 +1,6 @@
 (** Multi-vendor Event_bus taxonomy invariants.
 
-    Every provider OAS supports — Anthropic, Provider_d (+ compatibles),
+    Every provider OAS supports — Anthropic, Chat_completions_v1 (+ compatibles),
     Gemini, Glm, Provider_o_router, llama.cpp, Ollama, vLLM, LM Studio, etc. —
     produces the same native Event_bus payload variants when running
     through OAS.  This test encodes the taxonomy invariants so any

--- a/test/test_multivendor_live.ml
+++ b/test/test_multivendor_live.ml
@@ -4,9 +4,9 @@
     providers are reachable in the current environment:
 
     - Anthropic      if [PROVIDER_A_API_KEY] is set
-    - Provider_d         if [PROVIDER_D_API_KEY] is set
+    - Chat_completions_v1         if [PROVIDER_D_API_KEY] is set
     - Gemini         if [PROVIDER_F_API_KEY] is set
-    - Provider_d-compat  for every healthy endpoint in [LLM_ENDPOINTS]
+    - Chat_completions_v1-compat  for every healthy endpoint in [LLM_ENDPOINTS]
                      (llama-server, Ollama, vLLM, LM Studio, TGI, ...)
 
     Each provider case is [Quick] but skips gracefully (logs +
@@ -138,17 +138,17 @@ let test_provider_a () =
       ~model:"agent_llm_a-haiku-4-5"
 ;;
 
-(* ── Provider_d (via OpenAICompat) ────────────────────────────────── *)
+(* ── Chat_completions_v1 (via OpenAICompat) ────────────────────────────────── *)
 
-let test_provider_d () =
+let test_chat_completions_v1 () =
   match Sys.getenv_opt "PROVIDER_D_API_KEY" with
-  | None | Some "" -> skip_note "provider_d" "PROVIDER_D_API_KEY not set"
+  | None | Some "" -> skip_note "chat_completions_v1" "PROVIDER_D_API_KEY not set"
   | Some _ ->
     Eio_main.run
     @@ fun env ->
     Eio.Switch.run
     @@ fun sw ->
-    let base_url = "https://api.provider_d.com" in
+    let base_url = "https://api.chat-completions-v1.example" in
     let provider : Provider.config =
       { provider =
           Provider.OpenAICompat
@@ -164,13 +164,13 @@ let test_provider_d () =
     run_minimal_agent
       ~env
       ~sw
-      ~provider_label:"provider_d"
+      ~provider_label:"chat_completions_v1"
       ~provider
       ~base_url
       ~model:"model-d-mini"
 ;;
 
-(* ── Gemini (via Provider_d-compat endpoint) ──────────────────────── *)
+(* ── Gemini (via Chat_completions_v1-compat endpoint) ──────────────────────── *)
 
 let test_provider_f () =
   match Sys.getenv_opt "PROVIDER_F_API_KEY" with
@@ -180,8 +180,10 @@ let test_provider_f () =
     @@ fun env ->
     Eio.Switch.run
     @@ fun sw ->
-    (* Google's Provider_d-compatible endpoint for Gemini. *)
-    let base_url = "https://generativelanguage.googleapis.com/v1beta/provider_d" in
+    (* Google's Chat_completions_v1-compatible endpoint for Gemini. *)
+    let base_url =
+      "https://generativelanguage.googleapis.com/v1beta/chat_completions_v1"
+    in
     let provider : Provider.config =
       { provider =
           Provider.OpenAICompat
@@ -203,7 +205,7 @@ let test_provider_f () =
       ~model:"provider_f-2.0-flash"
 ;;
 
-(* ── Local Provider_d-compatible (llama-server, Ollama, vLLM, ...) ─ *)
+(* ── Local Chat_completions_v1-compatible (llama-server, Ollama, vLLM, ...) ─ *)
 
 let test_local_compat () =
   Eio_main.run
@@ -258,7 +260,7 @@ let () =
     "Multivendor_live"
     [ ( "golden_transcript"
       , [ test_case "provider_a" `Quick test_provider_a
-        ; test_case "provider_d" `Quick test_provider_d
+        ; test_case "chat_completions_v1" `Quick test_chat_completions_v1
         ; test_case "provider_f" `Quick test_provider_f
         ; test_case "local openai-compat" `Quick test_local_compat
         ] )

--- a/test/test_pipeline_common_coverage.ml
+++ b/test/test_pipeline_common_coverage.ml
@@ -8,9 +8,9 @@ let check_string = Alcotest.(check string)
 let check_opt_string = Alcotest.(check (option string))
 let check_string_list = Alcotest.(check (list string))
 
-let provider_d_config : Provider.config =
+let chat_completions_v1_config : Provider.config =
   { provider = Local { base_url = "http://127.0.0.1:65535" }
-  ; model_id = "provider_d_chat"
+  ; model_id = "chat_completions_v1"
   ; api_key_env = "DUMMY_KEY"
   }
 ;;
@@ -33,7 +33,7 @@ let echo_tool =
 
 let text_response ?(content = [ Types.Text "ok" ]) () : Types.api_response =
   { id = "resp-1"
-  ; model = "provider_d_chat"
+  ; model = "chat_completions_v1"
   ; stop_reason = EndTurn
   ; content
   ; usage = None
@@ -95,12 +95,12 @@ let test_agent_type_checkpoint_stage_labels () =
 
 let test_agent_type_accessors_card_and_state_mutators () =
   let config =
-    { Types.default_config with name = "coverage-agent"; model = "provider_d_chat" }
+    { Types.default_config with name = "coverage-agent"; model = "chat_completions_v1" }
   in
   let options =
     { Internal_agent.default_options with
       description = Some "Coverage agent"
-    ; provider = Some provider_d_config
+    ; provider = Some chat_completions_v1_config
     ; allowed_paths = [ "/tmp/oas" ]
     }
   in
@@ -236,7 +236,7 @@ let test_validate_completion_contract_accepts_default_text () =
 let test_validate_completion_contract_rejects_missing_tool () =
   let config = { Types.default_config with tool_choice = Some Types.Any } in
   let options =
-    { Internal_agent.default_options with provider = Some provider_d_config }
+    { Internal_agent.default_options with provider = Some chat_completions_v1_config }
   in
   with_agent ~config ~options (fun agent ->
     match Pipeline_common.validate_completion_contract agent (text_response ()) with
@@ -248,7 +248,7 @@ let test_validate_completion_contract_rejects_missing_tool () =
 let test_validate_completion_contract_accepts_tool_use () =
   let config = { Types.default_config with tool_choice = Some Types.Any } in
   let options =
-    { Internal_agent.default_options with provider = Some provider_d_config }
+    { Internal_agent.default_options with provider = Some chat_completions_v1_config }
   in
   let response =
     text_response

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -197,7 +197,7 @@ let test_inference_contract_task_transcription () =
   let cfg : Provider.config =
     { provider =
         OpenAICompat
-          { base_url = "https://api.provider_d.com/v1"
+          { base_url = "https://api.chat-completions-v1.example/v1"
           ; auth_header = Some "Authorization"
           ; path = "/audio/transcriptions"
           ; static_token = None
@@ -317,7 +317,7 @@ let test_validate_inference_contract_rejects_unsupported_modality () =
   | Ok () -> Alcotest.fail "expected unsupported modality validation to fail"
 ;;
 
-let test_extended_provider_d_capabilities () =
+let test_extended_chat_completions_v1_capabilities () =
   let capabilities =
     Provider.capabilities_for_model
       ~provider:
@@ -617,7 +617,8 @@ let test_provider_config_of_agent_openai_compat_collapses () =
   let cfg : Provider.config =
     { provider =
         OpenAICompat
-          { base_url = "https://generativelanguage.googleapis.com/v1beta/provider_d"
+          { base_url =
+              "https://generativelanguage.googleapis.com/v1beta/chat_completions_v1"
           ; auth_header = Some "Authorization"
           ; path = "/chat/completions"
           ; static_token = None
@@ -637,7 +638,7 @@ let test_provider_config_of_agent_openai_compat_collapses () =
       (Llm_provider.Provider_config.string_of_provider_kind pc.kind);
     Alcotest.(check string)
       "base_url from resolve"
-      "https://generativelanguage.googleapis.com/v1beta/provider_d"
+      "https://generativelanguage.googleapis.com/v1beta/chat_completions_v1"
       pc.base_url;
     Alcotest.(check string) "request_path preserved" "/chat/completions" pc.request_path;
     Alcotest.(check bool)
@@ -725,7 +726,7 @@ let test_provider_config_of_agent_custom_registered_preserves_kind () =
   (* Regression for #1003: Custom_registered must preserve the
      registry-declared provider_kind (e.g. Gemini) rather than
      flattening to OpenAI_compat, which would route Gemini requests
-     through the Provider_d wire format and produce 404 against the
+     through the Chat_completions_v1 wire format and produce 404 against the
      Gemini base URL. *)
   let cfg : Provider.config =
     { provider = Custom_registered { name = "provider_f" }
@@ -865,11 +866,11 @@ let () =
         ; Alcotest.test_case "local skips env var" `Quick test_local_skips_env_var
         ; Alcotest.test_case "provider_a provider" `Quick test_provider_a_provider
         ; Alcotest.test_case
-            "provider_d compat success"
+            "chat_completions_v1 compat success"
             `Quick
             test_openai_compat_resolve_success
         ; Alcotest.test_case
-            "provider_d compat missing key"
+            "chat_completions_v1 compat missing key"
             `Quick
             test_openai_compat_resolve_missing_key
         ; Alcotest.test_case "provider_a headers" `Quick test_provider_a_headers
@@ -902,7 +903,7 @@ let () =
             `Quick
             test_zai_glm5v_capabilities_include_image_input
         ; Alcotest.test_case
-            "non-zai provider_k stays provider_d compat"
+            "non-zai provider_k stays chat_completions_v1 compat"
             `Quick
             test_non_zai_glm_capabilities_stay_openai_compat
         ; Alcotest.test_case
@@ -910,9 +911,9 @@ let () =
             `Quick
             test_validate_inference_contract_rejects_unsupported_modality
         ; Alcotest.test_case
-            "extended provider_d capabilities"
+            "extended chat_completions_v1 capabilities"
             `Quick
-            test_extended_provider_d_capabilities
+            test_extended_chat_completions_v1_capabilities
         ; Alcotest.test_case
             "provider_a consults for_model_id (#824)"
             `Quick

--- a/test/test_provider_bridge.ml
+++ b/test/test_provider_bridge.ml
@@ -60,10 +60,11 @@ let test_non_zai_glm_stays_openai_compat () =
     }
   in
   match Agent_sdk.Provider_bridge.to_provider_config legacy with
-  | Error _ -> Alcotest.fail "custom provider_d compat provider should not need env var"
+  | Error _ ->
+    Alcotest.fail "custom chat_completions_v1 compat provider should not need env var"
   | Ok cfg ->
     Alcotest.(check string)
-      "kind remains provider_d compat"
+      "kind remains chat_completions_v1 compat"
       "openai_compat"
       (match cfg.kind with
        | Llm_provider.Provider_config.OpenAI_compat -> "openai_compat"
@@ -170,12 +171,12 @@ let test_provider_a_auto_and_explicit_models () =
 ;;
 
 let test_openai_compat_auto_model_branches () =
-  with_env "OLLAMA_DEFAULT_MODEL" "provider-d-env-default" (fun () ->
+  with_env "OLLAMA_DEFAULT_MODEL" "chat-completions-v1-env-default" (fun () ->
     with_env "PROVIDER_F_DEFAULT_MODEL" "provider_f-env-default" (fun () ->
-      let provider_d_auto =
+      let chat_completions_v1_auto =
         { Agent_sdk.Provider.provider =
             OpenAICompat
-              { base_url = "https://provider-d.example/v1"
+              { base_url = "https://chat-completions-v1.example/v1"
               ; auth_header = None
               ; path = "/chat/completions"
               ; static_token = None
@@ -184,14 +185,19 @@ let test_openai_compat_auto_model_branches () =
         ; api_key_env = ""
         }
       in
-      let provider_f_prefixed = { provider_d_auto with model_id = "provider_f-auto" } in
-      let provider_f_explicit =
-        { provider_d_auto with model_id = "provider_f-2.5-pro" }
+      let provider_f_prefixed =
+        { chat_completions_v1_auto with model_id = "provider_f-auto" }
       in
-      (match Agent_sdk.Provider_bridge.to_provider_config provider_d_auto with
+      let provider_f_explicit =
+        { chat_completions_v1_auto with model_id = "provider_f-2.5-pro" }
+      in
+      (match Agent_sdk.Provider_bridge.to_provider_config chat_completions_v1_auto with
        | Ok cfg ->
-         check_kind "provider_d compat kind" "openai_compat" cfg;
-         Alcotest.(check string) "provider_d auto" "provider-d-env-default" cfg.model_id
+         check_kind "chat_completions_v1 compat kind" "openai_compat" cfg;
+         Alcotest.(check string)
+           "chat_completions_v1 auto"
+           "chat-completions-v1-env-default"
+           cfg.model_id
        | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err));
       (match Agent_sdk.Provider_bridge.to_provider_config provider_f_prefixed with
        | Ok cfg ->
@@ -241,10 +247,10 @@ let () =
     "provider_bridge"
     [ ( "to_provider_config"
       , [ test_case "provider_a" `Quick test_provider_a_bridge
-        ; test_case "provider_d compat" `Quick test_openai_compat_bridge
+        ; test_case "chat_completions_v1 compat" `Quick test_openai_compat_bridge
         ; test_case "local" `Quick test_local_provider_bridge
         ; test_case
-            "non-zai provider_k stays provider_d compat"
+            "non-zai provider_k stays chat_completions_v1 compat"
             `Quick
             test_non_zai_glm_stays_openai_compat
         ; test_case

--- a/test/test_provider_catalog_coverage.ml
+++ b/test/test_provider_catalog_coverage.ml
@@ -43,7 +43,7 @@ let test_full_entry_parses_auth_transport_and_capabilities () =
             "credential_scope": "workspace",
             "auth": {"type": "setup_token_env", "env": "SETUP_TOKEN"},
             "max_context": 32000,
-            "capabilities_base": "provider_d_chat",
+            "capabilities_base": "chat_completions_v1",
             "capabilities": {
               "max_context_tokens": 64000,
               "max_output_tokens": 4096,
@@ -257,7 +257,7 @@ let test_transport_auth_and_thinking_canonical_matrix () =
           {
             "id": "base-entry",
             "kind": "openai_compat",
-            "capabilities_base": "provider_d_chat",
+            "capabilities_base": "chat_completions_v1",
             "max_context": 9223372036854775807999,
             "capabilities": {
               "prompt_cache_alignment": 9223372036854775807999
@@ -337,7 +337,7 @@ let test_removed_catalog_aliases_are_rejected () =
     "removed provider catalog auth field";
   assert_reject
     "capability base alias rejected"
-    {|{"schema_version":1,"providers":[{"id":"p","base":"provider_d_chat"}]}|}
+    {|{"schema_version":1,"providers":[{"id":"p","base":"chat_completions_v1"}]}|}
     "removed provider catalog field \"base\"";
   assert_reject
     "auth alias rejected"

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -2,7 +2,7 @@
 
 module PC = Llm_provider.Provider_config
 module BA = Llm_provider.Backend_provider_a
-module BO = Llm_provider.Backend_provider_d
+module BO = Llm_provider.Backend_chat_completions_v1
 module BGlm = Llm_provider.Backend_provider_k
 module BOL = Llm_provider.Backend_ollama
 module BGemini = Llm_provider.Backend_provider_f
@@ -177,14 +177,14 @@ let test_provider_a_parse_response_initializes_telemetry () =
   | None -> Alcotest.fail "expected telemetry placeholder"
 ;;
 
-(* ── Provider_d build_request ────────────────────────────── *)
+(* ── Chat_completions_v1 build_request ────────────────────────────── *)
 
-let test_provider_d_basic_body () =
+let test_chat_completions_v1_basic_body () =
   let config =
     PC.make
       ~kind:OpenAI_compat
       ~model_id:"model-d-4"
-      ~base_url:"https://api.provider_d.com/v1"
+      ~base_url:"https://api.chat-completions-v1.example/v1"
       ~max_tokens:2048
       ()
   in
@@ -198,7 +198,7 @@ let test_provider_d_basic_body () =
   Alcotest.(check int) "1 message" 1 (List.length msgs_json)
 ;;
 
-let test_provider_d_with_system () =
+let test_chat_completions_v1_with_system () =
   let config =
     PC.make
       ~kind:OpenAI_compat
@@ -220,7 +220,7 @@ let test_provider_d_with_system () =
     (first |> member "content" |> to_string)
 ;;
 
-let test_provider_d_with_tools () =
+let test_chat_completions_v1_with_tools () =
   let config = PC.make ~kind:OpenAI_compat ~model_id:"model-d-4" ~base_url:"" () in
   let tool =
     `Assoc
@@ -238,7 +238,7 @@ let test_provider_d_with_tools () =
   Alcotest.(check int) "1 tool" 1 (List.length tools)
 ;;
 
-let test_provider_d_stream_flag () =
+let test_chat_completions_v1_stream_flag () =
   let config = PC.make ~kind:OpenAI_compat ~model_id:"m" ~base_url:"" () in
   let body = BO.build_request ~stream:true ~config ~messages:[ user_msg "hi" ] () in
   let json = Yojson.Safe.from_string body in
@@ -352,7 +352,7 @@ let test_ollama_parse_warns_on_malformed_tool_call () =
   Alcotest.(check bool) "malformed tool call warning" true has_warning
 ;;
 
-let test_provider_d_with_json_schema () =
+let test_chat_completions_v1_with_json_schema () =
   let schema =
     `Assoc
       [ "type", `String "object"
@@ -363,7 +363,7 @@ let test_provider_d_with_json_schema () =
     PC.make
       ~kind:OpenAI_compat
       ~model_id:"model-d-mini"
-      ~base_url:"https://api.provider_d.com/v1"
+      ~base_url:"https://api.chat-completions-v1.example/v1"
       ~response_format:(JsonSchema schema)
       ()
   in
@@ -608,7 +608,10 @@ let test_config_default_paths () =
   let provider_c = PC.make ~kind:Kimi ~model_id:"m" ~base_url:"" () in
   Alcotest.(check string) "provider_c path" "/v1/messages" provider_c.request_path;
   let oai = PC.make ~kind:OpenAI_compat ~model_id:"m" ~base_url:"" () in
-  Alcotest.(check string) "provider_d path" "/v1/chat/completions" oai.request_path
+  Alcotest.(check string)
+    "chat_completions_v1 path"
+    "/v1/chat/completions"
+    oai.request_path
 ;;
 
 let test_config_custom_path () =
@@ -1041,10 +1044,10 @@ let () =
             `Quick
             test_provider_a_parse_response_initializes_telemetry
         ] )
-    ; ( "provider_d_build_request"
-      , [ test_case "basic body" `Quick test_provider_d_basic_body
-        ; test_case "with system" `Quick test_provider_d_with_system
-        ; test_case "with tools" `Quick test_provider_d_with_tools
+    ; ( "chat_completions_v1_build_request"
+      , [ test_case "basic body" `Quick test_chat_completions_v1_basic_body
+        ; test_case "with system" `Quick test_chat_completions_v1_with_system
+        ; test_case "with tools" `Quick test_chat_completions_v1_with_tools
         ; test_case
             "provider_c direct tools + thinking"
             `Quick
@@ -1053,8 +1056,8 @@ let () =
             "provider_c direct tool_result uses text blocks"
             `Quick
             test_provider_c_direct_tool_result_uses_text_blocks
-        ; test_case "stream flag" `Quick test_provider_d_stream_flag
-        ; test_case "with json schema" `Quick test_provider_d_with_json_schema
+        ; test_case "stream flag" `Quick test_chat_completions_v1_stream_flag
+        ; test_case "with json schema" `Quick test_chat_completions_v1_with_json_schema
         ; test_case "ollama output schema" `Quick test_ollama_output_schema
         ; test_case
             "ollama parse parallel tool calls object args"

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -48,9 +48,9 @@ let test_request_path_provider_c () =
   check_string "kimi path" "/v1/chat/completions" cfg.request_path
 ;;
 
-let test_request_path_provider_d () =
+let test_request_path_chat_completions_v1 () =
   let cfg = Provider_config.make ~kind:OpenAI_compat ~model_id:"m" ~base_url:"" () in
-  check_string "provider_d path" "/v1/chat/completions" cfg.request_path
+  check_string "chat_completions_v1 path" "/v1/chat/completions" cfg.request_path
 ;;
 
 let test_request_path_provider_f () =
@@ -137,7 +137,7 @@ let test_make_response_format_json_mode () =
     Provider_config.make
       ~kind:OpenAI_compat
       ~model_id:"model-d"
-      ~base_url:"https://api.provider_d.com/v1"
+      ~base_url:"https://api.chat-completions-v1.example/v1"
       ~response_format_json:true
       ()
   in
@@ -171,17 +171,17 @@ let test_output_schema_of_response_format () =
        (Provider_config.output_schema_of_response_format ~override:schema Types.JsonMode))
 ;;
 
-let test_validate_output_schema_provider_d_official () =
+let test_validate_output_schema_chat_completions_v1_official () =
   let cfg =
     Provider_config.make
       ~kind:OpenAI_compat
       ~model_id:"model-d"
-      ~base_url:"https://api.provider_d.com/v1"
+      ~base_url:"https://api.chat-completions-v1.example/v1"
       ~output_schema:(`Assoc [ "type", `String "object" ])
       ()
   in
   check_bool
-    "official provider_d accepted"
+    "official chat_completions_v1 accepted"
     true
     (Result.is_ok (Provider_config.validate_output_schema_request cfg))
 ;;
@@ -279,7 +279,7 @@ let test_validate_output_schema_direct_response_format_record () =
     (Result.is_error (Provider_config.validate_output_schema_request cfg))
 ;;
 
-let test_validate_output_schema_supported_non_provider_d () =
+let test_validate_output_schema_supported_non_chat_completions_v1 () =
   let schema = `Assoc [ "type", `String "object" ] in
   List.iter
     (fun kind ->
@@ -303,7 +303,7 @@ let test_validate_output_schema_capability_rejected () =
     Provider_config.make
       ~kind:OpenAI_compat
       ~model_id:"unknown-model-without-schema-capability"
-      ~base_url:"https://api.provider_d.com/v1"
+      ~base_url:"https://api.chat-completions-v1.example/v1"
       ~output_schema:(`Assoc [ "type", `String "object" ])
       ()
   in
@@ -513,7 +513,7 @@ let test_provider_name_of_config_local_openai_compat () =
       ()
   in
   check_string
-    "local provider_d compat resolves to llama"
+    "local chat_completions_v1 compat resolves to llama"
     "provider_n"
     (Provider_registry.provider_name_of_config cfg)
 ;;
@@ -522,7 +522,7 @@ let test_provider_name_of_config_openrouter () =
   let cfg =
     Provider_config.make
       ~kind:OpenAI_compat
-      ~model_id:"provider_d/gpt-oss-20b"
+      ~model_id:"chat_completions_v1/gpt-oss-20b"
       ~base_url:"https://openrouter.ai/api/v1"
       ~request_path:"/chat/completions"
       ()
@@ -567,7 +567,14 @@ let test_kind_aliases_rejected () =
          ("alias rejected " ^ input)
          true
          (Option.is_none (Provider_config.provider_kind_of_string input)))
-    [ "agent_llm_a"; "provider_d"; "provider_n"; "claude"; "openai"; "llama"; "zhipu" ]
+    [ "agent_llm_a"
+    ; "chat_completions_v1"
+    ; "provider_n"
+    ; "claude"
+    ; "openai"
+    ; "llama"
+    ; "zhipu"
+    ]
 ;;
 
 let test_kind_case_insensitive () =
@@ -651,7 +658,7 @@ let test_of_yojson_rejects_aliases () =
        match Provider_config.provider_kind_of_yojson json with
        | Ok _ -> Alcotest.failf "of_yojson alias %S should fail" input
        | Error _ -> ())
-    [ "agent_llm_a"; "provider_d"; "provider_n" ]
+    [ "agent_llm_a"; "chat_completions_v1"; "provider_n" ]
 ;;
 
 let test_of_yojson_rejects_unknown_string () =
@@ -843,7 +850,7 @@ let test_default_api_key_env_known () =
 ;;
 
 let test_default_api_key_env_none_for_others () =
-  (* Local / transport-mediated / Provider_d-compatible share: OAS does not
+  (* Local / transport-mediated / Chat_completions_v1-compatible share: OAS does not
      dictate a single env var; callers supply their own. *)
   List.iter
     (fun (label, k) ->
@@ -882,7 +889,10 @@ let () =
     ; ( "request_path"
       , [ Alcotest.test_case "provider_a" `Quick test_request_path_provider_a
         ; Alcotest.test_case "provider_c" `Quick test_request_path_provider_c
-        ; Alcotest.test_case "provider_d" `Quick test_request_path_provider_d
+        ; Alcotest.test_case
+            "chat_completions_v1"
+            `Quick
+            test_request_path_chat_completions_v1
         ; Alcotest.test_case "provider_f" `Quick test_request_path_provider_f
         ; Alcotest.test_case "provider_k" `Quick test_request_path_glm
         ; Alcotest.test_case "ollama" `Quick test_request_path_ollama
@@ -903,9 +913,9 @@ let () =
         ] )
     ; ( "output_schema"
       , [ Alcotest.test_case
-            "official provider_d"
+            "official chat_completions_v1"
             `Quick
-            test_validate_output_schema_provider_d_official
+            test_validate_output_schema_chat_completions_v1_official
         ; Alcotest.test_case
             "generic compat rejected"
             `Quick
@@ -931,11 +941,11 @@ let () =
             `Quick
             test_validate_output_schema_direct_response_format_record
         ; Alcotest.test_case
-            "supported non-provider_d providers"
+            "supported non-chat_completions_v1 providers"
             `Quick
-            test_validate_output_schema_supported_non_provider_d
+            test_validate_output_schema_supported_non_chat_completions_v1
         ; Alcotest.test_case
-            "provider_d capability rejection"
+            "chat_completions_v1 capability rejection"
             `Quick
             test_validate_output_schema_capability_rejected
         ] )
@@ -982,7 +992,7 @@ let () =
             `Quick
             test_provider_name_of_config_glm_coding
         ; Alcotest.test_case
-            "local provider_d compat"
+            "local chat_completions_v1 compat"
             `Quick
             test_provider_name_of_config_local_openai_compat
         ; Alcotest.test_case

--- a/test/test_provider_f_edge_cases.ml
+++ b/test/test_provider_f_edge_cases.ml
@@ -103,7 +103,7 @@ let test_sse_function_call () =
     check "parsed chunk" true;
     check "has parts" (List.length chunk.gem_parts > 0);
     check "finish reason STOP" (chunk.gem_finish_reason = Some "STOP");
-    let state = Streaming.create_provider_d_stream_state () in
+    let state = Streaming.create_chat_completions_v1_stream_state () in
     let events, _tel = Streaming.provider_f_chunk_to_events state chunk in
     let has_tool_start =
       List.exists

--- a/test/test_provider_intf.ml
+++ b/test/test_provider_intf.ml
@@ -15,7 +15,7 @@ let test_of_config_provider_a () =
   ignore (module P : Provider_intf.PROVIDER)
 ;;
 
-let test_of_config_provider_d () =
+let test_of_config_chat_completions_v1 () =
   let config = Provider.provider_o_router ~model_id:"model-d-4" () in
   let (module P : Provider_intf.PROVIDER) = Provider_intf.of_config config in
   ignore (module P : Provider_intf.PROVIDER)
@@ -43,7 +43,7 @@ let test_streaming_provider_some () =
 
 (* ── HTTP dispatch ───────────────────────────────────────── *)
 
-let provider_d_response =
+let chat_completions_v1_response =
   {|{"id":"chatcmpl-provider-intf","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2}}|}
 ;;
 
@@ -117,7 +117,7 @@ let test_provider_dispatch_uses_http_client () =
     seen_content_length := Cohttp.Header.get headers "content-length";
     seen_path := Some (Uri.path (Cohttp.Request.uri req));
     ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
-    Cohttp_eio.Server.respond_string ~status:`OK ~body:provider_d_response ()
+    Cohttp_eio.Server.respond_string ~status:`OK ~body:chat_completions_v1_response ()
   in
   with_mock_server handler (fun ~sw ~net ~base_url ->
     let provider : Provider.config =
@@ -176,7 +176,7 @@ let test_provider_dispatch_maps_server_error () =
     | Ok _ -> Alcotest.fail "expected server error")
 ;;
 
-let test_provider_dispatch_rejects_malformed_provider_d_response () =
+let test_provider_dispatch_rejects_malformed_chat_completions_v1_response () =
   let handler _conn _req body =
     ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
     Cohttp_eio.Server.respond_string ~status:`OK ~body:{|{"choices":"not-a-list"}|} ()
@@ -269,9 +269,9 @@ let () =
             `Quick
             test_of_config_provider_a
         ; Alcotest.test_case
-            "provider_d satisfies PROVIDER"
+            "chat_completions_v1 satisfies PROVIDER"
             `Quick
-            test_of_config_provider_d
+            test_of_config_chat_completions_v1
         ] )
     ; ( "streaming"
       , [ Alcotest.test_case
@@ -292,7 +292,7 @@ let () =
         ; Alcotest.test_case
             "rejects malformed response"
             `Quick
-            test_provider_dispatch_rejects_malformed_provider_d_response
+            test_provider_dispatch_rejects_malformed_chat_completions_v1_response
         ; Alcotest.test_case
             "custom provider dispatch"
             `Quick

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -516,7 +516,7 @@ let test_catalog_overlay_adds_provider_and_alias () =
           "request_path": "/v1/chat/completions",
           "auth": {"type": "none"},
           "default_model": "local-model",
-          "capabilities_base": "provider_d_chat",
+          "capabilities_base": "chat_completions_v1",
           "capabilities": {
             "max_context_tokens": 131072,
             "supports_tools": true,
@@ -552,7 +552,7 @@ let test_catalog_overlay_replaces_seed_provider () =
           "base_url": "https://example.test/provider_o_router",
           "request_path": "/chat/completions",
           "auth": {"type": "api_key_env", "env": "OPENROUTER_API_KEY"},
-          "capabilities_base": "provider_d_chat"
+          "capabilities_base": "chat_completions_v1"
         }
       ]
     }|}
@@ -579,7 +579,7 @@ let test_catalog_overlay_normalizes_provider_id () =
           "transport": "http",
           "base_url": "https://acme.example/v1",
           "auth": {"type": "none"},
-          "capabilities_base": "provider_d_chat"
+          "capabilities_base": "chat_completions_v1"
         }
       ]
     }|}
@@ -681,7 +681,7 @@ let test_catalog_accepts_explicit_thinking_control_formats () =
               "capabilities": {"thinking_control_format": "thinking_object_only"}},
              {"id": "provider_h", "kind": "openai_compat",
               "capabilities": {"thinking_control_format": "enable_thinking"}},
-             {"id": "provider_d-reasoning", "kind": "openai_compat",
+             {"id": "chat_completions_v1-reasoning", "kind": "openai_compat",
               "capabilities": {"thinking_control_format": "reasoning_effort"}}
            ]
          }|})
@@ -700,7 +700,7 @@ let test_catalog_accepts_explicit_thinking_control_formats () =
     in
     check_format "provider_c-k2" Capabilities.Thinking_object_only;
     check_format "provider_h" Capabilities.Enable_thinking;
-    check_format "provider_d-reasoning" Capabilities.Reasoning_effort
+    check_format "chat_completions_v1-reasoning" Capabilities.Reasoning_effort
 ;;
 
 let test_catalog_lookup_first_match_wins () =
@@ -876,7 +876,7 @@ let test_catalog_api_key_env_availability () =
             "transport": "http",
             "base_url": "https://cloud-api.example/v1",
             "auth": {"type": "api_key_env", "env": "%s"},
-            "capabilities_base": "provider_d_chat"
+            "capabilities_base": "chat_completions_v1"
           }
         ]
       }|}

--- a/test/test_provider_runtime_binding.ml
+++ b/test/test_provider_runtime_binding.ml
@@ -22,7 +22,7 @@ let catalog_json =
       "request_path": "/v1/chat/completions",
       "auth": {"type": "none"},
       "default_model": "local-model",
-      "capabilities_base": "provider_d_chat",
+      "capabilities_base": "chat_completions_v1",
       "capabilities": {"supports_tools": true},
       "credential_scope": "test runtime"
     }
@@ -45,32 +45,32 @@ let catalog_variants_json =
       "request_path": "/chat/completions",
       "auth": {"type": "setup_token_env", "env": "RICH_SETUP_TOKEN"},
       "default_model": "rich-default",
-      "capabilities_base": "provider_d_chat"
+      "capabilities_base": "chat_completions_v1"
     },
     {
       "id": "managed-oauth",
       "kind": "openai_compat",
       "transport": "managed",
       "auth": {"type": "oauth_cached_login"},
-      "capabilities_base": "provider_d_chat"
+      "capabilities_base": "chat_completions_v1"
     },
         {
           "id": "file-auth",
           "kind": "openai_compat",
           "auth": {"type": "file", "path": "/tmp/provider-token"},
-      "capabilities_base": "provider_d_chat"
+      "capabilities_base": "chat_completions_v1"
     },
     {
       "id": "exec-auth",
       "kind": "openai_compat",
       "auth": {"type": "exec", "command": "op read token"},
-      "capabilities_base": "provider_d_chat"
+      "capabilities_base": "chat_completions_v1"
     },
     {
       "id": "api-key-auth",
       "kind": "openai_compat",
       "auth": {"type": "api_key_env", "env": "API_KEY_AUTH"},
-      "capabilities_base": "provider_d_chat"
+      "capabilities_base": "chat_completions_v1"
     }
   ]
 }

--- a/test/test_runtime_evidence.ml
+++ b/test/test_runtime_evidence.ml
@@ -586,7 +586,7 @@ let test_sessions_store_decodes_runtime_artifacts () =
   "step_count":1,
   "event_counts":{"Agent_completed":1},
   "event_name_counts":[{"event_name":"agent_completed","count":1}],
-  "steps":[{"seq":1,"ts":10.1,"kind":"Agent_completed","participant":"alice","detail":"done","actor":"agent","role":"worker","provider":"provider_d","model":"model-d","raw_trace_run_id":"run-1","stop_reason":"stop","artifact_id":"art-telemetry","artifact_name":"runtime-telemetry-json","artifact_kind":"json","checkpoint_label":"cp","outcome":"ok","dropped_output_deltas":2,"persistence_failure_phase":"append_event"}]
+  "steps":[{"seq":1,"ts":10.1,"kind":"Agent_completed","participant":"alice","detail":"done","actor":"agent","role":"worker","provider":"chat_completions_v1","model":"model-d","raw_trace_run_id":"run-1","stop_reason":"stop","artifact_id":"art-telemetry","artifact_name":"runtime-telemetry-json","artifact_kind":"json","checkpoint_label":"cp","outcome":"ok","dropped_output_deltas":2,"persistence_failure_phase":"append_event"}]
 }|}
        in
        let evidence_json =
@@ -673,7 +673,7 @@ let test_sessions_store_decodes_runtime_artifacts () =
          "agent_completed"
          (List.hd structured.event_counts).event_name;
        let step = List.hd structured.steps in
-       check (option string) "step provider" (Some "provider_d") step.provider;
+       check (option string) "step provider" (Some "chat_completions_v1") step.provider;
        check (option int) "dropped deltas" (Some 2) step.dropped_output_deltas;
        let evidence =
          Sessions_store.get_evidence ~session_root:root ~session_id () |> Result.get_ok

--- a/test/test_runtime_projection_cov2.ml
+++ b/test/test_runtime_projection_cov2.ml
@@ -312,7 +312,7 @@ let test_apply_agent_spawn () =
          { participant_name = "bob"
          ; role = Some "reviewer"
          ; prompt = "review"
-         ; provider = Some "provider_d"
+         ; provider = Some "chat_completions_v1"
          ; model = Some "model-d-4"
          ; permission_mode = None
          })
@@ -326,7 +326,7 @@ let test_apply_agent_spawn () =
     Alcotest.(check (option string)) "role" (Some "reviewer") bob.role;
     Alcotest.(check (option string))
       "req_provider"
-      (Some "provider_d")
+      (Some "chat_completions_v1")
       bob.requested_provider
   | Error e -> Alcotest.fail (Error.to_string e)
 ;;

--- a/test/test_runtime_server_resolve.ml
+++ b/test/test_runtime_server_resolve.ml
@@ -96,7 +96,7 @@ let test_provider_runtime_name_openai_compat () =
     Some
       { Provider.provider =
           Provider.OpenAICompat
-            { base_url = "https://api.provider_d.com"
+            { base_url = "https://api.chat-completions-v1.example"
             ; auth_header = None
             ; path = "/v1/chat/completions"
             ; static_token = None
@@ -108,7 +108,7 @@ let test_provider_runtime_name_openai_compat () =
   Alcotest.(check string)
     "openai-compat"
     "openai-compat"
-    (Runtime_server_resolve.provider_runtime_name "provider_d" cfg)
+    (Runtime_server_resolve.provider_runtime_name "chat_completions_v1" cfg)
 ;;
 
 let test_provider_runtime_name_custom_registered () =
@@ -239,7 +239,7 @@ let test_resolve_provider_catalog_entry () =
           "request_path": "/v1/chat/completions",
           "auth": {"type": "none"},
           "default_model": "local-model",
-          "capabilities_base": "provider_d_chat"
+          "capabilities_base": "chat_completions_v1"
         }
       ]
     }|}

--- a/test/test_streaming_chat_completions_v1.ml
+++ b/test/test_streaming_chat_completions_v1.ml
@@ -1,15 +1,15 @@
-(** Unit tests for Provider_d-compatible SSE streaming parser. *)
+(** Unit tests for Chat_completions_v1-compatible SSE streaming parser. *)
 
 open Llm_provider.Types
 module S = Llm_provider.Streaming
 
-(* ── parse_provider_d_sse_chunk ─────────────────────────────── *)
+(* ── parse_chat_completions_v1_sse_chunk ─────────────────────────────── *)
 
 let test_parse_text_chunk () =
   let data =
     {|{"id":"chatcmpl-abc","object":"chat.completion.chunk","model":"model-d-4","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}|}
   in
-  match S.parse_provider_d_sse_chunk data with
+  match S.parse_chat_completions_v1_sse_chunk data with
   | Some chunk ->
     Alcotest.(check string) "id" "chatcmpl-abc" chunk.chunk_id;
     Alcotest.(check string) "model" "model-d-4" chunk.chunk_model;
@@ -20,7 +20,7 @@ let test_parse_text_chunk () =
 ;;
 
 let test_parse_done_sentinel () =
-  match S.parse_provider_d_sse_chunk "[DONE]" with
+  match S.parse_chat_completions_v1_sse_chunk "[DONE]" with
   | None -> ()
   | Some _ -> Alcotest.fail "expected None for [DONE]"
 ;;
@@ -29,7 +29,7 @@ let test_parse_finish_reason () =
   let data =
     {|{"id":"c-1","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}|}
   in
-  match S.parse_provider_d_sse_chunk data with
+  match S.parse_chat_completions_v1_sse_chunk data with
   | Some chunk ->
     Alcotest.(check (option string)) "finish" (Some "stop") chunk.finish_reason;
     Alcotest.(check (option string)) "no content" None chunk.delta_content
@@ -40,7 +40,7 @@ let test_parse_tool_call_start () =
   let data =
     {|{"id":"c-2","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_abc","type":"function","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}|}
   in
-  match S.parse_provider_d_sse_chunk data with
+  match S.parse_chat_completions_v1_sse_chunk data with
   | Some chunk ->
     Alcotest.(check int) "1 tool_call" 1 (List.length chunk.delta_tool_calls);
     let tc = List.hd chunk.delta_tool_calls in
@@ -55,7 +55,7 @@ let test_parse_tool_call_args () =
   let data =
     {|{"id":"c-3","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"loc"}}]},"finish_reason":null}]}|}
   in
-  match S.parse_provider_d_sse_chunk data with
+  match S.parse_chat_completions_v1_sse_chunk data with
   | Some chunk ->
     let tc = List.hd chunk.delta_tool_calls in
     Alcotest.(check (option string)) "args" (Some {|{"loc|}) tc.tc_arguments;
@@ -68,7 +68,7 @@ let test_parse_usage () =
   let data =
     {|{"id":"c-4","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}|}
   in
-  match S.parse_provider_d_sse_chunk data with
+  match S.parse_chat_completions_v1_sse_chunk data with
   | Some chunk ->
     (match chunk.chunk_usage with
      | Some u ->
@@ -79,23 +79,23 @@ let test_parse_usage () =
 ;;
 
 let test_parse_invalid_json () =
-  match S.parse_provider_d_sse_chunk "not json" with
+  match S.parse_chat_completions_v1_sse_chunk "not json" with
   | None -> ()
   | Some _ -> Alcotest.fail "expected None for invalid JSON"
 ;;
 
 let test_parse_empty_choices () =
   let data = {|{"id":"c-5","model":"m","choices":[]}|} in
-  match S.parse_provider_d_sse_chunk data with
+  match S.parse_chat_completions_v1_sse_chunk data with
   | None -> ()
   | Some _ -> Alcotest.fail "expected None for empty choices"
 ;;
 
-(* ── provider_d_chunk_to_events ─────────────────────────────── *)
+(* ── chat_completions_v1_chunk_to_events ─────────────────────────────── *)
 
 let test_events_text_first_chunk () =
-  let state = S.create_provider_d_stream_state () in
-  let chunk : S.provider_d_chunk =
+  let state = S.create_chat_completions_v1_stream_state () in
+  let chunk : S.chat_completions_v1_chunk =
     { chunk_id = "c"
     ; chunk_model = "m"
     ; delta_content = Some "Hi"
@@ -105,7 +105,7 @@ let test_events_text_first_chunk () =
     ; chunk_usage = None
     }
   in
-  let events, _tel = S.provider_d_chunk_to_events state chunk in
+  let events, _tel = S.chat_completions_v1_chunk_to_events state chunk in
   Alcotest.(check int) "2 events" 2 (List.length events);
   (match List.nth events 0 with
    | ContentBlockStart { index = 0; content_type; _ } ->
@@ -118,10 +118,10 @@ let test_events_text_first_chunk () =
 ;;
 
 let test_events_text_subsequent () =
-  let state = S.create_provider_d_stream_state () in
+  let state = S.create_chat_completions_v1_stream_state () in
   (* First chunk starts the block *)
   let _ =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -134,7 +134,7 @@ let test_events_text_subsequent () =
   in
   (* Second chunk: no ContentBlockStart *)
   let events, _tel =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -152,8 +152,8 @@ let test_events_text_subsequent () =
 ;;
 
 let test_events_tool_call () =
-  let state = S.create_provider_d_stream_state () in
-  let tc : S.provider_d_tool_call_delta =
+  let state = S.create_chat_completions_v1_stream_state () in
+  let tc : S.chat_completions_v1_tool_call_delta =
     { tc_index = 0
     ; tc_id = Some "call_1"
     ; tc_name = Some "calc"
@@ -161,7 +161,7 @@ let test_events_tool_call () =
     }
   in
   let events, _tel =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -186,9 +186,9 @@ let test_events_tool_call () =
 ;;
 
 let test_events_finish_reason () =
-  let state = S.create_provider_d_stream_state () in
+  let state = S.create_chat_completions_v1_stream_state () in
   let events, _tel =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -206,9 +206,9 @@ let test_events_finish_reason () =
 ;;
 
 let test_events_tool_calls_finish () =
-  let state = S.create_provider_d_stream_state () in
+  let state = S.create_chat_completions_v1_stream_state () in
   let events, _tel =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -225,9 +225,9 @@ let test_events_tool_calls_finish () =
 ;;
 
 let test_events_length_finish () =
-  let state = S.create_provider_d_stream_state () in
+  let state = S.create_chat_completions_v1_stream_state () in
   let events, _tel =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -244,9 +244,9 @@ let test_events_length_finish () =
 ;;
 
 let test_events_empty_content_ignored () =
-  let state = S.create_provider_d_stream_state () in
+  let state = S.create_chat_completions_v1_stream_state () in
   let events, _tel =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -264,7 +264,7 @@ let test_parse_reasoning_chunk () =
   let data =
     {|{"id":"c-r","model":"provider_h","choices":[{"index":0,"delta":{"reasoning_content":"Let me think"},"finish_reason":null}]}|}
   in
-  match S.parse_provider_d_sse_chunk data with
+  match S.parse_chat_completions_v1_sse_chunk data with
   | Some chunk ->
     Alcotest.(check (option string))
       "reasoning"
@@ -279,7 +279,7 @@ let test_parse_ollama_reasoning_fallback () =
   let data =
     {|{"id":"c-ollama","model":"provider_h-3.5:35b","choices":[{"index":0,"delta":{"reasoning":"Ollama thinking"},"finish_reason":null}]}|}
   in
-  match S.parse_provider_d_sse_chunk data with
+  match S.parse_chat_completions_v1_sse_chunk data with
   | Some chunk ->
     Alcotest.(check (option string))
       "reasoning fallback"
@@ -294,7 +294,7 @@ let test_parse_reasoning_content_preferred () =
   let data =
     {|{"id":"c-both","model":"provider_h","choices":[{"index":0,"delta":{"reasoning_content":"preferred","reasoning":"fallback"},"finish_reason":null}]}|}
   in
-  match S.parse_provider_d_sse_chunk data with
+  match S.parse_chat_completions_v1_sse_chunk data with
   | Some chunk ->
     Alcotest.(check (option string))
       "reasoning_content wins"
@@ -308,7 +308,7 @@ let test_parse_blank_reasoning_content_falls_back () =
   let data =
     {|{"id":"c-blank","model":"provider_h","choices":[{"index":0,"delta":{"reasoning_content":"  ","reasoning":"actual thinking"},"finish_reason":null}]}|}
   in
-  match S.parse_provider_d_sse_chunk data with
+  match S.parse_chat_completions_v1_sse_chunk data with
   | Some chunk ->
     Alcotest.(check (option string))
       "blank falls back"
@@ -318,9 +318,9 @@ let test_parse_blank_reasoning_content_falls_back () =
 ;;
 
 let test_events_reasoning_then_text () =
-  let state = S.create_provider_d_stream_state () in
+  let state = S.create_chat_completions_v1_stream_state () in
   let r_events, _tel =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -341,7 +341,7 @@ let test_events_reasoning_then_text () =
      Alcotest.(check string) "thinking text" "thinking..." s
    | _ -> Alcotest.fail "expected ThinkingDelta at index 0");
   let t_events, _tel =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -366,10 +366,10 @@ let test_events_reasoning_then_text () =
 (** Regression test for issue #332: thinking delta index must match
     the assigned block index across multiple streaming chunks. *)
 let test_events_reasoning_delta_index_multi_chunk () =
-  let state = S.create_provider_d_stream_state () in
+  let state = S.create_chat_completions_v1_stream_state () in
   (* First reasoning chunk: starts block at index 0 *)
   let r1, _tel =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -392,7 +392,7 @@ let test_events_reasoning_delta_index_multi_chunk () =
    | _ -> Alcotest.fail "expected ThinkingDelta");
   (* Second reasoning chunk: must still use the same block index *)
   let r2, _tel =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -411,7 +411,7 @@ let test_events_reasoning_delta_index_multi_chunk () =
    | _ -> Alcotest.fail "expected ThinkingDelta at index 0");
   (* Text after thinking: must get index 1, not 0 *)
   let t_events, _tel =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -431,9 +431,9 @@ let test_events_reasoning_delta_index_multi_chunk () =
 (** Regression test for issue #333: tool-first stream must assign correct
     text block index when text arrives after tool calls. *)
 let test_events_tool_first_then_text () =
-  let state = S.create_provider_d_stream_state () in
+  let state = S.create_chat_completions_v1_stream_state () in
   (* Step 1: tool call arrives first, gets block index 0 *)
-  let tc : S.provider_d_tool_call_delta =
+  let tc : S.chat_completions_v1_tool_call_delta =
     { tc_index = 0
     ; tc_id = Some "call_1"
     ; tc_name = Some "get_weather"
@@ -441,7 +441,7 @@ let test_events_tool_first_then_text () =
     }
   in
   let tool_events, _tel =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -464,7 +464,7 @@ let test_events_tool_first_then_text () =
    | _ -> Alcotest.fail "expected InputJsonDelta at index 0");
   (* Step 2: text arrives — must get index 1, not 0 *)
   let text_events, _tel =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -488,7 +488,7 @@ let test_events_tool_first_then_text () =
    | _ -> Alcotest.fail "expected TextDelta at index 1");
   (* Step 3: subsequent text must reuse the same block index *)
   let text2_events, _tel =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -509,16 +509,16 @@ let test_events_tool_first_then_text () =
 
 (** Regression test for issue #333: multiple tool calls then text. *)
 let test_events_multi_tool_then_text () =
-  let state = S.create_provider_d_stream_state () in
+  let state = S.create_chat_completions_v1_stream_state () in
   (* Two tool calls: indices 0 and 1 *)
-  let tc0 : S.provider_d_tool_call_delta =
+  let tc0 : S.chat_completions_v1_tool_call_delta =
     { tc_index = 0
     ; tc_id = Some "call_a"
     ; tc_name = Some "fn_a"
     ; tc_arguments = Some "{}"
     }
   in
-  let tc1 : S.provider_d_tool_call_delta =
+  let tc1 : S.chat_completions_v1_tool_call_delta =
     { tc_index = 1
     ; tc_id = Some "call_b"
     ; tc_name = Some "fn_b"
@@ -526,7 +526,7 @@ let test_events_multi_tool_then_text () =
     }
   in
   let _ =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -540,7 +540,7 @@ let test_events_multi_tool_then_text () =
   Alcotest.(check int) "next_block_index after 2 tools" 2 state.next_block_index;
   (* Text must get index 2 *)
   let text_events, _tel =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -563,10 +563,10 @@ let test_events_multi_tool_then_text () =
 
 (** Regression test for issue #333: tool between thinking and text. *)
 let test_events_thinking_tool_text () =
-  let state = S.create_provider_d_stream_state () in
+  let state = S.create_chat_completions_v1_stream_state () in
   (* Thinking: gets index 0 *)
   let _ =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -579,7 +579,7 @@ let test_events_thinking_tool_text () =
   in
   Alcotest.(check int) "next after thinking" 1 state.next_block_index;
   (* Tool call: gets index 1 *)
-  let tc : S.provider_d_tool_call_delta =
+  let tc : S.chat_completions_v1_tool_call_delta =
     { tc_index = 0
     ; tc_id = Some "call_x"
     ; tc_name = Some "search"
@@ -587,7 +587,7 @@ let test_events_thinking_tool_text () =
     }
   in
   let _ =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -601,7 +601,7 @@ let test_events_thinking_tool_text () =
   Alcotest.(check int) "next after tool" 2 state.next_block_index;
   (* Text: must get index 2 *)
   let text_events, _tel =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       state
       { chunk_id = "c"
       ; chunk_model = "m"
@@ -626,8 +626,8 @@ let test_events_thinking_tool_text () =
 let () =
   let open Alcotest in
   run
-    "streaming_provider_d"
-    [ ( "parse_provider_d_sse_chunk"
+    "streaming_chat_completions_v1"
+    [ ( "parse_chat_completions_v1_sse_chunk"
       , [ test_case "text chunk" `Quick test_parse_text_chunk
         ; test_case "[DONE] sentinel" `Quick test_parse_done_sentinel
         ; test_case "finish_reason" `Quick test_parse_finish_reason
@@ -650,7 +650,7 @@ let () =
             `Quick
             test_parse_blank_reasoning_content_falls_back
         ] )
-    ; ( "provider_d_chunk_to_events"
+    ; ( "chat_completions_v1_chunk_to_events"
       , [ test_case "text first chunk" `Quick test_events_text_first_chunk
         ; test_case "text subsequent" `Quick test_events_text_subsequent
         ; test_case "tool_call" `Quick test_events_tool_call

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -11,14 +11,14 @@ let usage ?(input_tokens = 1) ?(output_tokens = 2) () =
   }
 ;;
 
-let provider_d_chunk
+let chat_completions_v1_chunk
       ?delta_content
       ?delta_reasoning
       ?(delta_tool_calls = [])
       ?finish_reason
       ?chunk_usage
       ()
-  : S.provider_d_chunk
+  : S.chat_completions_v1_chunk
   =
   { chunk_id = "chunk-1"
   ; chunk_model = "model-1"
@@ -156,14 +156,14 @@ let test_synthetic_events_media_blocks () =
     starts
 ;;
 
-let test_provider_d_parse_edge_shapes () =
+let test_chat_completions_v1_parse_edge_shapes () =
   let mixed_tool_calls =
     {|{"id":"c","model":"m","choices":[{"delta":{"tool_calls":[{"index":"bad"},{"index":0,"function":{"arguments":"{}"}}]},"finish_reason":null}],"usage":{"prompt_tokens":4,"completion_tokens":5,"prompt_tokens_details":{"cached_tokens":3}}}|}
   in
   let chunk =
     require_some
-      "provider_d mixed tool calls"
-      (S.parse_provider_d_sse_chunk mixed_tool_calls)
+      "chat_completions_v1 mixed tool calls"
+      (S.parse_chat_completions_v1_sse_chunk mixed_tool_calls)
   in
   check int "only valid tool call retained" 1 (List.length chunk.delta_tool_calls);
   (match chunk.chunk_usage with
@@ -176,18 +176,22 @@ let test_provider_d_parse_edge_shapes () =
   in
   let chunk =
     require_some
-      "provider_d non-list tool calls"
-      (S.parse_provider_d_sse_chunk non_list_tool_calls)
+      "chat_completions_v1 non-list tool calls"
+      (S.parse_chat_completions_v1_sse_chunk non_list_tool_calls)
   in
   check int "non-list tool calls ignored" 0 (List.length chunk.delta_tool_calls)
 ;;
 
-let test_provider_d_event_edge_branches () =
-  let state = S.create_provider_d_stream_state ~provider:"p" ~model:"m" () in
+let test_chat_completions_v1_event_edge_branches () =
+  let state = S.create_chat_completions_v1_stream_state ~provider:"p" ~model:"m" () in
   ignore
-    (S.provider_d_chunk_to_events state (provider_d_chunk ~delta_reasoning:"thinking" ()));
+    (S.chat_completions_v1_chunk_to_events
+       state
+       (chat_completions_v1_chunk ~delta_reasoning:"thinking" ()));
   let empty_reasoning_events, telemetry =
-    S.provider_d_chunk_to_events state (provider_d_chunk ~delta_reasoning:"" ())
+    S.chat_completions_v1_chunk_to_events
+      state
+      (chat_completions_v1_chunk ~delta_reasoning:"" ())
   in
   check_event_count "empty reasoning emits no content event" 0 empty_reasoning_events;
   (match telemetry with
@@ -197,13 +201,15 @@ let test_provider_d_event_edge_branches () =
    | _ -> fail "expected thinking completion telemetry");
   state.thinking_state <- S.Thinking_done;
   let repeat_reasoning_events, _ =
-    S.provider_d_chunk_to_events state (provider_d_chunk ~delta_reasoning:"again" ())
+    S.chat_completions_v1_chunk_to_events
+      state
+      (chat_completions_v1_chunk ~delta_reasoning:"again" ())
   in
   check_event_count
     "repeat reasoning after done emits delta only"
     1
     repeat_reasoning_events;
-  let tool_state = S.create_provider_d_stream_state () in
+  let tool_state = S.create_chat_completions_v1_stream_state () in
   let tc_empty =
     { S.tc_index = 0
     ; tc_id = Some "call-1"
@@ -213,21 +219,24 @@ let test_provider_d_event_edge_branches () =
   in
   let tc_none = { S.tc_index = 0; tc_id = None; tc_name = None; tc_arguments = None } in
   let first_tool_events, _ =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       tool_state
-      (provider_d_chunk ~delta_tool_calls:[ tc_empty ] ())
+      (chat_completions_v1_chunk ~delta_tool_calls:[ tc_empty ] ())
   in
   check_event_count "empty-args tool starts block only" 1 first_tool_events;
   let reused_tool_events, _ =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       tool_state
-      (provider_d_chunk ~delta_tool_calls:[ tc_none ] ())
+      (chat_completions_v1_chunk ~delta_tool_calls:[ tc_none ] ())
   in
   check_event_count "same tool index without args emits nothing" 0 reused_tool_events;
   let unknown_finish_events, _ =
-    S.provider_d_chunk_to_events
+    S.chat_completions_v1_chunk_to_events
       tool_state
-      (provider_d_chunk ~finish_reason:"safety_filter" ~chunk_usage:(usage ()) ())
+      (chat_completions_v1_chunk
+         ~finish_reason:"safety_filter"
+         ~chunk_usage:(usage ())
+         ())
   in
   match unknown_finish_events with
   | [ MessageDelta { stop_reason = Some (Unknown "safety_filter"); usage = Some _ } ] ->
@@ -269,7 +278,9 @@ let provider_f_chunk ?(parts = []) ?finish_reason ?usage () : S.provider_f_chunk
 ;;
 
 let test_provider_f_event_edge_branches () =
-  let state = S.create_provider_d_stream_state ~provider:"provider_f" ~model:"gem" () in
+  let state =
+    S.create_chat_completions_v1_stream_state ~provider:"provider_f" ~model:"gem" ()
+  in
   let thought_part = `Assoc [ "thought", `Bool true; "text", `String "plan" ] in
   ignore
     (S.provider_f_chunk_to_events state (provider_f_chunk ~parts:[ thought_part ] ()));
@@ -295,7 +306,7 @@ let test_provider_f_event_edge_branches () =
   in
   let tool_events, _ =
     S.provider_f_chunk_to_events
-      (S.create_provider_d_stream_state ())
+      (S.create_chat_completions_v1_stream_state ())
       (provider_f_chunk ~parts:[ empty_text_with_call ] ())
   in
   check_event_count "empty text can still carry function call" 2 tool_events;
@@ -304,13 +315,13 @@ let test_provider_f_event_edge_branches () =
   in
   let ignored_events, _ =
     S.provider_f_chunk_to_events
-      (S.create_provider_d_stream_state ())
+      (S.create_chat_completions_v1_stream_state ())
       (provider_f_chunk ~parts:[ empty_text_without_call ] ())
   in
   check_event_count "non-object functionCall ignored" 0 ignored_events;
   let max_tokens_events, _ =
     S.provider_f_chunk_to_events
-      (S.create_provider_d_stream_state ())
+      (S.create_chat_completions_v1_stream_state ())
       (provider_f_chunk ~finish_reason:"MAX_TOKENS" ~usage:(usage ()) ())
   in
   (match max_tokens_events with
@@ -318,7 +329,7 @@ let test_provider_f_event_edge_branches () =
    | _ -> fail "expected provider_f max-tokens finish");
   let unknown_events, _ =
     S.provider_f_chunk_to_events
-      (S.create_provider_d_stream_state ())
+      (S.create_chat_completions_v1_stream_state ())
       (provider_f_chunk ~finish_reason:"SAFETY" ())
   in
   match unknown_events with
@@ -364,7 +375,9 @@ let test_ollama_parse_edge_shapes () =
 ;;
 
 let test_ollama_event_edge_branches () =
-  let state = S.create_provider_d_stream_state ~provider:"ollama" ~model:"m" () in
+  let state =
+    S.create_chat_completions_v1_stream_state ~provider:"ollama" ~model:"m" ()
+  in
   ignore (S.ollama_chunk_to_events state (ollama_chunk ~delta_thinking:"first" ()));
   let repeated_thinking_events, _ =
     S.ollama_chunk_to_events state (ollama_chunk ~delta_thinking:"second" ())
@@ -386,11 +399,11 @@ let test_ollama_event_edge_branches () =
    | _ -> fail "expected none-thinking telemetry");
   let text_empty_events, _ =
     S.ollama_chunk_to_events
-      (S.create_provider_d_stream_state ())
+      (S.create_chat_completions_v1_stream_state ())
       (ollama_chunk ~delta_content:"" ())
   in
   check_event_count "empty text ignored" 0 text_empty_events;
-  let tool_state = S.create_provider_d_stream_state () in
+  let tool_state = S.create_chat_completions_v1_stream_state () in
   let tc_empty =
     { S.oll_tc_index = 0
     ; oll_tc_id = Some "call"
@@ -411,7 +424,7 @@ let test_ollama_event_edge_branches () =
   check_event_count "reused ollama tool without args emits nothing" 0 tool_reuse_events;
   let done_none_events, _ =
     S.ollama_chunk_to_events
-      (S.create_provider_d_stream_state ())
+      (S.create_chat_completions_v1_stream_state ())
       (ollama_chunk ~is_done:true ())
   in
   (match done_none_events with
@@ -419,7 +432,7 @@ let test_ollama_event_edge_branches () =
    | _ -> fail "done without reason should be EndTurn");
   let done_length_events, _ =
     S.ollama_chunk_to_events
-      (S.create_provider_d_stream_state ())
+      (S.create_chat_completions_v1_stream_state ())
       (ollama_chunk ~is_done:true ~done_reason:"length" ())
   in
   (match done_length_events with
@@ -427,7 +440,7 @@ let test_ollama_event_edge_branches () =
    | _ -> fail "done length should be MaxTokens");
   let done_unknown_tool_events, _ =
     S.ollama_chunk_to_events
-      (S.create_provider_d_stream_state ())
+      (S.create_chat_completions_v1_stream_state ())
       (ollama_chunk ~is_done:true ~done_reason:"future" ~tool_calls:[ tc_none ] ())
   in
   (match done_unknown_tool_events with
@@ -435,7 +448,7 @@ let test_ollama_event_edge_branches () =
    | _ -> fail "unknown done reason with tools should stop for tool use");
   let done_unknown_events, _ =
     S.ollama_chunk_to_events
-      (S.create_provider_d_stream_state ())
+      (S.create_chat_completions_v1_stream_state ())
       (ollama_chunk ~is_done:true ~done_reason:"content_filter" ())
   in
   match done_unknown_events with
@@ -454,9 +467,12 @@ let () =
             test_first_token_classifier_edges
         ; test_case "synthetic media events" `Quick test_synthetic_events_media_blocks
         ] )
-    ; ( "provider_d_sse"
-      , [ test_case "parse edge shapes" `Quick test_provider_d_parse_edge_shapes
-        ; test_case "event edge branches" `Quick test_provider_d_event_edge_branches
+    ; ( "chat_completions_v1_sse"
+      , [ test_case "parse edge shapes" `Quick test_chat_completions_v1_parse_edge_shapes
+        ; test_case
+            "event edge branches"
+            `Quick
+            test_chat_completions_v1_event_edge_branches
         ] )
     ; ( "provider_f_sse"
       , [ test_case "parse edge shapes" `Quick test_provider_f_parse_edge_shapes

--- a/test/test_streaming_summary.ml
+++ b/test/test_streaming_summary.ml
@@ -114,8 +114,12 @@ let test_terminal_cancelled_roundtrip () =
 module Streaming = Llm_provider.Streaming
 module Types = Llm_provider.Types
 
-let make_provider_d_chunk ?delta_content ?delta_reasoning ?(delta_tool_calls = []) ()
-  : Streaming.provider_d_chunk
+let make_chat_completions_v1_chunk
+      ?delta_content
+      ?delta_reasoning
+      ?(delta_tool_calls = [])
+      ()
+  : Streaming.chat_completions_v1_chunk
   =
   { chunk_id = "c1"
   ; chunk_model = "m"
@@ -128,7 +132,7 @@ let make_provider_d_chunk ?delta_content ?delta_reasoning ?(delta_tool_calls = [
 ;;
 
 let test_chunk_has_non_empty_delta_content () =
-  let c = make_provider_d_chunk ~delta_content:"hello" () in
+  let c = make_chat_completions_v1_chunk ~delta_content:"hello" () in
   Alcotest.(check bool)
     "non-empty content is a token signal"
     true
@@ -136,7 +140,7 @@ let test_chunk_has_non_empty_delta_content () =
 ;;
 
 let test_chunk_empty_delta_is_not_token () =
-  let c = make_provider_d_chunk ~delta_content:"" () in
+  let c = make_chat_completions_v1_chunk ~delta_content:"" () in
   Alcotest.(check bool)
     "empty string content is not a token"
     false
@@ -144,7 +148,7 @@ let test_chunk_empty_delta_is_not_token () =
 ;;
 
 let test_chunk_only_reasoning_is_token () =
-  let c = make_provider_d_chunk ~delta_reasoning:"thinking..." () in
+  let c = make_chat_completions_v1_chunk ~delta_reasoning:"thinking..." () in
   Alcotest.(check bool)
     "reasoning-only chunk is a token"
     true
@@ -152,14 +156,14 @@ let test_chunk_only_reasoning_is_token () =
 ;;
 
 let test_chunk_tool_call_is_token () =
-  let tc : Streaming.provider_d_tool_call_delta =
+  let tc : Streaming.chat_completions_v1_tool_call_delta =
     { tc_index = 0
     ; tc_id = Some "call_1"
     ; tc_name = Some "fetch"
     ; tc_arguments = Some "{}"
     }
   in
-  let c = make_provider_d_chunk ~delta_tool_calls:[ tc ] () in
+  let c = make_chat_completions_v1_chunk ~delta_tool_calls:[ tc ] () in
   Alcotest.(check bool)
     "tool_call delta is a token"
     true
@@ -167,7 +171,7 @@ let test_chunk_tool_call_is_token () =
 ;;
 
 let test_chunk_finish_only_is_not_token () =
-  let c = make_provider_d_chunk () in
+  let c = make_chat_completions_v1_chunk () in
   Alcotest.(check bool)
     "finish-only / empty chunk is not a token"
     false

--- a/test/test_telemetry_event.ml
+++ b/test/test_telemetry_event.ml
@@ -25,7 +25,7 @@ let check_float msg expected actual = check (float 0.001) msg expected actual
 let test_streaming_first_chunk () =
   let ev =
     Telemetry_event.Streaming_first_chunk
-      { provider = "provider_d"
+      { provider = "chat_completions_v1"
       ; model = "model-d-4"
       ; ttfrc_ms = 123.456
       ; requested_at = 1000.0
@@ -33,7 +33,7 @@ let test_streaming_first_chunk () =
   in
   match roundtrip ev with
   | Telemetry_event.Streaming_first_chunk r ->
-    check string "provider" "provider_d" r.provider;
+    check string "provider" "chat_completions_v1" r.provider;
     check string "model" "model-d-4" r.model;
     check_float "ttfrc_ms" 123.456 r.ttfrc_ms;
     check_float "requested_at" 1000.0 r.requested_at
@@ -61,7 +61,7 @@ let test_streaming_chunk_n () =
 let test_streaming_summary () =
   let ev =
     Telemetry_event.Streaming_summary
-      { provider = "provider_d"
+      { provider = "chat_completions_v1"
       ; model = "model-d-4"
       ; chunk_count = 3
       ; kind_breakdown =
@@ -85,7 +85,7 @@ let test_streaming_summary () =
   in
   match roundtrip ev with
   | Telemetry_event.Streaming_summary r ->
-    check string "provider" "provider_d" r.provider;
+    check string "provider" "chat_completions_v1" r.provider;
     check string "model" "model-d-4" r.model;
     check int "chunk_count" 3 r.chunk_count;
     check int "thinking chunks" 1 r.kind_breakdown.thinking;
@@ -101,7 +101,7 @@ let test_streaming_summary () =
 let test_thinking_complete () =
   let ev =
     Telemetry_event.Thinking_complete
-      { provider = "provider_d"; model = "o3"; thinking_duration_ms = 888.8 }
+      { provider = "chat_completions_v1"; model = "o3"; thinking_duration_ms = 888.8 }
   in
   match roundtrip ev with
   | Telemetry_event.Thinking_complete r ->

--- a/test/test_tool_middleware.ml
+++ b/test/test_tool_middleware.ml
@@ -477,7 +477,7 @@ let test_heal_max_retries_zero () =
 
 (* ── strip_orphaned_tool_results ──────────────────────────── *)
 
-module Serialize = Llm_provider.Backend_provider_d_serialize
+module Serialize = Llm_provider.Backend_chat_completions_v1_serialize
 
 let mk_msg role content : Types.message =
   { role; content; name = None; tool_call_id = None; metadata = [] }

--- a/test/test_tool_selector.ml
+++ b/test/test_tool_selector.ml
@@ -398,7 +398,7 @@ let test_default_rerank_fn_falls_back_to_candidates_on_provider_error () =
   let provider =
     Llm_provider.Provider_config.make
       ~kind:Llm_provider.Provider_config.OpenAI_compat
-      ~model_id:"provider_d_chat"
+      ~model_id:"chat_completions_v1"
       ~base_url:"http://"
       ()
   in

--- a/test/test_tool_use_recovery.ml
+++ b/test/test_tool_use_recovery.ml
@@ -70,7 +70,7 @@ let test_extract_provider_a_style () =
   | None -> fail "expected extraction"
 ;;
 
-let test_extract_provider_d_arguments_object () =
+let test_extract_chat_completions_v1_arguments_object () =
   let json = `Assoc [ "name", `String "tool"; "arguments", `Assoc [ "x", `Int 1 ] ] in
   match TUR.extract_name_and_input json with
   | Some (name, _) -> check string "name" "tool" name
@@ -78,7 +78,7 @@ let test_extract_provider_d_arguments_object () =
 ;;
 
 let test_extract_double_stringified () =
-  (* Provider_d-style: arguments value is a JSON-encoded string *)
+  (* Chat_completions_v1-style: arguments value is a JSON-encoded string *)
   let json = `Assoc [ "name", `String "tool"; "arguments", `String "{\"x\":42}" ] in
   match TUR.extract_name_and_input json with
   | Some (_, input) ->
@@ -176,9 +176,9 @@ let () =
     ; ( "extract_name_and_input"
       , [ test_case "provider_a style" `Quick test_extract_provider_a_style
         ; test_case
-            "provider_d arguments object"
+            "chat_completions_v1 arguments object"
             `Quick
-            test_extract_provider_d_arguments_object
+            test_extract_chat_completions_v1_arguments_object
         ; test_case "double stringified" `Quick test_extract_double_stringified
         ; test_case "tool_calls wrapper" `Quick test_extract_tool_calls_wrapper
         ; test_case "no shape" `Quick test_extract_none


### PR DESCRIPTION
## Summary
- rename provider_d API/backend/transport modules to chat_completions_v1 names
- update capability labels, fixtures, tests, docs, and public re-exports
- remove provider_d/provider-d cipher tokens from current OAS source/test/docs surfaces

## Verification
- `scripts/dune-local.sh build @default --display=short`
- `MASC_DUNE_THROTTLE=0 scripts/dune-local.sh exec -- ./test/test_backend_chat_completions_v1_codec.exe` (18 tests)
- `MASC_DUNE_THROTTLE=0 scripts/dune-local.sh exec -- ./test/test_streaming_chat_completions_v1.exe` (24 tests)
- `MASC_DUNE_THROTTLE=0 scripts/dune-local.sh exec -- ./test/test_capabilities.exe` (47 tests)
- `git diff --check`
- `rg` sweep for provider_d/provider-d legacy tokens -> 0 matches
