### PR TITLE
fix: address review follow-ups from #2028

### DIFF
--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -322,14 +322,16 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
        let idle_skip = ref false in
        let idle_handled = ref false in
        (* true when Nudge or Skip handled idle *)
-       (* Nudge text is delivered inside the tool-results user message (as a
-          trailing Text block) instead of as a standalone user message snoc'd
-          before tool execution. A standalone message would sit between the
-          assistant tool_calls message and its tool results; the OpenAI-compat
-          serializer's strip_orphaned_tool_results treats that gap as an orphan
-          boundary and drops every tool result of the turn, so the model never
-          sees the outcome of the calls it is being nudged about — locking in
-          the repetition the nudge is meant to break. *)
+       (* Nudge text is captured here and later delivered as a separate
+          role:User message appended AFTER the role:Tool results message (see
+          the snoc at the tool-results append below), never as a standalone
+          message before tool execution. A message placed before the tool
+          results would sit between the assistant tool_calls message and its
+          results; the OpenAI-compat serializer's strip_orphaned_tool_results
+          treats that gap as an orphan boundary and drops every tool result of
+          the turn, so the model never sees the outcome of the calls it is
+          being nudged about — locking in the repetition the nudge is meant to
+          break. *)
        let pending_nudge = ref None in
        if idle_result.is_idle
        then (

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -465,9 +465,10 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
               in
               update_state agent (fun s -> { s with messages = new_messages }));
            let* () = persist_turn_checkpoint agent After_tool_results_appended in
-           (* Anti-repetition hint is appended after the ToolResult message so
-              provider serializers can keep assistant tool_calls and role:tool
-              responses adjacent. *)
+           (* The idle nudge (and the fallback anti-repetition hint) is appended
+              as a separate role:User message after the role:Tool result message.
+              This keeps OpenAI-compatible serializers from placing user text
+              before the required tool replies, which strict providers reject. *)
            ignore idle_handled;
            (* suppress unused warning after dedup *)
            (* In-memory message hygiene after each tool execution round.

--- a/test/test_tool_middleware.ml
+++ b/test/test_tool_middleware.ml
@@ -576,8 +576,9 @@ let test_strip_empty () =
 (* A standalone user Text message (e.g. an idle nudge) between the assistant
    tool_calls message and the tool results breaks the result span: every tool
    result of the turn is treated as orphaned, and the results message is
-   dropped entirely. This is why the pipeline delivers idle nudges inside the
-   tool-results message — see the companion test below. *)
+   dropped entirely. This is why the pipeline delivers idle nudges as a
+   separate role:User message AFTER the tool-results message, never before it
+   — see the companion test below. *)
 let test_strip_drops_results_after_interleaved_text () =
   let msgs =
     [ mk_msg Assistant [ ToolUse { id = "t1"; name = "f"; input = `Null } ]


### PR DESCRIPTION
## Summary

Follow-up PR for the unresolved review thread on #2028.

### Review thread

- **File:** `lib/pipeline/pipeline.ml` (around the tool-results append path)
- **Concern:** When an `on_idle` hook returns `Nudge`, the nudge must be emitted *after* all corresponding tool replies so OpenAI-compatible serializers do not place a `user` text message before the required `tool` messages. A shape that puts text and tool results in the same internal message serializes as `assistant(tool_calls) -> user(nudge) -> tool(result)`, which strict providers can reject.

### Resolution

The ordering concern was already addressed by later work on `main`:

- Tool results are now stored on a dedicated `role:Tool` message.
- The idle nudge (and the fallback anti-repetition hint) is appended as a separate `role:User` message *after* that `role:Tool` message.
- The OpenAI serializer emits tool messages before user text for any mixed message.

Existing tests cover this wire order:

- `test_backend_openai_codec`: `wire adjacency: nudged tool turn`
- `test_hooks_integration`: `nudge follows the tool-results message`
- `test_tool_middleware`: `tool role result before nudge keeps results`
- `test_context_reducer`: `tool role result and nudge stay in turn`

This PR adds a clarifying inline comment at the append site so the invariant is explicit for future readers.

### Checks

- `dune build --root . @all` ✅
- Affected test executables ✅
- `dune build --root . @fmt` has pre-existing failures on unrelated files (also fail on `main`) and is not touched here.,timeout:120}