### PR TITLE
fix(test): format agent sdk alias assertion

### DIFF
--- a/test/test_agent_sdk.ml
+++ b/test/test_agent_sdk.ml
@@ -52,10 +52,7 @@ let test_consumer_tool_name_alias_registry () =
   with
   | Some ("WebSearch", `Assoc [ ("query", `String "ocaml") ]) -> ()
   | Some (name, input) ->
-    Alcotest.failf
-      "unexpected alias resolution: %s %s"
-      name
-      (Yojson.Safe.to_string input)
+    Alcotest.failf "unexpected alias resolution: %s %s" name (Yojson.Safe.to_string input)
   | None -> Alcotest.fail "registered alias did not resolve"
 ;;
 


### PR DESCRIPTION
Summary:
- Format test/test_agent_sdk.ml after #2048 so the OCaml Format check passes.

Verification:
- ocamlformat --check test/test_agent_sdk.ml
- git diff --check

Notes:
- Did not run scripts/dune-local.sh build @fmt because /tmp/me-dune-local.lock is currently held by another build.