### PR TITLE
refactor(provider): parallel_tool_calls 직렬화 SSOT 추출 (WP9 갭)

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -111,9 +111,7 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
     | Some top_k when capabilities.supports_top_k -> ("top_k", `Int top_k) :: body_assoc
     | None -> body_assoc
     | Some _ ->
-      Llm_provider.Backend_openai.warn_capability_drop
-        ~model_id:model_str
-        ~field:"top_k";
+      Llm_provider.Backend_openai.warn_capability_drop ~model_id:model_str ~field:"top_k";
       body_assoc
   in
   let body_assoc =
@@ -121,9 +119,7 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
     | Some min_p when capabilities.supports_min_p -> ("min_p", `Float min_p) :: body_assoc
     | None -> body_assoc
     | Some _ ->
-      Llm_provider.Backend_openai.warn_capability_drop
-        ~model_id:model_str
-        ~field:"min_p";
+      Llm_provider.Backend_openai.warn_capability_drop ~model_id:model_str ~field:"min_p";
       body_assoc
   in
   let body_assoc =
@@ -192,9 +188,10 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
     | None -> body_assoc
   in
   let body_assoc =
-    if config.config.disable_parallel_tool_use && capabilities.supports_tools
-    then ("parallel_tool_calls", `Bool false) :: body_assoc
-    else body_assoc
+    Llm_provider.Backend_openai_serialize.parallel_tool_calls_fields
+      ~disable_parallel:config.config.disable_parallel_tool_use
+      ~tools_present:capabilities.supports_tools
+    @ body_assoc
   in
   let body_assoc =
     match config.config.response_format with

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -37,8 +37,7 @@ let warn_capability_drop ~model_id ~field =
 let effective_tool_choice (config : Provider_config.t) =
   match config.tool_choice with
   | Some None_ -> None
-  | Some choice ->
-    Some (Backend_openai_serialize.tool_choice_to_provider_d_json choice)
+  | Some choice -> Some (Backend_openai_serialize.tool_choice_to_provider_d_json choice)
   | None -> None
 ;;
 
@@ -129,8 +128,7 @@ let build_request
       | Provider_config.OpenAI_compat
       | Provider_config.Ollama
       | Provider_config.DashScope
-      | Provider_config.Gemini ->
-        Backend_openai_serialize.openai_messages_of_message
+      | Provider_config.Gemini -> Backend_openai_serialize.openai_messages_of_message
     in
     (match config.system_prompt with
      | Some s when not (Api_common.string_is_blank s) ->
@@ -291,14 +289,14 @@ let build_request
     match tools with
     | [] -> body
     | ts ->
-      ( "tools"
-      , `List (List.map Backend_openai_serialize.build_provider_d_tool_json ts) )
+      ("tools", `List (List.map Backend_openai_serialize.build_provider_d_tool_json ts))
       :: body
   in
   let body =
-    if config.disable_parallel_tool_use && tools <> []
-    then ("parallel_tool_calls", `Bool false) :: body
-    else body
+    Backend_openai_serialize.parallel_tool_calls_fields
+      ~disable_parallel:config.disable_parallel_tool_use
+      ~tools_present:(tools <> [])
+    @ body
   in
   let body =
     match response_format_of_config config with

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -388,6 +388,18 @@ let tool_choice_to_provider_d_json = function
   | None_ -> `String "none"
 ;;
 
+(* Single source of truth for the OpenAI-compatible parallel-tool-call control.
+   Two layers decide *whether* to disable parallel calls (low-level
+   [Backend_openai_request] guards on [tools <> []]; agent-state-aware
+   [Api_openai] guards on [capabilities.supports_tools]); both serialize the
+   field through here so the wire shape lives in one place. OpenAI defaults to
+   parallel calls, so the field is emitted only to turn them off. *)
+let parallel_tool_calls_fields ~disable_parallel ~tools_present
+  : (string * Yojson.Safe.t) list
+  =
+  if disable_parallel && tools_present then [ "parallel_tool_calls", `Bool false ] else []
+;;
+
 let legacy_parameters_to_json_schema params =
   let properties, required =
     List.fold_left

--- a/lib/llm_provider/backend_openai_serialize.mli
+++ b/lib/llm_provider/backend_openai_serialize.mli
@@ -11,6 +11,17 @@ val openai_messages_of_message : Types.message -> Yojson.Safe.t list
 val provider_k_messages_of_message : Types.message -> Yojson.Safe.t list
 val ollama_messages_of_message : ?model_id:string -> Types.message -> Yojson.Safe.t list
 val tool_choice_to_provider_d_json : Types.tool_choice -> Yojson.Safe.t
+
+(** [parallel_tool_calls_fields ~disable_parallel ~tools_present] returns the
+    OpenAI-compatible [parallel_tool_calls] body field: [("parallel_tool_calls",
+    `Bool false)] in a singleton list when parallel calls are disabled and tools
+    are present, else the empty list. Shared by the low-level request builder and
+    the agent-state-aware API layer so the wire shape is defined once. *)
+val parallel_tool_calls_fields
+  :  disable_parallel:bool
+  -> tools_present:bool
+  -> (string * Yojson.Safe.t) list
+
 val build_provider_d_tool_json : Yojson.Safe.t -> Yojson.Safe.t
 
 (** Remove ToolResult blocks whose tool_use_id has no matching ToolUse

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -500,6 +500,26 @@ let test_strip_helpers_cover_non_tool_variants () =
   check_int "non-thinking blocks preserved" 6 (List.length (List.hd no_thinking).content)
 ;;
 
+let test_parallel_tool_calls_fields () =
+  (* SSOT for the parallel-tool-call wire field: emitted only to disable, and
+     only when tools are present. *)
+  let fields ~disable ~tools =
+    Serialize.parallel_tool_calls_fields ~disable_parallel:disable ~tools_present:tools
+  in
+  check_int
+    "disable + tools -> one field"
+    1
+    (List.length (fields ~disable:true ~tools:true));
+  check_int
+    "disable + no tools -> empty"
+    0
+    (List.length (fields ~disable:true ~tools:false));
+  check_int "not disabled -> empty" 0 (List.length (fields ~disable:false ~tools:true));
+  match fields ~disable:true ~tools:true with
+  | [ ("parallel_tool_calls", `Bool false) ] -> ()
+  | _ -> Alcotest.fail "expected parallel_tool_calls:false singleton"
+;;
+
 let test_tool_schema_defaults_and_legacy_edge_params () =
   let defaulted =
     Serialize.build_provider_d_tool_json
@@ -802,6 +822,10 @@ let () =
             "tool schema defaults and legacy edge params"
             `Quick
             test_tool_schema_defaults_and_legacy_edge_params
+        ; Alcotest.test_case
+            "parallel_tool_calls fields SSOT"
+            `Quick
+            test_parallel_tool_calls_fields
         ] )
     ; ( "parse"
       , [ Alcotest.test_case


### PR DESCRIPTION
## 목적

WP8-14 설계의 "확인된 갭" #2(Provider-D request path 중복) 해소. (#1840 후속)

## 근거

`parallel_tool_calls:false` 직렬화를 두 곳이 각자 소유했다:
- `backend_openai_request.ml`(저수준, `tools <> []` 가드)
- `api_openai.ml`(agent-state-aware, `capabilities.supports_tools` 가드)

둘 다 wire shape(`"parallel_tool_calls": false`)를 직접 emit해 drift 위험이 있었다. HTML 지침: "한쪽 삭제가 아니라 공유 serializer 함수 추출 후 양쪽이 호출(드리프트는 추출로 닫고 레이어 분리는 유지)".

## 변경

- `Backend_openai_serialize.parallel_tool_calls_fields ~disable_parallel ~tools_present` 추가 — 필드 wire shape의 SSOT. `disable_parallel && tools_present`일 때만 `[("parallel_tool_calls", `Bool false)]`, 아니면 `[]`.
- 두 레이어가 각자의 `tools_present` 가드(`tools <> []` / `capabilities.supports_tools`)로 이 함수를 호출. **레이어별 결정 로직 보존, 동작 불변.**
- `.mli` 계약 추가, 단위 테스트로 SSOT lock.

## 검증 (로컬)

- `dune build @runtest` exit 0
- 변경 `.ml/.mli` 5개 `ocamlformat --check` 통과 (변경 파일만 포맷)

RFC-WAIVED: lib/llm_provider/* 게이트 대상 아님. 동작 보존 추출 + 테스트. 워크어라운드 아님 — N-of-M 중복을 abstraction 추출로 닫음(CLAUDE.md 권장 근본 해결).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
