### PR TITLE
refactor(structured): use Result syntax in lib/structured.ml

### DIFF
--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -74,6 +74,14 @@ let parse_json_string text =
   | Yojson.Json_error detail -> Error detail
 ;;
 
+let parse_schema_text_json schema json =
+  try
+    schema.parse json
+    |> Result.map_error (fun e -> Error.Serialization (JsonParseError { detail = e }))
+  with
+  | Yojson.Json_error detail -> Error (Error.Serialization (JsonParseError { detail }))
+;;
+
 (** Extract structured output from the response text JSON. *)
 let extract_text_json ~(schema : _ schema) (response : api_response)
   : ('a, Error.sdk_error) result
@@ -95,8 +103,7 @@ let extract_text_json ~(schema : _ schema) (response : api_response)
       parse_json_string text
       |> Result.map_error (fun detail -> Error.Serialization (JsonParseError { detail }))
     in
-    schema.parse json
-    |> Result.map_error (fun e -> Error.Serialization (JsonParseError { detail = e }))
+    parse_schema_text_json schema json
 ;;
 
 let sdk_error_of_http_error = function

--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -58,14 +58,20 @@ let extract_tool_input ~(schema : _ schema) (content : content_block list) =
         | ToolResult _ -> None)
       content
   in
-  match found with
-  | Some json ->
-    schema.parse json
-    |> Result.map_error (fun e -> Error.Serialization (JsonParseError { detail = e }))
-  | None ->
-    Error
-      (Error.Internal
-         (Printf.sprintf "No tool_use block for '%s' in response" schema.name))
+  let* json =
+    found
+    |> Option.to_result
+         ~none:
+           (Error.Internal
+              (Printf.sprintf "No tool_use block for '%s' in response" schema.name))
+  in
+  schema.parse json
+  |> Result.map_error (fun e -> Error.Serialization (JsonParseError { detail = e }))
+;;
+
+let parse_json_string text =
+  try Ok (Yojson.Safe.from_string text) with
+  | Yojson.Json_error detail -> Error detail
 ;;
 
 (** Extract structured output from the response text JSON. *)
@@ -84,13 +90,13 @@ let extract_text_json ~(schema : _ schema) (response : api_response)
       (Error.Serialization
          (JsonParseError
             { detail = "structured output response did not contain text JSON" }))
-  else (
-    try
-      let json = Yojson.Safe.from_string text in
-      schema.parse json
-      |> Result.map_error (fun e -> Error.Serialization (JsonParseError { detail = e }))
-    with
-    | Yojson.Json_error detail -> Error (Error.Serialization (JsonParseError { detail })))
+  else
+    let* json =
+      parse_json_string text
+      |> Result.map_error (fun detail -> Error.Serialization (JsonParseError { detail }))
+    in
+    schema.parse json
+    |> Result.map_error (fun e -> Error.Serialization (JsonParseError { detail = e }))
 ;;
 
 let sdk_error_of_http_error = function
@@ -156,28 +162,38 @@ let schema_extractor (schema : 'a schema) : 'a extractor =
 
 (* NOTE: keep [json_extractor] / [text_extractor] for callers who parse
    free-form responses themselves. *)
+let try_parse f x =
+  try Ok (f x) with
+  | Yojson.Json_error e -> Error (Printf.sprintf "JSON parse: %s" e)
+  | Yojson.Safe.Util.Type_error (msg, _) -> Error (Printf.sprintf "JSON type: %s" msg)
+  | Failure msg -> Error (Printf.sprintf "parse failure: %s" msg)
+;;
+
 let json_extractor (parse : Yojson.Safe.t -> 'a) : 'a extractor =
   fun resp ->
   let texts = List.filter_map text_block resp.content in
-  match texts with
-  | [] -> Error "no text content in response"
-  | text :: _ ->
-    (try Ok (parse (Yojson.Safe.from_string text)) with
-     | Yojson.Json_error e -> Error (Printf.sprintf "JSON parse: %s" e)
-     | Yojson.Safe.Util.Type_error (msg, _) -> Error (Printf.sprintf "JSON type: %s" msg)
-     | Failure msg -> Error (Printf.sprintf "parse failure: %s" msg))
+  let* text =
+    match texts with
+    | [] -> Error "no text content in response"
+    | text :: _ -> Ok text
+  in
+  let* json =
+    parse_json_string text
+    |> Result.map_error (fun e -> Printf.sprintf "JSON parse: %s" e)
+  in
+  try_parse parse json
 ;;
 
 (** Extract a value from the first text block using a string parser. *)
 let text_extractor (parse : string -> 'a option) : 'a extractor =
   fun resp ->
   let texts = List.filter_map text_block resp.content in
-  match texts with
-  | [] -> Error "no text content in response"
-  | text :: _ ->
-    (match parse text with
-     | Some v -> Ok v
-     | None -> Error "text extractor returned None")
+  let* text =
+    match texts with
+    | [] -> Error "no text content in response"
+    | text :: _ -> Ok text
+  in
+  parse text |> Option.to_result ~none:"text extractor returned None"
 ;;
 
 (** Run an agent with a prompt and extract a structured value from the response.

--- a/test/test_structured.ml
+++ b/test/test_structured.ml
@@ -454,6 +454,26 @@ let test_schema_extractor_parse_failure () =
   | Ok _ -> Alcotest.fail "expected schema parse error"
 ;;
 
+let test_schema_extractor_parser_json_error () =
+  let schema : unit Structured.schema =
+    { name = "nested_json"
+    ; description = "Parse nested JSON"
+    ; params = []
+    ; parse =
+        (fun json ->
+          let open Yojson.Safe.Util in
+          let nested = json |> member "nested" |> to_string in
+          ignore (Yojson.Safe.from_string nested : Yojson.Safe.t);
+          Ok ())
+    }
+  in
+  let extract = Structured.schema_extractor schema in
+  let resp = make_response [ Text {|{"nested":"{"}|} ] in
+  match extract resp with
+  | Error e -> Alcotest.(check bool) "has json error text" true (String.length e > 0)
+  | Ok _ -> Alcotest.fail "expected parser json error"
+;;
+
 (* --- extract_with_retry: unit-level logic tests --- *)
 
 (** Test that max_retries=0 means only 1 attempt (no retry).
@@ -591,6 +611,10 @@ let () =
             "schema_extractor parse failure"
             `Quick
             test_schema_extractor_parse_failure
+        ; Alcotest.test_case
+            "schema_extractor parser json error"
+            `Quick
+            test_schema_extractor_parser_json_error
         ] )
     ; ( "extract_with_retry"
       , [ Alcotest.test_case


### PR DESCRIPTION
Phase 2 Result-usage modernization for lib/structured.ml.

- Replace verbose matches in extract_tool_input, extract_text_json, json_extractor, and text_extractor with let* / Option.to_result / Result.map_error.
- Add small private helpers parse_json_string and try_parse to share JSON parsing exception handling.
- Keep all public signatures and behavior unchanged.

Tested: dune build lib/structured.ml + structured test executables all pass.