### PR TITLE
fix(provider): close tool message pairs before requests

### DIFF
--- a/lib/api_anthropic.ml
+++ b/lib/api_anthropic.ml
@@ -35,6 +35,11 @@ let build_body_assoc
       ~supports_parallel_tool_calls:capabilities.supports_parallel_tool_calls
       ~tools_present
   in
+  let messages =
+    messages
+    |> Llm_provider.Tool_message_pairs.close_for_provider_request
+    |> Llm_provider.Api_common.merge_tool_result_followup_user_messages
+  in
   let body_assoc =
     [ "model", `String model_str
     ; "max_tokens", `Int (Option.value ~default:4096 config.config.max_tokens)

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -99,7 +99,9 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
            && should_include_tools ?provider_config config -> Some entries
     | _ -> None
   in
-  let sanitized_messages = strip_orphaned_tool_results messages in
+  let sanitized_messages =
+    Llm_provider.Backend_openai_serialize.close_tool_message_pairs_for_request messages
+  in
   let provider_messages =
     let message_serializer =
       if is_glm_request ?provider_config config

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -81,7 +81,11 @@ let build_request
       ~supports_parallel_tool_calls:caps.supports_parallel_tool_calls
       ~tools_present
   in
-  let messages = Api_common.merge_tool_result_followup_user_messages messages in
+  let messages =
+    messages
+    |> Tool_message_pairs.close_for_provider_request
+    |> Api_common.merge_tool_result_followup_user_messages
+  in
   let message_to_json = Api_common.message_to_json in
   let msgs_json = List.map message_to_json messages in
   let body =

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -107,7 +107,11 @@ let part_of_content_block id_to_name = function
 (* ── Message list -> (contents, systemInstruction option) ── *)
 
 let contents_of_messages (messages : message list) =
-  let messages = Api_common.merge_tool_result_followup_user_messages messages in
+  let messages =
+    messages
+    |> Tool_message_pairs.close_for_provider_request
+    |> Api_common.merge_tool_result_followup_user_messages
+  in
   let id_to_name = build_tool_id_to_name messages in
   let system_parts = ref [] in
   let contents = ref [] in

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -54,6 +54,7 @@ let build_request
     then Some (with_gemma4_think_token config.system_prompt)
     else config.system_prompt
   in
+  let messages = Tool_message_pairs.close_for_provider_request messages in
   let provider_messages =
     (match system_prompt with
      | Some s when not (Api_common.string_is_blank s) ->

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -29,6 +29,11 @@ let tool_choice_to_provider_d_json =
 
 let build_provider_d_tool_json = Backend_openai_serialize.build_provider_d_tool_json
 let strip_orphaned_tool_results = Backend_openai_serialize.strip_orphaned_tool_results
+
+let close_tool_message_pairs_for_request =
+  Backend_openai_serialize.close_tool_message_pairs_for_request
+;;
+
 let strip_thinking_blocks = Backend_openai_serialize.strip_thinking_blocks
 
 (* ── Re-exports from parsing ──────────────────────────── *)

--- a/lib/llm_provider/backend_openai.mli
+++ b/lib/llm_provider/backend_openai.mli
@@ -12,6 +12,7 @@ val strip_json_markdown_fences : string -> string
 val tool_choice_to_provider_d_json : Types.tool_choice -> Yojson.Safe.t
 val build_provider_d_tool_json : Yojson.Safe.t -> Yojson.Safe.t
 val strip_orphaned_tool_results : Types.message list -> Types.message list
+val close_tool_message_pairs_for_request : Types.message list -> Types.message list
 val response_format_to_provider_d_json : Types.response_format -> Yojson.Safe.t option
 
 (** Parse an OpenAI-compatible JSON response.

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -136,7 +136,7 @@ let build_request
   =
   let tools = effective_tools config tools in
   let sanitized_messages =
-    Backend_openai_serialize.strip_orphaned_tool_results messages
+    Backend_openai_serialize.close_tool_message_pairs_for_request messages
   in
   let is_deepseek_model model_id = String.starts_with ~prefix:"deepseek" model_id in
   let provider_messages =

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -250,101 +250,14 @@ let ollama_messages_of_message ?(model_id = "") msg =
     compaction drops or reorders a ToolUse while the corresponding
     ToolResult survives.
 
-    OpenAI-compatible APIs reject orphaned tool_call_ids; the Anthropic
-    API has its own dangling-tool-call repair, so this is Openai-path only.
+    Provider request builders call {!close_tool_message_pairs_for_request} so
+    OpenAI-compatible, Anthropic, Gemini, and Ollama paths share the same
+    outbound history invariant.
 
     Pure function — no I/O, no mutation. *)
-let strip_orphaned_tool_results (messages : message list) : message list =
-  let tool_use_ids (msg : message) =
-    List.filter_map
-      (function
-        | ToolUse { id; _ } -> Some id
-        | Text _
-        | Thinking _
-        | RedactedThinking _
-        | ToolResult _
-        | Image _
-        | Document _
-        | Audio _ -> None)
-      msg.content
-  in
-  let tool_result_ids (msg : message) =
-    List.filter_map
-      (function
-        | ToolResult { tool_use_id; _ } -> Some tool_use_id
-        | Text _
-        | Thinking _
-        | RedactedThinking _
-        | ToolUse _
-        | Image _
-        | Document _
-        | Audio _ -> None)
-      msg.content
-  in
-  let has_tool_result msg = tool_result_ids msg <> [] in
-  let split_tool_result_span messages =
-    let rec loop span = function
-      | msg :: rest when has_tool_result msg -> loop (msg :: span) rest
-      | rest -> List.rev span, rest
-    in
-    loop [] messages
-  in
-  let filter_tool_results allowed seen (msg : message) =
-    let seen_ref = ref seen in
-    let content =
-      List.filter
-        (function
-          | ToolResult { tool_use_id; _ } ->
-            let keep =
-              List.mem tool_use_id allowed && not (List.mem tool_use_id !seen_ref)
-            in
-            if keep then seen_ref := tool_use_id :: !seen_ref;
-            keep
-          | Text _
-          | Thinking _
-          | RedactedThinking _
-          | ToolUse _
-          | Image _
-          | Document _
-          | Audio _ -> true)
-        msg.content
-    in
-    let msg = if content = [] then None else Some { msg with content } in
-    msg, !seen_ref
-  in
-  let filter_result_span allowed span =
-    let filtered, _seen =
-      List.fold_left
-        (fun (acc, seen) msg ->
-           let msg, seen = filter_tool_results allowed seen msg in
-           match msg with
-           | Some msg -> msg :: acc, seen
-           | None -> acc, seen)
-        ([], [])
-        span
-    in
-    List.rev filtered
-  in
-  let rec aux acc = function
-    | [] -> List.rev acc
-    | (msg : message) :: rest ->
-      let use_ids = if msg.role = Assistant then tool_use_ids msg else [] in
-      if use_ids = []
-      then (
-        let msg, _seen = filter_tool_results [] [] msg in
-        let acc =
-          match msg with
-          | Some msg -> msg :: acc
-          | None -> acc
-        in
-        aux acc rest)
-      else (
-        let span, tail = split_tool_result_span rest in
-        let filtered_span = filter_result_span use_ids span in
-        aux (List.rev_append filtered_span (msg :: acc)) tail)
-  in
-  aux [] messages
-;;
+let strip_orphaned_tool_results = Tool_message_pairs.strip_orphaned_tool_results
+
+let close_tool_message_pairs_for_request = Tool_message_pairs.close_for_provider_request
 
 (** Strip Thinking blocks from all messages.
 

--- a/lib/llm_provider/backend_openai_serialize.mli
+++ b/lib/llm_provider/backend_openai_serialize.mli
@@ -24,11 +24,16 @@ val parallel_tool_calls_fields
 
 val build_provider_d_tool_json : Yojson.Safe.t -> Yojson.Safe.t
 
-(** Remove ToolResult blocks whose tool_use_id has no matching ToolUse
-    in any Assistant message. Call before serializing messages for
-    OpenAI-compatible APIs to prevent orphaned tool_call_id errors
-    after context compaction.  @since 0.103.0 *)
+(** Remove ToolResult blocks outside the immediate result span following their
+    Assistant ToolUse message. Kept for compatibility; provider request builders
+    should normally call {!close_tool_message_pairs_for_request}. @since 0.103.0
+*)
 val strip_orphaned_tool_results : Types.message list -> Types.message list
+
+(** Normalize tool-call pairing before provider request serialization:
+    orphan ToolResult blocks are removed and dangling Assistant ToolUse blocks
+    receive synthetic error ToolResult messages. *)
+val close_tool_message_pairs_for_request : Types.message list -> Types.message list
 
 (** Remove Thinking blocks from all messages. Deepseek-compatible APIs
     reject [reasoning_content] in request messages — it is response-only.

--- a/lib/llm_provider/tool_message_pairs.ml
+++ b/lib/llm_provider/tool_message_pairs.ml
@@ -1,0 +1,158 @@
+open Types
+
+let tool_use_ids (msg : message) =
+  List.filter_map
+    (function
+      | ToolUse { id; _ } -> Some id
+      | Text _
+      | Thinking _
+      | RedactedThinking _
+      | ToolResult _
+      | Image _
+      | Document _
+      | Audio _ -> None)
+    msg.content
+;;
+
+let tool_uses (msg : message) =
+  List.filter_map
+    (function
+      | ToolUse { id; name; _ } -> Some (id, name)
+      | Text _
+      | Thinking _
+      | RedactedThinking _
+      | ToolResult _
+      | Image _
+      | Document _
+      | Audio _ -> None)
+    msg.content
+;;
+
+let tool_result_ids (msg : message) =
+  List.filter_map
+    (function
+      | ToolResult { tool_use_id; _ } -> Some tool_use_id
+      | Text _
+      | Thinking _
+      | RedactedThinking _
+      | ToolUse _
+      | Image _
+      | Document _
+      | Audio _ -> None)
+    msg.content
+;;
+
+let has_tool_result msg = tool_result_ids msg <> []
+
+let split_tool_result_span messages =
+  let rec loop span = function
+    | msg :: rest when has_tool_result msg -> loop (msg :: span) rest
+    | rest -> List.rev span, rest
+  in
+  loop [] messages
+;;
+
+let strip_orphaned_tool_results (messages : message list) : message list =
+  let filter_tool_results allowed seen (msg : message) =
+    let seen_ref = ref seen in
+    let content =
+      List.filter
+        (function
+          | ToolResult { tool_use_id; _ } ->
+            let keep =
+              List.mem tool_use_id allowed && not (List.mem tool_use_id !seen_ref)
+            in
+            if keep then seen_ref := tool_use_id :: !seen_ref;
+            keep
+          | Text _
+          | Thinking _
+          | RedactedThinking _
+          | ToolUse _
+          | Image _
+          | Document _
+          | Audio _ -> true)
+        msg.content
+    in
+    let msg = if content = [] then None else Some { msg with content } in
+    msg, !seen_ref
+  in
+  let filter_result_span allowed span =
+    let filtered, _seen =
+      List.fold_left
+        (fun (acc, seen) msg ->
+           let msg, seen = filter_tool_results allowed seen msg in
+           match msg with
+           | Some msg -> msg :: acc, seen
+           | None -> acc, seen)
+        ([], [])
+        span
+    in
+    List.rev filtered
+  in
+  let rec aux acc = function
+    | [] -> List.rev acc
+    | (msg : message) :: rest ->
+      let use_ids = if msg.role = Assistant then tool_use_ids msg else [] in
+      if use_ids = []
+      then (
+        let msg, _seen = filter_tool_results [] [] msg in
+        let acc =
+          match msg with
+          | Some msg -> msg :: acc
+          | None -> acc
+        in
+        aux acc rest)
+      else (
+        let span, tail = split_tool_result_span rest in
+        let filtered_span = filter_result_span use_ids span in
+        aux (List.rev_append filtered_span (msg :: acc)) tail)
+  in
+  aux [] messages
+;;
+
+let synthetic_tool_result_message (id, _name) =
+  { role = Tool
+  ; content =
+      [ ToolResult
+          { tool_use_id = id
+          ; content =
+              "OAS synthesized this error tool result because provider request history \
+               contained a tool call without an adjacent result."
+          ; is_error = true
+          ; json = None
+          ; content_blocks = None
+          }
+      ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata =
+      [ "oas.synthetic_tool_result", `Bool true
+      ; "oas.synthetic_reason", `String "dangling_tool_use"
+      ; "oas.tool_use_id", `String id
+      ]
+  }
+;;
+
+let repair_dangling_tool_calls (messages : message list) : message list =
+  let rec aux acc = function
+    | [] -> List.rev acc
+    | (msg : message) :: rest ->
+      let uses = if msg.role = Assistant then tool_uses msg else [] in
+      if uses = []
+      then aux (msg :: acc) rest
+      else (
+        let result_span, tail = split_tool_result_span rest in
+        let result_ids = List.concat_map tool_result_ids result_span in
+        let dangling =
+          List.filter (fun (id, _name) -> not (List.mem id result_ids)) uses
+        in
+        let repairs = List.map synthetic_tool_result_message dangling in
+        let segment = (msg :: result_span) @ repairs in
+        aux (List.rev_append segment acc) tail)
+  in
+  aux [] messages
+;;
+
+let close_for_provider_request messages =
+  messages |> strip_orphaned_tool_results |> repair_dangling_tool_calls
+;;

--- a/lib/llm_provider/tool_message_pairs.mli
+++ b/lib/llm_provider/tool_message_pairs.mli
@@ -1,0 +1,15 @@
+(** Provider-agnostic ToolUse/ToolResult pairing repair.
+
+    These helpers run at provider request serialization boundaries. They keep
+    historical state untouched, but make the outbound message list satisfy the
+    common provider contract that assistant tool calls are immediately followed
+    by matching tool results. *)
+
+val strip_orphaned_tool_results : Types.message list -> Types.message list
+
+(** Insert synthetic error ToolResult messages for assistant ToolUse blocks that
+    do not have a matching ToolResult in the immediate result span. *)
+val repair_dangling_tool_calls : Types.message list -> Types.message list
+
+(** Drop orphan ToolResult blocks, then close dangling ToolUse blocks. *)
+val close_for_provider_request : Types.message list -> Types.message list

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -196,6 +196,43 @@ let test_tool_result () =
   check string "function name" "get_weather" (fr |> member "name" |> to_string)
 ;;
 
+let test_dangling_tool_use_closed_before_request () =
+  let config = provider_f_config () in
+  let messages =
+    [ Types.user_msg "question"
+    ; { role = Assistant
+      ; content = [ ToolUse { id = "call_1"; name = "lookup"; input = `Null } ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ; Types.user_msg "continue"
+    ]
+  in
+  let body = Backend_gemini.build_request ~config ~messages () in
+  let json = parse_body body in
+  let contents = json |> member "contents" |> to_list in
+  check int "synthetic function response inserted" 3 (List.length contents);
+  let roles = List.map (fun content -> content |> member "role" |> to_string) contents in
+  check (list string) "roles" [ "user"; "model"; "user" ] roles;
+  let synthetic = List.nth contents 2 in
+  let synthetic_parts = synthetic |> member "parts" |> to_list in
+  let fr = List.hd synthetic_parts |> member "functionResponse" in
+  check string "function name" "lookup" (fr |> member "name" |> to_string);
+  check
+    bool
+    "synthetic result"
+    true
+    (String.starts_with
+       ~prefix:"OAS synthesized"
+       (fr |> member "response" |> member "result" |> to_string));
+  check
+    string
+    "follow-up text remains after result"
+    "continue"
+    (List.nth synthetic_parts 1 |> member "text" |> to_string)
+;;
+
 let test_json_mode () =
   let config = provider_f_config ~json_mode:true () in
   let messages = [ Types.user_msg "Return JSON." ] in
@@ -790,6 +827,10 @@ let () =
             `Quick
             test_disable_parallel_tool_use_dropped
         ; test_case "tool result" `Quick test_tool_result
+        ; test_case
+            "dangling tool use closed"
+            `Quick
+            test_dangling_tool_use_closed_before_request
         ; test_case "json mode" `Quick test_json_mode
         ; test_case "output schema" `Quick test_output_schema
         ; test_case "role mapping" `Quick test_role_mapping

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -28,6 +28,7 @@ let as_list label = function
 let member key json = Yojson.Safe.Util.member key json
 let to_string json = Yojson.Safe.Util.to_string json
 let to_int json = Yojson.Safe.Util.to_int json
+let to_list json = Yojson.Safe.Util.to_list json
 
 let response_json ?(content = `String "ok") ?(finish_reason = "stop") ?message_fields () =
   let message_fields =
@@ -334,6 +335,89 @@ let test_strip_orphaned_tool_results_dedupes_and_drops_empty () =
     check_string "tool content" "first" content;
     check_string "text" "kept" text
   | _ -> Alcotest.fail "unexpected stripped user content"
+;;
+
+let test_close_tool_message_pairs_repairs_dangling_and_late_results () =
+  let messages =
+    [ msg Assistant [ ToolUse { id = "call-1"; name = "lookup"; input = `Null } ]
+    ; msg User [ Text "interleaving user text" ]
+    ; msg
+        Tool
+        [ ToolResult
+            { tool_use_id = "call-1"
+            ; content = "late result"
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
+        ]
+    ]
+  in
+  let closed = Serialize.close_tool_message_pairs_for_request messages in
+  check_int "synthetic inserted and late result dropped" 3 (List.length closed);
+  (match List.nth closed 1 with
+   | { role = Tool
+     ; content = [ ToolResult { tool_use_id; content; is_error; _ } ]
+     ; metadata
+     ; _
+     } ->
+     check_string "synthetic id" "call-1" tool_use_id;
+     check_bool "synthetic is error" true is_error;
+     check_bool
+       "synthetic content"
+       true
+       (String.starts_with ~prefix:"OAS synthesized" content);
+     Alcotest.(check (option bool))
+       "synthetic metadata"
+       (Some true)
+       (match List.assoc_opt "oas.synthetic_tool_result" metadata with
+        | Some (`Bool value) -> Some value
+        | _ -> None)
+   | _ -> Alcotest.fail "expected adjacent synthetic tool result");
+  let late_survived =
+    List.exists
+      (fun (m : message) ->
+         List.exists
+           (function
+             | ToolResult { content = "late result"; _ } -> true
+             | _ -> false)
+           m.content)
+      closed
+  in
+  check_bool "late result dropped" false late_survived
+;;
+
+let test_openai_build_request_closes_dangling_tool_call () =
+  let config =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"gpt-4o-mini"
+      ~base_url:"https://example.invalid/v1"
+      ()
+  in
+  let messages =
+    [ msg User [ Text "question" ]
+    ; msg Assistant [ ToolUse { id = "call-missing"; name = "lookup"; input = `Null } ]
+    ; msg User [ Text "continue" ]
+    ]
+  in
+  let body =
+    Backend_openai.build_request ~config ~messages () |> Yojson.Safe.from_string
+  in
+  let wire_messages = body |> member "messages" |> to_list in
+  let roles = List.map (fun json -> json |> member "role" |> to_string) wire_messages in
+  Alcotest.(check (list string))
+    "wire roles"
+    [ "user"; "assistant"; "tool"; "user" ]
+    roles;
+  let tool_msg = List.nth wire_messages 2 in
+  check_string "tool id" "call-missing" (tool_msg |> member "tool_call_id" |> to_string);
+  check_bool
+    "synthetic result body"
+    true
+    (String.starts_with
+       ~prefix:"OAS synthesized"
+       (tool_msg |> member "content" |> to_string))
 ;;
 
 let test_strip_thinking_blocks () =
@@ -830,6 +914,14 @@ let () =
             "strip orphaned tool results"
             `Quick
             test_strip_orphaned_tool_results_dedupes_and_drops_empty
+        ; Alcotest.test_case
+            "close tool message pairs"
+            `Quick
+            test_close_tool_message_pairs_repairs_dangling_and_late_results
+        ; Alcotest.test_case
+            "build_request closes dangling tool call"
+            `Quick
+            test_openai_build_request_closes_dangling_tool_call
         ; Alcotest.test_case "strip thinking blocks" `Quick test_strip_thinking_blocks
         ; Alcotest.test_case
             "tool choice and schema conversion"


### PR DESCRIPTION
## Summary
- add a provider-agnostic Tool_message_pairs normalizer in llm_provider
- drop orphan ToolResult blocks and synthesize adjacent error ToolResult messages for dangling assistant ToolUse blocks before provider requests
- apply the shared normalization to OpenAI-compatible, Anthropic, Gemini, and Ollama request builders

## Verification
- ocamlformat --check on touched OCaml files
- git diff --check
- scripts/dune-local.sh build test/test_backend_openai_codec.exe test/test_backend_gemini.exe
- ./_build/default/test/test_backend_openai_codec.exe
- ./_build/default/test/test_backend_gemini.exe