### PR TITLE
docs(pipeline): fix .mli stage diagram to match actual run_turn order

### DIFF
--- a/lib/pipeline/pipeline.mli
+++ b/lib/pipeline/pipeline.mli
@@ -1,6 +1,7 @@
 (** Turn pipeline: 6-stage decomposition of agent turn execution.
 
-    [Input] -> [Parse] -> [Route] -> [Execute] -> [Collect] -> [Output]
+    [Input] -> [Parse] -> [Route] -> [Collect] -> [Output]
+    (Execute runs inside Output on StopToolUse.)
 
     Each stage is a well-defined function.  The pipeline coordinates
     them, threading agent state through mutable updates.  This module


### PR DESCRIPTION
## 목적

OAS 실구현 체크 루프의 첫 라운드. carryover 주석 버그 1건 수정 + 코드 finding 2건 보고.

## 수정 (BUG1 — 주석, 컴파일 무관)

`lib/pipeline/pipeline.mli` 모듈-doc 다이어그램이 실제 실행 순서와 모순:
- doc: `[Input] -> [Parse] -> [Route] -> [Execute] -> [Collect] -> [Output]`
- 실제 `run_turn`: `stage_collect`(pipeline.ml:1223) → `stage_output`(1226), `stage_execute`는 `stage_output` **내부**(730)에서 StopToolUse 시 실행.
- pipeline.ml 자체 주석(Collect=4, Execute=5)과도, architecture.md와도 모순.
- → `[Input] -> [Parse] -> [Route] -> [Collect] -> [Output]` + "Execute runs inside Output" note로 정정 (architecture.md와 일치).

`ocamlformat --check` clean.

## 코드 finding (이 PR 범위 밖 — 별도 추적)

실구현 헌팅 중 발견. 단순 fix가 아니라 의도 확인/테스트가 필요해 보류:

### Finding A: example-capability-manifest.json — base_label 키 + invalid 값 + silent default (2겹+안티패턴)
- `docs/example-capability-manifest.json`은 `OAS_CAPABILITY_MANIFEST` env var로 **실제 로드되는** manifest (line 2 `_comment`).
- (1) 키 `"base_label"`을 쓰나 parser `capability_manifest.ml:103`은 `"base"` 키를 읽음 (schema.json도 `base`) → base preset 미적용.
- (2) 값 `provider_d_chat`/`cli_tool_a`는 `capabilities_for_provider_label`(capabilities.ml:950-964) valid label이 **아님** (provider_d는 있으나 provider_d_chat은 exact-match 실패).
- (3) `apply_manifest_entry`(capabilities.ml:35-37 of that block)는 invalid label을 `| None -> default_capabilities`로 **silent 처리** (warn 없음) — CLAUDE.md 안티패턴 #2(unknown→permissive default).
- 키만 고쳐도 값이 invalid라 lookup→default(동작 무변). 진짜 의도(어느 preset)는 RFC-OAS-023 §5.3 작성자만 앎 → 추측 금지. 근본 fix는 silent-default를 typed-warn/error로 + example 값을 valid label로.

## 검증

- comment-only, 컴파일 무관. Draft PR (agent는 Ready 금지, 사용자 머지).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
