### PR TITLE
fix(protocol): include _meta in tool_result records for mcp_protocol 0.16

### DIFF
--- a/examples/async_agent_demo.ml
+++ b/examples/async_agent_demo.ml
@@ -47,7 +47,8 @@ let read_only_tool =
     (fun args ->
        let open Yojson.Safe.Util in
        match args |> member "key" |> to_string_option with
-       | Some key -> Ok { Types.content = Printf.sprintf "value for %s" key }
+       | Some key ->
+         Ok { Types.content = Printf.sprintf "value for %s" key; _meta = None }
        | None ->
          Error
            { Types.message = "missing 'key' parameter"
@@ -87,7 +88,7 @@ let external_fetch_tool =
     (fun args ->
        let open Yojson.Safe.Util in
        match args |> member "url" |> to_string_option with
-       | Some url -> Ok { Types.content = Printf.sprintf "Fetched: %s" url }
+       | Some url -> Ok { Types.content = Printf.sprintf "Fetched: %s" url; _meta = None }
        | None ->
          Error
            { Types.message = "missing 'url' parameter"

--- a/examples/builder_patterns.ml
+++ b/examples/builder_patterns.ml
@@ -42,7 +42,7 @@ let demo_full () =
   @@ fun env ->
   let echo_tool =
     Tool.create ~name:"echo" ~description:"Echo input" ~parameters:[] (fun _input ->
-      Ok { content = "echoed" })
+      Ok { content = "echoed"; _meta = None })
   in
   let hooks =
     { Hooks.empty with

--- a/examples/codegen_agent.ml
+++ b/examples/codegen_agent.ml
@@ -59,8 +59,8 @@ let typecheck_tool =
          Sys.remove tmp;
          let output = Buffer.contents buf in
          if String.length output < 20
-         then Ok { content = "Typecheck passed (no errors)." }
-         else Ok { content = Printf.sprintf "Compiler output:\n%s" output })
+         then Ok { content = "Typecheck passed (no errors)."; _meta = None }
+         else Ok { content = Printf.sprintf "Compiler output:\n%s" output; _meta = None })
 ;;
 
 let format_tool =
@@ -102,7 +102,7 @@ let format_tool =
           | End_of_file -> ());
          ignore (Unix.close_process_in ic);
          Sys.remove tmp;
-         Ok { content = Buffer.contents buf })
+         Ok { content = Buffer.contents buf; _meta = None })
 ;;
 
 let write_file_tool =
@@ -148,6 +148,7 @@ let write_file_tool =
            close_out oc;
            Ok
              { content = Printf.sprintf "Written %d bytes to %s" (String.length code) path
+             ; _meta = None
              }
          with
          | exn ->

--- a/examples/error_handling.ml
+++ b/examples/error_handling.ml
@@ -27,7 +27,7 @@ let fragile_tool =
     (fun args ->
        let path = Yojson.Safe.Util.(args |> member "path" |> to_string) in
        if Sys.file_exists path
-       then Ok { content = Printf.sprintf "Contents of %s: [data]" path }
+       then Ok { content = Printf.sprintf "Contents of %s: [data]" path; _meta = None }
        else
          Error
            { message = Printf.sprintf "File not found: %s" path

--- a/examples/hooks_and_guardrails.ml
+++ b/examples/hooks_and_guardrails.ml
@@ -31,7 +31,10 @@ let list_files_tool =
       ]
     (fun args ->
        let path = Yojson.Safe.Util.(args |> member "path" |> to_string) in
-       Ok { content = Printf.sprintf "file1.txt\nfile2.ml\nREADME.md (in %s)" path })
+       Ok
+         { content = Printf.sprintf "file1.txt\nfile2.ml\nREADME.md (in %s)" path
+         ; _meta = None
+         })
 ;;
 
 let delete_file_tool =
@@ -47,7 +50,7 @@ let delete_file_tool =
       ]
     (fun args ->
        let path = Yojson.Safe.Util.(args |> member "path" |> to_string) in
-       Ok { content = Printf.sprintf "Deleted %s" path })
+       Ok { content = Printf.sprintf "Deleted %s" path; _meta = None })
 ;;
 
 (* ── Hooks ───────────────────────────────────────────── *)

--- a/examples/observable_agent.ml
+++ b/examples/observable_agent.ml
@@ -44,7 +44,7 @@ let print_event (event : Event_bus.event) =
   | ToolCompleted { agent_name; tool_name; output; turn = _ } ->
     let status =
       match output with
-      | Ok { content } -> green (Printf.sprintf "ok: %s" content)
+      | Ok { content; _meta = _ } -> green (Printf.sprintf "ok: %s" content)
       | Error { message; _ } -> Printf.sprintf "\027[31merr: %s\027[0m" message
     in
     Printf.eprintf
@@ -121,7 +121,7 @@ let calculator_tool =
       ]
     (fun args ->
        let expr = Yojson.Safe.Util.(args |> member "expression" |> to_string) in
-       Ok { content = Printf.sprintf "%s = 42" expr })
+       Ok { content = Printf.sprintf "%s = 42" expr; _meta = None })
 ;;
 
 let get_time_tool =
@@ -131,7 +131,10 @@ let get_time_tool =
     ~parameters:[]
     (fun _args ->
        let tm = Unix.localtime (Unix.gettimeofday ()) in
-       Ok { content = Printf.sprintf "%02d:%02d:%02d" tm.tm_hour tm.tm_min tm.tm_sec })
+       Ok
+         { content = Printf.sprintf "%02d:%02d:%02d" tm.tm_hour tm.tm_min tm.tm_sec
+         ; _meta = None
+         })
 ;;
 
 (* ── Mock HTTP server (fallback) ─────────────────────── *)

--- a/examples/review_agent.ml
+++ b/examples/review_agent.ml
@@ -66,7 +66,7 @@ let get_pr_info_tool =
            ; "title,body,additions,deletions,changedFiles,labels"
            ]
        with
-       | Ok output -> Ok { content = output }
+       | Ok output -> Ok { content = output; _meta = None }
        | Error msg -> Error { message = msg; recoverable = true; error_class = None })
 ;;
 
@@ -132,7 +132,7 @@ let get_pr_diff_tool =
            then String.sub filtered 0 max_len ^ "\n... [truncated]"
            else filtered
          in
-         Ok { content = result })
+         Ok { content = result; _meta = None })
 ;;
 
 let post_review_tool =
@@ -172,7 +172,10 @@ let post_review_tool =
        Sys.remove tmp;
        match result with
        | Ok output ->
-         Ok { content = Printf.sprintf "Review posted. %s" (String.trim output) }
+         Ok
+           { content = Printf.sprintf "Review posted. %s" (String.trim output)
+           ; _meta = None
+           }
        | Error msg -> Error { message = msg; recoverable = true; error_class = None })
 ;;
 

--- a/examples/tool_use.ml
+++ b/examples/tool_use.ml
@@ -52,7 +52,8 @@ let calculator_tool =
     (fun args ->
        let open Yojson.Safe.Util in
        match args |> member "expression" |> to_string_option with
-       | Some expr -> Ok { Types.content = Printf.sprintf "Result of '%s': 42" expr }
+       | Some expr ->
+         Ok { Types.content = Printf.sprintf "Result of '%s': 42" expr; _meta = None }
        | None ->
          Error
            { Types.message = "missing 'expression' parameter"
@@ -86,7 +87,8 @@ let weather_api_tool =
     (fun args ->
        let open Yojson.Safe.Util in
        match args |> member "city" |> to_string_option with
-       | Some city -> Ok { Types.content = Printf.sprintf "Weather in %s: sunny" city }
+       | Some city ->
+         Ok { Types.content = Printf.sprintf "Weather in %s: sunny" city; _meta = None }
        | None ->
          Error
            { Types.message = "missing 'city' parameter"
@@ -120,7 +122,7 @@ let counter_tool =
          | _ -> 1
        in
        Context.set ctx "count" (`Int n);
-       Ok { Types.content = string_of_int n })
+       Ok { Types.content = string_of_int n; _meta = None })
 ;;
 
 let () =

--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -450,6 +450,7 @@ let to_builder ?sw ?mgr ~net (cfg : agent_file_config) =
                       "[%s] called with %s"
                       tc.name
                       (Yojson.Safe.to_string input)
+                ; _meta = None
                 }))
       cfg.tools
   in

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -460,7 +460,7 @@ let find_and_execute_tool_with_index
               let duration_ms = (Unix.gettimeofday () -. t0) *. 1000.0 in
               let result_bytes =
                 match result with
-                | Ok { content } -> String.length content
+                | Ok { content; _meta = _ } -> String.length content
                 | Error { message; _ } -> String.length message
               in
               let _post =
@@ -516,7 +516,7 @@ let find_and_execute_tool_with_index
                | Ok _ -> ());
               let content, is_error, failure_kind, error_class =
                 match result with
-                | Ok { content } -> content, false, None, None
+                | Ok { content; _meta = _ } -> content, false, None, None
                 | Error { message; recoverable; error_class } ->
                   let failure_kind =
                     Some
@@ -590,7 +590,7 @@ let find_and_execute_tool_with_index
            ; recoverable = recoverable_of_failure_kind result.failure_kind
            ; error_class = result.error_class
            }
-       else Ok { content = output_content }
+       else Ok { content = output_content; _meta = None }
      in
      (try
         Event_bus.publish

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -349,7 +349,7 @@ let resolve_turn_params ~hooks ~messages ~max_turns ~turn ~invoke_hook =
                         (Error
                            { message = content; recoverable = true; error_class = None }
                          : tool_result)
-                    else Some (Ok { content } : tool_result)
+                    else Some (Ok { content; _meta = None } : tool_result)
                   | Text _
                   | Thinking _
                   | RedactedThinking _
@@ -424,7 +424,7 @@ let apply_context_injection ~context ~messages ~injector ~tool_uses ~results =
                ; recoverable = recoverable_of_failure_kind result.failure_kind
                ; error_class = result.error_class
                }
-           else Ok { content = result.content }
+           else Ok { content = result.content; _meta = None }
          in
          (try
             match injector ~tool_name:name ~input ~output with

--- a/lib/agent/agent_turn_budget.ml
+++ b/lib/agent/agent_turn_budget.ml
@@ -125,7 +125,7 @@ let make_tool ~agent_ref ~budget ?(max_idle_before_extend = 2) () =
           (current_max budget)
           budget.ceiling
       in
-      Ok { content = msg }
+      Ok { content = msg; _meta = None }
     | Ok () ->
       (match try_extend budget ~additional ~reason with
        | Error reason_code ->
@@ -138,7 +138,7 @@ let make_tool ~agent_ref ~budget ?(max_idle_before_extend = 2) () =
              (extensions_count budget)
              budget.max_extensions
          in
-         Ok { content = msg }
+         Ok { content = msg; _meta = None }
        | Ok result ->
          (* Apply to agent state *)
          (match !agent_ref with
@@ -159,7 +159,7 @@ let make_tool ~agent_ref ~budget ?(max_idle_before_extend = 2) () =
              budget.max_extensions
              reason
          in
-         Ok { content = msg })
+         Ok { content = msg; _meta = None })
   in
   Tool.create
     ~name:"extend_turns"

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -15,7 +15,7 @@
         }]
         (fun input ->
            let loc = Yojson.Safe.Util.(input |> member "location" |> to_string) in
-           Ok { Types.content = Printf.sprintf "Weather in %s: Sunny, 22C" loc })
+           Ok { Types.content = Printf.sprintf "Weather in %s: Sunny, 22C" loc; _meta = None })
 
       let () =
         Eio_main.run @@ fun env ->

--- a/lib/agent_tool.ml
+++ b/lib/agent_tool.ml
@@ -167,7 +167,7 @@ let make_handler config : Tool.tool_handler =
       | Some summarize -> summarize text
       | None -> text
     in
-    Ok { content = output }
+    Ok { content = output; _meta = None }
   | Error e ->
     Error { message = Error.to_string e; recoverable = false; error_class = None }
 ;;
@@ -247,14 +247,14 @@ let%test "tool has prompt parameter" =
 let%test "handler returns agent text" =
   let tool = create_simple ~name:"t" ~description:"d" (mock_runner "agent says hello") in
   match Tool.execute tool (`Assoc [ "prompt", `String "hi" ]) with
-  | Ok { content } -> content = "agent says hello"
+  | Ok { content; _meta = _ } -> content = "agent says hello"
   | Error _ -> false
 ;;
 
 let%test "handler with string input" =
   let tool = create_simple ~name:"t" ~description:"d" (mock_runner "ok") in
   match Tool.execute tool (`String "direct prompt") with
-  | Ok { content } -> content = "ok"
+  | Ok { content; _meta = _ } -> content = "ok"
   | Error _ -> false
 ;;
 
@@ -276,7 +276,7 @@ let%test "output_summarizer applied" =
       }
   in
   match Tool.execute tool (`Assoc [ "prompt", `String "q" ]) with
-  | Ok { content } -> content = "long"
+  | Ok { content; _meta = _ } -> content = "long"
   | Error _ -> false
 ;;
 

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -56,7 +56,12 @@ let param_type_to_string = function
 (** Tool execution result types.
     Defined before content_block/message/api_response to avoid
     field-name shadowing on the [content] record field. *)
-type tool_output = { content : string }
+type tool_output =
+  { content : string
+  ; _meta : Yojson.Safe.t option
+    (** Optional structured metadata forwarded to the MCP [tool_result._meta]
+        field. [None] omits the field on the wire. *)
+  }
 
 type tool_error_class =
   | Transient

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -37,7 +37,12 @@ type param_type =
 val param_type_to_string : param_type -> string
 
 (** Tool execution result types. *)
-type tool_output = { content : string }
+type tool_output =
+  { content : string
+  ; _meta : Yojson.Safe.t option
+    (** Optional structured metadata forwarded to the MCP [tool_result._meta]
+        field. [None] omits the field on the wire. *)
+  }
 
 type tool_error_class =
   | Transient

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -1041,7 +1041,7 @@ let%test "last_tool_results_from finds tool results in last tool message" =
     ]
   in
   match last_tool_results_from msgs with
-  | [ Ok { content = "result1" }
+  | [ Ok { content = "result1"; _meta = _ }
     ; Error { message = "error msg"; recoverable = true; error_class = None }
     ] -> true
   | _ -> false
@@ -1080,7 +1080,7 @@ let%test "last_tool_results_from skips non-tool user messages" =
   (* Should find the legacy user-role tool result since the last user message
      has no tool results. *)
   match last_tool_results_from msgs with
-  | [ Ok { content = "first" } ] -> true
+  | [ Ok { content = "first"; _meta = _ } ] -> true
   | _ -> false
 ;;
 
@@ -1156,7 +1156,7 @@ let%test "last_tool_results_from picks last tool-result message" =
     ]
   in
   match last_tool_results_from msgs with
-  | [ Ok { content = "second" } ] -> true
+  | [ Ok { content = "second"; _meta = _ } ] -> true
   | _ -> false
 ;;
 
@@ -1181,7 +1181,7 @@ let%test "last_tool_results_from mixed content in user message" =
     ]
   in
   match last_tool_results_from msgs with
-  | [ Ok { content = "ok" } ] -> true
+  | [ Ok { content = "ok"; _meta = _ } ] -> true
   | _ -> false
 ;;
 

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -85,7 +85,7 @@ let tool_result_of_projection (proj : Llm_provider.Canonical_tool.provider_tool_
   =
   if proj.is_error
   then Error { Types.message = proj.content; recoverable = true; error_class = None }
-  else Ok { Types.content = proj.content }
+  else Ok { Types.content = proj.content; _meta = None }
 ;;
 
 let role_can_carry_tool_results = function
@@ -117,7 +117,7 @@ let last_tool_results_from messages =
    path routes [ToolResult] blocks through
    [Canonical_tool.tool_result_of_block] and lowers the projection back to
    [Types.tool_result]. A result carrying a [json] (WP4 structured) payload
-   must still lower to [Ok {content}] — the projection surfaces
+   must still lower to [Ok { content; _meta = None }] — the projection surfaces
    [structured_content] without disturbing the existing string contract. *)
 let%test "last_tool_results_from routes through canonical projection (with json)" =
   let msgs =
@@ -145,7 +145,7 @@ let%test "last_tool_results_from routes through canonical projection (with json)
     ]
   in
   match last_tool_results_from msgs with
-  | [ Ok { content = "ok payload" }
+  | [ Ok { content = "ok payload"; _meta = _ }
     ; Error { message = "boom"; recoverable = true; error_class = None }
     ] -> true
   | _ -> false

--- a/lib/protocol/mcp.ml
+++ b/lib/protocol/mcp.ml
@@ -235,7 +235,7 @@ let call_tool t ~name ~arguments : Types.tool_result =
     let text = text_of_tool_result result in
     if Option.value ~default:false result.Sdk_types.is_error
     then Error { message = text; recoverable = true; error_class = None }
-    else Ok { content = text }
+    else Ok { content = text; _meta = None }
 ;;
 
 (** Convert MCP tools to SDK [Tool.t] list.

--- a/lib/protocol/mcp_http.ml
+++ b/lib/protocol/mcp_http.ml
@@ -65,7 +65,7 @@ let call_tool t ~name ~arguments =
     let content = Mcp.text_of_tool_result result in
     if Option.value ~default:false result.Mcp_schema.Sdk_types.is_error
     then Error { Types.message = content; recoverable = true; error_class = None }
-    else Ok { Types.content }
+    else Ok { Types.content; _meta = None }
 ;;
 
 let close t = ignore (Sdk_http_client.close t.client)

--- a/lib/tool_index.ml
+++ b/lib/tool_index.ml
@@ -571,7 +571,9 @@ let%test "retrieve_within excludes confiscated tools" =
 
 (* ── Rebuild / remove_entries tests ──────────────── *)
 
-let _dummy_handler : Tool.tool_handler = fun _args -> Ok { Types.content = "ok" }
+let _dummy_handler : Tool.tool_handler =
+  fun _args -> Ok { Types.content = "ok"; _meta = None }
+;;
 
 let _mk_tool name desc : Tool.t =
   { schema = { name; description = desc; parameters = []; strict = None }

--- a/lib/typed_tool.ml
+++ b/lib/typed_tool.ml
@@ -67,7 +67,7 @@ let execute ?context tool json =
      | Ok output ->
        let json_output = tool.encode output in
        let content = Yojson.Safe.to_string json_output in
-       Ok { Types.content }
+       Ok { Types.content; _meta = None }
      | Error e -> Error { Types.message = e; recoverable = false; error_class = None })
 ;;
 

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -185,7 +185,7 @@ let test_agent_run_tool_use () =
             ; required = true
             }
           ]
-        (fun _input -> Ok { Types.content = "12:00 UTC" })
+        (fun _input -> Ok { Types.content = "12:00 UTC"; _meta = None })
     in
     let agent = make_agent ~net:env#net ~tools:[ time_tool ] ~max_turns:5 url in
     match Agent.run ~sw agent "what time is it?" with
@@ -218,7 +218,7 @@ let test_agent_run_max_turns () =
         ~name:"loop_tool"
         ~description:"Always called"
         ~parameters:[]
-        (fun _input -> Ok { Types.content = "looped" })
+        (fun _input -> Ok { Types.content = "looped"; _meta = None })
     in
     let agent = make_agent ~net:env#net ~tools:[ loop_tool ] ~max_turns:2 url in
     match Agent.run ~sw agent "loop" with
@@ -405,7 +405,7 @@ let test_agent_run_pre_tool_hook () =
         ~name:"blocked_tool"
         ~description:"Should be blocked"
         ~parameters:[]
-        (fun _input -> Ok { Types.content = "should not run" })
+        (fun _input -> Ok { Types.content = "should not run"; _meta = None })
     in
     let hooks = { Hooks.empty with pre_tool_use = Some (fun _event -> Hooks.Skip) } in
     let agent = make_agent ~net:env#net ~tools:[ blocked_tool ] ~hooks ~max_turns:3 url in

--- a/test/test_agent_race.ml
+++ b/test/test_agent_race.ml
@@ -11,7 +11,7 @@ open Agent_sdk
 let make_agent env =
   let tools =
     [ Tool.create ~name:"echo" ~description:"echo" ~parameters:[] (fun input ->
-        Ok { Types.content = Yojson.Safe.to_string input })
+        Ok { Types.content = Yojson.Safe.to_string input; _meta = None })
     ]
   in
   Agent.create ~net:(Eio.Stdenv.net env) ~tools ()

--- a/test/test_agent_sdk.ml
+++ b/test/test_agent_sdk.ml
@@ -29,11 +29,11 @@ let test_simple_tool () =
         ]
       (fun input ->
          let msg = Yojson.Safe.Util.(input |> member "msg" |> to_string) in
-         Ok { Types.content = msg })
+         Ok { Types.content = msg; _meta = None })
   in
   let input = `Assoc [ "msg", `String "hello" ] in
   match Tool.execute tool input with
-  | Ok { content } -> Alcotest.(check string) "echo output" "hello" content
+  | Ok { content; _meta = _ } -> Alcotest.(check string) "echo output" "hello" content
   | Error _ -> Alcotest.fail "Tool execution failed"
 ;;
 

--- a/test/test_agent_tool.ml
+++ b/test/test_agent_tool.ml
@@ -81,14 +81,15 @@ let test_execute_with_prompt () =
     Agent_tool.create_simple ~name:"echo" ~description:"Echo agent" echo_runner
   in
   match Tool.execute tool (`Assoc [ "prompt", `String "test input" ]) with
-  | Ok { content } -> Alcotest.(check string) "echo" "echo: test input" content
+  | Ok { content; _meta = _ } -> Alcotest.(check string) "echo" "echo: test input" content
   | Error { message; _ } -> Alcotest.failf "error: %s" message
 ;;
 
 let test_execute_with_string_input () =
   let tool = Agent_tool.create_simple ~name:"echo" ~description:"d" echo_runner in
   match Tool.execute tool (`String "direct string") with
-  | Ok { content } -> Alcotest.(check string) "echo" "echo: direct string" content
+  | Ok { content; _meta = _ } ->
+    Alcotest.(check string) "echo" "echo: direct string" content
   | Error { message; _ } -> Alcotest.failf "error: %s" message
 ;;
 
@@ -113,7 +114,8 @@ let test_output_summarizer () =
       }
   in
   match Tool.execute tool (`Assoc [ "prompt", `String "q" ]) with
-  | Ok { content } -> Alcotest.(check string) "truncated" "this is a ..." content
+  | Ok { content; _meta = _ } ->
+    Alcotest.(check string) "truncated" "this is a ..." content
   | Error { message; _ } -> Alcotest.failf "error: %s" message
 ;;
 
@@ -159,7 +161,8 @@ let test_multi_content () =
   in
   let tool = Agent_tool.create_simple ~name:"multi" ~description:"d" runner in
   match Tool.execute tool (`Assoc [ "prompt", `String "test" ]) with
-  | Ok { content } -> Alcotest.(check string) "joined" "line 1\nline 2\nline 3" content
+  | Ok { content; _meta = _ } ->
+    Alcotest.(check string) "joined" "line 1\nline 2\nline 3" content
   | Error { message; _ } -> Alcotest.failf "error: %s" message
 ;;
 
@@ -189,7 +192,7 @@ let test_typed_child_invocation_output_json () =
   let tool = Agent_tool.create_typed (typed_config structured_runner) in
   match Typed_tool.execute tool (`Assoc [ "prompt", `String "hello" ]) with
   | Error { message; _ } -> Alcotest.failf "error: %s" message
-  | Ok { content } ->
+  | Ok { content; _meta = _ } ->
     let json = Yojson.Safe.from_string content in
     Alcotest.(check string)
       "type"
@@ -232,7 +235,7 @@ let test_typed_untyped_bridge_returns_json () =
   let tool = Agent_tool.create_typed_untyped (typed_config structured_runner) in
   match Tool.execute tool (`Assoc [ "prompt", `String "bridge" ]) with
   | Error { message; _ } -> Alcotest.failf "error: %s" message
-  | Ok { content } ->
+  | Ok { content; _meta = _ } ->
     let json = Yojson.Safe.from_string content in
     Alcotest.(check string) "text" "child: bridge" (json |> member "text" |> to_string)
 ;;

--- a/test/test_agent_tools_index.ml
+++ b/test/test_agent_tools_index.ml
@@ -6,7 +6,7 @@ let make_tool ?(content = "ok") name =
     ~name
     ~description:("desc:" ^ name ^ ":" ^ content)
     ~parameters:[]
-    (fun _ -> Ok { Types.content })
+    (fun _ -> Ok { Types.content; _meta = None })
 ;;
 
 let tool_description = function

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -31,7 +31,7 @@ let test_prepare_turn_with_tools () =
           ; required = true
           }
         ]
-      (fun _ -> Ok { Types.content = "ok" })
+      (fun _ -> Ok { Types.content = "ok"; _meta = None })
   in
   let prep =
     Agent_turn.prepare_turn
@@ -55,11 +55,11 @@ let test_prepare_turn_with_tools () =
 let test_prepare_turn_with_guardrails_filter () =
   let tool_a =
     Tool.create ~name:"a" ~description:"A" ~parameters:[] (fun _ ->
-      Ok { Types.content = "" })
+      Ok { Types.content = ""; _meta = None })
   in
   let tool_b =
     Tool.create ~name:"b" ~description:"B" ~parameters:[] (fun _ ->
-      Ok { Types.content = "" })
+      Ok { Types.content = ""; _meta = None })
   in
   let guardrails =
     { Guardrails.permissive with tool_filter = Guardrails.AllowList [ "a" ] }
@@ -107,7 +107,8 @@ let test_prepare_turn_visible_tool_names_empty () =
 
 let test_prepare_turn_visible_tool_names_preserves_order () =
   let make n =
-    Tool.create ~name:n ~description:n ~parameters:[] (fun _ -> Ok { Types.content = "" })
+    Tool.create ~name:n ~description:n ~parameters:[] (fun _ ->
+      Ok { Types.content = ""; _meta = None })
   in
   let tools = Tool_set.of_list [ make "Bash"; make "Read"; make "Edit" ] in
   let prep =
@@ -557,11 +558,11 @@ let test_make_tool_results () =
 let test_prepare_turn_filter_override () =
   let tool_a =
     Tool.create ~name:"a" ~description:"A" ~parameters:[] (fun _ ->
-      Ok { Types.content = "" })
+      Ok { Types.content = ""; _meta = None })
   in
   let tool_b =
     Tool.create ~name:"b" ~description:"B" ~parameters:[] (fun _ ->
-      Ok { Types.content = "" })
+      Ok { Types.content = ""; _meta = None })
   in
   let turn_params =
     { Hooks.default_turn_params with

--- a/test/test_approval.ml
+++ b/test/test_approval.ml
@@ -54,7 +54,7 @@ let contains_substring ~needle haystack =
 (** Helper: create a simple tool that echoes its input as JSON string *)
 let make_echo_tool ?descriptor name =
   Tool.create ?descriptor ~name ~description:"echo" ~parameters:[] (fun input ->
-    Ok { Types.content = Yojson.Safe.to_string input })
+    Ok { Types.content = Yojson.Safe.to_string input; _meta = None })
 ;;
 
 let execute_with_tools_in_env
@@ -395,7 +395,7 @@ let test_parallel_read_tools_share_batch () =
           (fun input ->
             Eio.Promise.resolve resolve_self ();
             Eio.Time.with_timeout_exn clock 0.05 (fun () -> Eio.Promise.await await_other);
-            Ok { Types.content = Yojson.Safe.to_string input })
+            Ok { Types.content = Yojson.Safe.to_string input; _meta = None })
     }
   in
   let tools =
@@ -436,7 +436,7 @@ let test_workspace_tools_run_sequentially () =
             running := true;
             Eio.Time.sleep clock 0.01;
             running := false;
-            Ok { Types.content = name })
+            Ok { Types.content = name; _meta = None })
     }
   in
   let results =
@@ -473,7 +473,7 @@ let test_undeclared_tools_default_to_sequential () =
             running := true;
             Eio.Time.sleep clock 0.01;
             running := false;
-            Ok { Types.content = name })
+            Ok { Types.content = name; _meta = None })
     }
   in
   let results =
@@ -513,7 +513,7 @@ let test_workspace_barrier_splits_parallel_read_batches () =
             incr read_running;
             Eio.Time.sleep clock 0.02;
             decr read_running;
-            Ok { Types.content = name })
+            Ok { Types.content = name; _meta = None })
     }
   in
   let make_workspace_tool name =
@@ -530,7 +530,7 @@ let test_workspace_barrier_splits_parallel_read_batches () =
             workspace_running := true;
             Eio.Time.sleep clock 0.02;
             workspace_running := false;
-            Ok { Types.content = name })
+            Ok { Types.content = name; _meta = None })
     }
   in
   let tools =
@@ -587,7 +587,7 @@ let test_exclusive_external_barrier_isolation () =
             any_running := true;
             Eio.Time.sleep clock 0.02;
             any_running := false;
-            Ok { Types.content = name })
+            Ok { Types.content = name; _meta = None })
     }
   in
   let make_workspace_tool name =
@@ -604,7 +604,7 @@ let test_exclusive_external_barrier_isolation () =
             any_running := true;
             Eio.Time.sleep clock 0.02;
             any_running := false;
-            Ok { Types.content = name })
+            Ok { Types.content = name; _meta = None })
     }
   in
   let make_exclusive_tool name =
@@ -621,7 +621,7 @@ let test_exclusive_external_barrier_isolation () =
             exclusive_running := true;
             Eio.Time.sleep clock 0.02;
             exclusive_running := false;
-            Ok { Types.content = name })
+            Ok { Types.content = name; _meta = None })
     }
   in
   let tools =
@@ -720,7 +720,7 @@ let test_shell_descriptor_constraint_blocks_execution () =
         ]
       (fun _ ->
          handler_called := true;
-         Ok { Types.content = "ran" })
+         Ok { Types.content = "ran"; _meta = None })
   in
   let results =
     run_execute_with_tools

--- a/test/test_bug_hunt.ml
+++ b/test/test_bug_hunt.ml
@@ -60,7 +60,7 @@ let test_b1_injector_exception_caught () =
        (boom_injector
           ~tool_name:"test"
           ~input:`Null
-          ~output:(Ok { Types.content = "ok" }))
+          ~output:(Ok { Types.content = "ok"; _meta = None }))
    with
    | Failure msg -> if msg = "injector_boom" then threw := true);
   check bool "injector throws Failure" true !threw;

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -13,7 +13,7 @@ let with_net f =
 (** Helper: create a simple echo tool. *)
 let make_tool name =
   Tool.create ~name ~description:("tool:" ^ name) ~parameters:[] (fun input ->
-    Ok { Types.content = Yojson.Safe.to_string input })
+    Ok { Types.content = Yojson.Safe.to_string input; _meta = None })
 ;;
 
 let contains_substring ~needle haystack =

--- a/test/test_builder_coverage.ml
+++ b/test/test_builder_coverage.ml
@@ -148,7 +148,7 @@ let test_agent_accessors () =
   @@ fun env ->
   let tool =
     Tool.create ~name:"test_tool" ~description:"desc" ~parameters:[] (fun _input ->
-      Ok { Types.content = "result" })
+      Ok { Types.content = "result"; _meta = None })
   in
   let ctx = Context.create () in
   Context.set ctx "key" (`String "value");

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -83,7 +83,7 @@ let sample_echo_tool =
       ]
     (fun input ->
        let msg = Yojson.Safe.Util.(input |> member "msg" |> to_string) in
-       Ok { Types.content = msg })
+       Ok { Types.content = msg; _meta = None })
 ;;
 
 let () =

--- a/test/test_clone.ml
+++ b/test/test_clone.ml
@@ -143,7 +143,7 @@ let test_clone_shares_tools () =
   @@ fun env ->
   let tool =
     Tool.create ~name:"echo" ~description:"echo" ~parameters:[] (fun _ ->
-      Ok { Types.content = "ok" })
+      Ok { Types.content = "ok"; _meta = None })
   in
   let agent = Agent.create ~net:env#net ~config:Types.default_config ~tools:[ tool ] () in
   let clone = Agent.clone agent in

--- a/test/test_context_flow_proof.ml
+++ b/test/test_context_flow_proof.ml
@@ -71,7 +71,7 @@ let fresh_echo_tool () =
   let tool =
     Tool.create ~name:"echo" ~description:"Echo" ~parameters:[] (fun _input ->
       incr calls;
-      Ok { Types.content = "echoed" })
+      Ok { Types.content = "echoed"; _meta = None })
   in
   tool, calls
 ;;

--- a/test/test_contract.ml
+++ b/test/test_contract.ml
@@ -334,9 +334,9 @@ let test_compose_system_prompt_with_trigger () =
 let test_filter_tools_none_grants () =
   let tools =
     [ Tool.create ~name:"a" ~description:"" ~parameters:[] (fun _ ->
-        Ok { Types.content = "" })
+        Ok { Types.content = ""; _meta = None })
     ; Tool.create ~name:"b" ~description:"" ~parameters:[] (fun _ ->
-        Ok { Types.content = "" })
+        Ok { Types.content = ""; _meta = None })
     ]
   in
   let filtered = Contract.filter_tools Contract.empty tools in
@@ -346,11 +346,11 @@ let test_filter_tools_none_grants () =
 let test_filter_tools_with_grants () =
   let tools =
     [ Tool.create ~name:"a" ~description:"" ~parameters:[] (fun _ ->
-        Ok { Types.content = "" })
+        Ok { Types.content = ""; _meta = None })
     ; Tool.create ~name:"b" ~description:"" ~parameters:[] (fun _ ->
-        Ok { Types.content = "" })
+        Ok { Types.content = ""; _meta = None })
     ; Tool.create ~name:"c" ~description:"" ~parameters:[] (fun _ ->
-        Ok { Types.content = "" })
+        Ok { Types.content = ""; _meta = None })
     ]
   in
   let c = Contract.with_tool_grants [ "a"; "c" ] Contract.empty in

--- a/test/test_cost_integration.ml
+++ b/test/test_cost_integration.ml
@@ -68,7 +68,7 @@ let test_tokens_accumulate_across_turns () =
   with_mock_server ~port:18301 handler (fun ~sw ~net ~base_url ->
     let tool =
       Tool.create ~name:"echo" ~description:"echo" ~parameters:[] (fun _input ->
-        Ok { content = "ok" })
+        Ok { content = "ok"; _meta = None })
     in
     let options = { Agent.default_options with base_url } in
     let config = { default_config with max_turns = 5 } in

--- a/test/test_disclosure_resolver.ml
+++ b/test/test_disclosure_resolver.ml
@@ -8,7 +8,7 @@
 open Alcotest
 open Agent_sdk
 
-let ok_result content : Types.tool_result = Ok { Types.content }
+let ok_result content : Types.tool_result = Ok { Types.content; _meta = None }
 
 let err_result message : Types.tool_result =
   Error { Types.message; recoverable = true; error_class = Some Types.Deterministic }

--- a/test/test_e2e_v024.ml
+++ b/test/test_e2e_v024.ml
@@ -90,7 +90,7 @@ let test_multi_turn_tool_loop () =
          incr call_count;
          let expr = Yojson.Safe.Util.(input |> member "expr" |> to_string) in
          Printf.printf "  [Tool %d] calculator(%s)\n%!" !call_count expr;
-         Ok { Types.content = "42" })
+         Ok { Types.content = "42"; _meta = None })
   in
   let config =
     provider_m_config
@@ -129,7 +129,7 @@ let test_idle_detection () =
       (fun _input ->
          incr call_count;
          Printf.printf "  [Tool %d] get_status()\n%!" !call_count;
-         Ok { Types.content = "status: all systems nominal" })
+         Ok { Types.content = "status: all systems nominal"; _meta = None })
   in
   let config =
     provider_m_config
@@ -194,7 +194,7 @@ let test_context_compaction () =
            !call_count
            file
            (String.length long_output);
-         Ok { Types.content = long_output })
+         Ok { Types.content = long_output; _meta = None })
   in
   let reducer =
     Context_reducer.compose
@@ -248,14 +248,14 @@ let test_context_injection () =
       (fun input ->
          let path = Yojson.Safe.Util.(input |> member "path" |> to_string) in
          Printf.printf "  [Tool] read_file(%s)\n%!" path;
-         Ok { Types.content = "line1: hello\nline2: world\n" })
+         Ok { Types.content = "line1: hello\nline2: world\n"; _meta = None })
   in
   let injector : Hooks.context_injector =
     fun ~tool_name ~input:_ ~output ->
     Printf.printf "  [Injector] tool=%s\n%!" tool_name;
     injector_called := true;
     match output with
-    | Ok { Types.content = _output_content } ->
+    | Ok { Types.content = _output_content; _meta = _ } ->
       Some
         { Hooks.context_updates = [ "last_file_read", `String tool_name ]
         ; extra_messages =

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -219,7 +219,7 @@ let test_eval_collector_basic () =
           { agent_name = "test"
           ; tool_name = "t1"
           ; tool_use_id = "tu-test"
-          ; output = Ok { Types.content = "done" }
+          ; output = Ok { Types.content = "done"; _meta = None }
           ; turn = 0
           }));
   let rm = Eval_collector.finalize ec in

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -205,7 +205,7 @@ let test_filter_tools_only () =
           { agent_name = "a"
           ; tool_name = "calc"
           ; tool_use_id = "tu-test"
-          ; output = Ok { Types.content = "42" }
+          ; output = Ok { Types.content = "42"; _meta = None }
           ; turn = 0
           }));
   Event_bus.publish bus (ev (TurnCompleted { agent_name = "a"; turn = 0 }));
@@ -357,7 +357,7 @@ let test_multiple_event_types () =
           { agent_name = "a"
           ; tool_name = "f"
           ; tool_use_id = "tu-test"
-          ; output = Ok { Types.content = "ok" }
+          ; output = Ok { Types.content = "ok"; _meta = None }
           ; turn = 0
           }));
   Event_bus.publish bus (ev (TurnCompleted { agent_name = "a"; turn = 0 }));
@@ -554,7 +554,7 @@ let test_on_tool_error_hook_silent_on_success () =
   let bus = Event_bus.create () in
   let tool =
     Tool.create ~name:"ok" ~description:"" ~parameters:[] (fun _ ->
-      Ok { Types.content = "done" })
+      Ok { Types.content = "done"; _meta = None })
   in
   let schedule : Hooks.tool_schedule =
     { planned_index = 0
@@ -659,7 +659,7 @@ let test_unknown_tool_reports_available_tools_and_retries () =
   let bus = Event_bus.create () in
   let read_file =
     Tool.create ~name:"ReadFile" ~description:"Read a file" ~parameters:[] (fun _ ->
-      Ok { Types.content = "unused" })
+      Ok { Types.content = "unused"; _meta = None })
   in
   let schedule : Hooks.tool_schedule =
     { planned_index = 0
@@ -742,7 +742,7 @@ let test_provider_read_alias_dispatches_to_read_file_when_visible () =
   let read_file =
     Tool.create ~name:"ReadFile" ~description:"Read a file" ~parameters:[] (fun input ->
       captured_input := input;
-      Ok { Types.content = "read-ok" })
+      Ok { Types.content = "read-ok"; _meta = None })
   in
   let schedule : Hooks.tool_schedule =
     { planned_index = 0
@@ -819,7 +819,7 @@ let test_provider_search_alias_dispatches_to_search_files_when_visible () =
       ~parameters:[]
       (fun input ->
          captured_input := input;
-         Ok { Types.content = "search-ok" })
+         Ok { Types.content = "search-ok"; _meta = None })
   in
   let schedule : Hooks.tool_schedule =
     { planned_index = 0
@@ -888,7 +888,7 @@ let test_provider_execute_alias_dispatches_simple_command_as_typed_argv () =
       ~parameters:[]
       (fun input ->
          captured_input := input;
-         Ok { Types.content = "execute-ok" })
+         Ok { Types.content = "execute-ok"; _meta = None })
   in
   let schedule : Hooks.tool_schedule =
     { planned_index = 0
@@ -954,7 +954,7 @@ let test_on_error_silent_on_successful_dispatch () =
   let bus = Event_bus.create () in
   let tool =
     Tool.create ~name:"ok" ~description:"" ~parameters:[] (fun _ ->
-      Ok { Types.content = "done" })
+      Ok { Types.content = "done"; _meta = None })
   in
   let schedule : Hooks.tool_schedule =
     { planned_index = 0

--- a/test/test_event_forward.ml
+++ b/test/test_event_forward.ml
@@ -281,7 +281,7 @@ let test_tool_events_payload () =
          { agent_name = "x"
          ; tool_name = "search"
          ; tool_use_id = "tu-test"
-         ; output = Ok { Types.content = "result" }
+         ; output = Ok { Types.content = "result"; _meta = None }
          ; turn = 1
          })
   in

--- a/test/test_full_pipeline_cov.ml
+++ b/test/test_full_pipeline_cov.ml
@@ -251,7 +251,7 @@ let test_tool_call_loop () =
           ]
         (fun input ->
            let x = Yojson.Safe.Util.(input |> member "x" |> to_int) in
-           Ok { Types.content = string_of_int x })
+           Ok { Types.content = string_of_int x; _meta = None })
     in
     let agent = make_agent ~net:env#net ~tools:[ tool ] ~max_turns:5 url in
     match Agent.run ~sw agent "calc 42" with
@@ -288,7 +288,7 @@ let test_multi_content_tool () =
             ; required = true
             }
           ]
-        (fun _input -> Ok { Types.content = "hello" })
+        (fun _input -> Ok { Types.content = "hello"; _meta = None })
     in
     let agent = make_agent ~net:env#net ~tools:[ tool ] ~max_turns:5 url in
     match Agent.run ~sw agent "greet" with
@@ -419,7 +419,7 @@ let test_max_turns () =
     in
     let tool =
       Tool.create ~name:"loop" ~description:"loops" ~parameters:[] (fun _input ->
-        Ok { Types.content = "again" })
+        Ok { Types.content = "again"; _meta = None })
     in
     let agent = make_agent ~net:env#net ~tools:[ tool ] ~max_turns:2 url in
     match Agent.run ~sw agent "loop" with
@@ -530,7 +530,7 @@ let test_pre_tool_skip () =
     let url = start_multi ~sw ~net:env#net ~port:21013 responses in
     let tool =
       Tool.create ~name:"skipped" ~description:"Skip me" ~parameters:[] (fun _input ->
-        Ok { Types.content = "should not run" })
+        Ok { Types.content = "should not run"; _meta = None })
     in
     let hooks = { Hooks.empty with pre_tool_use = Some (fun _e -> Hooks.Skip) } in
     let agent = make_agent ~net:env#net ~tools:[ tool ] ~hooks ~max_turns:3 url in
@@ -712,7 +712,7 @@ let test_context_tool () =
             ; required = true
             }
           ]
-        (fun _ctx _input -> Ok { Types.content = "ctx_result" })
+        (fun _ctx _input -> Ok { Types.content = "ctx_result"; _meta = None })
     in
     let agent = make_agent ~net:env#net ~tools:[ tool ] ~max_turns:5 url in
     match Agent.run ~sw agent "ctx" with

--- a/test/test_guardrails.ml
+++ b/test/test_guardrails.ml
@@ -6,7 +6,7 @@ open Types
 
 let make_tool name =
   Tool.create ~name ~description:"test" ~parameters:[] (fun _input ->
-    Ok { Types.content = "ok" })
+    Ok { Types.content = "ok"; _meta = None })
 ;;
 
 let test_default () =

--- a/test/test_guardrails_integration.ml
+++ b/test/test_guardrails_integration.ml
@@ -89,7 +89,7 @@ let with_mock_server ?port handler f =
 
 let make_tool name =
   Tool.create ~name ~description:("tool " ^ name) ~parameters:[] (fun _input ->
-    Ok { Types.content = name ^ " result" })
+    Ok { Types.content = name ^ " result"; _meta = None })
 ;;
 
 (* ── tool_filter tests ───────────────────────────────── *)
@@ -200,7 +200,7 @@ let test_limit_blocks_multi_tool_response () =
     let tool =
       Tool.create ~name:"echo" ~description:"echo" ~parameters:[] (fun _input ->
         incr tool_calls;
-        Ok { content = "ok" })
+        Ok { content = "ok"; _meta = None })
     in
     let options =
       { Agent.default_options with
@@ -226,7 +226,7 @@ let test_no_limit_allows_all () =
        let tool =
          Tool.create ~name:"echo" ~description:"echo" ~parameters:[] (fun _input ->
            incr tool_calls;
-           Ok { content = "ok" })
+           Ok { content = "ok"; _meta = None })
        in
        let options = { Agent.default_options with base_url } in
        let config = { default_config with max_turns = 5 } in

--- a/test/test_hooks.ml
+++ b/test/test_hooks.ml
@@ -96,7 +96,7 @@ let test_hook_receives_event () =
 let test_post_tool_use_event () =
   let received_output = ref "" in
   let hook = function
-    | Hooks.PostToolUse { output = Ok { content }; _ } ->
+    | Hooks.PostToolUse { output = Ok { content; _meta = _ }; _ } ->
       received_output := content;
       Hooks.Continue
     | _ -> Hooks.Continue
@@ -108,7 +108,7 @@ let test_post_tool_use_event () =
          { tool_use_id = "tu-echo"
          ; tool_name = "echo"
          ; input = `Null
-         ; output = Ok { Types.content = "hello" }
+         ; output = Ok { Types.content = "hello"; _meta = None }
          ; result_bytes = 5
          ; duration_ms = 1.0
          ; schedule = default_schedule ()
@@ -283,7 +283,7 @@ let dummy_post_tool_use =
     { tool_use_id = "tu-1"
     ; tool_name = "t"
     ; input = `Null
-    ; output = Ok { Types.content = "ok" }
+    ; output = Ok { Types.content = "ok"; _meta = None }
     ; result_bytes = 2
     ; duration_ms = 1.0
     ; schedule = default_schedule ()

--- a/test/test_hooks_integration.ml
+++ b/test/test_hooks_integration.ml
@@ -84,7 +84,7 @@ let fresh_echo_tool () =
   let tool =
     Tool.create ~name:"echo" ~description:"Echo" ~parameters:[] (fun _input ->
       incr calls;
-      Ok { Types.content = "echoed" })
+      Ok { Types.content = "echoed"; _meta = None })
   in
   tool, calls
 ;;
@@ -277,7 +277,7 @@ let test_post_tool_receives_output () =
             post_tool_use =
               Some
                 (function
-                  | Hooks.PostToolUse { output = Ok { content }; _ } ->
+                  | Hooks.PostToolUse { output = Ok { content; _meta = _ }; _ } ->
                     received_content := content;
                     Hooks.Continue
                   | _ -> Hooks.Continue)

--- a/test/test_injection.ml
+++ b/test/test_injection.ml
@@ -41,11 +41,19 @@ let test_injector_returns_some () =
     else None
   in
   (match
-     injector ~tool_name:"bash" ~input:`Null ~output:(Ok { Types.content = "ok" })
+     injector
+       ~tool_name:"bash"
+       ~input:`Null
+       ~output:(Ok { Types.content = "ok"; _meta = None })
    with
    | Some inj -> check int "1 update" 1 (List.length inj.context_updates)
    | None -> fail "expected Some");
-  match injector ~tool_name:"calc" ~input:`Null ~output:(Ok { Types.content = "42" }) with
+  match
+    injector
+      ~tool_name:"calc"
+      ~input:`Null
+      ~output:(Ok { Types.content = "42"; _meta = None })
+  with
   | Some _ -> fail "expected None for calc"
   | None -> ()
 ;;
@@ -66,7 +74,12 @@ let test_injector_with_extra_messages () =
           ]
       }
   in
-  match injector ~tool_name:"any" ~input:`Null ~output:(Ok { Types.content = "" }) with
+  match
+    injector
+      ~tool_name:"any"
+      ~input:`Null
+      ~output:(Ok { Types.content = ""; _meta = None })
+  with
   | Some inj -> check int "1 extra message" 1 (List.length inj.extra_messages)
   | None -> fail "expected Some"
 ;;

--- a/test/test_integration.ml
+++ b/test/test_integration.ml
@@ -131,7 +131,7 @@ let test_tool_use () =
       Tool.create ~name:"calculator" ~description:"add" ~parameters:[] (fun input ->
         let a = Yojson.Safe.Util.(input |> member "a" |> to_int) in
         let b = Yojson.Safe.Util.(input |> member "b" |> to_int) in
-        Ok { Types.content = string_of_int (a + b) })
+        Ok { Types.content = string_of_int (a + b); _meta = None })
     in
     let provider : Provider.config =
       { provider = Provider.Local { base_url }; model_id = "mock"; api_key_env = "" }

--- a/test/test_local_llm.ml
+++ b/test/test_local_llm.ml
@@ -99,7 +99,7 @@ let test_tool_calling () =
          let expr = Yojson.Safe.Util.(input |> member "expression" |> to_string) in
          Printf.printf "  [Tool called] calculator(%s)\n%!" expr;
          (* Simple eval for demo *)
-         Ok { Types.content = Printf.sprintf "Result of %s = 5" expr })
+         Ok { Types.content = Printf.sprintf "Result of %s = 5" expr; _meta = None })
   in
   let agent = Agent.create ~net:env#net ~config ~tools:[ calc_tool ] ~options () in
   match Agent.run ~sw agent "What is 2+3? Use the calculator tool." with
@@ -150,7 +150,7 @@ let test_multi_tool () =
       (fun input ->
          let path = Yojson.Safe.Util.(input |> member "path" |> to_string) in
          Printf.printf "  [Tool called] read_file(%s)\n%!" path;
-         Ok { Types.content = "hello world\nthis is a test file\n" })
+         Ok { Types.content = "hello world\nthis is a test file\n"; _meta = None })
   in
   let agent = Agent.create ~net:env#net ~config ~tools:[ read_file_tool ] ~options () in
   match

--- a/test/test_mcp.ml
+++ b/test/test_mcp.ml
@@ -162,7 +162,7 @@ let test_mcp_tool_to_sdk_tool () =
   let call_fn input : Types.tool_result =
     let open Yojson.Safe.Util in
     let text = input |> member "text" |> to_string in
-    Ok { content = "echo: " ^ text }
+    Ok { content = "echo: " ^ text; _meta = None }
   in
   let sdk_tool = Mcp.mcp_tool_to_sdk_tool ~call_fn mcp_tool in
   Alcotest.(check string) "tool name" "echo" sdk_tool.schema.name;
@@ -171,7 +171,7 @@ let test_mcp_tool_to_sdk_tool () =
   let input = `Assoc [ "text", `String "hello" ] in
   let result = Tool.execute sdk_tool input in
   match result with
-  | Ok { content } -> Alcotest.(check string) "execution" "echo: hello" content
+  | Ok { content; _meta = _ } -> Alcotest.(check string) "execution" "echo: hello" content
   | Error _ -> Alcotest.fail "expected Ok"
 ;;
 

--- a/test/test_mcp_coverage.ml
+++ b/test/test_mcp_coverage.ml
@@ -293,13 +293,13 @@ let test_mcp_tool_to_sdk_tool_empty_schema () =
   let mcp_tool : Mcp.mcp_tool =
     { name = "empty_params"; description = "No parameters"; input_schema = `Assoc [] }
   in
-  let call_fn _input : Types.tool_result = Ok { content = "ok" } in
+  let call_fn _input : Types.tool_result = Ok { content = "ok"; _meta = None } in
   let sdk_tool = Mcp.mcp_tool_to_sdk_tool ~call_fn mcp_tool in
   Alcotest.(check string) "name" "empty_params" sdk_tool.schema.name;
   Alcotest.(check int) "no params" 0 (List.length sdk_tool.schema.parameters);
   (* Execute with empty input *)
   match Tool.execute sdk_tool (`Assoc []) with
-  | Ok { content } -> Alcotest.(check string) "ok" "ok" content
+  | Ok { content; _meta = _ } -> Alcotest.(check string) "ok" "ok" content
   | Error _ -> Alcotest.fail "expected Ok"
 ;;
 

--- a/test/test_mcp_integration.ml
+++ b/test/test_mcp_integration.ml
@@ -14,7 +14,7 @@ let check_string_array =
 
 let make_test_tool name =
   Tool.create ~name ~description:("Tool " ^ name) ~parameters:[] (fun _input ->
-    Ok { Types.content = "result from " ^ name })
+    Ok { Types.content = "result from " ^ name; _meta = None })
 ;;
 
 (** Dummy Eio network for Agent.create (not used in these tests). *)

--- a/test/test_multivendor_events.ml
+++ b/test/test_multivendor_events.ml
@@ -37,7 +37,7 @@ let stub_api_response : Types.api_response =
   }
 ;;
 
-let stub_tool_result : Types.tool_result = Ok { Types.content = "ok" }
+let stub_tool_result : Types.tool_result = Ok { Types.content = "ok"; _meta = None }
 
 (* ── I1/I2: envelope preserved across variants ────────────────── *)
 

--- a/test/test_operator_policy.ml
+++ b/test/test_operator_policy.ml
@@ -13,7 +13,7 @@ open Agent_sdk
 
 let make_tool name =
   Tool.create ~name ~description:"test" ~parameters:[] (fun _input ->
-    Ok { Types.content = "ok" })
+    Ok { Types.content = "ok"; _meta = None })
 ;;
 
 (* ── merge_operator_policy unit tests ──────────────────── *)

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -130,7 +130,7 @@ let test_agent_tools_registered () =
   let net = Eio.Stdenv.net env in
   let tool =
     Tool.create ~name:"my_tool" ~description:"test" ~parameters:[] (fun _ ->
-      Ok { Types.content = "ok" })
+      Ok { Types.content = "ok"; _meta = None })
   in
   let agent = Agent.create ~net ~tools:[ tool ] () in
   let tools = Agent.tools agent in
@@ -148,9 +148,9 @@ let test_agent_turn_preparation () =
   let tools =
     Tool_set.of_list
       [ Tool.create ~name:"a" ~description:"tool a" ~parameters:[] (fun _ ->
-          Ok { Types.content = "a" })
+          Ok { Types.content = "a"; _meta = None })
       ; Tool.create ~name:"b" ~description:"tool b" ~parameters:[] (fun _ ->
-          Ok { Types.content = "b" })
+          Ok { Types.content = "b"; _meta = None })
       ]
   in
   let messages =
@@ -379,15 +379,15 @@ let test_agent_multiple_tools () =
   let net = Eio.Stdenv.net env in
   let t1 =
     Tool.create ~name:"tool_a" ~description:"A" ~parameters:[] (fun _ ->
-      Ok { Types.content = "a" })
+      Ok { Types.content = "a"; _meta = None })
   in
   let t2 =
     Tool.create ~name:"tool_b" ~description:"B" ~parameters:[] (fun _ ->
-      Ok { Types.content = "b" })
+      Ok { Types.content = "b"; _meta = None })
   in
   let t3 =
     Tool.create ~name:"tool_c" ~description:"C" ~parameters:[] (fun _ ->
-      Ok { Types.content = "c" })
+      Ok { Types.content = "c"; _meta = None })
   in
   let agent = Agent.create ~net ~tools:[ t1; t2; t3 ] () in
   Alcotest.(check int) "3 tools" 3 (Tool_set.size (Agent.tools agent))
@@ -702,9 +702,9 @@ let test_prepare_turn_tool_filter_override () =
   let tools =
     Tool_set.of_list
       [ Tool.create ~name:"allowed" ~description:"ok" ~parameters:[] (fun _ ->
-          Ok { Types.content = "ok" })
+          Ok { Types.content = "ok"; _meta = None })
       ; Tool.create ~name:"blocked" ~description:"no" ~parameters:[] (fun _ ->
-          Ok { Types.content = "no" })
+          Ok { Types.content = "no"; _meta = None })
       ]
   in
   let messages =

--- a/test/test_pipeline_common_coverage.ml
+++ b/test/test_pipeline_common_coverage.ml
@@ -28,7 +28,7 @@ let echo_tool =
       ]
     (fun input ->
        let open Yojson.Safe.Util in
-       Ok { Types.content = input |> member "message" |> to_string })
+       Ok { Types.content = input |> member "message" |> to_string; _meta = None })
 ;;
 
 let text_response ?(content = [ Types.Text "ok" ]) () : Types.api_response =

--- a/test/test_pipeline_deep.ml
+++ b/test/test_pipeline_deep.ml
@@ -336,7 +336,7 @@ let test_resolve_params_with_tool_results () =
   in
   Alcotest.(check int) "1 tool result captured" 1 (List.length !captured_results);
   match List.hd !captured_results with
-  | Ok { content } -> Alcotest.(check string) "content" "found it" content
+  | Ok { content; _meta = _ } -> Alcotest.(check string) "content" "found it" content
   | Error _ -> Alcotest.fail "expected Ok result"
 ;;
 

--- a/test/test_policy_channel.ml
+++ b/test/test_policy_channel.ml
@@ -63,7 +63,7 @@ let test_version_increments () =
 
 let make_tool name =
   Tool.create ~name ~description:name ~parameters:[] (fun _ ->
-    Ok { Types.content = name })
+    Ok { Types.content = name; _meta = None })
 ;;
 
 let test_channel_restricts_tools () =

--- a/test/test_raw_trace.ml
+++ b/test/test_raw_trace.ml
@@ -150,7 +150,7 @@ let test_agent_run_stream_append_only_raw_trace () =
         ]
       (fun input ->
          let rel = Yojson.Safe.Util.(input |> member "path" |> to_string) in
-         Ok { Types.content = read_file (Filename.concat root rel) })
+         Ok { Types.content = read_file (Filename.concat root rel); _meta = None })
   in
   let file_write_tool =
     Tool.create
@@ -182,7 +182,7 @@ let test_agent_run_stream_append_only_raw_trace () =
          let rel = Yojson.Safe.Util.(input |> member "path" |> to_string) in
          let content = Yojson.Safe.Util.(input |> member "content" |> to_string) in
          write_file (Filename.concat root rel) content;
-         Ok { Types.content = Printf.sprintf "wrote:%s" rel })
+         Ok { Types.content = Printf.sprintf "wrote:%s" rel; _meta = None })
   in
   let shell_exec_tool =
     Tool.create
@@ -214,6 +214,7 @@ let test_agent_run_stream_append_only_raw_trace () =
                  (if Sys.file_exists (Filename.concat root "input.txt")
                   then "PASS"
                   else "FAIL")
+             ; _meta = None
              }
          else if String.equal command "grep -q 'copied' output.txt && echo PASS"
          then
@@ -226,6 +227,7 @@ let test_agent_run_stream_append_only_raw_trace () =
                          "source text -> copied"
                   then "PASS"
                   else "FAIL")
+             ; _meta = None
              }
          else
            Error

--- a/test/test_session_resume.ml
+++ b/test/test_session_resume.ml
@@ -283,7 +283,7 @@ let test_resume_with_tools () =
   @@ fun net ->
   let tool =
     Tool.create ~name:"echo" ~description:"Echo input" ~parameters:[] (fun input ->
-      Ok { Types.content = Yojson.Safe.to_string input })
+      Ok { Types.content = Yojson.Safe.to_string input; _meta = None })
   in
   let cp = make_checkpoint () in
   let agent = Agent.resume ~net ~checkpoint:cp ~tools:[ tool ] () in

--- a/test/test_subagent.ml
+++ b/test/test_subagent.ml
@@ -111,11 +111,11 @@ let () =
             let spec = Subagent.of_markdown "body" in
             let t1 =
               Tool.create ~name:"read" ~description:"" ~parameters:[] (fun _ ->
-                Ok { Types.content = "" })
+                Ok { Types.content = ""; _meta = None })
             in
             let t2 =
               Tool.create ~name:"write" ~description:"" ~parameters:[] (fun _ ->
-                Ok { Types.content = "" })
+                Ok { Types.content = ""; _meta = None })
             in
             let result = Subagent.filter_tools spec [ t1; t2 ] in
             check int "count" 2 (List.length result))
@@ -124,11 +124,11 @@ let () =
             let spec = Subagent.of_markdown md in
             let t1 =
               Tool.create ~name:"read" ~description:"" ~parameters:[] (fun _ ->
-                Ok { Types.content = "" })
+                Ok { Types.content = ""; _meta = None })
             in
             let t2 =
               Tool.create ~name:"write" ~description:"" ~parameters:[] (fun _ ->
-                Ok { Types.content = "" })
+                Ok { Types.content = ""; _meta = None })
             in
             let result = Subagent.filter_tools spec [ t1; t2 ] in
             check int "count" 1 (List.length result))
@@ -137,11 +137,11 @@ let () =
             let spec = Subagent.of_markdown md in
             let t1 =
               Tool.create ~name:"read" ~description:"" ~parameters:[] (fun _ ->
-                Ok { Types.content = "" })
+                Ok { Types.content = ""; _meta = None })
             in
             let t2 =
               Tool.create ~name:"write" ~description:"" ~parameters:[] (fun _ ->
-                Ok { Types.content = "" })
+                Ok { Types.content = ""; _meta = None })
             in
             let result = Subagent.filter_tools spec [ t1; t2 ] in
             check int "count" 1 (List.length result))
@@ -150,15 +150,15 @@ let () =
             let spec = Subagent.of_markdown md in
             let t1 =
               Tool.create ~name:"read" ~description:"" ~parameters:[] (fun _ ->
-                Ok { Types.content = "" })
+                Ok { Types.content = ""; _meta = None })
             in
             let t2 =
               Tool.create ~name:"write" ~description:"" ~parameters:[] (fun _ ->
-                Ok { Types.content = "" })
+                Ok { Types.content = ""; _meta = None })
             in
             let t3 =
               Tool.create ~name:"exec" ~description:"" ~parameters:[] (fun _ ->
-                Ok { Types.content = "" })
+                Ok { Types.content = ""; _meta = None })
             in
             let result = Subagent.filter_tools spec [ t1; t2; t3 ] in
             check int "count" 1 (List.length result))
@@ -453,7 +453,7 @@ let () =
             let spec = Subagent.of_markdown md in
             let tools =
               [ Tool.create ~name:"read" ~description:"" ~parameters:[] (fun _ ->
-                  Ok { Types.content = "" })
+                  Ok { Types.content = ""; _meta = None })
               ]
             in
             let target =

--- a/test/test_telemetry_pipeline.ml
+++ b/test/test_telemetry_pipeline.ml
@@ -348,7 +348,7 @@ let test_checkpoint_sink_after_tool_feedback () =
           ; required = true
           }
         ]
-      (fun _input -> Ok { Types.content = "12:00 UTC" })
+      (fun _input -> Ok { Types.content = "12:00 UTC"; _meta = None })
   in
   let agent =
     make_checkpoint_agent

--- a/test/test_tool.ml
+++ b/test/test_tool.ml
@@ -17,11 +17,11 @@ let test_simple_handler_ok () =
         ]
       (fun input ->
          let open Yojson.Safe.Util in
-         Ok { Types.content = input |> member "msg" |> to_string })
+         Ok { Types.content = input |> member "msg" |> to_string; _meta = None })
   in
   let actual = Tool.execute tool (`Assoc [ "msg", `String "hello" ]) in
   match actual with
-  | Ok { content } -> check string "returns Ok" "hello" content
+  | Ok { content; _meta = _ } -> check string "returns Ok" "hello" content
   | Error _ -> fail "expected Ok"
 ;;
 
@@ -45,7 +45,7 @@ let test_context_handler_receives_context () =
       ~parameters:[]
       (fun ctx _input ->
          match Context.get ctx "key" with
-         | Some (`String v) -> Ok { Types.content = v }
+         | Some (`String v) -> Ok { Types.content = v; _meta = None }
          | _ ->
            Error
              { Types.message = "key not found"; recoverable = true; error_class = None })
@@ -54,7 +54,7 @@ let test_context_handler_receives_context () =
   Context.set ctx "key" (`String "ctx_value");
   let actual = Tool.execute ~context:ctx tool `Null in
   match actual with
-  | Ok { content } -> check string "reads context" "ctx_value" content
+  | Ok { content; _meta = _ } -> check string "reads context" "ctx_value" content
   | Error _ -> fail "expected Ok"
 ;;
 
@@ -66,7 +66,7 @@ let test_context_handler_writes_context () =
       ~parameters:[]
       (fun ctx _input ->
          Context.set ctx "written" (`Int 42);
-         Ok { Types.content = "done" })
+         Ok { Types.content = "done"; _meta = None })
   in
   let ctx = Context.create () in
   let _result = Tool.execute ~context:ctx tool `Null in
@@ -79,11 +79,11 @@ let test_context_handler_default_context () =
       ~name:"noctx"
       ~description:"No explicit context"
       ~parameters:[]
-      (fun _ctx _input -> Ok { Types.content = "works" })
+      (fun _ctx _input -> Ok { Types.content = "works"; _meta = None })
   in
   let actual = Tool.execute tool `Null in
   match actual with
-  | Ok { content } -> check string "default context" "works" content
+  | Ok { content; _meta = _ } -> check string "default context" "works" content
   | Error _ -> fail "expected Ok"
 ;;
 
@@ -104,7 +104,7 @@ let test_schema_to_json_structure () =
           ; required = false
           }
         ]
-      (fun _input -> Ok { Types.content = "" })
+      (fun _input -> Ok { Types.content = ""; _meta = None })
   in
   let json = Tool.schema_to_json tool in
   let open Yojson.Safe.Util in
@@ -133,7 +133,7 @@ let test_schema_param_types () =
   in
   let tool =
     Tool.create ~name:"types" ~description:"" ~parameters:params (fun _input ->
-      Ok { Types.content = "" })
+      Ok { Types.content = ""; _meta = None })
   in
   let json = Tool.schema_to_json tool in
   let open Yojson.Safe.Util in
@@ -176,7 +176,7 @@ let test_descriptor_preserved_and_not_in_schema () =
           ; required = true
           }
         ]
-      (fun _ -> Ok { Types.content = "ok" })
+      (fun _ -> Ok { Types.content = "ok"; _meta = None })
   in
   let descriptor = Tool.descriptor tool in
   check bool "descriptor present" true (Option.is_some descriptor);
@@ -287,7 +287,7 @@ let test_create_rejects_inconsistent_descriptor () =
             ~name:"bad"
             ~description:"bad"
             ~parameters:[]
-            (fun _ -> Ok { Types.content = "ok" })))
+            (fun _ -> Ok { Types.content = "ok"; _meta = None })))
 ;;
 
 let () =
@@ -337,21 +337,24 @@ let () =
                   ]
                 (fun input ->
                    let open Yojson.Safe.Util in
-                   Ok { Types.content = input |> member "name" |> to_string })
+                   Ok
+                     { Types.content = input |> member "name" |> to_string; _meta = None })
             in
             let wrapped = Tool.with_defaults [ "name", `String "default_user" ] tool in
             match Tool.execute wrapped (`Assoc []) with
-            | Ok { content } -> check string "default injected" "default_user" content
+            | Ok { content; _meta = _ } ->
+              check string "default injected" "default_user" content
             | Error _ -> fail "expected Ok")
         ; test_case "preserves explicit args" `Quick (fun () ->
             let tool =
               Tool.create ~name:"greet" ~description:"Greet" ~parameters:[] (fun input ->
                 let open Yojson.Safe.Util in
-                Ok { Types.content = input |> member "name" |> to_string })
+                Ok { Types.content = input |> member "name" |> to_string; _meta = None })
             in
             let wrapped = Tool.with_defaults [ "name", `String "default_user" ] tool in
             match Tool.execute wrapped (`Assoc [ "name", `String "alice" ]) with
-            | Ok { content } -> check string "explicit preserved" "alice" content
+            | Ok { content; _meta = _ } ->
+              check string "explicit preserved" "alice" content
             | Error _ -> fail "expected Ok")
         ; test_case "works with context handler" `Quick (fun () ->
             let tool =
@@ -361,12 +364,16 @@ let () =
                 ~parameters:[]
                 (fun _ctx input ->
                    let open Yojson.Safe.Util in
-                   Ok { Types.content = input |> member "agent" |> to_string })
+                   Ok
+                     { Types.content = input |> member "agent" |> to_string
+                     ; _meta = None
+                     })
             in
             let wrapped = Tool.with_defaults [ "agent", `String "worker-1" ] tool in
             let ctx = Context.create () in
             match Tool.execute ~context:ctx wrapped (`Assoc []) with
-            | Ok { content } -> check string "default in ctx handler" "worker-1" content
+            | Ok { content; _meta = _ } ->
+              check string "default in ctx handler" "worker-1" content
             | Error _ -> fail "expected Ok")
         ] )
       (* RFC-OAS-011 OAS-E PR-5: removed the "builtin_descriptor" test group.

--- a/test/test_tool_disclosure.ml
+++ b/test/test_tool_disclosure.ml
@@ -19,7 +19,7 @@ let make_tool name =
         ; required = false
         }
       ]
-    (fun _ -> Ok { Types.content = "ok" })
+    (fun _ -> Ok { Types.content = "ok"; _meta = None })
 ;;
 
 let json_keys = function

--- a/test/test_tool_index.ml
+++ b/test/test_tool_index.ml
@@ -26,7 +26,7 @@ let test_of_tools () =
       ~name:"read_file"
       ~description:"Read file contents"
       ~parameters:[]
-      (fun _ -> Ok { Types.content = "ok" })
+      (fun _ -> Ok { Types.content = "ok"; _meta = None })
   in
   let idx = Tool_index.of_tools [ tool ] in
   check int "size 1" 1 (Tool_index.size idx);

--- a/test/test_tool_op.ml
+++ b/test/test_tool_op.ml
@@ -92,7 +92,7 @@ let test_apply_remove_dedup_current () =
 
 let make_tool name =
   Tool.create ~name ~description:name ~parameters:[] (fun _ ->
-    Ok { Types.content = name })
+    Ok { Types.content = name; _meta = None })
 ;;
 
 let test_apply_to_tool_set_remove () =

--- a/test/test_tool_schema_gen.ml
+++ b/test/test_tool_schema_gen.ml
@@ -179,7 +179,7 @@ let test_typed_tool_integration () =
   in
   let input = `Assoc [ "message", `String "typed-gen" ] in
   match Typed_tool.execute tool input with
-  | Ok { content } ->
+  | Ok { content; _meta = _ } ->
     let json = Yojson.Safe.from_string content in
     let r = Yojson.Safe.Util.(json |> member "result" |> to_string) in
     Alcotest.(check string) "result" "sent: typed-gen" r

--- a/test/test_tool_selector.ml
+++ b/test/test_tool_selector.ml
@@ -7,7 +7,7 @@ open Agent_sdk
 
 let make_tool name desc =
   Tool.create ~name ~description:desc ~parameters:[] (fun _ ->
-    Ok { Types.content = "ok" })
+    Ok { Types.content = "ok"; _meta = None })
 ;;
 
 let tools_20 =

--- a/test/test_tool_set.ml
+++ b/test/test_tool_set.ml
@@ -4,12 +4,12 @@ open Agent_sdk
 
 let make_tool name =
   Tool.create ~name ~description:("desc_" ^ name) ~parameters:[] (fun _ ->
-    Ok { Types.content = "ok" })
+    Ok { Types.content = "ok"; _meta = None })
 ;;
 
 let make_tool_v2 name =
   Tool.create ~name ~description:("v2_" ^ name) ~parameters:[] (fun _ ->
-    Ok { Types.content = "v2" })
+    Ok { Types.content = "v2"; _meta = None })
 ;;
 
 (* ── Alcotest ────────────────────────────────────────────── *)

--- a/test/test_turn_budget.ml
+++ b/test/test_turn_budget.ml
@@ -116,7 +116,7 @@ let test_make_tool_no_agent () =
   let input = `Assoc [ "additional_turns", `Int 5; "reason", `String "testing" ] in
   let result = Tool.execute tool input in
   match result with
-  | Ok { content } ->
+  | Ok { content; _meta = _ } ->
     Alcotest.(check bool)
       "contains Granted"
       true

--- a/test/test_typed_tool.ml
+++ b/test/test_typed_tool.ml
@@ -82,7 +82,7 @@ let greet_ctx_tool =
 let test_execute_success () =
   let input = `Assoc [ "name", `String "Vincent"; "shout", `Bool false ] in
   match Typed_tool.execute greet_tool input with
-  | Ok { content } ->
+  | Ok { content; _meta = _ } ->
     let json = Yojson.Safe.from_string content in
     let greeting = Yojson.Safe.Util.(json |> member "greeting" |> to_string) in
     Alcotest.(check string) "greeting" "Hello, Vincent" greeting
@@ -92,7 +92,7 @@ let test_execute_success () =
 let test_execute_shout () =
   let input = `Assoc [ "name", `String "Vincent"; "shout", `Bool true ] in
   match Typed_tool.execute greet_tool input with
-  | Ok { content } ->
+  | Ok { content; _meta = _ } ->
     let json = Yojson.Safe.from_string content in
     let greeting = Yojson.Safe.Util.(json |> member "greeting" |> to_string) in
     Alcotest.(check string) "uppercase" "HELLO, VINCENT" greeting
@@ -143,7 +143,7 @@ let test_to_untyped_bridge () =
   let untyped = Typed_tool.to_untyped greet_tool in
   let input = `Assoc [ "name", `String "Bridge" ] in
   match Tool.execute untyped input with
-  | Ok { content } ->
+  | Ok { content; _meta = _ } ->
     let json = Yojson.Safe.from_string content in
     let greeting = Yojson.Safe.Util.(json |> member "greeting" |> to_string) in
     Alcotest.(check string) "bridge works" "Hello, Bridge" greeting
@@ -201,7 +201,7 @@ let test_context_handler () =
   Context.set ctx "prefix" (`String "Dear");
   let input = `Assoc [ "name", `String "Admin" ] in
   match Typed_tool.execute ~context:ctx greet_ctx_tool input with
-  | Ok { content } ->
+  | Ok { content; _meta = _ } ->
     let json = Yojson.Safe.from_string content in
     let greeting = Yojson.Safe.Util.(json |> member "greeting" |> to_string) in
     Alcotest.(check string) "with prefix" "Dear Hello, Admin" greeting
@@ -221,7 +221,7 @@ let test_to_untyped_context_bridge () =
   Context.set ctx "prefix" (`String "Hey");
   let input = `Assoc [ "name", `String "World" ] in
   match Tool.execute ~context:ctx untyped input with
-  | Ok { content } ->
+  | Ok { content; _meta = _ } ->
     let json = Yojson.Safe.from_string content in
     let greeting = Yojson.Safe.Util.(json |> member "greeting" |> to_string) in
     Alcotest.(check string) "ctx bridge" "Hey Hello, World" greeting
@@ -232,6 +232,20 @@ let test_null_input_parse () =
   match Typed_tool.execute greet_tool `Null with
   | Error e -> Alcotest.(check bool) "recoverable" true e.recoverable
   | Ok _ -> Alcotest.fail "expected error on null input"
+;;
+
+(** Compile-time and runtime guard for the [_meta] field on [Types.tool_output].
+    If the upstream MCP [tool_result] shape changes such that [_meta] is no
+    longer modelled here, this test will not compile. *)
+let test_meta_field_present () =
+  let result : Types.tool_result =
+    Ok { content = "ok"; _meta = Some (`Assoc [ "source", `String "typed_tool" ]) }
+  in
+  match result with
+  | Ok { content; _meta = Some _ } ->
+    Alcotest.(check string) "content preserved" "ok" content
+  | Ok { _meta = None; _ } -> Alcotest.fail "expected Some _meta"
+  | Error _ -> Alcotest.fail "expected Ok"
 ;;
 
 (* ── Test runner ────────────────────────────────────────── *)
@@ -271,5 +285,7 @@ let () =
       , [ Alcotest.test_case "with context" `Quick test_context_handler
         ; Alcotest.test_case "without context" `Quick test_context_handler_no_context
         ] )
+    ; ( "meta"
+      , [ Alcotest.test_case "_meta field is present" `Quick test_meta_field_present ] )
     ]
 ;;

--- a/test/test_typed_tool_safe.ml
+++ b/test/test_typed_tool_safe.ml
@@ -35,7 +35,7 @@ let valid_input = `Assoc [ "name", `String "Vincent" ]
 let test_read_only_success () =
   let safe = Typed_tool_safe.read_only base_tool in
   match Typed_tool_safe.execute_read_only safe valid_input with
-  | Ok { content } ->
+  | Ok { content; _meta = _ } ->
     let json = Yojson.Safe.from_string content in
     let g = Yojson.Safe.Util.(json |> member "greeting" |> to_string) in
     Alcotest.(check string) "greeting" "Hello, Vincent" g
@@ -53,7 +53,7 @@ let test_write_approved () =
   let safe = Typed_tool_safe.write base_tool in
   let approve ~tool_name:_ ~input_desc:(_ : _ Lazy.t) = Ok () in
   match Typed_tool_safe.execute_write ~approve safe valid_input with
-  | Ok { content } ->
+  | Ok { content; _meta = _ } ->
     let json = Yojson.Safe.from_string content in
     let g = Yojson.Safe.Util.(json |> member "greeting" |> to_string) in
     Alcotest.(check string) "greeting" "Hello, Vincent" g
@@ -110,7 +110,8 @@ let test_to_untyped () =
   let safe = Typed_tool_safe.write base_tool in
   let untyped = Typed_tool_safe.to_untyped safe in
   match Tool.execute untyped valid_input with
-  | Ok { content } -> Alcotest.(check bool) "works" true (String.length content > 0)
+  | Ok { content; _meta = _ } ->
+    Alcotest.(check bool) "works" true (String.length content > 0)
   | Error e -> Alcotest.fail e.message
 ;;
 

--- a/test/test_usability_v030.ml
+++ b/test/test_usability_v030.ml
@@ -81,7 +81,7 @@ let test_card_json_export () =
       ~parameters:
         [ { name = "query"; description = "Query"; param_type = String; required = true }
         ]
-      (fun _input -> Ok { Types.content = "results" })
+      (fun _input -> Ok { Types.content = "results"; _meta = None })
   in
   let agent =
     Builder.create ~net:env#net ~model:"claude-sonnet-4-6"

--- a/test/test_v024_fixes.ml
+++ b/test/test_v024_fixes.ml
@@ -120,7 +120,11 @@ let test_b9_injector_logs_instead_of_discard () =
   in
   let threw = ref false in
   (try
-     ignore (injector ~tool_name:"t" ~input:`Null ~output:(Ok { Types.content = "ok" }))
+     ignore
+       (injector
+          ~tool_name:"t"
+          ~input:`Null
+          ~output:(Ok { Types.content = "ok"; _meta = None }))
    with
    | Failure _ -> threw := true);
   check bool "injector still throws when called directly" true !threw


### PR DESCRIPTION
## Summary

`mcp_protocol` 0.16 introduced a `_meta` field on `tool_result`. This PR mirrors that shape in OAS's own `Types.tool_output` record (the `Ok` payload of `Types.tool_result`) and updates every construction/pattern site so the codebase compiles under `OCAMLPARAM=_,warn-error=+a`.

## Changes

- `lib/llm_provider/types.ml{,i}`: add `_meta : Yojson.Safe.t option` to `tool_output`.
- `lib/typed_tool.ml`, `lib/protocol/mcp*.ml`, `lib/agent/*.ml`, `lib/pipeline/*.ml`, etc.: include `_meta = None` in `Ok { ... }` constructions.
- Pattern sites that destructure `Ok { content }` now bind `_meta = _` to avoid warning 9.
- `test/test_typed_tool.ml`: add a compile-time/runtime guard (`test_meta_field_present`) that constructs a `tool_result` with `Some _meta`; if the record shape loses `_meta`, the test will not compile.

## Verification

- `OCAMLPARAM='_,warn-error=+a' ./scripts/dune-local.sh build lib` ✅
- `OCAMLPARAM='_,warn-error=+a' ./scripts/dune-local.sh build examples` ✅
- `OCAMLPARAM='_,warn-error=+a' ./scripts/dune-local.sh build test` ✅
- Focused tests run with `./scripts/dune-local.sh runtest`:
  - `test/test_typed_tool.exe` ✅
  - `test/test_typed_tool_safe.exe` ✅
  - `test/test_mcp.exe` ✅
  - `test/test_mcp_coverage.exe` ✅
  - `test/test_mcp_deep.exe` ✅
  - `test/test_tool.exe` ✅
  - `test/test_pipeline.exe` ✅
  - `test/test_agent_turn.exe` ✅

## Adversarial self-review

1. **Security**: no new authentication/authorization paths; purely a type-shape compatibility change.
2. **Type safety**: `_meta` is modelled as `Yojson.Safe.t option`, matching upstream `Mcp_types.tool_result`. No string matching introduced.
3. **Silent failures**: no error paths added or altered; existing `Result.t` semantics preserved.
4. **Tests**: a new guard test fails at compile time if `_meta` is removed from `tool_output`.
5. **SSOT**: the field type and default (`None`) mirror the upstream MCP type; no version/config values duplicated.
6. **Immutability**: `_meta` is an immutable record field; all helper code remains pure.
7. **Maintainability note**: ~70 files now contain `Ok { ...; _meta = None }`. A future refactor could introduce a `Types.tool_output` constructor to centralize the default, but that is out of scope for this compatibility fix.
