### PR TITLE
fix(sessions_store): return Error on malformed tool catalog instead of raising

### DIFF
--- a/lib/sessions_store.ml
+++ b/lib/sessions_store.ml
@@ -263,9 +263,14 @@ let get_tool_catalog ?session_root ~session_id () =
         ~artifact_id:artifact.artifact_id
         ()
     in
-    let* json = parse_json_string raw in
-    let open Yojson.Safe.Util in
-    Ok (json |> to_list |> List.map tool_contract_of_json)
+    (* decode_json_with parses [raw] (Json_error -> Error) and runs the decoder
+       under a Type_error guard, so a malformed catalog (non-list JSON, or a tool
+       object missing a required field) surfaces as Error instead of escaping
+       this function's result contract via an uncaught Type_error. Matches the
+       convention used by the telemetry/evidence decoders above. *)
+    decode_json_with
+      (fun json -> Yojson.Safe.Util.(json |> to_list |> List.map tool_contract_of_json))
+      raw
 ;;
 
 let get_raw_trace_runs ?session_root ~session_id () =

--- a/test/test_runtime_evidence.ml
+++ b/test/test_runtime_evidence.ml
@@ -699,6 +699,33 @@ let test_sessions_store_decodes_runtime_artifacts () =
        | None -> fail "expected shell constraints")
 ;;
 
+let test_get_tool_catalog_malformed_returns_error () =
+  with_temp_root "oas-tool-catalog-malformed"
+  @@ fun root ->
+  let store = Runtime_store.create ~root () |> Result.get_ok in
+  let session_id = "sess-tc" in
+  (* Well-formed JSON that is NOT a list: [to_list] (and [tool_contract_of_json])
+     raise Type_error. get_tool_catalog returns a result, so the decode failure
+     must surface as Error rather than escaping as an uncaught exception. The
+     artifact must be attached to the session (via save_session) so the named
+     lookup reaches the decode path rather than failing earlier. *)
+  let artifact =
+    write_artifact
+      store
+      session_id
+      ~artifact_id:"art-tool-catalog"
+      ~name:"tool-catalog"
+      ~kind:"json"
+      ~created_at:1.0
+      {|{"not":"a list"}|}
+  in
+  Runtime_store.save_session store (mk_session ~session_id ~artifacts:[ artifact ] ())
+  |> Result.get_ok;
+  check_error
+    "malformed tool catalog returns Error (not raise)"
+    (Sessions_store.get_tool_catalog ~session_root:root ~session_id ())
+;;
+
 let () =
   Alcotest.run
     "runtime_evidence"
@@ -730,6 +757,10 @@ let () =
             "sessions store artifact decoders"
             `Quick
             test_sessions_store_decodes_runtime_artifacts
+        ; Alcotest.test_case
+            "tool catalog malformed returns error"
+            `Quick
+            test_get_tool_catalog_malformed_returns_error
         ] )
     ]
 ;;


### PR DESCRIPTION
## 목표

`Sessions_store.get_tool_catalog`가 선언 타입 `(tool_contract list, Error.sdk_error) result`를 위반해, malformed tool-catalog 아티팩트에서 **`Error` 대신 `Type_error`를 raise**하던 parse-don't-validate 위반을 수정합니다.

```ocaml
(* sessions_store.ml:266-268 (before) *)
let* json = parse_json_string raw in       (* Json_error만 Error 처리 *)
let open Yojson.Safe.Util in
Ok (json |> to_list |> List.map tool_contract_of_json)   (* to_list/tool_contract_of_json의 Type_error는 escape *)
```

`parse_json_string`은 `Yojson.Json_error`(구문 오류)만 잡습니다. JSON은 valid하나 **list가 아닌 경우**(예: `{"not":"a list"}`)나 **tool object에 required 필드 누락** 시 `to_list`/`tool_contract_of_json`(`to_string`)이 `Yojson Type_error`를 던지고, 이게 Result 채널을 우회해 uncaught exception으로 호출자에 전파됩니다.

## 변경

`lib/sessions_store.ml`: 디코드를 `Sessions_store_parsers.decode_json_with`로 라우팅. 이 헬퍼는 `parse_json_string`(Json_error→Error) 후 `try Ok (decoder json) with Type_error -> Error`로 감쌉니다 — 같은 모듈의 `get_telemetry`/`get_evidence` 등이 이미 쓰는 관습입니다(:149/163/177). 손수 만든 우회 코드를 제거하고 관습에 정렬.

`test/test_runtime_evidence.ml`: 재현 테스트 추가 — `{"not":"a list"}` tool-catalog 아티팩트를 세션에 붙이고 `get_tool_catalog`가 `Error`를 반환함을 검증.

diff +39/-3 (2파일).

## 로컬 검증 (Draft는 CI Build&Test skip → 로컬이 유일 안전망)

- `scripts/dune-local.sh runtest`: **EXIT=0** (clean, fix 적용).
- **harness-first 양방향 증명**:
  - fix 제거 시 → `[FAIL] bundle 6 tool catalog malformed returns error` + `[exception] Yojson__Safe.Util.Type_error("Expected array, got object", _)` (= Type_error가 Result 밖으로 escape).
  - fix 복원 시 → `[OK]` (decode_json_with가 Type_error→Error).
  - (참고: 첫 테스트는 아티팩트를 세션에 연결 안 해 decode 전 단계에서 Error → vacuous였고, buggy-verify가 이를 잡아 `write_artifact`+`save_session`으로 교정.)
- `scripts/check-sdk-independence.sh`: PASS.
- `ocamlformat --check`: 변경 2파일 CLEAN.

## 게이트

- RFC-gate subsystem(credential/operator/keeper/sandbox) **비대상** — 세션 영속화 디코더.
- 워크어라운드 시그니처 **비해당** — parse-don't-validate 근본 수정(raise→typed Error). telemetry-as-fix/string분류기/N-of-M/cap-cooldown 아님. 파일 자체의 `decode_json_with` 관습을 사용(새 우회 추가 아님).

## 발견 경위

미탐색 top-level lib 클러스터(checkpoint/session-store/memory-parsers/eval-harness) 신규 헌팅. 같은 헌팅의 다른 후보들(silent skip, 누락 필드 backward-compat 기본값, tags→[], otel metric default 등)은 의도적/backward-compat/debatable로 판단해 미채택, 본 건만 Result 계약을 객관적으로 위반하는 명확 버그라 ship.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
