### PR TITLE
style: ocamlformat http_client.ml + test_http_client.ml (pinned 0.29.0)

### DIFF
--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -798,8 +798,8 @@ let require_clock_when_idle ~site ~clock ~idle_timeout =
        at the call site, not at 3 a.m. as a hung fiber. *)
     invalid_arg
       (site
-       ^ ": idle_timeout is set but no clock was supplied — the idle deadline \
-          would be silently disarmed (pass ?clock, or drop ?idle_timeout)")
+       ^ ": idle_timeout is set but no clock was supplied — the idle deadline would be \
+          silently disarmed (pass ?clock, or drop ?idle_timeout)")
   | Some _, _ | None, None -> ()
 ;;
 

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -158,11 +158,7 @@ let test_read_sse_idle_without_clock_raises () =
   let flow = Eio.Flow.string_source "data: x\n\n" in
   let reader = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) flow in
   match
-    Http_client.read_sse
-      ~idle_timeout:1.0
-      ~reader
-      ~on_data:(fun ~event_type:_ _ -> ())
-      ()
+    Http_client.read_sse ~idle_timeout:1.0 ~reader ~on_data:(fun ~event_type:_ _ -> ()) ()
   with
   | () -> Alcotest.fail "expected Invalid_argument for idle_timeout without clock"
   | exception Invalid_argument msg ->


### PR DESCRIPTION
PR #1989 후속. 두 파일은 main에 pre-existing 포맷 드리프트가 있었고 #1989가 내용을 변경했으므로, 건드린 파일의 드리프트를 핀 버전(ocamlformat 0.29.0 janestreet)으로 해소합니다. 동작 변경 없음 — `dune exec test/test_http_client.exe` 22/22, `test_complete_http` 25/25 green.

배경: #1989 머지 직후 이 커밋을 같은 브랜치에 push했으나 머지가 먼저 끝나 별도 PR로 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
