### PR TITLE
fix(llm_provider): detect truncated SSE streams instead of phantom completion

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -1268,6 +1268,146 @@ let%test "openai_compat_error_event returns None for a normal content chunk" =
        {|{"id":"c","choices":[{"delta":{"content":"hi"}}]}|})
 ;;
 
+(* Map the stream accumulator to a result, rejecting a phantom completion. A
+   stream whose socket closed mid-response — no [MessageStop] and no
+   [stop_reason]-bearing [MessageDelta] (finish_reason / done / finishReason) —
+   would otherwise finalize as [Ok] with the default [stop_reason = EndTurn],
+   indistinguishable from a real completion, and the caller would consume a
+   truncated turn. Surface that as a retryable [NetworkError {kind =
+   End_of_file}] so the caller retries. A recorded SSE error still wins (it is
+   the more specific cause and is returned by [finalize_stream_acc] itself). *)
+let result_of_finalize (acc : Complete_stream_acc.stream_acc)
+  : (Types.api_response, Http_client.http_error) result
+  =
+  match Complete_stream_acc.finalize_stream_acc acc with
+  | Error serr -> Error (http_error_of_stream_error serr)
+  | Ok resp ->
+    if Complete_stream_acc.saw_terminal acc
+    then Ok resp
+    else
+      Error
+        (Http_client.NetworkError
+           { message =
+               "SSE stream closed before a terminal event (no finish_reason / \
+                message_stop / done): truncated response"
+           ; kind = Http_client.End_of_file
+           })
+;;
+
+let%test "result_of_finalize: content without a terminal -> truncated End_of_file" =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  Complete_stream_acc.accumulate_event
+    acc
+    (Types.ContentBlockStart
+       { index = 0; content_type = "text"; tool_id = None; tool_name = None });
+  Complete_stream_acc.accumulate_event
+    acc
+    (Types.ContentBlockDelta { index = 0; delta = Types.TextDelta "partial" });
+  (* No MessageStop and no stop_reason-bearing MessageDelta => phantom completion. *)
+  match result_of_finalize acc with
+  | Error (Http_client.NetworkError { kind = Http_client.End_of_file; _ }) -> true
+  | _ -> false
+;;
+
+let%test "result_of_finalize: MessageStop terminal -> Ok (Anthropic)" =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  Complete_stream_acc.accumulate_event acc Types.MessageStop;
+  match result_of_finalize acc with
+  | Ok _ -> true
+  | Error _ -> false
+;;
+
+let%test "result_of_finalize: stop_reason-bearing MessageDelta -> Ok (universal terminal)"
+  =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  Complete_stream_acc.accumulate_event
+    acc
+    (Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None });
+  match result_of_finalize acc with
+  | Ok _ -> true
+  | Error _ -> false
+;;
+
+let%test "result_of_finalize: usage-only MessageDelta (stop_reason=None) is NOT terminal" =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  Complete_stream_acc.accumulate_event
+    acc
+    (Types.MessageDelta { stop_reason = None; usage = None });
+  not (Complete_stream_acc.saw_terminal acc)
+;;
+
+let%test "result_of_finalize: a recorded SSE error wins over the truncation check" =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  Complete_stream_acc.accumulate_event
+    acc
+    (Types.SSEError
+       { message = "rate limited"; error_type = Some "rate_limit_exceeded"; raw = "{}" });
+  match result_of_finalize acc with
+  | Error (Http_client.HttpError { code = 429; _ }) -> true
+  | _ -> false
+;;
+
+(* Per-provider clean-stream regression guards: each backend's real wire
+   terminal, run through its actual parser + converter, MUST set [saw_terminal]
+   so a clean stream finalizes [Ok] (never a false truncation). The
+   OpenAI-compat case is the trap: its "[DONE]" sentinel parses to [None], so
+   the signal is the finish_reason MessageDelta, not [DONE]. *)
+let accumulate_all acc evts = List.iter (Complete_stream_acc.accumulate_event acc) evts
+
+let%test "clean stream Ok: OpenAI-compat finish_reason (also covers GLM/Kimi/DashScope)" =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  let st = Streaming.create_openai_stream_state ~provider:"openai" ~model:"m" () in
+  (match
+     Streaming.parse_openai_sse_chunk
+       {|{"choices":[{"delta":{},"finish_reason":"stop"}]}|}
+   with
+   | Some chunk ->
+     let evts, _ = Streaming.openai_chunk_to_events st chunk in
+     accumulate_all acc evts
+   | None -> ());
+  Complete_stream_acc.saw_terminal acc
+  &&
+  match result_of_finalize acc with
+  | Ok _ -> true
+  | Error _ -> false
+;;
+
+let%test "clean stream Ok: Anthropic message_stop" =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  (match Streaming.parse_sse_event (Some "message_stop") "{}" with
+   | Some evt -> Complete_stream_acc.accumulate_event acc evt
+   | None -> ());
+  Complete_stream_acc.saw_terminal acc
+;;
+
+let%test "clean stream Ok: Gemini finishReason" =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  let st = Streaming.create_openai_stream_state ~provider:"gemini" ~model:"m" () in
+  (match
+     Streaming.parse_provider_f_sse_chunk
+       {|{"candidates":[{"content":{"parts":[{"text":"hi"}]},"finishReason":"STOP"}]}|}
+   with
+   | Some chunk ->
+     let evts, _ = Streaming.provider_f_chunk_to_events st chunk in
+     accumulate_all acc evts
+   | None -> ());
+  Complete_stream_acc.saw_terminal acc
+;;
+
+let%test "clean stream Ok: Ollama done:true" =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  let st = Streaming.create_openai_stream_state ~provider:"ollama" ~model:"m" () in
+  (match
+     Streaming.parse_ollama_ndjson_chunk
+       {|{"model":"m","done":true,"done_reason":"stop","message":{"role":"assistant","content":""}}|}
+   with
+   | Some chunk ->
+     let evts, _ = Streaming.ollama_chunk_to_events st chunk in
+     accumulate_all acc evts
+   | None -> ());
+  Complete_stream_acc.saw_terminal acc
+;;
+
 let complete_stream_http
       ~sw:_
       ~net
@@ -1658,11 +1798,11 @@ let complete_stream_http
               match stream_read_result with
               | Error _ as err -> err
               | Ok () ->
-                let result =
-                  match Complete_stream_acc.finalize_stream_acc acc with
-                  | Ok _ as ok -> ok
-                  | Error serr -> Error (http_error_of_stream_error serr)
-                in
+                (* The read loop returned normally, which includes a silent EOF
+                   mid-stream. [result_of_finalize] rejects a completion that
+                   never saw a terminal event (truncation) instead of returning
+                   a phantom [Ok]. *)
+                let result = result_of_finalize acc in
                 (* RFC-OAS-019: emit one [Streaming_summary] at stream
                    finalize on the normal path. terminal_state defaults to
                    [Terminal_done]; wire errors during dispatch upgrade it

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -15,6 +15,13 @@ type stream_acc =
   ; cache_read : int ref
   ; stop_reason : Types.stop_reason ref
   ; sse_error : Types.stream_error option ref
+  ; saw_terminal : bool ref
+    (** Set once the provider signals end-of-response: a [MessageStop] or a
+        [MessageDelta] carrying [stop_reason = Some _] (which every backend's
+        terminal maps to — Anthropic message_stop / message_delta, OpenAI-compat
+        & GLM finish_reason, Gemini finishReason, Ollama done). Stays [false]
+        when the socket closes mid-stream with no terminal, which the consumer
+        treats as a truncated (phantom) completion rather than a clean [Ok]. *)
   ; block_texts : (int, Buffer.t) Hashtbl.t
   ; block_types : (int, string) Hashtbl.t
   ; block_tool_ids : (int, string) Hashtbl.t
@@ -30,6 +37,7 @@ let create_stream_acc () =
   ; cache_read = ref 0
   ; stop_reason = ref Types.EndTurn
   ; sse_error = ref None
+  ; saw_terminal = ref false
   ; block_texts = Hashtbl.create 4
   ; block_types = Hashtbl.create 4
   ; block_tool_ids = Hashtbl.create 4
@@ -71,7 +79,13 @@ let accumulate_event (acc : stream_acc) = function
   | Types.ContentBlockStop _ -> ()
   | Types.MessageDelta { stop_reason; usage } ->
     (match stop_reason with
-     | Some sr -> acc.stop_reason := sr
+     | Some sr ->
+       acc.stop_reason := sr;
+       (* A [stop_reason]-bearing message_delta is every backend's normalized
+          end-of-response signal (finish_reason / finishReason / done /
+          Anthropic message_delta). A usage-only final chunk carries
+          [stop_reason = None] and must NOT mark the stream terminal. *)
+       acc.saw_terminal := true
      | None -> ());
     (match usage with
      | Some u ->
@@ -93,8 +107,15 @@ let accumulate_event (acc : stream_acc) = function
     acc.sse_error := Some (Types.Stream_parse_failed { reason; raw })
   | Types.SSEUnknownEventType { event_type; raw } ->
     acc.sse_error := Some (Types.Stream_unknown_event { event_type; raw })
-  | Types.MessageStop | Types.Ping | Types.Connected | Types.Timeout _ -> ()
+  | Types.MessageStop -> acc.saw_terminal := true
+  | Types.Ping | Types.Connected | Types.Timeout _ -> ()
 ;;
+
+(** [true] once the stream observed a provider end-of-response signal
+    ([MessageStop] or a [MessageDelta] with [stop_reason = Some _]). The consumer
+    uses this to distinguish a clean completion from a socket that closed
+    mid-stream (which would otherwise finalize as a phantom [Ok]). *)
+let saw_terminal (acc : stream_acc) = !(acc.saw_terminal)
 
 let finalize_stream_acc (acc : stream_acc) =
   match !(acc.sse_error) with

--- a/lib/llm_provider/complete_stream_acc.mli
+++ b/lib/llm_provider/complete_stream_acc.mli
@@ -19,6 +19,10 @@ type stream_acc =
   ; cache_read : int ref
   ; stop_reason : Types.stop_reason ref
   ; sse_error : Types.stream_error option ref
+  ; saw_terminal : bool ref
+    (** Set once a provider end-of-response signal is seen ([MessageStop] or a
+        [MessageDelta] with [stop_reason = Some _]). [false] at finalize means
+        the stream closed mid-response (truncation / phantom completion). *)
   ; block_texts : (int, Buffer.t) Hashtbl.t
   ; block_types : (int, string) Hashtbl.t
   ; block_tool_ids : (int, string) Hashtbl.t
@@ -31,6 +35,12 @@ val create_stream_acc : unit -> stream_acc
 (** Feed a single SSE event into the accumulator.
     Updates id, model, tokens, content blocks in-place. *)
 val accumulate_event : stream_acc -> Types.sse_event -> unit
+
+(** [true] once the stream observed a provider end-of-response signal
+    ([MessageStop] or a [MessageDelta] with [stop_reason = Some _]). The consumer
+    uses this to reject a socket that closed mid-stream as a truncated
+    completion instead of presenting a phantom [Ok]. *)
+val saw_terminal : stream_acc -> bool
 
 (** Produce the final {!Types.api_response} from the accumulated state.
     Returns [Error stream_error] if an SSE error was recorded during the stream


### PR DESCRIPTION
## 문제 (PR-A의 나머지 절반)

200 OK 후 SSE 스트림이 **중간에 소켓이 끊겨도**(터미널 이벤트 없이 EOF) accumulator가 `stop_reason` 기본값 `EndTurn`인 채 `Ok`로 finalize 했습니다. 정상 완료와 구분 불가 → 호출자가 **잘린(truncated) 응답을 정상 턴으로 소비**(phantom completion). 이것이 worktree 이름 `stuck-watchdog`의 본체입니다.

(provider 에러를 청크로 보내 드롭되던 phantom 벡터는 PR-A(#1956)에서 닫았고, 이 PR은 **clean silent-EOF** 케이스를 다룹니다.)

## 설계 — saw_terminal (provider별 검증된 universal 신호)

`★ 핵심`: 5개 백엔드 전부 정상 완료 시 **`MessageStop` 또는 `MessageDelta{stop_reason=Some _}`**를 emit합니다(각자의 native terminal이 stop_reason으로 정규화):

| Provider | wire terminal | 정규화 |
|---|---|---|
| Anthropic | `message_stop` / `message_delta` | MessageStop / MessageDelta{stop_reason} |
| OpenAI-compat · GLM | `finish_reason` (`[DONE]`은 None으로 드롭됨) | MessageDelta{stop_reason} |
| Gemini | `finishReason` | MessageDelta{stop_reason} |
| Ollama | `done:true` | MessageDelta{stop_reason} |

→ **safe universal saw_terminal = accumulator가 위 둘 중 하나를 봤는가.** OpenAI-compat의 `[DONE]→None` 함정을 우회합니다(신호는 finish_reason이지 [DONE]이 아님). usage-only 최종 청크(`stop_reason=None`)는 terminal로 안 잡힘(정확).

- `complete_stream_acc`: `saw_terminal` 플래그 추가, `MessageStop`/`MessageDelta{stop_reason=Some}`에서 설정. **`finalize_stream_acc`는 불변**(계약·기존 테스트 보존).
- `complete`: `result_of_finalize`가 finalize + saw_terminal을 묶어, terminal 없는 clean `Ok`를 **retryable `NetworkError{kind=End_of_file}`**로 변환 → 호출자가 잘린 응답 소비 대신 재시도. 기록된 SSE 에러는 그대로 우선(더 구체적 원인).

## 검증

- **provider별 clean-stream 회귀 가드 5종**: 각 백엔드의 실제 wire terminal을 **실제 parser + converter**에 통과시켜 `saw_terminal=true` 단언 → 정상 스트림이 절대 false-error 안 됨(이 fix가 피해야 할 실패 모드). 전부 green.
- truncation(terminal 없이 content) → `End_of_file` Error, usage-only → 비-terminal, sse_error 우선 — 전부 green.
- 전체 빌드(lib+bin+test) `EXIT=0`, 변경 3파일 ocamlformat clean.
- `provider_throttle.ml:272`(Eio 50ms 타이밍 테스트) 실패는 **origin/main baseline에서도 동일**(이 PR 무관).

## 범위 / Follow-on

- `lib/streaming.ml` 중복 accumulator(secondary `create_message_stream` surface)는 동일 phantom을 가지나 별개 — 통합과 함께 follow-on.
- masc-side enrich/classify(LP6/LP7)는 별개.

## Refs
PR-A #1956 (typed SSE provider errors), RFC-OAS-019 (스트림 라이프사이클 — 텔레메트리 terminal과 별개 축).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
