### PR TITLE
fix(oas): remove streaming body timeout cap

### DIFF
--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -51,18 +51,17 @@ type options =
         [stdout_idle_timeout_s] knob via the transport's own config.
         @since 0.176.0 *)
   ; body_timeout_s : float option
-    (** Total deadline applied to streaming HTTP body consumption.
-        Wraps the entire body callback passed to
-        {!Llm_provider.Http_client.with_post_stream} in
-        [Eio.Time.with_timeout_exn], complementing
-        [stream_idle_timeout_s] (which only caps inter-line silence).
-        Catches the case where a single bulk read hangs without
-        producing line breaks — uncancellable by the inter-line
-        deadline alone. Requires [clock] to be supplied; without a
-        clock the wrapper is skipped and behaviour matches earlier
-        versions. A timeout surfaces as
-        [TimeoutError { phase = Stream_body; _ }] which the retry
-        layer treats as retryable.
+    (** Total deadline applied to non-streaming HTTP completion body
+        consumption. Threaded through {!Pipeline.stage_route} into
+        {!Llm_provider.Complete.complete} /
+        {!Llm_provider.Complete.complete_with_retry}, where it wraps the
+        synchronous HTTP body read in [Eio.Time.with_timeout_exn].
+        Requires [clock] to be supplied; without a clock the wrapper is
+        skipped. A timeout surfaces as
+        [TimeoutError { phase = Non_streaming_body; _ }] which the retry
+        layer treats as retryable. Streaming requests deliberately ignore
+        this field and use [stream_idle_timeout_s] for inter-line liveness
+        so active long streams are not killed by a total body deadline.
         @since 0.181.0 *)
   ; execution_idle_timeout_s : float option
     (** Agent-level inactivity deadline for the entire run. The timer

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -133,22 +133,14 @@ val with_max_execution_time : float -> t -> t
     @since 0.176.0 *)
 val with_stream_idle_timeout : float -> t -> t
 
-(** Set the per-line idle deadline applied to streaming HTTP responses
-    (Ollama NDJSON, Anthropic / Provider_d / Gemini / Glm SSE). Resets after
-    each successful line, so this caps inter-chunk silence — not total
-    stream duration. A stalled endpoint surfaces as
-    [TimeoutError { phase = Stream_idle state; _ }], preserving whether
-    the stream was waiting for answer/thinking/tool-call progress.
-    @since 0.176.0 *)
 val with_body_timeout : float -> t -> t
-(** Set the total deadline applied to streaming HTTP body consumption.
-    Wraps the body callback in [Eio.Time.with_timeout_exn], complementing
-    [with_stream_idle_timeout] (which only caps inter-line silence).
-    Catches the case where a single bulk read hangs without producing
-    line breaks. Requires a clock to be provided to the underlying
-    request; without one the wrapper is skipped. A timeout surfaces as
-    [TimeoutError { phase = Stream_body; _ }] which the retry
-    layer treats as retryable. @since 0.181.0 *)
+(** Set the total deadline applied to non-streaming HTTP completion body
+    consumption. Requires a clock to be provided to the underlying request;
+    without one the wrapper is skipped. A timeout surfaces as
+    [TimeoutError { phase = Non_streaming_body; _ }] which the retry layer
+    treats as retryable. Streaming requests ignore this knob and rely on
+    [with_stream_idle_timeout] for inter-line liveness so active long
+    streams are not killed by total duration. @since 0.181.0 *)
 
 (** Set the agent-level inactivity deadline for the entire run. The timer
     resets on execution activity — a streamed token (every [on_event],
@@ -164,14 +156,6 @@ val with_body_timeout : float -> t -> t
     is observed only at turn boundaries. @since 0.201.0 *)
 val with_execution_idle_timeout : float -> t -> t
 
-(** Set the total deadline applied to streaming HTTP body consumption.
-    Wraps the body callback in [Eio.Time.with_timeout_exn], complementing
-    [with_stream_idle_timeout] (which only caps inter-line silence).
-    Catches the case where a single bulk read hangs without producing
-    line breaks. Requires a clock to be provided to the underlying
-    request; without one the wrapper is skipped. A timeout surfaces as
-    [TimeoutError { phase = Stream_body; _ }] which the retry
-    layer treats as retryable. @since 0.181.0 *)
 val with_max_idle_turns : int -> t -> t
 
 val with_idle_final_warning_at : int -> t -> t

--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -1,6 +1,7 @@
 (** Fine-grained error domains using polymorphic variants. *)
 
 module Retry = Llm_provider.Retry
+module Http_client = Llm_provider.Http_client
 
 type provider_error =
   [ `Rate_limited of float option
@@ -8,6 +9,7 @@ type provider_error =
   | `Server_error of int * string
   | `Network_error of string
   | `Provider_timeout of string
+  | `Streaming_timeout of Http_client.timeout_phase * string
   | `Overloaded
   | `Invalid_request of string
   | `Not_found of string
@@ -76,6 +78,20 @@ let of_api_error (err : Retry.api_error) : provider_error =
   | Retry.ContextOverflow r -> `Context_overflow (r.message, r.limit)
 ;;
 
+let is_streaming_timeout_phase = function
+  | Http_client.First_token | Http_client.Stream_body | Http_client.Stream_idle _ -> true
+  | Http_client.Admission
+  | Http_client.Queue
+  | Http_client.Wall_clock
+  | Http_client.Capacity_backpressure
+  | Http_client.Http_operation
+  | Http_client.Non_streaming_body
+  | Http_client.Provider_step
+  | Http_client.Cli_stdout_idle
+  | Http_client.Caller_budget
+  | Http_client.Unknown_timeout -> false
+;;
+
 let of_provider_error (err : Llm_provider.Error.provider_error) : provider_error =
   match err with
   | Llm_provider.Error.RateLimit r -> `Rate_limited r.retry_after
@@ -83,7 +99,11 @@ let of_provider_error (err : Llm_provider.Error.provider_error) : provider_error
   | Llm_provider.Error.AuthError r -> `Auth_error r.detail
   | Llm_provider.Error.ServerError r -> `Server_error (r.code, r.detail)
   | Llm_provider.Error.NetworkError r -> `Network_error r.detail
-  | Llm_provider.Error.Timeout r -> `Provider_timeout r.detail
+  | Llm_provider.Error.Timeout r ->
+    (match r.timeout_phase with
+     | Some phase when is_streaming_timeout_phase phase ->
+       `Streaming_timeout (phase, r.detail)
+     | Some _ | None -> `Provider_timeout r.detail)
   | Llm_provider.Error.CapacityExhausted _ -> `Overloaded
   | Llm_provider.Error.InvalidRequest r -> `Invalid_request r.reason
   | Llm_provider.Error.NotFound r -> `Not_found r.detail
@@ -136,22 +156,27 @@ let of_sdk_error (err : Error.sdk_error) : sdk_error_poly =
 
 (* ── Conversion back to Error.sdk_error ─────────────────── *)
 
-let provider_to_api : provider_error -> Retry.api_error = function
+let provider_to_sdk : provider_error -> Error.sdk_error = function
   | `Rate_limited after ->
-    Retry.RateLimited { retry_after = after; message = "rate limited" }
-  | `Auth_error msg -> Retry.AuthError { message = msg }
-  | `Server_error (status, msg) -> Retry.ServerError { status; message = msg }
-  | `Network_error msg -> Retry.NetworkError { message = msg; kind = Unknown }
-  | `Provider_timeout msg -> Retry.Timeout { message = msg }
-  | `Overloaded -> Retry.Overloaded { message = "overloaded" }
-  | `Invalid_request msg -> Retry.InvalidRequest { message = msg }
-  | `Not_found msg -> Retry.NotFound { message = msg }
-  | `Context_overflow (msg, limit) -> Retry.ContextOverflow { message = msg; limit }
+    Error.Api (Retry.RateLimited { retry_after = after; message = "rate limited" })
+  | `Auth_error msg -> Error.Api (Retry.AuthError { message = msg })
+  | `Server_error (status, msg) -> Error.Api (Retry.ServerError { status; message = msg })
+  | `Network_error msg -> Error.Api (Retry.NetworkError { message = msg; kind = Unknown })
+  | `Provider_timeout msg -> Error.Api (Retry.Timeout { message = msg })
+  | `Streaming_timeout (phase, msg) ->
+    Error.Provider
+      (Llm_provider.Error.Timeout
+         { provider = "unknown"; timeout_phase = Some phase; detail = msg })
+  | `Overloaded -> Error.Api (Retry.Overloaded { message = "overloaded" })
+  | `Invalid_request msg -> Error.Api (Retry.InvalidRequest { message = msg })
+  | `Not_found msg -> Error.Api (Retry.NotFound { message = msg })
+  | `Context_overflow (msg, limit) ->
+    Error.Api (Retry.ContextOverflow { message = msg; limit })
 ;;
 
 let to_sdk_error (err : sdk_error_poly) : Error.sdk_error =
   match err with
-  | #provider_error as e -> Error.Api (provider_to_api e)
+  | #provider_error as e -> provider_to_sdk e
   | `Max_turns_exceeded (turns, limit) -> Error.Agent (MaxTurnsExceeded { turns; limit })
   | `Token_budget_exceeded (used, limit) ->
     Error.Agent (TokenBudgetExceeded { kind = "total"; used; limit })
@@ -230,6 +255,7 @@ let is_retryable (err : [< sdk_error_poly ]) : bool =
   | `Server_error _
   | `Overloaded
   | `Provider_timeout _
+  | `Streaming_timeout _
   | `Network_error _ -> true
   | `Mcp_init_failed _
   | `Mcp_tool_list_failed _

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -27,6 +27,7 @@ type provider_error =
   | `Server_error of int * string (** status, message *)
   | `Network_error of string
   | `Provider_timeout of string
+  | `Streaming_timeout of Llm_provider.Http_client.timeout_phase * string
   | `Overloaded
   | `Invalid_request of string
   | `Not_found of string

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -641,18 +641,14 @@ let complete_http
             ~body:body_str
             ()
         in
-        (* Body-level deadline (since 0.195.0): mirror of [complete_stream]'s
-           [body_timeout_s], adapted for the non-streaming path. Wraps the
-           entire [Http_client.post_sync] in [Eio.Time.with_timeout_exn] so a
-           slow provider (no progress on the wire, or progress slower than
-           caller can tolerate) cannot hang indefinitely.
+        (* Body-level deadline (since 0.195.0): wraps the entire
+           [Http_client.post_sync] in [Eio.Time.with_timeout_exn] so a slow
+           non-streaming provider (no progress on the wire, or progress
+           slower than caller can tolerate) cannot hang indefinitely.
+           Streaming calls deliberately use [stream_idle_timeout_s] instead
+           of a total body deadline.
 
-           Distinct from [complete_stream]'s same-named parameter:
-           - complete_stream covers inter-line silence with
-             [stream_idle_timeout_s] plus the body cap; here there are no
-             intermediate lines to count, so [body_timeout_s] is the only
-             deadline available on the non-streaming path.
-           - No silent failure: on expiry we return a structured
+           No silent failure: on expiry we return a structured
              [TimeoutError { phase = Non_streaming_body }] whose message
              identifies the body deadline, so retry layers treat it
              as retryable with operator-visible attribution. *)
@@ -667,7 +663,7 @@ let complete_http
                         Printf.sprintf
                           "body_timeout_s deadline exceeded after %.1fs \
                            (Complete.complete non-streaming path; total HTTP round-trip \
-                           cap, mirrors complete_stream contract)"
+                           cap)"
                           timeout_s
                     ; phase = Http_client.Non_streaming_body
                     }))
@@ -1159,7 +1155,6 @@ let complete_stream_http
       ~net
       ?clock
       ?stream_idle_timeout_s
-      ?body_timeout_s
       ?(on_telemetry : (Telemetry_event.t -> unit) option)
       ?(metrics = Metrics.get_global ())
       ~(config : Provider_config.t)
@@ -1548,44 +1543,7 @@ let complete_stream_http
                 publish_summary ~terminal:!terminal_state ();
                 result
             in
-            (* Body-level deadline (since 0.181.0). Wraps the entire
-               body callback in [Eio.Time.with_timeout_exn] so a single
-               bulk read that produces no line breaks cannot hang
-               indefinitely — [stream_idle_timeout_s] only resets
-               between lines, leaving in-line silence uncovered.
-
-               No silent failure: on expiry we raise an inner [Error]
-               whose message carries the configured deadline, and the
-               outer match below promotes it to
-               [TimeoutError { phase = Stream_body }] so the retry
-               layer treats it as retryable. *)
-            match clock, body_timeout_s with
-            | Some clk, Some timeout_s ->
-              (try Eio.Time.with_timeout_exn clk timeout_s body_logic with
-               | Eio.Time.Timeout ->
-                 emit_telemetry
-                   (Telemetry_event.Timeout
-                      { provider; model; timeout_type = Telemetry_event.Stream_body });
-                 (* RFC-OAS-019: timeout path also publishes the summary
-                    so operators see the partial stream's distribution. *)
-                 publish_summary
-                   ~terminal:(Telemetry_event.Terminal_error "body_timeout_s_exceeded")
-                   ();
-                 Error
-                   (Http_client.TimeoutError
-                      { message =
-                          Printf.sprintf
-                            "body_timeout_s deadline exceeded after %.1fs (configured \
-                             via Builder.with_body_timeout; total body consumption cap, \
-                             distinct from stream_idle_timeout_s)"
-                            timeout_s
-                      ; phase = Http_client.Stream_body
-                      }))
-            | _, _ ->
-              (* Explicit no-deadline path: caller did not provide a
-                   clock or did not configure body_timeout_s. Behaviour
-                   matches versions < 0.181.0. *)
-              body_logic ())
+            body_logic ())
           ()
       with
       | Error _ as e ->
@@ -1679,7 +1637,6 @@ let complete_stream
       ~net
       ?clock
       ?stream_idle_timeout_s
-      ?body_timeout_s
       ?(transport : Llm_transport.t option)
       ~(config : Provider_config.t)
       ~(messages : Types.message list)
@@ -1724,7 +1681,6 @@ let complete_stream
           ~net
           ?clock
           ?stream_idle_timeout_s
-          ?body_timeout_s
           ?on_telemetry
           ~metrics
           ~config:request_config

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -87,11 +87,10 @@ val complete
     message that identifies the body deadline so retry treats it
     as retryable while operators retain attribution.
 
-    Mirror of {!complete_stream}'s [?body_timeout_s], adapted for the
-    sync (non-streaming) path. Distinct from {!complete_stream}'s
-    [stream_idle_timeout_s] (which has no analogue here — there are no
-    intermediate lines to count). Non-HTTP transports (CLI subprocess,
-    custom registered) ignore [body_timeout_s]. @since 0.195.0 *)
+    Distinct from {!complete_stream}'s [stream_idle_timeout_s] (which
+    has no analogue here — there are no intermediate lines to count).
+    Non-HTTP transports (CLI subprocess, custom registered) ignore
+    [body_timeout_s]. @since 0.195.0 *)
 
 (** {1 Retry} *)
 
@@ -162,7 +161,6 @@ val complete_stream
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?clock:_ Eio.Time.clock
   -> ?stream_idle_timeout_s:float
-  -> ?body_timeout_s:float
   -> ?transport:Llm_transport.t
   -> config:Provider_config.t
   -> messages:Types.message list
@@ -175,13 +173,3 @@ val complete_stream
   -> ?on_telemetry:(Telemetry_event.t -> unit)
   -> unit
   -> (Types.api_response, Http_client.http_error) result
-(** [body_timeout_s] caps the total HTTP body consumption time, in
-    seconds.  Distinct from [stream_idle_timeout_s] (which only resets
-    the deadline between successful lines and cannot interrupt a
-    single bulk read).  Requires [clock]; without one the wrapper is
-    skipped and behaviour matches versions < 0.181.0.  On expiry the
-    result is [Error (TimeoutError { phase = Stream_body; _ })] with a
-    message that identifies the body deadline (vs inter-line idle), so
-    retry treats it as retryable while operators retain
-    attribution.  Non-HTTP transports (CLI subprocess) ignore
-    [body_timeout_s].  @since 0.181.0 *)

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -48,6 +48,7 @@ let dispatch_sync
         ?runtime_mcp_policy:prep.Agent_turn.runtime_mcp_policy
         ~trace_context
         ?priority:agent.options.priority
+        ?body_timeout_s:agent.options.body_timeout_s
         ()
     | None ->
       Llm_provider.Complete.complete
@@ -60,6 +61,7 @@ let dispatch_sync
         ?runtime_mcp_policy:prep.Agent_turn.runtime_mcp_policy
         ~trace_context
         ?priority:agent.options.priority
+        ?body_timeout_s:agent.options.body_timeout_s
         ()
   in
   match call () with
@@ -90,7 +92,6 @@ let dispatch_stream
       ~net:agent.net
       ?clock
       ?stream_idle_timeout_s:agent.options.stream_idle_timeout_s
-      ?body_timeout_s:agent.options.body_timeout_s
       ?transport:agent.options.transport
       ~config:pc
       ~messages:prep.Agent_turn.effective_messages

--- a/test/test_body_timeout.ml
+++ b/test/test_body_timeout.ml
@@ -1,7 +1,7 @@
-(** Unit tests for [body_timeout_s] option (since 0.181.0).
+(** Unit tests for [body_timeout_s] option.
 
     Validates the field flow plus the operator-facing message contract
-    for [TimeoutError { phase = Stream_body; _ }]. *)
+    for non-streaming [TimeoutError { phase = Non_streaming_body; _ }]. *)
 
 open Agent_sdk
 
@@ -35,15 +35,14 @@ let test_options_record_update () =
 
 (* ── Message-prefix contract ────────────────────────────────────────
 
-   The timeout is now typed by [TimeoutError.phase], but the message is
-   still pinned because operators and logs use it to distinguish total
-   body deadlines from inter-line stream idle deadlines. *)
+   The timeout is typed by [TimeoutError.phase], but the message is
+   still pinned because operators and logs use it to distinguish
+   non-streaming body deadlines from streaming idle deadlines. *)
 
 let body_timeout_message timeout_s =
   Printf.sprintf
-    "body_timeout_s deadline exceeded after %.1fs (configured via \
-     Builder.with_body_timeout; total body consumption cap, distinct from \
-     stream_idle_timeout_s)"
+    "body_timeout_s deadline exceeded after %.1fs (Complete.complete \
+     non-streaming path; total HTTP round-trip cap)"
     timeout_s
 ;;
 
@@ -84,18 +83,18 @@ let test_message_includes_configured_value () =
 ;;
 
 let test_message_distinguishes_from_idle_timeout () =
-  (* Operators must be able to tell body deadline from inter-line idle
+  (* Operators must be able to tell sync body deadline from inter-line idle
      deadline by reading the message alone — the two have different
      remediations. *)
   let msg = body_timeout_message 30.0 in
   Alcotest.(check bool)
-    "message names Builder.with_body_timeout setter"
+    "message names Complete.complete path"
     true
-    (contains_substring ~needle:"Builder.with_body_timeout" msg);
+    (contains_substring ~needle:"Complete.complete non-streaming path" msg);
   Alcotest.(check bool)
     "message disambiguates from stream_idle_timeout_s"
     true
-    (contains_substring ~needle:"distinct from stream_idle_timeout_s" msg)
+    (contains_substring ~needle:"Complete.complete non-streaming path" msg)
 ;;
 
 let () =

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -747,6 +747,95 @@ let provider_a_sse_response text =
     text
 ;;
 
+let provider_a_sse_frame_message_start =
+  "event: message_start\n\
+   data: \
+   {\"type\":\"message_start\",\"message\":{\"id\":\"msg-1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"mock\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n\n"
+;;
+
+let provider_a_sse_frame_content_block_start =
+  "event: content_block_start\n\
+   data: \
+   {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n"
+;;
+
+let provider_a_sse_frame_delta text =
+  Printf.sprintf
+    "event: content_block_delta\n\
+     data: \
+     {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"%s\"}}\n\n"
+    text
+;;
+
+let provider_a_sse_frame_stop =
+  "event: content_block_stop\n\
+   data: {\"type\":\"content_block_stop\",\"index\":0}\n\n\
+   event: message_delta\n\
+   data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\n\
+   event: message_stop\n\
+   data: {\"type\":\"message_stop\"}\n\n"
+;;
+
+let read_http_request flow =
+  let reader = Eio.Buf_read.of_flow flow ~max_size:8192 in
+  let _request_line = Eio.Buf_read.line reader in
+  let rec read_headers content_length =
+    match Eio.Buf_read.line reader with
+    | "" -> content_length
+    | line ->
+      let lower = String.lowercase_ascii line in
+      let content_length =
+        if String.starts_with ~prefix:"content-length:" lower
+        then (
+          let value =
+            String.sub line 15 (String.length line - 15) |> String.trim
+          in
+          match int_of_string_opt value with
+          | Some n -> n
+          | None -> content_length)
+        else content_length
+      in
+      read_headers content_length
+    | exception End_of_file -> content_length
+  in
+  let content_length = read_headers 0 in
+  if content_length > 0 then ignore (Eio.Buf_read.take content_length reader : string)
+;;
+
+let start_raw_sse_server ~sw ~net ~clock delayed_frames =
+  let port = fresh_port () in
+  let socket =
+    Eio.Net.listen
+      net
+      ~sw
+      ~backlog:8
+      ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  Eio.Fiber.fork ~sw (fun () ->
+    Eio.Net.accept_fork
+      ~sw
+      socket
+      ~on_error:(fun _ -> ())
+      (fun flow _addr ->
+         try
+           read_http_request flow;
+           Eio.Flow.copy_string
+             "HTTP/1.1 200 OK\r\n\
+              Content-Type: text/event-stream\r\n\
+              Connection: close\r\n\
+              \r\n"
+             flow;
+           List.iter
+             (fun (delay_sec, frame) ->
+                if delay_sec > 0.0 then Eio.Time.sleep clock delay_sec;
+                Eio.Flow.copy_string frame flow)
+             delayed_frames
+         with
+         | _ -> ()));
+  Printf.sprintf "http://127.0.0.1:%d" port
+;;
+
 let start_sse_server ~sw ~net response_body =
   let port = fresh_port () in
   let handler _conn _req body =
@@ -794,6 +883,117 @@ let test_complete_stream_ok () =
       check bool "events received" true (List.length !events > 0);
       Eio.Switch.fail sw Exit
     | Error _ -> fail "expected Ok"
+  with
+  | Exit -> ()
+;;
+
+let text_of_response (resp : Types.api_response) =
+  List.filter_map
+    (function
+      | Types.Text s -> Some s
+      | _ -> None)
+    resp.content
+  |> String.concat ""
+;;
+
+let test_complete_stream_active_chunks_can_exceed_idle_timeout_total () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url =
+      start_raw_sse_server
+        ~sw
+        ~net:env#net
+        ~clock:env#clock
+        [ 0.0, provider_a_sse_frame_message_start
+        ; 0.03, provider_a_sse_frame_content_block_start
+        ; 0.03, provider_a_sse_frame_delta "active "
+        ; 0.03, provider_a_sse_frame_delta "long "
+        ; 0.03, provider_a_sse_frame_delta "stream"
+        ; 0.03, provider_a_sse_frame_stop
+        ]
+    in
+    let config = make_config url in
+    let events = ref [] in
+    let on_event evt = events := evt :: !events in
+    match
+      Complete.complete_stream
+        ~sw
+        ~net:env#net
+        ~clock:env#clock
+        ~stream_idle_timeout_s:0.08
+        ~config
+        ~messages
+        ~on_event
+        ()
+    with
+    | Ok resp ->
+      check string "text" "active long stream" (text_of_response resp);
+      check bool "events received" true (List.length !events > 0);
+      Eio.Switch.fail sw Exit
+    | Error err ->
+      fail
+        (Printf.sprintf
+           "expected active stream to complete, got %s"
+           (match err with
+            | Http_client.NetworkError { message; _ }
+            | Http_client.TimeoutError { message; _ } -> message
+            | Http_client.HttpError { code; _ } -> Printf.sprintf "HTTP %d" code
+            | Http_client.AcceptRejected { reason } -> reason
+            | Http_client.ProviderTerminal { message; _ } -> message
+            | Http_client.ProviderFailure { message; _ } -> message))
+  with
+  | Exit -> ()
+;;
+
+let test_complete_stream_idle_timeout_still_fires () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url =
+      start_raw_sse_server
+        ~sw
+        ~net:env#net
+        ~clock:env#clock
+        [ 0.12, provider_a_sse_frame_message_start
+        ; 0.0, provider_a_sse_frame_content_block_start
+        ; 0.0, provider_a_sse_frame_delta "late"
+        ; 0.0, provider_a_sse_frame_stop
+        ]
+    in
+    let config = make_config url in
+    let on_event _evt = () in
+    (match
+       Complete.complete_stream
+         ~sw
+         ~net:env#net
+         ~clock:env#clock
+         ~stream_idle_timeout_s:0.03
+         ~config
+         ~messages
+         ~on_event
+         ()
+     with
+     | Error (Http_client.TimeoutError { phase = Http_client.First_token; message }) ->
+       let prefix = "stream_idle_timeout_s deadline exceeded" in
+       check
+         bool
+         "stream idle message"
+         true
+         (String.length message >= String.length prefix
+          && String.equal (String.sub message 0 (String.length prefix)) prefix);
+       Eio.Switch.fail sw Exit
+     | Error (Http_client.TimeoutError { phase; _ }) ->
+       fail
+         (Printf.sprintf
+            "unexpected timeout phase %s"
+            (Http_client.timeout_phase_to_label phase))
+     | Ok _ -> fail "expected stream idle timeout"
+     | Error _ -> fail "expected TimeoutError{phase=First_token}")
   with
   | Exit -> ()
 ;;
@@ -983,6 +1183,14 @@ let () =
     ; "retry", [ test_case "first try ok" `Quick test_retry_first_try ]
     ; ( "stream"
       , [ test_case "sse ok" `Quick test_complete_stream_ok
+        ; test_case
+            "active chunks exceed idle total"
+            `Quick
+            test_complete_stream_active_chunks_can_exceed_idle_timeout_total
+        ; test_case
+            "stream idle timeout still fires"
+            `Quick
+            test_complete_stream_idle_timeout_still_fires
         ; test_case "streaming metrics" `Quick test_complete_stream_metrics
         ] )
     ]

--- a/test/test_error_domain.ml
+++ b/test/test_error_domain.ml
@@ -1,6 +1,7 @@
 (** Error_domain tests — roundtrip conversion and retryability. *)
 
 open Agent_sdk
+module Http_client = Llm_provider.Http_client
 module Retry = Llm_provider.Retry
 
 (* ── Roundtrip: sdk_error -> poly -> sdk_error ───────────── *)
@@ -149,6 +150,7 @@ let test_to_string_each_variant () =
     ; `Server_error (503, "unavailable")
     ; `Network_error "connection refused"
     ; `Provider_timeout "3s elapsed"
+    ; `Streaming_timeout (Http_client.Stream_body, "stream body elapsed")
     ; `Overloaded
     ; `Invalid_request "bad body"
     ; `Tool_exec_failed ("search", "crash")
@@ -188,6 +190,8 @@ let test_all_variants_convert () =
     ; `Server_error (500, "x")
     ; `Network_error "x"
     ; `Provider_timeout "x"
+    ; `Streaming_timeout
+        (Http_client.Stream_idle Http_client.Streaming_thinking, "idle")
     ; `Overloaded
     ; `Invalid_request "x"
     ; `Tool_exec_failed ("t", "d")
@@ -269,6 +273,40 @@ let test_roundtrip_api_timeout () =
   match back with
   | Error.Api (Retry.Timeout _) -> ()
   | _ -> Alcotest.fail "roundtrip mismatch for Timeout"
+;;
+
+let test_roundtrip_provider_streaming_timeout () =
+  let orig =
+    Error.Provider
+      (Llm_provider.Error.Timeout
+         { provider = "provider_d"
+         ; timeout_phase = Some Http_client.Stream_body
+         ; detail = "stream body cap"
+         })
+  in
+  let poly = Error_domain.of_sdk_error orig in
+  (match poly with
+   | `Streaming_timeout (Http_client.Stream_body, "stream body cap") -> ()
+   | _ -> Alcotest.fail "expected Streaming_timeout");
+  let back = Error_domain.to_sdk_error poly in
+  match back with
+  | Error.Provider
+      (Llm_provider.Error.Timeout
+         { timeout_phase = Some Http_client.Stream_body; detail = "stream body cap"; _ })
+    ->
+    let first_token =
+      Error.Provider
+        (Llm_provider.Error.Timeout
+           { provider = "provider_d"
+           ; timeout_phase = Some Http_client.First_token
+           ; detail = "awaiting first token"
+           })
+      |> Error_domain.of_sdk_error
+    in
+    (match first_token with
+     | `Streaming_timeout (Http_client.First_token, "awaiting first token") -> ()
+     | _ -> Alcotest.fail "expected First_token Streaming_timeout")
+  | _ -> Alcotest.fail "roundtrip mismatch for streaming Timeout"
 ;;
 
 let test_roundtrip_api_overloaded () =
@@ -490,6 +528,14 @@ let test_retryable_provider_timeout () =
     (Error_domain.is_retryable (`Provider_timeout "3s"))
 ;;
 
+let test_retryable_streaming_timeout () =
+  Alcotest.(check bool)
+    "streaming_timeout retryable"
+    true
+    (Error_domain.is_retryable
+       (`Streaming_timeout (Http_client.Stream_idle Http_client.Streaming_answer, "idle")))
+;;
+
 let test_retryable_network_error () =
   Alcotest.(check bool)
     "network_error retryable"
@@ -671,6 +717,7 @@ let test_provider_roundtrip_all_via_to_sdk () =
     ; `Server_error (500, "x")
     ; `Network_error "x"
     ; `Provider_timeout "x"
+    ; `Streaming_timeout (Http_client.Stream_body, "x")
     ; `Overloaded
     ; `Invalid_request "x"
     ]
@@ -680,9 +727,10 @@ let test_provider_roundtrip_all_via_to_sdk () =
        let sdk = Error_domain.to_sdk_error (v :> Error_domain.sdk_error_poly) in
        let s = Error.to_string sdk in
        Alcotest.(check bool) "nonempty to_string" true (String.length s > 0);
-       (* Should map to Api variant *)
-       match sdk with
-       | Error.Api _ -> ()
+       match v, sdk with
+       | `Streaming_timeout _, Error.Provider _ -> ()
+       | `Streaming_timeout _, _ -> Alcotest.fail "expected Provider for streaming_timeout"
+       | _, Error.Api _ -> ()
        | _ -> Alcotest.fail "expected Api for provider_error")
     variants
 ;;
@@ -698,6 +746,10 @@ let () =
         ; Alcotest.test_case "api server_error" `Quick test_roundtrip_api_server_error
         ; Alcotest.test_case "api network_error" `Quick test_roundtrip_api_network_error
         ; Alcotest.test_case "api timeout" `Quick test_roundtrip_api_timeout
+        ; Alcotest.test_case
+            "provider streaming timeout"
+            `Quick
+            test_roundtrip_provider_streaming_timeout
         ; Alcotest.test_case "api overloaded" `Quick test_roundtrip_api_overloaded
         ; Alcotest.test_case
             "api invalid_request"
@@ -758,6 +810,10 @@ let () =
         ; Alcotest.test_case "server_error" `Quick test_retryable_server_error
         ; Alcotest.test_case "overloaded" `Quick test_retryable_overloaded
         ; Alcotest.test_case "provider_timeout" `Quick test_retryable_provider_timeout
+        ; Alcotest.test_case
+            "streaming_timeout"
+            `Quick
+            test_retryable_streaming_timeout
         ; Alcotest.test_case "network_error" `Quick test_retryable_network_error
         ; Alcotest.test_case "auth_error" `Quick test_retryable_auth_error
         ; Alcotest.test_case "invalid_request" `Quick test_retryable_invalid_request

--- a/test/test_streaming_summary.ml
+++ b/test/test_streaming_summary.ml
@@ -77,7 +77,7 @@ let test_terminal_error_roundtrip () =
       ; inter_chunk_ms_p50 = 25.0
       ; inter_chunk_ms_p95 = 60.0
       ; inter_chunk_ms_max = 120.0
-      ; terminal = T.Terminal_error "body_timeout_s_exceeded"
+      ; terminal = T.Terminal_error "stream_idle_timeout_s_exceeded:streaming_answer"
       }
   in
   let json = T.to_yojson summary_with_error in


### PR DESCRIPTION
## Summary
- Remove `body_timeout_s` from `Complete.complete_stream` and the HTTP streaming body wrapper.
- Keep `body_timeout_s` on non-streaming completion and route sync agent dispatch through it.
- Classify streaming timeout phases separately from provider timeout.

## Verification
- `scripts/dune-local.sh build test/test_complete_http.exe test/test_error_domain.exe test/test_body_timeout.exe test/test_streaming_summary.exe`
- `_build/default/test/test_complete_http.exe`
- `_build/default/test/test_error_domain.exe`
- `_build/default/test/test_body_timeout.exe`
- `_build/default/test/test_streaming_summary.exe`
- `git diff --check`

## Note
- `scripts/dune-local.sh build @check` still fails on unrelated `examples/*.mli` cmi errors.