### PR TITLE
fix(responses): drop partial tool blocks for all incomplete reasons (#2076 follow-up)

### DIFF
--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -385,6 +385,7 @@ let complete_stream_http
           `Wire_error
         | Types.Connected -> `Skip
         | Types.Timeout _ -> `Wire_error
+        | Types.StreamIncomplete _ -> `Skip
       in
       let percentiles () =
         match !inter_chunk_samples with

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -15,6 +15,7 @@ type stream_acc =
   ; cache_read : int ref
   ; stop_reason : Types.stop_reason ref
   ; stop_reason_received : bool ref
+  ; terminal_incomplete : bool ref
   ; sse_error : Types.stream_error option ref
   ; block_texts : (int, Buffer.t) Hashtbl.t
   ; block_types : (int, string) Hashtbl.t
@@ -32,6 +33,7 @@ let create_stream_acc () =
   ; cache_read = ref 0
   ; stop_reason = ref Types.EndTurn
   ; stop_reason_received = ref false
+  ; terminal_incomplete = ref false
   ; sse_error = ref None
   ; block_texts = Hashtbl.create 4
   ; block_types = Hashtbl.create 4
@@ -109,6 +111,7 @@ let accumulate_event (acc : stream_acc) = function
     acc.sse_error := Some (Types.Stream_parse_failed { reason; raw })
   | Types.SSEUnknownEventType { event_type; raw } ->
     acc.sse_error := Some (Types.Stream_unknown_event { event_type; raw })
+  | Types.StreamIncomplete _ -> acc.terminal_incomplete := true
   | Types.MessageStop | Types.Ping | Types.Connected | Types.Timeout _ -> ()
 ;;
 
@@ -149,20 +152,26 @@ let finalize_stream_acc (acc : stream_acc) =
              (match Hashtbl.find_opt acc.block_tool_ids idx with
               | Some data when data <> "" -> Some (Types.RedactedThinking data)
               | Some _ | None -> None)
-           | Some "tool_use" when !(acc.stop_reason) = Types.MaxTokens ->
+           | Some "tool_use"
+             when !(acc.terminal_incomplete) || !(acc.stop_reason) = Types.MaxTokens ->
              (* A tool call only belongs to a turn the model finished at a tool
-                boundary. When the turn was truncated (stop_reason = MaxTokens —
-                e.g. an OpenAI Responses [response.incomplete] with reason
-                max_output_tokens), the accumulated tool block is partial: its
-                argument buffer may be empty (cut off before the first delta) or
-                even parse as JSON yet be incomplete. Drop it so the pipeline does
-                not store a dangling assistant ToolUse that a later turn repairs
-                with a synthetic error ToolResult. Status-aware, mirroring the
+                boundary. When the turn was cut off, the accumulated tool block is
+                partial: its argument buffer may be empty (cut off before the first
+                delta) or even parse as JSON yet be incomplete. Drop it so the
+                pipeline does not store a dangling assistant ToolUse that a later
+                turn repairs with a synthetic error ToolResult. Mirrors the
                 non-streaming parser Backend_openai_responses.parse_response_result,
                 which drops ToolUse for incomplete/failed Responses statuses.
+                Two cut-off signals:
+                - [terminal_incomplete]: an OpenAI Responses [response.incomplete]
+                  for ANY reason (max_output_tokens, content_filter, ...), carried
+                  via the [StreamIncomplete] event.
+                - [stop_reason = MaxTokens]: a token-limit truncation from any
+                  provider (e.g. Anthropic/OpenAI streaming) that does not emit a
+                  Responses incomplete terminal.
                 (#2073 streaming follow-up.) [response.failed]/[error] terminals
-                set [sse_error] instead, so finalize returns [Error] before
-                content assembly and never reaches this branch. *)
+                set [sse_error] instead, so finalize returns [Error] before content
+                assembly and never reaches this branch. *)
              None
            | Some "tool_use" ->
              let id =
@@ -632,6 +641,27 @@ let%test "finalize_stream_acc drops tool_use on truncated turn (MaxTokens)" =
   Buffer.add_string buf "{\"city\":\"Paris\"}";
   Hashtbl.replace acc.block_texts 0 buf;
   acc.stop_reason := Types.MaxTokens;
+  match
+    acc.stop_reason_received := true;
+    finalize_stream_acc acc
+  with
+  | Error _ -> false
+  | Ok result -> result.content = []
+;;
+
+let%test "finalize_stream_acc drops tool_use on incomplete non-token reason" =
+  (* A Responses [response.incomplete] for a non-max_output_tokens reason (e.g.
+     content_filter) carries [terminal_incomplete] via StreamIncomplete; the tool
+     block must drop even though stop_reason is not MaxTokens. #2073. *)
+  let acc = create_stream_acc () in
+  Hashtbl.replace acc.block_types 0 "tool_use";
+  Hashtbl.replace acc.block_tool_ids 0 "tool-id-1";
+  Hashtbl.replace acc.block_tool_names 0 "get_weather";
+  let buf = Buffer.create 16 in
+  Buffer.add_string buf "{\"city\":\"Paris\"}";
+  Hashtbl.replace acc.block_texts 0 buf;
+  acc.stop_reason := Types.Unknown "content_filter";
+  acc.terminal_incomplete := true;
   match
     acc.stop_reason_received := true;
     finalize_stream_acc acc

--- a/lib/llm_provider/complete_stream_acc.mli
+++ b/lib/llm_provider/complete_stream_acc.mli
@@ -19,6 +19,7 @@ type stream_acc =
   ; cache_read : int ref
   ; stop_reason : Types.stop_reason ref
   ; stop_reason_received : bool ref
+  ; terminal_incomplete : bool ref
   ; sse_error : Types.stream_error option ref
   ; block_texts : (int, Buffer.t) Hashtbl.t
   ; block_types : (int, string) Hashtbl.t

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -153,7 +153,8 @@ let sse_event_is_first_token_signal (e : sse_event) : bool =
   | SSEParseFailed _
   | SSEUnknownEventType _
   | Connected
-  | Timeout _ -> false
+  | Timeout _
+  | StreamIncomplete _ -> false
 ;;
 
 let sse_event_is_deliverable_progress_signal (e : sse_event) : bool =
@@ -174,7 +175,8 @@ let sse_event_is_deliverable_progress_signal (e : sse_event) : bool =
   | SSEParseFailed _
   | SSEUnknownEventType _
   | Connected
-  | Timeout _ -> false
+  | Timeout _
+  | StreamIncomplete _ -> false
 ;;
 
 let thinking_only_timeout_exceeded ~timeout_s ~started_at ~now =
@@ -627,8 +629,15 @@ let responses_output_has_function_call response =
   | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ -> false
 ;;
 
-let responses_stop_reason_of_response response =
+let responses_incomplete_reason response =
   let open Yojson.Safe.Util in
+  match response |> member "incomplete_details" with
+  | `Assoc _ as details ->
+    responses_member_string_opt "reason" details |> Option.value ~default:"incomplete"
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> "incomplete"
+;;
+
+let responses_stop_reason_of_response response =
   (* A cut-off generation ([status="incomplete"]/[status="failed"]) can still
      carry a partial [function_call] item. The terminal status must win over
      tool-call detection, otherwise the stream finalizes as [StopToolUse] and the
@@ -639,14 +648,9 @@ let responses_stop_reason_of_response response =
      symmetry. *)
   match responses_member_string_opt "status" response with
   | Some "incomplete" ->
-    let reason =
-      match response |> member "incomplete_details" with
-      | `Assoc _ as details ->
-        responses_member_string_opt "reason" details |> Option.value ~default:"incomplete"
-      | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
-        "incomplete"
-    in
-    if String.equal reason "max_output_tokens" then MaxTokens else Unknown reason
+    if String.equal (responses_incomplete_reason response) "max_output_tokens"
+    then MaxTokens
+    else Unknown (responses_incomplete_reason response)
   | Some "failed" -> Unknown "failed"
   | Some "completed" | None ->
     if responses_output_has_function_call response then StopToolUse else EndTurn
@@ -848,6 +852,15 @@ let responses_sse_to_events (state : provider_d_stream_state) event_type data_st
        | "response.completed" | "response.incomplete" ->
          let response = json |> member "response" in
          responses_emit_redacted_reasoning_outputs state emit response;
+         (* A [response.incomplete] terminal means the turn was cut off, so any
+            in-progress tool call is partial. Carry that to the accumulator
+            (which drops partial tool blocks at finalize) for ANY incomplete
+            reason — [stop_reason = MaxTokens] alone only covers
+            max_output_tokens, not e.g. content_filter. (#2073 follow-up.) *)
+         (match responses_member_string_opt "status" response with
+          | Some "incomplete" ->
+            emit (StreamIncomplete { reason = responses_incomplete_reason response })
+          | Some _ | None -> ());
          emit_terminal response
        | "response.failed" | "error" ->
          emit

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -406,6 +406,7 @@ type sse_event =
       }
   | Connected
   | Timeout of string
+  | StreamIncomplete of { reason : string }
 
 (** Terminal error captured while accumulating an SSE stream.
 

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -288,6 +288,14 @@ type sse_event =
             type the OAS adapter has not yet learned. Emit explicitly so
             the consumer can decide (log + skip vs fail-fast) instead of
             silent data loss. *)
+  | StreamIncomplete of { reason : string }
+  (** The provider signalled the turn was cut off before a natural stop (an
+      OpenAI Responses [response.incomplete]). Any in-progress tool call is
+      partial, so the accumulator drops tool blocks at finalize rather than
+      surfacing a dangling/executable ToolUse. [reason] is the provider's
+      incomplete reason (e.g. ["max_output_tokens"], ["content_filter"]). This
+      covers incomplete reasons beyond [max_output_tokens], which the
+      [stop_reason = MaxTokens] check alone misses. *)
 
 (** Terminal error captured while accumulating an SSE stream. The accumulator
     stores this typed value (not a flattened string) so a provider-reported

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -123,6 +123,11 @@ let accumulate_event (acc : stream_acc) = function
     acc.sse_error
     := Some (Printf.sprintf "sse_unknown_event_type: %s | chunk: %s" event_type preview)
   | MessageStop -> acc.stop_reason_received := true
+  (* StreamIncomplete drives the partial-tool drop on the primary
+     [Complete_stream_acc] path; this secondary accumulator (see WORKAROUND
+     above) does not assemble/drop tool blocks here, so it is a no-op pending the
+     same unification. *)
+  | StreamIncomplete _ -> ()
   | Ping | ContentBlockStop _ | Connected | Timeout _ -> ()
 ;;
 

--- a/test/test_streaming_openai.ml
+++ b/test/test_streaming_openai.ml
@@ -801,6 +801,46 @@ let test_responses_stream_incomplete_drops_partial_tool () =
          response.content)
 ;;
 
+(* Companion to the max_output_tokens case: a [response.incomplete] for a
+   non-token reason (content_filter) maps to [Unknown _], not [MaxTokens], yet the
+   partial tool call must still be dropped. This proves the StreamIncomplete
+   carry covers ALL incomplete reasons, not just MaxTokens. (#2073 follow-up.) *)
+let test_responses_stream_incomplete_content_filter_drops_tool () =
+  let module Acc = Llm_provider.Complete_stream_acc in
+  let state =
+    S.create_openai_stream_state ~provider:"openai_compat" ~model:"gpt-5.5" ()
+  in
+  let acc = Acc.create_stream_acc () in
+  let feed evt_type data =
+    let events, _ = S.responses_sse_to_events state (Some evt_type) data in
+    List.iter (Acc.accumulate_event acc) events
+  in
+  feed
+    "response.output_item.added"
+    {|{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"get_weather","arguments":""}}|};
+  feed
+    "response.function_call_arguments.delta"
+    {|{"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_1","delta":"{\"city\":\"Paris\"}"}|};
+  feed
+    "response.incomplete"
+    {|{"type":"response.incomplete","response":{"id":"resp_1","model":"gpt-5.5","status":"incomplete","incomplete_details":{"reason":"content_filter"},"output":[{"id":"fc_1","type":"function_call","call_id":"call_1","name":"get_weather","arguments":"{\"city\":\"Paris\"}"}],"usage":{"input_tokens":12,"output_tokens":8}}}|};
+  match Acc.finalize_stream_acc acc with
+  | Error _ -> Alcotest.fail "expected Ok response for incomplete terminal"
+  | Ok response ->
+    Alcotest.(check bool)
+      "content_filter incomplete -> Unknown, not MaxTokens"
+      true
+      (response.stop_reason = Unknown "content_filter");
+    Alcotest.(check bool)
+      "partial function_call dropped for non-token incomplete reason"
+      false
+      (List.exists
+         (function
+           | ToolUse _ -> true
+           | _ -> false)
+         response.content)
+;;
+
 let () =
   let open Alcotest in
   run
@@ -858,6 +898,10 @@ let () =
             "incomplete drops partial tool (#2073)"
             `Quick
             test_responses_stream_incomplete_drops_partial_tool
+        ; test_case
+            "incomplete content_filter drops tool (#2073)"
+            `Quick
+            test_responses_stream_incomplete_content_filter_drops_tool
         ] )
     ]
 ;;

--- a/test/test_structured_stream.ml
+++ b/test/test_structured_stream.ml
@@ -167,6 +167,7 @@ let test_on_event_callback_fires () =
       | SSEUnknownEventType _ -> "unknown_event_type"
       | Connected -> "connected"
       | Timeout _ -> "timeout"
+      | StreamIncomplete _ -> "stream_incomplete"
     in
     event_types := t :: !event_types);
   let types = List.rev !event_types in


### PR DESCRIPTION
## 요약

`#2076`이 streaming Responses incomplete 시 partial tool drop을 **`stop_reason = MaxTokens`로만** 처리해, **non-token incomplete reason(예: `content_filter`)을 놓쳤습니다**. Codex가 `#2076` 머지 직전 P2로 지적했으나 머지 타이밍상 미반영. 이 PR이 **모든 incomplete reason**을 처리합니다.

## 문제 (main에 잔존)

Responses 스트림이 `status="incomplete"`로 끝날 때 reason이 `max_output_tokens`가 아니면(`content_filter` 등) `responses_stop_reason_of_response`가 `Unknown reason`을 기록합니다. 그런데 `finalize_stream_acc`의 drop은 `MaxTokens`만 검사 → partial `ToolUse`가 그대로 emit → `stage_collect`가 dangling tool call을 저장 → `close_tool_message_pairs_for_request`가 synthetic error `ToolResult`로 repair. non-streaming 파서는 **모든** incomplete/failed status에서 ToolUse를 drop합니다.

## 수정 (Codex 제안: status를 accumulator로 carry, heuristic 대신 typed event)

`Unknown`을 generic하게 drop 트리거로 쓰면 다른 provider의 비표준 finish_reason→Unknown(+valid tools)을 잘못 버립니다. 그래서 Responses incomplete를 **typed event**로 정확히 전달:

- `Types.sse_event`에 `StreamIncomplete { reason }` 추가.
- `streaming.ml`: `response.incomplete` 터미널에서 reason 무관하게 `StreamIncomplete` emit (`responses_incomplete_reason` 추출).
- `complete_stream_acc`: `terminal_incomplete` 플래그를 `StreamIncomplete`가 set. finalize는 `terminal_incomplete || stop_reason = MaxTokens`일 때 tool_use drop.
  - `MaxTokens` arm은 non-Responses 토큰한도 절단(Anthropic/OpenAI streaming)을 계속 커버 → **회귀 없음**.
- `complete_stream` / `lib/streaming` / structured-stream 테스트: 새 variant 처리(tool 조립 안 하는 곳은 no-op).

## 왜 typed event인가 (트레이드오프)

- 장점: Responses incomplete를 정확히 식별, 모든 reason 커버, cross-provider 안전, 컴파일러가 모든 소비처를 강제(누락 불가).
- 단점: 공개 `sse_event` 타입에 variant 1개 추가(소비처 5곳 갱신). masc drift-check 대상 surface(event_bus/http_error/metrics)에는 영향 없음.

## 테스트

- e2e (`responses_sse_to_events` → accumulator → `finalize_stream_acc`): `content_filter` incomplete(→ `Unknown`, not `MaxTokens`)에서도 ToolUse 0개 + stop_reason 확인.
- inline finalize: non-token incomplete reason drop.
- 기존 max_output_tokens e2e + MaxTokens/StopToolUse 유지.

로컬: `@check` 0, `test_streaming_openai` 28, `test_structured_stream` 8, `@lib/llm_provider/runtest` 0, `@fmt` 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
