### PR TITLE
fix(otel_tracer): make global tracer fiber-safe and lazy

### DIFF
--- a/lib/otel_tracer.ml
+++ b/lib/otel_tracer.ml
@@ -441,32 +441,44 @@ let metric_type_to_string = function
 
 (* -- Global instance (backward compat) -------------------------------- *)
 
-let _global : instance =
-  { config = default_config
-  ; mu = Stdlib_mu (Mutex.create ())
-  ; fiber_key = None
-  ; current_spans = []
-  ; completed_spans = []
-  ; metrics = []
-  }
+(* The global tracer is lazy so that environment-sensitive configuration is
+   captured on first use, and so the fiber-local key is only allocated when
+   needed.  Using a fiber-local key makes the global API safe for concurrent
+   Eio fibers: each fiber gets its own span stack instead of sharing the
+   instance-wide [current_spans]. *)
+let _global : instance lazy_t =
+  lazy
+    (let endpoint = Sys.getenv_opt "OTEL_EXPORTER_OTLP_ENDPOINT" in
+     { config = { service_name = "agent-sdk"; endpoint }
+     ; mu = Stdlib_mu (Mutex.create ())
+     ; fiber_key = Some (Eio.Fiber.create_key ())
+     ; current_spans = []
+     ; completed_spans = []
+     ; metrics = []
+     })
 ;;
 
-let start_span attrs = inst_start_span _global attrs
-let end_span s ~ok = inst_end_span _global s ~ok
-let add_event s msg = inst_add_event _global s msg
-let add_attrs s attrs = inst_add_attrs _global s attrs
-let add_link s ~trace_id ~span_id = inst_add_link _global s ~trace_id ~span_id
-let flush () = inst_flush _global
-let reset () = inst_reset _global
-let completed_count () = inst_completed_count _global
-let active_count () = inst_active_count _global
+let start_span attrs = inst_start_span (Lazy.force _global) attrs
+let end_span s ~ok = inst_end_span (Lazy.force _global) s ~ok
+let add_event s msg = inst_add_event (Lazy.force _global) s msg
+let add_attrs s attrs = inst_add_attrs (Lazy.force _global) s attrs
+
+let add_link s ~trace_id ~span_id =
+  inst_add_link (Lazy.force _global) s ~trace_id ~span_id
+;;
+
+let flush () = inst_flush (Lazy.force _global)
+let reset () = inst_reset (Lazy.force _global)
+let completed_count () = inst_completed_count (Lazy.force _global)
+let active_count () = inst_active_count (Lazy.force _global)
 
 let record_metric ~name ~value ~metric_type =
-  inst_record_metric _global ~name ~value ~metric_type
+  inst_record_metric (Lazy.force _global) ~name ~value ~metric_type
 ;;
 
-let get_metrics () = inst_get_metrics _global
-let clear_metrics () = inst_clear_metrics _global
+let get_metrics () = inst_get_metrics (Lazy.force _global)
+let clear_metrics () = inst_clear_metrics (Lazy.force _global)
+let current_span () = inst_current_span (Lazy.force _global)
 
 (* -- JSON export ------------------------------------------------------ *)
 
@@ -557,9 +569,10 @@ let metric_entry_to_json (m : metric_entry) : Yojson.Safe.t =
 ;;
 
 let to_otlp_json (cfg : config) : Yojson.Safe.t =
+  let global = Lazy.force _global in
   let spans, metrics =
-    inst_with_lock _global (fun () ->
-      List.rev _global.completed_spans, List.rev _global.metrics)
+    inst_with_lock global (fun () ->
+      List.rev global.completed_spans, List.rev global.metrics)
   in
   let resource =
     `Assoc [ "attributes", attrs_to_json [ "service.name", cfg.service_name ] ]
@@ -669,6 +682,11 @@ let tracer_of_instance inst : Tracing.t =
            raise exn)
     ;;
   end)
+;;
+
+let with_span attrs f =
+  let module T = (val tracer_of_instance (Lazy.force _global)) in
+  T.with_span attrs f
 ;;
 
 (* -- First-class module constructors ---------------------------------- *)

--- a/lib/otel_tracer.mli
+++ b/lib/otel_tracer.mli
@@ -142,6 +142,8 @@ val end_span : span -> ok:bool -> unit
 val add_event : span -> string -> unit
 val add_attrs : span -> (string * string) list -> unit
 val add_link : span -> trace_id:string -> span_id:string -> unit
+val with_span : Tracing.span_attrs -> (unit -> 'a) -> 'a
+val current_span : unit -> span option
 val flush : unit -> span list
 val reset : unit -> unit
 val completed_count : unit -> int

--- a/test/test_otel_tracer_fiber.ml
+++ b/test/test_otel_tracer_fiber.ml
@@ -92,6 +92,58 @@ let test_parallel_spans_do_not_cross_contaminate () =
         active.Agent_sdk.Otel_tracer.name))
 ;;
 
+let test_global_with_span_is_fiber_safe () =
+  Eio_main.run (fun _env ->
+    (* Ensure the global tracer is initialized inside the Eio runtime. *)
+    let (_ : Agent_sdk.Otel_tracer.span) =
+      Agent_sdk.Otel_tracer.start_span
+        { Agent_sdk.Tracing.kind = Agent_run
+        ; name = "warmup"
+        ; agent_name = "test"
+        ; turn = 1
+        ; extra = []
+        ; links = []
+        }
+    in
+    Agent_sdk.Otel_tracer.reset ();
+    let root_attrs =
+      { Agent_sdk.Tracing.kind = Agent_run
+      ; name = "global_root"
+      ; agent_name = "test"
+      ; turn = 1
+      ; extra = []
+      ; links = []
+      }
+    in
+    Agent_sdk.Otel_tracer.with_span root_attrs (fun () ->
+      let parent_span = Option.get (Agent_sdk.Otel_tracer.current_span ()) in
+      let parent_id = parent_span.Agent_sdk.Otel_tracer.span_id in
+      let child_ids =
+        Eio.Fiber.List.map
+          (fun i ->
+             let child_attrs =
+               { Agent_sdk.Tracing.kind = Tool_exec
+               ; name = Printf.sprintf "global_child_%d" i
+               ; agent_name = "test"
+               ; turn = 1
+               ; extra = []
+               ; links = []
+               }
+             in
+             Agent_sdk.Otel_tracer.with_span child_attrs (fun () ->
+               let child = Option.get (Agent_sdk.Otel_tracer.current_span ()) in
+               child.Agent_sdk.Otel_tracer.parent_span_id))
+          [ 0; 1; 2 ]
+      in
+      List.iteri
+        (fun i ppid ->
+           check
+             (Printf.sprintf "global_child_%d has correct parent" i)
+             (Some parent_id)
+             ppid)
+        child_ids))
+;;
+
 let () =
   Alcotest.run
     "otel_tracer_fiber"
@@ -104,6 +156,10 @@ let () =
             "parallel spans do not cross-contaminate"
             `Quick
             test_parallel_spans_do_not_cross_contaminate
+        ; Alcotest.test_case
+            "global with_span is fiber-safe"
+            `Quick
+            test_global_with_span_is_fiber_safe
         ] )
     ]
 ;;


### PR DESCRIPTION
Closes #2132

Makes the module-level global tracer safe for concurrent Eio fibers:
- Lazily initializes [_global] so environment config is captured on first use.
- Gives [_global] a fiber-local key so [with_span] gives each fiber its own span stack.
- Adds global [with_span] and [current_span] helpers for the fiber-safe path.
- Adds a fiber-safety regression test for the global API.

Tested:
- dune exec test/test_otel_tracer.exe
- dune exec test/test_otel_tracer_fiber.exe
- ocamlformat --check