### PR TITLE
fix(pipeline): remove dead error tagging wrapper

### DIFF
--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -751,17 +751,6 @@ let emergency_compact ?raw_trace_run agent ?limit () =
 
 (* ── Pipeline coordinator ────────────────────────────────── *)
 
-let tag_error stage result =
-  match result with
-  | Ok _ as ok -> ok
-  | Error e ->
-    let poly = Error_domain.of_sdk_error e in
-    let _ctx = Error_domain.with_stage stage poly in
-    (* Stage context is created for diagnostics;
-       we still propagate sdk_error for backward compat *)
-    Error e
-;;
-
 let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
   (* Stage 1: Input *)
   let* () =
@@ -774,7 +763,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
       ; extra = []
       ; links = []
       }
-      (fun _tracer -> stage_input ?raw_trace_run agent |> tag_error "input")
+      (fun _tracer -> stage_input ?raw_trace_run agent)
   in
   (* Stage 2: Parse *)
   let prep, original_config, turn_params =
@@ -900,9 +889,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
               })
        | None -> ());
       let t0 = Unix.gettimeofday () in
-      let api_result =
-        stage_route ~sw ?clock ~api_strategy agent prep |> tag_error "route"
-      in
+      let api_result = stage_route ~sw ?clock ~api_strategy agent prep in
       let duration_ms = (Unix.gettimeofday () -. t0) *. 1000.0 in
       (match agent.options.journal, api_result with
        | Some j, Ok response ->
@@ -979,16 +966,12 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
           update_state agent (fun s -> { s with config = original_config });
           Error (Error.Agent (GuardrailViolation { validator = validator_name; reason }))
         | Guardrails_async.Pass ->
-          let* () =
-            stage_collect ?raw_trace_run agent ~original_config response
-            |> tag_error "collect"
-          in
+          let* () = stage_collect ?raw_trace_run agent ~original_config response in
           stage_output
             ?raw_trace_run
             agent
             ~effective_guardrails:prep.effective_guardrails
-            response
-          |> tag_error "output"))
+            response))
 ;;
 
 [@@@coverage off]
@@ -1082,18 +1065,6 @@ let%test "last_tool_results_from skips non-tool user messages" =
   match last_tool_results_from msgs with
   | [ Ok { content = "first"; _meta = _ } ] -> true
   | _ -> false
-;;
-
-let%test "tag_error passes through Ok" =
-  let result = tag_error "test_stage" (Ok 42) in
-  result = Ok 42
-;;
-
-let%test "tag_error passes through Error" =
-  let err = Error.Internal "test error" in
-  match tag_error "test_stage" (Error err) with
-  | Error e -> e = err
-  | Ok _ -> false
 ;;
 
 (* --- Additional coverage tests --- *)
@@ -1208,22 +1179,6 @@ let%test "last_tool_results_from error tool result" =
   | _ -> false
 ;;
 
-let%test "tag_error with Config error" =
-  let err = Error.Config (MissingEnvVar { var_name = "X" }) in
-  match tag_error "parse" (Error err) with
-  | Error e -> e = err
-  | Ok _ -> false
-;;
-
-let%test "tag_error with Agent error" =
-  let err = Error.Agent (UnrecognizedStopReason { reason = "weird" }) in
-  match tag_error "output" (Error err) with
-  | Error e -> e = err
-  | Ok _ -> false
-;;
-
-let%test "tag_error string result Ok" = tag_error "collect" (Ok "success") = Ok "success"
-
 (* --- Additional pipeline tests --- *)
 
 let%test "last_tool_results_from only non-result roles" =
@@ -1293,32 +1248,6 @@ let%test "last_tool_results_from user msg with only non-tool content" =
   in
   last_tool_results_from msgs = []
 ;;
-
-let%test "tag_error with Serialization error" =
-  let err = Error.Serialization (JsonParseError { detail = "bad json" }) in
-  match tag_error "route" (Error err) with
-  | Error e -> e = err
-  | Ok _ -> false
-;;
-
-let%test "tag_error with Io error" =
-  let err =
-    Error.Io (FileOpFailed { op = "read"; path = "/tmp/x"; detail = "not found" })
-  in
-  match tag_error "input" (Error err) with
-  | Error e -> e = err
-  | Ok _ -> false
-;;
-
-let%test "tag_error with Mcp error" =
-  let err = Error.Mcp (InitializeFailed { detail = "timeout" }) in
-  match tag_error "parse" (Error err) with
-  | Error e -> e = err
-  | Ok _ -> false
-;;
-
-let%test "tag_error Ok unit" = tag_error "collect" (Ok ()) = Ok ()
-let%test "tag_error Ok list" = tag_error "output" (Ok [ 1; 2; 3 ]) = Ok [ 1; 2; 3 ]
 
 (* --- Proactive compaction: phase selection is tested via
    Budget_strategy inline tests; integration tested via consumer agent

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -802,7 +802,7 @@ let test_stage_parse_narrows_runtime_mcp_policy () =
   | None -> Alcotest.fail "expected runtime MCP policy"
 ;;
 
-(* ── Error_domain: tag_error ─────────────────────────────── *)
+(* ── Error_domain conversion ─────────────────────────────── *)
 
 let test_error_domain_of_sdk_error () =
   let err = Error.Agent (UnrecognizedStopReason { reason = "weird" }) in

--- a/test/test_pipeline_deep.ml
+++ b/test/test_pipeline_deep.ml
@@ -714,9 +714,7 @@ let test_stage_context_internal () =
   Alcotest.(check bool)
     "stage prefix"
     true
-    (let prefix = "[route]" in
-     String.length s >= String.length prefix
-     && String.sub s 0 (String.length prefix) = prefix)
+    (String.starts_with ~prefix:"[route]" s)
 ;;
 
 let test_stage_context_agent () =
@@ -727,9 +725,7 @@ let test_stage_context_agent () =
   Alcotest.(check bool)
     "output stage"
     true
-    (let prefix = "[output]" in
-     String.length s >= String.length prefix
-     && String.sub s 0 (String.length prefix) = prefix)
+    (String.starts_with ~prefix:"[output]" s)
 ;;
 
 let test_stage_context_collect () =
@@ -740,9 +736,7 @@ let test_stage_context_collect () =
   Alcotest.(check bool)
     "collect stage"
     true
-    (let prefix = "[collect]" in
-     String.length s >= String.length prefix
-     && String.sub s 0 (String.length prefix) = prefix)
+    (String.starts_with ~prefix:"[collect]" s)
 ;;
 
 (* ── Suite ──────────────────────────────────────────────────── *)

--- a/test/test_pipeline_deep.ml
+++ b/test/test_pipeline_deep.ml
@@ -6,7 +6,7 @@
     - Agent_turn.resolve_turn_params (Stage 2)
     - Agent_turn.apply_context_injection (Stage 5)
     - Agent_turn.filter_valid_messages (Stage 5)
-    - Error_domain.tag_error pattern (coordinator)
+    - Error_domain stage-context conversion
     - Pipeline.run_turn via mock HTTP (Stages 1-6) *)
 
 open Agent_sdk
@@ -702,10 +702,11 @@ let test_filter_valid_single_different () =
   Alcotest.(check int) "1 message kept" 1 (List.length result)
 ;;
 
-(* ── Error_domain: pipeline tag_error pattern ─────────────── *)
+(* ── Error_domain: stage-context conversion ─────────────── *)
 
-(** Verify Error_domain functions used by pipeline's tag_error. *)
-let test_tag_error_pattern_internal () =
+(** Verify Error_domain stage-context conversion independently from pipeline
+    control flow. *)
+let test_stage_context_internal () =
   let err = Error.Internal "pipeline failure" in
   let poly = Error_domain.of_sdk_error err in
   let ctx = Error_domain.with_stage "route" poly in
@@ -718,7 +719,7 @@ let test_tag_error_pattern_internal () =
      && String.sub s 0 (String.length prefix) = prefix)
 ;;
 
-let test_tag_error_pattern_agent () =
+let test_stage_context_agent () =
   let err = Error.Agent (UnrecognizedStopReason { reason = "weird" }) in
   let poly = Error_domain.of_sdk_error err in
   let ctx = Error_domain.with_stage "output" poly in
@@ -731,7 +732,7 @@ let test_tag_error_pattern_agent () =
      && String.sub s 0 (String.length prefix) = prefix)
 ;;
 
-let test_tag_error_pattern_collect () =
+let test_stage_context_collect () =
   let err = Error.Api (AuthError { message = "bad key" }) in
   let poly = Error_domain.of_sdk_error err in
   let ctx = Error_domain.with_stage "collect" poly in
@@ -803,10 +804,10 @@ let () =
             `Quick
             test_filter_valid_single_different
         ] )
-    ; ( "tag_error_pattern"
-      , [ Alcotest.test_case "internal + route" `Quick test_tag_error_pattern_internal
-        ; Alcotest.test_case "agent + output" `Quick test_tag_error_pattern_agent
-        ; Alcotest.test_case "api + collect" `Quick test_tag_error_pattern_collect
+    ; ( "error_stage_context"
+      , [ Alcotest.test_case "internal + route" `Quick test_stage_context_internal
+        ; Alcotest.test_case "agent + output" `Quick test_stage_context_agent
+        ; Alcotest.test_case "api + collect" `Quick test_stage_context_collect
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- remove `Pipeline.tag_error`, which converted SDK errors to Error_domain context and then discarded the result
- wire pipeline stages directly so error flow is explicit and allocation-free
- remove identity-only inline tests for the deleted wrapper and rename Error_domain tests to their actual scope

## Review Notes
The removed wrapper did not publish, log, return, or attach the computed stage context. Keeping it made the pipeline look more observable than it was. This PR keeps existing `sdk_error` propagation behavior and removes only the dead diagnostic computation.

## Verification
- `ocamlformat --check lib/pipeline/pipeline.ml test/test_pipeline_deep.ml test/test_pipeline.ml`
- `git diff --check`
- residue scan: no `tag_error` references remain in `lib/pipeline/pipeline.ml`
- Dune build/test intentionally left to GitHub CI per hardening review workflow.
