### PR TITLE
perf: inject stream+options single pass + GLM parse-once + complete_stream timestamp reuse

### DIFF
--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -152,9 +152,8 @@ let build_request
 (** Glm error responses use string error codes:
     [{"error":{"code":"1305","message":"..."}}]
     Standard Openai uses numeric HTTP codes. *)
-let check_glm_error body : glm_error option =
+let check_glm_error_json (json : Yojson.Safe.t) : glm_error option =
   try
-    let json = Yojson.Safe.from_string body in
     let open Yojson.Safe.Util in
     match json |> member "error" with
     | `Null | `Assoc [] -> None
@@ -177,11 +176,15 @@ let check_glm_error body : glm_error option =
   | Yojson.Json_error _ -> None
 ;;
 
+let check_glm_error body : glm_error option =
+  try check_glm_error_json (Yojson.Safe.from_string body)
+  with Yojson.Json_error _ -> None
+;;
+
 (** Extract reasoning_content from Glm response and prepend as Thinking block.
     Glm returns reasoning in [message.reasoning_content] alongside [message.content]. *)
-let extract_reasoning_content (resp : api_response) body : api_response =
+let extract_reasoning_content_json (resp : api_response) (json : Yojson.Safe.t) : api_response =
   try
-    let json = Yojson.Safe.from_string body in
     let open Yojson.Safe.Util in
     let choices = json |> member "choices" in
     match choices with
@@ -202,21 +205,34 @@ let extract_reasoning_content (resp : api_response) body : api_response =
   | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> resp
 ;;
 
+let extract_reasoning_content (resp : api_response) body : api_response =
+  try extract_reasoning_content_json resp (Yojson.Safe.from_string body)
+  with Yojson.Json_error _ -> resp
+;;
+
 let glm_parse_error message =
   Glm_api_error
     { code = "parse"; message; error_class = Glm_invalid_request; is_retryable = false }
 ;;
 
 let parse_response body =
-  match check_glm_error body with
+  (* Parse the body once; a malformed body raises glm_parse_error (matching
+     the prior path where check_glm_error swallowed the parse error as None
+     and then parse_openai_response_result re-raised it). The three consumers
+     below all traverse this same [json] instead of each re-parsing the body
+     string -- was 3 full Yojson.Safe.from_string of the response per turn. *)
+  let json =
+    try Yojson.Safe.from_string body with
+    | Yojson.Json_error _ -> raise (glm_parse_error "response body is not valid JSON")
+  in
+  match check_glm_error_json json with
   | Some err -> raise (Glm_api_error err)
   | None ->
     (try
-       match Backend_openai_parse.parse_openai_response_result body with
+       match Backend_openai_parse.parse_openai_response_result_json json with
        | Error msg -> raise (glm_parse_error msg)
-       | Ok resp -> extract_reasoning_content resp body
+       | Ok resp -> extract_reasoning_content_json resp json
      with
-     | Yojson.Json_error msg -> raise (glm_parse_error msg)
      | Yojson.Safe.Util.Type_error (msg, _) -> raise (glm_parse_error msg)
      | Yojson.Safe.Util.Undefined (msg, _) -> raise (glm_parse_error msg))
 ;;

--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -105,8 +105,12 @@ let build_request
       ?(tools : Yojson.Safe.t list = [])
       ()
   =
-  let base_body = Backend_openai.build_request ~stream ~config ~messages ~tools () in
-  match Yojson.Safe.from_string base_body with
+  (* Take the request Assoc directly from the OpenAI builder instead of
+     serializing then parsing the whole message body back — removes one full
+     [Yojson.Safe.to_string] (OpenAI) + one [Yojson.Safe.from_string] (here)
+     per GLM turn. Byte-identical: [from_string (to_string assoc) = assoc]. *)
+  let base_assoc = Backend_openai.build_request_assoc ~stream ~config ~messages ~tools () in
+  match base_assoc with
   | `Assoc fields ->
     (* [thinking] single-owner normalization. The shared request builder's
        ZAI/GLM branch may already have emitted a [thinking] field (it fires for
@@ -139,7 +143,8 @@ let build_request
       else fields
     in
     Yojson.Safe.to_string (`Assoc fields)
-  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> base_body
+  | (`List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) as other ->
+    Yojson.Safe.to_string other
 ;;
 
 (* ── Response parsing ────────────────────────────── *)

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -45,6 +45,7 @@ let openai_json_schema_payload = Backend_openai_request.openai_json_schema_paylo
 let response_format_to_openai_json = Backend_openai_request.response_format_to_openai_json
 let response_format_of_config = Backend_openai_request.response_format_of_config
 let build_request = Backend_openai_request.build_request
+let build_request_assoc = Backend_openai_request.build_request_assoc
 
 [@@@coverage off]
 (* === Inline tests === *)

--- a/lib/llm_provider/backend_openai.mli
+++ b/lib/llm_provider/backend_openai.mli
@@ -21,6 +21,14 @@ val parse_openai_response_result : string -> (Types.api_response, string) result
 
 val usage_of_openai_json : Yojson.Safe.t -> Types.api_usage option
 
+val build_request_assoc
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> Yojson.Safe.t
+
 val build_request
   :  ?stream:bool
   -> config:Provider_config.t

--- a/lib/llm_provider/backend_openai_parse.ml
+++ b/lib/llm_provider/backend_openai_parse.ml
@@ -238,9 +238,8 @@ let telemetry_of_openai_json json =
 
 (** Parse an OpenAI-compatible JSON response string into an [api_response].
     Returns [Error msg] when the response body contains an API error. *)
-let parse_openai_response_result json_str =
+let parse_openai_response_result_json (raw_json : Yojson.Safe.t) =
   let open Yojson.Safe.Util in
-  let raw_json = Yojson.Safe.from_string json_str in
   let json =
     match raw_json with
     | `List (first :: _) -> first
@@ -332,6 +331,15 @@ let parse_openai_response_result json_str =
       |> Option.value ~default:"Unknown API error"
     in
     Error msg
+;;
+
+(** [parse_openai_response_result] parses [json_str] then delegates to
+    {!parse_openai_response_result_json}.  Callers that already hold the
+    parsed [Yojson.Safe.t] (e.g. {!Backend_glm.parse_response}, which also
+    error-checks and reasoning-extracts from the same body) should call
+    {!parse_openai_response_result_json} directly to avoid re-parsing. *)
+let parse_openai_response_result json_str =
+  parse_openai_response_result_json (Yojson.Safe.from_string json_str)
 ;;
 
 let%test "usage_of_openai_json supports mlx_vlm input/output token fields" =

--- a/lib/llm_provider/backend_openai_parse.mli
+++ b/lib/llm_provider/backend_openai_parse.mli
@@ -8,6 +8,12 @@
 val strip_json_markdown_fences : string -> string
 val usage_of_openai_json : Yojson.Safe.t -> Types.api_usage option
 
+(** Parse an OpenAI-compatible JSON response (from an already-parsed
+    [Yojson.Safe.t]).  Returns [Ok api_response] on success, [Error msg] on
+    API error.  Use when the caller already holds the parsed JSON to avoid
+    re-parsing. *)
+val parse_openai_response_result_json : Yojson.Safe.t -> (Types.api_response, string) result
+
 (** Parse an OpenAI-compatible JSON response.
     Returns [Ok api_response] on success, [Error msg] on API error. *)
 val parse_openai_response_result : string -> (Types.api_response, string) result

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -157,7 +157,7 @@ let is_zai_glm_request (config : Provider_config.t) =
 
 (** Build Openai Chat Completions request body from {!Provider_config.t}.
     Returns a JSON string ready for HTTP POST. *)
-let build_request
+let build_request_assoc
       ?(stream = false)
       ~(config : Provider_config.t)
       ~(messages : message list)
@@ -395,5 +395,20 @@ let build_request
       ("seed", `Int seed) :: body)
     else body
   in
-  Yojson.Safe.to_string (`Assoc body)
+  `Assoc body
+;;
+
+(** [build_request] serializes [build_request_assoc] to a JSON string.
+    Keeping the Assoc-producing variant separate lets sibling backends (e.g.
+    {!Backend_glm}) mutate the request Assoc directly instead of parsing the
+    serialized string back — one fewer full [Yojson.Safe.from_string] +
+    [Yojson.Safe.to_string] of the message body per turn. *)
+let build_request
+      ?(stream = false)
+      ~(config : Provider_config.t)
+      ~(messages : message list)
+      ?(tools : Yojson.Safe.t list = [])
+      ()
+  =
+  build_request_assoc ~stream ~config ~messages ~tools () |> Yojson.Safe.to_string
 ;;

--- a/lib/llm_provider/backend_openai_request.mli
+++ b/lib/llm_provider/backend_openai_request.mli
@@ -16,6 +16,17 @@ val openai_json_schema_payload : Yojson.Safe.t -> Yojson.Safe.t
 val response_format_to_openai_json : Types.response_format -> Yojson.Safe.t option
 val response_format_of_config : Provider_config.t -> Yojson.Safe.t option
 
+val build_request_assoc
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> Yojson.Safe.t
+(** [build_request_assoc] is {!build_request} before the final
+    [Yojson.Safe.to_string]; sibling backends (e.g. {!Backend_glm}) mutate the
+    Assoc directly instead of parsing the serialized string back. *)
+
 val build_request
   :  ?stream:bool
   -> config:Provider_config.t

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -313,8 +313,9 @@ let complete_stream_http
              request also sets stream_options.include_usage. Anthropic and
              Ollama carry usage natively (message_start/message_delta and the
              NDJSON done-chunk respectively), so they keep stream:true only. *)
-          Http_client.inject_stream_param body_str
-          |> Http_client.inject_stream_options_include_usage
+          (* Single parse/serialize pass for both fields (was two passes via the
+             inject_stream_param >> inject_stream_options_include_usage chain). *)
+          Http_client.inject_stream_and_options body_str
       in
       let t0 = Unix.gettimeofday () in
       let ttfrc_ref = ref None in

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -562,15 +562,27 @@ let complete_stream_http
                   if not !first_chunk_seen
                   then (
                     first_chunk_seen := true;
-                    let ttfrc_ms = (Unix.gettimeofday () -. t0) *. 1000.0 in
+                    (* Reuse the dispatch-entry [now] instead of a fresh
+                       [Unix.gettimeofday]: the sub-microsecond the event
+                       loop spent between dispatch entry and here is below
+                       the metric's resolution, and a single per-dispatch
+                       timestamp keeps inter-chunk gaps measured
+                       dispatch-to-dispatch (wire gap) instead of mixing in
+                       per-event processing time. *)
+                    let ttfrc_ms = (now -. t0) *. 1000.0 in
                     ttfrc_ref := Some ttfrc_ms;
                     emit_telemetry
                       (Telemetry_event.Streaming_first_chunk
                          { provider; model; ttfrc_ms; requested_at = t0 });
-                    last_chunk_t := Unix.gettimeofday ();
+                    last_chunk_t := now;
                     chunk_counter := 1)
                   else (
-                    let now = Unix.gettimeofday () in
+                    (* [now] is the dispatch-entry timestamp bound above;
+                       reusing it drops a second [Unix.gettimeofday] syscall
+                       per chunk — this branch runs once per SSE chunk, i.e.
+                       thousands of times per turn. [last_chunk_t] is now also
+                       a dispatch-entry time, so [inter_chunk_ms] is a clean
+                       dispatch-to-dispatch (wire) gap. *)
                     let inter_chunk_ms = (now -. !last_chunk_t) *. 1000.0 in
                     (* RFC-OAS-019: per-chunk [Streaming_chunk_n] publish
                        removed. Inter-chunk gaps are accumulated for the

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -984,6 +984,37 @@ let inject_stream_options_include_usage body_str =
   | exception Yojson.Json_error _ -> body_str
 ;;
 
+let inject_stream_and_options body_str =
+  match Yojson.Safe.from_string body_str with
+  | `Assoc fields ->
+    let without_existing =
+      List.filter (fun (k, _) -> k <> "stream" && k <> "stream_options") fields
+    in
+    Yojson.Safe.to_string
+      (`Assoc
+        ( ("stream_options", `Assoc [ "include_usage", `Bool true ])
+        :: ("stream", `Bool true)
+        :: without_existing ))
+  | other -> Yojson.Safe.to_string other
+  | exception Yojson.Json_error _ -> body_str
+;;
+
+let%test "inject_stream_and_options matches chained param >> options" =
+  (* Parity proof: the combined single-pass injector must be byte-identical to
+     [inject_stream_param body |> inject_stream_options_include_usage] across
+     Assoc variants, pre-existing stream/stream_options, non-json, array, empty. *)
+  List.for_all
+    (fun body ->
+       inject_stream_and_options body
+       = inject_stream_options_include_usage (inject_stream_param body))
+    [ {|{"model":"glm-4"}|}
+    ; {|{"model":"gpt-4","stream":false}|}
+    ; {|{"messages":[],"stream_options":{"include_usage":false}}|}
+    ; {|{"a":1,"stream":true,"stream_options":{"x":1}}|}
+    ; "not json"
+    ; {|[1,2,3]|}
+    ; "" ]
+
 [@@@coverage off]
 (* ── catch_network tests ─────────────────────────────── *)
 

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -337,3 +337,14 @@ val inject_stream_param : string -> string
     double-injection; a non-object or unparseable body is returned
     unchanged. *)
 val inject_stream_options_include_usage : string -> string
+
+(** Inject both ["stream": true] and [{"stream_options": {"include_usage": true}}]
+    in a single parse/serialize pass. Byte-identical to
+    [inject_stream_param body |> inject_stream_options_include_usage] (proven by
+    a parity test), but parses and serializes the body once instead of twice.
+    For the OpenAI-compatible streaming path that needs both fields (GLM, Kimi,
+    DashScope, OpenAI_compat) this removes one full Yojson parse and one full
+    [Yojson.Safe.to_string] of the request body per turn. Native-usage
+    providers (Anthropic, Ollama, Gemini) should keep using
+    [inject_stream_param] (stream only). *)
+val inject_stream_and_options : string -> string

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -46,6 +46,34 @@ let test_inject_stream_param_array () =
   Alcotest.(check string) "array unchanged" "[1,2,3]" result
 ;;
 
+let test_inject_stream_and_options_parity () =
+  (* inject_stream_and_options must be byte-identical to the chained
+     inject_stream_param >> inject_stream_options_include_usage across all
+     body shapes — the OpenAI-compat streaming path (complete_stream)
+     switched to it, so any divergence changes the request body sent to the
+     provider. Covers Assoc without/with pre-existing stream/stream_options,
+     non-json, array, empty. *)
+  let bodies =
+    [ {|{"model":"glm-4"}|}
+    ; {|{"model":"gpt-4","stream":false}|}
+    ; {|{"messages":[],"stream_options":{"include_usage":false}}|}
+    ; {|{"a":1,"stream":true,"stream_options":{"x":1}}|}
+    ; "not json"
+    ; {|[1,2,3]|}
+    ; ""
+    ]
+  in
+  List.iter
+    (fun body ->
+       let combined = Http_client.inject_stream_and_options body in
+       let chained =
+         Http_client.inject_stream_options_include_usage
+           (Http_client.inject_stream_param body)
+       in
+       Alcotest.(check string) "parity with chained" chained combined)
+    bodies
+;;
+
 let test_read_sse_basic () =
   Eio_main.run
   @@ fun _env ->
@@ -453,6 +481,9 @@ let () =
         ; Alcotest.test_case "non-json" `Quick test_inject_stream_param_non_json
         ; Alcotest.test_case "empty object" `Quick test_inject_stream_param_empty
         ; Alcotest.test_case "array" `Quick test_inject_stream_param_array
+        ; Alcotest.test_case
+            "and_options parity with chained"
+            `Quick test_inject_stream_and_options_parity
         ] )
     ; ( "read_sse"
       , [ Alcotest.test_case "basic events" `Quick test_read_sse_basic


### PR DESCRIPTION
## Performance optimizations — 4 commits (streaming/transport)

- `http_client` inject stream + stream_options in a single pass
- `backend_glm` take the request Assoc directly, drop parse+reserialize
- `backend_glm` parse the response body once, not three times
- `complete_stream` reuse dispatch-entry timestamp, drop per-chunk gettimeofday

OAS boundary: Provider/Model/transport — no MASC-specific code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
