### PR TITLE
docs: canonicalize example capability bases

### DIFF
--- a/docs/example-capability-manifest.json
+++ b/docs/example-capability-manifest.json
@@ -5,7 +5,7 @@
     {
       "_comment": "Kimi K2.6 — Moonshot AI. 1T MoE / 32B active. 256K ctx. Top-level thinking + budget. Released 2026-04-20. https://platform.kimi.ai/docs/guide/kimi-k2-6-quickstart",
       "id_prefix": "kimi-k2.6",
-      "base_label": "provider_d_chat",
+      "base_label": "openai_chat",
       "max_context_tokens": 262144,
       "supports_tools": true,
       "supports_tool_choice": true,
@@ -17,9 +17,8 @@
       "supports_system_prompt": true
     },
     {
-      "_comment": "GPT-5.3-Codex-Spark — OpenAI. Codex/ChatGPT-Pro subscription required, NOT public chat completions API. Reachable via Codex CLI bridge (non-interactive batch invocation), so base_label is cli_tool_a (Cli_tool_a transport) not provider_d_chat. supports_native_streaming=false because non-interactive call surface streams whole response. https://openai.com/index/introducing-gpt-5-3-codex-spark/",
+      "_comment": "GPT-5.3-Codex-Spark — OpenAI. Codex/ChatGPT-Pro subscription required, NOT public chat completions API. No base_label is set because this entry does not inherit a public chat-completions provider preset. supports_native_streaming=false because non-interactive call surface streams whole response. https://openai.com/index/introducing-gpt-5-3-codex-spark/",
       "id_prefix": "gpt-5.3-codex-spark",
-      "base_label": "cli_tool_a",
       "max_context_tokens": 131072,
       "supports_tools": true,
       "supports_tool_choice": true,
@@ -30,7 +29,7 @@
     {
       "_comment": "GPT-4.1 — OpenAI. 1M ctx, 32K output, image input, no extended thinking. https://openai.com/index/gpt-4-1/",
       "id_prefix": "gpt-4.1",
-      "base_label": "provider_d_chat",
+      "base_label": "openai_chat",
       "max_context_tokens": 1047576,
       "max_output_tokens": 32768,
       "supports_tools": true,
@@ -42,7 +41,7 @@
     {
       "_comment": "GLM-5.1 — Zhipu/Z.AI. 744B MoE / 40B active. 200K ctx, 128K output. Thinking on/off. Released 2026-04-07. https://docs.z.ai/guides/llm/glm-5.1",
       "id_prefix": "glm-5.1",
-      "base_label": "provider_d_chat",
+      "base_label": "openai_chat",
       "max_context_tokens": 200000,
       "max_output_tokens": 128000,
       "supports_tools": true,
@@ -54,7 +53,7 @@
     {
       "_comment": "GLM-5 Turbo — Z.AI faster tier of GLM-5. Same 202K ctx (CORRECTED — turbo is NOT smaller-context). 131K output. https://openrouter.ai/z-ai/glm-5-turbo",
       "id_prefix": "glm-5-turbo",
-      "base_label": "provider_d_chat",
+      "base_label": "openai_chat",
       "max_context_tokens": 202752,
       "max_output_tokens": 131072,
       "supports_tools": true,
@@ -66,7 +65,7 @@
     {
       "_comment": "GLM-5 — Z.AI. 202K ctx (CORRECTED — was 128K), 98K output. Released 2026-02-11. https://docs.z.ai/guides/llm/glm-5",
       "id_prefix": "glm-5",
-      "base_label": "provider_d_chat",
+      "base_label": "openai_chat",
       "max_context_tokens": 202752,
       "max_output_tokens": 98304,
       "supports_tools": true,
@@ -78,7 +77,7 @@
     {
       "_comment": "Gemma 4 E2B — Google. 131K ctx. Native function calling (CORRECTED — prior tools=false was WRONG). Multimodal (image input). https://ai.google.dev/gemma/docs/capabilities/text/function-calling-gemma4",
       "id_prefix": "gemma4",
-      "base_label": "provider_d_chat",
+      "base_label": "openai_chat",
       "max_context_tokens": 131072,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -88,7 +87,7 @@
     {
       "_comment": "Qwen3.5-Plus — Alibaba DashScope. 1M ctx (CORRECTED — was 128K), 65K output. enable_thinking with 3 budget modes. https://openrouter.ai/qwen/qwen3.5-plus-20260420",
       "id_prefix": "qwen3.5",
-      "base_label": "provider_d_chat",
+      "base_label": "openai_chat",
       "max_context_tokens": 1000000,
       "max_output_tokens": 65536,
       "supports_tools": true,
@@ -102,7 +101,7 @@
     {
       "_comment": "Qwen3.5-35B-A3B — Local llama-server / vLLM. 256K native ctx (CORRECTED — was 128K; extensible to 1M via YaRN). enable_thinking default on. https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
       "id_prefix": "qwen-local-35b-a3b",
-      "base_label": "provider_d_chat",
+      "base_label": "openai_chat",
       "max_context_tokens": 262144,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -112,13 +111,13 @@
     {
       "_comment": "qwen — generic alias, capability 모델 따라 다름. base inherit. downstream qwen3.5 / qwen-local-35b-a3b entries 가 더 정확.",
       "id_prefix": "qwen",
-      "base_label": "provider_d_chat",
+      "base_label": "openai_chat",
       "supports_native_streaming": true
     },
     {
       "_comment": "DeepSeek V4 Pro — 1.6T MoE / 49B active. 1M ctx, 65K output, reasoning_effort 3 modes (incl. Think Max), image input, prompt caching native. https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro",
       "id_prefix": "deepseek-v4-pro",
-      "base_label": "provider_d_chat",
+      "base_label": "openai_chat",
       "max_context_tokens": 1000000,
       "max_output_tokens": 65536,
       "supports_tools": true,
@@ -133,7 +132,7 @@
     {
       "_comment": "DeepSeek V4 Flash — 284B MoE / 13B active. 1M ctx (CORRECTED — was 64K; Flash differentiation is parameters not context). Same 3 effort modes, image input. https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
       "id_prefix": "deepseek-v4-flash",
-      "base_label": "provider_d_chat",
+      "base_label": "openai_chat",
       "max_context_tokens": 1000000,
       "max_output_tokens": 65536,
       "supports_tools": true,

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -507,6 +507,31 @@ let test_manifest_base_absent_uses_default () =
   | None -> fail "expected Some"
 ;;
 
+let test_example_manifest_base_labels_are_canonical () =
+  let path =
+    [ "docs/example-capability-manifest.json"
+    ; "../docs/example-capability-manifest.json"
+    ; "../../docs/example-capability-manifest.json"
+    ]
+    |> List.find_opt Sys.file_exists
+    |> Option.value ~default:"docs/example-capability-manifest.json"
+  in
+  match Capability_manifest.load_file path with
+  | Error msg -> failf "example manifest should parse: %s" msg
+  | Ok entries ->
+    List.iter
+      (fun (entry : Capability_manifest.entry) ->
+         match entry.base_label with
+         | None -> ()
+         | Some label ->
+           check
+             bool
+             (Printf.sprintf "base label resolves for %s: %s" entry.id_prefix label)
+             true
+             (Option.is_some (Capabilities.capabilities_for_provider_label label)))
+      entries
+;;
+
 let test_manifest_prefix_wins_over_longer_static_prefix () =
   (* Manifest entry "dashscope-3" must win over static table "dashscope-3" prefix too,
      letting operator override even well-known models. *)
@@ -862,6 +887,10 @@ let () =
         ; test_case "base openai_chat" `Quick test_manifest_base_label_openai_chat
         ; test_case "base anthropic" `Quick test_manifest_base_label_provider_a
         ; test_case "base absent = default" `Quick test_manifest_base_absent_uses_default
+        ; test_case
+            "example base labels are canonical"
+            `Quick
+            test_example_manifest_base_labels_are_canonical
         ; test_case
             "manifest prefix wins"
             `Quick


### PR DESCRIPTION
## Summary

- replace stale `provider_d_chat` base labels in the example capability manifest with the canonical `openai_chat` label
- remove the stale `cli_tool_a` inheritance from the Codex Spark example entry, because CLI-specific capability records were removed
- add a regression test that loads `docs/example-capability-manifest.json` and verifies every `base_label` resolves through `Capabilities.capabilities_for_provider_label`

## Scope

This intentionally leaves historical RFC/audit references alone. The goal is to clean the runtime-facing example manifest, not rewrite provenance notes.

## Validation

- `jq . docs/example-capability-manifest.json`
- `rg -n "provider_d_chat|cli_tool_a" docs/example-capability-manifest.json test/test_capabilities.ml` returned no matches
- `git diff --check`
- `scripts/dune-local.sh build test/test_capabilities.exe`
- `./_build/default/test/test_capabilities.exe test manifest 6`

## Known pre-existing local test failures

Full `./_build/default/test/test_capabilities.exe` currently still fails outside this change in `model_lookup`:

- `kimi-k2 cloud`: catalog returns `Some 262144`, while the test expects `Some 256000`
- `grok 2M context`: `model-e` is not present in `models.toml`

The new manifest regression case passes.
