### PR TITLE
feat(streaming): propagate Connected and Timeout events down the callback line

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,14 +1,6 @@
 (lang dune 3.22)
 (name agent_sdk)
 (version 0.204.3) ; x-release-please-version
-(lang dune 3.22)
-(name agent_sdk)
-(version 0.204.3) ; x-release-please-version
-||||||| parent of b38a7dd2 (chore(release): bump version to 0.204.2)
-(version 0.204.3) ; x-release-please-version
-=======
-(version 0.204.3) ; x-release-please-version
->>>>>>> b38a7dd2 (chore(release): bump version to 0.204.2)
 
 (generate_opam_files true)
 

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -1276,6 +1276,8 @@ let complete_stream_http
         | Types.Ping -> `Heartbeat
         | Types.SSEError _ | Types.SSEParseFailed _ | Types.SSEUnknownEventType _ ->
           `Wire_error
+        | Types.Connected -> `Skip
+        | Types.Timeout _ -> `Wire_error
       in
       let percentiles () =
         match !inter_chunk_samples with
@@ -1339,6 +1341,7 @@ let complete_stream_http
           ~headers:(config.headers @ Provider_config.auth_headers_for_config config)
           ~body:body_with_stream
           ~f:(fun reader ->
+            on_event Types.Connected;
             let body_logic () =
               let acc = Complete_stream_acc.create_stream_acc () in
               let provider_d_state = ref None in
@@ -1501,6 +1504,12 @@ let complete_stream_http
                   let phase =
                     Http_client.timeout_phase_of_stream_idle_state !stream_idle_state
                   in
+                  let message =
+                    Printf.sprintf
+                      "stream_idle_timeout_s deadline exceeded while %s"
+                      (Http_client.stream_idle_state_to_label !stream_idle_state)
+                  in
+                  on_event (Types.Timeout message);
                   emit_telemetry
                     (Telemetry_event.Timeout
                        { provider
@@ -1516,10 +1525,7 @@ let complete_stream_http
                     ();
                   Error
                     (Http_client.TimeoutError
-                       { message =
-                           Printf.sprintf
-                             "stream_idle_timeout_s deadline exceeded while %s"
-                             (Http_client.stream_idle_state_to_label !stream_idle_state)
+                       { message
                        ; phase
                        })
               in

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -100,7 +100,7 @@ let accumulate_event (acc : stream_acc) = function
     in
     acc.sse_error
     := Some (Printf.sprintf "sse_unknown_event_type: %s | chunk: %s" event_type preview)
-  | Types.MessageStop | Types.Ping -> ()
+  | Types.MessageStop | Types.Ping | Types.Connected | Types.Timeout _ -> ()
 ;;
 
 let finalize_stream_acc (acc : stream_acc) =

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -138,7 +138,9 @@ let sse_event_is_first_token_signal (e : sse_event) : bool =
   | Ping
   | SSEError _
   | SSEParseFailed _
-  | SSEUnknownEventType _ -> false
+  | SSEUnknownEventType _
+  | Connected
+  | Timeout _ -> false
 ;;
 
 (** Emit synthetic SSE events from a complete [api_response].

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -391,6 +391,8 @@ type sse_event =
       { event_type : string
       ; raw : string
       }
+  | Connected
+  | Timeout of string
 
 (** {1 Convenience Constructors}
 

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -271,6 +271,8 @@ type sse_event =
       { event_type : string
       ; raw : string
       }
+  | Connected
+  | Timeout of string
   (** The chunk parsed cleanly but [event_type] did not match any
             documented variant. Likely a provider that added a new event
             type the OAS adapter has not yet learned. Emit explicitly so

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -99,7 +99,7 @@ let accumulate_event (acc : stream_acc) = function
     in
     acc.sse_error
     := Some (Printf.sprintf "sse_unknown_event_type: %s | chunk: %s" event_type preview)
-  | MessageStop | Ping | ContentBlockStop _ -> ()
+  | MessageStop | Ping | ContentBlockStop _ | Connected | Timeout _ -> ()
 ;;
 
 let finalize_stream_acc (acc : stream_acc) =

--- a/test/test_structured_stream.ml
+++ b/test/test_structured_stream.ml
@@ -165,6 +165,8 @@ let test_on_event_callback_fires () =
       | SSEError _ -> "error"
       | SSEParseFailed _ -> "parse_failed"
       | SSEUnknownEventType _ -> "unknown_event_type"
+      | Connected -> "connected"
+      | Timeout _ -> "timeout"
     in
     event_types := t :: !event_types);
   let types = List.rev !event_types in


### PR DESCRIPTION
Propagate Connected and Timeout events down the callback line to make stream connection status SSOT.