### PR TITLE
fix(llm_provider): repair post-1833 review feedback

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -990,23 +990,6 @@ let complete
            in
            { Llm_transport.response = resp; latency_ms = Some lat }
        in
-       (* HTTP-backed transports bypass complete_http, so emit the status
-         here using the transport result. Non-HTTP CLI transports must
-         stay silent because they never observed an HTTP status code. *)
-       if Option.is_some transport && not (requires_non_http_transport config.kind)
-       then (
-         match result with
-         | Ok _ ->
-           m.on_http_status
-             ~provider:(Provider_registry.provider_name_of_config config)
-             ~model_id
-             ~status:200
-         | Error (Http_client.HttpError { code; _ }) ->
-           m.on_http_status
-             ~provider:(Provider_registry.provider_name_of_config config)
-             ~model_id
-             ~status:code
-         | Error _ -> ());
        (match result with
         | Ok resp ->
           let resp = Pricing.annotate_response_cost resp in

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -20,7 +20,7 @@ type provider_kind = Provider_kind.t =
     it does not dispatch over an HTTP path. *)
 let request_path_default_for_kind = function
   | Anthropic -> "/v1/messages"
-  | Kimi -> "/v1/chat/completions"
+  | Kimi -> "/v1/messages"
   | OpenAI_compat -> "/v1/chat/completions"
   | Ollama -> "/api/chat"
   | Gemini -> ""

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -570,7 +570,7 @@ let test_complete_error_metrics () =
   | Exit -> ()
 ;;
 
-let test_complete_transport_http_metrics_ok () =
+let test_complete_transport_ok_does_not_emit_http_status () =
   Eio_main.run
   @@ fun env ->
   try
@@ -588,16 +588,14 @@ let test_complete_transport_http_metrics_ok () =
     let transport = make_transport (Ok (mock_transport_response "transport ok")) in
     match Complete.complete ~sw ~net:env#net ~transport ~config ~messages ~metrics () with
     | Ok _ ->
-      (match !status_calls with
-       | [ ("openai_compat", "model-d-4", 200) ] -> Eio.Switch.fail sw Exit
-       | [ (_, _, code) ] -> fail (Printf.sprintf "expected 200, got %d" code)
-       | _ -> fail "expected exactly one transport status call")
+      check int "custom transport does not emit http status" 0 (List.length !status_calls);
+      Eio.Switch.fail sw Exit
     | Error _ -> fail "expected Ok"
   with
   | Exit -> ()
 ;;
 
-let test_complete_transport_http_metrics_error () =
+let test_complete_transport_error_does_not_emit_http_status () =
   Eio_main.run
   @@ fun env ->
   try
@@ -619,16 +617,14 @@ let test_complete_transport_http_metrics_error () =
     | Ok _ -> fail "expected Error"
     | Error (Http_client.HttpError { code; _ }) ->
       check int "status 429" 429 code;
-      (match !status_calls with
-       | [ ("openai_compat", "model-d-4", 429) ] -> Eio.Switch.fail sw Exit
-       | [ (_, _, seen) ] -> fail (Printf.sprintf "expected 429, got %d" seen)
-       | _ -> fail "expected exactly one transport status call")
+      check int "custom transport does not emit http status" 0 (List.length !status_calls);
+      Eio.Switch.fail sw Exit
     | Error _ -> fail "expected HttpError"
   with
   | Exit -> ()
 ;;
 
-let test_complete_transport_mock_emits_status () =
+let test_complete_transport_mock_does_not_emit_http_status () =
   Eio_main.run
   @@ fun env ->
   try
@@ -650,7 +646,7 @@ let test_complete_transport_mock_emits_status () =
     let transport = make_transport (Ok (mock_transport_response "cli ok")) in
     match Complete.complete ~sw ~net:env#net ~transport ~config ~messages ~metrics () with
     | Ok _ ->
-      check int "mock transport emits status" 1 !hits;
+      check int "mock transport does not emit http status" 0 !hits;
       Eio.Switch.fail sw Exit
     | Error _ -> fail "expected Ok"
   with
@@ -964,15 +960,18 @@ let () =
       , [ test_case "callbacks" `Quick test_complete_metrics
         ; test_case "tool call callback" `Quick test_complete_tool_call_metrics
         ; test_case "error callback" `Quick test_complete_error_metrics
-        ; test_case "transport http ok" `Quick test_complete_transport_http_metrics_ok
         ; test_case
-            "transport http error"
+            "transport ok does not emit http status"
             `Quick
-            test_complete_transport_http_metrics_error
+            test_complete_transport_ok_does_not_emit_http_status
         ; test_case
-            "transport mock emits status"
+            "transport error does not emit http status"
             `Quick
-            test_complete_transport_mock_emits_status
+            test_complete_transport_error_does_not_emit_http_status
+        ; test_case
+            "transport mock does not emit http status"
+            `Quick
+            test_complete_transport_mock_does_not_emit_http_status
         ; test_case "global default is noop" `Quick test_metrics_global_default_is_noop
         ; test_case "global set and get" `Quick test_metrics_global_set_and_get
         ; test_case

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -600,7 +600,7 @@ let test_config_default_paths () =
   let anth = PC.make ~kind:Anthropic ~model_id:"m" ~base_url:"" () in
   Alcotest.(check string) "provider_a path" "/v1/messages" anth.request_path;
   let provider_c = PC.make ~kind:Kimi ~model_id:"m" ~base_url:"" () in
-  Alcotest.(check string) "provider_c path" "/v1/chat/completions" provider_c.request_path;
+  Alcotest.(check string) "provider_c path" "/v1/messages" provider_c.request_path;
   let oai = PC.make ~kind:OpenAI_compat ~model_id:"m" ~base_url:"" () in
   Alcotest.(check string) "provider_d path" "/v1/chat/completions" oai.request_path
 ;;


### PR DESCRIPTION
## Summary
- restore the direct Kimi/provider_c default request path to /v1/messages so Provider_config.make matches the public contract and registry default
- stop fabricating on_http_status metrics for injected Llm_transport completions, since the transport interface does not prove a real HTTP response status
- update provider/transport tests to pin both contracts

## Validation
- git diff --check origin/main..HEAD
- ocamlformat --check lib/llm_provider/provider_config.ml test/test_provider_complete.ml lib/llm_provider/complete.ml test/test_complete_http.ml
- local Dune intentionally not run; user requested Dune processes stay closed

## Context
- Follow-up for unresolved review feedback left on merged PR #1833.