### PR TITLE
perf(event_bus): O(1) subscriber count and empty-bus publish fast path

### DIFF
--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -247,6 +247,9 @@ type t =
   ; (* Nanosecond accumulator (monotonic int add); exposed as float seconds
      via [stats] to avoid float accumulation drift across publishers. *)
     block_nanos_total : int Atomic.t
+  ; (* Cached subscriber count for O(1) queries and a lock-free fast path
+     when the bus has no subscribers. Updated under [mu]. *)
+    subscriber_count : int Atomic.t
   }
 
 let create ?(buffer_size = 256) ?(policy = Block) () =
@@ -256,6 +259,7 @@ let create ?(buffer_size = 256) ?(policy = Block) () =
   ; buffer_size
   ; policy
   ; block_nanos_total = Atomic.make 0
+  ; subscriber_count = Atomic.make 0
   }
 ;;
 
@@ -336,12 +340,16 @@ let subscribe ?(filter = accept_all) ?purpose bus =
     in
     bus.subscribers <- sub :: bus.subscribers;
     bus.next_id <- id + 1;
+    ignore (Atomic.fetch_and_add bus.subscriber_count 1);
     sub)
 ;;
 
 let unsubscribe bus sub =
   Eio.Mutex.use_rw ~protect:true bus.mu (fun () ->
-    bus.subscribers <- List.filter (fun s -> s.id <> sub.id) bus.subscribers)
+    let before = List.length bus.subscribers in
+    bus.subscribers <- List.filter (fun s -> s.id <> sub.id) bus.subscribers;
+    let after = List.length bus.subscribers in
+    if after < before then ignore (Atomic.fetch_and_add bus.subscriber_count (-1)) else ())
 ;;
 
 (* ── Publish ──────────────────────────────────────────────────────── *)
@@ -392,11 +400,17 @@ let deliver_to_sub bus sub event =
 ;;
 
 let publish bus event =
-  (* Snapshot subscriber list under lock, then deliver outside lock.
-     Stream.add can block on a full stream — holding the lock would
-     deadlock if another fiber tries to subscribe concurrently. *)
-  let subs = Eio.Mutex.use_ro bus.mu (fun () -> bus.subscribers) in
-  List.iter (fun sub -> if sub.filter event then deliver_to_sub bus sub event) subs
+  (* Fast path: no subscribers means no lock, no filter evaluation, no
+     stream operations. Common for buses created speculatively or while
+     subscribers are temporarily drained. *)
+  if Atomic.get bus.subscriber_count = 0
+  then ()
+  else (
+    (* Snapshot subscriber list under lock, then deliver outside lock.
+       Stream.add can block on a full stream — holding the lock would
+       deadlock if another fiber tries to subscribe concurrently. *)
+    let subs = Eio.Mutex.use_ro bus.mu (fun () -> bus.subscribers) in
+    List.iter (fun sub -> if sub.filter event then deliver_to_sub bus sub event) subs)
 ;;
 
 (* ── Drain ────────────────────────────────────────────────────────── *)
@@ -414,7 +428,7 @@ let drain sub =
 
 (* ── Queries ──────────────────────────────────────────────────────── *)
 
-let subscriber_count bus = Eio.Mutex.use_ro bus.mu (fun () -> List.length bus.subscribers)
+let subscriber_count bus = Atomic.get bus.subscriber_count
 
 type subscription_stats =
   { purpose : string option

--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -338,9 +338,14 @@ let subscribe ?(filter = accept_all) ?purpose bus =
       ; deliver_mu = Eio.Mutex.create ()
       }
     in
+    (* Increment the published counter before mutating the subscriber list.
+       [publish] reads the counter lock-free to decide whether to take the
+       fast path; both updates happen under [mu], so a publisher that sees a
+       non-zero counter is guaranteed to see the corresponding subscriber(s)
+       once it acquires [mu]. *)
+    ignore (Atomic.fetch_and_add bus.subscriber_count 1);
     bus.subscribers <- sub :: bus.subscribers;
     bus.next_id <- id + 1;
-    ignore (Atomic.fetch_and_add bus.subscriber_count 1);
     sub)
 ;;
 

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -97,6 +97,24 @@ let test_unsubscribed_no_receive () =
   check int "no events after unsub" 0 (List.length events)
 ;;
 
+let test_publish_no_subscribers_is_noop () =
+  Eio_main.run
+  @@ fun _env ->
+  let bus = Event_bus.create () in
+  Event_bus.publish bus (ev (TurnStarted { agent_name = "a"; turn = 0 }));
+  check int "count stays zero" 0 (Event_bus.subscriber_count bus)
+;;
+
+let test_unsubscribe_idempotent_count () =
+  Eio_main.run
+  @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  Event_bus.unsubscribe bus sub;
+  Event_bus.unsubscribe bus sub;
+  check int "count not negative" 0 (Event_bus.subscriber_count bus)
+;;
+
 (* ── drain ────────────────────────────────────────────────────────── *)
 
 let test_drain_fifo () =
@@ -1200,6 +1218,11 @@ let () =
       , [ test_case "received" `Quick test_publish_received
         ; test_case "multiple subscribers" `Quick test_publish_multiple_subscribers
         ; test_case "unsubscribed no receive" `Quick test_unsubscribed_no_receive
+        ; test_case "no subscribers is noop" `Quick test_publish_no_subscribers_is_noop
+        ; test_case
+            "unsubscribe idempotent count"
+            `Quick
+            test_unsubscribe_idempotent_count
         ] )
     ; ( "drain"
       , [ test_case "fifo order" `Quick test_drain_fifo


### PR DESCRIPTION
Adds an atomic subscriber-count cache to Event_bus.t and uses it for a lock-free fast path in [publish] when no subscribers are attached.

Changes:
- Cache subscriber count in an atomic so [subscriber_count] and the empty-bus fast path need no lock.
- Update the cached count on subscribe/unsubscribe; unsubscribe is idempotent w.r.t. the counter.
- Skip lock acquisition, filter evaluation, and stream operations in [publish] when there are no subscribers.
- Add tests for the no-subscriber publish path and idempotent unsubscribe counter.

Related work: stacks on top of the HTTP connection cache effort (feat/http-connection-cache) as another pure-OAS performance improvement.