### PR TITLE
fix(streaming): default stream idle timeout to 60s and support clock

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -1373,6 +1373,11 @@ let complete_stream_http
       ~(on_event : Types.sse_event -> unit)
       ()
   =
+  let stream_idle_timeout_s =
+    match stream_idle_timeout_s with
+    | Some _ as v -> v
+    | None -> Some 60.0
+  in
   match validate_all config with
   | Error err -> Error err
   | Ok () ->

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -49,6 +49,8 @@ module type STREAMING_PROVIDER = sig
   val create_message_stream
     :  sw:Eio.Switch.t
     -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+    -> ?clock:_ Eio.Time.clock
+    -> ?idle_timeout:float
     -> config:Types.agent_state
     -> messages:Types.message list
     -> ?tools:Yojson.Safe.t list
@@ -165,10 +167,12 @@ let of_config_streaming (provider_cfg : Provider.config)
     let module SP = struct
       include Base
 
-      let create_message_stream ~sw ~net ~config ~messages ?tools ~on_event () =
+      let create_message_stream ~sw ~net ?clock ?idle_timeout ~config ~messages ?tools ~on_event () =
         Streaming.create_message_stream
           ~sw
           ~net
+          ?clock
+          ?idle_timeout
           ~base_url
           ~provider:provider_cfg
           ~config

--- a/lib/provider_intf.mli
+++ b/lib/provider_intf.mli
@@ -25,6 +25,8 @@ module type STREAMING_PROVIDER = sig
   val create_message_stream
     :  sw:Eio.Switch.t
     -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+    -> ?clock:_ Eio.Time.clock
+    -> ?idle_timeout:float
     -> config:Types.agent_state
     -> messages:Types.message list
     -> ?tools:Yojson.Safe.t list

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -216,6 +216,8 @@ let map_http_error = function
 let create_message_stream
       ~sw
       ~net
+      ?clock
+      ?idle_timeout
       ?(base_url = Api.default_base_url)
       ?provider
       ~config
@@ -259,6 +261,7 @@ let create_message_stream
        let url = base_url ^ "/v1/messages" in
        (match
           Llm_provider.Http_client.with_post_stream
+            ?clock
             ~net
             ~url
             ~headers
@@ -266,6 +269,8 @@ let create_message_stream
             ~f:(fun reader ->
               let acc = create_stream_acc () in
               Llm_provider.Http_client.read_sse
+                ?clock
+                ?idle_timeout
                 ~reader
                 ~on_data:(fun ~event_type data ->
                   if data <> "[DONE]"
@@ -318,6 +323,7 @@ let create_message_stream
        let url = base_url ^ stream_path in
        (match
           Llm_provider.Http_client.with_post_stream
+            ?clock
             ~net
             ~url
             ~headers
@@ -327,6 +333,8 @@ let create_message_stream
               let oai_state = Llm_provider.Streaming.create_openai_stream_state () in
               let msg_started = ref false in
               Llm_provider.Http_client.read_sse
+                ?clock
+                ?idle_timeout
                 ~reader
                 ~on_data:(fun ~event_type:_ data ->
                   if data = "[DONE]"

--- a/lib/streaming.mli
+++ b/lib/streaming.mli
@@ -62,6 +62,8 @@ val map_http_error : Llm_provider.Http_client.http_error -> Error.sdk_error
 val create_message_stream
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> ?clock:_ Eio.Time.clock
+  -> ?idle_timeout:float
   -> ?base_url:string
   -> ?provider:Provider.config
   -> config:Types.agent_state


### PR DESCRIPTION
Default stream idle timeout to 60s when not specified, and thread ?clock and ?idle_timeout parameters so Eio.Time.with_timeout_exn can actually trip.