### PR TITLE
fix(fs): surface mkdir path failures

### DIFF
--- a/lib/fs_result.ml
+++ b/lib/fs_result.ml
@@ -28,6 +28,10 @@ let read_file path =
 let ensure_dir_recursive ?(mode = 0o700) path =
   let op = "mkdir_p" in
   let file_error path detail = Error (Error.Io (FileOpFailed { op; path; detail })) in
+  (* Use Unix.* here rather than Sys.* so mkdir failures retain structured errno
+     values. The EEXIST -> stat check below is necessarily racy if another
+     process replaces the path between the two syscalls; the result is still a
+     best-effort diagnostic for local directory preparation. *)
   let ensure_existing_dir p =
     try
       match (Unix.stat p).st_kind with
@@ -37,30 +41,36 @@ let ensure_dir_recursive ?(mode = 0o700) path =
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn -> io_error_of_exn ~op ~path:p exn
   in
+  let mkdir_once p =
+    try
+      Unix.mkdir p mode;
+      Ok `Created
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | Unix.Unix_error (Unix.EEXIST, _, _) -> Ok `Already_exists
+    | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok `Missing_parent
+    | exn -> io_error_of_exn ~op ~path:p exn
+  in
   let rec aux p =
     if String.equal p ""
     then file_error p "empty directory path"
     else (
-      try
-        Unix.mkdir p mode;
-        Ok ()
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | Unix.Unix_error (Unix.EEXIST, _, _) -> ensure_existing_dir p
-      | Unix.Unix_error (Unix.ENOENT, _, _) ->
+      match mkdir_once p with
+      | Error _ as err -> err
+      | Ok `Created -> Ok ()
+      | Ok `Already_exists -> ensure_existing_dir p
+      | Ok `Missing_parent ->
         let parent = Filename.dirname p in
         if String.equal parent p
         then io_error_of_exn ~op ~path:p (Unix.Unix_error (Unix.ENOENT, op, p))
         else
           let* () = aux parent in
-          (try
-             Unix.mkdir p mode;
-             Ok ()
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | Unix.Unix_error (Unix.EEXIST, _, _) -> ensure_existing_dir p
-           | exn -> io_error_of_exn ~op ~path:p exn)
-      | exn -> io_error_of_exn ~op ~path:p exn)
+          (match mkdir_once p with
+           | Error _ as err -> err
+           | Ok `Created -> Ok ()
+           | Ok `Already_exists -> ensure_existing_dir p
+           | Ok `Missing_parent ->
+             io_error_of_exn ~op ~path:p (Unix.Unix_error (Unix.ENOENT, op, p))))
   in
   aux path
 ;;

--- a/lib/fs_result.ml
+++ b/lib/fs_result.ml
@@ -26,20 +26,43 @@ let read_file path =
 ;;
 
 let ensure_dir_recursive ?(mode = 0o700) path =
-  let rec aux p =
-    if Sys.file_exists p
-    then ()
-    else (
-      aux (Filename.dirname p);
-      try Sys.mkdir p mode with
-      | Sys_error _ -> ())
+  let op = "mkdir_p" in
+  let file_error path detail = Error (Error.Io (FileOpFailed { op; path; detail })) in
+  let ensure_existing_dir p =
+    try
+      match (Unix.stat p).st_kind with
+      | Unix.S_DIR -> Ok ()
+      | _ -> file_error p "path exists and is not a directory"
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn -> io_error_of_exn ~op ~path:p exn
   in
-  try
-    aux path;
-    Ok ()
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn -> io_error_of_exn ~op:"mkdir_p" ~path exn
+  let rec aux p =
+    if String.equal p ""
+    then file_error p "empty directory path"
+    else (
+      try
+        Unix.mkdir p mode;
+        Ok ()
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | Unix.Unix_error (Unix.EEXIST, _, _) -> ensure_existing_dir p
+      | Unix.Unix_error (Unix.ENOENT, _, _) ->
+        let parent = Filename.dirname p in
+        if String.equal parent p
+        then io_error_of_exn ~op ~path:p (Unix.Unix_error (Unix.ENOENT, op, p))
+        else
+          let* () = aux parent in
+          (try
+             Unix.mkdir p mode;
+             Ok ()
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | Unix.Unix_error (Unix.EEXIST, _, _) -> ensure_existing_dir p
+           | exn -> io_error_of_exn ~op ~path:p exn)
+      | exn -> io_error_of_exn ~op ~path:p exn)
+  in
+  aux path
 ;;
 
 let ensure_dir path = ensure_dir_recursive path

--- a/lib/fs_result.mli
+++ b/lib/fs_result.mli
@@ -28,7 +28,9 @@ val write_file_secret : string -> string -> (unit, Error.sdk_error) result
 
 (** {1 Directory operations} *)
 
-(** Ensure directory exists (recursive). *)
+(** Ensure directory exists (recursive).
+    Returns [Error] if any existing path component is not a directory or a
+    directory creation syscall fails. *)
 val ensure_dir : string -> (unit, Error.sdk_error) result
 
 (** List directory entries. *)

--- a/lib/fs_result.mli
+++ b/lib/fs_result.mli
@@ -29,8 +29,8 @@ val write_file_secret : string -> string -> (unit, Error.sdk_error) result
 (** {1 Directory operations} *)
 
 (** Ensure directory exists (recursive).
-    Returns [Error] if any existing path component is not a directory or a
-    directory creation syscall fails. *)
+    Returns [Error] if [path] is empty, any existing path component is not a
+    directory, or a directory creation syscall fails. *)
 val ensure_dir : string -> (unit, Error.sdk_error) result
 
 (** List directory entries. *)

--- a/test/test_fs_result.ml
+++ b/test/test_fs_result.ml
@@ -77,6 +77,23 @@ let test_write_file_creates_dirs () =
        | Error _ -> Alcotest.fail "write should create dirs")
 ;;
 
+let test_write_file_parent_is_file () =
+  let parent = Filename.temp_file "fs_parent_file_" ".txt" in
+  let path = Filename.concat parent "child.txt" in
+  Fun.protect
+    ~finally:(fun () ->
+      try Sys.remove parent with
+      | _ -> ())
+    (fun () ->
+       match Fs_result.write_file path "content" with
+       | Error (Error.Io (FileOpFailed { op; path = err_path; detail })) ->
+         check_string "op" "mkdir_p" op;
+         check_string "path" parent err_path;
+         check_bool "detail" true (Util.string_contains ~needle:"not a directory" detail)
+       | Error _ -> Alcotest.fail "wrong error type"
+       | Ok () -> Alcotest.fail "write should reject file parent")
+;;
+
 (* ── append_file ──────────────────────────────────────── *)
 
 let test_append_file () =
@@ -115,6 +132,22 @@ let test_ensure_dir_new () =
        match Fs_result.ensure_dir path with
        | Ok () -> check_bool "dir exists" true (Sys.file_exists path)
        | Error _ -> Alcotest.fail "should succeed")
+;;
+
+let test_ensure_dir_existing_file () =
+  let path = Filename.temp_file "fs_ensure_file_" ".txt" in
+  Fun.protect
+    ~finally:(fun () ->
+      try Sys.remove path with
+      | _ -> ())
+    (fun () ->
+       match Fs_result.ensure_dir path with
+       | Error (Error.Io (FileOpFailed { op; path = err_path; detail })) ->
+         check_string "op" "mkdir_p" op;
+         check_string "path" path err_path;
+         check_bool "detail" true (Util.string_contains ~needle:"not a directory" detail)
+       | Error _ -> Alcotest.fail "wrong error type"
+       | Ok () -> Alcotest.fail "file path should not be accepted as a directory")
 ;;
 
 (* ── file_exists ──────────────────────────────────────── *)
@@ -199,11 +232,13 @@ let () =
     ; ( "write_file"
       , [ Alcotest.test_case "success" `Quick test_write_file_success
         ; Alcotest.test_case "creates dirs" `Quick test_write_file_creates_dirs
+        ; Alcotest.test_case "parent is file" `Quick test_write_file_parent_is_file
         ] )
     ; "append_file", [ Alcotest.test_case "append" `Quick test_append_file ]
     ; ( "ensure_dir"
       , [ Alcotest.test_case "existing" `Quick test_ensure_dir_existing
         ; Alcotest.test_case "new" `Quick test_ensure_dir_new
+        ; Alcotest.test_case "existing file" `Quick test_ensure_dir_existing_file
         ] )
     ; ( "file_exists"
       , [ Alcotest.test_case "true" `Quick test_file_exists_true

--- a/test/test_fs_result.ml
+++ b/test/test_fs_result.ml
@@ -89,7 +89,7 @@ let test_write_file_parent_is_file () =
        | Error (Error.Io (FileOpFailed { op; path = err_path; detail })) ->
          check_string "op" "mkdir_p" op;
          check_string "path" parent err_path;
-         check_bool "detail" true (Util.string_contains ~needle:"not a directory" detail)
+         check_string "detail" "path exists and is not a directory" detail
        | Error _ -> Alcotest.fail "wrong error type"
        | Ok () -> Alcotest.fail "write should reject file parent")
 ;;
@@ -145,9 +145,19 @@ let test_ensure_dir_existing_file () =
        | Error (Error.Io (FileOpFailed { op; path = err_path; detail })) ->
          check_string "op" "mkdir_p" op;
          check_string "path" path err_path;
-         check_bool "detail" true (Util.string_contains ~needle:"not a directory" detail)
+         check_string "detail" "path exists and is not a directory" detail
        | Error _ -> Alcotest.fail "wrong error type"
        | Ok () -> Alcotest.fail "file path should not be accepted as a directory")
+;;
+
+let test_ensure_dir_empty_path () =
+  match Fs_result.ensure_dir "" with
+  | Error (Error.Io (FileOpFailed { op; path; detail })) ->
+    check_string "op" "mkdir_p" op;
+    check_string "path" "" path;
+    check_string "detail" "empty directory path" detail
+  | Error _ -> Alcotest.fail "wrong error type"
+  | Ok () -> Alcotest.fail "empty path should fail"
 ;;
 
 (* ── file_exists ──────────────────────────────────────── *)
@@ -239,6 +249,7 @@ let () =
       , [ Alcotest.test_case "existing" `Quick test_ensure_dir_existing
         ; Alcotest.test_case "new" `Quick test_ensure_dir_new
         ; Alcotest.test_case "existing file" `Quick test_ensure_dir_existing_file
+        ; Alcotest.test_case "empty path" `Quick test_ensure_dir_empty_path
         ] )
     ; ( "file_exists"
       , [ Alcotest.test_case "true" `Quick test_file_exists_true


### PR DESCRIPTION
## Summary
- replace silent recursive mkdir handling with Result-returning Unix.mkdir/stat flow
- reject existing non-directory path components instead of treating them as success
- preserve Eio cancellation and map mkdir syscall failures to Error.Io(FileOpFailed)
- add regression tests for ensure_dir on an existing file and write_file with a file parent

## Local verification
- ocamlformat --check lib/fs_result.ml lib/fs_result.mli test/test_fs_result.ml
- git diff --check
- rg -n "Sys\.mkdir p mode with|Sys_error _ -> \\(\\)|path exists and is not a directory|empty directory path" lib/fs_result.ml test/test_fs_result.ml

Full build/test intentionally left to GitHub CI per repo workflow.