### PR TITLE
fix(models): register minimax-m3 capability (librarian thinking control)

### DIFF
--- a/models.toml
+++ b/models.toml
@@ -289,6 +289,34 @@ output_per_million = 0.28
 cache_write_multiplier = 1.0
 cache_read_multiplier = 0.02
 
+# MiniMax Models
+# Source: ollama-cloud /api/show 2026-06-17 caps=[completion,tools,thinking,vision].
+# minimax-m3 is the memory-os librarian runtime (runtime.toml [runtime].librarian).
+# Without this entry it resolved to provider_default (OpenAI_compat) whose
+# thinking_control_format = No_thinking_control, so the librarian's
+# enable_thinking = false was silently dropped at the wire and the reasoning model
+# polluted/emptied the JSON-mode body (librarian "empty response" / "invalid episode
+# JSON"). This entry supersedes the inert MASC runtime.toml [models.minimax-m3.capabilities]
+# block (#21521), which OAS for_model_id never reads.
+# thinking_control_format mirrors the sibling ollama-cloud deepseek-v4 entries
+# ("thinking_object" -> request emits {"thinking":{"type":"disabled"}}); verify against
+# a live ollama-cloud probe if minimax uses a different disable dialect.
+# Pricing intentionally omitted (float option): minimax-m3 rates not yet confirmed.
+[[models]]
+id_prefix = "minimax-m3"
+base = "openai_chat"
+max_context_tokens = 524288
+supports_tools = true
+supports_tool_choice = true
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "thinking_object"
+supports_response_format_json = true
+supports_structured_output = true
+supports_image_input = true
+supports_native_streaming = true
+
 # Gemini Models
 [[models]]
 id_prefix = "gemini-2.5"


### PR DESCRIPTION
## 문제
memory-os librarian가 `ollama_cloud.minimax-m3`로 라우팅되는데, `minimax-m3`가 `models.toml`에 없어 OAS `for_model_id`가 `provider_default`(OpenAI_compat, `thinking_control_format = No_thinking_control`)로 폴백. librarian의 `enable_thinking=false`가 와이어에서 **조용히 드롭** → reasoning 모델이 자유롭게 thinking → JSON 본문 오염/공백.

라이브 증상:
```
[WARN] memory os librarian failed runtime=ollama_cloud.minimax-m3: librarian provider returned empty response
[WARN] ... returned invalid episode JSON
[llm_provider] capability_observation ... minimax-m3 ... "Thinking_returned_but_declared_unsupported" (provider_default, low)
```

## 인과 고리
1. `for_model_id "minimax-m3"` → `None` (models.toml 부재, capabilities.ml:719-732)
2. `resolve_capabilities_for_config` None-arm → `provider_default` (complete_common.ml:30, 거부 안 함)
3. provider_default = `No_thinking_control` (capabilities.ml:108-111)
4. 요청 빌더 `No_thinking_control -> body` (backend_openai_request.ml:341) → 비활성 파라미터 미전송
5. reasoning 누출 → `text_of_content`가 Thinking 버림(types.ml:554) → empty / `<think>` 인라인 → invalid JSON

## 수정
sibling ollama-cloud `deepseek-v4` 엔트리를 미러링해 `minimax-m3` 등록. `thinking_object` → `enable_thinking=false`가 `{"thinking":{"type":"disabled"}}`로 인코딩(thinking_object→Thinking_object capabilities.ml:506, 인코딩 backend_openai_request.ml:318).

`#21521`의 MASC `runtime.toml [models.minimax-m3.capabilities]`를 대체 — 그건 OAS `for_model_id`가 안 읽고(여전히 `provider_default` 로그), JSON 플래그만 선언했는데 JSON은 capability 무관하게 전송되므로 inert였음.

## 검증
- `tomllib` 파싱 OK (95 엔트리), minimax 엔트리 정확
- `thinking_object` → `Thinking_object` 변형 매핑 확인
- `Thinking_object` + `enable_thinking=false` → `{"thinking":{"type":"disabled"}}` 인코딩 경로 확인
- coverage 테스트는 고정 목록 단언 아님 (영향 없음)

## 미확정 (추정 금지)
- minimax-m3가 ollama-cloud openai-compat에서 `thinking_object` 다이얼렉트를 honor하는지 **라이브 probe로 확정 권장** (deepseek-v4-flash가 같은 엔드포인트에서 이 값으로 작동하므로 확률 높음)
- 가격(`input/output_per_million`) 미상이라 생략

## 라이브 반영
서버는 `~/.config/oas/models.toml`(→ 이 파일 심링크)를 `Lazy` 1회 로드. **masc-mcp 재시작 필요** (rebuild 불필요).

## 후속 (별개)
unknown 모델이 `provider_default`로 조용히 떨어지는 silent-failure 자체는 별도 근본 개선 대상 (RFC-OAS-023 capability axis). 본 PR은 데이터 엔트리만.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>