### PR TITLE
fix(capabilities): RFC-OAS-023 de-anon increment 1 — DeepSeek route + live model-id fix

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -15,7 +15,7 @@
 type thinking_control_format =
   | No_thinking_control (** No thinking control supported *)
   | Thinking_object
-  (** Provider_g-style: top-level [thinking] object plus [reasoning_effort]. *)
+  (** DeepSeek-style: top-level [thinking] object plus [reasoning_effort]. *)
   | Thinking_object_only
   (** Kimi K2.5-style: top-level [thinking] object without [reasoning_effort]. *)
   | Chat_template_kwargs
@@ -400,8 +400,8 @@ type static_model_route =
   | Kimi_k2
   | DashScope_3
   | Provider_n_4
-  | Provider_g_v4_flash
-  | Provider_g_v4_pro
+  | Deepseek_v4_flash
+  | Deepseek_v4_pro
   | Provider_j_large
   | Provider_j_small
   | Provider_m_command
@@ -486,10 +486,10 @@ let static_model_route_of_id model_id =
       else if
         String.starts_with ~prefix:"model-n-4" m || String.starts_with ~prefix:"llama4" m
       then Some Provider_n_4
-      else if String.starts_with ~prefix:"provider_g-v4-flash" m
-      then Some Provider_g_v4_flash
-      else if String.starts_with ~prefix:"provider_g-v4-pro" m
-      then Some Provider_g_v4_pro
+      else if starts_with_any m [ "deepseek-v4-flash"; "provider_g-v4-flash" ]
+      then Some Deepseek_v4_flash
+      else if starts_with_any m [ "deepseek-v4-pro"; "provider_g-v4-pro" ]
+      then Some Deepseek_v4_pro
       else if String.starts_with ~prefix:"provider_j-large" m
       then Some Provider_j_large
       else if String.starts_with ~prefix:"provider_j-small" m
@@ -630,7 +630,7 @@ let capabilities_of_static_model_route = function
       ; supports_image_input = true
       ; supports_native_streaming = true
       }
-  | Provider_g_v4_flash ->
+  | Deepseek_v4_flash ->
     Some
       { default_capabilities with
         max_context_tokens = Some 1_000_000
@@ -647,7 +647,7 @@ let capabilities_of_static_model_route = function
       ; supports_prompt_caching = false
       ; prompt_cache_alignment = None
       }
-  | Provider_g_v4_pro ->
+  | Deepseek_v4_pro ->
     Some
       { default_capabilities with
         max_context_tokens = Some 1_000_000
@@ -1372,7 +1372,31 @@ let%test "for_model_id_static: specific model IDs get correct (not shadowed) cap
     ; ("glm-ocr-test", fun c -> c.supports_image_input && not c.supports_tools)
     ; ("agent_llm_a-opus-4-20250501", fun c -> c.max_output_tokens = Some 128_000)
     ; ("model-d-4.1-mini", fun c -> c.max_output_tokens = Some 32_000)
-    ; ("provider_g-v4-flash-test", fun c -> c.thinking_control_format = Thinking_object)
+      (* RFC-OAS-023: the real fleet model ids ([deepseek-v4-flash],
+         [deepseek-v4-pro]) must resolve to the DeepSeek capability route.
+         Before the de-anonymization these matched only the anon
+         [provider_g-v4-*] prefixes, so the live fleet missed the static
+         table and silently fell back to provider-default capabilities. The
+         anon prefixes are retained as aliases and asserted here too. The
+         fingerprint ([Thinking_object] + [384_000] output cap) is specific
+         to the DeepSeek record, so a fall-through to defaults fails the
+         test. *)
+    ; ( "deepseek-v4-flash"
+      , fun c ->
+          c.thinking_control_format = Thinking_object
+          && c.max_output_tokens = Some 384_000 )
+    ; ( "provider_g-v4-flash-test"
+      , fun c ->
+          c.thinking_control_format = Thinking_object
+          && c.max_output_tokens = Some 384_000 )
+    ; ( "deepseek-v4-pro"
+      , fun c ->
+          c.thinking_control_format = Thinking_object
+          && c.max_output_tokens = Some 384_000 )
+    ; ( "provider_g-v4-pro-test"
+      , fun c ->
+          c.thinking_control_format = Thinking_object
+          && c.max_output_tokens = Some 384_000 )
     ; ( "provider_l-ultra-253b"
       , fun c ->
           c.thinking_control_format = Chat_template_kwargs && c.supports_tool_choice )

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -9,7 +9,7 @@
 type thinking_control_format =
   | No_thinking_control (** No thinking control supported *)
   | Thinking_object
-  (** Provider_g-style: top-level [thinking] object plus [reasoning_effort]. *)
+  (** DeepSeek-style: top-level [thinking] object plus [reasoning_effort]. *)
   | Thinking_object_only
   (** Kimi K2.5-style: top-level [thinking] object without [reasoning_effort]. *)
   | Chat_template_kwargs
@@ -132,8 +132,8 @@ type static_model_route =
   | Kimi_k2
   | DashScope_3
   | Provider_n_4
-  | Provider_g_v4_flash
-  | Provider_g_v4_pro
+  | Deepseek_v4_flash
+  | Deepseek_v4_pro
   | Provider_j_large
   | Provider_j_small
   | Provider_m_command

--- a/lib/llm_provider/pricing.ml
+++ b/lib/llm_provider/pricing.ml
@@ -127,9 +127,13 @@ let static_pricing_opt_normalized normalized =
        Promotional 75%% discount until 2026-05-31.
        Cache read rate: flash $0.0028/M (2%% of input), pro $0.003625/M.
        Cache write is billed at standard input rate (no surcharge). *)
-    else if string_contains ~needle:"provider_g-v4-pro" normalized
+    else if
+      string_contains ~needle:"deepseek-v4-pro" normalized
+      || string_contains ~needle:"provider_g-v4-pro" normalized
     then Some ((0.435, 0.87), (1.0, 0.008333333333333333))
-    else if string_contains ~needle:"provider_g-v4-flash" normalized
+    else if
+      string_contains ~needle:"deepseek-v4-flash" normalized
+      || string_contains ~needle:"provider_g-v4-flash" normalized
     then
       Some ((0.14, 0.28), (1.0, 0.02))
       (* Gemini 3-계 preview. Source: ai.google.dev/gemini-api/docs/pricing,

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -178,8 +178,8 @@ let pp_static_model_route ppf = function
   | Capabilities.Kimi_k2 -> Format.fprintf ppf "Kimi_k2"
   | Capabilities.DashScope_3 -> Format.fprintf ppf "DashScope_3"
   | Capabilities.Provider_n_4 -> Format.fprintf ppf "Provider_n_4"
-  | Capabilities.Provider_g_v4_flash -> Format.fprintf ppf "Provider_g_v4_flash"
-  | Capabilities.Provider_g_v4_pro -> Format.fprintf ppf "Provider_g_v4_pro"
+  | Capabilities.Deepseek_v4_flash -> Format.fprintf ppf "Deepseek_v4_flash"
+  | Capabilities.Deepseek_v4_pro -> Format.fprintf ppf "Deepseek_v4_pro"
   | Capabilities.Provider_j_large -> Format.fprintf ppf "Provider_j_large"
   | Capabilities.Provider_j_small -> Format.fprintf ppf "Provider_j_small"
   | Capabilities.Provider_m_command -> Format.fprintf ppf "Provider_m_command"
@@ -279,9 +279,15 @@ let test_static_model_route_normalizes_cloud_suffix () =
     (Capabilities.static_model_route_of_id " provider_c-k2.6:cloud ");
   check
     (option static_model_route_testable)
-    "provider_g cloud route"
-    (Some Capabilities.Provider_g_v4_pro)
+    "deepseek anon-alias cloud route"
+    (Some Capabilities.Deepseek_v4_pro)
     (Capabilities.static_model_route_of_id "provider_g-v4-pro:cloud");
+  (* RFC-OAS-023: the real fleet id must also route post-de-anonymization. *)
+  check
+    (option static_model_route_testable)
+    "deepseek real-id cloud route"
+    (Some Capabilities.Deepseek_v4_pro)
+    (Capabilities.static_model_route_of_id "deepseek-v4-pro:cloud");
   check
     (option static_model_route_testable)
     "provider_k cloud route"

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -95,6 +95,27 @@ let gemini_cfg =
 let glm_cfg = cfg ~kind:Glm ~base_url:"https://open.bigmodel.cn/api/paas/v4"
 let ollama_cfg = cfg ~kind:Ollama ~base_url:"http://127.0.0.1:11434"
 
+(* RFC-OAS-023 fixture. Unlike the shared [cfg] above, this one uses the REAL
+   fleet model id ([deepseek-v4-flash], the live default in masc
+   [runtime.toml]) and deliberately OMITS [supports_tool_choice_override], so
+   the OpenAI-compat request builder runs the real capability lookup
+   ([Capabilities.for_model_id]) instead of the override. The Ollama Cloud
+   provider speaks the OpenAI-compat Chat Completions wire
+   (provider_d-http / https://ollama.com/v1), so [OpenAI_compat] is the
+   matching kind for the fleet wire. *)
+let deepseek_cfg ~tool_choice =
+  Provider_config.make
+    ~kind:OpenAI_compat
+    ~model_id:"deepseek-v4-flash"
+    ~base_url:"https://ollama.com/v1"
+    ~api_key:"test-key"
+    ~max_tokens:1024
+    ~temperature:0.7
+    ~tool_choice
+    ~disable_parallel_tool_use:true
+    ()
+;;
+
 (* ── Helpers ────────────────────────────────────────── *)
 
 let snapshot label expected actual = check string label expected actual
@@ -179,6 +200,49 @@ let test_openai_none () =
     false
     (contains ~needle:{|"tool_choice"|} body);
   check bool "None_ omits tools field" false (contains ~needle:{|"tools"|} body)
+;;
+
+(* ── DeepSeek via OpenAI-compat (RFC-OAS-023 routing fence) ───
+   This fixture pins the CURRENT live-fleet wire for [deepseek-v4-flash]
+   through the OpenAI-compat backend. It exercises the REAL capability
+   lookup (no [supports_tool_choice_override]), so it runs through the
+   prefix dispatcher fixed in RFC-OAS-023.
+
+   It is a regression FENCE, not a discrimination proof: with
+   [enable_thinking=None] and [max_tokens=1024], none of the capability
+   fields the DeepSeek route changes ([thinking_control_format],
+   [max_output_tokens]) alter the OpenAI chat-completions request body,
+   so the wire is byte-identical before/after the de-anonymization. The
+   actual proof that [deepseek-v4-flash] resolves to [Deepseek_v4_flash]
+   lives in the inline [let%test "for_model_id_static: specific model IDs
+   get correct (not shadowed) capabilities"] in [capabilities.ml] and in
+   [test_capabilities.ml]'s cloud-suffix route checks. *)
+let deepseek_required_expected =
+  {|{"parallel_tool_calls":false,"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"tool_choice":"required","temperature":0.7,"model":"deepseek-v4-flash","messages":[{"role":"user","content":"What's the weather in Seoul?"},{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Seoul\"}"}}],"role":"assistant","content":null},{"role":"tool","tool_call_id":"call_1","content":"Sunny, 25C"}],"max_tokens":1024}|}
+;;
+
+let test_deepseek_required () =
+  let body =
+    Backend_openai_request.build_request
+      ~config:(deepseek_cfg ~tool_choice:Any)
+      ~messages
+      ~tools:[ tool_decl ]
+      ()
+  in
+  snapshot
+    "deepseek-v4-flash openai-compat tool_choice=required(Any) snapshot"
+    deepseek_required_expected
+    body;
+  check
+    bool
+    "tool_choice emitted (capability lookup resolves supports_tool_choice)"
+    true
+    (contains ~needle:{|"tool_choice":"required"|} body);
+  check
+    bool
+    "model id is the real fleet id"
+    true
+    (contains ~needle:{|"model":"deepseek-v4-flash"|} body)
 ;;
 
 (* ── Anthropic ──────────────────────────────────────── *)
@@ -318,6 +382,7 @@ let () =
       , [ test_case "tool_choice forced(Tool)" `Quick test_openai_forced
         ; test_case "tool_choice required(Any)" `Quick test_openai_required
         ; test_case "tool_choice none(None_)" `Quick test_openai_none
+        ; test_case "deepseek-v4-flash required(Any)" `Quick test_deepseek_required
         ] )
     ; "anthropic", [ test_case "tool_choice forced(Tool)" `Quick test_anthropic_forced ]
     ; "gemini", [ test_case "tool_choice Any" `Quick test_gemini_any ]


### PR DESCRIPTION
## RFC-OAS-023 de-anonymization — increment 1: DeepSeek

Implements the first slice of **RFC-OAS-023** (capability axis reshape; de-anonymize vendor names, model=brand). RFC-OAS-023 supersedes the withdrawn RFC-0001 vendor purge ("brand → alphabet-code substitution is encryption, not abstraction").

This branch will accumulate the rest of the de-anonymization + the two-record (model × transport) capability reshape; DeepSeek goes first because it is the only **live** fleet bug.

### Bug (live)
`capabilities.ml static_model_route_of_id` matched DeepSeek only via the anonymized prefix `provider_g-v4-flash` / `provider_g-v4-pro`. The fleet (`masc runtime.toml`, `default = ollama_cloud.deepseek-v4-flash`) sends the real ids `deepseek-v4-flash` / `deepseek-v4-pro`, which never matched → catalog miss → silent provider-default capabilities (RFC-OAS-023 §1.2 `Thinking_returned_but_declared_unsupported` drift). `provider_runtime_binding` aliases only the provider **label** (`"deepseek" → "provider_g"`), not model ids, so the miss was unrescued.

### Changes (DeepSeek only)
- Rename `static_model_route` `Provider_g_v4_flash`/`_pro` → `Deepseek_v4_flash`/`_pro` (`capabilities.ml` + `.mli` + `test_capabilities.ml`). Enum is oas-internal (0 external refs).
- Match the real `deepseek-v4-*` prefixes; anon prefix kept as a transitional alias (mirrors the existing GLM/Gemini both-prefix pattern), dropped in the stack's cleanup PR.
- `pricing.ml`: real `deepseek-v4-*` needles (anon retained as `||` alternative).
- New `deepseek-v4-flash` snapshot fixture (regression fence). The routing-fix proof is the `capabilities` route `let%test` + `test_capabilities` route checks (`None` pre-fix → `Some` 384k DeepSeek record post-fix), **not** the snapshot bytes (identical pre/post for this fixture — noted honestly in the fixture comment rather than asserting a proof the bytes don't carry).

No capability **values** changed (`thinking_control_format` stays `Thinking_object`). Per-model wire correctness (e.g. `reasoning_effort` vs thinking object on the Ollama Cloud transport) is a later RFC-OAS-023 PR (the two-record axis reshape).

### Verification
- `dune build` (lib/llm_provider + the two test exes): clean.
- `test_capabilities`: 47/47. `test_snapshot_provider_serialization`: 8/8.

### Scope note (not a partial-migration workaround)
Per RFC-OAS-023's defined PR stack, this is the intentional first increment (live-bug-first), not an abandoned partial. Remaining anonymized families (OpenAI/Anthropic/Mistral/Kimi/Llama/DashScope/Grok/Cohere/NVIDIA) and the axis reshape follow on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
