### PR TITLE
feat(gemini): disable_parallel_tool_use 미지원 가시화 (WP9 갭)

### DIFF
--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -11,6 +11,27 @@ exception Gemini_api_error of string
 
 (* ── Helpers ────────────────────────────────────────── *)
 
+(* The Gemini API has no parallel-function-call disable. [functionCallingConfig]
+   supports only [mode] (AUTO/ANY/VALIDATED/NONE) and [allowedFunctionNames] --
+   there is no equivalent of OpenAI [parallel_tool_calls:false] or Anthropic
+   [tool_choice.disable_parallel_tool_use]. A caller's [disable_parallel_tool_use]
+   therefore cannot be honored on the wire and is dropped; we surface that
+   asymmetry once per model rather than ignoring it silently. Verified 2026-06-03
+   against ai.google.dev/gemini-api/docs/function-calling. *)
+let parallel_disable_warned : (string, unit) Hashtbl.t = Hashtbl.create 8
+
+let warn_parallel_disable_unsupported ~model_id =
+  if not (Hashtbl.mem parallel_disable_warned model_id)
+  then (
+    Hashtbl.replace parallel_disable_warned model_id ();
+    Diag.warn
+      "backend_gemini"
+      "disable_parallel_tool_use requested for model %s but the Gemini API has no \
+       parallel-disable option (functionCallingConfig supports only mode and \
+       allowedFunctionNames); ignoring."
+      model_id)
+;;
+
 let provider_f_role_of_oas = function
   | User | System | Tool -> "user"
   | Assistant -> "model"
@@ -246,6 +267,8 @@ let build_request
     match tools with
     | [] -> body
     | ts ->
+      if config.disable_parallel_tool_use
+      then warn_parallel_disable_unsupported ~model_id:config.model_id;
       let func_decls = List.map build_function_declaration ts in
       ("tools", `List [ `Assoc [ "functionDeclarations", `List func_decls ] ]) :: body
   in

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -125,6 +125,32 @@ let test_tools () =
   check string "tool name" "get_weather" (List.hd func_decls |> member "name" |> to_string)
 ;;
 
+let test_disable_parallel_tool_use_dropped () =
+  (* The Gemini API has no parallel-disable; the request must omit it entirely
+     even when the caller sets disable_parallel_tool_use. *)
+  let config = { (provider_f_config ()) with disable_parallel_tool_use = true } in
+  let messages = [ Types.user_msg "What's the weather?" ] in
+  let tools =
+    [ `Assoc
+        [ "name", `String "get_weather"
+        ; "description", `String "Get weather"
+        ; "input_schema", `Assoc [ "type", `String "object" ]
+        ]
+    ]
+  in
+  let body = Backend_gemini.build_request ~config ~messages ~tools () in
+  let contains needle =
+    let nl = String.length needle
+    and hl = String.length body in
+    let rec go i = i + nl <= hl && (String.sub body i nl = needle || go (i + 1)) in
+    nl = 0 || go 0
+  in
+  check bool "no parallel_tool_calls on the wire" false (contains "parallel_tool_calls");
+  check bool "no disable_parallel on the wire" false (contains "disable_parallel");
+  let json = parse_body body in
+  check int "tools still present" 1 (json |> member "tools" |> to_list |> List.length)
+;;
+
 let test_tool_result () =
   let config = provider_f_config () in
   let messages =
@@ -741,6 +767,10 @@ let () =
         ; test_case "system from messages" `Quick test_system_from_messages
         ; test_case "thinking config" `Quick test_thinking_config
         ; test_case "tools" `Quick test_tools
+        ; test_case
+            "disable_parallel dropped"
+            `Quick
+            test_disable_parallel_tool_use_dropped
         ; test_case "tool result" `Quick test_tool_result
         ; test_case "json mode" `Quick test_json_mode
         ; test_case "output schema" `Quick test_output_schema


### PR DESCRIPTION
## 목적

WP8-14 설계의 "현재 코드 기반에서 확인된 갭" 중 하나(Gemini parallel-disable 비대칭)를 해소한다. provider canonicalization 방향: tool_choice 계열 capability를 provider 간 일관되게 다루되, 미지원은 silent하지 않게 가시화.

## 근거 (공식 문서, 2026-06-03 확인)

- Anthropic: `tool_choice.disable_parallel_tool_use` 지원 (`api_anthropic.ml:87`, `backend_anthropic.ml:190`)
- OpenAI: `parallel_tool_calls:false` 지원 (`api_openai.ml:195`, `backend_openai_request.ml:299`)
- **Gemini: parallel-disable 옵션 없음.** `functionCallingConfig`는 `mode`(AUTO/ANY/VALIDATED/NONE) + `allowedFunctionNames`만 지원 — `parallel_tool_calls:false`/`disable_parallel_tool_use` 등가물이 없다. (ai.google.dev/gemini-api/docs/function-calling)

기존 `backend_gemini`는 caller의 `disable_parallel_tool_use`를 **조용히 무시**했다(silent failure).

## 변경

- `backend_gemini.build_request`: tools가 있고 `disable_parallel_tool_use=true`이면, model당 1회 WARN을 emit하고(backend_openai의 capability-drop warning 패턴 미러) wire 한계를 주석으로 명시. 동작은 그대로(Gemini는 어차피 emit할 필드가 없음)지만 비대칭이 가시화된다.
- 테스트: Gemini 요청이 `disable_parallel_tool_use=true`여도 wire에 parallel/disable_parallel 필드가 없고 tool 선언은 정상 전송됨을 lock.

## 검증 (로컬)

- `dune build @runtest` exit 0
- 변경 `.ml` 2개 `ocamlformat --check` 통과 (변경 파일만 포맷)

RFC-WAIVED: lib/llm_provider/* 는 게이트 대상 아님. 동작 변경 없이 가시성(WARN)+테스트 추가. 워크어라운드 아님 — 근본은 "Gemini는 미지원"이라는 사실이며 이를 숨기지 않고 표면화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
