### PR TITLE
fix(durable_event): make journal appends atomic

### DIFF
--- a/lib/durable_event.ml
+++ b/lib/durable_event.ml
@@ -70,18 +70,28 @@ type journal =
   ; on_append : (event -> unit) option
     (** Optional fan-out callback invoked after every append.
         Used to project journal events onto Event_bus or other sinks. *)
+  ; mutex : Eio.Mutex.t
+    (** Guards all reads/writes of [entries] and [size]. The journal may be
+        appended to from parallel tool-execution fibers (e.g. [Parallel_batch]),
+        so every access must be serialized. *)
   }
 
-let create ?on_append () = { entries = []; size = 0; on_append }
+let create ?on_append () =
+  { entries = []; size = 0; on_append; mutex = Eio.Mutex.create () }
+;;
 
 let append journal event =
+  Eio.Mutex.use_rw ~protect:true journal.mutex @@ fun () ->
   journal.entries <- event :: journal.entries;
   journal.size <- journal.size + 1;
   Option.iter (fun f -> f event) journal.on_append
 ;;
 
-let events journal = List.rev journal.entries
-let length journal = journal.size
+let events journal =
+  Eio.Mutex.use_ro journal.mutex @@ fun () -> List.rev journal.entries
+;;
+
+let length journal = Eio.Mutex.use_ro journal.mutex @@ fun () -> journal.size
 
 (* ── Idempotency ──────────────────────────────────── *)
 
@@ -103,6 +113,7 @@ let make_idempotency_key ~tool_name ~input =
 ;;
 
 let find_completed_activity journal key =
+  Eio.Mutex.use_ro journal.mutex @@ fun () ->
   List.find_map
     (fun event ->
        match event with
@@ -126,6 +137,7 @@ type replay_summary =
 (* Fold over entries directly (reverse chronological) — avoids List.rev allocation *)
 let replay_summary journal =
   let acc =
+    Eio.Mutex.use_ro journal.mutex @@ fun () ->
     List.fold_left
       (fun (lt, ct, ls, it, ot, ec) event ->
          match event with
@@ -175,6 +187,7 @@ let events_for_turn journal turn =
 ;;
 
 let last_timestamp journal =
+  Eio.Mutex.use_ro journal.mutex @@ fun () ->
   match journal.entries with
   | [] -> None
   | first :: _ ->
@@ -354,7 +367,7 @@ let journal_of_json json =
     let items = to_list json in
     (* acc accumulates in reverse — matches journal.entries internal format *)
     let rec parse acc count = function
-      | [] -> Ok { entries = acc; size = count; on_append = None }
+      | [] -> Ok { entries = acc; size = count; on_append = None; mutex = Eio.Mutex.create () }
       | item :: rest ->
         (match event_of_json item with
          | Ok evt -> parse (evt :: acc) (count + 1) rest
@@ -385,7 +398,7 @@ let save_to_file journal path =
 
 let load_from_file path =
   if not (Sys.file_exists path)
-  then Ok { entries = []; size = 0; on_append = None }
+  then Ok { entries = []; size = 0; on_append = None; mutex = Eio.Mutex.create () }
   else (
     try
       let ic = open_in path in
@@ -410,7 +423,7 @@ let load_from_file path =
                     | Ok evt -> read_lines (evt :: acc) (count + 1) (line_no + 1)
                     | Error e -> Error (Printf.sprintf "line %d: %s" line_no e)))
              | exception End_of_file ->
-               Ok { entries = acc; size = count; on_append = None }
+               Ok { entries = acc; size = count; on_append = None; mutex = Eio.Mutex.create () }
            in
            read_lines [] 0 1)
     with

--- a/lib/durable_event.ml
+++ b/lib/durable_event.ml
@@ -65,33 +65,37 @@ type event =
 (* ── Journal ──────────────────────────────────────── *)
 
 type journal =
-  { mutable entries : event list (** Stored in reverse chronological order *)
-  ; mutable size : int
+  { state : (event list * int) Atomic.t
+    (** Stored as [(reversed entries, size)]. Atomic pair so reads and writes
+        are lock-free and safe when the journal is appended from parallel
+        tool-execution fibers (e.g. [Parallel_batch]). *)
   ; on_append : (event -> unit) option
     (** Optional fan-out callback invoked after every append.
         Used to project journal events onto Event_bus or other sinks. *)
-  ; mutex : Eio.Mutex.t
-    (** Guards all reads/writes of [entries] and [size]. The journal may be
-        appended to from parallel tool-execution fibers (e.g. [Parallel_batch]),
-        so every access must be serialized. *)
   }
 
-let create ?on_append () =
-  { entries = []; size = 0; on_append; mutex = Eio.Mutex.create () }
-;;
+let create ?on_append () = { state = Atomic.make ([], 0); on_append }
 
 let append journal event =
-  Eio.Mutex.use_rw ~protect:true journal.mutex @@ fun () ->
-  journal.entries <- event :: journal.entries;
-  journal.size <- journal.size + 1;
-  Option.iter (fun f -> f event) journal.on_append
+  let rec loop () =
+    let old_entries, old_size = Atomic.get journal.state in
+    let new_state = event :: old_entries, old_size + 1 in
+    if Atomic.compare_and_set journal.state (old_entries, old_size) new_state
+    then Option.iter (fun f -> f event) journal.on_append
+    else loop ()
+  in
+  loop ()
 ;;
 
 let events journal =
-  Eio.Mutex.use_ro journal.mutex @@ fun () -> List.rev journal.entries
+  let entries, _size = Atomic.get journal.state in
+  List.rev entries
 ;;
 
-let length journal = Eio.Mutex.use_ro journal.mutex @@ fun () -> journal.size
+let length journal =
+  let _entries, size = Atomic.get journal.state in
+  size
+;;
 
 (* ── Idempotency ──────────────────────────────────── *)
 
@@ -113,14 +117,14 @@ let make_idempotency_key ~tool_name ~input =
 ;;
 
 let find_completed_activity journal key =
-  Eio.Mutex.use_ro journal.mutex @@ fun () ->
+  let entries, _size = Atomic.get journal.state in
   List.find_map
     (fun event ->
        match event with
        | Tool_completed { idempotency_key; output_json; _ } when idempotency_key = key ->
          Some output_json
        | _ -> None)
-    journal.entries (* entries is reversed, so finds most recent first *)
+    entries (* entries is reversed, so finds most recent first *)
 ;;
 
 (* ── Replay ───────────────────────────────────────── *)
@@ -136,8 +140,8 @@ type replay_summary =
 
 (* Fold over entries directly (reverse chronological) — avoids List.rev allocation *)
 let replay_summary journal =
+  let entries, _size = Atomic.get journal.state in
   let acc =
-    Eio.Mutex.use_ro journal.mutex @@ fun () ->
     List.fold_left
       (fun (lt, ct, ls, it, ot, ec) event ->
          match event with
@@ -150,7 +154,7 @@ let replay_summary journal =
          | Error_occurred _ -> lt, ct, ls, it, ot, ec + 1
          | Tool_called _ | Checkpoint_saved _ -> lt, ct, ls, it, ot, ec)
       (0, [], "unknown", 0, 0, 0)
-      journal.entries
+      entries
   in
   let ( last_turn
       , completed_tools_rev
@@ -187,8 +191,8 @@ let events_for_turn journal turn =
 ;;
 
 let last_timestamp journal =
-  Eio.Mutex.use_ro journal.mutex @@ fun () ->
-  match journal.entries with
+  let entries, _size = Atomic.get journal.state in
+  match entries with
   | [] -> None
   | first :: _ ->
     let ts =
@@ -365,9 +369,9 @@ let journal_of_json json =
   let open Yojson.Safe.Util in
   try
     let items = to_list json in
-    (* acc accumulates in reverse — matches journal.entries internal format *)
+    (* acc accumulates in reverse — matches the reversed internal entries format *)
     let rec parse acc count = function
-      | [] -> Ok { entries = acc; size = count; on_append = None; mutex = Eio.Mutex.create () }
+      | [] -> Ok { state = Atomic.make (acc, count); on_append = None }
       | item :: rest ->
         (match event_of_json item with
          | Ok evt -> parse (evt :: acc) (count + 1) rest
@@ -398,7 +402,7 @@ let save_to_file journal path =
 
 let load_from_file path =
   if not (Sys.file_exists path)
-  then Ok { entries = []; size = 0; on_append = None; mutex = Eio.Mutex.create () }
+  then Ok { state = Atomic.make ([], 0); on_append = None }
   else (
     try
       let ic = open_in path in
@@ -423,7 +427,7 @@ let load_from_file path =
                     | Ok evt -> read_lines (evt :: acc) (count + 1) (line_no + 1)
                     | Error e -> Error (Printf.sprintf "line %d: %s" line_no e)))
              | exception End_of_file ->
-               Ok { entries = acc; size = count; on_append = None; mutex = Eio.Mutex.create () }
+               Ok { state = Atomic.make (acc, count); on_append = None }
            in
            read_lines [] 0 1)
     with

--- a/lib/durable_event.ml
+++ b/lib/durable_event.ml
@@ -78,13 +78,19 @@ let create ?on_append () = { state = Atomic.make ([], 0); on_append }
 
 let append journal event =
   let rec loop () =
-    let old_entries, old_size = Atomic.get journal.state in
+    let old_state = Atomic.get journal.state in
+    let old_entries, old_size = old_state in
     let new_state = event :: old_entries, old_size + 1 in
-    if Atomic.compare_and_set journal.state (old_entries, old_size) new_state
-    then Option.iter (fun f -> f event) journal.on_append
-    else loop ()
+    if not (Atomic.compare_and_set journal.state old_state new_state) then loop ()
   in
-  loop ()
+  loop ();
+  (* Fan-out callbacks must not be able to poison durable state. If a sink
+     raises, the event is already recorded; ignore the projection failure. *)
+  Option.iter
+    (fun f ->
+       try f event with
+       | _ -> ())
+    journal.on_append
 ;;
 
 let events journal =

--- a/test/test_durable_event.ml
+++ b/test/test_durable_event.ml
@@ -28,6 +28,26 @@ let test_append_and_events () =
   | _ -> fail "expected chronological order"
 ;;
 
+let test_parallel_append_preserves_all_events () =
+  let j = Durable_event.create () in
+  let domain_count = 4 in
+  let events_per_domain = 250 in
+  let workers =
+    List.init domain_count (fun domain_idx ->
+      Domain.spawn (fun () ->
+        for idx = 1 to events_per_domain do
+          let turn = (domain_idx * events_per_domain) + idx in
+          Durable_event.append
+            j
+            (Turn_started { turn; timestamp = ts +. float_of_int turn })
+        done))
+  in
+  List.iter (fun worker -> Domain.join worker) workers;
+  let expected = domain_count * events_per_domain in
+  check int "parallel append length" expected (Durable_event.length j);
+  check int "parallel append events" expected (List.length (Durable_event.events j))
+;;
+
 let test_last_timestamp () =
   let j = Durable_event.create () in
   Durable_event.append j (Turn_started { turn = 1; timestamp = ts });
@@ -266,6 +286,19 @@ let test_no_callback_default () =
   check int "still appends" 1 (Durable_event.length j)
 ;;
 
+let test_callback_exception_does_not_rollback_append () =
+  let j =
+    Durable_event.create
+      ~on_append:(fun _event -> failwith "projection sink unavailable")
+      ()
+  in
+  Durable_event.append j (Turn_started { turn = 1; timestamp = ts });
+  check int "journal still records event" 1 (Durable_event.length j);
+  match Durable_event.events j with
+  | [ Durable_event.Turn_started { turn = 1; _ } ] -> ()
+  | _ -> fail "expected appended event to remain visible"
+;;
+
 (* ── Persistence ──────────────────────────────────── *)
 
 let test_save_and_load_roundtrip () =
@@ -327,11 +360,19 @@ let () =
     [ ( "journal"
       , [ test_case "empty" `Quick test_empty_journal
         ; test_case "append and events" `Quick test_append_and_events
+        ; test_case
+            "parallel append preserves all events"
+            `Quick
+            test_parallel_append_preserves_all_events
         ; test_case "last_timestamp" `Quick test_last_timestamp
         ] )
     ; ( "on_append"
       , [ test_case "callback fires" `Quick test_on_append_fires
         ; test_case "no callback default" `Quick test_no_callback_default
+        ; test_case
+            "callback exception does not rollback append"
+            `Quick
+            test_callback_exception_does_not_rollback_append
         ] )
     ; ( "idempotency"
       , [ test_case "deterministic key" `Quick test_idempotency_key_deterministic


### PR DESCRIPTION
## Problem

Parallel tool execution dispatches tool handlers across multiple fibers/domains that can append to the same durable event journal. The old journal state was mutable and unsynchronized, and the first lock-free rewrite accidentally compared against a freshly constructed tuple in `Atomic.compare_and_set`, which could spin forever on the first append.

## Change

- Store journal state as one atomic `(reversed_entries, size)` pair.
- Preserve the exact fetched state object as the CAS expected value before constructing the next state.
- Keep reads snapshot-based via one `Atomic.get`.
- Make `on_append` projection callbacks fail-open after the durable event is recorded, so a projection sink cannot poison journal state.
- Add regression coverage for scheduler-free append, parallel append preservation, and callback exception rollback behavior.

## Verification

- `ocamlformat --check lib/durable_event.ml test/test_durable_event.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_durable_event.exe`
- `./_build/default/test/test_durable_event.exe`

Refs: audit finding OAS-mutable-ref-001