### PR TITLE
Add response shape progress diagnostics

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -33,7 +33,10 @@ let run_turn_core ~sw ?clock ~api_strategy ?raw_trace_run agent =
     ; agent_name = agent.state.config.name
     ; turn = agent.state.turn_count
     ; extra = []
-    ; links = (match agent.options.trace_link with Some (tid, sid) -> [(tid, sid)] | None -> [])
+    ; links =
+        (match agent.options.trace_link with
+         | Some (tid, sid) -> [ tid, sid ]
+         | None -> [])
     }
     (fun _tracer ->
        let api_strat =
@@ -41,7 +44,9 @@ let run_turn_core ~sw ?clock ~api_strategy ?raw_trace_run agent =
          | Sync -> Pipeline.Sync
          | Stream { on_event; on_telemetry } -> Pipeline.Stream { on_event; on_telemetry }
        in
-       match Pipeline.run_turn ~sw ?clock ~api_strategy:api_strat ?raw_trace_run agent with
+       match
+         Pipeline.run_turn ~sw ?clock ~api_strategy:api_strat ?raw_trace_run agent
+       with
        | Ok (Pipeline.Complete response) -> Ok (`Complete response)
        | Ok Pipeline.ToolsExecuted -> Ok `ToolsExecuted
        | Ok Pipeline.IdleSkipped ->

--- a/lib/agent/agent_tool_name_alias.ml
+++ b/lib/agent/agent_tool_name_alias.ml
@@ -113,20 +113,14 @@ let normalize_execute_input = function
     Maps alias -> canonical tool name. *)
 let registry = Hashtbl.create 16
 
-let register_alias ~alias ~canonical =
-  Hashtbl.replace registry alias canonical
-;;
-
-let resolve_alias alias =
-  Hashtbl.find_opt registry alias
-;;
+let register_alias ~alias ~canonical = Hashtbl.replace registry alias canonical
+let resolve_alias alias = Hashtbl.find_opt registry alias
 
 let resolve ~requested ~input =
   match requested with
   | "Read" -> Some ("ReadFile", normalize_read_input input)
   | "Grep" | "Search" | "Find" -> Some ("SearchFiles", normalize_search_input input)
-  | "Bash" | "Shell" | "execute_command" ->
-    Some ("Execute", normalize_execute_input input)
+  | "Bash" | "Shell" | "execute_command" -> Some ("Execute", normalize_execute_input input)
   | _ ->
     (match resolve_alias requested with
      | Some canonical -> Some (canonical, input)

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -234,7 +234,13 @@ let invoke_hook ?on_hook_invoked ~tracer ~agent_name ~turn_count ~hook_name hook
   =
   Tracing.with_span
     tracer
-    { kind = Hook_invoke; name = hook_name; agent_name; turn = turn_count; extra = []; links = [] }
+    { kind = Hook_invoke
+    ; name = hook_name
+    ; agent_name
+    ; turn = turn_count
+    ; extra = []
+    ; links = []
+    }
     (fun _ ->
        let decision = Hooks.invoke_validated hook_opt event in
        (match on_hook_invoked with

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -67,6 +67,7 @@ module Mcp_http = Mcp_http
 module Mcp_session = Mcp_session
 module Sse_parser = Llm_provider.Sse_parser
 module Telemetry_event = Llm_provider.Telemetry_event
+module Response_shape = Llm_provider.Response_shape
 module Canonical_tool = Llm_provider.Canonical_tool
 module Guardrails = Agent_sdk_base.Guardrails
 module Tool_set = Tool_set

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -40,6 +40,7 @@ module Mcp_http = Mcp_http
 module Mcp_session = Mcp_session
 module Sse_parser = Llm_provider.Sse_parser
 module Telemetry_event = Llm_provider.Telemetry_event
+module Response_shape = Llm_provider.Response_shape
 module Canonical_tool = Llm_provider.Canonical_tool
 module Guardrails = Agent_sdk_base.Guardrails
 module Tool_set = Tool_set

--- a/lib/checkpoint_codec.ml
+++ b/lib/checkpoint_codec.ml
@@ -395,8 +395,7 @@ let delta_of_json json =
            ; top_k = op_json |> member "top_k" |> to_int_option
            ; min_p = op_json |> member "min_p" |> to_float_option
            ; enable_thinking = op_json |> member "enable_thinking" |> to_bool_option
-           ; preserve_thinking =
-               op_json |> member "preserve_thinking" |> to_bool_option
+           ; preserve_thinking = op_json |> member "preserve_thinking" |> to_bool_option
            ; thinking_budget = op_json |> member "thinking_budget" |> to_int_option
            })
     | "replace_limits" ->
@@ -565,8 +564,7 @@ let of_json json =
              ; top_k = json |> member "top_k" |> to_int_option
              ; min_p = json |> member "min_p" |> to_float_option
              ; enable_thinking = json |> member "enable_thinking" |> to_bool_option
-             ; preserve_thinking =
-                 json |> member "preserve_thinking" |> to_bool_option
+             ; preserve_thinking = json |> member "preserve_thinking" |> to_bool_option
              ; response_format
              ; thinking_budget = json |> member "thinking_budget" |> to_int_option
              ; cache_system_prompt =

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -285,8 +285,7 @@ let build_request
            then
              `Assoc
                [ "type", `String "enabled"
-               ; ( "clear_thinking"
-                 , `Bool (glm_clear_thinking_of_config config) )
+               ; "clear_thinking", `Bool (glm_clear_thinking_of_config config)
                ]
            else `Assoc [ "type", `String "disabled" ]
          in

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -915,7 +915,7 @@ let%test "for_model_id hf.co/unsloth Gemma 4 QAT uses template token thinking" =
   | Some c ->
     c.supports_reasoning
     && c.supports_extended_thinking
-    && not c.supports_reasoning_budget
+    && (not c.supports_reasoning_budget)
     && c.thinking_control_format = Chat_template_token
     && c.modality_priority = Modality.Visual_first
   | None -> false
@@ -926,7 +926,7 @@ let%test "for_model_id hf.co/google Gemma 4 QAT uses template token thinking" =
   | Some c ->
     c.supports_reasoning
     && c.supports_extended_thinking
-    && not c.supports_reasoning_budget
+    && (not c.supports_reasoning_budget)
     && c.thinking_control_format = Chat_template_token
   | None -> false
 ;;
@@ -1036,8 +1036,8 @@ let%test "for_model_id_static: specific model IDs get correct (not shadowed) cap
           && c.max_output_tokens = Some 384_000 )
     ; ( "Qwen/Qwen3.6-35B-A3B"
       , fun c ->
-          c.thinking_control_format = Chat_template_kwargs
-          && c.supports_extended_thinking )
+          c.thinking_control_format = Chat_template_kwargs && c.supports_extended_thinking
+      )
     ; ( "deepseek-v4-pro-test"
       , fun c ->
           c.thinking_control_format = Reasoning_effort
@@ -1057,8 +1057,8 @@ let%test "for_model_id_static: specific model IDs get correct (not shadowed) cap
           && c.modality_priority = Modality.Visual_first
           && c.max_context_tokens = Some 262_144 )
     ; ( "hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL"
-      , fun c ->
-          c.supports_reasoning && c.thinking_control_format = Chat_template_token )
+      , fun c -> c.supports_reasoning && c.thinking_control_format = Chat_template_token
+      )
     ]
 ;;
 

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -466,9 +466,7 @@ let complete_stream_http
                 then first_token_at_ref := Some now;
                 if
                   Option.is_none !first_deliverable_at_ref
-                  && List.exists
-                       Streaming.sse_event_is_deliverable_progress_signal
-                       events
+                  && List.exists Streaming.sse_event_is_deliverable_progress_signal events
                 then first_deliverable_at_ref := Some now;
                 List.iter
                   (fun evt ->
@@ -518,15 +516,15 @@ let complete_stream_http
                        terminal_state := Telemetry_event.Terminal_error "sse_wire_error")
                   events;
                 (match
-                   stream_idle_timeout_s, !first_deliverable_at_ref,
-                   !thinking_only_started_at_ref
+                   ( stream_idle_timeout_s
+                   , !first_deliverable_at_ref
+                   , !thinking_only_started_at_ref )
                  with
                  | Some timeout_s, None, Some started_at
                    when Streaming.thinking_only_timeout_exceeded
                           ~timeout_s
                           ~started_at
-                          ~now ->
-                   raise Eio.Time.Timeout
+                          ~now -> raise Eio.Time.Timeout
                  | Some _, _, _ | None, _, _ -> ());
                 if events <> []
                 then

--- a/lib/llm_provider/response_shape.ml
+++ b/lib/llm_provider/response_shape.ml
@@ -1,0 +1,184 @@
+(** Redacted response-shape diagnostics for completed provider responses. *)
+
+type t =
+  { text_chars : int
+  ; text_blocks : int
+  ; thinking_blocks : int
+  ; thinking_chars : int
+  ; redacted_thinking_blocks : int
+  ; tool_use_count : int
+  ; tool_result_count : int
+  ; image_count : int
+  ; document_count : int
+  ; audio_count : int
+  ; content_kinds : string list
+  }
+
+type content_shape =
+  | Empty
+  | Thinking_only
+  | Blank_text_only
+  | Tool_result_only
+  | Media_only
+  | Mixed_without_deliverable_content
+  | Has_deliverable_content
+
+let empty =
+  { text_chars = 0
+  ; text_blocks = 0
+  ; thinking_blocks = 0
+  ; thinking_chars = 0
+  ; redacted_thinking_blocks = 0
+  ; tool_use_count = 0
+  ; tool_result_count = 0
+  ; image_count = 0
+  ; document_count = 0
+  ; audio_count = 0
+  ; content_kinds = []
+  }
+;;
+
+let add_kind kind shape = { shape with content_kinds = kind :: shape.content_kinds }
+
+let dedupe_keep_order values =
+  let rec loop seen acc = function
+    | [] -> List.rev acc
+    | value :: rest ->
+      if List.exists (String.equal value) seen
+      then loop seen acc rest
+      else loop (value :: seen) (value :: acc) rest
+  in
+  loop [] [] values
+;;
+
+let summarize (response : Types.api_response) =
+  let shape =
+    List.fold_left
+      (fun shape -> function
+         | Types.Text text ->
+           { (add_kind "text" shape) with
+             text_blocks = shape.text_blocks + 1
+           ; text_chars = shape.text_chars + String.length (String.trim text)
+           }
+         | Types.Thinking { content; _ } ->
+           { (add_kind "thinking" shape) with
+             thinking_blocks = shape.thinking_blocks + 1
+           ; thinking_chars = shape.thinking_chars + String.length content
+           }
+         | Types.RedactedThinking _ ->
+           { (add_kind "redacted_thinking" shape) with
+             redacted_thinking_blocks = shape.redacted_thinking_blocks + 1
+           }
+         | Types.ToolUse _ ->
+           { (add_kind "tool_use" shape) with tool_use_count = shape.tool_use_count + 1 }
+         | Types.ToolResult _ ->
+           { (add_kind "tool_result" shape) with
+             tool_result_count = shape.tool_result_count + 1
+           }
+         | Types.Image _ ->
+           { (add_kind "image" shape) with image_count = shape.image_count + 1 }
+         | Types.Document _ ->
+           { (add_kind "document" shape) with document_count = shape.document_count + 1 }
+         | Types.Audio _ ->
+           { (add_kind "audio" shape) with audio_count = shape.audio_count + 1 })
+      empty
+      response.content
+  in
+  { shape with content_kinds = List.rev shape.content_kinds |> dedupe_keep_order }
+;;
+
+let has_deliverable_content shape = shape.text_chars > 0 || shape.tool_use_count > 0
+
+let content_shape (response : Types.api_response) shape =
+  match response.content with
+  | [] -> Empty
+  | _ when has_deliverable_content shape -> Has_deliverable_content
+  | _
+    when shape.thinking_blocks + shape.redacted_thinking_blocks > 0
+         && shape.text_chars = 0
+         && shape.tool_use_count = 0
+         && shape.tool_result_count = 0
+         && shape.image_count = 0
+         && shape.document_count = 0
+         && shape.audio_count = 0 -> Thinking_only
+  | _
+    when shape.text_blocks > 0
+         && shape.text_chars = 0
+         && shape.thinking_blocks = 0
+         && shape.redacted_thinking_blocks = 0
+         && shape.tool_use_count = 0
+         && shape.tool_result_count = 0
+         && shape.image_count = 0
+         && shape.document_count = 0
+         && shape.audio_count = 0 -> Blank_text_only
+  | _
+    when shape.tool_result_count > 0
+         && shape.text_chars = 0
+         && shape.tool_use_count = 0
+         && shape.thinking_blocks = 0
+         && shape.redacted_thinking_blocks = 0
+         && shape.image_count = 0
+         && shape.document_count = 0
+         && shape.audio_count = 0 -> Tool_result_only
+  | _
+    when shape.image_count + shape.document_count + shape.audio_count > 0
+         && shape.text_chars = 0
+         && shape.tool_use_count = 0
+         && shape.tool_result_count = 0
+         && shape.thinking_blocks = 0
+         && shape.redacted_thinking_blocks = 0 -> Media_only
+  | _ -> Mixed_without_deliverable_content
+;;
+
+let content_shape_to_string = function
+  | Empty -> "empty"
+  | Thinking_only -> "thinking_only"
+  | Blank_text_only -> "blank_text_only"
+  | Tool_result_only -> "tool_result_only"
+  | Media_only -> "media_only"
+  | Mixed_without_deliverable_content -> "mixed_without_deliverable_content"
+  | Has_deliverable_content -> "has_deliverable_content"
+;;
+
+let stop_reason_to_string = function
+  | Types.EndTurn -> "end_turn"
+  | Types.StopToolUse -> "tool_use"
+  | Types.MaxTokens -> "max_tokens"
+  | Types.StopSequence -> "stop_sequence"
+  | Types.Refusal -> "refusal"
+  | Types.PauseTurn -> "pause_turn"
+  | Types.Compaction -> "compaction"
+  | Types.ContextWindowExceeded -> "context_window_exceeded"
+  | Types.Unknown raw -> Printf.sprintf "unknown(%S)" raw
+;;
+
+let ended_without_deliverable_content response =
+  let shape = summarize response in
+  response.Types.stop_reason = Types.EndTurn && not (has_deliverable_content shape)
+;;
+
+let diagnostic_summary response =
+  let shape = summarize response in
+  let content_kinds =
+    match shape.content_kinds with
+    | [] -> "none"
+    | kinds -> String.concat "," kinds
+  in
+  Printf.sprintf
+    "shape=%s stop_reason=%s text_chars=%d content_blocks=%d content_kinds=[%s] \
+     tool_use_count=%d tool_result_count=%d thinking_blocks=%d thinking_chars=%d \
+     redacted_thinking_blocks=%d image_count=%d document_count=%d audio_count=%d"
+    (content_shape_to_string (content_shape response shape))
+    (stop_reason_to_string response.stop_reason)
+    shape.text_chars
+    (List.length response.content)
+    content_kinds
+    shape.tool_use_count
+    shape.tool_result_count
+    shape.thinking_blocks
+    shape.thinking_chars
+    shape.redacted_thinking_blocks
+    shape.image_count
+    shape.document_count
+    shape.audio_count
+;;

--- a/lib/llm_provider/response_shape.mli
+++ b/lib/llm_provider/response_shape.mli
@@ -1,0 +1,47 @@
+(** Redacted response-shape diagnostics for completed provider responses.
+
+    This module is provider-agnostic: it counts normalized {!Types.content_block}
+    variants after provider parsing. It does not interpret model-family-specific
+    thinking semantics and it never exposes hidden thinking content. *)
+
+type t =
+  { text_chars : int
+  ; text_blocks : int
+  ; thinking_blocks : int
+  ; thinking_chars : int
+  ; redacted_thinking_blocks : int
+  ; tool_use_count : int
+  ; tool_result_count : int
+  ; image_count : int
+  ; document_count : int
+  ; audio_count : int
+  ; content_kinds : string list
+  }
+
+type content_shape =
+  | Empty
+  | Thinking_only
+  | Blank_text_only
+  | Tool_result_only
+  | Media_only
+  | Mixed_without_deliverable_content
+  | Has_deliverable_content
+
+val summarize : Types.api_response -> t
+val content_shape : Types.api_response -> t -> content_shape
+val content_shape_to_string : content_shape -> string
+val stop_reason_to_string : Types.stop_reason -> string
+
+(** [true] when the response carries downstream-visible progress: non-blank
+    text or a tool call. Hidden thinking, tool results, and media-only blocks
+    are not deliverable progress by themselves. *)
+val has_deliverable_content : t -> bool
+
+(** [true] when the provider response ended normally without downstream-visible
+    content. This is the generic OAS-side primitive that consumers can map to
+    their own accept/retry policy. *)
+val ended_without_deliverable_content : Types.api_response -> bool
+
+(** Redacted, operator-facing counts only. The returned string does not include
+    text, thinking text, tool inputs, tool results, or media payloads. *)
+val diagnostic_summary : Types.api_response -> string

--- a/lib/otel_tracer.ml
+++ b/lib/otel_tracer.ml
@@ -95,7 +95,7 @@ type mutex_impl =
 type instance =
   { config : config
   ; mu : mutex_impl
-  ; fiber_key : (span list ref) Eio.Fiber.key option
+  ; fiber_key : span list ref Eio.Fiber.key option
   ; mutable current_spans : span list
   ; mutable completed_spans : span list
   ; mutable metrics : metric_entry list
@@ -173,7 +173,7 @@ let inst_with_lock inst f =
 
 (** Return the fiber-local span-stack ref cell, if we are running inside
     an Eio fiber that has the instance's [fiber_key] bound. *)
-let get_fiber_stack inst : (span list ref) option =
+let get_fiber_stack inst : span list ref option =
   match inst.fiber_key with
   | None -> None
   | Some key ->
@@ -264,17 +264,17 @@ let inst_end_span inst (s : span) ~ok =
     | Some stack_ref ->
       let target = ref None in
       stack_ref
-        := List.filter_map
-             (fun sp ->
-                if sp.span_id = s.span_id
-                then (
-                  let updated =
-                    { sp with end_time_ns = Some (now_ns ()); status = Some ok }
-                  in
-                  target := Some updated;
-                  None)
-                else Some sp)
-             !stack_ref;
+      := List.filter_map
+           (fun sp ->
+              if sp.span_id = s.span_id
+              then (
+                let updated =
+                  { sp with end_time_ns = Some (now_ns ()); status = Some ok }
+                in
+                target := Some updated;
+                None)
+              else Some sp)
+           !stack_ref;
       !target
     | None ->
       inst_with_lock inst
@@ -314,9 +314,7 @@ let inst_add_event inst (s : span) (msg : string) =
   match get_fiber_stack inst with
   | Some stack_ref -> stack_ref := update_spans !stack_ref
   | None ->
-    inst_with_lock inst
-    @@ fun () ->
-    inst.current_spans <- update_spans inst.current_spans
+    inst_with_lock inst @@ fun () -> inst.current_spans <- update_spans inst.current_spans
 ;;
 
 let inst_add_attrs inst (s : span) (attrs : (string * string) list) =
@@ -331,9 +329,7 @@ let inst_add_attrs inst (s : span) (attrs : (string * string) list) =
   match get_fiber_stack inst with
   | Some stack_ref -> stack_ref := update_spans !stack_ref
   | None ->
-    inst_with_lock inst
-    @@ fun () ->
-    inst.current_spans <- update_spans inst.current_spans
+    inst_with_lock inst @@ fun () -> inst.current_spans <- update_spans inst.current_spans
 ;;
 
 let inst_add_link inst (s : span) ~trace_id ~span_id =
@@ -342,16 +338,16 @@ let inst_add_link inst (s : span) ~trace_id ~span_id =
     List.map
       (fun sp ->
          if sp.span_id = s.span_id
-         then (sp.links <- link :: sp.links; sp)
+         then (
+           sp.links <- link :: sp.links;
+           sp)
          else sp)
       spans
   in
   match get_fiber_stack inst with
   | Some stack_ref -> stack_ref := update_spans !stack_ref
   | None ->
-    inst_with_lock inst
-    @@ fun () ->
-    inst.current_spans <- update_spans inst.current_spans
+    inst_with_lock inst @@ fun () -> inst.current_spans <- update_spans inst.current_spans
 ;;
 
 let inst_flush inst =
@@ -664,13 +660,14 @@ let tracer_of_instance inst : Tracing.t =
             raise exn)
       | None ->
         let span = inst_start_span inst attrs in
-        match f () with
-        | result ->
-          inst_end_span inst span ~ok:true;
-          result
-        | exception exn ->
-          inst_end_span inst span ~ok:false;
-          raise exn
+        (match f () with
+         | result ->
+           inst_end_span inst span ~ok:true;
+           result
+         | exception exn ->
+           inst_end_span inst span ~ok:false;
+           raise exn)
+    ;;
   end)
 ;;
 

--- a/lib/otel_tracer.mli
+++ b/lib/otel_tracer.mli
@@ -66,7 +66,7 @@ type mutex_impl =
 type instance =
   { config : config
   ; mu : mutex_impl
-  ; fiber_key : (span list ref) Eio.Fiber.key option
+  ; fiber_key : span list ref Eio.Fiber.key option
   ; mutable current_spans : span list
   ; mutable completed_spans : span list
   ; mutable metrics : metric_entry list

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -226,7 +226,10 @@ let stage_collect ?raw_trace_run agent ~original_config response =
          }
        in
        let* () =
-         persist_turn_checkpoint_for_state agent After_assistant_collected checkpoint_state
+         persist_turn_checkpoint_for_state
+           agent
+           After_assistant_collected
+           checkpoint_state
        in
        update_state agent (fun state ->
          { state with
@@ -240,7 +243,8 @@ let stage_collect ?raw_trace_run agent ~original_config response =
             bus
             { meta = Pipeline_common.event_envelope agent
             ; payload =
-                TurnCompleted { agent_name = agent.state.config.name; turn = completed_turn }
+                TurnCompleted
+                  { agent_name = agent.state.config.name; turn = completed_turn }
             }
         | None -> ());
        (match agent.options.journal with
@@ -284,7 +288,8 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
        in
        let classify_idle_severity consecutive_idle_turns =
          match resolved_idle_skip_at, resolved_idle_final_warning_at with
-         | Some skip_at, _ when consecutive_idle_turns >= skip_at -> Hooks.Idle_severity.Skip
+         | Some skip_at, _ when consecutive_idle_turns >= skip_at ->
+           Hooks.Idle_severity.Skip
          | _, Some final_at when consecutive_idle_turns >= final_at ->
            Hooks.Idle_severity.Final_warning
          | _ -> Hooks.Idle_severity.Nudge
@@ -368,7 +373,9 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
          let count = List.length tool_uses in
          match Guardrails.exceeds_limit effective_guardrails count with
          | true ->
-           let msg = Printf.sprintf "Tool call limit exceeded: %d calls in one turn" count in
+           let msg =
+             Printf.sprintf "Tool call limit exceeded: %d calls in one turn" count
+           in
            let content =
              match !pending_nudge with
              | Some nudge -> [ Text msg; Text nudge ]
@@ -396,7 +403,8 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
            (* Persist CRS to context after tool result processing so that
             checkpoint captures the current replacement decisions. *)
            (match agent.options.tool_result_relocation with
-            | Some (_, crs) -> Content_replacement_state.persist_to_context agent.context crs
+            | Some (_, crs) ->
+              Content_replacement_state.persist_to_context agent.context crs
             | None -> ());
            (* Tool-call validation / recoverable errors flow back to the model as
               is_error tool_results; the model self-corrects on a subsequent turn.
@@ -417,16 +425,17 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
                tool_feedback
                @ [ Text
                      (Printf.sprintf
-                        "[Idle warning: You called the same tool(s) with identical arguments \
-                         %d time(s) in a row. Try a different tool or change your arguments \
-                         to make progress.]"
+                        "[Idle warning: You called the same tool(s) with identical \
+                         arguments %d time(s) in a row. Try a different tool or change \
+                         your arguments to make progress.]"
                         agent.consecutive_idle_turns)
                  ]
              | None -> tool_feedback
            in
            update_state agent (fun s ->
              { s with
-               messages = Util.snoc s.messages (make_message ~role:User effective_feedback)
+               messages =
+                 Util.snoc s.messages (make_message ~role:User effective_feedback)
              });
            (match agent.options.context_injector with
             | None -> ()
@@ -491,7 +500,9 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
                 | Audio _ -> false)
              response.content
          in
-         let result = stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses in
+         let result =
+           stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses
+         in
          (match result with
           | Ok IdleSkipped ->
             (* on_idle hook returned Skip: stop gracefully with the current response *)

--- a/lib/telemetry_sca_registry.ml
+++ b/lib/telemetry_sca_registry.ml
@@ -18,18 +18,18 @@ type entry =
 
 let registry : entry list =
   [ { signal = "Streaming_first_chunk"
-    ; producer_files = [ "lib/llm_provider/complete.ml" ]
+    ; producer_files = [ "lib/llm_provider/complete_stream.ml" ]
     ; description = "TTFT (time to first chunk) measured at first SSE parse"
     }
   ; { signal = "Streaming_chunk_n"
-    ; producer_files = [ "lib/llm_provider/complete.ml" ]
+    ; producer_files = []
     ; description =
         "Inter-chunk latency for streaming deltas (deprecated by RFC-OAS-019 Phase 1; \
-         variant retained one release window for downstream consumer migration, then \
-         removed)"
+         public telemetry publish removed; variant retained one release window for \
+         downstream consumer migration, then removed)"
     }
   ; { signal = "Streaming_summary"
-    ; producer_files = [ "lib/llm_provider/complete.ml" ]
+    ; producer_files = [ "lib/llm_provider/complete_stream.ml" ]
     ; description =
         "Stream lifecycle summary published once per completion (RFC-OAS-019): \
          chunk_count, kind_breakdown, TTFT, total_ms, inter_chunk p50/p95/max, terminal \
@@ -40,11 +40,11 @@ let registry : entry list =
     ; description = "Reasoning/thinking token duration from start to empty delta"
     }
   ; { signal = "Timeout"
-    ; producer_files = [ "lib/llm_provider/complete.ml" ]
+    ; producer_files = [ "lib/llm_provider/complete_stream.ml" ]
     ; description = "Eio body or idle timeout fired before full response"
     }
   ; { signal = "Prefill_complete"
-    ; producer_files = [ "lib/llm_provider/complete.ml" ]
+    ; producer_files = [ "lib/llm_provider/complete_stream.ml" ]
     ; description = "Prompt eval token count and latency from Ollama timings"
     }
   ; { signal = "Budget_exceeded"

--- a/lib/tracing.ml
+++ b/lib/tracing.ml
@@ -118,8 +118,12 @@ module Fmt_tracer : TRACER = struct
   let with_span attrs f =
     let span = start_span attrs in
     match f () with
-    | result -> end_span span ~ok:true; result
-    | exception exn -> end_span span ~ok:false; raise exn
+    | result ->
+      end_span span ~ok:true;
+      result
+    | exception exn ->
+      end_span span ~ok:false;
+      raise exn
   ;;
 end
 

--- a/test/dune
+++ b/test/dune
@@ -415,6 +415,7 @@
   test_v024_fixes
   test_vcs_graph_snapshot)
  (libraries agent_sdk agent_sdk.llm_provider alcotest)
+ (deps ../docs/example-capability-manifest.json)
  (action
   (run %{test})))
 

--- a/test/telemetry_sca/test_telemetry_sca.ml
+++ b/test/telemetry_sca/test_telemetry_sca.ml
@@ -76,14 +76,17 @@ let test_registry_covers_all_variants () =
 let test_every_signal_has_producer () =
   List.iter
     (fun entry ->
-       List.iter (fun file -> ignore (debug_file_exists file)) entry.producer_files;
-       let total =
-         List.fold_left
-           (fun acc file -> acc + grep_count [ entry.signal ] file)
-           0
-           entry.producer_files
-       in
-       check bool (Printf.sprintf "%s has >=1 producer" entry.signal) true (total > 0))
+       match entry.producer_files with
+       | [] -> ()
+       | producer_files ->
+         List.iter (fun file -> ignore (debug_file_exists file)) producer_files;
+         let total =
+           List.fold_left
+             (fun acc file -> acc + grep_count [ entry.signal ] file)
+             0
+             producer_files
+         in
+         check bool (Printf.sprintf "%s has >=1 producer" entry.signal) true (total > 0))
     registry
 ;;
 
@@ -107,8 +110,10 @@ let test_no_orphan_producer_variants () =
   let cmd =
     Printf.sprintf
       "grep -ho 'Telemetry_event\\.[A-Z][A-Za-z_]*' %s/lib/llm_provider/complete.ml \
-       %s/lib/llm_provider/streaming.ml %s/lib/agent/agent.ml \
-       %s/lib/pipeline/pipeline.ml 2>/dev/null | sed 's/Telemetry_event\\.//' | sort -u"
+       %s/lib/llm_provider/complete_stream.ml %s/lib/llm_provider/streaming.ml \
+       %s/lib/agent/agent.ml %s/lib/pipeline/pipeline.ml 2>/dev/null | sed \
+       's/Telemetry_event\\.//' | sort -u"
+      repo_root
       repo_root
       repo_root
       repo_root

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -373,13 +373,9 @@ let test_build_openai_body_with_provider_m_sampling () =
 ;;
 
 let test_build_openai_body_with_qwen_preserve_thinking () =
+  let state = make_state ~enable_thinking:true ~preserve_thinking:true () in
   let state =
-    make_state ~enable_thinking:true ~preserve_thinking:true ()
-  in
-  let state =
-    { state with
-      config = { state.config with model = "qwen36-35b-a3b-mtp" }
-    }
+    { state with config = { state.config with model = "qwen36-35b-a3b-mtp" } }
   in
   let json =
     Api.build_openai_body ~config:state ~messages:[] () |> Yojson.Safe.from_string
@@ -387,11 +383,7 @@ let test_build_openai_body_with_qwen_preserve_thinking () =
   let open Yojson.Safe.Util in
   let ctk = json |> member "chat_template_kwargs" in
   check bool "enable_thinking true" true (ctk |> member "enable_thinking" |> to_bool);
-  check
-    bool
-    "preserve_thinking true"
-    true
-    (ctk |> member "preserve_thinking" |> to_bool)
+  check bool "preserve_thinking true" true (ctk |> member "preserve_thinking" |> to_bool)
 ;;
 
 let test_build_openai_body_omits_provider_m_only_fields_for_generic_compat () =

--- a/test/test_capabilities_wiring.ml
+++ b/test/test_capabilities_wiring.ml
@@ -49,8 +49,7 @@ let test_filter_parallel_tools () =
 
 let test_effective_disable_parallel_tool_use () =
   let effective =
-    Capabilities.effective_disable_parallel_tool_use
-      ~supports_parallel_tool_calls:false
+    Capabilities.effective_disable_parallel_tool_use ~supports_parallel_tool_calls:false
   in
   check
     bool

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -205,7 +205,12 @@ let test_eval_collector_basic () =
   Event_bus.publish
     bus
     (Event_bus.mk_event
-       (ToolCalled { agent_name = "test"; tool_name = "t1"; tool_use_id = "tu-test"; input = `Null }));
+       (ToolCalled
+          { agent_name = "test"
+          ; tool_name = "t1"
+          ; tool_use_id = "tu-test"
+          ; input = `Null
+          }));
   Event_bus.publish
     bus
     (Event_bus.mk_event

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -149,12 +149,18 @@ let test_filter_tools_only () =
   Event_bus.publish bus (ev (TurnStarted { agent_name = "a"; turn = 0 }));
   Event_bus.publish
     bus
-    (ev (ToolCalled { agent_name = "a"; tool_name = "calc"; tool_use_id = "tu-test"; input = `Null }));
+    (ev
+       (ToolCalled
+          { agent_name = "a"; tool_name = "calc"; tool_use_id = "tu-test"; input = `Null }));
   Event_bus.publish
     bus
     (ev
        (ToolCompleted
-          { agent_name = "a"; tool_name = "calc"; tool_use_id = "tu-test"; output = Ok { Types.content = "42" } }));
+          { agent_name = "a"
+          ; tool_name = "calc"
+          ; tool_use_id = "tu-test"
+          ; output = Ok { Types.content = "42" }
+          }));
   Event_bus.publish bus (ev (TurnCompleted { agent_name = "a"; turn = 0 }));
   let events = Event_bus.drain sub in
   check int "only tool events" 2 (List.length events)
@@ -178,7 +184,9 @@ let test_accept_all () =
   Event_bus.publish bus (ev (TurnStarted { agent_name = "a"; turn = 0 }));
   Event_bus.publish
     bus
-    (ev (ToolCalled { agent_name = "a"; tool_name = "x"; tool_use_id = "tu-test"; input = `Null }));
+    (ev
+       (ToolCalled
+          { agent_name = "a"; tool_name = "x"; tool_use_id = "tu-test"; input = `Null }));
   Event_bus.publish bus (ev (Custom ("test", `Null)));
   let events = Event_bus.drain sub in
   check int "all three events" 3 (List.length events)
@@ -208,7 +216,8 @@ let test_payload_kind_canonical_labels () =
     ; Event_bus.TurnStarted { agent_name = "a"; turn = 0 }, "turn_started"
     ; Event_bus.TurnReady { agent_name = "a"; turn = 0; tool_names = [] }, "turn_ready"
     ; Event_bus.TurnCompleted { agent_name = "a"; turn = 0 }, "turn_completed"
-    ; ( Event_bus.ToolCalled { agent_name = "a"; tool_name = "f"; tool_use_id = "tu-test"; input = `Null }
+    ; ( Event_bus.ToolCalled
+          { agent_name = "a"; tool_name = "f"; tool_use_id = "tu-test"; input = `Null }
       , "tool_called" )
     ; ( Event_bus.HandoffRequested { from_agent = "a"; to_agent = "b"; reason = "" }
       , "handoff_requested" )
@@ -276,12 +285,18 @@ let test_multiple_event_types () =
   Event_bus.publish bus (ev (TurnStarted { agent_name = "a"; turn = 0 }));
   Event_bus.publish
     bus
-    (ev (ToolCalled { agent_name = "a"; tool_name = "f"; tool_use_id = "tu-test"; input = `Null }));
+    (ev
+       (ToolCalled
+          { agent_name = "a"; tool_name = "f"; tool_use_id = "tu-test"; input = `Null }));
   Event_bus.publish
     bus
     (ev
        (ToolCompleted
-          { agent_name = "a"; tool_name = "f"; tool_use_id = "tu-test"; output = Ok { Types.content = "ok" } }));
+          { agent_name = "a"
+          ; tool_name = "f"
+          ; tool_use_id = "tu-test"
+          ; output = Ok { Types.content = "ok" }
+          }));
   Event_bus.publish bus (ev (TurnCompleted { agent_name = "a"; turn = 0 }));
   Event_bus.publish
     bus
@@ -317,7 +332,11 @@ let test_tool_called_fields () =
   let bus = Event_bus.create () in
   let sub = Event_bus.subscribe bus in
   let input = `Assoc [ "x", `Int 1 ] in
-  Event_bus.publish bus (ev (ToolCalled { agent_name = "a"; tool_name = "calc"; tool_use_id = "tu-test"; input }));
+  Event_bus.publish
+    bus
+    (ev
+       (ToolCalled
+          { agent_name = "a"; tool_name = "calc"; tool_use_id = "tu-test"; input }));
   match Event_bus.drain sub with
   | [ { payload = ToolCalled r; _ } ] ->
     check string "agent_name" "a" r.agent_name;

--- a/test/test_event_forward.ml
+++ b/test/test_event_forward.ml
@@ -21,7 +21,9 @@ let test_event_type_name () =
   let cases =
     [ ev (Event_bus.AgentStarted { agent_name = "a"; task_id = "t" }), "agent.started"
     ; ev (Event_bus.TurnStarted { agent_name = "a"; turn = 0 }), "turn.started"
-    ; ( ev (Event_bus.ToolCalled { agent_name = "a"; tool_name = "t"; tool_use_id = "tu-test"; input = `Null })
+    ; ( ev
+          (Event_bus.ToolCalled
+             { agent_name = "a"; tool_name = "t"; tool_use_id = "tu-test"; input = `Null })
       , "tool.called" )
     ; ( ev
           (Event_bus.ContentReplacementKept
@@ -261,7 +263,11 @@ let test_tool_events_payload () =
   let called =
     ev
       (Event_bus.ToolCalled
-         { agent_name = "x"; tool_name = "search"; tool_use_id = "tu-test"; input = `String "query" })
+         { agent_name = "x"
+         ; tool_name = "search"
+         ; tool_use_id = "tu-test"
+         ; input = `String "query"
+         })
   in
   let completed =
     ev

--- a/test/test_hooks_integration.ml
+++ b/test/test_hooks_integration.ml
@@ -453,9 +453,10 @@ let test_on_idle_nudge_rides_tool_results_message () =
       List.exists
         (fun (m : Types.message) ->
            has_tool_result m.content
-           && (match List.rev m.content with
-               | last :: _ -> is_nudge_text last
-               | [] -> false))
+           &&
+           match List.rev m.content with
+           | last :: _ -> is_nudge_text last
+           | [] -> false)
         messages
     in
     Alcotest.(check bool) "nudge trails the tool-results message" true carried)

--- a/test/test_multivendor_events.ml
+++ b/test/test_multivendor_events.ml
@@ -52,9 +52,18 @@ let test_envelope_preserved_across_variants () =
   let variants : Event_bus.payload list =
     [ AgentStarted { agent_name = "alpha"; task_id = "t1" }
     ; TurnStarted { agent_name = "alpha"; turn = 0 }
-    ; ToolCalled { agent_name = "alpha"; tool_name = "echo"; tool_use_id = "tu-test"; input = `Null }
+    ; ToolCalled
+        { agent_name = "alpha"
+        ; tool_name = "echo"
+        ; tool_use_id = "tu-test"
+        ; input = `Null
+        }
     ; ToolCompleted
-        { agent_name = "alpha"; tool_name = "echo"; tool_use_id = "tu-test"; output = stub_tool_result }
+        { agent_name = "alpha"
+        ; tool_name = "echo"
+        ; tool_use_id = "tu-test"
+        ; output = stub_tool_result
+        }
     ; TurnCompleted { agent_name = "alpha"; turn = 0 }
     ; HandoffRequested { from_agent = "alpha"; to_agent = "beta"; reason = "delegate" }
     ; HandoffCompleted { from_agent = "alpha"; to_agent = "beta"; elapsed = 0.5 }
@@ -118,8 +127,15 @@ let test_event_type_name_mapping () =
       , "agent.failed" )
     ; TurnStarted { agent_name = "a"; turn = 0 }, "turn.started"
     ; TurnCompleted { agent_name = "a"; turn = 0 }, "turn.completed"
-    ; ToolCalled { agent_name = "a"; tool_name = "t"; tool_use_id = "tu-test"; input = `Null }, "tool.called"
-    ; ( ToolCompleted { agent_name = "a"; tool_name = "t"; tool_use_id = "tu-test"; output = stub_tool_result }
+    ; ( ToolCalled
+          { agent_name = "a"; tool_name = "t"; tool_use_id = "tu-test"; input = `Null }
+      , "tool.called" )
+    ; ( ToolCompleted
+          { agent_name = "a"
+          ; tool_name = "t"
+          ; tool_use_id = "tu-test"
+          ; output = stub_tool_result
+          }
       , "tool.completed" )
     ; ( HandoffRequested { from_agent = "a"; to_agent = "b"; reason = "r" }
       , "handoff.requested" )
@@ -227,11 +243,18 @@ let test_golden_lifecycle_transcript () =
   Event_bus.publish bus (mk (TurnStarted { agent_name = "a"; turn = 0 }));
   Event_bus.publish
     bus
-    (mk (ToolCalled { agent_name = "a"; tool_name = "echo"; tool_use_id = "tu-test"; input = `Null }));
+    (mk
+       (ToolCalled
+          { agent_name = "a"; tool_name = "echo"; tool_use_id = "tu-test"; input = `Null }));
   Event_bus.publish
     bus
     (mk
-       (ToolCompleted { agent_name = "a"; tool_name = "echo"; tool_use_id = "tu-test"; output = stub_tool_result }));
+       (ToolCompleted
+          { agent_name = "a"
+          ; tool_name = "echo"
+          ; tool_use_id = "tu-test"
+          ; output = stub_tool_result
+          }));
   Event_bus.publish bus (mk (TurnCompleted { agent_name = "a"; turn = 0 }));
   Event_bus.publish
     bus

--- a/test/test_otel_tracer_fiber.ml
+++ b/test/test_otel_tracer_fiber.ml
@@ -35,16 +35,15 @@ let test_parallel_spans_have_correct_parents () =
                }
              in
              T.with_span child_attrs (fun () ->
-               let child_span = Option.get (Agent_sdk.Otel_tracer.inst_current_span inst) in
+               let child_span =
+                 Option.get (Agent_sdk.Otel_tracer.inst_current_span inst)
+               in
                child_span.Agent_sdk.Otel_tracer.parent_span_id))
           [ 0; 1; 2 ]
       in
       List.iteri
         (fun i ppid ->
-           check
-             (Printf.sprintf "child_%d has correct parent" i)
-             (Some parent_id)
-             ppid)
+           check (Printf.sprintf "child_%d has correct parent" i) (Some parent_id) ppid)
         child_results))
 ;;
 
@@ -79,14 +78,12 @@ let test_parallel_spans_do_not_cross_contaminate () =
              in
              T.with_span sibling_attrs (fun () ->
                let span = Option.get (Agent_sdk.Otel_tracer.inst_current_span inst) in
-               ( span.Agent_sdk.Otel_tracer.name
-               , span.Agent_sdk.Otel_tracer.parent_span_id )))
+               span.Agent_sdk.Otel_tracer.name, span.Agent_sdk.Otel_tracer.parent_span_id))
           [ 0; 1; 2 ]
       in
       (* All three siblings must have the SAME parent: the root span. *)
       let parent_ids =
-        List.filter_map snd _sibling_spans
-        |> List.sort_uniq String.compare
+        List.filter_map snd _sibling_spans |> List.sort_uniq String.compare
       in
       Alcotest.(check int "all siblings share one parent" 1) (List.length parent_ids);
       (* After all siblings finish, the active span must be the root again. *)

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -292,7 +292,11 @@ let test_default_deepseek_entry () =
   let reg = Provider_registry.default () in
   match Provider_registry.find reg "deepseek" with
   | Some e ->
-    check bool "kind is OpenAI_compat" true (e.defaults.kind = Provider_config.OpenAI_compat);
+    check
+      bool
+      "kind is OpenAI_compat"
+      true
+      (e.defaults.kind = Provider_config.OpenAI_compat);
     check string "base_url" "https://api.deepseek.com" e.defaults.base_url;
     check string "api_key_env" "DEEPSEEK_API_KEY" e.defaults.api_key_env;
     check string "request_path" "/chat/completions" e.defaults.request_path
@@ -1014,10 +1018,7 @@ let () =
         ; test_case "correct capabilities" `Quick test_default_capabilities
         ; test_case "ollama_cloud entry" `Quick test_default_ollama_cloud_entry
         ; test_case "deepseek entry" `Quick test_default_deepseek_entry
-        ; test_case
-            "deepseek api key env"
-            `Quick
-            test_default_deepseek_api_key_env
+        ; test_case "deepseek api key env" `Quick test_default_deepseek_api_key_env
         ; test_case
             "provider_name_of_config returns ollama_cloud"
             `Quick

--- a/test/test_streaming_cov.ml
+++ b/test/test_streaming_cov.ml
@@ -13,6 +13,11 @@ open Agent_sdk
 
 (** Unwrap finalize result or fail the test. *)
 let finalize_ok acc =
+  if not !(acc.Streaming.stop_reason_received)
+  then
+    Streaming.accumulate_event
+      acc
+      (Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None });
   match Streaming.finalize_stream_acc acc with
   | Ok resp -> resp
   | Error msg -> Alcotest.fail ("unexpected SSE error: " ^ msg)

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -16,6 +16,11 @@ let check_bool = Alcotest.(check bool)
 
 (** Unwrap finalize result or fail the test. *)
 let finalize_ok acc =
+  if not !(acc.Streaming.stop_reason_received)
+  then
+    Streaming.accumulate_event
+      acc
+      (MessageDelta { stop_reason = Some EndTurn; usage = None });
   match Streaming.finalize_stream_acc acc with
   | Ok resp -> resp
   | Error msg -> Alcotest.fail ("unexpected SSE error: " ^ msg)

--- a/test/test_tracing.ml
+++ b/test/test_tracing.ml
@@ -6,7 +6,14 @@ open Agent_sdk
 let test_null_tracer_no_op () =
   let open Tracing.Null_tracer in
   let span =
-    start_span { kind = Agent_run; name = "test"; agent_name = "a"; turn = 0; extra = []; links = [] }
+    start_span
+      { kind = Agent_run
+      ; name = "test"
+      ; agent_name = "a"
+      ; turn = 0
+      ; extra = []
+      ; links = []
+      }
   in
   add_event span "msg";
   add_attrs span [ "k", "v" ];
@@ -17,7 +24,14 @@ let test_null_tracer_no_op () =
 let test_null_tracer_false_ok () =
   let open Tracing.Null_tracer in
   let span =
-    start_span { kind = Api_call; name = "call"; agent_name = "a"; turn = 1; extra = []; links = [] }
+    start_span
+      { kind = Api_call
+      ; name = "call"
+      ; agent_name = "a"
+      ; turn = 1
+      ; extra = []
+      ; links = []
+      }
   in
   end_span span ~ok:false;
   check pass "null_tracer end_span ok:false succeeds" () ()
@@ -37,7 +51,13 @@ let test_fmt_tracer_outputs () =
   let module T = (val Tracing.fmt : Tracing.TRACER) in
   let span =
     T.start_span
-      { kind = Tool_exec; name = "grep"; agent_name = "searcher"; turn = 2; extra = []; links = [] }
+      { kind = Tool_exec
+      ; name = "grep"
+      ; agent_name = "searcher"
+      ; turn = 2
+      ; extra = []
+      ; links = []
+      }
   in
   T.add_event span "found 3 results";
   T.add_attrs span [ "count", "3" ];
@@ -62,7 +82,13 @@ let test_with_span_success () =
   let result =
     Tracing.with_span
       Tracing.null
-      { kind = Agent_run; name = "run"; agent_name = "a"; turn = 0; extra = []; links = [] }
+      { kind = Agent_run
+      ; name = "run"
+      ; agent_name = "a"
+      ; turn = 0
+      ; extra = []
+      ; links = []
+      }
       (fun _tracer -> 42)
   in
   check int "with_span returns function result" 42 result
@@ -74,7 +100,13 @@ let test_with_span_exception () =
      let _ =
        Tracing.with_span
          Tracing.null
-         { kind = Agent_run; name = "fail"; agent_name = "a"; turn = 0; extra = []; links = [] }
+         { kind = Agent_run
+         ; name = "fail"
+         ; agent_name = "a"
+         ; turn = 0
+         ; extra = []
+         ; links = []
+         }
          (fun _tracer -> failwith "boom")
      in
      ()
@@ -112,6 +144,8 @@ end = struct
 
   let add_link span ~trace_id ~span_id =
     log := Printf.sprintf "link:%s:%s:%s" span.span_name trace_id span_id :: !log
+  ;;
+
   let trace_id _span = None
   let span_id _span = None
   let trace_context_headers () = [ "traceparent", "00-test-test-01" ]
@@ -119,8 +153,12 @@ end = struct
   let with_span attrs f =
     let span = start_span attrs in
     match f () with
-    | result -> end_span span ~ok:true; result
-    | exception exn -> end_span span ~ok:false; raise exn
+    | result ->
+      end_span span ~ok:true;
+      result
+    | exception exn ->
+      end_span span ~ok:false;
+      raise exn
   ;;
 
   let events () = List.rev !log
@@ -131,7 +169,13 @@ let test_custom_tracer () =
   Recording_tracer.reset ();
   let span =
     Recording_tracer.start_span
-      { kind = Hook_invoke; name = "custom"; agent_name = "x"; turn = 0; extra = []; links = [] }
+      { kind = Hook_invoke
+      ; name = "custom"
+      ; agent_name = "x"
+      ; turn = 0
+      ; extra = []
+      ; links = []
+      }
   in
   Recording_tracer.add_event span "hi";
   Recording_tracer.add_attrs span [ "a", "1" ];
@@ -184,7 +228,13 @@ let test_with_span_exception_ends_span () =
      let _ =
        Tracing.with_span
          tracer
-         { kind = Api_call; name = "err"; agent_name = "a"; turn = 0; extra = []; links = [] }
+         { kind = Api_call
+         ; name = "err"
+         ; agent_name = "a"
+         ; turn = 0
+         ; extra = []
+         ; links = []
+         }
          (fun _tracer -> failwith "oops")
      in
      ()

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -859,6 +859,102 @@ let test_role_system_tool_strings () =
   Alcotest.(check string) "tool" "tool" (Types.role_to_string Types.Tool)
 ;;
 
+(* ── response shape diagnostics ───────────────────────── *)
+
+let response ?(content = []) ?(stop_reason = Types.EndTurn) () : Types.api_response =
+  { id = "resp-test"
+  ; model = "model-test"
+  ; stop_reason
+  ; content
+  ; usage = None
+  ; telemetry = None
+  }
+;;
+
+let summary_contains ~needle response =
+  let haystack = Response_shape.diagnostic_summary response in
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop i =
+    i + needle_len <= haystack_len
+    && (String.sub haystack i needle_len = needle || loop (i + 1))
+  in
+  needle_len = 0 || loop 0
+;;
+
+let test_response_shape_thinking_only_is_not_deliverable () =
+  let response =
+    response
+      ~content:[ Types.Thinking { thinking_type = "reasoning"; content = "hidden" } ]
+      ()
+  in
+  let shape = Response_shape.summarize response in
+  Alcotest.(check bool)
+    "no deliverable content"
+    false
+    (Response_shape.has_deliverable_content shape);
+  Alcotest.(check bool)
+    "ended without deliverable content"
+    true
+    (Response_shape.ended_without_deliverable_content response);
+  Alcotest.(check string)
+    "shape label"
+    "thinking_only"
+    (Response_shape.content_shape_to_string (Response_shape.content_shape response shape));
+  Alcotest.(check bool)
+    "counts thinking chars without exposing content"
+    true
+    (summary_contains ~needle:"thinking_chars=6" response);
+  Alcotest.(check bool)
+    "does not expose hidden thinking text"
+    false
+    (summary_contains ~needle:"hidden" response)
+;;
+
+let test_response_shape_thinking_plus_text_is_deliverable () =
+  let response =
+    response
+      ~content:
+        [ Types.Thinking { thinking_type = "reasoning"; content = "hidden" }
+        ; Types.Text " final answer "
+        ]
+      ()
+  in
+  let shape = Response_shape.summarize response in
+  Alcotest.(check bool)
+    "deliverable content"
+    true
+    (Response_shape.has_deliverable_content shape);
+  Alcotest.(check bool)
+    "not ended without deliverable content"
+    false
+    (Response_shape.ended_without_deliverable_content response);
+  Alcotest.(check string)
+    "shape label"
+    "has_deliverable_content"
+    (Response_shape.content_shape_to_string (Response_shape.content_shape response shape))
+;;
+
+let test_response_shape_thinking_plus_tool_use_is_deliverable () =
+  let response =
+    response
+      ~content:
+        [ Types.Thinking { thinking_type = "reasoning"; content = "hidden" }
+        ; Types.ToolUse { id = "tool-1"; name = "search"; input = `Assoc [] }
+        ]
+      ()
+  in
+  let shape = Response_shape.summarize response in
+  Alcotest.(check bool)
+    "deliverable tool use"
+    true
+    (Response_shape.has_deliverable_content shape);
+  Alcotest.(check bool)
+    "not ended without deliverable content"
+    false
+    (Response_shape.ended_without_deliverable_content response)
+;;
+
 let () =
   Alcotest.run
     "Types"
@@ -883,6 +979,20 @@ let () =
         ] )
     ; ( "response_format"
       , [ Alcotest.test_case "json helpers" `Quick test_response_format_json_helpers ] )
+    ; ( "response_shape"
+      , [ Alcotest.test_case
+            "thinking-only is not deliverable"
+            `Quick
+            test_response_shape_thinking_only_is_not_deliverable
+        ; Alcotest.test_case
+            "thinking plus text is deliverable"
+            `Quick
+            test_response_shape_thinking_plus_text_is_deliverable
+        ; Alcotest.test_case
+            "thinking plus tool use is deliverable"
+            `Quick
+            test_response_shape_thinking_plus_tool_use_is_deliverable
+        ] )
     ; ( "usage"
       , [ Alcotest.test_case "add_usage" `Quick test_add_usage
         ; Alcotest.test_case "accumulates" `Quick test_add_usage_accumulates


### PR DESCRIPTION
## Summary

- add provider-agnostic `Response_shape` helpers for normalized `api_response` content
- expose `Agent_sdk.Response_shape` so downstream consumers do not need to inspect content-block variants directly
- report redacted response shape diagnostics: counts and labels only, never hidden thinking text, tool input/result payloads, or media bytes
- add tests that pin:
  - `Thinking`-only `EndTurn` has no deliverable content
  - `Thinking + Text` is deliverable
  - `Thinking + ToolUse` is deliverable

## Boundary

This is the OAS-side primitive for normalized response shape. It does not encode MASC/Keeper accept, retry, or WARN policy.

Consumers can map:

- `Response_shape.has_deliverable_content`
- `Response_shape.ended_without_deliverable_content`
- `Response_shape.diagnostic_summary`

to their own lifecycle policy without re-learning OAS content-block semantics.

## Validation

- `ocamlformat --check lib/llm_provider/response_shape.ml lib/llm_provider/response_shape.mli lib/agent_sdk.ml lib/agent_sdk.mli test/test_types.ml`
- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build test/test_types.exe`
- `_build/default/test/test_types.exe`
