### PR TITLE
[codex] Remove team tool ids from OAS builtins

### DIFF
--- a/docs/rfc/RFC-OAS-008-typed-tool-identification.md
+++ b/docs/rfc/RFC-OAS-008-typed-tool-identification.md
@@ -63,7 +63,6 @@ type t =
   | Write | Edit | Create_text_file | Replace_content
   | Rename_symbol | Notebook_edit
   | Task_create | Task_update | Task_stop
-  | Team_create | Team_delete
   (* external-effect *)
   | Ask_user_question
   | Navigate | Computer | Find | Form_input

--- a/lib/base/tool_id.ml
+++ b/lib/base/tool_id.ml
@@ -26,8 +26,6 @@ type t =
   | Task_create
   | Task_update
   | Task_stop
-  | Team_create
-  | Team_delete
   | Ask_user_question
   | Navigate
   | Computer
@@ -77,8 +75,6 @@ let to_string = function
   | Task_create -> "task_create"
   | Task_update -> "task_update"
   | Task_stop -> "task_stop"
-  | Team_create -> "team_create"
-  | Team_delete -> "team_delete"
   | Ask_user_question -> "ask_user_question"
   | Navigate -> "navigate"
   | Computer -> "computer"
@@ -120,8 +116,6 @@ let all_builtins =
   ; Task_create
   ; Task_update
   ; Task_stop
-  ; Team_create
-  ; Team_delete
   ; Ask_user_question
   ; Navigate
   ; Computer
@@ -199,8 +193,6 @@ let of_string raw =
   | "task_create" -> Task_create
   | "task_update" -> Task_update
   | "task_stop" -> Task_stop
-  | "team_create" -> Team_create
-  | "team_delete" -> Team_delete
   | "ask_user_question" -> Ask_user_question
   | "navigate" -> Navigate
   | "computer" -> Computer

--- a/lib/base/tool_id.mli
+++ b/lib/base/tool_id.mli
@@ -39,12 +39,10 @@ type t =
   | Insert_before_symbol
   | Replace_symbol_body
   | Notebook_edit
-  (* Local-mutation — task & team management *)
+  (* Local-mutation — task management *)
   | Task_create
   | Task_update
   | Task_stop
-  | Team_create
-  | Team_delete
   (* External-effect — HITL *)
   | Ask_user_question
   (* External-effect — browser interaction *)


### PR DESCRIPTION
## Summary
- remove `Team_create` / `Team_delete` from the closed `Tool_id.t` builtin variants
- make `team_create` / `team_delete` downstream/tool-server supplied names instead of OAS-owned builtins
- update the RFC-OAS-008 sample type so it no longer advertises team tool variants

## Why
OAS should not own team-management tool capabilities. Those names can exist in downstream MCP/tool-server surfaces, but OAS core should only carry generic tool identity and runtime contracts.

## Local checks
- `rg -n '\bTeam_create\b|\bTeam_delete\b|\bteam_create\b|\bteam_delete\b' lib test docs -S` returns no matches
- `scripts/dune-local.sh build test/test_agent_tools_index.exe test/test_mcp.exe`
- `./_build/default/test/test_agent_tools_index.exe`
- `./_build/default/test/test_mcp.exe`
- `git diff --check`
- `scripts/lint-core-cdal-boundary.sh`
- `scripts/check-sdk-independence.sh`
