### PR TITLE
fix(anthropic): gate adaptive effort on thinking being enabled (#2082 Codex P2)

### DIFF
--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -68,16 +68,23 @@ let effort_of_budget = function
 ;;
 
 let effort_for_config mode (config : Provider_config.t) =
-  match mode, config.thinking_budget with
-  | ( ( Capabilities.Anthropic_adaptive_only
-      | Capabilities.Anthropic_adaptive_preferred
-      | Capabilities.Anthropic_always_adaptive )
-    , Some budget ) -> Some (effort_of_budget budget)
-  | Capabilities.Anthropic_manual_budget, _
-  | ( ( Capabilities.Anthropic_adaptive_only
-      | Capabilities.Anthropic_adaptive_preferred
-      | Capabilities.Anthropic_always_adaptive )
-    , None ) -> None
+  (* Gate adaptive effort on thinking being enabled, mirroring
+     [thinking_config_for_config]. Otherwise a turn hook that disables thinking
+     ([enable_thinking = Some false]) while a [thinking_budget] is still set would
+     emit [output_config: {effort}] with no accompanying [thinking] block. *)
+  match config.enable_thinking with
+  | Some false | None -> None
+  | Some true ->
+    (match mode, config.thinking_budget with
+     | ( ( Capabilities.Anthropic_adaptive_only
+         | Capabilities.Anthropic_adaptive_preferred
+         | Capabilities.Anthropic_always_adaptive )
+       , Some budget ) -> Some (effort_of_budget budget)
+     | Capabilities.Anthropic_manual_budget, _
+     | ( ( Capabilities.Anthropic_adaptive_only
+         | Capabilities.Anthropic_adaptive_preferred
+         | Capabilities.Anthropic_always_adaptive )
+       , None ) -> None)
 ;;
 
 let thinking_config_for_config mode (config : Provider_config.t) =

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -92,6 +92,31 @@ let test_provider_a_with_thinking () =
     (json |> member "output_config" |> member "effort" |> to_string)
 ;;
 
+let test_provider_a_disabled_thinking_omits_adaptive_effort () =
+  (* A turn hook may disable thinking while a thinking_budget is still set. The
+     adaptive effort must be gated on thinking being enabled, otherwise
+     output_config.effort leaks without an accompanying thinking block. *)
+  let config =
+    PC.make
+      ~kind:Anthropic
+      ~model_id:"agent_llm_a-sonnet-4-6"
+      ~base_url:""
+      ~enable_thinking:false
+      ~thinking_budget:5000
+      ()
+  in
+  let body = BA.build_request ~config ~messages:[ user_msg "hi" ] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  Alcotest.(check bool) "thinking omitted" true (json |> member "thinking" = `Null);
+  (* With thinking disabled and no output schema, output_config carries no
+     fields, so the whole object is omitted rather than leaking a bare effort. *)
+  Alcotest.(check bool)
+    "output_config omitted (no leaked effort)"
+    true
+    (json |> member "output_config" = `Null)
+;;
+
 let test_provider_a_stream_flag () =
   let config = PC.make ~kind:Anthropic ~model_id:"m" ~base_url:"" () in
   let body = BA.build_request ~stream:true ~config ~messages:[ user_msg "hi" ] () in
@@ -1060,6 +1085,10 @@ let () =
       , [ test_case "basic body" `Quick test_provider_a_basic_body
         ; test_case "with system" `Quick test_provider_a_with_system
         ; test_case "with thinking" `Quick test_provider_a_with_thinking
+        ; test_case
+            "disabled thinking omits adaptive effort"
+            `Quick
+            test_provider_a_disabled_thinking_omits_adaptive_effort
         ; test_case "with output schema" `Quick test_provider_a_output_schema
         ; test_case
             "with json schema response_format"


### PR DESCRIPTION
## 요약

머지된 #2082의 미해결 Codex P2를 닫습니다. `effort_for_config`가 `enable_thinking`을 검사하지 않아, turn hook이 thinking을 끈(`enable_thinking = Some false`) 상태에서 `thinking_budget`이 남아있으면 adaptive Anthropic 모델이 `output_config: {effort}`를 thinking block 없이 emit했습니다(공유 헬퍼 `output_config_for_config`를 쓰는 양쪽 Anthropic builder 모두).

## 수정
`effort_for_config`를 `enable_thinking = Some true`로 gate (이미 그렇게 동작하는 `thinking_config_for_config`와 동일) → effort와 thinking block이 함께 나오거나 함께 생략.

## 테스트
`test_provider_complete.ml`: disabled thinking + budget(agent_llm_a-sonnet-4-6) → output_config 전체 생략(effort 누출 없음). 로컬 `@check`=0, `@fmt`=0, `test_provider_complete` 39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)