### PR TITLE
feat(capability_manifest): carry thinking_control_format (RFC-OAS-023)

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -983,6 +983,22 @@ let with_tool_support caps ~supports_tools = { caps with supports_tools }
     [capabilities_for_provider_label]; defaults to [default_capabilities]
     when absent or unrecognised.  Each [Some] field in [entry] overrides
     the corresponding field of the base; [None] fields are left unchanged. *)
+
+(* Parse the manifest's [thinking_control_format] string into the typed
+   variant. Mirrors {!Provider_catalog.parse_thinking_control_format}; kept
+   local to avoid a Provider_catalog -> Capabilities dependency cycle. An
+   unrecognised value leaves the base format unchanged (handled by the caller). *)
+let thinking_control_format_of_manifest_string raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "none" -> Some No_thinking_control
+  | "thinking_object" -> Some Thinking_object
+  | "thinking_object_only" -> Some Thinking_object_only
+  | "chat_template_kwargs" -> Some Chat_template_kwargs
+  | "reasoning_effort" -> Some Reasoning_effort
+  | "enable_thinking" -> Some Enable_thinking
+  | _ -> None
+;;
+
 let apply_manifest_entry (entry : Capability_manifest.entry) : capabilities =
   let base =
     match entry.base_label with
@@ -1039,6 +1055,13 @@ let apply_manifest_entry (entry : Capability_manifest.entry) : capabilities =
       override_bool base.supports_computer_use entry.supports_computer_use
   ; supports_code_execution =
       override_bool base.supports_code_execution entry.supports_code_execution
+  ; thinking_control_format =
+      (match entry.thinking_control_format with
+       | Some s ->
+         (match thinking_control_format_of_manifest_string s with
+          | Some t -> t
+          | None -> base.thinking_control_format)
+       | None -> base.thinking_control_format)
   }
 ;;
 
@@ -1049,6 +1072,27 @@ let for_model_id_with_manifest manifest model_id =
   match Capability_manifest.lookup manifest model_id with
   | Some entry -> Some (apply_manifest_entry entry)
   | None -> for_model_id_static model_id
+;;
+
+let%test "apply_manifest_entry applies thinking_control_format (RFC-OAS-023)" =
+  match
+    Capability_manifest.of_json
+      (Yojson.Safe.from_string
+         {|{"schema_version":1,"models":[{"id_prefix":"m","thinking_control_format":"chat_template_kwargs"}]}|})
+  with
+  | Ok [ entry ] ->
+    (apply_manifest_entry entry).thinking_control_format = Chat_template_kwargs
+  | Ok _ | Error _ -> false
+;;
+
+let%test "apply_manifest_entry without thinking_control_format keeps base format" =
+  match
+    Capability_manifest.of_json
+      (Yojson.Safe.from_string {|{"schema_version":1,"models":[{"id_prefix":"m"}]}|})
+  with
+  | Ok [ entry ] ->
+    (apply_manifest_entry entry).thinking_control_format = No_thinking_control
+  | Ok _ | Error _ -> false
 ;;
 
 (** Look up capabilities for [model_id].

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -28,6 +28,12 @@ type entry =
   ; supports_seed : bool option
   ; supports_computer_use : bool option
   ; supports_code_execution : bool option
+  ; thinking_control_format : string option
+    (** Canonical thinking-wire format the model uses (none / thinking_object /
+        thinking_object_only / chat_template_kwargs / reasoning_effort /
+        enable_thinking). Parsed + applied in
+        {!Capabilities.apply_manifest_entry}. Without this field a manifest
+        entry silently dropped the model's thinking knob (RFC-OAS-023). *)
   }
 
 (** A parsed capability manifest. *)
@@ -124,6 +130,7 @@ let parse_entry json =
       ; supports_seed = member_bool "supports_seed" json
       ; supports_computer_use = member_bool "supports_computer_use" json
       ; supports_code_execution = member_bool "supports_code_execution" json
+      ; thinking_control_format = member_string_opt "thinking_control_format" json
       }
 ;;
 

--- a/lib/llm_provider/capability_manifest.mli
+++ b/lib/llm_provider/capability_manifest.mli
@@ -70,6 +70,10 @@ type entry =
   ; supports_seed : bool option
   ; supports_computer_use : bool option
   ; supports_code_execution : bool option
+  ; thinking_control_format : string option
+    (** Canonical thinking-wire format (none / thinking_object /
+        thinking_object_only / chat_template_kwargs / reasoning_effort /
+        enable_thinking); applied in {!Capabilities.apply_manifest_entry}. *)
   }
 
 (** A parsed capability manifest: an ordered list of model entries.


### PR DESCRIPTION
## Why

The capability-manifest schema (`capability_manifest.entry`) had **no `thinking_control_format` field**, so any manifest entry silently dropped the model's thinking knob: `apply_manifest_entry` never set it → result defaulted to `No_thinking_control`.

This is the root of the live-fleet issue we just hit: the operator manifest (`~/me/.masc/config/capability-manifest.json`) overrode the correct code capabilities with "no thinking", **negating the per-model DeepSeek/Qwen/GLM thinking config** — so the manifest had to be **emptied** to make per-model tuning take effect. This PR lets the manifest carry thinking, so it no longer has to stay empty.

## What
- `capability_manifest.{ml,mli}`: add `thinking_control_format : string option` to `entry` + parse from JSON.
- `capabilities.ml`: parse the string (`none` / `thinking_object` / `thinking_object_only` / `chat_template_kwargs` / `reasoning_effort` / `enable_thinking`; mirrors `Provider_catalog.parse_thinking_control_format`, kept local to avoid a `Provider_catalog → Capabilities` cycle) and apply it in `apply_manifest_entry`. Absent/unrecognised → base format unchanged.
- Inline tests: `chat_template_kwargs` → `Chat_template_kwargs`; absent → base (`No_thinking_control`).

## Verification
- `dune build` clean.
- `dune runtest lib/llm_provider` passes (only the pre-existing `provider_throttle:272` timing flake).

## Follow-up (not in this PR)
- The live manifest is currently empty (code is SSOT). With this schema fix, it **can** be repopulated correctly for operator overrides — optional, only if per-model overrides are wanted.
- `capabilities.ml` has pre-existing ocamlformat drift at lines 540/960 (de-anon leftovers, incl. a duplicated `glm-4.6/4.7/5` prefix list) unrelated to this change — left untouched; worth a separate `dune fmt` cleanup PR for the de-anon'd files (also affects `complete.ml`, `discovery.ml:1263`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
