### PR TITLE
fix: address review follow-up from #2120

### DIFF
--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -223,7 +223,7 @@ let parse_response body =
      string -- was 3 full Yojson.Safe.from_string of the response per turn. *)
   let json =
     try Yojson.Safe.from_string body with
-    | Yojson.Json_error _ -> raise (glm_parse_error "response body is not valid JSON")
+    | Yojson.Json_error msg -> raise (glm_parse_error msg)
   in
   match check_glm_error_json json with
   | Some err -> raise (Glm_api_error err)


### PR DESCRIPTION
Addresses the unresolved review thread on #2120.

## Fix
- In `lib/llm_provider/backend_glm.ml`, preserve the original Yojson `Json_error` message when a GLM response body fails to parse.
- Previously the specific parse message was replaced with the generic text `"response body is not valid JSON"`, which no longer matched `Retry.malformed_json_indicators` (e.g. "unexpected", "unterminated", "parse error"). This could make transient malformed GLM 2xx responses terminal instead of retryable.

## Local checks
- `MASC_DUNE_ALLOW_BARE_DUNE=1 dune build --root . @all` ✅
- `MASC_DUNE_ALLOW_BARE_DUNE=1 dune runtest --root . lib/llm_provider` ✅
- `MASC_DUNE_ALLOW_BARE_DUNE=1 dune build --root . @fmt` shows pre-existing formatting differences in files from #2120; no new formatting issues were introduced by this change.