### PR TITLE
chore(release): bump version to 0.204.2

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,14 @@
 (lang dune 3.22)
 (name agent_sdk)
+(version 0.204.2) ; x-release-please-version
+(lang dune 3.22)
+(name agent_sdk)
 (version 0.204.1) ; x-release-please-version
+||||||| parent of b38a7dd2 (chore(release): bump version to 0.204.2)
+(version 0.203.0) ; x-release-please-version
+=======
+(version 0.204.2) ; x-release-please-version
+>>>>>>> b38a7dd2 (chore(release): bump version to 0.204.2)
 
 (generate_opam_files true)
 

--- a/lib/sdk_version.ml
+++ b/lib/sdk_version.ml
@@ -1,5 +1,5 @@
 (** Single source of truth for the SDK version string.
     All other modules reference this instead of hardcoding. *)
 
-let version = "0.204.1" (* x-release-please-version *)
+let version = "0.204.2" (* x-release-please-version *)
 let sdk_name = "agent_sdk"


### PR DESCRIPTION
## Summary

Bumps `agent_sdk` version to `0.204.2`, incorporating the provider slot scheduler bypass (`7c69ebbe`).

### Key change included

**`7c69ebbe` refactor(llm_provider): bypass provider slot scheduler**

The per-provider `Slot_scheduler` in `provider_throttle.ml` created invisible queueing when MASC sent more concurrent requests than the hardcoded slot limit. These queued requests never reached the HTTP layer, causing:

- `no_first_token` liveness guard kills (120s timeout)
- No observable backpressure for MASC to manage
- 17 keeper fibers permanently stuck in the lane capacity spin-loop
- Zero outbound HTTPS connections to `ollama.com` despite FSM showing `streaming` state

**Root cause**: OAS's internal slot scheduler was an invisible bottleneck between MASC's lane capacity gates and the actual HTTP call. MASC already has fine-grained concurrency control (`Keeper_turn_capacity`, `Runtime_lane_capacity` after PR #20402). OAS-level slot queueing was redundant and harmful.

**Fix**: `with_permit_priority` now bypasses `Slot_scheduler` and runs `f` directly. FD throttle hook is preserved as a process-wide safety net.

### Verification

- `sample` profiling confirmed all keeper fibers stuck in `with_lane_capacity` spin-loop
- `lsof` confirmed zero outbound HTTPS connections from the process
- `curl` to `ollama.com/v1` worked perfectly from the same machine
- After applying this fix + masc-mcp lane key fix (#20429), HTTP calls resume

### BREAKING

`queue_length`, `available`, `in_use` now return meaningless values. Downstream code relying on OAS queue backpressure must move that concern upstream (MASC).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>