### PR TITLE
[codex] Fix provider registry boundary SSOT

### DIFF
--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -51,12 +51,7 @@ let llm_endpoints_env_var = "LLM_ENDPOINTS"
 let ollama_host_env_var = "OLLAMA_HOST"
 let default_ollama_endpoint = "http://127.0.0.1:11434"
 let env_get_non_empty ~getenv name = getenv name |> Cli_common_env.trim_non_empty_opt
-
-let default_endpoint =
-  match Cli_common_env.get local_llm_url_env_var with
-  | Some v -> v
-  | None -> Constants.Endpoints.default_url
-;;
+let default_endpoint = Constants.Endpoints.default_url
 
 let resolve_default_endpoint ?(getenv = fun name -> Cli_common_env.get name) () =
   match env_get_non_empty ~getenv local_llm_url_env_var with
@@ -64,11 +59,7 @@ let resolve_default_endpoint ?(getenv = fun name -> Cli_common_env.get name) () 
   | None -> Constants.Endpoints.default_url
 ;;
 
-let ollama_endpoint =
-  match Cli_common_env.get ollama_host_env_var with
-  | Some url -> url
-  | None -> default_ollama_endpoint
-;;
+let ollama_endpoint = default_ollama_endpoint
 
 let resolve_ollama_endpoint ?(getenv = fun name -> Cli_common_env.get name) () =
   match env_get_non_empty ~getenv ollama_host_env_var with

--- a/lib/llm_provider/discovery.mli
+++ b/lib/llm_provider/discovery.mli
@@ -65,10 +65,10 @@ val ollama_host_env_var : string
 (** Compile-time fallback for {!resolve_ollama_endpoint}. *)
 val default_ollama_endpoint : string
 
-(** Canonical local LLM endpoint default.
-    Reads [OAS_LOCAL_LLM_URL], falls back to
-    {!Constants.Endpoints.default_url}.
-    All local endpoint defaults in llm_provider reference this value. *)
+(** Canonical local LLM endpoint fallback.
+    This is intentionally not an environment snapshot. Use
+    {!resolve_default_endpoint} when runtime configuration should read
+    [OAS_LOCAL_LLM_URL]. *)
 val default_endpoint : string
 
 (** Call-time resolver for the canonical local LLM endpoint.
@@ -79,8 +79,9 @@ val default_endpoint : string
     process environment. *)
 val resolve_default_endpoint : ?getenv:(string -> string option) -> unit -> string
 
-(** Ollama endpoint.  Reads OLLAMA_HOST env var,
-    falls back to ["http://127.0.0.1:11434"]. *)
+(** Ollama endpoint fallback. This is intentionally not an environment
+    snapshot. Use {!resolve_ollama_endpoint} when runtime configuration should
+    read [OLLAMA_HOST]. *)
 val ollama_endpoint : string
 
 (** Call-time resolver for the Ollama endpoint.

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -153,15 +153,11 @@ let overlay_provider_catalog t =
   | Some entries -> List.iter (register_catalog_entry t) entries
 ;;
 
-(** Initial endpoints from LLM_ENDPOINTS env var.
-    Falls back to [[Discovery.resolve_default_endpoint ()]] when the variable is
-    unset or has no non-empty entries (SSOT: see
-    {!Discovery.parse_llm_endpoints_env}). *)
-let initial_llama_endpoints =
-  match Discovery.parse_llm_endpoints_env () with
-  | [] -> [ Discovery.resolve_default_endpoint () ]
-  | urls -> urls
-;;
+(** Initial endpoint snapshot.
+    Keep module initialization free of environment reads. Runtime callers that
+    need env-aware values use [default_llama_endpoint] or
+    [refresh_llama_endpoints]. *)
+let initial_llama_endpoints = [ Discovery.default_endpoint ]
 
 (** Mutable endpoint list, protected by atomic snapshot swap.
     Updated by [refresh_llama_endpoints]. *)
@@ -461,7 +457,7 @@ let default () =
     "ollama_cloud"
     ollama_cloud_defaults
     ~max_context:262_144
-    Capabilities.ollama_capabilities;
+    Capabilities.ollama_cloud_capabilities;
   overlay_provider_catalog t;
   t
 ;;

--- a/lib/llm_provider/provider_registry.mli
+++ b/lib/llm_provider/provider_registry.mli
@@ -74,8 +74,10 @@ val default : unit -> t
     config does not match a known registry entry exactly. *)
 val provider_name_of_config : Provider_config.t -> string
 
-(** Initial LLM_ENDPOINTS URLs parsed from the environment at module load.
-    For current active endpoints, use [active_llama_endpoints]. *)
+(** Initial fallback endpoint snapshot. This is intentionally not parsed from
+    [LLM_ENDPOINTS] at module load. For current env-aware active endpoints, use
+    [active_llama_endpoints] after [refresh_llama_endpoints], or
+    [default_llama_endpoint] for call-time default resolution. *)
 val llama_all_endpoints : string list
 
 (** Pick the next llama endpoint via round-robin.

--- a/test/test_discovery.ml
+++ b/test/test_discovery.ml
@@ -91,6 +91,27 @@ let test_resolve_ollama_endpoint_reads_getenv () =
        ())
 ;;
 
+let test_fallback_endpoint_constants_ignore_env () =
+  with_env Discovery.local_llm_url_env_var "http://127.0.0.1:19101" (fun () ->
+    Alcotest.(check string)
+      "default_endpoint remains fallback constant"
+      Constants.Endpoints.default_url
+      Discovery.default_endpoint;
+    Alcotest.(check string)
+      "resolver reads local url"
+      "http://127.0.0.1:19101"
+      (Discovery.resolve_default_endpoint ()));
+  with_env Discovery.ollama_host_env_var "http://127.0.0.1:19102" (fun () ->
+    Alcotest.(check string)
+      "ollama_endpoint remains fallback constant"
+      Discovery.default_ollama_endpoint
+      Discovery.ollama_endpoint;
+    Alcotest.(check string)
+      "resolver reads ollama host"
+      "http://127.0.0.1:19102"
+      (Discovery.resolve_ollama_endpoint ()))
+;;
+
 let test_endpoints_from_env_default () =
   let getenv = test_getenv [] in
   let result = Discovery.endpoints_from_env ~getenv () in
@@ -497,6 +518,10 @@ let () =
             "resolve ollama endpoint from getenv"
             `Quick
             test_resolve_ollama_endpoint_reads_getenv
+        ; Alcotest.test_case
+            "fallback endpoint constants ignore env"
+            `Quick
+            test_fallback_endpoint_constants_ignore_env
         ; Alcotest.test_case "default" `Quick test_endpoints_from_env_default
         ; Alcotest.test_case "custom" `Quick test_endpoints_from_env_custom
         ; Alcotest.test_case

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -280,7 +280,12 @@ let test_default_ollama_cloud_entry () =
     check bool "kind is Ollama" true (e.defaults.kind = Provider_config.Ollama);
     check string "base_url" "https://ollama.com" e.defaults.base_url;
     check string "api_key_env" "OLLAMA_CLOUD_API_KEY" e.defaults.api_key_env;
-    check string "request_path" "/api/chat" e.defaults.request_path
+    check string "request_path" "/api/chat" e.defaults.request_path;
+    check
+      bool
+      "ollama_cloud uses ollama_cloud_capabilities"
+      true
+      (e.capabilities.reasoning_visibility_override = Capabilities.Force_visible_text)
   | None -> fail "ollama_cloud should exist"
 ;;
 


### PR DESCRIPTION
## Summary

- Register `ollama_cloud` with `ollama_cloud_capabilities` instead of reusing the base Ollama capability record.
- Make `Discovery.default_endpoint` and `Discovery.ollama_endpoint` fallback constants rather than module-load environment snapshots.
- Keep runtime environment reads in the explicit `resolve_*` call-time APIs and add regression coverage.

## Why

The registry had a provider/capability SSOT mismatch: `ollama_cloud_capabilities` existed but the default registry used `ollama_capabilities`. The endpoint constants also looked like defaults while capturing environment at module load, which makes runtime/test configuration harder to reason about.

## Validation

- `ocamlformat --check lib/llm_provider/discovery.ml lib/llm_provider/discovery.mli lib/llm_provider/provider_registry.ml lib/llm_provider/provider_registry.mli test/test_discovery.ml test/test_provider_registry.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_discovery.exe test/test_provider_registry.exe`
- `./_build/default/test/test_discovery.exe`
- `./_build/default/test/test_provider_registry.exe`