### PR TITLE
fix: implement complete_stream_with_retry to handle deepseek 500 errors

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -1114,6 +1114,14 @@ let complete_with_retry
          if attempt >= rc.max_retries
          then Error err
          else (
+           Diag.warn
+             "complete"
+             "retrying provider %s model %s (attempt %d/%d) after error: %s"
+             provider
+             model_id
+             (attempt + 1)
+             rc.max_retries
+             (Retry.error_message api_err);
            m.on_retry ~provider ~model_id ~attempt:(attempt + 1);
            let delay =
              match api_err with
@@ -1987,6 +1995,14 @@ let complete_stream_with_retry
          if attempt >= rc.max_retries
          then Error err
          else (
+           Diag.warn
+             "complete"
+             "retrying stream provider %s model %s (attempt %d/%d) after error: %s"
+             provider
+             model_id
+             (attempt + 1)
+             rc.max_retries
+             (Retry.error_message api_err);
            m.on_retry ~provider ~model_id ~attempt:(attempt + 1);
            let delay =
              match api_err with

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -1938,6 +1938,76 @@ let complete_stream
       result
 ;;
 
+let complete_stream_with_retry
+      ~sw
+      ~net
+      ?transport
+      ~clock
+      ~(config : Provider_config.t)
+      ~(messages : Types.message list)
+      ?(tools = [])
+      ?runtime_mcp_policy
+      ?trace_context
+      ?(retry_config = default_retry_config)
+      ~on_event
+      ?metrics
+      ?priority
+      ?stream_idle_timeout_s
+      ?on_telemetry
+      ()
+  =
+  let m = Option.value metrics ~default:(Metrics.get_global ()) in
+  let rc = shared_retry_config_of_complete retry_config in
+  let provider = Provider_registry.provider_name_of_config config in
+  let model_id = config.model_id in
+  let f () =
+    complete_stream
+      ~sw
+      ~net
+      ~clock
+      ?transport
+      ~config
+      ~messages
+      ~tools
+      ?runtime_mcp_policy
+      ?trace_context
+      ~on_event
+      ~metrics:m
+      ?priority
+      ?stream_idle_timeout_s
+      ?on_telemetry
+      ()
+  in
+  let rec loop attempt =
+    match f () with
+    | Ok _ as success -> success
+    | Error err ->
+      (match classify_retry_error err with
+       | Some api_err when Retry.is_retryable api_err ->
+         if attempt >= rc.max_retries
+         then Error err
+         else (
+           m.on_retry ~provider ~model_id ~attempt:(attempt + 1);
+           let delay =
+             match api_err with
+             | Retry.RateLimited { retry_after = Some ra; _ } -> ra
+             | Retry.RateLimited { retry_after = None; _ }
+             | Retry.Overloaded _
+             | Retry.ServerError _
+             | Retry.AuthError _
+             | Retry.InvalidRequest _
+             | Retry.NotFound _
+             | Retry.ContextOverflow _
+             | Retry.NetworkError _
+             | Retry.Timeout _ -> Retry.calculate_delay rc attempt
+           in
+           Eio.Time.sleep clock delay;
+           loop (attempt + 1))
+       | Some _ | None -> Error err)
+  in
+  loop 0
+;;
+
 (* ── HTTP Transport constructor ─────────────────────── *)
 
 let make_http_transport ?clock ?stream_idle_timeout_s ?body_timeout_s ~sw ~net ()

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -177,3 +177,24 @@ val complete_stream
   -> ?on_telemetry:(Telemetry_event.t -> unit)
   -> unit
   -> (Types.api_response, Http_client.http_error) result
+
+(** Streaming completion with exponential backoff retry.
+    Passes [transport] and [metrics] through to each attempt. *)
+val complete_stream_with_retry
+  :  sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> ?transport:Llm_transport.t
+  -> clock:_ Eio.Time.clock
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> ?runtime_mcp_policy:Llm_transport.runtime_mcp_policy
+  -> ?trace_context:(string * string) list
+  -> ?retry_config:retry_config
+  -> on_event:(Types.sse_event -> unit)
+  -> ?metrics:Metrics.t
+  -> ?priority:Request_priority.t
+  -> ?stream_idle_timeout_s:float
+  -> ?on_telemetry:(Telemetry_event.t -> unit)
+  -> unit
+  -> (Types.api_response, Http_client.http_error) result

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -86,23 +86,41 @@ let dispatch_stream
       ~base_url:agent.options.base_url
       agent.options.provider
   in
-  match
-    Llm_provider.Complete.complete_stream
-      ~sw
-      ~net:agent.net
-      ?clock
-      ?stream_idle_timeout_s:agent.options.stream_idle_timeout_s
-      ?transport:agent.options.transport
-      ~config:pc
-      ~messages:prep.Agent_turn.effective_messages
-      ~tools
-      ?runtime_mcp_policy:prep.Agent_turn.runtime_mcp_policy
-      ~trace_context
-      ~on_event
-      ?on_telemetry
-      ?priority:agent.options.priority
-      ()
-  with
+  let call () =
+    match clock with
+    | Some clock ->
+      Llm_provider.Complete.complete_stream_with_retry
+        ~sw
+        ~net:agent.net
+        ?transport:agent.options.transport
+        ~clock
+        ~config:pc
+        ~messages:prep.Agent_turn.effective_messages
+        ~tools
+        ?runtime_mcp_policy:prep.Agent_turn.runtime_mcp_policy
+        ~trace_context
+        ~on_event
+        ?on_telemetry
+        ?priority:agent.options.priority
+        ?stream_idle_timeout_s:agent.options.stream_idle_timeout_s
+        ()
+    | None ->
+      Llm_provider.Complete.complete_stream
+        ~sw
+        ~net:agent.net
+        ?transport:agent.options.transport
+        ~config:pc
+        ~messages:prep.Agent_turn.effective_messages
+        ~tools
+        ?runtime_mcp_policy:prep.Agent_turn.runtime_mcp_policy
+        ~trace_context
+        ~on_event
+        ?on_telemetry
+        ?priority:agent.options.priority
+        ?stream_idle_timeout_s:agent.options.stream_idle_timeout_s
+        ()
+  in
+  match call () with
   | Ok resp -> Ok resp
   | Error err -> Error (sdk_error_of_http_error err)
 ;;

--- a/test/complete_retry/test_complete_retry.ml
+++ b/test/complete_retry/test_complete_retry.ml
@@ -23,7 +23,12 @@ let scripted_transport scripted_responses request_count : Llm_transport.t =
         | [] -> failwith "scripted transport exhausted")
   ; complete_stream =
       (fun ?on_telemetry:_ ~on_event:_ _req ->
-        failwith "stream transport not used in this test")
+        incr request_count;
+        match !responses with
+        | next :: rest ->
+          responses := rest;
+          next
+        | [] -> failwith "scripted transport exhausted")
   }
 ;;
 
@@ -152,6 +157,89 @@ let test_complete_with_retry_retries_malformed_json_400 () =
   | Exit -> ()
 ;;
 
+let test_complete_stream_with_retry_stops_on_hard_quota_429 () =
+  Eio_main.run
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let request_count = ref 0 in
+    let transport =
+      scripted_transport
+        [ Error (Http_client.HttpError { code = 429; body = hard_quota_body }) ]
+        request_count
+    in
+    let config = make_config "http://unused.test" in
+    let on_event _ = () in
+    match
+      Complete.complete_stream_with_retry
+        ~sw
+        ~net:env#net
+        ~transport
+        ~clock
+        ~config
+        ~messages
+        ~retry_config:fast_retry_config
+        ~on_event
+        ()
+    with
+    | Ok _ -> fail "expected hard quota failure"
+    | Error (Http_client.HttpError { code; _ }) ->
+      check int "status" 429 code;
+      check int "single request" 1 !request_count;
+      Eio.Switch.fail sw Exit
+    | Error _ -> fail "expected HttpError"
+  with
+  | Exit -> ()
+;;
+
+let test_complete_stream_with_retry_retries_malformed_json_400 () =
+  Eio_main.run
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let request_count = ref 0 in
+    let transport =
+      scripted_transport
+        [ Error (Http_client.HttpError { code = 400; body = malformed_json_body })
+        ; Ok (mock_response "recovered after retry")
+        ]
+        request_count
+    in
+    let config = make_config "http://unused.test" in
+    let on_event _ = () in
+    match
+      Complete.complete_stream_with_retry
+        ~sw
+        ~net:env#net
+        ~transport
+        ~clock
+        ~config
+        ~messages
+        ~retry_config:fast_retry_config
+        ~on_event
+        ()
+    with
+    | Ok resp ->
+      let text =
+        List.filter_map
+          (function
+            | Types.Text s -> Some s
+            | _ -> None)
+          resp.content
+        |> String.concat ""
+      in
+      check string "response text" "recovered after retry" text;
+      check int "two requests" 2 !request_count;
+      Eio.Switch.fail sw Exit
+    | Error _ -> fail "expected recovery after malformed json"
+  with
+  | Exit -> ()
+;;
+
 let () =
   run
     "complete_retry"
@@ -168,6 +256,14 @@ let () =
             "malformed json retries same provider"
             `Quick
             test_complete_with_retry_retries_malformed_json_400
+        ; test_case
+            "stream hard quota stops immediately"
+            `Quick
+            test_complete_stream_with_retry_stops_on_hard_quota_429
+        ; test_case
+            "stream malformed json retries same provider"
+            `Quick
+            test_complete_stream_with_retry_retries_malformed_json_400
         ] )
     ]
 ;;


### PR DESCRIPTION
This PR adds complete_stream_with_retry and routes streaming requests through it, allowing recovery from transient errors (such as DeepSeek 500 Internal Server Errors on Ollama Cloud). It also updates tests to verify retry behavior.