### PR TITLE
feat(parse): support catalog-scoped visible reasoning text

### DIFF
--- a/docs/capability-manifest.md
+++ b/docs/capability-manifest.md
@@ -98,6 +98,7 @@ for the full JSON Schema (draft-07).
 | `supports_computer_use` | bool | from base | Computer-use tools. |
 | `supports_code_execution` | bool | from base | Server-side code sandbox. |
 | `thinking_control_format` | string | from base | Thinking wire control. Accepted values: `none`, `thinking_object`, `thinking_object_only`, `chat_template_kwargs`, `chat_template_token`, `reasoning_effort`, `enable_thinking`. |
+| `reasoning_visibility` | string | `default` | Optional parsed reasoning visibility override. Accepted values: `default`, `provider_hidden`, `visible_channel`, `visible_text`. |
 
 Unknown fields are silently ignored (forward-compatible).
 

--- a/docs/capability-manifest.md
+++ b/docs/capability-manifest.md
@@ -115,6 +115,7 @@ default is `default_capabilities` (all flags false, no limits).
 | `anthropic` | Claude (1M ctx, extended thinking, caching) |
 | `gemini` | Gemini (1M ctx, audio/video, code execution) |
 | `ollama` | Ollama local server |
+| `ollama_cloud` | Ollama Cloud OpenAI-compatible endpoint; parsed reasoning may be final visible text |
 | `glm` | GLM / ZhipuAI |
 | `kimi` | Kimi (262K ctx, reasoning) |
 | `nemotron` | NVIDIA NIM Nemotron (chat\_template\_kwargs thinking) |

--- a/docs/schemas/capability-manifest-v1.json
+++ b/docs/schemas/capability-manifest-v1.json
@@ -141,6 +141,16 @@
             "reasoning_effort",
             "enable_thinking"
           ]
+        },
+        "reasoning_visibility": {
+          "type": "string",
+          "description": "Optional override for surfacing parsed reasoning output.",
+          "enum": [
+            "default",
+            "provider_hidden",
+            "visible_channel",
+            "visible_text"
+          ]
         }
       },
       "additionalProperties": true

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -184,7 +184,15 @@ let create_message
             match kind with
             | Provider.Anthropic_messages ->
               Ok (parse_response (Yojson.Safe.from_string body_str))
-            | Provider.Openai_chat_completions -> parse_openai_response_result body_str
+            | Provider.Openai_chat_completions ->
+              (* Thread the provider's reasoning_visibility policy so a
+                 reasoning-only reply (content="" + reasoning, e.g.
+                 ollama_cloud.minimax-m3) is promoted to a visible Text block
+                 when the dialect is Visible_text. *)
+              let visibility =
+                Api_openai.reasoning_visibility_of_request ~provider_config:provider_cfg config
+              in
+              parse_openai_response_result ~reasoning_visibility:visibility body_str
             | Provider.Custom name ->
               (match Provider.find_provider name with
                | Some impl -> Ok (impl.parse_response body_str)

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -186,11 +186,12 @@ let create_message
               Ok (parse_response (Yojson.Safe.from_string body_str))
             | Provider.Openai_chat_completions ->
               (* Thread the provider's reasoning_visibility policy so a
-                 reasoning-only reply (content="" + reasoning, e.g.
-                 ollama_cloud.minimax-m3) is promoted to a visible Text block
-                 when the dialect is Visible_text. *)
+                 reasoning-only reply can be promoted to a visible Text block
+                 only when the provider/model capability opts into Visible_text. *)
               let visibility =
-                Api_openai.reasoning_visibility_of_request ~provider_config:provider_cfg config
+                Api_openai.reasoning_visibility_of_request
+                  ~provider_config:provider_cfg
+                  config
               in
               parse_openai_response_result ~reasoning_visibility:visibility body_str
             | Provider.Custom name ->

--- a/lib/api.mli
+++ b/lib/api.mli
@@ -54,7 +54,10 @@ val build_openai_body
 
 (** Parse an OpenAI-compatible JSON response.
     Returns [Ok api_response] on success, [Error msg] on API error. *)
-val parse_openai_response_result : string -> (Types.api_response, string) result
+val parse_openai_response_result
+  :  ?reasoning_visibility:Llm_provider.Reasoning_dialect.reasoning_visibility
+  -> string
+  -> (Types.api_response, string) result
 
 (** {1 Non-streaming request} *)
 

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -110,6 +110,15 @@ let reasoning_dialect_for_request capabilities (config : agent_state) =
        ~preserve_thinking:config.config.preserve_thinking
 ;;
 
+let reasoning_visibility_of_request ?provider_config (config : agent_state) =
+  (* Resolve the provider's reasoning_visibility policy so the response parser
+     can promote a reasoning-only reply (content="" + reasoning) into a visible
+     Text block when the dialect is Visible_text (reasoning-only-answer models
+     like ollama_cloud.minimax-m3). *)
+  let capabilities = capabilities_for_request ?provider_config config in
+  (reasoning_dialect_for_request capabilities config).Llm_provider.Reasoning_dialect.visibility
+;;
+
 let add_sampling_field dialect (config : agent_state) field value body_assoc =
   if
     Llm_provider.Reasoning_dialect.ignores_sampling_param

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -79,6 +79,7 @@ let llm_capabilities_of_provider_capabilities (caps : Provider.capabilities)
   ; supports_extended_thinking = caps.supports_extended_thinking
   ; supports_reasoning_budget = caps.supports_reasoning_budget
   ; thinking_control_format = caps.thinking_control_format
+  ; reasoning_visibility_override = caps.reasoning_visibility_override
   ; supports_response_format_json = caps.supports_response_format_json
   ; supports_structured_output = caps.supports_structured_output
   ; supports_multimodal_inputs = caps.supports_multimodal_inputs
@@ -111,12 +112,12 @@ let reasoning_dialect_for_request capabilities (config : agent_state) =
 ;;
 
 let reasoning_visibility_of_request ?provider_config (config : agent_state) =
-  (* Resolve the provider's reasoning_visibility policy so the response parser
-     can promote a reasoning-only reply (content="" + reasoning) into a visible
-     Text block when the dialect is Visible_text (reasoning-only-answer models
-     like ollama_cloud.minimax-m3). *)
+  (* Resolve the provider/model reasoning_visibility policy so the response
+     parser can promote a reasoning-only reply into visible Text only when an
+     explicit capability override asks for that behavior. *)
   let capabilities = capabilities_for_request ?provider_config config in
-  (reasoning_dialect_for_request capabilities config).Llm_provider.Reasoning_dialect.visibility
+  (reasoning_dialect_for_request capabilities config)
+    .Llm_provider.Reasoning_dialect.visibility
 ;;
 
 let add_sampling_field dialect (config : agent_state) field value body_assoc =

--- a/lib/api_openai.mli
+++ b/lib/api_openai.mli
@@ -18,3 +18,11 @@ val build_openai_body
   -> ?slot_id:int
   -> unit
   -> string
+
+(** Resolve the reasoning_visibility policy for a request so the OpenAI
+    response parser can promote a reasoning-only reply into a visible Text
+    block. *)
+val reasoning_visibility_of_request
+  :  ?provider_config:Provider.config
+  -> Types.agent_state
+  -> Llm_provider.Reasoning_dialect.reasoning_visibility

--- a/lib/llm_provider/backend_openai.mli
+++ b/lib/llm_provider/backend_openai.mli
@@ -17,7 +17,10 @@ val response_format_to_openai_json : Types.response_format -> Yojson.Safe.t opti
 
 (** Parse an OpenAI-compatible JSON response.
     Returns [Ok api_response] on success, [Error msg] on API error. *)
-val parse_openai_response_result : string -> (Types.api_response, string) result
+val parse_openai_response_result
+  :  ?reasoning_visibility:Reasoning_dialect.reasoning_visibility
+  -> string
+  -> (Types.api_response, string) result
 
 val usage_of_openai_json : Yojson.Safe.t -> Types.api_usage option
 

--- a/lib/llm_provider/backend_openai_parse.ml
+++ b/lib/llm_provider/backend_openai_parse.ml
@@ -232,8 +232,8 @@ let telemetry_of_openai_json json =
 (** Parse an OpenAI-compatible JSON response string into an [api_response].
     Returns [Error msg] when the response body contains an API error. *)
 let parse_openai_response_result_json
-  ?(reasoning_visibility = Reasoning_dialect.Provider_hidden)
-  (raw_json : Yojson.Safe.t)
+      ?(reasoning_visibility = Reasoning_dialect.Provider_hidden)
+      (raw_json : Yojson.Safe.t)
   =
   let open Yojson.Safe.Util in
   let json =
@@ -290,9 +290,8 @@ let parse_openai_response_result_json
     (* Ollama uses "reasoning" field; Openai/Deepseek use "reasoning_content".
        Check both, preferring reasoning_content. reasoning_text is hoisted out
        of [thinking_blocks] so the content-assembly below can promote it to a
-       visible Text block when the provider's reasoning_visibility policy is
-       Visible_text (reasoning-only responses from models like
-       ollama_cloud.minimax-m3 that reply with content="" + reasoning="..."). *)
+       visible Text block when the provider/model reasoning_visibility policy is
+       Visible_text. *)
     let reasoning_text =
       match non_blank_json_string (msg |> member "reasoning_content") with
       | Some _ as text -> text
@@ -328,7 +327,7 @@ let parse_openai_response_result_json
               reasoning-only reply collapses to content=[Thinking] which every
               Text-only projection reads as empty. *)
            let promoted_reasoning =
-             match (reasoning_visibility, reasoning_text, text_blocks, tool_blocks) with
+             match reasoning_visibility, reasoning_text, text_blocks, tool_blocks with
              | Reasoning_dialect.Visible_text, Some r, [], [] -> [ Text r ]
              | _ -> []
            in
@@ -352,10 +351,12 @@ let parse_openai_response_result_json
     error-checks and reasoning-extracts from the same body) should call
     {!parse_openai_response_result_json} directly to avoid re-parsing. *)
 let parse_openai_response_result
-  ?(reasoning_visibility = Reasoning_dialect.Provider_hidden)
-  json_str
+      ?(reasoning_visibility = Reasoning_dialect.Provider_hidden)
+      json_str
   =
-  parse_openai_response_result_json ~reasoning_visibility (Yojson.Safe.from_string json_str)
+  parse_openai_response_result_json
+    ~reasoning_visibility
+    (Yojson.Safe.from_string json_str)
 ;;
 
 let%test "usage_of_openai_json supports mlx_vlm input/output token fields" =

--- a/lib/llm_provider/backend_openai_parse.ml
+++ b/lib/llm_provider/backend_openai_parse.ml
@@ -231,7 +231,10 @@ let telemetry_of_openai_json json =
 
 (** Parse an OpenAI-compatible JSON response string into an [api_response].
     Returns [Error msg] when the response body contains an API error. *)
-let parse_openai_response_result_json (raw_json : Yojson.Safe.t) =
+let parse_openai_response_result_json
+  ?(reasoning_visibility = Reasoning_dialect.Provider_hidden)
+  (raw_json : Yojson.Safe.t)
+  =
   let open Yojson.Safe.Util in
   let json =
     match raw_json with
@@ -284,14 +287,18 @@ let parse_openai_response_result_json (raw_json : Yojson.Safe.t) =
           calls
       | `Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> []
     in
+    (* Ollama uses "reasoning" field; Openai/Deepseek use "reasoning_content".
+       Check both, preferring reasoning_content. reasoning_text is hoisted out
+       of [thinking_blocks] so the content-assembly below can promote it to a
+       visible Text block when the provider's reasoning_visibility policy is
+       Visible_text (reasoning-only responses from models like
+       ollama_cloud.minimax-m3 that reply with content="" + reasoning="..."). *)
+    let reasoning_text =
+      match non_blank_json_string (msg |> member "reasoning_content") with
+      | Some _ as text -> text
+      | None -> non_blank_json_string (msg |> member "reasoning")
+    in
     let thinking_blocks =
-      (* Ollama uses "reasoning" field; Openai/Deepseek use "reasoning_content".
-           Check both, preferring reasoning_content. *)
-      let reasoning_text =
-        match non_blank_json_string (msg |> member "reasoning_content") with
-        | Some _ as text -> text
-        | None -> non_blank_json_string (msg |> member "reasoning")
-      in
       match reasoning_text with
       | Some s -> [ Thinking { thinking_type = "reasoning"; content = s } ]
       | None -> []
@@ -310,9 +317,22 @@ let parse_openai_response_result_json (raw_json : Yojson.Safe.t) =
       ; model = Cli_common_json.member_str "model" json
       ; stop_reason
       ; content =
-          thinking_blocks
-          @ (if Api_common.string_is_blank text_content then [] else [ Text text_content ])
-          @ tool_blocks
+          (let text_blocks =
+             if Api_common.string_is_blank text_content then [] else [ Text text_content ]
+           in
+           (* Visible_text policy: when the model replied with reasoning only
+              (no content text, no tool calls), promote the reasoning into a
+              visible Text block so downstream consumers (text_of_content /
+              Response_shape / fusion answer / keeper) see a non-empty answer
+              instead of an empty Thinking-only response. Without this, a
+              reasoning-only reply collapses to content=[Thinking] which every
+              Text-only projection reads as empty. *)
+           let promoted_reasoning =
+             match (reasoning_visibility, reasoning_text, text_blocks, tool_blocks) with
+             | Reasoning_dialect.Visible_text, Some r, [], [] -> [ Text r ]
+             | _ -> []
+           in
+           thinking_blocks @ text_blocks @ promoted_reasoning @ tool_blocks)
       ; usage = usage_of_openai_json json
       ; telemetry = telemetry_of_openai_json json
       }
@@ -331,8 +351,11 @@ let parse_openai_response_result_json (raw_json : Yojson.Safe.t) =
     parsed [Yojson.Safe.t] (e.g. {!Backend_glm.parse_response}, which also
     error-checks and reasoning-extracts from the same body) should call
     {!parse_openai_response_result_json} directly to avoid re-parsing. *)
-let parse_openai_response_result json_str =
-  parse_openai_response_result_json (Yojson.Safe.from_string json_str)
+let parse_openai_response_result
+  ?(reasoning_visibility = Reasoning_dialect.Provider_hidden)
+  json_str
+  =
+  parse_openai_response_result_json ~reasoning_visibility (Yojson.Safe.from_string json_str)
 ;;
 
 let%test "usage_of_openai_json supports mlx_vlm input/output token fields" =

--- a/lib/llm_provider/backend_openai_parse.ml
+++ b/lib/llm_provider/backend_openai_parse.ml
@@ -321,11 +321,10 @@ let parse_openai_response_result_json
            in
            (* Visible_text policy: when the model replied with reasoning only
               (no content text, no tool calls), promote the reasoning into a
-              visible Text block so downstream consumers (text_of_content /
-              Response_shape / fusion answer / keeper) see a non-empty answer
-              instead of an empty Thinking-only response. Without this, a
-              reasoning-only reply collapses to content=[Thinking] which every
-              Text-only projection reads as empty. *)
+              visible Text block so SDK consumers that project textual answers
+              do not read the response as empty. Without this, a reasoning-only
+              reply collapses to content=[Thinking] which every Text-only
+              projection reads as empty. *)
            let promoted_reasoning =
              match reasoning_visibility, reasoning_text, text_blocks, tool_blocks with
              | Reasoning_dialect.Visible_text, Some r, [], [] -> [ Text r ]

--- a/lib/llm_provider/backend_openai_parse.mli
+++ b/lib/llm_provider/backend_openai_parse.mli
@@ -13,9 +13,13 @@ val usage_of_openai_json : Yojson.Safe.t -> Types.api_usage option
     API error.  Use when the caller already holds the parsed JSON to avoid
     re-parsing. *)
 val parse_openai_response_result_json
-  :  Yojson.Safe.t
+  :  ?reasoning_visibility:Reasoning_dialect.reasoning_visibility
+  -> Yojson.Safe.t
   -> (Types.api_response, string) result
 
 (** Parse an OpenAI-compatible JSON response.
     Returns [Ok api_response] on success, [Error msg] on API error. *)
-val parse_openai_response_result : string -> (Types.api_response, string) result
+val parse_openai_response_result
+  :  ?reasoning_visibility:Reasoning_dialect.reasoning_visibility
+  -> string
+  -> (Types.api_response, string) result

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -33,6 +33,12 @@ type thinking_control_format =
   (** DashScope-style top-level [enable_thinking] / [preserve_thinking] bools
       plus optional [thinking_budget]. *)
 
+type reasoning_visibility_override =
+  | Default_reasoning_visibility
+  | Force_provider_hidden
+  | Force_visible_channel
+  | Force_visible_text
+
 type capabilities =
   { (* ── Numeric limits ────────────────────────────────── *)
     max_context_tokens : int option (** Model's context window. None = unknown. *)
@@ -53,6 +59,11 @@ type capabilities =
         Only meaningful when [supports_reasoning] or [supports_extended_thinking]
         is true and the request goes through backend_openai.
         @since 0.184.0 *)
+  ; reasoning_visibility_override : reasoning_visibility_override
+    (** Optional override for how parsed reasoning content is surfaced. Most
+        providers inherit from [thinking_control_format]; catalog entries use
+        this only when a provider/model returns final answers solely in its
+        reasoning field and that field must become visible text. *)
   ; (* ── Output format ─────────────────────────────────── *)
     supports_response_format_json : bool (** JSON mode *)
   ; supports_structured_output : bool (** JSON schema 100% guarantee *)
@@ -109,6 +120,7 @@ let default_capabilities =
   ; supports_extended_thinking = false
   ; supports_reasoning_budget = false
   ; thinking_control_format = No_thinking_control
+  ; reasoning_visibility_override = Default_reasoning_visibility
   ; supports_response_format_json = false
   ; supports_structured_output = false
   ; supports_multimodal_inputs = false
@@ -512,6 +524,15 @@ let thinking_control_format_of_manifest_string raw =
   | _ -> None
 ;;
 
+let reasoning_visibility_override_of_catalog_string raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "" | "default" -> Some Default_reasoning_visibility
+  | "provider_hidden" | "hidden" -> Some Force_provider_hidden
+  | "visible_channel" -> Some Force_visible_channel
+  | "visible_text" -> Some Force_visible_text
+  | _ -> None
+;;
+
 let modality_priority_of_catalog_string raw =
   match String.lowercase_ascii (String.trim raw) with
   | "preserve_input_order" | "preserve-input-order" | "preserve" ->
@@ -583,6 +604,13 @@ let apply_manifest_entry (entry : Capability_manifest.entry) : capabilities =
           | Some t -> t
           | None -> base.thinking_control_format)
        | None -> base.thinking_control_format)
+  ; reasoning_visibility_override =
+      (match entry.reasoning_visibility with
+       | Some s ->
+         (match reasoning_visibility_override_of_catalog_string s with
+          | Some visibility -> visibility
+          | None -> base.reasoning_visibility_override)
+       | None -> base.reasoning_visibility_override)
   }
 ;;
 
@@ -677,6 +705,13 @@ let apply_catalog_entry (entry : Model_catalog.model_entry) : capabilities =
           | Some t -> t
           | None -> base.thinking_control_format)
        | None -> base.thinking_control_format)
+  ; reasoning_visibility_override =
+      (match entry.reasoning_visibility with
+       | Some s ->
+         (match reasoning_visibility_override_of_catalog_string s with
+          | Some visibility -> visibility
+          | None -> base.reasoning_visibility_override)
+       | None -> base.reasoning_visibility_override)
   }
 ;;
 
@@ -890,6 +925,7 @@ let test_catalog_entry id_prefix : Model_catalog.model_entry =
   ; supports_computer_use = None
   ; supports_code_execution = None
   ; thinking_control_format = None
+  ; reasoning_visibility = None
   ; input_per_million = None
   ; output_per_million = None
   ; cache_write_multiplier = None
@@ -1449,6 +1485,7 @@ let%test "capabilities_for_provider_label: aliases resolve to identical capabili
       && ca.max_output_tokens = cb.max_output_tokens
       && ca.supports_image_input = cb.supports_image_input
       && ca.thinking_control_format = cb.thinking_control_format
+      && ca.reasoning_visibility_override = cb.reasoning_visibility_override
     | _ -> false
   in
   let alias_pairs = [ "openai", "openai_chat"; "glm", "glm-coding" ] in

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -334,6 +334,10 @@ let ollama_capabilities =
   }
 ;;
 
+let ollama_cloud_capabilities =
+  { ollama_capabilities with reasoning_visibility_override = Force_visible_text }
+;;
+
 let dashscope_capabilities =
   { openai_compat_chat_extended_capabilities with
     supports_tool_choice = true
@@ -486,7 +490,8 @@ let capabilities_for_provider_label label =
   | "openai_compat_chat_extended" | "openai_chat_extended" ->
     Some openai_compat_chat_extended_capabilities
   | "gemini" -> Some gemini_capabilities
-  | "ollama" | "ollama_cloud" -> Some ollama_capabilities
+  | "ollama" -> Some ollama_capabilities
+  | "ollama_cloud" -> Some ollama_cloud_capabilities
   | "glm" | "zhipu" | "glm-coding" -> Some glm_capabilities
   | "dashscope" -> Some dashscope_capabilities
   | "nvidia" -> Some provider_l_capabilities

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -28,6 +28,12 @@ type thinking_control_format =
   (** DashScope-style top-level [enable_thinking] / [preserve_thinking] bools
       plus optional [thinking_budget]. *)
 
+type reasoning_visibility_override =
+  | Default_reasoning_visibility
+  | Force_provider_hidden
+  | Force_visible_channel
+  | Force_visible_text
+
 type capabilities =
   { (* Numeric limits *)
     max_context_tokens : int option
@@ -43,6 +49,7 @@ type capabilities =
   ; supports_extended_thinking : bool
   ; supports_reasoning_budget : bool
   ; thinking_control_format : thinking_control_format
+  ; reasoning_visibility_override : reasoning_visibility_override
   ; (* Output format *)
     supports_response_format_json : bool
   ; supports_structured_output : bool

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -99,6 +99,7 @@ val openai_compat_chat_capabilities : capabilities
 val openai_compat_chat_extended_capabilities : capabilities
 val gemini_capabilities : capabilities
 val ollama_capabilities : capabilities
+val ollama_cloud_capabilities : capabilities
 val dashscope_capabilities : capabilities
 val glm_capabilities : capabilities
 

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -34,6 +34,7 @@ type entry =
         reasoning_effort / enable_thinking). Parsed + applied in
         {!Capabilities.apply_manifest_entry}. Without this field a manifest
         entry silently dropped the model's thinking knob (RFC-OAS-023). *)
+  ; reasoning_visibility : string option
   }
 
 (** A parsed capability manifest. *)
@@ -138,6 +139,7 @@ let known_entry_keys =
   ; "supports_computer_use"
   ; "supports_code_execution"
   ; "thinking_control_format"
+  ; "reasoning_visibility"
   ]
 ;;
 
@@ -190,6 +192,7 @@ let parse_entry json =
     ; supports_computer_use = member_bool "supports_computer_use" json
     ; supports_code_execution = member_bool "supports_code_execution" json
     ; thinking_control_format = member_string_opt "thinking_control_format" json
+    ; reasoning_visibility = member_string_opt "reasoning_visibility" json
     }
 ;;
 

--- a/lib/llm_provider/capability_manifest.mli
+++ b/lib/llm_provider/capability_manifest.mli
@@ -75,6 +75,9 @@ type entry =
         thinking_object_only / chat_template_kwargs / chat_template_token /
         reasoning_effort / enable_thinking); applied in
         {!Capabilities.apply_manifest_entry}. *)
+  ; reasoning_visibility : string option
+    (** Optional parsed reasoning visibility override (default /
+        provider_hidden / visible_channel / visible_text). *)
   }
 
 (** A parsed capability manifest: an ordered list of model entries.

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -728,7 +728,12 @@ let complete_stream_http
               | Error _ as err -> err
               | Ok () ->
                 let result =
-                  match Complete_stream_acc.finalize_stream_acc acc with
+                  match
+                    Complete_stream_acc.finalize_stream_acc
+                      ~reasoning_visibility:
+                        (Reasoning_dialect.for_provider_config config).visibility
+                      acc
+                  with
                   | Ok _ as ok -> ok
                   | Error serr -> Error (http_error_of_stream_error serr)
                 in

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -116,8 +116,8 @@ let accumulate_event (acc : stream_acc) = function
 ;;
 
 let finalize_stream_acc
-  ?(reasoning_visibility = Reasoning_dialect.Provider_hidden)
-  (acc : stream_acc)
+      ?(reasoning_visibility = Reasoning_dialect.Provider_hidden)
+      (acc : stream_acc)
   =
   match !(acc.sse_error) with
   | Some serr -> Error serr
@@ -215,19 +215,33 @@ let finalize_stream_acc
         indices
     in
     (* Visible_text policy: a reasoning-only stream (no Text block, no tool
-       calls) collapses to content=[Thinking] which every Text-only downstream
-       projection reads as empty. Promote the reasoning into a visible Text
-       block so consumers (text_of_content / Response_shape / keeper) see a
-       non-empty answer. Mirrors the non-streaming parser promotion. *)
-    let has_text = List.exists (function Types.Text _ -> true | _ -> false) content in
-    let has_tool = List.exists (function Types.ToolUse _ -> true | _ -> false) content in
+       calls) collapses to content=[Thinking] which every Text-only projection
+       reads as empty. Promote the reasoning into a visible Text block for
+       provider/model contracts that expose reasoning-only answer text. Mirrors
+       the non-streaming parser promotion. *)
+    let has_text =
+      List.exists
+        (function
+          | Types.Text _ -> true
+          | _ -> false)
+        content
+    in
+    let has_tool =
+      List.exists
+        (function
+          | Types.ToolUse _ -> true
+          | _ -> false)
+        content
+    in
     let reasoning_text =
       List.find_map
-        (function Types.Thinking { content = c; _ } -> Some c | _ -> None)
+        (function
+          | Types.Thinking { content = c; _ } -> Some c
+          | _ -> None)
         content
     in
     let promoted_reasoning =
-      match (reasoning_visibility, has_text, has_tool, reasoning_text) with
+      match reasoning_visibility, has_text, has_tool, reasoning_text with
       | Reasoning_dialect.Visible_text, false, false, Some r when String.trim r <> "" ->
         [ Types.Text r ]
       | _ -> []

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -115,7 +115,10 @@ let accumulate_event (acc : stream_acc) = function
   | Types.MessageStop | Types.Ping | Types.Connected | Types.Timeout _ -> ()
 ;;
 
-let finalize_stream_acc (acc : stream_acc) =
+let finalize_stream_acc
+  ?(reasoning_visibility = Reasoning_dialect.Provider_hidden)
+  (acc : stream_acc)
+  =
   match !(acc.sse_error) with
   | Some serr -> Error serr
   | None when not !(acc.stop_reason_received) ->
@@ -211,11 +214,29 @@ let finalize_stream_acc (acc : stream_acc) =
            | _ -> None)
         indices
     in
+    (* Visible_text policy: a reasoning-only stream (no Text block, no tool
+       calls) collapses to content=[Thinking] which every Text-only downstream
+       projection reads as empty. Promote the reasoning into a visible Text
+       block so consumers (text_of_content / Response_shape / keeper) see a
+       non-empty answer. Mirrors the non-streaming parser promotion. *)
+    let has_text = List.exists (function Types.Text _ -> true | _ -> false) content in
+    let has_tool = List.exists (function Types.ToolUse _ -> true | _ -> false) content in
+    let reasoning_text =
+      List.find_map
+        (function Types.Thinking { content = c; _ } -> Some c | _ -> None)
+        content
+    in
+    let promoted_reasoning =
+      match (reasoning_visibility, has_text, has_tool, reasoning_text) with
+      | Reasoning_dialect.Visible_text, false, false, Some r when String.trim r <> "" ->
+        [ Types.Text r ]
+      | _ -> []
+    in
     Ok
       { Types.id = !(acc.id)
       ; model = !(acc.model)
       ; stop_reason = !(acc.stop_reason)
-      ; content
+      ; content = content @ promoted_reasoning
       ; usage =
           Some
             { input_tokens = !(acc.input_tokens)

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -226,7 +226,10 @@ let finalize_stream_acc
           | Types.Thinking _
           | Types.RedactedThinking _
           | Types.ToolUse _
-          | Types.ToolResult _ -> false)
+          | Types.ToolResult _
+          | Types.Image _
+          | Types.Document _
+          | Types.Audio _ -> false)
         content
     in
     let has_tool =
@@ -236,15 +239,23 @@ let finalize_stream_acc
           | Types.Text _
           | Types.Thinking _
           | Types.RedactedThinking _
-          | Types.ToolResult _ -> false)
+          | Types.ToolResult _
+          | Types.Image _
+          | Types.Document _
+          | Types.Audio _ -> false)
         content
     in
     let reasoning_text =
       List.find_map
         (function
           | Types.Thinking { content = c; _ } -> Some c
-          | Types.Text _ | Types.RedactedThinking _ | Types.ToolUse _ | Types.ToolResult _
-            -> None)
+          | Types.Text _
+          | Types.RedactedThinking _
+          | Types.ToolUse _
+          | Types.ToolResult _
+          | Types.Image _
+          | Types.Document _
+          | Types.Audio _ -> None)
         content
     in
     let promoted_reasoning =

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -223,21 +223,28 @@ let finalize_stream_acc
       List.exists
         (function
           | Types.Text _ -> true
-          | _ -> false)
+          | Types.Thinking _
+          | Types.RedactedThinking _
+          | Types.ToolUse _
+          | Types.ToolResult _ -> false)
         content
     in
     let has_tool =
       List.exists
         (function
           | Types.ToolUse _ -> true
-          | _ -> false)
+          | Types.Text _
+          | Types.Thinking _
+          | Types.RedactedThinking _
+          | Types.ToolResult _ -> false)
         content
     in
     let reasoning_text =
       List.find_map
         (function
           | Types.Thinking { content = c; _ } -> Some c
-          | _ -> None)
+          | Types.Text _ | Types.RedactedThinking _ | Types.ToolUse _ | Types.ToolResult _
+            -> None)
         content
     in
     let promoted_reasoning =

--- a/lib/llm_provider/complete_stream_acc.mli
+++ b/lib/llm_provider/complete_stream_acc.mli
@@ -40,4 +40,7 @@ val accumulate_event : stream_acc -> Types.sse_event -> unit
     (typed so the consumer can route a provider-reported error through the same
     classification path as a non-streaming error); content blocks are ordered by
     their stream index. *)
-val finalize_stream_acc : stream_acc -> (Types.api_response, Types.stream_error) result
+val finalize_stream_acc
+  :  ?reasoning_visibility:Reasoning_dialect.reasoning_visibility
+  -> stream_acc
+  -> (Types.api_response, Types.stream_error) result

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -28,6 +28,7 @@ type model_entry =
   ; supports_computer_use : bool option
   ; supports_code_execution : bool option
   ; thinking_control_format : string option
+  ; reasoning_visibility : string option
   ; input_per_million : float option
   ; output_per_million : float option
   ; cache_write_multiplier : float option
@@ -103,6 +104,7 @@ let parse_entry entry_toml =
       ; supports_computer_use = find_bool_opt entry_toml [ "supports_computer_use" ]
       ; supports_code_execution = find_bool_opt entry_toml [ "supports_code_execution" ]
       ; thinking_control_format = find_string_opt entry_toml [ "thinking_control_format" ]
+      ; reasoning_visibility = find_string_opt entry_toml [ "reasoning_visibility" ]
       ; input_per_million = find_float_opt entry_toml [ "input_per_million" ]
       ; output_per_million = find_float_opt entry_toml [ "output_per_million" ]
       ; cache_write_multiplier = find_float_opt entry_toml [ "cache_write_multiplier" ]

--- a/lib/llm_provider/model_catalog.mli
+++ b/lib/llm_provider/model_catalog.mli
@@ -31,6 +31,7 @@ type model_entry =
   ; supports_computer_use : bool option
   ; supports_code_execution : bool option
   ; thinking_control_format : string option
+  ; reasoning_visibility : string option
   ; input_per_million : float option
   ; output_per_million : float option
   ; cache_write_multiplier : float option

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -217,6 +217,23 @@ let parse_thinking_control_format = function
             other))
 ;;
 
+let parse_reasoning_visibility = function
+  | None -> Ok None
+  | Some raw ->
+    let trimmed = String.lowercase_ascii (String.trim raw) in
+    (match trimmed with
+     | "" | "default" -> Ok (Some Capabilities.Default_reasoning_visibility)
+     | "provider_hidden" | "hidden" -> Ok (Some Capabilities.Force_provider_hidden)
+     | "visible_channel" -> Ok (Some Capabilities.Force_visible_channel)
+     | "visible_text" -> Ok (Some Capabilities.Force_visible_text)
+     | other ->
+       Error
+         (Printf.sprintf
+            "unknown reasoning_visibility %S (canonical: default, provider_hidden, \
+             visible_channel, visible_text)"
+            other))
+;;
+
 let member_supported_models json = member_string_list "supported_models" json
 
 let capability_base json =
@@ -262,6 +279,9 @@ let parse_capabilities provider_json =
   let* base = capability_base provider_json in
   let* thinking_control_format =
     parse_thinking_control_format (member_string "thinking_control_format" cap_json)
+  in
+  let* reasoning_visibility =
+    parse_reasoning_visibility (member_string "reasoning_visibility" cap_json)
   in
   let caps =
     base
@@ -438,6 +458,12 @@ let parse_capabilities provider_json =
     match thinking_control_format with
     | None -> caps
     | Some thinking_control_format -> { caps with Capabilities.thinking_control_format }
+  in
+  let caps =
+    match reasoning_visibility with
+    | None -> caps
+    | Some reasoning_visibility_override ->
+      { caps with Capabilities.reasoning_visibility_override }
   in
   let caps =
     match member_supported_models cap_json with

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -101,9 +101,16 @@ let of_capabilities (caps : Capabilities.capabilities) =
     ; streaming = Template_parser
     }
   | Reasoning_effort ->
+    (* Reasoning_effort providers (ollama_cloud incl. minimax-m3) frequently
+       reply with content="" + reasoning="..." (reasoning-only answer). Side_channel
+       keeps the reasoning as a Thinking block which every Text-only downstream
+       projection reads as empty. Visible_text lets the parser promote the
+       reasoning into a visible Text block when the reply is reasoning-only
+       (no content text, no tool calls); providers that emit a real content
+       Text are unaffected because promotion only fires on an empty Text. *)
     { default with
       toggle_wire = Reasoning_effort
-    ; visibility = Side_channel "reasoning"
+    ; visibility = Visible_text
     ; streaming = Delta_field "reasoning"
     }
   | Enable_thinking ->

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -66,7 +66,7 @@ let deepseek_ignored_sampling_params =
   [ "temperature"; "top_p"; "presence_penalty"; "frequency_penalty" ]
 ;;
 
-let of_capabilities (caps : Capabilities.capabilities) =
+let base_of_capabilities (caps : Capabilities.capabilities) =
   match caps.thinking_control_format with
   | No_thinking_control ->
     if caps.supports_reasoning
@@ -101,16 +101,9 @@ let of_capabilities (caps : Capabilities.capabilities) =
     ; streaming = Template_parser
     }
   | Reasoning_effort ->
-    (* Reasoning_effort providers (ollama_cloud incl. minimax-m3) frequently
-       reply with content="" + reasoning="..." (reasoning-only answer). Side_channel
-       keeps the reasoning as a Thinking block which every Text-only downstream
-       projection reads as empty. Visible_text lets the parser promote the
-       reasoning into a visible Text block when the reply is reasoning-only
-       (no content text, no tool calls); providers that emit a real content
-       Text are unaffected because promotion only fires on an empty Text. *)
     { default with
       toggle_wire = Reasoning_effort
-    ; visibility = Visible_text
+    ; visibility = Side_channel "reasoning"
     ; streaming = Delta_field "reasoning"
     }
   | Enable_thinking ->
@@ -120,6 +113,16 @@ let of_capabilities (caps : Capabilities.capabilities) =
     ; streaming = Delta_field "reasoning_content"
     }
 ;;
+
+let apply_visibility_override caps dialect =
+  match caps.Capabilities.reasoning_visibility_override with
+  | Default_reasoning_visibility -> dialect
+  | Force_provider_hidden -> { dialect with visibility = Provider_hidden }
+  | Force_visible_channel -> { dialect with visibility = Visible_channel }
+  | Force_visible_text -> { dialect with visibility = Visible_text }
+;;
+
+let of_capabilities caps = base_of_capabilities caps |> apply_visibility_override caps
 
 let with_preserve_thinking ~preserve_thinking dialect =
   match preserve_thinking, dialect.toggle_wire with

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -62,6 +62,13 @@ type thinking_control_format = Llm_provider.Capabilities.thinking_control_format
   | Reasoning_effort (** @since 0.195.0 *)
   | Enable_thinking (** @since 0.196.11 *)
 
+type reasoning_visibility_override =
+      Llm_provider.Capabilities.reasoning_visibility_override =
+  | Default_reasoning_visibility
+  | Force_provider_hidden
+  | Force_visible_channel
+  | Force_visible_text
+
 type capabilities =
   { max_context_tokens : int option
   ; max_output_tokens : int option
@@ -74,6 +81,7 @@ type capabilities =
   ; supports_extended_thinking : bool
   ; supports_reasoning_budget : bool
   ; thinking_control_format : thinking_control_format
+  ; reasoning_visibility_override : reasoning_visibility_override
   ; supports_response_format_json : bool
   ; supports_structured_output : bool
   ; supports_multimodal_inputs : bool

--- a/lib/provider_runtime_binding.ml
+++ b/lib/provider_runtime_binding.ml
@@ -85,6 +85,7 @@ let public_capabilities (caps : Llm_provider.Capabilities.capabilities)
   ; supports_extended_thinking = caps.supports_extended_thinking
   ; supports_reasoning_budget = caps.supports_reasoning_budget
   ; thinking_control_format = caps.thinking_control_format
+  ; reasoning_visibility_override = caps.reasoning_visibility_override
   ; supports_response_format_json = caps.supports_response_format_json
   ; supports_structured_output = caps.supports_structured_output
   ; supports_multimodal_inputs = caps.supports_multimodal_inputs

--- a/models.toml
+++ b/models.toml
@@ -662,6 +662,7 @@ supports_reasoning = true
 supports_extended_thinking = true
 supports_reasoning_budget = true
 thinking_control_format = "reasoning_effort"
+reasoning_visibility = "visible_text"
 supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"

--- a/models.toml
+++ b/models.toml
@@ -662,7 +662,6 @@ supports_reasoning = true
 supports_extended_thinking = true
 supports_reasoning_budget = true
 thinking_control_format = "reasoning_effort"
-reasoning_visibility = "visible_text"
 supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -98,11 +98,10 @@ let test_parse_reasoning_content_and_tool_calls_coexist () =
 ;;
 
 let test_reasoning_only_promoted_to_text_under_visible_text () =
-  (* ollama_cloud.minimax-m3 replies with content="" + reasoning="..." (reasoning-only
-     answer). Under Visible_text the parser promotes the reasoning into a visible
-     Text block so downstream Text-only projections see a non-empty answer
-     instead of an empty Thinking-only response. With the default policy
-     (Provider_hidden / Side_channel) the same reply stays Thinking-only. *)
+  (* Under an explicit Visible_text capability override, the parser promotes a
+     reasoning-only reply into a visible Text block so downstream Text-only
+     projections see a non-empty answer. With the default policy the same reply
+     stays Thinking-only. *)
   let json =
     response_json
       ~content:(`String "")
@@ -122,11 +121,17 @@ let test_reasoning_only_promoted_to_text_under_visible_text () =
   let visible = promote Reasoning_dialect.Visible_text in
   let default_resp = promote Reasoning_dialect.Provider_hidden in
   let has_text r =
-    List.exists (function Text s -> String.trim s = "최종 답은 42" | _ -> false) r.content
+    List.exists
+      (function
+        | Text s -> String.trim s = "최종 답은 42"
+        | _ -> false)
+      r.content
   in
   check_bool "Visible_text promotes reasoning to Text" true (has_text visible);
-  check_bool "default policy keeps reasoning as Thinking-only (no Text)"
-    false (has_text default_resp)
+  check_bool
+    "default policy keeps reasoning as Thinking-only (no Text)"
+    false
+    (has_text default_resp)
 ;;
 
 let test_content_parts_cover_modalities () =

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -97,6 +97,38 @@ let test_parse_reasoning_content_and_tool_calls_coexist () =
   check_bool "stop_reason is StopToolUse" true (response.stop_reason = StopToolUse)
 ;;
 
+let test_reasoning_only_promoted_to_text_under_visible_text () =
+  (* ollama_cloud.minimax-m3 replies with content="" + reasoning="..." (reasoning-only
+     answer). Under Visible_text the parser promotes the reasoning into a visible
+     Text block so downstream Text-only projections see a non-empty answer
+     instead of an empty Thinking-only response. With the default policy
+     (Provider_hidden / Side_channel) the same reply stays Thinking-only. *)
+  let json =
+    response_json
+      ~content:(`String "")
+      ~finish_reason:"stop"
+      ~message_fields:[ "reasoning_content", `String "최종 답은 42" ]
+      ()
+  in
+  let promote visibility =
+    match
+      Parse.parse_openai_response_result
+        ~reasoning_visibility:visibility
+        (Yojson.Safe.to_string json)
+    with
+    | Ok r -> r
+    | Error msg -> Alcotest.fail ("unexpected parse error: " ^ msg)
+  in
+  let visible = promote Reasoning_dialect.Visible_text in
+  let default_resp = promote Reasoning_dialect.Provider_hidden in
+  let has_text r =
+    List.exists (function Text s -> String.trim s = "최종 답은 42" | _ -> false) r.content
+  in
+  check_bool "Visible_text promotes reasoning to Text" true (has_text visible);
+  check_bool "default policy keeps reasoning as Thinking-only (no Text)"
+    false (has_text default_resp)
+;;
+
 let test_content_parts_cover_modalities () =
   let parts =
     Serialize.openai_content_parts_of_blocks
@@ -1405,6 +1437,10 @@ let () =
             "reasoning_content and tool_calls coexist"
             `Quick
             test_parse_reasoning_content_and_tool_calls_coexist
+        ; Alcotest.test_case
+            "reasoning-only promoted to Text under Visible_text"
+            `Quick
+            test_reasoning_only_promoted_to_text_under_visible_text
         ; Alcotest.test_case
             "error default message"
             `Quick

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -505,16 +505,11 @@ let test_ollama_cloud_current_catalog_resolves () =
          check (option int) (model_id ^ " context") (Some context) c.max_context_tokens;
          check bool (model_id ^ " vision") vision c.supports_image_input;
          check bool (model_id ^ " multimodal") vision c.supports_multimodal_inputs;
-         let expected_visibility =
-           if String.equal model_id "minimax-m3"
-           then Capabilities.Force_visible_text
-           else Capabilities.Default_reasoning_visibility
-         in
          check
            bool
            (model_id ^ " reasoning visibility")
            true
-           (c.reasoning_visibility_override = expected_visibility))
+           (c.reasoning_visibility_override = Capabilities.Force_visible_text))
     cases
 ;;
 

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -504,7 +504,17 @@ let test_ollama_cloud_current_catalog_resolves () =
        | Some c ->
          check (option int) (model_id ^ " context") (Some context) c.max_context_tokens;
          check bool (model_id ^ " vision") vision c.supports_image_input;
-         check bool (model_id ^ " multimodal") vision c.supports_multimodal_inputs)
+         check bool (model_id ^ " multimodal") vision c.supports_multimodal_inputs;
+         let expected_visibility =
+           if String.equal model_id "minimax-m3"
+           then Capabilities.Force_visible_text
+           else Capabilities.Default_reasoning_visibility
+         in
+         check
+           bool
+           (model_id ^ " reasoning visibility")
+           true
+           (c.reasoning_visibility_override = expected_visibility))
     cases
 ;;
 

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -639,7 +639,8 @@ let test_catalog_accepts_explicit_thinking_control_formats () =
              {"id": "dashscope", "kind": "openai_compat",
               "capabilities": {"thinking_control_format": "enable_thinking"}},
              {"id": "openai-reasoning", "kind": "openai_compat",
-              "capabilities": {"thinking_control_format": "reasoning_effort"}}
+              "capabilities": {"thinking_control_format": "reasoning_effort",
+                               "reasoning_visibility": "visible_text"}}
            ]
          }|})
   with
@@ -657,7 +658,16 @@ let test_catalog_accepts_explicit_thinking_control_formats () =
     in
     check_format "kimi-k2" Capabilities.Thinking_object_only;
     check_format "dashscope" Capabilities.Enable_thinking;
-    check_format "openai-reasoning" Capabilities.Reasoning_effort
+    check_format "openai-reasoning" Capabilities.Reasoning_effort;
+    (match Provider_catalog.lookup catalog "openai-reasoning" with
+     | Some entry ->
+       check
+         bool
+         "openai-reasoning visible_text override"
+         true
+         (entry.capabilities.reasoning_visibility_override
+          = Capabilities.Force_visible_text)
+     | None -> fail "openai-reasoning should exist")
 ;;
 
 let test_catalog_lookup_first_match_wins () =

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -190,7 +190,11 @@ let test_openai_reasoning_dialect_uses_reasoning_effort () =
     "toggle wire"
     "reasoning_effort"
     (RD.toggle_wire_to_string dialect.toggle_wire);
-  check string "visibility" "visible_text" (RD.visibility_to_string dialect.visibility);
+  check
+    string
+    "visibility"
+    "side_channel:reasoning"
+    (RD.visibility_to_string dialect.visibility);
   check
     string
     "replay policy"
@@ -212,6 +216,16 @@ let test_openai_reasoning_dialect_uses_reasoning_effort () =
     "typed preserve xhigh"
     (Some "xhigh")
     (RD.normalize_effort_value dialect RE.XHigh)
+;;
+
+let test_reasoning_visibility_override_visible_text () =
+  let caps =
+    { Capabilities.openai_compat_chat_extended_capabilities with
+      reasoning_visibility_override = Capabilities.Force_visible_text
+    }
+  in
+  let dialect = RD.of_capabilities caps in
+  check string "visibility" "visible_text" (RD.visibility_to_string dialect.visibility)
 ;;
 
 let test_openai_reasoning_request_uses_reasoning_effort () =
@@ -647,6 +661,10 @@ let () =
             "openai reasoning dialect uses reasoning_effort"
             `Quick
             test_openai_reasoning_dialect_uses_reasoning_effort
+        ; test_case
+            "reasoning visibility override visible text"
+            `Quick
+            test_reasoning_visibility_override_visible_text
         ; test_case
             "openai reasoning request uses reasoning_effort"
             `Quick

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -193,7 +193,7 @@ let test_openai_reasoning_dialect_uses_reasoning_effort () =
   check
     string
     "visibility"
-    "side_channel:reasoning"
+    "visible_text"
     (RD.visibility_to_string dialect.visibility);
   check
     string

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -190,11 +190,7 @@ let test_openai_reasoning_dialect_uses_reasoning_effort () =
     "toggle wire"
     "reasoning_effort"
     (RD.toggle_wire_to_string dialect.toggle_wire);
-  check
-    string
-    "visibility"
-    "visible_text"
-    (RD.visibility_to_string dialect.visibility);
+  check string "visibility" "visible_text" (RD.visibility_to_string dialect.visibility);
   check
     string
     "replay policy"

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -9,6 +9,7 @@ module PC = Llm_provider.Provider_config
 module BOR = Llm_provider.Backend_openai_request
 module BOL = Llm_provider.Backend_ollama
 module BAN = Llm_provider.Backend_anthropic
+module CAP = Llm_provider.Capabilities
 module CM = Llm_provider.Capability_manifest
 module RD = Llm_provider.Reasoning_dialect
 module RE = Llm_provider.Reasoning_effort
@@ -220,8 +221,8 @@ let test_openai_reasoning_dialect_uses_reasoning_effort () =
 
 let test_reasoning_visibility_override_visible_text () =
   let caps =
-    { Capabilities.openai_compat_chat_extended_capabilities with
-      reasoning_visibility_override = Capabilities.Force_visible_text
+    { CAP.openai_compat_chat_extended_capabilities with
+      reasoning_visibility_override = CAP.Force_visible_text
     }
   in
   let dialect = RD.of_capabilities caps in


### PR DESCRIPTION
## Context

Some `ollama_cloud` OpenAI-compatible models can return a final answer as
`content="" + reasoning="..."`. The first observed case was
`ollama_cloud/minimax-m3`, but the failure mode is provider-surface behavior,
not a single-model special case. If OAS keeps that payload as Thinking-only,
downstream text projections can treat the turn as empty.

The important boundary is that `reasoning_effort` is only a request wire shape.
It is not, by itself, proof that every OpenAI-compatible provider wants reasoning
rendered as visible assistant text.

## Change

1. Keep generic `Reasoning_effort` visibility as `Side_channel "reasoning"`.
2. Add a typed `reasoning_visibility` capability override with values:
   `default`, `provider_hidden`, `visible_channel`, `visible_text`.
3. Thread that override through model TOML, capability manifests, provider
   catalogs, and request parser selection.
4. Split `ollama_cloud` from local `ollama` provider capabilities and give only
   the `ollama_cloud` preset `reasoning_visibility = visible_text`.
5. Keep the non-streaming and streaming parser promotion behavior gated on
   `Visible_text && no content Text && no tool calls`.
6. Remove MASC-specific keeper/fusion rationale from OAS library comments.

## Safety

- OpenAI-compatible `reasoning_effort` providers remain side-channel by default.
- Local `ollama` remains separate from `ollama_cloud`.
- Visible text promotion is opt-in through typed capability data, not parser
  string matching.
- Tool-call responses are not promoted.
- Responses with normal content text are not changed.

## Verification

- `ocamlformat --check` passed for the touched OCaml files.
- `git diff --check` passed.
- Boundary grep for `MASC|keeper|fusion` in the touched parser/test surfaces is
  clean.
- Build/test remains CI-authoritative for this repository.

## Follow-up

- After CI passes and the MASC OAS pin is bumped, validate live reasoning-only
  answers across the active `ollama_cloud` keeper models, not only minimax-m3.
