### PR TITLE
fix(ci): align provider throttle timeout test

### DIFF
--- a/lib/llm_provider/provider_throttle.ml
+++ b/lib/llm_provider/provider_throttle.ml
@@ -270,14 +270,14 @@ let%test "with_permit_timeout releases on exception" =
     available t = 2)
 ;;
 
-let%test "with_permit_timeout raises on timeout without leaking permit" =
+let%test "with_permit_timeout raises on body timeout without leaking scheduler state" =
   Eio_main.run (fun env ->
     let clock = Eio.Stdenv.clock env in
     let t = create ~max_concurrent:1 ~provider_name:"test" in
-    (* Pre-acquire to force contention *)
-    with_permit_priority ~priority:Interactive t (fun () ->
-      let timed_out = ref false in
-      (try with_permit_timeout clock ~timeout_sec:0.05 t (fun () -> ()) with
-       | Eio.Time.Timeout -> timed_out := true);
-      !timed_out))
+    let timed_out = ref false in
+    (try
+       with_permit_timeout clock ~timeout_sec:0.1 t (fun () -> Eio.Time.sleep clock 10.0)
+     with
+     | Eio.Time.Timeout -> timed_out := true);
+    !timed_out && available t = 1 && in_use t = 0)
 ;;

--- a/lib/llm_provider/provider_throttle.mli
+++ b/lib/llm_provider/provider_throttle.mli
@@ -1,8 +1,11 @@
-(** Provider-level concurrency throttle with priority-aware scheduling.
+(** Provider-level throttle facade for OAS request admission.
 
-    Limits concurrent LLM requests per provider to avoid overwhelming
-    backends with limited capacity (e.g. llama-server with N slots).
-    When slots are full, requests are queued by priority.
+    The legacy [with_permit*] entrypoints delegate to the process-wide FD
+    throttle hook. Downstream consumers own provider slot admission and
+    backpressure visibility.
+
+    The explicit turn-level APIs still expose local slot permits for callers
+    that opt into acquire/yield/resume semantics.
 
     @since 0.84.0
 
@@ -20,9 +23,9 @@ type t
     @raise Invalid_argument if [max_concurrent] < 1 *)
 val create : max_concurrent:int -> provider_name:string -> t
 
-(** Run [f] with a permit at the given [priority].
-    If all permits are in use, the request is queued by priority.
-    Higher priority requests are dequeued first.
+(** Run [f] through the configured FD throttle hook.
+    [priority] is accepted for compatibility with pre-consumer-owned admission
+    callers; local provider slots are not acquired here.
     @since 0.96.0 *)
 val with_permit_priority : priority:Request_priority.t -> t -> (unit -> 'a) -> 'a
 
@@ -30,8 +33,8 @@ val with_permit_priority : priority:Request_priority.t -> t -> (unit -> 'a) -> '
     Kept for backward compatibility with pre-scheduling callers. *)
 val with_permit : t -> (unit -> 'a) -> 'a
 
-(** Like {!with_permit_priority} but with a timeout on acquire.
-    @raise Eio.Time.Timeout if permit is not acquired within [timeout_sec].
+(** Like {!with_permit_priority} but bounds the wrapped call.
+    @raise Eio.Time.Timeout if [f] does not complete within [timeout_sec].
     @since 0.91.0 *)
 val with_permit_timeout
   :  _ Eio.Time.clock


### PR DESCRIPTION
## Summary

- Align `Provider_throttle` public docs with current consumer-owned admission semantics.
- Replace the stale timeout inline test that assumed local slot contention with a body-timeout check.
- Assert timeout cancellation leaves the local scheduler state unchanged.

## Validation

- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-provider-throttle-direct opam exec -- dune build --root . @lib/llm_provider/runtest @fmt`
- `git diff --check`

## Notes

- This addresses the `provider_throttle.ml` inline failure seen in the PR #1992 merge CI.
- A broader local `@runtest` run passes this provider_throttle partition but still fails unrelated current-main tests; recorded separately in #1994.
