### PR TITLE
[codex] Isolate observer callback failures

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -13,6 +13,16 @@ open Agent_trace
 
 let _log = Log.create ~module_name:"agent" ()
 
+let protect_stream_callback callback ev =
+  try callback ev with
+  | Out_of_memory -> raise Out_of_memory
+  | Stack_overflow -> raise Stack_overflow
+  | Sys.Break -> raise Sys.Break
+  | Eio.Cancel.Cancelled _ as ex -> raise ex
+  | exn ->
+    Log.warn _log "stream callback raised" [ Log.S ("error", Printexc.to_string exn) ]
+;;
+
 (* ── Unified turn execution (delegated to Pipeline) ──────────── *)
 
 type api_strategy = Pipeline.api_strategy =
@@ -490,7 +500,7 @@ let run_stream ~sw ?clock ~on_event ?on_yield ?on_resume agent user_prompt =
   let caller_on_event = on_event in
   let on_event ev =
     on_activity ();
-    caller_on_event ev
+    protect_stream_callback caller_on_event ev
   in
   with_periodic_callbacks ~sw ?clock ~last_activity agent (fun () ->
     run_loop
@@ -728,7 +738,7 @@ let run_turn_stream ~sw ?clock ~on_event ?on_telemetry agent =
   let caller_on_event = on_event in
   let on_event ev =
     last_activity := now_or_zero clock;
-    caller_on_event ev
+    protect_stream_callback caller_on_event ev
   in
   with_optional_timeout ?clock ~last_activity agent (fun () ->
     run_turn_core ~sw ?clock ~api_strategy:(Stream { on_event; on_telemetry }) agent)

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -156,6 +156,8 @@ val run
   -> string
   -> (Types.api_response, Error.sdk_error) result
 
+(** Stream a full agent run. Non-fatal exceptions raised by [on_event] are
+    logged and do not abort the run. *)
 val run_stream
   :  sw:Eio.Switch.t
   -> ?clock:_ Eio.Time.clock
@@ -166,6 +168,8 @@ val run_stream
   -> string
   -> (Types.api_response, Error.sdk_error) result
 
+(** Stream one agent turn. Non-fatal exceptions raised by [on_event] are
+    logged and do not abort the turn. *)
 val run_turn_stream
   :  sw:Eio.Switch.t
   -> ?clock:_ Eio.Time.clock

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -175,6 +175,22 @@ let tool_exception_result ~id ~name exn =
   }
 ;;
 
+let protect_tool_lifecycle_callback ~tool_name ~callback_name f =
+  try f () with
+  | Out_of_memory -> raise Out_of_memory
+  | Stack_overflow -> raise Stack_overflow
+  | Sys.Break -> raise Sys.Break
+  | Eio.Cancel.Cancelled _ as ex -> raise ex
+  | exn ->
+    Log.warn
+      _log
+      "tool lifecycle callback raised"
+      [ Log.S ("tool", tool_name)
+      ; Log.S ("callback", callback_name)
+      ; Log.S ("error", Printexc.to_string exn)
+      ]
+;;
+
 let approval_required_without_callback_result ~id ~name =
   let reason = "approval required but no approval callback is registered" in
   { tool_use_id = id
@@ -663,7 +679,9 @@ let execute_scheduled_tool
           })
    | None -> ());
   (match on_tool_execution_started with
-   | Some callback -> callback ~tool_use_id:id ~tool_name:name ~input ~schedule
+   | Some callback ->
+     protect_tool_lifecycle_callback ~tool_name:name ~callback_name:"started" (fun () ->
+       callback ~tool_use_id:id ~tool_name:name ~input ~schedule)
    | None -> ());
   let t0_tool = Unix.gettimeofday () in
   let triple =
@@ -860,11 +878,12 @@ let execute_scheduled_tool
    | None -> ());
   (match on_tool_execution_finished with
    | Some callback ->
-     callback
-       ~tool_use_id:id
-       ~tool_name:name
-       ~content:triple.content
-       ~is_error:triple.is_error
+     protect_tool_lifecycle_callback ~tool_name:name ~callback_name:"finished" (fun () ->
+       callback
+         ~tool_use_id:id
+         ~tool_name:name
+         ~content:triple.content
+         ~is_error:triple.is_error)
    | None -> ());
   index, triple
 ;;

--- a/lib/agent/agent_tools.mli
+++ b/lib/agent/agent_tools.mli
@@ -105,6 +105,10 @@ val find_and_execute_tool
     from canceling siblings (except [Out_of_memory], [Stack_overflow],
     [Sys.Break], and cancellation).
 
+    [on_tool_execution_started] and [on_tool_execution_finished] are
+    best-effort lifecycle observers. Non-fatal exceptions raised by these
+    callbacks are logged and do not change the tool result.
+
     Returns one [tool_execution_result] per [ToolUse] block in the same
     relative order as the input. *)
 val execute_tools

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -274,6 +274,7 @@ let complete_stream
   match validate_all config with
   | Error err -> Error err
   | Ok () ->
+    let on_event = emit_stream_event on_event in
     let _priority = priority in
     let request_config = config_with_trace_context config trace_context in
     let t0 = Unix.gettimeofday () in

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -141,6 +141,8 @@ val complete_with_retry
 (** Execute a streaming LLM completion.
     Each SSE event is passed to [on_event] as it arrives.
     Returns the final assembled {!Types.api_response} after the stream ends.
+    Non-fatal exceptions raised by [on_event] are logged and do not abort the
+    stream assembly.
 
     Supports both Anthropic native SSE and OpenAI-compatible SSE formats,
     dispatched by {!Provider_config.t.kind}.

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -8,6 +8,19 @@
 include Complete_common
 include Complete_sampling
 
+let emit_stream_event on_event evt =
+  try on_event evt with
+  | Out_of_memory -> raise Out_of_memory
+  | Stack_overflow -> raise Stack_overflow
+  | Sys.Break -> raise Sys.Break
+  | Eio.Cancel.Cancelled _ as ex -> raise ex
+  | exn ->
+    Diag.warn
+      "complete_stream"
+      "stream event callback raised: %s"
+      (Printexc.to_string exn)
+;;
+
 let record_streaming_metrics (metrics : Metrics.t) = function
   | Telemetry_event.Streaming_first_chunk { provider; model; ttfrc_ms; _ } ->
     metrics.on_streaming_first_chunk ~provider ~model_id:model ~ttfrc_ms
@@ -433,7 +446,7 @@ let complete_stream_http
           ~headers:(config.headers @ Provider_config.auth_headers_for_config config)
           ~body:body_with_stream
           ~f:(fun reader ->
-            on_event Types.Connected;
+            emit_stream_event on_event Types.Connected;
             let body_logic () =
               let acc = Complete_stream_acc.create_stream_acc () in
               let provider_d_state = ref None in
@@ -470,7 +483,7 @@ let complete_stream_http
                 then first_deliverable_at_ref := Some now;
                 List.iter
                   (fun evt ->
-                     on_event evt;
+                     emit_stream_event on_event evt;
                      Complete_stream_acc.accumulate_event acc evt;
                      (* RFC-OAS-019: classify each delta for the
                         [Streaming_summary] kind_breakdown that fires at
@@ -650,7 +663,7 @@ let complete_stream_http
                       "stream_idle_timeout_s deadline exceeded while %s"
                       (Http_client.stream_idle_state_to_label !stream_idle_state)
                   in
-                  on_event (Types.Timeout message);
+                  emit_stream_event on_event (Types.Timeout message);
                   emit_telemetry
                     (Telemetry_event.Timeout
                        { provider

--- a/test/test_approval.ml
+++ b/test/test_approval.ml
@@ -64,6 +64,8 @@ let execute_with_tools_in_env
       ?event_bus
       ?approval
       ?(missing_approval_callback_policy = Hooks.Execute_without_callback)
+      ?on_tool_execution_started
+      ?on_tool_execution_finished
       tool_uses
   =
   let net = Eio.Stdenv.net env in
@@ -88,6 +90,8 @@ let execute_with_tools_in_env
     ~usage:(Agent.state agent).usage
     ~approval:opts.approval
     ~missing_approval_callback_policy:opts.missing_approval_callback_policy
+    ?on_tool_execution_started
+    ?on_tool_execution_finished
     tool_uses
 ;;
 
@@ -98,6 +102,8 @@ let run_execute_with_tools
       ~hooks
       ?approval
       ?missing_approval_callback_policy
+      ?on_tool_execution_started
+      ?on_tool_execution_finished
       tool_uses
   =
   Eio_main.run
@@ -108,6 +114,8 @@ let run_execute_with_tools
     ~hooks
     ?approval
     ?missing_approval_callback_policy
+    ?on_tool_execution_started
+    ?on_tool_execution_finished
     tool_uses
 ;;
 
@@ -134,6 +142,35 @@ let test_approval_required_no_callback () =
   | [ result ] ->
     check string "id" "t1" result.tool_use_id;
     check string "content" {|"hello"|} result.content;
+    check bool "no error" false result.is_error
+  | _ -> fail "expected exactly one result"
+;;
+
+let test_tool_lifecycle_callback_exceptions_are_nonfatal () =
+  let started_calls = ref 0 in
+  let finished_calls = ref 0 in
+  let on_tool_execution_started ~tool_use_id:_ ~tool_name:_ ~input:_ ~schedule:_ =
+    incr started_calls;
+    failwith "started callback boom"
+  in
+  let on_tool_execution_finished ~tool_use_id:_ ~tool_name:_ ~content:_ ~is_error:_ =
+    incr finished_calls;
+    failwith "finished callback boom"
+  in
+  let results =
+    run_execute_with_tools
+      ~tools:[ make_echo_tool "safe" ]
+      ~hooks:Hooks.empty
+      ~on_tool_execution_started
+      ~on_tool_execution_finished
+      [ ToolUse { id = "t1"; name = "safe"; input = `Assoc [ "x", `Int 1 ] } ]
+  in
+  match results with
+  | [ result ] ->
+    check int "started callback called" 1 !started_calls;
+    check int "finished callback called" 1 !finished_calls;
+    check string "id" "t1" result.tool_use_id;
+    check string "content" {|{"x":1}|} result.content;
     check bool "no error" false result.is_error
   | _ -> fail "expected exactly one result"
 ;;
@@ -815,6 +852,12 @@ let () =
             "tool exception still publishes ToolCompleted"
             `Quick
             test_tool_exception_still_publishes_tool_completed
+        ] )
+    ; ( "callbacks"
+      , [ test_case
+            "lifecycle callback exceptions are nonfatal"
+            `Quick
+            test_tool_lifecycle_callback_exceptions_are_nonfatal
         ] )
     ]
 ;;

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -854,6 +854,15 @@ let start_sse_server ~sw ~net response_body =
   Printf.sprintf "http://127.0.0.1:%d" port
 ;;
 
+let text_of_response (resp : Types.api_response) =
+  List.filter_map
+    (function
+      | Types.Text s -> Some s
+      | _ -> None)
+    resp.content
+  |> String.concat ""
+;;
+
 let test_complete_stream_ok () =
   Eio_main.run
   @@ fun env ->
@@ -884,13 +893,58 @@ let test_complete_stream_ok () =
   | Exit -> ()
 ;;
 
-let text_of_response (resp : Types.api_response) =
-  List.filter_map
-    (function
-      | Types.Text s -> Some s
-      | _ -> None)
-    resp.content
-  |> String.concat ""
+let test_complete_stream_on_event_exception_is_nonfatal () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url =
+      start_sse_server ~sw ~net:env#net (provider_a_sse_response "streamed text")
+    in
+    let config = make_config url in
+    let calls = ref 0 in
+    let on_event _evt =
+      incr calls;
+      failwith "stream observer failed"
+    in
+    match Complete.complete_stream ~sw ~net:env#net ~config ~messages ~on_event () with
+    | Ok resp ->
+      check string "text" "streamed text" (text_of_response resp);
+      check bool "callback invoked" true (!calls > 0);
+      Eio.Switch.fail sw Exit
+    | Error _ -> fail "expected Ok"
+  with
+  | Exit -> ()
+;;
+
+let test_complete_stream_transport_on_event_exception_is_nonfatal () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let calls = ref 0 in
+  let transport =
+    { (make_transport (Ok (mock_transport_response "transport streamed"))) with
+      complete_stream =
+        (fun ?on_telemetry:_ ~on_event _req ->
+          on_event
+            (Types.ContentBlockDelta { index = 0; delta = Types.TextDelta "ignored" });
+          Ok (mock_transport_response "transport streamed"))
+    }
+  in
+  let on_event _evt =
+    incr calls;
+    failwith "transport observer failed"
+  in
+  let config = make_config "http://unused.test" in
+  match
+    Complete.complete_stream ~sw ~net:env#net ~transport ~config ~messages ~on_event ()
+  with
+  | Ok resp ->
+    check string "text" "transport streamed" (text_of_response resp);
+    check int "callback invoked" 1 !calls
+  | Error _ -> fail "expected Ok"
 ;;
 
 let test_complete_stream_active_chunks_can_exceed_idle_timeout_total () =
@@ -1229,6 +1283,14 @@ let () =
     ; "retry", [ test_case "first try ok" `Quick test_retry_first_try ]
     ; ( "stream"
       , [ test_case "sse ok" `Quick test_complete_stream_ok
+        ; test_case
+            "on_event exceptions are nonfatal"
+            `Quick
+            test_complete_stream_on_event_exception_is_nonfatal
+        ; test_case
+            "transport on_event exceptions are nonfatal"
+            `Quick
+            test_complete_stream_transport_on_event_exception_is_nonfatal
         ; test_case
             "active chunks exceed idle total"
             `Quick


### PR DESCRIPTION
## Summary
- isolate non-fatal tool lifecycle observer callback exceptions from tool execution results
- isolate non-fatal streaming `on_event` callback exceptions at Agent and Complete streaming boundaries
- add regression tests for lifecycle callbacks, HTTP streaming callbacks, and custom transport streaming callbacks

## Why
Observer callbacks should not change the primary tool execution or stream assembly result. Before this, a tracing/UI/log observer failure could abort a tool run or streaming response even though the underlying work succeeded.

## Validation
- `ocamlformat --check lib/agent/agent.ml lib/agent/agent.mli lib/agent/agent_tools.ml lib/agent/agent_tools.mli lib/llm_provider/complete.ml lib/llm_provider/complete.mli lib/llm_provider/complete_stream.ml test/test_approval.ml test/test_complete_http.ml`
- `scripts/dune-local.sh build test/test_approval.exe test/test_complete_http.exe test/test_agent_pipeline.exe`
- `scripts/dune-local.sh exec ./test/test_approval.exe`
- `scripts/dune-local.sh exec ./test/test_complete_http.exe`
- `scripts/dune-local.sh exec ./test/test_agent_pipeline.exe`