### PR TITLE
feat(agent): add missing tool name aliases for deprecated names (#18922)

### DIFF
--- a/lib/agent/agent_tool_name_alias.ml
+++ b/lib/agent/agent_tool_name_alias.ml
@@ -114,7 +114,9 @@ let resolve ~requested ~input =
   | "Read" -> Some ("ReadFile", normalize_read_input input)
   | "Grep" | "Search" | "Find" -> Some ("SearchFiles", normalize_search_input input)
   (* boundary-allow *)
-  | "Bash" | "Shell" | "execute_command" | "masc_code_shell" ->
+  | "Bash" | "Shell" | "execute_command" | "masc_code_shell" | "keeper_bash" ->
     Some ("Execute", normalize_execute_input input)
+  | "masc_tasks_list" -> Some ("masc_tasks", input)
+  | "masc_code_search" -> Some ("SearchFiles", normalize_search_input input)
   | _ -> None
 ;;


### PR DESCRIPTION
## Summary

Add missing tool name aliases to prevent \"Tool not found\" fleet errors from keeper-analyst and other keepers that still emit deprecated tool names.

## Aliases added

| Deprecated name | Maps to | Input normalization |
|-----------------|---------|---------------------|
| `keeper_bash` | `Execute` | `normalize_execute_input` |
| `masc_tasks_list` | `masc_tasks` | pass-through |
| `masc_code_search` | `SearchFiles` | `normalize_search_input` |

## Verification

- `dune build lib/agent/` compiles successfully
- These aliases follow the same pattern as existing aliases (`Bash` → `Execute`, `Grep` → `SearchFiles`, etc.)

## Related

- masc-mcp #18922: \"Tool not found: LLM calls deprecated/non-existent tool names — 13/day fleet baseline\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)