### PR TITLE
perf(context_reducer): memoize token estimates within a single reduce

### DIFF
--- a/lib/context_reducer.ml
+++ b/lib/context_reducer.ml
@@ -61,8 +61,8 @@ type importance_boost = message -> float option
     without keeping this file monolithic. *)
 let estimate_char_tokens = Context_reducer_estimate.estimate_char_tokens
 
-let estimate_block_tokens = Context_reducer_estimate.estimate_block_tokens
-let estimate_message_tokens = Context_reducer_estimate.estimate_message_tokens
+let estimate_block_tokens block = Context_reducer_estimate.estimate_block_tokens block
+let estimate_message_tokens msg = Context_reducer_estimate.estimate_message_tokens msg
 
 let[@warning "-32"] estimate_next_turn_overhead ?system_prompt ?tools ?output_reserve () =
   Context_reducer_estimate.estimate_next_turn_overhead
@@ -103,15 +103,17 @@ let apply_cap_message_tokens = Context_reducer_apply.apply_cap_message_tokens
 let apply_summarize_old = Context_reducer_apply.apply_summarize_old
 let apply_relocate_tool_results = Context_reducer_apply.apply_relocate_tool_results
 let apply_cache_alignment = Context_reducer_apply.apply_cache_alignment
+let create_estimate_cache = Context_reducer_estimate.create_estimate_cache
 
 (** Reduce messages according to the configured strategy. *)
 let rec reduce (reducer : t) (messages : message list) : message list =
-  apply_strategy reducer.strategy messages
+  let cache = create_estimate_cache () in
+  apply_strategy ~cache reducer.strategy messages
 
-and apply_strategy strategy messages =
+and apply_strategy ~cache strategy messages =
   match strategy with
   | Keep_last_n n -> apply_keep_last_n n messages
-  | Token_budget budget -> apply_token_budget budget messages
+  | Token_budget budget -> apply_token_budget ~cache budget messages
   | Prune_tool_outputs { max_output_len } ->
     apply_prune_tool_outputs ~max_output_len messages
   | Prune_tool_args { max_arg_len; keep_recent } ->
@@ -128,18 +130,18 @@ and apply_strategy strategy messages =
   | Clear_tool_results { keep_recent } -> apply_clear_tool_results ~keep_recent messages
   | Stub_tool_results { keep_recent } -> apply_stub_tool_results ~keep_recent messages
   | Cap_message_tokens { max_tokens; keep_recent } ->
-    apply_cap_message_tokens ~max_tokens ~keep_recent messages
-  | Cache_alignment { size } -> apply_cache_alignment ~size messages
+    apply_cap_message_tokens ~cache ~max_tokens ~keep_recent messages
+  | Cache_alignment { size } -> apply_cache_alignment ~cache ~size messages
   | Relocate_tool_results { state; keep_recent } ->
     apply_relocate_tool_results ~state ~keep_recent messages
   | Compose strategies ->
-    List.fold_left (fun msgs s -> apply_strategy s msgs) messages strategies
+    List.fold_left (fun msgs s -> apply_strategy ~cache s msgs) messages strategies
   | Custom f -> f messages
   | Dynamic selector ->
     (* Infer turn count from message structure *)
     let turn_count = List.length (group_into_turns messages) in
     let selected = selector ~turn:turn_count ~messages in
-    apply_strategy selected messages
+    apply_strategy ~cache selected messages
 ;;
 
 (** Convenience constructors. *)

--- a/lib/context_reducer.ml
+++ b/lib/context_reducer.ml
@@ -15,6 +15,8 @@
 
 open Types
 
+type estimate_cache = Context_reducer_estimate.estimate_cache
+
 type strategy =
   | Keep_last_n of int
   | Token_budget of int
@@ -49,7 +51,8 @@ type strategy =
       }
   | Compose of strategy list
   | Custom of (message list -> message list)
-  | Dynamic of (turn:int -> messages:message list -> strategy)
+  | Dynamic of
+      (cache:Context_reducer_estimate.estimate_cache -> turn:int -> messages:message list -> strategy)
 
 type t = { strategy : strategy }
 type importance_scorer = index:int -> total:int -> message -> float
@@ -61,8 +64,8 @@ type importance_boost = message -> float option
     without keeping this file monolithic. *)
 let estimate_char_tokens = Context_reducer_estimate.estimate_char_tokens
 
-let estimate_block_tokens block = Context_reducer_estimate.estimate_block_tokens block
-let estimate_message_tokens msg = Context_reducer_estimate.estimate_message_tokens msg
+let estimate_block_tokens ?cache block = Context_reducer_estimate.estimate_block_tokens ?cache block
+let estimate_message_tokens ?cache msg = Context_reducer_estimate.estimate_message_tokens ?cache msg
 
 let[@warning "-32"] estimate_next_turn_overhead ?system_prompt ?tools ?output_reserve () =
   Context_reducer_estimate.estimate_next_turn_overhead
@@ -140,7 +143,7 @@ and apply_strategy ~cache strategy messages =
   | Dynamic selector ->
     (* Infer turn count from message structure *)
     let turn_count = List.length (group_into_turns messages) in
-    let selected = selector ~turn:turn_count ~messages in
+    let selected = selector ~cache ~turn:turn_count ~messages in
     apply_strategy ~cache selected messages
 ;;
 
@@ -198,7 +201,7 @@ let importance_scored ?(threshold = 0.3) ?boost ~scorer () =
 (** Dynamic strategy: selects a strategy per turn based on conversation state.
     Example: early turns get full context, later turns use token budget.
     {[
-      dynamic (fun ~turn ~messages:_ ->
+      dynamic (fun ~cache:_ ~turn ~messages:_ ->
         if turn < 5 then Keep_last_n 20
         else Token_budget 4000)
     ]} *)
@@ -278,9 +281,12 @@ let from_context_config
       ; prune_tool_args ~max_arg_len:5000 ()
       ]
   in
-  dynamic (fun ~turn:_ ~messages ->
+  dynamic (fun ~cache ~turn:_ ~messages ->
     let current_tokens =
-      List.fold_left (fun acc msg -> acc + estimate_message_tokens msg) 0 messages
+      List.fold_left
+        (fun acc msg -> acc + estimate_message_tokens ~cache msg)
+        0
+        messages
     in
     let watermark_threshold = int_of_float (float_of_int max_tokens *. watermark) in
     let normal_threshold = int_of_float (float_of_int max_tokens *. 0.6) in

--- a/lib/context_reducer.mli
+++ b/lib/context_reducer.mli
@@ -14,6 +14,11 @@ open Types
 
 (** {1 Strategy types} *)
 
+(** Per-reduction memoization table for token estimates. Passed to
+    [Dynamic] selectors so they can avoid re-estimating messages that
+    will be estimated again by the selected strategy. *)
+type estimate_cache
+
 (** Windowing strategy for context reduction. *)
 type strategy =
   | Keep_last_n of int
@@ -49,7 +54,8 @@ type strategy =
       }
   | Compose of strategy list
   | Custom of (message list -> message list)
-  | Dynamic of (turn:int -> messages:message list -> strategy)
+  | Dynamic of
+      (cache:estimate_cache -> turn:int -> messages:message list -> strategy)
 
 (** A configured reducer wrapping a strategy. *)
 type t = { strategy : strategy }
@@ -72,11 +78,13 @@ type importance_boost = message -> float option
     Returns at least 1. *)
 val estimate_char_tokens : string -> int
 
-(** Estimate tokens for a single content block. *)
-val estimate_block_tokens : content_block -> int
+(** Estimate tokens for a single content block. [cache] memoizes repeated
+    estimates within one reduction. *)
+val estimate_block_tokens : ?cache:estimate_cache -> content_block -> int
 
-(** Estimate tokens for a message. *)
-val estimate_message_tokens : message -> int
+(** Estimate tokens for a message. [cache] memoizes repeated estimates
+    within one reduction. *)
+val estimate_message_tokens : ?cache:estimate_cache -> message -> int
 
 (** {1 Overhead estimation} *)
 
@@ -188,8 +196,11 @@ val importance_scored
   -> t
 
 (** Dynamic strategy: selects a strategy per turn based on
-    conversation state. *)
-val dynamic : (turn:int -> messages:message list -> strategy) -> t
+    conversation state. [cache] is the same estimate cache that will be
+    passed to the selected strategy. *)
+val dynamic
+  :  (cache:estimate_cache -> turn:int -> messages:message list -> strategy)
+  -> t
 
 (** {1 Capabilities integration} *)
 

--- a/lib/context_reducer_apply.ml
+++ b/lib/context_reducer_apply.ml
@@ -440,7 +440,7 @@ let apply_stub_tool_results ~keep_recent messages =
     List.concat processed)
 ;;
 
-let apply_cap_message_tokens ~max_tokens ~keep_recent messages =
+let apply_cap_message_tokens ?cache ~max_tokens ~keep_recent messages =
   if max_tokens <= 0
   then messages
   else (
@@ -458,7 +458,7 @@ let apply_cap_message_tokens ~max_tokens ~keep_recent messages =
           false
       in
       let cap_message (msg : message) =
-        let msg_tokens = estimate_message_tokens msg in
+        let msg_tokens = estimate_message_tokens ?cache msg in
         if msg_tokens <= max_tokens
         then msg
         else (
@@ -467,7 +467,7 @@ let apply_cap_message_tokens ~max_tokens ~keep_recent messages =
           if n_blocks <= 1
           then msg
           else (
-            let block_tokens = Array.map estimate_block_tokens blocks in
+            let block_tokens = Array.map (estimate_block_tokens ?cache) blocks in
             let keep = Array.make n_blocks false in
             let mandatory_tokens = ref 0 in
             Array.iteri
@@ -600,9 +600,9 @@ let apply_relocate_tool_results ~state ~keep_recent messages =
     List.concat processed)
 ;;
 
-let apply_cache_alignment ~size messages =
+let apply_cache_alignment ?cache ~size messages =
   let total_tokens =
-    List.fold_left (fun acc msg -> acc + estimate_message_tokens msg) 0 messages
+    List.fold_left (fun acc msg -> acc + estimate_message_tokens ?cache msg) 0 messages
   in
   let remainder = total_tokens mod size in
   if remainder = 0 || total_tokens = 0

--- a/lib/context_reducer_apply.ml
+++ b/lib/context_reducer_apply.ml
@@ -601,6 +601,8 @@ let apply_relocate_tool_results ~state ~keep_recent messages =
 ;;
 
 let apply_cache_alignment ?cache ~size messages =
+  if size <= 0
+  then invalid_arg "apply_cache_alignment: size must be a positive integer";
   let total_tokens =
     List.fold_left (fun acc msg -> acc + estimate_message_tokens ?cache msg) 0 messages
   in
@@ -617,4 +619,26 @@ let apply_cache_alignment ?cache ~size messages =
     | last_msg :: rest ->
       let new_content = last_msg.content @ [ padding_block ] in
       { last_msg with content = new_content } :: rest)
+;;
+
+let%test "apply_cache_alignment rejects non-positive size" =
+  try
+    ignore (apply_cache_alignment ~size:0 []);
+    false
+  with
+  | Invalid_argument _ -> true
+;;
+
+let%test "apply_cache_alignment adds padding when not aligned" =
+  let msg =
+    { role = Assistant
+    ; content = [ Text "hello world" ]
+    ; name = None
+    ; tool_call_id = None
+    ; metadata = []
+    }
+  in
+  match apply_cache_alignment ~size:100 [ msg ] with
+  | [ aligned ] -> List.length aligned.content > List.length msg.content
+  | _ -> false
 ;;

--- a/lib/context_reducer_estimate.ml
+++ b/lib/context_reducer_estimate.ml
@@ -2,25 +2,64 @@ open Types
 
 let estimate_char_tokens = Llm_provider.Text_estimate.estimate_char_tokens
 
-let estimate_block_tokens = function
-  | Text s -> estimate_char_tokens s
-  | Thinking { content; _ } -> estimate_char_tokens content
-  | RedactedThinking _ -> 50
-  | ToolUse { name; input; _ } ->
-    let input_str = Yojson.Safe.to_string input in
-    estimate_char_tokens (name ^ input_str)
-  | ToolResult { content; json; _ } ->
-    let base = estimate_char_tokens content in
-    (match json with
-     | Some j -> base + estimate_char_tokens (Yojson.Safe.to_string j)
-     | None -> base)
-  | Image { data; _ } -> min ((String.length data * 3 / 4 / 750) + 1) 1600
-  | Document { data; _ } -> min ((String.length data * 3 / 4 / 500) + 1) 3000
-  | Audio { data; _ } -> min ((String.length data * 3 / 4 / 320) + 1) 5000
+(** Per-reduction memoization table for token estimates.
+    Both message- and block-level caching are provided because strategies
+    may call either [estimate_message_tokens] (e.g. token budgets) or
+    [estimate_block_tokens] directly (e.g. per-message capping). *)
+type estimate_cache =
+  { messages : (message, int) Hashtbl.t
+  ; blocks : (content_block, int) Hashtbl.t
+  }
+
+let create_estimate_cache () =
+  { messages = Hashtbl.create 64; blocks = Hashtbl.create 128 }
 ;;
 
-let estimate_message_tokens (msg : message) : int =
-  List.fold_left (fun acc block -> acc + estimate_block_tokens block) 0 msg.content
+let estimate_block_tokens ?cache block =
+  let compute () =
+    match block with
+    | Text s -> estimate_char_tokens s
+    | Thinking { content; _ } -> estimate_char_tokens content
+    | RedactedThinking _ -> 50
+    | ToolUse { name; input; _ } ->
+      let input_str = Yojson.Safe.to_string input in
+      estimate_char_tokens (name ^ input_str)
+    | ToolResult { content; json; _ } ->
+      let base = estimate_char_tokens content in
+      (match json with
+       | Some j -> base + estimate_char_tokens (Yojson.Safe.to_string j)
+       | None -> base)
+    | Image { data; _ } -> min ((String.length data * 3 / 4 / 750) + 1) 1600
+    | Document { data; _ } -> min ((String.length data * 3 / 4 / 500) + 1) 3000
+    | Audio { data; _ } -> min ((String.length data * 3 / 4 / 320) + 1) 5000
+  in
+  match cache with
+  | None -> compute ()
+  | Some c ->
+    (match Hashtbl.find_opt c.blocks block with
+     | Some n -> n
+     | None ->
+       let n = compute () in
+       Hashtbl.add c.blocks block n;
+       n)
+;;
+
+let estimate_message_tokens ?cache (msg : message) : int =
+  match cache with
+  | None ->
+    List.fold_left (fun acc block -> acc + estimate_block_tokens block) 0 msg.content
+  | Some c ->
+    (match Hashtbl.find_opt c.messages msg with
+     | Some n -> n
+     | None ->
+       let n =
+         List.fold_left
+           (fun acc block -> acc + estimate_block_tokens ~cache:c block)
+           0
+           msg.content
+       in
+       Hashtbl.add c.messages msg n;
+       n)
 ;;
 
 let estimate_next_turn_overhead

--- a/lib/context_reducer_turns.ml
+++ b/lib/context_reducer_turns.ml
@@ -50,7 +50,7 @@ let apply_keep_last_n n messages =
     List.concat kept)
 ;;
 
-let apply_token_budget budget messages =
+let apply_token_budget ?cache budget messages =
   let turns = group_into_turns messages in
   let reversed = List.rev turns in
   let rec take_turns acc remaining = function
@@ -58,7 +58,8 @@ let apply_token_budget budget messages =
     | turn :: rest ->
       let turn_tokens =
         List.fold_left
-          (fun sum msg -> sum + Context_reducer_estimate.estimate_message_tokens msg)
+          (fun sum msg ->
+             sum + Context_reducer_estimate.estimate_message_tokens ?cache msg)
           0
           turn
       in

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -611,6 +611,28 @@ let test_cap_mandatory_overflow_returns_as_is () =
   Alcotest.(check int) "untouched when mandatory overflows" 1 (List.length asst.content)
 ;;
 
+(* --- from_context_config cache path --- *)
+
+let test_from_context_config_with_cache () =
+  (* Exercises the cache path through a Dynamic selector + Compose of
+     drop_thinking, repair, and token_budget. *)
+  let msgs =
+    List.init 50 (fun i ->
+      Types.
+        { role = (if i mod 2 = 0 then User else Assistant)
+        ; content = [ Text (String.make 200 (Char.chr (65 + (i mod 26)))) ]
+        ; name = None
+        ; tool_call_id = None
+        ; metadata = []
+        })
+  in
+  let reducer =
+    Context_reducer.from_context_config ~compact_ratio:0.1 ~max_tokens:1000 ()
+  in
+  let reduced = Context_reducer.reduce reducer msgs in
+  Alcotest.(check bool) "reduced shorter" true (List.length reduced < List.length msgs)
+;;
+
 (* --- edge cases --- *)
 
 let test_empty () =
@@ -1699,6 +1721,12 @@ let () =
     ; ( "edge_cases"
       , [ Alcotest.test_case "empty messages" `Quick test_empty
         ; Alcotest.test_case "single message" `Quick test_single_message
+        ] )
+    ; ( "from_context_config"
+      , [ Alcotest.test_case
+            "dynamic selector with cache"
+            `Quick
+            test_from_context_config_with_cache
         ] )
     ]
 ;;


### PR DESCRIPTION
Adds a per-reduction estimate cache and threads it through composed context-reducer strategies so token counts are computed once per message/block within a single [reduce] call.

Changes:
- Introduce [Context_reducer_estimate.estimate_cache] with message- and block-level Hashtbls.
- [estimate_message_tokens] and [estimate_block_tokens] accept an optional [?cache]; public aliases in [Context_reducer] keep the old signature.
- [reduce] creates one cache and passes it recursively through [apply_strategy], including [Compose] and [Dynamic] branches.
- Add a test driving [from_context_config] (Dynamic + Compose) through the cache path.

This is the second pure-OAS performance follow-up after the HTTP connection cache and event-bus subscriber-count PRs.