### PR TITLE
chore(fmt): reformat files left drifted by protocol-sublibrary extraction (#1896)

### DIFF
--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -261,8 +261,7 @@ let card t =
     match t.options.skill_registry with
     | Some reg ->
       List.map
-        (fun (s : Skill.t) ->
-           { Agent_card.name = s.name; description = s.description })
+        (fun (s : Skill.t) -> { Agent_card.name = s.name; description = s.description })
         (Skill_registry.list reg)
     | None -> []
   in

--- a/lib/base/util.ml
+++ b/lib/base/util.ml
@@ -162,4 +162,3 @@ let int_env_or default var =
      | _ -> default)
   | None -> default
 ;;
-

--- a/lib/base/util.mli
+++ b/lib/base/util.mli
@@ -100,4 +100,3 @@ val json_of_string_pairs : (string * string) list -> Yojson.Safe.t
 (** [int_env_or default var] looks up env var [var], trims it, parses it as a positive integer,
     and returns the integer value if valid, otherwise [default]. *)
 val int_env_or : int -> string -> int
-

--- a/lib/protocol/agent_card.mli
+++ b/lib/protocol/agent_card.mli
@@ -83,4 +83,3 @@ val of_info : agent_info -> agent_card
 val has_capability : agent_card -> capability -> bool
 val can_handle_tool : agent_card -> string -> bool
 val has_skill : agent_card -> string -> bool
-

--- a/lib/protocol/dune
+++ b/lib/protocol/dune
@@ -5,12 +5,12 @@
  (public_name agent_sdk.protocol)
  (wrapped true)
  (libraries
-   agent_sdk.base
-   yojson
-   eio
-   mcp_protocol
-   mcp_protocol.eio
-   mcp_protocol.http)
+  agent_sdk.base
+  yojson
+  eio
+  mcp_protocol
+  mcp_protocol.eio
+  mcp_protocol.http)
  (flags
   (:standard -open Agent_sdk_base))
  (inline_tests)


### PR DESCRIPTION
## 목표

**main이 현재 OCaml Format에서 RED입니다** (HEAD `1382bc28`, `OCaml Format: completed/failure`). 이 PR이 green으로 복구합니다.

원인: #1896(`agent_sdk.protocol` sublibrary 추출)이 **Draft로 머지** → Draft는 `OCaml Format` CI 게이트를 skip → squash 머지 시 그 PR이 건드린 5개 파일의 fmt drift가 main에 그대로 들어감. (반복 패턴: Draft가 fmt/Build&Test를 skip하므로 clean-diff PR이라도 머지 후 main이 red가 될 수 있음.)

Build & Test는 통과(success)했으므로 #1896의 구조 리팩토링 자체는 동작 보존됨 — 순수 포맷 drift만 남았습니다.

## 변경 (whitespace/layout only, semantic 변화 0)

CI가 플래그한 **정확히 그 5개 파일만** pinned `ocamlformat 0.29.0` + `dune format-dune-file`로 재포맷:

| 파일 | drift |
|------|-------|
| `lib/protocol/dune` | `(libraries ...)` stanza 들여쓰기 3→2 space |
| `lib/agent/agent_types.ml` | layout |
| `lib/base/util.ml` | trailing whitespace |
| `lib/base/util.mli` | EOF trailing blank line |
| `lib/protocol/agent_card.mli` | layout |

전체 repo reformat 아님(메모리 교훈: `dune fmt --root .`는 무관 파일까지 건드림) — `git diff --name-only` = 위 5개만.

## 로컬 검증

- `scripts/dune-local.sh build @fmt` (CI의 정확한 검사): **EXIT=0** — 잔여 diff 0, fmt green.
- `scripts/dune-local.sh runtest`: **EXIT=0**, 0 failures.
- `scripts/check-sdk-independence.sh`: PASS.
- diff 전수 리뷰: whitespace/layout만, 코드 변화 없음.

## 게이트

- RFC-gate subsystem 비대상 (포맷 chore).
- 워크어라운드 시그니처 비해당 (main green 복구, 코드 무변경).
- `chore(fmt)` → release-please 버전 bump 없음.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
