### PR TITLE
[codex] Deduplicate streaming request flag

### DIFF
--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -880,7 +880,9 @@ let read_ndjson ?clock ?idle_timeout ~reader ~on_line () =
 
 let inject_stream_param body_str =
   match Yojson.Safe.from_string body_str with
-  | `Assoc fields -> Yojson.Safe.to_string (`Assoc (("stream", `Bool true) :: fields))
+  | `Assoc fields ->
+    let without_existing = List.filter (fun (k, _) -> k <> "stream") fields in
+    Yojson.Safe.to_string (`Assoc (("stream", `Bool true) :: without_existing))
   | other -> Yojson.Safe.to_string other
   | exception Yojson.Json_error _ -> body_str
 ;;

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -316,7 +316,8 @@ val read_ndjson
     provider cannot help — the bottleneck is the local machine. *)
 val is_local_resource_exhaustion : http_error -> bool
 
-(** Inject ["stream": true] into a JSON body string. *)
+(** Inject ["stream": true] into a JSON body string.
+    Any caller-supplied [stream] is replaced to avoid duplicate object keys. *)
 val inject_stream_param : string -> string
 
 (** Inject [{"stream_options": {"include_usage": true}}] into a JSON body

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -19,15 +19,14 @@ let test_inject_stream_param_existing_stream () =
   let body = {|{"stream":false,"model":"test"}|} in
   let result = Http_client.inject_stream_param body in
   let json = Yojson.Safe.from_string result in
-  (* stream=true is prepended; the duplicate "stream":false is still there
-     but the first occurrence wins in most JSON parsers. *)
   let fields =
     match json with
     | `Assoc fs -> fs
     | _ -> []
   in
-  let first_stream = List.assoc "stream" fields in
-  Alcotest.(check bool) "first stream is true" true (first_stream = `Bool true)
+  let stream_fields = List.filter (fun (k, _) -> k = "stream") fields in
+  Alcotest.(check int) "one stream key" 1 (List.length stream_fields);
+  Alcotest.(check bool) "stream is true" true (List.assoc "stream" fields = `Bool true)
 ;;
 
 let test_inject_stream_param_non_json () =


### PR DESCRIPTION
## Summary
- make `Http_client.inject_stream_param` replace existing `stream` fields before adding `stream=true`
- update the existing-stream test so duplicate JSON object keys are rejected by contract
- document the replacement behavior in the interface

Fixes #2021.

## Why
OpenAI-compatible streaming can already include `stream` when `Backend_openai.build_request ~stream:true` is used. The later streaming helper prepended a second `stream` key. DeepSeek Platform rejects duplicate object keys with `duplicate field `stream``, so this must be fixed in OAS rather than worked around by MASC provider config.

## Validation
- `env DUNE_BUILD_DIR=/private/tmp/oas-dedup-stream-build dune build --root . test/test_http_client.exe`
- `/private/tmp/oas-dedup-stream-build/default/test/test_http_client.exe`
- `git diff --check`