### PR TITLE
feat(tracing): MASC↔OAS trace boundary linking (Phase 1-3)

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -26,25 +26,35 @@ type api_strategy = Pipeline.api_strategy =
     Converts Pipeline.turn_outcome to the polymorphic variant interface
     expected by run_loop and the public API. *)
 let run_turn_core ~sw ?clock ~api_strategy ?raw_trace_run agent =
-  let api_strat =
-    match api_strategy with
-    | Sync -> Pipeline.Sync
-    | Stream { on_event; on_telemetry } -> Pipeline.Stream { on_event; on_telemetry }
-  in
-  match Pipeline.run_turn ~sw ?clock ~api_strategy:api_strat ?raw_trace_run agent with
-  | Ok (Pipeline.Complete response) -> Ok (`Complete response)
-  | Ok Pipeline.ToolsExecuted -> Ok `ToolsExecuted
-  | Ok Pipeline.IdleSkipped ->
-    Ok
-      (`Complete
-          { Types.id = "idle-skipped"
-          ; model = ""
-          ; stop_reason = EndTurn
-          ; content = []
-          ; usage = None
-          ; telemetry = None
-          })
-  | Error e -> Error e
+  Tracing.with_span
+    agent.options.tracer
+    { kind = Agent_run
+    ; name = "agent_turn"
+    ; agent_name = agent.state.config.name
+    ; turn = agent.state.turn_count
+    ; extra = []
+    ; links = (match agent.options.trace_link with Some (tid, sid) -> [(tid, sid)] | None -> [])
+    }
+    (fun _tracer ->
+       let api_strat =
+         match api_strategy with
+         | Sync -> Pipeline.Sync
+         | Stream { on_event; on_telemetry } -> Pipeline.Stream { on_event; on_telemetry }
+       in
+       match Pipeline.run_turn ~sw ?clock ~api_strategy:api_strat ?raw_trace_run agent with
+       | Ok (Pipeline.Complete response) -> Ok (`Complete response)
+       | Ok Pipeline.ToolsExecuted -> Ok `ToolsExecuted
+       | Ok Pipeline.IdleSkipped ->
+         Ok
+           (`Complete
+               { Types.id = "idle-skipped"
+               ; model = ""
+               ; stop_reason = EndTurn
+               ; content = []
+               ; usage = None
+               ; telemetry = None
+               })
+       | Error e -> Error e)
 ;;
 
 (* Original run_turn_core implementation removed — now in Pipeline.run_turn.

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -43,6 +43,7 @@ type options = Agent_types.options =
   ; guardrails : Guardrails.t
   ; guardrails_async : Guardrails_async.t
   ; tracer : Tracing.t
+  ; trace_link : (string * string) option
   ; raw_trace : Raw_trace.t option
   ; approval : Hooks.approval_callback option
   ; missing_approval_callback_policy : Hooks.missing_approval_callback_policy

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -234,7 +234,7 @@ let invoke_hook ?on_hook_invoked ~tracer ~agent_name ~turn_count ~hook_name hook
   =
   Tracing.with_span
     tracer
-    { kind = Hook_invoke; name = hook_name; agent_name; turn = turn_count; extra = [] }
+    { kind = Hook_invoke; name = hook_name; agent_name; turn = turn_count; extra = []; links = [] }
     (fun _ ->
        let decision = Hooks.invoke_validated hook_opt event in
        (match on_hook_invoked with
@@ -663,7 +663,7 @@ let execute_scheduled_tool
   let triple =
     Tracing.with_span
       tracer
-      { kind = Tool_exec; name; agent_name; turn = turn_count; extra = [] }
+      { kind = Tool_exec; name; agent_name; turn = turn_count; extra = []; links = [] }
       (fun _tracer ->
          try
            let decision =

--- a/lib/agent/agent_trace.ml
+++ b/lib/agent/agent_trace.ml
@@ -40,6 +40,7 @@ let invoke_hook_with_trace agent ?raw_trace_run ~hook_name hook_opt event =
     ; agent_name = agent.state.config.name
     ; turn = agent.state.turn_count
     ; extra = []
+    ; links = []
     }
     (fun _ ->
        let decision = Hooks.invoke_validated hook_opt event in

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -40,6 +40,9 @@ type options =
   ; guardrails : Guardrails.t
   ; guardrails_async : Guardrails_async.t
   ; tracer : Tracing.t
+  ; trace_link : (string * string) option
+    (** Optional (trace_id, span_id) of a parent span to link to.
+        Used to connect OAS agent turns to an external trace root. *)
   ; raw_trace : Raw_trace.t option
   ; approval : Hooks.approval_callback option
   ; missing_approval_callback_policy : Hooks.missing_approval_callback_policy
@@ -157,6 +160,7 @@ let default_options =
   ; guardrails = Guardrails.default
   ; guardrails_async = Guardrails_async.empty
   ; tracer = Tracing.null
+  ; trace_link = None
   ; raw_trace = None
   ; approval = None
   ; missing_approval_callback_policy = Hooks.Execute_without_callback

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -95,6 +95,7 @@ type options =
   ; guardrails : Guardrails.t
   ; guardrails_async : Guardrails_async.t
   ; tracer : Tracing.t
+  ; trace_link : (string * string) option
   ; raw_trace : Raw_trace.t option
   ; approval : Hooks.approval_callback option
   ; missing_approval_callback_policy : Hooks.missing_approval_callback_policy

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -39,6 +39,7 @@ type t =
   ; guardrails : Guardrails.t
   ; guardrails_async : Guardrails_async.t
   ; tracer : Tracing.t
+  ; trace_link : (string * string) option
   ; raw_trace : Raw_trace.t option
   ; approval : Hooks.approval_callback option
   ; missing_approval_callback_policy : Hooks.missing_approval_callback_policy
@@ -111,6 +112,7 @@ let create ~net ~model =
   ; guardrails = Guardrails.default
   ; guardrails_async = Guardrails_async.empty
   ; tracer = Tracing.null
+  ; trace_link = None
   ; raw_trace = None
   ; approval = None
   ; missing_approval_callback_policy = Hooks.Execute_without_callback
@@ -196,6 +198,7 @@ let with_tools tools b = { b with tools = Tool_set.of_list tools }
 let with_tool tool b = { b with tools = Tool_set.merge b.tools (Tool_set.singleton tool) }
 let with_hooks hooks b = { b with hooks }
 let with_tracer tracer b = { b with tracer }
+let with_trace_link trace_link b = { b with trace_link }
 let with_raw_trace raw_trace b = { b with raw_trace = Some raw_trace }
 let with_approval approval b = { b with approval = Some approval }
 
@@ -412,6 +415,7 @@ let build b =
     ; guardrails = b.guardrails
     ; guardrails_async = b.guardrails_async
     ; tracer = b.tracer
+    ; trace_link = b.trace_link
     ; raw_trace = b.raw_trace
     ; approval = b.approval
     ; missing_approval_callback_policy = b.missing_approval_callback_policy

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -88,6 +88,7 @@ val with_priority : Llm_provider.Request_priority.t -> t -> t
 val with_slot_id : int -> t -> t
 
 val with_tracer : Tracing.t -> t -> t
+val with_trace_link : (string * string) option -> t -> t
 val with_raw_trace : Raw_trace.t -> t -> t
 val with_approval : Hooks.approval_callback -> t -> t
 

--- a/lib/eval_otel_bridge.ml
+++ b/lib/eval_otel_bridge.ml
@@ -170,6 +170,7 @@ let emit_run_metrics (inst : Otel_tracer.instance) (rm : Eval.run_metrics) : uni
     ; agent_name = snap.agent_name
     ; turn = 0
     ; extra = [ "oas.run_id", snap.run_id ]
+    ; links = []
     }
   in
   let span = Otel_tracer.inst_start_span inst span_attrs in
@@ -189,6 +190,7 @@ let emit_run_metrics (inst : Otel_tracer.instance) (rm : Eval.run_metrics) : uni
 let default_otel_instance : Otel_tracer.instance =
   { config = Otel_tracer.default_config
   ; mu = Otel_tracer.Stdlib_mu (Mutex.create ())
+  ; fiber_key = None
   ; current_spans = []
   ; completed_spans = []
   ; metrics = []
@@ -334,6 +336,7 @@ let%test "all metric names start with oas." =
 let _mk_stdlib_inst () : Otel_tracer.instance =
   { config = Otel_tracer.default_config
   ; mu = Otel_tracer.Stdlib_mu (Mutex.create ())
+  ; fiber_key = None
   ; current_spans = []
   ; completed_spans = []
   ; metrics = []

--- a/lib/otel_tracer.ml
+++ b/lib/otel_tracer.ml
@@ -8,7 +8,14 @@
     v0.43.0: Instance-based state — each [create] call returns an
     independent tracer with its own span stack. The global functions
     ([start_span], [flush], etc.) delegate to a shared global instance
-    for backward compatibility. *)
+    for backward compatibility.
+
+    v0.44.0: Fiber-safe Eio instances.  Per-instance [Eio.Fiber.key]
+    stores a [span list ref] so parallel fibers (e.g. tool batches)
+    each have their own active-span stack.  Parent lookups and
+    current-spans mutations are lock-free inside a fiber;
+    [completed_spans] remains mutex-protected because many fibers
+    may finish spans concurrently. *)
 
 (* -- OTel span kind --------------------------------------------------- *)
 
@@ -35,6 +42,11 @@ type otel_event =
   ; attributes : (string * string) list
   }
 
+type otel_link =
+  { trace_id : string
+  ; span_id : string
+  }
+
 type span =
   { trace_id : string
   ; span_id : string
@@ -46,6 +58,7 @@ type span =
   ; status : bool option
   ; attributes : (string * string) list
   ; events : otel_event list
+  ; mutable links : otel_link list
   }
 
 (* -- Config ----------------------------------------------------------- *)
@@ -82,6 +95,7 @@ type mutex_impl =
 type instance =
   { config : config
   ; mu : mutex_impl
+  ; fiber_key : (span list ref) Eio.Fiber.key option
   ; mutable current_spans : span list
   ; mutable completed_spans : span list
   ; mutable metrics : metric_entry list
@@ -157,85 +171,187 @@ let inst_with_lock inst f =
     Fun.protect f ~finally:(fun () -> Mutex.unlock mu)
 ;;
 
+(** Return the fiber-local span-stack ref cell, if we are running inside
+    an Eio fiber that has the instance's [fiber_key] bound. *)
+let get_fiber_stack inst : (span list ref) option =
+  match inst.fiber_key with
+  | None -> None
+  | Some key ->
+    (try
+       match Eio.Fiber.get key with
+       | Some ref -> Some ref
+       | None -> None
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | _ -> None)
+;;
+
 let inst_start_span inst (attrs : Tracing.span_attrs) : span =
   let new_trace_id = gen_trace_id () in
   let span_id = gen_span_id () in
-  inst_with_lock inst
-  @@ fun () ->
-  let parent =
-    match inst.current_spans with
-    | p :: _ -> Some p
-    | [] -> None
-  in
-  let trace_id =
-    match parent with
-    | Some p -> p.trace_id
-    | None -> new_trace_id
-  in
-  let parent_span_id =
-    match parent with
-    | Some p -> Some p.span_id
-    | None -> None
-  in
-  let s =
-    { trace_id
-    ; span_id
-    ; parent_span_id
-    ; name = make_span_name attrs
-    ; kind = map_span_kind attrs.kind
-    ; start_time_ns = now_ns ()
-    ; end_time_ns = None
-    ; status = None
-    ; attributes = semantic_attrs attrs
-    ; events = []
-    }
-  in
-  inst.current_spans <- s :: inst.current_spans;
-  s
+  match get_fiber_stack inst with
+  | Some stack_ref ->
+    let parent =
+      match !stack_ref with
+      | p :: _ -> Some p
+      | [] -> None
+    in
+    let trace_id =
+      match parent with
+      | Some p -> p.trace_id
+      | None -> new_trace_id
+    in
+    let parent_span_id =
+      match parent with
+      | Some p -> Some p.span_id
+      | None -> None
+    in
+    let s =
+      { trace_id
+      ; span_id
+      ; parent_span_id
+      ; name = make_span_name attrs
+      ; kind = map_span_kind attrs.kind
+      ; start_time_ns = now_ns ()
+      ; end_time_ns = None
+      ; status = None
+      ; attributes = semantic_attrs attrs
+      ; events = []
+      ; links = List.map (fun (trace_id, span_id) -> { trace_id; span_id }) attrs.links
+      }
+    in
+    stack_ref := s :: !stack_ref;
+    s
+  | None ->
+    inst_with_lock inst
+    @@ fun () ->
+    let parent =
+      match inst.current_spans with
+      | p :: _ -> Some p
+      | [] -> None
+    in
+    let trace_id =
+      match parent with
+      | Some p -> p.trace_id
+      | None -> new_trace_id
+    in
+    let parent_span_id =
+      match parent with
+      | Some p -> Some p.span_id
+      | None -> None
+    in
+    let s =
+      { trace_id
+      ; span_id
+      ; parent_span_id
+      ; name = make_span_name attrs
+      ; kind = map_span_kind attrs.kind
+      ; start_time_ns = now_ns ()
+      ; end_time_ns = None
+      ; status = None
+      ; attributes = semantic_attrs attrs
+      ; events = []
+      ; links = List.map (fun (trace_id, span_id) -> { trace_id; span_id }) attrs.links
+      }
+    in
+    inst.current_spans <- s :: inst.current_spans;
+    s
 ;;
 
 let inst_end_span inst (s : span) ~ok =
-  inst_with_lock inst
-  @@ fun () ->
-  let target = ref None in
-  inst.current_spans
-  <- List.filter_map
-       (fun sp ->
-          if sp.span_id = s.span_id
-          then (
-            let updated = { sp with end_time_ns = Some (now_ns ()); status = Some ok } in
-            target := Some updated;
-            None)
-          else Some sp)
-       inst.current_spans;
-  match !target with
-  | Some completed -> inst.completed_spans <- completed :: inst.completed_spans
+  let target_opt =
+    match get_fiber_stack inst with
+    | Some stack_ref ->
+      let target = ref None in
+      stack_ref
+        := List.filter_map
+             (fun sp ->
+                if sp.span_id = s.span_id
+                then (
+                  let updated =
+                    { sp with end_time_ns = Some (now_ns ()); status = Some ok }
+                  in
+                  target := Some updated;
+                  None)
+                else Some sp)
+             !stack_ref;
+      !target
+    | None ->
+      inst_with_lock inst
+      @@ fun () ->
+      let target = ref None in
+      inst.current_spans
+      <- List.filter_map
+           (fun sp ->
+              if sp.span_id = s.span_id
+              then (
+                let updated =
+                  { sp with end_time_ns = Some (now_ns ()); status = Some ok }
+                in
+                target := Some updated;
+                None)
+              else Some sp)
+           inst.current_spans;
+      !target
+  in
+  match target_opt with
+  | Some completed ->
+    inst_with_lock inst (fun () ->
+      inst.completed_spans <- completed :: inst.completed_spans)
   | None -> ()
 ;;
 
 let inst_add_event inst (s : span) (msg : string) =
-  inst_with_lock inst
-  @@ fun () ->
-  let evt = { event_name = msg; timestamp_ns = now_ns (); attributes = [] } in
-  inst.current_spans
-  <- List.map
-       (fun sp ->
-          if sp.span_id = s.span_id
-          then { sp with events = Util.snoc sp.events evt }
-          else sp)
-       inst.current_spans
+  let update_spans spans =
+    let evt = { event_name = msg; timestamp_ns = now_ns (); attributes = [] } in
+    List.map
+      (fun sp ->
+         if sp.span_id = s.span_id
+         then { sp with events = Util.snoc sp.events evt }
+         else sp)
+      spans
+  in
+  match get_fiber_stack inst with
+  | Some stack_ref -> stack_ref := update_spans !stack_ref
+  | None ->
+    inst_with_lock inst
+    @@ fun () ->
+    inst.current_spans <- update_spans inst.current_spans
 ;;
 
 let inst_add_attrs inst (s : span) (attrs : (string * string) list) =
-  inst_with_lock inst
-  @@ fun () ->
-  inst.current_spans
-  <- List.map
-       (fun sp ->
-          if sp.span_id = s.span_id
-          then { sp with attributes = Util.snoc_list sp.attributes attrs }
-          else sp)
-       inst.current_spans
+  let update_spans spans =
+    List.map
+      (fun sp ->
+         if sp.span_id = s.span_id
+         then { sp with attributes = Util.snoc_list sp.attributes attrs }
+         else sp)
+      spans
+  in
+  match get_fiber_stack inst with
+  | Some stack_ref -> stack_ref := update_spans !stack_ref
+  | None ->
+    inst_with_lock inst
+    @@ fun () ->
+    inst.current_spans <- update_spans inst.current_spans
+;;
+
+let inst_add_link inst (s : span) ~trace_id ~span_id =
+  let link = { trace_id; span_id } in
+  let update_spans spans =
+    List.map
+      (fun sp ->
+         if sp.span_id = s.span_id
+         then (sp.links <- link :: sp.links; sp)
+         else sp)
+      spans
+  in
+  match get_fiber_stack inst with
+  | Some stack_ref -> stack_ref := update_spans !stack_ref
+  | None ->
+    inst_with_lock inst
+    @@ fun () ->
+    inst.current_spans <- update_spans inst.current_spans
 ;;
 
 let inst_flush inst =
@@ -247,6 +363,9 @@ let inst_flush inst =
 ;;
 
 let inst_reset inst =
+  (match get_fiber_stack inst with
+   | Some stack_ref -> stack_ref := []
+   | None -> ());
   inst_with_lock inst
   @@ fun () ->
   inst.current_spans <- [];
@@ -258,15 +377,23 @@ let inst_completed_count inst =
 ;;
 
 let inst_active_count inst =
-  inst_with_lock inst @@ fun () -> List.length inst.current_spans
+  match get_fiber_stack inst with
+  | Some stack_ref -> List.length !stack_ref
+  | None -> inst_with_lock inst @@ fun () -> List.length inst.current_spans
 ;;
 
 let inst_current_span inst =
-  inst_with_lock inst
-  @@ fun () ->
-  match inst.current_spans with
-  | current :: _ -> Some current
-  | [] -> None
+  match get_fiber_stack inst with
+  | Some stack_ref ->
+    (match !stack_ref with
+     | current :: _ -> Some current
+     | [] -> None)
+  | None ->
+    inst_with_lock inst
+    @@ fun () ->
+    (match inst.current_spans with
+     | current :: _ -> Some current
+     | [] -> None)
 ;;
 
 let traceparent_of_span ?(sampled = true) (span : span) =
@@ -321,6 +448,7 @@ let metric_type_to_string = function
 let _global : instance =
   { config = default_config
   ; mu = Stdlib_mu (Mutex.create ())
+  ; fiber_key = None
   ; current_spans = []
   ; completed_spans = []
   ; metrics = []
@@ -331,6 +459,7 @@ let start_span attrs = inst_start_span _global attrs
 let end_span s ~ok = inst_end_span _global s ~ok
 let add_event s msg = inst_add_event _global s msg
 let add_attrs s attrs = inst_add_attrs _global s attrs
+let add_link s ~trace_id ~span_id = inst_add_link _global s ~trace_id ~span_id
 let flush () = inst_flush _global
 let reset () = inst_reset _global
 let completed_count () = inst_completed_count _global
@@ -370,6 +499,15 @@ let status_to_json (s : span) : Yojson.Safe.t =
 
 (* ERROR *)
 
+let link_to_json (link : otel_link) : Yojson.Safe.t =
+  `Assoc
+    [ "traceId", `String link.trace_id
+    ; "spanId", `String link.span_id
+    ; "attributes", `List []
+    ; "droppedAttributesCount", `Int 0
+    ]
+;;
+
 let span_to_json (s : span) : Yojson.Safe.t =
   let end_ns =
     match s.end_time_ns with
@@ -386,6 +524,7 @@ let span_to_json (s : span) : Yojson.Safe.t =
     ; "status", status_to_json s
     ; "attributes", attrs_to_json s.attributes
     ; "events", `List (List.map event_to_json s.events)
+    ; "links", `List (List.map link_to_json s.links)
     ]
   in
   let with_parent =
@@ -475,7 +614,8 @@ let to_otlp_json (cfg : config) : Yojson.Safe.t =
 
 let create_instance ?(config = default_config) () : instance =
   { config
-  ; mu = Eio_mu (Eio.Mutex.create ())
+  ; mu = Stdlib_mu (Mutex.create ())
+  ; fiber_key = None
   ; current_spans = []
   ; completed_spans = []
   ; metrics = []
@@ -483,7 +623,13 @@ let create_instance ?(config = default_config) () : instance =
 ;;
 
 let create_instance_eio ?(config = default_config) () : instance =
-  create_instance ~config ()
+  { config
+  ; mu = Eio_mu (Eio.Mutex.create ())
+  ; fiber_key = Some (Eio.Fiber.create_key ())
+  ; current_spans = []
+  ; completed_spans = []
+  ; metrics = []
+  }
 ;;
 
 let tracer_of_instance inst : Tracing.t =
@@ -494,9 +640,37 @@ let tracer_of_instance inst : Tracing.t =
     let end_span = inst_end_span inst
     let add_event = inst_add_event inst
     let add_attrs = inst_add_attrs inst
+    let add_link s ~trace_id ~span_id = inst_add_link inst s ~trace_id ~span_id
     let trace_id s = Some s.trace_id
     let span_id s = Some s.span_id
     let trace_context_headers () = inst_trace_context_headers inst
+
+    let with_span attrs f =
+      match inst.fiber_key with
+      | Some key ->
+        let stack_ref =
+          match Eio.Fiber.get key with
+          | Some ref -> ref
+          | None -> ref []
+        in
+        Eio.Fiber.with_binding key stack_ref (fun () ->
+          let span = inst_start_span inst attrs in
+          match f () with
+          | result ->
+            inst_end_span inst span ~ok:true;
+            result
+          | exception exn ->
+            inst_end_span inst span ~ok:false;
+            raise exn)
+      | None ->
+        let span = inst_start_span inst attrs in
+        match f () with
+        | result ->
+          inst_end_span inst span ~ok:true;
+          result
+        | exception exn ->
+          inst_end_span inst span ~ok:false;
+          raise exn
   end)
 ;;
 

--- a/lib/otel_tracer.mli
+++ b/lib/otel_tracer.mli
@@ -22,6 +22,11 @@ type otel_event =
   ; attributes : (string * string) list
   }
 
+type otel_link =
+  { trace_id : string
+  ; span_id : string
+  }
+
 type span =
   { trace_id : string
   ; span_id : string
@@ -33,6 +38,7 @@ type span =
   ; status : bool option
   ; attributes : (string * string) list
   ; events : otel_event list
+  ; mutable links : otel_link list
   }
 
 type config =
@@ -60,6 +66,7 @@ type mutex_impl =
 type instance =
   { config : config
   ; mu : mutex_impl
+  ; fiber_key : (span list ref) Eio.Fiber.key option
   ; mutable current_spans : span list
   ; mutable completed_spans : span list
   ; mutable metrics : metric_entry list
@@ -86,6 +93,7 @@ val inst_start_span : instance -> Tracing.span_attrs -> span
 val inst_end_span : instance -> span -> ok:bool -> unit
 val inst_add_event : instance -> span -> string -> unit
 val inst_add_attrs : instance -> span -> (string * string) list -> unit
+val inst_add_link : instance -> span -> trace_id:string -> span_id:string -> unit
 val inst_flush : instance -> span list
 val inst_reset : instance -> unit
 val inst_completed_count : instance -> int
@@ -133,6 +141,7 @@ val start_span : Tracing.span_attrs -> span
 val end_span : span -> ok:bool -> unit
 val add_event : span -> string -> unit
 val add_attrs : span -> (string * string) list -> unit
+val add_link : span -> trace_id:string -> span_id:string -> unit
 val flush : unit -> span list
 val reset : unit -> unit
 val completed_count : unit -> int

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -163,6 +163,7 @@ let stage_route ~sw ?clock ~api_strategy agent prep =
       ; agent_name = agent.state.config.name
       ; turn = agent.state.turn_count
       ; extra = []
+      ; links = []
       }
       (fun tracer ->
          let trace_context = Tracing.trace_context_headers tracer in
@@ -175,6 +176,7 @@ let stage_route ~sw ?clock ~api_strategy agent prep =
       ; agent_name = agent.state.config.name
       ; turn = agent.state.turn_count
       ; extra = []
+      ; links = []
       }
       (fun tracer ->
          let trace_context = Tracing.trace_context_headers tracer in
@@ -186,289 +188,319 @@ let stage_route ~sw ?clock ~api_strategy agent prep =
 (** Accumulate usage, invoke AfterTurn hook, emit events, append
     assistant message, increment turn_count.  Restores original_config. *)
 let stage_collect ?raw_trace_run agent ~original_config response =
-  update_state agent (fun s -> { s with config = original_config });
-  let ts = Unix.gettimeofday () in
-  set_lifecycle agent ~first_progress_at:ts ~last_progress_at:ts Running;
-  let* () = trace_assistant_blocks raw_trace_run response.content in
-  let usage =
-    Agent_turn.accumulate_usage
-      ~current_usage:agent.state.usage
-      ~provider:agent.options.provider
-      ~response_usage:response.usage
-  in
-  let _after =
-    invoke_hook_with_trace
-      agent
-      ?raw_trace_run
-      ~hook_name:"after_turn"
-      agent.options.hooks.after_turn
-      (Hooks.AfterTurn { turn = agent.state.turn_count; response })
-  in
-  let completed_turn = agent.state.turn_count in
-  let assistant_message = make_message ~role:Assistant response.content in
-  let checkpoint_state =
-    { agent.state with
-      messages = Util.snoc agent.state.messages assistant_message
-    ; turn_count = agent.state.turn_count + 1
-    ; usage
+  Tracing.with_span
+    agent.options.tracer
+    { kind = Hook_invoke
+    ; name = "turn:collect"
+    ; agent_name = agent.state.config.name
+    ; turn = agent.state.turn_count
+    ; extra = []
+    ; links = []
     }
-  in
-  let* () =
-    persist_turn_checkpoint_for_state agent After_assistant_collected checkpoint_state
-  in
-  update_state agent (fun state ->
-    { state with
-      messages = Util.snoc state.messages assistant_message
-    ; turn_count = state.turn_count + 1
-    ; usage
-    });
-  (match agent.options.event_bus with
-   | Some bus ->
-     safe_publish
-       bus
-       { meta = Pipeline_common.event_envelope agent
-       ; payload =
-           TurnCompleted { agent_name = agent.state.config.name; turn = completed_turn }
-       }
-   | None -> ());
-  (match agent.options.journal with
-   | Some j ->
-     Durable_event.append
-       j
-       (State_transition
-          { from_state = "turn_running"
-          ; to_state = "turn_complete"
-          ; reason = response.stop_reason |> Types.show_stop_reason
-          ; timestamp = Unix.gettimeofday ()
-          })
-   | None -> ());
-  Ok ()
+    (fun _tracer ->
+       update_state agent (fun s -> { s with config = original_config });
+       let ts = Unix.gettimeofday () in
+       set_lifecycle agent ~first_progress_at:ts ~last_progress_at:ts Running;
+       let* () = trace_assistant_blocks raw_trace_run response.content in
+       let usage =
+         Agent_turn.accumulate_usage
+           ~current_usage:agent.state.usage
+           ~provider:agent.options.provider
+           ~response_usage:response.usage
+       in
+       let _after =
+         invoke_hook_with_trace
+           agent
+           ?raw_trace_run
+           ~hook_name:"after_turn"
+           agent.options.hooks.after_turn
+           (Hooks.AfterTurn { turn = agent.state.turn_count; response })
+       in
+       let completed_turn = agent.state.turn_count in
+       let assistant_message = make_message ~role:Assistant response.content in
+       let checkpoint_state =
+         { agent.state with
+           messages = Util.snoc agent.state.messages assistant_message
+         ; turn_count = agent.state.turn_count + 1
+         ; usage
+         }
+       in
+       let* () =
+         persist_turn_checkpoint_for_state agent After_assistant_collected checkpoint_state
+       in
+       update_state agent (fun state ->
+         { state with
+           messages = Util.snoc state.messages assistant_message
+         ; turn_count = state.turn_count + 1
+         ; usage
+         });
+       (match agent.options.event_bus with
+        | Some bus ->
+          safe_publish
+            bus
+            { meta = Pipeline_common.event_envelope agent
+            ; payload =
+                TurnCompleted { agent_name = agent.state.config.name; turn = completed_turn }
+            }
+        | None -> ());
+       (match agent.options.journal with
+        | Some j ->
+          Durable_event.append
+            j
+            (State_transition
+               { from_state = "turn_running"
+               ; to_state = "turn_complete"
+               ; reason = response.stop_reason |> Types.show_stop_reason
+               ; timestamp = Unix.gettimeofday ()
+               })
+        | None -> ());
+       Ok ())
 ;;
 
 (* ── Stage 5: Execute ────────────────────────────────────── *)
 
 (** Handle tool execution: idle detection, guardrails, context injection. *)
 let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
-  let resolved_idle_skip_at =
-    let skip_at = agent.options.max_idle_turns in
-    if skip_at > 0 then Some skip_at else None
-  in
-  let resolved_idle_final_warning_at =
-    match agent.options.idle_final_warning_at, resolved_idle_skip_at with
-    | Some n, _ when n > 0 -> Some n
-    | Some _, _ -> None
-    | None, Some skip_at when skip_at > 1 -> Some (skip_at - 1)
-    | None, _ -> None
-  in
-  let classify_idle_severity consecutive_idle_turns =
-    match resolved_idle_skip_at, resolved_idle_final_warning_at with
-    | Some skip_at, _ when consecutive_idle_turns >= skip_at -> Hooks.Idle_severity.Skip
-    | _, Some final_at when consecutive_idle_turns >= final_at ->
-      Hooks.Idle_severity.Final_warning
-    | _ -> Hooks.Idle_severity.Nudge
-  in
-  let idle_result =
-    Agent_turn.update_idle_detection
-      ~idle_state:
-        { last_tool_calls = agent.last_tool_calls
-        ; consecutive_idle_turns = agent.consecutive_idle_turns
-        }
-      ~tool_uses
-  in
-  Eio.Mutex.use_rw ~protect:true agent.mu (fun () ->
-    agent.last_tool_calls <- idle_result.new_state.last_tool_calls;
-    agent.consecutive_idle_turns <- idle_result.new_state.consecutive_idle_turns);
-  let idle_skip = ref false in
-  let idle_handled = ref false in
-  (* true when Nudge or Skip handled idle *)
-  if idle_result.is_idle
-  then (
-    let tool_names =
-      List.filter_map
-        (fun (block : content_block) ->
-           match block with
-           | ToolUse { name; _ } -> Some name
-           | Text _
-           | Thinking _
-           | RedactedThinking _
-           | ToolResult _
-           | Image _
-           | Document _
-           | Audio _ -> None)
-        tool_uses
-    in
-    let consecutive_idle_turns = agent.consecutive_idle_turns in
-    let idle_decision =
-      match agent.options.hooks.on_idle_escalated with
-      | Some hook ->
-        let severity = classify_idle_severity consecutive_idle_turns in
-        invoke_hook_with_trace
-          agent
-          ?raw_trace_run
-          ~hook_name:"on_idle_escalated"
-          (Some hook)
-          (Hooks.OnIdleEscalated { severity; consecutive_idle_turns; tool_names })
-      | None ->
-        invoke_hook_with_trace
-          agent
-          ?raw_trace_run
-          ~hook_name:"on_idle"
-          agent.options.hooks.on_idle
-          (Hooks.OnIdle { consecutive_idle_turns; tool_names })
-    in
-    match idle_decision with
-    | Hooks.Skip ->
-      idle_skip := true;
-      idle_handled := true
-    | Hooks.Nudge nudge_msg ->
-      (* Inject a nudge message and leave the idle counter unchanged,
-         so repeated idle turns continue to accumulate toward later
-         escalation. With accumulation, repeated idle turns can
-         continue to nudge until the on_idle hook eventually decides
-         to Skip (for example, at a configured threshold). *)
-      update_state agent (fun s ->
-        { s with
-          messages = Util.snoc s.messages (make_message ~role:User [ Text nudge_msg ])
-        });
-      idle_handled := true
-    | _ -> ());
-  (* Early exit: skip tool execution when on_idle hook says Skip.
-     Prevents executing redundant tools and avoids further counter drift. *)
-  if !idle_skip
-  then Ok IdleSkipped
-  else (
-    let count = List.length tool_uses in
-    match Guardrails.exceeds_limit effective_guardrails count with
-    | true ->
-      let msg = Printf.sprintf "Tool call limit exceeded: %d calls in one turn" count in
-      update_state agent (fun s ->
-        { s with messages = Util.snoc s.messages (make_message ~role:User [ Text msg ]) });
-      let* () = persist_turn_checkpoint agent After_tool_results_appended in
-      Ok ToolsExecuted
-    | false ->
-      let results =
-        try Ok (execute_tools_with_trace agent raw_trace_run tool_uses) with
-        | Raw_trace.Trace_error err -> Error err
-      in
-      let* results = results in
-      let tool_result_event_envelope = Pipeline_common.event_envelope agent in
-      let tool_results =
-        Agent_turn.make_tool_results
-          ?event_bus:agent.options.event_bus
-          ~correlation_id:tool_result_event_envelope.correlation_id
-          ~run_id:tool_result_event_envelope.run_id
-          ?relocation:agent.options.tool_result_relocation
-          results
-      in
-      (* Persist CRS to context after tool result processing so that
-       checkpoint captures the current replacement decisions. *)
-      (match agent.options.tool_result_relocation with
-       | Some (_, crs) -> Content_replacement_state.persist_to_context agent.context crs
-       | None -> ());
-      (* Tool-call validation / recoverable errors flow back to the model as
-         is_error tool_results; the model self-corrects on a subsequent turn.
-         There is no separate retry-count gate — runaway is bounded by the
-         shared loop guard (max_turns + idle detection + token budget), the real
-         backpressure. (origin/main reached the same "tool failure is never
-         turn-fatal" outcome by neutering the Exhausted branch; this removes the
-         Tool_retry_policy mechanism entirely, which subsumes that change.) *)
-      let tool_feedback = tool_results in
-      (* Anti-repetition hint: append warning to tool feedback when idle detected
-       but not already handled by Nudge or Skip. Nudge injects its own message
-       and injects its own message; Skip causes early return above. *)
-      let effective_feedback =
-        if idle_result.is_idle && not !idle_handled
-        then
-          tool_feedback
-          @ [ Text
-                (Printf.sprintf
-                   "[Idle warning: You called the same tool(s) with identical arguments \
-                    %d time(s) in a row. Try a different tool or change your arguments \
-                    to make progress.]"
-                   agent.consecutive_idle_turns)
-            ]
-        else tool_feedback
-      in
-      update_state agent (fun s ->
-        { s with
-          messages = Util.snoc s.messages (make_message ~role:User effective_feedback)
-        });
-      (match agent.options.context_injector with
-       | None -> ()
-       | Some injector ->
-         let new_messages =
-           Agent_turn.apply_context_injection
-             ~context:agent.context
-             ~messages:agent.state.messages
-             ~injector
-             ~tool_uses
-             ~results
+  Tracing.with_span
+    agent.options.tracer
+    { kind = Tool_exec
+    ; name = "turn:execute"
+    ; agent_name = agent.state.config.name
+    ; turn = agent.state.turn_count
+    ; extra = []
+    ; links = []
+    }
+    (fun _tracer ->
+       let resolved_idle_skip_at =
+         let skip_at = agent.options.max_idle_turns in
+         if skip_at > 0 then Some skip_at else None
+       in
+       let resolved_idle_final_warning_at =
+         match agent.options.idle_final_warning_at, resolved_idle_skip_at with
+         | Some n, _ when n > 0 -> Some n
+         | Some _, _ -> None
+         | None, Some skip_at when skip_at > 1 -> Some (skip_at - 1)
+         | None, _ -> None
+       in
+       let classify_idle_severity consecutive_idle_turns =
+         match resolved_idle_skip_at, resolved_idle_final_warning_at with
+         | Some skip_at, _ when consecutive_idle_turns >= skip_at -> Hooks.Idle_severity.Skip
+         | _, Some final_at when consecutive_idle_turns >= final_at ->
+           Hooks.Idle_severity.Final_warning
+         | _ -> Hooks.Idle_severity.Nudge
+       in
+       let idle_result =
+         Agent_turn.update_idle_detection
+           ~idle_state:
+             { last_tool_calls = agent.last_tool_calls
+             ; consecutive_idle_turns = agent.consecutive_idle_turns
+             }
+           ~tool_uses
+       in
+       Eio.Mutex.use_rw ~protect:true agent.mu (fun () ->
+         agent.last_tool_calls <- idle_result.new_state.last_tool_calls;
+         agent.consecutive_idle_turns <- idle_result.new_state.consecutive_idle_turns);
+       let idle_skip = ref false in
+       let idle_handled = ref false in
+       (* true when Nudge or Skip handled idle *)
+       if idle_result.is_idle
+       then (
+         let tool_names =
+           List.filter_map
+             (fun (block : content_block) ->
+                match block with
+                | ToolUse { name; _ } -> Some name
+                | Text _
+                | Thinking _
+                | RedactedThinking _
+                | ToolResult _
+                | Image _
+                | Document _
+                | Audio _ -> None)
+             tool_uses
          in
-         update_state agent (fun s -> { s with messages = new_messages }));
-      let* () = persist_turn_checkpoint agent After_tool_results_appended in
-      (* Anti-repetition hint is now in effective_feedback above.
-       Removed duplicate User message injection (Copilot review #3). *)
-      ignore idle_handled;
-      (* suppress unused warning after dedup *)
-      (* In-memory message hygiene after each tool execution round.
-       Without this, agent.state.messages grows unbounded across turns —
-       context_reducer only trims before API calls, not in the stored state.
+         let consecutive_idle_turns = agent.consecutive_idle_turns in
+         let idle_decision =
+           match agent.options.hooks.on_idle_escalated with
+           | Some hook ->
+             let severity = classify_idle_severity consecutive_idle_turns in
+             invoke_hook_with_trace
+               agent
+               ?raw_trace_run
+               ~hook_name:"on_idle_escalated"
+               (Some hook)
+               (Hooks.OnIdleEscalated { severity; consecutive_idle_turns; tool_names })
+           | None ->
+             invoke_hook_with_trace
+               agent
+               ?raw_trace_run
+               ~hook_name:"on_idle"
+               agent.options.hooks.on_idle
+               (Hooks.OnIdle { consecutive_idle_turns; tool_names })
+         in
+         match idle_decision with
+         | Hooks.Skip ->
+           idle_skip := true;
+           idle_handled := true
+         | Hooks.Nudge nudge_msg ->
+           (* Inject a nudge message and leave the idle counter unchanged,
+              so repeated idle turns continue to accumulate toward later
+              escalation. With accumulation, repeated idle turns can
+              continue to nudge until the on_idle hook eventually decides
+              to Skip (for example, at a configured threshold). *)
+           update_state agent (fun s ->
+             { s with
+               messages = Util.snoc s.messages (make_message ~role:User [ Text nudge_msg ])
+             });
+           idle_handled := true
+         | _ -> ());
+       (* Early exit: skip tool execution when on_idle hook says Skip.
+          Prevents executing redundant tools and avoids further counter drift. *)
+       if !idle_skip
+       then Ok IdleSkipped
+       else (
+         let count = List.length tool_uses in
+         match Guardrails.exceeds_limit effective_guardrails count with
+         | true ->
+           let msg = Printf.sprintf "Tool call limit exceeded: %d calls in one turn" count in
+           update_state agent (fun s ->
+             { s with messages = Util.snoc s.messages (make_message ~role:User [ Text msg ]) });
+           let* () = persist_turn_checkpoint agent After_tool_results_appended in
+           Ok ToolsExecuted
+         | false ->
+           let results =
+             try Ok (execute_tools_with_trace agent raw_trace_run tool_uses) with
+             | Raw_trace.Trace_error err -> Error err
+           in
+           let* results = results in
+           let tool_result_event_envelope = Pipeline_common.event_envelope agent in
+           let tool_results =
+             Agent_turn.make_tool_results
+               ?event_bus:agent.options.event_bus
+               ~correlation_id:tool_result_event_envelope.correlation_id
+               ~run_id:tool_result_event_envelope.run_id
+               ?relocation:agent.options.tool_result_relocation
+               results
+           in
+           (* Persist CRS to context after tool result processing so that
+            checkpoint captures the current replacement decisions. *)
+           (match agent.options.tool_result_relocation with
+            | Some (_, crs) -> Content_replacement_state.persist_to_context agent.context crs
+            | None -> ());
+           (* Tool-call validation / recoverable errors flow back to the model as
+              is_error tool_results; the model self-corrects on a subsequent turn.
+              There is no separate retry-count gate — runaway is bounded by the
+              shared loop guard (max_turns + idle detection + token budget), the real
+              backpressure. (origin/main reached the same "tool failure is never
+              turn-fatal" outcome by neutering the Exhausted branch; this removes the
+              Tool_retry_policy mechanism entirely, which subsumes that change.) *)
+           let tool_feedback = tool_results in
+           (* Anti-repetition hint: append warning to tool feedback when idle detected
+            but not already handled by Nudge or Skip. Nudge injects its own message
+            and injects its own message; Skip causes early return above. *)
+           let effective_feedback =
+             if idle_result.is_idle && not !idle_handled
+             then
+               tool_feedback
+               @ [ Text
+                     (Printf.sprintf
+                        "[Idle warning: You called the same tool(s) with identical arguments \
+                         %d time(s) in a row. Try a different tool or change your arguments \
+                         to make progress.]"
+                        agent.consecutive_idle_turns)
+                 ]
+             else tool_feedback
+           in
+           update_state agent (fun s ->
+             { s with
+               messages = Util.snoc s.messages (make_message ~role:User effective_feedback)
+             });
+           (match agent.options.context_injector with
+            | None -> ()
+            | Some injector ->
+              let new_messages =
+                Agent_turn.apply_context_injection
+                  ~context:agent.context
+                  ~messages:agent.state.messages
+                  ~injector
+                  ~tool_uses
+                  ~results
+              in
+              update_state agent (fun s -> { s with messages = new_messages }));
+           let* () = persist_turn_checkpoint agent After_tool_results_appended in
+           (* Anti-repetition hint is now in effective_feedback above.
+            Removed duplicate User message injection (Copilot review #3). *)
+           ignore idle_handled;
+           (* suppress unused warning after dedup *)
+           (* In-memory message hygiene after each tool execution round.
+            Without this, agent.state.messages grows unbounded across turns —
+            context_reducer only trims before API calls, not in the stored state.
 
-       Two-step pruning (Agent_llm_a Code Tier 1 pattern):
-       1. Stub old tool results: keep 2 most recent in full, replace older
-          with short stubs. Tool results are the largest allocation source.
-       2. Hard message cap: keep last 100 messages. Prevents unbounded growth
-          in long-running agents (600+ turns). *)
-      (* Tool-result stubbing and message cap are now applied at call-time
-       in Agent_turn.prepare_messages, not here.  Keeping stored messages
-       unmodified preserves the byte-identical conversation prefix that
-       local LLM KV-cache (Ollama/llama.cpp) depends on for reuse. *)
-      Ok ToolsExecuted)
+            Two-step pruning (Agent_llm_a Code Tier 1 pattern):
+            1. Stub old tool results: keep 2 most recent in full, replace older
+               with short stubs. Tool results are the largest allocation source.
+            2. Hard message cap: keep last 100 messages. Prevents unbounded growth
+               in long-running agents (600+ turns). *)
+           (* Tool-result stubbing and message cap are now applied at call-time
+            in Agent_turn.prepare_messages, not here.  Keeping stored messages
+            unmodified preserves the byte-identical conversation prefix that
+            local LLM KV-cache (Ollama/llama.cpp) depends on for reuse. *)
+           Ok ToolsExecuted))
 ;;
 
 (* ── Stage 6: Output ─────────────────────────────────────── *)
 
 (** Map stop_reason to turn_outcome. *)
 let stage_output ?raw_trace_run agent ~effective_guardrails response =
-  match response.stop_reason with
-  | StopToolUse ->
-    let tool_uses =
-      List.filter
-        (fun (block : content_block) ->
-           match block with
-           | ToolUse _ -> true
-           | Text _
-           | Thinking _
-           | RedactedThinking _
-           | ToolResult _
-           | Image _
-           | Document _
-           | Audio _ -> false)
-        response.content
-    in
-    let result = stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses in
-    (match result with
-     | Ok IdleSkipped ->
-       (* on_idle hook returned Skip: stop gracefully with the current response *)
-       Ok (Complete response)
-     | other -> other)
-  | EndTurn
-  | MaxTokens
-  | StopSequence
-  | Refusal
-  | PauseTurn
-  | Compaction
-  | ContextWindowExceeded ->
-    let _stop =
-      invoke_hook_with_trace
-        agent
-        ?raw_trace_run
-        ~hook_name:"on_stop"
-        agent.options.hooks.on_stop
-        (Hooks.OnStop { reason = response.stop_reason; response })
-    in
-    Ok (Complete response)
-  | Unknown reason -> Error (Error.Agent (UnrecognizedStopReason { reason }))
+  Tracing.with_span
+    agent.options.tracer
+    { kind = Hook_invoke
+    ; name = "turn:output"
+    ; agent_name = agent.state.config.name
+    ; turn = agent.state.turn_count
+    ; extra = []
+    ; links = []
+    }
+    (fun _tracer ->
+       match response.stop_reason with
+       | StopToolUse ->
+         let tool_uses =
+           List.filter
+             (fun (block : content_block) ->
+                match block with
+                | ToolUse _ -> true
+                | Text _
+                | Thinking _
+                | RedactedThinking _
+                | ToolResult _
+                | Image _
+                | Document _
+                | Audio _ -> false)
+             response.content
+         in
+         let result = stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses in
+         (match result with
+          | Ok IdleSkipped ->
+            (* on_idle hook returned Skip: stop gracefully with the current response *)
+            Ok (Complete response)
+          | other -> other)
+       | EndTurn
+       | MaxTokens
+       | StopSequence
+       | Refusal
+       | PauseTurn
+       | Compaction
+       | ContextWindowExceeded ->
+         let _stop =
+           invoke_hook_with_trace
+             agent
+             ?raw_trace_run
+             ~hook_name:"on_stop"
+             agent.options.hooks.on_stop
+             (Hooks.OnStop { reason = response.stop_reason; response })
+         in
+         Ok (Complete response)
+       | Unknown reason -> Error (Error.Agent (UnrecognizedStopReason { reason })))
 ;;
 
 (* ── Proactive watermark compaction (Phase 2) ───────────── *)
@@ -728,9 +760,31 @@ let tag_error stage result =
 
 let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
   (* Stage 1: Input *)
-  let* () = stage_input ?raw_trace_run agent |> tag_error "input" in
+  let* () =
+    Tracing.with_span
+      agent.options.tracer
+      { kind = Hook_invoke
+      ; name = "turn:input"
+      ; agent_name = agent.state.config.name
+      ; turn = agent.state.turn_count
+      ; extra = []
+      ; links = []
+      }
+      (fun _tracer -> stage_input ?raw_trace_run agent |> tag_error "input")
+  in
   (* Stage 2: Parse *)
-  let prep, original_config, turn_params = stage_parse ?raw_trace_run agent in
+  let prep, original_config, turn_params =
+    Tracing.with_span
+      agent.options.tracer
+      { kind = Hook_invoke
+      ; name = "turn:parse"
+      ; agent_name = agent.state.config.name
+      ; turn = agent.state.turn_count
+      ; extra = []
+      ; links = []
+      }
+      (fun _tracer -> stage_parse ?raw_trace_run agent)
+  in
   let context_window = proactive_context_window_tokens agent in
   let est_tokens = total_prompt_tokens_for_agent agent agent.state.messages in
   publish_context_window_usage

--- a/lib/tracing.ml
+++ b/lib/tracing.ml
@@ -17,6 +17,7 @@ type span_attrs =
   ; agent_name : string
   ; turn : int
   ; extra : (string * string) list
+  ; links : (string * string) list
   }
 
 module type TRACER = sig
@@ -26,9 +27,11 @@ module type TRACER = sig
   val end_span : span -> ok:bool -> unit
   val add_event : span -> string -> unit
   val add_attrs : span -> (string * string) list -> unit
+  val add_link : span -> trace_id:string -> span_id:string -> unit
   val trace_id : span -> string option
   val span_id : span -> string option
   val trace_context_headers : unit -> (string * string) list
+  val with_span : span_attrs -> (unit -> 'a) -> 'a
 end
 
 module Null_tracer : TRACER with type span = unit = struct
@@ -38,9 +41,11 @@ module Null_tracer : TRACER with type span = unit = struct
   let end_span () ~ok:_ = ()
   let add_event () _msg = ()
   let add_attrs () _attrs = ()
+  let add_link () ~trace_id:_ ~span_id:_ = ()
   let trace_id () = None
   let span_id () = None
   let trace_context_headers () = []
+  let with_span _attrs f = f ()
 end
 
 module Fmt_tracer : TRACER = struct
@@ -97,9 +102,25 @@ module Fmt_tracer : TRACER = struct
       attrs
   ;;
 
+  let add_link span ~trace_id ~span_id =
+    Format.eprintf
+      "[TRACE] LINK %s/%s -> trace=%s span=%s@."
+      (span_kind_to_string span.attrs.kind)
+      span.attrs.name
+      trace_id
+      span_id
+  ;;
+
   let trace_id _span = None
   let span_id _span = None
   let trace_context_headers () = []
+
+  let with_span attrs f =
+    let span = start_span attrs in
+    match f () with
+    | result -> end_span span ~ok:true; result
+    | exception exn -> end_span span ~ok:false; raise exn
+  ;;
 end
 
 type t = (module TRACER)
@@ -112,16 +133,9 @@ let trace_context_headers (type a) (tracer : t) =
   T.trace_context_headers ()
 ;;
 
-(** Run [f] within a traced span. [end_span] is called on both normal return
-    and exception, with [ok] set accordingly. The exception is re-raised. *)
+(** Run [f] within a traced span. Delegates to [TRACER.with_span] so the
+    tracer can manage fiber-local context around [start_span]/[end_span]. *)
 let with_span (type a) (tracer : t) (attrs : span_attrs) (f : t -> a) : a =
   let module T = (val tracer : TRACER) in
-  let span = T.start_span attrs in
-  match f tracer with
-  | result ->
-    T.end_span span ~ok:true;
-    result
-  | exception exn ->
-    T.end_span span ~ok:false;
-    raise exn
+  T.with_span attrs (fun () -> f tracer)
 ;;

--- a/lib/tracing.mli
+++ b/lib/tracing.mli
@@ -23,6 +23,8 @@ type span_attrs =
   ; agent_name : string
   ; turn : int
   ; extra : (string * string) list
+  ; links : (string * string) list
+    (** (trace_id, span_id) pairs for cross-trace linking. *)
   }
 
 (** {1 Tracer Interface} *)
@@ -34,9 +36,17 @@ module type TRACER = sig
   val end_span : span -> ok:bool -> unit
   val add_event : span -> string -> unit
   val add_attrs : span -> (string * string) list -> unit
+  val add_link : span -> trace_id:string -> span_id:string -> unit
   val trace_id : span -> string option
   val span_id : span -> string option
   val trace_context_headers : unit -> (string * string) list
+
+  (** Run [f] within a traced span.  This is the preferred entry point
+      because the implementation can set up fiber-local context before
+      [start_span] and tear it down after [end_span].  [end_span] is
+      called on both normal return and exception, with [ok] set
+      accordingly.  The exception is re-raised. *)
+  val with_span : span_attrs -> (unit -> 'a) -> 'a
 end
 
 (** {1 Built-in Tracers} *)
@@ -59,7 +69,8 @@ val fmt : t
     or [[]] when the tracer has no active context. *)
 val trace_context_headers : t -> (string * string) list
 
-(** Run [f] within a traced span.  [end_span] is called on both normal
-    return and exception, with [ok] set accordingly.  The exception is
-    re-raised after the span is ended. *)
+(** Run [f] within a traced span.  Delegates to the tracer's
+    [TRACER.with_span] so the implementation can manage fiber-local
+    context.  [end_span] is called on both normal return and exception,
+    with [ok] set accordingly.  The exception is re-raised. *)
 val with_span : t -> span_attrs -> (t -> 'a) -> 'a

--- a/test/dune
+++ b/test/dune
@@ -549,6 +549,11 @@
  (libraries agent_sdk llm_provider alcotest eio eio_main))
 
 (test
+ (name test_otel_tracer_fiber)
+ (modules test_otel_tracer_fiber)
+ (libraries agent_sdk alcotest eio_main))
+
+(test
  (name test_tls_cancellability)
  (modules test_tls_cancellability)
  (libraries

--- a/test/test_otel.ml
+++ b/test/test_otel.ml
@@ -11,10 +11,11 @@ let default_attrs
       ?(agent_name = "agent-a")
       ?(turn = 1)
       ?(extra = [])
+      ?(links = [])
       ()
   : Tracing.span_attrs
   =
-  { kind; name; agent_name; turn; extra }
+  { kind; name; agent_name; turn; extra; links }
 ;;
 
 let with_reset f () =

--- a/test/test_otel_export.ml
+++ b/test/test_otel_export.ml
@@ -20,6 +20,7 @@ let make_test_span ?(name = "test_span") () : Otel_tracer.span =
   ; status = Some true
   ; attributes = [ "test.key", "test.value" ]
   ; events = []
+  ; links = []
   }
 ;;
 
@@ -34,6 +35,7 @@ let record_span ?(name = "exported_span") ?(turn = 1) instance =
     ; turn
     ; kind = Tracing.Agent_run
     ; extra = [ "test.case", name ]
+    ; links = []
     }
   in
   let span = Otel_tracer.inst_start_span instance attrs in
@@ -447,6 +449,7 @@ let test_instance_flush_clears_spans () =
     ; turn = 1
     ; kind = Tracing.Agent_run
     ; extra = []
+    ; links = []
     }
   in
   let span = Otel_tracer.inst_start_span instance attrs in

--- a/test/test_otel_tracer.ml
+++ b/test/test_otel_tracer.ml
@@ -13,10 +13,11 @@ let default_attrs
       ?(turn = 1)
       ?(kind = Tracing.Agent_run)
       ?(extra = [])
+      ?(links = [])
       ()
   : Tracing.span_attrs
   =
-  { kind; name; agent_name = agent; turn; extra }
+  { kind; name; agent_name = agent; turn; extra; links }
 ;;
 
 let is_hex s =
@@ -400,6 +401,7 @@ let test_record_metric_counter () =
   let inst : Otel_tracer.instance =
     { config = Otel_tracer.default_config
     ; mu = Otel_tracer.Stdlib_mu (Mutex.create ())
+    ; fiber_key = None
     ; current_spans = []
     ; completed_spans = []
     ; metrics = []
@@ -422,6 +424,7 @@ let test_record_metric_gauge () =
   let inst : Otel_tracer.instance =
     { config = Otel_tracer.default_config
     ; mu = Otel_tracer.Stdlib_mu (Mutex.create ())
+    ; fiber_key = None
     ; current_spans = []
     ; completed_spans = []
     ; metrics = []
@@ -442,6 +445,7 @@ let test_record_multiple_metrics () =
   let inst : Otel_tracer.instance =
     { config = Otel_tracer.default_config
     ; mu = Otel_tracer.Stdlib_mu (Mutex.create ())
+    ; fiber_key = None
     ; current_spans = []
     ; completed_spans = []
     ; metrics = []
@@ -468,6 +472,7 @@ let test_clear_metrics () =
   let inst : Otel_tracer.instance =
     { config = Otel_tracer.default_config
     ; mu = Otel_tracer.Stdlib_mu (Mutex.create ())
+    ; fiber_key = None
     ; current_spans = []
     ; completed_spans = []
     ; metrics = []

--- a/test/test_otel_tracer_fiber.ml
+++ b/test/test_otel_tracer_fiber.ml
@@ -1,0 +1,112 @@
+(** Fiber-safety tests for Otel_tracer.
+
+    Runs inside [Eio_main.run] so [Eio.Fiber.List.map] is available.
+    Verifies that parallel tool-batch fibers each get their own
+    active-span stack and that parent/child relationships are correct. *)
+
+let check = Alcotest.(check (option string))
+
+let test_parallel_spans_have_correct_parents () =
+  Eio_main.run (fun _env ->
+    let inst = Agent_sdk.Otel_tracer.create_instance_eio () in
+    let module T = (val Agent_sdk.Otel_tracer.tracer_of_instance inst) in
+    let parent_attrs =
+      { Agent_sdk.Tracing.kind = Agent_run
+      ; name = "parent"
+      ; agent_name = "test"
+      ; turn = 1
+      ; extra = []
+      ; links = []
+      }
+    in
+    T.with_span parent_attrs (fun () ->
+      let parent_span = Option.get (Agent_sdk.Otel_tracer.inst_current_span inst) in
+      let parent_id = parent_span.Agent_sdk.Otel_tracer.span_id in
+      let child_results =
+        Eio.Fiber.List.map
+          (fun i ->
+             let child_attrs =
+               { Agent_sdk.Tracing.kind = Tool_exec
+               ; name = Printf.sprintf "child_%d" i
+               ; agent_name = "test"
+               ; turn = 1
+               ; extra = []
+               ; links = []
+               }
+             in
+             T.with_span child_attrs (fun () ->
+               let child_span = Option.get (Agent_sdk.Otel_tracer.inst_current_span inst) in
+               child_span.Agent_sdk.Otel_tracer.parent_span_id))
+          [ 0; 1; 2 ]
+      in
+      List.iteri
+        (fun i ppid ->
+           check
+             (Printf.sprintf "child_%d has correct parent" i)
+             (Some parent_id)
+             ppid)
+        child_results))
+;;
+
+let test_parallel_spans_do_not_cross_contaminate () =
+  Eio_main.run (fun _env ->
+    let inst = Agent_sdk.Otel_tracer.create_instance_eio () in
+    let module T = (val Agent_sdk.Otel_tracer.tracer_of_instance inst) in
+    let root_attrs =
+      { Agent_sdk.Tracing.kind = Agent_run
+      ; name = "root"
+      ; agent_name = "test"
+      ; turn = 1
+      ; extra = []
+      ; links = []
+      }
+    in
+    T.with_span root_attrs (fun () ->
+      (* Spawn 3 fibers, each starting its own sibling span.
+         Without fiber-local stacks they would race and one
+         would become the parent of another. *)
+      let _sibling_spans =
+        Eio.Fiber.List.map
+          (fun i ->
+             let sibling_attrs =
+               { Agent_sdk.Tracing.kind = Tool_exec
+               ; name = Printf.sprintf "sibling_%d" i
+               ; agent_name = "test"
+               ; turn = 1
+               ; extra = []
+               ; links = []
+               }
+             in
+             T.with_span sibling_attrs (fun () ->
+               let span = Option.get (Agent_sdk.Otel_tracer.inst_current_span inst) in
+               ( span.Agent_sdk.Otel_tracer.name
+               , span.Agent_sdk.Otel_tracer.parent_span_id )))
+          [ 0; 1; 2 ]
+      in
+      (* All three siblings must have the SAME parent: the root span. *)
+      let parent_ids =
+        List.filter_map snd _sibling_spans
+        |> List.sort_uniq String.compare
+      in
+      Alcotest.(check int "all siblings share one parent" 1) (List.length parent_ids);
+      (* After all siblings finish, the active span must be the root again. *)
+      let active = Option.get (Agent_sdk.Otel_tracer.inst_current_span inst) in
+      Alcotest.(check string "active span is root after siblings" "agent_run/root")
+        active.Agent_sdk.Otel_tracer.name))
+;;
+
+let () =
+  Alcotest.run
+    "otel_tracer_fiber"
+    [ ( "fiber_safety"
+      , [ Alcotest.test_case
+            "parallel spans have correct parents"
+            `Quick
+            test_parallel_spans_have_correct_parents
+        ; Alcotest.test_case
+            "parallel spans do not cross-contaminate"
+            `Quick
+            test_parallel_spans_do_not_cross_contaminate
+        ] )
+    ]
+;;

--- a/test/test_trace_eval.ml
+++ b/test/test_trace_eval.ml
@@ -8,7 +8,7 @@ let default_attrs
       ()
   : Tracing.span_attrs
   =
-  { kind; name; agent_name = agent; turn; extra = [] }
+  { kind; name; agent_name = agent; turn; extra = []; links = [] }
 ;;
 
 let with_reset f =

--- a/test/test_tracing.ml
+++ b/test/test_tracing.ml
@@ -6,7 +6,7 @@ open Agent_sdk
 let test_null_tracer_no_op () =
   let open Tracing.Null_tracer in
   let span =
-    start_span { kind = Agent_run; name = "test"; agent_name = "a"; turn = 0; extra = [] }
+    start_span { kind = Agent_run; name = "test"; agent_name = "a"; turn = 0; extra = []; links = [] }
   in
   add_event span "msg";
   add_attrs span [ "k", "v" ];
@@ -17,7 +17,7 @@ let test_null_tracer_no_op () =
 let test_null_tracer_false_ok () =
   let open Tracing.Null_tracer in
   let span =
-    start_span { kind = Api_call; name = "call"; agent_name = "a"; turn = 1; extra = [] }
+    start_span { kind = Api_call; name = "call"; agent_name = "a"; turn = 1; extra = []; links = [] }
   in
   end_span span ~ok:false;
   check pass "null_tracer end_span ok:false succeeds" () ()
@@ -37,7 +37,7 @@ let test_fmt_tracer_outputs () =
   let module T = (val Tracing.fmt : Tracing.TRACER) in
   let span =
     T.start_span
-      { kind = Tool_exec; name = "grep"; agent_name = "searcher"; turn = 2; extra = [] }
+      { kind = Tool_exec; name = "grep"; agent_name = "searcher"; turn = 2; extra = []; links = [] }
   in
   T.add_event span "found 3 results";
   T.add_attrs span [ "count", "3" ];
@@ -62,7 +62,7 @@ let test_with_span_success () =
   let result =
     Tracing.with_span
       Tracing.null
-      { kind = Agent_run; name = "run"; agent_name = "a"; turn = 0; extra = [] }
+      { kind = Agent_run; name = "run"; agent_name = "a"; turn = 0; extra = []; links = [] }
       (fun _tracer -> 42)
   in
   check int "with_span returns function result" 42 result
@@ -74,7 +74,7 @@ let test_with_span_exception () =
      let _ =
        Tracing.with_span
          Tracing.null
-         { kind = Agent_run; name = "fail"; agent_name = "a"; turn = 0; extra = [] }
+         { kind = Agent_run; name = "fail"; agent_name = "a"; turn = 0; extra = []; links = [] }
          (fun _tracer -> failwith "boom")
      in
      ()
@@ -110,9 +110,19 @@ end = struct
       kvs
   ;;
 
+  let add_link span ~trace_id ~span_id =
+    log := Printf.sprintf "link:%s:%s:%s" span.span_name trace_id span_id :: !log
   let trace_id _span = None
   let span_id _span = None
   let trace_context_headers () = [ "traceparent", "00-test-test-01" ]
+
+  let with_span attrs f =
+    let span = start_span attrs in
+    match f () with
+    | result -> end_span span ~ok:true; result
+    | exception exn -> end_span span ~ok:false; raise exn
+  ;;
+
   let events () = List.rev !log
   let reset () = log := []
 end
@@ -121,7 +131,7 @@ let test_custom_tracer () =
   Recording_tracer.reset ();
   let span =
     Recording_tracer.start_span
-      { kind = Hook_invoke; name = "custom"; agent_name = "x"; turn = 0; extra = [] }
+      { kind = Hook_invoke; name = "custom"; agent_name = "x"; turn = 0; extra = []; links = [] }
   in
   Recording_tracer.add_event span "hi";
   Recording_tracer.add_attrs span [ "a", "1" ];
@@ -159,6 +169,7 @@ let test_span_kind_coverage () =
            ; agent_name = "a"
            ; turn = 0
            ; extra = []
+           ; links = []
            }
            (fun _tracer -> i)
        in
@@ -173,7 +184,7 @@ let test_with_span_exception_ends_span () =
      let _ =
        Tracing.with_span
          tracer
-         { kind = Api_call; name = "err"; agent_name = "a"; turn = 0; extra = [] }
+         { kind = Api_call; name = "err"; agent_name = "a"; turn = 0; extra = []; links = [] }
          (fun _tracer -> failwith "oops")
      in
      ()


### PR DESCRIPTION
## Summary

Closes the OTel telemetry gaps across MASC and OAS, ensuring distributed traces are complete, fiber-safe, and cross the MASC↔OAS boundary.

### Phase 1 — Fiber-safe tracer
- Replaces global mutable span stack with per-fiber [Eio.Fiber.create_key] storage
- Parallel tool batches no longer race on span parent lookups

### Phase 2 — Pipeline stage spans
- Wraps all 6 pipeline stages in [Tracing.with_span]
- Parent ["agent_turn"] span wraps entire turn

### Phase 3 — Trace boundary linking
- [trace_link] field carries (trace_id, span_id) from MASC into OAS
- OAS [agent_turn] span includes OTel Link back to MASC keeper-turn span
- OTLP JSON export emits [links] array

### Tests
- [test_otel_tracer_fiber.ml] verifies parallel span parent correctness
- All existing tracing tests pass