### PR TITLE
fix(otel_export): propagate Eio.Cancel.Cancelled instead of retrying

### DIFF
--- a/lib/otel_export.ml
+++ b/lib/otel_export.ml
@@ -162,6 +162,7 @@ let post_otlp ~sw ~clock ~client ~config ~endpoint body =
       in
       if code >= 200 && code < 300 then Ok () else Error (Printf.sprintf "HTTP %d" code))
   with
+  | Eio.Cancel.Cancelled _ as e -> raise e
   | Eio.Time.Timeout -> Error (Printf.sprintf "timeout after %.1fs" config.timeout_sec)
   | exn -> Error (Printexc.to_string exn)
 ;;
@@ -172,13 +173,16 @@ let export_batch ~sw ~clock ~client ~config ~service_name spans =
   let body = build_otlp_body ~service_name spans in
   let endpoint = endpoint_for_signal config.endpoint "/v1/traces" in
   let rec attempt n =
-    match post_otlp ~sw ~clock ~client ~config ~endpoint body with
-    | Ok () -> Ok (List.length spans)
-    | Error _ when n < config.max_retries ->
-      let delay = Float.pow 2.0 (Float.of_int n) *. 0.5 in
-      Eio.Time.sleep clock delay;
-      attempt (n + 1)
-    | Error reason -> Error reason
+    try
+      match post_otlp ~sw ~clock ~client ~config ~endpoint body with
+      | Ok () -> Ok (List.length spans)
+      | Error _ when n < config.max_retries ->
+        let delay = Float.pow 2.0 (Float.of_int n) *. 0.5 in
+        Eio.Time.sleep clock delay;
+        attempt (n + 1)
+      | Error reason -> Error reason
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
   in
   attempt 0
 ;;
@@ -187,13 +191,16 @@ let export_metrics ~sw ~clock ~client ~config ~service_name metrics =
   let body = build_otlp_metrics_body ~service_name metrics in
   let endpoint = endpoint_for_signal config.endpoint "/v1/metrics" in
   let rec attempt n =
-    match post_otlp ~sw ~clock ~client ~config ~endpoint body with
-    | Ok () -> Ok (List.length metrics)
-    | Error _ when n < config.max_retries ->
-      let delay = Float.pow 2.0 (Float.of_int n) *. 0.5 in
-      Eio.Time.sleep clock delay;
-      attempt (n + 1)
-    | Error reason -> Error reason
+    try
+      match post_otlp ~sw ~clock ~client ~config ~endpoint body with
+      | Ok () -> Ok (List.length metrics)
+      | Error _ when n < config.max_retries ->
+        let delay = Float.pow 2.0 (Float.of_int n) *. 0.5 in
+        Eio.Time.sleep clock delay;
+        attempt (n + 1)
+      | Error reason -> Error reason
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
   in
   attempt 0
 ;;

--- a/test/test_otel_export.ml
+++ b/test/test_otel_export.ml
@@ -404,6 +404,48 @@ let test_force_flush_updates_total_exported () =
     | Failed { reason } -> Alcotest.failf "expected force flush success: %s" reason)
 ;;
 
+exception Cancel_test
+
+let test_export_batch_cancellation_not_retried () =
+  let request_count = ref 0 in
+  let handler _conn _req body =
+    ignore (read_request_body body : string);
+    incr request_count;
+    Cohttp_eio.Server.respond_string ~status:`Internal_server_error ~body:"boom" ()
+  in
+  with_mock_collector ~port:18357 handler (fun ~sw ~clock ~net ~endpoint ->
+    let instance = make_instance ~service_name:"otel-export-cancel" () in
+    record_span ~name:"span-a" ~turn:1 instance;
+    let config =
+      { (default_export_config ~endpoint) with max_retries = 3; timeout_sec = 0.1 }
+    in
+    let t0 = Eio.Time.now clock in
+    let outcome = ref None in
+    (try
+       Eio.Switch.run
+       @@ fun export_sw ->
+       Eio.Fiber.fork ~sw:export_sw (fun () ->
+         outcome
+         := Some
+              (try
+                 `Result (flush_to_collector ~sw:export_sw ~clock ~net ~config instance)
+               with
+               | Eio.Cancel.Cancelled _ -> `Cancelled
+               | exn -> `Other exn));
+       Eio.Time.sleep clock 0.3;
+       Eio.Switch.fail export_sw Cancel_test
+     with
+     | Cancel_test -> ());
+    let elapsed = Eio.Time.now clock -. t0 in
+    Alcotest.(check bool) "cancelled quickly" true (elapsed < 1.0);
+    match !outcome with
+    | None -> Alcotest.fail "expected outcome before switch failed"
+    | Some `Cancelled -> ()
+    | Some (`Result _) -> Alcotest.fail "expected cancellation, got result"
+    | Some (`Other exn) ->
+      Alcotest.failf "expected cancellation, got %s" (Printexc.to_string exn))
+;;
+
 (* ── Export result type tests ────────────────────────────────── *)
 
 let test_export_result_variants () =
@@ -529,6 +571,10 @@ let () =
             "force flush total"
             `Quick
             test_force_flush_updates_total_exported
+        ; Alcotest.test_case
+            "cancellation not retried"
+            `Quick
+            test_export_batch_cancellation_not_retried
         ] )
     ; "result_types", [ Alcotest.test_case "variants" `Quick test_export_result_variants ]
     ; ( "instance"


### PR DESCRIPTION
## Problem

`post_otlp` caught all exceptions with `Printexc.to_string`, including `Eio.Cancel.Cancelled`, and `export_batch` / `export_metrics` retried after sleeping. This turned switch cancellation into a retried network failure and delayed shutdown.

## Fix

Re-raise `Eio.Cancel.Cancelled` immediately in `post_otlp`, `export_batch`, and `export_metrics` so that cancellation is not converted into a retry-eligible error. Only actual network / timeout errors are retried.

## Verification

- `scripts/dune-local.sh runtest test/test_otel_export.exe` — 19 tests pass, including the new regression test.
- `scripts/dune-local.sh runtest test/test_otel.exe test/test_otel_tracer.exe test/test_otel_tracer_fiber.exe test/test_otel_export.exe` — all otel-related tests pass.