### PR TITLE
[codex] Validate handoff block inputs

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -587,145 +587,148 @@ let find_handoff_in_messages = Agent_handoff.find_handoff_in_messages
 let replace_tool_result = Agent_handoff.replace_tool_result
 
 let run_with_handoffs_blocks ~sw ?clock agent ~targets user_blocks =
-  let handoff_tools = List.map Handoff.make_handoff_tool targets in
-  let all_tools = Tool_set.merge agent.tools (Tool_set.of_list handoff_tools) in
-  let agent_with_handoffs = { agent with tools = all_tools } in
-  let user_blocks = append_user_input agent_with_handoffs user_blocks in
-  let trace_prompt = trace_prompt_of_blocks user_blocks in
-  with_raw_trace_run agent_with_handoffs trace_prompt
-  @@ fun raw_trace_run ->
-  let rec loop () =
-    match check_loop_guard agent_with_handoffs with
-    | Some err -> Error err
-    | None ->
-      (match run_turn_with_trace ~sw ?clock ?raw_trace_run agent_with_handoffs with
-       | Error e -> Error e
-       | Ok (`Complete response) -> Ok response
-       | Ok `ToolsExecuted ->
-         (match find_handoff_in_messages agent_with_handoffs.state.messages with
-          | Some (tool_id, target_name, prompt) ->
-            let target_opt =
-              List.find_opt
-                (fun (t : Handoff.handoff_target) -> t.name = target_name)
-                targets
-            in
-            (match target_opt with
-             | None ->
-               let err_msg = Printf.sprintf "Unknown handoff target: %s" target_name in
-               update_state agent_with_handoffs (fun s ->
-                 { s with
-                   messages =
-                     replace_tool_result
-                       s.messages
-                       ~tool_id
-                       ~content:err_msg
-                       ~is_error:true
-                 });
-               loop ()
-             | Some target ->
-               let from_name = agent_with_handoffs.state.config.name in
-               (* HandoffRequested: capture the run_id so HandoffCompleted
-                 can record it as [caused_by], preserving the
-                 request -> completion causation chain (#877). *)
-               let handoff_requested_run_id =
-                 match agent_with_handoffs.options.event_bus with
-                 | Some bus ->
-                   let run_id = Event_bus.fresh_id () in
-                   (try
-                      Event_bus.publish
-                        bus
-                        (Event_bus.mk_event
-                           ~run_id
-                           (HandoffRequested
-                              { from_agent = from_name
-                              ; to_agent = target.name
-                              ; reason = prompt
-                              }))
-                    with
-                    | exn ->
-                      Log.warn
-                        _log
-                        "Event_bus.publish failed (HandoffRequested)"
-                        [ Log.S ("error", Printexc.to_string exn) ]);
-                   Some run_id
-                 | None -> None
-               in
-               let handoff_t0 = Unix.gettimeofday () in
-               let sub =
-                 create
-                   ~net:agent.net
-                   ~config:target.config
-                   ~tools:target.tools
-                   ~options:
-                     { default_options with
-                       base_url = agent.options.base_url
-                     ; provider = agent.options.provider
-                     ; policy_channel = agent.options.policy_channel
-                     }
-                   ()
-               in
-               let sub_result = run ~sw ?clock sub prompt in
-               let handoff_elapsed = Unix.gettimeofday () -. handoff_t0 in
-               (match agent_with_handoffs.options.event_bus with
-                | Some bus ->
-                  (try
-                     Event_bus.publish
-                       bus
-                       (Event_bus.mk_event
-                          ?caused_by:handoff_requested_run_id
-                          (HandoffCompleted
-                             { from_agent = from_name
-                             ; to_agent = target.name
-                             ; elapsed = handoff_elapsed
-                             }))
-                   with
-                   | exn ->
-                     Log.warn
-                       _log
-                       "Event_bus.publish failed (HandoffCompleted)"
-                       [ Log.S ("error", Printexc.to_string exn) ])
-                | None -> ());
-               (match sub_result with
-                | Error e ->
-                  let err_msg =
-                    Printf.sprintf
-                      "Handoff to %s failed: %s"
-                      target_name
-                      (Error.to_string e)
-                  in
-                  update_state agent_with_handoffs (fun s ->
-                    { s with
-                      messages =
-                        replace_tool_result
-                          s.messages
-                          ~tool_id
-                          ~content:err_msg
-                          ~is_error:true
-                    });
-                  loop ()
-                | Ok sub_response ->
-                  let text =
-                    List.fold_left
-                      (fun acc block ->
-                         match block with
-                         | Text s -> if acc = "" then s else acc ^ "\n" ^ s
-                         | _ -> acc)
-                      ""
-                      sub_response.content
-                  in
-                  update_state agent_with_handoffs (fun s ->
-                    { s with
-                      messages =
-                        replace_tool_result
-                          s.messages
-                          ~tool_id
-                          ~content:text
-                          ~is_error:false
-                    });
-                  loop ()))
-          | None -> loop ()))
-  in
-  loop ()
+  match validate_user_input_blocks user_blocks with
+  | Error _ as err -> err
+  | Ok () ->
+    let handoff_tools = List.map Handoff.make_handoff_tool targets in
+    let all_tools = Tool_set.merge agent.tools (Tool_set.of_list handoff_tools) in
+    let agent_with_handoffs = { agent with tools = all_tools } in
+    let user_blocks = append_user_input agent_with_handoffs user_blocks in
+    let trace_prompt = trace_prompt_of_blocks user_blocks in
+    with_raw_trace_run agent_with_handoffs trace_prompt
+    @@ fun raw_trace_run ->
+    let rec loop () =
+      match check_loop_guard agent_with_handoffs with
+      | Some err -> Error err
+      | None ->
+        (match run_turn_with_trace ~sw ?clock ?raw_trace_run agent_with_handoffs with
+         | Error e -> Error e
+         | Ok (`Complete response) -> Ok response
+         | Ok `ToolsExecuted ->
+           (match find_handoff_in_messages agent_with_handoffs.state.messages with
+            | Some (tool_id, target_name, prompt) ->
+              let target_opt =
+                List.find_opt
+                  (fun (t : Handoff.handoff_target) -> t.name = target_name)
+                  targets
+              in
+              (match target_opt with
+               | None ->
+                 let err_msg = Printf.sprintf "Unknown handoff target: %s" target_name in
+                 update_state agent_with_handoffs (fun s ->
+                   { s with
+                     messages =
+                       replace_tool_result
+                         s.messages
+                         ~tool_id
+                         ~content:err_msg
+                         ~is_error:true
+                   });
+                 loop ()
+               | Some target ->
+                 let from_name = agent_with_handoffs.state.config.name in
+                 (* HandoffRequested: capture the run_id so HandoffCompleted
+                    can record it as [caused_by], preserving the
+                    request -> completion causation chain (#877). *)
+                 let handoff_requested_run_id =
+                   match agent_with_handoffs.options.event_bus with
+                   | Some bus ->
+                     let run_id = Event_bus.fresh_id () in
+                     (try
+                        Event_bus.publish
+                          bus
+                          (Event_bus.mk_event
+                             ~run_id
+                             (HandoffRequested
+                                { from_agent = from_name
+                                ; to_agent = target.name
+                                ; reason = prompt
+                                }))
+                      with
+                      | exn ->
+                        Log.warn
+                          _log
+                          "Event_bus.publish failed (HandoffRequested)"
+                          [ Log.S ("error", Printexc.to_string exn) ]);
+                     Some run_id
+                   | None -> None
+                 in
+                 let handoff_t0 = Unix.gettimeofday () in
+                 let sub =
+                   create
+                     ~net:agent.net
+                     ~config:target.config
+                     ~tools:target.tools
+                     ~options:
+                       { default_options with
+                         base_url = agent.options.base_url
+                       ; provider = agent.options.provider
+                       ; policy_channel = agent.options.policy_channel
+                       }
+                     ()
+                 in
+                 let sub_result = run ~sw ?clock sub prompt in
+                 let handoff_elapsed = Unix.gettimeofday () -. handoff_t0 in
+                 (match agent_with_handoffs.options.event_bus with
+                  | Some bus ->
+                    (try
+                       Event_bus.publish
+                         bus
+                         (Event_bus.mk_event
+                            ?caused_by:handoff_requested_run_id
+                            (HandoffCompleted
+                               { from_agent = from_name
+                               ; to_agent = target.name
+                               ; elapsed = handoff_elapsed
+                               }))
+                     with
+                     | exn ->
+                       Log.warn
+                         _log
+                         "Event_bus.publish failed (HandoffCompleted)"
+                         [ Log.S ("error", Printexc.to_string exn) ])
+                  | None -> ());
+                 (match sub_result with
+                  | Error e ->
+                    let err_msg =
+                      Printf.sprintf
+                        "Handoff to %s failed: %s"
+                        target_name
+                        (Error.to_string e)
+                    in
+                    update_state agent_with_handoffs (fun s ->
+                      { s with
+                        messages =
+                          replace_tool_result
+                            s.messages
+                            ~tool_id
+                            ~content:err_msg
+                            ~is_error:true
+                      });
+                    loop ()
+                  | Ok sub_response ->
+                    let text =
+                      List.fold_left
+                        (fun acc block ->
+                           match block with
+                           | Text s -> if acc = "" then s else acc ^ "\n" ^ s
+                           | _ -> acc)
+                        ""
+                        sub_response.content
+                    in
+                    update_state agent_with_handoffs (fun s ->
+                      { s with
+                        messages =
+                          replace_tool_result
+                            s.messages
+                            ~tool_id
+                            ~content:text
+                            ~is_error:false
+                      });
+                    loop ()))
+            | None -> loop ()))
+    in
+    loop ()
 ;;
 
 let run_with_handoffs ~sw ?clock agent ~targets user_prompt =

--- a/test/test_multimodal.ml
+++ b/test/test_multimodal.ml
@@ -196,6 +196,30 @@ let test_agent_run_blocks_rejects_internal_blocks () =
   Alcotest.(check int) "state unchanged" 0 (List.length (Agent.state agent).messages)
 ;;
 
+let test_agent_run_with_handoffs_blocks_rejects_internal_blocks () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let config = { Types.default_config with max_turns = 0 } in
+  let agent = Agent.create ~net:env#net ~config () in
+  let blocks =
+    [ Types.ToolResult
+        { tool_use_id = "call-1"
+        ; content = "internal result"
+        ; is_error = false
+        ; json = None
+        ; content_blocks = None
+        }
+    ]
+  in
+  (match Agent.run_with_handoffs_blocks ~sw agent ~targets:[] blocks with
+   | Error (Error.Config (Error.InvalidConfig { field = "user_blocks"; _ })) -> ()
+   | Ok _ -> Alcotest.fail "expected invalid config"
+   | Error err -> Alcotest.fail ("unexpected error: " ^ Error.to_string err));
+  Alcotest.(check int) "state unchanged" 0 (List.length (Agent.state agent).messages)
+;;
+
 (* ------------------------------------------------------------------ *)
 (* JSON structure verification                                          *)
 (* ------------------------------------------------------------------ *)
@@ -322,6 +346,10 @@ let () =
             "agent run_blocks rejects internal blocks"
             `Quick
             test_agent_run_blocks_rejects_internal_blocks
+        ; Alcotest.test_case
+            "agent run_with_handoffs_blocks rejects internal blocks"
+            `Quick
+            test_agent_run_with_handoffs_blocks_rejects_internal_blocks
         ] )
     ; ( "json_structure"
       , [ Alcotest.test_case "image json structure" `Quick test_image_json_structure


### PR DESCRIPTION
## Summary
- run the same user content-block validation in run_with_handoffs_blocks that run_blocks and run_stream_blocks already use
- reject internal blocks such as ToolResult before mutating agent state or entering the handoff loop
- add a regression test covering the handoff block entrypoint

## Validation
- git diff --check
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_codex_handoff dune build --root . test/test_multimodal.exe
- _build_codex_handoff/default/test/test_multimodal.exe

Note: scripts/dune-local.sh was queued behind another worktree's Dune lock, so the focused build used an isolated DUNE_BUILD_DIR fallback.