### PR TITLE
feat(event_bus): carry provider tool_use_id on ToolCalled/ToolCompleted

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -302,7 +302,7 @@ let find_and_execute_tool_with_index
         Event_bus.mk_event
           ?correlation_id
           ?run_id
-          (ToolCalled { agent_name; tool_name = name; input })
+          (ToolCalled { agent_name; tool_name = name; tool_use_id = id; input })
       in
       (try Event_bus.publish bus ev with
        | exn ->
@@ -576,7 +576,7 @@ let find_and_execute_tool_with_index
              ?correlation_id
              ?run_id
              ?caused_by:tool_called_run_id
-             (ToolCompleted { agent_name; tool_name = name; output }))
+             (ToolCompleted { agent_name; tool_name = name; tool_use_id = id; output }))
       with
       | exn ->
         Log.warn

--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -47,11 +47,13 @@ type payload =
   | ToolCalled of
       { agent_name : string
       ; tool_name : string
+      ; tool_use_id : string
       ; input : Yojson.Safe.t
       }
   | ToolCompleted of
       { agent_name : string
       ; tool_name : string
+      ; tool_use_id : string
       ; output : Types.tool_result
       }
   | TurnStarted of

--- a/lib/event_bus.mli
+++ b/lib/event_bus.mli
@@ -66,11 +66,22 @@ type payload =
   | ToolCalled of
       { agent_name : string
       ; tool_name : string
+      ; tool_use_id : string
+        (** Provider tool-call id (e.g. Anthropic [tool_use.id], OpenAI
+            [tool_call.id]) for the invocation this event describes. The
+            same value reaches {!Hooks.PreToolUse}/{!Hooks.PostToolUse},
+            so subscribers can join bus events with hook-side records
+            deterministically instead of guessing by tool name and
+            timestamp. Empty string when the provider supplied no id.
+            @since 0.207.0 *)
       ; input : Yojson.Safe.t
       }
   | ToolCompleted of
       { agent_name : string
       ; tool_name : string
+      ; tool_use_id : string
+        (** Same id as the matching [ToolCalled]; see its doc.
+            @since 0.207.0 *)
       ; output : Types.tool_result
       }
   | TurnStarted of

--- a/lib/event_forward.ml
+++ b/lib/event_forward.ml
@@ -124,12 +124,14 @@ let event_to_payload (event : Event_bus.event) : event_payload =
       `Assoc
         [ "agent_name", `String r.agent_name
         ; "tool_name", `String r.tool_name
+        ; "tool_use_id", `String r.tool_use_id
         ; "input", r.input
         ]
     | ToolCompleted r ->
       `Assoc
         [ "agent_name", `String r.agent_name
         ; "tool_name", `String r.tool_name
+        ; "tool_use_id", `String r.tool_use_id
         ; "success", `Bool (Result.is_ok r.output)
         ]
     | TurnStarted r -> `Assoc [ "agent_name", `String r.agent_name; "turn", `Int r.turn ]

--- a/test/test_approval.ml
+++ b/test/test_approval.ml
@@ -739,9 +739,10 @@ let test_tool_exception_still_publishes_tool_completed () =
       (fun (event : Event_bus.event) -> event.payload)
       (Event_bus.drain subscription)
   with
-  | [ ToolCalled { tool_name = "boom"; _ }
+  | [ ToolCalled { tool_name = "boom"; tool_use_id = called_id; _ }
     ; ToolCompleted
         { tool_name = "boom"
+        ; tool_use_id = completed_id
         ; output = Error { message; recoverable = false; error_class = Some Unknown }
         ; _
         }
@@ -750,7 +751,11 @@ let test_tool_exception_still_publishes_tool_completed () =
       bool
       "completion event reports exception"
       true
-      (contains_substring ~needle:"Tool 'boom' raised" message)
+      (contains_substring ~needle:"Tool 'boom' raised" message);
+    (* Both events carry the provider tool_use id, so subscribers can
+       join called/completed pairs (and hook-side records) on it. *)
+    check string "ToolCalled carries the provider id" "t1" called_id;
+    check string "ToolCompleted carries the provider id" "t1" completed_id
   | _ -> fail "expected ToolCalled followed by ToolCompleted error"
 ;;
 

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -205,13 +205,14 @@ let test_eval_collector_basic () =
   Event_bus.publish
     bus
     (Event_bus.mk_event
-       (ToolCalled { agent_name = "test"; tool_name = "t1"; input = `Null }));
+       (ToolCalled { agent_name = "test"; tool_name = "t1"; tool_use_id = "tu-test"; input = `Null }));
   Event_bus.publish
     bus
     (Event_bus.mk_event
        (ToolCompleted
           { agent_name = "test"
           ; tool_name = "t1"
+          ; tool_use_id = "tu-test"
           ; output = Ok { Types.content = "done" }
           }));
   let rm = Eval_collector.finalize ec in

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -149,12 +149,12 @@ let test_filter_tools_only () =
   Event_bus.publish bus (ev (TurnStarted { agent_name = "a"; turn = 0 }));
   Event_bus.publish
     bus
-    (ev (ToolCalled { agent_name = "a"; tool_name = "calc"; input = `Null }));
+    (ev (ToolCalled { agent_name = "a"; tool_name = "calc"; tool_use_id = "tu-test"; input = `Null }));
   Event_bus.publish
     bus
     (ev
        (ToolCompleted
-          { agent_name = "a"; tool_name = "calc"; output = Ok { Types.content = "42" } }));
+          { agent_name = "a"; tool_name = "calc"; tool_use_id = "tu-test"; output = Ok { Types.content = "42" } }));
   Event_bus.publish bus (ev (TurnCompleted { agent_name = "a"; turn = 0 }));
   let events = Event_bus.drain sub in
   check int "only tool events" 2 (List.length events)
@@ -178,7 +178,7 @@ let test_accept_all () =
   Event_bus.publish bus (ev (TurnStarted { agent_name = "a"; turn = 0 }));
   Event_bus.publish
     bus
-    (ev (ToolCalled { agent_name = "a"; tool_name = "x"; input = `Null }));
+    (ev (ToolCalled { agent_name = "a"; tool_name = "x"; tool_use_id = "tu-test"; input = `Null }));
   Event_bus.publish bus (ev (Custom ("test", `Null)));
   let events = Event_bus.drain sub in
   check int "all three events" 3 (List.length events)
@@ -208,7 +208,7 @@ let test_payload_kind_canonical_labels () =
     ; Event_bus.TurnStarted { agent_name = "a"; turn = 0 }, "turn_started"
     ; Event_bus.TurnReady { agent_name = "a"; turn = 0; tool_names = [] }, "turn_ready"
     ; Event_bus.TurnCompleted { agent_name = "a"; turn = 0 }, "turn_completed"
-    ; ( Event_bus.ToolCalled { agent_name = "a"; tool_name = "f"; input = `Null }
+    ; ( Event_bus.ToolCalled { agent_name = "a"; tool_name = "f"; tool_use_id = "tu-test"; input = `Null }
       , "tool_called" )
     ; ( Event_bus.HandoffRequested { from_agent = "a"; to_agent = "b"; reason = "" }
       , "handoff_requested" )
@@ -276,12 +276,12 @@ let test_multiple_event_types () =
   Event_bus.publish bus (ev (TurnStarted { agent_name = "a"; turn = 0 }));
   Event_bus.publish
     bus
-    (ev (ToolCalled { agent_name = "a"; tool_name = "f"; input = `Null }));
+    (ev (ToolCalled { agent_name = "a"; tool_name = "f"; tool_use_id = "tu-test"; input = `Null }));
   Event_bus.publish
     bus
     (ev
        (ToolCompleted
-          { agent_name = "a"; tool_name = "f"; output = Ok { Types.content = "ok" } }));
+          { agent_name = "a"; tool_name = "f"; tool_use_id = "tu-test"; output = Ok { Types.content = "ok" } }));
   Event_bus.publish bus (ev (TurnCompleted { agent_name = "a"; turn = 0 }));
   Event_bus.publish
     bus
@@ -317,7 +317,7 @@ let test_tool_called_fields () =
   let bus = Event_bus.create () in
   let sub = Event_bus.subscribe bus in
   let input = `Assoc [ "x", `Int 1 ] in
-  Event_bus.publish bus (ev (ToolCalled { agent_name = "a"; tool_name = "calc"; input }));
+  Event_bus.publish bus (ev (ToolCalled { agent_name = "a"; tool_name = "calc"; tool_use_id = "tu-test"; input }));
   match Event_bus.drain sub with
   | [ { payload = ToolCalled r; _ } ] ->
     check string "agent_name" "a" r.agent_name;

--- a/test/test_event_forward.ml
+++ b/test/test_event_forward.ml
@@ -21,7 +21,7 @@ let test_event_type_name () =
   let cases =
     [ ev (Event_bus.AgentStarted { agent_name = "a"; task_id = "t" }), "agent.started"
     ; ev (Event_bus.TurnStarted { agent_name = "a"; turn = 0 }), "turn.started"
-    ; ( ev (Event_bus.ToolCalled { agent_name = "a"; tool_name = "t"; input = `Null })
+    ; ( ev (Event_bus.ToolCalled { agent_name = "a"; tool_name = "t"; tool_use_id = "tu-test"; input = `Null })
       , "tool.called" )
     ; ( ev
           (Event_bus.ContentReplacementKept
@@ -261,20 +261,30 @@ let test_tool_events_payload () =
   let called =
     ev
       (Event_bus.ToolCalled
-         { agent_name = "x"; tool_name = "search"; input = `String "query" })
+         { agent_name = "x"; tool_name = "search"; tool_use_id = "tu-test"; input = `String "query" })
   in
   let completed =
     ev
       (Event_bus.ToolCompleted
          { agent_name = "x"
          ; tool_name = "search"
+         ; tool_use_id = "tu-test"
          ; output = Ok { Types.content = "result" }
          })
   in
   let p1 = Event_forward.event_to_payload called in
   let p2 = Event_forward.event_to_payload completed in
   Alcotest.(check string) "called type" "tool.called" p1.event_type;
-  Alcotest.(check string) "completed type" "tool.completed" p2.event_type
+  Alcotest.(check string) "completed type" "tool.completed" p2.event_type;
+  let open Yojson.Safe.Util in
+  Alcotest.(check string)
+    "called payload carries tool_use_id"
+    "tu-test"
+    (p1.data |> member "tool_use_id" |> to_string);
+  Alcotest.(check string)
+    "completed payload carries tool_use_id"
+    "tu-test"
+    (p2.data |> member "tool_use_id" |> to_string)
 ;;
 
 let test_native_telemetry_payloads () =
@@ -462,6 +472,7 @@ let test_tool_completed_error_payload () =
       (Event_bus.ToolCompleted
          { agent_name = "x"
          ; tool_name = "calc"
+         ; tool_use_id = "tu-test"
          ; output =
              Error { Types.message = "fail"; recoverable = false; error_class = None }
          })

--- a/test/test_multivendor_events.ml
+++ b/test/test_multivendor_events.ml
@@ -52,9 +52,9 @@ let test_envelope_preserved_across_variants () =
   let variants : Event_bus.payload list =
     [ AgentStarted { agent_name = "alpha"; task_id = "t1" }
     ; TurnStarted { agent_name = "alpha"; turn = 0 }
-    ; ToolCalled { agent_name = "alpha"; tool_name = "echo"; input = `Null }
+    ; ToolCalled { agent_name = "alpha"; tool_name = "echo"; tool_use_id = "tu-test"; input = `Null }
     ; ToolCompleted
-        { agent_name = "alpha"; tool_name = "echo"; output = stub_tool_result }
+        { agent_name = "alpha"; tool_name = "echo"; tool_use_id = "tu-test"; output = stub_tool_result }
     ; TurnCompleted { agent_name = "alpha"; turn = 0 }
     ; HandoffRequested { from_agent = "alpha"; to_agent = "beta"; reason = "delegate" }
     ; HandoffCompleted { from_agent = "alpha"; to_agent = "beta"; elapsed = 0.5 }
@@ -118,8 +118,8 @@ let test_event_type_name_mapping () =
       , "agent.failed" )
     ; TurnStarted { agent_name = "a"; turn = 0 }, "turn.started"
     ; TurnCompleted { agent_name = "a"; turn = 0 }, "turn.completed"
-    ; ToolCalled { agent_name = "a"; tool_name = "t"; input = `Null }, "tool.called"
-    ; ( ToolCompleted { agent_name = "a"; tool_name = "t"; output = stub_tool_result }
+    ; ToolCalled { agent_name = "a"; tool_name = "t"; tool_use_id = "tu-test"; input = `Null }, "tool.called"
+    ; ( ToolCompleted { agent_name = "a"; tool_name = "t"; tool_use_id = "tu-test"; output = stub_tool_result }
       , "tool.completed" )
     ; ( HandoffRequested { from_agent = "a"; to_agent = "b"; reason = "r" }
       , "handoff.requested" )
@@ -227,11 +227,11 @@ let test_golden_lifecycle_transcript () =
   Event_bus.publish bus (mk (TurnStarted { agent_name = "a"; turn = 0 }));
   Event_bus.publish
     bus
-    (mk (ToolCalled { agent_name = "a"; tool_name = "echo"; input = `Null }));
+    (mk (ToolCalled { agent_name = "a"; tool_name = "echo"; tool_use_id = "tu-test"; input = `Null }));
   Event_bus.publish
     bus
     (mk
-       (ToolCompleted { agent_name = "a"; tool_name = "echo"; output = stub_tool_result }));
+       (ToolCompleted { agent_name = "a"; tool_name = "echo"; tool_use_id = "tu-test"; output = stub_tool_result }));
   Event_bus.publish bus (mk (TurnCompleted { agent_name = "a"; turn = 0 }));
   Event_bus.publish
     bus


### PR DESCRIPTION
## 무엇

`ToolCalled`/`ToolCompleted` 이벤트 페이로드에 provider tool-call id(`tool_use_id`)를 추가했습니다. Pre/PostToolUse 훅이 이미 받는 것과 같은 id입니다.

## 왜

한 도구 호출의 두 이벤트가 조인 불가능했습니다:
- raw trace가 없으면 `mk_envelope`가 이벤트마다 correlation_id/run_id를 신규 mint — 라이브 keeper fleet 측정에서 called 8,527 vs completed 8,526 correlation_id **교집합 0**
- 페이로드에는 agent_name + tool_name뿐 → 구독자는 도구명+타임스탬프 추측만 가능
- `caused_by`(#877)는 pair key지만 called 이벤트의 run_id를 알아야만 쓸 수 있음

provider call id는 OAS 자신의 어휘(Anthropic `tool_use.id`, OpenAI `tool_call.id`)이고 발행 지점(`agent_tools.ml`)에 이미 스코프에 있었습니다. 이벤트가 자기 호출의 identity를 싣지 않을 이유가 없습니다.

## 변경

- `Event_bus.payload`: `ToolCalled`/`ToolCompleted`에 `tool_use_id : string` (provider 미지급 시 빈 문자열, doc 명시)
- `agent_tools.ml`: 양 발행 지점에서 `id` 전달
- `Event_forward`: 직렬화에 포함
- 테스트 constructor 12곳 갱신 + 신규 단언 2종 (실제 실행 경유 양 이벤트 id 일치, 직렬화 필드)

## 검증

- `dune build @check` + default target: exit 0
- focused: test_event_bus / test_event_forward / test_eval / test_multivendor_events / test_approval 5/5 PASS

## downstream

masc(RFC-0233 PR-2b)가 이 필드로 keeper execution_id ↔ oas-event 행 결정론 조인을 구현합니다. masc는 열린 레코드 패턴만 사용하므로 pin bump 시 컴파일 영향 없음을 확인했습니다.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
