### PR TITLE
fix(provider): honor parallel tool capability

### DIFF
--- a/docs/provider-capabilities-spec.md
+++ b/docs/provider-capabilities-spec.md
@@ -49,7 +49,7 @@ Cloud providers need hardcoded lookup tables keyed by model_id.
 |-------|---------|--------|-----------|
 | `supports_tools` | exists | keep | |
 | `supports_tool_choice` | exists | keep | |
-| `supports_parallel_tool_calls` | missing | add | DeepSeek R1 has no tool calling at all. Cohere supports it. OAS has `disable_parallel_tool_use` but no capability check. |
+| `supports_parallel_tool_calls` | exists | keep | Request builders derive effective `disable_parallel_tool_use` from caller intent plus provider/model capability. |
 | `supports_system_prompt` | missing | add | Most models support it, but some fine-tuned/distilled variants do not. Agent must fold system into first user message. |
 | `supports_reasoning` | exists | **split into 4** | See Thinking Taxonomy below. |
 | `supports_extended_thinking` | missing | add | budget_tokens control. Claude, Gemini, GPT-5.4. |

--- a/lib/api_anthropic.ml
+++ b/lib/api_anthropic.ml
@@ -19,6 +19,22 @@ let build_body_assoc
       ()
   =
   let model_str = model_to_string config.config.model in
+  let tools_present =
+    match tools with
+    | Some (_ :: _) -> true
+    | Some [] | None -> false
+  in
+  let capabilities =
+    match Llm_provider.Capabilities.for_model_id model_str with
+    | Some capabilities -> capabilities
+    | None -> Llm_provider.Capabilities.anthropic_capabilities
+  in
+  let disable_parallel_tool_use =
+    Llm_provider.Capabilities.effective_disable_parallel_tool_use
+      ~caller_disabled:config.config.disable_parallel_tool_use
+      ~supports_parallel_tool_calls:capabilities.supports_parallel_tool_calls
+      ~tools_present
+  in
   let body_assoc =
     [ "model", `String model_str
     ; "max_tokens", `Int (Option.value ~default:4096 config.config.max_tokens)
@@ -84,7 +100,7 @@ let build_body_assoc
     | Some tc ->
       let tc_json = tool_choice_to_json tc in
       let tc_json =
-        if config.config.disable_parallel_tool_use
+        if disable_parallel_tool_use
         then (
           match tc_json with
           | `Assoc fields -> `Assoc (("disable_parallel_tool_use", `Bool true) :: fields)
@@ -93,7 +109,7 @@ let build_body_assoc
       in
       ("tool_choice", tc_json) :: body_assoc
     | None ->
-      if config.config.disable_parallel_tool_use
+      if disable_parallel_tool_use && tools_present
       then (
         let tc_json =
           `Assoc [ "type", `String "auto"; "disable_parallel_tool_use", `Bool true ]

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -81,6 +81,15 @@ let should_include_tools ?provider_config (config : agent_state) =
 let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
   let model_str = model_to_string config.config.model in
   let capabilities = capabilities_for_request ?provider_config config in
+  let tools_to_send =
+    match tools with
+    | Some entries
+      when entries <> []
+           && capabilities.supports_tools
+           && should_include_tools ?provider_config config ->
+      Some entries
+    | _ -> None
+  in
   let sanitized_messages = strip_orphaned_tool_results messages in
   let provider_messages =
     let message_serializer =
@@ -174,13 +183,9 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
     | Some _ -> body_assoc
   in
   let body_assoc =
-    match tools with
-    | Some entries
-      when entries <> []
-           && capabilities.supports_tools
-           && should_include_tools ?provider_config config ->
-      ("tools", `List (List.map build_provider_d_tool_json entries)) :: body_assoc
-    | _ -> body_assoc
+    match tools_to_send with
+    | Some entries -> ("tools", `List (List.map build_provider_d_tool_json entries)) :: body_assoc
+    | None -> body_assoc
   in
   let body_assoc =
     match effective_tool_choice_json capabilities ?provider_config config with
@@ -188,9 +193,16 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
     | None -> body_assoc
   in
   let body_assoc =
+    let tools_present = Option.is_some tools_to_send in
+    let disable_parallel =
+      Llm_provider.Capabilities.effective_disable_parallel_tool_use
+        ~caller_disabled:config.config.disable_parallel_tool_use
+        ~supports_parallel_tool_calls:capabilities.supports_parallel_tool_calls
+        ~tools_present
+    in
     Llm_provider.Backend_openai_serialize.parallel_tool_calls_fields
-      ~disable_parallel:config.config.disable_parallel_tool_use
-      ~tools_present:capabilities.supports_tools
+      ~disable_parallel
+      ~tools_present
     @ body_assoc
   in
   let body_assoc =

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -69,6 +69,18 @@ let build_request
       ?(tools : Yojson.Safe.t list = [])
       ()
   =
+  let caps =
+    match Capabilities.for_model_id config.model_id with
+    | Some caps -> caps
+    | None -> Capabilities.anthropic_capabilities
+  in
+  let tools_present = tools <> [] in
+  let disable_parallel_tool_use =
+    Capabilities.effective_disable_parallel_tool_use
+      ~caller_disabled:config.disable_parallel_tool_use
+      ~supports_parallel_tool_calls:caps.supports_parallel_tool_calls
+      ~tools_present
+  in
   let message_to_json = Api_common.message_to_json in
   let msgs_json = List.map message_to_json messages in
   let body =
@@ -187,7 +199,7 @@ let build_request
      already nests correctly. *)
   let tool_choice_json_with_disable choice =
     let base = tool_choice_to_json choice in
-    if config.disable_parallel_tool_use
+    if disable_parallel_tool_use
     then (
       match base with
       | `Assoc fields -> `Assoc (("disable_parallel_tool_use", `Bool true) :: fields)
@@ -198,7 +210,7 @@ let build_request
     match config.tool_choice with
     | Some choice -> ("tool_choice", tool_choice_json_with_disable choice) :: body
     | None ->
-      if config.disable_parallel_tool_use && tools <> []
+      if disable_parallel_tool_use && tools_present
       then (
         (* No explicit tool_choice but caller still wants to disable
            parallel tool use — synthesize an [auto] choice to carry

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -296,9 +296,16 @@ let build_request
       :: body
   in
   let body =
+    let tools_present = tools <> [] in
+    let disable_parallel =
+      Capabilities.effective_disable_parallel_tool_use
+        ~caller_disabled:config.disable_parallel_tool_use
+        ~supports_parallel_tool_calls:caps.supports_parallel_tool_calls
+        ~tools_present
+    in
     Backend_openai_serialize.parallel_tool_calls_fields
-      ~disable_parallel:config.disable_parallel_tool_use
-      ~tools_present:(tools <> [])
+      ~disable_parallel
+      ~tools_present
     @ body
   in
   let body =

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -130,6 +130,14 @@ let default_capabilities =
   }
 ;;
 
+let effective_disable_parallel_tool_use
+      ~caller_disabled
+      ~supports_parallel_tool_calls
+      ~tools_present
+  =
+  caller_disabled || (tools_present && not supports_parallel_tool_calls)
+;;
+
 let anthropic_capabilities =
   { default_capabilities with
     max_context_tokens = Some 200_000

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -95,6 +95,18 @@ val glm_capabilities : capabilities
     @since 0.185.0 *)
 val provider_l_capabilities : capabilities
 
+(** Effective request-level parallel tool-use disablement.
+
+    Explicit caller disablement always wins. Otherwise, when a request carries
+    tools and the selected provider/model says it does not support parallel tool
+    calls, callers should serialize the provider-specific "disable parallel
+    tool use" wire field when the provider has one. *)
+val effective_disable_parallel_tool_use
+  :  caller_disabled:bool
+  -> supports_parallel_tool_calls:bool
+  -> tools_present:bool
+  -> bool
+
 (** Typed Gemini model family. SSOT for the [gemini-*] prefix dispatch that
     used to live as scattered [String.starts_with] calls. Downstream code
     should switch on this variant rather than re-compare strings.

--- a/test/test_capabilities_wiring.ml
+++ b/test/test_capabilities_wiring.ml
@@ -47,6 +47,36 @@ let test_filter_parallel_tools () =
   check bool "default lacks parallel" false (Capability_filter.requires_parallel_tools no)
 ;;
 
+let test_effective_disable_parallel_tool_use () =
+  let effective =
+    Capabilities.effective_disable_parallel_tool_use
+      ~supports_parallel_tool_calls:false
+  in
+  check
+    bool
+    "explicit caller disable wins without tools"
+    true
+    (effective ~caller_disabled:true ~tools_present:false);
+  check
+    bool
+    "capability disables when tools are present"
+    true
+    (effective ~caller_disabled:false ~tools_present:true);
+  check
+    bool
+    "no tools does not force disable"
+    false
+    (effective ~caller_disabled:false ~tools_present:false);
+  check
+    bool
+    "parallel-capable model stays enabled"
+    false
+    (Capabilities.effective_disable_parallel_tool_use
+       ~caller_disabled:false
+       ~supports_parallel_tool_calls:true
+       ~tools_present:true)
+;;
+
 let test_filter_thinking () =
   let agent_llm_a = Capabilities.anthropic_capabilities in
   let basic = Capabilities.openai_compat_chat_capabilities in
@@ -146,6 +176,10 @@ let () =
         ] )
     ; ( "filter"
       , [ test_case "parallel tools" `Quick test_filter_parallel_tools
+        ; test_case
+            "effective parallel tool disable"
+            `Quick
+            test_effective_disable_parallel_tool_use
         ; test_case "thinking" `Quick test_filter_thinking
         ; test_case "fits context" `Quick test_filter_fits_context
         ; test_case "fits output" `Quick test_filter_fits_output

--- a/test/test_custom_provider.ml
+++ b/test/test_custom_provider.ml
@@ -186,6 +186,50 @@ let test_lifecycle_runtime_name () =
   Alcotest.(check (option string)) "runtime name" (Some "life-test") name
 ;;
 
+(* ── API request capability wiring ─────────────────────── *)
+
+let test_openai_body_forces_parallel_disable_from_provider_capability () =
+  let provider_name = "no-parallel-tools-provider" in
+  let impl = make_test_impl ~name:provider_name () in
+  Provider.register_provider impl;
+  let provider_config =
+    Provider.custom_provider ~name:provider_name ~model_id:"custom-no-parallel" ()
+  in
+  let state =
+    { Types.config =
+        { Types.default_config with
+          model = provider_config.model_id
+        ; tool_choice = Some Types.Auto
+        ; disable_parallel_tool_use = false
+        }
+    ; messages = []
+    ; turn_count = 0
+    ; usage = Types.empty_usage
+    }
+  in
+  let tool_json =
+    `Assoc
+      [ "name", `String "lookup"
+      ; "description", `String "lookup"
+      ; "input_schema", `Assoc [ "type", `String "object" ]
+      ]
+  in
+  let json =
+    Api.build_openai_body
+      ~provider_config
+      ~config:state
+      ~messages:[]
+      ~tools:[ tool_json ]
+      ()
+    |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  Alcotest.(check bool)
+    "provider capability disables parallel tool calls"
+    false
+    (json |> member "parallel_tool_calls" |> to_bool)
+;;
+
 (* ── Test runner ────────────────────────────────────────── *)
 
 let () =
@@ -248,5 +292,11 @@ let () =
         ] )
     ; ( "lifecycle"
       , [ Alcotest.test_case "runtime name" `Quick test_lifecycle_runtime_name ] )
+    ; ( "api"
+      , [ Alcotest.test_case
+            "parallel tool capability controls wire"
+            `Quick
+            (with_eio test_openai_body_forces_parallel_disable_from_provider_capability)
+        ] )
     ]
 ;;

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -95,6 +95,19 @@ let gemini_cfg =
 let glm_cfg = cfg ~kind:Glm ~base_url:"https://open.bigmodel.cn/api/paas/v4"
 let ollama_cfg = cfg ~kind:Ollama ~base_url:"http://127.0.0.1:11434"
 
+let openai_no_parallel_capability_cfg =
+  Provider_config.make
+    ~kind:OpenAI_compat
+    ~model_id:"unknown-no-parallel-tools"
+    ~base_url:"https://api.openai.com/v1"
+    ~api_key:"test-key"
+    ~max_tokens:1024
+    ~temperature:0.7
+    ~tool_choice:Any
+    ~disable_parallel_tool_use:false
+    ()
+;;
+
 (* RFC-OAS-023 fixture. Unlike the shared [cfg] above, this one uses the REAL
    fleet model id ([deepseek-v4-flash], the live default in masc
    [runtime.toml]) and deliberately OMITS [supports_tool_choice_override], so
@@ -202,6 +215,21 @@ let test_openai_none () =
   check bool "None_ omits tools field" false (contains ~needle:{|"tools"|} body)
 ;;
 
+let test_openai_parallel_disabled_by_capability () =
+  let body =
+    Backend_openai_request.build_request
+      ~config:openai_no_parallel_capability_cfg
+      ~messages
+      ~tools:[ tool_decl ]
+      ()
+  in
+  check
+    bool
+    "parallel_tool_calls:false follows provider capability"
+    true
+    (contains ~needle:{|"parallel_tool_calls":false|} body)
+;;
+
 (* ── DeepSeek via OpenAI-compat (RFC-OAS-023 routing fence) ───
    This fixture pins the CURRENT live-fleet wire for [deepseek-v4-flash]
    through the OpenAI-compat backend. It exercises the REAL capability
@@ -218,7 +246,7 @@ let test_openai_none () =
    get correct (not shadowed) capabilities"] in [capabilities.ml] and in
    [test_capabilities.ml]'s cloud-suffix route checks. *)
 let deepseek_required_expected =
-  {|{"parallel_tool_calls":false,"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"tool_choice":"required","reasoning_effort":"none","temperature":0.7,"model":"deepseek-v4-flash","messages":[{"role":"user","content":"What's the weather in Seoul?"},{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Seoul\"}"}}],"role":"assistant","content":null},{"role":"tool","tool_call_id":"call_1","content":"Sunny, 25C"}],"max_tokens":1024}|}
+  {|{"parallel_tool_calls":false,"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"tool_choice":"required","reasoning_effort":"none","temperature":0.7,"model":"deepseek-v4-flash","messages":[{"role":"user","content":"What's the weather in Seoul?"},{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Seoul\"}"}}],"role":"assistant","content":""},{"role":"tool","tool_call_id":"call_1","content":"Sunny, 25C"}],"max_tokens":1024}|}
 ;;
 
 let test_deepseek_required () =
@@ -382,6 +410,10 @@ let () =
       , [ test_case "tool_choice forced(Tool)" `Quick test_openai_forced
         ; test_case "tool_choice required(Any)" `Quick test_openai_required
         ; test_case "tool_choice none(None_)" `Quick test_openai_none
+        ; test_case
+            "parallel disabled by capability"
+            `Quick
+            test_openai_parallel_disabled_by_capability
         ; test_case "deepseek-v4-flash required(Any)" `Quick test_deepseek_required
         ] )
     ; "anthropic", [ test_case "tool_choice forced(Tool)" `Quick test_anthropic_forced ]


### PR DESCRIPTION
## Summary

- Add a shared effective parallel-tool disable helper in provider capabilities.
- Wire provider/model `supports_parallel_tool_calls` into OpenAI-compatible and Anthropic request builders.
- Preserve explicit caller disablement while forcing disable when tools are present and the provider/model does not support parallel tool calls.
- Refresh the DeepSeek snapshot fixture to current serializer output for assistant tool-call content.

Fixes #2002

## Verification

- `scripts/dune-local.sh build test/test_capabilities_wiring.exe`
- `./_build/default/test/test_capabilities_wiring.exe`
- `scripts/dune-local.sh build test/test_custom_provider.exe`
- `./_build/default/test/test_custom_provider.exe`
- `scripts/dune-local.sh build test/test_snapshot_provider_serialization.exe`
- `./_build/default/test/test_snapshot_provider_serialization.exe`
- `git diff --check`
