### PR TITLE
fix(mcp): resolve http transport env at call time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ original tag dates. `0.100.4` was never tagged or released.
 
 ## Unreleased
 
+### Breaking Changes
+
+* **mcp_http:** `Mcp_http.default_config` is now `unit -> config` so
+  `OAS_MCP_HTTP_URL` is read at call time. Update downstream callers from
+  `Mcp_http.default_config` to `Mcp_http.default_config ()`.
+
 ## [0.207.8](https://github.com/jeong-sik/oas/compare/v0.207.7...v0.207.8) (2026-06-24)
 
 

--- a/lib/protocol/mcp_http.ml
+++ b/lib/protocol/mcp_http.ml
@@ -6,9 +6,11 @@ type config =
   ; headers : (string * string) list
   }
 
+let default_endpoint_env_var = "OAS_MCP_HTTP_URL"
+
 let default_config () =
   { base_url =
-      Util.env_or "http://localhost:8080/mcp" "OAS_MCP_HTTP_URL"
+      Util.env_or "http://localhost:8080/mcp" default_endpoint_env_var
       (* Set OAS_MCP_HTTP_URL to override the MCP server endpoint.
          Default assumes local dev server on port 8080. *)
   ; headers = []

--- a/lib/protocol/mcp_http.ml
+++ b/lib/protocol/mcp_http.ml
@@ -6,7 +6,7 @@ type config =
   ; headers : (string * string) list
   }
 
-let default_config =
+let default_config () =
   { base_url =
       Util.env_or "http://localhost:8080/mcp" "OAS_MCP_HTTP_URL"
       (* Set OAS_MCP_HTTP_URL to override the MCP server endpoint.

--- a/lib/protocol/mcp_http.mli
+++ b/lib/protocol/mcp_http.mli
@@ -13,6 +13,10 @@ type config =
     ["http://localhost:8080/mcp"]. *)
 val default_config : unit -> config
 
+(** Environment variable used by {!default_config} to resolve the MCP HTTP
+    endpoint. *)
+val default_endpoint_env_var : string
+
 type t
 
 val connect

--- a/lib/protocol/mcp_http.mli
+++ b/lib/protocol/mcp_http.mli
@@ -8,7 +8,10 @@ type config =
   ; headers : (string * string) list
   }
 
-val default_config : config
+(** Default HTTP MCP transport config.
+    Reads [OAS_MCP_HTTP_URL] at call time, defaulting to
+    ["http://localhost:8080/mcp"]. *)
+val default_config : unit -> config
 
 type t
 

--- a/test/test_mcp_coverage.ml
+++ b/test/test_mcp_coverage.ml
@@ -306,7 +306,7 @@ let test_mcp_tool_to_sdk_tool_empty_schema () =
 (* ── Mcp_http.default_config ──────────────────────────────── *)
 
 let test_mcp_http_default_config_values () =
-  let cfg = Mcp_http.default_config in
+  let cfg = Mcp_http.default_config () in
   Alcotest.(check string) "default base_url" "http://localhost:8080/mcp" cfg.base_url;
   Alcotest.(check (list (pair string string))) "no headers" [] cfg.headers
 ;;

--- a/test/test_mcp_http.ml
+++ b/test/test_mcp_http.ml
@@ -32,13 +32,13 @@ let test_default_config () =
 ;;
 
 let test_default_config_reads_env_at_call_time () =
-  with_env "OAS_MCP_HTTP_URL" "http://127.0.0.1:7777/mcp" (fun () ->
+  with_env Mcp_http.default_endpoint_env_var "http://127.0.0.1:7777/mcp" (fun () ->
     let cfg = Mcp_http.default_config () in
     check string "first env" "http://127.0.0.1:7777/mcp" cfg.base_url;
-    Unix.putenv "OAS_MCP_HTTP_URL" "  http://127.0.0.1:8888/mcp  ";
+    Unix.putenv Mcp_http.default_endpoint_env_var "  http://127.0.0.1:8888/mcp  ";
     let cfg = Mcp_http.default_config () in
     check string "second env" "http://127.0.0.1:8888/mcp" cfg.base_url;
-    Unix.putenv "OAS_MCP_HTTP_URL" "";
+    Unix.putenv Mcp_http.default_endpoint_env_var "";
     let cfg = Mcp_http.default_config () in
     check string "empty env default" "http://localhost:8080/mcp" cfg.base_url)
 ;;

--- a/test/test_mcp_http.ml
+++ b/test/test_mcp_http.ml
@@ -11,10 +11,36 @@ open Agent_sdk
 
 (* ── Config defaults ────────────────────────────────────── *)
 
+let with_env key value f =
+  let previous = Sys.getenv_opt key in
+  (* OCaml's Unix module has no portable unsetenv; OAS env readers treat an
+     empty value as unset. *)
+  let restore () =
+    match previous with
+    | Some previous -> Unix.putenv key previous
+    | None -> Unix.putenv key ""
+  in
+  Fun.protect ~finally:restore (fun () ->
+    Unix.putenv key value;
+    f ())
+;;
+
 let test_default_config () =
-  let cfg = Mcp_http.default_config in
+  let cfg = Mcp_http.default_config () in
   check string "base_url" "http://localhost:8080/mcp" cfg.base_url;
   check (list (pair string string)) "headers" [] cfg.headers
+;;
+
+let test_default_config_reads_env_at_call_time () =
+  with_env "OAS_MCP_HTTP_URL" "http://127.0.0.1:7777/mcp" (fun () ->
+    let cfg = Mcp_http.default_config () in
+    check string "first env" "http://127.0.0.1:7777/mcp" cfg.base_url;
+    Unix.putenv "OAS_MCP_HTTP_URL" "  http://127.0.0.1:8888/mcp  ";
+    let cfg = Mcp_http.default_config () in
+    check string "second env" "http://127.0.0.1:8888/mcp" cfg.base_url;
+    Unix.putenv "OAS_MCP_HTTP_URL" "";
+    let cfg = Mcp_http.default_config () in
+    check string "empty env default" "http://localhost:8080/mcp" cfg.base_url)
 ;;
 
 (* ── Connect to unreachable server ──────────────────────── *)
@@ -25,7 +51,9 @@ let test_connect_returns_ok () =
   let net = Eio.Stdenv.net env in
   Eio.Switch.run
   @@ fun sw ->
-  let config = { Mcp_http.default_config with base_url = "http://127.0.0.1:19999" } in
+  let config =
+    { (Mcp_http.default_config ()) with base_url = "http://127.0.0.1:19999" }
+  in
   match Mcp_http.connect ~sw ~net config with
   | Ok _client -> () (* connect itself succeeds; initialize would fail *)
   | Error e -> fail (Error.to_string e)
@@ -37,7 +65,9 @@ let test_initialize_unreachable () =
   let net = Eio.Stdenv.net env in
   Eio.Switch.run
   @@ fun sw ->
-  let config = { Mcp_http.default_config with base_url = "http://127.0.0.1:19999" } in
+  let config =
+    { (Mcp_http.default_config ()) with base_url = "http://127.0.0.1:19999" }
+  in
   match Mcp_http.connect ~sw ~net config with
   | Error e -> fail (Error.to_string e)
   | Ok client ->
@@ -52,7 +82,9 @@ let test_list_tools_without_init () =
   let net = Eio.Stdenv.net env in
   Eio.Switch.run
   @@ fun sw ->
-  let config = { Mcp_http.default_config with base_url = "http://127.0.0.1:19999" } in
+  let config =
+    { (Mcp_http.default_config ()) with base_url = "http://127.0.0.1:19999" }
+  in
   match Mcp_http.connect ~sw ~net config with
   | Error e -> fail (Error.to_string e)
   | Ok client ->
@@ -67,7 +99,9 @@ let test_call_tool_unreachable () =
   let net = Eio.Stdenv.net env in
   Eio.Switch.run
   @@ fun sw ->
-  let config = { Mcp_http.default_config with base_url = "http://127.0.0.1:19999" } in
+  let config =
+    { (Mcp_http.default_config ()) with base_url = "http://127.0.0.1:19999" }
+  in
   match Mcp_http.connect ~sw ~net config with
   | Error e -> fail (Error.to_string e)
   | Ok client ->
@@ -84,7 +118,7 @@ let test_close_safe () =
   let net = Eio.Stdenv.net env in
   Eio.Switch.run
   @@ fun sw ->
-  let config = Mcp_http.default_config in
+  let config = Mcp_http.default_config () in
   match Mcp_http.connect ~sw ~net config with
   | Error e -> fail (Error.to_string e)
   | Ok client ->
@@ -195,7 +229,13 @@ let test_session_transport_kind_required () =
 let () =
   run
     "Mcp_http"
-    [ "config", [ test_case "defaults" `Quick test_default_config ]
+    [ ( "config"
+      , [ test_case "defaults" `Quick test_default_config
+        ; test_case
+            "defaults read env at call time"
+            `Quick
+            test_default_config_reads_env_at_call_time
+        ] )
     ; ( "connect"
       , [ test_case "connect returns Ok" `Quick test_connect_returns_ok
         ; test_case "initialize unreachable" `Quick test_initialize_unreachable


### PR DESCRIPTION
## Summary
- change Mcp_http.default_config from a module-load record to unit -> config
- read OAS_MCP_HTTP_URL at call time so same-process config changes are observable
- add a regression test for call-time env resolution and empty-env fallback

## Local verification
- ocamlformat --check lib/protocol/mcp_http.ml lib/protocol/mcp_http.mli test/test_mcp_http.ml test/test_mcp_coverage.ml
- git diff --check
- rg -n "Mcp_http\.default_config" lib test examples

Full build/test intentionally left to GitHub CI per repo workflow.