### PR TITLE
[codex] Trim web tool ids from OAS builtins

### DIFF
--- a/lib/base/tool_id.ml
+++ b/lib/base/tool_id.ml
@@ -29,8 +29,6 @@ type t =
   | Team_create
   | Team_delete
   | Ask_user_question
-  | Web_fetch
-  | Web_search
   | Navigate
   | Computer
   | Find
@@ -82,8 +80,6 @@ let to_string = function
   | Team_create -> "team_create"
   | Team_delete -> "team_delete"
   | Ask_user_question -> "ask_user_question"
-  | Web_fetch -> "web_fetch"
-  | Web_search -> "web_search"
   | Navigate -> "navigate"
   | Computer -> "computer"
   | Find -> "find"
@@ -127,8 +123,6 @@ let all_builtins =
   ; Team_create
   ; Team_delete
   ; Ask_user_question
-  ; Web_fetch
-  ; Web_search
   ; Navigate
   ; Computer
   ; Find
@@ -208,8 +202,6 @@ let of_string raw =
   | "team_create" -> Team_create
   | "team_delete" -> Team_delete
   | "ask_user_question" -> Ask_user_question
-  | "web_fetch" -> Web_fetch
-  | "web_search" -> Web_search
   | "navigate" -> Navigate
   | "computer" -> Computer
   | "find" -> Find
@@ -233,7 +225,7 @@ let%test "of_string_lowercases_builtin" = equal (of_string "READ_FILE") Read_fil
 let%test "of_string_retired_native_tool_names_are_user_tools" =
   List.for_all
     (fun name -> equal (of_string name) (User (String.lowercase_ascii name)))
-    [ "Read"; "Glob"; "Grep"; "Write"; "Edit"; "Bash" ]
+    [ "Read"; "Glob"; "Grep"; "Write"; "Edit"; "Bash"; "web_fetch"; "web_search" ]
 ;;
 
 let%test "of_string_user_lowercases" = equal (of_string "MyTool") (User "mytool")

--- a/lib/base/tool_id.mli
+++ b/lib/base/tool_id.mli
@@ -47,9 +47,6 @@ type t =
   | Team_delete
   (* External-effect — HITL *)
   | Ask_user_question
-  (* External-effect — web & research *)
-  | Web_fetch
-  | Web_search
   (* External-effect — browser interaction *)
   | Navigate
   | Computer

--- a/lib/protocol/mcp_schema.ml
+++ b/lib/protocol/mcp_schema.ml
@@ -175,9 +175,8 @@ let%test "mcp_tool_of_sdk_tool None description becomes empty" =
 ;;
 
 (* RFC-OAS-009 v2 PR-C: removed 5 inline tests for descriptor_for_builtin_tool.
-   These tests pinned Agent_llm_a Code/Serena/Team builtin names ("read", "web_fetch",
-   "task_create", "ask_user_question", "nonexistent_xyz") into mcp_schema's
-   inline tests, which is the precise layering violation RFC-OAS-009 v2 closes.
+   These tests pinned downstream builtin names into mcp_schema's inline tests,
+   which is the precise layering violation RFC-OAS-009 v2 closes.
    The descriptor_for_builtin_tool alias itself is also removed (line 63).
    Behavior of mcp_tool_to_sdk_tool is now: descriptor=None for every MCP tool —
    consumers supply via Tool.with_descriptor or a post-conversion enrichment. *)

--- a/test/test_mcp.ml
+++ b/test/test_mcp.ml
@@ -177,11 +177,11 @@ let test_mcp_tool_to_sdk_tool () =
 
 (* RFC-OAS-009 v2 PR-C: removed test_mcp_builtin_tool_descriptor_permission.
    This test pinned the layering violation: it expected mcp_tool_to_sdk_tool
-   to auto-fill descriptors based on builtin tool names ("read_file", "write",
-   "web_fetch") via the CDAL Mode_enforcer.builtin_descriptor registry —
-   precisely the boundary RFC-OAS-009 v2 closes. Per RFC §2.2, descriptor is
-   now consumer-supplied. Completion-contract satisfaction predicates are
-   validated independently of the MCP bridge. *)
+   to auto-fill descriptors based on downstream tool names via the CDAL
+   Mode_enforcer.builtin_descriptor registry — precisely the boundary
+   RFC-OAS-009 v2 closes. Per RFC §2.2, descriptor is now consumer-supplied.
+   Completion-contract satisfaction predicates are validated independently of
+   the MCP bridge. *)
 
 let test_mcp_tool_bridge_error () =
   let mcp_tool : Mcp.mcp_tool =


### PR DESCRIPTION
## Summary
- remove `Web_fetch` / `Web_search` from the closed `Tool_id.t` builtin variants
- make `Tool_id.of_string "web_fetch"` / `"web_search"` fall through to `User _`
- scrub active MCP bridge comments that made downstream web tools look OAS-owned

## Why
OAS should not own web-search or web-fetch capabilities. Those names can exist as downstream/tool-server supplied tools, but OAS core should not classify them as builtins or imply it owns their descriptor/runtime behavior.

## Local checks
- `scripts/dune-local.sh build test/test_agent_tools_index.exe test/test_mcp.exe`
- `./_build/default/test/test_agent_tools_index.exe`
- `./_build/default/test/test_mcp.exe`
- `git diff --check`
- `scripts/lint-core-cdal-boundary.sh`
- `scripts/check-sdk-independence.sh`
