### PR TITLE
fix(http_client): spec-grammar SSE field parsing + fail-loud idle-without-clock

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -1374,9 +1374,19 @@ let complete_stream_http
       ()
   =
   let stream_idle_timeout_s =
-    match stream_idle_timeout_s with
-    | Some _ as v -> v
-    | None -> Some 60.0
+    (* Default the idle deadline only when it can actually arm: read_sse
+       now rejects idle-without-clock loudly instead of silently
+       disarming, so manufacturing [Some 60.0] for a clock-less caller
+       would turn every such stream into an [Invalid_argument]. An
+       EXPLICIT [stream_idle_timeout_s] without a clock still reaches
+       that loud rejection — that combination is a caller bug, not a
+       default we created. Clock-less callers get what they always
+       effectively had (no idle protection), now visible in the
+       signature instead of buried in a silent disarm. *)
+    match stream_idle_timeout_s, clock with
+    | (Some _ as v), _ -> v
+    | None, Some _ -> Some 60.0
+    | None, None -> None
   in
   match validate_all config with
   | Error err -> Error err

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -756,35 +756,94 @@ let with_post_stream
       Error (HttpError { code; body = body_str }))
 ;;
 
+(* One W3C EventSource line, parsed per spec (§9.2.6 event stream
+   interpretation):
+   - empty line: event dispatch boundary
+   - line starting with ':': comment (keepalive)
+   - otherwise "name[:[ ]value]": a field; exactly one leading space is
+     stripped from the value, and a line with no ':' is a field with an
+     empty value.
+   The previous implementation matched the literal prefixes "event: " /
+   "data: " with index arithmetic, silently dropping spec-valid lines
+   like "data:foo" (no space after the colon) — a provider or proxy
+   that omits the optional space would make the whole stream vanish
+   without a trace. *)
+type sse_line =
+  | Sse_blank
+  | Sse_comment
+  | Sse_field of string * string
+
+let parse_sse_line line =
+  if String.length line = 0
+  then Sse_blank
+  else (
+    match String.index_opt line ':' with
+    | Some 0 -> Sse_comment
+    | None -> Sse_field (line, "")
+    | Some i ->
+      let value_start =
+        if String.length line > i + 1 && line.[i + 1] = ' ' then i + 2 else i + 1
+      in
+      Sse_field
+        ( String.sub line 0 i
+        , String.sub line value_start (String.length line - value_start) ))
+;;
+
+let require_clock_when_idle ~site ~clock ~idle_timeout =
+  match clock, idle_timeout with
+  | None, Some _ ->
+    (* Fail-loud contract: a configured idle deadline with no clock used
+       to silently disarm and leave a stalled stream blocking forever
+       (the read_sse idle-disarm bug family). Misconfiguration must fail
+       at the call site, not at 3 a.m. as a hung fiber. *)
+    invalid_arg
+      (site
+       ^ ": idle_timeout is set but no clock was supplied — the idle deadline \
+          would be silently disarmed (pass ?clock, or drop ?idle_timeout)")
+  | Some _, _ | None, None -> ()
+;;
+
 let read_sse ?clock ?idle_timeout ~reader ~on_data () =
-  (* SSE keepalive comments (lines starting with ":" per W3C
-     EventSource) carry no payload. Skipping them inside the SAME
-     [with_timeout_exn] window preserves the idle deadline so a
+  require_clock_when_idle ~site:"read_sse" ~clock ~idle_timeout;
+  (* SSE keepalive comments carry no payload. Skipping them inside the
+     SAME [with_timeout_exn] window preserves the idle deadline so a
      provider that emits only keepalives still trips [idle_timeout]
      when no real event arrives. *)
-  let is_keepalive_comment line = String.length line > 0 && line.[0] = ':' in
   let read_meaningful_line () =
     let rec inner () =
-      let line = Eio.Buf_read.line reader in
-      if is_keepalive_comment line then inner () else line
+      match parse_sse_line (Eio.Buf_read.line reader) with
+      | Sse_comment -> inner ()
+      | (Sse_blank | Sse_field _) as parsed -> parsed
     in
     match clock, idle_timeout with
     | Some c, Some t -> Eio.Time.with_timeout_exn c t inner
-    | Some _, None | None, Some _ | None, None -> inner ()
+    | Some _, None | None, None -> inner ()
+    | None, Some _ ->
+      (* Rejected by [require_clock_when_idle] above. *)
+      assert false
   in
   let current_event_type = ref None in
   let rec loop () =
     match read_meaningful_line () with
-    | line ->
-      let len = String.length line in
-      if len = 0
-      then current_event_type := None
-      else if len > 7 && String.sub line 0 7 = "event: "
-      then current_event_type := Some (String.sub line 7 (len - 7))
-      else if len > 6 && String.sub line 0 6 = "data: "
-      then (
-        let data = String.sub line 6 (len - 6) in
-        on_data ~event_type:!current_event_type data);
+    | Sse_blank ->
+      current_event_type := None;
+      loop ()
+    | Sse_comment ->
+      (* Filtered inside [read_meaningful_line]. *)
+      loop ()
+    | Sse_field ("event", value) ->
+      current_event_type := Some value;
+      loop ()
+    | Sse_field ("data", value) ->
+      (* Empty data is dispatched rather than dropped: the downstream
+         accumulator surfaces unparsable payloads as SSEParseFailed
+         events, which beats making protocol garbage invisible here. *)
+      on_data ~event_type:!current_event_type value;
+      loop ()
+    | Sse_field (_, _) ->
+      (* "id" / "retry" are valid EventSource fields this client
+         deliberately does not use (no reconnect support); unknown
+         field names are ignored per spec. *)
       loop ()
     | exception End_of_file -> ()
   in
@@ -799,10 +858,14 @@ let read_sse ?clock ?idle_timeout ~reader ~on_data () =
     wrapped in [Eio.Time.with_timeout_exn] so a stalled stream raises
     [Eio.Time.Timeout] after [idle_timeout] seconds of silence. *)
 let read_ndjson ?clock ?idle_timeout ~reader ~on_line () =
+  require_clock_when_idle ~site:"read_ndjson" ~clock ~idle_timeout;
   let read_line () =
     match clock, idle_timeout with
     | Some c, Some t -> Eio.Time.with_timeout_exn c t (fun () -> Eio.Buf_read.line reader)
-    | Some _, None | None, Some _ | None, None -> Eio.Buf_read.line reader
+    | Some _, None | None, None -> Eio.Buf_read.line reader
+    | None, Some _ ->
+      (* Rejected by [require_clock_when_idle] above. *)
+      assert false
   in
   let rec loop () =
     match read_line () with

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -258,21 +258,31 @@ val with_post_stream
   -> ('a, http_error) result
 
 (** Read SSE-formatted lines from a reader.
-    Strips [data: ] prefixes and passes the payload to [on_data].
-    Tracks [event: ] lines and provides the current event type.
-    Returns normally on [End_of_file].
+
+    Field lines are parsed per the W3C EventSource grammar
+    ("name[:[ ]value]" — at most one leading space stripped from the
+    value), so both [data: x] and [data:x] dispatch. [event:] sets the
+    current event type; [data:] payloads (including empty ones) go to
+    [on_data]; [id]/[retry] and unknown field names are ignored; a
+    blank line resets the event type. Returns normally on
+    [End_of_file].
+
+    [on_data] runs OUTSIDE the idle-timeout window: it must not block —
+    a parked handler silences the idle deadline for the whole stream.
 
     When both [clock] and [idle_timeout] are supplied, raises
     [Eio.Time.Timeout] if no line arrives within [idle_timeout]
     seconds. The deadline resets after each successful meaningful
     line, so this bounds inter-event idle — not total stream
-    duration. SSE keepalive comments (lines starting with [:] per
-    the W3C EventSource spec) are skipped inside the same timeout
-    window — they do NOT reset the deadline, so a stream of pure
-    keepalives still trips [idle_timeout]. Wrapped by
-    {!with_post_stream} the timeout should be caught by the caller and
-    surfaced as [TimeoutError { phase = Stream_idle state; _ }] so
-    downstream policy can see which stream state stalled. *)
+    duration. SSE keepalive comments (lines starting with [:]) are
+    skipped inside the same timeout window — they do NOT reset the
+    deadline, so a stream of pure keepalives still trips
+    [idle_timeout]. Supplying [idle_timeout] WITHOUT [clock] raises
+    [Invalid_argument]: that combination used to silently disarm the
+    deadline. Wrapped by {!with_post_stream} the timeout should be
+    caught by the caller and surfaced as
+    [TimeoutError { phase = Stream_idle state; _ }] so downstream
+    policy can see which stream state stalled. *)
 val read_sse
   :  ?clock:_ Eio.Time.clock
   -> ?idle_timeout:float
@@ -288,10 +298,11 @@ val read_sse
     When both [clock] and [idle_timeout] are supplied, raises
     [Eio.Time.Timeout] if no line arrives within [idle_timeout]
     seconds. The deadline resets after each successful line, so this
-    bounds inter-line idle — not total stream duration. The raised
-    timeout should be caught by the caller and surfaced as
-    [TimeoutError { phase = Stream_idle state; _ }] so downstream
-    policy can see which stream state stalled. *)
+    bounds inter-line idle — not total stream duration. Supplying
+    [idle_timeout] WITHOUT [clock] raises [Invalid_argument] (silent
+    disarm removed). The raised timeout should be caught by the caller
+    and surfaced as [TimeoutError { phase = Stream_idle state; _ }] so
+    downstream policy can see which stream state stalled. *)
 val read_ndjson
   :  ?clock:_ Eio.Time.clock
   -> ?idle_timeout:float

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -100,6 +100,78 @@ let test_read_sse_done_marker () =
   Alcotest.(check string) "data is DONE" "[DONE]" (snd (List.hd !events))
 ;;
 
+(* Spec-valid field lines WITHOUT the optional space after ':' used to be
+   silently dropped by the literal "data: " / "event: " prefix match — a
+   provider or proxy omitting the space made the whole stream vanish. *)
+let test_read_sse_no_space_after_colon () =
+  Eio_main.run
+  @@ fun _env ->
+  let input = "event:message\ndata:hello\n\n" in
+  let flow = Eio.Flow.string_source input in
+  let reader = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) flow in
+  let events = ref [] in
+  Http_client.read_sse
+    ~reader
+    ~on_data:(fun ~event_type data -> events := (event_type, data) :: !events)
+    ();
+  Alcotest.(check int) "1 event" 1 (List.length !events);
+  let ev = List.hd !events in
+  Alcotest.(check (option string)) "event type without space" (Some "message") (fst ev);
+  Alcotest.(check string) "data without space" "hello" (snd ev)
+;;
+
+let test_read_sse_ignores_id_and_retry_fields () =
+  Eio_main.run
+  @@ fun _env ->
+  let input = "id: 42\nretry: 3000\ndata: payload\n\n" in
+  let flow = Eio.Flow.string_source input in
+  let reader = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) flow in
+  let events = ref [] in
+  Http_client.read_sse
+    ~reader
+    ~on_data:(fun ~event_type data -> events := (event_type, data) :: !events)
+    ();
+  Alcotest.(check int) "only the data field dispatches" 1 (List.length !events);
+  Alcotest.(check string) "payload intact" "payload" (snd (List.hd !events))
+;;
+
+let test_read_sse_comment_lines_skipped () =
+  Eio_main.run
+  @@ fun _env ->
+  let input = ": keepalive\n: another\ndata: real\n\n" in
+  let flow = Eio.Flow.string_source input in
+  let reader = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) flow in
+  let events = ref [] in
+  Http_client.read_sse
+    ~reader
+    ~on_data:(fun ~event_type data -> events := (event_type, data) :: !events)
+    ();
+  Alcotest.(check int) "comments are not events" 1 (List.length !events);
+  Alcotest.(check string) "real payload" "real" (snd (List.hd !events))
+;;
+
+(* idle_timeout without clock used to silently disarm the deadline (a
+   stalled stream blocked forever); it is now a loud misconfiguration. *)
+let test_read_sse_idle_without_clock_raises () =
+  Eio_main.run
+  @@ fun _env ->
+  let flow = Eio.Flow.string_source "data: x\n\n" in
+  let reader = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) flow in
+  match
+    Http_client.read_sse
+      ~idle_timeout:1.0
+      ~reader
+      ~on_data:(fun ~event_type:_ _ -> ())
+      ()
+  with
+  | () -> Alcotest.fail "expected Invalid_argument for idle_timeout without clock"
+  | exception Invalid_argument msg ->
+    Alcotest.(check bool)
+      "message names the disarm hazard"
+      true
+      (Util.contains_substring_ci ~haystack:msg ~needle:"idle_timeout")
+;;
+
 let test_post_stream_invalid_url_returns_network_error () =
   Eio_main.run
   @@ fun env ->
@@ -394,6 +466,22 @@ let () =
       , [ Alcotest.test_case "basic events" `Quick test_read_sse_basic
         ; Alcotest.test_case "empty lines" `Quick test_read_sse_empty_lines
         ; Alcotest.test_case "DONE marker" `Quick test_read_sse_done_marker
+        ; Alcotest.test_case
+            "no space after colon (spec grammar)"
+            `Quick
+            test_read_sse_no_space_after_colon
+        ; Alcotest.test_case
+            "id/retry fields ignored"
+            `Quick
+            test_read_sse_ignores_id_and_retry_fields
+        ; Alcotest.test_case
+            "comment lines skipped"
+            `Quick
+            test_read_sse_comment_lines_skipped
+        ; Alcotest.test_case
+            "idle_timeout without clock raises"
+            `Quick
+            test_read_sse_idle_without_clock_raises
         ; Alcotest.test_case
             "invalid url returns network error"
             `Quick


### PR DESCRIPTION
## 문제

masc keeper fleet freeze RCA(2026-06-10, masc PR #20677) 중 발견된 SSE 읽기 경로의 silent failure 2종:

**① 인덱스 산술 필드 매칭** — `read_sse`가 `String.sub line 0 7 = "event: "` / `len > 6 && sub 0 6 = "data: "` 리터럴 prefix 비교로 파싱. W3C EventSource 문법상 콜론 뒤 공백은 **선택**인데(`data:foo`도 유효), 공백 없는 라인은 **무음으로 폐기**됨 — 공백을 생략하는 provider/proxy를 만나면 스트림 전체가 흔적 없이 증발하는 경로.

**② idle-without-clock silent disarm** — `read_sse`/`read_ndjson`이 `idle_timeout=Some` + `clock=None` 조합에서 데드라인을 조용히 무장해제 (0.205.x에서 잡은 streaming idle disarm과 같은 버그 패밀리). 스트림이 멈추면 fiber가 영원히 블록.

## 변경

- 필드 라인을 typed `sse_line` variant(`Sse_blank | Sse_comment | Sse_field of name * value`)로 스펙 문법 파싱: 선택적 공백 1개 strip, `event:`/`data:` dispatch, `id`/`retry`/unknown 필드는 스펙대로 무시, keepalive comment는 기존처럼 idle 윈도 **내부**에서 skip(데드라인 리셋 안 함). 빈 data는 드랍 대신 dispatch — 하류 accumulator가 `SSEParseFailed`로 가시화.
- `read_sse`/`read_ndjson`: `idle_timeout` Some + `clock` None → `Invalid_argument` (fail-loud).
- `complete_stream_http`: 기본값 `Some 60.0`은 **clock이 있을 때만** 제조 (clock-less 호출자는 원래도 사실상 보호가 없었음 — 이제 시그니처에서 보임). 명시적 idle + clock 부재는 호출자 버그로 loud 유지.

기존 dispatch 의미론(이벤트별 즉시 dispatch, blank에서 event type 리셋)은 보존 — multi-line data 누적은 비범위 (mli에 명시).

## 검증

- `scripts/dune-local.sh build lib` clean
- `test_http_client` 22/22 (+4 신규: no-space 문법 / id·retry 무시 / comment skip / idle-without-clock raise)
- `test_complete_http` 25/25 — "sse ok"·"streaming metrics"가 게이트 도입 직후 실패했는데, 이는 **clock 없이 idle 기본값이 read_sse에 도달하던 잠재 disarm 경로가 정확히 드러난 것** (complete_stream_http 기본값 수정으로 해소)
- `test_streaming` 32/32, `test_agent_stream` 28/28, `test_provider_complete` 37/37, `test_complete_ext` 21/21, `test_stream_accumulator` 23/23, `test_sse_parser` 8/8, `test_streaming_cut_cleanup` 2/2 (e2e는 `LLAMA_LIVE_TEST` 게이트 skip)

## 참고

- masc측 RCA/수정: jeong-sik/masc#20677
- 잔존 알려진 disarm 지점(비범위, 후속): `agent.ml with_optional_timeout`(clock None → max_execution/execution_idle 무효), `pipeline_stage_route.dispatch_stream` clock-None 분기 — 이 분기는 이제 idle이 명시 설정된 경우 read_sse에서 loud하게 드러남.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
