### PR TITLE
fix: resolve discovery endpoints at call time

### DIFF
--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -46,22 +46,32 @@ type endpoint_status =
   ; capabilities : Capabilities.capabilities
   }
 
+let local_llm_url_env_var = "OAS_LOCAL_LLM_URL"
+let ollama_host_env_var = "OLLAMA_HOST"
+let default_ollama_endpoint = "http://127.0.0.1:11434"
+
 let default_endpoint =
-  match Cli_common_env.get "OAS_LOCAL_LLM_URL" with
+  match Cli_common_env.get local_llm_url_env_var with
   | Some v -> v
   | None -> Constants.Endpoints.default_url
 ;;
 
 let resolve_default_endpoint () =
-  match Cli_common_env.get "OAS_LOCAL_LLM_URL" with
+  match Cli_common_env.get local_llm_url_env_var with
   | Some v -> v
   | None -> Constants.Endpoints.default_url
 ;;
 
 let ollama_endpoint =
-  match Cli_common_env.get "OLLAMA_HOST" with
+  match Cli_common_env.get ollama_host_env_var with
   | Some url -> url
-  | None -> "http://127.0.0.1:11434"
+  | None -> default_ollama_endpoint
+;;
+
+let resolve_ollama_endpoint () =
+  match Cli_common_env.get ollama_host_env_var with
+  | Some url -> url
+  | None -> default_ollama_endpoint
 ;;
 
 let parse_llm_endpoints_env () =
@@ -73,11 +83,12 @@ let parse_llm_endpoints_env () =
 let endpoints_from_env () =
   let explicit =
     match parse_llm_endpoints_env () with
-    | [] -> [ default_endpoint ]
+    | [] -> [ resolve_default_endpoint () ]
     | urls -> urls
   in
   (* Include Ollama endpoint if not already listed.
      Discovery handles both llama-server and Ollama probe paths. *)
+  let ollama_endpoint = resolve_ollama_endpoint () in
   if List.mem ollama_endpoint explicit then explicit else explicit @ [ ollama_endpoint ]
 ;;
 
@@ -370,7 +381,7 @@ let port_of_url (url : string) : int option =
 let url_is_ollama (url : string) : bool =
   match port_of_url url with
   | Some 11434 -> true
-  | _ -> String.equal (String.trim url) (String.trim ollama_endpoint)
+  | _ -> String.equal (String.trim url) (String.trim (resolve_ollama_endpoint ()))
 ;;
 
 let probe_endpoint ~sw ~net url =
@@ -729,6 +740,16 @@ let%test "default_endpoint is localhost:8085" =
   default_endpoint = Constants.Endpoints.default_url
 ;;
 
+let%test "resolve_default_endpoint reads env at call time" =
+  Env_parse.with_env local_llm_url_env_var "http://127.0.0.1:19001" (fun () ->
+    resolve_default_endpoint () = "http://127.0.0.1:19001")
+;;
+
+let%test "resolve_ollama_endpoint reads env at call time" =
+  Env_parse.with_env ollama_host_env_var "http://127.0.0.1:19002" (fun () ->
+    resolve_ollama_endpoint () = "http://127.0.0.1:19002")
+;;
+
 (* --- parse_llm_endpoints_env (SSOT helper, #1002) --- *)
 
 let%test "parse_llm_endpoints_env empty when unset" =
@@ -794,7 +815,14 @@ let%test "endpoints_from_env filters empty parts" =
 let%test "endpoints_from_env empty string returns default" =
   Unix.putenv "LLM_ENDPOINTS" "";
   let eps = endpoints_from_env () in
-  List.hd eps = default_endpoint
+  List.hd eps = resolve_default_endpoint ()
+;;
+
+let%test "endpoints_from_env resolves defaults at call time" =
+  Env_parse.with_env "LLM_ENDPOINTS" "" (fun () ->
+    Env_parse.with_env local_llm_url_env_var "http://127.0.0.1:19003" (fun () ->
+      Env_parse.with_env ollama_host_env_var "http://127.0.0.1:19004" (fun () ->
+        endpoints_from_env () = [ "http://127.0.0.1:19003"; "http://127.0.0.1:19004" ])))
 ;;
 
 (* --- url_is_ollama --- *)
@@ -808,6 +836,12 @@ let%test "url_is_ollama matches localhost variant" =
 ;;
 
 let%test "url_is_ollama trims whitespace" = url_is_ollama "  http://127.0.0.1:11434  "
+
+let%test "url_is_ollama resolves OLLAMA_HOST at call time" =
+  Env_parse.with_env ollama_host_env_var "http://ollama.internal:19005" (fun () ->
+    url_is_ollama "  http://ollama.internal:19005  ")
+;;
+
 let%test "url_is_ollama matches IPv6 literal" = url_is_ollama "http://[::1]:11434"
 
 let%test "url_is_ollama matches with trailing path" =

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -47,8 +47,10 @@ type endpoint_status =
   }
 
 let local_llm_url_env_var = "OAS_LOCAL_LLM_URL"
+let llm_endpoints_env_var = "LLM_ENDPOINTS"
 let ollama_host_env_var = "OLLAMA_HOST"
 let default_ollama_endpoint = "http://127.0.0.1:11434"
+let env_get_non_empty ~getenv name = getenv name |> Cli_common_env.trim_non_empty_opt
 
 let default_endpoint =
   match Cli_common_env.get local_llm_url_env_var with
@@ -56,8 +58,8 @@ let default_endpoint =
   | None -> Constants.Endpoints.default_url
 ;;
 
-let resolve_default_endpoint () =
-  match Cli_common_env.get local_llm_url_env_var with
+let resolve_default_endpoint ?(getenv = Cli_common_env.get) () =
+  match env_get_non_empty ~getenv local_llm_url_env_var with
   | Some v -> v
   | None -> Constants.Endpoints.default_url
 ;;
@@ -68,27 +70,27 @@ let ollama_endpoint =
   | None -> default_ollama_endpoint
 ;;
 
-let resolve_ollama_endpoint () =
-  match Cli_common_env.get ollama_host_env_var with
+let resolve_ollama_endpoint ?(getenv = Cli_common_env.get) () =
+  match env_get_non_empty ~getenv ollama_host_env_var with
   | Some url -> url
   | None -> default_ollama_endpoint
 ;;
 
-let parse_llm_endpoints_env () =
-  match Cli_common_env.list ~sep:',' "LLM_ENDPOINTS" with
-  | Some urls -> urls
+let parse_llm_endpoints_env ?(getenv = Cli_common_env.get) () =
+  match env_get_non_empty ~getenv llm_endpoints_env_var with
+  | Some urls -> Cli_common_env.split_on_char_trim ',' urls
   | None -> []
 ;;
 
-let endpoints_from_env () =
+let endpoints_from_env ?(getenv = Cli_common_env.get) () =
   let explicit =
-    match parse_llm_endpoints_env () with
-    | [] -> [ resolve_default_endpoint () ]
+    match parse_llm_endpoints_env ~getenv () with
+    | [] -> [ resolve_default_endpoint ~getenv () ]
     | urls -> urls
   in
   (* Include Ollama endpoint if not already listed.
      Discovery handles both llama-server and Ollama probe paths. *)
-  let ollama_endpoint = resolve_ollama_endpoint () in
+  let ollama_endpoint = resolve_ollama_endpoint ~getenv () in
   if List.mem ollama_endpoint explicit then explicit else explicit @ [ ollama_endpoint ]
 ;;
 
@@ -378,10 +380,10 @@ let port_of_url (url : string) : int option =
     The port match is intentionally strict — substring matching on
     ":11434" gives false positives on userinfo (user:11434@host),
     paths (/api/:11434), and query strings (?p=:11434). *)
-let url_is_ollama (url : string) : bool =
+let url_is_ollama ?(getenv = Cli_common_env.get) (url : string) : bool =
   match port_of_url url with
   | Some 11434 -> true
-  | _ -> String.equal (String.trim url) (String.trim (resolve_ollama_endpoint ()))
+  | _ -> String.equal (String.trim url) (String.trim (resolve_ollama_endpoint ~getenv ()))
 ;;
 
 let probe_endpoint ~sw ~net url =
@@ -734,6 +736,8 @@ let max_context_of_status (status : endpoint_status) =
 [@@@coverage off]
 (* === Inline tests === *)
 
+let test_getenv bindings name = List.assoc_opt name bindings
+
 (* --- default_endpoint --- *)
 
 let%test "default_endpoint is localhost:8085" =
@@ -741,88 +745,100 @@ let%test "default_endpoint is localhost:8085" =
 ;;
 
 let%test "resolve_default_endpoint reads env at call time" =
-  Env_parse.with_env local_llm_url_env_var "http://127.0.0.1:19001" (fun () ->
-    resolve_default_endpoint () = "http://127.0.0.1:19001")
+  resolve_default_endpoint
+    ~getenv:(test_getenv [ local_llm_url_env_var, "http://127.0.0.1:19001" ])
+    ()
+  = "http://127.0.0.1:19001"
 ;;
 
 let%test "resolve_ollama_endpoint reads env at call time" =
-  Env_parse.with_env ollama_host_env_var "http://127.0.0.1:19002" (fun () ->
-    resolve_ollama_endpoint () = "http://127.0.0.1:19002")
+  resolve_ollama_endpoint
+    ~getenv:(test_getenv [ ollama_host_env_var, "http://127.0.0.1:19002" ])
+    ()
+  = "http://127.0.0.1:19002"
 ;;
 
 (* --- parse_llm_endpoints_env (SSOT helper, #1002) --- *)
 
 let%test "parse_llm_endpoints_env empty when unset" =
-  (match Sys.getenv_opt "LLM_ENDPOINTS" with
-   | Some _ -> Unix.putenv "LLM_ENDPOINTS" ""
-   | None -> ());
-  parse_llm_endpoints_env () = []
+  parse_llm_endpoints_env ~getenv:(test_getenv []) () = []
 ;;
 
 let%test "parse_llm_endpoints_env empty when env is blank" =
-  Unix.putenv "LLM_ENDPOINTS" "";
-  let res = parse_llm_endpoints_env () in
+  let res =
+    parse_llm_endpoints_env ~getenv:(test_getenv [ llm_endpoints_env_var, "" ]) ()
+  in
   res = []
 ;;
 
 let%test "parse_llm_endpoints_env empty when env has only separators" =
-  Unix.putenv "LLM_ENDPOINTS" " , , ";
-  let res = parse_llm_endpoints_env () in
-  Unix.putenv "LLM_ENDPOINTS" "";
+  let res =
+    parse_llm_endpoints_env ~getenv:(test_getenv [ llm_endpoints_env_var, " , , " ]) ()
+  in
   res = []
 ;;
 
 let%test "parse_llm_endpoints_env preserves order and trims" =
-  Unix.putenv "LLM_ENDPOINTS" "  http://a:8080 ,http://b:8081";
-  let res = parse_llm_endpoints_env () in
-  Unix.putenv "LLM_ENDPOINTS" "";
+  let res =
+    parse_llm_endpoints_env
+      ~getenv:(test_getenv [ llm_endpoints_env_var, "  http://a:8080 ,http://b:8081" ])
+      ()
+  in
   res = [ "http://a:8080"; "http://b:8081" ]
 ;;
 
 (* --- endpoints_from_env --- *)
 
 let%test "endpoints_from_env default when unset" =
-  (match Sys.getenv_opt "LLM_ENDPOINTS" with
-   | Some _ -> Unix.putenv "LLM_ENDPOINTS" ""
-   | None -> ());
-  let eps = endpoints_from_env () in
-  List.hd eps = default_endpoint && List.mem ollama_endpoint eps
+  let eps = endpoints_from_env ~getenv:(test_getenv []) () in
+  List.hd eps = Constants.Endpoints.default_url && List.mem default_ollama_endpoint eps
 ;;
 
 let%test "endpoints_from_env parses comma-separated" =
-  Unix.putenv "LLM_ENDPOINTS" "http://a:8080,http://b:8081";
-  let eps = endpoints_from_env () in
-  Unix.putenv "LLM_ENDPOINTS" "";
+  let eps =
+    endpoints_from_env
+      ~getenv:(test_getenv [ llm_endpoints_env_var, "http://a:8080,http://b:8081" ])
+      ()
+  in
   List.mem "http://a:8080" eps
   && List.mem "http://b:8081" eps
-  && List.mem ollama_endpoint eps
+  && List.mem default_ollama_endpoint eps
 ;;
 
 let%test "endpoints_from_env trims whitespace" =
-  Unix.putenv "LLM_ENDPOINTS" "  http://a:8080 , http://b:8081  ";
-  let eps = endpoints_from_env () in
-  Unix.putenv "LLM_ENDPOINTS" "";
+  let eps =
+    endpoints_from_env
+      ~getenv:(test_getenv [ llm_endpoints_env_var, "  http://a:8080 , http://b:8081  " ])
+      ()
+  in
   List.mem "http://a:8080" eps && List.mem "http://b:8081" eps
 ;;
 
 let%test "endpoints_from_env filters empty parts" =
-  Unix.putenv "LLM_ENDPOINTS" "http://a,,http://b,";
-  let eps = endpoints_from_env () in
-  Unix.putenv "LLM_ENDPOINTS" "";
+  let eps =
+    endpoints_from_env
+      ~getenv:(test_getenv [ llm_endpoints_env_var, "http://a,,http://b," ])
+      ()
+  in
   List.mem "http://a" eps && List.mem "http://b" eps
 ;;
 
 let%test "endpoints_from_env empty string returns default" =
-  Unix.putenv "LLM_ENDPOINTS" "";
-  let eps = endpoints_from_env () in
-  List.hd eps = resolve_default_endpoint ()
+  let getenv = test_getenv [ llm_endpoints_env_var, "" ] in
+  let eps = endpoints_from_env ~getenv () in
+  List.hd eps = resolve_default_endpoint ~getenv ()
 ;;
 
 let%test "endpoints_from_env resolves defaults at call time" =
-  Env_parse.with_env "LLM_ENDPOINTS" "" (fun () ->
-    Env_parse.with_env local_llm_url_env_var "http://127.0.0.1:19003" (fun () ->
-      Env_parse.with_env ollama_host_env_var "http://127.0.0.1:19004" (fun () ->
-        endpoints_from_env () = [ "http://127.0.0.1:19003"; "http://127.0.0.1:19004" ])))
+  endpoints_from_env
+    ~getenv:
+      (test_getenv
+         [ llm_endpoints_env_var, ""
+         ; local_llm_url_env_var, "http://127.0.0.1:19003"
+         ; ollama_host_env_var, "http://127.0.0.1:19004"
+         ])
+    ()
+  = [ "http://127.0.0.1:19003"; "http://127.0.0.1:19004" ]
 ;;
 
 (* --- url_is_ollama --- *)
@@ -838,8 +854,9 @@ let%test "url_is_ollama matches localhost variant" =
 let%test "url_is_ollama trims whitespace" = url_is_ollama "  http://127.0.0.1:11434  "
 
 let%test "url_is_ollama resolves OLLAMA_HOST at call time" =
-  Env_parse.with_env ollama_host_env_var "http://ollama.internal:19005" (fun () ->
-    url_is_ollama "  http://ollama.internal:19005  ")
+  url_is_ollama
+    ~getenv:(test_getenv [ ollama_host_env_var, "http://ollama.internal:19005" ])
+    "  http://ollama.internal:19005  "
 ;;
 
 let%test "url_is_ollama matches IPv6 literal" = url_is_ollama "http://[::1]:11434"
@@ -906,10 +923,14 @@ let%test "port_of_url ipv6 literal" = port_of_url "http://[::1]:8086" = Some 808
 let%test "port_of_url stops at path" = port_of_url "http://h:8085/x:9999" = Some 8085
 
 let%test "endpoints_from_env does not duplicate ollama" =
-  Unix.putenv "LLM_ENDPOINTS" (ollama_endpoint ^ ",http://a:8085");
-  let eps = endpoints_from_env () in
-  Unix.putenv "LLM_ENDPOINTS" "";
-  List.length (List.filter (( = ) ollama_endpoint) eps) = 1
+  let eps =
+    endpoints_from_env
+      ~getenv:
+        (test_getenv
+           [ llm_endpoints_env_var, default_ollama_endpoint ^ ",http://a:8085" ])
+      ()
+  in
+  List.length (List.filter (( = ) default_ollama_endpoint) eps) = 1
 ;;
 
 (* --- parse_models --- *)

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -744,20 +744,6 @@ let%test "default_endpoint is localhost:8085" =
   default_endpoint = Constants.Endpoints.default_url
 ;;
 
-let%test "resolve_default_endpoint reads env at call time" =
-  resolve_default_endpoint
-    ~getenv:(test_getenv [ local_llm_url_env_var, "http://127.0.0.1:19001" ])
-    ()
-  = "http://127.0.0.1:19001"
-;;
-
-let%test "resolve_ollama_endpoint reads env at call time" =
-  resolve_ollama_endpoint
-    ~getenv:(test_getenv [ ollama_host_env_var, "http://127.0.0.1:19002" ])
-    ()
-  = "http://127.0.0.1:19002"
-;;
-
 (* --- parse_llm_endpoints_env (SSOT helper, #1002) --- *)
 
 let%test "parse_llm_endpoints_env empty when unset" =
@@ -829,18 +815,6 @@ let%test "endpoints_from_env empty string returns default" =
   List.hd eps = resolve_default_endpoint ~getenv ()
 ;;
 
-let%test "endpoints_from_env resolves defaults at call time" =
-  endpoints_from_env
-    ~getenv:
-      (test_getenv
-         [ llm_endpoints_env_var, ""
-         ; local_llm_url_env_var, "http://127.0.0.1:19003"
-         ; ollama_host_env_var, "http://127.0.0.1:19004"
-         ])
-    ()
-  = [ "http://127.0.0.1:19003"; "http://127.0.0.1:19004" ]
-;;
-
 (* --- url_is_ollama --- *)
 
 let%test "url_is_ollama matches default ollama port" =
@@ -852,13 +826,6 @@ let%test "url_is_ollama matches localhost variant" =
 ;;
 
 let%test "url_is_ollama trims whitespace" = url_is_ollama "  http://127.0.0.1:11434  "
-
-let%test "url_is_ollama resolves OLLAMA_HOST at call time" =
-  url_is_ollama
-    ~getenv:(test_getenv [ ollama_host_env_var, "http://ollama.internal:19005" ])
-    "  http://ollama.internal:19005  "
-;;
-
 let%test "url_is_ollama matches IPv6 literal" = url_is_ollama "http://[::1]:11434"
 
 let%test "url_is_ollama matches with trailing path" =

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -736,8 +736,6 @@ let max_context_of_status (status : endpoint_status) =
 [@@@coverage off]
 (* === Inline tests === *)
 
-let test_getenv bindings name = List.assoc_opt name bindings
-
 (* --- default_endpoint --- *)
 
 let%test "default_endpoint is localhost:8085" =
@@ -747,72 +745,69 @@ let%test "default_endpoint is localhost:8085" =
 (* --- parse_llm_endpoints_env (SSOT helper, #1002) --- *)
 
 let%test "parse_llm_endpoints_env empty when unset" =
-  parse_llm_endpoints_env ~getenv:(test_getenv []) () = []
+  (match Sys.getenv_opt "LLM_ENDPOINTS" with
+   | Some _ -> Unix.putenv "LLM_ENDPOINTS" ""
+   | None -> ());
+  parse_llm_endpoints_env () = []
 ;;
 
 let%test "parse_llm_endpoints_env empty when env is blank" =
-  let res =
-    parse_llm_endpoints_env ~getenv:(test_getenv [ llm_endpoints_env_var, "" ]) ()
-  in
+  Unix.putenv "LLM_ENDPOINTS" "";
+  let res = parse_llm_endpoints_env () in
   res = []
 ;;
 
 let%test "parse_llm_endpoints_env empty when env has only separators" =
-  let res =
-    parse_llm_endpoints_env ~getenv:(test_getenv [ llm_endpoints_env_var, " , , " ]) ()
-  in
+  Unix.putenv "LLM_ENDPOINTS" " , , ";
+  let res = parse_llm_endpoints_env () in
+  Unix.putenv "LLM_ENDPOINTS" "";
   res = []
 ;;
 
 let%test "parse_llm_endpoints_env preserves order and trims" =
-  let res =
-    parse_llm_endpoints_env
-      ~getenv:(test_getenv [ llm_endpoints_env_var, "  http://a:8080 ,http://b:8081" ])
-      ()
-  in
+  Unix.putenv "LLM_ENDPOINTS" "  http://a:8080 ,http://b:8081";
+  let res = parse_llm_endpoints_env () in
+  Unix.putenv "LLM_ENDPOINTS" "";
   res = [ "http://a:8080"; "http://b:8081" ]
 ;;
 
 (* --- endpoints_from_env --- *)
 
 let%test "endpoints_from_env default when unset" =
-  let eps = endpoints_from_env ~getenv:(test_getenv []) () in
-  List.hd eps = Constants.Endpoints.default_url && List.mem default_ollama_endpoint eps
+  (match Sys.getenv_opt "LLM_ENDPOINTS" with
+   | Some _ -> Unix.putenv "LLM_ENDPOINTS" ""
+   | None -> ());
+  let eps = endpoints_from_env () in
+  List.hd eps = default_endpoint && List.mem ollama_endpoint eps
 ;;
 
 let%test "endpoints_from_env parses comma-separated" =
-  let eps =
-    endpoints_from_env
-      ~getenv:(test_getenv [ llm_endpoints_env_var, "http://a:8080,http://b:8081" ])
-      ()
-  in
+  Unix.putenv "LLM_ENDPOINTS" "http://a:8080,http://b:8081";
+  let eps = endpoints_from_env () in
+  Unix.putenv "LLM_ENDPOINTS" "";
   List.mem "http://a:8080" eps
   && List.mem "http://b:8081" eps
-  && List.mem default_ollama_endpoint eps
+  && List.mem ollama_endpoint eps
 ;;
 
 let%test "endpoints_from_env trims whitespace" =
-  let eps =
-    endpoints_from_env
-      ~getenv:(test_getenv [ llm_endpoints_env_var, "  http://a:8080 , http://b:8081  " ])
-      ()
-  in
+  Unix.putenv "LLM_ENDPOINTS" "  http://a:8080 , http://b:8081  ";
+  let eps = endpoints_from_env () in
+  Unix.putenv "LLM_ENDPOINTS" "";
   List.mem "http://a:8080" eps && List.mem "http://b:8081" eps
 ;;
 
 let%test "endpoints_from_env filters empty parts" =
-  let eps =
-    endpoints_from_env
-      ~getenv:(test_getenv [ llm_endpoints_env_var, "http://a,,http://b," ])
-      ()
-  in
+  Unix.putenv "LLM_ENDPOINTS" "http://a,,http://b,";
+  let eps = endpoints_from_env () in
+  Unix.putenv "LLM_ENDPOINTS" "";
   List.mem "http://a" eps && List.mem "http://b" eps
 ;;
 
 let%test "endpoints_from_env empty string returns default" =
-  let getenv = test_getenv [ llm_endpoints_env_var, "" ] in
-  let eps = endpoints_from_env ~getenv () in
-  List.hd eps = resolve_default_endpoint ~getenv ()
+  Unix.putenv "LLM_ENDPOINTS" "";
+  let eps = endpoints_from_env () in
+  List.hd eps = default_endpoint
 ;;
 
 (* --- url_is_ollama --- *)
@@ -890,14 +885,10 @@ let%test "port_of_url ipv6 literal" = port_of_url "http://[::1]:8086" = Some 808
 let%test "port_of_url stops at path" = port_of_url "http://h:8085/x:9999" = Some 8085
 
 let%test "endpoints_from_env does not duplicate ollama" =
-  let eps =
-    endpoints_from_env
-      ~getenv:
-        (test_getenv
-           [ llm_endpoints_env_var, default_ollama_endpoint ^ ",http://a:8085" ])
-      ()
-  in
-  List.length (List.filter (( = ) default_ollama_endpoint) eps) = 1
+  Unix.putenv "LLM_ENDPOINTS" (ollama_endpoint ^ ",http://a:8085");
+  let eps = endpoints_from_env () in
+  Unix.putenv "LLM_ENDPOINTS" "";
+  List.length (List.filter (( = ) ollama_endpoint) eps) = 1
 ;;
 
 (* --- parse_models --- *)

--- a/lib/llm_provider/discovery.mli
+++ b/lib/llm_provider/discovery.mli
@@ -56,6 +56,9 @@ val discover
 (** Environment variable consulted by {!resolve_default_endpoint}. *)
 val local_llm_url_env_var : string
 
+(** Environment variable parsed by {!parse_llm_endpoints_env}. *)
+val llm_endpoints_env_var : string
+
 (** Environment variable consulted by {!resolve_ollama_endpoint}. *)
 val ollama_host_env_var : string
 
@@ -71,8 +74,10 @@ val default_endpoint : string
 (** Call-time resolver for the canonical local LLM endpoint.
     Reads [OAS_LOCAL_LLM_URL] at call time, falling back to
     {!Constants.Endpoints.default_url}. Prefer this over {!default_endpoint}
-    when the value must reflect environment changes after module init. *)
-val resolve_default_endpoint : unit -> string
+    when the value must reflect environment changes after module init. [getenv]
+    defaults to {!Cli_common_env.get}; tests may inject it to avoid mutating the
+    process environment. *)
+val resolve_default_endpoint : ?getenv:(string -> string option) -> unit -> string
 
 (** Ollama endpoint.  Reads OLLAMA_HOST env var,
     falls back to ["http://127.0.0.1:11434"]. *)
@@ -80,8 +85,10 @@ val ollama_endpoint : string
 
 (** Call-time resolver for the Ollama endpoint.
     Reads [OLLAMA_HOST] at call time. Prefer this over {!ollama_endpoint}
-    when the value must reflect environment changes after module init. *)
-val resolve_ollama_endpoint : unit -> string
+    when the value must reflect environment changes after module init. [getenv]
+    defaults to {!Cli_common_env.get}; tests may inject it to avoid mutating the
+    process environment. *)
+val resolve_ollama_endpoint : ?getenv:(string -> string option) -> unit -> string
 
 (** Parse the [LLM_ENDPOINTS] env var as a comma-separated list of
     URLs, trimming whitespace and dropping empty entries.  Returns
@@ -93,13 +100,16 @@ val resolve_ollama_endpoint : unit -> string
     Ollama append (see {!endpoints_from_env}) should layer their
     semantics on top of this raw list.
 
+    [getenv] defaults to {!Cli_common_env.get}; tests may inject it to avoid
+    mutating the process environment.
+
     @since 0.161.0 *)
-val parse_llm_endpoints_env : unit -> string list
+val parse_llm_endpoints_env : ?getenv:(string -> string option) -> unit -> string list
 
 (** Parse LLM_ENDPOINTS env var (comma-separated) and append the call-time
     Ollama endpoint if not already included.
     Falls back to [[resolve_default_endpoint (); resolve_ollama_endpoint ()]]. *)
-val endpoints_from_env : unit -> string list
+val endpoints_from_env : ?getenv:(string -> string option) -> unit -> string list
 
 (** JSON serialization for endpoint_status. *)
 val endpoint_status_to_json : endpoint_status -> Yojson.Safe.t

--- a/lib/llm_provider/discovery.mli
+++ b/lib/llm_provider/discovery.mli
@@ -53,6 +53,15 @@ val discover
   -> endpoints:string list
   -> endpoint_status list
 
+(** Environment variable consulted by {!resolve_default_endpoint}. *)
+val local_llm_url_env_var : string
+
+(** Environment variable consulted by {!resolve_ollama_endpoint}. *)
+val ollama_host_env_var : string
+
+(** Compile-time fallback for {!resolve_ollama_endpoint}. *)
+val default_ollama_endpoint : string
+
 (** Canonical local LLM endpoint default.
     Reads [OAS_LOCAL_LLM_URL], falls back to
     {!Constants.Endpoints.default_url}.
@@ -69,6 +78,11 @@ val resolve_default_endpoint : unit -> string
     falls back to ["http://127.0.0.1:11434"]. *)
 val ollama_endpoint : string
 
+(** Call-time resolver for the Ollama endpoint.
+    Reads [OLLAMA_HOST] at call time. Prefer this over {!ollama_endpoint}
+    when the value must reflect environment changes after module init. *)
+val resolve_ollama_endpoint : unit -> string
+
 (** Parse the [LLM_ENDPOINTS] env var as a comma-separated list of
     URLs, trimming whitespace and dropping empty entries.  Returns
     [[]] when the variable is unset, empty, or contains only empty
@@ -82,9 +96,9 @@ val ollama_endpoint : string
     @since 0.161.0 *)
 val parse_llm_endpoints_env : unit -> string list
 
-(** Parse LLM_ENDPOINTS env var (comma-separated) and append
-    {!ollama_endpoint} if not already included.
-    Falls back to [[default_endpoint; ollama_endpoint]]. *)
+(** Parse LLM_ENDPOINTS env var (comma-separated) and append the call-time
+    Ollama endpoint if not already included.
+    Falls back to [[resolve_default_endpoint (); resolve_ollama_endpoint ()]]. *)
 val endpoints_from_env : unit -> string list
 
 (** JSON serialization for endpoint_status. *)

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -248,9 +248,15 @@ let discovered_endpoint_max_context (url : string) =
   Discovery.discovered_context_for_url url
 ;;
 
-let llama_defaults =
+let default_llama_endpoint () =
+  match Discovery.parse_llm_endpoints_env () with
+  | first :: _ -> first
+  | [] -> Discovery.resolve_default_endpoint ()
+;;
+
+let llama_defaults () =
   { kind = OpenAI_compat
-  ; base_url = List.hd llama_all_endpoints
+  ; base_url = default_llama_endpoint ()
   ; api_key_env = ""
   ; request_path = "/v1/chat/completions"
   }
@@ -303,9 +309,9 @@ let kimi_defaults =
   }
 ;;
 
-let ollama_defaults =
+let ollama_defaults () =
   { kind = Ollama
-  ; base_url = Discovery.ollama_endpoint
+  ; base_url = Discovery.resolve_ollama_endpoint ()
   ; api_key_env = ""
   ; request_path = "/api/chat"
   }
@@ -396,7 +402,7 @@ let default () =
   in
   reg
     "nous"
-    llama_defaults
+    (llama_defaults ())
     ~max_context:128_000
     Capabilities.openai_compat_chat_extended_capabilities;
   reg "claude" claude_defaults ~max_context:200_000 Capabilities.anthropic_capabilities;
@@ -446,7 +452,7 @@ let default () =
   register
     t
     { name = "ollama"
-    ; defaults = ollama_defaults
+    ; defaults = ollama_defaults ()
     ; max_context = 262_144
     ; capabilities = Capabilities.ollama_capabilities
     ; is_available = (fun () -> true)

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -154,12 +154,12 @@ let overlay_provider_catalog t =
 ;;
 
 (** Initial endpoints from LLM_ENDPOINTS env var.
-    Falls back to [[Discovery.default_endpoint]] when the variable is
+    Falls back to [[Discovery.resolve_default_endpoint ()]] when the variable is
     unset or has no non-empty entries (SSOT: see
     {!Discovery.parse_llm_endpoints_env}). *)
 let initial_llama_endpoints =
   match Discovery.parse_llm_endpoints_env () with
-  | [] -> [ Discovery.default_endpoint ]
+  | [] -> [ Discovery.resolve_default_endpoint () ]
   | urls -> urls
 ;;
 
@@ -229,7 +229,7 @@ let refresh_llama_endpoints ~sw ~net () =
           (fun (s : Discovery.endpoint_status) -> if s.healthy then Some s.url else None)
           statuses
       in
-      if found = [] then [ Discovery.default_endpoint ] else found
+      if found = [] then [ Discovery.resolve_default_endpoint () ] else found
   in
   (* When LLM_ENDPOINTS is explicit, still probe for context sync *)
   (match explicit with

--- a/test/test_discovery.ml
+++ b/test/test_discovery.ml
@@ -4,6 +4,8 @@
 
 open Llm_provider
 
+let test_getenv bindings name = List.assoc_opt name bindings
+
 let fresh_port () =
   let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
   Unix.setsockopt socket Unix.SO_REUSEADDR true;
@@ -44,31 +46,29 @@ let with_mock_server handler f =
 ;;
 
 let test_endpoints_from_env_default () =
-  (* When LLM_ENDPOINTS is not set, should return default *)
-  let saved = Sys.getenv_opt "LLM_ENDPOINTS" in
-  (match saved with
-   | Some _ -> Unix.putenv "LLM_ENDPOINTS" ""
-   | None -> ());
-  let result = Discovery.endpoints_from_env () in
-  (match saved with
-   | Some v -> Unix.putenv "LLM_ENDPOINTS" v
-   | None -> ());
+  let getenv = test_getenv [] in
+  let result = Discovery.endpoints_from_env ~getenv () in
   Alcotest.(check (list string))
     "default endpoint"
-    [ "http://127.0.0.1:8085"; Discovery.ollama_endpoint ]
+    [ Discovery.resolve_default_endpoint ~getenv ()
+    ; Discovery.resolve_ollama_endpoint ~getenv ()
+    ]
     result
 ;;
 
 let test_endpoints_from_env_custom () =
-  let saved = Sys.getenv_opt "LLM_ENDPOINTS" in
-  Unix.putenv "LLM_ENDPOINTS" "http://a:8085, http://b:8086,http://c:8087";
-  let result = Discovery.endpoints_from_env () in
-  (match saved with
-   | Some v -> Unix.putenv "LLM_ENDPOINTS" v
-   | None -> ());
+  let getenv =
+    test_getenv
+      [ Discovery.llm_endpoints_env_var, "http://a:8085, http://b:8086,http://c:8087" ]
+  in
+  let result = Discovery.endpoints_from_env ~getenv () in
   Alcotest.(check (list string))
     "parsed endpoints"
-    [ "http://a:8085"; "http://b:8086"; "http://c:8087"; Discovery.ollama_endpoint ]
+    [ "http://a:8085"
+    ; "http://b:8086"
+    ; "http://c:8087"
+    ; Discovery.resolve_ollama_endpoint ~getenv ()
+    ]
     result
 ;;
 

--- a/test/test_discovery.ml
+++ b/test/test_discovery.ml
@@ -6,6 +6,18 @@ open Llm_provider
 
 let test_getenv bindings name = List.assoc_opt name bindings
 
+let with_env name value f =
+  let saved = Sys.getenv_opt name in
+  Fun.protect
+    ~finally:(fun () ->
+      match saved with
+      | Some old_value -> Unix.putenv name old_value
+      | None -> Unix.putenv name "")
+    (fun () ->
+       Unix.putenv name value;
+       f ())
+;;
+
 let fresh_port () =
   let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
   Unix.setsockopt socket Unix.SO_REUSEADDR true;
@@ -120,14 +132,54 @@ let test_endpoints_from_env_resolves_defaults_from_getenv () =
     (Discovery.endpoints_from_env ~getenv ())
 ;;
 
-let test_url_is_ollama_reads_getenv () =
-  let getenv =
-    test_getenv [ Discovery.ollama_host_env_var, "http://ollama.internal:19007" ]
+let test_discover_uses_call_time_ollama_host () =
+  let props_hits = ref 0 in
+  let slots_hits = ref 0 in
+  let handler _conn req body =
+    ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
+    match Uri.path (Cohttp.Request.uri req) with
+    | "/health" -> Cohttp_eio.Server.respond_string ~status:`OK ~body:"ok" ()
+    | "/v1/models" ->
+      Cohttp_eio.Server.respond_string
+        ~status:`OK
+        ~body:{|{"data":[{"id":"phi4","owned_by":"ollama"}]}|}
+        ()
+    | "/api/tags" ->
+      Cohttp_eio.Server.respond_string
+        ~status:`OK
+        ~body:{|{"models":[{"name":"phi4"}]}|}
+        ()
+    | "/api/show" ->
+      Cohttp_eio.Server.respond_string
+        ~status:`OK
+        ~body:{|{"model_info":{"context_length":8192},"template":"{{ .Content }}"}|}
+        ()
+    | "/props" ->
+      incr props_hits;
+      Cohttp_eio.Server.respond_string ~status:`Not_found ~body:"unexpected props" ()
+    | "/slots" ->
+      incr slots_hits;
+      Cohttp_eio.Server.respond_string ~status:`Not_found ~body:"unexpected slots" ()
+    | _ -> Cohttp_eio.Server.respond_string ~status:`Not_found ~body:"missing" ()
   in
-  Alcotest.(check bool)
-    "custom ollama host"
-    true
-    (Discovery.url_is_ollama ~getenv "  http://ollama.internal:19007  ")
+  with_mock_server handler (fun ~sw ~net ~endpoint ->
+    with_env Discovery.ollama_host_env_var endpoint (fun () ->
+      match Discovery.discover ~sw ~net ~endpoints:[ endpoint ] with
+      | [ status ] ->
+        Alcotest.(check bool) "healthy" true status.healthy;
+        Alcotest.(check int) "props probe skipped" 0 !props_hits;
+        Alcotest.(check int) "slots probe skipped" 0 !slots_hits;
+        Alcotest.(check (option int))
+          "ollama context"
+          (Some 8192)
+          (Option.map
+             (fun (props : Discovery.server_props) -> props.ctx_size)
+             status.props);
+        Alcotest.(check bool)
+          "reasoning effort behavior"
+          true
+          (status.capabilities.thinking_control_format = Capabilities.Reasoning_effort)
+      | _ -> Alcotest.fail "expected one endpoint status"))
 ;;
 
 let test_parse_models_json () =
@@ -451,7 +503,10 @@ let () =
             "resolved endpoint defaults"
             `Quick
             test_endpoints_from_env_resolves_defaults_from_getenv
-        ; Alcotest.test_case "url_is_ollama getenv" `Quick test_url_is_ollama_reads_getenv
+        ; Alcotest.test_case
+            "discover uses call-time ollama host"
+            `Quick
+            test_discover_uses_call_time_ollama_host
         ] )
     ; "parsing", [ Alcotest.test_case "models json" `Quick test_parse_models_json ]
     ; ( "json"

--- a/test/test_discovery.ml
+++ b/test/test_discovery.ml
@@ -45,6 +45,40 @@ let with_mock_server handler f =
   | Exit -> ()
 ;;
 
+let test_resolve_default_endpoint_reads_getenv () =
+  let first = "http://127.0.0.1:19001" in
+  let second = "http://127.0.0.1:19002" in
+  Alcotest.(check string)
+    "first value"
+    first
+    (Discovery.resolve_default_endpoint
+       ~getenv:(test_getenv [ Discovery.local_llm_url_env_var, first ])
+       ());
+  Alcotest.(check string)
+    "second value"
+    second
+    (Discovery.resolve_default_endpoint
+       ~getenv:(test_getenv [ Discovery.local_llm_url_env_var, second ])
+       ())
+;;
+
+let test_resolve_ollama_endpoint_reads_getenv () =
+  let first = "http://127.0.0.1:19003" in
+  let second = "http://127.0.0.1:19004" in
+  Alcotest.(check string)
+    "first value"
+    first
+    (Discovery.resolve_ollama_endpoint
+       ~getenv:(test_getenv [ Discovery.ollama_host_env_var, first ])
+       ());
+  Alcotest.(check string)
+    "second value"
+    second
+    (Discovery.resolve_ollama_endpoint
+       ~getenv:(test_getenv [ Discovery.ollama_host_env_var, second ])
+       ())
+;;
+
 let test_endpoints_from_env_default () =
   let getenv = test_getenv [] in
   let result = Discovery.endpoints_from_env ~getenv () in
@@ -70,6 +104,30 @@ let test_endpoints_from_env_custom () =
     ; Discovery.resolve_ollama_endpoint ~getenv ()
     ]
     result
+;;
+
+let test_endpoints_from_env_resolves_defaults_from_getenv () =
+  let getenv =
+    test_getenv
+      [ Discovery.llm_endpoints_env_var, ""
+      ; Discovery.local_llm_url_env_var, "http://127.0.0.1:19005"
+      ; Discovery.ollama_host_env_var, "http://127.0.0.1:19006"
+      ]
+  in
+  Alcotest.(check (list string))
+    "resolved defaults"
+    [ "http://127.0.0.1:19005"; "http://127.0.0.1:19006" ]
+    (Discovery.endpoints_from_env ~getenv ())
+;;
+
+let test_url_is_ollama_reads_getenv () =
+  let getenv =
+    test_getenv [ Discovery.ollama_host_env_var, "http://ollama.internal:19007" ]
+  in
+  Alcotest.(check bool)
+    "custom ollama host"
+    true
+    (Discovery.url_is_ollama ~getenv "  http://ollama.internal:19007  ")
 ;;
 
 let test_parse_models_json () =
@@ -379,8 +437,21 @@ let () =
   Alcotest.run
     "Discovery"
     [ ( "env"
-      , [ Alcotest.test_case "default" `Quick test_endpoints_from_env_default
+      , [ Alcotest.test_case
+            "resolve default endpoint from getenv"
+            `Quick
+            test_resolve_default_endpoint_reads_getenv
+        ; Alcotest.test_case
+            "resolve ollama endpoint from getenv"
+            `Quick
+            test_resolve_ollama_endpoint_reads_getenv
+        ; Alcotest.test_case "default" `Quick test_endpoints_from_env_default
         ; Alcotest.test_case "custom" `Quick test_endpoints_from_env_custom
+        ; Alcotest.test_case
+            "resolved endpoint defaults"
+            `Quick
+            test_endpoints_from_env_resolves_defaults_from_getenv
+        ; Alcotest.test_case "url_is_ollama getenv" `Quick test_url_is_ollama_reads_getenv
         ] )
     ; "parsing", [ Alcotest.test_case "models json" `Quick test_parse_models_json ]
     ; ( "json"

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -805,6 +805,31 @@ let test_provider_config_of_agent_custom_registered_kimi_preserves_headers () =
   | Error e -> Alcotest.fail (Printf.sprintf "unexpected error: %s" (Error.to_string e))
 ;;
 
+let test_provider_config_of_agent_custom_registered_nous_uses_calltime_default () =
+  with_env "LLM_ENDPOINTS" (Some "") (fun () ->
+    with_env
+      Llm_provider.Discovery.local_llm_url_env_var
+      (Some "http://127.0.0.1:19013")
+      (fun () ->
+         let cfg : Provider.config =
+           { provider = Custom_registered { name = "nous" }
+           ; model_id = "local-model"
+           ; api_key_env = ""
+           }
+         in
+         let state = agent_state_with_params () in
+         match
+           Provider.provider_config_of_agent ~state ~base_url:"unused-fallback" (Some cfg)
+         with
+         | Ok pc ->
+           Alcotest.(check string)
+             "custom nous base_url"
+             "http://127.0.0.1:19013"
+             pc.base_url
+         | Error e ->
+           Alcotest.fail (Printf.sprintf "unexpected error: %s" (Error.to_string e))))
+;;
+
 let test_provider_config_of_agent_custom_registered_ollama_cloud_headers () =
   with_env "OLLAMA_CLOUD_API_KEY" (Some "ollama-cloud-provider-test-key") (fun () ->
     with_env "OLLAMA_API_KEY" (Some "fallback-ollama-api-key") (fun () ->
@@ -1018,6 +1043,10 @@ let () =
             "custom registered kimi preserves headers"
             `Quick
             test_provider_config_of_agent_custom_registered_kimi_preserves_headers
+        ; Alcotest.test_case
+            "custom registered nous uses call-time default"
+            `Quick
+            test_provider_config_of_agent_custom_registered_nous_uses_calltime_default
         ; Alcotest.test_case
             "custom registered ollama_cloud adds auth header"
             `Quick

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -327,6 +327,31 @@ let test_provider_name_of_ollama_cloud_config () =
     (Provider_registry.provider_name_of_config cfg)
 ;;
 
+let default_entry_base_url name =
+  let reg = Provider_registry.default () in
+  match Provider_registry.find reg name with
+  | Some e -> e.defaults.base_url
+  | None -> failf "%s should exist" name
+;;
+
+let test_default_nous_base_url_reads_llm_endpoints_at_call_time () =
+  let first = "http://127.0.0.1:18085" in
+  let second = "http://127.0.0.1:18086" in
+  with_env "LLM_ENDPOINTS" first (fun () ->
+    check string "first registry" first (default_entry_base_url "nous");
+    Unix.putenv "LLM_ENDPOINTS" second;
+    check string "second registry" second (default_entry_base_url "nous"))
+;;
+
+let test_default_ollama_base_url_reads_ollama_host_at_call_time () =
+  let first = "http://127.0.0.1:19134" in
+  let second = "http://127.0.0.1:19135" in
+  with_env "OLLAMA_HOST" first (fun () ->
+    check string "first registry" first (default_entry_base_url "ollama");
+    Unix.putenv "OLLAMA_HOST" second;
+    check string "second registry" second (default_entry_base_url "ollama"))
+;;
+
 let test_default_max_context () =
   let reg = Provider_registry.default () in
   (match Provider_registry.find reg "nous" with
@@ -1029,6 +1054,14 @@ let () =
             "provider_name_of_config returns ollama_cloud"
             `Quick
             test_provider_name_of_ollama_cloud_config
+        ; test_case
+            "nous base_url reads LLM_ENDPOINTS at registry construction"
+            `Quick
+            test_default_nous_base_url_reads_llm_endpoints_at_call_time
+        ; test_case
+            "ollama base_url reads OLLAMA_HOST at registry construction"
+            `Quick
+            test_default_ollama_base_url_reads_ollama_host_at_call_time
         ; test_case "max_context values" `Quick test_default_max_context
         ; test_case
             "max_context matches capabilities"

--- a/test/test_provider_runtime_binding.ml
+++ b/test/test_provider_runtime_binding.ml
@@ -1,5 +1,18 @@
 open Agent_sdk
 
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+;;
+
 let with_provider_catalog json f =
   match Llm_provider.Provider_catalog.of_json (Yojson.Safe.from_string json) with
   | Error msg -> Alcotest.fail msg
@@ -242,6 +255,19 @@ let test_builtin_binding_resolves () =
     (Provider_runtime_binding.resolve_model binding ~requested_model:None)
 ;;
 
+let test_builtin_nous_binding_uses_calltime_default_endpoint () =
+  with_env "LLM_ENDPOINTS" (Some "") (fun () ->
+    with_env
+      Llm_provider.Discovery.local_llm_url_env_var
+      (Some "http://127.0.0.1:19014")
+      (fun () ->
+         let binding = expect_binding "nous" in
+         Alcotest.(check string)
+           "runtime binding base_url"
+           "http://127.0.0.1:19014"
+           binding.base_url))
+;;
+
 let test_builtin_aliases_are_canonicalized () =
   let cases =
     [ "anthropic", "claude"
@@ -330,6 +356,10 @@ let () =
         ] )
     ; ( "builtins"
       , [ Alcotest.test_case "builtin resolves" `Quick test_builtin_binding_resolves
+        ; Alcotest.test_case
+            "nous binding uses call-time default endpoint"
+            `Quick
+            test_builtin_nous_binding_uses_calltime_default_endpoint
         ; Alcotest.test_case
             "builtin aliases canonicalize"
             `Quick


### PR DESCRIPTION
## Summary
- add named env/fallback constants plus Discovery.resolve_ollama_endpoint ()
- make Discovery.endpoints_from_env use call-time default/Ollama endpoint resolvers
- make url_is_ollama compare against call-time OLLAMA_HOST
- update provider registry fallback refresh paths to call Discovery.resolve_default_endpoint ()
- add deterministic inline tests for post-module-init env changes

## Local checks
- opam exec -- ocamlformat --check lib/llm_provider/discovery.ml lib/llm_provider/discovery.mli lib/llm_provider/provider_registry.ml
- git diff --check origin/main...HEAD

Build/test authority: GitHub CI, per repo workflow.