### PR TITLE
docs: purge Provider_g DeepSeek residue

### DIFF
--- a/docs/RFC-0001-vendor-purge.md
+++ b/docs/RFC-0001-vendor-purge.md
@@ -46,7 +46,7 @@ OAS has one external consumer (masc-mcp), under the same operator's control. For
 | `OpenAI_compat` | `Provider_d_compat` |
 | `OpenAI` (if any) | `Provider_d` |
 | `Gemini` | `Provider_f` |
-| `DeepSeek` | `Provider_g` |
+| `DeepSeek` | `DeepSeek` |
 | `DashScope` | `Provider_h` |
 | `Glm` / `GLM` | `Provider_k` |
 | `Claude_code` | `Cli_tool_d` |
@@ -57,7 +57,7 @@ OAS has one external consumer (masc-mcp), under the same operator's control. For
 | `Gemini_3_1`, `Gemini_3`, `Gemini_2_5`, `Gemini_other` (model variants) | `Provider_f_3_1`, etc. |
 | `Claude_opus_4`, `Claude_sonnet_4`, `Claude_haiku_4` | `Agent_llm_a_opus_4`, etc. |
 | `Kimi_for_coding`, `Kimi_k2` | `Provider_c_for_coding`, `Provider_c_k2` |
-| `Deepseek_v4_flash`, `Deepseek_v4_pro` | `Provider_g_v4_flash`, `Provider_g_v4_pro` |
+| `Deepseek_v4_flash`, `Deepseek_v4_pro` | `Deepseek_v4_flash`, `Deepseek_v4_pro` |
 | `Qwen3` (capabilities static_model_route) | `Provider_h_3` |
 | `Mistral_large`, `Mistral_small` | `Provider_j_large`, `Provider_j_small` |
 | `Glm_quota_exceeded`, `Glm_rate_limited`, `Glm_auth_error`, `Glm_server_error`, `Glm_invalid_request` (backend_provider_k error variants) | `Provider_k_quota_exceeded`, `Provider_k_rate_limited`, `Provider_k_auth_error`, `Provider_k_server_error`, `Provider_k_invalid_request` |
@@ -156,7 +156,7 @@ Module references updated repo-wide; `test/dune` test list updated.
 | `KIMI_API_KEY`, `KIMI_BASE_URL`, `KIMI_DEFAULT_MODEL` | `PROVIDER_C_*` |
 | `OPENAI_API_KEY`, `OPENAI_DEFAULT_MODEL` | `PROVIDER_D_*` |
 | `MOONSHOT_API_KEY` | `PROVIDER_B_API_KEY` |
-| `DEEPSEEK_API_KEY` | `PROVIDER_G_API_KEY` |
+| `DEEPSEEK_API_KEY` | `DEEPSEEK_API_KEY` |
 | `GLM_API_KEY` | `PROVIDER_K_API_KEY` |
 | `DASHSCOPE_API_KEY` | `PROVIDER_H_API_KEY` |
 | `CODEX_API_KEY` | `CLI_TOOL_A_API_KEY` |

--- a/docs/rfc/RFC-OAS-023-capability-axis-reshape.md
+++ b/docs/rfc/RFC-OAS-023-capability-axis-reshape.md
@@ -35,7 +35,7 @@ Moonshot        → Provider_b
 Kimi            → Provider_c
 OpenAI_compat   → Provider_d_compat
 Gemini          → Provider_f
-DeepSeek        → Provider_g
+DeepSeek        → DeepSeek
 DashScope       → Provider_h
 Mistral         → Provider_j
 Glm/GLM         → Provider_k
@@ -271,7 +271,7 @@ type transport_caps = {
 | `Provider_d` | `OpenAI` | model brand |
 | `Provider_d_compat` | `Chat_completions_v1` | **wire protocol** (OpenAI-호환 wire를 의미하므로) |
 | `Provider_f` | `Gemini` | model brand |
-| `Provider_g` | `DeepSeek` | model brand |
+| `DeepSeek` | `DeepSeek` | model brand |
 | `Provider_h` | `DashScope` | model brand |
 | `Provider_h_3` (Qwen family) | `Qwen` | model brand |
 | `Provider_j` | `Mistral` | model brand |
@@ -305,7 +305,7 @@ provider_k_capabilities             → glm_model_default_caps
 | `provider_a_capabilities` | `anthropic_model_caps` |
 | `provider_c_capabilities` | `kimi_model_caps` |
 | `provider_f_capabilities` | `gemini_model_caps` |
-| `provider_g_v4_pro_capabilities` | `deepseek_v4_pro_model_caps` |
+| `deepseek_v4_pro_capabilities` | `deepseek_v4_pro_model_caps` |
 | `provider_h_3_capabilities` | `qwen_3_model_caps` |
 | `provider_j_large_capabilities` | `mistral_large_model_caps` |
 | `provider_k_capabilities` | `glm_model_caps` |
@@ -357,8 +357,8 @@ provider_k_capabilities             → glm_model_default_caps
 | `glm-5.1:cloud` | GLM | Provider_k | — | **MISS** |
 | `qwen3.5` | Qwen | Provider_h_3 | `provider_h-3*` | **MISS** |
 | `kimi-k2.6:cloud` | Kimi | Provider_c | `provider_c-k2*` | **MISS** |
-| `deepseek-v4-pro:cloud` | DeepSeek | Provider_g | `provider_g-v4-pro*` | **MISS** |
-| `deepseek-v4-flash:cloud` | DeepSeek | Provider_g | `provider_g-v4-flash*` | **MISS** |
+| `deepseek-v4-pro:cloud` | DeepSeek | DeepSeek | `deepseek-v4-pro*` | **MISS** |
+| `deepseek-v4-flash:cloud` | DeepSeek | DeepSeek | `deepseek-v4-flash*` | **MISS** |
 | `qwen` | Qwen | Provider_h_3 | `provider_h-3*` | **MISS** |
 | `qwen-local-35b-a3b` | Qwen | Provider_h_3 | `provider_h-3*` | **MISS** |
 


### PR DESCRIPTION
## Summary
- remove remaining `Provider_g` / `provider_g` DeepSeek anonymization residue from OAS RFC docs
- keep DeepSeek entries direct (`DeepSeek`, `deepseek-v4-*`, `DEEPSEEK_API_KEY`) instead of the old Provider_G alias naming

## Validation
- `rg -n --hidden -S "Provider_G|Provider_g|provider_g|PROVIDER_G|provider-g|Provider-G" . --glob '!.git' --glob '!.git/**' --glob '!_build/**'` (only non-alias false positives remain)\n- `git diff --check`