### PR TITLE
fix(provider_intf): propagate Provider.resolve errors from of_config

### DIFF
--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -66,15 +66,15 @@ type provider_module = (module PROVIDER)
 type streaming_provider_module = (module STREAMING_PROVIDER)
 
 (** Runtime dispatch: resolve a provider config to a first-class module.
-    Returns [Some (module STREAMING_PROVIDER)] if native streaming is
-    supported, [None] otherwise (caller should fall back to sync + synthetic). *)
-let of_config (provider_cfg : Provider.config) : provider_module =
-  let spec = Provider.model_spec_of_config provider_cfg in
-  let base_url, api_key, headers =
-    match Provider.resolve provider_cfg with
-    | Ok (url, key, hdrs) -> url, key, hdrs
-    | Error _ -> "", "", []
-  in
+    Returns an error if provider configuration or credentials cannot be
+    resolved. *)
+let of_config (provider_cfg : Provider.config)
+  : (provider_module, Error.sdk_error) result
+  =
+  match Provider.resolve provider_cfg with
+  | Error err -> Error err
+  | Ok (base_url, api_key, headers) ->
+    let spec = Provider.model_spec_of_config provider_cfg in
   let module P = struct
     type t = unit
 
@@ -141,7 +141,7 @@ let of_config (provider_cfg : Provider.config) : provider_module =
     ;;
   end
   in
-  (module P : PROVIDER)
+  Ok (module P : PROVIDER)
 ;;
 
 (** Check if a provider config supports native streaming. *)
@@ -151,50 +151,54 @@ let supports_streaming (provider_cfg : Provider.config) : bool =
 ;;
 
 (** Resolve to a streaming provider if supported.
-    Returns [Some] for Anthropic and OpenAI-compatible providers. *)
+    Returns [Ok (Some _)] when native streaming is supported, [Ok None]
+    otherwise (caller should fall back to sync + synthetic). Returns an
+    error if provider configuration or credentials cannot be resolved. *)
 let of_config_streaming (provider_cfg : Provider.config)
-  : streaming_provider_module option
+  : (streaming_provider_module option, Error.sdk_error) result
   =
   if not (supports_streaming provider_cfg)
-  then None
+  then Ok None
   else (
-    let base_module = of_config provider_cfg in
-    let module Base = (val base_module : PROVIDER) in
-    let base_url =
-      match Provider.resolve provider_cfg with
-      | Ok (url, _, _) -> url
-      | Error _ -> ""
-    in
-    let module SP = struct
-      include Base
+    match of_config provider_cfg with
+    | Error err -> Error err
+    | Ok base_module ->
+      let module Base = (val base_module : PROVIDER) in
+      let base_url =
+        match Provider.resolve provider_cfg with
+        | Ok (url, _, _) -> url
+        | Error _ -> ""
+      in
+      let module SP = struct
+        include Base
 
-      let create_message_stream
+        let create_message_stream
+              ~sw
+              ~net
+              ?clock
+              ?idle_timeout
+              ~config
+              ~messages
+              ?tools
+              ~on_event
+              ()
+          =
+          Streaming.create_message_stream
             ~sw
             ~net
             ?clock
             ?idle_timeout
+            ~base_url
+            ~provider:provider_cfg
             ~config
             ~messages
             ?tools
             ~on_event
             ()
-        =
-        Streaming.create_message_stream
-          ~sw
-          ~net
-          ?clock
-          ?idle_timeout
-          ~base_url
-          ~provider:provider_cfg
-          ~config
-          ~messages
-          ?tools
-          ~on_event
-          ()
-      ;;
-    end
-    in
-    Some (module SP : STREAMING_PROVIDER))
+        ;;
+      end
+      in
+      Ok (Some (module SP : STREAMING_PROVIDER)))
 ;;
 
 [@@@coverage off]
@@ -228,25 +232,26 @@ let%test "supports_streaming OpenAICompat" =
 ;;
 
 let%test "of_config returns a provider_module" =
-  let cfg : Provider.config =
-    { provider = Provider.Anthropic
-    ; model_id = "claude-3-5-sonnet-20241022"
-    ; api_key_env = "ANTHROPIC_API_KEY"
-    }
-  in
-  let _m = of_config cfg in
-  (* Just verify it doesn't raise *)
-  true
+  match of_config (Provider.local_llm ()) with
+  | Ok _ -> true
+  | Error _ -> false
 ;;
 
-let%test "of_config_streaming Anthropic returns Some" =
+let%test "of_config propagates resolve errors" =
   let cfg : Provider.config =
     { provider = Provider.Anthropic
     ; model_id = "claude-3-5-sonnet-20241022"
-    ; api_key_env = "ANTHROPIC_API_KEY"
+    ; api_key_env = "OAS_PROVIDER_INTF_NONEXISTENT_KEY"
     }
   in
-  match of_config_streaming cfg with
-  | Some _ -> true
-  | None -> false
+  match of_config cfg with
+  | Error (Error.Config (MissingEnvVar _)) -> true
+  | Ok _ -> false
+  | Error _ -> false
+;;
+
+let%test "of_config_streaming Local returns Some" =
+  match of_config_streaming (Provider.local_llm ()) with
+  | Ok (Some _) -> true
+  | _ -> false
 ;;

--- a/lib/provider_intf.mli
+++ b/lib/provider_intf.mli
@@ -38,11 +38,18 @@ end
 type provider_module = (module PROVIDER)
 type streaming_provider_module = (module STREAMING_PROVIDER)
 
-(** Resolve a provider config to a first-class PROVIDER module. *)
-val of_config : Provider.config -> provider_module
+(** Resolve a provider config to a first-class PROVIDER module.
+    Returns an error if provider configuration or credentials cannot be
+    resolved (e.g. a required environment variable is missing). *)
+val of_config : Provider.config -> (provider_module, Error.sdk_error) result
 
 (** Check if a provider config supports native streaming. *)
 val supports_streaming : Provider.config -> bool
 
-(** Resolve to a STREAMING_PROVIDER if native streaming is supported. *)
-val of_config_streaming : Provider.config -> streaming_provider_module option
+(** Resolve to a STREAMING_PROVIDER if native streaming is supported.
+    Returns [Ok None] when streaming is not supported for this provider.
+    Returns an error if provider configuration or credentials cannot be
+    resolved. *)
+val of_config_streaming
+  :  Provider.config
+  -> (streaming_provider_module option, Error.sdk_error) result

--- a/test/test_provider_intf.ml
+++ b/test/test_provider_intf.ml
@@ -4,11 +4,25 @@ open Agent_sdk
 open Agent_sdk.Types
 module Retry = Llm_provider.Retry
 
+let require_provider config =
+  match Provider_intf.of_config config with
+  | Ok m -> m
+  | Error err -> Alcotest.failf "Expected provider, got error: %s" (Error.to_string err)
+;;
+
+let require_streaming_provider config =
+  match Provider_intf.of_config_streaming config with
+  | Ok (Some m) -> m
+  | Ok None -> Alcotest.fail "Expected a streaming provider, got None"
+  | Error err ->
+    Alcotest.failf "Expected streaming provider, got error: %s" (Error.to_string err)
+;;
+
 (* ── Module type satisfaction ────────────────────────────── *)
 
-let test_of_config_anthropic () =
-  let config = Provider.anthropic_sonnet () in
-  let (module P : Provider_intf.PROVIDER) = Provider_intf.of_config config in
+let test_of_config_local () =
+  let config = Provider.local_llm () in
+  let (module P : Provider_intf.PROVIDER) = require_provider config in
   (* Module was constructed — type check passed at compile time.
      We can't call create_message without a real network, but the
      module satisfying PROVIDER is the key guarantee. *)
@@ -17,8 +31,22 @@ let test_of_config_anthropic () =
 
 let test_of_config_openai () =
   let config = Provider.openrouter ~model_id:"gpt-4" () in
-  let (module P : Provider_intf.PROVIDER) = Provider_intf.of_config config in
+  let (module P : Provider_intf.PROVIDER) = require_provider config in
   ignore (module P : Provider_intf.PROVIDER)
+;;
+
+let test_of_config_propagates_resolve_error () =
+  let config =
+    { Provider.provider = Provider.Anthropic
+    ; model_id = "claude-3-5-sonnet-20241022"
+    ; api_key_env = "OAS_PROVIDER_INTF_NONEXISTENT_KEY"
+    }
+  in
+  match Provider_intf.of_config config with
+  | Error (Error.Config (MissingEnvVar _)) -> ()
+  | Ok _ -> Alcotest.fail "Expected resolve error for missing env var"
+  | Error err ->
+    Alcotest.failf "Expected MissingEnvVar error, got: %s" (Error.to_string err)
 ;;
 
 (* ── supports_streaming ──────────────────────────────────── *)
@@ -31,11 +59,9 @@ let test_anthropic_supports_streaming () =
 (* ── of_config_streaming ─────────────────────────────────── *)
 
 let test_streaming_provider_some () =
-  let config = Provider.anthropic_sonnet () in
-  match Provider_intf.of_config_streaming config with
-  | Some (module SP : Provider_intf.STREAMING_PROVIDER) ->
-    ignore (module SP : Provider_intf.STREAMING_PROVIDER)
-  | None -> Alcotest.fail "expected Some for anthropic"
+  let config = Provider.local_llm () in
+  let (module SP : Provider_intf.STREAMING_PROVIDER) = require_streaming_provider config in
+  ignore (module SP : Provider_intf.STREAMING_PROVIDER)
 ;;
 
 (* ── HTTP dispatch ───────────────────────────────────────── *)
@@ -120,7 +146,7 @@ let test_provider_dispatch_uses_http_client () =
     let provider : Provider.config =
       { provider = Local { base_url }; model_id = "mock"; api_key_env = "DUMMY_KEY" }
     in
-    let (module P : Provider_intf.PROVIDER) = Provider_intf.of_config provider in
+    let (module P : Provider_intf.PROVIDER) = require_provider provider in
     match
       P.create_message
         ~sw
@@ -157,7 +183,7 @@ let test_provider_dispatch_maps_server_error () =
     let provider : Provider.config =
       { provider = Local { base_url }; model_id = "mock"; api_key_env = "DUMMY_KEY" }
     in
-    let (module P : Provider_intf.PROVIDER) = Provider_intf.of_config provider in
+    let (module P : Provider_intf.PROVIDER) = require_provider provider in
     match
       P.create_message
         ~sw
@@ -182,7 +208,7 @@ let test_provider_dispatch_rejects_malformed_openai_response () =
     let provider : Provider.config =
       { provider = Local { base_url }; model_id = "mock"; api_key_env = "DUMMY_KEY" }
     in
-    let (module P : Provider_intf.PROVIDER) = Provider_intf.of_config provider in
+    let (module P : Provider_intf.PROVIDER) = require_provider provider in
     match
       P.create_message
         ~sw
@@ -231,9 +257,11 @@ let test_custom_provider_dispatch_uses_registered_impl () =
       Provider.custom_provider ~name:custom_name ~model_id:"custom-model" ()
     in
     (match Provider_intf.of_config_streaming provider with
-     | None -> ()
-     | Some _ -> Alcotest.fail "custom provider should not expose streaming");
-    let (module P : Provider_intf.PROVIDER) = Provider_intf.of_config provider in
+     | Ok None -> ()
+     | Ok (Some _) -> Alcotest.fail "custom provider should not expose streaming"
+     | Error err ->
+       Alcotest.failf "unexpected streaming resolve error: %s" (Error.to_string err));
+    let (module P : Provider_intf.PROVIDER) = require_provider provider in
     match
       P.create_message
         ~sw
@@ -262,10 +290,14 @@ let () =
     "Provider_intf"
     [ ( "of_config"
       , [ Alcotest.test_case
-            "anthropic satisfies PROVIDER"
+            "local satisfies PROVIDER"
             `Quick
-            test_of_config_anthropic
+            test_of_config_local
         ; Alcotest.test_case "openai satisfies PROVIDER" `Quick test_of_config_openai
+        ; Alcotest.test_case
+            "propagates resolve errors"
+            `Quick
+            test_of_config_propagates_resolve_error
         ] )
     ; ( "streaming"
       , [ Alcotest.test_case


### PR DESCRIPTION
Fixes `oas_provider_intf_resolve_error`.

`Provider_intf.of_config` previously ignored errors from `Provider.resolve` and returned a provider module with empty base URL, API key, and headers. Missing env vars therefore only surfaced as confusing 404/401 errors at HTTP time.

Changes:
- `of_config` now returns `(provider_module, Error.sdk_error) result` and propagates resolve errors immediately.
- `of_config_streaming` returns `(streaming_provider_module option, Error.sdk_error) result` so streaming resolution also surfaces resolve failures.
- Updated tests and inline tests for the new signatures, replacing env-dependent Anthropic cases with the local provider and adding a test that verifies missing env vars yield a `Config MissingEnvVar` error.

Verification:
- `scripts/dune-local.sh build lib/agent_sdk.cmxa` passes.
- `scripts/dune-local.sh runtest test/test_provider_intf.exe` passes (9/9).