### PR TITLE
docs(event_bus): correct tool_use_id @since to 0.206.2

### DIFF
--- a/lib/event_bus.mli
+++ b/lib/event_bus.mli
@@ -73,7 +73,7 @@ type payload =
             so subscribers can join bus events with hook-side records
             deterministically instead of guessing by tool name and
             timestamp. Empty string when the provider supplied no id.
-            @since 0.207.0 *)
+            @since 0.206.2 *)
       ; input : Yojson.Safe.t
       }
   | ToolCompleted of
@@ -81,7 +81,7 @@ type payload =
       ; tool_name : string
       ; tool_use_id : string
         (** Same id as the matching [ToolCalled]; see its doc.
-            @since 0.207.0 *)
+            @since 0.206.2 *)
       ; output : Types.tool_result
       }
   | TurnStarted of


### PR DESCRIPTION
release-please가 #2025를 0.207.0이 아닌 patch(0.206.2)로 릴리즈해 @since 표기가 어긋났습니다. 실제 릴리즈 버전으로 교정.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)