### PR TITLE
fix: add call-time default model resolver

### DIFF
--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -198,6 +198,7 @@ let create_agent
       ()
   =
   let open Types in
+  let default_config = default_config_value () in
   let config =
     { name = Option.value name ~default:default_config.name
     ; model = Option.value model ~default:default_config.model

--- a/lib/base/model_registry.ml
+++ b/lib/base/model_registry.ml
@@ -11,7 +11,9 @@ let default_model_id_fallback = "claude-sonnet-4-6-20250514"
 
 let default_model_id_value ?(getenv = Llm_provider.Cli_common_env.get) () =
   match getenv default_model_id_env_var with
-  | Some v -> v
+  | Some v ->
+    let v = String.trim v in
+    if String.equal v "" then default_model_id_fallback else v
   | None -> default_model_id_fallback
 ;;
 

--- a/lib/base/model_registry.ml
+++ b/lib/base/model_registry.ml
@@ -6,11 +6,16 @@
     @stability Evolving
     @since 0.93.1 *)
 
-let default_model_id =
-  match Llm_provider.Cli_common_env.get "OAS_DEFAULT_MODEL" with
+let default_model_id_env_var = "OAS_DEFAULT_MODEL"
+let default_model_id_fallback = "claude-sonnet-4-6-20250514"
+
+let default_model_id_value ?(getenv = Llm_provider.Cli_common_env.get) () =
+  match getenv default_model_id_env_var with
   | Some v -> v
-  | None -> "claude-sonnet-4-6-20250514"
+  | None -> default_model_id_fallback
 ;;
+
+let default_model_id = default_model_id_value ()
 
 (** Resolve a model alias or short name to its full API model ID.
     Unknown strings pass through unchanged — this allows custom models. *)

--- a/lib/base/model_registry.mli
+++ b/lib/base/model_registry.mli
@@ -6,7 +6,22 @@
     @stability Evolving
     @since 0.93.1 *)
 
-(** The default model ID, overridable via OAS_DEFAULT_MODEL env var. *)
+(** Environment variable consulted by {!default_model_id_value}. *)
+val default_model_id_env_var : string
+
+(** Compile-time fallback when {!default_model_id_env_var} is unset or empty. *)
+val default_model_id_fallback : string
+
+(** Resolve the default model ID at call time.
+
+    [getenv] exists for deterministic tests and for callers that already carry
+    an explicit environment boundary. Production callers use
+    {!Llm_provider.Cli_common_env.get}. *)
+val default_model_id_value : ?getenv:(string -> string option) -> unit -> string
+
+(** Compatibility snapshot of the default model ID.
+    Prefer {!default_model_id_value} when the value must reflect environment
+    changes after module initialization. *)
 val default_model_id : string
 
 (** Resolve a model alias or short name to its full API model ID.

--- a/lib/base/types.ml
+++ b/lib/base/types.ml
@@ -153,9 +153,9 @@ type agent_config =
   }
 [@@deriving show]
 
-let default_config =
+let default_config_value ?getenv () =
   { name = "agent"
-  ; model = Model_registry.default_model_id
+  ; model = Model_registry.default_model_id_value ?getenv ()
   ; system_prompt = None
   ; max_tokens = None
   ; max_turns = 10
@@ -182,6 +182,8 @@ let default_config =
   ; call_time_pruner_keep_last = 100
   }
 ;;
+
+let default_config = default_config_value ()
 
 (** Usage tracking accumulated across provider calls. Per-response usage stays
     in [Llm_provider.Types.api_usage].

--- a/lib/base/types.mli
+++ b/lib/base/types.mli
@@ -72,6 +72,16 @@ type agent_config =
   }
 [@@deriving show]
 
+(** Build a fresh default configuration.
+
+    Unlike {!default_config}, this consults call-time default resolvers such as
+    {!Model_registry.default_model_id_value}. Use it when a newly created agent
+    should observe environment/configuration changes made after module
+    initialization. *)
+val default_config_value : ?getenv:(string -> string option) -> unit -> agent_config
+
+(** Compatibility snapshot of the default configuration at module load time.
+    Prefer {!default_config_value} for new agent/session defaults. *)
 val default_config : agent_config
 
 (** Default proactive context compaction watermark used when

--- a/lib/provider_runtime_binding.ml
+++ b/lib/provider_runtime_binding.ml
@@ -370,7 +370,7 @@ let resolve_model binding ~requested_model =
      | _ ->
        (match binding.kind with
         | PConfig.Ollama -> "default"
-        | _ -> Model_registry.default_model_id))
+        | _ -> Model_registry.default_model_id_value ()))
 ;;
 
 let to_provider_config ?model binding =

--- a/lib/runtime_server.ml
+++ b/lib/runtime_server.ml
@@ -47,12 +47,13 @@ type participant_run_result =
   | Participant_input_required of Runtime.input_request * paused_participant
 
 let agent_config_of_session (session : session) (detail : spawn_agent_request) =
-  { Types.default_config with
+  let default_config = Types.default_config_value () in
+  { default_config with
     name = detail.participant_name
   ; model =
       (match detail.model with
        | Some value when String.trim value <> "" -> Model_registry.resolve_model_id value
-       | _missing_model_override -> Types.default_config.model)
+       | _missing_model_override -> default_config.model)
   ; system_prompt =
       (match detail.system_prompt with
        | Some prompt when String.trim prompt <> "" -> Some prompt

--- a/test/test_agent_sdk.ml
+++ b/test/test_agent_sdk.ml
@@ -2,6 +2,18 @@ open Alcotest
 open Agent_sdk
 open Types
 
+let with_env key value f =
+  let previous = Sys.getenv_opt key in
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    (fun () ->
+       Unix.putenv key value;
+       f ())
+;;
+
 let test_model_string () =
   Alcotest.(check string)
     "claude_sonnet"
@@ -142,6 +154,15 @@ let test_create_agent_defaults () =
   Alcotest.(check int) "initial turn count" 0 st.turn_count
 ;;
 
+let test_create_agent_default_model_reads_current_env () =
+  with_env Model_registry.default_model_id_env_var "create-agent-default-model" (fun () ->
+    Eio_main.run
+    @@ fun env ->
+    let agent = Agent_sdk.create_agent ~net:env#net () in
+    let config = (Agent.state agent).config in
+    Alcotest.(check string) "model" "create-agent-default-model" config.model)
+;;
+
 let test_create_agent_with_name_model () =
   Eio_main.run
   @@ fun env ->
@@ -248,6 +269,10 @@ let () =
         ] )
     ; ( "create_agent"
       , [ test_case "defaults" `Quick test_create_agent_defaults
+        ; test_case
+            "default model reads current env"
+            `Quick
+            test_create_agent_default_model_reads_current_env
         ; test_case "with name/model/prompt" `Quick test_create_agent_with_name_model
         ; test_case "with provider" `Quick test_create_agent_with_provider
         ; test_case "with raw_trace" `Quick test_create_agent_with_raw_trace

--- a/test/test_model_registry.ml
+++ b/test/test_model_registry.ml
@@ -9,9 +9,10 @@
     actually reachable, then pins each alias arm + the pass-through
     contract.
 
-    Two public values pinned (per [lib/model_registry.mli] surface):
-    1. [default_model_id] — env-resolved constant.
-    2. [resolve_model_id alias] — pass-through default for unknown
+    Public values pinned (per [lib/model_registry.mli] surface):
+    1. [default_model_id_value] — call-time env resolver.
+    2. [default_model_id] — compatibility snapshot.
+    3. [resolve_model_id alias] — pass-through default for unknown
        names; intentional (custom-model support) so the test pins it
        to prevent an accidental fail-closed refactor. *)
 
@@ -26,6 +27,27 @@ let test_default_model_id_non_empty () =
     "default_model_id is non-empty"
     true
     (String.length Model_registry.default_model_id > 0)
+;;
+
+let test_default_model_id_value_fallback () =
+  check
+    string
+    "default fallback"
+    Model_registry.default_model_id_fallback
+    (Model_registry.default_model_id_value ~getenv:(fun _ -> None) ())
+;;
+
+let test_default_model_id_value_uses_injected_env () =
+  let getenv name =
+    if String.equal name Model_registry.default_model_id_env_var
+    then Some "custom-default-model"
+    else None
+  in
+  check
+    string
+    "injected default"
+    "custom-default-model"
+    (Model_registry.default_model_id_value ~getenv ())
 ;;
 
 (* ── resolve_model_id — explicit aliases ────────────── *)
@@ -147,7 +169,14 @@ let test_resolve_idempotent () =
 let () =
   run
     "model_registry"
-    [ "default_model_id", [ test_case "non-empty" `Quick test_default_model_id_non_empty ]
+    [ ( "default_model_id"
+      , [ test_case "snapshot non-empty" `Quick test_default_model_id_non_empty
+        ; test_case "call-time fallback" `Quick test_default_model_id_value_fallback
+        ; test_case
+            "call-time injected env"
+            `Quick
+            test_default_model_id_value_uses_injected_env
+        ] )
     ; ( "resolve_model_id (aliases)"
       , [ test_case "opus 4-6 + opus shorthand" `Quick test_resolve_opus_4_6_alias
         ; test_case "sonnet 4-6 + sonnet shorthand" `Quick test_resolve_sonnet_4_6_alias

--- a/test/test_model_registry.ml
+++ b/test/test_model_registry.ml
@@ -58,6 +58,19 @@ let test_default_model_id_value_blank_env_falls_back () =
     (Model_registry.default_model_id_value ~getenv:(fun _ -> Some "   ") ())
 ;;
 
+let test_default_config_value_uses_calltime_model () =
+  let getenv name =
+    if String.equal name Model_registry.default_model_id_env_var
+    then Some "config-default-model"
+    else None
+  in
+  check
+    string
+    "default_config_value model"
+    "config-default-model"
+    (Types.default_config_value ~getenv ()).model
+;;
+
 (* ── resolve_model_id — explicit aliases ────────────── *)
 
 let test_resolve_opus_4_6_alias () =
@@ -188,6 +201,10 @@ let () =
             "call-time blank env fallback"
             `Quick
             test_default_model_id_value_blank_env_falls_back
+        ; test_case
+            "default config uses call-time model"
+            `Quick
+            test_default_config_value_uses_calltime_model
         ] )
     ; ( "resolve_model_id (aliases)"
       , [ test_case "opus 4-6 + opus shorthand" `Quick test_resolve_opus_4_6_alias

--- a/test/test_model_registry.ml
+++ b/test/test_model_registry.ml
@@ -50,6 +50,14 @@ let test_default_model_id_value_uses_injected_env () =
     (Model_registry.default_model_id_value ~getenv ())
 ;;
 
+let test_default_model_id_value_blank_env_falls_back () =
+  check
+    string
+    "blank env fallback"
+    Model_registry.default_model_id_fallback
+    (Model_registry.default_model_id_value ~getenv:(fun _ -> Some "   ") ())
+;;
+
 (* ── resolve_model_id — explicit aliases ────────────── *)
 
 let test_resolve_opus_4_6_alias () =
@@ -176,6 +184,10 @@ let () =
             "call-time injected env"
             `Quick
             test_default_model_id_value_uses_injected_env
+        ; test_case
+            "call-time blank env fallback"
+            `Quick
+            test_default_model_id_value_blank_env_falls_back
         ] )
     ; ( "resolve_model_id (aliases)"
       , [ test_case "opus 4-6 + opus shorthand" `Quick test_resolve_opus_4_6_alias


### PR DESCRIPTION
## Summary
- add Model_registry.default_model_id_value ?getenv () so OAS_DEFAULT_MODEL can be resolved at call time
- keep Model_registry.default_model_id as the existing compatibility snapshot
- use the call-time resolver in provider runtime binding fallback instead of the snapshot
- add deterministic injected-getenv tests for fallback and override behavior

## Local checks
- opam exec -- ocamlformat --check lib/base/model_registry.ml lib/base/model_registry.mli lib/provider_runtime_binding.ml test/test_model_registry.ml
- git diff --check origin/main...HEAD

Build/test authority: GitHub CI, per repo workflow.