### PR TITLE
fix(config): reject malformed agent list fields

### DIFF
--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -147,6 +147,22 @@ let json_type_name = function
   | `String _ -> "string"
 ;;
 
+let root_config_field = "<root>"
+
+let json_pointer_escape s =
+  s
+  |> String.split_on_char '~'
+  |> String.concat "~0"
+  |> String.split_on_char '/'
+  |> String.concat "~1"
+;;
+
+let field_path_to_string = function
+  | [] -> root_config_field
+  | [ field ] -> field
+  | fields -> "/" ^ String.concat "/" (List.map json_pointer_escape fields)
+;;
+
 let invalid_type ~field ~expected json =
   Error
     (Error.Config
@@ -166,22 +182,26 @@ let require_object ~field = function
   | other -> invalid_type ~field ~expected:"object" other
 ;;
 
-let list_field_or_empty ~field json =
+let invalid_type_at ~field_path ~expected json =
+  invalid_type ~field:(field_path_to_string field_path) ~expected json
+;;
+
+let parse_optional_list_field ~field json =
   match field_opt field json with
   | None -> Ok []
   | Some (`List values) -> Ok values
   | Some other -> invalid_type ~field ~expected:"list" other
 ;;
 
-let assoc_field_or_empty ~field json =
+let parse_optional_object_field ~field json =
   match field_opt field json with
   | None -> Ok []
   | Some (`Assoc pairs) -> Ok pairs
   | Some other -> invalid_type ~field ~expected:"object" other
 ;;
 
-let string_list_field_or_empty ~field json =
-  let* values = list_field_or_empty ~field json in
+let parse_optional_string_list_field ~field json =
+  let* values = parse_optional_list_field ~field json in
   List.fold_left
     (fun acc value ->
        match acc, value with
@@ -217,7 +237,7 @@ let parse_tool json =
   try
     let name = json |> member "name" |> to_string in
     let description = Util.json_member_str "description" json in
-    let* params_json = list_field_or_empty ~field:"parameters" json in
+    let* params_json = parse_optional_list_field ~field:"parameters" json in
     let params_result =
       List.fold_left
         (fun acc j ->
@@ -244,7 +264,7 @@ let parse_mcp json =
     | Some url ->
       (* HTTP MCP: { "url": "...", "name": "...", "headers": {...} } *)
       let name = json |> member "name" |> to_string_option |> Option.value ~default:url in
-      let* header_fields = assoc_field_or_empty ~field:"headers" json in
+      let* header_fields = parse_optional_object_field ~field:"headers" json in
       let* headers =
         List.fold_left
           (fun acc (k, v) ->
@@ -252,7 +272,7 @@ let parse_mcp json =
              | (Error _ as e), _ -> e
              | Ok headers, `String value -> Ok ((k, value) :: headers)
              | Ok _, other ->
-               invalid_type ~field:("headers." ^ k) ~expected:"string" other)
+               invalid_type_at ~field_path:[ "headers"; k ] ~expected:"string" other)
           (Ok [])
           header_fields
         |> Result.map List.rev
@@ -261,11 +281,11 @@ let parse_mcp json =
     | None ->
       (* Stdio MCP: { "command": "...", "args": [...], ... } *)
       let command = json |> member "command" |> to_string in
-      let* args = string_list_field_or_empty ~field:"args" json in
+      let* args = parse_optional_string_list_field ~field:"args" json in
       let name =
         json |> member "name" |> to_string_option |> Option.value ~default:command
       in
-      let* env = string_list_field_or_empty ~field:"env" json in
+      let* env = parse_optional_string_list_field ~field:"env" json in
       Ok (Stdio_mcp { command; args; name; env })
   with
   | Type_error (msg, _) ->
@@ -275,7 +295,7 @@ let parse_mcp json =
 let of_json json =
   let open Yojson.Safe.Util in
   try
-    let* () = require_object ~field:"agent_config" json in
+    let* () = require_object ~field:root_config_field json in
     let name =
       json |> member "name" |> to_string_option |> Option.value ~default:"agent"
     in
@@ -293,7 +313,7 @@ let of_json json =
     let thinking_budget = json |> member "thinking_budget" |> to_int_option in
     let provider = json |> member "provider" |> to_string_option in
     let base_url = json |> member "base_url" |> to_string_option in
-    let* tools_json = list_field_or_empty ~field:"tools" json in
+    let* tools_json = parse_optional_list_field ~field:"tools" json in
     let tools_result =
       List.fold_left
         (fun acc j ->
@@ -307,7 +327,7 @@ let of_json json =
         tools_json
     in
     let* tools = tools_result in
-    let* mcp_json = list_field_or_empty ~field:"mcp_servers" json in
+    let* mcp_json = parse_optional_list_field ~field:"mcp_servers" json in
     let mcp_result =
       List.fold_left
         (fun acc j ->
@@ -337,7 +357,7 @@ let of_json json =
       }
   with
   | Type_error (msg, _) ->
-    Error (Error.Config (InvalidConfig { field = "agent_config"; detail = msg }))
+    Error (Error.Config (InvalidConfig { field = root_config_field; detail = msg }))
 ;;
 
 let load path =

--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -131,19 +131,66 @@ type agent_file_config =
 
 (* ── JSON parsing ────────────────────────────────────────── *)
 
-let list_or_empty = function
-  | `List values -> values
-  | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `Null | `String _ -> []
-;;
-
-let assoc_or_empty = function
-  | `Assoc pairs -> pairs
-  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> []
-;;
-
 let string_option = function
   | `String value -> Some value
   | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null -> None
+;;
+
+let json_type_name = function
+  | `Assoc _ -> "object"
+  | `Bool _ -> "bool"
+  | `Float _ -> "float"
+  | `Int _ -> "int"
+  | `Intlit _ -> "int"
+  | `List _ -> "list"
+  | `Null -> "null"
+  | `String _ -> "string"
+;;
+
+let invalid_type ~field ~expected json =
+  Error
+    (Error.Config
+       (InvalidConfig
+          { field
+          ; detail = Printf.sprintf "expected %s, got %s" expected (json_type_name json)
+          }))
+;;
+
+let field_opt field = function
+  | `Assoc pairs -> List.assoc_opt field pairs
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
+;;
+
+let require_object ~field = function
+  | `Assoc _ -> Ok ()
+  | other -> invalid_type ~field ~expected:"object" other
+;;
+
+let list_field_or_empty ~field json =
+  match field_opt field json with
+  | None -> Ok []
+  | Some (`List values) -> Ok values
+  | Some other -> invalid_type ~field ~expected:"list" other
+;;
+
+let assoc_field_or_empty ~field json =
+  match field_opt field json with
+  | None -> Ok []
+  | Some (`Assoc pairs) -> Ok pairs
+  | Some other -> invalid_type ~field ~expected:"object" other
+;;
+
+let string_list_field_or_empty ~field json =
+  let* values = list_field_or_empty ~field json in
+  List.fold_left
+    (fun acc value ->
+       match acc, value with
+       | (Error _ as e), _ -> e
+       | Ok values, `String value -> Ok (value :: values)
+       | Ok _, other -> invalid_type ~field ~expected:"list of strings" other)
+    (Ok [])
+    values
+  |> Result.map List.rev
 ;;
 
 let parse_param json =
@@ -170,7 +217,7 @@ let parse_tool json =
   try
     let name = json |> member "name" |> to_string in
     let description = Util.json_member_str "description" json in
-    let params_json = json |> member "parameters" |> list_or_empty in
+    let* params_json = list_field_or_empty ~field:"parameters" json in
     let params_result =
       List.fold_left
         (fun acc j ->
@@ -197,26 +244,28 @@ let parse_mcp json =
     | Some url ->
       (* HTTP MCP: { "url": "...", "name": "...", "headers": {...} } *)
       let name = json |> member "name" |> to_string_option |> Option.value ~default:url in
-      let headers =
-        json
-        |> member "headers"
-        |> assoc_or_empty
-        |> List.filter_map (fun (k, v) ->
-          match string_option v with
-          | Some s -> Some (k, s)
-          | None -> None)
+      let* header_fields = assoc_field_or_empty ~field:"headers" json in
+      let* headers =
+        List.fold_left
+          (fun acc (k, v) ->
+             match acc, v with
+             | (Error _ as e), _ -> e
+             | Ok headers, `String value -> Ok ((k, value) :: headers)
+             | Ok _, other ->
+               invalid_type ~field:("headers." ^ k) ~expected:"string" other)
+          (Ok [])
+          header_fields
+        |> Result.map List.rev
       in
       Ok (Http_mcp { url; headers; name })
     | None ->
       (* Stdio MCP: { "command": "...", "args": [...], ... } *)
       let command = json |> member "command" |> to_string in
-      let args =
-        json |> member "args" |> list_or_empty |> List.filter_map string_option
-      in
+      let* args = string_list_field_or_empty ~field:"args" json in
       let name =
         json |> member "name" |> to_string_option |> Option.value ~default:command
       in
-      let env = json |> member "env" |> list_or_empty |> List.filter_map string_option in
+      let* env = string_list_field_or_empty ~field:"env" json in
       Ok (Stdio_mcp { command; args; name; env })
   with
   | Type_error (msg, _) ->
@@ -226,6 +275,7 @@ let parse_mcp json =
 let of_json json =
   let open Yojson.Safe.Util in
   try
+    let* () = require_object ~field:"agent_config" json in
     let name =
       json |> member "name" |> to_string_option |> Option.value ~default:"agent"
     in
@@ -243,7 +293,7 @@ let of_json json =
     let thinking_budget = json |> member "thinking_budget" |> to_int_option in
     let provider = json |> member "provider" |> to_string_option in
     let base_url = json |> member "base_url" |> to_string_option in
-    let tools_json = json |> member "tools" |> list_or_empty in
+    let* tools_json = list_field_or_empty ~field:"tools" json in
     let tools_result =
       List.fold_left
         (fun acc j ->
@@ -257,7 +307,7 @@ let of_json json =
         tools_json
     in
     let* tools = tools_result in
-    let mcp_json = json |> member "mcp_servers" |> list_or_empty in
+    let* mcp_json = list_field_or_empty ~field:"mcp_servers" json in
     let mcp_result =
       List.fold_left
         (fun acc j ->

--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -131,22 +131,6 @@ type agent_file_config =
 
 (* ── JSON parsing ────────────────────────────────────────── *)
 
-let string_option = function
-  | `String value -> Some value
-  | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null -> None
-;;
-
-let json_type_name = function
-  | `Assoc _ -> "object"
-  | `Bool _ -> "bool"
-  | `Float _ -> "float"
-  | `Int _ -> "int"
-  | `Intlit _ -> "int"
-  | `List _ -> "list"
-  | `Null -> "null"
-  | `String _ -> "string"
-;;
-
 let root_config_field = "<root>"
 
 let json_pointer_escape s =
@@ -168,7 +152,7 @@ let invalid_type ~field ~expected json =
     (Error.Config
        (InvalidConfig
           { field
-          ; detail = Printf.sprintf "expected %s, got %s" expected (json_type_name json)
+          ; detail = Printf.sprintf "expected %s, got %s" expected (Llm_provider.Json_util.json_type_name json)
           }))
 ;;
 

--- a/lib/llm_provider/backend_tool_call_harness.ml
+++ b/lib/llm_provider/backend_tool_call_harness.ml
@@ -39,15 +39,6 @@ type response_parse_error =
 
 (* ── Minimal JSON Schema validator ──────────────────── *)
 
-let json_type_name = function
-  | `Assoc _ -> "object"
-  | `List _ -> "array"
-  | `String _ -> "string"
-  | `Int _ | `Intlit _ | `Float _ -> "number"
-  | `Bool _ -> "boolean"
-  | `Null -> "null"
-;;
-
 let json_schema_type_name = function
   | `String s -> Some s
   | `Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
@@ -109,7 +100,7 @@ let rec validate_against_schema
   in
   (match json_schema_type_name (schema |> member "type") with
    | Some expected when not (json_matches_schema_type expected value) ->
-     add json_path expected (json_type_name value)
+     add json_path expected (Json_util.json_type_name value)
    | Some _ | None -> ());
   (* Check "required" fields *)
   (match schema |> member "required", value with

--- a/lib/llm_provider/json_util.ml
+++ b/lib/llm_provider/json_util.ml
@@ -1,0 +1,10 @@
+(** Shared JSON helpers for the llm_provider library. *)
+
+let json_type_name = function
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `String _ -> "string"
+  | `Int _ | `Intlit _ | `Float _ -> "number"
+  | `Bool _ -> "boolean"
+  | `Null -> "null"
+;;

--- a/lib/llm_provider/json_util.mli
+++ b/lib/llm_provider/json_util.mli
@@ -1,0 +1,7 @@
+(** Shared JSON helpers for the llm_provider library. *)
+
+(** Return a human-readable JSON type name.
+
+    Uses JSON-schema vocabulary: [object], [array], [string], [number],
+    [boolean], [null]. *)
+val json_type_name : Yojson.Safe.t -> string

--- a/test/test_agent_config.ml
+++ b/test/test_agent_config.ml
@@ -90,9 +90,7 @@ let expect_invalid_config_field field json =
   | Ok _ -> fail "expected invalid config"
 ;;
 
-let test_rejects_non_object_config () =
-  expect_invalid_config_field "agent_config" (`List [])
-;;
+let test_rejects_non_object_config () = expect_invalid_config_field "<root>" (`List [])
 
 let test_rejects_non_list_tools () =
   expect_invalid_config_field "tools" (`Assoc [ "tools", `Assoc [] ])
@@ -120,7 +118,7 @@ let test_rejects_non_string_mcp_args () =
 
 let test_rejects_non_string_http_headers () =
   expect_invalid_config_field
-    "headers.Authorization"
+    "/headers/Authorization"
     (`Assoc
         [ ( "mcp_servers"
           , `List

--- a/test/test_agent_config.ml
+++ b/test/test_agent_config.ml
@@ -82,6 +82,56 @@ let test_defaults () =
   | Error e -> fail (Error.to_string e)
 ;;
 
+let expect_invalid_config_field field json =
+  match Agent_config.of_json json with
+  | Error (Error.Config (InvalidConfig { field = actual; _ })) ->
+    check string "field" field actual
+  | Error e -> fail (Printf.sprintf "unexpected error: %s" (Error.to_string e))
+  | Ok _ -> fail "expected invalid config"
+;;
+
+let test_rejects_non_object_config () =
+  expect_invalid_config_field "agent_config" (`List [])
+;;
+
+let test_rejects_non_list_tools () =
+  expect_invalid_config_field "tools" (`Assoc [ "tools", `Assoc [] ])
+;;
+
+let test_rejects_non_list_tool_parameters () =
+  expect_invalid_config_field
+    "parameters"
+    (`Assoc
+        [ "tools", `List [ `Assoc [ "name", `String "calc"; "parameters", `Assoc [] ] ] ])
+;;
+
+let test_rejects_non_list_mcp_servers () =
+  expect_invalid_config_field "mcp_servers" (`Assoc [ "mcp_servers", `String "node" ])
+;;
+
+let test_rejects_non_string_mcp_args () =
+  expect_invalid_config_field
+    "args"
+    (`Assoc
+        [ ( "mcp_servers"
+          , `List [ `Assoc [ "command", `String "node"; "args", `List [ `Int 1 ] ] ] )
+        ])
+;;
+
+let test_rejects_non_string_http_headers () =
+  expect_invalid_config_field
+    "headers.Authorization"
+    (`Assoc
+        [ ( "mcp_servers"
+          , `List
+              [ `Assoc
+                  [ "url", `String "http://example.com/mcp"
+                  ; "headers", `Assoc [ "Authorization", `Int 1 ]
+                  ]
+              ] )
+        ])
+;;
+
 (* ── load ───────────────────────────────────────────────── *)
 
 let test_load_nonexistent () =
@@ -400,6 +450,18 @@ let () =
         ; test_case "http mcp" `Quick test_http_mcp_config
         ; test_case "http mcp defaults" `Quick test_http_mcp_defaults
         ; test_case "mixed mcp" `Quick test_mixed_mcp_config
+        ; test_case "reject non-object config" `Quick test_rejects_non_object_config
+        ; test_case "reject non-list tools" `Quick test_rejects_non_list_tools
+        ; test_case
+            "reject non-list tool parameters"
+            `Quick
+            test_rejects_non_list_tool_parameters
+        ; test_case "reject non-list mcp_servers" `Quick test_rejects_non_list_mcp_servers
+        ; test_case "reject non-string mcp args" `Quick test_rejects_non_string_mcp_args
+        ; test_case
+            "reject non-string http headers"
+            `Quick
+            test_rejects_non_string_http_headers
         ] )
     ; ( "load"
       , [ test_case "nonexistent" `Quick test_load_nonexistent

--- a/test/test_agent_config_deep.ml
+++ b/test/test_agent_config_deep.ml
@@ -265,7 +265,17 @@ let test_mcp_http_non_string_header_value () =
     "mcp_servers": [{"url": "http://x.com", "headers": {"a": "b", "c": 123}}]
   }|}
   in
-  expect_invalid_config_field "non-string header" "headers.c" json
+  expect_invalid_config_field "non-string header" "/headers/c" json
+;;
+
+let test_mcp_stdio_non_string_env_value () =
+  let json =
+    Yojson.Safe.from_string
+      {|{
+    "mcp_servers": [{"command": "node", "env": ["FOO=bar", 123]}]
+  }|}
+  in
+  expect_invalid_config_field "non-string env" "env" json
 ;;
 
 (* ── load from file ──────────────────────────────────────────── *)
@@ -529,6 +539,11 @@ let test_of_json_bad_tool () =
   | Ok _ -> Alcotest.fail "expected error for bad tool"
 ;;
 
+let test_of_json_non_object_tool () =
+  let json = Yojson.Safe.from_string {|{"tools": ["not-object"]}|} in
+  expect_invalid_config_field "non-object tool" "tool" json
+;;
+
 let test_of_json_bad_mcp () =
   (* mcp without command or url *)
   let json =
@@ -540,6 +555,11 @@ let test_of_json_bad_mcp () =
   match Agent_config.of_json json with
   | Error _ -> ()
   | Ok _ -> Alcotest.fail "expected error for bad mcp"
+;;
+
+let test_of_json_non_object_mcp () =
+  let json = Yojson.Safe.from_string {|{"mcp_servers": ["not-object"]}|} in
+  expect_invalid_config_field "non-object mcp" "mcp_server" json
 ;;
 
 let test_of_json_tools_not_list () =
@@ -568,7 +588,9 @@ let () =
         ; tc "mcp not list" test_of_json_mcp_not_list
         ; tc "bad param" test_of_json_bad_param
         ; tc "bad tool" test_of_json_bad_tool
+        ; tc "non-object tool" test_of_json_non_object_tool
         ; tc "bad mcp" test_of_json_bad_mcp
+        ; tc "non-object mcp" test_of_json_non_object_mcp
         ] )
     ; ( "mcp_servers"
       , [ tc "stdio" test_mcp_stdio
@@ -577,6 +599,7 @@ let () =
         ; tc "stdio defaults" test_mcp_stdio_defaults
         ; tc "headers not assoc" test_mcp_http_headers_not_assoc
         ; tc "non-string header" test_mcp_http_non_string_header_value
+        ; tc "non-string env" test_mcp_stdio_non_string_env_value
         ] )
     ; ( "load"
       , [ tc "valid file" test_load_valid_file

--- a/test/test_agent_config_deep.ml
+++ b/test/test_agent_config_deep.ml
@@ -19,6 +19,14 @@ let with_temp_file content f =
     (fun () -> f path)
 ;;
 
+let expect_invalid_config_field label field json =
+  match Agent_config.of_json json with
+  | Error (Error.Config (InvalidConfig { field = actual; _ })) ->
+    Alcotest.(check string) label field actual
+  | Error e -> Alcotest.fail (label ^ ": unexpected error: " ^ Error.to_string e)
+  | Ok _ -> Alcotest.fail (label ^ ": expected InvalidConfig")
+;;
+
 (* ── of_json: minimal / defaults ─────────────────────────────── *)
 
 let test_of_json_minimal () =
@@ -133,11 +141,7 @@ let test_tool_parameters_not_list () =
     "tools": [{"name": "ping", "parameters": "not-a-list"}]
   }|}
   in
-  match Agent_config.of_json json with
-  | Error e -> Alcotest.fail ("params not list: " ^ Error.to_string e)
-  | Ok cfg ->
-    let t = List.nth cfg.tools 0 in
-    Alcotest.(check int) "empty params" 0 (List.length t.parameters)
+  expect_invalid_config_field "params not list" "parameters" json
 ;;
 
 let test_param_defaults () =
@@ -251,13 +255,7 @@ let test_mcp_http_headers_not_assoc () =
     "mcp_servers": [{"url": "http://x.com", "headers": "not-obj"}]
   }|}
   in
-  match Agent_config.of_json json with
-  | Error e -> Alcotest.fail ("headers not assoc: " ^ Error.to_string e)
-  | Ok cfg ->
-    (match List.nth cfg.mcp_servers 0 with
-     | Agent_config.Http_mcp { headers; _ } ->
-       Alcotest.(check int) "no headers" 0 (List.length headers)
-     | _ -> Alcotest.fail "expected Http_mcp")
+  expect_invalid_config_field "headers not assoc" "headers" json
 ;;
 
 let test_mcp_http_non_string_header_value () =
@@ -267,13 +265,7 @@ let test_mcp_http_non_string_header_value () =
     "mcp_servers": [{"url": "http://x.com", "headers": {"a": "b", "c": 123}}]
   }|}
   in
-  match Agent_config.of_json json with
-  | Error e -> Alcotest.fail ("non-string header: " ^ Error.to_string e)
-  | Ok cfg ->
-    (match List.nth cfg.mcp_servers 0 with
-     | Agent_config.Http_mcp { headers; _ } ->
-       Alcotest.(check int) "only string headers" 1 (List.length headers)
-     | _ -> Alcotest.fail "expected Http_mcp")
+  expect_invalid_config_field "non-string header" "headers.c" json
 ;;
 
 (* ── load from file ──────────────────────────────────────────── *)
@@ -552,16 +544,12 @@ let test_of_json_bad_mcp () =
 
 let test_of_json_tools_not_list () =
   let json = Yojson.Safe.from_string {|{"tools": "not-list"}|} in
-  match Agent_config.of_json json with
-  | Error e -> Alcotest.fail ("should handle: " ^ Error.to_string e)
-  | Ok cfg -> Alcotest.(check int) "no tools" 0 (List.length cfg.tools)
+  expect_invalid_config_field "tools not list" "tools" json
 ;;
 
 let test_of_json_mcp_not_list () =
   let json = Yojson.Safe.from_string {|{"mcp_servers": "not-list"}|} in
-  match Agent_config.of_json json with
-  | Error e -> Alcotest.fail ("should handle: " ^ Error.to_string e)
-  | Ok cfg -> Alcotest.(check int) "no mcp" 0 (List.length cfg.mcp_servers)
+  expect_invalid_config_field "mcp not list" "mcp_servers" json
 ;;
 
 (* ── Test suite ──────────────────────────────────────────────── *)


### PR DESCRIPTION
## Summary
- reject non-object agent config JSON instead of defaulting silently
- reject malformed `tools`, `parameters`, `mcp_servers`, `args`, `env`, and `headers` field types instead of treating them as empty or filtering invalid values
- add Agent_config regression coverage for malformed list/object/string fields

## Verification
- `ocamlformat --check lib/agent/agent_config.ml test/test_agent_config.ml`
- `git diff --check`
- `rg -n "list_or_empty|assoc_or_empty|filter_map string_option|List\.filter_map \(fun \(k, v\)" lib/agent/agent_config.ml` (no matches)

Local Dune build/tests intentionally not run; GitHub CI is the build authority for this pass.