### PR TITLE
style: apply ocamlformat to current main

### DIFF
--- a/lib/agent/agent_config.ml
+++ b/lib/agent/agent_config.ml
@@ -152,7 +152,11 @@ let invalid_type ~field ~expected json =
     (Error.Config
        (InvalidConfig
           { field
-          ; detail = Printf.sprintf "expected %s, got %s" expected (Llm_provider.Json_util.json_type_name json)
+          ; detail =
+              Printf.sprintf
+                "expected %s, got %s"
+                expected
+                (Llm_provider.Json_util.json_type_name json)
           }))
 ;;
 

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -249,10 +249,7 @@ let set_idle_state t (s : Agent_turn.idle_state) =
     t.consecutive_idle_turns <- s.consecutive_idle_turns)
 ;;
 
-let reset_idle_state t =
-  set_idle_state t (Agent_turn.reset_idle_detection ()).new_state
-;;
-
+let reset_idle_state t = set_idle_state t (Agent_turn.reset_idle_detection ()).new_state
 let description t = t.options.description
 let allowed_paths t = t.options.allowed_paths
 let sdk_version = Sdk_version.version

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -278,6 +278,7 @@ val set_idle_state : t -> idle_state -> unit
 (** Reset idle-detection counters to their initial (zero) state.
     Equivalent to [set_idle_state t { last_tool_calls = None; consecutive_idle_turns = 0 }]. *)
 val reset_idle_state : t -> unit
+
 val description : t -> string option
 val allowed_paths : t -> string list
 

--- a/lib/base/util.ml
+++ b/lib/base/util.ml
@@ -105,7 +105,6 @@ let trim_non_empty_opt = function
 (** Deprecated: use [Llm_provider.Cli_common_env.get]. Kept for backward
     compatibility until remaining internal callers are migrated. *)
 let get = Llm_provider.Cli_common_env.get
-;;
 
 let env_or default var =
   match get var with

--- a/lib/llm_provider/cli_common_env.ml
+++ b/lib/llm_provider/cli_common_env.ml
@@ -30,13 +30,13 @@ let bool ?(default = false) ?on_invalid name =
      | "1" | "true" | "yes" | "on" -> true
      | "0" | "false" | "no" | "off" -> false
      | _ ->
-       warn_invalid
-         ~on_invalid
-         ~var:name
-         ~raw:v
-         ~expected:"boolean"
-         ~diag:(fun () ->
-           Diag.warn "cli_common_env" "%s=%S is not a boolean; using default %b" name v default);
+       warn_invalid ~on_invalid ~var:name ~raw:v ~expected:"boolean" ~diag:(fun () ->
+         Diag.warn
+           "cli_common_env"
+           "%s=%S is not a boolean; using default %b"
+           name
+           v
+           default);
        default)
 ;;
 
@@ -80,29 +80,28 @@ let int ?(allow_negative = false) ?on_invalid ~default var =
     (match int_of_string_opt raw with
      | Some v when v >= 0 || allow_negative -> v
      | Some v ->
-       warn_invalid
-         ~on_invalid
-         ~var
-         ~raw
-         ~expected
-         ~diag:(fun () ->
-           Diag.warn "cli_common_env" "%s=%S is negative (%d); using default %d" var raw v default);
+       warn_invalid ~on_invalid ~var ~raw ~expected ~diag:(fun () ->
+         Diag.warn
+           "cli_common_env"
+           "%s=%S is negative (%d); using default %d"
+           var
+           raw
+           v
+           default);
        default
      | None ->
-       warn_invalid
-         ~on_invalid
-         ~var
-         ~raw
-         ~expected
-         ~diag:(fun () ->
-           Diag.warn "cli_common_env" "%s=%S is not an integer; using default %d" var raw default);
+       warn_invalid ~on_invalid ~var ~raw ~expected ~diag:(fun () ->
+         Diag.warn
+           "cli_common_env"
+           "%s=%S is not an integer; using default %d"
+           var
+           raw
+           default);
        default)
 ;;
 
 let float ?(allow_negative = false) ?on_invalid ~default var =
-  let expected =
-    if allow_negative then "finite float" else "non-negative finite float"
-  in
+  let expected = if allow_negative then "finite float" else "non-negative finite float" in
   match get var with
   | None -> default
   | Some raw ->
@@ -110,22 +109,24 @@ let float ?(allow_negative = false) ?on_invalid ~default var =
      | Some v when Float.is_finite v && (v >= 0.0 || allow_negative) -> v
      | Some v ->
        let kind = if Float.is_finite v then "negative" else "not a finite" in
-       warn_invalid
-         ~on_invalid
-         ~var
-         ~raw
-         ~expected
-         ~diag:(fun () ->
-           Diag.warn "cli_common_env" "%s=%S is %s (%f); using default %f" var raw kind v default);
+       warn_invalid ~on_invalid ~var ~raw ~expected ~diag:(fun () ->
+         Diag.warn
+           "cli_common_env"
+           "%s=%S is %s (%f); using default %f"
+           var
+           raw
+           kind
+           v
+           default);
        default
      | None ->
-       warn_invalid
-         ~on_invalid
-         ~var
-         ~raw
-         ~expected
-         ~diag:(fun () ->
-           Diag.warn "cli_common_env" "%s=%S is not a float; using default %f" var raw default);
+       warn_invalid ~on_invalid ~var ~raw ~expected ~diag:(fun () ->
+         Diag.warn
+           "cli_common_env"
+           "%s=%S is not a float; using default %f"
+           var
+           raw
+           default);
        default)
 ;;
 

--- a/lib/llm_provider/cli_common_env.mli
+++ b/lib/llm_provider/cli_common_env.mli
@@ -69,11 +69,21 @@ val trim_non_empty_opt : string option -> string option
     rejected unless [allow_negative] is [true].  Rejected values call
     [on_invalid] if provided, otherwise emit a diagnostic warning before
     falling back to [default]. *)
-val int : ?allow_negative:bool -> ?on_invalid:(invalid_env -> unit) -> default:int -> string -> int
+val int
+  :  ?allow_negative:bool
+  -> ?on_invalid:(invalid_env -> unit)
+  -> default:int
+  -> string
+  -> int
 
 (** [float ?allow_negative ?on_invalid ~default var] parses env var [var] as a
     float.  Returns [default] when unset or empty.  Negative and non-finite
     values are rejected unless [allow_negative] is [true] (non-finite values
     are always rejected).  Rejected values call [on_invalid] if provided,
     otherwise emit a diagnostic warning before falling back to [default]. *)
-val float : ?allow_negative:bool -> ?on_invalid:(invalid_env -> unit) -> default:float -> string -> float
+val float
+  :  ?allow_negative:bool
+  -> ?on_invalid:(invalid_env -> unit)
+  -> default:float
+  -> string
+  -> float

--- a/test/test_mcp_deep.ml
+++ b/test/test_mcp_deep.ml
@@ -315,7 +315,10 @@ let () =
         ; Alcotest.test_case "long" `Quick test_truncate_long
         ; Alcotest.test_case "exact boundary" `Quick test_truncate_exact_boundary
         ; Alcotest.test_case "one over" `Quick test_truncate_one_over
-        ; Alcotest.test_case "zero budget unlimited" `Quick test_truncate_zero_budget_unlimited
+        ; Alcotest.test_case
+            "zero budget unlimited"
+            `Quick
+            test_truncate_zero_budget_unlimited
         ] )
     ; ( "text_of_tool_result"
       , [ Alcotest.test_case "single text" `Quick test_text_single_text


### PR DESCRIPTION
## Summary
- Apply ocamlformat to files currently failing OAS OCaml Format CI on main.
- No source behavior changes; this is the same format drift surfaced while validating #2203.

## Verification
- `git diff --check`
- `ocamlformat --check test/test_mcp_deep.ml lib/llm_provider/cli_common_env.mli lib/llm_provider/cli_common_env.ml lib/base/util.ml lib/agent/agent_config.ml lib/agent/agent_types.mli lib/agent/agent_types.ml test/test_types.ml`
