### PR TITLE
[codex] Add Ollama Cloud model catalog coverage

### DIFF
--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -118,7 +118,7 @@ let capabilities_of_config (config : Provider_config.t) =
   match config.kind with
   | Provider_config.DashScope -> Capabilities.dashscope_capabilities
   | _ ->
-    (match Capabilities.for_model_id config.model_id with
+    (match Provider_config.capabilities_for_config_model config with
      | Some caps -> caps
      | None ->
        (match config.kind with
@@ -359,7 +359,7 @@ let build_request_assoc
     match config.supports_tool_choice_override with
     | Some v -> v
     | None ->
-      (match Capabilities.for_model_id config.model_id with
+      (match Provider_config.capabilities_for_config_model config with
        | Some c -> c.supports_tool_choice
        | None -> true)
   in

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -731,6 +731,41 @@ let for_model_id model_id =
      | None -> for_model_id_catalog model_id)
 ;;
 
+let starts_with ~prefix s =
+  String.length s >= String.length prefix
+  && String.sub s 0 (String.length prefix) = prefix
+;;
+
+let for_provider_model_id_catalog ~(provider_label : string) ~(model_id : string) =
+  let provider_label = String.lowercase_ascii (String.trim provider_label) in
+  let model_id = String.trim model_id in
+  let candidates = [ provider_label ^ "/" ^ model_id; provider_label ^ ":" ^ model_id ] in
+  let qualified_prefixes = [ provider_label ^ "/"; provider_label ^ ":" ] in
+  match Model_catalog.global () with
+  | None -> None
+  | Some catalog ->
+    let rec loop = function
+      | [] -> None
+      | candidate :: rest ->
+        (match Model_catalog.lookup catalog candidate with
+         | Some entry
+           when List.exists
+                  (fun prefix ->
+                     starts_with
+                       ~prefix
+                       (String.lowercase_ascii (String.trim entry.id_prefix)))
+                  qualified_prefixes -> Some (apply_catalog_entry entry)
+         | Some _ | None -> loop rest)
+    in
+    loop candidates
+;;
+
+let for_provider_model_id ~(provider_label : string) ~(model_id : string) =
+  match for_provider_model_id_catalog ~provider_label ~model_id with
+  | Some _ as caps -> caps
+  | None -> for_model_id model_id
+;;
+
 [@@@coverage off]
 
 let%test "for_model_id glm-4.5 has reasoning" =

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -171,6 +171,20 @@ val gemini_thinking_control_of_id : string -> gemini_thinking_control
     prefix-matches [model_id]; there is no in-code fallback table. *)
 val for_model_id_catalog : string -> capabilities option
 
+(** Look up capabilities for [model_id] with a provider-qualified catalog
+    override first.
+
+    Provider-qualified entries use [<provider_label>/<model_id>] or
+    [<provider_label>:<model_id>] prefixes in [models.toml]. When no qualified
+    entry matches, this falls back to {!for_model_id}. This lets transports
+    such as Ollama Cloud override bare model-family entries that are shared
+    with other providers (for example [glm-5] or [kimi-k2.6]) without coupling
+    the catalog to any embedding application. *)
+val for_provider_model_id
+  :  provider_label:string
+  -> model_id:string
+  -> capabilities option
+
 (** Lookup capabilities for a known model_id.
 
     Checks the globally loaded model catalog first, then the capability

--- a/lib/llm_provider/complete_common.ml
+++ b/lib/llm_provider/complete_common.ml
@@ -25,7 +25,7 @@ let base_capabilities_for_kind = function
 ;;
 
 let resolve_capabilities_for_config (config : Provider_config.t) =
-  match Capabilities.for_model_id config.model_id with
+  match Provider_config.capabilities_for_config_model config with
   | Some caps -> caps, Model_capability
   | None -> base_capabilities_for_kind config.kind, Provider_default_capability
 ;;

--- a/lib/llm_provider/complete_sampling.ml
+++ b/lib/llm_provider/complete_sampling.ml
@@ -52,7 +52,7 @@ let provider_sampling_defaults (kind : Provider_config.provider_kind) : sampling
 ;;
 
 let openai_compat_should_default_min_p (config : Provider_config.t) : bool =
-  match Capabilities.for_model_id config.model_id with
+  match Provider_config.capabilities_for_config_model config with
   | Some caps -> caps.supports_min_p
   | None -> Provider_config.is_local config
 ;;

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -184,6 +184,24 @@ let show_provider_kind = Provider_kind.show
 let provider_kind_to_yojson = Provider_kind.to_yojson
 let provider_kind_of_yojson = Provider_kind.of_yojson
 
+let base_url_targets_ollama_cloud base_url =
+  let base_url = String.lowercase_ascii (String.trim base_url) in
+  String.starts_with ~prefix:"https://ollama.com" base_url
+  || String.starts_with ~prefix:"http://ollama.com" base_url
+;;
+
+let capability_provider_label (config : t) =
+  if base_url_targets_ollama_cloud config.base_url
+  then "ollama_cloud"
+  else string_of_provider_kind config.kind
+;;
+
+let capabilities_for_config_model (config : t) =
+  Capabilities.for_provider_model_id
+    ~provider_label:(capability_provider_label config)
+    ~model_id:config.model_id
+;;
+
 (** Return only the auth-specific headers for a config.
     Callers merge this into [config.headers] at HTTP request time so that
     [Provider_config.t.headers] never carries sensitive tokens like API keys.
@@ -400,7 +418,7 @@ let validate_output_schema_request (config : t) =
           documented in the current Z.AI API"
      | Kimi | OpenAI_compat ->
        let caps =
-         match Capabilities.for_model_id config.model_id with
+         match capabilities_for_config_model config with
          | Some c -> c
          | None -> Capabilities.default_capabilities
        in
@@ -473,7 +491,9 @@ let%test "validate_output_schema_request: Ollama Cloud accepts json_schema" =
   validate_output_schema_request config = Ok ()
 ;;
 
-let%test "validate_output_schema_request: unknown OpenAI-compatible host rejects json_schema" =
+let%test
+    "validate_output_schema_request: unknown OpenAI-compatible host rejects json_schema"
+  =
   let config =
     make
       ~kind:OpenAI_compat

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -274,6 +274,17 @@ val reasoning_effort_request_value
     @since 0.114.0 *)
 val reasoning_effort_of_config : t -> string option
 
+(** Capability catalog provider namespace for [config].
+
+    This is usually {!string_of_provider_kind}, except official Ollama Cloud
+    endpoints are scoped as ["ollama_cloud"] even when they use the
+    OpenAI-compatible wire kind. *)
+val capability_provider_label : t -> string
+
+(** Resolve model capabilities using provider-qualified catalog entries first,
+    then bare model entries. *)
+val capabilities_for_config_model : t -> Capabilities.capabilities option
+
 (** Derive a provider-safe schema name for native structured-output APIs
     that require one (for example Openai's [json_schema.name]). *)
 val structured_output_name_of_schema : Yojson.Safe.t -> string

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -158,7 +158,7 @@ let for_provider_config (config : Provider_config.t) =
     ; streaming = Delta_field "thought"
     }
   | Kimi | OpenAI_compat | Ollama | Glm ->
-    (match Capabilities.for_model_id config.model_id with
+    (match Provider_config.capabilities_for_config_model config with
      | Some caps ->
        of_capabilities caps
        |> with_preserve_thinking ~preserve_thinking:config.preserve_thinking

--- a/models.toml
+++ b/models.toml
@@ -317,6 +317,494 @@ supports_structured_output = true
 supports_image_input = true
 supports_native_streaming = true
 
+# Ollama Cloud Models
+# Source: https://ollama.com/api/tags + /api/show, checked 2026-06-19 KST.
+# Provider-qualified entries override shared bare model ids only for Ollama Cloud.
+[[models]]
+id_prefix = "ollama_cloud/deepseek-v4-pro"
+base = "ollama_cloud"
+max_context_tokens = 524288
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/minimax-m2.1"
+base = "ollama_cloud"
+max_context_tokens = 204800
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/minimax-m2.5"
+base = "ollama_cloud"
+max_context_tokens = 196608
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/qwen3.5:397b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "ollama_cloud/deepseek-v3.1:671b"
+base = "ollama_cloud"
+max_context_tokens = 163840
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/nemotron-3-nano:30b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/devstral-2:123b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/gemma3:12b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "ollama_cloud/rnj-1:8b"
+base = "ollama_cloud"
+max_context_tokens = 32768
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/nemotron-3-ultra"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/qwen3-coder:480b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/devstral-small-2:24b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "ollama_cloud/gemini-3-flash-preview"
+base = "ollama_cloud"
+max_context_tokens = 1048576
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "ollama_cloud/gemma4:31b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "ollama_cloud/kimi-k2.5"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "ollama_cloud/kimi-k2.7-code"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "ollama_cloud/gpt-oss:20b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/gemma3:27b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "ollama_cloud/kimi-k2.6"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "ollama_cloud/deepseek-v3.2"
+base = "ollama_cloud"
+max_context_tokens = 163840
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/mistral-large-3:675b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "ollama_cloud/glm-5.1"
+base = "ollama_cloud"
+max_context_tokens = 202752
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/glm-5.2"
+base = "ollama_cloud"
+max_context_tokens = 1000000
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/gpt-oss:120b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/minimax-m3"
+base = "ollama_cloud"
+max_context_tokens = 524288
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "ollama_cloud/ministral-3:3b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "ollama_cloud/glm-5"
+base = "ollama_cloud"
+max_context_tokens = 202752
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/qwen3-coder-next"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/minimax-m2.7"
+base = "ollama_cloud"
+max_context_tokens = 196608
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/ministral-3:8b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "ollama_cloud/deepseek-v4-flash"
+base = "ollama_cloud"
+max_context_tokens = 1048576
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/ministral-3:14b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "ollama_cloud/gemma3:4b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "ollama_cloud/nemotron-3-super"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ollama_cloud/glm-4.7"
+base = "ollama_cloud"
+max_context_tokens = 202752
+supports_multimodal_inputs = false
+supports_image_input = false
+
+# Bare Ollama Cloud model ids not already covered by an existing catalog prefix.
+[[models]]
+id_prefix = "minimax-m2.1"
+base = "ollama_cloud"
+max_context_tokens = 204800
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "minimax-m2.5"
+base = "ollama_cloud"
+max_context_tokens = 196608
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "deepseek-v3.1:671b"
+base = "ollama_cloud"
+max_context_tokens = 163840
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "nemotron-3-nano:30b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "devstral-2:123b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "gemma3:12b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "rnj-1:8b"
+base = "ollama_cloud"
+max_context_tokens = 32768
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "nemotron-3-ultra"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "devstral-small-2:24b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "gemma4:31b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "gemma3:27b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "deepseek-v3.2"
+base = "ollama_cloud"
+max_context_tokens = 163840
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ministral-3:3b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "minimax-m2.7"
+base = "ollama_cloud"
+max_context_tokens = 196608
+supports_multimodal_inputs = false
+supports_image_input = false
+
+[[models]]
+id_prefix = "ministral-3:8b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "ministral-3:14b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "gemma3:4b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+
+[[models]]
+id_prefix = "nemotron-3-super"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_multimodal_inputs = false
+supports_image_input = false
+
 # Gemini Models
 [[models]]
 id_prefix = "gemini-2.5"

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -402,6 +402,97 @@ let test_lookup_glm_ocr () =
   | None -> fail "should match glm-ocr"
 ;;
 
+let test_ollama_cloud_current_catalog_resolves () =
+  let cases =
+    [ "deepseek-v4-pro", 524_288, false
+    ; "minimax-m2.1", 204_800, false
+    ; "minimax-m2.5", 196_608, false
+    ; "qwen3.5:397b", 262_144, true
+    ; "deepseek-v3.1:671b", 163_840, false
+    ; "nemotron-3-nano:30b", 262_144, false
+    ; "devstral-2:123b", 262_144, false
+    ; "gemma3:12b", 131_072, true
+    ; "rnj-1:8b", 32_768, false
+    ; "nemotron-3-ultra", 262_144, false
+    ; "qwen3-coder:480b", 262_144, false
+    ; "devstral-small-2:24b", 262_144, true
+    ; "gemini-3-flash-preview", 1_048_576, true
+    ; "gemma4:31b", 262_144, true
+    ; "kimi-k2.5", 262_144, true
+    ; "kimi-k2.7-code", 262_144, true
+    ; "gpt-oss:20b", 131_072, false
+    ; "gemma3:27b", 131_072, true
+    ; "kimi-k2.6", 262_144, true
+    ; "deepseek-v3.2", 163_840, false
+    ; "mistral-large-3:675b", 262_144, true
+    ; "glm-5.1", 202_752, false
+    ; "glm-5.2", 1_000_000, false
+    ; "gpt-oss:120b", 131_072, false
+    ; "minimax-m3", 524_288, true
+    ; "ministral-3:3b", 262_144, true
+    ; "glm-5", 202_752, false
+    ; "qwen3-coder-next", 262_144, false
+    ; "minimax-m2.7", 196_608, false
+    ; "ministral-3:8b", 262_144, true
+    ; "deepseek-v4-flash", 1_048_576, false
+    ; "ministral-3:14b", 262_144, true
+    ; "gemma3:4b", 131_072, true
+    ; "nemotron-3-super", 262_144, false
+    ; "glm-4.7", 202_752, false
+    ]
+  in
+  List.iter
+    (fun (model_id, context, vision) ->
+       match
+         Capabilities.for_provider_model_id ~provider_label:"ollama_cloud" ~model_id
+       with
+       | None -> failf "ollama_cloud/%s should resolve" model_id
+       | Some c ->
+         check (option int) (model_id ^ " context") (Some context) c.max_context_tokens;
+         check bool (model_id ^ " vision") vision c.supports_image_input;
+         check bool (model_id ^ " multimodal") vision c.supports_multimodal_inputs)
+    cases
+;;
+
+let test_ollama_cloud_provider_qualified_overrides_bare_family () =
+  let open Capabilities in
+  let bare_glm =
+    match for_model_id "glm-5.1" with
+    | Some c -> c
+    | None -> fail "bare glm-5.1 should resolve"
+  in
+  let cloud_glm =
+    match for_provider_model_id ~provider_label:"ollama_cloud" ~model_id:"glm-5.1" with
+    | Some c -> c
+    | None -> fail "ollama_cloud/glm-5.1 should resolve"
+  in
+  check (option int) "bare GLM context" (Some 200_000) bare_glm.max_context_tokens;
+  check (option int) "cloud GLM context" (Some 202_752) cloud_glm.max_context_tokens;
+  check_thinking_control
+    "cloud GLM uses Ollama reasoning_effort"
+    Reasoning_effort
+    cloud_glm.thinking_control_format;
+  let bare_kimi =
+    match for_model_id "kimi-k2.6" with
+    | Some c -> c
+    | None -> fail "bare kimi-k2.6 should resolve"
+  in
+  let cloud_kimi =
+    match for_provider_model_id ~provider_label:"ollama_cloud" ~model_id:"kimi-k2.6" with
+    | Some c -> c
+    | None -> fail "ollama_cloud/kimi-k2.6 should resolve"
+  in
+  check_thinking_control
+    "bare Kimi keeps Kimi dialect"
+    Thinking_object_only
+    bare_kimi.thinking_control_format;
+  check_thinking_control
+    "cloud Kimi uses Ollama reasoning_effort"
+    Reasoning_effort
+    cloud_kimi.thinking_control_format;
+  check bool "cloud Kimi vision" true cloud_kimi.supports_image_input
+;;
+
 (* ── with_context_size ───────────────────────────────── *)
 
 let test_with_context_size () =
@@ -898,6 +989,14 @@ let () =
         ; test_case "glm-5v vision" `Quick test_lookup_glm5v_vision
         ; test_case "glm-4.6v vision" `Quick test_lookup_glm46v_vision
         ; test_case "glm-ocr vision" `Quick test_lookup_glm_ocr
+        ; test_case
+            "ollama cloud current catalog"
+            `Quick
+            test_ollama_cloud_current_catalog_resolves
+        ; test_case
+            "ollama cloud overrides shared bare families"
+            `Quick
+            test_ollama_cloud_provider_qualified_overrides_bare_family
         ; test_case "mimo-v2.5-pro" `Quick test_lookup_mimo_v25_pro
         ; test_case "qwen3 thinking control" `Quick test_lookup_qwen3_thinking_control
         ; test_case "unknown" `Quick test_lookup_unknown


### PR DESCRIPTION
## Summary
- Add provider-qualified capability lookup so Ollama Cloud can override shared bare model families like glm-5 and kimi-k2 without changing non-Cloud providers.
- Add Ollama Cloud catalog entries from the current official /api/tags and /api/show model list, including vision flags and context windows for all 35 Cloud models.
- Route config-level capability resolution through the provider-qualified lookup across OpenAI-compatible request building, sampling defaults, reasoning dialect selection, and structured output validation.

## Evidence
- Official source: https://ollama.com/api/tags and https://ollama.com/api/show checked on 2026-06-19 KST; 35 Cloud models, 15 vision-capable models.
- Related docs: https://docs.ollama.com/cloud, https://docs.ollama.com/capabilities/vision, https://docs.ollama.com/api/openai-compatibility.

## Validation
- ocamlformat --check on modified OCaml files.
- scripts/dune-local.sh build test/test_capabilities.exe
- _build/default/test/test_capabilities.exe