### PR TITLE
fix(otel): avoid module-load env capture

### DIFF
--- a/lib/eval_otel_bridge.ml
+++ b/lib/eval_otel_bridge.ml
@@ -199,9 +199,24 @@ let _mk_stdlib_inst () : Otel_tracer.instance =
   }
 ;;
 
-(* Lazy so default_config_from_env runs on first use, not module load. *)
-let default_otel_instance : Otel_tracer.instance lazy_t = lazy (_mk_stdlib_inst ())
-let default_instance () = Lazy.force default_otel_instance
+(* Initialized on first use under a stdlib mutex so concurrent callers cannot
+   race through process-wide default instance creation. *)
+let default_otel_instance_mu = Mutex.create ()
+let default_otel_instance_ref : Otel_tracer.instance option ref = ref None
+
+let default_instance () =
+  Mutex.lock default_otel_instance_mu;
+  Fun.protect
+    (fun () ->
+       match !default_otel_instance_ref with
+       | Some inst -> inst
+       | None ->
+         let inst = _mk_stdlib_inst () in
+         default_otel_instance_ref := Some inst;
+         inst)
+    ~finally:(fun () -> Mutex.unlock default_otel_instance_mu)
+;;
+
 let emit_run_metrics_default rm = emit_run_metrics (default_instance ()) rm
 
 (* ── JSON export ──────────────────────────────────────────────── *)

--- a/lib/eval_otel_bridge.ml
+++ b/lib/eval_otel_bridge.ml
@@ -199,9 +199,10 @@ let _mk_stdlib_inst () : Otel_tracer.instance =
   }
 ;;
 
-let default_otel_instance : Otel_tracer.instance = _mk_stdlib_inst ()
-let default_instance () = default_otel_instance
-let emit_run_metrics_default rm = emit_run_metrics default_otel_instance rm
+(* Lazy so default_config_from_env runs on first use, not module load. *)
+let default_otel_instance : Otel_tracer.instance lazy_t = lazy (_mk_stdlib_inst ())
+let default_instance () = Lazy.force default_otel_instance
+let emit_run_metrics_default rm = emit_run_metrics (default_instance ()) rm
 
 (* ── JSON export ──────────────────────────────────────────────── *)
 

--- a/lib/eval_otel_bridge.ml
+++ b/lib/eval_otel_bridge.ml
@@ -187,8 +187,10 @@ let emit_run_metrics (inst : Otel_tracer.instance) (rm : Eval.run_metrics) : uni
   Otel_tracer.inst_end_span inst span ~ok:(snap.verdict_failed_total = 0)
 ;;
 
-let default_otel_instance : Otel_tracer.instance =
-  { config = Otel_tracer.default_config
+(* Shared stdlib-mutex instance construction.  Kept as a single helper so
+   tests and the shared default instance use the same config source. *)
+let _mk_stdlib_inst () : Otel_tracer.instance =
+  { config = Otel_tracer.default_config_from_env ()
   ; mu = Otel_tracer.Stdlib_mu (Mutex.create ())
   ; fiber_key = None
   ; current_spans = []
@@ -197,6 +199,7 @@ let default_otel_instance : Otel_tracer.instance =
   }
 ;;
 
+let default_otel_instance : Otel_tracer.instance = _mk_stdlib_inst ()
 let default_instance () = default_otel_instance
 let emit_run_metrics_default rm = emit_run_metrics default_otel_instance rm
 
@@ -328,19 +331,6 @@ let%test "all metric names start with oas." =
   in
   let ms = to_metric_list (extract rm) in
   List.for_all (fun m -> String.length m.name > 4 && String.sub m.name 0 4 = "oas.") ms
-;;
-
-(* emit tests use a Stdlib.Mutex instance because inline tests
-   run outside an Eio context.  create_instance() uses Eio.Mutex
-   which raises Unhandled(Get_context) without Eio.main. *)
-let _mk_stdlib_inst () : Otel_tracer.instance =
-  { config = Otel_tracer.default_config
-  ; mu = Otel_tracer.Stdlib_mu (Mutex.create ())
-  ; fiber_key = None
-  ; current_spans = []
-  ; completed_spans = []
-  ; metrics = []
-  }
 ;;
 
 let%test "emit_run_metrics creates one span" =

--- a/lib/eval_otel_bridge.mli
+++ b/lib/eval_otel_bridge.mli
@@ -55,7 +55,10 @@ val otel_metric_type_to_tracer : string -> Otel_tracer.metric_type
 val emit_run_metrics : Otel_tracer.instance -> Eval.run_metrics -> unit
 
 (** Shared eval telemetry instance used by synchronous eval helpers that do
-    not own an Eio network context. Exporters can drain this instance. *)
+    not own an Eio network context. Exporters can drain this instance.
+
+    The instance is created lazily on first call, so environment-sensitive OTel
+    configuration is not captured at module load. *)
 val default_instance : unit -> Otel_tracer.instance
 
 (** Emit eval metrics on {!default_instance}. *)

--- a/lib/eval_otel_bridge.mli
+++ b/lib/eval_otel_bridge.mli
@@ -57,8 +57,8 @@ val emit_run_metrics : Otel_tracer.instance -> Eval.run_metrics -> unit
 (** Shared eval telemetry instance used by synchronous eval helpers that do
     not own an Eio network context. Exporters can drain this instance.
 
-    The instance is created lazily on first call, so environment-sensitive OTel
-    configuration is not captured at module load. *)
+    The instance is initialized on first call under a stdlib mutex, so
+    environment-sensitive OTel configuration is not captured at module load. *)
 val default_instance : unit -> Otel_tracer.instance
 
 (** Emit eval metrics on {!default_instance}. *)

--- a/lib/otel_tracer.ml
+++ b/lib/otel_tracer.ml
@@ -68,10 +68,13 @@ type config =
   ; endpoint : string option
   }
 
-let default_config = { service_name = "agent-sdk"; endpoint = None }
+let default_service_name = "agent-sdk"
+let otel_endpoint_env_var = "OTEL_EXPORTER_OTLP_ENDPOINT"
+
+let default_config = { service_name = default_service_name; endpoint = None }
 
 let default_config_from_env ?(getenv = Sys.getenv_opt) () =
-  { default_config with endpoint = getenv "OTEL_EXPORTER_OTLP_ENDPOINT" }
+  { default_config with endpoint = getenv otel_endpoint_env_var }
 ;;
 
 (* -- Metric types ----------------------------------------------------- *)
@@ -446,7 +449,12 @@ let metric_type_to_string = function
    captured on first use, and so the fiber-local key is only allocated when
    needed.  Using a fiber-local key makes the global API safe for concurrent
    Eio fibers: each fiber gets its own span stack instead of sharing the
-   instance-wide [current_spans]. *)
+   instance-wide [current_spans].
+
+   NOTE: the endpoint is resolved once when [_global] is first forced.  Later
+   changes to [OTEL_EXPORTER_OTLP_ENDPOINT] do not affect the already-created
+   shared instance; create a fresh instance with [create_instance] for per-call
+   env resolution. *)
 let _global : instance lazy_t =
   lazy
     { config = default_config_from_env ()
@@ -621,7 +629,12 @@ let to_otlp_json (cfg : config) : Yojson.Safe.t =
 
 (* -- Instance creation ------------------------------------------------ *)
 
-let create_instance ?(config = default_config_from_env ()) () : instance =
+let create_instance ?config ?getenv () : instance =
+  let config =
+    match config with
+    | Some config -> config
+    | None -> default_config_from_env ?getenv ()
+  in
   { config
   ; mu = Stdlib_mu (Mutex.create ())
   ; fiber_key = None
@@ -631,7 +644,12 @@ let create_instance ?(config = default_config_from_env ()) () : instance =
   }
 ;;
 
-let create_instance_eio ?(config = default_config_from_env ()) () : instance =
+let create_instance_eio ?config ?getenv () : instance =
+  let config =
+    match config with
+    | Some config -> config
+    | None -> default_config_from_env ?getenv ()
+  in
   { config
   ; mu = Eio_mu (Eio.Mutex.create ())
   ; fiber_key = Some (Eio.Fiber.create_key ())
@@ -691,20 +709,9 @@ let with_span attrs f =
 
 (* -- First-class module constructors ---------------------------------- *)
 
-let create ?config () : Tracing.t =
-  let inst =
-    match config with
-    | Some config -> create_instance ~config ()
-    | None -> create_instance ()
-  in
-  tracer_of_instance inst
-;;
+let create ?config ?getenv () : Tracing.t =
+  tracer_of_instance (create_instance ?config ?getenv ())
 
-let create_eio ?config () : Tracing.t =
-  let inst =
-    match config with
-    | Some config -> create_instance_eio ~config ()
-    | None -> create_instance_eio ()
-  in
-  tracer_of_instance inst
+let create_eio ?config ?getenv () : Tracing.t =
+  tracer_of_instance (create_instance_eio ?config ?getenv ())
 ;;

--- a/lib/otel_tracer.ml
+++ b/lib/otel_tracer.ml
@@ -444,48 +444,65 @@ let metric_type_to_string = function
 
 (* -- Global instance (backward compat) -------------------------------- *)
 
-(* The global tracer is lazy so that environment-sensitive configuration is
-   captured on first use, and so the fiber-local key is only allocated when
-   needed.  Using a fiber-local key makes the global API safe for concurrent
-   Eio fibers: each fiber gets its own span stack instead of sharing the
-   instance-wide [current_spans].
+(* The global tracer is initialized on first use so that environment-sensitive
+   configuration is not captured at module load, and so the fiber-local key is
+   only allocated when needed. First-use creation is protected by a stdlib
+   mutex because the global API can be reached by non-Eio callers. Using a
+   fiber-local key makes the global API safe for concurrent Eio fibers: each
+   fiber gets its own span stack instead of sharing the instance-wide
+   [current_spans].
 
-   NOTE: the endpoint is resolved once from [otel_endpoint_env_var] when
-   [_global] is first forced. Later env changes do not affect the
+   NOTE: the endpoint is resolved once from [otel_endpoint_env_var] when the
+   global instance is created. Later env changes do not affect the
    already-created shared instance; create a fresh instance with
    [create_instance] for per-call env resolution. *)
-let _global : instance lazy_t =
-  lazy
-    { config = default_config_from_env ()
-    ; mu = Stdlib_mu (Mutex.create ())
-    ; fiber_key = Some (Eio.Fiber.create_key ())
-    ; current_spans = []
-    ; completed_spans = []
-    ; metrics = []
-    }
+let make_global_instance () : instance =
+  { config = default_config_from_env ()
+  ; mu = Stdlib_mu (Mutex.create ())
+  ; fiber_key = Some (Eio.Fiber.create_key ())
+  ; current_spans = []
+  ; completed_spans = []
+  ; metrics = []
+  }
 ;;
 
-let start_span attrs = inst_start_span (Lazy.force _global) attrs
-let end_span s ~ok = inst_end_span (Lazy.force _global) s ~ok
-let add_event s msg = inst_add_event (Lazy.force _global) s msg
-let add_attrs s attrs = inst_add_attrs (Lazy.force _global) s attrs
+let global_instance_mu = Mutex.create ()
+let global_instance_ref : instance option ref = ref None
+
+let global_instance () =
+  Mutex.lock global_instance_mu;
+  Fun.protect
+    (fun () ->
+       match !global_instance_ref with
+       | Some inst -> inst
+       | None ->
+         let inst = make_global_instance () in
+         global_instance_ref := Some inst;
+         inst)
+    ~finally:(fun () -> Mutex.unlock global_instance_mu)
+;;
+
+let start_span attrs = inst_start_span (global_instance ()) attrs
+let end_span s ~ok = inst_end_span (global_instance ()) s ~ok
+let add_event s msg = inst_add_event (global_instance ()) s msg
+let add_attrs s attrs = inst_add_attrs (global_instance ()) s attrs
 
 let add_link s ~trace_id ~span_id =
-  inst_add_link (Lazy.force _global) s ~trace_id ~span_id
+  inst_add_link (global_instance ()) s ~trace_id ~span_id
 ;;
 
-let flush () = inst_flush (Lazy.force _global)
-let reset () = inst_reset (Lazy.force _global)
-let completed_count () = inst_completed_count (Lazy.force _global)
-let active_count () = inst_active_count (Lazy.force _global)
+let flush () = inst_flush (global_instance ())
+let reset () = inst_reset (global_instance ())
+let completed_count () = inst_completed_count (global_instance ())
+let active_count () = inst_active_count (global_instance ())
 
 let record_metric ~name ~value ~metric_type =
-  inst_record_metric (Lazy.force _global) ~name ~value ~metric_type
+  inst_record_metric (global_instance ()) ~name ~value ~metric_type
 ;;
 
-let get_metrics () = inst_get_metrics (Lazy.force _global)
-let clear_metrics () = inst_clear_metrics (Lazy.force _global)
-let current_span () = inst_current_span (Lazy.force _global)
+let get_metrics () = inst_get_metrics (global_instance ())
+let clear_metrics () = inst_clear_metrics (global_instance ())
+let current_span () = inst_current_span (global_instance ())
 
 (* -- JSON export ------------------------------------------------------ *)
 
@@ -576,7 +593,7 @@ let metric_entry_to_json (m : metric_entry) : Yojson.Safe.t =
 ;;
 
 let to_otlp_json (cfg : config) : Yojson.Safe.t =
-  let global = Lazy.force _global in
+  let global = global_instance () in
   let spans, metrics =
     inst_with_lock global (fun () ->
       List.rev global.completed_spans, List.rev global.metrics)
@@ -702,7 +719,7 @@ let tracer_of_instance inst : Tracing.t =
 ;;
 
 let with_span attrs f =
-  let module T = (val tracer_of_instance (Lazy.force _global)) in
+  let module T = (val tracer_of_instance (global_instance ())) in
   T.with_span attrs f
 ;;
 

--- a/lib/otel_tracer.ml
+++ b/lib/otel_tracer.ml
@@ -70,7 +70,6 @@ type config =
 
 let default_service_name = "agent-sdk"
 let otel_endpoint_env_var = "OTEL_EXPORTER_OTLP_ENDPOINT"
-
 let default_config = { service_name = default_service_name; endpoint = None }
 
 let default_config_from_env ?(getenv = Sys.getenv_opt) () =
@@ -451,10 +450,10 @@ let metric_type_to_string = function
    Eio fibers: each fiber gets its own span stack instead of sharing the
    instance-wide [current_spans].
 
-   NOTE: the endpoint is resolved once when [_global] is first forced.  Later
-   changes to [OTEL_EXPORTER_OTLP_ENDPOINT] do not affect the already-created
-   shared instance; create a fresh instance with [create_instance] for per-call
-   env resolution. *)
+   NOTE: the endpoint is resolved once from [otel_endpoint_env_var] when
+   [_global] is first forced. Later env changes do not affect the
+   already-created shared instance; create a fresh instance with
+   [create_instance] for per-call env resolution. *)
 let _global : instance lazy_t =
   lazy
     { config = default_config_from_env ()
@@ -711,6 +710,7 @@ let with_span attrs f =
 
 let create ?config ?getenv () : Tracing.t =
   tracer_of_instance (create_instance ?config ?getenv ())
+;;
 
 let create_eio ?config ?getenv () : Tracing.t =
   tracer_of_instance (create_instance_eio ?config ?getenv ())

--- a/lib/otel_tracer.ml
+++ b/lib/otel_tracer.ml
@@ -68,9 +68,10 @@ type config =
   ; endpoint : string option
   }
 
-let default_config =
-  let endpoint = Sys.getenv_opt "OTEL_EXPORTER_OTLP_ENDPOINT" in
-  { service_name = "agent-sdk"; endpoint }
+let default_config = { service_name = "agent-sdk"; endpoint = None }
+
+let default_config_from_env ?(getenv = Sys.getenv_opt) () =
+  { default_config with endpoint = getenv "OTEL_EXPORTER_OTLP_ENDPOINT" }
 ;;
 
 (* -- Metric types ----------------------------------------------------- *)
@@ -448,14 +449,13 @@ let metric_type_to_string = function
    instance-wide [current_spans]. *)
 let _global : instance lazy_t =
   lazy
-    (let endpoint = Sys.getenv_opt "OTEL_EXPORTER_OTLP_ENDPOINT" in
-     { config = { service_name = "agent-sdk"; endpoint }
-     ; mu = Stdlib_mu (Mutex.create ())
-     ; fiber_key = Some (Eio.Fiber.create_key ())
-     ; current_spans = []
-     ; completed_spans = []
-     ; metrics = []
-     })
+    { config = default_config_from_env ()
+    ; mu = Stdlib_mu (Mutex.create ())
+    ; fiber_key = Some (Eio.Fiber.create_key ())
+    ; current_spans = []
+    ; completed_spans = []
+    ; metrics = []
+    }
 ;;
 
 let start_span attrs = inst_start_span (Lazy.force _global) attrs
@@ -621,7 +621,7 @@ let to_otlp_json (cfg : config) : Yojson.Safe.t =
 
 (* -- Instance creation ------------------------------------------------ *)
 
-let create_instance ?(config = default_config) () : instance =
+let create_instance ?(config = default_config_from_env ()) () : instance =
   { config
   ; mu = Stdlib_mu (Mutex.create ())
   ; fiber_key = None
@@ -631,7 +631,7 @@ let create_instance ?(config = default_config) () : instance =
   }
 ;;
 
-let create_instance_eio ?(config = default_config) () : instance =
+let create_instance_eio ?(config = default_config_from_env ()) () : instance =
   { config
   ; mu = Eio_mu (Eio.Mutex.create ())
   ; fiber_key = Some (Eio.Fiber.create_key ())
@@ -691,10 +691,20 @@ let with_span attrs f =
 
 (* -- First-class module constructors ---------------------------------- *)
 
-let create ?(config : config = default_config) () : Tracing.t =
-  tracer_of_instance (create_instance ~config ())
+let create ?config () : Tracing.t =
+  let inst =
+    match config with
+    | Some config -> create_instance ~config ()
+    | None -> create_instance ()
+  in
+  tracer_of_instance inst
 ;;
 
-let create_eio ?(config : config = default_config) () : Tracing.t =
-  tracer_of_instance (create_instance_eio ~config ())
+let create_eio ?config () : Tracing.t =
+  let inst =
+    match config with
+    | Some config -> create_instance_eio ~config ()
+    | None -> create_instance_eio ()
+  in
+  tracer_of_instance inst
 ;;

--- a/lib/otel_tracer.mli
+++ b/lib/otel_tracer.mli
@@ -74,6 +74,13 @@ type instance =
 
 (** {1 Config} *)
 
+(** Default service name used when no config is supplied. *)
+val default_service_name : string
+
+(** Environment variable name read by [default_config_from_env] and by the
+    constructors below when [config] is omitted. *)
+val otel_endpoint_env_var : string
+
 (** Environment-free baseline config. *)
 val default_config : config
 
@@ -92,8 +99,19 @@ val make_span_name : Tracing.span_attrs -> string
 
 (** {1 Instance operations} *)
 
-val create_instance : ?config:config -> unit -> instance
-val create_instance_eio : ?config:config -> unit -> instance
+(** Create a stdlib-mutex backed instance.
+
+    If [config] is omitted, [default_config_from_env ()] is called at creation
+    time, which reads [OTEL_EXPORTER_OTLP_ENDPOINT] from the environment.
+    [getenv] is forwarded to [default_config_from_env] and is useful for tests. *)
+val create_instance : ?config:config -> ?getenv:(string -> string option) -> unit -> instance
+
+(** Create an Eio-mutex backed instance.
+
+    If [config] is omitted, [default_config_from_env ()] is called at creation
+    time, which reads [OTEL_EXPORTER_OTLP_ENDPOINT] from the environment.
+    [getenv] is forwarded to [default_config_from_env] and is useful for tests. *)
+val create_instance_eio : ?config:config -> ?getenv:(string -> string option) -> unit -> instance
 val inst_start_span : instance -> Tracing.span_attrs -> span
 val inst_end_span : instance -> span -> ok:bool -> unit
 val inst_add_event : instance -> span -> string -> unit
@@ -177,5 +195,17 @@ val to_otlp_json : config -> Yojson.Safe.t
 (** {1 First-class module constructors} *)
 
 val tracer_of_instance : instance -> Tracing.t
-val create : ?config:config -> unit -> Tracing.t
-val create_eio : ?config:config -> unit -> Tracing.t
+
+(** Build a first-class tracer backed by a stdlib-mutex instance.
+
+    If [config] is omitted, [default_config_from_env ()] is called at creation
+    time, which reads [OTEL_EXPORTER_OTLP_ENDPOINT] from the environment.
+    [getenv] is forwarded to [default_config_from_env] and is useful for tests. *)
+val create : ?config:config -> ?getenv:(string -> string option) -> unit -> Tracing.t
+
+(** Build a first-class tracer backed by an Eio-mutex instance.
+
+    If [config] is omitted, [default_config_from_env ()] is called at creation
+    time, which reads [OTEL_EXPORTER_OTLP_ENDPOINT] from the environment.
+    [getenv] is forwarded to [default_config_from_env] and is useful for tests. *)
+val create_eio : ?config:config -> ?getenv:(string -> string option) -> unit -> Tracing.t

--- a/lib/otel_tracer.mli
+++ b/lib/otel_tracer.mli
@@ -74,7 +74,12 @@ type instance =
 
 (** {1 Config} *)
 
+(** Environment-free baseline config. *)
 val default_config : config
+
+(** Build the default config using the provided environment lookup at call time. *)
+val default_config_from_env : ?getenv:(string -> string option) -> unit -> config
+
 val otel_span_kind_to_int : otel_span_kind -> int
 
 (** {1 Utilities} *)

--- a/lib/otel_tracer.mli
+++ b/lib/otel_tracer.mli
@@ -102,16 +102,25 @@ val make_span_name : Tracing.span_attrs -> string
 (** Create a stdlib-mutex backed instance.
 
     If [config] is omitted, [default_config_from_env ()] is called at creation
-    time, which reads [OTEL_EXPORTER_OTLP_ENDPOINT] from the environment.
+    time, which reads [otel_endpoint_env_var] from the environment.
     [getenv] is forwarded to [default_config_from_env] and is useful for tests. *)
-val create_instance : ?config:config -> ?getenv:(string -> string option) -> unit -> instance
+val create_instance
+  :  ?config:config
+  -> ?getenv:(string -> string option)
+  -> unit
+  -> instance
 
 (** Create an Eio-mutex backed instance.
 
     If [config] is omitted, [default_config_from_env ()] is called at creation
-    time, which reads [OTEL_EXPORTER_OTLP_ENDPOINT] from the environment.
+    time, which reads [otel_endpoint_env_var] from the environment.
     [getenv] is forwarded to [default_config_from_env] and is useful for tests. *)
-val create_instance_eio : ?config:config -> ?getenv:(string -> string option) -> unit -> instance
+val create_instance_eio
+  :  ?config:config
+  -> ?getenv:(string -> string option)
+  -> unit
+  -> instance
+
 val inst_start_span : instance -> Tracing.span_attrs -> span
 val inst_end_span : instance -> span -> ok:bool -> unit
 val inst_add_event : instance -> span -> string -> unit
@@ -199,13 +208,13 @@ val tracer_of_instance : instance -> Tracing.t
 (** Build a first-class tracer backed by a stdlib-mutex instance.
 
     If [config] is omitted, [default_config_from_env ()] is called at creation
-    time, which reads [OTEL_EXPORTER_OTLP_ENDPOINT] from the environment.
+    time, which reads [otel_endpoint_env_var] from the environment.
     [getenv] is forwarded to [default_config_from_env] and is useful for tests. *)
 val create : ?config:config -> ?getenv:(string -> string option) -> unit -> Tracing.t
 
 (** Build a first-class tracer backed by an Eio-mutex instance.
 
     If [config] is omitted, [default_config_from_env ()] is called at creation
-    time, which reads [OTEL_EXPORTER_OTLP_ENDPOINT] from the environment.
+    time, which reads [otel_endpoint_env_var] from the environment.
     [getenv] is forwarded to [default_config_from_env] and is useful for tests. *)
 val create_eio : ?config:config -> ?getenv:(string -> string option) -> unit -> Tracing.t

--- a/test/test_otel_tracer.ml
+++ b/test/test_otel_tracer.ml
@@ -43,12 +43,64 @@ let test_default_config_from_env_reads_getenv_at_call_time () =
   let calls = ref [] in
   let getenv name =
     calls := name :: !calls;
-    if String.equal name "OTEL_EXPORTER_OTLP_ENDPOINT" then Some endpoint else None
+    if String.equal name Otel_tracer.otel_endpoint_env_var then Some endpoint else None
   in
   let config = Otel_tracer.default_config_from_env ~getenv () in
-  check string "service_name" "agent-sdk" config.service_name;
+  check string "service_name" Otel_tracer.default_service_name config.service_name;
   check (option string) "endpoint" (Some endpoint) config.endpoint;
-  check (list string) "env keys" [ "OTEL_EXPORTER_OTLP_ENDPOINT" ] (List.rev !calls)
+  check (list string) "env keys" [ Otel_tracer.otel_endpoint_env_var ] (List.rev !calls)
+;;
+
+let test_create_instance_reads_env_at_call_time () =
+  let endpoint = "http://ctor.example/v1/traces" in
+  let calls = ref [] in
+  let getenv name =
+    calls := name :: !calls;
+    if String.equal name Otel_tracer.otel_endpoint_env_var then Some endpoint else None
+  in
+  let inst = Otel_tracer.create_instance ~getenv () in
+  check (option string) "endpoint" (Some endpoint) inst.config.endpoint;
+  check (list string) "env keys" [ Otel_tracer.otel_endpoint_env_var ] (List.rev !calls)
+;;
+
+let test_create_instance_eio_reads_env_at_call_time () =
+  let endpoint = "http://ctor-eio.example/v1/traces" in
+  let calls = ref [] in
+  let getenv name =
+    calls := name :: !calls;
+    if String.equal name Otel_tracer.otel_endpoint_env_var then Some endpoint else None
+  in
+  let inst = Otel_tracer.create_instance_eio ~getenv () in
+  check (option string) "endpoint" (Some endpoint) inst.config.endpoint;
+  check (list string) "env keys" [ Otel_tracer.otel_endpoint_env_var ] (List.rev !calls)
+;;
+
+let test_create_reads_env_at_call_time () =
+  let endpoint = "http://create.example/v1/traces" in
+  let calls = ref [] in
+  let getenv name =
+    calls := name :: !calls;
+    if String.equal name Otel_tracer.otel_endpoint_env_var then Some endpoint else None
+  in
+  let (module T : Tracing.TRACER) = Otel_tracer.create ~getenv () in
+  let span = T.start_span (default_attrs ~name:"env_probe" ()) in
+  T.end_span span ~ok:true;
+  check (list string) "env keys" [ Otel_tracer.otel_endpoint_env_var ] (List.rev !calls)
+;;
+
+let test_create_eio_reads_env_at_call_time () =
+  let endpoint = "http://create-eio.example/v1/traces" in
+  let calls = ref [] in
+  let getenv name =
+    calls := name :: !calls;
+    if String.equal name Otel_tracer.otel_endpoint_env_var then Some endpoint else None
+  in
+  Eio_main.run
+    (fun _env ->
+       let (module T : Tracing.TRACER) = Otel_tracer.create_eio ~getenv () in
+       let span = T.start_span (default_attrs ~name:"env_probe" ()) in
+       T.end_span span ~ok:true;
+       check (list string) "env keys" [ Otel_tracer.otel_endpoint_env_var ] (List.rev !calls))
 ;;
 
 (* ── Span Lifecycle ──────────────────────────────────────────────── *)
@@ -650,6 +702,19 @@ let () =
             "default_config_from_env reads injected env"
             `Quick
             test_default_config_from_env_reads_getenv_at_call_time
+        ; test_case
+            "create_instance reads env at call time"
+            `Quick
+            test_create_instance_reads_env_at_call_time
+        ; test_case
+            "create_instance_eio reads env at call time"
+            `Quick
+            (with_eio test_create_instance_eio_reads_env_at_call_time)
+        ; test_case "create reads env at call time" `Quick test_create_reads_env_at_call_time
+        ; test_case
+            "create_eio reads env at call time"
+            `Quick
+            (with_eio test_create_eio_reads_env_at_call_time)
         ] )
     ; ( "span_lifecycle"
       , [ test_case "start_span name format" `Quick test_start_span_name_format

--- a/test/test_otel_tracer.ml
+++ b/test/test_otel_tracer.ml
@@ -31,6 +31,26 @@ let json_assoc_field key = function
   | _ -> None
 ;;
 
+(* -- Config ------------------------------------------------------------- *)
+
+let test_default_config_is_env_free () =
+  check string "service_name" "agent-sdk" Otel_tracer.default_config.service_name;
+  check (option string) "endpoint" None Otel_tracer.default_config.endpoint
+;;
+
+let test_default_config_from_env_reads_getenv_at_call_time () =
+  let endpoint = "http://collector.example/v1/traces" in
+  let calls = ref [] in
+  let getenv name =
+    calls := name :: !calls;
+    if String.equal name "OTEL_EXPORTER_OTLP_ENDPOINT" then Some endpoint else None
+  in
+  let config = Otel_tracer.default_config_from_env ~getenv () in
+  check string "service_name" "agent-sdk" config.service_name;
+  check (option string) "endpoint" (Some endpoint) config.endpoint;
+  check (list string) "env keys" [ "OTEL_EXPORTER_OTLP_ENDPOINT" ] (List.rev !calls)
+;;
+
 (* ── Span Lifecycle ──────────────────────────────────────────────── *)
 
 let test_start_span_name_format () =
@@ -624,7 +644,14 @@ let test_first_class_trace_context_headers () =
 let () =
   run
     "Otel_tracer"
-    [ ( "span_lifecycle"
+    [ ( "config"
+      , [ test_case "default_config is env-free" `Quick test_default_config_is_env_free
+        ; test_case
+            "default_config_from_env reads injected env"
+            `Quick
+            test_default_config_from_env_reads_getenv_at_call_time
+        ] )
+    ; ( "span_lifecycle"
       , [ test_case "start_span name format" `Quick test_start_span_name_format
         ; test_case "start_span attributes" `Quick test_start_span_attributes
         ; test_case "start_span kind mapping" `Quick test_start_span_kind_mapping

--- a/test/test_otel_tracer.ml
+++ b/test/test_otel_tracer.ml
@@ -34,7 +34,11 @@ let json_assoc_field key = function
 (* -- Config ------------------------------------------------------------- *)
 
 let test_default_config_is_env_free () =
-  check string "service_name" "agent-sdk" Otel_tracer.default_config.service_name;
+  check
+    string
+    "service_name"
+    Otel_tracer.default_service_name
+    Otel_tracer.default_config.service_name;
   check (option string) "endpoint" None Otel_tracer.default_config.endpoint
 ;;
 
@@ -95,12 +99,11 @@ let test_create_eio_reads_env_at_call_time () =
     calls := name :: !calls;
     if String.equal name Otel_tracer.otel_endpoint_env_var then Some endpoint else None
   in
-  Eio_main.run
-    (fun _env ->
-       let (module T : Tracing.TRACER) = Otel_tracer.create_eio ~getenv () in
-       let span = T.start_span (default_attrs ~name:"env_probe" ()) in
-       T.end_span span ~ok:true;
-       check (list string) "env keys" [ Otel_tracer.otel_endpoint_env_var ] (List.rev !calls))
+  Eio_main.run (fun _env ->
+    let (module T : Tracing.TRACER) = Otel_tracer.create_eio ~getenv () in
+    let span = T.start_span (default_attrs ~name:"env_probe" ()) in
+    T.end_span span ~ok:true;
+    check (list string) "env keys" [ Otel_tracer.otel_endpoint_env_var ] (List.rev !calls))
 ;;
 
 (* ── Span Lifecycle ──────────────────────────────────────────────── *)
@@ -710,7 +713,10 @@ let () =
             "create_instance_eio reads env at call time"
             `Quick
             (with_eio test_create_instance_eio_reads_env_at_call_time)
-        ; test_case "create reads env at call time" `Quick test_create_reads_env_at_call_time
+        ; test_case
+            "create reads env at call time"
+            `Quick
+            test_create_reads_env_at_call_time
         ; test_case
             "create_eio reads env at call time"
             `Quick


### PR DESCRIPTION
## Summary
- make Otel_tracer.default_config an environment-free baseline
- add default_config_from_env so OTEL_EXPORTER_OTLP_ENDPOINT is read at call time
- route omitted tracer instance config and the lazy global tracer through the call-time helper
- cover the config split without mutating process environment in tests

## Verification
- ocamlformat --check lib/otel_tracer.ml lib/otel_tracer.mli test/test_otel_tracer.ml
- git diff --check
- local Dune build not run; CI is the build authority for this change