### PR TITLE
[codex] remove stale CLI env remnants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3633,10 +3633,7 @@ dead surface accumulated alongside the CDAL framework.
 
 ### Added
 
-- **Env-driven CLI flags for non-interactive transports.** `transport_claude_code`, `transport_codex_cli`, and `transport_gemini_cli` now read a small, opt-in set of `OAS_*` environment variables at `build_args` time and append matching CLI flags. Config records are unchanged; unset env means "no flag added" so existing callers see identical argv. Intended for MASC keeper-style callers that want to tighten MCP / approval surface without a code change.
-  - **Claude Code:** `OAS_CLAUDE_STRICT_MCP=1` → `--strict-mcp-config`; `OAS_CLAUDE_MCP_CONFIG=<file|json>` → `--mcp-config` (only when `config.mcp_config = None`); `OAS_CLAUDE_DISALLOWED_TOOLS="a,b"` → repeated `--disallowedTools` flags. LSP / hooks / auto-memory stay ON — no `--bare`.
-  - **Codex CLI:** `OAS_CODEX_CONFIG="k=v,k2=v2"` → `-c k=v -c k2=v2` (the only way to toggle MCP / hooks / sandbox at the Codex boundary); `OAS_CODEX_SANDBOX=read-only|workspace-write|danger-full-access` → `-s`; `OAS_CODEX_PROFILE=<name>` → `-p`; `OAS_CODEX_SKIP_GIT=1` → `--skip-git-repo-check`.
-  - **Gemini CLI:** `OAS_GEMINI_NO_MCP=1` → `--allowed-mcp-server-names ""` (empty whitelist = all MCP OFF); `OAS_GEMINI_ALLOWED_MCP="a,b"` → per-server whitelist; `OAS_GEMINI_APPROVAL_MODE=default|auto_edit|yolo|plan` → `--approval-mode` (supersedes `config.yolo` when set); `OAS_GEMINI_EXTENSIONS="a,b"` → repeated `-e` flags.
+- **Historical env-driven CLI flag experiment.** Non-interactive CLI transports briefly accepted transport-specific env aliases at `build_args` time. Those aliases are retired; current callers should use explicit transport config records and current provider/model env keys.
 - `lib/llm_provider/cli_common_env.{ml,mli}` centralises env parsing (`get`, `bool`, `list`, `kv_pairs`) so the three transports agree on truthy values and splitting rules.
 
 ### Notes
@@ -4259,7 +4256,7 @@ Cascade_executor.complete_cascade_with_accept ~sw ~net ?clock
 - Cascade: apply per-model timeout to last provider (#805)
 
 ### Changed
-- Discovery: drop legacy `OAS_LOCAL_QWEN_URL` env fallback; emits a one-time migration warning when the legacy var is set (#818)
+- Discovery: drop the model-specific local URL fallback; use `OAS_LOCAL_LLM_URL` for local runtime overrides (#818)
 
 ## [0.121.0] - 2026-04-11
 

--- a/README.md
+++ b/README.md
@@ -33,68 +33,6 @@ opam install . --deps-only --with-test --yes
 scripts/dune-local.sh build @all
 ```
 
-## Non-interactive CLI transports and MCP defaults
-
-OAS only owns the runtime policy for headless CLI subprocesses. Upstream CLI tools still have their own:
-
-1. server registry layer (`claude mcp ...`, `codex mcp ...`, `gemini mcp ...`)
-2. persistent config layer (user/project config files)
-3. per-run execution policy layer (what OAS injects for this specific subprocess)
-
-The recent bug lived in layer 3: a machine could have MCP servers registered, but a non-interactive OAS run was supposed to fail closed unless the caller opted back in.
-
-Current headless defaults:
-
-| Transport | Default runtime policy | Opt-back-in path |
-|----------|------------------------|------------------|
-| Claude Code | Always adds `--strict-mcp-config` | Supply `config.mcp_config` or `OAS_CLAUDE_MCP_CONFIG=/abs/path/mcp.json` |
-| Codex CLI | Always prepends `-c mcp_servers={}` | Pass a non-empty `mcp_servers` TOML fragment through `OAS_CODEX_CONFIG` / caller config |
-| Gemini CLI | Always sends an empty `--allowed-mcp-server-names` whitelist | Set `OAS_GEMINI_ALLOWED_MCP=name1,name2` |
-
-Model selection remains request-scoped: Claude Code, Gemini CLI, and Codex CLI all honor a non-empty, non-`auto` `Provider_config.model_id` by passing the transport's model flag (`--model`). `auto` keeps the user's CLI default.
-
-Why this can feel hidden:
-
-- Claude exposes MCP registration and runtime policy as separate commands/flags.
-- Codex exposes runtime policy through generic `-c key=value` overrides instead of a dedicated `--no-mcp` flag.
-- Gemini is the clearest: runtime MCP exposure is controlled by `--allowed-mcp-server-names`.
-
-### Codex sandbox cheat sheet
-
-This is **Codex CLI's own sandbox flag**, not a downstream container sandbox.
-
-Use these three levels:
-
-- `OAS_CODEX_SANDBOX=read-only`: inspect / grep / diagnosis only
-- `OAS_CODEX_SANDBOX=workspace-write`: normal local coding
-- `OAS_CODEX_SANDBOX=danger-full-access`: last resort
-
-Examples:
-
-```bash
-# safest explicit Codex run
-OAS_CODEX_SANDBOX=read-only dune exec ./examples/review_agent.exe -- org/repo 123
-
-# normal editing run
-OAS_CODEX_SANDBOX=workspace-write dune exec ./examples/review_agent.exe -- org/repo 123
-```
-
-If `OAS_CODEX_SANDBOX` is unset, OAS does not add `-s`; only MCP-off
-(`-c mcp_servers={}`) remains forced by default.
-
-Examples:
-
-```bash
-# Claude Code: keep strict mode, but allow only the config you pass explicitly
-OAS_CLAUDE_MCP_CONFIG=/abs/path/to/mcp.json dune exec ./examples/review_agent.exe -- org/repo 123
-
-# Gemini CLI: allow only named MCP servers for this run
-OAS_GEMINI_ALLOWED_MCP=filesystem,github dune exec ./examples/review_agent.exe -- org/repo 123
-
-# Codex CLI: default remains MCP OFF unless the caller injects a non-empty
-# mcp_servers TOML fragment via OAS_CODEX_CONFIG or equivalent caller wiring.
-```
-
 ## Quickstart
 
 ```ocaml

--- a/docs/RFC-0001-vendor-purge.md
+++ b/docs/RFC-0001-vendor-purge.md
@@ -160,7 +160,6 @@ Module references updated repo-wide; `test/dune` test list updated.
 | `GLM_API_KEY` | `PROVIDER_K_API_KEY` |
 | `DASHSCOPE_API_KEY` | `PROVIDER_H_API_KEY` |
 | `CODEX_API_KEY` | `CLI_TOOL_A_API_KEY` |
-| `OAS_ANTHROPIC_*`, `OAS_GEMINI_*`, `OAS_KIMI_*`, `OAS_OPENAI_*`, `OAS_CLAUDE_*`, `OAS_CODEX_*`, `OAS_DEEPSEEK_*`, `OAS_GLM_*`, `OAS_DASHSCOPE_*`, `OAS_MOONSHOT_*` | `OAS_PROVIDER_{A..K}_*`, `OAS_CLI_TOOL_{A..D}_*` |
 
 **Operator action**: update `.zshenv` to re-export with new names. Old env vars are no longer read.
 

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -46,26 +46,6 @@ type endpoint_status =
   ; capabilities : Capabilities.capabilities
   }
 
-(* [OAS_LOCAL_QWEN_URL] was the original model-specific name for this
-   knob. It was superseded by [OAS_LOCAL_LLM_URL] (same shape, neutral
-   name). If a deployment still has the legacy var set we emit a
-   one-time migration warning to stderr at module-init time so the
-   operator sees it on the next process start, but we do not route to
-   the legacy URL — that would couple the public SDK contract to a
-   model name that isn't part of the endpoint's meaning. Operators
-   should rename their env var; the migration is mechanical. *)
-let () =
-  match Cli_common_env.get "OAS_LOCAL_QWEN_URL" with
-  | Some v ->
-    Diag.warn
-      "discovery"
-      "OAS_LOCAL_QWEN_URL is set (%s) but has been removed in favor of \
-       OAS_LOCAL_LLM_URL. The legacy value will be ignored. Rename the env var to \
-       migrate."
-      v
-  | None -> ()
-;;
-
 let default_endpoint =
   match Cli_common_env.get "OAS_LOCAL_LLM_URL" with
   | Some v -> v


### PR DESCRIPTION
## Summary

- Remove the remaining `OAS_LOCAL_QWEN_URL` module-init warning/remnant from local runtime discovery.
- Delete README guidance for retired non-interactive CLI env aliases.
- Generalize historical changelog/RFC entries so stale CLI env names are not presented as a current contract.

## Validation

- `scripts/dune-local.sh build @lib/llm_provider/runtest`
- `git diff --check HEAD^`
