### PR TITLE
fix(llm_provider): StopToolUse requires a tool block — stop_reason SSOT (infinite Thinking P0)

### DIFF
--- a/lib/base/nonempty.ml
+++ b/lib/base/nonempty.ml
@@ -1,0 +1,13 @@
+type 'a t =
+  { hd : 'a
+  ; tl : 'a list
+  }
+
+let of_list = function
+  | [] -> None
+  | hd :: tl -> Some { hd; tl }
+;;
+
+let to_list t = t.hd :: t.tl
+let hd t = t.hd
+let length t = 1 + List.length t.tl

--- a/lib/base/nonempty.mli
+++ b/lib/base/nonempty.mli
@@ -7,11 +7,9 @@
 
 type 'a t
 
-val of_list : 'a list -> 'a t option
 (** [None] for the empty list, [Some t] otherwise. *)
+val of_list : 'a list -> 'a t option
 
 val to_list : 'a t -> 'a list
-
 val hd : 'a t -> 'a
-
 val length : 'a t -> int

--- a/lib/base/nonempty.mli
+++ b/lib/base/nonempty.mli
@@ -1,0 +1,17 @@
+(** A list guaranteed to hold at least one element.
+
+    Lets a function reject an empty input at compile time instead of accepting
+    (and silently mis-handling) it at runtime. The turn pipeline uses it so the
+    tool-execute stage cannot be invoked with zero tool calls — a [StopToolUse]
+    turn that carried no tool block must terminate, not be re-issued. *)
+
+type 'a t
+
+val of_list : 'a list -> 'a t option
+(** [None] for the empty list, [Some t] otherwise. *)
+
+val to_list : 'a t -> 'a list
+
+val hd : 'a t -> 'a
+
+val length : 'a t -> int

--- a/lib/llm_provider/backend_openai_parse.ml
+++ b/lib/llm_provider/backend_openai_parse.ml
@@ -303,13 +303,12 @@ let parse_openai_response_result_json
       | None -> []
     in
     let stop_reason =
-      match String.lowercase_ascii finish_reason with
-      | "tool_calls" when tool_blocks <> [] -> StopToolUse
-      | "length" -> MaxTokens
-      | "stop" | "end_turn" -> EndTurn
-      | "refusal" -> Refusal
-      | _other when tool_blocks <> [] -> StopToolUse
-      | other -> Unknown other
+      (* SSOT: Stop_reason_wire owns the wire finish-reason -> stop_reason table
+         and the StopToolUse => has-tool-block invariant (previously duplicated
+         here and in the streaming chunk handler with divergent guards). *)
+      Stop_reason_wire.of_finish
+        (Stop_reason_wire.wire_finish_of_string finish_reason)
+        ~has_tool_blocks:(tool_blocks <> [])
     in
     Ok
       { id = Cli_common_json.member_str "id" json

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -435,9 +435,9 @@ let%test "finalize downgrades StopToolUse with no tool block to Unknown" =
   Hashtbl.replace acc.block_texts 0 buf;
   acc.stop_reason := Types.StopToolUse;
   acc.stop_reason_received := true;
-  (match finalize_stream_acc acc with
-   | Error _ -> false
-   | Ok result -> result.stop_reason = Types.Unknown "tool_calls")
+  match finalize_stream_acc acc with
+  | Error _ -> false
+  | Ok result -> result.stop_reason = Types.Unknown "tool_calls"
 ;;
 
 let%test "finalize keeps StopToolUse when a tool block is present" =
@@ -450,9 +450,9 @@ let%test "finalize keeps StopToolUse when a tool block is present" =
   Hashtbl.replace acc.block_texts 0 buf;
   acc.stop_reason := Types.StopToolUse;
   acc.stop_reason_received := true;
-  (match finalize_stream_acc acc with
-   | Error _ -> false
-   | Ok result -> result.stop_reason = Types.StopToolUse)
+  match finalize_stream_acc acc with
+  | Error _ -> false
+  | Ok result -> result.stop_reason = Types.StopToolUse
 ;;
 
 let%test "finalize_stream_acc multiple blocks ordered by index" =

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -422,6 +422,39 @@ let%test "finalize_stream_acc assembles thinking block" =
      | _ -> false)
 ;;
 
+(* Drift guard for the infinite-Thinking fix: a reasoning-only stream that the
+   provider tagged finish_reason="tool_calls" (provisional StopToolUse) must be
+   reconciled to Unknown when no tool block was assembled, so the driver does not
+   re-issue the identical Thinking turn forever. Reverting the reconcile in
+   finalize_stream_acc turns this RED. *)
+let%test "finalize downgrades StopToolUse with no tool block to Unknown" =
+  let acc = create_stream_acc () in
+  Hashtbl.replace acc.block_types 0 "thinking";
+  let buf = Buffer.create 16 in
+  Buffer.add_string buf "reasoning...";
+  Hashtbl.replace acc.block_texts 0 buf;
+  acc.stop_reason := Types.StopToolUse;
+  acc.stop_reason_received := true;
+  (match finalize_stream_acc acc with
+   | Error _ -> false
+   | Ok result -> result.stop_reason = Types.Unknown "tool_calls")
+;;
+
+let%test "finalize keeps StopToolUse when a tool block is present" =
+  let acc = create_stream_acc () in
+  Hashtbl.replace acc.block_types 0 "tool_use";
+  Hashtbl.replace acc.block_tool_ids 0 "tool-id-1";
+  Hashtbl.replace acc.block_tool_names 0 "my_tool";
+  let buf = Buffer.create 16 in
+  Buffer.add_string buf "{\"key\":\"val\"}";
+  Hashtbl.replace acc.block_texts 0 buf;
+  acc.stop_reason := Types.StopToolUse;
+  acc.stop_reason_received := true;
+  (match finalize_stream_acc acc with
+   | Error _ -> false
+   | Ok result -> result.stop_reason = Types.StopToolUse)
+;;
+
 let%test "finalize_stream_acc multiple blocks ordered by index" =
   let acc = create_stream_acc () in
   Hashtbl.replace acc.block_types 0 "thinking";

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -264,10 +264,20 @@ let finalize_stream_acc
         [ Types.Text r ]
       | _ -> []
     in
+    (* Enforce the StopToolUse => has-tool-block invariant now that the full
+       block set (including dropped partial tool calls above) is known. A
+       reasoning-only or dropped-partial-tool stream that the provider tagged
+       finish_reason="tool_calls" must NOT reach the driver as a tool-use turn
+       with zero tools -- the pipeline re-issues that forever (infinite Thinking
+       loop). SSOT: Stop_reason_wire.reconcile (same rule as the non-streaming
+       parser via Stop_reason_wire.of_finish). *)
+    let stop_reason =
+      Stop_reason_wire.reconcile !(acc.stop_reason) ~has_tool_blocks:has_tool
+    in
     Ok
       { Types.id = !(acc.id)
       ; model = !(acc.model)
-      ; stop_reason = !(acc.stop_reason)
+      ; stop_reason
       ; content = content @ promoted_reasoning
       ; usage =
           Some

--- a/lib/llm_provider/stop_reason_wire.ml
+++ b/lib/llm_provider/stop_reason_wire.ml
@@ -1,0 +1,103 @@
+type wire_finish =
+  | Tool_calls
+  | Length
+  | Stop
+  | Refusal
+  | Other of string
+
+(* The canonical [Unknown] payload for a tool-use finish that delivered no tool
+   block. One named value so the parse-time mapping and the streaming
+   reconciliation agree on the exact string instead of scattering the literal. *)
+let unmatched_tool_calls = "tool_calls"
+
+let wire_finish_of_string s =
+  match String.lowercase_ascii s with
+  | "tool_calls" -> Tool_calls
+  | "length" -> Length
+  | "stop" | "end_turn" -> Stop
+  | "refusal" -> Refusal
+  | other -> Other other
+;;
+
+let of_finish (w : wire_finish) ~has_tool_blocks : Types.stop_reason =
+  match w with
+  | Tool_calls ->
+    if has_tool_blocks then Types.StopToolUse else Types.Unknown unmatched_tool_calls
+  | Length -> Types.MaxTokens
+  | Stop -> Types.EndTurn
+  | Refusal -> Types.Refusal
+  (* "trust content over label": a non-tool finish that nonetheless carried tool
+     blocks is a tool-use turn (mirrors the historical non-streaming guard);
+     without tool blocks it is surfaced verbatim as [Unknown]. *)
+  | Other other ->
+    if has_tool_blocks then Types.StopToolUse else Types.Unknown other
+;;
+
+let provisional_of_string s : Types.stop_reason =
+  match wire_finish_of_string s with
+  | Tool_calls -> Types.StopToolUse
+  | Length -> Types.MaxTokens
+  | Stop -> Types.EndTurn
+  | Refusal -> Types.Refusal
+  | Other other -> Types.Unknown other
+;;
+
+let reconcile (sr : Types.stop_reason) ~has_tool_blocks : Types.stop_reason =
+  match sr with
+  | Types.StopToolUse when not has_tool_blocks -> Types.Unknown unmatched_tool_calls
+  | Types.StopToolUse
+  | Types.EndTurn
+  | Types.MaxTokens
+  | Types.StopSequence
+  | Types.Refusal
+  | Types.PauseTurn
+  | Types.Compaction
+  | Types.ContextWindowExceeded
+  | Types.Unknown _ -> sr
+;;
+
+[@@@coverage off]
+
+(* === Inline drift-guard tests ===
+   Pin the StopToolUse => has-tool-block invariant across the parse-time
+   ([of_finish]) and streaming ([provisional_of_string] |> [reconcile]) paths.
+   Reverting either the [of_finish] guard or the [reconcile] downgrade turns
+   these RED (non-vacuous regression guard). Gemini/Ollama use a different wire
+   vocabulary and already guard at their own (accumulating) finish chunk; their
+   coverage belongs with the pipeline no-reissue test. *)
+
+let%test "of_finish tool_calls without tools fails closed to Unknown" =
+  of_finish Tool_calls ~has_tool_blocks:false = Types.Unknown "tool_calls"
+;;
+
+let%test "of_finish tool_calls with tools is StopToolUse" =
+  of_finish Tool_calls ~has_tool_blocks:true = Types.StopToolUse
+;;
+
+let%test "reconcile downgrades StopToolUse without tools" =
+  reconcile Types.StopToolUse ~has_tool_blocks:false = Types.Unknown "tool_calls"
+;;
+
+let%test "reconcile preserves StopToolUse with tools" =
+  reconcile Types.StopToolUse ~has_tool_blocks:true = Types.StopToolUse
+;;
+
+let%test "provisional tool_calls is StopToolUse (faithful wire claim)" =
+  provisional_of_string "tool_calls" = Types.StopToolUse
+;;
+
+let%test "streaming chain (provisional |> reconcile) matches parse-time of_finish" =
+  let chain hb =
+    reconcile (provisional_of_string "tool_calls") ~has_tool_blocks:hb
+    = of_finish (wire_finish_of_string "tool_calls") ~has_tool_blocks:hb
+  in
+  chain true && chain false
+;;
+
+let%test "stop/length/refusal map identically on both paths" =
+  let same s =
+    provisional_of_string s
+    = of_finish (wire_finish_of_string s) ~has_tool_blocks:false
+  in
+  same "stop" && same "end_turn" && same "length" && same "refusal"
+;;

--- a/lib/llm_provider/stop_reason_wire.ml
+++ b/lib/llm_provider/stop_reason_wire.ml
@@ -29,8 +29,7 @@ let of_finish (w : wire_finish) ~has_tool_blocks : Types.stop_reason =
   (* "trust content over label": a non-tool finish that nonetheless carried tool
      blocks is a tool-use turn (mirrors the historical non-streaming guard);
      without tool blocks it is surfaced verbatim as [Unknown]. *)
-  | Other other ->
-    if has_tool_blocks then Types.StopToolUse else Types.Unknown other
+  | Other other -> if has_tool_blocks then Types.StopToolUse else Types.Unknown other
 ;;
 
 let provisional_of_string s : Types.stop_reason =
@@ -45,6 +44,7 @@ let provisional_of_string s : Types.stop_reason =
 let reconcile (sr : Types.stop_reason) ~has_tool_blocks : Types.stop_reason =
   match sr with
   | Types.StopToolUse when not has_tool_blocks -> Types.Unknown unmatched_tool_calls
+  | Types.Unknown _ when has_tool_blocks -> Types.StopToolUse
   | Types.StopToolUse
   | Types.EndTurn
   | Types.MaxTokens
@@ -94,10 +94,18 @@ let%test "streaming chain (provisional |> reconcile) matches parse-time of_finis
   chain true && chain false
 ;;
 
+let%test
+    "streaming chain (provisional |> reconcile) matches parse-time of_finish for Other + \
+     tools"
+  =
+  let s = "function_call" in
+  reconcile (provisional_of_string s) ~has_tool_blocks:true
+  = of_finish (wire_finish_of_string s) ~has_tool_blocks:true
+;;
+
 let%test "stop/length/refusal map identically on both paths" =
   let same s =
-    provisional_of_string s
-    = of_finish (wire_finish_of_string s) ~has_tool_blocks:false
+    provisional_of_string s = of_finish (wire_finish_of_string s) ~has_tool_blocks:false
   in
   same "stop" && same "end_turn" && same "length" && same "refusal"
 ;;

--- a/lib/llm_provider/stop_reason_wire.mli
+++ b/lib/llm_provider/stop_reason_wire.mli
@@ -1,0 +1,46 @@
+(** Single source of truth for OpenAI-compatible wire finish-reason ->
+    {!Types.stop_reason} mapping, and the invariant that a tool-use stop must
+    carry at least one tool block.
+
+    Before this module the mapping was duplicated across the non-streaming parser
+    ([Backend_openai_parse]) and the streaming chunk handler ([Streaming]) with
+    divergent guards: the streaming path emitted [StopToolUse] for
+    [finish_reason = "tool_calls"] WITHOUT checking that any tool block was
+    actually assembled. A reasoning-only / dropped-partial-tool stream therefore
+    reached the agent driver as a tool-use turn carrying zero tools, which the
+    pipeline re-issued forever (the "infinite Thinking turn" defect).
+
+    The OpenAI streaming finish chunk does not carry tool information (tool
+    arguments arrive as deltas in earlier chunks), so the guard cannot be applied
+    at the chunk boundary. The chunk records a provisional reason
+    ({!provisional_of_string}); the accumulator applies the invariant once the
+    full block set is known ({!reconcile}). *)
+
+type wire_finish =
+  | Tool_calls
+  | Length
+  | Stop
+  | Refusal
+  | Other of string
+
+val wire_finish_of_string : string -> wire_finish
+(** Case-insensitive OpenAI-compatible vocabulary. ["end_turn"] maps to [Stop]. *)
+
+val of_finish : wire_finish -> has_tool_blocks:bool -> Types.stop_reason
+(** Canonical parse-time mapping for backends that know the assembled tool-block
+    set at parse time (the non-streaming OpenAI parser). [Tool_calls] and [Other]
+    with [has_tool_blocks = false] fail closed to [Unknown] rather than asserting
+    a tool-use turn that carries no tool. *)
+
+val provisional_of_string : string -> Types.stop_reason
+(** Faithful wire claim for the streaming chunk boundary, where the accumulated
+    tool-block set is NOT yet known. The result MUST be passed through
+    {!reconcile} once accumulation completes; see
+    [Complete_stream_acc.finalize_stream_acc]. *)
+
+val reconcile : Types.stop_reason -> has_tool_blocks:bool -> Types.stop_reason
+(** Enforce the [StopToolUse => has_tool_blocks] invariant on an already-mapped
+    stop reason. Maps [StopToolUse] with [has_tool_blocks = false] to
+    [Unknown "tool_calls"] (matching {!of_finish} and the non-streaming parser);
+    leaves every other reason unchanged. Total over {!Types.stop_reason}: no
+    catch-all, so a new [stop_reason] constructor forces a compile error here. *)

--- a/lib/llm_provider/stop_reason_wire.mli
+++ b/lib/llm_provider/stop_reason_wire.mli
@@ -23,24 +23,25 @@ type wire_finish =
   | Refusal
   | Other of string
 
-val wire_finish_of_string : string -> wire_finish
 (** Case-insensitive OpenAI-compatible vocabulary. ["end_turn"] maps to [Stop]. *)
+val wire_finish_of_string : string -> wire_finish
 
-val of_finish : wire_finish -> has_tool_blocks:bool -> Types.stop_reason
 (** Canonical parse-time mapping for backends that know the assembled tool-block
     set at parse time (the non-streaming OpenAI parser). [Tool_calls] and [Other]
     with [has_tool_blocks = false] fail closed to [Unknown] rather than asserting
     a tool-use turn that carries no tool. *)
+val of_finish : wire_finish -> has_tool_blocks:bool -> Types.stop_reason
 
-val provisional_of_string : string -> Types.stop_reason
 (** Faithful wire claim for the streaming chunk boundary, where the accumulated
     tool-block set is NOT yet known. The result MUST be passed through
     {!reconcile} once accumulation completes; see
     [Complete_stream_acc.finalize_stream_acc]. *)
+val provisional_of_string : string -> Types.stop_reason
 
+(** Enforce parse-time parity after streaming accumulation. Maps [StopToolUse]
+    with [has_tool_blocks = false] to [Unknown "tool_calls"], and maps
+    [Unknown _] with [has_tool_blocks = true] to [StopToolUse] so nonstandard
+    finish labels that carried tool blocks follow {!of_finish}. Leaves other
+    reasons unchanged. Total over {!Types.stop_reason}: no catch-all, so a new
+    [stop_reason] constructor forces a compile error here. *)
 val reconcile : Types.stop_reason -> has_tool_blocks:bool -> Types.stop_reason
-(** Enforce the [StopToolUse => has_tool_blocks] invariant on an already-mapped
-    stop reason. Maps [StopToolUse] with [has_tool_blocks = false] to
-    [Unknown "tool_calls"] (matching {!of_finish} and the non-streaming parser);
-    leaves every other reason unchanged. Total over {!Types.stop_reason}: no
-    catch-all, so a new [stop_reason] constructor forces a compile error here. *)

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -542,16 +542,15 @@ let openai_chunk_to_events (state : openai_stream_state) (chunk : openai_chunk)
   (match chunk.finish_reason with
    | Some reason ->
      let stop_reason =
-       (* OpenAI wire vocabulary -> stop_reason. Kept in sync with the
-          non-streaming parser (Backend_openai_parse): "refusal" -> Refusal.
-          "content_filter" stays Unknown — it is a moderation cutoff, not a
-          model refusal. *)
-       match String.lowercase_ascii reason with
-       | "stop" -> EndTurn
-       | "tool_calls" -> StopToolUse
-       | "length" -> MaxTokens
-       | "refusal" -> Refusal
-       | other -> Unknown other
+       (* OpenAI wire vocabulary -> PROVISIONAL stop_reason. The accumulated
+          tool-block set is unknown at the chunk boundary (tool arguments arrive
+          as deltas before this terminal chunk), so a "tool_calls" finish is
+          recorded as a provisional StopToolUse and reconciled against the
+          assembled content in Complete_stream_acc.finalize_stream_acc
+          (Stop_reason_wire.reconcile). SSOT: the wire vocabulary lives in
+          Stop_reason_wire, not in an unguarded chunk-level match.
+          "content_filter" stays Unknown — a moderation cutoff, not a refusal. *)
+       Stop_reason_wire.provisional_of_string reason
      in
      emit (MessageDelta { stop_reason = Some stop_reason; usage = chunk.chunk_usage })
    | None ->

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -566,11 +566,7 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
                     { reason = "StopToolUse turn carried no tool block" }))
           | Some tool_uses_nonempty ->
             let result =
-              stage_execute
-                ?raw_trace_run
-                agent
-                ~effective_guardrails
-                tool_uses_nonempty
+              stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses_nonempty
             in
             (match result with
              | Ok IdleSkipped ->

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -285,7 +285,13 @@ let stage_collect ?raw_trace_run ?clock agent ~original_config response =
 (* ── Stage 5: Execute ────────────────────────────────────── *)
 
 (** Handle tool execution: idle detection, guardrails, context injection. *)
-let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses =
+let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses_nonempty =
+  (* The caller (stage_output) proves the tool-call set is non-empty: a
+     StopToolUse turn that carried no tool block is rejected before this stage
+     (Stop_reason_wire.reconcile downgrades it to Unknown at parse time).
+     Threading [Nonempty.t] makes the empty case a compile error instead of a
+     silent [ToolsExecuted] that re-issues the same Thinking turn forever. *)
+  let tool_uses = Nonempty.to_list tool_uses_nonempty in
   Tracing.with_span
     agent.options.tracer
     { kind = Tool_exec
@@ -545,15 +551,33 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
                 | Audio _ -> false)
              response.content
          in
-         let result =
-           stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses
-         in
-         (match result with
-          | Ok IdleSkipped ->
-            (* on_idle hook returned Skip: stop gracefully with the current response *)
+         (match Nonempty.of_list tool_uses with
+          | None ->
+            (* Defends the StopToolUse => has-tool-block invariant at the driver.
+               F1 (Stop_reason_wire.reconcile) guarantees the parsers never emit
+               StopToolUse without a tool block, so this is unreachable in
+               practice; if a future parser regresses it fails closed with a
+               typed error instead of silently returning [ToolsExecuted] and
+               re-issuing the identical Thinking turn forever. *)
             Agent_types.reset_idle_state agent;
-            Ok (Complete response)
-          | other -> other)
+            Error
+              (Error.Agent
+                 (UnrecognizedStopReason
+                    { reason = "StopToolUse turn carried no tool block" }))
+          | Some tool_uses_nonempty ->
+            let result =
+              stage_execute
+                ?raw_trace_run
+                agent
+                ~effective_guardrails
+                tool_uses_nonempty
+            in
+            (match result with
+             | Ok IdleSkipped ->
+               (* on_idle hook returned Skip: stop gracefully with the current response *)
+               Agent_types.reset_idle_state agent;
+               Ok (Complete response)
+             | other -> other))
        | EndTurn
        | MaxTokens
        | StopSequence


### PR DESCRIPTION
## 목적 (Radius-1, F1)

reasoning-only / dropped-partial-tool 스트림이 **무한 Thinking turn**으로 재발행되는 P0 근본 원인을 타입으로 제거합니다.

## 근본 원인 (코드 검증됨)

OpenAI **스트리밍** 청크 핸들러가 `finish_reason="tool_calls" -> StopToolUse`를 **무조건** 매핑합니다 (`streaming.ml:551`). 반면:
- 비스트리밍 파서 `backend_openai_parse.ml:307` — `when tool_blocks <> []` 가드
- Gemini `streaming.ml:1059` — `when ...tool_block_indices > 0` 가드
- Ollama `streaming.ml:1328` — `when chunk.oll_tool_calls <> []` 가드

OpenAI 스트리밍의 finish 청크에는 tool 정보가 없습니다 (tool 인자는 이전 delta들에 누적). 그래서 청크 단계에서는 가드가 불가능하고, 누적이 끝나는 `finalize_stream_acc`에서만 `has_tool`을 알 수 있습니다. 가드 누락으로 `{stop_reason=StopToolUse; content=[Thinking]; has_tool=false}`가 드라이버에 도달하면, `pipeline.ml`이 tool 0개를 실행하고도 `Ok ToolsExecuted`(=progress)를 반환 → `Agent.run_loop`가 동일 요청을 재발행 → 같은 thinking을 무한 재방출합니다.

또한 partial-tool DROP(`complete_stream_acc.ml:158-178`)은 ToolUse 블록만 제거하고 `stop_reason`은 그대로 두므로, 잘린 tool 호출도 같은 경로로 무한루프가 됩니다. 이 PR의 finalize reconcile이 두 경우를 모두 덮습니다.

## 변경 (SSOT)

신규 `lib/llm_provider/stop_reason_wire.ml{,i}` — OpenAI wire finish-reason → `stop_reason` 매핑과 `StopToolUse ⇒ has-tool-block` 불변식의 단일 SSOT:

| 함수 | 역할 |
|------|------|
| `of_finish ~has_tool_blocks` | 파스타임 정규 매핑(tool 인지). tool finish인데 tool 블록 없으면 `Unknown "tool_calls"`로 **fail-closed** |
| `provisional_of_string` | 스트리밍 청크의 faithful wire claim (tool 미누적 단계) |
| `reconcile ~has_tool_blocks` | finalize에서 불변식 강제. `stop_reason` 전체에 대해 exhaustive (no `_ ->`) |

- `backend_openai_parse.ml` → `of_finish` 사용 (기존 inline string-match 제거)
- `streaming.ml` 청크 → `provisional_of_string`
- `complete_stream_acc.ml finalize_stream_acc` → 조립된 content의 `has_tool`로 `reconcile`

기존 매핑은 **동작 보존** (lowercase 처리, "label보다 content 우선"인 `_other when tools<>[]` 규칙 포함, case별 동치 검증). 차이는 버그 수정뿐.

## 검증

`stop_reason_wire.ml` 인라인 drift-guard 테스트(`ppx_inline_test`):
- `of_finish`/`reconcile`가 tool 없는 `StopToolUse`를 `Unknown "tool_calls"`로 강등
- 스트리밍 체인 `provisional_of_string |> reconcile` == 파스타임 `of_finish`
- `of_finish`/`reconcile` 가드를 되돌리면 RED (non-vacuous)

빌드/테스트는 CI("Build and Test")에서 검증합니다 (로컬 빌드 미실행).

## Workaround Signature self-check
- counter-as-fix? **NO** — 카운터/텔레메트리 추가 없음. 카테고리 에러를 제거.
- string-classifier 보강? **NO** — 4-way string 분산을 한 typed 모듈로 **수렴**(추가가 아니라 제거).
- N-of-M? **NO** — divergent했던 OpenAI 두 경로를 한 PR에서 모두 라우팅.

## 남은 작업 (이 브랜치, Draft 유지)
- F2: `pipeline.ml stage_execute`에 `Nonempty.t` 계약 → tool 0개 `StopToolUse`를 **표현 불가능**(컴파일 에러)하게. + pipeline no-reissue 테스트.
- 그 전까지 머지하지 않습니다.

Refs: thinking-recursion diagnosis FINDINGS F1/F2 · 무한 Thinking 루프 P0
