### PR TITLE
fix(oas): repair main CI — ocamlformat + SDK independence

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -324,7 +324,8 @@ let find_and_execute_tool_with_index
         Event_bus.mk_event
           ?correlation_id
           ?run_id
-          (ToolCalled { agent_name; tool_name = name; tool_use_id = id; input; turn = turn_count })
+          (ToolCalled
+             { agent_name; tool_name = name; tool_use_id = id; input; turn = turn_count })
       in
       (try Event_bus.publish bus ev with
        | exn ->
@@ -599,7 +600,12 @@ let find_and_execute_tool_with_index
              ?run_id
              ?caused_by:tool_called_run_id
              (ToolCompleted
-                { agent_name; tool_name = name; tool_use_id = id; output; turn = turn_count }))
+                { agent_name
+                ; tool_name = name
+                ; tool_use_id = id
+                ; output
+                ; turn = turn_count
+                }))
       with
       | exn ->
         Log.warn

--- a/lib/event_bus.mli
+++ b/lib/event_bus.mli
@@ -77,7 +77,7 @@ type payload =
       ; input : Yojson.Safe.t
       ; turn : int
         (** Zero-based turn index within the current agent run. Lets
-            downstream FSM observers (e.g. MASC) correlate a tool event
+            downstream FSM observers correlate a tool event
             with the turn that emitted it without reaching into OAS
             internals. OAS does not interpret this field.
             @since 0.207.0 (#SSOT-DRIFT-REMEDIATION) *)

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -192,7 +192,12 @@ let test_accept_all () =
     bus
     (ev
        (ToolCalled
-          { agent_name = "a"; tool_name = "x"; tool_use_id = "tu-test"; input = `Null; turn = 0 }));
+          { agent_name = "a"
+          ; tool_name = "x"
+          ; tool_use_id = "tu-test"
+          ; input = `Null
+          ; turn = 0
+          }));
   Event_bus.publish bus (ev (Custom ("test", `Null)));
   let events = Event_bus.drain sub in
   check int "all three events" 3 (List.length events)
@@ -298,7 +303,12 @@ let test_multiple_event_types () =
     bus
     (ev
        (ToolCalled
-          { agent_name = "a"; tool_name = "f"; tool_use_id = "tu-test"; input = `Null; turn = 0 }));
+          { agent_name = "a"
+          ; tool_name = "f"
+          ; tool_use_id = "tu-test"
+          ; input = `Null
+          ; turn = 0
+          }));
   Event_bus.publish
     bus
     (ev
@@ -348,7 +358,12 @@ let test_tool_called_fields () =
     bus
     (ev
        (ToolCalled
-          { agent_name = "a"; tool_name = "calc"; tool_use_id = "tu-test"; input; turn = 0 }));
+          { agent_name = "a"
+          ; tool_name = "calc"
+          ; tool_use_id = "tu-test"
+          ; input
+          ; turn = 0
+          }));
   match Event_bus.drain sub with
   | [ { payload = ToolCalled r; _ } ] ->
     check string "agent_name" "a" r.agent_name;

--- a/test/test_event_forward.ml
+++ b/test/test_event_forward.ml
@@ -23,7 +23,12 @@ let test_event_type_name () =
     ; ev (Event_bus.TurnStarted { agent_name = "a"; turn = 0 }), "turn.started"
     ; ( ev
           (Event_bus.ToolCalled
-             { agent_name = "a"; tool_name = "t"; tool_use_id = "tu-test"; input = `Null; turn = 0 })
+             { agent_name = "a"
+             ; tool_name = "t"
+             ; tool_use_id = "tu-test"
+             ; input = `Null
+             ; turn = 0
+             })
       , "tool.called" )
     ; ( ev
           (Event_bus.ContentReplacementKept


### PR DESCRIPTION
Fixes the two failures on main after merging the adversarial eio PR group.