### PR TITLE
fix(glm): gate native reasoning_content replay on Preserved Thinking

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -191,7 +191,16 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
   in
   let provider_messages =
     let message_serializer =
-      if is_glm_request ?provider_config config
+      (* Gate GLM reasoning_content replay on Preserved Thinking, matching the
+         provider-client path in Backend_openai_request via the same SSOT
+         predicate. [Types.agent_config] carries no [clear_thinking] field, so it
+         resolves from [preserve_thinking]. *)
+      if
+        is_glm_request ?provider_config config
+        && Llm_provider.Provider_config.glm_should_replay_reasoning_fields
+             ~enable_thinking:config.config.enable_thinking
+             ~clear_thinking:None
+             ~preserve_thinking:config.config.preserve_thinking
       then Llm_provider.Backend_openai_serialize.glm_messages_of_message
       else Llm_provider.Backend_openai_serialize.dialect_messages_of_message dialect
     in

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -160,14 +160,10 @@ let thinking_object_only_fields dialect (config : Provider_config.t) =
   if control.keep_all then fields @ [ "keep", `String "all" ] else fields
 ;;
 
-let glm_clear_thinking_of_config (config : Provider_config.t) =
-  match config.clear_thinking with
-  | Some clear -> clear
-  | None ->
-    (match config.preserve_thinking with
-     | Some preserve -> not preserve
-     | None -> true)
-;;
+(* Resolution delegated to [Provider_config.glm_clear_thinking] (SSOT) so the
+   request-body clear_thinking field below and the reasoning-replay gate cannot
+   diverge. *)
+let glm_clear_thinking_of_config = Provider_config.glm_clear_thinking
 
 let is_zai_glm_request (config : Provider_config.t) =
   Zai_catalog.is_zai_base_url config.base_url
@@ -175,9 +171,7 @@ let is_zai_glm_request (config : Provider_config.t) =
 ;;
 
 let zai_glm_preserve_thinking_request (config : Provider_config.t) =
-  is_zai_glm_request config
-  && config.enable_thinking = Some true
-  && not (glm_clear_thinking_of_config config)
+  is_zai_glm_request config && Provider_config.glm_should_replay_reasoning config
 ;;
 
 let normalized_reasoning_effort dialect (config : Provider_config.t) =
@@ -207,13 +201,20 @@ let build_request_assoc
   let provider_messages =
     let message_serializer =
       match config.kind with
-      | Provider_config.Glm -> Backend_openai_serialize.glm_messages_of_message
+      | Provider_config.Glm when Provider_config.glm_should_replay_reasoning config ->
+        (* Native GLM replays historical reasoning_content only under Preserved
+           Thinking (thinking active AND clear_thinking=false). *)
+        Backend_openai_serialize.glm_messages_of_message
       | Provider_config.OpenAI_compat when zai_glm_preserve_thinking_request config ->
         (* ZAI GLM accepts reasoning_content in request messages only when the
            same request body enables thinking with clear_thinking=false. The
            generic OpenAI_compat serializer drops Thinking blocks, so route
            bare-ZAI GLM through the GLM serializer only for that wire shape. *)
         Backend_openai_serialize.glm_messages_of_message
+      | Provider_config.Glm
+      (* Default native GLM (clear_thinking=true): the server discards prior-turn
+         reasoning, so drop it via the No_replay dialect serializer rather than
+         replaying content the contract ignores (which bloats every request). *)
       | Provider_config.Anthropic
       | Provider_config.Kimi
       | Provider_config.OpenAI_compat

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -333,6 +333,47 @@ let reasoning_effort_request_value
     (reasoning_effort_request_value_typed ~enable_thinking ~thinking_budget)
 ;;
 
+(* GLM (Z.AI) Preserved-Thinking gate (SSOT).
+
+   The GLM Chat Completion API replays prior-turn [reasoning_content] from the
+   request history only under Preserved Thinking — that is, when thinking is
+   active AND [clear_thinking] is false. With the default [clear_thinking=true]
+   the server ignores/removes prior-turn reasoning, so sending it back violates
+   the documented contract and grows the request every turn. [clear_thinking]
+   resolves from the explicit field, else the inverse of [preserve_thinking],
+   else the API default [true].
+
+   Exposed on raw fields as well as on [t] because the two request builders
+   carry different config records ([Provider_config.t] vs [Types.agent_config]);
+   both route through this one resolver so the gate cannot drift between them. *)
+let glm_clear_thinking_value ~clear_thinking ~preserve_thinking =
+  match clear_thinking with
+  | Some clear -> clear
+  | None ->
+    (match preserve_thinking with
+     | Some preserve -> not preserve
+     | None -> true)
+;;
+
+let glm_should_replay_reasoning_fields ~enable_thinking ~clear_thinking ~preserve_thinking
+  =
+  enable_thinking = Some true
+  && not (glm_clear_thinking_value ~clear_thinking ~preserve_thinking)
+;;
+
+let glm_clear_thinking (config : t) =
+  glm_clear_thinking_value
+    ~clear_thinking:config.clear_thinking
+    ~preserve_thinking:config.preserve_thinking
+;;
+
+let glm_should_replay_reasoning (config : t) =
+  glm_should_replay_reasoning_fields
+    ~enable_thinking:config.enable_thinking
+    ~clear_thinking:config.clear_thinking
+    ~preserve_thinking:config.preserve_thinking
+;;
+
 (** Compute reasoning_effort for a provider config.
     Returns [None] for non-Ollama providers.
     @since 0.114.0 *)

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -328,6 +328,29 @@ val reasoning_effort_request_value
   -> thinking_budget:int option
   -> string option
 
+(** Resolve GLM [clear_thinking]: the explicit field, else the inverse of
+    [preserve_thinking], else the API default [true]. SSOT for both request
+    builders' clear_thinking handling. *)
+val glm_clear_thinking_value
+  :  clear_thinking:bool option
+  -> preserve_thinking:bool option
+  -> bool
+
+val glm_clear_thinking : t -> bool
+
+(** [true] iff GLM should replay prior-turn [reasoning_content] into request
+    history: thinking active AND [clear_thinking] false (Preserved Thinking).
+    Under the default [clear_thinking=true] the server discards prior reasoning,
+    so replaying it violates the GLM contract and bloats the request. SSOT for
+    every GLM message-serializer routing site. *)
+val glm_should_replay_reasoning_fields
+  :  enable_thinking:bool option
+  -> clear_thinking:bool option
+  -> preserve_thinking:bool option
+  -> bool
+
+val glm_should_replay_reasoning : t -> bool
+
 (** Compute reasoning_effort for a provider config.
     Returns [None] for non-Ollama providers.
     @since 0.114.0 *)

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -463,6 +463,66 @@ let test_zai_glm_openai_compat_drops_reasoning_when_thinking_absent () =
     body
 ;;
 
+(* Native [kind:Glm] reasoning_content replay gate (oas#2236). The native GLM
+   provider-client path must mirror the OpenAI_compat ZAI path above: replay
+   historical reasoning_content only under Preserved Thinking
+   (clear_thinking=false). Before the gate the native path replayed
+   unconditionally, contradicting the default clear_thinking=true contract. *)
+let native_glm_cfg ?(enable_thinking = Some true) ?preserve_thinking ?clear_thinking () =
+  Provider_config.make
+    ~kind:Glm
+    ~model_id:"glm-5"
+    ~base_url:"https://api.z.ai/api/paas/v4"
+    ~api_key:"test-key"
+    ~max_tokens:1024
+    ~temperature:0.7
+    ~tool_choice:Any
+    ~disable_parallel_tool_use:true
+    ?enable_thinking
+    ?preserve_thinking
+    ?clear_thinking
+    ()
+;;
+
+let test_native_glm_replays_reasoning_when_preserve_thinking () =
+  let body =
+    Backend_openai_request.build_request
+      ~config:(native_glm_cfg ~preserve_thinking:true ())
+      ~messages:zai_glm_messages_with_reasoning
+      ()
+  in
+  check_reasoning_content
+    "native GLM replays reasoning_content under preserve thinking"
+    true
+    body
+;;
+
+let test_native_glm_drops_reasoning_by_default () =
+  let body =
+    Backend_openai_request.build_request
+      ~config:(native_glm_cfg ())
+      ~messages:zai_glm_messages_with_reasoning
+      ()
+  in
+  check_reasoning_content
+    "native GLM omits reasoning_content with default clear_thinking=true"
+    false
+    body
+;;
+
+let test_native_glm_drops_reasoning_when_thinking_disabled () =
+  let body =
+    Backend_openai_request.build_request
+      ~config:(native_glm_cfg ~enable_thinking:(Some false) ~preserve_thinking:true ())
+      ~messages:zai_glm_messages_with_reasoning
+      ()
+  in
+  check_reasoning_content
+    "native GLM omits reasoning_content when thinking disabled"
+    false
+    body
+;;
+
 (* ── Anthropic ──────────────────────────────────────── *)
 
 let anthropic_forced_expected =
@@ -684,6 +744,18 @@ let () =
             "zai-glm-openai-compat drops reasoning when thinking absent"
             `Quick
             test_zai_glm_openai_compat_drops_reasoning_when_thinking_absent
+        ; test_case
+            "native-glm replays reasoning when preserve_thinking"
+            `Quick
+            test_native_glm_replays_reasoning_when_preserve_thinking
+        ; test_case
+            "native-glm drops reasoning by default (clear_thinking=true)"
+            `Quick
+            test_native_glm_drops_reasoning_by_default
+        ; test_case
+            "native-glm drops reasoning when thinking disabled"
+            `Quick
+            test_native_glm_drops_reasoning_when_thinking_disabled
         ] )
     ; ( "anthropic"
       , [ test_case "tool_choice forced(Tool)" `Quick test_anthropic_forced


### PR DESCRIPTION
## 목표

native `kind:Glm`(및 `api_openai`의 GLM 경로)이 과거 턴의 `reasoning_content`를 **무조건** 매 요청에 직렬화하던 것을, GLM 공식 계약에 맞춰 **Preserved Thinking일 때만** replay하도록 게이팅합니다. oas#2236 per-model 감사에서 확인된 GLM 계약 위반(M2)의 직접 fix입니다.

## 근본 원인

GLM Chat Completion API는 과거 턴의 `reasoning_content`를 **Preserved Thinking**(thinking 활성 + `clear_thinking=false`)일 때만 history로 받습니다. 기본값 `clear_thinking=true`에서는 서버가 이전 reasoning을 폐기하므로, 무조건 replay는 (1) 계약 위반이고 (2) 매 턴 요청을 키워 비용/컨텍스트를 증가시키며, preserve 경로에서는 concat+sanitize로 재작성된 블록을 보내 Preserved Thinking을 오히려 저해합니다.

운영자 PR #2125가 이 invariant("gate reasoning replay on active thinking")를 **bare-ZAI `OpenAI_compat`** 경로에는 적용했지만, **native `kind:Glm` serializer**와 **`api_openai.build_openai_body`** 두 경로는 무조건 replay로 남아 있었습니다. (sibling 경로는 `zai_glm_preserve_thinking_request`로 게이팅 / native는 미게이팅 — 불일치.)

## 변경 (5 files, +159/−13)

SSOT predicate를 `Provider_config`에 1개 두고, **3개 GLM serializer 라우팅 site가 모두 그것을 통과**하도록 통일했습니다 (N-of-M의 반대 = 변환 함수 추출).

- **`provider_config.{ml,mli}`**: `glm_should_replay_reasoning`(typed) / `glm_should_replay_reasoning_fields`(raw, `Types.agent_config`용) / `glm_clear_thinking{,_value}`. 두 request builder가 서로 다른 config 레코드를 쓰므로 raw-fields 진입점을 함께 노출하되 해소 로직은 단일 `glm_clear_thinking_value`에 둠.
- **`backend_openai_request.ml`**: native `Glm` arm을 `when glm_should_replay_reasoning config`로 게이팅(preserve일 때만 glm serializer, 기본은 No_replay dialect serializer로 fall-through). `glm_clear_thinking_of_config`는 SSOT로 위임. `with_preserve_thinking`이 GLM(`No_preserve_thinking_control`)에 no-op이라 fall-through dialect는 항상 No_replay → 모순 없음.
- **`api_openai.ml`**: `build_openai_body`의 `is_glm_request` 분기를 동일 predicate(raw-fields, `clear_thinking:None` → preserve에서 해소)로 게이팅.
- **`test_snapshot_provider_serialization.ml`**: native-glm 회귀 3종 (preserve→replay / 기본 clear_thinking=true→drop / thinking disabled→drop). 기존 ZAI OpenAI_compat 4종과 대칭.

## 워크어라운드 아님 (self-check)

- telemetry-as-fix ✗ (실제 wire 동작 수정) · string 분류기 ✗ (typed predicate) · N-of-M ✗ (predicate를 SSOT로 추출해 전 site uniform 적용 = 근본 fix). silent 계약 위반(서버가 폐기하는 reasoning을 매 턴 전송)을 *제거*하며 #2125 invariant를 마저 닫음.

## Self-review

- **변경 파일**: 위 5개.
- **로컬 검증**: ocamlformat 0.29.0 적용 완료. 빌드/테스트는 CI에서 확인(로컬 full build 미실행 — repo 정책).
- **미검증(CI 확인 대상)**: `dune build`(warn-error), `make test`(native-glm 회귀 3종, 특히 `drop by default`는 fix 전 fail/후 pass), bisect 커버리지 ratchet.
- **인과 주의**: GLM 루프 causation은 "clear_thinking=true에서 서버가 폐기"라 무한루프보다 context bloat이 지배적일 수 있음(oas#2236 코멘트 참조). 본 PR은 계약 정합 + 비용 + 경로 일관성을 확실히 개선하며, 서버가 reasoning을 폐기하지 않는 환경에서는 루프 fix이기도 함.

## Refs
- oas#2236 (per-model thinking-replay 감사 — GLM mismatch HIGH)
- #2125 (bare-ZAI OpenAI_compat replay gate, 이 invariant의 출처)
- RFC-OAS-023 (GLM typed reshape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
