### PR TITLE
fix(test): green oas main — preserved redacted-thinking synthetic events + fmt drift

### DIFF
--- a/test/test_agent_sdk.ml
+++ b/test/test_agent_sdk.ml
@@ -52,10 +52,7 @@ let test_consumer_tool_name_alias_registry () =
   with
   | Some ("WebSearch", `Assoc [ ("query", `String "ocaml") ]) -> ()
   | Some (name, input) ->
-    Alcotest.failf
-      "unexpected alias resolution: %s %s"
-      name
-      (Yojson.Safe.to_string input)
+    Alcotest.failf "unexpected alias resolution: %s %s" name (Yojson.Safe.to_string input)
   | None -> Alcotest.fail "registered alias did not resolve"
 ;;
 

--- a/test/test_gemini_edge_cases.ml
+++ b/test/test_gemini_edge_cases.ml
@@ -120,14 +120,17 @@ let test_sse_function_call () =
         events
     in
     check "InputJsonDelta emitted" has_input_delta;
-    let has_end =
+    (* A Gemini stream that emitted a functionCall and finishes with STOP now
+       reports StopToolUse, not EndTurn (#2061): the model wants a tool call.
+       Mirrors the Alcotest gemini stop-reason tests #2061 already updated. *)
+    let has_stop_tool_use =
       List.exists
         (function
-          | Types.MessageDelta { stop_reason = Some Types.EndTurn; _ } -> true
+          | Types.MessageDelta { stop_reason = Some Types.StopToolUse; _ } -> true
           | _ -> false)
         events
     in
-    check "EndTurn MessageDelta emitted" has_end
+    check "StopToolUse MessageDelta emitted" has_stop_tool_use
   | None -> check "parsed chunk" false
 ;;
 

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -210,10 +210,19 @@ let test_synthetic_events_media_blocks () =
         | _ -> None)
       events
   in
+  (* Image/Document/Audio/ToolResult flatten to synthetic text blocks, but
+     RedactedThinking is preserved as a [redacted_thinking] block carrying its
+     opaque payload (#2061) so the thinking carrier round-trips for tool loops
+     instead of being silently dropped. *)
   check
     (list (pair string (option string)))
     "media-like synthetic starts"
-    [ "text", None; "text", None; "text", None; "text", None; "text", None ]
+    [ "text", None
+    ; "text", None
+    ; "text", None
+    ; "redacted_thinking", Some "hidden"
+    ; "text", None
+    ]
     starts
 ;;
 


### PR DESCRIPTION
## 목표
`origin/main` 의 red 게이트를 모두 해소한다 (oas#2062). #2061 의 CI 가 후속 PR 머지로 cancelled 되어 검증된 적이 없고, 동작 변경에 대한 paired test update 2건이 누락된 채 머지됨.

| 게이트 | 원인 | 본 PR |
|--------|------|-------|
| Build & Test | #2061 의 동작 변경에 대한 paired test update 2건 누락 | commit 1, 3 |
| OCaml Format | `test_agent_sdk.ml` pre-existing ocamlformat drift | commit 2 (= #2059, supersedes) |

## commit 1 — provider_a_sse synthetic media
#2061 이 `emit_synthetic_events` 의 RedactedThinking 을 빈 `text` 블록이 아니라 opaque payload 를 담은 `redacted_thinking` ContentBlockStart 로 방출하도록 변경. `test_synthetic_events_media_blocks` 가 옛 매핑(전부 text)을 단언해 실패 → 새 동작(carrier 보존)으로 기대값 갱신. event 수 불변(13).

## commit 2 — fmt drift
`test_agent_sdk.ml` 의 multi-line `Alcotest.failf` 를 ocamlformat 정규형으로. `@fmt --auto-promote` 재생성, #2059 와 동일 (supersedes).

## commit 3 — gemini functionCall stop reason
#2061 이 Gemini `finishReason "STOP"` + tool blocks 를 `StopToolUse`(EndTurn 아님)로 매핑(backend_gemini). Alcotest 케이스는 갱신했으나 printf 기반 `test_sse_function_call` 누락 → `StopToolUse` 기대로 갱신.

## 검증
- `dune build --root . @runtest` (전체) exit 0
- `dune build --root . @check` / `@fmt` (check) exit 0
- 개별: test_streaming_edge_cases 12/12, test_gemini_edge_cases pass, test_agent_sdk 18/18

Closes #2062. Supersedes #2059. (#2061 이 깬 동작은 모두 의도된 개선이고, 누락된 테스트 갱신만 보완 — workaround 아님.)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
