### PR TITLE
refactor(throttle): make slot-bypass rationale consumer-agnostic

### DIFF
--- a/lib/llm_provider/provider_throttle.ml
+++ b/lib/llm_provider/provider_throttle.ml
@@ -40,11 +40,12 @@ let create ~max_concurrent ~provider_name =
 
 let with_permit_priority ~priority:_ _t f =
   (* OAS is a stateless adapter; concurrency control is the responsibility
-   * of upstream consumers (MASC). Per-provider slot scheduling is bypassed
-   * because MASC already has fine-grained per-keeper / per-lane capacity
-   * gates (Keeper_turn_capacity, Runtime_lane_capacity). OAS-level slot
-   * queueing creates invisible backpressure that MASC cannot observe,
-   * leading to liveness timeout mismatches (no_first_token).
+   * of the downstream consumer. Per-provider slot scheduling is bypassed
+   * because the consumer owns request admission and applies its own
+   * fine-grained capacity gates with the context to make backpressure
+   * observable. OAS-level slot queueing would create invisible backpressure
+   * the consumer cannot observe, leading to liveness timeout mismatches
+   * (no_first_token).
    *
    * Process-wide FD throttle hook is preserved as a safety net. *)
   Fd_throttle_hook.with_slot f


### PR DESCRIPTION
## 요약
`provider_throttle.with_permit_priority`는 per-provider slot scheduling을 우회하고 동시성 제어를 caller에 위임합니다. 그 근거 주석이 특정 downstream coordinator와 그 내부 모듈명 2개를 명명해, **소비자 가정을 SDK 경계에 박아넣고** 있었습니다. 동작 변경 없이 주석을 generic하게 재작성합니다 (downstream consumer가 request admission·capacity gating을 소유).

## 배경
`check-sdk-independence.sh`는 `lib/bin/README`에서 coordinator 어휘를 스캔하지만 **OCaml 주석 라인을 제외**(filter_noise)하므로, 이 참조들이 주석에 있어 게이트를 통과했습니다. 본 PR이 해당 파일에서 그 누수를 소스 레벨에서 닫습니다. OAS CLAUDE.md의 house style("responsibility of downstream consumers")과 일치.

## 변경
- `lib/llm_provider/provider_throttle.ml` 주석만 (코드/동작 무변경)

## 검증
- `check-sdk-independence.sh`: OK
- `ocamlformat --check`: OK
- 잔여 masc/keeper/board/room 단어: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)