### PR TITLE
fix(typed_tool): improve result safety in lib/typed_tool.ml

### DIFF
--- a/lib/typed_tool.ml
+++ b/lib/typed_tool.ml
@@ -2,6 +2,8 @@
 
     @since 0.120.0 *)
 
+open Result_syntax
+
 (** Internal handler representation. Parametric variant — the type parameters
     ['input] and ['output] are threaded through both constructors. *)
 type ('input, 'output) handler_kind =
@@ -53,11 +55,8 @@ let run_handler
 ;;
 
 let execute_parsed ?context tool json =
-  match tool.parse json with
-  | Error e -> Error e
-  | Ok input ->
-    let result = run_handler ?context tool.handler input in
-    Ok (input, result)
+  let* input = tool.parse json in
+  Ok (input, run_handler ?context tool.handler input)
 ;;
 
 let execute ?context tool json =


### PR DESCRIPTION
P2 result modernization for lib/typed_tool.ml.

Changes:
- Add open Result_syntax.
- Flatten execute_parsed with let* instead of manual match/Ok/Error.

Skipped:
- check_descriptor still raises invalid_arg because create/create_with_context are public APIs; converting it would change their .mli signatures (breaking change).

Validation:
- ocamlformat --check lib/typed_tool.ml: passed
- MASC_DUNE_THROTTLE=0 ./scripts/dune-local.sh build lib/typed_tool.ml: passed
- dune exec test/test_typed_tool.exe: 16/16 passed
- dune exec test/test_typed_tool_safe.exe: 11/11 passed