### PR TITLE
Tighten reasoning preserve dialect matches

### DIFF
--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -1332,11 +1332,11 @@ let%test "build_request emits reasoning_effort for Openai reasoning models" =
   && json |> member "enable_thinking" = `Null
 ;;
 
-let%test "build_request emits thinking object only for native Kimi K2" =
+let%test "build_request omits thinking request fields for latest native Kimi" =
   let config =
     Provider_config.make
       ~kind:Kimi
-      ~model_id:"kimi-k2"
+      ~model_id:"kimi-k2.7-code"
       ~base_url:"https://api.moonshot.ai/v1"
       ~enable_thinking:false
       ()
@@ -1344,7 +1344,7 @@ let%test "build_request emits thinking object only for native Kimi K2" =
   let body = build_request ~config ~messages:[] () in
   let json = Yojson.Safe.from_string body in
   let open Yojson.Safe.Util in
-  json |> member "thinking" |> member "type" |> to_string = "disabled"
+  json |> member "thinking" = `Null
   && json |> member "reasoning_effort" = `Null
   && json |> member "chat_template_kwargs" = `Null
 ;;

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -168,9 +168,15 @@ let thinking_enabled ~enable_thinking =
 
 let thinking_object_only_control dialect ~enable_thinking ~preserve_thinking =
   let keep_all =
-    match dialect.preserve_wire, preserve_thinking, enable_thinking with
-    | Thinking_object_keep_all, Some true, (None | Some true) -> true
-    | _ -> false
+    match dialect.preserve_wire with
+    | Thinking_object_keep_all ->
+      (match preserve_thinking, enable_thinking with
+       | Some true, (None | Some true) -> true
+       | Some true, Some false | Some false, _ | None, _ -> false)
+    | No_preserve_thinking_control
+    | Chat_template_kwargs_preserve_thinking
+    | Top_level_preserve_thinking
+    | Always_preserved_thinking -> false
   in
   let enabled =
     match enable_thinking with
@@ -182,15 +188,21 @@ let thinking_object_only_control dialect ~enable_thinking ~preserve_thinking =
 ;;
 
 let chat_template_kwargs_preserve_field dialect ~preserve_thinking =
-  match dialect.preserve_wire, preserve_thinking with
-  | Chat_template_kwargs_preserve_thinking, Some preserve -> Some preserve
-  | _ -> None
+  match dialect.preserve_wire with
+  | Chat_template_kwargs_preserve_thinking -> preserve_thinking
+  | No_preserve_thinking_control
+  | Thinking_object_keep_all
+  | Top_level_preserve_thinking
+  | Always_preserved_thinking -> None
 ;;
 
 let top_level_preserve_field dialect ~preserve_thinking =
-  match dialect.preserve_wire, preserve_thinking with
-  | Top_level_preserve_thinking, Some preserve -> Some preserve
-  | _ -> None
+  match dialect.preserve_wire with
+  | Top_level_preserve_thinking -> preserve_thinking
+  | No_preserve_thinking_control
+  | Thinking_object_keep_all
+  | Chat_template_kwargs_preserve_thinking
+  | Always_preserved_thinking -> None
 ;;
 
 let ignores_sampling_param dialect ~enable_thinking field =


### PR DESCRIPTION
## Summary
- replace permissive catch-all preserve dialect matches with exhaustive preserve_wire handling
- keep the post-#2228 reasoning preserve behavior unchanged while holding hardening ratchet at baseline

## Verification
- scripts/hardening-ratchet.sh --check
- git diff --check
- scripts/dune-local.sh build @fmt test/test_thinking_control_dialects.exe
- ./_build/default/test/test_thinking_control_dialects.exe