### PR TITLE
feat(sessions): add participant_by_name accessor to Sessions facade

### DIFF
--- a/lib/sessions.ml
+++ b/lib/sessions.ml
@@ -7,3 +7,9 @@
 
 include Sessions_types
 include Sessions_store
+
+let participant_by_name (session : Runtime.session) name =
+  List.find_opt
+    (fun (participant : Runtime.participant) -> String.equal participant.name name)
+    session.participants
+;;

--- a/lib/sessions.mli
+++ b/lib/sessions.mli
@@ -14,7 +14,9 @@ include module type of Sessions_store
 
 (** {1 Participant lookup} *)
 
-(** [participant_by_name session name] returns the participant whose
-    [name] matches [name] exactly, or [None] if no such participant exists.
-    The lookup is case-sensitive and does not inspect aliases. *)
+(** [participant_by_name session name] returns the first participant (in
+    [session.participants] order) whose [name] equals [name] exactly, or
+    [None] if none match. If several participants share [name], only the
+    first is returned. The lookup is case-sensitive and does not inspect
+    aliases. *)
 val participant_by_name : Runtime.session -> string -> Runtime.participant option

--- a/lib/sessions.mli
+++ b/lib/sessions.mli
@@ -11,3 +11,10 @@
 
 include module type of Sessions_types
 include module type of Sessions_store
+
+(** {1 Participant lookup} *)
+
+(** [participant_by_name session name] returns the participant whose
+    [name] matches [name] exactly, or [None] if no such participant exists.
+    The lookup is case-sensitive and does not inspect aliases. *)
+val participant_by_name : Runtime.session -> string -> Runtime.participant option

--- a/test/test_runtime_projection_cov2.ml
+++ b/test/test_runtime_projection_cov2.ml
@@ -349,7 +349,9 @@ let test_apply_agent_spawn () =
   match Runtime_projection.apply_event session event with
   | Ok s ->
     let bob =
-      List.find (fun (p : Runtime.participant) -> p.name = "bob") s.participants
+      match Sessions.participant_by_name s "bob" with
+      | Some p -> p
+      | None -> Alcotest.fail "participant 'bob' not found"
     in
     Alcotest.(check bool) "state Starting" true (bob.state = Starting);
     Alcotest.(check (option string)) "role" (Some "reviewer") bob.role;
@@ -775,7 +777,9 @@ let test_apply_event_sequence () =
     Alcotest.(check int) "turn_count" 1 final.turn_count;
     Alcotest.(check (option string)) "outcome" (Some "success") final.outcome;
     let alice =
-      List.find (fun (p : Runtime.participant) -> p.name = "alice") final.participants
+      match Sessions.participant_by_name final "alice" with
+      | Some p -> p
+      | None -> Alcotest.fail "participant 'alice' not found"
     in
     Alcotest.(check bool) "alice Done" true (alice.state = Done)
   | Error e -> Alcotest.fail (Error.to_string e)

--- a/test/test_runtime_projection_cov2.ml
+++ b/test/test_runtime_projection_cov2.ml
@@ -93,6 +93,12 @@ let mk_participant ?(name = "alice") ?(state = Runtime.Planned) ?(started_at = N
   }
 ;;
 
+let find_proof_check (checks : Runtime.proof_check list) name =
+  match List.find_opt (fun (c : Runtime.proof_check) -> c.name = name) checks with
+  | Some c -> c
+  | None -> Alcotest.fail ("proof_check not found: " ^ name)
+;;
+
 (* ── initial_session ──────────────────────────────────── *)
 
 let test_initial_session_basic () =
@@ -662,7 +668,7 @@ let test_build_proof_failing () =
   Alcotest.(check bool) "proof not ok" false proof.ok;
   (* seq_contiguous should fail for empty events *)
   let seq_check =
-    List.find (fun (c : Runtime.proof_check) -> c.name = "seq_contiguous") proof.checks
+    find_proof_check proof.checks "seq_contiguous"
   in
   Alcotest.(check bool) "seq_contiguous fails" false seq_check.passed
 ;;
@@ -688,9 +694,7 @@ let test_build_proof_duplicate_artifact_ids () =
   in
   let proof = Runtime_projection.build_proof session events in
   let artifact_check =
-    List.find
-      (fun (c : Runtime.proof_check) -> c.name = "artifact_ids_unique")
-      proof.checks
+    find_proof_check proof.checks "artifact_ids_unique"
   in
   Alcotest.(check bool) "artifact_ids_unique fails" false artifact_check.passed
 ;;
@@ -704,7 +708,7 @@ let test_build_proof_non_contiguous_seq () =
   in
   let proof = Runtime_projection.build_proof session events in
   let seq_check =
-    List.find (fun (c : Runtime.proof_check) -> c.name = "seq_contiguous") proof.checks
+    find_proof_check proof.checks "seq_contiguous"
   in
   Alcotest.(check bool) "seq_contiguous fails" false seq_check.passed
 ;;

--- a/test/test_sessions_cov2.ml
+++ b/test/test_sessions_cov2.ml
@@ -516,6 +516,85 @@ let test_evidence_capabilities () =
     v2
 ;;
 
+(* ── Participant lookup ─────────────────────────────────────────── *)
+
+let make_participant name : Runtime.participant =
+  let open Runtime in
+  { name
+  ; role = None
+  ; aliases = []
+  ; worker_id = None
+  ; runtime_actor = Some name
+  ; requested_provider = None
+  ; requested_model = None
+  ; requested_policy = None
+  ; provider = None
+  ; model = None
+  ; resolved_provider = None
+  ; resolved_model = None
+  ; state = Planned
+  ; summary = None
+  ; accepted_at = None
+  ; ready_at = None
+  ; first_progress_at = None
+  ; started_at = None
+  ; finished_at = None
+  ; last_progress_at = None
+  ; last_error = None
+  }
+;;
+
+let make_session participants : Runtime.session =
+  let open Runtime in
+  { session_id = "s-test"
+  ; goal = "test"
+  ; title = None
+  ; tag = None
+  ; permission_mode = None
+  ; phase = Bootstrapping
+  ; created_at = 0.0
+  ; updated_at = 0.0
+  ; provider = None
+  ; model = None
+  ; system_prompt = None
+  ; max_turns = 8
+  ; workdir = None
+  ; planned_participants = List.map (fun (p : participant) -> p.name) participants
+  ; participants
+  ; artifacts = []
+  ; pending_input = None
+  ; turn_count = 0
+  ; last_seq = 0
+  ; outcome = None
+  }
+;;
+
+let participant_name_opt result =
+  let open Runtime in
+  Option.map (fun (p : participant) -> p.name) result
+;;
+
+let test_participant_by_name_found () =
+  let session = make_session [ make_participant "alice"; make_participant "bob" ] in
+  let result = Sessions.participant_by_name session "alice" in
+  Alcotest.(check (option string))
+    "finds alice"
+    (Some "alice")
+    (participant_name_opt result)
+;;
+
+let test_participant_by_name_not_found () =
+  let session = make_session [ make_participant "alice" ] in
+  let result = Sessions.participant_by_name session "carol" in
+  Alcotest.(check (option string)) "not found" None (participant_name_opt result)
+;;
+
+let test_participant_by_name_empty () =
+  let session = make_session [] in
+  let result = Sessions.participant_by_name session "anyone" in
+  Alcotest.(check (option string)) "empty" None (participant_name_opt result)
+;;
+
 (* ── Suite ─────────────────────────────────────────────────────── *)
 
 let () =
@@ -556,5 +635,10 @@ let () =
         ] )
     ; ( "evidence_capabilities"
       , [ Alcotest.test_case "roundtrip" `Quick test_evidence_capabilities ] )
+    ; ( "participant_by_name"
+      , [ Alcotest.test_case "found" `Quick test_participant_by_name_found
+        ; Alcotest.test_case "not_found" `Quick test_participant_by_name_not_found
+        ; Alcotest.test_case "empty" `Quick test_participant_by_name_empty
+        ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

Add `participant_by_name` to the `Sessions` public facade. Looking up a
participant by name is a session operation over OAS-owned types
(`Runtime.session.participants`, `Runtime.participant.name`), so it belongs on
the `Sessions` facade rather than being reimplemented by each consumer.

## Changes

- `lib/sessions.mli` / `lib/sessions.ml`: add
  `val participant_by_name : Runtime.session -> string -> Runtime.participant option`,
  implemented as a pure `List.find_opt` over `session.participants`. Total
  (option-returning), case-sensitive, no alias inspection.
- `test/test_sessions_cov2.ml`: unit tests for the accessor (found / not_found / empty).
- `test/test_runtime_projection_cov2.ml`: migrate two inline partial `List.find`
  participant lookups to the new total accessor; totalize three `proof.checks`
  lookups via a local `find_proof_check` helper (same partial→total class, kept
  test-internal because `proof.checks` is an assertion detail with no consumer).

## Why a public accessor (correcting the earlier framing)

An earlier revision justified this export "for coverage instrumentation." That
framing was wrong and is corrected here. The function is a legitimate
session-facade accessor, and its real downstream consumer is masc, which today
carries a byte-identical reimplementation at
`lib/cdal_runtime/sessions_proof.ml` (`participant_by_name`, used by
`worker_run_of_raw`).

## SSOT follow-up (cross-repo)

This PR is step 1 of consolidating that duplication onto a single owner (the
SDK that defines the types). Step 2 — a separate masc PR, blocked on this merge
— bumps masc's OAS git-pin to this merge SHA, deletes masc's local
`participant_by_name`, and calls `Agent_sdk.Sessions.participant_by_name`. Until
step 2 lands, the accessor's only callers are OAS tests; that window is
intentional and tracked in jeong-sik/masc#22192.

Note on RFC-OAS-011: that migration moved proof-bundle *assembly* downstream
(masc keeps `worker_run_of_raw` / bundle construction). Re-homing a generic leaf
accessor to the `Sessions` facade does not reverse that migration.

## Verification

Local builds are not run here per the repo's CI-first workflow; CI is
authoritative. The participant migration is type-preserving (old and new lookups
both yield `Runtime.participant`). No new auth paths, no mutation, no string
heuristics; every lookup path is explicit (`option` / explicit test failure).
