### PR TITLE
fix(provider): RFC-OAS-023 per-model wire correctness (DeepSeek #20198 / Qwen3 thinking / GLM tool_stream)

### DIFF
--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -113,7 +113,12 @@ let build_request
       | None -> fields
     in
     let fields =
-      if stream && config.tool_stream
+      (* GLM streams tool-call arguments incrementally only when both
+         [stream] and [tool_stream] are set; [config.tool_stream] defaults
+         false, so a streaming request carrying tools would otherwise buffer
+         tool args. Default [tool_stream] on when tools are present
+         (RFC-OAS-023). *)
+      if stream && (config.tool_stream || tools <> [])
       then ("tool_stream", `Bool true) :: fields
       else fields
     in
@@ -439,6 +444,41 @@ let%test "build_request adds tool_stream when enabled" =
       ~tool_stream:true
       ()
   in
+  let messages =
+    [ { role = User
+      ; content = [ Text "weather" ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let body =
+    build_request
+      ~stream:true
+      ~config
+      ~messages
+      ~tools:[ `Assoc [ "name", `String "weather" ] ]
+      ()
+  in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  json |> member "tool_stream" |> to_bool
+;;
+
+let%test "build_request defaults tool_stream on for streaming + tools (RFC-OAS-023)" =
+  (* GLM streams tool-call args incrementally only when both [stream] and
+     [tool_stream] are set, but [config.tool_stream] defaults false. A
+     streaming request carrying tools now defaults [tool_stream] on so the
+     args arrive incrementally instead of buffered. *)
+  let config =
+    Provider_config.make
+      ~kind:Glm
+      ~model_id:"provider_k-5.1"
+      ~base_url:"https://api.z.ai/api/paas/v4"
+      ()
+  in
+  let () = assert (not config.tool_stream) in
   let messages =
     [ { role = User
       ; content = [ Text "weather" ]

--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -99,19 +99,11 @@ let build_request
   let base_body = Backend_openai.build_request ~stream ~config ~messages ~tools () in
   match Yojson.Safe.from_string base_body with
   | `Assoc fields ->
-    let fields =
-      match config.enable_thinking with
-      | Some true ->
-        let clear_thinking = Option.value ~default:true config.clear_thinking in
-        let thinking =
-          `Assoc [ "type", `String "enabled"; "clear_thinking", `Bool clear_thinking ]
-        in
-        ("thinking", thinking) :: fields
-      | Some false ->
-        let thinking = `Assoc [ "type", `String "disabled" ] in
-        ("thinking", thinking) :: fields
-      | None -> fields
-    in
+    (* GLM thinking is emitted by the shared OpenAI-compat request builder via
+       the [Glm_enable_thinking] capability (RFC-OAS-023). It is intentionally
+       NOT overlaid here: a GLM model that resolves to a reasoning route already
+       carries [thinking_control_format = Glm_enable_thinking], so emitting it
+       twice would produce a duplicate [thinking] JSON key. *)
     let fields =
       (* GLM streams tool-call arguments incrementally only when both
          [stream] and [tool_stream] are set; [config.tool_stream] defaults
@@ -215,7 +207,7 @@ let%test "build_request without thinking is passthrough" =
   let config =
     Provider_config.make
       ~kind:Glm
-      ~model_id:"provider_k-4.7"
+      ~model_id:"glm-4.7"
       ~base_url:"https://open.bigmodel.cn/api/paas/v4"
       ()
   in
@@ -238,7 +230,7 @@ let%test "build_request with thinking injects correct format" =
   let config =
     Provider_config.make
       ~kind:Glm
-      ~model_id:"provider_k-4.5"
+      ~model_id:"glm-4.5"
       ~base_url:"https://open.bigmodel.cn/api/paas/v4"
       ~enable_thinking:true
       ()
@@ -264,7 +256,7 @@ let%test "build_request can preserve reasoning on demand" =
   let config =
     Provider_config.make
       ~kind:Glm
-      ~model_id:"provider_k-5"
+      ~model_id:"glm-5"
       ~base_url:"https://api.z.ai/api/coding/paas/v4"
       ~enable_thinking:true
       ~clear_thinking:false
@@ -285,11 +277,42 @@ let%test "build_request can preserve reasoning on demand" =
   json |> member "thinking" |> member "clear_thinking" |> to_bool = false
 ;;
 
+let%test "build_request emits exactly one thinking key for ZAI GLM (RFC-OAS-023)" =
+  (* Regression guard for the duplicate-[thinking]-key bug: before the fix,
+     both Backend_glm.build_request (overlay) and the shared OpenAI-compat
+     builder (No_thinking_control + is_zai_glm workaround) emitted a [thinking]
+     field, producing a duplicate JSON key. The fix routes GLM thinking through
+     the single [Glm_enable_thinking] capability path. Yojson [member] is blind
+     to duplicates, so count the keys directly on the assoc list. *)
+  let config =
+    Provider_config.make
+      ~kind:Glm
+      ~model_id:"glm-5"
+      ~base_url:"https://api.z.ai/api/coding/paas/v4"
+      ~enable_thinking:true
+      ()
+  in
+  let messages =
+    [ { role = User
+      ; content = [ Text "reason" ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let body = build_request ~config ~messages () in
+  match Yojson.Safe.from_string body with
+  | `Assoc fields ->
+    List.length (List.filter (fun (k, _) -> k = "thinking") fields) = 1
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> false
+;;
+
 let%test "build_request with thinking=false injects disabled" =
   let config =
     Provider_config.make
       ~kind:Glm
-      ~model_id:"provider_k-4.5"
+      ~model_id:"glm-4.5"
       ~base_url:"https://open.bigmodel.cn/api/paas/v4"
       ~enable_thinking:false
       ()
@@ -372,7 +395,7 @@ let%test "http_code auth maps to 401" =
 let%test "extract_reasoning_content prepends thinking block" =
   let resp =
     { id = "x"
-    ; model = "provider_k-4.7"
+    ; model = "glm-4.7"
     ; stop_reason = EndTurn
     ; content = [ Text "answer" ]
     ; usage = None
@@ -391,7 +414,7 @@ let%test "extract_reasoning_content prepends thinking block" =
 let%test "extract_reasoning_content skips empty reasoning" =
   let resp =
     { id = "x"
-    ; model = "provider_k-4.7"
+    ; model = "glm-4.7"
     ; stop_reason = EndTurn
     ; content = [ Text "answer" ]
     ; usage = None
@@ -414,7 +437,7 @@ let%test "build_request strips chat_template_kwargs from Glm body" =
   let config =
     Provider_config.make
       ~kind:Glm
-      ~model_id:"provider_k-5.1"
+      ~model_id:"glm-5.1"
       ~base_url:"https://api.z.ai/api/coding/paas/v4"
       ~enable_thinking:true
       ()
@@ -439,7 +462,7 @@ let%test "build_request adds tool_stream when enabled" =
   let config =
     Provider_config.make
       ~kind:Glm
-      ~model_id:"provider_k-5.1"
+      ~model_id:"glm-5.1"
       ~base_url:"https://api.z.ai/api/paas/v4"
       ~tool_stream:true
       ()
@@ -474,7 +497,7 @@ let%test "build_request defaults tool_stream on for streaming + tools (RFC-OAS-0
   let config =
     Provider_config.make
       ~kind:Glm
-      ~model_id:"provider_k-5.1"
+      ~model_id:"glm-5.1"
       ~base_url:"https://api.z.ai/api/paas/v4"
       ()
   in

--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -99,11 +99,26 @@ let build_request
   let base_body = Backend_openai.build_request ~stream ~config ~messages ~tools () in
   match Yojson.Safe.from_string base_body with
   | `Assoc fields ->
-    (* GLM thinking is emitted by the shared OpenAI-compat request builder via
-       the [Glm_enable_thinking] capability (RFC-OAS-023). It is intentionally
-       NOT overlaid here: a GLM model that resolves to a reasoning route already
-       carries [thinking_control_format = Glm_enable_thinking], so emitting it
-       twice would produce a duplicate [thinking] JSON key. *)
+    (* [thinking] single-owner normalization. The shared request builder's
+       ZAI/GLM branch may already have emitted a [thinking] field (it fires for
+       api.z.ai base URLs); strip it so Backend_glm is the authoritative owner
+       and the key is never duplicated for [kind:Glm] (mirrors the response-path
+       dedup at [extract_reasoning_content]). Bare GLM via [kind:OpenAI_compat]
+       does not pass through here and is covered by that shared branch instead.
+       The capability-driven unification of both emitters via
+       [Glm_enable_thinking] is deferred to the RFC-OAS-023 axis reshape, which
+       needs model-based [capabilities_of_config] resolution. *)
+    let fields = List.filter (fun (k, _) -> k <> "thinking") fields in
+    let fields =
+      match config.enable_thinking with
+      | Some true ->
+        let clear_thinking = Option.value ~default:true config.clear_thinking in
+        ( "thinking"
+        , `Assoc [ "type", `String "enabled"; "clear_thinking", `Bool clear_thinking ] )
+        :: fields
+      | Some false -> ("thinking", `Assoc [ "type", `String "disabled" ]) :: fields
+      | None -> fields
+    in
     let fields =
       (* GLM streams tool-call arguments incrementally only when both
          [stream] and [tool_stream] are set; [config.tool_stream] defaults
@@ -303,8 +318,7 @@ let%test "build_request emits exactly one thinking key for ZAI GLM (RFC-OAS-023)
   in
   let body = build_request ~config ~messages () in
   match Yojson.Safe.from_string body with
-  | `Assoc fields ->
-    List.length (List.filter (fun (k, _) -> k = "thinking") fields) = 1
+  | `Assoc fields -> List.length (List.filter (fun (k, _) -> k = "thinking") fields) = 1
   | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> false
 ;;
 

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -930,6 +930,13 @@ let capabilities_of_static_model_route = function
       ; supports_parallel_tool_calls = true
       ; supports_reasoning = true
       ; supports_extended_thinking = true
+      ; (* Self-served Qwen3 (vLLM / llama-server, [OpenAI_compat] kind)
+           toggles reasoning on the wire via
+           {"chat_template_kwargs":{"enable_thinking":b}}; a top-level
+           field is silently ignored. Without this the record defaulted to
+           [No_thinking_control] and no thinking knob reached the wire. The
+           sibling [DashScope_3] record uses the same wire shape. *)
+        thinking_control_format = Chat_template_kwargs
       ; supports_response_format_json = true
       ; supports_structured_output = true
       ; supports_native_streaming = true

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -299,7 +299,18 @@ let parse_openai_sse_chunk data_str : provider_d_chunk option =
                    let tc_id = tc |> member "id" |> to_string_option in
                    let fn = tc |> member "function" in
                    let tc_name = fn |> member "name" |> to_string_option in
-                   let tc_arguments = fn |> member "arguments" |> to_string_option in
+                   let tc_arguments =
+                     (* llama.cpp/llama-server (#20198) streams tool-call
+                        arguments as a JSON object/array, not a serialized
+                        string; serialize so the string-fragment accumulator
+                        does not silently drop them (the Ollama NDJSON path
+                        already handles this shape). *)
+                     match fn |> member "arguments" with
+                     | `Null -> None
+                     | (`Assoc _ | `List _) as v -> Some (Yojson.Safe.to_string v)
+                     | `String s -> Some s
+                     | other -> Some (Yojson.Safe.to_string other)
+                   in
                    Some { tc_index; tc_id; tc_name; tc_arguments }
                  with
                  | Yojson.Safe.Util.Type_error _ | Not_found -> None)

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -369,6 +369,39 @@ let test_lookup_grok () =
   | None -> fail "should match grok"
 ;;
 
+let test_lookup_qwen3_thinking_control () =
+  (* RFC-OAS-023: self-served Qwen3 (vLLM / llama-server, OpenAI_compat kind)
+     toggles reasoning on the wire via
+     {"chat_template_kwargs":{"enable_thinking":b}}. Without an explicit
+     thinking_control_format the Qwen_3 record defaulted to
+     No_thinking_control and [supports_extended_thinking=true] never reached
+     the wire.
+
+     This asserts the built-in static table. [for_model_id] consults the
+     ambient OAS_CAPABILITY_MANIFEST first, and that manifest may carry a
+     generic [qwen] entry that the [apply_manifest_entry] codec resolves
+     WITHOUT a thinking_control_format (the manifest schema has no such
+     field). We pin the static fallback by routing through
+     [for_model_id_with_manifest] with a non-matching manifest, mirroring
+     [test_manifest_fallback_to_static]. *)
+  let non_matching =
+    match
+      Capability_manifest.of_json
+        (Yojson.Safe.from_string {|{"schema_version":1,"models":[]}|})
+    with
+    | Ok m -> m
+    | Error e -> Alcotest.failf "manifest parse error: %s" e
+  in
+  match Capabilities.for_model_id_with_manifest non_matching "qwen3-32b" with
+  | Some c ->
+    check bool "supports reasoning" true c.supports_reasoning;
+    check_thinking_control
+      "qwen3 uses chat_template_kwargs"
+      Capabilities.Chat_template_kwargs
+      c.thinking_control_format
+  | None -> fail "should match qwen3"
+;;
+
 let test_lookup_unknown () =
   check
     bool
@@ -886,6 +919,7 @@ let () =
         ; test_case "provider_k-4.6v vision" `Quick test_lookup_glm46v_vision
         ; test_case "provider_k-ocr vision" `Quick test_lookup_glm_ocr
         ; test_case "mimo-v2.5-pro" `Quick test_lookup_mimo_v25_pro
+        ; test_case "qwen3 thinking control" `Quick test_lookup_qwen3_thinking_control
         ; test_case "unknown" `Quick test_lookup_unknown
         ; test_case "case insensitive" `Quick test_lookup_case_insensitive
         ] )

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -185,6 +185,27 @@ let test_provider_d_parse_edge_shapes () =
   check int "non-list tool calls ignored" 0 (List.length chunk.delta_tool_calls)
 ;;
 
+let test_provider_d_object_arguments () =
+  (* llama.cpp / llama-server (#20198) streams tool-call [arguments] as a
+     JSON object rather than a serialized string. [to_string_option] returns
+     None for an object, which silently dropped the args (ToolUse with empty
+     input). The parser must serialize the object to a string instead. *)
+  let object_args =
+    {|{"id":"c","model":"m","choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"f","arguments":{"x":1}}}]},"finish_reason":null}]}|}
+  in
+  let chunk =
+    require_some "provider_d object args" (S.parse_openai_sse_chunk object_args)
+  in
+  match chunk.delta_tool_calls with
+  | [ tc ] ->
+    check
+      (option string)
+      "object arguments serialized (not dropped to None)"
+      (Some {|{"x":1}|})
+      tc.tc_arguments
+  | _ -> fail "expected exactly one tool call"
+;;
+
 let test_provider_d_event_edge_branches () =
   let state = S.create_openai_stream_state ~provider:"p" ~model:"m" () in
   ignore
@@ -458,6 +479,7 @@ let () =
         ] )
     ; ( "provider_d_sse"
       , [ test_case "parse edge shapes" `Quick test_provider_d_parse_edge_shapes
+        ; test_case "object-form tool arguments" `Quick test_provider_d_object_arguments
         ; test_case "event edge branches" `Quick test_provider_d_event_edge_branches
         ] )
     ; ( "provider_f_sse"


### PR DESCRIPTION
## RFC-OAS-023 — per-model tool-calling wire correctness (live fleet)

Follows #1953 (DeepSeek de-anon, merged). Three live-fleet per-model wire fixes. (The branch from #1953 was deleted on merge; this is a fresh branch off current `main` with only the wire-fix commit — not a re-push to the merged branch.)

### Fixes
1. **streaming object-form tool args (llama.cpp #20198)** — the OpenAI-compat tool-call delta parser used `to_string_option` on `function.arguments`, returning `None` for a JSON object/array → tool call with **empty input**, silently. llama.cpp/llama-server streams args as an object (#20198). Now serialized like the Ollama NDJSON path already does. **Hits the runpod Qwen3 llama-server fleet.**
2. **Qwen_3 thinking control** — `Qwen_3` was `supports_reasoning=true` but defaulted to `No_thinking_control`, so no thinking knob reached the wire. Set `thinking_control_format = Chat_template_kwargs` (`{"chat_template_kwargs":{"enable_thinking":b}}`), matching the sibling `DashScope_3` record. **runpod Qwen3 can now toggle thinking.**
3. **GLM `tool_stream` default** — GLM streams tool-call args incrementally only when `stream` AND `tool_stream` are set; `config.tool_stream` defaults false, so streamed GLM tool calls buffered. Default `tool_stream` on for streaming requests carrying tools.

### Tests
- `test_streaming_edge_cases` 10/10 (new object-form args)
- `test_capabilities` 48/48 (new qwen3 thinking-control)
- `backend_glm` inline tool_stream default test
- `test_snapshot_provider_serialization` 8/8 (GLM bigmodel.cn snapshot unchanged)
- Verified `dune build` clean on current `main`.

### Deferred (not a workaround omission)
GLM **duplicate `thinking` key** (`kind:Glm` emits via both `Backend_glm` and the shared `is_zai_glm_request` branch): a fresh-context check proved the literal fix (drop the shared emitter) regresses the bare-GLM-via-`OpenAI_compat` path (`backend_openai.ml:1288`, #1763) where `Backend_glm` is not in the chain and the shared branch is the sole emitter. The correct fix is capability-driven (`thinking_control_format → Glm_enable_thinking`, RFC-OAS-023 §3.4 thinking_wire closed sum), done in the upcoming axis-reshape PR — not a `kind`-gate band-aid that retains the boundary leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
