### PR TITLE
perf(util): use Str literal search for CI substring

### DIFF
--- a/lib/base/util.ml
+++ b/lib/base/util.ml
@@ -61,29 +61,17 @@ let safe_sub s start len =
   if actual_len <= 0 then "" else String.sub s start actual_len
 ;;
 
-(** Case-insensitive substring search. *)
-let contains_substring_ci ~haystack ~needle =
-  let h = String.lowercase_ascii haystack in
-  let n = String.lowercase_ascii needle in
-  let lh = String.length h in
-  let ln = String.length n in
-  if ln = 0
-  then true
-  else if ln > lh
-  then false
-  else (
-    let rec loop i =
-      if i + ln > lh then false else if String.sub h i ln = n then true else loop (i + 1)
-    in
-    loop 0)
-;;
-
 let regex_match re str =
   try
     let (_ : int) = Str.search_forward re str 0 in
     true
   with
   | Not_found -> false
+;;
+
+(** Case-insensitive substring search. *)
+let contains_substring_ci ~haystack ~needle =
+  needle = "" || regex_match (Str.regexp_string_case_fold needle) haystack
 ;;
 
 let filter_non_empty = List.filter (fun s -> s <> "")

--- a/test/test_util.ml
+++ b/test/test_util.ml
@@ -169,6 +169,14 @@ let test_ci_needle_longer () =
     (Util.contains_substring_ci ~haystack:"abc" ~needle:"abcdef")
 ;;
 
+let test_ci_literal_metacharacters () =
+  check
+    bool
+    "regex metacharacters are literal"
+    false
+    (Util.contains_substring_ci ~haystack:"abc" ~needle:".*")
+;;
+
 (* ── regex_match ──────────────────────────────────────── *)
 
 let test_regex_match_hit () =
@@ -258,6 +266,7 @@ let () =
         ; test_case "no match" `Quick test_ci_no_match
         ; test_case "empty needle" `Quick test_ci_empty_needle
         ; test_case "needle longer" `Quick test_ci_needle_longer
+        ; test_case "literal metacharacters" `Quick test_ci_literal_metacharacters
         ] )
     ; ( "regex_match"
       , [ test_case "hit" `Quick test_regex_match_hit


### PR DESCRIPTION
## Summary
- replace the hand-rolled case-insensitive substring scan with Str.regexp_string_case_fold
- keep empty-needle semantics and add a literal metacharacter regression test

## Verification
- git diff --check
- opam exec -- ocamlformat --check lib/base/util.ml test/test_util.ml
- Full build/test: GitHub CI per operator instruction