### PR TITLE
fix(test): repair test/dune after provider de-anon renames (un-break main test build)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -100,7 +100,7 @@
   test_event_forward
   test_schema_surface_index
   test_fs_result
-  test_provider_f_edge_cases
+  test_gemini_edge_cases
   test_guardrail_llm
   test_guardrail_tripwire
   test_guardrails
@@ -181,7 +181,7 @@
   test_streaming_coverage
   test_streaming_e2e
   test_streaming_keepalive_idle
-  test_streaming_provider_d
+  test_streaming_openai
   test_streaming_summary
   test_structured
   test_structured_coverage
@@ -300,7 +300,7 @@
   test_event_forward
   test_schema_surface_index
   test_fs_result
-  test_provider_f_edge_cases
+  test_gemini_edge_cases
   test_guardrail_llm
   test_guardrail_tripwire
   test_guardrails
@@ -381,7 +381,7 @@
   test_streaming_coverage
   test_streaming_e2e
   test_streaming_keepalive_idle
-  test_streaming_provider_d
+  test_streaming_openai
   test_streaming_summary
   test_structured
   test_structured_coverage


### PR DESCRIPTION
## Problem

Main's test build is broken: `dune build @test` fails with **"Module Test_streaming_provider_d doesn't exist"** (then `Test_provider_f_edge_cases`).

The provider de-anonymization PRs (#1959 / #1962 — restore real vendor names) renamed test files but left stale `test/dune` entries:

| stale dune entry | renamed `.ml` (exists) | vendor |
|---|---|---|
| `test_streaming_provider_d` | `test_streaming_openai` | provider_d = OpenAI |
| `test_provider_f_edge_cases` | `test_gemini_edge_cases` | provider_f = Gemini |

Each appears in two stanzas. This blocks CI test builds on main **and** the verification builds of every open PR (e.g. #1960/#1961 — which is why they looked "stuck").

## Fix
Update the 4 stale references to the existing renamed module names.

## Verification
- Systematic check: 0 remaining stale entries (every `test/dune` module now has a matching `.ml`).
- `dune build test/` clean (no "Module doesn't exist").
- `test_streaming_openai` 24/24; `test_gemini_edge_cases` all 5 edge cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
