### PR TITLE
feat(provider): per-function strict mode on tool_schema (WP2)

### DIFF
--- a/lib/base/guardrails.ml
+++ b/lib/base/guardrails.ml
@@ -88,7 +88,7 @@ let intersect_filters a b =
 [@@@coverage off]
 (* === Inline tests === *)
 
-let _ts name : tool_schema = { name; description = ""; parameters = [] }
+let _ts name : tool_schema = { name; description = ""; parameters = []; strict = None }
 
 let%test "intersect AllowAll with AllowList yields AllowList" =
   match intersect_filters AllowAll (AllowList [ "a"; "b" ]) with

--- a/lib/base/tool.ml
+++ b/lib/base/tool.ml
@@ -101,14 +101,14 @@ let validate_descriptor_opt = function
 (** Create a tool with a simple handler *)
 let create ?descriptor ~name ~description ~parameters handler =
   validate_descriptor_opt descriptor;
-  let schema = { name; description; parameters } in
+  let schema = { name; description; parameters; strict = None } in
   { schema; descriptor; handler = Simple handler }
 ;;
 
 (** Create a tool with a context-aware handler *)
 let create_with_context ?descriptor ~name ~description ~parameters handler =
   validate_descriptor_opt descriptor;
-  let schema = { name; description; parameters } in
+  let schema = { name; description; parameters; strict = None } in
   { schema; descriptor; handler = WithContext handler }
 ;;
 

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -668,6 +668,33 @@ let%test "build_provider_d_tool_json with parameters field" =
   = "object"
 ;;
 
+let%test "build_provider_d_tool_json forwards strict into the function object" =
+  let tool_json =
+    `Assoc
+      [ "name", `String "my_fn"
+      ; "description", `String "does stuff"
+      ; "parameters", `Assoc [ "type", `String "object" ]
+      ; "strict", `Bool true
+      ]
+  in
+  let result = build_provider_d_tool_json tool_json in
+  let open Yojson.Safe.Util in
+  (result |> member "function" |> member "strict") = `Bool true
+;;
+
+let%test "build_provider_d_tool_json omits strict when the tool did not set it" =
+  let tool_json =
+    `Assoc
+      [ "name", `String "my_fn"
+      ; "description", `String "does stuff"
+      ; "parameters", `Assoc [ "type", `String "object" ]
+      ]
+  in
+  let result = build_provider_d_tool_json tool_json in
+  let open Yojson.Safe.Util in
+  (result |> member "function" |> member "strict") = `Null
+;;
+
 let%test "build_provider_d_tool_json converts legacy parameter list to json schema" =
   let tool_json =
     `Assoc

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -467,14 +467,24 @@ let build_provider_d_tool_json = function
          | Some schema -> schema
          | None -> `Assoc [])
     in
+    (* Per-function strict mode (OpenAI / DeepSeek Beta / Kimi / MiMo): forward
+       it into the function object only when the tool carried [strict], so a
+       tool without it keeps the provider default. *)
+    let strict_field =
+      match List.assoc_opt "strict" fields with
+      | Some (`Bool b) -> [ "strict", `Bool b ]
+      | Some (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Null)
+      | None -> []
+    in
     `Assoc
       [ "type", `String "function"
       ; ( "function"
         , `Assoc
-            [ "name", `String name
-            ; "description", `String description
-            ; "parameters", parameters
-            ] )
+            ([ "name", `String name
+             ; "description", `String description
+             ; "parameters", parameters
+             ]
+             @ strict_field) )
       ]
   | other -> other
 ;;

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -140,15 +140,25 @@ type tool_schema =
   { name : string
   ; description : string
   ; parameters : tool_param list
+  ; strict : bool option
+    (** Per-function JSON Schema strict validation. [Some true] opts the tool
+        into strict mode (OpenAI, DeepSeek Beta, Kimi, MiMo); [None] omits the
+        field so providers apply their default. *)
   }
 [@@deriving yojson, show]
 
 let tool_schema_to_json (s : tool_schema) : Yojson.Safe.t =
   `Assoc
-    [ "name", `String s.name
-    ; "description", `String s.description
-    ; "parameters", `List (List.map tool_param_to_json s.parameters)
-    ]
+    ([ "name", `String s.name
+     ; "description", `String s.description
+     ; "parameters", `List (List.map tool_param_to_json s.parameters)
+     ]
+     (* Emit "strict" only when set so [None] round-trips to an absent field
+        and providers keep their own default. *)
+     @
+     match s.strict with
+     | Some b -> [ "strict", `Bool b ]
+     | None -> [])
 ;;
 
 let result_all items =
@@ -171,6 +181,7 @@ let tool_schema_of_json (json : Yojson.Safe.t) : (tool_schema, string) result =
       { name = json |> member "name" |> to_string
       ; description = json |> member "description" |> to_string
       ; parameters
+      ; strict = json |> member "strict" |> to_bool_option
       }
 ;;
 

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -70,6 +70,10 @@ type tool_schema =
   { name : string
   ; description : string
   ; parameters : tool_param list
+  ; strict : bool option
+    (** Per-function JSON Schema strict validation. [Some true] opts the tool
+        into strict mode (OpenAI, DeepSeek Beta, Kimi, MiMo); [None] omits the
+        field so providers apply their default. *)
   }
 [@@deriving yojson, show]
 

--- a/lib/tool_index.ml
+++ b/lib/tool_index.ml
@@ -574,7 +574,7 @@ let%test "retrieve_within excludes confiscated tools" =
 let _dummy_handler : Tool.tool_handler = fun _args -> Ok { Types.content = "ok" }
 
 let _mk_tool name desc : Tool.t =
-  { schema = { name; description = desc; parameters = [] }
+  { schema = { name; description = desc; parameters = []; strict = None }
   ; descriptor = None
   ; handler = Simple _dummy_handler
   }

--- a/lib/tool_middleware.ml
+++ b/lib/tool_middleware.ml
@@ -106,7 +106,7 @@ let validate_shell_constraints ~tool_name ~(descriptor : Tool.descriptor) args =
 
 let tool_schema_of_json ~name ?(description = "") json_schema : Types.tool_schema =
   let parameters = Mcp_schema.json_schema_to_params json_schema in
-  { name; description; parameters }
+  { name; description; parameters; strict = None }
 ;;
 
 (* ── Hook factory ─────────────────────────────────────────── *)

--- a/lib/typed_tool.ml
+++ b/lib/typed_tool.ml
@@ -26,13 +26,17 @@ let check_descriptor = function
 
 let create ~name ~description ~params ~parse ~handler ~encode ?descriptor () =
   check_descriptor descriptor;
-  let schema : Types.tool_schema = { name; description; parameters = params } in
+  let schema : Types.tool_schema =
+    { name; description; parameters = params; strict = None }
+  in
   { schema; descriptor; parse; handler = Simple handler; encode }
 ;;
 
 let create_with_context ~name ~description ~params ~parse ~handler ~encode ?descriptor () =
   check_descriptor descriptor;
-  let schema : Types.tool_schema = { name; description; parameters = params } in
+  let schema : Types.tool_schema =
+    { name; description; parameters = params; strict = None }
+  in
   { schema; descriptor; parse; handler = WithContext handler; encode }
 ;;
 

--- a/test/test_agent_card.ml
+++ b/test/test_agent_card.ml
@@ -20,6 +20,7 @@ let base_info : Agent_card.agent_info =
               ; required = true
               }
             ]
+        ; strict = None
         }
       ]
   ; provider = None

--- a/test/test_agent_registry.ml
+++ b/test/test_agent_registry.ml
@@ -208,7 +208,9 @@ let test_list_by_tool () =
     ; authentication = None
     ; supported_interfaces = []
     ; capabilities = [ Tools ]
-    ; tools = [ { name = "get_weather"; description = "Weather"; parameters = [] } ]
+    ; tools =
+        [ { name = "get_weather"; description = "Weather"; parameters = []; strict = None }
+        ]
     ; skills = []
     ; supported_providers = []
     ; metadata = []

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -67,6 +67,7 @@ let sample_tool_schema : Types.tool_schema =
         ; required = false
         }
       ]
+  ; strict = None
   }
 ;;
 
@@ -403,7 +404,7 @@ let () =
                 ]
             in
             let tool : Types.tool_schema =
-              { name = "multi"; description = "test"; parameters = params }
+              { name = "multi"; description = "test"; parameters = params; strict = None }
             in
             let cp = make_checkpoint ~tools:[ tool ] () in
             let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in

--- a/test/test_checkpoint_delta.ml
+++ b/test/test_checkpoint_delta.ml
@@ -75,7 +75,7 @@ let tool_param_gen =
 let tool_schema_gen =
   let open QCheck.Gen in
   map3
-    (fun name description parameters -> { name; description; parameters })
+    (fun name description parameters -> { name; description; parameters; strict = None })
     small_string_gen
     small_string_gen
     (list_size (int_range 0 2) tool_param_gen)
@@ -245,6 +245,7 @@ let sample_tool_schema =
   ; description = "Lookup a value"
   ; parameters =
       [ { name = "key"; description = "Key"; param_type = String; required = true } ]
+  ; strict = None
   }
 ;;
 

--- a/test/test_checkpoint_store.ml
+++ b/test/test_checkpoint_store.ml
@@ -50,6 +50,7 @@ let sample_tool_schema : Types.tool_schema =
         ; required = true
         }
       ]
+  ; strict = None
   }
 ;;
 

--- a/test/test_correction_pipeline.ml
+++ b/test/test_correction_pipeline.ml
@@ -3,7 +3,7 @@
 open Agent_sdk
 
 let make_schema params : Types.tool_schema =
-  { name = "test_tool"; description = "test"; parameters = params }
+  { name = "test_tool"; description = "test"; parameters = params; strict = None }
 ;;
 
 let int_param name required : Types.tool_param =

--- a/test/test_mcp_session.ml
+++ b/test/test_mcp_session.ml
@@ -10,6 +10,7 @@ let sample_tool_schema : Types.tool_schema =
         ; required = true
         }
       ]
+  ; strict = None
   }
 ;;
 
@@ -33,6 +34,7 @@ let multi_param_tool : Types.tool_schema =
         ; required = false
         }
       ]
+  ; strict = None
   }
 ;;
 
@@ -343,6 +345,7 @@ let () =
                     ; required = false
                     }
                   ]
+              ; strict = None
               }
             in
             let info = make_info ~tool_schemas:[ all_types_tool ] () in

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -303,7 +303,7 @@ let test_mock_to_provider_config () =
 let test_guardrails_allow_all () =
   let g = Guardrails.permissive in
   let schema : Types.tool_schema =
-    { name = "test"; description = "test"; parameters = [] }
+    { name = "test"; description = "test"; parameters = []; strict = None }
   in
   Alcotest.(check bool) "allow all" true (Guardrails.is_allowed g schema)
 ;;
@@ -314,8 +314,12 @@ let test_guardrails_allow_list () =
     ; max_tool_calls_per_turn = None
     }
   in
-  let s1 : Types.tool_schema = { name = "search"; description = ""; parameters = [] } in
-  let s2 : Types.tool_schema = { name = "unknown"; description = ""; parameters = [] } in
+  let s1 : Types.tool_schema =
+    { name = "search"; description = ""; parameters = []; strict = None }
+  in
+  let s2 : Types.tool_schema =
+    { name = "unknown"; description = ""; parameters = []; strict = None }
+  in
   Alcotest.(check bool) "search allowed" true (Guardrails.is_allowed g s1);
   Alcotest.(check bool) "unknown denied" false (Guardrails.is_allowed g s2)
 ;;
@@ -324,9 +328,11 @@ let test_guardrails_deny_list () =
   let g =
     { Guardrails.tool_filter = DenyList [ "dangerous" ]; max_tool_calls_per_turn = None }
   in
-  let s1 : Types.tool_schema = { name = "safe"; description = ""; parameters = [] } in
+  let s1 : Types.tool_schema =
+    { name = "safe"; description = ""; parameters = []; strict = None }
+  in
   let s2 : Types.tool_schema =
-    { name = "dangerous"; description = ""; parameters = [] }
+    { name = "dangerous"; description = ""; parameters = []; strict = None }
   in
   Alcotest.(check bool) "safe allowed" true (Guardrails.is_allowed g s1);
   Alcotest.(check bool) "dangerous denied" false (Guardrails.is_allowed g s2)

--- a/test/test_session_resume.ml
+++ b/test/test_session_resume.ml
@@ -94,6 +94,7 @@ let sample_tool_schema : Types.tool_schema =
         ; required = true
         }
       ]
+  ; strict = None
   }
 ;;
 

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -8,7 +8,7 @@ let make_param ?(required = true) ~param_type name =
 ;;
 
 let make_schema params =
-  { Types.name = "test_tool"; description = "test"; parameters = params }
+  { Types.name = "test_tool"; description = "test"; parameters = params; strict = None }
 ;;
 
 (* ── Required field tests ──────────────────────────────── *)

--- a/test/test_tool_middleware.ml
+++ b/test/test_tool_middleware.ml
@@ -65,7 +65,9 @@ let shell_descriptor
 (* ── validate_and_coerce ─────────────────────────────────── *)
 
 let test_pass_no_params () =
-  let schema : Types.tool_schema = { name = "noop"; description = ""; parameters = [] } in
+  let schema : Types.tool_schema =
+    { name = "noop"; description = ""; parameters = []; strict = None }
+  in
   match Tool_middleware.validate_and_coerce ~tool_name:"noop" ~schema `Null with
   | Tool_middleware.Pass -> ()
   | _ -> Alcotest.fail "empty params should Pass"

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -411,11 +411,27 @@ let test_tool_param_manual_json_helpers () =
        (Agent_sdk.Util.contains_substring_ci ~haystack:msg ~needle:"param_type")
    | Ok _ -> Alcotest.fail "expected bad param type");
   let tool_schema =
-    { Types.name = "search"; description = "Search"; parameters = params }
+    { Types.name = "search"; description = "Search"; parameters = params; strict = None }
   in
   let manual_json = Types.tool_schema_to_json tool_schema in
-  match Types.tool_schema_of_json manual_json with
-  | Ok decoded -> Alcotest.(check int) "params" 2 (List.length decoded.parameters)
+  (* strict = None must not emit the field, and must round-trip back to None. *)
+  Alcotest.(check bool)
+    "strict omitted when None"
+    false
+    (List.mem_assoc "strict" (Yojson.Safe.Util.to_assoc manual_json));
+  (match Types.tool_schema_of_json manual_json with
+   | Ok decoded ->
+     Alcotest.(check int) "params" 2 (List.length decoded.parameters);
+     Alcotest.(check bool) "strict stays None" true (decoded.strict = None)
+   | Error msg -> Alcotest.fail msg);
+  (* strict = Some true must emit "strict": true and round-trip to Some true. *)
+  let strict_json = Types.tool_schema_to_json { tool_schema with strict = Some true } in
+  Alcotest.(check bool)
+    "strict emitted when Some"
+    true
+    (Yojson.Safe.Util.(member "strict" strict_json) = `Bool true);
+  match Types.tool_schema_of_json strict_json with
+  | Ok decoded -> Alcotest.(check bool) "strict round-trips" true (decoded.strict = Some true)
   | Error msg -> Alcotest.fail msg
 ;;
 
@@ -895,6 +911,7 @@ let () =
                     ; required = false
                     }
                   ]
+              ; strict = None
               }
             in
             let json = Types.tool_schema_to_yojson schema in


### PR DESCRIPTION
## 목적

OAS tool calling 현대화 WP2. OpenAI 계열 프로바이더의 per-function strict mode를 지원한다. (#1835 WP0/WP1 후속)

## 변경

`tool_schema`에 `strict : bool option` 추가하고 OpenAI 호환 function 정의로 전달.

- `types`: `tool_schema_to_json`은 `strict`를 `Some`일 때만 방출 — `None`은 필드를 생략해 프로바이더 기본값을 유지하고 round-trip된다. `tool_schema_of_json`은 optional 필드를 파싱한다.
- `backend_openai_serialize`: `build_provider_d_tool_json`이 tool이 `strict`를 가졌을 때만 function 객체에 전달한다 (OpenAI / DeepSeek Beta / Kimi / MiMo).
- 모든 `tool_schema` 생성 사이트에 `strict` 지정 (기본 `None`). Anthropic은 per-function strict 개념이 없어 영향 없음.

생성 사이트 마이그레이션은 컴파일러가 누락을 강제하도록 진행했고(레코드 필드 추가 = exhaustive), 중첩 `tool_param` 레코드(같은 name/description 필드 공유)는 컴파일러 확인 라인만 수정해 오염을 피했다.

## 검증 (로컬)

- `dune build lib/agent_sdk.cma` exit 0
- `dune build @runtest` exit 0 (전체 green)
- 단위 테스트: serializer가 strict를 전달/생략, `tool_schema_to_json`/`of_json`이 `None`과 `Some true` 양방향 round-trip

RFC-WAIVED: lib/llm_provider/* 는 credential/identity/operator/sandbox/hooks/workflow 게이트 대상 아님. additive 필드 + 직렬화로 워크어라운드 시그니처 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
