### PR TITLE
refactor(error_domain): make is_retryable exhaustive over sdk_error_poly (no catch-all)

### DIFF
--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -255,7 +255,43 @@ let is_retryable (err : [< sdk_error_poly ]) : bool =
   | `Mcp_tool_list_failed _
   | `Mcp_tool_call_failed _
   | `Mcp_http_failed _ -> true
-  | _ -> false
+  (* Non-retryable: enumerated explicitly (no [_] catch-all) so a future
+     sdk_error_poly tag triggers a partial-match compiler warning instead of
+     being silently treated as non-retryable. error_domain.mli's purpose is to
+     eliminate defensive catch-alls; this matches the exhaustive sibling
+     Error.is_retryable. *)
+  | `Auth_error _
+  | `Invalid_request _
+  | `Not_found _
+  | `Context_overflow _
+  | `Tool_exec_failed _
+  | `Tool_timeout _
+  | `Max_turns_exceeded _
+  | `Token_budget_exceeded _
+  | `Cost_budget_exceeded
+  | `Cost_budget_unenforceable _
+  | `Idle_detected _
+  | `Tool_retry_exhausted _
+  | `Agent_execution_timeout _
+  | `Agent_execution_idle_timeout _
+  | `Guardrail_violation _
+  | `Tripwire_violation _
+  | `Input_required _
+  | `Unrecognized_stop_reason _
+  | `Exit_condition_met _
+  | `Missing_env_var _
+  | `Unsupported_provider _
+  | `Invalid_config _
+  | `Mcp_server_start_failed _
+  | `Serialization _
+  | `Io _
+  | `Orchestration _
+  | `A2a_task_not_found _
+  | `A2a_invalid_transition _
+  | `A2a_message_send_failed _
+  | `A2a_protocol_error _
+  | `A2a_store_capacity_exceeded _
+  | `Internal _ -> false
 ;;
 
 let ctx_to_string (ctx : error_ctx) : string =


### PR DESCRIPTION
## 목적

`Error_domain.is_retryable`의 `_ -> false` catch-all을 명시 열거로 교체합니다. closed `sdk_error_poly` union 위에서 미래 transient tag가 silent 비재시도화되던 FSM sparse-match 안티패턴 제거. (sweep-3 적발, 컴파일러로 set-equality 검증.)

## 근거 (origin/main c01ce56b)

`lib/error_domain.ml:247`:

```ocaml
let is_retryable (err : [< sdk_error_poly ]) : bool =
  match (err :> sdk_error_poly) with
  | `Rate_limited _ | `Server_error _ | `Overloaded | `Provider_timeout _ | `Network_error _ -> true
  | `Mcp_init_failed _ | `Mcp_tool_list_failed _ | `Mcp_tool_call_failed _ | `Mcp_http_failed _ -> true
  | _ -> false      (* ← 미래 transient variant를 silent 비재시도화 *)
```

- `sdk_error_poly`(error_domain.ml:52)는 `provider_error|tool_error|agent_error|config_error|mcp_error` + 직접 tag 합성. `_ -> false`는 새 transient tag(예: 새 `Provider_*`/`Mcp_*`)가 추가돼도 컴파일러 경고 없이 비재시도로 흡수.
- **자기모순**: `error_domain.mli:4`가 "eliminating defensive `| _ -> assert false` patterns"를 모듈 목적으로 명시하고, 형제 `Error.is_retryable`(base/error.ml)는 이미 exhaustive.

## 변경

`_ -> false`를 비재시도 32개 tag 명시 열거로 교체 (`#subtype` 약어 미사용 — 그건 silent auto-expansion 재도입). 9개 retryable arm 불변.

## 동작 보존 (컴파일러 검증)

- 빌드 시 **partial-match 경고(Warning 8) 없음** = 41-tag 열거가 `sdk_error_poly`와 정확히 set-equal (누락=not-exhaustive, 초과=unused/unbound 모두 컴파일러가 잡음 → 없음 확인).
- 9 retryable→true, 32→false: 기존 `_->false`와 byte-identical. `test_error_domain.ml`의 is_retryable 테스트 통과.
- 미래 tag 추가 시 이제 컴파일 타임에 결정 강제.
- `.mli` 시그니처·caller 불변.

## 로컬 검증 (Draft는 CI skip → 로컬이 증거)

| 게이트 | 결과 |
|--------|------|
| `dune-local.sh build lib` | EXIT=0 (Warning 8 없음) |
| `dune-local.sh build @runtest` | EXIT=0 (test_error_domain 통과) |
| `scripts/check-sdk-independence.sh` | EXIT=0 |
| `dune-local.sh build @fmt` | EXIT=0 (drift 0) |

## 워크어라운드 게이트 self-check

비해당 — catch-all 제거 + exhaustive 명시 교체 (anti-pattern #4 root-fix). string-classifier/telemetry/cap-cooldown 아님. RFC-게이트 subsystem 미접촉.

(sweep-3 #1 = #1871 http_client Cancelled 전파, 이미 ship. 이건 #2.)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)