### PR TITLE
fix(streaming): add auth header and usage options to OpenAI-compatible stream

### DIFF
--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -332,10 +332,9 @@ let create_message_stream
                      }))))
      | Provider.Openai_chat_completions ->
        (* OpenAI-compatible SSE streaming. *)
+       let openai_compat_kind = Llm_provider.Provider_config.OpenAI_compat in
        let auth_headers =
-         Provider.auth_headers_only_for_kind
-           ~kind:Llm_provider.Provider_config.OpenAI_compat
-           ~api_key
+         Provider.auth_headers_only_for_kind ~kind:openai_compat_kind ~api_key
        in
        let headers =
          match Provider.resolve provider_cfg with
@@ -350,6 +349,8 @@ let create_message_stream
            ~messages
            ?tools
            ()
+         (* Streaming must request both SSE chunks and usage deltas so the
+            accumulator can surface final token/cost metrics. *)
          |> Llm_provider.Http_client.inject_stream_and_options
        in
        let url = base_url ^ stream_path in

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -332,10 +332,15 @@ let create_message_stream
                      }))))
      | Provider.Openai_chat_completions ->
        (* OpenAI-compatible SSE streaming. *)
+       let auth_headers =
+         Provider.auth_headers_only_for_kind
+           ~kind:Llm_provider.Provider_config.OpenAI_compat
+           ~api_key
+       in
        let headers =
          match Provider.resolve provider_cfg with
-         | Ok (_, _, h) -> h
-         | Error _ -> [ "Content-Type", "application/json" ]
+         | Ok (_, _, h) -> h @ auth_headers
+         | Error _ -> [ "Content-Type", "application/json" ] @ auth_headers
        in
        let stream_path = Provider.request_path provider_cfg.provider in
        let body =
@@ -345,7 +350,7 @@ let create_message_stream
            ~messages
            ?tools
            ()
-         |> Llm_provider.Http_client.inject_stream_param
+         |> Llm_provider.Http_client.inject_stream_and_options
        in
        let url = base_url ^ stream_path in
        (match


### PR DESCRIPTION
## Problem

The OpenAI-compatible streaming path in `Streaming.create_message_stream` discarded the API key returned by `Provider.resolve`:

OCaml version 5.4.1
Enter #help;; for help.

# 

Only the non-auth headers (Content-Type) were sent, so OpenAI-compatible endpoints returned 401/403.

Additionally, the request body used `inject_stream_param`, which only adds `stream: true`. OpenAI-compatible endpoints require `stream_options.include_usage: true\' to include usage data in the final SSE chunk; without it usage is permanently missing.

## Change

1. Merge `Provider.auth_headers_only_for_kind ~kind:OpenAI_compat ~api_key` into the request headers.
2. Use `Llm_provider.Http_client.inject_stream_and_options` so the body contains `stream_options.include_usage: true`.

## Verification

- `scripts/dune-local.sh runtest test/test_streaming.exe` passes (34/34).
- `scripts/dune-local.sh runtest test/test_streaming_openai.exe` passes (28/28).

## Severity

Critical: OpenAI-compatible streaming was effectively unusable against authenticated endpoints.