### PR TITLE
chore(format): base-broken 5파일 ocamlformat 적용

### DIFF
--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -109,7 +109,9 @@ let build_request
      serializing then parsing the whole message body back — removes one full
      [Yojson.Safe.to_string] (OpenAI) + one [Yojson.Safe.from_string] (here)
      per GLM turn. Byte-identical: [from_string (to_string assoc) = assoc]. *)
-  let base_assoc = Backend_openai.build_request_assoc ~stream ~config ~messages ~tools () in
+  let base_assoc =
+    Backend_openai.build_request_assoc ~stream ~config ~messages ~tools ()
+  in
   match base_assoc with
   | `Assoc fields ->
     (* [thinking] single-owner normalization. The shared request builder's
@@ -177,13 +179,15 @@ let check_glm_error_json (json : Yojson.Safe.t) : glm_error option =
 ;;
 
 let check_glm_error body : glm_error option =
-  try check_glm_error_json (Yojson.Safe.from_string body)
-  with Yojson.Json_error _ -> None
+  try check_glm_error_json (Yojson.Safe.from_string body) with
+  | Yojson.Json_error _ -> None
 ;;
 
 (** Extract reasoning_content from Glm response and prepend as Thinking block.
     Glm returns reasoning in [message.reasoning_content] alongside [message.content]. *)
-let extract_reasoning_content_json (resp : api_response) (json : Yojson.Safe.t) : api_response =
+let extract_reasoning_content_json (resp : api_response) (json : Yojson.Safe.t)
+  : api_response
+  =
   try
     let open Yojson.Safe.Util in
     let choices = json |> member "choices" in
@@ -206,8 +210,8 @@ let extract_reasoning_content_json (resp : api_response) (json : Yojson.Safe.t) 
 ;;
 
 let extract_reasoning_content (resp : api_response) body : api_response =
-  try extract_reasoning_content_json resp (Yojson.Safe.from_string body)
-  with Yojson.Json_error _ -> resp
+  try extract_reasoning_content_json resp (Yojson.Safe.from_string body) with
+  | Yojson.Json_error _ -> resp
 ;;
 
 let glm_parse_error message =

--- a/lib/llm_provider/backend_openai_parse.mli
+++ b/lib/llm_provider/backend_openai_parse.mli
@@ -12,7 +12,9 @@ val usage_of_openai_json : Yojson.Safe.t -> Types.api_usage option
     [Yojson.Safe.t]).  Returns [Ok api_response] on success, [Error msg] on
     API error.  Use when the caller already holds the parsed JSON to avoid
     re-parsing. *)
-val parse_openai_response_result_json : Yojson.Safe.t -> (Types.api_response, string) result
+val parse_openai_response_result_json
+  :  Yojson.Safe.t
+  -> (Types.api_response, string) result
 
 (** Parse an OpenAI-compatible JSON response.
     Returns [Ok api_response] on success, [Error msg] on API error. *)

--- a/lib/llm_provider/backend_openai_request.mli
+++ b/lib/llm_provider/backend_openai_request.mli
@@ -16,6 +16,9 @@ val openai_json_schema_payload : Yojson.Safe.t -> Yojson.Safe.t
 val response_format_to_openai_json : Types.response_format -> Yojson.Safe.t option
 val response_format_of_config : Provider_config.t -> Yojson.Safe.t option
 
+(** [build_request_assoc] is {!build_request} before the final
+    [Yojson.Safe.to_string]; sibling backends (e.g. {!Backend_glm}) mutate the
+    Assoc directly instead of parsing the serialized string back. *)
 val build_request_assoc
   :  ?stream:bool
   -> config:Provider_config.t
@@ -23,9 +26,6 @@ val build_request_assoc
   -> ?tools:Yojson.Safe.t list
   -> unit
   -> Yojson.Safe.t
-(** [build_request_assoc] is {!build_request} before the final
-    [Yojson.Safe.to_string]; sibling backends (e.g. {!Backend_glm}) mutate the
-    Assoc directly instead of parsing the serialized string back. *)
 
 val build_request
   :  ?stream:bool

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -1331,9 +1331,9 @@ let inject_stream_and_options body_str =
     in
     Yojson.Safe.to_string
       (`Assoc
-        ( ("stream_options", `Assoc [ "include_usage", `Bool true ])
-        :: ("stream", `Bool true)
-        :: without_existing ))
+          (("stream_options", `Assoc [ "include_usage", `Bool true ])
+           :: ("stream", `Bool true)
+           :: without_existing))
   | other -> Yojson.Safe.to_string other
   | exception Yojson.Json_error _ -> body_str
 ;;
@@ -1352,7 +1352,9 @@ let%test "inject_stream_and_options matches chained param >> options" =
     ; {|{"a":1,"stream":true,"stream_options":{"x":1}}|}
     ; "not json"
     ; {|[1,2,3]|}
-    ; "" ]
+    ; ""
+    ]
+;;
 
 [@@@coverage off]
 (* ── catch_network tests ─────────────────────────────── *)

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -481,7 +481,8 @@ let () =
         ; Alcotest.test_case "array" `Quick test_inject_stream_param_array
         ; Alcotest.test_case
             "and_options parity with chained"
-            `Quick test_inject_stream_and_options_parity
+            `Quick
+            test_inject_stream_and_options_parity
         ] )
     ; ( "read_sse"
       , [ Alcotest.test_case "basic events" `Quick test_read_sse_basic


### PR DESCRIPTION
## 목적

`OCaml Format` 체크가 main에서 5개 파일 때문에 항상 red 상태다. 이 체크는 non-required라 머지를 막지는 않지만(#2122·#2123·#2124가 red인 채 머지됨), **영구 red 체크는 신호 가치를 잃는다** — 새 파일에 진짜 포맷 회귀가 들어와도 묻힌다.

## 변경

ocamlformat 0.29.0(janestreet 프로파일)로 깨져 있던 정확히 5개 파일만 `ocamlformat -i`로 포맷:

- `lib/llm_provider/backend_glm.ml`
- `lib/llm_provider/backend_openai_parse.mli`
- `lib/llm_provider/backend_openai_request.mli`
- `lib/llm_provider/http_client.ml`
- `test/test_http_client.ml`

## 범위/검증

- **format-only**: 로직 변경 없음. `git ls-files '*.ml' '*.mli'` 전수 스캔으로 깨진 파일이 이 5개뿐임을 확인 → 이 PR로 체크가 완전 green이 된다.
- focused 빌드 통과: `dune build lib/llm_provider`(exit 0), `dune build test/test_http_client.exe`(exit 0).
- `dune build @fmt --auto-promote` 대신 `ocamlformat -i`로 깨진 파일만 타격(무관 파일 재포맷 회피).

RFC-WAIVED: format-only 변경, 로직/credential/operator/sandbox/hooks 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)