### PR TITLE
Fix runtime provider identity resolution

### DIFF
--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -26,8 +26,11 @@
       }
     ]}
 
-    Provider values: "local" (llama-server), "provider_a", "provider_d",
-    or any string (treated as Provider_d-compatible with api_key_env = that string).
+    Provider values are runtime provider ids or aliases from
+    {!Provider_runtime_binding}; ["local"] remains the built-in llama-server
+    shorthand. Unknown strings are custom provider names unless paired with an
+    explicit [base_url], in which case they are treated as an explicit
+    OpenAI-compatible endpoint using the string as [api_key_env].
 *)
 
 open Result_syntax
@@ -295,23 +298,26 @@ let load path =
     Error (Error.Io (FileOpFailed { op = "load"; path; detail = "JSON error: " ^ msg }))
 ;;
 
-(** Resolve provider string + optional base_url to a Provider.config.
+(** Resolve provider string + optional base_url to a Provider.config. *)
+let provider_config_of_binding ~model_id ?base_url (binding : Provider_runtime_binding.t) =
+  match base_url with
+  | Some url ->
+    { Provider.provider =
+        openai_compat_config
+          ~base_url:url
+          ~api_key_env:binding.api_key_env
+          ~path:binding.request_path
+          ()
+    ; model_id
+    ; api_key_env = binding.api_key_env
+    }
+  | None ->
+    { Provider.provider = Custom_registered { name = binding.id }
+    ; model_id
+    ; api_key_env = binding.api_key_env
+    }
+;;
 
-    Canonical provider kinds ({!Llm_provider.Provider_kind.t}) are dispatched
-    through {!Llm_provider.Provider_kind.of_string}, which accepts the
-    canonical wire forms (["provider_a"], ["openai_compat"], …) plus the
-    documented aliases (["agent_llm_a"] -> Anthropic,
-    ["provider_d"] -> OpenAI_compat, ["provider_n"] -> Ollama), case-insensitively
-    with leading/trailing whitespace trimmed.
-
-    ["local"] remains a first-class routing shorthand (not a Provider_kind
-    variant) and is matched explicitly before the parser so that
-    ["LOCAL"] / [" local "] also reach the Local branch.
-
-    Any kind the parser recognises beyond Anthropic / OpenAI_compat — or
-    anything it does not recognise at all — falls through to the registry
-    lookup path, preserving the legacy [Custom_registered] behaviour that
-    downstream tests and configs depend on. *)
 let resolve_provider ~model_id provider_str base_url =
   let normalized = String.lowercase_ascii (String.trim provider_str) in
   if normalized = "local"
@@ -323,60 +329,20 @@ let resolve_provider ~model_id provider_str base_url =
     in
     { Provider.provider = Local { base_url = url }; model_id; api_key_env = "" })
   else (
-    match Llm_provider.Provider_kind.of_string provider_str with
-    | Some Anthropic ->
-      { Provider.provider = Anthropic; model_id; api_key_env = "PROVIDER_A_API_KEY" }
-    | Some OpenAI_compat ->
-      let api_key_env = "PROVIDER_D_API_KEY" in
-      let url =
-        match base_url with
-        | Some u -> u
-        | None -> "https://api.provider_d.com"
-      in
-      { Provider.provider = openai_compat_config ~base_url:url ~api_key_env ()
-      ; model_id
-      ; api_key_env
-      }
-    | Some (Kimi | Ollama | Gemini | Glm | DashScope) | None ->
-      let registry = Llm_provider.Provider_registry.default () in
-      (match Llm_provider.Provider_registry.find registry provider_str with
-       | Some entry ->
-         (match base_url with
-          | None ->
-            (* Preserve registry-declared kind (Gemini/Glm/Ollama/etc.)
-                    via Custom_registered. Downstream (provider_config_of_agent,
-                    request_path, Capabilities, resolve) dispatches through
-                    Provider_registry by name, retaining entry.defaults.kind. *)
-            { Provider.provider = Custom_registered { name = provider_str }
-            ; model_id
-            ; api_key_env = entry.defaults.api_key_env
-            }
-          | Some url ->
-            (* Explicit base_url override: legacy Provider.config variant
-                    cannot carry kind + arbitrary URL simultaneously, so kind
-                    flattens to OpenAI_compat. For kind-preserving override,
-                    construct Llm_provider.Provider_config.t directly via
-                    Provider_config.make. *)
-            let api_key_env = entry.defaults.api_key_env in
-            { Provider.provider =
-                openai_compat_config
-                  ~base_url:url
-                  ~api_key_env
-                  ~path:entry.defaults.request_path
-                  ()
-            ; model_id
-            ; api_key_env
-            })
-       | None ->
-         let api_key_env = provider_str in
-         let url =
-           match base_url with
-           | Some u -> u
-           | None -> Defaults.local_llm_url
-         in
+    match Provider_runtime_binding.find normalized with
+    | Some binding -> provider_config_of_binding ~model_id ?base_url binding
+    | None ->
+      (match base_url with
+       | Some url ->
+         let api_key_env = String.trim provider_str in
          { Provider.provider = openai_compat_config ~base_url:url ~api_key_env ()
          ; model_id
          ; api_key_env
+         }
+       | None ->
+         { Provider.provider = Custom_registered { name = normalized }
+         ; model_id
+         ; api_key_env = String.trim provider_str
          }))
 ;;
 

--- a/lib/agent/agent_lifecycle.ml
+++ b/lib/agent/agent_lifecycle.ml
@@ -77,12 +77,7 @@ type lifecycle_snapshot =
 let provider_runtime_name (cfg : Provider.config option) =
   match cfg with
   | None -> None
-  | Some cfg ->
-    (match cfg.provider with
-     | Provider.Local _ -> Some "local"
-     | Provider.Anthropic -> Some "provider_a"
-     | Provider.OpenAICompat _ -> Some "openai-compat"
-     | Provider.Custom_registered { name } -> Some ("custom:" ^ name))
+  | Some cfg -> Some (Provider_runtime_binding.provider_id_of_legacy_config cfg)
 ;;
 
 let hook_decision_to_string = function

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -486,5 +486,5 @@ let provider_name_of_config (config : Provider_config.t) =
           && String.equal (String.trim entry.defaults.request_path) request_path)
       with
       | Some entry -> entry.name
-      | None -> "provider_d")
+      | None -> "openai_compat")
 ;;

--- a/lib/llm_provider/provider_registry.mli
+++ b/lib/llm_provider/provider_registry.mli
@@ -69,8 +69,8 @@ val default : unit -> t
 (** Best-effort canonical provider name for a concrete provider config.
     Unlike [Provider_config.string_of_provider_kind], this keeps
     registry-level distinctions that share a wire kind but differ by
-    endpoint (for example [provider_k] vs [provider_k-coding], or [provider_d] vs
-    [provider_o_router]). Falls back to a stable kind-derived label when the
+    endpoint (for example [provider_k] vs [provider_k-coding], or
+    [openai_compat] vs [provider_o_router]). Falls back to a stable kind-derived label when the
     config does not match a known registry entry exactly. *)
 val provider_name_of_config : Provider_config.t -> string
 

--- a/lib/provider_runtime_binding.ml
+++ b/lib/provider_runtime_binding.ml
@@ -170,6 +170,38 @@ let catalog_names entries =
 
 let sort_bindings bindings = List.sort (fun a b -> String.compare a.id b.id) bindings
 
+let builtin_provider_aliases =
+  [ "anthropic", "agent_llm_a"
+  ; "claude", "agent_llm_a"
+  ; "provider_a", "agent_llm_a"
+  ; "moonshot", "provider_c"
+  ; "kimi", "provider_c"
+  ; "gemini", "provider_f"
+  ; "glm", "provider_k"
+  ; "zai", "provider_k"
+  ; "zhipu", "provider_k"
+  ; "glm-coding", "provider_k-coding"
+  ; "zai-coding", "provider_k-coding"
+  ; "zhipu-coding", "provider_k-coding"
+  ; "openrouter", "provider_o_router"
+  ; "deepseek", "provider_g"
+  ; "groq", "provider_i"
+  ; "dashscope", "provider_h"
+  ; "qwen", "provider_h"
+  ]
+;;
+
+let builtin_alias_target label = List.assoc_opt (normalize label) builtin_provider_aliases
+
+let binding_by_exact_label registry normalized =
+  match PC.global () with
+  | Some catalog ->
+    (match PC.lookup catalog normalized with
+     | Some entry -> Some (binding_of_catalog_entry registry entry)
+     | None -> Option.map binding_of_registry_entry (PR.find registry normalized))
+  | None -> Option.map binding_of_registry_entry (PR.find registry normalized)
+;;
+
 let all () =
   let registry = PR.default () in
   let catalog = catalog_entries () in
@@ -190,12 +222,22 @@ let find label =
   then None
   else (
     let registry = PR.default () in
-    match PC.global () with
-    | Some catalog ->
-      (match PC.lookup catalog normalized with
-       | Some entry -> Some (binding_of_catalog_entry registry entry)
-       | None -> Option.map binding_of_registry_entry (PR.find registry normalized))
-    | None -> Option.map binding_of_registry_entry (PR.find registry normalized))
+    match binding_by_exact_label registry normalized with
+    | Some _ as binding -> binding
+    | None ->
+      (match builtin_alias_target normalized with
+       | Some target -> binding_by_exact_label registry target
+       | None -> None))
+;;
+
+let known_labels () =
+  let binding_labels =
+    all ()
+    |> List.concat_map (fun binding -> binding.id :: binding.aliases)
+    |> List.map normalize
+  in
+  let alias_labels = List.map fst builtin_provider_aliases in
+  List.sort_uniq String.compare (binding_labels @ alias_labels)
 ;;
 
 let normalize_endpoint_url value =
@@ -254,10 +296,33 @@ let binding_for_provider_config (cfg : PConfig.t) =
   let registry = PR.default () in
   match catalog_binding_for_provider_config registry cfg with
   | Some binding -> Some binding
-  | None ->
-    (match registry_binding_for_provider_config registry cfg with
-     | Some binding -> Some binding
-     | None -> PR.provider_name_of_config cfg |> find)
+  | None -> registry_binding_for_provider_config registry cfg
+;;
+
+let provider_id_of_provider_config cfg =
+  match binding_for_provider_config cfg with
+  | Some binding -> binding.id
+  | None -> PR.provider_name_of_config cfg
+;;
+
+let provider_id_of_legacy_config (cfg : Provider.config) =
+  match cfg.provider with
+  | Provider.Local _ -> "local"
+  | Provider.Anthropic -> "agent_llm_a"
+  | Provider.Custom_registered { name } ->
+    (match find name with
+     | Some binding -> binding.id
+     | None -> normalize name)
+  | Provider.OpenAICompat { base_url; path; _ } ->
+    let provider_config =
+      PConfig.make
+        ~kind:PConfig.OpenAI_compat
+        ~model_id:cfg.model_id
+        ~base_url
+        ~request_path:path
+        ()
+    in
+    provider_id_of_provider_config provider_config
 ;;
 
 let base_capabilities_of_kind = function

--- a/lib/provider_runtime_binding.mli
+++ b/lib/provider_runtime_binding.mli
@@ -47,12 +47,28 @@ val all : unit -> t list
     case-insensitive and whitespace-trimmed. *)
 val find : string -> t option
 
+(** Return all known binding ids and selector aliases. This is a display /
+    diagnostics surface; callers should use {!find} for resolution. *)
+val known_labels : unit -> string list
+
 (** Resolve the runtime binding that owns a concrete provider config.
 
     Catalog endpoint matches are resolved before registry provider-name
     fallbacks, so catalog-provided OpenAI-compatible providers remain
     OAS-owned even when the endpoint is local. *)
 val binding_for_provider_config : Llm_provider.Provider_config.t -> t option
+
+(** Best-effort runtime provider id for a concrete provider config.
+
+    When the endpoint matches a catalog or registry binding, returns that
+    binding id. Otherwise returns a stable kind-derived label such as
+    ["openai_compat"]; it never invents a fake provider id. *)
+val provider_id_of_provider_config : Llm_provider.Provider_config.t -> string
+
+(** Best-effort runtime provider id for the legacy {!Provider.config}
+    adapter. Custom providers are reported by their registered name, without
+    a ["custom:"] display prefix. *)
+val provider_id_of_legacy_config : Provider.config -> string
 
 (** Resolve OAS-owned provider capabilities for a concrete provider config.
 

--- a/lib/runtime_server_resolve.ml
+++ b/lib/runtime_server_resolve.ml
@@ -27,105 +27,48 @@ let ensure_test_provider_enabled selected =
 let provider_runtime_name selected (cfg : Provider.config option) =
   match cfg with
   | None -> selected
-  | Some cfg ->
-    (match cfg.provider with
-     | Provider.Local _ -> "local"
-     | Provider.Anthropic -> "provider_a"
-     | Provider.OpenAICompat _ -> "openai-compat"
-     | Provider.Custom_registered { name } -> "custom:" ^ name)
+  | Some cfg -> Provider_runtime_binding.provider_id_of_legacy_config cfg
 ;;
 
-let registry_valid_provider_detail registry =
-  let names =
-    Llm_provider.Provider_registry.all registry
-    |> List.map (fun (entry : Llm_provider.Provider_registry.entry) -> entry.name)
-    |> List.sort_uniq String.compare
-  in
-  let names = "local" :: names in
+let valid_provider_detail () =
+  let names = "local" :: Provider_runtime_binding.known_labels () in
   let names =
     if Defaults.allow_test_providers () then "mock" :: "echo" :: names else names
   in
   String.concat ", " (List.sort_uniq String.compare names)
 ;;
 
-let provider_config_of_registry_entry
-      ~provider_name
-      ~model_id
-      (entry : Llm_provider.Provider_registry.entry)
-  =
-  match entry.defaults.kind with
-  | Llm_provider.Provider_config.Anthropic ->
-    { Provider.provider = Provider.Anthropic
-    ; model_id
-    ; api_key_env = entry.defaults.api_key_env
-    }
-  | Llm_provider.Provider_config.OpenAI_compat ->
-    { Provider.provider =
-        Provider.OpenAICompat
-          { base_url = entry.defaults.base_url
-          ; auth_header =
-              (if String.trim entry.defaults.api_key_env = ""
-               then None
-               else Some "Authorization")
-          ; path = entry.defaults.request_path
-          ; static_token = None
-          }
-    ; model_id
-    ; api_key_env = entry.defaults.api_key_env
-    }
-  | _ ->
-    { Provider.provider = Provider.Custom_registered { name = provider_name }
-    ; model_id
-    ; api_key_env = entry.defaults.api_key_env
-    }
+let provider_config_of_binding ~model_id (binding : Provider_runtime_binding.t) =
+  { Provider.provider = Provider.Custom_registered { name = binding.id }
+  ; model_id
+  ; api_key_env = binding.api_key_env
+  }
 ;;
 
-let catalog_default_model provider_name =
-  match Llm_provider.Provider_catalog.global () with
-  | None -> None
-  | Some catalog ->
-    Llm_provider.Provider_catalog.default_model_for_provider catalog provider_name
-;;
-
-let effective_model_id ~provider_name ~entry ?model () =
-  match model with
-  | Some value when String.trim value <> "" -> value
-  | _ ->
-    (match catalog_default_model provider_name with
-     | Some model_id when String.trim model_id <> "" -> model_id
-     | _ ->
-       (match entry.Llm_provider.Provider_registry.defaults.kind with
-        | Llm_provider.Provider_config.Ollama -> "default"
-        | _ -> Model_registry.default_model_id))
-;;
-
-let resolve_from_registry registry ~provider_name ?model () =
-  match Llm_provider.Provider_registry.find registry provider_name with
-  | Some entry ->
-    let model_id = effective_model_id ~provider_name ~entry ?model () in
-    Ok (Some (provider_config_of_registry_entry ~provider_name ~model_id entry))
+let resolve_from_bindings ~provider_name ?model () =
+  match Provider_runtime_binding.find provider_name with
+  | Some binding ->
+    let model_id =
+      Provider_runtime_binding.resolve_model binding ~requested_model:model
+    in
+    Ok (Some (provider_config_of_binding ~model_id binding))
   | None ->
     let resolved_model = Model_registry.resolve_model_id provider_name in
     if not (String.equal resolved_model provider_name)
     then (
-      match Llm_provider.Provider_registry.find registry "agent_llm_a" with
-      | Some entry ->
-        Ok
-          (Some
-             (provider_config_of_registry_entry
-                ~provider_name:"agent_llm_a"
-                ~model_id:resolved_model
-                entry))
+      match Provider_runtime_binding.find "agent_llm_a" with
+      | Some binding ->
+        Ok (Some (provider_config_of_binding ~model_id:resolved_model binding))
       | None ->
         unsupported_provider
-          "provider alias resolved to an Anthropic model but provider catalog has no \
+          "provider alias resolved to an Anthropic model but provider bindings have no \
            \"agent_llm_a\" entry")
     else
       unsupported_provider
         (Printf.sprintf
            "unknown provider %S; valid: %s"
            provider_name
-           (registry_valid_provider_detail registry))
+           (valid_provider_detail ()))
 ;;
 
 let resolve_provider ?provider ?model () =
@@ -135,14 +78,13 @@ let resolve_provider ?provider ?model () =
       String.lowercase_ascii (String.trim value)
     | _ -> Defaults.fallback_provider
   in
-  let registry = Llm_provider.Provider_registry.default () in
   let base =
     match selected with
     | "mock" | "echo" ->
       let* () = ensure_test_provider_enabled selected in
       Ok None
     | "local" -> Ok (Some (Provider.local_llm ()))
-    | other -> resolve_from_registry registry ~provider_name:other ?model ()
+    | other -> resolve_from_bindings ~provider_name:other ?model ()
   in
   match base with
   | Error _ as e -> e

--- a/test/dune
+++ b/test/dune
@@ -542,3 +542,8 @@
  (name test_agent_cancellation_tla_parity)
  (modules test_agent_cancellation_tla_parity)
  (libraries agent_sdk alcotest))
+
+(test
+ (name test_runtime_server_resolve)
+ (modules test_runtime_server_resolve)
+ (libraries agent_sdk alcotest unix))

--- a/test/test_agent_config_deep.ml
+++ b/test/test_agent_config_deep.ml
@@ -325,20 +325,20 @@ let test_resolve_provider_a () =
     Agent_config.resolve_provider ~model_id:"agent_llm_a-sonnet" "provider_a" None
   in
   match cfg.provider with
-  | Provider.Anthropic ->
+  | Provider.Custom_registered { name } ->
+    Alcotest.(check string) "provider id" "agent_llm_a" name;
     Alcotest.(check string) "model_id" "agent_llm_a-sonnet" cfg.model_id;
     Alcotest.(check string) "api_key_env" "PROVIDER_A_API_KEY" cfg.api_key_env
-  | _ -> Alcotest.fail "expected Anthropic"
+  | _ -> Alcotest.fail "expected registered provider"
 ;;
 
 let test_resolve_provider_d () =
   let cfg = Agent_config.resolve_provider ~model_id:"model-d-4" "provider_d" None in
   match cfg.provider with
-  | Provider.OpenAICompat { base_url; auth_header; _ } ->
-    Alcotest.(check string) "base_url" "https://api.provider_d.com" base_url;
-    Alcotest.(check (option string)) "auth header" (Some "Authorization") auth_header;
-    Alcotest.(check string) "api_key_env" "PROVIDER_D_API_KEY" cfg.api_key_env
-  | _ -> Alcotest.fail "expected OpenAICompat"
+  | Provider.Custom_registered { name } ->
+    Alcotest.(check string) "not a built-in provider id" "provider_d" name;
+    Alcotest.(check string) "api_key_env preserves selector" "provider_d" cfg.api_key_env
+  | _ -> Alcotest.fail "expected unresolved registered-provider adapter"
 ;;
 
 let test_resolve_provider_d_custom_url () =
@@ -358,10 +358,10 @@ let test_resolve_provider_d_custom_url () =
 let test_resolve_other () =
   let cfg = Agent_config.resolve_provider ~model_id:"m1" "MY_CUSTOM_KEY" None in
   match cfg.provider with
-  | Provider.OpenAICompat { auth_header; _ } ->
-    Alcotest.(check string) "api_key_env" "MY_CUSTOM_KEY" cfg.api_key_env;
-    Alcotest.(check (option string)) "auth header" (Some "Authorization") auth_header
-  | _ -> Alcotest.fail "expected OpenAICompat"
+  | Provider.Custom_registered { name } ->
+    Alcotest.(check string) "provider id" "my_custom_key" name;
+    Alcotest.(check string) "api_key_env" "MY_CUSTOM_KEY" cfg.api_key_env
+  | _ -> Alcotest.fail "expected unresolved registered-provider adapter"
 ;;
 
 let test_resolve_other_custom_url () =
@@ -457,22 +457,12 @@ let test_resolve_provider_f_preserves_kind () =
 (* ── Provider_kind dispatch (drift-fix regressions) ───────────── *)
 
 let test_resolve_openai_compat_ssot () =
-  (* "openai_compat" is the canonical string emitted by
-     Provider_kind.to_string OpenAI_compat. Before the parser dispatch,
-     it fell through to the registry fallback and ended up with
-     api_key_env = "openai_compat" — a meaningless value. *)
   let cfg = Agent_config.resolve_provider ~model_id:"model-d-4" "openai_compat" None in
   match cfg.provider with
-  | Provider.OpenAICompat { base_url; _ } ->
-    Alcotest.(check string)
-      "canonical form reaches provider_d branch"
-      "https://api.provider_d.com"
-      base_url;
-    Alcotest.(check string)
-      "api_key_env is PROVIDER_D_API_KEY"
-      "PROVIDER_D_API_KEY"
-      cfg.api_key_env
-  | _ -> Alcotest.fail "expected OpenAICompat for openai_compat"
+  | Provider.Custom_registered { name } ->
+    Alcotest.(check string) "kind string is not provider id" "openai_compat" name;
+    Alcotest.(check string) "api_key_env preserves input" "openai_compat" cfg.api_key_env
+  | _ -> Alcotest.fail "expected unresolved registered-provider adapter"
 ;;
 
 let test_resolve_provider_a_case_insensitive () =
@@ -484,12 +474,16 @@ let test_resolve_provider_a_case_insensitive () =
          Agent_config.resolve_provider ~model_id:"agent_llm_a-sonnet" input None
        in
        match cfg.provider with
-       | Provider.Anthropic ->
+       | Provider.Custom_registered { name } ->
+         Alcotest.(check string)
+           (Printf.sprintf "provider id for %S" input)
+           "agent_llm_a"
+           name;
          Alcotest.(check string)
            (Printf.sprintf "api_key_env for %S" input)
            "PROVIDER_A_API_KEY"
            cfg.api_key_env
-       | _ -> Alcotest.failf "expected Anthropic for %S" input)
+       | _ -> Alcotest.failf "expected registered provider for %S" input)
     [ "Anthropic"; " PROVIDER_A "; "provider_a" ]
 ;;
 
@@ -502,26 +496,25 @@ let test_resolve_agent_llm_a_alias_routes_to_provider_a () =
     Agent_config.resolve_provider ~model_id:"agent_llm_a-sonnet" "agent_llm_a" None
   in
   match cfg.provider with
-  | Provider.Anthropic ->
+  | Provider.Custom_registered { name } ->
+    Alcotest.(check string) "provider id" "agent_llm_a" name;
     Alcotest.(check string)
-      "api_key_env routed to Anthropic"
+      "api_key_env routed to registered provider"
       "PROVIDER_A_API_KEY"
       cfg.api_key_env
-  | _ -> Alcotest.fail "expected Anthropic for agent_llm_a alias"
+  | _ -> Alcotest.fail "expected registered provider for agent_llm_a alias"
 ;;
 
 let test_resolve_unknown_still_goes_to_registry_fallback () =
-  (* Non-canonical non-alias input should continue to flow through the
-     registry-or-fallback path. This guards against over-eager parser
-     capture when we add more kinds. *)
   let cfg = Agent_config.resolve_provider ~model_id:"m1" "TOTALLY_BOGUS_KEY" None in
   match cfg.provider with
-  | Provider.OpenAICompat _ ->
+  | Provider.Custom_registered { name } ->
+    Alcotest.(check string) "provider id" "totally_bogus_key" name;
     Alcotest.(check string)
       "api_key_env preserves input"
       "TOTALLY_BOGUS_KEY"
       cfg.api_key_env
-  | _ -> Alcotest.fail "expected registry fallback OpenAICompat"
+  | _ -> Alcotest.fail "expected unresolved registered-provider adapter"
 ;;
 
 let test_resolve_ollama_custom_url_stays_no_auth () =
@@ -628,8 +621,8 @@ let () =
       , [ tc "local" test_resolve_local
         ; tc "local custom url" test_resolve_local_custom_url
         ; tc "provider_a" test_resolve_provider_a
-        ; tc "provider_d" test_resolve_provider_d
-        ; tc "provider_d custom url" test_resolve_provider_d_custom_url
+        ; tc "provider_d is not built in" test_resolve_provider_d
+        ; tc "explicit provider_d custom url" test_resolve_provider_d_custom_url
         ; tc "other" test_resolve_other
         ; tc "other custom url" test_resolve_other_custom_url
         ; tc "other OpenAI /v1 base url" test_resolve_other_openai_v1_base_url
@@ -637,13 +630,13 @@ let () =
         ; tc "provider_i custom url" test_resolve_provider_i_custom_url
         ; tc "provider_g" test_resolve_provider_g
         ; tc "provider_f preserves kind (#1003)" test_resolve_provider_f_preserves_kind
-        ; tc "openai_compat SSOT string" test_resolve_openai_compat_ssot
+        ; tc "openai_compat is kind string" test_resolve_openai_compat_ssot
         ; tc "provider_a case-insensitive" test_resolve_provider_a_case_insensitive
         ; tc
             "agent_llm_a alias routes to Anthropic"
             test_resolve_agent_llm_a_alias_routes_to_provider_a
         ; tc
-            "unknown still goes to registry fallback"
+            "unknown stays unresolved provider id"
             test_resolve_unknown_still_goes_to_registry_fallback
         ; tc
             "ollama custom url stays no-auth"

--- a/test/test_agent_lifecycle.ml
+++ b/test/test_agent_lifecycle.ml
@@ -85,7 +85,7 @@ let test_build_snapshot_with_provider () =
   in
   Alcotest.(check (option string))
     "requested_provider"
-    (Some "provider_a")
+    (Some "agent_llm_a")
     snap.requested_provider;
   Alcotest.(check (option string))
     "resolved_model"
@@ -120,8 +120,8 @@ let test_runtime_name_provider_a () =
     { provider = Anthropic; model_id = "test"; api_key_env = "DUMMY" }
   in
   Alcotest.(check (option string))
-    "provider_a"
-    (Some "provider_a")
+    "agent_llm_a"
+    (Some "agent_llm_a")
     (Agent_lifecycle.provider_runtime_name (Some cfg))
 ;;
 
@@ -129,7 +129,7 @@ let test_runtime_name_openai_compat () =
   let cfg : Provider.config =
     { provider =
         OpenAICompat
-          { base_url = "http://localhost"
+          { base_url = "https://unlisted.example"
           ; auth_header = None
           ; path = "/v1/chat"
           ; static_token = None
@@ -139,8 +139,8 @@ let test_runtime_name_openai_compat () =
     }
   in
   Alcotest.(check (option string))
-    "openai-compat"
-    (Some "openai-compat")
+    "openai_compat"
+    (Some "openai_compat")
     (Agent_lifecycle.provider_runtime_name (Some cfg))
 ;;
 
@@ -153,7 +153,7 @@ let test_runtime_name_custom () =
   in
   Alcotest.(check (option string))
     "custom"
-    (Some "custom:my-custom")
+    (Some "my-custom")
     (Agent_lifecycle.provider_runtime_name (Some cfg))
 ;;
 

--- a/test/test_custom_provider.ml
+++ b/test/test_custom_provider.ml
@@ -183,7 +183,7 @@ let test_model_spec_registered () =
 let test_lifecycle_runtime_name () =
   let cfg : Provider.config = Provider.custom_provider ~name:"life-test" () in
   let name = Agent_lifecycle.provider_runtime_name (Some cfg) in
-  Alcotest.(check (option string)) "runtime name" (Some "custom:life-test") name
+  Alcotest.(check (option string)) "runtime name" (Some "life-test") name
 ;;
 
 (* ── Test runner ────────────────────────────────────────── *)

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -533,6 +533,21 @@ let test_provider_name_of_config_openrouter () =
     (Provider_registry.provider_name_of_config cfg)
 ;;
 
+let test_provider_name_of_config_unmatched_openai_compat () =
+  let cfg =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"unlisted-model"
+      ~base_url:"https://unlisted.example/v1"
+      ~request_path:"/chat/completions"
+      ()
+  in
+  check_string
+    "unmatched openai compat"
+    "openai_compat"
+    (Provider_registry.provider_name_of_config cfg)
+;;
+
 (* ── provider_kind_of_string ─────────────────────────── *)
 
 (** Check a raw string parses to the expected variant. Compared via
@@ -989,6 +1004,10 @@ let () =
             "provider_o_router"
             `Quick
             test_provider_name_of_config_openrouter
+        ; Alcotest.test_case
+            "unmatched openai_compat"
+            `Quick
+            test_provider_name_of_config_unmatched_openai_compat
         ] )
     ; ( "kind_of_string"
       , [ Alcotest.test_case "roundtrip all variants" `Quick test_kind_roundtrip

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -204,10 +204,10 @@ let test_find_capable_composite () =
 
 (* ── Default registry ───────────────────────────────── *)
 
-let test_default_has_19 () =
+let test_default_has_14 () =
   let reg = Provider_registry.default () in
   let all = Provider_registry.all reg in
-  check int "19 known providers" 19 (List.length all);
+  check int "14 known providers" 14 (List.length all);
   check
     bool
     "llama exists"
@@ -269,28 +269,7 @@ let test_default_has_19 () =
     bool
     "siliconflow exists"
     true
-    (Option.is_some (Provider_registry.find reg "siliconflow"));
-  check
-    bool
-    "cli_tool_d exists"
-    true
-    (Option.is_some (Provider_registry.find reg "cli_tool_d"));
-  check bool "cc exists" true (Option.is_some (Provider_registry.find reg "cc"));
-  check
-    bool
-    "cli_tool_b exists"
-    true
-    (Option.is_some (Provider_registry.find reg "cli_tool_b"));
-  check
-    bool
-    "cli_tool_c exists"
-    true
-    (Option.is_some (Provider_registry.find reg "cli_tool_c"));
-  check
-    bool
-    "cli_tool_a exists"
-    true
-    (Option.is_some (Provider_registry.find reg "cli_tool_a"))
+    (Option.is_some (Provider_registry.find reg "siliconflow"))
 ;;
 
 let test_default_capabilities () =
@@ -351,9 +330,6 @@ let test_default_max_context () =
   (match Provider_registry.find reg "provider_c" with
    | Some e -> check int "provider_c 262K" 262_144 e.max_context
    | None -> fail "provider_c should exist");
-  (match Provider_registry.find reg "cc" with
-   | Some e -> check int "cc 1M" 1_000_000 e.max_context
-   | None -> fail "cc should exist");
   (match Provider_registry.find reg "provider_i" with
    | Some e -> check int "provider_i 131K" 131_072 e.max_context
    | None -> fail "provider_i should exist");
@@ -366,15 +342,9 @@ let test_default_max_context () =
   (match Provider_registry.find reg "alibaba" with
    | Some e -> check int "alibaba 131K" 131_072 e.max_context
    | None -> fail "alibaba should exist");
-  (match Provider_registry.find reg "siliconflow" with
-   | Some e -> check int "siliconflow 128K" 128_000 e.max_context
-   | None -> fail "siliconflow should exist");
-  (match Provider_registry.find reg "cli_tool_a" with
-   | Some e -> check int "cli_tool_a 1.05M" 1_050_000 e.max_context
-   | None -> fail "cli_tool_a should exist");
-  match Provider_registry.find reg "cli_tool_c" with
-  | Some e -> check int "cli_tool_c 262K" 262_144 e.max_context
-  | None -> fail "cli_tool_c should exist"
+  match Provider_registry.find reg "siliconflow" with
+  | Some e -> check int "siliconflow 128K" 128_000 e.max_context
+  | None -> fail "siliconflow should exist"
 ;;
 
 let test_default_max_context_matches_capabilities () =
@@ -1053,7 +1023,7 @@ let () =
         ; test_case "requires_any" `Quick test_requires_any
         ] )
     ; ( "default"
-      , [ test_case "has 19 providers" `Quick test_default_has_19
+      , [ test_case "has 14 providers" `Quick test_default_has_14
         ; test_case "correct capabilities" `Quick test_default_capabilities
         ; test_case "ollama_cloud entry" `Quick test_default_ollama_cloud_entry
         ; test_case

--- a/test/test_provider_runtime_binding.ml
+++ b/test/test_provider_runtime_binding.ml
@@ -258,6 +258,58 @@ let test_builtin_binding_resolves () =
     (Provider_runtime_binding.resolve_model binding ~requested_model:None)
 ;;
 
+let test_builtin_aliases_are_canonicalized () =
+  let cases =
+    [ "provider_a", "agent_llm_a"
+    ; "anthropic", "agent_llm_a"
+    ; "kimi", "provider_c"
+    ; "gemini", "provider_f"
+    ; "glm", "provider_k"
+    ; "dashscope", "provider_h"
+    ]
+  in
+  List.iter
+    (fun (input, expected_id) ->
+       let binding = expect_binding input in
+       Alcotest.(check string) input expected_id binding.id)
+    cases;
+  Alcotest.(check bool)
+    "openai_compat is a kind, not a provider selector"
+    true
+    (Option.is_none (Provider_runtime_binding.find "openai_compat"))
+;;
+
+let test_provider_id_fallbacks_do_not_invent_provider_d () =
+  let cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"unlisted-model"
+      ~base_url:"https://unlisted.example/v1"
+      ~request_path:"/chat/completions"
+      ()
+  in
+  Alcotest.(check string)
+    "unmatched openai compat"
+    "openai_compat"
+    (Provider_runtime_binding.provider_id_of_provider_config cfg);
+  let legacy : Provider.config =
+    { provider =
+        Provider.OpenAICompat
+          { base_url = "https://unlisted.example/v1"
+          ; auth_header = None
+          ; path = "/chat/completions"
+          ; static_token = None
+          }
+    ; model_id = "unlisted-model"
+    ; api_key_env = "UNLISTED_API_KEY"
+    }
+  in
+  Alcotest.(check string)
+    "legacy unmatched openai compat"
+    "openai_compat"
+    (Provider_runtime_binding.provider_id_of_legacy_config legacy)
+;;
+
 let () =
   Alcotest.run
     "Provider_runtime_binding"
@@ -293,6 +345,15 @@ let () =
             test_find_empty_missing_and_provider_config_fallbacks
         ] )
     ; ( "builtins"
-      , [ Alcotest.test_case "builtin resolves" `Quick test_builtin_binding_resolves ] )
+      , [ Alcotest.test_case "builtin resolves" `Quick test_builtin_binding_resolves
+        ; Alcotest.test_case
+            "builtin aliases canonicalize"
+            `Quick
+            test_builtin_aliases_are_canonicalized
+        ; Alcotest.test_case
+            "provider id fallback"
+            `Quick
+            test_provider_id_fallbacks_do_not_invent_provider_d
+        ] )
     ]
 ;;

--- a/test/test_runtime_server_resolve.ml
+++ b/test/test_runtime_server_resolve.ml
@@ -86,8 +86,8 @@ let test_provider_runtime_name_provider_a () =
       }
   in
   Alcotest.(check string)
-    "provider_a"
-    "provider_a"
+    "agent_llm_a"
+    "agent_llm_a"
     (Runtime_server_resolve.provider_runtime_name "provider_a" cfg)
 ;;
 
@@ -96,7 +96,7 @@ let test_provider_runtime_name_openai_compat () =
     Some
       { Provider.provider =
           Provider.OpenAICompat
-            { base_url = "https://api.provider_d.com"
+            { base_url = "https://example.invalid"
             ; auth_header = None
             ; path = "/v1/chat/completions"
             ; static_token = None
@@ -106,9 +106,9 @@ let test_provider_runtime_name_openai_compat () =
       }
   in
   Alcotest.(check string)
-    "openai-compat"
-    "openai-compat"
-    (Runtime_server_resolve.provider_runtime_name "provider_d" cfg)
+    "openai_compat"
+    "openai_compat"
+    (Runtime_server_resolve.provider_runtime_name "openai_compat" cfg)
 ;;
 
 let test_provider_runtime_name_custom_registered () =
@@ -120,8 +120,8 @@ let test_provider_runtime_name_custom_registered () =
       }
   in
   Alcotest.(check string)
-    "custom:myvendor"
-    "custom:myvendor"
+    "myvendor"
+    "myvendor"
     (Runtime_server_resolve.provider_runtime_name "custom" cfg)
 ;;
 
@@ -157,21 +157,30 @@ let test_resolve_provider_local () =
 let test_resolve_provider_sonnet () =
   match Runtime_server_resolve.resolve_provider ~provider:"sonnet" () with
   | Ok (Some cfg) ->
-    Alcotest.(check bool) "provider_a" true (cfg.Provider.provider = Provider.Anthropic)
+    (match cfg.Provider.provider with
+     | Provider.Custom_registered { name } ->
+       Alcotest.(check string) "provider id" "agent_llm_a" name
+     | _ -> Alcotest.fail "expected registered provider")
   | _ -> Alcotest.fail "expected Ok (Some cfg)"
 ;;
 
 let test_resolve_provider_haiku () =
   match Runtime_server_resolve.resolve_provider ~provider:"haiku" () with
   | Ok (Some cfg) ->
-    Alcotest.(check bool) "provider_a" true (cfg.Provider.provider = Provider.Anthropic)
+    (match cfg.Provider.provider with
+     | Provider.Custom_registered { name } ->
+       Alcotest.(check string) "provider id" "agent_llm_a" name
+     | _ -> Alcotest.fail "expected registered provider")
   | _ -> Alcotest.fail "expected Ok (Some cfg)"
 ;;
 
 let test_resolve_provider_opus () =
   match Runtime_server_resolve.resolve_provider ~provider:"opus" () with
   | Ok (Some cfg) ->
-    Alcotest.(check bool) "provider_a" true (cfg.Provider.provider = Provider.Anthropic)
+    (match cfg.Provider.provider with
+     | Provider.Custom_registered { name } ->
+       Alcotest.(check string) "provider id" "agent_llm_a" name
+     | _ -> Alcotest.fail "expected registered provider")
   | _ -> Alcotest.fail "expected Ok (Some cfg)"
 ;;
 
@@ -179,9 +188,26 @@ let test_resolve_provider_openrouter () =
   match Runtime_server_resolve.resolve_provider ~provider:"provider_o_router" () with
   | Ok (Some cfg) ->
     (match cfg.Provider.provider with
-     | Provider.OpenAICompat _ -> ()
-     | _ -> Alcotest.fail "expected OpenAICompat")
+     | Provider.Custom_registered { name } ->
+       Alcotest.(check string) "provider id" "provider_o_router" name
+     | _ -> Alcotest.fail "expected registered provider")
   | _ -> Alcotest.fail "expected Ok (Some cfg)"
+;;
+
+let test_resolve_provider_alias_provider_a () =
+  match Runtime_server_resolve.resolve_provider ~provider:"provider_a" () with
+  | Ok (Some cfg) ->
+    (match cfg.Provider.provider with
+     | Provider.Custom_registered { name } ->
+       Alcotest.(check string) "provider id" "agent_llm_a" name
+     | _ -> Alcotest.fail "expected registered provider")
+  | _ -> Alcotest.fail "expected Ok (Some cfg)"
+;;
+
+let test_resolve_provider_openai_compat_kind_is_not_provider () =
+  match Runtime_server_resolve.resolve_provider ~provider:"openai_compat" () with
+  | Error (Error.Config (Error.UnsupportedProvider _)) -> ()
+  | _ -> Alcotest.fail "expected UnsupportedProvider"
 ;;
 
 let test_resolve_provider_unknown () =
@@ -248,10 +274,9 @@ let test_resolve_provider_catalog_entry () =
        | Ok (Some cfg) ->
          Alcotest.(check string) "default model" "local-model" cfg.Provider.model_id;
          (match cfg.Provider.provider with
-          | Provider.OpenAICompat { base_url; path; _ } ->
-            Alcotest.(check string) "base_url" "http://127.0.0.1:8000" base_url;
-            Alcotest.(check string) "path" "/v1/chat/completions" path
-          | _ -> Alcotest.fail "expected OpenAICompat")
+          | Provider.Custom_registered { name } ->
+            Alcotest.(check string) "provider id" "vllm-local" name
+          | _ -> Alcotest.fail "expected registered provider")
        | _ -> Alcotest.fail "expected catalog provider")
 ;;
 
@@ -295,7 +320,7 @@ let test_resolve_execution_non_mock_has_provider_cfg () =
     Alcotest.(check bool) "has provider cfg" true (Option.is_some res.provider_cfg);
     Alcotest.(check (option string))
       "resolved provider"
-      (Some "provider_a")
+      (Some "agent_llm_a")
       res.resolved_provider
   | Error _ -> Alcotest.fail "expected Ok"
 ;;
@@ -380,7 +405,7 @@ let () =
             `Quick
             test_provider_runtime_name_provider_a
         ; Alcotest.test_case
-            "OpenAICompat provider"
+            "unmatched OpenAI-compatible adapter"
             `Quick
             test_provider_runtime_name_openai_compat
         ; Alcotest.test_case
@@ -400,15 +425,29 @@ let () =
             `Quick
             test_resolve_provider_local
         ; Alcotest.test_case
-            "sonnet returns Anthropic"
+            "sonnet returns registered Anthropic provider"
             `Quick
             test_resolve_provider_sonnet
-        ; Alcotest.test_case "haiku returns Anthropic" `Quick test_resolve_provider_haiku
-        ; Alcotest.test_case "opus returns Anthropic" `Quick test_resolve_provider_opus
         ; Alcotest.test_case
-            "provider_o_router returns OpenAICompat"
+            "haiku returns registered Anthropic provider"
+            `Quick
+            test_resolve_provider_haiku
+        ; Alcotest.test_case
+            "opus returns registered Anthropic provider"
+            `Quick
+            test_resolve_provider_opus
+        ; Alcotest.test_case
+            "provider_o_router returns registered provider"
             `Quick
             test_resolve_provider_openrouter
+        ; Alcotest.test_case
+            "provider_a alias returns registered provider"
+            `Quick
+            test_resolve_provider_alias_provider_a
+        ; Alcotest.test_case
+            "openai_compat kind is not a provider"
+            `Quick
+            test_resolve_provider_openai_compat_kind_is_not_provider
         ; Alcotest.test_case
             "unknown returns UnsupportedProvider error"
             `Quick


### PR DESCRIPTION
## Summary
- centralize runtime provider selector aliases in Provider_runtime_binding
- stop runtime/agent config from inventing provider_d/OpenAICompat defaults without an explicit base_url
- report canonical provider ids in runtime/lifecycle snapshots and clean stale registry tests

## Verification
- dune fmt --root . --auto-promote
- git diff --check
- DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_provider_runtime_redesign dune build --root . focused provider/runtime tests
- test_runtime_server_resolve, test_provider_runtime_binding, test_agent_lifecycle, test_agent_config_deep, test_custom_provider, test_provider_config, test_provider_registry