### PR TITLE
fix: ocamlformat drift and Dynamic selector API fallout on main

### DIFF
--- a/examples/async_agent_demo.ml
+++ b/examples/async_agent_demo.ml
@@ -38,7 +38,11 @@ let read_only_tool =
     ~name:"lookup"
     ~description:"Lookup a value"
     ~parameters:
-      [ { name = "key"; description = "Key to look up"; param_type = String; required = true }
+      [ { name = "key"
+        ; description = "Key to look up"
+        ; param_type = String
+        ; required = true
+        }
       ]
     (fun args ->
        let open Yojson.Safe.Util in
@@ -74,7 +78,11 @@ let external_fetch_tool =
     ~name:"fetch_url"
     ~description:"Fetch a URL (simulated)"
     ~parameters:
-      [ { name = "url"; description = "URL to fetch"; param_type = String; required = true }
+      [ { name = "url"
+        ; description = "URL to fetch"
+        ; param_type = String
+        ; required = true
+        }
       ]
     (fun args ->
        let open Yojson.Safe.Util in
@@ -123,8 +131,14 @@ let () =
   (* 2. Race two agents; the first to finish wins, the other is cancelled. *)
   let agent_b = make_agent ~net "racer-b" in
   let agent_c = make_agent ~net "racer-c" in
-  (match Async_agent.race ~sw ~clock [ agent_b, "Look up 'ocaml'."; agent_c, "Look up 'eio'." ] with
-   | Ok (name, resp) -> Printf.printf "[race] winner=%s result=%s\n" name (extract_text resp)
+  (match
+     Async_agent.race
+       ~sw
+       ~clock
+       [ agent_b, "Look up 'ocaml'."; agent_c, "Look up 'eio'." ]
+   with
+   | Ok (name, resp) ->
+     Printf.printf "[race] winner=%s result=%s\n" name (extract_text resp)
    | Error e -> Printf.eprintf "[race] error: %s\n" (Error.to_string e));
   (* 3. Run several agents in parallel and collect all results. *)
   let agents =

--- a/examples/tool_use.ml
+++ b/examples/tool_use.ml
@@ -81,11 +81,7 @@ let weather_api_tool =
     ~name:"weather"
     ~description:"Fetch current weather for a city"
     ~parameters:
-      [ { name = "city"
-        ; description = "City name"
-        ; param_type = String
-        ; required = true
-        }
+      [ { name = "city"; description = "City name"; param_type = String; required = true }
       ]
     (fun args ->
        let open Yojson.Safe.Util in
@@ -137,8 +133,7 @@ let () =
     { default_config with
       name = "tool-demo"
     ; system_prompt =
-        Some
-          "You have access to a calculator, a weather API, and a counter. Use them."
+        Some "You have access to a calculator, a weather API, and a counter. Use them."
     ; max_turns = 3
     }
   in

--- a/lib/context_reducer.ml
+++ b/lib/context_reducer.ml
@@ -52,7 +52,10 @@ type strategy =
   | Compose of strategy list
   | Custom of (message list -> message list)
   | Dynamic of
-      (cache:Context_reducer_estimate.estimate_cache -> turn:int -> messages:message list -> strategy)
+      (cache:Context_reducer_estimate.estimate_cache
+       -> turn:int
+       -> messages:message list
+       -> strategy)
 
 type t = { strategy : strategy }
 type importance_scorer = index:int -> total:int -> message -> float
@@ -64,8 +67,13 @@ type importance_boost = message -> float option
     without keeping this file monolithic. *)
 let estimate_char_tokens = Context_reducer_estimate.estimate_char_tokens
 
-let estimate_block_tokens ?cache block = Context_reducer_estimate.estimate_block_tokens ?cache block
-let estimate_message_tokens ?cache msg = Context_reducer_estimate.estimate_message_tokens ?cache msg
+let estimate_block_tokens ?cache block =
+  Context_reducer_estimate.estimate_block_tokens ?cache block
+;;
+
+let estimate_message_tokens ?cache msg =
+  Context_reducer_estimate.estimate_message_tokens ?cache msg
+;;
 
 let[@warning "-32"] estimate_next_turn_overhead ?system_prompt ?tools ?output_reserve () =
   Context_reducer_estimate.estimate_next_turn_overhead
@@ -283,10 +291,7 @@ let from_context_config
   in
   dynamic (fun ~cache ~turn:_ ~messages ->
     let current_tokens =
-      List.fold_left
-        (fun acc msg -> acc + estimate_message_tokens ~cache msg)
-        0
-        messages
+      List.fold_left (fun acc msg -> acc + estimate_message_tokens ~cache msg) 0 messages
     in
     let watermark_threshold = int_of_float (float_of_int max_tokens *. watermark) in
     let normal_threshold = int_of_float (float_of_int max_tokens *. 0.6) in

--- a/lib/context_reducer.mli
+++ b/lib/context_reducer.mli
@@ -54,8 +54,7 @@ type strategy =
       }
   | Compose of strategy list
   | Custom of (message list -> message list)
-  | Dynamic of
-      (cache:estimate_cache -> turn:int -> messages:message list -> strategy)
+  | Dynamic of (cache:estimate_cache -> turn:int -> messages:message list -> strategy)
 
 (** A configured reducer wrapping a strategy. *)
 type t = { strategy : strategy }
@@ -198,9 +197,7 @@ val importance_scored
 (** Dynamic strategy: selects a strategy per turn based on
     conversation state. [cache] is the same estimate cache that will be
     passed to the selected strategy. *)
-val dynamic
-  :  (cache:estimate_cache -> turn:int -> messages:message list -> strategy)
-  -> t
+val dynamic : (cache:estimate_cache -> turn:int -> messages:message list -> strategy) -> t
 
 (** {1 Capabilities integration} *)
 

--- a/lib/context_reducer.mli
+++ b/lib/context_reducer.mli
@@ -19,6 +19,9 @@ open Types
     will be estimated again by the selected strategy. *)
 type estimate_cache
 
+(** Create a fresh estimate cache for a single reduction. *)
+val create_estimate_cache : unit -> estimate_cache
+
 (** Windowing strategy for context reduction. *)
 type strategy =
   | Keep_last_n of int

--- a/lib/context_reducer_apply.ml
+++ b/lib/context_reducer_apply.ml
@@ -601,8 +601,7 @@ let apply_relocate_tool_results ~state ~keep_recent messages =
 ;;
 
 let apply_cache_alignment ?cache ~size messages =
-  if size <= 0
-  then invalid_arg "apply_cache_alignment: size must be a positive integer";
+  if size <= 0 then invalid_arg "apply_cache_alignment: size must be a positive integer";
   let total_tokens =
     List.fold_left (fun acc msg -> acc + estimate_message_tokens ?cache msg) 0 messages
   in

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -616,11 +616,12 @@ let context_budget_probe_messages =
 (** Extract the [Token_budget] value from reducer strategies produced by
     [Context_reducer.from_context_config]. Returns [None] if not found. *)
 let extract_token_budget reducer =
+  let cache = Context_reducer.create_estimate_cache () in
   let rec loop strategy =
     match strategy with
     | Context_reducer.Token_budget n -> Some n
     | Context_reducer.Dynamic selector ->
-      loop (selector ~turn:1 ~messages:context_budget_probe_messages)
+      loop (selector ~cache ~turn:1 ~messages:context_budget_probe_messages)
     | Context_reducer.Compose strategies -> List.find_map loop strategies
     | _ -> None
   in

--- a/test/test_turn_params.ml
+++ b/test/test_turn_params.ml
@@ -216,7 +216,7 @@ let test_provider_mock_tool_use () =
 
 let test_dynamic_reducer () =
   let reducer =
-    Context_reducer.dynamic (fun ~turn ~messages:_ ->
+    Context_reducer.dynamic (fun ~cache:_ ~turn ~messages:_ ->
       if turn < 3
       then Context_reducer.Keep_last_n 20
       else Context_reducer.Token_budget 100)


### PR DESCRIPTION
Applies ocamlformat to main after the merged performance PRs (#2116, #2117) and fixes the build/test failures introduced by the [Dynamic] selector API change in #2116.

Changes:
- Format [context_reducer*] and example files.
- Expose [Context_reducer.create_estimate_cache] in the mli so tests and selectors can create a cache.
- Update [test_builder] and [test_turn_params] to pass [~cache] to [Dynamic] selectors.

Closes format and build failures on main.