### PR TITLE
chore(oas): format streaming timeout tests

### DIFF
--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -133,7 +133,6 @@ val with_max_execution_time : float -> t -> t
     @since 0.176.0 *)
 val with_stream_idle_timeout : float -> t -> t
 
-val with_body_timeout : float -> t -> t
 (** Set the total deadline applied to non-streaming HTTP completion body
     consumption. Requires a clock to be provided to the underlying request;
     without one the wrapper is skipped. A timeout surfaces as
@@ -141,6 +140,7 @@ val with_body_timeout : float -> t -> t
     treats as retryable. Streaming requests ignore this knob and rely on
     [with_stream_idle_timeout] for inter-line liveness so active long
     streams are not killed by total duration. @since 0.181.0 *)
+val with_body_timeout : float -> t -> t
 
 (** Set the agent-level inactivity deadline for the entire run. The timer
     resets on execution activity — a streamed token (every [on_event],
@@ -157,7 +157,6 @@ val with_body_timeout : float -> t -> t
 val with_execution_idle_timeout : float -> t -> t
 
 val with_max_idle_turns : int -> t -> t
-
 val with_idle_final_warning_at : int -> t -> t
 val with_elicitation : Hooks.elicitation_callback -> t -> t
 val with_description : string -> t -> t

--- a/test/test_body_timeout.ml
+++ b/test/test_body_timeout.ml
@@ -41,8 +41,8 @@ let test_options_record_update () =
 
 let body_timeout_message timeout_s =
   Printf.sprintf
-    "body_timeout_s deadline exceeded after %.1fs (Complete.complete \
-     non-streaming path; total HTTP round-trip cap)"
+    "body_timeout_s deadline exceeded after %.1fs (Complete.complete non-streaming path; \
+     total HTTP round-trip cap)"
     timeout_s
 ;;
 

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -771,7 +771,8 @@ let provider_a_sse_frame_stop =
   "event: content_block_stop\n\
    data: {\"type\":\"content_block_stop\",\"index\":0}\n\n\
    event: message_delta\n\
-   data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\n\
+   data: \
+   {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\n\
    event: message_stop\n\
    data: {\"type\":\"message_stop\"}\n\n"
 ;;
@@ -787,9 +788,7 @@ let read_http_request flow =
       let content_length =
         if String.starts_with ~prefix:"content-length:" lower
         then (
-          let value =
-            String.sub line 15 (String.length line - 15) |> String.trim
-          in
+          let value = String.sub line 15 (String.length line - 15) |> String.trim in
           match int_of_string_opt value with
           | Some n -> n
           | None -> content_length)
@@ -967,33 +966,33 @@ let test_complete_stream_idle_timeout_still_fires () =
     in
     let config = make_config url in
     let on_event _evt = () in
-    (match
-       Complete.complete_stream
-         ~sw
-         ~net:env#net
-         ~clock:env#clock
-         ~stream_idle_timeout_s:0.03
-         ~config
-         ~messages
-         ~on_event
-         ()
-     with
-     | Error (Http_client.TimeoutError { phase = Http_client.First_token; message }) ->
-       let prefix = "stream_idle_timeout_s deadline exceeded" in
-       check
-         bool
-         "stream idle message"
-         true
-         (String.length message >= String.length prefix
-          && String.equal (String.sub message 0 (String.length prefix)) prefix);
-       Eio.Switch.fail sw Exit
-     | Error (Http_client.TimeoutError { phase; _ }) ->
-       fail
-         (Printf.sprintf
-            "unexpected timeout phase %s"
-            (Http_client.timeout_phase_to_label phase))
-     | Ok _ -> fail "expected stream idle timeout"
-     | Error _ -> fail "expected TimeoutError{phase=First_token}")
+    match
+      Complete.complete_stream
+        ~sw
+        ~net:env#net
+        ~clock:env#clock
+        ~stream_idle_timeout_s:0.03
+        ~config
+        ~messages
+        ~on_event
+        ()
+    with
+    | Error (Http_client.TimeoutError { phase = Http_client.First_token; message }) ->
+      let prefix = "stream_idle_timeout_s deadline exceeded" in
+      check
+        bool
+        "stream idle message"
+        true
+        (String.length message >= String.length prefix
+         && String.equal (String.sub message 0 (String.length prefix)) prefix);
+      Eio.Switch.fail sw Exit
+    | Error (Http_client.TimeoutError { phase; _ }) ->
+      fail
+        (Printf.sprintf
+           "unexpected timeout phase %s"
+           (Http_client.timeout_phase_to_label phase))
+    | Ok _ -> fail "expected stream idle timeout"
+    | Error _ -> fail "expected TimeoutError{phase=First_token}"
   with
   | Exit -> ()
 ;;

--- a/test/test_error_domain.ml
+++ b/test/test_error_domain.ml
@@ -190,8 +190,7 @@ let test_all_variants_convert () =
     ; `Server_error (500, "x")
     ; `Network_error "x"
     ; `Provider_timeout "x"
-    ; `Streaming_timeout
-        (Http_client.Stream_idle Http_client.Streaming_thinking, "idle")
+    ; `Streaming_timeout (Http_client.Stream_idle Http_client.Streaming_thinking, "idle")
     ; `Overloaded
     ; `Invalid_request "x"
     ; `Tool_exec_failed ("t", "d")
@@ -729,7 +728,8 @@ let test_provider_roundtrip_all_via_to_sdk () =
        Alcotest.(check bool) "nonempty to_string" true (String.length s > 0);
        match v, sdk with
        | `Streaming_timeout _, Error.Provider _ -> ()
-       | `Streaming_timeout _, _ -> Alcotest.fail "expected Provider for streaming_timeout"
+       | `Streaming_timeout _, _ ->
+         Alcotest.fail "expected Provider for streaming_timeout"
        | _, Error.Api _ -> ()
        | _ -> Alcotest.fail "expected Api for provider_error")
     variants
@@ -810,10 +810,7 @@ let () =
         ; Alcotest.test_case "server_error" `Quick test_retryable_server_error
         ; Alcotest.test_case "overloaded" `Quick test_retryable_overloaded
         ; Alcotest.test_case "provider_timeout" `Quick test_retryable_provider_timeout
-        ; Alcotest.test_case
-            "streaming_timeout"
-            `Quick
-            test_retryable_streaming_timeout
+        ; Alcotest.test_case "streaming_timeout" `Quick test_retryable_streaming_timeout
         ; Alcotest.test_case "network_error" `Quick test_retryable_network_error
         ; Alcotest.test_case "auth_error" `Quick test_retryable_auth_error
         ; Alcotest.test_case "invalid_request" `Quick test_retryable_invalid_request


### PR DESCRIPTION
## Summary
- Promote ocamlformat output for the streaming timeout follow-up merged in #1930.
- Keep this PR format-only against current `origin/main` after release #1931.

## Verification
- `scripts/dune-local.sh build @fmt test/test_complete_http.exe test/test_error_domain.exe test/test_body_timeout.exe`
- `_build/default/test/test_complete_http.exe`
- `_build/default/test/test_error_domain.exe`
- `_build/default/test/test_body_timeout.exe`
- `git diff --check`