### PR TITLE
fix(typed_tool_safe): improve result safety in lib/typed_tool_safe.ml

### DIFF
--- a/lib/typed_tool_safe.ml
+++ b/lib/typed_tool_safe.ml
@@ -49,12 +49,15 @@ let execute_read_only ?context safe_tool args =
 ;;
 
 let execute_with_approval ?context ~approve safe_tool args =
+  let open Result_syntax in
   let tool_name = Typed_tool.name safe_tool.tool in
   let input_desc = lazy (Yojson.Safe.to_string args) in
-  match approve ~tool_name ~input_desc with
-  | Ok () -> Typed_tool.execute ?context safe_tool.tool args
-  | Error reason ->
-    Error { Types.message = reason; recoverable = false; error_class = None }
+  let* () =
+    approve ~tool_name ~input_desc
+    |> Result.map_error (fun reason ->
+      { Types.message = reason; recoverable = false; error_class = None })
+  in
+  Typed_tool.execute ?context safe_tool.tool args
 ;;
 
 let execute_write ?context ~approve tool args =


### PR DESCRIPTION
P2 result modernization for `lib/typed_tool_safe.ml`.

Changes:
- Use `Result_syntax` and `let*` to flatten the approval/execution result chain in `execute_with_approval`.
- Convert the `(unit, string) result` approval callback error to `Types.tool_error` via `Result.map_error`.

Skipped:
- `check_perm_compat` still raises `invalid_arg` because its callers (`read_only`, `write`, `destructive`) are exported in `typed_tool_safe.mli` with non-result return types. Widening those signatures to `(_, string) result` would be a breaking change, so conversion is out of scope for P2.

Validation:
- `MASC_DUNE_THROTTLE=0 ./scripts/dune-local.sh build lib/typed_tool_safe.ml` ✅
- `dune runtest test/test_typed_tool_safe.exe --root . --force` ✅ (11 tests)
- `ocamlformat --check lib/typed_tool_safe.ml` ✅