### PR TITLE
fix(streaming): drive thinking-only cutoff from injected Eio clock

### DIFF
--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -476,6 +476,20 @@ let complete_stream_http
                    including hidden reasoning. The two refs together
                    distinguish prefill from generation latency. *)
                 let now = Unix.gettimeofday () in
+                (* Thinking-only cutoff timestamps follow the injected Eio
+                   clock when one is available, so a mock clock controls the
+                   cutoff in tests. The telemetry stamps below stay on
+                   [Unix.gettimeofday] because they are offsets against the
+                   wall-time [t0]. With the default Eio clock both sources
+                   advance identically, so production behaviour is unchanged.
+                   [Unix.gettimeofday] remains only as the clock-less
+                   fallback (clock-less callers have no idle protection
+                   either; see the [stream_idle_timeout_s] default above). *)
+                let cutoff_now =
+                  match clock with
+                  | Some c -> Eio.Time.now c
+                  | None -> now
+                in
                 if events <> [] && Option.is_none !first_event_at_ref
                 then (
                   first_event_at_ref := Some now;
@@ -504,7 +518,7 @@ let complete_stream_http
                        if
                          Option.is_none !first_deliverable_at_ref
                          && Option.is_none !thinking_only_started_at_ref
-                       then thinking_only_started_at_ref := Some now;
+                       then thinking_only_started_at_ref := Some cutoff_now;
                        incr n_thinking
                      | `Answer ->
                        stream_idle_state := Http_client.Streaming_answer;
@@ -544,7 +558,7 @@ let complete_stream_http
                    when Streaming.thinking_only_timeout_exceeded
                           ~timeout_s
                           ~started_at
-                          ~now -> raise Eio.Time.Timeout
+                          ~now:cutoff_now -> raise Eio.Time.Timeout
                  | Some _, _, _ | None, _, _ -> ());
                 if events <> []
                 then

--- a/test/dune
+++ b/test/dune
@@ -464,7 +464,7 @@
 (test
  (name test_complete_http)
  (modules test_complete_http)
- (libraries agent_sdk llm_provider alcotest eio_main))
+ (libraries agent_sdk llm_provider alcotest eio_main eio.mock))
 
 (test
  (name test_llm_provider_cov)

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -1036,6 +1036,54 @@ let provider_a_sse_frame_stop =
    data: {\"type\":\"message_stop\"}\n\n"
 ;;
 
+let provider_a_sse_frame_thinking_block_start =
+  "event: content_block_start\n\
+   data: \
+   {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n\n"
+;;
+
+let provider_a_sse_frame_thinking_delta text =
+  Printf.sprintf
+    "event: content_block_delta\n\
+     data: \
+     {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"%s\"}}\n\n"
+    text
+;;
+
+(* Thinking-only prelude (block 0) followed by a deliverable text answer
+   (block 1). Used by the mock-clock cutoff tests: the cutoff must fire
+   while still inside the block-0 thinking deltas, and the trailing text
+   answer lets the no-advance control finalize [Ok]. *)
+let provider_a_thinking_then_answer_frames ~frame_gap_s =
+  [ 0.0, provider_a_sse_frame_message_start
+  ; frame_gap_s, provider_a_sse_frame_thinking_block_start
+  ; frame_gap_s, provider_a_sse_frame_thinking_delta "t1"
+  ; frame_gap_s, provider_a_sse_frame_thinking_delta "t2"
+  ; frame_gap_s, provider_a_sse_frame_thinking_delta "t3"
+  ; ( frame_gap_s
+    , "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n"
+    )
+  ; ( frame_gap_s
+    , "event: content_block_start\n\
+       data: \
+       {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n"
+    )
+  ; ( frame_gap_s
+    , "event: content_block_delta\n\
+       data: \
+       {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"answer\"}}\n\n"
+    )
+  ; ( frame_gap_s
+    , "event: content_block_stop\n\
+       data: {\"type\":\"content_block_stop\",\"index\":1}\n\n\
+       event: message_delta\n\
+       data: \
+       {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\n\
+       event: message_stop\n\
+       data: {\"type\":\"message_stop\"}\n\n" )
+  ]
+;;
+
 let read_http_request flow =
   let reader = Eio.Buf_read.of_flow flow ~max_size:8192 in
   let _request_line = Eio.Buf_read.line reader in
@@ -1350,6 +1398,122 @@ let test_complete_stream_idle_timeout_still_fires () =
   | Exit -> ()
 ;;
 
+(* T12 audit — the thinking-only cutoff (#2011) must read the injected
+   Eio clock, not [Unix.gettimeofday]. A mock clock drives the cutoff:
+   each hidden-reasoning delta advances mock time by 6s. Every
+   inter-event gap (6s) stays under the 10s idle deadline — so the
+   line-idle timer cannot be the thing that fires — but the cumulative
+   thinking-only span crosses 10s on the third delta (mock 12s).
+   Wall-clock time elapsed here is milliseconds, so an implementation
+   still reading [Unix.gettimeofday] never reaches the 10s cutoff and
+   returns [Ok] — which this test rejects. *)
+let test_complete_stream_thinking_only_cutoff_follows_injected_clock () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let mock_clock = Eio_mock.Clock.make () in
+    let url =
+      start_raw_sse_server
+        ~sw
+        ~net:env#net
+        ~clock:env#clock
+        (provider_a_thinking_then_answer_frames ~frame_gap_s:0.01)
+    in
+    let config = make_config url in
+    let mock_now = ref 0.0 in
+    let on_event = function
+      | Types.ContentBlockDelta { delta = Types.ThinkingDelta _; _ } ->
+        (* [on_data] in read_sse invokes this outside any
+           [with_timeout_exn] window, so advancing the mock here cannot
+           wake the line-idle timer fiber. *)
+        mock_now := !mock_now +. 6.0;
+        Eio_mock.Clock.set_time mock_clock !mock_now
+      | _ -> ()
+    in
+    match
+      Complete.complete_stream
+        ~sw
+        ~net:env#net
+        ~clock:mock_clock
+        ~stream_idle_timeout_s:10.0
+        ~config
+        ~messages
+        ~on_event
+        ()
+    with
+    | Error
+        (Http_client.TimeoutError
+           { phase = Http_client.Stream_idle Http_client.Streaming_thinking; message }) ->
+      let prefix = "stream_idle_timeout_s deadline exceeded" in
+      check
+        bool
+        "thinking-only cutoff message"
+        true
+        (String.length message >= String.length prefix
+         && String.equal (String.sub message 0 (String.length prefix)) prefix);
+      Eio.Switch.fail sw Exit
+    | Error (Http_client.TimeoutError { phase; _ }) ->
+      fail
+        (Printf.sprintf
+           "unexpected timeout phase %s"
+           (Http_client.timeout_phase_to_label phase))
+    | Ok _ ->
+      fail "expected thinking-only cutoff via mock clock — is the cutoff on wall time?"
+    | Error _ -> fail "expected TimeoutError{phase=Stream_idle Streaming_thinking}"
+  with
+  | Exit -> ()
+;;
+
+(* Control for the test above: same stream, same mock clock, but mock
+   time is never advanced. The cutoff comparison therefore always sees
+   elapsed = 0 and the stream finalizes [Ok] with the block-1 answer,
+   pinning that the cutoff follows ONLY the injected clock. *)
+let test_complete_stream_thinking_only_cutoff_idle_without_clock_advance () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let mock_clock = Eio_mock.Clock.make () in
+    let url =
+      start_raw_sse_server
+        ~sw
+        ~net:env#net
+        ~clock:env#clock
+        (provider_a_thinking_then_answer_frames ~frame_gap_s:0.01)
+    in
+    let config = make_config url in
+    match
+      Complete.complete_stream
+        ~sw
+        ~net:env#net
+        ~clock:mock_clock
+        ~stream_idle_timeout_s:10.0
+        ~config
+        ~messages
+        ~on_event:(fun _ -> ())
+        ()
+    with
+    | Ok resp ->
+      check string "text" "answer" (text_of_response resp);
+      Eio.Switch.fail sw Exit
+    | Error err ->
+      fail
+        (Printf.sprintf
+           "expected Ok without clock advance, got %s"
+           (match err with
+            | Http_client.NetworkError { message; _ }
+            | Http_client.TimeoutError { message; _ } -> message
+            | Http_client.HttpError { code; _ } -> Printf.sprintf "HTTP %d" code
+            | Http_client.AcceptRejected { reason } -> reason
+            | Http_client.ProviderTerminal { message; _ } -> message
+            | Http_client.ProviderFailure { message; _ } -> message))
+  with
+  | Exit -> ()
+;;
+
 let test_complete_stream_metrics () =
   Eio_main.run
   @@ fun env ->
@@ -1621,6 +1785,14 @@ let () =
             "transport arm idle timeout (RFC-OAS-026)"
             `Quick
             test_complete_stream_transport_arm_idle_timeout
+        ; test_case
+            "thinking-only cutoff follows injected clock (T12)"
+            `Quick
+            test_complete_stream_thinking_only_cutoff_follows_injected_clock
+        ; test_case
+            "thinking-only cutoff idle without clock advance (T12 control)"
+            `Quick
+            test_complete_stream_thinking_only_cutoff_idle_without_clock_advance
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제

audit T12 (narrowed verdict: 3개 주장 사이트 중 실제 1개): #2011 (0302112f)이 도입한 thinking-only stream cutoff가 `?clock` 파라미터를 무시하고 `Unix.gettimeofday`로 시작 시각 스탬프와 경과 비교를 수행했다.

- `lib/llm_provider/complete_stream.ml`의 `dispatch`가 `now = Unix.gettimeofday ()`를 계산해 `thinking_only_started_at_ref := Some now`로 저장하고, `Streaming.thinking_only_timeout_exceeded ~now`에도 같은 wall-time 값을 전달.
- 그 결과 테스트에서 mock Eio clock으로 cutoff를 제어할 수 없었다. 프로덕션에서는 Eio 기본 clock도 wall time이라 동작 차이는 없다.
- audit이 지목했던 다른 `Unix.gettimeofday` 사용처(t0/TTFT/total_ms 등)는 telemetry wall-time 오프셋으로 정상 — 이번 수정 범위에서 제외.

## 수정

- `dispatch` 진입 시 `cutoff_now`를 계산: clock이 주어지면 `Eio.Time.now clock`, 없으면 기존 `Unix.gettimeofday` 폴백 (clock 없는 호출자는 idle 보호도 없는 기존 의미 유지, 주석으로 명시).
- thinking-only 시작 스탬프(`thinking_only_started_at_ref := Some cutoff_now`)와 비교(`~now:cutoff_now`) 양쪽 모두 `cutoff_now` 사용. `streaming.ml`의 순수 함수 `thinking_only_timeout_exceeded`는 변경하지 않고 값만 전달.
- telemetry 스탬프(`first_event/first_token/first_deliverable`)는 wall-time `t0` 대비 오프셋이므로 `Unix.gettimeofday` 유지.

## 검증

워크트리에서 `DUNE_CACHE=disabled`로 실행:

- `dune build --root . @check` — 통과 (출력 없음)
- `dune build --root . @fmt --auto-promote` — promote 후 재빌드 통과 (`test_agent_sdk.ml`의 무관한 기존 fmt drift는 revert해 범위 밖 유지)
- `dune build --root .` (default target, final gate) — 통과 (출력 없음)
- `./_build/default/test/test_complete_http.exe` — `Test Successful in 6.113s. 32 tests run.`
- `./_build/default/test/test_streaming_edge_cases.exe` — `Test Successful in 0.002s. 12 tests run.`
- **red 증명**: `git checkout origin/main -- lib/llm_provider/complete_stream.ml` 후 동일 테스트 실행 → `[FAIL] stream 7 thinking-only cutoff follows injected clock` (`ASSERT expected thinking-only cutoff via mock clock`), control(stream 8)은 OK. 수정 복원 후 9/9 green.

### 추가된 테스트 (`test/test_complete_http.ml`)

1. `thinking-only cutoff follows injected clock (T12)` — `Eio_mock.Clock`을 `~clock`으로 주입, raw SSE 서버는 실제 env clock으로 페이싱. `on_event`에서 ThinkingDelta마다 mock 시간을 6s씩 전진(각 inter-event 간격 6s < line-idle 10s → idle 타이머는 발화 불가, 누적 thinking-only 구간은 3번째 delta에서 12s ≥ 10s). 기대 결과 `TimeoutError { phase = Stream_idle Streaming_thinking }` 확인. 실제 wall-clock 경과는 ms 단위라 `Unix.gettimeofday` 구현에서는 cutoff가 발화하지 않음 → 구버전에서 red.
2. `thinking-only cutoff idle without clock advance (T12 control)` — 같은 스트림, mock 시간 무전진 → cutoff 미발화, block-1 answer로 `Ok` finalize.

`#2011`의 기존 테스트(`test/test_streaming_edge_cases.ml`의 `thinking_only_timeout_exceeded` 순수 술어 테스트)는 그대로 통과.

## 근거

- 혼입 사이트: `lib/llm_provider/complete_stream.ml:477` (`now = Unix.gettimeofday ()`), `:506` (시작 스탬프), `:537-547` (비교 + `raise Eio.Time.Timeout`) — 본 PR에서 `cutoff_now`로 교체
- 순수 술어 (변경 없음): `lib/llm_provider/streaming.ml:172-174`
- Timeout → `TimeoutError` 변환: `lib/llm_provider/complete_stream.ml:668-691` (수정 전 라인 기준)
- 도입 커밋: 0302112f `fix(streaming): bound thinking-only streams (#2011)`
- `on_event`는 `read_sse`의 `with_timeout_exn` 윈도우 밖(`on_data` 콜백)에서 호출되므로 mock `set_time`이 line-idle 타이머 fiber를 깨우지 않음: `lib/llm_provider/http_client.ml:812-850`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
