### PR TITLE
test(gemini): tool_choice Tool(name) maps to ANY + allowedFunctionNames

### DIFF
--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -586,6 +586,24 @@ let test_tool_choice_mapping () =
   test_choice Types.None_ "NONE"
 ;;
 
+let test_tool_choice_tool_name () =
+  (* tool_choice = Tool "name" forces a function-call (mode ANY) restricted to
+     that named function via allowedFunctionNames. *)
+  let config =
+    { (provider_f_config ()) with tool_choice = Some (Types.Tool "get_weather") }
+  in
+  let tools =
+    [ `Assoc [ "name", `String "get_weather"; "description", `String "Get weather" ] ]
+  in
+  let messages = [ Types.user_msg "What's the weather?" ] in
+  let body = Backend_gemini.build_request ~config ~messages ~tools () in
+  let json = parse_body body in
+  let fcc = json |> member "toolConfig" |> member "functionCallingConfig" in
+  check string "mode" "ANY" (fcc |> member "mode" |> to_string);
+  let allowed = fcc |> member "allowedFunctionNames" |> to_list |> List.map to_string in
+  check (list string) "allowedFunctionNames" [ "get_weather" ] allowed
+;;
+
 let test_thinking_part_roundtrip () =
   (* Test that Thinking content blocks become thought:true parts *)
   let config = provider_f_config () in
@@ -776,6 +794,7 @@ let () =
         ; test_case "output schema" `Quick test_output_schema
         ; test_case "role mapping" `Quick test_role_mapping
         ; test_case "tool choice" `Quick test_tool_choice_mapping
+        ; test_case "tool choice tool name" `Quick test_tool_choice_tool_name
         ; test_case "thinking part roundtrip" `Quick test_thinking_part_roundtrip
         ] )
     ; ( "parse_response"


### PR DESCRIPTION
## 목적

Gemini 백엔드에서 `tool_choice = Some (Tool "name")` 매핑을 테스트로 고정한다.

`lib/llm_provider/backend_gemini.ml` `build_request`는 이미 다음을 생성한다:

- `toolConfig.functionCallingConfig.mode = "ANY"`
- `toolConfig.functionCallingConfig.allowedFunctionNames = [name]`

그러나 기존 `test_tool_choice_mapping`은 `Auto` / `Any` / `None_`만 검증하고
named-tool 분기(`Tool name`)는 검증하지 않았다. 이 분기를 회귀로부터 보호한다.

## 변경

- `test/test_backend_gemini.ml`: `test_tool_choice_tool_name` 추가 + build_request
  `test_case` 목록에 등록.
- 단언: tools가 있고 `tool_choice = Some (Types.Tool "get_weather")`인 요청이
  `functionCallingConfig.mode = "ANY"` 와 `allowedFunctionNames = ["get_weather"]`
  를 생성.

## 검증

- `scripts/dune-local.sh build @runtest` → exit 0. 신규 테스트
  `backend_gemini.build_request 11 tool choice tool name` `[OK]`, 신규 실패 없음.
- `ocamlformat --check test/test_backend_gemini.ml` → exit 0.

소스 코드는 변경하지 않았다. 테스트 1건만 추가했다.

RFC-WAIVED: lib/llm_provider 및 test 변경, credential/operator/sandbox/hooks 게이트 비대상

🤖 Generated with [Claude Code](https://claude.com/claude-code)
