### PR TITLE
fix(agent): accurate correction_pipeline WARN for the no-correction case

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -396,9 +396,18 @@ let find_and_execute_tool_with_index
                 ]);
             Ok corrected
           | Correction_pipeline.Still_invalid { errors; attempted } ->
+            (* attempted = [] means no deterministic correction was applicable
+               (e.g. a missing required field that coercion cannot synthesize),
+               distinct from corrections having run and the input still being
+               invalid. The previous single message implied fixes always ran. *)
+            let summary =
+              match attempted with
+              | [] -> "correction_pipeline: no deterministic correction applicable"
+              | _ :: _ -> "correction_pipeline still invalid after deterministic fixes"
+            in
             Log.warn
               _log
-              "correction_pipeline still invalid after deterministic fixes"
+              summary
               [ Log.S ("tool", name)
               ; Log.I ("error_count", List.length errors)
               ; Log.I ("attempted_corrections", List.length attempted)


### PR DESCRIPTION
## What

Make the `correction_pipeline` WARN message accurate when no deterministic
correction was applicable.

## Why

`Correction_pipeline.run` returns `Still_invalid { errors; attempted }`. When
`attempted = []`, coercion/format normalization had nothing to apply (e.g. a
missing required field), which is distinct from corrections having run and the
input still being invalid. The previous single message —
`"correction_pipeline still invalid after deterministic fixes"` — implied fixes
always ran, so an operator reading it alongside `attempted_corrections=0` got a
contradictory signal.

This was surfaced while grounding research R11: the pipeline is a sound
deterministic-first -> LLM-feedback design, and `attempted=0` is an honest
"nothing was coercible" signal rather than a no-op bug. Only the log wording
misread it.

## Change

- Select the summary string from `match attempted with [] | _ :: _`.
- Keep WARN severity: a weak helper model emitting non-coercible args is a real
  model-quality signal worth surfacing, not noise to demote.
- `attempted_corrections` structured field, `build_nondet_feedback`, and the
  `Error` return are all unchanged.

No control-flow or behavior change — only the human-readable log line.

## Verification

`scripts/dune-local.sh build @check` green from a clean worktree.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
