### PR TITLE
fix(discovery): warn on invalid port env tokens

### DIFF
--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -540,34 +540,77 @@ let refresh_and_sync ~sw ~net ~endpoints =
 
 let builtin_scan_ports = [ 8085; 8086; 8087; 8088; 8089; 8090; 11434 ]
 let valid_tcp_port p = p >= 1 && p <= 65535
+let discovery_ports_env = "OAS_DISCOVERY_PORTS"
+let discovery_diag_context = "discovery"
 
-let warn_invalid_discovery_port ~token ~reason =
-  Diag.warn "discovery" "OAS_DISCOVERY_PORTS token %S ignored: %s" token reason
+type invalid_scan_port_reason =
+  | Not_an_integer
+  | Outside_tcp_port_range
+
+type invalid_scan_port =
+  { token : string
+  ; reason : invalid_scan_port_reason
+  }
+
+let invalid_scan_port_reason_to_string = function
+  | Not_an_integer -> "not an integer"
+  | Outside_tcp_port_range -> "outside TCP port range 1-65535"
 ;;
 
-let parse_ports_env ?(on_invalid = fun ~token:_ ~reason:_ -> ()) s =
+let warn_invalid_discovery_port ~env_var ~diag_context ~token ~reason =
+  Diag.warn
+    diag_context
+    "%s token %S ignored: %s"
+    env_var
+    token
+    (invalid_scan_port_reason_to_string reason)
+;;
+
+let missing_invalid_port_handler ~token ~reason =
+  invalid_arg
+    (Printf.sprintf
+       "parse_ports_env invalid token %S: %s"
+       token
+       (invalid_scan_port_reason_to_string reason))
+;;
+
+let parse_ports_env_result s =
   String.split_on_char ',' s
   |> List.fold_left
-       (fun ports raw ->
+       (fun (ports, invalids) raw ->
           let trimmed = String.trim raw in
           match int_of_string_opt trimmed with
-          | None when trimmed = "" -> ports
-          | Some p when valid_tcp_port p && not (List.mem p ports) -> p :: ports
-          | Some p when valid_tcp_port p -> ports
+          | None when trimmed = "" ->
+            (* Empty tokens make trailing/repeated separators harmless. *)
+            ports, invalids
+          | Some p when valid_tcp_port p && not (List.mem p ports) -> p :: ports, invalids
+          | Some p when valid_tcp_port p ->
+            (* Keep the first occurrence so user-provided probe order is stable. *)
+            ports, invalids
           | Some _ ->
-            on_invalid ~token:trimmed ~reason:"outside TCP port range 1-65535";
-            ports
-          | None ->
-            on_invalid ~token:trimmed ~reason:"not an integer";
-            ports)
-       []
-  |> List.rev
+            ports, { token = trimmed; reason = Outside_tcp_port_range } :: invalids
+          | None -> ports, { token = trimmed; reason = Not_an_integer } :: invalids)
+       ([], [])
+  |> fun (ports, invalids) -> List.rev ports, List.rev invalids
+;;
+
+let parse_ports_env ?(on_invalid = missing_invalid_port_handler) s =
+  let ports, invalids = parse_ports_env_result s in
+  List.iter (fun { token; reason } -> on_invalid ~token ~reason) invalids;
+  ports
 ;;
 
 let default_scan_ports =
-  match Cli_common_env.get "OAS_DISCOVERY_PORTS" with
+  match Cli_common_env.get discovery_ports_env with
   | Some s ->
-    (match parse_ports_env ~on_invalid:warn_invalid_discovery_port s with
+    (match
+       parse_ports_env
+         ~on_invalid:
+           (warn_invalid_discovery_port
+              ~env_var:discovery_ports_env
+              ~diag_context:discovery_diag_context)
+         s
+     with
      | [] -> builtin_scan_ports
      | ps -> ps)
   | None -> builtin_scan_ports
@@ -1204,27 +1247,17 @@ let%test "parse_ports_env skips empty tokens" =
 ;;
 
 let%test "parse_ports_env reports non-numeric tokens" =
-  let warnings = ref [] in
-  let ports =
-    parse_ports_env
-      ~on_invalid:(fun ~token ~reason -> warnings := (token, reason) :: !warnings)
-      "9000,abc,9001"
-  in
-  ports = [ 9000; 9001 ] && List.rev !warnings = [ "abc", "not an integer" ]
+  let ports, invalids = parse_ports_env_result "9000,abc,9001" in
+  ports = [ 9000; 9001 ] && invalids = [ { token = "abc"; reason = Not_an_integer } ]
 ;;
 
 let%test "parse_ports_env reports invalid TCP ports" =
-  let warnings = ref [] in
-  let ports =
-    parse_ports_env
-      ~on_invalid:(fun ~token ~reason -> warnings := (token, reason) :: !warnings)
-      "-1,0,1,65535,65536"
-  in
+  let ports, invalids = parse_ports_env_result "-1,0,1,65535,65536" in
   ports = [ 1; 65535 ]
-  && List.rev !warnings
-     = [ "-1", "outside TCP port range 1-65535"
-       ; "0", "outside TCP port range 1-65535"
-       ; "65536", "outside TCP port range 1-65535"
+  && invalids
+     = [ { token = "-1"; reason = Outside_tcp_port_range }
+       ; { token = "0"; reason = Outside_tcp_port_range }
+       ; { token = "65536"; reason = Outside_tcp_port_range }
        ]
 ;;
 

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -600,7 +600,7 @@ let parse_ports_env ?(on_invalid = missing_invalid_port_handler) s =
   ports
 ;;
 
-let default_scan_ports =
+let default_scan_ports () =
   match Cli_common_env.get discovery_ports_env with
   | Some s ->
     (match
@@ -616,7 +616,7 @@ let default_scan_ports =
   | None -> builtin_scan_ports
 ;;
 
-let scan_local_endpoints ?(ports = default_scan_ports) ~sw ~net () =
+let scan_local_endpoints ?(ports = default_scan_ports ()) ~sw ~net () =
   let candidates = List.map (fun p -> Printf.sprintf "http://127.0.0.1:%d" p) ports in
   let statuses = discover ~sw ~net ~endpoints:candidates in
   List.filter_map

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -541,14 +541,25 @@ let refresh_and_sync ~sw ~net ~endpoints =
 let builtin_scan_ports = [ 8085; 8086; 8087; 8088; 8089; 8090; 11434 ]
 let valid_tcp_port p = p >= 1 && p <= 65535
 
-let parse_ports_env s =
+let warn_invalid_discovery_port ~token ~reason =
+  Diag.warn "discovery" "OAS_DISCOVERY_PORTS token %S ignored: %s" token reason
+;;
+
+let parse_ports_env ?(on_invalid = fun ~token:_ ~reason:_ -> ()) s =
   String.split_on_char ',' s
   |> List.fold_left
        (fun ports raw ->
           let trimmed = String.trim raw in
           match int_of_string_opt trimmed with
+          | None when trimmed = "" -> ports
           | Some p when valid_tcp_port p && not (List.mem p ports) -> p :: ports
-          | _ -> ports)
+          | Some p when valid_tcp_port p -> ports
+          | Some _ ->
+            on_invalid ~token:trimmed ~reason:"outside TCP port range 1-65535";
+            ports
+          | None ->
+            on_invalid ~token:trimmed ~reason:"not an integer";
+            ports)
        []
   |> List.rev
 ;;
@@ -556,7 +567,7 @@ let parse_ports_env s =
 let default_scan_ports =
   match Cli_common_env.get "OAS_DISCOVERY_PORTS" with
   | Some s ->
-    (match parse_ports_env s with
+    (match parse_ports_env ~on_invalid:warn_invalid_discovery_port s with
      | [] -> builtin_scan_ports
      | ps -> ps)
   | None -> builtin_scan_ports
@@ -1192,12 +1203,29 @@ let%test "parse_ports_env skips empty tokens" =
   parse_ports_env "9000,,9001," = [ 9000; 9001 ]
 ;;
 
-let%test "parse_ports_env skips non-numeric tokens silently" =
-  parse_ports_env "9000,abc,9001" = [ 9000; 9001 ]
+let%test "parse_ports_env reports non-numeric tokens" =
+  let warnings = ref [] in
+  let ports =
+    parse_ports_env
+      ~on_invalid:(fun ~token ~reason -> warnings := (token, reason) :: !warnings)
+      "9000,abc,9001"
+  in
+  ports = [ 9000; 9001 ] && List.rev !warnings = [ "abc", "not an integer" ]
 ;;
 
-let%test "parse_ports_env skips invalid TCP ports" =
-  parse_ports_env "-1,0,1,65535,65536" = [ 1; 65535 ]
+let%test "parse_ports_env reports invalid TCP ports" =
+  let warnings = ref [] in
+  let ports =
+    parse_ports_env
+      ~on_invalid:(fun ~token ~reason -> warnings := (token, reason) :: !warnings)
+      "-1,0,1,65535,65536"
+  in
+  ports = [ 1; 65535 ]
+  && List.rev !warnings
+     = [ "-1", "outside TCP port range 1-65535"
+       ; "0", "outside TCP port range 1-65535"
+       ; "65536", "outside TCP port range 1-65535"
+       ]
 ;;
 
 let%test "parse_ports_env deduplicates while preserving order" =

--- a/lib/llm_provider/discovery.mli
+++ b/lib/llm_provider/discovery.mli
@@ -97,7 +97,7 @@ val max_context_of_status : endpoint_status -> int option
     @since 0.86.0 *)
 
 (** Default ports to scan for local llama-server instances. *)
-val default_scan_ports : int list
+val default_scan_ports : unit -> int list
 
 val scan_local_endpoints
   :  ?ports:int list

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -221,7 +221,7 @@ let refresh_llama_endpoints ~sw ~net () =
       let candidates =
         List.map
           (fun p -> Printf.sprintf "http://127.0.0.1:%d" p)
-          Discovery.default_scan_ports
+          (Discovery.default_scan_ports ())
       in
       let statuses = Discovery.refresh_and_sync ~sw ~net ~endpoints:candidates in
       let found =


### PR DESCRIPTION
## Summary
- warn when `OAS_DISCOVERY_PORTS` contains non-numeric or out-of-range port tokens
- keep existing behavior for empty tokens and duplicate valid ports
- update inline parser tests so invalid tokens are observable instead of silent

## Verification
- `ocamlformat --check lib/llm_provider/discovery.ml`
- `git diff --check`
- `rg -n "silently|silent" lib/llm_provider/discovery.ml` (no matches)

Local Dune build/tests intentionally not run; GitHub CI is the build authority for this pass.