### PR TITLE
[codex] Remove remaining web tool id mentions

### DIFF
--- a/docs/rfc/RFC-OAS-008-typed-tool-identification.md
+++ b/docs/rfc/RFC-OAS-008-typed-tool-identification.md
@@ -65,7 +65,7 @@ type t =
   | Task_create | Task_update | Task_stop
   | Team_create | Team_delete
   (* external-effect *)
-  | Ask_user_question | Web_fetch | Web_search
+  | Ask_user_question
   | Navigate | Computer | Find | Form_input
   | Javascript_tool | Tabs_create_mcp | Upload_image
   (* shell-dynamic *)

--- a/lib/base/tool_id.ml
+++ b/lib/base/tool_id.ml
@@ -225,7 +225,7 @@ let%test "of_string_lowercases_builtin" = equal (of_string "READ_FILE") Read_fil
 let%test "of_string_retired_native_tool_names_are_user_tools" =
   List.for_all
     (fun name -> equal (of_string name) (User (String.lowercase_ascii name)))
-    [ "Read"; "Glob"; "Grep"; "Write"; "Edit"; "Bash"; "web_fetch"; "web_search" ]
+    [ "Read"; "Glob"; "Grep"; "Write"; "Edit"; "Bash" ]
 ;;
 
 let%test "of_string_user_lowercases" = equal (of_string "MyTool") (User "mytool")


### PR DESCRIPTION
## Summary
- remove the remaining web-search/fetch string literals from active `Tool_id` inline tests
- update the RFC-OAS-008 sample type so it no longer advertises web-search/fetch variants

## Why
PR #2031 removed web tool ids from OAS builtin ownership. This follow-up removes the leftover active code/test/docs mentions so OAS no longer teaches agents that web-search/fetch belong in the OAS tool id surface.

## Local checks
- `rg -n '\bWeb_fetch\b|\bWeb_search\b|\bweb_fetch\b|\bweb_search\b' lib test docs -S` returns no matches
- `rg -n '\bWeb[A-Za-z_]*\b' lib test docs -S` returns no matches
- `scripts/dune-local.sh build test/test_agent_tools_index.exe test/test_mcp.exe`
- `./_build/default/test/test_agent_tools_index.exe`
- `./_build/default/test/test_mcp.exe`
- `git diff --check`
- `scripts/lint-core-cdal-boundary.sh`
- `scripts/check-sdk-independence.sh`
