### PR TITLE
fix(streaming): repair main red after #1866 (empty-choices chunk + fmt drift)

### DIFF
--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -830,13 +830,10 @@ let inject_stream_param body_str =
 let inject_stream_options_include_usage body_str =
   match Yojson.Safe.from_string body_str with
   | `Assoc fields ->
-    let without_existing =
-      List.filter (fun (k, _) -> k <> "stream_options") fields
-    in
+    let without_existing = List.filter (fun (k, _) -> k <> "stream_options") fields in
     Yojson.Safe.to_string
       (`Assoc
-          (("stream_options", `Assoc [ "include_usage", `Bool true ])
-           :: without_existing))
+          (("stream_options", `Assoc [ "include_usage", `Bool true ]) :: without_existing))
   | other -> Yojson.Safe.to_string other
   | exception Yojson.Json_error _ -> body_str
 ;;

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -260,53 +260,60 @@ let parse_openai_sse_chunk data_str : provider_d_chunk option =
         | `List l -> l
         | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ -> []
       in
-      (match choices with
-       | [] ->
-         (* Usage-only final chunk: no delta, no finish_reason. *)
-         Some
-           { chunk_id
-           ; chunk_model
-           ; delta_content = None
-           ; delta_reasoning = None
-           ; delta_tool_calls = []
-           ; finish_reason = None
-           ; chunk_usage
-           }
-       | choice :: _ ->
-         let delta = choice |> member "delta" in
-         let delta_content = delta |> member "content" |> to_string_option in
-         let delta_reasoning =
-           match delta |> member "reasoning_content" |> to_string_option with
-           | Some s when String.trim s <> "" -> Some s
-           | Some _ | None -> delta |> member "reasoning" |> to_string_option
-         in
-         let delta_tool_calls =
-           match delta |> member "tool_calls" with
-           | `List calls ->
-             List.filter_map
-               (fun tc ->
-                  try
-                    let tc_index = tc |> member "index" |> to_int in
-                    let tc_id = tc |> member "id" |> to_string_option in
-                    let fn = tc |> member "function" in
-                    let tc_name = fn |> member "name" |> to_string_option in
-                    let tc_arguments = fn |> member "arguments" |> to_string_option in
-                    Some { tc_index; tc_id; tc_name; tc_arguments }
-                  with
-                  | Yojson.Safe.Util.Type_error _ | Not_found -> None)
-               calls
-           | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ -> []
-         in
-         let finish_reason = choice |> member "finish_reason" |> to_string_option in
-         Some
-           { chunk_id
-           ; chunk_model
-           ; delta_content
-           ; delta_reasoning
-           ; delta_tool_calls
-           ; finish_reason
-           ; chunk_usage
-           })
+      match choices with
+      | [] ->
+        (* Usage-only final chunk: no delta, no finish_reason. Surface it only
+            when it actually carries [usage] (the stream_options.include_usage
+            final chunk). A [choices = []] chunk with no usage carries nothing,
+            so drop it (None) — this keeps non-usage empty chunks from producing
+            an eventless Some. *)
+        (match chunk_usage with
+         | Some _ ->
+           Some
+             { chunk_id
+             ; chunk_model
+             ; delta_content = None
+             ; delta_reasoning = None
+             ; delta_tool_calls = []
+             ; finish_reason = None
+             ; chunk_usage
+             }
+         | None -> None)
+      | choice :: _ ->
+        let delta = choice |> member "delta" in
+        let delta_content = delta |> member "content" |> to_string_option in
+        let delta_reasoning =
+          match delta |> member "reasoning_content" |> to_string_option with
+          | Some s when String.trim s <> "" -> Some s
+          | Some _ | None -> delta |> member "reasoning" |> to_string_option
+        in
+        let delta_tool_calls =
+          match delta |> member "tool_calls" with
+          | `List calls ->
+            List.filter_map
+              (fun tc ->
+                 try
+                   let tc_index = tc |> member "index" |> to_int in
+                   let tc_id = tc |> member "id" |> to_string_option in
+                   let fn = tc |> member "function" in
+                   let tc_name = fn |> member "name" |> to_string_option in
+                   let tc_arguments = fn |> member "arguments" |> to_string_option in
+                   Some { tc_index; tc_id; tc_name; tc_arguments }
+                 with
+                 | Yojson.Safe.Util.Type_error _ | Not_found -> None)
+              calls
+          | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ -> []
+        in
+        let finish_reason = choice |> member "finish_reason" |> to_string_option in
+        Some
+          { chunk_id
+          ; chunk_model
+          ; delta_content
+          ; delta_reasoning
+          ; delta_tool_calls
+          ; finish_reason
+          ; chunk_usage
+          }
     with
     | Yojson.Safe.Util.Type_error _
     | Yojson.Safe.Util.Undefined _


### PR DESCRIPTION
## 긴급: broken main 복구

origin/main `b243b0b1`의 CI가 **OCaml Format + Build & Test 실패** 상태입니다. 원인은 **#1866**(stream_options.include_usage)이 두 게이트를 Draft에서 skip한 채 머지돼 발현된 latent regression입니다. (내 #1867 Stage 2와 무관 — 실패는 전부 `lib/llm_provider/` streaming.)

## 두 실패 + 수정

**1) Build & Test — `test_parse_empty_choices` FAIL** ("expected None for empty choices")
- `streaming.ml:264` `parse_openai_sse_chunk`의 `choices=[]` 분기가 `chunk_usage` 무관하게 **무조건 `Some` 반환**. 테스트 입력 `{"choices":[]}`(usage 없음)이 `Some`이 돼 깨짐.
- **fix**: empty-choices 분기를 `chunk_usage`로 가드 — `Some _`일 때만 `Some`(= #1866의 usage-only final chunk 기능 보존), `None`이면 `None`(빈 청크는 전달할 게 없음 → drop). #1866의 include_usage 동작(`choices=[] WITH usage → Some`)은 그대로 유지.

**2) OCaml Format FAIL** — `http_client.ml` + `streaming.ml` ocamlformat drift (#1866이 fmt-clean 없이 머지; OCaml Format 게이트는 전트리 스캔). `@fmt --auto-promote`로 재포맷.

## 검증 (Draft는 CI skip → 로컬이 증거)

| 게이트 | 결과 |
|--------|------|
| `dune-local.sh build @all` | EXIT=0 |
| `test/test_streaming_provider_d.exe` | EXIT=0 (`parse_openai_sse_chunk empty choices` [OK], 24 tests) |
| `dune-local.sh build @fmt` | EXIT=0 (drift 0) |
| `scripts/check-sdk-independence.sh` | EXIT=0 |

## 노트

- streaming.ml diff가 큰 건(~90줄) #1866 drift 재포맷이 대부분 — logic 변경은 `[] ->` 가드 한 곳.
- broken-main-race 체크: 작업 전 in-flight fix PR 없음 확인(메모리 교훈). 병렬 세션이 동일 fix를 올렸으면 close하고 양보.
- **긴급 — main이 red이므로 우선 머지 권장.** (agent는 Ready/머지 안 함.)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)