### PR TITLE
refactor(llm_provider): bypass provider slot scheduler

### DIFF
--- a/lib/llm_provider/provider_throttle.ml
+++ b/lib/llm_provider/provider_throttle.ml
@@ -36,12 +36,16 @@ let create ~max_concurrent ~provider_name =
   }
 ;;
 
-let with_permit_priority ~priority t f =
-  (* RFC-0101 PR-3: compose per-provider permit with process-wide FD
-     throttle hook. Identity default when no embedder registered, so
-     standalone OAS behaviour is unchanged. *)
-  Slot_scheduler.with_permit ~priority t.scheduler (fun () ->
-    Fd_throttle_hook.with_slot f)
+let with_permit_priority ~priority:_ _t f =
+  (* OAS is a stateless adapter; concurrency control is the responsibility
+     of upstream consumers (MASC). Per-provider slot scheduling is bypassed
+     because MASC already has fine-grained per-keeper / per-lane capacity
+     gates (Keeper_turn_capacity, Runtime_lane_capacity). OAS-level slot
+     queueing creates invisible backpressure that MASC cannot observe,
+     leading to liveness timeout mismatches (no_first_token).
+
+     Process-wide FD throttle hook is preserved as a safety net. *)
+  Fd_throttle_hook.with_slot f
 ;;
 
 let with_permit t f = with_permit_priority ~priority:Request_priority.Background t f


### PR DESCRIPTION
## Problem

OAS `provider_throttle.ml` enforces a hardcoded per-provider concurrency limit (e.g., `max_concurrent=4` for Ollama/OpenAI_compat). When MASC sends more concurrent requests than this limit, OAS queues them in an **invisible** `Slot_scheduler` priority queue. MASC cannot observe this queueing, so its liveness guard (`ttft_max=600s`) kills requests with `no_first_token` even though the provider is healthy and the request is making legitimate progress.

This creates a mismatch: MASC manages concurrency via `Keeper_turn_capacity` (global=32) and `Runtime_lane_capacity` (per-lane, configurable via `runtime.toml`), but OAS adds a second, hidden layer that MASC cannot see.

## Root Cause

OAS was designed as a stateless adapter/proxy, but `provider_throttle.ml` treats it as a concurrency gate. This is a layering violation:

- **MASC owns fleet scheduling** (per-keeper, per-lane, per-runtime)
- **OAS owns provider protocol adaptation** (HTTP, SSE, parsing)
- **OAS slot scheduler = hidden queue** that breaks liveness accounting

PR #20402 already added fine-grained MASC-side capacity gates (`Keeper_turn_capacity`, `Runtime_lane_capacity`). OAS-level throttling is now redundant.

## Changes

`lib/llm_provider/provider_throttle.ml`:
- `with_permit_priority` bypasses `Slot_scheduler.with_permit` and runs `f` directly
- `Fd_throttle_hook.with_slot` is preserved as a process-wide safety net

## Impact

| Before | After |
|--------|-------|
| OAS queues requests when >4 concurrent to Ollama | OAS passes all requests through immediately |
| Liveness guard kills queued requests (no_first_token) | Liveness guard sees actual provider latency |
| Invisible backpressure | Backpressure is MASC's responsibility |

## Breaking

- `queue_length`, `available`, `in_use` return meaningless values (scheduler no longer used)
- Any downstream logic relying on OAS queue backpressure must move upstream

## Related

- masc-mcp PR #20402 (turn slot → turn capacity refactor)
- masc-mcp PR #20416 (per-provider liveness budget isolation)
- masc-mcp PR #20423 (per-runtime-lane concurrency gate)
