### PR TITLE
docs(examples): parallel/async tool usage and concurrency guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ let agent =
     ~tools:[] ()
 ```
 
-See `examples/` for more: `basic_agent.ml`, `tool_use.ml`, `streaming.ml`, `review_agent.ml`, `governance_demo.ml`, `plan_execute_demo.ml`, `autonomy_primitives_demo.ml`.
+See `examples/` for more: `basic_agent.ml`, `tool_use.ml`, `async_agent_demo.ml`, `streaming.ml`, `review_agent.ml`, `governance_demo.ml`, `plan_execute_demo.ml`, `autonomy_primitives_demo.ml`.
+For tool concurrency rules see `docs/tool-concurrency.md`.
 
 ## Provider support
 

--- a/docs/tool-concurrency.md
+++ b/docs/tool-concurrency.md
@@ -1,0 +1,86 @@
+# Tool Concurrency and Descriptor Classification
+
+OAS batches tool calls within a single turn based on each tool's
+[concurrency_class](lib/base/tool.mli). The runtime groups consecutive tools
+with the same class into batches and executes them as follows:
+
+- `Parallel_read` — independent read-only tools run concurrently via
+  `Eio.Fiber.List.map`. Results are returned in the original order regardless
+  of completion order.
+- `Sequential_workspace` — workspace-mutating tools run one at a time, in the
+  order requested by the model.
+- `Exclusive_external` — external/network tools run in isolation. Any parallel
+  batch before or after is flushed so the external call never overlaps with
+  another tool.
+
+## Setting the concurrency class
+
+Pass a `Tool.descriptor` with `concurrency_class` to `Tool.create` or
+`Tool.create_with_context`:
+
+```ocaml
+open Agent_sdk
+
+let read_file_tool =
+  let descriptor =
+    { Tool.kind = Some "fs"
+    ; mutation_class = Some "read_only"
+    ; concurrency_class = Some Tool.Parallel_read
+    ; permission = Some Tool.ReadOnly
+    ; evidence_role = None
+    ; shell = None
+    ; notes = []
+    ; examples = []
+    }
+  in
+  Tool.create
+    ~descriptor
+    ~name:"read_file"
+    ~description:"Read a file from the workspace"
+    ~parameters:[]
+    (fun _args -> Ok { Types.content = "contents" })
+```
+
+## External read-only tools must NOT be `Parallel_read`
+
+A tool that calls an external HTTP API (web search, page fetch, payment
+lookup, etc.) should be classified as `Exclusive_external`, not `ReadOnly`
+and not `Parallel_read`. Concurrent external calls can:
+
+- exceed provider rate limits,
+- produce non-deterministic ordering,
+- incur unnecessary cost,
+- violate provider terms of service.
+
+Example:
+
+```ocaml
+let web_search_tool =
+  let descriptor =
+    { Tool.kind = Some "web"
+    ; mutation_class = Some "external_effect"
+    ; concurrency_class = Some Tool.Exclusive_external
+    ; permission = Some Tool.ReadOnly
+    ; evidence_role = None
+    ; shell = None
+    ; notes = []
+    ; examples = []
+    }
+  in
+  Tool.create ~descriptor ~name:"web_search" ~parameters:[] handler
+```
+
+## How MASC wires the class
+
+MASC derives an OAS `Tool.descriptor` in `lib/tool_bridge.ml`. Read-only
+workspace tools map to `Parallel_read`; writes map to `Sequential_workspace`;
+destructive tools map to `Exclusive_external`. Web-search and web-fetch
+aliases (`WebSearch`, `WebFetch`, internal names `masc_web_search`,
+`masc_web_fetch`) are explicitly treated as external-network tools and mapped
+to `Exclusive_external` so the OAS runtime never batches them in parallel.
+
+See also:
+
+- `lib/agent/agent_tools.ml` for the batching implementation.
+- `examples/tool_use.ml` for a runnable example with mixed concurrency classes.
+- `examples/async_agent_demo.ml` for async agents that use tools.

--- a/examples/async_agent_demo.ml
+++ b/examples/async_agent_demo.ml
@@ -1,0 +1,145 @@
+(** Async Agent example — run agents concurrently on Eio fibers.
+
+    Demonstrates:
+    - [Async_agent.spawn] / [await] for a background agent run
+    - [Async_agent.race] to take the first successful result
+    - [Async_agent.all] to collect results from several agents
+    - Async agents using the same tool bundle as synchronous agents
+
+    Tool descriptors carry [concurrency_class] just like synchronous tool
+    calls. A read-only tool can be marked [Parallel_read]; an external API
+    tool should be [Exclusive_external] so it is never batched concurrently
+    with another call.
+
+    Prerequisites:
+    - A running llama-server (or any OpenAI-compatible endpoint) on port 8085
+    - Or set OAS_PROVIDER=anthropic and ANTHROPIC_API_KEY
+
+    Usage:
+      dune exec examples/async_agent_demo.exe *)
+
+open Agent_sdk
+open Types
+
+let read_only_tool =
+  let descriptor =
+    { Tool.kind = Some "demo"
+    ; mutation_class = Some "read_only"
+    ; concurrency_class = Some Tool.Parallel_read
+    ; permission = Some Tool.ReadOnly
+    ; evidence_role = None
+    ; shell = None
+    ; notes = []
+    ; examples = []
+    }
+  in
+  Tool.create
+    ~descriptor
+    ~name:"lookup"
+    ~description:"Lookup a value"
+    ~parameters:
+      [ { name = "key"; description = "Key to look up"; param_type = String; required = true }
+      ]
+    (fun args ->
+       let open Yojson.Safe.Util in
+       match args |> member "key" |> to_string_option with
+       | Some key -> Ok { Types.content = Printf.sprintf "value for %s" key }
+       | None ->
+         Error
+           { Types.message = "missing 'key' parameter"
+           ; recoverable = true
+           ; error_class = None
+           })
+;;
+
+(** External API tools should be marked [Exclusive_external] even when they are
+    read-only. The OAS runtime will then flush any parallel-read batch before
+    and after the call, avoiding concurrent requests against rate-limited
+    remote services. MASC maps [WebSearch]/[WebFetch]-style tools to this
+    class automatically. *)
+let external_fetch_tool =
+  let descriptor =
+    { Tool.kind = Some "demo"
+    ; mutation_class = Some "external_effect"
+    ; concurrency_class = Some Tool.Exclusive_external
+    ; permission = Some Tool.ReadOnly
+    ; evidence_role = None
+    ; shell = None
+    ; notes = [ "External HTTP fetch; never parallelize" ]
+    ; examples = []
+    }
+  in
+  Tool.create
+    ~descriptor
+    ~name:"fetch_url"
+    ~description:"Fetch a URL (simulated)"
+    ~parameters:
+      [ { name = "url"; description = "URL to fetch"; param_type = String; required = true }
+      ]
+    (fun args ->
+       let open Yojson.Safe.Util in
+       match args |> member "url" |> to_string_option with
+       | Some url -> Ok { Types.content = Printf.sprintf "Fetched: %s" url }
+       | None ->
+         Error
+           { Types.message = "missing 'url' parameter"
+           ; recoverable = true
+           ; error_class = None
+           })
+;;
+
+let make_agent ~net name =
+  let config =
+    { default_config with
+      name
+    ; system_prompt = Some "You have a lookup tool. Use it when helpful. Be concise."
+    }
+  in
+  Agent.create ~net ~config ~tools:[ read_only_tool; external_fetch_tool ] ()
+;;
+
+let extract_text (resp : Types.api_response) =
+  List.filter_map
+    (function
+      | Types.Text s -> Some s
+      | _ -> None)
+    resp.content
+  |> String.concat " "
+;;
+
+let () =
+  Eio_main.run
+  @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run
+  @@ fun sw ->
+  (* 1. Spawn a single background agent and await its result. *)
+  let agent_a = make_agent ~net "async-a" in
+  let future_a = Async_agent.spawn ~sw ~clock agent_a "Look up 'fibonacci'." in
+  (match Async_agent.await future_a with
+   | Ok resp -> Printf.printf "[spawn] %s\n" (extract_text resp)
+   | Error e -> Printf.eprintf "[spawn] error: %s\n" (Error.to_string e));
+  (* 2. Race two agents; the first to finish wins, the other is cancelled. *)
+  let agent_b = make_agent ~net "racer-b" in
+  let agent_c = make_agent ~net "racer-c" in
+  (match Async_agent.race ~sw ~clock [ agent_b, "Look up 'ocaml'."; agent_c, "Look up 'eio'." ] with
+   | Ok (name, resp) -> Printf.printf "[race] winner=%s result=%s\n" name (extract_text resp)
+   | Error e -> Printf.eprintf "[race] error: %s\n" (Error.to_string e));
+  (* 3. Run several agents in parallel and collect all results. *)
+  let agents =
+    [ make_agent ~net "fan-1", "Look up 'agent'."
+    ; make_agent ~net "fan-2", "Look up 'sdk'."
+    ; make_agent ~net "fan-3", "Look up 'fiber'."
+    ]
+  in
+  match Async_agent.all ~sw ~clock ~max_fibers:3 agents with
+  | [] -> Printf.eprintf "[all] no results\n"
+  | results ->
+    List.iter
+      (fun (name, result) ->
+         match result with
+         | Ok resp -> Printf.printf "[all] %s -> %s\n" name (extract_text resp)
+         | Error e -> Printf.eprintf "[all] %s error: %s\n" name (Error.to_string e))
+      results
+;;

--- a/examples/dune
+++ b/examples/dune
@@ -2,6 +2,7 @@
  (names
   basic_agent
   tool_use
+  async_agent_demo
   streaming
   review_agent
   codegen_agent

--- a/examples/tool_use.ml
+++ b/examples/tool_use.ml
@@ -4,7 +4,17 @@
     - Defining a tool with parameters and JSON schema
     - Simple handler (pure function)
     - Context-aware handler (stateful via Context.t)
-    - Running an agent with tools
+    - Concurrency classification via [Tool.descriptor]
+
+    [Tool.descriptor.concurrency_class] tells the OAS runtime how a tool may be
+    batched with other tools in a single turn:
+    - [Parallel_read]    : independent read-only tools can run concurrently.
+    - [Sequential_workspace] : workspace-mutating tools run one at a time.
+    - [Exclusive_external]   : external/network tools run in isolation.
+
+    Do NOT mark external API calls as [Parallel_read] even if they are
+    read-only: concurrent requests can hit rate limits or violate provider
+    terms.
 
     Prerequisites:
     - A running llama-server on port 8085 (or set provider accordingly)
@@ -15,8 +25,21 @@
 open Agent_sdk
 open Types
 
+(** A pure read-only tool. Safe to run concurrently with other reads. *)
 let calculator_tool =
+  let descriptor =
+    { Tool.kind = Some "demo"
+    ; mutation_class = Some "read_only"
+    ; concurrency_class = Some Tool.Parallel_read
+    ; permission = Some Tool.ReadOnly
+    ; evidence_role = None
+    ; shell = None
+    ; notes = []
+    ; examples = []
+    }
+  in
   Tool.create
+    ~descriptor
     ~name:"calculator"
     ~description:"Evaluate a math expression"
     ~parameters:
@@ -38,8 +61,59 @@ let calculator_tool =
            })
 ;;
 
+(** An external HTTP-like tool. Marked [Exclusive_external] so the runtime
+    never fires it concurrently with another tool, protecting provider rate
+    limits even though the call is read-only. *)
+let weather_api_tool =
+  let descriptor =
+    { Tool.kind = Some "demo"
+    ; mutation_class = Some "external_effect"
+    ; concurrency_class = Some Tool.Exclusive_external
+    ; permission = Some Tool.ReadOnly
+    ; evidence_role = None
+    ; shell = None
+    ; notes = []
+    ; examples = []
+    }
+  in
+  Tool.create
+    ~descriptor
+    ~name:"weather"
+    ~description:"Fetch current weather for a city"
+    ~parameters:
+      [ { name = "city"
+        ; description = "City name"
+        ; param_type = String
+        ; required = true
+        }
+      ]
+    (fun args ->
+       let open Yojson.Safe.Util in
+       match args |> member "city" |> to_string_option with
+       | Some city -> Ok { Types.content = Printf.sprintf "Weather in %s: sunny" city }
+       | None ->
+         Error
+           { Types.message = "missing 'city' parameter"
+           ; recoverable = true
+           ; error_class = None
+           })
+;;
+
+(** A workspace-mutating tool. Context state survives checkpoints. *)
 let counter_tool =
+  let descriptor =
+    { Tool.kind = Some "demo"
+    ; mutation_class = Some "workspace_mutating"
+    ; concurrency_class = Some Tool.Sequential_workspace
+    ; permission = Some Tool.Write
+    ; evidence_role = None
+    ; shell = None
+    ; notes = []
+    ; examples = []
+    }
+  in
   Tool.create_with_context
+    ~descriptor
     ~name:"counter"
     ~description:"Increment and return a counter"
     ~parameters:[]
@@ -62,11 +136,19 @@ let () =
   let config =
     { default_config with
       name = "tool-demo"
-    ; system_prompt = Some "You have access to a calculator and a counter. Use them."
+    ; system_prompt =
+        Some
+          "You have access to a calculator, a weather API, and a counter. Use them."
     ; max_turns = 3
     }
   in
-  let agent = Agent.create ~net ~config ~tools:[ calculator_tool; counter_tool ] () in
+  let agent =
+    Agent.create
+      ~net
+      ~config
+      ~tools:[ calculator_tool; weather_api_tool; counter_tool ]
+      ()
+  in
   match Agent.run ~sw agent "Calculate 6 * 7, then increment the counter twice." with
   | Ok response ->
     List.iter


### PR DESCRIPTION
## Summary
- Extend examples/tool_use.ml with Parallel_read, Sequential_workspace, and Exclusive_external patterns.
- Add examples/async_agent_demo.ml demonstrating Async_agent spawn/await/race/all.
- Add docs/tool-concurrency.md explaining concurrency classes and best practices.

## Verification
- dune build examples/tool_use.exe examples/async_agent_demo.exe docs/tool-concurrency.md succeeds.

## Related
- MASC companion PR: jeong-sik/masc#<number> (Keeper WebSearch/WebFetch descriptor fixes).