### PR TITLE
Add Gemma 4 coder catalog entry

### DIFF
--- a/models.toml
+++ b/models.toml
@@ -1474,6 +1474,22 @@ supports_seed = true
 input_per_million = 0.0
 output_per_million = 0.0
 
+[[models]]
+id_prefix = "gemma4-coder-"
+base = "openai_chat"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = true
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = false
+thinking_control_format = "chat_template_token"
+supports_native_streaming = true
+supports_top_k = true
+supports_seed = true
+input_per_million = 0.0
+output_per_million = 0.0
+
 # Generic/Ollama/Other Fallbacks
 [[models]]
 id_prefix = "ollama"


### PR DESCRIPTION
## Summary

- add a catalog entry for `gemma4-coder-*` OpenAI-compatible chat aliases
- declare 262144 context tokens for Gemma 4 coder GGUF deployments
- enable tools, forced `tool_choice`, reasoning/thinking, native streaming, top-k, and seed support

## Validation

- `python3 -c 'import pathlib,tomllib; p=pathlib.Path("models.toml"); tomllib.loads(p.read_text()); print("ok", p)'`
- `env OAS_MODEL_CATALOG=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/add-runpod-gemma4-coder-catalog/models.toml /Users/dancer/me/workspace/yousleepwhen/masc/_build/default/bin/fusion_run.exe --base /Users/dancer/me --preset __config_probe__ catalog-check`
  - expected result: catalog loads 148 entries, then exits at `preset not found: __config_probe__`

## Live Probe

- llama.cpp `/v1/models` on the current hosted endpoint reported `gemma4-coder-fable5-q4km` with `n_ctx=262144`
- OpenAI-compatible `/v1/chat/completions` returned `finish_reason="tool_calls"` for both `tool_choice:"auto"` and forced named `tool_choice`
