### PR TITLE
docs(pipeline): align .ml stage header with .mli (Execute is inside Output)

### DIFF
--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -6,7 +6,12 @@
     3. Route   — provider selection, API call dispatch (sync/stream)
     4. Collect — usage accumulation, AfterTurn hook, events, message append
     5. Execute — tool execution on StopToolUse (idle detection, guardrails)
-    6. Output  — stop reason → turn_outcome *)
+    6. Output  — stop reason → turn_outcome
+
+    [Output] ([stage_output]) dispatches [Execute] ([stage_execute]) internally
+    on StopToolUse, so Execute is a sub-step of Output, not a stage that runs
+    between Collect and Output. This matches the dataflow diagram in
+    pipeline.mli: [Input] -> [Parse] -> [Route] -> [Collect] -> [Output]. *)
 
 module Retry = Llm_provider.Retry
 open Types


### PR DESCRIPTION
## 목적

`lib/pipeline/pipeline.ml` 헤더 주석과 `pipeline.mli` 다이어그램이 stage 순서를 서로 다르게 서술하던 모순을 해소합니다. 실제 코드(`stage_output`)를 ground truth로 삼아 `.ml`을 `.mli`/코드에 맞춥니다.

## 근거 (file:line 직접 확인, origin/main 468e78dd)

- `pipeline.ml:1-9` 헤더는 `4. Collect → 5. Execute → 6. Output` 번호 리스트라, Execute가 Collect와 Output **사이의 별도 stage**로 읽힙니다.
- 실제 control flow는 반대입니다: `stage_execute`의 호출처는 전 트리에서 **단 한 곳** — `pipeline.ml:730`, `stage_output`의 `StopToolUse` 분기 내부입니다. (`git grep stage_execute` 결과 정의 1 + 호출 1뿐, `.mli` 미노출.)
- 즉 Execute는 Output이 `StopToolUse`에서 내부 dispatch하는 sub-step이지, Output 앞에 실행되는 stage가 아닙니다.
- PR #1851이 `pipeline.mli` 다이어그램을 이 사실에 맞게 고쳤으나(`(Execute runs inside Output on StopToolUse.)`), sibling `.ml` 헤더는 옛 순서를 그대로 두어 두 파일이 어긋난 상태였습니다.

## 변경

`.ml` 헤더에 runtime 관계를 명시하는 문단 추가 (주석 전용, 코드 변경 0):

> `[Output]` (`stage_output`) dispatches `[Execute]` (`stage_execute`) internally on StopToolUse, so Execute is a sub-step of Output, not a stage that runs between Collect and Output. This matches the dataflow diagram in pipeline.mli.

번호 리스트(1–6)와 파일 내 `(* ── Stage N ── *)` 배너는 source-definition 순서라 그대로 두고, runtime dataflow만 별도 명시했습니다. 번호 매김의 *의도*는 추측하지 않았습니다.

## 로컬 검증 (Draft는 CI 게이트 skip → 로컬이 유일한 증거)

| 게이트 | 결과 |
|--------|------|
| `scripts/dune-local.sh build lib` | EXIT=0 |
| `scripts/dune-local.sh build @fmt` | EXIT=0 (drift 0, ocamlformat 0.29.0 == pin) |
| `scripts/check-sdk-independence.sh` | EXIT=0 |
| `scripts/dune-local.sh build @runtest` | EXIT=0 (전체 통과) |

## 워크어라운드 게이트 self-check

telemetry-as-fix / string-classifier / cap-cooldown-dedup-repair 비해당. 유일한 yellow flag는 N-of-M(#1851이 `.mli`만 수정)이나, prose 주석 2개에는 추출할 abstraction/codemod가 없으므로 워크어라운드 시그니처가 아닙니다. 본 PR은 #1851의 doc fix를 sibling 파일까지 완결하는 closure입니다.

## 관계

- #1851 (pipeline.mli 다이어그램 수정)의 follow-up이자 알려진 doc-order 모순의 명시적 closure.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)