### PR TITLE
refactor(eval_report): build generate over a match, dropping List.hd (parse, don't validate)

### DIFF
--- a/lib/eval_report.ml
+++ b/lib/eval_report.ml
@@ -19,8 +19,8 @@ type t =
 
 (** Generate a report from a baseline comparison and run metrics. *)
 let generate ?baseline (runs : Eval.run_metrics list) : t =
-  if runs = []
-  then
+  match runs with
+  | [] ->
     { agent_name = "unknown"
     ; run_count = 0
     ; evaluated_runs = 0
@@ -30,8 +30,7 @@ let generate ?baseline (runs : Eval.run_metrics list) : t =
     ; verdict = `Fail
     ; summary = "No runs to evaluate"
     }
-  else (
-    let first = List.hd runs in
+  | first :: _ ->
     let evaluated_runs =
       List.length
         (List.filter (fun (rm : Eval.run_metrics) -> rm.harness_verdicts <> []) runs)
@@ -87,7 +86,7 @@ let generate ?baseline (runs : Eval.run_metrics list) : t =
     ; comparison
     ; verdict
     ; summary
-    })
+    }
 ;;
 
 (** Serialize report to JSON. *)


### PR DESCRIPTION
## 목적

`Eval_report.generate`의 `if runs = []` 가드 + else 분기 `List.hd runs` partial 추출을, `match`로 재구조화해 partial 호출을 제거합니다. "Parse, don't validate" — 비어있음을 체크한 뒤 다시 head를 추출하지 않고, 패턴이 head를 직접 바인딩.

## 근거 (file:line 직접 확인, origin/main 5b00a166)

`lib/eval_report.ml:21-34` 기존 구조:

```ocaml
let generate ?baseline (runs : Eval.run_metrics list) : t =
  if runs = []
  then { ...; summary = "No runs to evaluate" }   (* 비어있음 체크, 바인딩 없음 *)
  else (
    let first = List.hd runs in                    (* partial 추출 *)
    ... )
```

- `if runs = []`는 emptiness만 확인하고 아무것도 바인딩하지 않은 뒤, else 분기에서 `List.hd runs`로 head를 추출 (validate-then-extract split).
- `List.hd`는 partial. 현재는 `if runs = []` else 분기라 안전하지만, 가드와 추출이 분리돼 있어 미래 리팩토링이 둘을 어긋나게 할 수 있음.

## 변경

```ocaml
let generate ?baseline (runs : Eval.run_metrics list) : t =
  match runs with
  | [] -> { ...; summary = "No runs to evaluate" }
  | first :: _ ->
    ... (* first는 패턴이 바인딩, runs는 파라미터로 그대로 in-scope *)
```

`if/else`를 `match`로 교체. head는 `first :: _` 패턴이 바인딩하고, 전체 `runs`는 함수 파라미터로 cons 분기에서 그대로 접근 가능 → `List.length runs`/`List.filter ... runs`/`pass_at_k runs` 전부 불변.

## 동작 보존

- `runs = []` ↔ `[]` 패턴 (동일한 "No runs to evaluate" 레코드).
- `else` ↔ `first :: _`, `first = List.hd runs` ↔ 패턴 바인딩된 `first` (동일 값).
- 빌드 성공 = 괄호 짝 + exhaustiveness 정확성 증명 (`else (...)` 괄호 블록을 match arm으로 전환).
- `.mli:20` 시그니처 불변 (body-only).
- 기존 `Eval_report`/`Eval_report_full` 테스트 green → 동작 보존 확인. #1857(eval check_thresholds)과 동일 parse-don't-validate class.

## 로컬 검증 (Draft는 CI 게이트 skip → 로컬이 유일 증거)

| 게이트 | 결과 |
|--------|------|
| `scripts/dune-local.sh build lib` | EXIT=0 |
| `scripts/dune-local.sh build @runtest` | EXIT=0 (Eval_report 테스트 포함 전체 통과) |
| `scripts/check-sdk-independence.sh` | EXIT=0 |
| `scripts/dune-local.sh build @fmt` | EXIT=0 (drift 0) |

## 워크어라운드 게이트 self-check

비해당 — partial 함수(`List.hd`) 제거로 totality를 높이는 parse-don't-validate 리팩토링 (string-classifier/telemetry/cap-cooldown/N-of-M 아님). RFC-게이트 subsystem 미접촉.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)