### PR TITLE
fix: address review follow-ups from #2023

### DIFF
--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -155,6 +155,12 @@ let is_zai_glm_request (config : Provider_config.t) =
   && Zai_catalog.is_glm_model_id config.model_id
 ;;
 
+let zai_glm_preserve_thinking_request (config : Provider_config.t) =
+  is_zai_glm_request config
+  && config.enable_thinking = Some true
+  && not (glm_clear_thinking_of_config config)
+;;
+
 (** Build Openai Chat Completions request body from {!Provider_config.t}.
     Returns a JSON string ready for HTTP POST. *)
 let build_request_assoc
@@ -173,12 +179,11 @@ let build_request_assoc
     let message_serializer =
       match config.kind with
       | Provider_config.Glm -> Backend_openai_serialize.glm_messages_of_message
-      | Provider_config.OpenAI_compat
-        when is_zai_glm_request config && not (glm_clear_thinking_of_config config) ->
-        (* ZAI GLM accepts reasoning_content in request messages whenever we
-           ask it to preserve thinking (clear_thinking=false). The generic
-           OpenAI_compat serializer drops Thinking blocks, so route bare-ZAI
-           GLM through the GLM serializer for those turns. *)
+      | Provider_config.OpenAI_compat when zai_glm_preserve_thinking_request config ->
+        (* ZAI GLM accepts reasoning_content in request messages only when the
+           same request body enables thinking with clear_thinking=false. The
+           generic OpenAI_compat serializer drops Thinking blocks, so route
+           bare-ZAI GLM through the GLM serializer only for that wire shape. *)
         Backend_openai_serialize.glm_messages_of_message
       | Provider_config.Anthropic
       | Provider_config.Kimi

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -173,6 +173,13 @@ let build_request_assoc
     let message_serializer =
       match config.kind with
       | Provider_config.Glm -> Backend_openai_serialize.glm_messages_of_message
+      | Provider_config.OpenAI_compat
+        when is_zai_glm_request config && not (glm_clear_thinking_of_config config) ->
+        (* ZAI GLM accepts reasoning_content in request messages whenever we
+           ask it to preserve thinking (clear_thinking=false). The generic
+           OpenAI_compat serializer drops Thinking blocks, so route bare-ZAI
+           GLM through the GLM serializer for those turns. *)
+        Backend_openai_serialize.glm_messages_of_message
       | Provider_config.Anthropic
       | Provider_config.Kimi
       | Provider_config.OpenAI_compat

--- a/lib/llm_provider/zai_catalog.ml
+++ b/lib/llm_provider/zai_catalog.ml
@@ -10,7 +10,7 @@ let zai_anthropic_base_url = "https://api.z.ai/api/anthropic"
 
 let is_glm_model_id model_id =
   let m = String.lowercase_ascii (String.trim model_id) in
-  m = "glm" || String.starts_with ~prefix:"glm-" m || String.starts_with ~prefix:"glm-" m
+  m = "glm" || String.starts_with ~prefix:"glm-" m
 ;;
 
 let has_prefix value prefix =
@@ -168,7 +168,6 @@ let throttle_key_for_chat ~base_url ~model_id =
 let%test "is_glm_model_id accepts glm and bare glm prefixes" =
   is_glm_model_id "glm-5"
   && is_glm_model_id "glm"
-  && is_glm_model_id "glm-5"
   && is_glm_model_id "GLM-4.7-Flash"
   && not (is_glm_model_id "gpt-5")
 ;;

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -338,6 +338,76 @@ let test_deepseek_zero_budget_omits_reasoning_effort () =
     (contains ~needle:{|"reasoning_effort"|} body)
 ;;
 
+(* ZAI GLM reached through the OpenAI-compat backend must replay historical
+   reasoning_content when it asks the provider to preserve thinking
+   (clear_thinking=false). Regression fence for the review follow-up from
+   PR #2023. *)
+let zai_glm_openai_compat_cfg ?(preserve_thinking = true) () =
+  Provider_config.make
+    ~kind:OpenAI_compat
+    ~model_id:"glm-5"
+    ~base_url:"https://api.z.ai/api/paas/v4"
+    ~api_key:"test-key"
+    ~max_tokens:1024
+    ~temperature:0.7
+    ~tool_choice:Any
+    ~disable_parallel_tool_use:true
+    ~enable_thinking:true
+    ~preserve_thinking
+    ()
+;;
+
+let zai_glm_messages_with_reasoning =
+  [ msg User [ Text "solve" ]
+  ; msg
+      Assistant
+      [ Text "answer"
+      ; Thinking { thinking_type = "reasoning"; content = "chain of thought" }
+      ]
+  ]
+;;
+
+let test_zai_glm_openai_compat_replays_reasoning_when_preserve_thinking () =
+  let body =
+    Backend_openai_request.build_request
+      ~config:(zai_glm_openai_compat_cfg ())
+      ~messages:zai_glm_messages_with_reasoning
+      ()
+  in
+  check
+    bool
+    "thinking enabled with clear_thinking=false"
+    true
+    (contains ~needle:{|"thinking":{"type":"enabled","clear_thinking":false}|} body);
+  check
+    bool
+    "assistant message replays reasoning_content"
+    true
+    (contains
+       ~needle:
+         {|"reasoning_content":"chain of thought","role":"assistant","content":"answer"|}
+       body)
+;;
+
+let test_zai_glm_openai_compat_drops_reasoning_without_preserve () =
+  let body =
+    Backend_openai_request.build_request
+      ~config:(zai_glm_openai_compat_cfg ~preserve_thinking:false ())
+      ~messages:zai_glm_messages_with_reasoning
+      ()
+  in
+  check
+    bool
+    "thinking enabled with clear_thinking=true"
+    true
+    (contains ~needle:{|"thinking":{"type":"enabled","clear_thinking":true}|} body);
+  check
+    bool
+    "assistant message omits reasoning_content when not preserving"
+    false
+    (contains ~needle:{|"reasoning_content"|} body)
+;;
+
 (* ── Anthropic ──────────────────────────────────────── *)
 
 let anthropic_forced_expected =
@@ -543,6 +613,14 @@ let () =
             "deepseek-v4-flash zero budget omits reasoning_effort"
             `Quick
             test_deepseek_zero_budget_omits_reasoning_effort
+        ; test_case
+            "zai-glm-openai-compat replays reasoning when preserve_thinking"
+            `Quick
+            test_zai_glm_openai_compat_replays_reasoning_when_preserve_thinking
+        ; test_case
+            "zai-glm-openai-compat drops reasoning without preserve_thinking"
+            `Quick
+            test_zai_glm_openai_compat_drops_reasoning_without_preserve
         ] )
     ; ( "anthropic"
       , [ test_case "tool_choice forced(Tool)" `Quick test_anthropic_forced

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -342,7 +342,11 @@ let test_deepseek_zero_budget_omits_reasoning_effort () =
    reasoning_content when it asks the provider to preserve thinking
    (clear_thinking=false). Regression fence for the review follow-up from
    PR #2023. *)
-let zai_glm_openai_compat_cfg ?(preserve_thinking = true) () =
+let zai_glm_openai_compat_cfg
+      ?(enable_thinking = Some true)
+      ?(preserve_thinking = true)
+      ()
+  =
   Provider_config.make
     ~kind:OpenAI_compat
     ~model_id:"glm-5"
@@ -352,7 +356,7 @@ let zai_glm_openai_compat_cfg ?(preserve_thinking = true) () =
     ~temperature:0.7
     ~tool_choice:Any
     ~disable_parallel_tool_use:true
-    ~enable_thinking:true
+    ?enable_thinking
     ~preserve_thinking
     ()
 ;;
@@ -404,6 +408,44 @@ let test_zai_glm_openai_compat_drops_reasoning_without_preserve () =
   check
     bool
     "assistant message omits reasoning_content when not preserving"
+    false
+    (contains ~needle:{|"reasoning_content"|} body)
+;;
+
+let test_zai_glm_openai_compat_drops_reasoning_when_thinking_disabled () =
+  let body =
+    Backend_openai_request.build_request
+      ~config:
+        (zai_glm_openai_compat_cfg
+           ~enable_thinking:(Some false)
+           ~preserve_thinking:true
+           ())
+      ~messages:zai_glm_messages_with_reasoning
+      ()
+  in
+  check
+    bool
+    "thinking disabled"
+    true
+    (contains ~needle:{|"thinking":{"type":"disabled"}|} body);
+  check
+    bool
+    "disabled thinking does not replay reasoning_content"
+    false
+    (contains ~needle:{|"reasoning_content"|} body)
+;;
+
+let test_zai_glm_openai_compat_drops_reasoning_when_thinking_absent () =
+  let body =
+    Backend_openai_request.build_request
+      ~config:(zai_glm_openai_compat_cfg ~enable_thinking:None ~preserve_thinking:true ())
+      ~messages:zai_glm_messages_with_reasoning
+      ()
+  in
+  check bool "thinking object omitted" false (contains ~needle:{|"thinking"|} body);
+  check
+    bool
+    "absent thinking control does not replay reasoning_content"
     false
     (contains ~needle:{|"reasoning_content"|} body)
 ;;
@@ -621,6 +663,14 @@ let () =
             "zai-glm-openai-compat drops reasoning without preserve_thinking"
             `Quick
             test_zai_glm_openai_compat_drops_reasoning_without_preserve
+        ; test_case
+            "zai-glm-openai-compat drops reasoning when thinking disabled"
+            `Quick
+            test_zai_glm_openai_compat_drops_reasoning_when_thinking_disabled
+        ; test_case
+            "zai-glm-openai-compat drops reasoning when thinking absent"
+            `Quick
+            test_zai_glm_openai_compat_drops_reasoning_when_thinking_absent
         ] )
     ; ( "anthropic"
       , [ test_case "tool_choice forced(Tool)" `Quick test_anthropic_forced

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -167,6 +167,39 @@ let contains ~needle haystack =
   nl = 0 || go 0
 ;;
 
+let json_body body = Yojson.Safe.from_string body
+
+let has_field name json =
+  match Yojson.Safe.Util.member name json with
+  | `Null -> false
+  | _ -> true
+;;
+
+let assistant_message body =
+  let open Yojson.Safe.Util in
+  body
+  |> json_body
+  |> member "messages"
+  |> to_list
+  |> List.find (fun msg -> msg |> member "role" |> to_string = "assistant")
+;;
+
+let check_reasoning_content label expected body =
+  let msg = assistant_message body in
+  check bool label expected (has_field "reasoning_content" msg)
+;;
+
+let check_thinking_enabled_clear label expected_clear body =
+  let open Yojson.Safe.Util in
+  let thinking = body |> json_body |> member "thinking" in
+  check string (label ^ " type") "enabled" (thinking |> member "type" |> to_string);
+  check
+    bool
+    (label ^ " clear_thinking")
+    expected_clear
+    (thinking |> member "clear_thinking" |> to_bool)
+;;
+
 (* ── OpenAI-compatible ──────────────────────────────── *)
 
 let openai_forced_expected =
@@ -378,19 +411,8 @@ let test_zai_glm_openai_compat_replays_reasoning_when_preserve_thinking () =
       ~messages:zai_glm_messages_with_reasoning
       ()
   in
-  check
-    bool
-    "thinking enabled with clear_thinking=false"
-    true
-    (contains ~needle:{|"thinking":{"type":"enabled","clear_thinking":false}|} body);
-  check
-    bool
-    "assistant message replays reasoning_content"
-    true
-    (contains
-       ~needle:
-         {|"reasoning_content":"chain of thought","role":"assistant","content":"answer"|}
-       body)
+  check_thinking_enabled_clear "thinking enabled with clear_thinking=false" false body;
+  check_reasoning_content "assistant message replays reasoning_content" true body
 ;;
 
 let test_zai_glm_openai_compat_drops_reasoning_without_preserve () =
@@ -400,16 +422,11 @@ let test_zai_glm_openai_compat_drops_reasoning_without_preserve () =
       ~messages:zai_glm_messages_with_reasoning
       ()
   in
-  check
-    bool
-    "thinking enabled with clear_thinking=true"
-    true
-    (contains ~needle:{|"thinking":{"type":"enabled","clear_thinking":true}|} body);
-  check
-    bool
+  check_thinking_enabled_clear "thinking enabled with clear_thinking=true" true body;
+  check_reasoning_content
     "assistant message omits reasoning_content when not preserving"
     false
-    (contains ~needle:{|"reasoning_content"|} body)
+    body
 ;;
 
 let test_zai_glm_openai_compat_drops_reasoning_when_thinking_disabled () =
@@ -423,16 +440,13 @@ let test_zai_glm_openai_compat_drops_reasoning_when_thinking_disabled () =
       ~messages:zai_glm_messages_with_reasoning
       ()
   in
+  let open Yojson.Safe.Util in
   check
-    bool
+    string
     "thinking disabled"
-    true
-    (contains ~needle:{|"thinking":{"type":"disabled"}|} body);
-  check
-    bool
-    "disabled thinking does not replay reasoning_content"
-    false
-    (contains ~needle:{|"reasoning_content"|} body)
+    "disabled"
+    (body |> json_body |> member "thinking" |> member "type" |> to_string);
+  check_reasoning_content "disabled thinking does not replay reasoning_content" false body
 ;;
 
 let test_zai_glm_openai_compat_drops_reasoning_when_thinking_absent () =
@@ -442,12 +456,11 @@ let test_zai_glm_openai_compat_drops_reasoning_when_thinking_absent () =
       ~messages:zai_glm_messages_with_reasoning
       ()
   in
-  check bool "thinking object omitted" false (contains ~needle:{|"thinking"|} body);
-  check
-    bool
+  check bool "thinking object omitted" false (body |> json_body |> has_field "thinking");
+  check_reasoning_content
     "absent thinking control does not replay reasoning_content"
     false
-    (contains ~needle:{|"reasoning_content"|} body)
+    body
 ;;
 
 (* ── Anthropic ──────────────────────────────────────── *)


### PR DESCRIPTION
This PR addresses the unresolved review thread on #2023.

## Fix
- In `lib/llm_provider/backend_openai_request.ml`, when `kind=OpenAI_compat` targets a ZAI GLM base URL and `preserve_thinking=true` causes `thinking.clear_thinking=false`, route message serialization through the GLM serializer instead of the generic OpenAI-compat serializer.
- This ensures historical `reasoning_content` is replayed in multi-turn/tool-call continuations, matching what ZAI GLM expects when asked to preserve thinking.

## Tests
- Added regression tests in `test/test_snapshot_provider_serialization.ml`:
  - `zai-glm-openai-compat replays reasoning when preserve_thinking`
  - `zai-glm-openai-compat drops reasoning without preserve_thinking`

## Verification
- `MASC_DUNE_ALLOW_BARE_DUNE=1 dune build --root . @all` passes.
- Affected test executables pass:
  - `test_snapshot_provider_serialization.exe`
  - `test_backend_glm_coverage.exe`
  - `test_backend_openai_codec.exe`