### PR TITLE
refactor: remove cost and token/turn budget enforcement (observe-only)

### DIFF
--- a/examples/builder_patterns.ml
+++ b/examples/builder_patterns.ml
@@ -5,7 +5,7 @@
     - Minimal vs full configuration
     - Validation errors from build_safe
     - with_hooks, with_guardrails, with_provider
-    - with_context, with_initial_messages, with_max_cost_usd
+    - with_context, with_initial_messages
 
     Prerequisites:
     - A running llama-server on port 8085 (or set provider accordingly)
@@ -69,7 +69,6 @@ let demo_full () =
     |> Builder.with_hooks hooks
     |> Builder.with_guardrails
          { tool_filter = AllowList [ "echo" ]; max_tool_calls_per_turn = Some 3 }
-    |> Builder.with_max_cost_usd 0.10
     |> Builder.with_initial_messages
          [ { role = User
            ; content = [ Text "context: this is a demo" ]
@@ -85,11 +84,6 @@ let demo_full () =
     let st = Agent.state agent in
     Printf.printf "  Agent: %s\n" st.config.name;
     Printf.printf "  Max turns: %d\n" st.config.max_turns;
-    Printf.printf
-      "  Max cost: %s USD\n"
-      (match st.config.max_cost_usd with
-       | Some c -> Printf.sprintf "%.2f" c
-       | None -> "unlimited");
     Printf.printf "  Tools: %d\n" (Tool_set.size (Agent.tools agent));
     Printf.printf "  Initial messages: %d\n" (List.length st.config.initial_messages)
   | Error e -> Printf.printf "  Build failed: %s\n" (Error.to_string e)

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -81,12 +81,10 @@ let provide_input agent request response =
   Agent_elicitation.apply_response agent request response
 ;;
 
-let check_token_budget = Agent_turn.check_token_budget
+(* ── Shared loop guard (max_turns + idle) ─────────── *)
 
-(* ── Shared loop guard (max_turns + idle + token budget) ─────────── *)
-
-(** Check max_turns, idle detection, and token budget.
-    Cost is telemetry-only and never gates the loop.
+(** Check max_turns and idle detection.
+    Token and cost are telemetry-only and never gate the loop.
     Returns [Some error] when any guard fires, [None] to proceed. *)
 let check_loop_guard agent =
   match agent.state.config.exit_condition with
@@ -106,9 +104,7 @@ let check_loop_guard agent =
       Some
         (Error.Agent
            (Error.IdleDetected { consecutive_idle_turns = agent.consecutive_idle_turns }))
-    else
-      (* dummy for SCA: Telemetry_event.Budget_exceeded *)
-      check_token_budget agent.state.config agent.state.usage
+    else None
 ;;
 
 (* ── Unified run loop ────────────────────────────────────────── *)

--- a/lib/agent/agent_checkpoint.ml
+++ b/lib/agent/agent_checkpoint.ml
@@ -34,8 +34,6 @@ let build_resume ~(checkpoint : Checkpoint.t) ?config ?context () =
     ; tool_choice = checkpoint.tool_choice
     ; disable_parallel_tool_use = checkpoint.disable_parallel_tool_use
     ; cache_system_prompt = checkpoint.cache_system_prompt
-    ; max_input_tokens = checkpoint.max_input_tokens
-    ; max_total_tokens = checkpoint.max_total_tokens
     }
   in
   let state =
@@ -86,8 +84,6 @@ let build_checkpoint
   ; response_format = state.config.response_format
   ; thinking_budget = state.config.thinking_budget
   ; cache_system_prompt = state.config.cache_system_prompt
-  ; max_input_tokens = state.config.max_input_tokens
-  ; max_total_tokens = state.config.max_total_tokens
   ; context = Context.copy context
   ; mcp_sessions = Mcp_session.capture_all mcp_clients
   ; working_context

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -458,32 +458,6 @@ let apply_context_injection ~context ~messages ~injector ~tool_uses ~results =
   !current_messages
 ;;
 
-(* ── Token budget check ───────────────────────────────────────── *)
-
-let check_token_budget config usage =
-  let exceeded_input =
-    match config.max_input_tokens with
-    | Some limit when usage.total_input_tokens > limit ->
-      Some
-        (Error.Agent
-           (TokenBudgetExceeded { kind = "Input"; used = usage.total_input_tokens; limit }))
-    | Some _ | None -> None
-  in
-  let exceeded_total =
-    match config.max_total_tokens with
-    | Some limit ->
-      let total = usage.total_input_tokens + usage.total_output_tokens in
-      if total > limit
-      then
-        Some (Error.Agent (TokenBudgetExceeded { kind = "Total"; used = total; limit }))
-      else None
-    | None -> None
-  in
-  match exceeded_input with
-  | Some _ as err -> err
-  | None -> exceeded_total
-;;
-
 (* ── Stop reason handling (tool execution branch) ─────────────── *)
 
 type idle_state =

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -206,11 +206,6 @@ val apply_context_injection
   -> results:Agent_tools.tool_execution_result list
   -> Types.message list
 
-(** {1 Token budget} *)
-
-(** Check input/total token budgets; return an error if exceeded. *)
-val check_token_budget : Types.agent_config -> Types.usage_stats -> Error.sdk_error option
-
 (** {1 Idle state tracking} *)
 
 type idle_state =

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -22,10 +22,7 @@ type t =
   ; disable_parallel_tool_use : bool
   ; cache_system_prompt : bool
   ; cache_extended_ttl : bool
-  ; max_input_tokens : int option
-  ; max_total_tokens : int option
   ; initial_messages : message list
-  ; max_cost_usd : float option
   ; tools : Tool_set.t
   ; context : Context.t option
   ; base_url : string
@@ -96,10 +93,7 @@ let create ~net ~model =
   ; disable_parallel_tool_use = default_config.disable_parallel_tool_use
   ; cache_system_prompt = default_config.cache_system_prompt
   ; cache_extended_ttl = default_config.cache_extended_ttl
-  ; max_input_tokens = default_config.max_input_tokens
-  ; max_total_tokens = default_config.max_total_tokens
   ; initial_messages = default_config.initial_messages
-  ; max_cost_usd = default_config.max_cost_usd
   ; tools = Tool_set.empty
   ; context = None
   ; base_url = Api.default_base_url
@@ -225,26 +219,18 @@ let with_context_thresholds
   (* Resolution chain for the context window used by the reducer:
      1. explicit [?context_window_tokens] argument (caller knows the
         per-agent override),
-     2. builder's [max_input_tokens] (whole-run input cap),
-     3. builder's [max_total_tokens] (whole-run total cap),
-     4. [Provider.resolve_max_context_tokens] on [b.provider] when set
+     2. [Provider.resolve_max_context_tokens] on [b.provider] when set
         (e.g. a [qwen3*] model_id → 262_144) — this shares the
         "provider → capabilities → max_context_tokens" resolution with
         [Pipeline.proactive_context_window_tokens] so the reducer budget
         and the compaction watermark agree for the same agent.
-     5. conservative 200_000 literal as the final fallback when nothing
+     3. conservative 200_000 literal as the final fallback when nothing
         is known — better to under-report than to assume a giant window
         and skip compaction. *)
   let effective_max =
     match context_window_tokens with
     | Some n when n > 0 -> n
-    | _ ->
-      (match b.max_input_tokens with
-       | Some n when n > 0 -> n
-       | _ ->
-         (match b.max_total_tokens with
-          | Some n when n > 0 -> n
-          | _ -> Provider.resolve_max_context_tokens ~fallback:200_000 b.provider))
+    | _ -> Provider.resolve_max_context_tokens ~fallback:200_000 b.provider
   in
   let reducer =
     Context_reducer.from_context_config ~compact_ratio ~max_tokens:effective_max ()
@@ -284,10 +270,7 @@ let with_tool_choice tc b = { b with tool_choice = Some tc }
 let with_response_format response_format b = { b with response_format }
 let with_disable_parallel_tool_use v b = { b with disable_parallel_tool_use = v }
 let with_thinking_budget n b = { b with thinking_budget = Some n }
-let with_max_input_tokens n b = { b with max_input_tokens = Some n }
-let with_max_total_tokens n b = { b with max_total_tokens = Some n }
 let with_initial_messages msgs b = { b with initial_messages = msgs }
-let with_max_cost_usd v b = { b with max_cost_usd = Some v }
 
 let with_response_format_json v b =
   with_response_format (response_format_of_json_mode v) b
@@ -360,10 +343,7 @@ let build b =
     ; disable_parallel_tool_use = b.disable_parallel_tool_use
     ; cache_system_prompt = b.cache_system_prompt
     ; cache_extended_ttl = b.cache_extended_ttl
-    ; max_input_tokens = b.max_input_tokens
-    ; max_total_tokens = b.max_total_tokens
     ; initial_messages = b.initial_messages
-    ; max_cost_usd = b.max_cost_usd
     ; context_compact_ratio = b.context_compact_ratio
     ; context_prepare_ratio = b.context_prepare_ratio
     ; context_handoff_ratio = b.context_handoff_ratio
@@ -483,14 +463,5 @@ let build_safe b =
                  { field = "thinking_budget"
                  ; detail = "thinking_budget requires enable_thinking = true"
                  }))
-       | _ ->
-         (match b.max_cost_usd with
-          | Some v when v < 0.0 ->
-            Error
-              (Error.Config
-                 (Error.InvalidConfig
-                    { field = "max_cost_usd"
-                    ; detail = Printf.sprintf "must be >= 0.0, got %.4f" v
-                    }))
-          | _ -> Ok (build b))))
+       | _ -> Ok (build b)))
 ;;

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -26,10 +26,7 @@ val with_thinking_budget : int -> t -> t
 val with_tool_choice : Types.tool_choice -> t -> t
 val with_response_format : Types.response_format -> t -> t
 val with_disable_parallel_tool_use : bool -> t -> t
-val with_max_input_tokens : int -> t -> t
-val with_max_total_tokens : int -> t -> t
 val with_initial_messages : Types.message list -> t -> t
-val with_max_cost_usd : float -> t -> t
 val with_response_format_json : bool -> t -> t
 val with_cache_system_prompt : bool -> t -> t
 val with_cache_extended_ttl : bool -> t -> t
@@ -106,7 +103,7 @@ val with_context_reducer : Context_reducer.t -> t -> t
     This is used to estimate available input/context capacity for reduction
     decisions, and is distinct from [with_max_tokens], which controls the
     agent's per-response output token limit.
-    When omitted, derives from [max_input_tokens], then [max_total_tokens],
+    When omitted, derives from the provider's resolved context window,
     then falls back to 200_000.  Values <= 0 are ignored.
     [prepare_ratio] and [handoff_ratio] are stored for future use.
 

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -211,10 +211,7 @@ let create_agent
     ; cache_system_prompt =
         Option.value cache_system_prompt ~default:default_config.cache_system_prompt
     ; cache_extended_ttl = default_config.cache_extended_ttl
-    ; max_input_tokens = default_config.max_input_tokens
-    ; max_total_tokens = default_config.max_total_tokens
     ; initial_messages = default_config.initial_messages
-    ; max_cost_usd = default_config.max_cost_usd
     ; context_compact_ratio = default_config.context_compact_ratio
     ; context_prepare_ratio = default_config.context_prepare_ratio
     ; context_handoff_ratio = default_config.context_handoff_ratio

--- a/lib/base/error.ml
+++ b/lib/base/error.ml
@@ -32,19 +32,6 @@ type agent_error =
       { turns : int
       ; limit : int
       }
-  | TokenBudgetExceeded of
-      { kind : string
-      ; used : int
-      ; limit : int
-      }
-  | CostBudgetExceeded of
-      { spent_usd : float
-      ; limit_usd : float
-      }
-  | CostBudgetUnenforceable of
-      { model_id : string
-      ; limit_usd : float
-      }
   | UnrecognizedStopReason of { reason : string }
   | IdleDetected of { consecutive_idle_turns : int }
   | AgentExecutionTimeout of
@@ -152,19 +139,6 @@ type sdk_error =
 let agent_error_to_string = function
   | MaxTurnsExceeded r ->
     Printf.sprintf "Max turns exceeded (turn %d, limit %d)" r.turns r.limit
-  | TokenBudgetExceeded r ->
-    Printf.sprintf "%s token budget exceeded: %d/%d" r.kind r.used r.limit
-  | CostBudgetExceeded r ->
-    Printf.sprintf
-      "Legacy cost threshold exceeded: $%.4f spent (threshold $%.4f); cost is advisory"
-      r.spent_usd
-      r.limit_usd
-  | CostBudgetUnenforceable r ->
-    Printf.sprintf
-      "Legacy cost threshold ($%.4f) saw unpriced model %S; cost is advisory and does \
-       not gate execution"
-      r.limit_usd
-      r.model_id
   | UnrecognizedStopReason r ->
     Printf.sprintf "Unrecognized stop_reason from API: %s" r.reason
   | IdleDetected r ->

--- a/lib/base/error.mli
+++ b/lib/base/error.mli
@@ -31,21 +31,6 @@ type agent_error =
       { turns : int
       ; limit : int
       }
-  | TokenBudgetExceeded of
-      { kind : string
-      ; used : int
-      ; limit : int
-      }
-  | CostBudgetExceeded of
-      { spent_usd : float
-      ; limit_usd : float
-      }
-  | CostBudgetUnenforceable of
-      { model_id : string
-      ; limit_usd : float
-      }
-  (** Legacy compatibility variant. [max_cost_usd] is advisory telemetry only
-      and new execution paths must not emit this as a gate. *)
   | UnrecognizedStopReason of { reason : string }
   | IdleDetected of { consecutive_idle_turns : int }
   | AgentExecutionTimeout of

--- a/lib/base/types.ml
+++ b/lib/base/types.ml
@@ -101,12 +101,8 @@ type agent_config =
     (* Anthropic: tool_choice.disable_parallel_tool_use, Openai: parallel_tool_calls=false *)
   ; cache_system_prompt : bool (* Wrap system prompt with cache_control ephemeral *)
   ; cache_extended_ttl : bool (* true=1h TTL (2x write cost), false=5min default *)
-  ; max_input_tokens : int option (* Token budget: max cumulative input tokens *)
-  ; max_total_tokens : int option (* Token budget: max cumulative total tokens *)
   ; initial_messages : message list
     (* Seed conversation with prior history on first run *)
-  ; max_cost_usd : float option
-    (* Advisory cost telemetry threshold in USD. Never gates execution. @since 0.62.0 *)
   ; context_compact_ratio : float option
     (** Ratio of context budget at which to compact. Default 0.8 *)
   ; context_prepare_ratio : float option
@@ -146,10 +142,7 @@ let default_config =
   ; disable_parallel_tool_use = false
   ; cache_system_prompt = false
   ; cache_extended_ttl = false
-  ; max_input_tokens = None
-  ; max_total_tokens = None
   ; initial_messages = []
-  ; max_cost_usd = None
   ; context_compact_ratio = None
   ; context_prepare_ratio = None
   ; context_handoff_ratio = None

--- a/lib/base/types.mli
+++ b/lib/base/types.mli
@@ -55,11 +55,7 @@ type agent_config =
       Write cost is 2x but the cache persists 12x longer — intended
       for long-running agents that go idle 5+ minutes between turns.
       @since 0.151.0 *)
-  ; max_input_tokens : int option
-  ; max_total_tokens : int option
   ; initial_messages : message list
-  ; max_cost_usd : float option
-    (** Advisory cost telemetry threshold in USD. Never gates execution. *)
   ; context_compact_ratio : float option
   ; context_prepare_ratio : float option
   ; context_handoff_ratio : float option

--- a/lib/checkpoint.ml
+++ b/lib/checkpoint.ml
@@ -29,8 +29,6 @@ type t = Checkpoint_types.t =
   ; response_format : response_format
   ; thinking_budget : int option
   ; cache_system_prompt : bool
-  ; max_input_tokens : int option
-  ; max_total_tokens : int option
   ; context : Context.t
   ; mcp_sessions : Mcp_session.info list
   ; working_context : Yojson.Safe.t option
@@ -63,8 +61,6 @@ type limits_patch = Checkpoint_types.limits_patch =
   { disable_parallel_tool_use : bool
   ; response_format : response_format
   ; cache_system_prompt : bool
-  ; max_input_tokens : int option
-  ; max_total_tokens : int option
   }
 
 type delta_op = Checkpoint_types.delta_op =

--- a/lib/checkpoint.mli
+++ b/lib/checkpoint.mli
@@ -36,8 +36,6 @@ type t =
   ; response_format : Types.response_format
   ; thinking_budget : int option
   ; cache_system_prompt : bool
-  ; max_input_tokens : int option
-  ; max_total_tokens : int option
   ; context : Context.t
   ; mcp_sessions : Mcp_session.info list
   ; working_context : Yojson.Safe.t option
@@ -70,8 +68,6 @@ type limits_patch =
   { disable_parallel_tool_use : bool
   ; response_format : Types.response_format
   ; cache_system_prompt : bool
-  ; max_input_tokens : int option
-  ; max_total_tokens : int option
   }
 
 type delta_op =

--- a/lib/checkpoint_codec.ml
+++ b/lib/checkpoint_codec.ml
@@ -191,8 +191,6 @@ let checkpoint_to_json cp =
     ; "thinking_budget", Util.json_of_int_opt cp.thinking_budget
     ; "disable_parallel_tool_use", `Bool cp.disable_parallel_tool_use
     ; "cache_system_prompt", `Bool cp.cache_system_prompt
-    ; "max_input_tokens", Util.json_of_int_opt cp.max_input_tokens
-    ; "max_total_tokens", Util.json_of_int_opt cp.max_total_tokens
     ; "context", Context.to_json cp.context
     ; "mcp_sessions", Mcp_session.info_list_to_json cp.mcp_sessions
     ; "working_context", Option.value ~default:`Null cp.working_context
@@ -308,14 +306,6 @@ let delta_to_json (delta : delta) =
         ; "disable_parallel_tool_use", `Bool patch.disable_parallel_tool_use
         ; "response_format", response_format_to_json patch.response_format
         ; "cache_system_prompt", `Bool patch.cache_system_prompt
-        ; ( "max_input_tokens"
-          , Option.value
-              ~default:`Null
-              (Option.map (fun value -> `Int value) patch.max_input_tokens) )
-        ; ( "max_total_tokens"
-          , Option.value
-              ~default:`Null
-              (Option.map (fun value -> `Int value) patch.max_total_tokens) )
         ]
     | Patch_context diff ->
       `Assoc [ "kind", `String "patch_context"; "diff", context_diff_to_json diff ]
@@ -414,8 +404,6 @@ let delta_of_json json =
                  op_json |> member "disable_parallel_tool_use" |> to_bool
              ; response_format
              ; cache_system_prompt = op_json |> member "cache_system_prompt" |> to_bool
-             ; max_input_tokens = op_json |> member "max_input_tokens" |> to_int_option
-             ; max_total_tokens = op_json |> member "max_total_tokens" |> to_int_option
              })
         response_format
     | "patch_context" ->
@@ -572,8 +560,6 @@ let of_json json =
                  |> member "cache_system_prompt"
                  |> to_bool_option
                  |> Option.value ~default:false
-             ; max_input_tokens = json |> member "max_input_tokens" |> to_int_option
-             ; max_total_tokens = json |> member "max_total_tokens" |> to_int_option
              ; context
              ; mcp_sessions
              ; working_context

--- a/lib/checkpoint_delta.ml
+++ b/lib/checkpoint_delta.ml
@@ -110,8 +110,6 @@ let limits_patch_changed (before : t) (after : t) =
   before.disable_parallel_tool_use <> after.disable_parallel_tool_use
   || before.response_format <> after.response_format
   || before.cache_system_prompt <> after.cache_system_prompt
-  || before.max_input_tokens <> after.max_input_tokens
-  || before.max_total_tokens <> after.max_total_tokens
 ;;
 
 let delta_version = 2
@@ -201,8 +199,6 @@ let compute_delta (before : t) (after : t) =
          { disable_parallel_tool_use = after.disable_parallel_tool_use
          ; response_format = after.response_format
          ; cache_system_prompt = after.cache_system_prompt
-         ; max_input_tokens = after.max_input_tokens
-         ; max_total_tokens = after.max_total_tokens
          });
   let context_diff = Context.diff before.context after.context in
   if not (context_diff_is_empty context_diff) then push (Patch_context context_diff);
@@ -270,8 +266,6 @@ let apply_delta base delta =
             disable_parallel_tool_use = patch.disable_parallel_tool_use
           ; response_format = patch.response_format
           ; cache_system_prompt = patch.cache_system_prompt
-          ; max_input_tokens = patch.max_input_tokens
-          ; max_total_tokens = patch.max_total_tokens
           }
       | Patch_context diff ->
         Ok { checkpoint with context = apply_context_patch checkpoint.context diff }

--- a/lib/checkpoint_types.ml
+++ b/lib/checkpoint_types.ml
@@ -24,8 +24,6 @@ type t =
   ; response_format : response_format
   ; thinking_budget : int option
   ; cache_system_prompt : bool
-  ; max_input_tokens : int option
-  ; max_total_tokens : int option
   ; context : Context.t
   ; mcp_sessions : Mcp_session.info list
   ; working_context : Yojson.Safe.t option
@@ -58,8 +56,6 @@ type limits_patch =
   { disable_parallel_tool_use : bool
   ; response_format : response_format
   ; cache_system_prompt : bool
-  ; max_input_tokens : int option
-  ; max_total_tokens : int option
   }
 
 type delta_op =

--- a/lib/cost_tracker.ml
+++ b/lib/cost_tracker.ml
@@ -19,14 +19,6 @@ type cost_report =
   ; avg_cost_per_call : float
   }
 
-(** Compatibility shim for older callers.
-
-    Cost thresholds are advisory telemetry only. This function must never
-    return an execution-stopping error, even when [config.max_cost_usd] is
-    set, accumulated cost is above the threshold, or usage includes an
-    unpriced model. *)
-let check_budget (_config : Types.agent_config) (_usage : Types.usage_stats) = None
-
 (** Generate a cost report from accumulated usage stats. *)
 let report (usage : Types.usage_stats) : cost_report =
   let avg =

--- a/lib/cost_tracker.mli
+++ b/lib/cost_tracker.mli
@@ -16,12 +16,6 @@ type cost_report =
   ; avg_cost_per_call : float
   }
 
-(** Compatibility shim for older callers.
-
-    Cost thresholds are advisory telemetry only. This function returns
-    [None] unconditionally and must not gate execution. *)
-val check_budget : Types.agent_config -> Types.usage_stats -> Error.sdk_error option
-
 (** Generate a structured cost report from usage stats. *)
 val report : Types.usage_stats -> cost_report
 

--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -23,9 +23,6 @@ type tool_error =
 
 type agent_error =
   [ `Max_turns_exceeded of int * int
-  | `Token_budget_exceeded of int * int
-  | `Cost_budget_exceeded
-  | `Cost_budget_unenforceable of string * float
   | `Idle_detected of int
   | `Agent_execution_timeout of float * float * int * int
   | `Agent_execution_idle_timeout of float * float * int * int
@@ -122,10 +119,6 @@ let of_sdk_error (err : Error.sdk_error) : sdk_error_poly =
   | Error.Api err -> (of_api_error err :> sdk_error_poly)
   | Error.Provider err -> (of_provider_error err :> sdk_error_poly)
   | Error.Agent (MaxTurnsExceeded r) -> `Max_turns_exceeded (r.turns, r.limit)
-  | Error.Agent (TokenBudgetExceeded r) -> `Token_budget_exceeded (r.used, r.limit)
-  | Error.Agent (CostBudgetExceeded _) -> `Cost_budget_exceeded
-  | Error.Agent (CostBudgetUnenforceable r) ->
-    `Cost_budget_unenforceable (r.model_id, r.limit_usd)
   | Error.Agent (IdleDetected r) -> `Idle_detected r.consecutive_idle_turns
   | Error.Agent (AgentExecutionTimeout r) ->
     `Agent_execution_timeout (r.elapsed_sec, r.timeout_sec, r.turn_count, r.max_turns)
@@ -175,12 +168,6 @@ let to_sdk_error (err : sdk_error_poly) : Error.sdk_error =
   match err with
   | #provider_error as e -> provider_to_sdk e
   | `Max_turns_exceeded (turns, limit) -> Error.Agent (MaxTurnsExceeded { turns; limit })
-  | `Token_budget_exceeded (used, limit) ->
-    Error.Agent (TokenBudgetExceeded { kind = "total"; used; limit })
-  | `Cost_budget_exceeded ->
-    Error.Agent (CostBudgetExceeded { spent_usd = 0.0; limit_usd = 0.0 })
-  | `Cost_budget_unenforceable (model_id, limit_usd) ->
-    Error.Agent (CostBudgetUnenforceable { model_id; limit_usd })
   | `Idle_detected n -> Error.Agent (IdleDetected { consecutive_idle_turns = n })
   | `Agent_execution_timeout (elapsed_sec, timeout_sec, turn_count, max_turns) ->
     Error.Agent
@@ -268,9 +255,6 @@ let is_retryable (err : [< sdk_error_poly ]) : bool =
   | `Tool_exec_failed _
   | `Tool_timeout _
   | `Max_turns_exceeded _
-  | `Token_budget_exceeded _
-  | `Cost_budget_exceeded
-  | `Cost_budget_unenforceable _
   | `Idle_detected _
   | `Agent_execution_timeout _
   | `Agent_execution_idle_timeout _

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -45,11 +45,6 @@ type tool_error =
 
 type agent_error =
   [ `Max_turns_exceeded of int * int (** turns, limit *)
-  | `Token_budget_exceeded of int * int (** used, limit *)
-  | `Cost_budget_exceeded
-  | `Cost_budget_unenforceable of string * float
-    (** model_id, threshold_usd — legacy advisory cost classification.
-        New execution paths must not emit this as a gate. *)
   | `Idle_detected of int (** consecutive_idle_turns *)
   | `Agent_execution_timeout of float * float * int * int
     (** elapsed_sec, timeout_sec, turn_count, max_turns *)

--- a/lib/harness.ml
+++ b/lib/harness.ml
@@ -263,18 +263,10 @@ module Performance = struct
 
   type expectation =
     { max_p95_latency_ms : float option
-    ; max_total_tokens : int option
-    ; max_cost_usd : float option
     ; max_turns : int option
     }
 
-  let default_expectation =
-    { max_p95_latency_ms = None
-    ; max_total_tokens = None
-    ; max_cost_usd = None
-    ; max_turns = None
-    }
-  ;;
+  let default_expectation = { max_p95_latency_ms = None; max_turns = None }
 
   (** Calculate p95 from a sorted list of latencies. *)
   let p95 latencies =
@@ -293,19 +285,6 @@ module Performance = struct
          | Some limit ->
            let actual = p95 obs.latencies_ms in
            Some (actual <= limit, Printf.sprintf "p95_ms=%.1f limit=%.1f" actual limit)
-         | None -> None)
-      ; (match exp.max_total_tokens with
-         | Some limit ->
-           Some
-             ( obs.total_tokens <= limit
-             , Printf.sprintf "tokens=%d limit=%d" obs.total_tokens limit )
-         | None -> None)
-      ; (match exp.max_cost_usd with
-         | Some limit ->
-           Some
-             ( true
-             , Printf.sprintf "cost=%.4f advisory_threshold=%.4f" obs.total_cost_usd limit
-             )
          | None -> None)
       ; (match exp.max_turns with
          | Some limit ->

--- a/lib/harness.mli
+++ b/lib/harness.mli
@@ -104,9 +104,6 @@ module Performance : sig
 
   type expectation =
     { max_p95_latency_ms : float option
-    ; max_total_tokens : int option
-    ; max_cost_usd : float option
-      (** Advisory telemetry threshold; does not make the verdict fail. *)
     ; max_turns : int option
     }
 

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -25,7 +25,6 @@ let record_streaming_metrics (metrics : Metrics.t) = function
   | Thinking_complete _
   | Timeout _
   | Prefill_complete _
-  | Budget_exceeded _
   | Context_window_usage _ -> ()
 ;;
 

--- a/lib/llm_provider/telemetry_event.ml
+++ b/lib/llm_provider/telemetry_event.ml
@@ -80,12 +80,6 @@ type t =
       ; prompt_eval_ms : float
       ; cache_hit : bool
       }
-  | Budget_exceeded of
-      { agent_name : string
-      ; run_id : string
-      ; spent_usd : float
-      ; limit_usd : float
-      }
   | Context_window_usage of
       { agent_name : string
       ; turn : int
@@ -101,6 +95,5 @@ let event_type_name = function
   | Thinking_complete _ -> "thinking_complete"
   | Timeout _ -> "timeout"
   | Prefill_complete _ -> "prefill_complete"
-  | Budget_exceeded _ -> "budget_exceeded"
   | Context_window_usage _ -> "context_window_usage"
 ;;

--- a/lib/llm_provider/telemetry_event.mli
+++ b/lib/llm_provider/telemetry_event.mli
@@ -79,12 +79,6 @@ type t =
       ; prompt_eval_ms : float
       ; cache_hit : bool
       }
-  | Budget_exceeded of
-      { agent_name : string
-      ; run_id : string
-      ; spent_usd : float
-      ; limit_usd : float
-      }
   | Context_window_usage of
       { agent_name : string
       ; turn : int

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -547,11 +547,8 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
 
 (** Context-window size for proactive compaction.
 
-    Do not derive this from [max_total_tokens] or [max_input_tokens]:
-    those are cumulative token budgets, not the model's per-request
-    context-window size.  Until an explicit context-window value is
-    available from configuration or provider/model capabilities, use a
-    conservative default. *)
+    This is the model's per-request context-window size, resolved from
+    provider/model capabilities, with a conservative default fallback. *)
 let proactive_context_window_tokens agent =
   Provider.resolve_max_context_tokens ~fallback:128_000 agent.options.provider
 ;;

--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -233,10 +233,10 @@ let extract_with_retry
   (* Mirror [Agent_turn.accumulate_usage]: when [u.cost_usd = None], use
      pricing-for-model to compute the cost; if there is no pricing entry,
      mark [unpriced_model] (with a stable sentinel for blank model_ids) so
-     [Cost_tracker.check_budget] can fail closed on retry-driven cost
-     paths.  Previously this path treated [None] as $0 and never stamped
-     [unpriced_model], so retries with unpriced models silently
-     under-reported cost. *)
+     cost telemetry records the gap.  Previously this path treated [None]
+     as $0 and never stamped [unpriced_model], so retries with unpriced
+     models silently under-reported cost.  Cost is telemetry only and
+     never gates execution. *)
   let add_retry_usage ~provider_cfg acc resp_usage =
     match resp_usage with
     | None -> acc

--- a/lib/telemetry_sca_registry.ml
+++ b/lib/telemetry_sca_registry.ml
@@ -40,10 +40,6 @@ let registry : entry list =
     ; producer_files = [ "lib/llm_provider/complete_stream.ml" ]
     ; description = "Prompt eval token count and latency from Ollama timings"
     }
-  ; { signal = "Budget_exceeded"
-    ; producer_files = [ "lib/agent/agent.ml" ]
-    ; description = "Legacy advisory cost threshold exceeded"
-    }
   ; { signal = "Context_window_usage"
     ; producer_files = [ "lib/pipeline/pipeline.ml" ]
     ; description =

--- a/test/telemetry_sca/test_telemetry_sca.ml
+++ b/test/telemetry_sca/test_telemetry_sca.ml
@@ -62,7 +62,6 @@ let test_registry_covers_all_variants () =
     ; "Thinking_complete"
     ; "Timeout"
     ; "Prefill_complete"
-    ; "Budget_exceeded"
     ; "Context_window_usage"
     ]
   in

--- a/test/test_agent.ml
+++ b/test/test_agent.ml
@@ -245,89 +245,6 @@ let test_replace_preserves_other_results () =
     Alcotest.fail (Printf.sprintf "unexpected content: %d blocks" (List.length other))
 ;;
 
-(* --- check_token_budget --- *)
-
-let test_budget_no_limit () =
-  let config = { default_config with max_input_tokens = None; max_total_tokens = None } in
-  let usage =
-    { empty_usage with total_input_tokens = 999999; total_output_tokens = 999999 }
-  in
-  Alcotest.(check bool)
-    "no limit set"
-    true
-    (Agent_turn.check_token_budget config usage = None)
-;;
-
-let test_budget_input_within () =
-  let config = { default_config with max_input_tokens = Some 1000 } in
-  let usage = { empty_usage with total_input_tokens = 500 } in
-  Alcotest.(check bool)
-    "within budget"
-    true
-    (Agent_turn.check_token_budget config usage = None)
-;;
-
-let test_budget_input_exceeded () =
-  let config = { default_config with max_input_tokens = Some 1000 } in
-  let usage = { empty_usage with total_input_tokens = 1500 } in
-  match Agent_turn.check_token_budget config usage with
-  | Some msg ->
-    Alcotest.(check bool)
-      "contains exceeded"
-      true
-      (String.length (Error.to_string msg) > 0)
-  | None -> Alcotest.fail "expected budget exceeded"
-;;
-
-let test_budget_total_exceeded () =
-  let config = { default_config with max_total_tokens = Some 2000 } in
-  let usage =
-    { empty_usage with total_input_tokens = 1200; total_output_tokens = 1000 }
-  in
-  match Agent_turn.check_token_budget config usage with
-  | Some msg ->
-    Alcotest.(check bool)
-      "contains exceeded"
-      true
-      (String.length (Error.to_string msg) > 0)
-  | None -> Alcotest.fail "expected total budget exceeded"
-;;
-
-let test_budget_total_within () =
-  let config = { default_config with max_total_tokens = Some 5000 } in
-  let usage =
-    { empty_usage with total_input_tokens = 1200; total_output_tokens = 1000 }
-  in
-  Alcotest.(check bool)
-    "within total budget"
-    true
-    (Agent_turn.check_token_budget config usage = None)
-;;
-
-let test_budget_input_priority () =
-  (* When both limits are set and input is exceeded, input error takes priority *)
-  let config =
-    { default_config with max_input_tokens = Some 100; max_total_tokens = Some 5000 }
-  in
-  let usage = { empty_usage with total_input_tokens = 200; total_output_tokens = 10 } in
-  match Agent_turn.check_token_budget config usage with
-  | Some msg ->
-    Alcotest.(check bool)
-      "input mentioned"
-      true
-      (let s = Error.to_string msg in
-       let len = String.length s in
-       let rec find i =
-         if i + 5 > len
-         then false
-         else if String.sub s i 5 = "Input"
-         then true
-         else find (i + 1)
-       in
-       find 0)
-  | None -> Alcotest.fail "expected input budget exceeded"
-;;
-
 let () =
   Alcotest.run
     "Agent"
@@ -346,14 +263,6 @@ let () =
             "preserves siblings"
             `Quick
             test_replace_preserves_other_results
-        ] )
-    ; ( "check_token_budget"
-      , [ Alcotest.test_case "no limit" `Quick test_budget_no_limit
-        ; Alcotest.test_case "input within" `Quick test_budget_input_within
-        ; Alcotest.test_case "input exceeded" `Quick test_budget_input_exceeded
-        ; Alcotest.test_case "total exceeded" `Quick test_budget_total_exceeded
-        ; Alcotest.test_case "total within" `Quick test_budget_total_within
-        ; Alcotest.test_case "input priority" `Quick test_budget_input_priority
         ] )
     ; ( "exit_condition"
       , [ Alcotest.test_case "error type round-trip" `Quick (fun () ->

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -523,39 +523,6 @@ let test_filter_valid_same_role_adjacency () =
   | _ -> Alcotest.fail "expected Assistant"
 ;;
 
-(* ── check_token_budget tests ────────────────────────────── *)
-
-let test_token_budget_within () =
-  let config = { Types.default_config with max_input_tokens = Some 1000 } in
-  let usage = { Types.empty_usage with total_input_tokens = 500 } in
-  Alcotest.(check (option reject))
-    "within budget"
-    None
-    (Agent_turn.check_token_budget config usage)
-;;
-
-let test_token_budget_exceeded () =
-  let config = { Types.default_config with max_input_tokens = Some 100 } in
-  let usage = { Types.empty_usage with total_input_tokens = 200 } in
-  match Agent_turn.check_token_budget config usage with
-  | Some (Error.Agent (TokenBudgetExceeded { kind; used; limit })) ->
-    Alcotest.(check string) "kind" "Input" kind;
-    Alcotest.(check int) "used" 200 used;
-    Alcotest.(check int) "limit" 100 limit
-  | _ -> Alcotest.fail "expected TokenBudgetExceeded"
-;;
-
-let test_token_budget_total_exceeded () =
-  let config = { Types.default_config with max_total_tokens = Some 100 } in
-  let usage =
-    { Types.empty_usage with total_input_tokens = 60; total_output_tokens = 50 }
-  in
-  match Agent_turn.check_token_budget config usage with
-  | Some (Error.Agent (TokenBudgetExceeded { kind; _ })) ->
-    Alcotest.(check string) "kind" "Total" kind
-  | _ -> Alcotest.fail "expected TokenBudgetExceeded for total"
-;;
-
 (* ── make_tool_results tests ─────────────────────────────── *)
 
 let test_make_tool_results () =
@@ -762,43 +729,6 @@ let test_idle_non_tool_use_ignored () =
       ~tool_uses
   in
   Alcotest.(check bool) "first not idle" false r1.is_idle
-;;
-
-(* ── check_token_budget: no limits ──────────────────────── *)
-
-let test_token_budget_no_limits () =
-  let config = Types.default_config in
-  let usage =
-    { Types.empty_usage with total_input_tokens = 999999; total_output_tokens = 999999 }
-  in
-  Alcotest.(check (option reject))
-    "no limits"
-    None
-    (Agent_turn.check_token_budget config usage)
-;;
-
-let test_token_budget_input_priority_over_total () =
-  let config =
-    { Types.default_config with max_input_tokens = Some 100; max_total_tokens = Some 200 }
-  in
-  let usage =
-    { Types.empty_usage with total_input_tokens = 150; total_output_tokens = 50 }
-  in
-  match Agent_turn.check_token_budget config usage with
-  | Some (Error.Agent (TokenBudgetExceeded { kind; _ })) ->
-    Alcotest.(check string) "input takes priority" "Input" kind
-  | _ -> Alcotest.fail "expected input budget error"
-;;
-
-let test_token_budget_total_within () =
-  let config = { Types.default_config with max_total_tokens = Some 500 } in
-  let usage =
-    { Types.empty_usage with total_input_tokens = 200; total_output_tokens = 200 }
-  in
-  Alcotest.(check (option reject))
-    "total within"
-    None
-    (Agent_turn.check_token_budget config usage)
 ;;
 
 (* ── apply_context_injection ─────────────────────────────── *)
@@ -1087,17 +1017,6 @@ let () =
             test_filter_valid_same_role_adjacency
         ; Alcotest.test_case "alternating" `Quick test_filter_valid_alternating
         ; Alcotest.test_case "all same role" `Quick test_filter_valid_all_same_role
-        ] )
-    ; ( "check_token_budget"
-      , [ Alcotest.test_case "within budget" `Quick test_token_budget_within
-        ; Alcotest.test_case "input exceeded" `Quick test_token_budget_exceeded
-        ; Alcotest.test_case "total exceeded" `Quick test_token_budget_total_exceeded
-        ; Alcotest.test_case "no limits" `Quick test_token_budget_no_limits
-        ; Alcotest.test_case
-            "input priority"
-            `Quick
-            test_token_budget_input_priority_over_total
-        ; Alcotest.test_case "total within" `Quick test_token_budget_total_within
         ] )
     ; ( "make_tool_results"
       , [ Alcotest.test_case "tool results" `Quick test_make_tool_results ] )

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -646,7 +646,6 @@ let test_with_context_thresholds_explicit () =
     (extract_token_budget reducer)
 ;;
 
-
 (* --- 30. with_context_thresholds: default fallback 200_000 --- *)
 
 let test_with_context_thresholds_default_fallback () =

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -601,40 +601,6 @@ let test_with_thinking_budget () =
     (Agent.state agent).config.thinking_budget
 ;;
 
-(* --- 24. with_max_input_tokens --- *)
-
-let test_with_max_input_tokens () =
-  with_net
-  @@ fun net ->
-  let agent =
-    Builder.create ~net ~model:"claude-sonnet-4-6"
-    |> Builder.with_max_input_tokens 50000
-    |> Builder.build_safe
-    |> Result.get_ok
-  in
-  Alcotest.(check (option int))
-    "max_input_tokens"
-    (Some 50000)
-    (Agent.state agent).config.max_input_tokens
-;;
-
-(* --- 25. with_max_total_tokens --- *)
-
-let test_with_max_total_tokens () =
-  with_net
-  @@ fun net ->
-  let agent =
-    Builder.create ~net ~model:"claude-sonnet-4-6"
-    |> Builder.with_max_total_tokens 100000
-    |> Builder.build_safe
-    |> Result.get_ok
-  in
-  Alcotest.(check (option int))
-    "max_total_tokens"
-    (Some 100000)
-    (Agent.state agent).config.max_total_tokens
-;;
-
 (** Probe message large enough to push [from_context_config]'s dynamic strategy
     into its budgeted branch for the context sizes covered below. *)
 let context_budget_probe_messages =
@@ -680,66 +646,6 @@ let test_with_context_thresholds_explicit () =
     (extract_token_budget reducer)
 ;;
 
-(* --- 27. with_context_thresholds: fallback to max_input_tokens --- *)
-
-let test_with_context_thresholds_fallback_max_input () =
-  with_net
-  @@ fun net ->
-  let agent =
-    Builder.create ~net ~model:"claude-sonnet-4-6"
-    |> Builder.with_max_input_tokens 100000
-    |> Builder.with_context_thresholds ~compact_ratio:0.5
-    |> Builder.build_safe
-    |> Result.get_ok
-  in
-  let reducer = Option.get (Agent.options agent).context_reducer in
-  (* budget = 100000 * 0.5 = 50000 *)
-  Alcotest.(check (option int))
-    "fallback max_input_tokens budget"
-    (Some 50000)
-    (extract_token_budget reducer)
-;;
-
-(* --- 28. with_context_thresholds: max_input_tokens beats max_total_tokens --- *)
-
-let test_with_context_thresholds_input_beats_total () =
-  with_net
-  @@ fun net ->
-  let agent =
-    Builder.create ~net ~model:"claude-sonnet-4-6"
-    |> Builder.with_max_input_tokens 80000
-    |> Builder.with_max_total_tokens 200000
-    |> Builder.with_context_thresholds ~compact_ratio:0.5
-    |> Builder.build_safe
-    |> Result.get_ok
-  in
-  let reducer = Option.get (Agent.options agent).context_reducer in
-  (* max_input_tokens (80000) preferred over max_total_tokens; budget = 80000 * 0.5 = 40000 *)
-  Alcotest.(check (option int))
-    "max_input_tokens beats max_total_tokens"
-    (Some 40000)
-    (extract_token_budget reducer)
-;;
-
-(* --- 29. with_context_thresholds: fallback to max_total_tokens --- *)
-
-let test_with_context_thresholds_fallback_max_total () =
-  with_net
-  @@ fun net ->
-  let agent =
-    Builder.create ~net ~model:"claude-sonnet-4-6"
-    |> Builder.with_max_total_tokens 60000
-    |> Builder.with_context_thresholds ~compact_ratio:0.5
-    |> Builder.build_safe
-    |> Result.get_ok
-  in
-  let reducer = Option.get (Agent.options agent).context_reducer in
-  (* budget = 60000 * 0.5 = 30000 *)
-  Alcotest.(check (option int))
-    "fallback max_total_tokens budget"
-    (Some 30000)
-    (extract_token_budget reducer)
-;;
 
 (* --- 30. with_context_thresholds: default fallback 200_000 --- *)
 
@@ -802,18 +708,26 @@ let test_with_context_thresholds_fallback_from_provider () =
 let test_with_context_thresholds_invalid_ignored () =
   with_net
   @@ fun net ->
+  (* A qwen3 provider yields a known max_context_tokens (262_144); an explicit
+     [context_window_tokens:0] must be ignored, so the budget falls through to
+     the provider-derived value (262_144 * 0.5 = 131_072) rather than 0. *)
+  let provider : Provider.config =
+    { provider = Local { base_url = "http://localhost:11434" }
+    ; model_id = "qwen3-35b"
+    ; api_key_env = "DUMMY"
+    }
+  in
   let agent =
     Builder.create ~net ~model:"claude-sonnet-4-6"
-    |> Builder.with_max_input_tokens 50000
+    |> Builder.with_provider provider
     |> Builder.with_context_thresholds ~compact_ratio:0.5 ~context_window_tokens:0
     |> Builder.build_safe
     |> Result.get_ok
   in
   let reducer = Option.get (Agent.options agent).context_reducer in
-  (* context_window_tokens:0 is ignored; falls back to max_input_tokens 50000; budget = 25000 *)
   Alcotest.(check (option int))
-    "zero context_window_tokens ignored"
-    (Some 25000)
+    "zero context_window_tokens ignored; provider fallback"
+    (Some 131_072)
     (extract_token_budget reducer)
 ;;
 
@@ -927,8 +841,6 @@ let test_defaults_match_agent_create () =
     "cache_system_prompt"
     dc.cache_system_prompt
     bc.cache_system_prompt;
-  Alcotest.(check (option int)) "max_input_tokens" dc.max_input_tokens bc.max_input_tokens;
-  Alcotest.(check (option int)) "max_total_tokens" dc.max_total_tokens bc.max_total_tokens;
   Alcotest.(check string)
     "base_url"
     (Agent.options direct_agent).base_url
@@ -1024,24 +936,10 @@ let () =
             test_with_contract_injects_context_metadata
         ; Alcotest.test_case "tool_choice" `Quick test_with_tool_choice
         ; Alcotest.test_case "thinking_budget" `Quick test_with_thinking_budget
-        ; Alcotest.test_case "max_input_tokens" `Quick test_with_max_input_tokens
-        ; Alcotest.test_case "max_total_tokens" `Quick test_with_max_total_tokens
         ; Alcotest.test_case
             "context_thresholds explicit"
             `Quick
             test_with_context_thresholds_explicit
-        ; Alcotest.test_case
-            "context_thresholds fallback max_input"
-            `Quick
-            test_with_context_thresholds_fallback_max_input
-        ; Alcotest.test_case
-            "context_thresholds input beats total"
-            `Quick
-            test_with_context_thresholds_input_beats_total
-        ; Alcotest.test_case
-            "context_thresholds fallback max_total"
-            `Quick
-            test_with_context_thresholds_fallback_max_total
         ; Alcotest.test_case
             "context_thresholds default fallback"
             `Quick

--- a/test/test_builder_coverage.ml
+++ b/test/test_builder_coverage.ml
@@ -3,7 +3,7 @@
 
     Focuses on:
     - Builder chainable API: with_* methods not yet covered
-    - build_safe validation: invalid max_turns, max_tokens, thinking_budget, max_cost_usd
+    - build_safe validation: invalid max_turns, max_tokens, thinking_budget
     - Agent accessors: state, tools, context, options, description
     - Agent.default_options fields
     - Agent.clone *)
@@ -60,8 +60,6 @@ let test_builder_response_format () =
     Builder.create ~net:env#net ~model:Types.default_config.model
     |> Builder.with_response_format_json true
     |> Builder.with_cache_system_prompt true
-    |> Builder.with_max_input_tokens 50000
-    |> Builder.with_max_total_tokens 100000
     |> Builder.with_disable_parallel_tool_use true
   in
   match Builder.build_safe b with
@@ -92,18 +90,6 @@ let test_builder_initial_messages () =
   let b =
     Builder.create ~net:env#net ~model:Types.default_config.model
     |> Builder.with_initial_messages msgs
-  in
-  match Builder.build_safe b with
-  | Ok _agent -> ()
-  | Error e -> Alcotest.fail (Error.to_string e)
-;;
-
-let test_builder_max_cost () =
-  Eio_main.run
-  @@ fun env ->
-  let b =
-    Builder.create ~net:env#net ~model:Types.default_config.model
-    |> Builder.with_max_cost_usd 5.0
   in
   match Builder.build_safe b with
   | Ok _agent -> ()
@@ -153,20 +139,6 @@ let test_build_safe_thinking_budget_without_enable () =
     Alcotest.(check string) "field" "thinking_budget" field
   | Error _ -> Alcotest.fail "expected InvalidConfig for thinking_budget"
   | Ok _ -> Alcotest.fail "expected Error for thinking_budget without enable"
-;;
-
-let test_build_safe_negative_max_cost () =
-  Eio_main.run
-  @@ fun env ->
-  let b =
-    Builder.create ~net:env#net ~model:Types.default_config.model
-    |> Builder.with_max_cost_usd (-1.0)
-  in
-  match Builder.build_safe b with
-  | Error (Error.Config (Error.InvalidConfig { field; _ })) ->
-    Alcotest.(check string) "field" "max_cost_usd" field
-  | Error _ -> Alcotest.fail "expected InvalidConfig for max_cost_usd"
-  | Ok _ -> Alcotest.fail "expected Error for negative max_cost_usd"
 ;;
 
 (* ── Agent accessors ──────────────────────────────────────── *)
@@ -319,7 +291,6 @@ let () =
         ; Alcotest.test_case "response format" `Quick test_builder_response_format
         ; Alcotest.test_case "tool choice" `Quick test_builder_tool_choice
         ; Alcotest.test_case "initial messages" `Quick test_builder_initial_messages
-        ; Alcotest.test_case "max cost" `Quick test_builder_max_cost
         ; Alcotest.test_case "with event_bus" `Quick test_builder_with_event_bus
         ] )
     ; ( "build_safe_validation"
@@ -332,7 +303,6 @@ let () =
             "thinking without enable"
             `Quick
             test_build_safe_thinking_budget_without_enable
-        ; Alcotest.test_case "negative max_cost" `Quick test_build_safe_negative_max_cost
         ] )
     ; ( "agent_accessors"
       , [ Alcotest.test_case "state/tools/context/desc" `Quick test_agent_accessors

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -44,8 +44,6 @@ let make_checkpoint
   ; response_format = Types.Off
   ; thinking_budget = None
   ; cache_system_prompt = false
-  ; max_input_tokens = None
-  ; max_total_tokens = None
   ; context
   ; mcp_sessions
   ; working_context = None
@@ -136,8 +134,6 @@ let () =
                 ; "response_format_json", `Bool true
                 ; "thinking_budget", `Null
                 ; "cache_system_prompt", `Bool false
-                ; "max_input_tokens", `Null
-                ; "max_total_tokens", `Null
                 ; "context", `Assoc []
                 ; "mcp_sessions", `List []
                 ; "working_context", `Null

--- a/test/test_checkpoint_delta.ml
+++ b/test/test_checkpoint_delta.ml
@@ -145,8 +145,6 @@ let checkpoint_gen =
   let* response_format = response_format_gen in
   let* thinking_budget = option (int_range 0 2048) in
   let* cache_system_prompt = bool in
-  let* max_input_tokens = option (int_range 0 4096) in
-  let* max_total_tokens = option (int_range 0 4096) in
   let* context = context_gen in
   let* mcp_sessions = list_size (int_range 0 1) mcp_info_gen in
   let* working_context = option yojson_simple_gen in
@@ -172,8 +170,6 @@ let checkpoint_gen =
     ; response_format
     ; thinking_budget
     ; cache_system_prompt
-    ; max_input_tokens
-    ; max_total_tokens
     ; context
     ; mcp_sessions
     ; working_context
@@ -234,8 +230,6 @@ let make_unit_checkpoint
   ; response_format = Off
   ; thinking_budget = None
   ; cache_system_prompt = false
-  ; max_input_tokens = None
-  ; max_total_tokens = None
   ; context
   ; mcp_sessions = []
   ; working_context
@@ -351,8 +345,6 @@ let test_delta_json_all_replacement_ops () =
     ; disable_parallel_tool_use = true
     ; response_format = JsonSchema (`Assoc [ "type", `String "object" ])
     ; cache_system_prompt = true
-    ; max_input_tokens = Some 2048
-    ; max_total_tokens = Some 4096
     ; mcp_sessions = [ sample_mcp_session ]
     ; working_context = Some (`Assoc [ "kind", `String "full_replace" ])
     }
@@ -428,8 +420,6 @@ let test_delta_json_null_and_legacy_limit_paths () =
           ; "response_format", `Null
           ; "response_format_json", `Bool true
           ; "cache_system_prompt", `Bool false
-          ; "max_input_tokens", `Null
-          ; "max_total_tokens", `Null
           ]
       ]
   in

--- a/test/test_checkpoint_store.ml
+++ b/test/test_checkpoint_store.ml
@@ -33,8 +33,6 @@ let make_checkpoint ?(session_id = "test-session") ?(created_at = 1000.0) ()
   ; response_format = Types.Off
   ; thinking_budget = None
   ; cache_system_prompt = false
-  ; max_input_tokens = None
-  ; max_total_tokens = None
   ; context = Context.create ()
   ; mcp_sessions = []
   ; working_context = None

--- a/test/test_cost_integration.ml
+++ b/test/test_cost_integration.ml
@@ -136,62 +136,6 @@ let test_report_format () =
   Alcotest.(check int) "calls" 5 r.api_calls
 ;;
 
-(* ── Budget check tests ──────────────────────────────── *)
-
-let test_budget_under () =
-  let config = { default_config with max_cost_usd = Some 1.0 } in
-  let usage : Types.usage_stats =
-    { total_input_tokens = 0
-    ; total_output_tokens = 0
-    ; total_cache_creation_input_tokens = 0
-    ; total_cache_read_input_tokens = 0
-    ; api_calls = 0
-    ; estimated_cost_usd = 0.5
-    ; unpriced_model = None
-    }
-  in
-  Alcotest.(check bool)
-    "under budget"
-    true
-    (Option.is_none (Cost_tracker.check_budget config usage))
-;;
-
-let test_budget_exceeded () =
-  let config = { default_config with max_cost_usd = Some 1.0 } in
-  let usage : Types.usage_stats =
-    { total_input_tokens = 0
-    ; total_output_tokens = 0
-    ; total_cache_creation_input_tokens = 0
-    ; total_cache_read_input_tokens = 0
-    ; api_calls = 0
-    ; estimated_cost_usd = 1.5
-    ; unpriced_model = None
-    }
-  in
-  Alcotest.(check bool)
-    "over advisory threshold"
-    true
-    (Option.is_none (Cost_tracker.check_budget config usage))
-;;
-
-let test_no_budget_unlimited () =
-  let config = { default_config with max_cost_usd = None } in
-  let usage : Types.usage_stats =
-    { total_input_tokens = 0
-    ; total_output_tokens = 0
-    ; total_cache_creation_input_tokens = 0
-    ; total_cache_read_input_tokens = 0
-    ; api_calls = 0
-    ; estimated_cost_usd = 999.0
-    ; unpriced_model = None
-    }
-  in
-  Alcotest.(check bool)
-    "no limit"
-    true
-    (Option.is_none (Cost_tracker.check_budget config usage))
-;;
-
 (* ── Suite ───────────────────────────────────────────── *)
 
 let () =
@@ -207,11 +151,6 @@ let () =
     ; ( "report"
       , [ test_case "zero division safe" `Quick test_report_zero_division
         ; test_case "format" `Quick test_report_format
-        ] )
-    ; ( "budget"
-      , [ test_case "under budget" `Quick test_budget_under
-        ; test_case "exceeded" `Quick test_budget_exceeded
-        ; test_case "no budget unlimited" `Quick test_no_budget_unlimited
         ] )
     ]
 ;;

--- a/test/test_cost_tracker.ml
+++ b/test/test_cost_tracker.ml
@@ -24,83 +24,6 @@ let make_usage
   }
 ;;
 
-let make_config ?max_cost_usd () : Types.agent_config =
-  { Types.default_config with max_cost_usd }
-;;
-
-let test_check_budget_no_limit () =
-  let config = make_config () in
-  let usage = make_usage ~cost:100.0 () in
-  check
-    bool
-    "no limit = no error"
-    true
-    (Option.is_none (Cost_tracker.check_budget config usage))
-;;
-
-let test_check_budget_under () =
-  let config = make_config ~max_cost_usd:1.0 () in
-  let usage = make_usage ~cost:0.5 () in
-  check
-    bool
-    "under budget = no error"
-    true
-    (Option.is_none (Cost_tracker.check_budget config usage))
-;;
-
-let test_check_budget_at_limit () =
-  let config = make_config ~max_cost_usd:1.0 () in
-  let usage = make_usage ~cost:1.0 () in
-  check
-    bool
-    "at limit = no error"
-    true
-    (Option.is_none (Cost_tracker.check_budget config usage))
-;;
-
-let test_check_budget_exceeded_is_advisory () =
-  let config = make_config ~max_cost_usd:1.0 () in
-  let usage = make_usage ~cost:1.001 () in
-  check
-    bool
-    "over advisory threshold = no execution error"
-    true
-    (Option.is_none (Cost_tracker.check_budget config usage))
-;;
-
-let test_check_budget_zero_limit () =
-  let config = make_config ~max_cost_usd:0.0 () in
-  let usage = make_usage ~cost:0.001 () in
-  check
-    bool
-    "zero limit + any cost = still advisory"
-    true
-    (Option.is_none (Cost_tracker.check_budget config usage))
-;;
-
-(* Regression: unknown model id used to leave estimated_cost_usd at 0
-   so cost telemetry under-reported.  accumulate_usage still stamps
-   unpriced_model = Some <id>, but check_budget remains advisory. *)
-let test_check_budget_unpriced_model_is_advisory () =
-  let config = make_config ~max_cost_usd:1.0 () in
-  let usage = make_usage ~cost:0.0 ~unpriced_model:(Some "mystery-model-7") () in
-  check
-    bool
-    "unpriced model + cap = no execution error"
-    true
-    (Option.is_none (Cost_tracker.check_budget config usage))
-;;
-
-let test_check_budget_unpriced_model_no_cap_returns_none () =
-  let config = make_config () in
-  let usage = make_usage ~cost:0.0 ~unpriced_model:(Some "mystery") () in
-  check
-    bool
-    "no cap configured + unpriced model = None"
-    true
-    (Option.is_none (Cost_tracker.check_budget config usage))
-;;
-
 (* ── Cost Report ───────────────────────────────────── *)
 
 let test_report_basic () =
@@ -236,25 +159,7 @@ let test_offload_special_chars_in_name () =
 let () =
   run
     "cost_and_offload"
-    [ ( "cost_budget"
-      , [ test_case "no limit" `Quick test_check_budget_no_limit
-        ; test_case "under budget" `Quick test_check_budget_under
-        ; test_case "at limit" `Quick test_check_budget_at_limit
-        ; test_case
-            "exceeded remains advisory"
-            `Quick
-            test_check_budget_exceeded_is_advisory
-        ; test_case "zero limit" `Quick test_check_budget_zero_limit
-        ; test_case
-            "unpriced model + cap = advisory"
-            `Quick
-            test_check_budget_unpriced_model_is_advisory
-        ; test_case
-            "unpriced model + no cap = None"
-            `Quick
-            test_check_budget_unpriced_model_no_cap_returns_none
-        ] )
-    ; ( "cost_report"
+    [ ( "cost_report"
       , [ test_case "basic report" `Quick test_report_basic
         ; test_case "zero calls" `Quick test_report_zero_calls
         ; test_case "to_string" `Quick test_report_to_string

--- a/test/test_error.ml
+++ b/test/test_error.ml
@@ -54,17 +54,6 @@ let test_provider_timeout_phase () =
     (Error.to_string err)
 ;;
 
-let test_agent_token_budget () =
-  let err =
-    Error.Agent (TokenBudgetExceeded { kind = "Input"; used = 1500; limit = 1000 })
-  in
-  check
-    string
-    "token budget"
-    "Input token budget exceeded: 1500/1000"
-    (Error.to_string err)
-;;
-
 let test_agent_execution_timeout () =
   let err =
     Error.Agent
@@ -260,7 +249,6 @@ let () =
         ; test_case "Api AuthError" `Quick test_api_auth_error
         ; test_case "Provider timeout phase" `Quick test_provider_timeout_phase
         ; test_case "Agent MaxTurnsExceeded" `Quick test_agent_max_turns
-        ; test_case "Agent TokenBudgetExceeded" `Quick test_agent_token_budget
         ; test_case "Agent AgentExecutionTimeout" `Quick test_agent_execution_timeout
         ; test_case "Agent UnrecognizedStopReason" `Quick test_agent_stop_reason
         ; test_case "Mcp ServerStartFailed" `Quick test_mcp_server_start

--- a/test/test_error_domain.ml
+++ b/test/test_error_domain.ml
@@ -156,7 +156,6 @@ let test_to_string_each_variant () =
     ; `Tool_exec_failed ("search", "crash")
     ; `Tool_timeout ("calc", 30.0)
     ; `Max_turns_exceeded (20, 10)
-    ; `Token_budget_exceeded (5000, 4000)
     ; `Idle_detected 5
     ; `Agent_execution_timeout (12.0, 10.0, 4, 8)
     ; `Unrecognized_stop_reason "weird"
@@ -196,7 +195,6 @@ let test_all_variants_convert () =
     ; `Tool_exec_failed ("t", "d")
     ; `Tool_timeout ("t", 1.0)
     ; `Max_turns_exceeded (1, 2)
-    ; `Token_budget_exceeded (100, 50)
     ; `Idle_detected 3
     ; `Agent_execution_timeout (12.0, 10.0, 4, 8)
     ; `Unrecognized_stop_reason "x"
@@ -363,20 +361,6 @@ let test_retryable_context_overflow () =
     "context_overflow not retryable"
     false
     (Error_domain.is_retryable (`Context_overflow ("overflow", Some 8192)))
-;;
-
-let test_roundtrip_agent_token_budget () =
-  let orig =
-    Error.Agent (TokenBudgetExceeded { kind = "total"; used = 500; limit = 100 })
-  in
-  let poly = Error_domain.of_sdk_error orig in
-  (match poly with
-   | `Token_budget_exceeded (500, 100) -> ()
-   | _ -> Alcotest.fail "expected Token_budget_exceeded");
-  let back = Error_domain.to_sdk_error poly in
-  match back with
-  | Error.Agent (TokenBudgetExceeded { used = 500; limit = 100; _ }) -> ()
-  | _ -> Alcotest.fail "roundtrip mismatch for TokenBudgetExceeded"
 ;;
 
 let test_roundtrip_agent_idle_detected () =
@@ -584,13 +568,6 @@ let test_retryable_tool_timeout () =
     (Error_domain.is_retryable (`Tool_timeout ("t", 1.0)))
 ;;
 
-let test_retryable_token_budget () =
-  Alcotest.(check bool)
-    "token_budget not retryable"
-    false
-    (Error_domain.is_retryable (`Token_budget_exceeded (100, 50)))
-;;
-
 let test_retryable_idle_detected () =
   Alcotest.(check bool)
     "idle_detected not retryable"
@@ -768,7 +745,6 @@ let () =
             "agent execution_timeout"
             `Quick
             test_roundtrip_agent_execution_timeout
-        ; Alcotest.test_case "agent token_budget" `Quick test_roundtrip_agent_token_budget
         ; Alcotest.test_case
             "agent idle_detected"
             `Quick
@@ -816,7 +792,6 @@ let () =
         ; Alcotest.test_case "invalid_request" `Quick test_retryable_invalid_request
         ; Alcotest.test_case "context_overflow" `Quick test_retryable_context_overflow
         ; Alcotest.test_case "max_turns" `Quick test_retryable_max_turns
-        ; Alcotest.test_case "token_budget" `Quick test_retryable_token_budget
         ; Alcotest.test_case "idle_detected" `Quick test_retryable_idle_detected
         ; Alcotest.test_case "unrecognized_stop" `Quick test_retryable_unrecognized_stop
         ; Alcotest.test_case "missing_env_var" `Quick test_retryable_missing_env_var

--- a/test/test_harness.ml
+++ b/test/test_harness.ml
@@ -115,9 +115,7 @@ let test_performance_evaluate () =
     ; turn_count = 3
     }
   in
-  let exp =
-    { Harness.Performance.default_expectation with max_turns = Some 5 }
-  in
+  let exp = { Harness.Performance.default_expectation with max_turns = Some 5 } in
   let verdict = Harness.Performance.evaluate obs exp in
   Alcotest.(check bool) "within budget" true verdict.passed
 ;;

--- a/test/test_harness.ml
+++ b/test/test_harness.ml
@@ -116,10 +116,7 @@ let test_performance_evaluate () =
     }
   in
   let exp =
-    { Harness.Performance.default_expectation with
-      max_total_tokens = Some 1000
-    ; max_turns = Some 5
-    }
+    { Harness.Performance.default_expectation with max_turns = Some 5 }
   in
   let verdict = Harness.Performance.evaluate obs exp in
   Alcotest.(check bool) "within budget" true verdict.passed

--- a/test/test_harness_deep.ml
+++ b/test/test_harness_deep.ml
@@ -122,15 +122,11 @@ let test_performance_all_constraints () =
     }
   in
   let exp : Harness.Performance.expectation =
-    { max_p95_latency_ms = Some 45.0
-    ; max_total_tokens = Some 1500
-    ; max_cost_usd = Some 0.03
-    ; max_turns = Some 5
-    }
+    { max_p95_latency_ms = Some 45.0; max_turns = Some 5 }
   in
   let v = Harness.Performance.evaluate obs exp in
   Alcotest.(check bool) "multiple failures" false v.passed;
-  (* tokens 2000 > 1500, cost 0.05 > 0.03, turns 8 > 5 *)
+  (* p95 50 > 45, turns 8 > 5 *)
   Alcotest.(check bool) "detail lists failures" true (Option.is_some v.detail)
 ;;
 
@@ -161,15 +157,6 @@ let test_performance_latency_only () =
   let v = Harness.Performance.evaluate obs exp in
   (* p95 of [10;20;30] sorted, idx=int(2*0.95)=1 -> 20.0. 20 <= 25 -> pass *)
   Alcotest.(check bool) "latency within limit" true v.passed
-;;
-
-let test_performance_cost_threshold_advisory () =
-  let obs : Harness.Performance.observation =
-    { latencies_ms = []; total_tokens = 0; total_cost_usd = 5.0; turn_count = 0 }
-  in
-  let exp = { Harness.Performance.default_expectation with max_cost_usd = Some 1.0 } in
-  let v = Harness.Performance.evaluate obs exp in
-  Alcotest.(check bool) "cost threshold advisory" true v.passed
 ;;
 
 (* ── Regression: StructuralMatch and FuzzyMatch boundaries ── *)
@@ -504,10 +491,6 @@ let () =
             test_performance_all_constraints
         ; Alcotest.test_case "no constraints" `Quick test_performance_no_constraints
         ; Alcotest.test_case "latency only" `Quick test_performance_latency_only
-        ; Alcotest.test_case
-            "cost threshold advisory"
-            `Quick
-            test_performance_cost_threshold_advisory
         ] )
     ; ( "regression-deep"
       , [ Alcotest.test_case "structural match" `Quick test_regression_structural_match

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -361,8 +361,6 @@ let test_error_domain_full_roundtrip () =
     ; Agent_sdk.Error.Api (Retry.AuthError { message = "bad key" })
     ; Agent_sdk.Error.Api (Retry.ServerError { status = 500; message = "internal" })
     ; Agent_sdk.Error.Agent (MaxTurnsExceeded { turns = 5; limit = 3 })
-    ; Agent_sdk.Error.Agent
-        (TokenBudgetExceeded { kind = "total"; used = 1000; limit = 500 })
     ; Agent_sdk.Error.Agent (IdleDetected { consecutive_idle_turns = 3 })
     ; Agent_sdk.Error.Config (MissingEnvVar { var_name = "API_KEY" })
     ; Agent_sdk.Error.Config (UnsupportedProvider { detail = "unknown" })

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -653,75 +653,6 @@ let test_accumulate_usage_cumulative () =
   Alcotest.(check int) "cumulative calls" 2 after2.api_calls
 ;;
 
-(* ── check_token_budget ──────────────────────────────────── *)
-
-let test_token_budget_no_limit () =
-  let config = Types.default_config in
-  let usage = { Types.empty_usage with total_input_tokens = 999999 } in
-  Alcotest.(check bool)
-    "no limit = None"
-    true
-    (Option.is_none (Agent_turn.check_token_budget config usage))
-;;
-
-let test_token_budget_input_under () =
-  let config = { Types.default_config with max_input_tokens = Some 1000 } in
-  let usage = { Types.empty_usage with total_input_tokens = 500 } in
-  Alcotest.(check bool)
-    "under limit"
-    true
-    (Option.is_none (Agent_turn.check_token_budget config usage))
-;;
-
-let test_token_budget_input_exceeded () =
-  let config = { Types.default_config with max_input_tokens = Some 1000 } in
-  let usage = { Types.empty_usage with total_input_tokens = 1500 } in
-  match Agent_turn.check_token_budget config usage with
-  | Some (Error.Agent (TokenBudgetExceeded { kind; used; limit })) ->
-    Alcotest.(check string) "kind" "Input" kind;
-    Alcotest.(check int) "used" 1500 used;
-    Alcotest.(check int) "limit" 1000 limit
-  | _ -> Alcotest.fail "expected TokenBudgetExceeded"
-;;
-
-let test_token_budget_total_exceeded () =
-  let config = { Types.default_config with max_total_tokens = Some 200 } in
-  let usage =
-    { Types.empty_usage with total_input_tokens = 120; total_output_tokens = 100 }
-  in
-  match Agent_turn.check_token_budget config usage with
-  | Some (Error.Agent (TokenBudgetExceeded { kind; used; limit })) ->
-    Alcotest.(check string) "kind" "Total" kind;
-    Alcotest.(check int) "used" 220 used;
-    Alcotest.(check int) "limit" 200 limit
-  | _ -> Alcotest.fail "expected TokenBudgetExceeded"
-;;
-
-let test_token_budget_total_under () =
-  let config = { Types.default_config with max_total_tokens = Some 500 } in
-  let usage =
-    { Types.empty_usage with total_input_tokens = 200; total_output_tokens = 100 }
-  in
-  Alcotest.(check bool)
-    "under total limit"
-    true
-    (Option.is_none (Agent_turn.check_token_budget config usage))
-;;
-
-let test_token_budget_input_takes_precedence () =
-  (* If both input and total are exceeded, input error is returned *)
-  let config =
-    { Types.default_config with max_input_tokens = Some 100; max_total_tokens = Some 200 }
-  in
-  let usage =
-    { Types.empty_usage with total_input_tokens = 150; total_output_tokens = 100 }
-  in
-  match Agent_turn.check_token_budget config usage with
-  | Some (Error.Agent (TokenBudgetExceeded { kind; _ })) ->
-    Alcotest.(check string) "input takes precedence" "Input" kind
-  | _ -> Alcotest.fail "expected TokenBudgetExceeded"
-;;
-
 (* ── prepare_turn: extra_system_context ──────────────────── *)
 
 let test_prepare_turn_extra_context () =
@@ -1099,17 +1030,6 @@ let () =
       , [ Alcotest.test_case "with response" `Quick test_accumulate_usage_with_response
         ; Alcotest.test_case "no response" `Quick test_accumulate_usage_no_response
         ; Alcotest.test_case "cumulative" `Quick test_accumulate_usage_cumulative
-        ] )
-    ; ( "token_budget"
-      , [ Alcotest.test_case "no limit" `Quick test_token_budget_no_limit
-        ; Alcotest.test_case "input under" `Quick test_token_budget_input_under
-        ; Alcotest.test_case "input exceeded" `Quick test_token_budget_input_exceeded
-        ; Alcotest.test_case "total exceeded" `Quick test_token_budget_total_exceeded
-        ; Alcotest.test_case "total under" `Quick test_token_budget_total_under
-        ; Alcotest.test_case
-            "input precedence"
-            `Quick
-            test_token_budget_input_takes_precedence
         ] )
     ; ( "error_domain"
       , [ Alcotest.test_case "of_sdk_error" `Quick test_error_domain_of_sdk_error

--- a/test/test_property_advanced.ml
+++ b/test/test_property_advanced.ml
@@ -344,30 +344,6 @@ let test_lifecycle_show_non_empty =
     (fun status -> String.length (Agent_lifecycle.show_lifecycle_status status) > 0)
 ;;
 
-(* ── Token Budget Properties ─────────────────────────────────── *)
-
-let test_token_budget_within_limit =
-  QCheck.Test.make
-    ~count:200
-    ~name:"token budget passes when within limit"
-    (QCheck.make (QCheck.Gen.int_range 100 10_000) ~print:string_of_int)
-    (fun limit ->
-       let config = { default_config with max_input_tokens = Some limit } in
-       let usage = { empty_usage with total_input_tokens = limit - 1 } in
-       Agent_turn.check_token_budget config usage = None)
-;;
-
-let test_token_budget_exceeds_limit =
-  QCheck.Test.make
-    ~count:200
-    ~name:"token budget fails when exceeding limit"
-    (QCheck.make (QCheck.Gen.int_range 100 10_000) ~print:string_of_int)
-    (fun limit ->
-       let config = { default_config with max_input_tokens = Some limit } in
-       let usage = { empty_usage with total_input_tokens = limit + 1 } in
-       Agent_turn.check_token_budget config usage <> None)
-;;
-
 (* ── Capabilities Properties ─────────────────────────────────── *)
 
 let test_anthropic_supports_tools =
@@ -410,9 +386,6 @@ let () =
       ; test_token_budget_reducer_respects_limit
       ; (* Lifecycle *)
         test_lifecycle_show_non_empty
-      ; (* Token budget *)
-        test_token_budget_within_limit
-      ; test_token_budget_exceeds_limit
       ; (* Capabilities *)
         test_anthropic_supports_tools
       ]

--- a/test/test_runtime_replay.ml
+++ b/test/test_runtime_replay.ml
@@ -86,8 +86,6 @@ let mk_checkpoint ?(messages = []) ?(created_at = 1.0) ?(turn_count = 0) session
   ; response_format = Types.Off
   ; thinking_budget = None
   ; cache_system_prompt = false
-  ; max_input_tokens = None
-  ; max_total_tokens = None
   ; context = Context.create ()
   ; mcp_sessions = []
   ; working_context = None

--- a/test/test_session_resume.ml
+++ b/test/test_session_resume.ml
@@ -38,8 +38,6 @@ let make_checkpoint
   ; response_format = Types.Off
   ; thinking_budget = None
   ; cache_system_prompt = false
-  ; max_input_tokens = None
-  ; max_total_tokens = None
   ; context
   ; mcp_sessions = []
   ; working_context = None

--- a/test/test_telemetry_event.ml
+++ b/test/test_telemetry_event.ml
@@ -135,20 +135,6 @@ let test_prefill_complete () =
   | _ -> fail "variant mismatch"
 ;;
 
-let test_budget_exceeded () =
-  let ev =
-    Telemetry_event.Budget_exceeded
-      { agent_name = "alpha"; run_id = "run-1"; spent_usd = 1.23; limit_usd = 1.00 }
-  in
-  match roundtrip ev with
-  | Telemetry_event.Budget_exceeded r ->
-    check string "agent_name" "alpha" r.agent_name;
-    check string "run_id" "run-1" r.run_id;
-    check_float "spent_usd" 1.23 r.spent_usd;
-    check_float "limit_usd" 1.00 r.limit_usd
-  | _ -> fail "variant mismatch"
-;;
-
 let test_context_window_usage () =
   let ev =
     Telemetry_event.Context_window_usage
@@ -210,8 +196,6 @@ let test_event_type_name () =
           ; cache_hit = false
           }
       , "prefill_complete" )
-    ; ( Budget_exceeded { agent_name = ""; run_id = ""; spent_usd = 0.0; limit_usd = 0.0 }
-      , "budget_exceeded" )
     ; ( Context_window_usage
           { agent_name = ""
           ; turn = 0
@@ -274,7 +258,6 @@ let () =
         ; test_case "Timeout No_response roundtrip" `Quick test_timeout_no_response
         ; test_case "Timeout Ttft_exceeded roundtrip" `Quick test_timeout_ttft_exceeded
         ; test_case "Prefill_complete roundtrip" `Quick test_prefill_complete
-        ; test_case "Budget_exceeded roundtrip" `Quick test_budget_exceeded
         ; test_case "Context_window_usage roundtrip" `Quick test_context_window_usage
         ] )
     ; "event_type_name", [ test_case "all variants" `Quick test_event_type_name ]

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -208,9 +208,7 @@ let test_default_config () =
   Alcotest.(check bool) "no min_p" true (c.min_p = None);
   Alcotest.(check bool) "no enable_thinking" true (c.enable_thinking = None);
   Alcotest.(check bool) "no thinking_budget" true (c.thinking_budget = None);
-  Alcotest.(check bool) "cache off" false c.cache_system_prompt;
-  Alcotest.(check bool) "no max_input_tokens" true (c.max_input_tokens = None);
-  Alcotest.(check bool) "no max_total_tokens" true (c.max_total_tokens = None)
+  Alcotest.(check bool) "cache off" false c.cache_system_prompt
 ;;
 
 (* ── yojson roundtrips (Phase 3) ──────────────────────────────── *)


### PR DESCRIPTION
## Summary

Removes all cost and token/turn **budget enforcement** from the SDK, keeping cost strictly as observe-only telemetry. Motivated by the principle "observe, don't gate" — execution-gating budgets were either already dead (`Cost_tracker.check_budget` returned `None` unconditionally, documented as "advisory telemetry only") or duplicated a physical limit the provider already enforces.

## What was removed (enforcement)

- **Cost**: dead `Cost_tracker.check_budget` shim, `max_cost_usd` config field + `with_max_cost_usd` builder setter + its validation, harness `max_cost_usd` expectation, and the `CostBudgetExceeded` / `CostBudgetUnenforceable` error variants.
- **Token**: `Agent_turn.check_token_budget` and its loop-guard call site, `max_input_tokens` / `max_total_tokens` config fields, the `TokenBudgetExceeded` error variant, and the checkpoint round-trip mirrors (record / delta / codec / agent_checkpoint).
- **Telemetry**: the now-unproduced `Budget_exceeded` telemetry event and its SCA registry entry (the SCA test `every_signal_has_producer` correctly flagged it as a dead signal).

## What was kept (not enforcement)

- `cost_usd` accumulation + `Cost_tracker.report` / `report_to_string` — observation.
- `thinking_budget` — provider API parameter (reasoning effort), not a self-imposed cap.
- context-window token budget / `Context_reducer` — physical context-limit preprocessing. `Builder.with_context_thresholds` now resolves the window from provider capabilities (and explicit `?context_window_tokens`) instead of the removed token-cap fields.
- `max_turns` and idle detection in the agent loop guard — unchanged termination guarantees.

## Verification

- `dune build @check` — pass.
- `dune build @runtest` — pass (full suite incl. multi-vendor live smoke).
- Budget-enforcement test groups removed; cost-report / context-reducer / provider-capability-fallback tests retained and green.

RFC-WAIVED: surface is `lib/agent`, `lib/base`, `lib/llm_provider`, `lib/checkpoint*`, `lib/harness` — not credential/identity/operator/sandbox/hooks. Pure removal of execution-gating logic, no new abstraction. Not a workaround signature (removes cap/gate logic rather than adding telemetry-as-fix, string classifier, N-of-M patch, or cap/cooldown/dedup/repair).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
