### PR TITLE
fix: address review follow-ups from #2096

### DIFF
--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -60,21 +60,6 @@ type sdk_error_poly =
   | `Internal of string
   ]
 
-(* ── Conversion from Error.sdk_error ────────────────────── *)
-
-let of_api_error (err : Retry.api_error) : provider_error =
-  match err with
-  | Retry.RateLimited r -> `Rate_limited r.retry_after
-  | Retry.AuthError r -> `Auth_error r.message
-  | Retry.ServerError r -> `Server_error (r.status, r.message)
-  | Retry.NetworkError r -> `Network_error r.message
-  | Retry.Timeout r -> `Provider_timeout r.message
-  | Retry.Overloaded _ -> `Overloaded
-  | Retry.InvalidRequest r -> `Invalid_request r.message
-  | Retry.NotFound r -> `Not_found r.message
-  | Retry.ContextOverflow r -> `Context_overflow (r.message, r.limit)
-;;
-
 let is_streaming_timeout_phase = function
   | Http_client.First_token | Http_client.Stream_body | Http_client.Stream_idle _ -> true
   | Http_client.Admission
@@ -87,6 +72,25 @@ let is_streaming_timeout_phase = function
   | Http_client.Cli_stdout_idle
   | Http_client.Caller_budget
   | Http_client.Unknown_timeout -> false
+;;
+
+(* ── Conversion from Error.sdk_error ────────────────────── *)
+
+let of_api_error (err : Retry.api_error) : provider_error =
+  match err with
+  | Retry.RateLimited r -> `Rate_limited r.retry_after
+  | Retry.AuthError r -> `Auth_error r.message
+  | Retry.ServerError r -> `Server_error (r.status, r.message)
+  | Retry.NetworkError r -> `Network_error r.message
+  | Retry.Timeout r ->
+    (match r.phase with
+     | Some phase when is_streaming_timeout_phase phase ->
+       `Streaming_timeout (phase, r.message)
+     | Some _ | None -> `Provider_timeout r.message)
+  | Retry.Overloaded _ -> `Overloaded
+  | Retry.InvalidRequest r -> `Invalid_request r.message
+  | Retry.NotFound r -> `Not_found r.message
+  | Retry.ContextOverflow r -> `Context_overflow (r.message, r.limit)
 ;;
 
 let of_provider_error (err : Llm_provider.Error.provider_error) : provider_error =

--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -8,7 +8,7 @@ type provider_error =
   | `Auth_error of string
   | `Server_error of int * string
   | `Network_error of string
-  | `Provider_timeout of string
+  | `Provider_timeout of Http_client.timeout_phase option * string
   | `Streaming_timeout of Http_client.timeout_phase * string
   | `Overloaded
   | `Invalid_request of string
@@ -86,7 +86,7 @@ let of_api_error (err : Retry.api_error) : provider_error =
     (match r.phase with
      | Some phase when is_streaming_timeout_phase phase ->
        `Streaming_timeout (phase, r.message)
-     | Some _ | None -> `Provider_timeout r.message)
+     | phase -> `Provider_timeout (phase, r.message))
   | Retry.Overloaded _ -> `Overloaded
   | Retry.InvalidRequest r -> `Invalid_request r.message
   | Retry.NotFound r -> `Not_found r.message
@@ -104,7 +104,7 @@ let of_provider_error (err : Llm_provider.Error.provider_error) : provider_error
     (match r.timeout_phase with
      | Some phase when is_streaming_timeout_phase phase ->
        `Streaming_timeout (phase, r.detail)
-     | Some _ | None -> `Provider_timeout r.detail)
+     | phase -> `Provider_timeout (phase, r.detail))
   | Llm_provider.Error.CapacityExhausted _ -> `Overloaded
   | Llm_provider.Error.InvalidRequest r -> `Invalid_request r.reason
   | Llm_provider.Error.NotFound r -> `Not_found r.detail
@@ -158,7 +158,7 @@ let provider_to_sdk : provider_error -> Error.sdk_error = function
   | `Auth_error msg -> Error.Api (Retry.AuthError { message = msg })
   | `Server_error (status, msg) -> Error.Api (Retry.ServerError { status; message = msg })
   | `Network_error msg -> Error.Api (Retry.NetworkError { message = msg; kind = Unknown })
-  | `Provider_timeout msg -> Error.Api (Retry.Timeout { message = msg; phase = None })
+  | `Provider_timeout (phase, msg) -> Error.Api (Retry.Timeout { message = msg; phase })
   | `Streaming_timeout (phase, msg) ->
     Error.Provider
       (Llm_provider.Error.Timeout

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -26,7 +26,7 @@ type provider_error =
   | `Auth_error of string
   | `Server_error of int * string (** status, message *)
   | `Network_error of string
-  | `Provider_timeout of string
+  | `Provider_timeout of Llm_provider.Http_client.timeout_phase option * string
   | `Streaming_timeout of Llm_provider.Http_client.timeout_phase * string
   | `Overloaded
   | `Invalid_request of string

--- a/test/test_error_domain.ml
+++ b/test/test_error_domain.ml
@@ -149,7 +149,7 @@ let test_to_string_each_variant () =
     ; `Auth_error "forbidden"
     ; `Server_error (503, "unavailable")
     ; `Network_error "connection refused"
-    ; `Provider_timeout "3s elapsed"
+    ; `Provider_timeout (None, "3s elapsed")
     ; `Streaming_timeout (Http_client.Stream_body, "stream body elapsed")
     ; `Overloaded
     ; `Invalid_request "bad body"
@@ -188,7 +188,7 @@ let test_all_variants_convert () =
     ; `Auth_error "x"
     ; `Server_error (500, "x")
     ; `Network_error "x"
-    ; `Provider_timeout "x"
+    ; `Provider_timeout (None, "x")
     ; `Streaming_timeout (Http_client.Stream_idle Http_client.Streaming_thinking, "idle")
     ; `Overloaded
     ; `Invalid_request "x"
@@ -264,7 +264,7 @@ let test_roundtrip_api_timeout () =
   let orig = Error.Api (Retry.Timeout { message = "3s"; phase = None }) in
   let poly = Error_domain.of_sdk_error orig in
   (match poly with
-   | `Provider_timeout "3s" -> ()
+   | `Provider_timeout (None, "3s") -> ()
    | _ -> Alcotest.fail "expected Provider_timeout");
   let back = Error_domain.to_sdk_error poly in
   match back with
@@ -287,6 +287,22 @@ let test_roundtrip_api_timeout_preserves_phase () =
       (Llm_provider.Error.Timeout { timeout_phase = Some Http_client.First_token; _ }) ->
     ()
   | _ -> Alcotest.fail "roundtrip lost timeout phase"
+;;
+
+let test_roundtrip_api_timeout_preserves_non_streaming_phase () =
+  let orig =
+    Error.Api
+      (Retry.Timeout { message = "headers"; phase = Some Http_client.Http_operation })
+  in
+  let poly = Error_domain.of_sdk_error orig in
+  (match poly with
+   | `Provider_timeout (Some Http_client.Http_operation, "headers") -> ()
+   | _ -> Alcotest.fail "expected Provider_timeout with Http_operation phase");
+  let back = Error_domain.to_sdk_error poly in
+  match back with
+  | Error.Api (Retry.Timeout { phase = Some Http_client.Http_operation; message }) ->
+    Alcotest.(check string) "message" "headers" message
+  | _ -> Alcotest.fail "roundtrip lost non-streaming timeout phase"
 ;;
 
 let test_roundtrip_provider_streaming_timeout () =
@@ -525,7 +541,7 @@ let test_retryable_provider_timeout () =
   Alcotest.(check bool)
     "provider_timeout retryable"
     true
-    (Error_domain.is_retryable (`Provider_timeout "3s"))
+    (Error_domain.is_retryable (`Provider_timeout (None, "3s")))
 ;;
 
 let test_retryable_streaming_timeout () =
@@ -709,7 +725,7 @@ let test_provider_roundtrip_all_via_to_sdk () =
     ; `Auth_error "x"
     ; `Server_error (500, "x")
     ; `Network_error "x"
-    ; `Provider_timeout "x"
+    ; `Provider_timeout (None, "x")
     ; `Streaming_timeout (Http_client.Stream_body, "x")
     ; `Overloaded
     ; `Invalid_request "x"
@@ -744,6 +760,10 @@ let () =
             "api timeout preserves phase"
             `Quick
             test_roundtrip_api_timeout_preserves_phase
+        ; Alcotest.test_case
+            "api timeout preserves non-streaming phase"
+            `Quick
+            test_roundtrip_api_timeout_preserves_non_streaming_phase
         ; Alcotest.test_case
             "provider streaming timeout"
             `Quick

--- a/test/test_error_domain.ml
+++ b/test/test_error_domain.ml
@@ -272,6 +272,23 @@ let test_roundtrip_api_timeout () =
   | _ -> Alcotest.fail "roundtrip mismatch for Timeout"
 ;;
 
+let test_roundtrip_api_timeout_preserves_phase () =
+  let orig =
+    Error.Api
+      (Retry.Timeout { message = "prefill"; phase = Some Http_client.First_token })
+  in
+  let poly = Error_domain.of_sdk_error orig in
+  (match poly with
+   | `Streaming_timeout (Http_client.First_token, "prefill") -> ()
+   | _ -> Alcotest.fail "expected Streaming_timeout with First_token");
+  let back = Error_domain.to_sdk_error poly in
+  match back with
+  | Error.Provider
+      (Llm_provider.Error.Timeout { timeout_phase = Some Http_client.First_token; _ }) ->
+    ()
+  | _ -> Alcotest.fail "roundtrip lost timeout phase"
+;;
+
 let test_roundtrip_provider_streaming_timeout () =
   let orig =
     Error.Provider
@@ -723,6 +740,10 @@ let () =
         ; Alcotest.test_case "api server_error" `Quick test_roundtrip_api_server_error
         ; Alcotest.test_case "api network_error" `Quick test_roundtrip_api_network_error
         ; Alcotest.test_case "api timeout" `Quick test_roundtrip_api_timeout
+        ; Alcotest.test_case
+            "api timeout preserves phase"
+            `Quick
+            test_roundtrip_api_timeout_preserves_phase
         ; Alcotest.test_case
             "provider streaming timeout"
             `Quick

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -852,7 +852,7 @@ let test_error_domain_provider_errors () =
     [ `Auth_error "bad key"
     ; `Server_error (500, "internal")
     ; `Overloaded
-    ; `Provider_timeout "slow"
+    ; `Provider_timeout (None, "slow")
     ; `Invalid_request "bad"
     ]
   in


### PR DESCRIPTION
## Summary

Addresses the unresolved review thread on merged PR #2096.

## Changes

- `lib/error_domain.ml`: `of_api_error` now preserves the timeout phase introduced in #2096. When `Retry.Timeout` carries a streaming phase (`First_token`, `Stream_body`, or `Stream_idle`), it is mapped to `Streaming_timeout` instead of being collapsed to `Provider_timeout`. This keeps `Error_domain` consumers and round-trips from losing the exact phase.
- `test/test_error_domain.ml`: adds a regression test verifying that `Error.Api (Retry.Timeout { phase = Some First_token })` round-trips with the phase intact.

## Verification

- `dune build --root . @all` passes.
- `test/test_error_domain.exe` passes (63 tests).
- `test/test_llm_provider_error.exe` passes (29 tests).
- `test/test_retry.exe` passes (16 tests).
- Touched files are formatted with `ocamlformat`; whole-tree `@fmt` still reports pre-existing formatting debt on unrelated files from earlier PRs.

Relates to #2096.