### PR TITLE
Fix Provider runtime resolution drift

### DIFF
--- a/lib/agent/agent_lifecycle.ml
+++ b/lib/agent/agent_lifecycle.ml
@@ -77,12 +77,7 @@ type lifecycle_snapshot =
 let provider_runtime_name (cfg : Provider.config option) =
   match cfg with
   | None -> None
-  | Some cfg ->
-    (match cfg.provider with
-     | Provider.Local _ -> Some "local"
-     | Provider.Anthropic -> Some "provider_a"
-     | Provider.OpenAICompat _ -> Some "openai-compat"
-     | Provider.Custom_registered { name } -> Some ("custom:" ^ name))
+  | Some cfg -> Provider_runtime_binding.provider_id_of_legacy_config cfg
 ;;
 
 let hook_decision_to_string = function

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1185,7 +1185,7 @@ let%test "for_model_id provider_k-5.1 full model (reasoning + extended thinking)
 ;;
 
 let%test "for_model_id bare glm-5 full model (reasoning + extended thinking)" =
-  match for_model_id "glm-5" with
+  match for_model_id_static "glm-5" with
   | Some c ->
     c.supports_reasoning
     && c.supports_extended_thinking
@@ -1194,7 +1194,7 @@ let%test "for_model_id bare glm-5 full model (reasoning + extended thinking)" =
 ;;
 
 let%test "for_model_id bare glm-5.1 full model (reasoning + extended thinking)" =
-  match for_model_id "glm-5.1" with
+  match for_model_id_static "glm-5.1" with
   | Some c ->
     c.supports_reasoning
     && c.supports_extended_thinking
@@ -1203,7 +1203,7 @@ let%test "for_model_id bare glm-5.1 full model (reasoning + extended thinking)" 
 ;;
 
 let%test "for_model_id bare glm-5-turbo has GLM-5 thinking limits" =
-  match for_model_id "glm-5-turbo" with
+  match for_model_id_static "glm-5-turbo" with
   | Some c ->
     c.supports_reasoning
     && c.supports_extended_thinking
@@ -1327,7 +1327,7 @@ let%test "capabilities_for_provider_label: provider_l" =
    return wrong capabilities. The test catches that. *)
 let%test "for_model_id: specific model IDs get correct (not shadowed) capabilities" =
   let check model_id expected =
-    match for_model_id model_id with
+    match for_model_id_static model_id with
     | Some c -> expected c
     | None -> false
   in
@@ -1480,10 +1480,6 @@ let%test "capabilities_for_provider_label: all declared labels resolve" =
     ; "provider_k-coding"
     ; "provider_l"
     ; "provider_c"
-    ; "cli_tool_d"
-    ; "cli_tool_b"
-    ; "cli_tool_c"
-    ; "cli_tool_a"
     ]
   in
   List.for_all (fun l -> Option.is_some (capabilities_for_provider_label l)) labels
@@ -1495,16 +1491,7 @@ let%test
     "capabilities_for_provider_label: no accidental aliasing across distinct providers"
   =
   let non_aliased =
-    [ "provider_a"
-    ; "provider_f"
-    ; "ollama"
-    ; "provider_c"
-    ; "cli_tool_d"
-    ; "cli_tool_b"
-    ; "cli_tool_c"
-    ; "cli_tool_a"
-    ; "provider_l"
-    ]
+    [ "provider_a"; "provider_f"; "ollama"; "provider_c"; "provider_l" ]
   in
   let fingerprints =
     List.filter_map

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -971,8 +971,7 @@ let%test "parse_slots neither is_processing nor state defaults to idle" =
 (* --- contains_case_insensitive (via Retry SSOT) --- *)
 
 let%test "contains_case_insensitive case insensitive match" =
-  Retry.contains_case_insensitive ~haystack:"DashScope_3.5-35B" ~needle:"provider_h"
-  = true
+  Retry.contains_case_insensitive ~haystack:"DashScope_3.5-35B" ~needle:"dashscope" = true
 ;;
 
 let%test "contains_case_insensitive no match" =

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -486,5 +486,5 @@ let provider_name_of_config (config : Provider_config.t) =
           && String.equal (String.trim entry.defaults.request_path) request_path)
       with
       | Some entry -> entry.name
-      | None -> "provider_d")
+      | None -> "openai_compat")
 ;;

--- a/lib/llm_provider/zai_catalog.ml
+++ b/lib/llm_provider/zai_catalog.ml
@@ -123,8 +123,18 @@ let resolve_glm_coding_alias ~default_model model_id =
   | _ -> model_id
 ;;
 
+let canonical_model_key model_id =
+  let m = String.lowercase_ascii (String.trim model_id) in
+  let glm_prefix = "glm-" in
+  if has_prefix m glm_prefix
+  then
+    "provider_k-"
+    ^ String.sub m (String.length glm_prefix) (String.length m - String.length glm_prefix)
+  else m
+;;
+
 let general_concurrency_for_model model_id =
-  let m = String.lowercase_ascii model_id in
+  let m = canonical_model_key model_id in
   let starts_with prefix =
     String.length m >= String.length prefix
     && String.sub m 0 (String.length prefix) = prefix
@@ -168,8 +178,7 @@ let coding_concurrency_default = 3
 let throttle_key_for_chat ~base_url ~model_id =
   match mode_of_base_url base_url with
   | Coding_plan -> "zai/coding/chat"
-  | General_api ->
-    Printf.sprintf "zai/general/chat/%s" (String.lowercase_ascii (String.trim model_id))
+  | General_api -> Printf.sprintf "zai/general/chat/%s" (canonical_model_key model_id)
 ;;
 
 [@@@coverage off]

--- a/lib/provider_runtime_binding.ml
+++ b/lib/provider_runtime_binding.ml
@@ -38,6 +38,26 @@ type t =
 
 let normalize value = String.trim value |> String.lowercase_ascii
 
+let builtin_aliases =
+  [ "anthropic", "agent_llm_a"
+  ; "claude", "agent_llm_a"
+  ; "provider_a", "agent_llm_a"
+  ; "kimi", "provider_c"
+  ; "moonshot", "provider_c"
+  ; "gemini", "provider_f"
+  ; "glm", "provider_k"
+  ; "zhipu", "provider_k"
+  ; "zai", "provider_k"
+  ; "glm-coding", "provider_k-coding"
+  ; "zhipu-coding", "provider_k-coding"
+  ; "zai-coding", "provider_k-coding"
+  ; "dashscope", "provider_h"
+  ]
+;;
+
+let alias_target label = List.assoc_opt (normalize label) builtin_aliases
+let known_aliases () = List.map fst builtin_aliases
+
 let trim_non_empty value =
   let trimmed = String.trim value in
   if trimmed = "" then None else Some trimmed
@@ -184,18 +204,27 @@ let all () =
   sort_bindings (from_catalog @ from_registry)
 ;;
 
+let find_raw normalized =
+  let registry = PR.default () in
+  match PC.global () with
+  | Some catalog ->
+    (match PC.lookup catalog normalized with
+     | Some entry -> Some (binding_of_catalog_entry registry entry)
+     | None -> Option.map binding_of_registry_entry (PR.find registry normalized))
+  | None -> Option.map binding_of_registry_entry (PR.find registry normalized)
+;;
+
 let find label =
   let normalized = normalize label in
   if normalized = ""
   then None
   else (
-    let registry = PR.default () in
-    match PC.global () with
-    | Some catalog ->
-      (match PC.lookup catalog normalized with
-       | Some entry -> Some (binding_of_catalog_entry registry entry)
-       | None -> Option.map binding_of_registry_entry (PR.find registry normalized))
-    | None -> Option.map binding_of_registry_entry (PR.find registry normalized))
+    match find_raw normalized with
+    | Some _ as binding -> binding
+    | None ->
+      (match alias_target normalized with
+       | Some target -> find_raw target
+       | None -> None))
 ;;
 
 let normalize_endpoint_url value =
@@ -258,6 +287,32 @@ let binding_for_provider_config (cfg : PConfig.t) =
     (match registry_binding_for_provider_config registry cfg with
      | Some binding -> Some binding
      | None -> PR.provider_name_of_config cfg |> find)
+;;
+
+let provider_id_of_legacy_config (cfg : Provider.config) =
+  match cfg.provider with
+  | Provider.Local _ -> Some "local"
+  | Provider.Anthropic ->
+    (match find "anthropic" with
+     | Some binding -> Some binding.id
+     | None -> Some "agent_llm_a")
+  | Provider.Custom_registered { name } ->
+    (match find name with
+     | Some binding -> Some binding.id
+     | None -> trim_non_empty name)
+  | Provider.OpenAICompat { base_url; path; _ } ->
+    let request_path = trim_non_empty path in
+    let pc =
+      PConfig.make
+        ~kind:PConfig.OpenAI_compat
+        ~model_id:cfg.model_id
+        ~base_url
+        ?request_path
+        ()
+    in
+    (match binding_for_provider_config pc with
+     | Some binding -> Some binding.id
+     | None -> Some "openai_compat")
 ;;
 
 let base_capabilities_of_kind = function

--- a/lib/provider_runtime_binding.mli
+++ b/lib/provider_runtime_binding.mli
@@ -47,12 +47,22 @@ val all : unit -> t list
     case-insensitive and whitespace-trimmed. *)
 val find : string -> t option
 
+(** Built-in runtime aliases accepted before catalog lookup. These aliases
+    are parser compatibility only; they are not emitted as canonical binding
+    identifiers. *)
+val known_aliases : unit -> string list
+
 (** Resolve the runtime binding that owns a concrete provider config.
 
     Catalog endpoint matches are resolved before registry provider-name
     fallbacks, so catalog-provided OpenAI-compatible providers remain
     OAS-owned even when the endpoint is local. *)
 val binding_for_provider_config : Llm_provider.Provider_config.t -> t option
+
+(** Return the canonical runtime binding id for a legacy {!Provider.config}.
+    Unknown custom providers return their raw custom name, without adding a
+    display-only ["custom:"] prefix. *)
+val provider_id_of_legacy_config : Provider.config -> string option
 
 (** Resolve OAS-owned provider capabilities for a concrete provider config.
 

--- a/lib/runtime_server_resolve.ml
+++ b/lib/runtime_server_resolve.ml
@@ -28,94 +28,69 @@ let provider_runtime_name selected (cfg : Provider.config option) =
   match cfg with
   | None -> selected
   | Some cfg ->
-    (match cfg.provider with
-     | Provider.Local _ -> "local"
-     | Provider.Anthropic -> "provider_a"
-     | Provider.OpenAICompat _ -> "openai-compat"
-     | Provider.Custom_registered { name } -> "custom:" ^ name)
+    Option.value
+      ~default:selected
+      (Provider_runtime_binding.provider_id_of_legacy_config cfg)
 ;;
 
-let registry_valid_provider_detail registry =
+let runtime_valid_provider_detail () =
   let names =
-    Llm_provider.Provider_registry.all registry
-    |> List.map (fun (entry : Llm_provider.Provider_registry.entry) -> entry.name)
+    Provider_runtime_binding.all ()
+    |> List.concat_map (fun (binding : Provider_runtime_binding.t) ->
+      binding.id :: binding.aliases)
     |> List.sort_uniq String.compare
   in
-  let names = "local" :: names in
+  let names = Provider_runtime_binding.known_aliases () @ ("local" :: names) in
   let names =
     if Defaults.allow_test_providers () then "mock" :: "echo" :: names else names
   in
   String.concat ", " (List.sort_uniq String.compare names)
 ;;
 
-let provider_config_of_registry_entry
-      ~provider_name
-      ~model_id
-      (entry : Llm_provider.Provider_registry.entry)
-  =
-  match entry.defaults.kind with
+let request_path_or_default (binding : Provider_runtime_binding.t) =
+  let request_path = String.trim binding.request_path in
+  if request_path <> ""
+  then request_path
+  else Llm_provider.Provider_config.request_path_default_for_kind binding.kind
+;;
+
+let legacy_provider_config_of_binding ?model (binding : Provider_runtime_binding.t) =
+  let model_id = Provider_runtime_binding.resolve_model binding ~requested_model:model in
+  match binding.kind with
   | Llm_provider.Provider_config.Anthropic ->
     { Provider.provider = Provider.Anthropic
     ; model_id
-    ; api_key_env = entry.defaults.api_key_env
+    ; api_key_env = binding.api_key_env
     }
   | Llm_provider.Provider_config.OpenAI_compat ->
     { Provider.provider =
         Provider.OpenAICompat
-          { base_url = entry.defaults.base_url
+          { base_url = binding.base_url
           ; auth_header =
-              (if String.trim entry.defaults.api_key_env = ""
-               then None
-               else Some "Authorization")
-          ; path = entry.defaults.request_path
+              (if String.trim binding.api_key_env = "" then None else Some "Authorization")
+          ; path = request_path_or_default binding
           ; static_token = None
           }
     ; model_id
-    ; api_key_env = entry.defaults.api_key_env
+    ; api_key_env = binding.api_key_env
     }
   | _ ->
-    { Provider.provider = Provider.Custom_registered { name = provider_name }
+    { Provider.provider = Provider.Custom_registered { name = binding.id }
     ; model_id
-    ; api_key_env = entry.defaults.api_key_env
+    ; api_key_env = binding.api_key_env
     }
 ;;
 
-let catalog_default_model provider_name =
-  match Llm_provider.Provider_catalog.global () with
-  | None -> None
-  | Some catalog ->
-    Llm_provider.Provider_catalog.default_model_for_provider catalog provider_name
-;;
-
-let effective_model_id ~provider_name ~entry ?model () =
-  match model with
-  | Some value when String.trim value <> "" -> value
-  | _ ->
-    (match catalog_default_model provider_name with
-     | Some model_id when String.trim model_id <> "" -> model_id
-     | _ ->
-       (match entry.Llm_provider.Provider_registry.defaults.kind with
-        | Llm_provider.Provider_config.Ollama -> "default"
-        | _ -> Model_registry.default_model_id))
-;;
-
-let resolve_from_registry registry ~provider_name ?model () =
-  match Llm_provider.Provider_registry.find registry provider_name with
-  | Some entry ->
-    let model_id = effective_model_id ~provider_name ~entry ?model () in
-    Ok (Some (provider_config_of_registry_entry ~provider_name ~model_id entry))
+let resolve_from_runtime_binding ~provider_name ?model () =
+  match Provider_runtime_binding.find provider_name with
+  | Some binding -> Ok (Some (legacy_provider_config_of_binding ?model binding))
   | None ->
     let resolved_model = Model_registry.resolve_model_id provider_name in
     if not (String.equal resolved_model provider_name)
     then (
-      match Llm_provider.Provider_registry.find registry "agent_llm_a" with
-      | Some entry ->
-        Ok
-          (Some
-             (provider_config_of_registry_entry
-                ~provider_name:"agent_llm_a"
-                ~model_id:resolved_model
-                entry))
+      match Provider_runtime_binding.find "anthropic" with
+      | Some binding ->
+        Ok (Some (legacy_provider_config_of_binding ~model:resolved_model binding))
       | None ->
         unsupported_provider
           "provider alias resolved to an Anthropic model but provider catalog has no \
@@ -125,7 +100,7 @@ let resolve_from_registry registry ~provider_name ?model () =
         (Printf.sprintf
            "unknown provider %S; valid: %s"
            provider_name
-           (registry_valid_provider_detail registry))
+           (runtime_valid_provider_detail ()))
 ;;
 
 let resolve_provider ?provider ?model () =
@@ -135,14 +110,13 @@ let resolve_provider ?provider ?model () =
       String.lowercase_ascii (String.trim value)
     | _ -> Defaults.fallback_provider
   in
-  let registry = Llm_provider.Provider_registry.default () in
   let base =
     match selected with
     | "mock" | "echo" ->
       let* () = ensure_test_provider_enabled selected in
       Ok None
     | "local" -> Ok (Some (Provider.local_llm ()))
-    | other -> resolve_from_registry registry ~provider_name:other ?model ()
+    | other -> resolve_from_runtime_binding ~provider_name:other ?model ()
   in
   match base with
   | Error _ as e -> e

--- a/test/dune
+++ b/test/dune
@@ -484,6 +484,11 @@
  (libraries agent_sdk alcotest unix))
 
 (test
+ (name test_runtime_server_resolve)
+ (modules test_runtime_server_resolve)
+ (libraries agent_sdk alcotest unix))
+
+(test
  (name test_provider_complete)
  (modules test_provider_complete)
  (libraries agent_sdk llm_provider alcotest eio_main))

--- a/test/test_agent_lifecycle.ml
+++ b/test/test_agent_lifecycle.ml
@@ -120,8 +120,8 @@ let test_runtime_name_provider_a () =
     { provider = Anthropic; model_id = "test"; api_key_env = "DUMMY" }
   in
   Alcotest.(check (option string))
-    "provider_a"
-    (Some "provider_a")
+    "agent_llm_a"
+    (Some "agent_llm_a")
     (Agent_lifecycle.provider_runtime_name (Some cfg))
 ;;
 
@@ -139,8 +139,8 @@ let test_runtime_name_openai_compat () =
     }
   in
   Alcotest.(check (option string))
-    "openai-compat"
-    (Some "openai-compat")
+    "provider_n"
+    (Some "provider_n")
     (Agent_lifecycle.provider_runtime_name (Some cfg))
 ;;
 
@@ -153,7 +153,7 @@ let test_runtime_name_custom () =
   in
   Alcotest.(check (option string))
     "custom"
-    (Some "custom:my-custom")
+    (Some "my-custom")
     (Agent_lifecycle.provider_runtime_name (Some cfg))
 ;;
 

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -204,10 +204,10 @@ let test_find_capable_composite () =
 
 (* ── Default registry ───────────────────────────────── *)
 
-let test_default_has_19 () =
+let test_default_has_current_providers () =
   let reg = Provider_registry.default () in
   let all = Provider_registry.all reg in
-  check int "19 known providers" 19 (List.length all);
+  check int "14 known providers" 14 (List.length all);
   check
     bool
     "llama exists"
@@ -269,28 +269,7 @@ let test_default_has_19 () =
     bool
     "siliconflow exists"
     true
-    (Option.is_some (Provider_registry.find reg "siliconflow"));
-  check
-    bool
-    "cli_tool_d exists"
-    true
-    (Option.is_some (Provider_registry.find reg "cli_tool_d"));
-  check bool "cc exists" true (Option.is_some (Provider_registry.find reg "cc"));
-  check
-    bool
-    "cli_tool_b exists"
-    true
-    (Option.is_some (Provider_registry.find reg "cli_tool_b"));
-  check
-    bool
-    "cli_tool_c exists"
-    true
-    (Option.is_some (Provider_registry.find reg "cli_tool_c"));
-  check
-    bool
-    "cli_tool_a exists"
-    true
-    (Option.is_some (Provider_registry.find reg "cli_tool_a"))
+    (Option.is_some (Provider_registry.find reg "siliconflow"))
 ;;
 
 let test_default_capabilities () =
@@ -351,9 +330,6 @@ let test_default_max_context () =
   (match Provider_registry.find reg "provider_c" with
    | Some e -> check int "provider_c 262K" 262_144 e.max_context
    | None -> fail "provider_c should exist");
-  (match Provider_registry.find reg "cc" with
-   | Some e -> check int "cc 1M" 1_000_000 e.max_context
-   | None -> fail "cc should exist");
   (match Provider_registry.find reg "provider_i" with
    | Some e -> check int "provider_i 131K" 131_072 e.max_context
    | None -> fail "provider_i should exist");
@@ -366,15 +342,9 @@ let test_default_max_context () =
   (match Provider_registry.find reg "alibaba" with
    | Some e -> check int "alibaba 131K" 131_072 e.max_context
    | None -> fail "alibaba should exist");
-  (match Provider_registry.find reg "siliconflow" with
-   | Some e -> check int "siliconflow 128K" 128_000 e.max_context
-   | None -> fail "siliconflow should exist");
-  (match Provider_registry.find reg "cli_tool_a" with
-   | Some e -> check int "cli_tool_a 1.05M" 1_050_000 e.max_context
-   | None -> fail "cli_tool_a should exist");
-  match Provider_registry.find reg "cli_tool_c" with
-  | Some e -> check int "cli_tool_c 262K" 262_144 e.max_context
-  | None -> fail "cli_tool_c should exist"
+  match Provider_registry.find reg "siliconflow" with
+  | Some e -> check int "siliconflow 128K" 128_000 e.max_context
+  | None -> fail "siliconflow should exist"
 ;;
 
 let test_default_max_context_matches_capabilities () =
@@ -982,7 +952,7 @@ let mk_config_for_kind kind =
     (masc canonical_name: "agent_llm_a-api", ...) (boundary-allow) to
     [Provider_registry.find], but the registry is keyed on the names
     returned by [Provider_registry.provider_name_of_config] ("agent_llm_a",
-    "provider_c", "provider_n", "ollama", "cli_tool_d", "cli_tool_b", ...). For
+    "provider_c", "provider_n", "ollama", "provider_k", "provider_h", ...). For
     direct-API kinds the lookup silently fell back to
     [default_capabilities]; for CLI kinds the masc vocabulary (boundary-allow) happened
     to match direct-API entries ("agent_llm_a" → Anthropic, "provider_f" → Gemini,
@@ -1053,7 +1023,7 @@ let () =
         ; test_case "requires_any" `Quick test_requires_any
         ] )
     ; ( "default"
-      , [ test_case "has 19 providers" `Quick test_default_has_19
+      , [ test_case "has current providers" `Quick test_default_has_current_providers
         ; test_case "correct capabilities" `Quick test_default_capabilities
         ; test_case "ollama_cloud entry" `Quick test_default_ollama_cloud_entry
         ; test_case

--- a/test/test_provider_runtime_binding.ml
+++ b/test/test_provider_runtime_binding.ml
@@ -258,6 +258,23 @@ let test_builtin_binding_resolves () =
     (Provider_runtime_binding.resolve_model binding ~requested_model:None)
 ;;
 
+let test_builtin_aliases_resolve_to_canonical_bindings () =
+  let cases =
+    [ "anthropic", "agent_llm_a"
+    ; "glm", "provider_k"
+    ; "zai-coding", "provider_k-coding"
+    ; "dashscope", "provider_h"
+    ; "gemini", "provider_f"
+    ; "kimi", "provider_c"
+    ]
+  in
+  List.iter
+    (fun (alias, expected_id) ->
+       let binding = expect_binding alias in
+       Alcotest.(check string) alias expected_id binding.id)
+    cases
+;;
+
 let () =
   Alcotest.run
     "Provider_runtime_binding"
@@ -293,6 +310,11 @@ let () =
             test_find_empty_missing_and_provider_config_fallbacks
         ] )
     ; ( "builtins"
-      , [ Alcotest.test_case "builtin resolves" `Quick test_builtin_binding_resolves ] )
+      , [ Alcotest.test_case "builtin resolves" `Quick test_builtin_binding_resolves
+        ; Alcotest.test_case
+            "aliases resolve to canonical bindings"
+            `Quick
+            test_builtin_aliases_resolve_to_canonical_bindings
+        ] )
     ]
 ;;

--- a/test/test_runtime_server_resolve.ml
+++ b/test/test_runtime_server_resolve.ml
@@ -86,8 +86,8 @@ let test_provider_runtime_name_provider_a () =
       }
   in
   Alcotest.(check string)
-    "provider_a"
-    "provider_a"
+    "agent_llm_a"
+    "agent_llm_a"
     (Runtime_server_resolve.provider_runtime_name "provider_a" cfg)
 ;;
 
@@ -96,7 +96,7 @@ let test_provider_runtime_name_openai_compat () =
     Some
       { Provider.provider =
           Provider.OpenAICompat
-            { base_url = "https://api.provider_d.com"
+            { base_url = "https://openai-compatible.example.test"
             ; auth_header = None
             ; path = "/v1/chat/completions"
             ; static_token = None
@@ -106,9 +106,9 @@ let test_provider_runtime_name_openai_compat () =
       }
   in
   Alcotest.(check string)
-    "openai-compat"
-    "openai-compat"
-    (Runtime_server_resolve.provider_runtime_name "provider_d" cfg)
+    "openai_compat"
+    "openai_compat"
+    (Runtime_server_resolve.provider_runtime_name "openai_compat" cfg)
 ;;
 
 let test_provider_runtime_name_custom_registered () =
@@ -120,8 +120,8 @@ let test_provider_runtime_name_custom_registered () =
       }
   in
   Alcotest.(check string)
-    "custom:myvendor"
-    "custom:myvendor"
+    "myvendor"
+    "myvendor"
     (Runtime_server_resolve.provider_runtime_name "custom" cfg)
 ;;
 
@@ -181,6 +181,32 @@ let test_resolve_provider_openrouter () =
     (match cfg.Provider.provider with
      | Provider.OpenAICompat _ -> ()
      | _ -> Alcotest.fail "expected OpenAICompat")
+  | _ -> Alcotest.fail "expected Ok (Some cfg)"
+;;
+
+let test_resolve_provider_openai_compat_requires_concrete_binding () =
+  match Runtime_server_resolve.resolve_provider ~provider:"openai_compat" () with
+  | Error (Error.Config (Error.UnsupportedProvider _)) -> ()
+  | _ -> Alcotest.fail "expected OpenAI-compatible kind without binding to fail closed"
+;;
+
+let test_resolve_provider_glm_alias () =
+  match Runtime_server_resolve.resolve_provider ~provider:"glm" () with
+  | Ok (Some cfg) ->
+    (match cfg.Provider.provider with
+     | Provider.Custom_registered { name } ->
+       Alcotest.(check string) "canonical binding" "provider_k" name
+     | _ -> Alcotest.fail "expected Custom_registered provider_k")
+  | _ -> Alcotest.fail "expected Ok (Some cfg)"
+;;
+
+let test_resolve_provider_dashscope_alias () =
+  match Runtime_server_resolve.resolve_provider ~provider:"dashscope" () with
+  | Ok (Some cfg) ->
+    (match cfg.Provider.provider with
+     | Provider.Custom_registered { name } ->
+       Alcotest.(check string) "canonical binding" "provider_h" name
+     | _ -> Alcotest.fail "expected Custom_registered provider_h")
   | _ -> Alcotest.fail "expected Ok (Some cfg)"
 ;;
 
@@ -295,7 +321,7 @@ let test_resolve_execution_non_mock_has_provider_cfg () =
     Alcotest.(check bool) "has provider cfg" true (Option.is_some res.provider_cfg);
     Alcotest.(check (option string))
       "resolved provider"
-      (Some "provider_a")
+      (Some "agent_llm_a")
       res.resolved_provider
   | Error _ -> Alcotest.fail "expected Ok"
 ;;
@@ -409,6 +435,18 @@ let () =
             "provider_o_router returns OpenAICompat"
             `Quick
             test_resolve_provider_openrouter
+        ; Alcotest.test_case
+            "openai_compat requires concrete binding"
+            `Quick
+            test_resolve_provider_openai_compat_requires_concrete_binding
+        ; Alcotest.test_case
+            "glm resolves provider_k binding"
+            `Quick
+            test_resolve_provider_glm_alias
+        ; Alcotest.test_case
+            "dashscope resolves provider_h binding"
+            `Quick
+            test_resolve_provider_dashscope_alias
         ; Alcotest.test_case
             "unknown returns UnsupportedProvider error"
             `Quick


### PR DESCRIPTION
Follow-up to main CI run 26760971890 after #1827, but scoped to the Provider runtime interpretation layer instead of papering over inline tests only.

Design:
- Runtime provider lookup now goes through Provider_runtime_binding instead of Runtime_server_resolve reading Provider_registry directly.
- Built-in runtime aliases are parsed in one place for real provider bindings: anthropic/claude/provider_a -> agent_llm_a, kimi -> provider_c, gemini -> provider_f, glm/zhipu/zai -> provider_k, zai-coding/glm-coding -> provider_k-coding, dashscope -> provider_h.
- openai_compat is treated as a provider kind / transport class, not a provider id. Without a concrete catalog or named provider binding, runtime resolution fails closed instead of inventing https://api.provider_d.com or PROVIDER_D_API_KEY.
- Runtime output stops inventing display-only provider names like openai-compat and custom:<name>; it emits the canonical runtime binding id, openai_compat for unmatched legacy OpenAICompat configs, or the raw custom provider name.
- The previous CI inline failures are still fixed: deleted CLI labels are removed from capability label invariants, DashScope_3.5-35B matches dashscope, and bare glm-* IDs share Z.ai throttle keys with provider_k-*.

Local verification:
- git diff --check
- opam exec -- dune fmt --root . --auto-promote
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_runtime_provider_fix opam exec -- dune build --root . ./test/test_runtime_server_resolve.exe ./test/test_provider_runtime_binding.exe ./test/test_agent_lifecycle.exe ./test/test_provider_registry.exe
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_runtime_provider_fix opam exec -- dune exec --root . ./test/test_runtime_server_resolve.exe
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_runtime_provider_fix opam exec -- dune exec --root . ./test/test_provider_runtime_binding.exe
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_runtime_provider_fix opam exec -- dune exec --root . ./test/test_agent_lifecycle.exe -- test provider_runtime_name
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_runtime_provider_fix opam exec -- dune exec --root . ./test/test_provider_registry.exe
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_runtime_provider_fix opam exec -- dune runtest --root . lib/llm_provider