### PR TITLE
fix(llm_provider): Ollama native /api/chat multimodal serialization

### DIFF
--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -256,8 +256,12 @@ let modality_priority_for_model_id model_id =
     array of content parts, Ollama's native chat API requires [content] to be a
     plain string and carries image payloads in a separate [images] array of
     base64-encoded strings. Audio is not supported by the native endpoint and
-    is dropped. *)
-let ollama_native_user_message ~modality_priority content =
+    is dropped.
+
+    Returns [None] when the message carries no representable user content (e.g.
+    an audio-only or orphaned-tool-result message), so callers do not emit an
+    empty [content:""] placeholder on the wire. *)
+let ollama_native_user_message ~modality_priority content : Yojson.Safe.t option =
   let ordered_content = Modality.reorder modality_priority content in
   let text_parts, images =
     List.fold_left
@@ -276,16 +280,21 @@ let ollama_native_user_message ~modality_priority content =
       ([], [])
       ordered_content
   in
-  let fields = [ "role", `String "user" ] in
   let text_content =
     match List.rev text_parts with
     | [] -> ""
     | parts -> String.concat "\n" parts
   in
-  let fields = ("content", `String text_content) :: fields in
   match List.rev images with
-  | [] -> `Assoc fields
-  | imgs -> `Assoc (("images", `List (List.map (fun img -> `String img) imgs)) :: fields)
+  | [] when text_content = "" -> None
+  | [] -> Some (`Assoc [ "role", `String "user"; "content", `String text_content ])
+  | imgs ->
+    Some
+      (`Assoc
+          [ "role", `String "user"
+          ; "content", `String text_content
+          ; "images", `List (List.map (fun img -> `String img) imgs)
+          ])
 ;;
 
 let ollama_messages_of_message ?(model_id = "") msg =
@@ -295,7 +304,9 @@ let ollama_messages_of_message ?(model_id = "") msg =
     (* Native /api/chat: content must be a string; images go in images array. *)
     let user_msg = ollama_native_user_message ~modality_priority msg.content in
     let tool_msgs = openai_tool_messages_of_blocks msg.content in
-    tool_msgs @ [ user_msg ]
+    (match user_msg with
+     | None -> tool_msgs
+     | Some m -> tool_msgs @ [ m ])
   | _ ->
     messages_of_message_with
       ~tool_calls_fn:tool_calls_to_ollama_json

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -272,8 +272,7 @@ let ollama_native_user_message ~modality_priority content =
          | Audio _ ->
            (* Ollama native /api/chat does not support audio input. *)
            texts, images
-         | Thinking _ | RedactedThinking _ | ToolUse _ | ToolResult _ ->
-           texts, images)
+         | Thinking _ | RedactedThinking _ | ToolUse _ | ToolResult _ -> texts, images)
       ([], [])
       ordered_content
   in
@@ -286,8 +285,7 @@ let ollama_native_user_message ~modality_priority content =
   let fields = ("content", `String text_content) :: fields in
   match List.rev images with
   | [] -> `Assoc fields
-  | imgs ->
-    `Assoc (("images", `List (List.map (fun img -> `String img) imgs)) :: fields)
+  | imgs -> `Assoc (("images", `List (List.map (fun img -> `String img) imgs)) :: fields)
 ;;
 
 let ollama_messages_of_message ?(model_id = "") msg =

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -251,11 +251,58 @@ let modality_priority_for_model_id model_id =
   | None -> Modality.Preserve_input_order
 ;;
 
+(** Ollama native [/api/chat] user message serialization.
+    Unlike OpenAI-compatible endpoints where [content] may be a string or an
+    array of content parts, Ollama's native chat API requires [content] to be a
+    plain string and carries image payloads in a separate [images] array of
+    base64-encoded strings. Audio is not supported by the native endpoint and
+    is dropped. *)
+let ollama_native_user_message ~modality_priority content =
+  let ordered_content = Modality.reorder modality_priority content in
+  let text_parts, images =
+    List.fold_left
+      (fun (texts, images) block ->
+         match block with
+         | Text s -> Utf8_sanitize.sanitize s :: texts, images
+         | Image { data; _ } | Document { data; _ } ->
+           (* Ollama native /api/chat accepts base64 image payloads in the
+              images field. Document blocks are forwarded the same way so
+              vision models can attempt to process them as pages. *)
+           texts, data :: images
+         | Audio _ ->
+           (* Ollama native /api/chat does not support audio input. *)
+           texts, images
+         | Thinking _ | RedactedThinking _ | ToolUse _ | ToolResult _ ->
+           texts, images)
+      ([], [])
+      ordered_content
+  in
+  let fields = [ "role", `String "user" ] in
+  let text_content =
+    match List.rev text_parts with
+    | [] -> ""
+    | parts -> String.concat "\n" parts
+  in
+  let fields = ("content", `String text_content) :: fields in
+  match List.rev images with
+  | [] -> `Assoc fields
+  | imgs ->
+    `Assoc (("images", `List (List.map (fun img -> `String img) imgs)) :: fields)
+;;
+
 let ollama_messages_of_message ?(model_id = "") msg =
-  messages_of_message_with
-    ~tool_calls_fn:tool_calls_to_ollama_json
-    ~modality_priority:(modality_priority_for_model_id model_id)
-    msg
+  let modality_priority = modality_priority_for_model_id model_id in
+  match msg.role with
+  | User ->
+    (* Native /api/chat: content must be a string; images go in images array. *)
+    let user_msg = ollama_native_user_message ~modality_priority msg.content in
+    let tool_msgs = openai_tool_messages_of_blocks msg.content in
+    tool_msgs @ [ user_msg ]
+  | _ ->
+    messages_of_message_with
+      ~tool_calls_fn:tool_calls_to_ollama_json
+      ~modality_priority
+      msg
 ;;
 
 (** Strip ToolResult blocks that are outside the immediate result span

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -245,23 +245,15 @@ let test_ollama_native_multimodal_variants () =
   let doc_images = member "images" doc_msg |> as_list "document images" in
   check_int "document images count" 1 (List.length doc_images);
   check_string "document payload" "pdf1" (List.nth doc_images 0 |> to_string);
-  (* Audio is not supported by Ollama native /api/chat and must not leak into images. *)
-  let audio_msg =
+  (* Audio is not supported by Ollama native /api/chat and must not leak into
+     images; an audio-only user message produces no representable wire message. *)
+  let audio_msgs =
     Serialize.ollama_messages_of_message
       (msg
          User
          [ Audio { media_type = "audio/wav"; data = "wav1"; source_type = "base64" } ])
-    |> only "ollama"
   in
-  check_string "audio content empty" "" (member "content" audio_msg |> to_string);
-  (match Yojson.Safe.Util.member "images" audio_msg with
-   | `List [] -> ()
-   | `Null -> ()
-   | other ->
-     Alcotest.fail
-       (Printf.sprintf
-          "audio message should not have images, got %s"
-          (Yojson.Safe.to_string other)));
+  check_int "audio-only produces no ollama messages" 0 (List.length audio_msgs);
   (* Mixed text + image + document preserves text in content and both payloads in images. *)
   let mixed =
     Serialize.ollama_messages_of_message

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -205,17 +205,69 @@ let test_user_multimodal_preserve_and_visual_first () =
     "openai preserves text first"
     "text"
     (List.nth openai_parts 0 |> member "type" |> to_string);
-  let visual_first =
+  let ollama =
     Serialize.ollama_messages_of_message
       ~model_id:"google/gemma-4-26B-A4B-it"
       (msg User content)
     |> only "ollama"
   in
-  let visual_parts = member "content" visual_first |> as_list "ollama content" in
-  check_string
-    "visual model moves image first"
-    "image_url"
-    (List.nth visual_parts 0 |> member "type" |> to_string)
+  (* Ollama native /api/chat requires content to be a plain string and places
+     base64 image payloads in a separate images array. *)
+  check_string "ollama content is string" "caption" (member "content" ollama |> to_string);
+  let images = member "images" ollama |> as_list "ollama images" in
+  check_int "ollama images count" 1 (List.length images);
+  check_string "ollama image payload" "jpeg" (List.nth images 0 |> to_string)
+;;
+
+let test_ollama_native_multimodal_variants () =
+  (* Image-only user message: content is an empty string, images carries the payload. *)
+  let image_only =
+    Serialize.ollama_messages_of_message
+      (msg User [ Image { media_type = "image/png"; data = "png1"; source_type = "base64" } ])
+    |> only "ollama"
+  in
+  check_string "image-only content empty" "" (member "content" image_only |> to_string);
+  let images = member "images" image_only |> as_list "image-only images" in
+  check_int "image-only images count" 1 (List.length images);
+  check_string "image-only payload" "png1" (List.nth images 0 |> to_string);
+  (* Document blocks are forwarded as images for vision-model compatibility. *)
+  let doc_msg =
+    Serialize.ollama_messages_of_message
+      (msg User [ Document { media_type = "application/pdf"; data = "pdf1"; source_type = "base64" } ])
+    |> only "ollama"
+  in
+  let doc_images = member "images" doc_msg |> as_list "document images" in
+  check_int "document images count" 1 (List.length doc_images);
+  check_string "document payload" "pdf1" (List.nth doc_images 0 |> to_string);
+  (* Audio is not supported by Ollama native /api/chat and must not leak into images. *)
+  let audio_msg =
+    Serialize.ollama_messages_of_message
+      (msg User [ Audio { media_type = "audio/wav"; data = "wav1"; source_type = "base64" } ])
+    |> only "ollama"
+  in
+  check_string "audio content empty" "" (member "content" audio_msg |> to_string);
+  (match Yojson.Safe.Util.member "images" audio_msg with
+   | `List [] -> ()
+   | `Null -> ()
+   | other ->
+     Alcotest.fail
+       (Printf.sprintf "audio message should not have images, got %s" (Yojson.Safe.to_string other)));
+  (* Mixed text + image + document preserves text in content and both payloads in images. *)
+  let mixed =
+    Serialize.ollama_messages_of_message
+      (msg
+         User
+         [ Text "describe these"
+         ; Image { media_type = "image/png"; data = "png2"; source_type = "base64" }
+         ; Document { media_type = "application/pdf"; data = "pdf2"; source_type = "base64" }
+         ])
+    |> only "ollama"
+  in
+  check_string "mixed content" "describe these" (member "content" mixed |> to_string);
+  let mixed_images = member "images" mixed |> as_list "mixed images" in
+  check_int "mixed images count" 2 (List.length mixed_images);
+  check_string "mixed first image" "png2" (List.nth mixed_images 0 |> to_string);
+  check_string "mixed second image" "pdf2" (List.nth mixed_images 1 |> to_string)
 ;;
 
 let test_assistant_tool_calls_openai_ollama_and_glm () =
@@ -1282,6 +1334,10 @@ let () =
             "multimodal ordering policies"
             `Quick
             test_user_multimodal_preserve_and_visual_first
+        ; Alcotest.test_case
+            "ollama native multimodal variants"
+            `Quick
+            test_ollama_native_multimodal_variants
         ; Alcotest.test_case
             "assistant tool calls provider variants"
             `Quick

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -223,7 +223,9 @@ let test_ollama_native_multimodal_variants () =
   (* Image-only user message: content is an empty string, images carries the payload. *)
   let image_only =
     Serialize.ollama_messages_of_message
-      (msg User [ Image { media_type = "image/png"; data = "png1"; source_type = "base64" } ])
+      (msg
+         User
+         [ Image { media_type = "image/png"; data = "png1"; source_type = "base64" } ])
     |> only "ollama"
   in
   check_string "image-only content empty" "" (member "content" image_only |> to_string);
@@ -233,7 +235,11 @@ let test_ollama_native_multimodal_variants () =
   (* Document blocks are forwarded as images for vision-model compatibility. *)
   let doc_msg =
     Serialize.ollama_messages_of_message
-      (msg User [ Document { media_type = "application/pdf"; data = "pdf1"; source_type = "base64" } ])
+      (msg
+         User
+         [ Document
+             { media_type = "application/pdf"; data = "pdf1"; source_type = "base64" }
+         ])
     |> only "ollama"
   in
   let doc_images = member "images" doc_msg |> as_list "document images" in
@@ -242,7 +248,9 @@ let test_ollama_native_multimodal_variants () =
   (* Audio is not supported by Ollama native /api/chat and must not leak into images. *)
   let audio_msg =
     Serialize.ollama_messages_of_message
-      (msg User [ Audio { media_type = "audio/wav"; data = "wav1"; source_type = "base64" } ])
+      (msg
+         User
+         [ Audio { media_type = "audio/wav"; data = "wav1"; source_type = "base64" } ])
     |> only "ollama"
   in
   check_string "audio content empty" "" (member "content" audio_msg |> to_string);
@@ -251,7 +259,9 @@ let test_ollama_native_multimodal_variants () =
    | `Null -> ()
    | other ->
      Alcotest.fail
-       (Printf.sprintf "audio message should not have images, got %s" (Yojson.Safe.to_string other)));
+       (Printf.sprintf
+          "audio message should not have images, got %s"
+          (Yojson.Safe.to_string other)));
   (* Mixed text + image + document preserves text in content and both payloads in images. *)
   let mixed =
     Serialize.ollama_messages_of_message
@@ -259,7 +269,8 @@ let test_ollama_native_multimodal_variants () =
          User
          [ Text "describe these"
          ; Image { media_type = "image/png"; data = "png2"; source_type = "base64" }
-         ; Document { media_type = "application/pdf"; data = "pdf2"; source_type = "base64" }
+         ; Document
+             { media_type = "application/pdf"; data = "pdf2"; source_type = "base64" }
          ])
     |> only "ollama"
   in

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -327,6 +327,45 @@ let test_ollama_gemma4_thinking_uses_template_token () =
        (first_message |> member "content" |> to_string))
 ;;
 
+let test_ollama_native_multimodal_request_body () =
+  (* Ollama native /api/chat rejects an array-valued content field and expects
+     images in a separate images array of base64 payloads. *)
+  let config =
+    PC.make
+      ~kind:Ollama
+      ~model_id:"gemma4:9b"
+      ~base_url:"http://localhost:11434"
+      ()
+  in
+  let messages =
+    [ { role = User
+      ; content =
+          [ Text "What is in this image?"
+          ; Image { media_type = "image/png"; data = "base64img"; source_type = "base64" }
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let body = BOL.build_request ~config ~messages () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  let user_msg = json |> member "messages" |> index 0 in
+  Alcotest.(check string) "role" "user" (user_msg |> member "role" |> to_string);
+  Alcotest.(check string)
+    "content is plain string"
+    "What is in this image?"
+    (user_msg |> member "content" |> to_string);
+  let images = user_msg |> member "images" |> to_list in
+  Alcotest.(check int) "images count" 1 (List.length images);
+  Alcotest.(check string) "image payload" "base64img" (List.nth images 0 |> to_string);
+  (* Verify the overall body still carries model/stream/keep_alive as before. *)
+  Alcotest.(check string) "model" "gemma4:9b" (json |> member "model" |> to_string);
+  Alcotest.(check bool) "stream" false (json |> member "stream" |> to_bool)
+;;
+
 let test_ollama_parse_parallel_tool_calls_object_arguments () =
   let body =
     {|{"model":"dashscope-3:8b","done":true,"done_reason":"tool_calls",
@@ -1116,6 +1155,10 @@ let () =
             "ollama gemma4 thinking uses template token"
             `Quick
             test_ollama_gemma4_thinking_uses_template_token
+        ; test_case
+            "ollama native multimodal request body"
+            `Quick
+            test_ollama_native_multimodal_request_body
         ; test_case
             "ollama parse parallel tool calls object args"
             `Quick

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -331,11 +331,7 @@ let test_ollama_native_multimodal_request_body () =
   (* Ollama native /api/chat rejects an array-valued content field and expects
      images in a separate images array of base64 payloads. *)
   let config =
-    PC.make
-      ~kind:Ollama
-      ~model_id:"gemma4:9b"
-      ~base_url:"http://localhost:11434"
-      ()
+    PC.make ~kind:Ollama ~model_id:"gemma4:9b" ~base_url:"http://localhost:11434" ()
   in
   let messages =
     [ { role = User


### PR DESCRIPTION
Ollama native /api/chat expects user message content as a plain string and image payloads in a separate `images` array. The previous serializer emitted OpenAI-compatible array-valued `content`, causing the Go runtime to reject multimodal turns with:

> json: cannot unmarshal array into Go struct field ChatRequest.messages.content of type string

Changes:
- `ollama_messages_of_message` now routes Image/Document payloads to `images` and keeps text in `content`.
- Audio blocks are dropped (native /api/chat does not support audio input).
- Added adversarial tests for image-only, document, audio, mixed text+image+document payloads, and a full `Backend_ollama.build_request` round-trip.

Local verification:
- `test_backend_openai_codec`: 31/31 pass
- `test_provider_complete`: 40/40 pass
- `test_llm_provider_cov`: 142/142 pass
- MASC `test_gate_keeper_backend`: 53/53 pass
- MASC `test_runtime_modality_reroute`: 10/10 pass