### PR TITLE
fix(api): keep default_config as a value (non-breaking) — semver repair (#2194/#2204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ original tag dates. `0.100.4` was never tagged or released.
 
 * **context:** diff sorted snapshots directly ([#2183](https://github.com/jeong-sik/oas/issues/2183)) ([fff74f6](https://github.com/jeong-sik/oas/commit/fff74f6bb0b4f1135e0048b658c266632cd37ead))
 
+> **Post-release correction (0.207.12, #2207):** [#2194](https://github.com/jeong-sik/oas/issues/2194)
+> also changed `Context_offload.default_config` and `Mcp_http.default_config` from
+> values to `unit -> config` functions — a breaking API change that should have
+> been a minor version bump. 0.207.12 reverts `default_config` to a value
+> (captured at module init) and exposes the call-time capability as
+> `make_default_config`. Downstream that migrated to `default_config ()` on
+> 0.207.11 should revert to `default_config` or use `make_default_config ()`.
+
 ## [0.207.10](https://github.com/jeong-sik/oas/compare/v0.207.9...v0.207.10) (2026-06-27)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ original tag dates. `0.100.4` was never tagged or released.
 
 * **context_offload:** emit a diagnostic warning when tool-result offload write
   fails before preserving the original content.
-* **defaults:** add call-time local endpoint and fallback-provider resolvers while preserving compatibility snapshot values.
+* **defaults:** restore `Context_offload.default_config` and
+  `Mcp_http.default_config` as compatibility values; use
+  `Context_offload.make_default_config ()` or `Mcp_http.make_default_config ()`
+  for call-time environment resolution.
 * **llm_provider:** resolve env-backed max token, thinking budget, and Anthropic prompt-cache defaults at request-build time; static prompt-cache threshold alias is kept only for compatibility.
 
 ### Features
@@ -22,15 +25,6 @@ original tag dates. `0.100.4` was never tagged or released.
 * **mcp:** `OAS_MCP_OUTPUT_MAX_TOKENS=0` is now treated as "unlimited" by `truncate_output` instead of truncating every non-empty result to the marker.
 * **pipeline:** `OAS_COMPACT_WATERMARK` parsing emits a single local `Log.warn` for all invalid cases, preserving the original raw string.
 * **util:** mark `Util.get` as `[@@ocaml.deprecated]` in favor of `Llm_provider.Cli_common_env.get`.
-### Breaking Changes
-
-* **context_offload:** `Context_offload.default_config` is now `unit -> config`
-  so the temporary directory is resolved at call time. Update downstream callers
-  from `Context_offload.default_config` to `Context_offload.default_config ()`.
-
-* **mcp_http:** `Mcp_http.default_config` is now `unit -> config` so
-  `OAS_MCP_HTTP_URL` is read at call time. Update downstream callers from
-  `Mcp_http.default_config` to `Mcp_http.default_config ()`.
 
 ## [0.207.11](https://github.com/jeong-sik/oas/compare/v0.207.10...v0.207.11) (2026-06-28)
 

--- a/lib/context_offload.ml
+++ b/lib/context_offload.ml
@@ -17,11 +17,17 @@ type config =
   ; preview_len : int (** Characters of content to keep as preview *)
   }
 
-let default_config () =
+let make_default_config () =
   { threshold_bytes = 4096
   ; output_dir = Filename.get_temp_dir_name ()
   ; preview_len = 200
   }
+;;
+
+(** Default offload configuration captured at module init. Callers that need to
+    re-resolve [Filename.get_temp_dir_name ()] at use time (e.g. when [TMPDIR]
+    is set after this module loads) should call {!make_default_config} instead. *)
+let default_config = make_default_config ()
 ;;
 
 (** Diagnostic context string used for [Llm_provider.Diag] warnings. *)

--- a/lib/context_offload.mli
+++ b/lib/context_offload.mli
@@ -21,9 +21,16 @@ type config =
   ; preview_len : int
   }
 
-(** Default offload configuration.
-    Resolves [Filename.get_temp_dir_name ()] at call time. *)
-val default_config : unit -> config
+(** Build a default offload configuration, resolving
+    [Filename.get_temp_dir_name ()] at call time. Use this when the temp
+    directory may be re-resolved after module init. *)
+val make_default_config : unit -> config
+
+(** Default offload configuration captured at module init. Equivalent to
+    {!make_default_config} evaluated once when the module loads; kept as a
+    value for backwards-compatible callers (so a prior [default_config] value
+    continues to type-check). *)
+val default_config : config
 
 (** Diagnostic context string used for [Llm_provider.Diag] warnings emitted by
     this module. Exposed so tests can assert on context without hard-coding the

--- a/lib/protocol/mcp_http.ml
+++ b/lib/protocol/mcp_http.ml
@@ -8,13 +8,19 @@ type config =
 
 let default_endpoint_env_var = "OAS_MCP_HTTP_URL"
 
-let default_config () =
+let make_default_config () =
   { base_url =
       Util.env_or "http://localhost:8080/mcp" default_endpoint_env_var
       (* Set OAS_MCP_HTTP_URL to override the MCP server endpoint.
          Default assumes local dev server on port 8080. *)
   ; headers = []
   }
+;;
+
+(** Default MCP HTTP configuration captured at module init. Callers that need
+    to re-read [OAS_MCP_HTTP_URL] at use time should call {!make_default_config}
+    instead. *)
+let default_config = make_default_config ()
 ;;
 
 type t = { client : Sdk_http_client.t }

--- a/lib/protocol/mcp_http.mli
+++ b/lib/protocol/mcp_http.mli
@@ -8,10 +8,14 @@ type config =
   ; headers : (string * string) list
   }
 
-(** Default HTTP MCP transport config.
-    Reads [OAS_MCP_HTTP_URL] at call time, defaulting to
-    ["http://localhost:8080/mcp"]. *)
-val default_config : unit -> config
+(** [make_default_config ()] builds a default HTTP MCP transport config, reading
+    [OAS_MCP_HTTP_URL] at call time, defaulting to ["http://localhost:8080/mcp"]. *)
+val make_default_config : unit -> config
+
+(** Default HTTP MCP transport config captured at module init. Equivalent to
+    {!make_default_config} evaluated once when the module loads; kept as a value
+    for backwards-compatible callers. *)
+val default_config : config
 
 (** Environment variable used by {!default_config} to resolve the MCP HTTP
     endpoint. *)

--- a/test/test_context_offload.ml
+++ b/test/test_context_offload.ml
@@ -9,7 +9,7 @@ let check_int = Alcotest.(check int)
 (* ── default_config ───────────────────────────────────── *)
 
 let test_default_config () =
-  let c = Context_offload.default_config () in
+  let c = Context_offload.default_config in
   check_int "threshold" 4096 c.threshold_bytes;
   check_int "preview_len" 200 c.preview_len;
   check_bool "output_dir non-empty" true (String.length c.output_dir > 0)

--- a/test/test_cost_tracker.ml
+++ b/test/test_cost_tracker.ml
@@ -62,7 +62,7 @@ let test_report_to_string () =
 (* ── Context Offload ───────────────────────────────── *)
 
 let test_offload_small_content () =
-  let config = Context_offload.default_config () in
+  let config = Context_offload.default_config in
   let result = Context_offload.maybe_offload ~config ~tool_name:"test" "small" in
   match result with
   | Context_offload.Kept s -> check string "kept" "small" s
@@ -70,7 +70,7 @@ let test_offload_small_content () =
 ;;
 
 let test_offload_large_content () =
-  let config = { (Context_offload.default_config ()) with threshold_bytes = 10 } in
+  let config = { (Context_offload.default_config) with threshold_bytes = 10 } in
   let content = String.make 100 'x' in
   let result = Context_offload.maybe_offload ~config ~tool_name:"big" content in
   match result with
@@ -85,7 +85,7 @@ let test_offload_large_content () =
 ;;
 
 let test_offload_exact_threshold () =
-  let config = { (Context_offload.default_config ()) with threshold_bytes = 10 } in
+  let config = { (Context_offload.default_config) with threshold_bytes = 10 } in
   let content = String.make 10 'y' in
   match Context_offload.maybe_offload ~config ~tool_name:"exact" content with
   | Context_offload.Kept _ -> () (* At threshold, kept *)
@@ -123,7 +123,7 @@ let test_offload_to_context_string_offloaded () =
 ;;
 
 let test_offload_convenience () =
-  let config = { (Context_offload.default_config ()) with threshold_bytes = 5 } in
+  let config = { (Context_offload.default_config) with threshold_bytes = 5 } in
   let result =
     Context_offload.offload_tool_result ~config ~tool_name:"conv" "this is longer than 5"
   in
@@ -139,7 +139,7 @@ let test_offload_convenience () =
 ;;
 
 let test_offload_special_chars_in_name () =
-  let config = { (Context_offload.default_config ()) with threshold_bytes = 5 } in
+  let config = { (Context_offload.default_config) with threshold_bytes = 5 } in
   let content = String.make 20 'z' in
   let result = Context_offload.maybe_offload ~config ~tool_name:"my/tool name" content in
   match result with

--- a/test/test_mcp_coverage.ml
+++ b/test/test_mcp_coverage.ml
@@ -313,7 +313,7 @@ let test_mcp_tool_to_sdk_tool_empty_schema () =
 (* ── Mcp_http.default_config ──────────────────────────────── *)
 
 let test_mcp_http_default_config_values () =
-  let cfg = Mcp_http.default_config () in
+  let cfg = Mcp_http.default_config in
   Alcotest.(check string) "default base_url" "http://localhost:8080/mcp" cfg.base_url;
   Alcotest.(check (list (pair string string))) "no headers" [] cfg.headers
 ;;

--- a/test/test_mcp_http.ml
+++ b/test/test_mcp_http.ml
@@ -26,20 +26,20 @@ let with_env key value f =
 ;;
 
 let test_default_config () =
-  let cfg = Mcp_http.default_config () in
+  let cfg = Mcp_http.default_config in
   check string "base_url" "http://localhost:8080/mcp" cfg.base_url;
   check (list (pair string string)) "headers" [] cfg.headers
 ;;
 
 let test_default_config_reads_env_at_call_time () =
   with_env Mcp_http.default_endpoint_env_var "http://127.0.0.1:7777/mcp" (fun () ->
-    let cfg = Mcp_http.default_config () in
+    let cfg = Mcp_http.make_default_config () in
     check string "first env" "http://127.0.0.1:7777/mcp" cfg.base_url;
     Unix.putenv Mcp_http.default_endpoint_env_var "  http://127.0.0.1:8888/mcp  ";
-    let cfg = Mcp_http.default_config () in
+    let cfg = Mcp_http.make_default_config () in
     check string "second env" "http://127.0.0.1:8888/mcp" cfg.base_url;
     Unix.putenv Mcp_http.default_endpoint_env_var "";
-    let cfg = Mcp_http.default_config () in
+    let cfg = Mcp_http.make_default_config () in
     check string "empty env default" "http://localhost:8080/mcp" cfg.base_url)
 ;;
 
@@ -52,7 +52,7 @@ let test_connect_returns_ok () =
   Eio.Switch.run
   @@ fun sw ->
   let config =
-    { (Mcp_http.default_config ()) with base_url = "http://127.0.0.1:19999" }
+    { (Mcp_http.default_config) with base_url = "http://127.0.0.1:19999" }
   in
   match Mcp_http.connect ~sw ~net config with
   | Ok _client -> () (* connect itself succeeds; initialize would fail *)
@@ -66,7 +66,7 @@ let test_initialize_unreachable () =
   Eio.Switch.run
   @@ fun sw ->
   let config =
-    { (Mcp_http.default_config ()) with base_url = "http://127.0.0.1:19999" }
+    { (Mcp_http.default_config) with base_url = "http://127.0.0.1:19999" }
   in
   match Mcp_http.connect ~sw ~net config with
   | Error e -> fail (Error.to_string e)
@@ -83,7 +83,7 @@ let test_list_tools_without_init () =
   Eio.Switch.run
   @@ fun sw ->
   let config =
-    { (Mcp_http.default_config ()) with base_url = "http://127.0.0.1:19999" }
+    { (Mcp_http.default_config) with base_url = "http://127.0.0.1:19999" }
   in
   match Mcp_http.connect ~sw ~net config with
   | Error e -> fail (Error.to_string e)
@@ -100,7 +100,7 @@ let test_call_tool_unreachable () =
   Eio.Switch.run
   @@ fun sw ->
   let config =
-    { (Mcp_http.default_config ()) with base_url = "http://127.0.0.1:19999" }
+    { (Mcp_http.default_config) with base_url = "http://127.0.0.1:19999" }
   in
   match Mcp_http.connect ~sw ~net config with
   | Error e -> fail (Error.to_string e)
@@ -118,7 +118,7 @@ let test_close_safe () =
   let net = Eio.Stdenv.net env in
   Eio.Switch.run
   @@ fun sw ->
-  let config = Mcp_http.default_config () in
+  let config = Mcp_http.default_config in
   match Mcp_http.connect ~sw ~net config with
   | Error e -> fail (Error.to_string e)
   | Ok client ->


### PR DESCRIPTION
## Summary
Repairs the semver violation introduced by #2194 (released as patch 0.207.11 in #2204): `Context_offload.default_config` and `Mcp_http.default_config` were changed from values to `unit -> config` functions, which is a breaking API change. Codex P1 flagged this on release PR #2204 (review 4586818891).

Restores backwards compatibility while keeping #2194's call-time resolution capability:
- `default_config : config` — value again (captured at module init), so prior callers type-check unchanged (re-pins public API at the 0.207.9 shape)
- `make_default_config : unit -> config` — new, opt-in call-time (re-)resolution of TMPDIR / OAS_MCP_HTTP_URL (the capability #2194 added)
- in-tree tests updated to the value form

## Why
value → function is breaking (callers writing `default_config` as a value fail to compile). Shipping it as patch 0.207.11 violated semver. Option B (this PR) chosen over re-cutting as minor: **make the change non-breaking** — keep both shapes, no downstream churn, semver restored (root fix).

## Validation
- `ocamlformat --check` on 4 edited lib files ✓
- all in-tree `default_config ()` callers converted (rg empty) ✓
- full build + `dune runtest`: CI

## Notes
- `default_config` value captures TMPDIR / OAS_MCP_HTTP_URL at module init; callers needing fresh resolution use `make_default_config ()`.
- mascot does not use these APIs (verified), so no downstream impact there.

Refs: #2194, #2204, Codex review 4586818891.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
