### PR TITLE
fix(provider): isolate assistant tool content capability

### DIFF
--- a/docs/capability-manifest.md
+++ b/docs/capability-manifest.md
@@ -79,6 +79,7 @@ for the full JSON Schema (draft-07).
 | `supports_tools` | bool | from base | Tool/function calling. |
 | `supports_tool_choice` | bool | from base | Forced tool selection. |
 | `supports_parallel_tool_calls` | bool | from base | Multiple tool calls per turn. |
+| `assistant_tool_content_format` | string | from base | Wire shape for assistant messages with tool calls and no visible text. Accepted values: `null`, `empty_string`. |
 | `supports_reasoning` | bool | from base | Any reasoning capability (union). |
 | `supports_extended_thinking` | bool | from base | budget\_tokens-controlled thinking. |
 | `supports_reasoning_budget` | bool | from base | Reasoning effort control. |

--- a/docs/example-capability-manifest.json
+++ b/docs/example-capability-manifest.json
@@ -50,6 +50,7 @@
       "supports_tool_choice": true,
       "supports_reasoning": true,
       "supports_extended_thinking": true,
+      "assistant_tool_content_format": "empty_string",
       "supports_native_streaming": true
     },
     {
@@ -62,6 +63,7 @@
       "supports_tool_choice": true,
       "supports_reasoning": true,
       "supports_extended_thinking": true,
+      "assistant_tool_content_format": "empty_string",
       "supports_native_streaming": true
     },
     {
@@ -74,6 +76,7 @@
       "supports_tool_choice": true,
       "supports_reasoning": true,
       "supports_extended_thinking": true,
+      "assistant_tool_content_format": "empty_string",
       "supports_native_streaming": true
     },
     {

--- a/docs/provider-capabilities-spec.md
+++ b/docs/provider-capabilities-spec.md
@@ -50,6 +50,7 @@ Cloud providers need hardcoded lookup tables keyed by model_id.
 | `supports_tools` | exists | keep | |
 | `supports_tool_choice` | exists | keep | |
 | `supports_parallel_tool_calls` | exists | keep | Request builders derive effective `disable_parallel_tool_use` from caller intent plus provider/model capability. |
+| `assistant_tool_content_format` | exists in code | keep separate | Assistant tool-call content shape (`content:null` vs `content:""`) is a provider wire-contract axis, independent from reasoning replay. |
 | `supports_system_prompt` | missing | add | Most models support it, but some fine-tuned/distilled variants do not. Agent must fold system into first user message. |
 | `supports_reasoning` | exists | **split into 4** | See Thinking Taxonomy below. |
 | `supports_extended_thinking` | missing | add | budget_tokens control. Claude, Gemini, GPT-5.4. |

--- a/docs/provider-catalog.md
+++ b/docs/provider-catalog.md
@@ -153,6 +153,7 @@ The `capabilities` object accepts the same capability field names used by
 
 - `max_context_tokens`, `max_output_tokens`
 - `supports_tools`, `supports_tool_choice`, `supports_parallel_tool_calls`
+- `assistant_tool_content_format`
 - `supports_runtime_mcp_tools`, `supports_runtime_tool_events`
 - `supports_reasoning`, `supports_extended_thinking`, `supports_reasoning_budget`
 - `thinking_control_format`, `preserve_thinking_control_format`
@@ -183,6 +184,11 @@ Accepted `preserve_thinking_control_format` values are:
 - `chat_template_kwargs_preserve_thinking`
 - `top_level_preserve_thinking`
 - `always_preserved` (historical reasoning must be replayed; no request field)
+
+Accepted `assistant_tool_content_format` values are:
+
+- `null` (`content: null` for assistant tool-call messages with no visible text)
+- `empty_string` (`content: ""` for assistant tool-call messages with no visible text)
 
 ## External Design References
 

--- a/docs/schemas/capability-manifest-v1.json
+++ b/docs/schemas/capability-manifest-v1.json
@@ -65,6 +65,11 @@
           "type": "boolean",
           "description": "Whether the model can call multiple tools in a single turn."
         },
+        "assistant_tool_content_format": {
+          "type": "string",
+          "description": "Wire shape for assistant messages that contain tool calls but no visible text.",
+          "enum": ["null", "empty_string"]
+        },
         "supports_reasoning": {
           "type": "boolean",
           "description": "Whether the model has any reasoning/thinking capability (union flag)."

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -55,12 +55,6 @@ let is_glm_request ?provider_config (config : agent_state) =
   | None -> Llm_provider.Zai_catalog.is_glm_model_id (model_to_string config.config.model)
 ;;
 
-let assistant_tool_content_format_for_request ?provider_config capabilities config =
-  if is_glm_request ?provider_config config
-  then Llm_provider.Capability_vocab.Assistant_tool_content_empty_string
-  else capabilities.Provider.assistant_tool_content_format
-;;
-
 let bool_field name = function
   | Some value -> [ name, `Bool value ]
   | None -> []
@@ -185,9 +179,7 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
   let model_str = model_to_string config.config.model in
   let capabilities = capabilities_for_request ?provider_config config in
   let dialect = reasoning_dialect_for_request capabilities config in
-  let assistant_tool_content_format =
-    assistant_tool_content_format_for_request ?provider_config capabilities config
-  in
+  let assistant_tool_content_format = capabilities.Provider.assistant_tool_content_format in
   let tools_to_send =
     match tools with
     | Some entries

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -179,7 +179,9 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
   let model_str = model_to_string config.config.model in
   let capabilities = capabilities_for_request ?provider_config config in
   let dialect = reasoning_dialect_for_request capabilities config in
-  let assistant_tool_content_format = capabilities.Provider.assistant_tool_content_format in
+  let assistant_tool_content_format =
+    capabilities.Provider.assistant_tool_content_format
+  in
   let tools_to_send =
     match tools with
     | Some entries

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -55,6 +55,12 @@ let is_glm_request ?provider_config (config : agent_state) =
   | None -> Llm_provider.Zai_catalog.is_glm_model_id (model_to_string config.config.model)
 ;;
 
+let assistant_tool_content_format_for_request ?provider_config capabilities config =
+  if is_glm_request ?provider_config config
+  then Llm_provider.Capability_vocab.Assistant_tool_content_empty_string
+  else capabilities.Provider.assistant_tool_content_format
+;;
+
 let bool_field name = function
   | Some value -> [ name, `Bool value ]
   | None -> []
@@ -94,6 +100,7 @@ let llm_capabilities_of_provider_capabilities (caps : Provider.capabilities)
   ; supports_parallel_tool_calls = caps.supports_parallel_tool_calls
   ; supports_runtime_mcp_tools = caps.supports_runtime_mcp_tools
   ; supports_runtime_tool_events = caps.supports_runtime_tool_events
+  ; assistant_tool_content_format = caps.assistant_tool_content_format
   ; supports_reasoning = caps.supports_reasoning
   ; supports_extended_thinking = caps.supports_extended_thinking
   ; supports_reasoning_budget = caps.supports_reasoning_budget
@@ -178,6 +185,9 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
   let model_str = model_to_string config.config.model in
   let capabilities = capabilities_for_request ?provider_config config in
   let dialect = reasoning_dialect_for_request capabilities config in
+  let assistant_tool_content_format =
+    assistant_tool_content_format_for_request ?provider_config capabilities config
+  in
   let tools_to_send =
     match tools with
     | Some entries
@@ -202,7 +212,10 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
              ~clear_thinking:None
              ~preserve_thinking:config.config.preserve_thinking
       then Llm_provider.Backend_openai_serialize.glm_messages_of_message
-      else Llm_provider.Backend_openai_serialize.dialect_messages_of_message dialect
+      else
+        Llm_provider.Backend_openai_serialize.dialect_messages_of_message
+          ~assistant_tool_content_format
+          dialect
     in
     system_message_json config @ List.concat_map message_serializer sanitized_messages
   in

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -160,8 +160,9 @@ let effective_tool_choice_json
   let is_glm = is_glm_request ?provider_config config in
   match config.config.tool_choice with
   | Some Types.None_ when is_glm -> None
-  | Some (Types.Auto | Types.Any | Types.Tool _) when is_glm ->
+  | Some (Types.Auto | Types.Any) when is_glm ->
     Some (tool_choice_to_openai_json Types.Auto)
+  | Some (Types.Tool _) when is_glm -> None
   | Some Types.Auto when capabilities.supports_tool_choice ->
     Some (tool_choice_to_openai_json Types.Auto)
   | Some choice when capabilities.supports_tool_choice ->

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -1136,6 +1136,8 @@ let%test "glm build_request replays reasoning_content without leaking it into co
       ~kind:Provider_config.Glm
       ~model_id:"glm-5.1"
       ~base_url:Zai_catalog.coding_base_url
+      ~enable_thinking:true
+      ~preserve_thinking:true
       ()
   in
   let messages =

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -174,12 +174,6 @@ let zai_glm_preserve_thinking_request (config : Provider_config.t) =
   is_zai_glm_request config && Provider_config.glm_should_replay_reasoning config
 ;;
 
-let assistant_tool_content_format_for_config config caps =
-  if is_zai_glm_request config
-  then Capability_vocab.Assistant_tool_content_empty_string
-  else caps.Capabilities.assistant_tool_content_format
-;;
-
 let normalized_reasoning_effort dialect (config : Provider_config.t) =
   match
     Provider_config.reasoning_effort_request_value_typed
@@ -205,9 +199,7 @@ let build_request_assoc
   in
   let dialect = Reasoning_dialect.for_provider_config config in
   let caps = capabilities_of_config config in
-  let assistant_tool_content_format =
-    assistant_tool_content_format_for_config config caps
-  in
+  let assistant_tool_content_format = caps.Capabilities.assistant_tool_content_format in
   let provider_messages =
     let message_serializer =
       match config.kind with

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -174,6 +174,12 @@ let zai_glm_preserve_thinking_request (config : Provider_config.t) =
   is_zai_glm_request config && Provider_config.glm_should_replay_reasoning config
 ;;
 
+let assistant_tool_content_format_for_config config caps =
+  if is_zai_glm_request config
+  then Capability_vocab.Assistant_tool_content_empty_string
+  else caps.Capabilities.assistant_tool_content_format
+;;
+
 let normalized_reasoning_effort dialect (config : Provider_config.t) =
   match
     Provider_config.reasoning_effort_request_value_typed
@@ -198,6 +204,10 @@ let build_request_assoc
     Backend_openai_serialize.close_tool_message_pairs_for_request messages
   in
   let dialect = Reasoning_dialect.for_provider_config config in
+  let caps = capabilities_of_config config in
+  let assistant_tool_content_format =
+    assistant_tool_content_format_for_config config caps
+  in
   let provider_messages =
     let message_serializer =
       match config.kind with
@@ -221,7 +231,9 @@ let build_request_assoc
       | Provider_config.Ollama
       | Provider_config.DashScope
       | Provider_config.Gemini ->
-        Backend_openai_serialize.dialect_messages_of_message dialect
+        Backend_openai_serialize.dialect_messages_of_message
+          ~assistant_tool_content_format
+          dialect
     in
     (match config.system_prompt with
      | Some s when not (Api_common.string_is_blank s) ->
@@ -237,7 +249,6 @@ let build_request_assoc
      If no model-specific record exists, fall back to the provider-kind
      preset, then to conservative defaults for unknown OpenAI-compatible
      configs. *)
-  let caps = capabilities_of_config config in
   (* Resolve [max_tokens] from three layers:
      1. Caller override ([config.max_tokens = Some n]) - explicit request
      2. Model capability ([caps.max_output_tokens]) - provider's ceiling

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -147,6 +147,7 @@ let openai_tool_messages_of_blocks blocks =
 let messages_of_message_with
       ?(tool_calls_fn = tool_calls_to_openai_json)
       ?(include_reasoning_content = false)
+      ?(assistant_tool_content_format = Capability_vocab.Assistant_tool_content_null)
       ?(modality_priority = Modality.Preserve_input_order)
       (msg : message)
   : Yojson.Safe.t list
@@ -190,15 +191,18 @@ let messages_of_message_with
       else ""
     in
     let tool_calls = tool_calls_fn msg.content in
-    let fields =
-      [ "role", `String "assistant"
-      ; (if include_reasoning_content
-         then "content", `String text_content
-         else if Api_common.string_is_blank text_content && tool_calls <> []
-         then "content", `Null
-         else "content", `String text_content)
-      ]
+    let assistant_content =
+      if Api_common.string_is_blank text_content && tool_calls <> []
+      then
+        if include_reasoning_content
+        then `String text_content
+        else (
+          match assistant_tool_content_format with
+          | Capability_vocab.Assistant_tool_content_null -> `Null
+          | Capability_vocab.Assistant_tool_content_empty_string -> `String text_content)
+      else `String text_content
     in
+    let fields = [ "role", `String "assistant"; "content", assistant_content ] in
     let fields =
       if include_reasoning_content && not (Api_common.string_is_blank reasoning_content)
       then ("reasoning_content", `String reasoning_content) :: fields
@@ -229,10 +233,15 @@ let glm_messages_of_message msg =
   messages_of_message_with
     ~tool_calls_fn:tool_calls_to_openai_json
     ~include_reasoning_content:true
+    ~assistant_tool_content_format:Capability_vocab.Assistant_tool_content_empty_string
     msg
 ;;
 
-let dialect_messages_of_message dialect (msg : Types.message) =
+let dialect_messages_of_message
+      ?(assistant_tool_content_format = Capability_vocab.Assistant_tool_content_null)
+      dialect
+      (msg : Types.message)
+  =
   let tool_calls = tool_calls_to_openai_json msg.content in
   let include_reasoning_content =
     Reasoning_dialect.should_replay_reasoning
@@ -242,6 +251,7 @@ let dialect_messages_of_message dialect (msg : Types.message) =
   messages_of_message_with
     ~tool_calls_fn:(fun _ -> tool_calls)
     ~include_reasoning_content
+    ~assistant_tool_content_format
     msg
 ;;
 

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -193,13 +193,10 @@ let messages_of_message_with
     let tool_calls = tool_calls_fn msg.content in
     let assistant_content =
       if Api_common.string_is_blank text_content && tool_calls <> []
-      then
-        if include_reasoning_content
-        then `String text_content
-        else (
-          match assistant_tool_content_format with
-          | Capability_vocab.Assistant_tool_content_null -> `Null
-          | Capability_vocab.Assistant_tool_content_empty_string -> `String text_content)
+      then (
+        match assistant_tool_content_format with
+        | Capability_vocab.Assistant_tool_content_null -> `Null
+        | Capability_vocab.Assistant_tool_content_empty_string -> `String text_content)
       else `String text_content
     in
     let fields = [ "role", `String "assistant"; "content", assistant_content ] in

--- a/lib/llm_provider/backend_openai_serialize.mli
+++ b/lib/llm_provider/backend_openai_serialize.mli
@@ -11,7 +11,8 @@ val openai_messages_of_message : Types.message -> Yojson.Safe.t list
 val glm_messages_of_message : Types.message -> Yojson.Safe.t list
 
 val dialect_messages_of_message
-  :  Reasoning_dialect.t
+  :  ?assistant_tool_content_format:Capability_vocab.assistant_tool_content_format
+  -> Reasoning_dialect.t
   -> Types.message
   -> Yojson.Safe.t list
 

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -65,6 +65,10 @@ type reasoning_replay_override = Capability_vocab.reasoning_replay_override =
   | Force_drop_without_tool_preserve_with_tool
   | Force_preserve_always
 
+type assistant_tool_content_format = Capability_vocab.assistant_tool_content_format =
+  | Assistant_tool_content_null
+  | Assistant_tool_content_empty_string
+
 type capabilities =
   { (* ── Numeric limits ────────────────────────────────── *)
     max_context_tokens : int option (** Model's context window. None = unknown. *)
@@ -75,6 +79,11 @@ type capabilities =
   ; supports_parallel_tool_calls : bool
   ; supports_runtime_mcp_tools : bool
   ; supports_runtime_tool_events : bool
+  ; assistant_tool_content_format : assistant_tool_content_format
+    (** Wire shape for assistant messages that contain tool calls but no visible
+        text. OpenAI-compatible providers disagree here: OpenAI accepts
+        [content:null], while GLM's OpenAI-compatible contract keeps
+        [content:""]. This is independent from reasoning replay. *)
   ; (* ── Thinking / reasoning ──────────────────────────── *)
     supports_reasoning : bool (** Any form of reasoning/thinking *)
   ; supports_extended_thinking : bool (** budget_tokens / reasoning_effort *)
@@ -151,6 +160,7 @@ let default_capabilities =
   ; supports_parallel_tool_calls = false
   ; supports_runtime_mcp_tools = false
   ; supports_runtime_tool_events = false
+  ; assistant_tool_content_format = Assistant_tool_content_null
   ; supports_reasoning = false
   ; supports_extended_thinking = false
   ; supports_reasoning_budget = false
@@ -414,6 +424,7 @@ let glm_capabilities =
      violations. Ref checked 2026-04-21:
      https://docs.z.ai/guides/capabilities/function-calling *)
     supports_tool_choice = false
+  ; assistant_tool_content_format = Assistant_tool_content_empty_string
   ; supports_reasoning = true
   ; supports_extended_thinking = true
   ; supports_response_format_json = true
@@ -621,6 +632,10 @@ let reasoning_replay_override_of_catalog_string raw =
   Capability_vocab.reasoning_replay_override_of_string raw
 ;;
 
+let assistant_tool_content_format_of_catalog_string raw =
+  Capability_vocab.assistant_tool_content_format_of_string raw
+;;
+
 let modality_priority_of_catalog_string raw =
   match String.lowercase_ascii (String.trim raw) with
   | "preserve_input_order" | "preserve-input-order" | "preserve" ->
@@ -654,6 +669,15 @@ let apply_manifest_entry (entry : Capability_manifest.entry) : capabilities =
       override_bool base.supports_tool_choice entry.supports_tool_choice
   ; supports_parallel_tool_calls =
       override_bool base.supports_parallel_tool_calls entry.supports_parallel_tool_calls
+  ; assistant_tool_content_format =
+      (match entry.assistant_tool_content_format with
+       | Some s ->
+         (match assistant_tool_content_format_of_catalog_string s with
+          | Some format -> format
+          | None ->
+            warn_unknown_capability_value ~field:"assistant_tool_content_format" s;
+            base.assistant_tool_content_format)
+       | None -> base.assistant_tool_content_format)
   ; supports_reasoning = override_bool base.supports_reasoning entry.supports_reasoning
   ; supports_extended_thinking =
       override_bool base.supports_extended_thinking entry.supports_extended_thinking
@@ -754,6 +778,18 @@ let%test "apply_manifest_entry applies reasoning_replay preserve_always" =
   | Ok _ | Error _ -> false
 ;;
 
+let%test "apply_manifest_entry applies assistant_tool_content_format" =
+  match
+    Capability_manifest.of_json
+      (Yojson.Safe.from_string
+         {|{"schema_version":1,"models":[{"id_prefix":"m","assistant_tool_content_format":"empty_string"}]}|})
+  with
+  | Ok [ entry ] ->
+    (apply_manifest_entry entry).assistant_tool_content_format
+    = Assistant_tool_content_empty_string
+  | _ -> false
+;;
+
 let%test "apply_manifest_entry without reasoning_replay keeps base default" =
   match
     Capability_manifest.of_json
@@ -799,6 +835,15 @@ let apply_catalog_entry (entry : Model_catalog.model_entry) : capabilities =
       override_bool base.supports_tool_choice entry.supports_tool_choice
   ; supports_parallel_tool_calls =
       override_bool base.supports_parallel_tool_calls entry.supports_parallel_tool_calls
+  ; assistant_tool_content_format =
+      (match entry.assistant_tool_content_format with
+       | Some s ->
+         (match assistant_tool_content_format_of_catalog_string s with
+          | Some format -> format
+          | None ->
+            warn_unknown_capability_value ~field:"assistant_tool_content_format" s;
+            base.assistant_tool_content_format)
+       | None -> base.assistant_tool_content_format)
   ; supports_reasoning = override_bool base.supports_reasoning entry.supports_reasoning
   ; supports_extended_thinking =
       override_bool base.supports_extended_thinking entry.supports_extended_thinking
@@ -1083,6 +1128,7 @@ let test_catalog_entry id_prefix : Model_catalog.model_entry =
   ; supports_tools = None
   ; supports_tool_choice = None
   ; supports_parallel_tool_calls = None
+  ; assistant_tool_content_format = None
   ; supports_reasoning = None
   ; supports_extended_thinking = None
   ; supports_reasoning_budget = None
@@ -1667,6 +1713,7 @@ let%test "capabilities_for_provider_label: aliases resolve to identical capabili
       && ca.supports_image_input = cb.supports_image_input
       && ca.thinking_control_format = cb.thinking_control_format
       && ca.preserve_thinking_control_format = cb.preserve_thinking_control_format
+      && ca.assistant_tool_content_format = cb.assistant_tool_content_format
       && ca.reasoning_visibility_override = cb.reasoning_visibility_override
       && ca.reasoning_replay_override = cb.reasoning_replay_override
     | _ -> false

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -54,6 +54,10 @@ type reasoning_replay_override = Capability_vocab.reasoning_replay_override =
   | Force_drop_without_tool_preserve_with_tool
   | Force_preserve_always
 
+type assistant_tool_content_format = Capability_vocab.assistant_tool_content_format =
+  | Assistant_tool_content_null
+  | Assistant_tool_content_empty_string
+
 type capabilities =
   { (* Numeric limits *)
     max_context_tokens : int option
@@ -64,6 +68,7 @@ type capabilities =
   ; supports_parallel_tool_calls : bool
   ; supports_runtime_mcp_tools : bool
   ; supports_runtime_tool_events : bool
+  ; assistant_tool_content_format : assistant_tool_content_format
   ; (* Thinking / reasoning *)
     supports_reasoning : bool
   ; supports_extended_thinking : bool

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -10,6 +10,7 @@ type entry =
   ; supports_tools : bool option
   ; supports_tool_choice : bool option
   ; supports_parallel_tool_calls : bool option
+  ; assistant_tool_content_format : string option
   ; supports_reasoning : bool option
   ; supports_extended_thinking : bool option
   ; supports_reasoning_budget : bool option
@@ -154,6 +155,10 @@ let preserve_thinking_control_format_values =
   ]
 ;;
 
+let assistant_tool_content_format_values =
+  Capability_vocab.assistant_tool_content_format_values
+;;
+
 let known_manifest_keys = [ "_comment"; "schema_version"; "models" ]
 
 let known_entry_keys =
@@ -165,6 +170,7 @@ let known_entry_keys =
   ; "supports_tools"
   ; "supports_tool_choice"
   ; "supports_parallel_tool_calls"
+  ; "assistant_tool_content_format"
   ; "supports_reasoning"
   ; "supports_extended_thinking"
   ; "supports_reasoning_budget"
@@ -230,6 +236,12 @@ let parse_entry json =
       ~allowed:Capability_vocab.reasoning_replay_values
       json
   in
+  let* assistant_tool_content_format =
+    canonical_choice
+      "assistant_tool_content_format"
+      ~allowed:assistant_tool_content_format_values
+      json
+  in
   Ok
     { id_prefix
     ; base_label = member_string_opt "base" json
@@ -238,6 +250,7 @@ let parse_entry json =
     ; supports_tools = member_bool "supports_tools" json
     ; supports_tool_choice = member_bool "supports_tool_choice" json
     ; supports_parallel_tool_calls = member_bool "supports_parallel_tool_calls" json
+    ; assistant_tool_content_format
     ; supports_reasoning = member_bool "supports_reasoning" json
     ; supports_extended_thinking = member_bool "supports_extended_thinking" json
     ; supports_reasoning_budget = member_bool "supports_reasoning_budget" json

--- a/lib/llm_provider/capability_manifest.mli
+++ b/lib/llm_provider/capability_manifest.mli
@@ -52,6 +52,9 @@ type entry =
   ; supports_tools : bool option
   ; supports_tool_choice : bool option
   ; supports_parallel_tool_calls : bool option
+  ; assistant_tool_content_format : string option
+    (** Wire shape for assistant messages that contain tool calls but no visible
+        text (null / empty_string). *)
   ; supports_reasoning : bool option
   ; supports_extended_thinking : bool option
   ; supports_reasoning_budget : bool option

--- a/lib/llm_provider/capability_vocab.ml
+++ b/lib/llm_provider/capability_vocab.ml
@@ -11,6 +11,10 @@ type reasoning_replay_override =
   | Force_drop_without_tool_preserve_with_tool
   | Force_preserve_always
 
+type assistant_tool_content_format =
+  | Assistant_tool_content_null
+  | Assistant_tool_content_empty_string
+
 let normalize raw = String.lowercase_ascii (String.trim raw)
 
 let reasoning_replay_table =
@@ -28,4 +32,20 @@ let reasoning_replay_override_of_string raw =
   match normalize raw with
   | "" -> Some Default_reasoning_replay
   | normalized -> List.assoc_opt normalized reasoning_replay_table
+;;
+
+let assistant_tool_content_format_table =
+  [ "null", Assistant_tool_content_null
+  ; "empty_string", Assistant_tool_content_empty_string
+  ]
+;;
+
+let assistant_tool_content_format_values =
+  List.map fst assistant_tool_content_format_table
+;;
+
+let assistant_tool_content_format_of_string raw =
+  match normalize raw with
+  | "" -> Some Assistant_tool_content_null
+  | normalized -> List.assoc_opt normalized assistant_tool_content_format_table
 ;;

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -120,8 +120,8 @@ let accumulate_event (acc : stream_acc) = function
    finalizer below matches it exhaustively, so adding a kind breaks this compile
    site rather than slipping through the prior [_ -> None] catch-all that
    silently dropped any unrecognized block (RFC-OAS-029 S6.1). An unmodeled wire
-   kind becomes [Unknown_block] — handled explicitly and forward-compatibly
-   (S8.3), never silently. *)
+   kind becomes [Unknown_block] — handled explicitly as an unsupported stream
+   surface (S8.3), never silently or as assistant-visible text. *)
 type block_kind =
   | Text_block
   | Thinking_block
@@ -159,33 +159,29 @@ let finalize_stream_acc
     let indices =
       Hashtbl.fold (fun k _ acc -> k :: acc) acc.block_types [] |> List.sort compare
     in
-    let content =
-      List.filter_map
-        (fun idx ->
-           let text =
-             match Hashtbl.find_opt acc.block_texts idx with
-             | Some buf -> Buffer.contents buf
-             | None -> ""
-           in
-           match
-             Option.map block_kind_of_string (Hashtbl.find_opt acc.block_types idx)
-           with
-           | None -> None
-           | Some Text_block -> Some (Types.Text text)
-           | Some Thinking_block ->
-             let thinking_type =
-               match Hashtbl.find_opt acc.block_thinking_signatures idx with
-               | Some buf when Buffer.length buf > 0 -> Buffer.contents buf
-               | Some _ | None -> "thinking"
-             in
-             Some (Types.Thinking { thinking_type; content = text })
-           | Some Redacted_thinking_block ->
-             (match Hashtbl.find_opt acc.block_tool_ids idx with
-              | Some data when data <> "" -> Some (Types.RedactedThinking data)
-              | Some _ | None -> None)
-           | Some Tool_use_block
-             when !(acc.terminal_incomplete) || !(acc.stop_reason) = Types.MaxTokens ->
-             (* A tool call only belongs to a turn the model finished at a tool
+    let content_of_index idx =
+      let text =
+        match Hashtbl.find_opt acc.block_texts idx with
+        | Some buf -> Buffer.contents buf
+        | None -> ""
+      in
+      match Option.map block_kind_of_string (Hashtbl.find_opt acc.block_types idx) with
+      | None -> Ok None
+      | Some Text_block -> Ok (Some (Types.Text text))
+      | Some Thinking_block ->
+        let thinking_type =
+          match Hashtbl.find_opt acc.block_thinking_signatures idx with
+          | Some buf when Buffer.length buf > 0 -> Buffer.contents buf
+          | Some _ | None -> "thinking"
+        in
+        Ok (Some (Types.Thinking { thinking_type; content = text }))
+      | Some Redacted_thinking_block ->
+        (match Hashtbl.find_opt acc.block_tool_ids idx with
+         | Some data when data <> "" -> Ok (Some (Types.RedactedThinking data))
+         | Some _ | None -> Ok None)
+      | Some Tool_use_block
+        when !(acc.terminal_incomplete) || !(acc.stop_reason) = Types.MaxTokens ->
+        (* A tool call only belongs to a turn the model finished at a tool
                 boundary. When the turn was cut off, the accumulated tool block is
                 partial: its argument buffer may be empty (cut off before the first
                 delta) or even parse as JSON yet be incomplete. Drop it so the
@@ -203,124 +199,138 @@ let finalize_stream_acc
                 (#2073 streaming follow-up.) [response.failed]/[error] terminals
                 set [sse_error] instead, so finalize returns [Error] before content
                 assembly and never reaches this branch. *)
-             None
-           | Some Tool_use_block ->
-             let id =
-               match Hashtbl.find_opt acc.block_tool_ids idx with
-               | Some s -> s
-               | None -> ""
-             in
-             let name =
-               match Hashtbl.find_opt acc.block_tool_names idx with
-               | Some s -> s
-               | None -> ""
-             in
-             let input =
-               try Yojson.Safe.from_string text with
-               | Yojson.Json_error _ -> `Assoc []
-             in
-             Some (Types.ToolUse { id; name; input })
-           | Some (Tool_result_block { is_error }) ->
-             let tool_use_id =
-               match Hashtbl.find_opt acc.block_tool_ids idx with
-               | Some s -> s
-               | None -> ""
-             in
-             Some
-               (Types.ToolResult
-                  { tool_use_id
-                  ; content = text
-                  ; is_error
-                  ; json = (if is_error then None else Types.try_parse_json text)
-                  ; content_blocks = None
-                  })
-           | Some (Unknown_block _kind) ->
-             (* RFC-OAS-029 S6.1/S8.3: an unmodeled content-block kind is handled
-                explicitly, not silently dropped by a [_ -> None] catch-all.
-                Preserve any visible text it carried so newly introduced
-                text-bearing block kinds (e.g. provider server-tool result
-                blocks) survive in the response instead of vanishing. A kind that
-                accumulated no text has no renderable content; the raw kind string
-                remains inspectable in [acc.block_types]. Structurally malformed
-                SSE is a separate concern already surfaced via [sse_error]. *)
-             if String.trim text <> "" then Some (Types.Text text) else None)
-        indices
+        Ok None
+      | Some Tool_use_block ->
+        let id =
+          match Hashtbl.find_opt acc.block_tool_ids idx with
+          | Some s -> s
+          | None -> ""
+        in
+        let name =
+          match Hashtbl.find_opt acc.block_tool_names idx with
+          | Some s -> s
+          | None -> ""
+        in
+        let input =
+          try Yojson.Safe.from_string text with
+          | Yojson.Json_error _ -> `Assoc []
+        in
+        Ok (Some (Types.ToolUse { id; name; input }))
+      | Some (Tool_result_block { is_error }) ->
+        let tool_use_id =
+          match Hashtbl.find_opt acc.block_tool_ids idx with
+          | Some s -> s
+          | None -> ""
+        in
+        Ok
+          (Some
+             (Types.ToolResult
+                { tool_use_id
+                ; content = text
+                ; is_error
+                ; json = (if is_error then None else Types.try_parse_json text)
+                ; content_blocks = None
+                }))
+      | Some (Unknown_block kind) ->
+        (* RFC-OAS-029 S6.1/S8.3: an unmodeled content-block kind is handled
+           explicitly and fail-closed. Unknown wire semantics are not safely
+           equivalent to assistant-visible text, and surfacing [text] here can
+           leak future server/tool/control blocks into conversation history. Keep
+           the provider payload out of [raw]; the block index and kind identify
+           the unsupported surface without replaying its content. *)
+        Error
+          (Types.Stream_parse_failed
+             { reason =
+                 Printf.sprintf "unsupported_content_block_kind:%s:index:%d" kind idx
+             ; raw = ""
+             })
     in
-    (* Visible_text policy: a reasoning-only stream (no Text block, no tool
+    let rec collect_content acc = function
+      | [] -> Ok (List.rev acc)
+      | idx :: rest ->
+        (match content_of_index idx with
+         | Error _ as e -> e
+         | Ok None -> collect_content acc rest
+         | Ok (Some item) -> collect_content (item :: acc) rest)
+    in
+    (match collect_content [] indices with
+     | Error _ as e -> e
+     | Ok content ->
+       (* Visible_text policy: a reasoning-only stream (no Text block, no tool
        calls) collapses to content=[Thinking] which every Text-only projection
        reads as empty. Promote the reasoning into a visible Text block for
        provider/model contracts that expose reasoning-only answer text. Mirrors
        the non-streaming parser promotion. *)
-    let has_text =
-      List.exists
-        (function
-          | Types.Text _ -> true
-          | Types.Thinking _
-          | Types.RedactedThinking _
-          | Types.ToolUse _
-          | Types.ToolResult _
-          | Types.Image _
-          | Types.Document _
-          | Types.Audio _ -> false)
-        content
-    in
-    let has_tool =
-      List.exists
-        (function
-          | Types.ToolUse _ -> true
-          | Types.Text _
-          | Types.Thinking _
-          | Types.RedactedThinking _
-          | Types.ToolResult _
-          | Types.Image _
-          | Types.Document _
-          | Types.Audio _ -> false)
-        content
-    in
-    let reasoning_text =
-      List.find_map
-        (function
-          | Types.Thinking { content = c; _ } -> Some c
-          | Types.Text _
-          | Types.RedactedThinking _
-          | Types.ToolUse _
-          | Types.ToolResult _
-          | Types.Image _
-          | Types.Document _
-          | Types.Audio _ -> None)
-        content
-    in
-    let promoted_reasoning =
-      match reasoning_visibility, has_text, has_tool, reasoning_text with
-      | Reasoning_dialect.Visible_text, false, false, Some r when String.trim r <> "" ->
-        [ Types.Text r ]
-      | _ -> []
-    in
-    (* Enforce the StopToolUse => has-tool-block invariant now that the full
+       let has_text =
+         List.exists
+           (function
+             | Types.Text _ -> true
+             | Types.Thinking _
+             | Types.RedactedThinking _
+             | Types.ToolUse _
+             | Types.ToolResult _
+             | Types.Image _
+             | Types.Document _
+             | Types.Audio _ -> false)
+           content
+       in
+       let has_tool =
+         List.exists
+           (function
+             | Types.ToolUse _ -> true
+             | Types.Text _
+             | Types.Thinking _
+             | Types.RedactedThinking _
+             | Types.ToolResult _
+             | Types.Image _
+             | Types.Document _
+             | Types.Audio _ -> false)
+           content
+       in
+       let reasoning_text =
+         List.find_map
+           (function
+             | Types.Thinking { content = c; _ } -> Some c
+             | Types.Text _
+             | Types.RedactedThinking _
+             | Types.ToolUse _
+             | Types.ToolResult _
+             | Types.Image _
+             | Types.Document _
+             | Types.Audio _ -> None)
+           content
+       in
+       let promoted_reasoning =
+         match reasoning_visibility, has_text, has_tool, reasoning_text with
+         | Reasoning_dialect.Visible_text, false, false, Some r when String.trim r <> ""
+           -> [ Types.Text r ]
+         | _ -> []
+       in
+       (* Enforce the StopToolUse => has-tool-block invariant now that the full
        block set (including dropped partial tool calls above) is known. A
        reasoning-only or dropped-partial-tool stream that the provider tagged
        finish_reason="tool_calls" must NOT reach the driver as a tool-use turn
        with zero tools -- the pipeline re-issues that forever (infinite Thinking
        loop). SSOT: Stop_reason_wire.reconcile (same rule as the non-streaming
        parser via Stop_reason_wire.of_finish). *)
-    let stop_reason =
-      Stop_reason_wire.reconcile !(acc.stop_reason) ~has_tool_blocks:has_tool
-    in
-    Ok
-      { Types.id = !(acc.id)
-      ; model = !(acc.model)
-      ; stop_reason
-      ; content = content @ promoted_reasoning
-      ; usage =
-          Some
-            { input_tokens = !(acc.input_tokens)
-            ; output_tokens = !(acc.output_tokens)
-            ; cache_creation_input_tokens = !(acc.cache_creation)
-            ; cache_read_input_tokens = !(acc.cache_read)
-            ; cost_usd = None
-            }
-      ; telemetry = None
-      }
+       let stop_reason =
+         Stop_reason_wire.reconcile !(acc.stop_reason) ~has_tool_blocks:has_tool
+       in
+       Ok
+         { Types.id = !(acc.id)
+         ; model = !(acc.model)
+         ; stop_reason
+         ; content = content @ promoted_reasoning
+         ; usage =
+             Some
+               { input_tokens = !(acc.input_tokens)
+               ; output_tokens = !(acc.output_tokens)
+               ; cache_creation_input_tokens = !(acc.cache_creation)
+               ; cache_read_input_tokens = !(acc.cache_read)
+               ; cost_usd = None
+               }
+         ; telemetry = None
+         })
 ;;
 
 [@@@coverage off]
@@ -725,11 +735,10 @@ let%test "finalize_stream_acc empty produces empty content" =
   | Ok result -> result.content = []
 ;;
 
-let%test "finalize_stream_acc preserves text of unknown block kind (S6.1/S8.3)" =
-  (* RFC-OAS-029 S6.1/S8.3: an unmodeled content-block kind that carried visible
-     text is preserved as a Text block (forward-compatible with newly introduced
-     provider block kinds), not silently dropped by the former [_ -> None]
-     catch-all. Revert this fix -> content = [] (red). *)
+let%test "finalize_stream_acc fails closed for unknown block kind with text" =
+  (* RFC-OAS-029 S6.1/S8.3: unmodeled content-block kinds are not silently
+     dropped and are not coerced into assistant-visible Text. Revert this fix to
+     the old branch -> [Ok { content = [Types.Text "data"]; _ }] (red). *)
   let acc = create_stream_acc () in
   Hashtbl.replace acc.block_types 0 "server_tool_use";
   let buf = Buffer.create 16 in
@@ -739,21 +748,29 @@ let%test "finalize_stream_acc preserves text of unknown block kind (S6.1/S8.3)" 
     acc.stop_reason_received := true;
     finalize_stream_acc acc
   with
-  | Error _ -> false
-  | Ok result -> result.content = [ Types.Text "data" ]
+  | Error (Types.Stream_parse_failed { reason; raw }) ->
+    raw = ""
+    && String.starts_with
+         ~prefix:"unsupported_content_block_kind:server_tool_use:index:0"
+         reason
+  | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false
 ;;
 
-let%test "finalize_stream_acc drops empty unknown block kind" =
-  (* An unmodeled kind with no accumulated text has no renderable content, so it
-     is omitted via the explicit Unknown_block branch (not a silent catch-all). *)
+let%test "finalize_stream_acc fails closed for empty unknown block kind" =
+  (* Empty unknown blocks are still unsupported wire semantics. Returning [Ok []]
+     would silently erase a future server/tool/control surface. *)
   let acc = create_stream_acc () in
   Hashtbl.replace acc.block_types 0 "container_upload";
   match
     acc.stop_reason_received := true;
     finalize_stream_acc acc
   with
-  | Error _ -> false
-  | Ok result -> result.content = []
+  | Error (Types.Stream_parse_failed { reason; raw }) ->
+    raw = ""
+    && String.starts_with
+         ~prefix:"unsupported_content_block_kind:container_upload:index:0"
+         reason
+  | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false
 ;;
 
 let%test "finalize_stream_acc tool_use with invalid json falls back to empty assoc" =

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -8,6 +8,7 @@ type model_entry =
   ; supports_tools : bool option
   ; supports_tool_choice : bool option
   ; supports_parallel_tool_calls : bool option
+  ; assistant_tool_content_format : string option
   ; supports_reasoning : bool option
   ; supports_extended_thinking : bool option
   ; supports_reasoning_budget : bool option
@@ -89,15 +90,23 @@ let parse_entry entry_toml =
   | None -> Error "model entry missing required \"id_prefix\" field"
   | Some id_prefix ->
     let id_prefix = String.trim id_prefix in
-    (match
-       canonical_string_opt
-         ~entry_id:id_prefix
-         "reasoning_replay"
-         ~allowed:Capability_vocab.reasoning_replay_values
-         entry_toml
-     with
-     | Error _ as e -> e
-     | Ok reasoning_replay ->
+    let reasoning_replay_result =
+      canonical_string_opt
+        ~entry_id:id_prefix
+        "reasoning_replay"
+        ~allowed:Capability_vocab.reasoning_replay_values
+        entry_toml
+    in
+    let assistant_tool_content_format_result =
+      canonical_string_opt
+        ~entry_id:id_prefix
+        "assistant_tool_content_format"
+        ~allowed:Capability_vocab.assistant_tool_content_format_values
+        entry_toml
+    in
+    (match reasoning_replay_result, assistant_tool_content_format_result with
+     | (Error _ as e), _ | _, (Error _ as e) -> e
+     | Ok reasoning_replay, Ok assistant_tool_content_format ->
        Ok
          { id_prefix
          ; base_label = find_string_opt entry_toml [ "base" ]
@@ -107,6 +116,7 @@ let parse_entry entry_toml =
          ; supports_tool_choice = find_bool_opt entry_toml [ "supports_tool_choice" ]
          ; supports_parallel_tool_calls =
              find_bool_opt entry_toml [ "supports_parallel_tool_calls" ]
+         ; assistant_tool_content_format
          ; supports_reasoning = find_bool_opt entry_toml [ "supports_reasoning" ]
          ; supports_extended_thinking =
              find_bool_opt entry_toml [ "supports_extended_thinking" ]

--- a/lib/llm_provider/model_catalog.mli
+++ b/lib/llm_provider/model_catalog.mli
@@ -11,6 +11,7 @@ type model_entry =
   ; supports_tools : bool option
   ; supports_tool_choice : bool option
   ; supports_parallel_tool_calls : bool option
+  ; assistant_tool_content_format : string option
   ; supports_reasoning : bool option
   ; supports_extended_thinking : bool option
   ; supports_reasoning_budget : bool option

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -255,6 +255,19 @@ let parse_reasoning_visibility = function
             other))
 ;;
 
+let parse_assistant_tool_content_format = function
+  | None -> Ok None
+  | Some raw ->
+    (match Capability_vocab.assistant_tool_content_format_of_string raw with
+     | Some format -> Ok (Some format)
+     | None ->
+       Error
+         (Printf.sprintf
+            "unknown assistant_tool_content_format %S (canonical: %s)"
+            (String.lowercase_ascii (String.trim raw))
+            (String.concat ", " Capability_vocab.assistant_tool_content_format_values)))
+;;
+
 let member_supported_models json = member_string_list "supported_models" json
 
 let capability_base json =
@@ -308,6 +321,10 @@ let parse_capabilities provider_json =
   let* reasoning_visibility =
     parse_reasoning_visibility (member_string "reasoning_visibility" cap_json)
   in
+  let* assistant_tool_content_format =
+    parse_assistant_tool_content_format
+      (member_string "assistant_tool_content_format" cap_json)
+  in
   let caps =
     base
     |> fun caps ->
@@ -352,6 +369,11 @@ let parse_capabilities provider_json =
       caps
       (fun caps v -> { caps with Capabilities.supports_runtime_tool_events = v })
       cap_json
+    |> fun caps ->
+    (match assistant_tool_content_format with
+     | Some assistant_tool_content_format ->
+       { caps with Capabilities.assistant_tool_content_format }
+     | None -> caps)
     |> fun caps ->
     override_bool
       "supports_reasoning"

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -83,6 +83,11 @@ type reasoning_replay_override = Llm_provider.Capabilities.reasoning_replay_over
   | Force_drop_without_tool_preserve_with_tool
   | Force_preserve_always
 
+type assistant_tool_content_format =
+      Llm_provider.Capabilities.assistant_tool_content_format =
+  | Assistant_tool_content_null
+  | Assistant_tool_content_empty_string
+
 type capabilities =
   { max_context_tokens : int option
   ; max_output_tokens : int option
@@ -91,6 +96,7 @@ type capabilities =
   ; supports_parallel_tool_calls : bool
   ; supports_runtime_mcp_tools : bool
   ; supports_runtime_tool_events : bool
+  ; assistant_tool_content_format : assistant_tool_content_format
   ; supports_reasoning : bool
   ; supports_extended_thinking : bool
   ; supports_reasoning_budget : bool

--- a/lib/provider_runtime_binding.ml
+++ b/lib/provider_runtime_binding.ml
@@ -81,6 +81,7 @@ let public_capabilities (caps : Llm_provider.Capabilities.capabilities)
   ; supports_parallel_tool_calls = caps.supports_parallel_tool_calls
   ; supports_runtime_mcp_tools = caps.supports_runtime_mcp_tools
   ; supports_runtime_tool_events = caps.supports_runtime_tool_events
+  ; assistant_tool_content_format = caps.assistant_tool_content_format
   ; supports_reasoning = caps.supports_reasoning
   ; supports_extended_thinking = caps.supports_extended_thinking
   ; supports_reasoning_budget = caps.supports_reasoning_budget

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -905,6 +905,8 @@ let test_build_openai_body_glm_preserves_reasoning_content () =
     { Types.config =
         { Types.default_config with
           model = provider_config.model_id
+        ; enable_thinking = Some true
+        ; preserve_thinking = Some true
         ; tool_choice = Some (Types.Tool "calculator")
         }
     ; messages = []

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -763,7 +763,7 @@ let test_build_openai_body_omits_provider_m_only_fields_for_generic_compat () =
   check bool "tools preserved" true (List.mem_assoc "tools" assoc)
 ;;
 
-let test_build_openai_body_uses_glm_thinking_and_auto_tool_choice () =
+let test_build_openai_body_uses_glm_thinking_and_drops_forced_tool_choice () =
   let provider_config =
     { Provider.provider =
         Provider.OpenAICompat
@@ -812,10 +812,14 @@ let test_build_openai_body_uses_glm_thinking_and_auto_tool_choice () =
     "clear_thinking default true"
     true
     (thinking |> member "clear_thinking" |> to_bool);
-  check string "glm tool choice coerced" "auto" (json |> member "tool_choice" |> to_string)
+  check
+    bool
+    "glm forced tool_choice omitted"
+    false
+    (List.mem_assoc "tool_choice" (to_assoc json))
 ;;
 
-let test_build_openai_body_uses_bare_glm_thinking_and_auto_tool_choice () =
+let test_build_openai_body_uses_bare_glm_thinking_and_drops_forced_tool_choice () =
   let provider_config =
     { Provider.provider =
         Provider.OpenAICompat
@@ -865,10 +869,10 @@ let test_build_openai_body_uses_bare_glm_thinking_and_auto_tool_choice () =
     true
     (thinking |> member "clear_thinking" |> to_bool);
   check
-    string
-    "bare glm tool choice coerced"
-    "auto"
-    (json |> member "tool_choice" |> to_string)
+    bool
+    "bare glm forced tool_choice omitted"
+    false
+    (List.mem_assoc "tool_choice" (to_assoc json))
 ;;
 
 let test_build_openai_body_glm_preserves_reasoning_content () =
@@ -926,7 +930,11 @@ let test_build_openai_body_glm_preserves_reasoning_content () =
     "reasoning_content replayed"
     "I should call the calculator."
     (assistant |> member "reasoning_content" |> to_string);
-  check string "tool choice still auto" "auto" (json |> member "tool_choice" |> to_string)
+  check
+    bool
+    "forced tool_choice omitted"
+    false
+    (List.mem_assoc "tool_choice" (to_assoc json))
 ;;
 
 let test_build_openai_body_does_not_treat_non_zai_glm_as_glm () =
@@ -1850,13 +1858,13 @@ let () =
             `Quick
             test_build_openai_body_omits_provider_m_only_fields_for_generic_compat
         ; test_case
-            "glm thinking + auto tool choice"
+            "glm thinking + unsupported forced tool choice"
             `Quick
-            test_build_openai_body_uses_glm_thinking_and_auto_tool_choice
+            test_build_openai_body_uses_glm_thinking_and_drops_forced_tool_choice
         ; test_case
-            "bare glm thinking + auto tool choice"
+            "bare glm thinking + unsupported forced tool choice"
             `Quick
-            test_build_openai_body_uses_bare_glm_thinking_and_auto_tool_choice
+            test_build_openai_body_uses_bare_glm_thinking_and_drops_forced_tool_choice
         ; test_case
             "glm preserved reasoning replay"
             `Quick

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -332,6 +332,49 @@ let test_assistant_tool_calls_openai_ollama_and_glm () =
     "ollama arguments raw json"
     "x"
     (member "function" ollama_call |> member "arguments" |> member "q" |> to_string);
+  let replay_assistant =
+    msg
+      Assistant
+      [ Thinking { thinking_type = "reasoning"; content = "because" }
+      ; ToolUse { id = "call-2"; name = "lookup"; input = `Assoc [ "q", `String "y" ] }
+      ]
+  in
+  let replay_dialect =
+    Reasoning_dialect.of_capabilities
+      { Capabilities.openai_compat_chat_extended_capabilities with
+        thinking_control_format = Capabilities.Thinking_object
+      }
+  in
+  let replay_null =
+    Serialize.dialect_messages_of_message
+      ~assistant_tool_content_format:Capability_vocab.Assistant_tool_content_null
+      replay_dialect
+      replay_assistant
+    |> only "replay null"
+  in
+  Alcotest.(check bool)
+    "reasoning replay keeps null content when capability says null"
+    true
+    (member "content" replay_null = `Null);
+  check_string
+    "reasoning replay still emits reasoning_content"
+    "because"
+    (member "reasoning_content" replay_null |> to_string);
+  let replay_empty =
+    Serialize.dialect_messages_of_message
+      ~assistant_tool_content_format:Capability_vocab.Assistant_tool_content_empty_string
+      replay_dialect
+      replay_assistant
+    |> only "replay empty"
+  in
+  check_string
+    "reasoning replay emits empty content when capability says empty string"
+    ""
+    (member "content" replay_empty |> to_string);
+  check_string
+    "empty-string capability still emits reasoning_content"
+    "because"
+    (member "reasoning_content" replay_empty |> to_string);
   let glm =
     Serialize.glm_messages_of_message
       (msg

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -303,7 +303,7 @@ let test_openai_parallel_disabled_by_capability () =
    get correct (not shadowed) capabilities"] in [capabilities.ml] and in
    [test_capabilities.ml]'s cloud-suffix route checks. *)
 let deepseek_required_expected =
-  {|{"parallel_tool_calls":false,"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"tool_choice":"required","model":"deepseek-v4-flash","messages":[{"role":"user","content":"What's the weather in Seoul?"},{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Seoul\"}"}}],"role":"assistant","content":""},{"role":"tool","tool_call_id":"call_1","content":"Sunny, 25C"}],"max_tokens":1024}|}
+  {|{"parallel_tool_calls":false,"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"tool_choice":"required","model":"deepseek-v4-flash","messages":[{"role":"user","content":"What's the weather in Seoul?"},{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Seoul\"}"}}],"role":"assistant","content":null},{"role":"tool","tool_call_id":"call_1","content":"Sunny, 25C"}],"max_tokens":1024}|}
 ;;
 
 let test_deepseek_required () =


### PR DESCRIPTION
## Summary
- add a typed assistant_tool_content_format capability for assistant messages that contain tool calls but no visible text
- keep OpenAI/Anthropic default behavior at content:null while allowing GLM/Z.AI-style empty-string content through capability data
- fail closed on unknown provider stream content blocks instead of coercing unsupported block kinds into assistant-visible Text
- keep this branch focused; it replaces the assistant-content and unknown-block slices that were tangled into broader draft PRs

## Verification
- env OAS_MODEL_CATALOG=models.toml scripts/dune-local.sh exec test/test_api.exe
- env OAS_MODEL_CATALOG=models.toml scripts/dune-local.sh exec test/test_capabilities.exe
- env OAS_MODEL_CATALOG=models.toml scripts/dune-local.sh exec test/test_provider_catalog_coverage.exe
- env OAS_MODEL_CATALOG=models.toml scripts/dune-local.sh exec test/test_snapshot_provider_serialization.exe
- env OAS_MODEL_CATALOG=models.toml scripts/dune-local.sh exec test/test_backend_openai_codec.exe
- env -u OAS_CAPABILITY_MANIFEST OAS_MODEL_CATALOG=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/fix/oas-assistant-tool-content-capability-20260629/models.toml scripts/dune-local.sh runtest lib/llm_provider
- opam exec -- ocamlformat --check touched OCaml files
- git diff --check origin/main...HEAD