### PR TITLE
test(provider): request serialization snapshot ratchet (WP9)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -48,6 +48,7 @@
   test_backend_glm_coverage
   test_backend_tool_call_harness
   test_backend_gemini
+  test_snapshot_provider_serialization
   test_body_timeout
   test_budget_strategy
   test_bug_hunt
@@ -257,6 +258,7 @@
   test_backend_glm_coverage
   test_backend_tool_call_harness
   test_backend_gemini
+  test_snapshot_provider_serialization
   test_body_timeout
   test_budget_strategy
   test_bug_hunt

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -1,0 +1,327 @@
+(** Request-serialization snapshot ratchet (WP9).
+
+    Pins the CURRENT request-body wire output of each provider backend's
+    request builder against an inline expected string. The pinned strings
+    record present behavior — they are a regression fence, not an assertion
+    that the current shape is "correct". When a serializer changes on
+    purpose, regenerate the expected string in the same PR and review the
+    diff.
+
+    Determinism note: every field in the fixture is supplied explicitly so
+    the wire string is a pure function of the fixture, not of the host
+    environment. In particular:
+    - [model_id] ("oas-snapshot-fixture-model") matches no static capability
+      prefix and is not expected in any capability manifest, so capability
+      lookup falls through to per-kind defaults.
+    - [supports_tool_choice_override:true] pins whether the OpenAI/GLM
+      [tool_choice] field is emitted, independent of any manifest entry.
+    - [keep_alive:"-1"] pins the Ollama [keep_alive] field, independent of
+      the [OAS_OLLAMA_KEEP_ALIVE] env var.
+    - No model in this fixture reports [supports_seed], so no [seed] field is
+      injected and [OAS_DEFAULT_SEED] does not affect the output. *)
+
+open Alcotest
+open Llm_provider
+open Types
+
+(* ── Shared fixture ─────────────────────────────────── *)
+
+let msg role content : message =
+  { role; content; name = None; tool_call_id = None; metadata = [] }
+;;
+
+(* One tool declaration in the SDK's input_schema shape. *)
+let tool_decl =
+  `Assoc
+    [ "name", `String "get_weather"
+    ; "description", `String "Get weather for a city"
+    ; ( "input_schema"
+      , `Assoc
+          [ "type", `String "object"
+          ; "properties", `Assoc [ "city", `Assoc [ "type", `String "string" ] ]
+          ; "required", `List [ `String "city" ]
+          ] )
+    ]
+;;
+
+(* A representative conversation exercising a ToolUse turn followed by a
+   ToolResult, so the snapshot covers assistant tool-call serialization and
+   user/tool-result serialization (block ordering included). *)
+let messages =
+  [ msg User [ Text "What's the weather in Seoul?" ]
+  ; msg
+      Assistant
+      [ ToolUse
+          { id = "call_1"
+          ; name = "get_weather"
+          ; input = `Assoc [ "city", `String "Seoul" ]
+          }
+      ]
+  ; msg
+      User
+      [ ToolResult
+          { tool_use_id = "call_1"
+          ; content = "Sunny, 25C"
+          ; is_error = false
+          ; json = None
+          ; content_blocks = None
+          }
+      ]
+  ]
+;;
+
+let cfg ~kind ~base_url ~tool_choice =
+  Provider_config.make
+    ~kind
+    ~model_id:"oas-snapshot-fixture-model"
+    ~base_url
+    ~api_key:"test-key"
+    ~max_tokens:1024
+    ~temperature:0.7
+    ~tool_choice
+    ~disable_parallel_tool_use:true
+    ~supports_tool_choice_override:true
+    ~keep_alive:"-1"
+    ()
+;;
+
+let openai_cfg = cfg ~kind:OpenAI_compat ~base_url:"https://api.openai.com/v1"
+let anthropic_cfg = cfg ~kind:Anthropic ~base_url:"https://api.anthropic.com"
+
+let gemini_cfg =
+  cfg ~kind:Gemini ~base_url:"https://generativelanguage.googleapis.com/v1beta"
+;;
+
+let glm_cfg = cfg ~kind:Glm ~base_url:"https://open.bigmodel.cn/api/paas/v4"
+let ollama_cfg = cfg ~kind:Ollama ~base_url:"http://127.0.0.1:11434"
+
+(* ── Helpers ────────────────────────────────────────── *)
+
+let snapshot label expected actual = check string label expected actual
+
+(* Substring containment, used for legible per-field assertions in addition
+   to the full-string ratchet. *)
+let contains ~needle haystack =
+  let nl = String.length needle
+  and hl = String.length haystack in
+  let rec go i = i + nl <= hl && (String.sub haystack i nl = needle || go (i + 1)) in
+  nl = 0 || go 0
+;;
+
+(* ── OpenAI-compatible ──────────────────────────────── *)
+
+let openai_forced_expected =
+  {|{"parallel_tool_calls":false,"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"tool_choice":{"type":"function","function":{"name":"get_weather"}},"temperature":0.7,"model":"oas-snapshot-fixture-model","messages":[{"role":"user","content":"What's the weather in Seoul?"},{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Seoul\"}"}}],"role":"assistant","content":null},{"role":"tool","tool_call_id":"call_1","content":"Sunny, 25C"}],"max_tokens":1024}|}
+;;
+
+let openai_required_expected =
+  {|{"parallel_tool_calls":false,"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"tool_choice":"required","temperature":0.7,"model":"oas-snapshot-fixture-model","messages":[{"role":"user","content":"What's the weather in Seoul?"},{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Seoul\"}"}}],"role":"assistant","content":null},{"role":"tool","tool_call_id":"call_1","content":"Sunny, 25C"}],"max_tokens":1024}|}
+;;
+
+(* None_ omits both [tools] and [tool_choice] entirely (it does not emit
+   "none"). Pinned as current behavior, not a serializer fix. *)
+let openai_none_expected =
+  {|{"temperature":0.7,"model":"oas-snapshot-fixture-model","messages":[{"role":"user","content":"What's the weather in Seoul?"},{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Seoul\"}"}}],"role":"assistant","content":null},{"role":"tool","tool_call_id":"call_1","content":"Sunny, 25C"}],"max_tokens":1024}|}
+;;
+
+let test_openai_forced () =
+  let body =
+    Backend_openai_request.build_request
+      ~config:(openai_cfg ~tool_choice:(Tool "get_weather"))
+      ~messages
+      ~tools:[ tool_decl ]
+      ()
+  in
+  snapshot "openai tool_choice=forced(Tool) snapshot" openai_forced_expected body;
+  check
+    bool
+    "parallel_tool_calls:false present when disabled"
+    true
+    (contains ~needle:{|"parallel_tool_calls":false|} body);
+  check bool "role:tool present" true (contains ~needle:{|"role":"tool"|} body);
+  check
+    bool
+    "forced tool_choice names the function"
+    true
+    (contains
+       ~needle:{|"tool_choice":{"type":"function","function":{"name":"get_weather"}}|}
+       body)
+;;
+
+let test_openai_required () =
+  let body =
+    Backend_openai_request.build_request
+      ~config:(openai_cfg ~tool_choice:Any)
+      ~messages
+      ~tools:[ tool_decl ]
+      ()
+  in
+  snapshot "openai tool_choice=required(Any) snapshot" openai_required_expected body;
+  check
+    bool
+    {|Any maps to tool_choice:"required"|}
+    true
+    (contains ~needle:{|"tool_choice":"required"|} body)
+;;
+
+let test_openai_none () =
+  let body =
+    Backend_openai_request.build_request
+      ~config:(openai_cfg ~tool_choice:None_)
+      ~messages
+      ~tools:[ tool_decl ]
+      ()
+  in
+  snapshot "openai tool_choice=none(None_) snapshot" openai_none_expected body;
+  check
+    bool
+    "None_ omits tool_choice field"
+    false
+    (contains ~needle:{|"tool_choice"|} body);
+  check bool "None_ omits tools field" false (contains ~needle:{|"tools"|} body)
+;;
+
+(* ── Anthropic ──────────────────────────────────────── *)
+
+let anthropic_forced_expected =
+  {|{"tool_choice":{"disable_parallel_tool_use":true,"type":"tool","name":"get_weather"},"tools":[{"name":"get_weather","description":"Get weather for a city","input_schema":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}],"temperature":0.7,"model":"oas-snapshot-fixture-model","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"text","text":"What's the weather in Seoul?"}]},{"role":"assistant","content":[{"type":"tool_use","id":"call_1","name":"get_weather","input":{"city":"Seoul"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":"Sunny, 25C","is_error":false}]}],"stream":false}|}
+;;
+
+let test_anthropic_forced () =
+  let body =
+    Backend_anthropic.build_request
+      ~config:(anthropic_cfg ~tool_choice:(Tool "get_weather"))
+      ~messages
+      ~tools:[ tool_decl ]
+      ()
+  in
+  snapshot "anthropic tool_choice=forced(Tool) snapshot" anthropic_forced_expected body;
+  check
+    bool
+    "disable_parallel_tool_use nested inside tool_choice"
+    true
+    (contains
+       ~needle:{|"tool_choice":{"disable_parallel_tool_use":true,"type":"tool"|}
+       body);
+  check bool "tool_use block present" true (contains ~needle:{|"type":"tool_use"|} body);
+  check
+    bool
+    "tool_result block present"
+    true
+    (contains ~needle:{|"type":"tool_result"|} body);
+  (* Block ordering: text/tool_use/tool_result appear in message order. *)
+  check
+    bool
+    "no top-level disable_parallel field"
+    false
+    (contains ~needle:{|,"disable_parallel_tool_use":true}|} body
+     && not (contains ~needle:{|"type":"tool"|} body))
+;;
+
+(* ── Gemini ─────────────────────────────────────────── *)
+
+let gemini_any_expected =
+  {|{"toolConfig":{"functionCallingConfig":{"mode":"ANY"}},"tools":[{"functionDeclarations":[{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}]}],"generationConfig":{"temperature":0.7,"maxOutputTokens":1024},"contents":[{"role":"user","parts":[{"text":"What's the weather in Seoul?"}]},{"role":"model","parts":[{"functionCall":{"name":"get_weather","args":{"city":"Seoul"}}}]},{"role":"user","parts":[{"functionResponse":{"name":"get_weather","response":{"result":"Sunny, 25C"}}}]}]}|}
+;;
+
+let test_gemini_any () =
+  let body =
+    Backend_gemini.build_request
+      ~config:(gemini_cfg ~tool_choice:Any)
+      ~messages
+      ~tools:[ tool_decl ]
+      ()
+  in
+  snapshot "gemini tool_choice=Any snapshot" gemini_any_expected body;
+  check
+    bool
+    "functionDeclarations present"
+    true
+    (contains ~needle:{|"functionDeclarations"|} body);
+  check
+    bool
+    "functionCallingConfig present"
+    true
+    (contains ~needle:{|"functionCallingConfig":{"mode":"ANY"}|} body);
+  (* #1840: Gemini has no parallel-disable; the field must be absent even
+     though disable_parallel_tool_use=true. *)
+  check
+    bool
+    "no parallel_tool_calls on the wire (#1840)"
+    false
+    (contains ~needle:"parallel_tool_calls" body);
+  check
+    bool
+    "no disable_parallel on the wire (#1840)"
+    false
+    (contains ~needle:"disable_parallel" body)
+;;
+
+(* ── GLM (OpenAI-compatible wire format) ────────────── *)
+
+let glm_any_expected =
+  {|{"parallel_tool_calls":false,"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"tool_choice":"required","temperature":0.7,"model":"oas-snapshot-fixture-model","messages":[{"role":"user","content":"What's the weather in Seoul?"},{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Seoul\"}"}}],"role":"assistant","content":""},{"role":"tool","tool_call_id":"call_1","content":"Sunny, 25C"}],"max_tokens":1024}|}
+;;
+
+let test_glm_any () =
+  let body =
+    Backend_glm.build_request
+      ~config:(glm_cfg ~tool_choice:Any)
+      ~messages
+      ~tools:[ tool_decl ]
+      ()
+  in
+  snapshot "glm tool_choice=Any snapshot" glm_any_expected body;
+  check
+    bool
+    "parallel_tool_calls:false present when disabled"
+    true
+    (contains ~needle:{|"parallel_tool_calls":false|} body);
+  check
+    bool
+    {|Any maps to tool_choice:"required"|}
+    true
+    (contains ~needle:{|"tool_choice":"required"|} body)
+;;
+
+(* ── Ollama (native /api/chat shape) ────────────────── *)
+
+let ollama_any_expected =
+  {|{"options":{"temperature":0.7,"num_predict":1024},"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"keep_alive":-1,"stream":false,"think":false,"model":"oas-snapshot-fixture-model","messages":[{"role":"user","content":"What's the weather in Seoul?"},{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":{"city":"Seoul"}}}],"role":"assistant","content":null},{"role":"tool","tool_call_id":"call_1","content":"Sunny, 25C"}]}|}
+;;
+
+let test_ollama_any () =
+  let body =
+    Backend_ollama.build_request
+      ~config:(ollama_cfg ~tool_choice:Any)
+      ~messages
+      ~tools:[ tool_decl ]
+      ()
+  in
+  snapshot "ollama tool_choice=Any snapshot" ollama_any_expected body;
+  check
+    bool
+    "ollama options carries temperature + num_predict"
+    true
+    (contains ~needle:{|"options":{"temperature":0.7,"num_predict":1024}|} body);
+  check bool "keep_alive pinned to -1" true (contains ~needle:{|"keep_alive":-1|} body);
+  (* Ollama native /api/chat takes no tool_choice / parallel_tool_calls. *)
+  check bool "no tool_choice field" false (contains ~needle:{|"tool_choice"|} body)
+;;
+
+(* ── Suite ──────────────────────────────────────────── *)
+
+let () =
+  run
+    "snapshot_provider_serialization"
+    [ ( "openai"
+      , [ test_case "tool_choice forced(Tool)" `Quick test_openai_forced
+        ; test_case "tool_choice required(Any)" `Quick test_openai_required
+        ; test_case "tool_choice none(None_)" `Quick test_openai_none
+        ] )
+    ; "anthropic", [ test_case "tool_choice forced(Tool)" `Quick test_anthropic_forced ]
+    ; "gemini", [ test_case "tool_choice Any" `Quick test_gemini_any ]
+    ; "glm", [ test_case "tool_choice Any" `Quick test_glm_any ]
+    ; "ollama", [ test_case "tool_choice Any" `Quick test_ollama_any ]
+    ]
+;;


### PR DESCRIPTION
## 목적 (WP9)

provider별 request 직렬화 wire 출력을 현재 동작 그대로 inline 스냅샷 문자열로 고정(pin)하여, 이후 serializer drift가 CI에서 감지되도록 한다. 새 `test/test_snapshot_provider_serialization.ml` 한 파일 + `test/dune` wiring만 추가하며 `lib/` serializer는 건드리지 않는다.

## 커버리지

각 backend의 `build_request`를 동일한 fixture(ToolUse + ToolResult 대화 1개, tool 선언 1개, `disable_parallel_tool_use=true`)로 호출하고 full request JSON 문자열을 expected와 EQUALS 비교한다.

- OpenAI-compatible (`Backend_openai_request.build_request`): `tool_choice` forced(`Tool`)/required(`Any`)/none(`None_`) 3종. `parallel_tool_calls:false`, `role:"tool"` 존재 확인. `None_`은 `tools`/`tool_choice` 둘 다 생략 — 현재 동작을 그대로 고정(서버 fix 아님, 주석 명시).
- Anthropic (`Backend_anthropic.build_request`): `tool_choice` 내부에 `disable_parallel_tool_use:true` nesting, `tool_use`/`tool_result` block, block ordering 확인.
- Gemini (`Backend_gemini.build_request`): `functionDeclarations` + `functionCallingConfig` 존재, parallel 관련 필드 부재(#1840).
- GLM (`Backend_glm.build_request`): OpenAI 호환 wire + `tool_choice:"required"` + `parallel_tool_calls:false`.
- Ollama (`Backend_ollama.build_request`): native `/api/chat` shape(`options`/`keep_alive`/`think`), `tool_choice` 부재.

full-string ratchet 외에 provider별 2~3개 targeted 필드 assertion을 추가해 실패 메시지를 읽기 쉽게 했다.

## 결정성 (환경 비의존)

스냅샷 문자열이 host 환경이 아니라 fixture만의 순수 함수가 되도록 wire에 영향 주는 필드를 모두 명시했다:
- `model_id`("oas-snapshot-fixture-model")는 static capability prefix와 매칭되지 않고 manifest에도 없어 per-kind default로 fall through → seed 미주입.
- `supports_tool_choice_override:true`로 OpenAI/GLM `tool_choice` emit 여부를 manifest와 무관하게 고정.
- `keep_alive:"-1"`로 Ollama `keep_alive`를 `OAS_OLLAMA_KEEP_ALIVE` env와 무관하게 고정.

probe로 normal shell vs clean env(capability manifest 없음, `OAS_DEFAULT_SEED`/`OAS_OLLAMA_KEEP_ALIVE`/`OAS_CAPABILITY_MANIFEST`/`MASC_CONFIG_DIR` unset, `HOME` 비움) 출력이 byte-identical임을 확인 후 pin했다.

## 검증

- `scripts/dune-local.sh build lib/agent_sdk.cma` → exit 0
- 신규 suite 단독 실행: 7/7 `[OK]`
- `scripts/dune-local.sh build @runtest` → exit 0 (신규 실패 없음)
- `ocamlformat --check test/test_snapshot_provider_serialization.ml` → exit 0

## 미검증/caveat

- 스냅샷은 "현재 동작" 고정용 regression fence이며, 출력 shape가 "옳다"는 주장이 아니다. serializer를 의도적으로 바꿀 때는 같은 PR에서 expected 문자열을 재생성하고 diff를 리뷰해야 한다.

RFC-WAIVED: lib/llm_provider 및 test 변경, credential/operator/sandbox/hooks 게이트 비대상

🤖 Generated with [Claude Code](https://claude.com/claude-code)