### PR TITLE
Add runtime continuation boundary primitives

### DIFF
--- a/docs/EVENT-CATALOG.md
+++ b/docs/EVENT-CATALOG.md
@@ -238,6 +238,7 @@ on **two channels simultaneously**:
 | `Turn_recorded` | `runtime.turn_recorded` |
 | `Input_required` | `runtime.input_required` |
 | `Input_provided` | `runtime.input_provided` |
+| `Pending_input_updated` | `runtime.pending_input_updated` |
 | `Agent_spawn_requested` | `runtime.agent_spawn_requested` |
 | `Agent_became_live` | `runtime.agent_became_live` |
 | `Agent_output_delta` | `runtime.agent_output_delta` |
@@ -265,6 +266,10 @@ different payload shapes. Disambiguate by Custom name prefix:
   while phase is `Input_required`; `Provide_input` emits
   `Input_provided`, clears the payload, and returns the session to
   `Running`.
+- `Runtime.Pending_input_updated` reports ordinary input that arrived while a
+  turn was busy. Status values are `queued`, `applied`, `interrupted`, or
+  `ignored`. The event is intentionally not a lifecycle phase: ordinary queued
+  input must not imply keeper pause/stop.
 - Runtime finalization persists the operator-facing evidence set:
   `report.json`, `proof.json`, `runtime-telemetry-json`,
   `runtime-telemetry`, `runtime-raw-trace-json`, and `runtime-evidence`.

--- a/docs/design/runtime-continuation-boundaries.md
+++ b/docs/design/runtime-continuation-boundaries.md
@@ -1,0 +1,37 @@
+# Runtime Continuation Boundaries
+
+Date: 2026-06-14
+
+## Purpose
+
+OAS exposes typed continuation boundaries so hosts can accept user input while
+an agent is busy without inserting it into unsafe positions in the provider
+history. The host, such as MASC, owns the queue and UI. OAS owns the boundary
+policy.
+
+## Boundaries
+
+| Boundary | Ordinary input policy |
+| --- | --- |
+| `Before_provider_request` | Apply now |
+| `Provider_streaming_reasoning` | Queue until a safe boundary |
+| `Before_assistant_tool_use` | Queue until tool results are closed |
+| `After_assistant_tool_use_before_results` | Reject/ignore for the current turn |
+| `After_tool_results_before_next_provider_request` | Apply now |
+| `After_final_answer` | Apply as next turn input |
+
+Explicit operator interrupts are separate from ordinary input. An interrupt may
+cancel/checkpoint/resume the running turn, but it is not a pause or stop command.
+
+## Runtime Event
+
+`Runtime.Pending_input_updated` reports host queue state with status labels:
+
+- `queued`
+- `applied`
+- `interrupted`
+- `ignored`
+
+This is deliberately not a runtime lifecycle phase. A busy keeper with queued
+input should keep running until it reaches a safe boundary or receives an
+explicit interrupt.

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -108,6 +108,7 @@ module Otel_tracer = Otel_tracer
 module Otel_export = Otel_export
 module Trace_eval = Trace_eval
 module Runtime = Runtime
+module Runtime_continuation = Runtime_continuation
 module Runtime_projection = Runtime_projection
 module Runtime_sync = Runtime_sync
 module Runtime_replay = Runtime_replay

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -81,6 +81,7 @@ module Otel_tracer = Otel_tracer
 module Otel_export = Otel_export
 module Trace_eval = Trace_eval
 module Runtime = Runtime
+module Runtime_continuation = Runtime_continuation
 module Runtime_projection = Runtime_projection
 module Runtime_sync = Runtime_sync
 module Runtime_replay = Runtime_replay

--- a/lib/runtime.ml
+++ b/lib/runtime.ml
@@ -226,6 +226,18 @@ type input_provided_event =
   }
 [@@deriving yojson, show]
 
+type pending_input_update_event =
+  { input_id : string option
+  ; participant_name : string option
+  ; source : string option
+  ; boundary : Runtime_continuation.continuation_boundary
+  ; policy : Runtime_continuation.pending_input_policy
+  ; status : string
+  ; message : string option
+  ; created_at : float
+  }
+[@@deriving yojson, show]
+
 type spawn_event =
   { participant_name : string
   ; role : string option
@@ -291,6 +303,7 @@ type event_kind =
   | Turn_recorded of turn_event
   | Input_required of input_request
   | Input_provided of input_provided_event
+  | Pending_input_updated of pending_input_update_event
   | Agent_spawn_requested of spawn_event
   | Agent_became_live of participant_event
   | Agent_output_delta of output_delta_event

--- a/lib/runtime.mli
+++ b/lib/runtime.mli
@@ -242,6 +242,18 @@ type input_provided_event =
   }
 [@@deriving yojson, show]
 
+type pending_input_update_event =
+  { input_id : string option
+  ; participant_name : string option
+  ; source : string option
+  ; boundary : Runtime_continuation.continuation_boundary
+  ; policy : Runtime_continuation.pending_input_policy
+  ; status : string
+  ; message : string option
+  ; created_at : float
+  }
+[@@deriving yojson, show]
+
 type spawn_event =
   { participant_name : string
   ; role : string option
@@ -307,6 +319,7 @@ type event_kind =
   | Turn_recorded of turn_event
   | Input_required of input_request
   | Input_provided of input_provided_event
+  | Pending_input_updated of pending_input_update_event
   | Agent_spawn_requested of spawn_event
   | Agent_became_live of participant_event
   | Agent_output_delta of output_delta_event

--- a/lib/runtime_continuation.ml
+++ b/lib/runtime_continuation.ml
@@ -1,0 +1,113 @@
+(** Runtime continuation-boundary primitives. *)
+
+type continuation_boundary =
+  | Before_provider_request
+  | Provider_streaming_reasoning
+  | Before_assistant_tool_use
+  | After_assistant_tool_use_before_results
+  | After_tool_results_before_next_provider_request
+  | After_final_answer
+[@@deriving yojson, show]
+
+type pending_input_policy =
+  | Queue_until_safe_boundary
+  | Apply_at_boundary
+  | Reject_at_boundary
+  | Interrupt_current_turn
+  | Ignore_for_current_turn
+[@@deriving yojson, show]
+
+type pending_input_decision =
+  { boundary : continuation_boundary
+  ; policy : pending_input_policy
+  ; accepts_input : bool
+  ; applies_input : bool
+  ; interrupts_turn : bool
+  ; preserves_tool_result_adjacency : bool
+  ; reason : string
+  }
+[@@deriving yojson, show]
+
+let policy_for_boundary ?(explicit_interrupt = false) boundary =
+  if explicit_interrupt
+  then Interrupt_current_turn
+  else (
+    match boundary with
+    | Before_provider_request
+    | After_tool_results_before_next_provider_request
+    | After_final_answer -> Apply_at_boundary
+    | Provider_streaming_reasoning | Before_assistant_tool_use ->
+      Queue_until_safe_boundary
+    | After_assistant_tool_use_before_results -> Reject_at_boundary)
+;;
+
+let reason_of_boundary policy boundary =
+  match policy, boundary with
+  | Interrupt_current_turn, _ ->
+    "explicit interrupt requested; host may cancel and checkpoint before resuming"
+  | Apply_at_boundary, Before_provider_request ->
+    "safe to add input before the next provider request"
+  | Apply_at_boundary, After_tool_results_before_next_provider_request ->
+    "tool results are complete; safe to add input before the next provider request"
+  | Apply_at_boundary, After_final_answer ->
+    "turn is complete; input starts or augments the next turn"
+  | Queue_until_safe_boundary, Provider_streaming_reasoning ->
+    "provider is still streaming reasoning; queue ordinary input until a safe boundary"
+  | Queue_until_safe_boundary, Before_assistant_tool_use ->
+    "assistant tool call is selected; queue ordinary input until tool results are closed"
+  | Reject_at_boundary, After_assistant_tool_use_before_results ->
+    "do not insert user input between assistant tool calls and their tool results"
+  | Ignore_for_current_turn, _ -> "input is ignored for the current turn"
+  | Apply_at_boundary, _ | Queue_until_safe_boundary, _ | Reject_at_boundary, _ ->
+    "boundary policy selected"
+;;
+
+let decision ?explicit_interrupt boundary =
+  let policy = policy_for_boundary ?explicit_interrupt boundary in
+  let accepts_input =
+    match policy with
+    | Apply_at_boundary | Queue_until_safe_boundary | Interrupt_current_turn -> true
+    | Reject_at_boundary | Ignore_for_current_turn -> false
+  in
+  let applies_input =
+    match policy with
+    | Apply_at_boundary -> true
+    | Queue_until_safe_boundary
+    | Reject_at_boundary
+    | Interrupt_current_turn
+    | Ignore_for_current_turn -> false
+  in
+  let interrupts_turn =
+    match policy with
+    | Interrupt_current_turn -> true
+    | Apply_at_boundary
+    | Queue_until_safe_boundary
+    | Reject_at_boundary
+    | Ignore_for_current_turn -> false
+  in
+  let preserves_tool_result_adjacency =
+    match boundary with
+    | After_assistant_tool_use_before_results -> false
+    | Before_provider_request
+    | Provider_streaming_reasoning
+    | Before_assistant_tool_use
+    | After_tool_results_before_next_provider_request
+    | After_final_answer -> true
+  in
+  { boundary
+  ; policy
+  ; accepts_input
+  ; applies_input
+  ; interrupts_turn
+  ; preserves_tool_result_adjacency
+  ; reason = reason_of_boundary policy boundary
+  }
+;;
+
+let pending_input_policy_to_runtime_status = function
+  | Queue_until_safe_boundary -> "queued"
+  | Apply_at_boundary -> "applied"
+  | Reject_at_boundary -> "ignored"
+  | Interrupt_current_turn -> "interrupted"
+  | Ignore_for_current_turn -> "ignored"
+;;

--- a/lib/runtime_continuation.mli
+++ b/lib/runtime_continuation.mli
@@ -1,0 +1,44 @@
+(** Runtime continuation-boundary primitives.
+
+    These types describe when host-provided input may be applied to an active
+    agent turn without violating provider/tool ordering. They are provider- and
+    runtime-agnostic: OAS exposes the policy; MASC or another host owns the
+    queue and UI wiring.
+
+    @since 0.207.0 *)
+
+type continuation_boundary =
+  | Before_provider_request
+  | Provider_streaming_reasoning
+  | Before_assistant_tool_use
+  | After_assistant_tool_use_before_results
+  | After_tool_results_before_next_provider_request
+  | After_final_answer
+[@@deriving yojson, show]
+
+type pending_input_policy =
+  | Queue_until_safe_boundary
+  | Apply_at_boundary
+  | Reject_at_boundary
+  | Interrupt_current_turn
+  | Ignore_for_current_turn
+[@@deriving yojson, show]
+
+type pending_input_decision =
+  { boundary : continuation_boundary
+  ; policy : pending_input_policy
+  ; accepts_input : bool
+  ; applies_input : bool
+  ; interrupts_turn : bool
+  ; preserves_tool_result_adjacency : bool
+  ; reason : string
+  }
+[@@deriving yojson, show]
+
+val policy_for_boundary
+  :  ?explicit_interrupt:bool
+  -> continuation_boundary
+  -> pending_input_policy
+
+val decision : ?explicit_interrupt:bool -> continuation_boundary -> pending_input_decision
+val pending_input_policy_to_runtime_status : pending_input_policy -> string

--- a/lib/runtime_evidence.ml
+++ b/lib/runtime_evidence.ml
@@ -149,6 +149,13 @@ let participant_and_detail_of_event = function
   | Turn_recorded detail -> detail.actor, Some detail.message
   | Input_required detail -> detail.participant_name, Some detail.question
   | Input_provided detail -> detail.participant_name, Some detail.request_id
+  | Pending_input_updated detail ->
+    let text =
+      match detail.message with
+      | Some message -> detail.status ^ ":" ^ message
+      | None -> detail.status
+    in
+    detail.participant_name, Some text
   | Agent_spawn_requested detail -> Some detail.participant_name, Some detail.prompt
   | Agent_became_live detail -> Some detail.participant_name, detail.summary
   | Agent_output_delta detail -> Some detail.participant_name, Some detail.delta
@@ -186,6 +193,7 @@ let event_name_of_kind = function
   | Turn_recorded _ -> "turn_recorded"
   | Input_required _ -> "input_required"
   | Input_provided _ -> "input_provided"
+  | Pending_input_updated _ -> "pending_input_updated"
   | Agent_spawn_requested _ -> "agent_spawn_requested"
   | Agent_became_live _ -> "agent_became_live"
   | Agent_output_delta _ -> "agent_output_delta"
@@ -207,6 +215,8 @@ let structured_fields_of_event = function
   | Input_required detail ->
     detail.participant_name, None, None, None, None, None, None, None, None, None, None
   | Input_provided detail ->
+    detail.participant_name, None, None, None, None, None, None, None, None, None, None
+  | Pending_input_updated detail ->
     detail.participant_name, None, None, None, None, None, None, None, None, None, None
   | Agent_spawn_requested detail ->
     ( None

--- a/lib/runtime_projection.ml
+++ b/lib/runtime_projection.ml
@@ -150,6 +150,9 @@ let apply_event (session : session) (event : event) =
        Error
          (Error.Internal
             (Printf.sprintf "Input response %s has no pending request" detail.request_id)))
+  | Pending_input_updated _ ->
+    let* session = ensure_active_phase session in
+    Ok session
   | Agent_spawn_requested detail ->
     let* session = ensure_active_phase session in
     Ok

--- a/lib/runtime_server_types.ml
+++ b/lib/runtime_server_types.ml
@@ -45,6 +45,7 @@ let custom_name_of_kind = function
   | Turn_recorded _ -> "runtime.turn_recorded"
   | Input_required _ -> "runtime.input_required"
   | Input_provided _ -> "runtime.input_provided"
+  | Pending_input_updated _ -> "runtime.pending_input_updated"
   | Agent_spawn_requested _ -> "runtime.agent_spawn_requested"
   | Agent_became_live _ -> "runtime.agent_became_live"
   | Agent_output_delta _ -> "runtime.agent_output_delta"
@@ -74,6 +75,7 @@ let event_bus_run_id_of_event (event : event) =
   | Turn_recorded _
   | Input_required _
   | Input_provided _
+  | Pending_input_updated _
   | Agent_spawn_requested _
   | Artifact_attached _
   | Checkpoint_saved _

--- a/test/dune
+++ b/test/dune
@@ -526,6 +526,7 @@
   test_runtime_evidence
   test_runtime_health
   test_runtime_projection_cov2
+  test_runtime_continuation
   test_runtime_replay
   test_runtime_server_coverage
   test_runtime_server_types
@@ -536,6 +537,7 @@
   test_runtime_evidence
   test_runtime_health
   test_runtime_projection_cov2
+  test_runtime_continuation
   test_runtime_replay
   test_runtime_server_coverage
   test_runtime_server_types

--- a/test/test_runtime_continuation.ml
+++ b/test/test_runtime_continuation.ml
@@ -1,0 +1,144 @@
+open Agent_sdk
+
+let check_decision
+      label
+      ?(explicit_interrupt = false)
+      boundary
+      expected_policy
+      ~accepts
+      ~applies
+      ~interrupts
+      ~preserves_tool_adjacency
+  =
+  let decision = Runtime_continuation.decision ~explicit_interrupt boundary in
+  Alcotest.(check string)
+    (label ^ " policy")
+    (Runtime_continuation.show_pending_input_policy expected_policy)
+    (Runtime_continuation.show_pending_input_policy decision.policy);
+  Alcotest.(check bool) (label ^ " accepts") accepts decision.accepts_input;
+  Alcotest.(check bool) (label ^ " applies") applies decision.applies_input;
+  Alcotest.(check bool) (label ^ " interrupts") interrupts decision.interrupts_turn;
+  Alcotest.(check bool)
+    (label ^ " tool adjacency")
+    preserves_tool_adjacency
+    decision.preserves_tool_result_adjacency
+;;
+
+let test_safe_boundaries_apply () =
+  List.iter
+    (fun boundary ->
+       check_decision
+         (Runtime_continuation.show_continuation_boundary boundary)
+         boundary
+         Runtime_continuation.Apply_at_boundary
+         ~accepts:true
+         ~applies:true
+         ~interrupts:false
+         ~preserves_tool_adjacency:true)
+    [ Runtime_continuation.Before_provider_request
+    ; Runtime_continuation.After_tool_results_before_next_provider_request
+    ; Runtime_continuation.After_final_answer
+    ]
+;;
+
+let test_reasoning_boundary_queues_without_interrupting () =
+  check_decision
+    "streaming reasoning"
+    Runtime_continuation.Provider_streaming_reasoning
+    Runtime_continuation.Queue_until_safe_boundary
+    ~accepts:true
+    ~applies:false
+    ~interrupts:false
+    ~preserves_tool_adjacency:true
+;;
+
+let test_tool_result_gap_rejects_input () =
+  check_decision
+    "tool result gap"
+    Runtime_continuation.After_assistant_tool_use_before_results
+    Runtime_continuation.Reject_at_boundary
+    ~accepts:false
+    ~applies:false
+    ~interrupts:false
+    ~preserves_tool_adjacency:false
+;;
+
+let test_explicit_interrupt_is_not_pause_or_stop () =
+  check_decision
+    "interrupt"
+    ~explicit_interrupt:true
+    Runtime_continuation.Provider_streaming_reasoning
+    Runtime_continuation.Interrupt_current_turn
+    ~accepts:true
+    ~applies:false
+    ~interrupts:true
+    ~preserves_tool_adjacency:true
+;;
+
+let test_runtime_status_labels () =
+  let cases =
+    [ Runtime_continuation.Queue_until_safe_boundary, "queued"
+    ; Runtime_continuation.Apply_at_boundary, "applied"
+    ; Runtime_continuation.Reject_at_boundary, "ignored"
+    ; Runtime_continuation.Interrupt_current_turn, "interrupted"
+    ; Runtime_continuation.Ignore_for_current_turn, "ignored"
+    ]
+  in
+  List.iter
+    (fun (policy, expected) ->
+       Alcotest.(check string)
+         expected
+         expected
+         (Runtime_continuation.pending_input_policy_to_runtime_status policy))
+    cases
+;;
+
+let test_runtime_pending_input_update_roundtrip () =
+  let event =
+    Runtime.Pending_input_updated
+      { input_id = Some "input-1"
+      ; participant_name = Some "keeper"
+      ; source = Some "dashboard"
+      ; boundary = Runtime_continuation.Provider_streaming_reasoning
+      ; policy = Runtime_continuation.Queue_until_safe_boundary
+      ; status = "queued"
+      ; message = Some "ordinary input queued while provider is reasoning"
+      ; created_at = 1.0
+      }
+  in
+  let json = Runtime.event_kind_to_yojson event in
+  match Runtime.event_kind_of_yojson json with
+  | Ok (Runtime.Pending_input_updated decoded) ->
+    Alcotest.(check (option string)) "input_id" (Some "input-1") decoded.input_id;
+    Alcotest.(check string) "status" "queued" decoded.status
+  | Ok other -> Alcotest.failf "unexpected event kind: %s" (Runtime.show_event_kind other)
+  | Error err -> Alcotest.fail err
+;;
+
+let () =
+  Alcotest.run
+    "runtime_continuation"
+    [ ( "policy"
+      , [ Alcotest.test_case "safe boundaries apply" `Quick test_safe_boundaries_apply
+        ; Alcotest.test_case
+            "streaming reasoning queues"
+            `Quick
+            test_reasoning_boundary_queues_without_interrupting
+        ; Alcotest.test_case
+            "tool result gap rejects"
+            `Quick
+            test_tool_result_gap_rejects_input
+        ; Alcotest.test_case
+            "explicit interrupt"
+            `Quick
+            test_explicit_interrupt_is_not_pause_or_stop
+        ; Alcotest.test_case "status labels" `Quick test_runtime_status_labels
+        ] )
+    ; ( "runtime"
+      , [ Alcotest.test_case
+            "pending input update event roundtrip"
+            `Quick
+            test_runtime_pending_input_update_roundtrip
+        ] )
+    ]
+;;

--- a/test/test_runtime_projection_cov2.ml
+++ b/test/test_runtime_projection_cov2.ml
@@ -277,6 +277,35 @@ let test_apply_input_provided_resumes_running () =
   | Error e -> Alcotest.fail (Error.to_string e)
 ;;
 
+let test_apply_pending_input_update_is_not_lifecycle_state () =
+  let request = input_request () in
+  let session =
+    mk_session ~phase:Running ~pending_input:(Some request) ~turn_count:7 ()
+  in
+  let event =
+    mk_event
+      (Pending_input_updated
+         { input_id = Some "pending-1"
+         ; participant_name = Some "alice"
+         ; source = Some "dashboard"
+         ; boundary = Runtime_continuation.Provider_streaming_reasoning
+         ; policy = Runtime_continuation.Queue_until_safe_boundary
+         ; status = "queued"
+         ; message = Some "queued while reasoning"
+         ; created_at = 456.0
+         })
+  in
+  match Runtime_projection.apply_event session event with
+  | Ok s ->
+    Alcotest.(check bool) "phase unchanged" true (s.phase = Running);
+    Alcotest.(check int) "turn_count unchanged" 7 s.turn_count;
+    (match s.pending_input with
+     | Some pending ->
+       Alcotest.(check string) "pending retained" request.request_id pending.request_id
+     | None -> Alcotest.fail "pending input should be retained")
+  | Error e -> Alcotest.fail (Error.to_string e)
+;;
+
 let test_apply_input_provided_rejects_mismatch () =
   let session =
     mk_session
@@ -784,6 +813,10 @@ let () =
             "Input_provided resumes"
             `Quick
             test_apply_input_provided_resumes_running
+        ; Alcotest.test_case
+            "Pending_input_updated is not lifecycle state"
+            `Quick
+            test_apply_pending_input_update_is_not_lifecycle_state
         ; Alcotest.test_case
             "Input_provided mismatch"
             `Quick

--- a/test/test_runtime_server_types.ml
+++ b/test/test_runtime_server_types.ml
@@ -134,6 +134,17 @@ let test_custom_name_of_kind_all_variants () =
           ; response = Runtime.Input_answer (`String "yes")
           }
       , "runtime.input_provided" )
+    ; ( Runtime.Pending_input_updated
+          { input_id = Some "pending-1"
+          ; participant_name = Some "worker-1"
+          ; source = Some "dashboard"
+          ; boundary = Runtime_continuation.Provider_streaming_reasoning
+          ; policy = Runtime_continuation.Queue_until_safe_boundary
+          ; status = "queued"
+          ; message = Some "queued while reasoning"
+          ; created_at = 1.0
+          }
+      , "runtime.pending_input_updated" )
     ; ( Runtime.Agent_spawn_requested
           { participant_name = "worker-1"
           ; role = Some "reviewer"


### PR DESCRIPTION
## Summary
- add `Runtime_continuation` with typed safe-boundary policies for busy-turn input
- add `Runtime.Pending_input_updated` so hosts can surface queued/applied/interrupted/ignored pending input state
- keep pending input updates out of lifecycle projection: they do not pause/stop a session and do not clear `pending_input`
- document runtime continuation boundaries and update the event catalog

## Verification
- `scripts/dune-local.sh build test/test_runtime_continuation.exe`
- `scripts/dune-local.sh build test/test_runtime_server_types.exe`
- `scripts/dune-local.sh build test/test_runtime_projection_cov2.exe`
- `scripts/dune-local.sh build test/test_runtime_evidence.exe`
- `./_build/default/test/test_runtime_continuation.exe`
- `./_build/default/test/test_runtime_server_types.exe`
- `./_build/default/test/test_runtime_projection_cov2.exe`
- `./_build/default/test/test_runtime_evidence.exe`

## Notes
- This is OAS protocol/policy only. MASC still needs the queue store and dashboard/Discord wiring in a follow-up.
- Ordinary queued input is deliberately not a lifecycle phase; explicit interrupt remains separate from pause/stop.
