### PR TITLE
fix(openai): omit disabled reasoning effort

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -165,15 +165,13 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
          | Some true, Some budget -> ("thinking_budget", `Int budget) :: body_assoc
          | _ -> body_assoc)
       | Llm_provider.Capabilities.Reasoning_effort ->
-        (match config.config.enable_thinking with
-         | Some _ ->
-           let effort =
-             Llm_provider.Provider_config.effort_of_thinking_config
-               ~enable_thinking:config.config.enable_thinking
-               ~thinking_budget:config.config.thinking_budget
-           in
-           ("reasoning_effort", `String effort) :: body_assoc
-         | None -> ("reasoning_effort", `String "none") :: body_assoc)
+        (match
+           Llm_provider.Provider_config.reasoning_effort_request_value
+             ~enable_thinking:config.config.enable_thinking
+             ~thinking_budget:config.config.thinking_budget
+         with
+         | Some effort -> ("reasoning_effort", `String effort) :: body_assoc
+         | None -> body_assoc)
       | Llm_provider.Capabilities.Thinking_object ->
         (match config.config.enable_thinking with
          | Some true ->

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -248,15 +248,13 @@ let build_request
        | Some true, Some budget -> ("thinking_budget", `Int budget) :: body
        | _ -> body)
     | Reasoning_effort ->
-      (match config.enable_thinking with
-       | Some _ ->
-         let effort =
-           Provider_config.effort_of_thinking_config
-             ~enable_thinking:config.enable_thinking
-             ~thinking_budget:config.thinking_budget
-         in
-         ("reasoning_effort", `String effort) :: body
-       | None -> ("reasoning_effort", `String "none") :: body)
+      (match
+         Provider_config.reasoning_effort_request_value
+           ~enable_thinking:config.enable_thinking
+           ~thinking_budget:config.thinking_budget
+       with
+       | Some effort -> ("reasoning_effort", `String effort) :: body
+       | None -> body)
     | Thinking_object ->
       (match config.enable_thinking with
        | Some true ->

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -21,10 +21,10 @@ type thinking_control_format =
       sending a top-level thinking field. *)
   | Reasoning_effort
   (** Openai-style top-level [reasoning_effort] string field. The set of
-      values this codebase emits is [{"none","low","medium","high"}] —
-      see {!Provider_config.effort_of_thinking_config}. (Openai's spec
-      also accepts ["minimal"], but no current OAS request builder emits
-      it.) Ollama's OpenAI-compatible mode uses this shape. *)
+      non-disabled values this codebase emits is [{"low","medium","high"}] —
+      see {!Provider_config.reasoning_effort_request_value}. Disabled
+      reasoning is represented by omitting the field, because DeepSeek v4
+      rejects ["none"]. Ollama's OpenAI-compatible mode uses this shape. *)
   | Enable_thinking
   (** DashScope-style top-level [enable_thinking] / [preserve_thinking] bools
       plus optional [thinking_budget]. *)

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -232,6 +232,18 @@ let effort_of_thinking_config
      | None -> default_reasoning_effort ())
 ;;
 
+let reasoning_effort_request_value
+      ~(enable_thinking : bool option)
+      ~(thinking_budget : int option)
+  : string option
+  =
+  match enable_thinking with
+  | Some true ->
+    let effort = effort_of_thinking_config ~enable_thinking ~thinking_budget in
+    if String.equal effort "none" then None else Some effort
+  | Some false | None -> None
+;;
+
 (** Compute reasoning_effort for a provider config.
     Returns [None] for non-Ollama providers.
     @since 0.114.0 *)

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -252,6 +252,15 @@ val effort_of_thinking_config
   -> thinking_budget:int option
   -> string
 
+(** Provider request body value for OpenAI-compatible [reasoning_effort].
+    Returns [None] when thinking is disabled, unset, or resolved to ["none"],
+    so callers omit the field instead of sending a provider-rejected sentinel.
+    @since 0.206.5 *)
+val reasoning_effort_request_value
+  :  enable_thinking:bool option
+  -> thinking_budget:int option
+  -> string option
+
 (** Compute reasoning_effort for a provider config.
     Returns [None] for non-Ollama providers.
     @since 0.114.0 *)

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -460,6 +460,19 @@ let test_reasoning_effort_of_config () =
     (Provider_config.reasoning_effort_of_config anthropic)
 ;;
 
+let test_reasoning_effort_request_value () =
+  let check_value label expected enable_thinking thinking_budget =
+    Alcotest.(check (option string))
+      label
+      expected
+      (Provider_config.reasoning_effort_request_value ~enable_thinking ~thinking_budget)
+  in
+  check_value "unset omits field" None None (Some 4096);
+  check_value "disabled omits field" None (Some false) (Some 4096);
+  check_value "zero budget omits field" None (Some true) (Some 0);
+  check_value "enabled maps effort" (Some "low") (Some true) (Some 2048)
+;;
+
 let test_structured_output_name_of_schema () =
   let check_name label expected schema =
     check_string label expected (Provider_config.structured_output_name_of_schema schema)
@@ -976,6 +989,10 @@ let () =
             "reasoning effort by config"
             `Quick
             test_reasoning_effort_of_config
+        ; Alcotest.test_case
+            "reasoning effort request value"
+            `Quick
+            test_reasoning_effort_request_value
         ; Alcotest.test_case
             "structured output names"
             `Quick

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -140,7 +140,7 @@ let openai_no_parallel_capability_cfg =
    provider speaks the OpenAI-compat Chat Completions wire
    (openai-http / https://ollama.com/v1), so [OpenAI_compat] is the
    matching kind for the fleet wire. *)
-let deepseek_cfg ~tool_choice =
+let deepseek_cfg ?enable_thinking ?thinking_budget ~tool_choice () =
   Provider_config.make
     ~kind:OpenAI_compat
     ~model_id:"deepseek-v4-flash"
@@ -150,6 +150,8 @@ let deepseek_cfg ~tool_choice =
     ~temperature:0.7
     ~tool_choice
     ~disable_parallel_tool_use:true
+    ?enable_thinking
+    ?thinking_budget
     ()
 ;;
 
@@ -261,22 +263,22 @@ let test_openai_parallel_disabled_by_capability () =
    prefix dispatcher fixed in RFC-OAS-023.
 
    It is a regression FENCE, not a discrimination proof: with
-   [enable_thinking=None] and [max_tokens=1024], none of the capability
-   fields the DeepSeek route changes ([thinking_control_format],
-   [max_output_tokens]) alter the OpenAI chat-completions request body,
-   so the wire is byte-identical before/after the de-anonymization. The
+   [enable_thinking=None] and [max_tokens=1024], no [reasoning_effort]
+   field is emitted (DeepSeek rejects "none"; only high/low/medium/max/xhigh
+   are valid), so the wire is byte-identical before/after the
+   de-anonymization. The
    actual proof that [deepseek-v4-flash] resolves to [Deepseek_v4_flash]
    lives in the inline [let%test "for_model_id_static: specific model IDs
    get correct (not shadowed) capabilities"] in [capabilities.ml] and in
    [test_capabilities.ml]'s cloud-suffix route checks. *)
 let deepseek_required_expected =
-  {|{"parallel_tool_calls":false,"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"tool_choice":"required","reasoning_effort":"none","temperature":0.7,"model":"deepseek-v4-flash","messages":[{"role":"user","content":"What's the weather in Seoul?"},{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Seoul\"}"}}],"role":"assistant","content":""},{"role":"tool","tool_call_id":"call_1","content":"Sunny, 25C"}],"max_tokens":1024}|}
+  {|{"parallel_tool_calls":false,"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"tool_choice":"required","temperature":0.7,"model":"deepseek-v4-flash","messages":[{"role":"user","content":"What's the weather in Seoul?"},{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Seoul\"}"}}],"role":"assistant","content":""},{"role":"tool","tool_call_id":"call_1","content":"Sunny, 25C"}],"max_tokens":1024}|}
 ;;
 
 let test_deepseek_required () =
   let body =
     Backend_openai_request.build_request
-      ~config:(deepseek_cfg ~tool_choice:Any)
+      ~config:(deepseek_cfg ~tool_choice:Any ())
       ~messages
       ~tools:[ tool_decl ]
       ()
@@ -295,6 +297,22 @@ let test_deepseek_required () =
     "model id is the real fleet id"
     true
     (contains ~needle:{|"model":"deepseek-v4-flash"|} body)
+;;
+
+let test_deepseek_disabled_reasoning_omits_reasoning_effort () =
+  let body =
+    Backend_openai_request.build_request
+      ~config:
+        (deepseek_cfg ~enable_thinking:false ~thinking_budget:4096 ~tool_choice:Any ())
+      ~messages
+      ~tools:[ tool_decl ]
+      ()
+  in
+  check
+    bool
+    {|DeepSeek disabled reasoning omits rejected reasoning_effort:"none"|}
+    false
+    (contains ~needle:{|"reasoning_effort"|} body)
 ;;
 
 (* ── Anthropic ──────────────────────────────────────── *)
@@ -494,6 +512,10 @@ let () =
             `Quick
             test_openai_parallel_disabled_by_capability
         ; test_case "deepseek-v4-flash required(Any)" `Quick test_deepseek_required
+        ; test_case
+            "deepseek-v4-flash disabled reasoning omits reasoning_effort"
+            `Quick
+            test_deepseek_disabled_reasoning_omits_reasoning_effort
         ] )
     ; ( "anthropic"
       , [ test_case "tool_choice forced(Tool)" `Quick test_anthropic_forced


### PR DESCRIPTION
## Summary
- omit `reasoning_effort` for OpenAI-compatible reasoning-effort providers when thinking is disabled, unset, or resolves to `none`
- keep enabled reasoning mapped to concrete effort values (`low`, `medium`, `high`)
- add DeepSeek v4 snapshot coverage for the `enable_thinking=false` path that triggered the live 400

## Root Cause
DeepSeek v4 rejects `reasoning_effort: "none"` with HTTP 400. MASC librarian calls intentionally use `enable_thinking=false`; OAS serialized that disabled state into the rejected sentinel instead of omitting the field.

The earlier branch only handled `enable_thinking=None`; this update also handles `Some false` and `Some true` with a zero/none-equivalent budget.

## Verification
- `scripts/dune-local.sh build test/test_provider_config.exe test/test_snapshot_provider_serialization.exe`
- `_build/default/test/test_provider_config.exe`
- `_build/default/test/test_snapshot_provider_serialization.exe`
- `scripts/dune-local.sh build test/test_api.exe`
- `_build/default/test/test_api.exe`
- `ocamlformat --check lib/llm_provider/provider_config.mli lib/llm_provider/provider_config.ml lib/llm_provider/backend_openai_request.ml lib/api_openai.ml lib/llm_provider/capabilities.mli test/test_provider_config.ml test/test_snapshot_provider_serialization.ml`
- `git diff --check`