### PR TITLE
[codex] Align provider reasoning controls

### DIFF
--- a/docs/design/provider-reasoning-dialects.md
+++ b/docs/design/provider-reasoning-dialects.md
@@ -44,9 +44,11 @@ not introduce a second model registry.
   <https://platform.claude.com/docs/en/build-with-claude/extended-thinking>,
   <https://platform.claude.com/docs/en/build-with-claude/effort>, checked
   2026-06-14.
-- OpenAI official docs: reasoning models expose reasoning controls and prior
-  reasoning state can be preserved with `previous_response_id` or by manually
-  passing reasoning items forward. Source:
+- OpenAI official docs: reasoning models expose `reasoning.effort`; currently
+  documented values include `none`, `minimal`, `low`, `medium`, `high`, and
+  `xhigh`, with support/defaults varying by model. Prior reasoning state can
+  be preserved with `previous_response_id` or by manually passing reasoning
+  items forward. Source:
   <https://platform.openai.com/docs/guides/reasoning>, checked 2026-06-14.
 - Gemini official docs: Gemini exposes `thinkingConfig`; Gemini 3+ should use
   `thinkingLevel`, while Gemini 2.5 uses `thinkingBudget`; optional thought

--- a/docs/design/provider-reasoning-dialects.md
+++ b/docs/design/provider-reasoning-dialects.md
@@ -22,8 +22,8 @@ not introduce a second model registry.
 | `Chat_template_token` | Template token injection such as Gemma `<\|think\|>` | No mandatory replay; parse visible thought channel from generated text |
 | `Reasoning_effort` | OpenAI-compatible `reasoning_effort` field | No mandatory replay yet |
 | `Enable_thinking` | DashScope-style top-level `enable_thinking` | No mandatory replay yet |
-| `Anthropic_thinking` | Claude Messages API `thinking` blocks | Preserve thinking blocks in history; Claude filters relevant blocks |
-| `Gemini_thinking_config` | Gemini native `generationConfig.thinkingConfig` and thought parts/signatures | Preserve tool-call-linked thought signatures |
+| `Anthropic_thinking` | Claude Messages API `thinking` blocks. Older/current manual-thinking models use `thinking: {type:"enabled", budget_tokens:N}`; adaptive models use `thinking: {type:"adaptive"}` plus optional `output_config.effort`. | Preserve thinking blocks in history; Claude filters relevant blocks |
+| `Gemini_thinking_config` | Gemini native `generationConfig.thinkingConfig`. Gemini 3+ uses `thinkingLevel`; Gemini 2.5 uses `thinkingBudget`; thought parts/signatures carry visible summaries/tool continuity. | Preserve tool-call-linked thought signatures |
 
 ## Evidence
 
@@ -37,24 +37,27 @@ not introduce a second model registry.
   a thought channel plus answer content, and parsing requires keeping special
   tokens. Source: <https://ai.google.dev/gemma/docs/capabilities/thinking?hl=ko>,
   checked 2026-06-14.
-- Claude official docs: extended thinking uses `thinking` blocks, and during
-  tool use those blocks must be passed back unchanged; Claude filters relevant
-  blocks. Source:
+- Claude official docs: extended thinking uses `thinking` blocks, during tool
+  use those blocks must be passed back unchanged, Opus 4.7/4.8 reject manual
+  `budget_tokens` and require adaptive thinking, and effort is carried through
+  `output_config.effort`. Source:
   <https://platform.claude.com/docs/en/build-with-claude/extended-thinking>,
-  checked 2026-06-14.
+  <https://platform.claude.com/docs/en/build-with-claude/effort>, checked
+  2026-06-14.
 - OpenAI official docs: reasoning models expose reasoning controls and prior
   reasoning state can be preserved with `previous_response_id` or by manually
   passing reasoning items forward. Source:
-  <https://developers.openai.com/api/docs/guides/reasoning>, checked
-  2026-06-14.
-- Gemini official docs: Gemini exposes `thinkingConfig`, `thinkingBudget`, and
-  optional thought summaries marked on response parts. Source:
+  <https://platform.openai.com/docs/guides/reasoning>, checked 2026-06-14.
+- Gemini official docs: Gemini exposes `thinkingConfig`; Gemini 3+ should use
+  `thinkingLevel`, while Gemini 2.5 uses `thinkingBudget`; optional thought
+  summaries are marked on response parts. Source:
   <https://ai.google.dev/gemini-api/docs/thinking>, checked 2026-06-14.
 - DashScope/Qwen official docs: OpenAI-compatible Qwen thinking uses
   `enable_thinking`, optional `thinking_budget`, side-channel
   `reasoning_content`, and `preserve_thinking` for carrying historical
   assistant reasoning forward. Source:
-  <https://help.aliyun.com/zh/model-studio/deep-thinking>, checked 2026-06-14.
+  <https://www.alibabacloud.com/help/en/model-studio/deep-thinking>, checked
+  2026-06-14.
 
 ## Boundary
 

--- a/lib/api_anthropic.ml
+++ b/lib/api_anthropic.ml
@@ -35,6 +35,23 @@ let build_body_assoc
       ~supports_parallel_tool_calls:capabilities.supports_parallel_tool_calls
       ~tools_present
   in
+  let provider_config =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Anthropic
+      ~model_id:model_str
+      ~base_url:""
+      ?max_tokens:config.config.max_tokens
+      ?temperature:config.config.temperature
+      ?top_p:config.config.top_p
+      ?top_k:config.config.top_k
+      ?enable_thinking:config.config.enable_thinking
+      ?thinking_budget:config.config.thinking_budget
+      ~response_format:config.config.response_format
+      ()
+  in
+  let thinking_mode =
+    Llm_provider.Capabilities.anthropic_thinking_control_of_id model_str
+  in
   let messages =
     messages
     |> Llm_provider.Tool_message_pairs.close_for_provider_request
@@ -122,30 +139,23 @@ let build_body_assoc
         ("tool_choice", tc_json) :: body_assoc)
       else body_assoc
   in
-  (* Thinking gate keys on [enable_thinking], not on [thinking_budget].
-     Previously the match was on [thinking_budget = Some _], which
-     meant:
-       (a) [enable_thinking = Some true, thinking_budget = None]
-           → no thinking block emitted (wrong — operator asked for
-             thinking, got none)
-       (b) [enable_thinking = Some false, thinking_budget = Some n]
-           → thinking block emitted anyway (wrong — operator disabled
-             thinking but a stray budget turned it back on)
-     Match the llm_provider backend's semantics from
-     lib/llm_provider/backend_anthropic.ml:75-83: gate on
-     [enable_thinking = Some true] and fall back to a 10_000-token
-     default budget if the caller did not specify one. *)
   let body_assoc =
-    match config.config.enable_thinking with
-    | Some true ->
-      let budget =
-        match config.config.thinking_budget with
-        | Some b -> b
-        | None -> 10_000
-      in
-      ("thinking", `Assoc [ "type", `String "enabled"; "budget_tokens", `Int budget ])
-      :: body_assoc
-    | _ -> body_assoc
+    match
+      Llm_provider.Backend_anthropic.thinking_config_for_config
+        thinking_mode
+        provider_config
+    with
+    | Some thinking -> ("thinking", thinking) :: body_assoc
+    | None -> body_assoc
+  in
+  let body_assoc =
+    match
+      Llm_provider.Backend_anthropic.output_config_for_config
+        thinking_mode
+        provider_config
+    with
+    | Some output_config -> ("output_config", output_config) :: body_assoc
+    | None -> body_assoc
   in
   (* Sampling parameters were previously omitted entirely from the
      Anthropic agent_sdk request path — any [temperature], [top_p],

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -65,6 +65,61 @@ let chat_template_kwargs_fields (config : agent_state) =
   @ bool_field "preserve_thinking" config.config.preserve_thinking
 ;;
 
+let llm_capabilities_of_provider_capabilities (caps : Provider.capabilities)
+  : Llm_provider.Capabilities.capabilities
+  =
+  { max_context_tokens = caps.max_context_tokens
+  ; max_output_tokens = caps.max_output_tokens
+  ; supports_tools = caps.supports_tools
+  ; supports_tool_choice = caps.supports_tool_choice
+  ; supports_parallel_tool_calls = caps.supports_parallel_tool_calls
+  ; supports_runtime_mcp_tools = caps.supports_runtime_mcp_tools
+  ; supports_runtime_tool_events = caps.supports_runtime_tool_events
+  ; supports_reasoning = caps.supports_reasoning
+  ; supports_extended_thinking = caps.supports_extended_thinking
+  ; supports_reasoning_budget = caps.supports_reasoning_budget
+  ; thinking_control_format = caps.thinking_control_format
+  ; supports_response_format_json = caps.supports_response_format_json
+  ; supports_structured_output = caps.supports_structured_output
+  ; supports_multimodal_inputs = caps.supports_multimodal_inputs
+  ; supports_image_input = caps.supports_image_input
+  ; supports_audio_input = caps.supports_audio_input
+  ; supports_video_input = caps.supports_video_input
+  ; modality_priority = caps.modality_priority
+  ; supports_native_streaming = caps.supports_native_streaming
+  ; supports_system_prompt = caps.supports_system_prompt
+  ; supports_caching = caps.supports_caching
+  ; supports_prompt_caching = caps.supports_prompt_caching
+  ; prompt_cache_alignment = caps.prompt_cache_alignment
+  ; supports_top_k = caps.supports_top_k
+  ; supports_min_p = caps.supports_min_p
+  ; supports_seed = caps.supports_seed
+  ; supports_seed_with_images = caps.supports_seed_with_images
+  ; supports_computer_use = caps.supports_computer_use
+  ; supports_code_execution = caps.supports_code_execution
+  ; emits_usage_tokens = caps.emits_usage_tokens
+  ; supported_models = caps.supported_models
+  }
+;;
+
+let reasoning_dialect_for_request capabilities (config : agent_state) =
+  capabilities
+  |> llm_capabilities_of_provider_capabilities
+  |> Llm_provider.Reasoning_dialect.of_capabilities
+  |> Llm_provider.Reasoning_dialect.with_preserve_thinking
+       ~preserve_thinking:config.config.preserve_thinking
+;;
+
+let add_sampling_field dialect (config : agent_state) field value body_assoc =
+  if
+    Llm_provider.Reasoning_dialect.ignores_sampling_param
+      dialect
+      ~enable_thinking:config.config.enable_thinking
+      field
+  then body_assoc
+  else (field, value) :: body_assoc
+;;
+
 let effective_tool_choice_json
       (capabilities : Provider.capabilities)
       ?provider_config
@@ -91,6 +146,7 @@ let should_include_tools ?provider_config (config : agent_state) =
 let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
   let model_str = model_to_string config.config.model in
   let capabilities = capabilities_for_request ?provider_config config in
+  let dialect = reasoning_dialect_for_request capabilities config in
   let tools_to_send =
     match tools with
     | Some entries
@@ -106,7 +162,7 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
     let message_serializer =
       if is_glm_request ?provider_config config
       then Llm_provider.Backend_openai_serialize.provider_k_messages_of_message
-      else openai_messages_of_message
+      else Llm_provider.Backend_openai_serialize.dialect_messages_of_message dialect
     in
     system_message_json config @ List.concat_map message_serializer sanitized_messages
   in
@@ -116,27 +172,16 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
     ; "max_tokens", `Int (Option.value ~default:4096 config.config.max_tokens)
     ]
   in
-  (* Mirror Backend_openai_request: drop sampling params the wire format ignores
-     while thinking (e.g. DeepSeek temperature/top_p). The public agent path
-     previously serialized them directly, so a thinking config leaked fields the
-     private path dropped. *)
-  let sampling_field_ignored field =
-    Llm_provider.Reasoning_dialect.sampling_field_ignored_when_thinking
-      ~thinking_control_format:capabilities.thinking_control_format
-      ~enable_thinking:config.config.enable_thinking
-      ~field
-  in
   let body_assoc =
     match config.config.temperature with
-    | Some temp when not (sampling_field_ignored "temperature") ->
-      ("temperature", `Float temp) :: body_assoc
-    | Some _ | None -> body_assoc
+    | Some temp ->
+      add_sampling_field dialect config "temperature" (`Float temp) body_assoc
+    | None -> body_assoc
   in
   let body_assoc =
     match config.config.top_p with
-    | Some top_p when not (sampling_field_ignored "top_p") ->
-      ("top_p", `Float top_p) :: body_assoc
-    | Some _ | None -> body_assoc
+    | Some top_p -> add_sampling_field dialect config "top_p" (`Float top_p) body_assoc
+    | None -> body_assoc
   in
   let body_assoc =
     match config.config.top_k with
@@ -184,7 +229,10 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
              ~enable_thinking:config.config.enable_thinking
              ~thinking_budget:config.config.thinking_budget
          with
-         | Some effort -> ("reasoning_effort", `String effort) :: body_assoc
+         | Some effort ->
+           (match Llm_provider.Reasoning_dialect.normalize_effort dialect effort with
+            | Some normalized -> ("reasoning_effort", `String normalized) :: body_assoc
+            | None -> body_assoc)
          | None -> body_assoc)
       | Llm_provider.Capabilities.Thinking_object ->
         (match config.config.enable_thinking with
@@ -195,7 +243,11 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
                  ~enable_thinking:config.config.enable_thinking
                  ~thinking_budget:config.config.thinking_budget
              with
-             | Some effort -> ("reasoning_effort", `String effort) :: body_assoc
+             | Some effort ->
+               (match Llm_provider.Reasoning_dialect.normalize_effort dialect effort with
+                | Some normalized ->
+                  ("reasoning_effort", `String normalized) :: body_assoc
+                | None -> body_assoc)
              | None -> body_assoc
            in
            ("thinking", `Assoc [ "type", `String "enabled" ]) :: body_assoc

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -60,6 +60,65 @@ let parse_response json =
   }
 ;;
 
+let effort_of_budget = function
+  | n when n <= 2_048 -> "low"
+  | n when n <= 8_192 -> "medium"
+  | n when n <= 32_768 -> "high"
+  | _ -> "max"
+;;
+
+let effort_for_config mode (config : Provider_config.t) =
+  match mode, config.thinking_budget with
+  | ( ( Capabilities.Anthropic_adaptive_only
+      | Capabilities.Anthropic_adaptive_preferred
+      | Capabilities.Anthropic_always_adaptive )
+    , Some budget ) -> Some (effort_of_budget budget)
+  | Capabilities.Anthropic_manual_budget, _
+  | ( ( Capabilities.Anthropic_adaptive_only
+      | Capabilities.Anthropic_adaptive_preferred
+      | Capabilities.Anthropic_always_adaptive )
+    , None ) -> None
+;;
+
+let thinking_config_for_config mode (config : Provider_config.t) =
+  match config.enable_thinking, mode with
+  | Some true, Capabilities.Anthropic_always_adaptive -> None
+  | ( Some true
+    , (Capabilities.Anthropic_adaptive_only | Capabilities.Anthropic_adaptive_preferred) )
+    -> Some (`Assoc [ "type", `String "adaptive" ])
+  | Some true, Capabilities.Anthropic_manual_budget ->
+    let budget =
+      match config.thinking_budget with
+      | Some b -> b
+      | None -> Constants.Thinking.provider_a_budget ()
+    in
+    Some (`Assoc [ "type", `String "enabled"; "budget_tokens", `Int budget ])
+  | Some false, _ | None, _ -> None
+;;
+
+let output_config_for_config mode (config : Provider_config.t) =
+  let output_format =
+    match config.output_schema, config.response_format with
+    | Some schema, _ -> Some schema
+    | None, JsonSchema schema -> Some schema
+    | None, JsonMode | None, Off -> None
+  in
+  let fields =
+    match output_format with
+    | Some schema ->
+      [ "format", `Assoc [ "type", `String "json_schema"; "schema", schema ] ]
+    | None -> []
+  in
+  let fields =
+    match effort_for_config mode config with
+    | Some effort -> ("effort", `String effort) :: fields
+    | None -> fields
+  in
+  match fields with
+  | [] -> None
+  | _ :: _ -> Some (`Assoc (List.rev fields))
+;;
+
 (** Build Anthropic Messages API request body from {!Provider_config.t}.
     Returns a JSON string ready for HTTP POST. *)
 let build_request
@@ -81,6 +140,7 @@ let build_request
       ~supports_parallel_tool_calls:caps.supports_parallel_tool_calls
       ~tools_present
   in
+  let thinking_mode = Capabilities.anthropic_thinking_control_of_id config.model_id in
   let messages =
     messages
     |> Tool_message_pairs.close_for_provider_request
@@ -138,29 +198,13 @@ let build_request
     | None -> body
   in
   let body =
-    match config.enable_thinking with
-    | Some true ->
-      let budget =
-        match config.thinking_budget with
-        | Some b -> b
-        | None -> Constants.Thinking.provider_a_budget ()
-      in
-      ("thinking", `Assoc [ "type", `String "enabled"; "budget_tokens", `Int budget ])
-      :: body
-    | _ -> body
+    match thinking_config_for_config thinking_mode config with
+    | Some thinking -> ("thinking", thinking) :: body
+    | None -> body
   in
   let body =
-    let output_schema =
-      match config.output_schema, config.response_format with
-      | Some schema, _ -> Some schema
-      | None, JsonSchema schema -> Some schema
-      | None, JsonMode | None, Off -> None
-    in
-    match output_schema with
-    | Some schema ->
-      ( "output_config"
-      , `Assoc [ "format", `Assoc [ "type", `String "json_schema"; "schema", schema ] ] )
-      :: body
+    match output_config_for_config thinking_mode config with
+    | Some output_config -> ("output_config", output_config) :: body
     | None -> body
   in
   let body =

--- a/lib/llm_provider/backend_anthropic.mli
+++ b/lib/llm_provider/backend_anthropic.mli
@@ -7,6 +7,21 @@
 
 val parse_response : Yojson.Safe.t -> Types.api_response
 
+(** Provider-correct Claude thinking request field for a model family.
+    Exposed so the legacy Agent SDK Anthropic builder can share the same
+    manual-budget vs adaptive-thinking dispatch as this backend. *)
+val thinking_config_for_config
+  :  Capabilities.anthropic_thinking_control
+  -> Provider_config.t
+  -> Yojson.Safe.t option
+
+(** Optional Claude [output_config], including adaptive [effort] and native
+    JSON-schema format when requested. *)
+val output_config_for_config
+  :  Capabilities.anthropic_thinking_control
+  -> Provider_config.t
+  -> Yojson.Safe.t option
+
 val build_request
   :  ?stream:bool
   -> config:Provider_config.t

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -42,6 +42,43 @@ let warn_parallel_disable_unsupported ~model_id =
     mark ())
 ;;
 
+let thinking_level_of_budget ~supports_minimal = function
+  | Some n when n <= 0 ->
+    if supports_minimal then "minimal" else "low"
+  | Some n when n <= 2_048 -> "low"
+  | Some n when n <= 8_192 -> "medium"
+  | Some _ | None -> "high"
+;;
+
+let thinking_config_of_config (config : Provider_config.t) =
+  let model_id = String.lowercase_ascii (String.trim config.model_id) in
+  match Capabilities.gemini_thinking_control_of_id model_id with
+  | Capabilities.Gemini_thinking_level { supports_minimal } ->
+    (match config.enable_thinking with
+     | Some false ->
+       let level = if supports_minimal then "minimal" else "low" in
+       Some (`Assoc [ "thinkingLevel", `String level ])
+     | Some true ->
+       let level = thinking_level_of_budget ~supports_minimal config.thinking_budget in
+       Some
+         (`Assoc
+             [ "thinkingLevel", `String level; "includeThoughts", `Bool true ])
+     | None -> None)
+  | Capabilities.Gemini_thinking_budget | Capabilities.Gemini_unknown_thinking_control ->
+    (match config.enable_thinking with
+     | Some false -> Some (`Assoc [ "thinkingBudget", `Int 0 ])
+     | Some true ->
+       let budget =
+         match config.thinking_budget with
+         | Some b -> b
+         | None -> Constants.Thinking.provider_f_budget ()
+       in
+       Some
+         (`Assoc
+             [ "thinkingBudget", `Int budget; "includeThoughts", `Bool true ])
+     | None -> None)
+;;
+
 let provider_f_role_of_oas = function
   | User | System | Tool -> "user"
   | Assistant -> "model"
@@ -314,19 +351,11 @@ let build_request
           | None -> Constants.Deterministic.default_seed)
      in
      gen_config := ("seed", `Int seed) :: !gen_config));
-  (* Thinking config *)
-  (match config.enable_thinking with
-   | Some true ->
-     let budget =
-       match config.thinking_budget with
-       | Some b -> b
-       | None -> Constants.Thinking.provider_f_budget ()
-     in
-     gen_config
-     := ( "thinkingConfig"
-        , `Assoc [ "thinkingBudget", `Int budget; "includeThoughts", `Bool true ] )
-        :: !gen_config
-   | _ -> ());
+  (* Gemini 3+ uses [thinkingLevel]; Gemini 2.5 uses [thinkingBudget]. *)
+  (match thinking_config_of_config config with
+   | Some thinking_config ->
+     gen_config := ("thinkingConfig", thinking_config) :: !gen_config
+   | None -> ());
   let structured_schema =
     match config.output_schema, config.response_format with
     | Some schema, _ -> Some schema

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -47,18 +47,12 @@ let warn_dialect_ignored ~model_id ~field =
       model_id)
 ;;
 
-let add_sampling_field
-      ~thinking_control_format
-      (config : Provider_config.t)
-      field
-      value
-      body
-  =
+let add_sampling_field dialect (config : Provider_config.t) field value body =
   if
-    Reasoning_dialect.sampling_field_ignored_when_thinking
-      ~thinking_control_format
+    Reasoning_dialect.ignores_sampling_param
+      dialect
       ~enable_thinking:config.enable_thinking
-      ~field
+      field
   then (
     warn_dialect_ignored ~model_id:config.model_id ~field;
     body)
@@ -230,24 +224,12 @@ let build_request
   in
   let body =
     match config.temperature with
-    | Some t ->
-      add_sampling_field
-        ~thinking_control_format:caps.thinking_control_format
-        config
-        "temperature"
-        (`Float t)
-        body
+    | Some t -> add_sampling_field dialect config "temperature" (`Float t) body
     | None -> body
   in
   let body =
     match config.top_p with
-    | Some p ->
-      add_sampling_field
-        ~thinking_control_format:caps.thinking_control_format
-        config
-        "top_p"
-        (`Float p)
-        body
+    | Some p -> add_sampling_field dialect config "top_p" (`Float p) body
     | None -> body
   in
   (* Silent drops of user-supplied sampling params are a debugging

--- a/lib/llm_provider/backend_openai_responses.ml
+++ b/lib/llm_provider/backend_openai_responses.ml
@@ -275,6 +275,16 @@ let effective_max_output_tokens (config : Provider_config.t) =
   | Some n, _ -> n
 ;;
 
+let add_sampling_field dialect (config : Provider_config.t) field value body =
+  if
+    Reasoning_dialect.ignores_sampling_param
+      dialect
+      ~enable_thinking:config.enable_thinking
+      field
+  then body
+  else (field, value) :: body
+;;
+
 let build_request
       ?(stream = false)
       ~(config : Provider_config.t)
@@ -286,10 +296,15 @@ let build_request
   let sanitized_messages =
     Backend_openai_serialize.close_tool_message_pairs_for_request messages
   in
+  let dialect = Reasoning_dialect.for_provider_config config in
   let reasoning_effort =
-    Provider_config.reasoning_effort_request_value
-      ~enable_thinking:config.enable_thinking
-      ~thinking_budget:config.thinking_budget
+    match
+      Provider_config.reasoning_effort_request_value
+        ~enable_thinking:config.enable_thinking
+        ~thinking_budget:config.thinking_budget
+    with
+    | Some effort -> Reasoning_dialect.normalize_effort dialect effort
+    | None -> None
   in
   let body =
     [ "model", `String config.model_id
@@ -305,12 +320,12 @@ let build_request
   in
   let body =
     match config.temperature with
-    | Some t -> ("temperature", `Float t) :: body
+    | Some t -> add_sampling_field dialect config "temperature" (`Float t) body
     | None -> body
   in
   let body =
     match config.top_p with
-    | Some p -> ("top_p", `Float p) :: body
+    | Some p -> add_sampling_field dialect config "top_p" (`Float p) body
     | None -> body
   in
   let body =

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -149,18 +149,38 @@ type anthropic_thinking_control =
 
 let anthropic_thinking_control_of_id model_id =
   let id = String.lowercase_ascii (String.trim model_id) in
-  if
-    String.starts_with ~prefix:"claude-fable-5" id
-    || String.starts_with ~prefix:"claude-mythos-5" id
-    || String.starts_with ~prefix:"claude-mythos-preview" id
+  let has_prefix prefixes =
+    List.exists (fun prefix -> String.starts_with ~prefix id) prefixes
+  in
+  if has_prefix
+       [ "claude-fable-5"
+       ; "fable-5"
+       ; "agent_llm_a-fable-5"
+       ; "claude-mythos-5"
+       ; "mythos-5"
+       ; "agent_llm_a-mythos-5"
+       ; "claude-mythos-preview"
+       ; "mythos-preview"
+       ; "agent_llm_a-mythos-preview"
+       ]
   then Anthropic_always_adaptive
-  else if
-    String.starts_with ~prefix:"claude-opus-4-8" id
-    || String.starts_with ~prefix:"claude-opus-4-7" id
+  else if has_prefix
+            [ "claude-opus-4-8"
+            ; "opus-4-8"
+            ; "agent_llm_a-opus-4-8"
+            ; "claude-opus-4-7"
+            ; "opus-4-7"
+            ; "agent_llm_a-opus-4-7"
+            ]
   then Anthropic_adaptive_only
-  else if
-    String.starts_with ~prefix:"claude-opus-4-6" id
-    || String.starts_with ~prefix:"claude-sonnet-4-6" id
+  else if has_prefix
+            [ "claude-opus-4-6"
+            ; "opus-4-6"
+            ; "agent_llm_a-opus-4-6"
+            ; "claude-sonnet-4-6"
+            ; "sonnet-4-6"
+            ; "agent_llm_a-sonnet-4-6"
+            ]
   then Anthropic_adaptive_preferred
   else Anthropic_manual_budget
 ;;

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -141,6 +141,30 @@ let effective_disable_parallel_tool_use
   caller_disabled || (tools_present && not supports_parallel_tool_calls)
 ;;
 
+type anthropic_thinking_control =
+  | Anthropic_manual_budget
+  | Anthropic_adaptive_preferred
+  | Anthropic_adaptive_only
+  | Anthropic_always_adaptive
+
+let anthropic_thinking_control_of_id model_id =
+  let id = String.lowercase_ascii (String.trim model_id) in
+  if
+    String.starts_with ~prefix:"claude-fable-5" id
+    || String.starts_with ~prefix:"claude-mythos-5" id
+    || String.starts_with ~prefix:"claude-mythos-preview" id
+  then Anthropic_always_adaptive
+  else if
+    String.starts_with ~prefix:"claude-opus-4-8" id
+    || String.starts_with ~prefix:"claude-opus-4-7" id
+  then Anthropic_adaptive_only
+  else if
+    String.starts_with ~prefix:"claude-opus-4-6" id
+    || String.starts_with ~prefix:"claude-sonnet-4-6" id
+  then Anthropic_adaptive_preferred
+  else Anthropic_manual_budget
+;;
+
 let anthropic_capabilities =
   { default_capabilities with
     max_context_tokens = Some 200_000
@@ -339,6 +363,11 @@ type gemini_family =
   (** Unknown gemini id or non-gemini id. Retains the literal so the
           caller can log / fall through without losing data. *)
 
+type gemini_thinking_control =
+  | Gemini_thinking_budget
+  | Gemini_thinking_level of { supports_minimal : bool }
+  | Gemini_unknown_thinking_control
+
 let strip_suffix ~suffix value =
   if String.ends_with ~suffix value
   then String.sub value 0 (String.length value - String.length suffix)
@@ -350,13 +379,25 @@ let strip_suffix ~suffix value =
     Input is expected lowercased (callers pass the already-normalized id). *)
 let gemini_family_of_id (id : string) : gemini_family =
   let starts p = String.starts_with ~prefix:p id in
-  if starts "gemini-3.1" || starts "gemini-3.1"
+  if starts "gemini-3.1"
   then Gemini_3_1
-  else if starts "gemini-3" || starts "gemini-3"
+  else if starts "gemini-3"
   then Gemini_3
-  else if starts "gemini-2.5" || starts "gemini-2.5"
+  else if starts "gemini-2.5"
   then Gemini_2_5
   else Gemini_other id
+;;
+
+let gemini_thinking_control_of_id id =
+  match gemini_family_of_id id with
+  | Gemini_3_1 ->
+    (* Google documents that Gemini 3.1 Pro does not support the [minimal]
+       thinking level; other Gemini 3.1 families do. *)
+    let supports_minimal = not (String.starts_with ~prefix:"gemini-3.1-pro" id) in
+    Gemini_thinking_level { supports_minimal }
+  | Gemini_3 -> Gemini_thinking_level { supports_minimal = true }
+  | Gemini_2_5 -> Gemini_thinking_budget
+  | Gemini_other _ -> Gemini_unknown_thinking_control
 ;;
 
 let gemini_capabilities =

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -111,6 +111,24 @@ val effective_disable_parallel_tool_use
   -> tools_present:bool
   -> bool
 
+(** Anthropic thinking-control protocol for a model family.
+
+    Older/current manual-thinking models accept
+    [thinking: {"type":"enabled","budget_tokens":N}]. Newer adaptive models
+    use [thinking: {"type":"adaptive"}] and optional [output_config.effort].
+    Some models require adaptive thinking, and some always run adaptive
+    thinking without an explicit [thinking] request field. *)
+type anthropic_thinking_control =
+  | Anthropic_manual_budget
+  | Anthropic_adaptive_preferred
+  | Anthropic_adaptive_only
+  | Anthropic_always_adaptive
+
+(** Return the documented thinking-control protocol for an Anthropic model id.
+    Input is expected lowercased, but the function trims and lowercases for
+    callers that pass raw config values. *)
+val anthropic_thinking_control_of_id : string -> anthropic_thinking_control
+
 (** Typed Gemini model family. SSOT for the [gemini-*] prefix dispatch that
     used to live as scattered [String.starts_with] calls. Downstream code
     should switch on this variant rather than re-compare strings.
@@ -122,11 +140,22 @@ type gemini_family =
   | Gemini_2_5 (** [gemini-2.5.*] (legacy line) *)
   | Gemini_other of string (** Unknown gemini id, or non-gemini id (literal retained). *)
 
+(** Gemini thinking-control protocol for a model family. Gemini 3+ uses
+    [thinkingLevel], while Gemini 2.5 uses [thinkingBudget]. *)
+type gemini_thinking_control =
+  | Gemini_thinking_budget
+  | Gemini_thinking_level of { supports_minimal : bool }
+  | Gemini_unknown_thinking_control
+
 (** Classify a model id into a [gemini_family]. Order: [3.1] before [3] so the
     more specific prefix wins. Input is expected lowercased; callers that
     cannot lowercase first should normalize via [String.lowercase_ascii] at
     the boundary. *)
 val gemini_family_of_id : string -> gemini_family
+
+(** Return the documented thinking-control protocol for a Gemini model id.
+    Input is expected lowercased, matching {!gemini_family_of_id}. *)
+val gemini_thinking_control_of_id : string -> gemini_thinking_control
 
 (** Look up capabilities for [model_id] in the loaded model catalog only
     (no manifest consultation).

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -194,16 +194,16 @@ let default_attempt_timeout_s = function
 
 (** Default reasoning effort level when thinking is enabled but no budget
     is specified. Override with [OAS_DEFAULT_REASONING_EFFORT] env var.
-    Accepted values: "low", "medium", "high". Invalid values fall back to
-    "medium".
+    Accepted values: "minimal", "low", "medium", "high", "xhigh". Invalid
+    values fall back to "medium".
     @since 0.185.0 *)
 let default_reasoning_effort () =
   match Cli_common_env.get "OAS_DEFAULT_REASONING_EFFORT" with
-  | Some (("low" | "medium" | "high") as v) -> v
+  | Some (("minimal" | "low" | "medium" | "high" | "xhigh") as v) -> v
   | Some v ->
     Diag.warn
       "provider_config"
-      "OAS_DEFAULT_REASONING_EFFORT=%S invalid (expected low/medium/high), using medium"
+      "OAS_DEFAULT_REASONING_EFFORT=%S invalid (expected minimal/low/medium/high/xhigh), using medium"
       v;
     "medium"
   | None -> "medium"

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -245,7 +245,9 @@ val clamp_max_turns : provider_kind -> int -> int
 val default_attempt_timeout_s : provider_kind -> float option
 
 (** Map thinking configuration fields to reasoning_effort string.
-    Returns "none", "low", "medium", or "high".
+    Returns ["none"], one of the budget-derived levels ["low" | "medium" |
+    "high"], or a supported [OAS_DEFAULT_REASONING_EFFORT] override
+    ["minimal" | "low" | "medium" | "high" | "xhigh"].
     @since 0.114.0 *)
 val effort_of_thinking_config
   :  enable_thinking:bool option

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -114,11 +114,25 @@ let of_capabilities (caps : Capabilities.capabilities) =
     }
 ;;
 
-let with_preserve_thinking config dialect =
-  match config.Provider_config.preserve_thinking, dialect.toggle_wire with
+let with_preserve_thinking ~preserve_thinking dialect =
+  match preserve_thinking, dialect.toggle_wire with
   | Some true, (Chat_template_kwargs | Enable_thinking) ->
     { dialect with replay_policy = Preserve_always }
   | _ -> dialect
+;;
+
+let thinking_enabled ~enable_thinking =
+  match enable_thinking with
+  | Some false -> false
+  | Some true | None -> true
+;;
+
+let ignores_sampling_param dialect ~enable_thinking field =
+  thinking_enabled ~enable_thinking
+  &&
+  match dialect.sampling_policy with
+  | Sampling_supported -> false
+  | Ignored_when_thinking params -> List.mem field params
 ;;
 
 let provider_capabilities_of_kind kind =
@@ -145,10 +159,14 @@ let for_provider_config (config : Provider_config.t) =
     }
   | Kimi | OpenAI_compat | Ollama | Glm ->
     (match Capabilities.for_model_id config.model_id with
-     | Some caps -> of_capabilities caps |> with_preserve_thinking config
+     | Some caps ->
+       of_capabilities caps
+       |> with_preserve_thinking ~preserve_thinking:config.preserve_thinking
      | None ->
        (match provider_capabilities_of_kind config.kind with
-        | Some caps -> of_capabilities caps |> with_preserve_thinking config
+        | Some caps ->
+          of_capabilities caps
+          |> with_preserve_thinking ~preserve_thinking:config.preserve_thinking
         | None -> default))
   | DashScope ->
     (* DashScope emits top-level enable_thinking/preserve_thinking regardless of
@@ -158,7 +176,8 @@ let for_provider_config (config : Provider_config.t) =
        request builder sends. Grouping DashScope with the model-catalog-first
        providers above made a DashScope Qwen config report Chat_template_kwargs
        while the builder emitted enable_thinking. *)
-    of_capabilities Capabilities.dashscope_capabilities |> with_preserve_thinking config
+    of_capabilities Capabilities.dashscope_capabilities
+    |> with_preserve_thinking ~preserve_thinking:config.preserve_thinking
 ;;
 
 let normalize_effort dialect raw =

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -186,7 +186,7 @@ let normalize_effort dialect raw =
   | ("none" | "off" | "disabled" | ""), _ -> None
   | ("low" | "medium" | "high"), Deepseek_high_or_max -> Some "high"
   | ("xhigh" | "max"), Deepseek_high_or_max -> Some "max"
-  | ("low" | "medium" | "high"), Preserve_effort -> Some normalized
+  | ("minimal" | "low" | "medium" | "high"), Preserve_effort -> Some normalized
   | "max", Preserve_effort -> Some "max"
   | "xhigh", Preserve_effort -> Some "xhigh"
   | _ -> None

--- a/lib/llm_provider/reasoning_dialect.mli
+++ b/lib/llm_provider/reasoning_dialect.mli
@@ -64,6 +64,9 @@ type t =
 val default : t
 val of_capabilities : Capabilities.capabilities -> t
 val for_provider_config : Provider_config.t -> t
+val with_preserve_thinking : preserve_thinking:bool option -> t -> t
+val thinking_enabled : enable_thinking:bool option -> bool
+val ignores_sampling_param : t -> enable_thinking:bool option -> string -> bool
 
 (** Normalize a caller effort for a provider dialect.
 

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -449,6 +449,142 @@ let test_build_openai_body_with_qwen_preserve_thinking () =
   check bool "preserve_thinking true" true (ctk |> member "preserve_thinking" |> to_bool)
 ;;
 
+let test_build_openai_body_qwen_preserve_replays_reasoning () =
+  let state = make_state ~enable_thinking:true ~preserve_thinking:true () in
+  let state =
+    { state with config = { state.config with model = "qwen36-35b-a3b-mtp" } }
+  in
+  let messages =
+    [ { Types.role = Types.Assistant
+      ; content =
+          [ Types.Thinking { thinking_type = "reasoning"; content = "keep this" }
+          ; Types.Text "answer"
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let json =
+    Api.build_openai_body ~config:state ~messages () |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  let assistant = json |> member "messages" |> index 1 in
+  check
+    string
+    "reasoning_content replayed"
+    "keep this"
+    (assistant |> member "reasoning_content" |> to_string)
+;;
+
+let deepseek_provider_config : Provider.config =
+  { Provider.provider =
+      Provider.OpenAICompat
+        { base_url = "https://api.deepseek.com"
+        ; auth_header = None
+        ; path = "/v1/chat/completions"
+        ; static_token = None
+        }
+  ; model_id = "deepseek-v4-pro"
+  ; api_key_env = ""
+  }
+;;
+
+let test_build_openai_body_deepseek_uses_dialect_controls () =
+  let state =
+    { Types.config =
+        { Types.default_config with
+          model = deepseek_provider_config.model_id
+        ; enable_thinking = Some true
+        ; thinking_budget = Some 2048
+        ; temperature = Some 0.7
+        ; top_p = Some 0.9
+        }
+    ; messages = []
+    ; turn_count = 0
+    ; usage = Types.empty_usage
+    }
+  in
+  let json =
+    Api.build_openai_body
+      ~provider_config:deepseek_provider_config
+      ~config:state
+      ~messages:[]
+      ()
+    |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  check
+    string
+    "thinking enabled"
+    "enabled"
+    (json |> member "thinking" |> member "type" |> to_string);
+  check string "low maps high" "high" (json |> member "reasoning_effort" |> to_string);
+  check bool "temperature omitted" true (json |> member "temperature" = `Null);
+  check bool "top_p omitted" true (json |> member "top_p" = `Null)
+;;
+
+let test_build_openai_body_deepseek_replays_tool_reasoning_only () =
+  let assistant_content tool =
+    if tool
+    then
+      [ Types.Thinking { thinking_type = "reasoning"; content = "call the tool" }
+      ; Types.ToolUse
+          { id = "call_1"; name = "calculator"; input = `Assoc [ "expr", `String "2+2" ] }
+      ]
+    else
+      [ Types.Thinking { thinking_type = "reasoning"; content = "plain thought" }
+      ; Types.Text "answer"
+      ]
+  in
+  let assistant_msg tool =
+    { Types.role = Types.Assistant
+    ; content = assistant_content tool
+    ; name = None
+    ; tool_call_id = None
+    ; metadata = []
+    }
+  in
+  let state =
+    { Types.config =
+        { Types.default_config with model = deepseek_provider_config.model_id }
+    ; messages = []
+    ; turn_count = 0
+    ; usage = Types.empty_usage
+    }
+  in
+  let plain =
+    Api.build_openai_body
+      ~provider_config:deepseek_provider_config
+      ~config:state
+      ~messages:[ assistant_msg false ]
+      ()
+    |> Yojson.Safe.from_string
+  in
+  let tool =
+    Api.build_openai_body
+      ~provider_config:deepseek_provider_config
+      ~config:state
+      ~messages:[ assistant_msg true ]
+      ()
+    |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  let plain_assistant = plain |> member "messages" |> index 0 in
+  let tool_assistant = tool |> member "messages" |> index 0 in
+  check
+    bool
+    "plain reasoning omitted"
+    true
+    (plain_assistant |> member "reasoning_content" = `Null);
+  check
+    string
+    "tool reasoning_content"
+    "call the tool"
+    (tool_assistant |> member "reasoning_content" |> to_string)
+;;
+
 let test_build_openai_body_omits_provider_m_only_fields_for_generic_compat () =
   let provider_config =
     Provider.openrouter ~model_id:"anthropic/agent_llm_a-sonnet-4-6" ()
@@ -1563,6 +1699,18 @@ let () =
             "qwen preserve thinking"
             `Quick
             test_build_openai_body_with_qwen_preserve_thinking
+        ; test_case
+            "qwen preserve replays reasoning"
+            `Quick
+            test_build_openai_body_qwen_preserve_replays_reasoning
+        ; test_case
+            "deepseek dialect controls"
+            `Quick
+            test_build_openai_body_deepseek_uses_dialect_controls
+        ; test_case
+            "deepseek tool reasoning replay"
+            `Quick
+            test_build_openai_body_deepseek_replays_tool_reasoning_only
         ; test_case
             "generic compat omits dashscope-only fields"
             `Quick

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -146,10 +146,23 @@ let test_provider_c_message_to_json_tool_result_uses_text_blocks () =
 (* build_body_assoc                                                     *)
 (* ------------------------------------------------------------------ *)
 
-let make_state ?thinking_budget ?tool_choice ?enable_thinking ?preserve_thinking () =
+let make_state
+      ?(model = Types.default_config.model)
+      ?thinking_budget
+      ?tool_choice
+      ?enable_thinking
+      ?preserve_thinking
+      ?response_format
+      ()
+  =
+  let response_format =
+    Option.value response_format ~default:Types.default_config.response_format
+  in
   let config =
     { Types.default_config with
-      system_prompt = Some "You are helpful."
+      model
+    ; response_format
+    ; system_prompt = Some "You are helpful."
     ; thinking_budget
     ; tool_choice
     ; enable_thinking
@@ -157,6 +170,23 @@ let make_state ?thinking_budget ?tool_choice ?enable_thinking ?preserve_thinking
     }
   in
   { Types.config; messages = []; turn_count = 0; usage = Types.empty_usage }
+;;
+
+let make_manual_thinking_state ?thinking_budget ?enable_thinking () =
+  make_state
+    ~model:"agent_llm_a-opus-4-5"
+    ?thinking_budget
+    ?enable_thinking
+    ()
+;;
+
+let make_adaptive_thinking_state ?thinking_budget ?enable_thinking ?response_format () =
+  make_state
+    ~model:"agent_llm_a-sonnet-4-6"
+    ?thinking_budget
+    ?enable_thinking
+    ?response_format
+    ()
 ;;
 
 let test_build_body_basic () =
@@ -177,7 +207,9 @@ let test_build_body_with_thinking_budget () =
   (* Thinking is gated on [enable_thinking = Some true]; a budget
      without enable_thinking must NOT emit a thinking block.
      Matches backend_anthropic.build_request semantics. *)
-  let config = make_state ~enable_thinking:true ~thinking_budget:1024 () in
+  let config =
+    make_manual_thinking_state ~enable_thinking:true ~thinking_budget:1024 ()
+  in
   let assoc = Api.build_body_assoc ~config ~messages:[] ~stream:false () in
   let json = `Assoc assoc in
   let open Yojson.Safe.Util in
@@ -188,10 +220,10 @@ let test_build_body_with_thinking_budget () =
 
 let test_build_body_with_enable_thinking_default_budget () =
   (* enable_thinking = true without an explicit budget should still
-     emit a thinking block, using the 10_000-token default budget
-     that matches backend_anthropic. Regression for the old gate
+     emit a thinking block, using the provider default budget for
+     manual-budget Claude models. Regression for the old gate
      that required thinking_budget = Some _ to activate. *)
-  let config = make_state ~enable_thinking:true () in
+  let config = make_manual_thinking_state ~enable_thinking:true () in
   let assoc = Api.build_body_assoc ~config ~messages:[] ~stream:false () in
   let json = `Assoc assoc in
   let open Yojson.Safe.Util in
@@ -199,9 +231,56 @@ let test_build_body_with_enable_thinking_default_budget () =
   check string "thinking type" "enabled" (thinking |> member "type" |> to_string);
   check
     int
-    "default budget_tokens 10_000"
-    10_000
+    "default budget_tokens"
+    (Llm_provider.Constants.Thinking.provider_a_budget ())
     (thinking |> member "budget_tokens" |> to_int)
+;;
+
+let test_build_body_adaptive_thinking () =
+  let config =
+    make_adaptive_thinking_state ~enable_thinking:true ~thinking_budget:1024 ()
+  in
+  let assoc = Api.build_body_assoc ~config ~messages:[] ~stream:false () in
+  let json = `Assoc assoc in
+  let open Yojson.Safe.Util in
+  let thinking = json |> member "thinking" in
+  check string "thinking type" "adaptive" (thinking |> member "type" |> to_string);
+  check bool "budget_tokens omitted" true (thinking |> member "budget_tokens" = `Null);
+  check
+    string
+    "adaptive effort"
+    "low"
+    (json |> member "output_config" |> member "effort" |> to_string)
+;;
+
+let test_build_body_adaptive_output_config_merges_format_and_effort () =
+  let schema =
+    `Assoc
+      [ "type", `String "object"
+      ; "properties", `Assoc [ "answer", `Assoc [ "type", `String "string" ] ]
+      ]
+  in
+  let config =
+    make_state
+      ~model:"agent_llm_a-opus-4-8"
+      ~enable_thinking:true
+      ~thinking_budget:50_000
+      ~response_format:(Types.JsonSchema schema)
+      ()
+  in
+  let assoc = Api.build_body_assoc ~config ~messages:[] ~stream:false () in
+  let json = `Assoc assoc in
+  let open Yojson.Safe.Util in
+  let thinking = json |> member "thinking" in
+  let output_config = json |> member "output_config" in
+  check string "thinking type" "adaptive" (thinking |> member "type" |> to_string);
+  check bool "budget_tokens omitted" true (thinking |> member "budget_tokens" = `Null);
+  check string "effort" "max" (output_config |> member "effort" |> to_string);
+  check
+    string
+    "format type"
+    "json_schema"
+    (output_config |> member "format" |> member "type" |> to_string)
 ;;
 
 let test_build_body_enable_thinking_false_drops_thinking () =
@@ -1667,6 +1746,14 @@ let () =
             "enable_thinking default budget"
             `Quick
             test_build_body_with_enable_thinking_default_budget
+        ; test_case
+            "adaptive thinking"
+            `Quick
+            test_build_body_adaptive_thinking
+        ; test_case
+            "adaptive output_config merges format and effort"
+            `Quick
+            test_build_body_adaptive_output_config_merges_format_and_effort
         ; test_case
             "enable_thinking false drops thinking"
             `Quick

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -4,7 +4,9 @@ open Llm_provider
 (* ── Helpers ────────────────────────────────────────── *)
 
 let provider_f_config
+      ?(model_id = "gemini-2.5-flash")
       ?(thinking = false)
+      ?enable_thinking
       ?(budget = 10000)
       ?(tools = [])
       ?(json_mode = false)
@@ -13,16 +15,21 @@ let provider_f_config
       ()
   =
   ignore tools;
+  let enable_thinking =
+    match enable_thinking with
+    | Some _ as explicit -> explicit
+    | None -> if thinking then Some true else None
+  in
   Provider_config.make
     ~kind:Gemini
-    ~model_id:"gemini-2.5-flash"
+    ~model_id
     ~base_url:"https://generativelanguage.googleapis.com/v1beta"
     ~api_key:"test-key"
     ~request_path:""
     ~max_tokens:4096
     ~temperature:0.7
-    ?enable_thinking:(if thinking then Some true else None)
-    ?thinking_budget:(if thinking then Some budget else None)
+    ?enable_thinking
+    ?thinking_budget:(if thinking || Option.is_some enable_thinking then Some budget else None)
     ~response_format_json:json_mode
     ?output_schema
     ?system_prompt:(if system = "" then None else Some system)
@@ -99,6 +106,56 @@ let test_thinking_config () =
   check bool "has thinkingConfig" true (tc <> `Null);
   check int "thinkingBudget" 8000 (tc |> member "thinkingBudget" |> to_int);
   check bool "includeThoughts" true (tc |> member "includeThoughts" |> to_bool)
+;;
+
+let test_thinking_disabled_uses_budget_zero () =
+  let config = provider_f_config ~enable_thinking:false () in
+  let messages = [ Types.user_msg "Keep it short." ] in
+  let body = Backend_gemini.build_request ~config ~messages () in
+  let json = parse_body body in
+  let tc = json |> member "generationConfig" |> member "thinkingConfig" in
+  check int "thinkingBudget=0" 0 (tc |> member "thinkingBudget" |> to_int);
+  check bool "includeThoughts absent" true (tc |> member "includeThoughts" = `Null)
+;;
+
+let test_gemini3_uses_thinking_level () =
+  let config =
+    provider_f_config
+      ~model_id:"gemini-3.5-flash"
+      ~enable_thinking:true
+      ~budget:1024
+      ()
+  in
+  let body =
+    Backend_gemini.build_request ~config ~messages:[ Types.user_msg "Think." ] ()
+  in
+  let tc = parse_body body |> member "generationConfig" |> member "thinkingConfig" in
+  check string "thinkingLevel" "low" (tc |> member "thinkingLevel" |> to_string);
+  check bool "thinkingBudget absent" true (tc |> member "thinkingBudget" = `Null);
+  check bool "includeThoughts true" true (tc |> member "includeThoughts" |> to_bool)
+;;
+
+let test_gemini3_disable_uses_minimal_level () =
+  let config =
+    provider_f_config ~model_id:"gemini-3-flash" ~enable_thinking:false ()
+  in
+  let body =
+    Backend_gemini.build_request ~config ~messages:[ Types.user_msg "Hi." ] ()
+  in
+  let tc = parse_body body |> member "generationConfig" |> member "thinkingConfig" in
+  check string "thinkingLevel" "minimal" (tc |> member "thinkingLevel" |> to_string);
+  check bool "includeThoughts absent" true (tc |> member "includeThoughts" = `Null)
+;;
+
+let test_gemini31_pro_disable_uses_low_level () =
+  let config =
+    provider_f_config ~model_id:"gemini-3.1-pro" ~enable_thinking:false ()
+  in
+  let body =
+    Backend_gemini.build_request ~config ~messages:[ Types.user_msg "Hi." ] ()
+  in
+  let tc = parse_body body |> member "generationConfig" |> member "thinkingConfig" in
+  check string "thinkingLevel" "low" (tc |> member "thinkingLevel" |> to_string)
 ;;
 
 let test_tools () =
@@ -1010,6 +1067,19 @@ let () =
         ; test_case "system instruction from config" `Quick test_system_instruction
         ; test_case "system from messages" `Quick test_system_from_messages
         ; test_case "thinking config" `Quick test_thinking_config
+        ; test_case
+            "thinking disabled uses budget zero"
+            `Quick
+            test_thinking_disabled_uses_budget_zero
+        ; test_case "gemini 3 uses thinkingLevel" `Quick test_gemini3_uses_thinking_level
+        ; test_case
+            "gemini 3 disable uses minimal"
+            `Quick
+            test_gemini3_disable_uses_minimal_level
+        ; test_case
+            "gemini 3.1 pro disable uses low"
+            `Quick
+            test_gemini31_pro_disable_uses_low_level
         ; test_case "tools" `Quick test_tools
         ; test_case
             "disable_parallel dropped"

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -1186,6 +1186,26 @@ let test_responses_build_request_round_trips_tool_result_items () =
   check_bool "tool strict" true (Yojson.Safe.Util.to_bool (member "strict" tool_json))
 ;;
 
+let test_responses_build_request_disabled_reasoning_omits_reasoning_config () =
+  let config =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"gpt-5.5"
+      ~base_url:"https://api.openai.com"
+      ~request_path:"/v1/responses"
+      ~enable_thinking:false
+      ~thinking_budget:4096
+      ~max_tokens:128
+      ()
+  in
+  let body =
+    Responses.build_request ~config ~messages:[ msg User [ Text "short answer" ] ] ()
+    |> Yojson.Safe.from_string
+  in
+  check_bool "reasoning omitted" true (member "reasoning" body = `Null);
+  check_bool "include omitted" true (member "include" body = `Null)
+;;
+
 let test_responses_build_request_uses_text_format_json_schema () =
   let schema =
     `Assoc
@@ -1352,6 +1372,10 @@ let () =
             "build request round-trips tool result items"
             `Quick
             test_responses_build_request_round_trips_tool_result_items
+        ; Alcotest.test_case
+            "build request disabled reasoning omits config"
+            `Quick
+            test_responses_build_request_disabled_reasoning_omits_reasoning_config
         ; Alcotest.test_case
             "build request text.format json_schema"
             `Quick

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -80,9 +80,13 @@ let test_provider_a_with_thinking () =
   let thinking = json |> member "thinking" in
   Alcotest.(check string)
     "thinking type"
-    "enabled"
+    "adaptive"
     (thinking |> member "type" |> to_string);
-  Alcotest.(check int) "budget" 5000 (thinking |> member "budget_tokens" |> to_int)
+  Alcotest.(check bool) "budget_tokens omitted" true (thinking |> member "budget_tokens" = `Null);
+  Alcotest.(check string)
+    "effort"
+    "medium"
+    (json |> member "output_config" |> member "effort" |> to_string)
 ;;
 
 let test_provider_a_stream_flag () =

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -199,7 +199,21 @@ let test_openai_reasoning_dialect_uses_reasoning_effort () =
     "replay policy"
     "no_replay"
     (RD.replay_policy_to_string dialect.replay_policy);
-  check (option string) "preserve high" (Some "high") (RD.normalize_effort dialect "high")
+  check
+    (option string)
+    "preserve minimal"
+    (Some "minimal")
+    (RD.normalize_effort dialect "minimal");
+  check
+    (option string)
+    "preserve high"
+    (Some "high")
+    (RD.normalize_effort dialect "high");
+  check
+    (option string)
+    "preserve xhigh"
+    (Some "xhigh")
+    (RD.normalize_effort dialect "xhigh")
 ;;
 
 let test_openai_reasoning_request_uses_reasoning_effort () =

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -521,6 +521,24 @@ let test_anthropic_opus48_uses_adaptive_effort () =
     (json |> member "output_config" |> member "effort" |> to_string)
 ;;
 
+let test_anthropic_agent_llm_alias_uses_adaptive_effort () =
+  let config =
+    anthropic_config
+      ~enable_thinking:true
+      ~thinking_budget:4096
+      "agent_llm_a-sonnet-4-6-20250514"
+  in
+  let json = BAN.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
+  let thinking = json |> member "thinking" in
+  check string "thinking type" "adaptive" (thinking |> member "type" |> to_string);
+  check_member_absent "budget_tokens" thinking;
+  check
+    string
+    "effort"
+    "medium"
+    (json |> member "output_config" |> member "effort" |> to_string)
+;;
+
 let test_anthropic_sonnet46_defaults_to_adaptive () =
   let config = anthropic_config ~enable_thinking:true "claude-sonnet-4-6" in
   let json = BAN.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
@@ -667,6 +685,10 @@ let () =
             "anthropic opus 4.8 uses adaptive effort"
             `Quick
             test_anthropic_opus48_uses_adaptive_effort
+        ; test_case
+            "anthropic agent_llm_a alias uses adaptive effort"
+            `Quick
+            test_anthropic_agent_llm_alias_uses_adaptive_effort
         ; test_case
             "anthropic sonnet 4.6 defaults to adaptive"
             `Quick

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -8,6 +8,8 @@
 module PC = Llm_provider.Provider_config
 module BOR = Llm_provider.Backend_openai_request
 module BOL = Llm_provider.Backend_ollama
+module BAN = Llm_provider.Backend_anthropic
+module CM = Llm_provider.Capability_manifest
 module RD = Llm_provider.Reasoning_dialect
 open Alcotest
 open Llm_provider.Types
@@ -15,6 +17,14 @@ open Yojson.Safe.Util
 
 let json_of_body body = Yojson.Safe.from_string body
 let member_is_absent name json = json |> member name = `Null
+
+let with_manifest json f =
+  match CM.of_json (Yojson.Safe.from_string json) with
+  | Error msg -> fail ("manifest parse failed: " ^ msg)
+  | Ok manifest ->
+    CM.set_global manifest;
+    Fun.protect ~finally:CM.clear_global f
+;;
 
 let check_member_absent name json =
   check bool (name ^ " absent") true (member_is_absent name json)
@@ -38,6 +48,18 @@ let ollama_config ?system_prompt ?enable_thinking model_id =
     ~base_url:"http://127.0.0.1:11434"
     ?system_prompt
     ?enable_thinking
+    ()
+;;
+
+let anthropic_config ?enable_thinking ?thinking_budget ?output_schema model_id =
+  PC.make
+    ~kind:Anthropic
+    ~model_id
+    ~base_url:"https://api.anthropic.com"
+    ~max_tokens:16_000
+    ?enable_thinking
+    ?thinking_budget
+    ?output_schema
     ()
 ;;
 
@@ -178,6 +200,32 @@ let test_openai_reasoning_dialect_uses_reasoning_effort () =
     "no_replay"
     (RD.replay_policy_to_string dialect.replay_policy);
   check (option string) "preserve high" (Some "high") (RD.normalize_effort dialect "high")
+;;
+
+let test_openai_reasoning_request_uses_reasoning_effort () =
+  with_manifest
+    {|{"schema_version":1,"models":[{"id_prefix":"openai-reasoning-test-9fx","base":"openai_chat_extended","thinking_control_format":"reasoning_effort"}]}|}
+    (fun () ->
+       let config =
+         PC.make
+           ~kind:OpenAI_compat
+           ~model_id:"openai-reasoning-test-9fx"
+           ~base_url:"https://api.openai.com/v1"
+           ~enable_thinking:true
+           ~thinking_budget:4096
+           ()
+       in
+       let json =
+         BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body
+       in
+       check
+         string
+         "reasoning_effort"
+         "medium"
+         (json |> member "reasoning_effort" |> to_string);
+       check_member_absent "thinking" json;
+       check_member_absent "enable_thinking" json;
+       check_member_absent "chat_template_kwargs" json)
 ;;
 
 let test_deepseek_openai_compat_uses_thinking_object () =
@@ -447,6 +495,65 @@ let test_anthropic_reasoning_dialect_preserves_thinking () =
     (RD.replay_policy_to_string dialect.replay_policy)
 ;;
 
+let test_anthropic_manual_model_uses_budget_tokens () =
+  let config =
+    anthropic_config ~enable_thinking:true ~thinking_budget:4096 "claude-opus-4-5"
+  in
+  let json = BAN.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
+  let thinking = json |> member "thinking" in
+  check string "thinking type" "enabled" (thinking |> member "type" |> to_string);
+  check int "budget tokens" 4096 (thinking |> member "budget_tokens" |> to_int);
+  check_member_absent "output_config" json
+;;
+
+let test_anthropic_opus48_uses_adaptive_effort () =
+  let config =
+    anthropic_config ~enable_thinking:true ~thinking_budget:4096 "claude-opus-4-8"
+  in
+  let json = BAN.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
+  let thinking = json |> member "thinking" in
+  check string "thinking type" "adaptive" (thinking |> member "type" |> to_string);
+  check_member_absent "budget_tokens" thinking;
+  check
+    string
+    "effort"
+    "medium"
+    (json |> member "output_config" |> member "effort" |> to_string)
+;;
+
+let test_anthropic_sonnet46_defaults_to_adaptive () =
+  let config = anthropic_config ~enable_thinking:true "claude-sonnet-4-6" in
+  let json = BAN.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
+  let thinking = json |> member "thinking" in
+  check string "thinking type" "adaptive" (thinking |> member "type" |> to_string);
+  check_member_absent "budget_tokens" thinking;
+  check_member_absent "output_config" json
+;;
+
+let test_anthropic_output_config_merges_format_and_effort () =
+  let schema =
+    `Assoc
+      [ "type", `String "object"
+      ; "properties", `Assoc [ "answer", `Assoc [ "type", `String "string" ] ]
+      ]
+  in
+  let config =
+    anthropic_config
+      ~enable_thinking:true
+      ~thinking_budget:50_000
+      ~output_schema:schema
+      "claude-opus-4-8"
+  in
+  let json = BAN.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
+  let output_config = json |> member "output_config" in
+  check string "effort" "max" (output_config |> member "effort" |> to_string);
+  check
+    string
+    "format type"
+    "json_schema"
+    (output_config |> member "format" |> member "type" |> to_string)
+;;
+
 let test_gemini_reasoning_dialect_uses_thinking_config () =
   let config =
     PC.make
@@ -501,6 +608,10 @@ let () =
             `Quick
             test_openai_reasoning_dialect_uses_reasoning_effort
         ; test_case
+            "openai reasoning request uses reasoning_effort"
+            `Quick
+            test_openai_reasoning_request_uses_reasoning_effort
+        ; test_case
             "deepseek uses thinking object"
             `Quick
             test_deepseek_openai_compat_uses_thinking_object
@@ -548,6 +659,22 @@ let () =
             "anthropic reasoning dialect preserves thinking"
             `Quick
             test_anthropic_reasoning_dialect_preserves_thinking
+        ; test_case
+            "anthropic manual model uses budget_tokens"
+            `Quick
+            test_anthropic_manual_model_uses_budget_tokens
+        ; test_case
+            "anthropic opus 4.8 uses adaptive effort"
+            `Quick
+            test_anthropic_opus48_uses_adaptive_effort
+        ; test_case
+            "anthropic sonnet 4.6 defaults to adaptive"
+            `Quick
+            test_anthropic_sonnet46_defaults_to_adaptive
+        ; test_case
+            "anthropic output_config merges format and effort"
+            `Quick
+            test_anthropic_output_config_merges_format_and_effort
         ; test_case
             "gemini reasoning dialect uses thinking config"
             `Quick


### PR DESCRIPTION
## Summary

- Align provider-specific reasoning controls with current documented wire formats.
- Add typed Anthropic thinking-control classification for manual budget vs adaptive thinking, including OAS `agent_llm_a-*` aliases, and emit `output_config.effort` for adaptive Claude models.
- Share the Anthropic thinking/output-config helpers with the legacy `Api_anthropic.build_body_assoc` path so Claude API behavior does not drift between SDK surfaces.
- Add Gemini 3+ `thinkingLevel` handling while keeping Gemini 2.5 on `thinkingBudget`.
- Extend the dialect regression matrix across Qwen/DashScope, OpenAI reasoning_effort, DeepSeek, Claude, Gemma/Ollama, and Gemini.
- Apply the same reasoning dialect semantics to the legacy `Api.build_openai_body` facade and Responses API builder, including DeepSeek sampling suppression/effort aliasing and reasoning replay policy.
- Preserve current OpenAI reasoning effort values (`minimal`, `low`, `medium`, `high`, `xhigh`) instead of dropping `minimal` at dialect normalization.
- Refresh the provider reasoning dialect design note with official documentation sources checked on 2026-06-14.

## Validation

- `env MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=/tmp/oas_reasoning_current_build scripts/dune-local.sh build test/test_api.exe test/test_thinking_control_dialects.exe test/test_provider_complete.exe test/test_snapshot_provider_serialization.exe test/test_backend_openai_codec.exe test/test_backend_gemini.exe`
- `env MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=/tmp/oas_reasoning_current_build scripts/dune-local.sh build test/test_thinking_control_dialects.exe test/test_provider_config.exe test/test_backend_openai_codec.exe`
- `/tmp/oas_reasoning_current_build/default/test/test_api.exe` - 74 tests
- `/tmp/oas_reasoning_current_build/default/test/test_thinking_control_dialects.exe` - 25 tests
- `/tmp/oas_reasoning_current_build/default/test/test_provider_complete.exe` - 38 tests
- `/tmp/oas_reasoning_current_build/default/test/test_snapshot_provider_serialization.exe` - 13 tests
- `/tmp/oas_reasoning_current_build/default/test/test_backend_openai_codec.exe` - 30 tests
- `/tmp/oas_reasoning_current_build/default/test/test_backend_gemini.exe` - 37 tests
- `/tmp/oas_reasoning_current_build/default/test/test_provider_config.exe` - 62 tests
- `git diff --check origin/main`
