### PR TITLE
Split reasoning preserve capability axis

### DIFF
--- a/docs/capability-manifest.md
+++ b/docs/capability-manifest.md
@@ -97,10 +97,12 @@ for the full JSON Schema (draft-07).
 | `supports_seed` | bool | from base | Deterministic seed. |
 | `supports_computer_use` | bool | from base | Computer-use tools. |
 | `supports_code_execution` | bool | from base | Server-side code sandbox. |
-| `thinking_control_format` | string | from base | Thinking wire control. Accepted values: `none`, `thinking_object`, `thinking_object_only`, `chat_template_kwargs`, `chat_template_token`, `reasoning_effort`, `enable_thinking`. |
+| `thinking_control_format` | string | from base | Thinking enable/depth wire control. Accepted values: `none`, `thinking_object`, `thinking_object_only`, `chat_template_kwargs`, `chat_template_token`, `reasoning_effort`, `enable_thinking`. |
+| `preserve_thinking_control_format` | string | from base | Historical reasoning replay/preserve wire control. Accepted values: `none`, `thinking_object_keep_all`, `chat_template_kwargs_preserve_thinking`, `top_level_preserve_thinking`, `always_preserved`. |
 | `reasoning_visibility` | string | `default` | Optional parsed reasoning visibility override. Accepted values: `default`, `provider_hidden`, `visible_channel`, `visible_text`. |
 
-Unknown fields are silently ignored (forward-compatible).
+Unknown fields and unknown enum values are rejected. Additive schema changes
+must update the parser and this schema together.
 
 ### Base presets
 
@@ -175,8 +177,9 @@ environment:
   specific one), place the more-specific entry earlier in the list.
 - The manifest is loaded **once** on first use (lazy singleton).  Restart the
   process to pick up changes.
-- Load errors are logged via `Diag.warn` and the manifest layer is silently
-  skipped, so a bad manifest file degrades gracefully to the built-in table.
+- Runtime load errors are logged via `Diag.warn` and the manifest layer is
+  skipped, so a bad manifest file degrades to the built-in table with an
+  operator-visible diagnostic.
 - `for_model_id` from the built-in table remains the fallback, so existing
   well-known model IDs (Claude, GPT, Gemini, etc.) do not need manifest entries
   unless you want to override their built-in capabilities.

--- a/docs/design/provider-reasoning-dialects.md
+++ b/docs/design/provider-reasoning-dialects.md
@@ -1,6 +1,6 @@
 # Provider Reasoning Dialects
 
-Date: 2026-06-14
+Date: 2026-06-29
 
 ## Purpose
 
@@ -10,20 +10,24 @@ strings when they decide how to display, replay, pause, or interrupt reasoning.
 
 `Llm_provider.Reasoning_dialect` is the typed surface for those facts. It is
 derived from the existing capability catalog and provider defaults, so it does
-not introduce a second model registry.
+not introduce a second model registry. The capability model deliberately splits
+thinking enable/depth control from historical-reasoning preserve/replay control:
+current models such as Kimi K2.7-code can require reasoning replay while
+accepting no request-time thinking parameter.
 
 ## Current Dialects
 
-| Capability wire format | Dialect meaning | Replay policy |
-| --- | --- | --- |
-| `Thinking_object` | DeepSeek-style top-level `thinking` object, optional `reasoning_effort`, side-channel `reasoning_content` | Drop reasoning between plain user turns, preserve reasoning after assistant tool calls |
-| `Thinking_object_only` | Top-level `thinking` object without effort | No mandatory replay yet |
-| `Chat_template_kwargs` | Self-hosted chat-template kwargs such as Qwen `enable_thinking` / `preserve_thinking` | No mandatory replay yet |
-| `Chat_template_token` | Template token injection such as Gemma `<\|think\|>` | No mandatory replay; parse visible thought channel from generated text |
-| `Reasoning_effort` | OpenAI-compatible `reasoning_effort` field | No mandatory replay yet |
-| `Enable_thinking` | DashScope-style top-level `enable_thinking` | No mandatory replay yet |
-| `Anthropic_thinking` | Claude Messages API `thinking` blocks. Older/current manual-thinking models use `thinking: {type:"enabled", budget_tokens:N}`; adaptive models use `thinking: {type:"adaptive"}` plus optional `output_config.effort`. | Preserve thinking blocks in history; Claude filters relevant blocks |
-| `Gemini_thinking_config` | Gemini native `generationConfig.thinkingConfig`. Gemini 3+ uses `thinkingLevel`; Gemini 2.5 uses `thinkingBudget`; thought parts/signatures carry visible summaries/tool continuity. | Preserve tool-call-linked thought signatures |
+| Thinking control format | Preserve control format | Dialect meaning | Replay policy |
+| --- | --- | --- | --- |
+| `Thinking_object` | `No_preserve_thinking_control` | DeepSeek-style top-level `thinking` object, optional `reasoning_effort`, side-channel `reasoning_content` | Drop reasoning between plain user turns, preserve reasoning after assistant tool calls |
+| `Thinking_object_only` | `Thinking_object_keep_all` | Top-level `thinking` object without effort plus `thinking.keep="all"` when requested | Preserve historical `reasoning_content` when `preserve_thinking=true` |
+| `Chat_template_kwargs` | `Chat_template_kwargs_preserve_thinking` | Self-hosted chat-template kwargs such as Qwen `enable_thinking` / `preserve_thinking` | Preserve historical reasoning only when requested |
+| `Enable_thinking` | `Top_level_preserve_thinking` | DashScope-style top-level `enable_thinking` plus separate `preserve_thinking` | Preserve historical reasoning only when requested |
+| `No_thinking_control` | `Always_preserved_thinking` | Latest Kimi-style models whose thinking is provider-controlled and whose historical `reasoning_content` must remain in messages | Always replay historical reasoning; emit no thinking request field |
+| `Chat_template_token` | `No_preserve_thinking_control` | Template token injection such as Gemma `<\|think\|>` | No mandatory replay; parse visible thought channel from generated text |
+| `Reasoning_effort` | `No_preserve_thinking_control` | OpenAI-compatible `reasoning_effort` field | No mandatory replay yet |
+| `Anthropic_thinking` | built-in | Claude Messages API `thinking` blocks. Older/current manual-thinking models use `thinking: {type:"enabled", budget_tokens:N}`; adaptive models use `thinking: {type:"adaptive"}` plus optional `output_config.effort`. | Preserve thinking blocks in history; Claude filters relevant blocks |
+| `Gemini_thinking_config` | built-in | Gemini native `generationConfig.thinkingConfig`. Gemini 3+ uses `thinkingLevel`; Gemini 2.5 uses `thinkingBudget`; thought parts/signatures carry visible summaries/tool continuity. | Preserve tool-call-linked thought signatures |
 
 ## Evidence
 
@@ -60,6 +64,13 @@ not introduce a second model registry.
   assistant reasoning forward. Source:
   <https://www.alibabacloud.com/help/en/model-studio/deep-thinking>, checked
   2026-06-14.
+- Kimi official docs: Kimi K2.7-code preserves thinking by default, should not
+  receive a request-time `thinking` parameter, and requires historical assistant
+  `reasoning_content` to remain in `messages`. Older Kimi variants can be
+  described through the separate preserve capability axis if an operator needs
+  them. Source:
+  <https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model>, checked
+  2026-06-29.
 
 ## Boundary
 

--- a/docs/example-capability-manifest.json
+++ b/docs/example-capability-manifest.json
@@ -3,15 +3,17 @@
   "schema_version": 1,
   "models": [
     {
-      "_comment": "Kimi K2.6 — Moonshot AI. 1T MoE / 32B active. 256K ctx. Top-level thinking + budget. Released 2026-04-20. https://platform.kimi.ai/docs/guide/kimi-k2-6-quickstart",
-      "id_prefix": "kimi-k2.6",
-      "base": "openai_chat",
-      "max_context_tokens": 262144,
+      "_comment": "Kimi K2.7-code — Moonshot AI. Latest K2 code model. Thinking is provider-controlled, no request-time thinking parameter, historical reasoning_content must be preserved. https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model",
+      "id_prefix": "kimi-k2.7-code",
+      "base": "kimi",
+      "max_context_tokens": 256000,
       "supports_tools": true,
       "supports_tool_choice": true,
       "supports_reasoning": true,
       "supports_extended_thinking": true,
-      "supports_reasoning_budget": true,
+      "supports_reasoning_budget": false,
+      "thinking_control_format": "none",
+      "preserve_thinking_control_format": "always_preserved",
       "supports_native_streaming": true,
       "supports_prompt_caching": true,
       "supports_system_prompt": true

--- a/docs/provider-capabilities-spec.md
+++ b/docs/provider-capabilities-spec.md
@@ -56,6 +56,7 @@ Cloud providers need hardcoded lookup tables keyed by model_id.
 | `supports_think_tool` | missing | add | Anthropic-only. Mid-reasoning pause between tool calls. |
 | `supports_adaptive_reasoning` | missing | add | Model auto-selects depth. Opus 4.6, Gemini 3 dynamic. |
 | `supports_reasoning_budget` | missing | add | budget_tokens (Anthropic), reasoning_effort (OpenAI), thinking_level (Gemini). |
+| `thinking_control_format` / `preserve_thinking_control_format` | exists in code | keep separate | Enable/depth wire shape and historical reasoning replay wire shape are independent axes. |
 | `supports_structured_output` | exists in code | keep, tighten semantics | Use only for provider-native schema-constrained output APIs. Do not use it for JSON mode or "prompt with schema text + app-side validator" patterns. |
 | `supports_response_format_json` | exists in code | keep, separate from schema guarantee | JSON mode means "return valid JSON" only. It is not a subset of native schema support and still requires caller-side shape validation. |
 | `supports_caching` | missing | add | Prompt caching: Anthropic (90% savings), OpenAI, Gemini, DeepSeek. |
@@ -134,6 +135,8 @@ add specific flags for SDK features that depend on the distinction.
 Minimum viable split:
 - `supports_extended_thinking` — enables `thinking_budget` in agent config
 - `supports_reasoning_budget` — enables cost-aware thinking control
+- `thinking_control_format` — request-time enable/depth wire shape
+- `preserve_thinking_control_format` — historical reasoning replay/preserve wire shape
 
 ## Multimodal Taxonomy
 

--- a/docs/provider-catalog.md
+++ b/docs/provider-catalog.md
@@ -155,7 +155,7 @@ The `capabilities` object accepts the same capability field names used by
 - `supports_tools`, `supports_tool_choice`, `supports_parallel_tool_calls`
 - `supports_runtime_mcp_tools`, `supports_runtime_tool_events`
 - `supports_reasoning`, `supports_extended_thinking`, `supports_reasoning_budget`
-- `thinking_control_format`
+- `thinking_control_format`, `preserve_thinking_control_format`
 - `supports_response_format_json`, `supports_structured_output`
 - `supports_image_input`, `supports_audio_input`, `supports_video_input`
 - `supports_native_streaming`, `supports_system_prompt`
@@ -175,6 +175,14 @@ Accepted `thinking_control_format` values are:
 - `chat_template_token` (inject a model-specific thinking token into the chat template)
 - `reasoning_effort`
 - `enable_thinking` (top-level `enable_thinking` plus optional `thinking_budget`)
+
+Accepted `preserve_thinking_control_format` values are:
+
+- `none`
+- `thinking_object_keep_all` (`thinking.keep = "all"`)
+- `chat_template_kwargs_preserve_thinking`
+- `top_level_preserve_thinking`
+- `always_preserved` (historical reasoning must be replayed; no request field)
 
 ## External Design References
 

--- a/docs/schemas/capability-manifest-v1.json
+++ b/docs/schemas/capability-manifest-v1.json
@@ -6,6 +6,10 @@
   "type": "object",
   "required": ["schema_version", "models"],
   "properties": {
+    "_comment": {
+      "type": "string",
+      "description": "Operator comment ignored by OAS."
+    },
     "schema_version": {
       "type": "integer",
       "description": "Schema version. Must be 1.",
@@ -26,6 +30,10 @@
       "required": ["id_prefix"],
       "description": "Capability overrides for models whose ID starts with id_prefix (case-insensitive prefix match). All fields except id_prefix are optional.",
       "properties": {
+        "_comment": {
+          "type": "string",
+          "description": "Operator comment ignored by OAS."
+        },
         "id_prefix": {
           "type": "string",
           "description": "Case-insensitive prefix matched against the model ID. E.g. 'my-llama-q4' matches 'my-llama-q4-k4' and 'my-llama-q4-k8'."
@@ -131,7 +139,7 @@
         },
         "thinking_control_format": {
           "type": "string",
-          "description": "Provider/model thinking control wire shape.",
+          "description": "Provider/model thinking enable/depth control wire shape.",
           "enum": [
             "none",
             "thinking_object",
@@ -140,6 +148,17 @@
             "chat_template_token",
             "reasoning_effort",
             "enable_thinking"
+          ]
+        },
+        "preserve_thinking_control_format": {
+          "type": "string",
+          "description": "Provider/model historical reasoning replay/preserve wire shape.",
+          "enum": [
+            "none",
+            "thinking_object_keep_all",
+            "chat_template_kwargs_preserve_thinking",
+            "top_level_preserve_thinking",
+            "always_preserved"
           ]
         },
         "reasoning_visibility": {
@@ -153,7 +172,7 @@
           ]
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     }
   },
   "examples": [

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -60,9 +60,28 @@ let bool_field name = function
   | None -> []
 ;;
 
-let chat_template_kwargs_fields (config : agent_state) =
+let chat_template_kwargs_fields dialect (config : agent_state) =
   bool_field "enable_thinking" config.config.enable_thinking
-  @ bool_field "preserve_thinking" config.config.preserve_thinking
+  @ bool_field
+      "preserve_thinking"
+      (Llm_provider.Reasoning_dialect.chat_template_kwargs_preserve_field
+         dialect
+         ~preserve_thinking:config.config.preserve_thinking)
+;;
+
+let thinking_object_only_fields dialect (config : agent_state) =
+  let control =
+    Llm_provider.Reasoning_dialect.thinking_object_only_control
+      dialect
+      ~enable_thinking:config.config.enable_thinking
+      ~preserve_thinking:config.config.preserve_thinking
+  in
+  let fields =
+    match control.enabled with
+    | Some enabled -> [ "type", `String (if enabled then "enabled" else "disabled") ]
+    | None -> []
+  in
+  if control.keep_all then fields @ [ "keep", `String "all" ] else fields
 ;;
 
 let llm_capabilities_of_provider_capabilities (caps : Provider.capabilities)
@@ -79,6 +98,7 @@ let llm_capabilities_of_provider_capabilities (caps : Provider.capabilities)
   ; supports_extended_thinking = caps.supports_extended_thinking
   ; supports_reasoning_budget = caps.supports_reasoning_budget
   ; thinking_control_format = caps.thinking_control_format
+  ; preserve_thinking_control_format = caps.preserve_thinking_control_format
   ; reasoning_visibility_override = caps.reasoning_visibility_override
   ; supports_response_format_json = caps.supports_response_format_json
   ; supports_structured_output = caps.supports_structured_output
@@ -215,7 +235,7 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
     else (
       match capabilities.thinking_control_format with
       | Llm_provider.Capabilities.Chat_template_kwargs ->
-        (match chat_template_kwargs_fields config with
+        (match chat_template_kwargs_fields dialect config with
          | [] -> body_assoc
          | fields -> ("chat_template_kwargs", `Assoc fields) :: body_assoc)
       | Llm_provider.Capabilities.Chat_template_token -> body_assoc
@@ -226,7 +246,11 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
           | None -> body_assoc
         in
         let body_assoc =
-          match config.config.preserve_thinking with
+          match
+            Llm_provider.Reasoning_dialect.top_level_preserve_field
+              dialect
+              ~preserve_thinking:config.config.preserve_thinking
+          with
           | Some preserve -> ("preserve_thinking", `Bool preserve) :: body_assoc
           | None -> body_assoc
         in
@@ -268,12 +292,9 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
          | Some false -> ("thinking", `Assoc [ "type", `String "disabled" ]) :: body_assoc
          | None -> body_assoc)
       | Llm_provider.Capabilities.Thinking_object_only ->
-        (match config.config.enable_thinking with
-         | Some enabled ->
-           ( "thinking"
-           , `Assoc [ "type", `String (if enabled then "enabled" else "disabled") ] )
-           :: body_assoc
-         | None -> body_assoc)
+        (match thinking_object_only_fields dialect config with
+         | [] -> body_assoc
+         | fields -> ("thinking", `Assoc fields) :: body_assoc)
       | Llm_provider.Capabilities.No_thinking_control
         when is_glm_request ?provider_config config ->
         (match config.config.enable_thinking with

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -136,9 +136,28 @@ let bool_field name = function
   | None -> []
 ;;
 
-let chat_template_kwargs_fields (config : Provider_config.t) =
+let chat_template_kwargs_fields dialect (config : Provider_config.t) =
   bool_field "enable_thinking" config.enable_thinking
-  @ bool_field "preserve_thinking" config.preserve_thinking
+  @ bool_field
+      "preserve_thinking"
+      (Reasoning_dialect.chat_template_kwargs_preserve_field
+         dialect
+         ~preserve_thinking:config.preserve_thinking)
+;;
+
+let thinking_object_only_fields dialect (config : Provider_config.t) =
+  let control =
+    Reasoning_dialect.thinking_object_only_control
+      dialect
+      ~enable_thinking:config.enable_thinking
+      ~preserve_thinking:config.preserve_thinking
+  in
+  let fields =
+    match control.enabled with
+    | Some enabled -> [ "type", `String (if enabled then "enabled" else "disabled") ]
+    | None -> []
+  in
+  if control.keep_all then fields @ [ "keep", `String "all" ] else fields
 ;;
 
 let glm_clear_thinking_of_config (config : Provider_config.t) =
@@ -281,7 +300,7 @@ let build_request_assoc
   let body =
     match caps.thinking_control_format with
     | Chat_template_kwargs ->
-      (match chat_template_kwargs_fields config with
+      (match chat_template_kwargs_fields dialect config with
        | [] -> body
        | fields -> ("chat_template_kwargs", `Assoc fields) :: body)
     | Chat_template_token -> body
@@ -292,7 +311,11 @@ let build_request_assoc
         | None -> body
       in
       let body =
-        match config.preserve_thinking with
+        match
+          Reasoning_dialect.top_level_preserve_field
+            dialect
+            ~preserve_thinking:config.preserve_thinking
+        with
         | Some preserve -> ("preserve_thinking", `Bool preserve) :: body
         | None -> body
       in
@@ -315,12 +338,9 @@ let build_request_assoc
        | Some false -> ("thinking", `Assoc [ "type", `String "disabled" ]) :: body
        | None -> body)
     | Thinking_object_only ->
-      (match config.enable_thinking with
-       | Some enabled ->
-         ( "thinking"
-         , `Assoc [ "type", `String (if enabled then "enabled" else "disabled") ] )
-         :: body
-       | None -> body)
+      (match thinking_object_only_fields dialect config with
+       | [] -> body
+       | fields -> ("thinking", `Assoc fields) :: body)
     | No_thinking_control when is_zai_glm_request config ->
       (match config.enable_thinking with
        | Some enabled ->

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -33,6 +33,20 @@ type thinking_control_format =
   (** DashScope-style top-level [enable_thinking] / [preserve_thinking] bools
       plus optional [thinking_budget]. *)
 
+type preserve_thinking_control_format =
+  | No_preserve_thinking_control
+  | Thinking_object_keep_all
+  (** [thinking.keep = "all"] inside the top-level
+      [thinking] object. *)
+  | Chat_template_kwargs_preserve_thinking
+  (** Self-hosted chat-template kwargs [preserve_thinking] flag. *)
+  | Top_level_preserve_thinking
+  (** Provider top-level [preserve_thinking] flag, separate from
+      [enable_thinking]. *)
+  | Always_preserved_thinking
+  (** Provider always requires historical reasoning replay and has no
+      request-time preserve toggle. *)
+
 type reasoning_visibility_override =
   | Default_reasoning_visibility
   | Force_provider_hidden
@@ -59,6 +73,11 @@ type capabilities =
         Only meaningful when [supports_reasoning] or [supports_extended_thinking]
         is true and the request goes through backend_openai.
         @since 0.184.0 *)
+  ; preserve_thinking_control_format : preserve_thinking_control_format
+    (** Wire-format for preserving historical reasoning between requests.
+        This is intentionally separate from [thinking_control_format]: some
+        models use [thinking.keep], some have no request toggle but require
+        replay, and Qwen-style chat templates use a nested boolean. *)
   ; reasoning_visibility_override : reasoning_visibility_override
     (** Optional override for how parsed reasoning content is surfaced. Most
         providers inherit from [thinking_control_format]; catalog entries use
@@ -120,6 +139,7 @@ let default_capabilities =
   ; supports_extended_thinking = false
   ; supports_reasoning_budget = false
   ; thinking_control_format = No_thinking_control
+  ; preserve_thinking_control_format = No_preserve_thinking_control
   ; reasoning_visibility_override = Default_reasoning_visibility
   ; supports_response_format_json = false
   ; supports_structured_output = false
@@ -247,8 +267,9 @@ let kimi_capabilities =
   ; supports_parallel_tool_calls = true
   ; supports_reasoning = true
   ; supports_extended_thinking = true
-  ; supports_reasoning_budget = true
-  ; thinking_control_format = Thinking_object_only
+  ; supports_reasoning_budget = false
+  ; thinking_control_format = No_thinking_control
+  ; preserve_thinking_control_format = Always_preserved_thinking
   ; supports_response_format_json = true
   ; supports_structured_output = true
   ; supports_system_prompt = true
@@ -322,6 +343,7 @@ let provider_l_capabilities =
     supports_tool_choice = true
   ; supports_reasoning = true
   ; thinking_control_format = Chat_template_kwargs
+  ; preserve_thinking_control_format = Chat_template_kwargs_preserve_thinking
   }
 ;;
 
@@ -343,6 +365,7 @@ let dashscope_capabilities =
     supports_tool_choice = true
   ; supports_min_p = true
   ; thinking_control_format = Enable_thinking
+  ; preserve_thinking_control_format = Top_level_preserve_thinking
   }
 ;;
 
@@ -529,6 +552,25 @@ let thinking_control_format_of_manifest_string raw =
   | _ -> None
 ;;
 
+let preserve_thinking_control_format_of_manifest_string raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "none" -> Some No_preserve_thinking_control
+  | "thinking_object_keep_all" -> Some Thinking_object_keep_all
+  | "chat_template_kwargs_preserve_thinking" ->
+    Some Chat_template_kwargs_preserve_thinking
+  | "top_level_preserve_thinking" -> Some Top_level_preserve_thinking
+  | "always_preserved" -> Some Always_preserved_thinking
+  | _ -> None
+;;
+
+let warn_unknown_capability_value ~field raw =
+  Diag.warn
+    "capabilities"
+    "unknown %s value %S; keeping provider base capability"
+    field
+    raw
+;;
+
 let reasoning_visibility_override_of_catalog_string raw =
   match String.lowercase_ascii (String.trim raw) with
   | "" | "default" -> Some Default_reasoning_visibility
@@ -607,8 +649,19 @@ let apply_manifest_entry (entry : Capability_manifest.entry) : capabilities =
        | Some s ->
          (match thinking_control_format_of_manifest_string s with
           | Some t -> t
-          | None -> base.thinking_control_format)
+          | None ->
+            warn_unknown_capability_value ~field:"thinking_control_format" s;
+            base.thinking_control_format)
        | None -> base.thinking_control_format)
+  ; preserve_thinking_control_format =
+      (match entry.preserve_thinking_control_format with
+       | Some s ->
+         (match preserve_thinking_control_format_of_manifest_string s with
+          | Some t -> t
+          | None ->
+            warn_unknown_capability_value ~field:"preserve_thinking_control_format" s;
+            base.preserve_thinking_control_format)
+       | None -> base.preserve_thinking_control_format)
   ; reasoning_visibility_override =
       (match entry.reasoning_visibility with
        | Some s ->
@@ -708,8 +761,19 @@ let apply_catalog_entry (entry : Model_catalog.model_entry) : capabilities =
        | Some s ->
          (match thinking_control_format_of_manifest_string s with
           | Some t -> t
-          | None -> base.thinking_control_format)
+          | None ->
+            warn_unknown_capability_value ~field:"thinking_control_format" s;
+            base.thinking_control_format)
        | None -> base.thinking_control_format)
+  ; preserve_thinking_control_format =
+      (match entry.preserve_thinking_control_format with
+       | Some s ->
+         (match preserve_thinking_control_format_of_manifest_string s with
+          | Some t -> t
+          | None ->
+            warn_unknown_capability_value ~field:"preserve_thinking_control_format" s;
+            base.preserve_thinking_control_format)
+       | None -> base.preserve_thinking_control_format)
   ; reasoning_visibility_override =
       (match entry.reasoning_visibility with
        | Some s ->
@@ -930,6 +994,7 @@ let test_catalog_entry id_prefix : Model_catalog.model_entry =
   ; supports_computer_use = None
   ; supports_code_execution = None
   ; thinking_control_format = None
+  ; preserve_thinking_control_format = None
   ; reasoning_visibility = None
   ; input_per_million = None
   ; output_per_million = None
@@ -948,6 +1013,7 @@ let qwen3_family_test_entry id_prefix : Model_catalog.model_entry =
   ; supports_reasoning = Some true
   ; supports_extended_thinking = Some true
   ; thinking_control_format = Some "chat_template_kwargs"
+  ; preserve_thinking_control_format = Some "chat_template_kwargs_preserve_thinking"
   ; supports_native_streaming = Some true
   }
 ;;
@@ -1490,6 +1556,7 @@ let%test "capabilities_for_provider_label: aliases resolve to identical capabili
       && ca.max_output_tokens = cb.max_output_tokens
       && ca.supports_image_input = cb.supports_image_input
       && ca.thinking_control_format = cb.thinking_control_format
+      && ca.preserve_thinking_control_format = cb.preserve_thinking_control_format
       && ca.reasoning_visibility_override = cb.reasoning_visibility_override
     | _ -> false
   in

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -10,7 +10,7 @@ type thinking_control_format =
   | No_thinking_control (** No thinking control supported *)
   | Thinking_object (** Top-level [thinking] object plus optional [reasoning_effort]. *)
   | Thinking_object_only
-  (** Kimi K2.5-style: top-level [thinking] object without [reasoning_effort]. *)
+  (** Kimi-style: top-level [thinking] object without [reasoning_effort]. *)
   | Chat_template_kwargs
   (** llama-server/vLLM/SGLang style:
       [{"chat_template_kwargs":{"enable_thinking":b,"preserve_thinking":b}}] *)
@@ -27,6 +27,20 @@ type thinking_control_format =
   | Enable_thinking
   (** DashScope-style top-level [enable_thinking] / [preserve_thinking] bools
       plus optional [thinking_budget]. *)
+
+type preserve_thinking_control_format =
+  | No_preserve_thinking_control
+  | Thinking_object_keep_all
+  (** [thinking.keep = "all"] inside the top-level
+      [thinking] object. *)
+  | Chat_template_kwargs_preserve_thinking
+  (** Self-hosted chat-template kwargs [preserve_thinking] flag. *)
+  | Top_level_preserve_thinking
+  (** Provider top-level [preserve_thinking] flag, separate from
+      [enable_thinking]. *)
+  | Always_preserved_thinking
+  (** Provider always requires historical reasoning replay and has no
+      request-time preserve toggle. *)
 
 type reasoning_visibility_override =
   | Default_reasoning_visibility
@@ -49,6 +63,7 @@ type capabilities =
   ; supports_extended_thinking : bool
   ; supports_reasoning_budget : bool
   ; thinking_control_format : thinking_control_format
+  ; preserve_thinking_control_format : preserve_thinking_control_format
   ; reasoning_visibility_override : reasoning_visibility_override
   ; (* Output format *)
     supports_response_format_json : bool

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -34,6 +34,11 @@ type entry =
         reasoning_effort / enable_thinking). Parsed + applied in
         {!Capabilities.apply_manifest_entry}. Without this field a manifest
         entry silently dropped the model's thinking knob (RFC-OAS-023). *)
+  ; preserve_thinking_control_format : string option
+    (** Canonical historical reasoning preservation wire format (none /
+        thinking_object_keep_all / chat_template_kwargs_preserve_thinking /
+        top_level_preserve_thinking / always_preserved). Parsed + applied in
+        {!Capabilities.apply_manifest_entry}. *)
   ; reasoning_visibility : string option
   }
 
@@ -109,6 +114,42 @@ let member_string_opt key json =
     None
 ;;
 
+let canonical_choice key ~allowed json =
+  match member_string_opt key json with
+  | None -> Ok None
+  | Some raw ->
+    let normalized = String.lowercase_ascii (String.trim raw) in
+    if List.mem normalized allowed
+    then Ok (Some raw)
+    else
+      Error
+        (Printf.sprintf
+           "entry field %S has unknown value %S (canonical: %s)"
+           key
+           normalized
+           (String.concat ", " allowed))
+;;
+
+let thinking_control_format_values =
+  [ "none"
+  ; "thinking_object"
+  ; "thinking_object_only"
+  ; "chat_template_kwargs"
+  ; "chat_template_token"
+  ; "reasoning_effort"
+  ; "enable_thinking"
+  ]
+;;
+
+let preserve_thinking_control_format_values =
+  [ "none"
+  ; "thinking_object_keep_all"
+  ; "chat_template_kwargs_preserve_thinking"
+  ; "top_level_preserve_thinking"
+  ; "always_preserved"
+  ]
+;;
+
 let known_manifest_keys = [ "_comment"; "schema_version"; "models" ]
 
 let known_entry_keys =
@@ -139,6 +180,7 @@ let known_entry_keys =
   ; "supports_computer_use"
   ; "supports_code_execution"
   ; "thinking_control_format"
+  ; "preserve_thinking_control_format"
   ; "reasoning_visibility"
   ]
 ;;
@@ -164,6 +206,18 @@ let parse_entry json =
     match member_string_opt "id_prefix" json with
     | None -> Error "entry missing required \"id_prefix\" field"
     | Some id_prefix -> Ok id_prefix
+  in
+  let* thinking_control_format =
+    canonical_choice
+      "thinking_control_format"
+      ~allowed:thinking_control_format_values
+      json
+  in
+  let* preserve_thinking_control_format =
+    canonical_choice
+      "preserve_thinking_control_format"
+      ~allowed:preserve_thinking_control_format_values
+      json
   in
   Ok
     { id_prefix
@@ -191,7 +245,8 @@ let parse_entry json =
     ; supports_seed = member_bool "supports_seed" json
     ; supports_computer_use = member_bool "supports_computer_use" json
     ; supports_code_execution = member_bool "supports_code_execution" json
-    ; thinking_control_format = member_string_opt "thinking_control_format" json
+    ; thinking_control_format
+    ; preserve_thinking_control_format
     ; reasoning_visibility = member_string_opt "reasoning_visibility" json
     }
 ;;

--- a/lib/llm_provider/capability_manifest.mli
+++ b/lib/llm_provider/capability_manifest.mli
@@ -75,6 +75,11 @@ type entry =
         thinking_object_only / chat_template_kwargs / chat_template_token /
         reasoning_effort / enable_thinking); applied in
         {!Capabilities.apply_manifest_entry}. *)
+  ; preserve_thinking_control_format : string option
+    (** Canonical historical reasoning preservation wire format (none /
+        thinking_object_keep_all / chat_template_kwargs_preserve_thinking /
+        top_level_preserve_thinking / always_preserved); applied in
+        {!Capabilities.apply_manifest_entry}. *)
   ; reasoning_visibility : string option
     (** Optional parsed reasoning visibility override (default /
         provider_hidden / visible_channel / visible_text). *)

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -28,6 +28,7 @@ type model_entry =
   ; supports_computer_use : bool option
   ; supports_code_execution : bool option
   ; thinking_control_format : string option
+  ; preserve_thinking_control_format : string option
   ; reasoning_visibility : string option
   ; input_per_million : float option
   ; output_per_million : float option
@@ -104,6 +105,8 @@ let parse_entry entry_toml =
       ; supports_computer_use = find_bool_opt entry_toml [ "supports_computer_use" ]
       ; supports_code_execution = find_bool_opt entry_toml [ "supports_code_execution" ]
       ; thinking_control_format = find_string_opt entry_toml [ "thinking_control_format" ]
+      ; preserve_thinking_control_format =
+          find_string_opt entry_toml [ "preserve_thinking_control_format" ]
       ; reasoning_visibility = find_string_opt entry_toml [ "reasoning_visibility" ]
       ; input_per_million = find_float_opt entry_toml [ "input_per_million" ]
       ; output_per_million = find_float_opt entry_toml [ "output_per_million" ]

--- a/lib/llm_provider/model_catalog.mli
+++ b/lib/llm_provider/model_catalog.mli
@@ -31,6 +31,7 @@ type model_entry =
   ; supports_computer_use : bool option
   ; supports_code_execution : bool option
   ; thinking_control_format : string option
+  ; preserve_thinking_control_format : string option
   ; reasoning_visibility : string option
   ; input_per_million : float option
   ; output_per_million : float option

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -217,6 +217,27 @@ let parse_thinking_control_format = function
             other))
 ;;
 
+let parse_preserve_thinking_control_format = function
+  | None -> Ok None
+  | Some raw ->
+    let trimmed = String.lowercase_ascii (String.trim raw) in
+    (match trimmed with
+     | "" -> Ok None
+     | "none" -> Ok (Some Capabilities.No_preserve_thinking_control)
+     | "thinking_object_keep_all" -> Ok (Some Capabilities.Thinking_object_keep_all)
+     | "chat_template_kwargs_preserve_thinking" ->
+       Ok (Some Capabilities.Chat_template_kwargs_preserve_thinking)
+     | "top_level_preserve_thinking" -> Ok (Some Capabilities.Top_level_preserve_thinking)
+     | "always_preserved" -> Ok (Some Capabilities.Always_preserved_thinking)
+     | other ->
+       Error
+         (Printf.sprintf
+            "unknown preserve_thinking_control_format %S (canonical: none, \
+             thinking_object_keep_all, chat_template_kwargs_preserve_thinking, \
+             top_level_preserve_thinking, always_preserved)"
+            other))
+;;
+
 let parse_reasoning_visibility = function
   | None -> Ok None
   | Some raw ->
@@ -279,6 +300,10 @@ let parse_capabilities provider_json =
   let* base = capability_base provider_json in
   let* thinking_control_format =
     parse_thinking_control_format (member_string "thinking_control_format" cap_json)
+  in
+  let* preserve_thinking_control_format =
+    parse_preserve_thinking_control_format
+      (member_string "preserve_thinking_control_format" cap_json)
   in
   let* reasoning_visibility =
     parse_reasoning_visibility (member_string "reasoning_visibility" cap_json)
@@ -458,6 +483,12 @@ let parse_capabilities provider_json =
     match thinking_control_format with
     | None -> caps
     | Some thinking_control_format -> { caps with Capabilities.thinking_control_format }
+  in
+  let caps =
+    match preserve_thinking_control_format with
+    | None -> caps
+    | Some preserve_thinking_control_format ->
+      { caps with Capabilities.preserve_thinking_control_format }
   in
   let caps =
     match reasoning_visibility with

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -65,10 +65,11 @@ type t =
   ; system_prompt : string option
   ; enable_thinking : bool option
   ; preserve_thinking : bool option
-    (** Preserve Qwen3.6 thinking traces across historical messages when
-        the provider supports it. Self-hosted OpenAI-compatible endpoints
-        use [chat_template_kwargs.preserve_thinking]; DashScope uses a
-        top-level [preserve_thinking]. Ignored by other wire formats.
+    (** Request historical reasoning preservation when the selected provider
+        exposes a preserve toggle. The concrete wire field is selected by
+        [Capabilities.preserve_thinking_control_format]: chat-template kwargs,
+        top-level [preserve_thinking], [thinking.keep], or no request field for
+        always-preserved models.
         @since 0.205.12 *)
   ; thinking_budget : int option
   ; clear_thinking : bool option

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -41,9 +41,15 @@ type streaming_reasoning =
   | Delta_field of string
   | Template_parser
 
+type thinking_object_only_control =
+  { enabled : bool option
+  ; keep_all : bool
+  }
+
 type t =
   { toggle_default : toggle_default
   ; toggle_wire : toggle_wire
+  ; preserve_wire : Capabilities.preserve_thinking_control_format
   ; effort_alias_policy : effort_alias_policy
   ; sampling_policy : sampling_policy
   ; visibility : reasoning_visibility
@@ -54,6 +60,7 @@ type t =
 let default =
   { toggle_default = Provider_default
   ; toggle_wire = No_toggle
+  ; preserve_wire = No_preserve_thinking_control
   ; effort_alias_policy = Preserve_effort
   ; sampling_policy = Sampling_supported
   ; visibility = Provider_hidden
@@ -67,14 +74,24 @@ let deepseek_ignored_sampling_params =
 ;;
 
 let base_of_capabilities (caps : Capabilities.capabilities) =
+  let preserve_wire = caps.preserve_thinking_control_format in
   match caps.thinking_control_format with
   | No_thinking_control ->
-    if caps.supports_reasoning
-    then { default with visibility = Provider_hidden }
-    else default
+    let dialect =
+      if caps.supports_reasoning
+      then { default with visibility = Provider_hidden; preserve_wire }
+      else { default with preserve_wire }
+    in
+    (match preserve_wire with
+     | Always_preserved_thinking -> { dialect with replay_policy = Preserve_always }
+     | No_preserve_thinking_control
+     | Thinking_object_keep_all
+     | Chat_template_kwargs_preserve_thinking
+     | Top_level_preserve_thinking -> dialect)
   | Thinking_object ->
     { toggle_default = Enabled
     ; toggle_wire = Thinking_object { includes_reasoning_effort = true }
+    ; preserve_wire
     ; effort_alias_policy = Deepseek_high_or_max
     ; sampling_policy = Ignored_when_thinking deepseek_ignored_sampling_params
     ; visibility = Side_channel "reasoning_content"
@@ -85,30 +102,35 @@ let base_of_capabilities (caps : Capabilities.capabilities) =
     { default with
       toggle_default = Provider_default
     ; toggle_wire = Thinking_object_only
+    ; preserve_wire
     ; visibility = Side_channel "reasoning_content"
     ; streaming = Delta_field "reasoning_content"
     }
   | Chat_template_kwargs ->
     { default with
       toggle_wire = Chat_template_kwargs
+    ; preserve_wire
     ; visibility = Visible_channel
     ; streaming = Template_parser
     }
   | Chat_template_token ->
     { default with
       toggle_wire = Chat_template_token
+    ; preserve_wire
     ; visibility = Visible_channel
     ; streaming = Template_parser
     }
   | Reasoning_effort ->
     { default with
       toggle_wire = Reasoning_effort
+    ; preserve_wire
     ; visibility = Side_channel "reasoning"
     ; streaming = Delta_field "reasoning"
     }
   | Enable_thinking ->
     { default with
       toggle_wire = Enable_thinking
+    ; preserve_wire
     ; visibility = Side_channel "reasoning_content"
     ; streaming = Delta_field "reasoning_content"
     }
@@ -125,16 +147,50 @@ let apply_visibility_override caps dialect =
 let of_capabilities caps = base_of_capabilities caps |> apply_visibility_override caps
 
 let with_preserve_thinking ~preserve_thinking dialect =
-  match preserve_thinking, dialect.toggle_wire with
-  | Some true, (Chat_template_kwargs | Enable_thinking) ->
-    { dialect with replay_policy = Preserve_always }
-  | _ -> dialect
+  match dialect.preserve_wire, preserve_thinking with
+  | Always_preserved_thinking, _ -> { dialect with replay_policy = Preserve_always }
+  | ( ( Thinking_object_keep_all
+      | Chat_template_kwargs_preserve_thinking
+      | Top_level_preserve_thinking )
+    , Some true ) -> { dialect with replay_policy = Preserve_always }
+  | ( ( No_preserve_thinking_control
+      | Thinking_object_keep_all
+      | Chat_template_kwargs_preserve_thinking
+      | Top_level_preserve_thinking )
+    , _ ) -> dialect
 ;;
 
 let thinking_enabled ~enable_thinking =
   match enable_thinking with
   | Some false -> false
   | Some true | None -> true
+;;
+
+let thinking_object_only_control dialect ~enable_thinking ~preserve_thinking =
+  let keep_all =
+    match dialect.preserve_wire, preserve_thinking, enable_thinking with
+    | Thinking_object_keep_all, Some true, (None | Some true) -> true
+    | _ -> false
+  in
+  let enabled =
+    match enable_thinking with
+    | Some _ as enabled -> enabled
+    | None when keep_all -> Some true
+    | None -> None
+  in
+  { enabled; keep_all }
+;;
+
+let chat_template_kwargs_preserve_field dialect ~preserve_thinking =
+  match dialect.preserve_wire, preserve_thinking with
+  | Chat_template_kwargs_preserve_thinking, Some preserve -> Some preserve
+  | _ -> None
+;;
+
+let top_level_preserve_field dialect ~preserve_thinking =
+  match dialect.preserve_wire, preserve_thinking with
+  | Top_level_preserve_thinking, Some preserve -> Some preserve
+  | _ -> None
 ;;
 
 let ignores_sampling_param dialect ~enable_thinking field =

--- a/lib/llm_provider/reasoning_dialect.mli
+++ b/lib/llm_provider/reasoning_dialect.mli
@@ -51,9 +51,15 @@ type streaming_reasoning =
   | Delta_field of string
   | Template_parser
 
+type thinking_object_only_control =
+  { enabled : bool option
+  ; keep_all : bool
+  }
+
 type t =
   { toggle_default : toggle_default
   ; toggle_wire : toggle_wire
+  ; preserve_wire : Capabilities.preserve_thinking_control_format
   ; effort_alias_policy : effort_alias_policy
   ; sampling_policy : sampling_policy
   ; visibility : reasoning_visibility
@@ -66,6 +72,19 @@ val of_capabilities : Capabilities.capabilities -> t
 val for_provider_config : Provider_config.t -> t
 val with_preserve_thinking : preserve_thinking:bool option -> t -> t
 val thinking_enabled : enable_thinking:bool option -> bool
+
+val thinking_object_only_control
+  :  t
+  -> enable_thinking:bool option
+  -> preserve_thinking:bool option
+  -> thinking_object_only_control
+
+val chat_template_kwargs_preserve_field
+  :  t
+  -> preserve_thinking:bool option
+  -> bool option
+
+val top_level_preserve_field : t -> preserve_thinking:bool option -> bool option
 val ignores_sampling_param : t -> enable_thinking:bool option -> string -> bool
 
 (** Normalize a typed caller effort for a provider dialect. *)

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -62,6 +62,14 @@ type thinking_control_format = Llm_provider.Capabilities.thinking_control_format
   | Reasoning_effort (** @since 0.195.0 *)
   | Enable_thinking (** @since 0.196.11 *)
 
+type preserve_thinking_control_format =
+      Llm_provider.Capabilities.preserve_thinking_control_format =
+  | No_preserve_thinking_control
+  | Thinking_object_keep_all
+  | Chat_template_kwargs_preserve_thinking
+  | Top_level_preserve_thinking
+  | Always_preserved_thinking
+
 type reasoning_visibility_override =
       Llm_provider.Capabilities.reasoning_visibility_override =
   | Default_reasoning_visibility
@@ -81,6 +89,7 @@ type capabilities =
   ; supports_extended_thinking : bool
   ; supports_reasoning_budget : bool
   ; thinking_control_format : thinking_control_format
+  ; preserve_thinking_control_format : preserve_thinking_control_format
   ; reasoning_visibility_override : reasoning_visibility_override
   ; supports_response_format_json : bool
   ; supports_structured_output : bool

--- a/lib/provider_runtime_binding.ml
+++ b/lib/provider_runtime_binding.ml
@@ -85,6 +85,7 @@ let public_capabilities (caps : Llm_provider.Capabilities.capabilities)
   ; supports_extended_thinking = caps.supports_extended_thinking
   ; supports_reasoning_budget = caps.supports_reasoning_budget
   ; thinking_control_format = caps.thinking_control_format
+  ; preserve_thinking_control_format = caps.preserve_thinking_control_format
   ; reasoning_visibility_override = caps.reasoning_visibility_override
   ; supports_response_format_json = caps.supports_response_format_json
   ; supports_structured_output = caps.supports_structured_output

--- a/models.toml
+++ b/models.toml
@@ -1531,6 +1531,16 @@ max_context_tokens = 256000
 input_per_million = 0.0
 output_per_million = 0.0
 
+[[models]]
+id_prefix = "kimi-k2.7-code"
+base = "kimi"
+max_context_tokens = 256000
+supports_reasoning_budget = false
+thinking_control_format = "none"
+preserve_thinking_control_format = "always_preserved"
+input_per_million = 0.0
+output_per_million = 0.0
+
 # Bare kimi-k2.* ids are native Kimi. Ollama Cloud's overlapping Kimi ids are
 # represented only by provider-qualified ollama_cloud/kimi-* rows so a bare
 # native route does not silently inherit Ollama Cloud wire semantics.
@@ -1646,6 +1656,7 @@ supports_reasoning = true
 supports_extended_thinking = true
 supports_reasoning_budget = true
 thinking_control_format = "chat_template_kwargs"
+preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
 supports_native_streaming = true
 supports_top_k = true
 supports_min_p = true
@@ -1668,6 +1679,7 @@ supports_reasoning = true
 supports_extended_thinking = true
 supports_reasoning_budget = true
 thinking_control_format = "chat_template_kwargs"
+preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
 supports_native_streaming = true
 supports_top_k = true
 supports_min_p = true
@@ -1686,6 +1698,7 @@ supports_parallel_tool_calls = true
 supports_reasoning = true
 supports_extended_thinking = true
 thinking_control_format = "chat_template_kwargs"
+preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
 supports_response_format_json = true
 supports_structured_output = true
 supports_native_streaming = true
@@ -1703,6 +1716,7 @@ supports_parallel_tool_calls = true
 supports_reasoning = true
 supports_extended_thinking = true
 thinking_control_format = "chat_template_kwargs"
+preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
 supports_response_format_json = true
 supports_structured_output = true
 supports_native_streaming = true
@@ -1720,6 +1734,7 @@ supports_parallel_tool_calls = true
 supports_reasoning = true
 supports_extended_thinking = true
 thinking_control_format = "chat_template_kwargs"
+preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
 supports_response_format_json = true
 supports_structured_output = true
 supports_native_streaming = true

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -3,6 +3,12 @@
 open Alcotest
 open Agent_sdk
 
+let member_absent json name =
+  match Yojson.Safe.Util.member name json with
+  | `Null -> true
+  | `Assoc _ | `List _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `String _ -> false
+;;
+
 (* Helper: compare content_block via show string *)
 let check_block msg expected actual =
   check string msg (Types.show_content_block expected) (Types.show_content_block actual)
@@ -550,6 +556,46 @@ let test_build_openai_body_qwen_preserve_replays_reasoning () =
     string
     "reasoning_content replayed"
     "keep this"
+    (assistant |> member "reasoning_content" |> to_string)
+;;
+
+let test_build_openai_body_kimi_latest_omits_thinking_param () =
+  let state = make_state ~model:"kimi-k2.7-code" ~preserve_thinking:true () in
+  let json =
+    Api.build_openai_body ~config:state ~messages:[] () |> Yojson.Safe.from_string
+  in
+  check bool "thinking absent" true (member_absent json "thinking");
+  check
+    bool
+    "chat_template_kwargs absent"
+    true
+    (member_absent json "chat_template_kwargs");
+  check bool "preserve_thinking absent" true (member_absent json "preserve_thinking")
+;;
+
+let test_build_openai_body_kimi_latest_replays_reasoning () =
+  let state = make_state ~model:"kimi-k2.7-code" ~preserve_thinking:false () in
+  let messages =
+    [ { Types.role = Types.Assistant
+      ; content =
+          [ Types.Thinking { thinking_type = "reasoning"; content = "keep latest" }
+          ; Types.Text "answer"
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let json =
+    Api.build_openai_body ~config:state ~messages () |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  let assistant = json |> member "messages" |> index 1 in
+  check
+    string
+    "reasoning_content replayed"
+    "keep latest"
     (assistant |> member "reasoning_content" |> to_string)
 ;;
 
@@ -1781,6 +1827,14 @@ let () =
             "qwen preserve replays reasoning"
             `Quick
             test_build_openai_body_qwen_preserve_replays_reasoning
+        ; test_case
+            "kimi latest omits thinking param"
+            `Quick
+            test_build_openai_body_kimi_latest_omits_thinking_param
+        ; test_case
+            "kimi latest replays reasoning"
+            `Quick
+            test_build_openai_body_kimi_latest_replays_reasoning
         ; test_case
             "deepseek dialect controls"
             `Quick

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -249,22 +249,27 @@ let test_lookup_kimi_k2_native_cloud_suffix () =
     | Modality.Preserve_input_order -> ()
     | Modality.Visual_first -> fail (label ^ " should preserve input order")
   in
-  match Capabilities.for_model_id "kimi-k2.6:cloud" with
+  match Capabilities.for_model_id "kimi-k2.7-code" with
   | Some native ->
-    (* Kimi K2.6: 256K context per platform.kimi.ai official docs (2026-05-30
-       verified). The :cloud suffix is a legacy native Kimi route, not the
-       Ollama Cloud row named kimi-k2.6. *)
+    (* Kimi built-in semantics track the latest K2 code model. Older K2
+       variants can still be expressed by external catalog entries through the
+       separate preserve_thinking_control_format axis. *)
     check (option int) "native Kimi context 256K" (Some 256_000) native.max_context_tokens;
     check (option int) "native Kimi output 32K" (Some 32_768) native.max_output_tokens;
     check bool "native Kimi tools" true native.supports_tools;
     check bool "native Kimi reasoning" true native.supports_reasoning;
     check_thinking_control
-      "native Kimi thinking object only"
-      Capabilities.Thinking_object_only
+      "native latest Kimi has no thinking request toggle"
+      Capabilities.No_thinking_control
       native.thinking_control_format;
-    check_preserve_order "native Kimi cloud suffix" native;
+    check
+      bool
+      "native latest Kimi always preserves reasoning"
+      true
+      (native.preserve_thinking_control_format = Capabilities.Always_preserved_thinking);
+    check_preserve_order "native Kimi latest" native;
     check bool "native Kimi code execution" true native.supports_code_execution;
-    (match Capabilities.for_model_id "kimi-k2.6" with
+    (match Capabilities.for_model_id "kimi-k2" with
      | Some bare_native ->
        check
          (option int)
@@ -279,9 +284,15 @@ let test_lookup_kimi_k2_native_cloud_suffix () =
        check bool "bare native Kimi tools" true bare_native.supports_tools;
        check bool "bare native Kimi reasoning" true bare_native.supports_reasoning;
        check_thinking_control
-         "bare native Kimi thinking object only"
-         Capabilities.Thinking_object_only
+         "bare native latest Kimi has no thinking request toggle"
+         Capabilities.No_thinking_control
          bare_native.thinking_control_format;
+       check
+         bool
+         "bare native latest Kimi always preserves reasoning"
+         true
+         (bare_native.preserve_thinking_control_format
+          = Capabilities.Always_preserved_thinking);
        check_preserve_order "bare native Kimi" bare_native;
        check
          bool
@@ -292,7 +303,7 @@ let test_lookup_kimi_k2_native_cloud_suffix () =
     (match
        Capabilities.for_provider_model_id
          ~provider_label:"ollama_cloud"
-         ~model_id:"kimi-k2.6"
+         ~model_id:"kimi-k2.7-code"
      with
      | Some cloud ->
        check
@@ -532,19 +543,26 @@ let test_ollama_cloud_provider_qualified_preserves_shared_bare_family () =
     Reasoning_effort
     cloud_glm.thinking_control_format;
   let bare_kimi =
-    match for_model_id "kimi-k2.6" with
+    match for_model_id "kimi-k2.7-code" with
     | Some c -> c
-    | None -> fail "bare kimi-k2.6 should resolve"
+    | None -> fail "bare kimi-k2.7-code should resolve"
   in
   let cloud_kimi =
-    match for_provider_model_id ~provider_label:"ollama_cloud" ~model_id:"kimi-k2.6" with
+    match
+      for_provider_model_id ~provider_label:"ollama_cloud" ~model_id:"kimi-k2.7-code"
+    with
     | Some c -> c
-    | None -> fail "ollama_cloud/kimi-k2.6 should resolve"
+    | None -> fail "ollama_cloud/kimi-k2.7-code should resolve"
   in
   check_thinking_control
-    "bare Kimi remains native thinking object"
-    Thinking_object_only
+    "bare latest Kimi has no thinking request toggle"
+    No_thinking_control
     bare_kimi.thinking_control_format;
+  check
+    bool
+    "bare latest Kimi always preserves reasoning"
+    true
+    (bare_kimi.preserve_thinking_control_format = Always_preserved_thinking);
   check_thinking_control
     "cloud Kimi uses Ollama reasoning_effort"
     Reasoning_effort
@@ -783,6 +801,16 @@ let test_manifest_wrong_type_fields_warn_and_ignore () =
   check bool "warned for supports_tools" true (has_warning "supports_tools" "bool")
 ;;
 
+let test_manifest_rejects_unknown_preserve_thinking_control_format () =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"bad-preserve","preserve_thinking_control_format":"memory_palace"}]}|}
+  in
+  match Capability_manifest.of_json json with
+  | Error msg -> check_contains "mentions field" msg "preserve_thinking_control_format"
+  | Ok _ -> Alcotest.fail "unknown preserve_thinking_control_format should reject"
+;;
+
 let test_manifest_intlit_in_range_accepted () =
   (* Yojson.Safe represents large literals as `Intlit s. Build the JSON value
      directly to exercise the Intlit branch deterministically. *)
@@ -928,9 +956,11 @@ let test_openai_compat_reasoning_records_have_explicit_control () =
          check bool (label ^ " supports reasoning") true c.supports_reasoning;
          check
            bool
-           (label ^ " has explicit thinking control")
+           (label ^ " has explicit reasoning control or preserve policy")
            true
-           (c.thinking_control_format <> Capabilities.No_thinking_control))
+           (c.thinking_control_format <> Capabilities.No_thinking_control
+            || c.preserve_thinking_control_format
+               <> Capabilities.No_preserve_thinking_control))
     cases
 ;;
 
@@ -1104,6 +1134,10 @@ let () =
             "wrong-type fields warn and ignore"
             `Quick
             test_manifest_wrong_type_fields_warn_and_ignore
+        ; test_case
+            "unknown preserve_thinking_control_format rejects"
+            `Quick
+            test_manifest_rejects_unknown_preserve_thinking_control_format
         ; test_case
             "intlit in range accepted"
             `Quick

--- a/test/test_provider_catalog_coverage.ml
+++ b/test/test_provider_catalog_coverage.ml
@@ -208,7 +208,10 @@ let test_transport_auth_and_thinking_canonical_matrix () =
             "kind": "openai_compat",
             "transport": "http",
             "auth": {"type": "none"},
-            "capabilities": {"thinking_control_format": "none"}
+            "capabilities": {
+              "thinking_control_format": "none",
+              "preserve_thinking_control_format": "always_preserved"
+            }
           },
           {
             "id": "cli-env",
@@ -261,6 +264,12 @@ let test_transport_auth_and_thinking_canonical_matrix () =
     "none thinking format"
     true
     (http_none.capabilities.thinking_control_format = Capabilities.No_thinking_control);
+  check
+    bool
+    "always preserved format"
+    true
+    (http_none.capabilities.preserve_thinking_control_format
+     = Capabilities.Always_preserved_thinking);
   let cli_env = require_lookup catalog "cli-env" in
   check bool "cli transport" true (cli_env.transport = Provider_catalog.Http);
   check bool "api key auth" true (cli_env.auth = Provider_catalog.Api_key_env "ENV_KEY");

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -652,6 +652,24 @@ let test_catalog_rejects_unknown_thinking_control_format () =
     fail "unknown thinking_control_format should be rejected, not silently coerced"
 ;;
 
+let test_catalog_rejects_unknown_preserve_thinking_control_format () =
+  match
+    Provider_catalog.of_json
+      (Yojson.Safe.from_string
+         {|{
+           "schema_version": 1,
+           "providers": [
+             {"id": "x", "kind": "openai_compat",
+              "capabilities": {"preserve_thinking_control_format": "memory_palace"}}
+           ]
+         }|})
+  with
+  | Error _ -> ()
+  | Ok _ ->
+    fail
+      "unknown preserve_thinking_control_format should be rejected, not silently coerced"
+;;
+
 let test_catalog_accepts_explicit_thinking_control_formats () =
   match
     Provider_catalog.of_json
@@ -666,6 +684,10 @@ let test_catalog_accepts_explicit_thinking_control_formats () =
              {"id": "openai-reasoning", "kind": "openai_compat",
               "capabilities": {"thinking_control_format": "reasoning_effort",
                                "reasoning_visibility": "visible_text"}}
+             ,
+             {"id": "kimi-latest", "kind": "openai_compat",
+              "capabilities": {"thinking_control_format": "none",
+                               "preserve_thinking_control_format": "always_preserved"}}
            ]
          }|})
   with
@@ -692,7 +714,16 @@ let test_catalog_accepts_explicit_thinking_control_formats () =
          true
          (entry.capabilities.reasoning_visibility_override
           = Capabilities.Force_visible_text)
-     | None -> fail "openai-reasoning should exist")
+     | None -> fail "openai-reasoning should exist");
+    (match Provider_catalog.lookup catalog "kimi-latest" with
+     | Some entry ->
+       check
+         bool
+         "kimi-latest always preserved"
+         true
+         (entry.capabilities.preserve_thinking_control_format
+          = Capabilities.Always_preserved_thinking)
+     | None -> fail "kimi-latest should exist")
 ;;
 
 let test_catalog_lookup_first_match_wins () =
@@ -1110,6 +1141,10 @@ let () =
             "rejects unknown thinking_control_format"
             `Quick
             test_catalog_rejects_unknown_thinking_control_format
+        ; test_case
+            "rejects unknown preserve_thinking_control_format"
+            `Quick
+            test_catalog_rejects_unknown_preserve_thinking_control_format
         ; test_case
             "accepts explicit thinking_control_format values"
             `Quick

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -43,6 +43,17 @@ let openai_compat_config ?enable_thinking ?preserve_thinking ?thinking_budget mo
     ()
 ;;
 
+let kimi_config ?enable_thinking ?preserve_thinking ?thinking_budget model_id =
+  PC.make
+    ~kind:Kimi
+    ~model_id
+    ~base_url:"https://api.moonshot.ai/v1"
+    ?enable_thinking
+    ?preserve_thinking
+    ?thinking_budget
+    ()
+;;
+
 let ollama_config ?system_prompt ?enable_thinking model_id =
   PC.make
     ~kind:Ollama
@@ -433,6 +444,78 @@ let test_qwen_preserve_replays_reasoning_content () =
     (assistant |> member "reasoning_content" |> to_string)
 ;;
 
+let keep_all_axis_manifest =
+  {|{"schema_version":1,"models":[{"id_prefix":"keep-all-axis-test","base":"openai_chat","supports_reasoning":true,"supports_extended_thinking":true,"thinking_control_format":"thinking_object_only","preserve_thinking_control_format":"thinking_object_keep_all"}]}|}
+;;
+
+let test_thinking_object_keep_all_axis_uses_keep_all () =
+  with_manifest keep_all_axis_manifest (fun () ->
+    let config = openai_compat_config ~preserve_thinking:true "keep-all-axis-test" in
+    let json = BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
+    let thinking = json |> member "thinking" in
+    check string "thinking type" "enabled" (thinking |> member "type" |> to_string);
+    check string "thinking keep" "all" (thinking |> member "keep" |> to_string);
+    check_member_absent "chat_template_kwargs" json;
+    check_member_absent "preserve_thinking" json)
+;;
+
+let test_thinking_object_keep_all_axis_replays_reasoning () =
+  with_manifest keep_all_axis_manifest (fun () ->
+    let config = openai_compat_config ~preserve_thinking:true "keep-all-axis-test" in
+    let dialect = RD.for_provider_config config in
+    check
+      string
+      "toggle wire"
+      "thinking_object_only"
+      (RD.toggle_wire_to_string dialect.toggle_wire);
+    check
+      string
+      "replay policy"
+      "preserve_always"
+      (RD.replay_policy_to_string dialect.replay_policy);
+    check
+      bool
+      "no tool-call replay requirement"
+      false
+      (RD.requires_reasoning_replay_on_tool_call dialect);
+    let json =
+      BOR.build_request ~config ~messages:[ assistant_with_reasoning () ] ()
+      |> json_of_body
+    in
+    let assistant = json |> member "messages" |> index 0 in
+    check
+      string
+      "reasoning_content"
+      "plain thought"
+      (assistant |> member "reasoning_content" |> to_string))
+;;
+
+let test_kimi_latest_always_preserved_omits_thinking_param () =
+  let config = kimi_config "kimi-k2.7-code" in
+  let dialect = RD.for_provider_config config in
+  check string "toggle wire" "no_toggle" (RD.toggle_wire_to_string dialect.toggle_wire);
+  check
+    string
+    "replay policy"
+    "preserve_always"
+    (RD.replay_policy_to_string dialect.replay_policy);
+  let user_json =
+    BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body
+  in
+  check_member_absent "thinking" user_json;
+  check_member_absent "chat_template_kwargs" user_json;
+  check_member_absent "preserve_thinking" user_json;
+  let reasoning_json =
+    BOR.build_request ~config ~messages:[ assistant_with_reasoning () ] () |> json_of_body
+  in
+  let assistant = reasoning_json |> member "messages" |> index 0 in
+  check
+    string
+    "reasoning_content"
+    "plain thought"
+    (assistant |> member "reasoning_content" |> to_string)
+;;
+
 let test_ollama_qwen_uses_native_think_bool () =
   let config = ollama_config ~enable_thinking:true "qwen3:32b" in
   let json = BOL.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
@@ -694,6 +777,18 @@ let () =
             "qwen preserve replays reasoning_content"
             `Quick
             test_qwen_preserve_replays_reasoning_content
+        ; test_case
+            "thinking_object_keep_all axis uses thinking keep all"
+            `Quick
+            test_thinking_object_keep_all_axis_uses_keep_all
+        ; test_case
+            "thinking_object_keep_all axis replays reasoning"
+            `Quick
+            test_thinking_object_keep_all_axis_replays_reasoning
+        ; test_case
+            "kimi latest always-preserved omits thinking param"
+            `Quick
+            test_kimi_latest_always_preserved_omits_thinking_param
         ] )
     ; ( "ollama"
       , [ test_case


### PR DESCRIPTION
## Summary
- split historical reasoning preserve/replay control from thinking enable/depth wire control
- add typed preserve_thinking_control_format across capabilities, manifest, provider catalog, model catalog, and public provider capabilities
- set latest Kimi K2 code semantics to no request-time thinking parameter with always-preserved reasoning replay
- route request builders through Reasoning_dialect helpers so API and backend serialization stay aligned
- document manifest/provider catalog schema and reject unknown preserve enum values instead of silently falling back

## Verification
- scripts/dune-local.sh build @fmt test/test_thinking_control_dialects.exe test/test_api.exe test/test_capabilities.exe test/test_provider_registry.exe test/test_provider_catalog_coverage.exe
- ./_build/default/test/test_thinking_control_dialects.exe
- ./_build/default/test/test_api.exe
- ./_build/default/test/test_capabilities.exe
- ./_build/default/test/test_provider_registry.exe
- ./_build/default/test/test_provider_catalog_coverage.exe