### PR TITLE
[codex] make cost thresholds telemetry-only

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -61,9 +61,10 @@ let provide_input agent request response =
 
 let check_token_budget = Agent_turn.check_token_budget
 
-(* ── Shared loop guard (max_turns + idle + budget) ─────────── *)
+(* ── Shared loop guard (max_turns + idle + token budget) ─────────── *)
 
-(** Check max_turns, idle detection, and token/cost budget.
+(** Check max_turns, idle detection, and token budget.
+    Cost is telemetry-only and never gates the loop.
     Returns [Some error] when any guard fires, [None] to proceed. *)
 let check_loop_guard agent =
   match agent.state.config.exit_condition with
@@ -83,10 +84,7 @@ let check_loop_guard agent =
       Some
         (Error.Agent
            (Error.IdleDetected { consecutive_idle_turns = agent.consecutive_idle_turns }))
-    else (
-      match check_token_budget agent.state.config agent.state.usage with
-      | Some _ as err -> err
-      | None -> Cost_tracker.check_budget agent.state.config agent.state.usage)
+    else check_token_budget agent.state.config agent.state.usage
 ;;
 
 (* ── Unified run loop ────────────────────────────────────────── *)
@@ -176,22 +174,7 @@ let run_loop ~sw ?clock ~api_strategy ?on_yield ?on_resume ?on_activity agent us
   (* First turn: caller already holds slot, no resume needed *)
   let rec loop ~is_first_turn =
     match check_loop_guard agent with
-    | Some err ->
-      (match err with
-       | Error.Agent (Error.CostBudgetExceeded { spent_usd; limit_usd }) ->
-         (match agent.options.event_bus with
-          | Some bus ->
-            Telemetry_bus.publish
-              (Telemetry_bus.of_event_bus bus)
-              (Llm_provider.Telemetry_event.Budget_exceeded
-                 { agent_name = agent.state.config.name
-                 ; run_id = Event_bus.fresh_id ()
-                 ; spent_usd
-                 ; limit_usd
-                 })
-          | None -> ())
-       | _ -> ());
-      Error err
+    | Some err -> Error err
     | None ->
       (* Resume slot before LLM turn (skip on first turn) *)
       if yield_enabled && not is_first_turn then do_resume ();

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -283,9 +283,8 @@ let accumulate_usage ~current_usage ~provider ~response_usage =
        (* Resolve a stable model identifier.  When [provider = None] or
           [model_id] is blank, the real problem is "provider/model unknown,"
           not "the model literally named the empty string priced at $0."
-          Use an explicit sentinel so [unpriced_model = Some "<unknown>"]
-          surfaces a readable [CostBudgetUnenforceable] message instead of
-          one quoting an empty string. *)
+          Use an explicit sentinel so cost telemetry can report a stable
+          unpriced model instead of quoting an empty string. *)
        let model_id =
          match provider with
          | Some (cfg : Provider.config) when cfg.model_id <> "" -> cfg.model_id
@@ -293,10 +292,8 @@ let accumulate_usage ~current_usage ~provider ~response_usage =
        in
        (* Use [pricing_for_model_opt] so an unknown model does not silently
           collapse to zero_pricing.  When there is no pricing entry, leave
-          [estimated_cost_usd] unchanged and mark the accumulator incomplete;
-          [Cost_tracker.check_budget] returns [CostBudgetUnenforceable] for
-          hosts that opted in to [max_cost_usd], so the dollar cap fails
-          closed rather than being silently void. *)
+          [estimated_cost_usd] unchanged and mark the accumulator incomplete.
+          Cost thresholds are advisory telemetry only and do not fail closed. *)
        (match Provider.pricing_for_model_opt model_id with
         | Some pricing ->
           let turn_cost =

--- a/lib/agent/agent_turn_budget.ml
+++ b/lib/agent/agent_turn_budget.ml
@@ -16,14 +16,12 @@ type denial_reason =
   | Extension_limit_reached
   | Per_extend_cap_exceeded
   | Agent_idle
-  | Cost_exceeded
 
 let denial_reason_to_string = function
   | Ceiling_reached -> "ceiling_reached"
   | Extension_limit_reached -> "extension_limit_reached"
   | Per_extend_cap_exceeded -> "per_extend_cap_exceeded"
   | Agent_idle -> "agent_idle"
-  | Cost_exceeded -> "cost_exceeded"
 ;;
 
 (** [history] is the only mutable cell. The previous implementation kept
@@ -86,35 +84,17 @@ let make_tool ~agent_ref ~budget ?(max_idle_before_extend = 2) () =
       try Yojson.Safe.Util.(member "reason" input |> to_string) with
       | Yojson.Safe.Util.Type_error _ | Not_found -> "no reason given"
     in
-    (* Check agent-level guardrails *)
+    (* Check agent-level guardrails. Cost telemetry never denies extension. *)
     let agent_check =
       match !agent_ref with
       | None -> Ok ()
       | Some agent ->
-        let state = Agent_types.state agent in
         (* Idle check: deny if agent has been idle *)
         if
           (Agent_types.options agent).max_idle_turns > 0
           && agent.consecutive_idle_turns >= max_idle_before_extend
         then Error Agent_idle
-        (* Cost check: deny if cost budget exceeded, or if any past turn
-           ran an unpriced model so the dollar cap cannot be enforced. *)
-        else (
-          match state.config.max_cost_usd with
-          | None -> Ok ()
-          | Some max_cost ->
-            if Option.is_some state.usage.unpriced_model
-            then
-              Error Cost_exceeded
-              (* Use strict greater-than to align with
-                 [Cost_tracker.check_budget], which is the SSOT for cost
-                 enforcement (see [lib/cost_tracker.ml]).  Previously this
-                 used [>=], so a run sitting exactly at the cap would have
-                 its extension denied while [check_budget] still allowed the
-                 turn loop to continue -- inconsistent. *)
-            else if state.usage.estimated_cost_usd > max_cost
-            then Error Cost_exceeded
-            else Ok ())
+        else Ok ()
     in
     match agent_check with
     | Error reason_code ->
@@ -165,8 +145,9 @@ let make_tool ~agent_ref ~budget ?(max_idle_before_extend = 2) () =
     ~name:"extend_turns"
     ~description:
       "Request additional turns when you need more time to complete your current task. \
-       The system checks guardrails (cost budget, idle detection, ceiling) before \
-       granting. Call this when you judge you need more steps, not preemptively."
+       The system checks guardrails (idle detection, ceiling, extension limits) before \
+       granting. Cost is reported as telemetry only. Call this when you judge you need \
+       more steps, not preemptively."
     ~parameters:
       [ { name = "additional_turns"
         ; description = "Number of additional turns to request (1-20)"

--- a/lib/agent/agent_turn_budget.mli
+++ b/lib/agent/agent_turn_budget.mli
@@ -7,8 +7,8 @@
     - Per-extension cap (max turns per single request)
     - Total extension count (max number of extend calls)
 
-    Cost and idle checks are delegated to the caller via the
-    agent ref (reads [agent_state.usage] and [consecutive_idle_turns]).
+    Idle checks are delegated to the caller via the agent ref (reads
+    [consecutive_idle_turns]). Cost telemetry never gates extension.
 
     @since 0.78.0
 
@@ -28,7 +28,6 @@ type denial_reason =
   | Extension_limit_reached
   | Per_extend_cap_exceeded
   | Agent_idle
-  | Cost_exceeded
 
 val denial_reason_to_string : denial_reason -> string
 
@@ -61,8 +60,8 @@ val current_max : t -> int
 
 (** Build the [extend_turns] Tool.t.
 
-    The tool reads the agent state via [agent_ref] to check idle turns
-    and cost budget.  The ref is initially [None] and must be set to
+    The tool reads the agent state via [agent_ref] to check idle turns.
+    The ref is initially [None] and must be set to
     [Some agent] after [Agent.create].
 
     @param agent_ref Mutable ref to the agent (set after creation)

--- a/lib/base/error.ml
+++ b/lib/base/error.ml
@@ -161,13 +161,13 @@ let agent_error_to_string = function
     Printf.sprintf "%s token budget exceeded: %d/%d" r.kind r.used r.limit
   | CostBudgetExceeded r ->
     Printf.sprintf
-      "Cost budget exceeded: $%.4f spent (limit $%.4f)"
+      "Legacy cost threshold exceeded: $%.4f spent (threshold $%.4f); cost is advisory"
       r.spent_usd
       r.limit_usd
   | CostBudgetUnenforceable r ->
     Printf.sprintf
-      "Cost budget ($%.4f limit) cannot be enforced: model %S has no pricing entry; add \
-       it to Pricing.pricing_for_model_opt or remove max_cost_usd"
+      "Legacy cost threshold ($%.4f) saw unpriced model %S; cost is advisory and does \
+       not gate execution"
       r.limit_usd
       r.model_id
   | UnrecognizedStopReason r ->

--- a/lib/base/error.mli
+++ b/lib/base/error.mli
@@ -44,9 +44,8 @@ type agent_error =
       { model_id : string
       ; limit_usd : float
       }
-  (** [max_cost_usd] is set but at least one turn ran a model with no pricing
-            entry, so [estimated_cost_usd] silently under-reports.  Fail closed
-            rather than let the dollar cap be void. *)
+  (** Legacy compatibility variant. [max_cost_usd] is advisory telemetry only
+      and new execution paths must not emit this as a gate. *)
   | UnrecognizedStopReason of { reason : string }
   | IdleDetected of { consecutive_idle_turns : int }
   | ToolRetryExhausted of

--- a/lib/base/types.ml
+++ b/lib/base/types.ml
@@ -105,7 +105,7 @@ type agent_config =
   ; initial_messages : message list
     (* Seed conversation with prior history on first run *)
   ; max_cost_usd : float option
-    (* Cost budget: max cumulative estimated cost in USD. @since 0.62.0 *)
+    (* Advisory cost telemetry threshold in USD. Never gates execution. @since 0.62.0 *)
   ; context_compact_ratio : float option
     (** Ratio of context budget at which to compact. Default 0.8 *)
   ; context_prepare_ratio : float option
@@ -164,11 +164,8 @@ let default_config =
 
     [unpriced_model] is [Some model_id] when at least one accumulated turn
     ran a model with no entry in [Pricing.pricing_for_model_opt], so
-    [estimated_cost_usd] silently under-reports.  Only the first such
-    model_id is recorded; subsequent unpriced models do not overwrite it
-    so the error message stays stable.  [Cost_tracker.check_budget] uses
-    this field to refuse enforcement of [max_cost_usd] rather than let
-    the dollar cap be void. *)
+    [estimated_cost_usd] under-reports.  Only the first such model_id is
+    recorded for stable telemetry; cost thresholds never gate execution. *)
 type usage_stats =
   { total_input_tokens : int
   ; total_output_tokens : int

--- a/lib/base/types.mli
+++ b/lib/base/types.mli
@@ -58,6 +58,7 @@ type agent_config =
   ; max_total_tokens : int option
   ; initial_messages : message list
   ; max_cost_usd : float option
+    (** Advisory cost telemetry threshold in USD. Never gates execution. *)
   ; context_compact_ratio : float option
   ; context_prepare_ratio : float option
   ; context_handoff_ratio : float option
@@ -81,10 +82,8 @@ val default_config : agent_config
 
     [unpriced_model] is [Some model_id] when at least one accumulated turn
     ran a model with no entry in {!Llm_provider.Pricing.pricing_for_model_opt},
-    so [estimated_cost_usd] silently under-reports.  Only the first such
-    model_id is recorded.  {!Cost_tracker.check_budget} uses this field to
-    refuse enforcement of [max_cost_usd] rather than let the dollar cap be
-    void. *)
+    so [estimated_cost_usd] under-reports.  Only the first such model_id is
+    recorded for stable telemetry; cost thresholds never gate execution. *)
 type usage_stats =
   { total_input_tokens : int
   ; total_output_tokens : int

--- a/lib/checkpoint_codec.ml
+++ b/lib/checkpoint_codec.ml
@@ -40,14 +40,11 @@ let usage_of_json json =
        | _ -> 0.0)
   ; unpriced_model =
       (* Older checkpoints (pre cost-estimation flag) lack this field; we
-         decode them as [None] (fully-priced) on resume.  Caveat: [usage]
-         is restored verbatim from the checkpoint (it is not recomputed
-         from raw turns), so any past turn that ran an unpriced model
-         before this field existed is silently lost on resume, and
-         [Cost_tracker.check_budget] will not be able to return
-         [CostBudgetUnenforceable] for that historical run.  New turns
-         after resume re-detect unpriced models normally via
-         [Agent_turn.accumulate_usage]. *)
+         decode them as [None] (fully-priced) on resume.  Usage is restored
+         verbatim from the checkpoint and not recomputed from raw turns, so
+         any past turn that ran an unpriced model before this field existed
+         is absent from cost telemetry.  New turns after resume re-detect
+         unpriced models normally via [Agent_turn.accumulate_usage]. *)
       (match json |> member "unpriced_model" with
        | `String s -> Some s
        | _ -> None)

--- a/lib/cost_tracker.ml
+++ b/lib/cost_tracker.ml
@@ -1,11 +1,10 @@
-(** Per-agent cost tracking and budget enforcement.
+(** Per-agent cost tracking and advisory reporting.
 
     Builds on {!Types.usage_stats.estimated_cost_usd} (accumulated
     per-turn by {!Agent_turn.accumulate_usage} via {!Pricing}).
 
-    This module adds:
-    - Budget checking against {!Types.agent_config.max_cost_usd}
-    - Structured cost reporting
+    This module adds structured cost reporting. Cost thresholds are
+    telemetry-only and must not gate agent execution.
 
     @since 0.62.0 *)
 
@@ -20,35 +19,13 @@ type cost_report =
   ; avg_cost_per_call : float
   }
 
-(** Check whether the accumulated cost exceeds the configured budget.
+(** Compatibility shim for older callers.
 
-    Returns [Some error] when [config.max_cost_usd] is set and either:
-    - [usage.estimated_cost_usd] exceeds the limit, OR
-    - [usage.unpriced_model = Some _], meaning at least one turn used a
-      model with no pricing entry so [estimated_cost_usd] under-reports
-      by an unknown amount.  In that case the dollar cap cannot be
-      enforced and we fail closed with [CostBudgetUnenforceable] rather
-      than let the cap be silently void.
-
-    Returns [None] otherwise.
-
-    Intended to be called in the agent run loop alongside
-    {!Agent_turn.check_token_budget}. *)
-let check_budget (config : Types.agent_config) (usage : Types.usage_stats) =
-  match config.max_cost_usd with
-  | None -> None
-  | Some limit ->
-    (match usage.unpriced_model with
-     | Some model_id ->
-       Some (Error.Agent (CostBudgetUnenforceable { model_id; limit_usd = limit }))
-     | None ->
-       if usage.estimated_cost_usd > limit
-       then
-         Some
-           (Error.Agent
-              (CostBudgetExceeded
-                 { spent_usd = usage.estimated_cost_usd; limit_usd = limit }))
-       else None)
+    Cost thresholds are advisory telemetry only. This function must never
+    return an execution-stopping error, even when [config.max_cost_usd] is
+    set, accumulated cost is above the threshold, or usage includes an
+    unpriced model. *)
+let check_budget (_config : Types.agent_config) (_usage : Types.usage_stats) = None
 ;;
 
 (** Generate a cost report from accumulated usage stats. *)

--- a/lib/cost_tracker.mli
+++ b/lib/cost_tracker.mli
@@ -1,4 +1,4 @@
-(** Per-agent cost tracking and budget enforcement.
+(** Per-agent cost tracking and advisory reporting.
 
     @since 0.62.0
 
@@ -16,10 +16,10 @@ type cost_report =
   ; avg_cost_per_call : float
   }
 
-(** Check whether accumulated cost exceeds [config.max_cost_usd].
+(** Compatibility shim for older callers.
 
-    Returns [Some (Error.Agent (CostBudgetExceeded _))] when over budget,
-    [None] when within budget or no limit is set. *)
+    Cost thresholds are advisory telemetry only. This function returns
+    [None] unconditionally and must not gate execution. *)
 val check_budget : Types.agent_config -> Types.usage_stats -> Error.sdk_error option
 
 (** Generate a structured cost report from usage stats. *)

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -48,8 +48,8 @@ type agent_error =
   | `Token_budget_exceeded of int * int (** used, limit *)
   | `Cost_budget_exceeded
   | `Cost_budget_unenforceable of string * float
-    (** model_id, limit_usd — [max_cost_usd] is set but a turn ran a model
-        with no pricing entry, so the cap cannot be enforced. *)
+    (** model_id, threshold_usd — legacy advisory cost classification.
+        New execution paths must not emit this as a gate. *)
   | `Idle_detected of int (** consecutive_idle_turns *)
   | `Tool_retry_exhausted of int * int * string (** attempts, limit, detail *)
   | `Agent_execution_timeout of float * float * int * int

--- a/lib/harness.ml
+++ b/lib/harness.ml
@@ -303,8 +303,11 @@ module Performance = struct
       ; (match exp.max_cost_usd with
          | Some limit ->
            Some
-             ( obs.total_cost_usd <= limit
-             , Printf.sprintf "cost=%.4f limit=%.4f" obs.total_cost_usd limit )
+             ( true
+             , Printf.sprintf
+                 "cost=%.4f advisory_threshold=%.4f"
+                 obs.total_cost_usd
+                 limit )
          | None -> None)
       ; (match exp.max_turns with
          | Some limit ->

--- a/lib/harness.mli
+++ b/lib/harness.mli
@@ -106,6 +106,7 @@ module Performance : sig
     { max_p95_latency_ms : float option
     ; max_total_tokens : int option
     ; max_cost_usd : float option
+      (** Advisory telemetry threshold; does not make the verdict fail. *)
     ; max_turns : int option
     }
 

--- a/lib/telemetry_sca_registry.ml
+++ b/lib/telemetry_sca_registry.ml
@@ -49,7 +49,7 @@ let registry : entry list =
     }
   ; { signal = "Budget_exceeded"
     ; producer_files = [ "lib/agent/agent.ml" ]
-    ; description = "Cost budget exceeded during agent run loop"
+    ; description = "Legacy advisory cost threshold exceeded"
     }
   ; { signal = "Context_window_usage"
     ; producer_files = [ "lib/pipeline/pipeline.ml" ]

--- a/test/test_agent_turn_budget_unit.ml
+++ b/test/test_agent_turn_budget_unit.ml
@@ -88,11 +88,7 @@ let test_denial_reason_strings () =
     "per_extend"
     "per_extend_cap_exceeded"
     (Agent_turn_budget.denial_reason_to_string Per_extend_cap_exceeded);
-  check_string "idle" "agent_idle" (Agent_turn_budget.denial_reason_to_string Agent_idle);
-  check_string
-    "cost"
-    "cost_exceeded"
-    (Agent_turn_budget.denial_reason_to_string Cost_exceeded)
+  check_string "idle" "agent_idle" (Agent_turn_budget.denial_reason_to_string Agent_idle)
 ;;
 
 (* ── stats_json ───────────────────────────────────────── *)

--- a/test/test_cost_integration.ml
+++ b/test/test_cost_integration.ml
@@ -1,7 +1,7 @@
-(** Integration tests for cost tracking — accumulation and budget enforcement.
+(** Integration tests for cost tracking — accumulation and advisory thresholds.
 
     Uses mock HTTP server to verify cost accumulates across turns
-    and budget limits are enforced by Agent.run.
+    and cost thresholds remain telemetry-only.
 
     Pattern: test_integration.ml (Anthropic Messages API mock) *)
 
@@ -168,9 +168,10 @@ let test_budget_exceeded () =
     ; unpriced_model = None
     }
   in
-  match Cost_tracker.check_budget config usage with
-  | Some (Error.Agent (CostBudgetExceeded _)) -> ()
-  | _ -> Alcotest.fail "expected CostBudgetExceeded"
+  Alcotest.(check bool)
+    "over advisory threshold"
+    true
+    (Option.is_none (Cost_tracker.check_budget config usage))
 ;;
 
 let test_no_budget_unlimited () =

--- a/test/test_cost_tracker.ml
+++ b/test/test_cost_tracker.ml
@@ -58,15 +58,14 @@ let test_check_budget_at_limit () =
     (Option.is_none (Cost_tracker.check_budget config usage))
 ;;
 
-let test_check_budget_exceeded () =
+let test_check_budget_exceeded_is_advisory () =
   let config = make_config ~max_cost_usd:1.0 () in
   let usage = make_usage ~cost:1.001 () in
-  match Cost_tracker.check_budget config usage with
-  | Some (Error.Agent (CostBudgetExceeded r)) ->
-    check (float 0.001) "spent" 1.001 r.spent_usd;
-    check (float 0.001) "limit" 1.0 r.limit_usd
-  | Some _ -> fail "expected CostBudgetExceeded"
-  | None -> fail "expected budget exceeded error"
+  check
+    bool
+    "over advisory threshold = no execution error"
+    true
+    (Option.is_none (Cost_tracker.check_budget config usage))
 ;;
 
 let test_check_budget_zero_limit () =
@@ -74,24 +73,22 @@ let test_check_budget_zero_limit () =
   let usage = make_usage ~cost:0.001 () in
   check
     bool
-    "zero limit + any cost = exceeded"
+    "zero limit + any cost = still advisory"
     true
-    (Option.is_some (Cost_tracker.check_budget config usage))
+    (Option.is_none (Cost_tracker.check_budget config usage))
 ;;
 
 (* Regression: unknown model id used to leave estimated_cost_usd at 0
-   so the dollar cap never tripped (silent bypass).  Now accumulate_usage
-   stamps unpriced_model = Some <id>, and check_budget refuses to enforce
-   the cap, returning CostBudgetUnenforceable. *)
-let test_check_budget_unpriced_model_fails_closed () =
+   so cost telemetry under-reported.  accumulate_usage still stamps
+   unpriced_model = Some <id>, but check_budget remains advisory. *)
+let test_check_budget_unpriced_model_is_advisory () =
   let config = make_config ~max_cost_usd:1.0 () in
   let usage = make_usage ~cost:0.0 ~unpriced_model:(Some "mystery-model-7") () in
-  match Cost_tracker.check_budget config usage with
-  | Some (Error.Agent (CostBudgetUnenforceable r)) ->
-    check string "model_id" "mystery-model-7" r.model_id;
-    check (float 0.001) "limit" 1.0 r.limit_usd
-  | Some _ -> fail "expected CostBudgetUnenforceable"
-  | None -> fail "expected unenforceable error (cap is set + model is unpriced)"
+  check
+    bool
+    "unpriced model + cap = no execution error"
+    true
+    (Option.is_none (Cost_tracker.check_budget config usage))
 ;;
 
 let test_check_budget_unpriced_model_no_cap_returns_none () =
@@ -99,7 +96,7 @@ let test_check_budget_unpriced_model_no_cap_returns_none () =
   let usage = make_usage ~cost:0.0 ~unpriced_model:(Some "mystery") () in
   check
     bool
-    "no cap configured + unpriced model = None (no enforcement to do)"
+    "no cap configured + unpriced model = None"
     true
     (Option.is_none (Cost_tracker.check_budget config usage))
 ;;
@@ -243,12 +240,12 @@ let () =
       , [ test_case "no limit" `Quick test_check_budget_no_limit
         ; test_case "under budget" `Quick test_check_budget_under
         ; test_case "at limit" `Quick test_check_budget_at_limit
-        ; test_case "exceeded" `Quick test_check_budget_exceeded
+        ; test_case "exceeded remains advisory" `Quick test_check_budget_exceeded_is_advisory
         ; test_case "zero limit" `Quick test_check_budget_zero_limit
         ; test_case
-            "unpriced model + cap = unenforceable"
+            "unpriced model + cap = advisory"
             `Quick
-            test_check_budget_unpriced_model_fails_closed
+            test_check_budget_unpriced_model_is_advisory
         ; test_case
             "unpriced model + no cap = None"
             `Quick

--- a/test/test_harness_deep.ml
+++ b/test/test_harness_deep.ml
@@ -163,13 +163,13 @@ let test_performance_latency_only () =
   Alcotest.(check bool) "latency within limit" true v.passed
 ;;
 
-let test_performance_cost_exceeded () =
+let test_performance_cost_threshold_advisory () =
   let obs : Harness.Performance.observation =
     { latencies_ms = []; total_tokens = 0; total_cost_usd = 5.0; turn_count = 0 }
   in
   let exp = { Harness.Performance.default_expectation with max_cost_usd = Some 1.0 } in
   let v = Harness.Performance.evaluate obs exp in
-  Alcotest.(check bool) "cost exceeded" false v.passed
+  Alcotest.(check bool) "cost threshold advisory" true v.passed
 ;;
 
 (* ── Regression: StructuralMatch and FuzzyMatch boundaries ── *)
@@ -504,7 +504,10 @@ let () =
             test_performance_all_constraints
         ; Alcotest.test_case "no constraints" `Quick test_performance_no_constraints
         ; Alcotest.test_case "latency only" `Quick test_performance_latency_only
-        ; Alcotest.test_case "cost exceeded" `Quick test_performance_cost_exceeded
+        ; Alcotest.test_case
+            "cost threshold advisory"
+            `Quick
+            test_performance_cost_threshold_advisory
         ] )
     ; ( "regression-deep"
       , [ Alcotest.test_case "structural match" `Quick test_regression_structural_match


### PR DESCRIPTION
## Summary

Make OAS cost thresholds telemetry-only instead of runtime gates.

- `Cost_tracker.check_budget` is now a compatibility shim that never returns an execution-stopping error.
- Agent loop guards no longer call cost-budget enforcement.
- Turn extension no longer denies extra turns because of accumulated cost or unpriced models.
- Performance harness cost thresholds record advisory evidence without failing the verdict.
- Legacy `CostBudgetExceeded` / `CostBudgetUnenforceable` variants remain for compatibility, but wording marks them as legacy advisory classifications.

## Why

`max_cost_usd` should not hide the actual runtime blocker. Cost data is useful for reporting and dashboards, but it should not gate agent execution.

## Validation

- `git diff --check`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_costbudget dune build --root . test/test_cost_tracker.exe test/test_cost_integration.exe test/test_agent_turn_budget_unit.exe test/test_harness_deep.exe`
- `./_build_costbudget/default/test/test_cost_tracker.exe`
- `./_build_costbudget/default/test/test_cost_integration.exe`
- `./_build_costbudget/default/test/test_agent_turn_budget_unit.exe`
- `./_build_costbudget/default/test/test_harness_deep.exe`
