### PR TITLE
fix(oas): tool retry policy fix + LLM format recovery

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -323,7 +323,7 @@ let find_and_execute_tool_with_index
           ; content = message
           ; is_error = true
           ; failure_kind = Some Validation_error
-          ; error_class = Some Types.Deterministic
+          ; error_class = None
           }
         in
         let emit_post_tool_use_failure ~input message =

--- a/lib/correction_pipeline.ml
+++ b/lib/correction_pipeline.ml
@@ -126,12 +126,50 @@ let make_format_normalization_stage ?(normalize = fun _name s -> String.trim s) 
 
 let format_normalization_stage = make_format_normalization_stage ()
 
+(* ── Stage 4: LLM Format Recovery ───────────────────────── *)
+
+(** LLMs sometimes wrap tool arguments in an extra object layer
+    (e.g. [{"input": {"count": 5}}] instead of [{"count": 5}]).
+    This stage unwraps known wrapper keys when the inner object
+    shares field names with the tool schema. *)
+let llm_format_recovery_apply (schema : Types.tool_schema) (input : Yojson.Safe.t)
+  : Yojson.Safe.t
+  =
+  match input with
+  | `Assoc [ (wrapper_key, (`Assoc _ as inner)) ] ->
+    let schema_param_names =
+      List.map (fun (p : Types.tool_param) -> p.name) schema.parameters
+    in
+    let inner_keys =
+      match inner with
+      | `Assoc fields -> List.map fst fields
+      | _ -> []
+    in
+    let known_wrappers = [ "input"; "params"; "arguments"; "args"; "payload"; "data" ] in
+    let is_known_wrapper = List.mem wrapper_key known_wrappers in
+    let shares_schema_keys =
+      List.exists (fun k -> List.mem k schema_param_names) inner_keys
+    in
+    if is_known_wrapper || shares_schema_keys then inner else input
+  | _ -> input
+;;
+
+let llm_format_recovery_stage =
+  { name = "llm_format_recovery"; apply = llm_format_recovery_apply }
+;;
+
 (* ── Default pipeline ───────────────────────────────────── *)
 
-let default_stages = [ coercion_stage; format_normalization_stage ]
+let default_stages =
+  [ llm_format_recovery_stage; coercion_stage; format_normalization_stage ]
+;;
 
 let zero_default_stages =
-  [ coercion_stage; default_injection_stage; format_normalization_stage ]
+  [ llm_format_recovery_stage
+  ; coercion_stage
+  ; default_injection_stage
+  ; format_normalization_stage
+  ]
 ;;
 
 (* ── Correction tracking ────────────────────────────────── *)

--- a/lib/correction_pipeline.mli
+++ b/lib/correction_pipeline.mli
@@ -5,8 +5,10 @@
     {!build_nondet_feedback} requires errors from a failed deterministic run.
 
     Default stage ordering (most specific first):
-    1. Type coercion — delegates to {!Tool_input_validation.try_coerce}
-    2. Format normalization — trims whitespace from string values
+    1. LLM format recovery — unwraps extra object nesting
+       (e.g. [{"input": {"count": 5}}] → [{"count": 5}])
+    2. Type coercion — delegates to {!Tool_input_validation.try_coerce}
+    3. Format normalization — trims whitespace from string values
 
     Zero-default injection remains available as an explicit stage for callers
     that own a closed input shape. It is not part of the default pipeline
@@ -51,9 +53,9 @@ type stage =
 
 (** Built-in stages. *)
 val coercion_stage : stage
-
 val default_injection_stage : stage
 val format_normalization_stage : stage
+val llm_format_recovery_stage : stage
 
 (** Zero-value default for a param_type (e.g. String → [""], Integer → [0]). *)
 val zero_default : Types.param_type -> Yojson.Safe.t
@@ -73,14 +75,15 @@ val make_format_normalization_stage
   -> unit
   -> stage
 
-(** The default pipeline: [coercion; format_normalization].
+(** The default pipeline:
+    [llm_format_recovery; coercion; format_normalization].
 
     Missing optional fields remain absent unless the caller opts into
     {!zero_default_stages} or passes {!default_injection_stage} explicitly. *)
 val default_stages : stage list
 
 (** Legacy zero-value pipeline:
-    [coercion; default_injection; format_normalization].
+    [llm_format_recovery; coercion; default_injection; format_normalization].
 
     Use only when absent optional fields are semantically equivalent to zero
     values for the target tool. *)

--- a/lib/tool_retry_policy.ml
+++ b/lib/tool_retry_policy.ml
@@ -28,7 +28,7 @@ type error_class = Types.tool_error_class =
   | Unknown
 
 let classify = function
-  | Validation_error -> Deterministic
+  | Validation_error -> Transient
   | Recoverable_tool_error -> Transient
 ;;
 
@@ -82,12 +82,12 @@ let clear_context_retry_count (context : Context.t) =
 ;;
 
 let failure_enabled (policy : t) (failure : failure) =
-  match failure.kind with
-  | Validation_error -> policy.retry_on_validation_error
-  | Recoverable_tool_error ->
-    (match failure.error_class with
-     | Deterministic -> false
-     | Transient | Unknown -> policy.retry_on_recoverable_tool_error)
+  match failure.error_class with
+  | Deterministic -> false
+  | Transient | Unknown ->
+    (match failure.kind with
+     | Validation_error -> policy.retry_on_validation_error
+     | Recoverable_tool_error -> policy.retry_on_recoverable_tool_error)
 ;;
 
 let dedup_preserve_order xs =

--- a/test/test_correction_pipeline.ml
+++ b/test/test_correction_pipeline.ml
@@ -126,7 +126,72 @@ let test_default_null_input () =
   | Still_invalid _ -> () (* also acceptable if required fields missing *)
 ;;
 
-(* ── Stage 3: Format Normalization ──────────────────────── *)
+(* ── Stage 3: LLM Format Recovery ───────────────────────── *)
+
+let test_llm_format_recovery_known_wrapper () =
+  let schema = make_schema [ int_param "count" true; str_param "label" false ] in
+  let input = `Assoc [ "input", `Assoc [ "count", `Int 5 ] ] in
+  match Correction_pipeline.run ~schema input with
+  | Fixed { corrected; corrections } ->
+    let count = Yojson.Safe.Util.(corrected |> member "count" |> to_int) in
+    Alcotest.(check int) "unwrapped count" 5 count;
+    Alcotest.(check bool)
+      "logged recovery"
+      true
+      (List.exists
+         (fun c -> c.Correction_pipeline.stage = "llm_format_recovery")
+         corrections)
+  | Still_invalid _ -> Alcotest.fail "expected Fixed after unwrap"
+;;
+
+let test_llm_format_recovery_schema_key_match () =
+  (* Wrapper is not a known keyword, but inner keys match schema names. *)
+  let schema = make_schema [ str_param "query" true ] in
+  let input = `Assoc [ "wrapped", `Assoc [ "query", `String "find repos" ] ] in
+  match Correction_pipeline.run ~schema input with
+  | Fixed { corrected; _ } ->
+    let query = Yojson.Safe.Util.(corrected |> member "query" |> to_string) in
+    Alcotest.(check string) "unwrapped query" "find repos" query
+  | Still_invalid _ -> Alcotest.fail "expected Fixed after unwrap by schema match"
+;;
+
+let test_llm_format_recovery_no_match_preserved () =
+  (* Unknown wrapper + no schema key overlap = preserve original. *)
+  let schema = make_schema [ str_param "name" true ] in
+  let input = `Assoc [ "foreign", `Assoc [ "other", `Int 42 ] ] in
+  match Correction_pipeline.run ~schema input with
+  | Fixed _ -> Alcotest.fail "expected Still_invalid — foreign wrapper preserved"
+  | Still_invalid { attempted; _ } ->
+    (* llm_format_recovery ran but decided not to unwrap, so no corrections *)
+    Alcotest.(check bool)
+      "no recovery correction"
+      false
+      (List.exists
+         (fun c -> c.Correction_pipeline.stage = "llm_format_recovery")
+         attempted)
+;;
+
+let test_llm_format_recovery_before_coercion () =
+  (* Unwrap happens first, then coercion can fix the unwrapped fields. *)
+  let schema = make_schema [ int_param "count" true ] in
+  let input = `Assoc [ "args", `Assoc [ "count", `String "99" ] ] in
+  match Correction_pipeline.run ~schema input with
+  | Fixed { corrected; corrections } ->
+    let count = Yojson.Safe.Util.(corrected |> member "count" |> to_int) in
+    Alcotest.(check int) "unwrapped then coerced" 99 count;
+    (* Should have corrections from BOTH stages *)
+    Alcotest.(check bool)
+      "has recovery correction"
+      true
+      (List.exists (fun c -> c.Correction_pipeline.stage = "llm_format_recovery") corrections);
+    Alcotest.(check bool)
+      "has coercion correction"
+      true
+      (List.exists (fun c -> c.Correction_pipeline.stage = "coercion") corrections)
+  | Still_invalid _ -> Alcotest.fail "expected Fixed"
+;;
+
+(* ── Stage 4: Format Normalization ──────────────────────── *)
 
 let test_format_trim_whitespace () =
   let schema = make_schema [ str_param "msg" true ] in
@@ -271,6 +336,21 @@ let () =
             `Quick
             test_default_no_inject_if_present
         ; Alcotest.test_case "null input" `Quick test_default_null_input
+        ] )
+    ; ( "llm_format_recovery"
+      , [ Alcotest.test_case "known wrapper" `Quick test_llm_format_recovery_known_wrapper
+        ; Alcotest.test_case
+            "schema key match"
+            `Quick
+            test_llm_format_recovery_schema_key_match
+        ; Alcotest.test_case
+            "no match preserved"
+            `Quick
+            test_llm_format_recovery_no_match_preserved
+        ; Alcotest.test_case
+            "before coercion"
+            `Quick
+            test_llm_format_recovery_before_coercion
         ] )
     ; ( "format_normalization"
       , [ Alcotest.test_case "trim whitespace" `Quick test_format_trim_whitespace ] )


### PR DESCRIPTION
## Summary

This PR bundles 2 related fixes to the OAS tool layer.

### 1. Fix tool retry policy self-contradiction

- \`Validation_error\` was classified as \`Deterministic\` in \`tool_retry_policy.ml\`, but the default policy had \`retry_on_validation_error = true\`. This made the retry decision contradictory — the classifier said \"never retry\" while the flag said \"retry\".
- Changed \`classify Validation_error\` to \`Transient\`.
- Fixed hardcoded \`error_class = Some Types.Deterministic\` in \`agent_tools.ml\` to \`None\`, allowing \`resolve_error_class\` to use the corrected \`classify\`.
- \`failure_enabled\` now checks \`error_class\` before kind-specific flags: \`Deterministic\` -> no retry, \`Transient|Unknown\` -> check policy flags.

### 2. Add LLM format recovery to correction pipeline

- New stage \`llm_format_recovery\` added as the **first** stage in \`default_stages\` (unwrap → coercion → format_normalization).
- Unwraps known wrapper objects like \`{\"input\": {\"count\": 5}}\` → \`{\"count\": 5}\` using known keywords (\`input\`, \`params\`, \`arguments\`, \`args\`, \`payload\`, \`data\`) or schema key overlap matching.
- 4 new tests added under \`test_correction_pipeline.ml\`, all passing.

## Test Results

| Test Suite | Result |
|------------|--------|
| \`test_correction_pipeline.exe\` | 18/18 pass |

## Files Changed

5 files, +137 / -16 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)