### PR TITLE
fix(metrics): preserve non-Eio aggregating snapshots

### DIFF
--- a/lib/llm_provider/metrics.ml
+++ b/lib/llm_provider/metrics.ml
@@ -246,6 +246,9 @@ let empty_state () : aggregate_state =
 
 (** Thread-safe aggregating metrics backend.
     Accumulates per-provider counters in a hash table guarded by a Mutex.
+    The critical sections are pure counter/Hashtbl updates with no I/O or
+    scheduler yield points, so a Stdlib mutex keeps the public snapshot/export
+    API usable from both Eio fibers and ordinary OCaml threads.
     Call {!Aggregating.snapshot} to read all counters as an immutable list.
 
     @since 0.188.0 *)
@@ -255,17 +258,22 @@ module Aggregating = struct
   type t =
     { hooks : hooks
     ; states : (aggregate_key, aggregate_state) Hashtbl.t
-    ; mutex : Eio.Mutex.t
+    ; mutex : Mutex.t
     }
 
   let key ~provider ~model_id = provider ^ "/" ^ model_id
 
   let create ?(inner = noop) () : t =
-    { hooks = inner; states = Hashtbl.create 16; mutex = Eio.Mutex.create () }
+    { hooks = inner; states = Hashtbl.create 16; mutex = Mutex.create () }
+  ;;
+
+  let with_lock agg f =
+    Mutex.lock agg.mutex;
+    Fun.protect ~finally:(fun () -> Mutex.unlock agg.mutex) f
   ;;
 
   let with_state agg key f =
-    Eio.Mutex.use_rw ~protect:true agg.mutex (fun () ->
+    with_lock agg (fun () ->
       let state =
         match Hashtbl.find_opt agg.states key with
         | Some s -> s
@@ -341,7 +349,7 @@ module Aggregating = struct
   ;;
 
   let snapshot (agg : t) : provider_snapshot list =
-    Eio.Mutex.use_rw ~protect:true agg.mutex (fun () ->
+    with_lock agg (fun () ->
       Hashtbl.fold
         (fun (k : aggregate_key) (s : aggregate_state) acc ->
            let provider, model_id =
@@ -376,7 +384,5 @@ module Aggregating = struct
     write_file_atomic path payload
   ;;
 
-  let reset (agg : t) =
-    Eio.Mutex.use_rw ~protect:true agg.mutex (fun () -> Hashtbl.reset agg.states)
-  ;;
+  let reset (agg : t) = with_lock agg (fun () -> Hashtbl.reset agg.states)
 end

--- a/lib/llm_provider/metrics.mli
+++ b/lib/llm_provider/metrics.mli
@@ -150,10 +150,12 @@ type hooks = t
 
 (** Thread-safe aggregating metrics backend.
 
-    Accumulates per-provider counters in a hash table guarded by an
-    {!Eio.Mutex.t}. Wrap an existing [Metrics.t] via {!Aggregating.create} to
-    layer counting on top of any other metrics sink. Call
-    {!Aggregating.snapshot} to read all counters as an immutable list.
+    Accumulates per-provider counters in a hash table guarded by a Stdlib
+    mutex. The guarded sections are pure counter updates, so this stays safe
+    for Eio callback paths while preserving the public snapshot/export API for
+    non-Eio exporters and tests. Wrap an existing [Metrics.t] via
+    {!Aggregating.create} to layer counting on top of any other metrics sink.
+    Call {!Aggregating.snapshot} to read all counters as an immutable list.
 
     @since 0.188.0 *)
 module Aggregating : sig

--- a/test/test_metrics_aggregating.ml
+++ b/test/test_metrics_aggregating.ml
@@ -352,41 +352,42 @@ let test_aggregating_inner_delegation () =
 ;;
 
 let () =
-  Eio_main.run (fun _ ->
-    run
-      "Metrics.Aggregating"
-      [ "create", [ test_case "empty snapshot" `Quick test_aggregating_create_empty ]
-      ; ( "counters"
-        , [ test_case "on_request_start" `Quick test_aggregating_on_request_start
-          ; test_case "on_retry" `Quick test_aggregating_on_retry
-          ; test_case "on_token_usage" `Quick test_aggregating_on_token_usage
-          ; test_case "on_tool_calls" `Quick test_aggregating_on_tool_calls
-          ; test_case "on_circuit_state" `Quick test_aggregating_on_circuit_state
-          ; test_case "on_error" `Quick test_aggregating_on_error
-          ; test_case
-              "on_request_end latency"
-              `Quick
-              test_aggregating_on_request_end_latency
-          ; test_case
-              "unknown request latency is not sampled"
-              `Quick
-              test_aggregating_unknown_latency_does_not_add_sample
-          ; test_case
-              "streaming latency callbacks"
-              `Quick
-              test_aggregating_on_streaming_latency
-          ] )
-      ; ( "lifecycle"
-        , [ test_case "reset clears all" `Quick test_aggregating_reset
-          ; test_case "key format" `Quick test_aggregating_key
-          ; test_case "multiple providers" `Quick test_aggregating_multiple_providers
-          ; test_case "snapshot to JSON" `Quick test_provider_snapshot_to_yojson
-          ; test_case
-              "snapshot list JSON is stable"
-              `Quick
-              test_provider_snapshots_to_yojson_is_stable
-          ; test_case "save snapshot JSON" `Quick test_aggregating_save_snapshot_json
-          ; test_case "inner delegation" `Quick test_aggregating_inner_delegation
-          ] )
-      ])
+  (* Intentionally not wrapped in Eio_main.run: snapshot/export APIs must work
+     for ordinary periodic exporters and tests that have no Eio scheduler. *)
+  run
+    "Metrics.Aggregating"
+    [ "create", [ test_case "empty snapshot" `Quick test_aggregating_create_empty ]
+    ; ( "counters"
+      , [ test_case "on_request_start" `Quick test_aggregating_on_request_start
+        ; test_case "on_retry" `Quick test_aggregating_on_retry
+        ; test_case "on_token_usage" `Quick test_aggregating_on_token_usage
+        ; test_case "on_tool_calls" `Quick test_aggregating_on_tool_calls
+        ; test_case "on_circuit_state" `Quick test_aggregating_on_circuit_state
+        ; test_case "on_error" `Quick test_aggregating_on_error
+        ; test_case
+            "on_request_end latency"
+            `Quick
+            test_aggregating_on_request_end_latency
+        ; test_case
+            "unknown request latency is not sampled"
+            `Quick
+            test_aggregating_unknown_latency_does_not_add_sample
+        ; test_case
+            "streaming latency callbacks"
+            `Quick
+            test_aggregating_on_streaming_latency
+        ] )
+    ; ( "lifecycle"
+      , [ test_case "reset clears all" `Quick test_aggregating_reset
+        ; test_case "key format" `Quick test_aggregating_key
+        ; test_case "multiple providers" `Quick test_aggregating_multiple_providers
+        ; test_case "snapshot to JSON" `Quick test_provider_snapshot_to_yojson
+        ; test_case
+            "snapshot list JSON is stable"
+            `Quick
+            test_provider_snapshots_to_yojson_is_stable
+        ; test_case "save snapshot JSON" `Quick test_aggregating_save_snapshot_json
+        ; test_case "inner delegation" `Quick test_aggregating_inner_delegation
+        ] )
+    ]
 ;;


### PR DESCRIPTION
## Problem

Follow-up to #2070. `Metrics.Aggregating.snapshot` and `save_snapshot_json` are public exporter APIs and are used from ordinary OCaml threads/tests as well as Eio callback paths.

#2070 moved the aggregator to `Eio.Mutex.use_rw ~protect:true`; that protects Eio fibers, but it also requires an Eio fiber context and makes non-Eio snapshot/export callers fail before jobs even need a scheduler.

## Change

- Use a Stdlib mutex for `Metrics.Aggregating` because the guarded work is pure counter/Hashtbl mutation with no I/O or scheduler yield points.
- Document that choice in both implementation and interface docs.
- Run `test_metrics_aggregating` outside `Eio_main.run` again so non-Eio snapshot/export use remains covered.

## Verification

- `ocamlformat --check lib/llm_provider/metrics.ml lib/llm_provider/metrics.mli test/test_metrics_aggregating.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_metrics_aggregating.exe`
- `./_build/default/test/test_metrics_aggregating.exe` (17 tests)

Refs: #2070 review thread, OAS-mutable-ref-metrics-mutex