### PR TITLE
refactor(handoff): make target_name_of_tool total (parse, don't validate)

### DIFF
--- a/lib/agent/agent_handoff.ml
+++ b/lib/agent/agent_handoff.ml
@@ -20,17 +20,19 @@ let find_handoff_in_messages messages =
          | Some _ -> acc
          | None ->
            (match block with
-            | ToolUse { id; name; input } when Handoff.is_handoff_tool name ->
-              let target_name = Handoff.target_name_of_tool name in
-              let prompt =
-                match input with
-                | `Assoc pairs ->
-                  (match List.assoc_opt "prompt" pairs with
-                   | Some (`String s) -> s
-                   | _ -> "Continue the conversation.")
-                | _ -> "Continue the conversation."
-              in
-              Some (id, target_name, prompt)
+            | ToolUse { id; name; input } ->
+              (match Handoff.target_name_of_tool name with
+               | Some target_name ->
+                 let prompt =
+                   match input with
+                   | `Assoc pairs ->
+                     (match List.assoc_opt "prompt" pairs with
+                      | Some (`String s) -> s
+                      | _ -> "Continue the conversation.")
+                   | _ -> "Continue the conversation."
+                 in
+                 Some (id, target_name, prompt)
+               | None -> None)
             | _ -> None))
       None
       assistant_message.content

--- a/lib/handoff.ml
+++ b/lib/handoff.ml
@@ -32,16 +32,61 @@ type delegate_fn =
 (** Prefix used to identify handoff tools in ToolUse blocks *)
 let handoff_prefix = "transfer_to_"
 
-(** Check if a tool name is a handoff tool *)
-let is_handoff_tool name =
-  let prefix_len = String.length handoff_prefix in
-  String.length name >= prefix_len && String.sub name 0 prefix_len = handoff_prefix
-;;
+(** Extract the handoff target name from a tool name, if it is a handoff tool.
 
-(** Extract target name from handoff tool name *)
+    Returns [Some suffix] when [name] starts with [handoff_prefix]; the suffix
+    may be empty, so the bare prefix ["transfer_to_"] yields [Some ""]. Returns
+    [None] otherwise.
+
+    Folding the prefix check and the suffix extraction into one function makes
+    this total: there is no input for which it raises [Invalid_argument]. The
+    earlier split — [is_handoff_tool] (guard) followed by a separate
+    [target_name_of_tool] that called [String.sub] assuming the guard held —
+    re-scanned the prefix and raised on undersized input if ever called without
+    the guard (parse, don't validate). *)
 let target_name_of_tool name =
   let prefix_len = String.length handoff_prefix in
-  String.sub name prefix_len (String.length name - prefix_len)
+  if String.length name >= prefix_len && String.sub name 0 prefix_len = handoff_prefix
+  then Some (String.sub name prefix_len (String.length name - prefix_len))
+  else None
+;;
+
+let%test "target_name_of_tool: extracts suffix after prefix" =
+  target_name_of_tool "transfer_to_researcher" = Some "researcher"
+;;
+
+let%test "target_name_of_tool: bare prefix yields empty suffix" =
+  (* Preserves the prior [is_handoff_tool] [>=] semantics: [name] of exactly
+     the prefix length still matches, with an empty target name. *)
+  target_name_of_tool "transfer_to_" = Some ""
+;;
+
+let%test "target_name_of_tool: non-handoff name is None" =
+  target_name_of_tool "get_weather" = None
+;;
+
+let%test "target_name_of_tool: undersized input is None, never raises" =
+  (* ["x"] is shorter than the 12-char prefix; the previous partial
+     implementation raised [Invalid_argument] on this input. *)
+  target_name_of_tool "x" = None
+;;
+
+let%test "target_name_of_tool: total across the prefix-length boundary" =
+  (* The only prior failure mode was [String.sub] with a negative length when
+     [String.length name < prefix_len]. Sweep lengths spanning the prefix
+     boundary plus near-miss prefixes and assert no input raises. *)
+  let raises s =
+    try
+      ignore (target_name_of_tool s);
+      false
+    with
+    | _ -> true
+  in
+  let samples =
+    List.init 25 (fun n -> String.make n 'a')
+    @ [ ""; handoff_prefix; handoff_prefix ^ "y"; "transfer_to"; "transfer_t" ]
+  in
+  not (List.exists raises samples)
 ;;
 
 (** Create a handoff tool visible to the LLM.


### PR DESCRIPTION
## 목적 (hardening, not a crash fix)

`Handoff.target_name_of_tool` 는 partial function 이었습니다:

```ocaml
let target_name_of_tool name =
  let prefix_len = String.length handoff_prefix in        (* "transfer_to_" = 12 *)
  String.sub name prefix_len (String.length name - prefix_len)
;;
```

`name` 이 prefix 보다 짧으면 length 인자가 음수 → `String.sub` 가 `Invalid_argument` 를 raise 합니다 (로컬에서 `target_name_of_tool "short"` → `Invalid_argument "String.sub / Bytes.sub"` 재현 확인).

단, 유일한 호출자 `Agent_handoff.find_handoff_in_messages` 가 `when Handoff.is_handoff_tool name` 으로 먼저 가드하므로 **이 crash 는 현재 도달 불가능**합니다. 본 PR 은 live crash 를 고치는 게 아니라 **latent partial function 을 total 로 경화**합니다 (`rg` 로 caller 가 그 1곳뿐임 확인).

## 변경 (Parse, don't validate)

`is_handoff_tool` (validate) + `target_name_of_tool` (extract) 의 validate-then-extract 쌍을 **하나의 total 함수**로 통합:

```ocaml
val target_name_of_tool : string -> string option
(* Some suffix  — prefix 매칭 시 (bare prefix "transfer_to_" → Some "", 기존 >= 의미 보존)
   None         — 그 외 *)
```

- `String.sub` precondition 을 타입상 표현 불가능한 실패로 만듦 (어떤 입력에도 raise 없음).
- 중복 prefix 스캔(가드 1회 + 추출 1회) 제거.
- `is_handoff_tool` 은 fan-in 0 이 되어 **제거** (이동/보존 아님).
- 단일 호출자를 `match ... with Some target_name -> ... | None -> None` 로 갱신 — 비-handoff ToolUse 와 비-ToolUse 는 동일하게 `None` (동작 동일).

## 검증

inline `let%test` 추가 (lib 가 `(inline_tests)` 활성):
- prefix 뒤 suffix 추출 / bare prefix → `Some ""` / 비-handoff → `None`
- undersized 입력 → `None` (구버전이 raise 하던 입력)
- prefix-length 경계 전수 sweep: 어떤 입력도 raise 안 함

로컬:
- `dune build lib` → exit 0
- `dune build @lib/runtest` → exit 0 (신규 5 case 포함 전체 통과)
- `test_agent` → 20/20 (기존 `find_handoff` 6 case 전부 그대로 통과 = 호출자 동작 보존)

SDK Independence Gate: 변경 파일에 coordinator term 0. (`lib bin README.md` strict-tier hit 는 무관한 #1852 에서 처리.)

## 머지 순서

base 가 origin/main 인데, main 은 현재 `OCaml Format`/`SDK Independence` red 입니다 → **#1852 (restore green main) 머지 후** 이 PR 을 Ready 로 전환해야 게이트가 정상 통과합니다. (Draft 동안은 해당 job 들이 skip 됨.)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
