### PR TITLE
fix(metrics): use Eio.Mutex in Aggregating to avoid scheduler yield issue

### DIFF
--- a/lib/llm_provider/metrics.ml
+++ b/lib/llm_provider/metrics.ml
@@ -255,29 +255,26 @@ module Aggregating = struct
   type t =
     { hooks : hooks
     ; states : (aggregate_key, aggregate_state) Hashtbl.t
-    ; mutex : Mutex.t
+    ; mutex : Eio.Mutex.t
     }
 
   let key ~provider ~model_id = provider ^ "/" ^ model_id
 
   let create ?(inner = noop) () : t =
-    { hooks = inner; states = Hashtbl.create 16; mutex = Mutex.create () }
+    { hooks = inner; states = Hashtbl.create 16; mutex = Eio.Mutex.create () }
   ;;
 
   let with_state agg key f =
-    Mutex.lock agg.mutex;
-    Fun.protect
-      ~finally:(fun () -> Mutex.unlock agg.mutex)
-      (fun () ->
-         let state =
-           match Hashtbl.find_opt agg.states key with
-           | Some s -> s
-           | None ->
-             let s = empty_state () in
-             Hashtbl.replace agg.states key s;
-             s
-         in
-         f state)
+    Eio.Mutex.use_rw ~protect:true agg.mutex (fun () ->
+      let state =
+        match Hashtbl.find_opt agg.states key with
+        | Some s -> s
+        | None ->
+          let s = empty_state () in
+          Hashtbl.replace agg.states key s;
+          s
+      in
+      f state)
   ;;
 
   let to_hooks (agg : t) : hooks =
@@ -344,36 +341,32 @@ module Aggregating = struct
   ;;
 
   let snapshot (agg : t) : provider_snapshot list =
-    Mutex.lock agg.mutex;
-    Fun.protect
-      ~finally:(fun () -> Mutex.unlock agg.mutex)
-      (fun () ->
-         Hashtbl.fold
-           (fun (k : aggregate_key) (s : aggregate_state) acc ->
-              let provider, model_id =
-                match String.index_opt k '/' with
-                | Some i ->
-                  String.sub k 0 i, String.sub k (i + 1) (String.length k - i - 1)
-                | None -> k, ""
-              in
-              { provider
-              ; model_id
-              ; request_total = s.request_total
-              ; error_total = s.error_total
-              ; retry_total = s.retry_total
-              ; input_tokens_total = s.input_tokens_total
-              ; output_tokens_total = s.output_tokens_total
-              ; tool_call_total = s.tool_call_total
-              ; latency_ms_sum = s.latency_ms_sum
-              ; latency_ms_count = s.latency_ms_count
-              ; ttfrc_ms_sum = s.ttfrc_ms_sum
-              ; ttfrc_ms_count = s.ttfrc_ms_count
-              ; inter_chunk_ms_sum = s.inter_chunk_ms_sum
-              ; inter_chunk_ms_count = s.inter_chunk_ms_count
-              }
-              :: acc)
-           agg.states
-           [])
+    Eio.Mutex.use_rw ~protect:true agg.mutex (fun () ->
+      Hashtbl.fold
+        (fun (k : aggregate_key) (s : aggregate_state) acc ->
+           let provider, model_id =
+             match String.index_opt k '/' with
+             | Some i -> String.sub k 0 i, String.sub k (i + 1) (String.length k - i - 1)
+             | None -> k, ""
+           in
+           { provider
+           ; model_id
+           ; request_total = s.request_total
+           ; error_total = s.error_total
+           ; retry_total = s.retry_total
+           ; input_tokens_total = s.input_tokens_total
+           ; output_tokens_total = s.output_tokens_total
+           ; tool_call_total = s.tool_call_total
+           ; latency_ms_sum = s.latency_ms_sum
+           ; latency_ms_count = s.latency_ms_count
+           ; ttfrc_ms_sum = s.ttfrc_ms_sum
+           ; ttfrc_ms_count = s.ttfrc_ms_count
+           ; inter_chunk_ms_sum = s.inter_chunk_ms_sum
+           ; inter_chunk_ms_count = s.inter_chunk_ms_count
+           }
+           :: acc)
+        agg.states
+        [])
   ;;
 
   let snapshot_to_yojson agg = provider_snapshots_to_yojson (snapshot agg)
@@ -384,9 +377,6 @@ module Aggregating = struct
   ;;
 
   let reset (agg : t) =
-    Mutex.lock agg.mutex;
-    Fun.protect
-      ~finally:(fun () -> Mutex.unlock agg.mutex)
-      (fun () -> Hashtbl.reset agg.states)
+    Eio.Mutex.use_rw ~protect:true agg.mutex (fun () -> Hashtbl.reset agg.states)
   ;;
 end

--- a/lib/llm_provider/metrics.mli
+++ b/lib/llm_provider/metrics.mli
@@ -150,8 +150,8 @@ type hooks = t
 
 (** Thread-safe aggregating metrics backend.
 
-    Accumulates per-provider counters in a hash table guarded by a
-    {!Mutex.t}. Wrap an existing [Metrics.t] via {!Aggregating.create} to
+    Accumulates per-provider counters in a hash table guarded by an
+    {!Eio.Mutex.t}. Wrap an existing [Metrics.t] via {!Aggregating.create} to
     layer counting on top of any other metrics sink. Call
     {!Aggregating.snapshot} to read all counters as an immutable list.
 

--- a/test/test_metrics_aggregating.ml
+++ b/test/test_metrics_aggregating.ml
@@ -352,40 +352,41 @@ let test_aggregating_inner_delegation () =
 ;;
 
 let () =
-  run
-    "Metrics.Aggregating"
-    [ "create", [ test_case "empty snapshot" `Quick test_aggregating_create_empty ]
-    ; ( "counters"
-      , [ test_case "on_request_start" `Quick test_aggregating_on_request_start
-        ; test_case "on_retry" `Quick test_aggregating_on_retry
-        ; test_case "on_token_usage" `Quick test_aggregating_on_token_usage
-        ; test_case "on_tool_calls" `Quick test_aggregating_on_tool_calls
-        ; test_case "on_circuit_state" `Quick test_aggregating_on_circuit_state
-        ; test_case "on_error" `Quick test_aggregating_on_error
-        ; test_case
-            "on_request_end latency"
-            `Quick
-            test_aggregating_on_request_end_latency
-        ; test_case
-            "unknown request latency is not sampled"
-            `Quick
-            test_aggregating_unknown_latency_does_not_add_sample
-        ; test_case
-            "streaming latency callbacks"
-            `Quick
-            test_aggregating_on_streaming_latency
-        ] )
-    ; ( "lifecycle"
-      , [ test_case "reset clears all" `Quick test_aggregating_reset
-        ; test_case "key format" `Quick test_aggregating_key
-        ; test_case "multiple providers" `Quick test_aggregating_multiple_providers
-        ; test_case "snapshot to JSON" `Quick test_provider_snapshot_to_yojson
-        ; test_case
-            "snapshot list JSON is stable"
-            `Quick
-            test_provider_snapshots_to_yojson_is_stable
-        ; test_case "save snapshot JSON" `Quick test_aggregating_save_snapshot_json
-        ; test_case "inner delegation" `Quick test_aggregating_inner_delegation
-        ] )
-    ]
+  Eio_main.run (fun _ ->
+    run
+      "Metrics.Aggregating"
+      [ "create", [ test_case "empty snapshot" `Quick test_aggregating_create_empty ]
+      ; ( "counters"
+        , [ test_case "on_request_start" `Quick test_aggregating_on_request_start
+          ; test_case "on_retry" `Quick test_aggregating_on_retry
+          ; test_case "on_token_usage" `Quick test_aggregating_on_token_usage
+          ; test_case "on_tool_calls" `Quick test_aggregating_on_tool_calls
+          ; test_case "on_circuit_state" `Quick test_aggregating_on_circuit_state
+          ; test_case "on_error" `Quick test_aggregating_on_error
+          ; test_case
+              "on_request_end latency"
+              `Quick
+              test_aggregating_on_request_end_latency
+          ; test_case
+              "unknown request latency is not sampled"
+              `Quick
+              test_aggregating_unknown_latency_does_not_add_sample
+          ; test_case
+              "streaming latency callbacks"
+              `Quick
+              test_aggregating_on_streaming_latency
+          ] )
+      ; ( "lifecycle"
+        , [ test_case "reset clears all" `Quick test_aggregating_reset
+          ; test_case "key format" `Quick test_aggregating_key
+          ; test_case "multiple providers" `Quick test_aggregating_multiple_providers
+          ; test_case "snapshot to JSON" `Quick test_provider_snapshot_to_yojson
+          ; test_case
+              "snapshot list JSON is stable"
+              `Quick
+              test_provider_snapshots_to_yojson_is_stable
+          ; test_case "save snapshot JSON" `Quick test_aggregating_save_snapshot_json
+          ; test_case "inner delegation" `Quick test_aggregating_inner_delegation
+          ] )
+      ])
 ;;


### PR DESCRIPTION
The Aggregating backend used Stdlib.Mutex inside Eio callback paths. Stdlib.Mutex blocks the entire domain instead of yielding to the Eio scheduler and cannot deliver cancellation while waiting.\n\n- Replace Stdlib.Mutex with Eio.Mutex in Aggregating.t.\n- Convert with_state, snapshot, and reset to Eio.Mutex.use_rw ~protect:true.\n- Wrap the Metrics.Aggregating Alcotest suite in Eio_main.run so it runs under an Eio scheduler.\n\nRefs: audit finding OAS-mutable-ref-metrics-mutex