### PR TITLE
feat(transport): carry stream_idle_timeout_s on completion_request (RFC-OAS-026, F1 step 1)

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -967,6 +967,7 @@ let complete
              ; messages
              ; tools
              ; runtime_mcp_policy
+             ; stream_idle_timeout_s = None (* sync path: no streaming idle deadline *)
              }
          | None ->
            let resp, lat =
@@ -1680,7 +1681,14 @@ let complete_stream
         t.complete_stream
           ?on_telemetry:transport_on_telemetry
           ~on_event
-          { Llm_transport.config = request_config; messages; tools; runtime_mcp_policy }
+          { Llm_transport.config = request_config
+          ; messages
+          ; tools
+          ; runtime_mcp_policy
+          ; stream_idle_timeout_s
+            (* RFC-OAS-026: carry the idle deadline through the transport
+               boundary so the [Some t] dispatch can no longer drop it. *)
+          }
       | None ->
         complete_stream_http
           ~sw
@@ -1733,6 +1741,14 @@ let make_http_transport ?clock ?stream_idle_timeout_s ?body_timeout_s ~sw ~net (
         { Llm_transport.response; latency_ms = Some latency_ms })
   ; complete_stream =
       (fun ?on_telemetry ~on_event (req : Llm_transport.completion_request) ->
+        (* RFC-OAS-026: the request-borne idle deadline is authoritative;
+           fall back to the construction-time value for callers that have not
+           migrated to setting it on the request. *)
+        let stream_idle_timeout_s =
+          match req.stream_idle_timeout_s with
+          | Some _ as v -> v
+          | None -> stream_idle_timeout_s
+        in
         complete_stream_http
           ~sw
           ~net

--- a/lib/llm_provider/llm_transport.ml
+++ b/lib/llm_provider/llm_transport.ml
@@ -30,6 +30,13 @@ type completion_request =
   ; messages : Types.message list
   ; tools : Yojson.Safe.t list
   ; runtime_mcp_policy : runtime_mcp_policy option
+  ; stream_idle_timeout_s : float option
+    (** Inter-chunk idle deadline for streaming reads, in seconds. Bounds the
+        gap between streamed SSE/NDJSON lines, not total stream duration.
+        [None] preserves pre-0.205.0 behaviour (no idle deadline; the read
+        blocks until the provider closes). Armed only when the transport also
+        holds a clock (closed over at construction). Carried on the request so
+        the dispatch cannot silently drop it. See RFC-OAS-026. @since 0.205.0 *)
   }
 
 let empty_runtime_mcp_policy =

--- a/lib/llm_provider/llm_transport.mli
+++ b/lib/llm_provider/llm_transport.mli
@@ -42,6 +42,12 @@ type completion_request =
   ; messages : Types.message list
   ; tools : Yojson.Safe.t list
   ; runtime_mcp_policy : runtime_mcp_policy option
+  ; stream_idle_timeout_s : float option
+    (** Inter-chunk idle deadline for streaming reads, in seconds. Bounds the
+        gap between streamed SSE/NDJSON lines, not total stream duration.
+        [None] preserves pre-0.205.0 behaviour (no idle deadline). Armed only
+        when the transport also holds a clock (closed over at construction).
+        See RFC-OAS-026. @since 0.205.0 *)
   }
 
 (** Result of a sync completion. *)

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -1046,6 +1046,55 @@ let test_complete_stream_metrics () =
   | Exit -> ()
 ;;
 
+(* RFC-OAS-026: drive the [Some t] transport dispatch arm with a transport that
+   has NO construction-time idle deadline. The high-level [stream_idle_timeout_s]
+   must reach [read_sse] via the request-borne carrier field on
+   [Llm_transport.completion_request]; pre-F1 the dispatch dropped it and a
+   first-token stall hung until an external watchdog. The sibling idle-timeout
+   tests above call [complete_stream] WITHOUT [~transport] (the [None] arm,
+   which always armed idle), so they pass even with the dispatch drop — this one
+   guards the transport arm specifically. *)
+let test_complete_stream_transport_arm_idle_timeout () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url =
+      start_raw_sse_server
+        ~sw
+        ~net:env#net
+        ~clock:env#clock
+        [ 0.15, provider_a_sse_frame_message_start
+        ; 0.0, provider_a_sse_frame_content_block_start
+        ; 0.0, provider_a_sse_frame_delta "late"
+        ; 0.0, provider_a_sse_frame_stop
+        ]
+    in
+    let config = make_config url in
+    (* No construction-time idle (omit [?stream_idle_timeout_s]); only the
+       request-borne deadline carried through the dispatch can arm read_sse. *)
+    let transport = Complete.make_http_transport ~clock:env#clock ~sw ~net:env#net () in
+    match
+      Complete.complete_stream
+        ~sw
+        ~net:env#net
+        ~clock:env#clock
+        ~stream_idle_timeout_s:0.03
+        ~transport
+        ~config
+        ~messages
+        ~on_event:(fun _ -> ())
+        ()
+    with
+    | Error (Http_client.TimeoutError { phase = Http_client.First_token; _ }) ->
+      Eio.Switch.fail sw Exit
+    | Ok _ -> fail "expected idle timeout via the Some-t dispatch — carrier dropped?"
+    | Error _ -> fail "expected TimeoutError{phase=First_token} via the transport arm"
+  with
+  | Exit -> ()
+;;
+
 (* ── complete: body_timeout_s ─────────────────────────── *)
 
 let test_complete_body_timeout_fires () =
@@ -1191,6 +1240,10 @@ let () =
             `Quick
             test_complete_stream_idle_timeout_still_fires
         ; test_case "streaming metrics" `Quick test_complete_stream_metrics
+        ; test_case
+            "transport arm idle timeout (RFC-OAS-026)"
+            `Quick
+            test_complete_stream_transport_arm_idle_timeout
         ] )
     ]
 ;;


### PR DESCRIPTION
## 목표

RFC-OAS-026 §6 **1단계 (OAS)**. streaming dispatch의 `Some t` transport arm이 stream-idle 데드라인을 운반할 수 없어 구조적으로 drop하던 것을, `completion_request`에 typed 필드를 추가해 막는다. 이게 consumer-side fleet 정지의 root(S1)다.

## 근본 원인

- `Llm_transport.completion_request`에 필드가, `complete_stream`에 파라미터가 없어 — caller가 transport를 넘기는 production 경로(`complete.ml:1678` `Some t` arm)에서 `clock`과 `stream_idle_timeout_s`를 **둘 다 버린다**(`None` arm만 전달).
- 그 transport는 per-line 데드라인 없이 SSE를 읽어(`read_sse ?idle_timeout:None`), provider가 소켓을 열어둔 채 mid-stream으로 멈추면 read가 외부 watchdog까지 hang.
- 0.204.5가 `make_http_transport`에 construction-capability를 추가해 masc 자기 transport는 무장됐지만, dispatch drop 자체는 여전 → drop이 *representable*.

## 변경

- `llm_transport.ml`/`.mli`: `completion_request`에 `stream_idle_timeout_s : float option` 추가. 데이터(`float`)라 dispatch가 forward하는 record를 타고 흘러 **drop을 unrepresentable하게**(Parse, don't validate). clock은 capability라 construction에 close-over 유지.
- `complete.ml:1683` (`Some t` arm): 필드를 record에 기입 → dispatch가 더 이상 못 버림.
- `complete.ml:1734` (`make_http_transport.complete_stream`): `req.stream_idle_timeout_s` 우선, 없으면 construction-time 값 fallback.
- `complete.ml:966` (sync arm): `stream_idle_timeout_s = None` (비스트리밍).
- 무장 경로는 기존 typed-timeout 체인 그대로(`read_sse` `with_timeout_exn` → `TimeoutError` → `Retry.Timeout`). 새 메커니즘 없음. httpx(per-chunk read, wall-clock total 없음)·gRPC(deadline-as-field) 선례.

## 검증

- `dune build --root . lib/` (agent_sdk): clean.
- `dune exec --root . test/test_complete_http.exe`: **25/25 OK**.
- 신규 테스트 `transport arm idle timeout (RFC-OAS-026)`: construction-time idle 없는 transport를 `Some t` arm으로 구동 → high-level `stream_idle_timeout_s`가 request-borne 필드로 `read_sse`까지 도달해 `TimeoutError{First_token}` 발화. 기존 idle 테스트들은 `~transport` 없는 `None` arm이라 drop이 있어도 통과 → 이 테스트가 transport arm을 특정해 가드.

## 비고 / 후속

- non-breaking minor feat: 필드 optional + 함수형 업데이트(`{req with}`)라 downstream 무변경. in-tree record 리터럴 2곳은 컴파일러가 열거해 채움.
- **후속(RFC-OAS-026 §6 2-3단계)**: masc pin `>= 0.205.0` + clock fail-fast(`stream_idle_timeout_s` 설정됐는데 clock None이면 silent disarm → fail-fast). **§6 순서 hard: F1 armed end-to-end 검증 전 masc 1800s watchdog/livelock 임계값 손대면 I1 무한 hang 부활.**
- examples `.cmi` @check 노이즈는 pre-existing(lib·tests는 clean).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
참고: SDK Independence Gate는 `agent_tool_name_alias.ml`(masc_ 별칭, #1943)·`provider_throttle.ml`(keeper 주석)의 **pre-existing 위반**으로 fail하며, 이 PR이 건드린 파일(llm_transport/complete/test)과 무관합니다. (Draft는 이 게이트 skip.)
