### PR TITLE
refactor(durable): make suspend exhaustive over execution_state (no catch-all)

### DIFF
--- a/lib/durable.ml
+++ b/lib/durable.ml
@@ -163,7 +163,11 @@ let suspend _t state ~reason =
   match state with
   | InProgress { current_step; journal; _ } ->
     Suspended { at_step = current_step; journal; reason }
-  | _ -> state
+  (* Only a running execution can be suspended; the other states are already
+     terminal or not-yet-running, so they pass through unchanged. Enumerated
+     explicitly (no [_] catch-all) so a future execution_state variant forces
+     a suspend decision at compile time. *)
+  | NotStarted | Suspended _ | Completed _ | Failed _ -> state
 ;;
 
 (* ── Serialization ────────────────────────────────── *)


### PR DESCRIPTION
## 목적

`Durable.suspend`가 closed 5-variant `execution_state`를 `_ -> state` catch-all로 매칭하던 것을, 나머지 변형을 명시 열거하도록 바꿉니다. FSM sparse-match 안티패턴(CLAUDE.md #4) 제거 — 미래에 `execution_state`에 변형이 추가되면 `suspend`가 컴파일 타임에 결정을 강제하도록.

## 근거 (file:line 직접 확인, origin/main 28973f6e)

- `execution_state` = closed 5-variant (`lib/durable.ml:18`): `NotStarted | InProgress | Suspended | Completed | Failed`.
- `suspend` (`lib/durable.ml:162`):

```ocaml
let suspend _t state ~reason =
  match state with
  | InProgress { current_step; journal; _ } -> Suspended { ... }
  | _ -> state          (* ← 4개 변형을 silent 흡수 *)
;;
```

- `_`가 덮는 건 정확히 `NotStarted | Suspended _ | Completed _ | Failed _`, 모두 `state`를 그대로 반환.
- 미래에 변형(예: 또 다른 in-flight 상태)이 추가되면, 그것도 silent하게 "non-suspendable, 무변경"으로 처리됨 → suspend 결정 누락이 런타임까지 숨음.

## 변경

```ocaml
  | NotStarted | Suspended _ | Completed _ | Failed _ -> state
```

명시 열거로 교체. 새 변형 추가 시 OCaml exhaustiveness check가 `suspend`에서 컴파일 에러를 일으켜 누락을 차단.

## 동작 보존

- 4개 변형이 현재 전부 `_ -> state`로 떨어지므로, 명시 열거도 **모든 기존 입력에 byte-identical** 결과.
- 빌드 성공 자체가 변형명 정확성 + 완전성 증명 (틀리거나 누락하면 exhaustiveness check가 컴파일 거부).
- `.mli:80` 시그니처 불변 (body-only).
- 파일의 sibling 매치(`is_terminal:59-61`, `resume`)는 이미 전 변형 명시 — `suspend`가 모듈 내 유일한 execution_state catch-all이었음. 본 변경은 local idiom 정합.

## 로컬 검증 (Draft는 CI 게이트 skip → 로컬이 유일 증거)

| 게이트 | 결과 |
|--------|------|
| `scripts/dune-local.sh build lib` | EXIT=0 |
| `scripts/dune-local.sh build @runtest` | EXIT=0 (durable 테스트 포함 전체 통과) |
| `scripts/check-sdk-independence.sh` | EXIT=0 |
| `scripts/dune-local.sh build @fmt` | EXIT=0 (drift 0) |

## 워크어라운드 게이트 self-check

비해당 — catch-all을 *제거*하고 exhaustive 명시로 교체하는 anti-pattern #4 root-fix (string-classifier/telemetry/cap-cooldown/N-of-M 아님). RFC-게이트 subsystem(credential/operator/keeper/sandbox) 미접촉.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)