### PR TITLE
fix(stream): closed block-kind variant — no silent block drop (RFC-OAS-029 S6.1/S8.3)

### DIFF
--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -115,6 +115,31 @@ let accumulate_event (acc : stream_acc) = function
   | Types.MessageStop | Types.Ping | Types.Connected | Types.Timeout _ -> ()
 ;;
 
+(* Closed set of streamed content-block kinds. The wire [content_type] string
+   is converted to this variant exactly once (parse, don't validate) and the
+   finalizer below matches it exhaustively, so adding a kind breaks this compile
+   site rather than slipping through the prior [_ -> None] catch-all that
+   silently dropped any unrecognized block (RFC-OAS-029 S6.1). An unmodeled wire
+   kind becomes [Unknown_block] — handled explicitly and forward-compatibly
+   (S8.3), never silently. *)
+type block_kind =
+  | Text_block
+  | Thinking_block
+  | Redacted_thinking_block
+  | Tool_use_block
+  | Tool_result_block of { is_error : bool }
+  | Unknown_block of string
+
+let block_kind_of_string = function
+  | "text" -> Text_block
+  | "thinking" -> Thinking_block
+  | "redacted_thinking" -> Redacted_thinking_block
+  | "tool_use" -> Tool_use_block
+  | "tool_result" -> Tool_result_block { is_error = false }
+  | "tool_result_error" -> Tool_result_block { is_error = true }
+  | other -> Unknown_block other
+;;
+
 let finalize_stream_acc
       ?(reasoning_visibility = Reasoning_dialect.Provider_hidden)
       (acc : stream_acc)
@@ -142,20 +167,23 @@ let finalize_stream_acc
              | Some buf -> Buffer.contents buf
              | None -> ""
            in
-           match Hashtbl.find_opt acc.block_types idx with
-           | Some "text" -> Some (Types.Text text)
-           | Some "thinking" ->
+           match
+             Option.map block_kind_of_string (Hashtbl.find_opt acc.block_types idx)
+           with
+           | None -> None
+           | Some Text_block -> Some (Types.Text text)
+           | Some Thinking_block ->
              let thinking_type =
                match Hashtbl.find_opt acc.block_thinking_signatures idx with
                | Some buf when Buffer.length buf > 0 -> Buffer.contents buf
                | Some _ | None -> "thinking"
              in
              Some (Types.Thinking { thinking_type; content = text })
-           | Some "redacted_thinking" ->
+           | Some Redacted_thinking_block ->
              (match Hashtbl.find_opt acc.block_tool_ids idx with
               | Some data when data <> "" -> Some (Types.RedactedThinking data)
               | Some _ | None -> None)
-           | Some "tool_use"
+           | Some Tool_use_block
              when !(acc.terminal_incomplete) || !(acc.stop_reason) = Types.MaxTokens ->
              (* A tool call only belongs to a turn the model finished at a tool
                 boundary. When the turn was cut off, the accumulated tool block is
@@ -176,7 +204,7 @@ let finalize_stream_acc
                 set [sse_error] instead, so finalize returns [Error] before content
                 assembly and never reaches this branch. *)
              None
-           | Some "tool_use" ->
+           | Some Tool_use_block ->
              let id =
                match Hashtbl.find_opt acc.block_tool_ids idx with
                | Some s -> s
@@ -192,16 +220,11 @@ let finalize_stream_acc
                | Yojson.Json_error _ -> `Assoc []
              in
              Some (Types.ToolUse { id; name; input })
-           | Some "tool_result" | Some "tool_result_error" ->
+           | Some (Tool_result_block { is_error }) ->
              let tool_use_id =
                match Hashtbl.find_opt acc.block_tool_ids idx with
                | Some s -> s
                | None -> ""
-             in
-             let is_error =
-               match Hashtbl.find_opt acc.block_types idx with
-               | Some "tool_result_error" -> true
-               | _ -> false
              in
              Some
                (Types.ToolResult
@@ -211,7 +234,16 @@ let finalize_stream_acc
                   ; json = (if is_error then None else Types.try_parse_json text)
                   ; content_blocks = None
                   })
-           | _ -> None)
+           | Some (Unknown_block _kind) ->
+             (* RFC-OAS-029 S6.1/S8.3: an unmodeled content-block kind is handled
+                explicitly, not silently dropped by a [_ -> None] catch-all.
+                Preserve any visible text it carried so newly introduced
+                text-bearing block kinds (e.g. provider server-tool result
+                blocks) survive in the response instead of vanishing. A kind that
+                accumulated no text has no renderable content; the raw kind string
+                remains inspectable in [acc.block_types]. Structurally malformed
+                SSE is a separate concern already surfaced via [sse_error]. *)
+             if String.trim text <> "" then Some (Types.Text text) else None)
         indices
     in
     (* Visible_text policy: a reasoning-only stream (no Text block, no tool
@@ -693,12 +725,29 @@ let%test "finalize_stream_acc empty produces empty content" =
   | Ok result -> result.content = []
 ;;
 
-let%test "finalize_stream_acc unknown block type filtered out" =
+let%test "finalize_stream_acc preserves text of unknown block kind (S6.1/S8.3)" =
+  (* RFC-OAS-029 S6.1/S8.3: an unmodeled content-block kind that carried visible
+     text is preserved as a Text block (forward-compatible with newly introduced
+     provider block kinds), not silently dropped by the former [_ -> None]
+     catch-all. Revert this fix -> content = [] (red). *)
   let acc = create_stream_acc () in
-  Hashtbl.replace acc.block_types 0 "unknown_type";
+  Hashtbl.replace acc.block_types 0 "server_tool_use";
   let buf = Buffer.create 16 in
   Buffer.add_string buf "data";
   Hashtbl.replace acc.block_texts 0 buf;
+  match
+    acc.stop_reason_received := true;
+    finalize_stream_acc acc
+  with
+  | Error _ -> false
+  | Ok result -> result.content = [ Types.Text "data" ]
+;;
+
+let%test "finalize_stream_acc drops empty unknown block kind" =
+  (* An unmodeled kind with no accumulated text has no renderable content, so it
+     is omitted via the explicit Unknown_block branch (not a silent catch-all). *)
+  let acc = create_stream_acc () in
+  Hashtbl.replace acc.block_types 0 "container_upload";
   match
     acc.stop_reason_received := true;
     finalize_stream_acc acc


### PR DESCRIPTION
## 목적

RFC-OAS-029 표준 적용 — **스트리밍 finalizer의 silent block-drop 제거 (S6.1 + S8.3)**. 적대 감사(2026-06-29) 확정 위반 `D3`.

Dashboard Keeper chat가 요구하는 **Thinking/Tools/Multi-turn 완전 interleaving**의 전제: 스트림으로 들어온 모든 content block이 응답 조립 단계에서 누락 없이 보존되어야 한다. 현재 finalizer는 그 보증을 깨고 있었다.

## 문제

`finalize_stream_acc`는 누적된 각 content block을 wire `content_type` **문자열 매치**로 분류하고, 끝에 `_ -> None` catch-all을 두어 인식 못 하는 block kind를 **조용히 drop**했다.

- provider가 새 text-bearing block kind(`server_tool_use`, `web_search_tool_result`, `mcp_tool_use`, `container` 등)를 도입하면 그 **가시 텍스트가 에러 없이 응답에서 사라진다**.
- 컴파일러가 reader 누락을 잡지 못한다 (string match → 새 kind 자유 추가, AI 코드 안티패턴 #4 `_ -> false`/`_ -> None` catch-all).

## 변경

`content_type` 문자열을 closed `block_kind` variant로 **1회 parse**(parse, don't validate)하고 finalizer에서 **exhaustive match**:

- block kind 추가 시 catch-all로 새는 대신 이 컴파일 사이트가 깨진다 (S6.1: block kind는 closed variant, `_ -> None` 없음).
- 미지의 wire kind는 `Unknown_block`으로 **명시 처리** — 가시 텍스트는 `Text` block으로 보존하여 신규 text-bearing kind가 응답에서 살아남는다 (S8.3, forward-compat). 텍스트가 없는 kind는 렌더 가능한 콘텐츠가 없으므로 생략(원시 kind 문자열은 `acc.block_types`에 inspectable).
- `tool_result`의 `is_error`를 variant payload로 운반 → 중복 Hashtbl lookup 제거 (SSOT).

구조적으로 깨진 SSE는 별개 — 콘텐츠 조립 전에 `sse_error`로 이미 표면화된다. MaxTokens partial-tool-drop 가드는 불변.

## 검증

- 로컬 focused build green: `scripts/dune-local.sh build lib` (exit 0).
- 신규 비-vacuous 테스트 2건, inline `let%test`:
  - `preserves text of unknown block kind (S6.1/S8.3)` — `server_tool_use` + text → `Text "data"` 보존.
  - `drops empty unknown block kind` — `container_upload`, text 없음 → `[]`.
- **Mutation 증명**: assertion을 일부러 틀린 값으로 바꾸면 정확히 그 테스트만 `line 726 ... is false`로 실패(테스트가 실행+비-vacuous). 올바른 값 복귀 시 `llm_provider` 실패 수 16/99(baseline과 동일) — 내 테스트가 실패를 추가하지 않음.
- baseline 16/99 실패는 모두 `pricing.ml`/`provider_config.ml`의 환경 카탈로그-미시드 이슈로, 본 변경(`complete_stream_acc.ml` 단일 파일)과 무관함을 stash diff로 확인.

## 워크어라운드 게이트

본 PR은 워크어라운드를 **제거**한다(silent `_ -> None` catch-all → 명시 variant + forward-compat 보존). counter/string-classifier/cap/dedup 추가 없음. RFC-OAS-029가 governing RFC.

RFC-WAIVED: `lib/llm_provider/complete_stream_acc.ml`은 credential/keeper/operator/hooks/workflow 등 RFC-gate subsystem이 아니며, 본 변경은 RFC-OAS-029 S6.1/S8.3을 구현한다.
