### PR TITLE
[codex] Accept multimodal user input blocks

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -120,6 +120,71 @@ let base_messages agent =
   | msgs -> msgs
 ;;
 
+let sanitize_user_input_blocks =
+  List.map (function
+    | Text s -> Text (Llm_provider.Utf8_sanitize.sanitize s)
+    | block -> block)
+;;
+
+let trace_prompt_of_blocks blocks =
+  let parts =
+    blocks
+    |> List.filter_map (function
+      | Text s -> Some (Llm_provider.Utf8_sanitize.sanitize s)
+      | Image { media_type; data; _ } ->
+        Some (Printf.sprintf "[image:%s data_chars=%d]" media_type (String.length data))
+      | Document { media_type; data; _ } ->
+        Some
+          (Printf.sprintf "[document:%s data_chars=%d]" media_type (String.length data))
+      | Audio { media_type; data; _ } ->
+        Some (Printf.sprintf "[audio:%s data_chars=%d]" media_type (String.length data))
+      | Thinking _ | RedactedThinking _ | ToolUse _ | ToolResult _ -> None)
+  in
+  match String.concat "\n" parts with
+  | "" -> "[multimodal input]"
+  | text -> text
+;;
+
+let validate_user_input_blocks blocks =
+  let unsupported =
+    List.find_map
+      (function
+        | Text _ | Image _ | Document _ | Audio _ -> None
+        | Thinking _ -> Some "Thinking"
+        | RedactedThinking _ -> Some "RedactedThinking"
+        | ToolUse _ -> Some "ToolUse"
+        | ToolResult _ -> Some "ToolResult")
+      blocks
+  in
+  match unsupported with
+  | None -> Ok ()
+  | Some kind ->
+    Error
+      (Error.Config
+         (Error.InvalidConfig
+            { field = "user_blocks"
+            ; detail =
+                Printf.sprintf
+                  "user input blocks may contain only Text, Image, Document, or Audio; \
+                   got %s"
+                  kind
+            }))
+;;
+
+let append_user_input agent user_blocks =
+  let user_msg =
+    { role = User
+    ; content = sanitize_user_input_blocks user_blocks
+    ; name = None
+    ; tool_call_id = None
+    ; metadata = []
+    }
+  in
+  update_state agent (fun s ->
+    { s with messages = Util.snoc (base_messages agent) user_msg });
+  user_msg.content
+;;
+
 (** Per-turn timing observability helper. Emits one structured record
     per turn so operators diagnosing wall-clock budget timeouts can see
     whether the budget was spent on many moderate turns or a single
@@ -158,24 +223,15 @@ let log_turn ~run_start ~turn_start ~turn_index ~max_turns ~model ~stop =
     ]
 ;;
 
-let run_loop ~sw ?clock ~api_strategy ?on_yield ?on_resume ?on_activity agent user_prompt =
+let run_loop ~sw ?clock ~api_strategy ?on_yield ?on_resume ?on_activity agent user_blocks =
   let bump_activity () =
     match on_activity with
     | Some f -> f ()
     | None -> ()
   in
-  let user_prompt = Llm_provider.Utf8_sanitize.sanitize user_prompt in
-  let user_msg =
-    { role = User
-    ; content = [ Text user_prompt ]
-    ; name = None
-    ; tool_call_id = None
-    ; metadata = []
-    }
-  in
-  update_state agent (fun s ->
-    { s with messages = Util.snoc (base_messages agent) user_msg });
-  with_raw_trace_run agent user_prompt
+  let user_blocks = append_user_input agent user_blocks in
+  let trace_prompt = trace_prompt_of_blocks user_blocks in
+  with_raw_trace_run agent trace_prompt
   @@ fun raw_trace_run ->
   let yield_enabled = agent.state.config.yield_on_tool in
   let do_yield () =
@@ -464,51 +520,65 @@ let with_periodic_callbacks ~sw:_ ?clock ~last_activity agent f =
        raise exn)
 ;;
 
+let run_blocks ~sw ?clock ?on_yield ?on_resume agent user_blocks =
+  match validate_user_input_blocks user_blocks with
+  | Error _ as err -> err
+  | Ok () ->
+    let last_activity = ref (now_or_zero clock) in
+    let on_activity () = last_activity := now_or_zero clock in
+    with_periodic_callbacks ~sw ?clock ~last_activity agent (fun () ->
+      run_loop
+        ~sw
+        ?clock
+        ~api_strategy:Sync
+        ?on_yield
+        ?on_resume
+        ~on_activity
+        agent
+        user_blocks)
+;;
+
 let run ~sw ?clock ?on_yield ?on_resume agent user_prompt =
-  let last_activity = ref (now_or_zero clock) in
-  let on_activity () = last_activity := now_or_zero clock in
-  with_periodic_callbacks ~sw ?clock ~last_activity agent (fun () ->
-    run_loop
-      ~sw
-      ?clock
-      ~api_strategy:Sync
-      ?on_yield
-      ?on_resume
-      ~on_activity
-      agent
-      user_prompt)
+  run_blocks ~sw ?clock ?on_yield ?on_resume agent [ Text user_prompt ]
+;;
+
+let run_stream_blocks ~sw ?clock ~on_event ?on_yield ?on_resume agent user_blocks =
+  match validate_user_input_blocks user_blocks with
+  | Error _ as err -> err
+  | Ok () ->
+    let on_telemetry =
+      Option.map
+        (fun bus -> Telemetry_bus.publish (Telemetry_bus.of_event_bus bus))
+        agent.options.event_bus
+    in
+    let last_activity = ref (now_or_zero clock) in
+    let on_activity () = last_activity := now_or_zero clock in
+    (* Every streamed event — including reasoning/thinking deltas, which
+       reach [on_event] as [ContentBlockDelta { delta = ThinkingDelta _ }]
+       (see Llm_provider.Streaming.openai_chunk_to_events) — counts as
+       progress, so a long reasoning burst keeps the idle watchdog from
+       firing. [caller_on_event] is the original callback (bound under a
+       distinct name so the wrapper is not misread as self-recursion); it
+       runs after the activity bump. *)
+    let caller_on_event = on_event in
+    let on_event ev =
+      on_activity ();
+      protect_stream_callback caller_on_event ev
+    in
+    with_periodic_callbacks ~sw ?clock ~last_activity agent (fun () ->
+      run_loop
+        ~sw
+        ?clock
+        ~api_strategy:(Stream { on_event; on_telemetry })
+        ?on_yield
+        ?on_resume
+        ~on_activity
+        agent
+        user_blocks)
 ;;
 
 let run_stream ~sw ?clock ~on_event ?on_yield ?on_resume agent user_prompt =
-  let on_telemetry =
-    Option.map
-      (fun bus -> Telemetry_bus.publish (Telemetry_bus.of_event_bus bus))
-      agent.options.event_bus
-  in
-  let last_activity = ref (now_or_zero clock) in
-  let on_activity () = last_activity := now_or_zero clock in
-  (* Every streamed event — including reasoning/thinking deltas, which
-     reach [on_event] as [ContentBlockDelta { delta = ThinkingDelta _ }]
-     (see Llm_provider.Streaming.openai_chunk_to_events) — counts as
-     progress, so a long reasoning burst keeps the idle watchdog from
-     firing. [caller_on_event] is the original callback (bound under a
-     distinct name so the wrapper is not misread as self-recursion); it
-     runs after the activity bump. *)
-  let caller_on_event = on_event in
-  let on_event ev =
-    on_activity ();
-    protect_stream_callback caller_on_event ev
-  in
-  with_periodic_callbacks ~sw ?clock ~last_activity agent (fun () ->
-    run_loop
-      ~sw
-      ?clock
-      ~api_strategy:(Stream { on_event; on_telemetry })
-      ?on_yield
-      ?on_resume
-      ~on_activity
-      agent
-      user_prompt)
+  run_stream_blocks ~sw ?clock ~on_event ?on_yield ?on_resume agent [ Text user_prompt ]
 ;;
 
 (* ── Handoff support ─────────────────────────────────────────── *)
@@ -516,21 +586,13 @@ let run_stream ~sw ?clock ~on_event ?on_yield ?on_resume agent user_prompt =
 let find_handoff_in_messages = Agent_handoff.find_handoff_in_messages
 let replace_tool_result = Agent_handoff.replace_tool_result
 
-let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
+let run_with_handoffs_blocks ~sw ?clock agent ~targets user_blocks =
   let handoff_tools = List.map Handoff.make_handoff_tool targets in
   let all_tools = Tool_set.merge agent.tools (Tool_set.of_list handoff_tools) in
   let agent_with_handoffs = { agent with tools = all_tools } in
-  let user_msg =
-    { role = User
-    ; content = [ Text user_prompt ]
-    ; name = None
-    ; tool_call_id = None
-    ; metadata = []
-    }
-  in
-  update_state agent_with_handoffs (fun s ->
-    { s with messages = Util.snoc (base_messages agent_with_handoffs) user_msg });
-  with_raw_trace_run agent_with_handoffs user_prompt
+  let user_blocks = append_user_input agent_with_handoffs user_blocks in
+  let trace_prompt = trace_prompt_of_blocks user_blocks in
+  with_raw_trace_run agent_with_handoffs trace_prompt
   @@ fun raw_trace_run ->
   let rec loop () =
     match check_loop_guard agent_with_handoffs with
@@ -664,6 +726,10 @@ let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
           | None -> loop ()))
   in
   loop ()
+;;
+
+let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
+  run_with_handoffs_blocks ~sw ?clock agent ~targets [ Text user_prompt ]
 ;;
 
 (* ── Checkpoint / Resume ─────────────────────────────────────── *)

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -156,6 +156,19 @@ val run
   -> string
   -> (Types.api_response, Error.sdk_error) result
 
+(** Run agent to completion with a user-authored content block list.
+    This is the multimodal entrypoint for callers that need to pass text
+    together with images, documents, or audio. Text blocks are UTF-8 sanitized;
+    non-text media payloads are preserved. *)
+val run_blocks
+  :  sw:Eio.Switch.t
+  -> ?clock:_ Eio.Time.clock
+  -> ?on_yield:(unit -> unit)
+  -> ?on_resume:(unit -> unit)
+  -> t
+  -> Types.content_block list
+  -> (Types.api_response, Error.sdk_error) result
+
 (** Stream a full agent run. Non-fatal exceptions raised by [on_event] are
     logged and do not abort the run. *)
 val run_stream
@@ -166,6 +179,18 @@ val run_stream
   -> ?on_resume:(unit -> unit)
   -> t
   -> string
+  -> (Types.api_response, Error.sdk_error) result
+
+(** Stream a full agent run with a user-authored content block list.
+    See {!run_blocks}. *)
+val run_stream_blocks
+  :  sw:Eio.Switch.t
+  -> ?clock:_ Eio.Time.clock
+  -> on_event:(Types.sse_event -> unit)
+  -> ?on_yield:(unit -> unit)
+  -> ?on_resume:(unit -> unit)
+  -> t
+  -> Types.content_block list
   -> (Types.api_response, Error.sdk_error) result
 
 (** Stream one agent turn. Non-fatal exceptions raised by [on_event] are
@@ -192,6 +217,14 @@ val run_with_handoffs
   -> t
   -> targets:Handoff.handoff_target list
   -> string
+  -> (Types.api_response, Error.sdk_error) result
+
+val run_with_handoffs_blocks
+  :  sw:Eio.Switch.t
+  -> ?clock:_ Eio.Time.clock
+  -> t
+  -> targets:Handoff.handoff_target list
+  -> Types.content_block list
   -> (Types.api_response, Error.sdk_error) result
 
 (** {1 Checkpoint / Resume} *)

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -442,8 +442,29 @@ let make_message ?name ?tool_call_id ?(metadata = []) ~role content =
   { role; content; name; tool_call_id; metadata }
 ;;
 
+(** Create a text content block. *)
+let text_block text = Text text
+
+(** Create a base64-backed image content block by default. *)
+let image_block ?(source_type = "base64") ~media_type ~data () =
+  Image { media_type; data; source_type }
+;;
+
+(** Create a base64-backed document content block by default. *)
+let document_block ?(source_type = "base64") ~media_type ~data () =
+  Document { media_type; data; source_type }
+;;
+
+(** Create a base64-backed audio content block by default. *)
+let audio_block ?(source_type = "base64") ~media_type ~data () =
+  Audio { media_type; data; source_type }
+;;
+
 (** Create a text-only message. *)
 let text_message role text = make_message ~role [ Text text ]
+
+(** Create a user message from arbitrary content blocks. *)
+let user_msg_blocks blocks = make_message ~role:User blocks
 
 (** Create a system message. *)
 let system_msg text = text_message System text

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -327,7 +327,31 @@ val make_message
   -> content_block list
   -> message
 
+val text_block : string -> content_block
+
+val image_block
+  :  ?source_type:string
+  -> media_type:string
+  -> data:string
+  -> unit
+  -> content_block
+
+val document_block
+  :  ?source_type:string
+  -> media_type:string
+  -> data:string
+  -> unit
+  -> content_block
+
+val audio_block
+  :  ?source_type:string
+  -> media_type:string
+  -> data:string
+  -> unit
+  -> content_block
+
 val text_message : role -> string -> message
+val user_msg_blocks : content_block list -> message
 val system_msg : string -> message
 val user_msg : string -> message
 val assistant_msg : string -> message

--- a/test/test_multimodal.ml
+++ b/test/test_multimodal.ml
@@ -139,6 +139,63 @@ let test_mixed_content_serialization () =
     parsed
 ;;
 
+let test_multimodal_constructors () =
+  let image = Types.image_block ~media_type:"image/png" ~data:"img" () in
+  let document = Types.document_block ~media_type:"application/pdf" ~data:"pdf" () in
+  let audio = Types.audio_block ~media_type:"audio/wav" ~data:"wav" () in
+  let msg =
+    Types.user_msg_blocks [ Types.text_block "Describe"; image; document; audio ]
+  in
+  Alcotest.(check string) "role" "user" (Types.role_to_string msg.role);
+  Alcotest.(check int) "blocks" 4 (List.length msg.content);
+  match image, document, audio with
+  | ( Types.Image { source_type = "base64"; media_type = "image/png"; _ }
+    , Types.Document { source_type = "base64"; media_type = "application/pdf"; _ }
+    , Types.Audio { source_type = "base64"; media_type = "audio/wav"; _ } ) -> ()
+  | _ -> Alcotest.fail "unexpected multimodal constructor shape"
+;;
+
+let test_agent_run_blocks_appends_multimodal_input () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let config = { Types.default_config with max_turns = 0 } in
+  let agent = Agent.create ~net:env#net ~config () in
+  let blocks =
+    [ Types.text_block "Inspect this"
+    ; Types.image_block ~media_type:"image/png" ~data:"img" ()
+    ; Types.document_block ~media_type:"application/pdf" ~data:"pdf" ()
+    ; Types.audio_block ~media_type:"audio/wav" ~data:"wav" ()
+    ]
+  in
+  (match Agent.run_blocks ~sw agent blocks with
+   | Error (Error.Agent (Error.MaxTurnsExceeded { turns = 0; limit = 0 })) -> ()
+   | Ok _ -> Alcotest.fail "expected max-turn guard before provider call"
+   | Error err -> Alcotest.fail ("unexpected error: " ^ Error.to_string err));
+  match List.rev (Agent.state agent).messages with
+  | { Types.role = User; content; _ } :: _ ->
+    Alcotest.(check int) "stored blocks" 4 (List.length content);
+    (match List.nth content 1, List.nth content 2, List.nth content 3 with
+     | Types.Image _, Types.Document _, Types.Audio _ -> ()
+     | _ -> Alcotest.fail "stored user input lost multimodal blocks")
+  | _ -> Alcotest.fail "missing appended user message"
+;;
+
+let test_agent_run_blocks_rejects_internal_blocks () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let agent = Agent.create ~net:env#net () in
+  let blocks = [ Types.ToolUse { id = "call-1"; name = "x"; input = `Null } ] in
+  (match Agent.run_blocks ~sw agent blocks with
+   | Error (Error.Config (Error.InvalidConfig { field = "user_blocks"; _ })) -> ()
+   | Ok _ -> Alcotest.fail "expected invalid config"
+   | Error err -> Alcotest.fail ("unexpected error: " ^ Error.to_string err));
+  Alcotest.(check int) "state unchanged" 0 (List.length (Agent.state agent).messages)
+;;
+
 (* ------------------------------------------------------------------ *)
 (* JSON structure verification                                          *)
 (* ------------------------------------------------------------------ *)
@@ -256,6 +313,15 @@ let () =
             "text + image + document"
             `Quick
             test_mixed_content_serialization
+        ; Alcotest.test_case "constructors" `Quick test_multimodal_constructors
+        ; Alcotest.test_case
+            "agent run_blocks appends input"
+            `Quick
+            test_agent_run_blocks_appends_multimodal_input
+        ; Alcotest.test_case
+            "agent run_blocks rejects internal blocks"
+            `Quick
+            test_agent_run_blocks_rejects_internal_blocks
         ] )
     ; ( "json_structure"
       , [ Alcotest.test_case "image json structure" `Quick test_image_json_structure


### PR DESCRIPTION
## What changed

- Added public `Types` helpers for typed text/image/document/audio content blocks and user messages built from block lists.
- Added `Agent.run_blocks`, `Agent.run_stream_blocks`, and `Agent.run_with_handoffs_blocks` so callers can pass multimodal user input without bypassing the agent turn lifecycle.
- Kept existing string-based `run` and `run_stream` APIs as wrappers over the new block path.
- Added focused multimodal tests for constructors, agent state insertion, and rejection of internal tool/thinking blocks on `run_blocks`.

## Why

OAS already had provider-level multimodal `content_block` variants and serializers, but the public agent run surface only accepted a string prompt. This exposes the existing typed block model at the SDK boundary without adding a second multimodal representation.

## Validation

- `env MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=/tmp/oas_multimodal_input_rebased_build scripts/dune-local.sh build test/test_multimodal.exe`
- `env MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=/tmp/oas_multimodal_input_rebased_test_build scripts/dune-local.sh exec test/test_multimodal.exe`
- `ocamlformat --check lib/llm_provider/types.ml lib/llm_provider/types.mli lib/agent/agent.ml lib/agent/agent.mli test/test_multimodal.ml`
- `git diff --check HEAD~1..HEAD`

Note: a same-`DUNE_BUILD_DIR` parallel `dune exec` invocation was interrupted after waiting on Dune state; the same test passed when run alone with a separate build dir.