### PR TITLE
fix(tools): input fail-closed + deterministic recovery ids (RFC-OAS-029 S8.1/S4.3/S10.1)

### DIFF
--- a/lib/agent_tool.ml
+++ b/lib/agent_tool.ml
@@ -148,28 +148,23 @@ let prompt_of_input = function
 
 let make_handler config : Tool.tool_handler =
   fun (input : Yojson.Safe.t) ->
-  let prompt =
-    match input with
-    | `Assoc fields ->
-      (match List.assoc_opt "prompt" fields with
-       | Some (`String s) -> s
-       | _ ->
-         (* Fallback: serialize entire input as prompt *)
-         Yojson.Safe.to_string input)
-    | `String s -> s
-    | _ -> Yojson.Safe.to_string input
-  in
-  match config.runner prompt with
-  | Ok response ->
-    let text = text_of_response response in
-    let output =
-      match config.output_summarizer with
-      | Some summarize -> summarize text
-      | None -> text
-    in
-    Ok { content = output; _meta = None }
-  | Error e ->
-    Error { message = Error.to_string e; recoverable = false; error_class = None }
+  (* RFC-OAS-029 S4.3: the untyped handler delegates to the typed parser
+     [prompt_of_input] (the SSOT) and propagates its [Error] instead of
+     silently serializing malformed input as the prompt. *)
+  match prompt_of_input input with
+  | Error message -> Error { message; recoverable = false; error_class = None }
+  | Ok prompt ->
+    (match config.runner prompt with
+     | Ok response ->
+       let text = text_of_response response in
+       let output =
+         match config.output_summarizer with
+         | Some summarize -> summarize text
+         | None -> text
+       in
+       Ok { content = output; _meta = None }
+     | Error e ->
+       Error { message = Error.to_string e; recoverable = false; error_class = None })
 ;;
 
 let parse_child_invocation input =

--- a/lib/llm_provider/backend_tool_call_harness.ml
+++ b/lib/llm_provider/backend_tool_call_harness.ml
@@ -49,22 +49,45 @@ let json_string = function
   | `Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
 ;;
 
+(* The complete JSON Schema primitive [type] vocabulary as a closed set. Parsing
+   the [type] string into this variant once (parse, don't validate) makes an
+   unknown/non-standard type explicit instead of a permissive default
+   (RFC-OAS-029 S8.1). Adding a future JSON Schema type is a single edit here. *)
+type json_schema_type =
+  | Schema_object
+  | Schema_array
+  | Schema_string
+  | Schema_number
+  | Schema_integer
+  | Schema_boolean
+  | Schema_null
+
+let json_schema_type_of_string = function
+  | "object" -> Some Schema_object
+  | "array" -> Some Schema_array
+  | "string" -> Some Schema_string
+  | "number" -> Some Schema_number
+  | "integer" -> Some Schema_integer
+  | "boolean" -> Some Schema_boolean
+  | "null" -> Some Schema_null
+  | _ -> None
+;;
+
 let json_matches_schema_type expected value =
-  match expected, value with
-  | "object", `Assoc _ -> true
-  | "array", `List _ -> true
-  | "string", `String _ -> true
-  | "number", (`Int _ | `Intlit _ | `Float _) -> true
-  | "integer", (`Int _ | `Intlit _) -> true
-  | "boolean", `Bool _ -> true
-  | "object", (`List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
-  | "array", (`Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
-  | "string", (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
-  | "number", (`Assoc _ | `List _ | `String _ | `Bool _ | `Null)
-  | "integer", (`Assoc _ | `List _ | `String _ | `Float _ | `Bool _ | `Null)
-  | "boolean", (`Assoc _ | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Null) ->
+  match json_schema_type_of_string expected with
+  | None ->
+    (* Unknown/non-standard schema [type]: do not silently accept any value.
+       A malformed type keyword is surfaced as a violation, not a permissive
+       pass (RFC-OAS-029 S8.1; replaces the prior [unsupported_type <> ""]). *)
     false
-  | unsupported_type, _ -> unsupported_type <> ""
+  | Some Schema_object -> (match value with `Assoc _ -> true | _ -> false)
+  | Some Schema_array -> (match value with `List _ -> true | _ -> false)
+  | Some Schema_string -> (match value with `String _ -> true | _ -> false)
+  | Some Schema_number ->
+    (match value with `Int _ | `Intlit _ | `Float _ -> true | _ -> false)
+  | Some Schema_integer -> (match value with `Int _ | `Intlit _ -> true | _ -> false)
+  | Some Schema_boolean -> (match value with `Bool _ -> true | _ -> false)
+  | Some Schema_null -> (match value with `Null -> true | _ -> false)
 ;;
 
 let schema_if_present = function

--- a/lib/tool_use_recovery.ml
+++ b/lib/tool_use_recovery.ml
@@ -146,14 +146,17 @@ let rec extract_name_and_input (json : Yojson.Safe.t) : (string * Yojson.Safe.t)
 
 (* ── Tool ID generation ──────────────────────────────────── *)
 
-let next_recovery_id =
-  let counter = ref 0 in
-  fun () ->
-    incr counter;
-    Printf.sprintf
-      "recovered_%d_%d"
-      (int_of_float (Unix.gettimeofday () *. 1000.0))
-      !counter
+(** Deterministic id for a recovered ToolUse block, derived from its position
+    in the content list and a content hash of the tool name and arguments. No
+    wall-clock and no mutable counter, so the same response recovers to the
+    same ids on every run — required because this module documents itself
+    "Pure" (RFC-OAS-029 S10.1). The block index keeps ids distinct even when
+    two recovered calls carry identical name and arguments. *)
+let recovery_id ~block_index ~name ~(input : Yojson.Safe.t) =
+  let digest =
+    Digest.to_hex (Digest.string (name ^ "\000" ^ Yojson.Safe.to_string input))
+  in
+  Printf.sprintf "recovered_%d_%s" block_index (String.sub digest 0 12)
 ;;
 
 (* ── Response-level recovery ─────────────────────────────── *)
@@ -167,8 +170,8 @@ let recover_content_blocks
   =
   let recovered = ref 0 in
   let new_content =
-    List.map
-      (fun block ->
+    List.mapi
+      (fun block_index block ->
          match block with
          | Text text ->
            (match try_parse_json_object text with
@@ -178,7 +181,7 @@ let recover_content_blocks
                | None -> block
                | Some (name, input) when List.mem name valid_tool_names ->
                  incr recovered;
-                 ToolUse { id = next_recovery_id (); name; input }
+                 ToolUse { id = recovery_id ~block_index ~name ~input; name; input }
                | Some _ -> block))
          | _ -> block)
       content

--- a/test/test_agent_tool.ml
+++ b/test/test_agent_tool.ml
@@ -100,6 +100,29 @@ let test_execute_error_propagation () =
   | Ok _ -> Alcotest.fail "expected error"
 ;;
 
+let test_execute_untyped_malformed_input_errors () =
+  (* RFC-OAS-029 S4.3: the untyped handler delegates to the typed parser and
+     propagates its Error instead of silently serializing malformed input as
+     the prompt (regression: missing/non-string prompt used to echo back the
+     serialized JSON as a successful run). *)
+  let tool = Agent_tool.create_simple ~name:"echo" ~description:"d" echo_runner in
+  (match Tool.execute tool (`Assoc [ "other", `String "x" ]) with
+   | Error { message; _ } ->
+     Alcotest.(check string)
+       "missing prompt surfaced"
+       "Agent_tool input requires a prompt field"
+       message
+   | Ok { content; _meta = _ } -> Alcotest.failf "expected error (missing prompt), got: %s" content);
+  match Tool.execute tool (`Assoc [ "prompt", `Int 5 ]) with
+  | Error { message; _ } ->
+    Alcotest.(check string)
+      "non-string prompt surfaced"
+      "Agent_tool prompt must be a string"
+      message
+  | Ok { content; _meta = _ } ->
+    Alcotest.failf "expected error (non-string prompt), got: %s" content
+;;
+
 (* ── Output summarizer ───────────────────────────────────────── *)
 
 let test_output_summarizer () =
@@ -259,6 +282,10 @@ let () =
       , [ Alcotest.test_case "with_prompt" `Quick test_execute_with_prompt
         ; Alcotest.test_case "string_input" `Quick test_execute_with_string_input
         ; Alcotest.test_case "error" `Quick test_execute_error_propagation
+        ; Alcotest.test_case
+            "untyped malformed input errors"
+            `Quick
+            test_execute_untyped_malformed_input_errors
         ] )
     ; "summarizer", [ Alcotest.test_case "truncate" `Quick test_output_summarizer ]
     ; "params", [ Alcotest.test_case "extra" `Quick test_extra_parameters ]

--- a/test/test_backend_tool_call_harness.ml
+++ b/test/test_backend_tool_call_harness.ml
@@ -293,6 +293,48 @@ let test_provider_convenience_validators_cover_tool_responses () =
   check int "gemini tool calls" 1 (List.length gemini.tool_calls_found)
 ;;
 
+let test_schema_validation_unknown_type_fails_closed () =
+  (* RFC-OAS-029 S8.1: a non-standard schema [type] must surface as a violation
+     instead of silently accepting any value (regression: the prior
+     [unsupported_type <> ""] catch-all passed every value). A valid "null"
+     type still validates a null value. *)
+  let schema =
+    `Assoc
+      [ "type", `String "object"
+      ; ( "properties"
+        , `Assoc
+            [ "weird", `Assoc [ "type", `String "frobnicate" ]
+            ; "nullable", `Assoc [ "type", `String "null" ]
+            ] )
+      ]
+  in
+  let response =
+    mk_response
+      [ T.ToolUse
+          { id = "call-unknown-type"
+          ; name = "shape_check"
+          ; input = `Assoc [ "weird", `String "anything"; "nullable", `Null ]
+          }
+      ]
+  in
+  let result =
+    H.validate_response_with_schemas
+      ~declared_tools:[ "shape_check" ]
+      ~tool_schemas:[ "shape_check", schema ]
+      response
+  in
+  match result.tool_calls_found with
+  | [ call ] ->
+    check bool "unknown type makes args invalid" false call.arguments_valid;
+    check
+      (list string)
+      "only the unknown-type path violates (null type accepts null)"
+      [ "$.weird" ]
+      (List.map (fun (v : H.schema_violation) -> v.path) call.violations
+       |> List.sort String.compare)
+  | _ -> fail "expected one tool call"
+;;
+
 let () =
   run
     "backend_tool_call_harness"
@@ -328,6 +370,10 @@ let () =
             "provider convenience validators"
             `Quick
             test_provider_convenience_validators_cover_tool_responses
+        ; test_case
+            "unknown schema type fails closed"
+            `Quick
+            test_schema_validation_unknown_type_fails_closed
         ] )
     ]
 ;;

--- a/test/test_tool_use_recovery.ml
+++ b/test/test_tool_use_recovery.ml
@@ -162,6 +162,33 @@ let test_recover_plain_text_preserved () =
   | _ -> fail "expected Text preserved"
 ;;
 
+let test_recovered_id_is_deterministic () =
+  (* RFC-OAS-029 S10.1: recovered ids derive from block index + content hash,
+     not wall-clock, so the same response recovers to the same id every run
+     (regression: the prior id embedded Unix.gettimeofday and a mutable
+     counter, so two runs produced different ids). *)
+  let mk () =
+    make_response
+      ~content:[ Text "```json\n{\"name\": \"my_tool\", \"input\": {\"x\": 1}}\n```" ]
+      ()
+  in
+  let id_of r =
+    match r.content with
+    | [ ToolUse { id; _ } ] -> id
+    | _ -> fail "expected single ToolUse block"
+  in
+  let id1 = id_of (TUR.recover_response ~valid_tool_names:[ "my_tool" ] (mk ())) in
+  let id2 = id_of (TUR.recover_response ~valid_tool_names:[ "my_tool" ] (mk ())) in
+  check string "deterministic id across runs" id1 id2;
+  let prefix = "recovered_0_" in
+  check
+    bool
+    "id carries block-index prefix"
+    true
+    (String.length id1 >= String.length prefix
+     && String.sub id1 0 (String.length prefix) = prefix)
+;;
+
 (* ── Suite ───────────────────────────────────────────────── *)
 
 let () =
@@ -189,6 +216,7 @@ let () =
             test_recover_noop_when_tool_use_present
         ; test_case "noop when no tools" `Quick test_recover_noop_when_no_tools
         ; test_case "plain text preserved" `Quick test_recover_plain_text_preserved
+        ; test_case "recovered id deterministic" `Quick test_recovered_id_is_deterministic
         ] )
     ]
 ;;


### PR DESCRIPTION
## 목적

RFC-OAS-029 표준의 첫 Direct 적용 — **Silent Failure 제거 (S8.1 + S4.3)**. typed surface가 이미 있는데 우회하던 두 지점을 fail-closed로 라우팅한다. 적대 감사(2026-06-29) 확정 위반 `D-TOOLS-9`, `D-TOOLS-6`.

## 변경

### 1. `backend_tool_call_harness` — unknown JSON-Schema type fail-closed (S8.1, D-TOOLS-9)

이전: `json_matches_schema_type`의 catch-all `unsupported_type, _ -> unsupported_type <> ""` — 인식 못 하는 `type` 문자열(타입 오타, 비표준, 그리고 누락돼 있던 `"null"`)에 대해 **어떤 값이든 통과**시킴(silent permissive).

이후: `type` 문자열을 closed `json_schema_type` variant로 **1회 parse**(parse, don't validate). JSON Schema 원시 타입 7종(`object/array/string/number/integer/boolean/null`)을 완전 enumerate하고, 그 외는 violation으로 표면화. `"null"` 타입 추가로 정상 schema도 올바르게 검증됨.

### 2. `agent_tool.make_handler` — typed parser 위임 (S4.3, D-TOOLS-6)

이전: untyped handler가 `prompt_of_input`(typed Result 파서)를 두고 inline 재구현하며, prompt 누락/비-string이면 `Yojson.Safe.to_string input`으로 **input 전체를 prompt로 직렬화**(silent).

이후: `make_handler`가 `prompt_of_input`(SSOT)에 위임하고 그 `Error`를 그대로 전파.

## 검증

- 로컬 focused build green (`scripts/dune-local.sh build lib + 두 test exe`).
- 신규 비-vacuous 테스트 2건 통과:
  - `test_backend_tool_call_harness`: `unknown schema type fails closed` — unknown `type`는 violation, `"null"` 타입은 null 값 수락. (revert 시 red: 이전엔 둘 다 통과해 `arguments_valid=true`)
  - `test_agent_tool`: `untyped malformed input errors` — 누락/비-string prompt가 typed Error 전파. (revert 시 red: 이전엔 직렬화 후 echo로 `Ok`)
- 영향 범위: harness 변경은 unknown/`null` 타입 schema에만, agent_tool 변경은 malformed prompt input에만. 표준 타입 도구 schema·정상 input 동작 불변. 기존 테스트 전부 통과(9 + 13).

## 워크어라운드 게이트

본 PR은 워크어라운드를 **제거**한다(silent permissive/serialize → typed fail-closed). counter/string-classifier/cap 추가 없음. RFC-OAS-029가 governing RFC.

RFC-WAIVED: 변경 파일(`lib/llm_provider/backend_tool_call_harness.ml`, `lib/agent_tool.ml`)은 credential/keeper/operator/hooks/workflow 등 RFC-gate subsystem이 아니며, 본 변경은 RFC-OAS-029 S8.1/S4.3을 구현한다.

---

### 3. `tool_use_recovery` — deterministic recovered ids (S10.1, D-TOOLS-8)

이전: "Pure module"로 문서화돼 있으나 recovered ToolUse id를 `Unix.gettimeofday` + module-level mutable `counter`로 생성 → 같은 응답이 매 실행마다 다른 id. goal의 결정론·재현성·"정직한 계약"에 위배.

이후: id를 **block index + content hash(`Digest`)**로 유도 — 결정론적·재현 가능, block index로 호출별 distinct. 모듈에서 유일한 `Unix` 의존 제거.

테스트: 같은 응답 2회 recover → id 동일 단언 (revert 시 red). recovery suite 15/15 green.
