### PR TITLE
fix(provider): round-trip reasoning_content for DeepSeek models

### DIFF
--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -119,10 +119,15 @@ let build_request
   let sanitized_messages =
     Backend_openai_serialize.strip_orphaned_tool_results messages
   in
+  let is_deepseek_model model_id =
+    String.starts_with ~prefix:"deepseek" model_id
+  in
   let provider_messages =
     let message_serializer =
       match config.kind with
       | Provider_config.Glm -> Backend_openai_serialize.provider_k_messages_of_message
+      | Provider_config.OpenAI_compat when is_deepseek_model config.model_id ->
+          Backend_openai_serialize.provider_k_messages_of_message
       | Provider_config.Anthropic
       | Provider_config.Kimi
       | Provider_config.OpenAI_compat

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -353,9 +353,15 @@ let strip_orphaned_tool_results (messages : message list) : message list =
 ;;
 
 (** Strip Thinking blocks from all messages.
-    Deepseek-compatible APIs reject [reasoning_content] in request
-    messages — it is response-only. Occurs before serialization so
-    theThinking blocks do not leak into the wire format.
+
+    Some OpenAI-compatible providers emit [reasoning_content] in
+    responses but do not accept it in request messages.  DeepSeek is
+    an exception — it *requires* [reasoning_content] round-tripping
+    for tool-call turns (see DeepSeek API docs).  The caller is
+    responsible for choosing the correct serializer (see
+    {!Backend_openai_request.is_deepseek_model}) so that DeepSeek
+    requests use [provider_k_messages_of_message] which preserves
+    [reasoning_content].
 
     Pure function — no I/O, no mutation. *)
 let strip_thinking_blocks (messages : message list) : message list =


### PR DESCRIPTION
## Problem
Sangsu keeper (deepseek-v4-flash) stuck in infinite loop calling `keeper_board_post_get({})` with missing post_id.

Root cause: OAS does not round-trip `reasoning_content` for OpenAI_compat providers, but DeepSeek v4 REQUIRES it for tool-call turns per official API docs.

## Changes
- `backend_openai_request.ml`: detect deepseek model IDs and route through `provider_k_messages_of_message` (`include_reasoning_content=true`), same path as GLM
- `backend_openai_serialize.ml`: correct misleading comment about DeepSeek reasoning_content handling

## Evidence
- DeepSeek API docs: reasoning_content must be passed back in ALL subsequent requests for tool-call turns
- Sangsu OAS snapshot (68 messages): repeated keeper_board_post_get({}) with empty params
- fix-deepseek-thinking-500 fixed 500 errors but reasoning_content round-trip remained broken

## Test plan
- [x] dune build passes
- [ ] Deploy to staging, verify sangsu keeper no longer loops
- [ ] Monitor tool_call_param_completeness for incomplete count drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)
