### PR TITLE
fix(streaming): include_usage for OpenAI-compatible streaming so token usage is returned

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -1211,8 +1211,14 @@ let complete_stream_http
       let body_with_stream =
         match config.kind with
         | Provider_config.Gemini -> body_str
-        | Anthropic | Kimi | OpenAI_compat | Ollama | Glm | DashScope ->
+        | Anthropic | Ollama -> Http_client.inject_stream_param body_str
+        | OpenAI_compat | Kimi | Glm | DashScope ->
+          (* OpenAI-compatible streaming returns token usage only when the
+             request also sets stream_options.include_usage. Anthropic and
+             Ollama carry usage natively (message_start/message_delta and the
+             NDJSON done-chunk respectively), so they keep stream:true only. *)
           Http_client.inject_stream_param body_str
+          |> Http_client.inject_stream_options_include_usage
       in
       let t0 = Unix.gettimeofday () in
       let ttfrc_ref = ref None in

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -74,7 +74,18 @@ let accumulate_event (acc : stream_acc) = function
      | Some sr -> acc.stop_reason := sr
      | None -> ());
     (match usage with
-     | Some u -> acc.output_tokens := !(acc.output_tokens) + u.output_tokens
+     | Some u ->
+       (* Additive so prompt-token totals are not lost when they arrive in a
+          MessageDelta rather than MessageStart. Anthropic carries input_tokens
+          in MessageStart and reports input_tokens = 0 in its message_delta, so
+          [+= 0] preserves that value. OpenAI-compatible streaming has no
+          MessageStart usage and delivers input_tokens only in the final
+          stream_options.include_usage chunk's MessageDelta, so this is the only
+          place those tokens are captured. Cache fields stay sourced from
+          MessageStart (Anthropic) and are left untouched here to avoid
+          double-counting against that prelude. *)
+       acc.input_tokens := !(acc.input_tokens) + u.input_tokens;
+       acc.output_tokens := !(acc.output_tokens) + u.output_tokens
      | None -> ())
   | Types.SSEError msg -> acc.sse_error := Some msg
   | Types.SSEParseFailed { raw; reason } ->

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -818,6 +818,29 @@ let inject_stream_param body_str =
   | exception Yojson.Json_error _ -> body_str
 ;;
 
+(* OpenAI streaming omits the [usage] object on every chunk unless the
+   request sets [stream_options.include_usage = true], at which point the
+   provider sends a final SSE chunk carrying [usage] with an empty
+   [choices] array. Without this flag, OpenAI-compatible streaming turns
+   report zero token usage. Anthropic/Ollama/Gemini carry usage natively
+   and must NOT receive this field. Mirrors [inject_stream_param]'s
+   JSON-manipulation style: drop any caller-supplied [stream_options]
+   before re-adding so the flag cannot be double-injected, and leave a
+   malformed/non-object body untouched. *)
+let inject_stream_options_include_usage body_str =
+  match Yojson.Safe.from_string body_str with
+  | `Assoc fields ->
+    let without_existing =
+      List.filter (fun (k, _) -> k <> "stream_options") fields
+    in
+    Yojson.Safe.to_string
+      (`Assoc
+          (("stream_options", `Assoc [ "include_usage", `Bool true ])
+           :: without_existing))
+  | other -> Yojson.Safe.to_string other
+  | exception Yojson.Json_error _ -> body_str
+;;
+
 [@@@coverage off]
 (* ── catch_network tests ─────────────────────────────── *)
 

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -307,3 +307,12 @@ val is_local_resource_exhaustion : http_error -> bool
 
 (** Inject ["stream": true] into a JSON body string. *)
 val inject_stream_param : string -> string
+
+(** Inject [{"stream_options": {"include_usage": true}}] into a JSON body
+    string. OpenAI-compatible providers omit token usage from streaming
+    responses unless this flag is set. Use only for OpenAI-compatible
+    kinds; native-usage providers (Anthropic, Ollama, Gemini) must not
+    receive it. Any caller-supplied [stream_options] is replaced to avoid
+    double-injection; a non-object or unparseable body is returned
+    unchanged. *)
+val inject_stream_options_include_usage : string -> string

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -230,32 +230,10 @@ let parse_openai_sse_chunk data_str : provider_d_chunk option =
       let json = Yojson.Safe.from_string data_str in
       let chunk_id = Cli_common_json.member_str "id" json in
       let chunk_model = Cli_common_json.member_str "model" json in
-      let choice = json |> member "choices" |> index 0 in
-      let delta = choice |> member "delta" in
-      let delta_content = delta |> member "content" |> to_string_option in
-      let delta_reasoning =
-        match delta |> member "reasoning_content" |> to_string_option with
-        | Some s when String.trim s <> "" -> Some s
-        | Some _ | None -> delta |> member "reasoning" |> to_string_option
-      in
-      let delta_tool_calls =
-        match delta |> member "tool_calls" with
-        | `List calls ->
-          List.filter_map
-            (fun tc ->
-               try
-                 let tc_index = tc |> member "index" |> to_int in
-                 let tc_id = tc |> member "id" |> to_string_option in
-                 let fn = tc |> member "function" in
-                 let tc_name = fn |> member "name" |> to_string_option in
-                 let tc_arguments = fn |> member "arguments" |> to_string_option in
-                 Some { tc_index; tc_id; tc_name; tc_arguments }
-               with
-               | Yojson.Safe.Util.Type_error _ | Not_found -> None)
-            calls
-        | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ -> []
-      in
-      let finish_reason = choice |> member "finish_reason" |> to_string_option in
+      (* [usage] is top-level, not under a choice, so it is read regardless of
+         whether [choices] is populated. With stream_options.include_usage the
+         provider sends a final chunk carrying [usage] with an empty [choices]
+         array; this is the only chunk that reports token totals. *)
       let chunk_usage =
         let u = json |> member "usage" in
         if u = `Null
@@ -273,15 +251,62 @@ let parse_openai_sse_chunk data_str : provider_d_chunk option =
             ; cost_usd = None
             })
       in
-      Some
-        { chunk_id
-        ; chunk_model
-        ; delta_content
-        ; delta_reasoning
-        ; delta_tool_calls
-        ; finish_reason
-        ; chunk_usage
-        }
+      (* Match the choices list directly rather than [index 0] / [to_list]:
+         both raise [Type_error] on a [`Null] or empty array, which the outer
+         handler would turn into a dropped chunk. The usage-only final chunk
+         has [choices = []] and must still surface its [chunk_usage]. *)
+      let choices =
+        match json |> member "choices" with
+        | `List l -> l
+        | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ -> []
+      in
+      (match choices with
+       | [] ->
+         (* Usage-only final chunk: no delta, no finish_reason. *)
+         Some
+           { chunk_id
+           ; chunk_model
+           ; delta_content = None
+           ; delta_reasoning = None
+           ; delta_tool_calls = []
+           ; finish_reason = None
+           ; chunk_usage
+           }
+       | choice :: _ ->
+         let delta = choice |> member "delta" in
+         let delta_content = delta |> member "content" |> to_string_option in
+         let delta_reasoning =
+           match delta |> member "reasoning_content" |> to_string_option with
+           | Some s when String.trim s <> "" -> Some s
+           | Some _ | None -> delta |> member "reasoning" |> to_string_option
+         in
+         let delta_tool_calls =
+           match delta |> member "tool_calls" with
+           | `List calls ->
+             List.filter_map
+               (fun tc ->
+                  try
+                    let tc_index = tc |> member "index" |> to_int in
+                    let tc_id = tc |> member "id" |> to_string_option in
+                    let fn = tc |> member "function" in
+                    let tc_name = fn |> member "name" |> to_string_option in
+                    let tc_arguments = fn |> member "arguments" |> to_string_option in
+                    Some { tc_index; tc_id; tc_name; tc_arguments }
+                  with
+                  | Yojson.Safe.Util.Type_error _ | Not_found -> None)
+               calls
+           | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ -> []
+         in
+         let finish_reason = choice |> member "finish_reason" |> to_string_option in
+         Some
+           { chunk_id
+           ; chunk_model
+           ; delta_content
+           ; delta_reasoning
+           ; delta_tool_calls
+           ; finish_reason
+           ; chunk_usage
+           })
     with
     | Yojson.Safe.Util.Type_error _
     | Yojson.Safe.Util.Undefined _
@@ -436,7 +461,16 @@ let openai_chunk_to_events (state : provider_d_stream_state) (chunk : provider_d
        | other -> Unknown other
      in
      emit (MessageDelta { stop_reason = Some stop_reason; usage = chunk.chunk_usage })
-   | None -> ());
+   | None ->
+     (* With stream_options.include_usage the provider sends token totals in a
+        separate final chunk that has no finish_reason and an empty choices
+        array (hence no content/tool deltas). Emit a MessageDelta carrying only
+        the usage so the accumulator records it. The finish_reason branch above
+        already forwards usage when a stop arrives in the same chunk, so the two
+        paths are mutually exclusive and usage is never emitted twice. *)
+     (match chunk.chunk_usage with
+      | Some _ -> emit (MessageDelta { stop_reason = None; usage = chunk.chunk_usage })
+      | None -> ()));
   List.rev !events, !telemetry_event
 ;;
 


### PR DESCRIPTION
## Problem

OpenAI-compatible streaming returns token usage only when the request sets `stream_options: {include_usage: true}`. OAS never sent that flag, so every OpenAI-compatible streaming turn returned no usage. In the consuming fleet this surfaced as `usage_reported=false` / `input=0 output=0` and "usage telemetry unavailable" — ~5035 occurrences in a single day. No error was raised; usage was just absent, which is a silent failure.

## Empirical evidence (live `https://ollama.com/v1/chat/completions`, model `deepseek-v4-flash`)

- Non-stream: `usage` present.
- Stream **without** `include_usage`: stream ends `...finish_reason:"stop"` then `data: [DONE]` — no `usage` object at all.
- Stream **with** `stream_options:{include_usage:true}`: an extra final chunk `{"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":59,"total_tokens":69}}` appears before `[DONE]`.

So the provider does return usage — only when asked, and only in a final chunk whose `choices` is an empty array.

## Fix (two parts)

1. Request — `lib/llm_provider/complete.ml` + `lib/llm_provider/http_client.ml`/`.mli`: for OpenAI-compatible kinds (`OpenAI_compat | Kimi | Glm | DashScope`) the streaming body now also carries `stream_options.include_usage = true` via a new `Http_client.inject_stream_options_include_usage`. Anthropic, Ollama (native NDJSON done-chunk), and Gemini carry usage natively and are excluded.

2. Parse — `lib/llm_provider/streaming.ml` + `lib/llm_provider/complete_stream_acc.ml`: `parse_openai_sse_chunk` matched `choices |> index 0`, which raised on the empty-choices usage chunk and dropped it (the outer handler turned the exception into a dropped chunk). It now reads top-level `usage` first and matches the `choices` list, surfacing the usage-only chunk with no deltas. `openai_chunk_to_events` emits a `MessageDelta` carrying the usage when there is no finish_reason, mutually exclusive with the finish_reason path. The accumulator now adds `input_tokens` as well as `output_tokens` (previously it set only `output_tokens` and never read `input_tokens`), so prompt-token totals delivered in the final chunk are recorded.

## Blast radius

All OpenAI-compatible streaming providers (OpenAI, OpenRouter, llama-server, ollama_cloud, etc.). Anthropic / native Ollama / Gemini paths are unchanged.

## Verification

OAS Draft PRs skip the CI gates, so local build + test is the evidence:
- `dune build lib --root .` clean.
- `dune runtest lib --root .` green (existing streaming / accumulator inline tests pass — no regression).
- Logic checked against the live ollama chunk shapes above.

## Follow-up (not in this change)

`lib/streaming.ml` (`Agent_sdk.Streaming`) has a second `accumulate_event` with the same `output_tokens :=` (set, not add) and no `input_tokens` capture. It consumes the same parser but is a separate path from `Complete.complete_stream_http`; left for a follow-up.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
