### PR TITLE
fix(pipeline): keep tool results on tool role before nudges

### DIFF
--- a/lib/agent/agent_handoff.ml
+++ b/lib/agent/agent_handoff.ml
@@ -39,7 +39,7 @@ let find_handoff_in_messages messages =
 ;;
 
 (** Replace the tool result emitted for a specific ToolUse id in the most recent
-    user tool_result message. This lets handoff interception overwrite the
+    tool-result message. This lets handoff interception overwrite the
     sentinel handler output with the delegated agent response. *)
 let replace_tool_result messages ~tool_id ~content ~is_error =
   let replace_in_content blocks =
@@ -57,7 +57,7 @@ let replace_tool_result messages ~tool_id ~content ~is_error =
     | [] ->
       Util.snoc
         acc
-        { role = User
+        { role = Tool
         ; content =
             [ ToolResult
                 { tool_use_id = tool_id
@@ -79,7 +79,12 @@ let replace_tool_result messages ~tool_id ~content ~is_error =
             | _ -> false)
           message.content
       in
-      if message.role = User && has_tool_result
+      let role_can_carry_tool_results =
+        match message.role with
+        | User | Tool -> true
+        | System | Assistant -> false
+      in
+      if role_can_carry_tool_results && has_tool_result
       then
         List.rev_append
           rest

--- a/lib/agent/agent_handoff.mli
+++ b/lib/agent/agent_handoff.mli
@@ -16,8 +16,8 @@ val find_handoff_in_messages : Types.message list -> (string * string * string) 
 (** {1 Message manipulation} *)
 
 (** Replace the [ToolResult] for a specific [tool_id] in the most recent
-    user message.  Used by handoff interception to overwrite the sentinel
-    handler output with the delegated agent response. *)
+    tool-result message.  Used by handoff interception to overwrite the
+    sentinel handler output with the delegated agent response. *)
 val replace_tool_result
   :  Types.message list
   -> tool_id:string

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -325,10 +325,14 @@ let resolve_turn_params ~hooks ~messages ~max_turns ~turn ~invoke_hook =
   | None -> Hooks.default_turn_params
   | Some _ ->
     let last_results =
+      let role_can_carry_tool_results = function
+        | User | Tool -> true
+        | System | Assistant -> false
+      in
       let rec find_last = function
         | [] -> []
         | msg :: rest ->
-          if msg.role = User
+          if role_can_carry_tool_results msg.role
           then (
             let results =
               List.filter_map

--- a/lib/context_reducer.ml
+++ b/lib/context_reducer.ml
@@ -4,9 +4,11 @@
     in agent state. This avoids sending the entire conversation on every
     request, cutting input tokens without losing debuggability.
 
-    Critical constraint: Anthropic API requires that every ToolUse block has
-    a matching ToolResult in the subsequent User message. All strategies
-    respect turn boundaries so ToolUse/ToolResult pairs are never split.
+    Critical constraint: provider APIs require that every ToolUse block has
+    a matching ToolResult in the subsequent tool-result message. Normal
+    histories use role [Tool]; legacy role [User] ToolResult messages remain
+    accepted. All strategies respect turn boundaries so ToolUse/ToolResult
+    pairs are never split.
 
     Token estimation is CJK-aware: ASCII uses a 4-char-per-token heuristic,
     multi-byte characters (CJK, emoji) use ~2/3 token per character. *)

--- a/lib/context_reducer_apply.ml
+++ b/lib/context_reducer_apply.ml
@@ -117,7 +117,7 @@ let has_tool_result msg = tool_result_ids msg <> []
 type dangling_repair_report = { synthesized_tool_results : int }
 
 let synthetic_tool_result_message id =
-  { role = User
+  { role = Tool
   ; content =
       [ ToolResult
           { tool_use_id = id

--- a/lib/context_reducer_turns.ml
+++ b/lib/context_reducer_turns.ml
@@ -1,27 +1,38 @@
 open Types
 
+let has_tool_result_message (msg : message) =
+  List.exists
+    (fun (block : content_block) ->
+       match block with
+       | ToolResult _ -> true
+       | Text _
+       | Thinking _
+       | RedactedThinking _
+       | ToolUse _
+       | Image _
+       | Document _
+       | Audio _ -> false)
+    msg.content
+;;
+
 let group_into_turns (messages : message list) : message list list =
   let rec aux current_turn acc = function
     | [] ->
       if current_turn = [] then List.rev acc else List.rev (List.rev current_turn :: acc)
     | msg :: rest ->
+      (* A User message starts a new turn unless it carries ToolResult blocks
+         itself (legacy mixed shape), or immediately follows a role:Tool
+         result message. The immediate-follow case covers pipeline-inserted
+         nudges while preserving the old split after legacy User-role
+         ToolResult messages. *)
       if msg.role = User && current_turn <> []
       then (
-        let has_tool_result =
-          List.exists
-            (fun (block : content_block) ->
-               match block with
-               | ToolResult _ -> true
-               | Text _
-               | Thinking _
-               | RedactedThinking _
-               | ToolUse _
-               | Image _
-               | Document _
-               | Audio _ -> false)
-            msg.content
+        let previous_is_tool_result_message =
+          match current_turn with
+          | previous :: _ -> previous.role = Tool && has_tool_result_message previous
+          | [] -> false
         in
-        if has_tool_result
+        if has_tool_result_message msg || previous_is_tool_result_message
         then aux (msg :: current_turn) acc rest
         else aux [ msg ] (List.rev current_turn :: acc) rest)
       else aux (msg :: current_turn) acc rest

--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -174,6 +174,35 @@ let content_block_of_json json =
   | _ -> None
 ;;
 
+let message_has_tool_result (msg : message) =
+  List.exists
+    (function
+      | ToolResult _ -> true
+      | Text _
+      | Thinking _
+      | RedactedThinking _
+      | ToolUse _
+      | Image _
+      | Document _
+      | Audio _ -> false)
+    msg.content
+;;
+
+let merge_tool_result_followup_user_messages messages =
+  let mergeable_followup (msg : message) =
+    msg.role = User && msg.name = None && msg.tool_call_id = None && msg.metadata = []
+  in
+  let rec aux acc = function
+    | ({ role = Tool; _ } as tool_msg) :: (followup : message) :: rest
+      when message_has_tool_result tool_msg && mergeable_followup followup ->
+      let merged = { tool_msg with content = tool_msg.content @ followup.content } in
+      aux (merged :: acc) rest
+    | msg :: rest -> aux (msg :: acc) rest
+    | [] -> List.rev acc
+  in
+  aux [] messages
+;;
+
 let message_to_json (msg : message) =
   let role_str =
     match msg.role with

--- a/lib/llm_provider/api_common.mli
+++ b/lib/llm_provider/api_common.mli
@@ -21,6 +21,7 @@ val json_of_string_or_raw : string -> Yojson.Safe.t
 
 val content_block_to_json : Types.content_block -> Yojson.Safe.t
 val content_block_of_json : Yojson.Safe.t -> Types.content_block option
+val merge_tool_result_followup_user_messages : Types.message list -> Types.message list
 val message_to_json : Types.message -> Yojson.Safe.t
 val provider_c_message_to_json : Types.message -> Yojson.Safe.t
 

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -81,6 +81,7 @@ let build_request
       ~supports_parallel_tool_calls:caps.supports_parallel_tool_calls
       ~tools_present
   in
+  let messages = Api_common.merge_tool_result_followup_user_messages messages in
   let message_to_json = Api_common.message_to_json in
   let msgs_json = List.map message_to_json messages in
   let body =

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -107,6 +107,7 @@ let part_of_content_block id_to_name = function
 (* ── Message list -> (contents, systemInstruction option) ── *)
 
 let contents_of_messages (messages : message list) =
+  let messages = Api_common.merge_tool_result_followup_user_messages messages in
   let id_to_name = build_tool_id_to_name messages in
   let system_parts = ref [] in
   let contents = ref [] in

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -114,6 +114,36 @@ let assistant_reasoning_content_of_blocks blocks =
   |> String.concat ""
 ;;
 
+let openai_tool_message_of_result ~tool_use_id ~content ~content_blocks =
+  let content_str =
+    match content_blocks with
+    | Some blocks ->
+      (* OpenAI tool messages accept string content only; encode structured
+         blocks as a JSON string so the result is not lost. *)
+      Yojson.Safe.to_string (`List (List.map Api_common.content_block_to_json blocks))
+    | None -> Utf8_sanitize.sanitize content
+  in
+  `Assoc
+    [ "role", `String "tool"
+    ; "tool_call_id", `String tool_use_id
+    ; "content", `String content_str
+    ]
+;;
+
+let openai_tool_messages_of_blocks blocks =
+  blocks
+  |> List.filter_map (function
+    | ToolResult { tool_use_id; content; content_blocks; _ } ->
+      Some (openai_tool_message_of_result ~tool_use_id ~content ~content_blocks)
+    | Text _
+    | Thinking _
+    | RedactedThinking _
+    | ToolUse _
+    | Image _
+    | Document _
+    | Audio _ -> None)
+;;
+
 let messages_of_message_with
       ?(tool_calls_fn = tool_calls_to_openai_json)
       ?(include_reasoning_content = false)
@@ -146,34 +176,12 @@ let messages_of_message_with
         let text_content = Api_common.text_blocks_to_string msg.content in
         [ `Assoc [ "role", `String "user"; "content", `String text_content ] ])
     in
-    let tool_msgs =
-      msg.content
-      |> List.filter_map (function
-        | ToolResult { tool_use_id; content; content_blocks; _ } ->
-          let content_str =
-            match content_blocks with
-            | Some blocks ->
-              (* OpenAI tool messages accept string content only; encode the
-                 structured blocks as a JSON string so the result is not lost. *)
-              Yojson.Safe.to_string
-                (`List (List.map Api_common.content_block_to_json blocks))
-            | None -> Utf8_sanitize.sanitize content
-          in
-          Some
-            (`Assoc
-                [ "role", `String "tool"
-                ; "tool_call_id", `String tool_use_id
-                ; "content", `String content_str
-                ])
-        | Text _
-        | Thinking _
-        | RedactedThinking _
-        | ToolUse _
-        | Image _
-        | Document _
-        | Audio _ -> None)
-    in
-    user_msgs @ tool_msgs
+    let tool_msgs = openai_tool_messages_of_blocks msg.content in
+    (* Legacy compatibility: older histories may pack ToolResult blocks and
+       user text into one role:User message. Normal pipeline output records
+       ToolResult blocks on role:Tool; this split keeps persisted mixed
+       messages wire-compatible without making the mixed shape the invariant. *)
+    tool_msgs @ user_msgs
   | Assistant ->
     let text_content = assistant_text_content_of_blocks msg.content in
     let reasoning_content =
@@ -205,21 +213,7 @@ let messages_of_message_with
     [ `Assoc [ "role", `String "system"; "content", `String text ] ]
   | Tool ->
     msg.content
-    |> List.filter_map (function
-      | ToolResult { tool_use_id; content; _ } ->
-        Some
-          (`Assoc
-              [ "role", `String "tool"
-              ; "tool_call_id", `String tool_use_id
-              ; "content", `String (Utf8_sanitize.sanitize content)
-              ])
-      | Text _
-      | Thinking _
-      | RedactedThinking _
-      | ToolUse _
-      | Image _
-      | Document _
-      | Audio _ -> None)
+    |> openai_tool_messages_of_blocks
     |> (function
      | [] ->
        let text = Api_common.text_blocks_to_string msg.content in

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -414,29 +414,30 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
               turn-fatal" outcome by neutering the Exhausted branch; this removes the
               Tool_retry_policy mechanism entirely, which subsumes that change.) *)
            let tool_feedback = tool_results in
-           (* Idle feedback rides the same user message as the tool results: a
-              stashed hook Nudge becomes a trailing Text block; when no hook
-              handled the idle turn, the built-in [Idle warning] hint is
-              appended instead. Skip causes early return above. *)
-           let effective_feedback =
+           let followup_text =
              match !pending_nudge with
-             | Some nudge -> tool_feedback @ [ Text nudge ]
+             | Some nudge -> Some nudge
              | None when idle_result.is_idle && not !idle_handled ->
-               tool_feedback
-               @ [ Text
-                     (Printf.sprintf
-                        "[Idle warning: You called the same tool(s) with identical \
-                         arguments %d time(s) in a row. Try a different tool or change \
-                         your arguments to make progress.]"
-                        agent.consecutive_idle_turns)
-                 ]
-             | None -> tool_feedback
+               Some
+                 (Printf.sprintf
+                    "[Idle warning: You called the same tool(s) with identical arguments \
+                     %d time(s) in a row. Try a different tool or change your arguments \
+                     to make progress.]"
+                    agent.consecutive_idle_turns)
+             | None -> None
            in
            update_state agent (fun s ->
-             { s with
-               messages =
-                 Util.snoc s.messages (make_message ~role:User effective_feedback)
-             });
+             let messages =
+               match tool_feedback with
+               | [] -> s.messages
+               | _ -> Util.snoc s.messages (make_message ~role:Tool tool_feedback)
+             in
+             let messages =
+               match followup_text with
+               | None -> messages
+               | Some text -> Util.snoc messages (make_message ~role:User [ Text text ])
+             in
+             { s with messages });
            (match agent.options.context_injector with
             | None -> ()
             | Some injector ->
@@ -450,8 +451,9 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
               in
               update_state agent (fun s -> { s with messages = new_messages }));
            let* () = persist_turn_checkpoint agent After_tool_results_appended in
-           (* Anti-repetition hint is now in effective_feedback above.
-            Removed duplicate User message injection (Copilot review #3). *)
+           (* Anti-repetition hint is appended after the ToolResult message so
+              provider serializers can keep assistant tool_calls and role:tool
+              responses adjacent. *)
            ignore idle_handled;
            (* suppress unused warning after dedup *)
            (* In-memory message hygiene after each tool execution round.
@@ -1029,7 +1031,7 @@ let%test "last_tool_results_from no tool results" =
   last_tool_results_from msgs = []
 ;;
 
-let%test "last_tool_results_from finds tool results in last user message" =
+let%test "last_tool_results_from finds tool results in last tool message" =
   let msgs =
     [ { role = Assistant
       ; content = [ Text "thinking..." ]
@@ -1037,7 +1039,7 @@ let%test "last_tool_results_from finds tool results in last user message" =
       ; tool_call_id = None
       ; metadata = []
       }
-    ; { role = User
+    ; { role = Tool
       ; content =
           [ ToolResult
               { tool_use_id = "t1"
@@ -1097,8 +1099,8 @@ let%test "last_tool_results_from skips non-tool user messages" =
       }
     ]
   in
-  (* Should find the tool result from the first user message since the last
-     user message has no tool results *)
+  (* Should find the legacy user-role tool result since the last user message
+     has no tool results. *)
   match last_tool_results_from msgs with
   | [ Ok { content = "first" } ] -> true
   | _ -> false
@@ -1137,7 +1139,7 @@ let%test "last_tool_results_from assistant-only messages" =
   last_tool_results_from msgs = []
 ;;
 
-let%test "last_tool_results_from picks last user with tool results" =
+let%test "last_tool_results_from picks last tool-result message" =
   let msgs =
     [ { role = User
       ; content =
@@ -1159,7 +1161,7 @@ let%test "last_tool_results_from picks last user with tool results" =
       ; tool_call_id = None
       ; metadata = []
       }
-    ; { role = User
+    ; { role = Tool
       ; content =
           [ ToolResult
               { tool_use_id = "t2"
@@ -1207,7 +1209,7 @@ let%test "last_tool_results_from mixed content in user message" =
 
 let%test "last_tool_results_from error tool result" =
   let msgs =
-    [ { role = User
+    [ { role = Tool
       ; content =
           [ ToolResult
               { tool_use_id = "t1"
@@ -1246,7 +1248,7 @@ let%test "tag_error string result Ok" = tag_error "collect" (Ok "success") = Ok 
 
 (* --- Additional pipeline tests --- *)
 
-let%test "last_tool_results_from only non-user roles" =
+let%test "last_tool_results_from only non-result roles" =
   let msgs =
     [ { role = System
       ; content = [ Text "system" ]
@@ -1267,7 +1269,7 @@ let%test "last_tool_results_from only non-user roles" =
 
 let%test "last_tool_results_from multiple tool results in one message" =
   let msgs =
-    [ { role = User
+    [ { role = Tool
       ; content =
           [ ToolResult
               { tool_use_id = "t1"

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -88,9 +88,14 @@ let tool_result_of_projection (proj : Llm_provider.Canonical_tool.provider_tool_
   else Ok { Types.content = proj.content }
 ;;
 
+let role_can_carry_tool_results = function
+  | User | Tool -> true
+  | System | Assistant -> false
+;;
+
 let last_tool_results_from messages =
   let extract_results msg =
-    if msg.role <> User
+    if not (role_can_carry_tool_results msg.role)
     then []
     else
       List.filter_map
@@ -116,7 +121,7 @@ let last_tool_results_from messages =
    [structured_content] without disturbing the existing string contract. *)
 let%test "last_tool_results_from routes through canonical projection (with json)" =
   let msgs =
-    [ { role = User
+    [ { role = Tool
       ; content =
           [ ToolResult
               { tool_use_id = "t1"

--- a/lib/tool_middleware.ml
+++ b/lib/tool_middleware.ml
@@ -193,7 +193,7 @@ let heal_tool_call
              | _ -> message
            in
            let error_feedback : Types.message =
-             { role = User
+             { role = Tool
              ; content =
                  [ ToolResult
                      { tool_use_id = current_id

--- a/test/test_agent.ml
+++ b/test/test_agent.ml
@@ -164,6 +164,7 @@ let test_replace_existing () =
       ~is_error:false
   in
   let last = List.nth updated (List.length updated - 1) in
+  Alcotest.(check bool) "legacy role preserved" true (last.role = User);
   match last.content with
   | [ ToolResult { tool_use_id; content; is_error; _ } ] ->
     Alcotest.(check string) "id preserved" "t1" tool_use_id;
@@ -190,6 +191,7 @@ let test_replace_missing_appends () =
       ~is_error:true
   in
   let last = List.nth updated (List.length updated - 1) in
+  Alcotest.(check bool) "fallback role" true (last.role = Tool);
   match last.content with
   | [ ToolResult { tool_use_id; content; is_error; _ } ] ->
     Alcotest.(check string) "id" "t99" tool_use_id;

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -147,18 +147,48 @@ let test_provider_d_user_messages_text_tool_and_empty () =
   in
   let messages = Serialize.openai_messages_of_message user in
   check_int "user + tool messages" 2 (List.length messages);
-  let user_json = List.nth messages 0 in
-  check_string "user role" "user" (member "role" user_json |> to_string);
-  check_string "user content" "first\nsecond" (member "content" user_json |> to_string);
-  let tool_json = List.nth messages 1 in
+  (* Legacy mixed User messages are split by channel: ToolResult lowers to
+     role:tool and text remains role:user. Normal pipeline output uses a
+     separate role:Tool message instead of this packed shape. *)
+  let tool_json = List.nth messages 0 in
   check_string "tool role" "tool" (member "role" tool_json |> to_string);
   check_string "tool id" "call-1" (member "tool_call_id" tool_json |> to_string);
   check_string "tool content" "42" (member "content" tool_json |> to_string);
+  let user_json = List.nth messages 1 in
+  check_string "user role" "user" (member "role" user_json |> to_string);
+  check_string "user content" "first\nsecond" (member "content" user_json |> to_string);
   let empty_user =
     Serialize.openai_messages_of_message
       (msg User [ Thinking { thinking_type = ""; content = "x" } ])
   in
   check_int "empty user drops message" 0 (List.length empty_user)
+;;
+
+(* Wire-level adjacency for a nudged tool turn: the internal shape is
+   [assistant(tool_calls); tool(ToolResult); user(Text nudge)] and it must
+   serialize without interleaving user text before the tool response. *)
+let test_wire_adjacency_nudged_tool_turn () =
+  let turn =
+    [ msg Assistant [ ToolUse { id = "call-9"; name = "f"; input = `Null } ]
+    ; msg
+        Tool
+        [ ToolResult
+            { tool_use_id = "call-9"
+            ; content = "ok"
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
+        ]
+    ; msg User [ Text "nudge: try a different tool" ]
+    ]
+  in
+  let wire = List.concat_map Serialize.openai_messages_of_message turn in
+  let roles = List.map (fun m -> member "role" m |> to_string) wire in
+  Alcotest.(check (list string))
+    "tool responses stay adjacent to tool_calls"
+    [ "assistant"; "tool"; "user" ]
+    roles
 ;;
 
 let test_user_multimodal_preserve_and_visual_first () =
@@ -780,6 +810,10 @@ let () =
             "openai user text/tool/empty"
             `Quick
             test_provider_d_user_messages_text_tool_and_empty
+        ; Alcotest.test_case
+            "wire adjacency: nudged tool turn"
+            `Quick
+            test_wire_adjacency_nudged_tool_turn
         ; Alcotest.test_case
             "multimodal ordering policies"
             `Quick

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -348,6 +348,20 @@ let test_group_tool_result_stays () =
   Alcotest.(check int) "4 msgs in turn" 4 (List.length (List.nth turns 0))
 ;;
 
+let test_group_tool_role_result_and_nudge_stay () =
+  let msgs =
+    [ user_msg "q"
+    ; tool_use_msg "t1" "calc"
+    ; Types.tool_result_msg ~tool_use_id:"t1" ~content:"42" ()
+    ; user_msg "nudge"
+    ; asst_msg "done"
+    ]
+  in
+  let turns = Context_reducer.group_into_turns msgs in
+  Alcotest.(check int) "1 turn" 1 (List.length turns);
+  Alcotest.(check int) "5 msgs in turn" 5 (List.length (List.nth turns 0))
+;;
+
 let test_group_assistant_first () =
   let msgs = [ asst_msg "orphan"; user_msg "a"; asst_msg "b" ] in
   let turns = Context_reducer.group_into_turns msgs in
@@ -1211,9 +1225,12 @@ let test_repair_single_orphan () =
   let result = Context_reducer.reduce Context_reducer.repair_dangling_tool_calls msgs in
   (* Should insert a synthetic ToolResult after the ToolUse message *)
   Alcotest.(check int) "repaired (+1 msg)" 4 (List.length result);
-  (* The inserted message should be a User message with ToolResult *)
+  (* The inserted message should be a Tool message with ToolResult *)
   match List.nth result 2 with
-  | { Types.content = [ Types.ToolResult { tool_use_id; is_error; _ } ]; _ } ->
+  | { Types.role = Types.Tool
+    ; content = [ Types.ToolResult { tool_use_id; is_error; _ } ]
+    ; _
+    } ->
     Alcotest.(check string) "matches id" "t1" tool_use_id;
     Alcotest.(check bool) "is_error" true is_error
   | _ -> Alcotest.fail "expected synthetic tool result"
@@ -1479,6 +1496,10 @@ let () =
             "tool_result stays in turn"
             `Quick
             test_group_tool_result_stays
+        ; Alcotest.test_case
+            "tool role result and nudge stay in turn"
+            `Quick
+            test_group_tool_role_result_and_nudge_stay
         ; Alcotest.test_case "assistant-first" `Quick test_group_assistant_first
         ] )
     ; "custom", [ Alcotest.test_case "custom fn called" `Quick test_custom ]

--- a/test/test_hooks_integration.ml
+++ b/test/test_hooks_integration.ml
@@ -403,12 +403,10 @@ let test_on_idle_escalated_skip_short_circuits_execution () =
     | Error e -> Alcotest.fail (Error.to_string e))
 ;;
 
-(* The nudge must ride the tool-results user message as a trailing Text
-   block. A standalone nudge message between the assistant tool_calls and
-   the tool results makes the OpenAI-compat serializer treat every result
-   of the turn as orphaned and drop it — the model then never sees the
-   outcome of the calls it is being nudged about. *)
-let test_on_idle_nudge_rides_tool_results_message () =
+(* The nudge must follow the role:Tool result message. It must not be packed
+   into the same message as ToolResult blocks, because that mixed shape is only
+   retained as serializer compatibility for older histories. *)
+let test_on_idle_nudge_follows_tool_results_message () =
   let responses =
     ref
       [ tool_use_body ~tool_name:"echo" ~input_json:{|{"msg":"hi"}|}
@@ -444,22 +442,33 @@ let test_on_idle_nudge_rides_tool_results_message () =
           | _ -> false)
         content
     in
+    let find_index pred =
+      let rec loop idx = function
+        | [] -> None
+        | x :: xs -> if pred x then Some idx else loop (idx + 1) xs
+      in
+      loop 0
+    in
     List.iter
       (fun (m : Types.message) ->
-         if List.exists is_nudge_text m.content && not (has_tool_result m.content)
-         then Alcotest.fail "nudge must not be a standalone message before tool results")
+         if List.exists is_nudge_text m.content && has_tool_result m.content
+         then Alcotest.fail "nudge must not share a message with tool results")
       messages;
-    let carried =
-      List.exists
-        (fun (m : Types.message) ->
-           has_tool_result m.content
-           &&
-           match List.rev m.content with
-           | last :: _ -> is_nudge_text last
-           | [] -> false)
+    let result_index =
+      find_index
+        (fun (m : Types.message) -> m.role = Tool && has_tool_result m.content)
         messages
     in
-    Alcotest.(check bool) "nudge trails the tool-results message" true carried)
+    let nudge_index =
+      find_index
+        (fun (m : Types.message) -> m.role = User && List.exists is_nudge_text m.content)
+        messages
+    in
+    match result_index, nudge_index with
+    | Some result_index, Some nudge_index ->
+      Alcotest.(check bool) "nudge follows tool results" true (result_index < nudge_index)
+    | None, _ -> Alcotest.fail "expected a role:Tool result message"
+    | _, None -> Alcotest.fail "expected a role:User nudge message")
 ;;
 
 (* ── multiple hooks test ─────────────────────────────── *)
@@ -566,9 +575,9 @@ let () =
         ] )
     ; ( "on_idle"
       , [ test_case
-            "nudge rides the tool-results message"
+            "nudge follows the tool-results message"
             `Quick
-            test_on_idle_nudge_rides_tool_results_message
+            test_on_idle_nudge_follows_tool_results_message
         ] )
     ; ( "chaining"
       , [ test_case "multiple hooks all fire" `Quick test_multiple_hooks_all_fire ] )

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -70,6 +70,30 @@ let messages =
   ]
 ;;
 
+let nudged_messages =
+  [ msg User [ Text "What's the weather in Seoul?" ]
+  ; msg
+      Assistant
+      [ ToolUse
+          { id = "call_1"
+          ; name = "get_weather"
+          ; input = `Assoc [ "city", `String "Seoul" ]
+          }
+      ]
+  ; msg
+      Tool
+      [ ToolResult
+          { tool_use_id = "call_1"
+          ; content = "Sunny, 25C"
+          ; is_error = false
+          ; json = None
+          ; content_blocks = None
+          }
+      ]
+  ; msg User [ Text "nudge: try a different tool" ]
+  ]
+;;
+
 let cfg ~kind ~base_url ~tool_choice =
   Provider_config.make
     ~kind
@@ -310,6 +334,34 @@ let test_anthropic_forced () =
      && not (contains ~needle:{|"type":"tool"|} body))
 ;;
 
+let test_anthropic_nudged_tool_turn_merges_followup_text () =
+  let body =
+    Backend_anthropic.build_request
+      ~config:(anthropic_cfg ~tool_choice:(Tool "get_weather"))
+      ~messages:nudged_messages
+      ~tools:[ tool_decl ]
+      ()
+  in
+  let open Yojson.Safe.Util in
+  let messages_json = Yojson.Safe.from_string body |> member "messages" |> to_list in
+  check int "wire messages" 3 (List.length messages_json);
+  let final_message = List.nth messages_json 2 in
+  check string "final role" "user" (final_message |> member "role" |> to_string);
+  let content = final_message |> member "content" |> to_list in
+  check int "merged content blocks" 2 (List.length content);
+  check
+    string
+    "first block"
+    "tool_result"
+    (List.nth content 0 |> member "type" |> to_string);
+  check string "second block" "text" (List.nth content 1 |> member "type" |> to_string);
+  check
+    string
+    "followup text"
+    "nudge: try a different tool"
+    (List.nth content 1 |> member "text" |> to_string)
+;;
+
 (* ── Gemini ─────────────────────────────────────────── *)
 
 let gemini_any_expected =
@@ -347,6 +399,33 @@ let test_gemini_any () =
     "no disable_parallel on the wire (#1840)"
     false
     (contains ~needle:"disable_parallel" body)
+;;
+
+let test_gemini_nudged_tool_turn_merges_followup_text () =
+  let body =
+    Backend_gemini.build_request
+      ~config:(gemini_cfg ~tool_choice:Any)
+      ~messages:nudged_messages
+      ~tools:[ tool_decl ]
+      ()
+  in
+  let open Yojson.Safe.Util in
+  let contents = Yojson.Safe.from_string body |> member "contents" |> to_list in
+  check int "wire contents" 3 (List.length contents);
+  let final_content = List.nth contents 2 in
+  check string "final role" "user" (final_content |> member "role" |> to_string);
+  let parts = final_content |> member "parts" |> to_list in
+  check int "merged parts" 2 (List.length parts);
+  check
+    bool
+    "functionResponse first"
+    true
+    (List.nth parts 0 |> member "functionResponse" <> `Null);
+  check
+    string
+    "text followup"
+    "nudge: try a different tool"
+    (List.nth parts 1 |> member "text" |> to_string)
 ;;
 
 (* ── GLM (OpenAI-compatible wire format) ────────────── *)
@@ -416,8 +495,20 @@ let () =
             test_openai_parallel_disabled_by_capability
         ; test_case "deepseek-v4-flash required(Any)" `Quick test_deepseek_required
         ] )
-    ; "anthropic", [ test_case "tool_choice forced(Tool)" `Quick test_anthropic_forced ]
-    ; "gemini", [ test_case "tool_choice Any" `Quick test_gemini_any ]
+    ; ( "anthropic"
+      , [ test_case "tool_choice forced(Tool)" `Quick test_anthropic_forced
+        ; test_case
+            "nudged tool turn merges followup text"
+            `Quick
+            test_anthropic_nudged_tool_turn_merges_followup_text
+        ] )
+    ; ( "gemini"
+      , [ test_case "tool_choice Any" `Quick test_gemini_any
+        ; test_case
+            "nudged tool turn merges followup text"
+            `Quick
+            test_gemini_nudged_tool_turn_merges_followup_text
+        ] )
     ; "glm", [ test_case "tool_choice Any" `Quick test_glm_any ]
     ; "ollama", [ test_case "tool_choice Any" `Quick test_ollama_any ]
     ]

--- a/test/test_tool_middleware.ml
+++ b/test/test_tool_middleware.ml
@@ -601,11 +601,11 @@ let test_strip_drops_results_after_interleaved_text () =
   | _ -> Alcotest.fail "expected only the nudge text to survive"
 ;;
 
-let test_strip_keeps_results_with_trailing_nudge_text () =
+let test_strip_keeps_tool_role_results_before_nudge_text () =
   let msgs =
     [ mk_msg Assistant [ ToolUse { id = "t1"; name = "f"; input = `Null } ]
     ; mk_msg
-        User
+        Tool
         [ ToolResult
             { tool_use_id = "t1"
             ; content = "ok"
@@ -613,14 +613,18 @@ let test_strip_keeps_results_with_trailing_nudge_text () =
             ; json = None
             ; content_blocks = None
             }
-        ; Text "nudge: try a different tool"
         ]
+    ; mk_msg User [ Text "nudge: try a different tool" ]
     ]
   in
   let result = Serialize.strip_orphaned_tool_results msgs in
-  Alcotest.(check int) "same length" 2 (List.length result);
-  let user_msg = List.nth result 1 in
-  Alcotest.(check int) "result and nudge both preserved" 2 (List.length user_msg.content)
+  Alcotest.(check int) "same length" 3 (List.length result);
+  let tool_msg = List.nth result 1 in
+  Alcotest.(check bool) "result role preserved" true (tool_msg.role = Tool);
+  Alcotest.(check int) "result preserved" 1 (List.length tool_msg.content);
+  let nudge_msg = List.nth result 2 in
+  Alcotest.(check bool) "nudge role preserved" true (nudge_msg.role = User);
+  Alcotest.(check int) "nudge preserved" 1 (List.length nudge_msg.content)
 ;;
 
 (* ── Runner ──────────────────────────────────────────────── *)
@@ -694,9 +698,9 @@ let () =
             `Quick
             test_strip_drops_results_after_interleaved_text
         ; Alcotest.test_case
-            "trailing nudge text keeps results"
+            "tool role result before nudge keeps results"
             `Quick
-            test_strip_keeps_results_with_trailing_nudge_text
+            test_strip_keeps_tool_role_results_before_nudge_text
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제

#2028은 idle nudge를 ToolResult와 같은 User 메시지에 태워 OpenAI-compat adjacency 문제를 피하려 했지만, 내부 히스토리 shape가 `User [ToolResult; Text]`로 섞였습니다. 그 뒤 serializer에서 순서만 뒤집는 방식은 레거시 shape를 정상 invariant처럼 만드는 증상 패치라서 취소했습니다.

정상 내부 불변식은 `Assistant [ToolUse] -> Tool [ToolResult...] -> User [Text nudge]`입니다. 단, provider wire shape는 API별로 다릅니다. OpenAI-compatible wire는 `assistant -> tool -> user`가 맞고, Anthropic/Gemini native wire는 immediate `ToolResult`와 follow-up text를 같은 user turn으로 낮춰야 합니다.

## 변경

- pipeline tool feedback을 `role:Tool` 메시지로 기록하고, idle nudge / built-in idle warning은 별도 `role:User` 텍스트 메시지로 뒤따르게 변경.
- last-tool-result consumers가 정상 `Tool` role과 레거시 `User` role ToolResult를 모두 읽도록 호환 처리.
- context reducer turn grouping은 `Tool` result 바로 뒤의 nudge를 같은 turn에 유지하되, 레거시 `User` ToolResult 뒤의 일반 User turn split은 보존.
- handoff replacement fallback, validation retry feedback, dangling ToolUse repair가 새 ToolResult를 `role:Tool`로 synthesize하도록 변경.
- OpenAI serializer는 `Tool` role과 레거시 mixed `User` ToolResult lowering을 공통 helper로 공유. mixed User는 compatibility path이고 정상 생성 경로가 아님.
- Anthropic/Gemini native provider projection은 immediate `Tool [ToolResult...]` + plain `User [...]` follow-up을 한 user turn으로 병합해 `tool_result/functionResponse` 뒤에 nudge text가 오도록 처리.

## 검증

- `git diff --check`
- `scripts/ci-code-smell-ratchet.sh --check`
- `scripts/dune-local.sh build test/test_agent.exe test/test_backend_openai_codec.exe test/test_context_reducer.exe test/test_hooks_integration.exe test/test_tool_middleware.exe`
- `scripts/dune-local.sh build lib/llm_provider/llm_provider.a test/test_snapshot_provider_serialization.exe test/test_backend_openai_codec.exe test/test_hooks_integration.exe`
- `scripts/dune-local.sh exec test/test_agent.exe`
- `scripts/dune-local.sh exec test/test_backend_openai_codec.exe`
- `scripts/dune-local.sh exec test/test_context_reducer.exe`
- `scripts/dune-local.sh exec test/test_hooks_integration.exe`
- `scripts/dune-local.sh exec test/test_tool_middleware.exe`
- `scripts/dune-local.sh exec test/test_snapshot_provider_serialization.exe`
- `scripts/dune-local.sh exec test/test_provider_complete.exe`
- `scripts/dune-local.sh exec test/test_gemini_edge_cases.exe`
- `scripts/dune-local.sh exec test/test_backend_gemini.exe`
- `scripts/dune-local.sh runtest lib`

## 관련

- #2028 후속 정정: nudge를 ToolResult 메시지에 섞지 않고 메시지 모델 자체를 분리
- 빡센 리뷰 blocker 대응: Anthropic/Gemini native projection에서 consecutive user wire 회귀 방지
