### PR TITLE
fix(guardrail_tripwire): avoid data race on shared violation ref

### DIFF
--- a/lib/guardrail_tripwire.ml
+++ b/lib/guardrail_tripwire.ml
@@ -22,7 +22,9 @@ type tripwire_result =
     If all pass, blocks forever (Promise.await) so the action fiber can win.
     Runs inside Fiber.first — the losing fiber gets cancelled. *)
 let check_tripwires ~messages tripwires =
-  let violation = ref None in
+  (* Atomic ensures only the first failing check records a violation,
+     avoiding concurrent writes to a shared [ref] by multiple fibers. *)
+  let violation = Stdlib.Atomic.make None in
   (* Run all checks in a switch — first failure wins *)
   let found_violation =
     try
@@ -34,9 +36,11 @@ let check_tripwires ~messages tripwires =
              match tw.check messages with
              | Ok () -> ()
              | Error reason ->
-               violation := Some (tw.name, reason);
-               (* Cancel the switch to stop other checks *)
-               raise Exit))
+               (* Only the first fiber to observe a failure cancels the switch.
+                  Other fibers that also fail simply return and get cancelled. *)
+               if Stdlib.Atomic.compare_and_set violation None (Some (tw.name, reason))
+               then raise Exit
+               else ()))
         tripwires;
       (* If we reach here, all checks passed *)
       false
@@ -44,7 +48,7 @@ let check_tripwires ~messages tripwires =
     | Exit -> true
     | Eio.Cancel.Cancelled _ -> false
   in
-  match found_violation, !violation with
+  match found_violation, Stdlib.Atomic.get violation with
   | true, Some (name, reason) -> Tripped { tripwire_name = name; reason }
   | _ -> All_clear
 ;;


### PR DESCRIPTION
The `check_tripwires` helper forked one Eio fiber per tripwire and had every failing fiber write to a shared `ref` before raising `Exit` to cancel the switch. On OCaml 5 this is undefined behavior: multiple fibers can write the ref concurrently and the recorded violation may not be the first one to fail.

Replace the ref with `Stdlib.Atomic` so only the first failing fiber records the violation and cancels the switch; later failures observe that the violation is already set and return normally. The function signature and return type are unchanged.

Fixes: oas_guardrail_tripwire_race