### PR TITLE
fix(otel): export native metrics

### DIFF
--- a/agent_sdk.opam
+++ b/agent_sdk.opam
@@ -19,6 +19,7 @@ depends: [
   "mirage-crypto-rng" {>= "1.0.0"}
   "ca-certs" {>= "1.0.0"}
   "yojson" {>= "3.0.0" & < "4.0.0"}
+  "otoml" {>= "1.0.5"}
   "ppx_deriving_yojson" {>= "3.10.0"}
   "ppx_deriving" {>= "6.1.0" & < "7.0.0"}
   "ppx_let" {>= "v0.17"}

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -84,10 +84,9 @@ let check_loop_guard agent =
       Some
         (Error.Agent
            (Error.IdleDetected { consecutive_idle_turns = agent.consecutive_idle_turns }))
-    else (
+    else
       (* dummy for SCA: Telemetry_event.Budget_exceeded *)
       check_token_budget agent.state.config agent.state.usage
-    )
 ;;
 
 (* ── Unified run loop ────────────────────────────────────────── *)

--- a/lib/eval_collector.ml
+++ b/lib/eval_collector.ml
@@ -120,6 +120,6 @@ let finalize t =
     t.collector
     { name = "wall_time_s"; value = Float_val elapsed; unit_ = Some "seconds"; tags = [] };
   let metrics = Eval.finalize t.collector in
-  Eval_otel_bridge.emit_run_metrics (Otel_tracer.create_instance ()) metrics;
+  Eval_otel_bridge.emit_run_metrics_default metrics;
   metrics
 ;;

--- a/lib/eval_otel_bridge.ml
+++ b/lib/eval_otel_bridge.ml
@@ -186,6 +186,21 @@ let emit_run_metrics (inst : Otel_tracer.instance) (rm : Eval.run_metrics) : uni
   Otel_tracer.inst_end_span inst span ~ok:(snap.verdict_failed_total = 0)
 ;;
 
+let default_otel_instance : Otel_tracer.instance =
+  { config = Otel_tracer.default_config
+  ; mu = Otel_tracer.Stdlib_mu (Mutex.create ())
+  ; current_spans = []
+  ; completed_spans = []
+  ; metrics = []
+  }
+;;
+
+let default_instance () = default_otel_instance
+
+let emit_run_metrics_default rm =
+  emit_run_metrics default_otel_instance rm
+;;
+
 (* ── JSON export ──────────────────────────────────────────────── *)
 
 let to_metrics_json (snap : metrics_snapshot) : Yojson.Safe.t =
@@ -341,6 +356,27 @@ let%test "emit_run_metrics creates one span" =
   in
   emit_run_metrics inst rm;
   Otel_tracer.inst_completed_count inst = 1
+;;
+
+let%test "emit_run_metrics_default records on shared instance" =
+  let inst = default_instance () in
+  Otel_tracer.inst_clear_metrics inst;
+  ignore (Otel_tracer.inst_flush inst : Otel_tracer.span list);
+  let pass : Harness.verdict =
+    { passed = true; score = None; evidence = []; detail = None }
+  in
+  let rm : Eval.run_metrics =
+    { run_id = "shared"
+    ; agent_name = "eval-agent"
+    ; timestamp = 0.0
+    ; metrics = []
+    ; harness_verdicts = [ pass ]
+    ; trace_summary = None
+    }
+  in
+  emit_run_metrics_default rm;
+  Otel_tracer.inst_get_metrics inst
+  |> List.exists (fun (name, _, _) -> String.equal name "oas.eval.verdict_passed_total")
 ;;
 
 let%test "emit span ok=true when no failures" =

--- a/lib/eval_otel_bridge.ml
+++ b/lib/eval_otel_bridge.ml
@@ -196,10 +196,7 @@ let default_otel_instance : Otel_tracer.instance =
 ;;
 
 let default_instance () = default_otel_instance
-
-let emit_run_metrics_default rm =
-  emit_run_metrics default_otel_instance rm
-;;
+let emit_run_metrics_default rm = emit_run_metrics default_otel_instance rm
 
 (* ── JSON export ──────────────────────────────────────────────── *)
 

--- a/lib/eval_otel_bridge.mli
+++ b/lib/eval_otel_bridge.mli
@@ -54,6 +54,13 @@ val otel_metric_type_to_tracer : string -> Otel_tracer.metric_type
     a summary span named ["eval_metrics"] for correlation. *)
 val emit_run_metrics : Otel_tracer.instance -> Eval.run_metrics -> unit
 
+(** Shared eval telemetry instance used by synchronous eval helpers that do
+    not own an Eio network context. Exporters can drain this instance. *)
+val default_instance : unit -> Otel_tracer.instance
+
+(** Emit eval metrics on {!default_instance}. *)
+val emit_run_metrics_default : Eval.run_metrics -> unit
+
 (** {1 JSON export} *)
 
 (** Produce a JSON array of metric objects for external consumption.

--- a/lib/harness_runner.ml
+++ b/lib/harness_runner.ml
@@ -322,7 +322,7 @@ let collect_metrics
           ; tags = []
           }));
   let metrics = Eval.finalize collector in
-  Eval_otel_bridge.emit_run_metrics (Otel_tracer.create_instance ()) metrics;
+  Eval_otel_bridge.emit_run_metrics_default metrics;
   metrics
 ;;
 
@@ -356,7 +356,7 @@ let grade_case
   List.iter (Eval.record collector) metrics.metrics;
   List.iter (Eval.add_verdict collector) verdicts;
   let metrics = Eval.finalize collector in
-  Eval_otel_bridge.emit_run_metrics (Otel_tracer.create_instance ()) metrics;
+  Eval_otel_bridge.emit_run_metrics_default metrics;
   let status, detail =
     match case_.assertions with
     | [] -> Harness_report.Skip, Some "case had no assertions"

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -119,15 +119,13 @@ let build_request
   let sanitized_messages =
     Backend_openai_serialize.strip_orphaned_tool_results messages
   in
-  let is_deepseek_model model_id =
-    String.starts_with ~prefix:"deepseek" model_id
-  in
+  let is_deepseek_model model_id = String.starts_with ~prefix:"deepseek" model_id in
   let provider_messages =
     let message_serializer =
       match config.kind with
       | Provider_config.Glm -> Backend_openai_serialize.provider_k_messages_of_message
       | Provider_config.OpenAI_compat when is_deepseek_model config.model_id ->
-          Backend_openai_serialize.provider_k_messages_of_message
+        Backend_openai_serialize.provider_k_messages_of_message
       | Provider_config.Anthropic
       | Provider_config.Kimi
       | Provider_config.OpenAI_compat

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -387,7 +387,6 @@ let gemini_capabilities =
 
 (* ── Model-specific overrides (lookup table) ─────────── *)
 
-
 (** Lookup capabilities by provider label string.
 
     Returns [None] for labels outside the recognized set so callers can
@@ -503,8 +502,6 @@ let apply_manifest_entry (entry : Capability_manifest.entry) : capabilities =
   }
 ;;
 
-
-
 let%test "apply_manifest_entry applies thinking_control_format (RFC-OAS-023)" =
   match
     Capability_manifest.of_json
@@ -547,26 +544,41 @@ let apply_catalog_entry (entry : Model_catalog.model_entry) : capabilities =
     max_context_tokens = override_int_opt base.max_context_tokens entry.max_context_tokens
   ; max_output_tokens = override_int_opt base.max_output_tokens entry.max_output_tokens
   ; supports_tools = override_bool base.supports_tools entry.supports_tools
-  ; supports_tool_choice = override_bool base.supports_tool_choice entry.supports_tool_choice
-  ; supports_parallel_tool_calls = override_bool base.supports_parallel_tool_calls entry.supports_parallel_tool_calls
+  ; supports_tool_choice =
+      override_bool base.supports_tool_choice entry.supports_tool_choice
+  ; supports_parallel_tool_calls =
+      override_bool base.supports_parallel_tool_calls entry.supports_parallel_tool_calls
   ; supports_reasoning = override_bool base.supports_reasoning entry.supports_reasoning
-  ; supports_extended_thinking = override_bool base.supports_extended_thinking entry.supports_extended_thinking
-  ; supports_reasoning_budget = override_bool base.supports_reasoning_budget entry.supports_reasoning_budget
-  ; supports_response_format_json = override_bool base.supports_response_format_json entry.supports_response_format_json
-  ; supports_structured_output = override_bool base.supports_structured_output entry.supports_structured_output
-  ; supports_multimodal_inputs = override_bool base.supports_multimodal_inputs entry.supports_multimodal_inputs
-  ; supports_image_input = override_bool base.supports_image_input entry.supports_image_input
-  ; supports_audio_input = override_bool base.supports_audio_input entry.supports_audio_input
-  ; supports_video_input = override_bool base.supports_video_input entry.supports_video_input
-  ; supports_native_streaming = override_bool base.supports_native_streaming entry.supports_native_streaming
-  ; supports_system_prompt = override_bool base.supports_system_prompt entry.supports_system_prompt
+  ; supports_extended_thinking =
+      override_bool base.supports_extended_thinking entry.supports_extended_thinking
+  ; supports_reasoning_budget =
+      override_bool base.supports_reasoning_budget entry.supports_reasoning_budget
+  ; supports_response_format_json =
+      override_bool base.supports_response_format_json entry.supports_response_format_json
+  ; supports_structured_output =
+      override_bool base.supports_structured_output entry.supports_structured_output
+  ; supports_multimodal_inputs =
+      override_bool base.supports_multimodal_inputs entry.supports_multimodal_inputs
+  ; supports_image_input =
+      override_bool base.supports_image_input entry.supports_image_input
+  ; supports_audio_input =
+      override_bool base.supports_audio_input entry.supports_audio_input
+  ; supports_video_input =
+      override_bool base.supports_video_input entry.supports_video_input
+  ; supports_native_streaming =
+      override_bool base.supports_native_streaming entry.supports_native_streaming
+  ; supports_system_prompt =
+      override_bool base.supports_system_prompt entry.supports_system_prompt
   ; supports_caching = override_bool base.supports_caching entry.supports_caching
-  ; supports_prompt_caching = override_bool base.supports_prompt_caching entry.supports_prompt_caching
+  ; supports_prompt_caching =
+      override_bool base.supports_prompt_caching entry.supports_prompt_caching
   ; supports_top_k = override_bool base.supports_top_k entry.supports_top_k
   ; supports_min_p = override_bool base.supports_min_p entry.supports_min_p
   ; supports_seed = override_bool base.supports_seed entry.supports_seed
-  ; supports_computer_use = override_bool base.supports_computer_use entry.supports_computer_use
-  ; supports_code_execution = override_bool base.supports_code_execution entry.supports_code_execution
+  ; supports_computer_use =
+      override_bool base.supports_computer_use entry.supports_computer_use
+  ; supports_code_execution =
+      override_bool base.supports_code_execution entry.supports_code_execution
   ; thinking_control_format =
       (match entry.thinking_control_format with
        | Some s ->
@@ -575,6 +587,8 @@ let apply_catalog_entry (entry : Model_catalog.model_entry) : capabilities =
           | None -> base.thinking_control_format)
        | None -> base.thinking_control_format)
   }
+;;
+
 let for_model_id_static model_id =
   match Model_catalog.global () with
   | Some catalog ->

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -74,17 +74,24 @@ let parse_entry entry_toml =
       ; max_output_tokens = find_int_opt entry_toml [ "max_output_tokens" ]
       ; supports_tools = find_bool_opt entry_toml [ "supports_tools" ]
       ; supports_tool_choice = find_bool_opt entry_toml [ "supports_tool_choice" ]
-      ; supports_parallel_tool_calls = find_bool_opt entry_toml [ "supports_parallel_tool_calls" ]
+      ; supports_parallel_tool_calls =
+          find_bool_opt entry_toml [ "supports_parallel_tool_calls" ]
       ; supports_reasoning = find_bool_opt entry_toml [ "supports_reasoning" ]
-      ; supports_extended_thinking = find_bool_opt entry_toml [ "supports_extended_thinking" ]
-      ; supports_reasoning_budget = find_bool_opt entry_toml [ "supports_reasoning_budget" ]
-      ; supports_response_format_json = find_bool_opt entry_toml [ "supports_response_format_json" ]
-      ; supports_structured_output = find_bool_opt entry_toml [ "supports_structured_output" ]
-      ; supports_multimodal_inputs = find_bool_opt entry_toml [ "supports_multimodal_inputs" ]
+      ; supports_extended_thinking =
+          find_bool_opt entry_toml [ "supports_extended_thinking" ]
+      ; supports_reasoning_budget =
+          find_bool_opt entry_toml [ "supports_reasoning_budget" ]
+      ; supports_response_format_json =
+          find_bool_opt entry_toml [ "supports_response_format_json" ]
+      ; supports_structured_output =
+          find_bool_opt entry_toml [ "supports_structured_output" ]
+      ; supports_multimodal_inputs =
+          find_bool_opt entry_toml [ "supports_multimodal_inputs" ]
       ; supports_image_input = find_bool_opt entry_toml [ "supports_image_input" ]
       ; supports_audio_input = find_bool_opt entry_toml [ "supports_audio_input" ]
       ; supports_video_input = find_bool_opt entry_toml [ "supports_video_input" ]
-      ; supports_native_streaming = find_bool_opt entry_toml [ "supports_native_streaming" ]
+      ; supports_native_streaming =
+          find_bool_opt entry_toml [ "supports_native_streaming" ]
       ; supports_system_prompt = find_bool_opt entry_toml [ "supports_system_prompt" ]
       ; supports_caching = find_bool_opt entry_toml [ "supports_caching" ]
       ; supports_prompt_caching = find_bool_opt entry_toml [ "supports_prompt_caching" ]
@@ -105,8 +112,10 @@ let load_file path =
   let parse_res =
     try Ok (Otoml.Parser.from_file path) with
     | Sys_error msg -> Error (Printf.sprintf "cannot read model catalog %s: %s" path msg)
-    | Otoml.Parse_error (_pos, msg) -> Error (Printf.sprintf "model catalog TOML parse error in %s: %s" path msg)
-    | Failure msg -> Error (Printf.sprintf "model catalog TOML failure in %s: %s" path msg)
+    | Otoml.Parse_error (_pos, msg) ->
+      Error (Printf.sprintf "model catalog TOML parse error in %s: %s" path msg)
+    | Failure msg ->
+      Error (Printf.sprintf "model catalog TOML failure in %s: %s" path msg)
   in
   match parse_res with
   | Error _ as e -> e
@@ -136,11 +145,7 @@ let load_file path =
 let load_runtime_file path =
   match load_file path with
   | Ok catalog ->
-    Diag.info
-      "model_catalog"
-      "loaded %d model entries from %s"
-      (List.length catalog)
-      path;
+    Diag.info "model_catalog" "loaded %d model entries from %s" (List.length catalog) path;
     Some catalog
   | Error msg ->
     Diag.warn "model_catalog" "failed to load %s: %s" path msg;
@@ -163,20 +168,24 @@ let lookup t model_id =
 ;;
 
 let rec find_in_parents filename dir depth =
-  if depth <= 0 then None
-  else
+  if depth <= 0
+  then None
+  else (
     let path = Filename.concat dir filename in
-    if Sys.file_exists path then Some path
-    else
+    if Sys.file_exists path
+    then Some path
+    else (
       let parent = Filename.dirname dir in
-      if parent = dir then None
-      else find_in_parents filename parent (depth - 1)
+      if parent = dir then None else find_in_parents filename parent (depth - 1)))
 ;;
 
 let env_loaded_catalog : t option Lazy.t =
   lazy
     (let env_path = Cli_common_env.get "OAS_MODEL_CATALOG" in
-     let home_opt = try Some (Unix.getenv "HOME") with Not_found -> None in
+     let home_opt =
+       try Some (Unix.getenv "HOME") with
+       | Not_found -> None
+     in
      let cwd = Sys.getcwd () in
      let search_paths =
        [ env_path
@@ -193,9 +202,7 @@ let env_loaded_catalog : t option Lazy.t =
      let rec try_load = function
        | [] -> None
        | path :: rest ->
-         if Sys.file_exists path
-         then load_runtime_file path
-         else try_load rest
+         if Sys.file_exists path then load_runtime_file path else try_load rest
      in
      try_load search_paths)
 ;;

--- a/lib/llm_provider/model_catalog.mli
+++ b/lib/llm_provider/model_catalog.mli
@@ -41,7 +41,6 @@ type t = model_entry list
 val load_file : string -> (t, string) result
 val load_runtime_file : string -> t option
 val lookup : t -> string -> model_entry option
-
 val global : unit -> t option
 val set_global : t -> unit
 val clear_global : unit -> unit

--- a/lib/llm_provider/pricing.ml
+++ b/lib/llm_provider/pricing.ml
@@ -119,12 +119,16 @@ let pricing_for_model_opt model_id =
     (match Model_catalog.global () with
      | Some catalog ->
        (match Model_catalog.lookup catalog model_id with
-        | Some entry when Option.is_some entry.input_per_million && Option.is_some entry.output_per_million ->
+        | Some entry
+          when Option.is_some entry.input_per_million
+               && Option.is_some entry.output_per_million ->
           Some
             ({ input_per_million = Option.get entry.input_per_million
              ; output_per_million = Option.get entry.output_per_million
-             ; cache_write_multiplier = Option.value entry.cache_write_multiplier ~default:1.0
-             ; cache_read_multiplier = Option.value entry.cache_read_multiplier ~default:1.0
+             ; cache_write_multiplier =
+                 Option.value entry.cache_write_multiplier ~default:1.0
+             ; cache_read_multiplier =
+                 Option.value entry.cache_read_multiplier ~default:1.0
              }
              : pricing)
         | _ -> static_pricing_opt_normalized normalized)

--- a/lib/otel_export.ml
+++ b/lib/otel_export.ml
@@ -89,7 +89,8 @@ let build_otlp_body ~service_name (spans : Otel_tracer.span list) : string =
 ;;
 
 let build_otlp_metrics_body ~service_name (metrics : Otel_tracer.metric_entry list)
-  : string =
+  : string
+  =
   let json =
     `Assoc
       [ ( "resourceMetrics"
@@ -109,8 +110,7 @@ let build_otlp_metrics_body ~service_name (metrics : Otel_tracer.metric_entry li
                                 ; "version", `String Sdk_version.version
                                 ] )
                           ; ( "metrics"
-                            , `List (List.map Otel_tracer.metric_entry_to_json metrics)
-                            )
+                            , `List (List.map Otel_tracer.metric_entry_to_json metrics) )
                           ]
                       ] )
                 ]

--- a/lib/otel_export.ml
+++ b/lib/otel_export.ml
@@ -25,10 +25,15 @@ let default_export_config ~endpoint =
 ;;
 
 type export_result =
-  | Exported of { span_count : int }
+  | Exported of
+      { span_count : int
+      ; metric_count : int
+      }
   | Partial_failure of
       { exported : int
       ; dropped : int
+      ; metric_exported : int
+      ; metric_dropped : int
       ; reason : string
       }
   | Failed of { reason : string }
@@ -83,10 +88,64 @@ let build_otlp_body ~service_name (spans : Otel_tracer.span list) : string =
   Yojson.Safe.to_string json
 ;;
 
+let build_otlp_metrics_body ~service_name (metrics : Otel_tracer.metric_entry list)
+  : string =
+  let json =
+    `Assoc
+      [ ( "resourceMetrics"
+        , `List
+            [ `Assoc
+                [ ( "resource"
+                  , `Assoc
+                      [ ( "attributes"
+                        , Otel_tracer.attrs_to_json [ "service.name", service_name ] )
+                      ] )
+                ; ( "scopeMetrics"
+                  , `List
+                      [ `Assoc
+                          [ ( "scope"
+                            , `Assoc
+                                [ "name", `String "agent_sdk.otel_export"
+                                ; "version", `String Sdk_version.version
+                                ] )
+                          ; ( "metrics"
+                            , `List (List.map Otel_tracer.metric_entry_to_json metrics)
+                            )
+                          ]
+                      ] )
+                ]
+            ] )
+      ]
+  in
+  Yojson.Safe.to_string json
+;;
+
 (* ── HTTP POST via cohttp-eio ───────────────────────────────── *)
 
-let post_otlp ~sw ~clock ~client ~config body =
-  let uri = Uri.of_string config.endpoint in
+let replace_suffix s ~suffix ~replacement =
+  let suffix_len = String.length suffix in
+  let len = String.length s in
+  if len >= suffix_len && String.equal (String.sub s (len - suffix_len) suffix_len) suffix
+  then String.sub s 0 (len - suffix_len) ^ replacement
+  else s
+;;
+
+let endpoint_for_signal endpoint signal_path =
+  let uri = Uri.of_string endpoint in
+  let path = Uri.path uri in
+  let path =
+    match path with
+    | "" | "/" -> signal_path
+    | _ ->
+      path
+      |> replace_suffix ~suffix:"/v1/traces" ~replacement:signal_path
+      |> replace_suffix ~suffix:"/v1/metrics" ~replacement:signal_path
+  in
+  Uri.to_string (Uri.with_path uri path)
+;;
+
+let post_otlp ~sw ~clock ~client ~config ~endpoint body =
+  let uri = Uri.of_string endpoint in
   let base_headers =
     Cohttp.Header.of_list ([ "content-type", "application/json" ] @ config.headers)
   in
@@ -111,9 +170,25 @@ let post_otlp ~sw ~clock ~client ~config body =
 
 let export_batch ~sw ~clock ~client ~config ~service_name spans =
   let body = build_otlp_body ~service_name spans in
+  let endpoint = endpoint_for_signal config.endpoint "/v1/traces" in
   let rec attempt n =
-    match post_otlp ~sw ~clock ~client ~config body with
+    match post_otlp ~sw ~clock ~client ~config ~endpoint body with
     | Ok () -> Ok (List.length spans)
+    | Error _ when n < config.max_retries ->
+      let delay = Float.pow 2.0 (Float.of_int n) *. 0.5 in
+      Eio.Time.sleep clock delay;
+      attempt (n + 1)
+    | Error reason -> Error reason
+  in
+  attempt 0
+;;
+
+let export_metrics ~sw ~clock ~client ~config ~service_name metrics =
+  let body = build_otlp_metrics_body ~service_name metrics in
+  let endpoint = endpoint_for_signal config.endpoint "/v1/metrics" in
+  let rec attempt n =
+    match post_otlp ~sw ~clock ~client ~config ~endpoint body with
+    | Ok () -> Ok (List.length metrics)
     | Error _ when n < config.max_retries ->
       let delay = Float.pow 2.0 (Float.of_int n) *. 0.5 in
       Eio.Time.sleep clock delay;
@@ -141,31 +216,47 @@ let rec split_batches max_size acc = function
 ;;
 
 let flush_to_collector ~sw ~clock ~net ~config instance =
-  (* Spans are flushed from the tracer upfront. If export fails, spans are
+  (* Telemetry is flushed from the tracer upfront. If export fails, data is
      dropped (not re-queued). Callers should treat [Partial_failure] and
-     [Failed] as permanent span loss for the affected batches. *)
+     [Failed] as permanent telemetry loss for the affected batches. *)
   let spans = Otel_tracer.inst_flush instance in
-  if spans = []
-  then Exported { span_count = 0 }
+  let metrics = Otel_tracer.inst_drain_metrics instance in
+  if spans = [] && metrics = []
+  then Exported { span_count = 0; metric_count = 0 }
   else (
     let client = make_client ~net in
     let service_name = instance.Otel_tracer.config.service_name in
     let batches = split_batches config.max_batch_size [] spans in
-    let total = List.length spans in
-    let exported = ref 0 in
+    let span_total = List.length spans in
+    let metric_total = List.length metrics in
+    let exported_spans = ref 0 in
+    let exported_metrics = ref 0 in
     let last_error = ref "" in
     List.iter
       (fun batch ->
          match export_batch ~sw ~clock ~client ~config ~service_name batch with
-         | Ok count -> exported := !exported + count
+         | Ok count -> exported_spans := !exported_spans + count
          | Error reason -> last_error := reason)
       batches;
-    if !exported = total
-    then Exported { span_count = total }
-    else if !exported > 0
+    (match metrics with
+     | [] -> ()
+     | _ ->
+       (match export_metrics ~sw ~clock ~client ~config ~service_name metrics with
+        | Ok count -> exported_metrics := !exported_metrics + count
+        | Error reason -> last_error := reason));
+    let total = span_total + metric_total in
+    let exported = !exported_spans + !exported_metrics in
+    if exported = total
+    then Exported { span_count = !exported_spans; metric_count = !exported_metrics }
+    else if exported > 0
     then
       Partial_failure
-        { exported = !exported; dropped = total - !exported; reason = !last_error }
+        { exported = !exported_spans
+        ; dropped = span_total - !exported_spans
+        ; metric_exported = !exported_metrics
+        ; metric_dropped = metric_total - !exported_metrics
+        ; reason = !last_error
+        }
     else Failed { reason = !last_error })
 ;;
 
@@ -184,10 +275,10 @@ let start_daemon ~sw ~clock ~net ~config ?on_export instance =
       Eio.Time.sleep clock config.flush_interval_sec;
       let result = flush_to_collector ~sw ~clock ~net ~config instance in
       (match result with
-       | Exported { span_count } ->
-         state.total_exported <- state.total_exported + span_count
-       | Partial_failure { exported; _ } ->
-         state.total_exported <- state.total_exported + exported
+       | Exported { span_count; metric_count } ->
+         state.total_exported <- state.total_exported + span_count + metric_count
+       | Partial_failure { exported; metric_exported; _ } ->
+         state.total_exported <- state.total_exported + exported + metric_exported
        | Failed _ -> ());
       match on_export with
       | Some cb -> cb result
@@ -200,8 +291,10 @@ let start_daemon ~sw ~clock ~net ~config ?on_export instance =
 let force_flush ~sw ~clock ~net t =
   let result = flush_to_collector ~sw ~clock ~net ~config:t.config t.instance in
   (match result with
-   | Exported { span_count } -> t.total_exported <- t.total_exported + span_count
-   | Partial_failure { exported; _ } -> t.total_exported <- t.total_exported + exported
+   | Exported { span_count; metric_count } ->
+     t.total_exported <- t.total_exported + span_count + metric_count
+   | Partial_failure { exported; metric_exported; _ } ->
+     t.total_exported <- t.total_exported + exported + metric_exported
    | Failed _ -> ());
   result
 ;;

--- a/lib/otel_export.mli
+++ b/lib/otel_export.mli
@@ -23,23 +23,28 @@ val default_export_config : endpoint:string -> export_config
 (** {1 Export result} *)
 
 type export_result =
-  | Exported of { span_count : int }
+  | Exported of
+      { span_count : int
+      ; metric_count : int
+      }
   | Partial_failure of
       { exported : int
       ; dropped : int
+      ; metric_exported : int
+      ; metric_dropped : int
       ; reason : string
       }
   | Failed of { reason : string }
 
 (** {1 One-shot export} *)
 
-(** Flush all completed spans from [instance] and POST them to the
+(** Flush all completed spans and metrics from [instance] and POST them to the
     configured OTLP endpoint. Does not start a background fiber.
 
-    Spans are dequeued from the tracer before export. On partial or
-    total export failure the affected spans are dropped (not re-queued);
+    Spans and metrics are dequeued from the tracer before export. On partial or
+    total export failure the affected data is dropped (not re-queued);
     callers should treat [Partial_failure] and [Failed] as permanent
-    span loss for those batches. *)
+    telemetry loss for those batches. *)
 val flush_to_collector
   :  sw:Eio.Switch.t
   -> clock:_ Eio.Time.clock
@@ -72,13 +77,19 @@ val force_flush
   -> t
   -> export_result
 
-(** Total spans exported since start. *)
+(** Total telemetry items exported since start. *)
 val total_exported : t -> int
 
 (** {1 Testing helpers — exposed for unit tests} *)
 
 (** Build an OTLP JSON body from a list of spans. *)
 val build_otlp_body : service_name:string -> Otel_tracer.span list -> string
+
+(** Build an OTLP JSON body from a list of metrics. *)
+val build_otlp_metrics_body
+  :  service_name:string
+  -> Otel_tracer.metric_entry list
+  -> string
 
 (** Split a span list into batches of at most [max_size]. *)
 val split_batches

--- a/lib/otel_tracer.ml
+++ b/lib/otel_tracer.ml
@@ -300,6 +300,14 @@ let inst_get_metrics inst =
   @@ fun () -> List.map (fun m -> m.m_name, m.m_value, m.m_type) (List.rev inst.metrics)
 ;;
 
+let inst_drain_metrics inst =
+  inst_with_lock inst
+  @@ fun () ->
+  let metrics = List.rev inst.metrics in
+  inst.metrics <- [];
+  metrics
+;;
+
 let inst_clear_metrics inst = inst_with_lock inst @@ fun () -> inst.metrics <- []
 
 let metric_type_to_string = function

--- a/lib/otel_tracer.mli
+++ b/lib/otel_tracer.mli
@@ -118,6 +118,9 @@ val inst_record_metric
 (** Retrieve all recorded metrics as [(name, value, type)] triples. *)
 val inst_get_metrics : instance -> (string * float * metric_type) list
 
+(** Drain and clear all recorded metrics from the instance. *)
+val inst_drain_metrics : instance -> metric_entry list
+
 (** Clear all recorded metrics from the instance. *)
 val inst_clear_metrics : instance -> unit
 

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -167,7 +167,17 @@ let of_config_streaming (provider_cfg : Provider.config)
     let module SP = struct
       include Base
 
-      let create_message_stream ~sw ~net ?clock ?idle_timeout ~config ~messages ?tools ~on_event () =
+      let create_message_stream
+            ~sw
+            ~net
+            ?clock
+            ?idle_timeout
+            ~config
+            ~messages
+            ?tools
+            ~on_event
+            ()
+        =
         Streaming.create_message_stream
           ~sw
           ~net

--- a/lib/sandbox_runner.ml
+++ b/lib/sandbox_runner.ml
@@ -202,7 +202,7 @@ let run ~config ~agent_name ~model ~prompt ~run_fn =
     collector
     { name = "success"; value = Bool_val success; unit_ = None; tags = [] };
   let metrics = Eval.finalize collector in
-  Eval_otel_bridge.emit_run_metrics (Otel_tracer.create_instance ()) metrics;
+  Eval_otel_bridge.emit_run_metrics_default metrics;
   (* Generate verdicts *)
   let verdicts =
     let budget_ok = state.tool_call_count <= config.max_tool_calls in

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -165,8 +165,6 @@ let pp_gemini_family ppf = function
 
 let gemini_family_testable = Alcotest.testable pp_gemini_family ( = )
 
-
-
 let test_gemini_family_3_1 () =
   check
     gemini_family_testable
@@ -231,8 +229,6 @@ let test_gemini_family_drives_capabilities () =
     (ctx "gemini-3.1-pro-preview");
   check (option int) "gemini-2.5-flash ctx" (Some 1_000_000) (ctx "gemini-2.5-flash")
 ;;
-
-
 
 let test_lookup_provider_c_k2_cloud () =
   match Capabilities.for_model_id "kimi-k2.6:cloud" with
@@ -843,7 +839,6 @@ let () =
             "gemini_family drives 1M ctx capabilities"
             `Quick
             test_gemini_family_drives_capabilities
-
         ; test_case "kimi-k2 cloud" `Quick test_lookup_provider_c_k2_cloud
         ; test_case "dashscope" `Quick test_lookup_provider_m
         ; test_case "dashscope runpod name" `Quick test_lookup_provider_m_runpod_name

--- a/test/test_eval_otel_bridge.ml
+++ b/test/test_eval_otel_bridge.ml
@@ -64,7 +64,8 @@ let () =
     let rm = make_run_metrics ~verdicts:[ make_verdict ~passed:true () ] () in
     Eval_otel_bridge.emit_run_metrics_default rm;
     let metrics = Otel_tracer.inst_get_metrics inst in
-    check bool
+    check
+      bool
       "shared instance has eval metric"
       true
       (List.exists

--- a/test/test_eval_otel_bridge.ml
+++ b/test/test_eval_otel_bridge.ml
@@ -57,12 +57,30 @@ let () =
       check string "agent name tag" "test-agent" agent_name
     | _ -> fail "expected JSON list"
   in
+  let test_default_instance_records_metrics () =
+    let inst = Eval_otel_bridge.default_instance () in
+    Otel_tracer.inst_clear_metrics inst;
+    ignore (Otel_tracer.inst_flush inst : Otel_tracer.span list);
+    let rm = make_run_metrics ~verdicts:[ make_verdict ~passed:true () ] () in
+    Eval_otel_bridge.emit_run_metrics_default rm;
+    let metrics = Otel_tracer.inst_get_metrics inst in
+    check bool
+      "shared instance has eval metric"
+      true
+      (List.exists
+         (fun (name, _, _) -> String.equal name "oas.eval.verdict_passed_total")
+         metrics)
+  in
   run
     "Eval_otel_bridge (external)"
     [ ( "module access"
       , [ test_case "extract accessible" `Quick test_extract_accessible
         ; test_case "metric list count" `Quick test_metric_list_count
         ; test_case "json export" `Quick test_json_export
+        ; test_case
+            "default instance records metrics"
+            `Quick
+            test_default_instance_records_metrics
         ] )
     ]
 ;;

--- a/test/test_otel_export.ml
+++ b/test/test_otel_export.ml
@@ -300,10 +300,7 @@ let test_flush_to_collector_exports_metrics () =
       ~value:0.75
       ~metric_type:Otel_tracer.Gauge;
     let config =
-      { (default_export_config ~endpoint) with
-        max_retries = 0
-      ; timeout_sec = 2.0
-      }
+      { (default_export_config ~endpoint) with max_retries = 0; timeout_sec = 2.0 }
     in
     match flush_to_collector ~sw ~clock ~net ~config instance with
     | Exported { span_count; metric_count } ->

--- a/test/test_otel_export.ml
+++ b/test/test_otel_export.ml
@@ -89,6 +89,25 @@ let body_has_service_name expected body =
     attrs
 ;;
 
+let body_has_metric expected body =
+  let open Yojson.Safe.Util in
+  let metrics =
+    body
+    |> Yojson.Safe.from_string
+    |> member "resourceMetrics"
+    |> to_list
+    |> List.hd
+    |> member "scopeMetrics"
+    |> to_list
+    |> List.hd
+    |> member "metrics"
+    |> to_list
+  in
+  List.exists
+    (fun metric -> String.equal (metric |> member "name" |> to_string) expected)
+    metrics
+;;
+
 (* ── Config tests ────────────────────────────────────────────── *)
 
 let test_default_config () =
@@ -217,7 +236,9 @@ let test_flush_empty_instance () =
   let config = default_export_config ~endpoint:"http://localhost:19999/v1/traces" in
   let result = flush_to_collector ~sw ~clock ~net ~config instance in
   match result with
-  | Exported { span_count } -> Alcotest.(check int) "0 spans exported" 0 span_count
+  | Exported { span_count; metric_count } ->
+    Alcotest.(check int) "0 spans exported" 0 span_count;
+    Alcotest.(check int) "0 metrics exported" 0 metric_count
   | _ -> Alcotest.fail "expected Exported for empty flush"
 ;;
 
@@ -244,8 +265,9 @@ let test_flush_to_collector_exports_batches () =
       }
     in
     match flush_to_collector ~sw ~clock ~net ~config instance with
-    | Exported { span_count } ->
+    | Exported { span_count; metric_count } ->
       Alcotest.(check int) "exported spans" 3 span_count;
+      Alcotest.(check int) "exported metrics" 0 metric_count;
       Alcotest.(check int) "two batches posted" 2 !request_count;
       Alcotest.(check int) "spans drained" 0 (Otel_tracer.inst_completed_count instance);
       Alcotest.(check (list string))
@@ -258,6 +280,47 @@ let test_flush_to_collector_exports_batches () =
         (List.exists (body_has_service_name "otel-export-success") !bodies)
     | Partial_failure _ -> Alcotest.fail "expected full export, got partial failure"
     | Failed { reason } -> Alcotest.failf "expected full export, got failure: %s" reason)
+;;
+
+let test_flush_to_collector_exports_metrics () =
+  let request_count = ref 0 in
+  let request_paths = ref [] in
+  let bodies = ref [] in
+  let handler _conn req body =
+    incr request_count;
+    request_paths := Uri.path (Cohttp.Request.uri req) :: !request_paths;
+    bodies := read_request_body body :: !bodies;
+    Cohttp_eio.Server.respond_string ~status:`OK ~body:"{}" ()
+  in
+  with_mock_collector ~port:18356 handler (fun ~sw ~clock ~net ~endpoint ->
+    let instance = make_instance ~service_name:"otel-export-metrics" () in
+    Otel_tracer.inst_record_metric
+      instance
+      ~name:"oas.eval.coverage"
+      ~value:0.75
+      ~metric_type:Otel_tracer.Gauge;
+    let config =
+      { (default_export_config ~endpoint) with
+        max_retries = 0
+      ; timeout_sec = 2.0
+      }
+    in
+    match flush_to_collector ~sw ~clock ~net ~config instance with
+    | Exported { span_count; metric_count } ->
+      Alcotest.(check int) "no spans" 0 span_count;
+      Alcotest.(check int) "one metric" 1 metric_count;
+      Alcotest.(check int) "one request" 1 !request_count;
+      Alcotest.(check (list string)) "metric path" [ "/v1/metrics" ] !request_paths;
+      Alcotest.(check int)
+        "metrics drained"
+        0
+        (List.length (Otel_tracer.inst_get_metrics instance));
+      Alcotest.(check bool)
+        "body carries metric"
+        true
+        (List.exists (body_has_metric "oas.eval.coverage") !bodies)
+    | Partial_failure _ -> Alcotest.fail "expected metric export success"
+    | Failed { reason } -> Alcotest.failf "expected metric export success: %s" reason)
 ;;
 
 let test_flush_to_collector_reports_partial_failure () =
@@ -282,9 +345,11 @@ let test_flush_to_collector_reports_partial_failure () =
       }
     in
     match flush_to_collector ~sw ~clock ~net ~config instance with
-    | Partial_failure { exported; dropped; reason } ->
+    | Partial_failure { exported; dropped; metric_exported; metric_dropped; reason } ->
       Alcotest.(check int) "exported first batch" 2 exported;
       Alcotest.(check int) "dropped failed batch" 1 dropped;
+      Alcotest.(check int) "no metric exported" 0 metric_exported;
+      Alcotest.(check int) "no metric dropped" 0 metric_dropped;
       Alcotest.(check string) "reason" "HTTP 500" reason
     | Exported _ -> Alcotest.fail "expected partial failure"
     | Failed { reason } -> Alcotest.failf "expected partial failure, got %s" reason)
@@ -332,8 +397,9 @@ let test_force_flush_updates_total_exported () =
     let exporter = start_daemon ~sw ~clock ~net ~config instance in
     Alcotest.(check int) "initial total" 0 (total_exported exporter);
     match force_flush ~sw ~clock ~net exporter with
-    | Exported { span_count } ->
+    | Exported { span_count; metric_count } ->
       Alcotest.(check int) "force span count" 2 span_count;
+      Alcotest.(check int) "force metric count" 0 metric_count;
       Alcotest.(check int) "total exported" 2 (total_exported exporter)
     | Partial_failure _ -> Alcotest.fail "expected force flush success"
     | Failed { reason } -> Alcotest.failf "expected force flush success: %s" reason)
@@ -343,16 +409,28 @@ let test_force_flush_updates_total_exported () =
 
 let test_export_result_variants () =
   (* Verify constructors are well-formed *)
-  let e = Exported { span_count = 5 } in
-  let p = Partial_failure { exported = 3; dropped = 2; reason = "timeout" } in
+  let e = Exported { span_count = 5; metric_count = 7 } in
+  let p =
+    Partial_failure
+      { exported = 3
+      ; dropped = 2
+      ; metric_exported = 4
+      ; metric_dropped = 1
+      ; reason = "timeout"
+      }
+  in
   let f = Failed { reason = "connection refused" } in
   (match e with
-   | Exported { span_count } -> Alcotest.(check int) "exported" 5 span_count
+   | Exported { span_count; metric_count } ->
+     Alcotest.(check int) "exported spans" 5 span_count;
+     Alcotest.(check int) "exported metrics" 7 metric_count
    | _ -> ());
   (match p with
-   | Partial_failure { exported; dropped; _ } ->
+   | Partial_failure { exported; dropped; metric_exported; metric_dropped; _ } ->
      Alcotest.(check int) "partial exported" 3 exported;
-     Alcotest.(check int) "partial dropped" 2 dropped
+     Alcotest.(check int) "partial dropped" 2 dropped;
+     Alcotest.(check int) "partial metric exported" 4 metric_exported;
+     Alcotest.(check int) "partial metric dropped" 1 metric_dropped
    | _ -> ());
   match f with
   | Failed { reason } ->
@@ -435,6 +513,10 @@ let () =
             "exports batches"
             `Quick
             test_flush_to_collector_exports_batches
+        ; Alcotest.test_case
+            "exports metrics"
+            `Quick
+            test_flush_to_collector_exports_metrics
         ; Alcotest.test_case
             "partial failure"
             `Quick

--- a/test/test_streaming_cut_cleanup.ml
+++ b/test/test_streaming_cut_cleanup.ml
@@ -28,10 +28,7 @@ let outer_budget_s = 5.0
 let bounded_threshold_s = 3.0
 
 let sse_headers =
-  "HTTP/1.1 200 OK\r\n\
-   Content-Type: text/event-stream\r\n\
-   Connection: close\r\n\
-   \r\n"
+  "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n"
 ;;
 
 let drain_request_headers flow =
@@ -59,12 +56,16 @@ let half_close_server ~sw ~net port ~n_lines =
   let addr = `Tcp (Eio.Net.Ipaddr.V4.loopback, port) in
   let listening = Eio.Net.listen ~sw ~backlog:5 ~reuse_addr:true net addr in
   Eio.Fiber.fork ~sw (fun () ->
-    Eio.Net.accept_fork ~sw listening ~on_error:(fun _ -> ()) (fun flow _addr ->
-      drain_request_headers flow;
-      send_prelude flow ~n_lines;
-      Eio.Flow.shutdown flow `Send;
-      (* hold the (now half-closed) fd so teardown is the client's job *)
-      Eio_unix.sleep (outer_budget_s +. 1.0)))
+    Eio.Net.accept_fork
+      ~sw
+      listening
+      ~on_error:(fun _ -> ())
+      (fun flow _addr ->
+         drain_request_headers flow;
+         send_prelude flow ~n_lines;
+         Eio.Flow.shutdown flow `Send;
+         (* hold the (now half-closed) fd so teardown is the client's job *)
+         Eio_unix.sleep (outer_budget_s +. 1.0)))
 ;;
 
 (* Variant (b): send prelude, then go silent (no FIN) — the inter-event
@@ -73,10 +74,14 @@ let silent_stall_server ~sw ~net port ~n_lines =
   let addr = `Tcp (Eio.Net.Ipaddr.V4.loopback, port) in
   let listening = Eio.Net.listen ~sw ~backlog:5 ~reuse_addr:true net addr in
   Eio.Fiber.fork ~sw (fun () ->
-    Eio.Net.accept_fork ~sw listening ~on_error:(fun _ -> ()) (fun flow _addr ->
-      drain_request_headers flow;
-      send_prelude flow ~n_lines;
-      Eio_unix.sleep (outer_budget_s +. 1.0)))
+    Eio.Net.accept_fork
+      ~sw
+      listening
+      ~on_error:(fun _ -> ())
+      (fun flow _addr ->
+         drain_request_headers flow;
+         send_prelude flow ~n_lines;
+         Eio_unix.sleep (outer_budget_s +. 1.0)))
 ;;
 
 type outcome =
@@ -127,9 +132,9 @@ let assert_bounded ~label ~elapsed ~outcome ~lines ~expect_min_lines =
   if elapsed >= bounded_threshold_s
   then
     Alcotest.failf
-      "[%s] streaming read did not terminate in bounded time: elapsed=%.3fs >= \
-       %.1fs (outcome=%s, lines=%d). The reader hung; the socket would leak in \
-       CLOSE_WAIT until process restart."
+      "[%s] streaming read did not terminate in bounded time: elapsed=%.3fs >= %.1fs \
+       (outcome=%s, lines=%d). The reader hung; the socket would leak in CLOSE_WAIT \
+       until process restart."
       label
       elapsed
       bounded_threshold_s
@@ -149,20 +154,20 @@ let test_half_close_is_bounded () =
   @@ fun env ->
   let net = env#net
   and clock = env#clock in
-  (try
-     Eio.Switch.run (fun sw ->
-       half_close_server ~sw ~net 19751 ~n_lines:3;
-       Eio_unix.sleep 0.2;
-       let outcome, elapsed, lines = run_client ~clock ~net ~port:19751 in
-       assert_bounded
-         ~label:"half-close (FIN mid-stream)"
-         ~elapsed
-         ~outcome
-         ~lines
-         ~expect_min_lines:3;
-       raise Exit)
-   with
-   | Exit -> ())
+  try
+    Eio.Switch.run (fun sw ->
+      half_close_server ~sw ~net 19751 ~n_lines:3;
+      Eio_unix.sleep 0.2;
+      let outcome, elapsed, lines = run_client ~clock ~net ~port:19751 in
+      assert_bounded
+        ~label:"half-close (FIN mid-stream)"
+        ~elapsed
+        ~outcome
+        ~lines
+        ~expect_min_lines:3;
+      raise Exit)
+  with
+  | Exit -> ()
 ;;
 
 let test_silent_stall_is_bounded () =
@@ -170,20 +175,20 @@ let test_silent_stall_is_bounded () =
   @@ fun env ->
   let net = env#net
   and clock = env#clock in
-  (try
-     Eio.Switch.run (fun sw ->
-       silent_stall_server ~sw ~net 19752 ~n_lines:3;
-       Eio_unix.sleep 0.2;
-       let outcome, elapsed, lines = run_client ~clock ~net ~port:19752 in
-       assert_bounded
-         ~label:"silent stall (no FIN)"
-         ~elapsed
-         ~outcome
-         ~lines
-         ~expect_min_lines:3;
-       raise Exit)
-   with
-   | Exit -> ())
+  try
+    Eio.Switch.run (fun sw ->
+      silent_stall_server ~sw ~net 19752 ~n_lines:3;
+      Eio_unix.sleep 0.2;
+      let outcome, elapsed, lines = run_client ~clock ~net ~port:19752 in
+      assert_bounded
+        ~label:"silent stall (no FIN)"
+        ~elapsed
+        ~outcome
+        ~lines
+        ~expect_min_lines:3;
+      raise Exit)
+  with
+  | Exit -> ()
 ;;
 
 let () =
@@ -191,7 +196,10 @@ let () =
   run
     "streaming_cut_cleanup"
     [ ( "bounded_termination"
-      , [ test_case "half-close (FIN) terminates bounded" `Quick test_half_close_is_bounded
+      , [ test_case
+            "half-close (FIN) terminates bounded"
+            `Quick
+            test_half_close_is_bounded
         ; test_case "silent stall terminates bounded" `Quick test_silent_stall_is_bounded
         ] )
     ]


### PR DESCRIPTION
Summary:
- drain and export OAS native metrics to OTLP /v1/metrics
- keep trace export to /v1/traces and normalize collector base endpoints
- route eval metrics through a shared telemetry instance instead of throwaway tracer instances

Tests:
- scripts/dune-local.sh build test/test_otel_export.exe test/test_otel_tracer.exe
- _build/default/test/test_otel_export.exe (rerun with elevated loopback bind permission)
- _build/default/test/test_otel_tracer.exe
- scripts/dune-local.sh build test/test_eval_otel_bridge.exe
- _build/default/test/test_eval_otel_bridge.exe