### PR TITLE
fix(http_client): propagate Eio.Cancel.Cancelled from drain_response_body

### DIFF
--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -568,6 +568,10 @@ let drain_response_body resp_body =
   | Sys_error _ -> ()
   | Failure _ -> ()
   | Invalid_argument _ -> ()
+  (* Re-raise cancellation so a fiber cancelled mid-drain unwinds instead of
+     being absorbed by the catch-all below (structured concurrency). Mirrors the
+     transport-close handler in this module. *)
+  | Eio.Cancel.Cancelled _ as e -> raise e
   | drain_failure ->
     let (_ : exn) = drain_failure in
     ()


### PR DESCRIPTION
## 목적

`drain_response_body`의 catch-all이 `Eio.Cancel.Cancelled`를 삼켜 구조적 동시성을 깨뜨리던 것을 수정합니다. (sweep-3 적발, file:line 직접 검증.)

## 근거 (origin/main c01ce56b)

`lib/llm_provider/http_client.ml:549~` `drain_response_body`:

```ocaml
try drain () with
| End_of_file -> () | Eio.Time.Timeout -> ()
| Unix.Unix_error (code, _, _) -> (match classify_unix_error code with ... -> ())
| Eio.Io _ -> () | Sys_error _ -> () | Failure _ -> () | Invalid_argument _ -> ()
| drain_failure -> let (_ : exn) = drain_failure in ()   (* ← Cancelled까지 삼킴 *)
```

- 앞의 named arm들(End_of_file/Timeout/Unix_error/Eio.Io/Sys_error/Failure/Invalid_argument) 중 `Eio.Cancel.Cancelled`에 매치되는 게 없으므로, 최종 catch-all `| drain_failure ->`가 **Cancelled를 흡수**합니다.
- 그러면 응답 body를 drain하는 도중 취소된 fiber가 **unwind하지 못하고** 정상 진행 → 바깥 Switch/Cancel scope가 취소를 못 봄 (구조적 동시성 붕괴). CLAUDE.md TLA+ bug-model이 명시적으로 경고하는 `Eio.Cancel.Cancelled` 삼킴 클래스.

## 변경

catch-all **앞에** Cancelled 재전파 추가 (같은 모듈 transport-close 핸들러 ~line 542와 동일 패턴):

```ocaml
| Eio.Cancel.Cancelled _ as e -> raise e
| drain_failure -> let (_ : exn) = drain_failure in ()
```

## 동작 보존

- top-to-bottom 매치라 모든 정상 예외 경로는 그대로(named arm이 먼저 매치). **Cancelled만** 이제 올바르게 재전파.
- `drain_response_body`는 `.mli` 미노출(internal) → caller/계약 변경 0. surgical.

## 로컬 검증 (Draft는 CI 게이트 skip → 로컬이 증거)

| 게이트 | 결과 |
|--------|------|
| `dune-local.sh build lib` | EXIT=0 |
| `dune-local.sh build @runtest` | EXIT=0 (전체 통과) |
| `scripts/check-sdk-independence.sh` | EXIT=0 |
| `dune-local.sh build @fmt` | EXIT=0 (drift 0) |

## 워크어라운드 게이트 self-check

비해당 — silent-swallow를 *제거*하고 예외 전파를 복원(취소된 fiber가 계속 도는 illegal control flow를 unrepresentable로). string-classifier/telemetry/cap-cooldown 아님. RFC-게이트 subsystem 미접촉.

(sweep-3 동시 적발 #2: `error_domain.ml:258 is_retryable`의 `_ -> false` catch-all → 별도 PR로 큐잉. 1 이슈/라운드.)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)