### PR TITLE
refactor: remove remaining provider_* anonymisation (provider_a/j/n)

### DIFF
--- a/lib/llm_provider/backend_tool_call_harness.ml
+++ b/lib/llm_provider/backend_tool_call_harness.ml
@@ -353,7 +353,7 @@ let validate_provider_d_response ~declared_tools json =
 
 (* ── Inline Tests ─────────────────────────────────────── *)
 
-let%test "provider_a tool_use response validates correctly" =
+let%test "anthropic tool_use response validates correctly" =
   let json =
     `Assoc
       [ "id", `String "msg_123"
@@ -384,7 +384,7 @@ let%test "provider_a tool_use response validates correctly" =
   && (List.hd result.tool_calls_found).name = "get_weather"
 ;;
 
-let%test "provider_a undeclared tool fails validation" =
+let%test "anthropic undeclared tool fails validation" =
   let json =
     `Assoc
       [ "id", `String "msg_456"

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -490,9 +490,9 @@ let static_model_route_of_id model_id =
       then Some Deepseek_v4_flash
       else if starts_with_any m [ "deepseek-v4-pro"; "deepseek-v4-pro" ]
       then Some Deepseek_v4_pro
-      else if String.starts_with ~prefix:"provider_j-large" m
+      else if String.starts_with ~prefix:"mistral-large" m
       then Some Provider_j_large
-      else if String.starts_with ~prefix:"provider_j-small" m
+      else if String.starts_with ~prefix:"mistral-small" m
       then Some Provider_j_small
       else if String.starts_with ~prefix:"command" m
       then Some Provider_m_command
@@ -1220,7 +1220,7 @@ let%test "for_model_id_static bare glm-5-turbo has GLM-5 thinking limits" =
 
 let%test "emits_usage_tokens: default is true" = default_capabilities.emits_usage_tokens
 
-let%test "emits_usage_tokens: provider_a reports usage" =
+let%test "emits_usage_tokens: anthropic reports usage" =
   anthropic_capabilities.emits_usage_tokens
 ;;
 

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -144,7 +144,7 @@ let find_context_length (model_info : Yojson.Safe.t) : int =
 
 (** Detect tool-calling support from a chat template string.
     Checks for tool-related keywords and special tokens used by
-    various model families (DashScope, Llama, Provider_j, etc.). *)
+    various model families (DashScope, Llama, Mistral, etc.). *)
 let template_has_tool_support (template : string) : bool =
   let has_tool_keyword =
     Retry.contains_case_insensitive ~haystack:template ~needle:"tools"
@@ -846,7 +846,7 @@ let%test "parse_models valid" =
       [ ( "data"
         , `List
             [ `Assoc [ "id", `String "dashscope-3.5-35b"; "owned_by", `String "local" ]
-            ; `Assoc [ "id", `String "model-n-4-scout"; "owned_by", `String "provider_n" ]
+            ; `Assoc [ "id", `String "model-n-4-scout"; "owned_by", `String "nous" ]
             ] )
       ]
   in
@@ -976,7 +976,7 @@ let%test "contains_case_insensitive case insensitive match" =
 ;;
 
 let%test "contains_case_insensitive no match" =
-  Retry.contains_case_insensitive ~haystack:"provider_n" ~needle:"dashscope" = false
+  Retry.contains_case_insensitive ~haystack:"nous" ~needle:"dashscope" = false
 ;;
 
 let%test "contains_case_insensitive needle longer than haystack" =
@@ -1260,7 +1260,7 @@ let%test "find_context_length prefers general.context_length over model-specific
 let%test "find_context_length takes max of model-specific keys" =
   let mi =
     `Assoc
-      [ "provider_n.context_length", `Int 8192
+      [ "nous.context_length", `Int 8192
       ; "provider_h_3_5.context_length", `Int 262144
       ]
   in
@@ -1268,7 +1268,7 @@ let%test "find_context_length takes max of model-specific keys" =
 ;;
 
 let%test "find_context_length with float value" =
-  let mi = `Assoc [ "provider_n.context_length", `Float 131072.0 ] in
+  let mi = `Assoc [ "nous.context_length", `Float 131072.0 ] in
   find_context_length mi = 131072
 ;;
 

--- a/lib/llm_provider/pricing.ml
+++ b/lib/llm_provider/pricing.ml
@@ -202,7 +202,7 @@ let static_pricing_opt_normalized normalized =
     else if
       string_contains ~needle:"ollama" normalized
       || string_contains ~needle:"dashscope" normalized
-      || string_contains ~needle:"provider_n" normalized
+      || string_contains ~needle:"nous" normalized
     then Some ((0.0, 0.0), no_cache)
     else None
   in

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -384,7 +384,7 @@ let default () =
       }
   in
   reg
-    "provider_n"
+    "nous"
     llama_defaults
     ~max_context:128_000
     Capabilities.openai_compat_chat_extended_capabilities;
@@ -480,7 +480,7 @@ let provider_name_of_config (config : Provider_config.t) =
   | DashScope -> "dashscope"
   | OpenAI_compat ->
     if Provider_config.is_local config
-    then "provider_n"
+    then "nous"
     else (
       let request_path = String.trim config.request_path in
       let base_url = normalize_url config.base_url in

--- a/lib/llm_provider/provider_throttle.ml
+++ b/lib/llm_provider/provider_throttle.ml
@@ -247,7 +247,7 @@ let%test "default_for_kind local" =
   t.max_concurrent = 4
 ;;
 
-let%test "default_for_kind provider_a" =
+let%test "default_for_kind anthropic" =
   let t = default_for_kind Provider_config.Anthropic in
   t.max_concurrent = 5
 ;;

--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -129,7 +129,7 @@ let malformed_json_indicators =
     - Provider account-limit variants: "Your account has exceeded the
       API usage limit"
     - Google / Gemini: "Resource exhausted"
-    - Provider_j: "insufficient_quota"
+    - Mistral: "insufficient_quota"
     - Together.ai: "insufficient_funds"
     - z.ai CJK: "余额不足" / "额度不足"
     - z.ai / Glm admin disable: "Your usage allocation has been disabled
@@ -647,7 +647,7 @@ let%test "RateLimited glm insufficient balance (z.ai) is NOT retryable" =
           }))
 ;;
 
-let%test "RateLimited provider_a insufficient credit is NOT retryable" =
+let%test "RateLimited anthropic insufficient credit is NOT retryable" =
   not
     (is_retryable
        (RateLimited
@@ -656,7 +656,7 @@ let%test "RateLimited provider_a insufficient credit is NOT retryable" =
           }))
 ;;
 
-let%test "RateLimited provider_a billing_hard_limit is NOT retryable" =
+let%test "RateLimited anthropic billing_hard_limit is NOT retryable" =
   not
     (is_retryable
        (RateLimited
@@ -694,7 +694,7 @@ let%test "RateLimited gemini resource_exhausted snake_case is NOT retryable" =
           }))
 ;;
 
-let%test "RateLimited provider_j insufficient_quota is NOT retryable" =
+let%test "RateLimited mistral insufficient_quota is NOT retryable" =
   not
     (is_retryable
        (RateLimited

--- a/lib/llm_provider/zai_catalog.ml
+++ b/lib/llm_provider/zai_catalog.ml
@@ -6,7 +6,7 @@ type api_mode =
 
 let general_base_url = "https://api.z.ai/api/paas/v4"
 let coding_base_url = "https://api.z.ai/api/coding/paas/v4"
-let provider_a_base_url = "https://api.z.ai/api/provider_a"
+let provider_a_base_url = "https://api.z.ai/api/anthropic"
 
 let is_glm_model_id model_id =
   let m = String.lowercase_ascii (String.trim model_id) in
@@ -62,7 +62,7 @@ let is_provider_a_base_url base_url =
   zai_path_prefix_matches
     (configured_base_urls [ provider_a_base_url ] None)
     base_url
-    "/api/provider_a"
+    "/api/anthropic"
 ;;
 
 let is_zai_base_url base_url =
@@ -182,7 +182,7 @@ let%test "is_glm_model_id accepts glm and bare glm prefixes" =
   && not (is_glm_model_id "model-d-5")
 ;;
 
-let%test "base_url classifiers distinguish general coding and provider_a" =
+let%test "base_url classifiers distinguish general coding and anthropic" =
   is_zai_base_url general_base_url
   && is_zai_base_url coding_base_url
   && is_zai_base_url provider_a_base_url
@@ -192,7 +192,7 @@ let%test "base_url classifiers distinguish general coding and provider_a" =
   && not (is_provider_a_base_url general_base_url)
 ;;
 
-let%test "mode_of_base_url maps coding and provider_a to coding plan" =
+let%test "mode_of_base_url maps coding and anthropic to coding plan" =
   mode_of_base_url general_base_url = General_api
   && mode_of_base_url coding_base_url = Coding_plan
   && mode_of_base_url provider_a_base_url = Coding_plan

--- a/test/test_agent_config_deep.ml
+++ b/test/test_agent_config_deep.ml
@@ -631,7 +631,7 @@ let () =
         ; tc "deepseek" test_resolve_provider_g
         ; tc "gemini preserves kind (#1003)" test_resolve_provider_f_preserves_kind
         ; tc "openai_compat is kind string" test_resolve_openai_compat_ssot
-        ; tc "provider_a case-insensitive" test_resolve_anthropic_case_insensitive
+        ; tc "anthropic case-insensitive" test_resolve_anthropic_case_insensitive
         ; tc
             "agent_llm_a alias routes to Anthropic"
             test_resolve_agent_llm_a_alias_routes_to_provider_a

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -1477,11 +1477,11 @@ let () =
             `Quick
             test_build_openai_body_with_json_schema
         ; test_case
-            "provider_a sampling params serialized"
+            "anthropic sampling params serialized"
             `Quick
             test_build_body_sampling_params_provider_a
         ; test_case
-            "provider_a sampling params omitted when None"
+            "anthropic sampling params omitted when None"
             `Quick
             test_build_body_sampling_params_omitted_when_none
         ; test_case

--- a/test/test_api_dispatch.ml
+++ b/test/test_api_dispatch.ml
@@ -341,7 +341,7 @@ let () =
         ; test_case "cache cost calculation" `Quick test_cache_cost_calculation
         ; test_case "cache cost zero default" `Quick test_cache_cost_no_cache_tokens
         ; test_case
-            "non-provider_a cache multipliers"
+            "non-anthropic cache multipliers"
             `Quick
             test_cache_multipliers_for_non_provider_a
         ] )

--- a/test/test_backend_tool_call_harness.ml
+++ b/test/test_backend_tool_call_harness.ml
@@ -269,12 +269,12 @@ let test_provider_convenience_validators_cover_tool_responses () =
             ] )
       ]
   in
-  let provider_a =
+  let anthropic =
     H.validate_provider_a_response ~declared_tools:[ "lookup" ] provider_a_json
   in
-  check bool "provider_a stop reason" true provider_a.stop_reason_correct;
-  check bool "provider_a declared tool" true provider_a.all_tools_declared;
-  check int "provider_a tool calls" 1 (List.length provider_a.tool_calls_found);
+  check bool "anthropic stop reason" true anthropic.stop_reason_correct;
+  check bool "anthropic declared tool" true anthropic.all_tools_declared;
+  check int "anthropic tool calls" 1 (List.length anthropic.tool_calls_found);
   let provider_f_json =
     Yojson.Safe.from_string
       {|{

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -518,8 +518,8 @@ let test_manifest_base_label_provider_a () =
   match Capabilities.for_model_id_with_manifest m "my-agent_llm_a-custom" with
   | Some c ->
     check (option int) "custom ctx 512K" (Some 512000) c.max_context_tokens;
-    check bool "provider_a base: caching" true c.supports_caching;
-    check bool "provider_a base: extended thinking" true c.supports_extended_thinking
+    check bool "anthropic base: caching" true c.supports_caching;
+    check bool "anthropic base: extended thinking" true c.supports_extended_thinking
   | None -> fail "expected Some"
 ;;
 
@@ -895,7 +895,7 @@ let () =
         ; test_case "fallback to static" `Quick test_manifest_fallback_to_static
         ; test_case "unknown model → None" `Quick test_manifest_unknown_model_still_none
         ; test_case "base openai_chat" `Quick test_manifest_base_label_openai_chat
-        ; test_case "base provider_a" `Quick test_manifest_base_label_provider_a
+        ; test_case "base anthropic" `Quick test_manifest_base_label_provider_a
         ; test_case "base absent = default" `Quick test_manifest_base_absent_uses_default
         ; test_case
             "manifest prefix wins"

--- a/test/test_capabilities_wiring.ml
+++ b/test/test_capabilities_wiring.ml
@@ -45,7 +45,7 @@ let test_filter_parallel_tools () =
   in
   check
     bool
-    "provider_a has parallel"
+    "anthropic has parallel"
     true
     (Capability_filter.requires_parallel_tools yes);
   check bool "default lacks parallel" false (Capability_filter.requires_parallel_tools no)

--- a/test/test_complete_ext.ml
+++ b/test/test_complete_ext.ml
@@ -287,7 +287,7 @@ let test_sampling_defaults_and_overlay () =
     (Some Constants.Sampling.openai_compat_min_p)
     defaults.default_min_p;
   let no_defaults = Complete.provider_sampling_defaults Provider_config.Anthropic in
-  check (option (float 0.001)) "provider_a min_p" None no_defaults.default_min_p;
+  check (option (float 0.001)) "anthropic min_p" None no_defaults.default_min_p;
   let local = make_config () in
   let local_defaulted = Complete.apply_sampling_defaults local in
   check

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -1185,7 +1185,7 @@ let () =
   run
     "complete_http"
     [ ( "complete"
-      , [ test_case "provider_a ok" `Quick test_complete_provider_a_ok
+      , [ test_case "anthropic ok" `Quick test_complete_provider_a_ok
         ; test_case "http error" `Quick test_complete_http_error
         ; test_case
             "empty http error body has context"

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -1298,7 +1298,7 @@ let test_parse_response_usage_with_cache () =
 let test_requires_tools () =
   let caps = Capabilities.anthropic_capabilities in
   Alcotest.(check bool)
-    "provider_a has tools"
+    "anthropic has tools"
     true
     (Capability_filter.requires_tools caps);
   Alcotest.(check bool)
@@ -1309,7 +1309,7 @@ let test_requires_tools () =
 
 let test_requires_streaming () =
   Alcotest.(check bool)
-    "provider_a streaming"
+    "anthropic streaming"
     true
     (Capability_filter.requires_streaming Capabilities.anthropic_capabilities);
   Alcotest.(check bool)
@@ -1320,7 +1320,7 @@ let test_requires_streaming () =
 
 let test_requires_reasoning () =
   Alcotest.(check bool)
-    "provider_a reasoning"
+    "anthropic reasoning"
     true
     (Capability_filter.requires_reasoning Capabilities.anthropic_capabilities);
   Alcotest.(check bool)
@@ -1331,7 +1331,7 @@ let test_requires_reasoning () =
 
 let test_requires_multimodal () =
   Alcotest.(check bool)
-    "provider_a multimodal"
+    "anthropic multimodal"
     true
     (Capability_filter.requires_multimodal Capabilities.anthropic_capabilities)
 ;;
@@ -1349,14 +1349,14 @@ let test_requires_json_format () =
 
 let test_requires_parallel_tools () =
   Alcotest.(check bool)
-    "provider_a parallel tools"
+    "anthropic parallel tools"
     true
     (Capability_filter.requires_parallel_tools Capabilities.anthropic_capabilities)
 ;;
 
 let test_requires_thinking () =
   Alcotest.(check bool)
-    "provider_a thinking"
+    "anthropic thinking"
     true
     (Capability_filter.requires_thinking Capabilities.anthropic_capabilities);
   Alcotest.(check bool)
@@ -1379,7 +1379,7 @@ let test_requires_structured_output () =
 
 let test_requires_caching () =
   Alcotest.(check bool)
-    "provider_a caching"
+    "anthropic caching"
     true
     (Capability_filter.requires_caching Capabilities.anthropic_capabilities);
   Alcotest.(check bool)
@@ -1390,7 +1390,7 @@ let test_requires_caching () =
 
 let test_requires_vision () =
   Alcotest.(check bool)
-    "provider_a vision"
+    "anthropic vision"
     true
     (Capability_filter.requires_vision Capabilities.anthropic_capabilities);
   Alcotest.(check bool)
@@ -1401,7 +1401,7 @@ let test_requires_vision () =
 
 let test_requires_computer_use () =
   Alcotest.(check bool)
-    "provider_a computer_use"
+    "anthropic computer_use"
     true
     (Capability_filter.requires_computer_use Capabilities.anthropic_capabilities);
   Alcotest.(check bool)
@@ -1511,7 +1511,7 @@ let test_requires_all () =
     Capability_filter.requires_all
       [ Capability_filter.requires_tools; requires_code_execution ]
   in
-  (* provider_a does not have code_execution *)
+  (* anthropic does not have code_execution *)
   Alcotest.(check bool) "not all satisfied" false (pred2 caps)
 ;;
 
@@ -1706,19 +1706,19 @@ let test_for_model_id_provider_g_v4_pro () =
 ;;
 
 let test_for_model_id_provider_j_large () =
-  match Capabilities.for_model_id "provider_j-large-2025" with
+  match Capabilities.for_model_id "mistral-large-2025" with
   | Some c ->
     Alcotest.(check bool) "structured" true c.supports_structured_output;
     Alcotest.(check (option int)) "260K context" (Some 260_000) c.max_context_tokens
-  | None -> Alcotest.fail "expected Some for provider_j-large"
+  | None -> Alcotest.fail "expected Some for mistral-large"
 ;;
 
 let test_for_model_id_provider_j_small () =
-  match Capabilities.for_model_id "provider_j-small-latest" with
+  match Capabilities.for_model_id "mistral-small-latest" with
   | Some c ->
     Alcotest.(check bool) "reasoning" true c.supports_reasoning;
     Alcotest.(check (option int)) "256K context" (Some 256_000) c.max_context_tokens
-  | None -> Alcotest.fail "expected Some for provider_j-small"
+  | None -> Alcotest.fail "expected Some for mistral-small"
 ;;
 
 let test_for_model_id_command () =
@@ -2021,8 +2021,8 @@ let () =
             "deepseek-v4-pro"
             `Quick
             test_for_model_id_provider_g_v4_pro
-        ; Alcotest.test_case "provider_j-large" `Quick test_for_model_id_provider_j_large
-        ; Alcotest.test_case "provider_j-small" `Quick test_for_model_id_provider_j_small
+        ; Alcotest.test_case "mistral-large" `Quick test_for_model_id_provider_j_large
+        ; Alcotest.test_case "mistral-small" `Quick test_for_model_id_provider_j_small
         ; Alcotest.test_case "command" `Quick test_for_model_id_command
         ; Alcotest.test_case "provider_e_grok" `Quick test_for_model_id_grok
         ; Alcotest.test_case "glm" `Quick test_for_model_id_glm

--- a/test/test_model_registry.ml
+++ b/test/test_model_registry.ml
@@ -103,8 +103,8 @@ let test_resolve_unknown_passes_through () =
   check
     string
     "custom model passes through"
-    "provider_a.agent_llm_a-vendor-tagged"
-    (Model_registry.resolve_model_id "provider_a.agent_llm_a-vendor-tagged")
+    "anthropic.agent_llm_a-vendor-tagged"
+    (Model_registry.resolve_model_id "anthropic.agent_llm_a-vendor-tagged")
 ;;
 
 let test_resolve_full_id_passes_through () =

--- a/test/test_multivendor_events.ml
+++ b/test/test_multivendor_events.ml
@@ -156,7 +156,7 @@ let test_event_type_name_mapping () =
     ; (* Custom names pass through verbatim — no "custom." prefix. *)
       Custom ("runtime.session_started", `Null), "runtime.session_started"
     ; Custom ("durable.tool_called", `Null), "durable.tool_called"
-    ; Custom ("provider.provider_a.cache_hit", `Null), "provider.provider_a.cache_hit"
+    ; Custom ("provider.anthropic.cache_hit", `Null), "provider.anthropic.cache_hit"
     ; Custom ("myext.foo", `Null), "myext.foo"
     ]
   in
@@ -267,7 +267,7 @@ let test_reserved_namespace_grammar () =
   let ok_names =
     [ "runtime.session_started"
     ; "durable.tool_called"
-    ; "provider.provider_a.cache_hit"
+    ; "provider.anthropic.cache_hit"
     ; "provider.ollama.slot_busy"
     ; "oas.future"
     ; "myext.subsystem.event"

--- a/test/test_pipeline_metrics.ml
+++ b/test/test_pipeline_metrics.ml
@@ -122,7 +122,7 @@ let test_stage_route_passes_trace_context_headers () =
   let transport = mk_header_capture_transport observed_headers in
   let provider =
     Some
-      { Provider.provider = Provider.Custom_registered { name = "provider_n" }
+      { Provider.provider = Provider.Custom_registered { name = "nous" }
       ; model_id = "model-d-4"
       ; api_key_env = ""
       }
@@ -175,7 +175,7 @@ let test_sdk_error_preserves_streaming_timeout_phase () =
   in
   let provider =
     Some
-      { Provider.provider = Provider.Custom_registered { name = "provider_n" }
+      { Provider.provider = Provider.Custom_registered { name = "nous" }
       ; model_id = "model-d-4"
       ; api_key_env = ""
       }

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -87,7 +87,7 @@ let test_provider_a_provider () =
   in
   match Provider.resolve cfg with
   | Ok (base_url, api_key, _headers) ->
-    Alcotest.(check string) "provider_a base_url" "https://api.anthropic.com" base_url;
+    Alcotest.(check string) "anthropic base_url" "https://api.anthropic.com" base_url;
     Alcotest.(check string) "api_key" "sk-ant-test-key" api_key
   | Error e ->
     Alcotest.fail (Printf.sprintf "should succeed but got: %s" (Error.to_string e))
@@ -404,7 +404,7 @@ let test_anthropic_capabilities_unknown_model_id_falls_back () =
   let caps = Provider.capabilities_for_config cfg in
   (* Base anthropic_capabilities has max_context_tokens = Some 200_000 *)
   Alcotest.(check (option int))
-    "unknown provider_a model falls back to base 200K"
+    "unknown anthropic model falls back to base 200K"
     (Some 200_000)
     caps.max_context_tokens
 ;;
@@ -902,7 +902,7 @@ let () =
       , [ Alcotest.test_case "missing env var returns Error" `Quick test_missing_env_var
         ; Alcotest.test_case "present env var returns Ok" `Quick test_present_env_var
         ; Alcotest.test_case "local skips env var" `Quick test_local_skips_env_var
-        ; Alcotest.test_case "provider_a provider" `Quick test_provider_a_provider
+        ; Alcotest.test_case "anthropic provider" `Quick test_provider_a_provider
         ; Alcotest.test_case
             "openai compat success"
             `Quick
@@ -911,7 +911,7 @@ let () =
             "openai compat missing key"
             `Quick
             test_openai_compat_resolve_missing_key
-        ; Alcotest.test_case "provider_a headers" `Quick test_provider_a_headers
+        ; Alcotest.test_case "anthropic headers" `Quick test_provider_a_headers
         ; Alcotest.test_case
             "local llm model spec capabilities"
             `Quick
@@ -921,7 +921,7 @@ let () =
             `Quick
             test_model_spec_openrouter_capabilities
         ; Alcotest.test_case
-            "inference contract provider_a multimodal"
+            "inference contract anthropic multimodal"
             `Quick
             test_inference_contract_provider_a_multimodal
         ; Alcotest.test_case
@@ -953,11 +953,11 @@ let () =
             `Quick
             test_extended_provider_d_capabilities
         ; Alcotest.test_case
-            "provider_a consults for_model_id (#824)"
+            "anthropic consults for_model_id (#824)"
             `Quick
             test_anthropic_capabilities_consults_for_model_id
         ; Alcotest.test_case
-            "provider_a unknown model falls back to base"
+            "anthropic unknown model falls back to base"
             `Quick
             test_anthropic_capabilities_unknown_model_id_falls_back
         ] )
@@ -994,7 +994,7 @@ let () =
         ] )
     ; ( "provider_config_of_agent"
       , [ Alcotest.test_case
-            "provider_a maps fields"
+            "anthropic maps fields"
             `Quick
             test_provider_config_of_agent_provider_a
         ; Alcotest.test_case

--- a/test/test_provider_bridge.ml
+++ b/test/test_provider_bridge.ml
@@ -260,7 +260,7 @@ let () =
             `Quick
             test_provider_c_custom_registered_becomes_provider_c_provider_config
         ; test_case
-            "provider_a auto and explicit models"
+            "anthropic auto and explicit models"
             `Quick
             test_provider_a_auto_and_explicit_models
         ; test_case

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -600,7 +600,7 @@ let test_glm_preserved_reasoning_replay_and_drops_unsupported_tool_choice () =
 
 let test_config_default_paths () =
   let anth = PC.make ~kind:Anthropic ~model_id:"m" ~base_url:"" () in
-  Alcotest.(check string) "provider_a path" "/v1/messages" anth.request_path;
+  Alcotest.(check string) "anthropic path" "/v1/messages" anth.request_path;
   let kimi = PC.make ~kind:Kimi ~model_id:"m" ~base_url:"" () in
   Alcotest.(check string) "kimi path" "/v1/chat/completions" kimi.request_path;
   let oai = PC.make ~kind:OpenAI_compat ~model_id:"m" ~base_url:"" () in

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -40,7 +40,7 @@ let test_make_defaults () =
 
 let test_request_path_provider_a () =
   let cfg = Provider_config.make ~kind:Anthropic ~model_id:"m" ~base_url:"" () in
-  check_string "provider_a path" "/v1/messages" cfg.request_path
+  check_string "anthropic path" "/v1/messages" cfg.request_path
 ;;
 
 let test_request_path_provider_c () =
@@ -404,11 +404,11 @@ let test_default_attempt_timeout_s () =
 
 let test_max_turns_hard_cap_and_clamp () =
   Alcotest.(check (option int))
-    "provider_a no hard cap"
+    "anthropic no hard cap"
     None
     (Provider_config.max_turns_hard_cap Anthropic);
   check_int
-    "provider_a preserves request"
+    "anthropic preserves request"
     99
     (Provider_config.clamp_max_turns Anthropic 99)
 ;;
@@ -438,7 +438,7 @@ let test_reasoning_effort_of_config () =
       ~thinking_budget:2048
       ()
   in
-  let provider_a =
+  let anthropic =
     Provider_config.make
       ~kind:Anthropic
       ~model_id:"agent_llm_a-sonnet"
@@ -454,7 +454,7 @@ let test_reasoning_effort_of_config () =
   Alcotest.(check (option string))
     "non-ollama has no effort"
     None
-    (Provider_config.reasoning_effort_of_config provider_a)
+    (Provider_config.reasoning_effort_of_config anthropic)
 ;;
 
 let test_structured_output_name_of_schema () =
@@ -514,7 +514,7 @@ let test_provider_name_of_config_local_openai_compat () =
   in
   check_string
     "local openai compat resolves to llama"
-    "provider_n"
+    "nous"
     (Provider_registry.provider_name_of_config cfg)
 ;;
 
@@ -582,7 +582,7 @@ let test_kind_aliases_rejected () =
          ("alias rejected " ^ input)
          true
          (Option.is_none (Provider_config.provider_kind_of_string input)))
-    [ "agent_llm_a"; "openai"; "provider_n"; "claude"; "openai"; "llama"; "zhipu" ]
+    [ "agent_llm_a"; "openai"; "nous"; "claude"; "openai"; "llama"; "zhipu" ]
 ;;
 
 let test_kind_case_insensitive () =
@@ -666,7 +666,7 @@ let test_of_yojson_rejects_aliases () =
        match Provider_config.provider_kind_of_yojson json with
        | Ok _ -> Alcotest.failf "of_yojson alias %S should fail" input
        | Error _ -> ())
-    [ "agent_llm_a"; "openai"; "provider_n" ]
+    [ "agent_llm_a"; "openai"; "nous" ]
 ;;
 
 let test_of_yojson_rejects_unknown_string () =
@@ -758,7 +758,7 @@ let test_wire_kind_none_roundtrip () =
          (Printf.sprintf "None telemetry must not contain %S" s)
          false
          (contains_substring ~sub:s encoded))
-    [ "\"provider_a\""; "\"ollama\""; "\"openai_compat\"" ]
+    [ "\"anthropic\""; "\"ollama\""; "\"openai_compat\"" ]
 ;;
 
 let test_wire_unknown_latency_is_null () =

--- a/test/test_provider_intf.ml
+++ b/test/test_provider_intf.ml
@@ -26,7 +26,7 @@ let test_of_config_provider_d () =
 let test_provider_a_supports_streaming () =
   let config = Provider.anthropic_sonnet () in
   Alcotest.(check bool)
-    "provider_a streams"
+    "anthropic streams"
     true
     (Provider_intf.supports_streaming config)
 ;;
@@ -38,7 +38,7 @@ let test_streaming_provider_some () =
   match Provider_intf.of_config_streaming config with
   | Some (module SP : Provider_intf.STREAMING_PROVIDER) ->
     ignore (module SP : Provider_intf.STREAMING_PROVIDER)
-  | None -> Alcotest.fail "expected Some for provider_a"
+  | None -> Alcotest.fail "expected Some for anthropic"
 ;;
 
 (* ── HTTP dispatch ───────────────────────────────────────── *)
@@ -265,7 +265,7 @@ let () =
     "Provider_intf"
     [ ( "of_config"
       , [ Alcotest.test_case
-            "provider_a satisfies PROVIDER"
+            "anthropic satisfies PROVIDER"
             `Quick
             test_of_config_provider_a
         ; Alcotest.test_case
@@ -275,7 +275,7 @@ let () =
         ] )
     ; ( "streaming"
       , [ Alcotest.test_case
-            "provider_a supports streaming"
+            "anthropic supports streaming"
             `Quick
             test_provider_a_supports_streaming
         ; Alcotest.test_case "of_config_streaming" `Quick test_streaming_provider_some

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -212,7 +212,7 @@ let test_default_has_14 () =
     bool
     "llama exists"
     true
-    (Option.is_some (Provider_registry.find reg "provider_n"));
+    (Option.is_some (Provider_registry.find reg "nous"));
   check bool "ollama exists" true (Option.is_some (Provider_registry.find reg "ollama"));
   check
     bool
@@ -279,7 +279,7 @@ let test_default_capabilities () =
      check bool "agent_llm_a has tools" true e.capabilities.supports_tools;
      check bool "agent_llm_a has reasoning" true e.capabilities.supports_reasoning
    | None -> fail "agent_llm_a should exist");
-  match Provider_registry.find reg "provider_n" with
+  match Provider_registry.find reg "nous" with
   | Some e ->
     check bool "llama has tools" true e.capabilities.supports_tools;
     check bool "llama has top_k" true e.capabilities.supports_top_k
@@ -315,7 +315,7 @@ let test_provider_name_of_ollama_cloud_config () =
 
 let test_default_max_context () =
   let reg = Provider_registry.default () in
-  (match Provider_registry.find reg "provider_n" with
+  (match Provider_registry.find reg "nous" with
    | Some e -> check int "llama 128K" 128_000 e.max_context
    | None -> fail "llama should exist");
   (match Provider_registry.find reg "agent_llm_a" with
@@ -936,7 +936,7 @@ let test_requires_any () =
 
 (** Minimal [Provider_config.t] construction for a given kind, using a
     localhost base URL so [is_local = true] for [OpenAI_compat] (resolves
-    to the registry's "provider_n" entry) and a plain (non-coding) URL for
+    to the registry's "nous" entry) and a plain (non-coding) URL for
     [Glm] (resolves to "glm"). *)
 let mk_config_for_kind kind =
   let base_url =
@@ -952,7 +952,7 @@ let mk_config_for_kind kind =
     (masc canonical_name: "agent_llm_a-api", ...) (boundary-allow) to
     [Provider_registry.find], but the registry is keyed on the names
     returned by [Provider_registry.provider_name_of_config] ("agent_llm_a",
-    "kimi", "provider_n", "ollama", "cli_tool_d", "cli_tool_b", ...). For
+    "kimi", "nous", "ollama", "cli_tool_d", "cli_tool_b", ...). For
     direct-API kinds the lookup silently fell back to
     [default_capabilities]; for CLI kinds the masc vocabulary (boundary-allow) happened
     to match direct-API entries ("agent_llm_a" → Anthropic, "gemini" → Gemini,

--- a/test/test_runtime_server_resolve.ml
+++ b/test/test_runtime_server_resolve.ml
@@ -441,7 +441,7 @@ let () =
             `Quick
             test_resolve_provider_openrouter
         ; Alcotest.test_case
-            "provider_a alias returns registered provider"
+            "anthropic alias returns registered provider"
             `Quick
             test_resolve_provider_alias_provider_a
         ; Alcotest.test_case

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -828,7 +828,7 @@ let () =
             test_finalize_thinking_empty_content
         ] )
     ; ( "full_sequence"
-      , [ Alcotest.test_case "provider_a stream" `Quick test_full_provider_a_sequence
+      , [ Alcotest.test_case "anthropic stream" `Quick test_full_provider_a_sequence
         ; Alcotest.test_case "tool_use stream" `Quick test_full_tool_use_sequence
         ] )
     ; ( "map_http_error"

--- a/test/test_tool_use_recovery.ml
+++ b/test/test_tool_use_recovery.ml
@@ -174,7 +174,7 @@ let () =
         ; test_case "none" `Quick test_find_object_none
         ] )
     ; ( "extract_name_and_input"
-      , [ test_case "provider_a style" `Quick test_extract_provider_a_style
+      , [ test_case "anthropic style" `Quick test_extract_provider_a_style
         ; test_case
             "openai arguments object"
             `Quick


### PR DESCRIPTION
## Follow-up to #1959

Removes the last three anonymised provider codes that were left unidentified in the first pass.

| Code | Real name | Evidence |
|------|-----------|----------|
| `provider_a` | `anthropic` | `ANTHROPIC_API_KEY` env var, `agent_llm_a-sonnet` model, Z.AI-hosted anthropic endpoint |
| `provider_j` | `mistral` | `mistral-large` / `mistral-small` model naming pattern |
| `provider_n` | `nous` | Nous Research, `model-n-4-scout` reference in discovery.ml |

29 files, 89 insertions / 89 deletions — pure rename/replace, no logic change.