### PR TITLE
style: apply ocamlformat to OAS helpers

### DIFF
--- a/lib/context_offload.ml
+++ b/lib/context_offload.ml
@@ -28,7 +28,6 @@ let make_default_config () =
     re-resolve [Filename.get_temp_dir_name ()] at use time (e.g. when [TMPDIR]
     is set after this module loads) should call {!make_default_config} instead. *)
 let default_config = make_default_config ()
-;;
 
 (** Diagnostic context string used for [Llm_provider.Diag] warnings. *)
 let diag_ctx = "context_offload"

--- a/lib/protocol/mcp_http.ml
+++ b/lib/protocol/mcp_http.ml
@@ -21,7 +21,6 @@ let make_default_config () =
     to re-read [OAS_MCP_HTTP_URL] at use time should call {!make_default_config}
     instead. *)
 let default_config = make_default_config ()
-;;
 
 type t = { client : Sdk_http_client.t }
 

--- a/test/test_cost_tracker.ml
+++ b/test/test_cost_tracker.ml
@@ -70,7 +70,7 @@ let test_offload_small_content () =
 ;;
 
 let test_offload_large_content () =
-  let config = { (Context_offload.default_config) with threshold_bytes = 10 } in
+  let config = { Context_offload.default_config with threshold_bytes = 10 } in
   let content = String.make 100 'x' in
   let result = Context_offload.maybe_offload ~config ~tool_name:"big" content in
   match result with
@@ -85,7 +85,7 @@ let test_offload_large_content () =
 ;;
 
 let test_offload_exact_threshold () =
-  let config = { (Context_offload.default_config) with threshold_bytes = 10 } in
+  let config = { Context_offload.default_config with threshold_bytes = 10 } in
   let content = String.make 10 'y' in
   match Context_offload.maybe_offload ~config ~tool_name:"exact" content with
   | Context_offload.Kept _ -> () (* At threshold, kept *)
@@ -123,7 +123,7 @@ let test_offload_to_context_string_offloaded () =
 ;;
 
 let test_offload_convenience () =
-  let config = { (Context_offload.default_config) with threshold_bytes = 5 } in
+  let config = { Context_offload.default_config with threshold_bytes = 5 } in
   let result =
     Context_offload.offload_tool_result ~config ~tool_name:"conv" "this is longer than 5"
   in
@@ -139,7 +139,7 @@ let test_offload_convenience () =
 ;;
 
 let test_offload_special_chars_in_name () =
-  let config = { (Context_offload.default_config) with threshold_bytes = 5 } in
+  let config = { Context_offload.default_config with threshold_bytes = 5 } in
   let content = String.make 20 'z' in
   let result = Context_offload.maybe_offload ~config ~tool_name:"my/tool name" content in
   match result with

--- a/test/test_mcp_http.ml
+++ b/test/test_mcp_http.ml
@@ -51,9 +51,7 @@ let test_connect_returns_ok () =
   let net = Eio.Stdenv.net env in
   Eio.Switch.run
   @@ fun sw ->
-  let config =
-    { (Mcp_http.default_config) with base_url = "http://127.0.0.1:19999" }
-  in
+  let config = { Mcp_http.default_config with base_url = "http://127.0.0.1:19999" } in
   match Mcp_http.connect ~sw ~net config with
   | Ok _client -> () (* connect itself succeeds; initialize would fail *)
   | Error e -> fail (Error.to_string e)
@@ -65,9 +63,7 @@ let test_initialize_unreachable () =
   let net = Eio.Stdenv.net env in
   Eio.Switch.run
   @@ fun sw ->
-  let config =
-    { (Mcp_http.default_config) with base_url = "http://127.0.0.1:19999" }
-  in
+  let config = { Mcp_http.default_config with base_url = "http://127.0.0.1:19999" } in
   match Mcp_http.connect ~sw ~net config with
   | Error e -> fail (Error.to_string e)
   | Ok client ->
@@ -82,9 +78,7 @@ let test_list_tools_without_init () =
   let net = Eio.Stdenv.net env in
   Eio.Switch.run
   @@ fun sw ->
-  let config =
-    { (Mcp_http.default_config) with base_url = "http://127.0.0.1:19999" }
-  in
+  let config = { Mcp_http.default_config with base_url = "http://127.0.0.1:19999" } in
   match Mcp_http.connect ~sw ~net config with
   | Error e -> fail (Error.to_string e)
   | Ok client ->
@@ -99,9 +93,7 @@ let test_call_tool_unreachable () =
   let net = Eio.Stdenv.net env in
   Eio.Switch.run
   @@ fun sw ->
-  let config =
-    { (Mcp_http.default_config) with base_url = "http://127.0.0.1:19999" }
-  in
+  let config = { Mcp_http.default_config with base_url = "http://127.0.0.1:19999" } in
   match Mcp_http.connect ~sw ~net config with
   | Error e -> fail (Error.to_string e)
   | Ok client ->


### PR DESCRIPTION
## Summary\n- Apply ocamlformat 0.29 output to files flagged by the #2210 OCaml Format CI job after merge.\n- No behavior change: record update parentheses are normalized and two redundant top-level separators are removed.\n\n## Evidence\n- CI source: #2210 OCaml Format job 83875385764 reported drift in `test/test_cost_tracker.ml`, `test/test_mcp_http.ml`, `lib/protocol/mcp_http.ml`, and `lib/context_offload.ml`.\n- Local narrow checks:\n  - `opam exec -- ocamlformat --check test/test_cost_tracker.ml test/test_mcp_http.ml lib/protocol/mcp_http.ml lib/context_offload.ml`\n  - `git diff --check`\n\nBuild/test authority remains GitHub CI.