### PR TITLE
fix(durable_event): propagate reserved append callback exceptions

### DIFF
--- a/lib/durable_event.ml
+++ b/lib/durable_event.ml
@@ -76,6 +76,13 @@ type journal =
 
 let create ?on_append () = { state = Atomic.make ([], 0); on_append }
 
+let reraise_if_reserved_callback_exception exn =
+  match exn with
+  | Out_of_memory | Stack_overflow | Sys.Break | Eio.Cancel.Cancelled _ ->
+    Printexc.raise_with_backtrace exn (Printexc.get_raw_backtrace ())
+  | _ -> ()
+;;
+
 let append journal event =
   let rec loop () =
     let old_state = Atomic.get journal.state in
@@ -84,12 +91,13 @@ let append journal event =
     if not (Atomic.compare_and_set journal.state old_state new_state) then loop ()
   in
   loop ();
-  (* Fan-out callbacks must not be able to poison durable state. If a sink
-     raises, the event is already recorded; ignore the projection failure. *)
+  (* Fan-out callbacks must not be able to poison durable state. Ordinary sink
+     failures are ignored after the event is recorded, while cancellation/fatal
+     exceptions still propagate so callers can unwind correctly. *)
   Option.iter
     (fun f ->
        try f event with
-       | _ -> ())
+       | exn -> reraise_if_reserved_callback_exception exn)
     journal.on_append
 ;;
 

--- a/test/test_durable_event.ml
+++ b/test/test_durable_event.ml
@@ -299,6 +299,16 @@ let test_callback_exception_does_not_rollback_append () =
   | _ -> fail "expected appended event to remain visible"
 ;;
 
+let test_callback_cancelled_propagates_after_append () =
+  let j =
+    Durable_event.create ~on_append:(fun _event -> raise (Eio.Cancel.Cancelled Exit)) ()
+  in
+  (match Durable_event.append j (Turn_started { turn = 1; timestamp = ts }) with
+   | () -> fail "expected callback cancellation to propagate"
+   | exception Eio.Cancel.Cancelled _ -> ());
+  check int "journal still records cancelled callback event" 1 (Durable_event.length j)
+;;
+
 (* ── Persistence ──────────────────────────────────── *)
 
 let test_save_and_load_roundtrip () =
@@ -373,6 +383,10 @@ let () =
             "callback exception does not rollback append"
             `Quick
             test_callback_exception_does_not_rollback_append
+        ; test_case
+            "callback cancellation propagates after append"
+            `Quick
+            test_callback_cancelled_propagates_after_append
         ] )
     ; ( "idempotency"
       , [ test_case "deterministic key" `Quick test_idempotency_key_deterministic


### PR DESCRIPTION
## Problem

Follow-up to #2050. Durable journal `on_append` projection callbacks should fail-open for ordinary sink failures, but they must not absorb reserved exceptions such as `Eio.Cancel.Cancelled`, `Out_of_memory`, `Stack_overflow`, or `Sys.Break`.

Absorbing cancellation lets the agent continue after the caller cancelled a callback that may be blocked/yielding, which diverges from the callback isolation contract used elsewhere in OAS.

## Change

- Add a local reserved-exception filter in `Durable_event.append` callback isolation.
- Continue ignoring ordinary projection failures after the durable event is recorded.
- Re-raise cancellation/fatal runtime exceptions with the original backtrace.
- Add a regression test proving cancellation propagates while the event remains recorded.

## Verification

- `ocamlformat --check lib/durable_event.ml test/test_durable_event.ml`
- `git diff --check HEAD~1..HEAD`
- `scripts/dune-local.sh build test/test_durable_event.exe`
- `./_build/default/test/test_durable_event.exe`

Refs: #2050 review follow-up, OAS-mutable-ref-001