### PR TITLE
[codex] Remove strict required-tool satisfaction helper

### DIFF
--- a/docs/rfc/RFC-OAS-009-tool-name-ignorance.md
+++ b/docs/rfc/RFC-OAS-009-tool-name-ignorance.md
@@ -93,7 +93,7 @@ $ rg -n "Cdal_proof|Mode_enforcer|Risk_contract|Execution_mode|Proof_capture|Aud
 
 검증:
 - `lib/completion_contract.mli` 미존재 — *gold-standard CDAL 7개* (cdal_proof, execution_mode, mode_resolver, proof_capture, proof_store, risk_class, risk_contract)에 안 들어감.
-- `lib/completion_contract.ml`: `type t = Completion_contract_id.t = ...` — base의 variant를 re-export + satisfaction predicate (`required_tool_satisfaction`, `any_tool_call_satisfies`, `effectful_tool_satisfies`).
+- `lib/completion_contract.ml`: `type t = Completion_contract_id.t = ...` — base의 variant를 re-export + satisfaction predicate extension point (`required_tool_satisfaction`, 기본 `any_tool_call_satisfies`).
 - CDAL import: 0건 (검증: `rg -n "Cdal_proof|Mode_enforcer|Risk_contract|Execution_mode|Proof_capture|Proof_store|Audit\b|Autonomy_" lib/completion_contract.ml`).
 - 의존: `Types`, `Log`, `Tool`, `Yojson`, `Completion_contract_id` — 모두 base/core.
 

--- a/lib/completion_contract.ml
+++ b/lib/completion_contract.ml
@@ -61,28 +61,6 @@ let violation_detail_to_string (detail : violation_detail) : string =
 
 let any_tool_call_satisfies (_call : tool_call) = Ok ()
 
-let effectful_tool_satisfies (call : tool_call) =
-  match call.tool with
-  | None ->
-    Error
-      (Printf.sprintf
-         "tool '%s' has no registered descriptor for strict required-tool validation"
-         call.name)
-  | Some tool ->
-    (match Tool.permission tool with
-     | Some Tool.ReadOnly ->
-       Error
-         (Printf.sprintf
-            "tool '%s' is read-only and cannot satisfy a required-tool contract"
-            call.name)
-     | Some (Tool.Write | Tool.Destructive) -> Ok ()
-     | None ->
-       Error
-         (Printf.sprintf
-            "tool '%s' has no permission metadata for strict required-tool validation"
-            call.name))
-;;
-
 let requested_of_tool_choice choice =
   match choice with
   | Some Any -> Require_tool_use
@@ -195,8 +173,13 @@ let stop_reason_is_resumable (sr : stop_reason) : bool =
   match sr with
   | MaxTokens -> true
   | PauseTurn -> true
-  | EndTurn | StopToolUse | StopSequence | Refusal | Compaction
-  | ContextWindowExceeded | Unknown _ -> false
+  | EndTurn
+  | StopToolUse
+  | StopSequence
+  | Refusal
+  | Compaction
+  | ContextWindowExceeded
+  | Unknown _ -> false
 ;;
 
 let validate_response
@@ -447,30 +430,21 @@ let%test "validate_response accepts matching ToolUse for Require_specific_tool" 
 ;;
 
 let%test "validate_response preserves first-match tool descriptor semantics" =
-  let descriptor perm =
-    Tool.
-      { kind = None
-      ; mutation_class = None
-      ; concurrency_class = None
-      ; permission = Some perm
-      ; evidence_role = None
-      ; shell = None
-      ; notes = []
-      ; examples = []
-      }
+  let tool content =
+    Tool.create ~name:"status" ~description:content ~parameters:[] (fun _ ->
+      Ok { content })
   in
-  let tool permission content =
-    Tool.create
-      ~descriptor:(descriptor permission)
-      ~name:"status"
-      ~description:content
-      ~parameters:[]
-      (fun _ -> Ok { content })
+  let first_match_only call =
+    match call.tool with
+    | Some tool when String.equal tool.schema.description "first descriptor" ->
+      Error "first descriptor used"
+    | Some _ -> Ok ()
+    | None -> Error "missing descriptor"
   in
   match
     validate_response
-      ~tools:[ tool Tool.ReadOnly "read-only first"; tool Tool.Write "write second" ]
-      ~required_tool_satisfaction:effectful_tool_satisfies
+      ~tools:[ tool "first descriptor"; tool "second descriptor" ]
+      ~required_tool_satisfaction:first_match_only
       ~contract:Require_tool_use
       { id = "r"
       ; model = "m"
@@ -482,7 +456,9 @@ let%test "validate_response preserves first-match tool descriptor semantics" =
   with
   | Error msg ->
     (try
-       let (_ : int) = Str.search_forward (Str.regexp_string "read-only") msg 0 in
+       let (_ : int) =
+         Str.search_forward (Str.regexp_string "first descriptor used") msg 0
+       in
        true
      with
      | Not_found -> false)
@@ -590,9 +566,7 @@ let%test "Require_tool_use accepts no-ToolUse response when stop_reason is MaxTo
   = Ok ()
 ;;
 
-let%test
-    "Require_tool_use accepts no-ToolUse response when stop_reason is PauseTurn"
-  =
+let%test "Require_tool_use accepts no-ToolUse response when stop_reason is PauseTurn" =
   validate_response
     ~contract:Require_tool_use
     { id = "r"
@@ -682,5 +656,5 @@ let%test "stop_reason_is_resumable classification" =
   && (not (stop_reason_is_resumable Refusal))
   && (not (stop_reason_is_resumable Compaction))
   && (not (stop_reason_is_resumable ContextWindowExceeded))
-  && (not (stop_reason_is_resumable (Unknown "anything-else")))
+  && not (stop_reason_is_resumable (Unknown "anything-else"))
 ;;

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -659,7 +659,13 @@ let test_agent_run_rejects_tool_use_when_tool_choice_is_none () =
   | Exit -> ()
 ;;
 
-let test_agent_run_strict_required_tool_rejects_read_only_tool () =
+let reject_status_call (call : Completion_contract.tool_call) =
+  if String.equal call.name "status"
+  then Error "custom predicate rejected status"
+  else Ok ()
+;;
+
+let test_agent_run_custom_required_tool_predicate_rejects_status_tool () =
   Eio_main.run
   @@ fun env ->
   try
@@ -674,7 +680,6 @@ let test_agent_run_strict_required_tool_rejects_read_only_tool () =
     in
     let status_tool =
       Tool.create
-        ~descriptor:(descriptor Tool.ReadOnly)
         ~name:"status"
         ~description:"Read current status"
         ~parameters:[]
@@ -684,26 +689,26 @@ let test_agent_run_strict_required_tool_rejects_read_only_tool () =
       make_agent
         ~net:env#net
         ~tools:[ status_tool ]
-        ~required_tool_satisfaction:Completion_contract.effectful_tool_satisfies
+        ~required_tool_satisfaction:reject_status_call
         ~tool_choice:Types.Any
         url
     in
-    match Agent.run ~sw agent "must use a productive tool" with
-    | Ok _ -> fail "expected read-only tool contract failure"
+    match Agent.run ~sw agent "must use a tool that passes the custom predicate" with
+    | Ok _ -> fail "expected custom predicate contract failure"
     | Error (Error.Agent (Error.CompletionContractViolation { contract; reason; _ })) ->
       check bool "contract" true (contract = Completion_contract.Require_tool_use);
       check
         bool
-        "reason mentions read-only"
+        "reason mentions custom predicate"
         true
-        (contains_substring ~needle:"read-only" reason);
+        (contains_substring ~needle:"custom predicate rejected status" reason);
       Eio.Switch.fail sw Exit
     | Error e -> fail (Error.to_string e)
   with
   | Exit -> ()
 ;;
 
-let test_agent_run_strict_required_tool_allows_write_tool () =
+let test_agent_run_custom_required_tool_predicate_allows_other_tool () =
   let write_tool =
     Tool.create
       ~descriptor:(descriptor Tool.Write)
@@ -725,7 +730,7 @@ let test_agent_run_strict_required_tool_allows_write_tool () =
   match
     Completion_contract.validate_response
       ~tools:[ write_tool ]
-      ~required_tool_satisfaction:Completion_contract.effectful_tool_satisfies
+      ~required_tool_satisfaction:reject_status_call
       ~contract:Completion_contract.Require_tool_use
       response
   with
@@ -733,7 +738,7 @@ let test_agent_run_strict_required_tool_allows_write_tool () =
   | Error e -> fail e
 ;;
 
-let test_agent_run_strict_specific_tool_rejects_read_only_match () =
+let test_agent_run_custom_specific_tool_predicate_rejects_match () =
   Eio_main.run
   @@ fun env ->
   try
@@ -748,7 +753,6 @@ let test_agent_run_strict_specific_tool_rejects_read_only_match () =
     in
     let status_tool =
       Tool.create
-        ~descriptor:(descriptor Tool.ReadOnly)
         ~name:"status"
         ~description:"Read current status"
         ~parameters:[]
@@ -758,12 +762,12 @@ let test_agent_run_strict_specific_tool_rejects_read_only_match () =
       make_agent
         ~net:env#net
         ~tools:[ status_tool ]
-        ~required_tool_satisfaction:Completion_contract.effectful_tool_satisfies
+        ~required_tool_satisfaction:reject_status_call
         ~tool_choice:(Types.Tool "status")
         url
     in
     match Agent.run ~sw agent "must use status" with
-    | Ok _ -> fail "expected read-only specific-tool contract failure"
+    | Ok _ -> fail "expected custom predicate specific-tool contract failure"
     | Error (Error.Agent (Error.CompletionContractViolation { contract; reason; _ })) ->
       check
         bool
@@ -774,7 +778,7 @@ let test_agent_run_strict_specific_tool_rejects_read_only_match () =
         bool
         "reason mentions predicate"
         true
-        (contains_substring ~needle:"predicate" reason);
+        (contains_substring ~needle:"custom predicate rejected status" reason);
       Eio.Switch.fail sw Exit
     | Error e -> fail (Error.to_string e)
   with
@@ -1490,17 +1494,17 @@ let () =
             `Quick
             test_agent_run_rejects_tool_use_when_tool_choice_is_none
         ; test_case
-            "strict tool_choice any rejects read-only tool"
+            "custom required predicate rejects matching tool"
             `Quick
-            test_agent_run_strict_required_tool_rejects_read_only_tool
+            test_agent_run_custom_required_tool_predicate_rejects_status_tool
         ; test_case
-            "strict tool_choice any allows write tool"
+            "custom required predicate allows other tool"
             `Quick
-            test_agent_run_strict_required_tool_allows_write_tool
+            test_agent_run_custom_required_tool_predicate_allows_other_tool
         ; test_case
-            "strict tool_choice tool rejects read-only match"
+            "custom specific-tool predicate rejects match"
             `Quick
-            test_agent_run_strict_specific_tool_rejects_read_only_match
+            test_agent_run_custom_specific_tool_predicate_rejects_match
         ; test_case "tool error" `Quick test_agent_run_tool_error
         ; test_case
             "validation retry success"

--- a/test/test_completion_contract_violation.ml
+++ b/test/test_completion_contract_violation.ml
@@ -23,22 +23,6 @@ let make_tool name =
   Tool.create ~name ~description:("desc:" ^ name) ~parameters:[] noop_handler
 ;;
 
-let read_only_tool name =
-  let descriptor =
-    Tool.
-      { kind = None
-      ; mutation_class = None
-      ; concurrency_class = None
-      ; permission = Some ReadOnly
-      ; evidence_role = None
-      ; shell = None
-      ; notes = []
-      ; examples = []
-      }
-  in
-  Tool.create ~descriptor ~name ~description:("desc:" ^ name) ~parameters:[] noop_handler
-;;
-
 (* --- violation_detail_to_string --- *)
 
 let test_to_string_with_satisfying_tools () =
@@ -46,7 +30,7 @@ let test_to_string_with_satisfying_tools () =
     Completion_contract.
       { called_tools = [ "search" ]
       ; satisfying_tools = [ "keeper_bash"; "keeper_write" ]
-      ; rejection_reasons = [ "search", "read-only and cannot satisfy" ]
+      ; rejection_reasons = [ "search", "custom predicate rejected search" ]
       }
   in
   let s = Completion_contract.violation_detail_to_string detail in
@@ -190,7 +174,12 @@ let test_detail_on_failure_no_calls () =
 ;;
 
 let test_detail_with_rejected_calls () =
-  let tool = read_only_tool "search" in
+  let reject_search_call (call : Completion_contract.tool_call) =
+    if String.equal call.name "search"
+    then Error "custom predicate rejected search"
+    else Ok ()
+  in
+  let tool = make_tool "search" in
   let response =
     make_response
       ~content:[ Lp.ToolUse { id = "c1"; name = "search"; input = `Assoc [] } ]
@@ -198,7 +187,7 @@ let test_detail_with_rejected_calls () =
   match
     Completion_contract.violation_detail_of_response
       ~tools:[ tool ]
-      ~required_tool_satisfaction:Completion_contract.effectful_tool_satisfies
+      ~required_tool_satisfaction:reject_search_call
       ~satisfying_tools:[ "keeper_bash" ]
       ~contract:Completion_contract.Require_tool_use
       response
@@ -208,14 +197,18 @@ let test_detail_with_rejected_calls () =
     Alcotest.(check int) "satisfying_tools has 1" 1 (List.length detail.satisfying_tools);
     (match detail.rejection_reasons with
      | [ ("search", reason) ] ->
-       let has_readonly =
+       let has_custom_reason =
          try
-           ignore (Str.search_forward (Str.regexp_string "read-only") reason 0);
+           ignore
+             (Str.search_forward
+                (Str.regexp_string "custom predicate rejected search")
+                reason
+                0);
            true
          with
          | Not_found -> false
        in
-       Alcotest.(check bool) "reason mentions read-only" true has_readonly
+       Alcotest.(check bool) "reason mentions custom predicate" true has_custom_reason
      | _ -> Alcotest.fail "expected single rejection reason for 'search'")
   | Ok () -> Alcotest.fail "expected Error"
 ;;

--- a/test/test_mcp.ml
+++ b/test/test_mcp.ml
@@ -180,9 +180,8 @@ let test_mcp_tool_to_sdk_tool () =
    to auto-fill descriptors based on builtin tool names ("read_file", "write",
    "web_fetch") via the CDAL Mode_enforcer.builtin_descriptor registry —
    precisely the boundary RFC-OAS-009 v2 closes. Per RFC §2.2, descriptor is
-   now consumer-supplied. The Completion_contract.effectful_tool_satisfies
-   coverage that lived inside this function is independent of the bridge and
-   remains validated by Tool.permission paths in other test suites. *)
+   now consumer-supplied. Completion-contract satisfaction predicates are
+   validated independently of the MCP bridge. *)
 
 let test_mcp_tool_bridge_error () =
   let mcp_tool : Mcp.mcp_tool =


### PR DESCRIPTION
## Summary
- Removes the public `effectful_tool_satisfies` helper so OAS no longer exposes read-only-vs-mutating required-tool satisfaction as a built-in policy.
- Keeps `required_tool_satisfaction` as a caller-supplied extension point, with the default remaining `any_tool_call_satisfies`.
- Updates completion-contract and pipeline tests to validate custom predicates instead of strict read-only rejection semantics.

## Validation
- `ocamlformat --check lib/completion_contract.ml test/test_completion_contract_violation.ml test/test_mcp.ml test/test_agent_pipeline.ml`
- `git diff --check`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-pr-tool-choice dune build --root . test/test_completion_contract_violation.exe test/test_agent_pipeline.exe test/test_mcp.exe`
- `./_build-codex-pr-tool-choice/default/test/test_completion_contract_violation.exe`
- `./_build-codex-pr-tool-choice/default/test/test_mcp.exe`
- `./_build-codex-pr-tool-choice/default/test/test_agent_pipeline.exe` (ran outside sandbox because it binds localhost mock servers)