### PR TITLE
Repair OAS main CI workflow drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,6 @@ jobs:
       - name: Build
         run: opam exec -- dune build @all
 
-      - name: Harness replay eval
-        run: |
-          opam exec -- dune exec ./bin/oas_cli.exe -- \
-            eval run \
-            --dataset examples/evals/replay.jsonl \
-            --out _build/evals
-
       - name: Test
         env:
           ALCOTEST_QUICK_TESTS: "1"
@@ -57,14 +50,6 @@ jobs:
           # locate the binary regardless of sandbox cwd.
           OAS_RUNTIME_PATH: ${{ github.workspace }}/_build/default/bin/oas_runtime.exe
         run: opam exec -- dune runtest
-
-      - name: Upload harness eval artifacts
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: harness-eval-${{ matrix.ocaml-compiler }}
-          path: _build/evals
-          if-no-files-found: warn
 
       - name: Coverage report
         if: matrix.ocaml-compiler == '5.4.1'

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -114,6 +114,7 @@ module Runtime = Runtime
 module Runtime_projection = Runtime_projection
 module Runtime_sync = Runtime_sync
 module Runtime_replay = Runtime_replay
+
 (* Transport/Runtime_client/Client removed — CLI Runtime purge *)
 module Sdk_client_types = Sdk_client_types
 module Artifact_service = Artifact_service

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -87,6 +87,7 @@ module Runtime = Runtime
 module Runtime_projection = Runtime_projection
 module Runtime_sync = Runtime_sync
 module Runtime_replay = Runtime_replay
+
 (* Transport/Runtime_client/Client removed — CLI Runtime purge *)
 module Sdk_client_types = Sdk_client_types
 module Artifact_service = Artifact_service

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -125,9 +125,7 @@ let create_message
            ( fallback_provider
            , base_url
            , key
-           , [ "Content-Type", "application/json"
-             ; "provider_a-version", api_version
-             ] )
+           , [ "Content-Type", "application/json"; "provider_a-version", api_version ] )
        | None -> Error (Error.Config (MissingEnvVar { var_name = "PROVIDER_A_API_KEY" })))
   in
   match resolve_result with
@@ -159,11 +157,13 @@ let create_message
       (* Merge auth headers at request time so that [header_list] (from
          [Provider.resolve]) never carries sensitive tokens. *)
       let auth_hdrs =
-        if api_key = "" then []
-        else match kind with
+        if api_key = ""
+        then []
+        else (
+          match kind with
           | Provider.Anthropic_messages -> [ "x-api-key", api_key ]
           | Provider.Openai_chat_completions | Provider.Custom _ ->
-            [ "Authorization", "Bearer " ^ api_key ]
+            [ "Authorization", "Bearer " ^ api_key ])
       in
       match
         Llm_provider.Http_client.post_sync

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -166,8 +166,9 @@ let anthropic_capabilities =
 
 let kimi_capabilities =
   { default_capabilities with
-    max_context_tokens = Some 256_000
-    (* platform.kimi.ai documents only the default max_tokens (32768); it does
+    max_context_tokens =
+      Some 256_000
+      (* platform.kimi.ai documents only the default max_tokens (32768); it does
        not state a higher output ceiling. Keep the verified default here. A
        higher ceiling (if any) is deferred to the per-provider capability pass. *)
   ; max_output_tokens = Some 32_768
@@ -184,8 +185,9 @@ let kimi_capabilities =
   ; supports_native_streaming = true
   ; supports_multimodal_inputs = true
   ; supports_image_input = true
-  ; supports_code_execution = true
-    (* Preserved from the pre-rename provider_c_capabilities; dropped by accident
+  ; supports_code_execution =
+      true
+      (* Preserved from the pre-rename provider_c_capabilities; dropped by accident
        in the capability rename. *)
   }
 ;;

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -172,8 +172,7 @@ let auth_headers_for_config (config : t) : (string * string) list =
     (match config.kind with
      | Anthropic | Kimi -> [ "x-api-key", key ]
      | Gemini -> []
-     | OpenAI_compat | Ollama | Glm | DashScope ->
-       [ "Authorization", "Bearer " ^ key ])
+     | OpenAI_compat | Ollama | Glm | DashScope -> [ "Authorization", "Bearer " ^ key ])
 ;;
 
 let max_turns_hard_cap = function
@@ -318,8 +317,8 @@ let validate_output_schema_request (config : t) =
      | Gemini | Anthropic | Ollama | DashScope -> Ok ()
      | Glm ->
        Error
-         "Glm supports JSON mode (json_object) only; native json_schema output is \
-          not documented in the current Z.AI API"
+         "Glm supports JSON mode (json_object) only; native json_schema output is not \
+          documented in the current Z.AI API"
      | Kimi | OpenAI_compat ->
        let caps =
          match Capabilities.for_model_id config.model_id with
@@ -339,7 +338,7 @@ let validate_output_schema_request (config : t) =
            (Printf.sprintf
               "native structured output is only wired for official Provider_d hosts, got \
                %s"
-               config.base_url))
+              config.base_url))
 ;;
 
 (** Validate that sampling parameters not supported by CLI subprocess

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -82,9 +82,7 @@ let command_in_path ?path name =
 
 let catalog_command_available (entry : Provider_catalog.entry) =
   match entry.transport with
-  | Provider_catalog.Http
-  | Provider_catalog.Managed
-  -> true
+  | Provider_catalog.Http | Provider_catalog.Managed -> true
 ;;
 
 let catalog_auth_available (entry : Provider_catalog.entry) =
@@ -404,9 +402,7 @@ let default () =
     { name = "provider_c"
     ; defaults = provider_c_defaults
     ; max_context =
-        max_context_from_capabilities
-          ~default:262_144
-          Capabilities.kimi_capabilities
+        max_context_from_capabilities ~default:262_144 Capabilities.kimi_capabilities
     ; capabilities = Capabilities.kimi_capabilities
     ; is_available = (fun () -> has_any_api_key [ "PROVIDER_C_API_KEY" ])
     };

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -205,9 +205,7 @@ let provider_c_direct_request_path = "/v1/messages"
     Auth header ("x-api-key") is NOT included — callers merge
     [auth_headers_only_for_kind] at HTTP request time. *)
 let provider_c_direct_headers _key =
-  [ "Content-Type", "application/json"
-  ; "provider_a-version", "2023-06-01"
-  ]
+  [ "Content-Type", "application/json"; "provider_a-version", "2023-06-01" ]
 ;;
 
 let provider_c_provider_impl : provider_impl =
@@ -415,9 +413,7 @@ let resolve (cfg : config) =
        Ok
          ( "https://api.provider_a.com"
          , key
-         , [ "provider_a-version", "2023-06-01"
-           ; "Content-Type", "application/json"
-           ] )
+         , [ "provider_a-version", "2023-06-01"; "Content-Type", "application/json" ] )
      | None -> Error (Error.Config (MissingEnvVar { var_name = cfg.api_key_env })))
   | OpenAICompat { base_url; auth_header = _; static_token; _ } ->
     (match static_token with
@@ -428,8 +424,7 @@ let resolve (cfg : config) =
        Ok (base_url, key, [ "Content-Type", "application/json" ])
      | _ ->
        (match Sys.getenv_opt cfg.api_key_env with
-        | Some key ->
-          Ok (base_url, key, [ "Content-Type", "application/json" ])
+        | Some key -> Ok (base_url, key, [ "Content-Type", "application/json" ])
         | None -> Ok (base_url, "", [ "Content-Type", "application/json" ])))
   | Custom_registered { name } ->
     (match find_provider name with
@@ -663,8 +658,7 @@ let auth_headers_only_for_kind
     (match kind with
      | Anthropic | Kimi -> [ "x-api-key", key ]
      | Gemini -> []
-     | OpenAI_compat | Ollama | Glm | DashScope ->
-       [ "Authorization", "Bearer " ^ key ])
+     | OpenAI_compat | Ollama | Glm | DashScope -> [ "Authorization", "Bearer " ^ key ])
 ;;
 
 (** Convert a [Llm_provider.Provider_config.t] into a

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -105,13 +105,23 @@ let of_config (provider_cfg : Provider.config) : provider_module =
       (* Merge auth headers at request time so that [headers] (from
          [Provider.resolve]) never carries sensitive tokens. *)
       let auth_hdrs =
-        if api_key = "" then []
-        else match kind with
+        if api_key = ""
+        then []
+        else (
+          match kind with
           | Provider.Anthropic_messages -> [ "x-api-key", api_key ]
           | Provider.Openai_chat_completions | Provider.Custom _ ->
-            [ "Authorization", "Bearer " ^ api_key ]
+            [ "Authorization", "Bearer " ^ api_key ])
       in
-      match Http_client.post_sync ~sw ~net ~url ~headers:(headers @ auth_hdrs) ~body:body_str () with
+      match
+        Http_client.post_sync
+          ~sw
+          ~net
+          ~url
+          ~headers:(headers @ auth_hdrs)
+          ~body:body_str
+          ()
+      with
       | Ok (200, body_str) ->
         (match kind with
          | Provider.Anthropic_messages ->

--- a/test/dune
+++ b/test/dune
@@ -523,7 +523,6 @@
  (modules test_builder)
  (libraries agent_sdk alcotest eio_main))
 
-
 (test
  (name test_full_pipeline_cov)
  (modules test_full_pipeline_cov)

--- a/test/test_agent_config_deep.ml
+++ b/test/test_agent_config_deep.ml
@@ -461,9 +461,7 @@ let test_resolve_openai_compat_ssot () =
      Provider_kind.to_string OpenAI_compat. Before the parser dispatch,
      it fell through to the registry fallback and ended up with
      api_key_env = "openai_compat" — a meaningless value. *)
-  let cfg =
-    Agent_config.resolve_provider ~model_id:"model-d-4" "openai_compat" None
-  in
+  let cfg = Agent_config.resolve_provider ~model_id:"model-d-4" "openai_compat" None in
   match cfg.provider with
   | Provider.OpenAICompat { base_url; _ } ->
     Alcotest.(check string)

--- a/test/test_backend_provider_f.ml
+++ b/test/test_backend_provider_f.ml
@@ -778,7 +778,6 @@ let () =
             test_provider_f_stream_tool_first_then_text
         ] )
     ; ( "capabilities"
-      , [ test_case "provider_f capabilities" `Quick test_gemini_capabilities_named ]
-      )
+      , [ test_case "provider_f capabilities" `Quick test_gemini_capabilities_named ] )
     ]
 ;;

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -731,7 +731,8 @@ let test_dashscope_capabilities () =
 
 let test_openai_compat_reasoning_records_have_explicit_control () =
   let cases =
-    [ "provider_d_chat_extended", Some Capabilities.openai_compat_chat_extended_capabilities
+    [ ( "provider_d_chat_extended"
+      , Some Capabilities.openai_compat_chat_extended_capabilities )
     ; "provider_c", Some Capabilities.kimi_capabilities
     ; "provider_h", Some Capabilities.dashscope_capabilities
     ; "mimo-v2.5-pro", Capabilities.for_model_id "mimo-v2.5-pro"

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -612,7 +612,6 @@ let test_map_http_error_auth_error () =
   | _ -> Alcotest.fail "expected Error.Api AuthError"
 ;;
 
-
 (* ── MessageDelta cache update with prior values ────────────────── *)
 
 let test_acc_message_delta_cache_update_nonzero () =


### PR DESCRIPTION
## Summary
- remove the obsolete CI harness replay step that still invoked removed ./bin/oas_cli.exe
- apply ocamlformat output required by the main CI @fmt check

## Validation
- git diff --check
- opam exec -- dune build @fmt --root .
- scripts/dune-local.sh build @all