### PR TITLE
docs(otel): correct stale metric-API comment in otel_tracer.mli

### DIFF
--- a/lib/eval_otel_bridge.mli
+++ b/lib/eval_otel_bridge.mli
@@ -1,9 +1,10 @@
 (** Eval Metrics OTel Bridge — emit [Eval.run_metrics] as OTel span events.
 
-    OAS's [Otel_tracer] is span-based (no native counter/gauge API).
-    This bridge records eval metrics as a dedicated span with structured
-    attributes following the [oas.eval.*] namespace convention from
-    RFC-OAS-002.
+    [Otel_tracer] exposes a native counter/gauge/histogram metric API
+    ([Otel_tracer.inst_record_metric]). This bridge records eval metrics
+    through that API and, in addition, encodes them as a dedicated span
+    with structured attributes following the [oas.eval.*] namespace
+    convention from RFC-OAS-002.
 
     Metric data is encoded as span attributes so OTel collectors can
     extract counters/gauges via attribute-based rules.  The bridge also


### PR DESCRIPTION
## 목적 (BATCH C — otel metric-API 주석 수정, doc-only)

`Otel_tracer` 가 native counter/gauge metric API 를 제공하는데도 그렇지 않다고 주장하는 stale 주석을 수정합니다.

## 수정 대상 파일 정정

배치 브리프는 `lib/otel_tracer.mli` 5-8행을 가리켰으나, 해당 파일에는 stale 주장이 없습니다 (header 가 metric 에 대해 침묵하고 있고 이는 정확함). 실제 잘못된 주석은 **`lib/eval_otel_bridge.mli:3`** 에 있습니다:

> `OAS's [Otel_tracer] is span-based (no native counter/gauge API).`

이 문장은 같은 파일 51행 (`emit_run_metrics` 가 "the native metric API ([Otel_tracer.inst_record_metric])" 를 사용한다고 명시) 과 모순되며, 사실과 다릅니다:

- `lib/otel_tracer.mli:111-116` 가 `inst_record_metric` 을 선언하고, `Counter | Gauge | Histogram` (`metric_type`) variant 가 존재합니다.
- `lib/eval_otel_bridge.ml:150` 가 `inst_record_metric` 을 실제로 호출합니다 (`emit_run_metrics`).

브리프가 지목한 `inst_record_metric` / `emit_run_metrics` semantic anchor 가 정확히 이 파일을 가리키므로, 수정은 `eval_otel_bridge.mli` 에 적용했습니다.

## 변경 내용

주석을 native metric API 가 존재하고 사용된다는 사실로 교정하되, span-attribute encoding rationale (8-10행) 는 그대로 유지했습니다. bridge 는 두 경로 (native API + span-attribute) 를 모두 사용하므로 metrics-only 로 뒤집지 않았습니다.

## 검증

- `scripts/dune-local.sh build lib/agent_sdk.cma` → exit 0
- `scripts/dune-local.sh build @runtest` → exit 0 (신규 실패 없음)
- `ocamlformat --check lib/eval_otel_bridge.mli` → exit 0

doc-comment 단독 변경이라 런타임 동작 변화가 없습니다. 기존 테스트 (`eval_otel_bridge.ml:321` `emit_run_metrics creates one span` 등) 가 이미 `inst_record_metric` 사용 경로를 검증하고 있어, 교정된 주석이 그 동작과 일치하게 되었습니다.

RFC-WAIVED: lib/llm_provider 및 test 변경, credential/operator/sandbox/hooks 게이트 비대상

🤖 Generated with [Claude Code](https://claude.com/claude-code)