### PR TITLE
refactor(provider): make pricing_for_provider exhaustive over provider (no catch-all)

### DIFF
--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -561,7 +561,11 @@ let pricing_for_model model_id =
 let pricing_for_provider ~(provider : provider) ~(model_id : string) =
   match provider with
   | Local _ -> zero_pricing
-  | _ -> pricing_for_model model_id
+  (* Cloud providers are priced by model id. Enumerated explicitly (no [_]
+     catch-all) so a future provider variant forces a pricing decision at
+     compile time rather than silently inheriting model-id pricing — e.g. a
+     new local-like backend that should be zero-priced. *)
+  | Anthropic | OpenAICompat _ | Custom_registered _ -> pricing_for_model model_id
 ;;
 
 let estimate_cost


### PR DESCRIPTION
## 목적

`Provider.pricing_for_provider`가 closed 4-variant `provider` 타입을 `_ -> pricing_for_model model_id` catch-all로 매칭하던 것을, cloud 변형을 명시 열거하도록 바꿉니다. FSM sparse-match 안티패턴(CLAUDE.md #4) 제거 — 비용 추정은 cost-critical이므로 미래 provider 변형이 컴파일 타임에 가격 결정을 강제하도록.

## 근거 (file:line 직접 확인, origin/main 78ab832a)

- `provider` = closed 4-variant (`lib/provider.ml:3`): `Local | Anthropic | OpenAICompat | Custom_registered`.
- `pricing_for_provider` (`lib/provider.ml:561`):

```ocaml
let pricing_for_provider ~provider ~model_id =
  match provider with
  | Local _ -> zero_pricing
  | _ -> pricing_for_model model_id     (* ← Anthropic|OpenAICompat|Custom_registered 흡수 *)
;;
```

- `_`가 덮는 건 정확히 `Anthropic | OpenAICompat _ | Custom_registered _`, 모두 `pricing_for_model model_id`로 라우팅.
- 미래에 local-like backend 변형(zero-priced여야 함)이 추가되면, `_`가 silent하게 cloud model-id 가격을 부과 → 비용 mis-estimation이 런타임까지 숨음.

## 변경

```ocaml
  | Anthropic | OpenAICompat _ | Custom_registered _ -> pricing_for_model model_id
```

명시 열거로 교체. 새 provider 변형 추가 시 OCaml exhaustiveness check가 컴파일 에러로 가격 결정을 강제.

## 동작 보존

- 3개 cloud 변형이 현재 전부 `_ -> pricing_for_model`로 떨어지므로, 명시 열거도 **byte-identical**. `Local`만 zero_pricing 유지 (불변).
- 빌드 성공 = 변형명 정확성 + 완전성 증명.
- `.mli:179` 시그니처 불변 (body-only).
- 어떤 변형의 *가격 값/정책*도 바꾸지 않음 → RFC-scope 아님 (#1859 durable.suspend와 동일 클래스의 순수 exhaustive 강화).

## 로컬 검증 (Draft는 CI 게이트 skip → 로컬이 유일 증거)

| 게이트 | 결과 |
|--------|------|
| `scripts/dune-local.sh build lib` | EXIT=0 |
| `scripts/dune-local.sh build @runtest` | EXIT=0 (pricing 테스트 포함 전체 통과) |
| `scripts/check-sdk-independence.sh` | EXIT=0 |
| `scripts/dune-local.sh build @fmt` | EXIT=0 (drift 0) |

## 워크어라운드 게이트 self-check

비해당 — catch-all 제거 + exhaustive 명시 교체(anti-pattern #4 root-fix). 별개 관찰: `pricing_for_model`의 `Option.value ~default:zero_pricing`(unknown model→0)은 anti-pattern #2 소지이나, 비용 추정은 unknown에 graceful degrade가 필요해 hard-fail 부적절 → 범위 밖. RFC-게이트 subsystem 미접촉.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)