### PR TITLE
fix(reasoning): preserve opaque thinking carriers for tool loops

### DIFF
--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -37,6 +37,62 @@ let provider_f_role_of_oas = function
   | Assistant -> "model"
 ;;
 
+let gemini_thought_signature_kind = "gemini_thought_signature"
+
+let string_field_opt key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String s) when not (Api_common.string_is_blank s) -> Some s
+     | Some _ | None -> None)
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
+;;
+
+let gemini_thought_signature_payload ~tool_use_id ~thought_signature =
+  Yojson.Safe.to_string
+    (`Assoc
+        [ "provider", `String "gemini"
+        ; "kind", `String gemini_thought_signature_kind
+        ; "tool_use_id", `String tool_use_id
+        ; "thoughtSignature", `String thought_signature
+        ])
+;;
+
+let gemini_thought_signature_carrier ~tool_use_id ~thought_signature =
+  RedactedThinking (gemini_thought_signature_payload ~tool_use_id ~thought_signature)
+;;
+
+let gemini_thought_signature_of_redacted data =
+  try
+    let json = Yojson.Safe.from_string data in
+    match string_field_opt "provider" json, string_field_opt "kind" json with
+    | Some "gemini", Some kind when String.equal kind gemini_thought_signature_kind ->
+      (match
+         ( string_field_opt "tool_use_id" json
+         , match string_field_opt "thoughtSignature" json with
+           | Some s -> Some s
+           | None -> string_field_opt "thought_signature" json )
+       with
+       | Some tool_use_id, Some thought_signature -> Some (tool_use_id, thought_signature)
+       | _ -> None)
+    | _ -> None
+  with
+  | Yojson.Json_error _ -> None
+;;
+
+let gemini_tool_signatures_of_blocks blocks =
+  let tbl = Hashtbl.create 8 in
+  List.iter
+    (function
+      | RedactedThinking data ->
+        (match gemini_thought_signature_of_redacted data with
+         | Some (tool_use_id, signature) -> Hashtbl.replace tbl tool_use_id signature
+         | None -> ())
+      | Text _ | Thinking _ | ToolUse _ | ToolResult _ | Image _ | Document _ | Audio _ ->
+        ())
+    blocks;
+  tbl
+;;
+
 (** Build a tool_use_id -> tool_name lookup table from message history.
     Gemini's functionResponse requires the function NAME, but OAS
     ToolResult only carries the tool_use_id (a UUID). *)
@@ -55,7 +111,7 @@ let build_tool_id_to_name (messages : message list) : (string, string) Hashtbl.t
 
 (* ── Content block -> Gemini part ───────────────────── *)
 
-let part_of_content_block id_to_name = function
+let part_of_content_block id_to_name tool_signatures = function
   | Text s -> Some (`Assoc [ "text", `String (Utf8_sanitize.sanitize s) ])
   | Thinking { content; _ } ->
     Some
@@ -75,8 +131,14 @@ let part_of_content_block id_to_name = function
       (`Assoc
           [ "inlineData", `Assoc [ "mimeType", `String media_type; "data", `String data ]
           ])
-  | ToolUse { name; input; _ } ->
-    Some (`Assoc [ "functionCall", `Assoc [ "name", `String name; "args", input ] ])
+  | ToolUse { id; name; input } ->
+    let fields = [ "functionCall", `Assoc [ "name", `String name; "args", input ] ] in
+    let fields =
+      match Hashtbl.find_opt tool_signatures id with
+      | Some signature -> ("thoughtSignature", `String signature) :: fields
+      | None -> fields
+    in
+    Some (`Assoc fields)
   | ToolResult { tool_use_id; content; _ } ->
     let name =
       match Hashtbl.find_opt id_to_name tool_use_id with
@@ -117,12 +179,17 @@ let contents_of_messages (messages : message list) =
   let contents = ref [] in
   List.iter
     (fun (msg : message) ->
+       let tool_signatures = gemini_tool_signatures_of_blocks msg.content in
        match msg.role with
        | System ->
-         let parts = List.filter_map (part_of_content_block id_to_name) msg.content in
+         let parts =
+           List.filter_map (part_of_content_block id_to_name tool_signatures) msg.content
+         in
          system_parts := !system_parts @ parts
        | User | Assistant | Tool ->
-         let parts = List.filter_map (part_of_content_block id_to_name) msg.content in
+         let parts =
+           List.filter_map (part_of_content_block id_to_name tool_signatures) msg.content
+         in
          if parts <> []
          then
            contents
@@ -322,22 +389,29 @@ let parse_response json =
       | _ -> []
     in
     let content =
-      List.filter_map
+      List.concat_map
         (fun part ->
            match part |> member "text" with
            | `String s ->
              let is_thought = Cli_common_json.member_bool "thought" part in
              if is_thought
-             then Some (Thinking { thinking_type = "thinking"; content = s })
-             else Some (Text s)
+             then [ Thinking { thinking_type = "thinking"; content = s } ]
+             else [ Text s ]
            | _ ->
              (match part |> member "functionCall" with
               | `Assoc _ as fc ->
                 let name = fc |> member "name" |> to_string in
                 let args = fc |> member "args" in
                 let id = Api_common.synthesize_tool_use_id ~name args in
-                Some (ToolUse { id; name; input = args })
-              | _ -> None))
+                let tool_use = ToolUse { id; name; input = args } in
+                (match part |> member "thoughtSignature" |> to_string_option with
+                 | Some thought_signature
+                   when not (Api_common.string_is_blank thought_signature) ->
+                   [ gemini_thought_signature_carrier ~tool_use_id:id ~thought_signature
+                   ; tool_use
+                   ]
+                 | Some _ | None -> [ tool_use ])
+              | _ -> []))
         parts
     in
     let finish_reason =

--- a/lib/llm_provider/backend_gemini.mli
+++ b/lib/llm_provider/backend_gemini.mli
@@ -27,6 +27,14 @@ val build_request
 (** Parse a Gemini [generateContent] response JSON into {!Types.api_response}. *)
 val parse_response : Yojson.Safe.t -> Types.api_response
 
+(** Opaque carrier payload for Gemini [thoughtSignature] values attached to
+    function-call parts. Provider request builders can preserve this through
+    {!Types.RedactedThinking} without widening the public [ToolUse] type. *)
+val gemini_thought_signature_payload
+  :  tool_use_id:string
+  -> thought_signature:string
+  -> string
+
 (** Extract [contents] list and optional [systemInstruction] from messages.
     Exposed for unit-testing the OAS-to-Gemini message mapping. *)
 val contents_of_messages : Types.message list -> Yojson.Safe.t list * Yojson.Safe.t option

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -380,6 +380,7 @@ let complete_stream_http
         | Types.ContentBlockStart _ -> `Substrate
         | Types.ContentBlockDelta { delta = TextDelta _; _ } -> `Answer
         | Types.ContentBlockDelta { delta = ThinkingDelta _; _ } -> `Thinking
+        | Types.ContentBlockDelta { delta = ThinkingSignatureDelta _; _ } -> `Substrate
         | Types.ContentBlockDelta { delta = InputJsonDelta _; _ } -> `Tool_call_arg_delta
         | Types.ContentBlockStop _ -> `Tool_call_complete
         | Types.MessageDelta _ -> `Skip

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -128,6 +128,10 @@ let finalize_stream_acc (acc : stream_acc) =
            | Some "text" -> Some (Types.Text text)
            | Some "thinking" ->
              Some (Types.Thinking { thinking_type = "thinking"; content = text })
+           | Some "redacted_thinking" ->
+             (match Hashtbl.find_opt acc.block_tool_ids idx with
+              | Some data when data <> "" -> Some (Types.RedactedThinking data)
+              | Some _ | None -> None)
            | Some "tool_use" ->
              let id =
                match Hashtbl.find_opt acc.block_tool_ids idx with

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -20,6 +20,7 @@ type stream_acc =
   ; block_types : (int, string) Hashtbl.t
   ; block_tool_ids : (int, string) Hashtbl.t
   ; block_tool_names : (int, string) Hashtbl.t
+  ; block_thinking_signatures : (int, Buffer.t) Hashtbl.t
   }
 
 let create_stream_acc () =
@@ -36,6 +37,7 @@ let create_stream_acc () =
   ; block_types = Hashtbl.create 4
   ; block_tool_ids = Hashtbl.create 4
   ; block_tool_names = Hashtbl.create 4
+  ; block_thinking_signatures = Hashtbl.create 4
   }
 ;;
 
@@ -69,7 +71,17 @@ let accumulate_event (acc : stream_acc) = function
     in
     (match delta with
      | Types.TextDelta s | Types.ThinkingDelta s | Types.InputJsonDelta s ->
-       Buffer.add_string buf s)
+       Buffer.add_string buf s
+     | Types.ThinkingSignatureDelta s ->
+       let sig_buf =
+         match Hashtbl.find_opt acc.block_thinking_signatures index with
+         | Some b -> b
+         | None ->
+           let b = Buffer.create 256 in
+           Hashtbl.replace acc.block_thinking_signatures index b;
+           b
+       in
+       Buffer.add_string sig_buf s)
   | Types.ContentBlockStop _ -> ()
   | Types.MessageDelta { stop_reason; usage } ->
     (match stop_reason with
@@ -127,7 +139,12 @@ let finalize_stream_acc (acc : stream_acc) =
            match Hashtbl.find_opt acc.block_types idx with
            | Some "text" -> Some (Types.Text text)
            | Some "thinking" ->
-             Some (Types.Thinking { thinking_type = "thinking"; content = text })
+             let thinking_type =
+               match Hashtbl.find_opt acc.block_thinking_signatures idx with
+               | Some buf when Buffer.length buf > 0 -> Buffer.contents buf
+               | Some _ | None -> "thinking"
+             in
+             Some (Types.Thinking { thinking_type; content = text })
            | Some "redacted_thinking" ->
              (match Hashtbl.find_opt acc.block_tool_ids idx with
               | Some data when data <> "" -> Some (Types.RedactedThinking data)
@@ -397,6 +414,56 @@ let%test "accumulate_event ThinkingDelta appends to buffer" =
     (Types.ContentBlockDelta { index = 0; delta = Types.ThinkingDelta " step2" });
   let buf = Hashtbl.find acc.block_texts 0 in
   Buffer.contents buf = "step1 step2"
+;;
+
+let%test "accumulate_event ThinkingSignatureDelta preserves opaque signature" =
+  let acc = create_stream_acc () in
+  accumulate_event
+    acc
+    (Types.ContentBlockStart
+       { index = 0; content_type = "thinking"; tool_id = None; tool_name = None });
+  accumulate_event
+    acc
+    (Types.ContentBlockDelta
+       { index = 0; delta = Types.ThinkingSignatureDelta "sig_opaque" });
+  match Hashtbl.find_opt acc.block_thinking_signatures 0 with
+  | Some buf -> Buffer.contents buf = "sig_opaque"
+  | None -> false
+;;
+
+let%test "finalize_stream_acc preserves omitted thinking signature" =
+  let acc = create_stream_acc () in
+  List.iter
+    (accumulate_event acc)
+    [ Types.MessageStart { id = "m"; model = "m"; usage = None }
+    ; Types.ContentBlockStart
+        { index = 0; content_type = "thinking"; tool_id = None; tool_name = None }
+    ; Types.ContentBlockDelta
+        { index = 0; delta = Types.ThinkingSignatureDelta "sig_opaque" }
+    ; Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None }
+    ];
+  match finalize_stream_acc acc with
+  | Ok { content = [ Types.Thinking { thinking_type; content } ]; _ } ->
+    thinking_type = "sig_opaque" && content = ""
+  | Ok _ | Error _ -> false
+;;
+
+let%test "finalize_stream_acc preserves redacted thinking carrier" =
+  let acc = create_stream_acc () in
+  List.iter
+    (accumulate_event acc)
+    [ Types.MessageStart { id = "m"; model = "m"; usage = None }
+    ; Types.ContentBlockStart
+        { index = 0
+        ; content_type = "redacted_thinking"
+        ; tool_id = Some "opaque_data"
+        ; tool_name = None
+        }
+    ; Types.MessageDelta { stop_reason = Some Types.StopToolUse; usage = None }
+    ];
+  match finalize_stream_acc acc with
+  | Ok { content = [ Types.RedactedThinking data ]; _ } -> data = "opaque_data"
+  | Ok _ | Error _ -> false
 ;;
 
 let%test "accumulate_event InputJsonDelta appends to buffer" =

--- a/lib/llm_provider/complete_stream_acc.mli
+++ b/lib/llm_provider/complete_stream_acc.mli
@@ -24,6 +24,7 @@ type stream_acc =
   ; block_types : (int, string) Hashtbl.t
   ; block_tool_ids : (int, string) Hashtbl.t
   ; block_tool_names : (int, string) Hashtbl.t
+  ; block_thinking_signatures : (int, Buffer.t) Hashtbl.t
   }
 
 (** Create a fresh accumulator with empty defaults. *)

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -577,6 +577,10 @@ let responses_member_int_default key json =
   json |> member key |> to_int_option |> Option.value ~default:0
 ;;
 
+let responses_advance_next_block_index state index =
+  if index >= state.next_block_index then state.next_block_index <- index + 1
+;;
+
 let responses_usage_of_response response =
   let open Yojson.Safe.Util in
   match response |> member "usage" with
@@ -652,38 +656,34 @@ let responses_error_type json =
     responses_member_string_opt "code" json
 ;;
 
-let responses_ensure_thinking_block state emit =
+let responses_ensure_thinking_block state emit ~output_index =
   (match state.thinking_state with
    | Not_thinking -> state.thinking_state <- Thinking_started (Unix.gettimeofday ())
    | Thinking_started _ | Thinking_done -> ());
   if not state.thinking_block_started
   then (
-    state.thinking_block_index <- state.next_block_index;
+    state.thinking_block_index <- output_index;
     emit
       (ContentBlockStart
-         { index = state.next_block_index
+         { index = output_index
          ; content_type = "thinking"
          ; tool_id = None
          ; tool_name = None
          });
     state.thinking_block_started <- true;
-    state.next_block_index <- state.next_block_index + 1);
+    responses_advance_next_block_index state output_index);
   state.thinking_block_index
 ;;
 
-let responses_ensure_text_block state emit =
+let responses_ensure_text_block state emit ~output_index =
   if not state.text_block_started
   then (
-    state.text_block_index <- state.next_block_index;
+    state.text_block_index <- output_index;
     emit
       (ContentBlockStart
-         { index = state.next_block_index
-         ; content_type = "text"
-         ; tool_id = None
-         ; tool_name = None
-         });
+         { index = output_index; content_type = "text"; tool_id = None; tool_name = None });
     state.text_block_started <- true;
-    state.next_block_index <- state.next_block_index + 1);
+    responses_advance_next_block_index state output_index);
   state.text_block_index
 ;;
 
@@ -697,12 +697,36 @@ let responses_ensure_tool_block state emit ~output_index ~tool_id ~tool_name =
   match Hashtbl.find_opt state.tool_block_indices output_index with
   | Some idx -> idx
   | None ->
-    let idx = state.next_block_index in
+    let idx = output_index in
     Hashtbl.replace state.tool_block_indices output_index idx;
     emit
       (ContentBlockStart { index = idx; content_type = "tool_use"; tool_id; tool_name });
-    state.next_block_index <- state.next_block_index + 1;
+    responses_advance_next_block_index state idx;
     idx
+;;
+
+let responses_emit_redacted_reasoning_outputs state emit response =
+  let open Yojson.Safe.Util in
+  match response |> member "output" with
+  | `List items ->
+    List.iteri
+      (fun output_index item ->
+         match responses_member_string_opt "type" item with
+         | Some "reasoning" ->
+           (match item |> member "encrypted_content" |> to_string_option with
+            | Some encrypted_content when String.trim encrypted_content <> "" ->
+              emit
+                (ContentBlockStart
+                   { index = output_index
+                   ; content_type = "redacted_thinking"
+                   ; tool_id = Some (Yojson.Safe.to_string item)
+                   ; tool_name = None
+                   });
+              responses_advance_next_block_index state output_index
+            | Some _ | None -> ())
+         | Some _ | None -> ())
+      items
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ -> ()
 ;;
 
 let responses_sse_to_events (state : provider_d_stream_state) event_type data_str
@@ -743,7 +767,8 @@ let responses_sse_to_events (state : provider_d_stream_state) event_type data_st
        | "response.output_text.delta" ->
          (match responses_member_string_opt "delta" json with
           | Some delta when delta <> "" ->
-            let index = responses_ensure_text_block state emit in
+            let output_index = responses_member_int_default "output_index" json in
+            let index = responses_ensure_text_block state emit ~output_index in
             emit (ContentBlockDelta { index; delta = TextDelta delta })
           | Some _ | None -> ())
        | "response.output_text.done" ->
@@ -751,13 +776,15 @@ let responses_sse_to_events (state : provider_d_stream_state) event_type data_st
          then (
            match responses_member_string_opt "text" json with
            | Some text when text <> "" ->
-             let index = responses_ensure_text_block state emit in
+             let output_index = responses_member_int_default "output_index" json in
+             let index = responses_ensure_text_block state emit ~output_index in
              emit (ContentBlockDelta { index; delta = TextDelta text })
            | Some _ | None -> ())
        | "response.reasoning_summary_text.delta" | "response.reasoning_text.delta" ->
          (match responses_member_string_opt "delta" json with
           | Some delta when delta <> "" ->
-            let index = responses_ensure_thinking_block state emit in
+            let output_index = responses_member_int_default "output_index" json in
+            let index = responses_ensure_thinking_block state emit ~output_index in
             emit (ContentBlockDelta { index; delta = ThinkingDelta delta })
           | Some _ | None -> ())
        | "response.reasoning_summary_text.done" | "response.reasoning_text.done" ->
@@ -765,7 +792,8 @@ let responses_sse_to_events (state : provider_d_stream_state) event_type data_st
          then (
            match responses_member_string_opt "text" json with
            | Some text when text <> "" ->
-             let index = responses_ensure_thinking_block state emit in
+             let output_index = responses_member_int_default "output_index" json in
+             let index = responses_ensure_thinking_block state emit ~output_index in
              emit (ContentBlockDelta { index; delta = ThinkingDelta text })
            | Some _ | None -> ())
        | "response.output_item.added" ->
@@ -799,7 +827,9 @@ let responses_sse_to_events (state : provider_d_stream_state) event_type data_st
             emit (ContentBlockDelta { index; delta = InputJsonDelta delta })
           | Some _ | None -> ())
        | "response.completed" | "response.incomplete" ->
-         emit_terminal (json |> member "response")
+         let response = json |> member "response" in
+         responses_emit_redacted_reasoning_outputs state emit response;
+         emit_terminal response
        | "response.failed" | "error" ->
          emit
            (SSEError
@@ -916,7 +946,26 @@ let provider_f_chunk_to_events
            let name = Cli_common_json.member_str "name" fc in
            let args = fc |> member "args" in
            let id = Api_common.synthesize_tool_use_id ~name args in
+           (match part |> member "thoughtSignature" |> to_string_option with
+            | Some thought_signature
+              when not (Api_common.string_is_blank thought_signature) ->
+              let idx = state.next_block_index in
+              let payload =
+                Backend_gemini.gemini_thought_signature_payload
+                  ~tool_use_id:id
+                  ~thought_signature
+              in
+              emit
+                (ContentBlockStart
+                   { index = idx
+                   ; content_type = "redacted_thinking"
+                   ; tool_id = Some payload
+                   ; tool_name = None
+                   });
+              state.next_block_index <- state.next_block_index + 1
+            | Some _ | None -> ());
            let idx = state.next_block_index in
+           Hashtbl.replace state.tool_block_indices idx idx;
            emit
              (ContentBlockStart
                 { index = idx
@@ -977,6 +1026,7 @@ let provider_f_chunk_to_events
           non-streaming parser (Backend_gemini.parse_response): SAFETY and
           RECITATION both surface as Refusal. *)
        match String.uppercase_ascii reason with
+       | "STOP" when Hashtbl.length state.tool_block_indices > 0 -> StopToolUse
        | "STOP" -> EndTurn
        | "MAX_TOKENS" -> MaxTokens
        | "SAFETY" | "RECITATION" -> Refusal

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -51,7 +51,11 @@ let parse_sse_event event_type data_str =
       let index = json |> member "index" |> to_int in
       let cb = json |> member "content_block" in
       let content_type = cb |> member "type" |> to_string in
-      let tool_id = cb |> member "id" |> to_string_option in
+      let tool_id =
+        match content_type with
+        | "redacted_thinking" -> cb |> member "data" |> to_string_option
+        | _ -> cb |> member "id" |> to_string_option
+      in
       let tool_name = cb |> member "name" |> to_string_option in
       Some (ContentBlockStart { index; content_type; tool_id; tool_name })
     | "content_block_delta" ->
@@ -62,6 +66,8 @@ let parse_sse_event event_type data_str =
         match delta_type with
         | "text_delta" -> TextDelta (delta_json |> member "text" |> to_string)
         | "thinking_delta" -> ThinkingDelta (delta_json |> member "thinking" |> to_string)
+        | "signature_delta" ->
+          ThinkingSignatureDelta (delta_json |> member "signature" |> to_string)
         | "input_json_delta" ->
           InputJsonDelta (delta_json |> member "partial_json" |> to_string)
         | unknown_delta_type ->
@@ -136,6 +142,7 @@ let sse_event_is_first_token_signal (e : sse_event) : bool =
   | ContentBlockDelta { delta = TextDelta s; _ } -> non_empty s
   | ContentBlockDelta { delta = ThinkingDelta s; _ } -> non_empty s
   | ContentBlockDelta { delta = InputJsonDelta s; _ } -> non_empty s
+  | ContentBlockDelta { delta = ThinkingSignatureDelta _; _ } -> false
   | MessageStart _
   | ContentBlockStart _
   | ContentBlockStop _
@@ -155,6 +162,7 @@ let sse_event_is_deliverable_progress_signal (e : sse_event) : bool =
   | ContentBlockDelta { delta = TextDelta s; _ } -> non_empty s
   | ContentBlockDelta { delta = InputJsonDelta s; _ } -> non_empty s
   | ContentBlockStart { content_type = "tool_use"; _ } -> true
+  | ContentBlockDelta { delta = ThinkingSignatureDelta _; _ }
   | ContentBlockDelta { delta = ThinkingDelta _; _ }
   | MessageStart _
   | ContentBlockStart _
@@ -188,14 +196,18 @@ let emit_synthetic_events (response : api_response) on_event =
          | Image _ -> "text", None, None
          | Document _ -> "text", None, None
          | Audio _ -> "text", None, None
-         | RedactedThinking _ -> "text", None, None
+         | RedactedThinking data -> "redacted_thinking", Some data, None
          | ToolResult _ -> "text", None, None
        in
        on_event (ContentBlockStart { index; content_type; tool_id; tool_name });
        (match block with
         | Text s -> on_event (ContentBlockDelta { index; delta = TextDelta s })
-        | Thinking { content; _ } ->
-          on_event (ContentBlockDelta { index; delta = ThinkingDelta content })
+        | Thinking { thinking_type; content } ->
+          on_event (ContentBlockDelta { index; delta = ThinkingDelta content });
+          if thinking_type <> ""
+          then
+            on_event
+              (ContentBlockDelta { index; delta = ThinkingSignatureDelta thinking_type })
         | ToolUse { input; _ } ->
           on_event
             (ContentBlockDelta

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -23,6 +23,7 @@ val emit_synthetic_events : api_response -> (sse_event -> unit) -> unit
     token delta. That means a [ContentBlockDelta] carrying a
     non-empty [TextDelta] / [ThinkingDelta] / [InputJsonDelta]
     payload. Prelude events ([MessageStart], [ContentBlockStart],
+    [ThinkingSignatureDelta] carriers,
     [Ping]), terminator events ([MessageStop], [MessageDelta] with
     no usage), and error events return [false].
 

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -357,6 +357,7 @@ type api_response =
 type content_delta =
   | TextDelta of string
   | ThinkingDelta of string
+  | ThinkingSignatureDelta of string
   | InputJsonDelta of string
 
 type sse_event =

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -230,6 +230,7 @@ type api_response =
 type content_delta =
   | TextDelta of string
   | ThinkingDelta of string
+  | ThinkingSignatureDelta of string
   | InputJsonDelta of string
 
 type sse_event =

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -28,6 +28,7 @@ type stream_acc =
   ; block_types : (int, string) Hashtbl.t
   ; block_tool_ids : (int, string) Hashtbl.t
   ; block_tool_names : (int, string) Hashtbl.t
+  ; block_thinking_signatures : (int, Buffer.t) Hashtbl.t
   }
 
 let create_stream_acc () =
@@ -44,6 +45,7 @@ let create_stream_acc () =
   ; block_types = Hashtbl.create 4
   ; block_tool_ids = Hashtbl.create 4
   ; block_tool_names = Hashtbl.create 4
+  ; block_thinking_signatures = Hashtbl.create 4
   }
 ;;
 
@@ -76,7 +78,17 @@ let accumulate_event (acc : stream_acc) = function
         b
     in
     (match delta with
-     | TextDelta s | ThinkingDelta s | InputJsonDelta s -> Buffer.add_string buf s)
+     | TextDelta s | ThinkingDelta s | InputJsonDelta s -> Buffer.add_string buf s
+     | ThinkingSignatureDelta s ->
+       let sig_buf =
+         match Hashtbl.find_opt acc.block_thinking_signatures index with
+         | Some b -> b
+         | None ->
+           let b = Buffer.create 256 in
+           Hashtbl.replace acc.block_thinking_signatures index b;
+           b
+       in
+       Buffer.add_string sig_buf s)
   | MessageDelta { stop_reason = sr; usage } ->
     (match sr with
      | Some r ->
@@ -131,7 +143,13 @@ let finalize_stream_acc (acc : stream_acc) =
            let block =
              match ctype with
              | "text" -> Some (Text text)
-             | "thinking" -> Some (Thinking { thinking_type = ""; content = text })
+             | "thinking" ->
+               let thinking_type =
+                 match Hashtbl.find_opt acc.block_thinking_signatures index with
+                 | Some buf when Buffer.length buf > 0 -> Buffer.contents buf
+                 | Some _ | None -> ""
+               in
+               Some (Thinking { thinking_type; content = text })
              | "redacted_thinking" ->
                (match Hashtbl.find_opt acc.block_tool_ids index with
                 | Some data when data <> "" -> Some (RedactedThinking data)

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -132,6 +132,10 @@ let finalize_stream_acc (acc : stream_acc) =
              match ctype with
              | "text" -> Some (Text text)
              | "thinking" -> Some (Thinking { thinking_type = ""; content = text })
+             | "redacted_thinking" ->
+               (match Hashtbl.find_opt acc.block_tool_ids index with
+                | Some data when data <> "" -> Some (RedactedThinking data)
+                | Some _ | None -> None)
              | "tool_use" ->
                let tool_id =
                  match Hashtbl.find_opt acc.block_tool_ids index with

--- a/lib/streaming.mli
+++ b/lib/streaming.mli
@@ -34,6 +34,7 @@ type stream_acc =
   ; block_types : (int, string) Hashtbl.t
   ; block_tool_ids : (int, string) Hashtbl.t
   ; block_tool_names : (int, string) Hashtbl.t
+  ; block_thinking_signatures : (int, Buffer.t) Hashtbl.t
   }
 
 (** Create a fresh accumulator. *)

--- a/test/test_agent_stream.ml
+++ b/test/test_agent_stream.ml
@@ -82,15 +82,19 @@ let test_emit_thinking () =
     make_response [ Types.Thinking { thinking_type = "sig"; content = "I think..." } ]
   in
   let events = collect_events response in
-  Alcotest.(check int) "6 events" 6 (List.length events);
+  Alcotest.(check int) "7 events" 7 (List.length events);
   (match List.nth events 1 with
    | Types.ContentBlockStart { content_type; _ } ->
      Alcotest.(check string) "content_type" "thinking" content_type
    | _ -> Alcotest.fail "expected ContentBlockStart with thinking");
-  match List.nth events 2 with
-  | Types.ContentBlockDelta { delta = Types.ThinkingDelta s; _ } ->
-    Alcotest.(check string) "thinking content" "I think..." s
-  | _ -> Alcotest.fail "expected ThinkingDelta"
+  (match List.nth events 2 with
+   | Types.ContentBlockDelta { delta = Types.ThinkingDelta s; _ } ->
+     Alcotest.(check string) "thinking content" "I think..." s
+   | _ -> Alcotest.fail "expected ThinkingDelta");
+  match List.nth events 3 with
+  | Types.ContentBlockDelta { delta = Types.ThinkingSignatureDelta s; _ } ->
+    Alcotest.(check string) "thinking signature" "sig" s
+  | _ -> Alcotest.fail "expected ThinkingSignatureDelta"
 ;;
 
 let test_emit_multiple_blocks () =
@@ -333,7 +337,7 @@ let test_roundtrip_mixed_block_count () =
       | Types.ContentBlockDelta _ -> true
       | _ -> false)
   in
-  Alcotest.(check int) "3 deltas for 3 blocks" 3 cbd_count
+  Alcotest.(check int) "4 deltas for 3 blocks plus thinking signature" 4 cbd_count
 ;;
 
 let test_roundtrip_message_start_fields () =

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -379,6 +379,121 @@ let test_parse_function_call () =
   | _ -> fail "expected StopToolUse"
 ;;
 
+let function_call_with_thought_signature_json () =
+  Yojson.Safe.from_string
+    {|{
+    "candidates": [{
+      "content": {
+        "parts": [{
+          "functionCall": {
+            "name": "search",
+            "args": {"q": "test"}
+          },
+          "thoughtSignature": "sig-gemini-123"
+        }],
+        "role": "model"
+      },
+      "finishReason": "STOP"
+    }],
+    "usageMetadata": {"promptTokenCount": 15, "candidatesTokenCount": 8},
+    "modelVersion": "gemini-2.5-flash"
+  }|}
+;;
+
+let test_parse_function_call_preserves_thought_signature () =
+  let resp =
+    Backend_gemini.parse_response (function_call_with_thought_signature_json ())
+  in
+  check int "two content blocks" 2 (List.length resp.content);
+  (match resp.content with
+   | [ Types.RedactedThinking raw; Types.ToolUse { id; name; input } ] ->
+     check string "name" "search" name;
+     check string "query arg" "test" (input |> member "q" |> to_string);
+     let carrier = Yojson.Safe.from_string raw in
+     check string "carrier provider" "gemini" (carrier |> member "provider" |> to_string);
+     check
+       string
+       "carrier kind"
+       "gemini_thought_signature"
+       (carrier |> member "kind" |> to_string);
+     check string "carrier tool_use_id" id (carrier |> member "tool_use_id" |> to_string);
+     check
+       string
+       "carrier thoughtSignature"
+       "sig-gemini-123"
+       (carrier |> member "thoughtSignature" |> to_string)
+   | _ -> fail "expected RedactedThinking carrier followed by ToolUse");
+  match resp.stop_reason with
+  | Types.StopToolUse -> ()
+  | _ -> fail "expected StopToolUse"
+;;
+
+let test_thought_signature_roundtrip_request () =
+  let parsed =
+    Backend_gemini.parse_response (function_call_with_thought_signature_json ())
+  in
+  let tool_use_id =
+    match parsed.content with
+    | [ Types.RedactedThinking _; Types.ToolUse { id; _ } ] -> id
+    | _ -> fail "expected parsed signed ToolUse"
+  in
+  let config = provider_f_config () in
+  let messages =
+    [ Types.user_msg "Use the search tool."
+    ; { Types.role = Assistant
+      ; content = parsed.content
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ; { role = User
+      ; content =
+          [ ToolResult
+              { tool_use_id
+              ; content = "found"
+              ; is_error = false
+              ; json = None
+              ; content_blocks = None
+              }
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let body = Backend_gemini.build_request ~config ~messages () in
+  let json = parse_body body in
+  let contents = json |> member "contents" |> to_list in
+  check int "three contents" 3 (List.length contents);
+  let assistant_content = List.nth contents 1 in
+  let function_part =
+    assistant_content
+    |> member "parts"
+    |> to_list
+    |> function
+    | [ part ] -> part
+    | _ -> fail "expected one assistant functionCall part"
+  in
+  check
+    string
+    "request thoughtSignature"
+    "sig-gemini-123"
+    (function_part |> member "thoughtSignature" |> to_string);
+  let fc = function_part |> member "functionCall" in
+  check string "function name" "search" (fc |> member "name" |> to_string);
+  check string "function arg" "test" (fc |> member "args" |> member "q" |> to_string);
+  let tool_response_content = List.nth contents 2 in
+  let fr =
+    tool_response_content
+    |> member "parts"
+    |> to_list
+    |> List.hd
+    |> member "functionResponse"
+  in
+  check string "response function name" "search" (fr |> member "name" |> to_string)
+;;
+
 let test_parse_usage () =
   let json =
     Yojson.Safe.from_string
@@ -811,6 +926,80 @@ let test_provider_f_stream_tool_first_then_text () =
   | None -> fail "expected Some chunk"
 ;;
 
+let test_provider_f_stream_function_call_preserves_thought_signature () =
+  let state = Streaming.create_openai_stream_state () in
+  let data =
+    {|{
+    "candidates": [{
+      "content": {
+        "parts": [{
+          "functionCall": {"name": "search", "args": {"q": "test"}},
+          "thoughtSignature": "sig-gemini-stream-123"
+        }],
+        "role": "model"
+      },
+      "finishReason": "STOP"
+    }]
+  }|}
+  in
+  match Streaming.parse_provider_f_sse_chunk data with
+  | None -> fail "expected Some chunk"
+  | Some chunk ->
+    let events, _tel = Streaming.provider_f_chunk_to_events state chunk in
+    (match events with
+     | [ ContentBlockStart
+           { index = redacted_idx
+           ; content_type = "redacted_thinking"
+           ; tool_id = Some carrier_payload
+           ; tool_name = None
+           }
+       ; ContentBlockStart
+           { index = tool_idx
+           ; content_type = "tool_use"
+           ; tool_id = Some tool_id
+           ; tool_name = Some "search"
+           }
+       ; ContentBlockDelta { index = delta_idx; delta = InputJsonDelta {|{"q":"test"}|} }
+       ; MessageDelta { stop_reason = Some StopToolUse; _ }
+       ] ->
+       check int "redacted index" 0 redacted_idx;
+       check int "tool index" 1 tool_idx;
+       check int "tool delta index" 1 delta_idx;
+       let carrier = Yojson.Safe.from_string carrier_payload in
+       check string "carrier provider" "gemini" (carrier |> member "provider" |> to_string);
+       check
+         string
+         "carrier kind"
+         "gemini_thought_signature"
+         (carrier |> member "kind" |> to_string);
+       check
+         string
+         "carrier tool_use_id"
+         tool_id
+         (carrier |> member "tool_use_id" |> to_string);
+       check
+         string
+         "carrier thoughtSignature"
+         "sig-gemini-stream-123"
+         (carrier |> member "thoughtSignature" |> to_string);
+       let acc = Complete_stream_acc.create_stream_acc () in
+       List.iter (Complete_stream_acc.accumulate_event acc) events;
+       (match Complete_stream_acc.finalize_stream_acc acc with
+        | Error _ -> fail "expected finalized stream response"
+        | Ok response ->
+          (match response.stop_reason with
+           | StopToolUse -> ()
+           | _ -> fail "expected StopToolUse");
+          (match response.content with
+           | [ RedactedThinking raw; ToolUse { id; name; input } ] ->
+             check string "final carrier" carrier_payload raw;
+             check string "final tool id" tool_id id;
+             check string "final tool name" "search" name;
+             check string "final tool input" "test" (input |> member "q" |> to_string)
+           | _ -> fail "expected RedactedThinking carrier followed by ToolUse"))
+     | _ -> fail "expected redacted carrier, tool_use, delta, and terminal event")
+;;
+
 (* ── Suite ────────────────────────────────────────── *)
 
 let () =
@@ -837,11 +1026,19 @@ let () =
         ; test_case "tool choice" `Quick test_tool_choice_mapping
         ; test_case "tool choice tool name" `Quick test_tool_choice_tool_name
         ; test_case "thinking part roundtrip" `Quick test_thinking_part_roundtrip
+        ; test_case
+            "thought signature roundtrip"
+            `Quick
+            test_thought_signature_roundtrip_request
         ] )
     ; ( "parse_response"
       , [ test_case "text" `Quick test_parse_text_response
         ; test_case "thinking parts" `Quick test_parse_thinking_response
         ; test_case "function call" `Quick test_parse_function_call
+        ; test_case
+            "function call thought signature"
+            `Quick
+            test_parse_function_call_preserves_thought_signature
         ; test_case "usage" `Quick test_parse_usage
         ; test_case "stop reasons" `Quick test_parse_stop_reasons
         ; test_case "error" `Quick test_parse_error
@@ -864,6 +1061,10 @@ let () =
             "tool-first then text (#333)"
             `Quick
             test_provider_f_stream_tool_first_then_text
+        ; test_case
+            "function call thought signature"
+            `Quick
+            test_provider_f_stream_function_call_preserves_thought_signature
         ] )
     ; ( "capabilities"
       , [ test_case "gemini capabilities" `Quick test_gemini_capabilities_named ] )

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -975,6 +975,37 @@ let provider_a_sse_response text =
     text
 ;;
 
+let provider_a_sse_thinking_signature_tool_response =
+  "event: message_start\n\
+   data: \
+   {\"type\":\"message_start\",\"message\":{\"id\":\"msg-1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"mock\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n\n\
+   event: content_block_start\n\
+   data: \
+   {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"\"}}\n\n\
+   event: content_block_delta\n\
+   data: \
+   {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Need \
+   a lookup.\"}}\n\n\
+   event: content_block_delta\n\
+   data: \
+   {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"sig_opaque\"}}\n\n\
+   event: content_block_stop\n\
+   data: {\"type\":\"content_block_stop\",\"index\":0}\n\n\
+   event: content_block_start\n\
+   data: \
+   {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"tu_1\",\"name\":\"lookup\",\"input\":{}}}\n\n\
+   event: content_block_delta\n\
+   data: \
+   {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"q\\\":\\\"weather\\\"}\"}}\n\n\
+   event: content_block_stop\n\
+   data: {\"type\":\"content_block_stop\",\"index\":1}\n\n\
+   event: message_delta\n\
+   data: \
+   {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":5}}\n\n\
+   event: message_stop\n\
+   data: {\"type\":\"message_stop\"}\n\n"
+;;
+
 let provider_a_sse_frame_message_start =
   "event: message_start\n\
    data: \
@@ -1117,6 +1148,46 @@ let test_complete_stream_ok () =
       in
       check string "text" "streamed text" text;
       check bool "events received" true (List.length !events > 0);
+      Eio.Switch.fail sw Exit
+    | Error _ -> fail "expected Ok"
+  with
+  | Exit -> ()
+;;
+
+let test_complete_stream_preserves_thinking_signature () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url =
+      start_sse_server ~sw ~net:env#net provider_a_sse_thinking_signature_tool_response
+    in
+    let config = make_config url in
+    match
+      Complete.complete_stream
+        ~sw
+        ~net:env#net
+        ~config
+        ~messages
+        ~on_event:(fun _ -> ())
+        ()
+    with
+    | Ok resp ->
+      check bool "stop tool use" true (resp.stop_reason = Types.StopToolUse);
+      (match resp.content with
+       | [ Types.Thinking { thinking_type; content }; Types.ToolUse { id; name; input } ]
+         ->
+         check string "thinking signature" "sig_opaque" thinking_type;
+         check string "thinking content" "Need a lookup." content;
+         check string "tool id" "tu_1" id;
+         check string "tool name" "lookup" name;
+         check
+           string
+           "tool arg"
+           "weather"
+           (Yojson.Safe.Util.member "q" input |> Yojson.Safe.Util.to_string)
+       | _ -> fail "expected thinking + tool use");
       Eio.Switch.fail sw Exit
     | Error _ -> fail "expected Ok"
   with
@@ -1525,6 +1596,10 @@ let () =
     ; "retry", [ test_case "first try ok" `Quick test_retry_first_try ]
     ; ( "stream"
       , [ test_case "sse ok" `Quick test_complete_stream_ok
+        ; test_case
+            "preserves thinking signature"
+            `Quick
+            test_complete_stream_preserves_thinking_signature
         ; test_case
             "on_event exceptions are nonfatal"
             `Quick

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -410,7 +410,9 @@ let openai_responses_sse_tool_call_response () =
    {\"type\":\"response.function_call_arguments.delta\",\"output_index\":1,\"item_id\":\"fc_1\",\"delta\":\"{\\\"q\\\":\\\"weather\\\"}\"}\n\n\
    event: response.completed\n\
    data: \
-   {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-stream-1\",\"model\":\"gpt-5.5\",\"status\":\"completed\",\"output\":[{\"id\":\"fc_1\",\"type\":\"function_call\",\"call_id\":\"call_lookup\",\"name\":\"lookup\",\"arguments\":\"{\\\"q\\\":\\\"weather\\\"}\"}],\"usage\":{\"input_tokens\":12,\"output_tokens\":8,\"input_tokens_details\":{\"cached_tokens\":2}}}}\n\n"
+   {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-stream-1\",\"model\":\"gpt-5.5\",\"status\":\"completed\",\"output\":[{\"id\":\"rs_1\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"Need \
+   a \
+   lookup.\"}],\"encrypted_content\":\"enc_reasoning_1\"},{\"id\":\"fc_1\",\"type\":\"function_call\",\"call_id\":\"call_lookup\",\"name\":\"lookup\",\"arguments\":\"{\\\"q\\\":\\\"weather\\\"}\"}],\"usage\":{\"input_tokens\":12,\"output_tokens\":8,\"input_tokens_details\":{\"cached_tokens\":2}}}}\n\n"
 ;;
 
 let test_complete_stream_openai_responses_ok () =
@@ -450,8 +452,19 @@ let test_complete_stream_openai_responses_ok () =
       check bool "stop tool use" true (resp.stop_reason = Types.StopToolUse);
       check bool "events emitted" true (List.length !events >= 5);
       (match resp.content with
-       | [ Types.Thinking { content; _ }; Types.ToolUse { id; name; input } ] ->
-         check string "reasoning" "Need a lookup." content;
+       | [ Types.RedactedThinking raw_reasoning; Types.ToolUse { id; name; input } ] ->
+         let reasoning = Yojson.Safe.from_string raw_reasoning in
+         check
+           string
+           "reasoning type"
+           "reasoning"
+           (Yojson.Safe.Util.member "type" reasoning |> Yojson.Safe.Util.to_string);
+         check
+           string
+           "encrypted reasoning"
+           "enc_reasoning_1"
+           (Yojson.Safe.Util.member "encrypted_content" reasoning
+            |> Yojson.Safe.Util.to_string);
          check string "tool id" "call_lookup" id;
          check string "tool name" "lookup" name;
          check
@@ -459,7 +472,7 @@ let test_complete_stream_openai_responses_ok () =
            "tool arg"
            "weather"
            (Yojson.Safe.Util.member "q" input |> Yojson.Safe.Util.to_string)
-       | _ -> fail "expected reasoning + tool use");
+       | _ -> fail "expected redacted reasoning + tool use");
       (match resp.usage with
        | Some usage ->
          check int "input tokens" 12 usage.input_tokens;

--- a/test/test_stream_accumulator.ml
+++ b/test/test_stream_accumulator.ml
@@ -131,6 +131,19 @@ let test_accumulate_thinking_delta () =
   Alcotest.(check string) "thinking text" "I think" (Buffer.contents buf)
 ;;
 
+let test_accumulate_thinking_signature_delta () =
+  let acc = Streaming.create_stream_acc () in
+  Streaming.accumulate_event
+    acc
+    (ContentBlockStart
+       { index = 0; content_type = "thinking"; tool_id = None; tool_name = None });
+  Streaming.accumulate_event
+    acc
+    (ContentBlockDelta { index = 0; delta = ThinkingSignatureDelta "sig_opaque" });
+  let buf = Hashtbl.find acc.block_thinking_signatures 0 in
+  Alcotest.(check string) "signature" "sig_opaque" (Buffer.contents buf)
+;;
+
 let test_accumulate_input_json_delta () =
   let acc = Streaming.create_stream_acc () in
   Streaming.accumulate_event
@@ -252,6 +265,48 @@ let test_finalize_thinking_block () =
      | Thinking { content; _ } ->
        Alcotest.(check string) "thinking" "reasoning here" content
      | _ -> Alcotest.fail "expected Thinking")
+;;
+
+let test_finalize_thinking_signature_block () =
+  let acc = Streaming.create_stream_acc () in
+  acc_events
+    acc
+    [ MessageStart { id = "m"; model = "m"; usage = None }
+    ; ContentBlockStart
+        { index = 0; content_type = "thinking"; tool_id = None; tool_name = None }
+    ; ContentBlockDelta { index = 0; delta = ThinkingDelta "" }
+    ; ContentBlockDelta { index = 0; delta = ThinkingSignatureDelta "sig_opaque" }
+    ; MessageDelta { stop_reason = Some EndTurn; usage = None }
+    ];
+  match Streaming.finalize_stream_acc acc with
+  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Ok resp ->
+    (match List.hd resp.content with
+     | Thinking { thinking_type; content } ->
+       Alcotest.(check string) "signature" "sig_opaque" thinking_type;
+       Alcotest.(check string) "omitted thinking text" "" content
+     | _ -> Alcotest.fail "expected Thinking")
+;;
+
+let test_finalize_redacted_thinking_block () =
+  let acc = Streaming.create_stream_acc () in
+  acc_events
+    acc
+    [ MessageStart { id = "m"; model = "m"; usage = None }
+    ; ContentBlockStart
+        { index = 0
+        ; content_type = "redacted_thinking"
+        ; tool_id = Some "opaque_data"
+        ; tool_name = None
+        }
+    ; MessageDelta { stop_reason = Some StopToolUse; usage = None }
+    ];
+  match Streaming.finalize_stream_acc acc with
+  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Ok resp ->
+    (match List.hd resp.content with
+     | RedactedThinking data -> Alcotest.(check string) "data" "opaque_data" data
+     | _ -> Alcotest.fail "expected RedactedThinking")
 ;;
 
 let test_finalize_tool_use () =
@@ -407,6 +462,10 @@ let () =
             `Quick
             test_accumulate_delta_without_start
         ; Alcotest.test_case "thinking delta" `Quick test_accumulate_thinking_delta
+        ; Alcotest.test_case
+            "thinking signature delta"
+            `Quick
+            test_accumulate_thinking_signature_delta
         ; Alcotest.test_case "input_json delta" `Quick test_accumulate_input_json_delta
         ; Alcotest.test_case "message_delta" `Quick test_accumulate_message_delta
         ; Alcotest.test_case
@@ -422,6 +481,14 @@ let () =
     ; ( "finalize"
       , [ Alcotest.test_case "text response" `Quick test_finalize_text_response
         ; Alcotest.test_case "thinking block" `Quick test_finalize_thinking_block
+        ; Alcotest.test_case
+            "thinking signature block"
+            `Quick
+            test_finalize_thinking_signature_block
+        ; Alcotest.test_case
+            "redacted thinking block"
+            `Quick
+            test_finalize_redacted_thinking_block
         ; Alcotest.test_case "tool_use" `Quick test_finalize_tool_use
         ; Alcotest.test_case
             "tool_use invalid json"

--- a/test/test_streaming.ml
+++ b/test/test_streaming.ml
@@ -163,6 +163,29 @@ let test_parse_content_block_delta_thinking () =
   | None -> Alcotest.fail "parse returned None"
 ;;
 
+let test_parse_content_block_delta_signature () =
+  let data =
+    {|{"type":"content_block_delta","index":1,"delta":{"type":"signature_delta","signature":"sig_opaque"}}|}
+  in
+  match Agent_sdk.Streaming.parse_sse_event None data with
+  | Some (ContentBlockDelta { index = 1; delta = ThinkingSignatureDelta s }) ->
+    Alcotest.(check string) "signature" "sig_opaque" s
+  | Some _ -> Alcotest.fail "unexpected event type"
+  | None -> Alcotest.fail "parse returned None"
+;;
+
+let test_parse_redacted_thinking_block_start () =
+  let data =
+    {|{"type":"content_block_start","index":0,"content_block":{"type":"redacted_thinking","data":"opaque_data"}}|}
+  in
+  match Agent_sdk.Streaming.parse_sse_event None data with
+  | Some (ContentBlockStart { index = 0; content_type; tool_id = Some data; _ }) ->
+    Alcotest.(check string) "content_type" "redacted_thinking" content_type;
+    Alcotest.(check string) "data carrier" "opaque_data" data
+  | Some _ -> Alcotest.fail "unexpected event type"
+  | None -> Alcotest.fail "parse returned None"
+;;
+
 let test_parse_content_block_delta_input_json () =
   let data =
     {|{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"k\":"}}|}
@@ -427,17 +450,19 @@ let test_synthetic_multi_block () =
     }
   in
   let events = collect_events response in
-  (* For each block: Start+Delta+Stop (Thinking, Text) or Start+Delta+Stop (ToolUse) *)
-  (* + MessageStart + MessageDelta + MessageStop = 3*3 + 3 = 12 *)
-  Alcotest.(check int) "12 events" 12 (List.length events);
+  (* Thinking emits content and signature deltas; other blocks emit one delta. *)
+  Alcotest.(check int) "13 events" 13 (List.length events);
   (* Check index increases *)
   (match List.nth events 1 with
    | ContentBlockStart { index = 0; _ } -> ()
    | _ -> Alcotest.fail "expected index 0");
-  (match List.nth events 4 with
+  (match List.nth events 3 with
+   | ContentBlockDelta { index = 0; delta = ThinkingSignatureDelta "s" } -> ()
+   | _ -> Alcotest.fail "expected thinking signature delta");
+  (match List.nth events 5 with
    | ContentBlockStart { index = 1; _ } -> ()
    | _ -> Alcotest.fail "expected index 1");
-  match List.nth events 7 with
+  match List.nth events 8 with
   | ContentBlockStart { index = 2; _ } -> ()
   | _ -> Alcotest.fail "expected index 2"
 ;;
@@ -499,6 +524,14 @@ let () =
             "content_block_delta_thinking"
             `Quick
             test_parse_content_block_delta_thinking
+        ; test_case
+            "content_block_delta_signature"
+            `Quick
+            test_parse_content_block_delta_signature
+        ; test_case
+            "redacted_thinking_block_start"
+            `Quick
+            test_parse_redacted_thinking_block_start
         ; test_case
             "content_block_delta_input_json"
             `Quick

--- a/test/test_streaming_openai.ml
+++ b/test/test_streaming_openai.ml
@@ -679,15 +679,80 @@ let test_responses_stream_reasoning_tool_and_terminal () =
     S.responses_sse_to_events
       state
       (Some "response.completed")
-      {|{"type":"response.completed","response":{"id":"resp_1","model":"gpt-5.5","status":"completed","output":[{"id":"fc_1","type":"function_call","call_id":"call_lookup","name":"lookup","arguments":"{\"q\":\"weather\"}"}],"usage":{"input_tokens":12,"output_tokens":8,"input_tokens_details":{"cached_tokens":2}}}}|}
+      {|{"type":"response.completed","response":{"id":"resp_1","model":"gpt-5.5","status":"completed","output":[{"id":"rs_1","type":"reasoning","summary":[{"type":"summary_text","text":"Need a lookup."}],"encrypted_content":"enc_reasoning_1"},{"id":"fc_1","type":"function_call","call_id":"call_lookup","name":"lookup","arguments":"{\"q\":\"weather\"}"}],"usage":{"input_tokens":12,"output_tokens":8,"input_tokens_details":{"cached_tokens":2}}}}|}
   in
   match events5 with
-  | [ MessageDelta { stop_reason = Some StopToolUse; usage = Some usage }; MessageStop ]
-    ->
+  | [ ContentBlockStart
+        { index = 0
+        ; content_type = "redacted_thinking"
+        ; tool_id = Some raw_reasoning
+        ; tool_name = None
+        }
+    ; MessageDelta { stop_reason = Some StopToolUse; usage = Some usage }
+    ; MessageStop
+    ] ->
+    let reasoning = Yojson.Safe.from_string raw_reasoning in
+    Alcotest.(check string)
+      "reasoning type"
+      "reasoning"
+      (Yojson.Safe.Util.member "type" reasoning |> Yojson.Safe.Util.to_string);
+    Alcotest.(check string)
+      "encrypted reasoning"
+      "enc_reasoning_1"
+      (Yojson.Safe.Util.member "encrypted_content" reasoning |> Yojson.Safe.Util.to_string);
     Alcotest.(check int) "input tokens" 12 usage.input_tokens;
     Alcotest.(check int) "output tokens" 8 usage.output_tokens;
     Alcotest.(check int) "cache read" 2 usage.cache_read_input_tokens
-  | _ -> Alcotest.fail "expected terminal StopToolUse with usage"
+  | _ -> Alcotest.fail "expected redacted reasoning carrier and terminal StopToolUse"
+;;
+
+let test_responses_stream_hidden_reasoning_before_tool () =
+  let state =
+    S.create_openai_stream_state ~provider:"openai_compat" ~model:"gpt-5.5" ()
+  in
+  let events1, _ =
+    S.responses_sse_to_events
+      state
+      (Some "response.output_item.added")
+      {|{"type":"response.output_item.added","output_index":1,"item":{"id":"fc_1","type":"function_call","call_id":"call_lookup","name":"lookup","arguments":""}}|}
+  in
+  (match events1 with
+   | [ ContentBlockStart { index = 1; content_type = "tool_use"; _ } ] -> ()
+   | _ -> Alcotest.fail "expected tool block to keep Responses output_index");
+  let events2, _ =
+    S.responses_sse_to_events
+      state
+      (Some "response.function_call_arguments.delta")
+      {|{"type":"response.function_call_arguments.delta","output_index":1,"item_id":"fc_1","delta":"{\"q\":\"weather\"}"}|}
+  in
+  (match events2 with
+   | [ ContentBlockDelta { index = 1; delta = InputJsonDelta "{\"q\":\"weather\"}" } ] ->
+     ()
+   | _ -> Alcotest.fail "expected function arguments delta at output index 1");
+  let events3, _ =
+    S.responses_sse_to_events
+      state
+      (Some "response.completed")
+      {|{"type":"response.completed","response":{"id":"resp_1","model":"gpt-5.5","status":"completed","output":[{"id":"rs_1","type":"reasoning","encrypted_content":"enc_hidden_1"},{"id":"fc_1","type":"function_call","call_id":"call_lookup","name":"lookup","arguments":"{\"q\":\"weather\"}"}],"usage":{"input_tokens":12,"output_tokens":8}}}|}
+  in
+  match events3 with
+  | [ ContentBlockStart
+        { index = 0
+        ; content_type = "redacted_thinking"
+        ; tool_id = Some raw_reasoning
+        ; tool_name = None
+        }
+    ; MessageDelta { stop_reason = Some StopToolUse; usage = Some usage }
+    ; MessageStop
+    ] ->
+    let reasoning = Yojson.Safe.from_string raw_reasoning in
+    Alcotest.(check string)
+      "encrypted reasoning"
+      "enc_hidden_1"
+      (Yojson.Safe.Util.member "encrypted_content" reasoning |> Yojson.Safe.Util.to_string);
+    Alcotest.(check int) "input tokens" 12 usage.input_tokens;
+    Alcotest.(check int) "output tokens" 8 usage.output_tokens
+  | _ -> Alcotest.fail "expected hidden reasoning carrier before terminal"
 ;;
 
 let () =
@@ -739,6 +804,10 @@ let () =
             "reasoning tool and terminal"
             `Quick
             test_responses_stream_reasoning_tool_and_terminal
+        ; test_case
+            "hidden reasoning before tool"
+            `Quick
+            test_responses_stream_hidden_reasoning_before_tool
         ] )
     ]
 ;;

--- a/test/test_structured_stream.ml
+++ b/test/test_structured_stream.ml
@@ -319,7 +319,8 @@ let test_extract_after_accumulation () =
       (match delta with
        | InputJsonDelta s -> Buffer.add_string buf s
        | TextDelta s -> Buffer.add_string buf s
-       | ThinkingDelta s -> Buffer.add_string buf s)
+       | ThinkingDelta s -> Buffer.add_string buf s
+       | ThinkingSignatureDelta _ -> ())
     | _ -> ());
   (* Step 2: reconstruct content blocks (same as streaming.ml) *)
   let content =


### PR DESCRIPTION
Summary:
- Preserve Gemini functionCall thoughtSignature across sync and stream tool-use turns as opaque RedactedThinking metadata, restored onto the matching functionCall part.
- Preserve OpenAI Responses streamed reasoning.encrypted_content from response.completed.output and keep Responses block indices aligned to output_index, so hidden reasoning before tool calls survives streaming accumulation.
- Preserve Anthropic streaming thinking signatures via signature_delta and redacted_thinking data carriers, including synthetic complete-response streams, so tool-use follow-up turns can replay opaque reasoning state.
- Normalize Gemini streaming STOP to StopToolUse when a tool call was emitted.

Tests:
- ocamlformat --check lib/llm_provider/backend_gemini.ml lib/llm_provider/backend_gemini.mli lib/llm_provider/streaming.ml lib/llm_provider/complete_stream_acc.ml lib/streaming.ml test/test_backend_gemini.ml
- ocamlformat --check lib/llm_provider/streaming.ml test/test_streaming_openai.ml test/test_complete_http.ml
- ocamlformat --check lib/llm_provider/types.ml lib/llm_provider/types.mli lib/llm_provider/streaming.ml lib/llm_provider/streaming.mli lib/llm_provider/complete_stream_acc.ml lib/llm_provider/complete_stream_acc.mli lib/llm_provider/complete_stream.ml lib/streaming.ml lib/streaming.mli test/test_streaming.ml test/test_stream_accumulator.ml test/test_complete_http.ml test/test_structured_stream.ml test/test_agent_stream.ml
- git diff --check
- scripts/dune-local.sh build test/test_backend_gemini.exe test/test_stream_accumulator.exe test/test_streaming_coverage.exe
- scripts/dune-local.sh exec test/test_backend_gemini.exe
- scripts/dune-local.sh exec test/test_stream_accumulator.exe
- scripts/dune-local.sh exec test/test_streaming_coverage.exe
- scripts/dune-local.sh build test/test_provider_complete.exe test/test_streaming_openai.exe test/test_agent_stream.exe test/test_complete_http.exe
- scripts/dune-local.sh exec test/test_provider_complete.exe
- scripts/dune-local.sh exec test/test_streaming_openai.exe
- scripts/dune-local.sh exec test/test_agent_stream.exe
- scripts/dune-local.sh exec test/test_complete_http.exe
- scripts/dune-local.sh build test/test_streaming.exe test/test_stream_accumulator.exe test/test_complete_http.exe test/test_structured_stream.exe test/test_streaming_coverage.exe test/test_provider_complete.exe test/test_streaming_openai.exe test/test_agent_stream.exe test/test_backend_gemini.exe
- scripts/dune-local.sh exec test/test_streaming.exe
- scripts/dune-local.sh exec test/test_structured_stream.exe

2026-06-14 carrier-focused recheck:
- scripts/dune-local.sh build test/test_streaming.exe test/test_stream_accumulator.exe test/test_complete_http.exe test/test_streaming_openai.exe test/test_backend_gemini.exe test/test_agent_stream.exe
- scripts/dune-local.sh exec test/test_streaming.exe
- scripts/dune-local.sh exec test/test_stream_accumulator.exe
- scripts/dune-local.sh exec test/test_complete_http.exe
- scripts/dune-local.sh exec test/test_streaming_openai.exe
- scripts/dune-local.sh exec test/test_backend_gemini.exe
- scripts/dune-local.sh exec test/test_agent_stream.exe