### PR TITLE
test(streaming): per-provider clean-stream regression guards for phantom-completion

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -1268,6 +1268,90 @@ let%test "openai_compat_error_event returns None for a normal content chunk" =
        {|{"id":"c","choices":[{"delta":{"content":"hi"}}]}|})
 ;;
 
+(* Per-provider clean-stream regression guards for the phantom-completion check
+   (finalize returns Error when no terminal [stop_reason] was seen -- see
+   [Complete_stream_acc.finalize_stream_acc]). Each backend's REAL wire terminal,
+   run through its actual parser + converter, must set the terminal flag so a
+   clean stream finalizes [Ok] -- never a false truncation. The OpenAI-compat
+   case is the trap: its "[DONE]" sentinel parses to [None], so the signal is the
+   finish_reason MessageDelta, not [DONE]. *)
+let accumulate_events acc events =
+  List.iter (Complete_stream_acc.accumulate_event acc) events
+;;
+
+let%test
+    "clean stream finalizes Ok: OpenAI-compat finish_reason (covers GLM/Kimi/DashScope)"
+  =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  let st = Streaming.create_openai_stream_state ~provider:"openai" ~model:"m" () in
+  (match
+     Streaming.parse_openai_sse_chunk
+       {|{"choices":[{"delta":{},"finish_reason":"stop"}]}|}
+   with
+   | Some chunk -> accumulate_events acc (fst (Streaming.openai_chunk_to_events st chunk))
+   | None -> ());
+  match Complete_stream_acc.finalize_stream_acc acc with
+  | Ok _ -> true
+  | Error _ -> false
+;;
+
+let%test "clean stream finalizes Ok: Anthropic message_delta stop_reason" =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  (match
+     Streaming.parse_sse_event
+       (Some "message_delta")
+       {|{"delta":{"stop_reason":"end_turn"}}|}
+   with
+   | Some evt -> Complete_stream_acc.accumulate_event acc evt
+   | None -> ());
+  match Complete_stream_acc.finalize_stream_acc acc with
+  | Ok _ -> true
+  | Error _ -> false
+;;
+
+let%test "clean stream finalizes Ok: Gemini finishReason" =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  let st = Streaming.create_openai_stream_state ~provider:"gemini" ~model:"m" () in
+  (match
+     Streaming.parse_provider_f_sse_chunk
+       {|{"candidates":[{"content":{"parts":[{"text":"hi"}]},"finishReason":"STOP"}]}|}
+   with
+   | Some chunk ->
+     accumulate_events acc (fst (Streaming.provider_f_chunk_to_events st chunk))
+   | None -> ());
+  match Complete_stream_acc.finalize_stream_acc acc with
+  | Ok _ -> true
+  | Error _ -> false
+;;
+
+let%test "clean stream finalizes Ok: Ollama done:true" =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  let st = Streaming.create_openai_stream_state ~provider:"ollama" ~model:"m" () in
+  (match
+     Streaming.parse_ollama_ndjson_chunk
+       {|{"model":"m","done":true,"done_reason":"stop","message":{"role":"assistant","content":""}}|}
+   with
+   | Some chunk -> accumulate_events acc (fst (Streaming.ollama_chunk_to_events st chunk))
+   | None -> ());
+  match Complete_stream_acc.finalize_stream_acc acc with
+  | Ok _ -> true
+  | Error _ -> false
+;;
+
+let%test "truncated stream (no terminal stop_reason) finalizes Error, not phantom Ok" =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  Complete_stream_acc.accumulate_event
+    acc
+    (Types.ContentBlockStart
+       { index = 0; content_type = "text"; tool_id = None; tool_name = None });
+  Complete_stream_acc.accumulate_event
+    acc
+    (Types.ContentBlockDelta { index = 0; delta = Types.TextDelta "partial" });
+  match Complete_stream_acc.finalize_stream_acc acc with
+  | Error _ -> true
+  | Ok _ -> false
+;;
+
 let complete_stream_http
       ~sw:_
       ~net


### PR DESCRIPTION
## 무엇

스트림 **phantom-completion 검사**(main `06f6f031`, `stop_reason_received` + `finalize_stream_acc`)에 대한 **provider별 clean-stream 회귀 가드** 추가. test-only.

## 왜

`06f6f031`의 메커니즘에는 "각 백엔드의 **실제 wire terminal**이 여전히 `Ok`로 finalize되는가"를 보장하는 provider별 가드가 없었습니다. 어느 provider의 parser/converter가 미래에 바뀌어 terminal `stop_reason`을 더 이상 만들지 않게 되면, 그 provider의 **모든 정상 스트림이 false-truncation**으로 finalize Error가 됩니다 — 원래 버그보다 나쁩니다. 이 가드가 그 회귀를 컴파일/CI에서 잡습니다.

## 추가된 가드

각 백엔드의 실제 terminal을 **실제 parser + converter**에 통과시켜 `finalize_stream_acc`가 `Ok`를 반환함을 단언:
- **OpenAI-compat** `finish_reason` (공유 parser로 GLM/Kimi/DashScope 커버; `[DONE]`은 `None`으로 파싱되므로 신호는 finish_reason MessageDelta)
- **Anthropic** `message_delta` stop_reason
- **Gemini** `finishReason`
- **Ollama** `done:true`
- **truncation 가드**: terminal stop_reason 없는 content → `finalize_stream_acc` **Error**(phantom Ok 아님)

## 맥락

원래 별도 PR(#1961, `saw_terminal` 메커니즘)으로 truncation을 고치려 했으나, main이 `06f6f031`로 동일 문제를 병렬 해결(+ lib/streaming.ml까지 커버)해 **#1961을 supersede·close**했습니다. 그 PR의 유일한 고유 가치(provider별 회귀 가드)를 main의 `stop_reason_received` 메커니즘에 맞게 **salvage**한 것이 이 PR입니다.

## 검증

- `lib/` 빌드 EXIT=0, 추가한 6개 inline %test 전부 통과, 추가 lib(complete.ml) **+84 단일 hunk**(무관 코드 미변경).
- ⚠️ 현재 main(`ac2fe982`)에 **pre-existing 테스트 실패 다수**(de-anon 추정 collateral: `backend_openai` glm tool_choice, `capabilities` glm-5v vision, `discovery` contains_case_insensitive + 알려진 `provider_throttle` Eio 타이밍). 모두 **내가 안 건드린 다른 모듈**이라 이 test-only 추가와 무관 — main-health 별도 이슈.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
