### PR TITLE
fix(agent): export tool alias registry

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -93,6 +93,7 @@ module Agent_lifecycle = Agent_lifecycle
 module Agent_turn = Agent_turn
 module Agent_handoff = Agent_handoff
 module Agent_tools = Agent_tools
+module Agent_tool_name_alias = Agent_tool_name_alias
 module Agent_checkpoint = Agent_checkpoint
 module Agent_turn_budget = Agent_turn_budget
 module Agent = Agent

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -66,6 +66,7 @@ module Agent_lifecycle = Agent_lifecycle
 module Agent_turn = Agent_turn
 module Agent_handoff = Agent_handoff
 module Agent_tools = Agent_tools
+module Agent_tool_name_alias = Agent_tool_name_alias
 module Agent_checkpoint = Agent_checkpoint
 module Agent_turn_budget = Agent_turn_budget
 module Agent = Agent

--- a/test/test_agent_sdk.ml
+++ b/test/test_agent_sdk.ml
@@ -37,6 +37,28 @@ let test_simple_tool () =
   | Error _ -> Alcotest.fail "Tool execution failed"
 ;;
 
+let test_consumer_tool_name_alias_registry () =
+  Agent_sdk.Agent_tool_name_alias.register_alias
+    ~alias:"consumer_web_search_for_test"
+    ~canonical:"WebSearch";
+  Alcotest.(check (option string))
+    "registered alias"
+    (Some "WebSearch")
+    (Agent_sdk.Agent_tool_name_alias.resolve_alias "consumer_web_search_for_test");
+  match
+    Agent_sdk.Agent_tool_name_alias.resolve
+      ~requested:"consumer_web_search_for_test"
+      ~input:(`Assoc [ "query", `String "ocaml" ])
+  with
+  | Some ("WebSearch", `Assoc [ ("query", `String "ocaml") ]) -> ()
+  | Some (name, input) ->
+    Alcotest.failf
+      "unexpected alias resolution: %s %s"
+      name
+      (Yojson.Safe.to_string input)
+  | None -> Alcotest.fail "registered alias did not resolve"
+;;
+
 let test_extract_text () =
   let content =
     [ Text "Hello"; ToolUse { id = "1"; name = "t"; input = `Null }; Text " World" ]
@@ -209,7 +231,13 @@ let () =
         ; test_case "role_string" `Quick test_role_string
         ; test_case "stop_reason" `Quick test_stop_reason
         ] )
-    ; "tool", [ test_case "simple_tool" `Quick test_simple_tool ]
+    ; ( "tool"
+      , [ test_case "simple_tool" `Quick test_simple_tool
+        ; test_case
+            "consumer tool name alias registry"
+            `Quick
+            test_consumer_tool_name_alias_registry
+        ] )
     ; "api", [ test_case "extract_text" `Quick test_extract_text ]
     ; ( "agent"
       , [ test_case "create" `Quick test_agent_create


### PR DESCRIPTION
## Summary
- re-export Agent_tool_name_alias through the public Agent_sdk root
- add a consumer-facing registry resolution test

## Tests
- scripts/dune-local.sh build test/test_agent_sdk.exe
- scripts/dune-local.sh exec test/test_agent_sdk.exe