### PR TITLE
refactor(pipeline): unify proactive and emergency compaction bodies

### DIFF
--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -576,143 +576,43 @@ let publish_context_window_usage agent ~estimated_tokens ~limit_tokens =
          })
 ;;
 
-(** Apply proactive compaction when context usage exceeds the configured
-    watermark ratio, BEFORE hitting the provider limit.  Uses
-    [Budget_strategy.phase_of_usage_ratio] to pick the lightest phase
-    that matches the current usage.  Fires PreCompact hook; respects
-    Skip.  Returns [true] if messages were actually reduced.
+(** Shared compaction body for {!proactive_compact} and
+    {!emergency_compact}.  Runs the common chain:
 
-    The raw usage ratio is remapped from [watermark, 1.0] → [0.5, 1.0]
-    before being passed to [Budget_strategy], so that crossing the
-    watermark always corresponds to the Compact phase (≥ 0.5) regardless
-    of how low the configured watermark is.
+    PreCompact hook → [Budget_strategy.reduce_for_budget] →
+    [Agent_turn.apply_context_reducer] → after-tokens guard →
+    state update → PostCompact hook → [ContextCompacted] publish →
+    [on_context_compacted] hook → journal [Checkpoint_saved] append.
 
-    @param watermark  Ratio (0.0-1.0) at which to begin compacting.
-                      Typical value: 0.7 (= 70 % of context window).
-    @since Phase 2 — proactive compaction *)
-let proactive_compact ?raw_trace_run agent ~watermark () =
+    The two call sites differ only in:
+    - [strategy_ratio]: usage ratio handed to [Budget_strategy]
+      (watermark-remapped for proactive, [1.0] for emergency);
+    - [budget_tokens]: budget reported in the PreCompact payload;
+    - [phase]: label carried by PostCompact / ContextCompacted /
+      OnContextCompacted;
+    - [checkpoint_prefix]: journal checkpoint id is
+      ["compact-<prefix>-<turn>"].
+
+    Fires PreCompact hook; respects Skip.  Returns [true] if messages
+    were actually reduced. *)
+let compact_messages
+      ?raw_trace_run
+      agent
+      ~strategy_ratio
+      ~budget_tokens
+      ~phase
+      ~checkpoint_prefix
+      ()
+  =
   let messages = agent.state.messages in
   let est_tokens = total_prompt_tokens_for_agent agent messages in
-  let context_window_tokens = proactive_context_window_tokens agent in
-  let usage_ratio = float_of_int est_tokens /. float_of_int context_window_tokens in
-  if usage_ratio < watermark
-  then false
-  else (
-    (* Remap [watermark, 1.0] → [0.5, 1.0] so Budget_strategy always picks
-       at least the Compact phase when the watermark is crossed.  Without
-       this, a watermark < 0.5 would never trigger Budget_strategy because
-       phase_of_usage_ratio returns Full for ratios below 0.5. *)
-    let scaled_ratio =
-      let watermark_range = 1.0 -. watermark in
-      if watermark_range <= 0.0
-      then 1.0
-      else 0.5 +. (0.5 *. (usage_ratio -. watermark) /. watermark_range)
-    in
-    let hook_decision =
-      invoke_hook_with_trace
-        agent
-        ?raw_trace_run
-        ~hook_name:"pre_compact"
-        agent.options.hooks.pre_compact
-        (Hooks.PreCompact
-           { messages
-           ; estimated_tokens = est_tokens
-           ; budget_tokens = context_window_tokens
-           })
-    in
-    match hook_decision with
-    | Hooks.Skip -> false
-    | _ ->
-      let reduced =
-        Budget_strategy.reduce_for_budget
-          ?summarizer:agent.options.summarizer
-          ~usage_ratio:scaled_ratio
-          ~messages
-          ()
-      in
-      let reduced =
-        Agent_turn.apply_context_reducer
-          ~messages:reduced
-          ~context_reducer:agent.options.context_reducer
-      in
-      let after_tokens = total_prompt_tokens_for_agent agent reduced in
-      if after_tokens >= est_tokens
-      then false
-      else (
-        let phase = Printf.sprintf "proactive(%.0f%%)" (usage_ratio *. 100.0) in
-        update_state agent (fun s -> { s with messages = reduced });
-        ignore
-          (invoke_hook_with_trace
-             agent
-             ?raw_trace_run
-             ~hook_name:"post_compact"
-             agent.options.hooks.post_compact
-             (Hooks.PostCompact
-                { before_messages = messages
-                ; after_messages = reduced
-                ; before_tokens = est_tokens
-                ; after_tokens
-                ; phase
-                }));
-        (match agent.options.event_bus with
-         | Some bus ->
-           safe_publish
-             bus
-             { meta = Pipeline_common.event_envelope agent
-             ; payload =
-                 ContextCompacted
-                   { agent_name = agent.state.config.name
-                   ; before_tokens = est_tokens
-                   ; after_tokens
-                   ; phase
-                   }
-             }
-         | None -> ());
-        let _ : Hooks.hook_decision =
-          Hooks.invoke
-            agent.options.hooks.on_context_compacted
-            (Hooks.OnContextCompacted
-               { agent_name = agent.state.config.name
-               ; before_tokens = est_tokens
-               ; after_tokens
-               ; phase
-               })
-        in
-        (match agent.options.journal with
-         | Some j ->
-           Durable_event.append
-             j
-             (Checkpoint_saved
-                { checkpoint_id =
-                    Printf.sprintf "compact-proactive-%d" agent.state.turn_count
-                ; timestamp = Unix.gettimeofday ()
-                })
-         | None -> ());
-        true))
-;;
-
-(* ── Emergency compaction ────────────────────────────────── *)
-
-(** Apply emergency compaction to stored messages when context overflow
-    is detected. Uses Budget_strategy Emergency phase (Summarize_old +
-    aggressive tool pruning). Fires PreCompact hook; respects Skip.
-    Returns [true] if messages were actually reduced. *)
-let emergency_compact ?raw_trace_run agent ?limit () =
-  let messages = agent.state.messages in
-  let est_tokens = total_prompt_tokens_for_agent agent messages in
-  let budget =
-    match limit with
-    | Some l -> l
-    | None -> est_tokens
-  in
   let hook_decision =
     invoke_hook_with_trace
       agent
       ?raw_trace_run
       ~hook_name:"pre_compact"
       agent.options.hooks.pre_compact
-      (Hooks.PreCompact
-         { messages; estimated_tokens = est_tokens; budget_tokens = budget })
+      (Hooks.PreCompact { messages; estimated_tokens = est_tokens; budget_tokens })
   in
   match hook_decision with
   | Hooks.Skip -> false
@@ -720,7 +620,7 @@ let emergency_compact ?raw_trace_run agent ?limit () =
     let reduced =
       Budget_strategy.reduce_for_budget
         ?summarizer:agent.options.summarizer
-        ~usage_ratio:1.0
+        ~usage_ratio:strategy_ratio
         ~messages
         ()
     in
@@ -733,7 +633,6 @@ let emergency_compact ?raw_trace_run agent ?limit () =
     if after_tokens >= est_tokens
     then false
     else (
-      let phase = "emergency" in
       update_state agent (fun s -> { s with messages = reduced });
       ignore
         (invoke_hook_with_trace
@@ -778,11 +677,76 @@ let emergency_compact ?raw_trace_run agent ?limit () =
            j
            (Checkpoint_saved
               { checkpoint_id =
-                  Printf.sprintf "compact-emergency-%d" agent.state.turn_count
+                  Printf.sprintf "compact-%s-%d" checkpoint_prefix agent.state.turn_count
               ; timestamp = Unix.gettimeofday ()
               })
        | None -> ());
       true)
+;;
+
+(** Apply proactive compaction when context usage exceeds the configured
+    watermark ratio, BEFORE hitting the provider limit.  Uses
+    [Budget_strategy.phase_of_usage_ratio] to pick the lightest phase
+    that matches the current usage.  Fires PreCompact hook; respects
+    Skip.  Returns [true] if messages were actually reduced.
+
+    The raw usage ratio is remapped from [watermark, 1.0] → [0.5, 1.0]
+    before being passed to [Budget_strategy], so that crossing the
+    watermark always corresponds to the Compact phase (≥ 0.5) regardless
+    of how low the configured watermark is.
+
+    @param watermark  Ratio (0.0-1.0) at which to begin compacting.
+                      Typical value: 0.7 (= 70 % of context window).
+    @since Phase 2 — proactive compaction *)
+let proactive_compact ?raw_trace_run agent ~watermark () =
+  let messages = agent.state.messages in
+  let est_tokens = total_prompt_tokens_for_agent agent messages in
+  let context_window_tokens = proactive_context_window_tokens agent in
+  let usage_ratio = float_of_int est_tokens /. float_of_int context_window_tokens in
+  if usage_ratio < watermark
+  then false
+  else (
+    (* Remap [watermark, 1.0] → [0.5, 1.0] so Budget_strategy always picks
+       at least the Compact phase when the watermark is crossed.  Without
+       this, a watermark < 0.5 would never trigger Budget_strategy because
+       phase_of_usage_ratio returns Full for ratios below 0.5. *)
+    let scaled_ratio =
+      let watermark_range = 1.0 -. watermark in
+      if watermark_range <= 0.0
+      then 1.0
+      else 0.5 +. (0.5 *. (usage_ratio -. watermark) /. watermark_range)
+    in
+    let phase = Printf.sprintf "proactive(%.0f%%)" (usage_ratio *. 100.0) in
+    compact_messages
+      ?raw_trace_run
+      agent
+      ~strategy_ratio:scaled_ratio
+      ~budget_tokens:context_window_tokens
+      ~phase
+      ~checkpoint_prefix:"proactive"
+      ())
+;;
+
+(* ── Emergency compaction ────────────────────────────────── *)
+
+(** Apply emergency compaction to stored messages when context overflow
+    is detected. Uses Budget_strategy Emergency phase (Summarize_old +
+    aggressive tool pruning). Fires PreCompact hook; respects Skip.
+    Returns [true] if messages were actually reduced. *)
+let emergency_compact ?raw_trace_run agent ?limit () =
+  let budget_tokens =
+    match limit with
+    | Some l -> l
+    | None -> total_prompt_tokens_for_agent agent agent.state.messages
+  in
+  compact_messages
+    ?raw_trace_run
+    agent
+    ~strategy_ratio:1.0
+    ~budget_tokens
+    ~phase:"emergency"
+    ~checkpoint_prefix:"emergency"
+    ()
 ;;
 
 (* ── Pipeline coordinator ────────────────────────────────── *)

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -568,6 +568,206 @@ let test_agent_run_context_overflow_auto_retry_can_be_disabled () =
   | Exit -> ()
 ;;
 
+(* ── Compaction path labels: phase string + checkpoint prefix ── *)
+
+(** History with a large tool result so both Budget_strategy phases
+    (Compact: PruneToolOutputs / Emergency: Summarize_old + prune)
+    actually reduce the estimated token count. *)
+let big_tool_history () =
+  [ { Types.role = User
+    ; content = [ Text "summarize the large result" ]
+    ; name = None
+    ; tool_call_id = None
+    ; metadata = []
+    }
+  ; { Types.role = Assistant
+    ; content =
+        [ ToolUse
+            { id = "tool_1"; name = "search"; input = `Assoc [ "q", `String "logs" ] }
+        ]
+    ; name = None
+    ; tool_call_id = None
+    ; metadata = []
+    }
+  ; { Types.role = User
+    ; content =
+        [ ToolResult
+            { tool_use_id = "tool_1"
+            ; content = String.make 20000 'x'
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
+        ]
+    ; name = None
+    ; tool_call_id = None
+    ; metadata = []
+    }
+  ]
+;;
+
+let compact_checkpoint_ids journal =
+  List.filter_map
+    (function
+      | Durable_event.Checkpoint_saved { checkpoint_id; _ }
+        when String.starts_with ~prefix:"compact-" checkpoint_id -> Some checkpoint_id
+      | _ -> None)
+    (Durable_event.events journal)
+;;
+
+let test_proactive_compaction_phase_and_checkpoint () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url =
+      start_multi_mock
+        ~sw
+        ~net:env#net
+        ~port:20030
+        [ provider_d_text_response "compacted" ]
+    in
+    let provider : Provider.config =
+      { provider = Provider.Local { base_url = url }
+      ; model_id = "mock-model"
+      ; api_key_env = ""
+      }
+    in
+    let post_compacts = ref [] in
+    let hooks =
+      { Hooks.empty with
+        post_compact =
+          Some
+            (function
+              | Hooks.PostCompact { phase; before_tokens; _ } ->
+                post_compacts := (phase, before_tokens) :: !post_compacts;
+                Hooks.Continue
+              | _ -> Hooks.Continue)
+      }
+    in
+    let journal = Durable_event.create () in
+    let config =
+      { Types.default_config with
+        name = "proactive-compact-owner"
+      ; max_turns = 3
+      ; context_compact_ratio = Some 0.01
+      }
+    in
+    let options =
+      { Agent.default_options with
+        base_url = url
+      ; provider = Some provider
+      ; hooks
+      ; journal = Some journal
+      }
+    in
+    let agent = Agent.create ~net:env#net ~config ~options () in
+    Agent.update_state agent (fun state -> { state with messages = big_tool_history () });
+    (match Agent.run ~sw agent "continue" with
+     | Error e -> fail (Error.to_string e)
+     | Ok _ ->
+       let window =
+         Provider.resolve_max_context_tokens ~fallback:128_000 (Some provider)
+       in
+       check bool "post_compact fired" true (!post_compacts <> []);
+       List.iter
+         (fun (phase, before_tokens) ->
+            let expected =
+              Printf.sprintf
+                "proactive(%.0f%%)"
+                (float_of_int before_tokens /. float_of_int window *. 100.0)
+            in
+            check string "proactive phase label" expected phase)
+         !post_compacts;
+       let ids = compact_checkpoint_ids journal in
+       check bool "compaction checkpoint recorded" true (ids <> []);
+       List.iter
+         (fun id ->
+            check
+              bool
+              (Printf.sprintf "checkpoint id %s has proactive prefix" id)
+              true
+              (String.starts_with ~prefix:"compact-proactive-" id))
+         ids);
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
+let test_emergency_compaction_phase_and_checkpoint () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let overflow_body =
+      {|{"error":{"message":"This model's maximum context length is 128000 tokens. available context size (128)"}}|}
+    in
+    let url, calls =
+      start_status_mock
+        ~sw
+        ~net:env#net
+        ~port:20031
+        [ `Bad_request, overflow_body; `OK, provider_d_text_response "recovered" ]
+    in
+    let provider : Provider.config =
+      { provider = Provider.Local { base_url = url }
+      ; model_id = "mock-model"
+      ; api_key_env = ""
+      }
+    in
+    let post_compacts = ref [] in
+    let hooks =
+      { Hooks.empty with
+        post_compact =
+          Some
+            (function
+              | Hooks.PostCompact { phase; _ } ->
+                post_compacts := phase :: !post_compacts;
+                Hooks.Continue
+              | _ -> Hooks.Continue)
+      }
+    in
+    let journal = Durable_event.create () in
+    let config =
+      { Types.default_config with name = "emergency-compact-owner"; max_turns = 3 }
+    in
+    let options =
+      { Agent.default_options with
+        base_url = url
+      ; provider = Some provider
+      ; hooks
+      ; journal = Some journal
+      }
+    in
+    (* auto_context_overflow_retry defaults to true: the first 400
+       overflow response triggers emergency compaction + retry. *)
+    let agent = Agent.create ~net:env#net ~config ~options () in
+    Agent.update_state agent (fun state -> { state with messages = big_tool_history () });
+    (match Agent.run ~sw agent "continue" with
+     | Error e -> fail (Error.to_string e)
+     | Ok _ ->
+       check bool "provider retried after compaction" true (Atomic.get calls >= 2);
+       check bool "post_compact fired" true (!post_compacts <> []);
+       List.iter
+         (fun phase -> check string "emergency phase label" "emergency" phase)
+         !post_compacts;
+       let ids = compact_checkpoint_ids journal in
+       check bool "compaction checkpoint recorded" true (ids <> []);
+       List.iter
+         (fun id ->
+            check
+              bool
+              (Printf.sprintf "checkpoint id %s has emergency prefix" id)
+              true
+              (String.starts_with ~prefix:"compact-emergency-" id))
+         ids);
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
 (* ── Test 10: Agent with guardrails ──────────────────── *)
 
 let test_agent_run_guardrails () =
@@ -621,6 +821,16 @@ let () =
         ; test_case "pre_tool hook" `Quick test_agent_run_pre_tool_hook
         ] )
     ; "streaming", [ test_case "run_stream" `Quick test_agent_run_stream ]
+    ; ( "compaction"
+      , [ test_case
+            "proactive phase and checkpoint labels"
+            `Quick
+            test_proactive_compaction_phase_and_checkpoint
+        ; test_case
+            "emergency phase and checkpoint labels"
+            `Quick
+            test_emergency_compaction_phase_and_checkpoint
+        ] )
     ; ( "hooks_and_reducers"
       , [ test_case "hooks" `Quick test_agent_run_with_hooks
         ; test_case "context reducer" `Quick test_agent_run_with_reducer


### PR DESCRIPTION
## 문제

audit T11 (verified): `lib/pipeline/pipeline.ml`의 `proactive_compact`(:593-692)와 `emergency_compact`(:700-786)는 본문 약 87줄 중 약 80줄(~91%)이 동일한 체인을 중복 구현하고 있었다. 두 경로의 실제 차이는 다음 3가지뿐:

- `Budget_strategy.reduce_for_budget`에 넘기는 usage ratio (proactive: watermark-remap된 `scaled_ratio` / emergency: `1.0`)
- phase 라벨 (`"proactive(N%)"` / `"emergency"`)
- journal checkpoint id prefix (`compact-proactive-` / `compact-emergency-`)

중복된 본문은 한쪽만 수정되는 drift의 원인이 된다.

## 수정

- `compact_messages ?raw_trace_run agent ~strategy_ratio ~budget_tokens ~phase ~checkpoint_prefix ()` 공유 함수 추출. 공통 체인 전체를 포함: PreCompact hook → `reduce_for_budget` → `apply_context_reducer` → after-tokens guard → `update_state` → PostCompact hook → `ContextCompacted` publish → `on_context_compacted` hook → journal `Checkpoint_saved` append.
- `proactive_compact` = watermark gate + ratio remap + phase 라벨 생성 후 `compact_messages` 호출.
- `emergency_compact` = `?limit` 기반 budget 계산 후 `~strategy_ratio:1.0`으로 호출.
- 동작 변경 없음. proactive gate가 async validation 전/후 두 번 도는 설계(Stage 2.3/2.7, validators가 메시지를 주입할 수 있음)는 의도된 것으로 건드리지 않음.
- 두 함수는 `pipeline.mli`에 노출되지 않는 내부 함수 — public API 변경 없음.
- 기존에 두 경로의 phase/checkpoint 라벨을 구분하는 동작 테스트가 없어, `test/test_agent_pipeline.ml`에 두 경로를 실제 파이프라인(`Agent.run` + mock HTTP)으로 구동해 phase 문자열 포맷과 checkpoint prefix를 고정하는 테스트 2건 추가.

## 검증

실행 명령과 결과 (worktree, `DUNE_CACHE=disabled`):

- `dune build --root . @check` — 통과 (출력 없음)
- `dune build --root . @fmt --auto-promote` — 적용 (무관한 `test/test_agent_sdk.ml`의 기존 fmt drift는 revert하여 diff에서 제외)
- `dune build --root .` (default target, 최종 게이트) — 통과 (출력 없음)
- focused 테스트 실행:
  - `test_agent_pipeline.exe` — `Test Successful in 4.711s. 13 tests run.` (신규 compaction 2건 포함)
  - `test_hooks.exe` — 33 tests, `test_event_integration.exe` — 4, `test_budget_strategy.exe` — 31, `test_context_reducer.exe` — 63, `test_multivendor_events.exe` — 5, `test_event_forward.exe` — 27. 전부 `Test Successful`. 기존 compaction 테스트는 수정 없이 통과.
- mutation check: `proactive_compact`의 `~checkpoint_prefix:"proactive"`를 임시로 다른 문자열로 바꾸면 신규 테스트가 `1 failure! in 0.575s. 2 tests run.`로 실패함을 확인 후 revert — 테스트가 라벨 회귀를 실제로 잡는다.

## 근거

- 중복 본문: 변경 전 `lib/pipeline/pipeline.ml:611-691` (proactive) vs `:708-785` (emergency) — PreCompact/reduce/reducer/guard/update/PostCompact/publish/on_context_compacted/journal 체인 동일.
- 차이 3종: `:629` (`~usage_ratio:scaled_ratio`) vs `:723` (`~usage_ratio:1.0`), `:642` vs `:736` (phase), `:687` vs `:781` (checkpoint id).
- double-gate 의도 근거: `lib/pipeline/pipeline.ml:896-898` Stage 2.7 주석 ("validators can inject messages") — 본 PR에서 미변경.
- 신규 테스트: `test/test_agent_pipeline.ml` `compaction` 그룹 (`test_proactive_compaction_phase_and_checkpoint`, `test_emergency_compaction_phase_and_checkpoint`).

audit T11 인용: verified ~91% duplication; double-gate is intentional design and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
