### PR TITLE
feat(event_bus): add turn index to ToolCalled/ToolCompleted for downstream FSM correlation

### DIFF
--- a/docs/EVENT-CATALOG.md
+++ b/docs/EVENT-CATALOG.md
@@ -70,8 +70,8 @@ Pattern-matchable OCaml sum type. **Stable across every provider.**
 | `TurnStarted` | `pipeline/pipeline.ml`, `pipeline/pipeline_input.ml` | Start of a single agent turn |
 | `TurnReady` | `pipeline/pipeline_input.ml` | Tool surface visible to the LLM after guardrails, policy, overrides, and selection |
 | `TurnCompleted` | `pipeline/pipeline.ml`, `pipeline/pipeline_collect.ml` | End of a single agent turn |
-| `ToolCalled` | `agent/agent_tools.ml` | Tool invocation requested by LLM |
-| `ToolCompleted` | `agent/agent_tools.ml` | Tool invocation result available |
+| `ToolCalled` | `agent/agent_tools.ml` | Tool invocation requested by LLM; carries `tool_use_id` and `turn` |
+| `ToolCompleted` | `agent/agent_tools.ml` | Tool invocation result available; carries matching `tool_use_id` and `turn` |
 | `HandoffRequested` | `agent/agent_handoff.ml` | Agent delegates control to another agent |
 | `HandoffCompleted` | `agent/agent_handoff.ml` | Handoff target finished |
 | `ElicitationCompleted` | `pipeline/pipeline.ml`, `pipeline/pipeline_input.ml` | User elicitation round completed |

--- a/examples/observable_agent.ml
+++ b/examples/observable_agent.ml
@@ -34,14 +34,14 @@ let print_event (event : Event_bus.event) =
     Printf.eprintf "%s %s turn %d started\n%!" (dim t) (cyan agent_name) turn
   | TurnCompleted { agent_name; turn } ->
     Printf.eprintf "%s %s turn %d completed\n%!" (dim t) (cyan agent_name) turn
-  | ToolCalled { agent_name; tool_name; input } ->
+  | ToolCalled { agent_name; tool_name; input; turn = _ } ->
     Printf.eprintf
       "%s %s %s called: %s\n%!"
       (dim t)
       (cyan agent_name)
       (yellow tool_name)
       (Yojson.Safe.to_string input)
-  | ToolCompleted { agent_name; tool_name; output } ->
+  | ToolCompleted { agent_name; tool_name; output; turn = _ } ->
     let status =
       match output with
       | Ok { content } -> green (Printf.sprintf "ok: %s" content)

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -324,7 +324,7 @@ let find_and_execute_tool_with_index
         Event_bus.mk_event
           ?correlation_id
           ?run_id
-          (ToolCalled { agent_name; tool_name = name; tool_use_id = id; input })
+          (ToolCalled { agent_name; tool_name = name; tool_use_id = id; input; turn = turn_count })
       in
       (try Event_bus.publish bus ev with
        | exn ->
@@ -598,7 +598,8 @@ let find_and_execute_tool_with_index
              ?correlation_id
              ?run_id
              ?caused_by:tool_called_run_id
-             (ToolCompleted { agent_name; tool_name = name; tool_use_id = id; output }))
+             (ToolCompleted
+                { agent_name; tool_name = name; tool_use_id = id; output; turn = turn_count }))
       with
       | exn ->
         Log.warn

--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -49,12 +49,14 @@ type payload =
       ; tool_name : string
       ; tool_use_id : string
       ; input : Yojson.Safe.t
+      ; turn : int
       }
   | ToolCompleted of
       { agent_name : string
       ; tool_name : string
       ; tool_use_id : string
       ; output : Types.tool_result
+      ; turn : int
       }
   | TurnStarted of
       { agent_name : string

--- a/lib/event_bus.mli
+++ b/lib/event_bus.mli
@@ -75,6 +75,12 @@ type payload =
             timestamp. Empty string when the provider supplied no id.
             @since 0.206.2 *)
       ; input : Yojson.Safe.t
+      ; turn : int
+        (** Zero-based turn index within the current agent run. Lets
+            downstream FSM observers (e.g. MASC) correlate a tool event
+            with the turn that emitted it without reaching into OAS
+            internals. OAS does not interpret this field.
+            @since 0.207.0 (#SSOT-DRIFT-REMEDIATION) *)
       }
   | ToolCompleted of
       { agent_name : string
@@ -83,6 +89,9 @@ type payload =
         (** Same id as the matching [ToolCalled]; see its doc.
             @since 0.206.2 *)
       ; output : Types.tool_result
+      ; turn : int
+        (** Same turn index as the matching [ToolCalled]. See its doc.
+            @since 0.207.0 (#SSOT-DRIFT-REMEDIATION) *)
       }
   | TurnStarted of
       { agent_name : string

--- a/lib/event_forward.ml
+++ b/lib/event_forward.ml
@@ -126,6 +126,7 @@ let event_to_payload (event : Event_bus.event) : event_payload =
         ; "tool_name", `String r.tool_name
         ; "tool_use_id", `String r.tool_use_id
         ; "input", r.input
+        ; "turn", `Int r.turn
         ]
     | ToolCompleted r ->
       `Assoc
@@ -133,6 +134,7 @@ let event_to_payload (event : Event_bus.event) : event_payload =
         ; "tool_name", `String r.tool_name
         ; "tool_use_id", `String r.tool_use_id
         ; "success", `Bool (Result.is_ok r.output)
+        ; "turn", `Int r.turn
         ]
     | TurnStarted r -> `Assoc [ "agent_name", `String r.agent_name; "turn", `Int r.turn ]
     | TurnReady r ->

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -210,6 +210,7 @@ let test_eval_collector_basic () =
           ; tool_name = "t1"
           ; tool_use_id = "tu-test"
           ; input = `Null
+          ; turn = 0
           }));
   Event_bus.publish
     bus
@@ -219,6 +220,7 @@ let test_eval_collector_basic () =
           ; tool_name = "t1"
           ; tool_use_id = "tu-test"
           ; output = Ok { Types.content = "done" }
+          ; turn = 0
           }));
   let rm = Eval_collector.finalize ec in
   (* Check auto-collected metrics *)

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -151,7 +151,12 @@ let test_filter_tools_only () =
     bus
     (ev
        (ToolCalled
-          { agent_name = "a"; tool_name = "calc"; tool_use_id = "tu-test"; input = `Null }));
+          { agent_name = "a"
+          ; tool_name = "calc"
+          ; tool_use_id = "tu-test"
+          ; input = `Null
+          ; turn = 0
+          }));
   Event_bus.publish
     bus
     (ev
@@ -160,6 +165,7 @@ let test_filter_tools_only () =
           ; tool_name = "calc"
           ; tool_use_id = "tu-test"
           ; output = Ok { Types.content = "42" }
+          ; turn = 0
           }));
   Event_bus.publish bus (ev (TurnCompleted { agent_name = "a"; turn = 0 }));
   let events = Event_bus.drain sub in
@@ -186,7 +192,7 @@ let test_accept_all () =
     bus
     (ev
        (ToolCalled
-          { agent_name = "a"; tool_name = "x"; tool_use_id = "tu-test"; input = `Null }));
+          { agent_name = "a"; tool_name = "x"; tool_use_id = "tu-test"; input = `Null; turn = 0 }));
   Event_bus.publish bus (ev (Custom ("test", `Null)));
   let events = Event_bus.drain sub in
   check int "all three events" 3 (List.length events)
@@ -217,7 +223,12 @@ let test_payload_kind_canonical_labels () =
     ; Event_bus.TurnReady { agent_name = "a"; turn = 0; tool_names = [] }, "turn_ready"
     ; Event_bus.TurnCompleted { agent_name = "a"; turn = 0 }, "turn_completed"
     ; ( Event_bus.ToolCalled
-          { agent_name = "a"; tool_name = "f"; tool_use_id = "tu-test"; input = `Null }
+          { agent_name = "a"
+          ; tool_name = "f"
+          ; tool_use_id = "tu-test"
+          ; input = `Null
+          ; turn = 0
+          }
       , "tool_called" )
     ; ( Event_bus.HandoffRequested { from_agent = "a"; to_agent = "b"; reason = "" }
       , "handoff_requested" )
@@ -287,7 +298,7 @@ let test_multiple_event_types () =
     bus
     (ev
        (ToolCalled
-          { agent_name = "a"; tool_name = "f"; tool_use_id = "tu-test"; input = `Null }));
+          { agent_name = "a"; tool_name = "f"; tool_use_id = "tu-test"; input = `Null; turn = 0 }));
   Event_bus.publish
     bus
     (ev
@@ -296,6 +307,7 @@ let test_multiple_event_types () =
           ; tool_name = "f"
           ; tool_use_id = "tu-test"
           ; output = Ok { Types.content = "ok" }
+          ; turn = 0
           }));
   Event_bus.publish bus (ev (TurnCompleted { agent_name = "a"; turn = 0 }));
   Event_bus.publish
@@ -336,12 +348,13 @@ let test_tool_called_fields () =
     bus
     (ev
        (ToolCalled
-          { agent_name = "a"; tool_name = "calc"; tool_use_id = "tu-test"; input }));
+          { agent_name = "a"; tool_name = "calc"; tool_use_id = "tu-test"; input; turn = 0 }));
   match Event_bus.drain sub with
   | [ { payload = ToolCalled r; _ } ] ->
     check string "agent_name" "a" r.agent_name;
     check string "tool_name" "calc" r.tool_name;
-    check string "input json" {|{"x":1}|} (Yojson.Safe.to_string r.input)
+    check string "input json" {|{"x":1}|} (Yojson.Safe.to_string r.input);
+    check int "turn" 0 r.turn
   | _ -> fail "expected ToolCalled"
 ;;
 

--- a/test/test_event_forward.ml
+++ b/test/test_event_forward.ml
@@ -23,7 +23,7 @@ let test_event_type_name () =
     ; ev (Event_bus.TurnStarted { agent_name = "a"; turn = 0 }), "turn.started"
     ; ( ev
           (Event_bus.ToolCalled
-             { agent_name = "a"; tool_name = "t"; tool_use_id = "tu-test"; input = `Null })
+             { agent_name = "a"; tool_name = "t"; tool_use_id = "tu-test"; input = `Null; turn = 0 })
       , "tool.called" )
     ; ( ev
           (Event_bus.ContentReplacementKept
@@ -267,6 +267,7 @@ let test_tool_events_payload () =
          ; tool_name = "search"
          ; tool_use_id = "tu-test"
          ; input = `String "query"
+         ; turn = 1
          })
   in
   let completed =
@@ -276,6 +277,7 @@ let test_tool_events_payload () =
          ; tool_name = "search"
          ; tool_use_id = "tu-test"
          ; output = Ok { Types.content = "result" }
+         ; turn = 1
          })
   in
   let p1 = Event_forward.event_to_payload called in
@@ -481,6 +483,7 @@ let test_tool_completed_error_payload () =
          ; tool_use_id = "tu-test"
          ; output =
              Error { Types.message = "fail"; recoverable = false; error_class = None }
+         ; turn = 2
          })
   in
   let p = Event_forward.event_to_payload evt in

--- a/test/test_multivendor_events.ml
+++ b/test/test_multivendor_events.ml
@@ -57,12 +57,14 @@ let test_envelope_preserved_across_variants () =
         ; tool_name = "echo"
         ; tool_use_id = "tu-test"
         ; input = `Null
+        ; turn = 0
         }
     ; ToolCompleted
         { agent_name = "alpha"
         ; tool_name = "echo"
         ; tool_use_id = "tu-test"
         ; output = stub_tool_result
+        ; turn = 0
         }
     ; TurnCompleted { agent_name = "alpha"; turn = 0 }
     ; HandoffRequested { from_agent = "alpha"; to_agent = "beta"; reason = "delegate" }
@@ -128,13 +130,19 @@ let test_event_type_name_mapping () =
     ; TurnStarted { agent_name = "a"; turn = 0 }, "turn.started"
     ; TurnCompleted { agent_name = "a"; turn = 0 }, "turn.completed"
     ; ( ToolCalled
-          { agent_name = "a"; tool_name = "t"; tool_use_id = "tu-test"; input = `Null }
+          { agent_name = "a"
+          ; tool_name = "t"
+          ; tool_use_id = "tu-test"
+          ; input = `Null
+          ; turn = 0
+          }
       , "tool.called" )
     ; ( ToolCompleted
           { agent_name = "a"
           ; tool_name = "t"
           ; tool_use_id = "tu-test"
           ; output = stub_tool_result
+          ; turn = 0
           }
       , "tool.completed" )
     ; ( HandoffRequested { from_agent = "a"; to_agent = "b"; reason = "r" }
@@ -245,7 +253,12 @@ let test_golden_lifecycle_transcript () =
     bus
     (mk
        (ToolCalled
-          { agent_name = "a"; tool_name = "echo"; tool_use_id = "tu-test"; input = `Null }));
+          { agent_name = "a"
+          ; tool_name = "echo"
+          ; tool_use_id = "tu-test"
+          ; input = `Null
+          ; turn = 0
+          }));
   Event_bus.publish
     bus
     (mk
@@ -254,6 +267,7 @@ let test_golden_lifecycle_transcript () =
           ; tool_name = "echo"
           ; tool_use_id = "tu-test"
           ; output = stub_tool_result
+          ; turn = 0
           }));
   Event_bus.publish bus (mk (TurnCompleted { agent_name = "a"; turn = 0 }));
   Event_bus.publish


### PR DESCRIPTION
Adds a zero-based turn index to [ToolCalled] and [ToolCompleted] event payloads so downstream FSM observers (e.g. MASC) can correlate tool events with the turn that emitted them without reaching into OAS internals.

- Update [lib/event_bus.mli] payload types and [lib/event_bus.ml] emission
- Thread [turn_count] through [lib/agent/agent_tools.ml]
- Include [turn] in [lib/event_forward.ml] JSON output
- Update [docs/EVENT-CATALOG.md], examples, and tests