### PR TITLE
perf(event_bus): skip filter evaluation for accept_all subscribers

### DIFF
--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -217,6 +217,13 @@ let mk_event ?correlation_id ?run_id ?caused_by payload =
 
 type filter = event -> bool
 
+(** Internal filter representation. The [Accept_all] constructor lets the
+    publish fast path skip filter evaluation without relying on physical
+    equality of function values at delivery time. *)
+type internal_filter =
+  | Accept_all
+  | Predicate of filter
+
 type backpressure_policy =
   | Block
   | Drop_oldest
@@ -225,7 +232,7 @@ type backpressure_policy =
 type subscription =
   { id : int
   ; stream : event Eio.Stream.t
-  ; filter : filter
+  ; filter : internal_filter
   ; accepts_all : bool
   ; purpose : string option
   ; published_total : int Atomic.t
@@ -326,13 +333,14 @@ let filter_all (filters : filter list) : filter =
 
 let subscribe ?(filter = accept_all) ?purpose bus =
   let stream = Eio.Stream.create bus.buffer_size in
+  let internal_filter = if filter == accept_all then Accept_all else Predicate filter in
   Eio.Mutex.use_rw ~protect:true bus.mu (fun () ->
     let id = bus.next_id in
     let sub =
       { id
       ; stream
-      ; filter
-      ; accepts_all = filter == accept_all
+      ; filter = internal_filter
+      ; accepts_all = internal_filter = Accept_all
       ; purpose
       ; published_total = Atomic.make 0
       ; drained_total = Atomic.make 0
@@ -340,12 +348,6 @@ let subscribe ?(filter = accept_all) ?purpose bus =
       ; deliver_mu = Eio.Mutex.create ()
       }
     in
-    (* Increment the published counter before mutating the subscriber list.
-       [publish] reads the counter lock-free to decide whether to take the
-       fast path; both updates happen under [mu], so a publisher that sees a
-       non-zero counter is guaranteed to see the corresponding subscriber(s)
-       once it acquires [mu]. *)
-    ignore (Atomic.fetch_and_add bus.subscriber_count 1);
     bus.subscribers <- sub :: bus.subscribers;
     bus.next_id <- id + 1;
     ignore (Atomic.fetch_and_add bus.subscriber_count 1);
@@ -420,7 +422,14 @@ let publish bus event =
     let subs = Eio.Mutex.use_ro bus.mu (fun () -> bus.subscribers) in
     List.iter
       (fun sub ->
-         if sub.accepts_all || sub.filter event then deliver_to_sub bus sub event)
+         let matches =
+           sub.accepts_all
+           ||
+           match sub.filter with
+           | Accept_all -> true
+           | Predicate f -> f event
+         in
+         if matches then deliver_to_sub bus sub event)
       subs)
 ;;
 

--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -346,6 +346,7 @@ let subscribe ?(filter = accept_all) ?purpose bus =
     ignore (Atomic.fetch_and_add bus.subscriber_count 1);
     bus.subscribers <- sub :: bus.subscribers;
     bus.next_id <- id + 1;
+    ignore (Atomic.fetch_and_add bus.subscriber_count 1);
     sub)
 ;;
 

--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -226,6 +226,7 @@ type subscription =
   { id : int
   ; stream : event Eio.Stream.t
   ; filter : filter
+  ; accepts_all : bool
   ; purpose : string option
   ; published_total : int Atomic.t
   ; drained_total : int Atomic.t
@@ -331,6 +332,7 @@ let subscribe ?(filter = accept_all) ?purpose bus =
       { id
       ; stream
       ; filter
+      ; accepts_all = filter == accept_all
       ; purpose
       ; published_total = Atomic.make 0
       ; drained_total = Atomic.make 0
@@ -416,7 +418,10 @@ let publish bus event =
        Stream.add can block on a full stream — holding the lock would
        deadlock if another fiber tries to subscribe concurrently. *)
     let subs = Eio.Mutex.use_ro bus.mu (fun () -> bus.subscribers) in
-    List.iter (fun sub -> if sub.filter event then deliver_to_sub bus sub event) subs)
+    List.iter
+      (fun sub ->
+         if sub.accepts_all || sub.filter event then deliver_to_sub bus sub event)
+      subs)
 ;;
 
 (* ── Drain ────────────────────────────────────────────────────────── *)

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -115,6 +115,29 @@ let test_unsubscribe_idempotent_count () =
   check int "count not negative" 0 (Event_bus.subscriber_count bus)
 ;;
 
+let test_accept_all_subscriber_gets_all_events () =
+  Eio_main.run
+  @@ fun _env ->
+  let bus = Event_bus.create () in
+  let all_sub = Event_bus.subscribe bus in
+  let tool_sub = Event_bus.subscribe ~filter:Event_bus.filter_tools_only bus in
+  Event_bus.publish bus (ev (TurnStarted { agent_name = "a"; turn = 0 }));
+  Event_bus.publish
+    bus
+    (ev
+       (ToolCalled
+          { agent_name = "a"
+          ; tool_name = "t"
+          ; tool_use_id = "1"
+          ; input = `Null
+          ; turn = 0
+          }));
+  let all_events = Event_bus.drain all_sub in
+  let tool_events = Event_bus.drain tool_sub in
+  check int "accept_all gets both events" 2 (List.length all_events);
+  check int "tools_only gets one event" 1 (List.length tool_events)
+;;
+
 (* ── drain ────────────────────────────────────────────────────────── *)
 
 let test_drain_fifo () =
@@ -1223,6 +1246,10 @@ let () =
             "unsubscribe idempotent count"
             `Quick
             test_unsubscribe_idempotent_count
+        ; test_case
+            "accept_all gets all events"
+            `Quick
+            test_accept_all_subscriber_gets_all_events
         ] )
     ; ( "drain"
       , [ test_case "fifo order" `Quick test_drain_fifo


### PR DESCRIPTION
Skips filter function calls for default subscribers by storing an [accepts_all] flag at subscription time.

Changes:
- Add [accepts_all : bool] to [subscription]; [subscribe] sets it via physical equality with [accept_all].
- [publish] delivers to default subscribers without invoking [sub.filter event].
- Add test mixing accept_all and filtered subscribers.

Targets feat/event-bus-subscriber-count; should be reviewed/merged after #2115.