### PR TITLE
fix(eval_collector): unsubscribe before final drain

### DIFF
--- a/lib/eval_collector.ml
+++ b/lib/eval_collector.ml
@@ -99,8 +99,8 @@ let process_events t =
 ;;
 
 let finalize t =
-  process_events t;
   Event_bus.unsubscribe t.bus t.sub;
+  process_events t;
   let elapsed = Unix.gettimeofday () -. t.start_time in
   (* Record aggregated metrics *)
   Eval.record

--- a/lib/eval_collector.mli
+++ b/lib/eval_collector.mli
@@ -29,6 +29,6 @@ val wrap_run : bus:Event_bus.t -> agent_name:string -> run_id:string -> unit -> 
     manually for intermediate inspection. *)
 val process_events : t -> unit
 
-(** Finalize collection: drain remaining events, unsubscribe,
+(** Finalize collection: unsubscribe, drain remaining events,
     record aggregate metrics, and return the completed run metrics. *)
 val finalize : t -> Eval.run_metrics


### PR DESCRIPTION
## Summary
- Unsubscribe the eval collector before final draining so no new events can arrive between drain and metric snapshot.
- Update the lifecycle doc comment to match the finalized order.

## Validation
- scripts/dune-local.sh build @install