### PR TITLE
test(guardrails): use OS-assigned free ports to fix EADDRINUSE flake

### DIFF
--- a/test/test_guardrails_integration.ml
+++ b/test/test_guardrails_integration.ml
@@ -45,12 +45,30 @@ let text_only_handler _conn _req body =
   Cohttp_eio.Server.respond_string ~status:`OK ~body:(text_body "ok") ()
 ;;
 
-let with_mock_server ~port handler f =
+(* Bind to port 0 so the OS assigns a free port, avoiding EADDRINUSE flakes
+   when test executables run in parallel (fixed ports here collided with the
+   same hardcoded range in test_context_flow_proof.ml). Mirrors the fresh_port
+   helper in test_provider_intf.ml. *)
+let fresh_port () =
+  let s = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Unix.setsockopt s Unix.SO_REUSEADDR true;
+  Unix.bind s (Unix.ADDR_INET (Unix.inet_addr_loopback, 0));
+  let port =
+    match Unix.getsockname s with
+    | Unix.ADDR_INET (_, p) -> p
+    | _ -> Alcotest.fail "expected inet socket"
+  in
+  Unix.close s;
+  port
+;;
+
+let with_mock_server ?port handler f =
   Eio_main.run
   @@ fun env ->
   try
     Eio.Switch.run
     @@ fun sw ->
+    let port = Option.value ~default:(fresh_port ()) port in
     let socket =
       Eio.Net.listen
         env#net
@@ -80,7 +98,6 @@ let test_deny_list_hides_tool () =
   let tools_seen = ref 0 in
   let tool_calls = ref 0 in
   with_mock_server
-    ~port:18201
     (tracking_handler ~tool_use_count:tool_calls ~tools_seen_count:tools_seen)
     (fun ~sw ~net ~base_url ->
        let tools = [ make_tool "a"; make_tool "b"; make_tool "c" ] in
@@ -101,7 +118,6 @@ let test_allow_list_filters () =
   let tools_seen = ref 0 in
   let tool_calls = ref 0 in
   with_mock_server
-    ~port:18202
     (tracking_handler ~tool_use_count:tool_calls ~tools_seen_count:tools_seen)
     (fun ~sw ~net ~base_url ->
        let tools = [ make_tool "a"; make_tool "b"; make_tool "c" ] in
@@ -122,7 +138,6 @@ let test_custom_prefix_filter () =
   let tools_seen = ref 0 in
   let tool_calls = ref 0 in
   with_mock_server
-    ~port:18203
     (tracking_handler ~tool_use_count:tool_calls ~tools_seen_count:tools_seen)
     (fun ~sw ~net ~base_url ->
        let tools =
@@ -180,7 +195,7 @@ let test_limit_blocks_multi_tool_response () =
     in
     Cohttp_eio.Server.respond_string ~status:`OK ~body:response_body ()
   in
-  with_mock_server ~port:18204 multi_tool_handler (fun ~sw ~net ~base_url ->
+  with_mock_server multi_tool_handler (fun ~sw ~net ~base_url ->
     let tool_calls = ref 0 in
     let tool =
       Tool.create ~name:"echo" ~description:"echo" ~parameters:[] (fun _input ->
@@ -205,7 +220,6 @@ let test_no_limit_allows_all () =
   let tool_use_count = ref 3 in
   let tools_seen = ref 0 in
   with_mock_server
-    ~port:18205
     (tracking_handler ~tool_use_count ~tools_seen_count:tools_seen)
     (fun ~sw ~net ~base_url ->
        let tool_calls = ref 0 in
@@ -225,7 +239,7 @@ let test_no_limit_allows_all () =
 (* ── edge case tests ─────────────────────────────────── *)
 
 let test_empty_tools_no_crash () =
-  with_mock_server ~port:18206 text_only_handler (fun ~sw ~net ~base_url ->
+  with_mock_server text_only_handler (fun ~sw ~net ~base_url ->
     let options =
       { Agent.default_options with
         base_url
@@ -242,7 +256,7 @@ let test_empty_tools_no_crash () =
 ;;
 
 let test_guardrails_default_with_agent () =
-  with_mock_server ~port:18207 text_only_handler (fun ~sw ~net ~base_url ->
+  with_mock_server text_only_handler (fun ~sw ~net ~base_url ->
     let options = { Agent.default_options with base_url } in
     let tools = [ make_tool "a"; make_tool "b" ] in
     let agent = Agent.create ~net ~options ~tools () in


### PR DESCRIPTION
## 목표

**main이 Build & Test에서 flake로 red**가 됐던 원인을 근본 수정합니다. `tool_filter / custom prefix filter` 테스트가 `Unix.EADDRINUSE`로 실패(merge SHA `c96dbe08`).

원인: `test_guardrails_integration.ml`의 mock server가 **고정 포트 18201-18207**을 bind하는데, `test_context_flow_proof.ml`도 **겹치는 18200-18203**을 하드코딩합니다. dune는 테스트 실행파일을 **병렬 실행**하므로 두 파일이 동시에 18203을 bind → 한쪽이 EADDRINUSE. (`~reuse_addr:true`가 있어도 두 *live listener*가 같은 loopback 포트를 점유하면 충돌 — SO_REUSEADDR는 TIME_WAIT만 해결.)

## 변경 (test-only, 동작 보존)

`test_provider_intf.ml`에 이미 검증된 `fresh_port ()` 패턴(포트 0 bind → `getsockname`으로 OS 할당 포트 읽기)을 도입:
- `with_mock_server ~port` → `?port` (`Option.value ~default:(fresh_port ())`).
- 7개 call site에서 `~port:182xx` 제거 → 각 서버가 OS 할당 ephemeral 포트 사용 → 병렬 실행파일과 bind 충돌이 **virtually never**(고정 포트는 병렬 시 *guaranteed* 충돌이었음).

포트는 `base_url` 생성에만 쓰였고(리터럴 포트 단언/handler closure 없음) → 동작 보존.

## 검증

- `scripts/dune-local.sh runtest`: **EXIT=0**. `tool_filter 0/1/2`(deny/allow/**custom prefix** — 깨졌던 테스트) 전부 `[OK]`, EADDRINUSE 없음.
- `ocamlformat --check`: CLEAN. SDK Independence Gate: PASS.
- flake fix harness 증명: (1) 7개 테스트가 ephemeral 포트에서 통과(동작 보존) + (2) 충돌 확률을 negligible화(비결정 flake라 buggy-verify 불가). 주의: `fresh_port`가 소켓을 close한 뒤 server가 re-bind하므로 close↔listen TOCTOU 창이 미세하게 남음 = *negligible*이지 *impossible* 아님. 창 제거(fd 유지)는 미적용 — `test_provider_intf.ml`이 동일 패턴으로 무사고 운영 = 실증.

## 범위

- **이 PR = 실패한 파일(guardrails)만** ephemeral 전환 → 파트너가 누구든 무관하게 면역(원칙: 실패한 것을 고친다).
- **더 큰 근본수정**(9개 테스트 파일이 하드코딩-포트 mock server를 중복 → 공유 `free_port` 헬퍼로 통합)은 별도 이슈로 분리(1 이슈/라운드).
- RFC-gate 비대상(test). 워크어라운드 비해당(ephemeral port = 올바른 패턴, renumber band-aid 거부).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
