### PR TITLE
feat: support DeepSeek runtime API key env

### DIFF
--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -324,10 +324,10 @@ let provider_i_defaults =
   }
 ;;
 
-let provider_g_defaults =
+let deepseek_defaults =
   { kind = OpenAI_compat
   ; base_url = env_or_default "DEEPSEEK_BASE_URL" "https://api.deepseek.com"
-  ; api_key_env = "PROVIDER_G_API_KEY"
+  ; api_key_env = "DEEPSEEK_API_KEY"
   ; request_path = "/chat/completions"
   }
 ;;
@@ -418,7 +418,7 @@ let default () =
   (* Deepseek v4 series (flash / pro). 1M context, reasoning, tools. *)
   reg
     "deepseek"
-    provider_g_defaults
+    deepseek_defaults
     ~max_context:1_000_000
     Capabilities.openai_compat_chat_capabilities;
   reg

--- a/test/test_agent_config_deep.ml
+++ b/test/test_agent_config_deep.ml
@@ -421,13 +421,13 @@ let test_resolve_provider_i_custom_url () =
   | _ -> Alcotest.fail "expected OpenAICompat for groq custom url"
 ;;
 
-let test_resolve_provider_g () =
+let test_resolve_deepseek () =
   (* base_url=None: Custom_registered preserves kind lookup via registry. *)
   let cfg = Agent_config.resolve_provider ~model_id:"deepseek-chat" "deepseek" None in
   match cfg.provider with
   | Provider.Custom_registered { name } ->
     Alcotest.(check string) "deepseek name" "deepseek" name;
-    Alcotest.(check string) "deepseek api_key_env" "PROVIDER_G_API_KEY" cfg.api_key_env
+    Alcotest.(check string) "deepseek api_key_env" "DEEPSEEK_API_KEY" cfg.api_key_env
   | _ -> Alcotest.fail "expected Custom_registered for deepseek (registered)"
 ;;
 
@@ -620,7 +620,7 @@ let () =
         ; tc "other OpenAI /v1 base url" test_resolve_other_openai_v1_base_url
         ; tc "groq" test_resolve_provider_i
         ; tc "groq custom url" test_resolve_provider_i_custom_url
-        ; tc "deepseek" test_resolve_provider_g
+        ; tc "deepseek" test_resolve_deepseek
         ; tc "gemini preserves kind (#1003)" test_resolve_provider_f_preserves_kind
         ; tc "openai_compat is kind string" test_resolve_openai_compat_ssot
         ; tc "anthropic case-insensitive" test_resolve_anthropic_case_insensitive

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -274,7 +274,7 @@ let test_lookup_provider_m_runpod_name () =
   | None -> fail "should match provider_h_3.6 runpod model id"
 ;;
 
-let test_lookup_provider_g_v4_flash () =
+let test_lookup_deepseek_v4_flash () =
   match Capabilities.for_model_id "deepseek-v4-flash" with
   | Some c ->
     check (option int) "context 1M" (Some 1_000_000) c.max_context_tokens;
@@ -285,7 +285,7 @@ let test_lookup_provider_g_v4_flash () =
   | None -> fail "should match deepseek-v4-flash"
 ;;
 
-let test_lookup_provider_g_v4_pro () =
+let test_lookup_deepseek_v4_pro () =
   match Capabilities.for_model_id "deepseek-v4-pro" with
   | Some c ->
     check (option int) "context 1M" (Some 1_000_000) c.max_context_tokens;
@@ -842,8 +842,8 @@ let () =
         ; test_case "kimi-k2 cloud" `Quick test_lookup_provider_c_k2_cloud
         ; test_case "dashscope" `Quick test_lookup_provider_m
         ; test_case "dashscope runpod name" `Quick test_lookup_provider_m_runpod_name
-        ; test_case "deepseek v4 flash" `Quick test_lookup_provider_g_v4_flash
-        ; test_case "deepseek v4 pro" `Quick test_lookup_provider_g_v4_pro
+        ; test_case "deepseek v4 flash" `Quick test_lookup_deepseek_v4_flash
+        ; test_case "deepseek v4 pro" `Quick test_lookup_deepseek_v4_pro
         ; test_case "grok 2M context" `Quick test_lookup_grok
         ; test_case "glm-5 text only" `Quick test_lookup_glm5_text_only
         ; test_case "glm-5v vision" `Quick test_lookup_glm5v_vision

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -1680,7 +1680,7 @@ let test_for_model_id_llama4_alt () =
   | None -> Alcotest.fail "expected Some for llama4"
 ;;
 
-let test_for_model_id_provider_g_v4_flash () =
+let test_for_model_id_deepseek_v4_flash () =
   match Capabilities.for_model_id "deepseek-v4-flash" with
   | Some c ->
     Alcotest.(check (option int)) "1M context" (Some 1_000_000) c.max_context_tokens;
@@ -1691,7 +1691,7 @@ let test_for_model_id_provider_g_v4_flash () =
   | None -> Alcotest.fail "expected Some for deepseek-v4-flash"
 ;;
 
-let test_for_model_id_provider_g_v4_pro () =
+let test_for_model_id_deepseek_v4_pro () =
   match Capabilities.for_model_id "deepseek-v4-pro" with
   | Some c ->
     Alcotest.(check (option int)) "1M context" (Some 1_000_000) c.max_context_tokens;
@@ -2013,8 +2013,8 @@ let () =
         ; Alcotest.test_case
             "deepseek-v4-flash"
             `Quick
-            test_for_model_id_provider_g_v4_flash
-        ; Alcotest.test_case "deepseek-v4-pro" `Quick test_for_model_id_provider_g_v4_pro
+            test_for_model_id_deepseek_v4_flash
+        ; Alcotest.test_case "deepseek-v4-pro" `Quick test_for_model_id_deepseek_v4_pro
         ; Alcotest.test_case "mistral-large" `Quick test_for_model_id_provider_j_large
         ; Alcotest.test_case "mistral-small" `Quick test_for_model_id_provider_j_small
         ; Alcotest.test_case "command" `Quick test_for_model_id_command

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -3,6 +3,17 @@
 open Alcotest
 open Llm_provider
 
+let with_env key value f =
+  let previous = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some previous -> Unix.putenv key previous
+      | None -> Unix.putenv key "")
+    f
+;;
+
 (* ── Registry CRUD ──────────────────────────────────── *)
 
 let test_empty_registry () =
@@ -277,6 +288,29 @@ let test_default_ollama_cloud_entry () =
   | None -> fail "ollama_cloud should exist"
 ;;
 
+let test_default_deepseek_entry () =
+  let reg = Provider_registry.default () in
+  match Provider_registry.find reg "deepseek" with
+  | Some e ->
+    check bool "kind is OpenAI_compat" true (e.defaults.kind = Provider_config.OpenAI_compat);
+    check string "base_url" "https://api.deepseek.com" e.defaults.base_url;
+    check string "api_key_env" "DEEPSEEK_API_KEY" e.defaults.api_key_env;
+    check string "request_path" "/chat/completions" e.defaults.request_path
+  | None -> fail "deepseek should exist"
+;;
+
+let test_default_deepseek_api_key_env () =
+  let availability ~deepseek =
+    with_env "DEEPSEEK_API_KEY" deepseek (fun () ->
+      let reg = Provider_registry.default () in
+      match Provider_registry.find reg "deepseek" with
+      | Some e -> e.is_available ()
+      | None -> fail "deepseek should exist")
+  in
+  check bool "no key unavailable" false (availability ~deepseek:"");
+  check bool "documented key available" true (availability ~deepseek:"deepseek-secret")
+;;
+
 let test_provider_name_of_ollama_cloud_config () =
   let cfg =
     Provider_config.make
@@ -427,17 +461,6 @@ let with_provider_catalog json f =
   | Ok catalog ->
     Provider_catalog.set_global catalog;
     Fun.protect ~finally:Provider_catalog.clear_global f
-;;
-
-let with_env key value f =
-  let previous = Sys.getenv_opt key in
-  Unix.putenv key value;
-  Fun.protect
-    ~finally:(fun () ->
-      match previous with
-      | Some previous -> Unix.putenv key previous
-      | None -> Unix.putenv key "")
-    f
 ;;
 
 let test_catalog_overlay_adds_provider_and_alias () =
@@ -990,6 +1013,11 @@ let () =
       , [ test_case "has 14 providers" `Quick test_default_has_14
         ; test_case "correct capabilities" `Quick test_default_capabilities
         ; test_case "ollama_cloud entry" `Quick test_default_ollama_cloud_entry
+        ; test_case "deepseek entry" `Quick test_default_deepseek_entry
+        ; test_case
+            "deepseek api key env"
+            `Quick
+            test_default_deepseek_api_key_env
         ; test_case
             "provider_name_of_config returns ollama_cloud"
             `Quick


### PR DESCRIPTION
## Summary
- Switch DeepSeek provider defaults to the documented `DEEPSEEK_API_KEY`.
- Keep the official OpenAI-compatible defaults: `https://api.deepseek.com` plus `/chat/completions`.
- Remove the `Provider_G`/`PROVIDER_G_API_KEY` DeepSeek alias path from implementation-facing registry/tests.

## Why
DeepSeek documents OpenAI-compatible API access at `https://api.deepseek.com` with `POST /chat/completions`, Bearer auth, current models `deepseek-v4-pro` and `deepseek-v4-flash`, and `DEEPSEEK_API_KEY` in examples.

[근거] DeepSeek official docs https://api-docs.deepseek.com/ and https://api-docs.deepseek.com/api/create-chat-completion, checked 2026-06-11 23:40 KST, High.

## Checks
- `scripts/dune-local.sh build test/test_provider_registry.exe test/test_agent_config_deep.exe test/test_capabilities.exe test/test_llm_provider_cov.exe`
- `_build/default/test/test_provider_registry.exe`
- `_build/default/test/test_agent_config_deep.exe`
- `_build/default/test/test_capabilities.exe test model_lookup 13,14`
- `_build/default/test/test_llm_provider_cov.exe test capabilities.for_model_id 11,12`