### PR TITLE
fix(reasoning_dialect): align DashScope dialect + apply sampling drop on public path (#2078 Codex P2)

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -116,15 +116,27 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
     ; "max_tokens", `Int (Option.value ~default:4096 config.config.max_tokens)
     ]
   in
+  (* Mirror Backend_openai_request: drop sampling params the wire format ignores
+     while thinking (e.g. DeepSeek temperature/top_p). The public agent path
+     previously serialized them directly, so a thinking config leaked fields the
+     private path dropped. *)
+  let sampling_field_ignored field =
+    Llm_provider.Reasoning_dialect.sampling_field_ignored_when_thinking
+      ~thinking_control_format:capabilities.thinking_control_format
+      ~enable_thinking:config.config.enable_thinking
+      ~field
+  in
   let body_assoc =
     match config.config.temperature with
-    | Some temp -> ("temperature", `Float temp) :: body_assoc
-    | None -> body_assoc
+    | Some temp when not (sampling_field_ignored "temperature") ->
+      ("temperature", `Float temp) :: body_assoc
+    | Some _ | None -> body_assoc
   in
   let body_assoc =
     match config.config.top_p with
-    | Some top_p -> ("top_p", `Float top_p) :: body_assoc
-    | None -> body_assoc
+    | Some top_p when not (sampling_field_ignored "top_p") ->
+      ("top_p", `Float top_p) :: body_assoc
+    | Some _ | None -> body_assoc
   in
   let body_assoc =
     match config.config.top_k with

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -1267,8 +1267,13 @@ let%test "build_request serializes thinking object for deepseek-v4-flash" =
   let body = build_request ~config ~messages:[] () in
   let json = Yojson.Safe.from_string body in
   let open Yojson.Safe.Util in
+  (* thinking_budget 2048 -> raw effort "low", but the DeepSeek dialect
+     (Deepseek_high_or_max) normalizes low/medium/high -> "high" (see
+     test_thinking_control_dialects.ml "low maps high"). This assertion was
+     stale at "low" since #2042 routed reasoning_effort through normalize_effort
+     and was merged red. *)
   json |> member "thinking" |> member "type" |> to_string = "enabled"
-  && json |> member "reasoning_effort" |> to_string = "low"
+  && json |> member "reasoning_effort" |> to_string = "high"
 ;;
 
 let%test "build_request serializes disabled thinking for deepseek-v4-pro" =

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -47,16 +47,18 @@ let warn_dialect_ignored ~model_id ~field =
       model_id)
 ;;
 
-let thinking_enabled_for_dialect (config : Provider_config.t) =
-  match config.enable_thinking with
-  | Some false -> false
-  | Some true | None -> true
-;;
-
-let add_sampling_field dialect config field value body =
+let add_sampling_field
+      ~thinking_control_format
+      (config : Provider_config.t)
+      field
+      value
+      body
+  =
   if
-    thinking_enabled_for_dialect config
-    && List.mem field (Reasoning_dialect.sampling_params_ignored_when_thinking dialect)
+    Reasoning_dialect.sampling_field_ignored_when_thinking
+      ~thinking_control_format
+      ~enable_thinking:config.enable_thinking
+      ~field
   then (
     warn_dialect_ignored ~model_id:config.model_id ~field;
     body)
@@ -228,12 +230,24 @@ let build_request
   in
   let body =
     match config.temperature with
-    | Some t -> add_sampling_field dialect config "temperature" (`Float t) body
+    | Some t ->
+      add_sampling_field
+        ~thinking_control_format:caps.thinking_control_format
+        config
+        "temperature"
+        (`Float t)
+        body
     | None -> body
   in
   let body =
     match config.top_p with
-    | Some p -> add_sampling_field dialect config "top_p" (`Float p) body
+    | Some p ->
+      add_sampling_field
+        ~thinking_control_format:caps.thinking_control_format
+        config
+        "top_p"
+        (`Float p)
+        body
     | None -> body
   in
   (* Silent drops of user-supplied sampling params are a debugging

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -143,13 +143,22 @@ let for_provider_config (config : Provider_config.t) =
     ; replay_policy = Drop_without_tool_preserve_with_tool
     ; streaming = Delta_field "thought"
     }
-  | Kimi | OpenAI_compat | Ollama | Glm | DashScope ->
+  | Kimi | OpenAI_compat | Ollama | Glm ->
     (match Capabilities.for_model_id config.model_id with
      | Some caps -> of_capabilities caps |> with_preserve_thinking config
      | None ->
        (match provider_capabilities_of_kind config.kind with
         | Some caps -> of_capabilities caps |> with_preserve_thinking config
         | None -> default))
+  | DashScope ->
+    (* DashScope emits top-level enable_thinking/preserve_thinking regardless of
+       the model catalog. Backend_openai_request.capabilities_of_config is
+       provider-first for DashScope (always dashscope_capabilities); resolve it
+       provider-first here too so the reported toggle_wire matches the bytes the
+       request builder sends. Grouping DashScope with the model-catalog-first
+       providers above made a DashScope Qwen config report Chat_template_kwargs
+       while the builder emitted enable_thinking. *)
+    of_capabilities Capabilities.dashscope_capabilities |> with_preserve_thinking config
 ;;
 
 let normalize_effort dialect raw =
@@ -168,6 +177,32 @@ let sampling_params_ignored_when_thinking dialect =
   match dialect.sampling_policy with
   | Sampling_supported -> []
   | Ignored_when_thinking params -> params
+;;
+
+(* Sampling params a wire format ignores while thinking is enabled, keyed purely
+   by the format so both request builders can consult it without a full dialect.
+   Only DeepSeek-style [Thinking_object] suppresses sampling; the constant is the
+   single source of truth, also used by [of_capabilities] above. *)
+let sampling_params_ignored_for_format
+  : Capabilities.thinking_control_format -> string list
+  = function
+  | Capabilities.Thinking_object -> deepseek_ignored_sampling_params
+  | Capabilities.No_thinking_control
+  | Capabilities.Thinking_object_only
+  | Capabilities.Chat_template_kwargs
+  | Capabilities.Chat_template_token
+  | Capabilities.Reasoning_effort
+  | Capabilities.Enable_thinking -> []
+;;
+
+let sampling_field_ignored_when_thinking ~thinking_control_format ~enable_thinking ~field =
+  let thinking_active =
+    match enable_thinking with
+    | Some false -> false
+    | Some true | None -> true
+  in
+  thinking_active
+  && List.mem field (sampling_params_ignored_for_format thinking_control_format)
 ;;
 
 let should_replay_reasoning dialect ~assistant_had_tool_call =

--- a/lib/llm_provider/reasoning_dialect.mli
+++ b/lib/llm_provider/reasoning_dialect.mli
@@ -72,6 +72,19 @@ val normalize_effort : t -> string -> string option
 
 val sampling_params_ignored_when_thinking : t -> string list
 
+(** [true] when [field] is a sampling parameter the wire format ignores while
+    thinking is enabled. Thinking defaults on: only an explicit
+    [enable_thinking = Some false] keeps the field. Keyed on
+    {!Capabilities.thinking_control_format} so both the [Provider_config]-based
+    request builder ([Backend_openai_request]) and the agent-state-based one
+    ([Api_openai.build_openai_body]) drop the same parameters; the public path
+    only has the format, not a full {!t}. *)
+val sampling_field_ignored_when_thinking
+  :  thinking_control_format:Capabilities.thinking_control_format
+  -> enable_thinking:bool option
+  -> field:string
+  -> bool
+
 (** Whether an assistant reasoning side-channel should be replayed into a
     subsequent request. [assistant_had_tool_call] is intentionally explicit:
     DeepSeek-style thinking requires replay after tool calls but can drop

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -372,6 +372,69 @@ let test_build_openai_body_with_provider_m_sampling () =
     (json |> member "chat_template_kwargs" |> member "enable_thinking" |> to_bool)
 ;;
 
+let test_build_openai_body_deepseek_thinking_drops_sampling () =
+  (* Public agent path must drop temperature/top_p for a DeepSeek (Thinking_object)
+     config while thinking is enabled, matching Backend_openai_request.build_request.
+     Thinking defaults on, so no enable_thinking is set here. *)
+  let state =
+    { Types.config =
+        { Types.default_config with
+          model = "deepseek-v4-flash"
+        ; temperature = Some 0.7
+        ; top_p = Some 0.9
+        }
+    ; messages = []
+    ; turn_count = 0
+    ; usage = Types.empty_usage
+    }
+  in
+  let json =
+    Api.build_openai_body ~config:state ~messages:[] () |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  check
+    (option (float 0.001))
+    "temperature dropped while thinking"
+    None
+    (json |> member "temperature" |> to_float_option);
+  check
+    (option (float 0.001))
+    "top_p dropped while thinking"
+    None
+    (json |> member "top_p" |> to_float_option)
+;;
+
+let test_build_openai_body_deepseek_disabled_thinking_keeps_sampling () =
+  (* With thinking explicitly disabled the suppression must not fire. *)
+  let state =
+    { Types.config =
+        { Types.default_config with
+          model = "deepseek-v4-flash"
+        ; temperature = Some 0.7
+        ; top_p = Some 0.9
+        ; enable_thinking = Some false
+        }
+    ; messages = []
+    ; turn_count = 0
+    ; usage = Types.empty_usage
+    }
+  in
+  let json =
+    Api.build_openai_body ~config:state ~messages:[] () |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  check
+    (option (float 0.001))
+    "temperature kept when thinking disabled"
+    (Some 0.7)
+    (json |> member "temperature" |> to_float_option);
+  check
+    (option (float 0.001))
+    "top_p kept when thinking disabled"
+    (Some 0.9)
+    (json |> member "top_p" |> to_float_option)
+;;
+
 let test_build_openai_body_with_qwen_preserve_thinking () =
   let state = make_state ~enable_thinking:true ~preserve_thinking:true () in
   let state =
@@ -1488,6 +1551,14 @@ let () =
             "with dashscope sampling"
             `Quick
             test_build_openai_body_with_provider_m_sampling
+        ; test_case
+            "deepseek thinking drops sampling"
+            `Quick
+            test_build_openai_body_deepseek_thinking_drops_sampling
+        ; test_case
+            "deepseek disabled thinking keeps sampling"
+            `Quick
+            test_build_openai_body_deepseek_disabled_thinking_keeps_sampling
         ; test_case
             "qwen preserve thinking"
             `Quick

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -137,6 +137,27 @@ let test_qwen36_dashscope_uses_top_level_enable_thinking () =
   check_member_absent "reasoning_effort" json
 ;;
 
+let test_qwen36_dashscope_dialect_reports_enable_thinking () =
+  (* The reported dialect metadata must match what build_request actually emits
+     for a DashScope Qwen config (top-level enable_thinking, asserted above),
+     not the model catalog's chat_template_kwargs. *)
+  let config =
+    PC.make
+      ~kind:DashScope
+      ~model_id:"Qwen3.6-35B-A3B"
+      ~base_url:"https://dashscope.aliyuncs.com/compatible-mode/v1"
+      ~enable_thinking:true
+      ~preserve_thinking:true
+      ()
+  in
+  let dialect = RD.for_provider_config config in
+  check
+    string
+    "toggle wire"
+    "enable_thinking"
+    (RD.toggle_wire_to_string dialect.toggle_wire)
+;;
+
 let test_openai_reasoning_dialect_uses_reasoning_effort () =
   let dialect =
     RD.of_capabilities Llm_provider.Capabilities.openai_compat_chat_extended_capabilities
@@ -471,6 +492,10 @@ let () =
             "qwen3.6 dashscope uses top-level enable_thinking"
             `Quick
             test_qwen36_dashscope_uses_top_level_enable_thinking
+        ; test_case
+            "qwen3.6 dashscope dialect reports enable_thinking"
+            `Quick
+            test_qwen36_dashscope_dialect_reports_enable_thinking
         ; test_case
             "openai reasoning dialect uses reasoning_effort"
             `Quick


### PR DESCRIPTION
## 요약

머지된 `#2078`(reasoning dialect)에 **미해결 Codex P2 2건**이 main에 잔존했습니다. 둘 다 dialect 메타데이터와 request builder가 실제로 보내는 바이트 사이의 split-brain입니다. 최근 머지 oas PR 미해결 Codex 스레드 전수 스윕(triage + 독립 verify)에서 확정한 유일한 genuine needs-fix 2건입니다 (나머지 6건은 이미 수정됨).

## F5 — DashScope dialect 메타 불일치 (`reasoning_dialect.ml`)

`for_provider_config`가 DashScope를 model-catalog-first 그룹(`Kimi | OpenAI_compat | Ollama | Glm | DashScope`)에 묶어, DashScope Qwen 설정이 `toggle_wire=Chat_template_kwargs`를 보고했습니다. 그러나 `Backend_openai_request.capabilities_of_config`는 DashScope에 대해 **provider-first**(`dashscope_capabilities`)이고 builder는 top-level `enable_thinking`을 emit합니다. `.mli`는 `toggle_wire`가 "실제 wire field"라고 명시하므로 메타가 거짓을 보고한 셈입니다.

→ DashScope를 provider-first 분기로 분리해 builder와 일치시켰습니다. Kimi/OpenAI_compat/Ollama/Glm은 이미 `capabilities_of_config`와 정합이라 변경 없습니다.

## F4 — 공개 경로 sampling drop 누락 (`api_openai.ml`)

`#2078`이 추가한 thinking-mode sampling drop은 `Backend_openai_request.build_request`(`complete_sync`가 쓰는 `Provider_config` 경로)에만 적용됐습니다. 공개 agent 경로 `build_openai_body`(= `Api_openai.ln`, `Provider_intf.of_config`/`streaming.ml` 경유)는 `temperature`/`top_p`를 직접 직렬화해, DeepSeek 설정이 한 경로에선 드롭되고 다른 경로에선 새어나갔습니다.

→ 단일 진실원: `Reasoning_dialect.sampling_field_ignored_when_thinking`을 `Capabilities.thinking_control_format` 키로 통일(기존 `deepseek_ignored_sampling_params` 상수 위). 두 builder가 동일 predicate를 소비 — `build_request`는 `caps.thinking_control_format`, `build_openai_body`는 `capabilities.thinking_control_format`을 전달.

format 키가 필요한 이유: `Provider.capabilities`는 `Llm_provider.Capabilities.capabilities`와 **봉인된 별개 타입**(`provider.mli`가 manifest equality 없이 record 재선언)이라 공개 경로는 full dialect를 재사용할 수 없습니다. 단 `thinking_control_format` 필드는 공유 타입입니다.

## 트레이드오프

- 장점: 메타-builder 정합, 두 경로 동일 드롭, 컴파일러가 format match를 exhaustive 강제(새 format 누락 불가), 우회 아닌 단일 진실원.
- 단점/제약: `sampling_field_ignored_when_thinking` 시그니처 변경(`t ->` → `~thinking_control_format:`); 내부 소비처 2곳(`add_sampling_field`, `build_openai_body`)만 영향. masc drift-check surface(event_bus/http_error/metrics)에는 영향 없음.

## 테스트

- `test_api.ml`: 공개 경로가 deepseek-v4-flash thinking-on에서 `temperature`/`top_p` 드롭, `enable_thinking=false`에선 유지.
- `test_thinking_control_dialects.ml`: `for_provider_config`가 DashScope Qwen에 대해 `enable_thinking`을 보고(위 build_request 단언과 일치).

로컬: `dune build @check` 0, `test_api` 69, `test_thinking_control_dialects` 19, `@fmt` 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
