### PR TITLE
fix(discovery): correct de-anon leftover in contains_case_insensitive tests

### DIFF
--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -971,8 +971,7 @@ let%test "parse_slots neither is_processing nor state defaults to idle" =
 (* --- contains_case_insensitive (via Retry SSOT) --- *)
 
 let%test "contains_case_insensitive case insensitive match" =
-  Retry.contains_case_insensitive ~haystack:"Provider_H_3.5-35B" ~needle:"dashscope"
-  = true
+  Retry.contains_case_insensitive ~haystack:"DashScope_3.5-35B" ~needle:"dashscope" = true
 ;;
 
 let%test "contains_case_insensitive no match" =
@@ -988,7 +987,7 @@ let%test "contains_case_insensitive empty needle" =
 ;;
 
 let%test "contains_case_insensitive exact match" =
-  Retry.contains_case_insensitive ~haystack:"PROVIDER_H" ~needle:"dashscope" = true
+  Retry.contains_case_insensitive ~haystack:"DASHSCOPE" ~needle:"dashscope" = true
 ;;
 
 (* --- infer_capabilities --- *)


### PR DESCRIPTION
## Problem

Two inline `let%test`s in `discovery.ml` fail (`dune runtest lib/llm_provider`):
- `contains_case_insensitive case insensitive match`
- `contains_case_insensitive exact match`

The provider de-anonymization renamed the **needle** to `"dashscope"` (matching production `discovery.ml:308`) but left the test **haystacks** anonymized (`"Provider_H_3.5-35B"` / `"PROVIDER_H"`), which do not contain `dashscope` → the asserts (`= true`) fail. This is manifest-independent (pure string helper) — a genuine test-data bug from the de-anon, separate from the `test/dune` build fix (#1964).

## Fix
Use real DashScope ids as haystacks:
- `Provider_H_3.5-35B` → `DashScope_3.5-35B` (preserves the case-insensitive intent)
- `PROVIDER_H` → `DASHSCOPE` (preserves the exact-match intent)

## Verification
`dune runtest lib/llm_provider` (with `OAS_CAPABILITY_MANIFEST` unset, i.e. CI conditions): both tests pass; no new failures (only the pre-existing `provider_throttle:272` timing flake remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
