### PR TITLE
fix(llm_provider): preserve timeout phase across retry path

### DIFF
--- a/lib/api.ml
+++ b/lib/api.ml
@@ -9,10 +9,12 @@ let retry_error_of_http_error = function
   | Llm_provider.Http_client.HttpError { code; body } ->
     Retry.classify_error ~status:code ~body
   | Llm_provider.Http_client.NetworkError
-      { message; kind = Llm_provider.Http_client.Timeout } -> Retry.Timeout { message }
+      { message; kind = Llm_provider.Http_client.Timeout } ->
+    Retry.Timeout { message; phase = None }
   | Llm_provider.Http_client.NetworkError { message; kind } ->
     Retry.NetworkError { message; kind }
-  | Llm_provider.Http_client.TimeoutError { message; _ } -> Retry.Timeout { message }
+  | Llm_provider.Http_client.TimeoutError { message; phase } ->
+    Retry.Timeout { message; phase = Some phase }
   | Llm_provider.Http_client.AcceptRejected { reason } ->
     Retry.InvalidRequest { message = "Response rejected: " ^ reason }
   | Llm_provider.Http_client.ProviderTerminal { message; _ } ->
@@ -232,6 +234,7 @@ let create_message
                  Printf.sprintf
                    "HTTP request exceeded %.1fs wall-clock timeout"
                    request_timeout_s
+             ; phase = None
              })
       | Eio.Io _ as exn ->
         Error (Retry.NetworkError { message = Printexc.to_string exn; kind = Unknown })
@@ -279,7 +282,8 @@ let%test "default_request_timeout_s is bounded to a reasonable ceiling" =
 
 let%test "Retry.Timeout classifies as retryable" =
   Retry.is_retryable
-    (Retry.Timeout { message = "HTTP request exceeded 60.0s wall-clock timeout" })
+    (Retry.Timeout
+       { message = "HTTP request exceeded 60.0s wall-clock timeout"; phase = None })
 ;;
 
 let%test "re-exported max_response_body is positive" = max_response_body > 0

--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -159,7 +159,7 @@ let provider_to_sdk : provider_error -> Error.sdk_error = function
   | `Auth_error msg -> Error.Api (Retry.AuthError { message = msg })
   | `Server_error (status, msg) -> Error.Api (Retry.ServerError { status; message = msg })
   | `Network_error msg -> Error.Api (Retry.NetworkError { message = msg; kind = Unknown })
-  | `Provider_timeout msg -> Error.Api (Retry.Timeout { message = msg })
+  | `Provider_timeout msg -> Error.Api (Retry.Timeout { message = msg; phase = None })
   | `Streaming_timeout (phase, msg) ->
     Error.Provider
       (Llm_provider.Error.Timeout

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -256,8 +256,7 @@ let complete_stream_http
        signature instead of buried in a silent disarm. *)
     match stream_idle_timeout_s, clock with
     | (Some _ as v), _ -> v
-    | None, Some _ ->
-      Some (Provider_config.default_stream_idle_timeout_s config.kind)
+    | None, Some _ -> Some (Provider_config.default_stream_idle_timeout_s config.kind)
     | None, None -> None
   in
   match validate_all config with

--- a/lib/llm_provider/error.ml
+++ b/lib/llm_provider/error.ml
@@ -200,7 +200,11 @@ let of_retry_api_error ?provider err =
     InvalidRequest { provider; reason = Retry.error_message (Retry.ContextOverflow r) }
   | Retry.NetworkError r ->
     NetworkError { provider; kind = r.kind; timeout_phase = None; detail = r.message }
-  | Retry.Timeout r -> Timeout { provider; timeout_phase = None; detail = r.message }
+  (* Preserve the transport phase carried by Retry.Timeout so a retried
+     prefill timeout surfaces as [First_token] (not the default [None]
+     that would collapse every retry-classified timeout into an
+     unclassifiable provider timeout).  See http_client.timeout_phase. *)
+  | Retry.Timeout r -> Timeout { provider; timeout_phase = r.phase; detail = r.message }
 ;;
 
 let capacity_scope_of_http = function

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -406,15 +406,17 @@ let classify_network_exn (e : exn) =
   | Eio.Io _ as exn ->
     let msg = Printexc.to_string exn in
     Some (NetworkError { message = msg; kind = classify_by_message msg })
-  | Sys_error msg ->
-    Some (NetworkError { message = msg; kind = classify_by_message msg })
+  | Sys_error msg -> Some (NetworkError { message = msg; kind = classify_by_message msg })
   | Failure msg -> Some (NetworkError { message = msg; kind = classify_by_message msg })
   | _ -> None
 ;;
 
 let catch_network f =
-  try f () with exn ->
-  (match classify_network_exn exn with Some e -> Error e | None -> raise exn)
+  try f () with
+  | exn ->
+    (match classify_network_exn exn with
+     | Some e -> Error e
+     | None -> raise exn)
 ;;
 
 (** Detect errors caused by local resource exhaustion (port/FD limits).
@@ -767,8 +769,7 @@ let with_post_stream
         let body_str =
           try
             Eio.Buf_read.(
-              of_flow ~max_size:Api_common.max_response_body resp_body
-              |> take_all)
+              of_flow ~max_size:Api_common.max_response_body resp_body |> take_all)
           with
           | exn ->
             drain_response_body resp_body;
@@ -783,15 +784,15 @@ let with_post_stream
      typed [Error] (see [Complete_stream.body_logic] and the Streaming
      callers). A body-phase timeout that [f] lets propagate escapes this
      function as the raw exception. *)
-  (match post_result with
-   | Error e -> Error e
-   | Ok reader ->
-     (* Body consumption. [Eio.Time.Timeout] propagates so the caller
+  match post_result with
+  | Error e -> Error e
+  | Ok reader ->
+    (* Body consumption. [Eio.Time.Timeout] propagates so the caller
         phases it (prefill → [First_token], inter-chunk → [Stream_idle]).
         Other network exceptions classify like {!catch_network} so a
         body-phase I/O failure still surfaces as a typed [NetworkError]
         instead of escaping as a raw exception. *)
-     try Ok (f reader) with
+    (try Ok (f reader) with
      | Eio.Time.Timeout ->
        (* Body-phase timeout. Stream-state-aware callers ([Complete_stream])
           catch this inside [f] and emit the precise [First_token] /
@@ -804,7 +805,10 @@ let with_post_stream
             { message = "stream body timed out (awaiting first token / inter-chunk idle)"
             ; phase = Unknown_timeout
             })
-     | exn -> (match classify_network_exn exn with Some e -> Error e | None -> raise exn))
+     | exn ->
+       (match classify_network_exn exn with
+        | Some e -> Error e
+        | None -> raise exn))
 ;;
 
 (* One W3C EventSource line, parsed per spec (§9.2.6 event stream

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -30,7 +30,6 @@ type provider_kind = Provider_kind.t =
 val request_path_default_for_kind : provider_kind -> string
 
 val default_connect_timeout_s : provider_kind -> float
-
 val default_stream_idle_timeout_s : provider_kind -> float
 
 (** Derive [output_schema] from a [response_format].

--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -21,7 +21,10 @@ type api_error =
       { message : string
       ; kind : Http_client.network_error_kind
       }
-  | Timeout of { message : string }
+  | Timeout of
+      { message : string
+      ; phase : Http_client.timeout_phase option
+      }
 
 type retry_config =
   { max_retries : int
@@ -788,7 +791,7 @@ let%test "is_hard_quota non-RateLimited variants are false" =
   && (not (is_hard_quota (ServerError { status = 500; message = "quota exceeded" })))
   && (not (is_hard_quota (AuthError { message = "invalid key" })))
   && (not (is_hard_quota (NetworkError { message = "connection reset"; kind = Unknown })))
-  && (not (is_hard_quota (Timeout { message = "deadline exceeded" })))
+  && (not (is_hard_quota (Timeout { message = "deadline exceeded"; phase = None })))
   && (not (is_hard_quota (InvalidRequest { message = "bad input" })))
   && not (is_hard_quota (ContextOverflow { message = "too long"; limit = None }))
 ;;

--- a/lib/llm_provider/retry.mli
+++ b/lib/llm_provider/retry.mli
@@ -26,7 +26,10 @@ type api_error =
       { message : string
       ; kind : Http_client.network_error_kind
       }
-  | Timeout of { message : string; phase : Http_client.timeout_phase option }
+  | Timeout of
+      { message : string
+      ; phase : Http_client.timeout_phase option
+      }
 
 type retry_config =
   { max_retries : int

--- a/lib/llm_provider/retry.mli
+++ b/lib/llm_provider/retry.mli
@@ -26,7 +26,7 @@ type api_error =
       { message : string
       ; kind : Http_client.network_error_kind
       }
-  | Timeout of { message : string }
+  | Timeout of { message : string; phase : Http_client.timeout_phase option }
 
 type retry_config =
   { max_retries : int

--- a/lib/llm_provider/retry_classify.ml
+++ b/lib/llm_provider/retry_classify.ml
@@ -27,7 +27,8 @@ let classify_retry_error = function
   | Http_client.HttpError { code; body } -> Some (Retry.classify_error ~status:code ~body)
   | Http_client.NetworkError { message; kind; _ } ->
     Some (Retry.NetworkError { message; kind })
-  | Http_client.TimeoutError { message; _ } -> Some (Retry.Timeout { message })
+  | Http_client.TimeoutError { message; phase } ->
+    Some (Retry.Timeout { message; phase = Some phase })
   | Http_client.AcceptRejected _ -> None
   (* Wiring bug, not transient — retrying cannot summon a missing
      transport. *)

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -12,9 +12,10 @@ module Retry = Llm_provider.Retry
 let retry_error_of_http_error = function
   | Http_client.HttpError { code; body } -> Retry.classify_error ~status:code ~body
   | Http_client.NetworkError { message; kind = Http_client.Timeout } ->
-    Retry.Timeout { message }
+    Retry.Timeout { message; phase = None }
   | Http_client.NetworkError { message; kind } -> Retry.NetworkError { message; kind }
-  | Http_client.TimeoutError { message; _ } -> Retry.Timeout { message }
+  | Http_client.TimeoutError { message; phase } ->
+    Retry.Timeout { message; phase = Some phase }
   | Http_client.AcceptRejected { reason } ->
     Retry.InvalidRequest { message = "Response rejected: " ^ reason }
   | Http_client.ProviderTerminal { message; _ } -> Retry.InvalidRequest { message }

--- a/test/test_error_domain.ml
+++ b/test/test_error_domain.ml
@@ -263,7 +263,7 @@ let test_roundtrip_api_network_error () =
 ;;
 
 let test_roundtrip_api_timeout () =
-  let orig = Error.Api (Retry.Timeout { message = "3s" }) in
+  let orig = Error.Api (Retry.Timeout { message = "3s"; phase = None }) in
   let poly = Error_domain.of_sdk_error orig in
   (match poly with
    | `Provider_timeout "3s" -> ()

--- a/test/test_llm_provider_error.ml
+++ b/test/test_llm_provider_error.ml
@@ -375,8 +375,8 @@ let test_retry_remaining_variants_mapping () =
           (Retry.NetworkError { message = "tls"; kind = Http_client.Tls_error })
       , "network" )
     ; ( Error.of_retry_api_error
-            ~provider:"openai"
-            (Retry.Timeout { message = "slow"; phase = None })
+          ~provider:"openai"
+          (Retry.Timeout { message = "slow"; phase = None })
       , "timeout" )
     ]
   in

--- a/test/test_llm_provider_error.ml
+++ b/test/test_llm_provider_error.ml
@@ -325,6 +325,33 @@ let test_http_timeout_error_mapping () =
   | _ -> fail "expected Timeout"
 ;;
 
+let test_retry_timeout_phase_mapping () =
+  (* Retry.Timeout carries the transport phase that Http_client.TimeoutError
+     attached (complete_stream's local catch sets First_token for prefill).
+     [of_retry_api_error] must preserve it onto Error.Timeout.timeout_phase:
+     a prefill timeout that exhausts retries must still surface as
+     [First_token], not collapse to [None] (which would re-introduce the
+     phase mislabeling that PR #2093 fixed at the transport layer). *)
+  let err =
+    Error.of_retry_api_error
+      ~provider:"ollama"
+      (Retry.Timeout
+         { message = "prefill exceeded first-token budget"
+         ; phase = Some Http_client.First_token
+         })
+  in
+  match err with
+  | Error.Timeout { provider; timeout_phase; detail } ->
+    check string "provider" "ollama" provider;
+    check
+      (option string)
+      "phase"
+      (Some "first_token")
+      (Option.map Http_client.timeout_phase_to_label timeout_phase);
+    check string "detail" "prefill exceeded first-token budget" detail
+  | _ -> fail "expected Timeout"
+;;
+
 let test_retry_remaining_variants_mapping () =
   let cases =
     [ ( Error.of_retry_api_error
@@ -347,7 +374,9 @@ let test_retry_remaining_variants_mapping () =
           ~provider:"openai"
           (Retry.NetworkError { message = "tls"; kind = Http_client.Tls_error })
       , "network" )
-    ; ( Error.of_retry_api_error ~provider:"openai" (Retry.Timeout { message = "slow" })
+    ; ( Error.of_retry_api_error
+            ~provider:"openai"
+            (Retry.Timeout { message = "slow"; phase = None })
       , "timeout" )
     ]
   in
@@ -558,6 +587,10 @@ let () =
         ; test_case "HTTP terminal" `Quick test_http_terminal_mapping
         ; test_case "HTTP network error" `Quick test_http_network_error_mapping
         ; test_case "HTTP timeout error" `Quick test_http_timeout_error_mapping
+        ; test_case
+            "Retry timeout phase preserved"
+            `Quick
+            test_retry_timeout_phase_mapping
         ; test_case
             "Retry remaining variants"
             `Quick

--- a/test/test_retry.ml
+++ b/test/test_retry.ml
@@ -92,7 +92,7 @@ let test_is_retryable () =
     bool
     "timeout retryable"
     true
-    (Retry.is_retryable (Retry.Timeout { message = "" }));
+    (Retry.is_retryable (Retry.Timeout { message = ""; phase = None }));
   check
     bool
     "auth not retryable"
@@ -124,7 +124,7 @@ let test_error_message_all_variants () =
       , "Network error (dns_failure): failed to resolve hostname: api.z.ai" )
     ; ( Retry.NetworkError { message = "reset"; kind = Connection_refused }
       , "Network error (connection_refused): reset" )
-    ; Retry.Timeout { message = "10s" }, "Timeout: 10s"
+    ; Retry.Timeout { message = "10s"; phase = None }, "Timeout: 10s"
     ]
   in
   List.iter


### PR DESCRIPTION
## Summary

Follow-up to #2093. PR #2093 attached a typed `timeout_phase` (`First_token` for prefill, `Http_operation` for connect/headers, `Stream_idle` for chunk gaps) to `Http_client.TimeoutError`. But the retry layer discarded it: every `Http_client.TimeoutError` collapsed to `Retry.Timeout { message }`, so **after one retry the phase was lost**. A prefill timeout that exhausted retries surfaced as a generic, unclassifiable provider timeout — the exact mislabeling #2093 fixed at the transport layer, re-introduced at the retry boundary.

## Problem

```
Http_client.TimeoutError { phase = First_token }   (* prefill, set by #2093 *)
  -> Retry.Timeout { message }                       (* phase DROPPED here *)
  -> (retry exhausted)
  -> Error.Timeout { timeout_phase = None }          (* operator can't tell it was prefill *)
```

## Changes

- `retry.ml`/`retry.mli`: add `phase : timeout_phase option` to `Retry.Timeout`.
- The three sites that classify `Http_client.TimeoutError` (`retry_classify.ml`, `provider_intf.ml`, `api.ml`) forward `Some phase`.
- Sites with no transport phase (`NetworkError { kind = Timeout }`, the `Eio.Time.Timeout` catch in `api.create_message`, the deadline-exceeded default) use `phase = None`.
- `error.ml:203` (`of_retry_api_error`): `timeout_phase = r.phase` instead of the hard-coded `None`.

## Why this is not a workaround

Per `software-development.md` 워크어라운드 거부 기준:

- **Not** a string/substring classifier — phase is carried as a typed `timeout_phase option` end to end.
- **Not** an N-of-M patch — adding a record field forces the compiler to enumerate *every* construction site (10 found and fixed in one pass).
- **Not** a catch-all / telemetry-as-fix — it removes the information loss, it doesn't count it.
- Root fix: the data that #2093 produced is now preserved through the retry conversion; no new classification added.

## Verification

- `dune build --root .` — green (record field addition surfaced every construction site via compiler errors).
- `dune runtest` — full suite green. `llm_provider_error` suite: 29 tests, including the new `Retry timeout phase preserved`.
- New regression test `test_retry_timeout_phase_mapping`: asserts `Some First_token` survives `of_retry_api_error` — guards against a silent regression back to `timeout_phase = None`.

## Out of scope (separate)

- Cleaning up dead `timeout_phase` variants (`Stream_body`, etc.) currently unreached.
- Exact phase attribution inside `streaming.ml` Anthropic/OpenAI-compat paths (noted in #2093 plan).

Co-Authored-By: Claude <noreply@anthropic.com>
