### PR TITLE
fix(agent): serialize tool-name alias registry

### DIFF
--- a/lib/agent/agent_tool_name_alias.ml
+++ b/lib/agent/agent_tool_name_alias.ml
@@ -112,9 +112,14 @@ let normalize_execute_input = function
 (** Mutable registry for consumer-registered aliases.
     Maps alias -> canonical tool name. *)
 let registry = Hashtbl.create 16
+let registry_mu = Eio.Mutex.create ()
 
-let register_alias ~alias ~canonical = Hashtbl.replace registry alias canonical
-let resolve_alias alias = Hashtbl.find_opt registry alias
+let register_alias ~alias ~canonical =
+  Eio.Mutex.use_rw ~protect:true registry_mu
+  @@ fun () -> Hashtbl.replace registry alias canonical
+
+let resolve_alias alias =
+  Eio.Mutex.use_ro registry_mu @@ fun () -> Hashtbl.find_opt registry alias
 
 let resolve ~requested ~input =
   match requested with

--- a/lib/agent/agent_tool_name_alias.ml
+++ b/lib/agent/agent_tool_name_alias.ml
@@ -112,14 +112,17 @@ let normalize_execute_input = function
 (** Mutable registry for consumer-registered aliases.
     Maps alias -> canonical tool name. *)
 let registry = Hashtbl.create 16
+
 let registry_mu = Eio.Mutex.create ()
 
 let register_alias ~alias ~canonical =
   Eio.Mutex.use_rw ~protect:true registry_mu
   @@ fun () -> Hashtbl.replace registry alias canonical
+;;
 
 let resolve_alias alias =
   Eio.Mutex.use_ro registry_mu @@ fun () -> Hashtbl.find_opt registry alias
+;;
 
 let resolve ~requested ~input =
   match requested with

--- a/lib/agent/agent_tool_name_alias.ml
+++ b/lib/agent/agent_tool_name_alias.ml
@@ -109,20 +109,23 @@ let normalize_execute_input = function
   | input -> input
 ;;
 
-(** Mutable registry for consumer-registered aliases.
-    Maps alias -> canonical tool name. *)
-let registry = Hashtbl.create 16
-
-let registry_mu = Eio.Mutex.create ()
+(** Lock-free registry for consumer-registered aliases.
+    Maps alias -> canonical tool name. Stored as an atomic association list
+    so reads and writes are safe from parallel tool-execution fibers without
+    requiring an Eio scheduler (the registry may be accessed from tests that
+    run outside of a scheduler). *)
+let registry : (string * string) list Atomic.t = Atomic.make []
 
 let register_alias ~alias ~canonical =
-  Eio.Mutex.use_rw ~protect:true registry_mu
-  @@ fun () -> Hashtbl.replace registry alias canonical
+  let rec loop () =
+    let old = Atomic.get registry in
+    let new_registry = (alias, canonical) :: List.remove_assoc alias old in
+    if Atomic.compare_and_set registry old new_registry then () else loop ()
+  in
+  loop ()
 ;;
 
-let resolve_alias alias =
-  Eio.Mutex.use_ro registry_mu @@ fun () -> Hashtbl.find_opt registry alias
-;;
+let resolve_alias alias = List.assoc_opt alias (Atomic.get registry)
 
 let resolve ~requested ~input =
   match requested with


### PR DESCRIPTION
## Problem

The process-wide registry hash table for tool-name aliases was accessed without synchronization. Concurrent registration/lookup from parallel tool-execution fibers could corrupt the buckets.

## Change

- Add an [Eio.Mutex] for the alias registry.
- Protect both [register_alias] and [resolve_alias].

## Verification

- [x] `scripts/dune-local.sh build lib/agent_sdk.a` passes.

Refs: audit finding OAS-mutable-ref-003