### PR TITLE
[codex] fix gemma4 ollama thinking control

### DIFF
--- a/docs/capability-manifest.md
+++ b/docs/capability-manifest.md
@@ -97,6 +97,7 @@ for the full JSON Schema (draft-07).
 | `supports_seed` | bool | from base | Deterministic seed. |
 | `supports_computer_use` | bool | from base | Computer-use tools. |
 | `supports_code_execution` | bool | from base | Server-side code sandbox. |
+| `thinking_control_format` | string | from base | Thinking wire control. Accepted values: `none`, `thinking_object`, `thinking_object_only`, `chat_template_kwargs`, `chat_template_token`, `reasoning_effort`, `enable_thinking`. |
 
 Unknown fields are silently ignored (forward-compatible).
 

--- a/docs/gemma4-ollama-thinking.md
+++ b/docs/gemma4-ollama-thinking.md
@@ -1,0 +1,200 @@
+# Gemma 4 QAT on Ollama
+
+This note covers Gemma 4 QAT GGUF models served by local Ollama and consumed
+through OAS.
+
+## Summary
+
+Gemma 4 thinking is chat-template controlled. Do not treat it as the generic
+Ollama `/api/chat` `think` boolean path.
+
+For the Unsloth Gemma 4 QAT GGUF models, current Ollama advertises completion,
+tools, and vision capability, but rejects a top-level `think: true` request.
+The working path is:
+
+1. Register the model with `thinking_control_format = "chat_template_token"`.
+2. Omit the top-level `think` field when thinking is enabled.
+3. Prefix the system turn with `<|think|>`.
+4. Parse `message.thinking` from the Ollama response.
+
+OAS now handles that path for model IDs matching:
+
+```toml
+id_prefix = "hf.co/unsloth/gemma-4"
+```
+
+## Model Catalog Entry
+
+The built-in `models.toml` entry is:
+
+```toml
+[[models]]
+id_prefix = "hf.co/unsloth/gemma-4"
+base = "ollama"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = false
+thinking_control_format = "chat_template_token"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+supports_seed = true
+input_per_million = 0.0
+output_per_million = 0.0
+```
+
+`supports_reasoning_budget = false` is intentional. Gemma 4 thinking is an
+on/off chat-template mode here, not a budgeted `reasoning_effort` or
+`thinking_budget` transport.
+
+## Local Ollama Probe
+
+Pull or run the model with Ollama:
+
+```sh
+ollama run hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL
+```
+
+Inspect the server-side model metadata:
+
+```sh
+curl -sS http://127.0.0.1:11434/api/show \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL"}' \
+  | jq '{capabilities:.capabilities, template:.template, parameters:.parameters}'
+```
+
+The failure mode that this OAS patch avoids:
+
+```sh
+curl -sS -i http://127.0.0.1:11434/api/chat \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model":"hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL",
+    "messages":[{"role":"user","content":"Say OK only."}],
+    "stream":false,
+    "think":true,
+    "options":{"num_predict":8}
+  }'
+```
+
+Expected failure:
+
+```json
+{"error":"\"hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL\" does not support thinking"}
+```
+
+The working request shape omits `think` and uses the template token:
+
+```sh
+curl -sS http://127.0.0.1:11434/api/chat \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model":"hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL",
+    "messages":[
+      {"role":"system","content":"<|think|>\nYou are a helpful assistant."},
+      {"role":"user","content":"Solve 19*21. Give final answer briefly."}
+    ],
+    "stream":false,
+    "options":{"num_predict":256,"temperature":1.0,"top_p":0.95,"top_k":64}
+  }' | jq '{content:.message.content, thinking:.message.thinking}'
+```
+
+Expected shape:
+
+```json
+{
+  "content": "399",
+  "thinking": "..."
+}
+```
+
+## OAS Usage
+
+Use the normal Ollama provider config. Set `enable_thinking=true` when the turn
+should expose Gemma 4 thinking:
+
+```ocaml
+let config =
+  Llm_provider.Provider_config.make
+    ~kind:Ollama
+    ~model_id:"hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL"
+    ~base_url:"http://127.0.0.1:11434"
+    ~system_prompt:"You are a helpful assistant."
+    ~enable_thinking:true
+    ~temperature:1.0
+    ~top_p:0.95
+    ~top_k:64
+    ()
+;;
+```
+
+When `enable_thinking=true`, OAS sends a system message that starts with
+`<|think|>` and intentionally omits `think`. When thinking is disabled, OAS
+keeps the existing generic Ollama behavior and sends `think:false`.
+
+The Ollama response parser already maps `message.thinking` to an OAS
+`Thinking` content block.
+
+## MASC Runtime Wiring
+
+MASC should reference the same local Ollama model through `runtime.toml`.
+If the local Ollama provider is not already present, define it first:
+
+```toml
+[providers.ollama]
+display-name = "Local Ollama"
+protocol = "ollama-http"
+endpoint = "http://localhost:11434"
+```
+
+Then add the model and provider-model binding:
+
+```toml
+[models.gemma4-26b-a4b-qat]
+api-name = "hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL"
+max-context = 262144
+tools-support = true
+thinking-support = true
+streaming = true
+
+[ollama.gemma4-26b-a4b-qat]
+max-concurrent = 1
+```
+
+Then assign a keeper explicitly. MASC's current parser expects
+`[runtime.assignments]` as a TOML table of `keeper = "provider.model"` entries:
+
+```toml
+[runtime.assignments]
+"sangsu" = "ollama.gemma4-26b-a4b-qat"
+```
+
+Keep concurrency low at first. The 26B-A4B QAT model is large enough that
+parallel keeper turns can compete for local GPU/VRAM even when single-turn
+latency is acceptable.
+
+## Operational Notes
+
+- Do not set `OAS_OLLAMA_THINK_DEFAULT=true` globally unless every Ollama model
+  in that process can tolerate the selected thinking wire format.
+- For Gemma 4 QAT, prefer explicit per-turn `enable_thinking=true` over global
+  defaults.
+- Do not add previous turn thoughts back into multi-turn history. Keep only the
+  final assistant response in history unless a consumer intentionally persists
+  thinking blocks for observability.
+- Use the documented sampling defaults for Gemma 4 unless a workload has a
+  measured reason to change them: `temperature=1.0`, `top_p=0.95`, `top_k=64`.
+
+## Evidence
+
+- Source: Unsloth Gemma 4 QAT documentation provided by the operator in the
+  implementation request. Checked: 2026-06-12 Asia/Seoul. Confidence: High for
+  the chat-template contract.
+- Source: local Ollama probes against
+  `hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL`. Checked:
+  2026-06-12 Asia/Seoul. Confidence: High for the local `think:true` failure
+  and `message.thinking` success path.

--- a/docs/provider-catalog.md
+++ b/docs/provider-catalog.md
@@ -172,6 +172,7 @@ Accepted `thinking_control_format` values are:
 - `thinking_object` (top-level `thinking` object plus `reasoning_effort`)
 - `thinking_object_only` (top-level `thinking` object only)
 - `chat_template_kwargs`
+- `chat_template_token` (inject a model-specific thinking token into the chat template)
 - `reasoning_effort`
 - `enable_thinking` (top-level `enable_thinking` plus optional `thinking_budget`)
 

--- a/docs/schemas/capability-manifest-v1.json
+++ b/docs/schemas/capability-manifest-v1.json
@@ -128,6 +128,19 @@
         "supports_code_execution": {
           "type": "boolean",
           "description": "Whether the model supports server-side code execution (sandbox)."
+        },
+        "thinking_control_format": {
+          "type": "string",
+          "description": "Provider/model thinking control wire shape.",
+          "enum": [
+            "none",
+            "thinking_object",
+            "thinking_object_only",
+            "chat_template_kwargs",
+            "chat_template_token",
+            "reasoning_effort",
+            "enable_thinking"
+          ]
         }
       },
       "additionalProperties": true

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -96,8 +96,7 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
     | Some entries
       when entries <> []
            && capabilities.supports_tools
-           && should_include_tools ?provider_config config ->
-      Some entries
+           && should_include_tools ?provider_config config -> Some entries
     | _ -> None
   in
   let sanitized_messages = strip_orphaned_tool_results messages in
@@ -150,6 +149,7 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
         (match chat_template_kwargs_fields config with
          | [] -> body_assoc
          | fields -> ("chat_template_kwargs", `Assoc fields) :: body_assoc)
+      | Llm_provider.Capabilities.Chat_template_token -> body_assoc
       | Llm_provider.Capabilities.Enable_thinking ->
         let body_assoc =
           match config.config.enable_thinking with
@@ -209,7 +209,8 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
   in
   let body_assoc =
     match tools_to_send with
-    | Some entries -> ("tools", `List (List.map build_provider_d_tool_json entries)) :: body_assoc
+    | Some entries ->
+      ("tools", `List (List.map build_provider_d_tool_json entries)) :: body_assoc
     | None -> body_assoc
   in
   let body_assoc =

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -1,6 +1,7 @@
 (** Ollama native API request building and response parsing.
 
-    Uses [/api/chat] endpoint with [think] parameter for thinking control,
+    Uses [/api/chat] endpoint with [think] parameter for thinking control
+    except Gemma 4, whose documented thinking control is chat-template based,
     and [options] object for sampling parameters.
 
     @since 0.113.0 *)
@@ -9,9 +10,21 @@ open Types
 
 (* ── Request building ────────────────────────────────── *)
 
+let gemma4_think_token = "<|think|>"
+
+let with_gemma4_think_token = function
+  | Some prompt when not (Api_common.string_is_blank prompt) ->
+    let trimmed = String.trim prompt in
+    if String.starts_with ~prefix:gemma4_think_token trimmed
+    then trimmed
+    else gemma4_think_token ^ "\n" ^ trimmed
+  | _ -> gemma4_think_token
+;;
+
 (** Build Ollama native [/api/chat] request body.
     Key differences from Openai compat:
-    - [think] parameter (boolean) instead of [chat_template_kwargs]
+    - [think] parameter (boolean) instead of [chat_template_kwargs], except
+      Gemma 4 where thinking is triggered by [<|think|>] in the system prompt
     - Sampling params go inside [options] object
     - [num_predict] instead of [max_tokens]
     - No [tool_choice] support *)
@@ -22,8 +35,27 @@ let build_request
       ?(tools : Yojson.Safe.t list = [])
       ()
   =
+  let think_requested =
+    match config.enable_thinking with
+    | Some true -> true
+    | Some false -> false
+    | None -> Cli_common_env.bool "OAS_OLLAMA_THINK_DEFAULT"
+  in
+  let caps =
+    match Capabilities.for_model_id config.model_id with
+    | Some c -> c
+    | None -> Capabilities.ollama_capabilities
+  in
+  let gemma4_template_thinking =
+    think_requested && caps.thinking_control_format = Capabilities.Chat_template_token
+  in
+  let system_prompt =
+    if gemma4_template_thinking
+    then Some (with_gemma4_think_token config.system_prompt)
+    else config.system_prompt
+  in
   let provider_messages =
-    (match config.system_prompt with
+    (match system_prompt with
      | Some s when not (Api_common.string_is_blank s) ->
        [ `Assoc
            [ "role", `String "system"; "content", `String (Utf8_sanitize.sanitize s) ]
@@ -37,15 +69,16 @@ let build_request
   (* think: false by default for Ollama to prevent thinking models from
      consuming all tokens in reasoning. Only enable when explicitly requested.
      Override with OAS_OLLAMA_THINK_DEFAULT=true to enable thinking for all
-     Ollama requests by default. *)
-  let think =
-    match config.enable_thinking with
-    | Some true -> true
-    | Some false -> false
-    | None -> Cli_common_env.bool "OAS_OLLAMA_THINK_DEFAULT"
-    (* default false: thinking models consume tokens in reasoning *)
+     Ollama requests by default.
+
+     Gemma 4 is the exception: current Ollama rejects [think:true] for the
+     Unsloth/Google Gemma 4 GGUFs even though the model's documented control is
+     the [<|think|>] chat-template token. For that family we inject the token
+     into the system turn and omit the top-level [think] field so Ollama returns
+     [message.thinking] instead of failing the request. *)
+  let body =
+    if gemma4_template_thinking then body else ("think", `Bool think_requested) :: body
   in
-  let body = ("think", `Bool think) :: body in
   (* Ollama defaults to stream=true, so always send explicit value *)
   let body = ("stream", `Bool stream) :: body in
   (* keep_alive: controls how long the model stays loaded in memory after
@@ -121,11 +154,6 @@ let build_request
      fires when an operator explicitly sets [supports_min_p = false]
      or [supports_top_k = false] for a specific Ollama variant — at
      which point the one-shot WARN from Backend_openai also fires. *)
-  let caps =
-    match Capabilities.for_model_id config.model_id with
-    | Some c -> c
-    | None -> Capabilities.ollama_capabilities
-  in
   let options = ref [] in
   (let mt =
      Option.value ~default:Constants.unknown_model_max_tokens_fallback config.max_tokens

--- a/lib/llm_provider/backend_ollama.mli
+++ b/lib/llm_provider/backend_ollama.mli
@@ -1,7 +1,7 @@
 (** Ollama native API backend.
 
     Builds requests for [/api/chat] endpoint with [think] parameter
-    and parses native API responses.
+    except for Gemma 4 chat-template thinking, and parses native API responses.
 
     @since 0.113.0 *)
 

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -223,6 +223,7 @@ let build_request
       (match chat_template_kwargs_fields config with
        | [] -> body
        | fields -> ("chat_template_kwargs", `Assoc fields) :: body)
+    | Chat_template_token -> body
     | Enable_thinking ->
       let body =
         match config.enable_thinking with
@@ -328,9 +329,7 @@ let build_request
         ~supports_parallel_tool_calls:caps.supports_parallel_tool_calls
         ~tools_present
     in
-    Backend_openai_serialize.parallel_tool_calls_fields
-      ~disable_parallel
-      ~tools_present
+    Backend_openai_serialize.parallel_tool_calls_fields ~disable_parallel ~tools_present
     @ body
   in
   let body =

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -21,6 +21,9 @@ type thinking_control_format =
   | Chat_template_kwargs
   (** llama-server/vLLM/SGLang style:
       [{"chat_template_kwargs":{"enable_thinking":b,"preserve_thinking":b}}] *)
+  | Chat_template_token
+  (** Chat-template control token style: inject a model-specific thinking token
+      into the conversation instead of sending a top-level thinking field. *)
   | Reasoning_effort
   (** Openai-style top-level [reasoning_effort] string field. The set of
       values this codebase emits is [{"none","low","medium","high"}] —
@@ -440,6 +443,7 @@ let thinking_control_format_of_manifest_string raw =
   | "thinking_object" -> Some Thinking_object
   | "thinking_object_only" -> Some Thinking_object_only
   | "chat_template_kwargs" -> Some Chat_template_kwargs
+  | "chat_template_token" -> Some Chat_template_token
   | "reasoning_effort" -> Some Reasoning_effort
   | "enable_thinking" -> Some Enable_thinking
   | _ -> None

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -15,6 +15,10 @@ type thinking_control_format =
   | Chat_template_kwargs
   (** llama-server/vLLM/SGLang style:
       [{"chat_template_kwargs":{"enable_thinking":b,"preserve_thinking":b}}] *)
+  | Chat_template_token
+  (** Chat-template control token style: the request builder injects a model
+      token such as [<|think|>] into the rendered conversation instead of
+      sending a top-level thinking field. *)
   | Reasoning_effort
   (** Openai-style top-level [reasoning_effort] string field. The set of
       values this codebase emits is [{"none","low","medium","high"}] —

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -30,8 +30,8 @@ type entry =
   ; supports_code_execution : bool option
   ; thinking_control_format : string option
     (** Canonical thinking-wire format the model uses (none / thinking_object /
-        thinking_object_only / chat_template_kwargs / reasoning_effort /
-        enable_thinking). Parsed + applied in
+        thinking_object_only / chat_template_kwargs / chat_template_token /
+        reasoning_effort / enable_thinking). Parsed + applied in
         {!Capabilities.apply_manifest_entry}. Without this field a manifest
         entry silently dropped the model's thinking knob (RFC-OAS-023). *)
   }

--- a/lib/llm_provider/capability_manifest.mli
+++ b/lib/llm_provider/capability_manifest.mli
@@ -72,8 +72,9 @@ type entry =
   ; supports_code_execution : bool option
   ; thinking_control_format : string option
     (** Canonical thinking-wire format (none / thinking_object /
-        thinking_object_only / chat_template_kwargs / reasoning_effort /
-        enable_thinking); applied in {!Capabilities.apply_manifest_entry}. *)
+        thinking_object_only / chat_template_kwargs / chat_template_token /
+        reasoning_effort / enable_thinking); applied in
+        {!Capabilities.apply_manifest_entry}. *)
   }
 
 (** A parsed capability manifest: an ordered list of model entries.

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -186,14 +186,15 @@ let parse_thinking_control_format = function
      | "thinking_object" -> Ok (Some Capabilities.Thinking_object)
      | "thinking_object_only" -> Ok (Some Capabilities.Thinking_object_only)
      | "chat_template_kwargs" -> Ok (Some Capabilities.Chat_template_kwargs)
+     | "chat_template_token" -> Ok (Some Capabilities.Chat_template_token)
      | "reasoning_effort" -> Ok (Some Capabilities.Reasoning_effort)
      | "enable_thinking" -> Ok (Some Capabilities.Enable_thinking)
      | other ->
        Error
          (Printf.sprintf
             "unknown thinking_control_format %S (canonical: none, thinking_object, \
-             thinking_object_only, chat_template_kwargs, reasoning_effort, \
-             enable_thinking)"
+             thinking_object_only, chat_template_kwargs, chat_template_token, \
+             reasoning_effort, enable_thinking)"
             other))
 ;;
 

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -58,6 +58,7 @@ type thinking_control_format = Llm_provider.Capabilities.thinking_control_format
   | Thinking_object
   | Thinking_object_only (** @since 0.196.11 *)
   | Chat_template_kwargs
+  | Chat_template_token
   | Reasoning_effort (** @since 0.195.0 *)
   | Enable_thinking (** @since 0.196.11 *)
 

--- a/models.toml
+++ b/models.toml
@@ -728,6 +728,23 @@ supports_image_input = true
 supports_native_streaming = true
 supports_seed = true
 
+[[models]]
+id_prefix = "hf.co/unsloth/gemma-4"
+base = "ollama"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = false
+thinking_control_format = "chat_template_token"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+supports_seed = true
+input_per_million = 0.0
+output_per_million = 0.0
+
 # Generic/Ollama/Other Fallbacks
 [[models]]
 id_prefix = "ollama"

--- a/test/test_provider_catalog_coverage.ml
+++ b/test/test_provider_catalog_coverage.ml
@@ -255,6 +255,11 @@ let test_transport_auth_and_thinking_canonical_matrix () =
             "capabilities": {"thinking_control_format": "enable_thinking"}
           },
           {
+            "id": "template-token",
+            "kind": "ollama",
+            "capabilities": {"thinking_control_format": "chat_template_token"}
+          },
+          {
             "id": "base-entry",
             "kind": "openai_compat",
             "capabilities_base": "openai_chat",
@@ -303,6 +308,13 @@ let test_transport_auth_and_thinking_canonical_matrix () =
     "enable thinking"
     true
     (enable.capabilities.thinking_control_format = Capabilities.Enable_thinking);
+  let template_token = require_lookup catalog "template-token" in
+  check
+    bool
+    "template token thinking"
+    true
+    (template_token.capabilities.thinking_control_format
+     = Capabilities.Chat_template_token);
   let base = require_lookup catalog "base-entry" in
   check bool "capabilities_base supports tools" true base.capabilities.supports_tools;
   check
@@ -310,7 +322,7 @@ let test_transport_auth_and_thinking_canonical_matrix () =
     "oversized prompt alignment ignored"
     None
     base.capabilities.prompt_cache_alignment;
-  check int "catalog size" 6 (List.length catalog)
+  check int "catalog size" 7 (List.length catalog)
 ;;
 
 let test_removed_catalog_aliases_are_rejected () =

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -268,6 +268,36 @@ let test_ollama_output_schema () =
   Alcotest.(check bool) "format copied" true (json |> member "format" = schema)
 ;;
 
+let test_ollama_gemma4_thinking_uses_template_token () =
+  let config =
+    PC.make
+      ~kind:Ollama
+      ~model_id:"hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL"
+      ~base_url:"http://localhost:11434"
+      ~system_prompt:"You are a helpful assistant."
+      ~enable_thinking:true
+      ()
+  in
+  let body = BOL.build_request ~config ~messages:[ user_msg "solve 19*21" ] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  Alcotest.(check bool)
+    "omits top-level think for Gemma 4"
+    true
+    (json |> member "think" = `Null);
+  let first_message = json |> member "messages" |> index 0 in
+  Alcotest.(check string)
+    "system role"
+    "system"
+    (first_message |> member "role" |> to_string);
+  Alcotest.(check bool)
+    "system prompt starts with Gemma 4 think token"
+    true
+    (String.starts_with
+       ~prefix:"<|think|>\n"
+       (first_message |> member "content" |> to_string))
+;;
+
 let test_ollama_parse_parallel_tool_calls_object_arguments () =
   let body =
     {|{"model":"dashscope-3:8b","done":true,"done_reason":"tool_calls",
@@ -1049,6 +1079,10 @@ let () =
         ; test_case "stream flag" `Quick test_provider_d_stream_flag
         ; test_case "with json schema" `Quick test_provider_d_with_json_schema
         ; test_case "ollama output schema" `Quick test_ollama_output_schema
+        ; test_case
+            "ollama gemma4 thinking uses template token"
+            `Quick
+            test_ollama_gemma4_thinking_uses_template_token
         ; test_case
             "ollama parse parallel tool calls object args"
             `Quick


### PR DESCRIPTION
## What changed

- Added `chat_template_token` as a thinking control format in provider capabilities, catalog parsing, public provider types, docs, and schema metadata.
- Registered `hf.co/unsloth/gemma-4` Ollama models in `models.toml` with reasoning enabled and `thinking_control_format = "chat_template_token"`.
- Updated the native Ollama request builder so Gemma 4 QAT thinking uses the documented chat-template control token path:
  - when `enable_thinking=true`, prefix the system turn with `<|think|>`;
  - omit the top-level Ollama `think` field for this model family;
  - keep existing generic Ollama `think:true/false` behavior for all other model families.
- Added focused tests for the Gemma 4 Ollama request shape and provider catalog parsing.
- Added a detailed operations manual at `docs/gemma4-ollama-thinking.md` covering local Ollama probes, expected failure mode, working request shape, OAS usage, and MASC `runtime.toml` wiring.

## Why

Gemma 4 QAT GGUF through Ollama is not the same as the generic Ollama thinking path. Local probes showed that Ollama rejects `think:true` for `hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL` with `does not support thinking`, while the documented Gemma 4 control-token path works when the request omits `think` and injects `<|think|>` into the system prompt.

## Root cause

OAS only modeled Ollama thinking as the top-level `/api/chat` `think` boolean. That is correct for generic Ollama thinking-capable models, but Gemma 4 uses chat-template/control-token thinking. The provider catalog had no way to represent that transport difference, so enabling thinking would send the wrong wire shape.

## Impact

MASC/OAS can now run local Unsloth Gemma 4 QAT models with `thinking-support = true` via Ollama while preserving the old Ollama behavior for non-Gemma models. Response parsing continues to use Ollama `message.thinking`, which was already mapped into OAS thinking content blocks.

## Manual

See `docs/gemma4-ollama-thinking.md` for:

- local `ollama run` and `/api/show` checks;
- the failing `think:true` request and expected error;
- the working `<|think|>` request shape;
- OCaml OAS provider config;
- MASC `runtime.toml` provider/model/binding/assignment snippets;
- operational notes for concurrency, global thinking defaults, and multi-turn history.

## Validation

- `scripts/dune-local.sh build @runtest-test_provider_complete`
- `scripts/dune-local.sh build @runtest-test_provider_catalog_coverage`
- `scripts/dune-local.sh build @lib/llm_provider/runtest`
- `git diff --check`

Touched OCaml files were formatted with `ocamlformat -i`. Full `@fmt` was not used as a gate because it reports existing unrelated formatting drift outside this patch.