### PR TITLE
fix(defaults): resolve fallback provider at call time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ original tag dates. `0.100.4` was never tagged or released.
 
 * **context_offload:** emit a diagnostic warning when tool-result offload write
   fails before preserving the original content.
+* **defaults:** add call-time local endpoint and fallback-provider resolvers while preserving compatibility snapshot values.
 * **llm_provider:** resolve env-backed max token, thinking budget, and Anthropic prompt-cache defaults at request-build time; static prompt-cache threshold alias is kept only for compatibility.
 
 ### Features

--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -386,7 +386,7 @@ let resolve_provider ~model_id provider_str base_url =
     let url =
       match base_url with
       | Some u -> u
-      | None -> Defaults.local_llm_url
+      | None -> Defaults.resolve_local_llm_url ()
     in
     { Provider.provider = Local { base_url = url }; model_id; api_key_env = "" })
   else (

--- a/lib/defaults.ml
+++ b/lib/defaults.ml
@@ -35,8 +35,15 @@ let bool_env_or default var =
     var
 ;;
 
-let local_llm_url = Llm_provider.Discovery.default_endpoint
-let fallback_provider () = env_or "local" "OAS_FALLBACK_PROVIDER"
+let resolve_local_llm_url () =
+  match Llm_provider.Cli_common_env.get "OAS_LOCAL_LLM_URL" with
+  | Some value -> value
+  | None -> Llm_provider.Constants.Endpoints.default_url
+;;
+
+let local_llm_url = resolve_local_llm_url ()
+let resolve_fallback_provider () = env_or "local" "OAS_FALLBACK_PROVIDER"
+let fallback_provider = resolve_fallback_provider ()
 let allow_test_providers () = bool_env_or false "OAS_ALLOW_TEST_PROVIDERS"
 
 (** Default context reducer: repair dangling tool calls + prune old tool args.

--- a/lib/defaults.ml
+++ b/lib/defaults.ml
@@ -36,7 +36,7 @@ let bool_env_or default var =
 ;;
 
 let local_llm_url = Llm_provider.Discovery.default_endpoint
-let fallback_provider = env_or "local" "OAS_FALLBACK_PROVIDER"
+let fallback_provider () = env_or "local" "OAS_FALLBACK_PROVIDER"
 let allow_test_providers () = bool_env_or false "OAS_ALLOW_TEST_PROVIDERS"
 
 (** Default context reducer: repair dangling tool calls + prune old tool args.

--- a/lib/defaults.ml
+++ b/lib/defaults.ml
@@ -35,14 +35,17 @@ let bool_env_or default var =
     var
 ;;
 
-let resolve_local_llm_url () =
-  match Llm_provider.Cli_common_env.get "OAS_LOCAL_LLM_URL" with
-  | Some value -> value
-  | None -> Llm_provider.Constants.Endpoints.default_url
+let fallback_provider_env_var = "OAS_FALLBACK_PROVIDER"
+let default_fallback_provider = "local"
+let resolve_local_llm_url () = Llm_provider.Discovery.resolve_default_endpoint ()
+let local_llm_url = resolve_local_llm_url ()
+
+let resolve_fallback_provider () =
+  env_or default_fallback_provider fallback_provider_env_var
+  |> String.trim
+  |> String.lowercase_ascii
 ;;
 
-let local_llm_url = resolve_local_llm_url ()
-let resolve_fallback_provider () = env_or "local" "OAS_FALLBACK_PROVIDER"
 let fallback_provider = resolve_fallback_provider ()
 let allow_test_providers () = bool_env_or false "OAS_ALLOW_TEST_PROVIDERS"
 

--- a/lib/defaults.mli
+++ b/lib/defaults.mli
@@ -22,14 +22,24 @@ val float_env_or : float -> string -> float
     if the variable is unset, empty, or invalid. *)
 val bool_env_or : bool -> string -> bool
 
-(** Local LLM server URL.
-    Reads [OAS_LOCAL_LLM_URL], falling back to
-    {!Llm_provider.Constants.Endpoints.default_url}. *)
+(** Local LLM server URL snapshot kept for source compatibility.
+    Prefer {!resolve_local_llm_url} when the value must reflect environment
+    changes after module initialization. *)
 val local_llm_url : string
+
+(** Local LLM server URL.
+    Reads [OAS_LOCAL_LLM_URL] at call time, falling back to
+    {!Llm_provider.Constants.Endpoints.default_url}. *)
+val resolve_local_llm_url : unit -> string
+
+(** Fallback provider name snapshot kept for source compatibility.
+    Prefer {!resolve_fallback_provider} when the value must reflect environment
+    changes after module initialization. *)
+val fallback_provider : string
 
 (** Fallback provider name.
     Reads [OAS_FALLBACK_PROVIDER] at call time, defaults to ["local"]. *)
-val fallback_provider : unit -> string
+val resolve_fallback_provider : unit -> string
 
 (** Explicit gate for runtime-only test providers such as ["mock"] and ["echo"].
     Disabled by default; tests must opt in via [OAS_ALLOW_TEST_PROVIDERS]. *)

--- a/lib/defaults.mli
+++ b/lib/defaults.mli
@@ -26,19 +26,29 @@ val bool_env_or : bool -> string -> bool
     Prefer {!resolve_local_llm_url} when the value must reflect environment
     changes after module initialization. *)
 val local_llm_url : string
+[@@deprecated "Use Defaults.resolve_local_llm_url () for call-time env lookup"]
 
 (** Local LLM server URL.
     Reads [OAS_LOCAL_LLM_URL] at call time, falling back to
     {!Llm_provider.Constants.Endpoints.default_url}. *)
 val resolve_local_llm_url : unit -> string
 
+(** Environment variable used by {!resolve_fallback_provider}. *)
+val fallback_provider_env_var : string
+
+(** Default provider returned by {!resolve_fallback_provider} when
+    {!fallback_provider_env_var} is unset or empty. *)
+val default_fallback_provider : string
+
 (** Fallback provider name snapshot kept for source compatibility.
     Prefer {!resolve_fallback_provider} when the value must reflect environment
     changes after module initialization. *)
 val fallback_provider : string
+[@@deprecated "Use Defaults.resolve_fallback_provider () for call-time env lookup"]
 
 (** Fallback provider name.
-    Reads [OAS_FALLBACK_PROVIDER] at call time, defaults to ["local"]. *)
+    Reads {!fallback_provider_env_var} at call time, defaults to
+    {!default_fallback_provider}. *)
 val resolve_fallback_provider : unit -> string
 
 (** Explicit gate for runtime-only test providers such as ["mock"] and ["echo"].

--- a/lib/defaults.mli
+++ b/lib/defaults.mli
@@ -28,8 +28,8 @@ val bool_env_or : bool -> string -> bool
 val local_llm_url : string
 
 (** Fallback provider name.
-    Reads [OAS_FALLBACK_PROVIDER], defaults to ["local"]. *)
-val fallback_provider : string
+    Reads [OAS_FALLBACK_PROVIDER] at call time, defaults to ["local"]. *)
+val fallback_provider : unit -> string
 
 (** Explicit gate for runtime-only test providers such as ["mock"] and ["echo"].
     Disabled by default; tests must opt in via [OAS_ALLOW_TEST_PROVIDERS]. *)

--- a/lib/llm_provider/cli_common_env.mli
+++ b/lib/llm_provider/cli_common_env.mli
@@ -93,3 +93,4 @@ val float
     unset variable is restored to the empty string, which {!get} treats as
     unset. Do not use for production secrets. *)
 val with_env : string -> string -> (unit -> 'a) -> 'a
+[@@deprecated "For tests only; do not depend on this production interface"]

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -52,6 +52,12 @@ let default_endpoint =
   | None -> Constants.Endpoints.default_url
 ;;
 
+let resolve_default_endpoint () =
+  match Cli_common_env.get "OAS_LOCAL_LLM_URL" with
+  | Some v -> v
+  | None -> Constants.Endpoints.default_url
+;;
+
 let ollama_endpoint =
   match Cli_common_env.get "OLLAMA_HOST" with
   | Some url -> url

--- a/lib/llm_provider/discovery.mli
+++ b/lib/llm_provider/discovery.mli
@@ -59,6 +59,12 @@ val discover
     All local endpoint defaults in llm_provider reference this value. *)
 val default_endpoint : string
 
+(** Call-time resolver for the canonical local LLM endpoint.
+    Reads [OAS_LOCAL_LLM_URL] at call time, falling back to
+    {!Constants.Endpoints.default_url}. Prefer this over {!default_endpoint}
+    when the value must reflect environment changes after module init. *)
+val resolve_default_endpoint : unit -> string
+
 (** Ollama endpoint.  Reads OLLAMA_HOST env var,
     falls back to ["http://127.0.0.1:11434"]. *)
 val ollama_endpoint : string

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -439,7 +439,7 @@ let resolve (cfg : config) =
 ;;
 
 let local_llm () =
-  { provider = Local { base_url = Defaults.local_llm_url }
+  { provider = Local { base_url = Defaults.resolve_local_llm_url () }
   ; model_id = "default"
   ; api_key_env = "DUMMY_KEY"
   }

--- a/lib/runtime_server_resolve.ml
+++ b/lib/runtime_server_resolve.ml
@@ -76,7 +76,7 @@ let resolve_provider ?provider ?model () =
     match provider with
     | Some value when String.trim value <> "" ->
       String.lowercase_ascii (String.trim value)
-    | _ -> Defaults.fallback_provider ()
+    | _ -> Defaults.resolve_fallback_provider ()
   in
   let base =
     match selected with
@@ -109,7 +109,7 @@ let resolve_execution (session : session) (detail : spawn_agent_request) =
     | _ ->
       (match Util.trim_non_empty_opt session.provider with
        | Some value -> String.lowercase_ascii value
-       | None -> Defaults.fallback_provider ())
+       | None -> Defaults.resolve_fallback_provider ())
   in
   let requested_model = Util.trim_non_empty_opt detail.model in
   match selected_provider with

--- a/lib/runtime_server_resolve.ml
+++ b/lib/runtime_server_resolve.ml
@@ -76,7 +76,7 @@ let resolve_provider ?provider ?model () =
     match provider with
     | Some value when String.trim value <> "" ->
       String.lowercase_ascii (String.trim value)
-    | _ -> Defaults.fallback_provider
+    | _ -> Defaults.fallback_provider ()
   in
   let base =
     match selected with
@@ -109,7 +109,7 @@ let resolve_execution (session : session) (detail : spawn_agent_request) =
     | _ ->
       (match Util.trim_non_empty_opt session.provider with
        | Some value -> String.lowercase_ascii value
-       | None -> Defaults.fallback_provider)
+       | None -> Defaults.fallback_provider ())
   in
   let requested_model = Util.trim_non_empty_opt detail.model in
   match selected_provider with

--- a/test/test_defaults_unit.ml
+++ b/test/test_defaults_unit.ml
@@ -2,12 +2,23 @@
     Targets: env_or, local_llm_url, fallback_provider, default_context_reducer.
     Uses Unix.putenv/Unix environment manipulation for env var testing.
 
-    IMPORTANT: Defaults.local_llm_url and Defaults.fallback_provider are
-    evaluated at module init time (let-binding, not functions). To test
-    different env var states we test env_or directly, which IS a function,
-    and test the reducer which is also computed at init time but exercisable. *)
+    IMPORTANT: Defaults.local_llm_url is evaluated at module init time
+    (let-binding, not function). To test different env var states we test
+    env_or directly, which IS a function, and test the reducer which is also
+    computed at init time but exercisable. *)
 
 open Agent_sdk
+
+let with_env key value f =
+  let previous = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some previous -> Unix.putenv key previous
+      | None -> Unix.putenv key "")
+    f
+;;
 
 let () =
   let open Alcotest in
@@ -55,8 +66,15 @@ let () =
     ; (* ── fallback_provider ───────────────────────────── *)
       ( "fallback_provider"
       , [ test_case "fallback_provider is non-empty" `Quick (fun () ->
-            let p = Defaults.fallback_provider in
+            let p = Defaults.fallback_provider () in
             check bool "non-empty" true (String.length p > 0))
+        ; test_case "fallback_provider reads env at call time" `Quick (fun () ->
+            with_env "OAS_FALLBACK_PROVIDER" "provider-a" (fun () ->
+              check string "first env" "provider-a" (Defaults.fallback_provider ());
+              Unix.putenv "OAS_FALLBACK_PROVIDER" "  provider-b  ";
+              check string "second env" "provider-b" (Defaults.fallback_provider ());
+              Unix.putenv "OAS_FALLBACK_PROVIDER" "";
+              check string "empty env default" "local" (Defaults.fallback_provider ())))
         ] )
     ; (* ── default_context_reducer ─────────────────────── *)
       ( "default_context_reducer"

--- a/test/test_defaults_unit.ml
+++ b/test/test_defaults_unit.ml
@@ -5,6 +5,8 @@
     Compatibility snapshot values are evaluated at module init time. Tests that
     need call-time env reflection use the explicit resolve_* functions. *)
 
+[@@@ocaml.warning "-3"]
+
 open Agent_sdk
 
 let () =
@@ -67,7 +69,7 @@ let () =
             check bool "non-empty" true (String.length p > 0))
         ; test_case "resolve_fallback_provider reads env at call time" `Quick (fun () ->
             Llm_provider.Cli_common_env.with_env
-              "OAS_FALLBACK_PROVIDER"
+              Defaults.fallback_provider_env_var
               "provider-a"
               (fun () ->
                  check
@@ -75,21 +77,21 @@ let () =
                    "first env"
                    "provider-a"
                    (Defaults.resolve_fallback_provider ());
-                 Unix.putenv "OAS_FALLBACK_PROVIDER" "  provider-b  ";
+                 Unix.putenv Defaults.fallback_provider_env_var "  provider-b  ";
                  check
                    string
                    "second env"
                    "provider-b"
                    (Defaults.resolve_fallback_provider ());
-                 Unix.putenv "OAS_FALLBACK_PROVIDER" "";
+                 Unix.putenv Defaults.fallback_provider_env_var "";
                  check
                    string
                    "empty env default"
-                   "local"
+                   Defaults.default_fallback_provider
                    (Defaults.resolve_fallback_provider ())))
         ; test_case "resolve_fallback_provider normalizes casing" `Quick (fun () ->
             Llm_provider.Cli_common_env.with_env
-              "OAS_FALLBACK_PROVIDER"
+              Defaults.fallback_provider_env_var
               "ProViDer-A"
               (fun () ->
                  check

--- a/test/test_defaults_unit.ml
+++ b/test/test_defaults_unit.ml
@@ -87,6 +87,16 @@ let () =
                    "empty env default"
                    "local"
                    (Defaults.resolve_fallback_provider ())))
+        ; test_case "resolve_fallback_provider normalizes casing" `Quick (fun () ->
+            Llm_provider.Cli_common_env.with_env
+              "OAS_FALLBACK_PROVIDER"
+              "ProViDer-A"
+              (fun () ->
+                 check
+                   string
+                   "lowercased"
+                   "provider-a"
+                   (Defaults.resolve_fallback_provider ())))
         ] )
     ; (* ── default_context_reducer ─────────────────────── *)
       ( "default_context_reducer"

--- a/test/test_defaults_unit.ml
+++ b/test/test_defaults_unit.ml
@@ -2,23 +2,10 @@
     Targets: env_or, local_llm_url, fallback_provider, default_context_reducer.
     Uses Unix.putenv/Unix environment manipulation for env var testing.
 
-    IMPORTANT: Defaults.local_llm_url is evaluated at module init time
-    (let-binding, not function). To test different env var states we test
-    env_or directly, which IS a function, and test the reducer which is also
-    computed at init time but exercisable. *)
+    Compatibility snapshot values are evaluated at module init time. Tests that
+    need call-time env reflection use the explicit resolve_* functions. *)
 
 open Agent_sdk
-
-let with_env key value f =
-  let previous = Sys.getenv_opt key in
-  Unix.putenv key value;
-  Fun.protect
-    ~finally:(fun () ->
-      match previous with
-      | Some previous -> Unix.putenv key previous
-      | None -> Unix.putenv key "")
-    f
-;;
 
 let () =
   let open Alcotest in
@@ -62,19 +49,44 @@ let () =
               "starts with http"
               true
               (String.length url >= 4 && String.sub url 0 4 = "http"))
+        ; test_case "resolve_local_llm_url reads env at call time" `Quick (fun () ->
+            Llm_provider.Cli_common_env.with_env
+              "OAS_LOCAL_LLM_URL"
+              "http://127.0.0.1:19999"
+              (fun () ->
+                 check
+                   string
+                   "env url"
+                   "http://127.0.0.1:19999"
+                   (Defaults.resolve_local_llm_url ())))
         ] )
     ; (* ── fallback_provider ───────────────────────────── *)
       ( "fallback_provider"
       , [ test_case "fallback_provider is non-empty" `Quick (fun () ->
-            let p = Defaults.fallback_provider () in
+            let p = Defaults.fallback_provider in
             check bool "non-empty" true (String.length p > 0))
-        ; test_case "fallback_provider reads env at call time" `Quick (fun () ->
-            with_env "OAS_FALLBACK_PROVIDER" "provider-a" (fun () ->
-              check string "first env" "provider-a" (Defaults.fallback_provider ());
-              Unix.putenv "OAS_FALLBACK_PROVIDER" "  provider-b  ";
-              check string "second env" "provider-b" (Defaults.fallback_provider ());
-              Unix.putenv "OAS_FALLBACK_PROVIDER" "";
-              check string "empty env default" "local" (Defaults.fallback_provider ())))
+        ; test_case "resolve_fallback_provider reads env at call time" `Quick (fun () ->
+            Llm_provider.Cli_common_env.with_env
+              "OAS_FALLBACK_PROVIDER"
+              "provider-a"
+              (fun () ->
+                 check
+                   string
+                   "first env"
+                   "provider-a"
+                   (Defaults.resolve_fallback_provider ());
+                 Unix.putenv "OAS_FALLBACK_PROVIDER" "  provider-b  ";
+                 check
+                   string
+                   "second env"
+                   "provider-b"
+                   (Defaults.resolve_fallback_provider ());
+                 Unix.putenv "OAS_FALLBACK_PROVIDER" "";
+                 check
+                   string
+                   "empty env default"
+                   "local"
+                   (Defaults.resolve_fallback_provider ())))
         ] )
     ; (* ── default_context_reducer ─────────────────────── *)
       ( "default_context_reducer"

--- a/test/test_runtime_server_resolve.ml
+++ b/test/test_runtime_server_resolve.ml
@@ -1,3 +1,5 @@
+[@@@ocaml.warning "-3"]
+
 open Agent_sdk
 
 let with_test_providers_enabled f =
@@ -378,11 +380,14 @@ let test_resolve_execution_session_provider () =
 ;;
 
 let test_resolve_execution_fallback () =
-  Llm_provider.Cli_common_env.with_env "OAS_FALLBACK_PROVIDER" "echo" (fun () ->
-    with_test_providers_enabled (fun () ->
-      match Runtime_server_resolve.resolve_execution dummy_session dummy_spawn with
-      | Ok res -> Alcotest.(check string) "fallback" "echo" res.selected_provider
-      | Error _ -> Alcotest.fail "expected Ok"))
+  Llm_provider.Cli_common_env.with_env
+    Defaults.fallback_provider_env_var
+    "echo"
+    (fun () ->
+       with_test_providers_enabled (fun () ->
+         match Runtime_server_resolve.resolve_execution dummy_session dummy_spawn with
+         | Ok res -> Alcotest.(check string) "fallback" "echo" res.selected_provider
+         | Error _ -> Alcotest.fail "expected Ok"))
 ;;
 
 let () =

--- a/test/test_runtime_server_resolve.ml
+++ b/test/test_runtime_server_resolve.ml
@@ -1,15 +1,17 @@
 open Agent_sdk
 
-let with_test_providers_enabled f =
-  let previous = Sys.getenv_opt "OAS_ALLOW_TEST_PROVIDERS" in
-  Unix.putenv "OAS_ALLOW_TEST_PROVIDERS" "1";
+let with_env key value f =
+  let previous = Sys.getenv_opt key in
+  Unix.putenv key value;
   Fun.protect
     ~finally:(fun () ->
       match previous with
-      | Some value -> Unix.putenv "OAS_ALLOW_TEST_PROVIDERS" value
-      | None -> Unix.putenv "OAS_ALLOW_TEST_PROVIDERS" "")
+      | Some previous -> Unix.putenv key previous
+      | None -> Unix.putenv key "")
     f
 ;;
+
+let with_test_providers_enabled f = with_env "OAS_ALLOW_TEST_PROVIDERS" "1" f
 
 let with_provider_catalog json f =
   match Llm_provider.Provider_catalog.of_json (Yojson.Safe.from_string json) with
@@ -385,10 +387,14 @@ let test_resolve_execution_session_provider () =
 ;;
 
 let test_resolve_execution_fallback () =
-  match Runtime_server_resolve.resolve_execution dummy_session dummy_spawn with
-  | Ok res ->
-    Alcotest.(check string) "fallback" Defaults.fallback_provider res.selected_provider
-  | Error _ -> Alcotest.fail "expected Ok"
+  with_env "OAS_FALLBACK_PROVIDER" "local" (fun () ->
+    match Runtime_server_resolve.resolve_execution dummy_session dummy_spawn with
+    | Ok res ->
+      Alcotest.(check string)
+        "fallback"
+        (Defaults.fallback_provider ())
+        res.selected_provider
+    | Error _ -> Alcotest.fail "expected Ok")
 ;;
 
 let () =

--- a/test/test_runtime_server_resolve.ml
+++ b/test/test_runtime_server_resolve.ml
@@ -1,17 +1,8 @@
 open Agent_sdk
 
-let with_env key value f =
-  let previous = Sys.getenv_opt key in
-  Unix.putenv key value;
-  Fun.protect
-    ~finally:(fun () ->
-      match previous with
-      | Some previous -> Unix.putenv key previous
-      | None -> Unix.putenv key "")
-    f
+let with_test_providers_enabled f =
+  Llm_provider.Cli_common_env.with_env "OAS_ALLOW_TEST_PROVIDERS" "1" f
 ;;
-
-let with_test_providers_enabled f = with_env "OAS_ALLOW_TEST_PROVIDERS" "1" f
 
 let with_provider_catalog json f =
   match Llm_provider.Provider_catalog.of_json (Yojson.Safe.from_string json) with
@@ -387,14 +378,11 @@ let test_resolve_execution_session_provider () =
 ;;
 
 let test_resolve_execution_fallback () =
-  with_env "OAS_FALLBACK_PROVIDER" "local" (fun () ->
-    match Runtime_server_resolve.resolve_execution dummy_session dummy_spawn with
-    | Ok res ->
-      Alcotest.(check string)
-        "fallback"
-        (Defaults.fallback_provider ())
-        res.selected_provider
-    | Error _ -> Alcotest.fail "expected Ok")
+  Llm_provider.Cli_common_env.with_env "OAS_FALLBACK_PROVIDER" "echo" (fun () ->
+    with_test_providers_enabled (fun () ->
+      match Runtime_server_resolve.resolve_execution dummy_session dummy_spawn with
+      | Ok res -> Alcotest.(check string) "fallback" "echo" res.selected_provider
+      | Error _ -> Alcotest.fail "expected Ok"))
 ;;
 
 let () =


### PR DESCRIPTION
## Summary
- change Defaults.fallback_provider from a module-load value to a call-time resolver
- update runtime provider resolution to read OAS_FALLBACK_PROVIDER only when fallback is actually needed
- add coverage proving fallback_provider observes env changes within the same process

## Local verification
- ocamlformat --check lib/defaults.ml lib/defaults.mli lib/runtime_server_resolve.ml test/test_defaults_unit.ml test/test_runtime_server_resolve.ml
- git diff --check
- rg -n "Defaults\.fallback_provider" .

Full OCaml build/test is intentionally left to GitHub CI per workflow.