### PR TITLE
fix(pipeline): make hook decisions exhaustive

### DIFF
--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -380,7 +380,11 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
               to Skip (for example, at a configured threshold). *)
            pending_nudge := Some nudge_msg;
            idle_handled := true
-         | _ -> ());
+         | Hooks.Continue
+         | Hooks.Override _
+         | Hooks.ApprovalRequired
+         | Hooks.AdjustParams _
+         | Hooks.ElicitInput _ -> ());
        (* Early exit: skip tool execution when on_idle hook says Skip.
           Prevents executing redundant tools and avoids further counter drift. *)
        if !idle_skip
@@ -616,7 +620,12 @@ let compact_messages
   in
   match hook_decision with
   | Hooks.Skip -> false
-  | _ ->
+  | Hooks.Continue
+  | Hooks.Override _
+  | Hooks.ApprovalRequired
+  | Hooks.AdjustParams _
+  | Hooks.ElicitInput _
+  | Hooks.Nudge _ ->
     let reduced =
       Budget_strategy.reduce_for_budget
         ?summarizer:agent.options.summarizer

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -385,9 +385,9 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
          | Hooks.ApprovalRequired
          | Hooks.AdjustParams _
          | Hooks.ElicitInput _ ->
-           (* Unreachable after [Hooks.invoke_validated] for on_idle; defensive
-              no-op keeps this match exhaustive if validation is bypassed. *)
-           ());
+           (* Unreachable after [Hooks.invoke_validated] for on_idle. Fail-fast
+              so a validation bypass cannot silently change idle behavior. *)
+           assert false);
        (* Early exit: skip tool execution when on_idle hook says Skip.
           Prevents executing redundant tools and avoids further counter drift. *)
        if !idle_skip
@@ -696,9 +696,9 @@ let compact_messages
   | Hooks.AdjustParams _
   | Hooks.ElicitInput _
   | Hooks.Nudge _ ->
-    (* Unreachable after [Hooks.invoke_validated] for pre_compact; defensive
-       continue behavior preserves the validated fallback policy. *)
-    run_compaction ()
+    (* Unreachable after [Hooks.invoke_validated] for pre_compact. Fail-fast
+       so a validation bypass cannot silently compact. *)
+    assert false
 ;;
 
 (** Apply proactive compaction when context usage exceeds the configured

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -380,11 +380,14 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
               to Skip (for example, at a configured threshold). *)
            pending_nudge := Some nudge_msg;
            idle_handled := true
-         | Hooks.Continue
+         | Hooks.Continue -> ()
          | Hooks.Override _
          | Hooks.ApprovalRequired
          | Hooks.AdjustParams _
-         | Hooks.ElicitInput _ -> ());
+         | Hooks.ElicitInput _ ->
+           (* Unreachable after [Hooks.invoke_validated] for on_idle; defensive
+              no-op keeps this match exhaustive if validation is bypassed. *)
+           ());
        (* Early exit: skip tool execution when on_idle hook says Skip.
           Prevents executing redundant tools and avoids further counter drift. *)
        if !idle_skip
@@ -618,14 +621,7 @@ let compact_messages
       agent.options.hooks.pre_compact
       (Hooks.PreCompact { messages; estimated_tokens = est_tokens; budget_tokens })
   in
-  match hook_decision with
-  | Hooks.Skip -> false
-  | Hooks.Continue
-  | Hooks.Override _
-  | Hooks.ApprovalRequired
-  | Hooks.AdjustParams _
-  | Hooks.ElicitInput _
-  | Hooks.Nudge _ ->
+  let run_compaction () =
     let reduced =
       Budget_strategy.reduce_for_budget
         ?summarizer:agent.options.summarizer
@@ -691,6 +687,18 @@ let compact_messages
               })
        | None -> ());
       true)
+  in
+  match hook_decision with
+  | Hooks.Skip -> false
+  | Hooks.Continue -> run_compaction ()
+  | Hooks.Override _
+  | Hooks.ApprovalRequired
+  | Hooks.AdjustParams _
+  | Hooks.ElicitInput _
+  | Hooks.Nudge _ ->
+    (* Unreachable after [Hooks.invoke_validated] for pre_compact; defensive
+       continue behavior preserves the validated fallback policy. *)
+    run_compaction ()
 ;;
 
 (** Apply proactive compaction when context usage exceeds the configured

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -71,7 +71,11 @@ let stage_input ?raw_trace_run agent =
             }
       });
     Ok ()
-  | _ -> Ok ()
+  | Hooks.Continue
+  | Hooks.Skip
+  | Hooks.Override _
+  | Hooks.ApprovalRequired
+  | Hooks.AdjustParams _ -> Ok ()
 ;;
 
 (* Lower a canonical tool-result projection to the [Types.tool_result] the

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -71,11 +71,11 @@ let stage_input ?raw_trace_run agent =
             }
       });
     Ok ()
-  | Hooks.Continue
-  | Hooks.Skip
-  | Hooks.Override _
-  | Hooks.ApprovalRequired
-  | Hooks.AdjustParams _ -> Ok ()
+  | Hooks.Continue -> Ok ()
+  | Hooks.Skip | Hooks.Override _ | Hooks.ApprovalRequired | Hooks.AdjustParams _ ->
+    (* Unreachable after [Hooks.invoke_validated] for before_turn; defensive
+       no-op keeps this match exhaustive if validation is bypassed. *)
+    Ok ()
 ;;
 
 (* Lower a canonical tool-result projection to the [Types.tool_result] the
@@ -283,7 +283,16 @@ let stage_parse ?raw_trace_run agent =
       in
       (match decision with
        | Hooks.AdjustParams params -> params
-       | _ -> Hooks.default_turn_params)
+       | Hooks.Continue -> Hooks.default_turn_params
+       | Hooks.Skip
+       | Hooks.Override _
+       | Hooks.ApprovalRequired
+       | Hooks.ElicitInput _
+       | Hooks.Nudge _ ->
+         (* Unreachable after [Hooks.invoke_validated] for before_turn_params;
+            defensive default keeps this match exhaustive without silently
+            accepting future constructors. *)
+         Hooks.default_turn_params)
   in
   let original_config = agent.state.config in
   let new_config =

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -73,9 +73,9 @@ let stage_input ?raw_trace_run agent =
     Ok ()
   | Hooks.Continue -> Ok ()
   | Hooks.Skip | Hooks.Override _ | Hooks.ApprovalRequired | Hooks.AdjustParams _ ->
-    (* Unreachable after [Hooks.invoke_validated] for before_turn; defensive
-       no-op keeps this match exhaustive if validation is bypassed. *)
-    Ok ()
+    (* Unreachable after [Hooks.invoke_validated] for before_turn. Fail-fast
+       so a validation bypass cannot silently start a turn. *)
+    assert false
 ;;
 
 (* Lower a canonical tool-result projection to the [Types.tool_result] the
@@ -289,10 +289,10 @@ let stage_parse ?raw_trace_run agent =
        | Hooks.ApprovalRequired
        | Hooks.ElicitInput _
        | Hooks.Nudge _ ->
-         (* Unreachable after [Hooks.invoke_validated] for before_turn_params;
-            defensive default keeps this match exhaustive without silently
-            accepting future constructors. *)
-         Hooks.default_turn_params)
+         (* Unreachable after [Hooks.invoke_validated] for before_turn_params.
+            Fail-fast so a validation bypass cannot silently use default
+            parameters. *)
+         assert false)
   in
   let original_config = agent.state.config in
   let new_config =

--- a/test/test_pipeline_deep.ml
+++ b/test/test_pipeline_deep.ml
@@ -178,6 +178,37 @@ let test_resolve_params_no_hook () =
     (Option.is_none params.extra_system_context)
 ;;
 
+(** resolve_turn_params with an explicit Continue decision returns defaults. *)
+let test_resolve_params_continue () =
+  let hooks = { Hooks.empty with before_turn_params = Some (fun _ -> Hooks.Continue) } in
+  let messages : Types.message list =
+    [ { role = User
+      ; content = [ Text "hello" ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let invoke_hook ~hook_name:_ hook event =
+    match hook with
+    | Some h -> h event
+    | None -> Hooks.Continue
+  in
+  let params =
+    Agent_turn.resolve_turn_params ~hooks ~messages ~max_turns:10 ~turn:0 ~invoke_hook
+  in
+  Alcotest.(check bool) "default temperature" true (Option.is_none params.temperature);
+  Alcotest.(check bool)
+    "default thinking_budget"
+    true
+    (Option.is_none params.thinking_budget);
+  Alcotest.(check bool)
+    "default extra_context"
+    true
+    (Option.is_none params.extra_system_context)
+;;
+
 (** resolve_turn_params with AdjustParams decision applies params. *)
 let test_resolve_params_adjust () =
   let adjusted : Hooks.turn_params =
@@ -764,6 +795,7 @@ let () =
         ] )
     ; ( "resolve_turn_params"
       , [ Alcotest.test_case "no hook" `Quick test_resolve_params_no_hook
+        ; Alcotest.test_case "continue uses defaults" `Quick test_resolve_params_continue
         ; Alcotest.test_case "adjust params" `Quick test_resolve_params_adjust
         ; Alcotest.test_case
             "system_prompt_override applied"


### PR DESCRIPTION
Summary
- replace hook-decision wildcard fallbacks in pipeline idle/pre-compact/before-turn handling with explicit constructors
- preserve current runtime behavior: Hooks.invoke_validated already coerces illegal decisions to Continue with diagnostics
- restore compiler exhaustiveness checking when hook_decision grows a new variant

Validation
- ocamlformat --check lib/pipeline/pipeline.ml lib/pipeline/pipeline_stage_prepare.ml
- git diff --check
- scripts/dune-local.sh build lib/agent_sdk.cma