### PR TITLE
refactor(runtime_sync): use Result syntax in lib/runtime_sync.ml

### DIFF
--- a/lib/async_agent.ml
+++ b/lib/async_agent.ml
@@ -58,7 +58,13 @@ let spawn ~sw ?clock agent prompt =
   let resolved = Atomic.make false in
   let cancel_sent = Atomic.make false in
   let future =
-    { promise; resolver; cancelled_u; resolved; cancel_sent; cancel_fn = Atomic.make None }
+    { promise
+    ; resolver
+    ; cancelled_u
+    ; resolved
+    ; cancel_sent
+    ; cancel_fn = Atomic.make None
+    }
   in
   Eio.Fiber.fork ~sw (fun () ->
     try
@@ -108,7 +114,8 @@ let cancel future =
      We also resolve the future immediately to preserve the established
      contract that [cancel] returns a ready future; resolve_once makes the
      final result idempotent. *)
-  if Atomic.compare_and_set future.cancel_sent false true then begin
+  if Atomic.compare_and_set future.cancel_sent false true
+  then (
     Eio.Promise.resolve future.cancelled_u ();
     resolve_once future (Error (Error.Internal "cancelled"));
     match Atomic.exchange future.cancel_fn None with
@@ -116,8 +123,7 @@ let cancel future =
       (try f () with
        | Eio.Cancel.Cancelled _ -> ()
        | Eio.Io _ | Unix.Unix_error _ | Failure _ | Invalid_argument _ -> ())
-    | None -> ()
-  end
+    | None -> ())
 ;;
 
 (* ── Combinators ──────────────────────────────────────────────── *)

--- a/lib/llm_provider/complete_common.ml
+++ b/lib/llm_provider/complete_common.ml
@@ -298,11 +298,12 @@ let validate_thinking_control_request (config : Provider_config.t) =
              Printf.sprintf
                "model %S is reasoning-capable but its capability record declares \
                 thinking_control_format=No_thinking_control: enable_thinking=false \
-                cannot be encoded and would be silently dropped, letting the model \
-                think freely and corrupt JSON-mode output. Declare a \
-                thinking_control_format for this model in Capabilities.for_model_id \
-                (models.toml), or route to a model that supports disabling thinking."
-               config.model_id })
+                cannot be encoded and would be silently dropped, letting the model think \
+                freely and corrupt JSON-mode output. Declare a thinking_control_format \
+                for this model in Capabilities.for_model_id (models.toml), or route to a \
+                model that supports disabling thinking."
+               config.model_id
+         })
   else Ok ()
 ;;
 

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -68,80 +68,84 @@ type streaming_provider_module = (module STREAMING_PROVIDER)
 (** Runtime dispatch: resolve a provider config to a first-class module.
     Returns an error if provider configuration or credentials cannot be
     resolved. *)
-let of_config (provider_cfg : Provider.config)
-  : (provider_module, Error.sdk_error) result
+let of_config (provider_cfg : Provider.config) : (provider_module, Error.sdk_error) result
   =
   match Provider.resolve provider_cfg with
   | Error err -> Error err
   | Ok (base_url, api_key, headers) ->
     let spec = Provider.model_spec_of_config provider_cfg in
-  let module P = struct
-    type t = unit
+    let module P = struct
+      type t = unit
 
-    let create_message ~sw ~net ~config ~messages ?tools () =
-      let kind = spec.request_kind in
-      let path = spec.request_path in
-      let body_str =
-        match kind with
-        | Provider.Anthropic_messages ->
-          Yojson.Safe.to_string
-            (`Assoc
-                (Api_anthropic.build_body_assoc ~config ~messages ?tools ~stream:false ()))
-        | Provider.Openai_chat_completions ->
-          Api_openai.build_openai_body
-            ~provider_config:provider_cfg
-            ~config
-            ~messages
-            ?tools
-            ()
-        | Provider.Custom name ->
-          (match Provider.find_provider name with
-           | Some impl -> impl.build_body ~config ~messages ?tools ()
-           | None -> Yojson.Safe.to_string (`Assoc []))
-      in
-      let url = base_url ^ path in
-      (* Merge auth headers at request time so that [headers] (from
-         [Provider.resolve]) never carries sensitive tokens. *)
-      let auth_hdrs =
-        if api_key = ""
-        then []
-        else (
+      let create_message ~sw ~net ~config ~messages ?tools () =
+        let kind = spec.request_kind in
+        let path = spec.request_path in
+        let body_str =
           match kind with
-          | Provider.Anthropic_messages -> [ "x-api-key", api_key ]
-          | Provider.Openai_chat_completions | Provider.Custom _ ->
-            [ "Authorization", "Bearer " ^ api_key ])
-      in
-      match
-        Http_client.post_sync
-          ~sw
-          ~net
-          ~url
-          ~headers:(headers @ auth_hdrs)
-          ~body:body_str
-          ()
-      with
-      | Ok (200, body_str) ->
-        (match kind with
-         | Provider.Anthropic_messages ->
-           Ok (Api_anthropic.parse_response (Yojson.Safe.from_string body_str))
-         | Provider.Openai_chat_completions ->
-           (match parse_openai_response_result body_str with
-            | Ok resp -> Ok resp
-            | Error msg -> Error (Error.Api (Retry.InvalidRequest { message = msg })))
-         | Provider.Custom name ->
-           (match Provider.find_provider name with
-            | Some impl -> Ok (impl.parse_response body_str)
-            | None ->
-              (match parse_openai_response_result body_str with
-               | Ok resp -> Ok resp
-               | Error msg -> Error (Error.Api (Retry.InvalidRequest { message = msg })))))
-      | Ok (code, body_str) ->
-        Error (Error.Api (Retry.classify_error ~status:code ~body:body_str))
-      | Error err -> Error (Error.Api (retry_error_of_http_error err))
-    ;;
-  end
-  in
-  Ok (module P : PROVIDER)
+          | Provider.Anthropic_messages ->
+            Yojson.Safe.to_string
+              (`Assoc
+                  (Api_anthropic.build_body_assoc
+                     ~config
+                     ~messages
+                     ?tools
+                     ~stream:false
+                     ()))
+          | Provider.Openai_chat_completions ->
+            Api_openai.build_openai_body
+              ~provider_config:provider_cfg
+              ~config
+              ~messages
+              ?tools
+              ()
+          | Provider.Custom name ->
+            (match Provider.find_provider name with
+             | Some impl -> impl.build_body ~config ~messages ?tools ()
+             | None -> Yojson.Safe.to_string (`Assoc []))
+        in
+        let url = base_url ^ path in
+        (* Merge auth headers at request time so that [headers] (from
+         [Provider.resolve]) never carries sensitive tokens. *)
+        let auth_hdrs =
+          if api_key = ""
+          then []
+          else (
+            match kind with
+            | Provider.Anthropic_messages -> [ "x-api-key", api_key ]
+            | Provider.Openai_chat_completions | Provider.Custom _ ->
+              [ "Authorization", "Bearer " ^ api_key ])
+        in
+        match
+          Http_client.post_sync
+            ~sw
+            ~net
+            ~url
+            ~headers:(headers @ auth_hdrs)
+            ~body:body_str
+            ()
+        with
+        | Ok (200, body_str) ->
+          (match kind with
+           | Provider.Anthropic_messages ->
+             Ok (Api_anthropic.parse_response (Yojson.Safe.from_string body_str))
+           | Provider.Openai_chat_completions ->
+             (match parse_openai_response_result body_str with
+              | Ok resp -> Ok resp
+              | Error msg -> Error (Error.Api (Retry.InvalidRequest { message = msg })))
+           | Provider.Custom name ->
+             (match Provider.find_provider name with
+              | Some impl -> Ok (impl.parse_response body_str)
+              | None ->
+                (match parse_openai_response_result body_str with
+                 | Ok resp -> Ok resp
+                 | Error msg -> Error (Error.Api (Retry.InvalidRequest { message = msg })))))
+        | Ok (code, body_str) ->
+          Error (Error.Api (Retry.classify_error ~status:code ~body:body_str))
+        | Error err -> Error (Error.Api (retry_error_of_http_error err))
+      ;;
+    end
+    in
+    Ok (module P : PROVIDER)
 ;;
 
 (** Check if a provider config supports native streaming. *)

--- a/lib/runtime_sync.ml
+++ b/lib/runtime_sync.ml
@@ -1,6 +1,6 @@
-let schema_version_current = 1
-
 open Result_syntax
+
+let schema_version_current = 1
 
 type persistence_backend =
   | Browser_indexeddb
@@ -166,34 +166,36 @@ let assoc_field name fields =
 ;;
 
 let int_field name fields =
-  match assoc_field name fields with
-  | Ok (`Int value) -> Ok value
-  | Ok _ -> Error (Printf.sprintf "field %s must be an int" name)
-  | Error _ as err -> err
+  let* value = assoc_field name fields in
+  match value with
+  | `Int value -> Ok value
+  | _ -> Error (Printf.sprintf "field %s must be an int" name)
 ;;
 
 let string_field name fields =
-  match assoc_field name fields with
-  | Ok (`String value) -> Ok value
-  | Ok _ -> Error (Printf.sprintf "field %s must be a string" name)
-  | Error _ as err -> err
+  let* value = assoc_field name fields in
+  match value with
+  | `String value -> Ok value
+  | _ -> Error (Printf.sprintf "field %s must be a string" name)
 ;;
 
 let string_list_field name fields =
-  match assoc_field name fields with
-  | Ok (`List items) ->
-    items
-    |> List.fold_left
-         (fun acc item ->
-            let* rev = acc in
-            match item with
-            | `String value -> Ok (value :: rev)
-            | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null ->
-              Error (Printf.sprintf "field %s must contain only strings" name))
-         (Ok [])
-    |> Result.map List.rev
-  | Ok _ -> Error (Printf.sprintf "field %s must be a list" name)
-  | Error _ as err -> err
+  let* value = assoc_field name fields in
+  match value with
+  | `List items ->
+    let+ rev =
+      List.fold_left
+        (fun acc item ->
+           let* rev = acc in
+           match item with
+           | `String value -> Ok (value :: rev)
+           | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null ->
+             Error (Printf.sprintf "field %s must contain only strings" name))
+        (Ok [])
+        items
+    in
+    List.rev rev
+  | _ -> Error (Printf.sprintf "field %s must be a list" name)
 ;;
 
 let option_field name fields decode =
@@ -223,26 +225,27 @@ let event_record_of_yojson = function
     let* envelope_json = assoc_field "envelope" fields in
     let* envelope = Event_envelope.of_json envelope_json in
     let* event_json = assoc_field "event" fields in
-    (match Runtime.event_of_yojson event_json with
-     | Ok event -> Ok { envelope; event }
-     | Error detail -> Error detail)
+    let* event = Runtime.event_of_yojson event_json in
+    Ok { envelope; event }
   | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
     Error "runtime sync event record must be a JSON object"
 ;;
 
 let event_record_list_field name fields =
-  match assoc_field name fields with
-  | Ok (`List items) ->
-    items
-    |> List.fold_left
-         (fun acc item ->
-            let* rev = acc in
-            let* record = event_record_of_yojson item in
-            Ok (record :: rev))
-         (Ok [])
-    |> Result.map List.rev
-  | Ok _ -> Error (Printf.sprintf "field %s must be a list" name)
-  | Error _ as err -> err
+  let* value = assoc_field name fields in
+  match value with
+  | `List items ->
+    let+ rev =
+      List.fold_left
+        (fun acc item ->
+           let* rev = acc in
+           let* record = event_record_of_yojson item in
+           Ok (record :: rev))
+        (Ok [])
+        items
+    in
+    List.rev rev
+  | _ -> Error (Printf.sprintf "field %s must be a list" name)
 ;;
 
 let window_to_yojson window =
@@ -268,14 +271,11 @@ let validate_cursor_field field_name expected_stream_id (cursor : cursor) =
 ;;
 
 let validate_persistence = function
-  | None -> Ok ()
-  | Some persistence ->
-    if String.equal persistence.namespace ""
-    then Error "persistence namespace must not be empty"
-    else (
-      match persistence.max_window_events with
-      | Some value when value <= 0 -> Error "max_window_events must be positive"
-      | Some _ | None -> Ok ())
+  | Some persistence when String.equal persistence.namespace "" ->
+    Error "persistence namespace must not be empty"
+  | Some { max_window_events = Some value; _ } when value <= 0 ->
+    Error "max_window_events must be positive"
+  | _ -> Ok ()
 ;;
 
 let validate_event_order cursor next_cursor records =
@@ -323,16 +323,16 @@ let window_of_yojson = function
       Error (Printf.sprintf "unsupported runtime sync schema_version: %d" schema_version)
     else
       let* stream_id = string_field "stream_id" fields in
-      let* cursor_json = assoc_field "cursor" fields in
-      let* cursor = cursor_of_yojson cursor_json in
-      let* next_cursor_json = assoc_field "next_cursor" fields in
-      let* next_cursor = cursor_of_yojson next_cursor_json in
-      let* () = validate_cursor_field "cursor" stream_id cursor in
-      let* () = validate_cursor_field "next_cursor" stream_id next_cursor in
-      let* events = event_record_list_field "events" fields in
-      let* artifact_refs = string_list_field "artifact_refs" fields in
-      let* persistence = option_field "persistence" fields persistence_contract_of_json in
-      let* merge_policy =
+      let* cursor_json = assoc_field "cursor" fields
+      and* next_cursor_json = assoc_field "next_cursor" fields in
+      let* cursor = cursor_of_yojson cursor_json
+      and* next_cursor = cursor_of_yojson next_cursor_json in
+      let* () = validate_cursor_field "cursor" stream_id cursor
+      and* () = validate_cursor_field "next_cursor" stream_id next_cursor in
+      let* events = event_record_list_field "events" fields
+      and* artifact_refs = string_list_field "artifact_refs" fields
+      and* persistence = option_field "persistence" fields persistence_contract_of_json
+      and* merge_policy =
         match List.assoc_opt "merge_policy" fields with
         | None -> Ok Append_only
         | Some value -> merge_policy_of_json value

--- a/test/test_provider_intf.ml
+++ b/test/test_provider_intf.ml
@@ -60,7 +60,9 @@ let test_anthropic_supports_streaming () =
 
 let test_streaming_provider_some () =
   let config = Provider.local_llm () in
-  let (module SP : Provider_intf.STREAMING_PROVIDER) = require_streaming_provider config in
+  let (module SP : Provider_intf.STREAMING_PROVIDER) =
+    require_streaming_provider config
+  in
   ignore (module SP : Provider_intf.STREAMING_PROVIDER)
 ;;
 
@@ -289,10 +291,7 @@ let () =
   Alcotest.run
     "Provider_intf"
     [ ( "of_config"
-      , [ Alcotest.test_case
-            "local satisfies PROVIDER"
-            `Quick
-            test_of_config_local
+      , [ Alcotest.test_case "local satisfies PROVIDER" `Quick test_of_config_local
         ; Alcotest.test_case "openai satisfies PROVIDER" `Quick test_of_config_openai
         ; Alcotest.test_case
             "propagates resolve errors"


### PR DESCRIPTION
Replace verbose explicit result matches with `let*` / `let+` / `and*` in `lib/runtime_sync.ml`.\n\n- Flatten `int_field`, `string_field`, `string_list_field`, and `event_record_list_field` with result bindings.\n- Replace nested `match Runtime.event_of_yojson` with a direct `let*`.\n- Collapse independent `window_of_yojson` lookups with `and*`.\n- Simplify `validate_persistence` with guarded patterns.\n\nBehavior is unchanged.