### PR TITLE
refactor(provider_registry): guard next_llama_endpoint against empty array (mirror sibling)

### DIFF
--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -167,8 +167,15 @@ let llama_rr_counter = Atomic.make 0
 let next_llama_endpoint () =
   let endpoints = Atomic.get llama_endpoints_ref in
   let n = Array.length endpoints in
-  let idx = Atomic.fetch_and_add llama_rr_counter 1 mod n in
-  endpoints.(idx)
+  (* Guard n = 0 like the sibling [current_llama_endpoint]: without it [_ mod n]
+     raises Division_by_zero. The array is non-empty for every reachable call
+     today (initial_llama_endpoints falls back to a singleton), so this only
+     makes the degenerate case total and consistent with the peer. *)
+  if n = 0
+  then ""
+  else (
+    let idx = Atomic.fetch_and_add llama_rr_counter 1 mod n in
+    endpoints.(idx))
 ;;
 
 (** Peek at the current llama endpoint without advancing the round-robin.


### PR DESCRIPTION
## 목적

`next_llama_endpoint`에 `n = 0` 가드를 추가해, 형제 함수 `current_llama_endpoint`와 일관되게 만들고 partial(`Division_by_zero`) 가능성을 제거합니다.

## 근거 (file:line 직접 확인, origin/main 961e1b04)

`lib/llm_provider/provider_registry.ml` — 같은 atomic array(`llama_endpoints_ref`)를 쓰는 두 형제 함수의 불일치:

```ocaml
let next_llama_endpoint () =                 (* line 167 — 가드 없음 *)
  let endpoints = Atomic.get llama_endpoints_ref in
  let n = Array.length endpoints in
  let idx = Atomic.fetch_and_add llama_rr_counter 1 mod n in   (* n=0 → Division_by_zero *)
  endpoints.(idx)

let current_llama_endpoint () =              (* line 177 — 가드 있음 *)
  ...
  if n = 0 then "" else (... mod n ...)
```

- `next_llama_endpoint`는 `_ mod n`과 array 인덱싱 전에 `n = 0`을 막지 않아, 빈 배열이면 `Division_by_zero`(이어서 out-of-bounds).
- 형제 `current_llama_endpoint`는 동일 데이터에 `if n = 0 then ""` 가드가 있음 → **불일치**.

## 변경

형제와 동일한 가드 추가 (폴백도 `""`로 일치):

```ocaml
  if n = 0
  then ""
  else (
    let idx = Atomic.fetch_and_add llama_rr_counter 1 mod n in
    endpoints.(idx))
```

(워크플로 초안은 폴백을 `Discovery.default_endpoint`로 제안했으나, 그러면 형제의 `""`와 *새로운* 불일치가 생겨 — 일관성 목적에 맞게 형제와 동일한 `""`를 채택.)

## 동작 보존 / 한계 (정직)

- **`n = 0`은 오늘 도달 불가**: `initial_llama_endpoints`가 `[] -> [Discovery.default_endpoint]` 폴백으로 항상 비어있지 않은 배열을 보장. 따라서 이건 **라이브 크래시 수정이 아니라 방어적 totality + 형제 일관성** 수정.
- `n > 0`(유일한 도달 경로): else 분기가 기존 body와 byte-identical (`fetch_and_add` 증가 → `mod n` → 인덱스). 관측 동작 불변.
- `.mli` 시그니처(`unit -> string`) 불변, caller ripple 0.

## 로컬 검증 (Draft는 CI 게이트 skip → 로컬이 유일 증거)

| 게이트 | 결과 |
|--------|------|
| `scripts/dune-local.sh build lib` | EXIT=0 |
| `scripts/dune-local.sh build @runtest` | EXIT=0 (provider_registry 테스트 포함 전체 통과) |
| `scripts/check-sdk-independence.sh` | EXIT=0 |
| `scripts/dune-local.sh build @fmt` | EXIT=0 (drift 0) |

## 워크어라운드 게이트 self-check

비해당 — partial array+mod 조회를 형제의 기존 가드 패턴을 미러링해 total로 만드는 것 (telemetry/string-classifier/cap-cooldown/N-of-M 아님). RFC-게이트 subsystem(credential/operator/keeper/sandbox) 미접촉. n=0 unreachable이라 urgency는 낮음 — consistency/totality 개선으로 ship.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)