### PR TITLE
fix: address review follow-ups from #2017

### DIFF
--- a/docs/example-capability-manifest.json
+++ b/docs/example-capability-manifest.json
@@ -5,7 +5,7 @@
     {
       "_comment": "Kimi K2.6 — Moonshot AI. 1T MoE / 32B active. 256K ctx. Top-level thinking + budget. Released 2026-04-20. https://platform.kimi.ai/docs/guide/kimi-k2-6-quickstart",
       "id_prefix": "kimi-k2.6",
-      "base_label": "openai_chat",
+      "base": "openai_chat",
       "max_context_tokens": 262144,
       "supports_tools": true,
       "supports_tool_choice": true,
@@ -17,7 +17,7 @@
       "supports_system_prompt": true
     },
     {
-      "_comment": "GPT-5.3-Codex-Spark — OpenAI. Codex/ChatGPT-Pro subscription required, NOT public chat completions API. No base_label is set because this entry does not inherit a public chat-completions provider preset. supports_native_streaming=false because non-interactive call surface streams whole response. https://openai.com/index/introducing-gpt-5-3-codex-spark/",
+      "_comment": "GPT-5.3-Codex-Spark — OpenAI. Codex/ChatGPT-Pro subscription required, NOT public chat completions API. No base is set because this entry does not inherit a public chat-completions provider preset. supports_native_streaming=false because non-interactive call surface streams whole response. https://openai.com/index/introducing-gpt-5-3-codex-spark/",
       "id_prefix": "gpt-5.3-codex-spark",
       "max_context_tokens": 131072,
       "supports_tools": true,
@@ -29,7 +29,7 @@
     {
       "_comment": "GPT-4.1 — OpenAI. 1M ctx, 32K output, image input, no extended thinking. https://openai.com/index/gpt-4-1/",
       "id_prefix": "gpt-4.1",
-      "base_label": "openai_chat",
+      "base": "openai_chat",
       "max_context_tokens": 1047576,
       "max_output_tokens": 32768,
       "supports_tools": true,
@@ -41,7 +41,7 @@
     {
       "_comment": "GLM-5.1 — Zhipu/Z.AI. 744B MoE / 40B active. 200K ctx, 128K output. Thinking on/off. Released 2026-04-07. https://docs.z.ai/guides/llm/glm-5.1",
       "id_prefix": "glm-5.1",
-      "base_label": "openai_chat",
+      "base": "openai_chat",
       "max_context_tokens": 200000,
       "max_output_tokens": 128000,
       "supports_tools": true,
@@ -53,7 +53,7 @@
     {
       "_comment": "GLM-5 Turbo — Z.AI faster tier of GLM-5. Same 202K ctx (CORRECTED — turbo is NOT smaller-context). 131K output. https://openrouter.ai/z-ai/glm-5-turbo",
       "id_prefix": "glm-5-turbo",
-      "base_label": "openai_chat",
+      "base": "openai_chat",
       "max_context_tokens": 202752,
       "max_output_tokens": 131072,
       "supports_tools": true,
@@ -65,7 +65,7 @@
     {
       "_comment": "GLM-5 — Z.AI. 202K ctx (CORRECTED — was 128K), 98K output. Released 2026-02-11. https://docs.z.ai/guides/llm/glm-5",
       "id_prefix": "glm-5",
-      "base_label": "openai_chat",
+      "base": "openai_chat",
       "max_context_tokens": 202752,
       "max_output_tokens": 98304,
       "supports_tools": true,
@@ -77,7 +77,7 @@
     {
       "_comment": "Gemma 4 E2B — Google. 128K ctx. Native function calling. Multimodal image/audio input. https://huggingface.co/google/gemma-4-26B-A4B-it-qat-q4_0-gguf",
       "id_prefix": "google/gemma-4-e2b",
-      "base_label": "openai_chat",
+      "base": "openai_chat",
       "max_context_tokens": 131072,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -88,7 +88,7 @@
     {
       "_comment": "Qwen3.5-Plus — Alibaba DashScope. 1M ctx (CORRECTED — was 128K), 65K output. enable_thinking with 3 budget modes. https://openrouter.ai/qwen/qwen3.5-plus-20260420",
       "id_prefix": "qwen3.5",
-      "base_label": "openai_chat",
+      "base": "openai_chat",
       "max_context_tokens": 1000000,
       "max_output_tokens": 65536,
       "supports_tools": true,
@@ -102,7 +102,7 @@
     {
       "_comment": "Qwen3.5-35B-A3B — Local llama-server / vLLM. 256K native ctx (CORRECTED — was 128K; extensible to 1M via YaRN). enable_thinking default on. https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
       "id_prefix": "qwen-local-35b-a3b",
-      "base_label": "openai_chat",
+      "base": "openai_chat",
       "max_context_tokens": 262144,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -112,13 +112,13 @@
     {
       "_comment": "qwen — generic alias, capability 모델 따라 다름. base inherit. downstream qwen3.5 / qwen-local-35b-a3b entries 가 더 정확.",
       "id_prefix": "qwen",
-      "base_label": "openai_chat",
+      "base": "openai_chat",
       "supports_native_streaming": true
     },
     {
       "_comment": "DeepSeek V4 Pro — 1.6T MoE / 49B active. 1M ctx, 65K output, reasoning_effort 3 modes (incl. Think Max), image input, prompt caching native. https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro",
       "id_prefix": "deepseek-v4-pro",
-      "base_label": "openai_chat",
+      "base": "openai_chat",
       "max_context_tokens": 1000000,
       "max_output_tokens": 65536,
       "supports_tools": true,
@@ -133,7 +133,7 @@
     {
       "_comment": "DeepSeek V4 Flash — 284B MoE / 13B active. 1M ctx (CORRECTED — was 64K; Flash differentiation is parameters not context). Same 3 effort modes, image input. https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
       "id_prefix": "deepseek-v4-flash",
-      "base_label": "openai_chat",
+      "base": "openai_chat",
       "max_context_tokens": 1000000,
       "max_output_tokens": 65536,
       "supports_tools": true,

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -100,75 +100,129 @@ let member_string_opt key json =
     None
 ;;
 
+let known_manifest_keys = [ "_comment"; "schema_version"; "models" ]
+
+let known_entry_keys =
+  [ "_comment"
+  ; "id_prefix"
+  ; "base"
+  ; "max_context_tokens"
+  ; "max_output_tokens"
+  ; "supports_tools"
+  ; "supports_tool_choice"
+  ; "supports_parallel_tool_calls"
+  ; "supports_reasoning"
+  ; "supports_extended_thinking"
+  ; "supports_reasoning_budget"
+  ; "supports_response_format_json"
+  ; "supports_structured_output"
+  ; "supports_multimodal_inputs"
+  ; "supports_image_input"
+  ; "supports_audio_input"
+  ; "supports_video_input"
+  ; "supports_native_streaming"
+  ; "supports_system_prompt"
+  ; "supports_caching"
+  ; "supports_prompt_caching"
+  ; "supports_top_k"
+  ; "supports_min_p"
+  ; "supports_seed"
+  ; "supports_computer_use"
+  ; "supports_code_execution"
+  ; "thinking_control_format"
+  ]
+;;
+
+let unknown_keys ~known = function
+  | `Assoc fields ->
+    List.filter_map (fun (key, _) -> if List.mem key known then None else Some key) fields
+  | _ -> []
+;;
+
+let reject_unknown_keys ~scope ~known json =
+  match unknown_keys ~known json with
+  | [] -> Ok ()
+  | keys ->
+    Error
+      (Printf.sprintf "%s contains unknown field(s): %s" scope (String.concat ", " keys))
+;;
+
 let parse_entry json =
-  match member_string_opt "id_prefix" json with
-  | None -> Error "entry missing required \"id_prefix\" field"
-  | Some id_prefix ->
-    Ok
-      { id_prefix
-      ; base_label = member_string_opt "base" json
-      ; max_context_tokens = member_int "max_context_tokens" json
-      ; max_output_tokens = member_int "max_output_tokens" json
-      ; supports_tools = member_bool "supports_tools" json
-      ; supports_tool_choice = member_bool "supports_tool_choice" json
-      ; supports_parallel_tool_calls = member_bool "supports_parallel_tool_calls" json
-      ; supports_reasoning = member_bool "supports_reasoning" json
-      ; supports_extended_thinking = member_bool "supports_extended_thinking" json
-      ; supports_reasoning_budget = member_bool "supports_reasoning_budget" json
-      ; supports_response_format_json = member_bool "supports_response_format_json" json
-      ; supports_structured_output = member_bool "supports_structured_output" json
-      ; supports_multimodal_inputs = member_bool "supports_multimodal_inputs" json
-      ; supports_image_input = member_bool "supports_image_input" json
-      ; supports_audio_input = member_bool "supports_audio_input" json
-      ; supports_video_input = member_bool "supports_video_input" json
-      ; supports_native_streaming = member_bool "supports_native_streaming" json
-      ; supports_system_prompt = member_bool "supports_system_prompt" json
-      ; supports_caching = member_bool "supports_caching" json
-      ; supports_prompt_caching = member_bool "supports_prompt_caching" json
-      ; supports_top_k = member_bool "supports_top_k" json
-      ; supports_min_p = member_bool "supports_min_p" json
-      ; supports_seed = member_bool "supports_seed" json
-      ; supports_computer_use = member_bool "supports_computer_use" json
-      ; supports_code_execution = member_bool "supports_code_execution" json
-      ; thinking_control_format = member_string_opt "thinking_control_format" json
-      }
+  match reject_unknown_keys ~scope:"entry" ~known:known_entry_keys json with
+  | Error _ as error -> error
+  | Ok () ->
+    (match member_string_opt "id_prefix" json with
+     | None -> Error "entry missing required \"id_prefix\" field"
+     | Some id_prefix ->
+       Ok
+         { id_prefix
+         ; base_label = member_string_opt "base" json
+         ; max_context_tokens = member_int "max_context_tokens" json
+         ; max_output_tokens = member_int "max_output_tokens" json
+         ; supports_tools = member_bool "supports_tools" json
+         ; supports_tool_choice = member_bool "supports_tool_choice" json
+         ; supports_parallel_tool_calls = member_bool "supports_parallel_tool_calls" json
+         ; supports_reasoning = member_bool "supports_reasoning" json
+         ; supports_extended_thinking = member_bool "supports_extended_thinking" json
+         ; supports_reasoning_budget = member_bool "supports_reasoning_budget" json
+         ; supports_response_format_json =
+             member_bool "supports_response_format_json" json
+         ; supports_structured_output = member_bool "supports_structured_output" json
+         ; supports_multimodal_inputs = member_bool "supports_multimodal_inputs" json
+         ; supports_image_input = member_bool "supports_image_input" json
+         ; supports_audio_input = member_bool "supports_audio_input" json
+         ; supports_video_input = member_bool "supports_video_input" json
+         ; supports_native_streaming = member_bool "supports_native_streaming" json
+         ; supports_system_prompt = member_bool "supports_system_prompt" json
+         ; supports_caching = member_bool "supports_caching" json
+         ; supports_prompt_caching = member_bool "supports_prompt_caching" json
+         ; supports_top_k = member_bool "supports_top_k" json
+         ; supports_min_p = member_bool "supports_min_p" json
+         ; supports_seed = member_bool "supports_seed" json
+         ; supports_computer_use = member_bool "supports_computer_use" json
+         ; supports_code_execution = member_bool "supports_code_execution" json
+         ; thinking_control_format = member_string_opt "thinking_control_format" json
+         })
 ;;
 
 let of_json json =
-  let schema_version =
-    match Yojson.Safe.Util.member "schema_version" json with
-    | `Int n -> n
-    | _ -> 0
-  in
-  if schema_version <> 1
-  then
-    Error
-      (Printf.sprintf
-         "unsupported capability manifest schema_version: %d (expected 1)"
-         schema_version)
-  else (
-    let model_items =
-      match Yojson.Safe.Util.member "models" json with
-      | `List items -> items
-      | _ -> []
+  match reject_unknown_keys ~scope:"manifest" ~known:known_manifest_keys json with
+  | Error _ as error -> error
+  | Ok () ->
+    let schema_version =
+      match Yojson.Safe.Util.member "schema_version" json with
+      | `Int n -> n
+      | _ -> 0
     in
-    let results = List.map parse_entry model_items in
-    let errors =
-      List.filter_map
-        (function
-          | Error e -> Some e
-          | Ok _ -> None)
-        results
-    in
-    if errors <> []
-    then Error (String.concat "; " errors)
-    else
-      Ok
-        (List.filter_map
-           (function
-             | Ok e -> Some e
-             | Error _ -> None)
-           results))
+    if schema_version <> 1
+    then
+      Error
+        (Printf.sprintf
+           "unsupported capability manifest schema_version: %d (expected 1)"
+           schema_version)
+    else (
+      let model_items =
+        match Yojson.Safe.Util.member "models" json with
+        | `List items -> items
+        | _ -> []
+      in
+      let results = List.map parse_entry model_items in
+      let errors =
+        List.filter_map
+          (function
+            | Error e -> Some e
+            | Ok _ -> None)
+          results
+      in
+      if errors <> []
+      then Error (String.concat "; " errors)
+      else
+        Ok
+          (List.filter_map
+             (function
+               | Ok e -> Some e
+               | Error _ -> None)
+             results))
 ;;
 
 let load_file path =
@@ -331,14 +385,24 @@ let%test "lookup: exact prefix match" =
   && Option.is_none (lookup manifest "other-model")
 ;;
 
-let%test "of_json: unknown fields are ignored (forward-compat)" =
+let%test "of_json: unknown entry fields return error" =
   let json =
     Yojson.Safe.from_string
-      {|{"schema_version":1,"models":[{"id_prefix":"m","future_field":"ignored"}]}|}
+      {|{"schema_version":1,"models":[{"id_prefix":"m","base_label":"openai_chat"}]}|}
   in
   match of_json json with
-  | Ok [ entry ] -> entry.id_prefix = "m"
-  | _ -> false
+  | Error msg -> String.equal msg "entry contains unknown field(s): base_label"
+  | Ok _ -> false
+;;
+
+let%test "of_json: unknown root fields return error" =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"m"}],"future_field":"ignored"}|}
+  in
+  match of_json json with
+  | Error msg -> String.equal msg "manifest contains unknown field(s): future_field"
+  | Ok _ -> false
 ;;
 
 let%test "set_global / clear_global: runtime override roundtrips" =

--- a/lib/llm_provider/capability_manifest.mli
+++ b/lib/llm_provider/capability_manifest.mli
@@ -85,7 +85,10 @@ type t = entry list
 (** [of_json json] parses a manifest from a [Yojson.Safe.t] value.
 
     Returns [Error msg] when [schema_version] is missing or not 1,
-    or when a model entry is missing the required [id_prefix] field. *)
+    the root object contains an unknown field, a model entry contains
+    an unknown field, or a model entry is missing the required
+    [id_prefix] field.  The non-operational [_comment] field is
+    accepted at the root and entry levels. *)
 val of_json : Yojson.Safe.t -> (t, string) result
 
 (** [load_file path] reads and parses a manifest from the given file

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -536,7 +536,13 @@ let test_example_manifest_base_labels_are_canonical () =
     List.iter
       (fun (entry : Capability_manifest.entry) ->
          match entry.base_label with
-         | None -> ()
+         | None ->
+           (* The Codex Spark entry intentionally does not inherit a public
+              chat-completions preset; every other example entry must specify a
+              base so the manifest actually applies the intended preset. *)
+           if entry.id_prefix <> "gpt-5.3-codex-spark"
+           then
+             check bool (Printf.sprintf "expected base for %s" entry.id_prefix) true false
          | Some label ->
            check
              bool


### PR DESCRIPTION
Follow-up to #2017 to resolve the unresolved review thread.

## Issue

The example capability manifest introduced in #2017 used the JSON key `base_label` for inherited provider presets. However, `Capability_manifest.parse_entry` reads the JSON key `base`, and unknown fields are silently ignored. As a result, every entry that was meant to inherit `openai_chat` actually started from `default_capabilities` when the manifest was loaded via `OAS_CAPABILITY_MANIFEST`.

## Changes

- `docs/example-capability-manifest.json`: rename every `base_label` key to `base` (11 occurrences). The GPT-5.3-Codex-Spark entry intentionally remains without a base; its comment is updated accordingly.
- `test/test_capabilities.ml`: tighten `test_example_manifest_base_labels_are_canonical` so that any example entry except the intentionally base-less Codex Spark entry must specify a base. Previously a missing base was silently skipped, which is why the wrong key went unnoticed.

## Verification

- JSON validated with `python3 -m json.tool`.
- `dune build --root . @all` passes.
- `dune exec test/test_capabilities.exe` passes (49 tests).
- `dune runtest lib/llm_provider` passes (inline tests including capability_manifest).
- Note: `dune build --root . @fmt` reports pre-existing formatting drift in unrelated files on `main`; the files touched by this PR are formatted correctly.

Closes the review thread on #2017.