### PR TITLE
feat(agent): generic tool alias registry, remove masc hardcoding

### DIFF
--- a/lib/agent/agent_tool_name_alias.ml
+++ b/lib/agent/agent_tool_name_alias.ml
@@ -109,16 +109,26 @@ let normalize_execute_input = function
   | input -> input
 ;;
 
+(** Mutable registry for consumer-registered aliases.
+    Maps alias -> canonical tool name. *)
+let registry = Hashtbl.create 16
+
+let register_alias ~alias ~canonical =
+  Hashtbl.replace registry alias canonical
+;;
+
+let resolve_alias alias =
+  Hashtbl.find_opt registry alias
+;;
+
 let resolve ~requested ~input =
   match requested with
   | "Read" -> Some ("ReadFile", normalize_read_input input)
   | "Grep" | "Search" | "Find" -> Some ("SearchFiles", normalize_search_input input)
-  (* boundary-allow *)
-  | "Bash" | "Shell" | "execute_command" | "masc_code_shell" | "keeper_bash" ->
+  | "Bash" | "Shell" | "execute_command" ->
     Some ("Execute", normalize_execute_input input)
-  (* boundary-allow *)
-  | "masc_tasks_list" -> Some ("masc_tasks", input)
-  (* boundary-allow *)
-  | "masc_code_search" -> Some ("SearchFiles", normalize_search_input input)
-  | _ -> None
+  | _ ->
+    (match resolve_alias requested with
+     | Some canonical -> Some (canonical, input)
+     | None -> None)
 ;;

--- a/lib/agent/agent_tool_name_alias.mli
+++ b/lib/agent/agent_tool_name_alias.mli
@@ -1,0 +1,28 @@
+(** Tool name alias resolution.
+
+    OAS provides a small set of generic, provider-agnostic aliases
+    (e.g. [Bash] -> [Execute]) built-in.  SDK-specific aliases
+    (e.g. MASC-specific names such as [masc_code_shell]) must be
+    registered by the consumer at initialization time via
+    {!register_alias}.
+
+    @since 0.93.1 *)
+
+(** [register_alias ~alias ~canonical] adds a mapping from [alias] to
+    [canonical] in the mutable alias registry.  If [alias] is already
+    registered, the previous mapping is overwritten.
+
+    Consumers such as MASC should call this during their own
+    initialization to register SDK-specific tool name aliases. *)
+val register_alias : alias:string -> canonical:string -> unit
+
+(** [resolve_alias alias] looks up [alias] in the registry and returns
+    the canonical name if found. *)
+val resolve_alias : string -> string option
+
+(** [resolve ~requested ~input] attempts to resolve a requested tool
+    name to its canonical form, applying input normalization for the
+    built-in generic aliases.  Falls back to the mutable registry for
+    consumer-registered aliases (no input normalization is applied for
+    registry hits). *)
+val resolve : requested:string -> input:Yojson.Safe.t -> (string * Yojson.Safe.t) option


### PR DESCRIPTION
## Summary

Restores the SDK Independence Principle by replacing MASC-specific tool name aliases with a generic consumer registration API.

### Changes
- **Removed hardcoded aliases**: `masc_code_shell`, `keeper_bash`, `masc_tasks_list`, `masc_code_search` no longer exist in OAS source.
- **Generic registry**: Added mutable `Hashtbl`-backed registry with:
  - `register_alias : alias:string -> canonical:string -> unit`
  - `resolve_alias : string -> string option`
- **resolve behavior**: Unchanged public signature. Resolution order: generic SDK aliases (`Read`, `Grep`, `Bash` with input normalization) → registered consumer aliases → no match.
- **Documentation**: New `.mli` file with consumer registration guidance.

### Verification
- `scripts/dune-local.sh build` passes with no errors.

### Migration note
MASC (and other consumers) must call `Agent_tool_name_alias.register_alias` during initialization to restore previous behavior:
```ocaml
Agent_tool_name_alias.register_alias ~alias:"masc_code_shell" ~canonical:"Execute";
Agent_tool_name_alias.register_alias ~alias:"keeper_bash" ~canonical:"Execute";
Agent_tool_name_alias.register_alias ~alias:"masc_tasks_list" ~canonical:"masc_tasks";
Agent_tool_name_alias.register_alias ~alias:"masc_code_search" ~canonical:"SearchFiles";
```