### PR TITLE
fix(pipeline): propagate Eio.Cancel.Cancelled from safe_publish

### DIFF
--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -20,11 +20,9 @@ open Agent_trace
 
 let _log = Log.create ~module_name:"pipeline" ()
 
-let safe_publish bus event =
-  try Event_bus.publish bus event with
-  | exn ->
-    Log.warn _log "Event_bus.publish failed" [ Log.S ("error", Printexc.to_string exn) ]
-;;
+(* Shared with Pipeline_stage_prepare via Pipeline_common (re-raises Eio
+   cancellation); the thin wrapper keeps this module's log label. *)
+let safe_publish bus event = Pipeline_common.safe_publish ~log:_log bus event
 
 (* ── Context compaction watermark ───────────────────── *)
 

--- a/lib/pipeline/pipeline_common.ml
+++ b/lib/pipeline/pipeline_common.ml
@@ -29,6 +29,46 @@ type turn_outcome =
   | ToolsExecuted
   | IdleSkipped
 
+(* Publish an event, logging only genuine delivery failures. Re-raises
+   [Eio.Cancel.Cancelled] so a fiber cancelled mid-publish — e.g. parked in
+   [Event_bus.publish] on a full subscriber stream under the [Block] policy —
+   unwinds instead of being absorbed by the catch-all (structured concurrency).
+   Mirrors the transport-drain handler in [Http_client]. Shared by [Pipeline]
+   and [Pipeline_stage_prepare], which previously held verbatim copies; the
+   re-raise arm was missing from both. *)
+let safe_publish ~log bus event =
+  try Event_bus.publish bus event with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.warn log "Event_bus.publish failed" [ Log.S ("error", Printexc.to_string exn) ]
+;;
+
+let%test "safe_publish does not absorb Eio cancellation" =
+  (* Reproduces the swallowed-cancellation bug: a fiber blocked inside
+     [Event_bus.publish] (Block policy, full one-slot stream, no drainer) is
+     cancelled; [safe_publish] must let Cancelled propagate. Without the
+     re-raise arm the catch-all returns unit and [propagated] stays false. *)
+  Eio_main.run (fun _env ->
+    let bus = Event_bus.create ~buffer_size:1 () in
+    let _sub = Event_bus.subscribe bus in
+    let log = Log.create ~module_name:"pipeline_common_test" () in
+    let ev = Event_bus.mk_event (Event_bus.TurnStarted { agent_name = "t"; turn = 0 }) in
+    (* Fill the single slot so the next publish parks in Stream.add. *)
+    safe_publish ~log bus ev;
+    let propagated = ref false in
+    Eio.Fiber.first
+      (fun () ->
+         try safe_publish ~log bus ev with
+         | Eio.Cancel.Cancelled _ as e ->
+           propagated := true;
+           raise e)
+      (fun () ->
+         (* Let the publish park on the full stream before winning the race. *)
+         Eio.Fiber.yield ();
+         Eio.Fiber.yield ());
+    !propagated)
+;;
+
 let event_envelope agent : Event_bus.envelope =
   let session_id = Option.bind agent.options.raw_trace Raw_trace.session_id in
   let worker_run_id =

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -10,14 +10,9 @@ open Agent_trace
 
 let _stage_log = Log.create ~module_name:"pipeline_stage_prepare" ()
 
-let safe_publish bus event =
-  try Event_bus.publish bus event with
-  | exn ->
-    Log.warn
-      _stage_log
-      "Event_bus.publish failed"
-      [ Log.S ("error", Printexc.to_string exn) ]
-;;
+(* Shared with Pipeline via Pipeline_common (re-raises Eio cancellation);
+   the thin wrapper keeps this module's log label. *)
+let safe_publish bus event = Pipeline_common.safe_publish ~log:_stage_log bus event
 
 let stage_input ?raw_trace_run agent =
   let ts = Unix.gettimeofday () in


### PR DESCRIPTION
## 목표

`safe_publish`가 `Eio.Cancel.Cancelled`를 삼키던 structured-concurrency 버그를 근본 수정합니다. `pipeline.ml`과 `pipeline_stage_prepare.ml`에 **글자 그대로 중복**된 `safe_publish`가 catch-all `| exn -> Log.warn`로 모든 예외(취소 포함)를 흡수해, publish 중 취소된 fiber가 unwind하지 못했습니다.

`Event_bus.publish`는 실제 취소점을 가집니다:
- `Block` 정책에서 full subscriber stream에 `Eio.Stream.add` → 블로킹 (`event_bus.ml:359-362`)
- `Eio.Mutex.use_ro/use_rw ~protect:true`로 뮤텍스 획득 (`event_bus.ml:368,394`)

즉 publish 도중 fiber가 취소되면 `Cancelled`가 발생하는데 catch-all이 이를 흡수 → 부모 switch의 취소가 무력화됨. http_client transport drain에서 동일 계열로 이미 고친 패턴(#1871)이고, 코드베이스 관습(`| Eio.Cancel.Cancelled _ as e -> raise e`, ~40개 사이트)을 따릅니다.

## 변경

- `lib/pipeline/pipeline_common.ml`: 공유 `safe_publish ~log bus event` 추가 — catch-all 앞에 `Cancelled` 재발생 arm. 인라인 재현 테스트 동봉.
- `lib/pipeline/pipeline.ml` / `pipeline_stage_prepare.ml`: 5줄 중복 def → `Pipeline_common.safe_publish`에 위임하는 1줄 wrapper. **각 모듈의 log 라벨(`pipeline`/`pipeline_stage_prepare`) 보존** → call site·로그 출력 무변경.

N-of-M 패치(두 사이트 따로 패치)를 피하고 중복을 단일 SSOT로 통합 = abstraction 추출(근본 수정). diff +46/-13.

## 로컬 검증 (Draft는 CI Build&Test skip → 로컬이 유일 안전망)

- `scripts/dune-local.sh build`: 컴파일 clean (consumer 포함, bin 포함).
- `scripts/dune-local.sh runtest`: **EXIT=0**. 추가 인라인 테스트 통과.
- **harness-first 양방향 증명**: 재발생 arm 제거 시 테스트 `FAILED 1/1` (`safe_publish does not absorb Eio cancellation is false`), arm 복원 시 PASS. = clean-pass + buggy-fail.
- `scripts/check-sdk-independence.sh`: PASS (masc/keeper/board/room 미참조).
- `ocamlformat --check`: 변경 3파일 전부 CLEAN.

## 게이트

- RFC-gate subsystem(credential/operator/keeper/sandbox) **비대상** — pipeline event 발행 헬퍼.
- 워크어라운드 시그니처 **비해당** — telemetry-as-fix(오히려 삼킴 제거)·string분류기·cap/cooldown/dedup 아님. 중복 통합 = N-of-M 회피.

## 남은 미검증 / 후속

- 같은 헌팅에서 발견했으나 이번 PR 범위 밖(별도 판단 필요): `guardrail_tripwire.ml:45`의 `| Eio.Cancel.Cancelled _ -> false`는 `Fiber.first` race loser 처리로 doc-commented 의도지만 **외부 취소 전파** 관점에선 debatable → 별도 이슈로 기록 예정.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
