### PR TITLE
test(llm_provider): align provider runtime contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,6 @@ jobs:
       - name: Test
         env:
           ALCOTEST_QUICK_TESTS: "1"
-          # Test stanzas wired in `test/dune` may exercise `Transport.find_runtime`,
-          # which searches `_build/default/bin/oas_runtime.exe` relative to the test's
-          # cwd. Under `dune runtest` each binary runs from a sandbox dir whose cwd
-          # is NOT the repo root, so the relative search misses the freshly-built
-          # runtime. Pin an absolute path so wired runtime/transport/sdk tests can
-          # locate the binary regardless of sandbox cwd.
-          OAS_RUNTIME_PATH: ${{ github.workspace }}/_build/default/bin/oas_runtime.exe
         run: opam exec -- dune runtest
 
       - name: Coverage report
@@ -62,10 +55,6 @@ jobs:
           # io_uring_queue_init under bisect eventually returns ENOMEM and
           # fails the step.
           EIO_BACKEND: "posix"
-          # See note on the Test step: dune sandbox cwd is not the repo root,
-          # so `Transport.find_runtime` cannot resolve the runtime via the
-          # default relative search. Pin the absolute path here too.
-          OAS_RUNTIME_PATH: ${{ github.workspace }}/_build/default/bin/oas_runtime.exe
         run: |
           mkdir -p _coverage
           # Pin coverage file location outside dune's per-test sandboxes.
@@ -76,11 +65,6 @@ jobs:
           # library to write files at a stable absolute prefix instead.
           export BISECT_FILE="$PWD/_coverage/bisect"
           opam exec -- dune clean
-          # Rebuild the runtime binary up-front so test stanzas that use
-          # `Transport.find_runtime` via `OAS_RUNTIME_PATH` find it. Without
-          # this explicit build, the runtest step below only rebuilds
-          # test-reachable targets and the bin/oas_runtime.exe path is empty.
-          opam exec -- dune build bin/oas_runtime.exe
           # `--instrument-with bisect_ppx` activates the
           # `(instrumentation (backend bisect_ppx))` stanza declared in
           # lib/dune. Without this flag dune ignores the stanza and no
@@ -173,7 +157,14 @@ jobs:
           # (24098/29746) after Stage G maintained provider bridge,
           # sessions, memory, and runtime evidence coverage. Raise the
           # floor to floor(81.01 - 1) = 80 per #1175 ratchet policy.
-          THRESHOLD=80
+          #
+          # 2026-06-02: after the provider/runtime hard cut removed the
+          # stale stdio runtime binary target, PR #1833 re-registered the
+          # surviving runtime orphan suites and local bisect measured
+          # 77.55% (21220/27362). Reset the ratchet floor to
+          # floor(77.55 - 1) = 76 until the removed binary/CLI-era
+          # coverage surface is replaced by in-process runtime coverage.
+          THRESHOLD=76
           if [ "$(echo "$COVERAGE < $THRESHOLD" | bc -l)" -eq 1 ]; then
             echo "::error::Coverage ${COVERAGE}% is below threshold ${THRESHOLD}%"
             exit 1

--- a/docs/schema-surfaces/runtime-output-surfaces.v1.json
+++ b/docs/schema-surfaces/runtime-output-surfaces.v1.json
@@ -82,7 +82,7 @@
       "wire_or_artifact": "runtime-telemetry-json artifact and structured telemetry reader payload",
       "schema_source": ["lib/runtime_evidence.mli", "lib/sessions_types.mli"],
       "validator": "Runtime_evidence.telemetry_report_to_json plus Sessions structured telemetry decoders",
-      "tests": ["test/test_runtime.ml", "test/test_sessions_types.ml", "test/test_sessions_cov2.ml"],
+      "tests": ["test/test_runtime_evidence.ml", "test/test_sessions_types.ml", "test/test_sessions_cov2.ml"],
       "stability": "evolving",
       "version_field": null,
       "notes": "Carries event counts, structured per-step fields, raw trace run ids, stop reasons, and anomaly counters."
@@ -96,7 +96,7 @@
       "wire_or_artifact": "runtime-evidence JSON artifact",
       "schema_source": ["lib/runtime_evidence.mli", "lib/sessions_types.mli"],
       "validator": "Runtime_evidence.evidence_bundle_to_json plus Sessions evidence decoder",
-      "tests": ["test/test_runtime.ml", "test/test_sessions_types.ml"],
+      "tests": ["test/test_runtime_evidence.ml", "test/test_sessions_types.ml"],
       "stability": "evolving",
       "version_field": null,
       "notes": "Records present/missing session, events, report, proof, telemetry, and raw trace manifest artifact files."
@@ -124,7 +124,7 @@
       "wire_or_artifact": "runtime-raw-trace-json artifact",
       "schema_source": ["lib/runtime_evidence.mli", "lib/sessions_types.mli"],
       "validator": "Sessions.raw_trace_manifest_of_yojson plus raw trace run validation",
-      "tests": ["test/test_runtime.ml", "test/test_sessions_types.ml", "test/test_raw_trace.ml"],
+      "tests": ["test/test_runtime_evidence.ml", "test/test_sessions_types.ml", "test/test_raw_trace.ml"],
       "stability": "evolving",
       "version_field": null,
       "notes": "Indexes latest run, run refs, summaries, and validations for a runtime session."
@@ -137,8 +137,8 @@
       "consumer": ["CI jobs", "human harness reviewers", "baseline tooling"],
       "wire_or_artifact": "report.json, report.md, and report.junit.xml",
       "schema_source": ["lib/harness_report.mli"],
-      "validator": "Harness_report.to_json/to_markdown/to_junit_xml plus CLI artifact tests",
-      "tests": ["test/test_harness_runner.ml", "test/test_cli.ml"],
+      "validator": "Harness_report.to_json/to_markdown/to_junit_xml plus harness artifact tests",
+      "tests": ["test/test_harness_runner.ml"],
       "stability": "evolving",
       "version_field": null,
       "notes": "Harness reports include case evidence, raw trace path references, and optional evaluation metrics."
@@ -151,8 +151,8 @@
       "consumer": ["CI jobs", "baseline comparison reviewers"],
       "wire_or_artifact": "eval report JSON and report.md evaluation appendix",
       "schema_source": ["lib/eval_report.mli"],
-      "validator": "Eval_report.to_json/to_string plus CLI baseline comparison tests",
-      "tests": ["test/test_eval_report.ml", "test/test_cli.ml"],
+      "validator": "Eval_report.to_json/to_string plus baseline comparison tests",
+      "tests": ["test/test_eval_report.ml"],
       "stability": "evolving",
       "version_field": null,
       "notes": "Evaluation reports carry pass@k, baseline comparison, skipped run counts, and text summary."

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1165,8 +1165,11 @@ let%test "for_model_id_static qwen-3-7b prefix variant resolves" =
   | None -> false
 ;;
 
-let%test "for_model_id provider_k-5-turbo has GLM-5 thinking limits" =
-  match for_model_id "provider_k-5-turbo" with
+(* GLM family tests use the static lookup for the same reason as the qwen3
+   tests above: they assert the built-in prefix table, not ambient runtime
+   manifest overrides. *)
+let%test "for_model_id_static provider_k-5-turbo has GLM-5 thinking limits" =
+  match for_model_id_static "provider_k-5-turbo" with
   | Some c ->
     c.supports_reasoning
     && c.supports_extended_thinking
@@ -1175,8 +1178,8 @@ let%test "for_model_id provider_k-5-turbo has GLM-5 thinking limits" =
   | None -> false
 ;;
 
-let%test "for_model_id provider_k-5.1 full model (reasoning + extended thinking)" =
-  match for_model_id "provider_k-5.1" with
+let%test "for_model_id_static provider_k-5.1 full model (reasoning + extended thinking)" =
+  match for_model_id_static "provider_k-5.1" with
   | Some c ->
     c.supports_reasoning
     && c.supports_extended_thinking
@@ -1184,8 +1187,8 @@ let%test "for_model_id provider_k-5.1 full model (reasoning + extended thinking)
   | None -> false
 ;;
 
-let%test "for_model_id bare glm-5 full model (reasoning + extended thinking)" =
-  match for_model_id "glm-5" with
+let%test "for_model_id_static bare glm-5 full model (reasoning + extended thinking)" =
+  match for_model_id_static "glm-5" with
   | Some c ->
     c.supports_reasoning
     && c.supports_extended_thinking
@@ -1193,8 +1196,8 @@ let%test "for_model_id bare glm-5 full model (reasoning + extended thinking)" =
   | None -> false
 ;;
 
-let%test "for_model_id bare glm-5.1 full model (reasoning + extended thinking)" =
-  match for_model_id "glm-5.1" with
+let%test "for_model_id_static bare glm-5.1 full model (reasoning + extended thinking)" =
+  match for_model_id_static "glm-5.1" with
   | Some c ->
     c.supports_reasoning
     && c.supports_extended_thinking
@@ -1202,8 +1205,8 @@ let%test "for_model_id bare glm-5.1 full model (reasoning + extended thinking)" 
   | None -> false
 ;;
 
-let%test "for_model_id bare glm-5-turbo has GLM-5 thinking limits" =
-  match for_model_id "glm-5-turbo" with
+let%test "for_model_id_static bare glm-5-turbo has GLM-5 thinking limits" =
+  match for_model_id_static "glm-5-turbo" with
   | Some c ->
     c.supports_reasoning
     && c.supports_extended_thinking
@@ -1322,12 +1325,13 @@ let%test "capabilities_for_provider_label: provider_l" =
 (* ── Prefix ordering invariant ──────────────────── *)
 
 (* Each case is a model_id and the expected capability fingerprint.
-   If [for_model_id] reorders its prefix checks incorrectly, these
+   If [for_model_id_static] reorders its prefix checks incorrectly, these
    specific models would be matched by a more general prefix and
    return wrong capabilities. The test catches that. *)
-let%test "for_model_id: specific model IDs get correct (not shadowed) capabilities" =
+let%test "for_model_id_static: specific model IDs get correct (not shadowed) capabilities"
+  =
   let check model_id expected =
-    match for_model_id model_id with
+    match for_model_id_static model_id with
     | Some c -> expected c
     | None -> false
   in

--- a/lib/runtime_server.mli
+++ b/lib/runtime_server.mli
@@ -1,8 +1,7 @@
 (** Runtime protocol server: reads NDJSON from stdin, dispatches requests.
 
-    Entry point for the oas_runtime binary. Integrates with
-    {!Runtime_server_types} and {!Runtime_server_resolve}
-    for request handling.
+    Library entry point for stdio runtime serving. Integrates with
+    {!Runtime_server_types} and {!Runtime_server_resolve} for request handling.
 
     @stability Internal
     @since 0.93.1 *)

--- a/test/dune
+++ b/test/dune
@@ -12,9 +12,6 @@
 ; The following suites compile but have pre-existing test failures.
 ; They are excluded until the failures are fixed in separate PRs:
 ;
-; Dune runs tests in sandboxes, so runtime-spawning tests cannot rely on
-; cwd-relative _build/default/bin/oas_runtime.exe discovery.
-; Point all wired suites at the locally built public runtime binary.
 
 (tests
  (names
@@ -540,3 +537,28 @@
  (name test_runtime_server_resolve)
  (modules test_runtime_server_resolve)
  (libraries agent_sdk alcotest unix))
+
+(tests
+ (names
+  test_runtime_evidence
+  test_runtime_health
+  test_runtime_projection_cov2
+  test_runtime_replay
+  test_runtime_server_coverage
+  test_runtime_server_types
+  test_runtime_store_unit
+  test_runtime_sync
+  test_runtime_types)
+ (modules
+  test_runtime_evidence
+  test_runtime_health
+  test_runtime_projection_cov2
+  test_runtime_replay
+  test_runtime_server_coverage
+  test_runtime_server_types
+  test_runtime_store_unit
+  test_runtime_sync
+  test_runtime_types)
+ (libraries agent_sdk alcotest eio eio_main unix yojson)
+ (action
+  (run %{test})))

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -589,7 +589,7 @@ let test_complete_transport_http_metrics_ok () =
     match Complete.complete ~sw ~net:env#net ~transport ~config ~messages ~metrics () with
     | Ok _ ->
       (match !status_calls with
-       | [ ("provider_d", "model-d-4", 200) ] -> Eio.Switch.fail sw Exit
+       | [ ("openai_compat", "model-d-4", 200) ] -> Eio.Switch.fail sw Exit
        | [ (_, _, code) ] -> fail (Printf.sprintf "expected 200, got %d" code)
        | _ -> fail "expected exactly one transport status call")
     | Error _ -> fail "expected Ok"
@@ -620,7 +620,7 @@ let test_complete_transport_http_metrics_error () =
     | Error (Http_client.HttpError { code; _ }) ->
       check int "status 429" 429 code;
       (match !status_calls with
-       | [ ("provider_d", "model-d-4", 429) ] -> Eio.Switch.fail sw Exit
+       | [ ("openai_compat", "model-d-4", 429) ] -> Eio.Switch.fail sw Exit
        | [ (_, _, seen) ] -> fail (Printf.sprintf "expected 429, got %d" seen)
        | _ -> fail "expected exactly one transport status call")
     | Error _ -> fail "expected HttpError"
@@ -628,7 +628,7 @@ let test_complete_transport_http_metrics_error () =
   | Exit -> ()
 ;;
 
-let test_complete_transport_cli_does_not_emit_status () =
+let test_complete_transport_mock_emits_status () =
   Eio_main.run
   @@ fun env ->
   try
@@ -650,7 +650,7 @@ let test_complete_transport_cli_does_not_emit_status () =
     let transport = make_transport (Ok (mock_transport_response "cli ok")) in
     match Complete.complete ~sw ~net:env#net ~transport ~config ~messages ~metrics () with
     | Ok _ ->
-      check int "cli transport emits no status" 0 !hits;
+      check int "mock transport emits status" 1 !hits;
       Eio.Switch.fail sw Exit
     | Error _ -> fail "expected Ok"
   with
@@ -829,14 +829,14 @@ let test_complete_stream_metrics () =
       check int "first chunk count" 1 (List.length !first_chunks);
       (match !first_chunks with
        | [ (provider, model_id, ttfrc_ms) ] ->
-         check string "provider" "provider_a" provider;
+         check string "provider" "anthropic" provider;
          check string "model_id" "test-model" model_id;
          check bool "ttfrc non-negative" true (ttfrc_ms >= 0.0)
        | _ -> fail "expected one first chunk");
       check bool "inter chunk metrics" true (List.length !inter_chunks > 0);
       List.iter
         (fun (provider, model_id, chunk_index, inter_chunk_ms) ->
-           check string "inter provider" "provider_a" provider;
+           check string "inter provider" "anthropic" provider;
            check string "inter model_id" "test-model" model_id;
            check bool "chunk_index non-negative" true (chunk_index >= 0);
            check bool "inter chunk non-negative" true (inter_chunk_ms >= 0.0))
@@ -970,9 +970,9 @@ let () =
             `Quick
             test_complete_transport_http_metrics_error
         ; test_case
-            "transport cli stays silent"
+            "transport mock emits status"
             `Quick
-            test_complete_transport_cli_does_not_emit_status
+            test_complete_transport_mock_emits_status
         ; test_case "global default is noop" `Quick test_metrics_global_default_is_noop
         ; test_case "global set and get" `Quick test_metrics_global_set_and_get
         ; test_case

--- a/test/test_pipeline_metrics.ml
+++ b/test/test_pipeline_metrics.ml
@@ -12,7 +12,7 @@
     - Install a [Metrics.t] sink that increments a separate counter on
       each [on_request_end].
     - Run one agent turn with [transport = Some mock_transport] and
-      a CLI provider config.
+      a registered HTTP-compatible provider config.
     - Assert transport was invoked once and metrics.on_request_end fired
       exactly once with matching [latency_ms >= 0]. *)
 
@@ -122,8 +122,8 @@ let test_stage_route_passes_trace_context_headers () =
   let transport = mk_header_capture_transport observed_headers in
   let provider =
     Some
-      { Provider.provider = Provider.Custom_registered { name = "cli_tool_d" }
-      ; model_id = "auto"
+      { Provider.provider = Provider.Custom_registered { name = "provider_n" }
+      ; model_id = "model-d-4"
       ; api_key_env = ""
       }
   in
@@ -175,8 +175,8 @@ let test_sdk_error_preserves_streaming_timeout_phase () =
   in
   let provider =
     Some
-      { Provider.provider = Provider.Custom_registered { name = "cli_tool_d" }
-      ; model_id = "auto"
+      { Provider.provider = Provider.Custom_registered { name = "provider_n" }
+      ; model_id = "model-d-4"
       ; api_key_env = ""
       }
   in

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -16,6 +16,17 @@ let with_env name value f =
     f
 ;;
 
+let check_no_header label name headers =
+  Alcotest.(check (option string)) label None (List.assoc_opt name headers)
+;;
+
+let check_auth_headers label expected (pc : Llm_provider.Provider_config.t) =
+  Alcotest.(check (list (pair string string)))
+    label
+    expected
+    (Provider.auth_headers_only_for_kind ~kind:pc.kind ~api_key:pc.api_key)
+;;
+
 let test_missing_env_var () =
   (* Anthropic provider checks env var; nonexistent key -> Error *)
   let cfg : Provider.config =
@@ -101,8 +112,13 @@ let test_openai_compat_resolve_success () =
   | Ok (base_url, api_key, headers) ->
     Alcotest.(check string) "base_url" "https://openrouter.ai/api/v1" base_url;
     Alcotest.(check string) "api_key" "or-test-key" api_key;
-    let auth = List.assoc "Authorization" headers in
-    Alcotest.(check string) "bearer token" "Bearer or-test-key" auth
+    check_no_header "auth omitted from resolve headers" "Authorization" headers;
+    Alcotest.(check (list (pair string string)))
+      "auth header derived"
+      [ "Authorization", "Bearer or-test-key" ]
+      (Provider.auth_headers_only_for_kind
+         ~kind:Llm_provider.Provider_config.OpenAI_compat
+         ~api_key)
   | Error e -> Alcotest.fail (Printf.sprintf "should succeed: %s" (Error.to_string e))
 ;;
 
@@ -120,14 +136,15 @@ let test_openai_compat_resolve_missing_key () =
     }
   in
   match Provider.resolve cfg with
-  | Error (Error.Config (MissingEnvVar { var_name })) ->
-    Alcotest.(check string)
-      "error mentions env var"
-      "AGENT_SDK_TEST_NONEXISTENT_COMPAT_KEY_z0z0"
-      var_name
+  | Ok (_base_url, api_key, headers) ->
+    Alcotest.(check string) "empty key" "" api_key;
+    Alcotest.(check (list (pair string string)))
+      "non-auth headers"
+      [ "Content-Type", "application/json" ]
+      headers
   | Error e ->
-    Alcotest.fail (Printf.sprintf "unexpected error variant: %s" (Error.to_string e))
-  | Ok _ -> Alcotest.fail "should fail when env var missing"
+    Alcotest.fail
+      (Printf.sprintf "missing OpenAI-compatible key is allowed: %s" (Error.to_string e))
 ;;
 
 let test_provider_a_headers () =
@@ -137,9 +154,14 @@ let test_provider_a_headers () =
     { provider = Anthropic; model_id = "test"; api_key_env = env_var }
   in
   match Provider.resolve cfg with
-  | Ok (_, _, headers) ->
-    let xkey = List.assoc "x-api-key" headers in
-    Alcotest.(check string) "x-api-key header" "sk-ant-hdr-test" xkey;
+  | Ok (_, api_key, headers) ->
+    check_no_header "x-api-key omitted from resolve headers" "x-api-key" headers;
+    Alcotest.(check (list (pair string string)))
+      "auth header derived"
+      [ "x-api-key", "sk-ant-hdr-test" ]
+      (Provider.auth_headers_only_for_kind
+         ~kind:Llm_provider.Provider_config.Anthropic
+         ~api_key);
     let version = List.assoc "provider_a-version" headers in
     Alcotest.(check string) "provider_a-version" "2023-06-01" version;
     let ct = List.assoc "Content-Type" headers in
@@ -523,8 +545,13 @@ let test_openai_compat_static_token () =
   match Provider.resolve cfg with
   | Ok (_, key, headers) ->
     Alcotest.(check string) "static key" "static-key-123" key;
-    let auth = List.assoc "Authorization" headers in
-    Alcotest.(check string) "bearer" "Bearer static-key-123" auth
+    check_no_header "auth omitted from resolve headers" "Authorization" headers;
+    Alcotest.(check (list (pair string string)))
+      "auth header derived"
+      [ "Authorization", "Bearer static-key-123" ]
+      (Provider.auth_headers_only_for_kind
+         ~kind:Llm_provider.Provider_config.OpenAI_compat
+         ~api_key:key)
   | Error e -> Alcotest.fail (Error.to_string e)
 ;;
 
@@ -590,10 +617,11 @@ let test_provider_config_of_agent_provider_a () =
     Alcotest.(check string) "model_id" "agent_llm_a-sonnet-4-20250514" pc.model_id;
     Alcotest.(check string) "api_key" "sk-ant-adapter-test" pc.api_key;
     Alcotest.(check string) "request_path" "/v1/messages" pc.request_path;
-    Alcotest.(check bool)
-      "x-api-key header present"
-      true
-      (List.mem ("x-api-key", "sk-ant-adapter-test") pc.headers);
+    check_no_header "x-api-key omitted from config headers" "x-api-key" pc.headers;
+    check_auth_headers
+      "x-api-key auth header derived"
+      [ "x-api-key", "sk-ant-adapter-test" ]
+      pc;
     Alcotest.(check bool)
       "provider_a-version header present"
       true
@@ -640,10 +668,11 @@ let test_provider_config_of_agent_openai_compat_collapses () =
       "https://generativelanguage.googleapis.com/v1beta/provider_d"
       pc.base_url;
     Alcotest.(check string) "request_path preserved" "/chat/completions" pc.request_path;
-    Alcotest.(check bool)
-      "authorization header preserved"
-      true
-      (List.mem ("Authorization", "Bearer sk-oai-adapter-test") pc.headers);
+    check_no_header "authorization omitted from config headers" "Authorization" pc.headers;
+    check_auth_headers
+      "authorization auth header derived"
+      [ "Authorization", "Bearer sk-oai-adapter-test" ]
+      pc;
     Alcotest.(check string) "model_id" "provider_f-2.5-flash" pc.model_id
   | Error e -> Alcotest.fail (Error.to_string e)
 ;;
@@ -689,10 +718,11 @@ let test_provider_config_of_agent_none_fallback () =
       "https://api.provider_a.com"
       pc.base_url;
     Alcotest.(check string) "request_path" "/v1/messages" pc.request_path;
-    Alcotest.(check bool)
-      "x-api-key header present"
-      true
-      (List.mem ("x-api-key", "sk-ant-default-fallback") pc.headers)
+    check_no_header "x-api-key omitted from config headers" "x-api-key" pc.headers;
+    check_auth_headers
+      "x-api-key auth header derived"
+      [ "x-api-key", "sk-ant-default-fallback" ]
+      pc
   | Error e -> Alcotest.fail (Error.to_string e)
 ;;
 
@@ -766,10 +796,11 @@ let test_provider_config_of_agent_custom_registered_provider_c_preserves_headers
       true
       (pc.kind = Llm_provider.Provider_config.Kimi);
     Alcotest.(check string) "request_path" "/v1/messages" pc.request_path;
-    Alcotest.(check bool)
-      "x-api-key header present"
-      true
-      (List.mem ("x-api-key", "provider_c-provider-test-key") pc.headers);
+    check_no_header "x-api-key omitted from config headers" "x-api-key" pc.headers;
+    check_auth_headers
+      "x-api-key auth header derived"
+      [ "x-api-key", "provider_c-provider-test-key" ]
+      pc;
     Alcotest.(check bool)
       "provider_a-version header present"
       true
@@ -801,10 +832,14 @@ let test_provider_config_of_agent_custom_registered_ollama_cloud_headers () =
           "uses cloud-specific key first"
           "ollama-cloud-provider-test-key"
           pc.api_key;
-        Alcotest.(check bool)
-          "Authorization header present"
-          true
-          (List.mem ("Authorization", "Bearer ollama-cloud-provider-test-key") pc.headers)
+        check_no_header
+          "authorization omitted from config headers"
+          "Authorization"
+          pc.headers;
+        check_auth_headers
+          "authorization auth header derived"
+          [ "Authorization", "Bearer ollama-cloud-provider-test-key" ]
+          pc
       | Error e ->
         Alcotest.fail (Printf.sprintf "unexpected error: %s" (Error.to_string e))))
 ;;
@@ -827,10 +862,14 @@ let test_provider_config_of_agent_custom_registered_ollama_cloud_api_key_fallbac
           "uses OLLAMA_API_KEY fallback"
           "ollama-api-fallback-key"
           pc.api_key;
-        Alcotest.(check bool)
-          "Authorization header present"
-          true
-          (List.mem ("Authorization", "Bearer ollama-api-fallback-key") pc.headers)
+        check_no_header
+          "authorization omitted from config headers"
+          "Authorization"
+          pc.headers;
+        check_auth_headers
+          "authorization auth header derived"
+          [ "Authorization", "Bearer ollama-api-fallback-key" ]
+          pc
       | Error e ->
         Alcotest.fail (Printf.sprintf "unexpected error: %s" (Error.to_string e))))
 ;;

--- a/test/test_provider_bridge.ml
+++ b/test/test_provider_bridge.ml
@@ -142,8 +142,8 @@ let test_provider_c_custom_registered_becomes_provider_c_provider_config () =
            (Agent_sdk.Error.to_string e))
     | Ok cfg ->
       Alcotest.(check string)
-        "kind becomes provider_c"
-        "provider_c"
+        "kind becomes kimi"
+        "kimi"
         (Llm_provider.Provider_config.string_of_provider_kind cfg.kind);
       Alcotest.(check string) "auto model" "provider_c-for-coding" cfg.model_id;
       Alcotest.(check string) "path" "/v1/messages" cfg.request_path)
@@ -159,12 +159,12 @@ let test_provider_a_auto_and_explicit_models () =
       let explicit = { auto with model_id = "agent_llm_a-explicit" } in
       (match Agent_sdk.Provider_bridge.to_provider_config auto with
        | Ok cfg ->
-         check_kind "provider_a kind" "provider_a" cfg;
+         check_kind "anthropic kind" "anthropic" cfg;
          Alcotest.(check string) "auto model" "agent_llm_a-test-default" cfg.model_id
        | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err));
       match Agent_sdk.Provider_bridge.to_provider_config explicit with
       | Ok cfg ->
-        check_kind "provider_a explicit kind" "provider_a" cfg;
+        check_kind "anthropic explicit kind" "anthropic" cfg;
         Alcotest.(check string) "explicit model" "agent_llm_a-explicit" cfg.model_id
       | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)))
 ;;
@@ -195,12 +195,12 @@ let test_openai_compat_auto_model_branches () =
        | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err));
       (match Agent_sdk.Provider_bridge.to_provider_config provider_f_prefixed with
        | Ok cfg ->
-         check_kind "provider_f kind" "provider_f" cfg;
+         check_kind "gemini kind" "gemini" cfg;
          Alcotest.(check string) "provider_f prefixed" "provider_f-auto" cfg.model_id
        | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err));
       match Agent_sdk.Provider_bridge.to_provider_config provider_f_explicit with
       | Ok cfg ->
-        check_kind "provider_f explicit kind" "provider_f" cfg;
+        check_kind "gemini explicit kind" "gemini" cfg;
         Alcotest.(check string) "provider_f explicit" "provider_f-2.5-pro" cfg.model_id
       | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)))
 ;;
@@ -217,7 +217,7 @@ let test_provider_c_explicit_model_and_non_coding_base_url () =
       in
       match Agent_sdk.Provider_bridge.to_provider_config non_coding with
       | Ok cfg ->
-        check_kind "non-coding base routes as provider_a" "provider_a" cfg;
+        check_kind "non-coding base routes as anthropic" "anthropic" cfg;
         Alcotest.(check string) "explicit provider_c model" "provider_c-k2" cfg.model_id
       | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)))
 ;;

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -506,7 +506,6 @@ let test_provider_c_direct_tool_result_uses_text_blocks () =
   let open Yojson.Safe.Util in
   let replay = json |> member "messages" |> index 1 in
   let block = replay |> member "content" |> index 0 in
-  let content_blocks = block |> member "content" |> to_list in
   Alcotest.(check string)
     "tool result role serialized as user"
     "user"
@@ -519,15 +518,10 @@ let test_provider_c_direct_tool_result_uses_text_blocks () =
     "tool_use id preserved"
     "tool_1"
     (block |> member "tool_use_id" |> to_string);
-  Alcotest.(check int) "tool_result content block count" 1 (List.length content_blocks);
   Alcotest.(check string)
-    "nested text block type"
-    "text"
-    (List.hd content_blocks |> member "type" |> to_string);
-  Alcotest.(check string)
-    "nested text block content"
+    "tool_result content"
     "5"
-    (List.hd content_blocks |> member "text" |> to_string)
+    (block |> member "content" |> to_string)
 ;;
 
 let test_glm_preserved_reasoning_replay_and_drops_unsupported_tool_choice () =
@@ -606,7 +600,7 @@ let test_config_default_paths () =
   let anth = PC.make ~kind:Anthropic ~model_id:"m" ~base_url:"" () in
   Alcotest.(check string) "provider_a path" "/v1/messages" anth.request_path;
   let provider_c = PC.make ~kind:Kimi ~model_id:"m" ~base_url:"" () in
-  Alcotest.(check string) "provider_c path" "/v1/messages" provider_c.request_path;
+  Alcotest.(check string) "provider_c path" "/v1/chat/completions" provider_c.request_path;
   let oai = PC.make ~kind:OpenAI_compat ~model_id:"m" ~base_url:"" () in
   Alcotest.(check string) "provider_d path" "/v1/chat/completions" oai.request_path
 ;;
@@ -1050,7 +1044,7 @@ let () =
             `Quick
             test_provider_c_direct_with_tools_and_thinking
         ; test_case
-            "provider_c direct tool_result uses text blocks"
+            "provider_c direct tool_result uses scalar text"
             `Quick
             test_provider_c_direct_tool_result_uses_text_blocks
         ; test_case "stream flag" `Quick test_provider_d_stream_flag


### PR DESCRIPTION
## Summary
- align provider/runtime tests with canonical provider kind labels and separated auth-header derivation
- make GLM capability prefix inline tests use the static lookup so local runtime manifests do not change the invariant
- refresh schema surface catalog test paths after removed runtime/CLI test files
- remove stale CI/runtime-binary references now that OAS is in-process library only

## Verification
- scripts/dune-local.sh build @fmt
- scripts/dune-local.sh build @all --display=short
- scripts/dune-local.sh build @runtest --display=short (passed after schema catalog fix; later long rerun was interrupted by tool session code -1, not a Dune failure)
- scripts/dune-local.sh build @runtest-test_capabilities @runtest-test_schema_surface_index @runtest-test_provider @runtest-test_provider_bridge @runtest-test_provider_complete @runtest-test_complete_http @runtest-test_pipeline_metrics --display=short
- jq empty docs/schema-surfaces/runtime-output-surfaces.v1.json
- git diff --check