### PR TITLE
fix(http): bind one-shot client cleanup to caller switch

### DIFF
--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -3,11 +3,11 @@
     Wraps Eio + cohttp-eio with TLS. All network and HTTP-level errors
     are captured as {!http_error} so callers do not need [try/with].
 
-    Each synchronous request without a [connection_cache] runs inside
-    its own [Eio.Switch.run] scope so the underlying TCP connection and
-    its file descriptor are released as soon as the response body is
-    fully consumed. With a cache, connections are bound to the cache's
-    switch and reused until eviction or switch release.
+    Each synchronous request without a [connection_cache] registers its
+    transport cleanup with the caller's switch and also closes the
+    transport as soon as the response body is fully consumed. With a cache,
+    connections are bound to the cache's switch and reused until eviction
+    or switch release.
 
     @since 0.45.0 *)
 
@@ -833,6 +833,11 @@ let make_closing_client ~sw ~net ~uri =
   client
 ;;
 
+let close_once close =
+  let closed = Atomic.make false in
+  fun () -> if Atomic.compare_and_set closed false true then close ()
+;;
+
 (** Run [f client] with a client obtained either from [cache] or created
     for one request. When [cache] is supplied, a hit reuses a parked
     connection, a miss creates one and parks it on success, and any error
@@ -845,12 +850,13 @@ let make_closing_client ~sw ~net ~uri =
 let with_client ?cache ~sw ~net ~uri f =
   match cache with
   | None ->
-    (* One-shot path: run the request under a fresh sub-switch so the
-       connection/FD is released as soon as [f] returns, even when the caller
-       supplied a long-lived switch. *)
-    Eio.Switch.run (fun sw' ->
-      let* client = make_closing_client ~sw:sw' ~net ~uri in
-      f client)
+    (* One-shot path: anchor cleanup to the caller's switch for cancellation
+       scope, but close eagerly after [f] returns so long-lived caller switches
+       do not retain idle FDs. *)
+    let* client, close = make_client ~net ~uri in
+    let close = close_once close in
+    Eio.Switch.on_release sw close;
+    Fun.protect ~finally:close (fun () -> f client)
   | Some cache ->
     let* conn, was_cached =
       match cache_take cache uri with

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -226,9 +226,10 @@ val cache_stats : cache -> cache_stats
 (** GET a URL synchronously, returning the full response.
     Returns [(status_code, body_string)] on success.
 
-    Without [cache], the connection is bound to [sw] and closed when [sw]
-    is released. With [cache], the connection is bound to the cache's
-    switch and parked back in the cache on success for reuse.
+    Without [cache], the connection cleanup is bound to [sw] and also runs
+    as soon as the response body is consumed. With [cache], the connection
+    is bound to the cache's switch and parked back in the cache on success
+    for reuse.
 
     When [cache] is supplied the [connection: close] request header is
     omitted so HTTP keep-alive can work.
@@ -252,9 +253,10 @@ val get_sync
 (** POST JSON body synchronously, returning the full response.
     Returns [(status_code, body_string)] on success.
 
-    Without [cache], the connection is bound to [sw] and closed when [sw]
-    is released. With [cache], the connection is bound to the cache's
-    switch and parked back in the cache on success for reuse.
+    Without [cache], the connection cleanup is bound to [sw] and also runs
+    as soon as the response body is consumed. With [cache], the connection
+    is bound to the cache's switch and parked back in the cache on success
+    for reuse.
 
     When [cache] is supplied the [connection: close] request header is
     omitted so HTTP keep-alive can work.

--- a/test/test_http_client_cache.ml
+++ b/test/test_http_client_cache.ml
@@ -186,6 +186,75 @@ let start_sse_server ~sw ~net response_body =
   Printf.sprintf "http://127.0.0.1:%d" port
 ;;
 
+let drain_request_headers reader =
+  let rec consume () =
+    match Eio.Buf_read.line reader with
+    | "" -> ()
+    | _ -> consume ()
+    | exception End_of_file -> ()
+  in
+  consume ()
+;;
+
+let resolve_once promise resolver =
+  if not (Eio.Promise.is_resolved promise) then Eio.Promise.resolve resolver ()
+;;
+
+let observe_client_eof reader promise resolver =
+  let rec consume () =
+    match Eio.Buf_read.line reader with
+    | _ -> consume ()
+    | exception End_of_file -> resolve_once promise resolver
+    | exception _ -> resolve_once promise resolver
+  in
+  consume ()
+;;
+
+let start_one_shot_lifecycle_server ~sw ~net ~clock ?body_delay_s body =
+  let port = fresh_port () in
+  let disconnected, notify_disconnected = Eio.Promise.create () in
+  let handler flow _addr =
+    let reader = Eio.Buf_read.of_flow flow ~max_size:8192 in
+    drain_request_headers reader;
+    Eio.Fiber.fork ~sw (fun () ->
+      observe_client_eof reader disconnected notify_disconnected);
+    let response_headers =
+      Printf.sprintf
+        "HTTP/1.1 200 OK\r\n\
+         Content-Length: %d\r\n\
+         Content-Type: text/plain\r\n\
+         Connection: keep-alive\r\n\
+         \r\n"
+        (String.length body)
+    in
+    try
+      Eio.Flow.copy_string response_headers flow;
+      (match body_delay_s with
+       | Some delay_s -> Eio.Time.sleep clock delay_s
+       | None -> ());
+      Eio.Flow.copy_string body flow
+    with
+    | _ -> resolve_once disconnected notify_disconnected
+  in
+  let socket =
+    Eio.Net.listen
+      net
+      ~sw
+      ~backlog:1
+      ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  Eio.Fiber.fork ~sw (fun () ->
+    Eio.Net.accept_fork ~sw socket ~on_error:(fun _ -> ()) handler);
+  Printf.sprintf "http://127.0.0.1:%d/one-shot" port, disconnected
+;;
+
+let await_client_disconnect ~clock ~label disconnected =
+  try Eio.Time.with_timeout_exn clock 1.0 (fun () -> Eio.Promise.await disconnected) with
+  | Eio.Time.Timeout ->
+    Alcotest.failf "%s: one-shot client did not close before parent switch release" label
+;;
+
 let test_stream_reuses_connection () =
   Eio_main.run
   @@ fun env ->
@@ -257,6 +326,58 @@ let test_per_host_cap_closes_excess () =
     let stats = Http_client.cache_stats cache in
     Alcotest.(check int) "two creates for concurrent" 2 stats.create_count_total;
     Alcotest.(check int) "only one idle due to cap" 1 stats.total_idle;
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
+let test_one_shot_get_closes_after_response () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url, disconnected =
+      start_one_shot_lifecycle_server ~sw ~net:env#net ~clock:env#clock "ok"
+    in
+    (match Http_client.get_sync ~sw ~net:env#net ~url ~headers:[] () with
+     | Ok (200, "ok") -> ()
+     | Ok (code, body) -> Alcotest.failf "expected 200/ok, got %d/%S" code body
+     | Error _ -> Alcotest.fail "expected Ok response");
+    await_client_disconnect ~clock:env#clock ~label:"normal response" disconnected;
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
+let test_one_shot_get_timeout_closes_connection () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url, disconnected =
+      start_one_shot_lifecycle_server
+        ~sw
+        ~net:env#net
+        ~clock:env#clock
+        ~body_delay_s:1.0
+        "ok"
+    in
+    (match
+       Http_client.get_sync
+         ~clock:env#clock
+         ~timeout_s:0.05
+         ~sw
+         ~net:env#net
+         ~url
+         ~headers:[]
+         ()
+     with
+     | Error (Http_client.TimeoutError { phase = Http_client.Http_operation; _ }) -> ()
+     | Error _ -> Alcotest.fail "expected Http_operation timeout"
+     | Ok (code, body) -> Alcotest.failf "expected timeout, got %d/%S" code body);
+    await_client_disconnect ~clock:env#clock ~label:"timed-out response" disconnected;
     Eio.Switch.fail sw Exit
   with
   | Exit -> ()
@@ -337,6 +458,14 @@ let () =
             "eviction fiber closes idle"
             `Quick
             test_eviction_fiber_closes_idle
+        ; Alcotest.test_case
+            "one-shot closes after response"
+            `Quick
+            test_one_shot_get_closes_after_response
+        ; Alcotest.test_case
+            "one-shot timeout closes connection"
+            `Quick
+            test_one_shot_get_timeout_closes_connection
         ] )
     ; ( "headers"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary
- bind one-shot HTTP client cleanup to the caller-provided Eio switch
- keep eager close-on-return with close-once so long-lived caller switches do not retain idle FDs
- remove the nested one-shot Eio.Switch.run path for synchronous requests without a cache

## Verification
- git diff --check
- opam exec -- ocamlformat --check lib/llm_provider/http_client.ml

Full build/test intentionally left to GitHub CI per repo workflow.