### PR TITLE
test(provider): reasoning_content + tool_calls 동시 지원 검증 (WP3)

### DIFF
--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -52,6 +52,49 @@ let parse_ok json =
   | Error msg -> Alcotest.fail ("unexpected parse error: " ^ msg)
 ;;
 
+let test_parse_reasoning_content_and_tool_calls_coexist () =
+  (* 2025-2026 providers (DeepSeek, Kimi, Qwen, MiMo) return reasoning_content
+     alongside tool_calls. Both must survive parsing into [content]: the
+     reasoning as a Thinking block and the call as a ToolUse block. *)
+  let json =
+    response_json
+      ~content:(`String "")
+      ~finish_reason:"tool_calls"
+      ~message_fields:
+        [ "reasoning_content", `String "think step by step"
+        ; ( "tool_calls"
+          , `List
+              [ `Assoc
+                  [ "id", `String "call-1"
+                  ; "type", `String "function"
+                  ; ( "function"
+                    , `Assoc
+                        [ "name", `String "search"; "arguments", `String {|{"q":"x"}|} ] )
+                  ]
+              ] )
+        ]
+      ()
+  in
+  let response = parse_ok json in
+  let has_thinking =
+    List.exists
+      (function
+        | Thinking { content; _ } -> content = "think step by step"
+        | _ -> false)
+      response.content
+  in
+  let has_tool =
+    List.exists
+      (function
+        | ToolUse { name; _ } -> name = "search"
+        | _ -> false)
+      response.content
+  in
+  check_bool "reasoning_content -> Thinking" true has_thinking;
+  check_bool "tool_calls -> ToolUse" true has_tool;
+  check_bool "stop_reason is StopToolUse" true (response.stop_reason = StopToolUse)
+;;
+
 let test_content_parts_cover_modalities () =
   let parts =
     Serialize.openai_content_parts_of_blocks
@@ -740,6 +783,10 @@ let () =
             "tool calls filter malformed"
             `Quick
             test_parse_tool_calls_filters_malformed_and_sets_stop_reason
+        ; Alcotest.test_case
+            "reasoning_content and tool_calls coexist"
+            `Quick
+            test_parse_reasoning_content_and_tool_calls_coexist
         ; Alcotest.test_case
             "error default message"
             `Quick


### PR DESCRIPTION
## 목적

OAS tool calling 현대화 WP3 — reasoning_content + tool calling 동시 지원. (#1837 WP2 후속)

## 발견

조사 결과 **핵심 동작은 이미 구현돼 있다**:
- 비-streaming OpenAI 호환 파서(`backend_openai_parse`)가 `content = thinking_blocks @ text @ tool_blocks`로 `reasoning_content`(→ `Thinking`)와 `tool_calls`(→ `ToolUse`)를 **동시에** 반환한다.
- `reasoning_content` 우선, blank 시 `reasoning` fallback도 구현됨.
- `thinking_control_format`은 6-variant typed 시스템(`No_thinking_control`/`Thinking_object`/`Thinking_object_only`/`Chat_template_kwargs`/`Reasoning_effort`/`Enable_thinking`)으로 per-provider 매핑 + 테스트가 이미 성숙하다.

DeepSeek/Kimi/Qwen/MiMo는 모두 OpenAI 호환이라 이 경로로 커버된다. (Gemini 네이티브 thinking은 WP6, streaming reasoning은 WP5 영역.)

## 변경

구현이 이미 있으므로 **없는 코드를 만들지 않고**, 회귀로부터 동작을 보호하는 테스트를 추가한다 — 비-streaming 파서에 `reasoning_content` + `tool_calls`를 동시에 먹여 결과 `content`에 `Thinking`과 `ToolUse`가 둘 다 있고 `stop_reason = StopToolUse`임을 검증.

## 검증 (로컬)

- `dune build @runtest` exit 0 (전체 green)
- 신규 테스트 `parse / reasoning_content and tool_calls coexist` [OK]

RFC-WAIVED: lib/llm_provider/* 는 게이트 대상 아님. 테스트 추가만으로 production 코드 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
