### PR TITLE
fix(provider): wire per-kind connect timeout in complete_sync

### DIFF
--- a/lib/llm_provider/complete_sync.ml
+++ b/lib/llm_provider/complete_sync.ml
@@ -157,6 +157,16 @@ let complete_http
             ~url
             ~headers:(config.headers @ Provider_config.auth_headers_for_config config)
             ~body:body_str
+            (* Per-kind connect/headers bound (RFC-OAS-026). A cold local Ollama
+               model load or an admission-queued request holds the response
+               headers well past the 60s that suits cloud providers, so bound
+               the op with default_connect_timeout_s (600s Ollama, 60s cloud),
+               the same value the streaming path already passes as
+               connect_timeout_s (complete_stream.ml). Without this post_sync
+               fell back to the constant default_http_timeout_s = 60.0 for every
+               kind, which truncated local model loads on the connect/headers
+               phase as a phase=Http_operation timeout. *)
+            ~timeout_s:(Provider_config.default_connect_timeout_s config.kind)
             ()
         in
         (* Body-level deadline (since 0.195.0): wraps the entire


### PR DESCRIPTION
## Summary

Wires the **existing** per-kind connect/headers timeout (`Provider_config.default_connect_timeout_s`) into the non-streaming completion path (`complete_sync`) — the only caller that didn't pass it.

## Why

`complete_sync` called `Http_client.post_sync` **without `~timeout_s`**, so every provider kind was bounded by the constant `default_http_timeout_s = 60.0` (`http_client.ml:194`). RFC-OAS-026 already defines per-kind connect/headers bounds (`provider_config.ml:37`: 600s Ollama / 60s cloud) and the **streaming path wires them** (`complete_stream.ml:447 ~connect_timeout_s:(default_connect_timeout_s config.kind)`). The sync path was missed — a half-wired RFC-OAS-026.

Symptom: a cold local Ollama model load (or an admission-queued request) holds response headers past 60s, so the sync path truncated local model loads on the connect/headers phase as `phase=Http_operation` — reported upstream (keeper `Agent.run`) as `Provider '...' timeout phase=http_operation: HTTP operation exceeded wall-clock timeout`.

## 기존 구현 재사용 (no new code)

- `default_connect_timeout_s` (Ollama 600s / cloud 60s) — already defined at `provider_config.ml:37` and already used by the streaming path.
- Identical wiring pattern to `complete_stream.ml:447`.
- No new `Provider_config` field, no new timeout value, no new constant. One labeled argument.

## Verification

- `dune build @check` — pass (timeout value + `config.kind` access verified in scope).
- Live confirmation pending: a local Ollama cold model load should receive response headers within the 600s Ollama bound instead of timing out at 60s.

## Not a workaround / RFC

Wiring recovery (reusing an existing, streaming-verified SSOT), not a cap/cooldown/dedup/string-classifier. No `Provider_config` field or contract change. Refs **RFC-OAS-026** (transport-liveness-carrier; I2-legal per-kind connect/headers bound, not a total wall-clock deadline).

Co-Authored-By: Claude <noreply@anthropic.com>
