### PR TITLE
fix(catalog): drop consumer-specific ~/.masc search path (SDK boundary)

### DIFF
--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -183,7 +183,10 @@ let env_loaded_catalog : t option Lazy.t =
        ; find_in_parents "models.toml" cwd 10
        ; find_in_parents "oas-models.toml" cwd 10
        ; Option.map (fun h -> Filename.concat h ".config/oas/models.toml") home_opt
-       ; Option.map (fun h -> Filename.concat h ".masc/config/models.toml") home_opt
+         (* Boundary: this SDK is generic and must not know any embedding
+            application's private runtime layout. A consumer points the SDK
+            at its own catalog via [OAS_MODEL_CATALOG]; the SDK only probes
+            its own namespace ([.config/oas]) and the cwd-parent chain. *)
        ]
        |> List.filter_map Fun.id
      in


### PR DESCRIPTION
## 문제 (경계 위반)

`model_catalog.ml`의 런타임 카탈로그 검색경로가 `\$HOME/.masc/config/models.toml`을 포함합니다. `.masc`는 이 SDK를 임베드하는 특정 소비자 애플리케이션의 **사설 런타임 디렉토리**입니다. 제네릭 SDK가 소비자의 홈 레이아웃을 하드코딩으로 알고/추측하는 것은 의존성 방향을 거스르는 경계 위반입니다 (하위 라이브러리가 상위 소비자를 참조).

## 변경

`\$HOME/.masc/config/models.toml` 검색경로 1줄 제거. SDK는 **자기 네임스페이스만** 탐색합니다:
- `OAS_MODEL_CATALOG` env (소비자가 명시적으로 주입)
- cwd-parent 체인의 `models.toml` / `oas-models.toml`
- `\$HOME/.config/oas/models.toml` (SDK 자체 XDG 네임스페이스)

소비자는 `OAS_MODEL_CATALOG`로 자기 카탈로그 위치를 **명시적으로 SDK에 넘깁니다**.

## 기능 영향: 없음

그 경로는 실무에서 아무것도 resolve하지 않았습니다 — 소비자는 `\$HOME`과 다른 base dir로 실행되므로 `\$HOME/.masc`는 소비자의 config root였던 적이 없습니다. 소비자 측이 `OAS_MODEL_CATALOG`를 세팅해 카탈로그를 로드하는 것이 책임입니다 (별도 소비자 PR에서 처리).

## 검증

- `scripts/dune-local.sh build lib/llm_provider/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)