### PR TITLE
feat(provider): tool_result 다중 콘텐츠 블록 지원 (WP4)

### DIFF
--- a/lib/agent/agent_handoff.ml
+++ b/lib/agent/agent_handoff.ml
@@ -44,7 +44,8 @@ let replace_tool_result messages ~tool_id ~content ~is_error =
     List.map
       (function
         | ToolResult { tool_use_id = id; _ } when id = tool_id ->
-          ToolResult { tool_use_id = id; content; is_error; json = None }
+          ToolResult
+            { tool_use_id = id; content; is_error; json = None; content_blocks = None }
         | block -> block)
       blocks
   in
@@ -56,7 +57,14 @@ let replace_tool_result messages ~tool_id ~content ~is_error =
         acc
         { role = User
         ; content =
-            [ ToolResult { tool_use_id = tool_id; content; is_error; json = None } ]
+            [ ToolResult
+                { tool_use_id = tool_id
+                ; content
+                ; is_error
+                ; json = None
+                ; content_blocks = None
+                }
+            ]
         ; name = None
         ; tool_call_id = None
         ; metadata = []

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -709,6 +709,7 @@ let make_tool_results
            ; content
            ; is_error = result.is_error
            ; json = None
+           ; content_blocks = None
            })
       results
   | Some (store, crs) ->
@@ -859,7 +860,8 @@ let make_tool_results
                max_result_chars)
            else content
          in
-         ToolResult { tool_use_id = tid; content; is_error; json = None })
+         ToolResult
+           { tool_use_id = tid; content; is_error; json = None; content_blocks = None })
       phase1
 ;;
 

--- a/lib/content_replacement_state.ml
+++ b/lib/content_replacement_state.ml
@@ -66,7 +66,14 @@ let apply_frozen t blocks =
            then (
              (* Frozen: apply cached replacement or keep *)
              match Hashtbl.find_opt t.replacements tool_use_id with
-             | Some r -> ToolResult { tool_use_id; content = r.preview; is_error; json }
+             | Some r ->
+               ToolResult
+                 { tool_use_id
+                 ; content = r.preview
+                 ; is_error
+                 ; json
+                 ; content_blocks = None
+                 }
              | None ->
                (* Was kept (not replaced) — send full content *)
                block)
@@ -209,11 +216,26 @@ let%test "apply_frozen: replaces frozen, collects fresh" =
   record_kept t "t2";
   let blocks =
     [ ToolResult
-        { tool_use_id = "t1"; content = "long content"; is_error = false; json = None }
+        { tool_use_id = "t1"
+        ; content = "long content"
+        ; is_error = false
+        ; json = None
+        ; content_blocks = None
+        }
     ; ToolResult
-        { tool_use_id = "t2"; content = "kept content"; is_error = false; json = None }
+        { tool_use_id = "t2"
+        ; content = "kept content"
+        ; is_error = false
+        ; json = None
+        ; content_blocks = None
+        }
     ; ToolResult
-        { tool_use_id = "t3"; content = "new content"; is_error = false; json = None }
+        { tool_use_id = "t3"
+        ; content = "new content"
+        ; is_error = false
+        ; json = None
+        ; content_blocks = None
+        }
     ]
   in
   let modified, fresh = apply_frozen t blocks in
@@ -236,7 +258,12 @@ let%test "apply_frozen: idempotent" =
   record_replacement t { tool_use_id = "t1"; preview = "p"; original_chars = 100 };
   let blocks =
     [ ToolResult
-        { tool_use_id = "t1"; content = "original"; is_error = false; json = None }
+        { tool_use_id = "t1"
+        ; content = "original"
+        ; is_error = false
+        ; json = None
+        ; content_blocks = None
+        }
     ]
   in
   let first_pass, _ = apply_frozen t blocks in

--- a/lib/context_reducer.ml
+++ b/lib/context_reducer.ml
@@ -368,7 +368,13 @@ let%test "cap_message_tokens: oversized message with Text blocks is truncated" =
   let text_blocks = List.init 50 (fun _ -> Text (String.make 400 'x')) in
   let blocks =
     text_blocks
-    @ [ ToolResult { tool_use_id = "keep"; content = "r"; is_error = false; json = None }
+    @ [ ToolResult
+          { tool_use_id = "keep"
+          ; content = "r"
+          ; is_error = false
+          ; json = None
+          ; content_blocks = None
+          }
       ]
   in
   let msg =
@@ -395,7 +401,14 @@ let%test "cap_message_tokens: truncation marker present when text dropped" =
   let text_blocks = List.init 20 (fun _ -> Text (String.make 400 'x')) in
   let blocks =
     text_blocks
-    @ [ ToolResult { tool_use_id = "t0"; content = "r"; is_error = false; json = None } ]
+    @ [ ToolResult
+          { tool_use_id = "t0"
+          ; content = "r"
+          ; is_error = false
+          ; json = None
+          ; content_blocks = None
+          }
+      ]
   in
   let msg =
     { role = User; content = blocks; name = None; tool_call_id = None; metadata = [] }
@@ -437,6 +450,7 @@ let%test
         ; content = String.make 400 'x'
         ; is_error = false
         ; json = None
+        ; content_blocks = None
         })
   in
   let msg =
@@ -455,6 +469,7 @@ let%test "cap_message_tokens: recent turns are not modified" =
         ; content = String.make 400 'x'
         ; is_error = false
         ; json = None
+        ; content_blocks = None
         })
   in
   let msg =
@@ -476,6 +491,7 @@ let%test "cap_message_tokens: monotonicity — never increases tokens" =
           ; content = String.make 500 'x'
           ; is_error = false
           ; json = None
+          ; content_blocks = None
           })
   in
   let msg =
@@ -587,6 +603,7 @@ let%test "estimate_block_tokens ToolResult uses CJK-aware estimation" =
       ; content = "\xEA\xB2\xB0\xEA\xB3\xBC\xEC\x9E\x85\xEB\x8B\x88\xEB\x8B\xA4"
       ; is_error = false
       ; json = None
+      ; content_blocks = None
       }
   in
   let tokens = estimate_block_tokens block in

--- a/lib/context_reducer_apply.ml
+++ b/lib/context_reducer_apply.ml
@@ -18,7 +18,12 @@ let apply_prune_tool_outputs ~max_output_len messages =
                   Printf.sprintf "\n[truncated: %d chars]" (String.length content)
                 in
                 ToolResult
-                  { tool_use_id; content = truncated ^ marker; is_error; json = None }
+                  { tool_use_id
+                  ; content = truncated ^ marker
+                  ; is_error
+                  ; json = None
+                  ; content_blocks = None
+                  }
               | other -> other)
            msg.content
        in
@@ -121,6 +126,7 @@ let synthetic_tool_result_message id =
                tool call had no matching ToolResult."
           ; is_error = true
           ; json = None
+          ; content_blocks = None
           }
       ]
   ; name = None
@@ -342,7 +348,13 @@ let apply_clear_tool_results ~keep_recent messages =
                             "[tool result cleared: %d chars]"
                             (String.length content)
                       in
-                      ToolResult { tool_use_id; content = summary; is_error; json = None }
+                      ToolResult
+                        { tool_use_id
+                        ; content = summary
+                        ; is_error
+                        ; json = None
+                        ; content_blocks = None
+                        }
                     | other -> other)
                  msg.content
              in
@@ -406,7 +418,13 @@ let apply_stub_tool_results ~keep_recent messages =
                           line_count
                           status
                       in
-                      ToolResult { tool_use_id; content = stub; is_error; json = None }
+                      ToolResult
+                        { tool_use_id
+                        ; content = stub
+                        ; is_error
+                        ; json = None
+                        ; content_blocks = None
+                        }
                     | other -> other)
                  msg.content
              in

--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -49,7 +49,8 @@ type tool_result_content_style =
   | Tool_result_content_text_blocks
 
 (** Content block <-> JSON *)
-let content_block_to_json_with ~(tool_result_content_style : tool_result_content_style)
+let rec content_block_to_json_with
+          ~(tool_result_content_style : tool_result_content_style)
   = function
   | Text s ->
     `Assoc [ "type", `String "text"; "text", `String (Utf8_sanitize.sanitize s) ]
@@ -68,15 +69,23 @@ let content_block_to_json_with ~(tool_result_content_style : tool_result_content
       ; "name", `String name
       ; "input", input
       ]
-  | ToolResult { tool_use_id; content; is_error; _ } ->
+  | ToolResult { tool_use_id; content; is_error; content_blocks; _ } ->
     let content_json =
-      match tool_result_content_style with
-      | Tool_result_content_string -> `String (Utf8_sanitize.sanitize content)
-      | Tool_result_content_text_blocks ->
-        `List
-          [ `Assoc
-              [ "type", `String "text"; "text", `String (Utf8_sanitize.sanitize content) ]
-          ]
+      match content_blocks with
+      | Some blocks ->
+        (* Structured result: emit the blocks (text/image/...) as the
+           tool_result content array. *)
+        `List (List.map (content_block_to_json_with ~tool_result_content_style) blocks)
+      | None ->
+        (match tool_result_content_style with
+         | Tool_result_content_string -> `String (Utf8_sanitize.sanitize content)
+         | Tool_result_content_text_blocks ->
+           `List
+             [ `Assoc
+                 [ "type", `String "text"
+                 ; "text", `String (Utf8_sanitize.sanitize content)
+                 ]
+             ])
     in
     `Assoc
       [ "type", `String "tool_result"
@@ -143,7 +152,7 @@ let content_block_of_json json =
     let content = json |> member "content" |> to_string in
     let is_error = Cli_common_json.member_bool "is_error" json in
     let json = Types.try_parse_json content in
-    Some (ToolResult { tool_use_id; content; is_error; json })
+    Some (ToolResult { tool_use_id; content; is_error; json; content_blocks = None })
   | Some "image" ->
     let source = json |> member "source" in
     let source_type = source |> member "type" |> to_string in

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -11,17 +11,13 @@ open Types
 
 (* ── Re-exports from serialization ─────────────────────── *)
 
-let tool_calls_to_openai_json =
-  Backend_openai_serialize.tool_calls_to_openai_json
-;;
+let tool_calls_to_openai_json = Backend_openai_serialize.tool_calls_to_openai_json
 
 let openai_content_parts_of_blocks =
   Backend_openai_serialize.openai_content_parts_of_blocks
 ;;
 
-let openai_messages_of_message =
-  Backend_openai_serialize.openai_messages_of_message
-;;
+let openai_messages_of_message = Backend_openai_serialize.openai_messages_of_message
 
 let provider_k_messages_of_message =
   Backend_openai_serialize.provider_k_messages_of_message
@@ -39,10 +35,7 @@ let strip_thinking_blocks = Backend_openai_serialize.strip_thinking_blocks
 
 let strip_json_markdown_fences = Backend_openai_parse.strip_json_markdown_fences
 let usage_of_provider_d_json = Backend_openai_parse.usage_of_provider_d_json
-
-let parse_openai_response_result =
-  Backend_openai_parse.parse_openai_response_result
-;;
+let parse_openai_response_result = Backend_openai_parse.parse_openai_response_result
 
 (* ── Re-exports from request building ─────────────────── *)
 
@@ -50,10 +43,7 @@ let warn_capability_drop = Backend_openai_request.warn_capability_drop
 let effective_tool_choice = Backend_openai_request.effective_tool_choice
 let effective_tools = Backend_openai_request.effective_tools
 let structured_schema_of_config = Backend_openai_request.structured_schema_of_config
-
-let openai_json_schema_payload =
-  Backend_openai_request.openai_json_schema_payload
-;;
+let openai_json_schema_payload = Backend_openai_request.openai_json_schema_payload
 
 let response_format_to_provider_d_json =
   Backend_openai_request.response_format_to_provider_d_json
@@ -409,7 +399,12 @@ let%test "openai_messages_of_message user with tool_result" =
     ; content =
         [ Text "follow up"
         ; ToolResult
-            { tool_use_id = "tc1"; content = "result"; is_error = false; json = None }
+            { tool_use_id = "tc1"
+            ; content = "result"
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
         ]
     ; name = None
     ; tool_call_id = None
@@ -443,6 +438,7 @@ let%test "build_request strips orphaned tool results from wire messages" =
               ; content = "stale"
               ; is_error = false
               ; json = None
+              ; content_blocks = None
               }
           ]
       ; name = None
@@ -620,6 +616,7 @@ let%test "openai_messages_of_message Tool role with ToolResult" =
             ; content = "result data"
             ; is_error = false
             ; json = None
+            ; content_blocks = None
             }
         ]
     ; name = None
@@ -679,7 +676,7 @@ let%test "build_provider_d_tool_json forwards strict into the function object" =
   in
   let result = build_provider_d_tool_json tool_json in
   let open Yojson.Safe.Util in
-  (result |> member "function" |> member "strict") = `Bool true
+  result |> member "function" |> member "strict" = `Bool true
 ;;
 
 let%test "build_provider_d_tool_json omits strict when the tool did not set it" =
@@ -692,7 +689,7 @@ let%test "build_provider_d_tool_json omits strict when the tool did not set it" 
   in
   let result = build_provider_d_tool_json tool_json in
   let open Yojson.Safe.Util in
-  (result |> member "function" |> member "strict") = `Null
+  result |> member "function" |> member "strict" = `Null
 ;;
 
 let%test "build_provider_d_tool_json converts legacy parameter list to json schema" =
@@ -1062,7 +1059,13 @@ let%test "openai_content_parts_of_blocks redacted thinking filtered" =
 
 let%test "openai_content_parts_of_blocks tool_result filtered" =
   let blocks =
-    [ ToolResult { tool_use_id = "t1"; content = "result"; is_error = false; json = None }
+    [ ToolResult
+        { tool_use_id = "t1"
+        ; content = "result"
+        ; is_error = false
+        ; json = None
+        ; content_blocks = None
+        }
     ]
   in
   openai_content_parts_of_blocks blocks = []

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -149,12 +149,21 @@ let messages_of_message_with
     let tool_msgs =
       msg.content
       |> List.filter_map (function
-        | ToolResult { tool_use_id; content; _ } ->
+        | ToolResult { tool_use_id; content; content_blocks; _ } ->
+          let content_str =
+            match content_blocks with
+            | Some blocks ->
+              (* OpenAI tool messages accept string content only; encode the
+                 structured blocks as a JSON string so the result is not lost. *)
+              Yojson.Safe.to_string
+                (`List (List.map Api_common.content_block_to_json blocks))
+            | None -> Utf8_sanitize.sanitize content
+          in
           Some
             (`Assoc
                 [ "role", `String "tool"
                 ; "tool_call_id", `String tool_use_id
-                ; "content", `String (Utf8_sanitize.sanitize content)
+                ; "content", `String content_str
                 ])
         | Text _
         | Thinking _

--- a/lib/llm_provider/cache.ml
+++ b/lib/llm_provider/cache.ml
@@ -87,6 +87,7 @@ let content_block_of_json json =
          ; content
          ; is_error = Cli_common_json.member_bool "is_error" json
          ; json = parsed_json
+         ; content_blocks = None
          })
   | _ -> None
 ;;

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -144,6 +144,7 @@ let finalize_stream_acc (acc : stream_acc) =
                   ; content = text
                   ; is_error
                   ; json = (if is_error then None else Types.try_parse_json text)
+                  ; content_blocks = None
                   })
            | _ -> None)
         indices

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -237,6 +237,10 @@ type content_block =
         (** Parsed JSON payload when available. Consumers
                         should prefer [json] over [content] for structured access.
                         [content] remains the canonical string for API serialization. *)
+      ; content_blocks : content_block list option
+        (** Structured multi-block result (e.g. text + image). When [Some],
+                        providers that accept an array tool_result content serialize
+                        the blocks; [content] stays the canonical string fallback. *)
       }
   | Image of
       { media_type : string
@@ -276,10 +280,10 @@ type stop_reason =
   | StopToolUse
   | MaxTokens
   | StopSequence
-  | Refusal                     (** Policy refusal (Anthropic, OpenAI, Gemini SAFETY). *)
-  | PauseTurn                   (** Anthropic long-running turn pause. *)
-  | Compaction                  (** Anthropic context compaction. *)
-  | ContextWindowExceeded       (** Anthropic context window exceeded. *)
+  | Refusal (** Policy refusal (Anthropic, OpenAI, Gemini SAFETY). *)
+  | PauseTurn (** Anthropic long-running turn pause. *)
+  | Compaction (** Anthropic context compaction. *)
+  | ContextWindowExceeded (** Anthropic context window exceeded. *)
   | Unknown of string
 [@@deriving show]
 
@@ -432,7 +436,7 @@ let tool_result_msg ~tool_use_id ~content ?(is_error = false) ?json () =
   make_message
     ~tool_call_id:tool_use_id
     ~role:Tool
-    [ ToolResult { tool_use_id; content; is_error; json } ]
+    [ ToolResult { tool_use_id; content; is_error; json; content_blocks = None } ]
 ;;
 
 (** {1 Tool Result Validation}

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -118,6 +118,10 @@ type content_block =
       ; content : string
       ; is_error : bool
       ; json : Yojson.Safe.t option (** Structured payload when parseable. *)
+      ; content_blocks : content_block list option
+        (** Structured multi-block result (e.g. text + image). When [Some],
+            providers that accept an array tool_result content serialize the
+            blocks; [content] stays the canonical string fallback. *)
       }
   | Image of
       { media_type : string

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -733,7 +733,12 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
        (* on_idle hook returned Skip: stop gracefully with the current response *)
        Ok (Complete response)
      | other -> other)
-  | EndTurn | MaxTokens | StopSequence | Refusal | PauseTurn | Compaction
+  | EndTurn
+  | MaxTokens
+  | StopSequence
+  | Refusal
+  | PauseTurn
+  | Compaction
   | ContextWindowExceeded ->
     Tool_retry_policy.clear_context_retry_count agent.context;
     let _stop =
@@ -1255,9 +1260,19 @@ let%test "last_tool_results_from finds tool results in last user message" =
     ; { role = User
       ; content =
           [ ToolResult
-              { tool_use_id = "t1"; content = "result1"; is_error = false; json = None }
+              { tool_use_id = "t1"
+              ; content = "result1"
+              ; is_error = false
+              ; json = None
+              ; content_blocks = None
+              }
           ; ToolResult
-              { tool_use_id = "t2"; content = "error msg"; is_error = true; json = None }
+              { tool_use_id = "t2"
+              ; content = "error msg"
+              ; is_error = true
+              ; json = None
+              ; content_blocks = None
+              }
           ]
       ; name = None
       ; tool_call_id = None
@@ -1277,7 +1292,12 @@ let%test "last_tool_results_from skips non-tool user messages" =
     [ { role = User
       ; content =
           [ ToolResult
-              { tool_use_id = "t1"; content = "first"; is_error = false; json = None }
+              { tool_use_id = "t1"
+              ; content = "first"
+              ; is_error = false
+              ; json = None
+              ; content_blocks = None
+              }
           ]
       ; name = None
       ; tool_call_id = None
@@ -1342,7 +1362,12 @@ let%test "last_tool_results_from picks last user with tool results" =
     [ { role = User
       ; content =
           [ ToolResult
-              { tool_use_id = "t1"; content = "first"; is_error = false; json = None }
+              { tool_use_id = "t1"
+              ; content = "first"
+              ; is_error = false
+              ; json = None
+              ; content_blocks = None
+              }
           ]
       ; name = None
       ; tool_call_id = None
@@ -1357,7 +1382,12 @@ let%test "last_tool_results_from picks last user with tool results" =
     ; { role = User
       ; content =
           [ ToolResult
-              { tool_use_id = "t2"; content = "second"; is_error = false; json = None }
+              { tool_use_id = "t2"
+              ; content = "second"
+              ; is_error = false
+              ; json = None
+              ; content_blocks = None
+              }
           ]
       ; name = None
       ; tool_call_id = None
@@ -1376,7 +1406,12 @@ let%test "last_tool_results_from mixed content in user message" =
       ; content =
           [ Text "some text"
           ; ToolResult
-              { tool_use_id = "t1"; content = "ok"; is_error = false; json = None }
+              { tool_use_id = "t1"
+              ; content = "ok"
+              ; is_error = false
+              ; json = None
+              ; content_blocks = None
+              }
           ; Text "more text"
           ]
       ; name = None
@@ -1395,7 +1430,12 @@ let%test "last_tool_results_from error tool result" =
     [ { role = User
       ; content =
           [ ToolResult
-              { tool_use_id = "t1"; content = "fail msg"; is_error = true; json = None }
+              { tool_use_id = "t1"
+              ; content = "fail msg"
+              ; is_error = true
+              ; json = None
+              ; content_blocks = None
+              }
           ]
       ; name = None
       ; tool_call_id = None
@@ -1450,11 +1490,26 @@ let%test "last_tool_results_from multiple tool results in one message" =
     [ { role = User
       ; content =
           [ ToolResult
-              { tool_use_id = "t1"; content = "r1"; is_error = false; json = None }
+              { tool_use_id = "t1"
+              ; content = "r1"
+              ; is_error = false
+              ; json = None
+              ; content_blocks = None
+              }
           ; ToolResult
-              { tool_use_id = "t2"; content = "r2"; is_error = false; json = None }
+              { tool_use_id = "t2"
+              ; content = "r2"
+              ; is_error = false
+              ; json = None
+              ; content_blocks = None
+              }
           ; ToolResult
-              { tool_use_id = "t3"; content = "r3"; is_error = true; json = None }
+              { tool_use_id = "t3"
+              ; content = "r3"
+              ; is_error = true
+              ; json = None
+              ; content_blocks = None
+              }
           ]
       ; name = None
       ; tool_call_id = None

--- a/lib/succession.ml
+++ b/lib/succession.ml
@@ -275,6 +275,7 @@ let normalize_for_model (msgs : message list) ~(target_model : string) : message
                            Printf.sprintf "[truncated: %s result unavailable]" name
                        ; is_error = true
                        ; json = None
+                       ; content_blocks = None
                        }
                    ]
                ; name = None

--- a/lib/tool_middleware.ml
+++ b/lib/tool_middleware.ml
@@ -207,6 +207,7 @@ let heal_tool_call
                            enriched_message
                      ; is_error = true
                      ; json = None
+                     ; content_blocks = None
                      }
                  ]
              ; name = None

--- a/lib/tool_retry_policy.ml
+++ b/lib/tool_retry_policy.ml
@@ -143,6 +143,7 @@ let structured_feedback_block ~tool_use_id ~retry_count ~max_retries ~summary =
     ; content = retry_feedback_text ~retry_count ~max_retries ~summary
     ; is_error = true
     ; json = None
+    ; content_blocks = None
     }
 ;;
 

--- a/test/test_agent.ml
+++ b/test/test_agent.ml
@@ -147,6 +147,7 @@ let test_replace_existing () =
               ; content = "old result"
               ; is_error = false
               ; json = None
+              ; content_blocks = None
               }
           ]
       ; name = None
@@ -202,12 +203,18 @@ let test_replace_preserves_other_results () =
     [ { role = User
       ; content =
           [ ToolResult
-              { tool_use_id = "t1"; content = "keep"; is_error = false; json = None }
+              { tool_use_id = "t1"
+              ; content = "keep"
+              ; is_error = false
+              ; json = None
+              ; content_blocks = None
+              }
           ; ToolResult
               { tool_use_id = "t2"
               ; content = "replace me"
               ; is_error = false
               ; json = None
+              ; content_blocks = None
               }
           ]
       ; name = None

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -1238,6 +1238,7 @@ let test_agent_run_context_overflow_auto_retry_can_be_disabled () =
                 ; content = String.make 2000 'x'
                 ; is_error = false
                 ; json = None
+                ; content_blocks = None
                 }
             ]
         ; name = None
@@ -1365,6 +1366,7 @@ let test_agent_run_tiered_memory_triggers_proactive_compaction () =
                 ; content = String.make 1000 'x'
                 ; is_error = false
                 ; json = None
+                ; content_blocks = None
                 }
             ]
         ; name = None

--- a/test/test_agent_tool.ml
+++ b/test/test_agent_tool.ml
@@ -42,6 +42,7 @@ let structured_runner prompt : (Types.api_response, Error.sdk_error) result =
             ; content = {|{"ok":true}|}
             ; is_error = false
             ; json = Some (`Assoc [ "ok", `Bool true ])
+            ; content_blocks = None
             }
         ]
     ; usage =

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -56,6 +56,7 @@ let test_tool_result_round_trip () =
       ; content = "4"
       ; is_error = false
       ; json = Types.try_parse_json "4"
+      ; content_blocks = None
       }
   in
   let json = Api.content_block_to_json block in
@@ -67,7 +68,12 @@ let test_tool_result_round_trip () =
 let test_tool_result_error_round_trip () =
   let block =
     Types.ToolResult
-      { tool_use_id = "tu_002"; content = "failed"; is_error = true; json = None }
+      { tool_use_id = "tu_002"
+      ; content = "failed"
+      ; is_error = true
+      ; json = None
+      ; content_blocks = None
+      }
   in
   let json = Api.content_block_to_json block in
   match Api.content_block_of_json json with
@@ -112,6 +118,7 @@ let test_provider_c_message_to_json_tool_result_uses_text_blocks () =
             ; content = "5"
             ; is_error = false
             ; json = Some (`Int 5)
+            ; content_blocks = None
             }
         ]
     ; name = None
@@ -1381,7 +1388,12 @@ let test_text_blocks_to_string () =
     ; Types.RedactedThinking "r"
     ; Types.ToolUse { id = "t"; name = "n"; input = `Null }
     ; Types.ToolResult
-        { tool_use_id = "t"; content = "ok"; is_error = false; json = None }
+        { tool_use_id = "t"
+        ; content = "ok"
+        ; is_error = false
+        ; json = None
+        ; content_blocks = None
+        }
     ; Types.Image { media_type = "image/png"; data = ""; source_type = "base64" }
     ; Types.Text "world"
     ]

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -148,6 +148,7 @@ let test_tool_result () =
               ; content = "Sunny, 25C"
               ; is_error = false
               ; json = None
+              ; content_blocks = None
               }
           ]
       ; name = None

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -94,7 +94,12 @@ let test_provider_d_user_messages_text_tool_and_empty () =
       [ Text "first"
       ; Text "second"
       ; ToolResult
-          { tool_use_id = "call-1"; content = "42"; is_error = false; json = None }
+          { tool_use_id = "call-1"
+          ; content = "42"
+          ; is_error = false
+          ; json = None
+          ; content_blocks = None
+          }
       ]
   in
   let messages = Serialize.openai_messages_of_message user in
@@ -146,9 +151,7 @@ let test_assistant_tool_calls_provider_d_ollama_and_provider_k () =
       Assistant
       [ ToolUse { id = "call-1"; name = "lookup"; input = `Assoc [ "q", `String "x" ] } ]
   in
-  let provider_d =
-    Serialize.openai_messages_of_message assistant |> only "provider_d"
-  in
+  let provider_d = Serialize.openai_messages_of_message assistant |> only "provider_d" in
   check_string "assistant role" "assistant" (member "role" provider_d |> to_string);
   Alcotest.(check bool)
     "provider_d content null"
@@ -192,7 +195,12 @@ let test_system_and_tool_role_messages () =
       (msg
          Tool
          [ ToolResult
-             { tool_use_id = "call-2"; content = "ok"; is_error = false; json = None }
+             { tool_use_id = "call-2"
+             ; content = "ok"
+             ; is_error = false
+             ; json = None
+             ; content_blocks = None
+             }
          ])
     |> only "tool"
   in
@@ -216,17 +224,37 @@ let test_strip_orphaned_tool_results_dedupes_and_drops_empty () =
     ; msg
         User
         [ ToolResult
-            { tool_use_id = "call-1"; content = "first"; is_error = false; json = None }
+            { tool_use_id = "call-1"
+            ; content = "first"
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
         ; ToolResult
-            { tool_use_id = "call-1"; content = "dupe"; is_error = false; json = None }
+            { tool_use_id = "call-1"
+            ; content = "dupe"
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
         ; ToolResult
-            { tool_use_id = "orphan"; content = "bad"; is_error = true; json = None }
+            { tool_use_id = "orphan"
+            ; content = "bad"
+            ; is_error = true
+            ; json = None
+            ; content_blocks = None
+            }
         ; Text "kept"
         ]
     ; msg
         User
         [ ToolResult
-            { tool_use_id = "orphan-2"; content = "drop"; is_error = false; json = None }
+            { tool_use_id = "orphan-2"
+            ; content = "drop"
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
         ]
     ; msg Assistant [ Text "done" ]
     ]
@@ -328,7 +356,12 @@ let ignored_blocks : content_block list =
   [ Thinking { thinking_type = "reasoning"; content = "   " }
   ; RedactedThinking "hidden"
   ; ToolResult
-      { tool_use_id = "call-x"; content = "ignored"; is_error = false; json = None }
+      { tool_use_id = "call-x"
+      ; content = "ignored"
+      ; is_error = false
+      ; json = None
+      ; content_blocks = None
+      }
   ; Image { media_type = "image/png"; data = "img"; source_type = "base64" }
   ; Document { media_type = "application/pdf"; data = "doc"; source_type = "base64" }
   ; Audio { media_type = "wav"; data = "aud"; source_type = "base64" }
@@ -408,7 +441,12 @@ let test_strip_helpers_cover_non_tool_variants () =
           [ RedactedThinking "hidden"
           ; ToolUse { id = "call"; name = "lookup"; input = `Null }
           ; ToolResult
-              { tool_use_id = "call"; content = "ok"; is_error = false; json = None }
+              { tool_use_id = "call"
+              ; content = "ok"
+              ; is_error = false
+              ; json = None
+              ; content_blocks = None
+              }
           ; Image { media_type = "image/png"; data = "img"; source_type = "base64" }
           ; Document
               { media_type = "application/pdf"; data = "doc"; source_type = "base64" }

--- a/test/test_backend_tool_call_harness.ml
+++ b/test/test_backend_tool_call_harness.ml
@@ -131,7 +131,12 @@ let test_validate_response_flags_unknown_tool_and_stop_reason () =
       ; T.Thinking { thinking_type = "visible"; content = "reason" }
       ; T.RedactedThinking "redacted"
       ; T.ToolResult
-          { tool_use_id = "call-2"; content = "ok"; is_error = false; json = None }
+          { tool_use_id = "call-2"
+          ; content = "ok"
+          ; is_error = false
+          ; json = None
+          ; content_blocks = None
+          }
       ; T.Image { media_type = "image/png"; data = "abc"; source_type = "base64" }
       ; T.Document { media_type = "text/plain"; data = "doc"; source_type = "base64" }
       ; T.Audio { media_type = "audio/wav"; data = "audio"; source_type = "base64" }

--- a/test/test_budget_strategy.ml
+++ b/test/test_budget_strategy.ml
@@ -36,7 +36,14 @@ let tool_result_msg id content =
   Types.
     { role = User
     ; content =
-        [ ToolResult { tool_use_id = id; content; is_error = false; json = None } ]
+        [ ToolResult
+            { tool_use_id = id
+            ; content
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
+        ]
     ; name = None
     ; tool_call_id = None
     ; metadata = []

--- a/test/test_bug_hunt.ml
+++ b/test/test_bug_hunt.ml
@@ -91,7 +91,12 @@ let test_b3_injection_role_validation () =
         { role = User
         ; content =
             [ ToolResult
-                { tool_use_id = "t1"; content = "42"; is_error = false; json = None }
+                { tool_use_id = "t1"
+                ; content = "42"
+                ; is_error = false
+                ; json = None
+                ; content_blocks = None
+                }
             ]
         ; name = None
         ; tool_call_id = None

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -242,6 +242,7 @@ let () =
                         ; content = "Sunny 22C"
                         ; is_error = false
                         ; json = None
+                        ; content_blocks = None
                         }
                     ]
                 ; name = None
@@ -285,6 +286,7 @@ let () =
                         ; content = "found it"
                         ; is_error = false
                         ; json = None
+                        ; content_blocks = None
                         }
                     ]
                 ; name = None

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -36,7 +36,14 @@ let tool_result_msg id content =
   Types.
     { role = User
     ; content =
-        [ ToolResult { tool_use_id = id; content; is_error = false; json = None } ]
+        [ ToolResult
+            { tool_use_id = id
+            ; content
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
+        ]
     ; name = None
     ; tool_call_id = None
     ; metadata = []
@@ -217,6 +224,7 @@ let test_estimate_tool_result () =
               ; content = "result text"
               ; is_error = false
               ; json = None
+              ; content_blocks = None
               }
           ]
       ; name = None
@@ -474,7 +482,12 @@ let test_cap_preserves_tool_result () =
   let mixed_content =
     [ big_text_block ()
     ; Types.ToolResult
-        { tool_use_id = "call_keep"; content = "r"; is_error = false; json = None }
+        { tool_use_id = "call_keep"
+        ; content = "r"
+        ; is_error = false
+        ; json = None
+        ; content_blocks = None
+        }
     ; big_text_block ()
     ]
   in
@@ -1020,6 +1033,7 @@ let test_clear_tool_results_error_marker () =
                 ; content = String.make 100 'E'
                 ; is_error = true
                 ; json = None
+                ; content_blocks = None
                 }
             ]
         ; name = None
@@ -1348,9 +1362,19 @@ let test_orphaned_results_mixed () =
         { role = User
         ; content =
             [ ToolResult
-                { tool_use_id = "t1"; content = "ok"; is_error = false; json = None }
+                { tool_use_id = "t1"
+                ; content = "ok"
+                ; is_error = false
+                ; json = None
+                ; content_blocks = None
+                }
             ; ToolResult
-                { tool_use_id = "t2"; content = "orphan"; is_error = false; json = None }
+                { tool_use_id = "t2"
+                ; content = "orphan"
+                ; is_error = false
+                ; json = None
+                ; content_blocks = None
+                }
             ]
         ; name = None
         ; tool_call_id = None

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -270,7 +270,12 @@ let test_api_common_content_block_roundtrip () =
       [ Text "hello"
       ; ToolUse { id = "t1"; name = "calc"; input = `Assoc [ "x", `Int 1 ] }
       ; ToolResult
-          { tool_use_id = "t1"; content = "result"; is_error = false; json = None }
+          { tool_use_id = "t1"
+          ; content = "result"
+          ; is_error = false
+          ; json = None
+          ; content_blocks = None
+          }
       ]
   in
   List.iter

--- a/test/test_llm_cache.ml
+++ b/test/test_llm_cache.ml
@@ -157,7 +157,12 @@ let test_roundtrip_tool_result () =
   let resp =
     simple_response
       [ ToolResult
-          { tool_use_id = "tu_1"; content = "result data"; is_error = false; json = None }
+          { tool_use_id = "tu_1"
+          ; content = "result data"
+          ; is_error = false
+          ; json = None
+          ; content_blocks = None
+          }
       ]
   in
   let json = Cache.response_to_json resp in
@@ -176,7 +181,12 @@ let test_roundtrip_tool_result_error () =
   let resp =
     simple_response
       [ ToolResult
-          { tool_use_id = "tu_2"; content = "failed"; is_error = true; json = None }
+          { tool_use_id = "tu_2"
+          ; content = "failed"
+          ; is_error = true
+          ; json = None
+          ; content_blocks = None
+          }
       ]
   in
   let json = Cache.response_to_json resp in

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -354,7 +354,13 @@ let test_content_block_to_json_tool_use () =
 let test_content_block_to_json_tool_result () =
   let json =
     Api_common.content_block_to_json
-      (ToolResult { tool_use_id = "tu1"; content = "done"; is_error = true; json = None })
+      (ToolResult
+         { tool_use_id = "tu1"
+         ; content = "done"
+         ; is_error = true
+         ; json = None
+         ; content_blocks = None
+         })
   in
   let open Yojson.Safe.Util in
   Alcotest.(check string) "type" "tool_result" (json |> member "type" |> to_string);
@@ -610,7 +616,12 @@ let test_contents_of_messages_tool_use () =
     ; { role = Tool
       ; content =
           [ ToolResult
-              { tool_use_id = "tu1"; content = "result42"; is_error = false; json = None }
+              { tool_use_id = "tu1"
+              ; content = "result42"
+              ; is_error = false
+              ; json = None
+              ; content_blocks = None
+              }
           ]
       ; name = None
       ; tool_call_id = None
@@ -651,9 +662,7 @@ let test_build_request_basic () =
       ~temperature:0.5
       ()
   in
-  let body_str =
-    Backend_gemini.build_request ~config ~messages:[ user_msg "hello" ] ()
-  in
+  let body_str = Backend_gemini.build_request ~config ~messages:[ user_msg "hello" ] () in
   let json = Yojson.Safe.from_string body_str in
   let open Yojson.Safe.Util in
   (* Check contents exist *)
@@ -674,9 +683,7 @@ let test_build_request_with_system_prompt () =
       ~system_prompt:"be helpful"
       ()
   in
-  let body_str =
-    Backend_gemini.build_request ~config ~messages:[ user_msg "hello" ] ()
-  in
+  let body_str = Backend_gemini.build_request ~config ~messages:[ user_msg "hello" ] () in
   let json = Yojson.Safe.from_string body_str in
   let open Yojson.Safe.Util in
   match json |> member "systemInstruction" with
@@ -999,9 +1006,7 @@ let test_build_request_tool_choice_none () =
   let config =
     make_config ~kind:Gemini ~model_id:provider_f25_flash_model ~tool_choice:None_ ()
   in
-  let body_str =
-    Backend_gemini.build_request ~config ~messages:[ user_msg "hi" ] ()
-  in
+  let body_str = Backend_gemini.build_request ~config ~messages:[ user_msg "hi" ] () in
   let json = Yojson.Safe.from_string body_str in
   let open Yojson.Safe.Util in
   let tc = json |> member "toolConfig" |> member "functionCallingConfig" in
@@ -1016,9 +1021,7 @@ let test_build_request_tool_choice_specific () =
       ~tool_choice:(Tool "get_weather")
       ()
   in
-  let body_str =
-    Backend_gemini.build_request ~config ~messages:[ user_msg "hi" ] ()
-  in
+  let body_str = Backend_gemini.build_request ~config ~messages:[ user_msg "hi" ] () in
   let json = Yojson.Safe.from_string body_str in
   let open Yojson.Safe.Util in
   let tc = json |> member "toolConfig" |> member "functionCallingConfig" in
@@ -1038,9 +1041,7 @@ let test_build_request_top_p_top_k () =
       ~top_k:40
       ()
   in
-  let body_str =
-    Backend_gemini.build_request ~config ~messages:[ user_msg "hi" ] ()
-  in
+  let body_str = Backend_gemini.build_request ~config ~messages:[ user_msg "hi" ] () in
   let json = Yojson.Safe.from_string body_str in
   let open Yojson.Safe.Util in
   let gc = json |> member "generationConfig" in

--- a/test/test_multimodal.ml
+++ b/test/test_multimodal.ml
@@ -176,6 +176,54 @@ let test_document_json_structure () =
 ;;
 
 (* ------------------------------------------------------------------ *)
+(* ToolResult structured content_blocks (WP4)                           *)
+(* ------------------------------------------------------------------ *)
+
+let test_tool_result_content_blocks_serialize () =
+  let open Yojson.Safe.Util in
+  (* content_blocks = None keeps the canonical string content. *)
+  let tr_string =
+    Types.ToolResult
+      { tool_use_id = "t1"
+      ; content = "plain"
+      ; is_error = false
+      ; json = None
+      ; content_blocks = None
+      }
+  in
+  Alcotest.(check string)
+    "string content"
+    "plain"
+    (Api.content_block_to_json tr_string |> member "content" |> to_string);
+  (* content_blocks = Some emits the blocks as the content array. *)
+  let tr_blocks =
+    Types.ToolResult
+      { tool_use_id = "t2"
+      ; content = "fallback"
+      ; is_error = false
+      ; json = None
+      ; content_blocks =
+          Some
+            [ Types.Text "hi"
+            ; Types.Image { media_type = "image/png"; data = "d"; source_type = "base64" }
+            ]
+      }
+  in
+  let content = Api.content_block_to_json tr_blocks |> member "content" in
+  (match content with
+   | `List items -> Alcotest.(check int) "two blocks" 2 (List.length items)
+   | _ -> Alcotest.fail "expected content array");
+  Alcotest.(check string)
+    "first block is text"
+    "text"
+    (content |> index 0 |> member "type" |> to_string);
+  Alcotest.(check string)
+    "second block is image"
+    "image"
+    (content |> index 1 |> member "type" |> to_string)
+;;
+
+(* ------------------------------------------------------------------ *)
 (* Test runner                                                          *)
 (* ------------------------------------------------------------------ *)
 
@@ -212,6 +260,12 @@ let () =
     ; ( "json_structure"
       , [ Alcotest.test_case "image json structure" `Quick test_image_json_structure
         ; Alcotest.test_case "document json structure" `Quick test_document_json_structure
+        ] )
+    ; ( "tool_result"
+      , [ Alcotest.test_case
+            "content_blocks serialize"
+            `Quick
+            test_tool_result_content_blocks_serialize
         ] )
     ]
 ;;

--- a/test/test_pipeline_deep.ml
+++ b/test/test_pipeline_deep.ml
@@ -316,6 +316,7 @@ let test_resolve_params_with_tool_results () =
               ; content = "found it"
               ; is_error = false
               ; json = None
+              ; content_blocks = None
               }
           ]
       ; name = None
@@ -373,6 +374,7 @@ let test_resolve_params_error_tool_results () =
               ; content = "permission denied"
               ; is_error = true
               ; json = None
+              ; content_blocks = None
               }
           ]
       ; name = None

--- a/test/test_property_advanced.ml
+++ b/test/test_property_advanced.ml
@@ -24,7 +24,12 @@ let content_block_gen =
     ; QCheck.Gen.map3
         (fun id content is_error ->
            ToolResult
-             { tool_use_id = id; content; is_error; json = Types.try_parse_json content })
+             { tool_use_id = id
+             ; content
+             ; is_error
+             ; json = Types.try_parse_json content
+             ; content_blocks = None
+             })
         QCheck.Gen.string_printable
         QCheck.Gen.string_printable
         QCheck.Gen.bool

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -493,6 +493,7 @@ let test_provider_c_direct_tool_result_uses_text_blocks () =
               ; content = "5"
               ; is_error = false
               ; json = Some (`Int 5)
+              ; content_blocks = None
               }
           ]
       ; name = None
@@ -558,6 +559,7 @@ let test_glm_preserved_reasoning_replay_and_drops_unsupported_tool_choice () =
               ; content = "{\"value\":4}"
               ; is_error = false
               ; json = Some (`Assoc [ "value", `Int 4 ])
+              ; content_blocks = None
               }
           ]
       ; name = None

--- a/test/test_provider_f_edge_cases.ml
+++ b/test/test_provider_f_edge_cases.ml
@@ -56,9 +56,7 @@ let test_cache_system_prompt () =
       ~system_prompt:"Be helpful."
       ()
   in
-  let body =
-    Backend_gemini.build_request ~config ~messages:[ Types.user_msg "hi" ] ()
-  in
+  let body = Backend_gemini.build_request ~config ~messages:[ Types.user_msg "hi" ] () in
   let json = Yojson.Safe.from_string body in
   let open Yojson.Safe.Util in
   let si = json |> member "systemInstruction" in
@@ -178,6 +176,7 @@ let test_tool_use_id_roundtrip () =
               ; content = "Sunny 25C"
               ; is_error = false
               ; json = None
+              ; content_blocks = None
               }
           ]
       ; name = None

--- a/test/test_raw_trace.ml
+++ b/test/test_raw_trace.ml
@@ -924,7 +924,12 @@ let test_tool_result_assistant_block_summary () =
        active
        ~block_index:0
        (Types.ToolResult
-          { tool_use_id = "tool-1"; content = "ok"; is_error = false; json = None }));
+          { tool_use_id = "tool-1"
+          ; content = "ok"
+          ; is_error = false
+          ; json = None
+          ; content_blocks = None
+          }));
   ignore
     (unwrap
        (Raw_trace.finish_run

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -134,7 +134,12 @@ let test_synthetic_events_media_blocks () =
         ; Audio { media_type = "wav"; data = "YXVkaW8="; source_type = "base64" }
         ; RedactedThinking "hidden"
         ; ToolResult
-            { tool_use_id = "call-1"; content = "ok"; is_error = false; json = None }
+            { tool_use_id = "call-1"
+            ; content = "ok"
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
         ]
     }
   in
@@ -161,9 +166,7 @@ let test_provider_d_parse_edge_shapes () =
     {|{"id":"c","model":"m","choices":[{"delta":{"tool_calls":[{"index":"bad"},{"index":0,"function":{"arguments":"{}"}}]},"finish_reason":null}],"usage":{"prompt_tokens":4,"completion_tokens":5,"prompt_tokens_details":{"cached_tokens":3}}}|}
   in
   let chunk =
-    require_some
-      "provider_d mixed tool calls"
-      (S.parse_openai_sse_chunk mixed_tool_calls)
+    require_some "provider_d mixed tool calls" (S.parse_openai_sse_chunk mixed_tool_calls)
   in
   check int "only valid tool call retained" 1 (List.length chunk.delta_tool_calls);
   (match chunk.chunk_usage with
@@ -321,7 +324,7 @@ let test_provider_f_event_edge_branches () =
       (provider_f_chunk ~finish_reason:"SAFETY" ())
   in
   match unknown_events with
-  | [ MessageDelta { stop_reason = Some (Refusal); _ } ] -> ()
+  | [ MessageDelta { stop_reason = Some Refusal; _ } ] -> ()
   | _ -> fail "expected provider_f unknown finish"
 ;;
 

--- a/test/test_structured.ml
+++ b/test/test_structured.ml
@@ -339,6 +339,7 @@ let test_extract_ignores_tool_result () =
         ; content = "previous result"
         ; is_error = false
         ; json = None
+        ; content_blocks = None
         }
     ; ToolUse { id = "tu_r"; name = "extract_person"; input = input_json }
     ]
@@ -475,7 +476,13 @@ let test_retry_message_construction () =
     let retry_msg =
       { role = User
       ; content =
-          [ ToolResult { tool_use_id; content = error_msg; is_error = true; json = None }
+          [ ToolResult
+              { tool_use_id
+              ; content = error_msg
+              ; is_error = true
+              ; json = None
+              ; content_blocks = None
+              }
           ]
       ; name = None
       ; tool_call_id = None

--- a/test/test_structured_coverage.ml
+++ b/test/test_structured_coverage.ml
@@ -347,7 +347,12 @@ let test_extract_mixed_blocks () =
     [ Text "preamble"
     ; Thinking { thinking_type = "s"; content = "reasoning" }
     ; ToolResult
-        { tool_use_id = "old"; content = "old result"; is_error = false; json = None }
+        { tool_use_id = "old"
+        ; content = "old result"
+        ; is_error = false
+        ; json = None
+        ; content_blocks = None
+        }
     ; Image { media_type = "image/png"; data = "img"; source_type = "base64" }
     ; ToolUse { id = "tu_mix"; name = "wrong_tool"; input = `Null }
     ; ToolUse { id = "tu_right"; name = "extract_person"; input = input_json }

--- a/test/test_succession.ml
+++ b/test/test_succession.ml
@@ -305,7 +305,12 @@ let test_normalize_preserves_matched_tool_calls () =
     ; { Types.role = Types.User
       ; content =
           [ Types.ToolResult
-              { tool_use_id = "t1"; content = "result"; is_error = false; json = None }
+              { tool_use_id = "t1"
+              ; content = "result"
+              ; is_error = false
+              ; json = None
+              ; content_blocks = None
+              }
           ]
       ; name = None
       ; tool_call_id = None

--- a/test/test_tool_middleware.ml
+++ b/test/test_tool_middleware.ml
@@ -490,7 +490,13 @@ let test_strip_no_orphans () =
     [ mk_msg Assistant [ ToolUse { id = "t1"; name = "f"; input = `Null } ]
     ; mk_msg
         User
-        [ ToolResult { tool_use_id = "t1"; content = "ok"; is_error = false; json = None }
+        [ ToolResult
+            { tool_use_id = "t1"
+            ; content = "ok"
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
         ]
     ]
   in
@@ -511,6 +517,7 @@ let test_strip_removes_orphan () =
             ; content = "stale"
             ; is_error = false
             ; json = None
+            ; content_blocks = None
             }
         ]
     ]
@@ -532,11 +539,27 @@ let test_strip_preserves_matched () =
         ]
     ; mk_msg
         User
-        [ ToolResult { tool_use_id = "t1"; content = "ok"; is_error = false; json = None }
+        [ ToolResult
+            { tool_use_id = "t1"
+            ; content = "ok"
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
         ; ToolResult
-            { tool_use_id = "orphan"; content = "bad"; is_error = true; json = None }
+            { tool_use_id = "orphan"
+            ; content = "bad"
+            ; is_error = true
+            ; json = None
+            ; content_blocks = None
+            }
         ; ToolResult
-            { tool_use_id = "t2"; content = "ok2"; is_error = false; json = None }
+            { tool_use_id = "t2"
+            ; content = "ok2"
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
         ]
     ]
   in

--- a/test/test_tool_result_relocation.ml
+++ b/test/test_tool_result_relocation.ml
@@ -37,7 +37,8 @@ let rm_rf dir =
 ;;
 
 let tool_result ?(is_error = false) id content : Types.content_block =
-  Types.ToolResult { tool_use_id = id; content; is_error; json = None }
+  Types.ToolResult
+    { tool_use_id = id; content; is_error; json = None; content_blocks = None }
 ;;
 
 let asst_msg text : Types.message =

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -36,8 +36,7 @@ let test_known_stop_reasons () =
   Alcotest.(check string)
     "model_context_window_exceeded"
     "Types.ContextWindowExceeded"
-    (Types.show_stop_reason
-       (Types.stop_reason_of_string "model_context_window_exceeded"))
+    (Types.show_stop_reason (Types.stop_reason_of_string "model_context_window_exceeded"))
 ;;
 
 let test_unknown_stop_reason () =
@@ -298,7 +297,12 @@ let test_show_content_block_variants () =
     ; Types.RedactedThinking "redacted"
     ; Types.ToolUse { id = "tu1"; name = "read"; input = `Null }
     ; Types.ToolResult
-        { tool_use_id = "tu1"; content = "ok"; is_error = false; json = None }
+        { tool_use_id = "tu1"
+        ; content = "ok"
+        ; is_error = false
+        ; json = None
+        ; content_blocks = None
+        }
     ; Types.Image { media_type = "image/png"; data = "abc"; source_type = "base64" }
     ; Types.Document
         { media_type = "application/pdf"; data = "pdf"; source_type = "base64" }
@@ -431,7 +435,8 @@ let test_tool_param_manual_json_helpers () =
     true
     (Yojson.Safe.Util.(member "strict" strict_json) = `Bool true);
   match Types.tool_schema_of_json strict_json with
-  | Ok decoded -> Alcotest.(check bool) "strict round-trips" true (decoded.strict = Some true)
+  | Ok decoded ->
+    Alcotest.(check bool) "strict round-trips" true (decoded.strict = Some true)
   | Error msg -> Alcotest.fail msg
 ;;
 
@@ -665,7 +670,12 @@ let test_text_of_content_mixed () =
 let test_text_of_content_tool_result () =
   let content =
     [ Types.ToolResult
-        { tool_use_id = "tu1"; content = "result text"; is_error = false; json = None }
+        { tool_use_id = "tu1"
+        ; content = "result text"
+        ; is_error = false
+        ; json = None
+        ; content_blocks = None
+        }
     ]
   in
   Alcotest.(check string)
@@ -706,7 +716,12 @@ let test_text_of_response_and_usage_helpers () =
     ; content =
         [ Types.Text "hello"
         ; Types.ToolResult
-            { tool_use_id = "tu"; content = "tool text"; is_error = false; json = None }
+            { tool_use_id = "tu"
+            ; content = "tool text"
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
         ; Types.Thinking { thinking_type = "sig"; content = "hidden" }
         ]
     ; usage = Some usage
@@ -731,6 +746,7 @@ let test_validate_tool_result_shape () =
       ; content = {|{"ok":true}|}
       ; is_error = false
       ; json = Some (`Assoc [ "ok", `Bool true ])
+      ; content_blocks = None
       }
   in
   let array_result =
@@ -739,15 +755,26 @@ let test_validate_tool_result_shape () =
       ; content = "[1,2]"
       ; is_error = false
       ; json = Some (`List [ `Int 1; `Int 2 ])
+      ; content_blocks = None
       }
   in
   let invalid_json_result =
     Types.ToolResult
-      { tool_use_id = "bad"; content = "not-json"; is_error = false; json = None }
+      { tool_use_id = "bad"
+      ; content = "not-json"
+      ; is_error = false
+      ; json = None
+      ; content_blocks = None
+      }
   in
   let empty_result =
     Types.ToolResult
-      { tool_use_id = "empty"; content = " "; is_error = false; json = None }
+      { tool_use_id = "empty"
+      ; content = " "
+      ; is_error = false
+      ; json = None
+      ; content_blocks = None
+      }
   in
   Alcotest.(check bool)
     "object ok"


### PR DESCRIPTION
## 목적

OAS tool calling 현대화 WP4 — tool_result의 다중 콘텐츠(content block 배열) 지원. (#1837 WP2 후속)

## 변경

ToolResult content block에 `content_blocks : content_block list option` 추가. 도구가 단일 문자열 대신 구조화된 다중 블록(예: 텍스트 + 이미지)을 결과로 반환할 수 있다.

- `types`: ToolResult가 `content_blocks`를 가지며, `content`는 canonical 문자열 fallback으로 유지
- `api_common`(Anthropic): `content_block_to_json_with`이 `Some`일 때 블록을 tool_result content 배열로 직렬화, `None`이면 기존 string/text-block 스타일. 중첩 블록 직렬화를 위해 `let rec`로 변경
- `backend_openai_serialize`(OpenAI): tool 메시지는 string content만 받으므로 `Some blocks`는 JSON 문자열로 인코딩, `None`은 기존 문자열 유지
- 모든 ToolResult 생성 사이트에 `content_blocks` 지정 (기본 `None`)

레코드 필드 추가라 생성 사이트 전부가 컴파일러에 의해 강제 갱신됐다(exhaustive). 중첩 `tool_param`/inner record 오염 없이 컴파일러 확인 사이트만 수정.

## 검증 (로컬)

- `dune build @runtest` exit 0 (전체 green)
- 변경 `.ml/.mli` 전부 `ocamlformat --check` 통과
- 신규 테스트: Anthropic 직렬화가 `Some`이면 content 배열, `None`이면 문자열

## 참고 (별도 사안)

이 PR이 건드리는 일부 파일은 ocamlformat 정규화를 포함한다. 이는 #1835/#1837이 Draft 상태로 머지되며 `OCaml Format` 체크를 skip해 main에 들어간 포맷 drift를 함께 정리한 것이다. main 전반의 drift는 별도 `chore(fmt)` 정리가 필요할 수 있다.

RFC-WAIVED: lib/llm_provider/* 는 게이트 대상 아님. additive 필드 + 직렬화로 워크어라운드 시그니처 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
