### PR TITLE
feat!: remove dead A2a error variant from sdk_error

### DIFF
--- a/lib/agent/agent_lifecycle.mli
+++ b/lib/agent/agent_lifecycle.mli
@@ -14,8 +14,6 @@
     [Running -> Ready] supports multi-turn agent loops where each turn
     cycles through [Ready -> Running -> Ready -> ...] before terminating.
 
-    Follows the pattern established by {!A2a_task.transition}.
-
     @stability Evolving
     @since 0.93.1
     @since 0.105.0 transition guards *)

--- a/lib/base/error.ml
+++ b/lib/base/error.ml
@@ -140,24 +140,6 @@ type orchestration_error =
       ; detail : string
       }
 
-(** A2A protocol errors. *)
-type a2a_error =
-  | TaskNotFound of { task_id : string }
-  | InvalidTransition of
-      { task_id : string
-      ; from_state : string
-      ; to_state : string
-      }
-  | MessageSendFailed of
-      { task_id : string
-      ; detail : string
-      }
-  | ProtocolError of { detail : string }
-  | StoreCapacityExceeded of
-      { current : int
-      ; max : int
-      }
-
 (** Top-level SDK error. *)
 type sdk_error =
   | Api of api_error
@@ -168,7 +150,6 @@ type sdk_error =
   | Serialization of serialization_error
   | Io of io_error
   | Orchestration of orchestration_error
-  | A2a of a2a_error
   | Internal of string
 
 (* ── Human-readable messages ──────────────────────────────────────── *)
@@ -265,21 +246,6 @@ let orchestration_error_to_string = function
   | DiscoveryFailed r -> Printf.sprintf "Agent discovery failed for %s: %s" r.url r.detail
 ;;
 
-let a2a_error_to_string = function
-  | TaskNotFound r -> Printf.sprintf "A2A task not found: %s" r.task_id
-  | InvalidTransition r ->
-    Printf.sprintf
-      "A2A invalid transition: %s -> %s (task %s)"
-      r.from_state
-      r.to_state
-      r.task_id
-  | MessageSendFailed r ->
-    Printf.sprintf "A2A message send failed for task %s: %s" r.task_id r.detail
-  | ProtocolError r -> Printf.sprintf "A2A protocol error: %s" r.detail
-  | StoreCapacityExceeded r ->
-    Printf.sprintf "A2A store capacity exceeded: %d/%d" r.current r.max
-;;
-
 let to_string = function
   | Api err -> Retry.error_message err
   | Provider err -> Llm_provider.Error.to_string err
@@ -289,7 +255,6 @@ let to_string = function
   | Serialization err -> serialization_error_to_string err
   | Io err -> io_error_to_string err
   | Orchestration err -> orchestration_error_to_string err
-  | A2a err -> a2a_error_to_string err
   | Internal msg -> Printf.sprintf "Internal error: %s" msg
 ;;
 
@@ -300,21 +265,5 @@ let is_retryable = function
   | Provider err -> Llm_provider.Error.is_retryable err
   | Mcp (ServerStartFailed _) -> false
   | Mcp _ -> true
-  | Agent _ | Config _ | Serialization _ | Io _ | Orchestration _ | A2a _ | Internal _ ->
-    false
-;;
-
-(* ── A2A convenience constructors ────────────────────────────────── *)
-
-let a2a_protocol detail = A2a (ProtocolError { detail })
-let a2a_task_not_found task_id = A2a (TaskNotFound { task_id })
-
-let a2a_invalid_transition ~task_id ~from_state ~to_state =
-  A2a (InvalidTransition { task_id; from_state; to_state })
-;;
-
-let a2a_message_send_failed ~task_id ~detail = A2a (MessageSendFailed { task_id; detail })
-
-let a2a_store_capacity_exceeded ~current ~max =
-  A2a (StoreCapacityExceeded { current; max })
+  | Agent _ | Config _ | Serialization _ | Io _ | Orchestration _ | Internal _ -> false
 ;;

--- a/lib/base/error.mli
+++ b/lib/base/error.mli
@@ -137,24 +137,6 @@ type orchestration_error =
       ; detail : string
       }
 
-(** A2A protocol errors. *)
-type a2a_error =
-  | TaskNotFound of { task_id : string }
-  | InvalidTransition of
-      { task_id : string
-      ; from_state : string
-      ; to_state : string
-      }
-  | MessageSendFailed of
-      { task_id : string
-      ; detail : string
-      }
-  | ProtocolError of { detail : string }
-  | StoreCapacityExceeded of
-      { current : int
-      ; max : int
-      }
-
 (** {1 Top-level error} *)
 
 type sdk_error =
@@ -166,7 +148,6 @@ type sdk_error =
   | Serialization of serialization_error
   | Io of io_error
   | Orchestration of orchestration_error
-  | A2a of a2a_error
   | Internal of string
 
 (** {1 Operations} *)
@@ -176,17 +157,3 @@ val to_string : sdk_error -> string
 
 (** Whether the error is transient and the operation can be retried. *)
 val is_retryable : sdk_error -> bool
-
-(** {1 A2A convenience constructors} *)
-
-val a2a_protocol : string -> sdk_error
-val a2a_task_not_found : string -> sdk_error
-
-val a2a_invalid_transition
-  :  task_id:string
-  -> from_state:string
-  -> to_state:string
-  -> sdk_error
-
-val a2a_message_send_failed : task_id:string -> detail:string -> sdk_error
-val a2a_store_capacity_exceeded : current:int -> max:int -> sdk_error

--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -58,11 +58,6 @@ type sdk_error_poly =
   | `Serialization of string
   | `Io of string
   | `Orchestration of string
-  | `A2a_task_not_found of string
-  | `A2a_invalid_transition of string * string * string
-  | `A2a_message_send_failed of string * string
-  | `A2a_protocol_error of string
-  | `A2a_store_capacity_exceeded of int * int
   | `Internal of string
   ]
 
@@ -136,13 +131,6 @@ let of_sdk_error (err : Error.sdk_error) : sdk_error_poly =
   | Error.Serialization e -> `Serialization (Error.to_string (Error.Serialization e))
   | Error.Io e -> `Io (Error.to_string (Error.Io e))
   | Error.Orchestration e -> `Orchestration (Error.to_string (Error.Orchestration e))
-  | Error.A2a (Error.TaskNotFound r) -> `A2a_task_not_found r.task_id
-  | Error.A2a (Error.InvalidTransition r) ->
-    `A2a_invalid_transition (r.task_id, r.from_state, r.to_state)
-  | Error.A2a (Error.MessageSendFailed r) -> `A2a_message_send_failed (r.task_id, r.detail)
-  | Error.A2a (Error.ProtocolError r) -> `A2a_protocol_error r.detail
-  | Error.A2a (Error.StoreCapacityExceeded r) ->
-    `A2a_store_capacity_exceeded (r.current, r.max)
   | Error.Internal s -> `Internal s
 ;;
 
@@ -213,14 +201,6 @@ let to_sdk_error (err : sdk_error_poly) : Error.sdk_error =
   | `Serialization detail -> Error.Serialization (JsonParseError { detail })
   | `Io detail -> Error.Io (ValidationFailed { detail })
   | `Orchestration detail -> Error.Internal detail
-  | `A2a_task_not_found task_id -> Error.a2a_task_not_found task_id
-  | `A2a_invalid_transition (task_id, from_state, to_state) ->
-    Error.a2a_invalid_transition ~task_id ~from_state ~to_state
-  | `A2a_message_send_failed (task_id, detail) ->
-    Error.a2a_message_send_failed ~task_id ~detail
-  | `A2a_protocol_error detail -> Error.a2a_protocol detail
-  | `A2a_store_capacity_exceeded (current, max) ->
-    Error.a2a_store_capacity_exceeded ~current ~max
   | `Internal s -> Error.Internal s
 ;;
 
@@ -286,11 +266,6 @@ let is_retryable (err : [< sdk_error_poly ]) : bool =
   | `Serialization _
   | `Io _
   | `Orchestration _
-  | `A2a_task_not_found _
-  | `A2a_invalid_transition _
-  | `A2a_message_send_failed _
-  | `A2a_protocol_error _
-  | `A2a_store_capacity_exceeded _
   | `Internal _ -> false
 ;;
 

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -89,11 +89,6 @@ type sdk_error_poly =
   | `Serialization of string
   | `Io of string
   | `Orchestration of string
-  | `A2a_task_not_found of string
-  | `A2a_invalid_transition of string * string * string
-  | `A2a_message_send_failed of string * string
-  | `A2a_protocol_error of string
-  | `A2a_store_capacity_exceeded of int * int
   | `Internal of string
   ]
 

--- a/test/test_error_domain.ml
+++ b/test/test_error_domain.ml
@@ -169,11 +169,6 @@ let test_to_string_each_variant () =
     ; `Serialization "bad json"
     ; `Io "file missing"
     ; `Orchestration "routing failed"
-    ; `A2a_task_not_found "tid"
-    ; `A2a_invalid_transition ("tid", "s1", "s2")
-    ; `A2a_message_send_failed ("tid", "err")
-    ; `A2a_protocol_error "proto"
-    ; `A2a_store_capacity_exceeded (100, 50)
     ; `Internal "bug"
     ]
   in
@@ -213,11 +208,6 @@ let test_all_variants_convert () =
     ; `Serialization "x"
     ; `Io "x"
     ; `Orchestration "x"
-    ; `A2a_task_not_found "t1"
-    ; `A2a_invalid_transition ("t1", "working", "submitted")
-    ; `A2a_message_send_failed ("t1", "timeout")
-    ; `A2a_protocol_error "bad request"
-    ; `A2a_store_capacity_exceeded (100, 100)
     ; `Internal "x"
     ]
   in
@@ -484,18 +474,6 @@ let test_roundtrip_orchestration () =
   | _ -> Alcotest.fail "roundtrip mismatch for Orchestration"
 ;;
 
-let test_roundtrip_a2a () =
-  let orig = Error.A2a (Error.ProtocolError { detail = "protocol error" }) in
-  let poly = Error_domain.of_sdk_error orig in
-  (match poly with
-   | `A2a_protocol_error "protocol error" -> ()
-   | _ -> Alcotest.fail "expected A2a_protocol_error");
-  let back = Error_domain.to_sdk_error poly in
-  match back with
-  | Error.A2a (Error.ProtocolError _) -> ()
-  | _ -> Alcotest.fail "roundtrip mismatch for A2a"
-;;
-
 (* ── is_retryable: cover remaining branches ─────────────── *)
 
 let test_retryable_overloaded () =
@@ -619,13 +597,6 @@ let test_retryable_orchestration () =
     "orchestration not retryable"
     false
     (Error_domain.is_retryable (`Orchestration "x"))
-;;
-
-let test_retryable_a2a () =
-  Alcotest.(check bool)
-    "a2a not retryable"
-    false
-    (Error_domain.is_retryable (`A2a_protocol_error "x"))
 ;;
 
 let test_retryable_internal () =
@@ -780,7 +751,6 @@ let () =
         ; Alcotest.test_case "serialization" `Quick test_roundtrip_serialization
         ; Alcotest.test_case "io" `Quick test_roundtrip_io
         ; Alcotest.test_case "orchestration" `Quick test_roundtrip_orchestration
-        ; Alcotest.test_case "a2a" `Quick test_roundtrip_a2a
         ; Alcotest.test_case "internal" `Quick test_roundtrip_internal
         ] )
     ; ( "retryable"
@@ -812,7 +782,6 @@ let () =
         ; Alcotest.test_case "serialization" `Quick test_retryable_serialization
         ; Alcotest.test_case "io" `Quick test_retryable_io
         ; Alcotest.test_case "orchestration" `Quick test_retryable_orchestration
-        ; Alcotest.test_case "a2a" `Quick test_retryable_a2a
         ; Alcotest.test_case "internal" `Quick test_retryable_internal
         ] )
     ; ( "context"

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -311,8 +311,6 @@ let test_error_domain_full_roundtrip () =
     ; Agent_sdk.Error.Mcp (ToolCallFailed { tool_name = "fs_read"; detail = "denied" })
     ; Agent_sdk.Error.Mcp
         (HttpTransportFailed { url = "http://x"; detail = "conn refused" })
-    ; Agent_sdk.Error.a2a_task_not_found "task-1"
-    ; Agent_sdk.Error.a2a_protocol "bad version"
     ; Agent_sdk.Error.Internal "something broke"
     ]
   in


### PR DESCRIPTION
## 목적

죽은 `A2a` 에러 variant와 `a2a_error` ADT를 SDK 공개 에러 타입에서 제거합니다. PR #118에서 도입된 구조화 A2A 에러(5 variant: `TaskNotFound`/`InvalidTransition`/`MessageSendFailed`/`ProtocolError`/`StoreCapacityExceeded`)이지만, 이를 **생성하는 live 코드가 없습니다** — `a2a_task_store`나 A2A 프로토콜 핸들러가 없고, `Error.A2a` variant·domain `` `A2a_* `` variant를 produce하는 곳이 error 배관(error.ml/error_domain.ml) 밖에 0건입니다. 즉 미배선 scaffolding입니다.

masc-mcp 의 portal/a2a 제거(masc-mcp #20016)에 이어, a2a를 외부 SDK 레벨에서도 정리하는 cross-repo 후속입니다.

## 제거

- `Error.a2a_error` 타입 + `Error.A2a` variant + `a2a_error_to_string` + 5개 `a2a_*` smart constructor (`lib/base/error.ml`/`.mli`)
- `sdk_error_poly` 의 `` `A2a_* `` 케이스 + `of_sdk_error`/`to_sdk_error`/`is_retryable` arm (`lib/error_domain.ml`/`.mli`)
- stale `{!A2a_task.transition}` doc 참조 (`agent_lifecycle.mli`)
- a2a 테스트 케이스 (`test_error_domain`, `test_http_client`)

## 건드리지 않은 것

`test_runtime_sync` 의 `"a2a://task/..."` 스트림/아티팩트 식별자와 `test_agent_card` 의 `"http://.../a2a"` URL은 **별개 개념**(A2A-as-streaming / agent-card URL)이며 제거한 에러 타입을 사용하지 않습니다.

## 영향 (breaking)

`Error.A2a` 와 `a2a_*` constructor는 공개 `sdk_error` API에서 제거됩니다 (`feat!` → release-please minor bump 0.200.x → 0.201.0). `Error.A2a` 를 match하는 소비자는 해당 arm을 제거해야 합니다.

masc-mcp 는 `agent_sdk` 를 **git 핀**(`masc.opam.locked`)으로 받으므로 이 변경에 즉시 영향받지 않습니다. masc-mcp 가 새 커밋으로 핀을 올릴 때 ~20개 `Agent_sdk.Error.A2a` match arm이 컴파일러 강제로 정리됩니다 (별도 후속).

## 검증

- `dune build --root .` : exit 0, 에러 0 (lib + test + bin)
- ocamlformat 0.29.0 : 변경 7파일 전부 clean
- 영향 테스트: `test_error_domain` 62 / `test_http_client` 18 — 모두 Test Successful

7 files changed.
