### PR TITLE
Wire provider reasoning dialect metadata

### DIFF
--- a/docs/design/provider-reasoning-dialects.md
+++ b/docs/design/provider-reasoning-dialects.md
@@ -1,0 +1,64 @@
+# Provider Reasoning Dialects
+
+Date: 2026-06-14
+
+## Purpose
+
+OAS owns provider and transport behavior. MASC and other agent runtimes should
+consume typed OAS facts instead of matching model names or provider-specific
+strings when they decide how to display, replay, pause, or interrupt reasoning.
+
+`Llm_provider.Reasoning_dialect` is the typed surface for those facts. It is
+derived from the existing capability catalog and provider defaults, so it does
+not introduce a second model registry.
+
+## Current Dialects
+
+| Capability wire format | Dialect meaning | Replay policy |
+| --- | --- | --- |
+| `Thinking_object` | DeepSeek-style top-level `thinking` object, optional `reasoning_effort`, side-channel `reasoning_content` | Drop reasoning between plain user turns, preserve reasoning after assistant tool calls |
+| `Thinking_object_only` | Top-level `thinking` object without effort | No mandatory replay yet |
+| `Chat_template_kwargs` | Self-hosted chat-template kwargs such as Qwen `enable_thinking` / `preserve_thinking` | No mandatory replay yet |
+| `Chat_template_token` | Template token injection such as Gemma `<\|think\|>` | No mandatory replay; parse visible thought channel from generated text |
+| `Reasoning_effort` | OpenAI-compatible `reasoning_effort` field | No mandatory replay yet |
+| `Enable_thinking` | DashScope-style top-level `enable_thinking` | No mandatory replay yet |
+| `Anthropic_thinking` | Claude Messages API `thinking` blocks | Preserve thinking blocks in history; Claude filters relevant blocks |
+| `Gemini_thinking_config` | Gemini native `generationConfig.thinkingConfig` and thought parts/signatures | Preserve tool-call-linked thought signatures |
+
+## Evidence
+
+- DeepSeek official docs: thinking defaults to enabled, `low` and `medium`
+  efforts map to `high`, `xhigh` maps to `max`, sampling parameters are ignored
+  in thinking mode, and `reasoning_content` must be replayed after tool-call
+  turns. Source: <https://api-docs.deepseek.com/guides/thinking_mode>,
+  checked 2026-06-14.
+- Gemma official docs: Gemma 4 thinking is enabled through chat-template
+  control (`enable_thinking=True` in the processor), generated output contains
+  a thought channel plus answer content, and parsing requires keeping special
+  tokens. Source: <https://ai.google.dev/gemma/docs/capabilities/thinking?hl=ko>,
+  checked 2026-06-14.
+- Claude official docs: extended thinking uses `thinking` blocks, and during
+  tool use those blocks must be passed back unchanged; Claude filters relevant
+  blocks. Source:
+  <https://platform.claude.com/docs/en/build-with-claude/extended-thinking>,
+  checked 2026-06-14.
+- OpenAI official docs: reasoning models expose reasoning controls and prior
+  reasoning state can be preserved with `previous_response_id` or by manually
+  passing reasoning items forward. Source:
+  <https://developers.openai.com/api/docs/guides/reasoning>, checked
+  2026-06-14.
+- Gemini official docs: Gemini exposes `thinkingConfig`, `thinkingBudget`, and
+  optional thought summaries marked on response parts. Source:
+  <https://ai.google.dev/gemini-api/docs/thinking>, checked 2026-06-14.
+- DashScope/Qwen official docs: OpenAI-compatible Qwen thinking uses
+  `enable_thinking`, optional `thinking_budget`, side-channel
+  `reasoning_content`, and `preserve_thinking` for carrying historical
+  assistant reasoning forward. Source:
+  <https://help.aliyun.com/zh/model-studio/deep-thinking>, checked 2026-06-14.
+
+## Boundary
+
+This module does not schedule tool calls, pause keepers, or decide whether a
+user interruption should preempt a running turn. It only exposes provider
+semantics. Agent runtimes should use these facts to build their own control
+loops without copying provider-specific rules into MASC.

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -16,6 +16,8 @@ open Types
     a race is harmless and only happens once per key. *)
 let capability_drop_warned : (string * string, unit) Hashtbl.t = Hashtbl.create 16
 
+let dialect_ignored_warned : (string * string, unit) Hashtbl.t = Hashtbl.create 16
+
 let warn_capability_drop ~model_id ~field =
   let key = model_id, field in
   if not (Hashtbl.mem capability_drop_warned key)
@@ -30,6 +32,35 @@ let warn_capability_drop ~model_id ~field =
       field
       model_id
       field)
+;;
+
+let warn_dialect_ignored ~model_id ~field =
+  let key = model_id, field in
+  if not (Hashtbl.mem dialect_ignored_warned key)
+  then (
+    Hashtbl.replace dialect_ignored_warned key ();
+    Diag.warn
+      "backend_openai"
+      "dropping request field %s for model %s: the selected reasoning dialect ignores \
+       this sampling parameter while thinking is enabled."
+      field
+      model_id)
+;;
+
+let thinking_enabled_for_dialect (config : Provider_config.t) =
+  match config.enable_thinking with
+  | Some false -> false
+  | Some true | None -> true
+;;
+
+let add_sampling_field dialect config field value body =
+  if
+    thinking_enabled_for_dialect config
+    && List.mem field (Reasoning_dialect.sampling_params_ignored_when_thinking dialect)
+  then (
+    warn_dialect_ignored ~model_id:config.model_id ~field;
+    body)
+  else (field, value) :: body
 ;;
 
 (* ── Request building ──────────────────────────────────── *)
@@ -101,7 +132,7 @@ let capabilities_of_config (config : Provider_config.t) =
         | Provider_config.Gemini -> Capabilities.gemini_capabilities
         | Provider_config.Anthropic -> Capabilities.anthropic_capabilities
         | Provider_config.OpenAI_compat -> Capabilities.default_capabilities
-        | Provider_config.DashScope -> assert false))
+        | Provider_config.DashScope -> Capabilities.dashscope_capabilities))
 ;;
 
 let bool_field name = function
@@ -141,19 +172,18 @@ let build_request
   let sanitized_messages =
     Backend_openai_serialize.close_tool_message_pairs_for_request messages
   in
-  let is_deepseek_model model_id = String.starts_with ~prefix:"deepseek" model_id in
+  let dialect = Reasoning_dialect.for_provider_config config in
   let provider_messages =
     let message_serializer =
       match config.kind with
       | Provider_config.Glm -> Backend_openai_serialize.provider_k_messages_of_message
-      | Provider_config.OpenAI_compat when is_deepseek_model config.model_id ->
-        Backend_openai_serialize.provider_k_messages_of_message
       | Provider_config.Anthropic
       | Provider_config.Kimi
       | Provider_config.OpenAI_compat
       | Provider_config.Ollama
       | Provider_config.DashScope
-      | Provider_config.Gemini -> Backend_openai_serialize.openai_messages_of_message
+      | Provider_config.Gemini ->
+        Backend_openai_serialize.dialect_messages_of_message dialect
     in
     (match config.system_prompt with
      | Some s when not (Api_common.string_is_blank s) ->
@@ -198,12 +228,12 @@ let build_request
   in
   let body =
     match config.temperature with
-    | Some t -> ("temperature", `Float t) :: body
+    | Some t -> add_sampling_field dialect config "temperature" (`Float t) body
     | None -> body
   in
   let body =
     match config.top_p with
-    | Some p -> ("top_p", `Float p) :: body
+    | Some p -> add_sampling_field dialect config "top_p" (`Float p) body
     | None -> body
   in
   (* Silent drops of user-supplied sampling params are a debugging
@@ -256,7 +286,10 @@ let build_request
            ~enable_thinking:config.enable_thinking
            ~thinking_budget:config.thinking_budget
        with
-       | Some effort -> ("reasoning_effort", `String effort) :: body
+       | Some effort ->
+         (match Reasoning_dialect.normalize_effort dialect effort with
+          | Some normalized -> ("reasoning_effort", `String normalized) :: body
+          | None -> body)
        | None -> body)
     | Thinking_object ->
       (match config.enable_thinking with
@@ -267,7 +300,10 @@ let build_request
                ~enable_thinking:config.enable_thinking
                ~thinking_budget:config.thinking_budget
            with
-           | Some effort -> ("reasoning_effort", `String effort) :: body
+           | Some effort ->
+             (match Reasoning_dialect.normalize_effort dialect effort with
+              | Some normalized -> ("reasoning_effort", `String normalized) :: body
+              | None -> body)
            | None -> body
          in
          ("thinking", `Assoc [ "type", `String "enabled" ]) :: body

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -232,6 +232,19 @@ let provider_k_messages_of_message msg =
     msg
 ;;
 
+let dialect_messages_of_message dialect (msg : Types.message) =
+  let tool_calls = tool_calls_to_openai_json msg.content in
+  let include_reasoning_content =
+    Reasoning_dialect.should_replay_reasoning
+      dialect
+      ~assistant_had_tool_call:(tool_calls <> [])
+  in
+  messages_of_message_with
+    ~tool_calls_fn:(fun _ -> tool_calls)
+    ~include_reasoning_content
+    msg
+;;
+
 let modality_priority_for_model_id model_id =
   match Capabilities.for_model_id model_id with
   | Some c -> c.modality_priority
@@ -262,13 +275,11 @@ let close_tool_message_pairs_for_request = Tool_message_pairs.close_for_provider
 (** Strip Thinking blocks from all messages.
 
     Some OpenAI-compatible providers emit [reasoning_content] in
-    responses but do not accept it in request messages.  DeepSeek is
-    an exception — it *requires* [reasoning_content] round-tripping
-    for tool-call turns (see DeepSeek API docs).  The caller is
-    responsible for choosing the correct serializer (see
-    {!Backend_openai_request.is_deepseek_model}) so that DeepSeek
-    requests use [provider_k_messages_of_message] which preserves
-    [reasoning_content].
+    responses but do not accept it in request messages. DeepSeek is an
+    exception for tool-call turns, and Qwen/DashScope can opt into replay
+    with [preserve_thinking]. Callers that need provider-specific replay
+    should use {!dialect_messages_of_message}; this helper remains a blunt
+    compatibility strip.
 
     Pure function — no I/O, no mutation. *)
 let strip_thinking_blocks (messages : message list) : message list =

--- a/lib/llm_provider/backend_openai_serialize.mli
+++ b/lib/llm_provider/backend_openai_serialize.mli
@@ -9,6 +9,12 @@ val tool_calls_to_openai_json : Types.content_block list -> Yojson.Safe.t list
 val openai_content_parts_of_blocks : Types.content_block list -> Yojson.Safe.t list
 val openai_messages_of_message : Types.message -> Yojson.Safe.t list
 val provider_k_messages_of_message : Types.message -> Yojson.Safe.t list
+
+val dialect_messages_of_message
+  :  Reasoning_dialect.t
+  -> Types.message
+  -> Yojson.Safe.t list
+
 val ollama_messages_of_message : ?model_id:string -> Types.message -> Yojson.Safe.t list
 val tool_choice_to_provider_d_json : Types.tool_choice -> Yojson.Safe.t
 

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -1,0 +1,210 @@
+(** Provider reasoning/thinking dialect semantics. *)
+
+type toggle_default =
+  | Enabled
+  | Disabled
+  | Provider_default
+
+type toggle_wire =
+  | No_toggle
+  | Thinking_object of { includes_reasoning_effort : bool }
+  | Thinking_object_only
+  | Chat_template_kwargs
+  | Chat_template_token
+  | Reasoning_effort
+  | Enable_thinking
+  | Anthropic_thinking
+  | Gemini_thinking_config
+
+type effort_alias_policy =
+  | Preserve_effort
+  | Deepseek_high_or_max
+
+type sampling_policy =
+  | Sampling_supported
+  | Ignored_when_thinking of string list
+
+type reasoning_visibility =
+  | Provider_hidden
+  | Side_channel of string
+  | Visible_channel
+  | Visible_text
+
+type replay_policy =
+  | No_replay
+  | Drop_without_tool_preserve_with_tool
+  | Preserve_always
+  | Provider_hidden_replay
+
+type streaming_reasoning =
+  | No_streaming_reasoning
+  | Delta_field of string
+  | Template_parser
+
+type t =
+  { toggle_default : toggle_default
+  ; toggle_wire : toggle_wire
+  ; effort_alias_policy : effort_alias_policy
+  ; sampling_policy : sampling_policy
+  ; visibility : reasoning_visibility
+  ; replay_policy : replay_policy
+  ; streaming : streaming_reasoning
+  }
+
+let default =
+  { toggle_default = Provider_default
+  ; toggle_wire = No_toggle
+  ; effort_alias_policy = Preserve_effort
+  ; sampling_policy = Sampling_supported
+  ; visibility = Provider_hidden
+  ; replay_policy = No_replay
+  ; streaming = No_streaming_reasoning
+  }
+;;
+
+let deepseek_ignored_sampling_params =
+  [ "temperature"; "top_p"; "presence_penalty"; "frequency_penalty" ]
+;;
+
+let of_capabilities (caps : Capabilities.capabilities) =
+  match caps.thinking_control_format with
+  | No_thinking_control ->
+    if caps.supports_reasoning
+    then { default with visibility = Provider_hidden }
+    else default
+  | Thinking_object ->
+    { toggle_default = Enabled
+    ; toggle_wire = Thinking_object { includes_reasoning_effort = true }
+    ; effort_alias_policy = Deepseek_high_or_max
+    ; sampling_policy = Ignored_when_thinking deepseek_ignored_sampling_params
+    ; visibility = Side_channel "reasoning_content"
+    ; replay_policy = Drop_without_tool_preserve_with_tool
+    ; streaming = Delta_field "reasoning_content"
+    }
+  | Thinking_object_only ->
+    { default with
+      toggle_default = Provider_default
+    ; toggle_wire = Thinking_object_only
+    ; visibility = Side_channel "reasoning_content"
+    ; streaming = Delta_field "reasoning_content"
+    }
+  | Chat_template_kwargs ->
+    { default with
+      toggle_wire = Chat_template_kwargs
+    ; visibility = Visible_channel
+    ; streaming = Template_parser
+    }
+  | Chat_template_token ->
+    { default with
+      toggle_wire = Chat_template_token
+    ; visibility = Visible_channel
+    ; streaming = Template_parser
+    }
+  | Reasoning_effort ->
+    { default with
+      toggle_wire = Reasoning_effort
+    ; visibility = Side_channel "reasoning"
+    ; streaming = Delta_field "reasoning"
+    }
+  | Enable_thinking ->
+    { default with
+      toggle_wire = Enable_thinking
+    ; visibility = Side_channel "reasoning_content"
+    ; streaming = Delta_field "reasoning_content"
+    }
+;;
+
+let with_preserve_thinking config dialect =
+  match config.Provider_config.preserve_thinking, dialect.toggle_wire with
+  | Some true, (Chat_template_kwargs | Enable_thinking) ->
+    { dialect with replay_policy = Preserve_always }
+  | _ -> dialect
+;;
+
+let provider_capabilities_of_kind kind =
+  kind
+  |> Provider_config.string_of_provider_kind
+  |> Capabilities.capabilities_for_provider_label
+;;
+
+let for_provider_config (config : Provider_config.t) =
+  match config.kind with
+  | Anthropic ->
+    { default with
+      toggle_wire = Anthropic_thinking
+    ; visibility = Visible_channel
+    ; replay_policy = Preserve_always
+    ; streaming = Delta_field "thinking_delta"
+    }
+  | Gemini ->
+    { default with
+      toggle_wire = Gemini_thinking_config
+    ; visibility = Visible_channel
+    ; replay_policy = Drop_without_tool_preserve_with_tool
+    ; streaming = Delta_field "thought"
+    }
+  | Kimi | OpenAI_compat | Ollama | Glm | DashScope ->
+    (match Capabilities.for_model_id config.model_id with
+     | Some caps -> of_capabilities caps |> with_preserve_thinking config
+     | None ->
+       (match provider_capabilities_of_kind config.kind with
+        | Some caps -> of_capabilities caps |> with_preserve_thinking config
+        | None -> default))
+;;
+
+let normalize_effort dialect raw =
+  let normalized = String.lowercase_ascii (String.trim raw) in
+  match normalized, dialect.effort_alias_policy with
+  | ("none" | "off" | "disabled" | ""), _ -> None
+  | ("low" | "medium" | "high"), Deepseek_high_or_max -> Some "high"
+  | ("xhigh" | "max"), Deepseek_high_or_max -> Some "max"
+  | ("low" | "medium" | "high"), Preserve_effort -> Some normalized
+  | "max", Preserve_effort -> Some "max"
+  | "xhigh", Preserve_effort -> Some "xhigh"
+  | _ -> None
+;;
+
+let sampling_params_ignored_when_thinking dialect =
+  match dialect.sampling_policy with
+  | Sampling_supported -> []
+  | Ignored_when_thinking params -> params
+;;
+
+let should_replay_reasoning dialect ~assistant_had_tool_call =
+  match dialect.replay_policy with
+  | No_replay | Provider_hidden_replay -> false
+  | Preserve_always -> true
+  | Drop_without_tool_preserve_with_tool -> assistant_had_tool_call
+;;
+
+let requires_reasoning_replay_on_tool_call dialect =
+  should_replay_reasoning dialect ~assistant_had_tool_call:true
+  && not (should_replay_reasoning dialect ~assistant_had_tool_call:false)
+;;
+
+let toggle_wire_to_string = function
+  | No_toggle -> "no_toggle"
+  | Thinking_object { includes_reasoning_effort = true } -> "thinking_object"
+  | Thinking_object { includes_reasoning_effort = false } -> "thinking_object_no_effort"
+  | Thinking_object_only -> "thinking_object_only"
+  | Chat_template_kwargs -> "chat_template_kwargs"
+  | Chat_template_token -> "chat_template_token"
+  | Reasoning_effort -> "reasoning_effort"
+  | Enable_thinking -> "enable_thinking"
+  | Anthropic_thinking -> "anthropic_thinking"
+  | Gemini_thinking_config -> "gemini_thinking_config"
+;;
+
+let replay_policy_to_string = function
+  | No_replay -> "no_replay"
+  | Drop_without_tool_preserve_with_tool -> "drop_without_tool_preserve_with_tool"
+  | Preserve_always -> "preserve_always"
+  | Provider_hidden_replay -> "provider_hidden_replay"
+;;
+
+let visibility_to_string = function
+  | Provider_hidden -> "provider_hidden"
+  | Side_channel field -> "side_channel:" ^ field
+  | Visible_channel -> "visible_channel"
+  | Visible_text -> "visible_text"
+;;

--- a/lib/llm_provider/reasoning_dialect.mli
+++ b/lib/llm_provider/reasoning_dialect.mli
@@ -1,0 +1,84 @@
+(** Provider reasoning/thinking dialect semantics.
+
+    {!Capabilities.thinking_control_format} describes the request wire field
+    used to toggle thinking. This module keeps the adjacent semantics in one
+    typed record: default toggle state, effort aliases, sampling interactions,
+    reasoning visibility, and history replay policy.
+
+    The intent is to keep provider policy in OAS while letting downstream
+    agent runtimes decide how to surface or pause around reasoning events.
+
+    @since 0.207.0 *)
+
+type toggle_default =
+  | Enabled
+  | Disabled
+  | Provider_default
+
+type toggle_wire =
+  | No_toggle
+  | Thinking_object of { includes_reasoning_effort : bool }
+  | Thinking_object_only
+  | Chat_template_kwargs
+  | Chat_template_token
+  | Reasoning_effort
+  | Enable_thinking
+  | Anthropic_thinking
+  | Gemini_thinking_config
+
+type effort_alias_policy =
+  | Preserve_effort
+  | Deepseek_high_or_max
+
+type sampling_policy =
+  | Sampling_supported
+  | Ignored_when_thinking of string list
+
+type reasoning_visibility =
+  | Provider_hidden
+  | Side_channel of string
+  | Visible_channel
+  | Visible_text
+
+type replay_policy =
+  | No_replay
+  | Drop_without_tool_preserve_with_tool
+  | Preserve_always
+  | Provider_hidden_replay
+
+type streaming_reasoning =
+  | No_streaming_reasoning
+  | Delta_field of string
+  | Template_parser
+
+type t =
+  { toggle_default : toggle_default
+  ; toggle_wire : toggle_wire
+  ; effort_alias_policy : effort_alias_policy
+  ; sampling_policy : sampling_policy
+  ; visibility : reasoning_visibility
+  ; replay_policy : replay_policy
+  ; streaming : streaming_reasoning
+  }
+
+val default : t
+val of_capabilities : Capabilities.capabilities -> t
+val for_provider_config : Provider_config.t -> t
+
+(** Normalize a caller effort for a provider dialect.
+
+    Returns [None] when the input means "no reasoning effort field". *)
+val normalize_effort : t -> string -> string option
+
+val sampling_params_ignored_when_thinking : t -> string list
+
+(** Whether an assistant reasoning side-channel should be replayed into a
+    subsequent request. [assistant_had_tool_call] is intentionally explicit:
+    DeepSeek-style thinking requires replay after tool calls but can drop
+    reasoning between plain user turns. *)
+val should_replay_reasoning : t -> assistant_had_tool_call:bool -> bool
+
+val requires_reasoning_replay_on_tool_call : t -> bool
+val toggle_wire_to_string : toggle_wire -> string
+val replay_policy_to_string : replay_policy -> string
+val visibility_to_string : reasoning_visibility -> string

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -270,7 +270,7 @@ let test_openai_parallel_disabled_by_capability () =
    get correct (not shadowed) capabilities"] in [capabilities.ml] and in
    [test_capabilities.ml]'s cloud-suffix route checks. *)
 let deepseek_required_expected =
-  {|{"parallel_tool_calls":false,"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"tool_choice":"required","temperature":0.7,"model":"deepseek-v4-flash","messages":[{"role":"user","content":"What's the weather in Seoul?"},{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Seoul\"}"}}],"role":"assistant","content":""},{"role":"tool","tool_call_id":"call_1","content":"Sunny, 25C"}],"max_tokens":1024}|}
+  {|{"parallel_tool_calls":false,"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"tool_choice":"required","model":"deepseek-v4-flash","messages":[{"role":"user","content":"What's the weather in Seoul?"},{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Seoul\"}"}}],"role":"assistant","content":""},{"role":"tool","tool_call_id":"call_1","content":"Sunny, 25C"}],"max_tokens":1024}|}
 ;;
 
 let test_deepseek_required () =

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -8,6 +8,7 @@
 module PC = Llm_provider.Provider_config
 module BOR = Llm_provider.Backend_openai_request
 module BOL = Llm_provider.Backend_ollama
+module RD = Llm_provider.Reasoning_dialect
 open Alcotest
 open Llm_provider.Types
 open Yojson.Safe.Util
@@ -70,6 +71,52 @@ let test_qwen36_self_hosted_openai_compat_uses_chat_template_kwargs () =
   check_member_absent "enable_thinking" json
 ;;
 
+let test_qwen36_reasoning_dialect_uses_chat_template_kwargs () =
+  let config =
+    openai_compat_config
+      ~enable_thinking:false
+      ~preserve_thinking:true
+      "Qwen/Qwen3.6-35B-A3B"
+  in
+  let dialect = RD.for_provider_config config in
+  check
+    string
+    "toggle wire"
+    "chat_template_kwargs"
+    (RD.toggle_wire_to_string dialect.toggle_wire);
+  check string "visibility" "visible_channel" (RD.visibility_to_string dialect.visibility);
+  check
+    string
+    "replay policy"
+    "preserve_always"
+    (RD.replay_policy_to_string dialect.replay_policy);
+  check
+    bool
+    "no tool-call replay requirement"
+    false
+    (RD.requires_reasoning_replay_on_tool_call dialect);
+  check
+    (list string)
+    "no ignored sampling params"
+    []
+    (RD.sampling_params_ignored_when_thinking dialect)
+;;
+
+let test_qwen36_reasoning_dialect_without_preserve_drops_reasoning () =
+  let config =
+    openai_compat_config
+      ~enable_thinking:true
+      ~preserve_thinking:false
+      "Qwen/Qwen3.6-35B-A3B"
+  in
+  let dialect = RD.for_provider_config config in
+  check
+    string
+    "replay policy"
+    "no_replay"
+    (RD.replay_policy_to_string dialect.replay_policy)
+;;
+
 let test_qwen36_dashscope_uses_top_level_enable_thinking () =
   let config =
     PC.make
@@ -88,6 +135,28 @@ let test_qwen36_dashscope_uses_top_level_enable_thinking () =
   check_member_absent "chat_template_kwargs" json;
   check_member_absent "thinking" json;
   check_member_absent "reasoning_effort" json
+;;
+
+let test_openai_reasoning_dialect_uses_reasoning_effort () =
+  let dialect =
+    RD.of_capabilities Llm_provider.Capabilities.openai_compat_chat_extended_capabilities
+  in
+  check
+    string
+    "toggle wire"
+    "reasoning_effort"
+    (RD.toggle_wire_to_string dialect.toggle_wire);
+  check
+    string
+    "visibility"
+    "side_channel:reasoning"
+    (RD.visibility_to_string dialect.visibility);
+  check
+    string
+    "replay policy"
+    "no_replay"
+    (RD.replay_policy_to_string dialect.replay_policy);
+  check (option string) "preserve high" (Some "high") (RD.normalize_effort dialect "high")
 ;;
 
 let test_deepseek_openai_compat_uses_thinking_object () =
@@ -109,6 +178,153 @@ let test_deepseek_openai_compat_uses_thinking_object () =
   check_member_absent "reasoning_effort" json;
   check_member_absent "chat_template_kwargs" json;
   check_member_absent "think" json
+;;
+
+let test_deepseek_reasoning_dialect_semantics () =
+  let config =
+    PC.make
+      ~kind:OpenAI_compat
+      ~model_id:"deepseek-v4-pro"
+      ~base_url:"https://api.deepseek.com"
+      ~enable_thinking:true
+      ()
+  in
+  let dialect = RD.for_provider_config config in
+  check
+    string
+    "toggle wire"
+    "thinking_object"
+    (RD.toggle_wire_to_string dialect.toggle_wire);
+  check
+    string
+    "visibility"
+    "side_channel:reasoning_content"
+    (RD.visibility_to_string dialect.visibility);
+  check
+    string
+    "replay policy"
+    "drop_without_tool_preserve_with_tool"
+    (RD.replay_policy_to_string dialect.replay_policy);
+  check
+    bool
+    "plain assistant reasoning may be dropped"
+    false
+    (RD.should_replay_reasoning dialect ~assistant_had_tool_call:false);
+  check
+    bool
+    "tool-call assistant reasoning must replay"
+    true
+    (RD.should_replay_reasoning dialect ~assistant_had_tool_call:true);
+  check
+    bool
+    "requires tool-call replay"
+    true
+    (RD.requires_reasoning_replay_on_tool_call dialect);
+  check (option string) "low maps high" (Some "high") (RD.normalize_effort dialect "low");
+  check
+    (option string)
+    "medium maps high"
+    (Some "high")
+    (RD.normalize_effort dialect "medium");
+  check
+    (option string)
+    "xhigh maps max"
+    (Some "max")
+    (RD.normalize_effort dialect "xhigh");
+  check
+    (list string)
+    "ignored sampling params"
+    [ "temperature"; "top_p"; "presence_penalty"; "frequency_penalty" ]
+    (RD.sampling_params_ignored_when_thinking dialect)
+;;
+
+let test_deepseek_sampling_suppressed_in_thinking_mode () =
+  let config =
+    PC.make
+      ~kind:OpenAI_compat
+      ~model_id:"deepseek-v4-flash"
+      ~base_url:"https://api.deepseek.com"
+      ~temperature:0.7
+      ~top_p:0.9
+      ()
+  in
+  let json = BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
+  check_member_absent "temperature" json;
+  check_member_absent "top_p" json
+;;
+
+let test_deepseek_disabled_thinking_keeps_sampling () =
+  let config =
+    PC.make
+      ~kind:OpenAI_compat
+      ~model_id:"deepseek-v4-flash"
+      ~base_url:"https://api.deepseek.com"
+      ~enable_thinking:false
+      ~temperature:0.7
+      ~top_p:0.9
+      ()
+  in
+  let json = BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
+  check (float 0.001) "temperature" 0.7 (json |> member "temperature" |> to_float);
+  check (float 0.001) "top_p" 0.9 (json |> member "top_p" |> to_float)
+;;
+
+let assistant_with_reasoning ?(tool = false) () =
+  let content =
+    if tool
+    then
+      [ Thinking { thinking_type = "reasoning"; content = "use calculator" }
+      ; ToolUse { id = "call_1"; name = "calc"; input = `Assoc [ "expr", `String "2+2" ] }
+      ]
+    else
+      [ Thinking { thinking_type = "reasoning"; content = "plain thought" }
+      ; Text "answer"
+      ]
+  in
+  { role = Assistant; content; name = None; tool_call_id = None; metadata = [] }
+;;
+
+let test_deepseek_replays_reasoning_only_for_tool_call_turns () =
+  let config =
+    PC.make
+      ~kind:OpenAI_compat
+      ~model_id:"deepseek-v4-flash"
+      ~base_url:"https://api.deepseek.com"
+      ()
+  in
+  let plain =
+    BOR.build_request ~config ~messages:[ assistant_with_reasoning () ] () |> json_of_body
+  in
+  let tool =
+    BOR.build_request ~config ~messages:[ assistant_with_reasoning ~tool:true () ] ()
+    |> json_of_body
+  in
+  let plain_assistant = plain |> member "messages" |> index 0 in
+  let tool_assistant = tool |> member "messages" |> index 0 in
+  check_member_absent "reasoning_content" plain_assistant;
+  check
+    string
+    "tool reasoning_content"
+    "use calculator"
+    (tool_assistant |> member "reasoning_content" |> to_string)
+;;
+
+let test_qwen_preserve_replays_reasoning_content () =
+  let config =
+    openai_compat_config
+      ~enable_thinking:true
+      ~preserve_thinking:true
+      "Qwen/Qwen3.6-35B-A3B"
+  in
+  let json =
+    BOR.build_request ~config ~messages:[ assistant_with_reasoning () ] () |> json_of_body
+  in
+  let assistant = json |> member "messages" |> index 0 in
+  check
+    string
+    "reasoning_content"
+    "plain thought"
+    (assistant |> member "reasoning_content" |> to_string)
 ;;
 
 let test_ollama_qwen_uses_native_think_bool () =
@@ -159,6 +375,78 @@ let test_ollama_gemma4_disabled_uses_native_think_false () =
     (first_message |> member "content" |> to_string)
 ;;
 
+let test_gemma4_reasoning_dialect_uses_template_parser () =
+  let config =
+    ollama_config
+      ~enable_thinking:true
+      "hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL"
+  in
+  let dialect = RD.for_provider_config config in
+  check
+    string
+    "toggle wire"
+    "chat_template_token"
+    (RD.toggle_wire_to_string dialect.toggle_wire);
+  check string "visibility" "visible_channel" (RD.visibility_to_string dialect.visibility);
+  check
+    string
+    "replay policy"
+    "no_replay"
+    (RD.replay_policy_to_string dialect.replay_policy);
+  check
+    bool
+    "no tool-call replay requirement"
+    false
+    (RD.requires_reasoning_replay_on_tool_call dialect);
+  check
+    (list string)
+    "no ignored sampling params"
+    []
+    (RD.sampling_params_ignored_when_thinking dialect)
+;;
+
+let test_anthropic_reasoning_dialect_preserves_thinking () =
+  let config =
+    PC.make
+      ~kind:Anthropic
+      ~model_id:"claude-sonnet-4-6"
+      ~base_url:"https://api.anthropic.com"
+      ()
+  in
+  let dialect = RD.for_provider_config config in
+  check
+    string
+    "toggle wire"
+    "anthropic_thinking"
+    (RD.toggle_wire_to_string dialect.toggle_wire);
+  check
+    string
+    "replay policy"
+    "preserve_always"
+    (RD.replay_policy_to_string dialect.replay_policy)
+;;
+
+let test_gemini_reasoning_dialect_uses_thinking_config () =
+  let config =
+    PC.make
+      ~kind:Gemini
+      ~model_id:"gemini-2.5-flash"
+      ~base_url:"https://generativelanguage.googleapis.com/v1beta"
+      ()
+  in
+  let dialect = RD.for_provider_config config in
+  check
+    string
+    "toggle wire"
+    "gemini_thinking_config"
+    (RD.toggle_wire_to_string dialect.toggle_wire);
+  check
+    string
+    "replay policy"
+    "drop_without_tool_preserve_with_tool"
+    (RD.replay_policy_to_string dialect.replay_policy)
+;;
+
 let () =
   run
     "thinking_control_dialects"
@@ -172,13 +460,45 @@ let () =
             `Quick
             test_qwen36_self_hosted_openai_compat_uses_chat_template_kwargs
         ; test_case
+            "qwen3.6 reasoning dialect uses chat_template_kwargs"
+            `Quick
+            test_qwen36_reasoning_dialect_uses_chat_template_kwargs
+        ; test_case
+            "qwen3.6 reasoning dialect without preserve drops reasoning"
+            `Quick
+            test_qwen36_reasoning_dialect_without_preserve_drops_reasoning
+        ; test_case
             "qwen3.6 dashscope uses top-level enable_thinking"
             `Quick
             test_qwen36_dashscope_uses_top_level_enable_thinking
         ; test_case
+            "openai reasoning dialect uses reasoning_effort"
+            `Quick
+            test_openai_reasoning_dialect_uses_reasoning_effort
+        ; test_case
             "deepseek uses thinking object"
             `Quick
             test_deepseek_openai_compat_uses_thinking_object
+        ; test_case
+            "deepseek reasoning dialect semantics"
+            `Quick
+            test_deepseek_reasoning_dialect_semantics
+        ; test_case
+            "deepseek suppresses ignored sampling in thinking mode"
+            `Quick
+            test_deepseek_sampling_suppressed_in_thinking_mode
+        ; test_case
+            "deepseek disabled thinking keeps sampling"
+            `Quick
+            test_deepseek_disabled_thinking_keeps_sampling
+        ; test_case
+            "deepseek replays reasoning only for tool call turns"
+            `Quick
+            test_deepseek_replays_reasoning_only_for_tool_call_turns
+        ; test_case
+            "qwen preserve replays reasoning_content"
+            `Quick
+            test_qwen_preserve_replays_reasoning_content
         ] )
     ; ( "ollama"
       , [ test_case
@@ -193,6 +513,20 @@ let () =
             "gemma4 disabled uses native think false"
             `Quick
             test_ollama_gemma4_disabled_uses_native_think_false
+        ; test_case
+            "gemma4 reasoning dialect uses template parser"
+            `Quick
+            test_gemma4_reasoning_dialect_uses_template_parser
+        ] )
+    ; ( "native"
+      , [ test_case
+            "anthropic reasoning dialect preserves thinking"
+            `Quick
+            test_anthropic_reasoning_dialect_preserves_thinking
+        ; test_case
+            "gemini reasoning dialect uses thinking config"
+            `Quick
+            test_gemini_reasoning_dialect_uses_thinking_config
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- add `Llm_provider.Reasoning_dialect` as the typed surface for provider reasoning semantics
- cover DeepSeek, Qwen/DashScope, OpenAI-style `reasoning_effort`, Claude/Anthropic thinking blocks, Gemini `thinkingConfig`, and Gemma chat-template thinking
- route OpenAI-compatible message serialization through dialect replay policy instead of hard-coded DeepSeek model string checks
- apply DeepSeek effort aliasing and suppress sampling fields ignored in thinking mode
- document official provider evidence for DeepSeek, Gemma, Claude, OpenAI, Gemini, and DashScope/Qwen

## Verification
- `scripts/dune-local.sh build test/test_thinking_control_dialects.exe`
- `scripts/dune-local.sh build test/test_snapshot_provider_serialization.exe`
- `./_build/default/test/test_thinking_control_dialects.exe`
- `./_build/default/test/test_snapshot_provider_serialization.exe`

## Notes
- This is still OAS-side provider/transport policy only. It does not add MASC pending-input queues or keeper pause/interrupt behavior.
- MASC should consume these typed facts in a follow-up slice instead of copying provider-specific replay rules.
