### PR TITLE
[codex] Fix post-merge OAS CI gates

### DIFF
--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -43,8 +43,7 @@ let warn_parallel_disable_unsupported ~model_id =
 ;;
 
 let thinking_level_of_budget ~supports_minimal = function
-  | Some n when n <= 0 ->
-    if supports_minimal then "minimal" else "low"
+  | Some n when n <= 0 -> if supports_minimal then "minimal" else "low"
   | Some n when n <= 2_048 -> "low"
   | Some n when n <= 8_192 -> "medium"
   | Some _ | None -> "high"
@@ -60,9 +59,7 @@ let thinking_config_of_config (config : Provider_config.t) =
        Some (`Assoc [ "thinkingLevel", `String level ])
      | Some true ->
        let level = thinking_level_of_budget ~supports_minimal config.thinking_budget in
-       Some
-         (`Assoc
-             [ "thinkingLevel", `String level; "includeThoughts", `Bool true ])
+       Some (`Assoc [ "thinkingLevel", `String level; "includeThoughts", `Bool true ])
      | None -> None)
   | Capabilities.Gemini_thinking_budget | Capabilities.Gemini_unknown_thinking_control ->
     (match config.enable_thinking with
@@ -73,9 +70,7 @@ let thinking_config_of_config (config : Provider_config.t) =
          | Some b -> b
          | None -> Constants.Thinking.provider_f_budget ()
        in
-       Some
-         (`Assoc
-             [ "thinkingBudget", `Int budget; "includeThoughts", `Bool true ])
+       Some (`Assoc [ "thinkingBudget", `Int budget; "includeThoughts", `Bool true ])
      | None -> None)
 ;;
 

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -152,35 +152,38 @@ let anthropic_thinking_control_of_id model_id =
   let has_prefix prefixes =
     List.exists (fun prefix -> String.starts_with ~prefix id) prefixes
   in
-  if has_prefix
-       [ "claude-fable-5"
-       ; "fable-5"
-       ; "agent_llm_a-fable-5"
-       ; "claude-mythos-5"
-       ; "mythos-5"
-       ; "agent_llm_a-mythos-5"
-       ; "claude-mythos-preview"
-       ; "mythos-preview"
-       ; "agent_llm_a-mythos-preview"
-       ]
+  if
+    has_prefix
+      [ "claude-fable-5"
+      ; "fable-5"
+      ; "agent_llm_a-fable-5"
+      ; "claude-mythos-5"
+      ; "mythos-5"
+      ; "agent_llm_a-mythos-5"
+      ; "claude-mythos-preview"
+      ; "mythos-preview"
+      ; "agent_llm_a-mythos-preview"
+      ]
   then Anthropic_always_adaptive
-  else if has_prefix
-            [ "claude-opus-4-8"
-            ; "opus-4-8"
-            ; "agent_llm_a-opus-4-8"
-            ; "claude-opus-4-7"
-            ; "opus-4-7"
-            ; "agent_llm_a-opus-4-7"
-            ]
+  else if
+    has_prefix
+      [ "claude-opus-4-8"
+      ; "opus-4-8"
+      ; "agent_llm_a-opus-4-8"
+      ; "claude-opus-4-7"
+      ; "opus-4-7"
+      ; "agent_llm_a-opus-4-7"
+      ]
   then Anthropic_adaptive_only
-  else if has_prefix
-            [ "claude-opus-4-6"
-            ; "opus-4-6"
-            ; "agent_llm_a-opus-4-6"
-            ; "claude-sonnet-4-6"
-            ; "sonnet-4-6"
-            ; "agent_llm_a-sonnet-4-6"
-            ]
+  else if
+    has_prefix
+      [ "claude-opus-4-6"
+      ; "opus-4-6"
+      ; "agent_llm_a-opus-4-6"
+      ; "claude-sonnet-4-6"
+      ; "sonnet-4-6"
+      ; "agent_llm_a-sonnet-4-6"
+      ]
   then Anthropic_adaptive_preferred
   else Anthropic_manual_budget
 ;;

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -203,7 +203,8 @@ let default_reasoning_effort () =
   | Some v ->
     Diag.warn
       "provider_config"
-      "OAS_DEFAULT_REASONING_EFFORT=%S invalid (expected minimal/low/medium/high/xhigh), using medium"
+      "OAS_DEFAULT_REASONING_EFFORT=%S invalid (expected minimal/low/medium/high/xhigh), \
+       using medium"
       v;
     "medium"
   | None -> "medium"

--- a/lib/runtime_continuation.mli
+++ b/lib/runtime_continuation.mli
@@ -2,8 +2,8 @@
 
     These types describe when host-provided input may be applied to an active
     agent turn without violating provider/tool ordering. They are provider- and
-    runtime-agnostic: OAS exposes the policy; MASC or another host owns the
-    queue and UI wiring.
+    runtime-agnostic: OAS exposes the policy; the embedding host owns the queue
+    and UI wiring.
 
     @since 0.207.0 *)
 

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -173,11 +173,7 @@ let make_state
 ;;
 
 let make_manual_thinking_state ?thinking_budget ?enable_thinking () =
-  make_state
-    ~model:"agent_llm_a-opus-4-5"
-    ?thinking_budget
-    ?enable_thinking
-    ()
+  make_state ~model:"agent_llm_a-opus-4-5" ?thinking_budget ?enable_thinking ()
 ;;
 
 let make_adaptive_thinking_state ?thinking_budget ?enable_thinking ?response_format () =
@@ -1746,10 +1742,7 @@ let () =
             "enable_thinking default budget"
             `Quick
             test_build_body_with_enable_thinking_default_budget
-        ; test_case
-            "adaptive thinking"
-            `Quick
-            test_build_body_adaptive_thinking
+        ; test_case "adaptive thinking" `Quick test_build_body_adaptive_thinking
         ; test_case
             "adaptive output_config merges format and effort"
             `Quick

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -29,7 +29,8 @@ let provider_f_config
     ~max_tokens:4096
     ~temperature:0.7
     ?enable_thinking
-    ?thinking_budget:(if thinking || Option.is_some enable_thinking then Some budget else None)
+    ?thinking_budget:
+      (if thinking || Option.is_some enable_thinking then Some budget else None)
     ~response_format_json:json_mode
     ?output_schema
     ?system_prompt:(if system = "" then None else Some system)
@@ -120,11 +121,7 @@ let test_thinking_disabled_uses_budget_zero () =
 
 let test_gemini3_uses_thinking_level () =
   let config =
-    provider_f_config
-      ~model_id:"gemini-3.5-flash"
-      ~enable_thinking:true
-      ~budget:1024
-      ()
+    provider_f_config ~model_id:"gemini-3.5-flash" ~enable_thinking:true ~budget:1024 ()
   in
   let body =
     Backend_gemini.build_request ~config ~messages:[ Types.user_msg "Think." ] ()
@@ -136,24 +133,16 @@ let test_gemini3_uses_thinking_level () =
 ;;
 
 let test_gemini3_disable_uses_minimal_level () =
-  let config =
-    provider_f_config ~model_id:"gemini-3-flash" ~enable_thinking:false ()
-  in
-  let body =
-    Backend_gemini.build_request ~config ~messages:[ Types.user_msg "Hi." ] ()
-  in
+  let config = provider_f_config ~model_id:"gemini-3-flash" ~enable_thinking:false () in
+  let body = Backend_gemini.build_request ~config ~messages:[ Types.user_msg "Hi." ] () in
   let tc = parse_body body |> member "generationConfig" |> member "thinkingConfig" in
   check string "thinkingLevel" "minimal" (tc |> member "thinkingLevel" |> to_string);
   check bool "includeThoughts absent" true (tc |> member "includeThoughts" = `Null)
 ;;
 
 let test_gemini31_pro_disable_uses_low_level () =
-  let config =
-    provider_f_config ~model_id:"gemini-3.1-pro" ~enable_thinking:false ()
-  in
-  let body =
-    Backend_gemini.build_request ~config ~messages:[ Types.user_msg "Hi." ] ()
-  in
+  let config = provider_f_config ~model_id:"gemini-3.1-pro" ~enable_thinking:false () in
+  let body = Backend_gemini.build_request ~config ~messages:[ Types.user_msg "Hi." ] () in
   let tc = parse_body body |> member "generationConfig" |> member "thinkingConfig" in
   check string "thinkingLevel" "low" (tc |> member "thinkingLevel" |> to_string)
 ;;

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -82,7 +82,10 @@ let test_provider_a_with_thinking () =
     "thinking type"
     "adaptive"
     (thinking |> member "type" |> to_string);
-  Alcotest.(check bool) "budget_tokens omitted" true (thinking |> member "budget_tokens" = `Null);
+  Alcotest.(check bool)
+    "budget_tokens omitted"
+    true
+    (thinking |> member "budget_tokens" = `Null);
   Alcotest.(check string)
     "effort"
     "medium"

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -204,11 +204,7 @@ let test_openai_reasoning_dialect_uses_reasoning_effort () =
     "preserve minimal"
     (Some "minimal")
     (RD.normalize_effort dialect "minimal");
-  check
-    (option string)
-    "preserve high"
-    (Some "high")
-    (RD.normalize_effort dialect "high");
+  check (option string) "preserve high" (Some "high") (RD.normalize_effort dialect "high");
   check
     (option string)
     "preserve xhigh"


### PR DESCRIPTION
## Summary

- Apply `ocamlformat` output for the provider reasoning changes merged in #2082.
- Remove coordinator-specific wording from `lib/runtime_continuation.mli` so the SDK independence gate remains runtime-agnostic.

## Why

#2082 merged, then full ready-state CI exposed two gate failures that were not present while the PR was draft-only:

- `OCaml Format`
- `SDK Independence Gate`

This follow-up branch is based on current `origin/main` after release #2083 and contains only the gate repair diff.

## Validation

- `env MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=/tmp/oas_reasoning_current_build scripts/dune-local.sh build @fmt`
- `bash scripts/check-sdk-independence.sh`
- `env MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=/tmp/oas_reasoning_current_build scripts/dune-local.sh build test/test_api.exe test/test_thinking_control_dialects.exe test/test_provider_complete.exe test/test_snapshot_provider_serialization.exe test/test_backend_openai_codec.exe test/test_backend_gemini.exe test/test_provider_config.exe`
- `/tmp/oas_reasoning_current_build/default/test/test_api.exe` - 74 tests
- `/tmp/oas_reasoning_current_build/default/test/test_thinking_control_dialects.exe` - 25 tests
- `/tmp/oas_reasoning_current_build/default/test/test_provider_complete.exe` - 38 tests
- `/tmp/oas_reasoning_current_build/default/test/test_snapshot_provider_serialization.exe` - 13 tests
- `/tmp/oas_reasoning_current_build/default/test/test_backend_openai_codec.exe` - 30 tests
- `/tmp/oas_reasoning_current_build/default/test/test_backend_gemini.exe` - 37 tests
- `/tmp/oas_reasoning_current_build/default/test/test_provider_config.exe` - 62 tests
- `git diff --check origin/main`
