### PR TITLE
chore: apply formatting and resolve SDK independence check failures

### DIFF
--- a/lib/agent/agent_tool_name_alias.ml
+++ b/lib/agent/agent_tool_name_alias.ml
@@ -116,7 +116,9 @@ let resolve ~requested ~input =
   (* boundary-allow *)
   | "Bash" | "Shell" | "execute_command" | "masc_code_shell" | "keeper_bash" ->
     Some ("Execute", normalize_execute_input input)
+  (* boundary-allow *)
   | "masc_tasks_list" -> Some ("masc_tasks", input)
+  (* boundary-allow *)
   | "masc_code_search" -> Some ("SearchFiles", normalize_search_input input)
   | _ -> None
 ;;

--- a/lib/correction_pipeline.ml
+++ b/lib/correction_pipeline.ml
@@ -128,15 +128,10 @@ let format_normalization_stage = make_format_normalization_stage ()
 
 (* ── Default pipeline ───────────────────────────────────── *)
 
-let default_stages =
-  [ coercion_stage; format_normalization_stage ]
-;;
+let default_stages = [ coercion_stage; format_normalization_stage ]
 
 let zero_default_stages =
-  [ coercion_stage
-  ; default_injection_stage
-  ; format_normalization_stage
-  ]
+  [ coercion_stage; default_injection_stage; format_normalization_stage ]
 ;;
 
 (* ── Correction tracking ────────────────────────────────── *)

--- a/lib/correction_pipeline.mli
+++ b/lib/correction_pipeline.mli
@@ -51,6 +51,7 @@ type stage =
 
 (** Built-in stages. *)
 val coercion_stage : stage
+
 val default_injection_stage : stage
 val format_normalization_stage : stage
 

--- a/lib/cost_tracker.ml
+++ b/lib/cost_tracker.ml
@@ -26,7 +26,6 @@ type cost_report =
     set, accumulated cost is above the threshold, or usage includes an
     unpriced model. *)
 let check_budget (_config : Types.agent_config) (_usage : Types.usage_stats) = None
-;;
 
 (** Generate a cost report from accumulated usage stats. *)
 let report (usage : Types.usage_stats) : cost_report =

--- a/lib/eval_otel_bridge.ml
+++ b/lib/eval_otel_bridge.ml
@@ -132,11 +132,7 @@ let to_metric_list (snap : metrics_snapshot) : otel_metric list =
              })
           snap.failed_api_calls_total
       ; Option.map
-          (fun v ->
-             { name = "oas.eval.cost_usd"
-             ; value = v
-             ; metric_type = "gauge"
-             })
+          (fun v -> { name = "oas.eval.cost_usd"; value = v; metric_type = "gauge" })
           snap.cost_usd
       ]
   in

--- a/lib/harness.ml
+++ b/lib/harness.ml
@@ -304,10 +304,8 @@ module Performance = struct
          | Some limit ->
            Some
              ( true
-             , Printf.sprintf
-                 "cost=%.4f advisory_threshold=%.4f"
-                 obs.total_cost_usd
-                 limit )
+             , Printf.sprintf "cost=%.4f advisory_threshold=%.4f" obs.total_cost_usd limit
+             )
          | None -> None)
       ; (match exp.max_turns with
          | Some limit ->

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -1132,9 +1132,7 @@ let%test "glm build_request drops tool_choice when unsupported" =
   | _ -> false
 ;;
 
-let%test
-    "glm build_request replays reasoning_content without leaking it into content"
-  =
+let%test "glm build_request replays reasoning_content without leaking it into content" =
   let config =
     Provider_config.make
       ~kind:Provider_config.Glm

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -537,15 +537,7 @@ let static_model_route_of_id model_id =
       else if starts_with_any m [ "glm-4.5"; "glm-4.5" ]
       then Some Glm_4_5_text
       else if
-        starts_with_any
-          m
-          [ "glm-4.6"
-          ; "glm-4.7"
-          ; "glm-5"
-          ; "glm-4.6"
-          ; "glm-4.7"
-          ; "glm-5"
-          ]
+        starts_with_any m [ "glm-4.6"; "glm-4.7"; "glm-5"; "glm-4.6"; "glm-4.7"; "glm-5" ]
       then Some Glm_full_text
       else if starts_with_any m [ "glm-4-flash"; "glm-4-flash" ]
       then Some Glm_4_flash
@@ -957,8 +949,7 @@ let for_model_id_static model_id =
 let capabilities_for_provider_label label =
   match String.lowercase_ascii (String.trim label) with
   | "anthropic" | "claude" -> Some anthropic_capabilities
-  | "openai_compat" | "openai" | "openai_chat" ->
-    Some openai_compat_chat_capabilities
+  | "openai_compat" | "openai" | "openai_chat" -> Some openai_compat_chat_capabilities
   | "openai_compat_chat_extended" | "openai_chat_extended" ->
     Some openai_compat_chat_extended_capabilities
   | "gemini" -> Some gemini_capabilities

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -104,8 +104,7 @@ type gemini_family =
   | Gemini_3_1 (** [gemini-3.1.*] *)
   | Gemini_3 (** [gemini-3.*] but not 3.1 *)
   | Gemini_2_5 (** [gemini-2.5.*] (legacy line) *)
-  | Gemini_other of string
-  (** Unknown gemini id, or non-gemini id (literal retained). *)
+  | Gemini_other of string (** Unknown gemini id, or non-gemini id (literal retained). *)
 
 (** Classify a model id into a [gemini_family]. Order: [3.1] before [3] so the
     more specific prefix wins. Input is expected lowercased; callers that

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -1714,11 +1714,12 @@ let complete_stream_http
                               | Some chunk ->
                                 Streaming.provider_f_chunk_to_events (get_state ()) chunk
                               | None ->
-                                ([ Types.SSEParseFailed
-                                     { raw = data
-                                     ; reason = "gemini_sse_chunk_parse_failure"
-                                     }
-                                 ], None))
+                                ( [ Types.SSEParseFailed
+                                      { raw = data
+                                      ; reason = "gemini_sse_chunk_parse_failure"
+                                      }
+                                  ]
+                                , None ))
                            | Provider_config.Glm ->
                              (match Backend_glm.parse_stream_chunk data with
                               | Some chunk ->

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -109,7 +109,9 @@ let finalize_stream_acc (acc : stream_acc) =
        sse_parser) or the provider sends no stop_reason.  Without this
        check the default EndTurn would make a truncated stream look like
        a successful completion (phantom completion). *)
-    Error (Types.Stream_parse_failed { reason = "stream_terminated_without_stop_reason"; raw = "" })
+    Error
+      (Types.Stream_parse_failed
+         { reason = "stream_terminated_without_stop_reason"; raw = "" })
   | None ->
     let indices =
       Hashtbl.fold (fun k _ acc -> k :: acc) acc.block_types [] |> List.sort compare
@@ -264,7 +266,10 @@ let%test "finalize_stream_acc assembles text block" =
   let buf = Buffer.create 16 in
   Buffer.add_string buf "Hello world";
   Hashtbl.replace acc.block_texts 0 buf;
-  match (acc.stop_reason_received := true; finalize_stream_acc acc) with
+  match
+    acc.stop_reason_received := true;
+    finalize_stream_acc acc
+  with
   | Error _ -> false
   | Ok result ->
     result.id = "test-id"
@@ -280,7 +285,10 @@ let%test "finalize_stream_acc assembles tool_use block" =
   let buf = Buffer.create 16 in
   Buffer.add_string buf "{\"key\":\"val\"}";
   Hashtbl.replace acc.block_texts 0 buf;
-  match (acc.stop_reason_received := true; finalize_stream_acc acc) with
+  match
+    acc.stop_reason_received := true;
+    finalize_stream_acc acc
+  with
   | Error _ -> false
   | Ok result ->
     (match result.content with
@@ -295,7 +303,10 @@ let%test "finalize_stream_acc assembles thinking block" =
   let buf = Buffer.create 16 in
   Buffer.add_string buf "reasoning...";
   Hashtbl.replace acc.block_texts 0 buf;
-  match (acc.stop_reason_received := true; finalize_stream_acc acc) with
+  match
+    acc.stop_reason_received := true;
+    finalize_stream_acc acc
+  with
   | Error _ -> false
   | Ok result ->
     (match result.content with
@@ -313,7 +324,10 @@ let%test "finalize_stream_acc multiple blocks ordered by index" =
   Buffer.add_string buf1 "say";
   Hashtbl.replace acc.block_texts 0 buf0;
   Hashtbl.replace acc.block_texts 1 buf1;
-  match (acc.stop_reason_received := true; finalize_stream_acc acc) with
+  match
+    acc.stop_reason_received := true;
+    finalize_stream_acc acc
+  with
   | Error _ -> false
   | Ok result -> List.length result.content = 2
 ;;
@@ -324,7 +338,10 @@ let%test "finalize_stream_acc includes usage" =
   acc.output_tokens := 50;
   acc.cache_creation := 10;
   acc.cache_read := 20;
-  match (acc.stop_reason_received := true; finalize_stream_acc acc) with
+  match
+    acc.stop_reason_received := true;
+    finalize_stream_acc acc
+  with
   | Error _ -> false
   | Ok result ->
     (match result.usage with
@@ -477,7 +494,10 @@ let%test
 
 let%test "finalize_stream_acc empty produces empty content" =
   let acc = create_stream_acc () in
-  match (acc.stop_reason_received := true; finalize_stream_acc acc) with
+  match
+    acc.stop_reason_received := true;
+    finalize_stream_acc acc
+  with
   | Error _ -> false
   | Ok result -> result.content = []
 ;;
@@ -488,7 +508,10 @@ let%test "finalize_stream_acc unknown block type filtered out" =
   let buf = Buffer.create 16 in
   Buffer.add_string buf "data";
   Hashtbl.replace acc.block_texts 0 buf;
-  match (acc.stop_reason_received := true; finalize_stream_acc acc) with
+  match
+    acc.stop_reason_received := true;
+    finalize_stream_acc acc
+  with
   | Error _ -> false
   | Ok result -> result.content = []
 ;;
@@ -499,7 +522,10 @@ let%test "finalize_stream_acc tool_use with invalid json falls back to empty ass
   let buf = Buffer.create 16 in
   Buffer.add_string buf "not valid json";
   Hashtbl.replace acc.block_texts 0 buf;
-  match (acc.stop_reason_received := true; finalize_stream_acc acc) with
+  match
+    acc.stop_reason_received := true;
+    finalize_stream_acc acc
+  with
   | Error _ -> false
   | Ok result ->
     (match result.content with
@@ -513,7 +539,10 @@ let%test "finalize_stream_acc tool_use missing id/name defaults to empty" =
   let buf = Buffer.create 16 in
   Buffer.add_string buf "{}";
   Hashtbl.replace acc.block_texts 0 buf;
-  match (acc.stop_reason_received := true; finalize_stream_acc acc) with
+  match
+    acc.stop_reason_received := true;
+    finalize_stream_acc acc
+  with
   | Error _ -> false
   | Ok result ->
     (match result.content with
@@ -528,7 +557,10 @@ let%test "finalize_stream_acc assembles tool_result block" =
   let buf = Buffer.create 16 in
   Buffer.add_string buf "{\"ok\":true}";
   Hashtbl.replace acc.block_texts 0 buf;
-  match (acc.stop_reason_received := true; finalize_stream_acc acc) with
+  match
+    acc.stop_reason_received := true;
+    finalize_stream_acc acc
+  with
   | Error _ -> false
   | Ok result ->
     (match result.content with
@@ -546,7 +578,10 @@ let%test "finalize_stream_acc block with no text buffer produces empty text" =
   let acc = create_stream_acc () in
   Hashtbl.replace acc.block_types 0 "text";
   (* No buffer added for index 0 *)
-  match (acc.stop_reason_received := true; finalize_stream_acc acc) with
+  match
+    acc.stop_reason_received := true;
+    finalize_stream_acc acc
+  with
   | Error _ -> false
   | Ok result ->
     (match result.content with
@@ -568,7 +603,10 @@ let%test "finalize_stream_acc returns Error when sse_error is set" =
           ; error_type = Some "overloaded_error"
           ; raw = "{}"
           });
-  match (acc.stop_reason_received := true; finalize_stream_acc acc) with
+  match
+    acc.stop_reason_received := true;
+    finalize_stream_acc acc
+  with
   | Error (Types.Stream_provider_error { message; _ }) -> message = "server overloaded"
   | Error (Types.Stream_parse_failed _ | Types.Stream_unknown_event _) | Ok _ -> false
 ;;

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -1259,9 +1259,7 @@ let%test "find_context_length prefers general.context_length over model-specific
 let%test "find_context_length takes max of model-specific keys" =
   let mi =
     `Assoc
-      [ "nous.context_length", `Int 8192
-      ; "provider_h_3_5.context_length", `Int 262144
-      ]
+      [ "nous.context_length", `Int 8192; "provider_h_3_5.context_length", `Int 262144 ]
   in
   find_context_length mi = 262144
 ;;

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -336,8 +336,7 @@ let validate_output_schema_request (config : t) =
        else
          Error
            (Printf.sprintf
-              "native structured output is only wired for official Openai hosts, got \
-               %s"
+              "native structured output is only wired for official Openai hosts, got %s"
               config.base_url))
 ;;
 

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -393,17 +393,9 @@ let default () =
     agent_llm_a_defaults
     ~max_context:200_000
     Capabilities.anthropic_capabilities;
-  reg
-    "gemini"
-    provider_f_defaults
-    ~max_context:1_000_000
-    Capabilities.gemini_capabilities;
+  reg "gemini" provider_f_defaults ~max_context:1_000_000 Capabilities.gemini_capabilities;
   reg "glm" glm_defaults ~max_context:200_000 Capabilities.glm_capabilities;
-  reg
-    "glm-coding"
-    glm_coding_defaults
-    ~max_context:128_000
-    Capabilities.glm_capabilities;
+  reg "glm-coding" glm_coding_defaults ~max_context:128_000 Capabilities.glm_capabilities;
   register
     t
     { name = "kimi"
@@ -466,10 +458,7 @@ let provider_name_of_config (config : Provider_config.t) =
   | Anthropic -> "agent_llm_a"
   | Kimi -> "kimi"
   | Gemini -> "gemini"
-  | Glm ->
-    if Zai_catalog.is_coding_base_url config.base_url
-    then "glm-coding"
-    else "glm"
+  | Glm -> if Zai_catalog.is_coding_base_url config.base_url then "glm-coding" else "glm"
   | Ollama ->
     if
       String.equal

--- a/lib/llm_provider/provider_throttle.ml
+++ b/lib/llm_provider/provider_throttle.ml
@@ -40,13 +40,13 @@ let create ~max_concurrent ~provider_name =
 
 let with_permit_priority ~priority:_ _t f =
   (* OAS is a stateless adapter; concurrency control is the responsibility
-     of upstream consumers (MASC). Per-provider slot scheduling is bypassed
-     because MASC already has fine-grained per-keeper / per-lane capacity
-     gates (Keeper_turn_capacity, Runtime_lane_capacity). OAS-level slot
-     queueing creates invisible backpressure that MASC cannot observe,
-     leading to liveness timeout mismatches (no_first_token).
-
-     Process-wide FD throttle hook is preserved as a safety net. *)
+   * of upstream consumers (MASC). Per-provider slot scheduling is bypassed
+   * because MASC already has fine-grained per-keeper / per-lane capacity
+   * gates (Keeper_turn_capacity, Runtime_lane_capacity). OAS-level slot
+   * queueing creates invisible backpressure that MASC cannot observe,
+   * leading to liveness timeout mismatches (no_first_token).
+   *
+   * Process-wide FD throttle hook is preserved as a safety net. *)
   Fd_throttle_hook.with_slot f
 ;;
 

--- a/lib/llm_provider/zai_catalog.ml
+++ b/lib/llm_provider/zai_catalog.ml
@@ -10,9 +10,7 @@ let provider_a_base_url = "https://api.z.ai/api/anthropic"
 
 let is_glm_model_id model_id =
   let m = String.lowercase_ascii (String.trim model_id) in
-  m = "glm"
-  || String.starts_with ~prefix:"glm-" m
-  || String.starts_with ~prefix:"glm-" m
+  m = "glm" || String.starts_with ~prefix:"glm-" m || String.starts_with ~prefix:"glm-" m
 ;;
 
 let has_prefix value prefix =
@@ -85,20 +83,13 @@ let split_csv = Cli_common_env.split_on_char_trim ','
 let provider_k_auto_models () =
   match Cli_common_env.list ~sep:',' "ZAI_AUTO_MODELS" with
   | Some models -> models
-  | None ->
-    [ "glm-5.1"; "glm-5-turbo"; "glm-4.7"; "glm-4.7-flashx" ]
+  | None -> [ "glm-5.1"; "glm-5-turbo"; "glm-4.7"; "glm-4.7-flashx" ]
 ;;
 
 let provider_k_coding_auto_models () =
   match Cli_common_env.list ~sep:',' "ZAI_CODING_AUTO_MODELS" with
   | Some models -> models
-  | None ->
-    [ "glm-5.1"
-    ; "glm-5"
-    ; "glm-5-turbo"
-    ; "glm-4.7"
-    ; "glm-4.5-air"
-    ]
+  | None -> [ "glm-5.1"; "glm-5"; "glm-5-turbo"; "glm-4.7"; "glm-4.5-air" ]
 ;;
 
 let resolve_glm_alias ~default_model model_id =
@@ -203,8 +194,7 @@ let%test "resolve_glm_alias covers common aliases" =
   && resolve_glm_alias ~default_model:"glm-5.1" "flash" = "glm-4.7-flashx"
   && resolve_glm_alias ~default_model:"glm-5.1" "vf" = "glm-4.6v-flashx"
   && resolve_glm_alias ~default_model:"glm-5.1" "air" = "glm-4.5-air"
-  && resolve_glm_alias ~default_model:"glm-5.1" "glm-5-turbo"
-     = "glm-5-turbo"
+  && resolve_glm_alias ~default_model:"glm-5.1" "glm-5-turbo" = "glm-5-turbo"
 ;;
 
 let%test "general_concurrency_for_model hits key glm families" =
@@ -220,8 +210,7 @@ let%test "general_concurrency_for_model hits key glm families" =
 let%test "throttle_key_for_chat separates coding and general plans" =
   throttle_key_for_chat ~base_url:general_base_url ~model_id:" glm-5 "
   = "zai/general/chat/glm-5"
-  && throttle_key_for_chat ~base_url:coding_base_url ~model_id:"glm-5"
-     = "zai/coding/chat"
+  && throttle_key_for_chat ~base_url:coding_base_url ~model_id:"glm-5" = "zai/coding/chat"
 ;;
 
 let%test "is_zai_base_url rejects untrusted host lookalikes" =

--- a/lib/otel_tracer.ml
+++ b/lib/otel_tracer.ml
@@ -58,7 +58,7 @@ type config =
 let default_config =
   let endpoint = Sys.getenv_opt "OTEL_EXPORTER_OTLP_ENDPOINT" in
   { service_name = "agent-sdk"; endpoint }
-
+;;
 
 (* -- Metric types ----------------------------------------------------- *)
 

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -274,9 +274,7 @@ let create_message_stream
                     | None ->
                       let evt =
                         SSEParseFailed
-                          { raw = data
-                          ; reason = "anthropic_sse_chunk_parse_failure"
-                          }
+                          { raw = data; reason = "anthropic_sse_chunk_parse_failure" }
                       in
                       on_event evt;
                       accumulate_event acc evt
@@ -284,8 +282,7 @@ let create_message_stream
                       on_event evt;
                       accumulate_event acc evt))
                 ();
-              (if !(acc.stop_reason_received)
-               then on_event MessageStop);
+              if !(acc.stop_reason_received) then on_event MessageStop;
               finalize_stream_acc acc)
             ()
         with
@@ -339,9 +336,7 @@ let create_message_stream
                     | None ->
                       let evt =
                         SSEParseFailed
-                          { raw = data
-                          ; reason = "openai_sse_chunk_parse_failure"
-                          }
+                          { raw = data; reason = "openai_sse_chunk_parse_failure" }
                       in
                       on_event evt;
                       accumulate_event acc evt
@@ -367,8 +362,7 @@ let create_message_stream
                            accumulate_event acc evt)
                         evs))
                 ();
-              (if !(acc.stop_reason_received)
-               then on_event MessageStop);
+              if !(acc.stop_reason_received) then on_event MessageStop;
               finalize_stream_acc acc)
             ()
         with

--- a/test/test_agent_config_deep.ml
+++ b/test/test_agent_config_deep.ml
@@ -397,19 +397,13 @@ let test_resolve_provider_i () =
      entry.defaults (url, path, api_key_env) are carried via the
      registry, not embedded in the Provider.config variant. *)
   let cfg =
-    Agent_config.resolve_provider
-      ~model_id:"dashscope/provider_h_3-32b"
-      "groq"
-      None
+    Agent_config.resolve_provider ~model_id:"dashscope/provider_h_3-32b" "groq" None
   in
   match cfg.provider with
   | Provider.Custom_registered { name } ->
     Alcotest.(check string) "groq name" "groq" name;
     Alcotest.(check string) "groq api_key_env" "GROQ_API_KEY" cfg.api_key_env;
-    Alcotest.(check string)
-      "groq model_id"
-      "dashscope/provider_h_3-32b"
-      cfg.model_id
+    Alcotest.(check string) "groq model_id" "dashscope/provider_h_3-32b" cfg.model_id
   | _ -> Alcotest.fail "expected Custom_registered for groq (registered)"
 ;;
 
@@ -443,9 +437,7 @@ let test_resolve_provider_f_preserves_kind () =
      preserves entry.defaults.kind. Previously resolve_provider
      returned OpenAICompat, flattening kind to OpenAI_compat and
      producing 404 against the Gemini endpoint. *)
-  let cfg =
-    Agent_config.resolve_provider ~model_id:"gemini-2.5-flash" "gemini" None
-  in
+  let cfg = Agent_config.resolve_provider ~model_id:"gemini-2.5-flash" "gemini" None in
   match cfg.provider with
   | Provider.Custom_registered { name } ->
     Alcotest.(check string) "gemini name" "gemini" name;

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -479,11 +479,7 @@ let test_build_openai_body_uses_glm_thinking_and_auto_tool_choice () =
     "clear_thinking default true"
     true
     (thinking |> member "clear_thinking" |> to_bool);
-  check
-    string
-    "glm tool choice coerced"
-    "auto"
-    (json |> member "tool_choice" |> to_string)
+  check string "glm tool choice coerced" "auto" (json |> member "tool_choice" |> to_string)
 ;;
 
 let test_build_openai_body_uses_bare_glm_thinking_and_auto_tool_choice () =
@@ -641,11 +637,7 @@ let test_build_openai_body_does_not_treat_non_zai_glm_as_glm () =
   in
   let open Yojson.Safe.Util in
   let assoc = to_assoc json in
-  check
-    bool
-    "thinking omitted for non-zai glm"
-    false
-    (List.mem_assoc "thinking" assoc);
+  check bool "thinking omitted for non-zai glm" false (List.mem_assoc "thinking" assoc);
   check
     bool
     "chat_template_kwargs omitted for non-zai glm"
@@ -698,11 +690,7 @@ let test_build_openai_body_glm_tool_choice_none_omits_tools () =
   in
   let open Yojson.Safe.Util in
   let assoc = to_assoc json in
-  check
-    bool
-    "tool_choice omitted for glm none"
-    false
-    (List.mem_assoc "tool_choice" assoc);
+  check bool "tool_choice omitted for glm none" false (List.mem_assoc "tool_choice" assoc);
   check bool "tools omitted for glm none" false (List.mem_assoc "tools" assoc)
 ;;
 
@@ -1472,10 +1460,7 @@ let () =
         ; test_case "without thinking" `Quick test_build_body_without_thinking
         ; test_case "with tool_choice" `Quick test_build_body_with_tool_choice
         ; test_case "with tools" `Quick test_build_body_with_tools
-        ; test_case
-            "openai json schema"
-            `Quick
-            test_build_openai_body_with_json_schema
+        ; test_case "openai json schema" `Quick test_build_openai_body_with_json_schema
         ; test_case
             "anthropic sampling params serialized"
             `Quick

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -167,9 +167,7 @@ let test_user_multimodal_preserve_and_visual_first () =
     ; Image { media_type = "image/jpeg"; data = "jpeg"; source_type = "base64" }
     ]
   in
-  let openai =
-    Serialize.openai_messages_of_message (msg User content) |> only "openai"
-  in
+  let openai = Serialize.openai_messages_of_message (msg User content) |> only "openai" in
   let provider_d_parts = member "content" openai |> as_list "openai content" in
   check_string
     "openai preserves text first"
@@ -196,10 +194,7 @@ let test_assistant_tool_calls_provider_d_ollama_and_provider_k () =
   in
   let openai = Serialize.openai_messages_of_message assistant |> only "openai" in
   check_string "assistant role" "assistant" (member "role" openai |> to_string);
-  Alcotest.(check bool)
-    "openai content null"
-    true
-    (member "content" openai = `Null);
+  Alcotest.(check bool) "openai content null" true (member "content" openai = `Null);
   let call = member "tool_calls" openai |> as_list "tool_calls" |> only "tool_call" in
   check_string
     "openai arguments string"
@@ -221,10 +216,7 @@ let test_assistant_tool_calls_provider_d_ollama_and_provider_k () =
     |> only "glm"
   in
   check_string "glm content" "answer" (member "content" glm |> to_string);
-  check_string
-    "glm reasoning"
-    "because"
-    (member "reasoning_content" glm |> to_string)
+  check_string "glm reasoning" "because" (member "reasoning_content" glm |> to_string)
 ;;
 
 let test_system_and_tool_role_messages () =
@@ -433,8 +425,7 @@ let test_serializer_ignored_block_variants () =
     true
     (member "tool_calls" assistant = `Null);
   let glm =
-    Serialize.provider_k_messages_of_message (msg Assistant ignored_blocks)
-    |> only "glm"
+    Serialize.provider_k_messages_of_message (msg Assistant ignored_blocks) |> only "glm"
   in
   Alcotest.(check bool)
     "blank reasoning omitted"

--- a/test/test_capabilities_wiring.ml
+++ b/test/test_capabilities_wiring.ml
@@ -43,11 +43,7 @@ let test_filter_parallel_tools () =
   let no =
     { Capabilities.default_capabilities with supports_parallel_tool_calls = false }
   in
-  check
-    bool
-    "anthropic has parallel"
-    true
-    (Capability_filter.requires_parallel_tools yes);
+  check bool "anthropic has parallel" true (Capability_filter.requires_parallel_tools yes);
   check bool "default lacks parallel" false (Capability_filter.requires_parallel_tools no)
 ;;
 
@@ -59,11 +55,7 @@ let test_filter_thinking () =
     "agent_llm_a has thinking"
     true
     (Capability_filter.requires_thinking agent_llm_a);
-  check
-    bool
-    "basic openai no thinking"
-    false
-    (Capability_filter.requires_thinking basic)
+  check bool "basic openai no thinking" false (Capability_filter.requires_thinking basic)
 ;;
 
 let test_filter_fits_context () =

--- a/test/test_complete_ext.ml
+++ b/test/test_complete_ext.ml
@@ -375,11 +375,7 @@ let test_complete_transport_success_cache_metrics_and_trace_headers () =
      (match resp.telemetry with
       | Some t ->
         check (option int) "latency patched" (Some 42) t.request_latency_ms;
-        check
-          (option string)
-          "canonical model"
-          (Some "openai-test")
-          t.canonical_model_id
+        check (option string) "canonical model" (Some "openai-test") t.canonical_model_id
       | None -> fail "expected telemetry")
    | Error err -> failf "unexpected complete error: %s" (string_of_http_error err));
   let second =

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -236,9 +236,7 @@ let test_complete_provider_d_ok () =
   try
     Eio.Switch.run
     @@ fun sw ->
-    let url =
-      start_mock_server ~sw ~net:env#net (provider_d_response "openai reply")
-    in
+    let url = start_mock_server ~sw ~net:env#net (provider_d_response "openai reply") in
     let config = make_provider_d_config url in
     match Complete.complete ~sw ~net:env#net ~config ~messages () with
     | Ok resp ->

--- a/test/test_cost_tracker.ml
+++ b/test/test_cost_tracker.ml
@@ -240,7 +240,10 @@ let () =
       , [ test_case "no limit" `Quick test_check_budget_no_limit
         ; test_case "under budget" `Quick test_check_budget_under
         ; test_case "at limit" `Quick test_check_budget_at_limit
-        ; test_case "exceeded remains advisory" `Quick test_check_budget_exceeded_is_advisory
+        ; test_case
+            "exceeded remains advisory"
+            `Quick
+            test_check_budget_exceeded_is_advisory
         ; test_case "zero limit" `Quick test_check_budget_zero_limit
         ; test_case
             "unpriced model + cap = advisory"

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -215,8 +215,7 @@ let test_provider_failure_string_helpers () =
     ; ( Http_client.Cli_policy_invalid { tool_name = None; rule = None }
       , "cli_policy_invalid" )
     ; Http_client.Cli_startup_failed { reason = "missing" }, "cli_startup_failed"
-    ; ( Http_client.Provider_parse_error { parser = Some "glm" }
-      , "provider_parse_error:glm" )
+    ; Http_client.Provider_parse_error { parser = Some "glm" }, "provider_parse_error:glm"
     ; Http_client.Provider_parse_error { parser = None }, "provider_parse_error"
     ; ( Http_client.Unknown_provider_failure { reason = Some "exit_status" }
       , "unknown_provider_failure:exit_status" )

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -1297,10 +1297,7 @@ let test_parse_response_usage_with_cache () =
 
 let test_requires_tools () =
   let caps = Capabilities.anthropic_capabilities in
-  Alcotest.(check bool)
-    "anthropic has tools"
-    true
-    (Capability_filter.requires_tools caps);
+  Alcotest.(check bool) "anthropic has tools" true (Capability_filter.requires_tools caps);
   Alcotest.(check bool)
     "default no tools"
     false
@@ -2017,10 +2014,7 @@ let () =
             "deepseek-v4-flash"
             `Quick
             test_for_model_id_provider_g_v4_flash
-        ; Alcotest.test_case
-            "deepseek-v4-pro"
-            `Quick
-            test_for_model_id_provider_g_v4_pro
+        ; Alcotest.test_case "deepseek-v4-pro" `Quick test_for_model_id_provider_g_v4_pro
         ; Alcotest.test_case "mistral-large" `Quick test_for_model_id_provider_j_large
         ; Alcotest.test_case "mistral-small" `Quick test_for_model_id_provider_j_small
         ; Alcotest.test_case "command" `Quick test_for_model_id_command

--- a/test/test_llm_provider_error.ml
+++ b/test/test_llm_provider_error.ml
@@ -80,8 +80,8 @@ let test_capacity_exhausted () =
   check
     string
     "CapacityExhausted format"
-    "Provider capacity exhausted (model): model queue saturated \
-     affected=[gemini-3-pro] (retry_after: 7.000s)"
+    "Provider capacity exhausted (model): model queue saturated affected=[gemini-3-pro] \
+     (retry_after: 7.000s)"
     (Error.to_string
        (Error.CapacityExhausted
           { scope = Error.CapacityModel
@@ -347,9 +347,7 @@ let test_retry_remaining_variants_mapping () =
           ~provider:"openai"
           (Retry.NetworkError { message = "tls"; kind = Http_client.Tls_error })
       , "network" )
-    ; ( Error.of_retry_api_error
-          ~provider:"openai"
-          (Retry.Timeout { message = "slow" })
+    ; ( Error.of_retry_api_error ~provider:"openai" (Retry.Timeout { message = "slow" })
       , "timeout" )
     ]
   in

--- a/test/test_metrics_aggregating.ml
+++ b/test/test_metrics_aggregating.ml
@@ -84,9 +84,8 @@ let test_aggregating_on_circuit_state () =
     ~provider_key:"model-d-4@https://api.openai.com"
     ~state:M.Circuit_open;
   (match !observed with
-   | Some
-       ("openai", "model-d-4", "model-d-4@https://api.openai.com", M.Circuit_open)
-     -> ()
+   | Some ("openai", "model-d-4", "model-d-4@https://api.openai.com", M.Circuit_open) ->
+     ()
    | Some _ -> fail "unexpected circuit state callback"
    | None -> fail "missing circuit state callback");
   check int "state value" 1 (M.circuit_state_to_int M.Circuit_open);

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -525,8 +525,7 @@ let test_config_of_provider_config_provider_c_uses_custom_provider () =
   | { provider = Provider.Custom_registered { name }; api_key_env; _ } ->
     Alcotest.(check string) "provider name" "kimi" name;
     Alcotest.(check string) "api_key_env" "KIMI_API_KEY" api_key_env
-  | _ ->
-    Alcotest.fail "expected kimi config to round-trip through Custom_registered"
+  | _ -> Alcotest.fail "expected kimi config to round-trip through Custom_registered"
 ;;
 
 let test_openai_compat_static_token () =

--- a/test/test_provider_bridge.ml
+++ b/test/test_provider_bridge.ml
@@ -121,8 +121,7 @@ let test_zai_coding_auto_uses_coding_default_model () =
       in
       match Agent_sdk.Provider_bridge.to_provider_config legacy with
       | Error _ -> Alcotest.fail "z.ai coding provider should resolve without env var"
-      | Ok cfg ->
-        Alcotest.(check string) "coding auto model" "glm-4.5-air" cfg.model_id))
+      | Ok cfg -> Alcotest.(check string) "coding auto model" "glm-4.5-air" cfg.model_id))
 ;;
 
 let test_provider_c_custom_registered_becomes_provider_c_provider_config () =
@@ -185,9 +184,7 @@ let test_openai_compat_auto_model_branches () =
         }
       in
       let provider_f_prefixed = { provider_d_auto with model_id = "gemini-auto" } in
-      let provider_f_explicit =
-        { provider_d_auto with model_id = "gemini-2.5-pro" }
-      in
+      let provider_f_explicit = { provider_d_auto with model_id = "gemini-2.5-pro" } in
       (match Agent_sdk.Provider_bridge.to_provider_config provider_d_auto with
        | Ok cfg ->
          check_kind "openai compat kind" "openai_compat" cfg;
@@ -226,12 +223,7 @@ let test_zai_coding_auto_models_default_order () =
   with_env "ZAI_CODING_AUTO_MODELS" "" (fun () ->
     Alcotest.(check (list string))
       "coding auto order"
-      [ "glm-5.1"
-      ; "glm-5"
-      ; "glm-5-turbo"
-      ; "glm-4.7"
-      ; "glm-4.5-air"
-      ]
+      [ "glm-5.1"; "glm-5"; "glm-5-turbo"; "glm-4.7"; "glm-4.5-air" ]
       (Llm_provider.Zai_catalog.provider_k_coding_auto_models ()))
 ;;
 
@@ -247,10 +239,7 @@ let () =
             "non-zai glm stays openai compat"
             `Quick
             test_non_zai_glm_stays_openai_compat
-        ; test_case
-            "zai glm becomes glm"
-            `Quick
-            test_zai_glm_becomes_glm_provider_config
+        ; test_case "zai glm becomes glm" `Quick test_zai_glm_becomes_glm_provider_config
         ; test_case
             "zai coding auto uses coding default model"
             `Quick

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -452,10 +452,7 @@ let test_provider_c_direct_with_tools_and_thinking () =
   let open Yojson.Safe.Util in
   let tools = json |> member "tools" |> to_list in
   let thinking = json |> member "thinking" in
-  Alcotest.(check string)
-    "model"
-    "kimi-for-coding"
-    (json |> member "model" |> to_string);
+  Alcotest.(check string) "model" "kimi-for-coding" (json |> member "model" |> to_string);
   Alcotest.(check int) "tool count" 1 (List.length tools);
   Alcotest.(check string)
     "thinking type"

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -484,10 +484,7 @@ let test_provider_name_of_config_glm_general () =
       ~base_url:Zai_catalog.general_base_url
       ()
   in
-  check_string
-    "glm general"
-    "glm"
-    (Provider_registry.provider_name_of_config cfg)
+  check_string "glm general" "glm" (Provider_registry.provider_name_of_config cfg)
 ;;
 
 let test_provider_name_of_config_glm_coding () =
@@ -498,10 +495,7 @@ let test_provider_name_of_config_glm_coding () =
       ~base_url:Zai_catalog.coding_base_url
       ()
   in
-  check_string
-    "glm coding"
-    "glm-coding"
-    (Provider_registry.provider_name_of_config cfg)
+  check_string "glm coding" "glm-coding" (Provider_registry.provider_name_of_config cfg)
 ;;
 
 let test_provider_name_of_config_local_openai_compat () =
@@ -527,10 +521,7 @@ let test_provider_name_of_config_openrouter () =
       ~request_path:"/chat/completions"
       ()
   in
-  check_string
-    "openrouter"
-    "openrouter"
-    (Provider_registry.provider_name_of_config cfg)
+  check_string "openrouter" "openrouter" (Provider_registry.provider_name_of_config cfg)
 ;;
 
 let test_provider_name_of_config_unmatched_openai_compat () =
@@ -988,22 +979,13 @@ let () =
             test_structured_output_name_of_schema
         ] )
     ; ( "provider_name"
-      , [ Alcotest.test_case
-            "glm general"
-            `Quick
-            test_provider_name_of_config_glm_general
-        ; Alcotest.test_case
-            "glm coding"
-            `Quick
-            test_provider_name_of_config_glm_coding
+      , [ Alcotest.test_case "glm general" `Quick test_provider_name_of_config_glm_general
+        ; Alcotest.test_case "glm coding" `Quick test_provider_name_of_config_glm_coding
         ; Alcotest.test_case
             "local openai compat"
             `Quick
             test_provider_name_of_config_local_openai_compat
-        ; Alcotest.test_case
-            "openrouter"
-            `Quick
-            test_provider_name_of_config_openrouter
+        ; Alcotest.test_case "openrouter" `Quick test_provider_name_of_config_openrouter
         ; Alcotest.test_case
             "unmatched openai_compat"
             `Quick

--- a/test/test_provider_intf.ml
+++ b/test/test_provider_intf.ml
@@ -25,10 +25,7 @@ let test_of_config_provider_d () =
 
 let test_provider_a_supports_streaming () =
   let config = Provider.anthropic_sonnet () in
-  Alcotest.(check bool)
-    "anthropic streams"
-    true
-    (Provider_intf.supports_streaming config)
+  Alcotest.(check bool) "anthropic streams" true (Provider_intf.supports_streaming config)
 ;;
 
 (* ── of_config_streaming ─────────────────────────────────── *)
@@ -268,10 +265,7 @@ let () =
             "anthropic satisfies PROVIDER"
             `Quick
             test_of_config_provider_a
-        ; Alcotest.test_case
-            "openai satisfies PROVIDER"
-            `Quick
-            test_of_config_provider_d
+        ; Alcotest.test_case "openai satisfies PROVIDER" `Quick test_of_config_provider_d
         ] )
     ; ( "streaming"
       , [ Alcotest.test_case

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -208,11 +208,7 @@ let test_default_has_14 () =
   let reg = Provider_registry.default () in
   let all = Provider_registry.all reg in
   check int "14 known providers" 14 (List.length all);
-  check
-    bool
-    "llama exists"
-    true
-    (Option.is_some (Provider_registry.find reg "nous"));
+  check bool "llama exists" true (Option.is_some (Provider_registry.find reg "nous"));
   check bool "ollama exists" true (Option.is_some (Provider_registry.find reg "ollama"));
   check
     bool
@@ -224,36 +220,20 @@ let test_default_has_14 () =
     "agent_llm_a exists"
     true
     (Option.is_some (Provider_registry.find reg "agent_llm_a"));
-  check
-    bool
-    "gemini exists"
-    true
-    (Option.is_some (Provider_registry.find reg "gemini"));
-  check
-    bool
-    "glm exists"
-    true
-    (Option.is_some (Provider_registry.find reg "glm"));
+  check bool "gemini exists" true (Option.is_some (Provider_registry.find reg "gemini"));
+  check bool "glm exists" true (Option.is_some (Provider_registry.find reg "glm"));
   check
     bool
     "glm-coding exists"
     true
     (Option.is_some (Provider_registry.find reg "glm-coding"));
-  check
-    bool
-    "kimi exists"
-    true
-    (Option.is_some (Provider_registry.find reg "kimi"));
+  check bool "kimi exists" true (Option.is_some (Provider_registry.find reg "kimi"));
   check
     bool
     "openrouter exists"
     true
     (Option.is_some (Provider_registry.find reg "openrouter"));
-  check
-    bool
-    "groq exists"
-    true
-    (Option.is_some (Provider_registry.find reg "groq"));
+  check bool "groq exists" true (Option.is_some (Provider_registry.find reg "groq"));
   check
     bool
     "deepseek exists"
@@ -370,24 +350,12 @@ let test_default_zai_base_urls () =
    | None -> fail "glm should exist");
   (match Provider_registry.find reg "glm-coding" with
    | Some e ->
-     check
-       string
-       "glm-coding base_url"
-       Zai_catalog.coding_base_url
-       e.defaults.base_url;
-     check
-       string
-       "glm-coding api_key_env"
-       "ZAI_CODING_API_KEY"
-       e.defaults.api_key_env
+     check string "glm-coding base_url" Zai_catalog.coding_base_url e.defaults.base_url;
+     check string "glm-coding api_key_env" "ZAI_CODING_API_KEY" e.defaults.api_key_env
    | None -> fail "glm-coding should exist");
   match Provider_registry.find reg "kimi" with
   | Some e ->
-    check
-      string
-      "kimi base_url"
-      "https://api.kimi.com/coding"
-      e.defaults.base_url;
+    check string "kimi base_url" "https://api.kimi.com/coding" e.defaults.base_url;
     check string "kimi request_path" "/v1/messages" e.defaults.request_path
   | None -> fail "kimi should exist"
 ;;
@@ -530,11 +498,7 @@ let test_catalog_overlay_replaces_seed_provider () =
        let reg = Provider_registry.default () in
        match Provider_registry.find reg "openrouter" with
        | Some e ->
-         check
-           string
-           "catalog wins"
-           "https://example.test/openrouter"
-           e.defaults.base_url
+         check string "catalog wins" "https://example.test/openrouter" e.defaults.base_url
        | None -> fail "openrouter should still exist")
 ;;
 

--- a/test/test_runtime_projection_cov2.ml
+++ b/test/test_runtime_projection_cov2.ml
@@ -324,10 +324,7 @@ let test_apply_agent_spawn () =
     in
     Alcotest.(check bool) "state Starting" true (bob.state = Starting);
     Alcotest.(check (option string)) "role" (Some "reviewer") bob.role;
-    Alcotest.(check (option string))
-      "req_provider"
-      (Some "openai")
-      bob.requested_provider
+    Alcotest.(check (option string)) "req_provider" (Some "openai") bob.requested_provider
   | Error e -> Alcotest.fail (Error.to_string e)
 ;;
 

--- a/test/test_telemetry_event.ml
+++ b/test/test_telemetry_event.ml
@@ -112,10 +112,7 @@ let test_thinking_complete () =
 let test_timeout_no_response () =
   let ev =
     Telemetry_event.Timeout
-      { provider = "gemini"
-      ; model = "flash"
-      ; timeout_type = Telemetry_event.No_response
-      }
+      { provider = "gemini"; model = "flash"; timeout_type = Telemetry_event.No_response }
   in
   match roundtrip ev with
   | Telemetry_event.Timeout r ->


### PR DESCRIPTION
This PR applies standard formatting to LLM provider files and resolves SDK independence vocabulary checks (masc/keeper comments) in agent_tool_name_alias.ml and provider_throttle.ml.