### PR TITLE
fix(oas): reset idle counter on non-tool-use turns and idle Skip

### DIFF
--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -487,6 +487,10 @@ let update_idle_detection ~idle_state ~tool_uses =
     ~tool_uses
 ;;
 
+let reset_idle_detection () =
+  { new_state = { last_tool_calls = None; consecutive_idle_turns = 0 }; is_idle = false }
+;;
+
 (** Default per-tool-result character cap.
     Aligned with Claude Code's DEFAULT_MAX_RESULT_SIZE_CHARS (50,000).
     Results exceeding this are truncated with a marker at creation time,

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -232,6 +232,9 @@ val update_idle_detection_with_normalizer
   -> tool_uses:Types.content_block list
   -> idle_result
 
+(** Reset idle detection state after a non-tool-use turn or an idle Skip. *)
+val reset_idle_detection : unit -> idle_result
+
 (** {1 Tool result construction} *)
 
 (** Default per-tool-result character cap (50,000).

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -191,6 +191,11 @@ let default_options =
 
 type tool_call_fingerprint = Agent_turn.tool_call_fingerprint
 
+type idle_state = Agent_turn.idle_state =
+  { last_tool_calls : tool_call_fingerprint list option
+  ; consecutive_idle_turns : int
+  }
+
 type t =
   { mu : Eio.Mutex.t
   ; mutable state : agent_state
@@ -232,6 +237,20 @@ let set_consecutive_idle_turns t n =
 
 let get_consecutive_idle_turns t =
   Eio.Mutex.use_ro t.mu (fun () -> t.consecutive_idle_turns)
+;;
+
+(** Mutex-protected atomic update of both idle-detection fields.  Keeps
+    [last_tool_calls] and [consecutive_idle_turns] consistent under
+    concurrent updates from parallel tool-execution fibers or periodic
+    callbacks. *)
+let set_idle_state t (s : Agent_turn.idle_state) =
+  Eio.Mutex.use_rw ~protect:true t.mu (fun () ->
+    t.last_tool_calls <- s.last_tool_calls;
+    t.consecutive_idle_turns <- s.consecutive_idle_turns)
+;;
+
+let reset_idle_state t =
+  set_idle_state t (Agent_turn.reset_idle_detection ()).new_state
 ;;
 
 let description t = t.options.description

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -225,6 +225,12 @@ type lifecycle_snapshot = Agent_lifecycle.lifecycle_snapshot =
 
 type tool_call_fingerprint = Agent_turn.tool_call_fingerprint
 
+(** Idle detection state snapshot. *)
+type idle_state = Agent_turn.idle_state =
+  { last_tool_calls : tool_call_fingerprint list option
+  ; consecutive_idle_turns : int
+  }
+
 (** Mutable agent record — library-internal only.
     External code must use [Agent.t] (abstract) and its accessors.
 
@@ -262,6 +268,16 @@ val set_state : t -> Types.agent_state -> unit
 val update_state : t -> (Types.agent_state -> Types.agent_state) -> unit
 val set_consecutive_idle_turns : t -> int -> unit
 val get_consecutive_idle_turns : t -> int
+
+(** Mutex-protected atomic update of both idle-detection fields.
+    Callers should use this instead of assigning [last_tool_calls] and
+    [consecutive_idle_turns] directly, so the two fields stay consistent
+    under concurrent tool-execution fibers and periodic callbacks. *)
+val set_idle_state : t -> idle_state -> unit
+
+(** Reset idle-detection counters to their initial (zero) state.
+    Equivalent to [set_idle_state t { last_tool_calls = None; consecutive_idle_turns = 0 }]. *)
+val reset_idle_state : t -> unit
 val description : t -> string option
 val allowed_paths : t -> string list
 

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -316,9 +316,7 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
              }
            ~tool_uses
        in
-       Eio.Mutex.use_rw ~protect:true agent.mu (fun () ->
-         agent.last_tool_calls <- idle_result.new_state.last_tool_calls;
-         agent.consecutive_idle_turns <- idle_result.new_state.consecutive_idle_turns);
+       Agent_types.set_idle_state agent idle_result.new_state;
        let idle_skip = ref false in
        let idle_handled = ref false in
        (* true when Nudge or Skip handled idle *)
@@ -503,12 +501,6 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
     ; links = []
     }
     (fun _tracer ->
-       let reset_idle_state () =
-         Eio.Mutex.use_rw ~protect:true agent.mu (fun () ->
-           let reset = Agent_turn.reset_idle_detection () in
-           agent.last_tool_calls <- reset.new_state.last_tool_calls;
-           agent.consecutive_idle_turns <- reset.new_state.consecutive_idle_turns)
-       in
        match response.stop_reason with
        | StopToolUse ->
          let tool_uses =
@@ -531,7 +523,7 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
          (match result with
           | Ok IdleSkipped ->
             (* on_idle hook returned Skip: stop gracefully with the current response *)
-            reset_idle_state ();
+            Agent_types.reset_idle_state agent;
             Ok (Complete response)
           | other -> other)
        | EndTurn
@@ -541,7 +533,9 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
        | PauseTurn
        | Compaction
        | ContextWindowExceeded ->
-         reset_idle_state ();
+         (* Invoke on_stop before resetting idle counters, so observers
+            (hooks, tracers, telemetry callbacks) can read the actual
+            consecutive_idle_turns value that drove this turn's behavior. *)
          let _stop =
            invoke_hook_with_trace
              agent
@@ -550,9 +544,10 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
              agent.options.hooks.on_stop
              (Hooks.OnStop { reason = response.stop_reason; response })
          in
+         Agent_types.reset_idle_state agent;
          Ok (Complete response)
        | Unknown reason ->
-         reset_idle_state ();
+         Agent_types.reset_idle_state agent;
          Error (Error.Agent (UnrecognizedStopReason { reason })))
 ;;
 

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -551,7 +551,9 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
              (Hooks.OnStop { reason = response.stop_reason; response })
          in
          Ok (Complete response)
-       | Unknown reason -> Error (Error.Agent (UnrecognizedStopReason { reason })))
+       | Unknown reason ->
+         reset_idle_state ();
+         Error (Error.Agent (UnrecognizedStopReason { reason })))
 ;;
 
 (* ── Proactive watermark compaction (Phase 2) ───────────── *)

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -503,6 +503,12 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
     ; links = []
     }
     (fun _tracer ->
+       let reset_idle_state () =
+         Eio.Mutex.use_rw ~protect:true agent.mu (fun () ->
+           let reset = Agent_turn.reset_idle_detection () in
+           agent.last_tool_calls <- reset.new_state.last_tool_calls;
+           agent.consecutive_idle_turns <- reset.new_state.consecutive_idle_turns)
+       in
        match response.stop_reason with
        | StopToolUse ->
          let tool_uses =
@@ -525,6 +531,7 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
          (match result with
           | Ok IdleSkipped ->
             (* on_idle hook returned Skip: stop gracefully with the current response *)
+            reset_idle_state ();
             Ok (Complete response)
           | other -> other)
        | EndTurn
@@ -534,6 +541,7 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
        | PauseTurn
        | Compaction
        | ContextWindowExceeded ->
+         reset_idle_state ();
          let _stop =
            invoke_hook_with_trace
              agent

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -732,6 +732,32 @@ let test_idle_non_tool_use_ignored () =
   Alcotest.(check bool) "first not idle" false r1.is_idle
 ;;
 
+let test_idle_reset_breaks_streak () =
+  let tool = make_tool_use "search" {|{"q":"test"}|} in
+  let first =
+    Agent_turn.update_idle_detection
+      ~idle_state:{ last_tool_calls = None; consecutive_idle_turns = 0 }
+      ~tool_uses:[ tool ]
+  in
+  Alcotest.(check bool) "first not idle" false first.is_idle;
+  let second =
+    Agent_turn.update_idle_detection ~idle_state:first.new_state ~tool_uses:[ tool ]
+  in
+  Alcotest.(check bool) "repeat is idle" true second.is_idle;
+  Alcotest.(check int) "streak 1" 1 second.new_state.consecutive_idle_turns;
+  let reset = Agent_turn.reset_idle_detection () in
+  Alcotest.(check int) "reset clears streak" 0 reset.new_state.consecutive_idle_turns;
+  Alcotest.(check bool)
+    "last cleared"
+    true
+    (Option.is_none reset.new_state.last_tool_calls);
+  let after_reset =
+    Agent_turn.update_idle_detection ~idle_state:reset.new_state ~tool_uses:[ tool ]
+  in
+  Alcotest.(check bool) "after reset same tool is not idle" false after_reset.is_idle;
+  Alcotest.(check int) "streak stays 0" 0 after_reset.new_state.consecutive_idle_turns
+;;
+
 (* ── apply_context_injection ─────────────────────────────── *)
 
 let test_apply_context_injection_no_injector () =
@@ -993,6 +1019,10 @@ let () =
             test_idle_normalized_alias_calls
         ; Alcotest.test_case "multiple tools" `Quick test_idle_multiple_tools
         ; Alcotest.test_case "non-tool ignored" `Quick test_idle_non_tool_use_ignored
+        ; Alcotest.test_case
+            "reset breaks idle streak"
+            `Quick
+            test_idle_reset_breaks_streak
         ; Alcotest.test_case
             "granularity=Exact distinguishes inputs"
             `Quick

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -4,6 +4,8 @@
     Provider_mock.next_response and agent state inspection. *)
 
 open Agent_sdk
+module Internal_agent = Agent_sdk__Agent_types
+module Internal_pipeline = Agent_sdk__Pipeline
 
 (* ── Provider mock: verify pipeline stages via mock responses ── *)
 
@@ -200,6 +202,100 @@ let test_agent_turn_idle_detection () =
   in
   Alcotest.(check bool) "repeated call is idle" true idle_result2.is_idle;
   Alcotest.(check int) "consecutive 1" 1 idle_result2.new_state.consecutive_idle_turns
+;;
+
+let pipeline_response stop_reason : Types.api_response =
+  { id = "pipeline-reset-test"
+  ; model = "mock-model"
+  ; stop_reason
+  ; content = [ Text "done" ]
+  ; usage = None
+  ; telemetry = None
+  }
+;;
+
+let transport_returning response =
+  { Llm_provider.Llm_transport.complete_sync =
+      (fun _req ->
+        { Llm_provider.Llm_transport.response = Ok response; latency_ms = Some 0 })
+  ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _req -> Ok response)
+  }
+;;
+
+let seed_idle_state agent =
+  Eio.Mutex.use_rw ~protect:true agent.Internal_agent.mu (fun () ->
+    agent.last_tool_calls <- Some [ { Agent_turn.fp_name = "search"; fp_input = "{}" } ];
+    agent.consecutive_idle_turns <- 7)
+;;
+
+let idle_state_snapshot agent =
+  Eio.Mutex.use_ro agent.Internal_agent.mu (fun () ->
+    agent.last_tool_calls, agent.consecutive_idle_turns)
+;;
+
+let make_pipeline_test_agent ~net ~response =
+  let transport = transport_returning response in
+  let options =
+    { Internal_agent.default_options with
+      transport = Some transport
+    ; provider = Some (Provider_mock.to_provider_config ())
+    ; guardrails = Guardrails.permissive
+    ; max_idle_turns = 99
+    }
+  in
+  let agent =
+    Internal_agent.create
+      ~net
+      ~config:{ Types.default_config with name = "pipeline-idle-reset-test" }
+      ~options
+      ()
+  in
+  Internal_agent.set_state
+    agent
+    { (Internal_agent.state agent) with messages = [ Types.user_msg "hello" ] };
+  seed_idle_state agent;
+  agent
+;;
+
+let assert_pipeline_idle_reset agent =
+  let last_tool_calls, consecutive_idle_turns = idle_state_snapshot agent in
+  Alcotest.(check bool) "last tool calls reset" true (Option.is_none last_tool_calls);
+  Alcotest.(check int) "consecutive idle reset" 0 consecutive_idle_turns
+;;
+
+let test_pipeline_output_resets_idle_on_end_turn () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let agent = make_pipeline_test_agent ~net ~response:(pipeline_response EndTurn) in
+  (match Internal_pipeline.run_turn ~sw ~api_strategy:Internal_pipeline.Sync agent with
+   | Ok (Internal_pipeline.Complete response) ->
+     Alcotest.(check bool) "completed" true (response.stop_reason = EndTurn)
+   | Ok Internal_pipeline.ToolsExecuted ->
+     Alcotest.fail "expected Complete, got ToolsExecuted"
+   | Ok Internal_pipeline.IdleSkipped ->
+     Alcotest.fail "expected Complete, got IdleSkipped"
+   | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err));
+  assert_pipeline_idle_reset agent
+;;
+
+let test_pipeline_output_resets_idle_on_unknown () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let agent =
+    make_pipeline_test_agent ~net ~response:(pipeline_response (Unknown "mystery-stop"))
+  in
+  (match Internal_pipeline.run_turn ~sw ~api_strategy:Internal_pipeline.Sync agent with
+   | Error (Error.Agent (UnrecognizedStopReason { reason })) ->
+     Alcotest.(check string) "unknown reason" "mystery-stop" reason
+   | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
+   | Ok _ -> Alcotest.fail "expected unrecognized stop reason");
+  assert_pipeline_idle_reset agent
 ;;
 
 (* ── Provider_mock: additional coverage ─────────────────── *)
@@ -1004,6 +1100,14 @@ let () =
         ; Alcotest.test_case "different tools" `Quick test_idle_detection_different_tools
         ; Alcotest.test_case "same input idle" `Quick test_idle_detection_same_input
         ; Alcotest.test_case "empty tools idle" `Quick test_idle_detection_empty_tools
+        ; Alcotest.test_case
+            "output resets idle on end turn"
+            `Quick
+            test_pipeline_output_resets_idle_on_end_turn
+        ; Alcotest.test_case
+            "output resets idle on unknown"
+            `Quick
+            test_pipeline_output_resets_idle_on_unknown
         ; Alcotest.test_case "extra system context" `Quick test_prepare_turn_extra_context
         ; Alcotest.test_case
             "tool filter override"


### PR DESCRIPTION
## Summary
Agent_turn.update_idle_detection only sees ToolUse blocks, so a run of repeated identical tool calls followed by a text/thinking/EndTurn/etc. turn would keep the stale consecutive_idle_turns counter. Reset it on every non-tool-use stop reason and on IdleSkipped so the idle loop detector starts fresh when the agent returns to tool use.

## Test Plan
- test/test_agent_turn.ml: 39 tests pass, including new "reset breaks idle streak" case.
- Full CI green required before merge.