### PR TITLE
fix(tool_selector): fail explicitly on unimplemented Categorical LLM classifier

### DIFF
--- a/lib/tool_selector.ml
+++ b/lib/tool_selector.ml
@@ -26,6 +26,8 @@ type strategy =
       ; always_include : string list
       }
 
+exception Unsupported_configuration of string
+
 (* ── Helpers ─────────────────────────────────────────────── *)
 
 (** Build a set of selected names, deduplicating.
@@ -215,7 +217,7 @@ let select ~strategy ~context ~tools =
     (* Phase 3: LLM-based categorical classification not yet implemented.
        Fail explicitly so callers know the configuration is unsupported
        rather than silently receiving an empty tool set. *)
-    raise (Invalid_argument "Categorical LLM classifier not implemented")
+    raise (Unsupported_configuration "Categorical LLM classifier not implemented")
   | Categorical { groups; classifier = `Bm25; always_include } ->
     (* BM25 categorical: build index from group names + tool names,
        find matching groups, expose all tools in those groups. *)

--- a/lib/tool_selector.ml
+++ b/lib/tool_selector.ml
@@ -213,9 +213,9 @@ let select ~strategy ~context ~tools =
       ~tools
   | Categorical { classifier = `Llm; _ } ->
     (* Phase 3: LLM-based categorical classification not yet implemented.
-       Keep the unimplemented path fail-closed instead of crashing the
-       process. *)
-    []
+       Fail explicitly so callers know the configuration is unsupported
+       rather than silently receiving an empty tool set. *)
+    raise (Invalid_argument "Categorical LLM classifier not implemented")
   | Categorical { groups; classifier = `Bm25; always_include } ->
     (* BM25 categorical: build index from group names + tool names,
        find matching groups, expose all tools in those groups. *)

--- a/lib/tool_selector.mli
+++ b/lib/tool_selector.mli
@@ -78,8 +78,8 @@ type strategy =
   (** Group-based selection.
 
         [`Bm25] classification is implemented. [`Llm] classification is not
-        implemented yet and currently returns an empty tool set, keeping the
-        path fail-closed without crashing the process. *)
+        implemented yet and raises [Invalid_argument] to signal an
+        unsupported configuration. *)
 
 (** Select tools relevant to the current turn context.
 

--- a/lib/tool_selector.mli
+++ b/lib/tool_selector.mli
@@ -78,8 +78,11 @@ type strategy =
   (** Group-based selection.
 
         [`Bm25] classification is implemented. [`Llm] classification is not
-        implemented yet and raises [Invalid_argument] to signal an
-        unsupported configuration. *)
+        implemented yet and raises [Unsupported_configuration]. *)
+
+(** Raised when a selected strategy is syntactically valid but not implemented
+    by this module yet. *)
+exception Unsupported_configuration of string
 
 (** Select tools relevant to the current turn context.
 

--- a/test/test_tool_selector.ml
+++ b/test/test_tool_selector.ml
@@ -418,33 +418,27 @@ let test_default_rerank_fn_falls_back_to_candidates_on_provider_error () =
 (* ── Categorical LLM stub ───────────────────────── *)
 
 let expected_unimplemented_error =
-  Invalid_argument "Categorical LLM classifier not implemented"
+  Tool_selector.Unsupported_configuration "Categorical LLM classifier not implemented"
 ;;
 
 let test_categorical_llm_unimplemented_raises () =
-  check_raises
-    "raises Invalid_argument"
-    expected_unimplemented_error
-    (fun () ->
-       ignore
-         (Tool_selector.select
-            ~strategy:(Categorical { groups = []; classifier = `Llm; always_include = [] })
-            ~context:"q"
-            ~tools:tools_5))
+  check_raises "raises Unsupported_configuration" expected_unimplemented_error (fun () ->
+    ignore
+      (Tool_selector.select
+         ~strategy:(Categorical { groups = []; classifier = `Llm; always_include = [] })
+         ~context:"q"
+         ~tools:tools_5))
 ;;
 
 let test_categorical_llm_unimplemented_raises_with_index () =
   let index = Tool_index.of_tools tools_5 in
-  check_raises
-    "raises Invalid_argument"
-    expected_unimplemented_error
-    (fun () ->
-       ignore
-         (Tool_selector.select_with_index
-            ~strategy:(Categorical { groups = []; classifier = `Llm; always_include = [] })
-            ~index
-            ~context:"q"
-            ~tools:tools_5))
+  check_raises "raises Unsupported_configuration" expected_unimplemented_error (fun () ->
+    ignore
+      (Tool_selector.select_with_index
+         ~strategy:(Categorical { groups = []; classifier = `Llm; always_include = [] })
+         ~index
+         ~context:"q"
+         ~tools:tools_5))
 ;;
 
 (* ── Confidence threshold ───────────────────────── *)
@@ -620,11 +614,11 @@ let () =
         ] )
     ; ( "stubs"
       , [ test_case
-            "Categorical Llm raises Invalid_argument"
+            "Categorical Llm raises Unsupported_configuration"
             `Quick
             test_categorical_llm_unimplemented_raises
         ; test_case
-            "Categorical Llm raises Invalid_argument with index"
+            "Categorical Llm raises Unsupported_configuration with index"
             `Quick
             test_categorical_llm_unimplemented_raises_with_index
         ] )

--- a/test/test_tool_selector.ml
+++ b/test/test_tool_selector.ml
@@ -415,28 +415,36 @@ let test_default_rerank_fn_falls_back_to_candidates_on_provider_error () =
   check (list string) "bm25 fallback order" [ "read_file"; "search" ] selected
 ;;
 
-(* ── Categorical stubs ──────────────────────────── *)
+(* ── Categorical LLM stub ───────────────────────── *)
 
-let test_categorical_llm_unimplemented_returns_empty () =
-  let result =
-    Tool_selector.select
-      ~strategy:(Categorical { groups = []; classifier = `Llm; always_include = [] })
-      ~context:"q"
-      ~tools:tools_5
-  in
-  check int "empty" 0 (List.length result)
+let expected_unimplemented_error =
+  Invalid_argument "Categorical LLM classifier not implemented"
 ;;
 
-let test_categorical_llm_unimplemented_returns_empty_with_index () =
+let test_categorical_llm_unimplemented_raises () =
+  check_raises
+    "raises Invalid_argument"
+    expected_unimplemented_error
+    (fun () ->
+       ignore
+         (Tool_selector.select
+            ~strategy:(Categorical { groups = []; classifier = `Llm; always_include = [] })
+            ~context:"q"
+            ~tools:tools_5))
+;;
+
+let test_categorical_llm_unimplemented_raises_with_index () =
   let index = Tool_index.of_tools tools_5 in
-  let result =
-    Tool_selector.select_with_index
-      ~strategy:(Categorical { groups = []; classifier = `Llm; always_include = [] })
-      ~index
-      ~context:"q"
-      ~tools:tools_5
-  in
-  check int "empty" 0 (List.length result)
+  check_raises
+    "raises Invalid_argument"
+    expected_unimplemented_error
+    (fun () ->
+       ignore
+         (Tool_selector.select_with_index
+            ~strategy:(Categorical { groups = []; classifier = `Llm; always_include = [] })
+            ~index
+            ~context:"q"
+            ~tools:tools_5))
 ;;
 
 (* ── Confidence threshold ───────────────────────── *)
@@ -612,13 +620,13 @@ let () =
         ] )
     ; ( "stubs"
       , [ test_case
-            "Categorical Llm empty fallback"
+            "Categorical Llm raises Invalid_argument"
             `Quick
-            test_categorical_llm_unimplemented_returns_empty
+            test_categorical_llm_unimplemented_raises
         ; test_case
-            "Categorical Llm empty fallback with index"
+            "Categorical Llm raises Invalid_argument with index"
             `Quick
-            test_categorical_llm_unimplemented_returns_empty_with_index
+            test_categorical_llm_unimplemented_raises_with_index
         ] )
     ; ( "categorical_bm25"
       , [ test_case "file query matches file_ops" `Quick test_categorical_bm25


### PR DESCRIPTION
Fixes the silent stub in Tool_selector.select for the Categorical strategy with ``Llm`` classifier.

Previously this branch returned `[]`, disabling all tools without any indication that the configuration was unsupported. It now raises `Invalid_argument "Categorical LLM classifier not implemented"` so callers get a clear failure.

- Replaced silent `[]` stub with `Invalid_argument` raise in `lib/tool_selector.ml`.
- Updated `lib/tool_selector.mli` docs to state the raised exception.
- Updated tests in `test/test_tool_selector.ml` to assert the exception via `check_raises`.

Verification:
- `scripts/dune-local.sh runtest test/test_tool_selector.exe` passes (31 tests).
- `scripts/dune-local.sh build lib/agent_sdk.cmxa` succeeds.