### PR TITLE
fix(llm_provider): reject unsatisfiable thinking-control instead of silent drop

### DIFF
--- a/lib/llm_provider/complete_common.ml
+++ b/lib/llm_provider/complete_common.ml
@@ -248,13 +248,74 @@ let validate_request_path (config : Provider_config.t) =
   | Error reason -> Error (Http_client.AcceptRejected { reason })
 ;;
 
+(* RFC-OAS-023 (capability axis) — fail-loud on an unsatisfiable thinking-control
+   request instead of dropping it silently.
+
+   When a caller explicitly disables thinking (enable_thinking = Some false) on a
+   reasoning-capable model whose resolved capability cannot encode a thinking
+   directive (thinking_control_format = No_thinking_control, and not the zai/GLM
+   special case that backend_openai_request handles), the directive is dropped at
+   the wire. The reasoning model then thinks freely and pollutes/empties JSON-mode
+   output — the memory-os librarian "empty response" / "invalid episode JSON" class.
+   Reject before sending so the caller sees a typed AcceptRejected error rather than
+   silent garbage.
+
+   Scope guards against over-firing:
+   - supports_reasoning = false: the model does not think, so enable_thinking=false
+     is a harmless no-op — not rejected.
+   - enable_thinking = Some true / None: a reasoning model thinks by default, so an
+     "enable" (or unset) request is satisfiable — not rejected.
+   Unknown models (provider_default) are caught earlier by the consumer's startup
+   binding validation; by the time a request reaches here the model is catalogued,
+   so a No_thinking_control + supports_reasoning hit signals a catalog gap to fix. *)
+(* Pure decision (no global state) so it is unit-testable in isolation: is an
+   explicit "disable thinking" request impossible to honor for [caps]? *)
+let thinking_control_disable_unsatisfiable
+      ~(caps : Capabilities.capabilities)
+      (config : Provider_config.t)
+  =
+  match config.enable_thinking with
+  | Some true | None -> false
+  | Some false ->
+    let glm_special_case =
+      (* backend_openai_request encodes thinking for zai/GLM even under
+         No_thinking_control, so that combination IS satisfiable. *)
+      Zai_catalog.is_zai_base_url config.base_url
+      && Zai_catalog.is_glm_model_id config.model_id
+    in
+    caps.supports_reasoning
+    && caps.thinking_control_format = Capabilities.No_thinking_control
+    && not glm_special_case
+;;
+
+let validate_thinking_control_request (config : Provider_config.t) =
+  let caps, _source = resolve_capabilities_for_config config in
+  if thinking_control_disable_unsatisfiable ~caps config
+  then
+    Error
+      (Http_client.AcceptRejected
+         { reason =
+             Printf.sprintf
+               "model %S is reasoning-capable but its capability record declares \
+                thinking_control_format=No_thinking_control: enable_thinking=false \
+                cannot be encoded and would be silently dropped, letting the model \
+                think freely and corrupt JSON-mode output. Declare a \
+                thinking_control_format for this model in Capabilities.for_model_id \
+                (models.toml), or route to a model that supports disabling thinking."
+               config.model_id })
+  else Ok ()
+;;
+
 let validate_all (config : Provider_config.t) =
   match validate_request_path config with
   | Error _ as e -> e
   | Ok () ->
     (match validate_output_schema_request config with
      | Error _ as e -> e
-     | Ok () -> validate_cli_sampling_params config)
+     | Ok () ->
+       (match validate_cli_sampling_params config with
+        | Error _ as e -> e
+        | Ok () -> validate_thinking_control_request config))
 ;;
 
 (** Strip query string and userinfo from a URL before logging.  Built-in

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -1776,6 +1776,69 @@ let test_with_context_size_overrides () =
   Alcotest.(check (option int)) "overrides" (Some 1_000_000) c.max_context_tokens
 ;;
 
+(* ── Complete_common.thinking_control_disable_unsatisfiable ──
+   Guards the fail-loud path that rejects an unsatisfiable "disable thinking"
+   request instead of dropping it silently (the librarian empty/invalid-JSON class). *)
+
+let reasoning_no_control_caps =
+  { Capabilities.openai_compat_chat_capabilities with supports_reasoning = true }
+;;
+
+let test_thinking_disable_unsatisfiable_when_reasoning_no_control () =
+  let config = make_config ~model_id:"reasoner-no-control" ~enable_thinking:false () in
+  Alcotest.(check bool)
+    "reasoning model + No_thinking_control + disable -> unsatisfiable"
+    true
+    (Complete_common.thinking_control_disable_unsatisfiable
+       ~caps:reasoning_no_control_caps
+       config)
+;;
+
+let test_thinking_enable_is_satisfiable () =
+  let config = make_config ~model_id:"reasoner-no-control" ~enable_thinking:true () in
+  Alcotest.(check bool)
+    "enable_thinking=true is satisfiable (model thinks by default)"
+    false
+    (Complete_common.thinking_control_disable_unsatisfiable
+       ~caps:reasoning_no_control_caps
+       config)
+;;
+
+let test_thinking_unset_is_satisfiable () =
+  let config = make_config ~model_id:"reasoner-no-control" () in
+  Alcotest.(check bool)
+    "enable_thinking unset -> nothing to satisfy"
+    false
+    (Complete_common.thinking_control_disable_unsatisfiable
+       ~caps:reasoning_no_control_caps
+       config)
+;;
+
+let test_thinking_disable_noop_for_non_reasoning () =
+  (* openai_compat_chat_capabilities has supports_reasoning = false *)
+  let config = make_config ~model_id:"non-reasoner" ~enable_thinking:false () in
+  Alcotest.(check bool)
+    "non-reasoning model -> disable is a harmless no-op"
+    false
+    (Complete_common.thinking_control_disable_unsatisfiable
+       ~caps:Capabilities.openai_compat_chat_capabilities
+       config)
+;;
+
+let test_thinking_disable_satisfiable_with_control_format () =
+  let caps =
+    { Capabilities.openai_compat_chat_capabilities with
+      supports_reasoning = true
+    ; thinking_control_format = Capabilities.Thinking_object
+    }
+  in
+  let config = make_config ~model_id:"reasoner-with-control" ~enable_thinking:false () in
+  Alcotest.(check bool)
+    "reasoning model WITH a thinking_control_format -> satisfiable"
+    false
+    (Complete_common.thinking_control_disable_unsatisfiable ~caps config)
+;;
+
 (* ═══════════════════════════════════════════════════
    Test runner
    ═══════════════════════════════════════════════════ *)
@@ -2013,6 +2076,28 @@ let () =
     ; ( "capabilities.with_context_size"
       , [ Alcotest.test_case "set" `Quick test_with_context_size
         ; Alcotest.test_case "overrides" `Quick test_with_context_size_overrides
+        ] )
+    ; ( "complete_common.thinking_control"
+      , [ Alcotest.test_case
+            "reasoning+no-control disable unsatisfiable"
+            `Quick
+            test_thinking_disable_unsatisfiable_when_reasoning_no_control
+        ; Alcotest.test_case
+            "enable is satisfiable"
+            `Quick
+            test_thinking_enable_is_satisfiable
+        ; Alcotest.test_case
+            "unset is satisfiable"
+            `Quick
+            test_thinking_unset_is_satisfiable
+        ; Alcotest.test_case
+            "non-reasoning no-op"
+            `Quick
+            test_thinking_disable_noop_for_non_reasoning
+        ; Alcotest.test_case
+            "with control format satisfiable"
+            `Quick
+            test_thinking_disable_satisfiable_with_control_format
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제 (silent failure)
`enable_thinking=Some false`(thinking 끄기)를 reasoning-capable 모델에 보냈는데 해당 모델의 resolved capability가 `thinking_control_format = No_thinking_control`이면, `backend_openai_request`의 `No_thinking_control` arm이 지시를 **조용히 드롭**(line 341). reasoning 모델은 자유롭게 thinking → JSON-mode 본문 오염/공백 → memory-os librarian "empty response" / "invalid episode JSON".

이번 세션 근본 원인: minimax-m3가 catalog 부재 → `provider_default`(No_thinking_control) → librarian의 `enable_thinking=false` 무력화. (#2155가 데이터 측면 수정.)

## 근본 개선 (typed fail-loud, NOT telemetry-as-fix)
기존 `warn_capability_drop`(top_k/min_p)을 thinking에 미러링하면 CLAUDE.md 워크어라운드 바의 **telemetry-as-fix**(가시화만 하고 fix 안 함)에 해당. thinking-control 드롭은 양성 열화가 아니라 *출력 오염*이므로 "경고+드롭"은 부적절.

대신 `validate_all` pre-flight 체인에 `validate_thinking_control_request` 추가 → 기존 capability-rejection 채널 `Http_client.AcceptRejected` 반환. 호출자(librarian)는 doomed 요청 전에 **typed 에러**를 받음(silent garbage 대신). librarian은 이를 `Transport_failed`로 받아 재시도 없이 표면화.

## 과발사 방지
- `enable_thinking=Some false` + `supports_reasoning=true` + `No_thinking_control` + zai/GLM 아님 → 발사
- non-reasoning 모델(no-op), `Some true`/`None`, zai/GLM 특례 → 통과
- 순수 결정 `thinking_control_disable_unsatisfiable`로 분리(글로벌 상태 없이 단위 테스트)

## 2계층 방어 중 layer-2
- layer-1 (MASC 부팅 게이트): unknown 모델 = provider_default면 시작 거부 — 별도 PR
- layer-2 (본 PR): known 모델이라도 미충족 explicit disable는 completion에서 typed 거부

## 검증
- `scripts/dune-local.sh build test/test_llm_provider_cov.exe` → BUILD OK
- 신규 테스트 그룹 `complete_common.thinking_control` 5/5 [OK] (firing 1 + non-firing 4)

## 참조
RFC-OAS-023 (capability axis reshape — capability 정확성 목표). 경계: OAS는 MASC-agnostic 유지 (provider/capability만 담당).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>