### PR TITLE
refactor(eval): make check_thresholds total (parse, don't validate)

### DIFF
--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -389,33 +389,37 @@ let check_thresholds (rm : run_metrics) (thresholds : threshold list) : Harness.
          match List.find_opt (fun (m : metric) -> m.name = th.metric_name) rm.metrics with
          | None -> None
          | Some m ->
-           let violates_max =
+           (* Build each violation message where the threshold value is in
+              scope (parse, don't validate): the [Some v when violated]
+              guard carries [v] directly, eliminating the [Option.get] that
+              previously re-extracted it from [th.max_value]/[th.min_value]
+              under the invariant that the bool guard implied [Some]. Max
+              takes priority over min, as before. *)
+           let max_violation =
              match th.max_value with
-             | None -> false
-             | Some max_v -> numeric_threshold_violated ~compare:( > ) m.value max_v
+             | Some max_v when numeric_threshold_violated ~compare:( > ) m.value max_v ->
+               Some
+                 (Printf.sprintf
+                    "%s=%s exceeds max %s"
+                    th.metric_name
+                    (show_metric_value m.value)
+                    (show_metric_value max_v))
+             | _ -> None
            in
-           let violates_min =
+           let min_violation =
              match th.min_value with
-             | None -> false
-             | Some min_v -> numeric_threshold_violated ~compare:( < ) m.value min_v
+             | Some min_v when numeric_threshold_violated ~compare:( < ) m.value min_v ->
+               Some
+                 (Printf.sprintf
+                    "%s=%s below min %s"
+                    th.metric_name
+                    (show_metric_value m.value)
+                    (show_metric_value min_v))
+             | _ -> None
            in
-           if violates_max
-           then
-             Some
-               (Printf.sprintf
-                  "%s=%s exceeds max %s"
-                  th.metric_name
-                  (show_metric_value m.value)
-                  (show_metric_value (Option.get th.max_value)))
-           else if violates_min
-           then
-             Some
-               (Printf.sprintf
-                  "%s=%s below min %s"
-                  th.metric_name
-                  (show_metric_value m.value)
-                  (show_metric_value (Option.get th.min_value)))
-           else None)
+           (match max_violation with
+            | Some _ -> max_violation
+            | None -> min_violation))
       thresholds
   in
   let passed = violations = [] in


### PR DESCRIPTION
## 목적

`Eval.check_thresholds`에서 이미 바인딩한 threshold 값을 버린 뒤 `Option.get`으로 재추출하던 partial call 2곳을 제거해 함수를 총함수(total)로 만듭니다. "Parse, don't validate" 원칙 적용 — 값을 한 번 parse했으면 다시 validate/추출하지 않습니다.

## 근거 (file:line, origin/main f5215778)

`lib/eval.ml:392-418` 기존 구조:

```ocaml
let violates_max =
  match th.max_value with None -> false | Some max_v -> ... m.value max_v   (* max_v 바인딩 후 버림 *)
in
...
if violates_max
then Some (Printf.sprintf "%s=%s exceeds max %s" ... (show_metric_value (Option.get th.max_value)))  (* 재추출 *)
else if violates_min then Some (... (Option.get th.min_value)) else None
```

- `violates_max : bool`은 `Some max_v`를 바인딩해놓고 버린 뒤, 메시지 생성부에서 `Option.get th.max_value`로 **같은 값을 재추출**합니다 (min도 동일).
- `Option.get`은 partial 함수입니다. 현재는 "bool 가드가 `Some`을 함의한다"는 불변식 덕에 raise하지 않지만, 그 불변식이 코드와 분리돼 있어 미래 리팩토링이 가드와 추출을 어긋나게 하면 런타임 raise가 됩니다.

## 변경

각 violation 메시지를 값이 in-scope인 곳에서 직접 구성 (`Some v when violated -> Some msg | _ -> None`), `Option.get` 2개 제거:

```ocaml
let max_violation =
  match th.max_value with
  | Some max_v when numeric_threshold_violated ~compare:( > ) m.value max_v ->
    Some (Printf.sprintf "%s=%s exceeds max %s" th.metric_name (show_metric_value m.value) (show_metric_value max_v))
  | _ -> None
in
let min_violation = (* min 대칭 *) in
(match max_violation with Some _ -> max_violation | None -> min_violation)
```

## 동작 보존

- max > min 우선순위 동일 (`Some _ -> max_violation | None -> min_violation`).
- 메시지 문자열 byte-identical: `violates_max`가 true이면 `th.max_value = Some max_v`이므로 `show_metric_value max_v ≡ show_metric_value (Option.get th.max_value)`.
- `numeric_threshold_violated` 호출 횟수 동일 (순수 함수, 관측 가능한 차이 없음).
- `.mli` 시그니처 불변 (함수 body 내부 변경) → surgical.
- **기존 테스트로 검증**: `test_eval.ml:143/156/166` + `test_eval_coverage.ml:371/382/397`이 "exceeds max"/"below min" 메시지를 단언, @runtest green.

## 로컬 검증 (Draft는 CI 게이트 skip → 로컬이 유일 증거)

| 게이트 | 결과 |
|--------|------|
| `scripts/dune-local.sh build lib` | EXIT=0 |
| `scripts/dune-local.sh build @runtest` | EXIT=0 (전체 통과, eval 테스트 포함) |
| `scripts/check-sdk-independence.sh` | EXIT=0 |
| `scripts/dune-local.sh build @fmt` | EXIT=0 (drift 0) |

## 워크어라운드 게이트 self-check

비해당. 본 변경은 워크어라운드의 *반대* — partial 함수(`Option.get`) 2개를 제거해 totality를 높이는 parse-don't-validate 리팩토링입니다. string-classifier/telemetry-as-fix/N-of-M/cap-cooldown 어디에도 해당하지 않으며, RFC-게이트 subsystem(credential/operator/keeper/sandbox) 미접촉.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)