### PR TITLE
fix(agent,responses): address open Codex P2 findings (incomplete-before-tooluse + lifecycle ordering)

### DIFF
--- a/lib/agent/agent_trace.ml
+++ b/lib/agent/agent_trace.ml
@@ -177,8 +177,13 @@ let with_raw_trace_run agent user_prompt f =
     set_lifecycle agent ~accepted_at:ts ~started_at:ts Accepted;
     let result = f None in
     (* Contract (agent_types.mli): on_run_complete runs *before* lifecycle is
-       updated, so completion hooks observe the pre-terminal run state. *)
-    invoke_on_run_complete agent ~ok:(Result.is_ok result);
+       updated, so completion hooks observe the pre-terminal run state.
+       Reserved exceptions (e.g. Eio.Cancel.Cancelled) still propagate, but the
+       terminal lifecycle transition must not be skipped. *)
+    (try invoke_on_run_complete agent ~ok:(Result.is_ok result) with
+     | exn ->
+       set_terminal_lifecycle agent result;
+       raise exn);
     set_terminal_lifecycle agent result;
     result
   | Some sink ->
@@ -216,12 +221,18 @@ let with_raw_trace_run agent user_prompt f =
          the lifecycle transition per the agent_types.mli contract. *)
       match Raw_trace.finish_run active ~final_text ~stop_reason ~error with
       | Ok _ ->
-        invoke_on_run_complete agent ~ok:(Result.is_ok result);
+        (try invoke_on_run_complete agent ~ok:(Result.is_ok result) with
+         | exn ->
+           set_terminal_lifecycle agent result;
+           raise exn);
         set_terminal_lifecycle agent result;
         result
       | Error err ->
         let trace_error = Error err in
-        invoke_on_run_complete agent ~ok:false;
+        (try invoke_on_run_complete agent ~ok:false with
+         | exn ->
+           set_terminal_lifecycle agent trace_error;
+           raise exn);
         set_terminal_lifecycle agent trace_error;
         trace_error
     in

--- a/lib/agent/agent_trace.ml
+++ b/lib/agent/agent_trace.ml
@@ -176,8 +176,10 @@ let with_raw_trace_run agent user_prompt f =
     let ts = Unix.gettimeofday () in
     set_lifecycle agent ~accepted_at:ts ~started_at:ts Accepted;
     let result = f None in
-    set_terminal_lifecycle agent result;
+    (* Contract (agent_types.mli): on_run_complete runs *before* lifecycle is
+       updated, so completion hooks observe the pre-terminal run state. *)
     invoke_on_run_complete agent ~ok:(Result.is_ok result);
+    set_terminal_lifecycle agent result;
     result
   | Some sink ->
     let* active =
@@ -209,15 +211,18 @@ let with_raw_trace_run agent user_prompt f =
           , None )
         | Error err -> None, None, Some (Error.to_string err)
       in
+      (* Raw trace is finished first (so a reserved exception re-raised from the
+         callback cannot leave the trace open), then on_run_complete runs before
+         the lifecycle transition per the agent_types.mli contract. *)
       match Raw_trace.finish_run active ~final_text ~stop_reason ~error with
       | Ok _ ->
-        set_terminal_lifecycle agent result;
         invoke_on_run_complete agent ~ok:(Result.is_ok result);
+        set_terminal_lifecycle agent result;
         result
       | Error err ->
         let trace_error = Error err in
-        set_terminal_lifecycle agent trace_error;
         invoke_on_run_complete agent ~ok:false;
+        set_terminal_lifecycle agent trace_error;
         trace_error
     in
     (match f (Some active) with

--- a/lib/llm_provider/backend_openai_responses.ml
+++ b/lib/llm_provider/backend_openai_responses.ml
@@ -496,30 +496,35 @@ let stop_reason_of_response_json ~has_tool_calls json =
   let status =
     opt_bind (json_assoc_opt "status" json) json_string_opt |> Option.value ~default:""
   in
-  if has_tool_calls
-  then StopToolUse
-  else (
-    match String.lowercase_ascii status with
-    | "completed" | "" -> EndTurn
-    | "incomplete" ->
-      let reason =
-        match json_assoc_opt "incomplete_details" json with
-        | Some details ->
-          opt_bind (json_assoc_opt "reason" details) json_string_opt
-          |> Option.value ~default:"incomplete"
-        | None -> "incomplete"
-      in
-      if String.equal reason "max_output_tokens" then MaxTokens else Unknown reason
-    | "failed" ->
-      (match
-         match json_assoc_opt "error" json with
-         | Some error -> json_assoc_opt "message" error
-         | None -> None
-       with
-       | Some (`String message) -> Unknown message
-       | Some (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
-       | None -> Unknown status)
-    | other -> Unknown other)
+  (* A terminal [incomplete]/[failed] response status wins over tool-use
+     detection: a Responses result can carry a [function_call] item while the
+     generation was actually cut off (status="incomplete", e.g. max output
+     tokens). Returning [StopToolUse] there would execute partial/invalid tool
+     arguments instead of surfacing MaxTokens/an incomplete response. So we
+     match the cut-off statuses first, then fall back to tool-use, then the
+     normal completion path. (Codex P2, #2048.) *)
+  match String.lowercase_ascii status with
+  | "incomplete" ->
+    let reason =
+      match json_assoc_opt "incomplete_details" json with
+      | Some details ->
+        opt_bind (json_assoc_opt "reason" details) json_string_opt
+        |> Option.value ~default:"incomplete"
+      | None -> "incomplete"
+    in
+    if String.equal reason "max_output_tokens" then MaxTokens else Unknown reason
+  | "failed" ->
+    (match
+       match json_assoc_opt "error" json with
+       | Some error -> json_assoc_opt "message" error
+       | None -> None
+     with
+     | Some (`String message) -> Unknown message
+     | Some (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
+     | None -> Unknown status)
+  | _ when has_tool_calls -> StopToolUse
+  | "completed" | "" -> EndTurn
+  | other -> Unknown other
 ;;
 
 let parse_response_result json_str =

--- a/lib/llm_provider/backend_openai_responses.ml
+++ b/lib/llm_provider/backend_openai_responses.ml
@@ -520,8 +520,8 @@ let stop_reason_of_response_json ~has_tool_calls json =
        | None -> None
      with
      | Some (`String message) -> Unknown message
-     | Some (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
-     | None -> Unknown status)
+     | Some (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) | None
+       -> Unknown status)
   | _ when has_tool_calls -> StopToolUse
   | "completed" | "" -> EndTurn
   | other -> Unknown other
@@ -546,6 +546,23 @@ let parse_response_result json_str =
         | None -> []
       in
       let content = List.concat_map content_blocks_of_output_item output in
+      (* Terminal [incomplete]/[failed] responses may carry a partial [function_call]
+         item; do not expose it as a dangling ToolUse that the pipeline would try to
+         execute or repair. Drop such blocks so the stop reason dominates. *)
+      let status =
+        opt_bind (json_assoc_opt "status" json) json_string_opt
+        |> Option.value ~default:""
+      in
+      let content =
+        match String.lowercase_ascii status with
+        | "incomplete" | "failed" ->
+          List.filter
+            (function
+              | ToolUse _ -> false
+              | _ -> true)
+            content
+        | _ -> content
+      in
       let has_tool_calls =
         List.exists
           (function

--- a/test/test_agent_periodic_cleanup.ml
+++ b/test/test_agent_periodic_cleanup.ml
@@ -253,6 +253,52 @@ let test_on_run_complete_cancelled_finishes_raw_trace () =
        records)
 ;;
 
+(* Contract (agent_types.mli): on_run_complete runs *before* the terminal
+   lifecycle transition, so a completion hook observes the pre-terminal run
+   state rather than Completed/Failed. (Codex P2 on #2057.) *)
+let test_on_run_complete_observes_pre_terminal_lifecycle () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let transport = make_transport ~clock ~sleep_s:0.0 () in
+  let agent_ref = ref None in
+  let observed = ref None in
+  let agent =
+    make_agent
+      ~net:(Eio.Stdenv.net env)
+      ~transport
+      ~on_run_complete:(fun _ ->
+        match !agent_ref with
+        | Some a ->
+          observed
+          := Option.map
+               (fun (s : Agent.lifecycle_snapshot) -> s.status)
+               (Agent.lifecycle a)
+        | None -> ())
+      ()
+  in
+  agent_ref := Some agent;
+  (match Agent.run ~sw ~clock agent "finish" with
+   | Ok _ -> ()
+   | Error err -> Alcotest.fail ("expected success: " ^ Error.to_string err));
+  (match !observed with
+   | Some status ->
+     Alcotest.(check bool)
+       "on_run_complete observed pre-terminal lifecycle"
+       false
+       (Agent_lifecycle.is_terminal status)
+   | None -> Alcotest.fail "on_run_complete did not observe a lifecycle snapshot");
+  match Agent.lifecycle agent with
+  | Some snap ->
+    Alcotest.(check bool)
+      "agent ends Completed after the callback"
+      true
+      (snap.status = Agent.Completed)
+  | None -> Alcotest.fail "expected terminal lifecycle after run"
+;;
+
 let test_periodic_callback_failure_is_structured_log () =
   with_log_capture
   @@ fun get_records ->
@@ -312,6 +358,10 @@ let () =
             "on_run_complete Cancelled still finishes raw trace"
             `Quick
             test_on_run_complete_cancelled_finishes_raw_trace
+        ; Alcotest.test_case
+            "on_run_complete observes pre-terminal lifecycle (#2057)"
+            `Quick
+            test_on_run_complete_observes_pre_terminal_lifecycle
         ; Alcotest.test_case
             "periodic callback failure uses structured log"
             `Quick

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -972,8 +972,7 @@ let responses_incomplete_with_function_call_json () =
               ; "arguments", `String {|{"city":"Par|}
               ]
           ] )
-    ; ( "usage"
-      , `Assoc [ "input_tokens", `Int 12; "output_tokens", `Int 256 ] )
+    ; "usage", `Assoc [ "input_tokens", `Int 12; "output_tokens", `Int 256 ]
     ]
 ;;
 

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -949,6 +949,47 @@ let test_responses_parse_reasoning_and_function_call () =
      | None -> Alcotest.fail "expected telemetry")
 ;;
 
+(* Regression for Codex P2 (#2048): a Responses result whose generation was cut
+   off (status="incomplete", incomplete_details.reason="max_output_tokens") can
+   still carry a [function_call] item with truncated arguments. The stop reason
+   must surface the cut-off ([MaxTokens]) rather than [StopToolUse], so the agent
+   does not execute partial/invalid tool arguments. Before the fix,
+   [has_tool_calls] short-circuited to [StopToolUse] before the status was
+   examined. *)
+let responses_incomplete_with_function_call_json () =
+  `Assoc
+    [ "id", `String "resp_inc"
+    ; "model", `String "gpt-5.5"
+    ; "status", `String "incomplete"
+    ; "incomplete_details", `Assoc [ "reason", `String "max_output_tokens" ]
+    ; ( "output"
+      , `List
+          [ `Assoc
+              [ "id", `String "fc_1"
+              ; "type", `String "function_call"
+              ; "call_id", `String "call_weather"
+              ; "name", `String "get_weather"
+              ; "arguments", `String {|{"city":"Par|}
+              ]
+          ] )
+    ; ( "usage"
+      , `Assoc [ "input_tokens", `Int 12; "output_tokens", `Int 256 ] )
+    ]
+;;
+
+let test_responses_incomplete_status_wins_over_function_call () =
+  match
+    Responses.parse_response_result
+      (responses_incomplete_with_function_call_json () |> Yojson.Safe.to_string)
+  with
+  | Error msg -> Alcotest.fail ("unexpected responses parse error: " ^ msg)
+  | Ok response ->
+    check_bool
+      "incomplete max_output_tokens maps to MaxTokens, not StopToolUse"
+      true
+      (response.stop_reason = MaxTokens)
+;;
+
 let test_responses_preserves_encrypted_reasoning_item_for_replay () =
   let encrypted_reasoning_item =
     `Assoc
@@ -1289,6 +1330,10 @@ let () =
             "parse reasoning and function_call items"
             `Quick
             test_responses_parse_reasoning_and_function_call
+        ; Alcotest.test_case
+            "incomplete status wins over function_call (#2048)"
+            `Quick
+            test_responses_incomplete_status_wins_over_function_call
         ; Alcotest.test_case
             "preserve encrypted reasoning item for replay"
             `Quick

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -986,7 +986,18 @@ let test_responses_incomplete_status_wins_over_function_call () =
     check_bool
       "incomplete max_output_tokens maps to MaxTokens, not StopToolUse"
       true
-      (response.stop_reason = MaxTokens)
+      (response.stop_reason = MaxTokens);
+    (* The partial function_call must be dropped from content so the pipeline
+       does not append a dangling ToolUse (which a later turn would repair with a
+       synthetic error ToolResult). Codex P2 follow-up on #2073. *)
+    check_bool
+      "partial function_call suppressed from incomplete response content"
+      false
+      (List.exists
+         (function
+           | ToolUse _ -> true
+           | _ -> false)
+         response.content)
 ;;
 
 let test_responses_preserves_encrypted_reasoning_item_for_replay () =


### PR DESCRIPTION
## 요약

concurrency-fix 배치에서 Codex가 P2로 지적했으나 **미대응으로 머지된** OPEN finding들을 수정합니다.

### 1) responses: incomplete/failed 상태가 tool-use보다 우선 (#2048)
`stop_reason_of_response_json`이 `has_tool_calls`이면 status 확인 전 `StopToolUse`로 단락 → 생성이 잘린(`status="incomplete"`) 응답의 부분 function_call을 잘린 인자로 실행할 위험. incomplete/failed를 먼저 매칭하도록 재배치. (`lib/llm_provider/backend_openai_responses.ml` + 회귀 테스트)

### 2) agent: on_run_complete를 terminal lifecycle 전이 *전*에 실행 (#2057 lifecycle)
`agent_types.mli` 계약은 "on_run_complete runs before lifecycle state is updated"인데 raw-trace 리팩터가 3개 finalize 경로에서 `set_terminal_lifecycle`을 콜백 앞으로 옮겨 계약 위반(hook이 pre-terminal 대신 Completed/Failed를 봄). 3곳 모두 callback→lifecycle 순서로 복원(raw trace는 `finish_run`이 먼저라 reserved 예외 re-raise 시에도 보존). (`lib/agent/agent_trace.ml` + 회귀 테스트)

### review-response 검증 메모
같은 배치의 다른 OPEN P2 2건은 **현재 main에 이미 수정 반영**됨(스레드만 미해결):
- #2050 durable_event Cancelled 흡수 → `reraise_if_reserved_callback_exception`.
- #2070 metrics Eio-only → Aggregating mutex `Stdlib.Mutex` 환원.

resolved 표시된 findings(#2053 alias, #2052 turn_budget)는 Atomic+CAS로 실제 수정 확인.

로컬 검증: `@check` exit 0, test_backend_openai_codec 29 green, test_agent_periodic_cleanup 8 green, test_hooks 35 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
