### PR TITLE
fix(pipeline): purge ToolRetryExhausted — a tool failure is never turn-fatal

### DIFF
--- a/lib/base/error.ml
+++ b/lib/base/error.ml
@@ -47,11 +47,6 @@ type agent_error =
       }
   | UnrecognizedStopReason of { reason : string }
   | IdleDetected of { consecutive_idle_turns : int }
-  | ToolRetryExhausted of
-      { attempts : int
-      ; limit : int
-      ; detail : string
-      }
   | AgentExecutionTimeout of
       { elapsed_sec : float
       ; timeout_sec : float
@@ -176,12 +171,6 @@ let agent_error_to_string = function
     Printf.sprintf
       "Idle detected: %d consecutive identical tool call turns"
       r.consecutive_idle_turns
-  | ToolRetryExhausted r ->
-    Printf.sprintf
-      "Tool retry budget exhausted after %d/%d retries: %s"
-      r.attempts
-      r.limit
-      r.detail
   | AgentExecutionTimeout r ->
     Printf.sprintf
       "Agent execution timed out after %.1fs (max_execution_time_s=%.1fs, turns=%d/%d)"

--- a/lib/base/error.mli
+++ b/lib/base/error.mli
@@ -48,11 +48,6 @@ type agent_error =
       and new execution paths must not emit this as a gate. *)
   | UnrecognizedStopReason of { reason : string }
   | IdleDetected of { consecutive_idle_turns : int }
-  | ToolRetryExhausted of
-      { attempts : int
-      ; limit : int
-      ; detail : string
-      }
   | AgentExecutionTimeout of
       { elapsed_sec : float
       ; timeout_sec : float

--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -27,7 +27,6 @@ type agent_error =
   | `Cost_budget_exceeded
   | `Cost_budget_unenforceable of string * float
   | `Idle_detected of int
-  | `Tool_retry_exhausted of int * int * string
   | `Agent_execution_timeout of float * float * int * int
   | `Agent_execution_idle_timeout of float * float * int * int
   | `Guardrail_violation of string * string
@@ -128,8 +127,6 @@ let of_sdk_error (err : Error.sdk_error) : sdk_error_poly =
   | Error.Agent (CostBudgetUnenforceable r) ->
     `Cost_budget_unenforceable (r.model_id, r.limit_usd)
   | Error.Agent (IdleDetected r) -> `Idle_detected r.consecutive_idle_turns
-  | Error.Agent (ToolRetryExhausted r) ->
-    `Tool_retry_exhausted (r.attempts, r.limit, r.detail)
   | Error.Agent (AgentExecutionTimeout r) ->
     `Agent_execution_timeout (r.elapsed_sec, r.timeout_sec, r.turn_count, r.max_turns)
   | Error.Agent (AgentExecutionIdleTimeout r) ->
@@ -185,8 +182,6 @@ let to_sdk_error (err : sdk_error_poly) : Error.sdk_error =
   | `Cost_budget_unenforceable (model_id, limit_usd) ->
     Error.Agent (CostBudgetUnenforceable { model_id; limit_usd })
   | `Idle_detected n -> Error.Agent (IdleDetected { consecutive_idle_turns = n })
-  | `Tool_retry_exhausted (attempts, limit, detail) ->
-    Error.Agent (ToolRetryExhausted { attempts; limit; detail })
   | `Agent_execution_timeout (elapsed_sec, timeout_sec, turn_count, max_turns) ->
     Error.Agent
       (AgentExecutionTimeout { elapsed_sec; timeout_sec; turn_count; max_turns })
@@ -277,7 +272,6 @@ let is_retryable (err : [< sdk_error_poly ]) : bool =
   | `Cost_budget_exceeded
   | `Cost_budget_unenforceable _
   | `Idle_detected _
-  | `Tool_retry_exhausted _
   | `Agent_execution_timeout _
   | `Agent_execution_idle_timeout _
   | `Guardrail_violation _

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -51,7 +51,6 @@ type agent_error =
     (** model_id, threshold_usd — legacy advisory cost classification.
         New execution paths must not emit this as a gate. *)
   | `Idle_detected of int (** consecutive_idle_turns *)
-  | `Tool_retry_exhausted of int * int * string (** attempts, limit, detail *)
   | `Agent_execution_timeout of float * float * int * int
     (** elapsed_sec, timeout_sec, turn_count, max_turns *)
   | `Agent_execution_idle_timeout of float * float * int * int

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -389,10 +389,16 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
            | Tool_retry_policy.Retry { retry_count; summary } ->
              Tool_retry_policy.set_context_retry_count agent.context retry_count;
              Ok (retry_feedback_blocks ~policy ~retry_count ~summary ~tool_results)
-           | Tool_retry_policy.Exhausted { attempts; limit; summary } ->
+           | Tool_retry_policy.Exhausted { attempts = _; limit = _; summary = _ } ->
+             (* A tool failure is never turn-fatal. When the retry budget is
+                exhausted, return the tool results (which carry the error) to
+                the model so the turn loop self-corrects on the next turn — the
+                standard agent-loop contract. Previously this raised
+                [Error (ToolRetryExhausted ...)], turning a tool failure into a
+                turn-fatal error that accumulated to keeper crash via N
+                consecutive turn failures. *)
              Tool_retry_policy.clear_context_retry_count agent.context;
-             Error
-               (Error.Agent (ToolRetryExhausted { attempts; limit; detail = summary })))
+             Ok tool_results)
       in
       (* Anti-repetition hint: append warning to tool feedback when idle detected
        but not already handled by Nudge or Skip. Nudge injects its own message

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -488,15 +488,11 @@ let test_agent_run_validation_retry_exhausted () =
         url
     in
     match Agent.run ~sw agent "what time is it?" with
-    | Ok _ -> fail "expected retry exhaustion error"
-    | Error (Error.Agent (Error.ToolRetryExhausted { attempts; limit; detail })) ->
-      check int "attempts" 1 attempts;
-      check int "limit" 1 limit;
-      check
-        bool
-        "detail mentions tool"
-        true
-        (contains_substring ~needle:"get_time" detail);
+    | Ok _ ->
+      (* Retry budget exhaustion is no longer turn-fatal. The repeated tool
+         failure is returned to the model as a tool_result, the turn loop
+         proceeds to the next response (text), and the run completes normally
+         instead of raising ToolRetryExhausted (purged). *)
       Eio.Switch.fail sw Exit
     | Error e -> fail (Error.to_string e)
   with


### PR DESCRIPTION
## 문제

tool 실패(예: 모델이 단일 required-arg tool에 빈 인자 `{}` 전송)가 `Tool_retry_policy`에서 `Transient`로 분류되어 retry되고, budget 소진 시 `Exhausted` 분기가 `Error (ToolRetryExhausted)`로 **tool 실패를 turn-fatal error로 승격**합니다. 소비자는 이를 consecutive turn failure로 누적합니다 (MASC keeper는 10회 후 crash).

이는 표준 agent-loop 계약 위반입니다 — **tool 실패는 모델이 봐야 할 결과(tool_result)이지 fatal error가 아닙니다.** turn loop(`max_turns`)이 이미 반복 tool 호출을 제한하므로, retry 소진을 fatal error로 만드는 것은 중복이고 해로웠습니다.

## 변경

- `pipeline.ml`: `Exhausted` 시 `Ok tool_results` 반환 → tool 실패가 모델에 전달되고 turn loop이 다음 turn에서 self-correct.
- `ToolRetryExhausted` error variant(`error.ml`/`.mli`)와 `` `Tool_retry_exhausted `` polyvariant 양방향 매핑·분류(`error_domain.ml`/`.mli`) 제거 — 남은 생산자 없음.
- `test_agent_run_validation_retry_exhausted`: retry 소진이 더 이상 fatal이 아니므로, 정상 완료(모델이 다음 응답에 도달)를 단언하도록 재작성.

## 검증

- [x] `dune build @check` 통과 (variant 제거 후 컴파일러가 모든 참조 사이트 정리 강제 — 누락 없음)
- [x] `test_agent_pipeline` 13 tests 통과 (재작성된 retry-exhausted 케이스 포함)

## 배경

`Tool_retry_policy`의 `classify`는 `Validation_error`를 `Transient`로 매핑하지만, `tool_retry_policy.mli` 계약은 "`invalid_arguments`는 `Deterministic`(retry futile)"이라 명시합니다. 이 PR은 그보다 근본적으로 **retry 소진이 turn을 죽이는 경로 자체**를 제거합니다 — classify가 어떻든 tool 실패는 turn-fatal이 아니게 됩니다.

관련: masc keeper crash 진단 (masc PR #20621은 masc-side에서 retry를 끈 회피였고, 본 PR이 OAS-side 근본 fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
