### PR TITLE
refactor(llm_provider): use Result syntax in capability_manifest.ml

### DIFF
--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -199,7 +199,7 @@ let of_json json =
       (Printf.sprintf
          "unsupported capability manifest schema_version: %d (expected 1)"
          schema_version)
-  else (
+  else
     let* model_items =
       match Yojson.Safe.Util.member "models" json with
       | `List items -> Ok items
@@ -218,7 +218,7 @@ let of_json json =
           | Error e -> Right e)
         results
     in
-    if errors <> [] then Error (String.concat "; " errors) else Ok oks)
+    if errors <> [] then Error (String.concat "; " errors) else Ok oks
 ;;
 
 let load_file path =

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -39,8 +39,13 @@ type entry =
 (** A parsed capability manifest. *)
 type t = entry list
 
-let ( let* ) = Result.bind
-let ( let+ ) x f = Result.map f x
+(* Local result-syntax bindings so this file can use [let*] / [let+]
+   without depending on [agent_sdk.base] (which would create a circular
+   library dependency). *)
+module Result_syntax = struct
+  let ( let* ) = Result.bind
+  let ( let+ ) x f = Result.map f x
+end
 
 (* ── JSON parsing helpers ───────────────────────────────── *)
 
@@ -151,42 +156,45 @@ let reject_unknown_keys ~scope ~known json =
 ;;
 
 let parse_entry json =
+  let open Result_syntax in
   let* () = reject_unknown_keys ~scope:"entry" ~known:known_entry_keys json in
-  let+ id_prefix =
+  let* id_prefix =
     match member_string_opt "id_prefix" json with
-    | Some id_prefix -> Ok id_prefix
     | None -> Error "entry missing required \"id_prefix\" field"
+    | Some id_prefix -> Ok id_prefix
   in
-  { id_prefix
-  ; base_label = member_string_opt "base" json
-  ; max_context_tokens = member_int "max_context_tokens" json
-  ; max_output_tokens = member_int "max_output_tokens" json
-  ; supports_tools = member_bool "supports_tools" json
-  ; supports_tool_choice = member_bool "supports_tool_choice" json
-  ; supports_parallel_tool_calls = member_bool "supports_parallel_tool_calls" json
-  ; supports_reasoning = member_bool "supports_reasoning" json
-  ; supports_extended_thinking = member_bool "supports_extended_thinking" json
-  ; supports_reasoning_budget = member_bool "supports_reasoning_budget" json
-  ; supports_response_format_json = member_bool "supports_response_format_json" json
-  ; supports_structured_output = member_bool "supports_structured_output" json
-  ; supports_multimodal_inputs = member_bool "supports_multimodal_inputs" json
-  ; supports_image_input = member_bool "supports_image_input" json
-  ; supports_audio_input = member_bool "supports_audio_input" json
-  ; supports_video_input = member_bool "supports_video_input" json
-  ; supports_native_streaming = member_bool "supports_native_streaming" json
-  ; supports_system_prompt = member_bool "supports_system_prompt" json
-  ; supports_caching = member_bool "supports_caching" json
-  ; supports_prompt_caching = member_bool "supports_prompt_caching" json
-  ; supports_top_k = member_bool "supports_top_k" json
-  ; supports_min_p = member_bool "supports_min_p" json
-  ; supports_seed = member_bool "supports_seed" json
-  ; supports_computer_use = member_bool "supports_computer_use" json
-  ; supports_code_execution = member_bool "supports_code_execution" json
-  ; thinking_control_format = member_string_opt "thinking_control_format" json
-  }
+  Ok
+    { id_prefix
+    ; base_label = member_string_opt "base" json
+    ; max_context_tokens = member_int "max_context_tokens" json
+    ; max_output_tokens = member_int "max_output_tokens" json
+    ; supports_tools = member_bool "supports_tools" json
+    ; supports_tool_choice = member_bool "supports_tool_choice" json
+    ; supports_parallel_tool_calls = member_bool "supports_parallel_tool_calls" json
+    ; supports_reasoning = member_bool "supports_reasoning" json
+    ; supports_extended_thinking = member_bool "supports_extended_thinking" json
+    ; supports_reasoning_budget = member_bool "supports_reasoning_budget" json
+    ; supports_response_format_json = member_bool "supports_response_format_json" json
+    ; supports_structured_output = member_bool "supports_structured_output" json
+    ; supports_multimodal_inputs = member_bool "supports_multimodal_inputs" json
+    ; supports_image_input = member_bool "supports_image_input" json
+    ; supports_audio_input = member_bool "supports_audio_input" json
+    ; supports_video_input = member_bool "supports_video_input" json
+    ; supports_native_streaming = member_bool "supports_native_streaming" json
+    ; supports_system_prompt = member_bool "supports_system_prompt" json
+    ; supports_caching = member_bool "supports_caching" json
+    ; supports_prompt_caching = member_bool "supports_prompt_caching" json
+    ; supports_top_k = member_bool "supports_top_k" json
+    ; supports_min_p = member_bool "supports_min_p" json
+    ; supports_seed = member_bool "supports_seed" json
+    ; supports_computer_use = member_bool "supports_computer_use" json
+    ; supports_code_execution = member_bool "supports_code_execution" json
+    ; thinking_control_format = member_string_opt "thinking_control_format" json
+    }
 ;;
 
 let of_json json =
+  let open Result_syntax in
   let* () = reject_unknown_keys ~scope:"manifest" ~known:known_manifest_keys json in
   let schema_version =
     match Yojson.Safe.Util.member "schema_version" json with
@@ -222,6 +230,7 @@ let of_json json =
 ;;
 
 let load_file path =
+  let open Result_syntax in
   let* json =
     try Ok (Yojson.Safe.from_file path) with
     | Sys_error msg ->
@@ -302,13 +311,12 @@ let%test "of_json: valid manifest parses successfully" =
       {|{"schema_version":1,"models":[{"id_prefix":"my-llm","base":"openai_chat","max_context_tokens":131072,"supports_tools":true}]}|}
   in
   match of_json json with
-  | Ok entries ->
-    List.length entries = 1
-    && (List.hd entries).id_prefix = "my-llm"
-    && (List.hd entries).base_label = Some "openai_chat"
-    && (List.hd entries).max_context_tokens = Some 131072
-    && (List.hd entries).supports_tools = Some true
-  | Error _ -> false
+  | Ok [ entry ] ->
+    entry.id_prefix = "my-llm"
+    && entry.base_label = Some "openai_chat"
+    && entry.max_context_tokens = Some 131072
+    && entry.supports_tools = Some true
+  | Ok _ | Error _ -> false
 ;;
 
 let%test "of_json: wrong schema_version returns error" =
@@ -360,18 +368,21 @@ let%test "lookup: prefix match is case-insensitive" =
     Yojson.Safe.from_string
       {|{"schema_version":1,"models":[{"id_prefix":"My-Model","supports_tools":true}]}|}
   in
-  let manifest = of_json json |> Result.get_ok in
-  match lookup manifest "my-model-q4" with
-  | Some entry -> entry.supports_tools = Some true
-  | None -> false
+  match of_json json with
+  | Ok manifest ->
+    (match lookup manifest "my-model-q4" with
+     | Some entry -> entry.supports_tools = Some true
+     | None -> false)
+  | Error _ -> false
 ;;
 
 let%test "lookup: no match returns None" =
   let json =
     Yojson.Safe.from_string {|{"schema_version":1,"models":[{"id_prefix":"model-a"}]}|}
   in
-  let manifest = of_json json |> Result.get_ok in
-  lookup manifest "model-b" = None
+  match of_json json with
+  | Ok manifest -> lookup manifest "model-b" = None
+  | Error _ -> false
 ;;
 
 let%test "lookup: first matching entry wins" =
@@ -379,10 +390,12 @@ let%test "lookup: first matching entry wins" =
     Yojson.Safe.from_string
       {|{"schema_version":1,"models":[{"id_prefix":"model","max_context_tokens":8192},{"id_prefix":"model","max_context_tokens":4096}]}|}
   in
-  let manifest = of_json json |> Result.get_ok in
-  match lookup manifest "model-v1" with
-  | Some entry -> entry.max_context_tokens = Some 8192
-  | None -> false
+  match of_json json with
+  | Ok manifest ->
+    (match lookup manifest "model-v1" with
+     | Some entry -> entry.max_context_tokens = Some 8192
+     | None -> false)
+  | Error _ -> false
 ;;
 
 let%test "lookup: exact prefix match" =
@@ -390,9 +403,11 @@ let%test "lookup: exact prefix match" =
     Yojson.Safe.from_string
       {|{"schema_version":1,"models":[{"id_prefix":"exact-model"}]}|}
   in
-  let manifest = of_json json |> Result.get_ok in
-  Option.is_some (lookup manifest "exact-model")
-  && Option.is_none (lookup manifest "other-model")
+  match of_json json with
+  | Ok manifest ->
+    Option.is_some (lookup manifest "exact-model")
+    && Option.is_none (lookup manifest "other-model")
+  | Error _ -> false
 ;;
 
 let%test "of_json: unknown entry fields return error" =

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -200,10 +200,15 @@ let of_json json =
          "unsupported capability manifest schema_version: %d (expected 1)"
          schema_version)
   else (
-    let model_items =
+    let* model_items =
       match Yojson.Safe.Util.member "models" json with
-      | `List items -> items
-      | _ -> []
+      | `List items -> Ok items
+      | `Null -> Ok []
+      | actual ->
+        Error
+          (Printf.sprintf
+             "capability manifest \"models\" must be a list, got %s"
+             (json_kind actual))
     in
     let results = List.map parse_entry model_items in
     let oks, errors =
@@ -334,6 +339,20 @@ let%test "of_json: empty models list is valid" =
   match of_json json with
   | Ok entries -> entries = []
   | Error _ -> false
+;;
+
+let%test "of_json: missing models defaults to empty manifest" =
+  let json = Yojson.Safe.from_string {|{"schema_version":1}|} in
+  match of_json json with
+  | Ok entries -> entries = []
+  | Error _ -> false
+;;
+
+let%test "of_json: non-list models returns error" =
+  let json = Yojson.Safe.from_string {|{"schema_version":1,"models":"oops"}|} in
+  match of_json json with
+  | Error msg -> String.contains msg 'm'
+  | Ok _ -> false
 ;;
 
 let%test "lookup: prefix match is case-insensitive" =

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -199,16 +199,11 @@ let of_json json =
       (Printf.sprintf
          "unsupported capability manifest schema_version: %d (expected 1)"
          schema_version)
-  else
-    let* model_items =
+  else (
+    let model_items =
       match Yojson.Safe.Util.member "models" json with
-      | `List items -> Ok items
-      | `Null -> Ok []
-      | actual ->
-        Error
-          (Printf.sprintf
-             "capability manifest \"models\" must be a list, got %s"
-             (json_kind actual))
+      | `List items -> items
+      | _ -> []
     in
     let results = List.map parse_entry model_items in
     let oks, errors =
@@ -218,7 +213,7 @@ let of_json json =
           | Error e -> Right e)
         results
     in
-    if errors <> [] then Error (String.concat "; " errors) else Ok oks
+    if errors <> [] then Error (String.concat "; " errors) else Ok oks)
 ;;
 
 let load_file path =
@@ -339,20 +334,6 @@ let%test "of_json: empty models list is valid" =
   match of_json json with
   | Ok entries -> entries = []
   | Error _ -> false
-;;
-
-let%test "of_json: missing models defaults to empty manifest" =
-  let json = Yojson.Safe.from_string {|{"schema_version":1}|} in
-  match of_json json with
-  | Ok entries -> entries = []
-  | Error _ -> false
-;;
-
-let%test "of_json: non-list models returns error" =
-  let json = Yojson.Safe.from_string {|{"schema_version":1,"models":"oops"}|} in
-  match of_json json with
-  | Error msg -> String.contains msg 'm'
-  | Ok _ -> false
 ;;
 
 let%test "lookup: prefix match is case-insensitive" =

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -39,6 +39,9 @@ type entry =
 (** A parsed capability manifest. *)
 type t = entry list
 
+let ( let* ) = Result.bind
+let ( let+ ) x f = Result.map f x
+
 (* ── JSON parsing helpers ───────────────────────────────── *)
 
 let json_kind = function
@@ -148,92 +151,80 @@ let reject_unknown_keys ~scope ~known json =
 ;;
 
 let parse_entry json =
-  match reject_unknown_keys ~scope:"entry" ~known:known_entry_keys json with
-  | Error _ as error -> error
-  | Ok () ->
-    (match member_string_opt "id_prefix" json with
-     | None -> Error "entry missing required \"id_prefix\" field"
-     | Some id_prefix ->
-       Ok
-         { id_prefix
-         ; base_label = member_string_opt "base" json
-         ; max_context_tokens = member_int "max_context_tokens" json
-         ; max_output_tokens = member_int "max_output_tokens" json
-         ; supports_tools = member_bool "supports_tools" json
-         ; supports_tool_choice = member_bool "supports_tool_choice" json
-         ; supports_parallel_tool_calls = member_bool "supports_parallel_tool_calls" json
-         ; supports_reasoning = member_bool "supports_reasoning" json
-         ; supports_extended_thinking = member_bool "supports_extended_thinking" json
-         ; supports_reasoning_budget = member_bool "supports_reasoning_budget" json
-         ; supports_response_format_json =
-             member_bool "supports_response_format_json" json
-         ; supports_structured_output = member_bool "supports_structured_output" json
-         ; supports_multimodal_inputs = member_bool "supports_multimodal_inputs" json
-         ; supports_image_input = member_bool "supports_image_input" json
-         ; supports_audio_input = member_bool "supports_audio_input" json
-         ; supports_video_input = member_bool "supports_video_input" json
-         ; supports_native_streaming = member_bool "supports_native_streaming" json
-         ; supports_system_prompt = member_bool "supports_system_prompt" json
-         ; supports_caching = member_bool "supports_caching" json
-         ; supports_prompt_caching = member_bool "supports_prompt_caching" json
-         ; supports_top_k = member_bool "supports_top_k" json
-         ; supports_min_p = member_bool "supports_min_p" json
-         ; supports_seed = member_bool "supports_seed" json
-         ; supports_computer_use = member_bool "supports_computer_use" json
-         ; supports_code_execution = member_bool "supports_code_execution" json
-         ; thinking_control_format = member_string_opt "thinking_control_format" json
-         })
+  let* () = reject_unknown_keys ~scope:"entry" ~known:known_entry_keys json in
+  let+ id_prefix =
+    match member_string_opt "id_prefix" json with
+    | Some id_prefix -> Ok id_prefix
+    | None -> Error "entry missing required \"id_prefix\" field"
+  in
+  { id_prefix
+  ; base_label = member_string_opt "base" json
+  ; max_context_tokens = member_int "max_context_tokens" json
+  ; max_output_tokens = member_int "max_output_tokens" json
+  ; supports_tools = member_bool "supports_tools" json
+  ; supports_tool_choice = member_bool "supports_tool_choice" json
+  ; supports_parallel_tool_calls = member_bool "supports_parallel_tool_calls" json
+  ; supports_reasoning = member_bool "supports_reasoning" json
+  ; supports_extended_thinking = member_bool "supports_extended_thinking" json
+  ; supports_reasoning_budget = member_bool "supports_reasoning_budget" json
+  ; supports_response_format_json = member_bool "supports_response_format_json" json
+  ; supports_structured_output = member_bool "supports_structured_output" json
+  ; supports_multimodal_inputs = member_bool "supports_multimodal_inputs" json
+  ; supports_image_input = member_bool "supports_image_input" json
+  ; supports_audio_input = member_bool "supports_audio_input" json
+  ; supports_video_input = member_bool "supports_video_input" json
+  ; supports_native_streaming = member_bool "supports_native_streaming" json
+  ; supports_system_prompt = member_bool "supports_system_prompt" json
+  ; supports_caching = member_bool "supports_caching" json
+  ; supports_prompt_caching = member_bool "supports_prompt_caching" json
+  ; supports_top_k = member_bool "supports_top_k" json
+  ; supports_min_p = member_bool "supports_min_p" json
+  ; supports_seed = member_bool "supports_seed" json
+  ; supports_computer_use = member_bool "supports_computer_use" json
+  ; supports_code_execution = member_bool "supports_code_execution" json
+  ; thinking_control_format = member_string_opt "thinking_control_format" json
+  }
 ;;
 
 let of_json json =
-  match reject_unknown_keys ~scope:"manifest" ~known:known_manifest_keys json with
-  | Error _ as error -> error
-  | Ok () ->
-    let schema_version =
-      match Yojson.Safe.Util.member "schema_version" json with
-      | `Int n -> n
-      | _ -> 0
+  let* () = reject_unknown_keys ~scope:"manifest" ~known:known_manifest_keys json in
+  let schema_version =
+    match Yojson.Safe.Util.member "schema_version" json with
+    | `Int n -> n
+    | _ -> 0
+  in
+  if schema_version <> 1
+  then
+    Error
+      (Printf.sprintf
+         "unsupported capability manifest schema_version: %d (expected 1)"
+         schema_version)
+  else (
+    let model_items =
+      match Yojson.Safe.Util.member "models" json with
+      | `List items -> items
+      | _ -> []
     in
-    if schema_version <> 1
-    then
-      Error
-        (Printf.sprintf
-           "unsupported capability manifest schema_version: %d (expected 1)"
-           schema_version)
-    else (
-      let model_items =
-        match Yojson.Safe.Util.member "models" json with
-        | `List items -> items
-        | _ -> []
-      in
-      let results = List.map parse_entry model_items in
-      let errors =
-        List.filter_map
-          (function
-            | Error e -> Some e
-            | Ok _ -> None)
-          results
-      in
-      if errors <> []
-      then Error (String.concat "; " errors)
-      else
-        Ok
-          (List.filter_map
-             (function
-               | Ok e -> Some e
-               | Error _ -> None)
-             results))
+    let results = List.map parse_entry model_items in
+    let oks, errors =
+      List.partition_map
+        (function
+          | Ok e -> Left e
+          | Error e -> Right e)
+        results
+    in
+    if errors <> [] then Error (String.concat "; " errors) else Ok oks)
 ;;
 
 let load_file path =
-  let read_result =
+  let* json =
     try Ok (Yojson.Safe.from_file path) with
     | Sys_error msg ->
       Error (Printf.sprintf "cannot read capability manifest %s: %s" path msg)
     | Yojson.Json_error msg ->
       Error (Printf.sprintf "capability manifest JSON parse error in %s: %s" path msg)
   in
-  Result.bind read_result of_json
+  of_json json
 ;;
 
 let load_runtime_file path =


### PR DESCRIPTION
Modernize Result usage in `lib/llm_provider/capability_manifest.ml`.

- Replace explicit `match` on `Ok/Error` with `let*` and `let+`.
- Collapse the per-entry result collection using `List.partition_map`.
- Keep behavior-preserving: all-error concatenation, ordering, and public signatures unchanged.

Note: the shared `Result_syntax` module lives in `agent_sdk.base`, which depends on `llm_provider`; adding that dependency would introduce a cycle. This change therefore defines the two local operators `let*` and `let+` at the top of the file, matching the pattern already used in `provider_catalog.ml` and `http_client.ml`.