### PR TITLE
fix(agent): harden tool and reasoning loop handling

### DIFF
--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -18,12 +18,17 @@ type tool_call_fingerprint =
   ; fp_input : string
   }
 
-let compute_fingerprints tool_uses =
+type tool_call_normalizer = name:string -> input:Yojson.Safe.t -> string * Yojson.Safe.t
+
+let identity_tool_call_normalizer ~name ~input = name, input
+
+let compute_fingerprints ?(normalize_tool_call = identity_tool_call_normalizer) tool_uses =
   List.filter_map
     (fun (block : content_block) ->
        match block with
        | ToolUse { name; input; _ } ->
-         Some { fp_name = name; fp_input = Yojson.Safe.to_string input }
+         let fp_name, fp_input = normalize_tool_call ~name ~input in
+         Some { fp_name; fp_input = Yojson.Safe.to_string fp_input }
        | Text _
        | Thinking _
        | RedactedThinking _
@@ -491,14 +496,21 @@ type idle_result =
   ; is_idle : bool
   }
 
-let update_idle_detection ~idle_state ~tool_uses =
-  let current_fps = compute_fingerprints tool_uses in
+let update_idle_detection_with_normalizer ~normalize_tool_call ~idle_state ~tool_uses =
+  let current_fps = compute_fingerprints ~normalize_tool_call tool_uses in
   let idle = is_idle idle_state.last_tool_calls current_fps in
   let new_consecutive = if idle then idle_state.consecutive_idle_turns + 1 else 0 in
   { new_state =
       { last_tool_calls = Some current_fps; consecutive_idle_turns = new_consecutive }
   ; is_idle = idle
   }
+;;
+
+let update_idle_detection ~idle_state ~tool_uses =
+  update_idle_detection_with_normalizer
+    ~normalize_tool_call:identity_tool_call_normalizer
+    ~idle_state
+    ~tool_uses
 ;;
 
 (** Default per-tool-result character cap.

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -18,6 +18,15 @@ type tool_call_fingerprint =
   ; fp_input : string
   }
 
+(** Optional normalizer applied before fingerprinting a tool call.
+
+    Use this when the execution path accepts public aliases or normalizes
+    arguments before dispatch, so idle detection compares the same semantic
+    call the executor will run rather than only the raw model spelling.
+
+    Returning the original [(name, input)] preserves legacy exact behavior. *)
+type tool_call_normalizer = name:string -> input:Yojson.Safe.t -> string * Yojson.Safe.t
+
 (** Granularity at which two fingerprints are considered the "same"
     for idle detection.
 
@@ -38,7 +47,10 @@ type idle_granularity =
   | Name_and_subset of string list
 
 (** Compute fingerprints from content blocks containing [ToolUse]. *)
-val compute_fingerprints : Types.content_block list -> tool_call_fingerprint list
+val compute_fingerprints
+  :  ?normalize_tool_call:tool_call_normalizer
+  -> Types.content_block list
+  -> tool_call_fingerprint list
 
 (** Return [true] when [current] fingerprints match [prev] at the
     given granularity. Default [?granularity] is [Exact] — preserves
@@ -214,6 +226,14 @@ type idle_result =
 (** Update idle detection state after a tool-use turn. *)
 val update_idle_detection
   :  idle_state:idle_state
+  -> tool_uses:Types.content_block list
+  -> idle_result
+
+(** Update idle detection state after a tool-use turn, normalizing each
+    [ToolUse] before fingerprinting. *)
+val update_idle_detection_with_normalizer
+  :  normalize_tool_call:tool_call_normalizer
+  -> idle_state:idle_state
   -> tool_uses:Types.content_block list
   -> idle_result
 

--- a/lib/context_reducer_apply.ml
+++ b/lib/context_reducer_apply.ml
@@ -113,6 +113,11 @@ let tool_result_ids (msg : message) =
 ;;
 
 let has_tool_result msg = tool_result_ids msg <> []
+let has_tool_use msg = tool_use_ids msg <> []
+
+let preserve_thinking_for_tool_use_message (msg : message) =
+  msg.role = Assistant && has_tool_use msg
+;;
 
 type dangling_repair_report = { synthesized_tool_results : int }
 
@@ -273,7 +278,7 @@ let apply_drop_thinking messages =
   let total = List.length messages in
   List.filter_map
     (fun (i, (msg : message)) ->
-       if i >= total - 2
+       if i >= total - 2 || preserve_thinking_for_tool_use_message msg
        then Some msg
        else (
          let content =

--- a/lib/llm_provider/backend_openai_request.mli
+++ b/lib/llm_provider/backend_openai_request.mli
@@ -11,6 +11,7 @@ val warn_capability_drop : model_id:string -> field:string -> unit
 val effective_tool_choice : Provider_config.t -> Yojson.Safe.t option
 val effective_tools : Provider_config.t -> Yojson.Safe.t list -> Yojson.Safe.t list
 val structured_schema_of_config : Provider_config.t -> Yojson.Safe.t option
+val capabilities_of_config : Provider_config.t -> Capabilities.capabilities
 val openai_json_schema_payload : Yojson.Safe.t -> Yojson.Safe.t
 val response_format_to_provider_d_json : Types.response_format -> Yojson.Safe.t option
 val response_format_of_config : Provider_config.t -> Yojson.Safe.t option

--- a/lib/llm_provider/backend_openai_responses.ml
+++ b/lib/llm_provider/backend_openai_responses.ml
@@ -1,0 +1,571 @@
+(** OpenAI Responses API codec.
+
+    Responses is item-based: assistant messages, reasoning summaries, function
+    calls, and function-call outputs are all ordered items. Keep this separate
+    from the Chat Completions codec so [choices[].message] assumptions cannot
+    leak into Responses request/response handling. *)
+
+open Types
+
+let json_assoc_opt key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
+;;
+
+let opt_bind opt f =
+  match opt with
+  | Some value -> f value
+  | None -> None
+;;
+
+let json_string_opt = function
+  | `String s -> Some s
+  | `Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
+;;
+
+let json_int_opt = function
+  | `Int n -> Some n
+  | `Intlit s -> int_of_string_opt s
+  | `Float _ | `String _ | `Assoc _ | `List _ | `Bool _ | `Null -> None
+;;
+
+let non_blank_json_string json =
+  match json_string_opt json with
+  | Some s when not (Api_common.string_is_blank s) -> Some s
+  | Some _ | None -> None
+;;
+
+let assoc_remove keys fields =
+  List.filter (fun (key, _) -> not (List.mem key keys)) fields
+;;
+
+let responses_raw_reasoning_item_of_redacted data =
+  try
+    match Yojson.Safe.from_string data with
+    | `Assoc fields as json ->
+      (match List.assoc_opt "type" fields with
+       | Some (`String "reasoning") -> Some json
+       | Some (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
+       | Some (`String _)
+       | None -> None)
+    | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
+  with
+  | Yojson.Json_error _ -> None
+;;
+
+let message_has_responses_raw_reasoning (msg : message) =
+  List.exists
+    (function
+      | RedactedThinking data ->
+        Option.is_some (responses_raw_reasoning_item_of_redacted data)
+      | Text _ | Thinking _ | ToolUse _ | ToolResult _ | Image _ | Document _ | Audio _ ->
+        false)
+    msg.content
+;;
+
+let responses_tool_json tool =
+  match Backend_openai_serialize.build_provider_d_tool_json tool with
+  | `Assoc fields ->
+    (match List.assoc_opt "function" fields with
+     | Some (`Assoc fn_fields) ->
+       let passthrough =
+         assoc_remove [ "name"; "description"; "parameters"; "strict" ] fn_fields
+       in
+       let name =
+         match List.assoc_opt "name" fn_fields with
+         | Some (`String s) -> s
+         | Some (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
+         | None -> "tool"
+       in
+       let description =
+         match List.assoc_opt "description" fn_fields with
+         | Some (`String s) -> s
+         | Some (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
+         | None -> ""
+       in
+       let parameters =
+         match List.assoc_opt "parameters" fn_fields with
+         | Some schema -> schema
+         | None -> `Assoc []
+       in
+       let strict_field =
+         match List.assoc_opt "strict" fn_fields with
+         | Some (`Bool b) -> [ "strict", `Bool b ]
+         | Some (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Null)
+         | None -> []
+       in
+       `Assoc
+         ([ "type", `String "function"
+          ; "name", `String name
+          ; "description", `String description
+          ; "parameters", parameters
+          ]
+          @ strict_field
+          @ passthrough)
+     | Some (`List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) | None
+       -> `Assoc fields)
+  | other -> other
+;;
+
+let content_string_of_tool_result ~content ~content_blocks =
+  match content_blocks with
+  | Some blocks ->
+    Yojson.Safe.to_string (`List (List.map Api_common.content_block_to_json blocks))
+  | None -> Utf8_sanitize.sanitize content
+;;
+
+let input_content_part_of_block = function
+  | Text s ->
+    Some
+      (`Assoc [ "type", `String "input_text"; "text", `String (Utf8_sanitize.sanitize s) ])
+  | Image { media_type; data; source_type = _ } ->
+    Some
+      (`Assoc
+          [ "type", `String "input_image"
+          ; "image_url", `String (Printf.sprintf "data:%s;base64,%s" media_type data)
+          ])
+  | Document { media_type; data; source_type = _ } ->
+    Some
+      (`Assoc
+          [ "type", `String "input_file"
+          ; "file_data", `String (Printf.sprintf "data:%s;base64,%s" media_type data)
+          ])
+  | Audio { media_type; data; source_type = _ } ->
+    Some
+      (`Assoc
+          [ "type", `String "input_audio"
+          ; "input_audio", `Assoc [ "data", `String data; "format", `String media_type ]
+          ])
+  | Thinking _ | RedactedThinking _ | ToolUse _ | ToolResult _ -> None
+;;
+
+let output_text_content_part text =
+  `Assoc [ "type", `String "output_text"; "text", `String (Utf8_sanitize.sanitize text) ]
+;;
+
+let message_item ~role content_blocks =
+  match List.filter_map input_content_part_of_block content_blocks with
+  | [] ->
+    let text = Api_common.text_blocks_to_string content_blocks in
+    if Api_common.string_is_blank text
+    then []
+    else
+      [ `Assoc [ "role", `String role; "content", `String (Utf8_sanitize.sanitize text) ]
+      ]
+  | parts -> [ `Assoc [ "role", `String role; "content", `List parts ] ]
+;;
+
+let assistant_output_item_of_block = function
+  | Thinking { content; _ } when not (Api_common.string_is_blank content) ->
+    Some
+      (`Assoc
+          [ "type", `String "reasoning"
+          ; ( "summary"
+            , `List [ `Assoc [ "type", `String "summary_text"; "text", `String content ] ]
+            )
+          ])
+  | Text s when not (Api_common.string_is_blank s) ->
+    Some
+      (`Assoc
+          [ "type", `String "message"
+          ; "role", `String "assistant"
+          ; "content", `List [ output_text_content_part s ]
+          ])
+  | RedactedThinking data -> responses_raw_reasoning_item_of_redacted data
+  | ToolUse { id; name; input } ->
+    Some
+      (`Assoc
+          [ "type", `String "function_call"
+          ; "call_id", `String id
+          ; "name", `String name
+          ; "arguments", `String (Yojson.Safe.to_string input)
+          ])
+  | Thinking _ | Text _ | ToolResult _ | Image _ | Document _ | Audio _ -> None
+;;
+
+let function_call_output_item ~tool_use_id ~content ~content_blocks =
+  `Assoc
+    [ "type", `String "function_call_output"
+    ; "call_id", `String tool_use_id
+    ; "output", `String (content_string_of_tool_result ~content ~content_blocks)
+    ]
+;;
+
+let tool_result_items blocks =
+  blocks
+  |> List.filter_map (function
+    | ToolResult { tool_use_id; content; content_blocks; _ } ->
+      Some (function_call_output_item ~tool_use_id ~content ~content_blocks)
+    | Text _
+    | Thinking _
+    | RedactedThinking _
+    | ToolUse _
+    | Image _
+    | Document _
+    | Audio _ -> None)
+;;
+
+let input_items_of_message (msg : message) =
+  match msg.role with
+  | System -> message_item ~role:"system" msg.content
+  | User ->
+    let tool_results = tool_result_items msg.content in
+    let non_tool_content =
+      List.filter
+        (function
+          | ToolResult _ -> false
+          | Text _
+          | Thinking _
+          | RedactedThinking _
+          | ToolUse _
+          | Image _
+          | Document _
+          | Audio _ -> true)
+        msg.content
+    in
+    tool_results @ message_item ~role:"user" non_tool_content
+  | Assistant -> List.filter_map assistant_output_item_of_block msg.content
+  | Tool -> tool_result_items msg.content
+;;
+
+let tool_choice_to_responses_json = function
+  | Auto -> Some (`String "auto")
+  | Any -> Some (`String "required")
+  | None_ -> Some (`String "none")
+  | Tool name -> Some (`Assoc [ "type", `String "function"; "name", `String name ])
+;;
+
+let responses_json_schema_payload schema =
+  match Backend_openai_request.openai_json_schema_payload schema with
+  | `Assoc fields ->
+    let schema_fields =
+      assoc_remove [ "description" ] fields
+      @
+      match List.assoc_opt "description" fields with
+      | Some (`String _ as description) -> [ "description", description ]
+      | Some (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) | None
+        -> []
+    in
+    `Assoc (("type", `String "json_schema") :: schema_fields)
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null ->
+    `Assoc
+      [ "type", `String "json_schema"
+      ; "name", `String (Provider_config.structured_output_name_of_schema schema)
+      ; "schema", schema
+      ; "strict", `Bool true
+      ]
+;;
+
+let response_text_config_of_config (config : Provider_config.t) =
+  match Backend_openai_request.structured_schema_of_config config with
+  | Some schema -> Some (`Assoc [ "format", responses_json_schema_payload schema ])
+  | None when config.response_format = JsonMode ->
+    Some (`Assoc [ "format", `Assoc [ "type", `String "json_object" ] ])
+  | None -> None
+;;
+
+let capabilities_of_config = Backend_openai_request.capabilities_of_config
+
+let effective_max_output_tokens (config : Provider_config.t) =
+  let caps = capabilities_of_config config in
+  match config.max_tokens, caps.max_output_tokens with
+  | None, Some cap -> cap
+  | None, None -> Constants.unknown_model_max_tokens_fallback
+  | Some n, Some cap when n > cap -> cap
+  | Some n, _ -> n
+;;
+
+let build_request
+      ?(stream = false)
+      ~(config : Provider_config.t)
+      ~(messages : message list)
+      ?(tools : Yojson.Safe.t list = [])
+      ()
+  =
+  let tools = Backend_openai_request.effective_tools config tools in
+  let sanitized_messages =
+    Backend_openai_serialize.close_tool_message_pairs_for_request messages
+  in
+  let reasoning_effort =
+    Provider_config.reasoning_effort_request_value
+      ~enable_thinking:config.enable_thinking
+      ~thinking_budget:config.thinking_budget
+  in
+  let body =
+    [ "model", `String config.model_id
+    ; "input", `List (List.concat_map input_items_of_message sanitized_messages)
+    ; "max_output_tokens", `Int (effective_max_output_tokens config)
+    ]
+  in
+  let body =
+    match config.system_prompt with
+    | Some s when not (Api_common.string_is_blank s) ->
+      ("instructions", `String (Utf8_sanitize.sanitize s)) :: body
+    | Some _ | None -> body
+  in
+  let body =
+    match config.temperature with
+    | Some t -> ("temperature", `Float t) :: body
+    | None -> body
+  in
+  let body =
+    match config.top_p with
+    | Some p -> ("top_p", `Float p) :: body
+    | None -> body
+  in
+  let body =
+    match response_text_config_of_config config with
+    | Some text -> ("text", text) :: body
+    | None -> body
+  in
+  let body =
+    match reasoning_effort with
+    | Some effort -> ("reasoning", `Assoc [ "effort", `String effort ]) :: body
+    | None -> body
+  in
+  let body =
+    if
+      Option.is_some reasoning_effort
+      || List.exists message_has_responses_raw_reasoning sanitized_messages
+    then ("include", `List [ `String "reasoning.encrypted_content" ]) :: body
+    else body
+  in
+  let body =
+    match config.tool_choice, Backend_openai_request.effective_tool_choice config with
+    | Some choice, Some _ ->
+      (match tool_choice_to_responses_json choice with
+       | Some choice -> ("tool_choice", choice) :: body
+       | None -> body)
+    | Some _, None | None, _ -> body
+  in
+  let body =
+    match tools with
+    | [] -> body
+    | ts -> ("tools", `List (List.map responses_tool_json ts)) :: body
+  in
+  let body =
+    let tools_present = tools <> [] in
+    let caps = capabilities_of_config config in
+    let disable_parallel =
+      Capabilities.effective_disable_parallel_tool_use
+        ~caller_disabled:config.disable_parallel_tool_use
+        ~supports_parallel_tool_calls:caps.supports_parallel_tool_calls
+        ~tools_present
+    in
+    Backend_openai_serialize.parallel_tool_calls_fields ~disable_parallel ~tools_present
+    @ body
+  in
+  let body = if stream then ("stream", `Bool true) :: body else body in
+  Yojson.Safe.to_string (`Assoc body)
+;;
+
+let output_text_of_content = function
+  | `Assoc fields ->
+    (match List.assoc_opt "type" fields, List.assoc_opt "text" fields with
+     | Some (`String ("output_text" | "text")), Some (`String text) -> Some text
+     | _, _ -> None)
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
+;;
+
+let content_blocks_of_output_message item =
+  match json_assoc_opt "content" item with
+  | Some (`List content) ->
+    content |> List.filter_map output_text_of_content |> List.map (fun text -> Text text)
+  | Some (`String text) when not (Api_common.string_is_blank text) -> [ Text text ]
+  | Some (`String _)
+  | Some (`Assoc _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
+  | None -> []
+;;
+
+let reasoning_text_of_summary_item = function
+  | `Assoc fields ->
+    (match List.assoc_opt "type" fields, List.assoc_opt "text" fields with
+     | Some (`String ("summary_text" | "text")), Some (`String text) -> Some text
+     | _, _ -> None)
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
+;;
+
+let content_blocks_of_reasoning_item item =
+  match opt_bind (json_assoc_opt "encrypted_content" item) non_blank_json_string with
+  | Some _ -> [ RedactedThinking (Yojson.Safe.to_string item) ]
+  | None ->
+    (match json_assoc_opt "summary" item with
+     | Some (`List summary) ->
+       let content =
+         summary |> List.filter_map reasoning_text_of_summary_item |> String.concat "\n"
+       in
+       if Api_common.string_is_blank content
+       then []
+       else [ Thinking { thinking_type = "reasoning_summary"; content } ]
+     | Some (`String text) when not (Api_common.string_is_blank text) ->
+       [ Thinking { thinking_type = "reasoning_summary"; content = text } ]
+     | Some (`String _)
+     | Some (`Assoc _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
+     | None -> [])
+;;
+
+let content_block_of_function_call item =
+  let call_id =
+    match opt_bind (json_assoc_opt "call_id" item) json_string_opt with
+    | Some s -> s
+    | None ->
+      (match opt_bind (json_assoc_opt "id" item) json_string_opt with
+       | Some s -> s
+       | None -> "")
+  in
+  let name =
+    opt_bind (json_assoc_opt "name" item) json_string_opt |> Option.value ~default:""
+  in
+  let arguments =
+    opt_bind (json_assoc_opt "arguments" item) json_string_opt
+    |> Option.value ~default:"{}"
+  in
+  if Api_common.string_is_blank call_id || Api_common.string_is_blank name
+  then None
+  else
+    Some
+      (ToolUse { id = call_id; name; input = Api_common.json_of_string_or_raw arguments })
+;;
+
+let content_blocks_of_output_item item =
+  match opt_bind (json_assoc_opt "type" item) json_string_opt with
+  | Some "message" -> content_blocks_of_output_message item
+  | Some "reasoning" -> content_blocks_of_reasoning_item item
+  | Some "function_call" ->
+    (match content_block_of_function_call item with
+     | Some block -> [ block ]
+     | None -> [])
+  | Some _ | None -> []
+;;
+
+let usage_of_response_json json =
+  match json_assoc_opt "usage" json with
+  | Some (`Assoc fields) ->
+    let member_int key = opt_bind (List.assoc_opt key fields) json_int_opt in
+    let input_tokens = member_int "input_tokens" |> Option.value ~default:0 in
+    let output_tokens = member_int "output_tokens" |> Option.value ~default:0 in
+    let cached_tokens =
+      match List.assoc_opt "input_tokens_details" fields with
+      | Some (`Assoc detail_fields) ->
+        opt_bind (List.assoc_opt "cached_tokens" detail_fields) json_int_opt
+        |> Option.value ~default:0
+      | Some (`List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
+      | None -> 0
+    in
+    Some
+      { input_tokens
+      ; output_tokens
+      ; cache_creation_input_tokens = 0
+      ; cache_read_input_tokens = cached_tokens
+      ; cost_usd = None
+      }
+  | Some (`List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) | None ->
+    None
+;;
+
+let telemetry_of_response_json json =
+  match json_assoc_opt "usage" json with
+  | Some (`Assoc fields) ->
+    let reasoning_tokens =
+      match List.assoc_opt "output_tokens_details" fields with
+      | Some (`Assoc detail_fields) ->
+        opt_bind (List.assoc_opt "reasoning_tokens" detail_fields) json_int_opt
+      | Some (`List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
+      | None -> None
+    in
+    Some
+      { system_fingerprint = None
+      ; timings = None
+      ; reasoning_tokens
+      ; reasoning_tokens_estimated = false
+      ; request_latency_ms = None
+      ; peak_memory_gb = None
+      ; provider_kind = None
+      ; reasoning_effort = None
+      ; canonical_model_id = None
+      ; effective_context_window = None
+      ; provider_internal_action_count = None
+      ; ttfrc_ms = None
+      ; prefill_ms = None
+      }
+  | Some (`List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) | None ->
+    None
+;;
+
+let stop_reason_of_response_json ~has_tool_calls json =
+  let status =
+    opt_bind (json_assoc_opt "status" json) json_string_opt |> Option.value ~default:""
+  in
+  if has_tool_calls
+  then StopToolUse
+  else (
+    match String.lowercase_ascii status with
+    | "completed" | "" -> EndTurn
+    | "incomplete" ->
+      let reason =
+        match json_assoc_opt "incomplete_details" json with
+        | Some details ->
+          opt_bind (json_assoc_opt "reason" details) json_string_opt
+          |> Option.value ~default:"incomplete"
+        | None -> "incomplete"
+      in
+      if String.equal reason "max_output_tokens" then MaxTokens else Unknown reason
+    | "failed" ->
+      (match
+         match json_assoc_opt "error" json with
+         | Some error -> json_assoc_opt "message" error
+         | None -> None
+       with
+       | Some (`String message) -> Unknown message
+       | Some (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
+       | None -> Unknown status)
+    | other -> Unknown other)
+;;
+
+let parse_response_result json_str =
+  try
+    let json = Yojson.Safe.from_string json_str in
+    match json_assoc_opt "error" json with
+    | Some (`Assoc fields) ->
+      let message =
+        opt_bind (List.assoc_opt "message" fields) json_string_opt
+        |> Option.value ~default:"Unknown API error"
+      in
+      Error message
+    | Some (`String message) -> Error message
+    | Some (`List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) | None ->
+      let output =
+        match json_assoc_opt "output" json with
+        | Some (`List items) -> items
+        | Some (`Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
+        | None -> []
+      in
+      let content = List.concat_map content_blocks_of_output_item output in
+      let has_tool_calls =
+        List.exists
+          (function
+            | ToolUse _ -> true
+            | Text _
+            | Thinking _
+            | RedactedThinking _
+            | ToolResult _
+            | Image _
+            | Document _
+            | Audio _ -> false)
+          content
+      in
+      Ok
+        { id =
+            opt_bind (json_assoc_opt "id" json) json_string_opt
+            |> Option.value ~default:""
+        ; model =
+            opt_bind (json_assoc_opt "model" json) json_string_opt
+            |> Option.value ~default:""
+        ; stop_reason = stop_reason_of_response_json ~has_tool_calls json
+        ; content
+        ; usage = usage_of_response_json json
+        ; telemetry = telemetry_of_response_json json
+        }
+  with
+  | Yojson.Json_error msg -> Error ("JSON parse error: " ^ msg)
+;;

--- a/lib/llm_provider/backend_openai_responses.mli
+++ b/lib/llm_provider/backend_openai_responses.mli
@@ -1,0 +1,23 @@
+(** OpenAI Responses API request/response codec.
+
+    This module is intentionally separate from {!Backend_openai_parse} and
+    {!Backend_openai_request}: Responses uses ordered [output] / [input] items,
+    while Chat Completions uses [choices[].message]. Mixing the two wire
+    contracts is what breaks reasoning/tool round trips. *)
+
+val responses_tool_json : Yojson.Safe.t -> Yojson.Safe.t
+
+val build_request
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> string
+
+(** Parse a Responses API JSON response into OAS canonical content blocks.
+
+    Reasoning summary items become {!Types.Thinking}; function call items become
+    {!Types.ToolUse} with [ToolUse.id = call_id], so existing tool execution can
+    correlate outputs via [function_call_output.call_id]. *)
+val parse_response_result : string -> (Types.api_response, string) result

--- a/lib/llm_provider/cache.ml
+++ b/lib/llm_provider/cache.ml
@@ -10,7 +10,7 @@ type t =
 let message_fingerprint (m : Types.message) : Yojson.Safe.t =
   `Assoc
     [ "role", `String (Types.role_to_string m.role)
-    ; "content", `String (Types.text_of_message m)
+    ; "content", `List (List.map Api_common.content_block_to_json m.content)
     ]
 ;;
 
@@ -44,7 +44,8 @@ let content_block_to_json = function
   | Types.Text s -> `Assoc [ "type", `String "text"; "text", `String s ]
   | Types.Thinking { content; _ } ->
     `Assoc [ "type", `String "thinking"; "text", `String content ]
-  | Types.RedactedThinking _ -> `Assoc [ "type", `String "redacted_thinking" ]
+  | Types.RedactedThinking data ->
+    `Assoc [ "type", `String "redacted_thinking"; "data", `String data ]
   | Types.ToolUse { id; name; input } ->
     `Assoc
       [ "type", `String "tool_use"
@@ -71,6 +72,11 @@ let content_block_of_json json =
     Some
       (Types.Thinking
          { thinking_type = "thinking"; content = json |> member "text" |> to_string })
+  | "redacted_thinking" ->
+    (match json |> member "data" |> to_string_option with
+     | Some data when not (Api_common.string_is_blank data) ->
+       Some (Types.RedactedThinking data)
+     | Some _ | None -> None)
   | "tool_use" ->
     Some
       (Types.ToolUse

--- a/lib/llm_provider/complete_common.ml
+++ b/lib/llm_provider/complete_common.ml
@@ -242,10 +242,19 @@ let validate_cli_sampling_params (config : Provider_config.t) =
   | Error reason -> Error (Http_client.AcceptRejected { reason })
 ;;
 
+let validate_request_path (config : Provider_config.t) =
+  match Provider_config.validate_request_path config with
+  | Ok () -> Ok ()
+  | Error reason -> Error (Http_client.AcceptRejected { reason })
+;;
+
 let validate_all (config : Provider_config.t) =
-  match validate_output_schema_request config with
+  match validate_request_path config with
   | Error _ as e -> e
-  | Ok () -> validate_cli_sampling_params config
+  | Ok () ->
+    (match validate_output_schema_request config with
+     | Error _ as e -> e
+     | Ok () -> validate_cli_sampling_params config)
 ;;
 
 (** Strip query string and userinfo from a URL before logging.  Built-in

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -279,6 +279,9 @@ let complete_stream_http
            })
     else (
       let config = apply_sampling_defaults config in
+      let uses_responses_api =
+        Provider_config.request_path_targets_responses_api config.request_path
+      in
       let body_str =
         match config.kind with
         | Provider_config.Anthropic ->
@@ -291,6 +294,8 @@ let complete_stream_http
            for every streaming caller. NDJSON parser is now in
            Streaming.parse_ollama_ndjson_chunk. *)
           Backend_ollama.build_request ~stream:true ~config ~messages ~tools ()
+        | Provider_config.OpenAI_compat when uses_responses_api ->
+          Backend_openai_responses.build_request ~stream:true ~config ~messages ~tools ()
         | Provider_config.OpenAI_compat | Provider_config.DashScope | Provider_config.Kimi
           -> Backend_openai.build_request ~stream:true ~config ~messages ~tools ()
         | Provider_config.Gemini ->
@@ -308,6 +313,7 @@ let complete_stream_http
         match config.kind with
         | Provider_config.Gemini -> body_str
         | Anthropic | Ollama -> Http_client.inject_stream_param body_str
+        | OpenAI_compat when uses_responses_api -> body_str
         | OpenAI_compat | Kimi | Glm | DashScope ->
           (* OpenAI-compatible streaming returns token usage only when the
              request also sets stream_options.include_usage. Anthropic and
@@ -612,6 +618,11 @@ let complete_stream_http
                              (match Streaming.parse_sse_event event_type data with
                               | Some evt -> [ evt ], None
                               | None -> [], None)
+                           | Provider_config.OpenAI_compat when uses_responses_api ->
+                             Streaming.responses_sse_to_events
+                               (get_state ())
+                               event_type
+                               data
                            | Provider_config.OpenAI_compat
                            | Provider_config.DashScope
                            | Provider_config.Kimi ->

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -79,17 +79,17 @@ let accumulate_event (acc : stream_acc) = function
      | None -> ());
     (match usage with
      | Some u ->
-       (* Additive so prompt-token totals are not lost when they arrive in a
+       (* Additive so token totals are not lost when they arrive in a
           MessageDelta rather than MessageStart. Anthropic carries input_tokens
-          in MessageStart and reports input_tokens = 0 in its message_delta, so
-          [+= 0] preserves that value. OpenAI-compatible streaming has no
-          MessageStart usage and delivers input_tokens only in the final
-          stream_options.include_usage chunk's MessageDelta, so this is the only
-          place those tokens are captured. Cache fields stay sourced from
-          MessageStart (Anthropic) and are left untouched here to avoid
-          double-counting against that prelude. *)
+          in MessageStart and reports input_tokens/cache fields as 0 in its
+          message_delta, so [+= 0] preserves that value. OpenAI-compatible
+          streaming and Responses streaming deliver final usage only in a
+          terminal MessageDelta, so this is the only place those tokens and
+          cached-token fields are captured. *)
        acc.input_tokens := !(acc.input_tokens) + u.input_tokens;
-       acc.output_tokens := !(acc.output_tokens) + u.output_tokens
+       acc.output_tokens := !(acc.output_tokens) + u.output_tokens;
+       acc.cache_creation := !(acc.cache_creation) + u.cache_creation_input_tokens;
+       acc.cache_read := !(acc.cache_read) + u.cache_read_input_tokens
      | None -> ())
   | Types.SSEError { message; error_type; raw } ->
     acc.sse_error := Some (Types.Stream_provider_error { message; error_type; raw })

--- a/lib/llm_provider/complete_sync.ml
+++ b/lib/llm_provider/complete_sync.ml
@@ -42,12 +42,17 @@ let complete_http
         | None -> ()
       in
       let config = apply_sampling_defaults config in
+      let uses_responses_api =
+        Provider_config.request_path_targets_responses_api config.request_path
+      in
       let body_str =
         match config.kind with
         | Provider_config.Anthropic ->
           Backend_anthropic.build_request ~config ~messages ~tools ()
         | Provider_config.Ollama ->
           Backend_ollama.build_request ~config ~messages ~tools ()
+        | Provider_config.OpenAI_compat when uses_responses_api ->
+          Backend_openai_responses.build_request ~config ~messages ~tools ()
         | Provider_config.OpenAI_compat | Provider_config.DashScope | Provider_config.Kimi
           -> Backend_openai.build_request ~config ~messages ~tools ()
         | Provider_config.Gemini ->
@@ -200,6 +205,12 @@ let complete_http
                   Ok (Backend_anthropic.parse_response (Yojson.Safe.from_string body))
                 | Provider_config.Ollama ->
                   (match Backend_ollama.parse_ollama_response body with
+                   | Ok resp -> Ok resp
+                   | Error msg -> Error (Http_client.HttpError { code = 400; body = msg }))
+                | Provider_config.OpenAI_compat
+                  when Provider_config.request_path_targets_responses_api
+                         config.request_path ->
+                  (match Backend_openai_responses.parse_response_result body with
                    | Ok resp -> Ok resp
                    | Error msg -> Error (Http_client.HttpError { code = 400; body = msg }))
                 | Provider_config.OpenAI_compat

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -324,6 +324,28 @@ let structured_schema_requested (config : t) : bool =
   | None, (Types.JsonMode | Types.Off) -> false
 ;;
 
+let request_path_targets_responses_api request_path =
+  let lower = String.lowercase_ascii (String.trim request_path) in
+  let path =
+    match String.index_opt lower '?' with
+    | Some i -> String.sub lower 0 i
+    | None -> lower
+  in
+  String.equal path "/v1/responses" || String.equal path "/responses"
+;;
+
+let validate_request_path (config : t) =
+  if request_path_targets_responses_api config.request_path
+  then (
+    match config.kind with
+    | OpenAI_compat -> Ok ()
+    | Anthropic | Kimi | Ollama | Gemini | Glm | DashScope ->
+      Error
+        "OpenAI Responses API request_path requires provider kind OpenAI_compat; other \
+         provider kinds use their own wire formats.")
+  else Ok ()
+;;
+
 let validate_output_schema_request (config : t) =
   match structured_schema_requested config with
   | false -> Ok ()

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -291,6 +291,15 @@ val structured_output_name_of_schema : Yojson.Safe.t -> string
     @since 0.163.0 *)
 val validate_output_schema_request : t -> (unit, string) result
 
+(** True when [request_path] targets the OpenAI Responses API item-based wire
+    format rather than Chat Completions. *)
+val request_path_targets_responses_api : string -> bool
+
+(** Validate that [request_path] names a wire format implemented by this
+    provider kind. OpenAI Responses API paths require [OpenAI_compat] and use a
+    Responses-specific sync serializer/parser. *)
+val validate_request_path : t -> (unit, string) result
+
 (** Validate that sampling parameters unsupported by CLI subprocess
     transports ([min_p], [top_k]) are not set.
     Returns [Error] with the unsupported parameter names for CLI providers.

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -553,6 +553,274 @@ let openai_chunk_to_events (state : provider_d_stream_state) (chunk : provider_d
   List.rev !events, !telemetry_event
 ;;
 
+(** {1 OpenAI Responses API SSE Streaming}
+
+    Responses streaming uses item-level event names:
+    - [response.output_text.delta] for assistant text
+    - [response.reasoning_summary_text.delta] / [response.reasoning_text.delta]
+      for reasoning summaries/text
+    - [response.output_item.added] + [response.function_call_arguments.delta]
+      for function calls
+    - [response.completed] / [response.incomplete] / [response.failed] for
+      terminal status and usage.
+
+    Keep this separate from {!parse_openai_sse_chunk}: Responses has no
+    [choices[].delta] envelope. *)
+
+let responses_member_string_opt key json =
+  let open Yojson.Safe.Util in
+  json |> member key |> to_string_option
+;;
+
+let responses_member_int_default key json =
+  let open Yojson.Safe.Util in
+  json |> member key |> to_int_option |> Option.value ~default:0
+;;
+
+let responses_usage_of_response response =
+  let open Yojson.Safe.Util in
+  match response |> member "usage" with
+  | `Assoc _ as usage ->
+    let input_tokens = responses_member_int_default "input_tokens" usage in
+    let output_tokens = responses_member_int_default "output_tokens" usage in
+    let cache_read_input_tokens =
+      match usage |> member "input_tokens_details" with
+      | `Assoc _ as details -> responses_member_int_default "cached_tokens" details
+      | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> 0
+    in
+    Some
+      { input_tokens
+      ; output_tokens
+      ; cache_creation_input_tokens = 0
+      ; cache_read_input_tokens
+      ; cost_usd = None
+      }
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> None
+;;
+
+let responses_output_has_function_call response =
+  let open Yojson.Safe.Util in
+  match response |> member "output" with
+  | `List items ->
+    List.exists
+      (fun item ->
+         match responses_member_string_opt "type" item with
+         | Some ("function_call" | "custom_tool_call") -> true
+         | Some _ | None -> false)
+      items
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ -> false
+;;
+
+let responses_stop_reason_of_response response =
+  let open Yojson.Safe.Util in
+  if responses_output_has_function_call response
+  then StopToolUse
+  else (
+    match responses_member_string_opt "status" response with
+    | Some "completed" | None -> EndTurn
+    | Some "incomplete" ->
+      let reason =
+        match response |> member "incomplete_details" with
+        | `Assoc _ as details ->
+          responses_member_string_opt "reason" details
+          |> Option.value ~default:"incomplete"
+        | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
+          "incomplete"
+      in
+      if String.equal reason "max_output_tokens" then MaxTokens else Unknown reason
+    | Some other -> Unknown other)
+;;
+
+let responses_error_message json =
+  let open Yojson.Safe.Util in
+  match json |> member "error" with
+  | `Assoc _ as err ->
+    responses_member_string_opt "message" err |> Option.value ~default:"Responses error"
+  | `String message -> message
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `List _ ->
+    responses_member_string_opt "message" json |> Option.value ~default:"Responses error"
+;;
+
+let responses_error_type json =
+  let open Yojson.Safe.Util in
+  match json |> member "error" with
+  | `Assoc _ as err ->
+    (match responses_member_string_opt "type" err with
+     | Some _ as t -> t
+     | None -> responses_member_string_opt "code" err)
+  | `String _ | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `List _ ->
+    responses_member_string_opt "code" json
+;;
+
+let responses_ensure_thinking_block state emit =
+  (match state.thinking_state with
+   | Not_thinking -> state.thinking_state <- Thinking_started (Unix.gettimeofday ())
+   | Thinking_started _ | Thinking_done -> ());
+  if not state.thinking_block_started
+  then (
+    state.thinking_block_index <- state.next_block_index;
+    emit
+      (ContentBlockStart
+         { index = state.next_block_index
+         ; content_type = "thinking"
+         ; tool_id = None
+         ; tool_name = None
+         });
+    state.thinking_block_started <- true;
+    state.next_block_index <- state.next_block_index + 1);
+  state.thinking_block_index
+;;
+
+let responses_ensure_text_block state emit =
+  if not state.text_block_started
+  then (
+    state.text_block_index <- state.next_block_index;
+    emit
+      (ContentBlockStart
+         { index = state.next_block_index
+         ; content_type = "text"
+         ; tool_id = None
+         ; tool_name = None
+         });
+    state.text_block_started <- true;
+    state.next_block_index <- state.next_block_index + 1);
+  state.text_block_index
+;;
+
+let responses_tool_id_of_item item =
+  match responses_member_string_opt "call_id" item with
+  | Some id when String.trim id <> "" -> Some id
+  | Some _ | None -> responses_member_string_opt "id" item
+;;
+
+let responses_ensure_tool_block state emit ~output_index ~tool_id ~tool_name =
+  match Hashtbl.find_opt state.tool_block_indices output_index with
+  | Some idx -> idx
+  | None ->
+    let idx = state.next_block_index in
+    Hashtbl.replace state.tool_block_indices output_index idx;
+    emit
+      (ContentBlockStart { index = idx; content_type = "tool_use"; tool_id; tool_name });
+    state.next_block_index <- state.next_block_index + 1;
+    idx
+;;
+
+let responses_sse_to_events (state : provider_d_stream_state) event_type data_str
+  : sse_event list * Telemetry_event.t option
+  =
+  if String.equal data_str "[DONE]"
+  then [], None
+  else (
+    match Yojson.Safe.from_string data_str with
+    | exception Yojson.Json_error msg ->
+      [ SSEParseFailed { raw = data_str; reason = "json_error: " ^ msg } ], None
+    | json ->
+      let open Yojson.Safe.Util in
+      let evt_type =
+        match event_type with
+        | Some t when String.trim t <> "" -> t
+        | Some _ | None -> Cli_common_json.member_str "type" json
+      in
+      let events = ref [] in
+      let emit evt = events := evt :: !events in
+      let emit_terminal response =
+        emit
+          (MessageDelta
+             { stop_reason = Some (responses_stop_reason_of_response response)
+             ; usage = responses_usage_of_response response
+             });
+        emit MessageStop
+      in
+      (match evt_type with
+       | "response.created" ->
+         let response = json |> member "response" in
+         emit
+           (MessageStart
+              { id = Cli_common_json.member_str "id" response
+              ; model = Cli_common_json.member_str "model" response
+              ; usage = responses_usage_of_response response
+              })
+       | "response.output_text.delta" ->
+         (match responses_member_string_opt "delta" json with
+          | Some delta when delta <> "" ->
+            let index = responses_ensure_text_block state emit in
+            emit (ContentBlockDelta { index; delta = TextDelta delta })
+          | Some _ | None -> ())
+       | "response.output_text.done" ->
+         if not state.text_block_started
+         then (
+           match responses_member_string_opt "text" json with
+           | Some text when text <> "" ->
+             let index = responses_ensure_text_block state emit in
+             emit (ContentBlockDelta { index; delta = TextDelta text })
+           | Some _ | None -> ())
+       | "response.reasoning_summary_text.delta" | "response.reasoning_text.delta" ->
+         (match responses_member_string_opt "delta" json with
+          | Some delta when delta <> "" ->
+            let index = responses_ensure_thinking_block state emit in
+            emit (ContentBlockDelta { index; delta = ThinkingDelta delta })
+          | Some _ | None -> ())
+       | "response.reasoning_summary_text.done" | "response.reasoning_text.done" ->
+         if not state.thinking_block_started
+         then (
+           match responses_member_string_opt "text" json with
+           | Some text when text <> "" ->
+             let index = responses_ensure_thinking_block state emit in
+             emit (ContentBlockDelta { index; delta = ThinkingDelta text })
+           | Some _ | None -> ())
+       | "response.output_item.added" ->
+         let output_index = responses_member_int_default "output_index" json in
+         let item = json |> member "item" in
+         (match responses_member_string_opt "type" item with
+          | Some ("function_call" | "custom_tool_call") ->
+            let _idx =
+              responses_ensure_tool_block
+                state
+                emit
+                ~output_index
+                ~tool_id:(responses_tool_id_of_item item)
+                ~tool_name:(responses_member_string_opt "name" item)
+            in
+            ()
+          | Some _ | None -> ())
+       | "response.function_call_arguments.delta" ->
+         (match responses_member_string_opt "delta" json with
+          | Some delta when delta <> "" ->
+            let output_index = responses_member_int_default "output_index" json in
+            let item_id = responses_member_string_opt "item_id" json in
+            let index =
+              responses_ensure_tool_block
+                state
+                emit
+                ~output_index
+                ~tool_id:item_id
+                ~tool_name:None
+            in
+            emit (ContentBlockDelta { index; delta = InputJsonDelta delta })
+          | Some _ | None -> ())
+       | "response.completed" | "response.incomplete" ->
+         emit_terminal (json |> member "response")
+       | "response.failed" | "error" ->
+         emit
+           (SSEError
+              { message = responses_error_message json
+              ; error_type = responses_error_type json
+              ; raw = data_str
+              })
+       | "response.in_progress"
+       | "response.output_item.done"
+       | "response.content_part.added"
+       | "response.content_part.done"
+       | "response.function_call_arguments.done"
+       | "response.reasoning_summary_part.added"
+       | "response.reasoning_summary_part.done"
+       | "response.refusal.delta"
+       | "response.refusal.done"
+       | "response.queued" -> ()
+       | other -> emit (SSEUnknownEventType { event_type = other; raw = data_str }));
+      List.rev !events, None)
+;;
+
 (** {1 Gemini SSE Streaming}
 
     Gemini [streamGenerateContent?alt=sse] emits SSE data lines with

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -122,6 +122,16 @@ val openai_chunk_to_events
   -> provider_d_chunk
   -> sse_event list * Telemetry_event.t option
 
+(** Convert one OpenAI Responses API streaming SSE payload into OAS stream
+    events. Responses streaming is item/event based, not Chat Completions delta
+    based: output text, reasoning summaries, and function call arguments each
+    have their own event family. *)
+val responses_sse_to_events
+  :  provider_d_stream_state
+  -> string option
+  -> string
+  -> sse_event list * Telemetry_event.t option
+
 (** {1 Gemini SSE}
 
     Gemini [streamGenerateContent?alt=sse] emits SSE chunks with

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -294,8 +294,22 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
            Hooks.Idle_severity.Final_warning
          | _ -> Hooks.Idle_severity.Nudge
        in
+       let tool_index = Agent_tools.build_index (Tool_set.to_list agent.tools) in
+       let registered_tool name =
+         Option.is_some (Agent_tools.find_in_index tool_index name)
+       in
+       let normalize_tool_call ~name ~input =
+         if registered_tool name
+         then name, input
+         else (
+           match Agent_tool_name_alias.resolve ~requested:name ~input with
+           | Some (canonical_name, canonical_input) when registered_tool canonical_name ->
+             canonical_name, canonical_input
+           | Some _ | None -> name, input)
+       in
        let idle_result =
-         Agent_turn.update_idle_detection
+         Agent_turn.update_idle_detection_with_normalizer
+           ~normalize_tool_call
            ~idle_state:
              { last_tool_calls = agent.last_tool_calls
              ; consecutive_idle_turns = agent.consecutive_idle_turns

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -380,6 +380,48 @@ let test_idle_different_calls () =
   Alcotest.(check int) "consecutive reset" 0 second.new_state.consecutive_idle_turns
 ;;
 
+let test_idle_normalized_alias_calls () =
+  let normalize_tool_call ~name ~input =
+    match name, input with
+    | "Search", `Assoc fields ->
+      (match List.assoc_opt "query" fields with
+       | Some query -> "Grep", `Assoc [ "pattern", query ]
+       | None -> name, input)
+    | _ -> name, input
+  in
+  let first_raw =
+    Agent_turn.update_idle_detection
+      ~idle_state:{ last_tool_calls = None; consecutive_idle_turns = 0 }
+      ~tool_uses:[ make_tool_use "Grep" {|{"pattern":"needle"}|} ]
+  in
+  let second_raw =
+    Agent_turn.update_idle_detection
+      ~idle_state:first_raw.new_state
+      ~tool_uses:[ make_tool_use "Search" {|{"query":"needle"}|} ]
+  in
+  Alcotest.(check bool)
+    "raw alias spelling is not idle by default"
+    false
+    second_raw.is_idle;
+  let first_normalized =
+    Agent_turn.update_idle_detection_with_normalizer
+      ~normalize_tool_call
+      ~idle_state:{ last_tool_calls = None; consecutive_idle_turns = 0 }
+      ~tool_uses:[ make_tool_use "Grep" {|{"pattern":"needle"}|} ]
+  in
+  let second_normalized =
+    Agent_turn.update_idle_detection_with_normalizer
+      ~normalize_tool_call
+      ~idle_state:first_normalized.new_state
+      ~tool_uses:[ make_tool_use "Search" {|{"query":"needle"}|} ]
+  in
+  Alcotest.(check bool) "normalized alias spelling is idle" true second_normalized.is_idle;
+  Alcotest.(check int)
+    "normalized alias increments idle counter"
+    1
+    second_normalized.new_state.consecutive_idle_turns
+;;
+
 (* ── is_idle ~granularity tests (#896) ───────────────────── *)
 
 let fp name input_str =
@@ -1014,6 +1056,10 @@ let () =
       , [ Alcotest.test_case "first call" `Quick test_idle_first_call
         ; Alcotest.test_case "same calls" `Quick test_idle_same_calls
         ; Alcotest.test_case "different calls" `Quick test_idle_different_calls
+        ; Alcotest.test_case
+            "normalized alias calls"
+            `Quick
+            test_idle_normalized_alias_calls
         ; Alcotest.test_case "multiple tools" `Quick test_idle_multiple_tools
         ; Alcotest.test_case "non-tool ignored" `Quick test_idle_non_tool_use_ignored
         ; Alcotest.test_case

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -1,6 +1,7 @@
 open Llm_provider
 open Types
 module Parse = Backend_openai_parse
+module Responses = Backend_openai_responses
 module Serialize = Backend_openai_serialize
 
 let check_string = Alcotest.(check string)
@@ -882,6 +883,314 @@ let test_parse_edge_shapes_for_text_and_telemetry () =
   | _ -> Alcotest.fail "expected telemetry from integer rates"
 ;;
 
+let responses_response_json () =
+  `Assoc
+    [ "id", `String "resp_123"
+    ; "model", `String "gpt-5.5"
+    ; "status", `String "completed"
+    ; ( "output"
+      , `List
+          [ `Assoc
+              [ "id", `String "rs_1"
+              ; "type", `String "reasoning"
+              ; ( "summary"
+                , `List
+                    [ `Assoc
+                        [ "type", `String "summary_text"
+                        ; "text", `String "Need current weather before answering."
+                        ]
+                    ] )
+              ]
+          ; `Assoc
+              [ "id", `String "fc_1"
+              ; "type", `String "function_call"
+              ; "call_id", `String "call_weather"
+              ; "name", `String "get_weather"
+              ; "arguments", `String {|{"city":"Paris"}|}
+              ]
+          ] )
+    ; ( "usage"
+      , `Assoc
+          [ "input_tokens", `Int 12
+          ; "output_tokens", `Int 8
+          ; "output_tokens_details", `Assoc [ "reasoning_tokens", `Int 3 ]
+          ] )
+    ]
+;;
+
+let test_responses_parse_reasoning_and_function_call () =
+  match
+    Responses.parse_response_result (responses_response_json () |> Yojson.Safe.to_string)
+  with
+  | Error msg -> Alcotest.fail ("unexpected responses parse error: " ^ msg)
+  | Ok response ->
+    check_string "id" "resp_123" response.id;
+    check_string "model" "gpt-5.5" response.model;
+    check_bool "stop tool use" true (response.stop_reason = StopToolUse);
+    (match response.content with
+     | [ Thinking { thinking_type; content }; ToolUse { id; name; input } ] ->
+       check_string "thinking type" "reasoning_summary" thinking_type;
+       check_string "thinking content" "Need current weather before answering." content;
+       check_string "tool call_id" "call_weather" id;
+       check_string "tool name" "get_weather" name;
+       check_string "tool arg" "Paris" (member "city" input |> to_string)
+     | _ -> Alcotest.fail "expected reasoning summary followed by function_call");
+    (match response.usage with
+     | Some usage ->
+       check_int "input tokens" 12 usage.input_tokens;
+       check_int "output tokens" 8 usage.output_tokens
+     | None -> Alcotest.fail "expected usage");
+    (match response.telemetry with
+     | Some telemetry ->
+       Alcotest.(check (option int))
+         "reasoning tokens"
+         (Some 3)
+         telemetry.reasoning_tokens
+     | None -> Alcotest.fail "expected telemetry")
+;;
+
+let test_responses_preserves_encrypted_reasoning_item_for_replay () =
+  let encrypted_reasoning_item =
+    `Assoc
+      [ "id", `String "rs_1"
+      ; "type", `String "reasoning"
+      ; "status", `String "completed"
+      ; ( "summary"
+        , `List
+            [ `Assoc
+                [ "type", `String "summary_text"
+                ; "text", `String "Need current weather before answering."
+                ]
+            ] )
+      ; "encrypted_content", `String "enc_reasoning_123"
+      ]
+  in
+  let json =
+    `Assoc
+      [ "id", `String "resp_123"
+      ; "model", `String "gpt-5.5"
+      ; "status", `String "completed"
+      ; ( "output"
+        , `List
+            [ encrypted_reasoning_item
+            ; `Assoc
+                [ "id", `String "fc_1"
+                ; "type", `String "function_call"
+                ; "call_id", `String "call_weather"
+                ; "name", `String "get_weather"
+                ; "arguments", `String {|{"city":"Paris"}|}
+                ]
+            ] )
+      ]
+  in
+  match Responses.parse_response_result (Yojson.Safe.to_string json) with
+  | Error msg -> Alcotest.fail ("unexpected responses parse error: " ^ msg)
+  | Ok response ->
+    (match response.content with
+     | [ RedactedThinking raw; ToolUse { id; name; input } ] ->
+       let raw_json = Yojson.Safe.from_string raw in
+       check_string "raw type" "reasoning" (member "type" raw_json |> to_string);
+       check_string "raw id" "rs_1" (member "id" raw_json |> to_string);
+       check_string
+         "raw encrypted content"
+         "enc_reasoning_123"
+         (member "encrypted_content" raw_json |> to_string);
+       check_string "tool call_id" "call_weather" id;
+       check_string "tool name" "get_weather" name;
+       check_string "tool arg" "Paris" (member "city" input |> to_string)
+     | _ -> Alcotest.fail "expected raw encrypted reasoning followed by function_call");
+    let config =
+      Provider_config.make
+        ~kind:OpenAI_compat
+        ~model_id:"gpt-5.5"
+        ~base_url:"https://api.openai.com"
+        ~request_path:"/v1/responses"
+        ~max_tokens:128
+        ()
+    in
+    let body =
+      Responses.build_request
+        ~config
+        ~messages:
+          [ msg User [ Text "weather?" ]
+          ; msg Assistant response.content
+          ; msg
+              Tool
+              [ ToolResult
+                  { tool_use_id = "call_weather"
+                  ; content = {|{"temp_c":12}|}
+                  ; is_error = false
+                  ; json = Some (`Assoc [ "temp_c", `Int 12 ])
+                  ; content_blocks = None
+                  }
+              ]
+          ]
+        ()
+      |> Yojson.Safe.from_string
+    in
+    Alcotest.(check (list string))
+      "include encrypted reasoning"
+      [ "reasoning.encrypted_content" ]
+      (member "include" body |> to_list |> List.map to_string);
+    let input = member "input" body |> to_list in
+    check_int "input items" 4 (List.length input);
+    let reasoning = List.nth input 1 in
+    check_string "replayed type" "reasoning" (member "type" reasoning |> to_string);
+    check_string "replayed id" "rs_1" (member "id" reasoning |> to_string);
+    check_string
+      "replayed encrypted content"
+      "enc_reasoning_123"
+      (member "encrypted_content" reasoning |> to_string);
+    check_string
+      "function call item"
+      "function_call"
+      (List.nth input 2 |> member "type" |> to_string);
+    check_string
+      "function output item"
+      "function_call_output"
+      (List.nth input 3 |> member "type" |> to_string)
+;;
+
+let test_responses_build_request_round_trips_tool_result_items () =
+  let config =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"gpt-5.5"
+      ~base_url:"https://api.openai.com"
+      ~request_path:"/v1/responses"
+      ~enable_thinking:true
+      ~thinking_budget:4096
+      ~max_tokens:128
+      ()
+  in
+  let tool =
+    `Assoc
+      [ "name", `String "get_weather"
+      ; "description", `String "weather lookup"
+      ; "input_schema", `Assoc [ "type", `String "object" ]
+      ; "strict", `Bool true
+      ]
+  in
+  let body =
+    Responses.build_request
+      ~config
+      ~messages:
+        [ msg User [ Text "weather?" ]
+        ; msg
+            Assistant
+            [ Thinking { thinking_type = "reasoning_summary"; content = "Need a tool." }
+            ; ToolUse
+                { id = "call_weather"
+                ; name = "get_weather"
+                ; input = `Assoc [ "city", `String "Paris" ]
+                }
+            ]
+        ; msg
+            Tool
+            [ ToolResult
+                { tool_use_id = "call_weather"
+                ; content = {|{"temp_c":12}|}
+                ; is_error = false
+                ; json = Some (`Assoc [ "temp_c", `Int 12 ])
+                ; content_blocks = None
+                }
+            ]
+        ]
+      ~tools:[ tool ]
+      ()
+    |> Yojson.Safe.from_string
+  in
+  check_string "model" "gpt-5.5" (member "model" body |> to_string);
+  check_int "max output" 128 (member "max_output_tokens" body |> to_int);
+  check_string
+    "reasoning effort"
+    "medium"
+    (member "reasoning" body |> member "effort" |> to_string);
+  Alcotest.(check (list string))
+    "include encrypted reasoning"
+    [ "reasoning.encrypted_content" ]
+    (member "include" body |> to_list |> List.map to_string);
+  let input = member "input" body |> to_list in
+  check_int "input items" 4 (List.length input);
+  check_string "first role" "user" (List.nth input 0 |> member "role" |> to_string);
+  check_string
+    "reasoning item"
+    "reasoning"
+    (List.nth input 1 |> member "type" |> to_string);
+  check_string
+    "function call item"
+    "function_call"
+    (List.nth input 2 |> member "type" |> to_string);
+  check_string
+    "function output item"
+    "function_call_output"
+    (List.nth input 3 |> member "type" |> to_string);
+  check_string
+    "output call id"
+    "call_weather"
+    (List.nth input 3 |> member "call_id" |> to_string);
+  let tool_json = member "tools" body |> to_list |> only "responses tool" in
+  check_string "tool type" "function" (member "type" tool_json |> to_string);
+  check_string "tool name" "get_weather" (member "name" tool_json |> to_string);
+  check_bool "tool strict" true (Yojson.Safe.Util.to_bool (member "strict" tool_json))
+;;
+
+let test_responses_build_request_uses_text_format_json_schema () =
+  let schema =
+    `Assoc
+      [ "title", `String "Weather Answer"
+      ; "type", `String "object"
+      ; ( "properties"
+        , `Assoc
+            [ "city", `Assoc [ "type", `String "string" ]
+            ; "temp_c", `Assoc [ "type", `String "number" ]
+            ] )
+      ; "required", `List [ `String "city"; `String "temp_c" ]
+      ; "additionalProperties", `Bool false
+      ]
+  in
+  let config =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"gpt-5.5"
+      ~base_url:"https://api.openai.com"
+      ~request_path:"/v1/responses"
+      ~output_schema:schema
+      ~max_tokens:128
+      ()
+  in
+  let body =
+    Responses.build_request ~config ~messages:[ msg User [ Text "weather?" ] ] ()
+    |> Yojson.Safe.from_string
+  in
+  let format = member "text" body |> member "format" in
+  check_string "format type" "json_schema" (member "type" format |> to_string);
+  check_string "format name" "weather_answer" (member "name" format |> to_string);
+  check_bool "format strict" true (Yojson.Safe.Util.to_bool (member "strict" format));
+  Alcotest.(check bool) "format schema" true (member "schema" format = schema)
+;;
+
+let test_responses_build_request_uses_text_format_json_object () =
+  let config =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"gpt-5.5"
+      ~base_url:"https://api.openai.com"
+      ~request_path:"/v1/responses"
+      ~response_format_json:true
+      ~max_tokens:128
+      ()
+  in
+  let body =
+    Responses.build_request ~config ~messages:[ msg User [ Text "json please" ] ] ()
+    |> Yojson.Safe.from_string
+  in
+  check_string
+    "format type"
+    "json_object"
+    (member "text" body |> member "format" |> member "type" |> to_string)
+;;
+
 let () =
   Alcotest.run
     "backend_openai_codec"
@@ -974,6 +1283,28 @@ let () =
             "edge text shapes and telemetry"
             `Quick
             test_parse_edge_shapes_for_text_and_telemetry
+        ] )
+    ; ( "responses"
+      , [ Alcotest.test_case
+            "parse reasoning and function_call items"
+            `Quick
+            test_responses_parse_reasoning_and_function_call
+        ; Alcotest.test_case
+            "preserve encrypted reasoning item for replay"
+            `Quick
+            test_responses_preserves_encrypted_reasoning_item_for_replay
+        ; Alcotest.test_case
+            "build request round-trips tool result items"
+            `Quick
+            test_responses_build_request_round_trips_tool_result_items
+        ; Alcotest.test_case
+            "build request text.format json_schema"
+            `Quick
+            test_responses_build_request_uses_text_format_json_schema
+        ; Alcotest.test_case
+            "build request text.format json_object"
+            `Quick
+            test_responses_build_request_uses_text_format_json_object
         ] )
     ]
 ;;

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -29,6 +29,14 @@ let provider_d_mlx_vlm_response text =
     text
 ;;
 
+let openai_responses_tool_call_response () =
+  {|{"id":"resp-1","model":"gpt-5.5","status":"completed","output":[
+      {"id":"rs-1","type":"reasoning","summary":[{"type":"summary_text","text":"Need a lookup."}]},
+      {"id":"fc-1","type":"function_call","call_id":"call_lookup","name":"lookup","arguments":"{\"q\":\"weather\"}"}
+    ],
+    "usage":{"input_tokens":12,"output_tokens":8,"output_tokens_details":{"reasoning_tokens":3}}}|}
+;;
+
 let ollama_tool_call_response () =
   {|{"model":"dashscope-3:8b","done":true,"done_reason":"tool_calls",
      "message":{"role":"assistant","content":"",
@@ -51,10 +59,21 @@ let fresh_port () =
   port
 ;;
 
-let start_mock_server ~sw ~net ?(status = `OK) ?(delay_sec = 0.0) ?clock response_body =
+let start_mock_server
+      ~sw
+      ~net
+      ?(status = `OK)
+      ?(delay_sec = 0.0)
+      ?clock
+      ?capture_body
+      response_body
+  =
   let port = fresh_port () in
   let handler _conn _req body =
-    let _ = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    let request_body = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    (match capture_body with
+     | Some seen -> seen := Some request_body
+     | None -> ());
     (match clock with
      | Some clk when delay_sec > 0.0 -> Eio.Time.sleep clk delay_sec
      | _ -> ());
@@ -125,6 +144,19 @@ let make_provider_d_config base_url =
 ;;
 
 let messages = [ Types.user_msg "hello" ]
+
+let contains_substring ~sub text =
+  let sub_len = String.length sub in
+  let text_len = String.length text in
+  let rec loop idx =
+    if idx + sub_len > text_len
+    then false
+    else if String.sub text idx sub_len = sub
+    then true
+    else loop (idx + 1)
+  in
+  sub_len = 0 || loop 0
+;;
 
 let mock_transport_response text =
   { Types.id = "transport-response"
@@ -251,6 +283,191 @@ let test_complete_provider_d_ok () =
       check string "text" "openai reply" text;
       Eio.Switch.fail sw Exit
     | Error _ -> fail "expected Ok for openai"
+  with
+  | Exit -> ()
+;;
+
+let test_complete_openai_responses_sync_ok () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url =
+      start_mock_server ~sw ~net:env#net (openai_responses_tool_call_response ())
+    in
+    let config =
+      Provider_config.make
+        ~kind:Provider_config.OpenAI_compat
+        ~model_id:"gpt-5.5"
+        ~base_url:url
+        ~request_path:"/v1/responses"
+        ~temperature:0.0
+        ~max_tokens:100
+        ()
+    in
+    match Complete.complete ~sw ~net:env#net ~config ~messages () with
+    | Ok resp ->
+      check bool "stop tool use" true (resp.stop_reason = Types.StopToolUse);
+      (match resp.content with
+       | [ Types.Thinking { content; _ }; Types.ToolUse { id; name; input } ] ->
+         check string "reasoning" "Need a lookup." content;
+         check string "tool id" "call_lookup" id;
+         check string "tool name" "lookup" name;
+         check
+           string
+           "tool arg"
+           "weather"
+           (Yojson.Safe.Util.member "q" input |> Yojson.Safe.Util.to_string)
+       | _ -> fail "expected reasoning + tool use");
+      (match resp.telemetry with
+       | Some telemetry ->
+         check (option int) "reasoning tokens" (Some 3) telemetry.reasoning_tokens
+       | None -> fail "expected telemetry");
+      Eio.Switch.fail sw Exit
+    | Error _ -> fail "expected Ok for OpenAI Responses sync"
+  with
+  | Exit -> ()
+;;
+
+let test_complete_openai_responses_json_mode_body () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let captured = ref None in
+    let url =
+      start_mock_server
+        ~sw
+        ~net:env#net
+        ~capture_body:captured
+        (openai_responses_tool_call_response ())
+    in
+    let config =
+      Provider_config.make
+        ~kind:Provider_config.OpenAI_compat
+        ~model_id:"gpt-5.5"
+        ~base_url:url
+        ~request_path:"/v1/responses"
+        ~response_format_json:true
+        ~temperature:0.0
+        ~max_tokens:100
+        ()
+    in
+    (match Complete.complete ~sw ~net:env#net ~config ~messages () with
+     | Ok _ -> ()
+     | Error _ -> fail "expected Ok for OpenAI Responses JSON mode");
+    match !captured with
+    | Some body ->
+      let json = Yojson.Safe.from_string body in
+      check
+        string
+        "responses text.format"
+        "json_object"
+        Yojson.Safe.Util.(
+          json |> member "text" |> member "format" |> member "type" |> to_string);
+      Eio.Switch.fail sw Exit
+    | None -> fail "server did not capture request body"
+  with
+  | Exit -> ()
+;;
+
+let start_responses_sse_server ~sw ~net response_body =
+  let port = fresh_port () in
+  let handler _conn _req body =
+    let _ = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    let headers = Cohttp.Header.of_list [ "content-type", "text/event-stream" ] in
+    Cohttp_eio.Server.respond_string ~status:`OK ~headers ~body:response_body ()
+  in
+  let socket =
+    Eio.Net.listen
+      net
+      ~sw
+      ~backlog:8
+      ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  let server = Cohttp_eio.Server.make ~callback:handler () in
+  Eio.Fiber.fork ~sw (fun () ->
+    Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+  Printf.sprintf "http://127.0.0.1:%d" port
+;;
+
+let openai_responses_sse_tool_call_response () =
+  "event: response.created\n\
+   data: \
+   {\"type\":\"response.created\",\"response\":{\"id\":\"resp-stream-1\",\"model\":\"gpt-5.5\",\"status\":\"in_progress\",\"usage\":null}}\n\n\
+   event: response.reasoning_summary_text.delta\n\
+   data: \
+   {\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_1\",\"output_index\":0,\"summary_index\":0,\"delta\":\"Need \
+   a lookup.\"}\n\n\
+   event: response.output_item.added\n\
+   data: \
+   {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"id\":\"fc_1\",\"type\":\"function_call\",\"call_id\":\"call_lookup\",\"name\":\"lookup\",\"arguments\":\"\"}}\n\n\
+   event: response.function_call_arguments.delta\n\
+   data: \
+   {\"type\":\"response.function_call_arguments.delta\",\"output_index\":1,\"item_id\":\"fc_1\",\"delta\":\"{\\\"q\\\":\\\"weather\\\"}\"}\n\n\
+   event: response.completed\n\
+   data: \
+   {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-stream-1\",\"model\":\"gpt-5.5\",\"status\":\"completed\",\"output\":[{\"id\":\"fc_1\",\"type\":\"function_call\",\"call_id\":\"call_lookup\",\"name\":\"lookup\",\"arguments\":\"{\\\"q\\\":\\\"weather\\\"}\"}],\"usage\":{\"input_tokens\":12,\"output_tokens\":8,\"input_tokens_details\":{\"cached_tokens\":2}}}}\n\n"
+;;
+
+let test_complete_stream_openai_responses_ok () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url =
+      start_responses_sse_server
+        ~sw
+        ~net:env#net
+        (openai_responses_sse_tool_call_response ())
+    in
+    let config =
+      Provider_config.make
+        ~kind:Provider_config.OpenAI_compat
+        ~model_id:"gpt-5.5"
+        ~base_url:url
+        ~request_path:"/v1/responses"
+        ~temperature:0.0
+        ~max_tokens:100
+        ()
+    in
+    let events = ref [] in
+    match
+      Complete.complete_stream
+        ~sw
+        ~net:env#net
+        ~config
+        ~messages
+        ~on_event:(fun evt -> events := evt :: !events)
+        ()
+    with
+    | Ok resp ->
+      check string "stream id" "resp-stream-1" resp.id;
+      check bool "stop tool use" true (resp.stop_reason = Types.StopToolUse);
+      check bool "events emitted" true (List.length !events >= 5);
+      (match resp.content with
+       | [ Types.Thinking { content; _ }; Types.ToolUse { id; name; input } ] ->
+         check string "reasoning" "Need a lookup." content;
+         check string "tool id" "call_lookup" id;
+         check string "tool name" "lookup" name;
+         check
+           string
+           "tool arg"
+           "weather"
+           (Yojson.Safe.Util.member "q" input |> Yojson.Safe.Util.to_string)
+       | _ -> fail "expected reasoning + tool use");
+      (match resp.usage with
+       | Some usage ->
+         check int "input tokens" 12 usage.input_tokens;
+         check int "output tokens" 8 usage.output_tokens;
+         check int "cached tokens" 2 usage.cache_read_input_tokens
+       | None -> fail "expected usage");
+      Eio.Switch.fail sw Exit
+    | Error _ -> fail "expected Ok for Responses streaming"
   with
   | Exit -> ()
 ;;
@@ -1244,6 +1461,18 @@ let () =
             `Quick
             test_complete_http_empty_error_body_has_context
         ; test_case "openai ok" `Quick test_complete_provider_d_ok
+        ; test_case
+            "openai responses sync ok"
+            `Quick
+            test_complete_openai_responses_sync_ok
+        ; test_case
+            "openai responses json mode body"
+            `Quick
+            test_complete_openai_responses_json_mode_body
+        ; test_case
+            "openai responses stream ok"
+            `Quick
+            test_complete_stream_openai_responses_ok
         ; test_case
             "openai mlx-vlm telemetry"
             `Quick

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -738,6 +738,46 @@ let test_drop_thinking_preserves_recent () =
     Alcotest.(check bool) "thinking preserved in recent" true has_thinking
 ;;
 
+let test_drop_thinking_preserves_tool_use_thinking () =
+  let msgs =
+    [ user_msg "q1"
+    ; Types.
+        { role = Assistant
+        ; content =
+            [ Thinking { thinking_type = "thinking"; content = "pick tool" }
+            ; RedactedThinking "encrypted"
+            ; ToolUse { id = "t1"; name = "search"; input = `Assoc [] }
+            ]
+        ; name = None
+        ; tool_call_id = None
+        ; metadata = []
+        }
+    ; tool_result_msg "t1" "result"
+    ; user_msg "q2"
+    ; asst_msg "done"
+    ]
+  in
+  let result = Context_reducer.reduce Context_reducer.drop_thinking msgs in
+  match List.nth result 1 with
+  | { Types.content; _ } ->
+    let has_thinking =
+      List.exists
+        (function
+          | Types.Thinking _ -> true
+          | _ -> false)
+        content
+    in
+    let has_redacted =
+      List.exists
+        (function
+          | Types.RedactedThinking _ -> true
+          | _ -> false)
+        content
+    in
+    Alcotest.(check bool) "thinking preserved beside tool_use" true has_thinking;
+    Alcotest.(check bool) "redacted thinking preserved beside tool_use" true has_redacted
+;;
+
 (* --- compose --- *)
 
 let test_compose () =
@@ -1530,6 +1570,10 @@ let () =
             "preserves recent thinking"
             `Quick
             test_drop_thinking_preserves_recent
+        ; Alcotest.test_case
+            "preserves tool-use thinking"
+            `Quick
+            test_drop_thinking_preserves_tool_use_thinking
         ] )
     ; "compose", [ Alcotest.test_case "compose strategies" `Quick test_compose ]
     ; ( "keep_first_and_last"

--- a/test/test_llm_cache.ml
+++ b/test/test_llm_cache.ml
@@ -98,6 +98,36 @@ let test_fingerprint_message_roles () =
   Alcotest.(check bool) "different roles = different key" true (k1 <> k2)
 ;;
 
+let test_fingerprint_tool_use_blocks () =
+  let config = make_config () in
+  let msg name =
+    { role = Assistant
+    ; content = [ ToolUse { id = "call_1"; name; input = `Assoc [ "q", `String "x" ] } ]
+    ; name = None
+    ; tool_call_id = None
+    ; metadata = []
+    }
+  in
+  let k1 = Cache.request_fingerprint ~config ~messages:[ msg "search" ] () in
+  let k2 = Cache.request_fingerprint ~config ~messages:[ msg "lookup" ] () in
+  Alcotest.(check bool) "tool_use changes key" true (k1 <> k2)
+;;
+
+let test_fingerprint_redacted_thinking_blocks () =
+  let config = make_config () in
+  let msg data =
+    { role = Assistant
+    ; content = [ RedactedThinking data; Text "visible" ]
+    ; name = None
+    ; tool_call_id = None
+    ; metadata = []
+    }
+  in
+  let k1 = Cache.request_fingerprint ~config ~messages:[ msg "encrypted-a" ] () in
+  let k2 = Cache.request_fingerprint ~config ~messages:[ msg "encrypted-b" ] () in
+  Alcotest.(check bool) "redacted_thinking changes key" true (k1 <> k2)
+;;
+
 (* ── response_to_json / response_of_json roundtrip ───────── *)
 
 let test_roundtrip_text () =
@@ -307,10 +337,20 @@ let test_roundtrip_stop_unknown () =
 let test_roundtrip_redacted_thinking () =
   let resp = simple_response [ RedactedThinking "secret" ] in
   let json = Cache.response_to_json resp in
+  let open Yojson.Safe.Util in
+  (match json |> member "content" |> to_list with
+   | [ block ] ->
+     Alcotest.(check string)
+       "type"
+       "redacted_thinking"
+       (block |> member "type" |> to_string);
+     Alcotest.(check string) "data" "secret" (block |> member "data" |> to_string)
+   | _ -> Alcotest.fail "expected serialized redacted_thinking block");
   match Cache.response_of_json json with
   | Some r ->
-    (* redacted_thinking has no content in JSON, so it is filtered out *)
-    Alcotest.(check int) "redacted filtered" 0 (List.length r.content)
+    (match r.content with
+     | [ RedactedThinking data ] -> Alcotest.(check string) "redacted data" "secret" data
+     | _ -> Alcotest.fail "expected redacted_thinking roundtrip")
   | None -> Alcotest.fail "roundtrip failed"
 ;;
 
@@ -504,6 +544,11 @@ let () =
         ; Alcotest.test_case "multiple messages" `Quick test_fingerprint_multiple_messages
         ; Alcotest.test_case "hex format" `Quick test_fingerprint_hex_format
         ; Alcotest.test_case "message roles" `Quick test_fingerprint_message_roles
+        ; Alcotest.test_case "tool_use blocks" `Quick test_fingerprint_tool_use_blocks
+        ; Alcotest.test_case
+            "redacted_thinking blocks"
+            `Quick
+            test_fingerprint_redacted_thinking_blocks
         ] )
     ; ( "roundtrip_content"
       , [ Alcotest.test_case "text" `Quick test_roundtrip_text

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -315,6 +315,38 @@ let test_validate_output_schema_capability_rejected () =
   | Ok () -> Alcotest.fail "expected model capability rejection"
 ;;
 
+let test_validate_responses_request_path_allows_structured_output () =
+  let cfg =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"gpt-5.5"
+      ~base_url:"https://api.openai.com/v1"
+      ~request_path:"/v1/responses"
+      ~output_schema:(`Assoc [ "type", `String "object" ])
+      ()
+  in
+  check_bool
+    "responses structured output accepted at path layer"
+    true
+    (Result.is_ok (Provider_config.validate_request_path cfg))
+;;
+
+let test_validate_responses_request_path_allows_json_mode () =
+  let cfg =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"gpt-5.5"
+      ~base_url:"https://api.openai.com/v1"
+      ~request_path:"/v1/responses"
+      ~response_format_json:true
+      ()
+  in
+  check_bool
+    "responses json mode accepted at path layer"
+    true
+    (Result.is_ok (Provider_config.validate_request_path cfg))
+;;
+
 (* ── make: headers default ────────────────────────────── *)
 
 let test_default_headers () =
@@ -960,6 +992,14 @@ let () =
             "openai capability rejection"
             `Quick
             test_validate_output_schema_capability_rejected
+        ; Alcotest.test_case
+            "responses structured path accepted"
+            `Quick
+            test_validate_responses_request_path_allows_structured_output
+        ; Alcotest.test_case
+            "responses json mode path accepted"
+            `Quick
+            test_validate_responses_request_path_allows_json_mode
         ] )
     ; ( "locality"
       , [ Alcotest.test_case "loopback ip" `Quick test_is_local_loopback_ip

--- a/test/test_streaming_openai.ml
+++ b/test/test_streaming_openai.ml
@@ -623,6 +623,73 @@ let test_events_thinking_tool_text () =
   | _ -> Alcotest.fail "expected TextDelta at index 2"
 ;;
 
+let test_responses_stream_reasoning_tool_and_terminal () =
+  let state =
+    S.create_openai_stream_state ~provider:"openai_compat" ~model:"gpt-5.5" ()
+  in
+  let events1, _ =
+    S.responses_sse_to_events
+      state
+      (Some "response.created")
+      {|{"type":"response.created","response":{"id":"resp_1","model":"gpt-5.5","status":"in_progress","usage":null}}|}
+  in
+  (match events1 with
+   | [ MessageStart { id; model; usage } ] ->
+     Alcotest.(check string) "id" "resp_1" id;
+     Alcotest.(check string) "model" "gpt-5.5" model;
+     Alcotest.(check bool) "usage absent" true (Option.is_none usage)
+   | _ -> Alcotest.fail "expected MessageStart");
+  let events2, _ =
+    S.responses_sse_to_events
+      state
+      (Some "response.reasoning_summary_text.delta")
+      {|{"type":"response.reasoning_summary_text.delta","item_id":"rs_1","output_index":0,"summary_index":0,"delta":"Need a lookup."}|}
+  in
+  (match events2 with
+   | [ ContentBlockStart { index = 0; content_type = "thinking"; _ }
+     ; ContentBlockDelta { index = 0; delta = ThinkingDelta "Need a lookup." }
+     ] -> ()
+   | _ -> Alcotest.fail "expected reasoning start+delta");
+  let events3, _ =
+    S.responses_sse_to_events
+      state
+      (Some "response.output_item.added")
+      {|{"type":"response.output_item.added","output_index":1,"item":{"id":"fc_1","type":"function_call","call_id":"call_lookup","name":"lookup","arguments":""}}|}
+  in
+  (match events3 with
+   | [ ContentBlockStart
+         { index = 1
+         ; content_type = "tool_use"
+         ; tool_id = Some "call_lookup"
+         ; tool_name = Some "lookup"
+         }
+     ] -> ()
+   | _ -> Alcotest.fail "expected tool start");
+  let events4, _ =
+    S.responses_sse_to_events
+      state
+      (Some "response.function_call_arguments.delta")
+      {|{"type":"response.function_call_arguments.delta","output_index":1,"item_id":"fc_1","delta":"{\"q\":\"weather\"}"}|}
+  in
+  (match events4 with
+   | [ ContentBlockDelta { index = 1; delta = InputJsonDelta "{\"q\":\"weather\"}" } ] ->
+     ()
+   | _ -> Alcotest.fail "expected function arguments delta");
+  let events5, _ =
+    S.responses_sse_to_events
+      state
+      (Some "response.completed")
+      {|{"type":"response.completed","response":{"id":"resp_1","model":"gpt-5.5","status":"completed","output":[{"id":"fc_1","type":"function_call","call_id":"call_lookup","name":"lookup","arguments":"{\"q\":\"weather\"}"}],"usage":{"input_tokens":12,"output_tokens":8,"input_tokens_details":{"cached_tokens":2}}}}|}
+  in
+  match events5 with
+  | [ MessageDelta { stop_reason = Some StopToolUse; usage = Some usage }; MessageStop ]
+    ->
+    Alcotest.(check int) "input tokens" 12 usage.input_tokens;
+    Alcotest.(check int) "output tokens" 8 usage.output_tokens;
+    Alcotest.(check int) "cache read" 2 usage.cache_read_input_tokens
+  | _ -> Alcotest.fail "expected terminal StopToolUse with usage"
+;;
+
 let () =
   let open Alcotest in
   run
@@ -666,6 +733,12 @@ let () =
         ; test_case "tool-first then text (#333)" `Quick test_events_tool_first_then_text
         ; test_case "multi-tool then text (#333)" `Quick test_events_multi_tool_then_text
         ; test_case "thinking + tool + text (#333)" `Quick test_events_thinking_tool_text
+        ] )
+    ; ( "responses_sse_to_events"
+      , [ test_case
+            "reasoning tool and terminal"
+            `Quick
+            test_responses_stream_reasoning_tool_and_terminal
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- add a normalizer-aware Agent_turn idle detector and wire it through pipeline tool alias resolution
- preserve thinking/redacted-thinking blocks across compaction for assistant tool-use turns
- add OpenAI Responses sync and SSE codecs for item-based reasoning summaries, function calls, function_call_output tool results, usage, and structured output `text.format`
- preserve and replay Responses encrypted reasoning items via `RedactedThinking` raw item JSON when tool loops continue
- keep cached `RedactedThinking` payloads and include full content blocks in cache fingerprints so ToolUse/raw reasoning requests do not collide

## Tests
- `ocamlformat --check lib/llm_provider/backend_openai_responses.ml lib/llm_provider/cache.ml test/test_backend_openai_codec.ml test/test_llm_cache.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_backend_openai_codec.exe test/test_llm_cache.exe`
- `_build/default/test/test_backend_openai_codec.exe`
- `_build/default/test/test_llm_cache.exe`
- `scripts/dune-local.sh build test/test_complete_http.exe test/test_provider_config.exe test/test_streaming_openai.exe test/test_streaming_coverage.exe test/test_stream_accumulator.exe test/test_context_reducer.exe test/test_agent_turn.exe`
- `_build/default/test/test_complete_http.exe`
- `_build/default/test/test_provider_config.exe`
- `_build/default/test/test_streaming_openai.exe`
- `_build/default/test/test_context_reducer.exe`
- `_build/default/test/test_agent_turn.exe`
- `_build/default/test/test_streaming_coverage.exe`
- `_build/default/test/test_stream_accumulator.exe`
