### PR TITLE
feat(llm_provider): reusable HTTP connection cache

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -23,6 +23,7 @@ let complete
       ?runtime_mcp_policy
       ?(trace_context = [])
       ?(cache : Cache.t option)
+      ?(connection_cache : Http_client.cache option)
       ?(metrics : Metrics.t option)
       ?(priority : Request_priority.t option)
       ?body_timeout_s
@@ -86,6 +87,7 @@ let complete
                ?clock
                ~on_http_status:m.on_http_status
                ?body_timeout_s
+               ?connection_cache
                ~config:request_config
                ~messages
                ~tools
@@ -188,6 +190,7 @@ let complete_with_retry
       ?trace_context
       ?(retry_config = default_retry_config)
       ?cache
+      ?connection_cache
       ?metrics
       ?priority
       ?body_timeout_s
@@ -209,6 +212,7 @@ let complete_with_retry
       ?runtime_mcp_policy
       ?trace_context
       ?cache
+      ?connection_cache
       ~metrics:m
       ?priority
       ?body_timeout_s
@@ -268,6 +272,7 @@ let complete_stream
       ~(on_event : Types.sse_event -> unit)
       ?metrics
       ?(priority : Request_priority.t option)
+      ?(connection_cache : Http_client.cache option)
       ?(on_telemetry : (Telemetry_event.t -> unit) option)
       ()
   =
@@ -313,6 +318,7 @@ let complete_stream
           ?stream_idle_timeout_s
           ?on_telemetry
           ~metrics
+          ?connection_cache
           ~config:request_config
           ~messages
           ~tools
@@ -352,6 +358,7 @@ let complete_stream_with_retry
       ~on_event
       ?metrics
       ?priority
+      ?connection_cache
       ?stream_idle_timeout_s
       ?on_telemetry
       ()
@@ -374,6 +381,7 @@ let complete_stream_with_retry
       ~on_event
       ~metrics:m
       ?priority
+      ?connection_cache
       ?stream_idle_timeout_s
       ?on_telemetry
       ()
@@ -418,7 +426,14 @@ let complete_stream_with_retry
 
 (* ── HTTP Transport constructor ─────────────────────── *)
 
-let make_http_transport ?clock ?stream_idle_timeout_s ?body_timeout_s ~sw ~net ()
+let make_http_transport
+      ?clock
+      ?stream_idle_timeout_s
+      ?body_timeout_s
+      ?(connection_cache : Http_client.cache option)
+      ~sw
+      ~net
+      ()
   : Llm_transport.t
   =
   { complete_sync =
@@ -429,6 +444,7 @@ let make_http_transport ?clock ?stream_idle_timeout_s ?body_timeout_s ~sw ~net (
             ~net
             ?clock
             ?body_timeout_s
+            ?connection_cache
             ~config:req.config
             ~messages:req.messages
             ~tools:req.tools
@@ -450,6 +466,7 @@ let make_http_transport ?clock ?stream_idle_timeout_s ?body_timeout_s ~sw ~net (
           ~net
           ?clock
           ?stream_idle_timeout_s
+          ?connection_cache
           ~config:req.config
           ~messages:req.messages
           ~tools:req.tools

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -67,7 +67,8 @@ val make_http_transport
     Otherwise falls back to the built-in HTTP transport.
 
     When [cache] is provided, checks response cache before I/O and stores on success.
-    When [connection_cache] is provided, reuses HTTP connections.
+    When [connection_cache] is provided, the built-in HTTP transport reuses idle
+    connections. It has no effect when a custom [transport] is supplied.
     When [metrics] is provided, fires lifecycle callbacks.
 
     @return [Ok api_response] on success (possibly from cache)

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -45,11 +45,15 @@ val apply_sampling_defaults : Provider_config.t -> Provider_config.t
     {!Llm_transport.t} value that can be passed to [complete]
     or [complete_stream] via [?transport].
 
+    When [connection_cache] is supplied, the transport reuses idle
+    HTTP connections and parks them back after each request.
+
     @since 0.78.0 *)
 val make_http_transport
   :  ?clock:_ Eio.Time.clock
   -> ?stream_idle_timeout_s:float
   -> ?body_timeout_s:float
+  -> ?connection_cache:Http_client.cache
   -> sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> unit
@@ -62,7 +66,8 @@ val make_http_transport
     When [transport] is provided, uses that transport for I/O.
     Otherwise falls back to the built-in HTTP transport.
 
-    When [cache] is provided, checks cache before I/O and stores on success.
+    When [cache] is provided, checks response cache before I/O and stores on success.
+    When [connection_cache] is provided, reuses HTTP connections.
     When [metrics] is provided, fires lifecycle callbacks.
 
     @return [Ok api_response] on success (possibly from cache)
@@ -78,6 +83,7 @@ val complete
   -> ?runtime_mcp_policy:Llm_transport.runtime_mcp_policy
   -> ?trace_context:(string * string) list
   -> ?cache:Cache.t
+  -> ?connection_cache:Http_client.cache
   -> ?metrics:Metrics.t
   -> ?priority:Request_priority.t
   -> ?body_timeout_s:float
@@ -114,7 +120,8 @@ val default_retry_config : retry_config
 val is_retryable : Http_client.http_error -> bool
 
 (** Completion with exponential backoff retry.
-    Passes [transport], [cache] and [metrics] through to each attempt. *)
+    Passes [transport], [cache], [connection_cache] and [metrics]
+    through to each attempt. *)
 val complete_with_retry
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
@@ -127,6 +134,7 @@ val complete_with_retry
   -> ?trace_context:(string * string) list
   -> ?retry_config:retry_config
   -> ?cache:Cache.t
+  -> ?connection_cache:Http_client.cache
   -> ?metrics:Metrics.t
   -> ?priority:Request_priority.t
   -> ?body_timeout_s:float
@@ -181,12 +189,13 @@ val complete_stream
   -> on_event:(Types.sse_event -> unit)
   -> ?metrics:Metrics.t
   -> ?priority:Request_priority.t
+  -> ?connection_cache:Http_client.cache
   -> ?on_telemetry:(Telemetry_event.t -> unit)
   -> unit
   -> (Types.api_response, Http_client.http_error) result
 
 (** Streaming completion with exponential backoff retry.
-    Passes [transport] and [metrics] through to each attempt. *)
+    Passes [transport], [connection_cache] and [metrics] through to each attempt. *)
 val complete_stream_with_retry
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
@@ -201,6 +210,7 @@ val complete_stream_with_retry
   -> on_event:(Types.sse_event -> unit)
   -> ?metrics:Metrics.t
   -> ?priority:Request_priority.t
+  -> ?connection_cache:Http_client.cache
   -> ?stream_idle_timeout_s:float
   -> ?on_telemetry:(Telemetry_event.t -> unit)
   -> unit

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -236,6 +236,7 @@ let complete_stream_http
       ?stream_idle_timeout_s
       ?(on_telemetry : (Telemetry_event.t -> unit) option)
       ?(metrics = Metrics.get_global ())
+      ?(connection_cache : Http_client.cache option)
       ~(config : Provider_config.t)
       ~(messages : Types.message list)
       ~tools
@@ -441,6 +442,7 @@ let complete_stream_http
       in
       match
         Http_client.with_post_stream
+          ?cache:connection_cache
           ?clock
           ~connect_timeout_s:(Provider_config.default_connect_timeout_s config.kind)
           ~net

--- a/lib/llm_provider/complete_sync.ml
+++ b/lib/llm_provider/complete_sync.ml
@@ -15,6 +15,7 @@ let complete_http
       ?(on_http_status :
          (provider:string -> model_id:string -> status:int -> unit) option)
       ?body_timeout_s
+      ?(connection_cache : Http_client.cache option)
       ~(config : Provider_config.t)
       ~(messages : Types.message list)
       ~tools
@@ -130,6 +131,7 @@ let complete_http
         let t0 = Unix.gettimeofday () in
         let post_sync_call () =
           Http_client.post_sync
+            ?cache:connection_cache
             ~sw
             ~net
             ?clock

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -3,12 +3,11 @@
     Wraps Eio + cohttp-eio with TLS. All network and HTTP-level errors
     are captured as {!http_error} so callers do not need [try/with].
 
-    Each synchronous request runs inside its own [Eio.Switch.run] scope
-    so the underlying TCP connection and its file descriptor are released
-    as soon as the response body is fully consumed.  Without this,
-    connections accumulate for the lifetime of the caller's switch —
-    typically the server's main switch — eventually exhausting OS file
-    descriptors.
+    Each synchronous request without a [connection_cache] runs inside
+    its own [Eio.Switch.run] scope so the underlying TCP connection and
+    its file descriptor are released as soon as the response body is
+    fully consumed. With a cache, connections are bound to the cache's
+    switch and reused until eviction or switch release.
 
     @since 0.45.0 *)
 
@@ -533,6 +532,10 @@ type cache =
 
 let create_cache ~sw ?clock ?(max_idle_per_host = 8) ?(idle_ttl_seconds = 60.0) () : cache
   =
+  if max_idle_per_host < 1
+  then invalid_arg "Http_client.create_cache: max_idle_per_host must be >= 1";
+  if idle_ttl_seconds <= 0.0
+  then invalid_arg "Http_client.create_cache: idle_ttl_seconds must be > 0";
   let cache =
     { sw
     ; mu = Eio.Mutex.create ()
@@ -624,32 +627,38 @@ let cache_stats (cache : cache) : cache_stats =
 (** Find a warm client for [uri] and remove it from the cache so it is
     owned by the caller. Returns [None] if no entry is available. *)
 let cache_take (cache : cache) uri : cache_entry option =
-  let key = Cache_key.of_uri uri in
-  Eio.Mutex.use_rw ~protect:true cache.mu (fun () ->
-    match Cache_map.find_opt key cache.entries with
-    | Some (e :: rest) ->
-      cache.entries <- Cache_map.add key rest cache.entries;
-      Atomic.incr cache.reuse_count_total;
-      Some e
-    | _ -> None)
+  if Atomic.get cache.stop
+  then None
+  else (
+    let key = Cache_key.of_uri uri in
+    Eio.Mutex.use_rw ~protect:true cache.mu (fun () ->
+      match Cache_map.find_opt key cache.entries with
+      | Some (e :: rest) ->
+        cache.entries <- Cache_map.add key rest cache.entries;
+        Atomic.incr cache.reuse_count_total;
+        Some e
+      | _ -> None))
 ;;
 
 (** Park a client back into the cache, or close it if the per-host cap
     is reached. [close] is the entry's own shutdown function. *)
 let cache_return (cache : cache) uri (entry : cache_entry) : unit =
-  let key = Cache_key.of_uri uri in
-  let now = Unix.gettimeofday () in
-  let entry = { entry with last_used_at = now } in
-  let parked =
-    Eio.Mutex.use_rw ~protect:true cache.mu (fun () ->
-      let existing = Cache_map.find_opt key cache.entries |> Option.value ~default:[] in
-      if List.length existing < cache.max_idle_per_host
-      then (
-        cache.entries <- Cache_map.add key (entry :: existing) cache.entries;
-        true)
-      else false)
-  in
-  if not parked then Eio.Resource.close entry.connection
+  if Atomic.get cache.stop
+  then Eio.Resource.close entry.connection
+  else (
+    let key = Cache_key.of_uri uri in
+    let now = Unix.gettimeofday () in
+    let entry = { entry with last_used_at = now } in
+    let parked =
+      Eio.Mutex.use_rw ~protect:true cache.mu (fun () ->
+        let existing = Cache_map.find_opt key cache.entries |> Option.value ~default:[] in
+        if List.length existing < cache.max_idle_per_host
+        then (
+          cache.entries <- Cache_map.add key (entry :: existing) cache.entries;
+          true)
+        else false)
+    in
+    if not parked then Eio.Resource.close entry.connection)
 ;;
 
 (** Resolve the origin for [uri] and prepare the TLS wrapper if needed.
@@ -809,10 +818,15 @@ let make_closing_client ~sw ~net ~uri =
     [Ok] from [Error] for cache lifecycle decisions; exceptions are treated
     as fatal for the connection. *)
 let with_client ?cache ~sw ~net ~uri f =
+  ignore sw;
   match cache with
   | None ->
-    let* client = make_closing_client ~sw ~net ~uri in
-    f client
+    (* Run each one-shot request in its own switch so the connection and FD
+       are released as soon as the response body is consumed, even when the
+       caller supplied a long-lived switch. *)
+    Eio.Switch.run (fun sw ->
+      let* client = make_closing_client ~sw ~net ~uri in
+      f client)
   | Some cache ->
     let* conn, was_cached =
       match cache_take cache uri with
@@ -1143,7 +1157,12 @@ let with_post_stream
       | exn ->
         (match classify_network_exn exn with
          | Some e -> Error e
-         | None -> raise exn)
+         | None ->
+           (* Unclassified exceptions (including cancellation) escape, so close
+              the connection before re-raising to avoid leaking a cached socket
+              bound to the long-lived cache switch. *)
+           Eio.Cancel.protect (fun () -> Eio.Resource.close conn);
+           raise exn)
     in
     (match body_result, cache with
      | Ok _, Some cache ->

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -526,8 +526,8 @@ type cache =
   ; max_idle_per_host : int
   ; idle_ttl_seconds : float
   ; mutable entries : cache_entry list Cache_map.t
-  ; mutable reuse_count_total : int
-  ; mutable create_count_total : int
+  ; reuse_count_total : int Atomic.t
+  ; create_count_total : int Atomic.t
   ; stop : bool Atomic.t
   }
 
@@ -539,8 +539,8 @@ let create_cache ~sw ?clock ?(max_idle_per_host = 8) ?(idle_ttl_seconds = 60.0) 
     ; max_idle_per_host
     ; idle_ttl_seconds
     ; entries = Cache_map.empty
-    ; reuse_count_total = 0
-    ; create_count_total = 0
+    ; reuse_count_total = Atomic.make 0
+    ; create_count_total = Atomic.make 0
     ; stop = Atomic.make false
     }
   in
@@ -574,7 +574,7 @@ let create_cache ~sw ?clock ?(max_idle_per_host = 8) ?(idle_ttl_seconds = 60.0) 
          then ()
          else (
            Eio.Time.sleep clock (cache.idle_ttl_seconds /. 2.0);
-           let now = Eio.Time.now clock in
+           let now = Unix.gettimeofday () in
            let expired =
              Eio.Mutex.use_rw ~protect:true cache.mu (fun () ->
                let expired = ref [] in
@@ -591,12 +591,13 @@ let create_cache ~sw ?clock ?(max_idle_per_host = 8) ?(idle_ttl_seconds = 60.0) 
                cache.entries <- remaining;
                !expired)
            in
-           List.iter
-             (fun e ->
-                try Eio.Resource.close e.connection with
-                | Eio.Cancel.Cancelled _ as exn -> raise exn
-                | _ -> ())
-             expired;
+           Eio.Cancel.protect (fun () ->
+             List.iter
+               (fun e ->
+                  try Eio.Resource.close e.connection with
+                  | Eio.Cancel.Cancelled _ as exn -> raise exn
+                  | _ -> ())
+               expired);
            loop ())
        in
        loop ())
@@ -614,8 +615,8 @@ let cache_stats (cache : cache) : cache_stats =
     let total_idle = List.fold_left (fun acc (_, n) -> acc + n) 0 idle_per_host in
     { idle_per_host
     ; total_idle
-    ; reuse_count_total = cache.reuse_count_total
-    ; create_count_total = cache.create_count_total
+    ; reuse_count_total = Atomic.get cache.reuse_count_total
+    ; create_count_total = Atomic.get cache.create_count_total
     })
 ;;
 
@@ -627,7 +628,7 @@ let cache_take (cache : cache) uri : cache_entry option =
     match Cache_map.find_opt key cache.entries with
     | Some (e :: rest) ->
       cache.entries <- Cache_map.add key rest cache.entries;
-      cache.reuse_count_total <- cache.reuse_count_total + 1;
+      Atomic.incr cache.reuse_count_total;
       Some e
     | _ -> None)
 ;;
@@ -816,7 +817,7 @@ let with_client ?cache ~sw ~net ~uri f =
       | Some e -> Ok (e.connection, true)
       | None ->
         let* conn = make_connection ~sw:cache.sw ~net ~uri in
-        cache.create_count_total <- cache.create_count_total + 1;
+        Atomic.incr cache.create_count_total;
         Ok (conn, false)
     in
     let client =
@@ -825,9 +826,17 @@ let with_client ?cache ~sw ~net ~uri f =
     let ok = ref false in
     Fun.protect
       ~finally:(fun () ->
-        if !ok
-        then cache_return cache uri { connection = conn; last_used_at = 0.0 }
-        else Eio.Resource.close conn)
+        try
+          if !ok
+          then cache_return cache uri { connection = conn; last_used_at = 0.0 }
+          else Eio.Resource.close conn
+        with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | exn ->
+          Diag.warn
+            "http_client"
+            "with_client cleanup failed: %s"
+            (Printexc.to_string exn))
       (fun () ->
          let result = f client in
          (match result with

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -456,12 +456,203 @@ let is_local_resource_exhaustion = function
 
 (* ── Public API ────────────────────────────────────────────── *)
 
+type connection = [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t
+
 let add_connection_close headers = ("connection", "close") :: headers
 
-(** Client wrapper that tracks the socket for explicit close.
-    The caller provides the concrete URI so host resolution and TLS
-    availability can be checked up front and reported as typed errors. *)
-let make_closing_client ~sw ~net ~uri =
+let maybe_add_connection_close ?cache headers =
+  match cache with
+  | Some _ -> headers
+  | None -> add_connection_close headers
+;;
+
+(* ── Connection cache ──────────────────────────────────────── *)
+
+(** Host identity for connection reuse. The cache intentionally ignores
+    path, query, and auth: a connection to the same origin can carry
+    requests with different URLs and headers. *)
+module Cache_key = struct
+  type t =
+    { scheme : string
+    ; host : string
+    ; port : int
+    }
+
+  let compare a b =
+    match String.compare a.scheme b.scheme with
+    | 0 ->
+      (match String.compare a.host b.host with
+       | 0 -> Int.compare a.port b.port
+       | n -> n)
+    | n -> n
+  ;;
+
+  let of_uri uri =
+    let scheme = Uri.scheme uri |> Option.value ~default:"http" in
+    let host =
+      match Uri.host uri with
+      | Some "" | None -> "localhost"
+      | Some h -> h
+    in
+    let port =
+      Uri.port uri
+      |> Option.value
+           ~default:
+             (match scheme with
+              | "https" -> 443
+              | _ -> 80)
+    in
+    { scheme; host; port }
+  ;;
+end
+
+module Cache_map = Map.Make (Cache_key)
+
+type cache_entry =
+  { connection : connection
+  ; last_used_at : float
+  }
+
+type cache_stats =
+  { idle_per_host : (string * int) list
+  ; total_idle : int
+  ; reuse_count_total : int
+  ; create_count_total : int
+  }
+
+type cache =
+  { sw : Eio.Switch.t
+  ; mu : Eio.Mutex.t
+  ; max_idle_per_host : int
+  ; idle_ttl_seconds : float
+  ; mutable entries : cache_entry list Cache_map.t
+  ; mutable reuse_count_total : int
+  ; mutable create_count_total : int
+  ; stop : bool Atomic.t
+  }
+
+let create_cache ~sw ?clock ?(max_idle_per_host = 8) ?(idle_ttl_seconds = 60.0) () : cache
+  =
+  let cache =
+    { sw
+    ; mu = Eio.Mutex.create ()
+    ; max_idle_per_host
+    ; idle_ttl_seconds
+    ; entries = Cache_map.empty
+    ; reuse_count_total = 0
+    ; create_count_total = 0
+    ; stop = Atomic.make false
+    }
+  in
+  Eio.Switch.on_release sw (fun () ->
+    Atomic.set cache.stop true;
+    let leftover =
+      Eio.Mutex.use_rw ~protect:true cache.mu (fun () ->
+        let all =
+          Cache_map.fold
+            (fun _ entries acc -> List.rev_append entries acc)
+            cache.entries
+            []
+        in
+        cache.entries <- Cache_map.empty;
+        all)
+    in
+    List.iter
+      (fun e ->
+         try Eio.Resource.close e.connection with
+         | Eio.Cancel.Cancelled _ as exn -> raise exn
+         | _ -> ())
+      leftover);
+  (* Eviction fiber: reap entries past [idle_ttl_seconds] when a clock
+     is supplied. Without a clock the cache still works; stale entries
+     are closed on switch release. *)
+  (match clock with
+   | Some clock ->
+     Eio.Fiber.fork ~sw (fun () ->
+       let rec loop () =
+         if Atomic.get cache.stop
+         then ()
+         else (
+           Eio.Time.sleep clock (cache.idle_ttl_seconds /. 2.0);
+           let now = Eio.Time.now clock in
+           let expired =
+             Eio.Mutex.use_rw ~protect:true cache.mu (fun () ->
+               let expired = ref [] in
+               let remaining =
+                 Cache_map.map
+                   (List.filter (fun e ->
+                      if now -. e.last_used_at > cache.idle_ttl_seconds
+                      then (
+                        expired := e :: !expired;
+                        false)
+                      else true))
+                   cache.entries
+               in
+               cache.entries <- remaining;
+               !expired)
+           in
+           List.iter
+             (fun e ->
+                try Eio.Resource.close e.connection with
+                | Eio.Cancel.Cancelled _ as exn -> raise exn
+                | _ -> ())
+             expired;
+           loop ())
+       in
+       loop ())
+   | None -> ());
+  cache
+;;
+
+let cache_stats (cache : cache) : cache_stats =
+  Eio.Mutex.use_ro cache.mu (fun () ->
+    let idle_per_host =
+      Cache_map.bindings cache.entries
+      |> List.map (fun ({ Cache_key.scheme; host; port }, v) ->
+        Printf.sprintf "%s://%s:%d" scheme host port, List.length v)
+    in
+    let total_idle = List.fold_left (fun acc (_, n) -> acc + n) 0 idle_per_host in
+    { idle_per_host
+    ; total_idle
+    ; reuse_count_total = cache.reuse_count_total
+    ; create_count_total = cache.create_count_total
+    })
+;;
+
+(** Find a warm client for [uri] and remove it from the cache so it is
+    owned by the caller. Returns [None] if no entry is available. *)
+let cache_take (cache : cache) uri : cache_entry option =
+  let key = Cache_key.of_uri uri in
+  Eio.Mutex.use_rw ~protect:true cache.mu (fun () ->
+    match Cache_map.find_opt key cache.entries with
+    | Some (e :: rest) ->
+      cache.entries <- Cache_map.add key rest cache.entries;
+      cache.reuse_count_total <- cache.reuse_count_total + 1;
+      Some e
+    | _ -> None)
+;;
+
+(** Park a client back into the cache, or close it if the per-host cap
+    is reached. [close] is the entry's own shutdown function. *)
+let cache_return (cache : cache) uri (entry : cache_entry) : unit =
+  let key = Cache_key.of_uri uri in
+  let now = Unix.gettimeofday () in
+  let entry = { entry with last_used_at = now } in
+  let parked =
+    Eio.Mutex.use_rw ~protect:true cache.mu (fun () ->
+      let existing = Cache_map.find_opt key cache.entries |> Option.value ~default:[] in
+      if List.length existing < cache.max_idle_per_host
+      then (
+        cache.entries <- Cache_map.add key (entry :: existing) cache.entries;
+        true)
+      else false)
+  in
+  if not parked then Eio.Resource.close entry.connection
+;;
+
+(** Resolve the origin for [uri] and prepare the TLS wrapper if needed.
+    The result is reused by both one-shot clients and cached connections. *)
+let resolve_origin net uri =
   let net = (net :> [ `Generic ] Eio.Net.ty Eio.Resource.t) in
   let https = Api_common.make_https_result () in
   let* host =
@@ -479,7 +670,7 @@ let make_closing_client ~sw ~net ~uri =
     | Some port -> Int.to_string port
     | None -> Uri.scheme uri |> Option.value ~default:"http"
   in
-  let addr =
+  let* addr =
     try
       match Eio.Net.getaddrinfo_stream ~service net host with
       | ip :: _ -> Ok ip
@@ -500,7 +691,7 @@ let make_closing_client ~sw ~net ~uri =
     | Failure msg ->
       Error (NetworkError { message = msg; kind = classify_by_message msg })
   in
-  let tls_wrap =
+  let* tls_wrap =
     match Uri.scheme uri with
     | Some "https" ->
       (match https with
@@ -517,72 +708,132 @@ let make_closing_client ~sw ~net ~uri =
               }))
     | Some "http" | Some _ | None -> Ok None
   in
-  match addr, tls_wrap with
-  | (Error _ as e), _ -> e
-  | _, (Error _ as e) -> e
-  | Ok addr, Ok tls_wrap ->
-    (* Track every transport returned by [connect] so switch release can
-         close all of them — not just the most recent one.  [cohttp_eio]
-         may call [connect] multiple times per client (keep-alive refresh,
-         retry after transient error, etc.), and any socket we stop
-         referencing leaks its fd and leaves the TCP endpoint in
-         CLOSE_WAIT.
+  Ok (net, addr, tls_wrap)
+;;
 
-         We also store the TLS-wrapped resource (not the raw socket) so
-         [Eio.Resource.close] triggers TLS close_notify before the TCP
-         layer closes.  Raw-socket close without TLS shutdown causes the
-         peer (e.g. Glm / Cloudflare-fronted endpoints) to interpret the
-         half-close as "keep waiting" and hold the connection in
-         CLOSE_WAIT indefinitely. *)
-    let tracked_transports
-      : [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t list Atomic.t
-      =
-      Atomic.make []
+(** Build a reusable client with explicit lifetime control.
+    Returns [Ok (client, close)] where [close] shuts down all transports
+    created by this client. The client is NOT bound to any switch; the
+    caller decides when to close it or park it in a cache. *)
+let make_client ~net ~uri =
+  let* net, addr, tls_wrap = resolve_origin net uri in
+  let tracked_transports : connection list Atomic.t = Atomic.make [] in
+  let connect ~sw:conn_sw _uri =
+    let sock = Eio.Net.connect ~sw:conn_sw net addr in
+    let transport : connection =
+      match tls_wrap with
+      | Some wrap -> (wrap uri sock :> connection)
+      | None -> (sock :> connection)
     in
-    let connect ~sw:conn_sw _uri =
-      let sock = Eio.Net.connect ~sw:conn_sw net addr in
-      let transport : [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t =
-        match tls_wrap with
-        | Some wrap ->
-          (wrap uri sock :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
-        | None -> (sock :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
-      in
-      let rec push () =
-        let prev = Atomic.get tracked_transports in
-        if Atomic.compare_and_set tracked_transports prev (transport :: prev)
-        then ()
-        else push ()
-      in
-      push ();
+    let rec push () =
+      let prev = Atomic.get tracked_transports in
+      if Atomic.compare_and_set tracked_transports prev (transport :: prev)
+      then ()
+      else push ()
+    in
+    push ();
+    Diag.debug
+      "http_client"
+      "connect: new transport #%d for %s"
+      (List.length (Atomic.get tracked_transports))
+      (Uri.to_string uri);
+    transport
+  in
+  let client = Cohttp_eio.Client.make_generic connect in
+  let close () =
+    let transports = Atomic.exchange tracked_transports [] in
+    let n = List.length transports in
+    if n > 0
+    then
       Diag.debug
         "http_client"
-        "connect: new transport #%d for %s"
-        (List.length (Atomic.get tracked_transports))
+        "close: closing %d transport(s) for %s"
+        n
         (Uri.to_string uri);
-      transport
+    List.iter
+      (fun t ->
+         try
+           Eio.Resource.close t;
+           Diag.debug "http_client" "transport closed for %s" (Uri.to_string uri)
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+           log_close_failure ~url:(Uri.to_string uri) ~message:(Printexc.to_string exn))
+      transports
+  in
+  Ok (client, close)
+;;
+
+(** Create a single transport connection bound to [sw]. This is the unit
+    stored in the connection cache and reused across requests. *)
+let make_connection ~sw ~net ~uri : (connection, http_error) result =
+  let* net, addr, tls_wrap = resolve_origin net uri in
+  try
+    let sock = Eio.Net.connect ~sw net addr in
+    let conn : connection =
+      match tls_wrap with
+      | Some wrap -> (wrap uri sock :> connection)
+      | None -> (sock :> connection)
     in
-    let client = Cohttp_eio.Client.make_generic connect in
-    Eio.Switch.on_release sw (fun () ->
-      let transports = Atomic.exchange tracked_transports [] in
-      let n = List.length transports in
-      if n > 0
-      then
-        Diag.debug
-          "http_client"
-          "on_release: closing %d transport(s) for %s"
-          n
-          (Uri.to_string uri);
-      List.iter
-        (fun t ->
-           try
-             Eio.Resource.close t;
-             Diag.debug "http_client" "transport closed for %s" (Uri.to_string uri)
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
-             log_close_failure ~url:(Uri.to_string uri) ~message:(Printexc.to_string exn))
-        transports);
-    Ok client
+    Diag.debug "http_client" "make_connection: new connection for %s" (Uri.to_string uri);
+    Ok conn
+  with
+  | Eio.Io _ as exn ->
+    let msg = Printexc.to_string exn in
+    Error (NetworkError { message = msg; kind = classify_by_message msg })
+  | Unix.Unix_error (code, _, _) as exn ->
+    Error
+      (NetworkError { message = Printexc.to_string exn; kind = classify_unix_error code })
+  | Failure msg -> Error (NetworkError { message = msg; kind = classify_by_message msg })
+;;
+
+(** Client wrapper that tracks the socket for explicit close.
+    The caller provides the concrete URI so host resolution and TLS
+    availability can be checked up front and reported as typed errors. *)
+let make_closing_client ~sw ~net ~uri =
+  let* client, close = make_client ~net ~uri in
+  Eio.Switch.on_release sw close;
+  Ok client
+;;
+
+(** Run [f client] with a client obtained either from [cache] or created
+    for one request. When [cache] is supplied, a hit reuses a parked
+    connection, a miss creates one and parks it on success, and any error
+    evicts it. When [cache] is omitted the behavior is the existing
+    one-shot behavior.
+
+    [f] must return an [('a, http_error) result]. The wrapper distinguishes
+    [Ok] from [Error] for cache lifecycle decisions; exceptions are treated
+    as fatal for the connection. *)
+let with_client ?cache ~sw ~net ~uri f =
+  match cache with
+  | None ->
+    let* client = make_closing_client ~sw ~net ~uri in
+    f client
+  | Some cache ->
+    let* conn, was_cached =
+      match cache_take cache uri with
+      | Some e -> Ok (e.connection, true)
+      | None ->
+        let* conn = make_connection ~sw:cache.sw ~net ~uri in
+        cache.create_count_total <- cache.create_count_total + 1;
+        Ok (conn, false)
+    in
+    let client =
+      Cohttp_eio.Client.make_generic (fun ~sw:_ _uri -> (conn :> _ Eio.Flow.two_way))
+    in
+    let ok = ref false in
+    Fun.protect
+      ~finally:(fun () ->
+        if !ok
+        then cache_return cache uri { connection = conn; last_used_at = 0.0 }
+        else Eio.Resource.close conn)
+      (fun () ->
+         let result = f client in
+         (match result with
+          | Ok _ -> ok := true
+          | Error _ -> ());
+         result)
 ;;
 
 let drain_response_body ?clock ?(timeout_s = 30.0) resp_body =
@@ -631,67 +882,78 @@ let drain_response_body ?clock ?(timeout_s = 30.0) resp_body =
     ()
 ;;
 
-let get_sync ?clock ?(timeout_s = default_http_timeout_s) ~sw ~net ~url ~headers () =
-  catch_network (fun () ->
-    let* uri = parse_uri url in
-    let* client = make_closing_client ~sw ~net ~uri in
-    let hdr = Http.Header.of_list (add_connection_close headers) in
-    with_optional_timeout ~clock ~timeout_s (fun () ->
-      let resp, resp_body = Cohttp_eio.Client.get ~sw client ~headers:hdr uri in
-      let code = Cohttp.Response.status resp |> Cohttp.Code.code_of_status in
-      let body_str =
-        try
-          Eio.Buf_read.(
-            of_flow ~max_size:Api_common.max_response_body resp_body |> take_all)
-        with
-        | exn ->
-          drain_response_body ?clock resp_body;
-          raise exn
-      in
-      Ok (code, body_str)))
-;;
-
-let post_sync ?clock ?(timeout_s = default_http_timeout_s) ~sw ~net ~url ~headers ~body ()
+let get_sync ?cache ?clock ?(timeout_s = default_http_timeout_s) ~sw ~net ~url ~headers ()
   =
   catch_network (fun () ->
     let* uri = parse_uri url in
-    let* client = make_closing_client ~sw ~net ~uri in
-    (* Explicitly set Content-Length to prevent chunked transfer encoding.
-       Ollama's yyjson parser rejects chunked bodies with
-       "Value looks like object, but can't find closing '}' symbol". *)
-    let headers_with_length =
-      ("content-length", string_of_int (String.length body))
-      :: add_connection_close headers
-    in
-    let hdr = Http.Header.of_list headers_with_length in
-    with_optional_timeout ~clock ~timeout_s (fun () ->
-      let resp, resp_body =
-        Cohttp_eio.Client.post
-          ~sw
-          client
-          ~headers:hdr
-          ~body:(Cohttp_eio.Body.of_string body)
-          uri
+    with_client ?cache ~sw ~net ~uri (fun client ->
+      let hdr = Http.Header.of_list (maybe_add_connection_close ?cache headers) in
+      with_optional_timeout ~clock ~timeout_s (fun () ->
+        let resp, resp_body = Cohttp_eio.Client.get ~sw client ~headers:hdr uri in
+        let code = Cohttp.Response.status resp |> Cohttp.Code.code_of_status in
+        let body_str =
+          try
+            Eio.Buf_read.(
+              of_flow ~max_size:Api_common.max_response_body resp_body |> take_all)
+          with
+          | exn ->
+            drain_response_body ?clock resp_body;
+            raise exn
+        in
+        Ok (code, body_str))))
+;;
+
+let post_sync
+      ?cache
+      ?clock
+      ?(timeout_s = default_http_timeout_s)
+      ~sw
+      ~net
+      ~url
+      ~headers
+      ~body
+      ()
+  =
+  catch_network (fun () ->
+    let* uri = parse_uri url in
+    with_client ?cache ~sw ~net ~uri (fun client ->
+      (* Explicitly set Content-Length to prevent chunked transfer encoding.
+         Ollama's yyjson parser rejects chunked bodies with
+         "Value looks like object, but can't find closing '}' symbol". *)
+      let headers_with_length =
+        ("content-length", string_of_int (String.length body))
+        :: maybe_add_connection_close ?cache headers
       in
-      let code = Cohttp.Response.status resp |> Cohttp.Code.code_of_status in
-      profile_headers_on_client_error
-        ~url
-        ~code
-        ~resp_headers:(Cohttp.Response.headers resp)
-        headers_with_length;
-      let body_str =
-        try
-          Eio.Buf_read.(
-            of_flow ~max_size:Api_common.max_response_body resp_body |> take_all)
-        with
-        | exn ->
-          drain_response_body ?clock resp_body;
-          raise exn
-      in
-      Ok (code, body_str)))
+      let hdr = Http.Header.of_list headers_with_length in
+      with_optional_timeout ~clock ~timeout_s (fun () ->
+        let resp, resp_body =
+          Cohttp_eio.Client.post
+            ~sw
+            client
+            ~headers:hdr
+            ~body:(Cohttp_eio.Body.of_string body)
+            uri
+        in
+        let code = Cohttp.Response.status resp |> Cohttp.Code.code_of_status in
+        profile_headers_on_client_error
+          ~url
+          ~code
+          ~resp_headers:(Cohttp.Response.headers resp)
+          headers_with_length;
+        let body_str =
+          try
+            Eio.Buf_read.(
+              of_flow ~max_size:Api_common.max_response_body resp_body |> take_all)
+          with
+          | exn ->
+            drain_response_body ?clock resp_body;
+            raise exn
+        in
+        Ok (code, body_str))))
 ;;
 
 let post_stream
+      ?cache
       ?clock
       ?(connect_timeout_s = default_http_timeout_s)
       ~sw
@@ -701,6 +963,11 @@ let post_stream
       ~body
       ()
   =
+  (* Cache is intentionally ignored for the streaming reader variant: the
+     returned [Buf_read.t] outlives this function, so we cannot safely park
+     the client until consumption finishes. Use [with_post_stream] for
+     cache-aware streaming. *)
+  ignore cache;
   catch_network (fun () ->
     let* uri = parse_uri url in
     let* client = make_closing_client ~sw ~net ~uri in
@@ -743,6 +1010,7 @@ let post_stream
 ;;
 
 let with_post_stream
+      ?cache
       ?clock
       ?(connect_timeout_s = default_http_timeout_s)
       ~net
@@ -754,6 +1022,14 @@ let with_post_stream
   =
   Eio.Switch.run
   @@ fun sw ->
+  (* When a cache is active, bind the transport to the cache's long-lived
+     switch so the connection can be reused across requests. Otherwise use
+     the per-call switch for one-shot cleanup. *)
+  let request_sw =
+    match cache with
+    | Some c -> c.sw
+    | None -> sw
+  in
   (* Phase 1a: connect + post + response headers, bounded by
      [connect_timeout_s]. Cohttp_eio.Client.post returns once headers are
      parsed (body is a lazy flow), so wrapping only this stage in
@@ -763,44 +1039,44 @@ let with_post_stream
   let post_result =
     catch_network (fun () ->
       let* uri = parse_uri url in
-      let* client = make_closing_client ~sw ~net ~uri in
-      let headers_with_length =
-        ("content-length", string_of_int (String.length body))
-        :: add_connection_close headers
-      in
-      let hdr = Http.Header.of_list headers_with_length in
-      let resp, resp_body =
-        with_optional_timeout ~clock ~timeout_s:connect_timeout_s (fun () ->
-          Cohttp_eio.Client.post
-            ~sw
-            client
-            ~headers:hdr
-            ~body:(Cohttp_eio.Body.of_string body)
-            uri)
-      in
-      match Cohttp.Response.status resp with
-      | `OK ->
-        let reader =
-          Eio.Buf_read.of_flow ~max_size:Api_common.max_response_body resp_body
+      with_client ?cache ~sw:request_sw ~net ~uri (fun client ->
+        let headers_with_length =
+          ("content-length", string_of_int (String.length body))
+          :: maybe_add_connection_close ?cache headers
         in
-        Ok reader
-      | status ->
-        let code = Cohttp.Code.code_of_status status in
-        profile_headers_on_client_error
-          ~url
-          ~code
-          ~resp_headers:(Cohttp.Response.headers resp)
-          headers_with_length;
-        let body_str =
-          try
-            Eio.Buf_read.(
-              of_flow ~max_size:Api_common.max_response_body resp_body |> take_all)
-          with
-          | exn ->
-            drain_response_body resp_body;
-            raise exn
+        let hdr = Http.Header.of_list headers_with_length in
+        let resp, resp_body =
+          with_optional_timeout ~clock ~timeout_s:connect_timeout_s (fun () ->
+            Cohttp_eio.Client.post
+              ~sw:request_sw
+              client
+              ~headers:hdr
+              ~body:(Cohttp_eio.Body.of_string body)
+              uri)
         in
-        Error (HttpError { code; body = body_str }))
+        match Cohttp.Response.status resp with
+        | `OK ->
+          let reader =
+            Eio.Buf_read.of_flow ~max_size:Api_common.max_response_body resp_body
+          in
+          Ok reader
+        | status ->
+          let code = Cohttp.Code.code_of_status status in
+          profile_headers_on_client_error
+            ~url
+            ~code
+            ~resp_headers:(Cohttp.Response.headers resp)
+            headers_with_length;
+          let body_str =
+            try
+              Eio.Buf_read.(
+                of_flow ~max_size:Api_common.max_response_body resp_body |> take_all)
+            with
+            | exn ->
+              drain_response_body resp_body;
+              raise exn
+          in
+          Error (HttpError { code; body = body_str })))
   in
   (* Phase 1b: body consumption. Deliberately OUTSIDE [catch_network]: a
      body-phase [Eio.Time.Timeout] is phase-distinct from the connect /

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -557,12 +557,13 @@ let create_cache ~sw ?clock ?(max_idle_per_host = 8) ?(idle_ttl_seconds = 60.0) 
         cache.entries <- Cache_map.empty;
         all)
     in
-    List.iter
-      (fun e ->
-         try Eio.Resource.close e.connection with
-         | Eio.Cancel.Cancelled _ as exn -> raise exn
-         | _ -> ())
-      leftover);
+    Eio.Cancel.protect (fun () ->
+      List.iter
+        (fun e ->
+           try Eio.Resource.close e.connection with
+           | Eio.Cancel.Cancelled _ as exn -> raise exn
+           | _ -> ())
+        leftover));
   (* Eviction fiber: reap entries past [idle_ttl_seconds] when a clock
      is supplied. Without a clock the cache still works; stale entries
      are closed on switch release. *)
@@ -751,16 +752,17 @@ let make_client ~net ~uri =
         "close: closing %d transport(s) for %s"
         n
         (Uri.to_string uri);
-    List.iter
-      (fun t ->
-         try
-           Eio.Resource.close t;
-           Diag.debug "http_client" "transport closed for %s" (Uri.to_string uri)
-         with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | exn ->
-           log_close_failure ~url:(Uri.to_string uri) ~message:(Printexc.to_string exn))
-      transports
+    Eio.Cancel.protect (fun () ->
+      List.iter
+        (fun t ->
+           try
+             Eio.Resource.close t;
+             Diag.debug "http_client" "transport closed for %s" (Uri.to_string uri)
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
+             log_close_failure ~url:(Uri.to_string uri) ~message:(Printexc.to_string exn))
+        transports)
   in
   Ok (client, close)
 ;;
@@ -1044,16 +1046,33 @@ let with_post_stream
      parsed (body is a lazy flow), so wrapping only this stage in
      [catch_network] keeps a connect / header-phase stall as
      [TimeoutError { phase = Http_operation }] without absorbing body-phase
-     timeouts (first-token / prefill wait, inter-chunk idle). *)
+     timeouts (first-token / prefill wait, inter-chunk idle).
+
+     Streaming is handled manually rather than through [with_client] so the
+     connection is NOT parked until [f] has fully consumed the reader. *)
   let post_result =
     catch_network (fun () ->
       let* uri = parse_uri url in
-      with_client ?cache ~sw:request_sw ~net ~uri (fun client ->
-        let headers_with_length =
-          ("content-length", string_of_int (String.length body))
-          :: maybe_add_connection_close ?cache headers
-        in
-        let hdr = Http.Header.of_list headers_with_length in
+      let* conn =
+        match cache with
+        | None -> make_connection ~sw:request_sw ~net ~uri
+        | Some cache ->
+          (match cache_take cache uri with
+           | Some e -> Ok e.connection
+           | None ->
+             let* conn = make_connection ~sw:cache.sw ~net ~uri in
+             Atomic.incr cache.create_count_total;
+             Ok conn)
+      in
+      let client =
+        Cohttp_eio.Client.make_generic (fun ~sw:_ _uri -> (conn :> _ Eio.Flow.two_way))
+      in
+      let headers_with_length =
+        ("content-length", string_of_int (String.length body))
+        :: maybe_add_connection_close ?cache headers
+      in
+      let hdr = Http.Header.of_list headers_with_length in
+      try
         let resp, resp_body =
           with_optional_timeout ~clock ~timeout_s:connect_timeout_s (fun () ->
             Cohttp_eio.Client.post
@@ -1065,10 +1084,10 @@ let with_post_stream
         in
         match Cohttp.Response.status resp with
         | `OK ->
-          let reader =
-            Eio.Buf_read.of_flow ~max_size:Api_common.max_response_body resp_body
-          in
-          Ok reader
+          Ok
+            ( uri
+            , conn
+            , Eio.Buf_read.of_flow ~max_size:Api_common.max_response_body resp_body )
         | status ->
           let code = Cohttp.Code.code_of_status status in
           profile_headers_on_client_error
@@ -1085,7 +1104,14 @@ let with_post_stream
               drain_response_body resp_body;
               raise exn
           in
-          Error (HttpError { code; body = body_str })))
+          Eio.Resource.close conn;
+          Error (HttpError { code; body = body_str })
+      with
+      | exn ->
+        Eio.Resource.close conn;
+        (match classify_network_exn exn with
+         | Some e -> Error e
+         | None -> raise exn))
   in
   (* Phase 1b: body consumption. Deliberately OUTSIDE [catch_network]: a
      body-phase [Eio.Time.Timeout] is phase-distinct from the connect /
@@ -1093,32 +1119,38 @@ let with_post_stream
      phase-aware timeout handling and must convert [Eio.Time.Timeout] into a
      typed [Error] (see [Complete_stream.body_logic] and the Streaming
      callers). A body-phase timeout that [f] lets propagate escapes this
-     function as the raw exception. *)
+     function as the raw exception.
+
+     The connection is parked back into the cache only after [f] returns
+     successfully, ensuring the reader is no longer using the flow. *)
   match post_result with
   | Error e -> Error e
-  | Ok reader ->
-    (* Body consumption. [Eio.Time.Timeout] propagates so the caller
-        phases it (prefill → [First_token], inter-chunk → [Stream_idle]).
-        Other network exceptions classify like {!catch_network} so a
-        body-phase I/O failure still surfaces as a typed [NetworkError]
-        instead of escaping as a raw exception. *)
-    (try Ok (f reader) with
-     | Eio.Time.Timeout ->
-       (* Body-phase timeout. Stream-state-aware callers ([Complete_stream])
-          catch this inside [f] and emit the precise [First_token] /
-          [Stream_idle] phase. Callers that let it propagate (e.g.
-          [Streaming]) get [Unknown_timeout] as a safe default rather
-          than it being mislabelled [Http_operation] (the connect /
-          headers phase, which a body-phase timeout is not). *)
-       Error
-         (TimeoutError
-            { message = "stream body timed out (awaiting first token / inter-chunk idle)"
-            ; phase = Unknown_timeout
-            })
-     | exn ->
-       (match classify_network_exn exn with
-        | Some e -> Error e
-        | None -> raise exn))
+  | Ok (uri, conn, reader) ->
+    let body_result =
+      try Ok (f reader) with
+      | Eio.Time.Timeout ->
+        (* Body-phase timeout. Stream-state-aware callers ([Complete_stream])
+           catch this inside [f] and emit the precise [First_token] /
+           [Stream_idle] phase. Callers that let it propagate (e.g.
+           [Streaming]) get [Unknown_timeout] as a safe default rather
+           than it being mislabelled [Http_operation] (the connect /
+           headers phase, which a body-phase timeout is not). *)
+        Error
+          (TimeoutError
+             { message = "stream body timed out (awaiting first token / inter-chunk idle)"
+             ; phase = Unknown_timeout
+             })
+      | exn ->
+        (match classify_network_exn exn with
+         | Some e -> Error e
+         | None -> raise exn)
+    in
+    (match body_result, cache with
+     | Ok _, Some cache ->
+       cache_return cache uri { connection = conn; last_used_at = Unix.gettimeofday () }
+     | Ok _, None -> Eio.Resource.close conn
+     | Error _, _ -> Eio.Resource.close conn);
+    body_result
 ;;
 
 (* One W3C EventSource line, parsed per spec (§9.2.6 event stream

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -186,9 +186,9 @@ val default_http_timeout_s : float
 
 (** Opaque reusable connection cache.
 
-    A cache holds idle [Cohttp_eio.Client.t] values keyed by origin
+    A cache holds idle Eio transport connections keyed by origin
     [(scheme, host, port)]. It is bound to the [sw] passed to
-    {!create_cache}; all cached clients are closed when that switch is
+    {!create_cache}; all cached connections are closed when that switch is
     released. An optional eviction fiber reaps entries that have been
     idle longer than [idle_ttl_seconds].
 
@@ -205,8 +205,8 @@ type cache_stats =
 
 (** Create a connection cache.
 
-    [max_idle_per_host] caps the number of idle clients kept per origin.
-    [idle_ttl_seconds] is the maximum time an idle client is kept.
+    [max_idle_per_host] caps the number of idle connections kept per origin.
+    [idle_ttl_seconds] is the maximum time an idle connection is kept.
     [clock], if supplied, drives the background eviction fiber.
 
     @since 0.208.0 *)
@@ -224,13 +224,12 @@ val cache_stats : cache -> cache_stats
 (** GET a URL synchronously, returning the full response.
     Returns [(status_code, body_string)] on success.
 
-    The connection is bound to [sw]; it is closed when [sw] is released.
-    This respects the caller's switch scope and cancellation.
+    Without [cache], the connection is bound to [sw] and closed when [sw]
+    is released. With [cache], the connection is bound to the cache's
+    switch and parked back in the cache on success for reuse.
 
-    When [cache] is supplied a matching idle connection is reused when
-    available, and the connection is parked back in the cache on success.
-    The [connection: close] request header is omitted so HTTP keep-alive
-    can work.
+    When [cache] is supplied the [connection: close] request header is
+    omitted so HTTP keep-alive can work.
 
     When [clock] is supplied the entire operation (connect + response
     + body read) is bounded by [timeout_s] (default
@@ -251,13 +250,12 @@ val get_sync
 (** POST JSON body synchronously, returning the full response.
     Returns [(status_code, body_string)] on success.
 
-    The connection is bound to [sw]; it is closed when [sw] is released.
-    This respects the caller's switch scope and cancellation.
+    Without [cache], the connection is bound to [sw] and closed when [sw]
+    is released. With [cache], the connection is bound to the cache's
+    switch and parked back in the cache on success for reuse.
 
-    When [cache] is supplied a matching idle connection is reused when
-    available, and the connection is parked back in the cache on success.
-    The [connection: close] request header is omitted so HTTP keep-alive
-    can work.
+    When [cache] is supplied the [connection: close] request header is
+    omitted so HTTP keep-alive can work.
 
     When [clock] is supplied the entire operation is bounded by
     [timeout_s] (default {!default_http_timeout_s}); a timeout owned by
@@ -308,7 +306,9 @@ val post_stream
     and its fd is released immediately.
 
     When [cache] is supplied, the streaming connection is bound to the
-    cache's long-lived switch so it can be reused across requests.
+    cache's long-lived switch and is parked back after [f] returns, so
+    it can be reused across requests. [f] must consume the full response
+    body; leaving unread bytes on the reader will corrupt the next reuse.
 
     [connect_timeout_s] bounds only the connect + initial response
     headers phase when [clock] is supplied; a stall there surfaces as

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -182,11 +182,55 @@ val timeout_phase_to_label : timeout_phase -> string
     only to bound the connect + initial-response-headers phase. *)
 val default_http_timeout_s : float
 
+(** {1 Connection cache} *)
+
+(** Opaque reusable connection cache.
+
+    A cache holds idle [Cohttp_eio.Client.t] values keyed by origin
+    [(scheme, host, port)]. It is bound to the [sw] passed to
+    {!create_cache}; all cached clients are closed when that switch is
+    released. An optional eviction fiber reaps entries that have been
+    idle longer than [idle_ttl_seconds].
+
+    @since 0.208.0 *)
+type cache
+
+(** Statistics snapshot for observability. *)
+type cache_stats =
+  { idle_per_host : (string * int) list
+  ; total_idle : int
+  ; reuse_count_total : int
+  ; create_count_total : int
+  }
+
+(** Create a connection cache.
+
+    [max_idle_per_host] caps the number of idle clients kept per origin.
+    [idle_ttl_seconds] is the maximum time an idle client is kept.
+    [clock], if supplied, drives the background eviction fiber.
+
+    @since 0.208.0 *)
+val create_cache
+  :  sw:Eio.Switch.t
+  -> ?clock:_ Eio.Time.clock
+  -> ?max_idle_per_host:int
+  -> ?idle_ttl_seconds:float
+  -> unit
+  -> cache
+
+(** Snapshot of current cache statistics. *)
+val cache_stats : cache -> cache_stats
+
 (** GET a URL synchronously, returning the full response.
     Returns [(status_code, body_string)] on success.
 
     The connection is bound to [sw]; it is closed when [sw] is released.
     This respects the caller's switch scope and cancellation.
+
+    When [cache] is supplied a matching idle connection is reused when
+    available, and the connection is parked back in the cache on success.
+    The [connection: close] request header is omitted so HTTP keep-alive
+    can work.
 
     When [clock] is supplied the entire operation (connect + response
     + body read) is bounded by [timeout_s] (default
@@ -194,7 +238,8 @@ val default_http_timeout_s : float
     surfaces as [TimeoutError { phase = Http_operation; _ }] which is
     classified as retryable by {!Retry.is_retryable}. *)
 val get_sync
-  :  ?clock:_ Eio.Time.clock
+  :  ?cache:cache
+  -> ?clock:_ Eio.Time.clock
   -> ?timeout_s:float
   -> sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
@@ -209,12 +254,18 @@ val get_sync
     The connection is bound to [sw]; it is closed when [sw] is released.
     This respects the caller's switch scope and cancellation.
 
+    When [cache] is supplied a matching idle connection is reused when
+    available, and the connection is parked back in the cache on success.
+    The [connection: close] request header is omitted so HTTP keep-alive
+    can work.
+
     When [clock] is supplied the entire operation is bounded by
     [timeout_s] (default {!default_http_timeout_s}); a timeout owned by
     this wrapper surfaces as
     [TimeoutError { phase = Http_operation; _ }]. *)
 val post_sync
-  :  ?clock:_ Eio.Time.clock
+  :  ?cache:cache
+  -> ?clock:_ Eio.Time.clock
   -> ?timeout_s:float
   -> sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
@@ -231,12 +282,18 @@ val post_sync
     The connection is bound to [sw]; prefer {!with_post_stream} to
     ensure the connection fd is released when the stream is consumed.
 
+    [cache] is accepted for API symmetry but is currently ignored: the
+    returned [Buf_read.t] outlives this function, so the client cannot
+    be safely parked until consumption finishes. Use {!with_post_stream}
+    for cache-aware streaming.
+
     When [clock] is supplied only the connect + initial response
     headers are bounded by [connect_timeout_s] (default
     {!default_http_timeout_s}); body consumption through the returned
     reader is the caller's responsibility to timebox. *)
 val post_stream
-  :  ?clock:_ Eio.Time.clock
+  :  ?cache:cache
+  -> ?clock:_ Eio.Time.clock
   -> ?connect_timeout_s:float
   -> sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
@@ -250,6 +307,9 @@ val post_stream
     [f] receives the reader; when [f] returns the connection is closed
     and its fd is released immediately.
 
+    When [cache] is supplied, the streaming connection is bound to the
+    cache's long-lived switch so it can be reused across requests.
+
     [connect_timeout_s] bounds only the connect + initial response
     headers phase when [clock] is supplied; a stall there surfaces as
     [TimeoutError { phase = Http_operation; _ }].
@@ -262,7 +322,8 @@ val post_stream
     [Stream_idle]); callers that let it propagate get
     [TimeoutError { phase = Unknown_timeout; _ }] as a safe default. *)
 val with_post_stream
-  :  ?clock:_ Eio.Time.clock
+  :  ?cache:cache
+  -> ?clock:_ Eio.Time.clock
   -> ?connect_timeout_s:float
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> url:string

--- a/test/dune
+++ b/test/dune
@@ -465,6 +465,11 @@
  (libraries agent_sdk llm_provider alcotest eio_main eio.mock))
 
 (test
+ (name test_http_client_cache)
+ (modules test_http_client_cache)
+ (libraries agent_sdk llm_provider alcotest eio_main eio.mock))
+
+(test
  (name test_llm_provider_cov)
  (modules test_llm_provider_cov)
  (libraries agent_sdk llm_provider alcotest))

--- a/test/test_http_client_cache.ml
+++ b/test/test_http_client_cache.ml
@@ -1,0 +1,268 @@
+(** Connection cache tests for Http_client.
+
+    These tests exercise the reusable TCP/TLS connection cache through both
+    the high-level {!Complete} API and direct {!Http_client} calls. *)
+
+open Agent_sdk
+open Llm_provider
+
+let fresh_port () =
+  let s = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Unix.setsockopt s Unix.SO_REUSEADDR true;
+  Unix.bind s (Unix.ADDR_INET (Unix.inet_addr_loopback, 0));
+  let port =
+    match Unix.getsockname s with
+    | Unix.ADDR_INET (_, p) -> p
+    | _ -> failwith "not inet"
+  in
+  Unix.close s;
+  port
+;;
+
+let start_mock_server ~sw ~net ?(status = `OK) ?capture_headers response_body =
+  let port = fresh_port () in
+  let handler _conn req body =
+    let request_body = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    (match capture_headers with
+     | Some seen -> seen := Cohttp.Request.headers req
+     | None -> ());
+    ignore request_body;
+    Cohttp_eio.Server.respond_string ~status ~body:response_body ()
+  in
+  let socket =
+    Eio.Net.listen
+      net
+      ~sw
+      ~backlog:8
+      ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  let server = Cohttp_eio.Server.make ~callback:handler () in
+  Eio.Fiber.fork ~sw (fun () ->
+    Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+  Printf.sprintf "http://127.0.0.1:%d" port
+;;
+
+let anthropic_response text =
+  Printf.sprintf
+    {|{"id":"msg-1","type":"message","role":"assistant","model":"mock","content":[{"type":"text","text":"%s"}],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}|}
+    text
+;;
+
+let make_anthropic_config base_url =
+  Provider_config.make
+    ~kind:Provider_config.Anthropic
+    ~model_id:"test-model"
+    ~base_url
+    ~request_path:"/v1/messages"
+    ~temperature:0.0
+    ~max_tokens:100
+    ()
+;;
+
+let test_complete_reuses_connection () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url = start_mock_server ~sw ~net:env#net (anthropic_response "cached") in
+    let config = make_anthropic_config url in
+    let cache = Http_client.create_cache ~sw () in
+    (match
+       Complete.complete ~sw ~net:env#net ~config ~messages:[] ~connection_cache:cache ()
+     with
+     | Ok _ -> ()
+     | Error _ -> Alcotest.fail "expected Ok first call");
+    let stats_after_first = Http_client.cache_stats cache in
+    Alcotest.(check int) "one create after first" 1 stats_after_first.create_count_total;
+    Alcotest.(check int) "no reuse yet" 0 stats_after_first.reuse_count_total;
+    Alcotest.(check int) "one idle connection" 1 stats_after_first.total_idle;
+    (match
+       Complete.complete ~sw ~net:env#net ~config ~messages:[] ~connection_cache:cache ()
+     with
+     | Ok _ -> ()
+     | Error _ -> Alcotest.fail "expected Ok second call");
+    let stats_after_second = Http_client.cache_stats cache in
+    Alcotest.(check int) "still one create" 1 stats_after_second.create_count_total;
+    Alcotest.(check int) "one reuse" 1 stats_after_second.reuse_count_total;
+    Alcotest.(check int) "still one idle" 1 stats_after_second.total_idle;
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
+let test_eviction_fiber_closes_idle () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url = start_mock_server ~sw ~net:env#net (anthropic_response "cached") in
+    let config = make_anthropic_config url in
+    let cache = Http_client.create_cache ~sw ~clock:env#clock ~idle_ttl_seconds:0.05 () in
+    (match
+       Complete.complete ~sw ~net:env#net ~config ~messages:[] ~connection_cache:cache ()
+     with
+     | Ok _ -> ()
+     | Error _ -> Alcotest.fail "expected Ok");
+    let stats_after_first = Http_client.cache_stats cache in
+    Alcotest.(check int) "one idle before eviction" 1 stats_after_first.total_idle;
+    Eio.Time.sleep env#clock 0.2;
+    let stats_after_wait = Http_client.cache_stats cache in
+    Alcotest.(check int) "idle evicted by fiber" 0 stats_after_wait.total_idle;
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
+let test_omits_connection_close_header () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let captured = ref (Cohttp.Header.of_list []) in
+    let url =
+      start_mock_server
+        ~sw
+        ~net:env#net
+        ~capture_headers:captured
+        (anthropic_response "cached")
+    in
+    let config = make_anthropic_config url in
+    let cache = Http_client.create_cache ~sw () in
+    (match
+       Complete.complete ~sw ~net:env#net ~config ~messages:[] ~connection_cache:cache ()
+     with
+     | Ok _ -> ()
+     | Error _ -> Alcotest.fail "expected Ok");
+    let conn = Cohttp.Header.get !captured "connection" in
+    Alcotest.(check (option string)) "no connection close" None conn;
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
+let anthropic_sse_response text =
+  Printf.sprintf
+    "event: message_start\n\
+     data: \
+     {\"type\":\"message_start\",\"message\":{\"id\":\"msg-1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"mock\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n\n\
+     event: content_block_start\n\
+     data: \
+     {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n\
+     event: content_block_delta\n\
+     data: \
+     {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"%s\"}}\n\n\
+     event: content_block_stop\n\
+     data: {\"type\":\"content_block_stop\",\"index\":0}\n\n\
+     event: message_delta\n\
+     data: \
+     {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\n\
+     event: message_stop\n\
+     data: {\"type\":\"message_stop\"}\n\n"
+    text
+;;
+
+let start_sse_server ~sw ~net response_body =
+  let port = fresh_port () in
+  let handler _conn _req body =
+    let _ = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    let headers = Cohttp.Header.of_list [ "content-type", "text/event-stream" ] in
+    Cohttp_eio.Server.respond_string ~status:`OK ~headers ~body:response_body ()
+  in
+  let socket =
+    Eio.Net.listen
+      net
+      ~sw
+      ~backlog:8
+      ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  let server = Cohttp_eio.Server.make ~callback:handler () in
+  Eio.Fiber.fork ~sw (fun () ->
+    Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+  Printf.sprintf "http://127.0.0.1:%d" port
+;;
+
+let test_stream_reuses_connection () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url = start_sse_server ~sw ~net:env#net (anthropic_sse_response "streamed") in
+    let config = make_anthropic_config url in
+    let cache = Http_client.create_cache ~sw () in
+    let got = ref [] in
+    (match
+       Complete.complete_stream
+         ~sw
+         ~net:env#net
+         ~config
+         ~messages:[]
+         ~connection_cache:cache
+         ~on_event:(function
+           | Types.ContentBlockDelta { delta = Types.TextDelta s; _ } -> got := s :: !got
+           | _ -> ())
+         ()
+     with
+     | Ok _ -> ()
+     | Error _ -> Alcotest.fail "expected Ok stream");
+    Alcotest.(check (list string)) "received text" [ "streamed" ] (List.rev !got);
+    let stats_after_first = Http_client.cache_stats cache in
+    Alcotest.(check int) "one create after stream" 1 stats_after_first.create_count_total;
+    Alcotest.(check int) "one idle after stream" 1 stats_after_first.total_idle;
+    got := [];
+    (match
+       Complete.complete_stream
+         ~sw
+         ~net:env#net
+         ~config
+         ~messages:[]
+         ~connection_cache:cache
+         ~on_event:(function
+           | Types.ContentBlockDelta { delta = Types.TextDelta s; _ } -> got := s :: !got
+           | _ -> ())
+         ()
+     with
+     | Ok _ -> ()
+     | Error _ -> Alcotest.fail "expected Ok stream second");
+    let stats_after_second = Http_client.cache_stats cache in
+    Alcotest.(check int) "one reuse" 1 stats_after_second.reuse_count_total;
+    Alcotest.(check int) "still one create" 1 stats_after_second.create_count_total;
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
+let () =
+  Alcotest.run
+    "HTTP Client Connection Cache"
+    [ ( "reuse"
+      , [ Alcotest.test_case
+            "sync connection reused"
+            `Quick
+            test_complete_reuses_connection
+        ] )
+    ; ( "lifecycle"
+      , [ Alcotest.test_case
+            "eviction fiber closes idle"
+            `Quick
+            test_eviction_fiber_closes_idle
+        ] )
+    ; ( "headers"
+      , [ Alcotest.test_case
+            "omits connection close"
+            `Quick
+            test_omits_connection_close_header
+        ] )
+    ; ( "stream"
+      , [ Alcotest.test_case
+            "reuses streaming connection"
+            `Quick
+            test_stream_reuses_connection
+        ] )
+    ]
+;;

--- a/test/test_http_client_cache.ml
+++ b/test/test_http_client_cache.ml
@@ -262,6 +262,63 @@ let test_per_host_cap_closes_excess () =
   | Exit -> ()
 ;;
 
+let test_create_cache_rejects_invalid_params () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let expect_invalid_arg f =
+      try
+        ignore (f ());
+        Alcotest.fail "expected Invalid_argument"
+      with
+      | Invalid_argument _ -> ()
+    in
+    expect_invalid_arg (fun () -> Http_client.create_cache ~sw ~max_idle_per_host:0 ());
+    expect_invalid_arg (fun () -> Http_client.create_cache ~sw ~max_idle_per_host:(-1) ());
+    expect_invalid_arg (fun () -> Http_client.create_cache ~sw ~idle_ttl_seconds:0.0 ());
+    expect_invalid_arg (fun () ->
+      Http_client.create_cache ~sw ~idle_ttl_seconds:(-1.0) ());
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
+let test_stream_cancellation_closes_connection () =
+  (* Slow SSE server: cancel the fiber mid-body and assert the cached
+     connection is closed, not parked back into the cache. *)
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url = start_sse_server ~sw ~net:env#net (anthropic_sse_response "never") in
+    let cache = Http_client.create_cache ~sw () in
+    let stream () =
+      Http_client.with_post_stream
+        ~cache
+        ~net:env#net
+        ~url
+        ~headers:[]
+        ~body:""
+        ~f:(fun reader ->
+          (* Read one line then block forever, simulating a stuck consumer. *)
+          ignore (Eio.Buf_read.line reader);
+          Eio.Time.sleep env#clock 60.0;
+          Ok ())
+        ()
+    in
+    (try ignore (Eio.Time.with_timeout_exn env#clock 0.2 stream) with
+     | Eio.Time.Timeout -> ());
+    let stats = Http_client.cache_stats cache in
+    Alcotest.(check int) "cancelled stream does not park connection" 0 stats.total_idle;
+    Alcotest.(check int) "one create" 1 stats.create_count_total;
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
 let () =
   Alcotest.run
     "HTTP Client Connection Cache"
@@ -292,6 +349,16 @@ let () =
             "reuses streaming connection"
             `Quick
             test_stream_reuses_connection
+        ; Alcotest.test_case
+            "cancellation closes connection"
+            `Quick
+            test_stream_cancellation_closes_connection
+        ] )
+    ; ( "validation"
+      , [ Alcotest.test_case
+            "create_cache rejects invalid params"
+            `Quick
+            test_create_cache_rejects_invalid_params
         ] )
     ]
 ;;

--- a/test/test_http_client_cache.ml
+++ b/test/test_http_client_cache.ml
@@ -237,6 +237,31 @@ let test_stream_reuses_connection () =
   | Exit -> ()
 ;;
 
+let test_per_host_cap_closes_excess () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url = start_mock_server ~sw ~net:env#net (anthropic_response "cached") in
+    let config = make_anthropic_config url in
+    let cache = Http_client.create_cache ~sw ~max_idle_per_host:1 () in
+    let once () =
+      match
+        Complete.complete ~sw ~net:env#net ~config ~messages:[] ~connection_cache:cache ()
+      with
+      | Ok _ -> ()
+      | Error _ -> Alcotest.fail "expected Ok concurrent"
+    in
+    Eio.Fiber.both once once;
+    let stats = Http_client.cache_stats cache in
+    Alcotest.(check int) "two creates for concurrent" 2 stats.create_count_total;
+    Alcotest.(check int) "only one idle due to cap" 1 stats.total_idle;
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
 let () =
   Alcotest.run
     "HTTP Client Connection Cache"
@@ -245,6 +270,10 @@ let () =
             "sync connection reused"
             `Quick
             test_complete_reuses_connection
+        ; Alcotest.test_case
+            "per-host cap closes excess"
+            `Quick
+            test_per_host_cap_closes_excess
         ] )
     ; ( "lifecycle"
       , [ Alcotest.test_case


### PR DESCRIPTION
This PR adds a reusable connection cache for OAS HTTP provider calls.

## What changed

- `Http_client` now exposes `create_cache`, `cache_stats`, and a `cache` type.
- Cached entries are keyed by origin (scheme, host, port) and store real Eio transport connections (not just `Cohttp_eio.Client.t` handles), so TCP+TLS handshakes are reused across requests.
- `?connection_cache` is threaded through `Complete.complete`, `complete_with_retry`, `complete_stream`, "complete_stream_with_retry`, and `make_http_transport`.
- When a cache is supplied the `connection: close` request header is omitted so HTTP keep-alive works.
- A TTL eviction fiber reaps idle connections; the cache switch closes all leftover connections on release.

## Tests

- Added `test/test_http_client_cache.ml` covering:
  - sync connection reuse (stats show one create, one reuse)
  - streaming connection reuse
  - no `connection: close` header when cached
  - TTL eviction fiber closes idle connections
- Full `dune build @runtest` passes locally.

Relates to the performance analysis in `memory/masc-performance-analysis-2026-06-17.md`.