### PR TITLE
chore(response_shape): inert 코드 검증 — 잉여 stop_reason_to_string export 제거

### DIFF
--- a/lib/llm_provider/response_shape.mli
+++ b/lib/llm_provider/response_shape.mli
@@ -30,7 +30,6 @@ type content_shape =
 val summarize : Types.api_response -> t
 val content_shape : Types.api_response -> t -> content_shape
 val content_shape_to_string : content_shape -> string
-val stop_reason_to_string : Types.stop_reason -> string
 
 (** [true] when the response carries downstream-visible progress: non-blank
     text or a tool call. Hidden thinking, tool results, and media-only blocks


### PR DESCRIPTION
## 배경

3일 머지 감사에서 두 항목이 "production consumer 0" inert 코드로 지목되었다. 두 주장을 측정으로 검증한 뒤 삭제 또는 배선을 결정했다. 결론부터: 두 핵심 항목 모두 **live 코드**여서 삭제/배선 대상이 아니었고, 측정 과정에서 발견한 잉여 public export 1건만 정리한다.

## 측정 (fan-in 수치)

측정은 `origin/main` tip `36df9004`(#2088 포함) 기준. 로컬 root checkout 은 #2082 에 머물러 있어 #2088 심볼이 부재했고, 초기 측정이 stale tree 를 가리켜 오판 위험이 있었음 — worktree 를 `origin/main` 에서 생성해 재측정.

### 1. `lib/llm_provider/response_shape.ml` (#2033)

- lib/bin 내부 호출자: 0
- 단, `lib/agent_sdk.mli:43` / `lib/agent_sdk.ml:70` 에서 `module Response_shape = Llm_provider.Response_shape` 로 **공개 SDK 표면에 재노출**.
- `.mli` 문서가 "the generic OAS-side primitive that consumers can map to their own accept/retry policy" 로 명시 — 다운스트림 소비자용 진단 primitive.
- `test/test_types.ml` 의 response_shape 그룹(3 케이스)이 `summarize` / `content_shape` / `has_deliverable_content` / `ended_without_deliverable_content` / `diagnostic_summary` 를 행사.
- OAS 자체 스트리밍 idle 판정은 별도 경로 `Streaming.sse_event_is_deliverable_progress_signal`(per-event `sse_event` 입력) 사용. `Response_shape` 는 완료된 `api_response` 입력의 post-hoc 진단 — 입력 타입/granularity 가 달라 중복(split-brain)이 아님.

### 2. #2088 `_blocks` variant API (`run_blocks` / `run_stream_blocks` / `run_with_handoffs_blocks`)

감사 주장("0 internal callers, 텍스트 경로가 우회")은 **역으로 거짓**. 텍스트 경로가 이미 `_blocks` 를 통과한다:

- `run` (agent.ml:541-542) = `run_blocks ... [ Text user_prompt ]` 얇은 래퍼
- `run_stream` (agent.ml:580-581) = `run_stream_blocks ...` 얇은 래퍼
- `run_with_handoffs` (agent.ml:731-732) = `run_with_handoffs_blocks ...` 얇은 래퍼
- `validate_user_input_blocks`: `run_blocks`/`run_stream_blocks` 2곳 호출
- `sanitize_user_input_blocks` / `trace_prompt_of_blocks` / `append_user_input`: `run_loop` 및 `run_with_handoffs_blocks` 경로에서 호출
- `Agent.run`/`run_stream` 호출처는 lib/examples/test 합산 약 118곳 — 전부 `_blocks` 경유.
- `test/test_multimodal.ml` 13 케이스 통과(`run_blocks appends input`, `run_blocks rejects internal blocks` 포함).

즉 #2088 은 이미 "`run` 을 `run_blocks` 얇은 래퍼로 collapse" 패턴을 구현해 둔 상태. 배선 추가 불필요.

### 발견한 잉여 export

`Response_shape.stop_reason_to_string`: `response_shape.ml:172`(`diagnostic_summary` 내부)에서만 사용. `.mli:33` 에 export 되어 있으나 모듈 밖 호출자 0. (참고로 `lib/cache.ml:101`, `lib/agent_tool.ml:38` 은 각자 module-local 동명 함수를 따로 둠 — pre-existing 중복, 본 PR 범위 밖.)

## 결정 (삭제 vs 배선)

| 항목 | 결정 | 근거 |
|------|------|------|
| `Response_shape` 모듈 | **유지(변경 없음)** | `agent_sdk.mli` 재노출 + 문서화된 consumer primitive + 테스트로 행사. live public SDK API 삭제 금지 원칙. |
| #2088 `_blocks` API | **유지(변경 없음)** | 텍스트 경로(`run`/`run_stream`/`run_with_handoffs`, 약 118 호출처)가 이미 전부 경유. canonical path. |
| `stop_reason_to_string` `.mli` export | **삭제** | 외부 호출자 0. 함수는 내부 helper 로 `.ml` 에 잔존(diagnostic_summary 가 사용). `.mli` 계약만 좁힘. |

순삭제 1줄(`.mli`). 모듈/함수 본체는 보존.

## 검증

- `dune build --root .` → exit 0
- `dune build --root . @runtest -j 2` → exit 0 (Multivendor_live golden 4건 포함 전체 통과)
- `test/test_types.exe -- test response_shape` → 3 tests OK
- `test/test_multimodal.exe` → 13 tests OK
- `git diff` = `response_shape.mli` 1줄 삭제만

## 미검증 / 불확실

- `stop_reason_to_string` 3중 정의(`response_shape.ml`/`cache.ml`/`agent_tool.ml`)는 중복이나 각자 module-local 이라 동작 영향 없음. 통합은 별도 작업(본 PR 미포함).
- bisect 커버리지 ratchet floor 충족 여부는 CI 에서 확인 필요(로컬 미측정). public export 1줄 삭제라 커버리지 하락 요인은 없음.
- `Response_shape` 의 외부 SDK 소비자(다른 repo)는 코드 검색 범위 밖이라 직접 확인 불가 — `agent_sdk.mli` 재노출은 그대로 유지하므로 영향 없음.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
