### PR TITLE
perf: replace manual substring loops with Str literal search

### DIFF
--- a/lib/base/util.ml
+++ b/lib/base/util.ml
@@ -11,16 +11,13 @@ let first_some a b =
 ;;
 
 let string_contains ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop index =
-    if index + needle_len > haystack_len
-    then false
-    else if String.sub haystack index needle_len = needle
-    then true
-    else loop (index + 1)
-  in
-  if needle_len = 0 then true else loop 0
+  needle = ""
+  ||
+  try
+    let (_ : int) = Str.search_forward (Str.regexp_string needle) haystack 0 in
+    true
+  with
+  | Not_found -> false
 ;;
 
 let json_parse_error detail = Error.Serialization (JsonParseError { detail })

--- a/lib/llm_provider/cli_common_env.ml
+++ b/lib/llm_provider/cli_common_env.ml
@@ -139,18 +139,13 @@ let msg_is_not_a_float = "is not a float"
 let msg_is_not_a_boolean = "is not a boolean"
 
 let string_contains ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop idx =
-    if needle_len = 0
-    then true
-    else if idx + needle_len > haystack_len
-    then false
-    else if String.sub haystack idx needle_len = needle
-    then true
-    else loop (idx + 1)
-  in
-  loop 0
+  needle = ""
+  ||
+  try
+    let (_ : int) = Str.search_forward (Str.regexp_string needle) haystack 0 in
+    true
+  with
+  | Not_found -> false
 ;;
 
 let with_env = Env_parse.with_env

--- a/lib/llm_provider/pricing.ml
+++ b/lib/llm_provider/pricing.ml
@@ -52,16 +52,13 @@ let _get_overrides () =
 ;;
 
 let string_contains ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop index =
-    if index + needle_len > haystack_len
-    then false
-    else if String.sub haystack index needle_len = needle
-    then true
-    else loop (index + 1)
-  in
-  if needle_len = 0 then true else loop 0
+  needle = ""
+  ||
+  try
+    let (_ : int) = Str.search_forward (Str.regexp_string needle) haystack 0 in
+    true
+  with
+  | Not_found -> false
 ;;
 
 (* Strip an OpenRouter-style provider/org prefix so that a model id such as

--- a/lib/runtime_evidence.ml
+++ b/lib/runtime_evidence.ml
@@ -86,18 +86,17 @@ let base_evidence_file_specs store session_id =
 ;;
 
 let find_last_substring_index ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop idx =
-    if idx < 0
-    then None
-    else if String.sub haystack idx needle_len = needle
-    then Some idx
-    else loop (idx - 1)
-  in
-  if needle_len = 0 || haystack_len < needle_len
+  if needle = "" || haystack = ""
   then None
-  else loop (haystack_len - needle_len)
+  else (
+    try
+      Some
+        (Str.search_backward
+           (Str.regexp_string needle)
+           haystack
+           (String.length haystack - 1))
+    with
+    | Not_found -> None)
 ;;
 
 let dropped_output_deltas_of_text = function


### PR DESCRIPTION
## Summary
- replace public Util.string_contains manual String.sub scanning with Str.regexp_string search
- replace equivalent llm_provider pricing and cli_common_env helpers with library literal search
- use Str.search_backward for runtime evidence's last-marker lookup instead of a reverse String.sub loop

## Local checks
- opam exec -- ocamlformat --check lib/base/util.ml lib/llm_provider/pricing.ml lib/llm_provider/cli_common_env.ml lib/runtime_evidence.ml
- git diff --check origin/main...HEAD

Build/test authority: GitHub CI, per repo workflow.