### PR TITLE
fix(pipeline): deliver idle nudge inside the tool-results message

### DIFF
--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -303,6 +303,15 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
        let idle_skip = ref false in
        let idle_handled = ref false in
        (* true when Nudge or Skip handled idle *)
+       (* Nudge text is delivered inside the tool-results user message (as a
+          trailing Text block) instead of as a standalone user message snoc'd
+          before tool execution. A standalone message would sit between the
+          assistant tool_calls message and its tool results; the OpenAI-compat
+          serializer's strip_orphaned_tool_results treats that gap as an orphan
+          boundary and drops every tool result of the turn, so the model never
+          sees the outcome of the calls it is being nudged about — locking in
+          the repetition the nudge is meant to break. *)
+       let pending_nudge = ref None in
        if idle_result.is_idle
        then (
          let tool_names =
@@ -343,15 +352,12 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
            idle_skip := true;
            idle_handled := true
          | Hooks.Nudge nudge_msg ->
-           (* Inject a nudge message and leave the idle counter unchanged,
-              so repeated idle turns continue to accumulate toward later
+           (* Stash the nudge and leave the idle counter unchanged, so
+              repeated idle turns continue to accumulate toward later
               escalation. With accumulation, repeated idle turns can
               continue to nudge until the on_idle hook eventually decides
               to Skip (for example, at a configured threshold). *)
-           update_state agent (fun s ->
-             { s with
-               messages = Util.snoc s.messages (make_message ~role:User [ Text nudge_msg ])
-             });
+           pending_nudge := Some nudge_msg;
            idle_handled := true
          | _ -> ());
        (* Early exit: skip tool execution when on_idle hook says Skip.
@@ -363,8 +369,13 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
          match Guardrails.exceeds_limit effective_guardrails count with
          | true ->
            let msg = Printf.sprintf "Tool call limit exceeded: %d calls in one turn" count in
+           let content =
+             match !pending_nudge with
+             | Some nudge -> [ Text msg; Text nudge ]
+             | None -> [ Text msg ]
+           in
            update_state agent (fun s ->
-             { s with messages = Util.snoc s.messages (make_message ~role:User [ Text msg ]) });
+             { s with messages = Util.snoc s.messages (make_message ~role:User content) });
            let* () = persist_turn_checkpoint agent After_tool_results_appended in
            Ok ToolsExecuted
          | false ->
@@ -395,12 +406,14 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
               turn-fatal" outcome by neutering the Exhausted branch; this removes the
               Tool_retry_policy mechanism entirely, which subsumes that change.) *)
            let tool_feedback = tool_results in
-           (* Anti-repetition hint: append warning to tool feedback when idle detected
-            but not already handled by Nudge or Skip. Nudge injects its own message
-            and injects its own message; Skip causes early return above. *)
+           (* Idle feedback rides the same user message as the tool results: a
+              stashed hook Nudge becomes a trailing Text block; when no hook
+              handled the idle turn, the built-in [Idle warning] hint is
+              appended instead. Skip causes early return above. *)
            let effective_feedback =
-             if idle_result.is_idle && not !idle_handled
-             then
+             match !pending_nudge with
+             | Some nudge -> tool_feedback @ [ Text nudge ]
+             | None when idle_result.is_idle && not !idle_handled ->
                tool_feedback
                @ [ Text
                      (Printf.sprintf
@@ -409,7 +422,7 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
                          to make progress.]"
                         agent.consecutive_idle_turns)
                  ]
-             else tool_feedback
+             | None -> tool_feedback
            in
            update_state agent (fun s ->
              { s with

--- a/test/test_hooks_integration.ml
+++ b/test/test_hooks_integration.ml
@@ -403,6 +403,64 @@ let test_on_idle_escalated_skip_short_circuits_execution () =
     | Error e -> Alcotest.fail (Error.to_string e))
 ;;
 
+(* The nudge must ride the tool-results user message as a trailing Text
+   block. A standalone nudge message between the assistant tool_calls and
+   the tool results makes the OpenAI-compat serializer treat every result
+   of the turn as orphaned and drop it — the model then never sees the
+   outcome of the calls it is being nudged about. *)
+let test_on_idle_nudge_rides_tool_results_message () =
+  let responses =
+    ref
+      [ tool_use_body ~tool_name:"echo" ~input_json:{|{"msg":"hi"}|}
+      ; tool_use_body ~tool_name:"echo" ~input_json:{|{"msg":"hi"}|}
+      ; text_body "done"
+      ]
+  in
+  with_mock_server ~port:18113 (sequence_handler responses) (fun ~sw ~net ~base_url ->
+    let tool, _tool_calls = fresh_echo_tool () in
+    let nudge_marker = "OAS_IDLE_NUDGE_MARKER" in
+    let options =
+      { Agent.default_options with
+        base_url
+      ; max_idle_turns = 5
+      ; hooks =
+          { Hooks.empty with on_idle = Some (fun _event -> Hooks.Nudge nudge_marker) }
+      }
+    in
+    let config = { default_config with max_turns = 5 } in
+    let agent = Agent.create ~net ~config ~options ~tools:[ tool ] () in
+    (match Agent.run ~sw agent "test" with
+     | Ok _ -> ()
+     | Error e -> Alcotest.fail (Error.to_string e));
+    let messages = (Agent.state agent).messages in
+    let is_nudge_text = function
+      | Text t -> t = nudge_marker
+      | _ -> false
+    in
+    let has_tool_result content =
+      List.exists
+        (function
+          | ToolResult _ -> true
+          | _ -> false)
+        content
+    in
+    List.iter
+      (fun (m : Types.message) ->
+         if List.exists is_nudge_text m.content && not (has_tool_result m.content)
+         then Alcotest.fail "nudge must not be a standalone message before tool results")
+      messages;
+    let carried =
+      List.exists
+        (fun (m : Types.message) ->
+           has_tool_result m.content
+           && (match List.rev m.content with
+               | last :: _ -> is_nudge_text last
+               | [] -> false))
+        messages
+    in
+    Alcotest.(check bool) "nudge trails the tool-results message" true carried)
+;;
+
 (* ── multiple hooks test ─────────────────────────────── *)
 
 let test_multiple_hooks_all_fire () =
@@ -504,6 +562,12 @@ let () =
             "skip short-circuits tool execution"
             `Quick
             test_on_idle_escalated_skip_short_circuits_execution
+        ] )
+    ; ( "on_idle"
+      , [ test_case
+            "nudge rides the tool-results message"
+            `Quick
+            test_on_idle_nudge_rides_tool_results_message
         ] )
     ; ( "chaining"
       , [ test_case "multiple hooks all fire" `Quick test_multiple_hooks_all_fire ] )

--- a/test/test_tool_middleware.ml
+++ b/test/test_tool_middleware.ml
@@ -573,6 +573,56 @@ let test_strip_empty () =
   Alcotest.(check int) "empty" 0 (List.length result)
 ;;
 
+(* A standalone user Text message (e.g. an idle nudge) between the assistant
+   tool_calls message and the tool results breaks the result span: every tool
+   result of the turn is treated as orphaned, and the results message is
+   dropped entirely. This is why the pipeline delivers idle nudges inside the
+   tool-results message — see the companion test below. *)
+let test_strip_drops_results_after_interleaved_text () =
+  let msgs =
+    [ mk_msg Assistant [ ToolUse { id = "t1"; name = "f"; input = `Null } ]
+    ; mk_msg User [ Text "nudge: try a different tool" ]
+    ; mk_msg
+        User
+        [ ToolResult
+            { tool_use_id = "t1"
+            ; content = "ok"
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
+        ]
+    ]
+  in
+  let result = Serialize.strip_orphaned_tool_results msgs in
+  Alcotest.(check int) "results message dropped" 2 (List.length result);
+  match (List.nth result 1).content with
+  | [ Text _ ] -> ()
+  | _ -> Alcotest.fail "expected only the nudge text to survive"
+;;
+
+let test_strip_keeps_results_with_trailing_nudge_text () =
+  let msgs =
+    [ mk_msg Assistant [ ToolUse { id = "t1"; name = "f"; input = `Null } ]
+    ; mk_msg
+        User
+        [ ToolResult
+            { tool_use_id = "t1"
+            ; content = "ok"
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
+        ; Text "nudge: try a different tool"
+        ]
+    ]
+  in
+  let result = Serialize.strip_orphaned_tool_results msgs in
+  Alcotest.(check int) "same length" 2 (List.length result);
+  let user_msg = List.nth result 1 in
+  Alcotest.(check int) "result and nudge both preserved" 2 (List.length user_msg.content)
+;;
+
 (* ── Runner ──────────────────────────────────────────────── *)
 
 let () =
@@ -639,6 +689,14 @@ let () =
             `Quick
             test_strip_preserves_matched
         ; Alcotest.test_case "empty messages" `Quick test_strip_empty
+        ; Alcotest.test_case
+            "interleaved text drops results"
+            `Quick
+            test_strip_drops_results_after_interleaved_text
+        ; Alcotest.test_case
+            "trailing nudge text keeps results"
+            `Quick
+            test_strip_keeps_results_with_trailing_nudge_text
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제

idle hook의 `Nudge`가 tool 실행 *전에* 독립 user 메시지로 히스토리에 삽입되어, 메시지 순서가 `assistant(tool_calls) → user(nudge) → user(tool_results)`가 됩니다.

모든 OpenAI-compat 요청은 `strip_orphaned_tool_results`를 통과하는데, span 수집(`backend_openai_serialize.ml:291-296`)이 ToolResult 없는 nudge 메시지에서 끊겨 **뒤따르는 tool 결과 메시지를 통째로 orphan 처리·드랍**합니다. 결과적으로 첫 nudge 이후 모델은 자기 호출의 결과를 받지 못하고 — 결과가 안 오니 같은 호출을 반복하는 것이 모델 입장에서 합리적이 됩니다. **반복을 끊으라는 장치가 반복을 고착**시키는 구조입니다.

실측: 2026-06-12 masc keeper `sangsu`의 dashboard chat 턴 2건이 `keeper_context_status {}` 반복 → nudge 2회+FINAL WARNING 무시 → `Idle detected: 3 consecutive identical tool call turns`로 사망. kill-time snapshot에서 nudge 주입 턴 이후 반복 호출의 결과가 wire 요청에서 소실되는 형태 확인.

## 변경

| 항목 | 내용 |
|---|---|
| Nudge 전달 위치 | 독립 user 메시지 → **tool-results user 메시지의 trailing `Text` 블록** (stash 후 결과와 동승) |
| 근거 형태 | 기존 `[Idle warning]` fallback이 이미 쓰는 동일 shape — Anthropic(tool_result 선행)·OpenAI-compat(span 보존) 양쪽 직렬화 유효 |
| tool-call-limit 분기 | limit 메시지에 stash된 nudge 동승 (silent drop 방지) |
| 의미 불변 | idle 카운터 미리셋(에스컬레이션 누적), Skip 조기 종료 경로 무변경 |

## 검증

- `test_tool_middleware` 31/31 — 신규 2: 구 형태(interleaved text)가 결과를 드랍함을 문서화하는 회귀 테스트 + 신 형태(trailing nudge)가 결과를 보존함을 증명
- `test_hooks_integration` 13/13 — 신규 1: on_idle Nudge 후 nudge가 독립 메시지로 존재하지 않고 tool-results 메시지 말미에 실리는지 히스토리 형태 단언
- `scripts/dune-local.sh build lib/pipeline test/...` EXIT=0

## 한계 (out of scope)

- `IdleSkipped`/tool-call-limit 경로의 미응답 assistant tool_calls(결과 없는 tool_use가 히스토리에 남는 pre-existing 형태)는 본 PR 범위 밖.
- masc 쪽 kmsg 턴의 `max_idle_turns=3` 기본값 문제는 masc PR에서 별도 수정.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
