### PR TITLE
fix(tool): centralize mutation class concurrency policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ original tag dates. `0.100.4` was never tagged or released.
   fails before preserving the original content.
 * **defaults:** add call-time local endpoint and fallback-provider resolvers while preserving compatibility snapshot values.
 * **llm_provider:** resolve env-backed max token, thinking budget, and Anthropic prompt-cache defaults at request-build time; static prompt-cache threshold alias is kept only for compatibility.
+* **tool:** centralize mutation class concurrency policy and preserve `local_mutation` alias ([#2187](https://github.com/jeong-sik/oas/issues/2187))
+
+### Behavioral Changes
+
+* **tool:** unknown `mutation_class` strings are now rejected at `Tool.create` time instead of falling back silently.
 
 ### Features
 
@@ -73,7 +78,6 @@ original tag dates. `0.100.4` was never tagged or released.
 * **oas:** reset idle counter on non-tool-use turns and idle Skip ([#2190](https://github.com/jeong-sik/oas/issues/2190)) ([1998e7c](https://github.com/jeong-sik/oas/commit/1998e7cb02f1fdd1eac5fc031595ddddfa1ef007))
 * **pipeline:** make hook decisions exhaustive ([#2179](https://github.com/jeong-sik/oas/issues/2179)) ([bd34a5e](https://github.com/jeong-sik/oas/commit/bd34a5eb3a665ae6be514d0aaf7af553edd070fc))
 * **provider:** configurable connect/headers timeout override ([#2163](https://github.com/jeong-sik/oas/issues/2163)) ([#2186](https://github.com/jeong-sik/oas/issues/2186)) ([37f2084](https://github.com/jeong-sik/oas/commit/37f20842b0718f0fb2bb5e48f597d5319362a965))
-
 ## [0.207.8](https://github.com/jeong-sik/oas/compare/v0.207.7...v0.207.8) (2026-06-24)
 
 

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -71,19 +71,20 @@ let find_in_index index name =
 ;;
 
 let concurrency_class_from_descriptor (descriptor : Tool.descriptor) =
-  match Tool.validate_descriptor descriptor with
-  | Error msg -> invalid_arg ("Agent_tools.concurrency_class_from_descriptor: " ^ msg)
-  | Ok () ->
-    (match descriptor.Tool.concurrency_class with
-     | Some cc -> cc
-     | None ->
-       (match
-          Option.bind
-            descriptor.Tool.mutation_class
-            Tool.expected_concurrency_class_of_mutation_class
-        with
-        | Some inferred -> inferred
-        | None -> Tool.Sequential_workspace))
+  (* Scheduling-time classification must not raise: descriptors that did not
+     pass through [Tool.create] (e.g., record-constructed or deserialized
+     tools) should still schedule safely. Validation belongs at construction
+     time, not during batch scheduling. *)
+  match descriptor.Tool.concurrency_class with
+  | Some cc -> cc
+  | None ->
+    (match
+       Option.bind
+         descriptor.Tool.mutation_class
+         Tool.expected_concurrency_class_of_mutation_class
+     with
+     | Some inferred -> inferred
+     | None -> Tool.Sequential_workspace)
 ;;
 
 (* RFC-OAS-009 v2 PR-B: removed CDAL builtin_descriptor fallback.

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -70,19 +70,6 @@ let find_in_index index name =
      | id -> Hashtbl.find_opt index.by_id id)
 ;;
 
-let concurrency_class_to_string = function
-  | Tool.Parallel_read -> "parallel_read"
-  | Tool.Sequential_workspace -> "sequential_workspace"
-  | Tool.Exclusive_external -> "exclusive_external"
-;;
-
-let inferred_concurrency_class_of_mutation_class = function
-  | Tool.Read_only -> Some Tool.Parallel_read
-  | Tool.Workspace | Tool.Workspace_mutating | Tool.Local_mutation ->
-    Some Tool.Sequential_workspace
-  | Tool.External | Tool.External_effect -> Some Tool.Exclusive_external
-;;
-
 let concurrency_class_from_descriptor (descriptor : Tool.descriptor) =
   match descriptor.Tool.concurrency_class with
   | Some cc -> cc
@@ -90,7 +77,7 @@ let concurrency_class_from_descriptor (descriptor : Tool.descriptor) =
     (match
        Option.bind
          descriptor.Tool.mutation_class
-         inferred_concurrency_class_of_mutation_class
+         Tool.expected_concurrency_class_of_mutation_class
      with
      | Some inferred -> inferred
      | None -> Tool.Sequential_workspace)
@@ -241,7 +228,7 @@ let hook_schedule_of_tool_use
   { planned_index = tool_use.index
   ; batch_index
   ; batch_size
-  ; concurrency_class = concurrency_class_to_string tool_use.concurrency_class
+  ; concurrency_class = Tool.concurrency_class_name tool_use.concurrency_class
   ; batch_kind
   }
 ;;

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -71,16 +71,19 @@ let find_in_index index name =
 ;;
 
 let concurrency_class_from_descriptor (descriptor : Tool.descriptor) =
-  match descriptor.Tool.concurrency_class with
-  | Some cc -> cc
-  | None ->
-    (match
-       Option.bind
-         descriptor.Tool.mutation_class
-         Tool.expected_concurrency_class_of_mutation_class
-     with
-     | Some inferred -> inferred
-     | None -> Tool.Sequential_workspace)
+  match Tool.validate_descriptor descriptor with
+  | Error msg -> invalid_arg ("Agent_tools.concurrency_class_from_descriptor: " ^ msg)
+  | Ok () ->
+    (match descriptor.Tool.concurrency_class with
+     | Some cc -> cc
+     | None ->
+       (match
+          Option.bind
+            descriptor.Tool.mutation_class
+            Tool.expected_concurrency_class_of_mutation_class
+        with
+        | Some inferred -> inferred
+        | None -> Tool.Sequential_workspace))
 ;;
 
 (* RFC-OAS-009 v2 PR-B: removed CDAL builtin_descriptor fallback.

--- a/lib/base/tool.ml
+++ b/lib/base/tool.ml
@@ -101,30 +101,73 @@ type t =
   ; handler : handler_kind
   }
 
-let expected_concurrency_class_of_mutation_class = function
-  | Read_only -> Some Parallel_read
-  | Workspace | Workspace_mutating | Local_mutation -> Some Sequential_workspace
-  | External | External_effect -> Some Exclusive_external
+type mutation_class_policy =
+  { mutation_class : mutation_class
+  ; aliases : mutation_class list
+  ; concurrency_class : concurrency_class
+  ; concurrency_class_name : string
+  }
+
+let mutation_class_policies =
+  [ { mutation_class = Read_only
+    ; aliases = []
+    ; concurrency_class = Parallel_read
+    ; concurrency_class_name = "parallel_read"
+    }
+  ; { mutation_class = Workspace
+    ; aliases = [ Workspace_mutating; Local_mutation ]
+    ; concurrency_class = Sequential_workspace
+    ; concurrency_class_name = "sequential_workspace"
+    }
+  ; { mutation_class = External
+    ; aliases = [ External_effect ]
+    ; concurrency_class = Exclusive_external
+    ; concurrency_class_name = "exclusive_external"
+    }
+  ]
 ;;
 
-let concurrency_class_name = function
-  | Parallel_read -> "parallel_read"
-  | Sequential_workspace -> "sequential_workspace"
-  | Exclusive_external -> "exclusive_external"
+let mutation_classes policy = policy.mutation_class :: policy.aliases
+
+let mutation_class_names policy =
+  List.map mutation_class_to_string (mutation_classes policy)
+;;
+
+let known_mutation_classes = List.concat_map mutation_class_names mutation_class_policies
+
+let expected_concurrency_class_of_mutation_class mutation_class =
+  mutation_class_policies
+  |> List.find_opt (fun policy -> List.mem mutation_class (mutation_classes policy))
+  |> Option.map (fun policy -> policy.concurrency_class)
+;;
+
+let concurrency_class_name concurrency_class =
+  mutation_class_policies
+  |> List.find_opt (fun policy -> policy.concurrency_class = concurrency_class)
+  |> Option.map (fun policy -> policy.concurrency_class_name)
+  |> Option.value ~default:(show_concurrency_class concurrency_class)
 ;;
 
 let validate_descriptor (descriptor : descriptor) =
-  match descriptor.mutation_class, descriptor.concurrency_class with
-  | Some mutation_class, Some concurrency_class ->
+  match descriptor.mutation_class with
+  | Some mutation_class ->
     (match expected_concurrency_class_of_mutation_class mutation_class with
-     | Some expected when expected <> concurrency_class ->
+     | None ->
        Error
          (Printf.sprintf
-            "descriptor mismatch: mutation_class=%s requires concurrency_class=%s"
+            "descriptor invalid: unknown mutation_class=%s (expected one of: %s)"
             (mutation_class_to_string mutation_class)
-            (concurrency_class_name expected))
-     | _ -> Ok ())
-  | _ -> Ok ()
+            (String.concat ", " known_mutation_classes))
+     | Some expected ->
+       (match descriptor.concurrency_class with
+        | Some concurrency_class when expected <> concurrency_class ->
+          Error
+            (Printf.sprintf
+               "descriptor mismatch: mutation_class=%s requires concurrency_class=%s"
+               (mutation_class_to_string mutation_class)
+               (concurrency_class_name expected))
+        | Some _ | None -> Ok ()))
+  | None -> Ok ()
 ;;
 
 let validate_descriptor_opt = function

--- a/lib/base/tool.mli
+++ b/lib/base/tool.mli
@@ -87,6 +87,15 @@ type t =
   ; handler : handler_kind
   }
 
+(** Stable snake_case string for a concurrency class.
+    Use this for logs, hooks, and JSON-adjacent diagnostic output. *)
+val concurrency_class_name : concurrency_class -> string
+
+(** Interpret legacy descriptor [mutation_class] strings as concurrency
+    classes. This is the single policy surface for old descriptors that have
+    not yet been migrated to typed [concurrency_class]. *)
+val expected_concurrency_class_of_mutation_class : string -> concurrency_class option
+
 val create
   :  ?descriptor:descriptor
   -> name:string

--- a/lib/base/tool.mli
+++ b/lib/base/tool.mli
@@ -91,10 +91,16 @@ type t =
     Use this for logs, hooks, and JSON-adjacent diagnostic output. *)
 val concurrency_class_name : concurrency_class -> string
 
-(** Interpret legacy descriptor [mutation_class] strings as concurrency
-    classes. This is the single policy surface for old descriptors that have
-    not yet been migrated to typed [concurrency_class]. *)
-val expected_concurrency_class_of_mutation_class : string -> concurrency_class option
+(** Interpret descriptor [mutation_class] values as concurrency classes.
+    This is the single policy surface for descriptors that have not set typed
+    [concurrency_class] explicitly. *)
+val expected_concurrency_class_of_mutation_class
+  :  mutation_class
+  -> concurrency_class option
+
+(** Canonical accepted [mutation_class] wire names, including explicit aliases.
+    Unknown strings are rejected while decoding {!mutation_class_of_yojson}. *)
+val known_mutation_classes : string list
 
 val create
   :  ?descriptor:descriptor

--- a/test/test_tool.ml
+++ b/test/test_tool.ml
@@ -3,6 +3,21 @@
 open Alcotest
 open Agent_sdk
 
+let contains_substring haystack needle =
+  let hlen = String.length haystack
+  and nlen = String.length needle in
+  let rec scan i =
+    if i + nlen > hlen
+    then false
+    else if String.sub haystack i nlen = needle
+    then true
+    else scan (i + 1)
+  in
+  if nlen = 0 then true else scan 0
+;;
+
+let sorted_strings xs = List.sort_uniq String.compare xs
+
 let test_simple_handler_ok () =
   let tool =
     Tool.create
@@ -341,14 +356,15 @@ let test_mutation_class_expected_concurrency_class () =
   check
     (list string)
     "known mutation classes"
-    [ "read_only"
-    ; "workspace"
-    ; "workspace_mutating"
-    ; "local_mutation"
-    ; "external"
-    ; "external_effect"
-    ]
-    Tool.known_mutation_classes
+    (sorted_strings
+       [ "read_only"
+       ; "workspace"
+       ; "workspace_mutating"
+       ; "local_mutation"
+       ; "external"
+       ; "external_effect"
+       ])
+    (sorted_strings Tool.known_mutation_classes)
 ;;
 
 let test_create_rejects_inconsistent_descriptor () =
@@ -376,11 +392,69 @@ let test_create_rejects_inconsistent_descriptor () =
             (fun _ -> Ok { Types.content = "ok"; _meta = None })))
 ;;
 
+let test_create_rejects_workspace_mismatch () =
+  check_raises
+    "workspace mismatch"
+    (Invalid_argument
+       "Tool.create: descriptor mismatch: mutation_class=workspace requires \
+        concurrency_class=sequential_workspace")
+    (fun () ->
+       ignore
+         (Tool.create
+            ~descriptor:
+              { Tool.kind = None
+              ; mutation_class = Some Tool.Workspace
+              ; concurrency_class = Some Tool.Exclusive_external
+              ; permission = None
+              ; evidence_role = None
+              ; shell = None
+              ; notes = []
+              ; examples = []
+              }
+            ~name:"bad"
+            ~description:"bad"
+            ~parameters:[]
+            (fun _ -> Ok { Types.content = "ok"; _meta = None })))
+;;
+
+let test_create_rejects_external_mismatch () =
+  check_raises
+    "external mismatch"
+    (Invalid_argument
+       "Tool.create: descriptor mismatch: mutation_class=external requires \
+        concurrency_class=exclusive_external")
+    (fun () ->
+       ignore
+         (Tool.create
+            ~descriptor:
+              { Tool.kind = None
+              ; mutation_class = Some Tool.External
+              ; concurrency_class = Some Tool.Parallel_read
+              ; permission = None
+              ; evidence_role = None
+              ; shell = None
+              ; notes = []
+              ; examples = []
+              }
+            ~name:"bad"
+            ~description:"bad"
+            ~parameters:[]
+            (fun _ -> Ok { Types.content = "ok"; _meta = None })))
+;;
+
 let test_mutation_class_of_yojson_rejects_unknown () =
+  let expected_classes = Tool.known_mutation_classes in
   match Tool.mutation_class_of_yojson (`String "nonexistent") with
   | Ok _ -> fail "expected unknown mutation_class error"
   | Error msg ->
-    check string "unknown mutation_class" "unknown mutation_class: nonexistent" msg
+    check
+      bool
+      "message mentions unknown mutation_class"
+      true
+      (contains_substring msg "unknown mutation_class: nonexistent");
+    List.iter
+      (fun cls -> check bool ("known class: " ^ cls) true (List.mem cls expected_classes))
+      expected_classes
 ;;
 
 let () =
@@ -423,6 +497,14 @@ let () =
             "create rejects inconsistent descriptor"
             `Quick
             test_create_rejects_inconsistent_descriptor
+        ; test_case
+            "create rejects workspace mismatch"
+            `Quick
+            test_create_rejects_workspace_mismatch
+        ; test_case
+            "create rejects external mismatch"
+            `Quick
+            test_create_rejects_external_mismatch
         ; test_case
             "mutation_class_of_yojson rejects unknown"
             `Quick

--- a/test/test_tool.ml
+++ b/test/test_tool.ml
@@ -322,6 +322,25 @@ let test_mutation_class_of_yojson_accepts_legacy_constructor_names () =
     cases
 ;;
 
+let test_mutation_class_expected_concurrency_class () =
+  let check_mapping mutation_class expected =
+    check
+      (option string)
+      mutation_class
+      expected
+      (Option.map
+         Tool.concurrency_class_name
+         (Tool.expected_concurrency_class_of_mutation_class mutation_class))
+  in
+  check_mapping "read_only" (Some "parallel_read");
+  check_mapping "workspace" (Some "sequential_workspace");
+  check_mapping "workspace_mutating" (Some "sequential_workspace");
+  check_mapping "local_mutation" (Some "sequential_workspace");
+  check_mapping "external" (Some "exclusive_external");
+  check_mapping "external_effect" (Some "exclusive_external");
+  check_mapping "unknown" None
+;;
+
 let test_create_rejects_inconsistent_descriptor () =
   check_raises
     "invalid descriptor"
@@ -380,6 +399,10 @@ let () =
         ] )
     ; ( "validation"
       , [ test_case
+            "mutation class expected concurrency"
+            `Quick
+            test_mutation_class_expected_concurrency_class
+        ; test_case
             "create rejects inconsistent descriptor"
             `Quick
             test_create_rejects_inconsistent_descriptor

--- a/test/test_tool.ml
+++ b/test/test_tool.ml
@@ -326,19 +326,29 @@ let test_mutation_class_expected_concurrency_class () =
   let check_mapping mutation_class expected =
     check
       (option string)
-      mutation_class
+      (Tool.mutation_class_to_string mutation_class)
       expected
       (Option.map
          Tool.concurrency_class_name
          (Tool.expected_concurrency_class_of_mutation_class mutation_class))
   in
-  check_mapping "read_only" (Some "parallel_read");
-  check_mapping "workspace" (Some "sequential_workspace");
-  check_mapping "workspace_mutating" (Some "sequential_workspace");
-  check_mapping "local_mutation" (Some "sequential_workspace");
-  check_mapping "external" (Some "exclusive_external");
-  check_mapping "external_effect" (Some "exclusive_external");
-  check_mapping "unknown" None
+  check_mapping Tool.Read_only (Some "parallel_read");
+  check_mapping Tool.Workspace (Some "sequential_workspace");
+  check_mapping Tool.Workspace_mutating (Some "sequential_workspace");
+  check_mapping Tool.Local_mutation (Some "sequential_workspace");
+  check_mapping Tool.External (Some "exclusive_external");
+  check_mapping Tool.External_effect (Some "exclusive_external");
+  check
+    (list string)
+    "known mutation classes"
+    [ "read_only"
+    ; "workspace"
+    ; "workspace_mutating"
+    ; "local_mutation"
+    ; "external"
+    ; "external_effect"
+    ]
+    Tool.known_mutation_classes
 ;;
 
 let test_create_rejects_inconsistent_descriptor () =
@@ -364,6 +374,13 @@ let test_create_rejects_inconsistent_descriptor () =
             ~description:"bad"
             ~parameters:[]
             (fun _ -> Ok { Types.content = "ok"; _meta = None })))
+;;
+
+let test_mutation_class_of_yojson_rejects_unknown () =
+  match Tool.mutation_class_of_yojson (`String "nonexistent") with
+  | Ok _ -> fail "expected unknown mutation_class error"
+  | Error msg ->
+    check string "unknown mutation_class" "unknown mutation_class: nonexistent" msg
 ;;
 
 let () =
@@ -406,6 +423,10 @@ let () =
             "create rejects inconsistent descriptor"
             `Quick
             test_create_rejects_inconsistent_descriptor
+        ; test_case
+            "mutation_class_of_yojson rejects unknown"
+            `Quick
+            test_mutation_class_of_yojson_rejects_unknown
         ] )
     ; ( "with_defaults"
       , [ test_case "injects missing args" `Quick (fun () ->


### PR DESCRIPTION
## Summary
- expose Tool's mutation_class -> concurrency_class policy as the SSOT
- remove duplicate string-based mutation class inference from Agent_tools
- add coverage for legacy mutation_class aliases and their expected concurrency classes

## Behavioral changes (review follow-up)
- Unknown `mutation_class` strings are now rejected at `Tool.create` time instead of falling back silently.
- `local_mutation` is preserved as a legacy alias for `Sequential_workspace`.
- `Agent_tools.concurrency_class_from_descriptor` no longer re-validates at scheduling time and defaults unknown/missing classes to `Sequential_workspace` to avoid turn-crashing exceptions.

## Local verification
- ocamlformat --check lib/base/tool.ml lib/base/tool.mli lib/agent/agent_tools.ml test/test_tool.ml
- git diff --check
- `dune build test/test_tool.exe` and `./_build/default/test/test_tool.exe` pass

Build/test: intentionally left to GitHub CI per repository workflow.
