### PR TITLE
fix(glm): honor preserve thinking in ZAI requests

### DIFF
--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -89,6 +89,15 @@ exception Glm_api_error of provider_k_error
 
 (* ── Request building ────────────────────────────── *)
 
+let clear_thinking_of_config (config : Provider_config.t) =
+  match config.clear_thinking with
+  | Some clear -> clear
+  | None ->
+    (match config.preserve_thinking with
+     | Some preserve -> not preserve
+     | None -> true)
+;;
+
 let build_request
       ?(stream = false)
       ~(config : Provider_config.t)
@@ -112,7 +121,7 @@ let build_request
     let fields =
       match config.enable_thinking with
       | Some true ->
-        let clear_thinking = Option.value ~default:true config.clear_thinking in
+        let clear_thinking = clear_thinking_of_config config in
         ( "thinking"
         , `Assoc [ "type", `String "enabled"; "clear_thinking", `Bool clear_thinking ] )
         :: fields
@@ -272,9 +281,34 @@ let%test "build_request can preserve reasoning on demand" =
     Provider_config.make
       ~kind:Glm
       ~model_id:"glm-5"
-      ~base_url:"https://api.z.ai/api/coding/paas/v4"
+      ~base_url:Zai_catalog.coding_base_url
       ~enable_thinking:true
       ~clear_thinking:false
+      ()
+  in
+  let messages =
+    [ { role = User
+      ; content = [ Text "reason" ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let body = build_request ~config ~messages () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  json |> member "thinking" |> member "clear_thinking" |> to_bool = false
+;;
+
+let%test "build_request maps preserve_thinking to GLM clear_thinking=false" =
+  let config =
+    Provider_config.make
+      ~kind:Glm
+      ~model_id:"glm-5"
+      ~base_url:"https://api.z.ai/api/coding/paas/v4"
+      ~enable_thinking:true
+      ~preserve_thinking:true
       ()
   in
   let messages =

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -1300,6 +1300,22 @@ let%test "build_request serializes ZAI thinking object for bare GLM compat model
   && json |> member "reasoning_effort" = `Null
 ;;
 
+let%test "build_request maps preserve_thinking for bare ZAI GLM compat model" =
+  let config =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"glm-5"
+      ~base_url:Zai_catalog.coding_base_url
+      ~enable_thinking:true
+      ~preserve_thinking:true
+      ()
+  in
+  let body = build_request ~config ~messages:[] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  json |> member "thinking" |> member "clear_thinking" |> to_bool = false
+;;
+
 let%test "build_request emits reasoning_effort for Openai reasoning models" =
   let config =
     Provider_config.make

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -111,6 +111,15 @@ let chat_template_kwargs_fields (config : Provider_config.t) =
   @ bool_field "preserve_thinking" config.preserve_thinking
 ;;
 
+let glm_clear_thinking_of_config (config : Provider_config.t) =
+  match config.clear_thinking with
+  | Some clear -> clear
+  | None ->
+    (match config.preserve_thinking with
+     | Some preserve -> not preserve
+     | None -> true)
+;;
+
 let is_zai_glm_request (config : Provider_config.t) =
   Zai_catalog.is_zai_base_url config.base_url
   && Zai_catalog.is_glm_model_id config.model_id
@@ -277,7 +286,7 @@ let build_request
              `Assoc
                [ "type", `String "enabled"
                ; ( "clear_thinking"
-                 , `Bool (Option.value ~default:true config.clear_thinking) )
+                 , `Bool (glm_clear_thinking_of_config config) )
                ]
            else `Assoc [ "type", `String "disabled" ]
          in


### PR DESCRIPTION
## Summary
- map OAS preserve_thinking=true to Z.AI thinking.clear_thinking=false for native Glm requests
- apply the same mapping to the ZAI GLM OpenAI-compatible request path
- keep glm and glm-coding as separate registry/provider surfaces; this does not merge auth, endpoint, or provider identity

## Notes
- GLM Coding Plan remains the existing glm-coding provider: https://api.z.ai/api/coding/paas/v4 + ZAI_CODING_API_KEY.
- General GLM remains https://api.z.ai/api/paas/v4 + ZAI_API_KEY.
- Strict model catalog already contains the GLM Coding Plan models/prefixes used here, so this PR does not add loose model aliases.

## Evidence
- Z.AI docs checked 2026-06-12 Asia/Seoul: Quick Start documents the dedicated Coding endpoint separately from the general endpoint.
- Z.AI Thinking Mode docs checked 2026-06-12 Asia/Seoul: preserved thinking is controlled with thinking.clear_thinking=false and requires reasoning_content replay.

## Verification
- env MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=/tmp/oas-glm-coding-provider-build scripts/dune-local.sh build test/test_backend_glm_coverage.exe test/test_provider_complete.exe test/test_provider_registry.exe test/test_provider_config.exe test/test_provider_bridge.exe
- /tmp/oas-glm-coding-provider-build/default/test/test_backend_glm_coverage.exe
- /tmp/oas-glm-coding-provider-build/default/test/test_provider_complete.exe
- /tmp/oas-glm-coding-provider-build/default/test/test_provider_registry.exe
- /tmp/oas-glm-coding-provider-build/default/test/test_provider_config.exe
- /tmp/oas-glm-coding-provider-build/default/test/test_provider_bridge.exe

## Non-blocking local note
- test/test_capabilities.exe and test/test_llm_provider_cov.exe are sensitive to ambient OAS_MODEL_CATALOG/OAS_CAPABILITY_MANIFEST on this machine. In this workspace they pick up repo models.toml and /Users/dancer/me/.masc/config/capability-manifest.json, causing pre-existing expectation drift unrelated to this PR.