### PR TITLE
fix(agent): complete reserved-exception filter and log illegal hook decision coercion

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -15,11 +15,8 @@ let _log = Log.create ~module_name:"agent" ()
 
 let protect_stream_callback callback ev =
   try callback ev with
-  | Out_of_memory -> raise Out_of_memory
-  | Stack_overflow -> raise Stack_overflow
-  | Sys.Break -> raise Sys.Break
-  | Eio.Cancel.Cancelled _ as ex -> raise ex
   | exn ->
+    Llm_provider.Reserved_exn.reraise_if_reserved exn;
     Log.warn _log "stream callback raised" [ Log.S ("error", Printexc.to_string exn) ]
 ;;
 

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -258,7 +258,7 @@ let invoke_hook ?on_hook_invoked ~tracer ~agent_name ~turn_count ~hook_name hook
     ; links = []
     }
     (fun _ ->
-       let decision = Hooks.invoke_validated hook_opt event in
+       let decision = Hooks.invoke_validated ~hook_name hook_opt event in
        (match on_hook_invoked with
         | Some callback ->
           callback

--- a/lib/agent/agent_trace.ml
+++ b/lib/agent/agent_trace.ml
@@ -157,6 +157,16 @@ let invoke_on_run_complete agent ~ok =
          [ Log.S ("error", Printexc.to_string exn) ])
 ;;
 
+let set_terminal_lifecycle agent = function
+  | Ok _ -> set_lifecycle agent ~finished_at:(Unix.gettimeofday ()) Completed
+  | Error err ->
+    set_lifecycle
+      agent
+      ~finished_at:(Unix.gettimeofday ())
+      ~last_error:(Error.to_string err)
+      Failed
+;;
+
 let with_raw_trace_run agent user_prompt f =
   (* Reset lifecycle so each run() starts fresh — allows agent reuse
      after Completed/Failed without hitting invalid transition. *)
@@ -166,12 +176,8 @@ let with_raw_trace_run agent user_prompt f =
     let ts = Unix.gettimeofday () in
     set_lifecycle agent ~accepted_at:ts ~started_at:ts Accepted;
     let result = f None in
+    set_terminal_lifecycle agent result;
     invoke_on_run_complete agent ~ok:(Result.is_ok result);
-    let ts = Unix.gettimeofday () in
-    (match result with
-     | Ok _ -> set_lifecycle agent ~finished_at:ts Completed
-     | Error err ->
-       set_lifecycle agent ~finished_at:ts ~last_error:(Error.to_string err) Failed);
     result
   | Some sink ->
     let* active =
@@ -194,7 +200,6 @@ let with_raw_trace_run agent user_prompt f =
       ~started_at:ts
       Accepted;
     let finalize result =
-      invoke_on_run_complete agent ~ok:(Result.is_ok result);
       let final_text, stop_reason, error =
         match result with
         | Ok response ->
@@ -206,19 +211,14 @@ let with_raw_trace_run agent user_prompt f =
       in
       match Raw_trace.finish_run active ~final_text ~stop_reason ~error with
       | Ok _ ->
-        let ts = Unix.gettimeofday () in
-        (match result with
-         | Ok _ -> set_lifecycle agent ~finished_at:ts Completed
-         | Error err ->
-           set_lifecycle agent ~finished_at:ts ~last_error:(Error.to_string err) Failed);
+        set_terminal_lifecycle agent result;
+        invoke_on_run_complete agent ~ok:(Result.is_ok result);
         result
       | Error err ->
-        set_lifecycle
-          agent
-          ~finished_at:(Unix.gettimeofday ())
-          ~last_error:(Error.to_string err)
-          Failed;
-        Error err
+        let trace_error = Error err in
+        set_terminal_lifecycle agent trace_error;
+        invoke_on_run_complete agent ~ok:false;
+        trace_error
     in
     (match f (Some active) with
      | result -> finalize result

--- a/lib/agent/agent_trace.ml
+++ b/lib/agent/agent_trace.ml
@@ -43,7 +43,7 @@ let invoke_hook_with_trace agent ?raw_trace_run ~hook_name hook_opt event =
     ; links = []
     }
     (fun _ ->
-       let decision = Hooks.invoke_validated hook_opt event in
+       let decision = Hooks.invoke_validated ~hook_name hook_opt event in
        record_hook_invocation raw_trace_run ~hook_name ~decision ();
        decision)
 ;;
@@ -140,13 +140,17 @@ let trace_assistant_blocks active_run blocks =
 
 (** Invoke the optional [on_run_complete] callback.
     Exceptions are caught and logged to prevent finalization failures
-    from masking the actual run result. *)
+    from masking the actual run result.  Reserved exceptions
+    ([Out_of_memory], [Stack_overflow], [Sys.Break],
+    [Eio.Cancel.Cancelled]) still propagate; see
+    {!Llm_provider.Reserved_exn}. *)
 let invoke_on_run_complete agent ~ok =
   match agent.options.on_run_complete with
   | None -> ()
   | Some cb ->
     (try cb ok with
      | exn ->
+       Llm_provider.Reserved_exn.reraise_if_reserved exn;
        Log.warn
          _log
          "on_run_complete callback raised"

--- a/lib/base/hooks.ml
+++ b/lib/base/hooks.ml
@@ -439,11 +439,13 @@ let invoke hook_opt event =
 
 (** Invoke a hook with decision validation.
     If the hook returns an illegal decision for the stage,
-    falls back to [Continue] and calls [on_illegal] (if provided).
+    logs a warning (naming the stage, the rejected decision and, when
+    [hook_name] is given, the hook), falls back to [Continue] and calls
+    [on_illegal] (if provided).
     If the hook raises (non-reserved), the exception is logged and
     [Continue] is returned without invoking [on_illegal] (which is
     reserved for decision-shape errors, not exceptions). *)
-let invoke_validated ?on_illegal hook_opt event =
+let invoke_validated ?hook_name ?on_illegal hook_opt event =
   match hook_opt with
   | None -> Continue
   | Some f ->
@@ -456,6 +458,12 @@ let invoke_validated ?on_illegal hook_opt event =
        (match validate_decision ~stage decision with
         | Ok d -> d
         | Error msg ->
+          Eio.traceln
+            "[warn] [hooks] %s%s -- coercing to Continue"
+            msg
+            (match hook_name with
+             | Some name -> Printf.sprintf " (hook: %s)" name
+             | None -> "");
           (match on_illegal with
            | Some cb -> cb ~stage ~decision ~msg
            | None -> ());

--- a/lib/base/hooks.mli
+++ b/lib/base/hooks.mli
@@ -271,10 +271,12 @@ val legal_decisions_for_stage : string -> hook_decision_kind list
 val validate_decision : stage:string -> hook_decision -> (hook_decision, string) result
 
 (** Like [invoke], but validates the decision against the matrix.
-    Illegal decisions fall back to [Continue]; [on_illegal] is called
-    with diagnostics when a violation is detected. *)
+    Illegal decisions fall back to [Continue]; the coercion is logged as
+    a warning (including [hook_name] when given) and [on_illegal] is
+    called with diagnostics when a violation is detected. *)
 val invoke_validated
-  :  ?on_illegal:(stage:string -> decision:hook_decision -> msg:string -> unit)
+  :  ?hook_name:string
+  -> ?on_illegal:(stage:string -> decision:hook_decision -> msg:string -> unit)
   -> hook option
   -> hook_event
   -> hook_decision

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -10,11 +10,8 @@ include Complete_sampling
 
 let emit_stream_event on_event evt =
   try on_event evt with
-  | Out_of_memory -> raise Out_of_memory
-  | Stack_overflow -> raise Stack_overflow
-  | Sys.Break -> raise Sys.Break
-  | Eio.Cancel.Cancelled _ as ex -> raise ex
   | exn ->
+    Reserved_exn.reraise_if_reserved exn;
     Diag.warn
       "complete_stream"
       "stream event callback raised: %s"

--- a/lib/llm_provider/reserved_exn.ml
+++ b/lib/llm_provider/reserved_exn.ml
@@ -1,0 +1,9 @@
+(** Reserved exceptions that observer-isolation wrappers must not absorb.
+    See {!reraise_if_reserved} in the interface for the contract. *)
+
+let reraise_if_reserved exn =
+  match exn with
+  | Out_of_memory | Stack_overflow | Sys.Break | Eio.Cancel.Cancelled _ ->
+    Printexc.raise_with_backtrace exn (Printexc.get_raw_backtrace ())
+  | _ -> ()
+;;

--- a/lib/llm_provider/reserved_exn.mli
+++ b/lib/llm_provider/reserved_exn.mli
@@ -1,0 +1,18 @@
+(** Reserved exceptions that observer-isolation wrappers must not absorb.
+
+    Callback isolation sites (introduced for stream observers in #2036)
+    catch exceptions raised by user-supplied callbacks, log them, and
+    continue so a buggy observer cannot abort a run.  Four exceptions are
+    exempt and always propagate:
+
+    - [Out_of_memory], [Stack_overflow], [Sys.Break] — runtime conditions
+      that must not be swallowed
+    - [Eio.Cancel.Cancelled] — absorbing it breaks structured cancellation
+
+    @since 0.206.8 *)
+
+(** [reraise_if_reserved exn] re-raises [exn] (preserving its backtrace)
+    when it is one of the reserved exceptions above; returns [()] for any
+    other exception.  Call it first inside a catch-all handler, before
+    logging and dropping the exception. *)
+val reraise_if_reserved : exn -> unit

--- a/test/test_agent_periodic_cleanup.ml
+++ b/test/test_agent_periodic_cleanup.ml
@@ -168,6 +168,29 @@ let test_on_run_complete_failure_is_structured_log () =
     (has_log_message "on_run_complete callback raised" (get_records ()))
 ;;
 
+(* Mirror of the #2036 observer-isolation contract for [on_run_complete]:
+   generic exceptions are contained (test above), but
+   [Eio.Cancel.Cancelled] must propagate so structured cancellation is
+   not absorbed by the finalize callback. *)
+let test_on_run_complete_cancelled_propagates () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let transport = make_transport ~clock ~sleep_s:0.0 () in
+  let agent =
+    make_agent
+      ~net:(Eio.Stdenv.net env)
+      ~transport
+      ~on_run_complete:(fun _ -> raise (Eio.Cancel.Cancelled Exit))
+      ()
+  in
+  match Agent.run ~sw ~clock agent "finish" with
+  | _ -> Alcotest.fail "expected Cancelled to propagate out of run"
+  | exception Eio.Cancel.Cancelled _ -> ()
+;;
+
 let test_periodic_callback_failure_is_structured_log () =
   with_log_capture
   @@ fun get_records ->
@@ -219,6 +242,10 @@ let () =
             "on_run_complete failure uses structured log"
             `Quick
             test_on_run_complete_failure_is_structured_log
+        ; Alcotest.test_case
+            "on_run_complete Cancelled propagates"
+            `Quick
+            test_on_run_complete_cancelled_propagates
         ; Alcotest.test_case
             "periodic callback failure uses structured log"
             `Quick

--- a/test/test_agent_periodic_cleanup.ml
+++ b/test/test_agent_periodic_cleanup.ml
@@ -35,13 +35,14 @@ let make_transport ~clock ~sleep_s () : Llm_provider.Llm_transport.t =
   }
 ;;
 
-let make_agent ?on_run_complete ~net ~transport ?(periodic_callbacks = []) () =
+let make_agent ?on_run_complete ?raw_trace ~net ~transport ?(periodic_callbacks = []) () =
   let options =
     { Agent.default_options with
       provider = Some provider
     ; transport = Some transport
     ; periodic_callbacks
     ; on_run_complete
+    ; raw_trace
     }
   in
   let config =
@@ -68,6 +69,30 @@ let with_log_capture f =
 
 let has_log_message message records =
   List.exists (fun (record : Log.record) -> String.equal record.message message) records
+;;
+
+let unwrap = function
+  | Ok value -> value
+  | Error err -> Alcotest.fail (Error.to_string err)
+;;
+
+let with_temp_dir prefix f =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "%s-%d-%06x" prefix (Unix.getpid ()) (Random.bits ()))
+  in
+  Unix.mkdir dir 0o755;
+  let rec rm_rf path =
+    if Sys.file_exists path
+    then
+      if Sys.is_directory path
+      then (
+        Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+        Unix.rmdir path)
+      else Sys.remove path
+  in
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 ;;
 
 let check_callback_loop_stopped ~clock calls =
@@ -191,6 +216,43 @@ let test_on_run_complete_cancelled_propagates () =
   | exception Eio.Cancel.Cancelled _ -> ()
 ;;
 
+let test_on_run_complete_cancelled_finishes_raw_trace () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir "oas-agent-complete-cancel-raw-trace"
+  @@ fun session_root ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let transport = make_transport ~clock ~sleep_s:0.0 () in
+  let raw_trace =
+    unwrap
+      (Raw_trace.create_for_session
+         ~session_root
+         ~session_id:"callback-cancel"
+         ~agent_name:"periodic-cleanup"
+         ())
+  in
+  let agent =
+    make_agent
+      ~net:(Eio.Stdenv.net env)
+      ~transport
+      ~raw_trace
+      ~on_run_complete:(fun _ -> raise (Eio.Cancel.Cancelled Exit))
+      ()
+  in
+  (match Agent.run ~sw ~clock agent "finish" with
+   | _ -> Alcotest.fail "expected Cancelled to propagate out of raw trace run"
+   | exception Eio.Cancel.Cancelled _ -> ());
+  let records = unwrap (Raw_trace.read_all ~path:(Raw_trace.file_path raw_trace) ()) in
+  Alcotest.(check bool)
+    "raw trace was finished before callback cancellation propagated"
+    true
+    (List.exists
+       (fun (record : Raw_trace.record) -> record.record_type = Raw_trace.Run_finished)
+       records)
+;;
+
 let test_periodic_callback_failure_is_structured_log () =
   with_log_capture
   @@ fun get_records ->
@@ -246,6 +308,10 @@ let () =
             "on_run_complete Cancelled propagates"
             `Quick
             test_on_run_complete_cancelled_propagates
+        ; Alcotest.test_case
+            "on_run_complete Cancelled still finishes raw trace"
+            `Quick
+            test_on_run_complete_cancelled_finishes_raw_trace
         ; Alcotest.test_case
             "periodic callback failure uses structured log"
             `Quick

--- a/test/test_hooks.ml
+++ b/test/test_hooks.ml
@@ -520,6 +520,66 @@ let test_invoke_validated_illegal_falls_back () =
   check bool "on_illegal was called" true !called
 ;;
 
+let contains_substring ~needle haystack =
+  let n = String.length needle in
+  let h = String.length haystack in
+  let rec loop i = i + n <= h && (String.sub haystack i n = needle || loop (i + 1)) in
+  n = 0 || loop 0
+;;
+
+(** Pin the Continue coercion for every decision that is illegal at
+    pre_tool_use (AdjustParams / ElicitInput / Nudge): the decision is
+    coerced to Continue and [on_illegal] receives the stage, the
+    rejected decision and a message naming the decision kind. *)
+let test_invoke_validated_pre_tool_use_coercion_pinned () =
+  let illegal =
+    [ Hooks.AdjustParams Hooks.default_turn_params
+    ; Hooks.ElicitInput { question = "q"; schema = None; timeout_s = None }
+    ; Hooks.Nudge "nudge"
+    ]
+  in
+  List.iter
+    (fun decision ->
+       let kind_name = Hooks.decision_kind_to_string (Hooks.classify_decision decision) in
+       let hook _event = decision in
+       let seen = ref None in
+       let on_illegal ~stage ~decision ~msg = seen := Some (stage, decision, msg) in
+       let result =
+         Hooks.invoke_validated
+           ~hook_name:"test_pre_tool_use_hook"
+           ~on_illegal
+           (Some hook)
+           dummy_pre_tool_use
+       in
+       check
+         bool
+         (Printf.sprintf "%s coerced to Continue" kind_name)
+         true
+         (result = Hooks.Continue);
+       match !seen with
+       | None -> fail (Printf.sprintf "on_illegal not called for %s" kind_name)
+       | Some (stage, rejected, msg) ->
+         check string "stage reported" "pre_tool_use" stage;
+         check
+           bool
+           "rejected decision passed through"
+           true
+           (Hooks.classify_decision rejected = Hooks.classify_decision decision);
+         check
+           bool
+           (Printf.sprintf "msg names %s" kind_name)
+           true
+           (contains_substring ~needle:kind_name msg))
+    illegal
+;;
+
+(** hook_name is optional: coercion still returns Continue without it. *)
+let test_invoke_validated_coercion_without_hook_name () =
+  let hook _event = Hooks.Nudge "n" in
+  let result = Hooks.invoke_validated (Some hook) dummy_pre_tool_use in
+  check bool "coerced to Continue without hook_name" true (result = Hooks.Continue)
+;;
+
 (** Test invoke_validated with None hook. *)
 let test_invoke_validated_none () =
   let result = Hooks.invoke_validated None dummy_before_turn in
@@ -638,6 +698,14 @@ let () =
             "observe-only Continue passes"
             `Quick
             test_invoke_validated_observe_only
+        ; test_case
+            "pre_tool_use illegal decisions coerce to Continue"
+            `Quick
+            test_invoke_validated_pre_tool_use_coercion_pinned
+        ; test_case
+            "coercion without hook_name returns Continue"
+            `Quick
+            test_invoke_validated_coercion_without_hook_name
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제

감사(audit) T3/T4 후속:

- **T3 (finalize-callback re-raise filter)**: #2036 (`18eb8b45`) 이 stream observer 격리 사이트 2곳(`agent.ml` `protect_stream_callback`, `complete_stream.ml` `emit_stream_event`)에 reserved exception re-raise 필터를 도입했으나, `lib/agent/agent_trace.ml` `invoke_on_run_complete` 는 bare catch-all 로 남아 `Eio.Cancel.Cancelled` / `Out_of_memory` / `Stack_overflow` / `Sys.Break` 를 흡수했다. 판정: T3 3개 사이트 중 2개는 #2036 으로 이미 수정됨 — 본 PR 이 세 번째를 완성한다.
- **T4 (illegal hook decision coercion)**: `lib/base/hooks.ml` `invoke_validated` 는 stage 에서 불법인 decision(예: pre_tool_use 의 AdjustParams/ElicitInput/Nudge)을 Continue 로 강제하는데, 이는 hooks.mli 에 문서화된 의도된 계약이다. 다만 강제가 로그 없이 일어나 비가시적이었다 — 의도된 degradation 을 관측 가능하게 만든다.

## 수정

- `lib/llm_provider/reserved_exn.{ml,mli}` 신설: `reraise_if_reserved : exn -> unit`. 필터가 #2036 사이트 2곳에 inline 으로 중복되어 있었고 재사용 가능한 helper 가 없었으므로, 세 사이트의 최하위 공통 의존 라이브러리인 `llm_provider` 에 추출했다. `Printexc.raise_with_backtrace` 로 원본 backtrace 를 보존한다.
- 세 사이트 모두 helper 사용: `protect_stream_callback`, `emit_stream_event` (기존 inline 필터 치환, 동작 동일), `invoke_on_run_complete` (필터 신규 적용 — 격리 의도를 설명하는 doc comment 는 유지·보강).
- `Hooks.invoke_validated`: 강제(coercion) 지점에 `Eio.traceln "[warn] [hooks] ..."` 로그 추가 — stage, 거부된 decision constructor, hook 식별자(신규 optional `?hook_name`, `agent_trace.ml` / `agent_tools.ml` 두 호출처에서 in-scope `~hook_name` 전달)를 포함한다. 카운터 추가 없음, Continue 강제 동작 변경 없음.
- `agent_tools.ml:815-846` 의 도달 불가 arm 들은 건드리지 않았다.

## 검증

워크트리에서 `DUNE_CACHE=disabled` 로 실행:

- `dune build --root . @check` — 통과 (출력 없음)
- `dune build --root .` (default target, 최종 게이트) — exit 0
- `dune build --root . @fmt --auto-promote` — 본 PR 파일 전부 포맷 일치 (`test/test_agent_sdk.ml` 의 promote 는 origin/main 기존 drift 라 미포함, 아래 참고)
- `./_build/default/test/test_hooks.exe` — `Test Successful in 0.010s. 35 tests run.` (신규 2건 포함: pre_tool_use 불법 decision 3종의 Continue 강제 + on_illegal 진단 pin, hook_name 미지정 경로)
- `./_build/default/test/test_agent_periodic_cleanup.exe` — `Test Successful. 6 tests run.` (신규: `on_run_complete Cancelled propagates`; 기존 `on_run_complete failure uses structured log` 가 generic exception 격리 측을 pin)
- **음성 검증**: `invoke_on_run_complete` 의 `reraise_if_reserved` 호출을 일시 제거하고 재빌드 → 신규 테스트가 `1 failure!` 로 실패함을 확인 후 복원. 테스트가 실제로 수정을 pin 한다.
- `dune build --root . @lib/base/runtest` — hooks inline test 통과 (exit 0)
- `./_build/default/test/test_complete_http.exe` — 30 tests 통과 (#2036 stream observer 격리 테스트 포함)
- `./_build/default/test/test_approval.exe` — 18 tests 통과 (#2036 tool lifecycle callback 테스트 포함)

참고: `test/test_agent_sdk.ml` 은 origin/main 에 ocamlformat drift 가 이미 존재한다 (`@fmt --auto-promote` 가 본 변경과 무관하게 promote). 범위 밖이라 본 PR 에서 되돌렸다.

## 근거

- T3 잔여 사이트: `lib/agent/agent_trace.ml:144-154` (변경 전) — bare `| exn ->` catch-all
- #2036 패턴 원본: `lib/agent/agent.ml:16-24`, `lib/llm_provider/complete_stream.ml:11-22` (변경 전, inline 중복)
- T4 강제 지점: `lib/base/hooks.ml:446-462` (변경 전) — `validate_decision` Error 시 무로그 Continue
- T4 계약 문서: `lib/base/hooks.mli:273-275`, legal decision matrix: `lib/base/hooks.ml:354-383`
- 신규 helper: `lib/llm_provider/reserved_exn.ml` — `llm_provider` 는 `agent_sdk` (agent.ml, agent_trace.ml) 와 `complete_stream.ml` 자신의 최하위 공통 의존 (`lib/dune`, `lib/llm_provider/dune` 참조)

API 참고: `Hooks.invoke_validated` 에 optional `?hook_name` 인자가 추가되었다. 직접 호출 사이트는 변경 없이 컴파일되며(optional 인자), 함수를 first-class 값으로 기존 타입에 바인딩한 경우에만 영향이 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
