### PR TITLE
docs(rfc): RFC-OAS-025 forced-tool-use enforcement boundary

### DIFF
--- a/docs/rfc/RFC-OAS-025-forced-tool-use-enforcement-boundary.md
+++ b/docs/rfc/RFC-OAS-025-forced-tool-use-enforcement-boundary.md
@@ -1,0 +1,164 @@
+# RFC-OAS-025: Forced-Tool-Use Enforcement Boundary
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Author | vincent (drafted by agent) |
+| Created | 2026-06-04 |
+| Target | `agent_sdk` (oas) |
+| Related | RFC-OAS-017 (coordinator-shape leak), RFC-OAS-021 (approval-required missing-callback policy), RFC-OAS-013 (keeper tool disclosure) |
+
+## 0. Summary
+
+OAS validates, on the response side, that a model honored the caller's
+`tool_choice` (the `Require_tool_use` / `Require_specific_tool` completion
+contracts) and, on violation, retries the turn to coerce a tool call. The two
+major providers already **guarantee** this server-side, so for compliant
+providers the validation is redundant and the retry path is effectively dead;
+the only case it guards is a **non-compliant local backend** that ignores
+`tool_choice`. This RFC proposes moving forced-tool *enforcement* out of the SDK
+(the SDK passes `tool_choice` through to the provider and reports, but does not
+coerce), leaving any local-model coercion to the consumer/coordinator.
+
+This is the same boundary principle as RFC-OAS-017: OAS should not own
+coordinator-shaped policy.
+
+## 1. Current state (file:line, origin/main `1b19c3f4`)
+
+`tool_choice` maps to a completion contract (`lib/completion_contract.ml:63`):
+
+```ocaml
+let requested_of_tool_choice choice =
+  match choice with
+  | Some Any -> Require_tool_use
+  | Some (Tool name) -> Require_specific_tool name
+  | Some None_ -> Require_no_tool_use
+  | Some Auto | None -> Allow_text_or_tool
+```
+
+`validate_response` (`lib/completion_contract.ml:185`) then checks the *response*
+against the contract; for `Require_tool_use` a text-only response on a
+non-resumable stop reason is an `Error`. The turn pipeline turns that into a
+`CompletionContractViolation` and, when a `tool_retry_policy` is set, re-runs the
+turn with a "you must call a tool" feedback message
+(`lib/pipeline/pipeline.ml` `handle_missing_required_tool_use`, ~6 contract
+sites at lines 65, 185, 218, 243, 249, 274). The contract type is public via
+`agent_sdk.mli` (`module Completion_contract_id`) and is carried by
+`Error.CompletionContractViolation` (`lib/base/error.ml:77`).
+
+## 2. Problem: enforcement is in the wrong layer ("거꾸로")
+
+`tool_choice` is a **request-side directive to the provider**. Both major
+providers enforce it server-side:
+
+- **OpenAI** `tool_choice: "required"`: "you can count on a tool being provided
+  with every call" — the response is guaranteed to contain a tool call.
+- **Anthropic** `tool_choice: {type: "any"}`: the API prefills the assistant
+  message to force a tool, so the model **cannot** emit a natural-language
+  (text-only) response.
+
+(Evidence: OpenAI developer docs/cookbook on `tool_choice: "required"`; Anthropic
+tool-use docs / cookbook `tool_choice.ipynb`, June 2026.)
+
+Therefore OAS re-validating the response against `tool_choice` re-checks a
+guarantee the provider already makes. The consequences:
+
+- For OpenAI/Anthropic the `Require_tool_use` error branch and its retry are
+  **dead** (the provider never produces the text-only response that would
+  trigger them).
+- The only live case is a **non-compliant local backend** (llama.cpp / Ollama /
+  small models that ignore `tool_choice`). There, OAS burns turns retrying to
+  coerce a tool call.
+- Coercing a non-compliant backend is a **policy** decision — when to retry, how
+  many times, whether to force at all. By RFC-OAS-017's principle (OAS does not
+  own coordinator-shaped concerns) and consistent with OAS already delegating
+  cross-provider failover / circuit-breaking to downstream consumers, this
+  belongs to the consumer/coordinator, not the SDK.
+
+The accept/reject logic itself is locally correct; what is inverted is **which
+layer enforces** — the SDK re-enforces what the provider guarantees.
+
+## 3. Non-goals
+
+- Removing the ability to *send* `tool_choice` to the provider. The request-side
+  parameter stays; providers keep enforcing it natively.
+- Changing `Allow_text_or_tool` (the default) or `Require_no_tool_use` semantics
+  beyond what each option below states.
+
+## 4. Options
+
+### Option A — Remove forced-tool response enforcement (recommended)
+
+Drop the response-side validation **and** retry for `Require_tool_use` /
+`Require_specific_tool`. `tool_choice` is still placed in the provider request.
+The SDK no longer raises `CompletionContractViolation` for "no tool when a tool
+was required", and the pipeline no longer retries to coerce one.
+
+- Pro: removes redundant/dead logic for compliant providers; takes the SDK out of
+  the tool-forcing-policy business (RFC-OAS-017 aligned); eliminates the
+  turn-burning retry the user flagged.
+- Con: a non-compliant local backend that ignores `tool_choice` will now return
+  text and the SDK will accept it; the consumer must detect/handle that. Public
+  API surface (`Completion_contract_id`) shrinks (breaking for any external
+  matcher).
+
+### Option B — Report-only (keep validation, drop retry)
+
+Keep the contract + validation so a violation is still surfaced (as an error or
+event), but remove the pipeline retry-coercion. The SDK reports "model did not
+call a required tool"; the consumer decides whether to retry.
+
+- Pro: smaller blast radius; preserves the diagnostic; directly removes the
+  turn-waste.
+- Con: keeps the redundant validation for compliant providers; the public
+  contract type stays.
+
+### Option C — Explicit policy toggle (RFC-OAS-021 pattern)
+
+Add `forced_tool_enforcement : Enforce | Report_only | Off` to `Agent_options`,
+default `Enforce` (compat). Mirrors RFC-OAS-021's
+`missing_approval_callback_policy`.
+
+- Pro: no breaking change; opt-in; profiles choose.
+- Con: keeps all the code paths; adds config surface rather than removing a
+  concern. Does not resolve the layering objection — it just makes it optional.
+
+## 5. Recommendation
+
+**Option A.** The research shows the enforcement is redundant for compliant
+providers and the only live case (local non-compliance) is a coordinator
+concern. Option A is the one that actually resolves the "거꾸로" layering. If a
+softer landing is wanted, ship Option B first (remove the turn-burning retry) and
+follow with A.
+
+## 6. Blast radius (Option A)
+
+| Area | Change |
+|---|---|
+| `lib/base/completion_contract_id.ml` + `.mli` | Remove `Require_tool_use` / `Require_specific_tool` variants (or the whole forced-tool family); decide `Some Any` / `Some (Tool _)` → `Allow_text_or_tool`. |
+| `lib/completion_contract.ml` | Drop the removed arms in `requested_of_tool_choice`, `validate_response`, `of_tool_choice`; drop ~10 inline tests for those variants. |
+| `lib/pipeline/pipeline.ml` | Remove the ~6 forced-tool sites (`contract_requires_tool`, the violation/retry in `handle_missing_required_tool_use`, prompt strings). |
+| `lib/base/error.ml` / `lib/error_domain.ml` | `CompletionContractViolation` no longer reachable for the removed contracts; keep or narrow the error variant. |
+| `agent_sdk.mli` | Public `Completion_contract_id` surface shrinks (breaking). |
+| `test/` | ~20 sites across `test_agent_pipeline`, `test_completion_contract_violation`, `test_error`, `test_error_domain`. |
+
+`tool_choice` request-building (provider backends) is **unchanged** — providers
+still receive and enforce it.
+
+## 7. Migration / compatibility
+
+- Removing public variants is a breaking change for external matchers on
+  `Completion_contract_id.t`. If that matters, gate via Option C first, or land A
+  in a major version bump per `lib/sdk_version.ml`.
+- Consumers relying on OAS to coerce a tool from a non-compliant local model must
+  add their own check (e.g. inspect `response` for a tool_use block and retry at
+  the coordinator).
+
+## 8. Acceptance
+
+- `tool_choice` is still sent to the provider request (verified by a backend
+  request-shape test).
+- No `CompletionContractViolation` is raised for "no tool when required" (Option
+  A/B), and the pipeline does not retry to coerce a tool.
+- `dune build lib` + `@runtest` + `check-sdk-independence.sh` + `@fmt` green.
+- Public surface change recorded in `CHANGELOG.md` (+ version bump if breaking).


### PR DESCRIPTION
## 목적

사용자가 제기한 "`require_tool_use`가 이상하다 / 거꾸로다 / 제거할 거다"에 대한 **design-first RFC**. 아키텍처+public API 변경이므로 구현 전 설계 문서로 scope를 확정합니다 (연구→RFC→구현 파이프라인).

## 핵심 발견 (웹 근거 + file:line)

`tool_choice`는 **provider에 대한 요청측 지시**이고, 두 주요 provider가 **서버측에서 보장**합니다:
- OpenAI `tool_choice:"required"` → "count on a tool being provided with every call"
- Anthropic `tool_choice:{type:"any"}` → assistant message를 prefill해 도구 강제, 텍스트 응답 불가

그런데 OAS는 `Require_tool_use`/`Require_specific_tool`로 **응답을 다시 검증**하고, 위반 시 pipeline이 **retry로 턴을 태워 강제**합니다(`handle_missing_required_tool_use`). 결과:
- 클라우드 provider에선 위반 분기·retry가 **사실상 dead**(provider가 text-only를 못 만듦).
- 유일한 live 경우 = `tool_choice`를 무시하는 **비순응 로컬 백엔드**(llama.cpp/Ollama 소형 모델).
- 비순응 백엔드 coercion은 **policy** → RFC-OAS-017(coordinator-shape leak) 원칙상 consumer/coordinator 몫. 사용자의 "tool = keeper가 쓸 도구" 지적과 일치.

즉 accept/reject 로직 자체가 틀린 게 아니라, **provider가 보장한 걸 SDK가 재강제하는 레이어가 거꾸로**입니다.

## 제안 (1개 scope 확정 요청)

| 옵션 | 내용 | 비고 |
|------|------|------|
| **A (권장)** | forced-tool 응답검증+retry 제거, `tool_choice`는 provider 요청에 계속 전달 | 레이어 역전 근본 해소, public API 축소(breaking) |
| B | contract 검증은 report-only로 두고 retry만 제거 | blast radius 작음, 진단 보존, 클라우드 중복은 남음 |
| C | `forced_tool_enforcement : Enforce\|Report_only\|Off` 정책 토글(기본 Enforce), RFC-OAS-021 패턴 | 비파괴, opt-in, 레이어 문제는 미해소 |

## Blast radius (Option A)

`completion_contract_id.ml/.mli`(public via `agent_sdk.mli`) + `completion_contract.ml`(of_tool_choice/validate_response + 인라인 테스트 ~10) + `pipeline.ml` 6곳 + `error.ml`/`error_domain.ml` + 테스트 ~20. `tool_choice` 요청 빌드는 **불변**(provider 네이티브 enforcement 유지).

## 검증

docs-only PR (코드 변경 0). SDK Independence Gate EXIT=0 (docs/ 미스캔). 구현 PR은 별도로 build/runtest/SDK/fmt green 충족 예정.

## 요청

**Option A/B/C 중 어느 scope로 갈지** 결정해주시면 그대로 구현 Draft PR을 올립니다. (breaking 여부에 따라 `lib/sdk_version.ml` bump 동반.)

Related: RFC-OAS-017 (coordinator-shape leak), RFC-OAS-021 (approval-required missing-callback policy), RFC-OAS-013 (keeper tool disclosure).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)