### PR TITLE
fix: restore green main (ocamlformat drift + SDK independence)

### DIFF
--- a/lib/api_zai.ml
+++ b/lib/api_zai.ml
@@ -410,8 +410,7 @@ let%test "parse_image_generation rejects malformed json" =
 
 let%test "parse_async_submit handles basic body" =
   match
-    parse_async_submit
-      {|{"model":"glm-image","id":"job-1","task_status":"PROCESSING"}|}
+    parse_async_submit {|{"model":"glm-image","id":"job-1","task_status":"PROCESSING"}|}
   with
   | Ok result -> result.id = "job-1" && result.task_status = Processing
   | Error _ -> false
@@ -472,10 +471,7 @@ let%test "parse_transcription handles sync response" =
 
 let%test "multipart_body reports missing file path" =
   match
-    multipart_body
-      ~model:"glm-asr-2512"
-      ~source:(File_path "/nonexistent/file.wav")
-      ()
+    multipart_body ~model:"glm-asr-2512" ~source:(File_path "/nonexistent/file.wav") ()
   with
   | Error _ -> true
   | Ok _ -> false

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -30,8 +30,7 @@ let build_request
        ]
      | _ -> [])
     @ List.concat_map
-        (Backend_openai_serialize.ollama_messages_of_message
-           ~model_id:config.model_id)
+        (Backend_openai_serialize.ollama_messages_of_message ~model_id:config.model_id)
         messages
   in
   let body = [ "model", `String config.model_id; "messages", `List provider_messages ] in
@@ -104,8 +103,7 @@ let build_request
     match tools with
     | [] -> body
     | ts ->
-      ( "tools"
-      , `List (List.map Backend_openai_serialize.build_provider_d_tool_json ts) )
+      ("tools", `List (List.map Backend_openai_serialize.build_provider_d_tool_json ts))
       :: body
   in
   (* Sampling parameters go inside Ollama's "options" object.

--- a/lib/llm_provider/backend_tool_call_harness.ml
+++ b/lib/llm_provider/backend_tool_call_harness.ml
@@ -187,7 +187,12 @@ let schema_tool_call_check schema_lookup = function
 
 let stop_reason_matches_tool_calls ~has_tool_calls = function
   | StopToolUse -> has_tool_calls
-  | EndTurn | MaxTokens | StopSequence | Refusal | PauseTurn | Compaction
+  | EndTurn
+  | MaxTokens
+  | StopSequence
+  | Refusal
+  | PauseTurn
+  | Compaction
   | ContextWindowExceeded -> not has_tool_calls
   | Unknown _ -> false
 ;;

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1459,9 +1459,7 @@ let%test "capabilities_for_provider_label: aliases resolve to identical capabili
       && ca.thinking_control_format = cb.thinking_control_format
     | _ -> false
   in
-  let alias_pairs =
-    [ "provider_d", "openai_chat"; "provider_k", "provider_k-coding" ]
-  in
+  let alias_pairs = [ "provider_d", "openai_chat"; "provider_k", "provider_k-coding" ] in
   List.for_all (fun (a, b) -> same_base a b) alias_pairs
   && Option.is_some (resolve "anthropic")
   && Option.is_some (resolve "provider_f")
@@ -1495,9 +1493,7 @@ let%test "capabilities_for_provider_label: all declared labels resolve" =
 let%test
     "capabilities_for_provider_label: no accidental aliasing across distinct providers"
   =
-  let non_aliased =
-    [ "anthropic"; "provider_f"; "ollama"; "provider_c"; "provider_l" ]
-  in
+  let non_aliased = [ "anthropic"; "provider_f"; "ollama"; "provider_c"; "provider_l" ] in
   let fingerprints =
     List.filter_map
       (fun l ->

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -539,8 +539,7 @@ let complete_http
           -> Backend_openai.build_request ~config ~messages ~tools ()
         | Provider_config.Gemini ->
           Backend_gemini.build_request ~config ~messages ~tools ()
-        | Provider_config.Glm ->
-          Backend_glm.build_request ~config ~messages ~tools ()
+        | Provider_config.Glm -> Backend_glm.build_request ~config ~messages ~tools ()
       in
       let url =
         match config.kind with
@@ -697,9 +696,7 @@ let complete_http
                 | Provider_config.OpenAI_compat
                 | Provider_config.DashScope
                 | Provider_config.Kimi ->
-                  (match
-                     Backend_openai_parse.parse_openai_response_result body
-                   with
+                  (match Backend_openai_parse.parse_openai_response_result body with
                    | Ok resp -> Ok resp
                    | Error msg -> Error (Http_client.HttpError { code = 400; body = msg }))
                 | Provider_config.Gemini ->

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -323,9 +323,7 @@ let create_openai_stream_state ?(provider = "") ?(model = "") () =
 (** Convert a parsed {!provider_d_chunk} into {!sse_event} list.
     Synthesizes [ContentBlockStart] events on first occurrence of
     text content or each new tool_call index. *)
-let openai_chunk_to_events
-      (state : provider_d_stream_state)
-      (chunk : provider_d_chunk)
+let openai_chunk_to_events (state : provider_d_stream_state) (chunk : provider_d_chunk)
   : sse_event list * Telemetry_event.t option
   =
   let events = ref [] in
@@ -686,7 +684,7 @@ let parse_ollama_ndjson_chunk data_str : ollama_chunk option =
     (* Token-count usage. Ollama only emits these on the done chunk.
        When both counts are zero we return None, matching the
        non-streaming path in [Backend_ollama.parse_ollama_response]
-       so that downstream (MASC usage-trust classification) sees
+       so that a downstream consumer's usage-trust classification sees
        [Usage_missing] instead of [zero_token_usage_reported]. *)
     let oll_usage =
       let input = json |> member "prompt_eval_count" |> to_int_option in

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -83,12 +83,7 @@ let of_config (provider_cfg : Provider.config) : provider_module =
         | Provider.Anthropic_messages ->
           Yojson.Safe.to_string
             (`Assoc
-                (Api_anthropic.build_body_assoc
-                   ~config
-                   ~messages
-                   ?tools
-                   ~stream:false
-                   ()))
+                (Api_anthropic.build_body_assoc ~config ~messages ?tools ~stream:false ()))
         | Provider.Openai_chat_completions ->
           Api_openai.build_openai_body
             ~provider_config:provider_cfg

--- a/test/test_agent_registry.ml
+++ b/test/test_agent_registry.ml
@@ -209,7 +209,11 @@ let test_list_by_tool () =
     ; supported_interfaces = []
     ; capabilities = [ Tools ]
     ; tools =
-        [ { name = "get_weather"; description = "Weather"; parameters = []; strict = None }
+        [ { name = "get_weather"
+          ; description = "Weather"
+          ; parameters = []
+          ; strict = None
+          }
         ]
     ; skills = []
     ; supported_providers = []

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -173,8 +173,7 @@ let pp_static_model_route ppf = function
   | Capabilities.Provider_d_4_1 -> Format.fprintf ppf "Provider_d_4_1"
   | Capabilities.Provider_d_4o -> Format.fprintf ppf "Provider_d_4o"
   | Capabilities.Mimo_v2_5_chat -> Format.fprintf ppf "Mimo_v2_5_chat"
-  | Capabilities.Gemini family ->
-    Format.fprintf ppf "Gemini(%a)" pp_gemini_family family
+  | Capabilities.Gemini family -> Format.fprintf ppf "Gemini(%a)" pp_gemini_family family
   | Capabilities.Kimi_for_coding -> Format.fprintf ppf "Kimi_for_coding"
   | Capabilities.Kimi_k2 -> Format.fprintf ppf "Kimi_k2"
   | Capabilities.DashScope_3 -> Format.fprintf ppf "DashScope_3"
@@ -269,11 +268,7 @@ let test_gemini_family_drives_capabilities () =
     "provider_f-3.1-pro-preview ctx"
     (Some 1_000_000)
     (ctx "gemini-3.1-pro-preview");
-  check
-    (option int)
-    "provider_f-2.5-flash ctx"
-    (Some 1_000_000)
-    (ctx "gemini-2.5-flash")
+  check (option int) "provider_f-2.5-flash ctx" (Some 1_000_000) (ctx "gemini-2.5-flash")
 ;;
 
 let test_static_model_route_normalizes_cloud_suffix () =
@@ -731,8 +726,7 @@ let test_dashscope_capabilities () =
 
 let test_openai_compat_reasoning_records_have_explicit_control () =
   let cases =
-    [ ( "openai_chat_extended"
-      , Some Capabilities.openai_compat_chat_extended_capabilities )
+    [ "openai_chat_extended", Some Capabilities.openai_compat_chat_extended_capabilities
     ; "provider_c", Some Capabilities.kimi_capabilities
     ; "provider_h", Some Capabilities.dashscope_capabilities
     ; "mimo-v2.5-pro", Capabilities.for_model_id "mimo-v2.5-pro"

--- a/test/test_llm_call.ml
+++ b/test/test_llm_call.ml
@@ -56,7 +56,11 @@ let run_live_test () =
        | Types.StopToolUse -> "tool_use"
        | Types.MaxTokens -> "max_tokens"
        | Types.StopSequence -> "stop_sequence"
-       | Types.Refusal -> "refusal" | Types.PauseTurn -> "pause_turn" | Types.Compaction -> "compaction" | Types.ContextWindowExceeded -> "model_context_window_exceeded" | Types.Unknown s -> s);
+       | Types.Refusal -> "refusal"
+       | Types.PauseTurn -> "pause_turn"
+       | Types.Compaction -> "compaction"
+       | Types.ContextWindowExceeded -> "model_context_window_exceeded"
+       | Types.Unknown s -> s);
     List.iter
       (fun block ->
          match block with


### PR DESCRIPTION
## 목적

origin/main (`8791f9b6`) 이 **2개 required CI check 에서 red** 상태였습니다 (broken main). 두 원인 모두 Draft-merge 로 게이트를 통과해 머지된 최근 PR 에서 유입되었고, 이를 고치는 in-flight PR 은 없었습니다.

`gh run list --branch main --workflow CI` → 최신 main run conclusion = **failure**, 실패 job 2개:
- `OCaml Format`
- `SDK Independence Gate`

## 원인과 수정

### 1. OCaml Format (10파일 drift → 9 + streaming)
`.ocamlformat` 핀 (0.29.0, janestreet) 기준으로 10개 파일이 drift. 로컬/CI ocamlformat 버전 동일(0.29.0) 확인 후 `dune build @fmt --auto-promote` 로 기계적 재포맷. **동작 변경 없음** (줄바꿈/병합만).

대상: `api_zai.ml`, `provider_intf.ml`, `llm_provider/{capabilities,complete,streaming,backend_ollama,backend_tool_call_harness}.ml`, `test/{test_agent_registry,test_capabilities,test_llm_call}.ml`.

### 2. SDK Independence Gate (1줄 주석)
`lib/llm_provider/streaming.ml` 의 주석이 다운스트림 coordinator 를 `MASC` 로 호명 → 게이트의 `\bmasc\b` (lib/ strict tier) 에 적발 (#1848 유입). OAS 는 coordinator-specific 개념을 참조하면 안 되므로 **이름만 제거**:

```
- so that downstream (MASC usage-trust classification) sees
+ so that a downstream consumer's usage-trust classification sees
```

동작 근거(zero count 시 `None` 반환 → 소비자가 `zero_token_usage_reported` 아닌 `Usage_missing` 를 보게 함)는 그대로 보존.

> 게이트의 `boundary-allow` 화이트리스트는 **쓰지 않았습니다**. 화이트리스트는 SDK 에서 coordinator 참조를 제거하지 않고 게이트만 통과시키는 우회(워크어라운드)이기 때문입니다.

`lib bin README.md` 전수 스캔(`rg -ni '\b(masc|keeper|board|room)\b'`)으로 strict-tier hit 가 이 1건뿐임을 확인 — N-of-M 부분수정 아님.

## 검증 (로컬, Draft 는 해당 CI job 들을 skip)

- `scripts/check-sdk-independence.sh` → **exit 0** (`OK: SDK independence check passed`)
- `dune build @fmt` → **exit 0**
- `dune build lib` → **exit 0**

diff 는 10파일 순수 포맷 + 주석 1줄. 로직 변경 0.

## 범위 밖 (후속 메모)

`#1848`/`#1851` 이 이 게이트들이 red 인 채로 머지된 정황 → Draft-merge 가 required job 을 통과시키는 구조. 본 PR 범위 밖이며 별도 추적 예정.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
