### PR TITLE
fix(build): unify mcp_protocol dependency names

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -19,9 +19,7 @@
   unix
   re
   str
-  mcp_protocol
-  mcp_protocol.eio
-  mcp_protocol.http)
+  mcp_protocol_bundle)
  (flags
   (:standard -open Agent_sdk_base -open Agent_sdk_protocol))
  (inline_tests)

--- a/lib/mcp_protocol_bundle/dune
+++ b/lib/mcp_protocol_bundle/dune
@@ -1,0 +1,9 @@
+(include_subdirs no)
+
+(library
+ (name mcp_protocol_bundle)
+ (public_name agent_sdk.mcp_protocol_bundle)
+ (libraries
+  (re_export mcp_protocol)
+  (re_export mcp_protocol.eio)
+  (re_export mcp_protocol.http)))

--- a/lib/mcp_protocol_bundle/mcp_protocol_bundle.ml
+++ b/lib/mcp_protocol_bundle/mcp_protocol_bundle.ml
@@ -1,0 +1,6 @@
+(** Dependency bundle for the pinned [mcp_protocol] package.
+
+    This private library exists so that the canonical findlib names
+    ([mcp_protocol], [mcp_protocol.eio], [mcp_protocol.http]) are declared
+    in exactly one dune file. Internal consumers link against this bundle
+    instead of repeating the upstream library names. *)

--- a/lib/protocol/dune
+++ b/lib/protocol/dune
@@ -8,9 +8,7 @@
   agent_sdk.base
   yojson
   eio
-  mcp_protocol
-  mcp_protocol.eio
-  mcp_protocol.http)
+  mcp_protocol_bundle)
  (flags
   (:standard -open Agent_sdk_base))
  (inline_tests)


### PR DESCRIPTION
## Summary

Centralize the canonical `mcp_protocol` library names (`mcp_protocol`, `mcp_protocol.eio`, `mcp_protocol.http`) in a single `agent_sdk.mcp_protocol_bundle` library so they are declared in exactly one dune file.

Internal consumers (`agent_sdk` and `agent_sdk.protocol`) now link against the bundle instead of repeating the upstream library names. The bundle re-exports the upstream modules without changing the public `agent_sdk` API surface.

## Motivation

The Phase 1 design (PR-OAS-1) asked to sync MCP dependency names to the canonical dotted form used by the pinned `mcp_protocol` package and to avoid string duplication. The names were already canonical; this change removes the remaining duplication across `lib/dune` and `lib/protocol/dune`.

## Local verification

```bash
# Package build
DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix/oas-mcp-dependency-names/_build \
  dune build --root . -p agent_sdk @install

# Focused MCP tests
DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix/oas-mcp-dependency-names/_build \
  dune build --root . ./test/test_mcp.exe ./test/test_mcp_http.exe ./test/test_mcp_session.exe
./_build/default/test/test_mcp.exe        # 23 tests pass
./_build/default/test/test_mcp_http.exe   # 11 tests pass
./_build/default/test/test_mcp_session.exe # 15 tests pass
```

## Adversarial self-review

1. **Security**: no new handlers, auth paths, mutable state, or information leakage; purely build-time dependency reshaping.
2. **Type safety / string matching**: no stringly-typed decisions introduced; the canonical names are now in a single dune file.
3. **Silent failures**: none; build errors are surfaced by dune.
4. **SSOT**: upstream library names live in one dune file; version and pin SSOT remain `scripts/mcp-sdk-pin.sh` and `agent_sdk.opam`.
5. **Immutability**: n/a (build configuration).
6. **Public API impact**: the bundle is public (`agent_sdk.mcp_protocol_bundle`) because Dune requires public libraries to depend on public libraries; `agent_sdk` itself does not re-export it, so the external API surface is unchanged.
