### PR TITLE
[codex] Refresh Ollama Cloud model catalog

### DIFF
--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -1334,11 +1334,11 @@ let%test "build_request emits reasoning_effort for Openai reasoning models" =
   && json |> member "enable_thinking" = `Null
 ;;
 
-let%test "build_request emits thinking object only for Kimi K2.5" =
+let%test "build_request emits thinking object only for native Kimi K2" =
   let config =
     Provider_config.make
       ~kind:Kimi
-      ~model_id:"kimi-k2.5"
+      ~model_id:"kimi-k2"
       ~base_url:"https://api.moonshot.ai/v1"
       ~enable_thinking:false
       ()

--- a/models.toml
+++ b/models.toml
@@ -1547,6 +1547,13 @@ input_per_million = 0.0
 output_per_million = 0.0
 
 [[models]]
+id_prefix = "kimi-k2.5:cloud"
+base = "kimi"
+max_context_tokens = 256000
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[models]]
 id_prefix = "kimi-k2.5"
 base = "ollama_cloud"
 max_context_tokens = 262144
@@ -1560,6 +1567,13 @@ supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"
 supports_native_streaming = true
+
+[[models]]
+id_prefix = "kimi-k2.6:cloud"
+base = "kimi"
+max_context_tokens = 256000
+input_per_million = 0.0
+output_per_million = 0.0
 
 [[models]]
 id_prefix = "kimi-k2.6"

--- a/models.toml
+++ b/models.toml
@@ -317,285 +317,86 @@ supports_structured_output = true
 supports_image_input = true
 supports_native_streaming = true
 
-# Ollama Cloud Models
-# Source: https://ollama.com/api/tags + /api/show, checked 2026-06-19 KST.
-# Provider-qualified entries override shared bare model ids only for Ollama Cloud.
-[[models]]
-id_prefix = "ollama_cloud/deepseek-v4-pro"
-base = "ollama_cloud"
-max_context_tokens = 524288
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "ollama_cloud/minimax-m2.1"
-base = "ollama_cloud"
-max_context_tokens = 204800
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "ollama_cloud/minimax-m2.5"
-base = "ollama_cloud"
-max_context_tokens = 196608
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "ollama_cloud/qwen3.5:397b"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
+# Ollama Cloud Models (canonical 2026-06 seed)
+# Source: https://ollama.com/api/tags + /api/show, checked 2026-06-20 KST.
+# Provider-qualified entries preserve Ollama Cloud wire behavior when a model id overlaps another provider.
 
 [[models]]
 id_prefix = "ollama_cloud/deepseek-v3.1:671b"
 base = "ollama_cloud"
 max_context_tokens = 163840
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = false
 supports_image_input = false
-
-[[models]]
-id_prefix = "ollama_cloud/nemotron-3-nano:30b"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "ollama_cloud/devstral-2:123b"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_reasoning = false
-supports_extended_thinking = false
-supports_reasoning_budget = false
-thinking_control_format = "none"
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "ollama_cloud/gemma3:12b"
-base = "ollama_cloud"
-max_context_tokens = 131072
-supports_tools = false
-supports_reasoning = false
-supports_extended_thinking = false
-supports_reasoning_budget = false
-thinking_control_format = "none"
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-
-[[models]]
-id_prefix = "ollama_cloud/rnj-1:8b"
-base = "ollama_cloud"
-max_context_tokens = 32768
-supports_reasoning = false
-supports_extended_thinking = false
-supports_reasoning_budget = false
-thinking_control_format = "none"
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "ollama_cloud/nemotron-3-ultra"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "ollama_cloud/qwen3-coder:480b"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_reasoning = false
-supports_extended_thinking = false
-supports_reasoning_budget = false
-thinking_control_format = "none"
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "ollama_cloud/devstral-small-2:24b"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_reasoning = false
-supports_extended_thinking = false
-supports_reasoning_budget = false
-thinking_control_format = "none"
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-
-[[models]]
-id_prefix = "ollama_cloud/gemini-3-flash-preview"
-base = "ollama_cloud"
-max_context_tokens = 1048576
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-
-[[models]]
-id_prefix = "ollama_cloud/gemma4:31b"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-
-[[models]]
-id_prefix = "ollama_cloud/kimi-k2.5"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-
-[[models]]
-id_prefix = "ollama_cloud/kimi-k2.7-code"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-
-[[models]]
-id_prefix = "ollama_cloud/gpt-oss:20b"
-base = "ollama_cloud"
-max_context_tokens = 131072
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "ollama_cloud/gemma3:27b"
-base = "ollama_cloud"
-max_context_tokens = 131072
-supports_tools = false
-supports_reasoning = false
-supports_extended_thinking = false
-supports_reasoning_budget = false
-thinking_control_format = "none"
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-
-[[models]]
-id_prefix = "ollama_cloud/kimi-k2.6"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
+supports_native_streaming = true
 
 [[models]]
 id_prefix = "ollama_cloud/deepseek-v3.2"
 base = "ollama_cloud"
 max_context_tokens = 163840
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = false
 supports_image_input = false
-
-[[models]]
-id_prefix = "ollama_cloud/mistral-large-3:675b"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_reasoning = false
-supports_extended_thinking = false
-supports_reasoning_budget = false
-thinking_control_format = "none"
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-
-[[models]]
-id_prefix = "ollama_cloud/glm-5.1"
-base = "ollama_cloud"
-max_context_tokens = 202752
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "ollama_cloud/glm-5.2"
-base = "ollama_cloud"
-max_context_tokens = 1000000
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "ollama_cloud/gpt-oss:120b"
-base = "ollama_cloud"
-max_context_tokens = 131072
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "ollama_cloud/minimax-m3"
-base = "ollama_cloud"
-max_context_tokens = 524288
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-
-[[models]]
-id_prefix = "ollama_cloud/ministral-3:3b"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_reasoning = false
-supports_extended_thinking = false
-supports_reasoning_budget = false
-thinking_control_format = "none"
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-
-[[models]]
-id_prefix = "ollama_cloud/glm-5"
-base = "ollama_cloud"
-max_context_tokens = 202752
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "ollama_cloud/qwen3-coder-next"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_reasoning = false
-supports_extended_thinking = false
-supports_reasoning_budget = false
-thinking_control_format = "none"
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "ollama_cloud/minimax-m2.7"
-base = "ollama_cloud"
-max_context_tokens = 196608
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "ollama_cloud/ministral-3:8b"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_reasoning = false
-supports_extended_thinking = false
-supports_reasoning_budget = false
-thinking_control_format = "none"
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
+supports_native_streaming = true
 
 [[models]]
 id_prefix = "ollama_cloud/deepseek-v4-flash"
 base = "ollama_cloud"
 max_context_tokens = 1048576
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = false
 supports_image_input = false
+supports_native_streaming = true
 
 [[models]]
-id_prefix = "ollama_cloud/ministral-3:14b"
+id_prefix = "ollama_cloud/deepseek-v4-pro"
+base = "ollama_cloud"
+max_context_tokens = 524288
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/devstral-2:123b"
 base = "ollama_cloud"
 max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/devstral-small-2:24b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
 supports_reasoning = false
 supports_extended_thinking = false
 supports_reasoning_budget = false
@@ -603,12 +404,29 @@ thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/gemini-3-flash-preview"
+base = "ollama_cloud"
+max_context_tokens = 1048576
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
 
 [[models]]
 id_prefix = "ollama_cloud/gemma3:4b"
 base = "ollama_cloud"
 max_context_tokens = 131072
 supports_tools = false
+supports_tool_choice = false
 supports_reasoning = false
 supports_extended_thinking = false
 supports_reasoning_budget = false
@@ -616,155 +434,451 @@ thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"
+supports_native_streaming = true
 
 [[models]]
-id_prefix = "ollama_cloud/nemotron-3-super"
+id_prefix = "ollama_cloud/gemma3:12b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = false
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/gemma3:27b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = false
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/gemma4:31b"
 base = "ollama_cloud"
 max_context_tokens = 262144
-supports_multimodal_inputs = false
-supports_image_input = false
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
 
 [[models]]
 id_prefix = "ollama_cloud/glm-4.7"
 base = "ollama_cloud"
 max_context_tokens = 202752
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = false
 supports_image_input = false
+supports_native_streaming = true
 
-# Bare Ollama Cloud model ids not already covered by an existing catalog prefix.
 [[models]]
-id_prefix = "minimax-m2.1"
+id_prefix = "ollama_cloud/glm-5"
+base = "ollama_cloud"
+max_context_tokens = 202752
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/glm-5.1"
+base = "ollama_cloud"
+max_context_tokens = 202752
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/glm-5.2"
+base = "ollama_cloud"
+max_context_tokens = 1000000
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/gpt-oss:20b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/gpt-oss:120b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/kimi-k2.5"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/kimi-k2.6"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/kimi-k2.7-code"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/minimax-m2.1"
 base = "ollama_cloud"
 max_context_tokens = 204800
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = false
 supports_image_input = false
+supports_native_streaming = true
 
 [[models]]
-id_prefix = "minimax-m2.5"
+id_prefix = "ollama_cloud/minimax-m2.5"
 base = "ollama_cloud"
 max_context_tokens = 196608
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = false
 supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/minimax-m2.7"
+base = "ollama_cloud"
+max_context_tokens = 196608
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/minimax-m3"
+base = "ollama_cloud"
+max_context_tokens = 524288
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_response_format_json = true
+supports_structured_output = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/ministral-3:3b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/ministral-3:8b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/ministral-3:14b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/mistral-large-3:675b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/nemotron-3-nano:30b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/nemotron-3-super"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/nemotron-3-ultra"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/qwen3-coder:480b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/qwen3-coder-next"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/qwen3.5:397b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/rnj-1:8b"
+base = "ollama_cloud"
+max_context_tokens = 32768
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+# Bare entries for Cloud models not already represented above by a direct-provider seed.
+# Runtime startup still checks bare model membership before OAS provider-qualified dispatch.
 
 [[models]]
 id_prefix = "deepseek-v3.1:671b"
 base = "ollama_cloud"
 max_context_tokens = 163840
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = false
 supports_image_input = false
-
-[[models]]
-id_prefix = "nemotron-3-nano:30b"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "devstral-2:123b"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_reasoning = false
-supports_extended_thinking = false
-supports_reasoning_budget = false
-thinking_control_format = "none"
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "gemma3:12b"
-base = "ollama_cloud"
-max_context_tokens = 131072
-supports_tools = false
-supports_reasoning = false
-supports_extended_thinking = false
-supports_reasoning_budget = false
-thinking_control_format = "none"
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-
-[[models]]
-id_prefix = "rnj-1:8b"
-base = "ollama_cloud"
-max_context_tokens = 32768
-supports_reasoning = false
-supports_extended_thinking = false
-supports_reasoning_budget = false
-thinking_control_format = "none"
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "nemotron-3-ultra"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_multimodal_inputs = false
-supports_image_input = false
-
-[[models]]
-id_prefix = "devstral-small-2:24b"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_reasoning = false
-supports_extended_thinking = false
-supports_reasoning_budget = false
-thinking_control_format = "none"
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-
-[[models]]
-id_prefix = "gemma4:31b"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-
-[[models]]
-id_prefix = "gemma3:27b"
-base = "ollama_cloud"
-max_context_tokens = 131072
-supports_tools = false
-supports_reasoning = false
-supports_extended_thinking = false
-supports_reasoning_budget = false
-thinking_control_format = "none"
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
+supports_native_streaming = true
 
 [[models]]
 id_prefix = "deepseek-v3.2"
 base = "ollama_cloud"
 max_context_tokens = 163840
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = false
 supports_image_input = false
+supports_native_streaming = true
 
 [[models]]
-id_prefix = "ministral-3:3b"
+id_prefix = "devstral-2:123b"
 base = "ollama_cloud"
 max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
 supports_reasoning = false
 supports_extended_thinking = false
 supports_reasoning_budget = false
 thinking_control_format = "none"
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-
-[[models]]
-id_prefix = "minimax-m2.7"
-base = "ollama_cloud"
-max_context_tokens = 196608
 supports_multimodal_inputs = false
 supports_image_input = false
+supports_native_streaming = true
 
 [[models]]
-id_prefix = "ministral-3:8b"
+id_prefix = "devstral-small-2:24b"
 base = "ollama_cloud"
 max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
 supports_reasoning = false
 supports_extended_thinking = false
 supports_reasoning_budget = false
@@ -772,24 +886,29 @@ thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"
+supports_native_streaming = true
 
 [[models]]
-id_prefix = "ministral-3:14b"
+id_prefix = "gemini-3-flash-preview"
 base = "ollama_cloud"
-max_context_tokens = 262144
-supports_reasoning = false
-supports_extended_thinking = false
-supports_reasoning_budget = false
-thinking_control_format = "none"
+max_context_tokens = 1048576
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"
+supports_native_streaming = true
 
 [[models]]
 id_prefix = "gemma3:4b"
 base = "ollama_cloud"
 max_context_tokens = 131072
 supports_tools = false
+supports_tool_choice = false
 supports_reasoning = false
 supports_extended_thinking = false
 supports_reasoning_budget = false
@@ -797,13 +916,368 @@ thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "gemma3:12b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = false
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "gemma3:27b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = false
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "gemma4:31b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "glm-5"
+base = "ollama_cloud"
+max_context_tokens = 202752
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "glm-5.1"
+base = "ollama_cloud"
+max_context_tokens = 202752
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "glm-5.2"
+base = "ollama_cloud"
+max_context_tokens = 1000000
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "gpt-oss:20b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "gpt-oss:120b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "kimi-k2.5"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "kimi-k2.6"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "kimi-k2.7-code"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "minimax-m2.1"
+base = "ollama_cloud"
+max_context_tokens = 204800
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "minimax-m2.5"
+base = "ollama_cloud"
+max_context_tokens = 196608
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "minimax-m2.7"
+base = "ollama_cloud"
+max_context_tokens = 196608
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ministral-3:3b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ministral-3:8b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ministral-3:14b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "mistral-large-3:675b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "nemotron-3-nano:30b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
 
 [[models]]
 id_prefix = "nemotron-3-super"
 base = "ollama_cloud"
 max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = false
 supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "nemotron-3-ultra"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "qwen3-coder:480b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "qwen3-coder-next"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "qwen3.5:397b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "rnj-1:8b"
+base = "ollama_cloud"
+max_context_tokens = 32768
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
 
 # Gemini Models
 [[models]]

--- a/models.toml
+++ b/models.toml
@@ -1548,17 +1548,33 @@ output_per_million = 0.0
 
 [[models]]
 id_prefix = "kimi-k2.5"
-base = "kimi"
-max_context_tokens = 256000
-input_per_million = 0.0
-output_per_million = 0.0
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
 
 [[models]]
 id_prefix = "kimi-k2.6"
-base = "kimi"
-max_context_tokens = 256000
-input_per_million = 0.0
-output_per_million = 0.0
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
 
 # xAI Grok Models
 [[models]]

--- a/models.toml
+++ b/models.toml
@@ -1546,6 +1546,10 @@ max_context_tokens = 256000
 input_per_million = 0.0
 output_per_million = 0.0
 
+# Legacy native Kimi cloud suffix. This is intentionally not Ollama Cloud:
+# bare official Ollama Cloud Kimi rows below use base = "ollama_cloud",
+# 262144 context tokens, reasoning_effort, and visual_first ordering.
+# Native Kimi keeps the existing Kimi transport dialect and 256000 context.
 [[models]]
 id_prefix = "kimi-k2.5:cloud"
 base = "kimi"
@@ -1568,6 +1572,9 @@ supports_image_input = true
 modality_priority = "visual_first"
 supports_native_streaming = true
 
+# Legacy native Kimi cloud suffix. Keep this more-specific prefix before the
+# bare official Ollama Cloud row so longest-prefix lookup preserves native Kimi
+# requests without changing Ollama Cloud Kimi semantics.
 [[models]]
 id_prefix = "kimi-k2.6:cloud"
 base = "kimi"

--- a/models.toml
+++ b/models.toml
@@ -991,21 +991,6 @@ supports_image_input = false
 supports_native_streaming = true
 
 [[models]]
-id_prefix = "kimi-k2.6"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_tools = true
-supports_tool_choice = false
-supports_reasoning = true
-supports_extended_thinking = true
-supports_reasoning_budget = true
-thinking_control_format = "reasoning_effort"
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-supports_native_streaming = true
-
-[[models]]
 id_prefix = "kimi-k2.7-code"
 base = "ollama_cloud"
 max_context_tokens = 262144
@@ -1563,6 +1548,13 @@ output_per_million = 0.0
 
 [[models]]
 id_prefix = "kimi-k2.5"
+base = "kimi"
+max_context_tokens = 256000
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[models]]
+id_prefix = "kimi-k2.6"
 base = "kimi"
 max_context_tokens = 256000
 input_per_million = 0.0

--- a/models.toml
+++ b/models.toml
@@ -828,7 +828,7 @@ supports_multimodal_inputs = false
 supports_image_input = false
 supports_native_streaming = true
 
-# Bare entries for Cloud models not already represented above by a direct-provider seed.
+# Bare entries for Cloud models not already represented elsewhere by a direct-provider seed.
 # Runtime startup still checks bare model membership before OAS provider-qualified dispatch.
 
 [[models]]
@@ -883,21 +883,6 @@ supports_reasoning = false
 supports_extended_thinking = false
 supports_reasoning_budget = false
 thinking_control_format = "none"
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-supports_native_streaming = true
-
-[[models]]
-id_prefix = "gemini-3-flash-preview"
-base = "ollama_cloud"
-max_context_tokens = 1048576
-supports_tools = true
-supports_tool_choice = false
-supports_reasoning = true
-supports_extended_thinking = true
-supports_reasoning_budget = true
-thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"
@@ -964,34 +949,6 @@ modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
-id_prefix = "glm-5"
-base = "ollama_cloud"
-max_context_tokens = 202752
-supports_tools = true
-supports_tool_choice = false
-supports_reasoning = true
-supports_extended_thinking = true
-supports_reasoning_budget = true
-thinking_control_format = "reasoning_effort"
-supports_multimodal_inputs = false
-supports_image_input = false
-supports_native_streaming = true
-
-[[models]]
-id_prefix = "glm-5.1"
-base = "ollama_cloud"
-max_context_tokens = 202752
-supports_tools = true
-supports_tool_choice = false
-supports_reasoning = true
-supports_extended_thinking = true
-supports_reasoning_budget = true
-thinking_control_format = "reasoning_effort"
-supports_multimodal_inputs = false
-supports_image_input = false
-supports_native_streaming = true
-
-[[models]]
 id_prefix = "glm-5.2"
 base = "ollama_cloud"
 max_context_tokens = 1000000
@@ -1031,21 +988,6 @@ supports_reasoning_budget = true
 thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = false
 supports_image_input = false
-supports_native_streaming = true
-
-[[models]]
-id_prefix = "kimi-k2.5"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_tools = true
-supports_tool_choice = false
-supports_reasoning = true
-supports_extended_thinking = true
-supports_reasoning_budget = true
-thinking_control_format = "reasoning_effort"
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -1614,6 +1556,13 @@ output_per_million = 0.0
 
 [[models]]
 id_prefix = "kimi-k2"
+base = "kimi"
+max_context_tokens = 256000
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[models]]
+id_prefix = "kimi-k2.5"
 base = "kimi"
 max_context_tokens = 256000
 input_per_million = 0.0

--- a/models.toml
+++ b/models.toml
@@ -991,21 +991,6 @@ supports_image_input = false
 supports_native_streaming = true
 
 [[models]]
-id_prefix = "kimi-k2.7-code"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_tools = true
-supports_tool_choice = false
-supports_reasoning = true
-supports_extended_thinking = true
-supports_reasoning_budget = true
-thinking_control_format = "reasoning_effort"
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-supports_native_streaming = true
-
-[[models]]
 id_prefix = "minimax-m2.1"
 base = "ollama_cloud"
 max_context_tokens = 204800
@@ -1546,10 +1531,9 @@ max_context_tokens = 256000
 input_per_million = 0.0
 output_per_million = 0.0
 
-# Legacy native Kimi cloud suffix. This is intentionally not Ollama Cloud:
-# bare official Ollama Cloud Kimi rows below use base = "ollama_cloud",
-# 262144 context tokens, reasoning_effort, and visual_first ordering.
-# Native Kimi keeps the existing Kimi transport dialect and 256000 context.
+# Bare kimi-k2.* ids are native Kimi. Ollama Cloud's overlapping Kimi ids are
+# represented only by provider-qualified ollama_cloud/kimi-* rows so a bare
+# native route does not silently inherit Ollama Cloud wire semantics.
 [[models]]
 id_prefix = "kimi-k2.5:cloud"
 base = "kimi"
@@ -1558,44 +1542,11 @@ input_per_million = 0.0
 output_per_million = 0.0
 
 [[models]]
-id_prefix = "kimi-k2.5"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_tools = true
-supports_tool_choice = false
-supports_reasoning = true
-supports_extended_thinking = true
-supports_reasoning_budget = true
-thinking_control_format = "reasoning_effort"
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-supports_native_streaming = true
-
-# Legacy native Kimi cloud suffix. Keep this more-specific prefix before the
-# bare official Ollama Cloud row so longest-prefix lookup preserves native Kimi
-# requests without changing Ollama Cloud Kimi semantics.
-[[models]]
 id_prefix = "kimi-k2.6:cloud"
 base = "kimi"
 max_context_tokens = 256000
 input_per_million = 0.0
 output_per_million = 0.0
-
-[[models]]
-id_prefix = "kimi-k2.6"
-base = "ollama_cloud"
-max_context_tokens = 262144
-supports_tools = true
-supports_tool_choice = false
-supports_reasoning = true
-supports_extended_thinking = true
-supports_reasoning_budget = true
-thinking_control_format = "reasoning_effort"
-supports_multimodal_inputs = true
-supports_image_input = true
-modality_priority = "visual_first"
-supports_native_streaming = true
 
 # xAI Grok Models
 [[models]]

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -238,20 +238,62 @@ let test_gemini_family_drives_capabilities () =
   check (option int) "gemini-2.5-flash ctx" (Some 1_000_000) (ctx "gemini-2.5-flash")
 ;;
 
-let test_lookup_kimi_k2_cloud () =
+let test_lookup_kimi_k2_native_cloud_suffix () =
+  let check_visual_first label caps =
+    match caps.Capabilities.modality_priority with
+    | Modality.Visual_first -> ()
+    | Modality.Preserve_input_order -> fail (label ^ " should be visual_first")
+  in
+  let check_preserve_order label caps =
+    match caps.Capabilities.modality_priority with
+    | Modality.Preserve_input_order -> ()
+    | Modality.Visual_first -> fail (label ^ " should preserve input order")
+  in
   match Capabilities.for_model_id "kimi-k2.6:cloud" with
-  | Some c ->
+  | Some native ->
     (* Kimi K2.6: 256K context per platform.kimi.ai official docs (2026-05-30
-       verified). Previously 262_144 from the anonymized kimi era. *)
-    check (option int) "context 256K" (Some 256_000) c.max_context_tokens;
-    check (option int) "output 32K" (Some 32_768) c.max_output_tokens;
-    check bool "tools" true c.supports_tools;
-    check bool "reasoning" true c.supports_reasoning;
+       verified). The :cloud suffix is a legacy native Kimi route, not the
+       Ollama Cloud row named kimi-k2.6. *)
+    check (option int) "native Kimi context 256K" (Some 256_000) native.max_context_tokens;
+    check (option int) "native Kimi output 32K" (Some 32_768) native.max_output_tokens;
+    check bool "native Kimi tools" true native.supports_tools;
+    check bool "native Kimi reasoning" true native.supports_reasoning;
     check_thinking_control
-      "thinking object only"
+      "native Kimi thinking object only"
       Capabilities.Thinking_object_only
-      c.thinking_control_format;
-    check bool "code execution" true c.supports_code_execution
+      native.thinking_control_format;
+    check_preserve_order "native Kimi cloud suffix" native;
+    check bool "native Kimi code execution" true native.supports_code_execution;
+    (match Capabilities.for_model_id "kimi-k2.6" with
+     | Some ollama ->
+       check
+         (option int)
+         "Ollama Cloud Kimi context"
+         (Some 262_144)
+         ollama.max_context_tokens;
+       check_thinking_control
+         "Ollama Cloud Kimi uses reasoning_effort"
+         Capabilities.Reasoning_effort
+         ollama.thinking_control_format;
+       check_visual_first "Ollama Cloud Kimi" ollama
+     | None -> fail "should match Ollama Cloud Kimi bare route");
+    (match
+       Capabilities.for_provider_model_id
+         ~provider_label:"ollama_cloud"
+         ~model_id:"kimi-k2.6"
+     with
+     | Some cloud ->
+       check
+         (option int)
+         "provider-qualified Ollama Cloud Kimi context"
+         (Some 262_144)
+         cloud.max_context_tokens;
+       check_thinking_control
+         "provider-qualified Ollama Cloud Kimi uses reasoning_effort"
+         Capabilities.Reasoning_effort
+         cloud.thinking_control_format;
+       check_visual_first "provider-qualified Ollama Cloud Kimi" cloud
+     | None -> fail "should match provider-qualified Ollama Cloud Kimi route")
   | None -> fail "should match kimi-k2 cloud route"
 ;;
 
@@ -986,7 +1028,10 @@ let () =
             "gemini_family drives 1M ctx capabilities"
             `Quick
             test_gemini_family_drives_capabilities
-        ; test_case "kimi-k2 cloud" `Quick test_lookup_kimi_k2_cloud
+        ; test_case
+            "kimi-k2 native cloud suffix vs Ollama Cloud"
+            `Quick
+            test_lookup_kimi_k2_native_cloud_suffix
         ; test_case "dashscope" `Quick test_lookup_provider_m
         ; test_case "dashscope runpod name" `Quick test_lookup_provider_m_runpod_name
         ; test_case "deepseek v4 flash" `Quick test_lookup_deepseek_v4_flash

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -483,13 +483,20 @@ let test_ollama_cloud_provider_qualified_overrides_bare_family () =
     | None -> fail "ollama_cloud/kimi-k2.6 should resolve"
   in
   check_thinking_control
-    "bare Kimi keeps Kimi dialect"
-    Thinking_object_only
+    "bare Kimi uses Ollama reasoning_effort"
+    Reasoning_effort
     bare_kimi.thinking_control_format;
   check_thinking_control
     "cloud Kimi uses Ollama reasoning_effort"
     Reasoning_effort
     cloud_kimi.thinking_control_format;
+  check (option int) "bare Kimi context" (Some 262_144) bare_kimi.max_context_tokens;
+  check
+    (option int)
+    "bare/cloud Kimi context parity"
+    cloud_kimi.max_context_tokens
+    bare_kimi.max_context_tokens;
+  check bool "bare Kimi vision" true bare_kimi.supports_image_input;
   check bool "cloud Kimi vision" true cloud_kimi.supports_image_input
 ;;
 

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -265,18 +265,30 @@ let test_lookup_kimi_k2_native_cloud_suffix () =
     check_preserve_order "native Kimi cloud suffix" native;
     check bool "native Kimi code execution" true native.supports_code_execution;
     (match Capabilities.for_model_id "kimi-k2.6" with
-     | Some ollama ->
+     | Some bare_native ->
        check
          (option int)
-         "Ollama Cloud Kimi context"
-         (Some 262_144)
-         ollama.max_context_tokens;
+         "bare native Kimi context 256K"
+         (Some 256_000)
+         bare_native.max_context_tokens;
+       check
+         (option int)
+         "bare native Kimi output 32K"
+         (Some 32_768)
+         bare_native.max_output_tokens;
+       check bool "bare native Kimi tools" true bare_native.supports_tools;
+       check bool "bare native Kimi reasoning" true bare_native.supports_reasoning;
        check_thinking_control
-         "Ollama Cloud Kimi uses reasoning_effort"
-         Capabilities.Reasoning_effort
-         ollama.thinking_control_format;
-       check_visual_first "Ollama Cloud Kimi" ollama
-     | None -> fail "should match Ollama Cloud Kimi bare route");
+         "bare native Kimi thinking object only"
+         Capabilities.Thinking_object_only
+         bare_native.thinking_control_format;
+       check_preserve_order "bare native Kimi" bare_native;
+       check
+         bool
+         "bare native Kimi code execution"
+         true
+         bare_native.supports_code_execution
+     | None -> fail "should match native bare Kimi route");
     (match
        Capabilities.for_provider_model_id
          ~provider_label:"ollama_cloud"
@@ -496,7 +508,7 @@ let test_ollama_cloud_current_catalog_resolves () =
     cases
 ;;
 
-let test_ollama_cloud_provider_qualified_overrides_bare_family () =
+let test_ollama_cloud_provider_qualified_preserves_shared_bare_family () =
   let open Capabilities in
   let bare_glm =
     match for_model_id "glm-5.1" with
@@ -525,19 +537,28 @@ let test_ollama_cloud_provider_qualified_overrides_bare_family () =
     | None -> fail "ollama_cloud/kimi-k2.6 should resolve"
   in
   check_thinking_control
-    "bare Kimi uses Ollama reasoning_effort"
-    Reasoning_effort
+    "bare Kimi remains native thinking object"
+    Thinking_object_only
     bare_kimi.thinking_control_format;
   check_thinking_control
     "cloud Kimi uses Ollama reasoning_effort"
     Reasoning_effort
     cloud_kimi.thinking_control_format;
-  check (option int) "bare Kimi context" (Some 262_144) bare_kimi.max_context_tokens;
   check
     (option int)
-    "bare/cloud Kimi context parity"
-    cloud_kimi.max_context_tokens
+    "bare Kimi native context"
+    (Some 256_000)
     bare_kimi.max_context_tokens;
+  check
+    (option int)
+    "cloud Kimi official context"
+    (Some 262_144)
+    cloud_kimi.max_context_tokens;
+  check
+    bool
+    "bare/cloud Kimi contexts intentionally differ"
+    true
+    (bare_kimi.max_context_tokens <> cloud_kimi.max_context_tokens);
   check bool "bare Kimi vision" true bare_kimi.supports_image_input;
   check bool "cloud Kimi vision" true cloud_kimi.supports_image_input
 ;;
@@ -1046,9 +1067,9 @@ let () =
             `Quick
             test_ollama_cloud_current_catalog_resolves
         ; test_case
-            "ollama cloud overrides shared bare families"
+            "ollama cloud preserves shared bare families"
             `Quick
-            test_ollama_cloud_provider_qualified_overrides_bare_family
+            test_ollama_cloud_provider_qualified_preserves_shared_bare_family
         ; test_case "mimo-v2.5-pro" `Quick test_lookup_mimo_v25_pro
         ; test_case "qwen3 thinking control" `Quick test_lookup_qwen3_thinking_control
         ; test_case "unknown" `Quick test_lookup_unknown


### PR DESCRIPTION
## Summary

- Refresh `models.toml` Ollama Cloud catalog from the official Ollama API snapshot: 35 official models, 15 vision-capable models.
- Add provider-qualified `ollama_cloud/<model>` rows for every official model, including vision flags and visual-first modality ordering for all vision-capable rows.
- Keep overlapping direct-provider bare families native. In particular, bare `kimi-k2.*` resolves through native Kimi semantics, while Ollama Cloud Kimi support is provided through `ollama_cloud/kimi-k2.*`.
- Preserve legacy native Kimi `:cloud` suffix routes such as `kimi-k2.5:cloud` and `kimi-k2.6:cloud` without letting them shadow provider-qualified Ollama Cloud rows.
- Pin the overlap contract in tests: bare Kimi stays native; provider-qualified Ollama Cloud Kimi uses Cloud context/reasoning/vision semantics.

## Evidence

- [근거] Official sources: `https://ollama.com/api/tags`, `https://ollama.com/api/show`; checked `2026-06-21T05:01:50+09:00`; confidence High.
- `python3 -c 'import tomllib; tomllib.load(open("models.toml", "rb")); print("models.toml: OK")'`
- `git diff --check`
- `opam exec -- ocamlformat --check test/test_capabilities.ml`
- Cross-repo live audit from the MASC repo, with `--runtime /Users/dancer/me/.masc/config/runtime.toml` and `--oas-models` pointing at this OAS PR worktree's `models.toml`:
  - `official_count=35`
  - `official_vision_count=15`
  - `runtime_canonical_count=35`
  - `runtime_binding_count=35`
  - `oas_provider_qualified_count=35`
  - `oas_bare_exact_membership_count=32`
  - `oas_bare_route_count=35`
  - `vision_models=devstral-small-2:24b,gemini-3-flash-preview,gemma3:12b,gemma3:27b,gemma3:4b,gemma4:31b,kimi-k2.5,kimi-k2.6,kimi-k2.7-code,minimax-m3,ministral-3:14b,ministral-3:3b,ministral-3:8b,mistral-large-3:675b,qwen3.5:397b`
  - `status=OK`

## CI

- GitHub Actions CI run: https://github.com/jeong-sik/oas/actions/runs/27880796136
  - `headSha=a1b442306819b8c8dedeab0dcdb6a8015524ffe3`
  - `conclusion=success`
- GitHub Actions Code Smell Ratchet run: https://github.com/jeong-sik/oas/actions/runs/27878282471
  - `headSha=a1b442306819b8c8dedeab0dcdb6a8015524ffe3`
  - `conclusion=success`
- GitHub Actions PR Automation run: https://github.com/jeong-sik/oas/actions/runs/27880796129
  - `headSha=a1b442306819b8c8dedeab0dcdb6a8015524ffe3`
  - `conclusion=success`

This PR is still draft, so this head's draft-gated CI skipped the heavyweight build/test jobs. Local build/test intentionally not run per operator direction.
