### PR TITLE
feat(llm_provider): allow json_schema response format for Ollama Cloud

### DIFF
--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -346,8 +346,12 @@ let structured_output_name_of_schema (schema : Yojson.Safe.t) : string =
 
 let openai_host_supports_output_schema base_url =
   match Uri.of_string base_url |> Uri.host with
-  | Some host -> String.lowercase_ascii host = "api.openai.com"
   | None -> false
+  | Some host ->
+    let host = String.lowercase_ascii host in
+    String.equal host "api.openai.com"
+    || String.equal host "ollama.com"
+    || String.ends_with ~suffix:".ollama.com" host
 ;;
 
 (** A native-schema request is in effect when either field carries one.
@@ -441,6 +445,47 @@ let is_local (config : t) =
   let url = String.lowercase_ascii (String.trim config.base_url) in
   has_host_prefix ~url ~prefix:Constants.Endpoints.local_prefix
   || has_host_prefix ~url ~prefix:Constants.Endpoints.localhost_prefix
+;;
+
+let%test "validate_output_schema_request: OpenAI official host accepts json_schema" =
+  let config =
+    make
+      ~kind:OpenAI_compat
+      ~model_id:"gpt-4o"
+      ~base_url:"https://api.openai.com/v1"
+      ~response_format_json:true
+      ~output_schema:(`Assoc [ "type", `String "object" ])
+      ()
+  in
+  validate_output_schema_request config = Ok ()
+;;
+
+let%test "validate_output_schema_request: Ollama Cloud accepts json_schema" =
+  let config =
+    make
+      ~kind:OpenAI_compat
+      ~model_id:"minimax-m3"
+      ~base_url:"https://ollama.com/v1"
+      ~response_format_json:true
+      ~output_schema:(`Assoc [ "type", `String "object" ])
+      ()
+  in
+  validate_output_schema_request config = Ok ()
+;;
+
+let%test "validate_output_schema_request: unknown OpenAI-compatible host rejects json_schema" =
+  let config =
+    make
+      ~kind:OpenAI_compat
+      ~model_id:"generic"
+      ~base_url:"https://openai-compatible.example.com/v1"
+      ~response_format_json:true
+      ~output_schema:(`Assoc [ "type", `String "object" ])
+      ()
+  in
+  match validate_output_schema_request config with
+  | Error _ -> true
+  | Ok () -> false
 ;;
 
 (* ── Inline tests ────────────────────────────────────── *)


### PR DESCRIPTION
## Problem

MASC routes the Memory-OS librarian through "ollama_cloud.minimax-m3", which uses OAS' "OpenAI_compat" backend. MASC would like to pass a JSON schema so the provider can enforce the episode shape, but "Provider_config.validate_output_schema_request" rejected any "OpenAI_compat" host other than "api.openai.com".

## Verification

Live test against "https://ollama.com/v1/chat/completions" with "response_format.type=json_schema" returns HTTP 200 and honors the schema argument. The model may still wrap the JSON in Markdown fences, so clients should keep parser robustness.

## Changes

- Extend "openai_host_supports_output_schema" to accept "api.openai.com", "ollama.com", and "*.ollama.com".
- Add inline tests for official OpenAI, Ollama Cloud, and an unknown OpenAI-compatible host.

## Related

- jeong-sik/masc#21632 (tracking MASC adoption of the schema)
- jeong-sik/masc#21631 (MASC-side parser hardening)