### PR TITLE
fix(llm_provider): improve result safety in capability_manifest.ml

### DIFF
--- a/lib/async_agent.ml
+++ b/lib/async_agent.ml
@@ -58,7 +58,13 @@ let spawn ~sw ?clock agent prompt =
   let resolved = Atomic.make false in
   let cancel_sent = Atomic.make false in
   let future =
-    { promise; resolver; cancelled_u; resolved; cancel_sent; cancel_fn = Atomic.make None }
+    { promise
+    ; resolver
+    ; cancelled_u
+    ; resolved
+    ; cancel_sent
+    ; cancel_fn = Atomic.make None
+    }
   in
   Eio.Fiber.fork ~sw (fun () ->
     try
@@ -108,7 +114,8 @@ let cancel future =
      We also resolve the future immediately to preserve the established
      contract that [cancel] returns a ready future; resolve_once makes the
      final result idempotent. *)
-  if Atomic.compare_and_set future.cancel_sent false true then begin
+  if Atomic.compare_and_set future.cancel_sent false true
+  then (
     Eio.Promise.resolve future.cancelled_u ();
     resolve_once future (Error (Error.Internal "cancelled"));
     match Atomic.exchange future.cancel_fn None with
@@ -116,8 +123,7 @@ let cancel future =
       (try f () with
        | Eio.Cancel.Cancelled _ -> ()
        | Eio.Io _ | Unix.Unix_error _ | Failure _ | Invalid_argument _ -> ())
-    | None -> ()
-  end
+    | None -> ())
 ;;
 
 (* ── Combinators ──────────────────────────────────────────────── *)

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -39,6 +39,14 @@ type entry =
 (** A parsed capability manifest. *)
 type t = entry list
 
+(* Local result-syntax bindings so this file can use [let*] / [let+]
+   without depending on [agent_sdk.base] (which would create a circular
+   library dependency). *)
+module Result_syntax = struct
+  let ( let* ) = Result.bind
+  let ( let+ ) x f = Result.map f x
+end
+
 (* ── JSON parsing helpers ───────────────────────────────── *)
 
 let json_kind = function
@@ -148,92 +156,92 @@ let reject_unknown_keys ~scope ~known json =
 ;;
 
 let parse_entry json =
-  match reject_unknown_keys ~scope:"entry" ~known:known_entry_keys json with
-  | Error _ as error -> error
-  | Ok () ->
-    (match member_string_opt "id_prefix" json with
-     | None -> Error "entry missing required \"id_prefix\" field"
-     | Some id_prefix ->
-       Ok
-         { id_prefix
-         ; base_label = member_string_opt "base" json
-         ; max_context_tokens = member_int "max_context_tokens" json
-         ; max_output_tokens = member_int "max_output_tokens" json
-         ; supports_tools = member_bool "supports_tools" json
-         ; supports_tool_choice = member_bool "supports_tool_choice" json
-         ; supports_parallel_tool_calls = member_bool "supports_parallel_tool_calls" json
-         ; supports_reasoning = member_bool "supports_reasoning" json
-         ; supports_extended_thinking = member_bool "supports_extended_thinking" json
-         ; supports_reasoning_budget = member_bool "supports_reasoning_budget" json
-         ; supports_response_format_json =
-             member_bool "supports_response_format_json" json
-         ; supports_structured_output = member_bool "supports_structured_output" json
-         ; supports_multimodal_inputs = member_bool "supports_multimodal_inputs" json
-         ; supports_image_input = member_bool "supports_image_input" json
-         ; supports_audio_input = member_bool "supports_audio_input" json
-         ; supports_video_input = member_bool "supports_video_input" json
-         ; supports_native_streaming = member_bool "supports_native_streaming" json
-         ; supports_system_prompt = member_bool "supports_system_prompt" json
-         ; supports_caching = member_bool "supports_caching" json
-         ; supports_prompt_caching = member_bool "supports_prompt_caching" json
-         ; supports_top_k = member_bool "supports_top_k" json
-         ; supports_min_p = member_bool "supports_min_p" json
-         ; supports_seed = member_bool "supports_seed" json
-         ; supports_computer_use = member_bool "supports_computer_use" json
-         ; supports_code_execution = member_bool "supports_code_execution" json
-         ; thinking_control_format = member_string_opt "thinking_control_format" json
-         })
+  let open Result_syntax in
+  let* () = reject_unknown_keys ~scope:"entry" ~known:known_entry_keys json in
+  let* id_prefix =
+    match member_string_opt "id_prefix" json with
+    | None -> Error "entry missing required \"id_prefix\" field"
+    | Some id_prefix -> Ok id_prefix
+  in
+  Ok
+    { id_prefix
+    ; base_label = member_string_opt "base" json
+    ; max_context_tokens = member_int "max_context_tokens" json
+    ; max_output_tokens = member_int "max_output_tokens" json
+    ; supports_tools = member_bool "supports_tools" json
+    ; supports_tool_choice = member_bool "supports_tool_choice" json
+    ; supports_parallel_tool_calls = member_bool "supports_parallel_tool_calls" json
+    ; supports_reasoning = member_bool "supports_reasoning" json
+    ; supports_extended_thinking = member_bool "supports_extended_thinking" json
+    ; supports_reasoning_budget = member_bool "supports_reasoning_budget" json
+    ; supports_response_format_json = member_bool "supports_response_format_json" json
+    ; supports_structured_output = member_bool "supports_structured_output" json
+    ; supports_multimodal_inputs = member_bool "supports_multimodal_inputs" json
+    ; supports_image_input = member_bool "supports_image_input" json
+    ; supports_audio_input = member_bool "supports_audio_input" json
+    ; supports_video_input = member_bool "supports_video_input" json
+    ; supports_native_streaming = member_bool "supports_native_streaming" json
+    ; supports_system_prompt = member_bool "supports_system_prompt" json
+    ; supports_caching = member_bool "supports_caching" json
+    ; supports_prompt_caching = member_bool "supports_prompt_caching" json
+    ; supports_top_k = member_bool "supports_top_k" json
+    ; supports_min_p = member_bool "supports_min_p" json
+    ; supports_seed = member_bool "supports_seed" json
+    ; supports_computer_use = member_bool "supports_computer_use" json
+    ; supports_code_execution = member_bool "supports_code_execution" json
+    ; thinking_control_format = member_string_opt "thinking_control_format" json
+    }
 ;;
 
 let of_json json =
-  match reject_unknown_keys ~scope:"manifest" ~known:known_manifest_keys json with
-  | Error _ as error -> error
-  | Ok () ->
-    let schema_version =
-      match Yojson.Safe.Util.member "schema_version" json with
-      | `Int n -> n
-      | _ -> 0
+  let open Result_syntax in
+  let* () = reject_unknown_keys ~scope:"manifest" ~known:known_manifest_keys json in
+  let schema_version =
+    match Yojson.Safe.Util.member "schema_version" json with
+    | `Int n -> n
+    | _ -> 0
+  in
+  if schema_version <> 1
+  then
+    Error
+      (Printf.sprintf
+         "unsupported capability manifest schema_version: %d (expected 1)"
+         schema_version)
+  else (
+    let model_items =
+      match Yojson.Safe.Util.member "models" json with
+      | `List items -> items
+      | _ -> []
     in
-    if schema_version <> 1
-    then
-      Error
-        (Printf.sprintf
-           "unsupported capability manifest schema_version: %d (expected 1)"
-           schema_version)
-    else (
-      let model_items =
-        match Yojson.Safe.Util.member "models" json with
-        | `List items -> items
-        | _ -> []
-      in
-      let results = List.map parse_entry model_items in
-      let errors =
-        List.filter_map
-          (function
-            | Error e -> Some e
-            | Ok _ -> None)
-          results
-      in
-      if errors <> []
-      then Error (String.concat "; " errors)
-      else
-        Ok
-          (List.filter_map
-             (function
-               | Ok e -> Some e
-               | Error _ -> None)
-             results))
+    let results = List.map parse_entry model_items in
+    let errors =
+      List.filter_map
+        (function
+          | Error e -> Some e
+          | Ok _ -> None)
+        results
+    in
+    if errors <> []
+    then Error (String.concat "; " errors)
+    else
+      Ok
+        (List.filter_map
+           (function
+             | Ok e -> Some e
+             | Error _ -> None)
+           results))
 ;;
 
 let load_file path =
-  let read_result =
+  let open Result_syntax in
+  let* json =
     try Ok (Yojson.Safe.from_file path) with
     | Sys_error msg ->
       Error (Printf.sprintf "cannot read capability manifest %s: %s" path msg)
     | Yojson.Json_error msg ->
       Error (Printf.sprintf "capability manifest JSON parse error in %s: %s" path msg)
   in
-  Result.bind read_result of_json
+  of_json json
 ;;
 
 let load_runtime_file path =
@@ -306,13 +314,12 @@ let%test "of_json: valid manifest parses successfully" =
       {|{"schema_version":1,"models":[{"id_prefix":"my-llm","base":"openai_chat","max_context_tokens":131072,"supports_tools":true}]}|}
   in
   match of_json json with
-  | Ok entries ->
-    List.length entries = 1
-    && (List.hd entries).id_prefix = "my-llm"
-    && (List.hd entries).base_label = Some "openai_chat"
-    && (List.hd entries).max_context_tokens = Some 131072
-    && (List.hd entries).supports_tools = Some true
-  | Error _ -> false
+  | Ok [ entry ] ->
+    entry.id_prefix = "my-llm"
+    && entry.base_label = Some "openai_chat"
+    && entry.max_context_tokens = Some 131072
+    && entry.supports_tools = Some true
+  | Ok _ | Error _ -> false
 ;;
 
 let%test "of_json: wrong schema_version returns error" =
@@ -350,18 +357,21 @@ let%test "lookup: prefix match is case-insensitive" =
     Yojson.Safe.from_string
       {|{"schema_version":1,"models":[{"id_prefix":"My-Model","supports_tools":true}]}|}
   in
-  let manifest = of_json json |> Result.get_ok in
-  match lookup manifest "my-model-q4" with
-  | Some entry -> entry.supports_tools = Some true
-  | None -> false
+  match of_json json with
+  | Ok manifest ->
+    (match lookup manifest "my-model-q4" with
+     | Some entry -> entry.supports_tools = Some true
+     | None -> false)
+  | Error _ -> false
 ;;
 
 let%test "lookup: no match returns None" =
   let json =
     Yojson.Safe.from_string {|{"schema_version":1,"models":[{"id_prefix":"model-a"}]}|}
   in
-  let manifest = of_json json |> Result.get_ok in
-  lookup manifest "model-b" = None
+  match of_json json with
+  | Ok manifest -> lookup manifest "model-b" = None
+  | Error _ -> false
 ;;
 
 let%test "lookup: first matching entry wins" =
@@ -369,10 +379,12 @@ let%test "lookup: first matching entry wins" =
     Yojson.Safe.from_string
       {|{"schema_version":1,"models":[{"id_prefix":"model","max_context_tokens":8192},{"id_prefix":"model","max_context_tokens":4096}]}|}
   in
-  let manifest = of_json json |> Result.get_ok in
-  match lookup manifest "model-v1" with
-  | Some entry -> entry.max_context_tokens = Some 8192
-  | None -> false
+  match of_json json with
+  | Ok manifest ->
+    (match lookup manifest "model-v1" with
+     | Some entry -> entry.max_context_tokens = Some 8192
+     | None -> false)
+  | Error _ -> false
 ;;
 
 let%test "lookup: exact prefix match" =
@@ -380,9 +392,11 @@ let%test "lookup: exact prefix match" =
     Yojson.Safe.from_string
       {|{"schema_version":1,"models":[{"id_prefix":"exact-model"}]}|}
   in
-  let manifest = of_json json |> Result.get_ok in
-  Option.is_some (lookup manifest "exact-model")
-  && Option.is_none (lookup manifest "other-model")
+  match of_json json with
+  | Ok manifest ->
+    Option.is_some (lookup manifest "exact-model")
+    && Option.is_none (lookup manifest "other-model")
+  | Error _ -> false
 ;;
 
 let%test "of_json: unknown entry fields return error" =

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -68,80 +68,84 @@ type streaming_provider_module = (module STREAMING_PROVIDER)
 (** Runtime dispatch: resolve a provider config to a first-class module.
     Returns an error if provider configuration or credentials cannot be
     resolved. *)
-let of_config (provider_cfg : Provider.config)
-  : (provider_module, Error.sdk_error) result
+let of_config (provider_cfg : Provider.config) : (provider_module, Error.sdk_error) result
   =
   match Provider.resolve provider_cfg with
   | Error err -> Error err
   | Ok (base_url, api_key, headers) ->
     let spec = Provider.model_spec_of_config provider_cfg in
-  let module P = struct
-    type t = unit
+    let module P = struct
+      type t = unit
 
-    let create_message ~sw ~net ~config ~messages ?tools () =
-      let kind = spec.request_kind in
-      let path = spec.request_path in
-      let body_str =
-        match kind with
-        | Provider.Anthropic_messages ->
-          Yojson.Safe.to_string
-            (`Assoc
-                (Api_anthropic.build_body_assoc ~config ~messages ?tools ~stream:false ()))
-        | Provider.Openai_chat_completions ->
-          Api_openai.build_openai_body
-            ~provider_config:provider_cfg
-            ~config
-            ~messages
-            ?tools
-            ()
-        | Provider.Custom name ->
-          (match Provider.find_provider name with
-           | Some impl -> impl.build_body ~config ~messages ?tools ()
-           | None -> Yojson.Safe.to_string (`Assoc []))
-      in
-      let url = base_url ^ path in
-      (* Merge auth headers at request time so that [headers] (from
-         [Provider.resolve]) never carries sensitive tokens. *)
-      let auth_hdrs =
-        if api_key = ""
-        then []
-        else (
+      let create_message ~sw ~net ~config ~messages ?tools () =
+        let kind = spec.request_kind in
+        let path = spec.request_path in
+        let body_str =
           match kind with
-          | Provider.Anthropic_messages -> [ "x-api-key", api_key ]
-          | Provider.Openai_chat_completions | Provider.Custom _ ->
-            [ "Authorization", "Bearer " ^ api_key ])
-      in
-      match
-        Http_client.post_sync
-          ~sw
-          ~net
-          ~url
-          ~headers:(headers @ auth_hdrs)
-          ~body:body_str
-          ()
-      with
-      | Ok (200, body_str) ->
-        (match kind with
-         | Provider.Anthropic_messages ->
-           Ok (Api_anthropic.parse_response (Yojson.Safe.from_string body_str))
-         | Provider.Openai_chat_completions ->
-           (match parse_openai_response_result body_str with
-            | Ok resp -> Ok resp
-            | Error msg -> Error (Error.Api (Retry.InvalidRequest { message = msg })))
-         | Provider.Custom name ->
-           (match Provider.find_provider name with
-            | Some impl -> Ok (impl.parse_response body_str)
-            | None ->
-              (match parse_openai_response_result body_str with
-               | Ok resp -> Ok resp
-               | Error msg -> Error (Error.Api (Retry.InvalidRequest { message = msg })))))
-      | Ok (code, body_str) ->
-        Error (Error.Api (Retry.classify_error ~status:code ~body:body_str))
-      | Error err -> Error (Error.Api (retry_error_of_http_error err))
-    ;;
-  end
-  in
-  Ok (module P : PROVIDER)
+          | Provider.Anthropic_messages ->
+            Yojson.Safe.to_string
+              (`Assoc
+                  (Api_anthropic.build_body_assoc
+                     ~config
+                     ~messages
+                     ?tools
+                     ~stream:false
+                     ()))
+          | Provider.Openai_chat_completions ->
+            Api_openai.build_openai_body
+              ~provider_config:provider_cfg
+              ~config
+              ~messages
+              ?tools
+              ()
+          | Provider.Custom name ->
+            (match Provider.find_provider name with
+             | Some impl -> impl.build_body ~config ~messages ?tools ()
+             | None -> Yojson.Safe.to_string (`Assoc []))
+        in
+        let url = base_url ^ path in
+        (* Merge auth headers at request time so that [headers] (from
+         [Provider.resolve]) never carries sensitive tokens. *)
+        let auth_hdrs =
+          if api_key = ""
+          then []
+          else (
+            match kind with
+            | Provider.Anthropic_messages -> [ "x-api-key", api_key ]
+            | Provider.Openai_chat_completions | Provider.Custom _ ->
+              [ "Authorization", "Bearer " ^ api_key ])
+        in
+        match
+          Http_client.post_sync
+            ~sw
+            ~net
+            ~url
+            ~headers:(headers @ auth_hdrs)
+            ~body:body_str
+            ()
+        with
+        | Ok (200, body_str) ->
+          (match kind with
+           | Provider.Anthropic_messages ->
+             Ok (Api_anthropic.parse_response (Yojson.Safe.from_string body_str))
+           | Provider.Openai_chat_completions ->
+             (match parse_openai_response_result body_str with
+              | Ok resp -> Ok resp
+              | Error msg -> Error (Error.Api (Retry.InvalidRequest { message = msg })))
+           | Provider.Custom name ->
+             (match Provider.find_provider name with
+              | Some impl -> Ok (impl.parse_response body_str)
+              | None ->
+                (match parse_openai_response_result body_str with
+                 | Ok resp -> Ok resp
+                 | Error msg -> Error (Error.Api (Retry.InvalidRequest { message = msg })))))
+        | Ok (code, body_str) ->
+          Error (Error.Api (Retry.classify_error ~status:code ~body:body_str))
+        | Error err -> Error (Error.Api (retry_error_of_http_error err))
+      ;;
+    end
+    in
+    Ok (module P : PROVIDER)
 ;;
 
 (** Check if a provider config supports native streaming. *)

--- a/test/test_provider_intf.ml
+++ b/test/test_provider_intf.ml
@@ -60,7 +60,9 @@ let test_anthropic_supports_streaming () =
 
 let test_streaming_provider_some () =
   let config = Provider.local_llm () in
-  let (module SP : Provider_intf.STREAMING_PROVIDER) = require_streaming_provider config in
+  let (module SP : Provider_intf.STREAMING_PROVIDER) =
+    require_streaming_provider config
+  in
   ignore (module SP : Provider_intf.STREAMING_PROVIDER)
 ;;
 
@@ -289,10 +291,7 @@ let () =
   Alcotest.run
     "Provider_intf"
     [ ( "of_config"
-      , [ Alcotest.test_case
-            "local satisfies PROVIDER"
-            `Quick
-            test_of_config_local
+      , [ Alcotest.test_case "local satisfies PROVIDER" `Quick test_of_config_local
         ; Alcotest.test_case "openai satisfies PROVIDER" `Quick test_of_config_openai
         ; Alcotest.test_case
             "propagates resolve errors"


### PR DESCRIPTION
P2 cross-repo modernization: improve OCaml `result` type usage in `lib/llm_provider/capability_manifest.ml`.

## Changes
- Added a tiny local `Result_syntax` module so `let*` / `let+` can be used without depending on `agent_sdk.base` (circular dependency).
- Flattened `parse_entry`, `of_json`, and `load_file` with `let*` instead of nested `match` / `Result.bind`.
- Replaced unsafe `Result.get_ok` in inline tests with explicit `Ok/Error` matching.
- Replaced unsafe `List.hd` in the first inline test with a single-element list pattern.

## Validation
- `ocamlformat --check lib/llm_provider/capability_manifest.ml` ✅
- `MASC_DUNE_THROTTLE=0 ./scripts/dune-local.sh build lib/llm_provider/capability_manifest.ml` ✅
- `MASC_DUNE_THROTTLE=0 ./scripts/dune-local.sh runtest lib/llm_provider/` ✅

## Skipped
- No public `.mli` signatures were changed.
- No functions with external callers were converted; all changes are internal to this file.